### PR TITLE
refactor(sonar): reduce cognitive complexity in 8 more functions (go:S3776)

### DIFF
--- a/backend/internal/modules/approvals/service.go
+++ b/backend/internal/modules/approvals/service.go
@@ -216,53 +216,7 @@ func (s *Service) decide(ctx context.Context, id ids.UUID, approve bool, reason 
 	var a row
 	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
 		var err error
-		a, err = get(ctx, tx, id)
-		if err != nil {
-			return err
-		}
-		visible, err := decidable(ctx, tx, p, a)
-		if err != nil {
-			return err
-		}
-		if !visible {
-			return apperrors.ErrNotFound
-		}
-		if st := a.effectiveStatus(s.now()); st != "pending" {
-			return &AlreadyDecidedError{Status: st}
-		}
-
-		status, action, verdict := "rejected", "reject", "rejected"
-		if approve {
-			status, action, verdict = "approved", "approve", "approved"
-		}
-		auditEvidence := map[string]any{
-			"kind": a.Kind, "verdict": verdict, "reason": reason,
-		}
-		decidedPayload := map[string]any{
-			"kind": a.Kind, "verdict": verdict, "decided_by": p.UserID,
-		}
-		if edited != nil {
-			if err := applyEditedPayload(ctx, tx, id, edited, a, auditEvidence, decidedPayload); err != nil {
-				return err
-			}
-		}
-		if _, err := tx.Exec(ctx,
-			`UPDATE approval SET status = $2, decided_by = $3, decided_at = now(), decision_reason = $4
-			 WHERE id = $1`,
-			id, status, p.UserID, reason); err != nil {
-			return err
-		}
-		auditID, err := s.audit(ctx, tx, p, action, id, auditEvidence)
-		if err != nil {
-			return err
-		}
-		if err := s.emit(ctx, tx, p, auditID, "approval.decided", id, decidedPayload); err != nil {
-			return err
-		}
-		if err := s.emitKindDecided(ctx, tx, p, auditID, id, a.Kind, approve); err != nil {
-			return err
-		}
-		a, err = get(ctx, tx, id)
+		a, err = s.decideInTx(ctx, tx, p, id, approve, reason, edited)
 		return err
 	})
 	if err != nil {
@@ -278,6 +232,61 @@ func (s *Service) decide(ctx context.Context, id ids.UUID, approve bool, reason 
 		}
 	}
 	return a, err
+}
+
+// decideInTx runs the decision inside the caller's transaction: the
+// decide-authority + row-scope gate, the pending guard, the optional
+// modify-then-approve edit, the status write, and the write shape. It
+// returns the re-read row so the follow-on effect runs against committed
+// state.
+func (s *Service) decideInTx(ctx context.Context, tx pgx.Tx, p principal.Principal, id ids.UUID, approve bool, reason *string, edited json.RawMessage) (row, error) {
+	a, err := get(ctx, tx, id)
+	if err != nil {
+		return row{}, err
+	}
+	visible, err := decidable(ctx, tx, p, a)
+	if err != nil {
+		return row{}, err
+	}
+	if !visible {
+		return row{}, apperrors.ErrNotFound
+	}
+	if st := a.effectiveStatus(s.now()); st != "pending" {
+		return row{}, &AlreadyDecidedError{Status: st}
+	}
+
+	status, action, verdict := "rejected", "reject", "rejected"
+	if approve {
+		status, action, verdict = "approved", "approve", "approved"
+	}
+	auditEvidence := map[string]any{
+		"kind": a.Kind, "verdict": verdict, "reason": reason,
+	}
+	decidedPayload := map[string]any{
+		"kind": a.Kind, "verdict": verdict, "decided_by": p.UserID,
+	}
+	if edited != nil {
+		if err := applyEditedPayload(ctx, tx, id, edited, a, auditEvidence, decidedPayload); err != nil {
+			return row{}, err
+		}
+	}
+	if _, err := tx.Exec(ctx,
+		`UPDATE approval SET status = $2, decided_by = $3, decided_at = now(), decision_reason = $4
+		 WHERE id = $1`,
+		id, status, p.UserID, reason); err != nil {
+		return row{}, err
+	}
+	auditID, err := s.audit(ctx, tx, p, action, id, auditEvidence)
+	if err != nil {
+		return row{}, err
+	}
+	if err := s.emit(ctx, tx, p, auditID, "approval.decided", id, decidedPayload); err != nil {
+		return row{}, err
+	}
+	if err := s.emitKindDecided(ctx, tx, p, auditID, id, a.Kind, approve); err != nil {
+		return row{}, err
+	}
+	return get(ctx, tx, id)
 }
 
 // applyEditedPayload is the modify-then-approve write (ADR-0036 §4): the

--- a/backend/internal/modules/deals/offer.go
+++ b/backend/internal/modules/deals/offer.go
@@ -89,66 +89,92 @@ func (s *Store) CreateOffer(ctx context.Context, dealID ids.UUID, in CreateOffer
 
 	var out crmcontracts.Offer
 	err = s.tx(ctx, func(tx pgx.Tx) error {
-		wsID := storekit.MustWorkspace(ctx)
-		// The deal anchors the offer's visibility: it must exist, be live
-		// and sit inside the caller's row scope (miss = 404).
-		if err := auth.EnsureLinkTarget(ctx, tx, "deal", dealID); err != nil {
-			return err
-		}
-
-		buyerOrg := in.BuyerOrgID
-		if buyerOrg == nil {
-			var dealOrg *ids.UUID
-			if err := tx.QueryRow(ctx,
-				`SELECT organization_id FROM deal WHERE id = $1`, dealID).Scan(&dealOrg); err != nil {
-				return fmt.Errorf("read deal organization: %w", err)
-			}
-			buyerOrg = dealOrg
-		} else if err := auth.EnsureLinkTarget(ctx, tx, "organization", *buyerOrg); err != nil {
-			return err
-		}
-
-		number, err := nextOfferNumber(ctx, tx, wsID)
-		if err != nil {
-			return err
-		}
-
-		id := ids.NewV7()
-		_, err = tx.Exec(ctx,
-			`INSERT INTO offer (id, workspace_id, deal_id, offer_number, revision, status, currency,
-			                    buyer_org_id, valid_until, intro_text, terms_text, source, captured_by)
-			 VALUES ($1, $2, $3, $4, 1, 'draft', $5, $6, $7, $8, $9, $10, $11)`,
-			id, wsID, dealID, number, in.Currency, buyerOrg, in.ValidUntil, in.IntroText, in.TermsText, in.Source, by)
-		if err != nil {
-			return fmt.Errorf("insert offer: %w", err)
-		}
-
-		for i, line := range in.LineItems {
-			if err := insertOfferLine(ctx, tx, wsID, id, in.Currency, line); err != nil {
-				return fmt.Errorf("line %d: %w", i+1, err)
-			}
-		}
-		if err := recomputeOfferTotals(ctx, tx, id); err != nil {
-			return err
-		}
-
-		auditID, err := storekit.Audit(ctx, tx, "create", "offer", id,
-			nil, map[string]any{"offer_number": number, "deal_id": dealID, "currency": in.Currency})
-		if err != nil {
-			return fmt.Errorf("audit offer create: %w", err)
-		}
-		if err := storekit.Emit(ctx, tx, auditID, "offer.created", "offer", id, map[string]any{
-			"offer_id": id, "deal_id": dealID, "revision": 1,
-			"currency": in.Currency, "source": in.Source, "captured_by": by,
-		}); err != nil {
-			return fmt.Errorf("emit offer.created: %w", err)
-		}
-		if out, err = readOfferWithLines(ctx, tx, id, storekit.LiveOnly); err != nil {
-			return fmt.Errorf("read created offer: %w", err)
-		}
-		return nil
+		var err error
+		out, err = createOfferTx(ctx, tx, dealID, in, by)
+		return err
 	})
 	return out, err
+}
+
+// createOfferTx resolves the buyer org, mints the offer number, inserts
+// the offer and its lines, derives the totals, and runs the write shape —
+// all inside the caller's transaction.
+func createOfferTx(ctx context.Context, tx pgx.Tx, dealID ids.UUID, in CreateOfferInput, by string) (crmcontracts.Offer, error) {
+	wsID := storekit.MustWorkspace(ctx)
+	// The deal anchors the offer's visibility: it must exist, be live
+	// and sit inside the caller's row scope (miss = 404).
+	if err := auth.EnsureLinkTarget(ctx, tx, "deal", dealID); err != nil {
+		return crmcontracts.Offer{}, err
+	}
+	buyerOrg, err := resolveBuyerOrg(ctx, tx, dealID, in.BuyerOrgID)
+	if err != nil {
+		return crmcontracts.Offer{}, err
+	}
+	number, err := nextOfferNumber(ctx, tx, wsID)
+	if err != nil {
+		return crmcontracts.Offer{}, err
+	}
+
+	id := ids.NewV7()
+	if _, err := tx.Exec(ctx,
+		`INSERT INTO offer (id, workspace_id, deal_id, offer_number, revision, status, currency,
+		                    buyer_org_id, valid_until, intro_text, terms_text, source, captured_by)
+		 VALUES ($1, $2, $3, $4, 1, 'draft', $5, $6, $7, $8, $9, $10, $11)`,
+		id, wsID, dealID, number, in.Currency, buyerOrg, in.ValidUntil, in.IntroText, in.TermsText, in.Source, by); err != nil {
+		return crmcontracts.Offer{}, fmt.Errorf("insert offer: %w", err)
+	}
+	if err := insertOfferLines(ctx, tx, wsID, id, in.Currency, in.LineItems); err != nil {
+		return crmcontracts.Offer{}, err
+	}
+	if err := recomputeOfferTotals(ctx, tx, id); err != nil {
+		return crmcontracts.Offer{}, err
+	}
+
+	auditID, err := storekit.Audit(ctx, tx, "create", "offer", id,
+		nil, map[string]any{"offer_number": number, "deal_id": dealID, "currency": in.Currency})
+	if err != nil {
+		return crmcontracts.Offer{}, fmt.Errorf("audit offer create: %w", err)
+	}
+	if err := storekit.Emit(ctx, tx, auditID, "offer.created", "offer", id, map[string]any{
+		"offer_id": id, "deal_id": dealID, "revision": 1,
+		"currency": in.Currency, "source": in.Source, "captured_by": by,
+	}); err != nil {
+		return crmcontracts.Offer{}, fmt.Errorf("emit offer.created: %w", err)
+	}
+	out, err := readOfferWithLines(ctx, tx, id, storekit.LiveOnly)
+	if err != nil {
+		return crmcontracts.Offer{}, fmt.Errorf("read created offer: %w", err)
+	}
+	return out, nil
+}
+
+// resolveBuyerOrg picks the offer's buyer org: an explicit org is
+// row-scope probed (a client-supplied FK, H1); absent one, the offer
+// inherits the deal's organization.
+func resolveBuyerOrg(ctx context.Context, tx pgx.Tx, dealID ids.UUID, buyerOrgID *ids.UUID) (*ids.UUID, error) {
+	if buyerOrgID != nil {
+		if err := auth.EnsureLinkTarget(ctx, tx, "organization", *buyerOrgID); err != nil {
+			return nil, err
+		}
+		return buyerOrgID, nil
+	}
+	var dealOrg *ids.UUID
+	if err := tx.QueryRow(ctx,
+		`SELECT organization_id FROM deal WHERE id = $1`, dealID).Scan(&dealOrg); err != nil {
+		return nil, fmt.Errorf("read deal organization: %w", err)
+	}
+	return dealOrg, nil
+}
+
+// insertOfferLines inserts each input line in order, numbering the 422
+// error by the caller's 1-based line position.
+func insertOfferLines(ctx context.Context, tx pgx.Tx, wsID, offerID ids.UUID, currency string, lines []OfferLineInputRow) error {
+	for i, line := range lines {
+		if err := insertOfferLine(ctx, tx, wsID, offerID, currency, line); err != nil {
+			return fmt.Errorf("line %d: %w", i+1, err)
+		}
+	}
+	return nil
 }
 
 // nextOfferNumber mints the workspace's next human-facing Angebot number

--- a/backend/internal/modules/people/coldstartprofile.go
+++ b/backend/internal/modules/people/coldstartprofile.go
@@ -74,64 +74,86 @@ func (s *Store) ApplyColdStartProfile(ctx context.Context, in ApplyColdStartProf
 
 	var orgID ids.UUID
 	err = s.tx(ctx, func(tx pgx.Tx) error {
-		wsID := storekit.MustWorkspace(ctx)
-
-		created := false
-		err := tx.QueryRow(ctx,
-			`SELECT organization_id FROM organization_domain WHERE domain = lower($1) AND archived_at IS NULL`,
-			host).Scan(&orgID)
-		if errors.Is(err, pgx.ErrNoRows) {
-			created = true
-			orgID = ids.NewV7()
-			displayName := host
-			if legal := fieldValue(in.Fields, "legal_name"); legal != "" {
-				displayName = legal
-			}
-			if _, err := tx.Exec(ctx,
-				`INSERT INTO organization (id, workspace_id, display_name, source, captured_by)
-				 VALUES ($1, $2, $3, 'coldstart', $4)`,
-				orgID, wsID, displayName, by); err != nil {
-				return fmt.Errorf("insert coldstart organization: %w", err)
-			}
-			if _, err := tx.Exec(ctx,
-				`INSERT INTO organization_domain (workspace_id, organization_id, domain, is_primary, source, captured_by)
-				 VALUES ($1, $2, lower($3), true, 'coldstart', $4)`,
-				wsID, orgID, host, by); err != nil {
-				return fmt.Errorf("insert coldstart organization domain: %w", err)
-			}
-		} else if err != nil {
-			return fmt.Errorf("resolve organization by domain: %w", err)
-		}
-
-		applied, err := applyEvidenceFields(ctx, tx, wsID, orgID, "coldstart", by, in.Fields)
-		if err != nil {
-			return err
-		}
-
-		action, eventType := "update", "organization.updated"
-		if created {
-			action, eventType = "create", "organization.created"
-		}
-		auditID, err := storekit.Audit(ctx, tx, action, "organization", orgID, nil, map[string]any{
-			"source": "coldstart", "source_url": in.SourceURL, "fields": applied,
-		})
-		if err != nil {
-			return fmt.Errorf("audit coldstart apply: %w", err)
-		}
-		payload := map[string]any{"delta": applied, "source": "coldstart", "source_url": in.SourceURL}
-		if created {
-			payload = map[string]any{"display_name": fieldValue(in.Fields, "legal_name"), "primary_domain": host,
-				"source": "coldstart", "captured_by": by}
-		}
-		if err := storekit.Emit(ctx, tx, auditID, eventType, "organization", orgID, payload); err != nil {
-			return fmt.Errorf("emit %s: %w", eventType, err)
-		}
-		return nil
+		var err error
+		orgID, err = applyColdStartTx(ctx, tx, in, host, by)
+		return err
 	})
 	if err != nil {
 		return ids.Nil, err
 	}
 	return orgID, nil
+}
+
+// applyColdStartTx resolves-or-creates the target organization, fills the
+// accepted fields (evidence for every one, columns only when empty), and
+// runs the write shape — create vs update chosen by whether the org was
+// just minted — all inside the caller's transaction.
+func applyColdStartTx(ctx context.Context, tx pgx.Tx, in ApplyColdStartProfileInput, host, by string) (ids.UUID, error) {
+	wsID := storekit.MustWorkspace(ctx)
+	orgID, created, err := resolveOrCreateColdStartOrg(ctx, tx, wsID, host, by, in.Fields)
+	if err != nil {
+		return ids.Nil, err
+	}
+	applied, err := applyEvidenceFields(ctx, tx, wsID, orgID, "coldstart", by, in.Fields)
+	if err != nil {
+		return ids.Nil, err
+	}
+
+	action, eventType := "update", "organization.updated"
+	if created {
+		action, eventType = "create", "organization.created"
+	}
+	auditID, err := storekit.Audit(ctx, tx, action, "organization", orgID, nil, map[string]any{
+		"source": "coldstart", "source_url": in.SourceURL, "fields": applied,
+	})
+	if err != nil {
+		return ids.Nil, fmt.Errorf("audit coldstart apply: %w", err)
+	}
+	payload := map[string]any{"delta": applied, "source": "coldstart", "source_url": in.SourceURL}
+	if created {
+		payload = map[string]any{"display_name": fieldValue(in.Fields, "legal_name"), "primary_domain": host,
+			"source": "coldstart", "captured_by": by}
+	}
+	if err := storekit.Emit(ctx, tx, auditID, eventType, "organization", orgID, payload); err != nil {
+		return ids.Nil, fmt.Errorf("emit %s: %w", eventType, err)
+	}
+	return orgID, nil
+}
+
+// resolveOrCreateColdStartOrg finds the organization the source domain
+// names, or creates it (with its primary domain) when absent. It reports
+// whether it created the org so the caller selects the create/update audit
+// action and event.
+func resolveOrCreateColdStartOrg(ctx context.Context, tx pgx.Tx, wsID ids.UUID, host, by string, fields []ColdStartFieldInput) (ids.UUID, bool, error) {
+	var orgID ids.UUID
+	err := tx.QueryRow(ctx,
+		`SELECT organization_id FROM organization_domain WHERE domain = lower($1) AND archived_at IS NULL`,
+		host).Scan(&orgID)
+	if err == nil {
+		return orgID, false, nil
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return ids.Nil, false, fmt.Errorf("resolve organization by domain: %w", err)
+	}
+
+	orgID = ids.NewV7()
+	displayName := host
+	if legal := fieldValue(fields, "legal_name"); legal != "" {
+		displayName = legal
+	}
+	if _, err := tx.Exec(ctx,
+		`INSERT INTO organization (id, workspace_id, display_name, source, captured_by)
+		 VALUES ($1, $2, $3, 'coldstart', $4)`,
+		orgID, wsID, displayName, by); err != nil {
+		return ids.Nil, false, fmt.Errorf("insert coldstart organization: %w", err)
+	}
+	if _, err := tx.Exec(ctx,
+		`INSERT INTO organization_domain (workspace_id, organization_id, domain, is_primary, source, captured_by)
+		 VALUES ($1, $2, lower($3), true, 'coldstart', $4)`,
+		wsID, orgID, host, by); err != nil {
+		return ids.Nil, false, fmt.Errorf("insert coldstart organization domain: %w", err)
+	}
+	return orgID, true, nil
 }
 
 // coldStartColumns whitelists the identifier a fillEmptyOrgColumn UPDATE

--- a/backend/internal/modules/people/lead.go
+++ b/backend/internal/modules/people/lead.go
@@ -94,11 +94,8 @@ func (s *Store) CreateLead(ctx context.Context, in CreateLeadInput) (crmcontract
 			// latter is a plain conflict, not a "duplicate email" (the
 			// email may not even be set). No re-read here: the failed
 			// INSERT aborted the transaction.
-			if name, ok := storekit.UniqueViolation(err); ok {
-				if name == "uq_lead_email_dedupe" {
-					return &DuplicateLeadError{Email: deref(in.Email)}
-				}
-				return apperrors.ErrConflict
+			if mapped, ok := leadUniqueViolation(err, in.Email); ok {
+				return mapped
 			}
 			return fmt.Errorf("insert lead: %w", err)
 		}
@@ -306,50 +303,67 @@ func (s *Store) UpdateLead(ctx context.Context, id ids.UUID, in UpdateLeadInput)
 	}
 	var out crmcontracts.Lead
 	err := s.tx(ctx, func(tx pgx.Tx) error {
-		if err := auth.EnsureVisible(ctx, tx, "lead", id); err != nil {
-			return err
-		}
-		current, err := readLead(ctx, tx, id, storekit.LiveOnly)
-		if err != nil {
-			return err
-		}
-
-		p, resumeRecompute, err := buildLeadPatch(current, in)
-		if err != nil {
-			return err
-		}
-		if p.Empty() {
-			out = current
-			return nil
-		}
-
-		if err := p.Apply(ctx, tx, "lead", id, in.IfVersion); err != nil {
-			if name, ok := storekit.UniqueViolation(err); ok {
-				if name == "uq_lead_email_dedupe" {
-					return &DuplicateLeadError{Email: deref(in.Email)}
-				}
-				return apperrors.ErrConflict
-			}
-			return err
-		}
-		auditID, err := storekit.Audit(ctx, tx, "update", "lead", id, p.Before(), p.After())
-		if err != nil {
-			return err
-		}
-		if err := storekit.Emit(ctx, tx, auditID, "lead.updated", "lead", id, p.After()); err != nil {
-			return err
-		}
-		// Clearing an override immediately recomputes from current signals
-		// (formulas §3.1): score no longer lags behind the machine value.
-		if resumeRecompute {
-			if err := recomputeLeadScoreTx(ctx, tx, id, time.Now().UTC()); err != nil {
-				return err
-			}
-		}
-		out, err = readLead(ctx, tx, id, storekit.LiveOnly)
+		var err error
+		out, err = s.updateLeadTx(ctx, tx, id, in)
 		return err
 	})
 	return out, err
+}
+
+// updateLeadTx runs the visibility gate, the sparse-patch fold, the write
+// shape, and the cleared-override recompute for one lead update inside the
+// caller's transaction.
+func (s *Store) updateLeadTx(ctx context.Context, tx pgx.Tx, id ids.UUID, in UpdateLeadInput) (crmcontracts.Lead, error) {
+	if err := auth.EnsureVisible(ctx, tx, "lead", id); err != nil {
+		return crmcontracts.Lead{}, err
+	}
+	current, err := readLead(ctx, tx, id, storekit.LiveOnly)
+	if err != nil {
+		return crmcontracts.Lead{}, err
+	}
+	p, resumeRecompute, err := buildLeadPatch(current, in)
+	if err != nil {
+		return crmcontracts.Lead{}, err
+	}
+	if p.Empty() {
+		return current, nil
+	}
+	if err := p.Apply(ctx, tx, "lead", id, in.IfVersion); err != nil {
+		if mapped, ok := leadUniqueViolation(err, in.Email); ok {
+			return crmcontracts.Lead{}, mapped
+		}
+		return crmcontracts.Lead{}, err
+	}
+	auditID, err := storekit.Audit(ctx, tx, "update", "lead", id, p.Before(), p.After())
+	if err != nil {
+		return crmcontracts.Lead{}, err
+	}
+	if err := storekit.Emit(ctx, tx, auditID, "lead.updated", "lead", id, p.After()); err != nil {
+		return crmcontracts.Lead{}, err
+	}
+	// Clearing an override immediately recomputes from current signals
+	// (formulas §3.1): score no longer lags behind the machine value.
+	if resumeRecompute {
+		if err := recomputeLeadScoreTx(ctx, tx, id, time.Now().UTC()); err != nil {
+			return crmcontracts.Lead{}, err
+		}
+	}
+	return readLead(ctx, tx, id, storekit.LiveOnly)
+}
+
+// leadUniqueViolation maps a lead write's unique-index violation to the
+// contract error: the email dedupe index answers 409 duplicate-email; any
+// other unique index a plain conflict. The bool is false when err is not a
+// unique violation at all, so the caller keeps its own wrapping.
+func leadUniqueViolation(err error, email *string) (error, bool) {
+	name, ok := storekit.UniqueViolation(err)
+	if !ok {
+		return nil, false
+	}
+	if name == "uq_lead_email_dedupe" {
+		return &DuplicateLeadError{Email: deref(email)}, true
+	}
+	return apperrors.ErrConflict, true
 }
 
 // buildLeadPatch folds the caller's sparse update onto the current lead

--- a/backend/internal/modules/people/merge.go
+++ b/backend/internal/modules/people/merge.go
@@ -87,59 +87,70 @@ func (s *Store) MergePerson(ctx context.Context, sourceID, targetID ids.UUID) (c
 
 	var out crmcontracts.Person
 	err := s.tx(ctx, func(tx pgx.Tx) error {
-		src, tgt, err := mergePair(ctx, tx, "person", sourceID, targetID, readPersonMergeState)
-		if err != nil {
-			return err
-		}
-
-		counts, err := relinkPersonReferences(ctx, tx, sourceID, targetID)
-		if err != nil {
-			return err
-		}
-
-		// Survivorship is fill-only: A never overwrites what B has.
-		p := storekit.NewPatch()
-		fillString(p, "first_name", tgt.FirstName, src.FirstName)
-		fillString(p, "last_name", tgt.LastName, src.LastName)
-		fillString(p, "title", tgt.Title, src.Title)
-		if tgt.ConvertedFromLeadId == nil && src.ConvertedFromLeadId != nil {
-			p.Set("converted_from_lead_id", nil, ids.UUID(*src.ConvertedFromLeadId))
-		}
-		if (tgt.Social == nil || len(*tgt.Social) == 0) && src.Social != nil && len(*src.Social) > 0 {
-			p.Set("social", nil, storekit.JSONArg(*src.Social))
-		}
-		if !p.Empty() {
-			if err := p.Apply(ctx, tx, "person", targetID, nil); err != nil {
-				return fmt.Errorf("apply survivorship fill: %w", err)
-			}
-		}
-
-		if err := archiveMergedAway(ctx, tx, "person", sourceID, targetID); err != nil {
-			return fmt.Errorf("retire merged-away person: %w", err)
-		}
-
-		auditID, err := storekit.Audit(ctx, tx, "merge", "person", sourceID,
-			map[string]any{"merged_into_id": nil},
-			map[string]any{"merged_into_id": targetID, "relinked": counts, "filled": p.After()})
-		if err != nil {
-			return fmt.Errorf("audit person merge: %w", err)
-		}
-		// One event, its own verb: the context graph collapses two nodes,
-		// which neither person.updated nor person.archived can say.
-		if err := storekit.Emit(ctx, tx, auditID, "person.merged", "person", sourceID, map[string]any{
-			"merged_from_id": sourceID,
-			"merged_into_id": targetID,
-			"relinked":       counts,
-		}); err != nil {
-			return fmt.Errorf("emit person.merged: %w", err)
-		}
-
-		if out, err = readPerson(ctx, tx, targetID, storekit.LiveOnly); err != nil {
-			return fmt.Errorf("read surviving person: %w", err)
-		}
-		return nil
+		var err error
+		out, err = s.mergePersonTx(ctx, tx, sourceID, targetID)
+		return err
 	})
 	return out, err
+}
+
+// mergePersonTx resolves both ends, relinks every reference, fills the
+// survivor's gaps, retires the source, and runs the write shape — all
+// inside the caller's transaction.
+func (s *Store) mergePersonTx(ctx context.Context, tx pgx.Tx, sourceID, targetID ids.UUID) (crmcontracts.Person, error) {
+	src, tgt, err := mergePair(ctx, tx, "person", sourceID, targetID, readPersonMergeState)
+	if err != nil {
+		return crmcontracts.Person{}, err
+	}
+	counts, err := relinkPersonReferences(ctx, tx, sourceID, targetID)
+	if err != nil {
+		return crmcontracts.Person{}, err
+	}
+	p := buildSurvivorshipPatch(tgt, src)
+	if !p.Empty() {
+		if err := p.Apply(ctx, tx, "person", targetID, nil); err != nil {
+			return crmcontracts.Person{}, fmt.Errorf("apply survivorship fill: %w", err)
+		}
+	}
+	if err := archiveMergedAway(ctx, tx, "person", sourceID, targetID); err != nil {
+		return crmcontracts.Person{}, fmt.Errorf("retire merged-away person: %w", err)
+	}
+	auditID, err := storekit.Audit(ctx, tx, "merge", "person", sourceID,
+		map[string]any{"merged_into_id": nil},
+		map[string]any{"merged_into_id": targetID, "relinked": counts, "filled": p.After()})
+	if err != nil {
+		return crmcontracts.Person{}, fmt.Errorf("audit person merge: %w", err)
+	}
+	// One event, its own verb: the context graph collapses two nodes,
+	// which neither person.updated nor person.archived can say.
+	if err := storekit.Emit(ctx, tx, auditID, "person.merged", "person", sourceID, map[string]any{
+		"merged_from_id": sourceID,
+		"merged_into_id": targetID,
+		"relinked":       counts,
+	}); err != nil {
+		return crmcontracts.Person{}, fmt.Errorf("emit person.merged: %w", err)
+	}
+	out, err := readPerson(ctx, tx, targetID, storekit.LiveOnly)
+	if err != nil {
+		return crmcontracts.Person{}, fmt.Errorf("read surviving person: %w", err)
+	}
+	return out, nil
+}
+
+// buildSurvivorshipPatch folds A's values onto B fill-only: B never loses
+// what it already holds; only its empty fields take A's non-empty values.
+func buildSurvivorshipPatch(target, source crmcontracts.Person) *storekit.Patch {
+	p := storekit.NewPatch()
+	fillString(p, "first_name", target.FirstName, source.FirstName)
+	fillString(p, "last_name", target.LastName, source.LastName)
+	fillString(p, "title", target.Title, source.Title)
+	if target.ConvertedFromLeadId == nil && source.ConvertedFromLeadId != nil {
+		p.Set("converted_from_lead_id", nil, ids.UUID(*source.ConvertedFromLeadId))
+	}
+	if (target.Social == nil || len(*target.Social) == 0) && source.Social != nil && len(*source.Social) > 0 {
+		p.Set("social", nil, storekit.JSONArg(*source.Social))
+	}
+	return p
 }
 
 // relinkPersonReferences re-homes everything that points at the source

--- a/backend/internal/modules/people/partner.go
+++ b/backend/internal/modules/people/partner.go
@@ -175,58 +175,78 @@ func (s *Store) ListPartners(ctx context.Context, in ListPartnersInput) ([]partn
 	var out []partnerRow
 	var page storekit.Page
 	err := s.tx(ctx, func(tx pgx.Tx) error {
-		var args []any
-		arg := func(v any) int { args = append(args, v); return len(args) }
-		where := []string{"p.archived_at IS NULL"}
-		if in.PartnerRole != nil {
-			where = append(where, storekit.SQLf("p.partner_role = $%d", arg(*in.PartnerRole)))
-		}
-		if in.CertStatus != nil {
-			where = append(where, storekit.SQLf("p.cert_status = $%d", arg(*in.CertStatus)))
-		}
-		if in.Cursor != "" {
-			after, err := ids.Parse(in.Cursor)
-			if err != nil {
-				return &RequiredFieldError{Field: "cursor"}
-			}
-			where = append(where, storekit.SQLf("p.organization_id > $%d", arg(after)))
-		}
-		// A partner row is a read of its organization: the org's own
-		// row scope bounds the list.
-		scope, err := auth.ScopeClauseFor(ctx, "organization", "o", arg)
-		if err != nil {
-			return err
-		}
-		if scope != "" {
-			where = append(where, scope)
-		}
-		sql := storekit.SQLf(`
-			SELECT %s FROM partner p
-			JOIN organization o ON o.id = p.organization_id AND o.archived_at IS NULL
-			WHERE %s ORDER BY p.organization_id LIMIT $%d`,
-			aliased(partnerColumns, "p"), strings.Join(where, " AND "), arg(limit+1))
-		rows, err := tx.Query(ctx, sql, args...)
-		if err != nil {
-			return err
-		}
-		defer rows.Close()
-		for rows.Next() {
-			p, err := scanPartner(rows)
-			if err != nil {
-				return err
-			}
-			out = append(out, p)
-		}
-		if err := rows.Err(); err != nil {
-			return err
-		}
-		if len(out) > limit {
-			out = out[:limit]
-			page = storekit.Page{HasMore: true, NextCursor: out[limit-1].OrganizationID.String()}
-		}
-		return nil
+		var err error
+		out, page, err = listPartnersTx(ctx, tx, in, limit)
+		return err
 	})
 	return out, page, err
+}
+
+// listPartnersTx runs the keyset-paged partner list inside the caller's
+// transaction: filters + org-derived row scope, one page + lookahead.
+func listPartnersTx(ctx context.Context, tx pgx.Tx, in ListPartnersInput, limit int) ([]partnerRow, storekit.Page, error) {
+	var args []any
+	arg := func(v any) int { args = append(args, v); return len(args) }
+	where, err := partnerListWhere(ctx, in, arg)
+	if err != nil {
+		return nil, storekit.Page{}, err
+	}
+	sql := storekit.SQLf(`
+		SELECT %s FROM partner p
+		JOIN organization o ON o.id = p.organization_id AND o.archived_at IS NULL
+		WHERE %s ORDER BY p.organization_id LIMIT $%d`,
+		aliased(partnerColumns, "p"), strings.Join(where, " AND "), arg(limit+1))
+	rows, err := tx.Query(ctx, sql, args...)
+	if err != nil {
+		return nil, storekit.Page{}, err
+	}
+	defer rows.Close()
+	var out []partnerRow
+	for rows.Next() {
+		p, err := scanPartner(rows)
+		if err != nil {
+			return nil, storekit.Page{}, err
+		}
+		out = append(out, p)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, storekit.Page{}, err
+	}
+	var page storekit.Page
+	if len(out) > limit {
+		out = out[:limit]
+		page = storekit.Page{HasMore: true, NextCursor: out[limit-1].OrganizationID.String()}
+	}
+	return out, page, nil
+}
+
+// partnerListWhere builds the WHERE fragments for the partner list: the
+// role/cert-status filters, the keyset cursor, and the org's own row scope
+// (a partner row is a read of its organization, so the org scope bounds
+// the list).
+func partnerListWhere(ctx context.Context, in ListPartnersInput, arg func(any) int) ([]string, error) {
+	where := []string{"p.archived_at IS NULL"}
+	if in.PartnerRole != nil {
+		where = append(where, storekit.SQLf("p.partner_role = $%d", arg(*in.PartnerRole)))
+	}
+	if in.CertStatus != nil {
+		where = append(where, storekit.SQLf("p.cert_status = $%d", arg(*in.CertStatus)))
+	}
+	if in.Cursor != "" {
+		after, err := ids.Parse(in.Cursor)
+		if err != nil {
+			return nil, &RequiredFieldError{Field: "cursor"}
+		}
+		where = append(where, storekit.SQLf("p.organization_id > $%d", arg(after)))
+	}
+	scope, err := auth.ScopeClauseFor(ctx, "organization", "o", arg)
+	if err != nil {
+		return nil, err
+	}
+	if scope != "" {
+		where = append(where, scope)
+	}
+	return where, nil
 }
 
 func wirePartner(p partnerRow) crmcontracts.Partner {

--- a/backend/internal/modules/search/graph.go
+++ b/backend/internal/modules/search/graph.go
@@ -188,63 +188,36 @@ func anchorTimeline(ctx context.Context, tx pgx.Tx, linkCol string, anchorID ids
 	return touches, openTasks, activityIDs, nil
 }
 
+// graphHop names one hop-2 target type: the entity, the activity_link
+// column that reaches it, and its human-facing title column.
+type graphHop struct {
+	entity string
+	column string
+	title  string
+}
+
+// relatedHops is the fixed set of hop-2 neighbor types, in the order the
+// related_* sections are emitted.
+var relatedHops = []graphHop{
+	{entity: "person", column: "person_id", title: "full_name"},
+	{entity: "organization", column: "organization_id", title: "display_name"},
+	{entity: "deal", column: "deal_id", title: "name"},
+}
+
 func (s *Store) relatedViaLinks(ctx context.Context, tx pgx.Tx, anchorType string, anchorID ids.UUID, activityIDs []ids.UUID, maxItems int) ([]graphSection, error) {
 	if len(activityIDs) == 0 {
 		return nil, nil
 	}
 	sectionsByType := map[string][]graphItem{}
-	for _, hop := range []struct {
-		entity string
-		column string
-		title  string
-	}{
-		{entity: "person", column: "person_id", title: "full_name"},
-		{entity: "organization", column: "organization_id", title: "display_name"},
-		{entity: "deal", column: "deal_id", title: "name"},
-	} {
+	for _, hop := range relatedHops {
 		if hop.entity == anchorType {
 			continue // the anchor is not its own neighbor
 		}
-		// Bounded like the activity leg: the id order makes the window
-		// deterministic before the per-row visibility probe thins it.
-		rows, err := tx.Query(ctx, fmt.Sprintf(`
-			SELECT DISTINCT t.id, t.%s
-			FROM activity_link l JOIN %s t ON t.id = l.%s
-			WHERE l.activity_id = ANY($1) AND t.archived_at IS NULL AND l.%s IS NOT NULL AND t.id <> $2
-			ORDER BY t.id LIMIT %d`,
-			hop.title, hop.entity, hop.column, hop.column, graphExpansionLimit), activityIDs, anchorID)
+		items, err := hopNeighbors(ctx, tx, hop, anchorID, activityIDs)
 		if err != nil {
 			return nil, err
 		}
-		type candidate struct {
-			id    ids.UUID
-			title string
-		}
-		var candidates []candidate
-		for rows.Next() {
-			var c candidate
-			if err := rows.Scan(&c.id, &c.title); err != nil {
-				rows.Close()
-				return nil, err
-			}
-			candidates = append(candidates, c)
-		}
-		rows.Close()
-		if err := rows.Err(); err != nil {
-			return nil, err
-		}
-		for _, c := range candidates {
-			visible, err := auth.VisibleTo(ctx, tx, hop.entity, c.id)
-			if err != nil {
-				return nil, err
-			}
-			if !visible {
-				continue
-			}
-			sectionsByType[hop.entity] = append(sectionsByType[hop.entity], graphItem{
-				entityType: hop.entity, id: c.id, summary: c.title,
-			})
-		}
+		sectionsByType[hop.entity] = items
 	}
 	var out []graphSection
 	for _, entity := range []string{"person", "organization", "deal"} {
@@ -259,6 +232,52 @@ func (s *Store) relatedViaLinks(ctx context.Context, tx pgx.Tx, anchorType strin
 		out = append(out, graphSection{name: "related_" + plural(entity), items: items})
 	}
 	return out, nil
+}
+
+// hopNeighbors reads one hop's bounded, deterministic candidate window and
+// returns the visible ones as graph items. Each candidate is
+// visibility-probed individually: the walk widens context, never authority.
+func hopNeighbors(ctx context.Context, tx pgx.Tx, hop graphHop, anchorID ids.UUID, activityIDs []ids.UUID) ([]graphItem, error) {
+	// Bounded like the activity leg: the id order makes the window
+	// deterministic before the per-row visibility probe thins it.
+	rows, err := tx.Query(ctx, fmt.Sprintf(`
+		SELECT DISTINCT t.id, t.%s
+		FROM activity_link l JOIN %s t ON t.id = l.%s
+		WHERE l.activity_id = ANY($1) AND t.archived_at IS NULL AND l.%s IS NOT NULL AND t.id <> $2
+		ORDER BY t.id LIMIT %d`,
+		hop.title, hop.entity, hop.column, hop.column, graphExpansionLimit), activityIDs, anchorID)
+	if err != nil {
+		return nil, err
+	}
+	type candidate struct {
+		id    ids.UUID
+		title string
+	}
+	var candidates []candidate
+	for rows.Next() {
+		var c candidate
+		if err := rows.Scan(&c.id, &c.title); err != nil {
+			rows.Close()
+			return nil, err
+		}
+		candidates = append(candidates, c)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	var items []graphItem
+	for _, c := range candidates {
+		visible, err := auth.VisibleTo(ctx, tx, hop.entity, c.id)
+		if err != nil {
+			return nil, err
+		}
+		if !visible {
+			continue
+		}
+		items = append(items, graphItem{entityType: hop.entity, id: c.id, summary: c.title})
+	}
+	return items, nil
 }
 
 // sortAndTrim orders by score descending with the §10.7.2 id-ascending

--- a/backend/internal/modules/signals/resolver.go
+++ b/backend/internal/modules/signals/resolver.go
@@ -119,120 +119,150 @@ func (s *Store) Resolve(ctx context.Context, signalID ids.UUID) (crmcontracts.Si
 	}
 	var out crmcontracts.Signal
 	err = s.tx(ctx, func(tx pgx.Tx) error {
-		if err := auth.EnsureSignalVisible(ctx, tx, signalID); err != nil {
-			return err
-		}
-		sig, err := readSignal(ctx, tx, signalID, storekit.LiveOnly)
-		if err != nil {
-			return err
-		}
-		switch sig.ResolutionState {
-		case "unresolved", "low_confidence":
-		default:
-			return &NotResolvableError{Reason: fmt.Sprintf("signal is already %s; resolution is terminal", sig.ResolutionState)}
-		}
-		if sig.RawRef == nil || strings.TrimSpace(*sig.RawRef) == "" {
-			return &RequiredFieldError{Field: "raw_ref"}
-		}
-
-		attribution := parseRawRef(*sig.RawRef)
-		candidates, err := matchCandidates(ctx, tx, attribution)
-		if err != nil {
-			return err
-		}
-		// Row-scope the attribution: a resolver may only attribute a signal
-		// to an organization the caller can see. Stamping resolved_org_id
-		// (a read of that org) for an org outside the caller's scope would
-		// leak its existence and id, so an invisible match is dropped —
-		// leaving the signal unattributable rather than disclosing it.
-		if candidates, err = visibleCandidates(ctx, tx, candidates); err != nil {
-			return err
-		}
-
-		var auditID ids.UUID
-		before := map[string]any{"resolution_state": sig.ResolutionState}
-		switch len(candidates) {
-		case 0:
-			// Drop-the-orphan guard (B-E08.1): unattributable
-			// → dropped, with the "why" on record — and NO person link.
-			if err := appendMatchBasis(ctx, tx, actor, signalID, "none", nil, nil,
-				`{"candidates": [], "reason": "no organization matched the raw_ref"}`); err != nil {
-				return err
-			}
-			if _, err := tx.Exec(ctx,
-				`UPDATE signal SET resolution_state = 'dropped', resolution_confidence = NULL WHERE id = $1`,
-				signalID); err != nil {
-				return fmt.Errorf("drop unattributable signal: %w", err)
-			}
-			auditID, err = storekit.Audit(ctx, tx, "resolve", "signal", signalID, before,
-				map[string]any{"resolution_state": "dropped"})
-			if err != nil {
-				return fmt.Errorf("audit signal drop: %w", err)
-			}
-		case 1:
-			chosen := candidates[0]
-			// Consent-gated person link: only an EXISTING person, only
-			// where the org match holds, only under a recorded grant.
-			personID, err := consentedPerson(ctx, tx, attribution.Email, chosen.OrgID)
-			if err != nil {
-				return err
-			}
-			detail, err := candidateDetail(candidates, &chosen)
-			if err != nil {
-				return err
-			}
-			if err := appendMatchBasis(ctx, tx, actor, signalID, chosen.MatchedOn, &chosen.OrgID, &chosen.Confidence, detail); err != nil {
-				return err
-			}
-			if _, err := tx.Exec(ctx,
-				`UPDATE signal SET resolution_state = 'resolved', resolution_confidence = $2,
-				        resolved_org_id = $3, resolved_person_id = $4,
-				        entity_type = COALESCE(entity_type, 'organization'),
-				        entity_id = COALESCE(entity_id, $3)
-				 WHERE id = $1`,
-				signalID, chosen.Confidence, chosen.OrgID, personID); err != nil {
-				return fmt.Errorf("stamp resolved signal: %w", err)
-			}
-			after := map[string]any{"resolution_state": "resolved", "resolved_org_id": chosen.OrgID, "matched_on": chosen.MatchedOn}
-			if personID != nil {
-				after["resolved_person_id"] = *personID
-			}
-			auditID, err = storekit.Audit(ctx, tx, "resolve", "signal", signalID, before, after)
-			if err != nil {
-				return fmt.Errorf("audit signal resolve: %w", err)
-			}
-		default:
-			// Ambiguity is surfaced, not asserted: several plausible orgs
-			// flag the signal for review; resolved_org_id stays NULL.
-			top := candidates[0]
-			detail, err := candidateDetail(candidates, nil)
-			if err != nil {
-				return err
-			}
-			if err := appendMatchBasis(ctx, tx, actor, signalID, top.MatchedOn, nil, &top.Confidence, detail); err != nil {
-				return err
-			}
-			if _, err := tx.Exec(ctx,
-				`UPDATE signal SET resolution_state = 'low_confidence', resolution_confidence = $2 WHERE id = $1`,
-				signalID, top.Confidence); err != nil {
-				return fmt.Errorf("flag ambiguous signal: %w", err)
-			}
-			auditID, err = storekit.Audit(ctx, tx, "resolve", "signal", signalID, before,
-				map[string]any{"resolution_state": "low_confidence", "candidates": len(candidates)})
-			if err != nil {
-				return fmt.Errorf("audit signal ambiguity: %w", err)
-			}
-		}
-
-		if out, err = readSignal(ctx, tx, signalID, storekit.LiveOnly); err != nil {
-			return fmt.Errorf("read resolved signal: %w", err)
-		}
-		if err := storekit.Emit(ctx, tx, auditID, "signal.resolved", "signal", signalID, resolvedPayload(out, candidates)); err != nil {
-			return fmt.Errorf("emit signal.resolved: %w", err)
-		}
-		return nil
+		var err error
+		out, err = s.resolveTx(ctx, tx, actor, signalID)
+		return err
 	})
 	return out, err
+}
+
+// resolveTx runs the resolver over one signal inside the caller's
+// transaction: the visibility gate, the terminal-state guard, candidate
+// matching narrowed to visible orgs, the state stamp, and the write shape.
+func (s *Store) resolveTx(ctx context.Context, tx pgx.Tx, actor principal.Principal, signalID ids.UUID) (crmcontracts.Signal, error) {
+	if err := auth.EnsureSignalVisible(ctx, tx, signalID); err != nil {
+		return crmcontracts.Signal{}, err
+	}
+	sig, err := readSignal(ctx, tx, signalID, storekit.LiveOnly)
+	if err != nil {
+		return crmcontracts.Signal{}, err
+	}
+	switch sig.ResolutionState {
+	case "unresolved", "low_confidence":
+	default:
+		return crmcontracts.Signal{}, &NotResolvableError{Reason: fmt.Sprintf("signal is already %s; resolution is terminal", sig.ResolutionState)}
+	}
+	if sig.RawRef == nil || strings.TrimSpace(*sig.RawRef) == "" {
+		return crmcontracts.Signal{}, &RequiredFieldError{Field: "raw_ref"}
+	}
+
+	attribution := parseRawRef(*sig.RawRef)
+	candidates, err := matchCandidates(ctx, tx, attribution)
+	if err != nil {
+		return crmcontracts.Signal{}, err
+	}
+	// Row-scope the attribution: a resolver may only attribute a signal
+	// to an organization the caller can see. Stamping resolved_org_id
+	// (a read of that org) for an org outside the caller's scope would
+	// leak its existence and id, so an invisible match is dropped —
+	// leaving the signal unattributable rather than disclosing it.
+	if candidates, err = visibleCandidates(ctx, tx, candidates); err != nil {
+		return crmcontracts.Signal{}, err
+	}
+
+	before := map[string]any{"resolution_state": sig.ResolutionState}
+	after, err := stampResolution(ctx, tx, actor, signalID, attribution.Email, candidates)
+	if err != nil {
+		return crmcontracts.Signal{}, err
+	}
+	auditID, err := storekit.Audit(ctx, tx, "resolve", "signal", signalID, before, after)
+	if err != nil {
+		return crmcontracts.Signal{}, fmt.Errorf("audit signal resolution: %w", err)
+	}
+	out, err := readSignal(ctx, tx, signalID, storekit.LiveOnly)
+	if err != nil {
+		return crmcontracts.Signal{}, fmt.Errorf("read resolved signal: %w", err)
+	}
+	if err := storekit.Emit(ctx, tx, auditID, "signal.resolved", "signal", signalID, resolvedPayload(out, candidates)); err != nil {
+		return crmcontracts.Signal{}, fmt.Errorf("emit signal.resolved: %w", err)
+	}
+	return out, nil
+}
+
+// stampResolution applies the resolver's verdict for this candidate set and
+// returns the audit after-image. The count IS the verdict (P12): zero
+// candidates drop the signal and link no person; exactly one resolves it to
+// that org under the consent-gated person link; several surface it as
+// low_confidence for review — resolved_org_id stays NULL unless exactly one
+// org matched, and no branch ever creates a person.
+func stampResolution(ctx context.Context, tx pgx.Tx, actor principal.Principal, signalID ids.UUID, email string, candidates []candidate) (map[string]any, error) {
+	switch len(candidates) {
+	case 0:
+		return dropUnattributable(ctx, tx, actor, signalID)
+	case 1:
+		return resolveToOrg(ctx, tx, actor, signalID, email, candidates)
+	default:
+		return flagAmbiguous(ctx, tx, actor, signalID, candidates)
+	}
+}
+
+// dropUnattributable is the drop-the-orphan guard (B-E08.1): an
+// unattributable signal is dropped with the "why" on record, and NO person
+// link. Returns the audit after-image.
+func dropUnattributable(ctx context.Context, tx pgx.Tx, actor principal.Principal, signalID ids.UUID) (map[string]any, error) {
+	if err := appendMatchBasis(ctx, tx, actor, signalID, "none", nil, nil,
+		`{"candidates": [], "reason": "no organization matched the raw_ref"}`); err != nil {
+		return nil, err
+	}
+	if _, err := tx.Exec(ctx,
+		`UPDATE signal SET resolution_state = 'dropped', resolution_confidence = NULL WHERE id = $1`,
+		signalID); err != nil {
+		return nil, fmt.Errorf("drop unattributable signal: %w", err)
+	}
+	return map[string]any{"resolution_state": "dropped"}, nil
+}
+
+// resolveToOrg stamps the single-candidate match: the consent-gated person
+// link (only an EXISTING person, only where the org match holds, only under
+// a recorded grant — never a person creation), the inspectable match basis,
+// and the resolved signal row. Returns the audit after-image.
+func resolveToOrg(ctx context.Context, tx pgx.Tx, actor principal.Principal, signalID ids.UUID, email string, candidates []candidate) (map[string]any, error) {
+	chosen := candidates[0]
+	personID, err := consentedPerson(ctx, tx, email, chosen.OrgID)
+	if err != nil {
+		return nil, err
+	}
+	detail, err := candidateDetail(candidates, &chosen)
+	if err != nil {
+		return nil, err
+	}
+	if err := appendMatchBasis(ctx, tx, actor, signalID, chosen.MatchedOn, &chosen.OrgID, &chosen.Confidence, detail); err != nil {
+		return nil, err
+	}
+	if _, err := tx.Exec(ctx,
+		`UPDATE signal SET resolution_state = 'resolved', resolution_confidence = $2,
+		        resolved_org_id = $3, resolved_person_id = $4,
+		        entity_type = COALESCE(entity_type, 'organization'),
+		        entity_id = COALESCE(entity_id, $3)
+		 WHERE id = $1`,
+		signalID, chosen.Confidence, chosen.OrgID, personID); err != nil {
+		return nil, fmt.Errorf("stamp resolved signal: %w", err)
+	}
+	after := map[string]any{"resolution_state": "resolved", "resolved_org_id": chosen.OrgID, "matched_on": chosen.MatchedOn}
+	if personID != nil {
+		after["resolved_person_id"] = *personID
+	}
+	return after, nil
+}
+
+// flagAmbiguous surfaces ambiguity rather than asserting it: several
+// plausible orgs flag the signal for review, resolved_org_id stays NULL,
+// and no person is linked. Returns the audit after-image.
+func flagAmbiguous(ctx context.Context, tx pgx.Tx, actor principal.Principal, signalID ids.UUID, candidates []candidate) (map[string]any, error) {
+	top := candidates[0]
+	detail, err := candidateDetail(candidates, nil)
+	if err != nil {
+		return nil, err
+	}
+	if err := appendMatchBasis(ctx, tx, actor, signalID, top.MatchedOn, nil, &top.Confidence, detail); err != nil {
+		return nil, err
+	}
+	if _, err := tx.Exec(ctx,
+		`UPDATE signal SET resolution_state = 'low_confidence', resolution_confidence = $2 WHERE id = $1`,
+		signalID, top.Confidence); err != nil {
+		return nil, fmt.Errorf("flag ambiguous signal: %w", err)
+	}
+	return map[string]any{"resolution_state": "low_confidence", "candidates": len(candidates)}, nil
 }
 
 // matchCandidates gathers the distinct plausible organizations, best


### PR DESCRIPTION
## What
Complexity tranche 4 — 8 more production functions to ≤15, including the worst offender (`signals.Resolve`, was 60).

| Function | was | Extracted (all ≤7 params) |
|---|---|---|
| signals `Resolve` | 60 | `resolveTx` + `stampResolution`/`dropUnattributable`/`resolveToOrg`/`flagAmbiguous` |
| approvals `decide` | 29 | `decideInTx` |
| people `UpdateLead` | 27 | `updateLeadTx`, `leadUniqueViolation` (also applied to `CreateLead`) |
| deals `CreateOffer` | 27 | `createOfferTx`, `resolveBuyerOrg`, `insertOfferLines` |
| search `relatedViaLinks` | 26 | `hopNeighbors`, `graphHop`/`relatedHops` |
| people `ListPartners` | 26 | `listPartnersTx`, `partnerListWhere` |
| people `MergePerson` | 26 | `mergePersonTx`, `buildSurvivorshipPatch` |
| people `ApplyColdStartProfile` | 27 | `applyColdStartTx`, `resolveOrCreateColdStartOrg` |

Common move: lift the tx-closure body into a level-0 helper (the closure's nesting penalty was the main complexity driver).

## Safety
Behavior-preserving. `Audit`+`Emit` kept co-located; no `auth.*` gate, tx boundary, SQL, bind-order, validation, or error sentinel altered; no helper >7 params (no new `go:S107`).

**`signals.Resolve` trust boundary verified intact:** `consentedPerson` still gated to the single-candidate org path only, `EnsureLinkTarget` visibility probes preserved, no `INSERT INTO person` (no-person-creation invariant holds), row-scope applied before dispatch.

## How verified
`make check`, targeted package tests, `go vet -tags integration ./...` all green; diff-scoped `craft static` 0 blockers.

## AI involvement
Extraction by a Claude Code subagent under ≤15 + ≤7-params + behavior-preservation guardrails; the security-sensitive signals refactor was spot-verified by the main agent.