### PR TITLE
chore(sonar): safe backend/misc mechanical cleanups

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -25,10 +25,10 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/modules/ai"
 
 	// The DE jurisdiction pack compiles into every edge binary of this
 	// DE-first deployment (ADR-0042: composition by require-set).
-	"github.com/gradionhq/margince/backend/internal/modules/ai"
 	_ "github.com/gradionhq/margince/backend/internal/modules/de"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/events"
@@ -83,7 +83,9 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 		opts = append(opts, compose.WithPublicBaseURL(*publicBaseURL))
 	}
 
-	stopRelay := func() {}
+	stopRelay := func() {
+		// No inline relay to stop unless --inline-relay wires one below.
+	}
 	if *inlineRelay {
 		busReady, stop, err := startInlineRelay(ctx, pool, *redisAddr, logger)
 		if err != nil {

--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -26,10 +26,10 @@ import (
 	"github.com/redis/go-redis/v9"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/modules/ai"
 
 	// The DE jurisdiction pack compiles into every edge binary of this
 	// DE-first deployment (ADR-0042: composition by require-set).
-	"github.com/gradionhq/margince/backend/internal/modules/ai"
 	_ "github.com/gradionhq/margince/backend/internal/modules/de"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
 	"github.com/gradionhq/margince/backend/internal/modules/privacy"

--- a/backend/internal/compose/consent_integration_test.go
+++ b/backend/internal/compose/consent_integration_test.go
@@ -252,10 +252,10 @@ func TestDOIIssuanceSupersedesAndValidatesPurpose(t *testing.T) {
 		t.Fatalf("superseded token redeemed → %d, want 422", status)
 	}
 	// …the fresh one does.
-	if status := c.call(t, "POST", "/v1/people/"+c.personID+"/consent", anyMap{
+	if c.call(t, "POST", "/v1/people/"+c.personID+"/consent", anyMap{
 		"purpose_id": c.purposes["marketing_email"], "new_state": "granted",
 		"double_opt_in_token": second,
-	}, nil, nil); status != http.StatusOK {
+	}, nil, nil) != http.StatusOK {
 		t.Fatalf("fresh token refused")
 	}
 

--- a/backend/internal/compose/e2e_agent_integration_test.go
+++ b/backend/internal/compose/e2e_agent_integration_test.go
@@ -171,7 +171,7 @@ func TestEndToEnd_agentWritesGovernedOnREST(t *testing.T) {
 		t.Fatalf("approved retry → %d, want the archive to execute", status)
 	}
 	// Single-use: the same token cannot authorize a second effect.
-	if status := e.call(t, "DELETE", "/v1/people/"+created.ID, nil, withToken, &problem); status == 200 {
+	if e.call(t, "DELETE", "/v1/people/"+created.ID, nil, withToken, &problem) == 200 {
 		t.Fatal("a consumed approval token authorized a second effect")
 	}
 }

--- a/backend/internal/compose/offers_integration_test.go
+++ b/backend/internal/compose/offers_integration_test.go
@@ -309,7 +309,7 @@ func TestOfferLifecycleSendAcceptRegenerate(t *testing.T) {
 
 	// Reject: a second sent offer takes the decline (with reason).
 	eur := createOffer("EUR")
-	if status := e.call(t, "POST", "/v1/offers/"+eur.ID+"/send", nil, nil, nil); status != http.StatusOK {
+	if e.call(t, "POST", "/v1/offers/"+eur.ID+"/send", nil, nil, nil) != http.StatusOK {
 		t.Fatal("send EUR offer failed")
 	}
 	var rejected offerBody
@@ -320,7 +320,7 @@ func TestOfferLifecycleSendAcceptRegenerate(t *testing.T) {
 	// Regenerate: a third sent offer mints revision 2 as a fresh draft
 	// and the original becomes superseded — never mutated in place.
 	third := createOffer("EUR")
-	if status := e.call(t, "POST", "/v1/offers/"+third.ID+"/send", nil, nil, nil); status != http.StatusOK {
+	if e.call(t, "POST", "/v1/offers/"+third.ID+"/send", nil, nil, nil) != http.StatusOK {
 		t.Fatal("send third offer failed")
 	}
 	var nextRev offerBody
@@ -411,7 +411,7 @@ func TestOfferAgentSendRequiresApproval(t *testing.T) {
 	if status := e.call(t, "POST", "/v1/offers/"+offer.ID+"/send", nil, withToken, &sent); status != http.StatusOK || sent.Status != "sent" {
 		t.Fatalf("approved send retry → %d %q, want 200 sent", status, sent.Status)
 	}
-	if status := e.call(t, "POST", "/v1/offers/"+offer.ID+"/send", nil, withToken, nil); status == http.StatusOK {
+	if e.call(t, "POST", "/v1/offers/"+offer.ID+"/send", nil, withToken, nil) == http.StatusOK {
 		t.Fatal("a consumed approval token authorized a second send")
 	}
 

--- a/backend/internal/compose/report_forecast_integration_test.go
+++ b/backend/internal/compose/report_forecast_integration_test.go
@@ -225,7 +225,7 @@ func wireInt(t *testing.T, row map[string]any, key string) int64 {
 // weightedMinor mirrors formulas-and-rules §6: round(amount ×
 // probability / 100) per deal, half away from zero — the ground truth
 // the report must reconcile to.
-func weightedMinor(amountMinor int64, probability int64) int64 {
+func weightedMinor(amountMinor, probability int64) int64 {
 	return (amountMinor*probability + 50) / 100
 }
 

--- a/backend/internal/compose/retention_jurisdiction_integration_test.go
+++ b/backend/internal/compose/retention_jurisdiction_integration_test.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	// Registering the DE jurisdiction pack arms the GoBD retention floors
+	// this test exercises (ADR-0042: composition by require-set).
 	_ "github.com/gradionhq/margince/backend/internal/modules/de"
 	"github.com/gradionhq/margince/backend/internal/modules/privacy"
 	"github.com/gradionhq/margince/backend/internal/platform/database"

--- a/backend/internal/compose/search_integration_test.go
+++ b/backend/internal/compose/search_integration_test.go
@@ -134,7 +134,7 @@ func (e *searchEnv) admin() context.Context {
 	})
 }
 
-func (e *searchEnv) asTeamRep(user ids.UUID, team ids.UUID) context.Context {
+func (e *searchEnv) asTeamRep(user, team ids.UUID) context.Context {
 	ctx := principal.WithWorkspaceID(context.Background(), e.ws)
 	return principal.WithActor(ctx, principal.Principal{
 		Type: principal.PrincipalHuman, ID: "human:" + user.String(), UserID: user,

--- a/backend/internal/modules/identity/oauth.go
+++ b/backend/internal/modules/identity/oauth.go
@@ -235,7 +235,7 @@ func (h Handlers) oauthAuthorize(w http.ResponseWriter, r *http.Request) {
 	}
 	// Modern browsers stamp the initiator; a cross-site POST is refused
 	// outright (defense in depth over the nonce).
-	if site := r.Header.Get("Sec-Fetch-Site"); site == "cross-site" {
+	if r.Header.Get("Sec-Fetch-Site") == "cross-site" {
 		oauthError(w, http.StatusForbidden, "access_denied", "cross-site consent is refused")
 		return
 	}

--- a/backend/tools/contract-overlay/main.go
+++ b/backend/tools/contract-overlay/main.go
@@ -110,7 +110,7 @@ func downgrade(n *yaml.Node) error {
 
 // rewriteTypeUnion turns type: [T, 'null'] into type: T + nullable: true
 // on the mapping that holds it.
-func rewriteTypeUnion(mapping *yaml.Node, union *yaml.Node) error {
+func rewriteTypeUnion(mapping, union *yaml.Node) error {
 	var concrete string
 	sawNull := false
 	for _, t := range union.Content {

--- a/dev/dev.sh
+++ b/dev/dev.sh
@@ -28,7 +28,7 @@ cleanup() {
   echo "dev: shutting down…"
   # Kill the whole process group's children we started.
   for pid in "${API_PID:-}" "${DOOR_PID:-}" "${VITE_PID:-}"; do
-    [ -n "$pid" ] && kill "$pid" 2>/dev/null || true
+    [[ -n "$pid" ]] && kill "$pid" 2>/dev/null || true
   done
   rm -rf "$SCRATCH"
 }
@@ -36,10 +36,10 @@ trap cleanup EXIT INT TERM
 
 # --- AI key: real model powers the /coldstart read-back happy path ----------
 AI_FLAG=(--ai-fake)
-if [ -f .env.local ]; then
+if [[ -f .env.local ]]; then
   set -a; . ./.env.local; set +a
 fi
-if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+if [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
   # Inject the literal key onto every anthropic tier binding.
   sed "s#provider: anthropic, model: \([^ }]*\)#provider: anthropic, model: \1, api_key: ${ANTHROPIC_API_KEY}#g" \
     backend/ai-routing.yaml > "$ROUTING"


### PR DESCRIPTION
## What
Batch 5 — the safe, mechanical backend/misc Sonar findings.

## Why
- **godre:S8184** blank-import comments (cmd/api, cmd/worker, retention-jurisdiction test).
- **godre:S8209** group consecutive same-type params (forecast + search integration tests, contract-overlay).
- **godre:S8193** inline a var used only in the following condition (oauth.go + 4 integration tests, 5 sites).
- **go:S1186** comment on the empty `stopRelay` no-op.
- **shelldre:S7688** `[[` over `[` in dev/dev.sh (bash).

## Deliberately NOT in this PR (reported for a decision)
- **godre:S8196** (rename 11 single-method interfaces): several are **frozen `shared/ports` seam interfaces** (DO NOT TOUCH) and the rest ripple across implementors — low value, high risk.
- **go:S107** (param counts) in `identity/internal/policy/policy.go` (14 params) and `storekit/fieldprovenance.go` (8): a params-struct refactor in sensitive RBAC / write-shape code.
- **web/static** legacy embedded SPA (`app.css` contrast, `app.js` S7773/S3358/S7764/S7785): being replaced by `frontend/`.
- **godre:S8188/S8239/S8242** (context handling / ctx-in-struct): effectively false positives — the relay's `cancel` is intentionally returned in a closure for post-shutdown drain; the mcp `context.Background()` is deliberate because the parent ctx is already Done; the ctx struct fields are test inputs / read many times.
- **dev/go.sum** (S8566) and **CI action SHA-pinning** (S7637): low value for this repo.

## How verified
`make check` green; `go vet -tags integration ./...` clean.

## AI involvement
Fixes executed by a Claude Code subagent under main-agent guidance and review.

## Note
These edits were briefly, accidentally captured by a concurrent session's commit in the shared working tree; I recovered them onto this branch. Details flagged to the repo owner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth consent handling so cross-site authorization attempts are still correctly denied.
  * Made local development cleanup more reliable when stopping background processes.

* **Tests**
  * Updated several integration tests for clearer assertions and maintainability.

* **Style**
  * Cleaned up import ordering, parameter formatting, and shell condition syntax for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->