### PR TITLE
chore(sonar): scope analysis to hand-written product code

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,26 @@
+# SonarCloud analysis scope (project gradionhq_margince-poc-v1).
+# This project uses SonarCloud Automatic Analysis; this file narrows the scope
+# so the quality signal reflects hand-written product code, not generated files
+# or append-only DDL.
+sonar.projectKey=gradionhq_margince-poc-v1
+sonar.organization=gradionhq
+
+# --- Exclusions: never analyze code we do not hand-write ---
+# Generated code is DO NOT TOUCH (make gen; the drift gate fails a hand edit),
+# so its findings are unactionable — fixing them by hand would fail CI.
+#   internal/contracts/**   OpenAPI-generated types + server interface
+#   **/*_gen.go             gen-stubs / gen-agentpolicy output
+# Migrations are append-only DDL (ADR-0017): duplicated type/literal tokens in
+# separate historical migrations are not a maintainability defect to refactor.
+sonar.exclusions=\
+  backend/internal/contracts/**,\
+  **/*_gen.go,\
+  backend/migrations/**
+
+# --- Targeted rule tuning (files stay analyzed for every other rule) ---
+sonar.issue.ignore.multicriteria=e1
+# Cognitive Complexity (go:S3776) fires on table-driven test harnesses whose
+# structure is intentional and read as a spec; keep it enforced on production
+# code, drop it for tests.
+sonar.issue.ignore.multicriteria.e1.ruleKey=go:S3776
+sonar.issue.ignore.multicriteria.e1.resourceKey=**/*_test.go


### PR DESCRIPTION
## What
Adds \`sonar-project.properties\` to scope SonarCloud Automatic Analysis to hand-written product code.

## Why
Of the 465 open Sonar issues, ~118 are unactionable noise:
- **~67 in generated code** (\`internal/contracts/**\`, \`**/*_gen.go\`) — marked DO NOT TOUCH in CLAUDE.md; the drift gate fails any hand edit, so they cannot be fixed in source (48 of them are \`go:S3776\` in \`api_gen.go\`).
- **~51 \`go:S3776\` in \`*_test.go\`** — table-driven Go test harnesses are intentionally structured and read as specs; the rule stays enforced on production code.
- Append-only migration DDL (\`backend/migrations/**\`) — duplicated type/literal tokens across historical migrations are not a refactor target.

This clears the noise so the remaining findings are real, hand-fixable product-code issues, which follow in subsequent PRs.

## How verified
- \`make check\` green (no code changed; config-only).
- **This PR is also the empirical check** that SonarCloud Automatic Analysis honors \`sonar-project.properties\` — the PR's Sonar check should show the excluded findings drop out.

## AI involvement
Authored by Claude Code (analysis-scope config + this description) under human review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added SonarCloud analysis settings for the project.
  * Refined scan coverage to exclude generated code and migration files from analysis.
  * Adjusted code-quality rules so test files are not flagged for cognitive-complexity issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->