### PR TITLE
chore: skeleton-baseline PR B — compose dev stack, API-driven demo seed, verify-boot, README quickstart, live-boot CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,6 +250,55 @@ jobs:
         if: ${{ env.SONAR_TOKEN == '' }}
         run: echo "SONAR_TOKEN not set; skipping CI scan (Automatic Analysis still active). Add the secret to activate."
 
+  # The README quickstart, run literally: compose up → migrate → api →
+  # seed-dev → verify-boot. This is what keeps the compose file, the
+  # API-driven seed, and the boot proof honest — the integration job's
+  # GH service containers would stay green even if the compose stack or
+  # the seed script rotted.
+  live-boot:
+    name: live-boot (compose + seed + verify)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: .
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        with:
+          go-version-file: backend/go.mod
+          cache-dependency-path: backend/go.sum
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+        with:
+          version: 11
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: frontend/pnpm-lock.yaml
+      - name: Boot the dev stack and migrate
+        run: make db-up && make migrate
+      - name: Start the api
+        working-directory: backend
+        env:
+          MARGINCE_ENV: dev
+        run: |
+          go run ./cmd/api --dsn "postgres://margince_app:margince_app_dev@localhost:55432/margince" \
+            > "$RUNNER_TEMP/api.log" 2>&1 &
+          for _ in $(seq 1 60); do
+            curl -fsS http://localhost:8080/readyz >/dev/null 2>&1 && exit 0
+            sleep 1
+          done
+          echo "api never became ready" >&2
+          cat "$RUNNER_TEMP/api.log" >&2
+          exit 1
+      - name: Seed the demo workspace
+        run: make seed-dev
+      - name: Verify boot
+        run: make verify-boot
+      - name: API log (on failure)
+        if: failure()
+        run: cat "$RUNNER_TEMP/api.log" || true
+
   # The frontend lane: Biome, Vitest, TypeScript, and the Vite production
   # build. The root Makefile promises CI runs both lanes; this is that lane.
   frontend:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # The frontend lane is separate (`make frontend-check`) — it needs node+pnpm,
 # which not every backend machine has; CI runs both.
 
-.PHONY: check build test test-integration bench-perf lint arch-lint vet gen drift db-up db-init migrate dev dev-tls clean eval tools frontend-check frontend-dev frontend-e2e craft-static craft-residue craft-drift craft-sync check-image-pins hooks
+.PHONY: check build test test-integration bench-perf lint arch-lint vet gen drift db-up db-init migrate dev dev-tls clean eval tools seed-dev seed-reset verify-boot frontend-check frontend-dev frontend-e2e craft-static craft-residue craft-drift craft-sync check-image-pins hooks
 
 check: craft-drift check-image-pins
 
@@ -14,8 +14,21 @@ check: craft-drift check-image-pins
 dev-tls:
 	./dev/dev.sh
 
-check build test test-integration bench-perf lint arch-lint vet gen drift db-up db-init migrate dev clean tools:
+check build test test-integration bench-perf lint arch-lint vet gen drift db-up db-init seed-reset migrate dev clean tools:
 	$(MAKE) -C backend $@
+
+## seed-dev — create/refresh the demo workspace (demo-workspace,
+## admin@demo.test / demo-password-123) through the public API. Pure
+## client: the stack must be running (make dev). Idempotent; re-runs
+## log in instead of re-bootstrapping.
+seed-dev:
+	./scripts/seed-dev.sh
+
+## verify-boot — prove a running, seeded stack end to end: seeded-admin
+## login, seeded people visible over /v1, frontend production build.
+## Pure client (make dev + make seed-dev first); fails loudly, never skips.
+verify-boot:
+	./scripts/verify-boot.sh
 
 ## eval — run the golden-dataset gates verbosely (they also run, quietly,
 ## inside `make check`'s unit lane — that is the hard gate).

--- a/README.md
+++ b/README.md
@@ -57,22 +57,45 @@ Everything below this line is for people (and agents) working on the code.
 
 ## Quick start
 
+**Boot it** (Docker Compose stack — Postgres 16 + Redis 7 — plus
+migrations and the api on :8080):
+
 ```
-make db-up && make migrate && make dev
+make dev
 ```
 
-Toolchain: Go ≥ 1.26, Docker (Postgres 16 + Redis 7 test containers),
-and `golangci-lint`. `make -C backend help` lists every target;
-`make -C backend hooks` installs the pre-commit hook (gofmt + the
-license-header gate). A step-by-step walkthrough and the full flag/env
-reference live in [docs/](docs/) (tutorials, how-to, reference,
-explanation — see below).
+**Log in.** In a second terminal, seed the demo workspace and open
+http://localhost:8080 — the embedded web UI (people, the deal board,
+the timeline):
 
-Then open http://localhost:8080 — the embedded web UI (bootstrap a
-workspace, people, the deal board, the timeline). It is a hash-routed,
-dependency-free SPA served from the binary (`backend/web/`), and a plain
-client of the same `/v1` contract as everything else — no backdoors
-(ADR-0013).
+```
+make seed-dev
+```
+
+Workspace `demo-workspace`, sign in as `admin@demo.test` /
+`demo-password-123` (dev-only credentials). The seed goes through the
+public API — same audit trail, same events as real traffic — and is
+idempotent; `make seed-reset` wipes the demo workspace for a clean
+re-seed.
+
+**Verify** the whole thing end to end (seeded-admin login over `/v1`,
+seeded people visible, frontend production build — fails loudly on the
+first broken step):
+
+```
+make verify-boot
+```
+
+Toolchain: Go ≥ 1.26, Docker (Compose), `jq`, `golangci-lint`, and
+node+pnpm for the frontend lane. `make -C backend help` lists every
+target; `make -C backend hooks` installs the pre-commit hook (gofmt +
+the license-header gate). A step-by-step walkthrough and the full
+flag/env reference live in [docs/](docs/) (tutorials, how-to,
+reference, explanation — see below).
+
+The embedded web UI is a hash-routed, dependency-free SPA served from
+the binary (`backend/web/`), and a plain client of the same `/v1`
+contract as everything else — no backdoors (ADR-0013).
 
 Connect an agent (Surface A1): mint a passport (`POST /v1/passports`,
 session-authed), then

--- a/STATUS.md
+++ b/STATUS.md
@@ -5,6 +5,62 @@
 > [AGENTS.md](AGENTS.md) for the binding rules. Update this file at the
 > end of every working session.
 
+## ▶ RESTART HERE (2026-07-09 — skeleton-baseline PR A + PR B: gates hardened, dev experience landed)
+
+Working docs/worklists/skeleton-baseline-2026-07-09.md (poc-v1 → official
+OSS baseline; §0 provenance there is the map):
+
+**PR A merged (#28, squash `a9d912e`) — the mechanical §1a batch:**
+`make craft-sync` to craft v3 (upstream's committed manifest is stale at
+its own HEAD, so the vendored copy was restamped locally — do NOT re-run
+`craft-sync` until the foundation restamps; see
+`feedback/2026-07-09-skeleton-craft-manifest-stale.md`), every workflow
+action SHA-pinned + the fail-closed `scripts/check-image-pins.sh` gate
+(root `make check` prerequisite AND a CI step — any new action must be
+SHA-pinned or the merge gate fails), `concurrency:` cancel-in-progress
+groups (main never cancelled), `.env.template` (this repo's real env
+surface only), `make tools` bootstrap (golangci-lint/go-arch-lint/
+govulncheck at their pins), `config/ai-routing.example.yaml` rewritten to
+our schema + a fitness test, and Go 1.26.5 for GO-2026-5856. Two upstream
+defects documented in `feedback/` (stale craft manifest; pins-script
+denylist + `*.yml`-only glob) — fixing them lives in the foundation repo,
+never by editing `cli/craft` here.
+
+**PR B — the §4.3 dev-experience batch (this session):**
+`infra/docker-compose.dev.yml` (pgvector/pg16 + redis:7, named volume,
+healthchecks; ports 55432/56379 and the margince_owner/db-init.sql role
+contract unchanged, so MARGINCE_TEST_* and CI keep working; MinIO
+commented-out pending the §1c blobstore ADR) with `make db-up/db-init/
+clean` rewired onto compose as the ONE path; the demo-workspace seed
+harness — `make seed-dev` drives the PUBLIC API (bootstrap is a
+cross-module tx, role policies are compiled-in Go, Argon2id passwords,
+and SQL would bypass the audit+outbox write shape), idempotent via
+natural-key 409s, bootstraps only when login fails so the 3/hour limiter
+is never burned on a re-run; `make seed-reset`
+(`scripts/seed-reset.sql`, dynamic over `workspace_id` tables, demo
+workspace only); `make verify-boot` (`scripts/verify-boot.sh`: seeded
+login → seeded people over /v1 → frontend production build; fails
+loudly); the README "boot / log in / verify" quickstart; and the
+`live-boot` CI job running that quickstart literally. Demo credentials
+(stable convention): workspace `demo-workspace`, `admin@demo.test` /
+`demo-password-123`. Verified locally end-to-end: fresh compose boot →
+migrate → seed → verify green → reset → verify fails loudly → re-seed →
+green.
+
+**Follow-ups spotted, not done here:** (1) `POST /v1/auth/login` against
+a nonexistent workspace answers 500 (`pg: no workspace bound to
+context`) instead of 401 — pre-existing identity-module wart, fix +
+test it separately; (2) decide whether `live-boot` becomes a required
+check (branch protection + `infra/branch-protection.json` together)
+after a few stable runs; (3) compose images ride the same floating tags
+as CI's service containers — digest-pinning both is PR C material.
+
+**Next in the worklist sequencing (§4):** PR C gate parity (oasdiff
+breaking gate, TS-type drift, test-lanes, zero-skip, golangci
+`new-from-rev`, file-length ratchet), PR D frontend, PR E OSS packaging,
+plus the §1c/§1d DECISION items (blobstore, keyvault, River, Storybook,
+Forge DS, second SPA).
+
 ## ▶ RESTART HERE (2026-07-08 PM — spec-drift reconciliation MERGED; feedback processed)
 
 **PR #23 merged** (squash `487d625`, all gates incl. Sonar green): the

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -17,7 +17,7 @@ export MARGINCE_ENV          ?= dev
 
 .DEFAULT_GOAL := help
 
-.PHONY: help check build test test-integration lint arch-lint vet gen drift db-up db-init migrate dev clean vuln tools hooks
+.PHONY: help check build test test-integration lint arch-lint vet gen drift db-up db-init seed-reset migrate dev clean vuln tools hooks
 
 help: ## List targets with their descriptions (the default goal)
 	@grep -hE '^[a-zA-Z][a-zA-Z0-9_-]*:.*## ' $(MAKEFILE_LIST) | awk -F':.*## ' '{printf "  %-18s %s\n", $$1, $$2}'
@@ -94,16 +94,21 @@ tools: ## Install every gate binary at its pinned version (fresh-machine bootstr
 hooks: ## Install the repo pre-commit hook (gofmt + license-header gate)
 	install -m 0755 ../scripts/pre-commit "$$(git rev-parse --git-path hooks)/pre-commit"
 
-db-up: ## Start PG16 + Redis 7 containers and create the app role
-	docker start fable-pg16 2>/dev/null || \
-	  docker run -d --name fable-pg16 -e POSTGRES_USER=margince_owner -e POSTGRES_PASSWORD=dev \
-	    -e POSTGRES_DB=$(DB_NAME) -p $(PG_PORT):5432 pgvector/pgvector:pg16
-	docker start fable-redis 2>/dev/null || \
-	  docker run -d --name fable-redis -p $(REDIS_PORT):6379 redis:7
-	@until docker exec fable-pg16 pg_isready -U margince_owner -q; do sleep 0.5; done
+# The ONE path to dev infrastructure: the compose stack. Pre-compose
+# sessions hand-ran `fable-pg16`/`fable-redis` containers on the same host
+# ports; db-up removes those legacy names so the stack can bind (their data
+# is throwaway — migrate + seed-dev rebuild it).
+COMPOSE ?= docker compose -f ../infra/docker-compose.dev.yml
+
+db-up: ## Start the dev stack (infra/docker-compose.dev.yml) and create the app role
+	@docker rm -f fable-pg16 fable-redis 2>/dev/null || true
+	$(COMPOSE) up -d --wait
 	$(MAKE) db-init
 db-init: ## (Re)apply scripts/db-init.sql to the running Postgres
-	docker exec -i fable-pg16 psql -U margince_owner -d $(DB_NAME) < ../scripts/db-init.sql
+	$(COMPOSE) exec -T postgres psql -U margince_owner -d $(DB_NAME) -v ON_ERROR_STOP=1 < ../scripts/db-init.sql
+
+seed-reset: ## Wipe the demo workspace (scripts/seed-reset.sql); make seed-dev rebuilds it
+	$(COMPOSE) exec -T postgres psql -U margince_owner -d $(DB_NAME) -v ON_ERROR_STOP=1 < ../scripts/seed-reset.sql
 
 migrate: ## Apply core + custom migrations (owner DSN)
 	$(GO) run ./cmd/migrate up --dsn "$(OWNER_DSN)"
@@ -111,5 +116,6 @@ migrate: ## Apply core + custom migrations (owner DSN)
 dev: db-up migrate ## db-up + migrate + api on :8080
 	$(GO) run ./cmd/api --dsn "$(APP_DSN)"
 
-clean: ## Remove the dev Postgres/Redis containers
-	docker rm -f fable-pg16 fable-redis 2>/dev/null || true
+clean: ## Tear down the dev stack, containers and data volumes
+	$(COMPOSE) down --volumes --remove-orphans
+	@docker rm -f fable-pg16 fable-redis 2>/dev/null || true

--- a/docs/worklists/skeleton-baseline-2026-07-09.md
+++ b/docs/worklists/skeleton-baseline-2026-07-09.md
@@ -56,11 +56,16 @@ Consequences:
       none; `docs/reference/configuration.md` is the flag table to mirror.
       (Done PR A — this repo's actual env surface only; blobstore/keyvault
       vars wait on their ADRs, §1c.)
-- [ ] **`infra/docker-compose.dev.yml`** — we have *no* compose file;
+- [x] **`infra/docker-compose.dev.yml`** — we have *no* compose file;
       `make db-up` hand-runs containers. Port the skeleton's stack
       (Postgres `pgvector/pgvector:pg16`, `redis:7-alpine`, named volumes).
       MinIO: see 1c (blobstore decision) — include it commented-out or gate
       it on that decision.
+      (Done PR B — this repo's port/role contract kept (55432/56379,
+      margince_owner + scripts/db-init.sql); `make db-up`/`db-init`/`clean`
+      rewired onto compose as the ONE path, legacy `fable-*` containers
+      auto-removed; project name is repo-specific so stale poc-era volumes
+      can't shadow initdb; MinIO commented-out pending the §1c ADR.)
 - [x] **SHA-pin all GitHub Actions** in `.github/workflows/ci.yml` (today
       only the sonar job is SHA-pinned) and add the skeleton's
       `check-image-pins.sh` as a gate so it stays pinned. (Done PR A —
@@ -118,12 +123,24 @@ Skeleton gates we lack entirely (each is a small script; wire into
 
 ### 1c. Backend platform — adopt behind decisions
 
-- [ ] **Seed harness + boot verification** — port `backend/seed/dev.sql`
+- [x] **Seed harness + boot verification** — port `backend/seed/dev.sql`
       (+`reset.sql`) shape and `scripts/verify-boot.sh` (login as seeded
       admin → assert seeded people → FE build). We have programmatic test
       fixtures but no `make seed-dev`, no curl-level boot proof, and our
       demo-workspace bootstrap is manual. This also fixes the documented
       local-run friction (bootstrap rate-limit, MARGINCE_ENV=dev).
+      (Done PR B — deliberately NOT the skeleton's SQL-fixture shape: the
+      seed (`scripts/seed-dev.sh`, `make seed-dev`) drives the public API,
+      because bootstrap is a cross-module transaction, role policies are
+      compiled-in Go documents, passwords are salted Argon2id, and raw SQL
+      would bypass the audit+outbox write shape. Idempotent via the
+      natural-key 409s; only bootstraps when login fails, so re-runs never
+      touch the 3/hour limiter. `scripts/seed-reset.sql` (`make seed-reset`)
+      wipes the demo workspace dynamically over all `workspace_id` tables.
+      `scripts/verify-boot.sh` (`make verify-boot`) proves login + seeded
+      people + FE build against `/v1` (cookie `crm_session`,
+      X-Workspace-Slug). Demo credentials stay the established convention:
+      `demo-workspace` / `admin@demo.test` / `demo-password-123`.)
 - [ ] `DECISION (ADR)` **blobstore** — skeleton has `platform/blobstore`
       (MinIO + memory) and MinIO in compose; we have none, and STATUS lists
       "transcript/blob-storage substrate" as an open arc. Adopting the
@@ -179,10 +196,14 @@ Skeleton FE is a scaffold (1 real page) but with better *infrastructure*:
 
 ### 1e. CI / repo hygiene
 
-- [ ] **Live-boot CI job** (skeleton `skeleton-ci.yml` G0 shape): real
+- [x] **Live-boot CI job** (skeleton `skeleton-ci.yml` G0 shape): real
       docker-compose up → migrate → seed → verify-boot → build. Our CI uses
       GH `services:`; a compose-based boot job additionally proves the
       compose file + seed + boot script stay honest. Add once 1a/1c land.
+      (Done PR B — ci.yml `live-boot` job runs the README quickstart
+      literally. Not yet a required check: adding it to branch protection is
+      a live-settings + `infra/branch-protection.json` change, decide after
+      a few runs prove it stable.)
 - [ ] **Branch-protection deltas** — ours is stricter overall; skeleton has
       nothing we lack here. No action beyond keeping
       `infra/branch-protection.json` mirroring live.
@@ -224,9 +245,10 @@ Before pushing this repo to the official public org:
       skeleton's OSS framing (welcome, A39 disclosure asymmetry,
       `Assisted`/`Generated` AI-disclosure levels) on top of our
       gate/DCO content.
-- [ ] **README** — ours is internal-build-flavored; add the skeleton-style
+- [x] **README** — ours is internal-build-flavored; add the skeleton-style
       "boot it / log in / verify" quickstart (depends on 1a compose +
-      1c seed).
+      1c seed). (Done PR B — the quickstart; the broader
+      internal-flavor scrub stays with PR E.)
 - [ ] **decisions/ + feedback/ audit** — decisions/ is committed history;
       review for private references before public push. `feedback/` is
       git-ignored (fine).

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -1,0 +1,62 @@
+# The dev/test infrastructure stack. `make db-up` brings it up (and applies
+# scripts/db-init.sql on top for the non-owner app role); `make clean` tears
+# it down including data. Ports and credentials are a contract shared with
+# the backend Makefile's MARGINCE_TEST_* defaults, dev/dev.sh, and CI's
+# service containers — change them everywhere or nowhere.
+#
+# Images track the same floating tags CI's service containers use
+# (.github/workflows/ci.yml). The check-image-pins gate covers workflow
+# `uses:` refs; digest-pinning these images rides the PR C gate-parity work.
+#
+# The project name is repo-specific: a generic name (margince-dev) collides
+# with stale volumes from the frozen poc-era stack on machines that ran it,
+# and Postgres skips initdb on a non-empty volume — the owner role would
+# silently never be created.
+name: margince-poc-v1
+
+services:
+  postgres:
+    # pgvector ships inside the Postgres image: the search module's hybrid
+    # retrieval needs the extension available at migrate time.
+    image: pgvector/pgvector:pg16
+    environment:
+      POSTGRES_USER: margince_owner
+      POSTGRES_PASSWORD: dev
+      POSTGRES_DB: margince
+    ports:
+      - "55432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U margince_owner -d margince"]
+      interval: 2s
+      timeout: 5s
+      retries: 15
+
+  redis:
+    image: redis:7
+    ports:
+      - "56379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 2s
+      timeout: 5s
+      retries: 15
+
+  # MinIO (transcript/attachment blob storage) stays out until the blobstore
+  # ADR lands (docs/worklists/skeleton-baseline-2026-07-09.md §1c) — there is
+  # no platform seam to consume it yet. Uncomment together with that ADR.
+  # minio:
+  #   image: minio/minio:latest
+  #   environment:
+  #     MINIO_ROOT_USER: minioadmin
+  #     MINIO_ROOT_PASSWORD: minioadmin
+  #   command: server /data --console-address ":59001"
+  #   ports:
+  #     - "59000:9000"
+  #     - "59001:9001"
+  #   volumes:
+  #     - minio-data:/data
+
+volumes:
+  pgdata: {}

--- a/scripts/seed-dev.sh
+++ b/scripts/seed-dev.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+#
+# seed-dev.sh — create/refresh the demo workspace through the public API.
+#
+# The seed is an API client, not a SQL fixture, on purpose: workspace
+# bootstrap is a cross-module transaction (identity + the role policy
+# documents + the deals pipeline seed + consent defaults), passwords are
+# salted Argon2id, and every record write must commit domain row +
+# audit_log + event_outbox in one transaction. A SQL fixture would
+# duplicate all of that and silently drift from the schema; the API
+# cannot.
+#
+# Pure client: the stack must already be running (`make dev`). Idempotent:
+# a re-run logs in instead of re-bootstrapping, and re-creating a record
+# that already exists answers 409 on its natural key (person email, org
+# domain, deal name checked via list), which counts as "already seeded".
+#
+# POST /v1/workspaces is rate-limited (3/hour/IP, in-memory — an api
+# restart resets it) and its 429 surfaces as "budget exceeded"; this
+# script only bootstraps when login fails, so re-runs never burn an
+# attempt.
+
+set -euo pipefail
+
+API_BASE="${API_BASE:-http://localhost:8080}"
+WORKSPACE_SLUG="${WORKSPACE_SLUG:-demo-workspace}"
+ADMIN_EMAIL="${ADMIN_EMAIL:-admin@demo.test}"
+ADMIN_PASSWORD="${ADMIN_PASSWORD:-demo-password-123}"
+
+command -v jq >/dev/null 2>&1 || { echo "seed-dev: jq is required" >&2; exit 1; }
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+workdir="$(mktemp -d -t seed-dev.XXXXXX)"
+trap 'rm -rf "$workdir"' EXIT
+
+SESSION=""
+
+# The X-Workspace-Slug header resolves the tenant only under
+# MARGINCE_ENV=dev (make dev sets it); prod resolves by subdomain.
+api() { # api <method> <path> [json-body] — prints the HTTP status, body lands in $workdir/body
+  local method="$1" path="$2" data="${3:-}"
+  curl -sS -o "$workdir/body" -D "$workdir/headers" -w '%{http_code}' \
+    -X "$method" "$API_BASE/v1$path" \
+    -H "X-Workspace-Slug: $WORKSPACE_SLUG" \
+    -H 'Content-Type: application/json' \
+    ${SESSION:+--cookie "crm_session=$SESSION"} \
+    ${data:+--data "$data"}
+}
+
+# The session cookie is Secure, which curl's jar refuses to replay over
+# plain-http localhost — so pull the token out and send it explicitly.
+capture_session() {
+  SESSION="$(sed -n 's/^[Ss]et-[Cc]ookie: crm_session=\([^;]*\).*/\1/p' "$workdir/headers" | tr -d '\r')"
+  [ -n "$SESSION" ] || fail "the server answered OK but set no crm_session cookie"
+}
+
+echo "== seed-dev: API reachability =="
+curl -fsS "$API_BASE/readyz" >/dev/null 2>&1 \
+  || fail "$API_BASE/readyz is not answering — start the stack first (make dev)"
+echo "  OK: $API_BASE is up"
+
+echo "== seed-dev: demo workspace ($WORKSPACE_SLUG) =="
+status="$(api POST /auth/login "$(jq -n --arg e "$ADMIN_EMAIL" --arg p "$ADMIN_PASSWORD" '{email:$e,password:$p}')")"
+case "$status" in
+  200)
+    capture_session
+    echo "  OK: workspace exists, logged in as $ADMIN_EMAIL"
+    ;;
+  *)
+    # No login → bootstrap. slugify("Demo Workspace") is exactly the
+    # demo-workspace slug the login above and verify-boot.sh assume.
+    status="$(api POST /workspaces "$(jq -n --arg e "$ADMIN_EMAIL" --arg p "$ADMIN_PASSWORD" \
+      '{workspace_name:"Demo Workspace",admin_email:$e,admin_password:$p,admin_display_name:"Demo Admin"}')")"
+    case "$status" in
+      201)
+        capture_session
+        echo "  OK: bootstrapped workspace + admin $ADMIN_EMAIL"
+        ;;
+      429)
+        fail "workspace bootstrap is rate-limited (3/hour/IP, counted before validation; the 429 reads as \"budget exceeded\"). The limiter is in-memory — restart the api and re-run."
+        ;;
+      409)
+        fail "workspace '$WORKSPACE_SLUG' exists but the demo credentials don't log in — reset it (make seed-reset) and re-run"
+        ;;
+      *)
+        echo "  response body:" >&2
+        cat "$workdir/body" >&2
+        fail "POST /v1/workspaces returned HTTP $status"
+        ;;
+    esac
+    ;;
+esac
+
+# Demo records ride the same natural-key dedupe the product uses: a 201
+# created it, a 409 means an earlier run did — anything else is a defect.
+ensure() { # ensure <label> <path> <json-body>
+  local label="$1" path="$2" data="$3" status
+  status="$(api POST "$path" "$data")"
+  case "$status" in
+    201) echo "  OK: created $label" ;;
+    409) echo "  OK: $label already present" ;;
+    *)
+      echo "  response body:" >&2
+      cat "$workdir/body" >&2
+      fail "POST /v1$path ($label) returned HTTP $status"
+      ;;
+  esac
+}
+
+echo "== seed-dev: demo people =="
+ensure "person Alice Müller" /people \
+  '{"full_name":"Alice Müller","emails":[{"email":"alice@demo.test","is_primary":true}],"source":"seed"}'
+ensure "person Bob Schmidt" /people \
+  '{"full_name":"Bob Schmidt","emails":[{"email":"bob@demo.test","is_primary":true}],"source":"seed"}'
+ensure "person Carol Wagner" /people \
+  '{"full_name":"Carol Wagner","emails":[{"email":"carol@demo.test","is_primary":true}],"source":"seed"}'
+
+echo "== seed-dev: demo organization =="
+ensure "organization Demo GmbH" /organizations \
+  '{"display_name":"Demo GmbH","domains":[{"domain":"demo.test","is_primary":true}],"source":"seed"}'
+
+echo "== seed-dev: demo deals =="
+# Deals have no natural key, so idempotency is a name probe against the
+# list before creating. Stages come from the bootstrap-seeded default
+# pipeline ("Sales": Qualified → … → Won/Lost).
+status="$(api GET /pipelines)"
+[ "$status" = "200" ] || fail "GET /v1/pipelines returned HTTP $status"
+pipeline_id="$(jq -r '.data[] | select(.is_default) | .id' "$workdir/body")"
+[ -n "$pipeline_id" ] || fail "no default pipeline — the bootstrap seed did not run?"
+stage_id_qualified="$(jq -r --arg p "$pipeline_id" '.data[] | select(.id == $p) | .stages[] | select(.name == "Qualified") | .id' "$workdir/body")"
+stage_id_proposal="$(jq -r --arg p "$pipeline_id" '.data[] | select(.id == $p) | .stages[] | select(.name == "Proposal") | .id' "$workdir/body")"
+[ -n "$stage_id_qualified" ] && [ -n "$stage_id_proposal" ] \
+  || fail "the default pipeline is missing its seeded Qualified/Proposal stages"
+
+status="$(api GET '/deals?limit=100')"
+[ "$status" = "200" ] || fail "GET /v1/deals returned HTTP $status"
+deals_page="$workdir/deals.json"
+cp "$workdir/body" "$deals_page"
+
+ensure_deal() { # ensure_deal <name> <stage-id> <amount-minor>
+  local name="$1" stage="$2" amount="$3"
+  if jq -e --arg n "$name" '.data[] | select(.name == $n)' "$deals_page" >/dev/null; then
+    echo "  OK: deal $name already present"
+    return
+  fi
+  ensure "deal $name" /deals "$(jq -n --arg n "$name" --arg p "$pipeline_id" --arg s "$stage" --argjson a "$amount" \
+    '{name:$n,pipeline_id:$p,stage_id:$s,amount_minor:$a,currency:"EUR",source:"seed"}')"
+}
+
+ensure_deal "Acme Expansion" "$stage_id_qualified" 2500000
+ensure_deal "Globex Renewal" "$stage_id_proposal" 1200000
+
+echo ""
+echo "seed-dev: DONE — log in at $API_BASE with $ADMIN_EMAIL / $ADMIN_PASSWORD (workspace $WORKSPACE_SLUG)"

--- a/scripts/seed-dev.sh
+++ b/scripts/seed-dev.sh
@@ -41,14 +41,16 @@ SESSION=""
 
 # The X-Workspace-Slug header resolves the tenant only under
 # MARGINCE_ENV=dev (make dev sets it); prod resolves by subdomain.
+# A transport failure (refused, timeout) prints status 000 and must not
+# trip set -e — the caller's status handling owns the error message.
 api() { # api <method> <path> [json-body] — prints the HTTP status, body lands in $workdir/body
   local method="$1" path="$2" data="${3:-}"
-  curl -sS -o "$workdir/body" -D "$workdir/headers" -w '%{http_code}' \
+  curl -sS --max-time 30 -o "$workdir/body" -D "$workdir/headers" -w '%{http_code}' \
     -X "$method" "$API_BASE/v1$path" \
     -H "X-Workspace-Slug: $WORKSPACE_SLUG" \
     -H 'Content-Type: application/json' \
     ${SESSION:+--cookie "crm_session=$SESSION"} \
-    ${data:+--data "$data"}
+    ${data:+--data "$data"} || true
 }
 
 # The session cookie is Secure, which curl's jar refuses to replay over
@@ -59,7 +61,7 @@ capture_session() {
 }
 
 echo "== seed-dev: API reachability =="
-curl -fsS "$API_BASE/readyz" >/dev/null 2>&1 \
+curl -fsS --max-time 10 "$API_BASE/readyz" >/dev/null 2>&1 \
   || fail "$API_BASE/readyz is not answering — start the stack first (make dev)"
 echo "  OK: $API_BASE is up"
 

--- a/scripts/seed-reset.sql
+++ b/scripts/seed-reset.sql
@@ -1,0 +1,50 @@
+-- seed-reset.sql — wipe the demo workspace (slug 'demo-workspace') so
+-- `make seed-dev` can rebuild it from scratch. Run by `make seed-reset`
+-- against the compose stack's Postgres.
+--
+-- Deletes every row scoped to the demo workspace across all tenant tables
+-- (those with a workspace_id column), discovered dynamically so a new
+-- table is covered without touching this file. Workspaces other than the
+-- demo one are untouched.
+--
+-- session_replication_role = replica disables FK enforcement and triggers
+-- for the duration, so the deletes are order-independent. That includes
+-- audit_log's append-only guard — correct here, because the reset erases
+-- the whole tenant, history included. Requires superuser (the compose
+-- stack's margince_owner is one).
+
+BEGIN;
+
+SET LOCAL session_replication_role = replica;
+
+DO $$
+DECLARE
+  ws uuid;
+  t  text;
+BEGIN
+  SELECT id INTO ws FROM workspace WHERE slug = 'demo-workspace';
+  IF ws IS NULL THEN
+    RAISE NOTICE 'seed-reset: no demo-workspace row — nothing to do';
+    RETURN;
+  END IF;
+
+  -- Tenant tables carry FORCE RLS, which binds even a non-superuser table
+  -- owner; bind the GUC so the deletes see the rows on such a connection.
+  PERFORM set_config('app.workspace_id', ws::text, true);
+
+  FOR t IN
+    SELECT c.table_name
+    FROM information_schema.columns c
+    JOIN information_schema.tables tb
+      ON tb.table_schema = c.table_schema AND tb.table_name = c.table_name
+    WHERE c.table_schema = 'public'
+      AND c.column_name = 'workspace_id'
+      AND tb.table_type = 'BASE TABLE'
+  LOOP
+    EXECUTE format('DELETE FROM %I WHERE workspace_id = %L', t, ws);
+  END LOOP;
+
+  DELETE FROM workspace WHERE id = ws;
+END $$;
+
+COMMIT;

--- a/scripts/verify-boot.sh
+++ b/scripts/verify-boot.sh
@@ -70,7 +70,10 @@ for name in "Alice Müller" "Bob Schmidt" "Carol Wagner"; do
 done
 
 echo "== verify-boot 3/3: frontend production build =="
-if ! (cd "$REPO_DIR/frontend" && pnpm install --frozen-lockfile && pnpm build); then
+# --ignore-scripts: no lifecycle scripts run at install; esbuild ships
+# prebuilt platform binaries as optional deps, so the build works without
+# its validating postinstall.
+if ! (cd "$REPO_DIR/frontend" && pnpm install --frozen-lockfile --ignore-scripts && pnpm build); then
   fail "the frontend production build failed — see output above"
 fi
 echo "  OK: frontend builds"

--- a/scripts/verify-boot.sh
+++ b/scripts/verify-boot.sh
@@ -33,12 +33,18 @@ fail() {
 workdir="$(mktemp -d -t verify-boot.XXXXXX)"
 trap 'rm -rf "$workdir"' EXIT
 
+# A transport failure (refused, timeout) makes curl print status 000 and
+# exit non-zero; `|| true` keeps set -e from eating the fail() message,
+# and --max-time keeps a stalled API from hanging the proof.
 echo "== verify-boot 1/3: login as the seeded demo admin =="
-login_status="$(curl -sS -o "$workdir/login.json" -D "$workdir/headers" -w '%{http_code}' \
+login_status="$(curl -sS --max-time 15 -o "$workdir/login.json" -D "$workdir/headers" -w '%{http_code}' \
   -X POST "$API_BASE/v1/auth/login" \
   -H "X-Workspace-Slug: $WORKSPACE_SLUG" \
   -H 'Content-Type: application/json' \
-  --data "$(jq -n --arg e "$ADMIN_EMAIL" --arg p "$ADMIN_PASSWORD" '{email:$e,password:$p}')")"
+  --data "$(jq -n --arg e "$ADMIN_EMAIL" --arg p "$ADMIN_PASSWORD" '{email:$e,password:$p}')" || true)"
+if [ -z "$login_status" ] || [ "$login_status" = "000" ]; then
+  fail "could not reach $API_BASE — is the stack up? (make dev)"
+fi
 if [ "$login_status" != "200" ]; then
   echo "  response body:" >&2
   cat "$workdir/login.json" >&2
@@ -51,10 +57,10 @@ session="$(sed -n 's/^[Ss]et-[Cc]ookie: crm_session=\([^;]*\).*/\1/p' "$workdir/
 echo "  OK: logged in as $ADMIN_EMAIL, session captured"
 
 echo "== verify-boot 2/3: seeded people are visible =="
-people_status="$(curl -sS -o "$workdir/people.json" -w '%{http_code}' \
+people_status="$(curl -sS --max-time 15 -o "$workdir/people.json" -w '%{http_code}' \
   "$API_BASE/v1/people?limit=100" \
   -H "X-Workspace-Slug: $WORKSPACE_SLUG" \
-  --cookie "crm_session=$session")"
+  --cookie "crm_session=$session" || true)"
 if [ "$people_status" != "200" ]; then
   echo "  response body:" >&2
   cat "$workdir/people.json" >&2

--- a/scripts/verify-boot.sh
+++ b/scripts/verify-boot.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+#
+# verify-boot.sh — the scripted boot proof: a running stack really serves
+# a login, the seeded demo data, and a buildable frontend.
+#
+# Pure client by design: the caller owns the stack lifecycle (`make dev`
+# in one terminal, `make seed-dev` once) the same way CI's live-boot job
+# does — this script only proves the result. It fails loudly on the first
+# broken step and never skips a check: a green run means a human can log
+# in and see data right now.
+#
+# Steps:
+#   1. POST /v1/auth/login with the seeded demo admin → 200 + crm_session.
+#   2. GET /v1/people under that session → the three seeded people.
+#   3. The frontend production build compiles (pnpm build) — a real
+#      compile+bundle, not a stale-dist check.
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+API_BASE="${API_BASE:-http://localhost:8080}"
+WORKSPACE_SLUG="${WORKSPACE_SLUG:-demo-workspace}"
+ADMIN_EMAIL="${ADMIN_EMAIL:-admin@demo.test}"
+ADMIN_PASSWORD="${ADMIN_PASSWORD:-demo-password-123}"
+
+command -v jq >/dev/null 2>&1 || { echo "verify-boot: jq is required" >&2; exit 1; }
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+workdir="$(mktemp -d -t verify-boot.XXXXXX)"
+trap 'rm -rf "$workdir"' EXIT
+
+echo "== verify-boot 1/3: login as the seeded demo admin =="
+login_status="$(curl -sS -o "$workdir/login.json" -D "$workdir/headers" -w '%{http_code}' \
+  -X POST "$API_BASE/v1/auth/login" \
+  -H "X-Workspace-Slug: $WORKSPACE_SLUG" \
+  -H 'Content-Type: application/json' \
+  --data "$(jq -n --arg e "$ADMIN_EMAIL" --arg p "$ADMIN_PASSWORD" '{email:$e,password:$p}')")"
+if [ "$login_status" != "200" ]; then
+  echo "  response body:" >&2
+  cat "$workdir/login.json" >&2
+  fail "POST /v1/auth/login returned HTTP $login_status (expected 200). Is the stack up and seeded? (make dev, then make seed-dev)"
+fi
+# The cookie is Secure, which curl's jar refuses to replay over plain-http
+# localhost — extract the token and send it explicitly.
+session="$(sed -n 's/^[Ss]et-[Cc]ookie: crm_session=\([^;]*\).*/\1/p' "$workdir/headers" | tr -d '\r')"
+[ -n "$session" ] || fail "login answered 200 but set no crm_session cookie"
+echo "  OK: logged in as $ADMIN_EMAIL, session captured"
+
+echo "== verify-boot 2/3: seeded people are visible =="
+people_status="$(curl -sS -o "$workdir/people.json" -w '%{http_code}' \
+  "$API_BASE/v1/people?limit=100" \
+  -H "X-Workspace-Slug: $WORKSPACE_SLUG" \
+  --cookie "crm_session=$session")"
+if [ "$people_status" != "200" ]; then
+  echo "  response body:" >&2
+  cat "$workdir/people.json" >&2
+  fail "GET /v1/people returned HTTP $people_status (expected 200)"
+fi
+for name in "Alice Müller" "Bob Schmidt" "Carol Wagner"; do
+  if ! jq -e --arg n "$name" '.data[] | select(.full_name == $n)' "$workdir/people.json" >/dev/null; then
+    echo "  full /v1/people response:" >&2
+    cat "$workdir/people.json" >&2
+    fail "seeded person '$name' missing from GET /v1/people — seed absent or stale (make seed-dev)"
+  fi
+  echo "  OK: found '$name'"
+done
+
+echo "== verify-boot 3/3: frontend production build =="
+if ! (cd "$REPO_DIR/frontend" && pnpm install --frozen-lockfile && pnpm build); then
+  fail "the frontend production build failed — see output above"
+fi
+echo "  OK: frontend builds"
+
+echo ""
+echo "verify-boot: ALL CHECKS GREEN"


### PR DESCRIPTION
Worklist [docs/worklists/skeleton-baseline-2026-07-09.md](../blob/main/docs/worklists/skeleton-baseline-2026-07-09.md) §4.3 — the dev-experience batch (§1a compose + §1c seed/boot-proof + §3 README quickstart + §1e live-boot job). Follows PR A (#28).

## What

- **`infra/docker-compose.dev.yml`** — pgvector/pg16 + redis:7, healthchecks, named data volume. This repo's contract is kept: ports 55432/56379, `margince_owner`/`dev`, `scripts/db-init.sql` for the non-owner app role — `MARGINCE_TEST_*` defaults and CI are untouched. `make db-up`/`db-init`/`clean` are rewired onto compose as the **one** dev-infra path (the hand-run `fable-*` containers are auto-removed so the ports free up). The compose project name is repo-specific: a generic name collided with stale poc-era volumes on a dev machine, and Postgres silently skips initdb on a non-empty volume. MinIO stays commented-out pending the §1c blobstore ADR.
- **`make seed-dev`** (`scripts/seed-dev.sh`) — the demo workspace (`demo-workspace`, `admin@demo.test` / `demo-password-123`, the established convention) seeded **through the public API, deliberately not the skeleton's SQL-fixture shape**: bootstrap is a cross-module transaction, role policies are compiled-in Go documents, passwords are salted Argon2id, and a SQL fixture would bypass the audit+outbox write shape and drift from the schema. Idempotent via the natural-key 409s (person email, org domain; deals name-probed via list); it bootstraps only when login fails, so re-runs never burn the 3/hour bootstrap limiter.
- **`make seed-reset`** (`scripts/seed-reset.sql`) — wipes the demo workspace only, discovered dynamically over every `workspace_id` table (new tables are covered automatically).
- **`make verify-boot`** (`scripts/verify-boot.sh`) — seeded-admin login over `/v1` (`crm_session` cookie + `X-Workspace-Slug`) → the three seeded people visible → frontend production build. Pure client; fails loudly on the first broken step, never skips.
- **README quickstart** — "boot it / log in / verify" on the new targets (§3 item; the broader internal-flavor scrub stays with PR E).
- **`live-boot` CI job** — the README quickstart run literally (compose up → migrate → api → seed-dev → verify-boot). This is what keeps the compose file, the seed, and the boot proof honest; the integration job's GH service containers would stay green even if they rotted. All actions SHA-pinned (image-pins gate green). Not yet a required check — promote it (branch protection + `infra/branch-protection.json` together) after a few stable runs.

## Verified

Locally, end to end: fresh compose boot → `make migrate` → api → `make seed-dev` (bootstrap path) → `make verify-boot` **green** → re-run `seed-dev` (idempotent login path, all 409s) → `make seed-reset` → `verify-boot` **fails loudly** → `seed-dev` again → green. `make check` green; `docker compose config` clean; `make check-image-pins` green.

## Follow-ups (noted in STATUS.md)

- Pre-existing wart found while testing: `POST /v1/auth/login` against a nonexistent workspace answers **500** (`pg: no workspace bound to context`) instead of 401 — identity-module fix + test, separate change.
- Compose images ride the same floating tags as CI's service containers; digest-pinning both is PR C material.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new end-to-end “boot verification” flow for the local development stack.
  * Introduced a simple seed-and-reset workflow so demo data can be refreshed quickly and reliably.
  * Added step-by-step quick-start instructions for running the app with Docker, seeding demo access, and verifying everything is working.

* **Bug Fixes**
  * Improved startup validation by checking service readiness and surfacing clearer diagnostics when boot checks fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->