### PR TITLE
feat: per-record audit history read (poc-1 delta port, arc 1c — closes Wave 1)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -85,6 +85,13 @@ Merged so far:
   missing rate, never a silent rate=1). Compose-homed — the read spans
   organization, deal, stage, activity, and fx_rate — with no new table.
   Arc 1b of the poc-1 feature-delta port.
+- **Record history read** — `GET /records/{entity_type}/{id}/history`:
+  chronological plain-language history lines with actor + agent-authority
+  attribution, viewer-masked before/after (by omission), keyset
+  pagination, and the erasure boundary (pre-scrub rows withheld, the
+  tombstone's own line served); third audit-spine read in the privacy
+  module; the erase tombstones now carry their tallies on the evidence
+  channel. Arc 1c — closes Wave 1 of the poc-1 delta port.
 
 ## Pick up here
 

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -3017,6 +3017,44 @@ paths:
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
 
+  /records/{entity_type}/{id}/history:
+    parameters:
+      - name: entity_type
+        in: path
+        required: true
+        schema: { type: string, enum: [person, organization, deal, lead, activity] }
+      - $ref: '#/components/parameters/Id'
+    get:
+      tags: [Compliance]
+      operationId: getRecordHistory
+      security: [ { cookieAuth: [] } ]   # human session only
+      x-agent-access: human-only
+      summary: Full audit history for one record, rendered as plain-language lines.
+      description: |
+        Every audit_log row for the record, rendered as a plain-language `summary` line
+        naming the actor and, for agent actions, the granting human (`on_behalf_of_name`).
+        Chronological oldest-first (`occurred_at` ASC, `id` tiebreak) with keyset pagination.
+        `before`/`after` are masked to the viewer's readable fields by omission — a field the
+        caller cannot see is absent from the object, never present as `null`. The projection
+        stops at the record's newest erasure scrub: rows at-or-before that tombstone are
+        withheld while the tombstone's own line remains, so the read never resurfaces
+        pre-erasure PII. A visible record with no history answers `200 {data: []}` — an empty
+        history is honest, not a gap. A record outside the caller's row scope answers 404
+        (existence-hiding), like every single-record read.
+      parameters:
+        - $ref: '#/components/parameters/Cursor'
+        - $ref: '#/components/parameters/Limit'
+      responses:
+        '200':
+          description: A page of rendered history lines, oldest first (empty when none).
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/AuditHistoryListResponse' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '422': { $ref: '#/components/responses/ValidationError' }
+
   /field-history:
     get:
       tags: [Compliance]
@@ -5985,6 +6023,34 @@ components:
       required: [data, page]
       properties:
         data: { type: array, items: { $ref: '#/components/schemas/FieldHistoryEntry' } }
+        page: { $ref: '#/components/schemas/PageInfo' }
+
+    AuditHistoryEntry:
+      type: object
+      description: |
+        One rendered history line for a record mutation. `before`/`after` are
+        masked to the viewer's readable fields — an absent key was hidden, not null.
+        `summary` is server-composed plain language; field-level detail lives in
+        before/after for the client to render.
+      required: [id, actor_type, actor_id, action, occurred_at, summary]
+      properties:
+        id: { type: string, format: uuid }
+        actor_type: { type: string, enum: [human, agent, system, connector] }
+        actor_id: { type: string }
+        on_behalf_of: { type: [string, 'null'], format: uuid, description: Granting human's user id for agent actions. }
+        on_behalf_of_name: { type: [string, 'null'], description: Resolved display name for on_behalf_of. }
+        action: { type: string }
+        occurred_at: { type: string, format: date-time }
+        authorization_rule: { type: [string, 'null'] }
+        before: { type: [object, 'null'], additionalProperties: true }
+        after: { type: [object, 'null'], additionalProperties: true }
+        summary: { type: string }
+
+    AuditHistoryListResponse:
+      type: object
+      required: [data, page]
+      properties:
+        data: { type: array, items: { $ref: '#/components/schemas/AuditHistoryEntry' } }
         page: { $ref: '#/components/schemas/PageInfo' }
 
     # ---- Reports ----

--- a/backend/internal/compose/integration/recordhistory_http_integration_test.go
+++ b/backend/internal/compose/integration/recordhistory_http_integration_test.go
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// HTTP-level coverage for GET /records/{entity_type}/{id}/history: the
+// handler (privacy.Handlers.GetRecordHistory) and its wire mapping
+// (recordHistoryEntryToWire) that recordhistory_integration_test.go never
+// drives — that suite calls privacy.ListRecordHistory directly, so the
+// entity_type path-param validation, the malformed-cursor 422, and the
+// JSON shape only exist at the transport. This suite rides the same
+// real-handler-stack e2e harness as e2e_integration_test.go (TLS httptest
+// server, session cookie, workspace header) and reuses
+// recordhistory_integration_test.go's seedRecordAuditRow/seedWorkspaceUser
+// plus fieldhistory_integration_test.go's seedAuditDiffRow to write the
+// audit rows the handler reads back.
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// recordHistoryEntryWire mirrors the contract's AuditHistoryEntry field by
+// field, decoded loosely so a wire-shape regression (a renamed or
+// mistyped key) fails the assertions below instead of silently zeroing.
+type recordHistoryEntryWire struct {
+	ID                string         `json:"id"`
+	ActorType         string         `json:"actor_type"`
+	ActorID           string         `json:"actor_id"`
+	OnBehalfOf        *string        `json:"on_behalf_of"`
+	OnBehalfOfName    *string        `json:"on_behalf_of_name"`
+	Action            string         `json:"action"`
+	OccurredAt        time.Time      `json:"occurred_at"`
+	AuthorizationRule *string        `json:"authorization_rule"`
+	Before            map[string]any `json:"before"`
+	After             map[string]any `json:"after"`
+	Summary           string         `json:"summary"`
+}
+
+type recordHistoryListWire struct {
+	Data []recordHistoryEntryWire `json:"data"`
+	Page struct {
+		HasMore    bool    `json:"has_more"`
+		NextCursor *string `json:"next_cursor"`
+	} `json:"page"`
+}
+
+// recordHistoryHTTPFixture is the seeded shape the happy-path subtest reads
+// back: a person created through the real HTTP write path (its own
+// create-audit row resolves the admin's display name — genuine genesis
+// history, not a fixture), a human-actor phone diff, and — dated newest so
+// it lands last in the chronological order — an agent-actor diff acting
+// under Ada Authority's delegated authority.
+type recordHistoryHTTPFixture struct {
+	personID ids.UUID
+	adaID    ids.UUID
+}
+
+func seedRecordHistoryHTTPFixture(t *testing.T, e *env, dbEnv *Env) recordHistoryHTTPFixture {
+	t.Helper()
+	var person anyMap
+	if status := e.call(t, "POST", "/v1/people", anyMap{
+		"full_name": "Record History Subject",
+		"source":    "ui",
+	}, nil, &person); status != http.StatusCreated {
+		t.Fatalf("create person = %d %v", status, person)
+	}
+	personID, err := ids.Parse(person["id"].(string))
+	if err != nil {
+		t.Fatalf("parsing person id %q: %v", person["id"], err)
+	}
+
+	// Dated forward from the create row so ordering is unambiguous
+	// (fieldhistory_http_integration_test.go's own convention).
+	humanAt := time.Now().Add(1 * time.Hour).UTC().Truncate(time.Microsecond)
+	agentAt := time.Now().Add(2 * time.Hour).UTC().Truncate(time.Microsecond)
+	seedAuditDiffRow(t, dbEnv, "person", personID, "human",
+		map[string]any{"phone": "555-0100"}, map[string]any{"phone": "555-0199"}, humanAt)
+
+	adaID := seedWorkspaceUser(t, dbEnv, "Ada Authority")
+	seedRecordAuditRow(t, dbEnv, "update", personID, "agent", "agent:enrich", &adaID,
+		map[string]any{"title": "VP"}, map[string]any{"title": "CTO"}, agentAt)
+
+	return recordHistoryHTTPFixture{personID: personID, adaID: adaID}
+}
+
+// assertRecordHistoryHappyPath drives the GET and checks the wire shape:
+// chronological ordering, the genesis line's resolved display name, the
+// human diff's exact (no-phantom-key) before/after images, and the
+// agent line's woven-in delegated authority.
+func assertRecordHistoryHappyPath(t *testing.T, e *env, fx recordHistoryHTTPFixture) {
+	t.Helper()
+	var page recordHistoryListWire
+	status := e.call(t, "GET", "/v1/records/person/"+fx.personID.String()+"/history", nil, nil, &page)
+	if status != http.StatusOK {
+		t.Fatalf("record-history status = %d, want 200: %+v", status, page)
+	}
+	if len(page.Data) != 3 {
+		t.Fatalf("want exactly 3 entries (create genesis + human diff + agent diff): %+v", page.Data)
+	}
+	for i := 1; i < len(page.Data); i++ {
+		if page.Data[i].OccurredAt.Before(page.Data[i-1].OccurredAt) {
+			t.Fatalf("entries not chronological ASC at index %d: %+v", i, page.Data)
+		}
+	}
+
+	genesis := page.Data[0]
+	if genesis.Action != "create" {
+		t.Fatalf("genesis action = %q, want create", genesis.Action)
+	}
+	if genesis.Summary != "Ada Admin created the record" {
+		t.Errorf("genesis summary = %q, want the resolved admin display name woven in", genesis.Summary)
+	}
+	if genesis.Before != nil {
+		t.Errorf("genesis before = %v, want absent (a create row has no prior image)", genesis.Before)
+	}
+
+	human := page.Data[1]
+	if human.Action != "update" || human.ActorType != "human" {
+		t.Fatalf("human entry = %+v, want the seeded update diff", human)
+	}
+	// No phantom keys: the seeded map is the whole of before/after, since
+	// defaultFieldMasks is empty for person in this repo.
+	if len(human.Before) != 1 || human.Before["phone"] != "555-0100" {
+		t.Errorf("human before = %v, want exactly {phone: 555-0100}", human.Before)
+	}
+	if len(human.After) != 1 || human.After["phone"] != "555-0199" {
+		t.Errorf("human after = %v, want exactly {phone: 555-0199}", human.After)
+	}
+
+	agent := page.Data[2]
+	if agent.ActorType != "agent" {
+		t.Fatalf("agent entry actor_type = %q, want agent", agent.ActorType)
+	}
+	if agent.OnBehalfOf == nil || *agent.OnBehalfOf != fx.adaID.String() {
+		t.Errorf("agent on_behalf_of = %v, want %s", agent.OnBehalfOf, fx.adaID)
+	}
+	if agent.OnBehalfOfName == nil || *agent.OnBehalfOfName != "Ada Authority" {
+		t.Errorf("agent on_behalf_of_name = %v, want Ada Authority", agent.OnBehalfOfName)
+	}
+	if agent.Summary != "Agent acting for Ada Authority updated the record" {
+		t.Errorf("agent summary = %q, want the delegating authority woven in", agent.Summary)
+	}
+
+	// page.has_more is a required (non-pointer) field on the wire — its
+	// mere presence in the decoded envelope is what this asserts.
+	if page.Page.HasMore {
+		t.Errorf("single page must report exhaustion: has_more=%v", page.Page.HasMore)
+	}
+	if page.Page.NextCursor != nil {
+		t.Errorf("single page must carry no next_cursor: %v", *page.Page.NextCursor)
+	}
+}
+
+func TestRecordHistoryHTTP(t *testing.T) {
+	e := setup(t)
+	e.bootstrapWorkspace(t)
+	dbEnv := fieldHistoryHTTPEnv(t, e)
+	fx := seedRecordHistoryHTTPFixture(t, e, dbEnv)
+
+	t.Run("200 happy path with wire mapping", func(t *testing.T) {
+		assertRecordHistoryHappyPath(t, e, fx)
+	})
+
+	t.Run("422 invalid entity_type", func(t *testing.T) {
+		var problem fieldHistoryProblem
+		status := e.call(t, "GET", "/v1/records/bogus/"+ids.NewV7().String()+"/history", nil, nil, &problem)
+		assertFieldHistoryValidation422(t, status, problem, "entity_type", "invalid_entity_type")
+	})
+
+	t.Run("422 malformed cursor", func(t *testing.T) {
+		var problem fieldHistoryProblem
+		status := e.call(t, "GET",
+			"/v1/records/person/"+fx.personID.String()+"/history?cursor=!!!notatoken", nil, nil, &problem)
+		assertFieldHistoryValidation422(t, status, problem, "cursor", "malformed_cursor")
+	})
+
+	t.Run("keyset page walk over the wire", func(t *testing.T) {
+		var walked []string
+		var cursor string
+		url := "/v1/records/person/" + fx.personID.String() + "/history?limit=1"
+		for page := 1; page <= 3; page++ {
+			var got recordHistoryListWire
+			reqURL := url
+			if cursor != "" {
+				reqURL += "&cursor=" + cursor
+			}
+			status := e.call(t, "GET", reqURL, nil, nil, &got)
+			if status != http.StatusOK {
+				t.Fatalf("page %d status = %d: %+v", page, status, got)
+			}
+			if len(got.Data) != 1 {
+				t.Fatalf("page %d entries = %d, want 1: %+v", page, len(got.Data), got.Data)
+			}
+			walked = append(walked, got.Data[0].ID)
+			if page < 3 {
+				if !got.Page.HasMore || got.Page.NextCursor == nil {
+					t.Fatalf("page %d must report more rows follow: %+v", page, got.Page)
+				}
+				cursor = *got.Page.NextCursor
+			} else if got.Page.HasMore || got.Page.NextCursor != nil {
+				t.Fatalf("page 3 is genuine exhaustion — has_more must not lie: %+v", got.Page)
+			}
+		}
+		if walked[0] == walked[1] || walked[1] == walked[2] || walked[0] == walked[2] {
+			t.Fatalf("walked ids not distinct across pages: %v — keyset overlap", walked)
+		}
+	})
+}

--- a/backend/internal/compose/integration/recordhistory_integration_test.go
+++ b/backend/internal/compose/integration/recordhistory_integration_test.go
@@ -1,0 +1,330 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The record-history read (GET /records/{entity_type}/{id}/history): one
+// plain-language line per audit row — the whole-mutation view next to
+// field-history's per-field diffs. Gated exactly like every other record
+// read (human-only, object-read, row-scope), keyset-paginated ASC, and cut
+// at the erasure boundary — but tombstone-INCLUSIVE: the erase line is the
+// honest disclosure that the record was scrubbed.
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/modules/privacy"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// seedRecordAuditRow inserts a raw person audit row with full control
+// over the actor columns — the record-history read renders actor_id and
+// on_behalf_of, which seedAuditActionRow (fieldhistory suite) pins to a
+// fixed literal. This suite exercises entity-type dispatch through the
+// shared gate stack (proven per-type by the fieldhistory suite), so its
+// seeds stay on person. INSERT is the one verb the append-only trigger
+// admits, and the workspace tx satisfies RLS.
+func seedRecordAuditRow(t *testing.T, e *Env, action string, personID ids.UUID,
+	actorType, actorID string, onBehalfOf *ids.UUID, before, after map[string]any, occurredAt time.Time,
+) ids.UUID {
+	t.Helper()
+	rowID := ids.NewV7()
+	ctx := principal.WithWorkspaceID(t.Context(), e.WS)
+	err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx,
+			`INSERT INTO audit_log (id, workspace_id, actor_type, actor_id, on_behalf_of,
+			                        action, entity_type, entity_id, before, after, occurred_at)
+			 VALUES ($1, $2, $3, $4, $5, $6, 'person', $7, $8, $9, $10)`,
+			rowID, e.WS, actorType, actorID, onBehalfOf, action, personID,
+			storekit.JSONArg(before), storekit.JSONArg(after), occurredAt)
+		return err
+	})
+	if err != nil {
+		t.Fatalf("seed record audit row: %v", err)
+	}
+	return rowID
+}
+
+// seedWorkspaceUser inserts an app_user with a distinct display name so
+// the read's name resolution has something real to resolve (the harness
+// seeds every rep as "Rep"). Owner connection like the harness itself:
+// app_user rows are identity fixtures, not app-role writes.
+func seedWorkspaceUser(t *testing.T, e *Env, displayName string) ids.UUID {
+	t.Helper()
+	id := ids.NewV7()
+	if _, err := OwnerConn(t).Exec(context.Background(),
+		`INSERT INTO app_user (id, workspace_id, email, display_name) VALUES ($1, $2, $3, $4)`,
+		id, e.WS, id.String()+"@recordhistory.test", displayName); err != nil {
+		t.Fatalf("seed app_user %q: %v", displayName, err)
+	}
+	return id
+}
+
+func TestRecordHistoryGatesOnPrincipalPermissionAndVisibility(t *testing.T) {
+	e := Setup(t)
+	// Owned by Rep1 (Team1): an ownerless record is workspace-shared at
+	// every tier, so the out-of-scope assertion needs a real owner to
+	// exclude the Team2-only caller.
+	personID := e.SeedPerson(t, "Gated Subject", &e.Rep1)
+
+	// Rep3 sits only in Team2: 404, not an empty page — existence-hiding
+	// on the row-scope gate like every record read.
+	outsider := e.As(e.Rep3, []ids.UUID{e.Team2}, RepPerms)
+	if _, err := privacy.ListRecordHistory(outsider, e.Pool, privacy.RecordHistoryFilter{
+		EntityType: "person", EntityID: personID,
+	}); !errors.Is(err, apperrors.ErrNotFound) {
+		t.Fatalf("out-of-scope read: err = %v, want not found", err)
+	}
+
+	// A principal without person:read at all: 403 before any row is touched.
+	noRead := e.As(e.Rep1, []ids.UUID{e.Team1}, principal.Permissions{RowScope: principal.RowScopeTeam})
+	if _, err := privacy.ListRecordHistory(noRead, e.Pool, privacy.RecordHistoryFilter{
+		EntityType: "person", EntityID: personID,
+	}); !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Fatalf("no-permission read: err = %v, want permission denied", err)
+	}
+
+	// The history surface is human-only: an agent principal is refused
+	// outright, before the entity gate.
+	if _, err := privacy.ListRecordHistory(e.AgentCtx(), e.Pool, privacy.RecordHistoryFilter{
+		EntityType: "person", EntityID: personID,
+	}); !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Fatalf("agent-principal read: err = %v, want permission denied", err)
+	}
+}
+
+func TestRecordHistoryRendersEveryActorChronologically(t *testing.T) {
+	e := Setup(t)
+	personID := e.SeedPerson(t, "History Subject", nil)
+	uma := seedWorkspaceUser(t, e, "Uma Underwriter")
+	ada := seedWorkspaceUser(t, e, "Ada Authority")
+
+	// SeedPerson's create row is stamped at real "now"; the four actor
+	// rows are dated forward so ordering is unambiguous.
+	base := time.Now().Add(time.Hour).UTC().Truncate(time.Microsecond)
+	seedRecordAuditRow(t, e, "update", personID, "human", "human:"+uma.String(), nil,
+		map[string]any{"email": "old@x.com"}, map[string]any{"email": "new@x.com"}, base)
+	seedRecordAuditRow(t, e, "update", personID, "agent", "agent:enrich", &ada,
+		nil, map[string]any{"title": "CTO"}, base.Add(time.Hour))
+	seedRecordAuditRow(t, e, "archive", personID, "system", "system", nil,
+		nil, nil, base.Add(2*time.Hour))
+	seedRecordAuditRow(t, e, "update", personID, "connector", "connector:hubspot", nil,
+		nil, map[string]any{"phone": "1"}, base.Add(3*time.Hour))
+
+	page, err := privacy.ListRecordHistory(e.Admin(), e.Pool, privacy.RecordHistoryFilter{
+		EntityType: "person", EntityID: personID,
+	})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(page.Entries) != 5 {
+		t.Fatalf("entries = %d, want 5 (create genesis + four seeded actors): %+v", len(page.Entries), page.Entries)
+	}
+	if page.HasMore || page.NextCursor != "" {
+		t.Errorf("single page must report exhaustion: has_more=%v cursor=%q", page.HasMore, page.NextCursor)
+	}
+	for i := 1; i < len(page.Entries); i++ {
+		if page.Entries[i].OccurredAt.Before(page.Entries[i-1].OccurredAt) {
+			t.Fatalf("entries not chronological ASC at index %d: %v after %v",
+				i, page.Entries[i].OccurredAt, page.Entries[i-1].OccurredAt)
+		}
+	}
+
+	// The genesis row's actor is the harness admin — a synthetic user with
+	// no app_user row, so the summary honestly falls back to the raw
+	// prefixed actor_id instead of inventing a name.
+	genesis := page.Entries[0]
+	if genesis.Action != "create" ||
+		!strings.HasPrefix(genesis.Summary, "human:") || !strings.HasSuffix(genesis.Summary, "created the record") {
+		t.Errorf("genesis line = %q (action %q), want raw-actor_id create line", genesis.Summary, genesis.Action)
+	}
+
+	human := page.Entries[1]
+	if human.Summary != "Uma Underwriter updated the record" {
+		t.Errorf("human line = %q, want resolved display name", human.Summary)
+	}
+	if human.After["email"] != "new@x.com" || human.Before["email"] != "old@x.com" {
+		t.Errorf("human line payload = before %v after %v, want the seeded images served", human.Before, human.After)
+	}
+
+	agent := page.Entries[2]
+	if agent.Summary != "Agent acting for Ada Authority updated the record" {
+		t.Errorf("agent line = %q, want the delegating authority woven in", agent.Summary)
+	}
+	if agent.OnBehalfOf == nil || *agent.OnBehalfOf != ada {
+		t.Errorf("agent line OnBehalfOf = %v, want %v", agent.OnBehalfOf, ada)
+	}
+	if agent.OnBehalfOfName == nil || *agent.OnBehalfOfName != "Ada Authority" {
+		t.Errorf("agent line OnBehalfOfName = %v, want Ada Authority", agent.OnBehalfOfName)
+	}
+
+	if got := page.Entries[3].Summary; got != "System archived the record" {
+		t.Errorf("system line = %q", got)
+	}
+	if got := page.Entries[4].Summary; got != "Connector updated the record" {
+		t.Errorf("connector line = %q", got)
+	}
+}
+
+// TestRecordHistoryErasureBoundaryServesOnlyTheTombstone proves D1's
+// tombstone-INCLUSIVE cut: after the REAL erasure engine runs, every line
+// older than the erase tombstone is withheld (their before/after images
+// are exactly the PII the scrub certified gone), while the tombstone line
+// itself IS served — its images are empty (the suppression tallies ride
+// audit_log.evidence, which this read never selects), so the erase line is
+// honest disclosure, not a leak.
+func TestRecordHistoryErasureBoundaryServesOnlyTheTombstone(t *testing.T) {
+	e := Setup(t)
+	personID := e.SeedPerson(t, "Selma Subject", nil)
+	past := time.Now().Add(-2 * time.Hour).UTC().Truncate(time.Microsecond)
+	seedRecordAuditRow(t, e, "update", personID, "human", "user-1", nil,
+		map[string]any{"email": "selma@example.com"},
+		map[string]any{"email": "selma.subject@example.com"}, past)
+
+	if err := privacy.NewEraser(e.Pool).ErasePerson(e.Admin(), personID, "dsr"); err != nil {
+		t.Fatalf("erase: %v", err)
+	}
+
+	page, err := privacy.ListRecordHistory(e.Admin(), e.Pool, privacy.RecordHistoryFilter{
+		EntityType: "person", EntityID: personID,
+	})
+	if err != nil {
+		t.Fatalf("post-erasure list: %v", err)
+	}
+	if len(page.Entries) != 1 {
+		t.Fatalf("entries = %d, want exactly the tombstone (pre-erasure lines withheld): %+v",
+			len(page.Entries), page.Entries)
+	}
+	tomb := page.Entries[0]
+	if tomb.Action != "erase" {
+		t.Fatalf("surviving line action = %q, want erase", tomb.Action)
+	}
+	// The eraser stamps the calling principal — the harness admin is a
+	// human — so the line renders from the human branch, honestly.
+	if tomb.ActorType != "human" || !strings.HasSuffix(tomb.Summary, "erased the record") {
+		t.Errorf("tombstone line = %q (actor %q), want an erased-the-record line by the caller",
+			tomb.Summary, tomb.ActorType)
+	}
+	if len(tomb.Before) != 0 || len(tomb.After) != 0 {
+		t.Errorf("tombstone images must be empty (meta rides evidence): before %v after %v",
+			tomb.Before, tomb.After)
+	}
+
+	// The boundary is a cut, not a ban: a change made AFTER the scrub is
+	// ordinary history again, rendered behind the erase line.
+	future := time.Now().Add(time.Hour).UTC().Truncate(time.Microsecond)
+	seedRecordAuditRow(t, e, "update", personID, "human", "user-1", nil,
+		nil, map[string]any{"owner_id": "rep-2"}, future)
+	page, err = privacy.ListRecordHistory(e.Admin(), e.Pool, privacy.RecordHistoryFilter{
+		EntityType: "person", EntityID: personID,
+	})
+	if err != nil {
+		t.Fatalf("post-scrub list: %v", err)
+	}
+	if len(page.Entries) != 2 || page.Entries[0].Action != "erase" || page.Entries[1].Action != "update" {
+		t.Fatalf("post-scrub timeline = %+v, want [erase, update]", page.Entries)
+	}
+}
+
+func TestRecordHistoryKeysetWalksAscendingWithoutOverlap(t *testing.T) {
+	e := Setup(t)
+	// SeedPerson's create row is the true oldest line; two forward-dated
+	// updates make three rows total.
+	personID := e.SeedPerson(t, "Paging Subject", nil)
+	base := time.Now().Add(time.Hour).UTC().Truncate(time.Microsecond)
+	r2 := seedRecordAuditRow(t, e, "update", personID, "human", "user-1", nil,
+		map[string]any{"phone": "1"}, map[string]any{"phone": "2"}, base)
+	r3 := seedRecordAuditRow(t, e, "update", personID, "human", "user-1", nil,
+		map[string]any{"phone": "2"}, map[string]any{"phone": "3"}, base.Add(time.Hour))
+
+	one := 1
+	var walked []ids.UUID
+	var cursor *string
+	for pageNo := 1; pageNo <= 3; pageNo++ {
+		page, err := privacy.ListRecordHistory(e.Admin(), e.Pool, privacy.RecordHistoryFilter{
+			EntityType: "person", EntityID: personID, Limit: &one, Cursor: cursor,
+		})
+		if err != nil {
+			t.Fatalf("page %d: %v", pageNo, err)
+		}
+		if len(page.Entries) != 1 {
+			t.Fatalf("page %d entries = %d, want 1", pageNo, len(page.Entries))
+		}
+		walked = append(walked, page.Entries[0].ID)
+		if pageNo < 3 {
+			if !page.HasMore || page.NextCursor == "" {
+				t.Fatalf("page %d must report more rows follow", pageNo)
+			}
+			cursor = &page.NextCursor
+		} else if page.HasMore || page.NextCursor != "" {
+			t.Fatalf("page 3 is genuine exhaustion — has_more must not lie")
+		}
+	}
+	if walked[1] != r2 || walked[2] != r3 {
+		t.Fatalf("walk order = %v, want [genesis, %v, %v]", walked, r2, r3)
+	}
+	seen := map[ids.UUID]bool{}
+	for _, id := range walked {
+		if seen[id] {
+			t.Fatalf("row %v served on two pages — keyset overlap", id)
+		}
+		seen[id] = true
+	}
+}
+
+// TestRecordHistoryHonestEmptyPageBeyondTheFinalRow: every store write
+// audits itself, so a VISIBLE record with a truly empty spine cannot be
+// seeded honestly through the stores — the honest zero-match construction
+// is a cursor positioned past the record's final row: the full gate stack
+// still runs, and the scan matches nothing.
+func TestRecordHistoryHonestEmptyPageBeyondTheFinalRow(t *testing.T) {
+	e := Setup(t)
+	personID := e.SeedPerson(t, "Quiet Subject", nil)
+
+	full, err := privacy.ListRecordHistory(e.Admin(), e.Pool, privacy.RecordHistoryFilter{
+		EntityType: "person", EntityID: personID,
+	})
+	if err != nil {
+		t.Fatalf("full list: %v", err)
+	}
+	if len(full.Entries) == 0 {
+		t.Fatal("SeedPerson must have audited its own create — harness drift")
+	}
+	last := full.Entries[len(full.Entries)-1]
+	pastTheEnd := storekit.EncodeCursor(last.OccurredAt, last.ID)
+
+	page, err := privacy.ListRecordHistory(e.Admin(), e.Pool, privacy.RecordHistoryFilter{
+		EntityType: "person", EntityID: personID, Cursor: &pastTheEnd,
+	})
+	if err != nil {
+		t.Fatalf("empty page must not error: %v", err)
+	}
+	if page.Entries == nil || len(page.Entries) != 0 || page.HasMore || page.NextCursor != "" {
+		t.Fatalf("want honest empty page (non-nil, zero entries, no more): %+v", page)
+	}
+}
+
+func TestRecordHistoryMalformedCursorIsAClientFault(t *testing.T) {
+	e := Setup(t)
+	personID := e.SeedPerson(t, "Cursor Subject", nil)
+	bad := "%%%not-a-cursor"
+	_, err := privacy.ListRecordHistory(e.Admin(), e.Pool, privacy.RecordHistoryFilter{
+		EntityType: "person", EntityID: personID, Cursor: &bad,
+	})
+	var malformed *storekit.MalformedCursorError
+	if !errors.As(err, &malformed) {
+		t.Fatalf("err = %v, want *storekit.MalformedCursorError untouched", err)
+	}
+}

--- a/backend/internal/compose/integration/recordhistory_integration_test.go
+++ b/backend/internal/compose/integration/recordhistory_integration_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/gradionhq/margince/backend/internal/modules/activities"
 	"github.com/gradionhq/margince/backend/internal/modules/privacy"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
@@ -313,6 +314,88 @@ func TestRecordHistoryHonestEmptyPageBeyondTheFinalRow(t *testing.T) {
 	}
 	if page.Entries == nil || len(page.Entries) != 0 || page.HasMore || page.NextCursor != "" {
 		t.Fatalf("want honest empty page (non-nil, zero entries, no more): %+v", page)
+	}
+}
+
+// TestRecordHistoryErasureBoundsCollateralScrubs mirrors the field-history
+// sibling (TestFieldHistoryErasureBoundsCollateralScrubs): the eraser's
+// reach is entity-generic — it doesn't stop at the person it was called
+// on. The lead twin shares the subject's email (the tie the eraser
+// follows) and the activity carries the subject's name in its subject
+// line; both create images predate the scrub and both records get their
+// OWN erase tombstone. Record-history must honor the same
+// tombstone-inclusive cut on every collaterally-scrubbed record: every
+// pre-erasure line withheld, the erase line itself served with empty
+// images, and the pre-erasure email never surfacing in any entry.
+func TestRecordHistoryErasureBoundsCollateralScrubs(t *testing.T) {
+	e := Setup(t)
+	personID := e.SeedPerson(t, "Selma Subject", nil)
+	const twinEmail = "selma.twin@example.test"
+	// The subject's address is what ties the twin to the person: the
+	// eraser wipes any lead carrying one of the subject's emails.
+	e.WsExec(t, `INSERT INTO person_email (workspace_id, person_id, email, source, captured_by)
+		 VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, 'manual', 'human:x')`,
+		personID, twinEmail)
+	leadID := seedLead(t, e, "Selma Subject", twinEmail, nil)
+
+	activity, _, err := e.Activities.LogActivity(e.Admin(), activities.LogActivityInput{
+		Kind: "note", Subject: strPtr("Call with Selma"), Source: "manual",
+		Links: []activities.ActivityLinkInput{{EntityType: "person", EntityID: personID}},
+	})
+	if err != nil {
+		t.Fatalf("log activity: %v", err)
+	}
+
+	if err := privacy.NewEraser(e.Pool).ErasePerson(e.Admin(), personID, "dsr"); err != nil {
+		t.Fatalf("erase: %v", err)
+	}
+
+	targets := []struct {
+		entityType string
+		id         ids.UUID
+	}{
+		{"lead", leadID.UUID},
+		{"activity", ids.UUID(activity.Id)},
+	}
+	for _, target := range targets {
+		page, err := privacy.ListRecordHistory(e.Admin(), e.Pool, privacy.RecordHistoryFilter{
+			EntityType: target.entityType, EntityID: target.id,
+		})
+		if err != nil {
+			t.Fatalf("%s record-history: %v", target.entityType, err)
+		}
+		// Tombstone-inclusive boundary: exactly the collateral erase line
+		// survives, every pre-erasure line (the twin's create, the
+		// activity's create) is withheld.
+		if len(page.Entries) != 1 || page.HasMore || page.NextCursor != "" {
+			t.Fatalf("%s: entries = %d (has_more=%v cursor=%q), want exactly the tombstone: %+v",
+				target.entityType, len(page.Entries), page.HasMore, page.NextCursor, page.Entries)
+		}
+		tomb := page.Entries[0]
+		if tomb.Action != "erase" {
+			t.Fatalf("%s surviving line action = %q, want erase", target.entityType, tomb.Action)
+		}
+		if len(tomb.Before) != 0 || len(tomb.After) != 0 {
+			t.Errorf("%s tombstone images must be empty (meta rides evidence): before %v after %v",
+				target.entityType, tomb.Before, tomb.After)
+		}
+		// Belt-and-braces on the concrete PII, independent of the entry
+		// count above: the pre-erasure email must not surface in ANY
+		// entry's actor id, summary, or before/after images.
+		for _, entry := range page.Entries {
+			if strings.Contains(entry.Summary, twinEmail) || strings.Contains(entry.ActorID, twinEmail) {
+				t.Errorf("%s entry %s leaked the erased email in actor/summary: %+v",
+					target.entityType, entry.Action, entry)
+			}
+			for field, images := range map[string]map[string]any{"before": entry.Before, "after": entry.After} {
+				for k, v := range images {
+					if s, ok := v.(string); ok && strings.Contains(s, twinEmail) {
+						t.Errorf("%s entry %s leaked the erased email in %s[%s]: %v",
+							target.entityType, entry.Action, field, k, v)
+					}
+				}
+			}
+		}
 	}
 }
 

--- a/backend/internal/compose/server.go
+++ b/backend/internal/compose/server.go
@@ -3,12 +3,13 @@
 
 package compose
 
-// The contract HTTP surface: module transport handlers shadow the
-// generated-interface stubs by embedding depth (the Server struct below
-// is the inventory), so every one of the contract's operations
-// either runs real module code or answers an explicit 501 — never a
-// silent 404. The chassis (headers, correlation, panic recovery) is
-// platform/httpserver; what lives here is the wiring.
+// The contract HTTP surface: module transport handlers, aggregated by
+// embedding (the Server struct below is the inventory), together cover
+// every operation crmcontracts.ServerInterface declares — there is no
+// generated-stub fallback left; a module gap now fails the build's
+// `var _ crmcontracts.ServerInterface = Server{}` assertion rather than
+// answering a silent 501. The chassis (headers, correlation, panic
+// recovery) is platform/httpserver; what lives here is the wiring.
 
 import (
 	"context"
@@ -44,12 +45,6 @@ import (
 	"github.com/gradionhq/margince/backend/web"
 )
 
-// fallback pushes the stubs one embedding level deeper than the module
-// handlers, so a module method always wins promotion and the stub only
-// answers operations nothing implements yet (currently: GetRecordHistory,
-// pending the privacy module handler).
-type fallback struct{ stubs }
-
 // Aliases give the embedded handler sets distinct field names; each
 // alias carries its module's full method set.
 type (
@@ -67,10 +62,10 @@ type (
 	voiceHandlers       = ai.Handlers
 )
 
-// Server satisfies crmcontracts.ServerInterface by embedding: the module
-// transport handlers at depth one shadow the depth-two stubs, so an
-// operation with no module handler yet resolves to its generated 501
-// (stubs_gen.go) rather than failing the build.
+// Server satisfies crmcontracts.ServerInterface by embedding: every
+// operation the contract declares resolves to exactly one of these
+// handler sets' methods — a module gap is a compile error, not a
+// runtime 501.
 type Server struct {
 	authHandlers
 	peopleHandlers
@@ -91,7 +86,6 @@ type Server struct {
 	imapConnectHandlers
 	filteredExportHandlers
 	orgRollupHandlers
-	fallback
 
 	// busReady is the /readyz bus probe, injected only by the process
 	// role that runs the inline relay — a split deployment's api answers

--- a/backend/internal/compose/server.go
+++ b/backend/internal/compose/server.go
@@ -44,6 +44,12 @@ import (
 	"github.com/gradionhq/margince/backend/web"
 )
 
+// fallback pushes the stubs one embedding level deeper than the module
+// handlers, so a module method always wins promotion and the stub only
+// answers operations nothing implements yet (currently: GetRecordHistory,
+// pending the privacy module handler).
+type fallback struct{ stubs }
+
 // Aliases give the embedded handler sets distinct field names; each
 // alias carries its module's full method set.
 type (
@@ -61,11 +67,10 @@ type (
 	voiceHandlers       = ai.Handlers
 )
 
-// Server satisfies crmcontracts.ServerInterface by embedding the module
-// transport handler sets. Every contract operation is implemented; the
-// generated stubs (stubs_gen.go) stay as the drift gate's inventory and
-// would resurface as a compile error here if a regenerated contract
-// added an operation nothing implements.
+// Server satisfies crmcontracts.ServerInterface by embedding: the module
+// transport handlers at depth one shadow the depth-two stubs, so an
+// operation with no module handler yet resolves to its generated 501
+// (stubs_gen.go) rather than failing the build.
 type Server struct {
 	authHandlers
 	peopleHandlers
@@ -86,6 +91,7 @@ type Server struct {
 	imapConnectHandlers
 	filteredExportHandlers
 	orgRollupHandlers
+	fallback
 
 	// busReady is the /readyz bus probe, injected only by the process
 	// role that runs the inline relay — a split deployment's api answers

--- a/backend/internal/compose/stubs_gen.go
+++ b/backend/internal/compose/stubs_gen.go
@@ -480,6 +480,10 @@ func (stubs) RevokeRecordGrant(w nethttp.ResponseWriter, r *nethttp.Request, id 
 	httperr.NotImplemented(w, r, "RevokeRecordGrant")
 }
 
+func (stubs) GetRecordHistory(w nethttp.ResponseWriter, r *nethttp.Request, entityType string, id crmcontracts.Id, params crmcontracts.GetRecordHistoryParams) {
+	httperr.NotImplemented(w, r, "GetRecordHistory")
+}
+
 func (stubs) ListRelationships(w nethttp.ResponseWriter, r *nethttp.Request, params crmcontracts.ListRelationshipsParams) {
 	httperr.NotImplemented(w, r, "ListRelationships")
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -276,6 +276,30 @@ func (e AttachmentEntityType) Valid() bool {
 	}
 }
 
+// Defines values for AuditHistoryEntryActorType.
+const (
+	AuditHistoryEntryActorTypeAgent     AuditHistoryEntryActorType = "agent"
+	AuditHistoryEntryActorTypeConnector AuditHistoryEntryActorType = "connector"
+	AuditHistoryEntryActorTypeHuman     AuditHistoryEntryActorType = "human"
+	AuditHistoryEntryActorTypeSystem    AuditHistoryEntryActorType = "system"
+)
+
+// Valid indicates whether the value is a known member of the AuditHistoryEntryActorType enum.
+func (e AuditHistoryEntryActorType) Valid() bool {
+	switch e {
+	case AuditHistoryEntryActorTypeAgent:
+		return true
+	case AuditHistoryEntryActorTypeConnector:
+		return true
+	case AuditHistoryEntryActorTypeHuman:
+		return true
+	case AuditHistoryEntryActorTypeSystem:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for AuditLogEntryAction.
 const (
 	ActivityRelink  AuditLogEntryAction = "activity_relink"
@@ -3251,22 +3275,22 @@ func (e GetFieldHistoryParamsEntityType) Valid() bool {
 
 // Defines values for GetFieldHistoryParamsActorType.
 const (
-	GetFieldHistoryParamsActorTypeAgent     GetFieldHistoryParamsActorType = "agent"
-	GetFieldHistoryParamsActorTypeConnector GetFieldHistoryParamsActorType = "connector"
-	GetFieldHistoryParamsActorTypeHuman     GetFieldHistoryParamsActorType = "human"
-	GetFieldHistoryParamsActorTypeSystem    GetFieldHistoryParamsActorType = "system"
+	Agent     GetFieldHistoryParamsActorType = "agent"
+	Connector GetFieldHistoryParamsActorType = "connector"
+	Human     GetFieldHistoryParamsActorType = "human"
+	System    GetFieldHistoryParamsActorType = "system"
 )
 
 // Valid indicates whether the value is a known member of the GetFieldHistoryParamsActorType enum.
 func (e GetFieldHistoryParamsActorType) Valid() bool {
 	switch e {
-	case GetFieldHistoryParamsActorTypeAgent:
+	case Agent:
 		return true
-	case GetFieldHistoryParamsActorTypeConnector:
+	case Connector:
 		return true
-	case GetFieldHistoryParamsActorTypeHuman:
+	case Human:
 		return true
-	case GetFieldHistoryParamsActorTypeSystem:
+	case System:
 		return true
 	default:
 		return false
@@ -3839,6 +3863,37 @@ type AttachmentEntityType string
 type AttachmentListResponse struct {
 	Data []Attachment `json:"data"`
 	Page PageInfo     `json:"page"`
+}
+
+// AuditHistoryEntry One rendered history line for a record mutation. `before`/`after` are
+// masked to the viewer's readable fields — an absent key was hidden, not null.
+// `summary` is server-composed plain language; field-level detail lives in
+// before/after for the client to render.
+type AuditHistoryEntry struct {
+	Action            string                     `json:"action"`
+	ActorId           string                     `json:"actor_id"`
+	ActorType         AuditHistoryEntryActorType `json:"actor_type"`
+	After             *map[string]interface{}    `json:"after,omitempty"`
+	AuthorizationRule *string                    `json:"authorization_rule,omitempty"`
+	Before            *map[string]interface{}    `json:"before,omitempty"`
+	Id                openapi_types.UUID         `json:"id"`
+	OccurredAt        time.Time                  `json:"occurred_at"`
+
+	// OnBehalfOf Granting human's user id for agent actions.
+	OnBehalfOf *openapi_types.UUID `json:"on_behalf_of,omitempty"`
+
+	// OnBehalfOfName Resolved display name for on_behalf_of.
+	OnBehalfOfName *string `json:"on_behalf_of_name,omitempty"`
+	Summary        string  `json:"summary"`
+}
+
+// AuditHistoryEntryActorType defines model for AuditHistoryEntry.ActorType.
+type AuditHistoryEntryActorType string
+
+// AuditHistoryListResponse defines model for AuditHistoryListResponse.
+type AuditHistoryListResponse struct {
+	Data []AuditHistoryEntry `json:"data"`
+	Page PageInfo            `json:"page"`
 }
 
 // AuditLogEntry An append-only audit row. Mirrors the `audit_log` table.
@@ -7515,6 +7570,20 @@ type RevokeRecordGrantParams struct {
 	// re-apply, retry. Omitting it is last-write-wins (discouraged for agent/automated writers).
 	// Accepted on every native (SoR-mode) mutating endpoint that returns a versioned entity.
 	IfMatch *IfMatch `json:"If-Match,omitempty"`
+}
+
+// GetRecordHistoryParams defines parameters for GetRecordHistory.
+type GetRecordHistoryParams struct {
+	// Cursor Opaque keyset cursor from a prior response's `page.next_cursor`. The cursor encodes the
+	// effective `sort` and `filter` of the originating request plus the last row's keyset
+	// (sort-key tuple + `id` tie-breaker). **Stability:** results are stable under concurrent
+	// inserts/updates (keyset pagination, not offset). Supplying `cursor` together with a `sort`
+	// or filter that differs from the one the cursor was minted under returns
+	// `422 code: cursor_param_mismatch` — re-issue the query without the cursor.
+	Cursor *Cursor `form:"cursor,omitempty" json:"cursor,omitempty"`
+
+	// Limit Max items in the page.
+	Limit *Limit `form:"limit,omitempty" json:"limit,omitempty"`
 }
 
 // ListRelationshipsParams defines parameters for ListRelationships.
@@ -12216,6 +12285,9 @@ type ServerInterface interface {
 	// Revoke a manual record grant. 🟡 — agent calls are queued behind the approval gate.
 	// (DELETE /record-grants/{id})
 	RevokeRecordGrant(w http.ResponseWriter, r *http.Request, id Id, params RevokeRecordGrantParams)
+	// Full audit history for one record, rendered as plain-language lines.
+	// (GET /records/{entity_type}/{id}/history)
+	GetRecordHistory(w http.ResponseWriter, r *http.Request, entityType string, id Id, params GetRecordHistoryParams)
 	// List relationships (employment, deal_stakeholder, or partner edges).
 	// (GET /relationships)
 	ListRelationships(w http.ResponseWriter, r *http.Request, params ListRelationshipsParams)
@@ -13020,6 +13092,12 @@ func (_ Unimplemented) CreateRecordGrant(w http.ResponseWriter, r *http.Request,
 // Revoke a manual record grant. 🟡 — agent calls are queued behind the approval gate.
 // (DELETE /record-grants/{id})
 func (_ Unimplemented) RevokeRecordGrant(w http.ResponseWriter, r *http.Request, id Id, params RevokeRecordGrantParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Full audit history for one record, rendered as plain-language lines.
+// (GET /records/{entity_type}/{id}/history)
+func (_ Unimplemented) GetRecordHistory(w http.ResponseWriter, r *http.Request, entityType string, id Id, params GetRecordHistoryParams) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -19298,6 +19376,76 @@ func (siw *ServerInterfaceWrapper) RevokeRecordGrant(w http.ResponseWriter, r *h
 	handler.ServeHTTP(w, r)
 }
 
+// GetRecordHistory operation middleware
+func (siw *ServerInterfaceWrapper) GetRecordHistory(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "entity_type" -------------
+	var entityType string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "entity_type", chi.URLParam(r, "entity_type"), &entityType, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "entity_type", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "id" -------------
+	var id Id
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", chi.URLParam(r, "id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetRecordHistoryParams
+
+	// ------------- Optional query parameter "cursor" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "cursor", r.URL.Query(), &params.Cursor, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "cursor"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "cursor", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "limit" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "limit", r.URL.Query(), &params.Limit, runtime.BindQueryParameterOptions{Type: "integer", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "limit"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "limit", Err: err})
+		}
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetRecordHistory(w, r, entityType, id, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // ListRelationships operation middleware
 func (siw *ServerInterfaceWrapper) ListRelationships(w http.ResponseWriter, r *http.Request) {
 
@@ -21432,6 +21580,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Delete(options.BaseURL+"/record-grants/{id}", wrapper.RevokeRecordGrant)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/records/{entity_type}/{id}/history", wrapper.GetRecordHistory)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/relationships", wrapper.ListRelationships)

--- a/backend/internal/modules/privacy/erasure.go
+++ b/backend/internal/modules/privacy/erasure.go
@@ -128,8 +128,12 @@ func (e *Eraser) ErasePerson(ctx context.Context, personID ids.UUID, reason stri
 		}
 
 		// The tombstone: action=erase with counts only — proof without
-		// PII. The paired event tells consumers the subject is gone.
-		auditID, err := storekit.Audit(ctx, tx, actionErase, "person", subject.UUID, nil, map[string]any{
+		// PII. The counts are evidence ABOUT the scrub, so they ride the
+		// evidence column; before/after stay empty — they are reserved for
+		// field images, and the record-history read serves a tombstone's
+		// images verbatim. The paired event tells consumers the subject is
+		// gone.
+		auditID, err := storekit.AuditWithEvidence(ctx, tx, actionErase, "person", subject.UUID, nil, nil, map[string]any{
 			"reason": reason, "emails_suppressed": len(emails), "raw_rows_purged": rawPurged,
 			"activities_redacted": len(activitiesRedacted),
 		})
@@ -261,14 +265,16 @@ func anonymizeSubjectRows(ctx context.Context, tx pgx.Tx, personID ids.PersonID,
 // person's tombstone cannot bound a lead twin's or an activity's spine,
 // so without these the scrubbed records' historical audit images (a lead
 // create's email, an activity create's subject line) would project the
-// erased PII straight back out. The payload is meta-only, like the
-// person tombstone: it must never re-store what it certifies gone. No
+// erased PII straight back out. The scrub context rides evidence, like
+// the person tombstone's counts — before/after stay empty, because a
+// tombstone must never re-store what it certifies gone and its images
+// are served verbatim by the record-history read. No
 // paired outbox event on purpose: the erasure's single retention.applied
 // on the person is the bus-visible fact, and the collateral scrubs have
 // never announced themselves per record.
 func tombstoneCollateralScrubs(ctx context.Context, tx pgx.Tx, entityType string, records []ids.UUID, reason string) error {
 	for _, id := range records {
-		if _, err := storekit.Audit(ctx, tx, actionErase, entityType, id, nil, map[string]any{
+		if _, err := storekit.AuditWithEvidence(ctx, tx, actionErase, entityType, id, nil, nil, map[string]any{
 			"reason": reason, "cause": "person_erasure",
 		}); err != nil {
 			return fmt.Errorf("tombstoning scrubbed %s: %w", entityType, err)

--- a/backend/internal/modules/privacy/fieldhistory.go
+++ b/backend/internal/modules/privacy/fieldhistory.go
@@ -286,7 +286,7 @@ func ListFieldHistory(ctx context.Context, pool *pgxpool.Pool, f FieldHistoryFil
 		if visErr != nil {
 			return visErr
 		}
-		boundary, err := latestScrubTombstone(ctx, tx, f)
+		boundary, err := latestScrubTombstone(ctx, tx, f.EntityType, f.EntityID)
 		if err != nil {
 			return err
 		}
@@ -390,16 +390,18 @@ func (b scrubBoundary) exists() bool { return !b.occurredAt.IsZero() }
 // fieldHistoryScrubActions); the zero boundary when the record was never
 // scrubbed. Everything at or before that position is exactly the PII the
 // scrub removed from the live row — the append-only spine still holds
-// those field images, so the read must refuse them; the tombstone's own
-// payload (suppression tallies) is withheld with them.
-func latestScrubTombstone(ctx context.Context, tx pgx.Tx, f FieldHistoryFilter) (scrubBoundary, error) {
+// those field images, so a read must refuse them. The two spine reads
+// apply the boundary differently: field-history withholds the tombstone
+// row too (its diff would fabricate entries), record-history serves it as
+// its own honest line — see each read's WHERE assembly.
+func latestScrubTombstone(ctx context.Context, tx pgx.Tx, entityType string, entityID ids.UUID) (scrubBoundary, error) {
 	var b scrubBoundary
 	err := tx.QueryRow(ctx, `
 		SELECT occurred_at, id FROM audit_log
 		WHERE entity_type = $1 AND entity_id = $2 AND action = ANY($3)
 		ORDER BY occurred_at DESC, id DESC
 		LIMIT 1`,
-		f.EntityType, f.EntityID, fieldHistoryScrubActions).Scan(&b.occurredAt, &b.id)
+		entityType, entityID, fieldHistoryScrubActions).Scan(&b.occurredAt, &b.id)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return scrubBoundary{}, nil
 	}

--- a/backend/internal/modules/privacy/fieldhistory_test.go
+++ b/backend/internal/modules/privacy/fieldhistory_test.go
@@ -70,9 +70,10 @@ func TestDiffRemovedFieldEmitsNilNewValue(t *testing.T) {
 }
 
 func TestDiffErasureTombstoneEmitsNothing(t *testing.T) {
-	// The real tombstone shape (erasure.go): action=erase, before=nil,
-	// after carrying the suppression tallies — proof of the scrub, not
-	// field images. None of its keys may surface as field changes.
+	// The real tombstone (erasure.go) carries nil images with its
+	// suppression tallies in evidence; this pins the belt-and-braces
+	// guard for the mis-written shape — a tombstone whose tallies landed
+	// in after must STILL project nothing, on the action alone.
 	row := fhRow("system", nil, map[string]any{
 		"reason": "dsr", "emails_suppressed": 2.0, "raw_rows_purged": 1.0, "activities_redacted": 3.0,
 	})

--- a/backend/internal/modules/privacy/handlers_recordhistory.go
+++ b/backend/internal/modules/privacy/handlers_recordhistory.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package privacy
+
+import (
+	"net/http"
+
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/platform/httperr"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// GetRecordHistory implements (GET /records/{entity_type}/{id}/history).
+// entityType arrives as a bare, generator-unvalidated string (an inline
+// path param, not a named enum type) — this handler is the only
+// enforcement point for the [person, organization, deal, lead, activity]
+// vocabulary, same as GetFieldHistory's entity_type query param.
+func (h Handlers) GetRecordHistory(w http.ResponseWriter, r *http.Request,
+	entityType string, id crmcontracts.Id, params crmcontracts.GetRecordHistoryParams,
+) {
+	if !fieldHistoryEntityTypes[entityType] {
+		httperr.Write(w, r, httperr.Validation("entity_type", "invalid_entity_type",
+			"entity_type must be one of person, organization, deal, lead, activity"))
+		return
+	}
+	f := RecordHistoryFilter{
+		EntityType: entityType,
+		EntityID:   ids.UUID(id),
+		Cursor:     params.Cursor,
+		Limit:      params.Limit,
+	}
+
+	page, err := ListRecordHistory(r.Context(), h.pool, f)
+	if err != nil {
+		httperr.Write(w, r, err)
+		return
+	}
+
+	data := make([]crmcontracts.AuditHistoryEntry, 0, len(page.Entries))
+	for _, entry := range page.Entries {
+		data = append(data, recordHistoryEntryToWire(entry))
+	}
+	resp := crmcontracts.AuditHistoryListResponse{
+		Data: data,
+		Page: crmcontracts.PageInfo{HasMore: page.HasMore},
+	}
+	if page.NextCursor != "" {
+		resp.Page.NextCursor = &page.NextCursor
+	}
+	httperr.WriteJSON(w, http.StatusOK, resp)
+}
+
+// recordHistoryEntryToWire mirrors fieldHistoryEntryToWire's conversion
+// style: uuid ids pass through openapi_types.UUID, a nullable uuid only
+// sets the pointer when present, and before/after — already masked by
+// omission in recordHistoryEntry — stay absent (a nil pointer, never an
+// empty object) when the store recorded no image for that side, so a
+// hidden key can never resurface as a phantom entry on the wire.
+func recordHistoryEntryToWire(e RecordHistoryEntry) crmcontracts.AuditHistoryEntry {
+	out := crmcontracts.AuditHistoryEntry{
+		Id:                openapi_types.UUID(e.ID),
+		ActorType:         crmcontracts.AuditHistoryEntryActorType(e.ActorType),
+		ActorId:           e.ActorID,
+		Action:            e.Action,
+		OccurredAt:        e.OccurredAt,
+		AuthorizationRule: e.AuthorizationRule,
+		OnBehalfOfName:    e.OnBehalfOfName,
+		Summary:           e.Summary,
+	}
+	if e.OnBehalfOf != nil {
+		onBehalfOf := openapi_types.UUID(*e.OnBehalfOf)
+		out.OnBehalfOf = &onBehalfOf
+	}
+	if e.Before != nil {
+		before := e.Before
+		out.Before = &before
+	}
+	if e.After != nil {
+		after := e.After
+		out.After = &after
+	}
+	return out
+}

--- a/backend/internal/modules/privacy/recordhistory.go
+++ b/backend/internal/modules/privacy/recordhistory.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package privacy
+
+import "fmt"
+
+// Actor-type and action literals that recur across this file (map key,
+// switch case, occurrence count 3+ once this file joins fieldhistory.go/
+// retention.go) — named once so goconst has one extraction target instead
+// of flagging each new occurrence.
+const (
+	actorTypeAgent     = "agent"
+	actorTypeHuman     = "human"
+	actorTypeSystem    = "system"
+	actorTypeConnector = "connector"
+	actionArchive      = "archive"
+)
+
+// recordHistoryVerbs renders each audit_log action as a past-tense phrase
+// for composeRecordSummary. The set here is reconciled to the CHECK
+// constraint's admitted vocabulary (migrations/core/0053_audit_verb_
+// vocabulary.up.sql, 25 verbs); TestRecordHistoryVerbsCoverTheAuditCheckVocabulary
+// parses that file directly and fails if a future widening lands without a
+// matching entry here. An action absent from the map (defensive only — the
+// CHECK already closes the set at the DB level) falls back to the raw
+// string, never an error: an unrenderable phrase is still honest history.
+var recordHistoryVerbs = map[string]string{
+	"create":           "created",
+	"update":           "updated",
+	actionArchive:      "archived",
+	"merge":            "merged",
+	"promote":          "promoted",
+	"restore":          "restored",
+	"export":           "exported",
+	"erase":            "erased",
+	"login":            "logged in",
+	"assign":           "assigned",
+	"advance_stage":    "advanced the stage of",
+	"approve":          "approved",
+	"reject":           "rejected",
+	"consent_grant":    "granted consent for",
+	"consent_withdraw": "withdrew consent for",
+	"activity_relink":  "relinked",
+	"record_share":     "shared",
+	"record_unshare":   "unshared",
+	"resolve":          "resolved",
+	"demote":           "demoted",
+	"import":           "imported",
+	"import_undo":      "undid the import of",
+	"disqualify":       "disqualified",
+	"anonymize":        "anonymized",
+	"send_email":       "sent an email for",
+}
+
+// composeRecordSummary renders one audit row as a plain-language sentence,
+// the record-history read's `summary` field. It is pure: callers resolve
+// actorDisplayName/onBehalfOfName (app_user lookups) before calling in, so
+// this stays testable without a database. onBehalfOfName is set only for
+// an agent acting under a human's delegated authority (D2's authority
+// weaving); an empty string is treated the same as nil — a resolved-but-
+// blank name is not authority to report.
+func composeRecordSummary(actorType, actorDisplayName string, onBehalfOfName *string, action string) string {
+	verb := recordHistoryVerbs[action]
+	if verb == "" {
+		verb = action
+	}
+	switch actorType {
+	case actorTypeAgent:
+		if onBehalfOfName != nil && *onBehalfOfName != "" {
+			return fmt.Sprintf("Agent acting for %s %s the record", *onBehalfOfName, verb)
+		}
+		return fmt.Sprintf("Agent %s the record", verb)
+	case actorTypeHuman:
+		return fmt.Sprintf("%s %s the record", actorDisplayName, verb)
+	case actorTypeSystem:
+		return fmt.Sprintf("System %s the record", verb)
+	case actorTypeConnector:
+		return fmt.Sprintf("Connector %s the record", verb)
+	default:
+		return fmt.Sprintf("%s %s the record", actorType, verb)
+	}
+}

--- a/backend/internal/modules/privacy/recordhistory.go
+++ b/backend/internal/modules/privacy/recordhistory.go
@@ -80,8 +80,11 @@ type RecordHistoryFilter struct {
 // RecordHistoryEntry is one audit_log row rendered as a history line —
 // the whole-mutation view, one entry per row (field-history's per-field
 // projection is the sibling read). Before/After are the row's own field
-// images with the entity's mask applied by omission; operational meta
-// rides audit_log.evidence, which this read never selects.
+// images with the entity's mask applied by omission. Scrub tombstones and
+// retention rows carry their operational tallies on audit_log.evidence,
+// which this read never selects; other meta verbs' before/after payloads
+// are served verbatim—workspace-operational context behind the same
+// record-read gate, never subject PII.
 type RecordHistoryEntry struct {
 	ID                ids.UUID
 	ActorType         string
@@ -156,8 +159,11 @@ func recordHistoryEntry(row recordAuditRow, mask entityFieldMask) RecordHistoryE
 //
 // Unlike field-history there is no action allowlist: a merge or export
 // line IS the point of this view. Payload honesty is inherited instead —
-// meta writers put operation metadata in audit_log.evidence, and this
-// read never selects that column.
+// scrub tombstones and retention rows carry operational tallies on
+// audit_log.evidence, which this read never selects; other meta verbs
+// (merge, promote, export, record_share, enrich, coldstart) serve
+// operational context verbatim from before/after, workspace-operational
+// data behind the same record-read gate, never subject PII.
 func ListRecordHistory(ctx context.Context, pool *pgxpool.Pool, f RecordHistoryFilter) (RecordHistoryPage, error) {
 	actor, ok := principal.Actor(ctx)
 	if !ok || actor.Type != principal.PrincipalHuman {

--- a/backend/internal/modules/privacy/recordhistory.go
+++ b/backend/internal/modules/privacy/recordhistory.go
@@ -3,7 +3,22 @@
 
 package privacy
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
 
 // Actor-type and action literals that recur across this file (map key,
 // switch case, occurrence count 3+ once this file joins fieldhistory.go/
@@ -51,6 +66,219 @@ var recordHistoryVerbs = map[string]string{
 	"disqualify":       "disqualified",
 	"anonymize":        "anonymized",
 	"send_email":       "sent an email for",
+}
+
+// RecordHistoryFilter carries the validated query surface of
+// (GET /records/{entity_type}/{id}/history).
+type RecordHistoryFilter struct {
+	EntityType string
+	EntityID   ids.UUID
+	Cursor     *string
+	Limit      *int
+}
+
+// RecordHistoryEntry is one audit_log row rendered as a history line —
+// the whole-mutation view, one entry per row (field-history's per-field
+// projection is the sibling read). Before/After are the row's own field
+// images with the entity's mask applied by omission; operational meta
+// rides audit_log.evidence, which this read never selects.
+type RecordHistoryEntry struct {
+	ID                ids.UUID
+	ActorType         string
+	ActorID           string
+	OnBehalfOf        *ids.UUID
+	OnBehalfOfName    *string
+	Action            string
+	OccurredAt        time.Time
+	AuthorizationRule *string
+	Before            map[string]any
+	After             map[string]any
+	Summary           string
+}
+
+// RecordHistoryPage is one keyset window of the timeline, chronological
+// (oldest first — the reading order of a story, unlike field-history's
+// newest-first diff feed).
+type RecordHistoryPage struct {
+	Entries    []RecordHistoryEntry
+	NextCursor string
+	HasMore    bool
+}
+
+// recordAuditRow carries one scanned audit_log row plus its resolved
+// display names, ready for the pure entry transform.
+type recordAuditRow struct {
+	id                ids.UUID
+	actorType         string
+	actorID           string
+	onBehalfOf        *ids.UUID
+	action            string
+	occurredAt        time.Time
+	authorizationRule *string
+	before            map[string]any
+	after             map[string]any
+	actorDisplayName  *string
+	onBehalfOfName    *string
+}
+
+// recordHistoryEntry renders one audit row as a history entry: mask both
+// payload sides by omission (hiding history and live value is one motion),
+// then compose the plain-language line. The actor display falls back to
+// the raw prefixed actor_id when no app_user resolves — an honest
+// identifier, never an invented name; agent/connector/system ids never
+// resolve, and their lines render from their own branch (an agent's human
+// context is the on-behalf-of authority, nothing else).
+func recordHistoryEntry(row recordAuditRow, mask entityFieldMask) RecordHistoryEntry {
+	display := row.actorID
+	if row.actorDisplayName != nil && *row.actorDisplayName != "" {
+		display = *row.actorDisplayName
+	}
+	return RecordHistoryEntry{
+		ID:                row.id,
+		ActorType:         row.actorType,
+		ActorID:           row.actorID,
+		OnBehalfOf:        row.onBehalfOf,
+		OnBehalfOfName:    row.onBehalfOfName,
+		Action:            row.action,
+		OccurredAt:        row.occurredAt,
+		AuthorizationRule: row.authorizationRule,
+		Before:            applyFieldMask(row.before, mask),
+		After:             applyFieldMask(row.after, mask),
+		Summary:           composeRecordSummary(row.actorType, display, row.onBehalfOfName, row.action),
+	}
+}
+
+// ListRecordHistory reads one record's whole-mutation timeline — every
+// audit verb, one line per row — inside a single workspace tx. The gate
+// stack is ListFieldHistory's, verbatim: a human session, object-level
+// read on the entity type, and the row-scope visibility check (out of
+// scope reads as not-found, indistinguishable from not-there).
+//
+// Unlike field-history there is no action allowlist: a merge or export
+// line IS the point of this view. Payload honesty is inherited instead —
+// meta writers put operation metadata in audit_log.evidence, and this
+// read never selects that column.
+func ListRecordHistory(ctx context.Context, pool *pgxpool.Pool, f RecordHistoryFilter) (RecordHistoryPage, error) {
+	actor, ok := principal.Actor(ctx)
+	if !ok || actor.Type != principal.PrincipalHuman {
+		return RecordHistoryPage{}, apperrors.ErrPermissionDenied
+	}
+	if !fieldHistoryEntityTypes[f.EntityType] {
+		return RecordHistoryPage{}, fmt.Errorf("record-history entity %q: %w", f.EntityType, apperrors.ErrNotFound)
+	}
+	if err := auth.Require(ctx, f.EntityType, principal.ActionRead); err != nil {
+		return RecordHistoryPage{}, err
+	}
+
+	limit := storekit.ClampLimit(f.Limit)
+	var cursor storekit.Cursor
+	useCursor := false
+	if f.Cursor != nil && *f.Cursor != "" {
+		c, err := storekit.DecodeCursor(*f.Cursor)
+		if err != nil {
+			return RecordHistoryPage{}, err
+		}
+		cursor, useCursor = c, true
+	}
+	mask := defaultFieldMasks[f.EntityType]
+
+	page := RecordHistoryPage{Entries: []RecordHistoryEntry{}}
+	err := database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
+		// activity carries no owner_id — it row-scopes through its links,
+		// so its visibility check dispatches to EnsureActivityVisible.
+		var visErr error
+		if f.EntityType == entityTypeActivity {
+			visErr = auth.EnsureActivityVisible(ctx, tx, f.EntityID)
+		} else {
+			visErr = auth.EnsureVisible(ctx, tx, f.EntityType, f.EntityID)
+		}
+		if visErr != nil {
+			return visErr
+		}
+		boundary, err := latestScrubTombstone(ctx, tx, f.EntityType, f.EntityID)
+		if err != nil {
+			return err
+		}
+		rows, err := queryRecordHistoryWindow(ctx, tx, f, boundary, cursor, useCursor, limit+1)
+		if err != nil {
+			return err
+		}
+		if len(rows) > limit {
+			rows = rows[:limit]
+			page.HasMore = true
+			page.NextCursor = storekit.EncodeCursor(rows[limit-1].occurredAt, rows[limit-1].id)
+		}
+		for _, row := range rows {
+			page.Entries = append(page.Entries, recordHistoryEntry(row, mask))
+		}
+		return nil
+	})
+	if err != nil {
+		return RecordHistoryPage{}, err
+	}
+	return page, nil
+}
+
+// queryRecordHistoryWindow fetches one chronological keyset window of the
+// record's audit spine, with both display-name joins resolved in SQL. The
+// actor join builds the prefixed key FROM app_user ('human:' || id), so a
+// non-UUID actor_id (agent:*, connector:*, system) simply resolves to no
+// name — never a cast error. RLS carries the workspace scope on both
+// tables, exactly like every sibling read.
+func queryRecordHistoryWindow(ctx context.Context, tx pgx.Tx, f RecordHistoryFilter,
+	boundary scrubBoundary, cursor storekit.Cursor, useCursor bool, fetch int,
+) ([]recordAuditRow, error) {
+	conds := []string{"a.entity_type = $1", "a.entity_id = $2"}
+	args := []any{f.EntityType, f.EntityID}
+	if boundary.exists() {
+		// Tombstone-INCLUSIVE (>=), where field-history cuts strictly
+		// after (>): projecting a tombstone's payload as field diffs would
+		// fabricate changes, so that read withholds the row — but here the
+		// tombstone renders as its own honest line ("… erased the
+		// record"), and its images are empty since the scrub meta rides
+		// evidence. Everything strictly older is still the PII the scrub
+		// certified gone, and stays withheld.
+		conds = append(conds, fmt.Sprintf("(a.occurred_at, a.id) >= ($%d, $%d)", len(args)+1, len(args)+2))
+		args = append(args, boundary.occurredAt, boundary.id)
+	}
+	if useCursor {
+		conds = append(conds, fmt.Sprintf("(a.occurred_at, a.id) > ($%d, $%d)", len(args)+1, len(args)+2))
+		args = append(args, cursor.CreatedAt, cursor.ID)
+	}
+	args = append(args, fetch)
+	rows, err := tx.Query(ctx, fmt.Sprintf(`
+		SELECT a.id, a.actor_type, a.actor_id, a.on_behalf_of, a.action, a.occurred_at,
+		       a.authorization_rule, a.before, a.after,
+		       actor_user.display_name, obo.display_name
+		FROM audit_log a
+		LEFT JOIN app_user actor_user
+		  ON a.actor_type = 'human' AND a.actor_id = 'human:' || actor_user.id::text
+		LEFT JOIN app_user obo ON obo.id = a.on_behalf_of
+		WHERE %s
+		ORDER BY a.occurred_at ASC, a.id ASC
+		LIMIT $%d`, strings.Join(conds, " AND "), len(args)), args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []recordAuditRow
+	for rows.Next() {
+		var r recordAuditRow
+		var beforeJSON, afterJSON []byte
+		if err := rows.Scan(&r.id, &r.actorType, &r.actorID, &r.onBehalfOf, &r.action, &r.occurredAt,
+			&r.authorizationRule, &beforeJSON, &afterJSON, &r.actorDisplayName, &r.onBehalfOfName); err != nil {
+			return nil, err
+		}
+		if err := unmarshalJSONBMap(beforeJSON, &r.before); err != nil {
+			return nil, fmt.Errorf("audit row %s before: %w", r.id, err)
+		}
+		if err := unmarshalJSONBMap(afterJSON, &r.after); err != nil {
+			return nil, fmt.Errorf("audit row %s after: %w", r.id, err)
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
 }
 
 // composeRecordSummary renders one audit row as a plain-language sentence,

--- a/backend/internal/modules/privacy/recordhistory_test.go
+++ b/backend/internal/modules/privacy/recordhistory_test.go
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package privacy
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func strPtr(s string) *string { return &s }
+
+func TestComposeRecordSummary(t *testing.T) {
+	tests := []struct {
+		name             string
+		actorType        string
+		actorDisplayName string
+		onBehalfOfName   *string
+		action           string
+		want             string
+	}{
+		{
+			name:             "human",
+			actorType:        "human",
+			actorDisplayName: "Alice",
+			action:           "update",
+			want:             "Alice updated the record",
+		},
+		{
+			name:             "agent acting with authority",
+			actorType:        "agent",
+			actorDisplayName: "Bot",
+			onBehalfOfName:   strPtr("Devin"),
+			action:           "archive",
+			want:             "Agent acting for Devin archived the record",
+		},
+		{
+			name:             "agent without authority",
+			actorType:        "agent",
+			actorDisplayName: "Bot",
+			action:           "create",
+			want:             "Agent created the record",
+		},
+		{
+			name:             "agent with empty onBehalfOfName treated as absent",
+			actorType:        "agent",
+			actorDisplayName: "Bot",
+			onBehalfOfName:   strPtr(""),
+			action:           "create",
+			want:             "Agent created the record",
+		},
+		{
+			name:             "system",
+			actorType:        "system",
+			actorDisplayName: "system",
+			action:           "export",
+			want:             "System exported the record",
+		},
+		{
+			name:             "connector",
+			actorType:        "connector",
+			actorDisplayName: "hubspot-sync",
+			action:           "import",
+			want:             "Connector imported the record",
+		},
+		{
+			name:             "unrecognized actor type falls back to the raw type as its own subject",
+			actorType:        "robot",
+			actorDisplayName: "Robot",
+			action:           "update",
+			want:             "robot updated the record",
+		},
+		{
+			name:             "unknown action falls back to the raw action string, never an error",
+			actorType:        "human",
+			actorDisplayName: "Alice",
+			action:           "frobnicate",
+			want:             "Alice frobnicate the record",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := composeRecordSummary(tt.actorType, tt.actorDisplayName, tt.onBehalfOfName, tt.action)
+			if got != tt.want {
+				t.Errorf("composeRecordSummary(%q, %q, %v, %q) = %q, want %q",
+					tt.actorType, tt.actorDisplayName, tt.onBehalfOfName, tt.action, got, tt.want)
+			}
+		})
+	}
+}
+
+// checkVocabularyPath is relative to this package directory
+// (backend/internal/modules/privacy), the same "walk up to the repo tree"
+// style as backend/license_test.go and backend/arch_test.go use from the
+// backend root — here the fixed point is one file, not the whole tree.
+const checkVocabularyPath = "../../../migrations/core/0053_audit_verb_vocabulary.up.sql"
+
+// auditActionCheckClause matches the single-quoted literal list inside the
+// audit_log_action_check CHECK constraint, across its multi-line layout.
+var auditActionCheckLiteral = regexp.MustCompile(`'([a-z_]+)'`)
+
+// verbsFromCheckConstraint parses 0053's CHECK(action IN (...)) clause and
+// returns every admitted verb. This is the fitness function (repo rule 2):
+// the expected verb set is derived from the migration file itself, not
+// copied by hand into the test — so a future widening of the CHECK without
+// a matching rendering phrase fails this test instead of silently falling
+// back to the raw action string at render time.
+func verbsFromCheckConstraint(t *testing.T) []string {
+	t.Helper()
+	raw, err := os.ReadFile(checkVocabularyPath) // #nosec G304 -- fixed repo-relative path, test-only
+	if err != nil {
+		t.Fatalf("reading %s: %v", checkVocabularyPath, err)
+	}
+	text := string(raw)
+	start := strings.Index(text, "action IN (")
+	if start == -1 {
+		t.Fatalf("%s: no \"action IN (\" clause found — has the constraint been renamed?", checkVocabularyPath)
+	}
+	clause := text[start:]
+	end := strings.Index(clause, ")")
+	if end == -1 {
+		t.Fatalf("%s: unterminated \"action IN (\" clause", checkVocabularyPath)
+	}
+	clause = clause[:end]
+	matches := auditActionCheckLiteral.FindAllStringSubmatch(clause, -1)
+	if len(matches) == 0 {
+		t.Fatalf("%s: matched the IN clause but found no quoted verbs inside it", checkVocabularyPath)
+	}
+	verbs := make([]string, 0, len(matches))
+	for _, m := range matches {
+		verbs = append(verbs, m[1])
+	}
+	return verbs
+}
+
+func TestRecordHistoryVerbsCoverTheAuditCheckVocabulary(t *testing.T) {
+	verbs := verbsFromCheckConstraint(t)
+	if len(verbs) < 25 {
+		// A parse regression (e.g. the clause moved or the regex stopped
+		// matching) would silently pass an empty/short list otherwise —
+		// the known 0053 count is a floor, not a ceiling, so a widening
+		// migration after this one still passes.
+		t.Fatalf("parsed only %d verb(s) from %s, want at least 25 — parser likely broken: %v",
+			len(verbs), checkVocabularyPath, verbs)
+	}
+	var missing []string
+	for _, verb := range verbs {
+		if _, ok := recordHistoryVerbs[verb]; !ok {
+			missing = append(missing, verb)
+		}
+	}
+	if len(missing) > 0 {
+		t.Errorf("recordHistoryVerbs is missing a rendering phrase for: %s (every verb the audit_log_action_check CHECK admits must have one)",
+			strings.Join(missing, ", "))
+	}
+}

--- a/backend/internal/modules/privacy/recordhistory_test.go
+++ b/backend/internal/modules/privacy/recordhistory_test.go
@@ -135,6 +135,41 @@ func verbsFromCheckConstraint(t *testing.T) []string {
 	return verbs
 }
 
+func TestRecordHistoryEntryMasksBothPayloadSidesByOmission(t *testing.T) {
+	row := recordAuditRow{
+		actorType: "human", actorID: "human:x", action: "update",
+		before: map[string]any{"email": "old@x.com", "iban": "DE01"},
+		after:  map[string]any{"email": "new@x.com", "iban": "DE02"},
+	}
+
+	entry := recordHistoryEntry(row, entityFieldMask{"iban": {}})
+	for side, payload := range map[string]map[string]any{"before": entry.Before, "after": entry.After} {
+		if _, leaked := payload["iban"]; leaked {
+			t.Errorf("masked field leaked through %s: %v", side, payload)
+		}
+		if payload["email"] == nil {
+			t.Errorf("unmasked field withheld from %s: %v", side, payload)
+		}
+	}
+
+	// The default mask is empty: the payload passes through whole.
+	entry = recordHistoryEntry(row, defaultFieldMasks["person"])
+	if entry.Before["iban"] != "DE01" || entry.After["iban"] != "DE02" {
+		t.Errorf("empty default mask must pass the payload through: before %v after %v", entry.Before, entry.After)
+	}
+}
+
+func TestRecordHistoryEntryActorDisplayFallsBackToRawActorID(t *testing.T) {
+	row := recordAuditRow{actorType: "human", actorID: "human:1a2b", action: "update"}
+	if got := recordHistoryEntry(row, nil).Summary; got != "human:1a2b updated the record" {
+		t.Errorf("unresolved actor summary = %q, want the raw actor_id, never an invented name", got)
+	}
+	row.actorDisplayName = strPtr("Uma Underwriter")
+	if got := recordHistoryEntry(row, nil).Summary; got != "Uma Underwriter updated the record" {
+		t.Errorf("resolved actor summary = %q", got)
+	}
+}
+
 func TestRecordHistoryVerbsCoverTheAuditCheckVocabulary(t *testing.T) {
 	verbs := verbsFromCheckConstraint(t)
 	if len(verbs) < 25 {

--- a/backend/writeshape_test.go
+++ b/backend/writeshape_test.go
@@ -107,7 +107,7 @@ func TestEveryAuditedMutationEmitsAnEvent(t *testing.T) {
 					}
 					if pkg, ok := sel.X.(*ast.Ident); ok && pkg.Name == "storekit" {
 						switch sel.Sel.Name {
-						case "Audit":
+						case "Audit", "AuditWithEvidence":
 							audits = true
 						case "Emit":
 							emits = true

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -1567,6 +1567,39 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/records/{entity_type}/{id}/history": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                entity_type: "person" | "organization" | "deal" | "lead" | "activity";
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        /**
+         * Full audit history for one record, rendered as plain-language lines.
+         * @description Every audit_log row for the record, rendered as a plain-language `summary` line
+         *     naming the actor and, for agent actions, the granting human (`on_behalf_of_name`).
+         *     Chronological oldest-first (`occurred_at` ASC, `id` tiebreak) with keyset pagination.
+         *     `before`/`after` are masked to the viewer's readable fields by omission — a field the
+         *     caller cannot see is absent from the object, never present as `null`. The projection
+         *     stops at the record's newest erasure scrub: rows at-or-before that tombstone are
+         *     withheld while the tombstone's own line remains, so the read never resurfaces
+         *     pre-erasure PII. A visible record with no history answers `200 {data: []}` — an empty
+         *     history is honest, not a gap. A record outside the caller's row scope answers 404
+         *     (existence-hiding), like every single-record read.
+         */
+        get: operations["getRecordHistory"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/field-history": {
         parameters: {
             query?: never;
@@ -3962,6 +3995,41 @@ export interface components {
         };
         FieldHistoryListResponse: {
             data: components["schemas"]["FieldHistoryEntry"][];
+            page: components["schemas"]["PageInfo"];
+        };
+        /**
+         * @description One rendered history line for a record mutation. `before`/`after` are
+         *     masked to the viewer's readable fields — an absent key was hidden, not null.
+         *     `summary` is server-composed plain language; field-level detail lives in
+         *     before/after for the client to render.
+         */
+        AuditHistoryEntry: {
+            /** Format: uuid */
+            id: string;
+            /** @enum {string} */
+            actor_type: "human" | "agent" | "system" | "connector";
+            actor_id: string;
+            /**
+             * Format: uuid
+             * @description Granting human's user id for agent actions.
+             */
+            on_behalf_of?: string | null;
+            /** @description Resolved display name for on_behalf_of. */
+            on_behalf_of_name?: string | null;
+            action: string;
+            /** Format: date-time */
+            occurred_at: string;
+            authorization_rule?: string | null;
+            before?: {
+                [key: string]: unknown;
+            } | null;
+            after?: {
+                [key: string]: unknown;
+            } | null;
+            summary: string;
+        };
+        AuditHistoryListResponse: {
+            data: components["schemas"]["AuditHistoryEntry"][];
             page: components["schemas"]["PageInfo"];
         };
         /**
@@ -8977,6 +9045,46 @@ export interface operations {
             };
             401: components["responses"]["Unauthorized"];
             403: components["responses"]["Forbidden"];
+        };
+    };
+    getRecordHistory: {
+        parameters: {
+            query?: {
+                /**
+                 * @description Opaque keyset cursor from a prior response's `page.next_cursor`. The cursor encodes the
+                 *     effective `sort` and `filter` of the originating request plus the last row's keyset
+                 *     (sort-key tuple + `id` tie-breaker). **Stability:** results are stable under concurrent
+                 *     inserts/updates (keyset pagination, not offset). Supplying `cursor` together with a `sort`
+                 *     or filter that differs from the one the cursor was minted under returns
+                 *     `422 code: cursor_param_mismatch` — re-issue the query without the cursor.
+                 */
+                cursor?: components["parameters"]["Cursor"];
+                /** @description Max items in the page. */
+                limit?: components["parameters"]["Limit"];
+            };
+            header?: never;
+            path: {
+                entity_type: "person" | "organization" | "deal" | "lead" | "activity";
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description A page of rendered history lines, oldest first (empty when none). */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuditHistoryListResponse"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+            422: components["responses"]["ValidationError"];
         };
     };
     getFieldHistory: {


### PR DESCRIPTION
## What

`GET /records/{entity_type}/{id}/history` — one record's whole-mutation audit
history as plain-language summary lines, the third audit-spine read in the
privacy module. No new table, no migration.

- **Rendering:** server-composed lines with actor attribution; agent actions
  weave the granting human's name ("Agent acting for Devin advanced the stage
  of the record"); every verb in the 0053 vocabulary has a phrase, enforced by
  a fitness test that parses the migration's CHECK.
- **Gates:** identical stack to `/field-history` — human-only, object read,
  row-scope visibility (activities via link-walk; out-of-scope → 404).
- **Erasure boundary:** rows at-or-before the record's newest erase tombstone
  are withheld; the tombstone's own line is served (tombstone-INCLUSIVE, vs
  field-history's exclusive cut — each side's why is commented). Proven for
  the person AND the collateral lead-twin/activity scrubs via the real eraser.
- **Spine-side fix:** erase tombstones (person + collateral) now carry their
  tallies on the `evidence` channel with nil before/after — the write-shape
  gate widened to see `AuditWithEvidence`.
- `before`/`after` masked by omission to viewer-readable fields; keyset ASC
  pagination (CAP-PAGE); honest-empty for visible records; malformed cursor →
  422.

## Tests

- Unit: renderer branches (all actor types, authority weaving, unknown-verb
  fallback), 0053-vocabulary fitness test, mask/actor-display fallbacks.
- Integration (7): gates parity, chronological rendering + name resolution,
  erasure boundary (person + collateral), keyset walk, honest-empty,
  malformed cursor.
- HTTP e2e: envelope + attribution over the wire, 422s, keyset walk; handler
  + wire mapper at 100% coverage.

## Follow-ups (documented, out of scope)

- "logged in the record" verb copy (unreachable today); `authorization_rule`
  exposure gating on this surface; `applyFieldMask` all-masked→`{}` edge +
  top-level-only masks (both inert until masks ship); `AuditLogEntry.evidence`
  description drift ("agent actors only" — now also erase/retention rows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a record history endpoint for viewing chronological audit events.
  * History entries include actor attribution, authorization details, summaries, and available before/after values.
  * Added cursor-based pagination for efficiently browsing history.
  * Applied field masking, access controls, and erasure boundaries to protect sensitive information.
  * Erasure records remain visible as tombstones with suppression details.

* **Bug Fixes**
  * Improved delegated actor attribution and handling of missing history data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->