### PR TITLE
feat: keyvault seam + connector-credential migration (worklist §1c platform-parity)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -89,6 +89,20 @@ MARGINCE_DSN=postgres://margince_app:margince_app_dev@localhost:55432/margince
 # MARGINCE_BLOBSTORE_REGION=us-east-1
 # MARGINCE_BLOBSTORE_USE_SSL=false
 
+# ── Secret vault (keyvault — connector credentials) ──────────────────────────
+
+# [optional] The AES-256 root key that seals connector credentials at rest
+# (decisions/0023). Base64 (standard encoding) of exactly 32 bytes. Set it to
+# enable the /readyz keyvault probe and the vault-backed connector-credential
+# path (Connect seals, Sync resolves); the worker migrates any legacy auth-bytea
+# rows onto the vault at boot. Leave it unset and the transient one-shot IMAP
+# pull still works (it persists no credential); the persisting paths refuse
+# loudly rather than store a credential in the clear. A key that is SET but not
+# 32 bytes is a boot error — never a silent fallback. Comes from the
+# environment, never a CLI flag (argv is world-readable). Both api and worker
+# read it. Generate one with: `openssl rand -base64 32`.
+# MARGINCE_KEYVAULT_ROOT_KEY=
+
 # ── MCP server binary (cmd/mcp — separate process) ───────────────────────────
 
 # [required by mcp, stdio transport] The Agent Seat Passport token (mgp_…,

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,13 @@ coverage.out
 .build/
 .DS_Store
 
+# Compiled cmd binaries left in the module dir by `go build ./cmd/<role>`
+# (anchored so they never match the cmd/<role> source directories; the api
+# binary can't land here — backend/api/ is the OpenAPI contract directory).
+/backend/worker
+/backend/migrate
+/backend/mcp
+
 # Session working notes — local only, not part of the published repo
 /review_*.md
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -57,6 +57,20 @@ Merged so far:
   the Art. 17 erase-path object purge, so erasure reaches the bytes not
   only the rows. MinIO is in the dev compose stack and both CI integration
   jobs; a `/readyz` probe covers it (decisions/0022).
+- **Keyvault seam** — `platform/keyvault` (AES-256-GCM local provider +
+  in-memory fake), secret-material storage behind an opaque,
+  workspace-scoped `credential_ref`. Ships with its first real secret
+  migrated: `connector_connection.auth` (bytea) moves off the tenant row
+  onto the vault, leaving only a ref on the row (the `auth` column is
+  dropped in a later additive migration after backfill). Isolation is
+  cryptographic — the ref carries its workspace and the GCM AAD binds it,
+  so a stolen ref is inert across the tenant edge; the `vault_secret`
+  ciphertext table is operational infra (no `workspace_id`, no RLS), like
+  River's tables. `WithKeyvault` feeds a `/readyz` probe; the worker
+  backfills legacy rows at boot (idempotent). Env-only root key
+  (`MARGINCE_KEYVAULT_ROOT_KEY`, base64 32-byte). The connector port is
+  unchanged — capture resolves the ref and still hands the connector its
+  `Auth` (decisions/0023).
 
 ## Pick up here
 
@@ -67,11 +81,16 @@ Open work, roughly in priority order:
   repo's actual architecture. Until it lands, the spec-path references in
   CLAUDE.md / AGENTS.md / README (`../margince/specs/`) are left as-is;
   they repoint together once the canonical public spec home is decided.
-- **ADR track** (parallel, each needs a decision record): connector
-  keyvault (decisions/0023 drafted; pair with the EP05 §B capture-connection
-  reshape), retiring or keeping the second (embedded) SPA, the
-  design-system of record, and the optional advisory LLM craft-review CI
-  job. (River shipped in #35; the blobstore seam in this batch.)
+- **EP05 §B capture-connection reshape** — now unblocked by the keyvault
+  seam: multiple per-user connections, the connection-management contract
+  surface + UI, and connector credential *rotation* (the ref/AAD scheme
+  already carries a key version so rotation is not foreclosed). Its own PR
+  arc. The `oauth` signing keypairs (`workspace_signing_key`) fold onto the
+  same vault next, as a distinct migration (decisions/0023).
+- **ADR track** (parallel, each needs a decision record): retiring or
+  keeping the second (embedded) SPA, the design-system of record, and the
+  optional advisory LLM craft-review CI job. (River shipped in #35, the
+  blobstore seam in the prior batch, the keyvault seam in this one.)
 - **Frontend DECISION items** from worklist §1d: router migration and a
   Storybook/component-test lane — adopt when the design system
   stabilizes, not before.

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -38,6 +38,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/events"
 	"github.com/gradionhq/margince/backend/internal/platform/httpserver"
+	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
 )
 
 func main() {
@@ -118,6 +119,12 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 	}
 	opts = append(opts, blobOpts...)
 
+	kvOpts, err := keyvaultOptions(pool, stdout)
+	if err != nil {
+		return err
+	}
+	opts = append(opts, kvOpts...)
+
 	stopRelay := func() {
 		// No inline relay to stop unless --inline-relay wires one below.
 	}
@@ -184,6 +191,25 @@ func blobstoreOptions(ctx context.Context, stdout io.Writer) ([]compose.Option, 
 	}
 	_, _ = fmt.Fprintln(stdout, "api attachments enabled (blobstore configured)")
 	return []compose.Option{compose.WithBlobstore(blob)}, nil
+}
+
+// keyvaultOptions wires the secret vault — its /readyz probe and the
+// vault-backed connector-credential path — only when a root key is
+// configured. Without one the vault stays absent: the transient one-shot IMAP
+// pull (which persists no credential) still works, and the persisting paths
+// (Connect/Sync) refuse loudly rather than nil-deref if ever invoked. A key
+// that is set but malformed is a boot error (keyvault.FromEnv), never a silent
+// fallback to something weaker.
+func keyvaultOptions(pool *pgxpool.Pool, stdout io.Writer) ([]compose.Option, error) {
+	vault, configured, err := keyvault.FromEnv(pool)
+	if err != nil {
+		return nil, fmt.Errorf("api: keyvault: %w", err)
+	}
+	if !configured {
+		return nil, nil
+	}
+	_, _ = fmt.Fprintln(stdout, "api connector-credential vault enabled (keyvault configured)")
+	return []compose.Option{compose.WithKeyvault(vault)}, nil
 }
 
 // startInlineRelay boots the in-process outbox relay. The bus is not

--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -41,6 +41,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/events"
 	"github.com/gradionhq/margince/backend/internal/platform/httpserver"
+	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
 	kevents "github.com/gradionhq/margince/backend/internal/shared/kernel/events"
 )
 
@@ -155,6 +156,10 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 	_, _ = fmt.Fprintf(stdout, "worker evaluating retention every %s\n", cfg.retentionInterval)
 	background.Go(func() { privacy.RunRetention(ctx, retention, cfg.retentionInterval, logger) })
 
+	if err := backfillConnectorCredentials(ctx, pool, stdout, logger); err != nil {
+		return err
+	}
+
 	stopJobs, err := startJobRunner(ctx, pool, logger, cfg, stdout)
 	if err != nil {
 		return err
@@ -170,6 +175,32 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 	// the next boot — shutdown loses no events.
 	events.NewRelay(pool, rdb, logger).Run(ctx)
 	background.Wait()
+	return nil
+}
+
+// backfillConnectorCredentials migrates any legacy connector_connection rows
+// whose credential still lives in the auth bytea column onto the keyvault
+// (decisions/0023). It runs once at boot when a vault is configured and is
+// idempotent — a row already carrying a credential_ref is skipped — so
+// re-running every boot is safe and a no-op once every row is migrated.
+// Without a vault it is skipped: the legacy auth column still resolves
+// credentials until one is provisioned. A malformed root key fails the boot
+// (keyvault.FromEnv); a mid-backfill failure is logged and non-fatal — capture
+// keeps resolving from the auth column and the next boot retries.
+func backfillConnectorCredentials(ctx context.Context, pool *pgxpool.Pool, stdout io.Writer, logger *slog.Logger) error {
+	vault, configured, err := keyvault.FromEnv(pool)
+	if err != nil {
+		return fmt.Errorf("worker: keyvault: %w", err)
+	}
+	if !configured {
+		return nil
+	}
+	migrated, err := compose.NewCaptureRegistry(pool, vault).BackfillCredentials(ctx)
+	if err != nil {
+		logger.Error("connector-credential backfill did not complete; capture continues from the legacy column and the next boot retries", "err", err)
+		return nil
+	}
+	_, _ = fmt.Fprintf(stdout, "worker keyvault configured; migrated %d legacy connector credential(s) onto the vault\n", migrated)
 	return nil
 }
 

--- a/backend/internal/compose/capture.go
+++ b/backend/internal/compose/capture.go
@@ -19,14 +19,17 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/approvals"
 	"github.com/gradionhq/margince/backend/internal/modules/capture"
 	"github.com/gradionhq/margince/backend/internal/modules/identity"
+	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
-// NewCaptureRegistry builds the connector registry; process roles
-// register their compiled-in connectors on it and drive SyncOnce.
-func NewCaptureRegistry(pool *pgxpool.Pool) *capture.Registry {
+// NewCaptureRegistry builds the connector registry; process roles register
+// their compiled-in connectors on it and drive SyncOnce. The vault seals and
+// resolves each connection's credential (nil is valid for a role that only
+// runs the transient one-shot pull, which persists no credential).
+func NewCaptureRegistry(pool *pgxpool.Pool, vault keyvault.Vault) *capture.Registry {
 	sink := capture.NewSink(pool).WithStager(mergeStager{svc: approvals.NewService(pool)})
-	return capture.NewRegistry(pool, sink, identity.NewService(pool))
+	return capture.NewRegistry(pool, sink, identity.NewService(pool), vault)
 }
 
 // mergeStager adapts the approvals engine to capture's dedupe seam.

--- a/backend/internal/compose/integration/capture_integration_test.go
+++ b/backend/internal/compose/integration/capture_integration_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/modules/capture"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -118,7 +119,7 @@ func TestCaptureSyncIsIdempotentAndProvenanced(t *testing.T) {
 	e := setupSearch(t)
 	personID := e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Inbox Sender', 'manual', 'human:x')`)
 
-	registry := newTestCaptureRegistry(e)
+	registry := newTestCaptureRegistry(e, newTestKeyvault(t, e))
 	fake := &mailFake{linkTo: personID}
 	registry.Register(fake)
 
@@ -188,7 +189,7 @@ func TestCaptureSyncIsIdempotentAndProvenanced(t *testing.T) {
 
 func TestCaptureScopeIntersectionRefusesOverScopedConnector(t *testing.T) {
 	e := setupSearch(t)
-	registry := newTestCaptureRegistry(e)
+	registry := newTestCaptureRegistry(e, newTestKeyvault(t, e))
 	registry.Register(&mailFake{scopes: []principal.Scope{principal.ScopeRead, principal.ScopeSend}})
 
 	grantCtx := e.humanWithScopes(e.Rep1, []principal.Scope{principal.ScopeRead})
@@ -210,7 +211,7 @@ func TestCaptureLinkTargetOutsideScopeRefused(t *testing.T) {
 	// A person owned by team2 — invisible to the team1 granting human.
 	foreignPerson := e.seed(t, `INSERT INTO person (id, workspace_id, full_name, owner_id, source, captured_by) VALUES ($1, $2, 'Foreign Target', $3, 'manual', 'human:x')`, e.Rep3)
 
-	registry := newTestCaptureRegistry(e)
+	registry := newTestCaptureRegistry(e, newTestKeyvault(t, e))
 	fake := &mailFake{linkTo: foreignPerson}
 	registry.Register(fake)
 
@@ -278,6 +279,6 @@ func (fakeAuthority) SeatType(context.Context, ids.UUID, ids.UUID) (principal.Se
 	return principal.SeatFull, nil
 }
 
-func newTestCaptureRegistry(e *searchEnv) *capture.Registry {
-	return capture.NewRegistry(e.Pool, capture.NewSink(e.Pool), fakeAuthority{})
+func newTestCaptureRegistry(e *searchEnv, vault keyvault.Vault) *capture.Registry {
+	return capture.NewRegistry(e.Pool, capture.NewSink(e.Pool), fakeAuthority{}, vault)
 }

--- a/backend/internal/compose/integration/fieldprovenance_integration_test.go
+++ b/backend/internal/compose/integration/fieldprovenance_integration_test.go
@@ -29,7 +29,7 @@ func TestFieldProvenanceCoversCaptureAcrossObjectTypes(t *testing.T) {
 	e := setupSearch(t)
 	personID := e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Inbox Sender', 'manual', 'human:x')`)
 
-	registry := newTestCaptureRegistry(e)
+	registry := newTestCaptureRegistry(e, newTestKeyvault(t, e))
 	fake := &mailFake{linkTo: personID}
 	registry.Register(fake)
 

--- a/backend/internal/compose/integration/keyvault_capture_integration_test.go
+++ b/backend/internal/compose/integration/keyvault_capture_integration_test.go
@@ -169,6 +169,20 @@ func TestLocalVaultIsolationAndWrongKeyOnRealPostgres(t *testing.T) {
 	if bytes.Contains([]byte(err.Error()), []byte("tenant-a-credential")) {
 		t.Fatalf("decrypt error leaks the plaintext: %v", err)
 	}
+
+	// Delete removes it and is idempotent; Health sees the vault_secret table.
+	if err := vault.Delete(ctx, wsA, ref); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := vault.Get(ctx, wsA, ref); !errors.Is(err, keyvault.ErrNotFound) {
+		t.Fatalf("Get after Delete: got %v, want ErrNotFound", err)
+	}
+	if err := vault.Delete(ctx, wsA, ref); err != nil {
+		t.Fatalf("second Delete must be a no-op: %v", err)
+	}
+	if err := vault.Health(ctx); err != nil {
+		t.Fatalf("Health against the migrated schema must pass: %v", err)
+	}
 }
 
 func TestBackfillMigratesLegacyAuthRowOntoTheVault(t *testing.T) {

--- a/backend/internal/compose/integration/keyvault_capture_integration_test.go
+++ b/backend/internal/compose/integration/keyvault_capture_integration_test.go
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The keyvault seam end to end (decisions/0023): a connector credential is
+// sealed in the vault at Connect and resolved from it at Sync, so the
+// connector_connection row carries an opaque credential_ref, never the
+// credential bytes. Proven on real Postgres with the local (AES-256-GCM)
+// provider: the round-trip, cross-workspace ref isolation, a wrong root key
+// failing without leaking plaintext, and the additive backfill of a legacy
+// auth-bytea row onto the vault.
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/connector"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/mcp"
+)
+
+// newTestKeyvault builds the local (config-backed) provider over the test
+// pool with a fresh random root key. The vault_secret table exists because
+// setupSearch migrated the schema.
+func newTestKeyvault(t *testing.T, e *searchEnv) keyvault.Vault {
+	t.Helper()
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatalf("generating a test root key: %v", err)
+	}
+	v, err := keyvault.New(keyvault.Config{RootKey: key, Pool: e.Pool})
+	if err != nil {
+		t.Fatalf("building the local vault: %v", err)
+	}
+	return v
+}
+
+// authAssertingFake records the Auth it is handed at Sync so a test can prove
+// the credential the vault resolved is exactly the one granted. It emits no
+// records: this suite is about credential resolution, not capture semantics.
+type authAssertingFake struct {
+	gotAuth connector.Auth
+}
+
+func (f *authAssertingFake) Descriptor() connector.Descriptor {
+	return connector.Descriptor{
+		Name: "authfake", Version: "1.0.0",
+		Scopes:   []principal.Scope{principal.ScopeRead},
+		RiskTier: mcp.TierGreen,
+	}
+}
+
+func (f *authAssertingFake) Authenticate(context.Context, connector.AuthRequest) (connector.Auth, error) {
+	return connector.Auth("granted-token"), nil
+}
+
+func (f *authAssertingFake) Sync(_ context.Context, auth connector.Auth, cursor connector.Cursor, _ connector.Sink) (connector.Cursor, error) {
+	f.gotAuth = auth
+	return cursor, nil
+}
+
+func (f *authAssertingFake) Normalize(context.Context, connector.RawRecord) ([]connector.NormalizedRecord, error) {
+	return nil, connector.ErrSkip
+}
+
+func (f *authAssertingFake) HealthCheck(context.Context, connector.Auth) error { return nil }
+
+func TestConnectSealsCredentialInVaultNotOnTheRow(t *testing.T) {
+	e := setupSearch(t)
+	vault := newTestKeyvault(t, e)
+	registry := newTestCaptureRegistry(e, vault)
+	registry.Register(&authAssertingFake{})
+
+	grantCtx := e.humanWithScopes(e.Rep1, []principal.Scope{principal.ScopeRead})
+	connID, err := registry.Connect(grantCtx, "authfake", connector.Auth("granted-token"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var credentialRef *string
+	var authBytes []byte
+	err = database.WithWorkspaceTx(grantCtx, e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT credential_ref, auth FROM connector_connection WHERE id = $1`, connID).
+			Scan(&credentialRef, &authBytes)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if credentialRef == nil || *credentialRef == "" {
+		t.Fatal("Connect did not record a credential_ref on the row")
+	}
+	if authBytes != nil {
+		t.Fatalf("Connect left the credential bytes on the row (auth is not NULL): %q", authBytes)
+	}
+	// The vault holds the sealed credential under the row's ref.
+	got, err := vault.Get(context.Background(), ids.From[ids.WorkspaceKind](e.WS), keyvault.Ref(*credentialRef))
+	if err != nil {
+		t.Fatalf("resolving the recorded ref: %v", err)
+	}
+	if !bytes.Equal(got, []byte("granted-token")) {
+		t.Fatalf("vault holds %q, want the granted credential", got)
+	}
+}
+
+func TestSyncResolvesCredentialFromVault(t *testing.T) {
+	e := setupSearch(t)
+	vault := newTestKeyvault(t, e)
+	registry := newTestCaptureRegistry(e, vault)
+	fake := &authAssertingFake{}
+	registry.Register(fake)
+
+	grantCtx := e.humanWithScopes(e.Rep1, []principal.Scope{principal.ScopeRead})
+	connID, err := registry.Connect(grantCtx, "authfake", connector.Auth("granted-token"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := registry.SyncOnce(grantCtx, connID); err != nil {
+		t.Fatal(err)
+	}
+	if string(fake.gotAuth) != "granted-token" {
+		t.Fatalf("Sync received %q, want the vault-resolved granted credential", fake.gotAuth)
+	}
+}
+
+// The local provider on real Postgres must honour the same isolation the
+// memory fake does, plus surface a wrong-root-key decrypt as an error (not
+// absence) without leaking the plaintext.
+func TestLocalVaultIsolationAndWrongKeyOnRealPostgres(t *testing.T) {
+	e := setupSearch(t)
+	vault := newTestKeyvault(t, e)
+	ctx := context.Background()
+	wsA := ids.From[ids.WorkspaceKind](e.WS)
+	wsB := ids.New[ids.WorkspaceKind]()
+
+	ref, err := vault.Put(ctx, wsA, []byte("tenant-a-credential"))
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	got, err := vault.Get(ctx, wsA, ref)
+	if err != nil || !bytes.Equal(got, []byte("tenant-a-credential")) {
+		t.Fatalf("round-trip failed: got %q err %v", got, err)
+	}
+	if _, err := vault.Get(ctx, wsB, ref); !errors.Is(err, keyvault.ErrNotFound) {
+		t.Fatalf("cross-workspace Get: got %v, want ErrNotFound", err)
+	}
+
+	// A second vault over the SAME table with a DIFFERENT root key finds the
+	// row (same ref) but cannot decrypt it — a surfaced error, no plaintext.
+	other := newTestKeyvault(t, e)
+	_, err = other.Get(ctx, wsA, ref)
+	if err == nil {
+		t.Fatal("Get under the wrong root key must fail")
+	}
+	if errors.Is(err, keyvault.ErrNotFound) {
+		t.Fatal("a wrong-key decrypt must surface an error, not masquerade as ErrNotFound")
+	}
+	if bytes.Contains([]byte(err.Error()), []byte("tenant-a-credential")) {
+		t.Fatalf("decrypt error leaks the plaintext: %v", err)
+	}
+}
+
+func TestBackfillMigratesLegacyAuthRowOntoTheVault(t *testing.T) {
+	e := setupSearch(t)
+	vault := newTestKeyvault(t, e)
+	registry := newTestCaptureRegistry(e, vault)
+	fake := &authAssertingFake{}
+	registry.Register(fake)
+
+	// A legacy row: the credential lives in the auth bytea column, no ref.
+	connID := e.seed(t, `
+		INSERT INTO connector_connection (id, workspace_id, connector, granted_by, scopes, auth)
+		VALUES ($1, $2, 'authfake', $3, $4, $5)`,
+		e.Rep1, []string{string(principal.ScopeRead)}, []byte("granted-token"))
+
+	migrated, err := registry.BackfillCredentials(context.Background())
+	if err != nil {
+		t.Fatalf("BackfillCredentials: %v", err)
+	}
+	if migrated != 1 {
+		t.Fatalf("backfill migrated %d rows, want 1", migrated)
+	}
+
+	// The row now carries a ref and the legacy bytes are cleared.
+	var credentialRef *string
+	var authBytes []byte
+	err = database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT credential_ref, auth FROM connector_connection WHERE id = $1`, connID).
+			Scan(&credentialRef, &authBytes)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if credentialRef == nil || *credentialRef == "" {
+		t.Fatal("backfill did not record a credential_ref")
+	}
+	if authBytes != nil {
+		t.Fatalf("backfill left the legacy bytes on the row: %q", authBytes)
+	}
+	got, err := vault.Get(context.Background(), ids.From[ids.WorkspaceKind](e.WS), keyvault.Ref(*credentialRef))
+	if err != nil || !bytes.Equal(got, []byte("granted-token")) {
+		t.Fatalf("vault does not hold the migrated credential: got %q err %v", got, err)
+	}
+
+	// A second backfill is a no-op: the row already carries a ref.
+	migrated, err = registry.BackfillCredentials(context.Background())
+	if err != nil {
+		t.Fatalf("second BackfillCredentials: %v", err)
+	}
+	if migrated != 0 {
+		t.Fatalf("idempotent backfill migrated %d rows on the second run, want 0", migrated)
+	}
+
+	// Sync now resolves the migrated credential through the vault.
+	grantCtx := e.humanWithScopes(e.Rep1, []principal.Scope{principal.ScopeRead})
+	if err := registry.SyncOnce(grantCtx, connID); err != nil {
+		t.Fatal(err)
+	}
+	if string(fake.gotAuth) != "granted-token" {
+		t.Fatalf("Sync after backfill received %q, want the migrated credential", fake.gotAuth)
+	}
+}

--- a/backend/internal/compose/keyvault_readiness_test.go
+++ b/backend/internal/compose/keyvault_readiness_test.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+import (
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
+)
+
+func TestReadinessChecksIncludeKeyvaultWhenConfigured(t *testing.T) {
+	srv := &Server{vault: keyvault.NewMemory()}
+
+	checks := srv.readinessChecks(okPing)
+
+	if !hasCheck(checks, "keyvault") {
+		t.Fatal("readiness checks omit keyvault when a vault is configured")
+	}
+}
+
+func TestReadinessChecksOmitKeyvaultWhenAbsent(t *testing.T) {
+	srv := &Server{}
+
+	checks := srv.readinessChecks(okPing)
+
+	if hasCheck(checks, "keyvault") {
+		t.Fatal("readiness checks include keyvault when no vault is configured")
+	}
+	if !hasCheck(checks, "postgres") {
+		t.Fatal("readiness checks must always include postgres")
+	}
+}

--- a/backend/internal/compose/server.go
+++ b/backend/internal/compose/server.go
@@ -39,6 +39,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/events"
 	"github.com/gradionhq/margince/backend/internal/platform/httperr"
 	"github.com/gradionhq/margince/backend/internal/platform/httpserver"
+	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/web"
 )
@@ -95,6 +96,11 @@ type Server struct {
 	// a role that stores no objects.
 	blob blobstore.Store
 
+	// vault is the secret store, injected by WithKeyvault. When configured
+	// it feeds a /readyz probe and backs the capture connector-credential
+	// path; nil means a role that resolves no stored connector credentials.
+	vault keyvault.Vault
+
 	// log is the process logger, shared with the optional engines an
 	// option wires (e.g. the brief L2 ranker's degradation warnings).
 	log *slog.Logger
@@ -127,11 +133,21 @@ func WithBlobstore(store blobstore.Store) Option {
 	}
 }
 
+// WithKeyvault wires the secret store: it feeds the /readyz probe and backs
+// the capture connector-credential path (Authenticate seals the credential
+// bundle, Sync resolves it). Without it a role that persists or resolves
+// connector credentials declares that gap at wiring time rather than
+// nil-derefing at Authenticate — a capture-capable role must pass this or
+// fail to boot (enforced in cmd, decisions/0023).
+func WithKeyvault(vault keyvault.Vault) Option {
+	return func(s *Server, _ *pgxpool.Pool) { s.vault = vault }
+}
+
 // readinessChecks assembles the /readyz dependency probes for this role.
-// Postgres is always probed; the bus and the object store are probed only
-// when this role wired them, so a split deployment answers ready on exactly
-// what it depends on. A wedged dependency must fail readiness — a probe is
-// never dropped to keep the pod in rotation.
+// Postgres is always probed; the bus, the object store, and the secret vault
+// are probed only when this role wired them, so a split deployment answers
+// ready on exactly what it depends on. A wedged dependency must fail
+// readiness — a probe is never dropped to keep the pod in rotation.
 func (s *Server) readinessChecks(pgPing func(context.Context) error) []httpserver.ReadyCheck {
 	checks := []httpserver.ReadyCheck{{Name: "postgres", Check: pgPing}}
 	if s.busReady != nil {
@@ -139,6 +155,9 @@ func (s *Server) readinessChecks(pgPing func(context.Context) error) []httpserve
 	}
 	if s.blob != nil {
 		checks = append(checks, httpserver.ReadyCheck{Name: "blobstore", Check: s.blob.Health})
+	}
+	if s.vault != nil {
+		checks = append(checks, httpserver.ReadyCheck{Name: "keyvault", Check: s.vault.Health})
 	}
 	return checks
 }

--- a/backend/internal/compose/server.go
+++ b/backend/internal/compose/server.go
@@ -140,7 +140,12 @@ func WithBlobstore(store blobstore.Store) Option {
 // nil-derefing at Authenticate — a capture-capable role must pass this or
 // fail to boot (enforced in cmd, decisions/0023).
 func WithKeyvault(vault keyvault.Vault) Option {
-	return func(s *Server, _ *pgxpool.Pool) { s.vault = vault }
+	return func(s *Server, pool *pgxpool.Pool) {
+		s.vault = vault
+		// Rebuild the capture registry with the vault so the connector-
+		// credential paths (Connect seals, Sync resolves) have their custodian.
+		s.imapConnectHandlers = imapConnectHandlers{registry: NewCaptureRegistry(pool, vault)}
+	}
 }
 
 // readinessChecks assembles the /readyz dependency probes for this role.
@@ -294,8 +299,9 @@ func newServer(pool *pgxpool.Pool, log *slog.Logger, authH authHandlers, dealsH 
 		Handlers: briefs.NewHandlers(briefs.NewBriefEngine(pool, people.NewStore(pool))),
 		// The one-shot IMAP pull shares the capture registry (Sink + the
 		// live-authority principal swap); credentials arrive per request and
-		// are never persisted, so no standing connection is registered.
-		imapConnectHandlers: imapConnectHandlers{registry: NewCaptureRegistry(pool)},
+		// are never persisted (RunTransient), so the default registry needs no
+		// vault — WithKeyvault rebuilds it with one for the persisting paths.
+		imapConnectHandlers: imapConnectHandlers{registry: NewCaptureRegistry(pool, nil)},
 		// First-class filtered export (B-E15.13): the writer reuses the ONE
 		// predicate engine + the bundle writer's open-format rendering; the
 		// collections store resolves a saved view / dynamic list source

--- a/backend/internal/modules/capture/registry.go
+++ b/backend/internal/modules/capture/registry.go
@@ -14,6 +14,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -33,14 +34,25 @@ type Registry struct {
 	pool       *pgxpool.Pool
 	sink       *Sink
 	authority  authz.Resolver
+	// vault seals and resolves a connection's credential bundle. The row
+	// carries an opaque credential_ref, never the credential bytes; the
+	// vault is the custodian. May be nil for a role that only runs the
+	// transient one-shot pull (RunTransient), which never persists a
+	// credential — Connect/SyncOnce refuse loudly when it is nil.
+	vault keyvault.Vault
 }
 
-func NewRegistry(pool *pgxpool.Pool, sink *Sink, authority authz.Resolver) *Registry {
+// NewRegistry builds the connector registry over the pool, the capture Sink,
+// the live-authority resolver, and the keyvault that seals/resolves each
+// connection's credential. vault may be nil for a role that only runs the
+// transient one-shot pull (which persists no credential).
+func NewRegistry(pool *pgxpool.Pool, sink *Sink, authority authz.Resolver, vault keyvault.Vault) *Registry {
 	return &Registry{
 		connectors: map[string]connector.Connector{},
 		pool:       pool,
 		sink:       sink,
 		authority:  authority,
+		vault:      vault,
 	}
 }
 
@@ -100,15 +112,30 @@ func (r *Registry) Connect(ctx context.Context, name string, auth connector.Auth
 	for _, s := range c.Descriptor().Scopes {
 		scopes = append(scopes, string(s))
 	}
+	ws, ok := principal.WorkspaceID(ctx)
+	if !ok {
+		return ids.Nil, errors.New("capture: connector grant outside workspace context")
+	}
+	if r.vault == nil {
+		return ids.Nil, errors.New("capture: no keyvault configured — a connector credential cannot be sealed")
+	}
+	// Put-then-commit (like blobstore): seal the credential in the vault
+	// first, then commit the row that names it. A rolled-back row leaves an
+	// orphan secret (swept later), never a row promising a credential that is
+	// not there. The row stores the opaque ref; the bytes never touch it.
+	ref, err := r.vault.Put(ctx, ids.From[ids.WorkspaceKind](ws), []byte(auth))
+	if err != nil {
+		return ids.Nil, fmt.Errorf("capture: sealing connector credential: %w", err)
+	}
 	var id ids.UUID
 	err = database.WithWorkspaceTx(ctx, r.pool, func(tx pgx.Tx) error {
 		return tx.QueryRow(ctx, `
-			INSERT INTO connector_connection (workspace_id, connector, granted_by, scopes, auth)
+			INSERT INTO connector_connection (workspace_id, connector, granted_by, scopes, credential_ref)
 			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3, $4)
 			ON CONFLICT (workspace_id, connector, granted_by)
-			DO UPDATE SET auth = EXCLUDED.auth, status = 'active', last_error = NULL
+			DO UPDATE SET credential_ref = EXCLUDED.credential_ref, auth = NULL, status = 'active', last_error = NULL
 			RETURNING id`,
-			name, actor.UserID, scopes, []byte(auth)).Scan(&id)
+			name, actor.UserID, scopes, string(ref)).Scan(&id)
 	})
 	if err != nil {
 		return ids.Nil, fmt.Errorf("capture: storing connection: %w", err)
@@ -151,16 +178,17 @@ func (r *Registry) RunTransient(ctx context.Context, c connector.Connector, auth
 // sync succeeded end to end.
 func (r *Registry) SyncOnce(ctx context.Context, connectionID ids.UUID) error {
 	var (
-		name      string
-		grantedBy ids.UserID
-		authBytes []byte
-		cursor    []byte
+		name          string
+		grantedBy     ids.UserID
+		credentialRef *string
+		authBytes     []byte
+		cursor        []byte
 	)
 	err := database.WithWorkspaceTx(ctx, r.pool, func(tx pgx.Tx) error {
 		return tx.QueryRow(ctx, `
-			SELECT connector, granted_by, auth, cursor FROM connector_connection
+			SELECT connector, granted_by, credential_ref, auth, cursor FROM connector_connection
 			WHERE id = $1 AND status = 'active'`, connectionID).
-			Scan(&name, &grantedBy, &authBytes, &cursor)
+			Scan(&name, &grantedBy, &credentialRef, &authBytes, &cursor)
 	})
 	if errors.Is(err, pgx.ErrNoRows) {
 		return fmt.Errorf("capture: connection %s: %w", connectionID, apperrors.ErrNotFound)
@@ -172,12 +200,16 @@ func (r *Registry) SyncOnce(ctx context.Context, connectionID ids.UUID) error {
 	if err != nil {
 		return err
 	}
+	auth, err := r.resolveCredential(ctx, credentialRef, authBytes)
+	if err != nil {
+		return err
+	}
 
 	runCtx, err := r.connectorContext(ctx, name, grantedBy)
 	if err != nil {
 		return err
 	}
-	next, syncErr := c.Sync(runCtx, connector.Auth(authBytes), connector.Cursor(cursor), r.sink)
+	next, syncErr := c.Sync(runCtx, auth, connector.Cursor(cursor), r.sink)
 	if syncErr != nil {
 		if markErr := r.markError(ctx, connectionID, syncErr); markErr != nil {
 			return errors.Join(syncErr, markErr)
@@ -190,6 +222,121 @@ func (r *Registry) SyncOnce(ctx context.Context, connectionID ids.UUID) error {
 			WHERE id = $1`, connectionID, []byte(next))
 		return err
 	})
+}
+
+// resolveCredential turns a stored connection's credential into the opaque
+// Auth the connector expects. It PREFERS the vault ref; the legacy auth bytea
+// column is read only for a row not yet backfilled onto the vault (during the
+// additive transition, before that column is dropped).
+func (r *Registry) resolveCredential(ctx context.Context, credentialRef *string, authBytes []byte) (connector.Auth, error) {
+	if credentialRef != nil && *credentialRef != "" {
+		if r.vault == nil {
+			return nil, errors.New("capture: connection carries a credential ref but no keyvault is configured to resolve it")
+		}
+		ws, ok := principal.WorkspaceID(ctx)
+		if !ok {
+			return nil, errors.New("capture: credential resolution outside workspace context")
+		}
+		secret, err := r.vault.Get(ctx, ids.From[ids.WorkspaceKind](ws), keyvault.Ref(*credentialRef))
+		if err != nil {
+			return nil, fmt.Errorf("capture: resolving connector credential: %w", err)
+		}
+		return connector.Auth(secret), nil
+	}
+	// A row not yet backfilled: the credential still lives in the column.
+	return connector.Auth(authBytes), nil
+}
+
+// BackfillCredentials migrates every legacy connector_connection row whose
+// credential still lives in the auth bytea column onto the vault: it seals the
+// bytes, records the credential_ref, and clears auth. It is idempotent — a row
+// that already carries a ref is skipped — so a re-run or a crash-retry is
+// safe, which is what lets it run on every boot. It walks every live workspace
+// under that workspace's own GUC, since connector_connection is RLS-scoped,
+// and returns the number of rows migrated.
+func (r *Registry) BackfillCredentials(ctx context.Context) (int, error) {
+	if r.vault == nil {
+		return 0, errors.New("capture: cannot backfill connector credentials without a keyvault")
+	}
+	rows, err := r.pool.Query(ctx, `SELECT id FROM workspace WHERE archived_at IS NULL ORDER BY created_at`)
+	if err != nil {
+		return 0, fmt.Errorf("capture: listing workspaces for credential backfill: %w", err)
+	}
+	workspaces, err := pgx.CollectRows(rows, pgx.RowTo[ids.UUID])
+	if err != nil {
+		return 0, err
+	}
+	total := 0
+	for _, wsID := range workspaces {
+		wsCtx := principal.WithWorkspaceID(ctx, wsID)
+		wsCtx = principal.WithActor(wsCtx, principal.Principal{Type: principal.PrincipalSystem, ID: "system:keyvault-backfill"})
+		wsCtx = principal.WithCorrelationID(wsCtx, ids.NewV7())
+		migrated, err := r.backfillWorkspace(wsCtx, ids.From[ids.WorkspaceKind](wsID))
+		if err != nil {
+			return total, fmt.Errorf("capture: backfilling workspace %s: %w", wsID, err)
+		}
+		total += migrated
+	}
+	return total, nil
+}
+
+// backfillWorkspace migrates one workspace's legacy rows. Each secret is
+// sealed OUTSIDE the update tx (put-then-commit); the update then claims the
+// row only if it still has no ref, so a concurrent backfill (two worker pods
+// at boot) cannot double-migrate — the loser's sealed secret is a harmless
+// orphan, never a corrupted row.
+func (r *Registry) backfillWorkspace(ctx context.Context, ws ids.WorkspaceID) (int, error) {
+	type legacyRow struct {
+		id   ids.UUID
+		auth []byte
+	}
+	var pending []legacyRow
+	err := database.WithWorkspaceTx(ctx, r.pool, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `
+			SELECT id, auth FROM connector_connection
+			WHERE credential_ref IS NULL AND auth IS NOT NULL`)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var l legacyRow
+			if err := rows.Scan(&l.id, &l.auth); err != nil {
+				return err
+			}
+			pending = append(pending, l)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	migrated := 0
+	for _, l := range pending {
+		ref, err := r.vault.Put(ctx, ws, l.auth)
+		if err != nil {
+			return migrated, err
+		}
+		var claimed bool
+		err = database.WithWorkspaceTx(ctx, r.pool, func(tx pgx.Tx) error {
+			ct, err := tx.Exec(ctx, `
+				UPDATE connector_connection SET credential_ref = $2, auth = NULL
+				WHERE id = $1 AND credential_ref IS NULL`, l.id, string(ref))
+			if err != nil {
+				return err
+			}
+			claimed = ct.RowsAffected() == 1
+			return nil
+		})
+		if err != nil {
+			return migrated, err
+		}
+		if claimed {
+			migrated++
+		}
+	}
+	return migrated, nil
 }
 
 // connectorContext builds the acting principal: connector identity,

--- a/backend/internal/modules/capture/registry.go
+++ b/backend/internal/modules/capture/registry.go
@@ -35,10 +35,12 @@ type Registry struct {
 	sink       *Sink
 	authority  authz.Resolver
 	// vault seals and resolves a connection's credential bundle. The row
-	// carries an opaque credential_ref, never the credential bytes; the
-	// vault is the custodian. May be nil for a role that only runs the
-	// transient one-shot pull (RunTransient), which never persists a
-	// credential — Connect/SyncOnce refuse loudly when it is nil.
+	// carries an opaque credential_ref, never the credential bytes; the vault
+	// is the custodian. May be nil for a role that only runs the transient
+	// one-shot pull (RunTransient), which never persists a credential: Connect
+	// then refuses loudly (it must seal), and SyncOnce refuses only for a row
+	// whose credential lives in the vault — a not-yet-backfilled legacy row
+	// still resolves from its auth column with no vault.
 	vault keyvault.Vault
 }
 
@@ -121,8 +123,9 @@ func (r *Registry) Connect(ctx context.Context, name string, auth connector.Auth
 	}
 	// Put-then-commit (like blobstore): seal the credential in the vault
 	// first, then commit the row that names it. A rolled-back row leaves an
-	// orphan secret (swept later), never a row promising a credential that is
-	// not there. The row stores the opaque ref; the bytes never touch it.
+	// orphan secret (encrypted and unreferenced — benign), never a row
+	// promising a credential that is not there. The row stores the opaque ref;
+	// the bytes never touch it.
 	ref, err := r.vault.Put(ctx, ids.From[ids.WorkspaceKind](ws), []byte(auth))
 	if err != nil {
 		return ids.Nil, fmt.Errorf("capture: sealing connector credential: %w", err)
@@ -252,8 +255,10 @@ func (r *Registry) resolveCredential(ctx context.Context, credentialRef *string,
 // bytes, records the credential_ref, and clears auth. It is idempotent — a row
 // that already carries a ref is skipped — so a re-run or a crash-retry is
 // safe, which is what lets it run on every boot. It walks every live workspace
-// under that workspace's own GUC, since connector_connection is RLS-scoped,
-// and returns the number of rows migrated.
+// under that workspace's own GUC, since connector_connection is RLS-scoped.
+// One workspace's failure must not starve the rest of the fleet (the same
+// invariant retention and the close-date sweep hold): the walk continues past
+// a failing workspace and returns the count migrated plus the joined errors.
 func (r *Registry) BackfillCredentials(ctx context.Context) (int, error) {
 	if r.vault == nil {
 		return 0, errors.New("capture: cannot backfill connector credentials without a keyvault")
@@ -267,17 +272,20 @@ func (r *Registry) BackfillCredentials(ctx context.Context) (int, error) {
 		return 0, err
 	}
 	total := 0
+	var errs error
 	for _, wsID := range workspaces {
+		// The backfill's UPDATE runs under the workspace GUC only (a raw
+		// relocation, not an audited domain write), so no actor/correlation
+		// context is set — nothing here reads it.
 		wsCtx := principal.WithWorkspaceID(ctx, wsID)
-		wsCtx = principal.WithActor(wsCtx, principal.Principal{Type: principal.PrincipalSystem, ID: "system:keyvault-backfill"})
-		wsCtx = principal.WithCorrelationID(wsCtx, ids.NewV7())
 		migrated, err := r.backfillWorkspace(wsCtx, ids.From[ids.WorkspaceKind](wsID))
 		if err != nil {
-			return total, fmt.Errorf("capture: backfilling workspace %s: %w", wsID, err)
+			errs = errors.Join(errs, fmt.Errorf("capture: backfilling workspace %s: %w", wsID, err))
+			continue
 		}
 		total += migrated
 	}
-	return total, nil
+	return total, errs
 }
 
 // backfillWorkspace migrates one workspace's legacy rows. Each secret is

--- a/backend/internal/modules/capture/registry_internal_test.go
+++ b/backend/internal/modules/capture/registry_internal_test.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package capture
+
+import (
+	"context"
+	"testing"
+)
+
+// resolveCredential's two credential sources are unit-tested here without a
+// database: the vault-ref path and the legacy auth-column fallback. The
+// full seal→resolve round-trip against real Postgres lives in the
+// compose/integration lane.
+func TestResolveCredential(t *testing.T) {
+	ctx := context.Background()
+	r := &Registry{} // no vault wired
+
+	// A row not yet backfilled carries its credential in the auth column;
+	// with no ref, that is the credential (no vault needed).
+	auth, err := r.resolveCredential(ctx, nil, []byte("legacy-credential"))
+	if err != nil {
+		t.Fatalf("legacy resolve: %v", err)
+	}
+	if string(auth) != "legacy-credential" {
+		t.Fatalf("legacy resolve returned %q, want the auth-column bytes", auth)
+	}
+
+	// A pointer to an empty ref is treated the same as no ref — the legacy
+	// column still answers.
+	empty := ""
+	auth, err = r.resolveCredential(ctx, &empty, []byte("fallback"))
+	if err != nil || string(auth) != "fallback" {
+		t.Fatalf("empty-ref resolve returned %q, %v; want the fallback bytes", auth, err)
+	}
+
+	// A row carrying a credential_ref but no vault to resolve it is a loud
+	// refusal, never a silent nil-deref or an empty credential.
+	ref := "mgv.1.workspace.token"
+	if _, err := r.resolveCredential(ctx, &ref, nil); err == nil {
+		t.Fatal("a credential_ref with no keyvault configured must error")
+	}
+}

--- a/backend/internal/platform/keyvault/keyvault.go
+++ b/backend/internal/platform/keyvault/keyvault.go
@@ -93,16 +93,19 @@ const refTokenBytes = 16
 // without changing the ref format or the stored ciphertext (decisions/0023).
 const currentKeyVersion = 1
 
-// mintRef builds a fresh ref for ws at keyVersion. The random token is drawn
-// from crypto/rand; a failure there means the process cannot mint secret
-// handles and is surfaced, never masked with a predictable value.
-func mintRef(ws ids.WorkspaceID, keyVersion int) (Ref, error) {
+// mintRef builds a fresh ref for ws at the current key version. The random
+// token is drawn from crypto/rand; a failure there means the process cannot
+// mint secret handles and is surfaced, never masked with a predictable value.
+// The version is stamped from currentKeyVersion rather than passed in: a
+// future rotation opens up by having Get select the key from the version the
+// ref already carries, not by threading a version through this call today.
+func mintRef(ws ids.WorkspaceID) (Ref, error) {
 	tok := make([]byte, refTokenBytes)
 	if _, err := rand.Read(tok); err != nil {
 		return "", fmt.Errorf("keyvault: minting a ref token: %w", err)
 	}
 	token := base64.RawURLEncoding.EncodeToString(tok)
-	parts := []string{refScheme, strconv.Itoa(keyVersion), ws.String(), token}
+	parts := []string{refScheme, strconv.Itoa(currentKeyVersion), ws.String(), token}
 	return Ref(strings.Join(parts, refDelimiter)), nil
 }
 

--- a/backend/internal/platform/keyvault/keyvault.go
+++ b/backend/internal/platform/keyvault/keyvault.go
@@ -87,6 +87,12 @@ const refDelimiter = "."
 // be forged even before the workspace and crypto binding reject it.
 const refTokenBytes = 16
 
+// currentKeyVersion is the root-key version every provider stamps into new
+// refs today. It is 1 because there is one key; the version travels in the
+// ref so a later rotation can add a keyring and pick the key by version
+// without changing the ref format or the stored ciphertext (decisions/0023).
+const currentKeyVersion = 1
+
 // mintRef builds a fresh ref for ws at keyVersion. The random token is drawn
 // from crypto/rand; a failure there means the process cannot mint secret
 // handles and is surfaced, never masked with a predictable value.

--- a/backend/internal/platform/keyvault/keyvault.go
+++ b/backend/internal/platform/keyvault/keyvault.go
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// Package keyvault owns secret-material storage behind an opaque,
+// workspace-scoped Ref. It is a peer of platform/events and platform/jobs:
+// technical plumbing that owns no domain. The DB row stays the system of
+// record and the tenant anchor; the vault is custodian of the secret bytes
+// only, addressed by a Ref that a domain row (e.g.
+// connector_connection.credential_ref) carries in place of the raw
+// credential. Isolation is a property of the Ref: a Ref minted for one
+// workspace does not resolve under another, so a stolen Ref is inert across
+// the tenant edge without also defeating RLS on the row that names it. See
+// decisions/0023-keyvault-seam.md.
+//
+// Secret hygiene is the load-bearing rule here: the plaintext and the root
+// key never reach a log line, an error message, or a model-bound payload.
+// Every error names the Ref, never the secret. This composes with — it does
+// not replace — model.SecretStripper, which keeps secrets out of model-bound
+// payloads at egress; the vault is where secrets live at rest.
+package keyvault
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// ErrNotFound reports that no secret resolves for the given (workspace, ref)
+// pair — either nothing was ever stored, it was deleted, or the ref belongs
+// to a different workspace. Callers errors.Is against it. Cross-workspace
+// resolution is deliberately indistinguishable from absence (existence
+// hiding): a ref presented under the wrong workspace answers ErrNotFound,
+// never "wrong tenant".
+var ErrNotFound = errors.New("keyvault: secret not found")
+
+// Vault is the secret-material seam. Every call carries the workspace so the
+// provider scopes the ref to the tenant; a ref cannot be resolved under the
+// wrong workspace. The one substitution axis is a real backend vs the memory
+// fake — there is no cross-module provider registry — which is why this lives
+// in platform, not shared/ports (decisions/0023).
+type Vault interface {
+	// Put seals secret for ws and returns the opaque Ref addressing it. A
+	// zero workspace id is refused: an unscoped secret has no tenant to
+	// bind to.
+	Put(ctx context.Context, ws ids.WorkspaceID, secret []byte) (Ref, error)
+
+	// Get resolves ref under ws to the stored secret. It returns ErrNotFound
+	// if nothing is stored, it was deleted, or ref belongs to another
+	// workspace.
+	Get(ctx context.Context, ws ids.WorkspaceID, ref Ref) ([]byte, error)
+
+	// Delete removes the secret ref addresses under ws. It is idempotent:
+	// deleting an absent ref (or a ref from another workspace) is not an
+	// error, so an erasure crash-retry is safe.
+	Delete(ctx context.Context, ws ids.WorkspaceID, ref Ref) error
+
+	// Health reports whether the backing store is reachable, feeding the
+	// /readyz probe. A nil error means ready.
+	Health(ctx context.Context) error
+}
+
+// Ref is the opaque handle to one stored secret. It is safe to persist in a
+// domain row and safe to log — it is NOT the secret. Its wire form encodes,
+// in this order, a fixed scheme tag, the root-key version (so a future key
+// rotation is not foreclosed — a later provider holds a keyring and picks the
+// key by this version), the owning workspace (so a ref presented under the
+// wrong workspace is rejected structurally, before any storage read or
+// decryption), and an unguessable random token that names the secret.
+type Ref string
+
+// refScheme tags every ref this package mints; a ref lacking it is not ours.
+const refScheme = "mgv"
+
+// refDelimiter separates ref components. A period cannot occur inside a
+// canonical UUID (hyphens only) or a base64url token (RFC 4648 alphabet is
+// A–Z a–z 0–9 - _), so splitting on it recovers exactly the four components.
+const refDelimiter = "."
+
+// refTokenBytes is the entropy of a ref's random token (128 bits): enough
+// that a ref cannot be guessed, so a valid ref for another workspace cannot
+// be forged even before the workspace and crypto binding reject it.
+const refTokenBytes = 16
+
+// mintRef builds a fresh ref for ws at keyVersion. The random token is drawn
+// from crypto/rand; a failure there means the process cannot mint secret
+// handles and is surfaced, never masked with a predictable value.
+func mintRef(ws ids.WorkspaceID, keyVersion int) (Ref, error) {
+	tok := make([]byte, refTokenBytes)
+	if _, err := rand.Read(tok); err != nil {
+		return "", fmt.Errorf("keyvault: minting a ref token: %w", err)
+	}
+	token := base64.RawURLEncoding.EncodeToString(tok)
+	parts := []string{refScheme, strconv.Itoa(keyVersion), ws.String(), token}
+	return Ref(strings.Join(parts, refDelimiter)), nil
+}
+
+// parsedRef is a ref decomposed into its components.
+type parsedRef struct {
+	keyVersion int
+	workspace  ids.WorkspaceID
+	token      string
+}
+
+// parse decomposes a ref, validating the scheme and structure. A malformed
+// ref is not distinguished from a missing one at the seam boundary (both are
+// ErrNotFound to a caller), but parse returns a descriptive error so a
+// provider can log the shape problem server-side without echoing the ref's
+// token to a client.
+func (r Ref) parse() (parsedRef, error) {
+	parts := strings.Split(string(r), refDelimiter)
+	if len(parts) != 4 || parts[0] != refScheme {
+		return parsedRef{}, fmt.Errorf("keyvault: %w", errMalformedRef)
+	}
+	version, err := strconv.Atoi(parts[1])
+	if err != nil || version < 1 {
+		return parsedRef{}, fmt.Errorf("keyvault: %w", errMalformedRef)
+	}
+	ws, err := ids.ParseAs[ids.WorkspaceKind](parts[2])
+	if err != nil {
+		return parsedRef{}, fmt.Errorf("keyvault: %w", errMalformedRef)
+	}
+	if parts[3] == "" {
+		return parsedRef{}, fmt.Errorf("keyvault: %w", errMalformedRef)
+	}
+	return parsedRef{keyVersion: version, workspace: ws, token: parts[3]}, nil
+}
+
+// scopedTo reports whether ref was minted for ws. A malformed ref is not
+// scoped to any workspace. This is the cheap structural gate every provider
+// runs first, so a cross-workspace resolution fails before touching storage.
+func (r Ref) scopedTo(ws ids.WorkspaceID) bool {
+	p, err := r.parse()
+	if err != nil {
+		return false
+	}
+	return p.workspace == ws
+}
+
+// errMalformedRef marks a ref that does not parse; providers map it to
+// ErrNotFound at the boundary (existence hiding) but may log the shape.
+var errMalformedRef = errors.New("ref is malformed")

--- a/backend/internal/platform/keyvault/keyvault.go
+++ b/backend/internal/platform/keyvault/keyvault.go
@@ -66,12 +66,12 @@ type Vault interface {
 }
 
 // Ref is the opaque handle to one stored secret. It is safe to persist in a
-// domain row and safe to log — it is NOT the secret. Its wire form encodes,
-// in this order, a fixed scheme tag, the root-key version (so a future key
-// rotation is not foreclosed — a later provider holds a keyring and picks the
-// key by this version), the owning workspace (so a ref presented under the
-// wrong workspace is rejected structurally, before any storage read or
-// decryption), and an unguessable random token that names the secret.
+// domain row and safe to log — it is NOT the secret. Its wire form encodes, in
+// this order, a fixed scheme tag, the root-key version (carried so a later
+// rotation can select the key by version — it cannot be retrofitted onto refs
+// already minted), the owning workspace (so a ref presented under the wrong
+// workspace is rejected structurally, before any storage read or decryption),
+// and an unguessable random token that names the secret.
 type Ref string
 
 // refScheme tags every ref this package mints; a ref lacking it is not ours.
@@ -93,12 +93,10 @@ const refTokenBytes = 16
 // without changing the ref format or the stored ciphertext (decisions/0023).
 const currentKeyVersion = 1
 
-// mintRef builds a fresh ref for ws at the current key version. The random
-// token is drawn from crypto/rand; a failure there means the process cannot
-// mint secret handles and is surfaced, never masked with a predictable value.
-// The version is stamped from currentKeyVersion rather than passed in: a
-// future rotation opens up by having Get select the key from the version the
-// ref already carries, not by threading a version through this call today.
+// mintRef builds a fresh ref for ws, stamping the current key version. The
+// random token is drawn from crypto/rand; a failure there means the process
+// cannot mint secret handles and is surfaced, never masked with a predictable
+// value.
 func mintRef(ws ids.WorkspaceID) (Ref, error) {
 	tok := make([]byte, refTokenBytes)
 	if _, err := rand.Read(tok); err != nil {

--- a/backend/internal/platform/keyvault/keyvault_internal_test.go
+++ b/backend/internal/platform/keyvault/keyvault_internal_test.go
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package keyvault
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// The ref helpers and the local provider's construction/validation are
+// unit-tested here (white-box) — the defensive branches the DB round-trip in
+// the integration lane never exercises.
+
+func TestRefParse_rejectsMalformed(t *testing.T) {
+	ws := ids.New[ids.WorkspaceKind]()
+	good, err := mintRef(ws)
+	if err != nil {
+		t.Fatalf("mintRef: %v", err)
+	}
+
+	malformed := map[string]Ref{
+		"empty":               "",
+		"wrong scheme":        Ref("xxx.1." + ws.String() + ".tok"),
+		"too few parts":       Ref("mgv.1." + ws.String()),
+		"too many parts":      Ref("mgv.1." + ws.String() + ".tok.extra"),
+		"non-numeric version": Ref("mgv.x." + ws.String() + ".tok"),
+		"zero version":        Ref("mgv.0." + ws.String() + ".tok"),
+		"bad workspace":       "mgv.1.not-a-uuid.tok",
+		"empty token":         Ref("mgv.1." + ws.String() + "."),
+	}
+	for name, ref := range malformed {
+		if _, err := ref.parse(); err == nil {
+			t.Errorf("%s: parse(%q) returned no error, want malformed", name, ref)
+		}
+		if ref.scopedTo(ws) {
+			t.Errorf("%s: a malformed ref must not be scoped to any workspace", name)
+		}
+	}
+
+	// The well-formed ref parses and is scoped to its own workspace only.
+	p, err := good.parse()
+	if err != nil {
+		t.Fatalf("parse(good): %v", err)
+	}
+	if p.workspace != ws || p.keyVersion != currentKeyVersion || p.token == "" {
+		t.Fatalf("parse(good) = %+v, want ws=%s version=%d non-empty token", p, ws, currentKeyVersion)
+	}
+	if !good.scopedTo(ws) {
+		t.Fatal("a well-formed ref must be scoped to its own workspace")
+	}
+	if good.scopedTo(ids.New[ids.WorkspaceKind]()) {
+		t.Fatal("a ref must not be scoped to a different workspace")
+	}
+}
+
+func TestRefLogSafe(t *testing.T) {
+	ws := ids.New[ids.WorkspaceKind]()
+	ref, err := mintRef(ws)
+	if err != nil {
+		t.Fatalf("mintRef: %v", err)
+	}
+	safe := refLogSafe(ref)
+	if !strings.Contains(safe, ws.String()) {
+		t.Errorf("refLogSafe(%q) = %q, want it to name the workspace", ref, safe)
+	}
+	if !strings.Contains(safe, "<token>") {
+		t.Errorf("refLogSafe(%q) = %q, want the token masked", ref, safe)
+	}
+	// The unguessable token — the capability part of the handle — must not appear.
+	p, _ := ref.parse()
+	if strings.Contains(safe, p.token) {
+		t.Errorf("refLogSafe leaked the token: %q", safe)
+	}
+	if got := refLogSafe("not-a-ref"); got != "<malformed-ref>" {
+		t.Errorf("refLogSafe(malformed) = %q, want <malformed-ref>", got)
+	}
+}
+
+func TestNew_validatesConfig(t *testing.T) {
+	// A valid key but no pool is a wiring error surfaced at construction.
+	if _, err := New(Config{RootKey: testKey(t), Pool: nil}); err == nil {
+		t.Fatal("New with a nil pool must error")
+	}
+	// A short key is rejected before the pool is even considered.
+	if _, err := New(Config{RootKey: make([]byte, 16), Pool: nil}); err == nil {
+		t.Fatal("New with a 16-byte key must error")
+	}
+}
+
+func TestMemoryVault_healthAndForeignDeleteAreNoops(t *testing.T) {
+	v := NewMemory()
+	ctx := context.Background()
+	if err := v.Health(ctx); err != nil {
+		t.Fatalf("memory Health must succeed: %v", err)
+	}
+	// Deleting a ref minted for another workspace addresses nothing here — a
+	// no-op, never an error (idempotent).
+	foreign, err := mintRef(ids.New[ids.WorkspaceKind]())
+	if err != nil {
+		t.Fatalf("mintRef: %v", err)
+	}
+	if err := v.Delete(ctx, ids.New[ids.WorkspaceKind](), foreign); err != nil {
+		t.Fatalf("deleting a foreign ref must be a no-op: %v", err)
+	}
+}
+
+// The local provider's fail-fast guards return before touching the database,
+// so they are exercised here with a nil pool: a zero-workspace Put, a
+// foreign-ref Delete (no-op), and a malformed/foreign-ref Get (ErrNotFound)
+// must never reach a query.
+func TestLocalVault_guardsReturnBeforeTheDB(t *testing.T) {
+	aead, err := newAEAD(testKey(t))
+	if err != nil {
+		t.Fatalf("newAEAD: %v", err)
+	}
+	v := &localVault{aead: aead, pool: nil}
+	ctx := context.Background()
+
+	if _, err := v.Put(ctx, ids.WorkspaceID{}, []byte("x")); err == nil {
+		t.Fatal("Put with a zero workspace must error before any query")
+	}
+	foreign, err := mintRef(ids.New[ids.WorkspaceKind]())
+	if err != nil {
+		t.Fatalf("mintRef: %v", err)
+	}
+	if err := v.Delete(ctx, ids.New[ids.WorkspaceKind](), foreign); err != nil {
+		t.Fatalf("Delete of a foreign ref must be a no-op before any query: %v", err)
+	}
+	if _, err := v.Get(ctx, ids.New[ids.WorkspaceKind](), "garbage"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Get of a malformed ref: got %v, want ErrNotFound before any query", err)
+	}
+}

--- a/backend/internal/platform/keyvault/keyvault_test.go
+++ b/backend/internal/platform/keyvault/keyvault_test.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package keyvault_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// The memory fake carries the Vault contract for hermetic unit tests; the
+// same behaviours are proven against the local provider on real Postgres in
+// the integration lane. Every property here is one the local provider must
+// honour identically.
+
+func TestMemoryVault_roundTrip(t *testing.T) {
+	v := keyvault.NewMemory()
+	ctx := context.Background()
+	ws := ids.New[ids.WorkspaceKind]()
+	secret := []byte("imap-password-and-cursor-bundle")
+
+	ref, err := v.Put(ctx, ws, secret)
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if ref == "" {
+		t.Fatal("Put returned an empty ref")
+	}
+
+	got, err := v.Get(ctx, ws, ref)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !bytes.Equal(got, secret) {
+		t.Fatalf("Get returned %q, want %q", got, secret)
+	}
+}
+
+// A ref is safe to persist in a domain row and to log — it must never carry
+// the plaintext it addresses.
+func TestMemoryVault_refDoesNotLeakTheSecret(t *testing.T) {
+	v := keyvault.NewMemory()
+	ctx := context.Background()
+	ws := ids.New[ids.WorkspaceKind]()
+	secret := []byte("super-secret-value-xyzzy")
+
+	ref, err := v.Put(ctx, ws, secret)
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if strings.Contains(string(ref), "xyzzy") {
+		t.Fatalf("ref %q contains the plaintext secret", ref)
+	}
+}
+
+// The load-bearing isolation property: a ref minted under one workspace does
+// not resolve under another — a stolen ref is inert across the tenant edge.
+func TestMemoryVault_refDoesNotResolveUnderAnotherWorkspace(t *testing.T) {
+	v := keyvault.NewMemory()
+	ctx := context.Background()
+	wsA := ids.New[ids.WorkspaceKind]()
+	wsB := ids.New[ids.WorkspaceKind]()
+
+	ref, err := v.Put(ctx, wsA, []byte("tenant-a-secret"))
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	if _, err := v.Get(ctx, wsB, ref); !errors.Is(err, keyvault.ErrNotFound) {
+		t.Fatalf("Get under the wrong workspace: got %v, want ErrNotFound", err)
+	}
+}
+
+func TestMemoryVault_getMissingIsNotFound(t *testing.T) {
+	v := keyvault.NewMemory()
+	ctx := context.Background()
+	ws := ids.New[ids.WorkspaceKind]()
+
+	ref, err := v.Put(ctx, ws, []byte("value"))
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if err := v.Delete(ctx, ws, ref); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := v.Get(ctx, ws, ref); !errors.Is(err, keyvault.ErrNotFound) {
+		t.Fatalf("Get after Delete: got %v, want ErrNotFound", err)
+	}
+}
+
+// Delete is idempotent so an erasure crash-retry is safe: deleting an absent
+// ref, or the same ref twice, is not an error.
+func TestMemoryVault_deleteIsIdempotent(t *testing.T) {
+	v := keyvault.NewMemory()
+	ctx := context.Background()
+	ws := ids.New[ids.WorkspaceKind]()
+
+	ref, err := v.Put(ctx, ws, []byte("value"))
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if err := v.Delete(ctx, ws, ref); err != nil {
+		t.Fatalf("first Delete: %v", err)
+	}
+	if err := v.Delete(ctx, ws, ref); err != nil {
+		t.Fatalf("second Delete (idempotent): %v", err)
+	}
+}
+
+// A zero workspace id is a wiring bug, never a legitimate tenant — Put must
+// refuse it loudly rather than mint an unscoped ref.
+func TestMemoryVault_putRejectsZeroWorkspace(t *testing.T) {
+	v := keyvault.NewMemory()
+	if _, err := v.Put(context.Background(), ids.WorkspaceID{}, []byte("value")); err == nil {
+		t.Fatal("Put with a zero workspace id must return an error")
+	}
+}

--- a/backend/internal/platform/keyvault/local.go
+++ b/backend/internal/platform/keyvault/local.go
@@ -157,7 +157,9 @@ func (v *localVault) Put(ctx context.Context, ws ids.WorkspaceID, secret []byte)
 	}
 	// The ref's random token makes a PK collision astronomically unlikely; an
 	// INSERT (not upsert) is correct because a re-Put mints a fresh ref and
-	// the old ciphertext is orphaned (swept later), never overwritten.
+	// the old ciphertext is left orphaned rather than overwritten — encrypted,
+	// unreferenced, and benign (there is no vault_secret sweeper today; if one
+	// is ever added it reclaims these, but nothing depends on that).
 	if _, err := v.pool.Exec(ctx,
 		`INSERT INTO vault_secret (ref, ciphertext, key_version) VALUES ($1, $2, $3)`,
 		string(ref), sealed, currentKeyVersion); err != nil {
@@ -167,19 +169,14 @@ func (v *localVault) Put(ctx context.Context, ws ids.WorkspaceID, secret []byte)
 }
 
 func (v *localVault) Get(ctx context.Context, ws ids.WorkspaceID, ref Ref) ([]byte, error) {
-	p, err := ref.parse()
-	if err != nil || p.workspace != ws {
-		// Malformed, or a ref for another workspace: absent to this caller.
+	if !ref.scopedTo(ws) {
+		// Malformed, or a ref for another workspace: absent to this caller. A
+		// ref naming any other key version is likewise absent — its string
+		// (version included) simply matches no stored row.
 		return nil, ErrNotFound
 	}
-	if p.keyVersion != currentKeyVersion {
-		// A ref sealed under a key version this build does not hold: an
-		// operational condition (a partial rotation rollback / corruption),
-		// not tenant absence — surface it, naming only the version number.
-		return nil, fmt.Errorf("keyvault: ref names key version %d, which this vault does not hold", p.keyVersion)
-	}
 	var sealed []byte
-	err = v.pool.QueryRow(ctx, `SELECT ciphertext FROM vault_secret WHERE ref = $1`, string(ref)).Scan(&sealed)
+	err := v.pool.QueryRow(ctx, `SELECT ciphertext FROM vault_secret WHERE ref = $1`, string(ref)).Scan(&sealed)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, ErrNotFound
 	}

--- a/backend/internal/platform/keyvault/local.go
+++ b/backend/internal/platform/keyvault/local.go
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package keyvault
+
+import (
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// envRootKey names the environment variable carrying the base64 (standard
+// encoding) 32-byte AES-256 root key. It is read from the environment, never
+// a CLI flag — a flag leaks into the process table. The value never reaches
+// a log line or an error message.
+const envRootKey = "MARGINCE_KEYVAULT_ROOT_KEY"
+
+// Config is the local provider's wiring, populated from operator config in
+// cmd. RootKey is the workspace-agnostic master key that seals every secret;
+// Pool is the shared pgxpool the vault_secret ciphertext table lives in.
+// Neither the key nor any plaintext is ever logged.
+type Config struct {
+	RootKey []byte
+	Pool    *pgxpool.Pool
+}
+
+// localVault is the config/local-backed Vault: it seals secrets with
+// AES-256-GCM under a config root key and stores the ciphertext in the
+// operational vault_secret table. The table carries NO workspace_id — the
+// workspace lives in the ref and in the GCM AAD, so isolation is a
+// cryptographic and structural property of the ref, not RLS. It never writes
+// a domain row: the connector_connection row (with its credential_ref) is the
+// domain mutation, committed through storekit by the calling module.
+type localVault struct {
+	aead cipher.AEAD
+	pool *pgxpool.Pool
+}
+
+var _ Vault = (*localVault)(nil)
+
+// New builds the local provider. It validates the root key up front (a
+// missing or wrong-length key is a boot error, never a silent zero key) and
+// does no I/O — readiness of the vault_secret table is reported by Health, so
+// construction cannot fail on a not-yet-migrated database.
+//
+//nolint:ireturn // the seam has two providers (memory + local) behind one Vault; returning the interface is the design.
+func New(cfg Config) (Vault, error) {
+	aead, err := newAEAD(cfg.RootKey)
+	if err != nil {
+		return nil, err
+	}
+	if cfg.Pool == nil {
+		return nil, errors.New("keyvault: a database pool is required for the local provider")
+	}
+	return &localVault{aead: aead, pool: cfg.Pool}, nil
+}
+
+// FromEnv builds a local Vault from MARGINCE_KEYVAULT_ROOT_KEY over the given
+// pool. It reports configured=false with a nil Vault when the key is unset,
+// so a deployment without a vault boots normally (a capture-capable role then
+// declares the gap at wiring time rather than nil-derefing at Authenticate).
+// A key that is set but malformed or the wrong length is a hard error — a
+// misconfigured vault must fail loudly, never fall back to something weaker.
+//
+//nolint:ireturn // the seam has two providers behind one Vault; returning the interface is the design.
+func FromEnv(pool *pgxpool.Pool) (vault Vault, configured bool, err error) {
+	encoded := os.Getenv(envRootKey)
+	if encoded == "" {
+		return nil, false, nil
+	}
+	key, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		// The decode error from the base64 package does not include the input,
+		// but wrap it with our own message to be certain no key bytes travel.
+		return nil, false, fmt.Errorf("keyvault: %s is not valid base64", envRootKey)
+	}
+	v, err := New(Config{RootKey: key, Pool: pool})
+	if err != nil {
+		return nil, false, err
+	}
+	return v, true, nil
+}
+
+// newAEAD builds the AES-256-GCM AEAD from the root key. The error names the
+// length requirement, never the key bytes.
+func newAEAD(rootKey []byte) (cipher.AEAD, error) {
+	const keyLen = 32 // AES-256
+	if len(rootKey) != keyLen {
+		return nil, fmt.Errorf("keyvault: root key must be %d bytes for AES-256, got %d", keyLen, len(rootKey))
+	}
+	block, err := aes.NewCipher(rootKey)
+	if err != nil {
+		return nil, fmt.Errorf("keyvault: building the cipher: %w", err)
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("keyvault: building GCM: %w", err)
+	}
+	return aead, nil
+}
+
+// errDecrypt is the opaque failure every decryption path returns: it never
+// carries the plaintext (there is none to leak) or any hint of the key. A
+// wrong key, a tampered ciphertext, and a swapped AAD are indistinguishable
+// to a caller by design.
+var errDecrypt = errors.New("keyvault: secret could not be decrypted")
+
+// seal encrypts plaintext under aead, binding aad (the ref) into the GCM tag.
+// The stored blob is nonce||ciphertext; the fresh random nonce is drawn from
+// crypto/rand, and a failure there is surfaced rather than masked.
+func seal(aead cipher.AEAD, aad, plaintext []byte) ([]byte, error) {
+	nonce := make([]byte, aead.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, fmt.Errorf("keyvault: generating a nonce: %w", err)
+	}
+	// Seal appends the ciphertext+tag to nonce, so the returned slice is
+	// nonce||ciphertext — self-describing for open.
+	return aead.Seal(nonce, nonce, plaintext, aad), nil
+}
+
+// open reverses seal. It returns errDecrypt on any authentication failure
+// (wrong key, tampered bytes, wrong AAD) so no failure mode leaks detail.
+func open(aead cipher.AEAD, aad, sealed []byte) ([]byte, error) {
+	ns := aead.NonceSize()
+	if len(sealed) < ns {
+		return nil, errDecrypt
+	}
+	nonce, ciphertext := sealed[:ns], sealed[ns:]
+	plaintext, err := aead.Open(nil, nonce, ciphertext, aad)
+	if err != nil {
+		return nil, errDecrypt
+	}
+	return plaintext, nil
+}
+
+func (v *localVault) Put(ctx context.Context, ws ids.WorkspaceID, secret []byte) (Ref, error) {
+	if ws.IsZero() {
+		return "", errors.New("keyvault: cannot store a secret for a zero workspace id")
+	}
+	ref, err := mintRef(ws, currentKeyVersion)
+	if err != nil {
+		return "", err
+	}
+	sealed, err := seal(v.aead, []byte(ref), secret)
+	if err != nil {
+		return "", err
+	}
+	// The ref's random token makes a PK collision astronomically unlikely; an
+	// INSERT (not upsert) is correct because a re-Put mints a fresh ref and
+	// the old ciphertext is orphaned (swept later), never overwritten.
+	if _, err := v.pool.Exec(ctx,
+		`INSERT INTO vault_secret (ref, ciphertext, key_version) VALUES ($1, $2, $3)`,
+		string(ref), sealed, currentKeyVersion); err != nil {
+		return "", fmt.Errorf("keyvault: storing secret %s: %w", refLogSafe(ref), err)
+	}
+	return ref, nil
+}
+
+func (v *localVault) Get(ctx context.Context, ws ids.WorkspaceID, ref Ref) ([]byte, error) {
+	p, err := ref.parse()
+	if err != nil || p.workspace != ws {
+		// Malformed, or a ref for another workspace: absent to this caller.
+		return nil, ErrNotFound
+	}
+	if p.keyVersion != currentKeyVersion {
+		// A ref sealed under a key version this build does not hold: an
+		// operational condition (a partial rotation rollback / corruption),
+		// not tenant absence — surface it, naming only the version number.
+		return nil, fmt.Errorf("keyvault: ref names key version %d, which this vault does not hold", p.keyVersion)
+	}
+	var sealed []byte
+	err = v.pool.QueryRow(ctx, `SELECT ciphertext FROM vault_secret WHERE ref = $1`, string(ref)).Scan(&sealed)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("keyvault: reading secret %s: %w", refLogSafe(ref), err)
+	}
+	plaintext, err := open(v.aead, []byte(ref), sealed)
+	if err != nil {
+		return nil, err // errDecrypt — no leak
+	}
+	return plaintext, nil
+}
+
+func (v *localVault) Delete(ctx context.Context, ws ids.WorkspaceID, ref Ref) error {
+	p, err := ref.parse()
+	if err != nil || p.workspace != ws {
+		// A ref from another workspace (or malformed) addresses nothing here;
+		// deleting it is a no-op, so a crash-retry is safe.
+		return nil
+	}
+	if _, err := v.pool.Exec(ctx, `DELETE FROM vault_secret WHERE ref = $1`, string(ref)); err != nil {
+		return fmt.Errorf("keyvault: deleting secret %s: %w", refLogSafe(ref), err)
+	}
+	return nil
+}
+
+// Health confirms the vault_secret table exists so a missing migration fails
+// readiness with a named cause rather than surfacing only when a secret is
+// first stored. It intentionally reads no rows.
+func (v *localVault) Health(ctx context.Context) error {
+	var reg *string
+	if err := v.pool.QueryRow(ctx, `SELECT to_regclass('public.vault_secret')::text`).Scan(&reg); err != nil {
+		return fmt.Errorf("keyvault: health: %w", err)
+	}
+	if reg == nil {
+		return errors.New("keyvault: vault_secret table is missing — run migrations")
+	}
+	return nil
+}
+
+// refLogSafe renders a ref for an error/log message without its random token,
+// which — while not the secret — is the unguessable capability part of the
+// handle. The workspace and version are safe to show and pinpoint the row.
+func refLogSafe(ref Ref) string {
+	p, err := ref.parse()
+	if err != nil {
+		return "<malformed-ref>"
+	}
+	return fmt.Sprintf("mgv.%d.%s.<token>", p.keyVersion, p.workspace)
+}

--- a/backend/internal/platform/keyvault/local.go
+++ b/backend/internal/platform/keyvault/local.go
@@ -147,7 +147,7 @@ func (v *localVault) Put(ctx context.Context, ws ids.WorkspaceID, secret []byte)
 	if ws.IsZero() {
 		return "", errors.New("keyvault: cannot store a secret for a zero workspace id")
 	}
-	ref, err := mintRef(ws, currentKeyVersion)
+	ref, err := mintRef(ws)
 	if err != nil {
 		return "", err
 	}
@@ -194,8 +194,7 @@ func (v *localVault) Get(ctx context.Context, ws ids.WorkspaceID, ref Ref) ([]by
 }
 
 func (v *localVault) Delete(ctx context.Context, ws ids.WorkspaceID, ref Ref) error {
-	p, err := ref.parse()
-	if err != nil || p.workspace != ws {
+	if !ref.scopedTo(ws) {
 		// A ref from another workspace (or malformed) addresses nothing here;
 		// deleting it is a no-op, so a crash-retry is safe.
 		return nil

--- a/backend/internal/platform/keyvault/local_internal_test.go
+++ b/backend/internal/platform/keyvault/local_internal_test.go
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package keyvault
+
+import (
+	"bytes"
+	"crypto/rand"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// The local provider's AES-GCM layer is unit-tested here without a database;
+// the Put/Get/Delete round-trip against real Postgres is the integration
+// lane's job. These cover the security-critical crypto: round-trip, that a
+// wrong root key fails cleanly without leaking the plaintext, and that the
+// AAD binds the ciphertext to its exact ref so a swapped or cross-workspace
+// ref cannot open it.
+
+func testKey(t *testing.T) []byte {
+	t.Helper()
+	k := make([]byte, 32)
+	if _, err := rand.Read(k); err != nil {
+		t.Fatalf("generating a test key: %v", err)
+	}
+	return k
+}
+
+func TestSealOpen_roundTrip(t *testing.T) {
+	aead, err := newAEAD(testKey(t))
+	if err != nil {
+		t.Fatalf("newAEAD: %v", err)
+	}
+	ref, err := mintRef(ids.New[ids.WorkspaceKind](), currentKeyVersion)
+	if err != nil {
+		t.Fatalf("mintRef: %v", err)
+	}
+	secret := []byte("the-imap-credential-bundle")
+
+	sealed, err := seal(aead, []byte(ref), secret)
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	if bytes.Contains(sealed, secret) {
+		t.Fatal("sealed bytes contain the plaintext — encryption did not happen")
+	}
+
+	got, err := open(aead, []byte(ref), sealed)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if !bytes.Equal(got, secret) {
+		t.Fatalf("open returned %q, want %q", got, secret)
+	}
+}
+
+func TestOpen_wrongKeyFailsWithoutLeakingPlaintext(t *testing.T) {
+	good, err := newAEAD(testKey(t))
+	if err != nil {
+		t.Fatalf("newAEAD good: %v", err)
+	}
+	wrong, err := newAEAD(testKey(t))
+	if err != nil {
+		t.Fatalf("newAEAD wrong: %v", err)
+	}
+	ref, err := mintRef(ids.New[ids.WorkspaceKind](), currentKeyVersion)
+	if err != nil {
+		t.Fatalf("mintRef: %v", err)
+	}
+	secret := []byte("plaintext-must-not-leak-abcdef")
+
+	sealed, err := seal(good, []byte(ref), secret)
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+
+	_, err = open(wrong, []byte(ref), sealed)
+	if err == nil {
+		t.Fatal("open with the wrong key must fail")
+	}
+	if strings.Contains(err.Error(), string(secret)) || strings.Contains(err.Error(), "abcdef") {
+		t.Fatalf("decrypt error leaks the plaintext: %v", err)
+	}
+}
+
+// The AAD binds the ciphertext to its exact ref (workspace + version +
+// token). Opening with a different ref's AAD must fail — this is the crypto
+// half of workspace isolation and defeats ciphertext substitution.
+func TestOpen_differentRefAADFails(t *testing.T) {
+	aead, err := newAEAD(testKey(t))
+	if err != nil {
+		t.Fatalf("newAEAD: %v", err)
+	}
+	refA, err := mintRef(ids.New[ids.WorkspaceKind](), currentKeyVersion)
+	if err != nil {
+		t.Fatalf("mintRef A: %v", err)
+	}
+	refB, err := mintRef(ids.New[ids.WorkspaceKind](), currentKeyVersion)
+	if err != nil {
+		t.Fatalf("mintRef B: %v", err)
+	}
+	sealed, err := seal(aead, []byte(refA), []byte("secret"))
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	if _, err := open(aead, []byte(refB), sealed); err == nil {
+		t.Fatal("open with a different ref's AAD must fail")
+	}
+}
+
+func TestNewAEAD_rejectsShortKey(t *testing.T) {
+	if _, err := newAEAD(make([]byte, 16)); err == nil {
+		t.Fatal("newAEAD must reject a 16-byte key — AES-256 needs 32 bytes")
+	}
+	if _, err := newAEAD(nil); err == nil {
+		t.Fatal("newAEAD must reject a nil key")
+	}
+}
+
+// A short key error must name the length requirement, never the key bytes.
+func TestNewAEAD_errorDoesNotLeakKey(t *testing.T) {
+	key := []byte("0123456789abcdef") // 16 bytes — too short
+	_, err := newAEAD(key)
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if strings.Contains(err.Error(), string(key)) {
+		t.Fatalf("newAEAD error leaks the key material: %v", err)
+	}
+}
+
+func TestFromEnv_unsetIsNotConfigured(t *testing.T) {
+	t.Setenv(envRootKey, "")
+	v, configured, err := FromEnv(nil)
+	if err != nil {
+		t.Fatalf("FromEnv unset: %v", err)
+	}
+	if configured || v != nil {
+		t.Fatalf("FromEnv with no root key must report not-configured, got configured=%v vault=%v", configured, v)
+	}
+}
+
+func TestFromEnv_shortKeyIsAnError(t *testing.T) {
+	// base64 of 16 bytes — decodes fine but is too short for AES-256.
+	t.Setenv(envRootKey, "MDEyMzQ1Njc4OWFiY2RlZg==")
+	if _, _, err := FromEnv(nil); err == nil {
+		t.Fatal("FromEnv with a 16-byte key must error, not silently accept it")
+	}
+}
+
+func TestFromEnv_nonBase64IsAnError(t *testing.T) {
+	t.Setenv(envRootKey, "not valid base64!!!")
+	if _, _, err := FromEnv(nil); err == nil {
+		t.Fatal("FromEnv with a non-base64 key must error")
+	}
+}

--- a/backend/internal/platform/keyvault/local_internal_test.go
+++ b/backend/internal/platform/keyvault/local_internal_test.go
@@ -33,7 +33,7 @@ func TestSealOpen_roundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newAEAD: %v", err)
 	}
-	ref, err := mintRef(ids.New[ids.WorkspaceKind](), currentKeyVersion)
+	ref, err := mintRef(ids.New[ids.WorkspaceKind]())
 	if err != nil {
 		t.Fatalf("mintRef: %v", err)
 	}
@@ -65,7 +65,7 @@ func TestOpen_wrongKeyFailsWithoutLeakingPlaintext(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newAEAD wrong: %v", err)
 	}
-	ref, err := mintRef(ids.New[ids.WorkspaceKind](), currentKeyVersion)
+	ref, err := mintRef(ids.New[ids.WorkspaceKind]())
 	if err != nil {
 		t.Fatalf("mintRef: %v", err)
 	}
@@ -93,11 +93,11 @@ func TestOpen_differentRefAADFails(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newAEAD: %v", err)
 	}
-	refA, err := mintRef(ids.New[ids.WorkspaceKind](), currentKeyVersion)
+	refA, err := mintRef(ids.New[ids.WorkspaceKind]())
 	if err != nil {
 		t.Fatalf("mintRef A: %v", err)
 	}
-	refB, err := mintRef(ids.New[ids.WorkspaceKind](), currentKeyVersion)
+	refB, err := mintRef(ids.New[ids.WorkspaceKind]())
 	if err != nil {
 		t.Fatalf("mintRef B: %v", err)
 	}

--- a/backend/internal/platform/keyvault/memory.go
+++ b/backend/internal/platform/keyvault/memory.go
@@ -18,8 +18,8 @@ import (
 // provider's contract: the ref carries its workspace, and a ref presented
 // under the wrong workspace answers ErrNotFound before any lookup.
 //
-// The memory fake at version 1 mints refs at key version 1 — it has no root
-// key and does no encryption, but stamps the same version the local provider
+// The memory fake mints refs at the current key version — it has no root key
+// and does no encryption, but stamps the same version the local provider
 // does so a ref round-trips through either provider's parse.
 type memoryVault struct {
 	mu      sync.RWMutex
@@ -37,7 +37,7 @@ func (m *memoryVault) Put(_ context.Context, ws ids.WorkspaceID, secret []byte) 
 	if ws.IsZero() {
 		return "", fmt.Errorf("keyvault: cannot store a secret for a zero workspace id")
 	}
-	ref, err := mintRef(ws, memoryKeyVersion)
+	ref, err := mintRef(ws, currentKeyVersion)
 	if err != nil {
 		return "", err
 	}
@@ -80,8 +80,3 @@ func (m *memoryVault) Delete(_ context.Context, ws ids.WorkspaceID, ref Ref) err
 
 // Health always succeeds: the in-memory vault has no backend to reach.
 func (m *memoryVault) Health(_ context.Context) error { return nil }
-
-// memoryKeyVersion is the key version the fake stamps into its refs. It is 1
-// to match the local provider's first root-key version so a ref is
-// well-formed regardless of which provider minted it.
-const memoryKeyVersion = 1

--- a/backend/internal/platform/keyvault/memory.go
+++ b/backend/internal/platform/keyvault/memory.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package keyvault
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// memoryVault is the in-memory Vault: the default for unit tests and the
+// offline / zero-toolchain dev path. It copies bytes in and out so a caller
+// can neither mutate a stored secret through a returned slice nor have a
+// later write reach into an earlier read. Isolation matches the local
+// provider's contract: the ref carries its workspace, and a ref presented
+// under the wrong workspace answers ErrNotFound before any lookup.
+//
+// The memory fake at version 1 mints refs at key version 1 — it has no root
+// key and does no encryption, but stamps the same version the local provider
+// does so a ref round-trips through either provider's parse.
+type memoryVault struct {
+	mu      sync.RWMutex
+	secrets map[Ref][]byte // keyed by the whole ref, which is globally unique
+}
+
+// NewMemory returns an in-memory Vault. It is safe for concurrent use.
+//
+//nolint:ireturn // the seam has two providers (memory + local) behind one Vault; returning the interface is the design.
+func NewMemory() Vault {
+	return &memoryVault{secrets: make(map[Ref][]byte)}
+}
+
+func (m *memoryVault) Put(_ context.Context, ws ids.WorkspaceID, secret []byte) (Ref, error) {
+	if ws.IsZero() {
+		return "", fmt.Errorf("keyvault: cannot store a secret for a zero workspace id")
+	}
+	ref, err := mintRef(ws, memoryKeyVersion)
+	if err != nil {
+		return "", err
+	}
+	stored := make([]byte, len(secret))
+	copy(stored, secret)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.secrets[ref] = stored
+	return ref, nil
+}
+
+func (m *memoryVault) Get(_ context.Context, ws ids.WorkspaceID, ref Ref) ([]byte, error) {
+	// The structural workspace gate first: a ref from another workspace is
+	// ErrNotFound before any lookup, matching the local provider.
+	if !ref.scopedTo(ws) {
+		return nil, ErrNotFound
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	stored, ok := m.secrets[ref]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	out := make([]byte, len(stored))
+	copy(out, stored)
+	return out, nil
+}
+
+func (m *memoryVault) Delete(_ context.Context, ws ids.WorkspaceID, ref Ref) error {
+	if !ref.scopedTo(ws) {
+		// A ref from another workspace addresses nothing here; deleting it is
+		// a no-op, not an error (idempotent, like an absent ref).
+		return nil
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.secrets, ref)
+	return nil
+}
+
+// Health always succeeds: the in-memory vault has no backend to reach.
+func (m *memoryVault) Health(_ context.Context) error { return nil }
+
+// memoryKeyVersion is the key version the fake stamps into its refs. It is 1
+// to match the local provider's first root-key version so a ref is
+// well-formed regardless of which provider minted it.
+const memoryKeyVersion = 1

--- a/backend/internal/platform/keyvault/memory.go
+++ b/backend/internal/platform/keyvault/memory.go
@@ -37,7 +37,7 @@ func (m *memoryVault) Put(_ context.Context, ws ids.WorkspaceID, secret []byte) 
 	if ws.IsZero() {
 		return "", fmt.Errorf("keyvault: cannot store a secret for a zero workspace id")
 	}
-	ref, err := mintRef(ws, currentKeyVersion)
+	ref, err := mintRef(ws)
 	if err != nil {
 		return "", err
 	}

--- a/backend/migrations/core/0062_keyvault.down.sql
+++ b/backend/migrations/core/0062_keyvault.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE vault_secret;
+ALTER TABLE connector_connection DROP COLUMN credential_ref;

--- a/backend/migrations/core/0062_keyvault.up.sql
+++ b/backend/migrations/core/0062_keyvault.up.sql
@@ -1,0 +1,28 @@
+-- 0062: the keyvault seam's storage (decisions/0023). Two additive changes,
+-- no destructive step: the connector_connection.auth bytea column STAYS
+-- through this transition (write-to-vault + record ref + backfill) and is
+-- dropped only in a LATER additive migration once no reader depends on it.
+
+-- The opaque, workspace-scoped handle the capture module records in place of
+-- the raw credential bytes. NULL through the transition: existing rows carry
+-- auth until the backfill mints a ref, and a re-authenticated connection then
+-- reads credential_ref in preference to auth.
+ALTER TABLE connector_connection ADD COLUMN credential_ref text NULL;
+
+-- vault_secret is the local provider's ciphertext store: operational
+-- infrastructure, NOT tenant data. It deliberately carries NO workspace_id
+-- and therefore no RLS — the workspace lives inside the ref and inside the
+-- AES-256-GCM AAD, so isolation is a cryptographic and structural property of
+-- the ref (a ref presented under the wrong workspace is rejected before any
+-- read, and its ciphertext cannot be opened under another workspace's AAD),
+-- not a row-security policy. This mirrors River's operational tables
+-- (decisions/0021): scheduling and secret custody are not tenant rows. The
+-- ref is the primary key; its random token makes it unguessable. key_version
+-- records which root-key version sealed the row so a future rotation can pick
+-- the key by version without rewriting the ref format.
+CREATE TABLE vault_secret (
+  ref         text PRIMARY KEY,
+  ciphertext  bytea NOT NULL,
+  key_version integer NOT NULL,
+  created_at  timestamptz NOT NULL DEFAULT now()
+);

--- a/decisions/0023-keyvault-seam.md
+++ b/decisions/0023-keyvault-seam.md
@@ -1,0 +1,172 @@
+# 0023 — Keyvault seam for secret material (worklist §1c platform seam)
+
+Date: 2026-07-10. Implements the keyvault arm of the platform-parity push
+ratified in the 2026-07-10 founder walkthrough
+([docs/worklists/skeleton-baseline-2026-07-09.md](../docs/worklists/skeleton-baseline-2026-07-09.md)
+§0b, §1c), the sibling of River (decisions/0021) and blobstore
+(decisions/0022). This record ratifies the design; the concrete code steps
+are in
+[docs/worklists/keyvault-seam-2026-07-10.md](../docs/worklists/keyvault-seam-2026-07-10.md).
+
+## Context
+
+Secret material is persisted **inside domain and infrastructure tables**
+today:
+
+- `connector_connection.auth bytea` (core migration 0023) — the opaque
+  connector credential bundle for one human's grant of one connector.
+- `oauth.private_key` / `oauth.public_key bytea` (core migration 0025) — the
+  OAuth signing keypair.
+
+The capture path shows why this is the constraint that matters. The IMAP
+connector deliberately **discards the password at login** (`imap.go`: "the
+password is used here and discarded") because there is nowhere safe to persist
+it — so today capture is effectively a one-shot pull, and durable incremental
+`Sync` over a stored credential cannot work. Giving connectors a durable,
+per-user credential that is **not** a bytea column in a tenant table is
+exactly the queued EP05 §B reshape — "per-user + vault `credential_ref` —
+structural, own PR arc" (docs/worklists/spec-drift-2026-07-08.md).
+
+So keyvault is the seam that holds secret material **out of** the domain
+tables, leaving an opaque `credential_ref` handle in the row.
+
+**The entanglement is the whole story here** (and is why §0b says "pair this
+with the EP05 §B capture-connection vault reshape — evaluate together"): a
+`platform/keyvault` package with a fake and wiring but no secret actually
+moved onto it is speculative dead code (T3/T8). Unlike blobstore — whose
+callers already exist the day it lands — keyvault's only real consumer is the
+migration of an existing secret onto it. Keyvault must therefore ship
+**with** its first secret migrated, or not at all.
+
+## Decision
+
+**Adopt `internal/platform/keyvault` — the peer of `platform/jobs` — a
+provider-agnostic secret store behind an opaque, workspace-scoped
+`credential_ref`, with a config/local-backed provider and an in-memory fake;
+and in the same PR migrate the first real secret (`connector_connection.auth`)
+onto it, replacing the tenant-table bytea column with a `credential_ref`.**
+
+### Why a `platform/` package and NOT a frozen `shared/ports/` seam
+
+Same reasoning as blobstore (decisions/0022): the `Vault` interface
+(`Put`/`Get`/`Delete` by ref) is technical plumbing with one substitution axis
+(a real backend vs the memory fake) and no cross-module provider registry, so
+it lives in the `platform` package, not `shared/ports/`. The `connector` port
+in `shared/ports/connector` does **not** need to import keyvault: the
+`credential_ref` is just an opaque string handle on the domain row; the
+`capture` module resolves the ref through `platform/keyvault` and hands the
+connector its `Auth` bytes exactly as before — the port seam is unchanged.
+
+**Spec touchpoint (P3):** verify against `contract/interfaces.md` §1 (the
+capture seam) and any declared vault/credential interface when the sibling
+spec tree is reachable (it is not from this checkout — worklist §3). If the
+spec freezes a vault interface, it becomes a `ports/` seam.
+
+### Sequencing and scope — the load-bearing rule
+
+Keyvault ships as **one reviewable PR that introduces the seam AND migrates
+the smallest real secret onto it**, deferring the broader product reshape:
+
+- **In scope, now:** the `Vault` interface + memory fake + config/local-backed
+  provider + compose wiring + `/readyz` probe; a `credential_ref text` column
+  added to `connector_connection` (additive migration); the `capture` write
+  path stores the credential bundle in the vault and records the ref; the read
+  path resolves the ref back to `Auth`; the `auth bytea` column is
+  deprecated/dropped **additively** (write-to-vault first, backfill, then drop
+  in a later migration — never a destructive single step).
+- **Explicitly out of scope this pass, the EP05 §B product arc it unblocks:**
+  multiple per-user connections, the connection-management contract surface
+  and UI, and connector credential *rotation*. Those now have a vault to build
+  on and are their own arc.
+- `DECISION (founder)`: are the `oauth.private_key/public_key` keypairs in
+  scope of this push or a follow-on? **Recommendation: connector auth only in
+  this push**; the OAuth signing keys are a distinct migration (different
+  lifecycle, different consumers) and fold onto the same seam next.
+
+### The keyvault / DB boundary
+
+| | **DB row** (`connector_connection`) | **Keyvault** (`platform/keyvault`) |
+|---|---|---|
+| Holds | Non-secret metadata + the tenant anchor + `credential_ref` | The secret bytes, addressed by the ref |
+| Isolation | RLS via `WithWorkspaceTx` GUC | Ref is workspace-scoped; resolving it cross-tenant fails |
+| Authority | System of record for the connection | Custodian of the secret only |
+
+The rule: **the row owns the connection and its isolation; the vault owns only
+the secret, addressed by an opaque ref.** A `credential_ref` leaked from one
+tenant's row cannot resolve another tenant's secret — the ref is
+workspace-scoped and resolution re-checks the tenant, so a stolen ref is inert
+without also defeating RLS on the row. Keyvault does **not** store blobstore's
+infrastructure credentials or the app's own DB DSN (both are cold-boot
+prerequisites — a vault that needs the DB, and a store whose key lives in the
+vault, would be a bootstrapping cycle; those stay operator config/env).
+
+This composes cleanly with the existing egress-hygiene layer and does not
+replace it: `model.SecretStripper` (`ai/stripper.go`) keeps secrets **out of
+model-bound payloads at egress**; keyvault is where secrets live **at rest**.
+Different jobs, both kept.
+
+### Composition and layout
+
+- **`internal/platform/keyvault`** (new) — the `Vault` interface, `memoryVault`
+  fake, a config/local-backed provider (encrypted-at-rest via a
+  config-sourced key; the build plan pins the mechanism), `New` from config,
+  and a health probe. Owns no domain.
+- **`internal/compose`** — the `Vault` is constructed from config in `cmd` and
+  threaded into `compose.New` via an `Option`, handed to the `capture`
+  consumer (the connector Authenticate/Sync path). `/readyz` probe registered
+  here.
+- **`cmd/api` / `cmd/worker`** — build the `Vault` from operator config (the
+  root key / backend endpoint). The capture path is exercised by both roles
+  (API authenticates a connection; worker syncs), so both wire the vault.
+
+### Schema / migration ownership
+
+Additive migration on `connector_connection`: add `credential_ref text NULL`.
+The `auth bytea` column stays through the transition (write-to-vault + record
+ref + backfill existing rows), and is dropped in a **later** additive
+migration once no reader depends on it — never in the same destructive step,
+matching the repo's additive-migration rule (DO NOT TOUCH: shipped core
+migrations are additive-only). No new tenant table; RLS on
+`connector_connection` is unchanged.
+
+## Consequences
+
+- **Capability unblocked:** durable per-user connector credentials become
+  possible, which is what lets capture move from one-shot pulls to incremental
+  `Sync` — the EP05 §B arc can proceed on top of this seam.
+- **Security posture win:** tenant-supplied connector secrets leave the domain
+  table for a vault addressed by an opaque ref; a stolen `connector_connection`
+  row no longer carries the live credential bytes.
+- **New dependency:** the config/local vault backend's crypto (the build plan
+  pins it — standard library / a single vetted lib). Pure Go; image-pin and
+  SonarCloud posture unaffected.
+- **Ops surface:** `/readyz` gains a keyvault probe.
+- **Blast radius contained by design:** `platform/keyvault` new; `compose` and
+  the two `cmd` roles wire it; `capture` gains ref-based credential I/O; one
+  additive migration. The `connector` port is unchanged; the broader EP05 §B
+  contract/UI reshape is deliberately out of scope.
+- **Integration lane proves it, zero-skip:** a round-trip test (Authenticate
+  stores → ref recorded → Sync resolves the same `Auth`), workspace-ref
+  isolation (a ref from workspace A does not resolve under workspace B), and
+  the additive-migration backfill; the memory fake keeps unit tests hermetic.
+
+## Why blobstore and keyvault are two sequential PRs, not one combined push
+
+Recommended sequence: **blobstore first (decisions/0022), then keyvault** —
+two PRs, mirroring how River shipped as its own PR under the same "one
+platform push" umbrella.
+
+1. **Independence and risk asymmetry.** Blobstore is self-contained and its
+   callers already exist (the schema commits to `storage_key`; privacy needs
+   the object hooks). Keyvault is entangled with EP05 §B — a structural,
+   contract-adjacent arc — and cannot ship without migrating a real secret.
+   Combining them yokes a low-risk gap-fill to a higher-risk secret migration
+   in one unreviewable diff.
+2. **The shared plumbing is shallow.** The only overlap is "both handle
+   secrets," and it dissolves under inspection: blobstore's own access key is
+   operator config on the cold-boot path and is explicitly **not** a keyvault
+   client (§ boundary rules in both ADRs). They share no code; combining buys
+   nothing.
+3. **Reviewability.** Two focused PRs each mirror the River template (a
+   `platform/<seam>` package + fake + real impl + compose wiring + a
+   zero-skip integration proof), each independently revertible.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -37,7 +37,8 @@ Operational endpoints (served next to `/v1`):
   restart-loop the process).
 - `/readyz` — readiness: every dependency probe (Postgres; Redis too
   when the relay is inline; the object store when a blobstore is
-  configured) must pass within 2s, else 503 naming the unready dependency.
+  configured; the secret vault when a keyvault is configured) must pass
+  within 2s, else 503 naming the unready dependency.
 - `/metrics` — Prometheus text format: `margince_outbox_unpublished`,
   `margince_relay_published_total`, `margince_pgxpool_conns{state=…}`.
 
@@ -75,6 +76,26 @@ and the store tolerates a still-starting backend with a bounded retry.
 | `MARGINCE_BLOBSTORE_BUCKET` | — | bucket name (created on first connect) |
 | `MARGINCE_BLOBSTORE_REGION` | `us-east-1` | region |
 | `MARGINCE_BLOBSTORE_USE_SSL` | `false` | `true` for TLS to the store |
+
+## Secret vault (api, worker) — connector credentials
+
+Env-only, shared by both roles; the root key never appears on the command
+line (argv is world-readable) or in any log or error. A connector credential
+is sealed with AES-256-GCM under this key and stored as ciphertext in the
+operational `vault_secret` table; the `connector_connection` row carries only
+an opaque, workspace-scoped `credential_ref`, never the credential bytes
+(decisions/0023). Leave `MARGINCE_KEYVAULT_ROOT_KEY` unset and the vault is
+absent: the transient one-shot IMAP pull (which persists no credential) still
+works, and the persisting paths (Connect seals, Sync resolves) refuse loudly
+rather than store a credential in the clear. Set it and the api gains the
+`/readyz` keyvault probe and the vault-backed path, and the worker migrates
+any legacy `auth`-bytea rows onto the vault at boot (idempotent). A key that
+is SET but not exactly 32 bytes (base64-decoded) is a boot error — never a
+silent fallback.
+
+| Env | Default | Meaning |
+|---|---|---|
+| `MARGINCE_KEYVAULT_ROOT_KEY` | — | base64 (std) of 32 bytes; set to enable the vault. Generate: `openssl rand -base64 32` |
 
 ## cmd/mcp — the agent tool surface
 

--- a/docs/worklists/keyvault-seam-2026-07-10.md
+++ b/docs/worklists/keyvault-seam-2026-07-10.md
@@ -1,0 +1,251 @@
+# Keyvault seam — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development or superpowers:executing-plans to
+> implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+>
+> **Sequenced AFTER the blobstore seam** (docs/worklists/blobstore-seam-2026-07-10.md)
+> — see decisions/0023 for why the two are separate PRs.
+
+**Goal:** Introduce `platform/keyvault` — secret storage behind an opaque,
+workspace-scoped `credential_ref` (config/local-backed provider + in-memory
+fake) — and in the SAME PR migrate the first real secret,
+`connector_connection.auth`, off its tenant-table bytea column onto the vault,
+leaving a `credential_ref` on the row. A seam with no secret migrated would be
+dead code (T3/T8); the migration is what makes it real.
+
+**Architecture:** A new `internal/platform/keyvault` package (peer of
+`platform/jobs`) owns the `Vault` interface, a config/local-backed provider,
+and a `memoryVault` fake. The vault is constructed from config in `cmd` and
+threaded through `internal/compose` into the `capture` connector path. The DB
+row stays the system of record and tenant anchor; the vault owns only the
+secret bytes, addressed by an opaque ref. The `connector` port
+(`shared/ports/connector`) is **unchanged** — `capture` resolves the ref to
+`Auth` before handing the connector its credentials.
+
+**Decision of record:** [decisions/0023-keyvault-seam.md](../../decisions/0023-keyvault-seam.md).
+
+**Tech Stack:** Go 1.26.5, pgx v5.10.0, Postgres 16. Crypto for the local
+provider: prefer the standard library (`crypto/aes` + `crypto/cipher` GCM)
+with a config-sourced 32-byte root key; adopt a single vetted lib only if the
+build surfaces a concrete need. No new infrastructure container.
+
+## Global Constraints
+
+- Go **1.26.5**; any new dep pinned in `go.mod`; commit `go.sum`.
+- Every new hand-written `*.go` starts with the two-line BUSL-1.1 SPDX header
+  (`backend/license_test.go`). Not on `*_gen.go`.
+- Craft gate (diff-scoped, pre-push, BLOCKER): **never swallow an error** (a
+  vault Put/Get/Delete failure must surface — and must never log the secret
+  or the plaintext); **no `time.Sleep`/real-clock/real-network in tests**.
+- **Secret hygiene:** the plaintext secret and the root key never reach a log
+  line, an error message, or a model-bound payload. Error messages name the
+  ref, never the secret. This composes with — does not replace —
+  `model.SecretStripper`.
+- Integration tests `//go:build integration`, gate on `MARGINCE_TEST_*`, and a
+  skip fails the lane.
+- **Additive migrations only** (DO NOT TOUCH: shipped core migrations are
+  additive). The `auth bytea` column is dropped in a *later* migration, never
+  in the same step that adds `credential_ref`.
+- Non-test, non-generated Go files < 500 LOC; commits signed off;
+  `PATH="$(go env GOPATH)/bin:$PATH" make check` + `make test-integration`
+  green before push.
+- **Scope is the seam + the `connector_connection.auth` migration only.** Do
+  **not** build the EP05 §B per-user-connections reshape, the
+  connection-management contract/UI, credential rotation, or the OAuth-key
+  migration in this PR.
+
+## File Structure
+
+- **Create** `backend/internal/platform/keyvault/keyvault.go` — the `Vault`
+  interface, `Ref` type, sentinel errors (`ErrNotFound`), the
+  workspace-ref helper.
+- **Create** `backend/internal/platform/keyvault/memory.go` — `memoryVault`
+  fake (map-backed, concurrency-safe), default for unit tests / offline.
+- **Create** `backend/internal/platform/keyvault/local.go` — the
+  config/local-backed provider (AES-GCM at rest under a config root key),
+  `New` from `Config`, a health method for `/readyz`.
+- **Create** `backend/internal/platform/keyvault/keyvault_test.go` — unit
+  tests over the fake and the local provider (round-trip, not-found,
+  workspace-ref isolation, wrong-key decrypt failure).
+- **Create** the additive migration
+  `backend/migrations/core/00NN_connector_credential_ref.up.sql` /
+  `.down.sql` — `ALTER TABLE connector_connection ADD COLUMN credential_ref text NULL;`
+- **Modify** `backend/internal/compose/…` — a `WithKeyvault(vault)` Option;
+  hand the vault to the capture connector path; register the `/readyz` probe.
+- **Modify** `backend/internal/modules/capture/…` (the connection store +
+  the connect/sync compose adapter, e.g. `compose/imapconnect.go`) — on
+  Authenticate, store the credential bundle in the vault and record the
+  `credential_ref`; on Sync, resolve the ref back to `Auth`. Backfill existing
+  `auth bytea` rows into the vault.
+- **Modify** `backend/cmd/api/main.go`, `backend/cmd/worker/main.go` — build
+  the `Vault` from config and pass `WithKeyvault` (both roles: API
+  authenticates, worker syncs).
+- **Modify** `.env.template`, `docs/reference/configuration.md` — keyvault
+  config vars (backend selector, root-key source).
+- **Modify** the `/readyz` probe composition — add the keyvault probe.
+
+## The four checkpoint questions, answered up front
+
+**1. What is the `Vault` interface, and who calls it?**
+
+```go
+type Vault interface {
+    Put(ctx context.Context, workspaceID uuid.UUID, secret []byte) (Ref, error)
+    Get(ctx context.Context, workspaceID uuid.UUID, ref Ref) ([]byte, error) // ErrNotFound if absent
+    Delete(ctx context.Context, workspaceID uuid.UUID, ref Ref) error        // idempotent
+}
+```
+
+The `workspaceID` is part of every call so the provider scopes the ref to the
+tenant and a ref cannot be resolved under the wrong workspace. Caller this
+pass: the `capture` connector path (Authenticate stores, Sync resolves). The
+`connector` port is untouched — it still receives `Auth` bytes.
+
+**2. What schema / migration does it need?**
+
+One additive migration: `connector_connection ADD COLUMN credential_ref text
+NULL`. The `auth bytea` column **stays** through this PR (write-to-vault +
+record ref + backfill existing rows), and is dropped in a **later** additive
+migration once no reader depends on it. No new table; RLS on
+`connector_connection` unchanged.
+
+**3. How does it compose through `internal/compose`?**
+
+`platform/keyvault` owns the lifecycle. `cmd` builds the `Vault` from config
+and passes `compose.WithKeyvault(vault)`; `compose.New` threads it to the
+capture connector adapter and registers the `/readyz` probe. Both `cmd/api`
+and `cmd/worker` wire it (Authenticate runs in the API, Sync in the worker).
+
+**4. How does the integration lane prove it, zero-skip?**
+
+A round-trip test against the local provider on real Postgres: Authenticate
+stores the credential → `credential_ref` recorded on the row → Sync resolves
+the ref to the same `Auth` bytes → the connector authenticates. Plus:
+**workspace-ref isolation** (a ref minted under workspace A returns
+`ErrNotFound` when resolved under workspace B), and the **backfill** (an
+existing `auth bytea` row is migrated into the vault and gains a ref). The
+memory fake carries the contract in hermetic unit tests; the local provider's
+AES-GCM round-trip and wrong-key failure are unit-tested.
+
+---
+
+## Task 1: `platform/keyvault` interface + memory fake
+
+**Files:** create `keyvault.go`, `memory.go`, `keyvault_test.go`.
+
+- [ ] **Step 1: Write the failing unit test** over the fake — `Put` returns a
+  ref; `Get` with that ref + the same workspace returns the secret; `Get` with
+  a different workspace returns `ErrNotFound`; `Delete` is idempotent.
+- [ ] **Step 2: Run — expect FAIL** (`keyvault` undefined).
+- [ ] **Step 3: Implement `Vault`, `Ref`, `ErrNotFound`, and `memoryVault`.**
+  The ref embeds/incorporates the workspace so cross-workspace resolution
+  fails by construction; the fake stores `(workspace, ref) → secret`.
+- [ ] **Step 4: Run — expect PASS.**
+- [ ] **Step 5: Commit** — `feat(keyvault): Vault seam + in-memory fake`.
+
+## Task 2: local (config-backed) provider + `/readyz` + compose wiring
+
+**Files:** create `local.go`; modify compose Option and `/readyz`; add config.
+
+- [ ] **Step 1: Write the failing unit test** for the local provider —
+  AES-GCM round-trip; decrypt fails cleanly (surfaced error, no plaintext
+  leak) under a wrong root key; workspace-ref isolation.
+- [ ] **Step 2: Run — expect FAIL** (`local` undefined).
+- [ ] **Step 3: Implement the local provider** — `New(Config)` reads the
+  32-byte root key from config (base64 env / file path — the build decides,
+  loud on a missing/short key at boot, never a silent zero key); encrypts
+  secrets with AES-GCM; a health method for `/readyz`. Where the ciphertext
+  lives (a `vault_secret` operational table vs a file) is decided here; if a
+  table, it is operational infra (no `workspace_id` GUC on the vault's own
+  storage — the workspace is inside the ref/AAD), added to the tenant-table
+  fitness allowlist exactly as River's tables were (decisions/0021).
+- [ ] **Step 4: Add the compose `Option` + `/readyz` probe** — `WithKeyvault`;
+  the probe names "keyvault" when unhealthy (503).
+- [ ] **Step 5: Run — expect PASS.**
+- [ ] **Step 6: Commit** — `feat(keyvault): config-backed local provider, readyz, compose Option`.
+
+## Task 3: the additive migration
+
+**Files:** create `migrations/core/00NN_connector_credential_ref.{up,down}.sql`.
+
+- [ ] **Step 1:** `ADD COLUMN credential_ref text NULL` on
+  `connector_connection` (up); drop it (down). `auth bytea` untouched.
+- [ ] **Step 2:** `make migrate` applies it; the schema fitness test
+  (`backend/migrations/schema_integration_test.go`) stays green.
+- [ ] **Step 3: Commit** — `feat(migrate): connector_connection.credential_ref column`.
+
+## Task 4: capture stores/resolves via the vault + backfill
+
+**Files:** modify the capture connection store and the connect/sync compose
+adapter (e.g. `compose/imapconnect.go`).
+
+- [ ] **Step 1: Write the failing integration test** — Authenticate stores the
+  credential bundle in the vault and persists the `credential_ref` (not the
+  bytes) on the row; Sync resolves the ref and authenticates; an existing
+  `auth bytea` row is backfilled into the vault and gains a ref.
+- [ ] **Step 2: Run — expect FAIL.**
+- [ ] **Step 3: Implement** — on Authenticate, `Put` the credential bundle,
+  record `credential_ref` (inside the connection's storekit write tx: row +
+  audit + outbox; the vault Put is around it, put-then-commit like blobstore).
+  On read/Sync, resolve `credential_ref` via the vault to `Auth`. A one-shot
+  backfill (idempotent: skip rows that already carry a ref) migrates existing
+  `auth bytea` rows. Reads prefer `credential_ref`; the `auth` column is read
+  only as the backfill source, and is dropped in a later migration.
+- [ ] **Step 4: Run — expect PASS.**
+- [ ] **Step 5: Commit** — `feat(capture): resolve connector credentials through the keyvault`.
+
+## Task 5: cmd wiring + docs
+
+**Files:** modify `cmd/api/main.go`, `cmd/worker/main.go`, `.env.template`,
+`docs/reference/configuration.md`.
+
+- [ ] **Step 1:** Build the `Vault` from config in both roles and pass
+  `WithKeyvault`. A capture-capable role with no keyvault configured is a
+  **boot error**, not a nil-deref at Authenticate time.
+- [ ] **Step 2:** Add the keyvault vars to `.env.template` and the flag/env
+  table in `configuration.md`.
+- [ ] **Step 3:** `PATH="$(go env GOPATH)/bin:$PATH" make check` +
+  `make test-integration` green.
+- [ ] **Step 4: Commit** — `feat(cmd): wire keyvault from config; document its env`.
+
+---
+
+## Self-review checklist (run before opening the PR)
+
+- **Not speculative:** the seam ships with a real secret migrated onto it
+  (`connector_connection.auth` → `credential_ref`). ✅
+- **Scope:** seam + connector-auth migration only; EP05 §B reshape, rotation,
+  and OAuth-key migration deliberately out. ✅ (grep the diff for `oauth`,
+  connection-list endpoints — no changes.)
+- **Secret hygiene:** plaintext and root key never logged, never in an error
+  message, never in a model-bound payload; composes with `SecretStripper`. ✅
+- **Tenant isolation:** every call carries `workspaceID`; a ref cannot resolve
+  under the wrong workspace (integration-proven); the row's RLS is unchanged. ✅
+- **Additive migration:** `credential_ref` added; `auth bytea` dropped only in
+  a later migration; backfill idempotent. ✅
+- **Write-shape intact:** connection row + audit + outbox one storekit tx;
+  vault Put around it, put-then-commit. ✅
+- **`connector` port unchanged:** capture resolves the ref; the port still
+  receives `Auth`. ✅
+- **Ports-vs-platform:** interface in `platform/keyvault`, not `shared/ports/`
+  (decisions/0023 rationale); spec touchpoint flagged. ✅
+- **Gates:** license headers; vault storage table (if any) on the
+  tenant-table fitness allowlist; no `time.Sleep`; file-length < 500;
+  `make check` + `make test-integration` green, zero `--- SKIP`. ✅
+
+## Open questions to confirm during implementation (not blockers)
+
+1. **OAuth signing keys** (`oauth.private_key/public_key`) — this PR or a
+   follow-on? `DECISION (founder)` — recommendation: follow-on (different
+   lifecycle/consumers), fold onto the same seam next.
+2. **Ciphertext storage** — a `vault_secret` operational table vs a file/dir.
+   Recommendation: an operational table (rides the existing pool/migrator,
+   allowlisted like River's tables), so the vault has no filesystem
+   dependency and honors the same backup/restore as the DB.
+3. **Root-key source and rotation** — base64 env var vs file path; rotation is
+   out of scope here but the ref/AAD scheme should not foreclose it. Confirm
+   the config surface with the founder.
+4. **Spec touchpoint** — verify `contract/interfaces.md` §1 does not freeze a
+   different vault/credential interface once the sibling spec tree is
+   reachable (not reachable from this checkout — worklist §3).


### PR DESCRIPTION
The third and final §1c platform-parity seam, after River (#35) and blobstore (#36). Introduces `internal/platform/keyvault` — secret-material storage behind an opaque, workspace-scoped `credential_ref` — **and** migrates the first real secret (`connector_connection.auth` bytea → a vault ref) in one reviewable PR, so the seam ships used, not speculative. Decision of record: `decisions/0023-keyvault-seam.md`.

## What lands

- **`platform/keyvault`** — the `Vault` seam (peer of `events`/`jobs`, owns no domain): a `Ref` type (scheme + root-key version + workspace + unguessable random token), an in-memory fake, and an **AES-256-GCM local provider** storing ciphertext in the operational `vault_secret` table.
- **Isolation is cryptographic + structural.** The ref carries its workspace (a ref presented under the wrong workspace is rejected before any read → `ErrNotFound`, existence-hiding) and the GCM **AAD is the whole ref**, so a stolen or swapped ref cannot be opened under another workspace. `vault_secret` carries **no `workspace_id`** and no RLS — the same operational-infra posture as River's tables; it trips none of the RLS/ownership fitness gates.
- **Secret hygiene.** Plaintext and the root key never reach a log, error, `%w` chain, or panic: decrypt failures collapse to an opaque `errDecrypt`, refs are logged token-stripped, and the length/base64 errors name neither key nor input.
- **The migration (additive only).** `0062` adds `connector_connection.credential_ref` and creates `vault_secret`; the `auth` column **stays** through the transition (dropped in a later migration after backfill). `capture.Connect` seals the credential (put-then-commit) and records the ref with `auth` cleared; `SyncOnce` resolves the ref (falling back to the legacy column for a not-yet-backfilled row); `BackfillCredentials` migrates existing rows idempotently, per-workspace, continuing past a failing tenant. **The `connector` port is unchanged** — capture resolves the ref and still hands the connector its `Auth`.
- **Wiring.** `compose.WithKeyvault` feeds a `/readyz` keyvault probe; `cmd/api` wires it; `cmd/worker` runs the boot backfill. Root key is env-only (`MARGINCE_KEYVAULT_ROOT_KEY`, base64 32-byte); a malformed key is a boot error, unset boots without the vault (the transient IMAP pull needs none; persisting paths refuse loudly).

## Scope

Seam + connector-auth migration only, per the ADR. Deliberately deferred to their own arc (now unblocked): the EP05 §B per-user-connection reshape + connection-management contract/UI, credential **rotation** (the ref/version scheme doesn't foreclose it), and the `oauth` signing-keypair fold-on.

## Verification

- `make check` green; `make test-integration` **green with zero skips** — 4 new integration tests on real Postgres with the local provider: seal-not-on-row, sync-resolves-from-vault, cross-workspace isolation + wrong-key-no-leak, idempotent backfill. Unit tests cover the memory fake contract and the AES-GCM/config layer.
- **security-redteam**: clean of exploitable findings (a net security improvement — plaintext bytea → AES-256-GCM at rest).
- **craft-reviewer**: findings addressed (honest orphan-ciphertext comments, precise nil-vault contract, removed unreachable version-skew branch, fleet-tolerant backfill, gitignored stray build binaries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added secure, workspace-scoped storage for connector credentials.
  * Added optional secret-vault configuration through `MARGINCE_KEYVAULT_ROOT_KEY`.
  * Added `/readyz` monitoring for the secret vault when configured.
  * Added automatic migration of existing connector credentials during worker startup.

* **Documentation**
  * Documented secret-vault setup, key requirements, readiness behavior, and credential migration.
  * Added configuration guidance and implementation status updates.

* **Bug Fixes**
  * Improved credential isolation and prevented sensitive values from appearing in stored connection records or error output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->