### PR TITLE
refactor(sonar): reduce cognitive complexity in 3 more functions (go:S3776)

### DIFF
--- a/backend/internal/modules/agents/automations_catalog.go
+++ b/backend/internal/modules/agents/automations_catalog.go
@@ -122,35 +122,56 @@ func validateLeadRoutingParams(params map[string]any) error {
 	for key, value := range params {
 		switch key {
 		case "owners":
-			list, ok := value.([]any)
-			if !ok {
-				return &ParamError{Field: "params.owners", Reason: "must be an array of user ids"}
-			}
-			for i, item := range list {
-				if !isUUIDString(item) {
-					return &ParamError{Field: fmt.Sprintf("params.owners[%d]", i), Reason: "must be a UUID"}
-				}
+			if err := validateRoutingOwners(value); err != nil {
+				return err
 			}
 		case "cap_per_owner":
-			n, ok := value.(float64) // decoded JSON numbers arrive as float64
-			if !ok || n != math.Trunc(n) {
-				return &ParamError{Field: "params.cap_per_owner", Reason: "must be an integer"}
-			}
-			if n < 1 {
-				return &ParamError{Field: "params.cap_per_owner", Reason: "must be at least 1"}
+			if err := validateRoutingCap(value); err != nil {
+				return err
 			}
 		case "rules":
-			list, ok := value.([]any)
-			if !ok {
-				return &ParamError{Field: "params.rules", Reason: "must be an array of rules"}
-			}
-			for i, item := range list {
-				if err := validateRoutingRule(i, item); err != nil {
-					return err
-				}
+			if err := validateRoutingRules(value); err != nil {
+				return err
 			}
 		default:
 			return &ParamError{Field: "params." + key, Reason: "not a parameter of this automation type"}
+		}
+	}
+	return nil
+}
+
+func validateRoutingOwners(value any) error {
+	list, ok := value.([]any)
+	if !ok {
+		return &ParamError{Field: "params.owners", Reason: "must be an array of user ids"}
+	}
+	for i, item := range list {
+		if !isUUIDString(item) {
+			return &ParamError{Field: fmt.Sprintf("params.owners[%d]", i), Reason: "must be a UUID"}
+		}
+	}
+	return nil
+}
+
+func validateRoutingCap(value any) error {
+	n, ok := value.(float64) // decoded JSON numbers arrive as float64
+	if !ok || n != math.Trunc(n) {
+		return &ParamError{Field: "params.cap_per_owner", Reason: "must be an integer"}
+	}
+	if n < 1 {
+		return &ParamError{Field: "params.cap_per_owner", Reason: "must be at least 1"}
+	}
+	return nil
+}
+
+func validateRoutingRules(value any) error {
+	list, ok := value.([]any)
+	if !ok {
+		return &ParamError{Field: "params.rules", Reason: "must be an array of rules"}
+	}
+	for i, item := range list {
+		if err := validateRoutingRule(i, item); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/backend/internal/modules/collections/lists.go
+++ b/backend/internal/modules/collections/lists.go
@@ -237,12 +237,6 @@ func (s *Store) ListMembers(ctx context.Context, listID ids.UUID, limit int, cur
 		if err := ensureListVisible(ctx, tx, listID); err != nil {
 			return err
 		}
-		// A list holds one entity_type (AddMember enforces it); every member
-		// is a row of that table. The parent-list gate above does not cover
-		// the members: without a per-member row-scope filter a shared list
-		// would leak the existence of records outside the caller's scope. So
-		// each member is disclosed only if its target passes that table's
-		// visibility predicate (unbounded actors get no filter).
 		var listEntityType, listType string
 		var definition map[string]any
 		if err := tx.QueryRow(ctx, `SELECT entity_type, list_type, definition FROM list WHERE id = $1`, listID).
@@ -260,48 +254,63 @@ func (s *Store) ListMembers(ctx context.Context, listID ids.UUID, limit int, cur
 			out, page, segErr = s.evaluateSegment(ctx, tx, listID, listEntityType, definition, limit, cursor)
 			return segErr
 		}
-		var args []any
-		arg := func(v any) int { args = append(args, v); return len(args) }
-		sql := fmt.Sprintf(`SELECT lm.id, lm.list_id, lm.entity_type, lm.entity_id, lm.added_by, lm.created_at
-			FROM list_member lm WHERE lm.list_id = $%d`, arg(listID))
-		scope, err := auth.ScopeClauseFor(ctx, listEntityType, "e", arg)
-		if err != nil {
-			return err
-		}
-		if scope != "" {
-			sql += fmt.Sprintf(" AND EXISTS (SELECT 1 FROM %s e WHERE e.id = lm.entity_id AND %s)",
-				listEntityType, scope)
-		}
-		if cursor != "" {
-			after, err := ids.Parse(cursor)
-			if err != nil {
-				return &BadInputError{Field: "cursor", Reason: "malformed"}
-			}
-			sql += fmt.Sprintf(" AND lm.id > $%d", arg(after))
-		}
-		sql += fmt.Sprintf(" ORDER BY lm.id LIMIT $%d", arg(limit+1))
-		rows, err := tx.Query(ctx, sql, args...)
-		if err != nil {
-			return err
-		}
-		defer rows.Close()
-		for rows.Next() {
-			var m memberRow
-			if err := rows.Scan(&m.ID, &m.ListID, &m.EntityType, &m.EntityID, &m.AddedBy, &m.CreatedAt); err != nil {
-				return err
-			}
-			out = append(out, m)
-		}
-		if err := rows.Err(); err != nil {
-			return err
-		}
-		if len(out) > limit {
-			out = out[:limit]
-			page = storekit.Page{HasMore: true, NextCursor: out[limit-1].ID.String()}
-		}
-		return nil
+		var err error
+		out, page, err = s.listStaticMembers(ctx, tx, listID, listEntityType, limit, cursor)
+		return err
 	})
 	return out, page, err
+}
+
+// listStaticMembers reads the explicit members of a static list. A list
+// holds one entity_type (AddMember enforces it); every member is a row of
+// that table. The parent-list gate does not cover the members: without a
+// per-member row-scope filter a shared list would leak the existence of
+// records outside the caller's scope. So each member is disclosed only if
+// its target passes that table's visibility predicate (unbounded actors
+// get no filter).
+func (s *Store) listStaticMembers(ctx context.Context, tx pgx.Tx, listID ids.UUID, listEntityType string, limit int, cursor string) ([]memberRow, storekit.Page, error) {
+	var out []memberRow
+	var page storekit.Page
+	var args []any
+	arg := func(v any) int { args = append(args, v); return len(args) }
+	sql := fmt.Sprintf(`SELECT lm.id, lm.list_id, lm.entity_type, lm.entity_id, lm.added_by, lm.created_at
+		FROM list_member lm WHERE lm.list_id = $%d`, arg(listID))
+	scope, err := auth.ScopeClauseFor(ctx, listEntityType, "e", arg)
+	if err != nil {
+		return nil, storekit.Page{}, err
+	}
+	if scope != "" {
+		sql += fmt.Sprintf(" AND EXISTS (SELECT 1 FROM %s e WHERE e.id = lm.entity_id AND %s)",
+			listEntityType, scope)
+	}
+	if cursor != "" {
+		after, err := ids.Parse(cursor)
+		if err != nil {
+			return nil, storekit.Page{}, &BadInputError{Field: "cursor", Reason: "malformed"}
+		}
+		sql += fmt.Sprintf(" AND lm.id > $%d", arg(after))
+	}
+	sql += fmt.Sprintf(" ORDER BY lm.id LIMIT $%d", arg(limit+1))
+	rows, err := tx.Query(ctx, sql, args...)
+	if err != nil {
+		return nil, storekit.Page{}, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var m memberRow
+		if err := rows.Scan(&m.ID, &m.ListID, &m.EntityType, &m.EntityID, &m.AddedBy, &m.CreatedAt); err != nil {
+			return nil, storekit.Page{}, err
+		}
+		out = append(out, m)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, storekit.Page{}, err
+	}
+	if len(out) > limit {
+		out = out[:limit]
+		page = storekit.Page{HasMore: true, NextCursor: out[limit-1].ID.String()}
+	}
+	return out, page, nil
 }
 
 func (s *Store) AddMember(ctx context.Context, listID ids.UUID, entityType string, entityID ids.UUID) (memberRow, error) {

--- a/backend/internal/modules/people/person.go
+++ b/backend/internal/modules/people/person.go
@@ -298,25 +298,7 @@ func (s *Store) UpdatePerson(ctx context.Context, id ids.UUID, in UpdatePersonIn
 			return fmt.Errorf("read person before update: %w", err)
 		}
 
-		p := storekit.NewPatch()
-		if in.FullName != nil {
-			p.Set("full_name", current.FullName, *in.FullName)
-		}
-		if in.FirstName != nil {
-			p.Set("first_name", current.FirstName, *in.FirstName)
-		}
-		if in.LastName != nil {
-			p.Set("last_name", current.LastName, *in.LastName)
-		}
-		if in.Title != nil {
-			p.Set("title", current.Title, *in.Title)
-		}
-		if in.OwnerID != nil {
-			p.Set("owner_id", current.OwnerId, *in.OwnerID)
-		}
-		if in.Social != nil {
-			p.Set("social", current.Social, storekit.JSONArg(in.Social))
-		}
+		p := buildPersonPatch(current, in)
 		if p.Empty() {
 			out = current
 			return nil
@@ -338,6 +320,32 @@ func (s *Store) UpdatePerson(ctx context.Context, id ids.UUID, in UpdatePersonIn
 		return nil
 	})
 	return out, err
+}
+
+// buildPersonPatch stages only the fields the caller supplied, each
+// diffed against the current row so the audit before/after captures the
+// real change and an unchanged field is left out of the UPDATE.
+func buildPersonPatch(current crmcontracts.Person, in UpdatePersonInput) *storekit.Patch {
+	p := storekit.NewPatch()
+	if in.FullName != nil {
+		p.Set("full_name", current.FullName, *in.FullName)
+	}
+	if in.FirstName != nil {
+		p.Set("first_name", current.FirstName, *in.FirstName)
+	}
+	if in.LastName != nil {
+		p.Set("last_name", current.LastName, *in.LastName)
+	}
+	if in.Title != nil {
+		p.Set("title", current.Title, *in.Title)
+	}
+	if in.OwnerID != nil {
+		p.Set("owner_id", current.OwnerId, *in.OwnerID)
+	}
+	if in.Social != nil {
+		p.Set("social", current.Social, storekit.JSONArg(in.Social))
+	}
+	return p
 }
 
 // ArchivePerson soft-deletes the person and cascades to its owned child


### PR DESCRIPTION
## What
Complexity tranche 3 — 3 more production functions brought to ≤15.

| Function | was | Extracted (all ≤6 params) |
|---|---|---|
| agents `validateLeadRoutingParams` | 30 | `validateRoutingOwners` / `validateRoutingCap` / `validateRoutingRules` |
| collections `ListMembers` | 28 | `listStaticMembers` |
| people `UpdatePerson` | 27 | `buildPersonPatch` |

## Safety
Behavior-preserving. No `Audit`/`Emit` (kept co-located), `auth.*` gate, tx boundary, SQL, bind-order, validation, or error sentinel altered. No helper exceeds 7 params (learned from PR #9 — didn't trade S3776 for S107 this time).

## How verified
`make check`, touched-package tests, `go vet -tags integration ./...` all green.

## AI involvement
Extraction by a Claude Code subagent under ≤15-and-≤7-params + behavior-preservation guardrails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for automation routing settings so invalid values are rejected more consistently.
  * Fixed list member loading to handle pagination cursor errors more reliably.
  * Made person updates apply only the fields you actually change, reducing unintended updates.

* **Refactor**
  * Streamlined internal handling for routing validation, list member retrieval, and person patching without changing expected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->