### PR TITLE
chore(renovate): activate scheduled auto-updates with CI-gated automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,19 +1,27 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", ":semanticCommitsDisabled"],
+  "timezone": "Asia/Ho_Chi_Minh",
+  "schedule": ["after 2am and before 6am"],
   "labels": ["dependencies"],
   "postUpdateOptions": ["gomodTidy"],
   "prConcurrentLimit": 5,
+  "platformAutomerge": true,
   "packageRules": [
     {
       "matchManagers": ["gomod"],
       "matchUpdateTypes": ["patch", "minor"],
-      "groupName": "go dependencies (non-major)"
+      "groupName": "go dependencies (non-major)",
+      "automerge": true
     },
     {
       "matchManagers": ["gomod"],
       "matchDepTypes": ["golang"],
       "enabled": false
     }
-  ]
+  ],
+  "vulnerabilityAlerts": {
+    "labels": ["security", "dependencies"],
+    "schedule": ["at any time"]
+  }
 }


### PR DESCRIPTION
## What

Turns the dormant `renovate.json` into a config worth running, ahead of installing the Mend-hosted Renovate app.

**Context:** the file was committed once (`ba713dc`, 2026-07-05) but the bot was never installed — zero Renovate PRs, no Dependency Dashboard. This PR enhances the config; a follow-up org-admin action installs the app.

## Changes

- **`schedule`** — routine PRs open/update only in a daily **2–6am Asia/Ho_Chi_Minh** window, so dependency churn lands predictably instead of mid-workday.
- **`automerge` (platform-native)** on the grouped non-major `gomod` updates — the full merge gate (`make check` + integration + contract-drift + CodeRabbit + Sonar) is the safety net, so passing patch/minor Go bumps merge themselves. Majors still stage for human review.
- **`vulnerabilityAlerts`** bypass the schedule (`"at any time"`) and carry a `security` label, so CVE fixes are never delayed by the window.
- **Go toolchain bumps stay disabled** (unchanged) — won't fight the Go 1.26 pin.
- **Frontend (npm)** updates remain **manual PRs** — the in-flight Vite/React workspace is owned by a parallel session, so no automerge there.

## Validation

`renovate-config-validator` (official, renovate@42): **Config validated successfully**.

## Follow-up (not in this PR — needs org admin)

Install the [Renovate GitHub App](https://github.com/apps/renovate) on `gradionhq/margince-poc-v1`. Public repo → free. Until then this config is inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)