### PR TITLE
chore(sonar): dedup SQL/column literals in collections (go:S1192)

### DIFF
--- a/backend/internal/modules/collections/savedviews.go
+++ b/backend/internal/modules/collections/savedviews.go
@@ -34,6 +34,10 @@ import (
 
 const savedViewColumns = `id, workspace_id, owner_id, shared_scope, resource, name, query, version, created_at, updated_at, archived_at`
 
+// selectSavedView is the shared projection prefix for every saved_view read —
+// one spelling so the columns can't drift between the list, get, and delete paths.
+const selectSavedView = "SELECT " + savedViewColumns + " FROM saved_view WHERE "
+
 type savedViewRow struct {
 	ID          ids.UUID
 	WorkspaceID ids.UUID
@@ -112,7 +116,7 @@ func (s *Store) ListSavedViews(ctx context.Context, resource *string, archived s
 			where = append(where, "archived_at IS NULL")
 		}
 		rows, err := tx.Query(ctx,
-			"SELECT "+savedViewColumns+" FROM saved_view WHERE "+strings.Join(where, " AND ")+
+			selectSavedView+strings.Join(where, " AND ")+
 				fmt.Sprintf(" ORDER BY name, id LIMIT $%d", arg(catalogCap+1)), args...)
 		if err != nil {
 			return err
@@ -188,7 +192,7 @@ func (s *Store) GetSavedView(ctx context.Context, id ids.UUID) (savedViewRow, er
 	err = database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
 		var err error
 		out, err = scanSavedView(tx.QueryRow(ctx,
-			"SELECT "+savedViewColumns+" FROM saved_view WHERE id = $1 AND owner_id = $2", id, owner))
+			selectSavedView+"id = $1 AND owner_id = $2", id, owner))
 		return err
 	})
 	if errors.Is(err, pgx.ErrNoRows) {
@@ -215,7 +219,7 @@ func (s *Store) UpdateSavedView(ctx context.Context, id ids.UUID, in UpdateSaved
 	var out savedViewRow
 	err = database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
 		current, err := scanSavedView(tx.QueryRow(ctx,
-			"SELECT "+savedViewColumns+" FROM saved_view WHERE id = $1 AND owner_id = $2 AND archived_at IS NULL", id, owner))
+			selectSavedView+"id = $1 AND owner_id = $2 AND archived_at IS NULL", id, owner))
 		if errors.Is(err, pgx.ErrNoRows) {
 			return apperrors.ErrNotFound
 		}
@@ -240,7 +244,7 @@ func (s *Store) UpdateSavedView(ctx context.Context, id ids.UUID, in UpdateSaved
 			return err
 		}
 		out, err = scanSavedView(tx.QueryRow(ctx,
-			"SELECT "+savedViewColumns+" FROM saved_view WHERE id = $1", id))
+			selectSavedView+"id = $1", id))
 		return err
 	})
 	return out, err

--- a/backend/internal/modules/collections/vocab.go
+++ b/backend/internal/modules/collections/vocab.go
@@ -9,6 +9,14 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 )
 
+// Column references shared across the per-entity segment engines below —
+// one spelling each so the archived filter and owner scope stay identical
+// across person/organization/deal/lead.
+const (
+	whereArchivedNull = "t.archived_at IS NULL"
+	colOwnerID        = "t.owner_id"
+)
+
 // A dynamic (smart) list is a stored filter that the members endpoint
 // evaluates live through the ONE predicate engine (B-E15.10/.11). The
 // filter names fields from the closed per-resource vocabulary
@@ -22,16 +30,16 @@ import (
 var segmentEngines = map[string]storekit.Query{
 	"person": {
 		Table:     "person",
-		BaseWhere: "t.archived_at IS NULL",
+		BaseWhere: whereArchivedNull,
 		Fields: map[string]storekit.Field{
-			"owner_id": {Expr: "t.owner_id", Type: storekit.FieldID},
+			"owner_id": {Expr: colOwnerID, Type: storekit.FieldID},
 		},
 	},
 	"organization": {
 		Table:     "organization",
-		BaseWhere: "t.archived_at IS NULL",
+		BaseWhere: whereArchivedNull,
 		Fields: map[string]storekit.Field{
-			"owner_id":       {Expr: "t.owner_id", Type: storekit.FieldID},
+			"owner_id":       {Expr: colOwnerID, Type: storekit.FieldID},
 			"industry":       {Expr: "t.industry", Type: storekit.FieldText},
 			"size_band":      {Expr: "t.size_band", Type: storekit.FieldPicklist},
 			"classification": {Expr: "t.classification", Type: storekit.FieldPicklist},
@@ -39,11 +47,11 @@ var segmentEngines = map[string]storekit.Query{
 	},
 	"deal": {
 		Table:     "deal",
-		BaseWhere: "t.archived_at IS NULL",
+		BaseWhere: whereArchivedNull,
 		Fields: map[string]storekit.Field{
 			"pipeline_id":       {Expr: "t.pipeline_id", Type: storekit.FieldID},
 			"stage_id":          {Expr: "t.stage_id", Type: storekit.FieldID},
-			"owner_id":          {Expr: "t.owner_id", Type: storekit.FieldID},
+			"owner_id":          {Expr: colOwnerID, Type: storekit.FieldID},
 			"organization_id":   {Expr: "t.organization_id", Type: storekit.FieldID},
 			"partner_org_id":    {Expr: "t.partner_org_id", Type: storekit.FieldID},
 			"status":            {Expr: "t.status", Type: storekit.FieldPicklist},
@@ -52,10 +60,10 @@ var segmentEngines = map[string]storekit.Query{
 	},
 	"lead": {
 		Table:     "lead",
-		BaseWhere: "t.archived_at IS NULL",
+		BaseWhere: whereArchivedNull,
 		Fields: map[string]storekit.Field{
 			"status":            {Expr: "t.status", Type: storekit.FieldPicklist},
-			"owner_id":          {Expr: "t.owner_id", Type: storekit.FieldID},
+			"owner_id":          {Expr: colOwnerID, Type: storekit.FieldID},
 			"candidate_org_key": {Expr: "t.candidate_org_key", Type: storekit.FieldText},
 		},
 	},


### PR DESCRIPTION
## What
Clears the remaining actionable `go:S1192` in product code — the `collections` module.

## Why
- `savedviews.go`: `"SELECT "` appeared 4× building `saved_view` reads → extracted `selectSavedView` prefix constant so the projection can't drift across list/get/delete.
- `vocab.go`: `"t.archived_at IS NULL"` and `"t.owner_id"` each appeared 4× across the per-entity segment engines → shared `whereArchivedNull` / `colOwnerID` constants.

Same pattern as the report.go cleanup in #3.

Not included (deliberately): the `go:S1192` in `tools/gen-evals` is eval **fixture data** (`"Acme GmbH"` etc.) where the literal value reads better than a constant — that tooling should be *excluded* from analysis, not refactored.

## How verified
`make check` green (the deals-package gosec G115 that briefly appeared was a stale golangci-lint cache from a concurrent worktree; `cache clean` → 0 issues).

## AI involvement
Authored by Claude Code under review.