### PR TITLE
feat(frontend): company-360 enrichment — the EP05 scrape verb gets its surface

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -172,6 +172,16 @@ export const de = {
   "home.factorMomentum": "Momentum",
   "home.factorWarmth": "Wärme",
 
+  "enrich.title": "Von der Website lesen",
+  "enrich.sub":
+    "belegt oder weggelassen — füllt nur leere Felder, und nur nach deiner Freigabe",
+  "enrich.cta": "Jetzt lesen",
+  "enrich.reading": "Liest…",
+  "enrich.staged":
+    "Vorgemerkt — noch nichts geschrieben. Übernimm es im Eingang; nur leere Felder werden gefüllt.",
+  "enrich.toInbox": "Eingang öffnen",
+  "enrich.from": "gelesen von {url}",
+
   "create.cancel": "Abbrechen",
   "create.save": "Anlegen",
   "create.saving": "Wird angelegt…",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -169,6 +169,16 @@ export const en = {
   "home.factorMomentum": "Momentum",
   "home.factorWarmth": "Warmth",
 
+  "enrich.title": "Read from the website",
+  "enrich.sub":
+    "evidence-or-omit — fills only empty fields, and only after your approval",
+  "enrich.cta": "Read now",
+  "enrich.reading": "Reading…",
+  "enrich.staged":
+    "Staged — nothing written yet. Accept it in your inbox; only empty fields fill.",
+  "enrich.toInbox": "Open inbox",
+  "enrich.from": "read from {url}",
+
   "create.cancel": "Cancel",
   "create.save": "Create",
   "create.saving": "Creating…",

--- a/frontend/src/screens/common.tsx
+++ b/frontend/src/screens/common.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import { Button, EmptyState, Skeleton } from "../design-system/atoms";
 import type { Provenance } from "../design-system/trust";
 import { useT } from "../i18n";
+import type { MessageKey } from "../i18n/en";
 
 // Shared screen plumbing: honest loading / error / empty states (§3a screen-
 // state matrix) and the captured_by → provenance mapping every list reuses.
@@ -67,4 +68,28 @@ export function problemMessage(problem: unknown): string {
     }
   }
   return "request failed";
+}
+
+// The cold-start / enrichment field vocabulary (compose/enrichextract.go)
+// rendered as human labels; an unmapped field falls back to its key with the
+// underscores spaced out — readable, never raw snake_case.
+const COLD_FIELD_LABELS: Record<string, MessageKey> = {
+  icp: "ob.field.icp",
+  buying_center: "ob.field.buying_center",
+  value_proposition: "ob.field.value_proposition",
+  usp: "ob.field.usp",
+  buying_intents: "ob.field.buying_intents",
+  legal_name: "ob.field.legal_name",
+  registered_address: "ob.field.registered_address",
+  register_vat: "ob.field.register_vat",
+  industry: "ob.field.industry",
+  history: "ob.field.history",
+};
+
+export function coldFieldLabel(
+  field: string,
+  t: (key: MessageKey) => string,
+): string {
+  const key = COLD_FIELD_LABELS[field];
+  return key ? t(key) : field.replace(/_/g, " ");
 }

--- a/frontend/src/screens/onboarding.tsx
+++ b/frontend/src/screens/onboarding.tsx
@@ -43,7 +43,7 @@ import {
 } from "../design-system/trust";
 import { useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
-import { problemMessage } from "./common";
+import { coldFieldLabel, problemMessage } from "./common";
 import { confidenceLevel } from "./inbox";
 import "./onboarding.css";
 
@@ -106,27 +106,6 @@ function deriveName(host: string): string {
     .map((w) => w[0]?.toUpperCase() + w.slice(1))
     .join(" ");
   return titled || host;
-}
-
-// The cold-start field vocabulary (compose/enrichextract.go) rendered as
-// human labels; an unmapped field falls back to its key with the underscores
-// spaced out — readable, never raw snake_case.
-const COLD_FIELD_LABELS: Record<string, MessageKey> = {
-  icp: "ob.field.icp",
-  buying_center: "ob.field.buying_center",
-  value_proposition: "ob.field.value_proposition",
-  usp: "ob.field.usp",
-  buying_intents: "ob.field.buying_intents",
-  legal_name: "ob.field.legal_name",
-  registered_address: "ob.field.registered_address",
-  register_vat: "ob.field.register_vat",
-  industry: "ob.field.industry",
-  history: "ob.field.history",
-};
-
-function coldFieldLabel(field: string, t: (key: MessageKey) => string): string {
-  const key = COLD_FIELD_LABELS[field];
-  return key ? t(key) : field.replace(/_/g, " ");
 }
 
 function stepState(index: number, current: number): "done" | "active" | "" {

--- a/frontend/src/screens/organizations.test.tsx
+++ b/frontend/src/screens/organizations.test.tsx
@@ -1,0 +1,131 @@
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  cleanup,
+  render as rtlRender,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { LocaleProvider } from "../i18n";
+import { CompanyScreen } from "./organizations";
+
+// Company-360 enrichment (EP05 scrapeCompany): one click stages a 🟡
+// evidence-backed proposal — human field labels, per-field confidence +
+// evidence, the confirm-first banner (nothing written until the inbox
+// accept), and honest 422 degradation with the server's detail verbatim.
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  window.location.hash = "";
+});
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function render(ui: ReactNode) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return rtlRender(
+    <QueryClientProvider client={client}>
+      <LocaleProvider initial="en">{ui}</LocaleProvider>
+    </QueryClientProvider>,
+  );
+}
+
+const org = {
+  id: "o-1",
+  workspace_id: "w",
+  display_name: "Brandt Automotive GmbH",
+  industry: "Automotive",
+  captured_by: "human:u1",
+  source: "manual",
+  version: 1,
+  created_at: "2026-06-01T08:00:00Z",
+  updated_at: "2026-06-01T08:00:00Z",
+};
+
+const proposal = {
+  proposal_id: "pr-1",
+  organization_id: "o-1",
+  source_url: "https://brandt.example",
+  status: "staged",
+  fields: [
+    {
+      field: "value_proposition",
+      value: "Fleet retrofits without downtime",
+      evidence_snippet: "We retrofit fleets without downtime",
+      source_url: "https://brandt.example",
+      confidence: 0.85,
+    },
+  ],
+};
+
+function stubApi(enrich: () => Response) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = input instanceof Request ? input : null;
+      const url = new URL(
+        request ? request.url : String(input),
+        "https://test.local",
+      );
+      const method = request?.method ?? init?.method ?? "GET";
+      if (method === "POST" && url.pathname.endsWith("/enrich")) {
+        return enrich();
+      }
+      if (url.pathname.endsWith("/organizations/o-1")) {
+        return jsonResponse(org);
+      }
+      return jsonResponse({ data: [], page: { next_cursor: null } });
+    }),
+  );
+}
+
+describe("company-360 enrichment", () => {
+  it("stages an evidence-backed proposal: human labels, confidence, confirm-first banner", async () => {
+    stubApi(() => jsonResponse(proposal));
+    render(<CompanyScreen id="o-1" />);
+    await waitFor(() =>
+      expect(screen.getByText("Brandt Automotive GmbH")).toBeTruthy(),
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Read now" }));
+    await waitFor(() =>
+      expect(screen.getByText("Value proposition")).toBeTruthy(),
+    );
+    expect(screen.queryByText("value_proposition")).toBeNull();
+    expect(screen.getByText("Fleet retrofits without downtime")).toBeTruthy();
+    expect(screen.getByText(/Staged — nothing written yet/)).toBeTruthy();
+    expect(screen.getByText(/read from https:\/\/brandt.example/)).toBeTruthy();
+  });
+
+  it("renders the honest 422 detail when the page is unreadable", async () => {
+    stubApi(() =>
+      jsonResponse(
+        {
+          title: "Unprocessable",
+          detail: "the organization has no domain to read",
+        },
+        422,
+      ),
+    );
+    render(<CompanyScreen id="o-1" />);
+    await waitFor(() =>
+      expect(screen.getByText("Brandt Automotive GmbH")).toBeTruthy(),
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Read now" }));
+    await waitFor(() =>
+      expect(
+        screen.getByText("the organization has no domain to read"),
+      ).toBeTruthy(),
+    );
+  });
+});

--- a/frontend/src/screens/organizations.tsx
+++ b/frontend/src/screens/organizations.tsx
@@ -1,13 +1,29 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { navigate } from "../app/router";
-import { Badge, DataTable, SectionHeader } from "../design-system/atoms";
+import {
+  Badge,
+  Button,
+  DataTable,
+  SectionHeader,
+} from "../design-system/atoms";
 import { RecordView } from "../design-system/composed";
-import { ProvenanceTag } from "../design-system/trust";
+import {
+  AutonomyDot,
+  ConfidenceMeter,
+  EvidenceChip,
+  ProvenanceTag,
+} from "../design-system/trust";
 import { useT } from "../i18n";
-import { problemMessage, provenanceOf, QueryGate } from "./common";
+import {
+  coldFieldLabel,
+  problemMessage,
+  provenanceOf,
+  QueryGate,
+} from "./common";
 import { CreateAction } from "./create";
+import { confidenceLevel } from "./inbox";
 import { activityTimeline } from "./people";
 
 // Companies list + company 360 (B-EP09.10a/b). Firmographics render
@@ -112,6 +128,97 @@ export function CompaniesScreen() {
   );
 }
 
+// The EP05 enrich verb on the company 360: one click reads the org's own
+// website through the cold-start fetch + no-guess gate and STAGES a 🟡
+// proposal — every rendered field carries evidence + confidence or was
+// omitted, and nothing writes until the human accepts it in the inbox
+// (accept fills only EMPTY fields).
+function EnrichCard({ orgId }: Readonly<{ orgId: string }>) {
+  const t = useT();
+  const enrich = useMutation({
+    mutationFn: async () => {
+      const { data, error } = await api.POST("/organizations/{id}/enrich", {
+        params: { path: { id: orgId } },
+      });
+      if (error) {
+        throw new Error(problemMessage(error));
+      }
+      return data;
+    },
+  });
+
+  return (
+    <section className="card" style={{ marginBottom: 16 }}>
+      <div className="list-head">
+        <SectionHeader title={t("enrich.title")} sub={t("enrich.sub")} />
+        <Button
+          small
+          disabled={enrich.isPending}
+          onClick={() => enrich.mutate()}
+        >
+          {enrich.isPending ? t("enrich.reading") : t("enrich.cta")}
+        </Button>
+      </div>
+      {enrich.isError && (
+        <p className="t-caption" style={{ color: "var(--danger)" }}>
+          {enrich.error instanceof Error ? enrich.error.message : null}
+        </p>
+      )}
+      {enrich.data && (
+        <div>
+          <p
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+              flexWrap: "wrap",
+              margin: "6px 0 12px",
+            }}
+          >
+            <AutonomyDot tier="confirm" />
+            <span className="t-small">{t("enrich.staged")}</span>
+            <Button small onClick={() => navigate({ screen: "inbox" })}>
+              {t("enrich.toInbox")}
+            </Button>
+          </p>
+          <p className="t-caption" style={{ marginBottom: 10 }}>
+            {t("enrich.from", { url: enrich.data.source_url })}
+          </p>
+          {enrich.data.fields.map((field) => {
+            const level = confidenceLevel(field.confidence);
+            return (
+              <div key={field.field} style={{ marginBottom: 12 }}>
+                <div
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 8,
+                    marginBottom: 3,
+                  }}
+                >
+                  <span className="t-label">
+                    {coldFieldLabel(field.field, t)}
+                  </span>
+                  {level && <ConfidenceMeter level={level} />}
+                </div>
+                <div>{field.value}</div>
+                {field.evidence_snippet && (
+                  <EvidenceChip
+                    evidence={{
+                      snippet: field.evidence_snippet,
+                      source: field.source_url ?? "",
+                    }}
+                  />
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </section>
+  );
+}
+
 export function CompanyScreen({ id }: Readonly<{ id: string }>) {
   const t = useT();
   const orgQuery = useQuery({
@@ -189,6 +296,7 @@ export function CompanyScreen({ id }: Readonly<{ id: string }>) {
                 )}
               </dl>
             </section>
+            <EnrichCard orgId={org.id} />
           </RecordView>
         )}
       </QueryGate>


### PR DESCRIPTION
**Stacked on #15 → #14.** Retarget as the stack merges.

## What

The company 360 gains a **"Read from the website"** card driving `POST /organizations/{id}/enrich` (EP05 scrapeCompany, built backend-side long ago but never surfaced): one click reads the org's own site through the cold-start fetch + no-guess gate and renders the staged 🟡 proposal — human field labels, per-field confidence + evidence snippets, the confirm-first banner (nothing written until the inbox accept, which fills only **empty** fields), honest 422 with the server's detail verbatim.

`coldFieldLabel` moves from onboarding to `common.tsx` now that the 360 is its second caller.

## Verification

- Live browser run: real-model read of gradion.com from the company 360 → staged evidence-backed proposal rendered (confidence dots, evidence chip, inbox link).
- `make frontend-check` green; 2 new unit tests (proposal rendering + honest 422).

🤖 Generated with [Claude Code](https://claude.com/claude-code)