### PR TITLE
build: resolve golangci-lint from the pinned install, not the engineer's PATH

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -75,14 +75,34 @@ test-integration-serial: ## Escape hatch: the old sequential lane, all packages 
 bench-perf: ## PERF-3/PERF-7 benchmark harness on the mid-market §6.7 tier (needs db-up; seeds 250k contacts)
 	MARGINCE_BENCH_TIER=mid_market $(GO) test -tags integration -run TestPerfBudgetsHoldOnSeededVolumeTier -v -timeout 30m ./internal/compose/integration
 
+# golangci-lint is the one gate tool this Makefile installs rather than
+# runs via pinned `go run` (arch-lint/vuln/oasdiff do): `go run` would
+# rebuild a ~60MB binary on every gate run. Resolving it is therefore
+# this Makefile's job, not the engineer's shell config — `make tools`
+# drops it in GOPATH/bin, which is on nobody's PATH by default, so a bare
+# `golangci-lint` made `make check` fail after a clean `make install`
+# with a confusing "No such file or directory".
+#
+# The pinned install wins over PATH deliberately: a golangci-lint from
+# Homebrew (or any other version parked earlier in PATH) would otherwise
+# silently lint at a version CI does not run, which is exactly what the
+# GOLANGCI_LINT_VERSION pin exists to prevent. PATH is the fallback, so a
+# deployment that resolves the pinned binary some other way still works.
+GOLANGCI_LINT_BIN := $(shell $(GO) env GOPATH)/bin/golangci-lint
+GOLANGCI_LINT ?= $(shell test -x $(GOLANGCI_LINT_BIN) && echo $(GOLANGCI_LINT_BIN) || command -v golangci-lint 2>/dev/null)
+
 # Two passes, two scopes: .golangci.yml is the repo-wide
 # baseline (the depguard DAG lives there and must never be diff-scoped);
 # .golangci.strict.yml is the expanded strict set, gated to new
 # code via new-from-merge-base so the pre-existing backlog is not a burn-down.
 lint: ## golangci-lint: repo-wide baseline + new-code strict set
-	golangci-lint run ./...
+	@test -n "$(GOLANGCI_LINT)" || { \
+		echo "lint: golangci-lint not found — run 'make tools' (installs $(GOLANGCI_LINT_VERSION) to $$($(GO) env GOPATH)/bin)"; \
+		exit 1; \
+	}
+	$(GOLANGCI_LINT) run ./...
 	@if git rev-parse --verify -q origin/main >/dev/null; then \
-		golangci-lint run --config .golangci.strict.yml ./...; \
+		$(GOLANGCI_LINT) run --config .golangci.strict.yml ./...; \
 	else \
 		echo "SKIP strict lint: origin/main not found — fetch it to arm the new-code gate"; \
 	fi
@@ -113,7 +133,9 @@ vuln: ## Scan dependencies for known vulnerabilities (govulncheck)
 	$(GO) run golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION) ./...
 
 # Fresh-machine bootstrap. golangci-lint is the one gate binary `make check`
-# expects on PATH; this version must stay identical to the pin in
+# runs from an install rather than a pinned `go run`; the lint target
+# resolves it out of GOPATH/bin itself (see GOLANGCI_LINT above), so no
+# PATH entry is required. This version must stay identical to the pin in
 # .tool-versions and the golangci-lint-action version in ci.yml — bump all
 # three together. arch-lint and vuln already run their tools via pinned
 # `go run`, so those installs just pre-warm the module cache (and give the
@@ -129,7 +151,7 @@ tools: ## Install every gate binary at its pinned version (fresh-machine bootstr
 	$(GO) install github.com/fe3dback/go-arch-lint@$(GO_ARCH_LINT_VERSION)
 	$(GO) install golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION)
 	$(GO) install github.com/oasdiff/oasdiff@$(OASDIFF_VERSION)
-	@echo "gate binaries ready in $$($(GO) env GOPATH)/bin — ensure it is on PATH"
+	@echo "gate binaries ready in $$($(GO) env GOPATH)/bin — 'make check' finds them there; add it to PATH only for direct use"
 
 # `git rev-parse --git-path hooks` honors core.hooksPath, so this works
 # both on a plain clone (.git/hooks) and after the root `make hooks`


### PR DESCRIPTION
## The bug

A clean `make install` leaves `make check` **failing**:

```
golangci-lint run ./...
make[1]: golangci-lint: No such file or directory
make[1]: *** [lint] Error 1
```

`make install` → `tools` installs golangci-lint into `$(go env GOPATH)/bin`, which is on no PATH by default. The `lint` target invoked a bare `golangci-lint`. So the one command the contributor docs promise is the merge gate dies on a missing-tool error that reads like a broken toolchain — on a machine that ran the documented one-shot setup.

Found while trying to gate a docs PR (#68) on this repo's own shipping loop.

## Why it's the Makefile's job

golangci-lint is the **only** gate binary run from an install rather than a pinned `go run` — reasonably, since `go run` would rebuild a ~60MB binary every gate run:

| tool | invocation | needs PATH? |
|---|---|---|
| go-arch-lint | `go run …@v1.12.0` | no |
| govulncheck | `go run …@v1.1.4` | no |
| oasdiff | `go run …@v1.22.0` | no |
| **golangci-lint** | **bare `golangci-lint`** | **yes** |

Being the exception is what makes resolving it this Makefile's job rather than each engineer's shell config. Today there are two separate workarounds for that one unresolved path: `tools` echoes "ensure it is on PATH", and `ci.yml` appends `$HOME/go/bin` to `$GITHUB_PATH`. CI knew it had to patch PATH; local developers get an echo that scrolls past a long install.

## The quieter hole this also closes

Resolving through PATH means a golangci-lint parked earlier in PATH (Homebrew, another project's pin) **silently lints at a version CI never runs**. The `tools` target's own comment calls the pin load-bearing — "a cached binary at a different version must be overwritten, or the pin doesn't bind" — but the pin only binds if the pinned binary is the one actually invoked. Preferring the install makes that true.

## The change

`lint` resolves `GOPATH/bin/golangci-lint` first, falls back to PATH, and fails with `run 'make tools'` if neither exists. Comments and the `tools` echo updated to match. No behaviour change in CI (which already had the binary on PATH); it now just resolves the same file by path.

## Verification

With `GOPATH/bin` **off** PATH — the exact condition that failed:

- `make check` → **EXIT=0**
- `make lint GOLANGCI_LINT=` → `lint: golangci-lint not found — run 'make tools' (installs v2.12.2 to /Users/…/go/bin)`, exit 1
- stray `golangci-lint` earlier in PATH → pinned install still wins (`-n` shows the absolute path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)