### PR TITLE
chore: skeleton-baseline PR D — frontend RBAC primitives + token-purity gates (worklist §1d)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,11 +35,17 @@ verify-boot:
 eval:
 	cd backend && go test ./internal/compose -run 'TestColdStartGolden' -v
 
-## frontend-check — the frontend merge lane. The gen:api + diff pair is the
+## frontend-check — the frontend merge lane. The three token-purity gates
+## (ported from the foundation skeleton) run first: cheap fail-closed greps
+## on top of the vitest conformance suite, so the discipline holds even if
+## the test tree regresses. The gen:api + diff pair is the
 ## TS type-drift gate: src/api/schema.d.ts is generated from crm.yaml, and a
 ## contract change that skips regeneration would silently strand the frontend
 ## types — regenerate and commit them together.
 frontend-check:
+	frontend/scripts/check-ds-purity.sh
+	frontend/scripts/check-font-lock.sh
+	frontend/scripts/check-icon-glyph.sh
 	cd frontend && pnpm install --frozen-lockfile && pnpm gen:api && \
 		{ git diff --exit-code -- src/api/schema.d.ts || \
 			{ echo "frontend types drifted from backend/api/crm.yaml — commit the regenerated src/api/schema.d.ts (printed above)"; exit 1; }; } && \

--- a/STATUS.md
+++ b/STATUS.md
@@ -5,6 +5,41 @@
 > [AGENTS.md](AGENTS.md) for the binding rules. Update this file at the
 > end of every working session.
 
+## ▶ RESTART HERE (2026-07-09 PM — skeleton-baseline PR D: frontend RBAC primitives + token-purity gates)
+
+**PR D — the §1d frontend batch (this session), the two non-DECISION items:**
+
+- **RBAC primitives** (skeleton concepts, adapted to our screens and the
+  /v1/me principal): ONE shared `useMe()` in `screens/common.tsx` — the App
+  auth gate, the settings identity card, and every role-aware surface now
+  read the same `["me"]` probe. `RoleBadge` + `FieldGuard`
+  (`design-system/rbac.tsx`) render localized role labels (five seeded keys,
+  raw fallback for workspace-defined roles) and "withheld, not absent"
+  masking — used on the settings passport rows for the never-re-disclosed
+  token. Nav gating landed where the server actually differentiates roles:
+  the canonical 9-item rail has no admin-only screen (AC-shell-1), so the
+  automations editor (config is admin/ops-owned, decisions/0006) hides its
+  Use/pause/edit/delete affordances behind `canConfigureAutomations` and
+  shows an honest read-only notice for manager/rep. Client-side gating is UX
+  honesty only — the server's `auth.Require` stays the authority; no new
+  endpoints. i18n en+de for all new copy; unit tests per touched screen
+  (rbac, settings — new suite, automations incl. rep-vs-admin affordances);
+  the `RoleBadge` prop is `roleKey` (Biome reads a JSX `role` prop as ARIA).
+- **Token-purity gates** — `frontend/scripts/check-{ds-purity,font-lock,
+  icon-glyph}.sh`, the first steps of `make frontend-check` (local + the
+  frontend CI job): colour literals only in `tokens.css`; only the three §2
+  families (+ generics and `var(--f-*)`); no emoji glyphs in rendered code
+  (comment content stripped — the house 🟢/🟡 tier notation is spec prose,
+  not UI; generated `schema.d.ts` excluded). Fail-closed like the PR C
+  gates, including an empty-scan guard; each verified red on a violation
+  fixture. They are the cheap grep arm ON TOP of the vitest conformance
+  suite, not a replacement. The skeleton's Tailwind-utility/px arms were
+  dropped, not ported — our DS is CSS-custom-property based.
+
+Worklist §1d: both non-DECISION items ticked; the DECISION items (routing,
+Storybook, Forge DS, second SPA) stay open. Still queued from §4: PR E OSS
+packaging, §1c ADRs, and the login-500-on-unknown-workspace identity wart.
+
 ## ▶ RESTART HERE (2026-07-09 PM — skeleton-baseline PR C: gate parity landed)
 
 **PR C — the §1b gate-parity batch (this session):** all seven scoped

--- a/STATUS.md
+++ b/STATUS.md
@@ -36,6 +36,14 @@
   suite, not a replacement. The skeleton's Tailwind-utility/px arms were
   dropped, not ported — our DS is CSS-custom-property based.
 
+- **Drive-by: the AC e2e suite is machine-independent now** — the AC
+  criteria assert the German chrome but the Playwright config never pinned
+  a locale, so 19 specs failed on any non-German machine (reproduced
+  identically on origin/main; the suite had only ever run on a de-locale
+  host). Pinned `locale: "de-DE"`; AC-shell-1's rail read additionally
+  raced the auth splash (`evaluateAll` never waits) — anchored on
+  `toHaveCount(9)`. 37/37 green twice on an en-locale machine.
+
 Worklist §1d: both non-DECISION items ticked; the DECISION items (routing,
 Storybook, Forge DS, second SPA) stay open. Still queued from §4: PR E OSS
 packaging, §1c ADRs, and the login-500-on-unknown-workspace identity wart.

--- a/docs/worklists/skeleton-baseline-2026-07-09.md
+++ b/docs/worklists/skeleton-baseline-2026-07-09.md
@@ -190,17 +190,34 @@ Skeleton FE is a scaffold (1 real page) but with better *infrastructure*:
       vs our custom hash router. Ours works across ~19 screens; migration is
       churn without user-visible gain. Recommend: keep hash router for now,
       note as tech-debt candidate.
-- [ ] **RBAC primitives** — skeleton's `adminOnly` rail gating, `FieldGuard`
+- [x] **RBAC primitives** — skeleton's `adminOnly` rail gating, `FieldGuard`
       masking, `RoleBadge`. We have no client-side role gating. Port the
       *concepts* into our shell/nav (small, real value).
+      (Done PR D — adapted to our IA: the canonical 9-item rail has no
+      admin-only screen (AC-shell-1), so the nav-gating concept lands where
+      the server actually differentiates roles — the automations editor
+      (admin/ops-owned config per decisions/0006) hides its mutation
+      affordances for other roles behind `canConfigureAutomations` and says
+      why. One shared `useMe()` (screens/common) feeds the auth gate and
+      every role-aware surface; `RoleBadge` renders localized role labels in
+      settings; `FieldGuard` masks the never-re-disclosed passport token as
+      "withheld, not absent". Client-side is UX honesty only — the server's
+      auth.Require stays the authority.)
 - [ ] `DECISION (frontend)` **Storybook + component test lane** — skeleton
       has 10 stories + storybook-in-vitest browser project + `ui-shots`
       capture. We have none. Valuable for the design-system surface; adds a
       toolchain. Recommend adopt when the design system stabilizes.
-- [ ] **Design-token purity gates** — `ds-purity` (no raw hex/px),
+- [x] **Design-token purity gates** — `ds-purity` (no raw hex/px),
       `font-lock`, `icon-lint`. We already have token conformance *tests*;
       the skeleton's are cheap greps wired as gates. Port and adapt to our
       token names.
+      (Done PR D — `frontend/scripts/check-{ds-purity,font-lock,icon-glyph}.sh`,
+      first steps of `make frontend-check` so the frontend CI job runs them;
+      fail-closed incl. an empty-scan guard. Adapted: colour literals only in
+      tokens.css; the three §2 families + var(--f-*); emoji scan strips
+      comments (the house 🟢/🟡 tier notation is not rendered UI) and skips
+      the generated schema.d.ts. The skeleton's Tailwind-utility/px arms have
+      no equivalent in our CSS-custom-property DS — dropped, not ported.)
 - [ ] `DECISION (frontend)` **Forge design system** — skeleton vendors
       `@shared/{token,ui}` (Forge); we have a bespoke ~740-LOC design
       system. Which is the product's DS of record? Ties to the foundation's

--- a/frontend/e2e/ac.spec.ts
+++ b/frontend/e2e/ac.spec.ts
@@ -27,6 +27,9 @@ test("AC-shell-1: the rail renders the canonical 9 items in order", async ({
   page,
 }) => {
   await page.goto("/#/home");
+  // evaluateAll never waits — anchor on the rendered count first, or the
+  // read races the auth splash and sees an empty rail.
+  await expect(page.locator("nav.rail a.navitem")).toHaveCount(9);
   const labels = await page
     .locator("nav.rail a.navitem")
     .evaluateAll((links) =>

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -12,6 +12,10 @@ export default defineConfig({
   use: {
     baseURL: process.env.BASE_URL ?? "http://localhost:4317",
     viewport: { width: 1280, height: 800 },
+    // The AC criteria assert the German chrome; detectLocale reads the
+    // browser's language, so pin it — otherwise the suite only passes on a
+    // machine whose system locale happens to be German.
+    locale: "de-DE",
     // the SW would compete with the network-edge seed mocks
     serviceWorkers: "block",
   },

--- a/frontend/scripts/check-ds-purity.sh
+++ b/frontend/scripts/check-ds-purity.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Design-token purity gate (ported from the foundation skeleton, adapted to
+# the Ledger-Green token system): every colour in hand-written frontend code
+# reads a token — literal colours live ONLY in src/design-system/tokens.css,
+# where tokens.test.ts pins each value to the design source of truth.
+#
+# Fails on, anywhere else under frontend/src (*.ts / *.tsx / *.css):
+#   1. Hex literals (#abc / #aabbcc / #aabbccdd) — use var(--token)
+#   2. Raw colour functions rgb()/rgba()/hsl()/hsla()/oklch() — use a token
+#
+# This is the fail-closed grep arm on top of the vitest conformance suite
+# (design-system/conformance.test.ts): the same discipline holds even if the
+# test tree regresses. The skeleton's Tailwind-utility checks (text-[Npx],
+# gf-prefix classes) have no equivalent here — our DS is CSS-custom-property
+# based, not Tailwind-class based.
+#
+# Usage: frontend/scripts/check-ds-purity.sh   (wired into `make frontend-check`)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SRC_DIR="$(cd "$SCRIPT_DIR/.." && pwd)/src"
+
+# Excluded: the token source file (literals are its job), generated contract
+# types, and test files (fixtures aren't shipped UI).
+FILES=()
+while IFS= read -r -d '' f; do FILES+=("$f"); done < <(
+  find "$SRC_DIR" -type f \( -name "*.ts" -o -name "*.tsx" -o -name "*.css" \) \
+    -not -name "*.test.*" \
+    -not -name "tokens.css" \
+    -not -name "schema.d.ts" \
+    -print0 2>/dev/null
+)
+
+# An empty scan means the gate is pointed at the wrong tree — fail closed.
+if [[ "${#FILES[@]}" -eq 0 ]]; then
+  echo "FAIL: DS purity found no files under $SRC_DIR — the gate is miswired" >&2
+  exit 1
+fi
+
+echo "==> DS purity check (${#FILES[@]} files under frontend/src)"
+
+EXIT=0
+
+check() {
+  local label="$1"
+  local pattern="$2"
+  local hits
+  hits=$(printf '%s\0' "${FILES[@]}" | xargs -0 grep -nHE "$pattern" || true)
+  if [[ -n "$hits" ]]; then
+    echo ""
+    echo "FAIL: $label"
+    echo "$hits"
+    EXIT=1
+  fi
+}
+
+check "hex colour literal (read it from a token — see design-system/tokens.css)" \
+  '#([0-9a-fA-F]{8}|[0-9a-fA-F]{6}|[0-9a-fA-F]{3})\b'
+
+check "raw colour function (use var(--token) or color-mix over a token)" \
+  '\b(rgba?|hsla?|oklch)\('
+
+if [[ "$EXIT" == "0" ]]; then
+  echo "PASS — every colour outside tokens.css reads a token"
+else
+  echo ""
+  echo "Literal colours live only in src/design-system/tokens.css (ADR-0040)."
+fi
+
+exit $EXIT

--- a/frontend/scripts/check-font-lock.sh
+++ b/frontend/scripts/check-font-lock.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Font-lock gate (ported from the foundation skeleton): the three-family type
+# rule (design §2) — every font-family declaration under frontend/src names
+# only Outfit (display), DM Sans (body), or JetBrains Mono (mono).
+#
+# Allowed besides the three families: the generic stack fallbacks the §2
+# token definitions name (system-ui, sans-serif, ui-monospace, monospace) and
+# var(--f-*) references, which resolve inside tokens.css.
+#
+# Fail-closed grep arm on top of the vitest conformance suite — same
+# discipline even if the test tree regresses.
+#
+# Usage: frontend/scripts/check-font-lock.sh   (wired into `make frontend-check`)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SRC_DIR="$(cd "$SCRIPT_DIR/.." && pwd)/src"
+
+FILES=()
+while IFS= read -r -d '' f; do FILES+=("$f"); done < <(
+  find "$SRC_DIR" -type f \( -name "*.ts" -o -name "*.tsx" -o -name "*.css" \) \
+    -not -name "*.test.*" \
+    -not -name "schema.d.ts" \
+    -print0 2>/dev/null
+)
+
+if [[ "${#FILES[@]}" -eq 0 ]]; then
+  echo "FAIL: font-lock found no files under $SRC_DIR — the gate is miswired" >&2
+  exit 1
+fi
+
+echo "==> Font-lock check (${#FILES[@]} files under frontend/src)"
+
+EXIT=0
+
+# For each font-family declaration, strip everything allowed; any residue is
+# a family outside the three-family rule.
+while IFS= read -r hit; do
+  value=$(echo "$hit" | grep -oE "font-family\s*:[^;]+" | head -1)
+  [[ -z "$value" ]] && continue
+  stripped=$(echo "$value" \
+    | sed -E 's/font-family\s*://g' \
+    | sed -E 's/var\(--[A-Za-z0-9-]+\)//g' \
+    | sed -E 's/JetBrains Mono//g' \
+    | sed -E 's/DM Sans//g' \
+    | sed -E 's/Outfit//g' \
+    | sed -E 's/system-ui//g' \
+    | sed -E 's/sans-serif//g' \
+    | sed -E 's/ui-monospace//g' \
+    | sed -E 's/monospace//g' \
+    | tr -d '",'"'"',; \t')
+  if [[ -n "$stripped" ]]; then
+    echo "FAIL (family outside the three-family rule): $hit"
+    EXIT=1
+  fi
+done < <(
+  printf '%s\0' "${FILES[@]}" \
+    | xargs -0 grep -nHE "font-family\s*:" 2>/dev/null \
+  || true
+)
+
+if [[ "$EXIT" == "0" ]]; then
+  echo "PASS — only Outfit / DM Sans / JetBrains Mono (+ generic fallbacks)"
+else
+  echo ""
+  echo "Allowed: Outfit, DM Sans, JetBrains Mono; generics system-ui,"
+  echo "sans-serif, ui-monospace, monospace; var(--f-*) token references."
+fi
+
+exit $EXIT

--- a/frontend/scripts/check-icon-glyph.sh
+++ b/frontend/scripts/check-icon-glyph.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Icon-glyph gate (ported from the foundation skeleton): UI glyphs are
+# lucide-react only — no emoji/pictographic Unicode in rendered frontend
+# code. The sanctioned 🟢/🟡 autonomy semantics render through the CSS .dot
+# component (design-system/trust.tsx AutonomyDot), never as text glyphs.
+#
+# Scope: code, not commentary. Comment content is stripped before scanning —
+# source comments quote the spec's 🟢/🟡 tier notation (house style across the
+# repo) and are not rendered UI. String literals hiding an emoji behind a
+# "//" (rare) are still caught by the AST-accurate vitest conformance gate;
+# this is the fail-closed grep arm on top of it.
+#
+# Excluded: test files (fixtures) and the generated schema.d.ts (its doc
+# comments quote crm.yaml prose verbatim).
+#
+# Uses perl -CSD for Unicode ranges (BSD grep lacks -P).
+#
+# Usage: frontend/scripts/check-icon-glyph.sh   (wired into `make frontend-check`)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SRC_DIR="$(cd "$SCRIPT_DIR/.." && pwd)/src"
+
+FILES=()
+while IFS= read -r -d '' f; do FILES+=("$f"); done < <(
+  find "$SRC_DIR" -type f \( -name "*.ts" -o -name "*.tsx" -o -name "*.css" \) \
+    -not -name "*.test.*" \
+    -not -name "schema.d.ts" \
+    -print0 2>/dev/null
+)
+
+if [[ "${#FILES[@]}" -eq 0 ]]; then
+  echo "FAIL: icon-glyph found no files under $SRC_DIR — the gate is miswired" >&2
+  exit 1
+fi
+
+echo "==> Icon-glyph check (${#FILES[@]} files under frontend/src)"
+
+EXIT=0
+
+# Ranges: Misc Symbols & Pictographs / Emoticons / Transport / Supplemental
+# (U+1F300–U+1FAFF), regional indicators (U+1F1E6–U+1F1FF), Misc Symbols &
+# Dingbats (U+2600–U+27BF), Misc Symbols and Arrows (U+2B00–U+2BFF), and
+# VS-16 (U+FE0F). U+2022 "•" (the FieldGuard mask) is outside all of them.
+while IFS= read -r hit; do
+  [[ -z "$hit" ]] && continue
+  echo "FAIL (emoji glyph in rendered code — use a lucide-react icon): $hit"
+  EXIT=1
+done < <(
+  printf '%s\0' "${FILES[@]}" \
+    | xargs -0 perl -CSD -ne '
+      my $line = $_;
+      $line =~ s{^\s*(?:/\*|\*|//).*$}{};   # whole-line comments
+      $line =~ s{\{?/\*.*?\*/\}?}{}g;       # inline (JSX) block comments
+      $line =~ s{//.*$}{};                  # trailing line comments
+      if ($line =~ /[\x{1F300}-\x{1FAFF}\x{1F1E6}-\x{1F1FF}\x{2600}-\x{27BF}\x{2B00}-\x{2BFF}\x{FE0F}]/) {
+        chomp; print $ARGV . ":" . $. . ": " . $_ . "\n";
+      }
+      close ARGV if eof
+    ' 2>/dev/null \
+  || true
+)
+
+if [[ "$EXIT" == "0" ]]; then
+  echo "PASS — no emoji glyphs in rendered code (lucide-react only)"
+else
+  echo ""
+  echo "Replace the glyph with a lucide-react icon, or — for autonomy tiers —"
+  echo "the AutonomyDot component (design-system/trust.tsx)."
+fi
+
+exit $EXIT

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
 import { type ReactNode, useCallback, useState } from "react";
-import { api, workspaceSlug } from "./api/client";
 import { AskFab } from "./app/fab";
 import {
   CommandPalette,
@@ -15,6 +13,7 @@ import { AuthScreen } from "./screens/auth";
 import { AutomationsScreen } from "./screens/automations";
 import { BookingScreen } from "./screens/book";
 import { ClientSurfaceScreen } from "./screens/client";
+import { useMe } from "./screens/common";
 import { DealScreen, DealsScreen } from "./screens/deals";
 import { DesignScreen } from "./screens/design";
 import { HomeScreen } from "./screens/home";
@@ -105,22 +104,7 @@ export function App() {
 function AuthedApp({
   route,
 }: Readonly<{ route: ReturnType<typeof useRoute> }>) {
-  const me = useQuery({
-    queryKey: ["me"],
-    retry: false,
-    queryFn: async () => {
-      if (!workspaceSlug()) {
-        // No workspace resolved yet — treat as unauthenticated without a
-        // guaranteed-401 round-trip.
-        throw new Error("no workspace");
-      }
-      const { data, error } = await api.GET("/me");
-      if (error) {
-        throw new Error("unauthenticated");
-      }
-      return data;
-    },
-  });
+  const me = useMe();
 
   const [paletteOpen, setPaletteOpen] = useState(false);
   const commands = useBuiltinCommands();

--- a/frontend/src/design-system/rbac.test.tsx
+++ b/frontend/src/design-system/rbac.test.tsx
@@ -1,0 +1,57 @@
+/** @vitest-environment jsdom */
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it } from "vitest";
+import { type Locale, LocaleProvider } from "../i18n";
+import { FieldGuard, RoleBadge } from "./rbac";
+
+afterEach(cleanup);
+
+const renderIn = (locale: Locale, ui: ReactNode) =>
+  render(<LocaleProvider initial={locale}>{ui}</LocaleProvider>);
+
+describe("RoleBadge", () => {
+  it("renders seeded role keys as localized labels", () => {
+    renderIn(
+      "en",
+      <>
+        <RoleBadge roleKey="admin" />
+        <RoleBadge roleKey="read_only" />
+      </>,
+    );
+    expect(screen.getByText("Admin")).toBeTruthy();
+    expect(screen.getByText("Read-only")).toBeTruthy();
+    expect(screen.queryByText("read_only")).toBeNull();
+  });
+
+  it("localizes to German", () => {
+    renderIn(
+      "de",
+      <>
+        <RoleBadge roleKey="rep" />
+        <RoleBadge roleKey="read_only" />
+      </>,
+    );
+    expect(screen.getByText("Vertrieb")).toBeTruthy();
+    expect(screen.getByText("Nur Lesen")).toBeTruthy();
+  });
+
+  it("falls back to the raw key for a workspace-defined role — never invented copy", () => {
+    renderIn("en", <RoleBadge roleKey="field_marketing" />);
+    expect(screen.getByText("field_marketing")).toBeTruthy();
+  });
+});
+
+describe("FieldGuard", () => {
+  it("masked reads as withheld — a visible mask with a11y semantics, the value never rendered", () => {
+    renderIn("en", <FieldGuard mode="masked">mgp_secret</FieldGuard>);
+    expect(screen.getByRole("img", { name: "Masked value" })).toBeTruthy();
+    expect(screen.queryByText(/mgp_secret/)).toBeNull();
+  });
+
+  it("visible passes the value through without a mask node", () => {
+    renderIn("en", <FieldGuard mode="visible">plain value</FieldGuard>);
+    expect(screen.getByText("plain value")).toBeTruthy();
+    expect(screen.queryByRole("img", { name: "Masked value" })).toBeNull();
+  });
+});

--- a/frontend/src/design-system/rbac.tsx
+++ b/frontend/src/design-system/rbac.tsx
@@ -1,0 +1,53 @@
+import type { ReactNode } from "react";
+import { useT } from "../i18n";
+import type { MessageKey } from "../i18n/en";
+import { Badge } from "./atoms";
+
+// RBAC presentation primitives (ported concepts from the foundation
+// skeleton's shared/ui): how a principal's role and a withheld value read on
+// screen. Presentation ONLY — the server's admission gates are the authority
+// on what a role may do and what the wire discloses.
+
+// The five seeded system roles (decisions/0006). A workspace-defined role key
+// outside this set renders as its raw key — honest, never invented copy.
+const ROLE_LABEL_KEYS: Record<string, MessageKey> = {
+  admin: "role.admin",
+  manager: "role.manager",
+  rep: "role.rep",
+  read_only: "role.readOnly",
+  ops: "role.ops",
+};
+
+export function RoleBadge({ roleKey }: Readonly<{ roleKey: string }>) {
+  const t = useT();
+  const labelKey = ROLE_LABEL_KEYS[roleKey];
+  return <Badge tone="accent">{labelKey ? t(labelKey) : roleKey}</Badge>;
+}
+
+// A withheld value must read as "withheld", not "absent" — omitting the node
+// is indistinguishable from there being no data. `masked` renders a visible
+// mask token; `visible` passes the value through. Masking is presentation
+// over values the wire already withholds (a passport token today; field-level
+// masks when B-EP03.4 lands) — it never hides data the client was given as a
+// substitute for a server gate.
+export function FieldGuard({
+  mode,
+  children,
+}: Readonly<{ mode: "visible" | "masked"; children?: ReactNode }>) {
+  const t = useT();
+  if (mode === "masked") {
+    return (
+      // NOSONAR: CSS-only mask glyph, same pattern as AutonomyDot — role=img
+      // gives assistive tech the "withheld value" semantics.
+      <span
+        role="img"
+        aria-label={t("rbac.masked")}
+        className="t-mono"
+        style={{ userSelect: "none", letterSpacing: "0.2em" }}
+      >
+        ••••
+      </span>
+    );
+  }
+  return <>{children}</>;
+}

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -252,6 +252,12 @@ export const de = {
   "ai.paletteHint": "Frag von überall mit",
 
   "settings.identity": "Du",
+  "role.admin": "Admin",
+  "role.manager": "Manager",
+  "role.rep": "Vertrieb",
+  "role.readOnly": "Nur Lesen",
+  "role.ops": "Ops",
+  "rbac.masked": "Verborgener Wert",
   "settings.workspace": "Workspace-Verbindung",
   "settings.workspaceSub":
     "nur lokale Entwicklung — produktiv kommt der Workspace aus der Subdomain",
@@ -263,6 +269,7 @@ export const de = {
   "settings.passportLabel": "Agentenname",
   "settings.mint": "Passport ausstellen",
   "settings.tokenOnce": "Jetzt kopieren — dieses Token siehst du nur einmal.",
+  "settings.token": "Token",
   "settings.autonomy": "Autonomie-Stufen",
   "settings.autonomySub": "was sofort läuft und was im Eingang wartet",
   "settings.tierRead":
@@ -561,6 +568,8 @@ export const de = {
 
   "auto.sub":
     "ein geschlossener Katalog — Typ wählen, Parameter setzen, aktivieren",
+  "auto.readOnly":
+    "Nur-Lese-Ansicht — Automatisierungen verwalten die Rollen Admin und Ops.",
   "auto.catalog": "Starter-Bibliothek",
   "auto.catalogSub": "die geschlossene Menge an Automatisierungstypen",
   "auto.instances": "Eingerichtete Automatisierungen",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -248,6 +248,12 @@ export const en = {
   "ai.paletteHint": "Ask from anywhere with",
 
   "settings.identity": "You",
+  "role.admin": "Admin",
+  "role.manager": "Manager",
+  "role.rep": "Rep",
+  "role.readOnly": "Read-only",
+  "role.ops": "Ops",
+  "rbac.masked": "Masked value",
   "settings.workspace": "Workspace connection",
   "settings.workspaceSub":
     "local dev only — production resolves the workspace from the subdomain",
@@ -259,6 +265,7 @@ export const en = {
   "settings.passportLabel": "Agent name",
   "settings.mint": "Mint passport",
   "settings.tokenOnce": "Copy it now — you'll only see this token once.",
+  "settings.token": "token",
   "settings.autonomy": "Autonomy tiers",
   "settings.autonomySub": "what runs instantly vs. what waits in the inbox",
   "settings.tierRead": "Read, summarize, draft — runs instantly, fully logged.",
@@ -548,6 +555,8 @@ export const en = {
     "I agree that my name and email are stored to arrange and follow up on this meeting.",
 
   "auto.sub": "a closed catalog — pick a type, set its parameters, enable it",
+  "auto.readOnly":
+    "Read-only view — automation settings are managed by the admin and ops roles.",
   "auto.catalog": "Starter library",
   "auto.catalogSub": "the closed set of automation types",
   "auto.instances": "Configured automations",

--- a/frontend/src/screens/automations.test.tsx
+++ b/frontend/src/screens/automations.test.tsx
@@ -9,7 +9,7 @@ import {
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { components } from "../api/schema";
 import { LocaleProvider } from "../i18n";
 import { AutomationRow, AutomationsScreen, paramFields } from "./automations";
@@ -21,9 +21,16 @@ import { AutomationRow, AutomationsScreen, paramFields } from "./automations";
 // (PATCH + If-Match), and authorship-blind rendering (the row is a pure
 // function of the Automation wire schema).
 
+beforeEach(() => {
+  // the screen sits behind the auth gate in the app; the useMe probe needs a
+  // resolved workspace before it will ask /v1/me
+  globalThis.localStorage.setItem("margince.workspaceSlug", "acme");
+});
+
 afterEach(() => {
   cleanup();
   vi.unstubAllGlobals();
+  globalThis.localStorage.clear();
   window.location.hash = "";
 });
 
@@ -88,11 +95,18 @@ type Recorded = {
   ifMatch: string | null;
 };
 
-function automationsBackend(automations: Automation[], calls: Recorded[]) {
+function automationsBackend(
+  automations: Automation[],
+  calls: Recorded[],
+  roles: string[] = ["admin"],
+) {
   return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
     const request = input instanceof Request ? input : null;
     const url = String(request ? request.url : input);
     const method = request ? request.method : (init?.method ?? "GET");
+    if (url.endsWith("/v1/me")) {
+      return jsonResponse({ user: {}, roles, teams: [] });
+    }
     if (url.includes("/automations/catalog")) {
       return jsonResponse({ data: catalog });
     }
@@ -247,16 +261,66 @@ describe("AutomationsScreen (B-EP09.15)", () => {
     const fields = instance({});
     const first = render(
       <ul>
-        <AutomationRow automation={{ ...fields }} entry={catalog[0]} />
+        <AutomationRow
+          automation={{ ...fields }}
+          entry={catalog[0]}
+          canConfigure
+        />
       </ul>,
     );
     const firstHtml = first.container.innerHTML;
     cleanup();
     const second = render(
       <ul>
-        <AutomationRow automation={{ ...fields }} entry={catalog[0]} />
+        <AutomationRow
+          automation={{ ...fields }}
+          entry={catalog[0]}
+          canConfigure
+        />
       </ul>,
     );
     expect(second.container.innerHTML).toBe(firstHtml);
+  });
+
+  it("a role without the automation config grant gets the honest read-only editor", async () => {
+    // manager/rep hold read-only automation grants (decisions/0006): the
+    // screen still shows catalog + instances, but no affordance that could
+    // only 403 — and it says WHY instead of silently thinning out.
+    const automations = [instance({})];
+    vi.stubGlobal("fetch", automationsBackend(automations, [], ["rep"]));
+    render(<AutomationsScreen />);
+    await waitFor(() =>
+      expect(screen.getByText("Nudge stalled fleet deals")).toBeTruthy(),
+    );
+    expect(
+      screen.getByText(
+        "Read-only view — automation settings are managed by the admin and ops roles.",
+      ),
+    ).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Use template" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Enable" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Edit" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Delete" })).toBeNull();
+  });
+
+  it("the config affordances stay for admin", async () => {
+    const automations = [instance({})];
+    vi.stubGlobal("fetch", automationsBackend(automations, []));
+    render(<AutomationsScreen />);
+    await waitFor(() =>
+      expect(screen.getByText("Nudge stalled fleet deals")).toBeTruthy(),
+    );
+    expect(
+      screen.queryByText(
+        "Read-only view — automation settings are managed by the admin and ops roles.",
+      ),
+    ).toBeNull();
+    await waitFor(() =>
+      expect(
+        screen.getAllByRole("button", { name: "Use template" }).length,
+      ).toBeGreaterThan(0),
+    );
+    expect(screen.getByRole("button", { name: "Enable" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Delete" })).toBeTruthy();
   });
 });

--- a/frontend/src/screens/automations.tsx
+++ b/frontend/src/screens/automations.tsx
@@ -10,7 +10,12 @@ import {
 } from "../design-system/atoms";
 import { AutonomyDot } from "../design-system/trust";
 import { useT } from "../i18n";
-import { problemMessage, QueryGate } from "./common";
+import {
+  canConfigureAutomations,
+  problemMessage,
+  QueryGate,
+  useMe,
+} from "./common";
 
 // The automations editor (B-EP09.15): a management UI over the CLOSED
 // catalog (E15/ADR-0035). The anti-DSL invariant of features/10 §1 holds by
@@ -182,12 +187,17 @@ function AutomationForm({
 
 // One instance row, rendered from the Automation wire schema alone — no
 // origin field exists on the wire, so authorship cannot change the render.
+// canConfigure gates the mutation affordances (pause/edit/delete): the seeded
+// policies make automation config admin/ops-owned, so other roles get the
+// honest read-only row instead of buttons that can only 403.
 export function AutomationRow({
   automation,
   entry,
+  canConfigure,
 }: Readonly<{
   automation: Automation;
   entry?: CatalogEntry;
+  canConfigure: boolean;
 }>) {
   const t = useT();
   const queryClient = useQueryClient();
@@ -267,28 +277,32 @@ export function AutomationRow({
             .join(" ")}
         </span>
         <span style={{ flexGrow: 1 }} />
-        <Button
-          small
-          disabled={patch.isPending}
-          onClick={() =>
-            patch.mutate({ status: enabled ? "paused" : "enabled" })
-          }
-        >
-          {enabled ? t("auto.pause") : t("auto.enable")}
-        </Button>
-        {entry && (
-          <Button small onClick={() => setEditing((open) => !open)}>
-            {t("trust.edit")}
-          </Button>
+        {canConfigure && (
+          <>
+            <Button
+              small
+              disabled={patch.isPending}
+              onClick={() =>
+                patch.mutate({ status: enabled ? "paused" : "enabled" })
+              }
+            >
+              {enabled ? t("auto.pause") : t("auto.enable")}
+            </Button>
+            {entry && (
+              <Button small onClick={() => setEditing((open) => !open)}>
+                {t("trust.edit")}
+              </Button>
+            )}
+            <Button
+              small
+              variant="danger"
+              disabled={remove.isPending}
+              onClick={() => remove.mutate()}
+            >
+              {t("auto.delete")}
+            </Button>
+          </>
         )}
-        <Button
-          small
-          variant="danger"
-          disabled={remove.isPending}
-          onClick={() => remove.mutate()}
-        >
-          {t("auto.delete")}
-        </Button>
       </div>
       {editing && entry && (
         <AutomationForm
@@ -317,6 +331,10 @@ export function AutomationsScreen() {
   const t = useT();
   const queryClient = useQueryClient();
   const [template, setTemplate] = useState<CatalogEntry | null>(null);
+  // Roles come from the session (/v1/me); until they arrive the screen shows
+  // no mutation affordances — buttons appear when the grant is confirmed.
+  const me = useMe();
+  const canConfigure = canConfigureAutomations(me.data?.roles);
 
   const catalog = useQuery({
     queryKey: ["automation-catalog"],
@@ -368,6 +386,11 @@ export function AutomationsScreen() {
   return (
     <div className="wrap">
       <SectionHeader title={t("nav.automations")} sub={t("auto.sub")} />
+      {me.isSuccess && !canConfigure && (
+        <p className="t-caption" style={{ marginBottom: 10 }}>
+          {t("auto.readOnly")}
+        </p>
+      )}
       <div style={{ display: "flex", gap: 14, flexWrap: "wrap" }}>
         <section className="card" style={{ flex: "1 1 260px", minWidth: 240 }}>
           <SectionHeader title={t("auto.catalog")} sub={t("auto.catalogSub")} />
@@ -397,9 +420,11 @@ export function AutomationsScreen() {
                         />
                       )}
                       <strong>{entry.name}</strong>
-                      <Button small onClick={() => setTemplate(entry)}>
-                        {t("auto.use")}
-                      </Button>
+                      {canConfigure && (
+                        <Button small onClick={() => setTemplate(entry)}>
+                          {t("auto.use")}
+                        </Button>
+                      )}
                     </div>
                     {entry.description && (
                       <p className="t-caption" style={{ marginTop: 2 }}>
@@ -451,6 +476,7 @@ export function AutomationsScreen() {
                     key={automation.id}
                     automation={automation}
                     entry={entryFor(automation.key)}
+                    canConfigure={canConfigure}
                   />
                 ))}
               </ul>

--- a/frontend/src/screens/common.tsx
+++ b/frontend/src/screens/common.tsx
@@ -1,12 +1,46 @@
-import type { UseQueryResult } from "@tanstack/react-query";
+import { type UseQueryResult, useQuery } from "@tanstack/react-query";
 import type { ReactNode } from "react";
+import { api, workspaceSlug } from "../api/client";
 import { Button, EmptyState, Skeleton } from "../design-system/atoms";
 import type { Provenance } from "../design-system/trust";
 import { useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 
 // Shared screen plumbing: honest loading / error / empty states (§3a screen-
-// state matrix) and the captured_by → provenance mapping every list reuses.
+// state matrix), the captured_by → provenance mapping every list reuses, and
+// the ONE /me query the auth gate and every role-aware surface share.
+
+// The session principal (GET /v1/me): identity + effective role keys. One
+// spelling, one ["me"] cache entry — the App auth gate, the settings identity
+// card, and role-aware affordances all read the same probe. Without a
+// workspace slug there is no tenant to ask, so the hook fails fast instead of
+// guaranteeing a 401 round-trip.
+export function useMe() {
+  return useQuery({
+    queryKey: ["me"],
+    retry: false,
+    queryFn: async () => {
+      if (!workspaceSlug()) {
+        throw new Error("no workspace");
+      }
+      const { data, error } = await api.GET("/me");
+      if (error) {
+        throw new Error(problemMessage(error));
+      }
+      return data;
+    },
+  });
+}
+
+// Automation (and pipeline) config is admin/ops-owned in the seeded role
+// policies (decisions/0006) — manager and rep hold read-only grants. This
+// mirror gates AFFORDANCES only (UX honesty: no buttons that can only 403);
+// the server's auth.Require gate stays the authority on every mutation.
+export function canConfigureAutomations(
+  roles: readonly string[] | undefined,
+): boolean {
+  return (roles ?? []).some((role) => role === "admin" || role === "ops");
+}
 
 export function QueryGate<Data>({
   query,

--- a/frontend/src/screens/settings.test.tsx
+++ b/frontend/src/screens/settings.test.tsx
@@ -1,0 +1,99 @@
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  cleanup,
+  render as rtlRender,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { LocaleProvider } from "../i18n";
+import { SettingsScreen } from "./settings";
+
+// The settings identity + passport surfaces through the RBAC primitives:
+// roles render as localized RoleBadges (a workspace-defined key stays raw),
+// and the passport list's token slot reads as WITHHELD (FieldGuard mask) —
+// the wire schema carries no token, and the row says so instead of omitting
+// the field as if none existed.
+
+beforeEach(() => {
+  globalThis.localStorage.setItem("margince.workspaceSlug", "acme");
+  vi.stubGlobal("fetch", settingsBackend());
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  globalThis.localStorage.clear();
+});
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+// Routed by URL so every card on the screen gets an honest per-endpoint
+// answer; the cards not under test render their empty states.
+function settingsBackend() {
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input instanceof Request ? input.url : input);
+    if (url.endsWith("/v1/me")) {
+      return jsonResponse({
+        user: { email: "ada@acme.test" },
+        roles: ["admin", "field_marketing"],
+        teams: [],
+      });
+    }
+    if (url.includes("/passports")) {
+      return jsonResponse({
+        data: [
+          {
+            id: "pp-1",
+            label: "Scout",
+            scopes: ["read"],
+            created_at: "2026-07-01T08:00:00Z",
+            expires_at: null,
+            revoked_at: null,
+          },
+        ],
+        page: { next_cursor: null, has_more: false },
+      });
+    }
+    return jsonResponse({
+      data: [],
+      page: { next_cursor: null, has_more: false },
+    });
+  });
+}
+
+const render = (ui: ReactNode) => {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return rtlRender(
+    <QueryClientProvider client={client}>
+      <LocaleProvider initial="en">{ui}</LocaleProvider>
+    </QueryClientProvider>,
+  );
+};
+
+describe("SettingsScreen RBAC surfaces", () => {
+  it("renders the session roles as localized badges; a custom key stays its raw self", async () => {
+    render(<SettingsScreen />);
+    await waitFor(() => expect(screen.getByText("ada@acme.test")).toBeTruthy());
+    expect(screen.getByText("Admin")).toBeTruthy();
+    expect(screen.getByText("field_marketing")).toBeTruthy();
+    // the seeded key never leaks raw once a label exists
+    expect(screen.queryByText("admin")).toBeNull();
+  });
+
+  it("the passport row's token reads as withheld — masked, never re-disclosed", async () => {
+    render(<SettingsScreen />);
+    await waitFor(() => expect(screen.getByText("Scout")).toBeTruthy());
+    expect(screen.getByRole("img", { name: "Masked value" })).toBeTruthy();
+    expect(screen.queryByText(/mgp_/)).toBeNull();
+  });
+});

--- a/frontend/src/screens/settings.tsx
+++ b/frontend/src/screens/settings.tsx
@@ -9,10 +9,11 @@ import {
   Skeleton,
   TextInput,
 } from "../design-system/atoms";
+import { FieldGuard, RoleBadge } from "../design-system/rbac";
 import { AutonomyDot } from "../design-system/trust";
 import { formatDate, formatDateTime } from "../format/format";
 import { useLocale, useT } from "../i18n";
-import { problemMessage, QueryGate } from "./common";
+import { problemMessage, QueryGate, useMe } from "./common";
 
 // Settings governance surface (B-EP09.13b): renders FROM the live seams —
 // /me (identity + effective roles), passports (mint + the metadata list,
@@ -41,16 +42,7 @@ export function SettingsScreen() {
 
 function IdentityCard() {
   const t = useT();
-  const query = useQuery({
-    queryKey: ["me"],
-    queryFn: async () => {
-      const { data, error } = await api.GET("/me");
-      if (error) {
-        throw new Error(problemMessage(error));
-      }
-      return data;
-    },
-  });
+  const query = useMe();
   return (
     <section className="card" style={{ marginBottom: 14 }}>
       <SectionHeader title={t("settings.identity")} />
@@ -66,9 +58,7 @@ function IdentityCard() {
           >
             <span>{me.user.email}</span>
             {me.roles.map((role) => (
-              <Badge key={role} tone="accent">
-                {role}
-              </Badge>
+              <RoleBadge key={role} roleKey={role} />
             ))}
           </div>
         )}
@@ -260,6 +250,10 @@ function PassportCard() {
                   }}
                 >
                   <strong>{passport.label}</strong>
+                  {/* The credential exists but is withheld by design (shown
+                      once at mint) — masked reads as "withheld", not absent. */}
+                  <span className="t-label">{t("settings.token")}</span>
+                  <FieldGuard mode="masked" />
                   {passport.scopes.map((scope) => (
                     <Badge key={scope}>{scope}</Badge>
                   ))}


### PR DESCRIPTION
The §4.5 "PR D (frontend)" batch from docs/worklists/skeleton-baseline-2026-07-09.md — the two non-DECISION §1d items, ported from the foundation skeleton and adapted to this repo. Follows PRs A (#28), B (#29), C (#30).

## 1. RBAC primitives (skeleton concepts → our screens, /v1/me principal)

- **One `useMe()`** (`screens/common.tsx`): the App auth gate, the settings identity card, and every role-aware surface now share the same `["me"]` probe/cache entry — previously two divergent inline spellings.
- **`RoleBadge`** (`design-system/rbac.tsx`): the five seeded role keys (decisions/0006) render as localized labels (en+de); a workspace-defined key stays its raw self. Used in the settings identity card. (Prop is `roleKey`, not `role` — Biome reads a JSX `role` prop as an ARIA role.)
- **`FieldGuard`**: a withheld value reads as *withheld*, not absent — used on the settings passport rows for the never-re-disclosed token (the wire schema deliberately carries none).
- **Affordance gating where the server actually differentiates roles**: automation config is admin/ops-owned (seeded policies); the automations editor now hides Use/pause/edit/delete behind `canConfigureAutomations` and shows an honest read-only notice for manager/rep, instead of buttons that can only 403.

Adaptation note: the canonical 9-item rail has no admin-only screen (AC-shell-1), so the skeleton's `adminOnly` rail arm lands as the automations affordance gate — no speculative nav mechanism without a live caller. Client-side gating is UX honesty only: the server's `auth.Require` stays the authority, and **no endpoints were added**.

Tests: new `rbac.test.tsx` (badge localization, mask semantics), new `settings.test.tsx` (localized badges, masked token, no `mgp_` leak), extended `automations.test.tsx` (rep sees the read-only editor; admin keeps the affordances).

## 2. Design-token purity gates

`frontend/scripts/check-{ds-purity,font-lock,icon-glyph}.sh`, wired as the first steps of `make frontend-check` (so the frontend CI job runs them). Fail-closed like the PR C gates, including an empty-scan guard; each verified red on a violation fixture. They are the cheap grep arm **on top of** the vitest conformance suite (same discipline holds even if the test tree regresses), adapted to our tokens:

- ds-purity: colour literals (hex, rgb/hsl/oklch) only in `src/design-system/tokens.css`
- font-lock: only the three §2 families + generic fallbacks + `var(--f-*)`
- icon-glyph: no emoji in rendered code (lucide-react only); comment content stripped — the house 🟢/🟡 tier notation quotes spec prose, not UI — and generated `schema.d.ts` excluded

Dropped, not ported: the skeleton's Tailwind-utility/px arms — our DS is CSS-custom-property based; there is no token vocabulary those checks could point at.

## 3. Drive-by: the AC e2e suite is now machine-independent

Found while verifying end-to-end: the AC criteria assert the German chrome, but the Playwright config never pinned a locale — 19 specs failed on any non-German machine (reproduced identically on origin/main). Pinned `locale: "de-DE"`; also anchored AC-shell-1's rail read on `toHaveCount(9)` (`evaluateAll` never waits — it raced the auth splash). Suite is 37/37 green twice in a row on an en-locale machine.

## Verification

- `make check` green (root + backend gates; no backend code touched)
- `make frontend-check` green (3 new gates → lint → 104 unit tests → tsc+vite build), TS-drift gate untouched
- `make frontend-e2e` 37/37 green ×2
- Each new gate proven red on a violation fixture; icon gate proven comment-exempt

Also ticks the two §1d worklist checkboxes and adds the STATUS.md session entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)