### PR TITLE
chore(sonar): Go S1192/S1313 product-code cleanups + exclude vendored gate

### DIFF
--- a/backend/internal/compose/report.go
+++ b/backend/internal/compose/report.go
@@ -35,6 +35,17 @@ import (
 // export, not a report.
 const reportRowLimit = 1000
 
+// Column references reused across the prebuilt report specs. One spelling
+// each so a dimension, measure, and filter that mean the same column cannot
+// drift apart.
+const (
+	colOwnerID        = "t.owner_id"
+	colAmountMinor    = "t.amount_minor"
+	colPipelineID     = "t.pipeline_id"
+	colStageID        = "t.stage_id"
+	whereArchivedNull = "t.archived_at IS NULL"
+)
+
 type reportAggregate struct {
 	Fn    string `json:"fn"`
 	Field string `json:"field,omitempty"`
@@ -91,9 +102,9 @@ var prebuiltReports = map[string]reportSpec{
 		table:      "deal",
 		baseWhere:  "t.archived_at IS NULL AND t.status = 'open'",
 		basePlain:  "live (unarchived) open deals",
-		dimensions: map[string]string{"organization_id": "t.organization_id", "owner_id": "t.owner_id"},
-		measures:   map[string]string{"amount_minor": "t.amount_minor"},
-		filters:    map[string]string{"owner_id": "t.owner_id", "pipeline_id": "t.pipeline_id"},
+		dimensions: map[string]string{"organization_id": "t.organization_id", "owner_id": colOwnerID},
+		measures:   map[string]string{"amount_minor": colAmountMinor},
+		filters:    map[string]string{"owner_id": colOwnerID, "pipeline_id": colPipelineID},
 		defaultBy:  []string{"organization_id"},
 		defaultAggs: []reportAggregate{
 			{Fn: "count", As: "open_deals"},
@@ -102,11 +113,11 @@ var prebuiltReports = map[string]reportSpec{
 	"deals-by-stage": {
 		entity:     datasource.EntityDeal,
 		table:      "deal",
-		baseWhere:  "t.archived_at IS NULL",
+		baseWhere:  whereArchivedNull,
 		basePlain:  "live (unarchived) deals",
-		dimensions: map[string]string{"stage_id": "t.stage_id", "status": "t.status", "pipeline_id": "t.pipeline_id"},
-		measures:   map[string]string{"amount_minor": "t.amount_minor"},
-		filters:    map[string]string{"pipeline_id": "t.pipeline_id", "status": "t.status", "owner_id": "t.owner_id"},
+		dimensions: map[string]string{"stage_id": colStageID, "status": "t.status", "pipeline_id": colPipelineID},
+		measures:   map[string]string{"amount_minor": colAmountMinor},
+		filters:    map[string]string{"pipeline_id": colPipelineID, "status": "t.status", "owner_id": colOwnerID},
 		defaultBy:  []string{"stage_id"},
 		defaultAggs: []reportAggregate{
 			{Fn: "count", As: "deals"},
@@ -116,7 +127,7 @@ var prebuiltReports = map[string]reportSpec{
 	"activities-by-kind": {
 		entity:       datasource.EntityActivity,
 		table:        "activity",
-		baseWhere:    "t.archived_at IS NULL",
+		baseWhere:    whereArchivedNull,
 		basePlain:    "live (unarchived) activities",
 		activityWalk: true,
 		dimensions:   map[string]string{"kind": "t.kind", "direction": "t.direction"},
@@ -142,21 +153,21 @@ var prebuiltReports = map[string]reportSpec{
 		baseWhere: "t.archived_at IS NULL AND t.status = 'open'",
 		basePlain: "open, unarchived deals (win probability read live from the deal's current stage; a commit/best_case deal whose close date is past, missing, or provisional reports as 'slipped' instead, per formulas §11)",
 		dimensions: map[string]string{
-			"owner_id":          "t.owner_id",
-			"stage_id":          "t.stage_id",
-			"pipeline_id":       "t.pipeline_id",
+			"owner_id":          colOwnerID,
+			"stage_id":          colStageID,
+			"pipeline_id":       colPipelineID,
 			"forecast_category": forecastCategoryExpr,
 			"currency":          "t.currency",
 			"win_probability":   "s.win_probability",
 		},
 		measures: map[string]string{
-			"amount_minor":          "t.amount_minor",
+			"amount_minor":          colAmountMinor,
 			"weighted_amount_minor": "round((t.amount_minor * s.win_probability) / 100.0)::bigint",
 		},
 		filters: map[string]string{
-			"owner_id":          "t.owner_id",
-			"stage_id":          "t.stage_id",
-			"pipeline_id":       "t.pipeline_id",
+			"owner_id":          colOwnerID,
+			"stage_id":          colStageID,
+			"pipeline_id":       colPipelineID,
 			"forecast_category": forecastCategoryExpr,
 			"currency":          "t.currency",
 		},
@@ -432,7 +443,7 @@ func (e *reportEngine) runAdHocPlan(ctx context.Context, plan datasource.ReportP
 	spec := reportSpec{
 		entity:       plan.Entity,
 		table:        string(plan.Entity),
-		baseWhere:    "t.archived_at IS NULL",
+		baseWhere:    whereArchivedNull,
 		activityWalk: plan.Entity == datasource.EntityActivity,
 		dimensions:   map[string]string{},
 		measures:     map[string]string{},

--- a/backend/internal/modules/consent/dsr.go
+++ b/backend/internal/modules/consent/dsr.go
@@ -30,6 +30,10 @@ import (
 
 const dsrColumns = `id, kind, status, subject_ref, assignee_id, due_at, resolution, created_at`
 
+// dsrSelectByID is the single-row fetch shared by GetDSR and UpdateDSR — one
+// spelling so the projected columns cannot drift between the two paths.
+const dsrSelectByID = "SELECT " + dsrColumns + " FROM data_subject_request WHERE id = $1"
+
 type dsrRow struct {
 	ID         ids.UUID
 	Kind       string
@@ -157,7 +161,7 @@ func (s *Store) GetDSR(ctx context.Context, id ids.UUID) (dsrRow, error) {
 	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
 		var err error
 		out, err = scanDSR(tx.QueryRow(ctx,
-			"SELECT "+dsrColumns+" FROM data_subject_request WHERE id = $1", id))
+			dsrSelectByID, id))
 		if errors.Is(err, pgx.ErrNoRows) {
 			return apperrors.ErrNotFound
 		}
@@ -179,7 +183,7 @@ func (s *Store) UpdateDSR(ctx context.Context, id ids.UUID, in UpdateDSRInput) (
 	var out dsrRow
 	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
 		current, err := scanDSR(tx.QueryRow(ctx,
-			"SELECT "+dsrColumns+" FROM data_subject_request WHERE id = $1", id))
+			dsrSelectByID, id))
 		if errors.Is(err, pgx.ErrNoRows) {
 			return apperrors.ErrNotFound
 		}

--- a/backend/internal/modules/search/store.go
+++ b/backend/internal/modules/search/store.go
@@ -226,6 +226,10 @@ func scanRankedPage(rows pgx.Rows, limit int) (Page, error) {
 // BadQueryError maps to a 422 at the transport.
 type BadQueryError struct{ Reason string }
 
+// reasonMalformedCursor is the BadQueryError reason for any un-decodable
+// keyset cursor — one spelling so the 422 body never drifts between paths.
+const reasonMalformedCursor = "malformed cursor"
+
 func (e *BadQueryError) Error() string { return "search: " + e.Reason }
 
 // rankedCursor is the (score, type, id) keyset position. Encoding keeps
@@ -245,19 +249,19 @@ func encodeCursor(c rankedCursor) string {
 func decodeCursor(s string) (rankedCursor, error) {
 	raw, err := base64.RawURLEncoding.DecodeString(s)
 	if err != nil {
-		return rankedCursor{}, &BadQueryError{Reason: "malformed cursor"}
+		return rankedCursor{}, &BadQueryError{Reason: reasonMalformedCursor}
 	}
 	parts := strings.SplitN(string(raw), "|", 3)
 	if len(parts) != 3 {
-		return rankedCursor{}, &BadQueryError{Reason: "malformed cursor"}
+		return rankedCursor{}, &BadQueryError{Reason: reasonMalformedCursor}
 	}
 	score, err := strconv.ParseFloat(parts[0], 64)
 	if err != nil {
-		return rankedCursor{}, &BadQueryError{Reason: "malformed cursor"}
+		return rankedCursor{}, &BadQueryError{Reason: reasonMalformedCursor}
 	}
 	id, err := ids.Parse(parts[2])
 	if err != nil {
-		return rankedCursor{}, &BadQueryError{Reason: "malformed cursor"}
+		return rankedCursor{}, &BadQueryError{Reason: reasonMalformedCursor}
 	}
 	return rankedCursor{Score: score, Type: parts[1], ID: id}, nil
 }

--- a/backend/internal/platform/dbmigrate/dbmigrate.go
+++ b/backend/internal/platform/dbmigrate/dbmigrate.go
@@ -19,6 +19,12 @@ import (
 	"github.com/jackc/pgx/v5"
 )
 
+// suffixUp / suffixDown name the two halves of a reversible migration pair.
+const (
+	suffixUp   = ".up.sql"
+	suffixDown = ".down.sql"
+)
+
 // Migration is one reversible schema step: NNNN_name.up.sql + .down.sql.
 type Migration struct {
 	Version string // "0001" (core, sequential) or "20260620143000" (custom, timestamp)
@@ -51,10 +57,10 @@ func Load(fsys fs.FS, dir string) ([]Migration, error) {
 		name := e.Name()
 		var suffix string
 		switch {
-		case strings.HasSuffix(name, ".up.sql"):
-			suffix = ".up.sql"
-		case strings.HasSuffix(name, ".down.sql"):
-			suffix = ".down.sql"
+		case strings.HasSuffix(name, suffixUp):
+			suffix = suffixUp
+		case strings.HasSuffix(name, suffixDown):
+			suffix = suffixDown
 		default:
 			continue
 		}
@@ -75,7 +81,7 @@ func Load(fsys fs.FS, dir string) ([]Migration, error) {
 			m = &Migration{Version: version, Name: title}
 			byKey[key] = m
 		}
-		if suffix == ".up.sql" {
+		if suffix == suffixUp {
 			m.UpSQL = string(sql)
 		} else {
 			m.DownSQL = string(sql)

--- a/backend/internal/platform/netguard/netguard.go
+++ b/backend/internal/platform/netguard/netguard.go
@@ -21,9 +21,11 @@ import (
 // IPv4 internals — NAT64 (64:ff9b::/96, e.g. 64:ff9b::a9fe:a9fe → link-local
 // metadata) and IPv4-compatible ::/96 — which To4()/IsPrivate() do not catch.
 var reservedNets = func() []*net.IPNet {
+	// These literal reserved/special-use ranges ARE the guard: the SSRF
+	// denylist must name them explicitly. NOSONAR: hardcoding them is the point.
 	cidrs := []string{
-		"0.0.0.0/8", "100.64.0.0/10", "192.0.0.0/24", "192.0.2.0/24",
-		"198.18.0.0/15", "198.51.100.0/24", "203.0.113.0/24", "240.0.0.0/4",
+		"0.0.0.0/8", "100.64.0.0/10", "192.0.0.0/24", "192.0.2.0/24", //NOSONAR
+		"198.18.0.0/15", "198.51.100.0/24", "203.0.113.0/24", "240.0.0.0/4", //NOSONAR
 		"2001:db8::/32", "64:ff9b::/96", "::/96",
 	}
 	nets := make([]*net.IPNet, len(cidrs))

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -12,10 +12,14 @@ sonar.organization=gradionhq
 #   **/*_gen.go             gen-stubs / gen-agentpolicy output
 # Migrations are append-only DDL (ADR-0017): duplicated type/literal tokens in
 # separate historical migrations are not a maintainability defect to refactor.
+# cli/craft/** is the foundation craftsmanship gate, vendored verbatim and
+# hash-pinned (craft-drift); a local edit fails CI, so its findings are
+# unactionable here — fix them upstream in the skeleton.
 sonar.exclusions=\
   backend/internal/contracts/**,\
   **/*_gen.go,\
-  backend/migrations/**
+  backend/migrations/**,\
+  cli/craft/**
 
 # --- Targeted rule tuning (files stay analyzed for every other rule) ---
 sonar.issue.ignore.multicriteria=e1


### PR DESCRIPTION
## What
Second Sonar batch — real hand-fixable Go findings in product code.

## Why
- **`go:S1192` (duplicate string literals) → named constants:**
  - `report.go`: `colOwnerID` / `colAmountMinor` / `colPipelineID` / `colStageID` / `whereArchivedNull` for column refs reused across report specs.
  - `search/store.go`: `reasonMalformedCursor` (the "malformed cursor" 422 reason, 4×).
  - `consent/dsr.go`: fold the duplicated get-by-id query into `dsrSelectByID` so the projected columns can't drift.
  - `dbmigrate.go`: `suffixUp` / `suffixDown`.
- **`go:S1313` (hardcoded IPs) → `//NOSONAR`:** `netguard.go`'s reserved-range CIDR table. Hardcoding the RFC 1918 / special-use ranges *is* the SSRF denylist — that's the guard's purpose, not a defect.
- **`sonar-project.properties`:** also exclude `cli/craft/**` — it's the foundation craftsmanship gate, vendored verbatim and hash-pinned (`craft-drift`); a local edit fails CI, so its findings are unactionable here (same class as generated code).

## How verified
- `go build ./...` clean; affected-package tests pass; `make check` green.

## AI involvement
Authored by Claude Code under human review.