### PR TITLE
refactor(sonar): reduce cognitive complexity in 8 more functions (go:S3776)

### DIFF
--- a/backend/internal/compose/agentgate.go
+++ b/backend/internal/compose/agentgate.go
@@ -57,64 +57,79 @@ func agentGate(reg *agents.Registry, staging agents.Approvals, stages agents.Sta
 				next.ServeHTTP(w, r)
 				return
 			}
-
-			// The generated table is keyed by the chi route pattern the
-			// contract router registered; a mutating route it doesn't
-			// know is refused, never admitted ungated (ADR-0055 §2).
-			pattern := chi.RouteContext(ctx).RoutePattern()
-			pol, known := agentPolicies[r.Method+" "+pattern]
-			if !known {
-				httperr.Write(w, r, fmt.Errorf(
-					"agent gate: %s %s carries no autonomy tier: %w", r.Method, pattern, apperrors.ErrPermissionDenied))
-				return
-			}
-			if pol.Access != "tool" {
-				// human-only governance (self-approval class) and the
-				// session/bootstrap machinery: an agent principal is
-				// rejected outright, whatever its scope or seat.
-				httperr.Write(w, r, fmt.Errorf(
-					"agent gate: %s is %s: %w", pol.Op, pol.Access, apperrors.ErrPermissionDenied))
-				return
-			}
-
-			spec, ok := operationSpec(pol, reg)
+			spec, resolve, pol, body, ok := prepareAgentGate(w, r, reg, deps)
 			if !ok {
-				httperr.Write(w, r, fmt.Errorf(
-					"agent gate: %s declares a dynamic tier with no resolvable tool: %w", pol.Op, apperrors.ErrPermissionDenied))
 				return
 			}
-
-			body, err := io.ReadAll(io.LimitReader(r.Body, maxGatedBody+1))
-			if err != nil || len(body) > maxGatedBody {
-				httperr.Write(w, r, httperr.Validation("body", "too_large", "request body unreadable or exceeds the gated limit"))
-				return
-			}
-			r.Body = io.NopCloser(bytes.NewReader(body))
-
-			resolve, ok := tierInput(ctx, spec, pol, deps, r, body)
-			if !ok {
-				httperr.Write(w, r, fmt.Errorf(
-					"agent gate: %s: no REST tier resolver for dynamic tool %s: %w", pol.Op, pol.Tool, apperrors.ErrPermissionDenied))
-				return
-			}
-
-			ctx, err = gate.Admit(ctx, spec, resolve)
+			ctx, err := gate.Admit(ctx, spec, resolve)
 			r = r.WithContext(ctx)
-			switch {
-			case err == nil:
-				if pol.Tool == "update_record" && !actionShapedUpdateOps[pol.Op] {
-					splitOrRedeemUpdate(w, r, next, staging, ownership, pol, body)
-					return
-				}
-				next.ServeHTTP(w, r)
-				return
-			case !errors.Is(err, apperrors.ErrRequiresApproval) || staging == nil:
-				httperr.Write(w, r, err)
-				return
-			}
-
-			stageOrRedeem(w, r, next, staging, pol, body)
+			admitAgentCall(w, r, next, staging, ownership, pol, body, err)
 		})
+	}
+}
+
+// prepareAgentGate resolves the admission inputs for a mutating agent call:
+// the op→tier policy for the route, its ToolSpec, the buffered body (reset
+// onto the request for the downstream handler), and the lazy tier-resolver
+// input. It writes the refusal and reports ok=false when the route is
+// unknown, human-only, unresolvable, or over the body cap (fail-closed).
+func prepareAgentGate(w http.ResponseWriter, r *http.Request, reg *agents.Registry, deps tierDeps) (mcp.ToolSpec, func() (mcp.TierResolverInput, error), agentPolicy, []byte, bool) {
+	ctx := r.Context()
+	// The generated table is keyed by the chi route pattern the contract
+	// router registered; a mutating route it doesn't know is refused, never
+	// admitted ungated (ADR-0055 §2).
+	pattern := chi.RouteContext(ctx).RoutePattern()
+	pol, known := agentPolicies[r.Method+" "+pattern]
+	if !known {
+		httperr.Write(w, r, fmt.Errorf(
+			"agent gate: %s %s carries no autonomy tier: %w", r.Method, pattern, apperrors.ErrPermissionDenied))
+		return mcp.ToolSpec{}, nil, agentPolicy{}, nil, false
+	}
+	if pol.Access != "tool" {
+		// human-only governance (self-approval class) and the
+		// session/bootstrap machinery: an agent principal is rejected
+		// outright, whatever its scope or seat.
+		httperr.Write(w, r, fmt.Errorf(
+			"agent gate: %s is %s: %w", pol.Op, pol.Access, apperrors.ErrPermissionDenied))
+		return mcp.ToolSpec{}, nil, agentPolicy{}, nil, false
+	}
+	spec, ok := operationSpec(pol, reg)
+	if !ok {
+		httperr.Write(w, r, fmt.Errorf(
+			"agent gate: %s declares a dynamic tier with no resolvable tool: %w", pol.Op, apperrors.ErrPermissionDenied))
+		return mcp.ToolSpec{}, nil, agentPolicy{}, nil, false
+	}
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxGatedBody+1))
+	if err != nil || len(body) > maxGatedBody {
+		httperr.Write(w, r, httperr.Validation("body", "too_large", "request body unreadable or exceeds the gated limit"))
+		return mcp.ToolSpec{}, nil, agentPolicy{}, nil, false
+	}
+	r.Body = io.NopCloser(bytes.NewReader(body))
+	resolve, ok := tierInput(ctx, spec, pol, deps, r, body)
+	if !ok {
+		httperr.Write(w, r, fmt.Errorf(
+			"agent gate: %s: no REST tier resolver for dynamic tool %s: %w", pol.Op, pol.Tool, apperrors.ErrPermissionDenied))
+		return mcp.ToolSpec{}, nil, agentPolicy{}, nil, false
+	}
+	return spec, resolve, pol, body, true
+}
+
+// admitAgentCall dispatches a mutating agent call on the admission outcome:
+// admitted 🟢 work runs (a field-shaped update_record edit routes through
+// the per-field owner check first); a 🟡 refusal stages or redeems the
+// approval; any other admission error is surfaced as-is.
+func admitAgentCall(w http.ResponseWriter, r *http.Request, next http.Handler, staging agents.Approvals, ownership agents.FieldOwnership, pol agentPolicy, body []byte, err error) {
+	switch {
+	case err == nil:
+		if pol.Tool == "update_record" && !actionShapedUpdateOps[pol.Op] {
+			splitOrRedeemUpdate(w, r, next, staging, ownership, pol, body)
+			return
+		}
+		next.ServeHTTP(w, r)
+	case !errors.Is(err, apperrors.ErrRequiresApproval) || staging == nil:
+		httperr.Write(w, r, err)
+	default:
+		stageOrRedeem(w, r, next, staging, pol, body)
 	}
 }
 

--- a/backend/internal/compose/agentgate.go
+++ b/backend/internal/compose/agentgate.go
@@ -63,7 +63,9 @@ func agentGate(reg *agents.Registry, staging agents.Approvals, stages agents.Sta
 			}
 			ctx, err := gate.Admit(ctx, spec, resolve)
 			r = r.WithContext(ctx)
-			admitAgentCall(w, r, next, staging, ownership, pol, body, err)
+			admitAgentCall(w, r, next, admissionOutcome{
+				staging: staging, ownership: ownership, pol: pol, body: body, err: err,
+			})
 		})
 	}
 }
@@ -114,22 +116,32 @@ func prepareAgentGate(w http.ResponseWriter, r *http.Request, reg *agents.Regist
 	return spec, resolve, pol, body, true
 }
 
+// admissionOutcome carries the result of the autonomy gate's Admit call
+// (err) plus the fields needed to act on it.
+type admissionOutcome struct {
+	staging   agents.Approvals
+	ownership agents.FieldOwnership
+	pol       agentPolicy
+	body      []byte
+	err       error
+}
+
 // admitAgentCall dispatches a mutating agent call on the admission outcome:
 // admitted 🟢 work runs (a field-shaped update_record edit routes through
 // the per-field owner check first); a 🟡 refusal stages or redeems the
 // approval; any other admission error is surfaced as-is.
-func admitAgentCall(w http.ResponseWriter, r *http.Request, next http.Handler, staging agents.Approvals, ownership agents.FieldOwnership, pol agentPolicy, body []byte, err error) {
+func admitAgentCall(w http.ResponseWriter, r *http.Request, next http.Handler, outcome admissionOutcome) {
 	switch {
-	case err == nil:
-		if pol.Tool == "update_record" && !actionShapedUpdateOps[pol.Op] {
-			splitOrRedeemUpdate(w, r, next, staging, ownership, pol, body)
+	case outcome.err == nil:
+		if outcome.pol.Tool == "update_record" && !actionShapedUpdateOps[outcome.pol.Op] {
+			splitOrRedeemUpdate(w, r, next, outcome.staging, outcome.ownership, outcome.pol, outcome.body)
 			return
 		}
 		next.ServeHTTP(w, r)
-	case !errors.Is(err, apperrors.ErrRequiresApproval) || staging == nil:
-		httperr.Write(w, r, err)
+	case !errors.Is(outcome.err, apperrors.ErrRequiresApproval) || outcome.staging == nil:
+		httperr.Write(w, r, outcome.err)
 	default:
-		stageOrRedeem(w, r, next, staging, pol, body)
+		stageOrRedeem(w, r, next, outcome.staging, outcome.pol, outcome.body)
 	}
 }
 

--- a/backend/internal/compose/report.go
+++ b/backend/internal/compose/report.go
@@ -342,69 +342,92 @@ func (e *reportEngine) fetchRows(ctx context.Context, report string, spec report
 	err := database.WithWorkspaceTx(ctx, e.pool, func(tx pgx.Tx) error {
 		var args []any
 		arg := func(v any) int { args = append(args, v); return len(args) }
-
-		where := []string{spec.baseWhere}
-		// Deterministic filter order — the plan echo and the SQL must not
-		// depend on map iteration.
-		filterKeys := make([]string, 0, len(req.Filters))
-		for key := range req.Filters {
-			filterKeys = append(filterKeys, key)
-		}
-		sort.Strings(filterKeys)
-		for _, key := range filterKeys {
-			expr, ok := spec.filters[key]
-			if !ok {
-				return &FieldNotAllowedError{Field: key}
-			}
-			where = append(where, fmt.Sprintf("%s = $%d", expr, arg(req.Filters[key])))
-		}
-		var scope string
-		var err error
-		if spec.activityWalk {
-			scope, err = auth.ActivityScopeClause(ctx, "t", arg)
-		} else {
-			scope, err = auth.ScopeClauseFor(ctx, string(spec.entity), "t", arg)
-		}
+		where, err := buildReportWhere(ctx, spec, req, arg)
 		if err != nil {
 			return err
 		}
-		if scope != "" {
-			where = append(where, scope)
-		}
-
-		sql := fmt.Sprintf("SELECT %s FROM %s WHERE %s",
-			strings.Join(selects, ", "), spec.fromClause(), strings.Join(where, " AND "))
-		if len(groupBy) > 0 {
-			positions := make([]string, len(groupBy))
-			for i := range groupBy {
-				positions[i] = fmt.Sprint(i + 1)
-			}
-			sql += " GROUP BY " + strings.Join(positions, ", ") + " ORDER BY " + strings.Join(positions, ", ")
-		}
-		sql += fmt.Sprintf(" LIMIT %d", reportRowLimit)
-
-		pgRows, err := tx.Query(ctx, sql, args...)
+		pgRows, err := tx.Query(ctx, reportSQL(spec, selects, where, groupBy), args...)
 		if err != nil {
 			return fmt.Errorf("report %s: %w", report, err)
 		}
 		defer pgRows.Close()
-		for pgRows.Next() {
-			values, err := pgRows.Values()
-			if err != nil {
-				return err
-			}
-			row := make(map[string]any, len(columns))
-			for i, col := range columns {
-				row[col] = wireValue(values[i])
-			}
-			rows = append(rows, row)
-		}
-		return pgRows.Err()
+		rows, err = scanReportRows(pgRows, columns)
+		return err
 	})
 	if err != nil {
 		return nil, err
 	}
 	return rows, nil
+}
+
+// buildReportWhere assembles the WHERE side — the spec's base predicate,
+// the validated caller filters (sorted for a deterministic plan echo), and
+// the caller's row-scope clause — binding every value through arg.
+func buildReportWhere(ctx context.Context, spec reportSpec, req reportRequest, arg func(any) int) ([]string, error) {
+	where := []string{spec.baseWhere}
+	// Deterministic filter order — the plan echo and the SQL must not
+	// depend on map iteration.
+	filterKeys := make([]string, 0, len(req.Filters))
+	for key := range req.Filters {
+		filterKeys = append(filterKeys, key)
+	}
+	sort.Strings(filterKeys)
+	for _, key := range filterKeys {
+		expr, ok := spec.filters[key]
+		if !ok {
+			return nil, &FieldNotAllowedError{Field: key}
+		}
+		where = append(where, fmt.Sprintf("%s = $%d", expr, arg(req.Filters[key])))
+	}
+	var scope string
+	var err error
+	if spec.activityWalk {
+		scope, err = auth.ActivityScopeClause(ctx, "t", arg)
+	} else {
+		scope, err = auth.ScopeClauseFor(ctx, string(spec.entity), "t", arg)
+	}
+	if err != nil {
+		return nil, err
+	}
+	if scope != "" {
+		where = append(where, scope)
+	}
+	return where, nil
+}
+
+// reportSQL renders the aggregate query: the validated SELECT list over the
+// spec's FROM and WHERE, grouped and ordered by the dimension positions,
+// bounded by the report row limit.
+func reportSQL(spec reportSpec, selects, where, groupBy []string) string {
+	sql := fmt.Sprintf("SELECT %s FROM %s WHERE %s",
+		strings.Join(selects, ", "), spec.fromClause(), strings.Join(where, " AND "))
+	if len(groupBy) > 0 {
+		positions := make([]string, len(groupBy))
+		for i := range groupBy {
+			positions[i] = fmt.Sprint(i + 1)
+		}
+		sql += " GROUP BY " + strings.Join(positions, ", ") + " ORDER BY " + strings.Join(positions, ", ")
+	}
+	sql += fmt.Sprintf(" LIMIT %d", reportRowLimit)
+	return sql
+}
+
+// scanReportRows shapes each result row into a column→value map, rendering
+// values wire-friendly.
+func scanReportRows(pgRows pgx.Rows, columns []string) ([]map[string]any, error) {
+	var rows []map[string]any
+	for pgRows.Next() {
+		values, err := pgRows.Values()
+		if err != nil {
+			return nil, err
+		}
+		row := make(map[string]any, len(columns))
+		for i, col := range columns {
+			row[col] = wireValue(values[i])
+		}
+		rows = append(rows, row)
+	}
+	return rows, pgRows.Err()
 }
 
 // wireValue renders driver-native values JSON-friendly: uuids as their

--- a/backend/internal/modules/deals/offer.go
+++ b/backend/internal/modules/deals/offer.go
@@ -173,61 +173,18 @@ func nextOfferNumber(ctx context.Context, tx pgx.Tx, wsID ids.UUID) (string, err
 // The snapshot is copied ONCE, here — a later product edit never touches
 // the line (B-E03.17).
 func insertOfferLine(ctx context.Context, tx pgx.Tx, wsID, offerID ids.UUID, offerCurrency string, in OfferLineInputRow) error {
-	description := in.Description
-	unit := in.Unit
-	price := in.UnitPriceMinor
-	taxRate := in.TaxRate
-
-	if in.ProductID != nil {
-		var pName, pUnit, pCurrency, pTax string
-		var pPrice int64
-		err := tx.QueryRow(ctx,
-			`SELECT name, unit, currency, default_tax_rate::text, unit_price_minor
-			 FROM product WHERE id = $1 AND archived_at IS NULL`, *in.ProductID).
-			Scan(&pName, &pUnit, &pCurrency, &pTax, &pPrice)
-		if err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
-				return apperrors.ErrNotFound
-			}
-			return fmt.Errorf("read product for snapshot: %w", err)
-		}
-		if description == nil {
-			description = &pName
-		}
-		if unit == nil {
-			unit = &pUnit
-		}
-		if price == nil {
-			// The rate-card price only carries over when the currencies
-			// agree — a silent conversion would fabricate a number.
-			if pCurrency != offerCurrency {
-				return &ProductCurrencyMismatchError{Product: pCurrency, Offer: offerCurrency}
-			}
-			price = &pPrice
-		}
-		if taxRate == nil {
-			taxRate = &pTax
-		}
+	description, unit, price, taxRate, err := resolveProductSnapshot(
+		ctx, tx, in.ProductID, offerCurrency, in.Description, in.Unit, in.UnitPriceMinor, in.TaxRate)
+	if err != nil {
+		return err
 	}
-
 	if description == nil || *description == "" {
 		return &RequiredFieldError{Field: "description"}
 	}
 	if price == nil {
 		return &RequiredFieldError{Field: "unit_price_minor"}
 	}
-	unitVal := "unit"
-	if unit != nil && *unit != "" {
-		unitVal = *unit
-	}
-	discount := "0.00"
-	if in.DiscountPct != nil {
-		discount = *in.DiscountPct
-	}
-	tax := "0.00"
-	if taxRate != nil {
-		tax = *taxRate
-	}
+	unitVal, discount, tax := normalizeLineDefaults(unit, in.DiscountPct, taxRate)
 	// Validate the money math before the row lands: a malformed decimal
 	// or a nonsense quantity answers 422 here, not a CHECK 500 later.
 	if _, err := LineTotals(OfferLineInput{
@@ -235,7 +192,69 @@ func insertOfferLine(ctx context.Context, tx pgx.Tx, wsID, offerID ids.UUID, off
 	}); err != nil {
 		return err
 	}
+	return insertOfferLineRow(ctx, tx, wsID, offerID, in, *description, unitVal, *price, discount, tax)
+}
 
+// resolveProductSnapshot fills a line's description/unit/price/tax defaults
+// from its product; a line with no product keeps the caller's values. The
+// snapshot is copied ONCE, here — a later product edit never touches the
+// line (B-E03.17). The rate-card price only carries over when the
+// currencies agree; a silent conversion would fabricate a number.
+func resolveProductSnapshot(ctx context.Context, tx pgx.Tx, productID *ids.UUID, offerCurrency string, description, unit *string, price *int64, taxRate *string) (*string, *string, *int64, *string, error) {
+	if productID == nil {
+		return description, unit, price, taxRate, nil
+	}
+	var pName, pUnit, pCurrency, pTax string
+	var pPrice int64
+	err := tx.QueryRow(ctx,
+		`SELECT name, unit, currency, default_tax_rate::text, unit_price_minor
+		 FROM product WHERE id = $1 AND archived_at IS NULL`, *productID).
+		Scan(&pName, &pUnit, &pCurrency, &pTax, &pPrice)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil, nil, nil, apperrors.ErrNotFound
+		}
+		return nil, nil, nil, nil, fmt.Errorf("read product for snapshot: %w", err)
+	}
+	if description == nil {
+		description = &pName
+	}
+	if unit == nil {
+		unit = &pUnit
+	}
+	if price == nil {
+		if pCurrency != offerCurrency {
+			return nil, nil, nil, nil, &ProductCurrencyMismatchError{Product: pCurrency, Offer: offerCurrency}
+		}
+		price = &pPrice
+	}
+	if taxRate == nil {
+		taxRate = &pTax
+	}
+	return description, unit, price, taxRate, nil
+}
+
+// normalizeLineDefaults resolves unit/discount/tax to their stored defaults
+// when neither the caller nor the product snapshot supplied a value.
+func normalizeLineDefaults(unit, discountPct, taxRate *string) (unitVal, discount, tax string) {
+	unitVal = "unit"
+	if unit != nil && *unit != "" {
+		unitVal = *unit
+	}
+	discount = "0.00"
+	if discountPct != nil {
+		discount = *discountPct
+	}
+	tax = "0.00"
+	if taxRate != nil {
+		tax = *taxRate
+	}
+	return unitVal, discount, tax
+}
+
+// insertOfferLineRow assigns the line's position (appending after the last
+// when unset) and inserts it, mapping a position collision to 409.
+func insertOfferLineRow(ctx context.Context, tx pgx.Tx, wsID, offerID ids.UUID, in OfferLineInputRow, description, unitVal string, price int64, discount, tax string) error {
 	position := in.Position
 	if position == nil {
 		var next int
@@ -246,13 +265,12 @@ func insertOfferLine(ctx context.Context, tx pgx.Tx, wsID, offerID ids.UUID, off
 		}
 		position = &next
 	}
-
 	_, err := tx.Exec(ctx,
 		`INSERT INTO offer_line_item (id, workspace_id, offer_id, position, product_id, description,
 		                              unit, quantity, unit_price_minor, discount_pct, tax_rate)
 		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
-		ids.NewV7(), wsID, offerID, *position, in.ProductID, *description,
-		unitVal, in.Quantity, *price, discount, tax)
+		ids.NewV7(), wsID, offerID, *position, in.ProductID, description,
+		unitVal, in.Quantity, price, discount, tax)
 	if err != nil {
 		if storekit.IsUniqueViolation(err) {
 			return fmt.Errorf("position %d is already taken on this offer: %w", *position, apperrors.ErrConflict)

--- a/backend/internal/modules/deals/offer.go
+++ b/backend/internal/modules/deals/offer.go
@@ -172,27 +172,50 @@ func nextOfferNumber(ctx context.Context, tx pgx.Tx, wsID ids.UUID) (string, err
 // price, tax default) and validates the resulting line before it lands.
 // The snapshot is copied ONCE, here — a later product edit never touches
 // the line (B-E03.17).
+// lineSnapshotDefaults carries a line's description/unit/price/tax as the
+// caller supplied them; a nil field falls back to the product snapshot
+// (resolveProductSnapshot) or a stored default (normalizeLineDefaults).
+type lineSnapshotDefaults struct {
+	Description *string
+	Unit        *string
+	Price       *int64
+	TaxRate     *string
+}
+
+// resolvedOfferLine is a fully-resolved line ready to insert: defaults
+// applied and money already validated.
+type resolvedOfferLine struct {
+	Description string
+	Unit        string
+	Price       int64
+	Discount    string
+	Tax         string
+}
+
 func insertOfferLine(ctx context.Context, tx pgx.Tx, wsID, offerID ids.UUID, offerCurrency string, in OfferLineInputRow) error {
-	description, unit, price, taxRate, err := resolveProductSnapshot(
-		ctx, tx, in.ProductID, offerCurrency, in.Description, in.Unit, in.UnitPriceMinor, in.TaxRate)
+	defaults, err := resolveProductSnapshot(ctx, tx, in.ProductID, offerCurrency, lineSnapshotDefaults{
+		Description: in.Description, Unit: in.Unit, Price: in.UnitPriceMinor, TaxRate: in.TaxRate,
+	})
 	if err != nil {
 		return err
 	}
-	if description == nil || *description == "" {
+	if defaults.Description == nil || *defaults.Description == "" {
 		return &RequiredFieldError{Field: "description"}
 	}
-	if price == nil {
+	if defaults.Price == nil {
 		return &RequiredFieldError{Field: "unit_price_minor"}
 	}
-	unitVal, discount, tax := normalizeLineDefaults(unit, in.DiscountPct, taxRate)
+	unitVal, discount, tax := normalizeLineDefaults(defaults.Unit, in.DiscountPct, defaults.TaxRate)
 	// Validate the money math before the row lands: a malformed decimal
 	// or a nonsense quantity answers 422 here, not a CHECK 500 later.
 	if _, err := LineTotals(OfferLineInput{
-		Quantity: in.Quantity, UnitPriceMinor: *price, DiscountPct: discount, TaxRate: tax,
+		Quantity: in.Quantity, UnitPriceMinor: *defaults.Price, DiscountPct: discount, TaxRate: tax,
 	}); err != nil {
 		return err
 	}
-	return insertOfferLineRow(ctx, tx, wsID, offerID, in, *description, unitVal, *price, discount, tax)
+	return insertOfferLineRow(ctx, tx, wsID, offerID, in, resolvedOfferLine{
+		Description: *defaults.Description, Unit: unitVal, Price: *defaults.Price, Discount: discount, Tax: tax,
+	})
 }
 
 // resolveProductSnapshot fills a line's description/unit/price/tax defaults
@@ -200,9 +223,9 @@ func insertOfferLine(ctx context.Context, tx pgx.Tx, wsID, offerID ids.UUID, off
 // snapshot is copied ONCE, here — a later product edit never touches the
 // line (B-E03.17). The rate-card price only carries over when the
 // currencies agree; a silent conversion would fabricate a number.
-func resolveProductSnapshot(ctx context.Context, tx pgx.Tx, productID *ids.UUID, offerCurrency string, description, unit *string, price *int64, taxRate *string) (*string, *string, *int64, *string, error) {
+func resolveProductSnapshot(ctx context.Context, tx pgx.Tx, productID *ids.UUID, offerCurrency string, in lineSnapshotDefaults) (lineSnapshotDefaults, error) {
 	if productID == nil {
-		return description, unit, price, taxRate, nil
+		return in, nil
 	}
 	var pName, pUnit, pCurrency, pTax string
 	var pPrice int64
@@ -212,26 +235,26 @@ func resolveProductSnapshot(ctx context.Context, tx pgx.Tx, productID *ids.UUID,
 		Scan(&pName, &pUnit, &pCurrency, &pTax, &pPrice)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, nil, nil, nil, apperrors.ErrNotFound
+			return lineSnapshotDefaults{}, apperrors.ErrNotFound
 		}
-		return nil, nil, nil, nil, fmt.Errorf("read product for snapshot: %w", err)
+		return lineSnapshotDefaults{}, fmt.Errorf("read product for snapshot: %w", err)
 	}
-	if description == nil {
-		description = &pName
+	if in.Description == nil {
+		in.Description = &pName
 	}
-	if unit == nil {
-		unit = &pUnit
+	if in.Unit == nil {
+		in.Unit = &pUnit
 	}
-	if price == nil {
+	if in.Price == nil {
 		if pCurrency != offerCurrency {
-			return nil, nil, nil, nil, &ProductCurrencyMismatchError{Product: pCurrency, Offer: offerCurrency}
+			return lineSnapshotDefaults{}, &ProductCurrencyMismatchError{Product: pCurrency, Offer: offerCurrency}
 		}
-		price = &pPrice
+		in.Price = &pPrice
 	}
-	if taxRate == nil {
-		taxRate = &pTax
+	if in.TaxRate == nil {
+		in.TaxRate = &pTax
 	}
-	return description, unit, price, taxRate, nil
+	return in, nil
 }
 
 // normalizeLineDefaults resolves unit/discount/tax to their stored defaults
@@ -254,7 +277,7 @@ func normalizeLineDefaults(unit, discountPct, taxRate *string) (unitVal, discoun
 
 // insertOfferLineRow assigns the line's position (appending after the last
 // when unset) and inserts it, mapping a position collision to 409.
-func insertOfferLineRow(ctx context.Context, tx pgx.Tx, wsID, offerID ids.UUID, in OfferLineInputRow, description, unitVal string, price int64, discount, tax string) error {
+func insertOfferLineRow(ctx context.Context, tx pgx.Tx, wsID, offerID ids.UUID, in OfferLineInputRow, line resolvedOfferLine) error {
 	position := in.Position
 	if position == nil {
 		var next int
@@ -269,8 +292,8 @@ func insertOfferLineRow(ctx context.Context, tx pgx.Tx, wsID, offerID ids.UUID, 
 		`INSERT INTO offer_line_item (id, workspace_id, offer_id, position, product_id, description,
 		                              unit, quantity, unit_price_minor, discount_pct, tax_rate)
 		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
-		ids.NewV7(), wsID, offerID, *position, in.ProductID, description,
-		unitVal, in.Quantity, price, discount, tax)
+		ids.NewV7(), wsID, offerID, *position, in.ProductID, line.Description,
+		line.Unit, in.Quantity, line.Price, line.Discount, line.Tax)
 	if err != nil {
 		if storekit.IsUniqueViolation(err) {
 			return fmt.Errorf("position %d is already taken on this offer: %w", *position, apperrors.ErrConflict)

--- a/backend/internal/modules/deals/offer_read.go
+++ b/backend/internal/modules/deals/offer_read.go
@@ -69,16 +69,11 @@ func (s *Store) ListDealOffers(ctx context.Context, dealID ids.UUID, in ListDeal
 		where := []string{"deal_id = $1", "archived_at IS NULL"}
 		args := []any{dealID}
 		arg := func(v any) int { args = append(args, v); return len(args) }
-		if in.Status != nil && *in.Status != "" {
-			where = append(where, storekit.SQLf("status = $%d", arg(*in.Status)))
+		extra, err := dealOffersFilters(in, arg)
+		if err != nil {
+			return err
 		}
-		if in.Cursor != nil && *in.Cursor != "" {
-			c, err := storekit.DecodeCursor(*in.Cursor)
-			if err != nil {
-				return err
-			}
-			where = append(where, storekit.SQLf("(created_at, id) < ($%d, $%d)", arg(c.CreatedAt), arg(c.ID)))
-		}
+		where = append(where, extra...)
 
 		rows, err := tx.Query(ctx,
 			`SELECT `+offerColumns+` FROM offer WHERE `+strings.Join(where, " AND ")+
@@ -88,14 +83,7 @@ func (s *Store) ListDealOffers(ctx context.Context, dealID ids.UUID, in ListDeal
 			return err
 		}
 		defer rows.Close()
-		for rows.Next() {
-			o, err := scanOffer(rows)
-			if err != nil {
-				return err
-			}
-			offers = append(offers, o)
-		}
-		if err := rows.Err(); err != nil {
+		if offers, err = scanOffers(rows); err != nil {
 			return err
 		}
 		if len(offers) > limit {
@@ -103,19 +91,58 @@ func (s *Store) ListDealOffers(ctx context.Context, dealID ids.UUID, in ListDeal
 			last := offers[len(offers)-1]
 			page = storekit.Page{HasMore: true, NextCursor: storekit.EncodeCursor(last.CreatedAt, ids.UUID(last.Id))}
 		}
-		for i := range offers {
-			lines, err := readOfferLines(ctx, tx, ids.UUID(offers[i].Id))
-			if err != nil {
-				return err
-			}
-			offers[i].LineItems = &lines
-		}
-		return nil
+		return attachOfferLines(ctx, tx, offers)
 	})
 	if offers == nil {
 		offers = []crmcontracts.Offer{}
 	}
 	return offers, page, err
+}
+
+// dealOffersFilters renders the status/cursor list filters, binding each
+// value through arg.
+func dealOffersFilters(in ListDealOffersInput, arg func(any) int) ([]string, error) {
+	var where []string
+	if in.Status != nil && *in.Status != "" {
+		where = append(where, storekit.SQLf("status = $%d", arg(*in.Status)))
+	}
+	if in.Cursor != nil && *in.Cursor != "" {
+		c, err := storekit.DecodeCursor(*in.Cursor)
+		if err != nil {
+			return nil, err
+		}
+		where = append(where, storekit.SQLf("(created_at, id) < ($%d, $%d)", arg(c.CreatedAt), arg(c.ID)))
+	}
+	return where, nil
+}
+
+// scanOffers drains an offer result set into rows (line items attached
+// separately).
+func scanOffers(rows pgx.Rows) ([]crmcontracts.Offer, error) {
+	var offers []crmcontracts.Offer
+	for rows.Next() {
+		o, err := scanOffer(rows)
+		if err != nil {
+			return nil, err
+		}
+		offers = append(offers, o)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return offers, nil
+}
+
+// attachOfferLines loads and nests each offer's derived line items.
+func attachOfferLines(ctx context.Context, tx pgx.Tx, offers []crmcontracts.Offer) error {
+	for i := range offers {
+		lines, err := readOfferLines(ctx, tx, ids.UUID(offers[i].Id))
+		if err != nil {
+			return err
+		}
+		offers[i].LineItems = &lines
+	}
+	return nil
 }
 
 const offerColumns = `id, workspace_id, deal_id, offer_number, revision, status, currency,

--- a/backend/internal/modules/deals/product.go
+++ b/backend/internal/modules/deals/product.go
@@ -107,31 +107,7 @@ func (s *Store) UpdateProduct(ctx context.Context, id ids.UUID, in UpdateProduct
 		if err != nil {
 			return err
 		}
-		p := storekit.NewPatch()
-		if in.Name != nil {
-			p.Set("name", current.Name, *in.Name)
-		}
-		if in.SKU != nil {
-			p.Set("sku", current.Sku, *in.SKU)
-		}
-		if in.Description != nil {
-			p.Set("description", current.Description, *in.Description)
-		}
-		if in.Unit != nil {
-			p.Set("unit", current.Unit, *in.Unit)
-		}
-		if in.UnitPriceMinor != nil {
-			p.Set("unit_price_minor", current.UnitPriceMinor, *in.UnitPriceMinor)
-		}
-		if in.Currency != nil {
-			p.Set("currency", current.Currency, *in.Currency)
-		}
-		if in.DefaultTaxRate != nil {
-			p.Set("default_tax_rate", current.DefaultTaxRate, formatPct(*in.DefaultTaxRate))
-		}
-		if in.Active != nil {
-			p.Set("active", current.Active, *in.Active)
-		}
+		p := buildProductPatch(current, in)
 		if p.Empty() {
 			out = current
 			return nil
@@ -151,6 +127,37 @@ func (s *Store) UpdateProduct(ctx context.Context, id ids.UUID, in UpdateProduct
 		return nil
 	})
 	return out, err
+}
+
+// buildProductPatch folds the caller's sparse product edit into a patch —
+// every set field carries its before/after image for the audit trail.
+func buildProductPatch(current crmcontracts.Product, in UpdateProductInput) *storekit.Patch {
+	p := storekit.NewPatch()
+	if in.Name != nil {
+		p.Set("name", current.Name, *in.Name)
+	}
+	if in.SKU != nil {
+		p.Set("sku", current.Sku, *in.SKU)
+	}
+	if in.Description != nil {
+		p.Set("description", current.Description, *in.Description)
+	}
+	if in.Unit != nil {
+		p.Set("unit", current.Unit, *in.Unit)
+	}
+	if in.UnitPriceMinor != nil {
+		p.Set("unit_price_minor", current.UnitPriceMinor, *in.UnitPriceMinor)
+	}
+	if in.Currency != nil {
+		p.Set("currency", current.Currency, *in.Currency)
+	}
+	if in.DefaultTaxRate != nil {
+		p.Set("default_tax_rate", current.DefaultTaxRate, formatPct(*in.DefaultTaxRate))
+	}
+	if in.Active != nil {
+		p.Set("active", current.Active, *in.Active)
+	}
+	return p
 }
 
 func (s *Store) ArchiveProduct(ctx context.Context, id ids.UUID) (crmcontracts.Product, error) {

--- a/backend/internal/modules/people/merge_organization.go
+++ b/backend/internal/modules/people/merge_organization.go
@@ -40,64 +40,86 @@ func (s *Store) MergeOrganization(ctx context.Context, sourceID, targetID ids.UU
 		if err != nil {
 			return err
 		}
-
-		if _, err := relinkDemotingPrimary(ctx, tx, `
-			UPDATE organization_domain a SET organization_id = $2,
-			  is_primary = a.is_primary AND NOT EXISTS (
-			    SELECT 1 FROM organization_domain b
-			    WHERE b.organization_id = $2 AND b.is_primary AND b.archived_at IS NULL)
-			WHERE a.organization_id = $1 AND a.archived_at IS NULL`, sourceID, targetID); err != nil {
-			return fmt.Errorf("relink domains: %w", err)
-		}
-		if err := relinkOrgEdges(ctx, tx, sourceID, targetID); err != nil {
-			return fmt.Errorf("relink relationships: %w", err)
-		}
-		if _, err := relinkLinkRows(ctx, tx, "organization", sourceID, targetID); err != nil {
-			return fmt.Errorf("relink activity/list/tag rows: %w", err)
-		}
-
-		targetIsPartner, err := absorbOrgReferences(ctx, tx, sourceID, targetID)
+		targetIsPartner, err := relinkOrgAssociations(ctx, tx, sourceID, targetID)
 		if err != nil {
 			return err
 		}
-
-		p := storekit.NewPatch()
-		fillString(p, "legal_name", tgt.LegalName, src.LegalName)
-		fillString(p, "industry", tgt.Industry, src.Industry)
-		if targetIsPartner && (tgt.Classification == nil || *tgt.Classification != crmcontracts.OrganizationClassificationPartner) {
-			// The partner invariant (A41): classification='partner' iff a
-			// partner row exists — the survivor gained one, so it flips.
-			p.Set("classification", tgt.Classification, "partner")
-		}
-		if !p.Empty() {
-			if err := p.Apply(ctx, tx, "organization", targetID, nil); err != nil {
-				return fmt.Errorf("apply survivorship fill: %w", err)
-			}
-		}
-
-		if err := archiveMergedAway(ctx, tx, "organization", sourceID, targetID); err != nil {
-			return fmt.Errorf("retire merged-away organization: %w", err)
-		}
-
-		auditID, err := storekit.Audit(ctx, tx, "merge", "organization", sourceID,
-			map[string]any{"merged_into_id": nil},
-			map[string]any{"merged_into_id": targetID, "filled": p.After()})
+		filled, err := fillOrgSurvivorship(ctx, tx, src, tgt, targetIsPartner, targetID)
 		if err != nil {
-			return fmt.Errorf("audit organization merge: %w", err)
+			return err
 		}
-		if err := storekit.Emit(ctx, tx, auditID, "organization.merged", "organization", sourceID, map[string]any{
-			"merged_from_id": sourceID,
-			"merged_into_id": targetID,
-		}); err != nil {
-			return fmt.Errorf("emit organization.merged: %w", err)
-		}
-
-		if out, err = readOrganization(ctx, tx, targetID, storekit.LiveOnly); err != nil {
-			return fmt.Errorf("read surviving organization: %w", err)
-		}
-		return nil
+		out, err = finalizeOrgMerge(ctx, tx, sourceID, targetID, filled)
+		return err
 	})
 	return out, err
+}
+
+// relinkOrgAssociations moves every association off the merged-away org
+// onto the survivor — domains (demoting a duplicate primary), relationship
+// edges, activity/list/tag rows, and the deal/hierarchy/partner references
+// — and reports whether the survivor ends up holding a partner row.
+func relinkOrgAssociations(ctx context.Context, tx pgx.Tx, sourceID, targetID ids.UUID) (bool, error) {
+	if _, err := relinkDemotingPrimary(ctx, tx, `
+		UPDATE organization_domain a SET organization_id = $2,
+		  is_primary = a.is_primary AND NOT EXISTS (
+		    SELECT 1 FROM organization_domain b
+		    WHERE b.organization_id = $2 AND b.is_primary AND b.archived_at IS NULL)
+		WHERE a.organization_id = $1 AND a.archived_at IS NULL`, sourceID, targetID); err != nil {
+		return false, fmt.Errorf("relink domains: %w", err)
+	}
+	if err := relinkOrgEdges(ctx, tx, sourceID, targetID); err != nil {
+		return false, fmt.Errorf("relink relationships: %w", err)
+	}
+	if _, err := relinkLinkRows(ctx, tx, "organization", sourceID, targetID); err != nil {
+		return false, fmt.Errorf("relink activity/list/tag rows: %w", err)
+	}
+	return absorbOrgReferences(ctx, tx, sourceID, targetID)
+}
+
+// fillOrgSurvivorship folds the merged-away org's fields into the survivor
+// where the survivor is blank and, when the survivor gained the 1:1 partner
+// extension, flips its classification to 'partner' (the A41 invariant:
+// classification='partner' iff a partner row exists). It returns the
+// applied after-image for the merge audit.
+func fillOrgSurvivorship(ctx context.Context, tx pgx.Tx, src, tgt crmcontracts.Organization, targetIsPartner bool, targetID ids.UUID) (map[string]any, error) {
+	p := storekit.NewPatch()
+	fillString(p, "legal_name", tgt.LegalName, src.LegalName)
+	fillString(p, "industry", tgt.Industry, src.Industry)
+	if targetIsPartner && (tgt.Classification == nil || *tgt.Classification != crmcontracts.OrganizationClassificationPartner) {
+		p.Set("classification", tgt.Classification, "partner")
+	}
+	if !p.Empty() {
+		if err := p.Apply(ctx, tx, "organization", targetID, nil); err != nil {
+			return nil, fmt.Errorf("apply survivorship fill: %w", err)
+		}
+	}
+	return p.After(), nil
+}
+
+// finalizeOrgMerge retires the merged-away org and records the merge on the
+// write shape — audit row plus organization.merged event in the one
+// transaction — then returns the reloaded survivor.
+func finalizeOrgMerge(ctx context.Context, tx pgx.Tx, sourceID, targetID ids.UUID, filled map[string]any) (crmcontracts.Organization, error) {
+	if err := archiveMergedAway(ctx, tx, "organization", sourceID, targetID); err != nil {
+		return crmcontracts.Organization{}, fmt.Errorf("retire merged-away organization: %w", err)
+	}
+	auditID, err := storekit.Audit(ctx, tx, "merge", "organization", sourceID,
+		map[string]any{"merged_into_id": nil},
+		map[string]any{"merged_into_id": targetID, "filled": filled})
+	if err != nil {
+		return crmcontracts.Organization{}, fmt.Errorf("audit organization merge: %w", err)
+	}
+	if err := storekit.Emit(ctx, tx, auditID, "organization.merged", "organization", sourceID, map[string]any{
+		"merged_from_id": sourceID,
+		"merged_into_id": targetID,
+	}); err != nil {
+		return crmcontracts.Organization{}, fmt.Errorf("emit organization.merged: %w", err)
+	}
+	out, err := readOrganization(ctx, tx, targetID, storekit.LiveOnly)
+	if err != nil {
+		return crmcontracts.Organization{}, fmt.Errorf("read surviving organization: %w", err)
+	}
+	return out, nil
 }
 
 // absorbOrgReferences re-homes everything beyond the relationship and

--- a/backend/internal/modules/people/organization.go
+++ b/backend/internal/modules/people/organization.go
@@ -274,51 +274,68 @@ func (s *Store) UpdateOrganization(ctx context.Context, id ids.UUID, in UpdateOr
 		if err != nil {
 			return fmt.Errorf("read organization before update: %w", err)
 		}
-
-		p := storekit.NewPatch()
-		if in.DisplayName != nil {
-			p.Set("display_name", current.DisplayName, *in.DisplayName)
-		}
-		if in.LegalName != nil {
-			p.Set("legal_name", current.LegalName, *in.LegalName)
-		}
-		if in.Industry != nil {
-			p.Set("industry", current.Industry, *in.Industry)
-		}
-		if in.SizeBand != nil {
-			p.Set("size_band", current.SizeBand, *in.SizeBand)
-		}
-		if in.OwnerID != nil {
-			p.Set("owner_id", current.OwnerId, *in.OwnerID)
-		}
-		if in.ParentOrgID != nil {
-			// Re-parenting is a read of the new parent (the create-path rule).
-			if err := auth.EnsureLinkTarget(ctx, tx, "organization", *in.ParentOrgID); err != nil {
-				return err
-			}
-			p.Set("parent_org_id", current.ParentOrgId, *in.ParentOrgID)
+		p, err := buildOrganizationPatch(ctx, tx, current, in)
+		if err != nil {
+			return err
 		}
 		if p.Empty() {
 			out = current
 			return nil
 		}
-
-		if err := p.Apply(ctx, tx, "organization", id, in.IfVersion); err != nil {
-			return fmt.Errorf("apply organization patch: %w", err)
-		}
-		auditID, err := storekit.Audit(ctx, tx, "update", "organization", id, p.Before(), p.After())
-		if err != nil {
-			return fmt.Errorf("audit organization update: %w", err)
-		}
-		if err := storekit.Emit(ctx, tx, auditID, "organization.updated", "organization", id, p.After()); err != nil {
-			return fmt.Errorf("emit organization.updated: %w", err)
-		}
-		if out, err = readOrganization(ctx, tx, id, storekit.LiveOnly); err != nil {
-			return fmt.Errorf("read updated organization: %w", err)
-		}
-		return nil
+		out, err = writeOrganizationUpdate(ctx, tx, id, in.IfVersion, p)
+		return err
 	})
 	return out, err
+}
+
+// buildOrganizationPatch folds the caller's sparse org edit into a patch.
+// Naming a new parent is a read of that parent (the create-path rule), so
+// it is visibility-probed before the edge lands.
+func buildOrganizationPatch(ctx context.Context, tx pgx.Tx, current crmcontracts.Organization, in UpdateOrganizationInput) (*storekit.Patch, error) {
+	p := storekit.NewPatch()
+	if in.DisplayName != nil {
+		p.Set("display_name", current.DisplayName, *in.DisplayName)
+	}
+	if in.LegalName != nil {
+		p.Set("legal_name", current.LegalName, *in.LegalName)
+	}
+	if in.Industry != nil {
+		p.Set("industry", current.Industry, *in.Industry)
+	}
+	if in.SizeBand != nil {
+		p.Set("size_band", current.SizeBand, *in.SizeBand)
+	}
+	if in.OwnerID != nil {
+		p.Set("owner_id", current.OwnerId, *in.OwnerID)
+	}
+	if in.ParentOrgID != nil {
+		if err := auth.EnsureLinkTarget(ctx, tx, "organization", *in.ParentOrgID); err != nil {
+			return nil, err
+		}
+		p.Set("parent_org_id", current.ParentOrgId, *in.ParentOrgID)
+	}
+	return p, nil
+}
+
+// writeOrganizationUpdate lands the patch on the write shape — domain row,
+// audit row, and organization.updated event in the one transaction — and
+// returns the reloaded survivor.
+func writeOrganizationUpdate(ctx context.Context, tx pgx.Tx, id ids.UUID, ifVersion *int64, p *storekit.Patch) (crmcontracts.Organization, error) {
+	if err := p.Apply(ctx, tx, "organization", id, ifVersion); err != nil {
+		return crmcontracts.Organization{}, fmt.Errorf("apply organization patch: %w", err)
+	}
+	auditID, err := storekit.Audit(ctx, tx, "update", "organization", id, p.Before(), p.After())
+	if err != nil {
+		return crmcontracts.Organization{}, fmt.Errorf("audit organization update: %w", err)
+	}
+	if err := storekit.Emit(ctx, tx, auditID, "organization.updated", "organization", id, p.After()); err != nil {
+		return crmcontracts.Organization{}, fmt.Errorf("emit organization.updated: %w", err)
+	}
+	out, err := readOrganization(ctx, tx, id, storekit.LiveOnly)
+	if err != nil {
+		return crmcontracts.Organization{}, fmt.Errorf("read updated organization: %w", err)
+	}
+	return out, nil
 }
 
 func (s *Store) ArchiveOrganization(ctx context.Context, id ids.UUID) (crmcontracts.Organization, error) {

--- a/backend/internal/modules/people/relationship.go
+++ b/backend/internal/modules/people/relationship.go
@@ -127,35 +127,9 @@ func (s *Store) ListRelationships(ctx context.Context, in ListRelationshipsInput
 	err := s.tx(ctx, func(tx pgx.Tx) error {
 		var args []any
 		arg := func(v any) int { args = append(args, v); return len(args) }
-		where := []string{"true"}
-		if in.Kind != nil {
-			where = append(where, storekit.SQLf("r.kind = $%d", arg(*in.Kind)))
-		}
-		if in.PersonID != nil {
-			where = append(where, storekit.SQLf("r.person_id = $%d", arg(*in.PersonID)))
-		}
-		if in.OrganizationID != nil {
-			where = append(where, storekit.SQLf("(r.organization_id = $%d OR r.counterparty_org_id = $%d)", arg(*in.OrganizationID), len(args)))
-		}
-		if in.DealID != nil {
-			where = append(where, storekit.SQLf("r.deal_id = $%d", arg(*in.DealID)))
-		}
-		if !in.IncludeArchived {
-			where = append(where, "r.archived_at IS NULL")
-		}
-		if in.Cursor != "" {
-			after, err := ids.Parse(in.Cursor)
-			if err != nil {
-				return &RequiredFieldError{Field: "cursor"}
-			}
-			where = append(where, storekit.SQLf("r.id > $%d", arg(after)))
-		}
-		scope, err := relationshipEndpointScope(ctx, "r", arg)
+		where, err := relationshipListWhere(ctx, in, arg)
 		if err != nil {
 			return err
-		}
-		if scope != "" {
-			where = append(where, scope)
 		}
 		rows, err := tx.Query(ctx, storekit.SQLf(
 			`SELECT %s FROM relationship r WHERE %s ORDER BY r.id LIMIT $%d`,
@@ -164,14 +138,7 @@ func (s *Store) ListRelationships(ctx context.Context, in ListRelationshipsInput
 			return err
 		}
 		defer rows.Close()
-		for rows.Next() {
-			rel, err := scanRelationship(rows)
-			if err != nil {
-				return err
-			}
-			out = append(out, rel)
-		}
-		if err := rows.Err(); err != nil {
+		if out, err = scanRelationships(rows); err != nil {
 			return err
 		}
 		if len(out) > limit {
@@ -181,6 +148,60 @@ func (s *Store) ListRelationships(ctx context.Context, in ListRelationshipsInput
 		return nil
 	})
 	return out, page, err
+}
+
+// relationshipListWhere renders the list filters (kind/person/org/deal,
+// archived, cursor) plus the endpoint-visibility scope into WHERE clauses,
+// binding each value through arg.
+func relationshipListWhere(ctx context.Context, in ListRelationshipsInput, arg func(any) int) ([]string, error) {
+	where := []string{"true"}
+	if in.Kind != nil {
+		where = append(where, storekit.SQLf("r.kind = $%d", arg(*in.Kind)))
+	}
+	if in.PersonID != nil {
+		where = append(where, storekit.SQLf("r.person_id = $%d", arg(*in.PersonID)))
+	}
+	if in.OrganizationID != nil {
+		pos := arg(*in.OrganizationID)
+		where = append(where, storekit.SQLf("(r.organization_id = $%d OR r.counterparty_org_id = $%d)", pos, pos))
+	}
+	if in.DealID != nil {
+		where = append(where, storekit.SQLf("r.deal_id = $%d", arg(*in.DealID)))
+	}
+	if !in.IncludeArchived {
+		where = append(where, "r.archived_at IS NULL")
+	}
+	if in.Cursor != "" {
+		after, err := ids.Parse(in.Cursor)
+		if err != nil {
+			return nil, &RequiredFieldError{Field: "cursor"}
+		}
+		where = append(where, storekit.SQLf("r.id > $%d", arg(after)))
+	}
+	scope, err := relationshipEndpointScope(ctx, "r", arg)
+	if err != nil {
+		return nil, err
+	}
+	if scope != "" {
+		where = append(where, scope)
+	}
+	return where, nil
+}
+
+// scanRelationships drains a relationship result set into rows.
+func scanRelationships(rows pgx.Rows) ([]relationshipRow, error) {
+	var out []relationshipRow
+	for rows.Next() {
+		rel, err := scanRelationship(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, rel)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 type CreateRelationshipInput struct {


### PR DESCRIPTION
## What
Complexity tranche 2 — brings 8 more production functions to ≤15 cognitive complexity (so the `go:S3776` finding actually clears, not just shrinks).

## Why
| Function | was | Extracted |
|---|---|---|
| people `ListRelationships` | 31 | `relationshipListWhere`, `scanRelationships` |
| deals `insertOfferLine` | 31 | `resolveProductSnapshot`, `normalizeLineDefaults`, `insertOfferLineRow` |
| people `UpdateOrganization` | 30 | `buildOrganizationPatch`, `writeOrganizationUpdate` |
| deals `UpdateProduct` | 30 | `buildProductPatch` |
| compose `fetchRows` (report) | 30 | `buildReportWhere`, `reportSQL`, `scanReportRows` |
| people `MergeOrganization` | 29 | `relinkOrgAssociations`, `fillOrgSurvivorship`, `finalizeOrgMerge` |
| deals `ListDealOffers` | 29 | `dealOffersFilters`, `scanOffers`, `attachOfferLines` |
| compose `agentGate` | 29 | `prepareAgentGate` (fail-closed refusals), `admitAgentCall` (run/stage/redeem dispatch) |

## Safety
Behavior-preserving. No `Audit`/`Emit`, `auth.*` gate, tx boundary, SQL, bind-param order, validation, or error sentinel reordered/dropped; `Audit`+`Emit` kept co-located (write-shape fitness gate green). The `agentGate` refactor preserves the exact admission semantics — 🟢 runs (with the `update_record` per-field owner split), 🟡 `ErrRequiresApproval` stages (never executes), any other error refuses; the admitted (tiered) context is threaded before dispatch.

## How verified
`make check`, touched-package tests, and `go vet -tags integration ./...` all green.

## AI involvement
Extraction by a Claude Code subagent under strict ≤15-or-skip + behavior-preservation guardrails; the security-sensitive `agentGate` flow was read end-to-end and verified by the main agent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability across organization, relationship, deal, report, and offer workflows.
  * Made updates and merges more consistent, with better handling of partial changes and approval-needed actions.
  * Strengthened list and report results so filtering, pagination, and row loading behave more predictably.
  * Improved validation for offer pricing details and product updates to reduce inconsistent data entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->