### PR TITLE
chore(dev): always run cmd/worker in make dev; isolate the integration lane on a _test namespace

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -150,16 +150,29 @@ MARGINCE_DSN=postgres://margince_app:margince_app_dev@localhost:55432/margince
 # MARGINCE_WORKSPACE=demo-workspace
 
 # ── Integration-test lane (make test-integration) ────────────────────────────
-# backend/Makefile exports all three for the `make db-up` containers; override
-# only to point the lane at different infrastructure. The lane fails loudly
-# when the database is unreachable — it never skips.
+# backend/Makefile exports these for the `make db-up` containers; override only
+# to point the lane at different infrastructure. The lane runs on its OWN
+# `_test`-suffixed namespace — a separate `margince_test` Postgres database and
+# Redis logical db (never the dev `margince` DB or Redis db 0) — so it can run
+# concurrently with `make dev` without touching the same mutable state. The lane
+# fails loudly when the database is unreachable — it never skips.
 
-# MARGINCE_TEST_DSN=postgres://margince_owner:dev@localhost:55432/margince
-# MARGINCE_TEST_APP_DSN=postgres://margince_app:margince_app_dev@localhost:55432/margince
+# MARGINCE_TEST_DSN=postgres://margince_owner:dev@localhost:55432/margince_test
+# MARGINCE_TEST_APP_DSN=postgres://margince_app:margince_app_dev@localhost:55432/margince_test
 # MARGINCE_TEST_REDIS=localhost:56379
+# [optional] Redis logical db for the test lane. Default 15. db 0 is reserved
+# for a running `make dev` (its relay/subscriber use the client default), so a
+# valid value is 1..15 — the parallel runner fans packages across that range so
+# concurrent packages never share a stream. An out-of-range value fails loudly.
+# MARGINCE_TEST_REDIS_DB=15
 # The blobstore lane points at the compose MinIO; the lane fails loudly if it
 # is unreachable — it never skips.
 # MARGINCE_TEST_BLOBSTORE_ENDPOINT=localhost:59000
 # MARGINCE_TEST_BLOBSTORE_ACCESS_KEY=minioadmin
 # MARGINCE_TEST_BLOBSTORE_SECRET_KEY=minioadmin
 # MARGINCE_TEST_BLOBSTORE_BUCKET=margince-test
+
+# [optional; make bench-perf only] The PERF-3/PERF-7 benchmark tier the
+# perfbench integration suite seeds — smb (default) or mid_market. An
+# unrecognized value fails the bench loudly.
+# MARGINCE_BENCH_TIER=smb

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,8 @@ make check-fe           # frontend half (biome + vitest + tsc + build)
 make test-integration   # real-Postgres lane: RLS gates + HTTP end-to-end (needs db-up).
                         # Parallel — each package on its own throwaway clone db; ends
                         # with `OK: integration passed with 0 skips`, never skips silently
-make dev                # full local stack: db + api (:8080) + Vite SPA (:5173)
+make dev                # full local stack: db + api (:8080) + worker + Vite SPA (:5173)
+                        # (worker = cmd/worker, always on: outbox relay + Surface-B runner)
                         # (DEV_SLUG=x → isolated margince_dev_<slug> on slug-derived ports)
 make dev-stop           # stop the stack (add DEV_SLUG=x [DROP=1] for an isolated env)
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,8 @@ make check-fe           # frontend half (biome + vitest + tsc + build)
 make test-integration   # real-Postgres lane: RLS gates + HTTP end-to-end (needs db-up).
                         # Parallel — each package on its own throwaway clone db; ends
                         # with `OK: integration passed with 0 skips`, never skips silently
-make dev                # full local stack: db + api (:8080) + Vite SPA (:5173)
+make dev                # full local stack: db + api (:8080) + worker + Vite SPA (:5173)
+                        # (worker = cmd/worker, always on: outbox relay + Surface-B runner)
                         # (DEV_SLUG=x → isolated margince_dev_<slug> on slug-derived ports)
 make dev-stop           # stop the stack (add DEV_SLUG=x [DROP=1] for an isolated env)
 ```

--- a/Makefile
+++ b/Makefile
@@ -72,8 +72,9 @@ infra-up: db-up
 infra-down:
 	$(MAKE) -C backend infra-down
 
-## dev — the full local stack in a real browser: Postgres + Redis, the api, and
-## the Vite dev server, so the SPA runs against a live api on http://localhost:8080
+## dev — the full local stack in a real browser: Postgres + Redis, the api, the
+## background worker (cmd/worker — outbox relay + Surface-B runner, always on),
+## and the Vite dev server, so the SPA runs against a live api on http://localhost:8080
 ## (FE on :5173). Bare `make dev` uses the shared `margince` database; `make dev
 ## DEV_SLUG=<slug>` gives an isolated margince_dev_<slug> on slug-derived ports,
 ## so two worktrees run concurrently without colliding. Reads an optional

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -7,9 +7,19 @@ DB_NAME   ?= margince
 OWNER_DSN ?= postgres://margince_owner:dev@localhost:$(PG_PORT)/$(DB_NAME)
 APP_DSN   ?= postgres://margince_app:margince_app_dev@localhost:$(PG_PORT)/$(DB_NAME)
 
-export MARGINCE_TEST_DSN     ?= $(OWNER_DSN)
-export MARGINCE_TEST_APP_DSN ?= $(APP_DSN)
-export MARGINCE_TEST_REDIS   ?= localhost:$(REDIS_PORT)
+# The integration lane runs on its OWN `_test`-suffixed namespace on the shared
+# containers, so `make dev` (DB `margince`, Redis logical db 0) and
+# `make test-integration` never touch the same mutable state and can run
+# concurrently. Postgres: a separate `margince_test` database (the parallel lane
+# clones per-package throwaways from a template of the same name; the serial
+# escape hatch runs directly on it). Redis: db 0 is reserved for `make dev`, so
+# the test lanes default to db 15 and the parallel runner fans packages across
+# 1..15 (see scripts/test-integration-parallel.sh) — no stream collisions.
+TEST_DB_NAME ?= margince_test
+export MARGINCE_TEST_DSN     ?= postgres://margince_owner:dev@localhost:$(PG_PORT)/$(TEST_DB_NAME)
+export MARGINCE_TEST_APP_DSN ?= postgres://margince_app:margince_app_dev@localhost:$(PG_PORT)/$(TEST_DB_NAME)
+export MARGINCE_TEST_REDIS    ?= localhost:$(REDIS_PORT)
+export MARGINCE_TEST_REDIS_DB ?= 15
 # Blobstore (MinIO) — the integration lane fails loudly without it, never
 # skips, so the endpoint/creds/bucket are part of the compose + CI contract.
 # The bucket is created by the store at first connect.
@@ -59,7 +69,8 @@ test-db-up: ## (Re)build the migrated margince_test template the parallel lane c
 test-it: ## Run ONE integration package (optionally RUN=Regex) on a throwaway clone: make test-it DIR=backend/internal/modules/people [RUN=TestName]
 	@bash ../scripts/test-integration-one.sh "$(DIR)" "$(RUN)"
 
-test-integration-serial: ## Escape hatch: the old sequential lane, all packages on the shared dev DB (debugging a parallel-isolation issue).
+test-integration-serial: ## Escape hatch: the old sequential lane, all packages on the shared margince_test DB (debugging a parallel-isolation issue).
+	@bash -c 'cd .. && source scripts/lib-testdb.sh && parse_test_dsn && ensure_template'
 	@log=$$(mktemp); st=$$(mktemp); \
 	{ $(GO) test -tags integration -p 1 -v ./... 2>&1; echo $$? >"$$st"; } | tee "$$log"; \
 	code=$$(cat "$$st"); rm -f "$$st"; \

--- a/backend/internal/platform/events/bus_integration_test.go
+++ b/backend/internal/platform/events/bus_integration_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strconv"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -33,9 +34,26 @@ import (
 	"github.com/gradionhq/margince/backend/migrations"
 )
 
-// testDB is Redis database 15: isolated from the dev server's default DB
-// so FlushDB between tests cannot eat a developer's local streams.
-const testDB = 15
+// testRedisDB is the Redis logical database this lane isolates its streams in.
+// setup FlushDB's the whole db between tests, so it must never be db 0 — that
+// one is reserved for a running `make dev`, whose relay/subscriber use the
+// client default. The parallel runner hands each package a distinct db in
+// 1..15 via MARGINCE_TEST_REDIS_DB so concurrent packages never share a stream;
+// absent the env (a bare `go test`), db 15 is the isolated default. An
+// out-of-range or non-numeric value fails loudly rather than silently eating
+// the wrong db.
+func testRedisDB(t *testing.T) int {
+	t.Helper()
+	raw := os.Getenv("MARGINCE_TEST_REDIS_DB")
+	if raw == "" {
+		return 15
+	}
+	db, err := strconv.Atoi(raw)
+	if err != nil || db < 1 || db > 15 {
+		t.Fatalf("MARGINCE_TEST_REDIS_DB=%q is not a Redis db index in 1..15", raw)
+	}
+	return db
+}
 
 type busEnv struct {
 	pool *pgxpool.Pool
@@ -91,7 +109,7 @@ func setup(t *testing.T) *busEnv {
 	}
 	t.Cleanup(pool.Close)
 
-	rdb := redis.NewClient(&redis.Options{Addr: redisAddr, DB: testDB})
+	rdb := redis.NewClient(&redis.Options{Addr: redisAddr, DB: testRedisDB(t)})
 	if err := rdb.Ping(ctx).Err(); err != nil {
 		t.Fatalf("redis at %s unreachable — run `make db-up`: %v", redisAddr, err)
 	}

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -149,7 +149,8 @@ migrate <up|down> --dsn <owner-dsn> [--steps n]
 | Var | Used by | Meaning |
 |---|---|---|
 | `MARGINCE_ENV` | api (identity handlers) | `dev` enables dev-only trust switches (the `X-Workspace-Slug` header). The Makefile exports `dev`; production must not set it. |
-| `MARGINCE_TEST_DSN`, `MARGINCE_TEST_APP_DSN`, `MARGINCE_TEST_REDIS` | integration tests | owner DSN / app-role DSN / Redis address for the real-Postgres lane; exported by the Makefile for the dev containers. |
+| `MARGINCE_TEST_DSN`, `MARGINCE_TEST_APP_DSN`, `MARGINCE_TEST_REDIS` | integration tests | owner DSN / app-role DSN / Redis address for the real-Postgres lane; exported by the Makefile. The lane runs on its own `_test` namespace (the `margince_test` DB, never the dev `margince` DB), so it can run alongside `make dev`. |
+| `MARGINCE_TEST_REDIS_DB` | integration tests | Redis logical db for the lane (default 15). db 0 is reserved for a running `make dev`; a valid value is 1..15, and the parallel runner assigns one per package so concurrent packages never share a stream. Out-of-range fails loudly. |
 
 Model credentials (BYOK cloud tiers) are configured in
 `ai-routing.yaml`, not through binary flags. The annotated reference is

--- a/docs/reference/make-targets.md
+++ b/docs/reference/make-targets.md
@@ -11,7 +11,7 @@ common backend targets and adds the frontend lane. In `backend/`, `make`
 |---|---|
 | `help` | List targets (the default goal) |
 | `install` | One-shot fresh-worktree setup (frontend deps + Go gate binaries + git hooks). The factory's `worktree-init` runs this by name |
-| `dev` | Full local stack: db-up + migrate + `cmd/api` + API-seed + the Vite SPA, on `http://localhost:5173` (api `:8080`). Returns when ready; the servers run in the background. `DEV_SLUG=<slug>` gives an isolated `margince_dev_<slug>` on slug-derived ports (two worktrees at once). Reads an optional Anthropic BYOK key from `.env.local` for the live cold-start read-back |
+| `dev` | Full local stack: db-up + migrate + `cmd/api` + `cmd/worker` (always on: the outbox relay + Surface-B runner) + API-seed + the Vite SPA, on `http://localhost:5173` (api `:8080`). Returns when ready; the servers run in the background. `DEV_SLUG=<slug>` gives an isolated `margince_dev_<slug>` on slug-derived ports (two worktrees at once). Reads an optional Anthropic BYOK key from `.env.local` for the live cold-start read-back |
 | `dev-stop` | `make dev-stop [DEV_SLUG=<slug>] [DROP=1]` — stop the stack started by `make dev` and free its ports; `DROP=1` also drops an isolated `margince_dev_<slug>` database |
 | `mcp-inspector` | `make mcp-inspector TOKEN=mgp_… [DEV_SLUG=<slug>] [WORKSPACE=<slug>]` — build `cmd/mcp` and open the MCP Inspector over stdio against the running `make dev` stack. Token comes from `TOKEN=` or `MARGINCE_PASSPORT_TOKEN` in `.env.local`; the DSN is read from the running stack (so `DEV_SLUG` just works). Token + DSN pass through the environment only, never argv |
 | `db-up` / `infra-up` | Start the dev Postgres 16 (pgvector, port 55432) and Redis 7 (port 56379) containers, create the app role (`infra-up` is an alias) |
@@ -41,10 +41,10 @@ UAT guides call by name (`docs/target-minimum-setup.md §3`). `check-q`,
 | `build` | `go build ./...` |
 | `vet` | `go vet ./...` |
 | `test` | Unit tests; the root fitness tests (license header, write shape, architecture, enum sync, `audit_log` enum coherence, contract `$ref` resolution) run uncached |
-| `test-integration` | Real-Postgres lane (`-tags integration`): RLS gates, governed-agent loop, HTTP end-to-end. **Parallel** — each package runs on its own throwaway clone db (`CREATE DATABASE … TEMPLATE margince_test`) + private MinIO bucket, so packages share nothing; within a package still `-p 1`. Fails loudly without a database — never skips. Tune concurrency with `INTEGRATION_JOBS=N` |
+| `test-integration` | Real-Postgres lane (`-tags integration`): RLS gates, governed-agent loop, HTTP end-to-end. Runs on its own `margince_test` namespace, never the dev `margince` DB, so it can run concurrently with `make dev`. **Parallel** — each package runs on its own throwaway clone db (`CREATE DATABASE … TEMPLATE margince_test`) + private MinIO bucket + its own Redis logical db (1..15 by slot; db 0 stays reserved for `make dev`), so packages share nothing; within a package still `-p 1`. Fails loudly without a database — never skips. Tune concurrency with `INTEGRATION_JOBS=N` |
 | `test-db-up` | (Re)build the migrated `margince_test` template the parallel lane clones from |
-| `test-it` | Run ONE integration package on a throwaway clone: `make test-it DIR=backend/internal/modules/people [RUN=TestName]` |
-| `test-integration-serial` | Escape hatch: the old sequential lane on the shared dev DB (for debugging a parallel-isolation issue) |
+| `test-it` | Run ONE integration package on a throwaway clone (+ own MinIO bucket + Redis db 15): `make test-it DIR=backend/internal/modules/people [RUN=TestName]` |
+| `test-integration-serial` | Escape hatch: the old sequential lane on the shared `margince_test` DB (for debugging a parallel-isolation issue) |
 | `lint` | `golangci-lint run` (depguard, gosec, misspell, revive, gofmt) |
 | `arch-lint` | go-arch-lint over `.go-arch-lint.yml` — a hard gate on the import DAG |
 | `gen` | Regenerate everything derived from `api/crm.yaml` (contract types, 501 stubs, agent-policy table) |

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # One-command local dev stack on the ONE shared infra: Postgres + Redis, the api
-# (cmd/api), and the Vite dev server — so the SPA runs in a real browser against
-# a live api. Bare `make dev` uses the shared `margince` database on :8080/:5173;
+# (cmd/api), the background worker (cmd/worker — outbox relay + Surface-B runner),
+# and the Vite dev server — so the SPA runs in a real browser against a live api.
+# Bare `make dev` uses the shared `margince` database on :8080/:5173;
 # `make dev DEV_SLUG=<slug>` gives an isolated `margince_dev_<slug>` database on
 # slug-derived ports, so two worktrees can run concurrently without colliding on
 # the database or the host ports.
@@ -208,19 +209,34 @@ up)
     exit 1
   fi
 
-  # The Gmail sync poller (cmd/worker) — the background loop that turns a
-  # connected mailbox into activities. It shares the app DSN + Redis and the
-  # exported dev vault key; a short poll makes the demo responsive.
-  worker_pid=""
+  # The background process role (cmd/worker) always runs alongside the api in
+  # dev: the standalone outbox relay (coexists with the api's inline relay —
+  # rows are claimed FOR UPDATE SKIP LOCKED, so two relays never double-ship),
+  # the Surface-B runner scheduler, and the retention / close-date / reconcile
+  # sweeps. It gets the SAME config surface as the api — the same $ai_flag
+  # (real Anthropic model when .env.local set ANTHROPIC_API_KEY, else the
+  # offline fake, so its runner matches the api), the same blobstore endpoint,
+  # and the .env.local keys already exported into this shell (vault + Gmail
+  # secrets travel via the environment, never CLI flags). Gmail adds a short
+  # sync poll only when the connector is configured.
+  ( cd backend && go build -o ../bin/worker ./cmd/worker ) >>"$log" 2>&1
+  worker_gmail_flags=()
   if [[ "$gmail_enabled" == "1" ]]; then
-    ( cd backend && go build -o ../bin/worker ./cmd/worker ) >>"$log" 2>&1
-    # Gmail client id/secret come from the exported env (not CLI flags); the
-    # worker's flags default to them.
-    MARGINCE_ENV=dev \
-      ./bin/worker --dsn "$dev_app_url" --redis "localhost:${REDIS_PORT}" \
-      --gmail-sync-interval 30s >>"$log" 2>&1 &
-    worker_pid=$!
-    echo "  gmail    sync worker running (poll every 30s)"
+    # A short poll makes the demo mailbox responsive; the default is 2m.
+    worker_gmail_flags=(--gmail-sync-interval 30s)
+  fi
+  MARGINCE_ENV=dev \
+    MARGINCE_BLOBSTORE_ENDPOINT="localhost:${MINIO_PORT}" \
+    MARGINCE_BLOBSTORE_ACCESS_KEY=minioadmin \
+    MARGINCE_BLOBSTORE_SECRET_KEY=minioadmin \
+    MARGINCE_BLOBSTORE_BUCKET=margince-dev \
+    ./bin/worker --dsn "$dev_app_url" --redis "localhost:${REDIS_PORT}" \
+    "${ai_flag[@]}" "${worker_gmail_flags[@]+"${worker_gmail_flags[@]}"}" >>"$log" 2>&1 &
+  worker_pid=$!
+  if [[ "$gmail_enabled" == "1" ]]; then
+    echo "  worker   background relay + Surface-B runner + Gmail sync (poll every 30s)"
+  else
+    echo "  worker   background relay + Surface-B runner running"
   fi
 
   # The FE's /v1 proxy follows the api via BACKEND_PORT (see vite.config.ts).

--- a/scripts/test-integration-one.sh
+++ b/scripts/test-integration-one.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # Run ONE integration package (optionally a single test) on a throwaway clone db +
-# private MinIO bucket — the fast inner-loop shortcut for iterating on one test
-# without booting the whole parallel lane.
+# private MinIO bucket + its own Redis logical db (MARGINCE_TEST_REDIS_DB, 15 by
+# default — never db 0, which a running `make dev` owns) — the fast inner-loop
+# shortcut for iterating on one test without booting the whole parallel lane.
 #
 #   scripts/test-integration-one.sh DIR [RUN]
 #     DIR  repo-root package dir, e.g. backend/internal/compose/integration
@@ -45,4 +46,5 @@ echo "test-integration-one: backend $rel ${RUN:+(-run $RUN) }(db=$db)"
        MARGINCE_TEST_DSN="$(owner_clone_dsn "$db")" \
        MARGINCE_TEST_APP_DSN="$(app_clone_dsn "$db")" \
        MARGINCE_TEST_BLOBSTORE_BUCKET="$(bucket_for one)" \
+       MARGINCE_TEST_REDIS_DB="${MARGINCE_TEST_REDIS_DB:-15}" \
     go test -p 1 -tags=integration -v -count=1 -timeout=300s "${run_flag[@]+"${run_flag[@]}"}" "$rel" )

--- a/scripts/test-integration-parallel.sh
+++ b/scripts/test-integration-parallel.sh
@@ -13,8 +13,12 @@
 #              TRUNCATEs between tests — see internal/platform/testdb).
 #   MinIO    — a private bucket (MARGINCE_TEST_BLOBSTORE_BUCKET=<base>-p<idx>),
 #              auto-created by the blobstore store.
-#   Redis    — the one shared instance, passed through: only the events package
-#              uses Redis (its own logical db 15), so nothing contends.
+#   Redis    — the one shared instance, but each package gets its own logical
+#              db (MARGINCE_TEST_REDIS_DB, mapped 1..15 by slot), so no two
+#              packages ever share a stream. Db 0 is reserved for `make dev`, so
+#              a running dev stack and this lane never collide either. Only the
+#              events package touches Redis today; the per-slot db keeps it
+#              collision-free if that ever changes.
 # Within a package nothing changes — still -p 1, the same sequential model that is
 # green today — so no test file needs editing.
 #
@@ -88,6 +92,8 @@ run_one() {
   local db="margince_it_p${idx}_$$"
   local log="$outdir/$idx.log"
   local bucket; bucket="$(bucket_for "$idx")"
+  # Redis logical db per slot, in 1..15 — db 0 stays reserved for `make dev`.
+  local redis_db=$(( 1 + (idx - 1) % 15 ))
   # Coverage args (empty unless COVERDIR is set). -coverpkg=./... attributes
   # cross-package exercise; binary output goes to a per-package dir, merged later.
   local cover_pre=() cover_post=()
@@ -97,7 +103,7 @@ run_one() {
     cover_post=(-args -test.gocoverdir="$COVERDIR/$idx")
   fi
   {
-    echo "=== integration $d $rel (db=$db bucket=$bucket) ==="
+    echo "=== integration $d $rel (db=$db bucket=$bucket redis-db=$redis_db) ==="
     make_clone "$db"
     local st=0
     ( cd "$d" \
@@ -105,6 +111,7 @@ run_one() {
            MARGINCE_TEST_DSN="$(owner_clone_dsn "$db")" \
            MARGINCE_TEST_APP_DSN="$(app_clone_dsn "$db")" \
            MARGINCE_TEST_BLOBSTORE_BUCKET="$bucket" \
+           MARGINCE_TEST_REDIS_DB="$redis_db" \
         go test -p 1 -tags=integration -v -count=1 -timeout="$IT_TIMEOUT" \
           "${cover_pre[@]+"${cover_pre[@]}"}" "$rel" "${cover_post[@]+"${cover_post[@]}"}" ) || st=$?
     drop_clone "$db"


### PR DESCRIPTION
## What & why

Two dev-workflow improvements:

### 1. `make dev` always runs `cmd/worker`
Previously the worker only started when Gmail was configured. Now it always runs alongside the api, so the **outbox relay**, the **Surface-B runner scheduler**, and the **retention / close-date / reconcile** sweeps run in local dev.

- The worker gets the **same config surface as the api** — the same `$ai_flag` (real Anthropic model when `.env.local` sets `ANTHROPIC_API_KEY`, else the offline fake), the blobstore endpoint, and the `.env.local` keys already exported into the shell (vault + Gmail secrets travel via the environment, never argv).
- Its relay **coexists** with the api's inline relay — outbox rows are claimed `FOR UPDATE SKIP LOCKED`, so two relays never double-ship.

### 2. Integration lane isolated on a `_test` namespace
`make dev` and `make test-integration` no longer share mutable state and can run concurrently:

- **Postgres** — the lane defaults to a separate `margince_test` database (dev keeps `margince`). The serial escape hatch ensures the template exists first.
- **Redis** — db 0 is reserved for `make dev`; the lane defaults to db 15, and the parallel runner assigns each package a **distinct logical db in 1..15**, so parallel packages never share a stream. The events integration test reads `MARGINCE_TEST_REDIS_DB` and **fails loudly** on db 0 / out-of-range (never silently flushes the wrong db).
- **MinIO** — already isolated (`margince-dev` vs `margince-test-p<idx>`); unchanged.

## Verification
- `make check-backend` — green
- `make test-integration` — `OK: integration passed with 0 skips (15 packages, parallel)`, real make exit 0
- Live `make dev DEV_SLUG=…` — worker process confirmed running (relay + Surface-B scheduler + retention + River jobs)
- Redis-db guard — verified it rejects db 0 / out-of-range and honors a valid override

## Docs
`CLAUDE.md`, `AGENTS.md`, `docs/reference/make-targets.md`, `docs/reference/configuration.md`, and `.env.template` updated to match (incl. the new `MARGINCE_TEST_REDIS_DB`, and a previously-undocumented `MARGINCE_BENCH_TIER`).

## Note
Known Redis limit (out of scope): with >16 concurrent Redis-using contexts on one host the 16 logical dbs are exhausted — today only the `events` package touches Redis, so no collision is reachable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integration tests now use a dedicated test database and configurable Redis logical databases to prevent conflicts with local development.
  * Parallel integration runs receive isolated Redis databases and private storage buckets.
  * The local development stack now always includes the background worker.

* **Documentation**
  * Expanded setup guidance for development and integration testing, including environment variables, isolation behavior, and benchmark configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->