### PR TITLE
feat: formula fields as database-GENERATED artifacts (poc-1 delta port, arc 2b — closes Wave 2)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -116,6 +116,14 @@ Merged so far:
   flagged as follow-up; a merged-away record's cf values stay on the
   archived source row — merge survivorship fill is core-columns-only in
   V1).
+- **Formula fields as database-GENERATED artifacts** (RD-T08) —
+  `deal.amount_minor_base` GENERATED column + the
+  `organization_open_pipeline_rollup` security_invoker view, surfaced as
+  gated `computed_fields[]` display rows on the org 360 read (STATE-4:
+  key absent without `computed_field:read`, a new read-only-everywhere
+  RBAC object); the hierarchy-rollup closed-won and brief SQL adopt the
+  column; schema-proof + no-runtime-authoring fitness tests stand guard.
+  Closes Wave 2 of the poc-1 delta port.
 
 ## Pick up here
 

--- a/backend/.go-arch-lint.yml
+++ b/backend/.go-arch-lint.yml
@@ -112,6 +112,12 @@ deps:
   migrations:
     mayDependOn: [platform]
     canUse: [pgx]
+  # The root fitness tests walk the authoritative contract document
+  # (api/crm.yaml) directly — the RD-AC-7 negative-scope gate reads the
+  # 3.1 source of truth, not the generated Go, so a contract-only change
+  # cannot slip past it.
+  root:
+    canUse: [yaml]
   cmd:
     mayDependOn: [compose, identity, people, privacy, deals, activities, approvals, agents, ai, search, capture, consent, collections, signals, de, customfields, contracts, platform, migrations]
     canUse: [pgx, redis]

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -5370,7 +5370,7 @@ components:
         computable: { type: boolean }
         reason:
           type: [string, 'null']
-          description: Set (non-null) iff computable=false, e.g. "not_yet_built".
+          description: Set (non-null) iff computable=false, e.g. "not_yet_built", "awaiting_fx".
 
     Organization:
       type: object

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -5340,6 +5340,38 @@ components:
         updated_at: { type: string, format: date-time }
         archived_at: { type: [string, 'null'], format: date-time }
 
+    ComputedField:
+      type: object
+      description: |
+        S-E15.8c formula-field display row (RD-AC-6/RD-AC-7/RD-AC-N-1) — a read-only,
+        database-computed value, never a runtime-authored expression. `computable: false` +
+        `reason` is the honest floor for a field with no backend data model yet — the row is
+        still returned, never omitted or fabricated.
+      required: [key, label, kind, formula_sql, dependencies, computable]
+      properties:
+        key: { type: string }
+        label: { type: string }
+        kind:
+          type: string
+          enum: [currency_minor, count, duration_months, percent]
+        value_minor:
+          type: [integer, 'null']
+          format: int64
+          description: Present (and non-null) only when kind=currency_minor and computable=true.
+        value:
+          type: [number, 'null']
+          description: Present (and non-null) only when kind is count/duration_months/percent and computable=true.
+        formula_sql:
+          type: string
+          description: The literal GENERATED-column/view SQL definition; empty string when computable=false.
+        dependencies:
+          type: array
+          items: { type: string }
+        computable: { type: boolean }
+        reason:
+          type: [string, 'null']
+          description: Set (non-null) iff computable=false, e.g. "not_yet_built".
+
     Organization:
       type: object
       description: A company. Mirrors the `organization` table.
@@ -5357,6 +5389,14 @@ components:
         owner_id: { type: [string, 'null'], format: uuid }
         parent_org_id: { type: [string, 'null'], format: uuid, description: Single-level hierarchy FK; no cycles. }
         merged_into_id: { type: [string, 'null'], format: uuid }
+        computed_fields:
+          type: array
+          readOnly: true
+          description: |
+            S-E15.8c formula-field display rows (RD-AC-6/RD-AC-7/RD-AC-N-1). Populated on
+            `getOrganization` only; the key is absent entirely (not an empty array) when the
+            viewer's role lacks computed_field:read visibility (STATE-4).
+          items: { $ref: '#/components/schemas/ComputedField' }
         domains:
           type: array
           items: { $ref: '#/components/schemas/OrganizationDomain' }

--- a/backend/formulafieldscope_test.go
+++ b/backend/formulafieldscope_test.go
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package backendarch
+
+// The negative-scope half of the formula-field boundary proof (RD-AC-7): a
+// formula field is a database-GENERATED artifact, never a runtime-authored
+// one, so NO contract operation may accept a writable formula_sql in its
+// request body — ComputedField.formula_sql (crm.yaml) is a response-only
+// display field, never echoed back as an editable one. This walks the
+// AUTHORITATIVE contract itself (api/crm.yaml, not the generated stubs), so
+// a future ticket that bolts a "define computed field" endpoint onto the
+// contract fails here before a single line of handler code exists.
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// loadContract parses the authoritative OpenAPI 3.1 document into a plain
+// map tree — this test walks $ref/properties/items/allOf by hand rather
+// than pulling in an OpenAPI-aware library, since the shapes it needs
+// (requestBody → content → schema, and schema composition) are a handful
+// of map lookups.
+func loadContract(t *testing.T) map[string]any {
+	t.Helper()
+	src, err := os.ReadFile("api/crm.yaml")
+	if err != nil {
+		t.Fatalf("reading api/crm.yaml: %v", err)
+	}
+	var doc map[string]any
+	if err := yaml.Unmarshal(src, &doc); err != nil {
+		t.Fatalf("parsing api/crm.yaml: %v", err)
+	}
+	return doc
+}
+
+// httpMethods are the OpenAPI path-item keys that carry an operation (and
+// so may carry a requestBody); the other path-item keys (parameters,
+// summary, description, …) are not operations.
+var httpMethods = map[string]bool{
+	"get": true, "put": true, "post": true, "delete": true,
+	"options": true, "head": true, "patch": true, "trace": true,
+}
+
+// resolveSchemaRef follows one components/schemas $ref — the only $ref
+// shape crm.yaml uses — to its schema map.
+func resolveSchemaRef(doc map[string]any, ref string) (map[string]any, bool) {
+	const prefix = "#/components/schemas/"
+	name, ok := strings.CutPrefix(ref, prefix)
+	if !ok {
+		return nil, false
+	}
+	components, ok := doc["components"].(map[string]any)
+	if !ok {
+		return nil, false
+	}
+	schemas, ok := components["schemas"].(map[string]any)
+	if !ok {
+		return nil, false
+	}
+	schema, ok := schemas[name].(map[string]any)
+	return schema, ok
+}
+
+// schemaWritesFormulaSQL walks one schema tree (following $ref, properties,
+// array items, and allOf/oneOf/anyOf composition) and reports whether it
+// reaches a "formula_sql" property that is not marked readOnly — i.e. one a
+// client could set on write. seen breaks $ref cycles.
+func schemaWritesFormulaSQL(doc map[string]any, schema map[string]any, seen map[string]bool) bool {
+	if schema == nil {
+		return false
+	}
+	if ref, ok := schema["$ref"].(string); ok {
+		if seen[ref] {
+			return false
+		}
+		seen[ref] = true
+		resolved, ok := resolveSchemaRef(doc, ref)
+		return ok && schemaWritesFormulaSQL(doc, resolved, seen)
+	}
+	if properties, ok := schema["properties"].(map[string]any); ok {
+		for name, propAny := range properties {
+			prop, _ := propAny.(map[string]any)
+			if name == "formula_sql" {
+				if readOnly, _ := prop["readOnly"].(bool); readOnly {
+					continue
+				}
+				return true
+			}
+			if schemaWritesFormulaSQL(doc, prop, seen) {
+				return true
+			}
+		}
+	}
+	if items, ok := schema["items"].(map[string]any); ok {
+		if schemaWritesFormulaSQL(doc, items, seen) {
+			return true
+		}
+	}
+	for _, key := range []string{"allOf", "oneOf", "anyOf"} {
+		list, ok := schema[key].([]any)
+		if !ok {
+			continue
+		}
+		for _, itemAny := range list {
+			if item, ok := itemAny.(map[string]any); ok && schemaWritesFormulaSQL(doc, item, seen) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// TestContract_noOperationWritesFormulaSQL is the RD-AC-7 fitness function:
+// no path operation's request body may carry a writable formula_sql
+// property, derived from the live contract rather than a point check on
+// today's operation list — an operation added tomorrow is covered for free.
+func TestContract_noOperationWritesFormulaSQL(t *testing.T) {
+	doc := loadContract(t)
+	paths, ok := doc["paths"].(map[string]any)
+	if !ok {
+		t.Fatal("api/crm.yaml has no top-level paths map — the contract failed to parse as expected")
+	}
+	// Vacuous-pass guard: the contract has dozens of paths; finding almost
+	// none means this test stopped seeing the real document, not that the
+	// API shrank.
+	if len(paths) < 30 {
+		t.Fatalf("found only %d paths in api/crm.yaml — the contract walk no longer sees the schema", len(paths))
+	}
+
+	checked := 0
+	for path, methodsAny := range paths {
+		methods, ok := methodsAny.(map[string]any)
+		if !ok {
+			continue
+		}
+		for method, opAny := range methods {
+			if !httpMethods[method] {
+				continue
+			}
+			op, ok := opAny.(map[string]any)
+			if !ok {
+				continue
+			}
+			reqBody, ok := op["requestBody"].(map[string]any)
+			if !ok {
+				continue
+			}
+			content, ok := reqBody["content"].(map[string]any)
+			if !ok {
+				continue
+			}
+			for _, mediaAny := range content {
+				media, ok := mediaAny.(map[string]any)
+				if !ok {
+					continue
+				}
+				schema, ok := media["schema"].(map[string]any)
+				if !ok {
+					continue
+				}
+				checked++
+				if schemaWritesFormulaSQL(doc, schema, map[string]bool{}) {
+					t.Errorf("%s %s: request body schema accepts a writable formula_sql — formula fields are DATABASE-GENERATED only (RD-AC-7); no operation may author or edit one", strings.ToUpper(method), path)
+				}
+			}
+		}
+	}
+	if checked < 30 {
+		t.Fatalf("found only %d request-body schemas in api/crm.yaml — the contract walk no longer sees the schema", checked)
+	}
+}
+
+// TestSchemaWritesFormulaSQL_detectsAWritableProperty is a self-test of the
+// detector TestContract_noOperationWritesFormulaSQL relies on: without it, a
+// detector that always returned false would make the fitness function
+// vacuously green forever. It exercises schemaWritesFormulaSQL directly
+// against a synthetic schema shaped like a hypothetical future
+// "define/edit computed field" request body — proving the gate actually
+// fires the moment such an operation is added, not just that today's
+// contract happens to lack one.
+func TestSchemaWritesFormulaSQL_detectsAWritableProperty(t *testing.T) {
+	doc := map[string]any{
+		"components": map[string]any{
+			"schemas": map[string]any{
+				"ComputedField": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"key":         map[string]any{"type": "string"},
+						"formula_sql": map[string]any{"type": "string"},
+					},
+				},
+			},
+		},
+	}
+	writable := map[string]any{"$ref": "#/components/schemas/ComputedField"}
+	if !schemaWritesFormulaSQL(doc, writable, map[string]bool{}) {
+		t.Fatal("schemaWritesFormulaSQL did not detect a writable formula_sql reached through a $ref — the RD-AC-7 gate would not fire on a future authoring op")
+	}
+
+	readOnlyDoc := map[string]any{
+		"components": map[string]any{
+			"schemas": map[string]any{
+				"ComputedField": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"formula_sql": map[string]any{"type": "string", "readOnly": true},
+					},
+				},
+			},
+		},
+	}
+	if schemaWritesFormulaSQL(readOnlyDoc, writable, map[string]bool{}) {
+		t.Fatal("schemaWritesFormulaSQL flagged a formula_sql property explicitly marked readOnly — it should only fire on a genuinely writable one")
+	}
+}

--- a/backend/internal/compose/briefs/briefrank.go
+++ b/backend/internal/compose/briefs/briefrank.go
@@ -77,15 +77,17 @@ func (e *BriefEngine) WithL2Ranker(brain briefBrain, log *slog.Logger) *BriefEng
 
 // briefBaseValueSQL renders the §6 base-currency value of d (joined to
 // its workspace w): native amount when already in base currency, the
-// frozen rate for closed deals, the latest daily rate on or before the
-// as-of date for open ones. A missing rate yields NULL — the revenue
-// factor floors rather than guessing (a wrong number is worse than a
-// missing one). asOfPos is the bind position of the as-of date.
+// frozen amount_minor_base (0065's GENERATED column — round(amount_minor
+// x fx_rate_to_base) computed once at write time) for closed deals, the
+// latest daily rate on or before the as-of date for open ones. A missing
+// rate yields NULL — the revenue factor floors rather than guessing (a
+// wrong number is worse than a missing one). asOfPos is the bind position
+// of the as-of date.
 func briefBaseValueSQL(asOfPos int) string {
 	return fmt.Sprintf(`CASE
 		WHEN d.amount_minor IS NULL THEN NULL
 		WHEN d.currency IS NULL OR d.currency = w.base_currency THEN d.amount_minor
-		WHEN d.fx_rate_to_base IS NOT NULL THEN round(d.amount_minor * d.fx_rate_to_base)::bigint
+		WHEN d.fx_rate_to_base IS NOT NULL THEN d.amount_minor_base
 		ELSE (SELECT round(d.amount_minor * fr.rate)::bigint FROM fx_rate fr
 		      WHERE fr.from_currency = d.currency AND fr.to_currency = w.base_currency
 		        AND fr.rate_date <= $%d::date

--- a/backend/internal/compose/integration/harness.go
+++ b/backend/internal/compose/integration/harness.go
@@ -186,6 +186,11 @@ var (
 			"lead":         {Create: true, Read: true, Update: true, Delete: true},
 			"activity":     {Create: true, Read: true, Update: true, Delete: true},
 			"pipeline":     {Create: true, Read: true, Update: true, Delete: true},
+			// computed_field is read-only for every system role, admin
+			// included (RD-AC-7: no runtime formula-authoring surface
+			// exists) — identity/internal/policy.go's real seed, mirrored
+			// here so the harness's admin fixture matches production.
+			"computed_field": {Read: true},
 		},
 		RowScope: principal.RowScopeAll,
 	}
@@ -249,6 +254,19 @@ func (e *Env) SeedOrg(t *testing.T, name string, owner *ids.UUID) ids.UUID {
 	org, err := e.People.CreateOrganization(e.Admin(), people.CreateOrganizationInput{
 		DisplayName: name, OwnerID: userIDPtr(owner),
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ids.UUID(org.Id)
+}
+
+// SeedOrgAs creates an ownerless organization under the caller's own
+// context — unlike SeedOrg (always e.Admin(), the harness's one primary
+// workspace), this lets a cross-tenant suite seed a fixture in a SECOND
+// workspace's own context.
+func (e *Env) SeedOrgAs(ctx context.Context, t *testing.T, name string) ids.UUID {
+	t.Helper()
+	org, err := e.People.CreateOrganization(ctx, people.CreateOrganizationInput{DisplayName: name})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/compose/integration/organization_computed_integration_test.go
+++ b/backend/internal/compose/integration/organization_computed_integration_test.go
@@ -1,0 +1,426 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The RD-T08 formula-field display rows on GET /organizations/{id}
+// (arc 2b Task 3) exercised over a real migrated Postgres: the gated
+// 5-row assembly with a real computed open_pipeline value, the two
+// honest-floor states (no view row at all vs. a row whose aggregate is
+// itself NULL), the STATE-4 absent-key proof, and the security_invoker
+// proof that RLS — not organization_id happening to be unique — is what
+// keeps one workspace's deals out of another's roll-up.
+//
+// Deals never carry fx_rate_to_base while status='open' through any
+// real write path (deal_closed_fx only requires it once a deal leaves
+// 'open', and no code path sets it early) — so a genuinely computable
+// open_pipeline figure is fabricated here via the owner connection, the
+// same "seed what the write paths cannot produce" pattern
+// dealhealth_integration_test.go uses for its stage-history timestamps.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// freezeDealFX sets fx_rate_to_base = 1 (identity conversion — every
+// fixture in this suite deals in the workspace's own EUR base currency)
+// directly through the owner connection: the one state no application
+// write path reaches for an OPEN deal, so amount_minor_base (0065's
+// GENERATED column) becomes a real, non-NULL figure for these tests to
+// sum.
+func freezeDealFX(t *testing.T, owner *pgx.Conn, dealID ids.UUID) {
+	t.Helper()
+	if _, err := owner.Exec(context.Background(),
+		`UPDATE deal SET fx_rate_to_base = 1 WHERE id = $1`, dealID); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// directOpenPipelineRead is the test's own ground truth: the exact
+// query organization_computed.go's openPipelineRollup runs, executed
+// independently here so the assertions below prove the store's
+// assembled figure against the view, not against itself. found is false
+// for the view's honest "nothing to sum" case (no row at all).
+func directOpenPipelineRead(ctx context.Context, t *testing.T, e *Env, orgID ids.UUID) (minor *int64, count int, found bool) {
+	t.Helper()
+	err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx,
+			`SELECT open_pipeline_minor_base, open_deal_count
+			 FROM organization_open_pipeline_rollup WHERE organization_id = $1`,
+			orgID).Scan(&minor, &count)
+	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, 0, false
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	return minor, count, true
+}
+
+// computedFieldByKey indexes the assembled rows for the reason/floor
+// assertions that don't care about row order.
+func computedFieldByKey(rows []crmcontracts.ComputedField, key string) crmcontracts.ComputedField {
+	for _, r := range rows {
+		if r.Key == key {
+			return r
+		}
+	}
+	return crmcontracts.ComputedField{}
+}
+
+// assertHonestFloors checks the four non-computable rows: weighted_pipeline
+// names the read that actually serves it (poc-v1 HAS that read, unlike
+// the poc-1 reference this ports), the other three are genuinely unbuilt.
+func assertHonestFloors(t *testing.T, rows []crmcontracts.ComputedField) {
+	t.Helper()
+	want := map[string]string{
+		"weighted_pipeline":     "served_by_hierarchy_rollup",
+		"customer_age":          "not_yet_built",
+		"net_revenue_retention": "not_yet_built",
+		"blended_gross_margin":  "not_yet_built",
+	}
+	for key, reason := range want {
+		row := computedFieldByKey(rows, key)
+		if row.Key == "" {
+			t.Fatalf("missing floor row %q", key)
+		}
+		if row.Computable {
+			t.Fatalf("%s must be computable=false, got %+v", key, row)
+		}
+		if row.Reason == nil || *row.Reason != reason {
+			t.Fatalf("%s.reason = %v, want %q", key, row.Reason, reason)
+		}
+		if row.ValueMinor != nil || row.Value != nil {
+			t.Fatalf("%s must carry no value while computable=false, got %+v", key, row)
+		}
+	}
+}
+
+// pipelineFixtureFor is DealFixture's body, parameterized over ctx so a
+// second workspace (the cross-tenant suite below) can seed its own
+// default pipeline — DealFixture itself is hard-wired to e.Admin(),
+// which is always bound to the harness's primary workspace.
+func pipelineFixtureFor(ctx context.Context, t *testing.T, e *Env) (pipeline ids.PipelineID, open ids.StageID) {
+	t.Helper()
+	if err := e.Deals.SeedDefaults(ctx); err != nil {
+		t.Fatal(err)
+	}
+	p, err := e.Deals.DefaultPipeline(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, st := range *p.Stages {
+		if st.Semantic == "open" {
+			open = ids.From[ids.StageKind](ids.UUID(st.Id))
+			break
+		}
+	}
+	return ids.From[ids.PipelineKind](ids.UUID(p.Id)), open
+}
+
+// computedFieldNoGrantPerms mirrors a real role's organization:read grant
+// with the computed_field object simply absent from the policy document
+// — the STATE-4 shape every non-admin custom role predates 0066's
+// backfill would have had, and exactly what the plan asks be minted by
+// hand since every one of poc-v1's five SEEDED system roles already
+// carries computed_field:read (0066/policy.go).
+var computedFieldNoGrantPerms = principal.Permissions{
+	RoleKeys: []string{"custom-no-computed-field"},
+	Objects: map[string]principal.ObjectGrant{
+		"organization": {Read: true},
+	},
+	RowScope: principal.RowScopeAll,
+}
+
+// computedFieldWorkspaceBPerms grants workspace B's synthetic admin
+// exactly what this suite's cross-tenant scenario needs — organization
+// and deal writes plus computed_field:read — narrower than
+// AdminPerms/cfAdminPerms because neither existing fixture carries the
+// organization+deal+computed_field combination this suite exercises.
+var computedFieldWorkspaceBPerms = principal.Permissions{
+	RoleKeys: []string{"admin"},
+	Objects: map[string]principal.ObjectGrant{
+		"organization":   {Create: true, Read: true},
+		"deal":           {Create: true, Read: true},
+		"pipeline":       {Create: true, Read: true},
+		"computed_field": {Read: true},
+	},
+	RowScope: principal.RowScopeAll,
+}
+
+// seedComputedFieldsWorkspaceB provisions a second tenant (own workspace
+// + one user) and returns an admin-shaped context scoped to it — the
+// customfields suite's seedSecondWorkspace grants only
+// custom_field+person, which doesn't cover this suite's organization/
+// deal/computed_field needs, so this is its own local variant rather
+// than a shared-fixture edit that would ripple into that suite.
+func seedComputedFieldsWorkspaceB(t *testing.T, owner *pgx.Conn) (ws ids.UUID, ctx context.Context) {
+	t.Helper()
+	ws, user := ids.NewV7(), ids.NewV7()
+	if _, err := owner.Exec(context.Background(),
+		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Tenant B Computed', $2, 'EUR')`,
+		ws, "computed-b-"+ws.String()[:8]); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := owner.Exec(context.Background(),
+		`INSERT INTO app_user (id, workspace_id, email, display_name) VALUES ($1, $2, $3, 'B Admin')`,
+		user, ws, "b@computed-b.test"); err != nil {
+		t.Fatal(err)
+	}
+	ctx = principal.WithWorkspaceID(context.Background(), ws)
+	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
+	ctx = principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:" + user.String(),
+		UserID: user, Permissions: computedFieldWorkspaceBPerms,
+	})
+	return ws, ctx
+}
+
+// TestOrganizationComputed_GatedVisible_RealValueMatchesDirectViewRead is
+// the happy path: two open deals with their FX frozen (the owner-conn
+// fixture above) sum to a known figure that must match both the view
+// read directly AND the assembled open_pipeline row, and the four floor
+// rows must carry their exact honest reasons.
+func TestOrganizationComputed_GatedVisible_RealValueMatchesDirectViewRead(t *testing.T) {
+	e := Setup(t)
+	owner := OwnerConn(t)
+	pipeline, open := pipelineFixtureFor(e.Admin(), t, e)
+	orgID := e.SeedOrg(t, "Acme Corp", nil)
+
+	d1, err := e.Deals.CreateDeal(e.Admin(), deals.CreateDealInput{
+		Name: "D1", AmountMinor: int64Ptr(100000), Currency: strPtr("EUR"),
+		PipelineID: pipeline, StageID: open, OrganizationID: orgIDPtr(orgIDOf(orgID)), Source: "manual",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	d2, err := e.Deals.CreateDeal(e.Admin(), deals.CreateDealInput{
+		Name: "D2", AmountMinor: int64Ptr(250000), Currency: strPtr("EUR"),
+		PipelineID: pipeline, StageID: open, OrganizationID: orgIDPtr(orgIDOf(orgID)), Source: "manual",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	freezeDealFX(t, owner, ids.UUID(d1.Id))
+	freezeDealFX(t, owner, ids.UUID(d2.Id))
+
+	wantMinor, wantCount, found := directOpenPipelineRead(e.Admin(), t, e, orgID)
+	if !found || wantMinor == nil || *wantMinor != 350000 || wantCount != 2 {
+		t.Fatalf("test fixture: direct view read = %v/%d/%v, want 350000/2/true", wantMinor, wantCount, found)
+	}
+
+	org, err := e.People.GetOrganization(e.Admin(), orgIDOf(orgID), storekit.IncludeArchived)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if org.ComputedFields == nil || len(*org.ComputedFields) != 5 {
+		t.Fatalf("want exactly 5 computed_fields rows, got %v", org.ComputedFields)
+	}
+	rows := *org.ComputedFields
+	open0 := computedFieldByKey(rows, "open_pipeline")
+	if !open0.Computable || open0.Reason != nil {
+		t.Fatalf("open_pipeline must be computable with no floor reason, got %+v", open0)
+	}
+	if open0.ValueMinor == nil || *open0.ValueMinor != *wantMinor {
+		t.Fatalf("open_pipeline.value_minor = %v, want %d (the direct view read)", open0.ValueMinor, *wantMinor)
+	}
+	if open0.Kind != crmcontracts.ComputedFieldKindCurrencyMinor {
+		t.Fatalf("open_pipeline.kind = %q, want currency_minor", open0.Kind)
+	}
+	if open0.FormulaSql == "" {
+		t.Fatal("open_pipeline.formula_sql must be non-empty")
+	}
+	assertHonestFloors(t, rows)
+}
+
+// TestOrganizationComputed_NoOpenDeals_FloorsToZero is the view's honest
+// "nothing to sum" state: an organization with no open deals produces no
+// view row at all, and the assembler floors that to a real 0 — the
+// poc-1-tested behaviour, since a tile has no way to render "unknown".
+func TestOrganizationComputed_NoOpenDeals_FloorsToZero(t *testing.T) {
+	e := Setup(t)
+	orgID := e.SeedOrg(t, "No Deals Inc", nil)
+
+	if _, _, found := directOpenPipelineRead(e.Admin(), t, e, orgID); found {
+		t.Fatal("test fixture: expected NO view row for an org with no open deals")
+	}
+
+	org, err := e.People.GetOrganization(e.Admin(), orgIDOf(orgID), storekit.IncludeArchived)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rows := *org.ComputedFields
+	open0 := computedFieldByKey(rows, "open_pipeline")
+	if !open0.Computable {
+		t.Fatal("the zero floor is still computable=true — a real (zero) sum, not a missing one")
+	}
+	if open0.ValueMinor == nil || *open0.ValueMinor != 0 {
+		t.Fatalf("open_pipeline.value_minor = %v, want 0", open0.ValueMinor)
+	}
+}
+
+// TestOrganizationComputed_OpenDealsWithoutFrozenFX_NullAggregateFloorsToZero
+// is the OTHER honest "not computable yet" state 0065 documents: open
+// deals exist (the view row IS present, open_deal_count > 0) but every
+// one is still missing fx_rate_to_base — the ordinary state for an open
+// deal through any real write path — so amount_minor_base is NULL for
+// every summand and SUM ignores them all, leaving the row's aggregate
+// itself NULL. The assembler floors this to the same 0 as the no-row
+// case (a record-page tile can't render "unknown" money), but the two
+// underlying database states are genuinely different, and this test
+// proves both: the row EXISTS with a NULL aggregate, not that no row
+// exists at all.
+func TestOrganizationComputed_OpenDealsWithoutFrozenFX_NullAggregateFloorsToZero(t *testing.T) {
+	e := Setup(t)
+	pipeline, open := pipelineFixtureFor(e.Admin(), t, e)
+	orgID := e.SeedOrg(t, "Unpriced Pipeline LLC", nil)
+
+	for _, amount := range []int64{75000, 125000} {
+		if _, err := e.Deals.CreateDeal(e.Admin(), deals.CreateDealInput{
+			Name: "Unpriced deal", AmountMinor: int64Ptr(amount), Currency: strPtr("EUR"),
+			PipelineID: pipeline, StageID: open, OrganizationID: orgIDPtr(orgIDOf(orgID)), Source: "manual",
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	minor, count, found := directOpenPipelineRead(e.Admin(), t, e, orgID)
+	if !found {
+		t.Fatal("test fixture: expected a view row (2 open deals reference this org)")
+	}
+	if minor != nil {
+		t.Fatalf("test fixture: expected a NULL aggregate (neither deal has fx_rate_to_base), got %d", *minor)
+	}
+	if count != 2 {
+		t.Fatalf("test fixture: open_deal_count = %d, want 2", count)
+	}
+
+	org, err := e.People.GetOrganization(e.Admin(), orgIDOf(orgID), storekit.IncludeArchived)
+	if err != nil {
+		t.Fatal(err)
+	}
+	open0 := computedFieldByKey(*org.ComputedFields, "open_pipeline")
+	if !open0.Computable {
+		t.Fatal("a NULL-aggregate row still floors to computable=true (a real zero, not a floor reason)")
+	}
+	if open0.ValueMinor == nil || *open0.ValueMinor != 0 {
+		t.Fatalf("open_pipeline.value_minor = %v, want 0", open0.ValueMinor)
+	}
+}
+
+// TestOrganizationComputed_UngatedPrincipal_ComputedFieldsKeyAbsentFromWire
+// is the STATE-4 proof: every one of poc-v1's five seeded system roles
+// already carries computed_field:read (0066's backfill + policy.go), so
+// this mints a custom permission set — organization:read without
+// computed_field — the shape a bespoke pre-0066 role's policy document
+// would have had. The raw-map decode (not a struct field check) proves
+// the key is absent from the wire entirely, not merely nil in Go.
+func TestOrganizationComputed_UngatedPrincipal_ComputedFieldsKeyAbsentFromWire(t *testing.T) {
+	e := Setup(t)
+	orgID := e.SeedOrg(t, "Gated Org", nil)
+	ctx := e.As(e.Rep1, nil, computedFieldNoGrantPerms)
+
+	org, err := e.People.GetOrganization(ctx, orgIDOf(orgID), storekit.IncludeArchived)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if org.ComputedFields != nil {
+		t.Fatalf("want a nil ComputedFields pointer for an ungated viewer, got %v", org.ComputedFields)
+	}
+
+	raw, err := json.Marshal(org)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var wire map[string]any
+	if err := json.Unmarshal(raw, &wire); err != nil {
+		t.Fatal(err)
+	}
+	if _, present := wire["computed_fields"]; present {
+		t.Fatalf("want the computed_fields KEY entirely absent from the wire, got %v", wire["computed_fields"])
+	}
+}
+
+// TestOrganizationComputed_SecurityInvokerNeverLeaksAcrossWorkspaces is
+// the RLS proof T2's notes ask for: the view is security_invoker=true
+// (0065), so it runs with the CALLING role's privileges and RLS — this
+// seeds two workspaces with SAME-NAMED organizations, each with its own
+// real (FX-frozen) open pipeline total, and proves two things a broken
+// or missing RLS policy would fail: (1) probing the OTHER workspace's
+// real organization id from THIS workspace's GUC-bound transaction finds
+// NO view row at all (deal rows exist in the database, they are just
+// invisible under the wrong tenant context — organization_id uniqueness
+// alone would never catch a regression here, only RLS does); (2) each
+// workspace's own GET reflects its own total, never the other's.
+func TestOrganizationComputed_SecurityInvokerNeverLeaksAcrossWorkspaces(t *testing.T) {
+	e := Setup(t)
+	owner := OwnerConn(t)
+
+	pipelineA, openA := pipelineFixtureFor(e.Admin(), t, e)
+	orgA := e.SeedOrg(t, "Acme", nil)
+	dealA, err := e.Deals.CreateDeal(e.Admin(), deals.CreateDealInput{
+		Name: "A deal", AmountMinor: int64Ptr(500000), Currency: strPtr("EUR"),
+		PipelineID: pipelineA, StageID: openA, OrganizationID: orgIDPtr(orgIDOf(orgA)), Source: "manual",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	freezeDealFX(t, owner, ids.UUID(dealA.Id))
+
+	_, ctxB := seedComputedFieldsWorkspaceB(t, owner)
+	pipelineB, openB := pipelineFixtureFor(ctxB, t, e)
+	orgB := e.SeedOrgAs(ctxB, t, "Acme")
+	dealB, err := e.Deals.CreateDeal(ctxB, deals.CreateDealInput{
+		Name: "B deal", AmountMinor: int64Ptr(999000), Currency: strPtr("EUR"),
+		PipelineID: pipelineB, StageID: openB, OrganizationID: orgIDPtr(orgIDOf(orgB)), Source: "manual",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	freezeDealFX(t, owner, ids.UUID(dealB.Id))
+
+	// The cross-context probe: workspace A's GUC bound, workspace B's
+	// real organization id — a leak would show B's 999000, not nothing.
+	if _, _, found := directOpenPipelineRead(e.Admin(), t, e, orgB); found {
+		t.Fatal("workspace A's context found a view row for workspace B's organization — RLS leak")
+	}
+	if _, _, found := directOpenPipelineRead(ctxB, t, e, orgA); found {
+		t.Fatal("workspace B's context found a view row for workspace A's organization — RLS leak")
+	}
+
+	orgAGet, err := e.People.GetOrganization(e.Admin(), orgIDOf(orgA), storekit.IncludeArchived)
+	if err != nil {
+		t.Fatal(err)
+	}
+	orgBGet, err := e.People.GetOrganization(ctxB, orgIDOf(orgB), storekit.IncludeArchived)
+	if err != nil {
+		t.Fatal(err)
+	}
+	aOpen := computedFieldByKey(*orgAGet.ComputedFields, "open_pipeline")
+	bOpen := computedFieldByKey(*orgBGet.ComputedFields, "open_pipeline")
+	if aOpen.ValueMinor == nil || *aOpen.ValueMinor != 500000 {
+		t.Fatalf("workspace A's own org.open_pipeline = %v, want 500000", aOpen.ValueMinor)
+	}
+	if bOpen.ValueMinor == nil || *bOpen.ValueMinor != 999000 {
+		t.Fatalf("workspace B's own org.open_pipeline = %v, want 999000", bOpen.ValueMinor)
+	}
+}
+
+// orgIDPtr matches int64Ptr/strPtr's convention (orgrollup_integration_test.go
+// / authz_integration_test.go): the *ids.OrganizationID CreateDealInput wants.
+func orgIDPtr(id ids.OrganizationID) *ids.OrganizationID { return &id }

--- a/backend/internal/compose/integration/organization_computed_integration_test.go
+++ b/backend/internal/compose/integration/organization_computed_integration_test.go
@@ -274,18 +274,19 @@ func TestOrganizationComputed_NoOpenDeals_FloorsToZero(t *testing.T) {
 	}
 }
 
-// TestOrganizationComputed_OpenDealsWithoutFrozenFX_NullAggregateFloorsToZero
-// is the OTHER honest "not computable yet" state 0065 documents: open
-// deals exist (the view row IS present, open_deal_count > 0) but every
-// one is still missing fx_rate_to_base — the ordinary state for an open
-// deal through any real write path — so amount_minor_base is NULL for
-// every summand and SUM ignores them all, leaving the row's aggregate
-// itself NULL. The assembler floors this to the same 0 as the no-row
-// case (a record-page tile can't render "unknown" money), but the two
-// underlying database states are genuinely different, and this test
-// proves both: the row EXISTS with a NULL aggregate, not that no row
-// exists at all.
-func TestOrganizationComputed_OpenDealsWithoutFrozenFX_NullAggregateFloorsToZero(t *testing.T) {
+// TestOrganizationComputed_OpenDealsWithoutFrozenFX_AwaitingFX is the
+// OTHER honest "not computable yet" state 0065 documents: open deals
+// exist (the view row IS present, open_deal_count > 0) but every one is
+// still missing fx_rate_to_base — the ordinary state for an open deal
+// through any real write path — so amount_minor_base is NULL for every
+// summand and SUM ignores them all, leaving the row's aggregate itself
+// NULL. Flooring this to a real 0 would be dishonest: it would sit
+// beside a non-zero weighted_pipeline (arc 1b's hierarchy-rollup) as a
+// fabricated "no pipeline" figure. The assembler instead floors it to
+// computable:false, reason:"awaiting_fx", with no value_minor on the
+// wire — the row EXISTS with a NULL aggregate, distinct from the
+// genuine-zero no-row case the next test covers.
+func TestOrganizationComputed_OpenDealsWithoutFrozenFX_AwaitingFX(t *testing.T) {
 	e := Setup(t)
 	pipeline, open := pipelineFixtureFor(e.Admin(), t, e)
 	orgID := e.SeedOrg(t, "Unpriced Pipeline LLC", nil)
@@ -315,11 +316,39 @@ func TestOrganizationComputed_OpenDealsWithoutFrozenFX_NullAggregateFloorsToZero
 		t.Fatal(err)
 	}
 	open0 := computedFieldByKey(*org.ComputedFields, "open_pipeline")
-	if !open0.Computable {
-		t.Fatal("a NULL-aggregate row still floors to computable=true (a real zero, not a floor reason)")
+	if open0.Computable {
+		t.Fatalf("a NULL-aggregate row with open deals present must be computable=false, got %+v", open0)
 	}
-	if open0.ValueMinor == nil || *open0.ValueMinor != 0 {
-		t.Fatalf("open_pipeline.value_minor = %v, want 0", open0.ValueMinor)
+	if open0.Reason == nil || *open0.Reason != "awaiting_fx" {
+		t.Fatalf("open_pipeline.reason = %v, want \"awaiting_fx\"", open0.Reason)
+	}
+	if open0.ValueMinor != nil {
+		t.Fatalf("open_pipeline.value_minor = %v, want absent (awaiting_fx carries no value)", open0.ValueMinor)
+	}
+	if open0.FormulaSql == "" {
+		t.Fatal("open_pipeline.formula_sql must stay populated: the formula exists, only its FX input doesn't yet")
+	}
+
+	raw, err := json.Marshal(org)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var wire map[string]any
+	if err := json.Unmarshal(raw, &wire); err != nil {
+		t.Fatal(err)
+	}
+	fields, ok := wire["computed_fields"].([]any)
+	if !ok {
+		t.Fatalf("computed_fields not a JSON array in the wire payload: %v", wire["computed_fields"])
+	}
+	for _, f := range fields {
+		row, ok := f.(map[string]any)
+		if !ok || row["key"] != "open_pipeline" {
+			continue
+		}
+		if _, present := row["value_minor"]; present {
+			t.Fatalf("open_pipeline.value_minor key must be entirely absent from the wire for awaiting_fx, got %v", row["value_minor"])
+		}
 	}
 }
 

--- a/backend/internal/compose/orgrollupread.go
+++ b/backend/internal/compose/orgrollupread.go
@@ -369,16 +369,19 @@ func weightedPipelineMinor(ctx context.Context, tx pgx.Tx, included []ids.UUID, 
 }
 
 // closedWonMinorThisQuarter sums won deals closed in the current
-// workspace-timezone quarter [start, end), converted at each deal's
-// FROZEN close-time rate — never a live lookup. No FX failure can arise
+// workspace-timezone quarter [start, end). amount_minor_base (0065) IS
+// round(amount_minor * fx_rate_to_base)::bigint, computed once at write
+// time from each deal's FROZEN close-time rate — never a live lookup;
+// reading the GENERATED column here is the same figure as recomputing
+// the product, just not re-derived per read. No FX failure can arise
 // here: the deal_closed_fx CHECK guarantees fx_rate_to_base for every
 // closed deal that has an amount, and an amountless won deal's NULL
-// product is skipped by SUM — an honest 0, not an invented rate.
+// amount_minor_base is skipped by SUM — an honest 0, not an invented rate.
 func closedWonMinorThisQuarter(ctx context.Context, tx pgx.Tx, included []ids.UUID, asOf time.Time, loc *time.Location) (int64, error) {
 	start, end := currentQuarterBounds(asOf, loc)
 	var total int64
 	err := tx.QueryRow(ctx, `
-		SELECT COALESCE(SUM(ROUND(d.amount_minor * d.fx_rate_to_base)), 0)::bigint
+		SELECT COALESCE(SUM(d.amount_minor_base), 0)::bigint
 		FROM deal d
 		WHERE d.organization_id = ANY($1) AND d.status = 'won' AND d.archived_at IS NULL
 		  AND d.closed_at >= $2 AND d.closed_at < $3`,

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -588,6 +588,30 @@ func (e ColdStartProposalStatus) Valid() bool {
 	}
 }
 
+// Defines values for ComputedFieldKind.
+const (
+	ComputedFieldKindCount          ComputedFieldKind = "count"
+	ComputedFieldKindCurrencyMinor  ComputedFieldKind = "currency_minor"
+	ComputedFieldKindDurationMonths ComputedFieldKind = "duration_months"
+	ComputedFieldKindPercent        ComputedFieldKind = "percent"
+)
+
+// Valid indicates whether the value is a known member of the ComputedFieldKind enum.
+func (e ComputedFieldKind) Valid() bool {
+	switch e {
+	case ComputedFieldKindCount:
+		return true
+	case ComputedFieldKindCurrencyMinor:
+		return true
+	case ComputedFieldKindDurationMonths:
+		return true
+	case ComputedFieldKindPercent:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for ConsentEventActorType.
 const (
 	ConsentEventActorTypeAgent     ConsentEventActorType = "agent"
@@ -2228,28 +2252,28 @@ func (e RelationshipStrengthBucket) Valid() bool {
 
 // Defines values for RunReportRequestAggregatesFn.
 const (
-	Avg           RunReportRequestAggregatesFn = "avg"
-	Count         RunReportRequestAggregatesFn = "count"
-	CountDistinct RunReportRequestAggregatesFn = "count_distinct"
-	Max           RunReportRequestAggregatesFn = "max"
-	Min           RunReportRequestAggregatesFn = "min"
-	Sum           RunReportRequestAggregatesFn = "sum"
+	RunReportRequestAggregatesFnAvg           RunReportRequestAggregatesFn = "avg"
+	RunReportRequestAggregatesFnCount         RunReportRequestAggregatesFn = "count"
+	RunReportRequestAggregatesFnCountDistinct RunReportRequestAggregatesFn = "count_distinct"
+	RunReportRequestAggregatesFnMax           RunReportRequestAggregatesFn = "max"
+	RunReportRequestAggregatesFnMin           RunReportRequestAggregatesFn = "min"
+	RunReportRequestAggregatesFnSum           RunReportRequestAggregatesFn = "sum"
 )
 
 // Valid indicates whether the value is a known member of the RunReportRequestAggregatesFn enum.
 func (e RunReportRequestAggregatesFn) Valid() bool {
 	switch e {
-	case Avg:
+	case RunReportRequestAggregatesFnAvg:
 		return true
-	case Count:
+	case RunReportRequestAggregatesFnCount:
 		return true
-	case CountDistinct:
+	case RunReportRequestAggregatesFnCountDistinct:
 		return true
-	case Max:
+	case RunReportRequestAggregatesFnMax:
 		return true
-	case Min:
+	case RunReportRequestAggregatesFnMin:
 		return true
-	case Sum:
+	case RunReportRequestAggregatesFnSum:
 		return true
 	default:
 		return false
@@ -4325,6 +4349,33 @@ type ColdStartRequest1 = interface{}
 // ColdStartRequest2 defines model for .
 type ColdStartRequest2 = interface{}
 
+// ComputedField S-E15.8c formula-field display row (RD-AC-6/RD-AC-7/RD-AC-N-1) — a read-only,
+// database-computed value, never a runtime-authored expression. `computable: false` +
+// `reason` is the honest floor for a field with no backend data model yet — the row is
+// still returned, never omitted or fabricated.
+type ComputedField struct {
+	Computable   bool     `json:"computable"`
+	Dependencies []string `json:"dependencies"`
+
+	// FormulaSql The literal GENERATED-column/view SQL definition; empty string when computable=false.
+	FormulaSql string            `json:"formula_sql"`
+	Key        string            `json:"key"`
+	Kind       ComputedFieldKind `json:"kind"`
+	Label      string            `json:"label"`
+
+	// Reason Set (non-null) iff computable=false, e.g. "not_yet_built".
+	Reason *string `json:"reason,omitempty"`
+
+	// Value Present (and non-null) only when kind is count/duration_months/percent and computable=true.
+	Value *float32 `json:"value,omitempty"`
+
+	// ValueMinor Present (and non-null) only when kind=currency_minor and computable=true.
+	ValueMinor *int64 `json:"value_minor,omitempty"`
+}
+
+// ComputedFieldKind defines model for ComputedField.Kind.
+type ComputedFieldKind string
+
 // ConsentEvent An append-only proof row (Art. 7 demonstrability). Never updated or deleted.
 type ConsentEvent struct {
 	ActorId     *string                `json:"actor_id,omitempty"`
@@ -5403,14 +5454,19 @@ type Organization struct {
 
 	// Classification An org IS a partner iff classification='partner' AND it has a `partner` row (A41/ADR-0032). Values match the data-model §4.1 CHECK.
 	Classification *OrganizationClassification `json:"classification,omitempty"`
-	CreatedAt      time.Time                   `json:"created_at"`
-	DisplayName    string                      `json:"display_name"`
-	Domains        *[]OrganizationDomain       `json:"domains,omitempty"`
-	Id             openapi_types.UUID          `json:"id"`
-	Industry       *string                     `json:"industry,omitempty"`
-	LegalName      *string                     `json:"legal_name,omitempty"`
-	MergedIntoId   *openapi_types.UUID         `json:"merged_into_id,omitempty"`
-	OwnerId        *openapi_types.UUID         `json:"owner_id,omitempty"`
+
+	// ComputedFields S-E15.8c formula-field display rows (RD-AC-6/RD-AC-7/RD-AC-N-1). Populated on
+	// `getOrganization` only; the key is absent entirely (not an empty array) when the
+	// viewer's role lacks computed_field:read visibility (STATE-4).
+	ComputedFields *[]ComputedField      `json:"computed_fields,omitempty"`
+	CreatedAt      time.Time             `json:"created_at"`
+	DisplayName    string                `json:"display_name"`
+	Domains        *[]OrganizationDomain `json:"domains,omitempty"`
+	Id             openapi_types.UUID    `json:"id"`
+	Industry       *string               `json:"industry,omitempty"`
+	LegalName      *string               `json:"legal_name,omitempty"`
+	MergedIntoId   *openapi_types.UUID   `json:"merged_into_id,omitempty"`
+	OwnerId        *openapi_types.UUID   `json:"owner_id,omitempty"`
 
 	// ParentOrgId Single-level hierarchy FK; no cycles.
 	ParentOrgId *openapi_types.UUID `json:"parent_org_id,omitempty"`
@@ -10456,6 +10512,14 @@ func (a *Organization) UnmarshalJSON(b []byte) error {
 		delete(object, "classification")
 	}
 
+	if raw, found := object["computed_fields"]; found {
+		err = json.Unmarshal(raw, &a.ComputedFields)
+		if err != nil {
+			return fmt.Errorf("error reading 'computed_fields': %w", err)
+		}
+		delete(object, "computed_fields")
+	}
+
 	if raw, found := object["created_at"]; found {
 		err = json.Unmarshal(raw, &a.CreatedAt)
 		if err != nil {
@@ -10634,6 +10698,13 @@ func (a Organization) MarshalJSON() ([]byte, error) {
 		object["classification"], err = json.Marshal(a.Classification)
 		if err != nil {
 			return nil, fmt.Errorf("error marshaling 'classification': %w", err)
+		}
+	}
+
+	if a.ComputedFields != nil {
+		object["computed_fields"], err = json.Marshal(a.ComputedFields)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'computed_fields': %w", err)
 		}
 	}
 

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -4363,7 +4363,7 @@ type ComputedField struct {
 	Kind       ComputedFieldKind `json:"kind"`
 	Label      string            `json:"label"`
 
-	// Reason Set (non-null) iff computable=false, e.g. "not_yet_built".
+	// Reason Set (non-null) iff computable=false, e.g. "not_yet_built", "awaiting_fx".
 	Reason *string `json:"reason,omitempty"`
 
 	// Value Present (and non-null) only when kind is count/duration_months/percent and computable=true.

--- a/backend/internal/modules/identity/internal/policy/policy.go
+++ b/backend/internal/modules/identity/internal/policy/policy.go
@@ -21,7 +21,7 @@ import (
 // (features/04 §1). A policy naming anything else is rejected — a typo'd
 // object would otherwise silently grant nothing and read as a bug in the
 // role, not the document.
-var coreObjects = []string{"person", "organization", "deal", "lead", "activity", "pipeline", "list", "tag", "relationship", "partner", "automation", "voice_profile", "product", "offer", "signal", "saved_view", "custom_field"}
+var coreObjects = []string{"person", "organization", "deal", "lead", "activity", "pipeline", "list", "tag", "relationship", "partner", "automation", "voice_profile", "product", "offer", "signal", "saved_view", "custom_field", "computed_field"}
 
 // Document is the role.permissions JSONB shape:
 // {"objects": {"<object>": {"create":…,"read":…,"update":…,"delete":…}},
@@ -53,14 +53,16 @@ var (
 // team-scoped with delete; pipeline, automation AND custom-field config
 // are admin/ops-owned — each reshapes what the system does (or stores)
 // on everyone's records, so they follow the pipeline-config posture:
-// everyone reads the catalog, only admin/ops change it).
+// everyone reads the catalog, only admin/ops change it. computed_field
+// is read-only for every role, admin/ops included — RD-AC-7: no runtime
+// formula-authoring surface exists, so there is no write to grant).
 var defaults = map[string]Document{
 	"admin": {
-		Objects:  objects(crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud),
+		Objects:  objects(crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, readOnly),
 		RowScope: principal.RowScopeAll,
 	},
 	"manager": {
-		Objects:  objects(crud, crud, crud, crud, crud, readOnly, crud, crud, crud, crud, readOnly, crud, crud, crud, crud, crud, readOnly),
+		Objects:  objects(crud, crud, crud, crud, crud, readOnly, crud, crud, crud, crud, readOnly, crud, crud, crud, crud, crud, readOnly, readOnly),
 		RowScope: principal.RowScopeTeam,
 	},
 	"rep": {
@@ -91,6 +93,7 @@ var defaults = map[string]Document{
 			grant{Create: true, Read: true, Update: true},
 			grant{Create: true, Read: true, Update: true},
 			crud,
+			readOnly,
 			readOnly),
 		RowScope: principal.RowScopeTeam,
 	},
@@ -98,18 +101,18 @@ var defaults = map[string]Document{
 		// A read-only role still owns its personal view state: saved views
 		// are P1-exempt per-user prefs (runtime-config-surface.md §3), not
 		// shared records, so full self-service is correct even here.
-		Objects:  objects(readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, crud, readOnly),
+		Objects:  objects(readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, readOnly, crud, readOnly, readOnly),
 		RowScope: principal.RowScopeAll,
 	},
 	"ops": {
-		Objects:  objects(crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud),
+		Objects:  objects(crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, crud, readOnly),
 		RowScope: principal.RowScopeAll,
 	},
 }
 
 // objects zips grants onto coreObjects in declaration order — one line
 // per role instead of twelve repeated map literals.
-func objects(person, organization, deal, lead, activity, pipeline, list, tag, relationship, partner, automation, voiceProfile, product, offer, signal, savedView, customField grant) map[string]grant {
+func objects(person, organization, deal, lead, activity, pipeline, list, tag, relationship, partner, automation, voiceProfile, product, offer, signal, savedView, customField, computedField grant) map[string]grant {
 	return map[string]grant{
 		"person": person, "organization": organization, "deal": deal,
 		"lead": lead, "activity": activity, "pipeline": pipeline,
@@ -117,6 +120,7 @@ func objects(person, organization, deal, lead, activity, pipeline, list, tag, re
 		"automation": automation, "voice_profile": voiceProfile,
 		"product": product, "offer": offer, "signal": signal,
 		"saved_view": savedView, "custom_field": customField,
+		"computed_field": computedField,
 	}
 }
 

--- a/backend/internal/modules/people/organization.go
+++ b/backend/internal/modules/people/organization.go
@@ -131,7 +131,7 @@ func (s *Store) GetOrganization(ctx context.Context, id ids.OrganizationID, arch
 		// rollup read below, and out.ComputedFields stays its nil zero
 		// value — omitempty then drops the key entirely on marshal (T1).
 		if computedFieldsVisible(ctx) {
-			minor, _, err := openPipelineRollup(ctx, tx, id)
+			minor, err := openPipelineRollup(ctx, tx, id)
 			if err != nil {
 				return fmt.Errorf("read open pipeline rollup: %w", err)
 			}

--- a/backend/internal/modules/people/organization.go
+++ b/backend/internal/modules/people/organization.go
@@ -123,8 +123,22 @@ func (s *Store) GetOrganization(ctx context.Context, id ids.OrganizationID, arch
 		if err := auth.EnsureVisible(ctx, tx, "organization", id.UUID); err != nil {
 			return err
 		}
-		out, err = readOrganization(ctx, tx, id, archived, active)
-		return err
+		if out, err = readOrganization(ctx, tx, id, archived, active); err != nil {
+			return err
+		}
+		// STATE-4: the gate is a pure permission check (no query), so a
+		// caller whose role lacks computed_field:read never pays for the
+		// rollup read below, and out.ComputedFields stays its nil zero
+		// value — omitempty then drops the key entirely on marshal (T1).
+		if computedFieldsVisible(ctx) {
+			minor, _, err := openPipelineRollup(ctx, tx, id)
+			if err != nil {
+				return fmt.Errorf("read open pipeline rollup: %w", err)
+			}
+			rows := organizationComputedFields(minor)
+			out.ComputedFields = &rows
+		}
+		return nil
 	})
 	return out, err
 }

--- a/backend/internal/modules/people/organization.go
+++ b/backend/internal/modules/people/organization.go
@@ -131,11 +131,11 @@ func (s *Store) GetOrganization(ctx context.Context, id ids.OrganizationID, arch
 		// rollup read below, and out.ComputedFields stays its nil zero
 		// value — omitempty then drops the key entirely on marshal (T1).
 		if computedFieldsVisible(ctx) {
-			minor, err := openPipelineRollup(ctx, tx, id)
+			minor, dealCount, err := openPipelineRollup(ctx, tx, id)
 			if err != nil {
 				return fmt.Errorf("read open pipeline rollup: %w", err)
 			}
-			rows := organizationComputedFields(minor)
+			rows := organizationComputedFields(minor, dealCount)
 			out.ComputedFields = &rows
 		}
 		return nil

--- a/backend/internal/modules/people/organization_computed.go
+++ b/backend/internal/modules/people/organization_computed.go
@@ -30,7 +30,14 @@ import (
 const (
 	notYetBuiltReason             = "not_yet_built"
 	servedByHierarchyRollupReason = "served_by_hierarchy_rollup"
-	openPipelineFormulaSQL        = "organization_open_pipeline_rollup (0065): SUM(deal.amount_minor_base) FROM deal WHERE deal.status = 'open' AND deal.organization_id = <this org> AND deal.archived_at IS NULL"
+	// awaitingFXReason floors open_pipeline when the view row EXISTS
+	// (open deals reference this organization) but its aggregate is
+	// itself NULL: every one of those deals is still missing
+	// fx_rate_to_base, the ordinary state for an open deal (0065's
+	// documented "not computable yet" case) — distinct from the
+	// genuine zero of an organization with no open deals at all.
+	awaitingFXReason       = "awaiting_fx"
+	openPipelineFormulaSQL = "organization_open_pipeline_rollup (0065): SUM(deal.amount_minor_base) FROM deal WHERE deal.status = 'open' AND deal.organization_id = <this org> AND deal.archived_at IS NULL"
 )
 
 // openPipelineDependencies names the columns feeding the view's
@@ -78,59 +85,77 @@ func computedFieldsVisible(ctx context.Context) bool {
 // transaction already established, not add protection.
 //
 // No row (an organization with no open deals at all) is the honest
-// "nothing to sum" case: (nil, 0, nil), never an error.
-func openPipelineRollup(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID) (minorBase *int64, err error) {
-	var dealCount int // scanned from the view but unused for display: the schema carries
-	// it for future rows; no consumer today per RD-T08 (rule T8).
+// "nothing to sum" case: (nil, 0, nil), never an error. dealCount is the
+// caller's only way to distinguish that genuine-zero state from the
+// OTHER honest "not computable yet" state — open deals exist
+// (dealCount > 0) but every one is still missing fx_rate_to_base, so
+// the aggregate itself comes back NULL.
+func openPipelineRollup(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID) (minorBase *int64, dealCount int, err error) {
 	err = tx.QueryRow(ctx,
 		`SELECT open_pipeline_minor_base, open_deal_count
 		 FROM organization_open_pipeline_rollup WHERE organization_id = $1`,
 		orgID).Scan(&minorBase, &dealCount)
 	if errors.Is(err, pgx.ErrNoRows) {
-		// Scan never ran, so minorBase is still its zero value (nil) —
-		// return the named var, not a literal nil, nil: the honest
-		// "nothing to sum" case above, not a swallowed error.
-		return minorBase, nil
+		// Scan never ran, so minorBase/dealCount are still their zero
+		// values (nil, 0) — return the named vars, not literal zeroes:
+		// the honest "nothing to sum" case above, not a swallowed error.
+		return minorBase, dealCount, nil
 	}
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
-	return minorBase, nil
+	return minorBase, dealCount, nil
 }
 
 // organizationComputedFields assembles the 5 display rows RD-T08 names.
-// It takes only the aggregate figure; the count from the view (rule T8:
-// no dead returns) stays at the SQL layer until a consumer claims it.
+// It takes the view's two output columns (rule T8: no dead returns —
+// openDealCount now has a real consumer, the three-way branch below).
 //
-// A NULL aggregate (open deals exist but every one is still missing its
-// FX input, so amount_minor_base is itself NULL — 0065's documented
-// "not computable yet" case) and NO row at all (no open deals) both
-// floor to a real value_minor of 0 here, with computable staying true:
-// the poc-1-tested behaviour. 0065's migration comment records the more
-// nuanced "NULL is honestly not-computable-yet" distinction at the SQL
-// layer; this display row deliberately takes the coarser floor because
-// a record-page tile has no way to render "unknown" money, and 0 is the
-// truthful lower bound of "the open deals we CAN price sum to this much."
-func organizationComputedFields(openPipelineMinor *int64) []crmcontracts.ComputedField {
-	value := int64(0)
-	if openPipelineMinor != nil {
-		value = *openPipelineMinor
-	}
+// open_pipeline is a genuine three-way state, not a single floor:
+//   - openDealCount == 0 (no view row: an organization with no open
+//     deals at all) is the honest "nothing to sum" case: computable:true,
+//     value_minor:0 — a real zero, not a missing one.
+//   - openPipelineMinor != nil (the view row's aggregate is non-NULL) is
+//     the genuinely computable case: computable:true, value_minor:sum.
+//   - openPipelineMinor == nil AND openDealCount > 0 (open deals exist
+//     but every one is still missing fx_rate_to_base, the ordinary state
+//     for an open deal — 0065's documented "not computable yet" case) is
+//     NOT a zero: flooring it would show a dishonest 0 pipeline beside a
+//     non-zero weighted_pipeline. It floors instead to computable:false,
+//     reason:"awaiting_fx", with no value_minor on the wire — the honest
+//     "not computable yet" state 0065's migration comment already names,
+//     now surfaced here instead of floored away. formula_sql stays
+//     populated: the formula exists, only its FX input doesn't yet.
+func organizationComputedFields(openPipelineMinor *int64, openDealCount int) []crmcontracts.ComputedField {
 	weightedReason := servedByHierarchyRollupReason
 	customerAgeReason := notYetBuiltReason
 	nrrReason := notYetBuiltReason
 	marginReason := notYetBuiltReason
 
+	openPipelineRow := crmcontracts.ComputedField{
+		Key:          "open_pipeline",
+		Label:        "Open pipeline",
+		Kind:         crmcontracts.ComputedFieldKindCurrencyMinor,
+		FormulaSql:   openPipelineFormulaSQL,
+		Dependencies: openPipelineDependencies,
+	}
+	switch {
+	case openPipelineMinor != nil:
+		value := *openPipelineMinor
+		openPipelineRow.Computable = true
+		openPipelineRow.ValueMinor = &value
+	case openDealCount == 0:
+		zero := int64(0)
+		openPipelineRow.Computable = true
+		openPipelineRow.ValueMinor = &zero
+	default:
+		reason := awaitingFXReason
+		openPipelineRow.Computable = false
+		openPipelineRow.Reason = &reason
+	}
+
 	return []crmcontracts.ComputedField{
-		{
-			Key:          "open_pipeline",
-			Label:        "Open pipeline",
-			Kind:         crmcontracts.ComputedFieldKindCurrencyMinor,
-			ValueMinor:   &value,
-			FormulaSql:   openPipelineFormulaSQL,
-			Dependencies: openPipelineDependencies,
-			Computable:   true,
-		},
+		openPipelineRow,
 		{
 			Key:          "weighted_pipeline",
 			Label:        "Weighted pipeline",

--- a/backend/internal/modules/people/organization_computed.go
+++ b/backend/internal/modules/people/organization_computed.go
@@ -79,25 +79,25 @@ func computedFieldsVisible(ctx context.Context) bool {
 //
 // No row (an organization with no open deals at all) is the honest
 // "nothing to sum" case: (nil, 0, nil), never an error.
-func openPipelineRollup(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID) (minorBase *int64, dealCount int, err error) {
+func openPipelineRollup(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID) (minorBase *int64, err error) {
+	var dealCount int // scanned from the view but unused for display: the schema carries
+	// it for future rows; no consumer today per RD-T08 (rule T8).
 	err = tx.QueryRow(ctx,
 		`SELECT open_pipeline_minor_base, open_deal_count
 		 FROM organization_open_pipeline_rollup WHERE organization_id = $1`,
 		orgID).Scan(&minorBase, &dealCount)
 	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, 0, nil
+		return nil, nil
 	}
 	if err != nil {
-		return nil, 0, err
+		return nil, err
 	}
-	return minorBase, dealCount, nil
+	return minorBase, nil
 }
 
 // organizationComputedFields assembles the 5 display rows RD-T08 names.
-// It takes only the aggregate figure — openPipelineRollup's dealCount
-// return has no display row today (the ComputedField schema names no
-// count field for open_pipeline), so the wiring call site drops it
-// rather than threading an unused value through here.
+// It takes only the aggregate figure; the count from the view (rule T8:
+// no dead returns) stays at the SQL layer until a consumer claims it.
 //
 // A NULL aggregate (open deals exist but every one is still missing its
 // FX input, so amount_minor_base is itself NULL — 0065's documented

--- a/backend/internal/modules/people/organization_computed.go
+++ b/backend/internal/modules/people/organization_computed.go
@@ -87,7 +87,10 @@ func openPipelineRollup(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID
 		 FROM organization_open_pipeline_rollup WHERE organization_id = $1`,
 		orgID).Scan(&minorBase, &dealCount)
 	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, nil
+		// Scan never ran, so minorBase is still its zero value (nil) —
+		// return the named var, not a literal nil, nil: the honest
+		// "nothing to sum" case above, not a swallowed error.
+		return minorBase, nil
 	}
 	if err != nil {
 		return nil, err

--- a/backend/internal/modules/people/organization_computed.go
+++ b/backend/internal/modules/people/organization_computed.go
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+// The RD-T08 formula-field display rows GetOrganization surfaces
+// (RD-AC-6/RD-AC-7/RD-AC-N-1): one DB-computed row (open_pipeline, fed
+// by the 0065 security_invoker view), plus four honest floor rows. The
+// visibility gate is a pure in-memory permission check — the STATE-4
+// absent-key case — never a database round trip.
+
+import (
+	"context"
+	"errors"
+
+	"github.com/jackc/pgx/v5"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// notYetBuiltReason floors a computed field with no backend data model
+// at all. servedByHierarchyRollupReason is the honest alternative for
+// weighted_pipeline: poc-v1, unlike the poc-1 reference this ports,
+// already serves that figure — GET /organizations/{id}/hierarchy-rollup
+// (arc 1b) — so "not_yet_built" would misstate the truth; the row still
+// floors computable=false because it is not a DB-GENERATED artifact
+// (RD-AC-6's own bar), it just isn't UNBUILT.
+const (
+	notYetBuiltReason             = "not_yet_built"
+	servedByHierarchyRollupReason = "served_by_hierarchy_rollup"
+	openPipelineFormulaSQL        = "organization_open_pipeline_rollup (0065): SUM(deal.amount_minor_base) FROM deal WHERE deal.status = 'open' AND deal.organization_id = <this org> AND deal.archived_at IS NULL"
+)
+
+// openPipelineDependencies names the columns feeding the view's
+// aggregate: the two inputs of deal.amount_minor_base's own GENERATED
+// expression (0065), plus the two columns the view's WHERE clause
+// gates participation on.
+var openPipelineDependencies = []string{"deal.amount_minor", "deal.fx_rate_to_base", "deal.status", "deal.archived_at"}
+
+// computedFieldsVisible answers the STATE-4 gate: does the acting
+// principal's merged role policy grant computed_field:read? poc-1
+// re-loaded role permissions from the database on every call
+// (RollupStore.ComputedFieldsVisible); poc-v1's principal already
+// carries its merged Permissions, resolved once at authentication
+// (B-EP03.1), so this is a pure in-memory check — no query. The system
+// principal (workspace provisioning, no role of its own) is trusted by
+// construction, mirroring auth.Require's own carve-out; a request with
+// no actor bound at all fails closed.
+func computedFieldsVisible(ctx context.Context) bool {
+	actor, ok := principal.Actor(ctx)
+	if !ok {
+		return false
+	}
+	if actor.Type == principal.PrincipalSystem {
+		return true
+	}
+	return actor.Permissions.Allows("computed_field", principal.ActionRead)
+}
+
+// openPipelineRollup reads the organization_open_pipeline_rollup view
+// (0065) for one organization, inside the SAME workspace transaction the
+// caller (GetOrganization) already opened. The view is
+// security_invoker=true (0065's own comment): it runs with the CALLING
+// role's privileges and RLS, so the deal rows it sums are already
+// scoped to the workspace the transaction's app.workspace_id GUC bound —
+// the same tenant-isolation policy that gates a direct SELECT on deal.
+//
+// The poc-1 reference added a defense-in-depth join to
+// organization.workspace_id here because it ran this read at pool
+// level, outside any per-call GUC scope. That join would be redundant
+// in this repo: the caller reaching this function has already run
+// auth.EnsureVisible on the SAME organization id in the SAME
+// transaction — itself RLS-gated on organization.workspace_id — so orgID
+// is already proven to belong to the caller's own workspace before this
+// query runs. Adding the join would only re-derive a fact the
+// transaction already established, not add protection.
+//
+// No row (an organization with no open deals at all) is the honest
+// "nothing to sum" case: (nil, 0, nil), never an error.
+func openPipelineRollup(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID) (minorBase *int64, dealCount int, err error) {
+	err = tx.QueryRow(ctx,
+		`SELECT open_pipeline_minor_base, open_deal_count
+		 FROM organization_open_pipeline_rollup WHERE organization_id = $1`,
+		orgID).Scan(&minorBase, &dealCount)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, 0, nil
+	}
+	if err != nil {
+		return nil, 0, err
+	}
+	return minorBase, dealCount, nil
+}
+
+// organizationComputedFields assembles the 5 display rows RD-T08 names.
+// It takes only the aggregate figure — openPipelineRollup's dealCount
+// return has no display row today (the ComputedField schema names no
+// count field for open_pipeline), so the wiring call site drops it
+// rather than threading an unused value through here.
+//
+// A NULL aggregate (open deals exist but every one is still missing its
+// FX input, so amount_minor_base is itself NULL — 0065's documented
+// "not computable yet" case) and NO row at all (no open deals) both
+// floor to a real value_minor of 0 here, with computable staying true:
+// the poc-1-tested behaviour. 0065's migration comment records the more
+// nuanced "NULL is honestly not-computable-yet" distinction at the SQL
+// layer; this display row deliberately takes the coarser floor because
+// a record-page tile has no way to render "unknown" money, and 0 is the
+// truthful lower bound of "the open deals we CAN price sum to this much."
+func organizationComputedFields(openPipelineMinor *int64) []crmcontracts.ComputedField {
+	value := int64(0)
+	if openPipelineMinor != nil {
+		value = *openPipelineMinor
+	}
+	weightedReason := servedByHierarchyRollupReason
+	customerAgeReason := notYetBuiltReason
+	nrrReason := notYetBuiltReason
+	marginReason := notYetBuiltReason
+
+	return []crmcontracts.ComputedField{
+		{
+			Key:          "open_pipeline",
+			Label:        "Open pipeline",
+			Kind:         crmcontracts.ComputedFieldKindCurrencyMinor,
+			ValueMinor:   &value,
+			FormulaSql:   openPipelineFormulaSQL,
+			Dependencies: openPipelineDependencies,
+			Computable:   true,
+		},
+		{
+			Key:          "weighted_pipeline",
+			Label:        "Weighted pipeline",
+			Kind:         crmcontracts.ComputedFieldKindCurrencyMinor,
+			FormulaSql:   "",
+			Dependencies: []string{},
+			Computable:   false,
+			Reason:       &weightedReason,
+		},
+		{
+			Key:          "customer_age",
+			Label:        "Customer age",
+			Kind:         crmcontracts.ComputedFieldKindDurationMonths,
+			FormulaSql:   "",
+			Dependencies: []string{},
+			Computable:   false,
+			Reason:       &customerAgeReason,
+		},
+		{
+			Key:          "net_revenue_retention",
+			Label:        "Net revenue retention",
+			Kind:         crmcontracts.ComputedFieldKindPercent,
+			FormulaSql:   "",
+			Dependencies: []string{},
+			Computable:   false,
+			Reason:       &nrrReason,
+		},
+		{
+			Key:          "blended_gross_margin",
+			Label:        "Blended gross margin",
+			Kind:         crmcontracts.ComputedFieldKindPercent,
+			FormulaSql:   "",
+			Dependencies: []string{},
+			Computable:   false,
+			Reason:       &marginReason,
+		},
+	}
+}

--- a/backend/internal/modules/people/organization_computed_test.go
+++ b/backend/internal/modules/people/organization_computed_test.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+import (
+	"context"
+	"testing"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// computedFieldsVisible is a pure in-memory check (no DB round trip):
+// it reads the acting principal's already-merged Permissions, the
+// divergence from poc-1's per-call role reload the plan calls out.
+func TestComputedFieldsVisible_GrantedRole(t *testing.T) {
+	ctx := principal.WithActor(context.Background(), principal.Principal{
+		Type: principal.PrincipalHuman,
+		Permissions: principal.Permissions{
+			Objects: map[string]principal.ObjectGrant{"computed_field": {Read: true}},
+		},
+	})
+	if !computedFieldsVisible(ctx) {
+		t.Fatal("want visible for a role granting computed_field:read")
+	}
+}
+
+func TestComputedFieldsVisible_UngatedRoleDenied(t *testing.T) {
+	ctx := principal.WithActor(context.Background(), principal.Principal{
+		Type: principal.PrincipalHuman,
+		Permissions: principal.Permissions{
+			// A role missing the computed_field grant entirely — the
+			// zero-value ObjectGrant denies, matching Permissions.Allows.
+			Objects: map[string]principal.ObjectGrant{"organization": {Read: true}},
+		},
+	})
+	if computedFieldsVisible(ctx) {
+		t.Fatal("want NOT visible when the role's policy carries no computed_field grant")
+	}
+}
+
+func TestComputedFieldsVisible_NoActorBoundDenied(t *testing.T) {
+	if computedFieldsVisible(context.Background()) {
+		t.Fatal("want NOT visible with no actor bound (fail-closed)")
+	}
+}
+
+func TestComputedFieldsVisible_SystemPrincipalTrusted(t *testing.T) {
+	ctx := principal.WithActor(context.Background(), principal.Principal{Type: principal.PrincipalSystem})
+	if !computedFieldsVisible(ctx) {
+		t.Fatal("want the system principal trusted by construction, matching auth.Require's own carve-out")
+	}
+}
+
+// organizationComputedFields is the pure 5-row assembler: exactly one
+// computable row (open_pipeline, fed by the view read), four floors —
+// weighted_pipeline honestly named as served by the hierarchy-rollup
+// read (poc-v1 HAS that read, unlike poc-1), the other three genuinely
+// not_yet_built.
+func TestOrganizationComputedFields_FiveRowsExactShape(t *testing.T) {
+	minor := int64(125000)
+	rows := organizationComputedFields(&minor)
+	if len(rows) != 5 {
+		t.Fatalf("want exactly 5 display rows, got %d", len(rows))
+	}
+
+	open := rows[0]
+	if open.Key != "open_pipeline" || open.Kind != crmcontracts.ComputedFieldKindCurrencyMinor {
+		t.Fatalf("row[0] = %+v, want open_pipeline/currency_minor", open)
+	}
+	if !open.Computable || open.Reason != nil {
+		t.Fatalf("open_pipeline must be computable with no floor reason, got %+v", open)
+	}
+	if open.ValueMinor == nil || *open.ValueMinor != minor {
+		t.Fatalf("open_pipeline.value_minor = %v, want %d", open.ValueMinor, minor)
+	}
+	if open.FormulaSql == "" {
+		t.Fatal("open_pipeline must carry a non-empty formula_sql (the view definition)")
+	}
+
+	byKey := map[string]crmcontracts.ComputedField{}
+	for _, r := range rows[1:] {
+		byKey[r.Key] = r
+	}
+	wantFloors := map[string]string{
+		"weighted_pipeline":     "served_by_hierarchy_rollup",
+		"customer_age":          "not_yet_built",
+		"net_revenue_retention": "not_yet_built",
+		"blended_gross_margin":  "not_yet_built",
+	}
+	for key, wantReason := range wantFloors {
+		row, ok := byKey[key]
+		if !ok {
+			t.Fatalf("missing floor row %q", key)
+		}
+		if row.Computable {
+			t.Fatalf("%s must be computable=false", key)
+		}
+		if row.Reason == nil || *row.Reason != wantReason {
+			t.Fatalf("%s.reason = %v, want %q", key, row.Reason, wantReason)
+		}
+		if row.ValueMinor != nil || row.Value != nil {
+			t.Fatalf("%s must carry no value while computable=false", key)
+		}
+		if row.Dependencies == nil {
+			t.Fatalf("%s.dependencies must be a real (possibly empty) array, never nil", key)
+		}
+	}
+}
+
+// The no-open-deals case (nil minorBase from the reader, meaning "no view
+// row at all") floors open_pipeline to a real 0 — the poc-1-tested
+// behaviour: a record-page tile has no way to render "unknown", so 0 is
+// the honest lower bound of what CAN be priced.
+func TestOrganizationComputedFields_NilMinorFloorsToZero(t *testing.T) {
+	rows := organizationComputedFields(nil)
+	if rows[0].ValueMinor == nil || *rows[0].ValueMinor != 0 {
+		t.Fatalf("open_pipeline.value_minor = %v, want 0", rows[0].ValueMinor)
+	}
+	if !rows[0].Computable {
+		t.Fatal("the zero floor is still computable=true — a real (zero) sum, not a missing one")
+	}
+}

--- a/backend/internal/modules/people/organization_computed_test.go
+++ b/backend/internal/modules/people/organization_computed_test.go
@@ -60,7 +60,7 @@ func TestComputedFieldsVisible_SystemPrincipalTrusted(t *testing.T) {
 // not_yet_built.
 func TestOrganizationComputedFields_FiveRowsExactShape(t *testing.T) {
 	minor := int64(125000)
-	rows := organizationComputedFields(&minor)
+	rows := organizationComputedFields(&minor, 1)
 	if len(rows) != 5 {
 		t.Fatalf("want exactly 5 display rows, got %d", len(rows))
 	}
@@ -109,16 +109,43 @@ func TestOrganizationComputedFields_FiveRowsExactShape(t *testing.T) {
 	}
 }
 
-// The no-open-deals case (nil minorBase from the reader, meaning "no view
-// row at all") floors open_pipeline to a real 0 — the poc-1-tested
-// behaviour: a record-page tile has no way to render "unknown", so 0 is
-// the honest lower bound of what CAN be priced.
-func TestOrganizationComputedFields_NilMinorFloorsToZero(t *testing.T) {
-	rows := organizationComputedFields(nil)
+// The no-open-deals case (nil minorBase and dealCount==0, meaning "no
+// view row at all") floors open_pipeline to a real 0 — the
+// poc-1-tested behaviour: a record-page tile has no way to render
+// "unknown", so 0 is the honest lower bound of what CAN be priced.
+func TestOrganizationComputedFields_NoOpenDeals_FloorsToZero(t *testing.T) {
+	rows := organizationComputedFields(nil, 0)
 	if rows[0].ValueMinor == nil || *rows[0].ValueMinor != 0 {
 		t.Fatalf("open_pipeline.value_minor = %v, want 0", rows[0].ValueMinor)
 	}
 	if !rows[0].Computable {
 		t.Fatal("the zero floor is still computable=true — a real (zero) sum, not a missing one")
+	}
+	if rows[0].Reason != nil {
+		t.Fatalf("open_pipeline.reason = %v, want nil for the genuine-zero case", rows[0].Reason)
+	}
+}
+
+// The OTHER honest "not computable yet" state 0065 documents: the view
+// row EXISTS (open deals reference this org, dealCount > 0) but its
+// aggregate is itself NULL because every one of those deals is still
+// missing fx_rate_to_base. Flooring this to 0 would be dishonest — a
+// non-zero weighted_pipeline sitting beside a fabricated zero — so it
+// must floor to computable:false, reason:"awaiting_fx" instead, with no
+// value_minor on the wire.
+func TestOrganizationComputedFields_NullAggregateWithOpenDeals_AwaitingFX(t *testing.T) {
+	rows := organizationComputedFields(nil, 2)
+	open := rows[0]
+	if open.Computable {
+		t.Fatalf("open_pipeline must be computable=false when the aggregate is NULL but open deals exist, got %+v", open)
+	}
+	if open.Reason == nil || *open.Reason != awaitingFXReason {
+		t.Fatalf("open_pipeline.reason = %v, want %q", open.Reason, awaitingFXReason)
+	}
+	if open.ValueMinor != nil {
+		t.Fatalf("open_pipeline.value_minor = %v, want nil (awaiting_fx carries no value)", open.ValueMinor)
+	}
+	if open.FormulaSql == "" {
+		t.Fatal("open_pipeline.formula_sql must stay populated: the formula exists, only its FX input doesn't yet")
 	}
 }

--- a/backend/migrations/core/0065_formula_field_boundary.down.sql
+++ b/backend/migrations/core/0065_formula_field_boundary.down.sql
@@ -1,0 +1,4 @@
+-- 0065 down — reverse of the up migration, in reverse dependency order (the
+-- view reads the column, so drop the view first).
+DROP VIEW organization_open_pipeline_rollup;
+ALTER TABLE deal DROP COLUMN amount_minor_base;

--- a/backend/migrations/core/0065_formula_field_boundary.up.sql
+++ b/backend/migrations/core/0065_formula_field_boundary.up.sql
@@ -33,6 +33,13 @@
 --    aggregate column NULL (SUM ignores NULLs) — both are the honest
 --    "not computable yet" state, distinct from a genuine zero-value
 --    roll-up.
+--
+-- Follow-up (not this migration): a deal already booked in the
+-- workspace's own base currency never needs an FX rate at all, so this
+-- view could serve it live instead of waiting on fx_rate_to_base — e.g.
+-- summing COALESCE(amount_minor_base, amount_minor) WHERE currency =
+-- <workspace base_currency>. Left for a later pass; today's view treats
+-- every open deal identically regardless of its native currency.
 ALTER TABLE deal ADD COLUMN amount_minor_base bigint
   GENERATED ALWAYS AS (round(amount_minor * fx_rate_to_base)::bigint) STORED;
 

--- a/backend/migrations/core/0065_formula_field_boundary.up.sql
+++ b/backend/migrations/core/0065_formula_field_boundary.up.sql
@@ -1,0 +1,49 @@
+-- 0065: the formula-field boundary proof (RD-T08, RD-AC-6/RD-AC-7/RD-AC-N-1):
+-- a formula field is a database-GENERATED artifact, never a runtime-authored
+-- expression. Two concrete examples:
+--
+-- 1. Same-row GENERATED column (RD-AC-6): deal.amount_minor_base, the
+--    base-currency-converted amount computed from the deal's own
+--    amount_minor x fx_rate_to_base — roll-ups must aggregate the
+--    base-currency value, never a raw native amount_minor across
+--    currencies. GENERATED ALWAYS AS ... STORED mirrors deal.search_tsv's
+--    existing GENERATED column (0006_deals.up.sql) in style. A NULL input
+--    (either amount_minor or fx_rate_to_base still unset) yields a NULL
+--    result: Postgres evaluates the expression per row, and ordinary
+--    NULL-propagating arithmetic already gives the honest
+--    "not-computable-yet" state for free, no CASE needed. An open deal
+--    commonly has fx_rate_to_base still NULL (deal_closed_fx only requires
+--    it once the deal transitions off 'open'), so this is a real, not a
+--    contrived, missing-input case.
+--
+-- 2. Cross-record aggregate (the RD-AC-N-1 reconciliation): a same-row
+--    GENERATED column structurally cannot read other rows (a Postgres
+--    limitation), so the per-organization open-pipeline roll-up is served
+--    as a security_invoker VIEW — it runs with the CALLING role's
+--    privileges and RLS, not the view owner's, so it inherits deal's
+--    tenant-isolation policy (0014_rls.up.sql) exactly as if the base
+--    table were queried directly; no new grant is needed beyond what
+--    0015 already extends to every future table-shaped object the owner
+--    creates (views included). It reads only existing columns
+--    (amount_minor_base, status, organization_id, archived_at) — no new
+--    tables, never a runtime interpreter. An organization with no open
+--    deals produces no row at all (never a fabricated zero); an
+--    organization with open deals whose amount_minor_base is itself not
+--    yet computable (missing FX input) still produces a row, with the
+--    aggregate column NULL (SUM ignores NULLs) — both are the honest
+--    "not computable yet" state, distinct from a genuine zero-value
+--    roll-up.
+ALTER TABLE deal ADD COLUMN amount_minor_base bigint
+  GENERATED ALWAYS AS (round(amount_minor * fx_rate_to_base)::bigint) STORED;
+
+CREATE VIEW organization_open_pipeline_rollup
+  WITH (security_invoker = true) AS
+    SELECT
+      d.organization_id,
+      sum(d.amount_minor_base) AS open_pipeline_minor_base,
+      count(*)                 AS open_deal_count
+    FROM deal d
+    WHERE d.status = 'open'
+      AND d.organization_id IS NOT NULL
+      AND d.archived_at IS NULL
+    GROUP BY d.organization_id;

--- a/backend/migrations/core/0066_computed_field_rbac.down.sql
+++ b/backend/migrations/core/0066_computed_field_rbac.down.sql
@@ -1,0 +1,1 @@
+UPDATE role SET permissions = permissions #- '{objects,computed_field}' WHERE is_system;

--- a/backend/migrations/core/0066_computed_field_rbac.up.sql
+++ b/backend/migrations/core/0066_computed_field_rbac.up.sql
@@ -1,0 +1,12 @@
+-- 0066: backfill the `computed_field` RBAC object into the seeded
+-- system-role policy documents of EXISTING workspaces (new workspaces get
+-- it from the code-side seed, identity/internal/policy). Posture: unlike
+-- custom_field (admin/ops-owned CRUD), computed_field is read-only for
+-- EVERY role, admin/ops included — RD-AC-7: no runtime formula-authoring
+-- surface exists, so there is no write to grant.
+
+UPDATE role SET permissions = jsonb_set(
+  permissions, '{objects,computed_field}',
+  '{"create":false,"read":true,"update":false,"delete":false}'::jsonb)
+WHERE is_system AND key IN ('admin','ops','manager','rep','read_only')
+  AND NOT permissions->'objects' ? 'computed_field';

--- a/backend/migrations/schema_fitness_integration_test.go
+++ b/backend/migrations/schema_fitness_integration_test.go
@@ -166,6 +166,85 @@ func TestFK_tenantLocalReferencesAreComposite(t *testing.T) {
 	}
 }
 
+// TestSchema_amountMinorBaseIsDatabaseGenerated is the fitness function for
+// the formula-field boundary invariant (RD-AC-6, 0065): deal.amount_minor_base
+// must be a database GENERATED column, never an application-computed or
+// hand-maintained one — the DATABASE is the source of truth, so a future
+// migration that quietly re-added it as a plain writable bigint (letting a
+// write path set it directly) fails here rather than surviving unnoticed.
+// The generation expression itself is checked structurally (both formula
+// inputs are named), not restated verbatim, so the test stays robust to a
+// harmless whitespace/parenthesization change in a later migration.
+func TestSchema_amountMinorBaseIsDatabaseGenerated(t *testing.T) {
+	ownerDSN, _ := dsns(t)
+	owner := connect(t, ownerDSN)
+	resetSchema(t, owner)
+	migrateAll(t, owner)
+	ctx := context.Background()
+
+	var isGenerated, generationExpr string
+	if err := owner.QueryRow(ctx, `
+		SELECT is_generated, generation_expression
+		FROM information_schema.columns
+		WHERE table_schema = 'public' AND table_name = 'deal' AND column_name = 'amount_minor_base'`,
+	).Scan(&isGenerated, &generationExpr); err != nil {
+		t.Fatalf("querying deal.amount_minor_base from information_schema: %v", err)
+	}
+	if isGenerated != "ALWAYS" {
+		t.Errorf("deal.amount_minor_base has information_schema.columns.is_generated=%q, want ALWAYS", isGenerated)
+	}
+	for _, want := range []string{"amount_minor", "fx_rate_to_base"} {
+		if !strings.Contains(generationExpr, want) {
+			t.Errorf("deal.amount_minor_base's generation expression %q does not reference %q", generationExpr, want)
+		}
+	}
+
+	// pg_attribute is a second, independent catalog: attgenerated = 's' is
+	// Postgres's STORED-generated marker (the only kind it currently
+	// supports), cross-checking the information_schema view above.
+	var attgenerated string
+	if err := owner.QueryRow(ctx, `
+		SELECT attgenerated FROM pg_attribute
+		WHERE attrelid = 'deal'::regclass AND attname = 'amount_minor_base' AND NOT attisdropped`,
+	).Scan(&attgenerated); err != nil {
+		t.Fatalf("querying pg_attribute for deal.amount_minor_base: %v", err)
+	}
+	if attgenerated != "s" {
+		t.Errorf("deal.amount_minor_base has pg_attribute.attgenerated=%q, want \"s\" (STORED)", attgenerated)
+	}
+}
+
+// TestSchema_organizationOpenPipelineRollupIsSecurityInvoker closes the
+// RD-AC-N-1 half of the same boundary proof: the cross-record roll-up MUST
+// run as security_invoker (inheriting the caller's own RLS), never as the
+// view owner's elevated privilege — a view created without the option, or
+// with it later stripped by a careless CREATE OR REPLACE, would silently
+// leak every workspace's pipeline total to every other workspace.
+func TestSchema_organizationOpenPipelineRollupIsSecurityInvoker(t *testing.T) {
+	ownerDSN, _ := dsns(t)
+	owner := connect(t, ownerDSN)
+	resetSchema(t, owner)
+	migrateAll(t, owner)
+	ctx := context.Background()
+
+	var reloptions []string
+	if err := owner.QueryRow(ctx, `
+		SELECT COALESCE(reloptions, '{}') FROM pg_class
+		WHERE relname = 'organization_open_pipeline_rollup' AND relnamespace = 'public'::regnamespace`,
+	).Scan(&reloptions); err != nil {
+		t.Fatalf("querying pg_class.reloptions for organization_open_pipeline_rollup: %v", err)
+	}
+	found := false
+	for _, opt := range reloptions {
+		if opt == "security_invoker=true" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("organization_open_pipeline_rollup view reloptions %v do not include security_invoker=true", reloptions)
+	}
+}
+
 // rowScopedFKDecisions is the classification: one entry per FK column
 // naming a row-scoped business record. Values are prose for the reader;
 // the map's completeness is the invariant.

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -2835,7 +2835,7 @@ export interface components {
             formula_sql: string;
             dependencies: string[];
             computable: boolean;
-            /** @description Set (non-null) iff computable=false, e.g. "not_yet_built". */
+            /** @description Set (non-null) iff computable=false, e.g. "not_yet_built", "awaiting_fx". */
             reason?: string | null;
         };
         /** @description A company. Mirrors the `organization` table. */

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -2813,6 +2813,31 @@ export interface components {
             /** Format: date-time */
             archived_at?: string | null;
         };
+        /**
+         * @description S-E15.8c formula-field display row (RD-AC-6/RD-AC-7/RD-AC-N-1) — a read-only,
+         *     database-computed value, never a runtime-authored expression. `computable: false` +
+         *     `reason` is the honest floor for a field with no backend data model yet — the row is
+         *     still returned, never omitted or fabricated.
+         */
+        ComputedField: {
+            key: string;
+            label: string;
+            /** @enum {string} */
+            kind: "currency_minor" | "count" | "duration_months" | "percent";
+            /**
+             * Format: int64
+             * @description Present (and non-null) only when kind=currency_minor and computable=true.
+             */
+            value_minor?: number | null;
+            /** @description Present (and non-null) only when kind is count/duration_months/percent and computable=true. */
+            value?: number | null;
+            /** @description The literal GENERATED-column/view SQL definition; empty string when computable=false. */
+            formula_sql: string;
+            dependencies: string[];
+            computable: boolean;
+            /** @description Set (non-null) iff computable=false, e.g. "not_yet_built". */
+            reason?: string | null;
+        };
         /** @description A company. Mirrors the `organization` table. */
         Organization: {
             /** Format: uuid */
@@ -2834,6 +2859,12 @@ export interface components {
             parent_org_id?: string | null;
             /** Format: uuid */
             merged_into_id?: string | null;
+            /**
+             * @description S-E15.8c formula-field display rows (RD-AC-6/RD-AC-7/RD-AC-N-1). Populated on
+             *     `getOrganization` only; the key is absent entirely (not an empty array) when the
+             *     viewer's role lacks computed_field:read visibility (STATE-4).
+             */
+            readonly computed_fields?: components["schemas"]["ComputedField"][];
             domains?: components["schemas"]["OrganizationDomain"][];
             /**
              * @description An org IS a partner iff classification='partner' AND it has a `partner` row (A41/ADR-0032). Values match the data-model §4.1 CHECK.


### PR DESCRIPTION
## What

RD-T08: formula fields are database-computed, never a runtime interpreter.

- **Migration 0065:** `deal.amount_minor_base` GENERATED ALWAYS AS
  (round(amount_minor × fx_rate_to_base)) STORED — NULL propagation is the
  honest not-computable state — plus the `organization_open_pipeline_rollup`
  security_invoker view (RLS-inherited; cross-record aggregates can't ride a
  same-row generated column).
- **`computed_fields[]` on the org 360 read:** five display rows —
  `open_pipeline` computable from the view with a three-way honest floor
  (no open deals → genuine 0; NULL aggregate with open deals →
  `computable:false, reason:"awaiting_fx"` — never a fabricated zero;
  computed → the sum), `weighted_pipeline` floored with
  `served_by_hierarchy_rollup` (that read exists), three `not_yet_built`
  floors. STATE-4: the key is entirely absent without `computed_field:read`.
- **New RBAC object `computed_field`:** read-only for every role including
  admin/ops (there is no runtime authoring — RD-AC-7) + 0066 backfill.
- **Adoption:** the hierarchy-rollup closed-won SQL and the brief's
  frozen-rate branch now read the column — arc-1b and brief suites pass
  unchanged (the equivalence proof).
- **Fitness guards:** schema-proof (column is GENERATED; view keeps
  security_invoker) + negative-scope (the contract walk fails any future op
  that accepts a writable formula_sql).

## Tests

Schema-proof + negative-scope fitness tests; 7 unit + 5 integration
(value == direct view read, both honest floors, STATE-4 raw-map absence,
cross-workspace security_invoker isolation); full integration sweep zero
skips.

## Follow-up (noted in 0065's comment)

Base-currency open deals could compute live
(`COALESCE(amount_minor_base, amount_minor) WHERE currency = base_currency`)
— a view enhancement, not V1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Organization details can now include read-only computed fields, including open pipeline totals and supporting metadata.
  * Computed fields are shown only when the viewer has the appropriate permission.
  * Open pipeline values reflect base-currency amounts and clearly indicate when calculation is unavailable, such as while awaiting exchange-rate data.
  * Additional planned metrics display their availability status and explanation.
* **Bug Fixes**
  * Improved accuracy and consistency of deal and pipeline currency calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->