### PR TITLE
chore: skeleton-baseline PR C — gate parity (worklist §1b)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,13 +52,19 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: ./scripts/check-dco.sh "$BASE_SHA" "$HEAD_SHA"
 
-  # The deterministic merge gate: build, vet, lint, arch-lint, unit + root
-  # fitness tests, generated-drift, and the craft-manifest drift check.
+  # The deterministic merge gate: build, vet, lint (baseline + new-code
+  # strict), arch-lint, unit + root fitness tests, generated-drift, and the
+  # script gates (image pins, contract breaking, test lanes, file length).
   deterministic-gates:
     name: deterministic-gates
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          # The contract-breaking gate and the strict lint's
+          # new-from-merge-base both diff against origin/main — a shallow
+          # checkout has no base ref and would silently disarm them.
+          fetch-depth: 0
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: backend/go.mod
@@ -67,9 +73,21 @@ jobs:
         with:
           version: v2.12.2
           working-directory: backend
-      - name: Workflow actions are SHA-pinned
+      - name: Workflow actions and container images are pinned
         working-directory: .
         run: make check-image-pins
+      - name: Contract breaking-change gate (oasdiff vs origin/main)
+        working-directory: .
+        env:
+          # In CI a missing base ref is a broken checkout, never a skip.
+          CONTRACT_BREAKING_REQUIRE_BASE: "1"
+        run: make contract-breaking-check
+      - name: Test-lane separation (unit lane stays hermetic)
+        working-directory: .
+        run: make test-lanes
+      - name: Go file-length ratchet
+        working-directory: .
+        run: make go-file-length
       - run: make check
 
   # The code-craftsmanship gate (ADR-0045) runs only after the deterministic
@@ -107,7 +125,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: pgvector/pgvector:pg16
+        image: pgvector/pgvector:pg16@sha256:1d533553fefe4f12e5d80c7b80622ba0c382abb5758856f52983d8789179f0fb
         env:
           POSTGRES_USER: margince_owner
           POSTGRES_PASSWORD: dev
@@ -118,7 +136,7 @@ jobs:
           --health-cmd "pg_isready -U margince_owner"
           --health-interval 2s --health-timeout 5s --health-retries 15
       redis:
-        image: redis:7
+        image: redis:7@sha256:b2b95679e3b46fb51864949ed25ea976fc3a6bcc00a40a1bc00d568cb2822e50
         ports:
           - 56379:6379
         options: >-
@@ -175,7 +193,7 @@ jobs:
     # integration job uses.
     services:
       postgres:
-        image: pgvector/pgvector:pg16
+        image: pgvector/pgvector:pg16@sha256:1d533553fefe4f12e5d80c7b80622ba0c382abb5758856f52983d8789179f0fb
         env:
           POSTGRES_USER: margince_owner
           POSTGRES_PASSWORD: dev
@@ -186,7 +204,7 @@ jobs:
           --health-cmd "pg_isready -U margince_owner"
           --health-interval 2s --health-timeout 5s --health-retries 15
       redis:
-        image: redis:7
+        image: redis:7@sha256:b2b95679e3b46fb51864949ed25ea976fc3a6bcc00a40a1bc00d568cb2822e50
         ports:
           - 56379:6379
         options: >-

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,10 @@ All Go code lives under `backend/` (one Go module,
 ```
 make db-up              # start PG16 + Redis 7 containers, create the app role
 make migrate            # apply core + custom migrations (owner DSN)
-make check              # the merge gate: build, vet, lint (baseline + new-code strict), arch-lint, unit tests, contract drift + breaking-change, test-lanes, file-length, image pins
+make check              # the merge gate. Backend: build, vet, lint (baseline +
+                        # new-code strict), arch-lint, unit tests, contract drift.
+                        # Root adds: craft drift, image pins, contract
+                        # breaking-change, test-lanes, file-length
 make test-integration   # real-Postgres lane: RLS gates + HTTP end-to-end (needs db-up)
 make dev                # db-up + migrate + api on :8080
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ All Go code lives under `backend/` (one Go module,
 ```
 make db-up              # start PG16 + Redis 7 containers, create the app role
 make migrate            # apply core + custom migrations (owner DSN)
-make check              # the merge gate: build, vet, lint, arch-lint, unit tests, contract drift
+make check              # the merge gate: build, vet, lint (baseline + new-code strict), arch-lint, unit tests, contract drift + breaking-change, test-lanes, file-length, image pins
 make test-integration   # real-Postgres lane: RLS gates + HTTP end-to-end (needs db-up)
 make dev                # db-up + migrate + api on :8080
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,10 @@ All Go code lives under `backend/` (one Go module,
 ```
 make db-up              # start PG16 + Redis 7 containers, create the app role
 make migrate            # apply core + custom migrations (owner DSN)
-make check              # the merge gate: build, vet, lint (baseline + new-code strict), arch-lint, unit tests, contract drift + breaking-change, test-lanes, file-length, image pins
+make check              # the merge gate. Backend: build, vet, lint (baseline +
+                        # new-code strict), arch-lint, unit tests, contract drift.
+                        # Root adds: craft drift, image pins, contract
+                        # breaking-change, test-lanes, file-length
 make test-integration   # real-Postgres lane: RLS gates + HTTP end-to-end (needs db-up)
 make dev                # db-up + migrate + api on :8080
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ All Go code lives under `backend/` (one Go module,
 ```
 make db-up              # start PG16 + Redis 7 containers, create the app role
 make migrate            # apply core + custom migrations (owner DSN)
-make check              # the merge gate: build, vet, lint, arch-lint, unit tests, contract drift
+make check              # the merge gate: build, vet, lint (baseline + new-code strict), arch-lint, unit tests, contract drift + breaking-change, test-lanes, file-length, image pins
 make test-integration   # real-Postgres lane: RLS gates + HTTP end-to-end (needs db-up)
 make dev                # db-up + migrate + api on :8080
 ```

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,9 @@
 # The frontend lane is separate (`make frontend-check`) — it needs node+pnpm,
 # which not every backend machine has; CI runs both.
 
-.PHONY: check build test test-integration bench-perf lint arch-lint vet gen drift db-up db-init migrate dev dev-tls clean eval tools seed-dev seed-reset verify-boot frontend-check frontend-dev frontend-e2e craft-static craft-residue craft-drift craft-sync check-image-pins hooks
+.PHONY: check build test test-integration bench-perf lint arch-lint vet gen drift db-up db-init migrate dev dev-tls clean eval tools seed-dev seed-reset verify-boot frontend-check frontend-dev frontend-e2e craft-static craft-residue craft-drift craft-sync check-image-pins contract-breaking-check test-lanes go-file-length hooks
 
-check: craft-drift check-image-pins
+check: craft-drift check-image-pins contract-breaking-check test-lanes go-file-length
 
 ## dev-tls — the full local stack in a real browser: an HTTPS front door on
 ## :8080 fronts the api (:8081) and the Vite dev server (:5173), so the SPA
@@ -35,8 +35,15 @@ verify-boot:
 eval:
 	cd backend && go test ./internal/compose -run 'TestColdStartGolden' -v
 
+## frontend-check — the frontend merge lane. The gen:api + diff pair is the
+## TS type-drift gate: src/api/schema.d.ts is generated from crm.yaml, and a
+## contract change that skips regeneration would silently strand the frontend
+## types — regenerate and commit them together.
 frontend-check:
-	cd frontend && pnpm install --frozen-lockfile && pnpm check
+	cd frontend && pnpm install --frozen-lockfile && pnpm gen:api && \
+		{ git diff --exit-code -- src/api/schema.d.ts || \
+			{ echo "frontend types drifted from backend/api/crm.yaml — commit the regenerated src/api/schema.d.ts (printed above)"; exit 1; }; } && \
+		pnpm check
 
 frontend-dev:
 	cd frontend && pnpm install && pnpm dev
@@ -74,12 +81,30 @@ craft-sync:
 	rsync -a --delete ../margince-foundation/skeleton/cli/craft/ cli/craft/
 	@$(MAKE) craft-drift
 
-## check-image-pins — every `uses:` in .github/workflows/ is pinned to a
-## full commit SHA or digest (supply-chain: a floating vN/main tag lets a
-## compromised action ride into CI unreviewed). Lives at the root because
-## the workflows do; also a CI step, so a pin can't regress.
+## check-image-pins — every `uses:` in .github/workflows/ AND every container
+## `image:` (workflow service containers + infra/docker-compose.dev.yml) is
+## pinned to an immutable ref (supply-chain: a floating vN/main tag or image
+## tag lets a compromised artifact ride into CI unreviewed). Lives at the root
+## because the workflows do; also a CI step, so a pin can't regress.
 check-image-pins:
 	@./scripts/check-image-pins.sh
+
+## contract-breaking-check — oasdiff severity gate on backend/api/crm.yaml vs
+## origin/main: a breaking change (removed op, narrowed type…) fails; additive
+## changes pass. A deliberate spec re-sync runs with CONTRACT_STABILITY=pre-live.
+contract-breaking-check:
+	@./scripts/check-contract-breaking.sh
+
+## test-lanes — hermetic-unit-lane enforcement: no untagged test may open a
+## real Postgres/Redis; real-infra suites carry //go:build integration.
+test-lanes:
+	@./scripts/check-test-lanes.sh
+
+## go-file-length — hard 500-LOC cap on hand-written Go files, ratcheted via
+## scripts/go-file-length-waivers.txt (pre-existing offenders may shrink,
+## never grow).
+go-file-length:
+	@./scripts/check-go-file-length.sh
 
 ## hooks — install the repo's git hooks (the pre-push craft-static gate).
 ## Run once after cloning.

--- a/STATUS.md
+++ b/STATUS.md
@@ -8,8 +8,9 @@
 ## ▶ RESTART HERE (2026-07-09 PM — skeleton-baseline PR C: gate parity landed)
 
 **PR C — the §1b gate-parity batch (this session):** all seven scoped
-gates ported from the foundation skeleton, each wired into `make check`
-(root or backend) AND CI; design decisions ratified in
+gates ported from the foundation skeleton — the backend/root ones wired
+into `make check`, the TS-drift gate into `make frontend-check`, and all
+of them enforced in CI; design decisions ratified in
 **decisions/0020-gate-parity.md**:
 
 - **contract-breaking-check** — pinned oasdiff (v1.22.0 via `go run`; also

--- a/STATUS.md
+++ b/STATUS.md
@@ -5,6 +5,49 @@
 > [AGENTS.md](AGENTS.md) for the binding rules. Update this file at the
 > end of every working session.
 
+## ▶ RESTART HERE (2026-07-09 PM — skeleton-baseline PR C: gate parity landed)
+
+**PR C — the §1b gate-parity batch (this session):** all seven scoped
+gates ported from the foundation skeleton, each wired into `make check`
+(root or backend) AND CI; design decisions ratified in
+**decisions/0020-gate-parity.md**:
+
+- **contract-breaking-check** — pinned oasdiff (v1.22.0 via `go run`; also
+  in `make tools`) severity-gates `backend/api/crm.yaml` vs `origin/main`;
+  breaking fails, additive passes; `CONTRACT_STABILITY=pre-live` is the
+  deliberate-re-sync escape. CI checks out `fetch-depth: 0` and sets
+  `CONTRACT_BREAKING_REQUIRE_BASE=1` so a missing base ref is red, not a
+  silent skip.
+- **TS type drift** — `make frontend-check` (local + the frontend CI job)
+  now runs `pnpm gen:api` + `git diff --exit-code`. The gate immediately
+  proved itself: `frontend/src/api/schema.d.ts` was 400+ lines stale
+  behind crm.yaml — regenerated, committed, frontend lane green on it.
+- **test-lanes** — `scripts/check-test-lanes.sh`: no untagged test may
+  carry real-PG/Redis markers (`MARGINCE_TEST_*`, `pgxpool.New`, …);
+  current tree clean.
+- **zero-skip integration** — `make test-integration` fails on any
+  `--- SKIP` in the lane (the "fails loudly" claim is now enforced, not
+  convention).
+- **golangci expansion, new-code-only** — the worklist DECISION's
+  recommended arm: `backend/.golangci.strict.yml` (skeleton's ~25-linter
+  set + gofumpt/gci, integration+livesmoke tags) gated by
+  `new-from-merge-base: origin/main`; the baseline `.golangci.yml` is
+  untouched so the depguard DAG stays repo-wide. `make lint` runs both.
+- **go-file-length** — hard 500-LOC cap with a ratchet
+  (`scripts/go-file-length-waivers.txt`: shrink yes, grow no, ≤500 ⇒
+  remove the entry). The worklist's named offenders were already split by
+  the Strojny work; the single live waiver is `compose/report.go` (501).
+- **digest-pinned images** — compose + CI service containers pin
+  `tag@sha256:` (multi-arch index digests, so arm64 dev and amd64 CI share
+  one pin); `scripts/check-image-pins.sh` grew a fail-closed `image:` pass
+  covering workflows and `infra/docker-compose.dev.yml`.
+
+Worklist §1b is fully ticked except `check-doc-style` (blocked on the §0
+spec-reconciliation decision) and the parallel integration harness (adopt
+when lane time hurts). Still queued from §4: PR D frontend, PR E OSS
+packaging, the §1c/§1d DECISION items, and the login-500-on-unknown-
+workspace identity wart.
+
 ## ▶ RESTART HERE (2026-07-09 — skeleton-baseline PR A + PR B: gates hardened, dev experience landed)
 
 Working docs/worklists/skeleton-baseline-2026-07-09.md (poc-v1 → official

--- a/backend/.golangci.strict.yml
+++ b/backend/.golangci.strict.yml
@@ -1,0 +1,140 @@
+# The expanded linter set (foundation skeleton parity), gated NEW-CODE-ONLY:
+# issues.new-from-merge-base keeps the pre-existing backlog un-gated, so this
+# config could land without a big-bang burn-down (decisions/0020). Write new
+# code clean; shrink the backlog as files are touched.
+#
+# The baseline .golangci.yml stays the REPO-WIDE gate (depguard DAG, gosec,
+# misspell, revive package-comments, the standard set) — `make lint` runs
+# both. Rules here are diff-scoped and therefore must never be the only home
+# of a boundary invariant.
+version: "2"
+
+run:
+  # The baseline lints only untagged code; this pass also covers the
+  # integration and livesmoke lanes so new test-harness code is gated too.
+  build-tags:
+    - integration
+    - livesmoke
+
+issues:
+  # Only findings introduced after the merge-base with origin/main fail.
+  # CI checks out with fetch-depth 0 so the ref exists; `make lint` skips
+  # this pass with a loud message when it doesn't.
+  new-from-merge-base: origin/main
+
+linters:
+  default: none
+  enable:
+    # --- idiom (gofumpt/gci live under `formatters:` in the v2 schema) ---
+    - revive          # configurable idiom: exported-without-comment, early-return, naming
+    - gocritic        # idiom & diagnostics: ifElseChain, sprintfQuotedString, rangeValCopy
+    - staticcheck     # v2 folds in stylecheck (ST*) + gosimple
+    # --- complexity & size (the god-file / god-func guards) ---
+    - funlen
+    - cyclop
+    - gocognit
+    - maintidx
+    - dupl
+    - nestif
+    # --- correctness & safety ---
+    - errcheck        # no unchecked / `_`-discarded errors
+    - rowserrcheck    # rows.Err() checked after Next() loops
+    - sqlclosecheck   # *sql.Rows / *sql.Stmt always closed
+    - bodyclose       # HTTP response bodies closed
+    - noctx           # no HTTP/DB call without a context
+    - gosec           # SAST incl. G201/G202 SQL string-building
+    - contextcheck    # context propagated, not dropped to Background()
+    - forcetypeassert # no unchecked x.(T)
+    - nilnil          # no return nil, nil
+    - nilerr          # no return nil after a non-nil err
+    - govet           # enable-all (the baseline runs the default vet suite)
+    # --- anti-slop & taste-adjacent ---
+    - forbidigo       # project blocklist (see settings)
+    - goconst         # repeated literals -> named const
+    - unparam         # unused function parameters (speculative API)
+    - unused          # dead/speculative code
+    - ireturn         # accept interfaces, return structs
+    - tagliatelle     # struct-tag case consistency (json)
+    - predeclared     # no shadowing of len/error/etc.
+    # --- config discipline ---
+    - nolintlint      # a bare //nolint is itself a failure
+
+  settings:
+    funlen:
+      lines: 80
+      statements: 50
+      ignore-comments: true
+    cyclop:
+      max-complexity: 15
+    gocognit:
+      min-complexity: 30
+    maintidx:
+      under: 20
+    dupl:
+      threshold: 150
+    nestif:
+      min-complexity: 5
+    goconst:
+      min-len: 3
+      min-occurrences: 3
+      ignore-tests: true   # test-string repetition should not force a production constant
+    govet:
+      enable-all: true
+      disable:
+        - fieldalignment   # memory-layout micro-opt
+        - shadow           # high-noise; revive/idiom covers the real cases
+    gosec:
+      excludes:
+        - G115             # int conversion overflow — pervasive false positives on DB ids
+    revive:
+      rules:
+        - name: exported
+        - name: blank-imports
+        - name: context-as-argument
+        - name: early-return
+        - name: confusing-naming
+        - name: unreachable-code
+        - name: redefines-builtin-id
+    staticcheck:
+      checks:
+        - all
+    ireturn:
+      allow:
+        - error
+        - empty
+        - stdlib
+        - generic
+    tagliatelle:
+      case:
+        rules:
+          json: snake
+          yaml: snake
+        use-field-name: false
+    forbidigo:
+      analyze-types: true
+      forbid:
+        - pattern: '^fmt\.Print.*$'
+          msg: "use slog, not fmt.Print*"
+        - pattern: '^http\.Error$'
+          msg: "ship RFC 7807 JSON via platform/httperr, not http.Error"
+
+  exclusions:
+    generated: lax
+    rules:
+      # Generated contract/codegen output is not hand-written; exempt from taste linters.
+      - path: '(_gen|\.gen)\.go$'
+        linters: [funlen, cyclop, gocognit, maintidx, dupl, revive, staticcheck, goconst, unparam]
+      # Tests: relax size/dup/return-style noise that does not reflect on test quality.
+      - path: '_test\.go$'
+        linters: [funlen, cyclop, gocognit, maintidx, dupl, goconst, ireturn, forcetypeassert, errcheck, gosec, contextcheck, noctx]
+
+formatters:
+  enable:
+    - gofumpt   # stricter-than-gofmt
+    - gci       # stdlib / third-party / intra-repo import grouping
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - localmodule

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -38,16 +38,37 @@ test: ## Unit tests (the root fitness tests run uncached)
 	# ride a stale green.
 	$(GO) test -count=1 .
 
+# -v is load-bearing, not chattiness: `go test` only names skipped tests in
+# verbose mode, and the zero-skip teeth below grep for them. A skip in this
+# lane means a security gate (RLS, erasure) silently didn't run — that must
+# read as red, never as green.
 test-integration: ## Integration lane: real Postgres, fails loudly without it (never skips)
-	$(GO) test -tags integration -p 1 ./...
+	@log=$$(mktemp); st=$$(mktemp); \
+	{ $(GO) test -tags integration -p 1 -v ./... 2>&1; echo $$? >"$$st"; } | tee "$$log"; \
+	code=$$(cat "$$st"); rm -f "$$st"; \
+	if [ "$$code" -ne 0 ]; then rm -f "$$log"; exit "$$code"; fi; \
+	if grep -q -- '--- SKIP' "$$log"; then \
+		echo "FAIL: the integration lane must not skip — provision the dependency, never skip:"; \
+		grep -- '--- SKIP' "$$log"; rm -f "$$log"; exit 1; \
+	fi; \
+	rm -f "$$log"; echo "test-integration: green with zero skips"
 
 # The integration lane above runs the same harness on the SMB tier as a
 # standing canary; this target is the tier the PERF-7 SLO binds at.
 bench-perf: ## PERF-3/PERF-7 benchmark harness on the mid-market §6.7 tier (needs db-up; seeds 250k contacts)
 	MARGINCE_BENCH_TIER=mid_market $(GO) test -tags integration -run TestPerfBudgetsHoldOnSeededVolumeTier -v -timeout 30m ./internal/compose/integration
 
-lint: ## golangci-lint (depguard, gosec, misspell, revive, gofmt)
+# Two passes, two scopes (decisions/0020): .golangci.yml is the repo-wide
+# baseline (the depguard DAG lives there and must never be diff-scoped);
+# .golangci.strict.yml is the expanded skeleton-parity set, gated to new
+# code via new-from-merge-base so the pre-existing backlog is not a burn-down.
+lint: ## golangci-lint: repo-wide baseline + new-code strict set (decisions/0020)
 	golangci-lint run ./...
+	@if git rev-parse --verify -q origin/main >/dev/null; then \
+		golangci-lint run --config .golangci.strict.yml ./...; \
+	else \
+		echo "SKIP strict lint: origin/main not found — fetch it to arm the new-code gate"; \
+	fi
 
 # Layer C of the boundary stack — a HARD gate: a forbidden import edge
 # fails `make check`, it is never advisory.
@@ -82,10 +103,15 @@ vuln: ## Scan dependencies for known vulnerabilities (govulncheck)
 # binaries a PATH home for direct use). Installs are unconditional: a cached
 # binary at a different version must be overwritten, or the pin doesn't bind.
 GOLANGCI_LINT_VERSION ?= v2.12.2
+# The contract-breaking gate (scripts/check-contract-breaking.sh) runs oasdiff
+# via pinned `go run`, so this install is a convenience binary for direct use —
+# keep the version identical to the pin in that script; bump both together.
+OASDIFF_VERSION ?= v1.22.0
 tools: ## Install every gate binary at its pinned version (fresh-machine bootstrap)
 	$(GO) install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 	$(GO) install github.com/fe3dback/go-arch-lint@$(GO_ARCH_LINT_VERSION)
 	$(GO) install golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION)
+	$(GO) install github.com/oasdiff/oasdiff@$(OASDIFF_VERSION)
 	@echo "gate binaries ready in $$($(GO) env GOPATH)/bin — ensure it is on PATH"
 
 # `git rev-parse --git-path hooks` honors core.hooksPath, so this works

--- a/decisions/0020-gate-parity.md
+++ b/decisions/0020-gate-parity.md
@@ -1,0 +1,104 @@
+# 0020 — Gate parity with the foundation skeleton (worklist §1b)
+
+Date: 2026-07-09. Implements PR C of
+[docs/worklists/skeleton-baseline-2026-07-09.md](../docs/worklists/skeleton-baseline-2026-07-09.md)
+§4.4: the skeleton's gate suite ported onto this repo's layout. PR A (#28)
+brought the mechanical batch, PR B (#29) the dev experience; this record
+ratifies the gate-design decisions PR C embodies.
+
+## 1. Stricter golangci: expanded set, new-code-only (the §1b DECISION)
+
+The worklist flagged a decision: adopt the skeleton's ~25-linter ruleset
+wholesale (a big-bang backlog burn-down over ~14 modules) or gated to new
+code. **Ratified: new code only, via a second config.**
+
+- `backend/.golangci.yml` (baseline) is UNCHANGED and stays repo-wide. The
+  depguard module DAG, the shared-layer default-deny, gosec, misspell, and
+  revive package-comments are boundary/security invariants — an invariant
+  diff-scoped is an invariant with holes, so the baseline must never gain
+  `new-from-*`.
+- `backend/.golangci.strict.yml` carries the skeleton's expanded set
+  (gocritic, staticcheck-all, funlen/cyclop/gocognit/maintidx/dupl/nestif,
+  rowserrcheck/sqlclosecheck/bodyclose/noctx/contextcheck, forcetypeassert,
+  nilnil/nilerr, forbidigo, goconst/unparam/ireturn/tagliatelle/predeclared,
+  nolintlint, gofumpt+gci as formatters) with
+  `issues.new-from-merge-base: origin/main`: only findings introduced after
+  the merge-base fail. It also lints the `integration`/`livesmoke` build
+  tags, which the baseline never covered.
+- `make lint` runs both passes. Locally the strict pass skips loudly if
+  `origin/main` is unfetched; in CI the checkout uses `fetch-depth: 0`, so
+  the anchor always exists (on a main push the merge-base is HEAD and the
+  pass is trivially green — PRs are where the gate bites).
+- Consequence to accept: the pre-existing backlog is paid down only as
+  files are touched. That is the point — the skeleton's ruleset lands
+  today instead of after a burn-down nobody scheduled.
+
+## 2. Contract breaking-change gate: hard by default
+
+`scripts/check-contract-breaking.sh` (root `make contract-breaking-check`,
+in root `make check` and CI) runs pinned oasdiff over
+`origin/main:backend/api/crm.yaml` vs the working tree and **fails on
+ERR-severity (breaking) changes**; additive/deprecation changes pass. The
+skeleton defaults this gate to advisory ("pre-live") until a first external
+consumer exists; we default to **hard** — this repo is becoming the OSS
+baseline and its MCP/REST surface is exercised by the frontend and agents
+today. A deliberate breaking re-sync from the spec repo runs with
+`CONTRACT_STABILITY=pre-live` (printed, not blocking) for that run, on the
+explicit judgment of whoever lands the sync. In CI,
+`CONTRACT_BREAKING_REQUIRE_BASE=1` turns a missing base ref (shallow
+checkout regression) into a failure instead of a silent skip.
+
+## 3. TS type drift joins the merge gate
+
+`frontend/src/api/schema.d.ts` is generated from `crm.yaml` (`pnpm gen:api`)
+but was never drift-gated — this PR found it 400+ lines stale, proving the
+gap. `make frontend-check` now regenerates and `git diff --exit-code`s the
+file, so a contract change that skips regeneration fails the frontend lane
+(locally and in CI, which runs the same target). The regenerated file is
+committed with the contract change, same rule as the Go `make drift` gate.
+
+## 4. Test-lane separation, enforced
+
+`scripts/check-test-lanes.sh` (root `make test-lanes`): no untagged test
+file may carry real-infrastructure markers (`pgxpool.New`,
+`sql.Open("pgx"/"postgres")`, the `MARGINCE_TEST_*` env reads,
+`redis.ParseURL`); real-infra suites carry `//go:build integration` (or
+`livesmoke`). Fakes carry none of the markers and pass. This turns the
+lane convention `make test` has relied on into a gate.
+
+## 5. Zero-skip integration lane
+
+`make test-integration` now runs `-v`, captures the output, and fails if
+any `--- SKIP` appears. The lane's harness already `t.Fatal`s on a missing
+DSN ("fails loudly, never skips"), but that was convention — a future
+`t.Skip` would have turned a security lane (RLS, erasure) silently green.
+Now it reads as red.
+
+## 6. File-length cap with a ratchet
+
+`scripts/check-go-file-length.sh` (root `make go-file-length`): hard
+500-LOC cap on hand-written Go (`backend/`, `dev/`; generated and `_test.go`
+files exempt; `cli/craft` exempt as foundation-vendored).
+`scripts/go-file-length-waivers.txt` freezes pre-existing offenders at
+their current length — shrinking allowed, growing not; at ≤500 the entry
+must be removed so the cap re-arms. Seeded with the single current
+offender, `internal/compose/report.go` (501). The worklist's named
+offenders (`people/person.go`, `people/lead.go`, `deals/offer.go`) had
+already been split under 500 by the Strojny workstream.
+
+## 7. Container images pinned by digest
+
+The compose dev stack and CI's service containers rode floating tags
+(`pgvector/pgvector:pg16`, `redis:7`). Both now pin `tag@sha256:<digest>`
+using the multi-arch INDEX digest (one pin serves arm64 dev machines and
+amd64 CI). `scripts/check-image-pins.sh` grew a second, fail-closed pass:
+every non-comment `image:` line in workflows and
+`infra/docker-compose.dev.yml` must carry `@sha256:`; commented-out lines
+(the parked MinIO block) are skipped. Renovate keeps digest bumps flowing;
+bump tag+digest together, everywhere or nowhere.
+
+## Not adopted here (tracked in the worklist)
+
+`check-doc-style` waits on the §0 spec-reconciliation decision; the
+parallel integration harness waits until lane time hurts; the LLM craft
+review CI job is a §1e DECISION.

--- a/decisions/0020-gate-parity.md
+++ b/decisions/0020-gate-parity.md
@@ -82,7 +82,7 @@ files exempt; `cli/craft` exempt as foundation-vendored).
 `scripts/go-file-length-waivers.txt` freezes pre-existing offenders at
 their current length — shrinking allowed, growing not; at ≤500 the entry
 must be removed so the cap re-arms. Seeded with the single current
-offender, `internal/compose/report.go` (501). The worklist's named
+offender, `backend/internal/compose/report.go` (501). The worklist's named
 offenders (`people/person.go`, `people/lead.go`, `deals/offer.go`) had
 already been split under 500 by the Strojny workstream.
 

--- a/docs/worklists/skeleton-baseline-2026-07-09.md
+++ b/docs/worklists/skeleton-baseline-2026-07-09.md
@@ -109,7 +109,8 @@ Skeleton gates we lack entirely (each is a small script; wire into
       ratchet/waiver list so the gate lands without a big-bang split.
       (Done PR C — ratchet via `scripts/go-file-length-waivers.txt`; the
       named offenders had already been split <500 by the Strojny work; the
-      only live waiver is `compose/report.go` at 501; decisions/0020 §6.)
+      only live waiver is `backend/internal/compose/report.go` at 501;
+      decisions/0020 §6.)
 - [x] `test-lanes` — hermetic-unit-lane check (no untagged test opens real
       PG/Redis). We rely on the `//go:build integration` convention with no
       enforcement. (Done PR C — `scripts/check-test-lanes.sh`, markers

--- a/docs/worklists/skeleton-baseline-2026-07-09.md
+++ b/docs/worklists/skeleton-baseline-2026-07-09.md
@@ -91,32 +91,48 @@ Consequences:
 Skeleton gates we lack entirely (each is a small script; wire into
 `backend/Makefile check` or root):
 
-- [ ] `contract-breaking-check` — **oasdiff** severity gate on `crm.yaml` vs
+- [x] `contract-breaking-check` — **oasdiff** severity gate on `crm.yaml` vs
       `origin/main` (we only have whole-file drift on generated Go).
-- [ ] **TS type drift** — `frontend/src/api/schema.d.ts` is generated but
+      (Done PR C — `scripts/check-contract-breaking.sh`, pinned oasdiff via
+      `go run`, hard-fail default with a `CONTRACT_STABILITY=pre-live`
+      escape for deliberate spec re-syncs; decisions/0020 §2.)
+- [x] **TS type drift** — `frontend/src/api/schema.d.ts` is generated but
       *not* drift-gated; a `crm.yaml` change can silently strand the
       frontend types. Fold `pnpm gen:api` + `git diff --exit-code` into the
       gate (skeleton: `gen-types.sh check`).
-- [ ] `go-file-length` — hard 500-LOC cap (non-test, non-generated). We
+      (Done PR C — in `make frontend-check`, so the frontend CI job runs it;
+      the gate immediately caught schema.d.ts 400+ lines stale, regenerated
+      and committed with the PR; decisions/0020 §3.)
+- [x] `go-file-length` — hard 500-LOC cap (non-test, non-generated). We
       already carry known >500 offenders (`people/person.go`,
       `people/lead.go`, `deals/offer.go`) — adopt diff-scoped or with a
       ratchet/waiver list so the gate lands without a big-bang split.
-- [ ] `test-lanes` — hermetic-unit-lane check (no untagged test opens real
+      (Done PR C — ratchet via `scripts/go-file-length-waivers.txt`; the
+      named offenders had already been split <500 by the Strojny work; the
+      only live waiver is `compose/report.go` at 501; decisions/0020 §6.)
+- [x] `test-lanes` — hermetic-unit-lane check (no untagged test opens real
       PG/Redis). We rely on the `//go:build integration` convention with no
-      enforcement.
-- [ ] `check-image-pins` — see 1a.
-- [ ] **Stricter `.golangci.yml`** — skeleton runs ~20 linters incl.
+      enforcement. (Done PR C — `scripts/check-test-lanes.sh`, markers
+      adapted to our `MARGINCE_TEST_*` env contract; decisions/0020 §4.)
+- [x] `check-image-pins` — see 1a. (Workflow `uses:` pins done PR A; PR C
+      extended the script to `image:` lines — CI service containers and the
+      compose stack are digest-pinned and gated; decisions/0020 §7.)
+- [x] **Stricter `.golangci.yml`** — skeleton runs ~20 linters incl.
       gofumpt+gci, gocritic, staticcheck, funlen/cyclop/gocognit, errcheck,
       rowserrcheck/sqlclosecheck/bodyclose, forcetypeassert, nolintlint;
       ours is `default: standard` + 4. `DECISION (build)`: adopt wholesale
       (big backlog burn-down) vs adopt with `new-from-rev` so only new code
       is gated. Recommend `new-from-rev`.
+      (Done PR C — the recommended arm, as `backend/.golangci.strict.yml`
+      with `new-from-merge-base: origin/main`; the baseline config is
+      untouched so the depguard DAG stays repo-wide; decisions/0020 §1.)
 - [ ] `check-doc-style` / subsystem-doc conventions — only if we adopt the
       foundation's subsystem-chapter format for `docs/` (ties to §0
       spec-reconciliation decision).
-- [ ] **Zero-skip integration enforcement** — our lane's "fails loudly
+- [x] **Zero-skip integration enforcement** — our lane's "fails loudly
       without a DB" claim is convention; skeleton scripts assert a skipped
-      test fails the run. Cheap to add.
+      test fails the run. Cheap to add. (Done PR C — `make test-integration`
+      greps `-v` output for `--- SKIP` and fails; decisions/0020 §5.)
 - [ ] Consider skeleton's **parallel integration harness** (per-package
       throwaway DB clones) — ours is `-p 1` serial; adopt when lane time
       hurts, not before.

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -894,6 +894,63 @@ export interface paths {
         patch: operations["updateAutomation"];
         trace?: never;
     };
+    "/automations/{id}/preview": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Dry-run an automation's blast radius (🟢 read; no writes, no sends).
+         * @description Powers the designer's live dry-run (A72/ADR-0035 Am.1). Evaluates the recipe's trigger + filter and
+         *     returns how many records match **now** and an estimate of how many times it *would have* fired over a
+         *     trailing window — **without** performing any action. This is a **🟢 read**, executed under the caller's
+         *     Passport: it never mutates a record, never sends, and never stages an approval. Accepts either the stored
+         *     automation or, for a not-yet-created draft, an inline recipe in the body (so the editor can preview
+         *     before the first save). `x-mcp-tool` read tier.
+         */
+        post: operations["previewAutomation"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/automations/{id}/runs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        /**
+         * Read-only run history for one automation — successes AND errored/blocked/skipped runs.
+         * @description The designer's run history (A72/ADR-0035 Am.1 — **promoted into V1**, previously fast-follow). Each
+         *     `AutomationRun` is reconstructed from `audit_log`/`automation_run` (data-model §12.5) and stamped with
+         *     the tier that fired and whether approval was needed. Runs of every outcome are first-class (mapping to
+         *     `automation_run.status`) — including `failed` (a provider/action error), `blocked` (a 🟡 step whose
+         *     approval expired or was rejected — **added to the status set by A72/ADR-0035 Am.1**), and `skipped`
+         *     (e.g. the Passport no longer permits the action) — never only `fired` successes. Read-only: runs are
+         *     produced by the engine, not created via the API. 🟡 actions still queue to `/approvals` at run time.
+         */
+        get: operations["listAutomationRuns"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/leads": {
         parameters: {
             query?: never;
@@ -1289,11 +1346,15 @@ export interface paths {
         put?: never;
         /**
          * Website cold-start read-back — returns a staged proposal with evidence.
-         * @description Given a company URL, fetches + parses it (via the ADR-0006 connector) and returns a
-         *     structured read-back: ICP, buying center, value proposition, USP, buying intents.
-         *     EVERY returned field carries a non-empty `evidence_snippet` + `source_url` +
-         *     `confidence`, or it is ABSENT (the no-guess gate, features/07 §1). NOTHING is written
-         *     to real records — this is a 🟡 staging surface; the user accepts via /approvals.
+         * @description Reads back a structured company profile (ICP, buying center, value proposition, USP, buying
+         *     intents) from EXACTLY ONE input (B-E01.2b/.13): a company `url` (fetched+parsed via the ADR-0006
+         *     connector), pasted `text` (the manual fallback when a site is robots-disallowed/unreadable — a
+         *     paste-text form, never an error wall), or a `self_description` (the user's own dictated/typed ICP).
+         *     EVERY returned field carries a non-empty `evidence_snippet` + `confidence` + a `source_kind`
+         *     (`source_url` only when `source_kind=url`), or it is ABSENT (the no-guess gate, features/07 §1).
+         *     NOTHING is written to real records — this is a 🟡 staging surface; the user accepts via /approvals.
+         *     A `self_description` field is "grounded" in the user's own words (source_kind=self_description) —
+         *     that is honest grounding, not fabrication, and it still stages 🟡.
          */
         post: operations["coldStartReadback"];
         delete?: never;
@@ -2148,6 +2209,33 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/brief/items/{itemId}/snooze": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description A brief_item id belonging to one of the acting rep's runs. */
+                itemId: string;
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Snooze a brief item (A77/AC-home-6) — hidden until `snoozed_until` passes, then it re-surfaces as actionable.
+         * @description Sets the item to `state=snoozed` with the given `snoozed_until`. While the instant has not
+         *     passed, the item is hidden from the home read AND the deal is suppressed from freshly
+         *     generated runs. Once `snoozed_until` passes, the item re-surfaces as actionable — distinct
+         *     from `dismissed` (which needs a new linked activity) and `acted` (which needs a material
+         *     change). Per-rep queue state, like act/dismiss.
+         */
+        post: operations["snoozeBriefItem"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -2291,6 +2379,35 @@ export interface components {
             /** Format: date-time */
             archived_at?: string | null;
         };
+        /**
+         * @description Deterministic relationship-strength (features/07 §4) — a transparent function over captured
+         *     interaction features (recency, frequency, direction, reciprocity), NOT a trained model. A fixed
+         *     interaction set + fixed clock yields a stable value (P6/P12). The `factors` decompose the score and
+         *     `contributing_activity_ids` are the receipts, so the UI can show its inputs — no mystery number.
+         */
+        RelationshipStrength: {
+            /** @description 0..100 composite. */
+            score: number;
+            /**
+             * @description Coarse band derived from score for display.
+             * @enum {string}
+             */
+            bucket: "dormant" | "weak" | "warm" | "strong";
+            /** @description The 0..1 sub-scores the composite was built from (the explanation). */
+            factors: {
+                recency: number;
+                frequency: number;
+                reciprocity: number;
+                direction: number;
+            };
+            /** @description The activities the score was computed from (the receipts behind the number). */
+            contributing_activity_ids?: string[];
+            /**
+             * Format: date-time
+             * @description When this value was last recomputed (fixed-clock reproducible).
+             */
+            computed_at?: string;
+        };
         /** @description A contact. Mirrors the `person` table. */
         Person: {
             /** Format: uuid */
@@ -2329,6 +2446,8 @@ export interface components {
              * @description Canonical origin pointer if promoted from a lead.
              */
             converted_from_lead_id?: string | null;
+            /** @description Deterministic relationship-strength (features/07 §4). Read-only derived view; NULL until capture has interactions. No mystery number — the factors + contributing activities are the explanation. */
+            readonly strength?: components["schemas"]["RelationshipStrength"];
             source: string;
             /** @description Server-stamped from the authenticated principal (human:<uuid> | agent:<id> | connector:<name>); never client-supplied. */
             readonly captured_by: string;
@@ -2450,6 +2569,8 @@ export interface components {
              * @enum {string|null}
              */
             classification?: null | "prospect" | "customer" | "agency" | "reseller" | "tech_vendor" | "platform" | "partner" | "competitor" | "other";
+            /** @description Deterministic org-level relationship-strength roll-up (features/07 §4). Read-only derived view; NULL until capture has interactions. */
+            readonly strength?: components["schemas"]["RelationshipStrength"];
             source: string;
             /** @description Server-stamped from the authenticated principal (human:<uuid> | agent:<id> | connector:<name>); never client-supplied. */
             readonly captured_by: string;
@@ -2830,7 +2951,7 @@ export interface components {
             /** Format: uuid */
             activity_id?: string;
             /** @enum {string} */
-            entity_type: "person" | "organization" | "deal";
+            entity_type: "person" | "organization" | "deal" | "lead";
             /** Format: uuid */
             entity_id: string;
         };
@@ -2861,7 +2982,7 @@ export interface components {
             due_at?: string | null;
             /**
              * Format: date-time
-             * @description Task only.
+             * @description Task only. Reminder-fire time; the B-E16.6 scan reads tasks whose reminder is due, not-done, and un-archived.
              */
             remind_at?: string | null;
             /**
@@ -2917,7 +3038,10 @@ export interface components {
             occurred_at?: string;
             /** Format: date-time */
             due_at?: string | null;
-            /** Format: date-time */
+            /**
+             * Format: date-time
+             * @description Task only.
+             */
             remind_at?: string | null;
             /** Format: uuid */
             assignee_id?: string | null;
@@ -2930,7 +3054,7 @@ export interface components {
             source_id?: string | null;
             links?: {
                 /** @enum {string} */
-                entity_type: "person" | "organization" | "deal";
+                entity_type: "person" | "organization" | "deal" | "lead";
                 /** Format: uuid */
                 entity_id: string;
             }[];
@@ -2946,11 +3070,14 @@ export interface components {
             occurred_at?: string;
             /** Format: date-time */
             due_at?: string | null;
-            /** Format: date-time */
-            remind_at?: string | null;
             /** Format: uuid */
             assignee_id?: string | null;
-            /** @description Completing a task writes one audit row + task.completed event. */
+            /**
+             * Format: date-time
+             * @description Task only. Set/clear the reminder; PATCH target for B-E16.2/.3. The reminder scan (B-E16.6) fires on this.
+             */
+            remind_at?: string | null;
+            /** @description Completing a task writes one audit row + an `activity.updated` event carrying the `is_done` delta (events.md §5.5 — there is no separate `task.*` family). */
             is_done?: boolean;
         };
         ActivityListResponse: {
@@ -2990,6 +3117,8 @@ export interface components {
              * @description Lowercased; lead-internal dedupe key.
              */
             email?: string | null;
+            /** @description Normalized LinkedIn profile URL — the E12.11 exact-match dedupe key. */
+            linkedin_url?: string | null;
             title?: string | null;
             /** @description FREE TEXT — NOT an organization FK. */
             company_name?: string | null;
@@ -3005,8 +3134,8 @@ export interface components {
              * @default 0
              */
             score: number;
-            /** @description Non-null when a human has set score as a Commercial Judgement override (formulas §3.1, A68/ADR-0053). A non-empty reason makes score sticky: the §3 recompute stops touching score and tracks the machine value in score_computed instead. Cleared → recompute resumes. */
-            score_override_reason?: string | null;
+            /** @description Non-null ⇒ `score` is a human Commercial-Judgement override (formulas §3.1) and recompute is suppressed; the machine value is retained in `score_computed`. */
+            readonly score_override_reason?: string | null;
             /** @description Server-derived. The latest machine-computed §3 score, retained ONLY while an override is in force (else null, because score itself is the machine value). */
             readonly score_computed?: number | null;
             /** Format: uuid */
@@ -3038,6 +3167,8 @@ export interface components {
             full_name?: string | null;
             /** Format: email */
             email?: string | null;
+            /** @description Normalized LinkedIn profile URL — the E12.11 exact-match dedupe key for LinkedIn-captured leads. */
+            linkedin_url?: string | null;
             title?: string | null;
             company_name?: string | null;
             candidate_org_key?: string | null;
@@ -3068,10 +3199,10 @@ export interface components {
             candidate_org_key?: string | null;
             /** @enum {string} */
             status?: "new" | "working";
-            /** @description Human Commercial-Judgement score override (formulas §3.1, AC-S1). Setting it REQUIRES a non-empty score_override_reason in the SAME request — a score with no reason is rejected 422. Establishing an override makes the value sticky (recompute stops overwriting it). Omit to keep the current value. */
+            /** @description Manual human score override (formulas §3.1, AC-S1). Omit to keep the computed lead-local score. Setting it REQUIRES `score_override_reason`; passing null clears the override and resumes recompute. */
             score?: number | null;
-            /** @description The written reason accompanying a score override (mandatory whenever score is set, AC-S1). Two gestures only: a non-empty reason SETS/keeps the override; an explicit empty string CLEARS an in-force override (resumes the §3 recompute so score tracks score_computed again). Omit the field to leave the override untouched. null is not accepted — omit instead. */
-            score_override_reason?: string;
+            /** @description Written reason for the Commercial Judgement override (formulas §3.1). REQUIRED when `score` is set (422 otherwise); the override is sticky — it suppresses recompute until cleared. */
+            score_override_reason?: string | null;
             /** Format: uuid */
             owner_id?: string | null;
         };
@@ -3610,7 +3741,7 @@ export interface components {
              */
             on_behalf_of?: string | null;
             /** @enum {string} */
-            action: "create" | "update" | "archive" | "merge" | "promote" | "disqualify" | "restore" | "export" | "erase" | "anonymize" | "login" | "assign" | "advance_stage" | "send_email" | "consent_grant" | "consent_withdraw" | "approve" | "reject" | "record_share" | "record_unshare";
+            action: "create" | "update" | "archive" | "merge" | "promote" | "demote" | "disqualify" | "restore" | "export" | "erase" | "anonymize" | "login" | "assign" | "advance_stage" | "send_email" | "consent_grant" | "consent_withdraw" | "approve" | "reject" | "record_share" | "record_unshare" | "activity_relink" | "import" | "import_undo";
             entity_type: string;
             /** Format: uuid */
             entity_id?: string | null;
@@ -3757,30 +3888,62 @@ export interface components {
             /** @description Distinct counterparties seen across the captured messages. */
             contacts: number;
         };
+        /**
+         * @description EXACTLY ONE input source (B-E01.2b/.13): `url` (fetch+parse a website, ADR-0006), `text` (the
+         *     manual paste-text fallback — a robots-disallowed / unreadable site degrades to "paste the text",
+         *     never an error wall), or `self_description` (the user's own dictated/typed description of their
+         *     ICP — B-E01.13 speech input). Provide one; supplying more than one is `422`.
+         */
         ColdStartRequest: {
             /**
              * Format: uri
              * @description Company website URL to read back.
              */
-            url: string;
-        };
-        /** @description One read-back field. EVERY field carries non-empty evidence + confidence, or it is omitted (no-guess gate). */
+            url?: string | null;
+            /** @description Pasted page/company text (the paste-text fallback when a URL is unfetchable). Treated as T2 untrusted; extraction cites text offsets, not a URL. */
+            text?: string | null;
+            /** @description The user's own words describing their business/ICP (typed or dictated). Grounded in the user's own statement — source_kind=self_description; still 🟡-staged, never auto-written. */
+            self_description?: string | null;
+        } & (unknown | unknown | unknown);
+        /**
+         * @description One read-back field. EVERY field carries a non-empty `evidence_snippet` + `confidence`, or it is
+         *     omitted (the no-guess gate). `source_kind` says where the evidence lives; `source_url` is present
+         *     ONLY for `source_kind=url` (nullable otherwise — text/self-description evidence has no URL).
+         */
         ColdStartField: {
             /** @enum {string} */
             field: "icp" | "buying_center" | "value_proposition" | "usp" | "buying_intents" | "legal_name" | "registered_address" | "register_vat" | "industry" | "history";
             value: string;
-            /** @description Verbatim source text — non-empty or the field is absent. */
+            /** @description Verbatim source text (from the page, the pasted text, or the user's own words) — non-empty or the field is absent. */
             evidence_snippet: string;
-            /** Format: uri */
-            source_url: string;
+            /**
+             * @description Where evidence_snippet came from. For self_description the "evidence" is the user's own statement — a self-declared ICP is grounded in that statement (B-E01.13), not fabricated.
+             * @enum {string}
+             */
+            source_kind: "url" | "text" | "self_description";
+            /**
+             * Format: uri
+             * @description Present only when source_kind=url; null for text/self_description.
+             */
+            source_url?: string | null;
+            /** @description Optional char offset of evidence_snippet within the pasted text (source_kind=text), for highlight-back; null for url/self_description. */
+            evidence_offset?: number | null;
             confidence: number;
         };
         /** @description A staged proposal. NOTHING is written to real records until accepted via /approvals. */
         ColdStartProposal: {
             /** Format: uuid */
             proposal_id: string;
-            /** Format: uri */
-            source_url: string;
+            /**
+             * @description The input source this proposal was read from.
+             * @enum {string}
+             */
+            source_kind: "url" | "text" | "self_description";
+            /**
+             * Format: uri
+             * @description The company URL when source_kind=url; null for text/self_description.
+             */
+            source_url?: string | null;
             /**
              * @description Always staged — accept via the approval inbox.
              * @enum {string}
@@ -3945,6 +4108,9 @@ export interface components {
         /**
          * @description First-class partner state as a 1:1 extension of an organization (an org IS a partner iff it
          *     has a `partner` row + classification='partner'). Company identity is never duplicated.
+         *     A68/ADR-0053 adds the relationship-in-flight layer: lifecycle stage, relationship health,
+         *     partner fit, next step, and served segments. Behavior is Fast-follow, but the V1 schema is
+         *     forward-compatible.
          */
         Partner: {
             /**
@@ -3968,6 +4134,25 @@ export interface components {
             gate_metrics?: {
                 [key: string]: unknown;
             } | null;
+            /**
+             * @default research
+             * @enum {string}
+             */
+            relationship_stage: "research" | "identified" | "contacted" | "in_conversation" | "fit_confirmed" | "agreement_pending" | "active" | "active_referring" | "dormant" | "no_fit";
+            /** @description Current partner-fit score; if partner_fit_override_reason is non-null this is the Commercial Judgement value. */
+            partner_fit_score?: number | null;
+            /** @description Retained machine-computed partner-fit value while a Commercial Judgement override is in force. */
+            readonly partner_fit_score_computed?: number | null;
+            /** @description Non-null ⇒ partner_fit_score is a human Commercial Judgement override and recompute is suppressed until cleared. */
+            readonly partner_fit_override_reason?: string | null;
+            /** @description Decimal-as-string 0..1 derived by formulas §16; basis for 30/60/90 partner dormancy flags. */
+            relationship_health?: string | null;
+            /** Format: date-time */
+            last_contact_at?: string | null;
+            next_step?: string | null;
+            /** Format: date */
+            next_step_due_at?: string | null;
+            served_segments?: string[] | null;
             version?: components["schemas"]["RowVersion"];
             /** Format: date-time */
             created_at: string;
@@ -3986,6 +4171,12 @@ export interface components {
             gate_metrics?: {
                 [key: string]: unknown;
             } | null;
+            /** @enum {string} */
+            relationship_stage?: "research" | "identified" | "contacted" | "in_conversation" | "fit_confirmed" | "agreement_pending" | "active" | "active_referring" | "dormant" | "no_fit";
+            next_step?: string | null;
+            /** Format: date */
+            next_step_due_at?: string | null;
+            served_segments?: string[] | null;
         };
         ConsentPurpose: {
             /** Format: uuid */
@@ -4221,6 +4412,71 @@ export interface components {
             } | null;
             /** @enum {string|null} */
             status?: "enabled" | "paused" | null;
+        };
+        /**
+         * @description Optional body for POST /automations/{id}/preview. Omit to preview the stored automation as-is; supply
+         *     an inline draft recipe (key + params) to preview a not-yet-created or edited automation from the
+         *     designer before saving (A72/ADR-0035 Am.1). Never causes a write or send — preview is a 🟢 read.
+         */
+        AutomationPreviewRequest: {
+            /** @description Catalog type for a draft preview (defaults to the stored instance's key). */
+            key?: string | null;
+            /** @description Draft parameters (trigger/filter/actions) to preview instead of the stored ones. */
+            params?: {
+                [key: string]: unknown;
+            } | null;
+            /** @description Trailing window for the would-have-fired estimate (default 30). */
+            window_days?: number | null;
+        };
+        /** @description Read-only blast-radius result for the designer's dry-run. No side effects. */
+        AutomationPreview: {
+            /** @description Records matching the trigger+filter right now, bounded by the caller's Passport visibility. */
+            matches_now: number;
+            /** @description Estimated firings over the trailing window (null when not computable). */
+            would_have_fired?: number | null;
+            /** @description The trailing window used for would_have_fired. */
+            window_days: number;
+            /** @description Up to a few matching record ids for the "affects these" preview (visibility-bounded). */
+            sample?: string[];
+            /** @description Matches the caller cannot see (masked, not silently dropped) — honest count, never widens scope. */
+            excluded_by_permission?: number;
+        };
+        /**
+         * @description One firing of an automation, reconstructed from audit_log/automation_run (data-model §12.5). Runs of
+         *     EVERY outcome are first-class — including errored/blocked/skipped — so the designer's run history is
+         *     honest, not success-only (A72/ADR-0035 Am.1). Read-only: produced by the engine, never created via API.
+         */
+        AutomationRun: {
+            /** Format: uuid */
+            id: string;
+            /** Format: uuid */
+            automation_id: string;
+            /**
+             * Format: date-time
+             * @description Maps to automation_run.ran_at.
+             */
+            occurred_at: string;
+            /**
+             * @description Maps 1:1 to automation_run.status (data-model §12.5); `blocked` added by A72/ADR-0035 Am.1.
+             * @enum {string}
+             */
+            outcome: "fired" | "failed" | "blocked" | "skipped" | "queued_for_approval";
+            /**
+             * @description The tier that fired for this run.
+             * @enum {string}
+             */
+            tier: "green" | "yellow";
+            approval_required?: boolean;
+            /** @description What matched (e.g. "no activity 14d on deal BÄR Pharma") — the "why did this fire?" line. */
+            trigger_evidence?: string | null;
+            /** @description Record the run acted on (type + id or label). */
+            target_ref?: string | null;
+            /** @description What happened (e.g. "created task", "queued to approval inbox"). */
+            action_result?: string | null;
+            /** @description For failed/blocked/skipped: why (e.g. "provider error", "approval expired", "Passport no longer permits send") — from automation_run.detail. */
+            reason?: string | null;
+            /** @description Link into the audit_log row for this run. */
+            audit_id?: string | null;
         };
         /**
          * @description A user's/team's voice DNA. `voice_profile_md` is machine-DERIVED (versioned by
@@ -4693,12 +4949,25 @@ export interface components {
              * @description The acting rep's queue state for this item.
              * @enum {string}
              */
-            state: "new" | "acted" | "dismissed";
+            state: "new" | "acted" | "dismissed" | "snoozed";
             /**
              * Format: date-time
-             * @description When the rep acted/dismissed; null while new.
+             * @description When the rep acted/dismissed/snoozed; null while new.
              */
             state_at?: string | null;
+            /**
+             * Format: date-time
+             * @description When a snoozed item re-surfaces (A77/AC-home-6); set exactly while state=snoozed, null otherwise.
+             */
+            snoozed_until?: string | null;
+        };
+        /** @description Snooze a brief item until a future instant (A77/AC-home-6); it re-surfaces once the instant passes. */
+        BriefSnoozeRequest: {
+            /**
+             * Format: date-time
+             * @description When the item re-surfaces; must be in the future.
+             */
+            snoozed_until: string;
         };
         /** @description The §10.1 factor decomposition, each normalized 0..1 — the composite reconciles to it. */
         MorningBriefFeatureVector: {
@@ -5762,6 +6031,10 @@ export interface operations {
                 status?: "open" | "won" | "lost";
                 /** @description Deterministic stalled flag (no activity past the threshold). */
                 stalled?: boolean;
+                /** @description Filter to deals attributed to a specific partner org (deal.partner_org_id). */
+                partner_org_id?: string;
+                /** @description true ⇒ partner_org_id IS NOT NULL; false ⇒ partner_org_id IS NULL. Drives the partner-sourced pipeline slice. */
+                partner_sourced?: boolean;
             };
             header?: never;
             path?: never;
@@ -6696,6 +6969,7 @@ export interface operations {
                         /** Format: uuid */
                         entity_id: string;
                     }[];
+                    consent?: components["schemas"]["CaptureConsent"];
                 };
             };
         };
@@ -7084,6 +7358,76 @@ export interface operations {
             };
             404: components["responses"]["NotFound"];
             422: components["responses"]["ValidationError"];
+        };
+    };
+    previewAutomation: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["AutomationPreviewRequest"];
+            };
+        };
+        responses: {
+            /** @description Blast-radius preview. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AutomationPreview"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    listAutomationRuns: {
+        parameters: {
+            query?: {
+                /**
+                 * @description Opaque keyset cursor from a prior response's `page.next_cursor`. The cursor encodes the
+                 *     effective `sort` and `filter` of the originating request plus the last row's keyset
+                 *     (sort-key tuple + `id` tie-breaker). **Stability:** results are stable under concurrent
+                 *     inserts/updates (keyset pagination, not offset). Supplying `cursor` together with a `sort`
+                 *     or filter that differs from the one the cursor was minted under returns
+                 *     `422 code: cursor_param_mismatch` — re-issue the query without the cursor.
+                 */
+                cursor?: components["parameters"]["Cursor"];
+                /** @description Max items in the page. */
+                limit?: components["parameters"]["Limit"];
+                /** @description Filter by run outcome (matches automation_run.status, data-model §12.5). */
+                outcome?: "fired" | "failed" | "blocked" | "skipped" | "queued_for_approval";
+            };
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description A page of run records. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data: components["schemas"]["AutomationRun"][];
+                        page: components["schemas"]["PageInfo"];
+                    };
+                };
+            };
+            404: components["responses"]["NotFound"];
         };
     };
     listLeads: {
@@ -9969,6 +10313,60 @@ export interface operations {
             };
             /** @description The item was already acted on or dismissed. */
             409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["Problem"];
+                };
+            };
+        };
+    };
+    snoozeBriefItem: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description A brief_item id belonging to one of the acting rep's runs. */
+                itemId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["BriefSnoozeRequest"];
+            };
+        };
+        responses: {
+            /** @description The updated brief item. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MorningBriefItem"];
+                };
+            };
+            /** @description No such item in one of the acting rep's runs (another rep's item reads as not-found). */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["Problem"];
+                };
+            };
+            /** @description The item was already acted on or dismissed. */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["Problem"];
+                };
+            };
+            /** @description `snoozed_until` is missing or not in the future. */
+            422: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -4,9 +4,10 @@
 # the backend Makefile's MARGINCE_TEST_* defaults, dev/dev.sh, and CI's
 # service containers — change them everywhere or nowhere.
 #
-# Images track the same floating tags CI's service containers use
-# (.github/workflows/ci.yml). The check-image-pins gate covers workflow
-# `uses:` refs; digest-pinning these images rides the PR C gate-parity work.
+# Images are digest-pinned to the multi-arch INDEX digest (works on both
+# arm64 dev machines and amd64 CI), same pins as CI's service containers
+# (.github/workflows/ci.yml) — bump tag and digest together, everywhere or
+# nowhere. The check-image-pins gate fails a floating tag here.
 #
 # The project name is repo-specific: a generic name (margince-dev) collides
 # with stale volumes from the frozen poc-era stack on machines that ran it,
@@ -18,7 +19,7 @@ services:
   postgres:
     # pgvector ships inside the Postgres image: the search module's hybrid
     # retrieval needs the extension available at migrate time.
-    image: pgvector/pgvector:pg16
+    image: pgvector/pgvector:pg16@sha256:1d533553fefe4f12e5d80c7b80622ba0c382abb5758856f52983d8789179f0fb
     environment:
       POSTGRES_USER: margince_owner
       POSTGRES_PASSWORD: dev
@@ -34,7 +35,7 @@ services:
       retries: 15
 
   redis:
-    image: redis:7
+    image: redis:7@sha256:b2b95679e3b46fb51864949ed25ea976fc3a6bcc00a40a1bc00d568cb2822e50
     ports:
       - "56379:6379"
     healthcheck:

--- a/scripts/check-contract-breaking.sh
+++ b/scripts/check-contract-breaking.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Contract-drift gate, breaking-change half (ported from the foundation
+# skeleton). Severity-classifies every change to backend/api/crm.yaml since the
+# base ref and fails on ERR-level (breaking) changes; WARN/INFO-level changes
+# (additive, deprecation) pass.
+#
+# Contract-first cuts both ways: the whole-file drift gate (`make drift`)
+# proves the generated Go matches the contract, but nothing proved the
+# contract itself stayed compatible. This gate does. A deliberate breaking
+# re-sync from the spec repo runs with CONTRACT_STABILITY=pre-live, which
+# still prints every breaking change but does not block.
+#
+# Usage: check-contract-breaking.sh [base-ref]   (default: origin/main)
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+CRM_YAML="${CRM_YAML:-backend/api/crm.yaml}"
+BASE_REF="${1:-origin/main}"
+
+# The pinned tool invocation. `go run` at an exact version keeps the gate
+# reproducible without a PATH install; `make tools` also installs the same
+# version as a binary for direct use — bump both pins together.
+OASDIFF="${OASDIFF:-go run github.com/oasdiff/oasdiff@v1.22.0}"
+
+# Stance: 'stable' (default) blocks the merge on any breaking change;
+# 'pre-live' prints them but passes (for a deliberate spec re-sync).
+CONTRACT_STABILITY="${CONTRACT_STABILITY:-stable}"
+case "$CONTRACT_STABILITY" in
+  stable)   FAIL_ON="ERR" ;;
+  pre-live) FAIL_ON="NONE" ;;
+  *) echo "check-contract-breaking: unknown CONTRACT_STABILITY='$CONTRACT_STABILITY' (want stable|pre-live)" >&2; exit 2 ;;
+esac
+
+if [ ! -f "$CRM_YAML" ]; then
+  echo "check-contract-breaking: contract not found at $CRM_YAML" >&2
+  exit 2
+fi
+if ! git rev-parse --verify -q "$BASE_REF" >/dev/null; then
+  # A shallow clone has no base to diff against. CI sets REQUIRE_BASE so a
+  # dropped fetch-depth surfaces as a red gate instead of a silent skip.
+  if [ "${CONTRACT_BREAKING_REQUIRE_BASE:-}" = "1" ]; then
+    echo "check-contract-breaking: base ref '$BASE_REF' not found and CONTRACT_BREAKING_REQUIRE_BASE=1 — fetch the base ref (checkout fetch-depth)" >&2
+    exit 1
+  fi
+  echo "skip contract-breaking-check: base ref '$BASE_REF' not found (nothing to diff against)"
+  exit 0
+fi
+if ! git cat-file -e "$BASE_REF:$CRM_YAML" 2>/dev/null; then
+  echo "skip contract-breaking-check: contract did not exist at $BASE_REF (nothing to diff)"
+  exit 0
+fi
+
+if $OASDIFF breaking "$BASE_REF:$CRM_YAML" "$CRM_YAML" --fail-on "$FAIL_ON" -f text; then
+  if [ "$CONTRACT_STABILITY" = pre-live ]; then
+    echo "contract-breaking-check: advisory (CONTRACT_STABILITY=pre-live) — breaking change(s) printed above, if any, are deliberately permitted for this run"
+  else
+    echo "contract-breaking-check: no breaking API changes since $BASE_REF"
+  fi
+else
+  echo "contract-breaking-check: breaking API change(s) since $BASE_REF — deprecate instead of removing, or run a deliberate re-sync with CONTRACT_STABILITY=pre-live" >&2
+  exit 1
+fi

--- a/scripts/check-go-file-length.sh
+++ b/scripts/check-go-file-length.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Go file-length gate with a ratchet (ported from the foundation skeleton,
+# waiver list added). A hand-written Go file above the cap is a god-file split
+# candidate; generated (*_gen.go / *.gen.go) and test (*_test.go) files are
+# exempt, as is cli/craft (vendored verbatim from the foundation, hash-pinned).
+#
+# The ratchet: scripts/go-file-length-waivers.txt records each pre-existing
+# offender with its frozen line count. A waived file may shrink but never
+# grow past its recorded count; once it drops to the cap or below, its entry
+# must be REMOVED so the file is back under the hard cap for good.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+CAP="${GO_FILE_LINE_CAP:-500}"
+WAIVERS="scripts/go-file-length-waivers.txt"
+
+find backend dev -name "*.go" \
+    ! -name "*_test.go" ! -name "*_gen.go" ! -name "*.gen.go" -exec wc -l {} + \
+| awk -v cap="$CAP" -v waivers="$WAIVERS" '
+BEGIN {
+  while ((getline line < waivers) > 0) {
+    if (line ~ /^[[:space:]]*#/ || line ~ /^[[:space:]]*$/) continue
+    split(line, a, " ")
+    waived[a[2]] = a[1] + 0
+  }
+  close(waivers)
+}
+$2 == "total" { next }
+{
+  lines = $1 + 0
+  file = $2
+  if (file in waived) {
+    seen[file] = 1
+    if (lines > waived[file]) {
+      printf "FAIL: %s grew to %d lines (waiver froze it at %d) — shrink it, never grow it\n", file, lines, waived[file]
+      fail = 1
+    } else if (lines <= cap) {
+      printf "FAIL: %s is down to %d lines (<= %d) — remove its stale entry from %s so the cap re-arms\n", file, lines, cap, waivers
+      fail = 1
+    }
+  } else if (lines > cap) {
+    printf "FAIL: %s is %d lines (> %d) — split into one-concept-per-file packages\n", file, lines, cap
+    fail = 1
+  }
+}
+END {
+  for (f in waived) if (!(f in seen)) {
+    printf "FAIL: waiver entry for missing file %s — remove it from %s\n", f, waivers
+    fail = 1
+  }
+  if (fail) {
+    printf "FAIL: go-file-length — the %d-LOC cap (ratcheted via %s)\n", cap, waivers
+    exit 1
+  }
+  n = 0; for (f in waived) n++
+  printf "OK: go-file-length — no hand-written Go file exceeds %d LOC (waivers: %d)\n", cap, n
+}
+'

--- a/scripts/check-image-pins.sh
+++ b/scripts/check-image-pins.sh
@@ -1,24 +1,27 @@
 #!/usr/bin/env bash
-# check-image-pins.sh — fail unless every .github/workflows/*.yml|*.yaml
-# `uses:` line is pinned to an immutable ref (supply-chain: a symbolic ref
-# lets a compromised action ride into CI unreviewed).
+# check-image-pins.sh — fail unless every workflow `uses:` action AND every
+# container `image:` (workflow service containers + the compose dev stack) is
+# pinned to an immutable ref (supply-chain: a symbolic ref lets a compromised
+# artifact ride into CI unreviewed).
 # Allows:  @<40-char-hex>       (git commit SHA, e.g. actions/checkout@11bd71...)
 #          @<64-char-hex>       (SHA-256 object id)
-#          @sha256:<hex>        (image digest)
+#          @sha256:<hex>        (image digest; tag@digest is the readable form)
 #          ./path               (local composite action — pinned by this repo)
-# Rejects: everything else — tags (@v4, @v1.2.3-beta), branches (@main,
-#          @develop), and an unpinned `uses:` with no @ at all. An allowlist,
-#          not a denylist: a ref shape we didn't anticipate fails closed.
+# Rejects: everything else — tags (@v4, redis:7), branches (@main), and an
+#          unpinned ref with no @ at all. An allowlist, not a denylist: a ref
+#          shape we didn't anticipate fails closed.
 set -euo pipefail
 
 fail=0
 workflow_dir=".github/workflows"
+compose_files="infra/docker-compose.dev.yml"
 
 if [ ! -d "$workflow_dir" ]; then
   echo "No $workflow_dir directory found — skipping image-pin check"
   exit 0
 fi
 
+# --- Workflow `uses:` actions: pinned to a commit SHA or digest ---
 while IFS= read -r line; do
   # Extract the part after `uses:` to check the pin
   pin=$(echo "$line" | sed 's/.*uses:[[:space:]]*//' | cut -d'#' -f1 | tr -d ' "'"'")
@@ -31,6 +34,23 @@ while IFS= read -r line; do
     fail=1
   fi
 done < <(grep -rn 'uses:' "$workflow_dir"/*.yml "$workflow_dir"/*.yaml 2>/dev/null || true)
+
+# --- Container images (workflow services + compose): pinned by digest ---
+# A tag pin is not enough for images: tags are mutable, only @sha256: binds
+# the bytes. Commented-out lines (e.g. the compose file's parked MinIO block)
+# are skipped; everything else fails closed.
+while IFS= read -r line; do
+  content="${line#*:}"                              # strip the file:lineno prefix
+  content="${content#*:}"
+  case "$(echo "$content" | sed 's/^[[:space:]]*//')" in
+    \#*) continue ;;                                # commented out — not pulled
+  esac
+  image=$(echo "$content" | sed 's/.*image:[[:space:]]*//' | cut -d'#' -f1 | tr -d ' "'"'")
+  if ! echo "$image" | grep -qE '@sha256:[0-9a-f]{64}$'; then
+    echo "UNPINNED IMAGE (pin as tag@sha256:<digest>): $line" >&2
+    fail=1
+  fi
+done < <(grep -rn 'image:' "$workflow_dir"/*.yml "$workflow_dir"/*.yaml $compose_files 2>/dev/null || true)
 
 if [ "$fail" -eq 0 ]; then
   echo "image pins OK"

--- a/scripts/check-test-lanes.sh
+++ b/scripts/check-test-lanes.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Test-lane separation (ported from the foundation skeleton).
+#
+# A unit test (one WITHOUT a `//go:build integration` or `//go:build livesmoke`
+# tag, so it runs under `make test`) must never open a REAL Postgres/Redis
+# connection. Anything that needs real infrastructure belongs in the
+# integration lane. This keeps `make test` hermetic and kills the "DB test
+# that silently degrades in the unit lane" anti-pattern.
+#
+# Fakes are fine and NOT flagged: in-memory drivers and miniredis-style
+# clients carry none of the markers below.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+# Markers that only a real connection uses. MARGINCE_TEST_* are the env vars
+# the integration harness reads (backend/Makefile exports them from db-up's
+# port contract); a unit test reaching for them is in the wrong lane.
+real='sql\.Open\("(postgres|pgx)"|pgxpool\.New|os\.Getenv\("MARGINCE_TEST_(DSN|APP_DSN|REDIS)"\)|redis\.ParseURL'
+
+violations=0
+while IFS= read -r f; do
+  # Skip files already in a non-unit lane (build-tagged below the SPDX header).
+  if head -5 "$f" | grep -qE '^//go:build .*(integration|livesmoke)'; then
+    continue
+  fi
+  if grep -Eq "$real" "$f"; then
+    echo "VIOLATION (unit test opens real infra — add //go:build integration, or fake the boundary): $f"
+    grep -nE "$real" "$f" | sed 's/^/    /'
+    violations=1
+  fi
+# Search roots: every hand-written Go tree. cli/craft is vendored verbatim
+# from the foundation (hash-pinned); its lane discipline is upstream's job.
+done < <(find backend dev -name '*_test.go' 2>/dev/null | sort)
+
+if [ "$violations" -ne 0 ]; then
+  echo "FAIL: test-lanes — real-infra tests must carry //go:build integration."
+  exit 1
+fi
+echo "OK: test-lanes — no unit test opens a real DB/Redis"

--- a/scripts/check-test-lanes.sh
+++ b/scripts/check-test-lanes.sh
@@ -7,20 +7,23 @@
 # integration lane. This keeps `make test` hermetic and kills the "DB test
 # that silently degrades in the unit lane" anti-pattern.
 #
-# Fakes are fine and NOT flagged: in-memory drivers and miniredis-style
-# clients carry none of the markers below.
+# Fakes are fine and NOT flagged: in-memory fake sql drivers carry none of
+# the markers below. If a miniredis-style fake (which does dial via
+# redis.NewClient) ever joins the unit lane, narrow that marker then —
+# deliberately, in this file — rather than pre-weakening the gate today.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
 # Markers that only a real connection uses. MARGINCE_TEST_* are the env vars
 # the integration harness reads (backend/Makefile exports them from db-up's
 # port contract); a unit test reaching for them is in the wrong lane.
-real='sql\.Open\("(postgres|pgx)"|pgxpool\.New|os\.Getenv\("MARGINCE_TEST_(DSN|APP_DSN|REDIS)"\)|redis\.ParseURL'
+real='sql\.Open\("(postgres|pgx)"|pgxpool\.New|pgx\.Connect|os\.Getenv\("MARGINCE_TEST_(DSN|APP_DSN|REDIS)"\)|redis\.ParseURL|redis\.New(Universal)?Client'
 
 violations=0
 while IFS= read -r f; do
-  # Skip files already in a non-unit lane (build-tagged below the SPDX header).
-  if head -5 "$f" | grep -qE '^//go:build .*(integration|livesmoke)'; then
+  # Skip files already in a non-unit lane. Build constraints sit anywhere
+  # above the package clause, so scan up to it instead of a fixed head.
+  if sed -n '/^package /q;p' "$f" | grep -qE '^//go:build .*(integration|livesmoke)'; then
     continue
   fi
   if grep -Eq "$real" "$f"; then

--- a/scripts/go-file-length-waivers.txt
+++ b/scripts/go-file-length-waivers.txt
@@ -1,0 +1,5 @@
+# Pre-existing files over the 500-LOC cap, frozen at their line count when
+# the gate landed (scripts/check-go-file-length.sh). Shrinking is allowed;
+# growing is not. When a file drops to 500 or below, DELETE its line here.
+# Format: <frozen-line-count> <path>
+501 backend/internal/compose/report.go


### PR DESCRIPTION
## Summary

PR C of the skeleton-baseline worklist (`docs/worklists/skeleton-baseline-2026-07-09.md` §1b / §4.4): the foundation skeleton's remaining gate suite, ported onto this repo's layout. Every gate is wired into `make check` (root or backend) **and** CI. Design decisions ratified in **decisions/0020-gate-parity.md**. Follows PR A (#28, mechanical batch) and PR B (#29, dev experience).

- **contract-breaking-check** — pinned oasdiff (v1.22.0 via `go run`; also in `make tools`) severity-gates `backend/api/crm.yaml` vs `origin/main`: breaking fails, additive passes. `CONTRACT_STABILITY=pre-live` is the deliberate-re-sync escape. CI checks out `fetch-depth: 0` and sets `CONTRACT_BREAKING_REQUIRE_BASE=1` so a shallow checkout reads as red, never as a silent skip.
- **TS type drift** — `make frontend-check` (local + the frontend CI job) runs `pnpm gen:api` + `git diff --exit-code`. The gate immediately proved itself: `frontend/src/api/schema.d.ts` was 400+ lines stale behind crm.yaml — the regenerated types are committed here and the frontend lane is green on them.
- **test-lanes** — `scripts/check-test-lanes.sh`: no untagged test may carry real-PG/Redis markers (`MARGINCE_TEST_*`, `pgxpool.New`, `sql.Open("pgx"/"postgres")`, `redis.ParseURL`); real-infra suites carry `//go:build integration` (or `livesmoke`).
- **zero-skip integration** — `make test-integration` greps its `-v` output for `--- SKIP` and fails: a skipped RLS/erasure suite reads as red.
- **golangci expansion, new-code-only** (the §1b DECISION, recommended arm) — `backend/.golangci.strict.yml` carries the skeleton's expanded set (gocritic, staticcheck-all, funlen/cyclop/gocognit/maintidx/dupl/nestif, rowserrcheck/sqlclosecheck/bodyclose/noctx/contextcheck, forcetypeassert, nilnil/nilerr, forbidigo, goconst/unparam/ireturn/tagliatelle/predeclared, nolintlint, gofumpt+gci) gated by `new-from-merge-base: origin/main`, and also lints the `integration`/`livesmoke` tags. The baseline `.golangci.yml` is untouched so the depguard DAG stays repo-wide. `make lint` runs both passes.
- **go-file-length** — hard 500-LOC cap with a ratchet (`scripts/go-file-length-waivers.txt`: shrink yes, grow no, ≤500 ⇒ entry removed). Single live waiver: `compose/report.go` (501) — the worklist's named offenders were already split under 500 by the Strojny work.
- **digest-pinned images** — compose + CI service containers pin `tag@sha256:` (multi-arch **index** digests, one pin for arm64 dev and amd64 CI); `scripts/check-image-pins.sh` grew a fail-closed `image:` pass over workflows and `infra/docker-compose.dev.yml`.

Also: worklist §1b checkboxes ticked, STATUS.md session entry, CLAUDE.md/AGENTS.md merge-gate line kept in sync.

## Verification

- Root `make check` green (all new root gates + backend build/vet/lint×2/arch-lint/tests/drift).
- `make frontend-check` green post-regeneration (and observed red on the stale types before — the gate bites).
- Full `make test-integration` green against the digest-pinned compose stack: **“test-integration: green with zero skips”**.
- Negative tests: oasdiff exits non-zero on a removed endpoint; the ratchet fails on grow/stale/missing-file entries; the pins gate fails on an unpinned `image:`; the strict lint flags a scratch `fmt.Println` violation as new code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new API capabilities for previewing automations, viewing automation run history, snoozing brief items, and richer deal/meeting/lead/partner data.
  * Improved relationship and activity visibility with additional derived fields and broader status tracking.

* **Bug Fixes**
  * Strengthened release safeguards so contract-breaking changes, skipped tests, schema drift, oversized files, and unpinned images are caught earlier.

* **Chores**
  * Reproducibility improved by pinning container images to exact versions in development and CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->