### PR TITLE
chore(sonar): fix all 123 frontend findings

### DIFF
--- a/frontend/e2e/seed.ts
+++ b/frontend/e2e/seed.ts
@@ -253,7 +253,7 @@ export async function mockApi(target: Page): Promise<void> {
   // must seed a slug in localStorage or every authed screen renders auth. The
   // value is a dev-side setting, not tenant authority (the mocked /me is).
   await target.addInitScript(() => {
-    window.localStorage.setItem("margince.workspaceSlug", "seed");
+    globalThis.localStorage.setItem("margince.workspaceSlug", "seed");
   });
   // hermetic runs: no external font fetches
   await target.route("https://fonts.googleapis.com/**", (route) =>

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -7,25 +7,25 @@
  */
 const CACHE = "margince-shell-v1";
 
-self.addEventListener("install", (event) => {
+globalThis.addEventListener("install", (event) => {
   event.waitUntil(
     caches.open(CACHE).then((cache) => cache.addAll(["/", "/manifest.webmanifest"])),
   );
-  self.skipWaiting();
+  globalThis.skipWaiting();
 });
 
-self.addEventListener("activate", (event) => {
+globalThis.addEventListener("activate", (event) => {
   event.waitUntil(
     caches
       .keys()
       .then((keys) =>
         Promise.all(keys.filter((key) => key !== CACHE).map((key) => caches.delete(key))),
       )
-      .then(() => self.clients.claim()),
+      .then(() => globalThis.clients.claim()),
   );
 });
 
-self.addEventListener("fetch", (event) => {
+globalThis.addEventListener("fetch", (event) => {
   const request = event.request;
   const url = new URL(request.url);
 
@@ -34,7 +34,7 @@ self.addEventListener("fetch", (event) => {
   if (request.method !== "GET" || url.pathname.startsWith("/v1")) {
     return;
   }
-  if (url.origin !== self.location.origin) {
+  if (url.origin !== globalThis.location.origin) {
     return;
   }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -39,7 +39,7 @@ function PendingScreen() {
   );
 }
 
-function ScreenView({ screen, id }: { screen: string; id?: string }) {
+function ScreenView({ screen, id }: Readonly<{ screen: string; id?: string }>) {
   switch (screen) {
     case "design":
       return <DesignScreen />;
@@ -98,7 +98,9 @@ export function App() {
 // has no session (and maybe no workspace slug) — either way /me is not 200, so
 // we show the signup/login screen. On success the screen refetches and the app
 // renders. No redirect races: the gate owns the authenticated/not decision.
-function AuthedApp({ route }: { route: ReturnType<typeof useRoute> }) {
+function AuthedApp({
+  route,
+}: Readonly<{ route: ReturnType<typeof useRoute> }>) {
   const me = useQuery({
     queryKey: ["me"],
     retry: false,
@@ -152,7 +154,7 @@ function AuthedApp({ route }: { route: ReturnType<typeof useRoute> }) {
 
 // The rail-less page frame (same shape Shell renders for onboarding/booking),
 // so the pre-session screens get the app background and scroll container.
-function RaillessFrame({ children }: { children: ReactNode }) {
+function RaillessFrame({ children }: Readonly<{ children: ReactNode }>) {
   return (
     <div className="app railless">
       <main className="main">

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -24,9 +24,9 @@ export const api = createClient<paths>({
   // same-origin absolute base + the /v1 mount: contract paths are
   // unprefixed, the server serves them under /v1 (same as curl :8080/v1/me)
   baseUrl:
-    typeof window === "undefined"
+    typeof globalThis.window === "undefined"
       ? "http://localhost/v1"
-      : `${window.location.origin}/v1`,
+      : `${globalThis.location.origin}/v1`,
   credentials: "include",
   // resolve the CURRENT global fetch per call (test stubs, SW interception)
   fetch: (request) => globalThis.fetch(request),

--- a/frontend/src/app/fab.tsx
+++ b/frontend/src/app/fab.tsx
@@ -10,7 +10,7 @@ import type { Route } from "./router";
 // screen/record. The scope copy is load-bearing (03b): the agent reads only
 // the RBAC ∩ Passport intersection — the panel must never imply more.
 
-export function AskFab({ route }: { route: Route }) {
+export function AskFab({ route }: Readonly<{ route: Route }>) {
   const t = useT();
   const [open, setOpen] = useState(false);
 
@@ -26,6 +26,7 @@ export function AskFab({ route }: { route: Route }) {
       {open && (
         <div
           className="askfab-panel card"
+          // NOSONAR: inline anchored panel, not a native modal dialog; styling and conditional mount don't map to <dialog>
           role="dialog"
           aria-label={t("fab.panelAria")}
         >

--- a/frontend/src/app/palette.tsx
+++ b/frontend/src/app/palette.tsx
@@ -69,11 +69,11 @@ export function CommandPalette({
   open,
   onClose,
   commands,
-}: {
+}: Readonly<{
   open: boolean;
   onClose: () => void;
   commands: Command[];
-}) {
+}>) {
   const t = useT();
   const [query, setQuery] = useState("");
   const [selected, setSelected] = useState(0);
@@ -116,6 +116,7 @@ export function CommandPalette({
 
   const run = (command: Command) => {
     if (command.id === "ask-ai") {
+      // NOSONAR: persisted value is a trimmed plain string from a controlled input, consumed as text (never eval'd or rendered as HTML)
       sessionStorage.setItem(ASK_QUERY_KEY, query.trim());
     }
     onClose();
@@ -127,6 +128,7 @@ export function CommandPalette({
   }
 
   return (
+    // NOSONAR: backdrop dismiss only; keyboard path (Esc) is handled on the input inside
     // biome-ignore lint/a11y/noStaticElementInteractions: backdrop dismiss; Esc is the keyboard path
     // biome-ignore lint/a11y/useKeyWithClickEvents: Esc handled on the input below
     <div
@@ -139,6 +141,7 @@ export function CommandPalette({
     >
       <div
         className="palette"
+        // NOSONAR: styled overlay palette, not a native modal; conditional mount and layout don't map cleanly to <dialog>
         role="dialog"
         aria-modal="true"
         aria-label={t("palette.aria")}
@@ -215,7 +218,7 @@ export function usePaletteHotkey(toggle: () => void) {
         toggle();
       }
     };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
+    globalThis.addEventListener("keydown", onKey);
+    return () => globalThis.removeEventListener("keydown", onKey);
   }, [toggle]);
 }

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -22,18 +22,18 @@ export function routeHash(route: Route): string {
 }
 
 export function navigate(route: Route): void {
-  window.location.hash = routeHash(route);
+  globalThis.location.hash = routeHash(route);
 }
 
 function subscribe(onChange: () => void): () => void {
-  window.addEventListener("hashchange", onChange);
-  return () => window.removeEventListener("hashchange", onChange);
+  globalThis.addEventListener("hashchange", onChange);
+  return () => globalThis.removeEventListener("hashchange", onChange);
 }
 
 export function useRoute(): Route {
   const hash = useSyncExternalStore(
     subscribe,
-    () => window.location.hash,
+    () => globalThis.location.hash,
     () => "",
   );
   return parseHash(hash);

--- a/frontend/src/app/shell.tsx
+++ b/frontend/src/app/shell.tsx
@@ -1,8 +1,9 @@
 import { Moon, Search, Sun, UserRound } from "lucide-react";
 import { type ReactNode, useEffect, useState } from "react";
 import { useLocale, useT } from "../i18n";
+import type { MessageKey } from "../i18n/en";
 import { NAV, RAIL_LESS_SCREENS } from "./nav";
-import { navigate, type Route, routeHash, useRoute } from "./router";
+import { type Route, routeHash, useRoute } from "./router";
 import "./shell.css";
 
 // The app shell (B-EP09.4): WorkspaceRail + top bar. The top bar shows only
@@ -48,10 +49,10 @@ function Logomark() {
 export function WorkspaceRail({
   route,
   counts,
-}: {
+}: Readonly<{
   route: Route;
   counts?: ShellCounts;
-}) {
+}>) {
   const t = useT();
   return (
     <nav className="rail" aria-label={t("shell.railAria")}>
@@ -84,15 +85,35 @@ export function WorkspaceRail({
   );
 }
 
+// Off-rail screens (reached from Settings, not the NAV rail) carry their own
+// title key; anything unmapped falls back to the raw screen slug.
+const OFF_RAIL_TITLE_KEYS: Record<string, MessageKey> = {
+  settings: "nav.settings",
+  design: "nav.design",
+  automations: "nav.automations",
+};
+
+function resolveTitle(
+  screen: string,
+  labelKey: MessageKey | undefined,
+  t: ReturnType<typeof useT>,
+): string {
+  if (labelKey) {
+    return t(labelKey);
+  }
+  const offRailKey = OFF_RAIL_TITLE_KEYS[screen];
+  return offRailKey ? t(offRailKey) : screen;
+}
+
 export function TopBar({
   route,
   onOpenSearch,
   actions,
-}: {
+}: Readonly<{
   route: Route;
   onOpenSearch: () => void;
   actions?: ReactNode;
-}) {
+}>) {
   const t = useT();
   const { locale, setLocale } = useLocale();
   const [theme, setTheme] = useState<"light" | "dark">("light");
@@ -102,15 +123,7 @@ export function TopBar({
   }, [theme]);
 
   const navItem = NAV.find((item) => item.screen === route.screen);
-  const title = navItem
-    ? t(navItem.labelKey)
-    : route.screen === "settings"
-      ? t("nav.settings")
-      : route.screen === "design"
-        ? t("nav.design")
-        : route.screen === "automations"
-          ? t("nav.automations")
-          : route.screen;
+  const title = resolveTitle(route.screen, navItem?.labelKey, t);
 
   return (
     <header className="topbar">
@@ -158,12 +171,12 @@ export function Shell({
   counts,
   onOpenSearch,
   topBarActions,
-}: {
+}: Readonly<{
   children: ReactNode;
   counts?: ShellCounts;
   onOpenSearch: () => void;
   topBarActions?: ReactNode;
-}) {
+}>) {
   const route = useRoute();
   const railless = RAIL_LESS_SCREENS.has(route.screen);
 
@@ -196,4 +209,5 @@ export function Shell({
   );
 }
 
-export { navigate, useRoute };
+export { navigate } from "./router";
+export { useRoute };

--- a/frontend/src/design-system/atoms.tsx
+++ b/frontend/src/design-system/atoms.tsx
@@ -37,16 +37,16 @@ export function Button({
 export function Badge({
   tone,
   children,
-}: {
+}: Readonly<{
   tone?: "success" | "warn" | "danger" | "ai" | "accent";
   children: ReactNode;
-}) {
+}>) {
   return (
     <span className={tone ? `badge badge-${tone}` : "badge"}>{children}</span>
   );
 }
 
-export function Avatar({ name }: { name: string }) {
+export function Avatar({ name }: Readonly<{ name: string }>) {
   const initials = name
     .split(/\s+/)
     .filter(Boolean)
@@ -79,11 +79,11 @@ export function Card({
   inset,
   children,
   className,
-}: {
+}: Readonly<{
   inset?: boolean;
   children: ReactNode;
   className?: string;
-}) {
+}>) {
   return (
     <div
       className={["card", inset ? "card-inset" : "", className ?? ""]
@@ -98,18 +98,21 @@ export function Card({
 export function Skeleton({
   width,
   height = 14,
-}: {
+}: Readonly<{
   width: number | string;
   height?: number;
-}) {
+}>) {
   return <div className="skeleton" style={{ width, height }} />;
 }
 
-export function EmptyState({ children }: { children: ReactNode }) {
+export function EmptyState({ children }: Readonly<{ children: ReactNode }>) {
   return <div className="card card-inset empty">{children}</div>;
 }
 
-export function SectionHeader({ title, sub }: { title: string; sub?: string }) {
+export function SectionHeader({
+  title,
+  sub,
+}: Readonly<{ title: string; sub?: string }>) {
   return (
     <div className="section-header">
       <h2>{title}</h2>
@@ -123,12 +126,12 @@ export function SegmentedControl<Option extends string>({
   value,
   onChange,
   labels,
-}: {
+}: Readonly<{
   options: readonly Option[];
   value: Option;
   onChange: (next: Option) => void;
   labels: Record<Option, string>;
-}) {
+}>) {
   return (
     <fieldset className="segmented">
       {options.map((option) => (
@@ -145,7 +148,7 @@ export function SegmentedControl<Option extends string>({
   );
 }
 
-export function Kbd({ children }: { children: ReactNode }) {
+export function Kbd({ children }: Readonly<{ children: ReactNode }>) {
   return <kbd className="kbd">{children}</kbd>;
 }
 
@@ -154,12 +157,12 @@ export function Modal({
   onClose,
   labelledBy,
   children,
-}: {
+}: Readonly<{
   open: boolean;
   onClose: () => void;
   labelledBy: string;
   children: ReactNode;
-}) {
+}>) {
   useEffect(() => {
     if (!open) {
       return;
@@ -169,13 +172,14 @@ export function Modal({
         onClose();
       }
     };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
+    globalThis.addEventListener("keydown", onKey);
+    return () => globalThis.removeEventListener("keydown", onKey);
   }, [open, onClose]);
   if (!open) {
     return null;
   }
   return (
+    // NOSONAR: backdrop dismiss only; keyboard path (Esc) handled by the effect above
     // biome-ignore lint/a11y/noStaticElementInteractions: backdrop dismiss is a convention; Esc is the keyboard path
     // biome-ignore lint/a11y/useKeyWithClickEvents: Esc handles the keyboard path above
     <div
@@ -187,6 +191,7 @@ export function Modal({
       }}
     >
       <div
+        // NOSONAR: styled modal overlay driven by React state, not a native <dialog>; conversion would change focus/backdrop behavior
         role="dialog"
         aria-modal="true"
         aria-labelledby={labelledBy}
@@ -203,12 +208,12 @@ export function DataTable<Row>({
   rows,
   rowKey,
   onRowClick,
-}: {
+}: Readonly<{
   columns: { key: string; header: string; render: (row: Row) => ReactNode }[];
   rows: Row[];
   rowKey: (row: Row) => string;
   onRowClick?: (row: Row) => void;
-}) {
+}>) {
   return (
     <div className="table-scroll">
       <table className="table">

--- a/frontend/src/design-system/composed.tsx
+++ b/frontend/src/design-system/composed.tsx
@@ -35,10 +35,10 @@ export type BriefItem = {
 export function MorningBriefItem({
   item,
   onResolve,
-}: {
+}: Readonly<{
   item: BriefItem;
   onResolve?: (resolution: Resolution) => void;
-}) {
+}>) {
   const t = useT();
   return (
     <article className="brief-item card">
@@ -89,14 +89,14 @@ export function DealCard({
   deal,
   onOpen,
   dragHandlers,
-}: {
+}: Readonly<{
   deal: BoardDeal;
   onOpen?: (deal: BoardDeal) => void;
   dragHandlers?: {
     draggable: true;
     onDragStart: (event: React.DragEvent) => void;
   };
-}) {
+}>) {
   const t = useT();
   const { locale } = useLocale();
   const classes = [
@@ -137,7 +137,7 @@ export function PipelineBoard({
   columnExtras,
   cardDragHandlers,
   columnDropHandlers,
-}: {
+}: Readonly<{
   columns: BoardColumn[];
   onOpen?: (deal: BoardDeal) => void;
   columnExtras?: (column: BoardColumn) => ReactNode;
@@ -153,7 +153,7 @@ export function PipelineBoard({
     onDrop: (event: React.DragEvent) => void;
     onDragLeave: (event: React.DragEvent) => void;
   };
-}) {
+}>) {
   const t = useT();
   const { locale } = useLocale();
   return (
@@ -221,14 +221,14 @@ export function RecordView({
   timeline,
   zone,
   children,
-}: {
+}: Readonly<{
   name: string;
   subtitle?: string;
   badges?: ReactNode;
   timeline: TimelineEntry[];
   zone: string;
   children?: ReactNode;
-}) {
+}>) {
   const t = useT();
   const { locale } = useLocale();
   return (

--- a/frontend/src/design-system/trust.tsx
+++ b/frontend/src/design-system/trust.tsx
@@ -15,11 +15,12 @@ export type Evidence = {
   source: string;
 };
 
-export function AutonomyDot({ tier }: { tier: "auto" | "confirm" }) {
+export function AutonomyDot({ tier }: Readonly<{ tier: "auto" | "confirm" }>) {
   const t = useT();
   return (
     <span
       className={`dot dot-${tier}`}
+      // NOSONAR: CSS-drawn status glyph (no bitmap); <img> would need a src the design has none of, and .dot styling targets the span
       role="img"
       aria-label={tier === "auto" ? t("autonomy.auto") : t("autonomy.confirm")}
     />
@@ -29,10 +30,10 @@ export function AutonomyDot({ tier }: { tier: "auto" | "confirm" }) {
 export function EvidenceChip({
   evidence,
   onOpen,
-}: {
+}: Readonly<{
   evidence: Evidence;
   onOpen?: () => void;
-}) {
+}>) {
   const text = (
     <>
       "{evidence.snippet}" · {evidence.source}
@@ -50,7 +51,9 @@ export function EvidenceChip({
 
 // Low confidence is shown as low, never hidden (§4.2) — there is no prop to
 // suppress the glyph.
-export function ConfidenceMeter({ level }: { level: ConfidenceLevel }) {
+export function ConfidenceMeter({
+  level,
+}: Readonly<{ level: ConfidenceLevel }>) {
   const t = useT();
   return (
     <span className={`confidence confidence-${level}`}>
@@ -63,7 +66,9 @@ export function ConfidenceMeter({ level }: { level: ConfidenceLevel }) {
 // Provenance is either an agent (`agent:capture`) or the human user.
 export type Provenance = { kind: "agent"; agent: string } | { kind: "human" };
 
-export function ProvenanceTag({ provenance }: { provenance: Provenance }) {
+export function ProvenanceTag({
+  provenance,
+}: Readonly<{ provenance: Provenance }>) {
   const t = useT();
   if (provenance.kind === "agent") {
     return (
@@ -81,11 +86,11 @@ export function ApprovalGate({
   onAccept,
   onEdit,
   onDismiss,
-}: {
+}: Readonly<{
   onAccept: () => void;
   onEdit: () => void;
   onDismiss: () => void;
-}) {
+}>) {
   const t = useT();
   return (
     <div className="approval-gate">
@@ -110,7 +115,7 @@ export function ApprovalGate({
   );
 }
 
-export function StagingCard({ children }: { children: ReactNode }) {
+export function StagingCard({ children }: Readonly<{ children: ReactNode }>) {
   const t = useT();
   return (
     <section className="staging-card" aria-label={t("trust.stagedProposal")}>
@@ -143,10 +148,10 @@ type ProposalState =
 export function StagedProposal({
   proposal,
   onResolve,
-}: {
+}: Readonly<{
   proposal: Proposal;
   onResolve?: (resolution: Resolution) => void;
-}) {
+}>) {
   const t = useT();
   const [state, setState] = useState<ProposalState>({ phase: "staged" });
 

--- a/frontend/src/format/format.test.ts
+++ b/frontend/src/format/format.test.ts
@@ -20,7 +20,10 @@ describe("money formatting (B-EP09.17)", () => {
     const en = formatMoney(stored, "EUR", "en");
     expect(de).toBe("1.234,56\u00a0€");
     expect(en).toBe("€1,234.56");
-    expect(stored).toBe(123_456); // the stored value is untouched
+    // formatting is a pure read: re-rendering the same stored value is stable,
+    // and the two locales render the one value differently.
+    expect(formatMoney(stored, "EUR", "de")).toBe(de);
+    expect(de).not.toBe(en);
   });
 
   it("respects the currency's minor-unit scale", () => {

--- a/frontend/src/format/format.ts
+++ b/frontend/src/format/format.ts
@@ -38,8 +38,9 @@ function assertIanaZone(zone: string): void {
       `timezone must be an IANA name, got fixed offset "${zone}"`,
     );
   }
-  // Intl itself rejects unknown names — let RangeError propagate.
-  new Intl.DateTimeFormat("en-US", { timeZone: zone });
+  // Intl itself rejects unknown names — constructing with the zone throws a
+  // RangeError we let propagate; format() forces the value to be consumed.
+  new Intl.DateTimeFormat("en-US", { timeZone: zone }).format();
 }
 
 // Zone-by-purpose (architecture/10 §2): personal deadlines localize to the

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -380,7 +380,7 @@ export const de = {
   "ob.s5.imapHost": "IMAP-Host",
   "ob.s5.imapHostPlaceholder": "imap.gmail.com",
   "ob.s5.imapEmail": "E-Mail",
-  "ob.s5.imapPassword": "App-Passwort",
+  "ob.s5.imapPassword": "App-Passwort", // NOSONAR: UI translation string, not a credential
   "ob.s5.imapMailbox": "Postfach",
   "ob.s5.imapMax": "Wie viele aktuelle E-Mails",
   "ob.s5.imapHint":

--- a/frontend/src/i18n/index.tsx
+++ b/frontend/src/i18n/index.tsx
@@ -45,10 +45,10 @@ const LocaleContext = createContext<LocaleContextValue>({
 export function LocaleProvider({
   initial = DEFAULT_LOCALE,
   children,
-}: {
+}: Readonly<{
   initial?: Locale;
   children: ReactNode;
-}) {
+}>) {
   const [locale, setLocale] = useState<Locale>(initial);
   const value = useMemo(() => ({ locale, setLocale }), [locale]);
   return (

--- a/frontend/src/screens/auth.tsx
+++ b/frontend/src/screens/auth.tsx
@@ -29,14 +29,14 @@ export function deriveWorkspaceSlug(name: string): string {
       out += "-";
     }
   }
-  return out.replace(/^-+|-+$/g, "");
+  return out.replace(/^-+/, "").replace(/-+$/, "");
 }
 
 const MIN_PASSWORD = 12;
 
 type Mode = "signup" | "login";
 
-export function AuthScreen({ onAuthed }: { onAuthed: () => void }) {
+export function AuthScreen({ onAuthed }: Readonly<{ onAuthed: () => void }>) {
   const t = useT();
   const [mode, setMode] = useState<Mode>("signup");
 
@@ -85,10 +85,10 @@ export function AuthScreen({ onAuthed }: { onAuthed: () => void }) {
 function SignupForm({
   onAuthed,
   onToLogin,
-}: {
+}: Readonly<{
   onAuthed: () => void;
   onToLogin: () => void;
-}) {
+}>) {
   const t = useT();
   const nameId = useId();
   const displayId = useId();
@@ -202,10 +202,10 @@ function SignupForm({
 function LoginForm({
   onAuthed,
   onToSignup,
-}: {
+}: Readonly<{
   onAuthed: () => void;
   onToSignup: () => void;
-}) {
+}>) {
   const t = useT();
   const slugId = useId();
   const emailId = useId();
@@ -295,12 +295,12 @@ function Field({
   label,
   hint,
   children,
-}: {
+}: Readonly<{
   id: string;
   label: string;
   hint?: string;
   children: ReactNode;
-}) {
+}>) {
   // The <label> names only the label text, so the input's accessible name is
   // exactly the label — the hint is a sibling below the input, not part of it.
   return (
@@ -312,7 +312,7 @@ function Field({
   );
 }
 
-function ErrorNote({ message }: { message: string | null }) {
+function ErrorNote({ message }: Readonly<{ message: string | null }>) {
   const t = useT();
   return (
     <div className="auth-error">

--- a/frontend/src/screens/automations.tsx
+++ b/frontend/src/screens/automations.tsx
@@ -35,6 +35,25 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+// Catalog defaults and stored params are JSON scalars; anything non-scalar
+// has no honest single-line rendering, so it collapses to empty.
+function scalarText(value: unknown): string {
+  if (value === undefined || value === null || typeof value === "object") {
+    return "";
+  }
+  return String(value);
+}
+
+function paramKind(type: unknown): ParamField["kind"] | null {
+  if (type === "integer" || type === "number") {
+    return "integer";
+  }
+  if (type === "string") {
+    return "string";
+  }
+  return null;
+}
+
 // The ONLY source of editable parameters: the catalog entry's JSON schema.
 export function paramFields(schema: Record<string, unknown>): ParamField[] {
   const properties = isRecord(schema.properties) ? schema.properties : {};
@@ -42,12 +61,7 @@ export function paramFields(schema: Record<string, unknown>): ParamField[] {
     if (!isRecord(raw)) {
       return [];
     }
-    const kind: ParamField["kind"] | null =
-      raw.type === "integer" || raw.type === "number"
-        ? "integer"
-        : raw.type === "string"
-          ? "string"
-          : null;
+    const kind = paramKind(raw.type);
     if (kind === null) {
       return [];
     }
@@ -57,7 +71,7 @@ export function paramFields(schema: Record<string, unknown>): ParamField[] {
         kind,
         min: typeof raw.minimum === "number" ? raw.minimum : undefined,
         max: typeof raw.maximum === "number" ? raw.maximum : undefined,
-        initial: raw.default === undefined ? "" : String(raw.default),
+        initial: scalarText(raw.default),
       },
     ];
   });
@@ -85,7 +99,7 @@ function AutomationForm({
   pending,
   onSubmit,
   onCancel,
-}: {
+}: Readonly<{
   entry: CatalogEntry;
   initialName: string;
   initialParams?: Automation["params"];
@@ -93,7 +107,7 @@ function AutomationForm({
   pending: boolean;
   onSubmit: (name: string, params: Record<string, unknown>) => void;
   onCancel: () => void;
-}) {
+}>) {
   const t = useT();
   const formId = useId();
   const fields = paramFields(entry.params_schema);
@@ -104,7 +118,7 @@ function AutomationForm({
         const configured = initialParams?.[field.key];
         return [
           field.key,
-          configured === undefined ? field.initial : String(configured),
+          configured === undefined ? field.initial : scalarText(configured),
         ];
       }),
     ),
@@ -171,10 +185,10 @@ function AutomationForm({
 export function AutomationRow({
   automation,
   entry,
-}: {
+}: Readonly<{
   automation: Automation;
   entry?: CatalogEntry;
-}) {
+}>) {
   const t = useT();
   const queryClient = useQueryClient();
   const [editing, setEditing] = useState(false);
@@ -222,6 +236,13 @@ export function AutomationRow({
 
   const enabled = automation.status === "enabled";
 
+  let mutationError: string | null = null;
+  if (patch.error instanceof Error) {
+    mutationError = patch.error.message;
+  } else if (remove.error instanceof Error) {
+    mutationError = remove.error.message;
+  }
+
   return (
     <li style={{ marginBottom: 12 }} data-automation={automation.id}>
       <div
@@ -242,7 +263,7 @@ export function AutomationRow({
         </Badge>
         <span className="t-mono t-small">
           {Object.entries(automation.params)
-            .map(([key, value]) => `${key}=${String(value)}`)
+            .map(([key, value]) => `${key}=${scalarText(value)}`)
             .join(" ")}
         </span>
         <span style={{ flexGrow: 1 }} />
@@ -285,11 +306,7 @@ export function AutomationRow({
           className="t-caption"
           style={{ color: "var(--danger)", marginTop: 8 }}
         >
-          {patch.error instanceof Error
-            ? patch.error.message
-            : remove.error instanceof Error
-              ? remove.error.message
-              : null}
+          {mutationError}
         </p>
       )}
     </li>

--- a/frontend/src/screens/book.tsx
+++ b/frontend/src/screens/book.tsx
@@ -31,7 +31,7 @@ export const PUBLIC_BOOKING_CONSENT = {
   policy_version: "2026-07",
 } as const;
 
-export function BookingScreen({ hostSlug }: { hostSlug?: string }) {
+export function BookingScreen({ hostSlug }: Readonly<{ hostSlug?: string }>) {
   if (hostSlug) {
     return <PublicBookingScreen hostSlug={hostSlug} />;
   }
@@ -182,7 +182,7 @@ function SessionBookingScreen() {
   );
 }
 
-function PublicBookingScreen({ hostSlug }: { hostSlug: string }) {
+function PublicBookingScreen({ hostSlug }: Readonly<{ hostSlug: string }>) {
   const t = useT();
   const { locale } = useLocale();
   const queryClient = useQueryClient();

--- a/frontend/src/screens/common.tsx
+++ b/frontend/src/screens/common.tsx
@@ -11,11 +11,11 @@ export function QueryGate<Data>({
   query,
   empty,
   children,
-}: {
+}: Readonly<{
   query: UseQueryResult<Data>;
   empty?: (data: Data) => boolean;
   children: (data: Data) => ReactNode;
-}) {
+}>) {
   const t = useT();
   if (query.isPending) {
     return (

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useMemo, useRef, useState } from "react";
+import { type DragEvent, useMemo, useRef, useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { navigate } from "../app/router";
@@ -103,7 +103,7 @@ export function buildColumns(stages: Stage[], deals: Deal[]): BoardColumn[] {
         probabilityPct: stage.win_probability,
         rawMinor: raw ?? 0,
         weightedMinor:
-          raw !== null ? Math.round((raw * stage.win_probability) / 100) : 0,
+          raw === null ? 0 : Math.round((raw * stage.win_probability) / 100),
         currency: currency ?? "EUR",
         deals: stageDeals.map(toBoardDeal),
         sumHidden: raw === null,
@@ -116,6 +116,19 @@ type PendingAdvance = {
   dealId: string;
   toStage: Stage;
 };
+
+// Won reads success, lost reads danger, an open deal carries no status tone.
+function dealStatusTone(
+  status: Deal["status"],
+): "success" | "danger" | undefined {
+  if (status === "won") {
+    return "success";
+  }
+  if (status === "lost") {
+    return "danger";
+  }
+  return undefined;
+}
 
 export function DealsScreen() {
   const t = useT();
@@ -174,6 +187,43 @@ export function DealsScreen() {
     }
   };
 
+  // Board interactions are hoisted here so the render-prop tree below doesn't
+  // nest their event callbacks past the readable depth.
+  const openDeal = (deal: BoardDeal) => {
+    if (Date.now() - lastDragEnd.current > 250) {
+      navigate({ screen: "deals", id: deal.id });
+    }
+  };
+
+  const cardDragHandlers = (deal: BoardDeal) => ({
+    draggable: true as const,
+    onDragStart: (event: DragEvent) => {
+      dragging.current = deal.id;
+      event.dataTransfer.setData("text/plain", deal.id);
+    },
+  });
+
+  const columnDropHandlers = (column: BoardColumn) => ({
+    onDragOver: (event: DragEvent) => {
+      event.preventDefault();
+      (event.currentTarget as HTMLElement).classList.add("droptarget");
+    },
+    onDragLeave: (event: DragEvent) => {
+      (event.currentTarget as HTMLElement).classList.remove("droptarget");
+    },
+    onDrop: (event: DragEvent) => {
+      event.preventDefault();
+      (event.currentTarget as HTMLElement).classList.remove("droptarget");
+      const dealId =
+        event.dataTransfer.getData("text/plain") || dragging.current;
+      dragging.current = null;
+      lastDragEnd.current = Date.now();
+      if (dealId) {
+        requestAdvance(dealId, column.stage);
+      }
+    },
+  });
+
   return (
     <div className="wrap">
       <SectionHeader title={t("nav.deals")} />
@@ -193,45 +243,9 @@ export function DealsScreen() {
               return view === "board" ? (
                 <PipelineBoard
                   columns={columns}
-                  onOpen={(deal) => {
-                    if (Date.now() - lastDragEnd.current > 250) {
-                      navigate({ screen: "deals", id: deal.id });
-                    }
-                  }}
-                  cardDragHandlers={(deal) => ({
-                    draggable: true,
-                    onDragStart: (event) => {
-                      dragging.current = deal.id;
-                      event.dataTransfer.setData("text/plain", deal.id);
-                    },
-                  })}
-                  columnDropHandlers={(column) => ({
-                    onDragOver: (event) => {
-                      event.preventDefault();
-                      (event.currentTarget as HTMLElement).classList.add(
-                        "droptarget",
-                      );
-                    },
-                    onDragLeave: (event) => {
-                      (event.currentTarget as HTMLElement).classList.remove(
-                        "droptarget",
-                      );
-                    },
-                    onDrop: (event) => {
-                      event.preventDefault();
-                      (event.currentTarget as HTMLElement).classList.remove(
-                        "droptarget",
-                      );
-                      const dealId =
-                        event.dataTransfer.getData("text/plain") ||
-                        dragging.current;
-                      dragging.current = null;
-                      lastDragEnd.current = Date.now();
-                      if (dealId) {
-                        requestAdvance(dealId, column.stage);
-                      }
-                    },
-                  })}
+                  onOpen={openDeal}
+                  cardDragHandlers={cardDragHandlers}
+                  columnDropHandlers={columnDropHandlers}
                 />
               ) : (
                 <DealTable deals={page.data} stages={pipeline.stages ?? []} />
@@ -311,7 +325,10 @@ export function DealsScreen() {
   );
 }
 
-function DealTable({ deals, stages }: { deals: Deal[]; stages: Stage[] }) {
+function DealTable({
+  deals,
+  stages,
+}: Readonly<{ deals: Deal[]; stages: Stage[] }>) {
   const t = useT();
   const { locale } = useLocale();
   const [sortKey, setSortKey] = useState<"name" | "amount" | "close">("name");
@@ -322,16 +339,20 @@ function DealTable({ deals, stages }: { deals: Deal[]; stages: Stage[] }) {
   );
 
   const sorted = useMemo(() => {
+    const compareDeals = (a: Deal, b: Deal): number => {
+      if (sortKey === "amount") {
+        return (a.amount_minor ?? 0) - (b.amount_minor ?? 0);
+      }
+      if (sortKey === "close") {
+        return (a.expected_close_date ?? "").localeCompare(
+          b.expected_close_date ?? "",
+        );
+      }
+      return a.name.localeCompare(b.name);
+    };
     const rows = [...deals];
     rows.sort((a, b) => {
-      const compare =
-        sortKey === "amount"
-          ? (a.amount_minor ?? 0) - (b.amount_minor ?? 0)
-          : sortKey === "close"
-            ? (a.expected_close_date ?? "").localeCompare(
-                b.expected_close_date ?? "",
-              )
-            : a.name.localeCompare(b.name);
+      const compare = compareDeals(a, b);
       return descending ? -compare : compare;
     });
     return rows;
@@ -393,17 +414,7 @@ function DealTable({ deals, stages }: { deals: Deal[]; stages: Stage[] }) {
             key: "status",
             header: t("lead.status"),
             render: (deal: Deal) => (
-              <Badge
-                tone={
-                  deal.status === "won"
-                    ? "success"
-                    : deal.status === "lost"
-                      ? "danger"
-                      : undefined
-                }
-              >
-                {deal.status}
-              </Badge>
+              <Badge tone={dealStatusTone(deal.status)}>{deal.status}</Badge>
             ),
           },
         ]}
@@ -415,7 +426,7 @@ function DealTable({ deals, stages }: { deals: Deal[]; stages: Stage[] }) {
   );
 }
 
-export function DealScreen({ id }: { id: string }) {
+export function DealScreen({ id }: Readonly<{ id: string }>) {
   const t = useT();
   const { locale } = useLocale();
   const queryClient = useQueryClient();
@@ -508,17 +519,7 @@ export function DealScreen({ id }: { id: string }) {
               }
               zone="Europe/Berlin"
               badges={
-                <Badge
-                  tone={
-                    deal.status === "won"
-                      ? "success"
-                      : deal.status === "lost"
-                        ? "danger"
-                        : undefined
-                  }
-                >
-                  {deal.status}
-                </Badge>
+                <Badge tone={dealStatusTone(deal.status)}>{deal.status}</Badge>
               }
               timeline={
                 timelineQuery.isSuccess

--- a/frontend/src/screens/design.tsx
+++ b/frontend/src/screens/design.tsx
@@ -108,7 +108,10 @@ function TrustShowcase() {
   );
 }
 
-function Swatches({ title, tokens }: { title: string; tokens: string[] }) {
+function Swatches({
+  title,
+  tokens,
+}: Readonly<{ title: string; tokens: string[] }>) {
   return (
     <section style={{ marginTop: 28 }}>
       <h2 className="t-sub">{title}</h2>

--- a/frontend/src/screens/inbox.tsx
+++ b/frontend/src/screens/inbox.tsx
@@ -59,7 +59,7 @@ function editableStrings(change: Record<string, unknown>): [string, string][] {
   });
 }
 
-export function ApprovalRow({ approval }: { approval: Approval }) {
+export function ApprovalRow({ approval }: Readonly<{ approval: Approval }>) {
   const t = useT();
   const { locale } = useLocale();
   const queryClient = useQueryClient();

--- a/frontend/src/screens/leads.tsx
+++ b/frontend/src/screens/leads.tsx
@@ -98,7 +98,7 @@ export function LeadsScreen() {
   );
 }
 
-export function LeadScreen({ id }: { id: string }) {
+export function LeadScreen({ id }: Readonly<{ id: string }>) {
   const t = useT();
   const queryClient = useQueryClient();
   const leadQuery = useQuery({

--- a/frontend/src/screens/onboarding.tsx
+++ b/frontend/src/screens/onboarding.tsx
@@ -88,6 +88,8 @@ function normalizeUrl(raw: string): {
     .replace(/^www\./i, "")
     .replace(/\/+$/, "");
   const host = s.split("/")[0] ?? "";
+  // NOSONAR: rewriting this host check to a linear pattern changes its accept/reject
+  // set (dotted-label edge cases); input is a bounded hostname, so backtracking is not a risk.
   const looksLikeHost =
     /^[a-z0-9.-]+\.[a-z]{2,}$/i.test(host) && !/\s/.test(host);
   return { ok: looksLikeHost, host, full: `https://${s}` };
@@ -103,6 +105,34 @@ function deriveName(host: string): string {
     .map((w) => w[0]?.toUpperCase() + w.slice(1))
     .join(" ");
   return titled || host;
+}
+
+function stepState(index: number, current: number): "done" | "active" | "" {
+  if (index < current) {
+    return "done";
+  }
+  if (index === current) {
+    return "active";
+  }
+  return "";
+}
+
+// The pinned CorpusMeterVersion=1 bands (features/09 §B1.4):
+// thin < 8k · good ≥ 8k · rich ≥ 20k · sharp ≥ 30k.
+function corpusQuality(total: number): { cls: string; key: MessageKey } {
+  if (total === 0) {
+    return { cls: "", key: "ob.s3.qualStart" };
+  }
+  if (total < 8000) {
+    return { cls: "thin", key: "ob.s3.qualThin" };
+  }
+  if (total < 20000) {
+    return { cls: "good", key: "ob.s3.qualGood" };
+  }
+  if (total < VOICE_TARGET) {
+    return { cls: "rich", key: "ob.s3.qualRich" };
+  }
+  return { cls: "sharp", key: "ob.s3.qualSharp" };
 }
 
 export function OnboardingScreen() {
@@ -131,7 +161,7 @@ export function OnboardingScreen() {
       // editable confirm. Scroll the read-back into view.
       setReadData(data);
       setHost(norm.host);
-      window.scrollTo({ top: 0, behavior: "smooth" });
+      globalThis.scrollTo({ top: 0, behavior: "smooth" });
     },
   });
 
@@ -140,7 +170,7 @@ export function OnboardingScreen() {
       return;
     }
     setStep(next);
-    window.scrollTo({ top: 0, behavior: "smooth" });
+    globalThis.scrollTo({ top: 0, behavior: "smooth" });
   };
 
   return (
@@ -152,7 +182,7 @@ export function OnboardingScreen() {
         </span>
         <nav className="stepper" aria-label={t("ob.title")}>
           {STEPS.map((s, i) => {
-            const state = i < step ? "done" : i === step ? "active" : "";
+            const state = stepState(i, step);
             return (
               <span key={s.key} style={{ display: "contents" }}>
                 <span
@@ -209,11 +239,11 @@ function Footer({
   step,
   canContinue,
   go,
-}: {
+}: Readonly<{
   step: number;
   canContinue: boolean;
   go: (n: number) => void;
-}) {
+}>) {
   const t = useT();
   return (
     <div className="wiz-foot">
@@ -273,7 +303,7 @@ function ReadStep({
   company,
   host,
   onManual,
-}: {
+}: Readonly<{
   url: string;
   setUrl: (v: string) => void;
   norm: { ok: boolean; host: string; full: string };
@@ -282,9 +312,34 @@ function ReadStep({
   company: string;
   host: string;
   onManual: () => void;
-}) {
+}>) {
   const t = useT();
   const showInvalid = url.trim() !== "" && !norm.ok;
+
+  let readButtonLabel: ReactNode;
+  if (read.isPending) {
+    readButtonLabel = (
+      <>
+        <span className="ob-spinner" /> {t("ob.reading")}
+      </>
+    );
+  } else if (readData) {
+    readButtonLabel = t("ob.readAgain");
+  } else {
+    readButtonLabel = (
+      <>
+        {t("ob.readGo")} <ArrowRight aria-hidden />
+      </>
+    );
+  }
+
+  let urlNoteClass = "";
+  if (norm.ok) {
+    urlNoteClass = "ok";
+  } else if (showInvalid) {
+    urlNoteClass = "err";
+  }
+
   return (
     <section className="ob-panel">
       <div className="kick">{t("ob.s1.kick")}</div>
@@ -312,20 +367,10 @@ function ReadStep({
           disabled={!norm.ok || read.isPending}
           onClick={() => read.mutate()}
         >
-          {read.isPending ? (
-            <>
-              <span className="ob-spinner" /> {t("ob.reading")}
-            </>
-          ) : readData ? (
-            t("ob.readAgain")
-          ) : (
-            <>
-              {t("ob.readGo")} <ArrowRight aria-hidden />
-            </>
-          )}
+          {readButtonLabel}
         </Button>
       </div>
-      <div className={`urlnote ${norm.ok ? "ok" : showInvalid ? "err" : ""}`}>
+      <div className={`urlnote ${urlNoteClass}`}>
         {norm.ok && (
           <>
             <Check aria-hidden /> {t("ob.urlWillRead", { host: norm.host })}
@@ -408,10 +453,10 @@ function ReadStep({
 function ReadFailure({
   message,
   onManual,
-}: {
+}: Readonly<{
   message: string;
   onManual: () => void;
-}) {
+}>) {
   const t = useT();
   return (
     <div className="readfail warn">
@@ -443,7 +488,7 @@ function ReadFailure({
 
 // ---- step 2: confirm -------------------------------------------------------
 
-function ConfirmStep({ readData }: { readData: ColdStart | null }) {
+function ConfirmStep({ readData }: Readonly<{ readData: ColdStart | null }>) {
   const t = useT();
   const [edits, setEdits] = useState<Record<string, string>>({});
   const [buyer, setBuyer] = useState("");
@@ -569,7 +614,7 @@ const SOURCES: Source[] = [
 const ACCEPTED_CORPUS_FILE = /\.(txt|md|vtt|srt|json)$/i;
 const ACCEPTED_CORPUS_ATTR = ".txt,.md,.vtt,.srt,.json";
 
-function VoiceStep({ company }: { company: string }) {
+function VoiceStep({ company }: Readonly<{ company: string }>) {
   const t = useT();
   const [optedIn, setOptedIn] = useState(false);
   const [added, setAdded] = useState<Set<string>>(new Set());
@@ -623,36 +668,23 @@ function VoiceStep({ company }: { company: string }) {
         rejected.push(file.name);
         continue;
       }
-      const reader = new FileReader();
-      reader.onload = () => {
-        const words = String(reader.result).split(/\s+/).filter(Boolean).length;
+      file.text().then((text) => {
+        const words = text.split(/\s+/).filter(Boolean).length;
         setUploads((prev) => [...prev, { name: file.name, words }]);
-      };
-      reader.readAsText(file);
+      });
     }
     setSkipped(rejected);
     e.target.value = "";
   };
 
-  // The pinned CorpusMeterVersion=1 bands (features/09 §B1.4):
-  // thin < 8k · good ≥ 8k · rich ≥ 20k · sharp ≥ 30k.
-  const quality: { cls: string; key: MessageKey } =
-    corpus.total === 0
-      ? { cls: "", key: "ob.s3.qualStart" }
-      : corpus.total < 8000
-        ? { cls: "thin", key: "ob.s3.qualThin" }
-        : corpus.total < 20000
-          ? { cls: "good", key: "ob.s3.qualGood" }
-          : corpus.total < VOICE_TARGET
-            ? { cls: "rich", key: "ob.s3.qualRich" }
-            : { cls: "sharp", key: "ob.s3.qualSharp" };
+  const quality = corpusQuality(corpus.total);
 
   const build = () => {
     setBuilding(true);
     // A short modelling beat, then the starter-voice card. This is a starter
     // preview built from the corpus you selected — it sharpens for real once
     // sent email is ingested at connect (see the footnote copy).
-    window.setTimeout(() => {
+    globalThis.setTimeout(() => {
       setBuilding(false);
       setBuilt(true);
     }, 1100);
@@ -696,6 +728,34 @@ function VoiceStep({ company }: { company: string }) {
         <div className="srcgrid">
           {SOURCES.map((s) => {
             const on = added.has(s.id);
+            let mark: ReactNode = null;
+            if (s.locked) {
+              mark = (
+                <span className="star">
+                  <Lock aria-hidden />
+                </span>
+              );
+            } else if (s.star) {
+              mark = (
+                <span className="star">
+                  <Star aria-hidden />
+                </span>
+              );
+            }
+            let words: ReactNode = null;
+            if (s.locked) {
+              words = (
+                <span className="added-w muted">
+                  {t("ob.s3.lockedWords", { count: s.words.toLocaleString() })}
+                </span>
+              );
+            } else if (on) {
+              words = (
+                <span className="added-w">
+                  {t("ob.s3.addedWords", { count: s.words.toLocaleString() })}
+                </span>
+              );
+            }
             return (
               <button
                 key={s.id}
@@ -703,15 +763,7 @@ function VoiceStep({ company }: { company: string }) {
                 className={`src ${on ? "added" : ""} ${s.locked ? "locked" : ""}`}
                 onClick={() => toggle(s)}
               >
-                {s.locked ? (
-                  <span className="star">
-                    <Lock aria-hidden />
-                  </span>
-                ) : s.star ? (
-                  <span className="star">
-                    <Star aria-hidden />
-                  </span>
-                ) : null}
+                {mark}
                 <span className="si">{s.icon}</span>
                 <span className="sb">
                   <span className="st">
@@ -721,19 +773,7 @@ function VoiceStep({ company }: { company: string }) {
                     </span>
                   </span>
                   <span className="sh">{t(s.hint)}</span>
-                  {s.locked ? (
-                    <span className="added-w muted">
-                      {t("ob.s3.lockedWords", {
-                        count: s.words.toLocaleString(),
-                      })}
-                    </span>
-                  ) : on ? (
-                    <span className="added-w">
-                      {t("ob.s3.addedWords", {
-                        count: s.words.toLocaleString(),
-                      })}
-                    </span>
-                  ) : null}
+                  {words}
                 </span>
               </button>
             );
@@ -756,7 +796,6 @@ function VoiceStep({ company }: { company: string }) {
           type="file"
           multiple
           hidden
-          aria-hidden
           accept={ACCEPTED_CORPUS_ATTR}
           onChange={onFiles}
         />
@@ -770,9 +809,9 @@ function VoiceStep({ company }: { company: string }) {
           </ul>
         )}
         {skipped.length > 0 && (
-          <p className="ob-sub" role="status" style={{ marginTop: 8 }}>
+          <output className="ob-sub" style={{ display: "block", marginTop: 8 }}>
             {t("ob.s3.dropSkipped", { files: skipped.join(", ") })}
-          </p>
+          </output>
         )}
 
         <div className="meter">
@@ -892,7 +931,7 @@ function VoiceStep({ company }: { company: string }) {
 
 // ---- step 4: results -------------------------------------------------------
 
-function ResultsStep({ company }: { company: string }) {
+function ResultsStep({ company }: Readonly<{ company: string }>) {
   const t = useT();
   const cards: { title: MessageKey; body: MessageKey }[] = [
     { title: "ob.s4.cardProfile", body: "ob.s4.cardProfileBody" },
@@ -961,7 +1000,7 @@ function ConnectStep() {
   const connect = useMutation({
     mutationFn: async () => {
       const res = await fetch(
-        `${window.location.origin}/v1/connectors/imap/connect`,
+        `${globalThis.location.origin}/v1/connectors/imap/connect`,
         {
           method: "POST",
           credentials: "include",

--- a/frontend/src/screens/organizations.tsx
+++ b/frontend/src/screens/organizations.tsx
@@ -78,7 +78,7 @@ export function CompaniesScreen() {
   );
 }
 
-export function CompanyScreen({ id }: { id: string }) {
+export function CompanyScreen({ id }: Readonly<{ id: string }>) {
   const t = useT();
   const orgQuery = useQuery({
     queryKey: ["organization", id],

--- a/frontend/src/screens/people.tsx
+++ b/frontend/src/screens/people.tsx
@@ -51,15 +51,20 @@ function useTimeline(
   });
 }
 
+function timelineKind(kind: string): TimelineEntry["kind"] {
+  if (kind === "email") {
+    return "email";
+  }
+  if (kind === "meeting") {
+    return "meeting";
+  }
+  return "note";
+}
+
 export function activityTimeline(activities: Activity[]): TimelineEntry[] {
   return activities.map((activity) => ({
     id: activity.id,
-    kind:
-      activity.kind === "email"
-        ? "email"
-        : activity.kind === "meeting"
-          ? "meeting"
-          : "note",
+    kind: timelineKind(activity.kind),
     title: activity.subject ?? activity.kind,
     atIso: activity.occurred_at,
     provenance: provenanceOf(activity.captured_by),
@@ -121,7 +126,7 @@ export function ContactsScreen() {
   );
 }
 
-export function PersonScreen({ id }: { id: string }) {
+export function PersonScreen({ id }: Readonly<{ id: string }>) {
   const t = useT();
   const personQuery = useQuery({
     queryKey: ["person", id],

--- a/frontend/src/screens/settings.tsx
+++ b/frontend/src/screens/settings.tsx
@@ -1,5 +1,5 @@
 import { useInfiniteQuery, useMutation, useQuery } from "@tanstack/react-query";
-import { useId, useState } from "react";
+import { type ReactNode, useId, useState } from "react";
 import { api, setWorkspaceSlug, workspaceSlug } from "../api/client";
 import {
   Badge,
@@ -416,6 +416,79 @@ function AuditLogCard() {
 
   const entries = query.data?.pages.flatMap((page) => page.data) ?? [];
 
+  // Honest state matrix (§3a): loading, error, empty, then the list — kept as
+  // sequential branches rather than a nested ternary in the JSX below.
+  let body: ReactNode;
+  if (query.isPending) {
+    body = (
+      <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+        <Skeleton width="60%" />
+        <Skeleton width="90%" />
+      </div>
+    );
+  } else if (query.isError) {
+    body = (
+      <EmptyState>
+        <p>{t("common.error")}</p>
+        <p className="t-mono" style={{ marginTop: 6 }}>
+          {query.error instanceof Error ? query.error.message : null}
+        </p>
+        <Button small onClick={() => query.refetch()} style={{ marginTop: 10 }}>
+          {t("common.retry")}
+        </Button>
+      </EmptyState>
+    );
+  } else if (entries.length === 0) {
+    body = <EmptyState>{t("common.empty")}</EmptyState>;
+  } else {
+    body = (
+      <>
+        <ul
+          style={{
+            listStyle: "none",
+            display: "flex",
+            flexDirection: "column",
+            gap: 6,
+          }}
+        >
+          {entries.map((entry) => (
+            <li
+              key={entry.id}
+              style={{
+                display: "flex",
+                gap: 8,
+                alignItems: "center",
+                flexWrap: "wrap",
+              }}
+            >
+              <span className="t-small">
+                {formatDateTime(entry.occurred_at, locale, "Europe/Berlin")}
+              </span>
+              <span className="t-mono t-small">
+                {entry.actor_type}:{entry.actor_id}
+              </span>
+              <Badge tone="accent">{entry.action}</Badge>
+              <span className="t-mono t-small">
+                {entry.entity_type}
+                {entry.entity_id ? ` ${entry.entity_id}` : ""}
+              </span>
+            </li>
+          ))}
+        </ul>
+        {query.hasNextPage && (
+          <Button
+            small
+            disabled={query.isFetchingNextPage}
+            onClick={() => query.fetchNextPage()}
+            style={{ marginTop: 10 }}
+          >
+            {t("settings.loadMore")}
+          </Button>
+        )}
+      </>
+    );
+  }
+
   return (
     <section className="card" style={{ marginBottom: 14 }}>
       <SectionHeader title={t("settings.audit")} sub={t("settings.auditSub")} />
@@ -453,75 +526,20 @@ function AuditLogCard() {
           onChange={(event) => setAction(event.target.value)}
         />
       </div>
-      {query.isPending ? (
-        <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
-          <Skeleton width="60%" />
-          <Skeleton width="90%" />
-        </div>
-      ) : query.isError ? (
-        <EmptyState>
-          <p>{t("common.error")}</p>
-          <p className="t-mono" style={{ marginTop: 6 }}>
-            {query.error instanceof Error ? query.error.message : null}
-          </p>
-          <Button
-            small
-            onClick={() => query.refetch()}
-            style={{ marginTop: 10 }}
-          >
-            {t("common.retry")}
-          </Button>
-        </EmptyState>
-      ) : entries.length === 0 ? (
-        <EmptyState>{t("common.empty")}</EmptyState>
-      ) : (
-        <>
-          <ul
-            style={{
-              listStyle: "none",
-              display: "flex",
-              flexDirection: "column",
-              gap: 6,
-            }}
-          >
-            {entries.map((entry) => (
-              <li
-                key={entry.id}
-                style={{
-                  display: "flex",
-                  gap: 8,
-                  alignItems: "center",
-                  flexWrap: "wrap",
-                }}
-              >
-                <span className="t-small">
-                  {formatDateTime(entry.occurred_at, locale, "Europe/Berlin")}
-                </span>
-                <span className="t-mono t-small">
-                  {entry.actor_type}:{entry.actor_id}
-                </span>
-                <Badge tone="accent">{entry.action}</Badge>
-                <span className="t-mono t-small">
-                  {entry.entity_type}
-                  {entry.entity_id ? ` ${entry.entity_id}` : ""}
-                </span>
-              </li>
-            ))}
-          </ul>
-          {query.hasNextPage && (
-            <Button
-              small
-              disabled={query.isFetchingNextPage}
-              onClick={() => query.fetchNextPage()}
-              style={{ marginTop: 10 }}
-            >
-              {t("settings.loadMore")}
-            </Button>
-          )}
-        </>
-      )}
+      {body}
     </section>
   );
+}
+
+// Erasure reads danger, a rectification reads warn, other DSR kinds are neutral.
+function dsrKindTone(kind: string): "danger" | "warn" | undefined {
+  if (kind === "erasure") {
+    return "danger";
+  }
+  if (kind === "rectify") {
+    return "warn";
+  }
+  return undefined;
 }
 
 function PrivacyInboxCard() {
@@ -560,17 +578,7 @@ function PrivacyInboxCard() {
                 key={dsr.id}
                 style={{ display: "flex", gap: 8, alignItems: "center" }}
               >
-                <Badge
-                  tone={
-                    dsr.kind === "erasure"
-                      ? "danger"
-                      : dsr.kind === "rectify"
-                        ? "warn"
-                        : undefined
-                  }
-                >
-                  {dsr.kind}
-                </Badge>
+                <Badge tone={dsrKindTone(dsr.kind)}>{dsr.kind}</Badge>
                 <span className="t-mono">{dsr.subject_ref}</span>
                 <Badge
                   tone={dsr.status === "fulfilled" ? "success" : undefined}

--- a/frontend/src/screens/tasks.tsx
+++ b/frontend/src/screens/tasks.tsx
@@ -29,9 +29,49 @@ export function groupTask(task: Activity, now: Date): TaskGroup {
 
 const GROUP_ORDER: TaskGroup[] = ["overdue", "today", "upcoming", "undated"];
 
-export function TasksScreen() {
+// One open task, with its complete / snooze actions. Extracted so the grouped
+// render tree above stays legible instead of nesting these handlers deeply.
+function TaskRow({
+  task,
+  overdue,
+  onComplete,
+  onSnooze,
+}: Readonly<{
+  task: Activity;
+  overdue: boolean;
+  onComplete: (id: string) => void;
+  onSnooze: (task: Activity) => void;
+}>) {
   const t = useT();
   const { locale } = useLocale();
+  return (
+    <div className="card" style={{ marginBottom: 8 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+        <span style={{ flex: 1 }}>
+          <strong>{task.subject ?? ""}</strong>
+          {task.due_at && (
+            <span className="t-caption">
+              {" "}
+              · {formatDateTime(task.due_at, locale, "Europe/Berlin")}
+            </span>
+          )}
+        </span>
+        {overdue && <Badge tone="danger">{t("tasks.overdue")}</Badge>}
+        <Button small variant="primary" onClick={() => onComplete(task.id)}>
+          {t("tasks.complete")}
+        </Button>
+        {task.due_at && (
+          <Button small onClick={() => onSnooze(task)}>
+            {t("tasks.snooze")}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function TasksScreen() {
+  const t = useT();
   const queryClient = useQueryClient();
   const query = useQuery({
     queryKey: ["tasks"],
@@ -69,6 +109,19 @@ export function TasksScreen() {
     undated: t("tasks.undated"),
   };
 
+  const completeTask = (id: string) =>
+    update.mutate({ id, body: { is_done: true } });
+
+  const snoozeTask = (task: Activity) => {
+    if (!task.due_at) {
+      return;
+    }
+    const nextDue = new Date(
+      new Date(task.due_at).getTime() + 86_400_000,
+    ).toISOString();
+    update.mutate({ id: task.id, body: { due_at: nextDue } });
+  };
+
   return (
     <div className="wrap narrow">
       <SectionHeader title={t("nav.tasks")} />
@@ -92,68 +145,13 @@ export function TasksScreen() {
                   <section key={group} aria-label={groupLabel[group]}>
                     <SectionHeader title={groupLabel[group]} />
                     {tasks.map((task) => (
-                      <div
+                      <TaskRow
                         key={task.id}
-                        className="card"
-                        style={{ marginBottom: 8 }}
-                      >
-                        <div
-                          style={{
-                            display: "flex",
-                            alignItems: "center",
-                            gap: 10,
-                          }}
-                        >
-                          <span style={{ flex: 1 }}>
-                            <strong>{task.subject ?? ""}</strong>
-                            {task.due_at && (
-                              <span className="t-caption">
-                                {" "}
-                                ·{" "}
-                                {formatDateTime(
-                                  task.due_at,
-                                  locale,
-                                  "Europe/Berlin",
-                                )}
-                              </span>
-                            )}
-                          </span>
-                          {group === "overdue" && (
-                            <Badge tone="danger">{groupLabel.overdue}</Badge>
-                          )}
-                          <Button
-                            small
-                            variant="primary"
-                            onClick={() =>
-                              update.mutate({
-                                id: task.id,
-                                body: { is_done: true },
-                              })
-                            }
-                          >
-                            {t("tasks.complete")}
-                          </Button>
-                          {task.due_at && (
-                            <Button
-                              small
-                              onClick={() =>
-                                update.mutate({
-                                  id: task.id,
-                                  body: {
-                                    due_at: new Date(
-                                      new Date(
-                                        task.due_at as string,
-                                      ).getTime() + 86_400_000,
-                                    ).toISOString(),
-                                  },
-                                })
-                              }
-                            >
-                              {t("tasks.snooze")}
-                            </Button>
-                          )}
-                        </div>
-                      </div>
+                        task={task}
+                        overdue={group === "overdue"}
+                        onComplete={completeTask}
+                        onSnooze={snoozeTask}
+                      />
                     ))}
                   </section>
                 );

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -22,9 +22,13 @@ sonar.exclusions=\
   cli/craft/**
 
 # --- Targeted rule tuning (files stay analyzed for every other rule) ---
-sonar.issue.ignore.multicriteria=e1
+sonar.issue.ignore.multicriteria=e1,e2
 # Cognitive Complexity (go:S3776) fires on table-driven test harnesses whose
 # structure is intentional and read as a spec; keep it enforced on production
 # code, drop it for tests.
 sonar.issue.ignore.multicriteria.e1.ruleKey=go:S3776
 sonar.issue.ignore.multicriteria.e1.resourceKey=**/*_test.go
+# Same rationale for the TS side: complexity in the e2e seed/mock harness and
+# test files is intentional test scaffolding, not shippable code.
+sonar.issue.ignore.multicriteria.e2.ruleKey=typescript:S3776
+sonar.issue.ignore.multicriteria.e2.resourceKey=frontend/e2e/**


### PR DESCRIPTION
## What
Resolves all 123 SonarCloud findings under `frontend/` in one isolated PR (readonly props, nested ternaries, globalThis, a11y, etc.).

## Why
Batch 4 of the Sonar cleanup. **114 real fixes + 9 `// NOSONAR`** (genuine false-positives or behaviour-risk), plus one config ignore.

Highlights:
- **S6759 (×54)** readonly component props → `Readonly<Props>`.
- **S7764 (×19)** `globalThis` over `window`/`self` (incl. `public/sw.js`).
- **S3358 (×20)** nested ternaries extracted to named `const`s.
- **S2004 (×6)** flattened >4-deep nested callbacks in deals/tasks.
- **S6551 (×3)** meaningful object stringification (added a `scalarText` helper).
- Singletons: `role="status"`→`<output>`, aria-hidden off focusable, `useState` destructure, `export…from`, de-negated condition, real test assertion, dropped dead `Intl.DateTimeFormat`, `Blob#text()` over `FileReader`, one regex de-backtracked.

**NOSONAR (9)** — documented in each spot: 3 styled-overlay `role="dialog"` + 1 CSS-glyph `role="img"` (no clean native mapping without changing focus/backdrop/layout), the backdrop click-dismiss pair (Esc is the keyboard path), the German UI label `App-Passwort`, a bounded-input hostname regex, and a trimmed controlled-input string persisted as text.

**Config:** ignore `typescript:S3776` in `frontend/e2e/**` — test scaffolding, same rationale as `go:S3776` in `*_test.go`.

## How verified
`make frontend-check` green — Biome lint clean, 89 Vitest tests pass, `tsc -b` + Vite production build succeed.

## AI involvement
Fixes executed by a Claude Code subagent under the main agent's per-rule guidance; diff scope + risky semantic changes (regex, stringification, storage) spot-reviewed by the main agent. All under human review.