### PR TITLE
feat(frontend): log a note or task from the 360 screens

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -203,6 +203,17 @@ export const de = {
   "create.organization": "Firma",
   "create.expectedClose": "Erwarteter Abschluss",
 
+  "log.title": "Aktivität erfassen",
+  "log.sub": "eine Notiz oder Aufgabe, direkt auf diese Timeline",
+  "log.kind": "Art",
+  "log.kindNote": "Notiz",
+  "log.kindTask": "Aufgabe",
+  "log.subject": "Betreff",
+  "log.body": "Details",
+  "log.dueAt": "Fällig am",
+  "log.save": "Erfassen",
+  "log.saving": "Wird erfasst…",
+
   "tasks.overdue": "Überfällig",
   "tasks.today": "Heute",
   "tasks.upcoming": "Demnächst",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -200,6 +200,17 @@ export const en = {
   "create.organization": "Company",
   "create.expectedClose": "Expected close",
 
+  "log.title": "Log activity",
+  "log.sub": "a note or task, straight onto this timeline",
+  "log.kind": "Type",
+  "log.kindNote": "Note",
+  "log.kindTask": "Task",
+  "log.subject": "Subject",
+  "log.body": "Details",
+  "log.dueAt": "Due date",
+  "log.save": "Log",
+  "log.saving": "Logging…",
+
   "tasks.overdue": "Overdue",
   "tasks.today": "Today",
   "tasks.upcoming": "Upcoming",

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -23,6 +23,7 @@ import { formatDate, formatMoney } from "../format/format";
 import { useLocale, useT } from "../i18n";
 import { problemMessage, QueryGate } from "./common";
 import { CreateAction } from "./create";
+import { LogActivity } from "./logactivity";
 import { activityTimeline } from "./people";
 
 // Deal surfaces (B-EP09.11a/b/c): the five-stage Kanban with drag-to-advance
@@ -702,6 +703,7 @@ export function DealScreen({ id }: Readonly<{ id: string }>) {
                     </div>
                   </section>
                 )}
+              <LogActivity entityType="deal" entityId={deal.id} />
             </RecordView>
           );
         }}

--- a/frontend/src/screens/logactivity.test.tsx
+++ b/frontend/src/screens/logactivity.test.tsx
@@ -1,0 +1,195 @@
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  cleanup,
+  render as rtlRender,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { LocaleProvider } from "../i18n";
+import { LogActivity } from "./logactivity";
+import { PersonScreen } from "./people";
+
+// Logging from a 360 (the "you can actually add to the timeline" acceptance):
+// the POST body carries the contract's shape (kind, subject, the viewed
+// record as the link, source stamped manual), a success refetches the
+// screen's activities query, a 422 renders its RFC 7807 detail verbatim, and
+// the due-date input exists only for a task.
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function render(ui: ReactNode) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return rtlRender(
+    <QueryClientProvider client={client}>
+      <LocaleProvider initial="en">{ui}</LocaleProvider>
+    </QueryClientProvider>,
+  );
+}
+
+const emptyPage = { data: [], page: { next_cursor: null } };
+
+type Captured = { key: string; body: unknown };
+
+function stubApi(
+  routes: Record<string, (body: unknown) => Response>,
+  captured?: Captured[],
+) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = input instanceof Request ? input : null;
+      const url = new URL(
+        request ? request.url : String(input),
+        "https://test.local",
+      );
+      const method = request?.method ?? init?.method ?? "GET";
+      const key = `${method} ${url.pathname.replace(/^\/v1/, "")}`;
+      let body: unknown = null;
+      if (method !== "GET") {
+        try {
+          body = request
+            ? await request.json()
+            : JSON.parse(String(init?.body));
+        } catch {
+          body = null;
+        }
+      }
+      captured?.push({ key, body });
+      const handler = routes[key];
+      return handler ? handler(body) : jsonResponse(emptyPage);
+    }),
+  );
+}
+
+const person = {
+  id: "p1",
+  workspace_id: "w",
+  full_name: "Petra Muster",
+  captured_by: "human:u1",
+  source: "manual",
+  version: 1,
+  created_at: "2026-07-06T08:00:00Z",
+  updated_at: "2026-07-06T08:00:00Z",
+};
+
+const createdActivity = (body: unknown) =>
+  jsonResponse(
+    {
+      id: "a-new",
+      workspace_id: "w",
+      kind: (body as { kind: string }).kind,
+      subject: (body as { subject: string }).subject,
+      occurred_at: "2026-07-06T09:00:00Z",
+      captured_by: "human:u1",
+      source: "manual",
+      version: 1,
+      created_at: "2026-07-06T09:00:00Z",
+      updated_at: "2026-07-06T09:00:00Z",
+    },
+    201,
+  );
+
+describe("log activity from a 360", () => {
+  it("posts a note linked to the viewed person and refetches the timeline", async () => {
+    const captured: Captured[] = [];
+    stubApi(
+      {
+        "GET /people/p1": () => jsonResponse(person),
+        "POST /activities": createdActivity,
+      },
+      captured,
+    );
+    render(<PersonScreen id="p1" />);
+    await userEvent.type(
+      await screen.findByLabelText("Subject *"),
+      "Call recap",
+    );
+    await userEvent.type(screen.getByLabelText("Details"), "Agreed next step");
+    await userEvent.click(screen.getByRole("button", { name: "Log" }));
+
+    await waitFor(() =>
+      expect(captured.some((entry) => entry.key === "POST /activities")).toBe(
+        true,
+      ),
+    );
+    const post = captured.find((entry) => entry.key === "POST /activities");
+    expect(post?.body).toMatchObject({
+      kind: "note",
+      subject: "Call recap",
+      body: "Agreed next step",
+      links: [{ entity_type: "person", entity_id: "p1" }],
+      source: "manual",
+    });
+    const { occurred_at } = post?.body as { occurred_at: string };
+    expect(occurred_at).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+    // the invalidation refetches the timeline the screen already loaded once
+    await waitFor(() =>
+      expect(
+        captured.filter((entry) => entry.key === "GET /activities").length,
+      ).toBeGreaterThanOrEqual(2),
+    );
+    // a successful log clears the draft for the next entry
+    expect((screen.getByLabelText("Subject *") as HTMLInputElement).value).toBe(
+      "",
+    );
+  });
+
+  it("renders the server's 422 detail verbatim", async () => {
+    stubApi({
+      "POST /activities": () =>
+        jsonResponse(
+          { title: "Unprocessable", detail: "subject must not be blank" },
+          422,
+        ),
+    });
+    render(<LogActivity entityType="deal" entityId="d1" />);
+    await userEvent.type(screen.getByLabelText("Subject *"), "x");
+    await userEvent.click(screen.getByRole("button", { name: "Log" }));
+    await waitFor(() =>
+      expect(screen.getByText("subject must not be blank")).toBeTruthy(),
+    );
+  });
+
+  it("reveals the due-date input only for a task and posts due_at", async () => {
+    const captured: Captured[] = [];
+    stubApi({ "POST /activities": createdActivity }, captured);
+    render(<LogActivity entityType="organization" entityId="o1" />);
+    expect(screen.queryByLabelText("Due date")).toBeNull();
+    await userEvent.selectOptions(screen.getByLabelText("Type"), "task");
+    await userEvent.type(screen.getByLabelText("Due date"), "2026-07-10");
+    await userEvent.type(screen.getByLabelText("Subject *"), "Send proposal");
+    await userEvent.click(screen.getByRole("button", { name: "Log" }));
+    await waitFor(() =>
+      expect(captured.some((entry) => entry.key === "POST /activities")).toBe(
+        true,
+      ),
+    );
+    const post = captured.find((entry) => entry.key === "POST /activities");
+    expect(post?.body).toMatchObject({
+      kind: "task",
+      subject: "Send proposal",
+      links: [{ entity_type: "organization", entity_id: "o1" }],
+      source: "manual",
+    });
+    const { due_at } = post?.body as { due_at: string };
+    expect(new Date(due_at).toISOString()).toBe(
+      new Date("2026-07-10").toISOString(),
+    );
+  });
+});

--- a/frontend/src/screens/logactivity.tsx
+++ b/frontend/src/screens/logactivity.tsx
@@ -1,0 +1,155 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useId, useState } from "react";
+import { api } from "../api/client";
+import { Button, SectionHeader, TextInput } from "../design-system/atoms";
+import { useT } from "../i18n";
+import { problemMessage } from "./common";
+
+// Log a note or task from a 360 (person/company/deal): the contract's
+// logActivity POST, linked to the record being viewed, occurred_at stamped
+// at submit, source=manual. On success the screen's timeline query is
+// invalidated so the fresh entry appears without a reload. Server-side
+// validation is the truth — a 422 renders its RFC 7807 detail verbatim.
+
+export type LinkedEntityType = "person" | "organization" | "deal";
+
+type ActivityDraft = {
+  kind: "note" | "task";
+  subject: string;
+  body: string;
+  // yyyy-mm-dd from the date input; only a task carries a due date.
+  dueAt: string;
+};
+
+const EMPTY_DRAFT: ActivityDraft = {
+  kind: "note",
+  subject: "",
+  body: "",
+  dueAt: "",
+};
+
+export function LogActivity({
+  entityType,
+  entityId,
+}: Readonly<{ entityType: LinkedEntityType; entityId: string }>) {
+  const t = useT();
+  const formId = useId();
+  const queryClient = useQueryClient();
+  const [draft, setDraft] = useState<ActivityDraft>(EMPTY_DRAFT);
+
+  const log = useMutation({
+    mutationFn: async (input: ActivityDraft) => {
+      const { data, error } = await api.POST("/activities", {
+        body: {
+          kind: input.kind,
+          subject: input.subject.trim(),
+          body: input.body.trim() || null,
+          occurred_at: new Date().toISOString(),
+          ...(input.kind === "task" && input.dueAt
+            ? { due_at: new Date(input.dueAt).toISOString() }
+            : {}),
+          links: [{ entity_type: entityType, entity_id: entityId }],
+          source: "manual",
+        },
+      });
+      if (error) {
+        throw new Error(problemMessage(error));
+      }
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["activities", entityType, entityId],
+      });
+      setDraft(EMPTY_DRAFT);
+    },
+  });
+
+  const setField = (patch: Partial<ActivityDraft>) =>
+    setDraft((current) => ({ ...current, ...patch }));
+
+  return (
+    <section className="card" style={{ marginBottom: 16 }}>
+      <SectionHeader title={t("log.title")} sub={t("log.sub")} />
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          log.mutate(draft);
+        }}
+        style={{ display: "flex", flexDirection: "column", gap: 10 }}
+      >
+        <div style={{ display: "flex", gap: 10 }}>
+          <div className="field">
+            <label className="t-label" htmlFor={`${formId}-kind`}>
+              {t("log.kind")}
+            </label>
+            <select
+              id={`${formId}-kind`}
+              className="input"
+              value={draft.kind}
+              onChange={(event) =>
+                setField({
+                  kind: event.target.value === "task" ? "task" : "note",
+                })
+              }
+            >
+              <option value="note">{t("log.kindNote")}</option>
+              <option value="task">{t("log.kindTask")}</option>
+            </select>
+          </div>
+          {draft.kind === "task" && (
+            <div className="field">
+              <label className="t-label" htmlFor={`${formId}-due`}>
+                {t("log.dueAt")}
+              </label>
+              <TextInput
+                id={`${formId}-due`}
+                type="date"
+                value={draft.dueAt}
+                onChange={(event) => setField({ dueAt: event.target.value })}
+              />
+            </div>
+          )}
+        </div>
+        <div className="field">
+          <label className="t-label" htmlFor={`${formId}-subject`}>
+            {t("log.subject")} *
+          </label>
+          <TextInput
+            id={`${formId}-subject`}
+            value={draft.subject}
+            required
+            onChange={(event) => setField({ subject: event.target.value })}
+          />
+        </div>
+        <div className="field">
+          <label className="t-label" htmlFor={`${formId}-body`}>
+            {t("log.body")}
+          </label>
+          <textarea
+            id={`${formId}-body`}
+            className="textarea"
+            rows={3}
+            value={draft.body}
+            onChange={(event) => setField({ body: event.target.value })}
+          />
+        </div>
+        {log.isError && (
+          <p className="t-caption" style={{ color: "var(--danger)" }}>
+            {log.error.message}
+          </p>
+        )}
+        <div style={{ display: "flex", justifyContent: "flex-end" }}>
+          <Button
+            small
+            variant="primary"
+            type="submit"
+            disabled={log.isPending || !draft.subject.trim()}
+          >
+            {log.isPending ? t("log.saving") : t("log.save")}
+          </Button>
+        </div>
+      </form>
+    </section>
+  );
+}

--- a/frontend/src/screens/organizations.tsx
+++ b/frontend/src/screens/organizations.tsx
@@ -24,6 +24,7 @@ import {
 } from "./common";
 import { CreateAction } from "./create";
 import { confidenceLevel } from "./inbox";
+import { LogActivity } from "./logactivity";
 import { activityTimeline } from "./people";
 
 // Companies list + company 360 (B-EP09.10a/b). Firmographics render
@@ -297,6 +298,7 @@ export function CompanyScreen({ id }: Readonly<{ id: string }>) {
               </dl>
             </section>
             <EnrichCard orgId={org.id} />
+            <LogActivity entityType="organization" entityId={org.id} />
           </RecordView>
         )}
       </QueryGate>

--- a/frontend/src/screens/people.tsx
+++ b/frontend/src/screens/people.tsx
@@ -8,6 +8,7 @@ import { ProvenanceTag } from "../design-system/trust";
 import { useT } from "../i18n";
 import { problemMessage, provenanceOf, QueryGate } from "./common";
 import { CreateAction } from "./create";
+import { LogActivity } from "./logactivity";
 
 // Contacts list + person 360 (B-EP09.10a/b). Every row carries its
 // provenance chip (captured_by is server truth); the 360 renders the
@@ -220,6 +221,7 @@ export function PersonScreen({ id }: Readonly<{ id: string }>) {
                 </div>
               </section>
             )}
+            <LogActivity entityType="person" entityId={person.id} />
           </RecordView>
         )}
       </QueryGate>


### PR DESCRIPTION
**Stacked on #17 → #15 → #14.** Retarget as the stack merges.

## What

The person/company/deal 360s render a timeline but had no way to feed it from the UI. A shared `LogActivity` card now sits above the timeline on all three: kind select (note|task), subject, body, task-only due date → `POST /activities` (operationId `logActivity`) with `links: [{entity_type, entity_id}]` and `source: manual`; on success the timeline query invalidates and refetches. RFC 7807 detail renders verbatim on failure.

## Verification

- 104 unit tests green (3 new: POST body + timeline refetch, verbatim 422, task-only due-date reveal); `make frontend-check` green.
- Built by a sandboxed build agent from the generated contract types; the task fields (`due_at`, `remind_at`) are top-level on `CreateActivityRequest`, matching the contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)