### PR TITLE
docs: backend onboarding hub + explanation/reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,7 @@ The `backend/internal/{modules,platform,shared}` triad — the DAG is
 - `internal/shared/` — Tier-0 leaves, stdlib-only (test-enforced):
   `kernel/{ids,events,provenance,principal}`, `apperrors` (the fixed
   sentinel registry — extend only with the spec's interfaces.md §0), and
-  `ports/{authz,datasource,mcp,connector,workflow,model,retrieval,jurisdiction}`
+  `ports/{authz,datasource,mcp,connector,workflow,model,retrieval,extraction,fieldcatalog,jurisdiction}`
   (the frozen seam interfaces + additive provider mechanics).
 - `internal/platform/` — technical plumbing, owns no domain:
   `database` (pg pool + the RLS `WithWorkspaceTx` GUC contract) +
@@ -96,7 +96,7 @@ The `backend/internal/{modules,platform,shared}` triad — the DAG is
   `Admit` (scope ∧ tier) + object RBAC + row-scope clauses incl. the
   activity link-walk), `events` (outbox relay/subscriber/dedupe),
   `dbmigrate`, `httperr` (RFC 7807 + wire helpers), `httpserver` (chassis).
-- `internal/modules/` — fourteen bounded capabilities, flat by default per
+- `internal/modules/` — sixteen bounded capabilities, flat by default per
   ADR-0054 §3 (store + mapping + transport + provider in one package),
   growing subpackages only under the decisions/0018 policy; a module NEVER
   imports a sibling: `identity` (workspaces, users, sessions, passports;
@@ -120,7 +120,11 @@ The `backend/internal/{modules,platform,shared}` triad — the DAG is
   gated by `backend/tableownership_test.go`), `collections`
   (lists — static and dynamic segments — and tags, visibility-probed),
   `signals` (the consent-gated warm-room substrate: company-level
-  signals, the inspectable resolver, warm/cold join), and `de` (the
+  signals, the inspectable resolver, warm/cold join), `customfields`
+  (the governed add-field engine: the sole runtime `ALTER TABLE`
+  chokepoint; record stores read the `cf_*` columns via the
+  `fieldcatalog` seam), `quotas` (RD-T06 owner-XOR-team revenue
+  targets, human-set, workspace-shared config posture), and `de` (the
   German jurisdiction pack: GoBD retention floors, registered via
   `ports/jurisdiction`).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,7 @@ The `backend/internal/{modules,platform,shared}` triad — the DAG is
 - `internal/shared/` — Tier-0 leaves, stdlib-only (test-enforced):
   `kernel/{ids,events,provenance,principal}`, `apperrors` (the fixed
   sentinel registry — extend only with the spec's interfaces.md §0), and
-  `ports/{datasource,mcp,connector,workflow,model,retrieval,jurisdiction}`
+  `ports/{authz,datasource,mcp,connector,workflow,model,retrieval,jurisdiction}`
   (the frozen seam interfaces + additive provider mechanics).
 - `internal/platform/` — technical plumbing, owns no domain:
   `database` (pg pool + the RLS `WithWorkspaceTx` GUC contract) +

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ numbers appear here when releases start.
   below the transport on MCP and REST alike, and the approval engine
   (stage → human decision → single-use redemption).
 - **AI surfaces**: model routing (`ai-routing.yaml`, Anthropic BYOK /
-  Ollama / offline fake), the Surface-B runner + scheduler, search
+  Ollama / vLLM / offline fake), the Surface-B runner + scheduler, search
   (FTS + pgvector hybrid), capture connector seam, cold-start read-back.
 - **GDPR arm**: per-purpose consent with default-deny suppression,
   retention evaluator with DE (GoBD) statutory floors, legal hold,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,7 @@ The `backend/internal/{modules,platform,shared}` triad — the DAG is
 - `internal/shared/` — Tier-0 leaves, stdlib-only (test-enforced):
   `kernel/{ids,events,provenance,principal}`, `apperrors` (the fixed
   sentinel registry — extend only with the spec's interfaces.md §0), and
-  `ports/{authz,datasource,mcp,connector,workflow,model,retrieval,jurisdiction}`
+  `ports/{authz,datasource,mcp,connector,workflow,model,retrieval,extraction,fieldcatalog,jurisdiction}`
   (the frozen seam interfaces + additive provider mechanics).
 - `internal/platform/` — technical plumbing, owns no domain:
   `database` (pg pool + the RLS `WithWorkspaceTx` GUC contract) +
@@ -124,7 +124,7 @@ The `backend/internal/{modules,platform,shared}` triad — the DAG is
   `Admit` (scope ∧ tier) + object RBAC + row-scope clauses incl. the
   activity link-walk), `events` (outbox relay/subscriber/dedupe),
   `dbmigrate`, `httperr` (RFC 7807 + wire helpers), `httpserver` (chassis).
-- `internal/modules/` — fourteen bounded capabilities, flat by default per
+- `internal/modules/` — sixteen bounded capabilities, flat by default per
   ADR-0054 §3 (store + mapping + transport + provider in one package),
   growing subpackages only under the decisions/0018 policy; a module NEVER
   imports a sibling: `identity` (workspaces, users, sessions, passports;
@@ -148,7 +148,11 @@ The `backend/internal/{modules,platform,shared}` triad — the DAG is
   gated by `backend/tableownership_test.go`), `collections`
   (lists — static and dynamic segments — and tags, visibility-probed),
   `signals` (the consent-gated warm-room substrate: company-level
-  signals, the inspectable resolver, warm/cold join), and `de` (the
+  signals, the inspectable resolver, warm/cold join), `customfields`
+  (the governed add-field engine: the sole runtime `ALTER TABLE`
+  chokepoint; record stores read the `cf_*` columns via the
+  `fieldcatalog` seam), `quotas` (RD-T06 owner-XOR-team revenue
+  targets, human-set, workspace-shared config posture), and `de` (the
   German jurisdiction pack: GoBD retention floors, registered via
   `ports/jurisdiction`).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,7 @@ The `backend/internal/{modules,platform,shared}` triad — the DAG is
 - `internal/shared/` — Tier-0 leaves, stdlib-only (test-enforced):
   `kernel/{ids,events,provenance,principal}`, `apperrors` (the fixed
   sentinel registry — extend only with the spec's interfaces.md §0), and
-  `ports/{datasource,mcp,connector,workflow,model,retrieval,jurisdiction}`
+  `ports/{authz,datasource,mcp,connector,workflow,model,retrieval,jurisdiction}`
   (the frozen seam interfaces + additive provider mechanics).
 - `internal/platform/` — technical plumbing, owns no domain:
   `database` (pg pool + the RLS `WithWorkspaceTx` GUC contract) +

--- a/README.md
+++ b/README.md
@@ -148,10 +148,10 @@ per-client throttling at the proxy.
   one Go module under `backend/` (`github.com/gradionhq/margince/backend`)
   as the `internal/{modules,platform,shared}` triad —
   `shared/{kernel,apperrors,ports}` (stdlib-only leaves), `platform/*`
-  (plumbing, owns no domain), fourteen `modules/` (identity, people,
+  (plumbing, owns no domain), sixteen `modules/` (identity, people,
   deals, activities, approvals, agents, ai, search, capture, consent,
-  privacy, collections, signals, and the `de` jurisdiction pack — no
-  sibling imports),
+  privacy, collections, signals, customfields, quotas, and the `de`
+  jurisdiction pack — no sibling imports),
   `internal/compose` (the one composition seam), and four process-role
   binaries
   `cmd/{api,worker,migrate,mcp}`. The DAG is enforced three ways

--- a/README.md
+++ b/README.md
@@ -44,17 +44,19 @@ work breakdown) lives in a separate spec repo at `../margince/specs/`.
 We build contract-first, and when code and spec disagree, the spec
 wins.
 
-Contributing: start with [CONTRIBUTING.md](CONTRIBUTING.md) (how the
-gates, DCO sign-off, and AI-disclosure work). Progress and the pickup
-point live in **[STATUS.md](STATUS.md)**; the binding engineering rules
-in [AGENTS.md](AGENTS.md). User and
-operator documentation lives under [docs/](docs/):
-[getting started](docs/tutorials/getting-started.md) ·
-[how-to guides](docs/how-to/) (MCP server, passports, migrations) ·
-[reference](docs/reference/) (every flag/env, make targets) ·
-[explanation](docs/explanation/) (architecture, contract-first).
-Vulnerabilities: see [SECURITY.md](SECURITY.md) — private reporting via
-GitHub Security Advisories. Changes: [CHANGELOG.md](CHANGELOG.md).
+**Start here:**
+
+- **[CONTRIBUTING.md](CONTRIBUTING.md)** — the gates, DCO sign-off, and AI-disclosure rules.
+- **[docs/explanation/backend-onboarding.md](docs/explanation/backend-onboarding.md)** — the backend
+  contributor hub: the codebase map, reading order, and how to add a feature.
+- **[docs/README.md](docs/README.md)** — the full documentation index (tutorials, how-to, reference,
+  explanation).
+
+Also: [STATUS.md](STATUS.md) — progress and session pickup point ·
+[AGENTS.md](AGENTS.md) — binding engineering rules ·
+[SECURITY.md](SECURITY.md) — vulnerability reporting (private, via GitHub Security Advisories) ·
+[CHANGELOG.md](CHANGELOG.md).
+
 Everything below this line is for people (and agents) working on the code.
 
 ## Quick start
@@ -146,9 +148,10 @@ per-client throttling at the proxy.
   one Go module under `backend/` (`github.com/gradionhq/margince/backend`)
   as the `internal/{modules,platform,shared}` triad —
   `shared/{kernel,apperrors,ports}` (stdlib-only leaves), `platform/*`
-  (plumbing, owns no domain), twelve `modules/` (identity, people,
+  (plumbing, owns no domain), fourteen `modules/` (identity, people,
   deals, activities, approvals, agents, ai, search, capture, consent,
-  collections, and the `de` jurisdiction pack — no sibling imports),
+  privacy, collections, signals, and the `de` jurisdiction pack — no
+  sibling imports),
   `internal/compose` (the one composition seam), and four process-role
   binaries
   `cmd/{api,worker,migrate,mcp}`. The DAG is enforced three ways

--- a/README.md
+++ b/README.md
@@ -265,16 +265,12 @@ per-client throttling at the proxy.
 ## Deliberately not here yet
 
 The approval edit-then-approve re-gating path (`edited_payload` answers
-422 until it re-enters the gate properly), disqualify/enrich/send tools
-(their underlying verbs first), the hosted A2 MCP server (OAuth2 + PKCE
-+ DCR + the JWS approval-token serialization — until then `/passports`
-is the A1 issuance path, decisions/0012), `run_report`/schema
-introspection on the SoR seam, capture connectors, search/context graph,
-the RLS row-scope backstop (B-EP03.3b), field-level masking (B-EP03.4),
-record grants (A52), consent enforcement, the Idempotency-Key replay
-store, event versioning/replay/dead-letter (B-EP04.12/.14/.15), and the
-River job runner (deferred, decisions/0005). The contract routes for all
-of these exist and answer 501.
+422 until it re-enters the gate properly), the disqualify/enrich/send
+tools (their underlying verbs first), `run_report`/schema introspection
+on the SoR seam, the RLS row-scope backstop (B-EP03.3b), field-level
+masking (B-EP03.4), record grants (A52), the Idempotency-Key replay
+store, and event versioning/replay/dead-letter (B-EP04.12/.14/.15). The
+contract routes for these exist and answer 501.
 
 ## Working conventions (where findings go)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@ maps the codebase and links everything below.
 - [run-the-frontend.md](how-to/run-the-frontend.md) — run the SPA in dev.
 
 ### Reference — look it up
-- [modules.md](reference/modules.md) — the 14 modules: what each owns, its tables, its HTTP surface.
+- [modules.md](reference/modules.md) — the 16 modules: what each owns, its tables, its HTTP surface.
 - [platform-toolkit.md](reference/platform-toolkit.md) — the reusable `platform/*` + `shared/*` utilities.
 - [configuration.md](reference/configuration.md) — every binary flag and environment variable.
 - [make-targets.md](reference/make-targets.md) — every `make` target.

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,7 +43,7 @@ maps the codebase and links everything below.
 1. [tutorials/getting-started.md](tutorials/getting-started.md) — get it running.
 2. [explanation/backend-onboarding.md](explanation/backend-onboarding.md) — the map + reading order hub.
 3. [architecture.md](explanation/architecture.md) → [contract-first.md](explanation/contract-first.md) → [authorization.md](explanation/authorization.md).
-4. Deep dives on demand: [write-backbone.md](explanation/write-backbone.md), [reference/modules.md](reference/modules.md), [reference/platform-toolkit.md](reference/platform-toolkit.md).
+4. Deep dives on demand: [write-backbone.md](explanation/write-backbone.md), [composition-layer.md](explanation/composition-layer.md), [agent-surface.md](explanation/agent-surface.md), [privacy-and-consent.md](explanation/privacy-and-consent.md), [reference/modules.md](reference/modules.md), [reference/platform-toolkit.md](reference/platform-toolkit.md).
 5. [CONTRIBUTING.md](../CONTRIBUTING.md) + [AGENTS.md](../AGENTS.md) — the PR loop and the binding engineering rules.
 
 ---

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,8 +33,10 @@ maps the codebase and links everything below.
 - [architecture.md](explanation/architecture.md) — the module DAG, the spine shapes, tenancy-as-structure.
 - [composition-layer.md](explanation/composition-layer.md) — how `internal/compose/` boots and where every cross-module edge is wired.
 - [contract-first.md](explanation/contract-first.md) — how code is generated from `crm.yaml`.
-- [authorization.md](explanation/authorization.md) — why the auth check lives at the store entry point.
-- [write-backbone.md](explanation/write-backbone.md) — storekit, `audit_log`, and the outbox, in depth.
+- [authorization.md](explanation/authorization.md) — why the auth check lives at the store entry point; the RLS backstop; what a passport is.
+- [write-backbone.md](explanation/write-backbone.md) — storekit, `audit_log`, the outbox, and who consumes the events.
+- [agent-surface.md](explanation/agent-surface.md) — the Surface-B reasoning loop and the model runtime.
+- [privacy-and-consent.md](explanation/privacy-and-consent.md) — the consent gate and the GDPR engines (erasure / SAR / retention).
 
 ## Reading order for a new contributor
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,50 @@
+# Margince documentation
+
+Documentation for building and operating **Margince** — a governed, multi-tenant CRM (Go backend +
+embedded SPA). The docs follow the [Diátaxis](https://diataxis.fr/) split: **tutorials** to learn,
+**how-to** guides for tasks, **reference** for lookup, **explanation** for the *why*.
+
+**New to the backend? Start with [tutorials/getting-started.md](tutorials/getting-started.md), then
+[explanation/backend-onboarding.md](explanation/backend-onboarding.md)** — the orientation hub that
+maps the codebase and links everything below.
+
+## Map
+
+### Tutorials — learn by doing
+- [getting-started.md](tutorials/getting-started.md) — clone → running instance with a bootstrapped workspace.
+
+### How-to — accomplish a task
+- [add-an-endpoint.md](how-to/add-an-endpoint.md) — add or change an API operation (contract → gen → handler).
+- [add-a-module.md](how-to/add-a-module.md) — add a new capability (module) or a cross-module edge, wired into compose.
+- [apply-migrations.md](how-to/apply-migrations.md) — write and apply a database migration.
+- [mint-a-passport.md](how-to/mint-a-passport.md) — issue an agent passport token.
+- [run-the-mcp-server.md](how-to/run-the-mcp-server.md) — serve the governed MCP tool surface.
+- [run-the-frontend.md](how-to/run-the-frontend.md) — run the SPA in dev.
+
+### Reference — look it up
+- [modules.md](reference/modules.md) — the 14 modules: what each owns, its tables, its HTTP surface.
+- [platform-toolkit.md](reference/platform-toolkit.md) — the reusable `platform/*` + `shared/*` utilities.
+- [configuration.md](reference/configuration.md) — every binary flag and environment variable.
+- [make-targets.md](reference/make-targets.md) — every `make` target.
+- [license-release-rule.md](reference/license-release-rule.md) — the BUSL Change-Date release-stamping rule. (The per-file SPDX license *header* rule is described in [backend-onboarding.md](explanation/backend-onboarding.md) and [AGENTS.md](../AGENTS.md).)
+
+### Explanation — understand the why
+- [backend-onboarding.md](explanation/backend-onboarding.md) — **the contributor hub**: system overview, the map, what's generated vs hand-written, the store shape, the gates.
+- [architecture.md](explanation/architecture.md) — the module DAG, the spine shapes, tenancy-as-structure.
+- [composition-layer.md](explanation/composition-layer.md) — how `internal/compose/` boots and where every cross-module edge is wired.
+- [contract-first.md](explanation/contract-first.md) — how code is generated from `crm.yaml`.
+- [authorization.md](explanation/authorization.md) — why the auth check lives at the store entry point.
+- [write-backbone.md](explanation/write-backbone.md) — storekit, `audit_log`, and the outbox, in depth.
+
+## Reading order for a new contributor
+
+1. [tutorials/getting-started.md](tutorials/getting-started.md) — get it running.
+2. [explanation/backend-onboarding.md](explanation/backend-onboarding.md) — the map + reading order hub.
+3. [architecture.md](explanation/architecture.md) → [contract-first.md](explanation/contract-first.md) → [authorization.md](explanation/authorization.md).
+4. Deep dives on demand: [write-backbone.md](explanation/write-backbone.md), [reference/modules.md](reference/modules.md), [reference/platform-toolkit.md](reference/platform-toolkit.md).
+5. [CONTRIBUTING.md](../CONTRIBUTING.md) + [AGENTS.md](../AGENTS.md) — the PR loop and the binding engineering rules.
+
+---
+
+*`worklists/` holds transient implementation plans and dated session notes, not product/operator
+documentation — skip it as a reader.*

--- a/docs/explanation/agent-surface.md
+++ b/docs/explanation/agent-surface.md
@@ -1,0 +1,89 @@
+# The agent surface & the model runtime
+
+How AI agents *act* inside Margince, and what *runs the model* behind them. This is the read/react
+counterpart to the write path: how a proposal becomes a governed action. The **governance** — the
+autonomy tiers, passports, and the one admission gate — is explained in
+[authorization.md](authorization.md); this page is what the agent *does* and how the model runtime is
+wired.
+
+## Two surfaces, one gate
+
+There are two ways an agent reaches the tool surface, and **both go through the same governed
+registry and the same admission gate** — there is no privileged back door:
+
+- **Surface A** — an *external* agent over MCP (stdio or hosted HTTP), acting under a passport.
+- **Surface B** — *our own* runner: the proactive reason-act-observe loop (e.g. the overnight passes).
+
+Both call every action through `agents.Registry.Invoke`, which admits each call through `platform/auth`
+(**scope ∧ seat ∧ tier**) before any handler runs. A 🟢 call executes and is audited; a 🟡 call stages a
+confirm-first approval. "Two surfaces, one gate" is a property of the construction, not a convention.
+
+## The reason-act-observe loop (Surface B)
+
+The runner (`internal/modules/agents/runner/`) is where **the model proposes and the governed tool
+surface decides**. Each iteration:
+
+1. **Guarantee checks first** — three hard per-run ceilings: wall-clock, a **step budget**
+   (`MaxSteps`, default 40), and an **output-token budget** (`MaxOutputTokens`, default 50 000).
+   Hitting one degrades the run honestly, so one unattended run can never claim the whole workspace's
+   model budget.
+2. **Reason** — one model call (`brain.Complete`).
+3. **Parse** the proposed step — the protocol requires *exactly one* of `tool` or `final`; malformed
+   output retries with feedback, and after 3 consecutive invalid steps the run **degrades honestly**
+   rather than fabricate a partial result.
+4. **Terminal** — a `final` step completes the run.
+5. **Act** — `registry.Invoke(tool, args)` (the runner's *only* path to an action).
+6. **Observe** — on the tool's result:
+   - a **🟡 refusal** *suspends* the run on the staged approval (`awaiting-approval`) — it never blocks;
+   - a **scope/budget refusal** is fed back as an *observation*, so the model re-plans within its
+     authority;
+   - **success** is observed and the loop continues.
+
+**Resume:** when a human approves, the run re-submits the *identical* staged call carrying the approval
+id; when rejected, it observes "re-plan without it." **Grounding** content seeded into the run is
+spotlighted as *data, not instructions* (a prompt-injection guard). The runner reaches records **only
+through the registry** — read-vs-write is governed by the gate, never by the loop itself.
+
+## The model runtime
+
+Behind the `ports/model` seam (`Client { Complete / Stream / Embed / Caps }`), **model choice is config,
+not architecture**. `internal/modules/ai/` owns it:
+
+- **`SelectBrain(cfg)`** turns one binding (from `ai-routing.yaml`) into a `Client` — "offline fake ↔
+  API key ↔ local, one line." Providers:
+  - **`anthropic`** — cloud-frontier **BYOK**: you supply the key, the product runs no inference of its own.
+  - **`ollama`** and **`vllm`** — local / self-host adapters (`LocalOnly`, eligible for the zero-egress
+    sovereign profile).
+  - **`fake`** — a fully deterministic offline client that every test drives (records each outbound
+    payload *after* stripping, so tests assert what would have left the process).
+- **The Router** — tasks name *tiers*; tiers resolve to bound clients; the budget guardrail bends the
+  route *before* the call; every call is metered. **Callers never pick a model.**
+- **The `SecretStripper`** runs over *every* outbound payload and irreversibly removes secrets — API
+  keys, tokens, private keys, password assignments (→ `[SECRET-REMOVED:<kind>]`). It is **hygiene, not
+  a PII filter**: names, emails, and phone numbers pass through (privacy is handled by the location
+  ladder and the erasure engines, not by stripping). The sovereign profile blocks egress entirely.
+- **Metering & budget** — `ai_usage` accumulates per-(workspace, day, task, tier) counters against a
+  monthly token budget. At ≥80% utilization the router soft-degrades a tier; at ≥100% it queues
+  non-interactive work (`ErrBudgetExhausted`). **Core CRM is never behind this error — only model
+  calls are.**
+
+## Automations & MCP transports (in brief)
+
+- **Automations** (`/v1/automations`) parameterize the workflow engine's closed catalog per workspace;
+  mutations are human-only, re-gated at the store on the `automation` RBAC object. (The workflow engine
+  itself is covered in [write-backbone.md → who consumes the events](write-backbone.md#5-the-consumer-side--groups--dedupe).)
+- **MCP** serves the *same* tool surface over **A1 stdio** and **A2 hosted HTTP** — one registry, one
+  admission gate, one audit stream. Running it: [how-to/run-the-mcp-server.md](../how-to/run-the-mcp-server.md);
+  minting the passport: [how-to/mint-a-passport.md](../how-to/mint-a-passport.md).
+
+## Honest gaps
+
+- **Per-agent quota is specified but not yet enforced.** The admission gate binds scope ∧ seat ∧ tier
+  today; a per-agent budget ceiling is designed but not wired.
+
+## Where to go next
+
+- The gate, autonomy tiers, and what a passport is: [authorization.md](authorization.md).
+- Where the runner's resume trigger comes from (the `approval.decided` event):
+  [write-backbone.md](write-backbone.md).
+- What each module owns (`agents`, `ai`): [reference/modules.md](../reference/modules.md).

--- a/docs/explanation/agent-surface.md
+++ b/docs/explanation/agent-surface.md
@@ -63,9 +63,10 @@ not architecture**. `internal/modules/ai/` owns it:
   a PII filter**: names, emails, and phone numbers pass through (privacy is handled by the location
   ladder and the erasure engines, not by stripping). The sovereign profile blocks egress entirely.
 - **Metering & budget** — `ai_usage` accumulates per-(workspace, day, task, tier) counters against a
-  monthly token budget. At ≥80% utilization the router soft-degrades a tier; at ≥100% it queues
-  non-interactive work (`ErrBudgetExhausted`). **Core CRM is never behind this error — only model
-  calls are.**
+  **workspace monthly token budget** (distinct from the per-run step/output-token ceilings above,
+  which stop a single runaway run). At ≥80% utilization the router soft-degrades a tier; at ≥100% it
+  queues non-interactive work (`ErrBudgetExhausted`). **Core CRM is never behind this error — only
+  model calls are.**
 
 ## Automations & MCP transports (in brief)
 

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -1,8 +1,8 @@
 # Architecture
 
-The normative blueprint lives in the spec repo
-(`../margince/specs/spec/architecture/`); this page is the condensed
-map of how this codebase realizes it.
+The condensed map of how this codebase is shaped. New backend contributors
+should start at [backend-onboarding.md](backend-onboarding.md) — the
+orientation hub — and read this for the *why* behind the structure.
 
 ## The triad DAG
 
@@ -17,7 +17,8 @@ shared  →  platform  →  modules  →  compose  →  cmd
 - **`internal/shared/`** — Tier-0 leaves, stdlib-only:
   `kernel/{ids,events,provenance,principal}`, `apperrors` (the fixed
   error-sentinel registry), and `ports/` (the frozen seam interfaces:
-  datasource, mcp, connector, workflow, model, retrieval, jurisdiction).
+  authz, datasource, mcp, connector, workflow, model, retrieval,
+  jurisdiction).
 - **`internal/platform/`** — technical plumbing that owns no domain:
   `database` (pool + the RLS workspace-transaction contract) and
   `database/storekit` (the one spelling of the write shape), `auth` (the
@@ -40,7 +41,8 @@ shared  →  platform  →  modules  →  compose  →  cmd
   orchestration groups live in subpackages under the same growth policy
   (`compose/briefs`), and the cross-module integration suites live in
   `compose/integration`; compose subpackages coordinate modules and
-  never durably own a business entity.
+  never durably own a business entity. How it boots and where every
+  cross-module edge is wired: [composition-layer.md](composition-layer.md).
 - **`cmd/{api,worker,migrate,mcp}`** — thin process roles.
 
 The DAG is enforced three ways, and deliberately mechanically: depguard
@@ -72,7 +74,9 @@ the relay ships committed rows to Redis Streams; no domain code touches
 the bus directly — and consumers wrap handlers in `events.Dedupe`
 because the bus is at-least-once. Every store entry point is RBAC-gated:
 object denial answers 403, a row-scope miss answers 404
-(existence-hiding).
+(existence-hiding). The full mechanism — `audit_log`, the outbox
+envelope, the relay, dedupe — is detailed in
+[write-backbone.md](write-backbone.md).
 
 ## Tenancy as structure
 

--- a/docs/explanation/authorization.md
+++ b/docs/explanation/authorization.md
@@ -56,16 +56,18 @@ Minting and using one: [how-to/mint-a-passport.md](../how-to/mint-a-passport.md)
 
 ## The two layers, precisely
 
-**1. Admission — *may this principal perform this kind of action at all?*** Minted in one place,
-`platform/auth`. `Admit`/`Gate` combines the agent scope, the seat ceiling (a `read` seat may GET but
-never mutate), the autonomy tier (below), and object-level RBAC — re-derived live on every call.
-Handlers decode the request and encode the response; they never decide authorization.
+**1. Admission — *may this agent take this kind of action at all?*** `platform/auth`'s `Gate.Admit`
+combines the agent **scope**, the **seat ceiling** (a `read` seat may GET but never mutate), and the
+**autonomy tier** (below), re-derived live on every call. Object-level RBAC and row visibility are
+**not** `Admit`'s job — they live at the store (layer 2). Handlers decode the request and encode the
+response; they never decide authorization.
 
-**2. Row scope — *may this principal see or touch this particular row?*** Enforced where the SQL is:
-`auth.Require` + `auth.EnsureVisible` at the store entry, the list-scope clauses composed into every
-query (`ScopeClause`), and `auth.EnsureLinkTarget` for foreign-key references. Row-scope checks often
-must run **inside the same transaction** as the read or write they guard — checking in a handler would
-be checking a different snapshot.
+**2. Object RBAC + row scope — *may this principal do this to this particular record?*** Enforced where
+the SQL is, at the store/service entry: **`auth.Require`** (object level — does the role grant this
+verb on this object type?), plus **`auth.EnsureVisible`** / the list-scope clauses (`ScopeClause`) /
+`auth.EnsureLinkTarget` (row level — may they see this row?). These often must run **inside the same
+transaction** as the read or write they guard — checking in a handler would be checking a different
+snapshot.
 
 ## Autonomy tiers — how agent actions are governed (🟢 / 🟡)
 

--- a/docs/explanation/authorization.md
+++ b/docs/explanation/authorization.md
@@ -13,7 +13,7 @@ The same module behavior is reached by:
 
 - the REST surface (`internal/compose/server.go`),
 - the MCP tool surface (`cmd/mcp`),
-- agent runs (the Surface-B runner acting under a passport),
+- agent runs (the Surface-B runner acting under a passport — see [agent-surface.md](agent-surface.md)),
 - workers (retention, reconciliation, the close-date sweep, the outbox relay's consumers),
 - compose orchestration flows (briefs, reports, exports, enrichment).
 

--- a/docs/explanation/authorization.md
+++ b/docs/explanation/authorization.md
@@ -1,68 +1,136 @@
-# Why authorization lives below the handlers
+# Authorization & access control
 
-Most web applications gate authorization in the HTTP layer — a middleware or
-controller checks the permission, and everything behind it trusts the caller.
-This codebase deliberately does not. If you are looking for the auth check in
-a handler and not finding it, this page is the explanation: **the check is at
-the store/service entry point, and that is a design decision, not drift.**
+How Margince decides **who may do what**, and — importantly — **where** that decision is made. If you
+are looking for the auth check in an HTTP handler and not finding it, this page is the explanation:
+the check is at the store/service entry point, and Postgres row-level security is the backstop beneath
+it. That is a design decision, not drift.
 
-## The problem with handler-only authorization
+## Why authorization lives below the handlers
 
-HTTP is only one of the callers. The same module behavior is reached by:
+Most web apps gate authorization in the HTTP layer — a middleware checks the permission and everything
+behind it trusts the caller. This codebase deliberately does not, because **HTTP is only one caller**.
+The same module behavior is reached by:
 
 - the REST surface (`internal/compose/server.go`),
-- the MCP tool surface (`cmd/mcp`, the hosted transport),
+- the MCP tool surface (`cmd/mcp`),
 - agent runs (the Surface-B runner acting under a passport),
-- workers (retention, reconciliation, close-date sweeps, the outbox relay's
-  consumers),
+- workers (retention, reconciliation, the close-date sweep, the outbox relay's consumers),
 - compose orchestration flows (briefs, reports, exports, enrichment).
 
-A permission check that lives in HTTP middleware protects exactly one of
-those paths. Every other caller becomes a bypass waiting to happen. So the
-shared boundary is the one place all of them must pass: the module's store
-(CRUD modules) or service (engine modules) entry points.
+A check in HTTP middleware protects exactly one of those paths; every other caller becomes a bypass.
+So the check lives at the one boundary all of them cross: the module's **store** (CRUD modules) or
+**service** (engine modules) entry points.
+
+## Who is calling — principals and the three transports
+
+Every request carries a **principal** (`shared/kernel/principal`): its type (human / agent / connector
+/ system), its identity, its seat, its scopes, and — for agents — the human it acts on behalf of.
+There are three ways a caller reaches `/v1` or the tools, and **all three resolve the same admission +
+RBAC**:
+
+| Caller | Transport | Credential |
+|---|---|---|
+| A **human** | web app / HTTP | the `crm_session` cookie (from `POST /v1/auth/login`) |
+| An **agent** | REST | `Authorization: Bearer mgp_…` (a passport) |
+| An **agent** | MCP (stdio or hosted HTTP) | a passport (`MARGINCE_PASSPORT_TOKEN`, or an OAuth-minted bearer) |
+
+(On the REST transports, local dev also sends the `X-Workspace-Slug` header to name the tenant;
+production resolves it from the subdomain.)
+
+### What a passport is
+
+A **passport** (formally an *Agent Seat Passport*) is the credential an AI agent uses on both agent
+transports. It is a scoped, expiring, revocable bearer token — a `mgp_`-prefixed string — that a
+**human mints for an agent** (`POST /v1/passports`, session-authed, human-only). Two properties make
+it safe:
+
+- **An agent never has more rights than the human who minted it.** Effective authority is the
+  passport's scopes (`read`, `draft`, `write`, `send`, `enrich`) **intersected with the granting
+  human's live RBAC and seat**.
+- **It is re-authenticated on every call**, and the human's seat + RBAC are re-derived each time — so
+  revoking the passport (or demoting the human) **binds mid-session**, including for an MCP session
+  that is already connected.
+
+Minting and using one: [how-to/mint-a-passport.md](../how-to/mint-a-passport.md) →
+[how-to/run-the-mcp-server.md](../how-to/run-the-mcp-server.md).
 
 ## The two layers, precisely
 
-**Admission** — *may this principal perform this kind of action at all?* —
-is minted in one place, `platform/auth`: `Admit` combines the agent gate
-(🟢/🟡 tier), the seat ceiling, and object RBAC, re-derived live on every
-call so a revocation binds mid-session (ADR-0055). Handlers decode the
-request, validate transport shape, and encode the response; they never
-decide authorization.
+**1. Admission — *may this principal perform this kind of action at all?*** Minted in one place,
+`platform/auth`. `Admit`/`Gate` combines the agent scope, the seat ceiling (a `read` seat may GET but
+never mutate), the autonomy tier (below), and object-level RBAC — re-derived live on every call.
+Handlers decode the request and encode the response; they never decide authorization.
 
-**Row scope** — *may this principal see or touch this particular row?* — is
-enforced where the SQL is: `auth.Require` + `auth.EnsureVisible` at store
-entry, the list-scope clauses composed into every query, and
-`auth.EnsureLinkTarget` for references. Row-scope checks often have to run
-inside the same transaction as the read or write they guard — checking in a
-handler would be checking a different snapshot. Beneath all of it, Postgres
-row-level security (`FORCE RLS` on every tenant table, reachable only through
-`database.WithWorkspaceTx`) is the structural backstop: even a bug above it
-cannot cross a workspace boundary.
+**2. Row scope — *may this principal see or touch this particular row?*** Enforced where the SQL is:
+`auth.Require` + `auth.EnsureVisible` at the store entry, the list-scope clauses composed into every
+query (`ScopeClause`), and `auth.EnsureLinkTarget` for foreign-key references. Row-scope checks often
+must run **inside the same transaction** as the read or write they guard — checking in a handler would
+be checking a different snapshot.
+
+## Autonomy tiers — how agent actions are governed (🟢 / 🟡)
+
+An action's autonomy tier is **declared once in the contract** (`x-mcp-tool: { tier: … }`) and enforced
+**below the transport**, so REST and MCP behave identically:
+
+- **🟢 (green)** — reversible internal actions **auto-execute**, audited, with agent-stamped provenance.
+- **🟡 (yellow)** — outbound / irreversible actions (send, merge, archive, close a deal, …) **stage a
+  confirm-first approval** that a human decides in the inbox; the agent then redeems the decision by
+  re-issuing the same call.
+- **Human-only** routes (approvals, consent, DSR) **refuse an agent principal outright**.
+- A mutating operation carrying **no tier is default-denied** for agents (the agent-policy generator
+  refuses to ship an un-tiered mutation in the first place — see
+  [contract-first.md](contract-first.md)).
+
+Approving is always human-only, and an agent never exceeds the granting human's live authority.
+
+## The structural backstop — Postgres row-level security
+
+Everything above is application code; beneath it, the database itself enforces tenant isolation, so a
+bug in a scope clause still cannot cross a workspace boundary.
+
+- Every tenant table has `ENABLE`+`FORCE` row-level security with a **deny-on-unset** policy keyed on
+  the `app.workspace_id` GUC (`FORCE` binds even the table owner; `ENABLE`-only "looks secure and is
+  not").
+- Those tables are reachable **only** through `database.WithWorkspaceTx`, which binds the GUC
+  transaction-local (`SELECT set_config('app.workspace_id', $1, true)`) and **fails closed before any
+  SQL** if no workspace is bound. If the GUC is unset, the policy's `NULLIF(current_setting(...), '')`
+  is `NULL` and `workspace_id = NULL` is never true → the connection **sees zero rows and writes
+  nothing**.
+- The runtime **`margince_app`** role is not a superuser, has no `BYPASSRLS`, and does not own the
+  tables — so there is no bypass path. (The schema owner `margince_owner` is used only by migrations.)
+- Every tenant-local foreign key is composite `(workspace_id, col)`, so a cross-workspace reference is
+  rejected by the database.
+
+Both RLS coverage and composite-FK obligations are fitness functions derived from the live schema —
+see [write-backbone.md](write-backbone.md) for the write path that rides inside this transaction.
+
+## How it is wired
+
+- **One gate, injected once.** `platform/auth` is the admission point; no module re-implements it. It
+  depends on the `ports/authz` seam (implemented by `identity`) so platform never imports a module.
+- **At the store/service entry** every exported method calls the gate (`auth.Require` +
+  `auth.EnsureVisible`); a fitness test (`rbacgate_test.go`) fails any store entry point that doesn't.
+- **REST** rides a compose middleware (`agentGate`): for an agent principal it resolves the operation's
+  tier/policy from the generated admission table before the handler runs, and default-denies an
+  un-policied mutation. A human caller skips it — their RBAC at the store *is* the approval.
+- **MCP** binds the same tool registry and admission gate (`compose.NewRegistry`) — one gate, two
+  transports.
 
 ## The rules that follow
 
-- **Anything that returns a record is a read** and carries the row-scope
-  gate — including replay paths, conflict responses, and error paths. A 409
-  that echoes a hidden row's id is a leak.
-- **A foreign-key reference to a row-scoped record is also a read.** Naming a
-  deal's organization, an activity's link target, or a merge survivor asserts
-  the target exists — so the reference is gated like a read of the target
-  (`auth.EnsureLinkTarget`).
-- **Object denial answers 403** (`apperrors.ErrPermissionDenied`): you asked
-  for something your role cannot do.
-- **A row-scope miss answers 404** (`apperrors.ErrNotFound`): a record you
-  cannot see must be indistinguishable from a record that does not exist,
-  so a leaked UUID buys nothing (existence-hiding).
-- **REST, MCP, agents, and workers therefore share one gate.** An agent under
-  a passport is capped by the granting human's live seat and RBAC; the same
-  store entry point enforces both.
+- **Anything that returns a record is a read** and carries the row-scope gate — including replay,
+  conflict, and error paths. A 409 that echoes a hidden row's id is a leak.
+- **A foreign-key reference to a row-scoped record is also a read** (`auth.EnsureLinkTarget`): naming a
+  deal's organization or an activity's link target asserts the target exists, so it is gated like a
+  read of that target.
+- **Object denial answers 403** (`apperrors.ErrPermissionDenied`): your role cannot do this at all.
+- **A row-scope miss answers 404** (`apperrors.ErrNotFound`): a record you cannot see is
+  indistinguishable from one that does not exist, so a leaked UUID buys nothing (existence-hiding).
+- **REST, MCP, agents, and workers share one gate** — an agent under a passport is capped by the
+  granting human's live seat and RBAC at the same store entry point.
 
 ## Where this is recorded
 
-The RBAC defaults and row-scope semantics are decisions/0006; the
-transport-agnostic admission gate is ADR-0055 (decisions/0012); the spec-side
-control map is `architecture/06-governance-as-structure.md` in the spec repo.
-The binding short form lives in [AGENTS.md](../../AGENTS.md) under "The write
-shape".
+RBAC defaults and row-scope semantics: [decisions/0006](../../decisions/0006-rbac-defaults-and-row-scope-semantics.md).
+The transport-agnostic admission gate: [decisions/0012](../../decisions/0012-adr0055-transport-agnostic-gate.md).
+The binding short form is in [AGENTS.md](../../AGENTS.md) under "The write shape".

--- a/docs/explanation/backend-onboarding.md
+++ b/docs/explanation/backend-onboarding.md
@@ -25,7 +25,8 @@ Deep dives (read when you touch that area):
 **[reference/modules.md](../reference/modules.md)** (what each of the 14 modules owns) ·
 **[reference/platform-toolkit.md](../reference/platform-toolkit.md)** (the reusable utilities — reach
 for these, don't reinvent) · **[explanation/write-backbone.md](write-backbone.md)** (storekit,
-`audit_log`, the outbox, in depth).
+`audit_log`, the outbox) · **[explanation/agent-surface.md](agent-surface.md)** (the reasoning loop +
+model runtime) · **[explanation/privacy-and-consent.md](privacy-and-consent.md)** (the GDPR engines).
 
 Reference, reach for as needed: **[reference/make-targets.md](../reference/make-targets.md)** ·
 **[reference/configuration.md](../reference/configuration.md)** (every flag/env) ·

--- a/docs/explanation/backend-onboarding.md
+++ b/docs/explanation/backend-onboarding.md
@@ -106,7 +106,7 @@ edit. Everything else you author.
 |---|---|
 | `backend/api/crm.yaml` | the contract itself — the *input* to codegen (this is the one "source" file the generators read) |
 | `internal/modules/<name>/` | the handler methods, the store/service, the SQL |
-| `backend/migrations/core|custom/*.sql` | schema changes (up + down) |
+| `backend/migrations/{core,custom}/*.sql` | schema changes (up + down) |
 | `internal/compose/{server,provider,registry}.go` + adapters | cross-module wiring and edges |
 | `backend/**/*_test.go` | unit, fitness, and integration tests |
 | `decisions/NNNN-*.md`, `docs/**` | the record of a non-obvious decision, and docs |
@@ -137,7 +137,7 @@ Four process roles, all assembled through `internal/compose`. Flags/env are tabl
 
 Every store method follows one shape: open the **workspace transaction**, gate at the entry point, run
 SQL over the tables the module owns, and — for a mutation — commit the domain row + an audit row + an
-event row together. That is the whole write contract in one call site:
+event row together. That is the whole write contract in one call site (illustrative, not copy-paste Go):
 
 ```go
 func (s *Store) CreateDeal(ctx context.Context, in CreateDealInput) (Deal, error) {

--- a/docs/explanation/backend-onboarding.md
+++ b/docs/explanation/backend-onboarding.md
@@ -1,0 +1,245 @@
+# Backend contributor orientation
+
+The single starting point for a developer new to the **margince-next** backend. It does **not**
+re-explain the concepts other docs already own — it is the map that ties them together, plus the
+code-level detail and change-recipes those docs deliberately leave out. Everything here is about
+*this* repository.
+
+## Start here (reading order)
+
+1. **[tutorials/getting-started.md](../tutorials/getting-started.md)** — clone → running instance in
+   five commands. Do this first.
+2. **[explanation/architecture.md](architecture.md)** — the shape: the `shared → platform → modules →
+   compose → cmd` DAG, the two spine shapes, the write shape, tenancy-as-structure, the one governed
+   agent surface. Read it for the *why*; this page won't repeat it.
+3. **[explanation/contract-first.md](contract-first.md)** — how the Go surface is generated from
+   `backend/api/crm.yaml`, and why drift is merge-blocking.
+4. **[explanation/authorization.md](authorization.md)** — why the auth check lives at the store/service
+   entry point, not in the handler.
+5. **This page** — the system in one screen, the map, what's generated vs what you write, the code you
+   actually call (store/RLS/write-shape), the gates that judge your PR, and the two change-recipes.
+6. **[CONTRIBUTING.md](../../CONTRIBUTING.md)** + **[AGENTS.md](../../AGENTS.md)** — the PR loop
+   (accountability, DCO sign-off, gates) and the binding engineering rules.
+
+Deep dives (read when you touch that area):
+**[reference/modules.md](../reference/modules.md)** (what each of the 14 modules owns) ·
+**[reference/platform-toolkit.md](../reference/platform-toolkit.md)** (the reusable utilities — reach
+for these, don't reinvent) · **[explanation/write-backbone.md](write-backbone.md)** (storekit,
+`audit_log`, the outbox, in depth).
+
+Reference, reach for as needed: **[reference/make-targets.md](../reference/make-targets.md)** ·
+**[reference/configuration.md](../reference/configuration.md)** (every flag/env) ·
+**[how-to/apply-migrations.md](../how-to/apply-migrations.md)** ·
+**[how-to/mint-a-passport.md](../how-to/mint-a-passport.md)** →
+**[how-to/run-the-mcp-server.md](../how-to/run-the-mcp-server.md)**. Implementation decisions are
+recorded under **[`decisions/`](../../decisions/)**.
+
+---
+
+## The system in one screen
+
+Margince is a **governed, multi-tenant CRM**: a Go backend serving a contract-defined HTTP API under
+`/v1` (plus an MCP tool surface for AI agents) over Postgres + Redis, with an embedded SPA. "Governed"
+is the theme — every read is tenant-isolated and RBAC-scoped, every write is audited and announced as
+an event, and every AI action is tiered (auto-execute vs stage-for-human-approval).
+
+What happens on one request:
+
+```
+1. cmd/api receives an HTTP request; the chassis middleware binds actor + workspace + correlation_id
+   onto the context and (for agents) resolves the autonomy tier.
+2. The generated chi router dispatches to the operation's method on compose.Server, which is a real
+   module Handler shadowing a generated 501 stub.
+3. The Handler decodes the request and calls its module's Store/Service — where the RBAC gate and the
+   workspace transaction (RLS) live. Handlers never decide authorization.
+4. The Store runs SQL over the tables it owns inside WithWorkspaceTx, and for a mutation writes the
+   domain row + an audit_log row + an event_outbox row in that one transaction.
+5. After commit, the outbox relay ships the event to Redis; consumer groups (context-graph, overnight
+   reasoning, read-model, …) react. The Handler maps any error through a sentinel and returns.
+```
+
+Everything below is the detail behind those five steps. The pieces:
+
+- **The contract** (`backend/api/crm.yaml`) defines the surface; code is generated from it
+  ([contract-first.md](contract-first.md)).
+- **Fourteen modules** (`internal/modules/`) are the capabilities; each owns its tables and never
+  imports a sibling ([reference/modules.md](../reference/modules.md)).
+- **The platform toolkit** (`internal/platform/`, `internal/shared/`) is the reusable plumbing every
+  module composes ([reference/platform-toolkit.md](../reference/platform-toolkit.md)).
+- **The compose layer** (`internal/compose/`) wires modules into the four binaries and injects every
+  cross-module edge.
+
+---
+
+## Find-it map — where things live, where to put things
+
+One Go module, `github.com/gradionhq/margince/backend`, rooted at `backend/`. When you're looking for
+something (or deciding where new code goes):
+
+| You want… | It lives in |
+|---|---|
+| An HTTP operation's request/response shape | `backend/api/crm.yaml` (the contract — source of truth) |
+| Generated types + the `ServerInterface` | `internal/contracts/api_gen.go` *(generated — never edit)* |
+| A capability's store, handlers, SQL | `internal/modules/<name>/` (flat package; **which module owns what → [reference/modules.md](../reference/modules.md)**) |
+| A reusable utility (don't reinvent it) | `internal/platform/*`, `internal/shared/*` (**catalog → [reference/platform-toolkit.md](../reference/platform-toolkit.md)**) |
+| The pool + the workspace-transaction contract | `internal/platform/database/database.go` |
+| The one write shape (audit + event) | `internal/platform/database/storekit/` |
+| The admission gate (RBAC + tier + seat) | `internal/platform/auth/` |
+| The outbox relay / bus dedupe | `internal/platform/events/` |
+| Cross-module wiring, the HTTP `Server`, the MCP registry | `internal/compose/` (**how it boots + the edge map → [composition-layer.md](composition-layer.md)**) |
+| Stdlib-only leaves (ids, principal, apperrors, ports) | `internal/shared/` |
+| SQL migrations | `backend/migrations/core/` (upstream) · `custom/` (fork) |
+| The four process binaries | `backend/cmd/{api,worker,migrate,mcp}/` |
+| Codegen tools | `backend/tools/` (its own Go module) |
+| The architecture gates (fitness tests) | `backend/*_test.go` (see below) |
+
+**The rule you'll hit first:** a module in `internal/modules/` **never imports a sibling module**.
+If capability A needs capability B, the edge is injected in `internal/compose/`, never by importing B.
+Three gates enforce this (depguard, go-arch-lint, `arch_test.go`), so a sibling import fails
+`make check` — it is not a style preference.
+
+---
+
+## What's generated vs what you write
+
+A common early confusion is which files you edit. `make gen` derives Go (and TS) from the contract;
+you never hand-edit its output — the drift gate (`make drift`, part of `make check`) fails a hand
+edit. Everything else you author.
+
+**Generated by `make gen` — never hand-edit** (each carries a `DO NOT EDIT` header):
+
+| File | What it is | Produced from |
+|---|---|---|
+| `internal/contracts/api_gen.go` | request/response model types, the `ServerInterface`, the chi router | `crm.yaml` → 3.0 overlay → oapi-codegen |
+| `internal/compose/stubs_gen.go` | one explicit **501** stub per operation (the shadow-able fallback) | `ServerInterface` |
+| `internal/compose/agentpolicy_gen.go` | the agent admission table (verb/tier per route) | `crm.yaml` `x-mcp-tool` / `x-agent-access` |
+| `.build/openapi30.yaml` | the downgraded contract (build artifact, gitignored) | `crm.yaml` |
+| `frontend/src/api/schema.d.ts` | the SPA's TS types | `crm.yaml` (via `pnpm gen:api`) |
+
+**Hand-written — you author these:**
+
+| File | What you write |
+|---|---|
+| `backend/api/crm.yaml` | the contract itself — the *input* to codegen (this is the one "source" file the generators read) |
+| `internal/modules/<name>/` | the handler methods, the store/service, the SQL |
+| `backend/migrations/core|custom/*.sql` | schema changes (up + down) |
+| `internal/compose/{server,provider,registry}.go` + adapters | cross-module wiring and edges |
+| `backend/**/*_test.go` | unit, fitness, and integration tests |
+| `decisions/NNNN-*.md`, `docs/**` | the record of a non-obvious decision, and docs |
+
+So a normal feature is: **edit `crm.yaml` → `make gen` (machine writes the plumbing) → you write the
+handler + store + SQL + tests** (the recipes below).
+
+---
+
+## The deployment model (the binaries)
+
+Four process roles, all assembled through `internal/compose`. Flags/env are tabled in
+[reference/configuration.md](../reference/configuration.md); the shapes to understand:
+
+- **`cmd/api`** — the HTTP surface on `:8080`. By default (`--inline-relay=true`) it *also* ships the
+  outbox to Redis in-process, so **one `cmd/api` is a complete install** for dev and small self-hosted
+  deployments ([decisions/0005](../../decisions/0005-in-process-outbox-relay.md)).
+- **`cmd/worker`** — background consumer (the standalone relay, the River periodic jobs, retention,
+  the Surface-B runner). Only needed for **split deployments**: run `cmd/api --inline-relay=false`
+  alongside one or more workers. River gives leader election, so worker replicas never double-run a
+  job ([decisions/0021](../../decisions/0021-river-job-queue.md)).
+- **`cmd/migrate`** — `up`/`down`, connects with the **owner** role (the app role never owns schema).
+- **`cmd/mcp`** — the governed agent tool surface over stdio or hosted HTTP.
+
+---
+
+## How a store reads and writes (the shape)
+
+Every store method follows one shape: open the **workspace transaction**, gate at the entry point, run
+SQL over the tables the module owns, and — for a mutation — commit the domain row + an audit row + an
+event row together. That is the whole write contract in one call site:
+
+```go
+func (s *Store) CreateDeal(ctx context.Context, in CreateDealInput) (Deal, error) {
+    if err := auth.Require(ctx, "deal", principal.Create); err != nil { return Deal{}, err }
+    return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+        // INSERT INTO deal (...) VALUES (...)                        ← the domain row(s)
+        auditID, _ := storekit.Audit(ctx, tx, "create", "deal", id, nil, after)   // ← audit_log row
+        return storekit.Emit(ctx, tx, auditID, "deal.created", "deal", id, payload) // ← event_outbox row
+    })
+}
+```
+
+`WithWorkspaceTx` binds the tenant to Postgres row-level security, so isolation holds even if a query
+forgets its `WHERE`; the three rows commit in the one transaction. Go deeper where you need it: the
+**tenant isolation** (RLS, `WithWorkspaceTx`, the auth gate) is in
+[authorization.md](authorization.md); the **write backbone** (the `audit_log` DDL, the outbox envelope,
+the relay, dedupe) is in [write-backbone.md](write-backbone.md).
+
+Notes that trip people up:
+
+- **`captured_by` / the actor is server-stamped** from the authenticated principal, never the request body.
+- **`Emit` requires a `correlation_id`** on the context (the HTTP middleware binds one per request; a
+  bespoke background job must bind its own).
+- **Updates need a concurrency guard** — `storekit.Patch.ApplyWithVersion` / `ApplyGuarded`, never a
+  bare by-id UPDATE (a fitness test enforces it).
+- **RBAC is gated at the store entry point** (`auth.Require` + `auth.EnsureVisible`): object denial →
+  403, row-scope miss → 404 (existence-hiding). Why it lives here: [authorization.md](authorization.md).
+- **Publish only through the outbox** — never `XADD` from domain code.
+
+You compose a store from the toolkit rather than hand-rolling it — the full helper set (auth gate,
+storekit, ids, principal, error sentinels, seams) is catalogued in
+[reference/platform-toolkit.md](../reference/platform-toolkit.md).
+
+---
+
+## The gates that judge your PR (fitness functions)
+
+The root of `backend/` holds `go test` "fitness functions" — each turns a rule you'd otherwise have to
+remember into a mechanical gate that derives its scope from the tree or the live schema. Knowing they
+exist tells you what will fail your PR and why:
+
+| Test file | Fails your change if… |
+|---|---|
+| `arch_test.go` | you break the import DAG (e.g. a module imports a sibling) |
+| `writeshape_test.go` | an audited mutation doesn't also emit an outbox event |
+| `tableownership_test.go` | a module writes SQL against a table it doesn't own |
+| `rbacgate_test.go` | an exported `*Store`/`*Service` method doesn't reference the auth gate |
+| `updateguard_test.go` | a single-row-by-id UPDATE of a versioned table has no concurrency guard |
+| `enumsync_test.go` | a Go enum drifts from its schema `CHECK (col IN (...))` set |
+| `consentproof_test.go` | a `person_consent` state write skips its append-only proof row |
+| `piicoverage_test.go` | a PII table isn't reached by erasure + SAR |
+| `errmatch_test.go` | code classifies an error by its `Error()` string instead of SQLSTATE |
+| `license_test.go` | a hand-written `.go` file lacks the BUSL-1.1 SPDX header |
+| `internal/compose/integration/rls_coverage_integration_test.go` | a `workspace_id` table lacks RLS ENABLE+FORCE+policy |
+
+They run in `make check` (unit ones uncached — they walk the module tree) and `make test-integration`
+(the RLS one). The full merge loop (gates, DCO sign-off, craft pre-push hook) is in
+[CONTRIBUTING.md](../../CONTRIBUTING.md); every target is in
+[make-targets.md](../reference/make-targets.md).
+
+---
+
+## Change recipes
+
+Step-by-step task walkthroughs live in **how-to** (the home for recipes) — they thread the contract,
+codegen, and the store shape above into one checklist:
+
+- **Add or change an API endpoint** → [how-to/add-an-endpoint.md](../how-to/add-an-endpoint.md)
+- **Add a new module or a cross-module edge** → [how-to/add-a-module.md](../how-to/add-a-module.md)
+- **Add a database migration** → [how-to/apply-migrations.md](../how-to/apply-migrations.md)
+
+---
+
+## Coordinates
+
+| | |
+|---|---|
+| Go module | `github.com/gradionhq/margince/backend` (root `backend/`) |
+| API port | `:8080` (HTTP under `make dev`; HTTPS front door under `make dev-tls`) |
+| Postgres / Redis / MinIO | `localhost:55432` / `56379` / `59000` |
+| Owner DSN (migrate) | `postgres://margince_owner:dev@localhost:55432/margince` |
+| App DSN (api/worker) | `postgres://margince_app:margince_app_dev@localhost:55432/margince` |
+| Tenant GUC | `app.workspace_id` (set transaction-local by `WithWorkspaceTx`) |
+| Contract | `backend/api/crm.yaml` — regenerate with `make gen` |
+| Generated (never edit) | `internal/contracts/api_gen.go`, `compose/stubs_gen.go`, `compose/agentpolicy_gen.go` |
+| Merge gate | `make check` (+ `make test-integration`, needs `make db-up`) |
+
+Every flag/env: [configuration.md](../reference/configuration.md). Every target:
+[make-targets.md](../reference/make-targets.md).

--- a/docs/explanation/backend-onboarding.md
+++ b/docs/explanation/backend-onboarding.md
@@ -1,74 +1,57 @@
 # Backend contributor orientation
 
-The single starting point for a developer new to the **margince-next** backend. It does **not**
-re-explain the concepts other docs already own — it is the map that ties them together, plus the
-code-level detail and change-recipes those docs deliberately leave out. Everything here is about
-*this* repository.
+The single starting point for a developer new to the **margince-next** backend — the map that ties the
+other docs together, plus the code-level detail and change-recipes they leave out. It does **not**
+re-explain what they already own.
 
 ## Start here (reading order)
 
-1. **[tutorials/getting-started.md](../tutorials/getting-started.md)** — clone → running instance in
-   five commands. Do this first.
-2. **[explanation/architecture.md](architecture.md)** — the shape: the `shared → platform → modules →
-   compose → cmd` DAG, the two spine shapes, the write shape, tenancy-as-structure, the one governed
-   agent surface. Read it for the *why*; this page won't repeat it.
-3. **[explanation/contract-first.md](contract-first.md)** — how the Go surface is generated from
-   `backend/api/crm.yaml`, and why drift is merge-blocking.
-4. **[explanation/authorization.md](authorization.md)** — why the auth check lives at the store/service
-   entry point, not in the handler.
-5. **This page** — the system in one screen, the map, what's generated vs what you write, the code you
-   actually call (store/RLS/write-shape), the gates that judge your PR, and the two change-recipes.
-6. **[CONTRIBUTING.md](../../CONTRIBUTING.md)** + **[AGENTS.md](../../AGENTS.md)** — the PR loop
-   (accountability, DCO sign-off, gates) and the binding engineering rules.
+1. **[tutorials/getting-started.md](../tutorials/getting-started.md)** — clone → running instance in five commands. Do this first.
+2. **[explanation/architecture.md](architecture.md)** — the shape: the `shared → platform → modules → compose → cmd` DAG, the spine shapes, tenancy-as-structure. The *why*.
+3. **[explanation/contract-first.md](contract-first.md)** — how the Go surface is generated from `crm.yaml`, and why drift is merge-blocking.
+4. **[explanation/authorization.md](authorization.md)** — why the auth check lives at the store entry point, not the handler.
+5. **This page** — the system in one screen, the find-it map, generated-vs-written, the code you call, the gates, the change-recipes.
+6. **[CONTRIBUTING.md](../../CONTRIBUTING.md)** + **[AGENTS.md](../../AGENTS.md)** — the PR loop and the binding engineering rules.
 
-Deep dives (read when you touch that area):
-**[reference/modules.md](../reference/modules.md)** (what each of the 14 modules owns) ·
-**[reference/platform-toolkit.md](../reference/platform-toolkit.md)** (the reusable utilities — reach
-for these, don't reinvent) · **[explanation/write-backbone.md](write-backbone.md)** (storekit,
-`audit_log`, the outbox) · **[explanation/agent-surface.md](agent-surface.md)** (the reasoning loop +
-model runtime) · **[explanation/privacy-and-consent.md](privacy-and-consent.md)** (the GDPR engines).
+**Deep dives** — read when you touch that area:
 
-Reference, reach for as needed: **[reference/make-targets.md](../reference/make-targets.md)** ·
-**[reference/configuration.md](../reference/configuration.md)** (every flag/env) ·
-**[how-to/apply-migrations.md](../how-to/apply-migrations.md)** ·
-**[how-to/mint-a-passport.md](../how-to/mint-a-passport.md)** →
-**[how-to/run-the-mcp-server.md](../how-to/run-the-mcp-server.md)**. Implementation decisions are
-recorded under **[`decisions/`](../../decisions/)**.
+- **[reference/modules.md](../reference/modules.md)** — what each module owns.
+- **[reference/platform-toolkit.md](../reference/platform-toolkit.md)** — the reusable utilities (reach for these, don't reinvent).
+- **[explanation/write-backbone.md](write-backbone.md)** — storekit, `audit_log`, the outbox.
+- **[explanation/composition-layer.md](composition-layer.md)** — how `internal/compose` boots and wires the modules.
+- **[explanation/agent-surface.md](agent-surface.md)** — the agent reasoning loop + model runtime.
+- **[explanation/privacy-and-consent.md](privacy-and-consent.md)** — the consent gate + GDPR engines.
+
+**Reference** — look it up:
+
+- **[reference/make-targets.md](../reference/make-targets.md)** — every `make` target.
+- **[reference/configuration.md](../reference/configuration.md)** — every flag and env var.
+- **[how-to/apply-migrations.md](../how-to/apply-migrations.md)**, **[mint-a-passport.md](../how-to/mint-a-passport.md)** → **[run-the-mcp-server.md](../how-to/run-the-mcp-server.md)** — common tasks.
+- **[`decisions/`](../../decisions/)** — the implementation decision records.
 
 ---
 
 ## The system in one screen
 
-Margince is a **governed, multi-tenant CRM**: a Go backend serving a contract-defined HTTP API under
+Margince is a **governed, multi-tenant CRM** — a Go backend serving a contract-defined HTTP API under
 `/v1` (plus an MCP tool surface for AI agents) over Postgres + Redis, with an embedded SPA. "Governed"
-is the theme — every read is tenant-isolated and RBAC-scoped, every write is audited and announced as
-an event, and every AI action is tiered (auto-execute vs stage-for-human-approval).
+is the theme: every read is tenant-isolated and RBAC-scoped, every write is audited and announced as an
+event, and every AI action is tiered (auto-execute vs. stage for human approval).
 
-What happens on one request:
+**What happens on one request:**
 
-```
-1. cmd/api receives an HTTP request; the chassis middleware binds actor + workspace + correlation_id
-   onto the context and (for agents) resolves the autonomy tier.
-2. The generated chi router dispatches to the operation's method on compose.Server, which is a real
-   module Handler shadowing a generated 501 stub.
-3. The Handler decodes the request and calls its module's Store/Service — where the RBAC gate and the
-   workspace transaction (RLS) live. Handlers never decide authorization.
-4. The Store runs SQL over the tables it owns inside WithWorkspaceTx, and for a mutation writes the
-   domain row + an audit_log row + an event_outbox row in that one transaction.
-5. After commit, the outbox relay ships the event to Redis; consumer groups (context-graph, overnight
-   reasoning, read-model, …) react. The Handler maps any error through a sentinel and returns.
-```
+1. **`cmd/api`** receives the request; middleware binds actor + workspace + `correlation_id` onto the context (and, for an agent, resolves the autonomy tier).
+2. The **generated router** dispatches to the operation's method on `compose.Server` — a real module handler shadowing a generated 501 stub.
+3. The **handler** decodes and calls its module's **Store/Service**, where the RBAC gate and the workspace transaction (RLS) live. Handlers never decide authorization.
+4. The **Store** runs SQL over the tables it owns inside `WithWorkspaceTx`; a mutation writes the domain row + an `audit_log` row + an `event_outbox` row in that one transaction.
+5. After commit, the **outbox relay** ships the event to Redis, where consumer groups (context-graph, workflows, overnight reasoning) react. The handler maps any error through a sentinel and returns.
 
-Everything below is the detail behind those five steps. The pieces:
+Everything below is the detail behind those five steps:
 
-- **The contract** (`backend/api/crm.yaml`) defines the surface; code is generated from it
-  ([contract-first.md](contract-first.md)).
-- **Fourteen modules** (`internal/modules/`) are the capabilities; each owns its tables and never
-  imports a sibling ([reference/modules.md](../reference/modules.md)).
-- **The platform toolkit** (`internal/platform/`, `internal/shared/`) is the reusable plumbing every
-  module composes ([reference/platform-toolkit.md](../reference/platform-toolkit.md)).
-- **The compose layer** (`internal/compose/`) wires modules into the four binaries and injects every
-  cross-module edge.
+- **The contract** (`backend/api/crm.yaml`) defines the surface; the Go is generated from it — [contract-first.md](contract-first.md).
+- **The modules** (`internal/modules/`) are the capabilities; each owns its tables and never imports a sibling — [reference/modules.md](../reference/modules.md).
+- **The platform toolkit** (`internal/platform/`, `internal/shared/`) is the reusable plumbing every module composes — [reference/platform-toolkit.md](../reference/platform-toolkit.md).
+- **The compose layer** (`internal/compose/`) wires the modules into the four binaries and injects every cross-module edge — [composition-layer.md](composition-layer.md).
 
 ---
 

--- a/docs/explanation/composition-layer.md
+++ b/docs/explanation/composition-layer.md
@@ -92,6 +92,7 @@ backed by the provider module's store — so neither module names the other. The
 | identity (bootstrap) | deals + consent + agents + activities defaults | `workspaceSeed(dealsH)` (one tx) |
 | activities | consent's outbound suppression gate; people (public booking); consent (unsubscribe link) | `.WithConsent(...)`, `.WithPublicBooking(...)`, `.WithUnsubscribe(...)` |
 | consent (DSR erase) | privacy's `Eraser` (blob-aware under `WithBlobstore`) | `consent.NewHandlers(pool).WithEraser(privacy.NewEraser(pool))` |
+| agents / automations | approvals' staging + redemption (the 🟡 confirm-first effects) | `approvalsHandlersWithEffects(pool)` (`.WithEffects(...)`) |
 | signals | people's relationship-strength | `signalStrength{people: people.NewStore(pool)}` adapter |
 | imap connect | capture's connector registry (vault under `WithKeyvault`) | `imapConnectHandlers{registry: NewCaptureRegistry(pool, vault)}` |
 | filtered export | collections' saved-view/list source | `filteredExportHandlers{collections: collections.NewStore(pool)}` |

--- a/docs/explanation/composition-layer.md
+++ b/docs/explanation/composition-layer.md
@@ -1,0 +1,137 @@
+# The composition layer
+
+`internal/compose/` is the only layer that knows about more than one module. Modules stay flat and
+**never import each other** ([architecture.md](architecture.md)); compose is where they are assembled
+into the running binaries and where **every cross-module edge is injected**. This page explains how it
+initializes and where things are wired. To *add* a feature that touches it, see
+[how-to/add-a-module.md](../how-to/add-a-module.md).
+
+## What compose owns
+
+- **The composite HTTP `Server`** — every module's handlers, shadowing the generated 501 stubs.
+- **The cross-module edges** — injected as small adapters, so no module imports a sibling.
+- **The datasource `Provider`** — the system-of-record seam the agent/MCP surface binds to.
+- **The MCP tool registry** — the one governed tool surface, shared by `cmd/mcp` and the REST agent gate.
+- **The background wiring** each binary needs — the River job runner, the Surface-B runner, the
+  workflow engine, the capture registry.
+- **The per-role `Option`s** — how each binary customizes the wiring.
+
+## The `Server`: module handlers shadow generated stubs
+
+`Server` (`server.go`) embeds each module's handler set (via a type alias per module) **and** the
+generated `stubs`. Go promotes the shallower method, so a module handler shadows the matching 501 stub:
+
+```go
+type Server struct {
+    authHandlers        // = identity.Handlers
+    peopleHandlers      // = people.Handlers
+    dealsHandlers       // = deals.Handlers
+    …                   // one embedded handler set per module
+    // + injected infra: busReady, blob, vault, log
+}
+var _ crmcontracts.ServerInterface = Server{}   // compile-time completeness guarantee
+```
+
+That assertion is load-bearing: if a regenerated contract adds an operation nothing implements,
+`Server` stops satisfying `ServerInterface` and the build fails **here** — the stubs are simultaneously
+the fallback (an unimplemented op answers a loud 501, never a silent 404) and the drift gate's
+inventory. (The generated stubs live in `stubs_gen.go`; see [contract-first.md](contract-first.md).)
+
+## How it boots — `compose.New` (the api handler)
+
+`cmd/api` calls `compose.New(pool, log, opts...) http.Handler`. The pipeline (`server.go`):
+
+```go
+func New(pool, log, opts...) http.Handler {
+    dealsH := deals.NewHandlers(pool)
+    identitySvc := identity.NewService(pool)
+    authH := identity.NewHandlers(identitySvc, workspaceSeed(dealsH)) // ← bootstrap hook (below)
+
+    srv := newServer(pool, log, authH, dealsH)  // 1. assemble handler sets + cross-module edges
+    for _, opt := range opts { opt(&srv, pool) } // 2. per-role customization
+
+    api := contractAPI(srv, pool, identitySvc)   // 3. mount /v1 (generated router + admission)
+    mux := operationalMux(srv, pool, log, authH, api) // 4. health/ready/metrics/public/oauth/SPA
+    return httpserver.RecoverPanics(log, httpserver.LimitBodies(httpserver.SecureHeaders(mux))) // 5.
+}
+```
+
+1. **`newServer`** builds every module's handler set and injects the cross-module edges (see the map
+   below).
+2. **Options** apply per-role customization (blobstore, keyvault, bus probe, …).
+3. **`contractAPI`** mounts the generated chi router at `BaseURL: "/v1"` with two middlewares:
+   `agentGate` (the transport-agnostic admission layer — same tier table as the MCP surface) then
+   `idempotency`. Idempotency sits **outermost** so a staged-approval refusal is never recorded as
+   "the" response for an idempotency key (the approved retry is the same request under the same key).
+4. **`operationalMux`** mounts the contract surface next to `/healthz`, `/readyz` (role-specific
+   dependency probes), `/metrics`, the anonymous `/v1/public/*` edges, the `/oauth` A2 authorization
+   server, and the embedded SPA.
+5. The whole thing is wrapped `RecoverPanics → LimitBodies → SecureHeaders`.
+
+## The workspace-bootstrap seed (one transaction)
+
+`workspaceSeed` is the hook `identity` runs when a workspace is bootstrapped (`POST /v1/workspaces`). It
+seeds **every module's per-workspace defaults in ONE transaction** — they stand or fall together — yet
+identity imports none of those modules, because the hook is injected here:
+
+```go
+func workspaceSeed(dealsH) func(ctx, tx) error {
+    // deals default pipeline → consent purposes → consent retention →
+    // agents starter automations → activities booking page — all in the caller's tx
+}
+```
+
+## The cross-module edges (the map)
+
+Every edge is an **adapter constructed in compose** that implements the consumer's small interface,
+backed by the provider module's store — so neither module names the other. The current edges
+(`newServer` + the blob/vault Options):
+
+| Consumer | ← needs | Wired as |
+|---|---|---|
+| identity (bootstrap) | deals + consent + agents + activities defaults | `workspaceSeed(dealsH)` (one tx) |
+| activities | consent's outbound suppression gate; people (public booking); consent (unsubscribe link) | `.WithConsent(...)`, `.WithPublicBooking(...)`, `.WithUnsubscribe(...)` |
+| consent (DSR erase) | privacy's `Eraser` (blob-aware under `WithBlobstore`) | `consent.NewHandlers(pool).WithEraser(privacy.NewEraser(pool))` |
+| signals | people's relationship-strength | `signalStrength{people: people.NewStore(pool)}` adapter |
+| imap connect | capture's connector registry (vault under `WithKeyvault`) | `imapConnectHandlers{registry: NewCaptureRegistry(pool, vault)}` |
+| filtered export | collections' saved-view/list source | `filteredExportHandlers{collections: collections.NewStore(pool)}` |
+
+The shape to copy: *a small consumer-side interface + a compose adapter struct that satisfies it from
+the provider's store.*
+
+## Per-role `Option`s, and "declare absence by omission"
+
+An `Option func(*Server, *pgxpool.Pool)` customizes the wiring for one process role; everything not
+optioned keeps its safe default. The current options: `WithBusReady`, `WithBlobstore`, `WithKeyvault`,
+`WithPublicBaseURL`, `WithColdStart`, `WithScrape`, `WithBrief`.
+
+The important rule: **a capability whose infra a role wasn't given leaves its endpoints as the generated
+501 stub rather than nil-derefing at request time.** No `WithBlobstore` → the `/attachments` endpoints
+answer 501 (a role that stores no objects declares that by omission). A capture-capable role must pass
+`WithKeyvault` or fail to boot. `/readyz` probes exactly the dependencies the role wired — so a split
+deployment answers ready on what it actually depends on.
+
+## The other compose entry points (per binary)
+
+Each binary composes only what its role needs, all through this one layer:
+
+| Entry point | Builds | Used by |
+|---|---|---|
+| `New(pool, log, opts…)` | the api HTTP handler | `cmd/api` |
+| `NewProvider(pool)` | the `datasource.SystemOfRecordProvider` (people/deals/activities/reports) | the agent gate + MCP registry |
+| `NewRegistry(pool)` | the MCP tool registry | `cmd/mcp` + the REST agent gate |
+| `NewJobRunner(pool, log, …)` | the River periodic jobs (close-date sweep, reconcile) | `cmd/worker` |
+| `NewRunnerService(pool, brain, retriever, log)` | the Surface-B reasoning runner | `cmd/worker` |
+| `NewWorkflowEngine(pool)` | the workflow dispatcher | `cmd/worker` |
+| `NewCaptureRegistry(pool, vault)` | the connector registry | `cmd/worker` backfill, api imap-connect |
+
+## Where the code lives
+
+| | |
+|---|---|
+| `Server`, `New`, `newServer`, Options, `contractAPI`, `operationalMux` | `internal/compose/server.go` |
+| The datasource provider | `internal/compose/provider.go` |
+| The MCP registry | `internal/compose/registry.go` |
+| The REST admission middleware | `internal/compose/agentgate.go`, `idempotency.go` |
+| Background wiring | `internal/compose/{jobs,runnerservice,workflows,capture}.go` |
+| Generated (never edit) | `internal/compose/{stubs_gen,agentpolicy_gen}.go` |

--- a/docs/explanation/contract-first.md
+++ b/docs/explanation/contract-first.md
@@ -36,14 +36,7 @@ runtime from day one:
 
 ## Changing the surface
 
-The order is always: spec/contract first, then code.
-
-1. Contract changes originate in the spec repo; `crm.yaml` here follows
-   it. Discrepancies you find while building are filed in `feedback/`,
-   not patched silently into the code.
-2. Regenerate (`make gen`) — new operations appear as 501 stubs and the
-   agent-policy lint tells you if a mutation lacks an autonomy tier.
-3. Implement the handler in the owning module and register it in
-   `internal/compose`, shadowing the stub.
-4. `make check` proves the contract, the generated artifacts, and the
-   implementation agree.
+The order is always **contract first, then code**: edit `crm.yaml`, regenerate (`make gen`), implement
+the handler in the owning module shadowing the generated stub, and let `make check` prove the contract,
+the generated artifacts, and the implementation agree. The step-by-step checklist is a how-to:
+**[how-to/add-an-endpoint.md](../how-to/add-an-endpoint.md)**.

--- a/docs/explanation/privacy-and-consent.md
+++ b/docs/explanation/privacy-and-consent.md
@@ -1,0 +1,80 @@
+# Privacy, consent & the GDPR engines
+
+How Margince meets data-subject obligations: the **consent suppression gate** that guards every
+outbound send, and the **privacy engines** (erasure, subject-access, retention) that a fulfilled
+request executes. Two modules cooperate — `consent` owns the gate and the case queue, `privacy` owns
+the machinery — and they are stitched together at the composition root, never by a sibling import.
+
+## The default-deny suppression gate (`consent`)
+
+`consent` owns per-purpose consent: the purpose catalog, each person's current state, and an
+**append-only proof log**. The load-bearing piece is the **Gate** — the default-deny check every
+outbound surface consults *before anything leaves the workspace*:
+
+- The question is always **per purpose**: a `marketing` grant never authorizes a `profiling` use.
+- **Default-deny in every direction** — an unknown purpose, an address that resolves to no subject,
+  state `unknown`, and state `withdrawn` all block. A double-opt-in purpose additionally requires the
+  confirmed round-trip on the proof log (a granted-but-unconfirmed row does not send).
+- A refusal answers `ErrConsentNotGranted` and names only the address — it discloses nothing new.
+
+The gate is spelled once (`consent.NewGate`) and **injected into the send path** (activities) at the
+composition root, so consent never becomes an import edge between siblings. Every consent *state* write
+also appends a proof row (Art. 7(1) demonstrability) — a fitness test (`consentproof_test.go`) fails any
+state write that skips its proof.
+
+## The privacy engines (`privacy`)
+
+`privacy` owns the GDPR machinery a fulfilled request runs. The DSR **case queue** lives in `consent`
+(the `data_subject_request` rows + their HTTP surface); the composition root injects privacy's engines
+into consent's handlers.
+
+- **Art. 17 erasure** (`Eraser.ErasePerson`) — anonymize the normalized rows in place, purge raw
+  capture, embeddings, and attachment bytes, hash the identifiers onto a **suppression list** so
+  re-capture can't resurrect the subject, and prove it with a **PII-free audit tombstone** — all in
+  **one transaction per record**. Atomicity *is* the guarantee. It refuses a subject under `legal_hold`.
+- **Art. 15 subject access** (`AssembleSAR`) — one *privileged* read (needs the `person.delete` grant
+  **and** an unbounded row scope) gathers everything held about a person — channels, deals, leads,
+  activities, attachments, consent + its proof log, raw capture, field origins — into one export
+  package, itself audited (`action=export`).
+- **The nightly retention evaluator** (`RunRetention`, scheduled in `cmd/worker`, default every 24h) —
+  evaluates each workspace's enabled policies and applies the policy's single action to over-age
+  records, **one audited transaction per record**. `legal_hold` rows are never auto-acted, and an
+  activity is held transitively when any linked person/organization/deal is held. A policy whose scope
+  the engine doesn't understand is **skipped loudly**, never half-applied.
+
+## The single-transaction cross-store exception
+
+`privacy` owns exactly one table (`erasure_suppression`) — yet erasure and retention deliberately
+**write tables they do not own**: `person`, `person_email`/`_phone`/`_social`, `lead`, `activity`,
+`deal`, `attachment`, `embedding`, `raw_capture`, `field_provenance`. That is by design: a data-subject
+obligation must reach **every** store that holds the subject, in **one transaction per record** —
+routing each purge through the owning module would trade away the atomicity that is the guarantee.
+
+This is the one sanctioned exception to "a module writes only its own tables." Every such write is
+**ratified per table** in `backend/tableownership_test.go` with a self-contained rationale; a reasonless
+or stale waiver fails the test. (The exception is recorded in
+[decisions/0011](../../decisions/0011-triad-restructure.md).) See
+[reference/modules.md](../reference/modules.md) for the ownership map and
+[write-backbone.md](write-backbone.md) for the write shape these purges still ride.
+
+## Jurisdiction retention floors
+
+A destructive retention action must not violate a statutory floor. Country packs register through the
+`ports/jurisdiction` seam and **compile into the binary by a blank import** — core code never names a
+jurisdiction. The **`de`** (German) pack declares GoBD retention classes; the retention evaluator takes
+the strictest compiled-in **commercial-correspondence** floor and shields external business
+correspondence (a *Handelsbrief*) from destruction below it — while an internal note or task, which is
+not correspondence, carries no floor. A fitness test pins that boundary (a 400-day email survives; a
+same-age note is erased).
+
+## Where the code lives
+
+| | |
+|---|---|
+| The suppression gate | `internal/modules/consent/gate.go` (`NewGate`) |
+| Consent state + proof log | `internal/modules/consent/` (`consent_purpose`, `person_consent`, `consent_event`) |
+| Art. 17 erasure | `internal/modules/privacy/erasure.go` (`NewEraser`, `ErasePerson`) |
+| Art. 15 SAR | `internal/modules/privacy/sar.go` (`AssembleSAR`) |
+| Retention evaluator | `internal/modules/privacy/retention.go` (`RunRetention`), scheduled in `cmd/worker` |
+| Cross-store ratification | `backend/tableownership_test.go` |
+| Jurisdiction packs | `internal/shared/ports/jurisdiction/`, `internal/modules/de/` |

--- a/docs/explanation/write-backbone.md
+++ b/docs/explanation/write-backbone.md
@@ -12,7 +12,7 @@ Read those first if you want the short version.
 
 ## The shape at a glance
 
-```
+```text
 HTTP request / agent run / bus consumer
         │  (middleware binds actor + workspace + correlation_id onto ctx)
         ▼

--- a/docs/explanation/write-backbone.md
+++ b/docs/explanation/write-backbone.md
@@ -1,0 +1,298 @@
+# The write backbone — storekit, `audit_log` & the outbox
+
+Every mutation in this backend commits **three rows in one transaction** — the domain row, an
+`audit_log` row, and an `event_outbox` row — through code spelled once in `storekit`. A relay then
+ships the outbox to the event bus, and consumers dedupe. That is one mechanism, not three, so this is
+one document.
+
+It is the deep reference behind the one-paragraph summary in
+[architecture.md](architecture.md#the-write-shape) and the store call-site in
+[backend-onboarding.md](backend-onboarding.md#how-a-store-reads-and-writes-the-shape).
+Read those first if you want the short version.
+
+## The shape at a glance
+
+```
+HTTP request / agent run / bus consumer
+        │  (middleware binds actor + workspace + correlation_id onto ctx)
+        ▼
+  module Handler ──► Store.tx(ctx, fn)  ==  database.WithWorkspaceTx(ctx, pool, fn)
+                          │  SET LOCAL app.workspace_id  (RLS bound)
+                          ▼
+        ┌───────────────── ONE transaction ─────────────────┐
+        │  INSERT INTO <domain table> …           ← the change │
+        │  storekit.Audit(…)  → INSERT audit_log  ← the record │  returns auditID
+        │  storekit.Emit(…, auditID, …) → INSERT event_outbox  │  (envelope links auditID)
+        └──────────────────── COMMIT ───────────────────────┘
+                          │
+                          ▼
+   platform/events.Relay  ── polls event_outbox WHERE published_at IS NULL ORDER BY seq
+                          ── XADD envelope → Redis stream  (gw:events:crm:<entity>)
+                          ── UPDATE event_outbox SET published_at = now()
+                          ▼
+   consumer groups (cg:context-graph, cg:overnight-agent, …)
+                          └─ each handler wrapped in events.Dedupe(event_id)
+```
+
+**Why three rows, one transaction.** The domain change, the proof it happened, and the event that
+announces it either all commit or none do. There is no "write the row, then best-effort publish" dual
+write to go wrong: the event is staged in the same Postgres transaction (the *transactional outbox*
+pattern), and a separate relay moves it to the bus afterwards. A crash between commit and relay leaves
+the row `published_at IS NULL` — the relay picks it up on the next poll.
+
+---
+
+## 1. `storekit` — the one spelling
+
+`internal/platform/database/storekit/` holds the mechanics every module store shares; modules own
+their tables and SQL, the invariants live here. The two functions that carry the write shape:
+
+```go
+// Writes the append-only audit_log row inside the mutation's tx; RETURNS its id
+// so the paired event can carry it as trace.audit_log_id.
+func Audit(ctx, tx, action, entityType string, entityID ids.UUID, before, after any) (ids.UUID, error)
+
+// Same, plus operational evidence ABOUT the mutation (which policy fired, which
+// inbound message triggered it) landing in audit_log.evidence — never in before/after.
+func AuditWithEvidence(ctx, tx, action, entityType string, entityID ids.UUID, before, after any, evidence map[string]any) (ids.UUID, error)
+
+// Stages the domain event in the transactional outbox, linked to the audit row.
+func Emit(ctx, tx, auditID ids.UUID, eventType, entityType string, entityID ids.UUID, payload any) error
+```
+
+What they do, precisely (from `storekit.go`):
+
+- **`Audit`** resolves the actor from context (`store: no actor bound` if missing — the middleware
+  always binds one), reads the workspace, marshals `before`/`after`/`evidence` to JSON, mints a
+  UUIDv7 id, and inserts the `audit_log` row — stamping `authorization_rule = auth.AuthzRule(p,
+  entityType, action)` (which RBAC/scope rule allowed it). It returns the new row id.
+- **`Emit`** resolves the actor and workspace, **requires** a `correlation_id` on the context
+  (`store: no correlation id bound` otherwise), builds the full `events.Envelope` (see §3), attaches
+  the `auditID` as `trace.audit_log_id` and a `causation_id` if the context carries one, resolves the
+  stream with `StreamFor(eventType)`, runs `env.Validate()`, and inserts `(stream, envelope)` into
+  `event_outbox`.
+- **`CapturedBy(ctx)`** returns the authenticated principal's id — the server-derived provenance
+  stamp. Provenance (`captured_by`) and the audit actor are **never** taken from a request body; a
+  client that could set them could forge the P5 provenance signal.
+
+**The before/after vs evidence discipline matters.** `before`/`after` are reserved for the *record's
+own field images* — the field-history read (`GET /v1/field-history`) projects per-field diffs directly
+from them. Operation metadata (a retention policy id, the inbound email that triggered a promotion)
+goes in `evidence`. Folding metadata into `before`/`after` would make field-history show field changes
+that never happened on the record.
+
+**Concurrency for updates.** A by-id UPDATE of a versioned row never uses a bare `UPDATE`; it goes
+through `storekit.Patch`:
+
+```go
+p := storekit.NewPatch()
+p.Set("name", old.Name, in.Name)            // accumulates the SET list + the before/after audit diff
+err := p.ApplyWithVersion(ctx, tx, "deal", id, version)   // version-CAS: 0 rows on a live row → ErrVersionSkew
+// or p.ApplyGuarded(ctx, tx, "deal", id, in.IfVersion)   // CAS when a version is supplied, else LockRow+ApplyLocked
+```
+
+`Patch.Before()/After()` then feed straight into `Audit`, so the update, its audit diff, and its event
+stay one story.
+
+---
+
+## 2. `audit_log` — the immutable spine
+
+Defined in `migrations/core/0012_audit_log.up.sql` (actor vocabulary extended additively by `0016`,
+action vocabulary by `0018`/`0053`):
+
+| Column | Meaning |
+|---|---|
+| `id` | UUIDv7 PK (time-ordered) |
+| `workspace_id` | tenant FK, `ON DELETE RESTRICT` — it **is** an RLS tenant table |
+| `actor_type` | `CHECK IN ('human','agent','connector','system')` |
+| `actor_id` | user uuid / agent id / connector name / `system` |
+| `passport_id` | the Agent Seat Passport that authorized an agent action (nullable) |
+| `on_behalf_of` | the human authority behind an agent/connector action (nullable FK `app_user`) |
+| `action` | `CHECK IN ('create','update','archive','merge','promote','restore','export','erase','login','assign','advance_stage', …)` — extended additively |
+| `entity_type` / `entity_id` | the subject (`entity_id` NULL for non-entity actions like login/export) |
+| `before` / `after` | the record's field images (jsonb) — **field-history reads these** |
+| `authorization_rule` | which RBAC/scope rule allowed the write |
+| `evidence` | operation metadata (jsonb) |
+| `occurred_at` | `timestamptz DEFAULT now()` |
+
+**Append-only, enforced two ways.** A trigger raises loudly on any mutation, and the app role's grants
+are revoked — so a tamper attempt *fails*, never silently no-ops:
+
+```sql
+CREATE TRIGGER trg_audit_no_mutate BEFORE UPDATE OR DELETE ON audit_log
+  FOR EACH ROW EXECUTE FUNCTION audit_log_immutable();   -- RAISE EXCEPTION … ERRCODE 'check_violation'
+-- plus migrations/core/0015: REVOKE UPDATE, DELETE ON audit_log FROM margince_app;
+```
+
+The actor columns are the structured mirror of the envelope's `Actor` (§3) — the same four classes,
+kept in lock-step by a fitness test so a fifth class can't slip onto the bus and break the mirror.
+
+---
+
+## 3. `event_outbox` — the transactional outbox
+
+Defined in `migrations/core/0013_event_outbox.up.sql` (+ the `seq` column in `0016`):
+
+| Column | Meaning |
+|---|---|
+| `id` | UUIDv7 PK |
+| `stream` | destination stream key, e.g. `gw:events:crm:deal` |
+| `envelope` | the full typed envelope (jsonb) |
+| `seq` | `bigint GENERATED ALWAYS AS IDENTITY` — assigned at INSERT |
+| `published_at` | NULL until the relay ships it |
+| `created_at` | `timestamptz DEFAULT now()` |
+
+It is **infra-owned and carries no RLS** — tenancy rides *inside* the envelope (`workspace_id`), not as
+a row policy. The relay poll orders by **`seq`, not `created_at`**: `created_at` is transaction-*start*
+time, so a long transaction could publish "before" a short one that committed earlier. `seq` is
+assigned at INSERT, and because two transactions touching one entity serialize on its row lock,
+per-entity `seq` order **is** commit order (no cross-entity order is promised, which is all the bus
+needs).
+
+### The envelope (`internal/shared/kernel/events/envelope.go`)
+
+`Emit` builds this shape; the relay ships it verbatim; consumers decode `payload` per the catalog.
+
+```go
+type Envelope struct {
+    EventID     ids.UUID        // UUIDv7 — the consumer-side idempotency key (dedupe on this)
+    Type        string          // "<entity>.<verb>", e.g. "deal.created"
+    Version     int             // payload schema version, stamped from VersionOf(Type)
+    WorkspaceID ids.UUID        // the bus analogue of RLS
+    OccurredAt  time.Time
+    Actor       Actor           // {Type, ID, PassportID, OnBehalfOf} — mirrors audit_log
+    Entity      EntityRef       // {Type, ID} — a REF, never the record body
+    Payload     json.RawMessage // per-type; consumers read the record back under their own scopes
+    Trace       Trace           // {CorrelationID, CausationID, AuditLogID}
+}
+```
+
+`Envelope.Validate()` is the shared gate both sides run: it rejects an envelope with no event_id,
+an unroutable `Type`, a version mismatch, no workspace, an unknown actor class, no entity ref, or an
+incomplete trace. `Emit` runs it **before** the outbox insert, so a malformed event fails at the write
+— never as a wedged relay row.
+
+### The event catalog (`internal/shared/kernel/events/catalog.go`)
+
+The enumerable set of `<entity>.<verb>` types, each mapped to its stream + payload version:
+
+- **Ten V1 streams**, prefix `gw:events:crm:` — `person, organization, deal, lead, activity,
+  approval, capture, coldstart, audit, identity`. Workspace is an envelope field, never a stream
+  (per-tenant streams would explode key count).
+- **Family routing:** a type whose entity segment isn't itself a stream rides its family — e.g.
+  `consent.*` / `retention.*` → the `person` stream; `offer.*` / `pipeline.*` / `stage.*` → `deal`;
+  `signal.*` → `capture`; `user.deactivated` / `role.changed` / `passport.revoked` → `identity`.
+- **`StreamFor(type)`** routes; an unknown type is a programming error surfaced *before* the outbox
+  write (an unroutable row would wedge the relay forever). **`VersionOf(type)`** is the single source
+  of the payload version, so a future v2 bump happens in one place.
+
+**Adding a new event type = adding one line to `catalog`** (plus its payload type). Miss it and
+`Emit`/`Validate` fail loudly at the write.
+
+---
+
+## 4. The relay — outbox → bus
+
+`internal/platform/events/relay.go`. It never *originates* an event; it only moves what a transaction
+already committed:
+
+- Inside `database.WithInfraTx` (the no-GUC helper — `event_outbox` has no RLS), it claims a batch:
+  ```sql
+  SELECT id, stream, envelope FROM event_outbox
+   WHERE published_at IS NULL ORDER BY seq LIMIT $1 FOR UPDATE SKIP LOCKED
+  ```
+  `FOR UPDATE SKIP LOCKED` lets two replicas split the backlog without double-shipping.
+- For each row it `XADD`s the envelope to its stream (capped `MAXLEN ~`), then
+  `UPDATE event_outbox SET published_at = now()` for the shipped prefix. Idle poll ~200ms.
+- **Where it runs:** inline in `cmd/api` by default (`--inline-relay=true`) — one process is a complete
+  install — or standalone in `cmd/worker` for split deployments
+  ([decisions/0005](../../decisions/0005-in-process-outbox-relay.md)). Domain code **never** `XADD`s
+  directly.
+- Delivery is **at-least-once** by design (a crash after XADD, before the `published_at` stamp,
+  re-ships the row). Backlog + throughput are exported on `/metrics`
+  (`margince_outbox_unpublished`, `margince_relay_published_total`), and when the relay is inline the
+  bus is a `/readyz` dependency.
+
+---
+
+## 5. The consumer side — groups & dedupe
+
+`internal/platform/events/subscriber.go` + `dedupe.go`. Redis consumer groups (seven in V1:
+`cg:context-graph`, `cg:overnight-agent`, `cg:workflows`, `cg:capture`, `cg:flow-bridge`,
+`cg:read-model`, `cg:audit-stream`) each see every event once and scale horizontally inside the group.
+Because Redis groups partition only by stream, the workspace and actor filters run in-process.
+
+Every handler is wrapped in `events.Dedupe`:
+
+```go
+func Dedupe(rdb, group, next) Handler   // key = "gw:dedupe:<group>:<event_id>", TTL 96h
+```
+
+The order is **run-then-mark**, and it's load-bearing: a mark written *before* the effect would, on a
+crash in between, survive as a claim with no effect — the redelivery would be swallowed and the event
+silently lost. Marking *after* means a crash can only cause a re-run, which the **authoritative**
+idempotency layer absorbs as a no-op. That layer is effects upserting by natural key
+(`uq_activity_source` and kin) — Dedupe is an optimization over it, never a correctness substitute.
+The 96h TTL sits above the stream retention horizon so a long-offline consumer can't re-see an event
+after its dedupe entry expired.
+
+---
+
+## 6. Correlation & causation (the trace)
+
+The `Trace` on every envelope lets you reconstruct one operation as a single story:
+
+- **`correlation_id`** groups every event of one originating operation. It is minted **once** per HTTP
+  request by the chassis middleware (`internal/platform/httpserver/chassis.go`:
+  `principal.WithCorrelationID(r.Context(), ids.NewV7())`) and once per agent run
+  (`compose/runnerservice.go`). A background job that emits must bind its own — `Emit` errors without
+  one.
+- **`causation_id`** is the `event_id` that *caused* this event (nil for the first in a chain) — set
+  from `principal.CausationEvent(ctx)` when a consumer re-binds its triggering event before doing more
+  work. Correlation is the whole operation; causation is the parent edge.
+- **`audit_log_id`** links the event back to the exact audit row written in its transaction.
+
+---
+
+## 7. The invariants, and the gates that hold them
+
+You don't have to remember these — a fitness test fails your PR if you break one (see
+[backend-onboarding.md](backend-onboarding.md#the-gates-that-judge-your-pr-fitness-functions)):
+
+| Rule | Gate |
+|---|---|
+| Every audited mutation also emits an outbox event (in the same function) | `writeshape_test.go` |
+| `audit_log` / `event_outbox` are written only through `storekit` | `tableownership_test.go` |
+| A by-id UPDATE of a versioned row carries a concurrency guard | `updateguard_test.go` |
+| The `audit_log` `action`/`actor_type` CHECK sets equal their Go enums | `enumsync_test.go` |
+| `audit_log` is a tenant table with RLS ENABLE+FORCE+policy | `rls_coverage_integration_test.go` |
+| Errors are classified by SQLSTATE, never `Error()` text | `errmatch_test.go` |
+
+---
+
+## Rules of thumb
+
+- **Never `INSERT` into `audit_log` or `event_outbox` directly** — always `storekit.Audit` / `Emit`,
+  in the domain write's transaction.
+- **Actor and `captured_by` are server-stamped** from the authenticated principal, never a request
+  body.
+- **`before`/`after` are the record's field images; `evidence` is operation metadata** — keep them
+  separate or field-history lies.
+- **A new event type needs a `catalog` entry** (and its payload type) — otherwise `StreamFor` /
+  `Validate` fail at the write, which is where you want to find out.
+- **Bind a `correlation_id`** on any write path the HTTP/runner middleware doesn't cover (a bespoke
+  background job).
+
+## Where the code lives
+
+| | |
+|---|---|
+| Write shape (`Audit`, `AuditWithEvidence`, `Emit`, `Patch`) | `internal/platform/database/storekit/{storekit,patch}.go` |
+| Envelope + catalog (types, streams, versions, groups) | `internal/shared/kernel/events/{envelope,catalog}.go` |
+| The relay | `internal/platform/events/relay.go` |
+| Consumer subscriber + dedupe | `internal/platform/events/{subscriber,dedupe}.go` |
+| `audit_log` DDL + immutability | `migrations/core/0012_audit_log.up.sql` (+ `0016`/`0018`/`0053`) |
+| `event_outbox` DDL + `seq` | `migrations/core/0013_event_outbox.up.sql` (+ `0016`) |
+| App-role grants (audit_log revoke) | `migrations/core/0015_app_role_grants.up.sql` |
+| Correlation minting | `internal/platform/httpserver/chassis.go`, `internal/compose/runnerservice.go` |

--- a/docs/explanation/write-backbone.md
+++ b/docs/explanation/write-backbone.md
@@ -218,10 +218,31 @@ already committed:
 
 ## 5. The consumer side — groups & dedupe
 
-`internal/platform/events/subscriber.go` + `dedupe.go`. Redis consumer groups (seven in V1:
-`cg:context-graph`, `cg:overnight-agent`, `cg:workflows`, `cg:capture`, `cg:flow-bridge`,
-`cg:read-model`, `cg:audit-stream`) each see every event once and scale horizontally inside the group.
-Because Redis groups partition only by stream, the workspace and actor filters run in-process.
+`internal/platform/events/subscriber.go` + `dedupe.go`. The catalog declares **seven** V1 consumer
+groups; each sees every event once and scales horizontally inside the group. Because Redis groups
+partition only by stream, the workspace and actor filters run in-process.
+
+**What each group does — and which are live.** Only **three** are wired to a subscriber today, all in
+`cmd/worker`; the other four are catalog-declared placeholders with no consumer yet (honest status —
+the streams carry events, but nothing reads these groups):
+
+| Group | Job | Status |
+|---|---|---|
+| `cg:context-graph` | maintain the pgvector retrieval embeddings as records change | **live** (worker; only when an embedder model is configured) |
+| `cg:workflows` | dispatch the automation/workflow engine off matching events | **live** (worker) |
+| `cg:overnight-agent` | on `approval.decided`, resume the parked Surface-B run with the human's answer | **live** (worker; only when a model is configured) |
+| `cg:capture` | (reserved) | declared, no subscriber |
+| `cg:flow-bridge` | (reserved) | declared, no subscriber |
+| `cg:read-model` | (reserved) read-model projections | declared, no subscriber |
+| `cg:audit-stream` | (reserved) the agent-action audit slice | declared, no subscriber |
+
+**The workflow seam** (`ports/workflow`) is how `cg:workflows` reacts without a visual builder:
+a `Handler` declares a `Spec` (name + trigger + tier), a pure `Match` predicate, a `Plan` that computes
+a **typed `Effect`** *without applying it* (so dry-run/diff preview work), and an `Apply` that executes
+it — 🟢 effects auto-execute, 🟡 effects need an approval token — idempotent on the handler's
+idempotency key. Effects are a **closed** action set (`create_record`, `update_record`, `assign_owner`,
+`advance_deal`, `send_email`, … — the anti-builder guard). `compose.NewWorkflowEngine` registers the
+shipped starter workflows plus the system ones (lead routing/scoring).
 
 Every handler is wrapped in `events.Dedupe`:
 

--- a/docs/how-to/add-a-module.md
+++ b/docs/how-to/add-a-module.md
@@ -1,0 +1,69 @@
+# Add a module (and wire it into compose)
+
+For adding a whole new **capability** (a module) or a **cross-module edge** — the cases that touch the
+composition layer. For adding a single operation to an *existing* module, use
+[add-an-endpoint.md](add-an-endpoint.md); for how compose assembles, read
+[explanation/composition-layer.md](../explanation/composition-layer.md).
+
+## Add a new module
+
+1. **Create the flat package** `internal/modules/<name>/` with a `doc.go` that states the one-line
+   purpose and a **"Tables owned"** list (the ownership fitness test reads it). Pick one spine shape:
+   *Handlers→Store* (CRUD) or *Handlers→Service* (engine) — see the existing modules in
+   [reference/modules.md](../reference/modules.md).
+2. **Add its migrations** ([apply-migrations.md](apply-migrations.md)) and list every new table in the
+   `doc.go`.
+3. **Add its contract operations** and regenerate ([add-an-endpoint.md](add-an-endpoint.md)) — the ops
+   now answer 501 until wired.
+4. **Embed the handler set in `Server`** (`internal/compose/server.go`): add a type alias
+   (`fooHandlers = foo.Handlers`), add the field to the `Server` struct, and construct it in
+   `newServer` (`fooHandlers: foo.NewHandlers(pool)`). Method promotion then shadows the generated 501
+   stubs automatically — no routing to write.
+5. **Only import `shared` + `platform` + the generated contract** — never a sibling module. `arch-lint`
+   fails a sibling import.
+6. **`make check`** — the `var _ ServerInterface = Server{}` assertion proves the ops are implemented,
+   `arch-lint` proves the DAG holds, and the fitness tests (table ownership, RBAC gate, write shape)
+   run.
+
+## Add a cross-module edge (module A needs module B)
+
+A module never imports a sibling. Inject the dependency in compose as an adapter:
+
+1. **Declare a small consumer-side interface in module A** for exactly what it needs (e.g.
+   `signals` declares a `StrengthSource` with the one method it calls), and take it as a constructor
+   parameter (`signals.NewHandlers(pool, strength)`).
+2. **Write the adapter in compose** that satisfies that interface, backed by module B's store:
+   ```go
+   type signalStrength struct{ people *people.Store }
+   func (a signalStrength) Strength(...) (...) { return a.people.Strength(...) } // delegate
+   ```
+3. **Inject it in `newServer`**: `signalsHandlers: signals.NewHandlers(pool, signalStrength{people: people.NewStore(pool)})`.
+   Now A depends on the interface, B is reached only through the compose adapter, and neither imports
+   the other. (Existing examples: activities←consent gate, consent←privacy eraser, imap←capture
+   registry — see the edge map in [composition-layer.md](../explanation/composition-layer.md).)
+
+## Wire optional infrastructure (blobstore, keyvault, a model)
+
+If the capability needs infra a given process role may not have:
+
+1. **Add an `Option`** (`With<Thing>`) in `server.go` that injects the dependency and rebuilds the
+   affected handler set.
+2. **Leave the endpoints as their generated 501 stub when the option is absent** — declare the gap by
+   omission, never nil-deref at request time (the pattern the attachment endpoints use without
+   `WithBlobstore`). Add a `/readyz` probe for the dependency when it *is* wired.
+3. **Pass the option from the binary** (`cmd/api`/`cmd/worker`), reading the infra from env
+   ([configuration.md](../reference/configuration.md)).
+
+## Expose it to agents or background work (only if needed)
+
+- **A system-of-record verb** the AI/MCP surface should reach → add it to the `Provider`
+  (`internal/compose/provider.go`).
+- **An MCP tool** → register it in `internal/compose/registry.go`.
+- **A scheduled/background job** → add a River worker via `NewJobRunner`
+  (`internal/compose/jobs.go`), run in `cmd/worker`.
+
+## Verify
+
+`make check` (build + arch-lint + fitness tests + drift) and `make test-integration` (the real-Postgres
+lane, including RLS coverage for any new tenant table). Commit the contract, the regenerated `*_gen.go`,
+the migrations, and the module together.

--- a/docs/how-to/add-a-module.md
+++ b/docs/how-to/add-a-module.md
@@ -21,9 +21,10 @@ composition layer. For adding a single operation to an *existing* module, use
    stubs automatically — no routing to write.
 5. **Only import `shared` + `platform` + the generated contract** — never a sibling module. `arch-lint`
    fails a sibling import.
-6. **`make check`** — the `var _ ServerInterface = Server{}` assertion proves the ops are implemented,
-   `arch-lint` proves the DAG holds, and the fitness tests (table ownership, RBAC gate, write shape)
-   run.
+6. **`make check`** — the `var _ ServerInterface = Server{}` assertion proves signature coverage (a
+   generated 501 stub satisfies it too, so add an endpoint test to prove your handler is actually
+   wired, not still the stub), `arch-lint` proves the DAG holds, and the fitness tests (table
+   ownership, RBAC gate, write shape) run.
 
 ## Add a cross-module edge (module A needs module B)
 

--- a/docs/how-to/add-a-module.md
+++ b/docs/how-to/add-a-module.md
@@ -35,6 +35,7 @@ A module never imports a sibling. Inject the dependency in compose as an adapter
    parameter (`signals.NewHandlers(pool, strength)`).
 2. **Write the adapter in compose** that satisfies that interface, backed by module B's store:
    ```go
+   // illustrative, not copy-paste Go — the real signature is signals.StrengthSource
    type signalStrength struct{ people *people.Store }
    func (a signalStrength) Strength(...) (...) { return a.people.Strength(...) } // delegate
    ```

--- a/docs/how-to/add-an-endpoint.md
+++ b/docs/how-to/add-an-endpoint.md
@@ -1,0 +1,58 @@
+# Add or change an API endpoint
+
+A task checklist for adding a new operation to the HTTP API (or changing an existing one). The API is
+contract-first: you edit the contract, regenerate, then implement — never hand-write routing or types.
+For *why* it works this way, see [explanation/contract-first.md](../explanation/contract-first.md); for
+the store mechanics step 3 relies on, see
+[explanation/write-backbone.md](../explanation/write-backbone.md).
+
+## Steps
+
+1. **Edit the contract** — `backend/api/crm.yaml`. Add the path + operation + request/response schemas.
+   A **mutating** operation (POST/PUT/PATCH/DELETE) MUST carry one of:
+   - `x-mcp-tool: { verb, record_type, tier: green|yellow|dynamic }` — exposes it as a governed agent
+     tool at that autonomy tier; or
+   - `x-agent-access: human-only` (rejects agent principals — e.g. approvals, consent) or
+     `auth-bootstrap` (login/session machinery).
+
+   The generator **fails** on a mutating op with neither, so an un-tiered endpoint cannot ship.
+
+2. **Regenerate** — `make gen`. This rewrites the generated files (never hand-edit them):
+   `internal/contracts/api_gen.go` (types + `ServerInterface`), `internal/compose/stubs_gen.go` (a new
+   **501** stub), and `internal/compose/agentpolicy_gen.go` (the admission row). The build now compiles
+   and the endpoint answers `501` until you implement it.
+
+3. **Implement the handler in the owning module** — add the method matching the generated signature to
+   that module's `Handlers` (`internal/modules/<name>/`). Do the work through the module's
+   `*Store`/`*Service`, following the store shape: `WithWorkspaceTx`, the auth gate at entry, and
+   `storekit.Audit`+`Emit` for any mutation (see
+   [explanation/backend-onboarding.md → how a store reads and writes](../explanation/backend-onboarding.md#how-a-store-reads-and-writes-the-shape)).
+   Because `compose.Server` embeds each module's handler set one level deep, your method **shadows the
+   501 stub automatically** — there is no routing to wire.
+
+4. **Wire in `compose` only if needed** — if the module's handler set isn't embedded in `Server` yet,
+   or the operation needs another module's data, see [add-a-module.md](add-a-module.md) (embedding a
+   handler set, injecting a cross-module adapter) and
+   [explanation/composition-layer.md](../explanation/composition-layer.md). Most endpoints on an
+   existing module need no compose change — the embedded handler set already shadows the stub.
+
+5. **Add a migration if the schema changed** — see [apply-migrations.md](apply-migrations.md), and
+   record any new table in the owning module's `doc.go` "Tables owned".
+
+6. **Verify** — `make check`. `build` proves the operation is implemented (the
+   `var _ ServerInterface = Server{}` assertion fails if it's still only the stub), `drift` proves the
+   generated files match the contract, and the fitness tests run. Add `make test-integration` for the
+   real-Postgres lane and `make frontend-check` if `frontend/` changed.
+
+7. **Commit the contract and generated output together** — `crm.yaml` **and** every regenerated
+   `*_gen.go` in the same commit (plus `frontend/src/api/schema.d.ts` if it changed). A hand edit or a
+   missed `make gen` fails the drift gate.
+
+## Notes
+
+- **Changing an existing operation** is the same loop, but watch the contract-breaking gate: root
+  `make check` runs `oasdiff` against `origin/main` — a *breaking* change (removed op, narrowed type)
+  fails; additive passes. A deliberate re-sync uses `CONTRACT_STABILITY=pre-live`.
+- **Reads are gated too.** Anything that returns a record carries the row-scope gate
+  (`auth.EnsureVisible`), including replay/conflict/error paths — see
+  [explanation/authorization.md](../explanation/authorization.md).

--- a/docs/how-to/add-an-endpoint.md
+++ b/docs/how-to/add-an-endpoint.md
@@ -39,10 +39,11 @@ the store mechanics step 3 relies on, see
 5. **Add a migration if the schema changed** — see [apply-migrations.md](apply-migrations.md), and
    record any new table in the owning module's `doc.go` "Tables owned".
 
-6. **Verify** — `make check`. `build` proves the operation is implemented (the
-   `var _ ServerInterface = Server{}` assertion fails if it's still only the stub), `drift` proves the
-   generated files match the contract, and the fitness tests run. Add `make test-integration` for the
-   real-Postgres lane and `make frontend-check` if `frontend/` changed.
+6. **Verify** — `make check`. `build` + the `var _ ServerInterface = Server{}` assertion prove the
+   operation exists on the contract surface — but a generated 501 stub also satisfies the interface, so
+   **an endpoint test asserting a non-501 response is what proves your handler is wired** (not still the
+   stub). `drift` proves the generated files match the contract, and the fitness tests run. Add
+   `make test-integration` for the real-Postgres lane and `make frontend-check` if `frontend/` changed.
 
 7. **Commit the contract and generated output together** — `crm.yaml` **and** every regenerated
    `*_gen.go` in the same commit (plus `frontend/src/api/schema.d.ts` if it changed). A hand edit or a

--- a/docs/how-to/apply-migrations.md
+++ b/docs/how-to/apply-migrations.md
@@ -36,12 +36,22 @@ policies, roles, and triggers need owner privileges to create.
 
 ## Writing a migration
 
-- Upstream (this repo) changes go in `backend/migrations/core/` with the
-  next sequential number; **never edit a shipped core migration** —
-  additive migrations only.
-- Fork-local schema goes in `backend/migrations/custom/`, which sorts
-  after core and survives upstream merges untouched.
-- Every tenant table must carry `workspace_id` with `ENABLE`+`FORCE`
-  row-level security and composite same-workspace foreign keys — the
-  integration lane derives these obligations from the live schema and
-  fails any table that misses them.
+Follow this checklist — several obligations are enforced by fitness tests, so missing one fails
+`make check` / `make test-integration` rather than shipping a latent bug.
+
+1. **Create the next sequential pair** in `backend/migrations/core/`: `NNNN_<name>.up.sql` **and**
+   `NNNN_<name>.down.sql`. Both halves are mandatory (the runner rejects a missing `.down.sql`).
+   **Never edit a shipped core migration** — additive migrations only; extend a `CHECK` vocabulary
+   with a new migration rather than rewriting the old one. (The runner is
+   [decisions/0002](../../decisions/0002-hand-rolled-migration-runner.md).)
+2. **Tenant tables** carry `workspace_id uuid NOT NULL REFERENCES workspace(id)` with `ENABLE`+`FORCE`
+   row-level security + an isolation policy, and composite same-workspace foreign keys — the RLS
+   coverage integration test derives these from the live schema and fails any table that misses them.
+3. **Keep enums in sync** — a new `CHECK (col IN (...))` that a Go enum mirrors means extending that Go
+   const set, or `enumsync_test.go` fails.
+4. **Reach erasure + SAR** if the table holds PII (`piicoverage_test.go`), and record the table in the
+   owning module's `doc.go` "Tables owned" list (`tableownership_test.go`).
+5. **Apply and verify** — `make migrate`, then `make check` / `make test-integration`.
+
+Fork-local schema goes in `backend/migrations/custom/`, which sorts after core (timestamp-named,
+`x_`-prefixed columns) and survives upstream merges untouched.

--- a/docs/reference/make-targets.md
+++ b/docs/reference/make-targets.md
@@ -20,7 +20,7 @@ common backend targets and adds the frontend lane. In `backend/`, `make`
 
 | Target | What it does |
 |---|---|
-| `check` | **The merge gate**: build + vet + lint + arch-lint + test + drift |
+| `check` | **The merge gate.** Backend `make check` = build + vet + lint + arch-lint + test + drift. Root `make check` runs that **plus** craft-drift, image pins, contract breaking-change (`oasdiff`), test-lane hygiene, and the file-length ratchet |
 | `build` | `go build ./...` |
 | `vet` | `go vet ./...` |
 | `test` | Unit tests; the root fitness tests (license header, write shape, architecture) run uncached |

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -56,7 +56,7 @@ still answer a generated `501` until its handler lands; it is not an implementat
 ## Where cross-module edges are wired
 
 A module never reaches a sibling; the composition root injects the edge (how that works:
-[explanation/composition-layer.md](../explanation/composition-layer.md)). The current edges (all in
+[explanation/composition-layer.md](../explanation/composition-layer.md)). The current edges (wired in
 `internal/compose/server.go`):
 
 - **identity's workspace seed** ← deals (default pipeline) + consent (default purposes/retention) +
@@ -65,6 +65,8 @@ A module never reaches a sibling; the composition root injects the edge (how tha
 - **consent's DSR erasure** ← privacy's `Eraser`.
 - **signals' relationship strength** ← people's store (adapter).
 - **activities' outbound gate** ← consent (the suppression gate) + people/consent public seams.
+- **imap connect** ← capture's connector registry (adapter).
+- **filtered export** ← collections' saved-view/list source (adapter).
 
 To place a new capability: add `internal/modules/<name>/` (flat), give it a `doc.go` with a "Tables
 owned" list, follow one spine shape, and wire any cross-module need as a compose adapter — never a

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -1,0 +1,69 @@
+# Module catalog
+
+The fourteen bounded capabilities under `backend/internal/modules/`. This is the "what owns what" map
+— use it to find the module a change belongs to, or to place a new one. For the *why* of the module
+boundary (the DAG, the two spine shapes), see [explanation/architecture.md](../explanation/architecture.md);
+for the store/write mechanics every module shares, see
+[explanation/write-backbone.md](../explanation/write-backbone.md).
+
+## The rules every module follows
+
+- **Flat by default** — store + contract mapping + transport handlers + provider slice in one package.
+  A module earns a subpackage only under a real need (a protocol adapter, an independent engine, a
+  hidden ruleset).
+- **A module never imports a sibling.** If capability A needs B, the edge is injected at the
+  composition root (`internal/compose/server.go`) via an adapter — never `import ".../modules/b"`.
+  Three gates enforce this ([backend-onboarding.md → gates](../explanation/backend-onboarding.md#the-gates-that-judge-your-pr-fitness-functions)).
+- **A module writes only the tables it owns.** The "Owns tables" column below is the ownership
+  declared in each module's `doc.go` and enforced by `backend/tableownership_test.go`. The few
+  sanctioned cross-store writes (merge relinks, GDPR erasure) are ratified in that test.
+- **Two spine shapes, and only two.** *Handlers→Store* (CRUD modules: the store owns the write shape
+  and the RBAC gate at its entry points) or *Handlers→Service* (engine modules: a service owns
+  multi-step logic and drives the SQL). A handful of modules are seam-shaped (a registry, a factory,
+  a jurisdiction pack) rather than an HTTP capability — noted below.
+
+## The catalog
+
+The **HTTP surface** column is the *contract* surface (from `crm.yaml`) each module owns — a route may
+still answer a generated `501` until its handler lands; it is not an implementation-status list.
+
+| Module | Owns (purpose) | Spine | Owns tables | HTTP surface (`/v1/…`) |
+|---|---|---|---|---|
+| **identity** | Workspaces, users, opaque server-side sessions, RBAC roles, and Agent Seat Passports. Auth is in-app — no separate identity service. | Handlers→Service (`NewService`) | `workspace, app_user, team, team_membership, session, passport, role, role_assignment` | `/me`, `/workspaces`, `/auth/login`, `/auth/logout`, `/passports`, `/record-grants` |
+| **people** | The person, organization, and lead aggregates — create, dedupe, list, optimistic update, archive, the two-record merge, and lead promotion. | Handlers→Store (`NewStore`) | `person, person_email, person_phone, person_consent, organization, organization_domain, relationship, partner, lead` | `/people` (+`/merge`), `/organizations` (+`/merge`,`/partner`,`/enrich`), `/relationships`, `/leads` (+`/promote`) |
+| **deals** | The deal aggregate + pipeline/stage scaffolding, stage advancement (won/lost + FX freeze), the per-workspace default-pipeline seed, and the offer engine (rate-card products + versioned deal-bound offers with server-computed totals). | Handlers→Store (`NewStore`) | `deal, deal_stage_history, pipeline, stage, fx_rate, product, offer, offer_line_item` | `/deals` (+`/advance`,`/stakeholders`), `/pipelines`, `/stages`, `/products`, `/offers` (+`/line-items`,`/send`,`/accept`,`/reject`,`/regenerate`) |
+| **activities** | The activity timeline — idempotent capture-keyed logging, polymorphic links to person/org/deal — plus attachments and scheduling/booking. | Handlers→Store (`NewStore`) | `activity, activity_link` | `/activities` (+`/relink`,`/draft-email`,`/send-email`), `/attachments`, `/availability`, `/bookings`, `/public/booking`, `/public/preferences` |
+| **approvals** | The 🟡 confirm-first engine — agents stage an action they may not perform, humans decide it in the inbox, the agent redeems the decision. The staged row is the authority object. | Handlers→Service (`NewService`) | `approval` | `/approvals` (+`/{id}/approve`,`/{id}/reject`) |
+| **agents** | The governed agent surface — the MCP tool registry, the admission gate (scope ∧ tier ∧ seat), the approval flow, and the Surface-B reasoning loop. Reaches records only through the datasource seam. | Engine (MCP registry + `runner/`; automations HTTP via Store) | none (holds no state; records belong to domain modules, staged actions to approvals) | `/automations` (+`/catalog`,`/{id}/preview`,`/{id}/runs`); the MCP tool surface (`cmd/mcp`) |
+| **ai** | The model runtime behind `ports/model` — provider adapters (Anthropic BYOK, Ollama, local vLLM, the offline fake), the `SelectBrain` factory, the outbound secret stripper — plus the Voice DNA HTTP slice. | Runtime factory (`SelectBrain`); voice HTTP via Store | `ai_usage, voice_profile, voice_corpus_source` | `/voice-profiles` (+`/sources`) |
+| **search** | Cross-object retrieval — ranked full-text over the generated `search_tsv` columns, with the pgvector/RRF hybrid and context graph. Every query carries the caller's row-scope predicate (a hit IS a read). | Handlers→Store (`NewStore`) | none (reads domain tables through their indexes) | `/search` |
+| **capture** | The one `connector.Sink` — normalized inbound capture, one transaction per record, idempotent on `(source_system, source_id)` — plus the connector registry (grant-time scope intersection). | Sink + Registry (`NewSink`/`NewRegistry`; connector HTTP wired in compose) | `raw_capture, connector_connection` | `/connectors/imap/connect` (via a compose adapter) |
+| **consent** | Per-purpose consent — the purpose catalog, each person's current state, the append-only proof log, and the default-deny outbound suppression gate. Hosts the DSR case queue. | Handlers→Store (`NewStore`) + `NewGate` | `consent_purpose, person_consent, consent_event, consent_doi_token, preference_token` | `/consent-purposes`, `/people/{id}/consent` (+`/double-opt-in`), `/data-subject-requests` |
+| **privacy** | The GDPR engines — Art. 17 erasure, Art. 15 SAR assembly, the nightly retention evaluator — the ratified cross-store writer. Serves the field-history + audit-log reads. | Engines (`NewEraser`, SAR, retention) + thin HTTP over the pool | `erasure_suppression` (deliberately writes, but does NOT own, person/lead/activity/deal/embedding/raw_capture rows during a purge — each ratified in `tableownership_test.go`) | `/field-history`, `/audit-log` |
+| **collections** | Lists (static sets and dynamic segments) and tags over the four core record types, each membership visibility-probed so a list can't become a side channel. Plus saved views + export sources. | Handlers→Store (`NewStore`) | `list, list_member, tag, taggable` | `/lists` (+`/members`), `/tags` (+`/apply`), `/views`, `/exports` |
+| **signals** | The company-level, consent-gated warm-room signal substrate, the inspectable signal→organization resolver, and the warm/cold join over our own contact graph. | Handlers→Store (`NewStore`, strength source injected) | `signal, signal_resolution` | `/signals` (+`/{id}/resolve`,`/{id}/warmth`,`/{id}/intro-path`) |
+| **de** | The German jurisdiction pack — GoBD statutory retention classes, registered in `init()` and pulled into an edge binary by a blank import. Core code never contains a jurisdiction string. | Jurisdiction pack (`ports/jurisdiction`, no Handlers/Store) | none | none (consumed by privacy's retention evaluator through the seam) |
+
+## Notable subpackages
+
+- `identity/internal/policy` — the role permission-policy documents (kept hidden from the rest of the module).
+- `identity/internal/password` — Argon2id hashing/verification.
+- `agents/runner` — the Surface-B reason-act-observe loop (its own `Store`, catalog, window).
+- `capture/imap` — the read-only IMAP mail-capture connector.
+
+## Where cross-module edges are wired
+
+A module never reaches a sibling; the composition root injects the edge (how that works:
+[explanation/composition-layer.md](../explanation/composition-layer.md)). The current edges (all in
+`internal/compose/server.go`):
+
+- **identity's workspace seed** ← deals (default pipeline) + consent (default purposes/retention) +
+  agents (starter automations) + activities (booking page) — one bootstrap transaction.
+- **agents' staging/redemption** ← approvals (adapter).
+- **consent's DSR erasure** ← privacy's `Eraser`.
+- **signals' relationship strength** ← people's store (adapter).
+- **activities' outbound gate** ← consent (the suppression gate) + people/consent public seams.
+
+To place a new capability: add `internal/modules/<name>/` (flat), give it a `doc.go` with a "Tables
+owned" list, follow one spine shape, and wire any cross-module need as a compose adapter — never a
+sibling import.

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -1,6 +1,6 @@
 # Module catalog
 
-The fourteen bounded capabilities under `backend/internal/modules/`. This is the "what owns what" map
+The sixteen bounded capabilities under `backend/internal/modules/`. This is the "what owns what" map
 — use it to find the module a change belongs to, or to place a new one. For the *why* of the module
 boundary (the DAG, the two spine shapes), see [explanation/architecture.md](../explanation/architecture.md);
 for the store/write mechanics every module shares, see
@@ -42,6 +42,8 @@ still answer a generated `501` until its handler lands; it is not an implementat
 | **privacy** | The GDPR engines — Art. 17 erasure, Art. 15 SAR assembly, the nightly retention evaluator — the ratified cross-store writer. Serves the field-history + audit-log reads. | Engines (`NewEraser`, SAR, retention) + thin HTTP over the pool | `erasure_suppression` (deliberately writes, but does NOT own, person/lead/activity/deal/embedding/raw_capture rows during a purge — each ratified in `tableownership_test.go`) | `/field-history`, `/audit-log` |
 | **collections** | Lists (static sets and dynamic segments) and tags over the four core record types, each membership visibility-probed so a list can't become a side channel. Plus saved views + export sources. | Handlers→Store (`NewStore`) | `list, list_member, tag, taggable` | `/lists` (+`/members`), `/tags` (+`/apply`), `/views`, `/exports` |
 | **signals** | The company-level, consent-gated warm-room signal substrate, the inspectable signal→organization resolver, and the warm/cold join over our own contact graph. | Handlers→Store (`NewStore`, strength source injected) | `signal, signal_resolution` | `/signals` (+`/{id}/resolve`,`/{id}/warmth`,`/{id}/intro-path`) |
+| **customfields** | The governed add-field engine — the single chokepoint allowed to run a runtime `ALTER TABLE`. Validates a field definition against the closed type/object sets, derives its namespaced physical `cf_*` column, and runs the DDL + `custom_field` catalog INSERT + audit atomically. Record stores read these columns through the `fieldcatalog` seam, never by importing this module. | Handlers→Service (`NewService`) | `custom_field` | `/custom-fields` (+`/{id}`,`/{id}/retire`,`/{id}/options`) |
+| **quotas** | The quota aggregate (RD-T06) — a per-owner XOR per-team revenue target over an explicit period, with a human-set `target_minor` (never AI-guessed or server-computed). Workspace-shared config posture: governed by the `quota` object grant alone, never row-scoped. Audit-only writes (events.md defines no `quota.*` type). | Handlers→Store (`NewStore`) | `quota` | `/quotas` (+`/{id}`,`/{id}/attainment`) |
 | **de** | The German jurisdiction pack — GoBD statutory retention classes, registered in `init()` and pulled into an edge binary by a blank import. Core code never contains a jurisdiction string. | Jurisdiction pack (`ports/jurisdiction`, no Handlers/Store) | none | none (consumed by privacy's retention evaluator through the seam) |
 
 ## Notable subpackages

--- a/docs/reference/platform-toolkit.md
+++ b/docs/reference/platform-toolkit.md
@@ -1,0 +1,160 @@
+# Platform & shared toolkit
+
+The reusable utilities every module composes — **reach for these instead of reinventing them**. A new
+store, handler, or consumer is mostly assembling the pieces below. Everything here lives under
+`backend/internal/platform/` (technical plumbing) or `backend/internal/shared/` (stdlib-only leaves);
+a module may import both, never a sibling module.
+
+The signatures are abbreviated (contexts/errors elided) — read the package for the exact shape.
+
+---
+
+## `platform/` — plumbing
+
+### `platform/database` — the pool & the workspace transaction
+The **only** place the RLS GUC contract is implemented; no store issues its own `SET LOCAL`.
+- `WithWorkspaceTx(ctx, pool, fn func(pgx.Tx) error) error` — the workspace transaction every store uses (binds the tenant to `app.workspace_id`).
+- `WithInfraTx(ctx, pool, fn) error` — a no-tenant-GUC transaction for the few cross-tenant infra paths (relay, bootstrap).
+- `NewPool(ctx, dsn) (*pgxpool.Pool, error)`, `RegisterIDTypes(conn)`.
+- **Reach for it when:** you need a DB transaction — always through these, never a raw `pool.Begin`.
+
+### `platform/database/storekit` — the write shape & store mechanics
+The one spelling of "domain row + `audit_log` + `event_outbox` in one tx", plus pagination, version
+patches, predicate compilation, and SQLSTATE branch helpers. (Deep dive:
+[write-backbone.md](../explanation/write-backbone.md).)
+- Write triple: `Audit(...) (auditID, err)`, `AuditWithEvidence(..., evidence)`, `Emit(..., auditID, eventType, ...)`.
+- Version patch: `NewPatch()`, `Patch.Set(col, old, new)`, `ApplyWithVersion(...)`, `ApplyGuarded(..., ifVersion)`, `ApplyLocked(..., lock)` → `ErrVersionSkew`.
+- Row locks: `LockRow(...)`, `LockPair(...)`.
+- Keyset pagination: `EncodeCursor`, `DecodeCursor` (→ `MalformedCursorError`), `ClampLimit`, `QuickFindClause`.
+- List predicates: `CompilePredicate(pred, fields, arg)`, `Query.SelectIDs(...)`.
+- SQLSTATE branch: `IsUniqueViolation`, `UniqueViolation(err) (constraint, ok)`, `IsForeignKeyViolation`, `CheckViolation`, `ExclusionViolation`.
+- Context/provenance: `Actor(ctx)`, `CapturedBy(ctx)`, `MustWorkspace(ctx)`, `StampFields`, `FieldOrigins`, `EmailSuppressed`, `SuppressionHash`, `EscapeLike`, `JSONArg`, `UUIDOrNil`.
+- **Reach for it when:** writing a store — compose these instead of hand-rolling audit/outbox/pagination/version SQL.
+
+### `platform/auth` — the admission point
+Object RBAC + row scope enforced at every store entry point, so HTTP and MCP ride one gate. (Why it
+lives here: [authorization.md](../explanation/authorization.md).)
+- `Require(ctx, object, action)` — object-level gate (may this role do this verb on this type?).
+- `EnsureVisible(ctx, tx, table, id)` — row scope on a single-row get/update/archive (out-of-scope → `ErrNotFound`).
+- `EnsureLinkTarget(ctx, tx, table, id)` — RLS-scoped existence probe for FK targets.
+- `VisibleTo(ctx, tx, table, id) (bool, error)` — non-erroring probe for dedupe-409 paths.
+- `ScopeClause` / `ScopeClauseFor(table, alias, arg)` — the SQL row-visibility predicate for list/search builders.
+- `AuthzRule(p, entityType, action)` — the `audit_log.authorization_rule` attribution string.
+- `NewGate(authority).Admit(ctx, spec, resolve)` — the agent admission gate (scope ∧ tier ∧ seat), re-derived live.
+- **Reach for it when:** any store read/write over an owner-scoped table, or admitting an agent/MCP call.
+
+### `platform/events` — the bus side of the backbone
+Outbox relay + consumer-group subscriber + dedupe. Never originates events. (Deep dive:
+[write-backbone.md](../explanation/write-backbone.md).)
+- `NewRelay(pool, rdb, log)`, `OutboxBacklog(ctx, pool)`, `PublishedTotal()`.
+- `NewSubscriber(rdb, group, handler, log)`; `type Handler func(ctx, env) error`.
+- `Dedupe(rdb, group, next)` (`DedupeTTL = 96h`), `ForWorkspace(wsID, next)`, `NewClient(ctx, addr)`.
+- **Reach for it when:** consuming domain events or wiring the relay.
+
+### `platform/httperr` — the sentinel → HTTP choke point
+Maps `apperrors` sentinels to RFC 7807 problem+json with stable machine codes; no handler hand-writes a status body.
+- `Write(w, r, err)` — maps any sentinel / `DetailedError` / parse error onto the wire; unknown → opaque 500.
+- `NotImplemented(w, r, op)` — explicit 501 (what the generated stubs return).
+- `Unauthorized(w, r, detail)`, `Validation(field, code, msg) *DetailedError` (422), `Duplicate(code, existingID) *DetailedError` (409).
+- **Reach for it when:** a handler needs to return any error — return a sentinel/`DetailedError` and call `Write`.
+
+### `platform/httpserver` — the HTTP chassis
+The middleware every process role rides; owns no domain.
+- Middleware: `Correlate` (mints the per-request `correlation_id`), `SecureHeaders`, `RecoverPanics`, `LimitBodies`, `AccessLog`.
+- Probes: `Healthz`, `Readyz(checks…)`, `Metrics(pool, backlog, published)`.
+- Logging: `LogHandler(w, level, format)`, `WithCorrelation(handler)`.
+- **Reach for it when:** assembling any HTTP surface — wrap routes in these, don't reinvent middleware.
+
+### `platform/jobs` — durable background work (River)
+Peer of the outbox: an event announces something happened, a job asks for work to be done.
+- `New(pool, cfg, log) (*Runner, error)`, `Migrate(ctx, pool)`.
+- **Reach for it when:** you need durable, retryable background work (the worker's periodic passes ride this).
+
+### `platform/blobstore` — object bytes
+DB row stays system-of-record; the store holds opaque bytes at a workspace-prefixed key.
+- `type Store interface { Put; Get; Delete; Health }`, `WorkspaceKey(ws, kind, id)`, `NewMemory()`, `New(ctx, cfg)`, `FromEnv(ctx)`, `ErrNotFound`.
+- **Reach for it when:** persisting/fetching binary blobs tied to an entity (attachments, logos).
+
+### `platform/keyvault` — secret material
+A domain row references an opaque, workspace-scoped `Ref`; the vault holds the secret bytes. Plaintext/root key never reach a log.
+- `type Vault interface { Put; Get; Delete; Health }`, `type Ref string` (log-safe, resolves only under its minting workspace), `New(cfg)`, `NewMemory()`, `FromEnv(pool)`.
+- **Reach for it when:** storing/retrieving a credential a domain row points at (e.g. `connector_connection.credential_ref`).
+
+### `platform/netguard` — SSRF egress guard
+A tenant-supplied host must never probe the deployment's own network; classifies the *resolved* IP so DNS can't bypass it.
+- `RefusePrivate(network, address, rawConn)` — a `net.Dialer.Control`; `PublicIP(ip) bool`.
+- **Reach for it when:** building an HTTP client that fetches a tenant-supplied URL — set `Dialer.Control = netguard.RefusePrivate`.
+
+### `platform/ratelimit` — in-process fixed-window limiter
+For unauthenticated endpoints (login brute-force, workspace-bootstrap).
+- `New(limit, window)`, `Allow(key)`, `Record(key)`, `Blocked(key)`, `NewWithClock(...)` (inject a clock in tests).
+- **Reach for it when:** throttling an expensive unauthenticated endpoint by key (IP/email).
+
+### `platform/dbmigrate` — the migration runner
+Hand-rolled runner for the ownership namespaces (core, custom, packs), each with its own tracking table.
+- `Load(fsys, dir)`, `Up(ctx, conn, namespaces…)`, `Down(ctx, conn, ns, n)`.
+- **Reach for it when:** applying/rolling back migrations in tooling (usually you just run `cmd/migrate`).
+
+---
+
+## `shared/` — stdlib-only leaves
+
+### `shared/apperrors` — the fixed error-sentinel registry
+Callers branch with `errors.Is`; the HTTP/MCP choke-points own the wire mapping. **Never** invent a
+new error string a handler must parse — extend this registry (with the contract) instead.
+- Core sentinels: `ErrNotFound`, `ErrConflict`, `ErrScopeExceeded`, `ErrPermissionDenied`, `ErrRequiresApproval`, `ErrVersionSkew`, `ErrBudgetExceeded`, `ErrApprovalTokenInvalid`, `ErrConsentNotGranted`, `ErrSeatTierInsufficient`.
+- Overlay sentinels: `ErrModeNotOverlay`, `ErrUnsupportedBySoR`, `ErrIncumbentAlreadyConnected`, `ErrOverlayFlipBlocked`, `ErrIncumbentBudgetExhausted`.
+- **Reach for it when:** returning any domain error.
+
+### `shared/kernel/ids` — UUIDv7 identifiers
+Dependency-free so seam signatures don't drag in a UUID library.
+- `type UUID [16]byte`, `Nil`, `NewV7()` (time-ordered), `Parse`, `MustParse`, `String()`, `IsZero()`.
+- Typed ids: `type ID[K]`, `New[K]()`, `From[K](u)`, `ParseAs[K](s)`, and aliases `WorkspaceID`, `UserID`, `PersonID`, `DealID`, … (per-entity phantom types).
+- **Reach for it when:** minting or parsing any entity id.
+
+### `shared/kernel/principal` — per-request identity
+The tenant key, acting principal, and trace ids on the context — read only through typed accessors (loose context keys are forbidden).
+- Accessors: `WithActor`/`Actor`, `WithWorkspaceID`/`WorkspaceID`, `WithCorrelationID`/`CorrelationID`, `WithCausationEvent`/`CausationEvent`.
+- `type Principal { Type, ID, UserID, TeamIDs, PassportID, OnBehalfOf, Scopes, SeatType, Permissions }`.
+- Enums: `PrincipalType` (Human/Agent/Connector/System), `Scope` (Read/Draft/Write/Send/Enrich), `SeatType` (Full/Read, `.CanMutate()`), `Action` (Create/Read/Update/Delete), `RowScope` (Own/Team/All).
+- `Permissions.Allows(object, action)`, `ScopeSet.Has(scope)`.
+- **Reach for it when:** reading who's acting / the tenant / trace ids from context, or checking RBAC in memory.
+
+### `shared/kernel/events` — the bus wire contract
+The `Envelope`, the `<entity>.<verb>` catalog, and the stream layout — shared by publisher and consumer.
+- `type Envelope { EventID, Type, Version, WorkspaceID, OccurredAt, Actor, Entity, Payload, Trace }`, `Envelope.Validate()`.
+- `type Trace { CorrelationID, CausationID, AuditLogID }`, `type Actor`, `type EntityRef`.
+- Catalog: `StreamFor(type)`, `VersionOf(type)`, `Types()`, `Streams()`, `Groups()`, `SplitType(type)`.
+- **Reach for it when:** publishing to the outbox (via storekit) or writing a consumer. Adding an event type = one catalog line.
+
+### `shared/kernel/provenance` — write provenance
+Store APIs accept no write without it (missing provenance is a compile error).
+- `type Provenance { Source, CapturedBy }`, `Validate()`.
+- **Reach for it when:** any write — pass where the value came from and who wrote it.
+
+### `shared/ports/*` — the frozen seam interfaces
+Dependency-free interfaces that decouple platform/AI/UI (and one module from another) from concrete
+implementations; the composition root injects the impls. **Depend on the interface, never the concrete
+module.**
+
+| Port | Interface | Role |
+|---|---|---|
+| `authz` | `Resolver { EffectiveRBAC; SeatType }` | live RBAC/seat resolver the auth gate re-derives an agent's authority through (impl: identity) |
+| `datasource` | `SystemOfRecordProvider { Read/Search/Create/Update/Archive/Merge/AdvanceDeal/PromoteLead/StageSemantic/RunReport/Freshness/ListObjects/ListFields }` | the system-of-record seam AI/MCP/UI bind to (impl: the compose `Provider` over people/deals/activities/reports) |
+| `mcp` | `Tool { Spec; Handle }`, `Registry { Register; Invoke; Specs }` | the governed tool contract (`ToolSpec`, `RiskTier` green/yellow/dynamic, tier resolver) — admission runs before `Handle` |
+| `connector` | `Connector { Descriptor/Authenticate/Sync/Normalize/HealthCheck }`, `Sink { Upsert }` | the capture/integration seam; a connector normalizes, the capture module writes |
+| `model` | `Client { Complete/Stream/Embed/Caps }`, `SecretStripper` | the provider-agnostic LLM seam (model choice is config, not architecture) |
+| `retrieval` | `Retriever { Search; AssembleContext }` | grounded hybrid retrieval with per-item evidence (evidence-or-omit) |
+| `workflow` | `Handler { Spec; Match; Plan }` | the automation seam — typed trigger + effect + idempotency key + risk tier; runs ride the job queue |
+| `jurisdiction` | `Pack { Code; Retention }` + `Register`/`For`/`Applicable` | compile-time country packs (the `de` pack); core never names a jurisdiction |
+
+**Reach for a ports interface when:** code above a seam needs a module's capability without importing it.
+
+---
+
+## The pattern, in one line
+
+A typical CRUD store method = `WithWorkspaceTx` (database) → `auth.Require`/`EnsureVisible` (auth) →
+SQL over your owned tables → `storekit.Audit` + `Emit` (storekit) → return, mapping errors through the
+`apperrors` sentinels that `httperr.Write` renders. You wrote the SQL and the mapping; everything else
+is composed from the toolkit above.

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -50,12 +50,23 @@ Open <http://localhost:8080> — the embedded web UI. The first screen
 lets you bootstrap a workspace (name, slug, your admin user). After
 login you have people, leads, the deal board, and the activity timeline.
 
-Prefer the API? The same bootstrap is `POST /v1/workspaces`. Local API
-calls need the workspace header (production uses the subdomain):
+Prefer the API? The same bootstrap is `POST /v1/workspaces`. For a ready-made demo workspace and admin,
+run `make seed-dev` (creates `demo-workspace` with `admin@demo.test` / `demo-password-123`).
+
+Then log in over the API and reuse the session. The `crm_session` cookie is `Secure`, so pull it out of
+the login response rather than relying on curl's jar; local calls also need the `X-Workspace-Slug`
+header (production resolves the workspace from the subdomain):
 
 ```sh
-curl http://localhost:8080/v1/me -H 'X-Workspace-Slug: <slug>' --cookie 'crm_session=<token>'
+SESSION=$(curl -sS -D - -o /dev/null http://localhost:8080/v1/auth/login \
+  -H 'X-Workspace-Slug: demo-workspace' -H 'Content-Type: application/json' \
+  -d '{"email":"admin@demo.test","password":"demo-password-123"}' \
+  | sed -n 's/^[Ss]et-[Cc]ookie: crm_session=\([^;]*\).*/\1/p' | tr -d '\r')
+
+curl http://localhost:8080/v1/me -H 'X-Workspace-Slug: demo-workspace' --cookie "crm_session=$SESSION"
 ```
+
+(An agent uses a passport instead of a session — see [how-to/mint-a-passport.md](../how-to/mint-a-passport.md).)
 
 ## 5. Verify your setup
 
@@ -76,6 +87,9 @@ missing — it never skips.
 
 ## Where next
 
+- **Contributing to the backend? Start here:**
+  [explanation/backend-onboarding.md](../explanation/backend-onboarding.md) — the orientation hub (map,
+  reading order, how to add an endpoint or a migration).
 - Connect an AI agent: [how-to/mint-a-passport.md](../how-to/mint-a-passport.md),
   then [how-to/run-the-mcp-server.md](../how-to/run-the-mcp-server.md).
 - Every flag and environment variable: [reference/configuration.md](../reference/configuration.md).


### PR DESCRIPTION
## What

A contributor-oriented backend documentation set for margince-next, plus a Diátaxis reorganization of the existing docs so there is **one front door** and each topic has a **single home** (link, don't restate).

### New docs
- **`docs/README.md`** — the documentation index + reading order (the front door).
- **`explanation/backend-onboarding.md`** — the contributor hub: system overview, the "one request in five steps", the find-it map, generated-vs-hand-written, the store shape, the gates.
- **`explanation/write-backbone.md`** — storekit, `audit_log`, the outbox/relay/dedupe, and **who consumes the events**.
- **`explanation/composition-layer.md`** — how `internal/compose` boots and where every cross-module edge is wired.
- **`explanation/authorization.md`** (rewrite) — admission + row scope + the RLS backstop, **what a passport is**, the three transports, and the 🟢/🟡 autonomy tiers.
- **`explanation/agent-surface.md`** — the Surface-B reason-act-observe loop and the model runtime (providers, the secret stripper, the budget guardrail).
- **`explanation/privacy-and-consent.md`** — the default-deny consent gate and the GDPR engines (erasure / SAR / retention), the single-transaction cross-store purge exception, jurisdiction floors.
- **`reference/modules.md`** — the 14-module catalog (owns-what, spine shape, tables, HTTP surface).
- **`reference/platform-toolkit.md`** — the reusable `platform/*` + `shared/*` utilities.
- **`how-to/add-an-endpoint.md`**, **`how-to/add-a-module.md`** — task recipes.

### Reorg & consistency
- Moved the endpoint/migration recipes out of the explanation hub into **how-to** (Diátaxis discipline).
- Fixed stale/inconsistent facts across `README`/`AGENTS`/`CLAUDE` and docs: module count **12 → 14**, added **`ports/authz`**, canonical **`make check`** (backend vs root), corrected the license-rule label, and added the **"log in over the API"** recipe.

## How verified

Three rounds of **docs-only reader subagents** — comprehension (can a newcomer run it and do common tasks?), consistency/navigation (contradictions, terminology, links, shallow→deep flows), and completeness (what's missing) — with every factual claim cross-checked against source. The four new explanation docs each had their facts extracted from source and keep **honest "not yet built" flags** (e.g. 4 of 7 event consumer groups are declared but not yet consumed; per-agent quota is specified but unenforced). All internal doc links and heading anchors resolve.

## AI disclosure

**Generated** — authored with Claude Code, reviewed and owned by the submitter.

## Follow-ups (not in this PR)

- **A generated data-model doc** — entity relationships are derivable from the schema after migrations, so they belong to doc-gen tooling rather than a hand-maintained page.
- **A `docs-check` gate** (link/anchor check + module & ports lists == the tree) to convert doc drift into a red build — the durable fix for the "twelve vs fourteen" class of staleness.
- **Re-sync the root README "What works today / Deliberately not here yet" inventory** — verified stale (migrations 19 → 62; River, search, capture, consent, hosted-A2 are built). Needs per-feature status verification; `STATUS.md` already flags it as pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a structured Diátaxis documentation hub with a contributor reading order, navigation map, and clarified what’s excluded from reader-facing docs.
  * Expanded backend contributor onboarding, including workspace bootstrapping, request flow, contract-first workflow, migrations, verification (“fitness functions”), and composition-layer/authorization/agent/write-backbone explanations.
  * Improved reference guidance with a module catalog, platform toolkit, and clearer `make check` “merge gate” wording.
  * Updated README “Start here” and refined what’s intentionally unsupported; broadened AI surfaces in the unreleased changelog to include vLLM.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->