### PR TITLE
fix(identity): public auth paths answer client errors, not 500, on an unresolvable workspace

### DIFF
--- a/backend/internal/modules/identity/oauth.go
+++ b/backend/internal/modules/identity/oauth.go
@@ -96,6 +96,11 @@ func (h Handlers) oauthRegister(w http.ResponseWriter, r *http.Request) {
 			clientID, req.ClientName, req.RedirectURIs)
 		return err
 	})
+	if errors.Is(err, database.ErrNoWorkspace) {
+		// Registration is per tenant; the request's host resolved to none.
+		oauthError(w, http.StatusBadRequest, "invalid_request", "no workspace resolved for this request")
+		return
+	}
 	if err != nil {
 		httperr.Write(w, r, err)
 		return

--- a/backend/internal/modules/identity/oauth_token.go
+++ b/backend/internal/modules/identity/oauth_token.go
@@ -48,7 +48,9 @@ func (h Handlers) oauthToken(w http.ResponseWriter, r *http.Request) {
 
 	userID, workspaceID, scopes, err := h.redeemAuthCode(r, code, verifier)
 	switch {
-	case errors.Is(err, errCodeSpent):
+	// A code cannot exist in a workspace that doesn't resolve, and the
+	// answer must not distinguish that from a spent code.
+	case errors.Is(err, errCodeSpent), errors.Is(err, database.ErrNoWorkspace):
 		oauthError(w, http.StatusBadRequest, "invalid_grant", "code is unknown, expired, or already used")
 		return
 	case errors.Is(err, errGrantMismatch):

--- a/backend/internal/modules/identity/service.go
+++ b/backend/internal/modules/identity/service.go
@@ -274,7 +274,11 @@ func mustRandomSecret() string {
 func (s *Service) Login(ctx context.Context, email, plaintext string) (Identity, string, error) {
 	rawWsID, ok := principal.WorkspaceID(ctx)
 	if !ok {
-		return Identity{}, "", database.ErrNoWorkspace
+		// The resolver middleware binds no workspace when the slug doesn't
+		// exist — login stays public so bootstrap can work — and the answer
+		// must not disclose which failed: credentials against a tenant that
+		// isn't there read exactly like wrong credentials.
+		return Identity{}, "", ErrBadCredentials
 	}
 	wsID := ids.From[ids.WorkspaceKind](rawWsID)
 	token, tokenHash, err := mintSessionToken()
@@ -365,6 +369,11 @@ func (s *Service) Authenticate(ctx context.Context, rawToken string) (Identity, 
 // Logout revokes the session behind the cookie. Revoking an unknown or
 // already-revoked token is a no-op: logout is idempotent.
 func (s *Service) Logout(ctx context.Context, rawToken string) error {
+	if _, ok := principal.WorkspaceID(ctx); !ok {
+		// A workspace that doesn't resolve holds no sessions — nothing to
+		// revoke, same no-op as an unknown token.
+		return nil
+	}
 	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx,
 			`UPDATE session SET revoked_at = now() WHERE token_hash = $1 AND revoked_at IS NULL`,

--- a/backend/internal/modules/identity/workspace_unresolved_test.go
+++ b/backend/internal/modules/identity/workspace_unresolved_test.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package identity
+
+// The public auth paths stay reachable when the tenant slug resolves to
+// nothing (the middleware binds no workspace so bootstrap keeps working).
+// Each of them must answer its protocol's client error, never a 500 —
+// and the credential surfaces must not disclose whether the workspace
+// exists: a login or code exchange against a tenant that isn't there
+// reads exactly like one against bad credentials.
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func workspacelessHandlers() Handlers {
+	// The guards under test fire before any SQL, so a zero Service (nil
+	// pool) proves no database round-trip happens on these paths.
+	return NewHandlers(&Service{}, nil)
+}
+
+func TestLoginAgainstUnresolvedWorkspaceReadsLikeBadCredentials(t *testing.T) {
+	h := workspacelessHandlers()
+	req := httptest.NewRequest(http.MethodPost, "/v1/auth/login",
+		strings.NewReader(`{"email":"someone@example.test","password":"whatever-password"}`))
+	rec := httptest.NewRecorder()
+
+	h.Login(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("login status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+	var problem struct {
+		Detail string `json:"detail"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &problem); err != nil {
+		t.Fatalf("login body is not a problem document: %v", err)
+	}
+	// The same detail the wrong-password branch writes — the response must
+	// not distinguish "workspace absent" from "credentials wrong".
+	if problem.Detail != "invalid email or password" {
+		t.Errorf("login detail = %q, want the bad-credentials wording", problem.Detail)
+	}
+}
+
+func TestLogoutAgainstUnresolvedWorkspaceStaysIdempotent(t *testing.T) {
+	h := workspacelessHandlers()
+	req := httptest.NewRequest(http.MethodPost, "/v1/auth/logout", nil)
+	req.AddCookie(&http.Cookie{Name: sessionCookie, Value: "stale-token"}) // #nosec G124 -- request-side cookie: AddCookie sends name=value only; Secure/HttpOnly are response attributes
+	rec := httptest.NewRecorder()
+
+	h.Logout(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("logout status = %d, want %d", rec.Code, http.StatusNoContent)
+	}
+	cleared := false
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == sessionCookie && c.MaxAge < 0 {
+			cleared = true
+		}
+	}
+	if !cleared {
+		t.Error("logout left the session cookie standing; want it cleared")
+	}
+}
+
+func TestOAuthTokenAgainstUnresolvedWorkspaceReadsLikeSpentCode(t *testing.T) {
+	h := workspacelessHandlers()
+	form := url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {"some-authorization-code"},
+		"code_verifier": {"some-code-verifier"},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/oauth/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	h.oauthToken(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("token status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+	var body struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("token body is not an oauth error document: %v", err)
+	}
+	// invalid_grant is what a spent or unknown code answers — a code in a
+	// workspace that doesn't resolve must be indistinguishable from it.
+	if body.Error != "invalid_grant" {
+		t.Errorf("token error = %q, want %q", body.Error, "invalid_grant")
+	}
+}
+
+func TestOAuthRegisterAgainstUnresolvedWorkspaceIsRefused(t *testing.T) {
+	h := workspacelessHandlers()
+	req := httptest.NewRequest(http.MethodPost, "/oauth/register",
+		strings.NewReader(`{"client_name":"probe","redirect_uris":["https://client.example/cb"]}`))
+	rec := httptest.NewRecorder()
+
+	h.oauthRegister(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("register status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+	var body struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("register body is not an oauth error document: %v", err)
+	}
+	if body.Error != "invalid_request" {
+		t.Errorf("register error = %q, want %q", body.Error, "invalid_request")
+	}
+}


### PR DESCRIPTION
## What

`POST /v1/auth/login` against a nonexistent workspace answered **500** (`pg: no workspace bound to context`) instead of 401 — the identity wart from the STATUS.md follow-ups (spotted during PR B seed work).

## Why it happened

The resolver middleware deliberately binds no workspace on public paths (bootstrap must stay reachable), so the request fell through to the tenant transaction and the infra sentinel `database.ErrNoWorkspace` surfaced as an unhandled 500.

## How it's fixed

Per the house error rules (RFC 7807, existence-hiding — the response must not disclose whether the workspace exists), and sweeping the whole class per binding rule 1 (*fix the invariant, not the call site* — every public path that can reach a tenant query got the same treatment):

- **`POST /v1/auth/login`** → 401 with the exact bad-credentials wording; a login against a tenant that isn't there reads identically to a wrong password.
- **`POST /v1/auth/logout`** → 204; a workspace that doesn't resolve holds no sessions, the same idempotent no-op as an unknown token.
- **`POST /oauth/token`** → 400 `invalid_grant`, identical to a spent/unknown code.
- **`POST /oauth/register`** → 400 `invalid_request`.

`/oauth/authorize` and `/v1/workspaces` were checked and need nothing: authorize demands a session (middleware already 401s), bootstrap legitimately runs workspace-less.

## How verified

- New hermetic unit suite `workspace_unresolved_test.go` pins all four statuses and the existence-hiding bodies; the guards fire before any SQL (proven by a nil pool). Red on main (all four answered 500), green here.
- `make check` green; `make test-integration` (real-Postgres RLS + HTTP e2e lane) green with zero skips.

## AI involvement

Generated — authored by a Claude Code session, reviewed under the repo's gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)