### PR TITLE
legal: counsel-redlined BUSL-1.1 parameters + PR process docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,29 @@ api, worker, and mcp take `--log-level` (debug|info|warn|error) and
 default. The full flag/env table:
 [docs/reference/configuration.md](docs/reference/configuration.md).
 
+## Shipping a change (branch → local gates → PR → green → merge)
+
+Every commit lands through this loop — code, docs, and config alike.
+Direct pushes to `main` are blocked by branch protection; there is no
+other path to merge.
+
+1. **Branch off `main`**: `git switch -c <type>/<slug> origin/main`.
+2. **Sign off every commit** (`git commit -s`) — the DCO gate rejects a
+   PR containing any commit without a `Signed-off-by` trailer.
+3. **Local gates BEFORE pushing**: `make check` (the merge gate — build,
+   vet, lint, arch-lint, unit tests, contract drift); add
+   `make frontend-check` when `frontend/` changed. The pre-push hook
+   (installed once via `make hooks`) runs `craft static` diff-scoped on
+   top — a BLOCKER finding stops the push; fix it, never bypass the hook.
+4. **Push the branch and open a PR** (`gh pr create`).
+5. **Watch the GitHub gates and fix red**: CI, DCO, CodeRabbit, and
+   SonarCloud must all pass (`gh pr checks <n> --watch`). Fix failures
+   locally, re-run the local gates, push again; address CodeRabbit
+   findings rather than dismissing them.
+6. **Merge only when everything is green** (squash is the house style:
+   `gh pr merge <n> --squash`), then delete the branch. Never merge over
+   a red or still-running check.
+
 ## Layout (spec ADR-0054/A69 as amended; see decisions/0011)
 
 The `backend/internal/{modules,platform,shared}` triad — the DAG is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,29 @@ api, worker, and mcp take `--log-level` (debug|info|warn|error) and
 default. The full flag/env table:
 [docs/reference/configuration.md](docs/reference/configuration.md).
 
+## Shipping a change (branch → local gates → PR → green → merge)
+
+Every commit lands through this loop — code, docs, and config alike.
+Direct pushes to `main` are blocked by branch protection; there is no
+other path to merge.
+
+1. **Branch off `main`**: `git switch -c <type>/<slug> origin/main`.
+2. **Sign off every commit** (`git commit -s`) — the DCO gate rejects a
+   PR containing any commit without a `Signed-off-by` trailer.
+3. **Local gates BEFORE pushing**: `make check` (the merge gate — build,
+   vet, lint, arch-lint, unit tests, contract drift); add
+   `make frontend-check` when `frontend/` changed. The pre-push hook
+   (installed once via `make hooks`) runs `craft static` diff-scoped on
+   top — a BLOCKER finding stops the push; fix it, never bypass the hook.
+4. **Push the branch and open a PR** (`gh pr create`).
+5. **Watch the GitHub gates and fix red**: CI, DCO, CodeRabbit, and
+   SonarCloud must all pass (`gh pr checks <n> --watch`). Fix failures
+   locally, re-run the local gates, push again; address CodeRabbit
+   findings rather than dismissing them.
+6. **Merge only when everything is green** (squash is the house style:
+   `gh pr merge <n> --squash`), then delete the branch. Never merge over
+   a red or still-running check.
+
 ## Layout (spec ADR-0054/A69 as amended; see decisions/0011)
 
 The `backend/internal/{modules,platform,shared}` triad — the DAG is

--- a/LICENSE
+++ b/LICENSE
@@ -7,10 +7,11 @@ License text copyright (c) 2017 MariaDB Corporation Ab, All Rights Reserved.
 
 Parameters
 
-Licensor:             Gradion (https://gradion.com)
+Licensor:             Gradion Pte. Ltd. (Singapore)
+                      https://gradion.com
 
 Licensed Work:        Margince CRM
-                      The Licensed Work is (c) 2026 Gradion
+                      The Licensed Work is (c) 2026 Gradion Pte. Ltd.
 
 Additional Use Grant: You may make production use of the Licensed Work,
                       provided that the total number of Seats authorized to
@@ -39,17 +40,22 @@ Additional Use Grant: You may make production use of the Licensed Work,
                       contact, lead, or customer whose data is stored in the
                       Licensed Work) who have no provisioned access to operate
                       it. "Affiliate" means any entity that controls, is
-                      controlled by, or is under common control with you;
-                      Seats are aggregated across Affiliates. "Authorized
-                      Hosting Partner" means a third party that has entered
-                      into the Licensor's written partner/hosting agreement.
+                      controlled by, or is under common control with you,
+                      where "control" means direct or indirect ownership of
+                      more than fifty percent (50%) of the voting securities
+                      or other ownership interests of an entity, or the
+                      right to direct its management, whether by contract
+                      or otherwise; Seats are aggregated across Affiliates.
+                      "Authorized Hosting Partner" means a third party that
+                      has entered into the Licensor's written
+                      partner/hosting agreement.
 
 Change Date:          2028-07-04
 
 Change License:       Apache License, Version 2.0
 
 For information about alternative licensing arrangements for the Licensed
-Work, please contact Gradion (https://gradion.com).
+Work, please contact Gradion Pte. Ltd. (https://gradion.com).
 
 -----------------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -306,8 +306,8 @@ future work in this repo (mirrored in [AGENTS.md](AGENTS.md)):
 ## License
 
 **Business Source License 1.1** (`BUSL-1.1`) — see [LICENSE](LICENSE). Licensor:
-Gradion. Source-available, **not** OSI open source: the full source is public and
-free to read, run, and modify.
+Gradion Pte. Ltd. (Singapore). Source-available, **not** OSI open source: the full
+source is public and free to read, run, and modify.
 
 - **Free** for your own internal production use up to **10 Seats** (a Seat is an
   identified person with credentials; AI agents, service accounts, and external
@@ -321,5 +321,6 @@ free to read, run, and modify.
 The Additional Use Grant fills only BUSL's parameter fields; the license body is
 the verbatim canonical text, so SPDX/GitHub detect it as `BUSL-1.1`. The full
 model, rationale, and enforcement design live in the spec's
-[`business/12-license.md`](../margince/specs/business/12-license.md). The exact
-Additional Use Grant wording is **provisional pending counsel** (12-license.md §10).
+[`business/12-license.md`](../margince/specs/business/12-license.md). Each tagged
+release restamps the Change Date to its publication date + 2 years — the rule is
+[docs/reference/license-release-rule.md](docs/reference/license-release-rule.md).

--- a/docs/reference/license-release-rule.md
+++ b/docs/reference/license-release-rule.md
@@ -1,0 +1,48 @@
+# LICENSE release rule — Change Date stamping
+
+**Owner:** Legal (Hà Trần Minh) | **Executed by:** whoever cuts a release
+**Ratified:** 2026-07-05 | **Canonical copy:** the spec's
+`business/licensing/CHANGE-DATE-release-rule.md`
+
+## The rule
+
+On **every tagged release**, before the tag is published, update the LICENSE
+Parameters block — and nothing else in the file:
+
+1. **Change Date** = the release's publication date **+ 2 years**, ISO format
+   (`YYYY-MM-DD`).
+2. The **Licensed Work** line gains the version identifier, e.g.
+   `Licensed Work: Margince CRM v1.3.0`.
+
+Everything from the first `---` separator after the Parameters block to the end
+of the file is the canonical BUSL-1.1 body and must never be edited
+(BUSL Covenant 4).
+
+## What counts as a "Release"
+
+A **Release** is a version tagged and published via a git tag / GitHub Release.
+Individual commits and branch pushes are **not** releases and do not carry their
+own Change Date. The BUSL body applies "separately for each version of the
+Licensed Work and the Change Date may vary for each version" — this rule is how
+we exercise that mechanism.
+
+## Why this is load-bearing
+
+- The README publicly promises every release converts to Apache 2.0 two years
+  after it ships. A stale hard-coded date breaks that promise in one of two
+  directions: later releases convert **earlier** than two years (giving away the
+  commercial window), and any release still carrying a past date is Apache 2.0
+  **immediately**.
+- If a release ships without the update, the BUSL body's four-year backstop
+  applies to that version — legally safe, commercially wrong, and publicly
+  inconsistent with the README.
+
+## Enforcement (to implement with the first release pipeline)
+
+Add a CI gate on tag creation: fail the release if `Change Date` in LICENSE ≠
+tag date + 2 years, or if the diff touches anything below the Parameters block.
+
+## Current state
+
+The version first published **2026-07-04** correctly carries
+`Change Date: 2028-07-04`. No action needed until the next tagged release.


### PR DESCRIPTION
## What

- **LICENSE**: adopt the four Parameters-block-only edits from in-house counsel's redline memo (2026-07-05, issued 2026-07-07): Licensor/copyright/contact lines name the legal entity **Gradion Pte. Ltd. (Singapore)**, and the Affiliate definition gains the market-standard **50%-ownership "control" test** (closes the seat-splitting loophole).
- **README** consequential fixes per the memo appendix, same commit as the LICENSE swap: Licensor line updated; the "provisional pending counsel" sentence removed — the Additional Use Grant wording is final.
- **docs/reference/license-release-rule.md**: the legal Change-Date stamping rule — every tagged release restamps `Change Date` = publication date + 2 years and versions the Licensed Work line; a CI gate on tags is the recommended enforcement (not yet implemented, only matters at the first tagged release).
- **CLAUDE.md / AGENTS.md**: document the shipping loop for every commit — branch → local gates (`make check` + craft pre-push hook) → PR → watch GitHub gates, fix red → squash-merge on green.

## Verification

- Diffed old vs new LICENSE: every changed line is inside the Parameters block; the BUSL-1.1 body is **byte-identical** (Covenant 4 intact, SPDX/GitHub detection unaffected).
- Change Date stays 2028-07-04 — correct for the version first published 2026-07-04.
- `make check` green locally.

Counterpart spec-repo PR records the counsel sign-off in `business/12-license.md` and lands the ratified text + memos under `business/licensing/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clearer release workflow guidance for shipping changes from branch creation through checks, PR review, and merge.
  * Added a new release rule for tagged versions, including how license dates are updated and what must not be edited.
  * Updated licensing notices in the README and license text to reflect the current company name and release terms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->