### PR TITLE
chore(ci): sync branch-protection.json with live main protection

### DIFF
--- a/infra/branch-protection.json
+++ b/infra/branch-protection.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Declarative branch-protection for `main`, applied out-of-band (gh api repos/:owner/:repo/branches/main/protection --method PUT --input infra/branch-protection.json). The craftsmanship gate is a required status check with no admin override (ADR-0045); the deterministic gates are required and craftsmanship runs only after them (see .github/workflows/ci.yml). Enforced structurally by cli/craft/wiring.",
+  "_comment": "Declarative branch-protection for `main`, applied via: gh api -X PUT repos/:owner/:repo/branches/main/protection --input infra/branch-protection.json. This mirrors the live setting on `main`. Both external quality tools (CodeRabbit, SonarCloud Code Analysis) and the full CI merge gate are required status checks; the craftsmanship gate runs only after the deterministic gates and has no admin override (ADR-0045, enforce_admins). No human-approval count is required — this is a single-owner repo, so requiring an approving review would deadlock every PR (an author cannot approve their own). Mandatory review is enforced through the tool checks instead. Structurally enforced by cli/craft/wiring.",
   "required_status_checks": {
     "strict": true,
     "contexts": [
@@ -8,16 +8,16 @@
       "craft-residue",
       "integration (RLS + erasure + HTTP e2e)",
       "govulncheck",
-      "frontend (biome + vitest + tsc + build)"
+      "frontend (biome + vitest + tsc + build)",
+      "CodeRabbit",
+      "SonarCloud Code Analysis"
     ]
   },
   "enforce_admins": true,
-  "required_pull_request_reviews": {
-    "required_approving_review_count": 1,
-    "dismiss_stale_reviews": true
-  },
+  "required_pull_request_reviews": null,
   "restrictions": null,
   "required_linear_history": true,
   "allow_force_pushes": false,
-  "allow_deletions": false
+  "allow_deletions": false,
+  "required_conversation_resolution": true
 }


### PR DESCRIPTION
## What
Updates the committed `infra/branch-protection.json` to mirror the protection now **live on `main`** (applied via `gh api PUT`).

## Why
Branch protection is now enabled with **both quality tools mandatory**:
- Required status checks: `deterministic-gates`, `craftsmanship`, `craft-residue`, `integration`, `govulncheck`, `frontend`, **`CodeRabbit`**, **`SonarCloud Code Analysis`**.
- `enforce_admins: true` (no override; craftsmanship still runs only after deterministic-gates).
- `required_conversation_resolution: true`.
- **No** `required_pull_request_reviews`: this is a single-owner repo, so requiring an approving review would deadlock every PR (an author can't approve their own). The mandatory-review intent is carried by the tool checks.

This PR is also the **first live test** of the new protection — it must pass CodeRabbit + SonarCloud + the full CI gate to merge.

## How verified
`go test -C cli/craft ./wiring/...` green (the wiring self-test still sees the required craftsmanship/deterministic-gates contexts + enforce_admins). Valid JSON.

## AI involvement
Authored by Claude Code; protection applied with the owner's explicit go-ahead.