### PR TITLE
refactor(sonar): reduce cognitive complexity in the 10 worst store methods

### DIFF
--- a/backend/internal/compose/derivation.go
+++ b/backend/internal/compose/derivation.go
@@ -259,26 +259,9 @@ func (e *reportEngine) fetchDerivation(ctx context.Context, report string, spec 
 		var args []any
 		arg := func(v any) int { args = append(args, v); return len(args) }
 
-		where := []string{spec.baseWhere}
-		for _, p := range plan.preds {
-			if p.value == "" {
-				where = append(where, p.expr+" IS NULL")
-			} else {
-				where = append(where, fmt.Sprintf("%s = $%d", p.expr, arg(p.value)))
-			}
-		}
-		var scope string
-		var err error
-		if spec.activityWalk {
-			scope, err = auth.ActivityScopeClause(ctx, "t", arg)
-		} else {
-			scope, err = auth.ScopeClauseFor(ctx, string(spec.entity), "t", arg)
-		}
+		where, err := derivationWhere(ctx, spec, plan, arg)
 		if err != nil {
 			return err
-		}
-		if scope != "" {
-			where = append(where, scope)
 		}
 		whereSQL := strings.Join(where, " AND ")
 
@@ -289,18 +272,8 @@ func (e *reportEngine) fetchDerivation(ctx context.Context, report string, spec 
 			return fmt.Errorf("derivation %s rows: %w", report, err)
 		}
 		defer pgRows.Close()
-		for pgRows.Next() {
-			values, err := pgRows.Values()
-			if err != nil {
-				return err
-			}
-			row := make(map[string]any, len(plan.columns))
-			for i, col := range plan.columns {
-				row[col] = wireValue(values[i])
-			}
-			out.Rows = append(out.Rows, row)
-		}
-		if err := pgRows.Err(); err != nil {
+		out.Rows, err = scanDerivationRows(pgRows, plan.columns)
+		if err != nil {
 			return err
 		}
 		pgRows.Close()
@@ -329,6 +302,58 @@ func (e *reportEngine) fetchDerivation(ctx context.Context, report string, spec 
 		}
 		return nil
 	})
+}
+
+// derivationWhere renders the drill-through's WHERE side: the report's
+// base predicate, the validated equality predicates ("" = SQL NULL), and
+// the caller's row-scope clause (the activity link-walk when the report
+// rides on activities). The identical clause backs both the rows query
+// and the aggregate recompute, so the explanation can never out-see the
+// number it explains.
+func derivationWhere(ctx context.Context, spec reportSpec, plan derivationPlan, arg func(any) int) ([]string, error) {
+	where := []string{spec.baseWhere}
+	for _, p := range plan.preds {
+		if p.value == "" {
+			where = append(where, p.expr+" IS NULL")
+		} else {
+			where = append(where, fmt.Sprintf("%s = $%d", p.expr, arg(p.value)))
+		}
+	}
+	var scope string
+	var err error
+	if spec.activityWalk {
+		scope, err = auth.ActivityScopeClause(ctx, "t", arg)
+	} else {
+		scope, err = auth.ScopeClauseFor(ctx, string(spec.entity), "t", arg)
+	}
+	if err != nil {
+		return nil, err
+	}
+	if scope != "" {
+		where = append(where, scope)
+	}
+	return where, nil
+}
+
+// scanDerivationRows materializes the drill-through rows, mapping each
+// column to its wire value positionally.
+func scanDerivationRows(pgRows pgx.Rows, columns []string) ([]map[string]any, error) {
+	var out []map[string]any
+	for pgRows.Next() {
+		values, err := pgRows.Values()
+		if err != nil {
+			return nil, err
+		}
+		row := make(map[string]any, len(columns))
+		for i, col := range columns {
+			row[col] = wireValue(values[i])
+		}
+		out = append(out, row)
+	}
+	if err := pgRows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // boundPredicate is one field = value binding rendered into the

--- a/backend/internal/modules/approvals/inbox.go
+++ b/backend/internal/modules/approvals/inbox.go
@@ -94,51 +94,71 @@ func (s *Service) List(ctx context.Context, status *string, limit int) ([]row, e
 		var afterCreated *time.Time
 		var afterID *ids.UUID
 		for {
-			q := `SELECT ` + columns + ` FROM approval`
-			args := []any{}
-			arg := func(v any) int { args = append(args, v); return len(args) }
-			where := []string{}
-			if status != nil {
-				where = append(where, fmt.Sprintf("status = $%d", arg(*status)))
-			}
-			if afterCreated != nil {
-				where = append(where, fmt.Sprintf("(created_at, id) < ($%d, $%d)", arg(*afterCreated), arg(*afterID)))
-			}
-			for i, w := range where {
-				if i == 0 {
-					q += " WHERE " + w
-				} else {
-					q += " AND " + w
-				}
-			}
-			q += fmt.Sprintf(` ORDER BY created_at DESC, id DESC LIMIT %d`, inboxBatch)
-
+			q, args := inboxPageQuery(status, afterCreated, afterID)
 			batch, err := collect(ctx, tx, q, args)
 			if err != nil {
 				return err
 			}
-			for i := range batch {
-				a := batch[i]
-				visible, err := decidable(ctx, tx, p, a)
-				if err != nil {
-					return err
-				}
-				if !visible {
-					continue
-				}
-				out = append(out, a)
-				if len(out) >= limit {
-					return nil
-				}
+			var full bool
+			out, full, err = appendDecidable(ctx, tx, p, batch, out, limit)
+			if err != nil {
+				return err
 			}
-			if len(batch) < inboxBatch {
-				return nil // table exhausted
+			if full || len(batch) < inboxBatch {
+				return nil // display limit met, or the table is exhausted
 			}
 			last := batch[len(batch)-1]
 			afterCreated, afterID = &last.CreatedAt, &last.ID
 		}
 	})
 	return out, err
+}
+
+// inboxPageQuery builds one keyset page of the inbox scan: newest first,
+// optionally filtered by status and paged past the (created_at, id)
+// cursor of the previous batch.
+func inboxPageQuery(status *string, afterCreated *time.Time, afterID *ids.UUID) (string, []any) {
+	q := `SELECT ` + columns + ` FROM approval`
+	args := []any{}
+	arg := func(v any) int { args = append(args, v); return len(args) }
+	where := []string{}
+	if status != nil {
+		where = append(where, fmt.Sprintf("status = $%d", arg(*status)))
+	}
+	if afterCreated != nil {
+		where = append(where, fmt.Sprintf("(created_at, id) < ($%d, $%d)", arg(*afterCreated), arg(*afterID)))
+	}
+	for i, w := range where {
+		if i == 0 {
+			q += " WHERE " + w
+		} else {
+			q += " AND " + w
+		}
+	}
+	q += fmt.Sprintf(` ORDER BY created_at DESC, id DESC LIMIT %d`, inboxBatch)
+	return q, args
+}
+
+// appendDecidable filters one scanned batch through the decidability
+// probe and appends the visible rows to out, stopping the moment the
+// display limit is met (full = true) so a burst of undecidable stagings
+// cannot starve older visible rows out of the caller's inbox.
+func appendDecidable(ctx context.Context, tx pgx.Tx, p principal.Principal, batch, out []row, limit int) ([]row, bool, error) {
+	for i := range batch {
+		a := batch[i]
+		visible, err := decidable(ctx, tx, p, a)
+		if err != nil {
+			return out, false, err
+		}
+		if !visible {
+			continue
+		}
+		out = append(out, a)
+		if len(out) >= limit {
+			return out, true, nil
+		}
+	}
+	return out, false, nil
 }
 
 // collect materializes one query's rows (the row-scope probes inside the

--- a/backend/internal/modules/approvals/service.go
+++ b/backend/internal/modules/approvals/service.go
@@ -242,28 +242,9 @@ func (s *Service) decide(ctx context.Context, id ids.UUID, approve bool, reason 
 			"kind": a.Kind, "verdict": verdict, "decided_by": p.UserID,
 		}
 		if edited != nil {
-			canonical, editedHash, hashErr := diffhash.Canonical(edited)
-			if hashErr != nil {
-				return &InvalidEditError{Cause: hashErr}
-			}
-			if _, err := tx.Exec(ctx,
-				`UPDATE approval SET proposed_change = $2, diff_hash = $3 WHERE id = $1`,
-				id, canonical, editedHash); err != nil {
+			if err := applyEditedPayload(ctx, tx, id, edited, a, auditEvidence, decidedPayload); err != nil {
 				return err
 			}
-			// Both sides of the human delta go on the record: what the
-			// agent proposed, and what the human actually released.
-			auditEvidence["edited"] = true
-			auditEvidence["original_change"] = json.RawMessage(a.ProposedChange)
-			auditEvidence["original_diff_hash"] = a.DiffHash
-			auditEvidence["edited_change"] = json.RawMessage(canonical)
-			auditEvidence["edited_diff_hash"] = editedHash
-			decidedPayload["edited"] = true
-			decidedPayload["diff_hash"] = editedHash
-			// The decided event carries the human's version: a suspended
-			// agent run resumes with THIS call — the original one no
-			// longer matches any authority.
-			decidedPayload["edited_change"] = json.RawMessage(canonical)
 		}
 		if _, err := tx.Exec(ctx,
 			`UPDATE approval SET status = $2, decided_by = $3, decided_at = now(), decision_reason = $4
@@ -278,16 +259,8 @@ func (s *Service) decide(ctx context.Context, id ids.UUID, approve bool, reason 
 		if err := s.emit(ctx, tx, p, auditID, "approval.decided", id, decidedPayload); err != nil {
 			return err
 		}
-		if echo, ok := kindDecidedEvents[a.Kind]; ok {
-			eventType := echo.rejected
-			if approve {
-				eventType = echo.approved
-			}
-			if err := s.emit(ctx, tx, p, auditID, eventType, id, map[string]any{
-				"approval_id": id, "decided_by": p.UserID,
-			}); err != nil {
-				return err
-			}
+		if err := s.emitKindDecided(ctx, tx, p, auditID, id, a.Kind, approve); err != nil {
+			return err
 		}
 		a, err = get(ctx, tx, id)
 		return err
@@ -305,6 +278,50 @@ func (s *Service) decide(ctx context.Context, id ids.UUID, approve bool, reason 
 		}
 	}
 	return a, err
+}
+
+// applyEditedPayload is the modify-then-approve write (ADR-0036 §4): the
+// human's edited payload replaces the staged change under a freshly
+// computed diff_hash, and both sides of the human delta go on the record
+// — what the agent proposed, and what the human actually released. The
+// decided event carries the human's version, so a suspended agent run
+// resumes with THIS call; the original hash no longer opens anything.
+func applyEditedPayload(ctx context.Context, tx pgx.Tx, id ids.UUID, edited json.RawMessage, a row, auditEvidence, decidedPayload map[string]any) error {
+	canonical, editedHash, hashErr := diffhash.Canonical(edited)
+	if hashErr != nil {
+		return &InvalidEditError{Cause: hashErr}
+	}
+	if _, err := tx.Exec(ctx,
+		`UPDATE approval SET proposed_change = $2, diff_hash = $3 WHERE id = $1`,
+		id, canonical, editedHash); err != nil {
+		return err
+	}
+	auditEvidence["edited"] = true
+	auditEvidence["original_change"] = json.RawMessage(a.ProposedChange)
+	auditEvidence["original_diff_hash"] = a.DiffHash
+	auditEvidence["edited_change"] = json.RawMessage(canonical)
+	auditEvidence["edited_diff_hash"] = editedHash
+	decidedPayload["edited"] = true
+	decidedPayload["diff_hash"] = editedHash
+	decidedPayload["edited_change"] = json.RawMessage(canonical)
+	return nil
+}
+
+// emitKindDecided fires the kind-specific echo of the verdict (e.g. a
+// coldstart read-back's approved/rejected event) on the same audit row,
+// when the staging's kind registers one.
+func (s *Service) emitKindDecided(ctx context.Context, tx pgx.Tx, p principal.Principal, auditID, id ids.UUID, kind string, approve bool) error {
+	echo, ok := kindDecidedEvents[kind]
+	if !ok {
+		return nil
+	}
+	eventType := echo.rejected
+	if approve {
+		eventType = echo.approved
+	}
+	return s.emit(ctx, tx, p, auditID, eventType, id, map[string]any{
+		"approval_id": id, "decided_by": p.UserID,
+	})
 }
 
 // Redeem consumes one approved staging for exactly the call it was staged

--- a/backend/internal/modules/consent/store.go
+++ b/backend/internal/modules/consent/store.go
@@ -210,14 +210,7 @@ func (s *Store) Record(ctx context.Context, in RecordInput) (State, error) {
 		if err := auth.EnsureVisible(ctx, tx, "person", in.PersonID); err != nil {
 			return err
 		}
-		var purposeKey string
-		var requiresDOI bool
-		err := tx.QueryRow(ctx,
-			`SELECT key, requires_double_opt_in FROM consent_purpose WHERE id = $1 AND archived_at IS NULL`,
-			in.PurposeID).Scan(&purposeKey, &requiresDOI)
-		if errors.Is(err, pgx.ErrNoRows) {
-			return fmt.Errorf("purpose %s: %w", in.PurposeID, apperrors.ErrNotFound)
-		}
+		purposeKey, requiresDOI, err := loadConsentPurpose(ctx, tx, in.PurposeID)
 		if err != nil {
 			return err
 		}
@@ -237,21 +230,9 @@ func (s *Store) Record(ctx context.Context, in RecordInput) (State, error) {
 			return nil // the decision on record stands; an anonymous capture cannot flip it
 		}
 
-		// The German email norm: a DOI purpose's grant is only effective
-		// once the double-opt-in round-trip confirmed. The token must be
-		// one this server issued (hash-matched, unconsumed, unexpired) —
-		// consuming it here makes the confirmation single-use and
-		// unfabricatable rather than stored half-true.
-		var doiConfirmedAt *time.Time
-		if in.NewState == "granted" && requiresDOI {
-			if in.DoubleOptInToken == nil || *in.DoubleOptInToken == "" {
-				return &ValidationError{Field: "double_opt_in_token", Reason: "purpose requires a confirmed double opt-in"}
-			}
-			confirmed, err := s.consumeDOIToken(ctx, tx, in.PersonID, in.PurposeID, *in.DoubleOptInToken)
-			if err != nil {
-				return err
-			}
-			doiConfirmedAt = &confirmed
+		doiConfirmedAt, err := s.resolveDOIConfirmation(ctx, tx, in, requiresDOI)
+		if err != nil {
+			return err
 		}
 
 		capturedAt := s.now().UTC()
@@ -279,6 +260,40 @@ func (s *Store) Record(ctx context.Context, in RecordInput) (State, error) {
 		return nil
 	})
 	return out, err
+}
+
+// loadConsentPurpose resolves the target purpose's key and DOI flag; an
+// unknown or archived purpose is 404.
+func loadConsentPurpose(ctx context.Context, tx pgx.Tx, purposeID ids.UUID) (key string, requiresDOI bool, err error) {
+	err = tx.QueryRow(ctx,
+		`SELECT key, requires_double_opt_in FROM consent_purpose WHERE id = $1 AND archived_at IS NULL`,
+		purposeID).Scan(&key, &requiresDOI)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", false, fmt.Errorf("purpose %s: %w", purposeID, apperrors.ErrNotFound)
+	}
+	if err != nil {
+		return "", false, err
+	}
+	return key, requiresDOI, nil
+}
+
+// resolveDOIConfirmation enforces the German email norm: a DOI purpose's
+// grant is only effective once the double-opt-in round-trip confirmed.
+// The token must be one this server issued (hash-matched, unconsumed,
+// unexpired) — consuming it here makes the confirmation single-use and
+// unfabricatable rather than stored half-true. Non-DOI paths return nil.
+func (s *Store) resolveDOIConfirmation(ctx context.Context, tx pgx.Tx, in RecordInput, requiresDOI bool) (*time.Time, error) {
+	if in.NewState != "granted" || !requiresDOI {
+		return nil, nil
+	}
+	if in.DoubleOptInToken == nil || *in.DoubleOptInToken == "" {
+		return nil, &ValidationError{Field: "double_opt_in_token", Reason: "purpose requires a confirmed double opt-in"}
+	}
+	confirmed, err := s.consumeDOIToken(ctx, tx, in.PersonID, in.PurposeID, *in.DoubleOptInToken)
+	if err != nil {
+		return nil, err
+	}
+	return &confirmed, nil
 }
 
 // upsertConsentWithProof writes the state row and appends the immutable

--- a/backend/internal/modules/deals/deal.go
+++ b/backend/internal/modules/deals/deal.go
@@ -172,36 +172,8 @@ func (s *Store) UpdateDeal(ctx context.Context, id ids.UUID, in UpdateDealInput)
 		if err := p.Apply(ctx, tx, "deal", id, in.IfVersion); err != nil {
 			return fmt.Errorf("apply deal patch: %w", err)
 		}
-		auditID, err := storekit.Audit(ctx, tx, "update", "deal", id, p.Before(), p.After())
-		if err != nil {
-			return fmt.Errorf("audit deal update: %w", err)
-		}
-
-		// Owner reassignment is a first-class fact with its own
-		// consumers (events.md §5.3): emit deal.owner_changed for the
-		// owner transition and deal.updated only for the other fields —
-		// both on this request's correlation_id when they co-occur.
-		ownerChanged := in.OwnerID != nil && (current.OwnerId == nil || ids.UUID(*current.OwnerId) != *in.OwnerID)
-		if ownerChanged {
-			payload := map[string]any{"to_owner_id": *in.OwnerID}
-			if current.OwnerId != nil {
-				payload["from_owner_id"] = *current.OwnerId
-			}
-			if err := storekit.Emit(ctx, tx, auditID, "deal.owner_changed", "deal", id, payload); err != nil {
-				return fmt.Errorf("emit deal.owner_changed: %w", err)
-			}
-		}
-		rest := make(map[string]any, len(p.After()))
-		for field, v := range p.After() {
-			if ownerChanged && field == "owner_id" {
-				continue
-			}
-			rest[field] = v
-		}
-		if len(rest) > 0 {
-			if err := storekit.Emit(ctx, tx, auditID, "deal.updated", "deal", id, rest); err != nil {
-				return fmt.Errorf("emit deal.updated: %w", err)
-			}
+		if err := recordDealUpdate(ctx, tx, id, current, in, p); err != nil {
+			return err
 		}
 		if out, err = readDeal(ctx, tx, id, storekit.LiveOnly); err != nil {
 			return fmt.Errorf("read updated deal: %w", err)
@@ -209,6 +181,42 @@ func (s *Store) UpdateDeal(ctx context.Context, id ids.UUID, in UpdateDealInput)
 		return nil
 	})
 	return out, err
+}
+
+// recordDealUpdate lands the write shape's audit row and its paired
+// outbox events. The fan-out splits by consumer (events.md §5.3): owner
+// reassignment is a first-class fact, so it emits deal.owner_changed for
+// the owner transition and deal.updated only for the other fields — both
+// on this request's correlation_id when they co-occur.
+func recordDealUpdate(ctx context.Context, tx pgx.Tx, id ids.UUID, current crmcontracts.Deal, in UpdateDealInput, p *storekit.Patch) error {
+	auditID, err := storekit.Audit(ctx, tx, "update", "deal", id, p.Before(), p.After())
+	if err != nil {
+		return fmt.Errorf("audit deal update: %w", err)
+	}
+	after := p.After()
+	ownerChanged := in.OwnerID != nil && (current.OwnerId == nil || ids.UUID(*current.OwnerId) != *in.OwnerID)
+	if ownerChanged {
+		payload := map[string]any{"to_owner_id": *in.OwnerID}
+		if current.OwnerId != nil {
+			payload["from_owner_id"] = *current.OwnerId
+		}
+		if err := storekit.Emit(ctx, tx, auditID, "deal.owner_changed", "deal", id, payload); err != nil {
+			return fmt.Errorf("emit deal.owner_changed: %w", err)
+		}
+	}
+	rest := make(map[string]any, len(after))
+	for field, v := range after {
+		if ownerChanged && field == "owner_id" {
+			continue
+		}
+		rest[field] = v
+	}
+	if len(rest) > 0 {
+		if err := storekit.Emit(ctx, tx, auditID, "deal.updated", "deal", id, rest); err != nil {
+			return fmt.Errorf("emit deal.updated: %w", err)
+		}
+	}
+	return nil
 }
 
 // dealUpdatePatch folds the caller's sparse update onto the current row

--- a/backend/internal/modules/deals/offer.go
+++ b/backend/internal/modules/deals/offer.go
@@ -470,56 +470,12 @@ func (s *Store) UpdateOfferLineItem(ctx context.Context, offerID, lineID ids.UUI
 			return err
 		}
 
-		var line OfferLineInput
-		var curPosition int
-		var curDescription, curUnit string
-		err = tx.QueryRow(ctx,
-			`SELECT position, description, unit, quantity::text, unit_price_minor, discount_pct::text, tax_rate::text
-			 FROM offer_line_item WHERE id = $1 AND offer_id = $2`, lineID, offerID).
-			Scan(&curPosition, &curDescription, &curUnit, &line.Quantity, &line.UnitPriceMinor, &line.DiscountPct, &line.TaxRate)
+		curPosition, curDescription, curUnit, line, err := readOfferLineForUpdate(ctx, tx, offerID, lineID)
 		if err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
-				return apperrors.ErrNotFound
-			}
-			return fmt.Errorf("read offer line: %w", err)
+			return err
 		}
 
-		// A hand-built patch: storekit's Patch targets archivable rows
-		// (its WHERE carries archived_at IS NULL) and a line lives or
-		// dies with its offer instead — the draft gate above is the
-		// mutability rule here.
-		before, after := map[string]any{}, map[string]any{}
-		sets, args := []string{}, []any{lineID}
-		set := func(column string, oldVal, newVal any) {
-			args = append(args, newVal)
-			sets = append(sets, fmt.Sprintf("%s = $%d", column, len(args)))
-			before[column], after[column] = oldVal, newVal
-		}
-		if in.Position != nil {
-			set("position", curPosition, *in.Position)
-		}
-		if in.Description != nil {
-			set("description", curDescription, *in.Description)
-		}
-		if in.Unit != nil {
-			set("unit", curUnit, *in.Unit)
-		}
-		if in.Quantity != nil {
-			set("quantity", line.Quantity, *in.Quantity)
-			line.Quantity = *in.Quantity
-		}
-		if in.UnitPriceMinor != nil {
-			set("unit_price_minor", line.UnitPriceMinor, *in.UnitPriceMinor)
-			line.UnitPriceMinor = *in.UnitPriceMinor
-		}
-		if in.DiscountPct != nil {
-			set("discount_pct", line.DiscountPct, *in.DiscountPct)
-			line.DiscountPct = *in.DiscountPct
-		}
-		if in.TaxRate != nil {
-			set("tax_rate", line.TaxRate, *in.TaxRate)
-			line.TaxRate = *in.TaxRate
-		}
+		sets, args, before, after, line := buildOfferLinePatch(lineID, in, curPosition, curDescription, curUnit, line)
 		// Validate the resulting line's math up front (422, not a CHECK 500).
 		if _, err := LineTotals(line); err != nil {
 			return err
@@ -548,6 +504,64 @@ func (s *Store) UpdateOfferLineItem(ctx context.Context, offerID, lineID ids.UUI
 		return nil
 	})
 	return out, err
+}
+
+// readOfferLineForUpdate loads the line's current snapshot for a patch;
+// a missing line (or one on another offer) is 404, not a fault.
+func readOfferLineForUpdate(ctx context.Context, tx pgx.Tx, offerID, lineID ids.UUID) (curPosition int, curDescription, curUnit string, line OfferLineInput, err error) {
+	err = tx.QueryRow(ctx,
+		`SELECT position, description, unit, quantity::text, unit_price_minor, discount_pct::text, tax_rate::text
+		 FROM offer_line_item WHERE id = $1 AND offer_id = $2`, lineID, offerID).
+		Scan(&curPosition, &curDescription, &curUnit, &line.Quantity, &line.UnitPriceMinor, &line.DiscountPct, &line.TaxRate)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return 0, "", "", OfferLineInput{}, apperrors.ErrNotFound
+	}
+	if err != nil {
+		return 0, "", "", OfferLineInput{}, fmt.Errorf("read offer line: %w", err)
+	}
+	return curPosition, curDescription, curUnit, line, nil
+}
+
+// buildOfferLinePatch folds the caller's sparse line edit into a
+// hand-built patch. storekit's Patch targets archivable rows (its WHERE
+// carries archived_at IS NULL) and a line lives or dies with its offer
+// instead — the draft gate is the mutability rule here. It returns the
+// SET fragments and args ($1 is the line id), the before/after audit
+// maps, and the resulting line with the edits applied for validation.
+func buildOfferLinePatch(lineID ids.UUID, in UpdateOfferLineInput, curPosition int, curDescription, curUnit string, line OfferLineInput) (sets []string, args []any, before, after map[string]any, validated OfferLineInput) {
+	before, after = map[string]any{}, map[string]any{}
+	sets, args = []string{}, []any{lineID}
+	set := func(column string, oldVal, newVal any) {
+		args = append(args, newVal)
+		sets = append(sets, fmt.Sprintf("%s = $%d", column, len(args)))
+		before[column], after[column] = oldVal, newVal
+	}
+	if in.Position != nil {
+		set("position", curPosition, *in.Position)
+	}
+	if in.Description != nil {
+		set("description", curDescription, *in.Description)
+	}
+	if in.Unit != nil {
+		set("unit", curUnit, *in.Unit)
+	}
+	if in.Quantity != nil {
+		set("quantity", line.Quantity, *in.Quantity)
+		line.Quantity = *in.Quantity
+	}
+	if in.UnitPriceMinor != nil {
+		set("unit_price_minor", line.UnitPriceMinor, *in.UnitPriceMinor)
+		line.UnitPriceMinor = *in.UnitPriceMinor
+	}
+	if in.DiscountPct != nil {
+		set("discount_pct", line.DiscountPct, *in.DiscountPct)
+		line.DiscountPct = *in.DiscountPct
+	}
+	if in.TaxRate != nil {
+		set("tax_rate", line.TaxRate, *in.TaxRate)
+		line.TaxRate = *in.TaxRate
+	}
+	return sets, args, before, after, line
 }
 
 func (s *Store) RemoveOfferLineItem(ctx context.Context, offerID, lineID ids.UUID) (crmcontracts.Offer, error) {

--- a/backend/internal/modules/people/lead.go
+++ b/backend/internal/modules/people/lead.go
@@ -314,34 +314,9 @@ func (s *Store) UpdateLead(ctx context.Context, id ids.UUID, in UpdateLeadInput)
 			return err
 		}
 
-		p := storekit.NewPatch()
-		if in.FullName != nil {
-			p.Set("full_name", current.FullName, *in.FullName)
-		}
-		if in.Email != nil {
-			p.Set("email", current.Email, strings.ToLower(*in.Email))
-		}
-		if in.Title != nil {
-			p.Set("title", current.Title, *in.Title)
-		}
-		if in.CompanyName != nil {
-			p.Set("company_name", current.CompanyName, *in.CompanyName)
-		}
-		if in.CandidateOrgKey != nil {
-			p.Set("candidate_org_key", current.CandidateOrgKey, *in.CandidateOrgKey)
-		}
-		if in.Status != nil {
-			p.Set("status", current.Status, *in.Status)
-		}
-		// Commercial Judgement score override (formulas §3.1, A68/ADR-0053):
-		// a human score is sticky. Setting it demands a written reason and
-		// retains the machine value; clearing the reason resumes recompute.
-		resumeRecompute, err := applyScoreOverride(p, current, in)
+		p, resumeRecompute, err := buildLeadPatch(current, in)
 		if err != nil {
 			return err
-		}
-		if in.OwnerID != nil {
-			p.Set("owner_id", current.OwnerId, *in.OwnerID)
 		}
 		if p.Empty() {
 			out = current
@@ -375,6 +350,42 @@ func (s *Store) UpdateLead(ctx context.Context, id ids.UUID, in UpdateLeadInput)
 		return err
 	})
 	return out, err
+}
+
+// buildLeadPatch folds the caller's sparse update onto the current lead
+// as a field patch, and reports whether the caller must resume recompute
+// (a cleared score override). The Commercial Judgement score override
+// (formulas §3.1, A68/ADR-0053) is sticky: setting a score demands a
+// written reason and retains the machine value; clearing the reason
+// resumes recompute.
+func buildLeadPatch(current crmcontracts.Lead, in UpdateLeadInput) (*storekit.Patch, bool, error) {
+	p := storekit.NewPatch()
+	if in.FullName != nil {
+		p.Set("full_name", current.FullName, *in.FullName)
+	}
+	if in.Email != nil {
+		p.Set("email", current.Email, strings.ToLower(*in.Email))
+	}
+	if in.Title != nil {
+		p.Set("title", current.Title, *in.Title)
+	}
+	if in.CompanyName != nil {
+		p.Set("company_name", current.CompanyName, *in.CompanyName)
+	}
+	if in.CandidateOrgKey != nil {
+		p.Set("candidate_org_key", current.CandidateOrgKey, *in.CandidateOrgKey)
+	}
+	if in.Status != nil {
+		p.Set("status", current.Status, *in.Status)
+	}
+	resumeRecompute, err := applyScoreOverride(p, current, in)
+	if err != nil {
+		return nil, false, err
+	}
+	if in.OwnerID != nil {
+		p.Set("owner_id", current.OwnerId, *in.OwnerID)
+	}
+	return p, resumeRecompute, nil
 }
 
 // applyScoreOverride folds the §3.1 sticky-override rules into the patch

--- a/backend/internal/modules/people/organization.go
+++ b/backend/internal/modules/people/organization.go
@@ -63,25 +63,8 @@ func (s *Store) CreateOrganization(ctx context.Context, in CreateOrganizationInp
 	err = s.tx(ctx, func(tx pgx.Tx) error {
 		wsID := storekit.MustWorkspace(ctx)
 
-		for _, d := range in.Domains {
-			var existing ids.UUID
-			err := tx.QueryRow(ctx,
-				`SELECT organization_id FROM organization_domain WHERE domain = lower($1) AND archived_at IS NULL`,
-				d.Domain).Scan(&existing)
-			if err == nil {
-				dup := &DuplicateDomainError{Domain: d.Domain}
-				visible, verr := auth.VisibleTo(ctx, tx, "organization", existing)
-				if verr != nil {
-					return verr
-				}
-				if visible {
-					dup.ExistingID = existing
-				}
-				return dup
-			}
-			if !errors.Is(err, pgx.ErrNoRows) {
-				return fmt.Errorf("probe domain dedupe: %w", err)
-			}
+		if err := ensureOrgDomainsUnclaimed(ctx, tx, in.Domains); err != nil {
+			return err
 		}
 
 		// Naming a parent is a read of the parent: the child discloses the
@@ -103,19 +86,8 @@ func (s *Store) CreateOrganization(ctx context.Context, in CreateOrganizationInp
 			return fmt.Errorf("insert organization: %w", err)
 		}
 
-		for _, d := range in.Domains {
-			if _, err := tx.Exec(ctx,
-				`INSERT INTO organization_domain (workspace_id, organization_id, domain, is_primary, source, captured_by)
-				 VALUES ($1, $2, lower($3), $4, $5, $6)`,
-				wsID, id, d.Domain, d.IsPrimary, in.Source, by); err != nil {
-				if name, ok := storekit.UniqueViolation(err); ok {
-					if name == "uq_org_domain" {
-						return &DuplicateDomainError{Domain: d.Domain}
-					}
-					return apperrors.ErrConflict // e.g. a second primary domain
-				}
-				return fmt.Errorf("insert organization domain: %w", err)
-			}
+		if err := insertOrgDomains(ctx, tx, wsID, id, in.Source, by, in.Domains); err != nil {
+			return err
 		}
 
 		auditID, err := storekit.Audit(ctx, tx, "create", "organization", id, nil, map[string]any{"display_name": in.DisplayName})
@@ -131,6 +103,56 @@ func (s *Store) CreateOrganization(ctx context.Context, in CreateOrganizationInp
 		return nil
 	})
 	return out, err
+}
+
+// ensureOrgDomainsUnclaimed answers the domain dedupe probe with the
+// contract's 409, disclosing the existing org id only when the caller
+// could read that row (a domain maps to at most one org per workspace,
+// data-model §4.2).
+func ensureOrgDomainsUnclaimed(ctx context.Context, tx pgx.Tx, domains []OrgDomainInput) error {
+	for _, d := range domains {
+		var existing ids.UUID
+		err := tx.QueryRow(ctx,
+			`SELECT organization_id FROM organization_domain WHERE domain = lower($1) AND archived_at IS NULL`,
+			d.Domain).Scan(&existing)
+		if errors.Is(err, pgx.ErrNoRows) {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("probe domain dedupe: %w", err)
+		}
+		dup := &DuplicateDomainError{Domain: d.Domain}
+		visible, verr := auth.VisibleTo(ctx, tx, "organization", existing)
+		if verr != nil {
+			return verr
+		}
+		if visible {
+			dup.ExistingID = existing
+		}
+		return dup
+	}
+	return nil
+}
+
+// insertOrgDomains lands the org's domains; the unique index remains the
+// structural guarantee under races, mapping uq_org_domain to the typed
+// 409 and a second primary domain to a plain conflict.
+func insertOrgDomains(ctx context.Context, tx pgx.Tx, wsID, orgID ids.UUID, source, by string, domains []OrgDomainInput) error {
+	for _, d := range domains {
+		if _, err := tx.Exec(ctx,
+			`INSERT INTO organization_domain (workspace_id, organization_id, domain, is_primary, source, captured_by)
+			 VALUES ($1, $2, lower($3), $4, $5, $6)`,
+			wsID, orgID, d.Domain, d.IsPrimary, source, by); err != nil {
+			if name, ok := storekit.UniqueViolation(err); ok {
+				if name == "uq_org_domain" {
+					return &DuplicateDomainError{Domain: d.Domain}
+				}
+				return apperrors.ErrConflict // e.g. a second primary domain
+			}
+			return fmt.Errorf("insert organization domain: %w", err)
+		}
+	}
+	return nil
 }
 
 func (s *Store) GetOrganization(ctx context.Context, id ids.UUID, archived storekit.ArchivedFilter) (crmcontracts.Organization, error) {

--- a/backend/internal/modules/people/person.go
+++ b/backend/internal/modules/people/person.go
@@ -89,30 +89,11 @@ func (s *Store) CreatePerson(ctx context.Context, in CreatePersonInput) (crmcont
 			return fmt.Errorf("insert person: %w", err)
 		}
 
-		for _, e := range in.Emails {
-			if _, err := tx.Exec(ctx,
-				`INSERT INTO person_email (workspace_id, person_id, email, email_type, is_primary, position, source, captured_by)
-				 VALUES ($1, $2, lower($3), $4, $5, $6, $7, $8)`,
-				wsID, id, e.Email, e.EmailType, e.IsPrimary, e.Position, in.Source, by); err != nil {
-				if name, ok := storekit.UniqueViolation(err); ok {
-					if name == "uq_person_email_dedupe" {
-						// Race with a concurrent create: the transaction is
-						// aborted, so no id re-query is possible; the 409
-						// omits existing_id.
-						return &DuplicateEmailError{Email: e.Email}
-					}
-					return apperrors.ErrConflict // e.g. two primary emails of one type
-				}
-				return fmt.Errorf("insert person email: %w", err)
-			}
+		if err := insertPersonEmails(ctx, tx, wsID, id, in.Source, by, in.Emails); err != nil {
+			return err
 		}
-		for _, p := range in.Phones {
-			if _, err := tx.Exec(ctx,
-				`INSERT INTO person_phone (workspace_id, person_id, phone, phone_type, is_primary, position, source, captured_by)
-				 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
-				wsID, id, p.Phone, p.PhoneType, p.IsPrimary, p.Position, in.Source, by); err != nil {
-				return fmt.Errorf("insert person phone: %w", err)
-			}
+		if err := insertPersonPhones(ctx, tx, wsID, id, in.Source, by, in.Phones); err != nil {
+			return err
 		}
 
 		auditID, err := storekit.Audit(ctx, tx, "create", "person", id, nil, map[string]any{"full_name": in.FullName})
@@ -129,6 +110,41 @@ func (s *Store) CreatePerson(ctx context.Context, in CreatePersonInput) (crmcont
 		return nil
 	})
 	return out, err
+}
+
+// insertPersonEmails lands the person's emails; the unique index stays
+// the structural guarantee under races, mapping uq_person_email_dedupe
+// to the typed 409 (which omits existing_id — the aborted transaction
+// cannot re-query) and two primary emails of one type to a plain conflict.
+func insertPersonEmails(ctx context.Context, tx pgx.Tx, wsID, personID ids.UUID, source, by string, emails []PersonEmailInput) error {
+	for _, e := range emails {
+		if _, err := tx.Exec(ctx,
+			`INSERT INTO person_email (workspace_id, person_id, email, email_type, is_primary, position, source, captured_by)
+			 VALUES ($1, $2, lower($3), $4, $5, $6, $7, $8)`,
+			wsID, personID, e.Email, e.EmailType, e.IsPrimary, e.Position, source, by); err != nil {
+			if name, ok := storekit.UniqueViolation(err); ok {
+				if name == "uq_person_email_dedupe" {
+					return &DuplicateEmailError{Email: e.Email}
+				}
+				return apperrors.ErrConflict
+			}
+			return fmt.Errorf("insert person email: %w", err)
+		}
+	}
+	return nil
+}
+
+// insertPersonPhones lands the person's phone rows.
+func insertPersonPhones(ctx context.Context, tx pgx.Tx, wsID, personID ids.UUID, source, by string, phones []PersonPhoneInput) error {
+	for _, p := range phones {
+		if _, err := tx.Exec(ctx,
+			`INSERT INTO person_phone (workspace_id, person_id, phone, phone_type, is_primary, position, source, captured_by)
+			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+			wsID, personID, p.Phone, p.PhoneType, p.IsPrimary, p.Position, source, by); err != nil {
+			return fmt.Errorf("insert person phone: %w", err)
+		}
+	}
+	return nil
 }
 
 // ensurePersonEmailsUnclaimed is the dedupe pre-check, so the 409 can

--- a/backend/internal/modules/people/relationship.go
+++ b/backend/internal/modules/people/relationship.go
@@ -216,20 +216,8 @@ func (s *Store) CreateRelationship(ctx context.Context, in CreateRelationshipInp
 
 	var out relationshipRow
 	err = s.tx(ctx, func(tx pgx.Tx) error {
-		// Every supplied endpoint is a client-supplied FK argument (H1).
-		for _, ref := range []struct {
-			table string
-			id    *ids.UUID
-		}{
-			{"person", in.PersonID}, {"organization", in.OrganizationID},
-			{"organization", in.CounterpartyOrgID}, {"deal", in.DealID},
-		} {
-			if ref.id == nil {
-				continue
-			}
-			if err := auth.EnsureLinkTarget(ctx, tx, ref.table, *ref.id); err != nil {
-				return err
-			}
+		if err := ensureRelationshipEndpoints(ctx, tx, in); err != nil {
+			return err
 		}
 		// One current primary employer per person: demote the incumbent
 		// inside the same transaction rather than failing the write.
@@ -250,29 +238,55 @@ func (s *Store) CreateRelationship(ctx context.Context, in CreateRelationshipInp
 			in.Kind, in.PersonID, in.OrganizationID, in.CounterpartyOrgID, in.DealID,
 			in.Role, in.IsCurrentPrimary, in.StartedAt, in.EndedAt, in.Source, capturedBy)
 		if out, err = scanRelationship(row); err != nil {
-			// The rel_* CHECKs are the kind→endpoint shape rules
-			// (migration 0007): a violation is bad input, not a fault.
-			if constraint, ok := storekit.CheckViolation(err); ok {
-				switch constraint {
-				case "rel_employment_shape", "rel_stakeholder_shape", "rel_partner_shape":
-					return &RequiredFieldError{Field: "kind: " + in.Kind + " endpoint shape"}
-				case "rel_dates":
-					return &RequiredFieldError{Field: "ended_at: must not precede started_at"}
-				}
-			}
-			// The partial unique indexes are the edge dedupe rules: a
-			// second identical edge is a conflict on the existing one.
-			if constraint, ok := storekit.UniqueViolation(err); ok {
-				switch constraint {
-				case "uq_rel_current_primary_employer", "uq_rel_deal_person_role":
-					return fmt.Errorf("relationship %s: %w", constraint, apperrors.ErrConflict)
-				}
-			}
-			return err
+			return mapRelationshipConstraint(err, in.Kind)
 		}
 		return emitRelationshipChange(ctx, tx, "create", out)
 	})
 	return out, err
+}
+
+// ensureRelationshipEndpoints validates every supplied endpoint as a
+// client-supplied FK argument (H1): each named target must be visible
+// under the caller's row scope before the edge lands.
+func ensureRelationshipEndpoints(ctx context.Context, tx pgx.Tx, in CreateRelationshipInput) error {
+	for _, ref := range []struct {
+		table string
+		id    *ids.UUID
+	}{
+		{"person", in.PersonID}, {"organization", in.OrganizationID},
+		{"organization", in.CounterpartyOrgID}, {"deal", in.DealID},
+	} {
+		if ref.id == nil {
+			continue
+		}
+		if err := auth.EnsureLinkTarget(ctx, tx, ref.table, *ref.id); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// mapRelationshipConstraint turns the insert's constraint failures into
+// typed input errors: the rel_* CHECKs are the kind→endpoint shape rules
+// (migration 0007) — bad input, not a fault — and the partial unique
+// indexes are the edge dedupe rules (a second identical edge conflicts
+// with the existing one). Anything else surfaces unchanged.
+func mapRelationshipConstraint(err error, kind string) error {
+	if constraint, ok := storekit.CheckViolation(err); ok {
+		switch constraint {
+		case "rel_employment_shape", "rel_stakeholder_shape", "rel_partner_shape":
+			return &RequiredFieldError{Field: "kind: " + kind + " endpoint shape"}
+		case "rel_dates":
+			return &RequiredFieldError{Field: "ended_at: must not precede started_at"}
+		}
+	}
+	if constraint, ok := storekit.UniqueViolation(err); ok {
+		switch constraint {
+		case "uq_rel_current_primary_employer", "uq_rel_deal_person_role":
+			return fmt.Errorf("relationship %s: %w", constraint, apperrors.ErrConflict)
+		}
+	}
+	return err
 }
 
 type UpdateRelationshipInput struct {


### PR DESCRIPTION
## What
Batch 6 (bounded first tranche) — reduces `go:S3776` cognitive complexity on the **10 worst-offending production functions** (complexity 45→30) by extracting cohesive helpers. No behavior change.

## Why
The largest remaining Sonar category is production cognitive complexity. Per the repo's own guidance (STATUS.md / Codex review) these are paid down incrementally, not all at once — this is the first tranche of the worst offenders.

Refactored (all behavior-preserving; helper extraction only):
| Function | Complexity | Extracted |
|---|---|---|
| people `CreateOrganization` | 45 | `ensureOrgDomainsUnclaimed`, `insertOrgDomains` |
| people `UpdateLead` | 41 | `buildLeadPatch` |
| approvals `(*Service).List` | 40 | `inboxPageQuery`, `appendDecidable` |
| deals `UpdateOfferLineItem` | 39 | `readOfferLineForUpdate`, `buildOfferLinePatch` |
| deals `UpdateDeal` | 38 | `recordDealUpdate` |
| approvals `(*Service).decide` | 38 | `applyEditedPayload`, `emitKindDecided` |
| consent `Record` | 35 | `loadConsentPurpose`, `resolveDOIConfirmation` |
| people `CreateRelationship` | 34 | `ensureRelationshipEndpoints`, `mapRelationshipConstraint` |
| compose `fetchDerivation` | 33 | `derivationWhere`, `scanDerivationRows` |
| people `CreatePerson` | 31 | `insertPersonEmails`, `insertPersonPhones` |

## Safety
No `Audit`/`Emit`, `auth.*` gate, tx boundary, SQL text, bind-param order, validation rule, or error sentinel was reordered, dropped, or altered. The write-shape fitness gate (`TestEveryAuditedMutationEmitsAnEvent`) stays green — Audit+Emit kept co-located in `recordDealUpdate`.

## How verified
`make check` green; touched-package unit tests + `go vet -tags integration ./...` green. Craft + security review to follow on the diff.

## AI involvement
Extraction executed by a Claude Code subagent under strict behavior-preservation guardrails; scope + the non-trivial refactors (write-shape helper, existence-hiding dedupe) spot-reviewed by the main agent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inbox pagination so visible items load more reliably and the list stops at the requested limit.
  * Tightened handling for duplicate domains, emails, and relationship conflicts to return clearer validation errors.
  * Made approval, consent, deal, offer line, lead, person, and relationship updates more consistent, reducing edge-case failures and incorrect state changes.
  * Improved edited approval handling and audit tracking for more reliable decision history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->