### PR TITLE
feat: org hierarchy roll-up read (poc-1 delta port, arc 1b)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -78,6 +78,13 @@ Merged so far:
   row-scope, activities dispatching through the link-walk); no new
   table or migration — the projection runs entirely off `audit_log`.
   First arc of the poc-1 feature-delta port.
+- **Org hierarchy roll-up read** — `GET /organizations/{id}/hierarchy-
+  rollup`: a tree or self account roll-up (weighted pipeline,
+  current-quarter closed-won, 30-day activity) with RBAC-honest
+  restricted-node disclosure and base-currency FX conversion (422 on a
+  missing rate, never a silent rate=1). Compose-homed — the read spans
+  organization, deal, stage, activity, and fx_rate — with no new table.
+  Arc 1b of the poc-1 feature-delta port.
 
 ## Pick up here
 

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -709,6 +709,36 @@ paths:
         '404': { $ref: '#/components/responses/NotFound' }
         '422': { $ref: '#/components/responses/ValidationError' }
 
+  /organizations/{id}/hierarchy-rollup:
+    parameters:
+      - $ref: '#/components/parameters/Id'
+    get:
+      tags: [Organizations]
+      operationId: getOrganizationHierarchyRollup
+      summary: Roll up an organization's account tree — weighted pipeline, current-quarter closed-won, 30-day activity count.
+      description: |
+        `roll-up(node) = self(node) + Σ roll-up(readable child)` over the parent_org_id tree,
+        walked with one bounded indexed recursive query. A child the caller cannot read
+        contributes nothing and is named in `restricted_excluded` — never silently summed.
+        All money converts to the workspace base currency; a missing stored FX rate fails
+        the whole read with `422 fx_rate_unavailable` rather than substituting a rate of 1.
+        Totals are server-computed and reconcile exactly to their parts — never client-summed.
+      parameters:
+        - name: scope
+          in: query
+          schema: { type: string, enum: [tree, self], default: tree }
+          description: 'tree (default): aggregate the whole subtree. self: the root''s own figures alone.'
+      responses:
+        '200':
+          description: The organization's hierarchy roll-up.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/OrganizationHierarchyRollup' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '422': { $ref: '#/components/responses/ValidationError' }
+
   /organizations/{id}/partner:
     parameters:
       - $ref: '#/components/parameters/Id'
@@ -4968,6 +4998,31 @@ components:
       properties:
         data: { type: array, items: { $ref: '#/components/schemas/Organization' } }
         page: { $ref: '#/components/schemas/PageInfo' }
+
+    OrganizationHierarchyRollup:
+      type: object
+      description: |
+        The account-tree roll-up over organization.parent_org_id. A server read only,
+        never client-summed. Money is base-currency converted — never a raw
+        cross-currency sum.
+      required: [root_id, scope, weighted_pipeline, closed_won, activity_count_30d, aggregated_account_count, restricted_excluded, computed_at]
+      properties:
+        root_id: { type: string, format: uuid }
+        scope: { type: string, enum: [tree, self] }
+        weighted_pipeline: { $ref: '#/components/schemas/Money' }
+        closed_won: { $ref: '#/components/schemas/Money' }
+        activity_count_30d: { type: integer }
+        aggregated_account_count: { type: integer, description: Count of accounts (nodes) included in the roll-up. }
+        restricted_excluded:
+          type: array
+          description: Nodes excluded because the viewer cannot read them — disclosed, never a silent drop.
+          items:
+            type: object
+            required: [id, display_name]
+            properties:
+              id: { type: string, format: uuid }
+              display_name: { type: string }
+        computed_at: { type: string, format: date-time }
 
     # ---- Relationship ----
     Relationship:

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -723,6 +723,9 @@ paths:
         All money converts to the workspace base currency; a missing stored FX rate fails
         the whole read with `422 fx_rate_unavailable` rather than substituting a rate of 1.
         Totals are server-computed and reconcile exactly to their parts — never client-summed.
+        Requires read on organizations, deals, and activities; figures aggregate every deal
+        and activity of each readable organization — per-record row visibility within a
+        readable account is deliberately not consulted, so account totals stay whole.
       parameters:
         - name: scope
           in: query

--- a/backend/internal/compose/integration/orgrollup_http_integration_test.go
+++ b/backend/internal/compose/integration/orgrollup_http_integration_test.go
@@ -1,0 +1,262 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// HTTP-level coverage for GET /organizations/{id}/hierarchy-rollup: the
+// handler (compose.orgRollupHandlers.GetOrganizationHierarchyRollup) and
+// its wire mapping (orgRollupToWire) that orgrollup_integration_test.go
+// never drives — that suite calls compose.OrgHierarchyRollup directly, so
+// the query-default/validation branches and the JSON shape (Money
+// envelopes, the restricted_excluded null-vs-empty distinction) only
+// exist at the transport. This suite rides the same real-handler-stack
+// e2e harness as e2e_integration_test.go (TLS httptest server, session
+// cookie, workspace header) and reuses fieldhistory_http_integration_test.go's
+// fieldHistoryProblem/assertFieldHistoryValidation422 for the shared
+// httperr.Validation 422 shape, since the scope-enum rejection rides the
+// exact same wire contract as every other bad query input.
+//
+// The tree/self fixture creates its org tree and its one open deal
+// through the real HTTP write paths (organizations accept parent_org_id
+// on create), never raw SQL — unlike orgrollup_integration_test.go, this
+// suite has no need for controlled win-probability stages or frozen FX
+// rates, so the workspace-seeded default pipeline is enough.
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// orgRollupMoneyWire mirrors the contract's Money schema.
+type orgRollupMoneyWire struct {
+	AmountMinor int64  `json:"amount_minor"`
+	Currency    string `json:"currency"`
+}
+
+// orgRollupRestrictedWire mirrors one restricted_excluded item's wire shape.
+type orgRollupRestrictedWire struct {
+	ID          string `json:"id"`
+	DisplayName string `json:"display_name"`
+}
+
+// orgRollupResponseWire mirrors the contract's OrganizationHierarchyRollup
+// field by field, decoded loosely so a wire-shape regression fails the
+// assertions below instead of silently zeroing. RestrictedExcluded is
+// decoded as a plain slice on purpose: encoding/json leaves it nil for a
+// JSON `null` and non-nil (possibly zero-length) for a JSON `[]`, which is
+// exactly the null-vs-empty distinction the happy path must assert on.
+type orgRollupResponseWire struct {
+	RootID                 string                    `json:"root_id"`
+	Scope                  string                    `json:"scope"`
+	WeightedPipeline       orgRollupMoneyWire        `json:"weighted_pipeline"`
+	ClosedWon              orgRollupMoneyWire        `json:"closed_won"`
+	ActivityCount30d       int                       `json:"activity_count_30d"`
+	AggregatedAccountCount int                       `json:"aggregated_account_count"`
+	RestrictedExcluded     []orgRollupRestrictedWire `json:"restricted_excluded"`
+	ComputedAt             string                    `json:"computed_at"`
+}
+
+// orgRollupFxProblem is the RFC 7807 body the handler's FXRateUnavailableError
+// mapping produces: fx_rate_unavailable carries the offending currency and
+// the as-of day, not a per-field validation error list.
+type orgRollupFxProblem struct {
+	Code    string `json:"code"`
+	Details struct {
+		Currency string `json:"currency"`
+		AsOf     string `json:"as_of"`
+	} `json:"details"`
+}
+
+// createOrgRollupOrg creates one organization through the real write path,
+// optionally hanging it under parentID (empty = a root).
+func createOrgRollupOrg(t *testing.T, e *env, name, parentID string) string {
+	t.Helper()
+	body := anyMap{"display_name": name, "source": "ui"}
+	if parentID != "" {
+		body["parent_org_id"] = parentID
+	}
+	var org anyMap
+	if status := e.call(t, "POST", "/v1/organizations", body, nil, &org); status != http.StatusCreated {
+		t.Fatalf("create organization %q = %d %v", name, status, org)
+	}
+	return org["id"].(string)
+}
+
+// orgRollupOpenStage resolves the workspace-seeded default pipeline's
+// open stage and its live win probability, so the happy-path assertion
+// below can compute the expected weighted-pipeline figure exactly rather
+// than asserting a mere non-zero value.
+func orgRollupOpenStage(t *testing.T, e *env) (pipelineID, stageID string, winProbability int) {
+	t.Helper()
+	var pipelines struct {
+		Data []struct {
+			ID     string `json:"id"`
+			Stages []struct {
+				ID             string `json:"id"`
+				Semantic       string `json:"semantic"`
+				WinProbability int    `json:"win_probability"`
+			} `json:"stages"`
+		} `json:"data"`
+	}
+	if status := e.call(t, "GET", "/v1/pipelines", nil, nil, &pipelines); status != http.StatusOK {
+		t.Fatalf("list pipelines = %d", status)
+	}
+	if len(pipelines.Data) != 1 {
+		t.Fatalf("want exactly one seeded pipeline: %+v", pipelines.Data)
+	}
+	pipelineID = pipelines.Data[0].ID
+	for _, s := range pipelines.Data[0].Stages {
+		if s.Semantic == "open" {
+			return pipelineID, s.ID, s.WinProbability
+		}
+	}
+	t.Fatalf("seeded pipeline carries no open stage: %+v", pipelines.Data[0])
+	return "", "", 0
+}
+
+// createOrgRollupOpenDeal opens one deal on org through the real write
+// path; amountMinor is the caller's choice so the rollup's weighted-value
+// rounding stays exact arithmetic in the caller's test, not a guess.
+func createOrgRollupOpenDeal(t *testing.T, e *env, pipelineID, stageID, orgID string, amountMinor int64, currency string) {
+	t.Helper()
+	var deal anyMap
+	status := e.call(t, "POST", "/v1/deals", anyMap{
+		"name":            "Rollup HTTP Deal",
+		"amount_minor":    amountMinor,
+		"currency":        currency,
+		"pipeline_id":     pipelineID,
+		"stage_id":        stageID,
+		"organization_id": orgID,
+		"source":          "ui",
+	}, nil, &deal)
+	if status != http.StatusCreated {
+		t.Fatalf("create deal = %d %v", status, deal)
+	}
+}
+
+// orgRollupHTTPDealAmountMinor is 10,000.00 in minor units: chosen so
+// amount × win_probability / 100 divides exactly for ANY 0-100
+// win_probability the seeded default pipeline happens to carry, so the
+// happy-path assertion is exact arithmetic rather than a guess at the
+// seed's stage configuration.
+const orgRollupHTTPDealAmountMinor = 1_000_000
+
+// assertOrgRollupTreeHappyPath drives the tree-scope GET on root and checks
+// the full wire envelope: the weighted-pipeline figure is exact arithmetic
+// over the seeded deal and the seeded stage's live win probability, both
+// money objects always carry the workspace base currency, and
+// restricted_excluded decodes as a real (non-nil) empty array.
+func assertOrgRollupTreeHappyPath(t *testing.T, e *env, root string, winProbability int) {
+	t.Helper()
+	var rollup orgRollupResponseWire
+	status := e.call(t, "GET", "/v1/organizations/"+root+"/hierarchy-rollup", nil, nil, &rollup)
+	if status != http.StatusOK {
+		t.Fatalf("rollup status = %d, want 200: %+v", status, rollup)
+	}
+	if rollup.RootID != root || rollup.Scope != "tree" {
+		t.Errorf("envelope = {root %q scope %q}, want {%s tree}", rollup.RootID, rollup.Scope, root)
+	}
+	wantWeighted := orgRollupHTTPDealAmountMinor / 100 * int64(winProbability)
+	if rollup.WeightedPipeline.AmountMinor != wantWeighted || rollup.WeightedPipeline.Currency != "EUR" {
+		t.Errorf("weighted_pipeline = %+v, want {%d EUR} (the workspace base currency, matching the deal's own EUR)",
+			rollup.WeightedPipeline, wantWeighted)
+	}
+	if rollup.ClosedWon.AmountMinor != 0 || rollup.ClosedWon.Currency != "EUR" {
+		t.Errorf("closed_won = %+v, want {0 EUR} — a real money object, never a raw zero-value with no currency", rollup.ClosedWon)
+	}
+	if rollup.AggregatedAccountCount != 2 {
+		t.Errorf("aggregated_account_count = %d, want 2 (root + child)", rollup.AggregatedAccountCount)
+	}
+	if rollup.RestrictedExcluded == nil {
+		t.Error("restricted_excluded decoded nil — the wire sent JSON null, want a real empty array")
+	}
+	if len(rollup.RestrictedExcluded) != 0 {
+		t.Errorf("restricted_excluded = %+v, want empty (nothing is caller-unreadable here)", rollup.RestrictedExcluded)
+	}
+	if rollup.ComputedAt == "" {
+		t.Error("computed_at missing from the envelope")
+	}
+}
+
+// assertOrgRollupSelfScope drives scope=self on child and checks it
+// reports the child alone — the parent's deal never rolls down.
+func assertOrgRollupSelfScope(t *testing.T, e *env, child string) {
+	t.Helper()
+	var rollup orgRollupResponseWire
+	status := e.call(t, "GET", "/v1/organizations/"+child+"/hierarchy-rollup?scope=self", nil, nil, &rollup)
+	if status != http.StatusOK {
+		t.Fatalf("self rollup status = %d, want 200: %+v", status, rollup)
+	}
+	if rollup.RootID != child || rollup.Scope != "self" {
+		t.Errorf("envelope = {root %q scope %q}, want {%s self}", rollup.RootID, rollup.Scope, child)
+	}
+	if rollup.AggregatedAccountCount != 1 {
+		t.Errorf("self aggregated_account_count = %d, want 1 (the child alone, its parent's deal never rolls down)", rollup.AggregatedAccountCount)
+	}
+	if rollup.WeightedPipeline.AmountMinor != 0 {
+		t.Errorf("self weighted_pipeline = %d, want 0 (the child carries no deal of its own)", rollup.WeightedPipeline.AmountMinor)
+	}
+}
+
+// assertOrgRollupFXUnavailable seeds a fresh root with an open USD deal and
+// no stored USD->EUR rate, and checks the wire shape of the resulting
+// fx_rate_unavailable refusal.
+func assertOrgRollupFXUnavailable(t *testing.T, e *env, pipelineID, stageID string) {
+	t.Helper()
+	fxRoot := createOrgRollupOrg(t, e, "Rollup HTTP FX Root", "")
+	createOrgRollupOpenDeal(t, e, pipelineID, stageID, fxRoot, 10_000, "USD") // no USD->EUR rate on file
+
+	var problem orgRollupFxProblem
+	status := e.call(t, "GET", "/v1/organizations/"+fxRoot+"/hierarchy-rollup", nil, nil, &problem)
+	if status != http.StatusUnprocessableEntity {
+		t.Fatalf("fx-unavailable status = %d, want 422: %+v", status, problem)
+	}
+	if problem.Code != "fx_rate_unavailable" {
+		t.Errorf("code = %q, want fx_rate_unavailable", problem.Code)
+	}
+	if problem.Details.Currency != "USD" {
+		t.Errorf("details.currency = %q, want USD", problem.Details.Currency)
+	}
+	if problem.Details.AsOf == "" {
+		t.Error("details.as_of missing from the fx_rate_unavailable problem")
+	}
+}
+
+func TestOrgRollupHTTP(t *testing.T) {
+	e := setup(t)
+	e.bootstrapWorkspace(t)
+	pipelineID, stageID, winProbability := orgRollupOpenStage(t, e)
+
+	root := createOrgRollupOrg(t, e, "Rollup HTTP Root", "")
+	child := createOrgRollupOrg(t, e, "Rollup HTTP Child", root)
+	createOrgRollupOpenDeal(t, e, pipelineID, stageID, root, orgRollupHTTPDealAmountMinor, "EUR")
+
+	t.Run("200 tree happy path", func(t *testing.T) {
+		assertOrgRollupTreeHappyPath(t, e, root, winProbability)
+	})
+
+	t.Run("200 self scope", func(t *testing.T) {
+		assertOrgRollupSelfScope(t, e, child)
+	})
+
+	t.Run("422 invalid scope", func(t *testing.T) {
+		var problem fieldHistoryProblem
+		status := e.call(t, "GET", "/v1/organizations/"+root+"/hierarchy-rollup?scope=bogus", nil, nil, &problem)
+		assertFieldHistoryValidation422(t, status, problem, "scope", "invalid_enum")
+	})
+
+	t.Run("422 fx_rate_unavailable", func(t *testing.T) {
+		assertOrgRollupFXUnavailable(t, e, pipelineID, stageID)
+	})
+
+	t.Run("404 nonexistent organization", func(t *testing.T) {
+		status := e.call(t, "GET", "/v1/organizations/"+ids.NewV7().String()+"/hierarchy-rollup", nil, nil, nil)
+		if status != http.StatusNotFound {
+			t.Fatalf("nonexistent org rollup status = %d, want 404", status)
+		}
+	})
+}

--- a/backend/internal/compose/integration/orgrollup_integration_test.go
+++ b/backend/internal/compose/integration/orgrollup_integration_test.go
@@ -1,0 +1,346 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The org hierarchy roll-up (GET /organizations/{id}/hierarchy-rollup,
+// RD-T04): roll-up(node) = self(node) + Σ roll-up(readable child) over
+// the parent_org_id tree. A child the caller cannot read contributes
+// nothing and is disclosed by {id, display_name} only; all money
+// converts to the workspace base currency, and a missing stored FX rate
+// fails the whole read rather than inventing a rate.
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// rollupStages is one dedicated pipeline with a known 40% open stage and
+// a won stage, so every weighted expectation below is arithmetic the
+// test controls rather than a value inherited from the workspace seed.
+type rollupStages struct {
+	pipeline, open, won ids.UUID
+}
+
+const rollupOpenWinProbability = 40
+
+func seedRollupStages(t *testing.T, e *Env) rollupStages {
+	t.Helper()
+	st := rollupStages{pipeline: ids.NewV7(), open: ids.NewV7(), won: ids.NewV7()}
+	e.WsExec(t, `INSERT INTO pipeline (id, workspace_id, name) VALUES ($1, $2, 'Rollup Pipeline')`,
+		st.pipeline, e.WS)
+	e.WsExec(t, `INSERT INTO stage (id, workspace_id, pipeline_id, name, position, semantic, win_probability)
+		VALUES ($1, $2, $3, 'Qualified', 1, 'open', $4)`,
+		st.open, e.WS, st.pipeline, rollupOpenWinProbability)
+	e.WsExec(t, `INSERT INTO stage (id, workspace_id, pipeline_id, name, position, semantic, win_probability)
+		VALUES ($1, $2, $3, 'Won', 2, 'won', 100)`,
+		st.won, e.WS, st.pipeline)
+	return st
+}
+
+// seedRollupOrg inserts one hierarchy node directly: the rollup is a
+// read, so the audit/outbox write shape the people store would add is
+// noise here, and parent_org_id wiring has no store-level entry point.
+func seedRollupOrg(t *testing.T, e *Env, name string, owner, parent *ids.UUID) ids.UUID {
+	t.Helper()
+	id := ids.NewV7()
+	e.WsExec(t, `INSERT INTO organization (id, workspace_id, display_name, owner_id, parent_org_id, source, captured_by)
+		VALUES ($1, $2, $3, $4, $5, 'manual', 'human:test')`,
+		id, e.WS, name, owner, parent)
+	return id
+}
+
+// seedRollupOpenDeal attaches one open deal; a nil amount/currency pair
+// seeds the honest half-empty deal the weighted sum must count as 0.
+func seedRollupOpenDeal(t *testing.T, e *Env, st rollupStages, org ids.UUID, amountMinor *int64, currency *string) {
+	t.Helper()
+	e.WsExec(t, `INSERT INTO deal (id, workspace_id, name, amount_minor, currency, pipeline_id, stage_id, organization_id, status, source, captured_by)
+		VALUES ($1, $2, 'Open Deal', $3, $4, $5, $6, $7, 'open', 'manual', 'human:test')`,
+		ids.NewV7(), e.WS, amountMinor, currency, st.pipeline, st.open, org)
+}
+
+// seedRollupWonDeal closes a deal with the frozen FX rate the
+// deal_closed_fx CHECK demands — the rate the quarter sum must reuse.
+func seedRollupWonDeal(t *testing.T, e *Env, st rollupStages, org ids.UUID,
+	amountMinor int64, currency, fxRateToBase string, closedAt time.Time,
+) {
+	t.Helper()
+	e.WsExec(t, `INSERT INTO deal (id, workspace_id, name, amount_minor, currency, fx_rate_to_base, pipeline_id, stage_id, organization_id, status, closed_at, source, captured_by)
+		VALUES ($1, $2, 'Won Deal', $3, $4, $5, $6, $7, $8, 'won', $9, 'manual', 'human:test')`,
+		ids.NewV7(), e.WS, amountMinor, currency, fxRateToBase, st.pipeline, st.won, org, closedAt)
+}
+
+func seedRollupFxRate(t *testing.T, e *Env, fromCurrency, rate string, day time.Time) {
+	t.Helper()
+	e.WsExec(t, `INSERT INTO fx_rate (workspace_id, from_currency, to_currency, rate, rate_date)
+		VALUES ($1, $2, 'EUR', $3, $4)`,
+		e.WS, fromCurrency, rate, day)
+}
+
+func seedRollupOrgActivity(t *testing.T, e *Env, org ids.UUID, occurredAt time.Time) {
+	t.Helper()
+	activityID := ids.NewV7()
+	e.WsExec(t, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, source, captured_by)
+		VALUES ($1, $2, 'note', 'rollup touch', $3, 'manual', 'human:test')`,
+		activityID, e.WS, occurredAt)
+	e.WsExec(t, `INSERT INTO activity_link (workspace_id, activity_id, entity_type, organization_id)
+		VALUES ($1, $2, 'organization', $3)`,
+		e.WS, activityID, org)
+}
+
+// rollupOrgReadPerms is the minimal caller the rollup admits: read on
+// organization at the given row-scope tier, nothing else.
+func rollupOrgReadPerms(scope principal.RowScope) principal.Permissions {
+	return principal.Permissions{
+		RoleKeys: []string{"rep"},
+		Objects:  map[string]principal.ObjectGrant{"organization": {Read: true}},
+		RowScope: scope,
+	}
+}
+
+func int64Ptr(v int64) *int64 { return &v }
+
+// TestOrgRollupReconcilesTreeToSelves is the reconciliation invariant:
+// the tree total equals the sum of every included node's scope=self
+// figures, an empty node contributes a real 0 (and still counts in
+// aggregated_account_count), a NULL-amount deal contributes 0, and a
+// non-base-currency open deal converts at the stored as-of rate.
+func TestOrgRollupReconcilesTreeToSelves(t *testing.T) {
+	e := Setup(t)
+	st := seedRollupStages(t, e)
+	root := seedRollupOrg(t, e, "Root Co", nil, nil)
+	childA := seedRollupOrg(t, e, "Child A", nil, &root)
+	childB := seedRollupOrg(t, e, "Child B (empty)", nil, &root)
+	grandchild := seedRollupOrg(t, e, "Grandchild", nil, &childA)
+	now := time.Now().UTC()
+
+	seedRollupOpenDeal(t, e, st, root, int64Ptr(100_000), strPtr("EUR"))
+	seedRollupOpenDeal(t, e, st, root, nil, nil) // NULL amount: a real 0, never an error
+	seedRollupOpenDeal(t, e, st, childA, int64Ptr(50_000), strPtr("EUR"))
+	seedRollupOpenDeal(t, e, st, childA, int64Ptr(10_000), strPtr("USD")) // 0.5 → 5_000 base
+	seedRollupOpenDeal(t, e, st, grandchild, int64Ptr(20_000), strPtr("EUR"))
+	seedRollupFxRate(t, e, "USD", "0.5", now.AddDate(0, 0, -2))
+	seedRollupWonDeal(t, e, st, root, 30_000, "EUR", "1.0", now)
+	seedRollupOrgActivity(t, e, root, now.Add(-24*time.Hour))
+	seedRollupOrgActivity(t, e, grandchild, now.Add(-24*time.Hour))
+	seedRollupOrgActivity(t, e, childA, now.Add(-40*24*time.Hour)) // outside the 30d window
+
+	tree, err := compose.OrgHierarchyRollup(e.Admin(), e.Pool, root, "tree")
+	if err != nil {
+		t.Fatalf("tree rollup: %v", err)
+	}
+	// Per-deal weighted at 40%: 40_000 (root) + 20_000 + 2_000 (childA) + 8_000 (grandchild).
+	if tree.WeightedPipelineMinor != 70_000 {
+		t.Errorf("tree weighted = %d, want 70000", tree.WeightedPipelineMinor)
+	}
+	if tree.ClosedWonMinor != 30_000 {
+		t.Errorf("tree closed-won = %d, want 30000", tree.ClosedWonMinor)
+	}
+	if tree.ActivityCount30d != 2 {
+		t.Errorf("tree activity count = %d, want 2 (the 40-day-old touch is out of window)", tree.ActivityCount30d)
+	}
+	if tree.AggregatedAccountCount != 4 {
+		t.Errorf("aggregated account count = %d, want 4 (the empty sibling still counts)", tree.AggregatedAccountCount)
+	}
+	if tree.BaseCurrency != "EUR" {
+		t.Errorf("base currency = %q, want EUR", tree.BaseCurrency)
+	}
+	if tree.RestrictedExcluded == nil || len(tree.RestrictedExcluded) != 0 {
+		t.Errorf("restricted = %v, want non-nil empty", tree.RestrictedExcluded)
+	}
+	if tree.RootID != root || tree.Scope != "tree" || tree.ComputedAt.IsZero() {
+		t.Errorf("result envelope = {%v %q %v}, want root id, tree scope, real computed_at",
+			tree.RootID, tree.Scope, tree.ComputedAt)
+	}
+
+	var sumWeighted, sumWon int64
+	var sumActivity, sumNodes int
+	for _, node := range []ids.UUID{root, childA, childB, grandchild} {
+		self, err := compose.OrgHierarchyRollup(e.Admin(), e.Pool, node, "self")
+		if err != nil {
+			t.Fatalf("self rollup of %v: %v", node, err)
+		}
+		if self.AggregatedAccountCount != 1 {
+			t.Errorf("self count of %v = %d, want 1", node, self.AggregatedAccountCount)
+		}
+		if node == childB && (self.WeightedPipelineMinor != 0 || self.ClosedWonMinor != 0 || self.ActivityCount30d != 0) {
+			t.Errorf("empty sibling self = %+v, want real zeros", self)
+		}
+		sumWeighted += self.WeightedPipelineMinor
+		sumWon += self.ClosedWonMinor
+		sumActivity += self.ActivityCount30d
+		sumNodes += self.AggregatedAccountCount
+	}
+	if sumWeighted != tree.WeightedPipelineMinor || sumWon != tree.ClosedWonMinor ||
+		sumActivity != tree.ActivityCount30d || sumNodes != tree.AggregatedAccountCount {
+		t.Errorf("Σ(self) = {%d %d %d %d}, want the tree totals {%d %d %d %d}",
+			sumWeighted, sumWon, sumActivity, sumNodes,
+			tree.WeightedPipelineMinor, tree.ClosedWonMinor, tree.ActivityCount30d, tree.AggregatedAccountCount)
+	}
+}
+
+// TestOrgRollupRestrictedNodeDisclosedAndGrantRestores: an unreadable
+// child is excluded from every total and disclosed by identity only, its
+// subtree is never visited (the ownerless — hence readable — grandchild
+// is neither summed nor separately disclosed), and a live record_grant
+// flips the child and its readable subtree back in on the next call.
+func TestOrgRollupRestrictedNodeDisclosedAndGrantRestores(t *testing.T) {
+	e := Setup(t)
+	st := seedRollupStages(t, e)
+	root := seedRollupOrg(t, e, "Root Co", &e.Rep1, nil)
+	child := seedRollupOrg(t, e, "Restricted Child", &e.Rep3, &root)
+	grandchild := seedRollupOrg(t, e, "Ownerless Grandchild", nil, &child)
+	for _, org := range []ids.UUID{root, child, grandchild} {
+		seedRollupOpenDeal(t, e, st, org, int64Ptr(10_000), strPtr("EUR"))
+	}
+
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, rollupOrgReadPerms(principal.RowScopeOwn))
+	pre, err := compose.OrgHierarchyRollup(rep, e.Pool, root, "tree")
+	if err != nil {
+		t.Fatalf("pre-grant rollup: %v", err)
+	}
+	if pre.WeightedPipelineMinor != 4_000 {
+		t.Errorf("pre-grant weighted = %d, want 4000 (root only)", pre.WeightedPipelineMinor)
+	}
+	if pre.AggregatedAccountCount != 1 {
+		t.Errorf("pre-grant account count = %d, want 1", pre.AggregatedAccountCount)
+	}
+	if len(pre.RestrictedExcluded) != 1 ||
+		pre.RestrictedExcluded[0].ID != child || pre.RestrictedExcluded[0].DisplayName != "Restricted Child" {
+		t.Fatalf("restricted = %+v, want exactly the child disclosed by id+name (grandchild never visited)",
+			pre.RestrictedExcluded)
+	}
+
+	e.WsExec(t, `INSERT INTO record_grant (workspace_id, record_type, record_id, subject_type, subject_id, access, granted_by)
+		VALUES ($1, 'organization', $2, 'user', $3, 'read', $3)`,
+		e.WS, child, e.Rep1)
+
+	post, err := compose.OrgHierarchyRollup(rep, e.Pool, root, "tree")
+	if err != nil {
+		t.Fatalf("post-grant rollup: %v", err)
+	}
+	if post.WeightedPipelineMinor != 12_000 {
+		t.Errorf("post-grant weighted = %d, want 12000 (child + readable grandchild restored)", post.WeightedPipelineMinor)
+	}
+	if post.AggregatedAccountCount != 3 {
+		t.Errorf("post-grant account count = %d, want 3", post.AggregatedAccountCount)
+	}
+	if len(post.RestrictedExcluded) != 0 {
+		t.Errorf("post-grant restricted = %+v, want empty", post.RestrictedExcluded)
+	}
+}
+
+// TestOrgRollupFXRateUnavailableFailsWholeRead: an open deal in a
+// currency with no stored rate to base fails the WHOLE read with the
+// typed error — never a partial sum, never a silent rate of 1.
+func TestOrgRollupFXRateUnavailableFailsWholeRead(t *testing.T) {
+	e := Setup(t)
+	st := seedRollupStages(t, e)
+	root := seedRollupOrg(t, e, "Root Co", nil, nil)
+	seedRollupOpenDeal(t, e, st, root, int64Ptr(100_000), strPtr("EUR"))
+	seedRollupOpenDeal(t, e, st, root, int64Ptr(10_000), strPtr("USD")) // no USD→EUR rate seeded
+
+	_, err := compose.OrgHierarchyRollup(e.Admin(), e.Pool, root, "tree")
+	var fxErr *compose.FXRateUnavailableError
+	if !errors.As(err, &fxErr) {
+		t.Fatalf("err = %v, want a typed FX-rate-unavailable failure", err)
+	}
+	if fxErr.Currency != "USD" || fxErr.AsOf.IsZero() {
+		t.Errorf("fx error = %+v, want the missing currency and a real as-of instant", fxErr)
+	}
+}
+
+// TestOrgRollupClosedWonQuarterWindow: closed-won counts only won deals
+// whose closed_at falls in the current workspace-timezone quarter
+// [start, end), converted at each deal's FROZEN rate — no fx_rate row
+// exists here, so a live-rate lookup would fail the read instead.
+func TestOrgRollupClosedWonQuarterWindow(t *testing.T) {
+	e := Setup(t)
+	st := seedRollupStages(t, e)
+	root := seedRollupOrg(t, e, "Root Co", nil, nil)
+	now := time.Now().UTC()
+	seedRollupWonDeal(t, e, st, root, 10_000, "USD", "0.5", now)
+	// 100 days back is outside any calendar quarter containing now (a
+	// quarter spans at most 92 days), whatever today's date is.
+	seedRollupWonDeal(t, e, st, root, 99_999, "USD", "1.0", now.AddDate(0, 0, -100))
+
+	res, err := compose.OrgHierarchyRollup(e.Admin(), e.Pool, root, "tree")
+	if err != nil {
+		t.Fatalf("rollup: %v", err)
+	}
+	if res.ClosedWonMinor != 5_000 {
+		t.Errorf("closed-won = %d, want 5000 (in-quarter deal at its frozen 0.5 rate only)", res.ClosedWonMinor)
+	}
+	if res.WeightedPipelineMinor != 0 {
+		t.Errorf("weighted = %d, want 0 (won deals never re-enter the pipeline sum)", res.WeightedPipelineMinor)
+	}
+}
+
+// TestOrgRollupRootGates: the threefold gate at the root — a missing
+// object-read grant answers 403 before any row is touched; a nonexistent
+// root and an out-of-scope root both answer 404, indistinguishable by
+// design; an out-of-vocabulary scope is refused, not defaulted.
+func TestOrgRollupRootGates(t *testing.T) {
+	e := Setup(t)
+	foreign := seedRollupOrg(t, e, "Foreign Org", &e.Rep3, nil)
+
+	// Nonexistent root, unbounded admin: the tree walk itself must
+	// answer not-found (the visibility gate has nothing to probe for an
+	// unbounded caller).
+	if _, err := compose.OrgHierarchyRollup(e.Admin(), e.Pool, ids.NewV7(), "tree"); !errors.Is(err, apperrors.ErrNotFound) {
+		t.Errorf("nonexistent root: err = %v, want not found", err)
+	}
+
+	// Rep1 sits in Team1; the root's owner Rep3 does not — out of scope
+	// reads as not-there, never as an empty rollup.
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, rollupOrgReadPerms(principal.RowScopeTeam))
+	if _, err := compose.OrgHierarchyRollup(rep, e.Pool, foreign, "tree"); !errors.Is(err, apperrors.ErrNotFound) {
+		t.Errorf("out-of-scope root: err = %v, want not found", err)
+	}
+
+	// RepPerms grants person/deal/pipeline but not organization: 403.
+	noPerm := e.As(e.Rep1, []ids.UUID{e.Team1}, RepPerms)
+	if _, err := compose.OrgHierarchyRollup(noPerm, e.Pool, foreign, "tree"); !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Errorf("no organization:read: err = %v, want permission denied", err)
+	}
+
+	// A scope outside {tree, self} is a refused input, not a default.
+	if _, err := compose.OrgHierarchyRollup(e.Admin(), e.Pool, foreign, "subtree"); err == nil {
+		t.Error("invalid scope accepted — must be refused")
+	}
+}
+
+// TestOrgRollupSelfScopeSkipsPruning: scope=self returns the root's own
+// figures without consulting child readability at all — unreadable
+// children neither block the read nor appear as restricted.
+func TestOrgRollupSelfScopeSkipsPruning(t *testing.T) {
+	e := Setup(t)
+	st := seedRollupStages(t, e)
+	root := seedRollupOrg(t, e, "Root Co", &e.Rep1, nil)
+	child := seedRollupOrg(t, e, "Hidden Child", &e.Rep3, &root)
+	seedRollupOpenDeal(t, e, st, root, int64Ptr(10_000), strPtr("EUR"))
+	seedRollupOpenDeal(t, e, st, child, int64Ptr(50_000), strPtr("EUR"))
+
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, rollupOrgReadPerms(principal.RowScopeOwn))
+	res, err := compose.OrgHierarchyRollup(rep, e.Pool, root, "self")
+	if err != nil {
+		t.Fatalf("self rollup: %v", err)
+	}
+	if res.WeightedPipelineMinor != 4_000 {
+		t.Errorf("self weighted = %d, want 4000 (root's own deal only)", res.WeightedPipelineMinor)
+	}
+	if res.AggregatedAccountCount != 1 || res.Scope != "self" {
+		t.Errorf("self envelope = {count %d, scope %q}, want {1, self}", res.AggregatedAccountCount, res.Scope)
+	}
+	if len(res.RestrictedExcluded) != 0 {
+		t.Errorf("self restricted = %+v, want empty — self scope never prunes", res.RestrictedExcluded)
+	}
+}

--- a/backend/internal/compose/integration/orgrollup_integration_test.go
+++ b/backend/internal/compose/integration/orgrollup_integration_test.go
@@ -312,6 +312,13 @@ func TestOrgRollupRootGates(t *testing.T) {
 		t.Errorf("no organization:read: err = %v, want permission denied", err)
 	}
 
+	// Permission refusal precedes input validation: a caller without
+	// organization:read gets 403 even for a scope outside the vocabulary
+	// — the bogus scope must never be judged before the grant is.
+	if _, err := compose.OrgHierarchyRollup(noPerm, e.Pool, foreign, "subtree"); !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Errorf("no organization:read + bogus scope: err = %v, want permission denied", err)
+	}
+
 	// A scope outside {tree, self} is a refused input, not a default.
 	if _, err := compose.OrgHierarchyRollup(e.Admin(), e.Pool, foreign, "subtree"); err == nil {
 		t.Error("invalid scope accepted — must be refused")

--- a/backend/internal/compose/integration/orgrollup_integration_test.go
+++ b/backend/internal/compose/integration/orgrollup_integration_test.go
@@ -97,11 +97,17 @@ func seedRollupOrgActivity(t *testing.T, e *Env, org ids.UUID, occurredAt time.T
 }
 
 // rollupOrgReadPerms is the minimal caller the rollup admits: read on
-// organization at the given row-scope tier, nothing else.
+// organization, deal, AND activity at the given row-scope tier — the
+// rollup surfaces deal money and activity counts, so it demands the same
+// object grants the forecast and activity reports do.
 func rollupOrgReadPerms(scope principal.RowScope) principal.Permissions {
 	return principal.Permissions{
 		RoleKeys: []string{"rep"},
-		Objects:  map[string]principal.ObjectGrant{"organization": {Read: true}},
+		Objects: map[string]principal.ObjectGrant{
+			"organization": {Read: true},
+			"deal":         {Read: true},
+			"activity":     {Read: true},
+		},
 		RowScope: scope,
 	}
 }
@@ -132,6 +138,7 @@ func TestOrgRollupReconcilesTreeToSelves(t *testing.T) {
 	seedRollupOrgActivity(t, e, root, now.Add(-24*time.Hour))
 	seedRollupOrgActivity(t, e, grandchild, now.Add(-24*time.Hour))
 	seedRollupOrgActivity(t, e, childA, now.Add(-40*24*time.Hour)) // outside the 30d window
+	seedRollupOrgActivity(t, e, root, now.Add(24*time.Hour))       // future-dated: never counts
 
 	tree, err := compose.OrgHierarchyRollup(e.Admin(), e.Pool, root, "tree")
 	if err != nil {
@@ -145,7 +152,7 @@ func TestOrgRollupReconcilesTreeToSelves(t *testing.T) {
 		t.Errorf("tree closed-won = %d, want 30000", tree.ClosedWonMinor)
 	}
 	if tree.ActivityCount30d != 2 {
-		t.Errorf("tree activity count = %d, want 2 (the 40-day-old touch is out of window)", tree.ActivityCount30d)
+		t.Errorf("tree activity count = %d, want 2 (the 40-day-old touch and the future-dated one are both out of window)", tree.ActivityCount30d)
 	}
 	if tree.AggregatedAccountCount != 4 {
 		t.Errorf("aggregated account count = %d, want 4 (the empty sibling still counts)", tree.AggregatedAccountCount)
@@ -238,6 +245,27 @@ func TestOrgRollupRestrictedNodeDisclosedAndGrantRestores(t *testing.T) {
 	}
 }
 
+// TestOrgRollupWeightedPipelineSurvivesStageArchival: an open deal whose
+// stage is archived still contributes its weighted value — archiving a
+// stage reshapes the pipeline's vocabulary, it never silently zeroes the
+// money already sitting in that stage (matching the forecast report's
+// stage join, which carries no archived_at filter either).
+func TestOrgRollupWeightedPipelineSurvivesStageArchival(t *testing.T) {
+	e := Setup(t)
+	st := seedRollupStages(t, e)
+	root := seedRollupOrg(t, e, "Root Co", nil, nil)
+	seedRollupOpenDeal(t, e, st, root, int64Ptr(10_000), strPtr("EUR"))
+	e.WsExec(t, `UPDATE stage SET archived_at = now() WHERE id = $1`, st.open)
+
+	res, err := compose.OrgHierarchyRollup(e.Admin(), e.Pool, root, "tree")
+	if err != nil {
+		t.Fatalf("rollup: %v", err)
+	}
+	if res.WeightedPipelineMinor != 4_000 {
+		t.Errorf("weighted = %d, want 4000 (the archived stage's live deal still counts)", res.WeightedPipelineMinor)
+	}
+}
+
 // TestOrgRollupFXRateUnavailableFailsWholeRead: an open deal in a
 // currency with no stored rate to base fails the WHOLE read with the
 // typed error — never a partial sum, never a silent rate of 1.
@@ -310,6 +338,31 @@ func TestOrgRollupRootGates(t *testing.T) {
 	noPerm := e.As(e.Rep1, []ids.UUID{e.Team1}, RepPerms)
 	if _, err := compose.OrgHierarchyRollup(noPerm, e.Pool, foreign, "tree"); !errors.Is(err, apperrors.ErrPermissionDenied) {
 		t.Errorf("no organization:read: err = %v, want permission denied", err)
+	}
+
+	// The rollup surfaces deal money and activity counts, so
+	// organization:read alone is not enough — a caller missing deal:read
+	// (or activity:read) is refused before any row is touched.
+	for missing, perms := range map[string]principal.Permissions{
+		"deal": {
+			RoleKeys: []string{"rep"},
+			Objects: map[string]principal.ObjectGrant{
+				"organization": {Read: true}, "activity": {Read: true},
+			},
+			RowScope: principal.RowScopeTeam,
+		},
+		"activity": {
+			RoleKeys: []string{"rep"},
+			Objects: map[string]principal.ObjectGrant{
+				"organization": {Read: true}, "deal": {Read: true},
+			},
+			RowScope: principal.RowScopeTeam,
+		},
+	} {
+		caller := e.As(e.Rep1, []ids.UUID{e.Team1}, perms)
+		if _, err := compose.OrgHierarchyRollup(caller, e.Pool, foreign, "tree"); !errors.Is(err, apperrors.ErrPermissionDenied) {
+			t.Errorf("missing %s:read: err = %v, want permission denied", missing, err)
+		}
 	}
 
 	// Permission refusal precedes input validation: a caller without

--- a/backend/internal/compose/integration/orgrollup_integration_test.go
+++ b/backend/internal/compose/integration/orgrollup_integration_test.go
@@ -114,6 +114,16 @@ func rollupOrgReadPerms(scope principal.RowScope) principal.Permissions {
 
 func int64Ptr(v int64) *int64 { return &v }
 
+// fixedClock pins OrgHierarchyRollup's injected clock to instant, so a
+// test that seeds rows relative to a captured "now" reads at that exact
+// same instant rather than racing a fresh time.Now() call inside the
+// read — the gap between the two is normally sub-millisecond, but a
+// quarter or calendar-day window boundary crossed in that gap would
+// otherwise flake the assertion.
+func fixedClock(instant time.Time) func() time.Time {
+	return func() time.Time { return instant }
+}
+
 // TestOrgRollupReconcilesTreeToSelves is the reconciliation invariant:
 // the tree total equals the sum of every included node's scope=self
 // figures, an empty node contributes a real 0 (and still counts in
@@ -140,7 +150,7 @@ func TestOrgRollupReconcilesTreeToSelves(t *testing.T) {
 	seedRollupOrgActivity(t, e, childA, now.Add(-40*24*time.Hour)) // outside the 30d window
 	seedRollupOrgActivity(t, e, root, now.Add(24*time.Hour))       // future-dated: never counts
 
-	tree, err := compose.OrgHierarchyRollup(e.Admin(), e.Pool, root, "tree")
+	tree, err := compose.OrgHierarchyRollup(e.Admin(), e.Pool, root, "tree", fixedClock(now))
 	if err != nil {
 		t.Fatalf("tree rollup: %v", err)
 	}
@@ -171,7 +181,7 @@ func TestOrgRollupReconcilesTreeToSelves(t *testing.T) {
 	var sumWeighted, sumWon int64
 	var sumActivity, sumNodes int
 	for _, node := range []ids.UUID{root, childA, childB, grandchild} {
-		self, err := compose.OrgHierarchyRollup(e.Admin(), e.Pool, node, "self")
+		self, err := compose.OrgHierarchyRollup(e.Admin(), e.Pool, node, "self", fixedClock(now))
 		if err != nil {
 			t.Fatalf("self rollup of %v: %v", node, err)
 		}
@@ -210,7 +220,7 @@ func TestOrgRollupRestrictedNodeDisclosedAndGrantRestores(t *testing.T) {
 	}
 
 	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, rollupOrgReadPerms(principal.RowScopeOwn))
-	pre, err := compose.OrgHierarchyRollup(rep, e.Pool, root, "tree")
+	pre, err := compose.OrgHierarchyRollup(rep, e.Pool, root, "tree", time.Now)
 	if err != nil {
 		t.Fatalf("pre-grant rollup: %v", err)
 	}
@@ -230,7 +240,7 @@ func TestOrgRollupRestrictedNodeDisclosedAndGrantRestores(t *testing.T) {
 		VALUES ($1, 'organization', $2, 'user', $3, 'read', $3)`,
 		e.WS, child, e.Rep1)
 
-	post, err := compose.OrgHierarchyRollup(rep, e.Pool, root, "tree")
+	post, err := compose.OrgHierarchyRollup(rep, e.Pool, root, "tree", time.Now)
 	if err != nil {
 		t.Fatalf("post-grant rollup: %v", err)
 	}
@@ -257,7 +267,7 @@ func TestOrgRollupWeightedPipelineSurvivesStageArchival(t *testing.T) {
 	seedRollupOpenDeal(t, e, st, root, int64Ptr(10_000), strPtr("EUR"))
 	e.WsExec(t, `UPDATE stage SET archived_at = now() WHERE id = $1`, st.open)
 
-	res, err := compose.OrgHierarchyRollup(e.Admin(), e.Pool, root, "tree")
+	res, err := compose.OrgHierarchyRollup(e.Admin(), e.Pool, root, "tree", time.Now)
 	if err != nil {
 		t.Fatalf("rollup: %v", err)
 	}
@@ -276,7 +286,7 @@ func TestOrgRollupFXRateUnavailableFailsWholeRead(t *testing.T) {
 	seedRollupOpenDeal(t, e, st, root, int64Ptr(100_000), strPtr("EUR"))
 	seedRollupOpenDeal(t, e, st, root, int64Ptr(10_000), strPtr("USD")) // no USD→EUR rate seeded
 
-	_, err := compose.OrgHierarchyRollup(e.Admin(), e.Pool, root, "tree")
+	_, err := compose.OrgHierarchyRollup(e.Admin(), e.Pool, root, "tree", time.Now)
 	var fxErr *compose.FXRateUnavailableError
 	if !errors.As(err, &fxErr) {
 		t.Fatalf("err = %v, want a typed FX-rate-unavailable failure", err)
@@ -290,17 +300,25 @@ func TestOrgRollupFXRateUnavailableFailsWholeRead(t *testing.T) {
 // whose closed_at falls in the current workspace-timezone quarter
 // [start, end), converted at each deal's FROZEN rate — no fx_rate row
 // exists here, so a live-rate lookup would fail the read instead.
+//
+// asOf is pinned to a fixed mid-quarter instant (not time.Now()): the
+// workspace's reporting timezone defaults to UTC, so an asOf resolved a
+// hair after the seeded "in-quarter" deal's closed_at could otherwise
+// cross a real quarter boundary right as the suite runs near one, and
+// the -100-day deal would then land in a different (but still
+// out-of-window) quarter — pinning removes the wall-clock dependency
+// entirely rather than merely making it a rare flake.
 func TestOrgRollupClosedWonQuarterWindow(t *testing.T) {
 	e := Setup(t)
 	st := seedRollupStages(t, e)
 	root := seedRollupOrg(t, e, "Root Co", nil, nil)
-	now := time.Now().UTC()
-	seedRollupWonDeal(t, e, st, root, 10_000, "USD", "0.5", now)
-	// 100 days back is outside any calendar quarter containing now (a
-	// quarter spans at most 92 days), whatever today's date is.
-	seedRollupWonDeal(t, e, st, root, 99_999, "USD", "1.0", now.AddDate(0, 0, -100))
+	asOf := time.Date(2026, time.May, 15, 12, 0, 0, 0, time.UTC)
+	seedRollupWonDeal(t, e, st, root, 10_000, "USD", "0.5", asOf)
+	// 100 days back is outside any calendar quarter containing asOf (a
+	// quarter spans at most 92 days), whatever asOf itself resolves to.
+	seedRollupWonDeal(t, e, st, root, 99_999, "USD", "1.0", asOf.AddDate(0, 0, -100))
 
-	res, err := compose.OrgHierarchyRollup(e.Admin(), e.Pool, root, "tree")
+	res, err := compose.OrgHierarchyRollup(e.Admin(), e.Pool, root, "tree", fixedClock(asOf))
 	if err != nil {
 		t.Fatalf("rollup: %v", err)
 	}
@@ -323,20 +341,20 @@ func TestOrgRollupRootGates(t *testing.T) {
 	// Nonexistent root, unbounded admin: the tree walk itself must
 	// answer not-found (the visibility gate has nothing to probe for an
 	// unbounded caller).
-	if _, err := compose.OrgHierarchyRollup(e.Admin(), e.Pool, ids.NewV7(), "tree"); !errors.Is(err, apperrors.ErrNotFound) {
+	if _, err := compose.OrgHierarchyRollup(e.Admin(), e.Pool, ids.NewV7(), "tree", time.Now); !errors.Is(err, apperrors.ErrNotFound) {
 		t.Errorf("nonexistent root: err = %v, want not found", err)
 	}
 
 	// Rep1 sits in Team1; the root's owner Rep3 does not — out of scope
 	// reads as not-there, never as an empty rollup.
 	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, rollupOrgReadPerms(principal.RowScopeTeam))
-	if _, err := compose.OrgHierarchyRollup(rep, e.Pool, foreign, "tree"); !errors.Is(err, apperrors.ErrNotFound) {
+	if _, err := compose.OrgHierarchyRollup(rep, e.Pool, foreign, "tree", time.Now); !errors.Is(err, apperrors.ErrNotFound) {
 		t.Errorf("out-of-scope root: err = %v, want not found", err)
 	}
 
 	// RepPerms grants person/deal/pipeline but not organization: 403.
 	noPerm := e.As(e.Rep1, []ids.UUID{e.Team1}, RepPerms)
-	if _, err := compose.OrgHierarchyRollup(noPerm, e.Pool, foreign, "tree"); !errors.Is(err, apperrors.ErrPermissionDenied) {
+	if _, err := compose.OrgHierarchyRollup(noPerm, e.Pool, foreign, "tree", time.Now); !errors.Is(err, apperrors.ErrPermissionDenied) {
 		t.Errorf("no organization:read: err = %v, want permission denied", err)
 	}
 
@@ -360,7 +378,7 @@ func TestOrgRollupRootGates(t *testing.T) {
 		},
 	} {
 		caller := e.As(e.Rep1, []ids.UUID{e.Team1}, perms)
-		if _, err := compose.OrgHierarchyRollup(caller, e.Pool, foreign, "tree"); !errors.Is(err, apperrors.ErrPermissionDenied) {
+		if _, err := compose.OrgHierarchyRollup(caller, e.Pool, foreign, "tree", time.Now); !errors.Is(err, apperrors.ErrPermissionDenied) {
 			t.Errorf("missing %s:read: err = %v, want permission denied", missing, err)
 		}
 	}
@@ -368,12 +386,12 @@ func TestOrgRollupRootGates(t *testing.T) {
 	// Permission refusal precedes input validation: a caller without
 	// organization:read gets 403 even for a scope outside the vocabulary
 	// — the bogus scope must never be judged before the grant is.
-	if _, err := compose.OrgHierarchyRollup(noPerm, e.Pool, foreign, "subtree"); !errors.Is(err, apperrors.ErrPermissionDenied) {
+	if _, err := compose.OrgHierarchyRollup(noPerm, e.Pool, foreign, "subtree", time.Now); !errors.Is(err, apperrors.ErrPermissionDenied) {
 		t.Errorf("no organization:read + bogus scope: err = %v, want permission denied", err)
 	}
 
 	// A scope outside {tree, self} is a refused input, not a default.
-	if _, err := compose.OrgHierarchyRollup(e.Admin(), e.Pool, foreign, "subtree"); err == nil {
+	if _, err := compose.OrgHierarchyRollup(e.Admin(), e.Pool, foreign, "subtree", time.Now); err == nil {
 		t.Error("invalid scope accepted — must be refused")
 	}
 }
@@ -390,7 +408,7 @@ func TestOrgRollupSelfScopeSkipsPruning(t *testing.T) {
 	seedRollupOpenDeal(t, e, st, child, int64Ptr(50_000), strPtr("EUR"))
 
 	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, rollupOrgReadPerms(principal.RowScopeOwn))
-	res, err := compose.OrgHierarchyRollup(rep, e.Pool, root, "self")
+	res, err := compose.OrgHierarchyRollup(rep, e.Pool, root, "self", time.Now)
 	if err != nil {
 		t.Fatalf("self rollup: %v", err)
 	}

--- a/backend/internal/compose/orgrollup.go
+++ b/backend/internal/compose/orgrollup.go
@@ -105,6 +105,8 @@ func weightedValue(baseMinor int64, winProbability int) int64 {
 // an inherently fractional stored FX rate, so unlike weightedValue this
 // runs in float64 — math.Round already implements round-half-away-from-
 // zero, which is the one rounding rule this system uses everywhere.
+// amount_minor magnitudes sit far below float64's ~2^53 exact-integer
+// ceiling, so the multiply-then-round never loses precision here.
 func convertToBase(amountMinor int64, rate float64) int64 {
 	return int64(roundHalfAwayFromZero(float64(amountMinor) * rate))
 }

--- a/backend/internal/compose/orgrollup.go
+++ b/backend/internal/compose/orgrollup.go
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// Pure mechanics behind GET /organizations/{id}/hierarchy-rollup
+// (RD-T04): the RBAC-aware BFS prune over the parent→children org
+// graph, calendar-quarter bounds in the workspace timezone, and the
+// two rounding rules (win-weighted value, FX base conversion) the
+// rollup's totals are built from. No DB and no HTTP live here —
+// Task 3 wires this against the org tree store and Task 4 wires the
+// HTTP handler.
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// orgTreeNode is one row of the flattened organization hierarchy:
+// enough to walk parent→children and to name a node the caller can't
+// see into.
+type orgTreeNode struct {
+	id          ids.UUID
+	parentID    *ids.UUID
+	displayName string
+}
+
+// restrictedNode is a hierarchy node the caller cannot read, disclosed
+// by identity and name only — never by its figures, and never by its
+// subtree's.
+type restrictedNode struct {
+	ID          ids.UUID
+	DisplayName string
+}
+
+// pruneUnreadable walks the org tree breadth-first from rootID over the
+// parent→children adjacency nodes encodes, splitting it into the
+// RBAC-readable set the rollup sums and the restricted set it discloses
+// without summing. The root itself is never disclosed as restricted —
+// an unreadable root is a 404 at the HTTP layer (rootReadable=false
+// signals that), not a member of any list.
+//
+// A node the caller can't read is the deepest point a branch is
+// visited: its children are never inspected, so a grandchild behind a
+// restricted node is neither included nor separately disclosed. Because
+// readable is consulted fresh for every node, a live grant that flips a
+// node back to readable pulls its whole readable subtree back in on the
+// very next call — pruneUnreadable holds no memory of a prior result.
+func pruneUnreadable(rootID ids.UUID, nodes []orgTreeNode, readable func(ids.UUID) bool) (included []ids.UUID, restricted []restrictedNode, rootReadable bool) {
+	included = []ids.UUID{}
+	restricted = []restrictedNode{}
+	if !readable(rootID) {
+		return included, restricted, false
+	}
+
+	childrenByParent := make(map[ids.UUID][]orgTreeNode, len(nodes))
+	for _, n := range nodes {
+		if n.parentID == nil {
+			continue
+		}
+		childrenByParent[*n.parentID] = append(childrenByParent[*n.parentID], n)
+	}
+
+	included = append(included, rootID)
+	queue := []ids.UUID{rootID}
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+		for _, child := range childrenByParent[current] {
+			if !readable(child.id) {
+				restricted = append(restricted, restrictedNode{ID: child.id, DisplayName: child.displayName})
+				continue
+			}
+			included = append(included, child.id)
+			queue = append(queue, child.id)
+		}
+	}
+	return included, restricted, true
+}
+
+// currentQuarterBounds returns the calendar quarter [start, end) that
+// now falls in, evaluated in loc — the workspace timezone, not UTC, so
+// a moment shortly after midnight UTC can still belong to the prior
+// quarter (and year) for a workspace west of Greenwich.
+func currentQuarterBounds(now time.Time, loc *time.Location) (start, end time.Time) {
+	local := now.In(loc)
+	quarterStartMonth := time.Month(((int(local.Month())-1)/3)*3 + 1)
+	start = time.Date(local.Year(), quarterStartMonth, 1, 0, 0, 0, 0, loc)
+	end = start.AddDate(0, 3, 0)
+	return start, end
+}
+
+// weightedValue rounds baseMinor × winProbability/100 half away from
+// zero, done in integer arithmetic (not float64) because baseMinor is
+// already a minor-unit money amount and winProbability a whole-number
+// percentage — the division is exact enough that float rounding error
+// has no business being introduced.
+func weightedValue(baseMinor int64, winProbability int) int64 {
+	return divRoundHalfAwayFromZero(baseMinor*int64(winProbability), 100)
+}
+
+// convertToBase rounds amountMinor × rate half away from zero. rate is
+// an inherently fractional stored FX rate, so unlike weightedValue this
+// runs in float64 — math.Round already implements round-half-away-from-
+// zero, which is the one rounding rule this system uses everywhere.
+func convertToBase(amountMinor int64, rate float64) int64 {
+	return int64(roundHalfAwayFromZero(float64(amountMinor) * rate))
+}
+
+// roundHalfAwayFromZero rounds v to the nearest integer, ties away from
+// zero — Go's math.Round is exactly this rule, spelled out locally so
+// the two money-rounding call sites read the same intent without an
+// extra import.
+func roundHalfAwayFromZero(v float64) float64 {
+	if v < 0 {
+		return -roundHalfAwayFromZero(-v)
+	}
+	whole := float64(int64(v))
+	if v-whole >= 0.5 {
+		return whole + 1
+	}
+	return whole
+}
+
+// divRoundHalfAwayFromZero divides two integers, rounding the quotient
+// half away from zero. denominator is always the positive divisor
+// (100, for both money-rounding call sites here).
+func divRoundHalfAwayFromZero(numerator, denominator int64) int64 {
+	quotient := numerator / denominator
+	remainder := numerator % denominator
+	if remainder == 0 {
+		return quotient
+	}
+	if absInt64(remainder)*2 >= denominator {
+		if numerator < 0 {
+			quotient--
+		} else {
+			quotient++
+		}
+	}
+	return quotient
+}
+
+func absInt64(v int64) int64 {
+	if v < 0 {
+		return -v
+	}
+	return v
+}
+
+// fxRateUnavailableError reports that the rollup needed a stored FX
+// rate for currency as of a point in time and none was on file — the
+// system never invents a rate=1 fallback, per formulas §11.
+type fxRateUnavailableError struct {
+	Currency string
+	AsOf     time.Time
+}
+
+func (e fxRateUnavailableError) Error() string {
+	return fmt.Sprintf("no stored FX rate for %s as of %s; record today's rate for %s before retrying the rollup",
+		e.Currency, e.AsOf.Format(time.DateOnly), e.Currency)
+}

--- a/backend/internal/compose/orgrollup.go
+++ b/backend/internal/compose/orgrollup.go
@@ -13,7 +13,10 @@ package compose
 
 import (
 	"fmt"
+	"math/big"
 	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
@@ -101,29 +104,50 @@ func weightedValue(baseMinor int64, winProbability int) int64 {
 	return divRoundHalfAwayFromZero(baseMinor*int64(winProbability), 100)
 }
 
-// convertToBase rounds amountMinor × rate half away from zero. rate is
-// an inherently fractional stored FX rate, so unlike weightedValue this
-// runs in float64 — math.Round already implements round-half-away-from-
-// zero, which is the one rounding rule this system uses everywhere.
-// amount_minor magnitudes sit far below float64's ~2^53 exact-integer
-// ceiling, so the multiply-then-round never loses precision here.
-func convertToBase(amountMinor int64, rate float64) int64 {
-	return int64(roundHalfAwayFromZero(float64(amountMinor) * rate))
+// convertToBase rounds amountMinor × rate half away from zero, in EXACT
+// decimal arithmetic over the rate's stored numeric digits (Int × 10^Exp)
+// — never float64, so the open-pipeline conversion carries the same
+// exactness Postgres ROUND over numeric gives closed-won, and an amount
+// past float64's 2^53 exact-integer ceiling cannot lose a minor unit. A
+// non-finite rate or an overflowing result refuses loudly: both would
+// otherwise put a silently wrong number in a money total.
+func convertToBase(amountMinor int64, rate pgtype.Numeric) (int64, error) {
+	if !rate.Valid || rate.NaN || rate.InfinityModifier != pgtype.Finite {
+		return 0, fmt.Errorf("stored FX rate is not a finite number; correct the fx_rate row before retrying the rollup")
+	}
+	product := new(big.Int).Mul(big.NewInt(amountMinor), rate.Int)
+	if rate.Exp >= 0 {
+		product.Mul(product, pow10(int64(rate.Exp)))
+	} else {
+		product = bigDivRoundHalfAwayFromZero(product, pow10(int64(-rate.Exp)))
+	}
+	if !product.IsInt64() {
+		return 0, fmt.Errorf("converted amount exceeds the representable money range in the base currency")
+	}
+	return product.Int64(), nil
 }
 
-// roundHalfAwayFromZero rounds v to the nearest integer, ties away from
-// zero — Go's math.Round is exactly this rule, spelled out locally so
-// the two money-rounding call sites read the same intent without an
-// extra import.
-func roundHalfAwayFromZero(v float64) float64 {
-	if v < 0 {
-		return -roundHalfAwayFromZero(-v)
+// bigDivRoundHalfAwayFromZero is divRoundHalfAwayFromZero over big
+// integers: numerator/denominator with the quotient rounded half away
+// from zero. denominator is always a positive power of ten here.
+func bigDivRoundHalfAwayFromZero(numerator, denominator *big.Int) *big.Int {
+	negative := numerator.Sign() < 0
+	quotient, remainder := new(big.Int).QuoRem(numerator, denominator, new(big.Int))
+	remainder.Abs(remainder)
+	remainder.Lsh(remainder, 1) // 2·|remainder| ≥ denominator ⇔ the dropped fraction is ≥ half
+	if remainder.Cmp(denominator) < 0 {
+		return quotient
 	}
-	whole := float64(int64(v))
-	if v-whole >= 0.5 {
-		return whole + 1
+	if negative {
+		return quotient.Sub(quotient, big.NewInt(1))
 	}
-	return whole
+	return quotient.Add(quotient, big.NewInt(1))
+}
+
+// pow10 returns 10^exp as a big integer; exp is a numeric's scale
+// magnitude, always small and never negative here.
+func pow10(exp int64) *big.Int {
+	return new(big.Int).Exp(big.NewInt(10), big.NewInt(exp), nil)
 }
 
 // divRoundHalfAwayFromZero divides two integers, rounding the quotient

--- a/backend/internal/compose/orgrollup.go
+++ b/backend/internal/compose/orgrollup.go
@@ -96,12 +96,20 @@ func currentQuarterBounds(now time.Time, loc *time.Location) (start, end time.Ti
 }
 
 // weightedValue rounds baseMinor × winProbability/100 half away from
-// zero, done in integer arithmetic (not float64) because baseMinor is
-// already a minor-unit money amount and winProbability a whole-number
-// percentage — the division is exact enough that float rounding error
-// has no business being introduced.
-func weightedValue(baseMinor int64, winProbability int) int64 {
-	return divRoundHalfAwayFromZero(baseMinor*int64(winProbability), 100)
+// zero, in EXACT big.Int arithmetic — never a native int64 multiply.
+// amount_minor is contract-unbounded, so baseMinor×winProbability can
+// exceed int64 before the division ever runs; a silent wraparound there
+// would put a wrong number in a money total. The overflow check mirrors
+// convertToBase's: a result outside int64's range refuses loudly rather
+// than truncating.
+func weightedValue(baseMinor int64, winProbability int) (int64, error) {
+	product := new(big.Int).Mul(big.NewInt(baseMinor), big.NewInt(int64(winProbability)))
+	rounded := bigDivRoundHalfAwayFromZero(product, big.NewInt(100))
+	if !rounded.IsInt64() {
+		return 0, fmt.Errorf("weighted pipeline value for a %d-minor-unit amount at %d%% exceeds the representable money range; correct the deal amount before retrying the rollup",
+			baseMinor, winProbability)
+	}
+	return rounded.Int64(), nil
 }
 
 // convertToBase rounds amountMinor × rate half away from zero, in EXACT
@@ -148,32 +156,6 @@ func bigDivRoundHalfAwayFromZero(numerator, denominator *big.Int) *big.Int {
 // magnitude, always small and never negative here.
 func pow10(exp int64) *big.Int {
 	return new(big.Int).Exp(big.NewInt(10), big.NewInt(exp), nil)
-}
-
-// divRoundHalfAwayFromZero divides two integers, rounding the quotient
-// half away from zero. denominator is always the positive divisor
-// (100, for both money-rounding call sites here).
-func divRoundHalfAwayFromZero(numerator, denominator int64) int64 {
-	quotient := numerator / denominator
-	remainder := numerator % denominator
-	if remainder == 0 {
-		return quotient
-	}
-	if absInt64(remainder)*2 >= denominator {
-		if numerator < 0 {
-			quotient--
-		} else {
-			quotient++
-		}
-	}
-	return quotient
-}
-
-func absInt64(v int64) int64 {
-	if v < 0 {
-		return -v
-	}
-	return v
 }
 
 // FXRateUnavailableError reports that the rollup needed a stored FX

--- a/backend/internal/compose/orgrollup.go
+++ b/backend/internal/compose/orgrollup.go
@@ -7,9 +7,9 @@ package compose
 // (RD-T04): the RBAC-aware BFS prune over the parent→children org
 // graph, calendar-quarter bounds in the workspace timezone, and the
 // two rounding rules (win-weighted value, FX base conversion) the
-// rollup's totals are built from. No DB and no HTTP live here —
-// Task 3 wires this against the org tree store and Task 4 wires the
-// HTTP handler.
+// rollup's totals are built from. No DB and no HTTP live here — the
+// gated tree walk and measures are in orgrollupread.go, the HTTP
+// handler arrives with the transport slice.
 
 import (
 	"fmt"
@@ -150,15 +150,17 @@ func absInt64(v int64) int64 {
 	return v
 }
 
-// fxRateUnavailableError reports that the rollup needed a stored FX
+// FXRateUnavailableError reports that the rollup needed a stored FX
 // rate for currency as of a point in time and none was on file — the
-// system never invents a rate=1 fallback, per formulas §11.
-type fxRateUnavailableError struct {
+// system never invents a rate=1 fallback, per formulas §11. Exported so
+// the HTTP layer and the integration suites match it via errors.As and
+// map it to 422 fx_rate_unavailable.
+type FXRateUnavailableError struct {
 	Currency string
 	AsOf     time.Time
 }
 
-func (e fxRateUnavailableError) Error() string {
+func (e FXRateUnavailableError) Error() string {
 	return fmt.Sprintf("no stored FX rate for %s as of %s; record today's rate for %s before retrying the rollup",
 		e.Currency, e.AsOf.Format(time.DateOnly), e.Currency)
 }

--- a/backend/internal/compose/orgrollup_handlers.go
+++ b/backend/internal/compose/orgrollup_handlers.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The HTTP transport for GET /organizations/{id}/hierarchy-rollup
+// (RD-T04): binds the query default, calls the gated aggregate read in
+// orgrollupread.go, and maps its result (and its one typed failure) onto
+// the generated wire shape. No aggregation logic lives here — this file
+// is pure edge + shape translation.
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/platform/httperr"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// orgRollupHandlers shadows the generated GetOrganizationHierarchyRollup
+// stub over the gated read.
+type orgRollupHandlers struct {
+	pool *pgxpool.Pool
+}
+
+// GetOrganizationHierarchyRollup implements (GET
+// /organizations/{id}/hierarchy-rollup). An absent scope defaults to the
+// contract's "tree"; anything else reaches OrgHierarchyRollup verbatim,
+// which is the read's own refusal point for an out-of-vocabulary value.
+func (h orgRollupHandlers) GetOrganizationHierarchyRollup(w http.ResponseWriter, r *http.Request, id crmcontracts.Id, params crmcontracts.GetOrganizationHierarchyRollupParams) {
+	scope := orgRollupScopeTree
+	if params.Scope != nil {
+		scope = string(*params.Scope)
+	}
+
+	result, err := OrgHierarchyRollup(r.Context(), h.pool, ids.UUID(id), scope)
+	if err != nil {
+		var fxErr *FXRateUnavailableError
+		if errors.As(err, &fxErr) {
+			asOf := fxErr.AsOf.Format(time.DateOnly)
+			httperr.Write(w, r, &httperr.DetailedError{
+				Status: http.StatusUnprocessableEntity,
+				Code:   "fx_rate_unavailable",
+				Detail: fmt.Sprintf("no stored FX rate for %s as of %s", fxErr.Currency, asOf),
+				Details: map[string]any{
+					"currency": fxErr.Currency, //nolint:goconst // a details-map key, coincidentally the same text as a SQL column/report-field name elsewhere in this package — not the same concept
+					"as_of":    asOf,
+				},
+			})
+			return
+		}
+		httperr.Write(w, r, err)
+		return
+	}
+
+	httperr.WriteJSON(w, http.StatusOK, orgRollupToWire(result))
+}
+
+// orgRollupToWire renders the computed result onto the contract's
+// OrganizationHierarchyRollup: both money figures carry the read's
+// resolved base currency, and restricted_excluded is always a real
+// (possibly empty) array — OrgRollupResult never leaves it nil.
+func orgRollupToWire(result OrgRollupResult) crmcontracts.OrganizationHierarchyRollup {
+	// The generated schema left restricted_excluded's item shape unnamed
+	// (see api_gen.go), so its field spelling — Id, not ID — is dictated
+	// by the wire contract this literal must match, not by house style.
+	restricted := make([]struct {
+		DisplayName string             `json:"display_name"`
+		Id          openapi_types.UUID `json:"id"` //nolint:staticcheck // matches the generated OrganizationHierarchyRollup.RestrictedExcluded item shape
+	}, len(result.RestrictedExcluded))
+	for i, n := range result.RestrictedExcluded {
+		restricted[i] = struct {
+			DisplayName string             `json:"display_name"`
+			Id          openapi_types.UUID `json:"id"` //nolint:staticcheck // matches the generated OrganizationHierarchyRollup.RestrictedExcluded item shape
+		}{DisplayName: n.DisplayName, Id: openapi_types.UUID(n.ID)}
+	}
+
+	return crmcontracts.OrganizationHierarchyRollup{
+		RootId:                 openapi_types.UUID(result.RootID),
+		Scope:                  crmcontracts.OrganizationHierarchyRollupScope(result.Scope),
+		WeightedPipeline:       orgRollupMoney(result.WeightedPipelineMinor, result.BaseCurrency),
+		ClosedWon:              orgRollupMoney(result.ClosedWonMinor, result.BaseCurrency),
+		ActivityCount30d:       result.ActivityCount30d,
+		AggregatedAccountCount: result.AggregatedAccountCount,
+		RestrictedExcluded:     restricted,
+		ComputedAt:             result.ComputedAt,
+	}
+}
+
+// orgRollupMoney renders one rollup figure as the wire Money shape — both
+// fields always present, since every rollup measure is a real computed
+// total in the workspace base currency, never a client-nullable input.
+func orgRollupMoney(minor int64, currency string) crmcontracts.Money {
+	amount := minor
+	cur := currency
+	return crmcontracts.Money{AmountMinor: &amount, Currency: &cur}
+}

--- a/backend/internal/compose/orgrollup_handlers.go
+++ b/backend/internal/compose/orgrollup_handlers.go
@@ -27,6 +27,12 @@ import (
 // stub over the gated read.
 type orgRollupHandlers struct {
 	pool *pgxpool.Pool
+	// now is the read's clock (newServer defaults it to time.Now); the HTTP
+	// surface never overrides it, but threading it as a real field — rather
+	// than the read calling time.Now() internally — keeps the handler's
+	// dependency honest and matches the house shape (deals.CloseDateCorrector,
+	// approvals.Service).
+	now func() time.Time
 }
 
 // GetOrganizationHierarchyRollup implements (GET
@@ -39,7 +45,7 @@ func (h orgRollupHandlers) GetOrganizationHierarchyRollup(w http.ResponseWriter,
 		scope = string(*params.Scope)
 	}
 
-	result, err := OrgHierarchyRollup(r.Context(), h.pool, ids.UUID(id), scope)
+	result, err := OrgHierarchyRollup(r.Context(), h.pool, ids.UUID(id), scope, h.now)
 	if err != nil {
 		var fxErr *FXRateUnavailableError
 		if errors.As(err, &fxErr) {

--- a/backend/internal/compose/orgrollup_handlers_test.go
+++ b/backend/internal/compose/orgrollup_handlers_test.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+import (
+	"testing"
+	"time"
+
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// TestOrgRollupToWireMapsRestrictedNodes proves the one branch the HTTP
+// integration suite cannot reach without inventing a second bounded
+// session (the contract has no user-invitation endpoint): a non-empty
+// RestrictedExcluded must map into the wire's anonymous item shape by
+// value, id and name each carried over exactly. orgRollupToWire is a pure
+// function, so this needs no database or HTTP harness at all.
+func TestOrgRollupToWireMapsRestrictedNodes(t *testing.T) {
+	restrictedID := ids.NewV7()
+	result := OrgRollupResult{
+		RootID:                 ids.NewV7(),
+		Scope:                  orgRollupScopeTree,
+		WeightedPipelineMinor:  12_345,
+		ClosedWonMinor:         6_789,
+		BaseCurrency:           "EUR",
+		ActivityCount30d:       3,
+		AggregatedAccountCount: 2,
+		RestrictedExcluded:     []restrictedNode{{ID: restrictedID, DisplayName: "Hidden Child"}},
+		ComputedAt:             time.Date(2026, time.July, 11, 12, 0, 0, 0, time.UTC),
+	}
+
+	wire := orgRollupToWire(result)
+
+	if wire.RootId != openapi_types.UUID(result.RootID) || wire.Scope != crmcontracts.OrganizationHierarchyRollupScopeTree {
+		t.Errorf("envelope = {root %v scope %v}, want {%v tree}", wire.RootId, wire.Scope, result.RootID)
+	}
+	if *wire.WeightedPipeline.AmountMinor != 12_345 || *wire.WeightedPipeline.Currency != "EUR" {
+		t.Errorf("weighted_pipeline = %+v, want {12345 EUR}", wire.WeightedPipeline)
+	}
+	if *wire.ClosedWon.AmountMinor != 6_789 || *wire.ClosedWon.Currency != "EUR" {
+		t.Errorf("closed_won = %+v, want {6789 EUR}", wire.ClosedWon)
+	}
+	if len(wire.RestrictedExcluded) != 1 {
+		t.Fatalf("restricted_excluded = %+v, want exactly one item", wire.RestrictedExcluded)
+	}
+	if got := wire.RestrictedExcluded[0]; got.Id != openapi_types.UUID(restrictedID) || got.DisplayName != "Hidden Child" {
+		t.Errorf("restricted_excluded[0] = %+v, want {%v Hidden Child}", got, restrictedID)
+	}
+	if !wire.ComputedAt.Equal(result.ComputedAt) {
+		t.Errorf("computed_at = %v, want %v", wire.ComputedAt, result.ComputedAt)
+	}
+}
+
+// TestOrgRollupToWireEmptyRestrictedIsNeverNil proves the make-with-length
+// path also produces a real (non-nil) empty slice when nothing is
+// restricted — encoding/json only omits the array shape for a nil slice,
+// and the contract requires restricted_excluded to always be present.
+func TestOrgRollupToWireEmptyRestrictedIsNeverNil(t *testing.T) {
+	result := OrgRollupResult{RootID: ids.NewV7(), Scope: orgRollupScopeSelf, BaseCurrency: "EUR", ComputedAt: time.Now().UTC()}
+
+	wire := orgRollupToWire(result)
+
+	if wire.RestrictedExcluded == nil {
+		t.Error("restricted_excluded is nil, want a real empty slice")
+	}
+	if len(wire.RestrictedExcluded) != 0 {
+		t.Errorf("restricted_excluded = %+v, want empty", wire.RestrictedExcluded)
+	}
+}

--- a/backend/internal/compose/orgrollup_test.go
+++ b/backend/internal/compose/orgrollup_test.go
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+func TestQuarterBounds(t *testing.T) {
+	losAngeles, err := time.LoadLocation("America/Los_Angeles")
+	if err != nil {
+		t.Fatalf("load America/Los_Angeles: %v", err)
+	}
+
+	cases := []struct {
+		name      string
+		now       time.Time
+		loc       *time.Location
+		wantStart time.Time
+		wantEnd   time.Time
+	}{
+		{
+			name:      "mid-quarter",
+			now:       time.Date(2026, time.May, 15, 10, 30, 0, 0, time.UTC),
+			loc:       time.UTC,
+			wantStart: time.Date(2026, time.April, 1, 0, 0, 0, 0, time.UTC),
+			wantEnd:   time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			// The instant exactly on a quarter boundary belongs to the
+			// quarter it opens, never the one it closes.
+			name:      "quarter boundary instant",
+			now:       time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC),
+			loc:       time.UTC,
+			wantStart: time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC),
+			wantEnd:   time.Date(2026, time.October, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			// One nanosecond before the boundary must still resolve to
+			// the closing quarter, proving the end bound is exclusive.
+			name:      "instant before quarter boundary stays in prior quarter",
+			now:       time.Date(2026, time.June, 30, 23, 59, 59, 999999999, time.UTC),
+			loc:       time.UTC,
+			wantStart: time.Date(2026, time.April, 1, 0, 0, 0, 0, time.UTC),
+			wantEnd:   time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			// UTC instant lands early morning Jan 1, but Los Angeles is
+			// still Dec 31 the prior year — the workspace timezone must
+			// shift which quarter (and year) this resolves to, not UTC.
+			name:      "timezone shifts the calendar date across a year boundary",
+			now:       time.Date(2026, time.January, 1, 4, 0, 0, 0, time.UTC),
+			loc:       losAngeles,
+			wantStart: time.Date(2025, time.October, 1, 0, 0, 0, 0, losAngeles),
+			wantEnd:   time.Date(2026, time.January, 1, 0, 0, 0, 0, losAngeles),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			start, end := currentQuarterBounds(tc.now, tc.loc)
+			if !start.Equal(tc.wantStart) {
+				t.Errorf("start = %v, want %v", start, tc.wantStart)
+			}
+			if !end.Equal(tc.wantEnd) {
+				t.Errorf("end = %v, want %v", end, tc.wantEnd)
+			}
+		})
+	}
+}
+
+func TestWeightedValue(t *testing.T) {
+	cases := []struct {
+		name       string
+		baseMinor  int64
+		winPercent int
+		want       int64
+	}{
+		{name: "exact quotient needs no rounding", baseMinor: 100000, winPercent: 50, want: 50000},
+		{name: "positive half rounds away from zero", baseMinor: 1, winPercent: 50, want: 1},
+		{name: "negative half rounds away from zero", baseMinor: -1, winPercent: 50, want: -1},
+		{name: "positive one-and-half rounds up", baseMinor: 3, winPercent: 50, want: 2},
+		{name: "negative one-and-half rounds down", baseMinor: -3, winPercent: 50, want: -2},
+		{name: "0% probability is a real zero", baseMinor: 123456, winPercent: 0, want: 0},
+		{name: "100% probability passes the amount through", baseMinor: 123456, winPercent: 100, want: 123456},
+		{name: "zero amount stays zero at any probability", baseMinor: 0, winPercent: 75, want: 0},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := weightedValue(tc.baseMinor, tc.winPercent)
+			if got != tc.want {
+				t.Errorf("weightedValue(%d, %d) = %d, want %d", tc.baseMinor, tc.winPercent, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestConvertToBase(t *testing.T) {
+	cases := []struct {
+		name        string
+		amountMinor int64
+		rate        float64
+		want        int64
+	}{
+		{name: "rate of 1.0 is a passthrough", amountMinor: 123456, rate: 1.0, want: 123456},
+		{name: "positive half rounds away from zero", amountMinor: 1, rate: 0.5, want: 1},
+		{name: "negative half rounds away from zero", amountMinor: -1, rate: 0.5, want: -1},
+		{name: "positive one-and-half rounds up", amountMinor: 3, rate: 0.5, want: 2},
+		{name: "negative one-and-half rounds down", amountMinor: -3, rate: 0.5, want: -2},
+		{name: "zero amount converts to zero at any rate", amountMinor: 0, rate: 1.37, want: 0},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := convertToBase(tc.amountMinor, tc.rate)
+			if got != tc.want {
+				t.Errorf("convertToBase(%d, %v) = %d, want %d", tc.amountMinor, tc.rate, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFxRateUnavailableErrorMessage(t *testing.T) {
+	asOf := time.Date(2026, time.July, 11, 0, 0, 0, 0, time.UTC)
+	err := fxRateUnavailableError{Currency: "JPY", AsOf: asOf}
+
+	msg := err.Error()
+	if msg == "" {
+		t.Fatal("Error() returned an empty message")
+	}
+	// The message must be actionable: it names the currency and the date
+	// the caller needs to go store a rate for, not an opaque failure.
+	if !contains(msg, "JPY") || !contains(msg, "2026-07-11") {
+		t.Errorf("Error() = %q, want it to name the currency and date", msg)
+	}
+}
+
+func contains(haystack, needle string) bool {
+	return len(haystack) >= len(needle) && indexOf(haystack, needle) >= 0
+}
+
+func indexOf(haystack, needle string) int {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return i
+		}
+	}
+	return -1
+}
+
+func uuidPtr(id ids.UUID) *ids.UUID { return &id }
+
+func TestPruneUnreadable(t *testing.T) {
+	root := ids.NewV7()
+	childA := ids.NewV7()
+	childB := ids.NewV7()
+	grandchildA1 := ids.NewV7()
+	grandchildB1 := ids.NewV7()
+
+	tree := []orgTreeNode{
+		{id: root, parentID: nil, displayName: "Root Co"},
+		{id: childA, parentID: uuidPtr(root), displayName: "Child A"},
+		{id: childB, parentID: uuidPtr(root), displayName: "Child B"},
+		{id: grandchildA1, parentID: uuidPtr(childA), displayName: "Grandchild A1"},
+		{id: grandchildB1, parentID: uuidPtr(childB), displayName: "Grandchild B1"},
+	}
+
+	t.Run("all readable includes the whole tree, root-first", func(t *testing.T) {
+		readable := func(ids.UUID) bool { return true }
+		included, restricted, rootReadable := pruneUnreadable(root, tree, readable)
+
+		if !rootReadable {
+			t.Fatal("rootReadable = false, want true")
+		}
+		if len(included) != 5 || included[0] != root {
+			t.Fatalf("included = %v, want all 5 nodes root-first", included)
+		}
+		if len(restricted) != 0 {
+			t.Fatalf("restricted = %v, want empty", restricted)
+		}
+	})
+
+	t.Run("root unreadable yields empty sets and rootReadable=false", func(t *testing.T) {
+		readable := func(ids.UUID) bool { return false }
+		included, restricted, rootReadable := pruneUnreadable(root, tree, readable)
+
+		if rootReadable {
+			t.Fatal("rootReadable = true, want false")
+		}
+		if len(included) != 0 {
+			t.Fatalf("included = %v, want empty", included)
+		}
+		if len(restricted) != 0 {
+			t.Fatalf("restricted = %v, want empty", restricted)
+		}
+	})
+
+	t.Run("mid-branch unreadable is disclosed once and its subtree is never visited", func(t *testing.T) {
+		readable := func(id ids.UUID) bool { return id != childA }
+		included, restricted, rootReadable := pruneUnreadable(root, tree, readable)
+
+		if !rootReadable {
+			t.Fatal("rootReadable = false, want true")
+		}
+		wantIncluded := map[ids.UUID]bool{root: true, childB: true, grandchildB1: true}
+		if len(included) != len(wantIncluded) {
+			t.Fatalf("included = %v, want exactly %v", included, wantIncluded)
+		}
+		for _, id := range included {
+			if !wantIncluded[id] {
+				t.Errorf("included unexpectedly contains %v", id)
+			}
+			if id == childA || id == grandchildA1 {
+				t.Errorf("included must never contain the restricted branch, got %v", id)
+			}
+		}
+		if len(restricted) != 1 || restricted[0].ID != childA || restricted[0].DisplayName != "Child A" {
+			t.Fatalf("restricted = %v, want exactly [{%v Child A}]", restricted, childA)
+		}
+		for _, r := range restricted {
+			if r.ID == grandchildA1 {
+				t.Error("grandchild of a restricted node must not be separately disclosed")
+			}
+		}
+	})
+
+	t.Run("two restricted siblings are both disclosed", func(t *testing.T) {
+		readable := func(id ids.UUID) bool { return id == root }
+		included, restricted, rootReadable := pruneUnreadable(root, tree, readable)
+
+		if !rootReadable {
+			t.Fatal("rootReadable = false, want true")
+		}
+		if len(included) != 1 || included[0] != root {
+			t.Fatalf("included = %v, want only [root]", included)
+		}
+		if len(restricted) != 2 {
+			t.Fatalf("restricted = %v, want both children disclosed", restricted)
+		}
+		gotIDs := map[ids.UUID]bool{restricted[0].ID: true, restricted[1].ID: true}
+		if !gotIDs[childA] || !gotIDs[childB] {
+			t.Fatalf("restricted ids = %v, want {%v, %v}", gotIDs, childA, childB)
+		}
+	})
+
+	t.Run("leaf-only tree is a one-node rollup", func(t *testing.T) {
+		leaf := ids.NewV7()
+		leafTree := []orgTreeNode{{id: leaf, parentID: nil, displayName: "Leaf Co"}}
+		readable := func(ids.UUID) bool { return true }
+
+		included, restricted, rootReadable := pruneUnreadable(leaf, leafTree, readable)
+
+		if !rootReadable {
+			t.Fatal("rootReadable = false, want true")
+		}
+		if len(included) != 1 || included[0] != leaf {
+			t.Fatalf("included = %v, want [leaf]", included)
+		}
+		if len(restricted) != 0 {
+			t.Fatalf("restricted = %v, want empty", restricted)
+		}
+	})
+
+	t.Run("a restored grant flips the node and its readable subtree back in", func(t *testing.T) {
+		// Same shape as the mid-branch case, but the grant now reads
+		// childA (and by extension its readable descendants) back in —
+		// exercising that pruneUnreadable makes no assumption from any
+		// prior evaluation, it only ever consults readable() fresh.
+		readable := func(ids.UUID) bool { return true }
+		included, restricted, rootReadable := pruneUnreadable(root, tree, readable)
+
+		if !rootReadable {
+			t.Fatal("rootReadable = false, want true")
+		}
+		wantIncluded := map[ids.UUID]bool{root: true, childA: true, childB: true, grandchildA1: true, grandchildB1: true}
+		if len(included) != len(wantIncluded) {
+			t.Fatalf("included = %v, want all 5 nodes back in", included)
+		}
+		for id := range wantIncluded {
+			found := false
+			for _, gotID := range included {
+				if gotID == id {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("included is missing restored node %v", id)
+			}
+		}
+		if len(restricted) != 0 {
+			t.Fatalf("restricted = %v, want empty once the grant is restored", restricted)
+		}
+	})
+}

--- a/backend/internal/compose/orgrollup_test.go
+++ b/backend/internal/compose/orgrollup_test.go
@@ -92,15 +92,47 @@ func TestWeightedValue(t *testing.T) {
 		{name: "0% probability is a real zero", baseMinor: 123456, winPercent: 0, want: 0},
 		{name: "100% probability passes the amount through", baseMinor: 123456, winPercent: 100, want: 123456},
 		{name: "zero amount stays zero at any probability", baseMinor: 0, winPercent: 75, want: 0},
+		{
+			// amount_minor is a bigint column: baseMinor can sit at the very
+			// top of int64's range. A native int64 multiply
+			// (baseMinor*winProbability, BEFORE the ÷100) wraps here — the old
+			// implementation returned -1 for this exact input — even though
+			// the true weighted value is representable (100% is an exact
+			// passthrough). The fix must compute the correct answer via
+			// big.Int, not merely avoid a crash.
+			name:      "MaxInt64 amount at 100% survives the intermediate without wrapping",
+			baseMinor: math.MaxInt64, winPercent: 100, want: math.MaxInt64,
+		},
+		{
+			name:      "MinInt64 amount at 100% survives the intermediate without wrapping",
+			baseMinor: math.MinInt64, winPercent: 100, want: math.MinInt64,
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := weightedValue(tc.baseMinor, tc.winPercent)
+			got, err := weightedValue(tc.baseMinor, tc.winPercent)
+			if err != nil {
+				t.Fatalf("weightedValue(%d, %d): %v", tc.baseMinor, tc.winPercent, err)
+			}
 			if got != tc.want {
 				t.Errorf("weightedValue(%d, %d) = %d, want %d", tc.baseMinor, tc.winPercent, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestWeightedValueRefusesOverflow: win_probability is DB-CHECKed to
+// [0,100] (migrations/core/0006_deals.up.sql), so a valid call can never
+// actually produce an unrepresentable result once baseMinor already fits
+// int64 (guaranteed by convertToBase) — 100% of a fitting amount always
+// fits. This drives winProbability past that domain on purpose: the
+// arithmetic itself, not the caller's discipline, must be what keeps a
+// money total honest, the same belt-and-suspenders posture
+// convertToBase takes for a rate that "should never" be non-finite.
+func TestWeightedValueRefusesOverflow(t *testing.T) {
+	if _, err := weightedValue(math.MaxInt64, 300); err == nil {
+		t.Error("overflowing weighted value returned no error — must refuse, a wrapped total would be a lie about money")
 	}
 }
 

--- a/backend/internal/compose/orgrollup_test.go
+++ b/backend/internal/compose/orgrollup_test.go
@@ -127,7 +127,7 @@ func TestConvertToBase(t *testing.T) {
 
 func TestFxRateUnavailableErrorMessage(t *testing.T) {
 	asOf := time.Date(2026, time.July, 11, 0, 0, 0, 0, time.UTC)
-	err := fxRateUnavailableError{Currency: "JPY", AsOf: asOf}
+	err := FXRateUnavailableError{Currency: "JPY", AsOf: asOf}
 
 	msg := err.Error()
 	if msg == "" {

--- a/backend/internal/compose/orgrollup_test.go
+++ b/backend/internal/compose/orgrollup_test.go
@@ -4,8 +4,12 @@
 package compose
 
 import (
+	"math"
+	"math/big"
 	"testing"
 	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
@@ -100,29 +104,72 @@ func TestWeightedValue(t *testing.T) {
 	}
 }
 
+// numericRate builds a pgtype.Numeric the way pgx materializes a stored
+// numeric: coefficient × 10^exp.
+func numericRate(coefficient int64, exp int32) pgtype.Numeric {
+	return pgtype.Numeric{Int: big.NewInt(coefficient), Exp: exp, Valid: true}
+}
+
 func TestConvertToBase(t *testing.T) {
 	cases := []struct {
 		name        string
 		amountMinor int64
-		rate        float64
+		rate        pgtype.Numeric
 		want        int64
 	}{
-		{name: "rate of 1.0 is a passthrough", amountMinor: 123456, rate: 1.0, want: 123456},
-		{name: "positive half rounds away from zero", amountMinor: 1, rate: 0.5, want: 1},
-		{name: "negative half rounds away from zero", amountMinor: -1, rate: 0.5, want: -1},
-		{name: "positive one-and-half rounds up", amountMinor: 3, rate: 0.5, want: 2},
-		{name: "negative one-and-half rounds down", amountMinor: -3, rate: 0.5, want: -2},
-		{name: "zero amount converts to zero at any rate", amountMinor: 0, rate: 1.37, want: 0},
+		{name: "rate of 1.0 is a passthrough", amountMinor: 123456, rate: numericRate(1, 0), want: 123456},
+		{name: "positive half rounds away from zero", amountMinor: 1, rate: numericRate(5, -1), want: 1},
+		{name: "negative half rounds away from zero", amountMinor: -1, rate: numericRate(5, -1), want: -1},
+		{name: "positive one-and-half rounds up", amountMinor: 3, rate: numericRate(5, -1), want: 2},
+		{name: "negative one-and-half rounds down", amountMinor: -3, rate: numericRate(5, -1), want: -2},
+		{name: "zero amount converts to zero at any rate", amountMinor: 0, rate: numericRate(137, -2), want: 0},
+		{name: "positive-exponent coefficient scales up", amountMinor: 3, rate: numericRate(2, 3), want: 6000},
+		{
+			// Above float64's 2^53 exact-integer ceiling the old float
+			// conversion would silently drop the odd minor unit; the exact
+			// decimal path must keep it.
+			name:        "amount past 2^53 keeps its last minor unit",
+			amountMinor: 9_007_199_254_740_993, // 2^53 + 1
+			rate:        numericRate(1, 0),
+			want:        9_007_199_254_740_993,
+		},
+		{
+			// Full numeric(20,10) scale: 0.0000000001 × 15,000,000,000
+			// lands exactly on the 1.5 tie, which rounds away from zero
+			// only when judged on exact decimal digits.
+			name:        "ten-decimal rate rounds on exact digits",
+			amountMinor: 15_000_000_000,
+			rate:        numericRate(1, -10),
+			want:        2, // 1.5 exactly, away from zero
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := convertToBase(tc.amountMinor, tc.rate)
+			got, err := convertToBase(tc.amountMinor, tc.rate)
+			if err != nil {
+				t.Fatalf("convertToBase(%d, %v): %v", tc.amountMinor, tc.rate, err)
+			}
 			if got != tc.want {
 				t.Errorf("convertToBase(%d, %v) = %d, want %d", tc.amountMinor, tc.rate, got, tc.want)
 			}
 		})
 	}
+}
+
+func TestConvertToBaseRefusesDishonestResults(t *testing.T) {
+	t.Run("non-finite rate is refused", func(t *testing.T) {
+		if _, err := convertToBase(100, pgtype.Numeric{NaN: true, Valid: true}); err == nil {
+			t.Error("NaN rate converted — must refuse, a money total can never absorb it")
+		}
+	})
+	t.Run("overflowing conversion is refused", func(t *testing.T) {
+		// max-int64 minor units at rate 100 cannot fit int64; a wrapped
+		// (silently truncated) figure would be a lie about money.
+		if _, err := convertToBase(math.MaxInt64, numericRate(1, 2)); err == nil {
+			t.Error("overflowing conversion returned a value — must refuse")
+		}
+	})
 }
 
 func TestFxRateUnavailableErrorMessage(t *testing.T) {

--- a/backend/internal/compose/orgrollupread.go
+++ b/backend/internal/compose/orgrollupread.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
@@ -28,6 +29,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
 )
 
 // The rollup's scope vocabulary (crm.yaml enum): the whole readable
@@ -52,19 +54,27 @@ type OrgRollupResult struct {
 	ComputedAt             time.Time
 }
 
-// OrgHierarchyRollup is the gated aggregate read: object-level
-// organization:read, then — inside ONE workspace transaction — the
-// root's row-scope visibility, the bounded tree walk, the per-node
-// readability prune (tree scope only), and the three measures over the
-// included nodes. Out-of-scope and nonexistent roots both answer
-// ErrNotFound, indistinguishable by design.
+// OrgHierarchyRollup is the gated aggregate read: object-level read on
+// organization, deal, AND activity, then — inside ONE workspace
+// transaction — the root's row-scope visibility, the bounded tree walk,
+// the per-node readability prune (tree scope only), and the three
+// measures over the included nodes. Out-of-scope and nonexistent roots
+// both answer ErrNotFound, indistinguishable by design.
+//
+// The rollup surfaces deal money and activity counts, so it demands the
+// same object grants the forecast and activity reports do. Aggregation
+// itself stays ORG-scoped: within a readable organization, per-deal and
+// per-activity row visibility is deliberately not consulted, so account
+// totals stay whole (the contract's description states the same policy).
 func OrgHierarchyRollup(ctx context.Context, pool *pgxpool.Pool, rootID ids.UUID, scope string) (OrgRollupResult, error) {
-	if err := auth.Require(ctx, "organization", principal.ActionRead); err != nil {
-		// Permission refusal precedes input validation: a caller without
-		// organization:read gets 403 even for a bogus scope value, matching
-		// arc 1a's gate order — what the caller can't do is decided before
-		// what the caller asked for is judged well-formed.
-		return OrgRollupResult{}, err
+	for _, object := range []datasource.EntityType{datasource.EntityOrganization, datasource.EntityDeal, datasource.EntityActivity} {
+		if err := auth.Require(ctx, string(object), principal.ActionRead); err != nil {
+			// Permission refusal precedes input validation: a caller missing
+			// any of the three grants gets 403 even for a bogus scope value,
+			// matching arc 1a's gate order — what the caller can't do is
+			// decided before what the caller asked for is judged well-formed.
+			return OrgRollupResult{}, err
+		}
 	}
 	if scope != orgRollupScopeTree && scope != orgRollupScopeSelf {
 		// The handler validates the enum at the edge; a value reaching
@@ -98,7 +108,7 @@ func OrgHierarchyRollup(ctx context.Context, pool *pgxpool.Pool, rootID ids.UUID
 			return err
 		}
 
-		fx := &fxConverter{tx: tx, baseCurrency: baseCurrency, asOf: asOf, rates: map[string]float64{}}
+		fx := &fxConverter{tx: tx, baseCurrency: baseCurrency, asOf: asOf, rates: map[string]pgtype.Numeric{}}
 		if result.WeightedPipelineMinor, err = weightedPipelineMinor(ctx, tx, included, fx); err != nil {
 			return err
 		}
@@ -145,6 +155,13 @@ const orgRollupMaxDepth = 50
 // loadOrgTree walks the live organization hierarchy downward from
 // rootID, root-first. RLS carries the workspace scope; an archived or
 // missing root yields an empty slice for the caller to refuse.
+//
+// The walk recurses ONE level past orgRollupMaxDepth on purpose: a row
+// at the cap depth proves the tree keeps going below what the rollup
+// would sum, and a total that silently dropped those nodes would be a
+// lie about money — the whole read fails loudly instead. (Seeding a
+// 51-deep chain to exercise this in the integration lane would be all
+// fixture and no insight; the sentinel row is plain SQL arithmetic.)
 func loadOrgTree(ctx context.Context, tx pgx.Tx, rootID ids.UUID) ([]orgTreeNode, error) {
 	rows, err := tx.Query(ctx, `
 		WITH RECURSIVE org_tree AS (
@@ -155,9 +172,9 @@ func loadOrgTree(ctx context.Context, tx pgx.Tx, rootID ids.UUID) ([]orgTreeNode
 			SELECT o.id, o.parent_org_id, o.display_name, t.depth + 1
 			FROM organization o
 			JOIN org_tree t ON o.parent_org_id = t.id
-			WHERE o.archived_at IS NULL AND t.depth + 1 < $2
+			WHERE o.archived_at IS NULL AND t.depth + 1 <= $2
 		)
-		SELECT id, parent_org_id, display_name FROM org_tree ORDER BY depth, id`,
+		SELECT id, parent_org_id, display_name, depth FROM org_tree ORDER BY depth, id`,
 		rootID, orgRollupMaxDepth)
 	if err != nil {
 		return nil, err
@@ -167,8 +184,14 @@ func loadOrgTree(ctx context.Context, tx pgx.Tx, rootID ids.UUID) ([]orgTreeNode
 	var nodes []orgTreeNode
 	for rows.Next() {
 		var n orgTreeNode
-		if err := rows.Scan(&n.id, &n.parentID, &n.displayName); err != nil {
+		var depth int
+		if err := rows.Scan(&n.id, &n.parentID, &n.displayName, &depth); err != nil {
 			return nil, err
+		}
+		if depth >= orgRollupMaxDepth {
+			return nil, fmt.Errorf(
+				"organization tree under %s exceeds the supported depth of %d; roll up from a lower node or flatten the hierarchy",
+				rootID, orgRollupMaxDepth)
 		}
 		nodes = append(nodes, n)
 	}
@@ -242,12 +265,14 @@ func orgReadablePredicate(ctx context.Context, tx pgx.Tx, nodes []orgTreeNode) (
 
 // fxConverter converts open-deal amounts to the workspace base currency
 // at the stored as-of rate, memoizing one lookup per currency for the
-// duration of a single rollup read.
+// duration of a single rollup read. Rates stay pgtype.Numeric end to
+// end: the conversion is exact decimal arithmetic, the same discipline
+// closed-won gets from Postgres ROUND over numeric.
 type fxConverter struct {
 	tx           pgx.Tx
 	baseCurrency string
 	asOf         time.Time
-	rates        map[string]float64
+	rates        map[string]pgtype.Numeric
 }
 
 // toBase converts amountMinor from currency to the base currency. A
@@ -277,7 +302,7 @@ func (c *fxConverter) toBase(ctx context.Context, amountMinor int64, currency st
 		}
 		c.rates[currency] = rate
 	}
-	return convertToBase(amountMinor, rate), nil
+	return convertToBase(amountMinor, rate)
 }
 
 // openDealRow is one open deal's contribution inputs: nullable money
@@ -295,10 +320,13 @@ type openDealRow struct {
 // are collected before converting because the FX lookup queries the
 // same transaction's connection.
 func weightedPipelineMinor(ctx context.Context, tx pgx.Tx, included []ids.UUID, fx *fxConverter) (int64, error) {
+	// The stage join deliberately carries NO archived_at filter, matching
+	// the forecast report's join: archiving a stage reshapes the pipeline
+	// vocabulary, it must never silently zero the open deals still in it.
 	rows, err := tx.Query(ctx, `
 		SELECT d.amount_minor, d.currency, s.win_probability
 		FROM deal d
-		JOIN stage s ON s.id = d.stage_id AND s.workspace_id = d.workspace_id AND s.archived_at IS NULL
+		JOIN stage s ON s.id = d.stage_id AND s.workspace_id = d.workspace_id
 		WHERE d.organization_id = ANY($1) AND d.status = 'open' AND d.archived_at IS NULL`,
 		included)
 	if err != nil {
@@ -348,15 +376,19 @@ func closedWonMinorThisQuarter(ctx context.Context, tx pgx.Tx, included []ids.UU
 }
 
 // orgActivityCount30d counts distinct live activities linked to any
-// included organization in the 30 days up to asOf. DISTINCT because one
-// activity may link several orgs of the same tree and must count once.
+// included organization in the half-open window [asOf−30d, asOf).
+// DISTINCT because one activity may link several orgs of the same tree
+// and must count once; the upper bound keeps a future-dated activity (a
+// scheduled call, a clock-skewed import) out of a count that claims to
+// describe the PAST 30 days.
 func orgActivityCount30d(ctx context.Context, tx pgx.Tx, included []ids.UUID, asOf time.Time) (int, error) {
 	var count int
 	err := tx.QueryRow(ctx, `
 		SELECT COUNT(DISTINCT a.id)
 		FROM activity a
 		JOIN activity_link l ON l.activity_id = a.id AND l.entity_type = 'organization'
-		WHERE l.organization_id = ANY($1) AND a.archived_at IS NULL AND a.occurred_at >= $2`,
-		included, asOf.AddDate(0, 0, -30)).Scan(&count)
+		WHERE l.organization_id = ANY($1) AND a.archived_at IS NULL
+		  AND a.occurred_at >= $2 AND a.occurred_at < $3`,
+		included, asOf.AddDate(0, 0, -30), asOf).Scan(&count)
 	return count, err
 }

--- a/backend/internal/compose/orgrollupread.go
+++ b/backend/internal/compose/orgrollupread.go
@@ -1,0 +1,358 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The gated aggregate read behind GET /organizations/{id}/
+// hierarchy-rollup (RD-T04): one workspace transaction walking the org
+// tree, pruning it to the caller's row scope, and computing the three
+// measures over the included nodes. Lives in compose because the read
+// spans organization, deal, stage, activity, and fx_rate — exactly the
+// composition layer's charter; it durably owns none of them. The pure
+// mechanics it builds on (prune, quarter bounds, rounding) live in
+// orgrollup.go.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/platform/httperr"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// The rollup's scope vocabulary (crm.yaml enum): the whole readable
+// subtree, or the root's own figures alone.
+const (
+	orgRollupScopeTree = "tree"
+	orgRollupScopeSelf = "self"
+)
+
+// OrgRollupResult is the computed hierarchy roll-up for one root
+// organization: every money figure in workspace base-currency minor
+// units, plus the identity-only disclosure of pruned branches.
+type OrgRollupResult struct {
+	RootID                 ids.UUID
+	Scope                  string
+	WeightedPipelineMinor  int64
+	ClosedWonMinor         int64
+	BaseCurrency           string
+	ActivityCount30d       int
+	AggregatedAccountCount int
+	RestrictedExcluded     []restrictedNode
+	ComputedAt             time.Time
+}
+
+// OrgHierarchyRollup is the gated aggregate read: object-level
+// organization:read, then — inside ONE workspace transaction — the
+// root's row-scope visibility, the bounded tree walk, the per-node
+// readability prune (tree scope only), and the three measures over the
+// included nodes. Out-of-scope and nonexistent roots both answer
+// ErrNotFound, indistinguishable by design.
+func OrgHierarchyRollup(ctx context.Context, pool *pgxpool.Pool, rootID ids.UUID, scope string) (OrgRollupResult, error) {
+	if scope != orgRollupScopeTree && scope != orgRollupScopeSelf {
+		// The handler validates the enum at the edge; a value reaching
+		// this far is refused with the wire-ready 422 shape rather than
+		// silently defaulted (the contract names the vocabulary).
+		return OrgRollupResult{}, httperr.Validation("scope", "invalid_enum",
+			fmt.Sprintf("scope must be %q or %q", orgRollupScopeTree, orgRollupScopeSelf))
+	}
+	if err := auth.Require(ctx, "organization", principal.ActionRead); err != nil {
+		return OrgRollupResult{}, err
+	}
+
+	asOf := time.Now().UTC()
+	result := OrgRollupResult{RootID: rootID, Scope: scope, RestrictedExcluded: []restrictedNode{}, ComputedAt: asOf}
+	err := database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
+		if err := auth.EnsureVisible(ctx, tx, "organization", rootID); err != nil {
+			return err
+		}
+		baseCurrency, loc, err := rollupWorkspaceMeta(ctx, tx)
+		if err != nil {
+			return err
+		}
+		nodes, err := loadOrgTree(ctx, tx, rootID)
+		if err != nil {
+			return err
+		}
+		if len(nodes) == 0 {
+			// EnsureVisible skips the existence probe for unbounded
+			// callers, so a nonexistent (or archived) root lands here.
+			return fmt.Errorf("organization %s: %w", rootID, apperrors.ErrNotFound)
+		}
+		included, restricted, err := rollupIncludedNodes(ctx, tx, rootID, scope, nodes)
+		if err != nil {
+			return err
+		}
+
+		fx := &fxConverter{tx: tx, baseCurrency: baseCurrency, asOf: asOf, rates: map[string]float64{}}
+		if result.WeightedPipelineMinor, err = weightedPipelineMinor(ctx, tx, included, fx); err != nil {
+			return err
+		}
+		if result.ClosedWonMinor, err = closedWonMinorThisQuarter(ctx, tx, included, asOf, loc); err != nil {
+			return err
+		}
+		if result.ActivityCount30d, err = orgActivityCount30d(ctx, tx, included, asOf); err != nil {
+			return err
+		}
+		result.BaseCurrency = baseCurrency
+		result.AggregatedAccountCount = len(included)
+		result.RestrictedExcluded = restricted
+		return nil
+	})
+	if err != nil {
+		return OrgRollupResult{}, err
+	}
+	return result, nil
+}
+
+// rollupWorkspaceMeta reads the workspace's base currency and reporting
+// timezone. A stored zone the host cannot resolve degrades the quarter
+// window to UTC rather than failing the read — the zone was validated
+// at write time, so this only fires when the host lost its tzdata, and
+// an aggregate read is the wrong place to surface that deployment fault.
+func rollupWorkspaceMeta(ctx context.Context, tx pgx.Tx) (string, *time.Location, error) {
+	var baseCurrency, tzName string
+	if err := tx.QueryRow(ctx, `SELECT base_currency, timezone FROM workspace WHERE id = $1`,
+		storekit.MustWorkspace(ctx)).Scan(&baseCurrency, &tzName); err != nil {
+		return "", nil, fmt.Errorf("read workspace meta: %w", err)
+	}
+	loc, err := time.LoadLocation(tzName)
+	if err != nil {
+		loc = time.UTC
+	}
+	return baseCurrency, loc, nil
+}
+
+// orgRollupMaxDepth caps the recursive tree walk. The DB trigger already
+// guarantees acyclicity, so this is a defensive belt against a
+// pathologically deep (or corrupted) hierarchy, never a correctness rule.
+const orgRollupMaxDepth = 50
+
+// loadOrgTree walks the live organization hierarchy downward from
+// rootID, root-first. RLS carries the workspace scope; an archived or
+// missing root yields an empty slice for the caller to refuse.
+func loadOrgTree(ctx context.Context, tx pgx.Tx, rootID ids.UUID) ([]orgTreeNode, error) {
+	rows, err := tx.Query(ctx, `
+		WITH RECURSIVE org_tree AS (
+			SELECT o.id, o.parent_org_id, o.display_name, 0 AS depth
+			FROM organization o
+			WHERE o.id = $1 AND o.archived_at IS NULL
+			UNION ALL
+			SELECT o.id, o.parent_org_id, o.display_name, t.depth + 1
+			FROM organization o
+			JOIN org_tree t ON o.parent_org_id = t.id
+			WHERE o.archived_at IS NULL AND t.depth + 1 < $2
+		)
+		SELECT id, parent_org_id, display_name FROM org_tree ORDER BY depth, id`,
+		rootID, orgRollupMaxDepth)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var nodes []orgTreeNode
+	for rows.Next() {
+		var n orgTreeNode
+		if err := rows.Scan(&n.id, &n.parentID, &n.displayName); err != nil {
+			return nil, err
+		}
+		nodes = append(nodes, n)
+	}
+	return nodes, rows.Err()
+}
+
+// rollupIncludedNodes resolves which tree nodes the totals may sum.
+// scope=self is the root alone and consults no child readability at
+// all; scope=tree prunes each branch at its first unreadable node,
+// disclosing it by identity only.
+func rollupIncludedNodes(ctx context.Context, tx pgx.Tx, rootID ids.UUID, scope string,
+	nodes []orgTreeNode,
+) ([]ids.UUID, []restrictedNode, error) {
+	if scope == orgRollupScopeSelf {
+		return []ids.UUID{rootID}, []restrictedNode{}, nil
+	}
+	readable, err := orgReadablePredicate(ctx, tx, nodes)
+	if err != nil {
+		return nil, nil, err
+	}
+	included, restricted, rootReadable := pruneUnreadable(rootID, nodes, readable)
+	if !rootReadable {
+		// EnsureVisible vouched for the root in this same transaction;
+		// disagreeing here would be a scope-clause defect — refuse with
+		// the same existence-hiding answer rather than sum anything.
+		return nil, nil, fmt.Errorf("organization %s: %w", rootID, apperrors.ErrNotFound)
+	}
+	return included, restricted, nil
+}
+
+// orgReadablePredicate answers which of the tree's nodes pass the
+// caller's row scope, resolved in ONE batch query over the house
+// visibility predicate. An unbounded caller reads everything, so no
+// query is spent proving it.
+func orgReadablePredicate(ctx context.Context, tx pgx.Tx, nodes []orgTreeNode) (func(ids.UUID) bool, error) {
+	var args []any
+	arg := func(v any) int { args = append(args, v); return len(args) }
+	clause, err := auth.ScopeClauseFor(ctx, "organization", "", arg)
+	if err != nil {
+		return nil, err
+	}
+	if clause == "" {
+		return func(ids.UUID) bool { return true }, nil
+	}
+
+	nodeIDs := make([]ids.UUID, len(nodes))
+	for i, n := range nodes {
+		nodeIDs[i] = n.id
+	}
+	rows, err := tx.Query(ctx,
+		fmt.Sprintf(`SELECT id FROM organization WHERE id = ANY($%d) AND %s`, arg(nodeIDs), clause),
+		args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	readable := make(map[ids.UUID]bool, len(nodes))
+	for rows.Next() {
+		var id ids.UUID
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		readable[id] = true
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return func(id ids.UUID) bool { return readable[id] }, nil
+}
+
+// fxConverter converts open-deal amounts to the workspace base currency
+// at the stored as-of rate, memoizing one lookup per currency for the
+// duration of a single rollup read.
+type fxConverter struct {
+	tx           pgx.Tx
+	baseCurrency string
+	asOf         time.Time
+	rates        map[string]float64
+}
+
+// toBase converts amountMinor from currency to the base currency. A
+// currency with no stored rate on or before the as-of day fails the
+// whole read with the typed error — a partial sum or a silent rate of 1
+// would be a lie about money.
+func (c *fxConverter) toBase(ctx context.Context, amountMinor int64, currency string) (int64, error) {
+	if currency == c.baseCurrency {
+		return amountMinor, nil
+	}
+	rate, ok := c.rates[currency]
+	if !ok {
+		// The as-of day is the UTC calendar date, matching fx_rate's
+		// one-rate-per-pair-per-UTC-day grain; the text bind + cast
+		// keeps the comparison independent of the session timezone.
+		err := c.tx.QueryRow(ctx, `
+			SELECT rate FROM fx_rate
+			WHERE from_currency = $1 AND to_currency = $2 AND rate_date <= $3::date
+			ORDER BY rate_date DESC
+			LIMIT 1`,
+			currency, c.baseCurrency, c.asOf.Format(time.DateOnly)).Scan(&rate)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return 0, &FXRateUnavailableError{Currency: currency, AsOf: c.asOf}
+		}
+		if err != nil {
+			return 0, err
+		}
+		c.rates[currency] = rate
+	}
+	return convertToBase(amountMinor, rate), nil
+}
+
+// openDealRow is one open deal's contribution inputs: nullable money
+// (a deal may honestly have no amount yet) and its stage's live win
+// probability.
+type openDealRow struct {
+	amountMinor    *int64
+	currency       *string
+	winProbability int
+}
+
+// weightedPipelineMinor sums round(base(amount) × win_probability/100)
+// per open deal over the included organizations (formulas §6: round per
+// deal, then sum, so the total reconciles exactly to its parts). Rows
+// are collected before converting because the FX lookup queries the
+// same transaction's connection.
+func weightedPipelineMinor(ctx context.Context, tx pgx.Tx, included []ids.UUID, fx *fxConverter) (int64, error) {
+	rows, err := tx.Query(ctx, `
+		SELECT d.amount_minor, d.currency, s.win_probability
+		FROM deal d
+		JOIN stage s ON s.id = d.stage_id AND s.workspace_id = d.workspace_id AND s.archived_at IS NULL
+		WHERE d.organization_id = ANY($1) AND d.status = 'open' AND d.archived_at IS NULL`,
+		included)
+	if err != nil {
+		return 0, err
+	}
+	deals, err := pgx.CollectRows(rows, func(row pgx.CollectableRow) (openDealRow, error) {
+		var d openDealRow
+		err := row.Scan(&d.amountMinor, &d.currency, &d.winProbability)
+		return d, err
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	var total int64
+	for _, d := range deals {
+		if d.amountMinor == nil {
+			continue // an amountless deal contributes a real 0, never an error
+		}
+		// The deal_amount_currency_pair CHECK guarantees a non-null
+		// amount carries its currency.
+		baseMinor, err := fx.toBase(ctx, *d.amountMinor, *d.currency)
+		if err != nil {
+			return 0, err
+		}
+		total += weightedValue(baseMinor, d.winProbability)
+	}
+	return total, nil
+}
+
+// closedWonMinorThisQuarter sums won deals closed in the current
+// workspace-timezone quarter [start, end), converted at each deal's
+// FROZEN close-time rate — never a live lookup. No FX failure can arise
+// here: the deal_closed_fx CHECK guarantees fx_rate_to_base for every
+// closed deal that has an amount, and an amountless won deal's NULL
+// product is skipped by SUM — an honest 0, not an invented rate.
+func closedWonMinorThisQuarter(ctx context.Context, tx pgx.Tx, included []ids.UUID, asOf time.Time, loc *time.Location) (int64, error) {
+	start, end := currentQuarterBounds(asOf, loc)
+	var total int64
+	err := tx.QueryRow(ctx, `
+		SELECT COALESCE(SUM(ROUND(d.amount_minor * d.fx_rate_to_base)), 0)::bigint
+		FROM deal d
+		WHERE d.organization_id = ANY($1) AND d.status = 'won' AND d.archived_at IS NULL
+		  AND d.closed_at >= $2 AND d.closed_at < $3`,
+		included, start, end).Scan(&total)
+	return total, err
+}
+
+// orgActivityCount30d counts distinct live activities linked to any
+// included organization in the 30 days up to asOf. DISTINCT because one
+// activity may link several orgs of the same tree and must count once.
+func orgActivityCount30d(ctx context.Context, tx pgx.Tx, included []ids.UUID, asOf time.Time) (int, error) {
+	var count int
+	err := tx.QueryRow(ctx, `
+		SELECT COUNT(DISTINCT a.id)
+		FROM activity a
+		JOIN activity_link l ON l.activity_id = a.id AND l.entity_type = 'organization'
+		WHERE l.organization_id = ANY($1) AND a.archived_at IS NULL AND a.occurred_at >= $2`,
+		included, asOf.AddDate(0, 0, -30)).Scan(&count)
+	return count, err
+}

--- a/backend/internal/compose/orgrollupread.go
+++ b/backend/internal/compose/orgrollupread.go
@@ -66,7 +66,13 @@ type OrgRollupResult struct {
 // itself stays ORG-scoped: within a readable organization, per-deal and
 // per-activity row visibility is deliberately not consulted, so account
 // totals stay whole (the contract's description states the same policy).
-func OrgHierarchyRollup(ctx context.Context, pool *pgxpool.Pool, rootID ids.UUID, scope string) (OrgRollupResult, error) {
+//
+// now is the read's injected clock (house shape: deals.CloseDateCorrector,
+// approvals.Service, ai.meter) — the HTTP handler defaults it to time.Now
+// at server construction, and a test pins a fixed instant so a quarter or
+// 30-day window boundary can never flake between when it seeds and when
+// the read evaluates "now".
+func OrgHierarchyRollup(ctx context.Context, pool *pgxpool.Pool, rootID ids.UUID, scope string, now func() time.Time) (OrgRollupResult, error) {
 	for _, object := range []datasource.EntityType{datasource.EntityOrganization, datasource.EntityDeal, datasource.EntityActivity} {
 		if err := auth.Require(ctx, string(object), principal.ActionRead); err != nil {
 			// Permission refusal precedes input validation: a caller missing
@@ -84,7 +90,7 @@ func OrgHierarchyRollup(ctx context.Context, pool *pgxpool.Pool, rootID ids.UUID
 			fmt.Sprintf("scope must be %q or %q", orgRollupScopeTree, orgRollupScopeSelf))
 	}
 
-	asOf := time.Now().UTC()
+	asOf := now().UTC()
 	result := OrgRollupResult{RootID: rootID, Scope: scope, RestrictedExcluded: []restrictedNode{}, ComputedAt: asOf}
 	err := database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
 		if err := auth.EnsureVisible(ctx, tx, "organization", rootID); err != nil {
@@ -191,7 +197,8 @@ func loadOrgTree(ctx context.Context, tx pgx.Tx, rootID ids.UUID) ([]orgTreeNode
 		if depth >= orgRollupMaxDepth {
 			return nil, fmt.Errorf(
 				"organization tree under %s exceeds the supported depth of %d; roll up from a lower node or flatten the hierarchy",
-				rootID, orgRollupMaxDepth)
+				rootID, orgRollupMaxDepth,
+			)
 		}
 		nodes = append(nodes, n)
 	}
@@ -352,7 +359,11 @@ func weightedPipelineMinor(ctx context.Context, tx pgx.Tx, included []ids.UUID, 
 		if err != nil {
 			return 0, err
 		}
-		total += weightedValue(baseMinor, d.winProbability)
+		weighted, err := weightedValue(baseMinor, d.winProbability)
+		if err != nil {
+			return 0, err
+		}
+		total += weighted
 	}
 	return total, nil
 }

--- a/backend/internal/compose/orgrollupread.go
+++ b/backend/internal/compose/orgrollupread.go
@@ -59,15 +59,19 @@ type OrgRollupResult struct {
 // included nodes. Out-of-scope and nonexistent roots both answer
 // ErrNotFound, indistinguishable by design.
 func OrgHierarchyRollup(ctx context.Context, pool *pgxpool.Pool, rootID ids.UUID, scope string) (OrgRollupResult, error) {
+	if err := auth.Require(ctx, "organization", principal.ActionRead); err != nil {
+		// Permission refusal precedes input validation: a caller without
+		// organization:read gets 403 even for a bogus scope value, matching
+		// arc 1a's gate order — what the caller can't do is decided before
+		// what the caller asked for is judged well-formed.
+		return OrgRollupResult{}, err
+	}
 	if scope != orgRollupScopeTree && scope != orgRollupScopeSelf {
 		// The handler validates the enum at the edge; a value reaching
 		// this far is refused with the wire-ready 422 shape rather than
 		// silently defaulted (the contract names the vocabulary).
 		return OrgRollupResult{}, httperr.Validation("scope", "invalid_enum",
 			fmt.Sprintf("scope must be %q or %q", orgRollupScopeTree, orgRollupScopeSelf))
-	}
-	if err := auth.Require(ctx, "organization", principal.ActionRead); err != nil {
-		return OrgRollupResult{}, err
 	}
 
 	asOf := time.Now().UTC()

--- a/backend/internal/compose/server.go
+++ b/backend/internal/compose/server.go
@@ -44,6 +44,12 @@ import (
 	"github.com/gradionhq/margince/backend/web"
 )
 
+// fallback pushes the stubs one embedding level deeper than the module
+// handlers, so a module method always wins promotion and the stub only
+// answers operations nothing implements yet (currently:
+// GetOrganizationHierarchyRollup, pending the compose-layer handler).
+type fallback struct{ stubs }
+
 // Aliases give the embedded handler sets distinct field names; each
 // alias carries its module's full method set.
 type (
@@ -61,11 +67,10 @@ type (
 	voiceHandlers       = ai.Handlers
 )
 
-// Server satisfies crmcontracts.ServerInterface by embedding the module
-// transport handler sets. Every contract operation is implemented; the
-// generated stubs (stubs_gen.go) stay as the drift gate's inventory and
-// would resurface as a compile error here if a regenerated contract
-// added an operation nothing implements.
+// Server satisfies crmcontracts.ServerInterface by embedding: the module
+// transport handlers at depth one shadow the depth-two stubs, so an
+// operation with no module handler yet resolves to its generated 501
+// (stubs_gen.go) rather than failing the build.
 type Server struct {
 	authHandlers
 	peopleHandlers
@@ -85,6 +90,7 @@ type Server struct {
 	scrapeHandlers
 	imapConnectHandlers
 	filteredExportHandlers
+	fallback
 
 	// busReady is the /readyz bus probe, injected only by the process
 	// role that runs the inline relay — a split deployment's api answers

--- a/backend/internal/compose/server.go
+++ b/backend/internal/compose/server.go
@@ -44,12 +44,6 @@ import (
 	"github.com/gradionhq/margince/backend/web"
 )
 
-// fallback pushes the stubs one embedding level deeper than the module
-// handlers, so a module method always wins promotion and the stub only
-// answers operations nothing implements yet (currently:
-// GetOrganizationHierarchyRollup, pending the compose-layer handler).
-type fallback struct{ stubs }
-
 // Aliases give the embedded handler sets distinct field names; each
 // alias carries its module's full method set.
 type (
@@ -67,10 +61,11 @@ type (
 	voiceHandlers       = ai.Handlers
 )
 
-// Server satisfies crmcontracts.ServerInterface by embedding: the module
-// transport handlers at depth one shadow the depth-two stubs, so an
-// operation with no module handler yet resolves to its generated 501
-// (stubs_gen.go) rather than failing the build.
+// Server satisfies crmcontracts.ServerInterface by embedding the module
+// transport handler sets. Every contract operation is implemented; the
+// generated stubs (stubs_gen.go) stay as the drift gate's inventory and
+// would resurface as a compile error here if a regenerated contract
+// added an operation nothing implements.
 type Server struct {
 	authHandlers
 	peopleHandlers
@@ -90,7 +85,7 @@ type Server struct {
 	scrapeHandlers
 	imapConnectHandlers
 	filteredExportHandlers
-	fallback
+	orgRollupHandlers
 
 	// busReady is the /readyz bus probe, injected only by the process
 	// role that runs the inline relay — a split deployment's api answers
@@ -316,7 +311,8 @@ func newServer(pool *pgxpool.Pool, log *slog.Logger, authH authHandlers, dealsH 
 			writer:      NewFilteredExportWriter(pool),
 			collections: collections.NewStore(pool),
 		},
-		log: log,
+		orgRollupHandlers: orgRollupHandlers{pool: pool},
+		log:               log,
 	}
 }
 

--- a/backend/internal/compose/server.go
+++ b/backend/internal/compose/server.go
@@ -311,7 +311,7 @@ func newServer(pool *pgxpool.Pool, log *slog.Logger, authH authHandlers, dealsH 
 			writer:      NewFilteredExportWriter(pool),
 			collections: collections.NewStore(pool),
 		},
-		orgRollupHandlers: orgRollupHandlers{pool: pool},
+		orgRollupHandlers: orgRollupHandlers{pool: pool, now: time.Now},
 		log:               log,
 	}
 }
@@ -363,7 +363,8 @@ func operationalMux(srv Server, pool *pgxpool.Pool, log *slog.Logger, authH auth
 	// binds a confined system principal. The preference edge wraps the
 	// booking edge — each passes a non-matching path straight through.
 	publicEdge := publicPreferences(consent.NewStore(pool), newPublicPreferenceLimiters())(
-		publicBooking(activities.NewStore(pool), newPublicBookingLimiters())(api))
+		publicBooking(activities.NewStore(pool), newPublicBookingLimiters())(api),
+	)
 	mux.Handle("/v1/", httpserver.Correlate(httpserver.AccessLog(log, authH.Middleware(publicEdge))))
 	// The A2 authorization server (ADR-0013): AS endpoints live outside
 	// the generated resource surface but behind the same workspace and

--- a/backend/internal/compose/stubs_gen.go
+++ b/backend/internal/compose/stubs_gen.go
@@ -344,6 +344,10 @@ func (stubs) ScrapeCompany(w nethttp.ResponseWriter, r *nethttp.Request, id crmc
 	httperr.NotImplemented(w, r, "ScrapeCompany")
 }
 
+func (stubs) GetOrganizationHierarchyRollup(w nethttp.ResponseWriter, r *nethttp.Request, id crmcontracts.Id, params crmcontracts.GetOrganizationHierarchyRollupParams) {
+	httperr.NotImplemented(w, r, "GetOrganizationHierarchyRollup")
+}
+
 func (stubs) MergeOrganization(w nethttp.ResponseWriter, r *nethttp.Request, id crmcontracts.Id, params crmcontracts.MergeOrganizationParams) {
 	httperr.NotImplemented(w, r, "MergeOrganization")
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -1704,6 +1704,24 @@ func (e OrganizationSizeBand) Valid() bool {
 	}
 }
 
+// Defines values for OrganizationHierarchyRollupScope.
+const (
+	OrganizationHierarchyRollupScopeSelf OrganizationHierarchyRollupScope = "self"
+	OrganizationHierarchyRollupScopeTree OrganizationHierarchyRollupScope = "tree"
+)
+
+// Valid indicates whether the value is a known member of the OrganizationHierarchyRollupScope enum.
+func (e OrganizationHierarchyRollupScope) Valid() bool {
+	switch e {
+	case OrganizationHierarchyRollupScopeSelf:
+		return true
+	case OrganizationHierarchyRollupScopeTree:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for PartnerCertStatus.
 const (
 	PartnerCertStatusApplied   PartnerCertStatus = "applied"
@@ -3303,6 +3321,24 @@ func (e ListListsParamsEntityType) Valid() bool {
 	}
 }
 
+// Defines values for GetOrganizationHierarchyRollupParamsScope.
+const (
+	GetOrganizationHierarchyRollupParamsScopeSelf GetOrganizationHierarchyRollupParamsScope = "self"
+	GetOrganizationHierarchyRollupParamsScopeTree GetOrganizationHierarchyRollupParamsScope = "tree"
+)
+
+// Valid indicates whether the value is a known member of the GetOrganizationHierarchyRollupParamsScope enum.
+func (e GetOrganizationHierarchyRollupParamsScope) Valid() bool {
+	switch e {
+	case GetOrganizationHierarchyRollupParamsScopeSelf:
+		return true
+	case GetOrganizationHierarchyRollupParamsScopeTree:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for ListPartnersParamsPartnerRole.
 const (
 	Consulting ListPartnersParamsPartnerRole = "consulting"
@@ -4825,6 +4861,15 @@ type MeResponse struct {
 // MeResponsePassportScopes defines model for MeResponse.Passport.Scopes.
 type MeResponsePassportScopes string
 
+// Money Money as integer minor-units + ISO-4217 currency. Never a float.
+type Money struct {
+	// AmountMinor Smallest currency unit (e.g. cents). 100000 EUR-cents = €1,000.00.
+	AmountMinor *int64 `json:"amount_minor,omitempty"`
+
+	// Currency ISO-4217 uppercase.
+	Currency *string `json:"currency,omitempty"`
+}
+
 // MorningBrief One persisted Morning-Brief run for the acting rep (data-model §12.5 `brief_run` +
 // `brief_item`): the ranked, honest-short queue of winnable deals plus the metadata that
 // reproduces it. `candidate_count` is how many deals cleared the §10 honest-short bar;
@@ -5099,6 +5144,34 @@ type OrganizationDomain struct {
 	Source         string              `json:"source"`
 	UpdatedAt      *time.Time          `json:"updated_at,omitempty"`
 }
+
+// OrganizationHierarchyRollup The account-tree roll-up over organization.parent_org_id. A server read only,
+// never client-summed. Money is base-currency converted — never a raw
+// cross-currency sum.
+type OrganizationHierarchyRollup struct {
+	ActivityCount30d int `json:"activity_count_30d"`
+
+	// AggregatedAccountCount Count of accounts (nodes) included in the roll-up.
+	AggregatedAccountCount int `json:"aggregated_account_count"`
+
+	// ClosedWon Money as integer minor-units + ISO-4217 currency. Never a float.
+	ClosedWon  Money     `json:"closed_won"`
+	ComputedAt time.Time `json:"computed_at"`
+
+	// RestrictedExcluded Nodes excluded because the viewer cannot read them — disclosed, never a silent drop.
+	RestrictedExcluded []struct {
+		DisplayName string             `json:"display_name"`
+		Id          openapi_types.UUID `json:"id"`
+	} `json:"restricted_excluded"`
+	RootId openapi_types.UUID               `json:"root_id"`
+	Scope  OrganizationHierarchyRollupScope `json:"scope"`
+
+	// WeightedPipeline Money as integer minor-units + ISO-4217 currency. Never a float.
+	WeightedPipeline Money `json:"weighted_pipeline"`
+}
+
+// OrganizationHierarchyRollupScope defines model for OrganizationHierarchyRollup.Scope.
+type OrganizationHierarchyRollupScope string
 
 // OrganizationListResponse defines model for OrganizationListResponse.
 type OrganizationListResponse struct {
@@ -7053,6 +7126,15 @@ type UpdateOrganizationParams struct {
 	// Accepted on every native (SoR-mode) mutating endpoint that returns a versioned entity.
 	IfMatch *IfMatch `json:"If-Match,omitempty"`
 }
+
+// GetOrganizationHierarchyRollupParams defines parameters for GetOrganizationHierarchyRollup.
+type GetOrganizationHierarchyRollupParams struct {
+	// Scope tree (default): aggregate the whole subtree. self: the root's own figures alone.
+	Scope *GetOrganizationHierarchyRollupParamsScope `form:"scope,omitempty" json:"scope,omitempty"`
+}
+
+// GetOrganizationHierarchyRollupParamsScope defines parameters for GetOrganizationHierarchyRollup.
+type GetOrganizationHierarchyRollupParamsScope string
 
 // MergeOrganizationJSONBody defines parameters for MergeOrganization.
 type MergeOrganizationJSONBody struct {
@@ -12032,6 +12114,9 @@ type ServerInterface interface {
 	// Enrich this organization from its website (evidence-or-omit) — a staged 🟡 proposal.
 	// (POST /organizations/{id}/enrich)
 	ScrapeCompany(w http.ResponseWriter, r *http.Request, id Id)
+	// Roll up an organization's account tree — weighted pipeline, current-quarter closed-won, 30-day activity count.
+	// (GET /organizations/{id}/hierarchy-rollup)
+	GetOrganizationHierarchyRollup(w http.ResponseWriter, r *http.Request, id Id, params GetOrganizationHierarchyRollupParams)
 	// Merge this organization into a target (non-lossy).
 	// (POST /organizations/{id}/merge)
 	MergeOrganization(w http.ResponseWriter, r *http.Request, id Id, params MergeOrganizationParams)
@@ -12731,6 +12816,12 @@ func (_ Unimplemented) UpdateOrganization(w http.ResponseWriter, r *http.Request
 // Enrich this organization from its website (evidence-or-omit) — a staged 🟡 proposal.
 // (POST /organizations/{id}/enrich)
 func (_ Unimplemented) ScrapeCompany(w http.ResponseWriter, r *http.Request, id Id) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Roll up an organization's account tree — weighted pipeline, current-quarter closed-won, 30-day activity count.
+// (GET /organizations/{id}/hierarchy-rollup)
+func (_ Unimplemented) GetOrganizationHierarchyRollup(w http.ResponseWriter, r *http.Request, id Id, params GetOrganizationHierarchyRollupParams) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -17370,6 +17461,56 @@ func (siw *ServerInterfaceWrapper) ScrapeCompany(w http.ResponseWriter, r *http.
 	handler.ServeHTTP(w, r)
 }
 
+// GetOrganizationHierarchyRollup operation middleware
+func (siw *ServerInterfaceWrapper) GetOrganizationHierarchyRollup(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id Id
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", chi.URLParam(r, "id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetOrganizationHierarchyRollupParams
+
+	// ------------- Optional query parameter "scope" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "scope", r.URL.Query(), &params.Scope, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "scope"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "scope", Err: err})
+		}
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetOrganizationHierarchyRollup(w, r, id, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // MergeOrganization operation middleware
 func (siw *ServerInterfaceWrapper) MergeOrganization(w http.ResponseWriter, r *http.Request) {
 
@@ -21189,6 +21330,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/organizations/{id}/enrich", wrapper.ScrapeCompany)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/organizations/{id}/hierarchy-rollup", wrapper.GetOrganizationHierarchyRollup)
 	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/organizations/{id}/merge", wrapper.MergeOrganization)

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -314,6 +314,9 @@ export interface paths {
          *     All money converts to the workspace base currency; a missing stored FX rate fails
          *     the whole read with `422 fx_rate_unavailable` rather than substituting a rate of 1.
          *     Totals are server-computed and reconcile exactly to their parts — never client-summed.
+         *     Requires read on organizations, deals, and activities; figures aggregate every deal
+         *     and activity of each readable organization — per-record row visibility within a
+         *     readable account is deliberately not consulted, so account totals stay whole.
          */
         get: operations["getOrganizationHierarchyRollup"];
         put?: never;

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -296,6 +296,34 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/organizations/{id}/hierarchy-rollup": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        /**
+         * Roll up an organization's account tree — weighted pipeline, current-quarter closed-won, 30-day activity count.
+         * @description `roll-up(node) = self(node) + Σ roll-up(readable child)` over the parent_org_id tree,
+         *     walked with one bounded indexed recursive query. A child the caller cannot read
+         *     contributes nothing and is named in `restricted_excluded` — never silently summed.
+         *     All money converts to the workspace base currency; a missing stored FX rate fails
+         *     the whole read with `422 fx_rate_unavailable` rather than substituting a rate of 1.
+         *     Totals are server-computed and reconcile exactly to their parts — never client-summed.
+         */
+        get: operations["getOrganizationHierarchyRollup"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/organizations/{id}/partner": {
         parameters: {
             query?: never;
@@ -2709,6 +2737,30 @@ export interface components {
         OrganizationListResponse: {
             data: components["schemas"]["Organization"][];
             page: components["schemas"]["PageInfo"];
+        };
+        /**
+         * @description The account-tree roll-up over organization.parent_org_id. A server read only,
+         *     never client-summed. Money is base-currency converted — never a raw
+         *     cross-currency sum.
+         */
+        OrganizationHierarchyRollup: {
+            /** Format: uuid */
+            root_id: string;
+            /** @enum {string} */
+            scope: "tree" | "self";
+            weighted_pipeline: components["schemas"]["Money"];
+            closed_won: components["schemas"]["Money"];
+            activity_count_30d: number;
+            /** @description Count of accounts (nodes) included in the roll-up. */
+            aggregated_account_count: number;
+            /** @description Nodes excluded because the viewer cannot read them — disclosed, never a silent drop. */
+            restricted_excluded: {
+                /** Format: uuid */
+                id: string;
+                display_name: string;
+            }[];
+            /** Format: date-time */
+            computed_at: string;
         };
         /**
          * @description The typed edge. Mirrors `relationship` (data-model §5). Shapes by `kind`:
@@ -5999,6 +6051,36 @@ export interface operations {
                     "application/json": components["schemas"]["Organization"];
                 };
             };
+            404: components["responses"]["NotFound"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    getOrganizationHierarchyRollup: {
+        parameters: {
+            query?: {
+                /** @description tree (default): aggregate the whole subtree. self: the root's own figures alone. */
+                scope?: "tree" | "self";
+            };
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The organization's hierarchy roll-up. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OrganizationHierarchyRollup"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
             404: components["responses"]["NotFound"];
             422: components["responses"]["ValidationError"];
         };


### PR DESCRIPTION
## What

`GET /organizations/{id}/hierarchy-rollup?scope=tree|self` — a server-computed
account-tree roll-up over the existing `parent_org_id` self-FK. No new table,
no migration.

- **Measures:** weighted open pipeline (per-deal FX-convert → weight → sum),
  current-quarter closed-won (frozen `fx_rate_to_base`), 30-day activity count
  — all per-deal-round-then-sum, base-currency only. A missing stored FX rate
  fails the whole read with `422 fx_rate_unavailable` (never a rate-of-1
  substitute). Exact numeric FX math (`pgtype.Numeric`, half-away-from-zero).
- **Tree walk:** one bounded recursive CTE (depth-capped, fails loudly rather
  than silently truncating); DB cycle trigger already guarantees termination.
- **RBAC:** requires read on organizations, deals, AND activities; the first
  unreadable child org on a branch is disclosed in `restricted_excluded`
  (id + display name) and its subtree never summed; root out-of-scope → 404.
  Aggregation is deliberately org-scoped (account totals stay whole) — stated
  explicitly in the contract description.
- **Home:** `internal/compose` (the cross-module aggregate home, following the
  report-engine precedent); `Money` schema reused; Σ(self) == tree
  reconciliation proven by test.

## Tests

- Unit: quarter bounds (TZ-aware, half-open), half-away-from-zero rounding both
  signs incl. 2^53+1 exactness + NaN/overflow refusals, BFS prune truth table,
  wire-mapper restricted-node + never-null branches.
- Integration (8): tree/self reconciliation, restricted-node disclosure +
  record-grant flip, FX-unavailable fails whole read, closed-won quarter
  window, root gates (403/404 incl. org-read-without-deal-read), future-dated
  activities excluded.
- HTTP e2e (5 subtests): envelope arithmetic, self scope, 422 bad scope,
  422 fx-unavailable with details, 404.

## Follow-ups (documented, out of scope)

- PO-AC-28 p95<200ms standing benchmark gate not stood up.
- Org-360 composite read (PO-EXT-3) — next arc.
- Write-time parent-chain depth cap (a 51-deep chain currently surfaces as a
  loud 500 on the read, by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an organization hierarchy roll-up endpoint with `tree` and `self` scopes.
  * Reports weighted pipeline, current-quarter closed-won totals, 30-day activity, aggregated accounts, base currency, and calculation timestamp.
  * Excludes inaccessible child organizations and identifies restricted results.
* **Bug Fixes**
  * Missing exchange rates now return a clear validation error instead of incomplete totals.
  * Invalid scopes and unavailable organizations return appropriate errors.
* **Tests**
  * Added comprehensive coverage for permissions, currency conversion, time windows, restricted data, and roll-up accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->