### PR TITLE
feat(frontend): Home rides the real /brief spine; onboarding label + honesty polish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,16 +166,19 @@ jobs:
       # The quality gate requires coverage on new code, so the scan must be
       # handed real coverage reports — both lanes run their unit tests here
       # with coverage enabled (paths declared in sonar-project.properties).
-      - uses: actions/setup-go@v5
+      # Setup actions SHA-pinned (githubactions:S7637 / supply-chain), same
+      # versions the other jobs use by tag: setup-go v5, action-setup v4,
+      # setup-node v4.
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         if: ${{ env.SONAR_TOKEN != '' }}
         with:
           go-version-file: backend/go.mod
           cache-dependency-path: backend/go.sum
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1
         if: ${{ env.SONAR_TOKEN != '' }}
         with:
           version: 11
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         if: ${{ env.SONAR_TOKEN != '' }}
         with:
           node-version: 22
@@ -188,8 +191,11 @@ jobs:
       - name: Frontend unit coverage
         if: ${{ env.SONAR_TOKEN != '' }}
         working-directory: frontend
+        # --ignore-scripts (githubactions:S6505): no lifecycle scripts run at
+        # install; esbuild ships prebuilt platform binaries as optional deps,
+        # so vitest works without its validating postinstall.
         run: |
-          pnpm install --frozen-lockfile
+          pnpm install --frozen-lockfile --ignore-scripts
           pnpm exec vitest run --coverage.enabled --coverage.provider=v8 --coverage.reporter=lcov
       - name: SonarCloud scan
         if: ${{ env.SONAR_TOKEN != '' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,34 @@ jobs:
         with:
           # Full history so SonarCloud can attribute blame / compute new code.
           fetch-depth: 0
+      # The quality gate requires coverage on new code, so the scan must be
+      # handed real coverage reports — both lanes run their unit tests here
+      # with coverage enabled (paths declared in sonar-project.properties).
+      - uses: actions/setup-go@v5
+        if: ${{ env.SONAR_TOKEN != '' }}
+        with:
+          go-version-file: backend/go.mod
+          cache-dependency-path: backend/go.sum
+      - uses: pnpm/action-setup@v4
+        if: ${{ env.SONAR_TOKEN != '' }}
+        with:
+          version: 11
+      - uses: actions/setup-node@v4
+        if: ${{ env.SONAR_TOKEN != '' }}
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: frontend/pnpm-lock.yaml
+      - name: Go unit coverage
+        if: ${{ env.SONAR_TOKEN != '' }}
+        working-directory: backend
+        run: go test ./... -coverprofile=coverage.out -covermode=atomic
+      - name: Frontend unit coverage
+        if: ${{ env.SONAR_TOKEN != '' }}
+        working-directory: frontend
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm exec vitest run --coverage.enabled --coverage.provider=v8 --coverage.reporter=lcov
       - name: SonarCloud scan
         if: ${{ env.SONAR_TOKEN != '' }}
         # Pinned to a full commit SHA (githubactions:S7637 / supply-chain): v5.

--- a/STATUS.md
+++ b/STATUS.md
@@ -5,7 +5,47 @@
 > [AGENTS.md](AGENTS.md) for the binding rules. Update this file at the
 > end of every working session.
 
-## ▶ RESTART HERE (2026-07-06 evening — product-completeness loop)
+## ▶ RESTART HERE (2026-07-07 — product loop paused; a 5-PR stack awaits merge)
+
+Session ended deliberately mid-pipeline. **Five gate-green-except-Sonar PRs
+are stacked and ready** (each verified live in a browser against the real
+backend, all unit+e2e lanes green):
+
+- **#14** `feat/home-morning-brief` — Home rides the real /brief spine
+  (ranked queue, §10.1 factor bars, act/dismiss); onboarding human field
+  labels + step-4 honesty; **plus the whole Sonar-gate enablement** (see
+  below). ← the stack base; merge this first.
+- **#15** `feat/record-create-flows` — create flows for contact / company /
+  lead / deal (shared CreateAction), styled .input/.field atoms.
+- **#17** `feat/360-enrich-strength` — company-360 enrichment card driving
+  POST /organizations/{id}/enrich (EP05 scrape verb surfaced).
+- **#18** `feat/log-activity` — log a note/task from the three 360s.
+- **#19** `feat/tasks-remind` — task create + remind_at set/clear (B-E16.1
+  surface). #18/#19 were built by parallel worktree agents; both branch off
+  #17's pre-rebase head — REBASE them once #17 merges (i18n adjacency
+  conflicts are likely between the two; both add keys at the same anchors).
+
+**The SonarCloud saga (all fixed, last scan still running at close):** the
+required "SonarCloud Code Analysis" check blocked ALL merges. Chain of
+causes, each fixed on #14: SONAR_TOKEN secret invalid (owner regenerated) →
+sonar.organization was `gradionhq`, real org key is **`gradion`** → quality
+gate failed on new_coverage=0% (scan job now runs go test -coverprofile +
+vitest lcov; properties declare report paths, test.inclusions, generated
+schema.d.ts excluded) → two new-code security findings (setup actions now
+SHA-pinned, pnpm install --ignore-scripts) → remaining duplication was
+en.ts↔de.ts cross-matching (parallel catalogs BY DESIGN; fixed via
+sonar.cpd.exclusions for exactly those two files). **Pickup: check the
+scans on #14/#15/#17 — if green, merge #14 → retarget #15 to main → merge →
+retarget #17 → merge → rebase #18/#19 → merge.** If duplication persists,
+read the per-file blocks via api/duplications/show (the technique that
+found the i18n cause).
+
+Memory `margince-sonarcloud-ci-state` records the whole gate chain for
+future sessions. The dev stack was STOPPED at session close (`make
+dev-tls` to relaunch). Note the api binary must be restarted after backend
+merges or the SPA hits missing routes.
+
+## Prior restart point (2026-07-06 evening — product-completeness loop)
 
 A product-facing loop session (goal: executable, testable product; onboarding
 + first screens beautiful and fully working; PR-per-slice through the CI +

--- a/STATUS.md
+++ b/STATUS.md
@@ -5,7 +5,34 @@
 > [AGENTS.md](AGENTS.md) for the binding rules. Update this file at the
 > end of every working session.
 
-## ▶ RESTART HERE (2026-07-06 PM — batch-5 CLEARED)
+## ▶ RESTART HERE (2026-07-06 evening — product-completeness loop)
+
+A product-facing loop session (goal: executable, testable product; onboarding
++ first screens beautiful and fully working; PR-per-slice through the CI +
+CodeRabbit + Sonar gates). Slice 1 = **PR #14** `feat/home-morning-brief`:
+
+- **Home now rides the real `/brief` spine** (B-EP09.12b×E05): no-run 404 →
+  honest generate card, POST refresh, ranked items with the §10.1 factor
+  bars, evidence counts, B-E05.13 act/dismiss updating in place, honest-short
+  footer; approvals stay on top, stalled deals close the page. New
+  `home.css` + `home.test.tsx`; e2e seed gained a coherent /brief run.
+- **Onboarding**: cold-start fields render human DE/EN labels (was raw
+  `LEGAL_NAME` keys); step 4 is honest about a skipped voice step and tags
+  the canned sample draft as an illustrative example.
+- `frontend/src/api/schema.d.ts` regenerated (picks up /brief, offers,
+  signals, views…).
+- Verified live in a browser end to end: signup → real-model cold-start of a
+  real site → funnel → generate brief over real deals → act/dismiss.
+  frontend-check green (94 unit), e2e 35/35.
+
+Browser-audit gaps still open (next slices): contacts/companies/leads lists
+are thin but work; deal 360 exists; offers/products, signals warm-room,
+smart lists/saved views, preference center have NO frontend surface yet —
+those are the highest-value next product slices. The dev stack must be
+restarted after backend merges (`make dev-tls`) or the SPA hits routes the
+running api doesn't have.
+
+## Prior restart point (2026-07-06 PM — batch-5 CLEARED)
 
 Clean stopping point. `origin/main` builds and carries no half-finished
 code. Migrations at **0049** (saved_view). Everything below is durable

--- a/frontend/e2e/ac.spec.ts
+++ b/frontend/e2e/ac.spec.ts
@@ -150,14 +150,11 @@ test("AC-automations-1 (B-EP09.15): create from the catalog arrives paused; enab
 }) => {
   await page.goto("/#/automations");
   await expect(page.getByText("Stillstands-Erinnerung")).toBeVisible();
-  await page
-    .getByRole("button", { name: "Vorlage verwenden" })
-    .first()
-    .click();
+  await page.getByRole("button", { name: "Vorlage verwenden" }).first().click();
   // the schema default arrives in the one parameter field
-  await expect(page.getByRole("spinbutton", { name: "due_in_days" })).toHaveValue(
-    "3",
-  );
+  await expect(
+    page.getByRole("spinbutton", { name: "due_in_days" }),
+  ).toHaveValue("3");
   await page.getByRole("button", { name: "Anlegen" }).click();
   await expect(
     page.getByText("Pausiert angelegt — es läuft nichts, bis du aktivierst."),
@@ -173,10 +170,7 @@ test("AC-automations-2 (features/10 §1): anti-DSL — no free-form rule body, n
 }) => {
   await page.goto("/#/automations");
   await expect(page.getByText("Stillstands-Erinnerung")).toBeVisible();
-  await page
-    .getByRole("button", { name: "Vorlage verwenden" })
-    .first()
-    .click();
+  await page.getByRole("button", { name: "Vorlage verwenden" }).first().click();
   await expect(page.locator("textarea")).toHaveCount(0);
   // exactly the instance name plus the schema-derived parameter
   await expect(page.getByRole("textbox")).toHaveCount(1);
@@ -253,7 +247,9 @@ test("AC-book-public-409: a taken slot degrades honestly — no fabricated confi
   await page.getByRole("checkbox").check();
   await page.getByRole("button", { name: /12:00/ }).click();
   await expect(
-    page.getByText("Die Buchung ging nicht durch — es wurde nichts eingetragen."),
+    page.getByText(
+      "Die Buchung ging nicht durch — es wurde nichts eingetragen.",
+    ),
   ).toBeVisible();
   await expect(page.getByText("slot no longer available")).toBeVisible();
   await expect(

--- a/frontend/e2e/seed.ts
+++ b/frontend/e2e/seed.ts
@@ -117,6 +117,51 @@ export const deals = [
   },
 ];
 
+// One persisted Morning-Brief run over the two seeded deals — the §10.1
+// composite with its factor decomposition, so the home queue's arithmetic
+// reads coherently against the deal amounts above.
+export const briefRun = {
+  id: "br-1",
+  generated_at: "2026-07-05T05:30:00Z",
+  as_of: "2026-07-05T05:00:00Z",
+  candidate_count: 2,
+  revenue_norm_minor: 4_800_000,
+  items: [
+    {
+      id: "bi-1",
+      deal_id: "d-fleet",
+      rank: 1,
+      composite: 0.74,
+      feature_vector: {
+        winnability: 0.4,
+        revenue: 1,
+        timing: 0.75,
+        momentum: 1,
+        warmth: 0.47,
+      },
+      evidence_ids: ["ev-1", "ev-2"],
+      state: "new",
+      state_at: null,
+    },
+    {
+      id: "bi-2",
+      deal_id: "d-service",
+      rank: 2,
+      composite: 0.41,
+      feature_vector: {
+        winnability: 0.2,
+        revenue: 0.26,
+        timing: 0.5,
+        momentum: 0,
+        warmth: 0.3,
+      },
+      evidence_ids: ["ev-3"],
+      state: "new",
+      state_at: null,
+    },
+  ],
+};
+
 export const approval = {
   id: "ap-1",
   workspace_id: "w",
@@ -263,6 +308,11 @@ export async function mockApi(target: Page): Promise<void> {
 
   // per-page automation state so the create→paused→enable flow is coherent
   let automations = [{ ...seededAutomation }];
+  // per-page brief state so act/dismiss marks stick within a test
+  const brief = {
+    ...briefRun,
+    items: briefRun.items.map((item) => ({ ...item })),
+  };
 
   await target.route(/\/v1\//, async (route) => {
     const url = new URL(route.request().url());
@@ -322,6 +372,22 @@ export async function mockApi(target: Page): Promise<void> {
     }
     if (path.startsWith("/deals/")) {
       return json(deals.find((deal) => path.endsWith(deal.id)) ?? deals[0]);
+    }
+    if (path === "/brief" && method === "GET") {
+      return json(brief);
+    }
+    if (path === "/brief" && method === "POST") {
+      return json(brief, 201);
+    }
+    const briefMark = /^\/brief\/items\/([^/]+)\/(act|dismiss)$/.exec(path);
+    if (briefMark && method === "POST") {
+      const item = brief.items.find((entry) => entry.id === briefMark[1]);
+      if (!item) {
+        return json({ title: "Not Found" }, 404);
+      }
+      item.state = briefMark[2] === "act" ? "acted" : "dismissed";
+      item.state_at = "2026-07-05T06:00:00Z";
+      return json(item);
     }
     if (path === "/approvals") {
       return json(page([approval]));

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,6 +32,7 @@
     "@types/react": "^19.1.0",
     "@types/react-dom": "^19.1.0",
     "@vitejs/plugin-react": "^4.5.0",
+    "@vitest/coverage-v8": "^3.2.6",
     "jsdom": "^29.1.1",
     "openapi-typescript": "^7.13.0",
     "tailwindcss": "^4.1.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.5.0
         version: 4.7.0(supports-color@10.2.2)(vite@6.4.3(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.32.0))
+      '@vitest/coverage-v8':
+        specifier: ^3.2.6
+        version: 3.2.6(vitest@3.2.6(@types/node@26.1.0)(jiti@2.7.0)(jsdom@29.1.1)(lightningcss@1.32.0)(supports-color@10.2.2))
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1
@@ -80,6 +83,10 @@ packages:
 
   '@adobe/css-tools@4.5.0':
     resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
+
+  '@ampproject/remapping@2.3.0':
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
 
   '@asamuzakjp/css-color@5.1.11':
     resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
@@ -187,6 +194,10 @@ packages:
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@biomejs/biome@2.5.2':
     resolution: {integrity: sha512-VQ3RCqr7JmDIX+w6stWYl+g/3bYofN3q2wDBHUKKc/c7i5QWrFKFBZYCYPWTE6agsUPMIZZe6/CMmVUfUAhkKA==}
@@ -450,6 +461,14 @@ packages:
       '@noble/hashes':
         optional: true
 
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
+  '@istanbuljs/schema@0.1.6':
+    resolution: {integrity: sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==}
+    engines: {node: '>=8'}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -465,6 +484,10 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
 
   '@playwright/test@1.61.1':
     resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
@@ -794,6 +817,15 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
+  '@vitest/coverage-v8@3.2.6':
+    resolution: {integrity: sha512-LsAdmUapA0qSN306d8+zOyawM0hFm2m2Hg9IwVNIKBm+qJV8cijiq2c+gxKZcB1HCfIWAy+0qEZDCUQA58A1cw==}
+    peerDependencies:
+      '@vitest/browser': 3.2.6
+      vitest: 3.2.6
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@3.2.6':
     resolution: {integrity: sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==}
 
@@ -835,9 +867,21 @@ packages:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
   ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -853,12 +897,19 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  ast-v8-to-istanbul@0.3.12:
+    resolution: {integrity: sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==}
+
   axe-core@4.12.1:
     resolution: {integrity: sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==}
     engines: {node: '>=4'}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
 
   baseline-browser-mapping@2.10.41:
     resolution: {integrity: sha512-WwS7MHhqGHHlaVsqRZnhvCEMS0owDX+SxRlve7JkuH7My1Ara3ZriTmCQupPfYjxMZ8I/tgxtJYr2t7taHaH4A==}
@@ -870,6 +921,10 @@ packages:
 
   brace-expansion@2.1.1:
     resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
+
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
+    engines: {node: 18 || 20 || >=22}
 
   browserslist@4.28.4:
     resolution: {integrity: sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==}
@@ -894,11 +949,22 @@ packages:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
 
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
   colorette@1.4.0:
     resolution: {integrity: sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
 
   css-tree@3.2.1:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
@@ -944,8 +1010,17 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
   electron-to-chromium@1.5.386:
     resolution: {integrity: sha512-f9yJE+9dJy+B4QC1iTu+mVP/KWLZviG5u/qtRwdBF0zPt3etWa1HSY1lMuWw0Nt8/KpLCY6ok+XlKHOs6ZhxSA==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   enhanced-resolve@5.21.6:
     resolution: {integrity: sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==}
@@ -986,6 +1061,10 @@ packages:
       picomatch:
         optional: true
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1000,12 +1079,24 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
 
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
@@ -1019,8 +1110,34 @@ packages:
     resolution: {integrity: sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==}
     engines: {node: '>=18'}
 
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
@@ -1029,6 +1146,9 @@ packages:
   js-levenshtein@1.1.6:
     resolution: {integrity: sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==}
     engines: {node: '>=0.10.0'}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -1139,6 +1259,9 @@ packages:
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
   lru-cache@11.5.1:
     resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
     engines: {node: 20 || >=22}
@@ -1158,6 +1281,13 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  magicast@0.3.5:
+    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
+
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
@@ -1165,9 +1295,21 @@ packages:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
 
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
   minimatch@5.1.9:
     resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
     engines: {node: '>=10'}
+
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -1193,12 +1335,23 @@ packages:
     peerDependencies:
       typescript: ^5.x
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
   parse-json@8.3.0:
     resolution: {integrity: sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==}
     engines: {node: '>=18'}
 
   parse5@8.0.1:
     resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -1280,8 +1433,25 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -1292,6 +1462,22 @@ packages:
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
 
   strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
@@ -1304,6 +1490,10 @@ packages:
     resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
     engines: {node: '>=18'}
 
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
@@ -1313,6 +1503,10 @@ packages:
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
+
+  test-exclude@7.0.2:
+    resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
+    engines: {node: '>=18'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -1465,10 +1659,23 @@ packages:
     resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
 
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
@@ -1490,6 +1697,11 @@ packages:
 snapshots:
 
   '@adobe/css-tools@4.5.0': {}
+
+  '@ampproject/remapping@2.3.0':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
 
   '@asamuzakjp/css-color@5.1.11':
     dependencies:
@@ -1629,6 +1841,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@biomejs/biome@2.5.2':
     optionalDependencies:
@@ -1773,6 +1987,17 @@ snapshots:
 
   '@exodus/bytes@1.15.1': {}
 
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.2.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@istanbuljs/schema@0.1.6': {}
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -1791,6 +2016,9 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
 
   '@playwright/test@1.61.1':
     dependencies:
@@ -2061,6 +2289,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/coverage-v8@3.2.6(vitest@3.2.6(@types/node@26.1.0)(jiti@2.7.0)(jsdom@29.1.1)(lightningcss@1.32.0)(supports-color@10.2.2))':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 1.0.2
+      ast-v8-to-istanbul: 0.3.12
+      debug: 4.4.3(supports-color@10.2.2)
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      magic-string: 0.30.21
+      magicast: 0.3.5
+      std-env: 3.10.0
+      test-exclude: 7.0.2
+      tinyrainbow: 2.0.0
+      vitest: 3.2.6(@types/node@26.1.0)(jiti@2.7.0)(jsdom@29.1.1)(lightningcss@1.32.0)(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitest/expect@3.2.6':
     dependencies:
       '@types/chai': 5.2.3
@@ -2109,7 +2356,15 @@ snapshots:
 
   ansi-regex@5.0.1: {}
 
+  ansi-regex@6.2.2: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
   ansi-styles@5.2.0: {}
+
+  ansi-styles@6.2.3: {}
 
   argparse@2.0.1: {}
 
@@ -2121,9 +2376,17 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  ast-v8-to-istanbul@0.3.12:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
+
   axe-core@4.12.1: {}
 
   balanced-match@1.0.2: {}
+
+  balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.10.41: {}
 
@@ -2134,6 +2397,10 @@ snapshots:
   brace-expansion@2.1.1:
     dependencies:
       balanced-match: 1.0.2
+
+  brace-expansion@5.0.7:
+    dependencies:
+      balanced-match: 4.0.4
 
   browserslist@4.28.4:
     dependencies:
@@ -2159,9 +2426,21 @@ snapshots:
 
   check-error@2.1.3: {}
 
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
   colorette@1.4.0: {}
 
   convert-source-map@2.0.0: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
 
   css-tree@3.2.1:
     dependencies:
@@ -2197,7 +2476,13 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
+  eastasianwidth@0.2.0: {}
+
   electron-to-chromium@1.5.386: {}
+
+  emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
 
   enhanced-resolve@5.21.6:
     dependencies:
@@ -2251,6 +2536,11 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.5
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   fsevents@2.3.2:
     optional: true
 
@@ -2259,13 +2549,26 @@ snapshots:
 
   gensync@1.0.0-beta.2: {}
 
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.9
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
   graceful-fs@4.2.11: {}
+
+  has-flag@4.0.0: {}
 
   html-encoding-sniffer@6.0.0:
     dependencies:
       '@exodus/bytes': 1.15.1
     transitivePeerDependencies:
       - '@noble/hashes'
+
+  html-escaper@2.0.2: {}
 
   https-proxy-agent@7.0.6(supports-color@10.2.2):
     dependencies:
@@ -2278,11 +2581,44 @@ snapshots:
 
   index-to-position@1.2.0: {}
 
+  is-fullwidth-code-point@3.0.0: {}
+
   is-potential-custom-element-name@1.0.1: {}
+
+  isexe@2.0.0: {}
+
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-lib-source-maps@5.0.6:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      debug: 4.4.3(supports-color@10.2.2)
+      istanbul-lib-coverage: 3.2.2
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
 
   jiti@2.7.0: {}
 
   js-levenshtein@1.1.6: {}
+
+  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -2375,6 +2711,8 @@ snapshots:
 
   loupe@3.2.1: {}
 
+  lru-cache@10.4.3: {}
+
   lru-cache@11.5.1: {}
 
   lru-cache@5.1.1:
@@ -2391,13 +2729,33 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  magicast@0.3.5:
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.8.5
+
   mdn-data@2.27.1: {}
 
   min-indent@1.0.1: {}
 
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.7
+
   minimatch@5.1.9:
     dependencies:
       brace-expansion: 2.1.1
+
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.1.1
+
+  minipass@7.1.3: {}
 
   ms@2.1.3: {}
 
@@ -2421,6 +2779,8 @@ snapshots:
       typescript: 5.9.3
       yargs-parser: 21.1.1
 
+  package-json-from-dist@1.0.1: {}
+
   parse-json@8.3.0:
     dependencies:
       '@babel/code-frame': 7.29.7
@@ -2430,6 +2790,13 @@ snapshots:
   parse5@8.0.1:
     dependencies:
       entities: 8.0.0
+
+  path-key@3.1.1: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
 
   pathe@2.0.3: {}
 
@@ -2520,13 +2887,43 @@ snapshots:
 
   semver@6.3.1: {}
 
+  semver@7.8.5: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
   siginfo@2.0.0: {}
+
+  signal-exit@4.1.0: {}
 
   source-map-js@1.2.1: {}
 
   stackback@0.0.2: {}
 
   std-env@3.10.0: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
 
   strip-indent@3.0.0:
     dependencies:
@@ -2538,11 +2935,21 @@ snapshots:
 
   supports-color@10.2.2: {}
 
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
   symbol-tree@3.2.4: {}
 
   tailwindcss@4.3.2: {}
 
   tapable@2.3.3: {}
+
+  test-exclude@7.0.2:
+    dependencies:
+      '@istanbuljs/schema': 0.1.6
+      glob: 10.5.0
+      minimatch: 10.2.5
 
   tinybench@2.9.0: {}
 
@@ -2682,10 +3089,26 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.2.0
 
   xml-name-validator@5.0.0: {}
 

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -763,6 +763,67 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/public/preferences/{token}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The recipient's unguessable preference-center token (carried in the List-Unsubscribe URL; not a session credential). */
+                token: string;
+            };
+            cookie?: never;
+        };
+        /**
+         * The recipient's per-purpose consent state (anonymous, token-authed).
+         * @description The no-login preference center behind `preference-center.html` (B-E11.32). The token resolves to
+         *     (workspace, person) before any session exists; the page shows each consent purpose and the
+         *     recipient's current state. A locked purpose (transactional) cannot be withdrawn while a deal is
+         *     live. An unknown or revoked token reads as absent (404) — never a consent-state oracle.
+         */
+        get: operations["getPreferenceCenter"];
+        /**
+         * Save per-purpose choices from the preference center (anonymous, token-authed).
+         * @description Records the recipient's explicit per-purpose choice as a withdrawable `consent_event` (verbatim
+         *     wording + timestamp + a distinct `preference_center` source). Withdrawing one purpose never
+         *     touches another (per-purpose default-deny). A locked purpose (transactional) is refused (422).
+         *     Re-subscribe is an explicit opt-in that writes a fresh grant; a purpose requiring double-opt-in
+         *     cannot be re-granted from this surface without the confirmation round-trip (422).
+         */
+        put: operations["updatePreferences"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/public/preferences/{token}/unsubscribe": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                token: string;
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * RFC 8058 one-click unsubscribe (anonymous, token-authed, POST-only).
+         * @description The endpoint the RFC 8058 `List-Unsubscribe-Post: List-Unsubscribe=One-Click` POST hits: no login,
+         *     no confirmation page, a fixed body. Records an immediate per-purpose withdrawal as a `consent_event`
+         *     (source `preference_center`) which the default-deny suppression gate honors on the very next send
+         *     across every path (manual + agent). Idempotent. Only POST acts — a GET/prefetch by a mail scanner
+         *     never unsubscribes anyone (the reason RFC 8058 mandates POST). With `purpose` only that purpose is
+         *     withdrawn (the one the message was sent under); without it every withdrawable purpose is.
+         */
+        post: operations["oneClickUnsubscribe"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/automations/catalog": {
         parameters: {
             query?: never;
@@ -1005,11 +1066,76 @@ export interface paths {
             };
             cookie?: never;
         };
-        /** List a (static) list's members. */
+        /** List a list's members — explicit rows for a static list, or the live filter evaluation for a dynamic segment. */
         get: operations["listListMembers"];
         put?: never;
         /** Add a member to a static list. */
         post: operations["addListMember"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/views": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List the caller's saved views (per-user; optionally scoped to one resource). */
+        get: operations["listSavedViews"];
+        put?: never;
+        /** Save a per-user view (columns, sort, filter state) for a resource. */
+        post: operations["createSavedView"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/views/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        /** Get one of the caller's saved views by id. */
+        get: operations["getSavedView"];
+        put?: never;
+        post?: never;
+        /** Archive a saved view. */
+        delete: operations["archiveSavedView"];
+        options?: never;
+        head?: never;
+        /** Update a saved view's name or query state. */
+        patch: operations["updateSavedView"];
+        trace?: never;
+    };
+    "/exports": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Export a filtered slice of one object (or a saved view / dynamic list) to an open format.
+         * @description First-class filtered export (features/10 §3): emits exactly the rows that match the active
+         *     filter AND that the caller may see (row-scoped through the same one filter engine that drives
+         *     lists and saved views), rendered to CSV or JSON. Supply exactly one source — an inline `object`
+         *     with a `filter` (the canonical §13.5 predicate), a `view_id`, or a `list_id`. Bulk record read
+         *     that can exfiltrate at scale, so it is **human-only** (an agent principal is rejected) and every
+         *     export writes one `audit_log` entry (who exported what slice, when — P7/P12).
+         */
+        post: operations["createFilteredExport"];
         delete?: never;
         options?: never;
         head?: never;
@@ -1093,6 +1219,39 @@ export interface paths {
          *     Bound by RBAC; an agent caller cannot read beyond the human's scope. Audit-logged.
          */
         post: operations["runReport"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/reports/{report}/derivation": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Report key (prebuilt) or a saved-report id. */
+                report: string;
+            };
+            cookie?: never;
+        };
+        /**
+         * "Explain This Number" — resolve a derivation handle to its definition + source rows.
+         * @description Resolves the drill-through handle minted as `derivation_url` on every `runReport`
+         *     aggregate row (features/03 §1.3, AC-R6). Returns (a) the exact filter+group+aggregate
+         *     definition **in plain language** and (b) the underlying source rows, row-scoped through
+         *     the SAME RBAC clauses the report itself used — an explanation never out-sees the report.
+         *     The drill-through rows reconcile exactly to the explained aggregate (AC-X1).
+         *
+         *     Query vocabulary: `by` names the plan's grouping dimensions and `agg` its aggregates
+         *     (`fn:field:alias` triplets); **every other query parameter is an equality predicate**
+         *     from the report's closed field vocabulary — the group-key values of the explained row
+         *     plus the plan's filters. An empty predicate value matches SQL NULL (the "no owner"
+         *     group). An out-of-vocabulary key returns `422 code: report_field_not_allowed`.
+         */
+        get: operations["explainReport"];
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -1447,6 +1606,543 @@ export interface paths {
          *     matches the `OR EXISTS (record_grant …)` clause). Audited (`action: record_unshare`).
          */
         delete: operations["revokeRecordGrant"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/voice-profiles": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List the voice profiles visible to the caller. */
+        get: operations["listVoiceProfiles"];
+        put?: never;
+        /**
+         * Create a voice profile (status=building, empty derived artifact).
+         * @description A `user`-scope profile is owned by the caller — one live profile per user (409 on a second).
+         *     `personality_md` is the human-authored identity half; the derived `voice_profile_md` is
+         *     written only by the profile builder and arrives empty here.
+         */
+        post: operations["createVoiceProfile"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/voice-profiles/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        /** Read one voice profile (derived artifact + human identity). */
+        get: operations["getVoiceProfile"];
+        put?: never;
+        post?: never;
+        /** Archive a voice profile (soft; its corpus stops being read). */
+        delete: operations["deleteVoiceProfile"];
+        options?: never;
+        head?: never;
+        /**
+         * Edit the human-authored personality_md (never the derived artifact).
+         * @description The PATCH surface deliberately carries ONLY `personality_md`: the derived
+         *     `voice_profile_md` + its `profile_version` are written by the rebuild path alone, so the
+         *     human-authored/machine-derived split (features/09 §B0.2) is enforced by the contract shape.
+         */
+        patch: operations["updateVoiceProfile"];
+        trace?: never;
+    };
+    "/voice-profiles/{id}/sources": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        /** The corpus manifest — every ingested source plus the live word/register meter. */
+        get: operations["listVoiceCorpusSources"];
+        put?: never;
+        /**
+         * Ingest one corpus source (idempotent on source_ref).
+         * @description Accepts the source text (`.txt`/`.md` as-is; `.vtt`/`.srt`/transcript-JSON are parsed and
+         *     SPEAKER-FILTERED to `speaker_label` — only the owner's own turns enter, features/09 §B1.2),
+         *     tags its register (explicit or defaulted by kind), counts the REAL words of the ingested
+         *     text (never an estimate), and upserts by `source_ref` — re-ingesting a source replaces its
+         *     row, it never double-counts the meter. The V1 corpus is text only (features/09 §B1.1):
+         *     binary documents (`.docx`/`.pdf`) are refused with a 422 — convert or paste the text
+         *     instead. Server-side binary extraction is deferred to B-E07.5c.
+         */
+        post: operations["ingestVoiceCorpusSource"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/voice-profiles/{id}/sources/{sourceId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+                sourceId: string;
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Flip a source's manifest opt-out (excluded) or its weight. */
+        patch: operations["updateVoiceCorpusSource"];
+        trace?: never;
+    };
+    "/products": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List rate-card products (live by default; cursor-paginated). */
+        get: operations["listProducts"];
+        put?: never;
+        /**
+         * Create a rate-card product.
+         * @description Price is integer minor-units + ISO-4217 currency (P11, no float money). `sku` is
+         *     optional; when present it is unique per workspace (409 on a live duplicate).
+         */
+        post: operations["createProduct"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/products/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        /** Get a product by id. */
+        get: operations["getProduct"];
+        put?: never;
+        post?: never;
+        /** Archive (soft-delete) a product. Lines referencing it survive with their snapshot. */
+        delete: operations["archiveProduct"];
+        options?: never;
+        head?: never;
+        /** Update a product (partial). Existing offer lines keep their price snapshot. */
+        patch: operations["updateProduct"];
+        trace?: never;
+    };
+    "/deals/{id}/offers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        /** List a deal's offers, newest revision first. */
+        get: operations["listDealOffers"];
+        put?: never;
+        /**
+         * Create a draft offer under a deal (offer_number minted server-side).
+         * @description Line items may ride the create; each snapshots description/price from its optional
+         *     `product_id` unless given explicitly. Totals are DERIVED — a body carrying
+         *     `net_minor`/`gross_minor`/`line_total` (any spelling) is rejected 422.
+         */
+        post: operations["createOffer"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/offers/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        /** Get an offer with its line items and computed totals. */
+        get: operations["getOffer"];
+        put?: never;
+        post?: never;
+        /** Archive (soft-delete) an offer. */
+        delete: operations["archiveOffer"];
+        options?: never;
+        head?: never;
+        /** Update offer header fields — allowed only while status=draft. */
+        patch: operations["updateOffer"];
+        trace?: never;
+    };
+    "/offers/{id}/line-items": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Add a line item to a draft offer (position defaults to next; totals recomputed). */
+        post: operations["addOfferLineItem"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/offers/{id}/line-items/{lineItemId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+                lineItemId: string;
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Remove a line item from a draft offer (totals recomputed). */
+        delete: operations["removeOfferLineItem"];
+        options?: never;
+        head?: never;
+        /** Update a draft offer's line item (totals recomputed; totals themselves are not settable). */
+        patch: operations["updateOfferLineItem"];
+        trace?: never;
+    };
+    "/offers/{id}/send": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Send a draft offer (🟡 — leaves the workspace; freezes FX + buyer/issuer snapshot).
+         * @description draft → sent. Freezes `fx_rate_to_base` as of today (422 `fx_rate_unavailable` when the
+         *     daily rate is missing — never rate=1, RT-PR-C2), captures the buyer/issuer snapshots and
+         *     emits `offer.sent`. Sending leaves the workspace, so an AGENT principal is refused with
+         *     `ErrRequiresApproval` and the call is staged to the approval inbox; the approved retry
+         *     redeems with the X-Approval-Token header (ADR-0036).
+         */
+        post: operations["sendOffer"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/offers/{id}/accept": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Record the buyer's acceptance — syncs the deal's amount from the offer's gross.
+         * @description sent → accepted; sets `accepted_at`, syncs `deal.amount_minor`/`currency` from the
+         *     accepted offer's `gross_minor` (the offer becomes the deal's value source) and emits
+         *     `offer.accepted`. Recording the buyer's acceptance is a human attestation — an agent
+         *     principal is rejected outright.
+         */
+        post: operations["acceptOffer"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/offers/{id}/reject": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Record the buyer's decline (sent → rejected; emits offer.rejected). */
+        post: operations["rejectOffer"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/offers/{id}/regenerate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Mint the next revision as a fresh draft; the sent original becomes superseded.
+         * @description The `draft_offer` verb (🟢 — a reversible internal write): copies the sent offer's
+         *     header + lines into revision N+1 as a new `draft`, marks the prior revision
+         *     `superseded` and emits `offer.superseded` + `offer.created`. A sent offer is never
+         *     mutated in place. The produced draft still cannot leave without the 🟡 send gate.
+         */
+        post: operations["regenerateOffer"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/signals": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List signals (cursor-paginated), newest first. */
+        get: operations["listSignals"];
+        put?: never;
+        /**
+         * Record a signal (a derived observation, or a raw inbound/web item awaiting resolution).
+         * @description A signal about a known record carries its subject (`entity_type`+`entity_id`, both or
+         *     neither) and enters `resolution_state=resolved`; a raw item (only a `raw_ref` source
+         *     pointer) enters `unresolved` until POST /signals/{id}/resolve attributes it to an
+         *     organization or drops it. Signals are COMPANY-LEVEL: there is no mandatory person
+         *     link, and `resolved_person_id` is only ever set by the resolver under recorded
+         *     consent (P12).
+         */
+        post: operations["createSignal"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/signals/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        /** Get a signal by id. */
+        get: operations["getSignal"];
+        put?: never;
+        post?: never;
+        /** Archive (soft-delete) a signal. */
+        delete: operations["archiveSignal"];
+        options?: never;
+        head?: never;
+        /**
+         * Triage a signal (acknowledge / resolve / dismiss, severity).
+         * @description A status change to `acknowledged`/`resolved`/`dismissed` appends the human-outcome
+         *     row to `signal_resolution` (`outcome`+`note`+`resolved_by`) — the same append-only
+         *     log that holds the resolver's match basis, distinguished by which columns are set.
+         */
+        patch: operations["updateSignal"];
+        trace?: never;
+    };
+    "/signals/{id}/resolve": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Run the signal→company resolver over the signal's raw_ref (inspectable match, never silently confident).
+         * @description Maps the raw source pointer to a specific organization via the domain index,
+         *     exact name, or a prior-interaction email match (B-E08.2), writing the append-only
+         *     `signal_resolution` match-basis row and stamping the signal. Exactly one candidate →
+         *     `resolved`; several plausible candidates → `low_confidence` (surfaced, never silently
+         *     asserted); none → `dropped` — an unattributable signal retains NO person-level
+         *     dossier. `resolved_person_id` is set only where the org match holds AND the person
+         *     has a recorded consent grant; the resolver never creates person rows. Read+resolve
+         *     only, no outbound.
+         */
+        post: operations["resolveSignal"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/signals/{id}/warmth": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        /**
+         * The warm/cold classification with the full "why warm" evidence (B-E08.3).
+         * @description A signal resolved to an organization where we hold ≥1 live contact edge
+         *     (employment or deal stakeholder) is WARM and routes to the warm room; a resolved
+         *     organization with no contact is COLD and routes to the cold queue. The answer is
+         *     evidence, not a score: the source signal id, the resolved org id, and the specific
+         *     contact id(s) in our own graph that make it warm, each with its §4 relationship
+         *     strength. Reads only our own relational core — never an external profile.
+         */
+        get: operations["getSignalWarmth"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/signals/{id}/intro-path": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        /**
+         * The proposed warm-intro path for a warm signal (B-E08.4) — an actionable move, not a notification.
+         * @description Names the route-in contact (the strongest live relationship at the resolved
+         *     organization), the relationship we have, and a concrete suggested next move with a
+         *     drafted message carrying the Art. 50 AI-assisted disclosure and evidence back to the
+         *     warm signal. PROPOSAL ONLY: nothing is sent and no record mutates — the outbound
+         *     send rides the 🟡 confirm-first send tool (POST /activities/{id}/send-email); the
+         *     warm room proposes, the rep sends.
+         */
+        get: operations["getSignalIntroPath"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/brief": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** The acting rep's latest Morning-Brief run (the on-open read-model re-read; never re-ranks). */
+        get: operations["getMorningBrief"];
+        put?: never;
+        /**
+         * Generate (refresh) the acting rep's brief now — ranks the candidate set and persists a new run.
+         * @description The on-open / explicit-refresh path (B-E05.3b): ranks the rep's open deals through the
+         *     §10.1 composite + the L2 re-order, and persists one `brief_run` with its ranked
+         *     `brief_item` rows. It reads and stages only — no deal field mutates and nothing is sent.
+         *     This is off the passive home GET; the home route re-reads the persisted run.
+         */
+        post: operations["generateMorningBrief"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/brief/items/{itemId}/act": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description A brief_item id belonging to one of the acting rep's runs. */
+                itemId: string;
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Mark a brief item acted (B-E05.13) — the deal drops from the next run until it materially changes. */
+        post: operations["markBriefItemActed"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/brief/items/{itemId}/dismiss": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description A brief_item id belonging to one of the acting rep's runs. */
+                itemId: string;
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Dismiss a brief item (B-E05.13) — it does not reappear unless a new linked activity arrives after the mark. */
+        post: operations["markBriefItemDismissed"];
+        delete?: never;
         options?: never;
         head?: never;
         patch?: never;
@@ -1932,8 +2628,13 @@ export interface components {
             lost_reason?: string | null;
             /** @enum {string|null} */
             forecast_category?: null | "commit" | "best_case" | "pipeline" | "omitted";
-            /** Format: date */
+            /**
+             * Format: date
+             * @description INV-CLOSE-PAST (formulas §11): an open deal never claims a past close date — saving one is rejected 422 (close_date_past); one that ages into the past is corrected by the nightly run.
+             */
             expected_close_date?: string | null;
+            /** @description True while the close date is a machine-computed replacement awaiting human confirmation (formulas §11 🟡 tier); a provisional deal stays out of Commit/Best-case. Cleared when a human sets the date. */
+            readonly close_date_provisional?: boolean;
             /**
              * Format: date
              * @description 'Customer asked us to wait until' date; suppresses the stalled flag but not the overdue close-date flag.
@@ -1977,7 +2678,10 @@ export interface components {
             organization_id?: string | null;
             /** Format: uuid */
             owner_id?: string | null;
-            /** Format: date */
+            /**
+             * Format: date
+             * @description Deals are born open, so a date before today is rejected 422 (INV-CLOSE-PAST, formulas §11).
+             */
             expected_close_date?: string | null;
             source: string;
         } & {
@@ -2003,7 +2707,10 @@ export interface components {
             fx_rate_date?: string | null;
             /** @enum {string|null} */
             forecast_category?: null | "commit" | "best_case" | "pipeline" | "omitted";
-            /** Format: date */
+            /**
+             * Format: date
+             * @description On an open deal a date before today is rejected 422 (INV-CLOSE-PAST, formulas §11); a human setting it also clears close_date_provisional.
+             */
             expected_close_date?: string | null;
             /** Format: date */
             wait_until?: string | null;
@@ -2153,6 +2860,11 @@ export interface components {
              */
             due_at?: string | null;
             /**
+             * Format: date-time
+             * @description Task only.
+             */
+            remind_at?: string | null;
+            /**
              * Format: uuid
              * @description Task only.
              */
@@ -2205,6 +2917,8 @@ export interface components {
             occurred_at?: string;
             /** Format: date-time */
             due_at?: string | null;
+            /** Format: date-time */
+            remind_at?: string | null;
             /** Format: uuid */
             assignee_id?: string | null;
             duration_seconds?: number | null;
@@ -2232,6 +2946,8 @@ export interface components {
             occurred_at?: string;
             /** Format: date-time */
             due_at?: string | null;
+            /** Format: date-time */
+            remind_at?: string | null;
             /** Format: uuid */
             assignee_id?: string | null;
             /** @description Completing a task writes one audit row + task.completed event. */
@@ -2285,10 +3001,14 @@ export interface components {
              */
             status: "new" | "working" | "promoted" | "disqualified";
             /**
-             * @description Lead-local scoring; never reads the contact graph.
+             * @description Lead-local scoring; never reads the contact graph. While an override is in force this is the human-set value (see score_override_reason).
              * @default 0
              */
             score: number;
+            /** @description Non-null when a human has set score as a Commercial Judgement override (formulas §3.1, A68/ADR-0053). A non-empty reason makes score sticky: the §3 recompute stops touching score and tracks the machine value in score_computed instead. Cleared → recompute resumes. */
+            score_override_reason?: string | null;
+            /** @description Server-derived. The latest machine-computed §3 score, retained ONLY while an override is in force (else null, because score itself is the machine value). */
+            readonly score_computed?: number | null;
             /** Format: uuid */
             owner_id?: string | null;
             source_system?: string | null;
@@ -2348,8 +3068,10 @@ export interface components {
             candidate_org_key?: string | null;
             /** @enum {string} */
             status?: "new" | "working";
-            /** @description Manual human score override (formulas §3.1, AC-S1). Omit to keep the computed lead-local score. */
+            /** @description Human Commercial-Judgement score override (formulas §3.1, AC-S1). Setting it REQUIRES a non-empty score_override_reason in the SAME request — a score with no reason is rejected 422. Establishing an override makes the value sticky (recompute stops overwriting it). Omit to keep the current value. */
             score?: number | null;
+            /** @description The written reason accompanying a score override (mandatory whenever score is set, AC-S1). Two gestures only: a non-empty reason SETS/keeps the override; an explicit empty string CLEARS an in-force override (resumes the §3 recompute so score tracks score_computed again). Omit the field to leave the override untouched. null is not accepted — omit instead. */
+            score_override_reason?: string;
             /** Format: uuid */
             owner_id?: string | null;
         };
@@ -2377,6 +3099,202 @@ export interface components {
         LeadListResponse: {
             data: components["schemas"]["Lead"][];
             page: components["schemas"]["PageInfo"];
+        };
+        /**
+         * @description A surfaced "something changed / worth attention" item. Mirrors the `signal` table:
+         *     company-level and consent-gated by construction — the only mandatory attribution is
+         *     organizational (`resolved_org_id` after resolution); `resolved_person_id` is optional
+         *     and set only under a recorded consent grant (P12). Unattributable signals are
+         *     `dropped`, never retained as a person-level dossier.
+         */
+        Signal: {
+            /** Format: uuid */
+            id: string;
+            /** Format: uuid */
+            workspace_id: string;
+            /** @enum {string} */
+            kind: "stalled_deal" | "champion_left" | "reengagement" | "buying_intent" | "risk" | "other";
+            /**
+             * @description Where the raw signal came from.
+             * @default derived
+             * @enum {string}
+             */
+            source_channel: "derived" | "inbound" | "web" | "social" | "deal_room_engagement";
+            /** @description Pointer to the raw source payload the resolver works from: an email address/handle, a domain, a URL, or a company mention. */
+            raw_ref?: string | null;
+            /**
+             * @description The subject record the signal is about; null until a raw signal resolves (both entity fields set together).
+             * @enum {string|null}
+             */
+            entity_type?: "deal" | "organization" | "person" | null;
+            /** Format: uuid */
+            entity_id?: string | null;
+            /**
+             * @description The raw→entity match outcome: an ambiguous match is `low_confidence` (surfaced, never silently asserted); an unattributable one is `dropped`.
+             * @enum {string}
+             */
+            resolution_state: "resolved" | "low_confidence" | "unresolved" | "dropped";
+            resolution_confidence?: number | null;
+            /**
+             * Format: uuid
+             * @description The organization the raw signal resolved to (the only required attribution level).
+             */
+            resolved_org_id?: string | null;
+            /**
+             * Format: uuid
+             * @description Optional person resolution — set only under a recorded consent grant
+             */
+            resolved_person_id?: string | null;
+            /**
+             * @default info
+             * @enum {string}
+             */
+            severity: "info" | "warn" | "urgent";
+            summary: string;
+            /** @description Per-claim evidence (evidence-or-omit, features/07 §11 gate 1). */
+            evidence: components["schemas"]["SignalEvidence"][];
+            /**
+             * @default open
+             * @enum {string}
+             */
+            status: "open" | "acknowledged" | "resolved" | "dismissed";
+            /** Format: date-time */
+            detected_at: string;
+            source: string;
+            /** @description Server-stamped from the authenticated principal; never client-supplied. */
+            readonly captured_by: string;
+            version?: components["schemas"]["RowVersion"];
+            /** Format: date-time */
+            created_at: string;
+            /** Format: date-time */
+            updated_at: string;
+            /** Format: date-time */
+            archived_at?: string | null;
+        };
+        SignalEvidence: {
+            snippet: string;
+            /** @enum {string|null} */
+            source_type?: "activity" | "deal" | "signal" | "relationship" | "page" | null;
+            source_id?: string | null;
+        };
+        CreateSignalRequest: {
+            /** @enum {string} */
+            kind: "stalled_deal" | "champion_left" | "reengagement" | "buying_intent" | "risk" | "other";
+            /**
+             * @default derived
+             * @enum {string}
+             */
+            source_channel: "derived" | "inbound" | "web" | "social" | "deal_room_engagement";
+            raw_ref?: string | null;
+            /**
+             * @description Subject record, both entity fields together or neither: with a subject the signal enters `resolved`; without one it enters `unresolved` (a raw item needing a raw_ref for POST /signals/{id}/resolve).
+             * @enum {string|null}
+             */
+            entity_type?: "deal" | "organization" | "person" | null;
+            /** Format: uuid */
+            entity_id?: string | null;
+            /**
+             * @default info
+             * @enum {string}
+             */
+            severity: "info" | "warn" | "urgent";
+            summary: string;
+            evidence?: components["schemas"]["SignalEvidence"][];
+            /**
+             * Format: date-time
+             * @description When the underlying observation happened (defaults to now).
+             */
+            detected_at?: string | null;
+            source: string;
+        };
+        /**
+         * @description Triage. A `status` move to acknowledged/resolved/dismissed appends the human-outcome
+         *     `signal_resolution` row; `note` travels with that outcome. `resolution_state` and the
+         *     resolved ids are resolver-owned and not writable here.
+         */
+        UpdateSignalRequest: {
+            /** @enum {string} */
+            status?: "open" | "acknowledged" | "resolved" | "dismissed";
+            /** @description Optional outcome note recorded with a status change. */
+            note?: string | null;
+            /** @enum {string} */
+            severity?: "info" | "warn" | "urgent";
+        };
+        SignalListResponse: {
+            data: components["schemas"]["Signal"][];
+            page: components["schemas"]["PageInfo"];
+        };
+        /** @description One contact edge in our own graph that makes the signal warm — evidence, with its explainable §4 strength. */
+        SignalWarmContact: {
+            /** Format: uuid */
+            person_id: string;
+            full_name?: string | null;
+            /** @enum {string} */
+            relationship_kind: "employment" | "deal_stakeholder";
+            /** @description e.g. cto, champion, economic_buyer. */
+            relationship_role?: string | null;
+            /** @description The deterministic §4 relationship strength (0–100). */
+            strength: number;
+            /** @enum {string} */
+            strength_bucket: "none" | "weak" | "moderate" | "strong";
+        };
+        /**
+         * @description The warm/cold branch with its full evidence: source signal id, resolved org id, and
+         *     the specific contact id(s) that make it warm. No mystery score — a numeric-only
+         *     answer would be a contract violation (features/07 §9).
+         */
+        SignalWarmth: {
+            warm: boolean;
+            /**
+             * @description The real routing branch — warm signals surface in the warm room, cold ones queue separately.
+             * @enum {string}
+             */
+            routing: "warm_room" | "cold_queue";
+            /** Format: uuid */
+            source_signal_id: string;
+            /** Format: uuid */
+            resolved_org_id: string;
+            /** @description Empty exactly when cold. */
+            contact_ids: string[];
+            contacts: components["schemas"]["SignalWarmContact"][];
+        };
+        /**
+         * @description An actionable warm-intro path — names the route-in contact, the relationship we
+         *     have, and a concrete next move with a drafted message. Proposal only: the send is
+         *     the 🟡 confirm-first send tool, never this read.
+         */
+        SignalIntroPath: {
+            /** Format: uuid */
+            signal_id: string;
+            /** Format: uuid */
+            resolved_org_id: string;
+            /**
+             * Format: uuid
+             * @description The route-in contact (the strongest live relationship at the resolved organization).
+             */
+            contact_id: string;
+            contact_name?: string | null;
+            relationship: components["schemas"]["SignalWarmContact"];
+            next_move: {
+                /**
+                 * @description intro_request when the signal resolved (under consent) to a specific person other than the route-in contact; otherwise a direct draft to the contact.
+                 * @enum {string}
+                 */
+                kind: "draft_to_contact" | "intro_request";
+                draft_subject: string;
+                /** @description Renders the Art. 50 AI-assisted disclosure (features/07 §11 gate 9). */
+                draft_body: string;
+                /** @description The machine-readable Art. 50 disclosure line the draft carries. */
+                ai_disclosure: string;
+            };
+            /** @description Provenance back to the warm signal (evidence-or-omit). */
+            evidence: {
+                /** Format: uuid */
+                source_signal_id: string;
+                /** Format: uuid */
+                resolved_org_id: string;
+                contact_ids: string[];
+            };
         };
         /** @description A static membership set or a dynamic segment. Mirrors the `list` table. */
         List: {
@@ -2491,6 +3409,82 @@ export interface components {
         TagListResponse: {
             data: components["schemas"]["Tag"][];
             page: components["schemas"]["PageInfo"];
+        };
+        /** @description A per-user saved view (columns, sort, filter state) over one resource. Mirrors the `saved_view` table. V1 is private (owner-only); shared/team views are a fast-follow. */
+        SavedView: {
+            /** Format: uuid */
+            id: string;
+            /** Format: uuid */
+            workspace_id: string;
+            /** Format: uuid */
+            owner_id: string;
+            /**
+             * @description V1 enforces private.
+             * @default private
+             * @enum {string}
+             */
+            shared_scope: "private" | "team" | "workspace";
+            /** @enum {string} */
+            resource: "people" | "organizations" | "deals" | "activities" | "leads" | "partners";
+            name: string;
+            /** @description The saved column choice, sort, and filter state (§13.5 vocabulary); persisted verbatim and restored exactly. */
+            query: {
+                [key: string]: unknown;
+            };
+            /**
+             * Format: int64
+             * @description Optimistic-concurrency version; echo it in If-Match on update.
+             */
+            version: number;
+            /** Format: date-time */
+            created_at?: string;
+            /** Format: date-time */
+            updated_at?: string;
+            /** Format: date-time */
+            archived_at?: string | null;
+        };
+        CreateSavedViewRequest: {
+            /** @enum {string} */
+            resource: "people" | "organizations" | "deals" | "activities" | "leads" | "partners";
+            name: string;
+            query: {
+                [key: string]: unknown;
+            };
+        };
+        /** @description A partial update; omitted fields keep their stored value. */
+        UpdateSavedViewRequest: {
+            name?: string;
+            query?: {
+                [key: string]: unknown;
+            };
+        };
+        SavedViewListResponse: {
+            data: components["schemas"]["SavedView"][];
+            page: components["schemas"]["PageInfo"];
+        };
+        /** @description A filtered export request. Supply exactly ONE source: an inline `object` (with a required `filter`), a `view_id` (a saved view whose filter state is exported), or a `list_id` (a dynamic list whose definition is exported). The slice is always row-scoped to the caller through the one filter engine. */
+        FilteredExportRequest: {
+            /**
+             * @description The object type to filter-export; requires `filter`. Mutually exclusive with view_id/list_id.
+             * @enum {string}
+             */
+            object?: "person" | "organization" | "deal" | "lead";
+            /** @description The canonical §13.5 predicate tree (nested and/or groups over typed leaves). Required with `object`. */
+            filter?: {
+                [key: string]: unknown;
+            };
+            /**
+             * Format: uuid
+             * @description Export the filter state of one of the caller's saved views. Mutually exclusive with object/list_id.
+             */
+            view_id?: string;
+            /**
+             * Format: uuid
+             * @description Export the definition of a dynamic list. Mutually exclusive with object/view_id.
+             */
+            list_id?: string;
+            /** @enum {string} */
+            format: "csv" | "json";
         };
         /** @description A seat — human or first-party agent. Mirrors `app_user`. */
         User: {
@@ -2672,14 +3666,42 @@ export interface components {
                 [key: string]: unknown;
             };
             columns: string[];
+            /** @description Aggregate rows; each carries its own `derivation_url` handle for the exact cell (group keys bound to the row's values). */
             rows: {
                 [key: string]: unknown;
             }[];
             total_rows?: number;
             /** Format: date-time */
             generated_at?: string;
-            /** @description Handle for "Explain This Number" drill-through to source rows. */
+            /** @description Handle for "Explain This Number" drill-through to source rows (`GET /reports/{report}/derivation`); the result-level handle explains the whole filtered set, each row's handle the single cell. */
             derivation_url?: string | null;
+        };
+        /**
+         * @description The "Explain This Number" resolution (features/03 §1.3): a plain-language definition of
+         *     the exact filter+group+aggregate plus the underlying source rows, which reconcile
+         *     exactly to the explained aggregate (AC-X1).
+         */
+        ReportDerivation: {
+            report: string;
+            /** @description Plain-language reading of the exact filter + group + aggregate that produced the number. */
+            definition: string;
+            /** @description The validated predicate/group/aggregate set that was resolved. */
+            plan: {
+                [key: string]: unknown;
+            };
+            columns: string[];
+            /** @description The underlying source rows (drill-through), row-scoped exactly like the report. */
+            rows: {
+                [key: string]: unknown;
+            }[];
+            /** @description The requested aggregates recomputed over exactly these source rows — equals the explained cell. */
+            aggregates?: {
+                [key: string]: unknown;
+            };
+            /** @description Source rows matched (rows is capped at the report row limit). */
+            total_rows?: number;
+            /** Format: date-time */
+            generated_at?: string;
         };
         SearchResult: {
             /** @enum {string} */
@@ -3131,6 +4153,21 @@ export interface components {
             /** @description Present when the surface delivered its own DOI confirmation (issueDoubleOptIn with deliver=false). */
             double_opt_in_token?: string | null;
         };
+        /**
+         * @description The buyer-facing preference center's per-purpose view (B-E11.32): each tracked consent purpose
+         *     with the recipient's current state and whether it is locked (transactional cannot be withdrawn
+         *     while a deal is live).
+         */
+        PreferenceCenter: {
+            purposes: {
+                key: string;
+                label: string;
+                /** @enum {string} */
+                state: "unknown" | "granted" | "withdrawn";
+                /** @description A locked purpose (transactional) cannot be changed from this surface. */
+                locked: boolean;
+            }[];
+        };
         /** @description An automation *type* in the closed starter library (E15/ADR-0035, feedback/14). */
         AutomationCatalogEntry: {
             /** @description Stable type key, e.g. stalled_deal_nudge. */
@@ -3185,6 +4222,385 @@ export interface components {
             /** @enum {string|null} */
             status?: "enabled" | "paused" | null;
         };
+        /**
+         * @description A user's/team's voice DNA. `voice_profile_md` is machine-DERIVED (versioned by
+         *     `profile_version`, rewritten wholesale on rebuild); `personality_md` is human-AUTHORED
+         *     free text a rebuild never touches.
+         */
+        VoiceProfile: {
+            /** Format: uuid */
+            id: string;
+            /**
+             * Format: uuid
+             * @description null = workspace/team profile.
+             */
+            owner_id?: string | null;
+            /** @enum {string} */
+            scope: "user" | "team" | "workspace";
+            /** @description Derived style descriptor / embedding ref. */
+            model_ref?: string | null;
+            /** @enum {string} */
+            status: "building" | "ready" | "stale";
+            /** @description The derived artifact (Identity · stats · signature moves · patterns · rules · vocabulary · anti-patterns · register notes · few-shot examples). */
+            voice_profile_md: string;
+            /** @description Bumps on every derived rebuild; 0 = never built. */
+            profile_version: number;
+            personality_md: string;
+            version?: number;
+            /** Format: date-time */
+            created_at: string;
+            /** Format: date-time */
+            updated_at?: string | null;
+        };
+        CreateVoiceProfileRequest: {
+            /**
+             * @description Defaults to user (owned by the caller).
+             * @enum {string|null}
+             */
+            scope?: "user" | "team" | "workspace" | null;
+            personality_md?: string | null;
+        };
+        UpdateVoiceProfileRequest: {
+            personality_md: string;
+        };
+        /** @description One corpus manifest row. The ingested text itself is builder-internal and never echoed back. */
+        VoiceCorpusSource: {
+            /** Format: uuid */
+            id: string;
+            /** @enum {string} */
+            kind: "post" | "transcript" | "email" | "chat" | "longform" | "voice_memo";
+            /** @enum {string} */
+            register: "spoken" | "written" | "casual" | "formal";
+            weight: number;
+            source_label: string;
+            /** @description The source natural key ingest is idempotent on. */
+            source_ref: string;
+            word_count: number;
+            excluded: boolean;
+            /** Format: date-time */
+            created_at: string;
+            /** Format: date-time */
+            updated_at?: string | null;
+        };
+        IngestVoiceCorpusSourceRequest: {
+            /** @enum {string} */
+            kind: "post" | "transcript" | "email" | "chat" | "longform" | "voice_memo";
+            /**
+             * @description Defaults by kind: transcript/voice_memo→spoken, chat→casual, post/longform/email→written.
+             * @enum {string|null}
+             */
+            register?: "spoken" | "written" | "casual" | "formal" | null;
+            /** @description 0.1–5.0; defaults to 1.0. */
+            weight?: number | null;
+            source_label: string;
+            /** @description Natural key (message id, upload name…); defaults to a hash of the content. */
+            source_ref?: string | null;
+            /**
+             * @description Defaults to txt. vtt/srt/json are transcript formats and require speaker_label when turns are speaker-labelled.
+             * @enum {string|null}
+             */
+            format?: "txt" | "md" | "vtt" | "srt" | "json" | null;
+            /** @description The owner's label in a transcript; only matching turns are ingested (features/09 §B1.2). */
+            speaker_label?: string | null;
+            /** @description The raw source text in the declared format. */
+            content: string;
+        };
+        /** @description Any subset; omit a field to leave it unchanged. */
+        UpdateVoiceCorpusSourceRequest: {
+            excluded?: boolean | null;
+            weight?: number | null;
+        };
+        /** @description The live word-count + register-mix meter over the non-excluded manifest (features/09 §B1.4). */
+        VoiceCorpusSummary: {
+            total_words: number;
+            /** @description The ~30k corpus target the meter fills toward. */
+            target_words: number;
+            /** @enum {string} */
+            quality_band: "thin" | "good" | "rich" | "sharp";
+            /** @description Word totals per register (spoken/written/casual/formal mix). */
+            register_words: {
+                [key: string]: number;
+            };
+            source_count: number;
+        };
+        /** @description A rate-card entry. Mirrors the `product` table — data an offer line snapshots from, never a configurator. */
+        Product: {
+            /** Format: uuid */
+            id: string;
+            /** Format: uuid */
+            workspace_id: string;
+            name: string;
+            /** @description Optional; unique per workspace while live. */
+            sku?: string | null;
+            description?: string | null;
+            /** @description 'unit' | 'hour' | 'day' | … — display only, free text. */
+            unit: string;
+            /**
+             * Format: int64
+             * @description Integer minor units (P11); no float money.
+             */
+            unit_price_minor: number;
+            currency: string;
+            /**
+             * Format: double
+             * @description Percent, e.g. 19.00 (DE USt.); per-line override allowed.
+             */
+            default_tax_rate: number;
+            active: boolean;
+            source: string;
+            /** @description Server-stamped from the authenticated principal; never client-supplied. */
+            readonly captured_by: string;
+            version?: components["schemas"]["RowVersion"];
+            /** Format: date-time */
+            created_at: string;
+            /** Format: date-time */
+            updated_at: string;
+            /** Format: date-time */
+            archived_at?: string | null;
+        } & {
+            [key: string]: unknown;
+        };
+        ProductListResponse: {
+            data: components["schemas"]["Product"][];
+            page: components["schemas"]["PageInfo"];
+        };
+        CreateProductRequest: {
+            name: string;
+            sku?: string | null;
+            description?: string | null;
+            /** @description Defaults to 'unit'. */
+            unit?: string | null;
+            /** Format: int64 */
+            unit_price_minor: number;
+            currency: string;
+            /**
+             * Format: double
+             * @description Percent; defaults to 0.
+             */
+            default_tax_rate?: number | null;
+            /** @description Defaults to true. */
+            active?: boolean | null;
+            source: string;
+        } & {
+            [key: string]: unknown;
+        };
+        /** @description Any subset; omit a field to leave it unchanged. A price change never re-prices existing offer lines (they hold snapshots). */
+        UpdateProductRequest: {
+            name?: string;
+            sku?: string | null;
+            description?: string | null;
+            unit?: string;
+            /** Format: int64 */
+            unit_price_minor?: number;
+            currency?: string;
+            /** Format: double */
+            default_tax_rate?: number;
+            active?: boolean;
+        } & {
+            [key: string]: unknown;
+        };
+        /**
+         * @description A typed offer line. `description`/`unit_price_minor` are SNAPSHOTS (copied from the
+         *     optional product at line creation); `line_net_minor`/`line_tax_minor`/`line_total_minor`
+         *     are DERIVED server-side (formulas §12.6) and never stored or client-settable.
+         */
+        OfferLineItem: {
+            /** Format: uuid */
+            id: string;
+            /** @description Display order */
+            position: number;
+            /**
+             * Format: uuid
+             * @description Optional rate-card ref; the line survives the product.
+             */
+            product_id?: string | null;
+            description: string;
+            unit: string;
+            /**
+             * Format: double
+             * @description Up to 3 decimal places (numeric 14,3); must be > 0.
+             */
+            quantity: number;
+            /**
+             * Format: int64
+             * @description Snapshot — never re-read from product after creation.
+             */
+            unit_price_minor: number;
+            /**
+             * Format: double
+             * @description 0–100, up to 2 decimal places.
+             */
+            discount_pct: number;
+            /**
+             * Format: double
+             * @description Percent, up to 2 decimal places.
+             */
+            tax_rate: number;
+            /**
+             * Format: int64
+             * @description round(qty × unit_price × (1 − discount_pct/100)) — server-computed.
+             */
+            readonly line_net_minor: number;
+            /**
+             * Format: int64
+             * @description round(line_net × tax_rate/100) — server-computed.
+             */
+            readonly line_tax_minor: number;
+            /**
+             * Format: int64
+             * @description line_net + line_tax — server-computed.
+             */
+            readonly line_total_minor: number;
+            /** @description {snippet, source_id} when AI-drafted (evidence-or-omit, features/07). */
+            evidence?: {
+                [key: string]: unknown;
+            } | null;
+            version?: components["schemas"]["RowVersion"];
+            /** Format: date-time */
+            created_at: string;
+            /** Format: date-time */
+            updated_at: string;
+        };
+        /** @description A versioned Angebot bound to one deal. Mirrors the `offer` table; totals are derived from the nested line items. */
+        Offer: {
+            /** Format: uuid */
+            id: string;
+            /** Format: uuid */
+            workspace_id: string;
+            /** Format: uuid */
+            deal_id: string;
+            /** @description Human-facing Angebot number */
+            readonly offer_number: string;
+            /** @description Bumped when a sent offer is regenerated; the prior revision becomes superseded. */
+            readonly revision: number;
+            /** @enum {string} */
+            status: "draft" | "sent" | "accepted" | "rejected" | "expired" | "superseded";
+            currency: string;
+            /** Format: uuid */
+            buyer_org_id?: string | null;
+            /** @description Buyer legal block captured at send time. */
+            readonly buyer_snapshot?: {
+                [key: string]: unknown;
+            } | null;
+            /** @description Seller legal block captured at send time. */
+            readonly issuer_snapshot?: {
+                [key: string]: unknown;
+            } | null;
+            /** Format: date */
+            valid_until?: string | null;
+            intro_text?: string | null;
+            terms_text?: string | null;
+            /**
+             * Format: int64
+             * @description Σ line nets — derived
+             */
+            readonly net_minor: number;
+            /**
+             * Format: int64
+             * @description Σ line taxes — derived
+             */
+            readonly tax_minor: number;
+            /**
+             * Format: int64
+             * @description net + tax — derived
+             */
+            readonly gross_minor: number;
+            /** @description Native→base, frozen at send (RT-PR-C2). Decimal-as-string to avoid float rounding. */
+            readonly fx_rate_to_base?: string | null;
+            /** Format: date */
+            readonly fx_rate_date?: string | null;
+            /** @description Rendered PDF ref (render is the WP7 slice). */
+            pdf_asset_ref?: string | null;
+            /** Format: date-time */
+            readonly accepted_at?: string | null;
+            readonly line_items: components["schemas"]["OfferLineItem"][];
+            source: string;
+            /** @description Server-stamped from the authenticated principal; never client-supplied. */
+            readonly captured_by: string;
+            version?: components["schemas"]["RowVersion"];
+            /** Format: date-time */
+            created_at: string;
+            /** Format: date-time */
+            updated_at: string;
+            /** Format: date-time */
+            archived_at?: string | null;
+        } & {
+            [key: string]: unknown;
+        };
+        OfferListResponse: {
+            data: components["schemas"]["Offer"][];
+            page: components["schemas"]["PageInfo"];
+        };
+        /**
+         * @description One line to add. With `product_id`, description/unit/unit_price_minor/tax_rate default
+         *     from the product (a SNAPSHOT — later product edits never touch the line); without it,
+         *     description and unit_price_minor are required. Totals are never accepted here (422).
+         */
+        OfferLineItemInput: {
+            /** @description Defaults to the next free position. */
+            position?: number | null;
+            /** Format: uuid */
+            product_id?: string | null;
+            description?: string | null;
+            unit?: string | null;
+            /**
+             * Format: double
+             * @description > 0, up to 3 decimal places.
+             */
+            quantity: number;
+            /** Format: int64 */
+            unit_price_minor?: number | null;
+            /** Format: double */
+            discount_pct?: number | null;
+            /** Format: double */
+            tax_rate?: number | null;
+        };
+        /** @description Any subset; omit a field to leave it unchanged. Totals are derived and not settable (422). */
+        UpdateOfferLineItemRequest: {
+            position?: number;
+            description?: string;
+            unit?: string;
+            /** Format: double */
+            quantity?: number;
+            /** Format: int64 */
+            unit_price_minor?: number;
+            /** Format: double */
+            discount_pct?: number;
+            /** Format: double */
+            tax_rate?: number;
+        };
+        CreateOfferRequest: {
+            currency: string;
+            /**
+             * Format: uuid
+             * @description Defaults to the deal's organization.
+             */
+            buyer_org_id?: string | null;
+            /** Format: date */
+            valid_until?: string | null;
+            intro_text?: string | null;
+            terms_text?: string | null;
+            line_items?: components["schemas"]["OfferLineItemInput"][] | null;
+            source: string;
+        } & {
+            [key: string]: unknown;
+        };
+        /** @description Header-field patch; allowed only while status=draft (422 offer_not_draft otherwise). Totals are derived and not settable (422). */
+        UpdateOfferRequest: {
+            currency?: string;
+            /** Format: uuid */
+            buyer_org_id?: string | null;
+            /** Format: date */
+            valid_until?: string | null;
+            intro_text?: string | null;
+            terms_text?: string | null;
+        } & {
+            [key: string]: unknown;
+        };
+        RejectOfferRequest: {
+            /** @description Optional buyer-given decline reason (rides offer.rejected). */
+            reason?: string | null;
+        };
         IssuePassportRequest: {
             /** @description Which agent this binds, e.g. "Claude Desktop". */
             label?: string | null;
@@ -3225,6 +4641,77 @@ export interface components {
             last_used_at?: string | null;
             /** Format: date-time */
             revoked_at?: string | null;
+        };
+        /**
+         * @description One persisted Morning-Brief run for the acting rep (data-model §12.5 `brief_run` +
+         *     `brief_item`): the ranked, honest-short queue of winnable deals plus the metadata that
+         *     reproduces it. `candidate_count` is how many deals cleared the §10 honest-short bar;
+         *     `items` is the top slice (≤ 7) — genuinely shorter when fewer qualify, never padded.
+         */
+        MorningBrief: {
+            /** Format: uuid */
+            id: string;
+            /**
+             * Format: date-time
+             * @description When this run was assembled.
+             */
+            generated_at: string;
+            /**
+             * Format: date-time
+             * @description The data cutoff this brief reflects; the next run derives "changed overnight" from it.
+             */
+            as_of: string;
+            /** @description Deals that cleared the §10 honest-short bar (may exceed the queue length). */
+            candidate_count: number;
+            /**
+             * Format: int64
+             * @description The workspace-P90 (or fallback) base value the revenue factor normalized against.
+             */
+            revenue_norm_minor?: number;
+            /** @description The ranked queue, best-first, capped at the honest-short target (7). */
+            items: components["schemas"]["MorningBriefItem"][];
+        };
+        /**
+         * @description One ranked queue entry: the §10.1 composite, its per-factor decomposition (no mystery
+         *     number), the source rows behind the factors (evidence-or-omit, B-E05.12), and the
+         *     per-rep acted/dismissed state (B-E05.13). `rank` reflects the L2 re-order within the
+         *     deterministic candidate set, so it is not necessarily descending in `composite`.
+         */
+        MorningBriefItem: {
+            /** Format: uuid */
+            id: string;
+            /** Format: uuid */
+            deal_id: string;
+            /** @description Position in the queue (1 = top) */
+            rank: number;
+            /** @description The deterministic §10.1 composite score. */
+            composite: number;
+            feature_vector: components["schemas"]["MorningBriefFeatureVector"];
+            /** @description The source rows (deal / activity / relationship) behind the factors; never empty (evidence-or-omit). */
+            evidence_ids: string[];
+            /**
+             * @description The acting rep's queue state for this item.
+             * @enum {string}
+             */
+            state: "new" | "acted" | "dismissed";
+            /**
+             * Format: date-time
+             * @description When the rep acted/dismissed; null while new.
+             */
+            state_at?: string | null;
+        };
+        /** @description The §10.1 factor decomposition, each normalized 0..1 — the composite reconciles to it. */
+        MorningBriefFeatureVector: {
+            /** @description stage win probability / 100. */
+            winnability: number;
+            /** @description min(1 */
+            revenue: number;
+            /** @description bucketed days-until-expected-close urgency. */
+            timing: number;
+            /** @description 1.0 with an evidenced overnight change */
+            momentum: number;
+            /** @description strongest visible stakeholder's §4 strength / 100; floor 0 without contributing interactions. */
+            warmth: number;
         };
     };
     responses: {
@@ -5342,6 +6829,97 @@ export interface operations {
             422: components["responses"]["ValidationError"];
         };
     };
+    getPreferenceCenter: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The recipient's unguessable preference-center token (carried in the List-Unsubscribe URL; not a session credential). */
+                token: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The per-purpose preference state. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PreferenceCenter"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+        };
+    };
+    updatePreferences: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The recipient's unguessable preference-center token (carried in the List-Unsubscribe URL; not a session credential). */
+                token: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    choices: {
+                        purpose_key: string;
+                        /** @enum {string} */
+                        state: "granted" | "withdrawn";
+                        /** @description The exact wording shown to the recipient */
+                        wording?: string;
+                    }[];
+                };
+            };
+        };
+        responses: {
+            /** @description The updated per-purpose state. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PreferenceCenter"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    oneClickUnsubscribe: {
+        parameters: {
+            query?: {
+                /** @description The consent purpose key to withdraw. Omit to withdraw every non-transactional purpose. */
+                purpose?: string;
+            };
+            header?: never;
+            path: {
+                token: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Unsubscribed (idempotent). */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description The purpose keys now withdrawn. */
+                        unsubscribed: string[];
+                    };
+                };
+            };
+            404: components["responses"]["NotFound"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
     listAutomationCatalog: {
         parameters: {
             query?: never;
@@ -6069,6 +7647,172 @@ export interface operations {
             409: components["responses"]["Conflict"];
         };
     };
+    listSavedViews: {
+        parameters: {
+            query?: {
+                resource?: "people" | "organizations" | "deals" | "activities" | "leads" | "partners";
+                /** @description Include soft-deleted (archived) rows. Default false. */
+                include_archived?: components["parameters"]["IncludeArchived"];
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Saved views. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SavedViewListResponse"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+        };
+    };
+    createSavedView: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateSavedViewRequest"];
+            };
+        };
+        responses: {
+            /** @description Created saved view. */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SavedView"];
+                };
+            };
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    getSavedView: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The saved view. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SavedView"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+        };
+    };
+    archiveSavedView: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Archived saved view. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SavedView"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+        };
+    };
+    updateSavedView: {
+        parameters: {
+            query?: never;
+            header?: {
+                /**
+                 * @description Optional optimistic-concurrency precondition for a mutating request (PATCH/advance/merge):
+                 *     the last-seen entity `version`. If the row's current `version` differs, the write is
+                 *     rejected with `409 code: version_skew` (ErrVersionSkew) and no change is made — re-read,
+                 *     re-apply, retry. Omitting it is last-write-wins (discouraged for agent/automated writers).
+                 *     Accepted on every native (SoR-mode) mutating endpoint that returns a versioned entity.
+                 */
+                "If-Match"?: components["parameters"]["IfMatch"];
+            };
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateSavedViewRequest"];
+            };
+        };
+        responses: {
+            /** @description Updated saved view. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SavedView"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+            409: components["responses"]["Conflict"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    createFilteredExport: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["FilteredExportRequest"];
+            };
+        };
+        responses: {
+            /** @description The filtered slice as a downloadable attachment (Content-Disposition header set). */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/csv": string;
+                    "application/json": string;
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
     listTags: {
         parameters: {
             query?: {
@@ -6201,6 +7945,46 @@ export interface operations {
             403: components["responses"]["Forbidden"];
             404: components["responses"]["NotFound"];
             /** @description The plan failed validation (out-of-vocabulary field, invalid aggregate). */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["Problem"];
+                };
+            };
+        };
+    };
+    explainReport: {
+        parameters: {
+            query?: {
+                /** @description The plan's grouping dimensions (each must also appear as a predicate parameter carrying the explained row's group-key value). */
+                by?: string[];
+                /** @description The plan's aggregates as `fn:field:alias` triplets (field empty for `count`), e.g. `sum:amount_minor:unweighted_minor`. */
+                agg?: string[];
+            };
+            header?: never;
+            path: {
+                /** @description Report key (prebuilt) or a saved-report id. */
+                report: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The plain-language definition + drill-through source rows behind the number. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ReportDerivation"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+            /** @description A predicate key, grouping dimension, or aggregate is outside the report's vocabulary. */
             422: {
                 headers: {
                     [name: string]: unknown;
@@ -6928,6 +8712,1270 @@ export interface operations {
                 };
             };
             404: components["responses"]["NotFound"];
+        };
+    };
+    listVoiceProfiles: {
+        parameters: {
+            query?: {
+                /**
+                 * @description Opaque keyset cursor from a prior response's `page.next_cursor`. The cursor encodes the
+                 *     effective `sort` and `filter` of the originating request plus the last row's keyset
+                 *     (sort-key tuple + `id` tie-breaker). **Stability:** results are stable under concurrent
+                 *     inserts/updates (keyset pagination, not offset). Supplying `cursor` together with a `sort`
+                 *     or filter that differs from the one the cursor was minted under returns
+                 *     `422 code: cursor_param_mismatch` — re-issue the query without the cursor.
+                 */
+                cursor?: components["parameters"]["Cursor"];
+                /** @description Max items in the page. */
+                limit?: components["parameters"]["Limit"];
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Voice profiles. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data: components["schemas"]["VoiceProfile"][];
+                        page: components["schemas"]["PageInfo"];
+                    };
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+        };
+    };
+    createVoiceProfile: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateVoiceProfileRequest"];
+            };
+        };
+        responses: {
+            /** @description Created (building). */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["VoiceProfile"];
+                };
+            };
+            409: components["responses"]["Conflict"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    getVoiceProfile: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The voice profile. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["VoiceProfile"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+        };
+    };
+    deleteVoiceProfile: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Archived. */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            404: components["responses"]["NotFound"];
+        };
+    };
+    updateVoiceProfile: {
+        parameters: {
+            query?: never;
+            header?: {
+                /**
+                 * @description Optional optimistic-concurrency precondition for a mutating request (PATCH/advance/merge):
+                 *     the last-seen entity `version`. If the row's current `version` differs, the write is
+                 *     rejected with `409 code: version_skew` (ErrVersionSkew) and no change is made — re-read,
+                 *     re-apply, retry. Omitting it is last-write-wins (discouraged for agent/automated writers).
+                 *     Accepted on every native (SoR-mode) mutating endpoint that returns a versioned entity.
+                 */
+                "If-Match"?: components["parameters"]["IfMatch"];
+            };
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateVoiceProfileRequest"];
+            };
+        };
+        responses: {
+            /** @description Updated. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["VoiceProfile"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+            409: components["responses"]["Conflict"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    listVoiceCorpusSources: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Manifest rows + meter summary. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data: components["schemas"]["VoiceCorpusSource"][];
+                        summary: components["schemas"]["VoiceCorpusSummary"];
+                    };
+                };
+            };
+            404: components["responses"]["NotFound"];
+        };
+    };
+    ingestVoiceCorpusSource: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["IngestVoiceCorpusSourceRequest"];
+            };
+        };
+        responses: {
+            /** @description Ingested (created or replaced). */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        source: components["schemas"]["VoiceCorpusSource"];
+                        summary: components["schemas"]["VoiceCorpusSummary"];
+                    };
+                };
+            };
+            404: components["responses"]["NotFound"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    updateVoiceCorpusSource: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+                sourceId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateVoiceCorpusSourceRequest"];
+            };
+        };
+        responses: {
+            /** @description Updated manifest row + refreshed meter. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        source: components["schemas"]["VoiceCorpusSource"];
+                        summary: components["schemas"]["VoiceCorpusSummary"];
+                    };
+                };
+            };
+            404: components["responses"]["NotFound"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    listProducts: {
+        parameters: {
+            query?: {
+                /**
+                 * @description Opaque keyset cursor from a prior response's `page.next_cursor`. The cursor encodes the
+                 *     effective `sort` and `filter` of the originating request plus the last row's keyset
+                 *     (sort-key tuple + `id` tie-breaker). **Stability:** results are stable under concurrent
+                 *     inserts/updates (keyset pagination, not offset). Supplying `cursor` together with a `sort`
+                 *     or filter that differs from the one the cursor was minted under returns
+                 *     `422 code: cursor_param_mismatch` — re-issue the query without the cursor.
+                 */
+                cursor?: components["parameters"]["Cursor"];
+                /** @description Max items in the page. */
+                limit?: components["parameters"]["Limit"];
+                /**
+                 * @description Sort spec: comma-separated fields, `-` prefix = descending (e.g. `-updated_at,full_name`).
+                 *     `id` is always appended as the final tie-breaker so ordering is total and the keyset cursor
+                 *     is deterministic. **Allowed sort fields per resource** are the indexed columns enumerated in
+                 *     data-model.md §13 (Sort/filter vocabulary); the default sort when omitted is `-created_at,id`.
+                 *     An out-of-vocabulary field returns `422 code: sort_field_not_allowed`.
+                 */
+                sort?: components["parameters"]["Sort"];
+                /** @description Include soft-deleted (archived) rows. Default false. */
+                include_archived?: components["parameters"]["IncludeArchived"];
+                active?: boolean;
+                /** @description Case-insensitive name/SKU substring match. */
+                q?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description A page of products. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProductListResponse"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+        };
+    };
+    createProduct: {
+        parameters: {
+            query?: never;
+            header?: {
+                /**
+                 * @description Client-supplied key making a POST safe to retry. **Scope:** the key is unique within
+                 *     `(workspace_id, principal, request-path)` and retained **24h**; a replay within that window
+                 *     returns the original status + body. Reusing the same key with a *different* request body
+                 *     returns `409 code: idempotency_key_conflict` (never a silent replay of mismatched intent).
+                 *     **Precedence vs natural keys:** on `logActivity`/`createLead`, the Idempotency-Key (transport
+                 *     retry-safety) is checked first; if absent, the `(source_system, source_id)` natural key
+                 *     (data-model dedupe) governs. The two never both create a row. Strongly recommended on all POSTs.
+                 */
+                "Idempotency-Key"?: components["parameters"]["IdempotencyKey"];
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateProductRequest"];
+            };
+        };
+        responses: {
+            /** @description Created product. */
+            201: {
+                headers: {
+                    Location?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Product"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            409: components["responses"]["Conflict"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    getProduct: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The product. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Product"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+        };
+    };
+    archiveProduct: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Archived product. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Product"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+        };
+    };
+    updateProduct: {
+        parameters: {
+            query?: never;
+            header?: {
+                /**
+                 * @description Optional optimistic-concurrency precondition for a mutating request (PATCH/advance/merge):
+                 *     the last-seen entity `version`. If the row's current `version` differs, the write is
+                 *     rejected with `409 code: version_skew` (ErrVersionSkew) and no change is made — re-read,
+                 *     re-apply, retry. Omitting it is last-write-wins (discouraged for agent/automated writers).
+                 *     Accepted on every native (SoR-mode) mutating endpoint that returns a versioned entity.
+                 */
+                "If-Match"?: components["parameters"]["IfMatch"];
+            };
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateProductRequest"];
+            };
+        };
+        responses: {
+            /** @description Updated product. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Product"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+            409: components["responses"]["Conflict"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    listDealOffers: {
+        parameters: {
+            query?: {
+                /**
+                 * @description Opaque keyset cursor from a prior response's `page.next_cursor`. The cursor encodes the
+                 *     effective `sort` and `filter` of the originating request plus the last row's keyset
+                 *     (sort-key tuple + `id` tie-breaker). **Stability:** results are stable under concurrent
+                 *     inserts/updates (keyset pagination, not offset). Supplying `cursor` together with a `sort`
+                 *     or filter that differs from the one the cursor was minted under returns
+                 *     `422 code: cursor_param_mismatch` — re-issue the query without the cursor.
+                 */
+                cursor?: components["parameters"]["Cursor"];
+                /** @description Max items in the page. */
+                limit?: components["parameters"]["Limit"];
+                status?: "draft" | "sent" | "accepted" | "rejected" | "expired" | "superseded";
+            };
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description A page of the deal's offers. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OfferListResponse"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+        };
+    };
+    createOffer: {
+        parameters: {
+            query?: never;
+            header?: {
+                /**
+                 * @description Client-supplied key making a POST safe to retry. **Scope:** the key is unique within
+                 *     `(workspace_id, principal, request-path)` and retained **24h**; a replay within that window
+                 *     returns the original status + body. Reusing the same key with a *different* request body
+                 *     returns `409 code: idempotency_key_conflict` (never a silent replay of mismatched intent).
+                 *     **Precedence vs natural keys:** on `logActivity`/`createLead`, the Idempotency-Key (transport
+                 *     retry-safety) is checked first; if absent, the `(source_system, source_id)` natural key
+                 *     (data-model dedupe) governs. The two never both create a row. Strongly recommended on all POSTs.
+                 */
+                "Idempotency-Key"?: components["parameters"]["IdempotencyKey"];
+            };
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateOfferRequest"];
+            };
+        };
+        responses: {
+            /** @description Created draft offer with computed totals. */
+            201: {
+                headers: {
+                    Location?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Offer"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    getOffer: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The offer. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Offer"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+        };
+    };
+    archiveOffer: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Archived offer. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Offer"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+        };
+    };
+    updateOffer: {
+        parameters: {
+            query?: never;
+            header?: {
+                /**
+                 * @description Optional optimistic-concurrency precondition for a mutating request (PATCH/advance/merge):
+                 *     the last-seen entity `version`. If the row's current `version` differs, the write is
+                 *     rejected with `409 code: version_skew` (ErrVersionSkew) and no change is made — re-read,
+                 *     re-apply, retry. Omitting it is last-write-wins (discouraged for agent/automated writers).
+                 *     Accepted on every native (SoR-mode) mutating endpoint that returns a versioned entity.
+                 */
+                "If-Match"?: components["parameters"]["IfMatch"];
+            };
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateOfferRequest"];
+            };
+        };
+        responses: {
+            /** @description Updated draft offer. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Offer"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+            409: components["responses"]["Conflict"];
+            /** @description Validation error — including any mutation of a non-draft offer (offer_not_draft). */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["Problem"];
+                };
+            };
+        };
+    };
+    addOfferLineItem: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["OfferLineItemInput"];
+            };
+        };
+        responses: {
+            /** @description The offer with the new line and recomputed totals. */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Offer"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    removeOfferLineItem: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+                lineItemId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The offer without the line, totals recomputed. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Offer"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    updateOfferLineItem: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+                lineItemId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateOfferLineItemRequest"];
+            };
+        };
+        responses: {
+            /** @description The offer with the updated line and recomputed totals. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Offer"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    sendOffer: {
+        parameters: {
+            query?: never;
+            header?: {
+                /**
+                 * @description Client-supplied key making a POST safe to retry. **Scope:** the key is unique within
+                 *     `(workspace_id, principal, request-path)` and retained **24h**; a replay within that window
+                 *     returns the original status + body. Reusing the same key with a *different* request body
+                 *     returns `409 code: idempotency_key_conflict` (never a silent replay of mismatched intent).
+                 *     **Precedence vs natural keys:** on `logActivity`/`createLead`, the Idempotency-Key (transport
+                 *     retry-safety) is checked first; if absent, the `(source_system, source_id)` natural key
+                 *     (data-model dedupe) governs. The two never both create a row. Strongly recommended on all POSTs.
+                 */
+                "Idempotency-Key"?: components["parameters"]["IdempotencyKey"];
+                /**
+                 * @description A signed, single-use approval token (see schema `ApprovalToken`) minted by
+                 *     POST /approvals/{id}/approve, authorizing exactly one 🟡 confirm-first operation. It is a
+                 *     compact JWS whose claims **bind** the token to a specific approval, effect, tenant and
+                 *     principal — it is NOT a bare opaque string (ADR-0036). The server rejects a token that is
+                 *     expired, already consumed, or whose `diff_hash`/`workspace_id`/`passport_id`/`tool` does not
+                 *     match the operation being executed (`403 code: approval_token_invalid`). Required when an
+                 *     AGENT principal invokes a 🟡 operation; a human's direct call is itself the approval.
+                 */
+                "X-Approval-Token"?: components["parameters"]["ApprovalToken"];
+                /**
+                 * @description Optional optimistic-concurrency precondition for a mutating request (PATCH/advance/merge):
+                 *     the last-seen entity `version`. If the row's current `version` differs, the write is
+                 *     rejected with `409 code: version_skew` (ErrVersionSkew) and no change is made — re-read,
+                 *     re-apply, retry. Omitting it is last-write-wins (discouraged for agent/automated writers).
+                 *     Accepted on every native (SoR-mode) mutating endpoint that returns a versioned entity.
+                 */
+                "If-Match"?: components["parameters"]["IfMatch"];
+            };
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The sent offer (frozen totals + FX). */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Offer"];
+                };
+            };
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    acceptOffer: {
+        parameters: {
+            query?: never;
+            header?: {
+                /**
+                 * @description Optional optimistic-concurrency precondition for a mutating request (PATCH/advance/merge):
+                 *     the last-seen entity `version`. If the row's current `version` differs, the write is
+                 *     rejected with `409 code: version_skew` (ErrVersionSkew) and no change is made — re-read,
+                 *     re-apply, retry. Omitting it is last-write-wins (discouraged for agent/automated writers).
+                 *     Accepted on every native (SoR-mode) mutating endpoint that returns a versioned entity.
+                 */
+                "If-Match"?: components["parameters"]["IfMatch"];
+            };
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The accepted offer. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Offer"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    rejectOffer: {
+        parameters: {
+            query?: never;
+            header?: {
+                /**
+                 * @description Optional optimistic-concurrency precondition for a mutating request (PATCH/advance/merge):
+                 *     the last-seen entity `version`. If the row's current `version` differs, the write is
+                 *     rejected with `409 code: version_skew` (ErrVersionSkew) and no change is made — re-read,
+                 *     re-apply, retry. Omitting it is last-write-wins (discouraged for agent/automated writers).
+                 *     Accepted on every native (SoR-mode) mutating endpoint that returns a versioned entity.
+                 */
+                "If-Match"?: components["parameters"]["IfMatch"];
+            };
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["RejectOfferRequest"];
+            };
+        };
+        responses: {
+            /** @description The rejected offer. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Offer"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    regenerateOffer: {
+        parameters: {
+            query?: never;
+            header?: {
+                /**
+                 * @description Client-supplied key making a POST safe to retry. **Scope:** the key is unique within
+                 *     `(workspace_id, principal, request-path)` and retained **24h**; a replay within that window
+                 *     returns the original status + body. Reusing the same key with a *different* request body
+                 *     returns `409 code: idempotency_key_conflict` (never a silent replay of mismatched intent).
+                 *     **Precedence vs natural keys:** on `logActivity`/`createLead`, the Idempotency-Key (transport
+                 *     retry-safety) is checked first; if absent, the `(source_system, source_id)` natural key
+                 *     (data-model dedupe) governs. The two never both create a row. Strongly recommended on all POSTs.
+                 */
+                "Idempotency-Key"?: components["parameters"]["IdempotencyKey"];
+            };
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The new draft revision. */
+            201: {
+                headers: {
+                    Location?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Offer"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    listSignals: {
+        parameters: {
+            query?: {
+                /**
+                 * @description Opaque keyset cursor from a prior response's `page.next_cursor`. The cursor encodes the
+                 *     effective `sort` and `filter` of the originating request plus the last row's keyset
+                 *     (sort-key tuple + `id` tie-breaker). **Stability:** results are stable under concurrent
+                 *     inserts/updates (keyset pagination, not offset). Supplying `cursor` together with a `sort`
+                 *     or filter that differs from the one the cursor was minted under returns
+                 *     `422 code: cursor_param_mismatch` — re-issue the query without the cursor.
+                 */
+                cursor?: components["parameters"]["Cursor"];
+                /** @description Max items in the page. */
+                limit?: components["parameters"]["Limit"];
+                /** @description Include soft-deleted (archived) rows. Default false. */
+                include_archived?: components["parameters"]["IncludeArchived"];
+                status?: "open" | "acknowledged" | "resolved" | "dismissed";
+                kind?: "stalled_deal" | "champion_left" | "reengagement" | "buying_intent" | "risk" | "other";
+                resolution_state?: "resolved" | "low_confidence" | "unresolved" | "dropped";
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description A page of signals. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SignalListResponse"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+        };
+    };
+    createSignal: {
+        parameters: {
+            query?: never;
+            header?: {
+                /**
+                 * @description Client-supplied key making a POST safe to retry. **Scope:** the key is unique within
+                 *     `(workspace_id, principal, request-path)` and retained **24h**; a replay within that window
+                 *     returns the original status + body. Reusing the same key with a *different* request body
+                 *     returns `409 code: idempotency_key_conflict` (never a silent replay of mismatched intent).
+                 *     **Precedence vs natural keys:** on `logActivity`/`createLead`, the Idempotency-Key (transport
+                 *     retry-safety) is checked first; if absent, the `(source_system, source_id)` natural key
+                 *     (data-model dedupe) governs. The two never both create a row. Strongly recommended on all POSTs.
+                 */
+                "Idempotency-Key"?: components["parameters"]["IdempotencyKey"];
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateSignalRequest"];
+            };
+        };
+        responses: {
+            /** @description Created signal. */
+            201: {
+                headers: {
+                    Location?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Signal"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            /** @description The subject entity does not exist or is outside the caller's row scope. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["Problem"];
+                };
+            };
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    getSignal: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The signal. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Signal"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+        };
+    };
+    archiveSignal: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Archived signal. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Signal"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+        };
+    };
+    updateSignal: {
+        parameters: {
+            query?: never;
+            header?: {
+                /**
+                 * @description Client-supplied key making a POST safe to retry. **Scope:** the key is unique within
+                 *     `(workspace_id, principal, request-path)` and retained **24h**; a replay within that window
+                 *     returns the original status + body. Reusing the same key with a *different* request body
+                 *     returns `409 code: idempotency_key_conflict` (never a silent replay of mismatched intent).
+                 *     **Precedence vs natural keys:** on `logActivity`/`createLead`, the Idempotency-Key (transport
+                 *     retry-safety) is checked first; if absent, the `(source_system, source_id)` natural key
+                 *     (data-model dedupe) governs. The two never both create a row. Strongly recommended on all POSTs.
+                 */
+                "Idempotency-Key"?: components["parameters"]["IdempotencyKey"];
+                /**
+                 * @description Optional optimistic-concurrency precondition for a mutating request (PATCH/advance/merge):
+                 *     the last-seen entity `version`. If the row's current `version` differs, the write is
+                 *     rejected with `409 code: version_skew` (ErrVersionSkew) and no change is made — re-read,
+                 *     re-apply, retry. Omitting it is last-write-wins (discouraged for agent/automated writers).
+                 *     Accepted on every native (SoR-mode) mutating endpoint that returns a versioned entity.
+                 */
+                "If-Match"?: components["parameters"]["IfMatch"];
+            };
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateSignalRequest"];
+            };
+        };
+        responses: {
+            /** @description Updated signal. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Signal"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    resolveSignal: {
+        parameters: {
+            query?: never;
+            header?: {
+                /**
+                 * @description Client-supplied key making a POST safe to retry. **Scope:** the key is unique within
+                 *     `(workspace_id, principal, request-path)` and retained **24h**; a replay within that window
+                 *     returns the original status + body. Reusing the same key with a *different* request body
+                 *     returns `409 code: idempotency_key_conflict` (never a silent replay of mismatched intent).
+                 *     **Precedence vs natural keys:** on `logActivity`/`createLead`, the Idempotency-Key (transport
+                 *     retry-safety) is checked first; if absent, the `(source_system, source_id)` natural key
+                 *     (data-model dedupe) governs. The two never both create a row. Strongly recommended on all POSTs.
+                 */
+                "Idempotency-Key"?: components["parameters"]["IdempotencyKey"];
+            };
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The stamped signal with its resolution outcome. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Signal"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+            /** @description The signal has no raw_ref to resolve, or is already terminally resolved/dropped. */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["Problem"];
+                };
+            };
+        };
+    };
+    getSignalWarmth: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The warm/cold branch with its evidence ids. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SignalWarmth"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+            /** @description The signal is not resolved to an organization (unresolved / low-confidence / dropped signals have no warmth). */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["Problem"];
+                };
+            };
+        };
+    };
+    getSignalIntroPath: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The proposed intro path. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SignalIntroPath"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+            /** @description The signal is cold or not resolved — there is no warm path to propose. */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["Problem"];
+                };
+            };
+        };
+    };
+    getMorningBrief: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The latest brief run with its ranked queue. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MorningBrief"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            /** @description The rep has no brief run yet (none has been generated). */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["Problem"];
+                };
+            };
+        };
+    };
+    generateMorningBrief: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The freshly generated brief run. */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MorningBrief"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+        };
+    };
+    markBriefItemActed: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description A brief_item id belonging to one of the acting rep's runs. */
+                itemId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The updated brief item. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MorningBriefItem"];
+                };
+            };
+            /** @description No such item in one of the acting rep's runs (another rep's item reads as not-found). */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["Problem"];
+                };
+            };
+            /** @description The item was already acted on or dismissed. */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["Problem"];
+                };
+            };
+        };
+    };
+    markBriefItemDismissed: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description A brief_item id belonging to one of the acting rep's runs. */
+                itemId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The updated brief item. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MorningBriefItem"];
+                };
+            };
+            /** @description No such item in one of the acting rep's runs (another rep's item reads as not-found). */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["Problem"];
+                };
+            };
+            /** @description The item was already acted on or dismissed. */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["Problem"];
+                };
+            };
         };
     };
 }

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -141,9 +141,36 @@ export const de = {
 
   "home.brief": "Morgenbriefing",
   "home.sub": "aus echten Signalen sortiert — Vorgemerktes zuerst",
-  "home.quiet": "Alles ruhig. Nichts vorgemerkt, nichts steht still.",
   "home.staged": "Wartet auf dich",
   "home.stalled": "Stillstehende Deals",
+  "home.queue": "Heute dran",
+  "home.asOf": "Stand {at}",
+  "home.refresh": "Briefing aktualisieren",
+  "home.refreshing": "Wird sortiert…",
+  "home.generate": "Erstes Briefing erstellen",
+  "home.noneTitle": "Noch kein Briefing",
+  "home.noneBody":
+    "Dein Morgenbriefing sortiert die Deals, die deine erste Stunde verdienen — Gewinnbarkeit, Umsatz, Timing, Momentum und Wärme, jeder Faktor mit Beleg. Erstell den ersten Lauf, sobald offene Deals da sind.",
+  "home.honestShort":
+    "Nur {count} Deals haben die Schwelle geschafft — die Liste wird nie aufgefüllt.",
+  "home.overflow":
+    "{shown} von {count} qualifizierten Deals — ehrlich kurz, oben die besten.",
+  "home.quietRun":
+    "Heute Morgen hat nichts die Schwelle geschafft. Keine erfundene Dringlichkeit — genieß die Ruhe.",
+  "home.act": "Erledigt",
+  "home.dismiss": "Ausblenden",
+  "home.actedState": "erledigt",
+  "home.dismissedState": "ausgeblendet",
+  "home.why": "Warum das rankt",
+  "home.evidence": "{count} Belege",
+  "home.evidenceOne": "1 Beleg",
+  "home.score": "Score {pct} %",
+  "home.openDeal": "Deal öffnen",
+  "home.factorWinnability": "Gewinnbarkeit",
+  "home.factorRevenue": "Umsatz",
+  "home.factorTiming": "Timing",
+  "home.factorMomentum": "Momentum",
+  "home.factorWarmth": "Wärme",
 
   "tasks.overdue": "Überfällig",
   "tasks.today": "Heute",
@@ -265,6 +292,17 @@ export const de = {
   "ob.tryAnother": "Andere URL versuchen",
   "ob.fillByHand": "Stattdessen von Hand ausfüllen",
 
+  "ob.field.icp": "Idealkunde",
+  "ob.field.buying_center": "Wer kauft",
+  "ob.field.value_proposition": "Nutzenversprechen",
+  "ob.field.usp": "Was dich unterscheidet",
+  "ob.field.buying_intents": "Kaufanlässe",
+  "ob.field.legal_name": "Firmenname",
+  "ob.field.registered_address": "Anschrift",
+  "ob.field.register_vat": "Register / USt-ID",
+  "ob.field.industry": "Branche",
+  "ob.field.history": "Firmengeschichte",
+
   "ob.s2.kick": "Schritt 2 von 5",
   "ob.s2.title": "Haben wir's richtig verstanden?",
   "ob.s2.sub":
@@ -350,12 +388,17 @@ export const de = {
     "ICP, Nutzenversprechen & USP von deiner Seite erfasst — jeweils mit Quelle.",
   "ob.s4.cardVoice": "Deine Schreibstimme",
   "ob.s4.cardVoiceBody":
-    "Direkt, warm, knapp. Entwürfe klingen ab Tag eins nach dir.",
+    "Gebaut aus dem Korpus, den du uns gerade gegeben hast. Entwürfe klingen ab Tag eins nach dir.",
+  "ob.s4.cardVoiceSkippedBody":
+    "Du hast den Tonfall-Schritt übersprungen — Entwürfe starten in einer neutralen Startstimme, bis du deine baust. Zwei Minuten, jederzeit, in den Einstellungen.",
   "ob.s4.cardPipeline": "Vertriebs-Pipeline",
   "ob.s4.cardPipelineBody":
     "Die Standard-B2B-Vorlage mit 7 Stufen, auf deine Branche vorgestimmt. Leer, bis du verbindest — dann füllen sich Deals aus deiner Post.",
   "ob.s4.cardDraft": "Ein Beispiel-Entwurf, in deiner Stimme",
+  "ob.s4.cardDraftExample": "Ein Beispiel-Entwurf",
   "ob.s4.cardDraftBody": "Sieh ihn unten.",
+  "ob.s4.exampleTag":
+    "Illustratives Beispiel — noch nicht aus deinen Daten geschrieben",
   "ob.s4.draftSample":
     "Betreff: Kurze Frage zu eurer Montagelinie\n\nHallo {{name}} — gesehen, dass {company} diskrete Montage im großen Stil fährt. Wir bringen Teams wie euch in 6 Wochen eine laufende Roboterzelle, ohne eure bestehenden SPS rauszureißen. 15 Minuten wert? Beste Grüße, Lars",
   "ob.s4.originLabel": "Woher diese Pipeline kommt",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -138,9 +138,36 @@ export const en = {
 
   "home.brief": "Morning brief",
   "home.sub": "ranked from live signals — staged actions first",
-  "home.quiet": "All quiet. Nothing staged, nothing stalled.",
   "home.staged": "Waiting on you",
   "home.stalled": "Stalled deals",
+  "home.queue": "Today's queue",
+  "home.asOf": "as of {at}",
+  "home.refresh": "Refresh brief",
+  "home.refreshing": "Ranking…",
+  "home.generate": "Generate my first brief",
+  "home.noneTitle": "No brief yet",
+  "home.noneBody":
+    "Your morning brief ranks the deals worth your first hour — winnability, revenue, timing, momentum, and warmth, each factor with its evidence. Generate the first run once you have open deals.",
+  "home.honestShort":
+    "Only {count} deals cleared the bar — the queue is never padded.",
+  "home.overflow":
+    "{shown} of {count} qualifying deals — the honest-short top slice.",
+  "home.quietRun":
+    "Nothing cleared the bar this morning. No invented urgency — enjoy the quiet.",
+  "home.act": "Done",
+  "home.dismiss": "Dismiss",
+  "home.actedState": "acted",
+  "home.dismissedState": "dismissed",
+  "home.why": "Why this ranks",
+  "home.evidence": "{count} evidence rows",
+  "home.evidenceOne": "1 evidence row",
+  "home.score": "score {pct}%",
+  "home.openDeal": "Open deal",
+  "home.factorWinnability": "Winnability",
+  "home.factorRevenue": "Revenue",
+  "home.factorTiming": "Timing",
+  "home.factorMomentum": "Momentum",
+  "home.factorWarmth": "Warmth",
 
   "tasks.overdue": "Overdue",
   "tasks.today": "Today",
@@ -258,6 +285,17 @@ export const en = {
   "ob.tryAnother": "Try another URL",
   "ob.fillByHand": "Fill it in by hand instead",
 
+  "ob.field.icp": "Ideal customer",
+  "ob.field.buying_center": "Who buys",
+  "ob.field.value_proposition": "Value proposition",
+  "ob.field.usp": "What sets you apart",
+  "ob.field.buying_intents": "Buying intents",
+  "ob.field.legal_name": "Company name",
+  "ob.field.registered_address": "Registered address",
+  "ob.field.register_vat": "Register / VAT ID",
+  "ob.field.industry": "Industry",
+  "ob.field.history": "Company history",
+
   "ob.s2.kick": "Step 2 of 5",
   "ob.s2.title": "Did we get it right?",
   "ob.s2.sub":
@@ -340,12 +378,16 @@ export const en = {
     "ICP, value proposition & USP captured from your site — each with its source.",
   "ob.s4.cardVoice": "Your writing voice",
   "ob.s4.cardVoiceBody":
-    "Direct, warm, concise. Drafts will sound like you from day one.",
+    "Built from the corpus you just gave us. Drafts will sound like you from day one.",
+  "ob.s4.cardVoiceSkippedBody":
+    "You skipped the voice step — drafts start in a neutral starter voice until you build yours. Two minutes, anytime, in Settings.",
   "ob.s4.cardPipeline": "Sales pipeline",
   "ob.s4.cardPipelineBody":
     "The standard 7-stage B2B template, pre-tuned to your industry. Empty until you connect — then deals fill in from your mail.",
   "ob.s4.cardDraft": "A sample draft, in your voice",
+  "ob.s4.cardDraftExample": "A sample draft",
   "ob.s4.cardDraftBody": "See it below.",
+  "ob.s4.exampleTag": "Illustrative example — not written from your data yet",
   "ob.s4.draftSample":
     "Subject: Quick question on your assembly line\n\nHi {{name}} — saw {company} runs discrete assembly at scale. We help teams like yours get a working robotic cell running in 6 weeks without ripping out your existing PLCs. Worth a 15-minute look? Best, Lars",
   "ob.s4.originLabel": "Where this pipeline comes from",

--- a/frontend/src/screens/home.css
+++ b/frontend/src/screens/home.css
@@ -1,0 +1,156 @@
+/* Home / Morning Brief — the /brief run rendered as a ranked queue: rank,
+ * deal, the §10.1 factor decomposition as readable bars (no mystery number),
+ * evidence count, and the act/dismiss pair. Settled items stay visible but
+ * recede, so the morning reads as progress, not deletion. */
+
+.brief-runbar {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.brief-runbar > :first-child {
+  flex: 1;
+  min-width: 0;
+}
+
+.brief-runbar > button {
+  margin-top: 4px;
+  flex: none;
+}
+
+.brief-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.brief-deal {
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.brief-deal.settled {
+  opacity: 0.6;
+}
+
+.brief-deal-head {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.brief-deal-head .brief-rank {
+  font-family: var(--f-mono);
+  font-size: 12px;
+  color: var(--textSecondary);
+  flex: none;
+}
+
+.brief-deal-name {
+  background: none;
+  border: 0;
+  padding: 0;
+  font: inherit;
+  font-weight: 600;
+  color: var(--textPrimary);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+}
+
+.brief-deal-name:hover {
+  color: var(--accent);
+}
+
+.brief-deal-name svg {
+  width: 14px;
+  height: 14px;
+  flex: none;
+}
+
+.brief-deal-amount {
+  color: var(--textSecondary);
+  font-variant-numeric: tabular-nums;
+}
+
+.brief-score {
+  margin-left: auto;
+  font-size: 12px;
+  color: var(--textSecondary);
+  flex: none;
+}
+
+.brief-factors {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.brief-factor {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+
+.brief-factor-label {
+  color: var(--textSecondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.brief-factor-track {
+  display: block;
+  height: 4px;
+  border-radius: 2px;
+  background: var(--borderSubtle);
+  overflow: hidden;
+}
+
+.brief-factor-fill {
+  display: block;
+  height: 100%;
+  border-radius: 2px;
+  background: var(--accent);
+}
+
+.brief-deal-foot {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.brief-deal-actions {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 8px;
+}
+
+.brief-deal-actions svg,
+.brief-runbar svg {
+  width: 14px;
+  height: 14px;
+}
+
+.brief-honesty {
+  color: var(--textSecondary);
+  margin: 2px 2px 0;
+}
+
+.brief-none {
+  padding: 18px;
+}
+
+@media (max-width: 640px) {
+  .brief-factors {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}

--- a/frontend/src/screens/home.test.tsx
+++ b/frontend/src/screens/home.test.tsx
@@ -1,0 +1,185 @@
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  cleanup,
+  render as rtlRender,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { LocaleProvider } from "../i18n";
+import { HomeScreen } from "./home";
+
+// Home / Morning Brief acceptance: the /brief run IS the queue (ranked items
+// with the §10.1 factor decomposition and evidence counts), a 404 renders the
+// honest generate card (never a fake run), an empty run renders honest quiet,
+// and act/dismiss mark the item without removing it from the morning's view.
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  window.location.hash = "";
+});
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function render(ui: ReactNode) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return rtlRender(
+    <QueryClientProvider client={client}>
+      <LocaleProvider initial="en">{ui}</LocaleProvider>
+    </QueryClientProvider>,
+  );
+}
+
+const fleetDeal = {
+  id: "d-1",
+  workspace_id: "w",
+  name: "Fleet retrofit",
+  amount_minor: 4_800_000,
+  currency: "EUR",
+  pipeline_id: "pl",
+  stage_id: "s2",
+  status: "open",
+  stalled: false,
+  source: "manual",
+  captured_by: "human:u1",
+  version: 1,
+  created_at: "2026-05-01T08:00:00Z",
+  updated_at: "2026-06-01T08:00:00Z",
+};
+
+const run = {
+  id: "br-1",
+  generated_at: "2026-07-05T05:30:00Z",
+  as_of: "2026-07-05T05:00:00Z",
+  candidate_count: 1,
+  items: [
+    {
+      id: "bi-1",
+      deal_id: "d-1",
+      rank: 1,
+      composite: 0.74,
+      feature_vector: {
+        winnability: 0.4,
+        revenue: 1,
+        timing: 0.75,
+        momentum: 1,
+        warmth: 0.47,
+      },
+      evidence_ids: ["ev-1", "ev-2"],
+      state: "new",
+      state_at: null,
+    },
+  ],
+};
+
+const emptyPage = { data: [], page: { next_cursor: null } };
+
+// Routes the stubbed fetch by path+method so each test declares only the
+// interesting responses; everything else answers an empty page.
+function stubApi(
+  routes: Record<string, (init?: RequestInit) => Response>,
+): ReturnType<typeof vi.fn> {
+  const mock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const request = input instanceof Request ? input : null;
+    const url = new URL(
+      request ? request.url : String(input),
+      "https://test.local",
+    );
+    const method = request?.method ?? init?.method ?? "GET";
+    const key = `${method} ${url.pathname.replace(/^\/v1/, "")}`;
+    const handler = routes[key];
+    return handler ? handler(init) : jsonResponse(emptyPage);
+  });
+  vi.stubGlobal("fetch", mock);
+  return mock;
+}
+
+describe("HomeScreen (Morning Brief on the /brief spine)", () => {
+  it("renders the ranked run: deal name, factor decomposition, evidence count, honest-short line", async () => {
+    stubApi({
+      "GET /brief": () => jsonResponse(run),
+      "GET /deals/d-1": () => jsonResponse(fleetDeal),
+    });
+    render(<HomeScreen />);
+    await waitFor(() =>
+      expect(screen.getByText("Fleet retrofit")).toBeTruthy(),
+    );
+    expect(screen.getByText("#1")).toBeTruthy();
+    expect(screen.getByText("score 74%")).toBeTruthy();
+    expect(screen.getByText("Winnability")).toBeTruthy();
+    expect(screen.getByText("Warmth")).toBeTruthy();
+    expect(screen.getByText("2 evidence rows")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Only 1 deals cleared the bar — the queue is never padded.",
+      ),
+    ).toBeTruthy();
+  });
+
+  it("a 404 (no run yet) renders the generate card, and generating renders the fresh run", async () => {
+    let generated = false;
+    stubApi({
+      "GET /brief": () =>
+        generated
+          ? jsonResponse(run)
+          : jsonResponse({ title: "Not Found" }, 404),
+      "POST /brief": () => {
+        generated = true;
+        return jsonResponse(run, 201);
+      },
+      "GET /deals/d-1": () => jsonResponse(fleetDeal),
+    });
+    render(<HomeScreen />);
+    await waitFor(() => expect(screen.getByText("No brief yet")).toBeTruthy());
+    await userEvent.click(screen.getByText("Generate my first brief"));
+    await waitFor(() =>
+      expect(screen.getByText("Fleet retrofit")).toBeTruthy(),
+    );
+  });
+
+  it("acting on an item marks it acted in place (still visible, receded)", async () => {
+    stubApi({
+      "GET /brief": () => jsonResponse(run),
+      "GET /deals/d-1": () => jsonResponse(fleetDeal),
+      "POST /brief/items/bi-1/act": () =>
+        jsonResponse({
+          ...run.items[0],
+          state: "acted",
+          state_at: "2026-07-05T06:00:00Z",
+        }),
+    });
+    render(<HomeScreen />);
+    await waitFor(() =>
+      expect(screen.getByText("Fleet retrofit")).toBeTruthy(),
+    );
+    await userEvent.click(screen.getByText("Done"));
+    await waitFor(() => expect(screen.getByText("acted")).toBeTruthy());
+    expect(screen.getByText("Fleet retrofit")).toBeTruthy();
+  });
+
+  it("an empty run renders honest quiet — no invented urgency", async () => {
+    stubApi({
+      "GET /brief": () =>
+        jsonResponse({ ...run, candidate_count: 0, items: [] }),
+    });
+    render(<HomeScreen />);
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          "Nothing cleared the bar this morning. No invented urgency — enjoy the quiet.",
+        ),
+      ).toBeTruthy(),
+    );
+  });
+});

--- a/frontend/src/screens/home.tsx
+++ b/frontend/src/screens/home.tsx
@@ -333,57 +333,56 @@ export function HomeScreen() {
     (deal) => deal.stalled && deal.status === "open",
   );
 
+  // The three sections are independent surfaces: a transient approvals or
+  // deals failure must never hide a healthy /brief queue (and vice versa),
+  // so each renders under its own gate.
   return (
     <div className="wrap narrow">
       <SectionHeader title={t("home.brief")} sub={t("home.sub")} />
-      <QueryGate query={approvalsQuery}>
-        {(approvals) => (
-          <div>
-            {approvals.data.length > 0 && (
-              <section aria-label={t("home.staged")}>
-                <SectionHeader
-                  title={t("home.staged")}
-                  sub={t("brief.nothingSent")}
-                />
-                {approvals.data.map((approval) => (
-                  <ApprovalRow key={approval.id} approval={approval} />
-                ))}
-              </section>
-            )}
-            <BriefSection />
-            {stalled.length > 0 && (
-              <section aria-label={t("home.stalled")}>
-                <SectionHeader title={t("home.stalled")} />
-                <div
-                  style={{ display: "flex", flexDirection: "column", gap: 8 }}
-                >
-                  {stalled.map((deal) => (
-                    <DealCard
-                      key={deal.id}
-                      deal={{
-                        id: deal.id,
-                        name: deal.name,
-                        org: "",
-                        valueMinor: deal.amount_minor ?? 0,
-                        currency: deal.currency ?? "EUR",
-                        ageMs: Math.max(
-                          0,
-                          Date.now() -
-                            new Date(
-                              deal.last_activity_at ?? deal.created_at,
-                            ).getTime(),
-                        ),
-                        stalled: true,
-                      }}
-                      onOpen={() => navigate({ screen: "deals", id: deal.id })}
-                    />
-                  ))}
-                </div>
-              </section>
-            )}
-          </div>
-        )}
+      <QueryGate query={approvalsQuery} empty={() => false}>
+        {(approvals) =>
+          approvals.data.length > 0 ? (
+            <section aria-label={t("home.staged")}>
+              <SectionHeader
+                title={t("home.staged")}
+                sub={t("brief.nothingSent")}
+              />
+              {approvals.data.map((approval) => (
+                <ApprovalRow key={approval.id} approval={approval} />
+              ))}
+            </section>
+          ) : null
+        }
       </QueryGate>
+      <BriefSection />
+      {stalled.length > 0 && (
+        <section aria-label={t("home.stalled")}>
+          <SectionHeader title={t("home.stalled")} />
+          <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            {stalled.map((deal) => (
+              <DealCard
+                key={deal.id}
+                deal={{
+                  id: deal.id,
+                  name: deal.name,
+                  org: "",
+                  valueMinor: deal.amount_minor ?? 0,
+                  currency: deal.currency ?? "EUR",
+                  ageMs: Math.max(
+                    0,
+                    Date.now() -
+                      new Date(
+                        deal.last_activity_at ?? deal.created_at,
+                      ).getTime(),
+                  ),
+                  stalled: true,
+                }}
+                onOpen={() => navigate({ screen: "deals", id: deal.id })}
+              />
+            ))}
+          </div>
+        </section>
+      )}
     </div>
   );
 }

--- a/frontend/src/screens/home.tsx
+++ b/frontend/src/screens/home.tsx
@@ -1,16 +1,317 @@
-import { useQuery } from "@tanstack/react-query";
+import {
+  type UseQueryResult,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
+import { ArrowRight, Check, RefreshCw, X } from "lucide-react";
 import { api } from "../api/client";
+import type { components } from "../api/schema";
 import { navigate } from "../app/router";
-import { EmptyState, SectionHeader } from "../design-system/atoms";
+import {
+  Badge,
+  Button,
+  Card,
+  EmptyState,
+  SectionHeader,
+} from "../design-system/atoms";
 import { DealCard } from "../design-system/composed";
-import { useT } from "../i18n";
+import { formatDateTime, formatMoney } from "../format/format";
+import { useLocale, useT } from "../i18n";
+import type { MessageKey } from "../i18n/en";
 import { problemMessage, QueryGate } from "./common";
 import { ApprovalRow, usePendingApprovals } from "./inbox";
+import "./home.css";
 
-// Home / Morning Brief (B-EP09.12b): a ranked queue composed from LIVE
-// signals — pending 🟡 approvals first (nothing sent yet; reusing the
-// canonical 12a inline editor), then stalled deals. No signal → an honest
-// quiet state, never invented urgency.
+// Home / Morning Brief (B-EP09.12b on the E05 spine): the persisted /brief
+// run IS the queue — the §10.1 composite with its factor decomposition (no
+// mystery number), evidence-or-omit, per-rep act/dismiss (B-E05.13). Pending
+// 🟡 approvals stay on top (nothing sent yet); stalled deals close the page.
+// No run yet → an honest generate card; an empty run → honest quiet, never
+// invented urgency.
+
+type MorningBrief = components["schemas"]["MorningBrief"];
+type MorningBriefItem = components["schemas"]["MorningBriefItem"];
+
+export function useMorningBrief(): UseQueryResult<MorningBrief | null> {
+  return useQuery({
+    queryKey: ["brief"],
+    queryFn: async (): Promise<MorningBrief | null> => {
+      const { data, error, response } = await api.GET("/brief");
+      if (response.status === 404) {
+        return null;
+      }
+      if (error) {
+        throw new Error(problemMessage(error));
+      }
+      return data ?? null;
+    },
+  });
+}
+
+// The §10.1 factor order is normative (winnability · revenue · timing ·
+// momentum · warmth) — displaying it in that order keeps the decomposition
+// recognizable across surfaces.
+const FACTORS: {
+  key: keyof components["schemas"]["MorningBriefFeatureVector"];
+  label: MessageKey;
+}[] = [
+  { key: "winnability", label: "home.factorWinnability" },
+  { key: "revenue", label: "home.factorRevenue" },
+  { key: "timing", label: "home.factorTiming" },
+  { key: "momentum", label: "home.factorMomentum" },
+  { key: "warmth", label: "home.factorWarmth" },
+];
+
+function FactorBars({
+  vector,
+  itemId,
+}: Readonly<{
+  vector: components["schemas"]["MorningBriefFeatureVector"];
+  itemId: string;
+}>) {
+  const t = useT();
+  return (
+    <div className="brief-factors" title={t("home.why")}>
+      {FACTORS.map((factor) => {
+        const value = Math.max(0, Math.min(1, vector[factor.key]));
+        return (
+          <div className="brief-factor" key={`${itemId}-${factor.key}`}>
+            <span className="brief-factor-label t-caption">
+              {t(factor.label)}
+            </span>
+            <span className="brief-factor-track">
+              <span
+                className="brief-factor-fill"
+                style={{ width: `${Math.round(value * 100)}%` }}
+              />
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function useBriefItemMark(itemId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (mark: "act" | "dismiss") => {
+      const path =
+        mark === "act"
+          ? "/brief/items/{itemId}/act"
+          : "/brief/items/{itemId}/dismiss";
+      const { data, error } = await api.POST(path, {
+        params: { path: { itemId } },
+      });
+      if (error) {
+        throw new Error(problemMessage(error));
+      }
+      return data;
+    },
+    onSuccess: (updated) => {
+      queryClient.setQueryData<MorningBrief | null>(["brief"], (current) =>
+        current
+          ? {
+              ...current,
+              items: current.items.map((item) =>
+                item.id === updated.id ? updated : item,
+              ),
+            }
+          : current,
+      );
+    },
+  });
+}
+
+function BriefItemCard({ item }: Readonly<{ item: MorningBriefItem }>) {
+  const t = useT();
+  const { locale } = useLocale();
+  const mark = useBriefItemMark(item.id);
+  const dealQuery = useQuery({
+    queryKey: ["deal", item.deal_id],
+    queryFn: async () => {
+      const { data, error } = await api.GET("/deals/{id}", {
+        params: { path: { id: item.deal_id } },
+      });
+      if (error) {
+        throw new Error(problemMessage(error));
+      }
+      return data;
+    },
+  });
+
+  const deal = dealQuery.data;
+  const settled = item.state !== "new";
+  const stateLabel: MessageKey =
+    item.state === "acted" ? "home.actedState" : "home.dismissedState";
+
+  return (
+    <article
+      className={`card brief-deal ${settled ? "settled" : ""}`}
+      data-brief-item={item.id}
+    >
+      <div className="brief-deal-head">
+        <span className="brief-rank">#{item.rank}</span>
+        <button
+          type="button"
+          className="brief-deal-name"
+          onClick={() => navigate({ screen: "deals", id: item.deal_id })}
+        >
+          {deal?.name ?? t("home.openDeal")} <ArrowRight aria-hidden />
+        </button>
+        {deal?.amount_minor != null && (
+          <span className="brief-deal-amount">
+            {formatMoney(deal.amount_minor, deal.currency ?? "EUR", locale)}
+          </span>
+        )}
+        <span className="brief-score t-mono">
+          {t("home.score", { pct: Math.round(item.composite * 100) })}
+        </span>
+      </div>
+      <FactorBars vector={item.feature_vector} itemId={item.id} />
+      <div className="brief-deal-foot">
+        <Badge>
+          {item.evidence_ids.length === 1
+            ? t("home.evidenceOne")
+            : t("home.evidence", { count: item.evidence_ids.length })}
+        </Badge>
+        {settled ? (
+          <Badge tone={item.state === "acted" ? "success" : "warn"}>
+            {t(stateLabel)}
+          </Badge>
+        ) : (
+          <span className="brief-deal-actions">
+            <Button
+              small
+              variant="primary"
+              disabled={mark.isPending}
+              onClick={() => mark.mutate("act")}
+            >
+              <Check aria-hidden /> {t("home.act")}
+            </Button>
+            <Button
+              small
+              disabled={mark.isPending}
+              onClick={() => mark.mutate("dismiss")}
+            >
+              <X aria-hidden /> {t("home.dismiss")}
+            </Button>
+          </span>
+        )}
+      </div>
+      {mark.isError && (
+        <p className="t-caption" style={{ color: "var(--danger)" }}>
+          {mark.error instanceof Error ? mark.error.message : null}
+        </p>
+      )}
+    </article>
+  );
+}
+
+function honestCountLine(
+  t: ReturnType<typeof useT>,
+  brief: MorningBrief,
+): string {
+  if (brief.candidate_count > brief.items.length) {
+    return t("home.overflow", {
+      shown: brief.items.length,
+      count: brief.candidate_count,
+    });
+  }
+  return t("home.honestShort", { count: brief.candidate_count });
+}
+
+function BriefSection() {
+  const t = useT();
+  const { locale } = useLocale();
+  const queryClient = useQueryClient();
+  const briefQuery = useMorningBrief();
+
+  const refresh = useMutation({
+    mutationFn: async () => {
+      const { data, error } = await api.POST("/brief");
+      if (error) {
+        throw new Error(problemMessage(error));
+      }
+      return data;
+    },
+    onSuccess: (data) => {
+      queryClient.setQueryData(["brief"], data ?? null);
+    },
+  });
+
+  const refreshButton = (label: MessageKey) => (
+    <Button
+      small
+      disabled={refresh.isPending}
+      onClick={() => refresh.mutate()}
+      data-testid="brief-refresh"
+    >
+      <RefreshCw aria-hidden />{" "}
+      {refresh.isPending ? t("home.refreshing") : t(label)}
+    </Button>
+  );
+
+  return (
+    <section aria-label={t("home.queue")}>
+      <QueryGate query={briefQuery}>
+        {(brief) => {
+          if (brief === null) {
+            return (
+              <Card className="brief-none">
+                <SectionHeader
+                  title={t("home.noneTitle")}
+                  sub={t("home.noneBody")}
+                />
+                {refreshButton("home.generate")}
+                {refresh.isError && (
+                  <p className="t-caption" style={{ color: "var(--danger)" }}>
+                    {refresh.error instanceof Error
+                      ? refresh.error.message
+                      : null}
+                  </p>
+                )}
+              </Card>
+            );
+          }
+          return (
+            <div>
+              <div className="brief-runbar">
+                <SectionHeader
+                  title={t("home.queue")}
+                  sub={t("home.asOf", {
+                    at: formatDateTime(brief.as_of, locale, "Europe/Berlin"),
+                  })}
+                />
+                {refreshButton("home.refresh")}
+              </div>
+              {brief.items.length === 0 ? (
+                <EmptyState>{t("home.quietRun")}</EmptyState>
+              ) : (
+                <div className="brief-list">
+                  {brief.items.map((item) => (
+                    <BriefItemCard key={item.id} item={item} />
+                  ))}
+                  <p className="t-caption brief-honesty">
+                    {honestCountLine(t, brief)}
+                  </p>
+                </div>
+              )}
+              {refresh.isError && (
+                <p className="t-caption" style={{ color: "var(--danger)" }}>
+                  {refresh.error instanceof Error
+                    ? refresh.error.message
+                    : null}
+                </p>
+              )}
+            </div>
+          );
+        }}
+      </QueryGate>
+    </section>
+  );
+}
 
 export function HomeScreen() {
   const t = useT();
@@ -28,65 +329,60 @@ export function HomeScreen() {
     },
   });
 
+  const stalled = (dealsQuery.data?.data ?? []).filter(
+    (deal) => deal.stalled && deal.status === "open",
+  );
+
   return (
     <div className="wrap narrow">
       <SectionHeader title={t("home.brief")} sub={t("home.sub")} />
       <QueryGate query={approvalsQuery}>
-        {(approvals) => {
-          const stalled = (dealsQuery.data?.data ?? []).filter(
-            (deal) => deal.stalled && deal.status === "open",
-          );
-          if (approvals.data.length === 0 && stalled.length === 0) {
-            return <EmptyState>{t("home.quiet")}</EmptyState>;
-          }
-          return (
-            <div>
-              {approvals.data.length > 0 && (
-                <section aria-label={t("home.staged")}>
-                  <SectionHeader
-                    title={t("home.staged")}
-                    sub={t("brief.nothingSent")}
-                  />
-                  {approvals.data.map((approval) => (
-                    <ApprovalRow key={approval.id} approval={approval} />
+        {(approvals) => (
+          <div>
+            {approvals.data.length > 0 && (
+              <section aria-label={t("home.staged")}>
+                <SectionHeader
+                  title={t("home.staged")}
+                  sub={t("brief.nothingSent")}
+                />
+                {approvals.data.map((approval) => (
+                  <ApprovalRow key={approval.id} approval={approval} />
+                ))}
+              </section>
+            )}
+            <BriefSection />
+            {stalled.length > 0 && (
+              <section aria-label={t("home.stalled")}>
+                <SectionHeader title={t("home.stalled")} />
+                <div
+                  style={{ display: "flex", flexDirection: "column", gap: 8 }}
+                >
+                  {stalled.map((deal) => (
+                    <DealCard
+                      key={deal.id}
+                      deal={{
+                        id: deal.id,
+                        name: deal.name,
+                        org: "",
+                        valueMinor: deal.amount_minor ?? 0,
+                        currency: deal.currency ?? "EUR",
+                        ageMs: Math.max(
+                          0,
+                          Date.now() -
+                            new Date(
+                              deal.last_activity_at ?? deal.created_at,
+                            ).getTime(),
+                        ),
+                        stalled: true,
+                      }}
+                      onOpen={() => navigate({ screen: "deals", id: deal.id })}
+                    />
                   ))}
-                </section>
-              )}
-              {stalled.length > 0 && (
-                <section aria-label={t("home.stalled")}>
-                  <SectionHeader title={t("home.stalled")} />
-                  <div
-                    style={{ display: "flex", flexDirection: "column", gap: 8 }}
-                  >
-                    {stalled.map((deal) => (
-                      <DealCard
-                        key={deal.id}
-                        deal={{
-                          id: deal.id,
-                          name: deal.name,
-                          org: "",
-                          valueMinor: deal.amount_minor ?? 0,
-                          currency: deal.currency ?? "EUR",
-                          ageMs: Math.max(
-                            0,
-                            Date.now() -
-                              new Date(
-                                deal.last_activity_at ?? deal.created_at,
-                              ).getTime(),
-                          ),
-                          stalled: true,
-                        }}
-                        onOpen={() =>
-                          navigate({ screen: "deals", id: deal.id })
-                        }
-                      />
-                    ))}
-                  </div>
-                </section>
-              )}
-            </div>
-          );
-        }}
+                </div>
+              </section>
+            )}
+          </div>
+        )}
       </QueryGate>
     </div>
   );

--- a/frontend/src/screens/inbox.test.tsx
+++ b/frontend/src/screens/inbox.test.tsx
@@ -82,6 +82,10 @@ function inboxBackend(calls: { url: string; body: unknown }[]) {
     if (url.includes("/approvals")) {
       return jsonResponse({ data: [approval], page: { next_cursor: null } });
     }
+    if (url.includes("/brief")) {
+      // no run persisted yet — home renders the honest generate card
+      return jsonResponse({ title: "Not Found" }, 404);
+    }
     return jsonResponse({ data: [], page: { next_cursor: null } });
   });
 }
@@ -139,19 +143,20 @@ describe("HomeScreen (B-EP09.12b)", () => {
     expect(screen.getByText("Nothing sent yet")).toBeTruthy();
   });
 
-  it("renders the honest quiet state when nothing is staged or stalled", async () => {
+  it("renders the honest generate card when no brief run exists yet", async () => {
     vi.stubGlobal(
       "fetch",
-      vi.fn(async () =>
-        jsonResponse({ data: [], page: { next_cursor: null } }),
-      ),
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input instanceof Request ? input.url : input);
+        if (url.includes("/brief")) {
+          return jsonResponse({ title: "Not Found" }, 404);
+        }
+        return jsonResponse({ data: [], page: { next_cursor: null } });
+      }),
     );
     render(<HomeScreen />);
-    await waitFor(() =>
-      expect(
-        screen.getByText("All quiet. Nothing staged, nothing stalled."),
-      ).toBeTruthy(),
-    );
+    await waitFor(() => expect(screen.getByText("No brief yet")).toBeTruthy());
+    expect(screen.getByText("Generate my first brief")).toBeTruthy();
   });
 });
 

--- a/frontend/src/screens/onboarding.test.tsx
+++ b/frontend/src/screens/onboarding.test.tsx
@@ -1,0 +1,118 @@
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  cleanup,
+  render as rtlRender,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { LocaleProvider } from "../i18n";
+import { OnboardingScreen } from "./onboarding";
+
+// Onboarding honesty pins: cold-start fields render HUMAN labels (never raw
+// snake_case keys), and the step-4 results tell the truth about a skipped
+// voice step — the neutral-starter copy, not "drafts sound like you", with
+// the canned sample draft visibly tagged as an illustrative example.
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  window.location.hash = "";
+});
+
+beforeEach(() => {
+  vi.stubGlobal("scrollTo", vi.fn());
+});
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function render(ui: ReactNode) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return rtlRender(
+    <QueryClientProvider client={client}>
+      <LocaleProvider initial="en">{ui}</LocaleProvider>
+    </QueryClientProvider>,
+  );
+}
+
+const coldstart = {
+  fields: [
+    {
+      field: "legal_name",
+      value: "Gradion",
+      evidence_snippet: "© 2026 Gradion",
+      source_url: "https://gradion.com",
+      confidence: 0.9,
+    },
+    {
+      field: "registered_address",
+      value: "Munich",
+      evidence_snippet: "Europe Munich",
+      source_url: "https://gradion.com",
+      confidence: 0.8,
+    },
+  ],
+};
+
+async function readBusiness() {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => jsonResponse(coldstart)),
+  );
+  render(<OnboardingScreen />);
+  await userEvent.type(
+    screen.getByRole("textbox", { name: "Website" }),
+    "gradion.com",
+  );
+  await userEvent.click(
+    screen.getByRole("button", { name: /Read my business/ }),
+  );
+  await waitFor(() => expect(screen.getByText("Company name")).toBeTruthy());
+}
+
+describe("cold-start read-back labels", () => {
+  it("renders the human label for every returned field, never the raw key", async () => {
+    await readBusiness();
+    expect(screen.getByText("Company name")).toBeTruthy();
+    expect(screen.getByText("Registered address")).toBeTruthy();
+    expect(screen.queryByText("legal_name")).toBeNull();
+    expect(screen.queryByText("registered_address")).toBeNull();
+  });
+
+  it("carries the same human labels into the editable confirm step", async () => {
+    await readBusiness();
+    await userEvent.click(screen.getByRole("button", { name: /Continue/ }));
+    expect(screen.getByLabelText(/Company name/)).toBeTruthy();
+    expect(screen.getByLabelText(/Registered address/)).toBeTruthy();
+  });
+});
+
+describe("step-4 honesty about the voice step", () => {
+  it("a skipped voice step gets the neutral-starter copy and the example tag — not 'sounds like you'", async () => {
+    await readBusiness();
+    await userEvent.click(screen.getByRole("button", { name: /Continue/ }));
+    await userEvent.click(screen.getByRole("button", { name: /Continue/ }));
+    // now on step 3 (voice) — skip it
+    await userEvent.click(
+      screen.getByRole("button", { name: "Skip this step" }),
+    );
+    expect(screen.getByText(/You skipped the voice step/)).toBeTruthy();
+    expect(
+      screen.queryByText(/Drafts will sound like you from day one/),
+    ).toBeNull();
+    expect(screen.getByText("A sample draft")).toBeTruthy();
+    expect(
+      screen.getByText(/Illustrative example — not written from your data/),
+    ).toBeTruthy();
+  });
+});

--- a/frontend/src/screens/onboarding.tsx
+++ b/frontend/src/screens/onboarding.tsx
@@ -28,6 +28,7 @@ import {
 import {
   type ChangeEvent,
   type ReactNode,
+  useEffect,
   useMemo,
   useRef,
   useState,
@@ -708,12 +709,25 @@ function VoiceStep({
 
   const quality = corpusQuality(corpus.total);
 
+  // The modelling beat must die with the step: a timer surviving unmount
+  // would flip the parent's voiceBuilt after the user navigated away and
+  // make step 4 claim a voice that was never built.
+  const buildTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(
+    () => () => {
+      if (buildTimer.current !== null) {
+        globalThis.clearTimeout(buildTimer.current);
+      }
+    },
+    [],
+  );
+
   const build = () => {
     setBuilding(true);
     // A short modelling beat, then the starter-voice card. This is a starter
     // preview built from the corpus you selected — it sharpens for real once
     // sent email is ingested at connect (see the footnote copy).
-    globalThis.setTimeout(() => {
+    buildTimer.current = globalThis.setTimeout(() => {
       setBuilding(false);
       setBuilt(true);
       onBuilt();

--- a/frontend/src/screens/onboarding.tsx
+++ b/frontend/src/screens/onboarding.tsx
@@ -107,6 +107,27 @@ function deriveName(host: string): string {
   return titled || host;
 }
 
+// The cold-start field vocabulary (compose/enrichextract.go) rendered as
+// human labels; an unmapped field falls back to its key with the underscores
+// spaced out — readable, never raw snake_case.
+const COLD_FIELD_LABELS: Record<string, MessageKey> = {
+  icp: "ob.field.icp",
+  buying_center: "ob.field.buying_center",
+  value_proposition: "ob.field.value_proposition",
+  usp: "ob.field.usp",
+  buying_intents: "ob.field.buying_intents",
+  legal_name: "ob.field.legal_name",
+  registered_address: "ob.field.registered_address",
+  register_vat: "ob.field.register_vat",
+  industry: "ob.field.industry",
+  history: "ob.field.history",
+};
+
+function coldFieldLabel(field: string, t: (key: MessageKey) => string): string {
+  const key = COLD_FIELD_LABELS[field];
+  return key ? t(key) : field.replace(/_/g, " ");
+}
+
 function stepState(index: number, current: number): "done" | "active" | "" {
   if (index < current) {
     return "done";
@@ -141,6 +162,7 @@ export function OnboardingScreen() {
   const [url, setUrl] = useState("");
   const [readData, setReadData] = useState<ColdStart | null>(null);
   const [host, setHost] = useState("");
+  const [voiceBuilt, setVoiceBuilt] = useState(false);
 
   const norm = useMemo(() => normalizeUrl(url), [url]);
   const company = host ? deriveName(host) : "";
@@ -223,8 +245,12 @@ export function OnboardingScreen() {
           />
         )}
         {step === 1 && <ConfirmStep readData={readData} />}
-        {step === 2 && <VoiceStep company={company} />}
-        {step === 3 && <ResultsStep company={company} />}
+        {step === 2 && (
+          <VoiceStep company={company} onBuilt={() => setVoiceBuilt(true)} />
+        )}
+        {step === 3 && (
+          <ResultsStep company={company} voiceBuilt={voiceBuilt} />
+        )}
         {step === 4 && <ConnectStep />}
 
         <Footer step={step} canContinue={readData !== null} go={go} />
@@ -413,7 +439,7 @@ function ReadStep({
             return (
               <div key={f.field} className="rfield">
                 <div className="rfhead">
-                  <span className="rflabel">{f.field}</span>
+                  <span className="rflabel">{coldFieldLabel(f.field, t)}</span>
                   {level && <ConfidenceMeter level={level} />}
                   <span className="rfprov">
                     <Bot aria-hidden /> {t("ob.readFromSite")}
@@ -506,7 +532,7 @@ function ConfirmStep({ readData }: Readonly<{ readData: ColdStart | null }>) {
             return (
               <div key={f.field} className="ob-field">
                 <label htmlFor={`s2-${f.field}`}>
-                  {f.field}{" "}
+                  {coldFieldLabel(f.field, t)}{" "}
                   {dirty && <ProvenanceTag provenance={{ kind: "human" }} />}
                 </label>
                 <textarea
@@ -614,7 +640,10 @@ const SOURCES: Source[] = [
 const ACCEPTED_CORPUS_FILE = /\.(txt|md|vtt|srt|json)$/i;
 const ACCEPTED_CORPUS_ATTR = ".txt,.md,.vtt,.srt,.json";
 
-function VoiceStep({ company }: Readonly<{ company: string }>) {
+function VoiceStep({
+  company,
+  onBuilt,
+}: Readonly<{ company: string; onBuilt: () => void }>) {
   const t = useT();
   const [optedIn, setOptedIn] = useState(false);
   const [added, setAdded] = useState<Set<string>>(new Set());
@@ -687,6 +716,7 @@ function VoiceStep({ company }: Readonly<{ company: string }>) {
     globalThis.setTimeout(() => {
       setBuilding(false);
       setBuilt(true);
+      onBuilt();
     }, 1100);
   };
 
@@ -931,13 +961,25 @@ function VoiceStep({ company }: Readonly<{ company: string }>) {
 
 // ---- step 4: results -------------------------------------------------------
 
-function ResultsStep({ company }: Readonly<{ company: string }>) {
+function ResultsStep({
+  company,
+  voiceBuilt,
+}: Readonly<{ company: string; voiceBuilt: boolean }>) {
   const t = useT();
+  // The cards tell the truth about what the funnel actually did: a skipped
+  // voice step gets the honest "starter voice" card, not a claim that drafts
+  // already sound like the user.
   const cards: { title: MessageKey; body: MessageKey }[] = [
     { title: "ob.s4.cardProfile", body: "ob.s4.cardProfileBody" },
-    { title: "ob.s4.cardVoice", body: "ob.s4.cardVoiceBody" },
+    {
+      title: "ob.s4.cardVoice",
+      body: voiceBuilt ? "ob.s4.cardVoiceBody" : "ob.s4.cardVoiceSkippedBody",
+    },
     { title: "ob.s4.cardPipeline", body: "ob.s4.cardPipelineBody" },
-    { title: "ob.s4.cardDraft", body: "ob.s4.cardDraftBody" },
+    {
+      title: voiceBuilt ? "ob.s4.cardDraft" : "ob.s4.cardDraftExample",
+      body: "ob.s4.cardDraftBody",
+    },
   ];
   return (
     <section className="ob-panel">
@@ -962,6 +1004,9 @@ function ResultsStep({ company }: Readonly<{ company: string }>) {
       <div className="draftbox" style={{ marginTop: 12 }}>
         {t("ob.s4.draftSample", { company: company || "your prospect" })}
       </div>
+      <p className="t-small" style={{ marginTop: 8, fontStyle: "italic" }}>
+        {t("ob.s4.exampleTag")}
+      </p>
       <div className="omit" style={{ marginTop: 16, borderStyle: "solid" }}>
         <GitBranch aria-hidden />
         <div>

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -14,6 +14,7 @@ sonar.organization=gradion
 #   backend/tools/gen-evals/**  eval fixture data — literals read better than constants
 #   backend/web/static/**   legacy embedded SPA, being replaced by frontend/
 #   dev/**                  local-dev scripts + throwaway creds (clears the dev.sh secrets:S6698)
+#   frontend/src/api/schema.d.ts  openapi-typescript output (pnpm gen:api)
 sonar.exclusions=\
   backend/internal/contracts/**,\
   **/*_gen.go,\
@@ -22,7 +23,25 @@ sonar.exclusions=\
   .claude/**,\
   backend/tools/gen-evals/**,\
   backend/web/static/**,\
-  dev/**
+  dev/**,\
+  frontend/src/api/schema.d.ts
+
+# --- Test code: measured for issues, exempt from coverage/duplication metrics ---
+sonar.test.inclusions=\
+  **/*_test.go,\
+  frontend/src/**/*.test.ts,\
+  frontend/src/**/*.test.tsx,\
+  frontend/e2e/**
+
+# --- Coverage: reports produced by the CI sonarcloud job before the scan ---
+sonar.go.coverage.reportPaths=backend/coverage.out
+sonar.javascript.lcov.reportPaths=frontend/coverage/lcov.info
+# Entry points and build config have no meaningful unit-test surface.
+sonar.coverage.exclusions=\
+  backend/cmd/**,\
+  frontend/src/main.tsx,\
+  frontend/vite.config.ts,\
+  frontend/playwright.config.ts
 
 # --- Targeted rule tuning (files stay analyzed for every other rule) ---
 sonar.issue.ignore.multicriteria=e1,e2

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@
 # narrows the quality signal to hand-written product code — not generated
 # files, append-only DDL, vendored tooling, or test scaffolding.
 sonar.projectKey=gradionhq_margince-poc-v1
-sonar.organization=gradionhq
+sonar.organization=gradion
 
 # --- Exclusions: never analyze code we do not hand-write / do not own ---
 #   internal/contracts/**   OpenAPI-generated types + server interface (make gen)

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -33,6 +33,13 @@ sonar.test.inclusions=\
   frontend/src/**/*.test.tsx,\
   frontend/e2e/**
 
+# --- Copy-paste detection: the two i18n catalogs mirror each other's key
+# structure BY DESIGN (exact parity is compile- and test-enforced), so CPD
+# cross-matches them wholesale. Parallel translations are not duplication.
+sonar.cpd.exclusions=\
+  frontend/src/i18n/en.ts,\
+  frontend/src/i18n/de.ts
+
 # --- Coverage: reports produced by the CI sonarcloud job before the scan ---
 sonar.go.coverage.reportPaths=backend/coverage.out
 sonar.javascript.lcov.reportPaths=frontend/coverage/lcov.info


### PR DESCRIPTION
## What

- **Home = the real Morning Brief.** The home screen now renders the persisted `/brief` run (B-EP09.12b on the E05 spine): honest no-run generate card (404 is a state, not an error), `POST /brief` refresh, ranked items with the §10.1 factor decomposition rendered as bars (no mystery number), evidence counts, and B-E05.13 act/dismiss marks that update in place — settled items recede, never vanish mid-morning. Honest-short footer states the candidate count; an empty run renders quiet. Pending 🟡 approvals stay on top; stalled deals close the page.
- **Onboarding polish + honesty.** Cold-start fields render human labels (DE/EN) instead of raw snake_case keys (`LEGAL_NAME` → "Firmenname"). Step 4 tells the truth about a skipped voice step (neutral starter voice — not "drafts sound like you"), and the canned sample draft is tagged as an illustrative example, not user data.
- `frontend/src/api/schema.d.ts` regenerated from `backend/api/crm.yaml` (`pnpm gen:api` — picks up /brief, offers, signals, views et al). Generated file; review the rest of the diff.

## Verification

- Driven end-to-end in a real browser against the live backend: signup → cold-start read of a real site (real model) → 5-step funnel → generate brief over real deals → act/dismiss round-trip.
- `make frontend-check` green (lint + 94 unit tests + build); `make frontend-e2e` 35/35 (seed mock gained a coherent /brief run so the axe/390px sweeps exercise the new home).
- New `home.test.tsx`: ranked-run rendering, 404→generate flow, act-in-place, honest empty run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Morning Brief” home experience with ranked queue, factor breakdown bars, refresh/generate flow, and per-item act/dismiss actions.
  * Enhanced onboarding with clearer localized field labels and improved step-4 results messaging for voice-built vs voice-skipped flows (including updated example tagging).
* **Bug Fixes**
  * Improved empty-state handling: shows “No brief yet” on missing briefs and an “honest quiet” message when there are zero candidates, avoiding implied urgency.
  * Brief item actions now correctly update the visible item state.
* **Tests / Chores**
  * Added home/onboarding/unit coverage and expanded Playwright brief API mocks; updated i18n catalogs and styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->