### PR TITLE
feat(platform): system_log ledger + entity-less pipeline events

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -7389,7 +7389,7 @@ components:
     AuditLogEntry:
       type: object
       description: An append-only audit row. Mirrors the `audit_log` table.
-      required: [id, workspace_id, actor_type, actor_id, action, entity_type, occurred_at]
+      required: [id, workspace_id, actor_type, actor_id, action, entity_type, entity_id, occurred_at]
       properties:
         id: { type: string, format: uuid }
         workspace_id: { type: string, format: uuid }
@@ -7400,9 +7400,11 @@ components:
         action:
           type: string
           # Every mutation is attributable (P12). connector captures audit as actor_type=connector.
-          enum: [create, update, archive, merge, promote, demote, disqualify, restore, export, erase, anonymize, login, assign, advance_stage, send_email, consent_grant, consent_withdraw, approve, reject, record_share, record_unshare, activity_relink, import, import_undo]
+          # audit_log is record-mutations-only: login and bulk export moved to system_log,
+          # so `login` is not here. `export` stays — the DSR person export is entity-bound.
+          enum: [create, update, archive, merge, promote, demote, disqualify, restore, export, erase, anonymize, assign, advance_stage, send_email, consent_grant, consent_withdraw, approve, reject, record_share, record_unshare, activity_relink, import, import_undo]
         entity_type: { type: string }
-        entity_id: { type: [string, 'null'], format: uuid }
+        entity_id: { type: string, format: uuid, description: Every audit_log row names the record it mutated (NOT NULL since 0075). }
         before: { type: [object, 'null'], additionalProperties: true }
         after: { type: [object, 'null'], additionalProperties: true }
         authorization_rule: { type: [string, 'null'], description: Which RBAC/scope rule allowed it. }

--- a/backend/internal/compose/filteredexport.go
+++ b/backend/internal/compose/filteredexport.go
@@ -130,11 +130,14 @@ func (w *FilteredExportWriter) WriteFiltered(ctx context.Context, resource strin
 			RowCount:    len(rows),
 		}
 
-		// The export operation itself is audited (P7/P12): who exported
-		// which slice, when. It targets no single record (entity_id NULL),
-		// so the filter and the row count stand in for "what slice".
-		_, err = storekit.Audit(ctx, tx, "export", engine.Table, ids.Nil, nil, map[string]any{
+		// The export operation itself is logged (P7/P12): who exported which
+		// slice, when. A bulk export targets no single record, so it belongs
+		// in system_log (the non-entity operational ledger), not the audit_log
+		// record-mutation spine. The exported table, filter, and row count
+		// stand in for "what slice".
+		_, err = storekit.LogSystem(ctx, tx, "export", map[string]any{
 			"kind":      "filtered",
+			"table":     engine.Table,
 			"format":    string(format),
 			"row_count": len(rows),
 			"filter":    pred,

--- a/backend/internal/compose/integration/export_integration_test.go
+++ b/backend/internal/compose/integration/export_integration_test.go
@@ -115,7 +115,7 @@ func (e *searchEnv) seedExportFixture(t *testing.T) exportFixture {
 	e.seed(t, `INSERT INTO attachment (id, workspace_id, entity_type, entity_id, filename, storage_key, source, captured_by)
 		VALUES ($1, $2, 'person', $3, 'rep3.pdf', 'blob/rep3', 'manual', 'human:x')`, f.rep3Person)
 
-	// Audit rows targeting each rep's person, and a login row (no entity).
+	// Audit rows targeting each rep's person (audit_log is record-mutations-only).
 	e.seed(t, `INSERT INTO audit_log (id, workspace_id, actor_type, actor_id, action, entity_type, entity_id)
 		VALUES ($1, $2, 'human', $3, 'create', 'person', $4)`, "human:"+e.Rep1.String(), f.rep1Person)
 	e.seed(t, `INSERT INTO audit_log (id, workspace_id, actor_type, actor_id, action, entity_type, entity_id)

--- a/backend/internal/compose/integration/filteredexport_integration_test.go
+++ b/backend/internal/compose/integration/filteredexport_integration_test.go
@@ -136,17 +136,18 @@ func TestFilteredExportOpenFormatsAndAudit(t *testing.T) {
 		}
 	}
 
-	// The export operation itself is audited: one 'export' row on 'deal'
-	// recording the format and row count of the slice.
-	action, entityType, after := lastAudit(t, e, "export")
-	if action != "export" || entityType != "deal" {
-		t.Fatalf("audit row = (%s, %s), want (export, deal)", action, entityType)
+	// The export operation itself is logged: one 'export' row in system_log
+	// (a bulk export mutates no record — it is a non-entity operational
+	// event) recording the exported table, format, and row count of the slice.
+	action, detail := lastSystemLog(t, e, "export")
+	if action != "export" || detail["table"] != "deal" {
+		t.Fatalf("system_log row = (%s, table=%v), want (export, deal)", action, detail["table"])
 	}
-	if after["format"] != "csv" && after["format"] != "json" {
-		t.Fatalf("audit row omits the export format: %v", after)
+	if detail["format"] != "csv" && detail["format"] != "json" {
+		t.Fatalf("system_log row omits the export format: %v", detail)
 	}
-	if after["row_count"] == nil {
-		t.Fatalf("audit row omits the exported slice size: %v", after)
+	if detail["row_count"] == nil {
+		t.Fatalf("system_log row omits the exported slice size: %v", detail)
 	}
 }
 
@@ -193,10 +194,10 @@ func TestFilteredExportRejectsOutOfVocabularyPredicate(t *testing.T) {
 	}
 }
 
-// lastAudit reads the most recent audit_log row for an action inside the
-// workspace-bound GUC (FORCE RLS applies even to the table owner), so the
+// lastSystemLog reads the most recent system_log row for an action inside
+// the workspace-bound GUC (FORCE RLS applies even to the table owner), so the
 // suite can assert the export was recorded.
-func lastAudit(t *testing.T, e *searchEnv, action string) (gotAction, entityType string, after map[string]any) {
+func lastSystemLog(t *testing.T, e *searchEnv, action string) (gotAction string, detail map[string]any) {
 	t.Helper()
 	ctx := context.Background()
 	tx, err := e.owner.Begin(ctx)
@@ -208,17 +209,17 @@ func lastAudit(t *testing.T, e *searchEnv, action string) (gotAction, entityType
 	if _, err := tx.Exec(ctx, `SELECT set_config('app.workspace_id', $1, true)`, e.WS.String()); err != nil {
 		t.Fatalf("set guc: %v", err)
 	}
-	var afterRaw []byte
+	var detailRaw []byte
 	err = tx.QueryRow(ctx,
-		`SELECT action, entity_type, after FROM audit_log WHERE action = $1 ORDER BY occurred_at DESC LIMIT 1`,
-		action).Scan(&gotAction, &entityType, &afterRaw)
+		`SELECT action, detail FROM system_log WHERE action = $1 ORDER BY occurred_at DESC LIMIT 1`,
+		action).Scan(&gotAction, &detailRaw)
 	if err != nil {
-		t.Fatalf("reading audit row: %v", err)
+		t.Fatalf("reading system_log row: %v", err)
 	}
-	if err := json.Unmarshal(afterRaw, &after); err != nil {
-		t.Fatalf("audit after is not JSON: %v", err)
+	if err := json.Unmarshal(detailRaw, &detail); err != nil {
+		t.Fatalf("system_log detail is not JSON: %v", err)
 	}
-	return gotAction, entityType, after
+	return gotAction, detail
 }
 
 // TestFilteredExportHTTPEndToEnd drives the endpoint over the wire: a valid

--- a/backend/internal/compose/integration/outbox_integration_test.go
+++ b/backend/internal/compose/integration/outbox_integration_test.go
@@ -147,11 +147,11 @@ func TestFailedLoginIsAuditedAndThrottled(t *testing.T) {
 	})
 	var failed int
 	if err := owner.QueryRow(t.Context(),
-		`SELECT count(*) FROM audit_log WHERE action = 'login' AND evidence->>'outcome' = 'failed'`).Scan(&failed); err != nil {
+		`SELECT count(*) FROM system_log WHERE action = 'login' AND detail->>'outcome' = 'failed'`).Scan(&failed); err != nil {
 		t.Fatal(err)
 	}
 	if failed != 1 {
-		t.Fatalf("failed-login audit rows = %d, want 1", failed)
+		t.Fatalf("failed-login system_log rows = %d, want 1", failed)
 	}
 
 	// Failures two through five stay 401; the fifth consecutive failure
@@ -178,10 +178,10 @@ func TestFailedLoginIsAuditedAndThrottled(t *testing.T) {
 	}
 	var lockouts int
 	if err := owner.QueryRow(t.Context(),
-		`SELECT count(*) FROM audit_log WHERE action = 'login' AND evidence->>'outcome' = 'lockout'`).Scan(&lockouts); err != nil {
+		`SELECT count(*) FROM system_log WHERE action = 'login' AND detail->>'outcome' = 'lockout'`).Scan(&lockouts); err != nil {
 		t.Fatal(err)
 	}
 	if lockouts != 1 {
-		t.Fatalf("lockout audit rows = %d, want 1", lockouts)
+		t.Fatalf("lockout system_log rows = %d, want 1", lockouts)
 	}
 }

--- a/backend/internal/compose/integration/systemlog_integration_test.go
+++ b/backend/internal/compose/integration/systemlog_integration_test.go
@@ -64,7 +64,7 @@ func TestLogSystem_writesConnectorRowWithDerivedActor(t *testing.T) {
 		return tx.QueryRow(ctx,
 			`SELECT actor_type, actor_id, on_behalf_of, action, detail,
 			        NOT EXISTS (SELECT 1 FROM information_schema.columns
-			                    WHERE table_name='system_log' AND column_name IN ('entity_type','entity_id'))
+			                    WHERE table_schema = current_schema() AND table_name='system_log' AND column_name IN ('entity_type','entity_id'))
 			 FROM system_log WHERE id = $1`, id).
 			Scan(&actorType, &actorID, &onBehalf, &action, &detailJSON, &entityAbsent)
 	}); err != nil {

--- a/backend/internal/compose/integration/systemlog_integration_test.go
+++ b/backend/internal/compose/integration/systemlog_integration_test.go
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// storekit.LogSystem over a real migrated schema: the append-only ledger
+// for SYSTEM / non-entity operational events (login, bulk export, capture
+// skip). It stamps actor + workspace from the principal exactly like Audit,
+// writes no entity, and returns the row id an entity-less pipeline event
+// carries as its ledger trace link. The row is append-only at the DB layer.
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// connectorCtx binds a connector principal acting for a granting human —
+// the capture-skip shape (the harness seeds no connector helper).
+func connectorCtx(e *Env, onBehalf ids.UUID) context.Context {
+	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
+	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
+	return principal.WithActor(ctx, principal.Principal{
+		Type:       principal.PrincipalConnector,
+		ID:         "connector:gmail",
+		OnBehalfOf: onBehalf,
+	})
+}
+
+func TestLogSystem_writesConnectorRowWithDerivedActor(t *testing.T) {
+	e := Setup(t)
+	ctx := connectorCtx(e, e.Rep1)
+	detail := map[string]any{"reason": "personal_exclusion", "source_system": "gmail", "source_id": "msg-1"}
+
+	var id ids.UUID
+	if err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
+		var err error
+		id, err = storekit.LogSystem(ctx, tx, "capture_skip", detail)
+		return err
+	}); err != nil {
+		t.Fatalf("LogSystem: %v", err)
+	}
+	if id.IsZero() {
+		t.Fatal("LogSystem returned a zero id — the ledger link would be unroutable")
+	}
+
+	var (
+		actorType, actorID, action string
+		onBehalf                   *ids.UUID
+		entityAbsent               bool
+		detailJSON                 []byte
+	)
+	rowCtx := principal.WithWorkspaceID(context.Background(), e.WS)
+	if err := database.WithWorkspaceTx(rowCtx, e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx,
+			`SELECT actor_type, actor_id, on_behalf_of, action, detail,
+			        NOT EXISTS (SELECT 1 FROM information_schema.columns
+			                    WHERE table_name='system_log' AND column_name IN ('entity_type','entity_id'))
+			 FROM system_log WHERE id = $1`, id).
+			Scan(&actorType, &actorID, &onBehalf, &action, &detailJSON, &entityAbsent)
+	}); err != nil {
+		t.Fatalf("reading back the row: %v", err)
+	}
+
+	if actorType != "connector" || actorID != "connector:gmail" {
+		t.Errorf("actor = %s/%s, want connector/connector:gmail", actorType, actorID)
+	}
+	if onBehalf == nil || *onBehalf != e.Rep1 {
+		t.Errorf("on_behalf_of = %v, want %s (the granting human)", onBehalf, e.Rep1)
+	}
+	if action != "capture_skip" {
+		t.Errorf("action = %q, want capture_skip", action)
+	}
+	if !entityAbsent {
+		t.Error("system_log must be LEAN — no entity_type/entity_id columns")
+	}
+	var got map[string]any
+	if err := json.Unmarshal(detailJSON, &got); err != nil {
+		t.Fatalf("detail is not valid json: %v", err)
+	}
+	if got["reason"] != "personal_exclusion" || got["source_system"] != "gmail" {
+		t.Errorf("detail = %v, want the excluded-message context", got)
+	}
+}
+
+func TestLogSystem_isAppendOnly(t *testing.T) {
+	e := Setup(t)
+	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, RepPerms)
+
+	var id ids.UUID
+	if err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
+		var err error
+		id, err = storekit.LogSystem(ctx, tx, "export", map[string]any{"kind": "filtered"})
+		return err
+	}); err != nil {
+		t.Fatalf("LogSystem: %v", err)
+	}
+
+	// UPDATE and DELETE must both raise the immutability trigger.
+	for _, stmt := range []string{
+		`UPDATE system_log SET action = 'tampered' WHERE id = $1`,
+		`DELETE FROM system_log WHERE id = $1`,
+	} {
+		err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
+			_, err := tx.Exec(ctx, stmt, id)
+			return err
+		})
+		if err == nil {
+			t.Errorf("statement %q succeeded — system_log must be append-only", stmt)
+		}
+	}
+}

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -377,7 +377,6 @@ const (
 	Export          AuditLogEntryAction = "export"
 	Import          AuditLogEntryAction = "import"
 	ImportUndo      AuditLogEntryAction = "import_undo"
-	Login           AuditLogEntryAction = "login"
 	Merge           AuditLogEntryAction = "merge"
 	Promote         AuditLogEntryAction = "promote"
 	RecordShare     AuditLogEntryAction = "record_share"
@@ -420,8 +419,6 @@ func (e AuditLogEntryAction) Valid() bool {
 	case Import:
 		return true
 	case ImportUndo:
-		return true
-	case Login:
 		return true
 	case Merge:
 		return true
@@ -4415,8 +4412,10 @@ type AuditLogEntry struct {
 	// AuthorizationRule Which RBAC/scope rule allowed it.
 	AuthorizationRule *string                 `json:"authorization_rule,omitempty"`
 	Before            *map[string]interface{} `json:"before,omitempty"`
-	EntityId          *openapi_types.UUID     `json:"entity_id,omitempty"`
-	EntityType        string                  `json:"entity_type"`
+
+	// EntityId Every audit_log row names the record it mutated (NOT NULL since 0075).
+	EntityId   openapi_types.UUID `json:"entity_id"`
+	EntityType string             `json:"entity_type"`
 
 	// Evidence e.g. which inbound email/meeting triggered a promotion.
 	Evidence   *map[string]interface{} `json:"evidence,omitempty"`

--- a/backend/internal/modules/identity/lockout.go
+++ b/backend/internal/modules/identity/lockout.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/modules/identity/internal/password"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
@@ -171,11 +172,18 @@ func (s *Service) recordFailedLogin(ctx context.Context, wsID ids.WorkspaceID, e
 		// the audit_log record-mutation spine. Written directly (not via
 		// storekit.LogSystem) because a failed login has no authenticated
 		// principal to stamp from — the actor is a literal unauthenticated human.
+		//
+		// The attempted address is logged as an irreversible hash, never
+		// plaintext: system_log is widely retained, and the failed-login path
+		// has no resolved user, so the address is the only target identifier.
+		// SuppressionHash (the one identifier hashing rule — trimmed+lowercased
+		// sha256) keeps a brute-force against one target correlatable across
+		// attempts (identical hash) without retaining the PII.
 		_, err = tx.Exec(ctx,
 			`INSERT INTO system_log (workspace_id, actor_type, actor_id, action, detail)
 			 VALUES ($1, 'human', 'human:unauthenticated', 'login',
-			         jsonb_build_object('outcome', $2::text, 'email', $3::text))`,
-			wsID, outcome, email)
+			         jsonb_build_object('outcome', $2::text, 'email_hash', $3::text))`,
+			wsID, outcome, storekit.SuppressionHash(email))
 		return err
 	})
 }

--- a/backend/internal/modules/identity/lockout.go
+++ b/backend/internal/modules/identity/lockout.go
@@ -166,9 +166,14 @@ func (s *Service) recordFailedLogin(ctx context.Context, wsID ids.WorkspaceID, e
 				outcome = "lockout" // §27: the lock transition is its own audited fact
 			}
 		}
+		// The failed/lockout login fact lands in system_log — a login mutates
+		// no record, so it belongs in the non-entity operational ledger, not
+		// the audit_log record-mutation spine. Written directly (not via
+		// storekit.LogSystem) because a failed login has no authenticated
+		// principal to stamp from — the actor is a literal unauthenticated human.
 		_, err = tx.Exec(ctx,
-			`INSERT INTO audit_log (workspace_id, actor_type, actor_id, action, entity_type, evidence)
-			 VALUES ($1, 'human', 'human:unauthenticated', 'login', 'session',
+			`INSERT INTO system_log (workspace_id, actor_type, actor_id, action, detail)
+			 VALUES ($1, 'human', 'human:unauthenticated', 'login',
 			         jsonb_build_object('outcome', $2::text, 'email', $3::text))`,
 			wsID, outcome, email)
 		return err

--- a/backend/internal/modules/identity/revocation_integration_test.go
+++ b/backend/internal/modules/identity/revocation_integration_test.go
@@ -359,8 +359,8 @@ func TestLoginLockoutEndToEnd(t *testing.T) {
 	}
 	var outcome string
 	if err := e.owner.QueryRow(context.Background(),
-		`SELECT evidence->>'outcome' FROM audit_log
-		 WHERE action = 'login' AND evidence->>'email' = $1
+		`SELECT detail->>'outcome' FROM system_log
+		 WHERE action = 'login' AND detail->>'email' = $1
 		 ORDER BY id DESC LIMIT 1`, e.member.Email).Scan(&outcome); err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/modules/identity/revocation_integration_test.go
+++ b/backend/internal/modules/identity/revocation_integration_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/modules/identity/internal/password"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/events"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -360,8 +361,8 @@ func TestLoginLockoutEndToEnd(t *testing.T) {
 	var outcome string
 	if err := e.owner.QueryRow(context.Background(),
 		`SELECT detail->>'outcome' FROM system_log
-		 WHERE action = 'login' AND detail->>'email' = $1
-		 ORDER BY id DESC LIMIT 1`, e.member.Email).Scan(&outcome); err != nil {
+		 WHERE action = 'login' AND detail->>'email_hash' = $1
+		 ORDER BY id DESC LIMIT 1`, storekit.SuppressionHash(e.member.Email)).Scan(&outcome); err != nil {
 		t.Fatal(err)
 	}
 	if outcome != "lockout" {

--- a/backend/internal/modules/identity/service.go
+++ b/backend/internal/modules/identity/service.go
@@ -390,10 +390,16 @@ func insertSession(ctx context.Context, tx pgx.Tx, wsID ids.WorkspaceID, userID 
 	return err
 }
 
+// auditLogin appends the login fact to system_log — the ledger for
+// non-entity operational events. A login mutates no record (it has no
+// entity), so it belongs in system_log, not the audit_log record-mutation
+// spine. It writes the row directly (not via storekit.LogSystem) because
+// the login path has no authenticated principal for LogSystem to stamp from
+// — the same reason identity owns its own audit-ledger writer.
 func auditLogin(ctx context.Context, tx pgx.Tx, wsID ids.WorkspaceID, userID ids.UserID, detail string) error {
 	_, err := tx.Exec(ctx,
-		`INSERT INTO audit_log (workspace_id, actor_type, actor_id, action, entity_type, evidence)
-		 VALUES ($1, 'human', $2, 'login', 'session', jsonb_build_object('detail', $3::text))`,
+		`INSERT INTO system_log (workspace_id, actor_type, actor_id, action, detail)
+		 VALUES ($1, 'human', $2, 'login', jsonb_build_object('detail', $3::text))`,
 		wsID, "human:"+userID.String(), detail)
 	return err
 }

--- a/backend/internal/modules/privacy/handlers.go
+++ b/backend/internal/modules/privacy/handlers.go
@@ -85,9 +85,11 @@ func auditEntryToWire(e AuditEntry) (crmcontracts.AuditLogEntry, error) {
 		id := openapi_types.UUID(e.OnBehalfOf.UUID)
 		out.OnBehalfOf = &id
 	}
+	// entity_id is NOT NULL since 0075 (audit_log is record-mutations-only);
+	// the contract field is non-optional to match. The domain read model
+	// still carries a pointer for historical rows, so guard defensively.
 	if e.EntityID != nil {
-		id := openapi_types.UUID(*e.EntityID)
-		out.EntityId = &id
+		out.EntityId = openapi_types.UUID(*e.EntityID)
 	}
 	var err error
 	if out.Before, err = decodeJSONObject(e.Before); err != nil {

--- a/backend/internal/platform/database/storekit/logsystem_test.go
+++ b/backend/internal/platform/database/storekit/logsystem_test.go
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package storekit
+
+import (
+	"context"
+	"testing"
+)
+
+// LogSystem stamps its actor from the authenticated principal, exactly like
+// Audit — so a call with no actor bound is a programming error that must be
+// refused BEFORE any SQL runs (a nil tx here proves it never reaches Exec).
+func TestLogSystem_requiresActor(t *testing.T) {
+	_, err := LogSystem(context.Background(), nil, "login", nil)
+	if err == nil {
+		t.Fatal("LogSystem with no actor bound must return an error, not write a row")
+	}
+}

--- a/backend/internal/platform/database/storekit/storekit.go
+++ b/backend/internal/platform/database/storekit/storekit.go
@@ -96,6 +96,32 @@ func AuditWithEvidence(ctx context.Context, tx pgx.Tx, action, entityType string
 	return id, err
 }
 
+// LogSystem writes one append-only system_log row inside the current
+// transaction — the ledger for a SYSTEM / non-entity operational event
+// (login, bulk export, capture skip) that mutates no record and so has no
+// place in audit_log (the P12 record-mutation spine). Actor and workspace
+// are derived exactly as Audit derives them — from the authenticated
+// principal and the workspace GUC — so a caller with no actor bound is a
+// programming error, refused before any SQL runs. It returns the row id so
+// an entity-less pipeline event can carry it as trace.audit_log_id (the
+// repurposed "ledger row id", events.md §2). detail is nil-safe: nil writes
+// SQL NULL.
+func LogSystem(ctx context.Context, tx pgx.Tx, action string, detail map[string]any) (ids.UUID, error) {
+	p, err := Actor(ctx)
+	if err != nil {
+		return ids.Nil, err
+	}
+	wsID, _ := principal.WorkspaceID(ctx)
+
+	id := ids.NewV7()
+	_, err = tx.Exec(ctx,
+		`INSERT INTO system_log (id, workspace_id, actor_type, actor_id, passport_id, on_behalf_of, action, detail)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+		id, wsID, string(p.Type), p.ID, UUIDOrNil(p.PassportID), UUIDOrNil(p.OnBehalfOf),
+		action, JSONArg(detail))
+	return id, err
+}
+
 // Emit stages a domain event in the transactional outbox (events.md
 // §4.2). The envelope is complete at staging time — event_id (UUIDv7),
 // actor incl. passport/on-behalf-of, and the trace linking this event to

--- a/backend/internal/platform/database/storekit/storekit.go
+++ b/backend/internal/platform/database/storekit/storekit.go
@@ -111,7 +111,10 @@ func LogSystem(ctx context.Context, tx pgx.Tx, action string, detail map[string]
 	if err != nil {
 		return ids.Nil, err
 	}
-	wsID, _ := principal.WorkspaceID(ctx)
+	// MustWorkspace is safe here: LogSystem only runs inside WithWorkspaceTx,
+	// which already failed if no workspace was bound, and the system_log RLS
+	// WITH CHECK rejects a mismatched workspace_id as a final backstop.
+	wsID := MustWorkspace(ctx)
 
 	id := ids.NewV7()
 	_, err = tx.Exec(ctx,

--- a/backend/internal/shared/kernel/events/catalog.go
+++ b/backend/internal/shared/kernel/events/catalog.go
@@ -116,6 +116,29 @@ var catalog = map[string]struct {
 	"passport.revoked": {"identity", 1},
 }
 
+// pipelineEventTypes are the capture-pipeline events that may ride the bus
+// WITHOUT a subject entity ref. A pipeline step can be subject-less by
+// nature — capture.skipped names NOTHING (an excluded personal message
+// creates no row), yet the spec still requires it on the bus as the
+// machine-checkable "personal mail is never ingested" proof (capture.md
+// AC1.3, EVT-SEM-10). These events carry no entity handle, but they DO keep
+// the ledger trace link (audit_log OR system_log) so the outcome stays
+// attributable — Validate enforces the trace, only the entity is relaxed.
+var pipelineEventTypes = map[string]struct{}{
+	"capture.received":   {},
+	"capture.normalized": {},
+	"capture.failed":     {},
+	"capture.skipped":    {},
+}
+
+// IsPipelineEvent reports whether an event type is an entity-less
+// pipeline-event class member (see pipelineEventTypes): its envelope may
+// carry an empty Entity ref where a normal event must name its subject.
+func IsPipelineEvent(eventType string) bool {
+	_, ok := pipelineEventTypes[eventType]
+	return ok
+}
+
 // Types returns every catalog event type, sorted — the enumerable set
 // codegen and the naming fitness test walk.
 func Types() []string {

--- a/backend/internal/shared/kernel/events/envelope.go
+++ b/backend/internal/shared/kernel/events/envelope.go
@@ -109,8 +109,15 @@ func (e Envelope) Validate() error {
 	// by nature — an excluded message names nothing (catalog.go
 	// pipelineEventTypes, capture.md AC1.3). Every other event must name its
 	// subject: the read-back handle a consumer fetches under its own RLS and
-	// the per-entity-type stream routing key.
-	if !IsPipelineEvent(e.Type) && (e.Entity.Type == "" || e.Entity.ID.IsZero()) {
+	// the per-entity-type stream routing key. When a pipeline event DOES carry
+	// an entity (capture.received names the raw record), it must be complete —
+	// a half-filled ref (a type with no id, or vice versa) is malformed and
+	// would route or read back wrong, so it is rejected either way.
+	if e.Entity.Type != "" || !e.Entity.ID.IsZero() {
+		if e.Entity.Type == "" || e.Entity.ID.IsZero() {
+			return fmt.Errorf("events: %s envelope has a partially populated entity ref", e.Type)
+		}
+	} else if !IsPipelineEvent(e.Type) {
 		return fmt.Errorf("events: %s envelope has no entity ref", e.Type)
 	}
 	if e.Trace.CorrelationID.IsZero() || e.Trace.AuditLogID.IsZero() {

--- a/backend/internal/shared/kernel/events/envelope.go
+++ b/backend/internal/shared/kernel/events/envelope.go
@@ -64,7 +64,13 @@ type Trace struct {
 	// CausationID is the event_id that caused THIS event; nil for the
 	// first event in a chain.
 	CausationID *ids.UUID `json:"causation_id"`
-	// AuditLogID is the audit_log row written in the same transaction.
+	// AuditLogID is the ledger row written in the SAME transaction as this
+	// event, so a consumer can join the event to its governance record. For
+	// a record mutation that is the audit_log row (the P12 spine); for an
+	// entity-less pipeline event (capture.skipped and its siblings) it is
+	// the system_log row instead. Either way it is non-zero — an event with
+	// no ledger row is unauditable. The JSON key stays `audit_log_id` for
+	// wire compatibility.
 	AuditLogID ids.UUID `json:"audit_log_id"`
 }
 
@@ -99,7 +105,12 @@ func (e Envelope) Validate() error {
 	if e.Actor.ID == "" {
 		return fmt.Errorf("events: %s envelope has no actor", e.Type)
 	}
-	if e.Entity.Type == "" || e.Entity.ID.IsZero() {
+	// A pipeline event (capture.skipped and its siblings) may be entity-less
+	// by nature — an excluded message names nothing (catalog.go
+	// pipelineEventTypes, capture.md AC1.3). Every other event must name its
+	// subject: the read-back handle a consumer fetches under its own RLS and
+	// the per-entity-type stream routing key.
+	if !IsPipelineEvent(e.Type) && (e.Entity.Type == "" || e.Entity.ID.IsZero()) {
 		return fmt.Errorf("events: %s envelope has no entity ref", e.Type)
 	}
 	if e.Trace.CorrelationID.IsZero() || e.Trace.AuditLogID.IsZero() {

--- a/backend/internal/shared/kernel/events/envelope_test.go
+++ b/backend/internal/shared/kernel/events/envelope_test.go
@@ -19,7 +19,7 @@ func validEnvelope(t *testing.T, eventType string) Envelope {
 		Type:        eventType,
 		Version:     VersionOf(eventType),
 		WorkspaceID: ids.NewV7(),
-		OccurredAt:  time.Now().UTC(),
+		OccurredAt:  time.Date(2026, 7, 16, 9, 38, 0, 0, time.UTC),
 		Actor:       Actor{Type: "connector", ID: "connector:gmail"},
 		Entity:      EntityRef{Type: "activity", ID: ids.NewV7()},
 		Trace:       Trace{CorrelationID: ids.NewV7(), AuditLogID: ids.NewV7()},
@@ -66,5 +66,16 @@ func TestValidate_pipelineEventMayCarryEntity(t *testing.T) {
 	env := validEnvelope(t, "capture.received")
 	if err := env.Validate(); err != nil {
 		t.Fatalf("capture.received with an entity should validate, got: %v", err)
+	}
+}
+
+// The relaxation makes the entity optional, not lax: a pipeline event that
+// carries a HALF-filled ref (a type with no id) is malformed and must be
+// rejected — it would route or read back wrong.
+func TestValidate_pipelineEventRejectsPartialEntity(t *testing.T) {
+	env := validEnvelope(t, "capture.received")
+	env.Entity = EntityRef{Type: "activity"} // id left zero
+	if err := env.Validate(); err == nil {
+		t.Fatal("a pipeline event with a type but no id must be rejected")
 	}
 }

--- a/backend/internal/shared/kernel/events/envelope_test.go
+++ b/backend/internal/shared/kernel/events/envelope_test.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package events
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// validEnvelope builds a fully-populated envelope for the given type — the
+// baseline a test then mutates one field of to probe a single Validate rule.
+func validEnvelope(t *testing.T, eventType string) Envelope {
+	t.Helper()
+	return Envelope{
+		EventID:     ids.NewV7(),
+		Type:        eventType,
+		Version:     VersionOf(eventType),
+		WorkspaceID: ids.NewV7(),
+		OccurredAt:  time.Now().UTC(),
+		Actor:       Actor{Type: "connector", ID: "connector:gmail"},
+		Entity:      EntityRef{Type: "activity", ID: ids.NewV7()},
+		Trace:       Trace{CorrelationID: ids.NewV7(), AuditLogID: ids.NewV7()},
+	}
+}
+
+// A pipeline event (capture.skipped) is subject-less by nature — an excluded
+// message creates NOTHING — yet the spec requires it on the bus as the AC1.3
+// proof. Validate must accept it with an empty Entity.
+func TestValidate_pipelineEventAllowsEmptyEntity(t *testing.T) {
+	env := validEnvelope(t, "capture.skipped")
+	env.Entity = EntityRef{}
+	if err := env.Validate(); err != nil {
+		t.Fatalf("capture.skipped with empty entity should validate, got: %v", err)
+	}
+}
+
+// Every non-pipeline event still names a subject: a consumer reads it back
+// under its own RLS and routes on the entity type. Empty entity must fail.
+func TestValidate_nonPipelineEventRequiresEntity(t *testing.T) {
+	env := validEnvelope(t, "person.created")
+	env.Entity = EntityRef{}
+	if err := env.Validate(); err == nil {
+		t.Fatal("person.created with empty entity must be rejected")
+	}
+}
+
+// Relaxing the entity ref must NOT drop the ledger trace link: a pipeline
+// event still carries its ledger row id (audit_log OR system_log) so the
+// outcome stays attributable.
+func TestValidate_pipelineEventStillRequiresLedgerTrace(t *testing.T) {
+	env := validEnvelope(t, "capture.skipped")
+	env.Entity = EntityRef{}
+	env.Trace.AuditLogID = ids.Nil
+	if err := env.Validate(); err == nil {
+		t.Fatal("a pipeline event with no ledger row id must be rejected (incomplete trace)")
+	}
+}
+
+// A pipeline event MAY still carry an entity where one exists
+// (capture.received names the raw record) — the relaxation makes the entity
+// optional, it does not forbid it.
+func TestValidate_pipelineEventMayCarryEntity(t *testing.T) {
+	env := validEnvelope(t, "capture.received")
+	if err := env.Validate(); err != nil {
+		t.Fatalf("capture.received with an entity should validate, got: %v", err)
+	}
+}

--- a/backend/migrations/core/0074_system_log.down.sql
+++ b/backend/migrations/core/0074_system_log.down.sql
@@ -1,0 +1,5 @@
+-- Reverse 0074: drop the table (its trigger goes with it) then the
+-- trigger function, so a full down leaves no orphaned function behind
+-- (TestMigrations_applyReverseReapply re-applies from zero).
+DROP TABLE IF EXISTS system_log;
+DROP FUNCTION IF EXISTS system_log_immutable();

--- a/backend/migrations/core/0074_system_log.up.sql
+++ b/backend/migrations/core/0074_system_log.up.sql
@@ -1,0 +1,53 @@
+-- 0074: system_log — the append-only ledger of SYSTEM / non-entity
+-- operational events (login, bulk export, capture skip). audit_log is the
+-- P12 ledger of RECORD MUTATIONS — "who changed this record" — so its rows
+-- always name an entity. A login, a filtered bulk export, or an excluded
+-- personal message mutates NO record; forcing those into audit_log is what
+-- made entity_id nullable there. system_log gives them their own home:
+-- LEAN (no entity_type/id, no before/after images), workspace-scoped, RLS
+-- ENABLE+FORCE+tenant-isolation (mirroring connector_connection, 0023),
+-- append-only at the DB layer (mirroring audit_log, 0012). An entity-less
+-- pipeline event (capture.skipped and its siblings, events envelope
+-- pipeline class) carries this row's id as its ledger trace link
+-- (Trace.AuditLogID, repurposed to "ledger row id").
+
+CREATE TABLE system_log (
+  id            uuid PRIMARY KEY DEFAULT uuidv7(),
+  workspace_id  uuid NOT NULL REFERENCES workspace(id) ON DELETE RESTRICT,
+
+  actor_type    text NOT NULL CHECK (actor_type IN ('human','agent','connector','system')),
+  actor_id      text NOT NULL,            -- user uuid, agent id, connector name, or 'system'
+  passport_id   uuid NULL,                -- Agent Seat Passport that authorized an agent action
+  on_behalf_of  uuid NULL,                -- the human authority behind an agent/connector action
+
+  action        text NOT NULL,            -- 'login','export','capture_skip',…
+  detail        jsonb NULL,               -- operation context (outcome, filter, reason, source_system,…)
+
+  occurred_at   timestamptz NOT NULL DEFAULT now(),
+
+  -- Same-workspace guarantee (C4, 0019 composite-FK pattern): the human
+  -- authority must live in this row's workspace. Nullable on_behalf_of ⇒
+  -- MATCH SIMPLE skips the check when unset; column-list SET NULL nulls only
+  -- on_behalf_of on a member delete, never workspace_id.
+  CONSTRAINT system_log_on_behalf_of_fkey FOREIGN KEY (workspace_id, on_behalf_of)
+    REFERENCES app_user (workspace_id, id) ON DELETE SET NULL (on_behalf_of)
+);
+CREATE INDEX idx_system_log_actor  ON system_log (workspace_id, actor_id, occurred_at DESC);
+CREATE INDEX idx_system_log_action ON system_log (workspace_id, action, occurred_at DESC);
+CREATE INDEX idx_system_log_time   ON system_log (workspace_id, occurred_at DESC);
+
+-- Append-only at the DB layer: a tamper attempt FAILS LOUDLY, never
+-- silently no-ops (the audit_log_immutable() shape, 0012).
+CREATE OR REPLACE FUNCTION system_log_immutable() RETURNS trigger AS $$
+BEGIN
+  RAISE EXCEPTION 'system_log is append-only (attempted % on row %)', TG_OP, OLD.id
+    USING ERRCODE = 'check_violation';
+END; $$ LANGUAGE plpgsql;
+CREATE TRIGGER trg_system_log_no_mutate BEFORE UPDATE OR DELETE ON system_log
+  FOR EACH ROW EXECUTE FUNCTION system_log_immutable();
+
+ALTER TABLE system_log ENABLE ROW LEVEL SECURITY;
+ALTER TABLE system_log FORCE ROW LEVEL SECURITY;
+CREATE POLICY system_log_tenant_isolation ON system_log
+  USING      (workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid)
+  WITH CHECK (workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid);

--- a/backend/migrations/core/0075_audit_log_entity_required.down.sql
+++ b/backend/migrations/core/0075_audit_log_entity_required.down.sql
@@ -1,0 +1,13 @@
+-- Reverse 0075: restore the nullable entity_id and re-add `login` to the
+-- action vocabulary (0053's set), so a full down leaves audit_log exactly as
+-- 0053+0074 left it (TestMigrations_applyReverseReapply re-applies from zero).
+ALTER TABLE audit_log ALTER COLUMN entity_id DROP NOT NULL;
+
+ALTER TABLE audit_log DROP CONSTRAINT audit_log_action_check;
+ALTER TABLE audit_log ADD CONSTRAINT audit_log_action_check
+  CHECK (action IN ('create','update','archive','merge','promote','restore','export','erase',
+                    'login','assign','advance_stage','approve','reject',
+                    'consent_grant','consent_withdraw','activity_relink',
+                    'record_share','record_unshare','resolve',
+                    'demote','import','import_undo',
+                    'disqualify','anonymize','send_email'));

--- a/backend/migrations/core/0075_audit_log_entity_required.up.sql
+++ b/backend/migrations/core/0075_audit_log_entity_required.up.sql
@@ -1,0 +1,25 @@
+-- 0075: audit_log is now RECORD MUTATIONS ONLY. The last non-entity verbs
+-- (login, failed-login, bulk export) moved to system_log (0074), so:
+--
+-- 1. `login` leaves the action vocabulary — nothing writes it here anymore
+--    (a verb that moves out of audit_log leaves its CHECK). `export` STAYS:
+--    the DSR person export (sar.go) still audits an entity-bound export.
+-- 2. entity_id becomes NOT NULL — every remaining audit_log row names the
+--    record it mutated. entity_id was nullable ONLY for those non-entity
+--    verbs; with them gone, a null entity_id would be a defect, so the
+--    database rejects it by construction (P12: the audit spine is the
+--    record's own history).
+--
+-- The action set below is 0053's vocabulary minus `login` (the effective
+-- CHECK is the highest-numbered migration that re-states it — auditcoherence
+-- reads it against crm.yaml, from which `login` is dropped in the same change).
+ALTER TABLE audit_log DROP CONSTRAINT audit_log_action_check;
+ALTER TABLE audit_log ADD CONSTRAINT audit_log_action_check
+  CHECK (action IN ('create','update','archive','merge','promote','restore','export','erase',
+                    'assign','advance_stage','approve','reject',
+                    'consent_grant','consent_withdraw','activity_relink',
+                    'record_share','record_unshare','resolve',
+                    'demote','import','import_undo',
+                    'disqualify','anonymize','send_email'));
+
+ALTER TABLE audit_log ALTER COLUMN entity_id SET NOT NULL;

--- a/backend/migrations/schema_integration_test.go
+++ b/backend/migrations/schema_integration_test.go
@@ -370,8 +370,9 @@ func TestAuditLogIsAppendOnly(t *testing.T) {
 	var id string
 	if err := withGUC(t, app, ws, func(tx pgx.Tx) error {
 		return tx.QueryRow(ctx,
-			`INSERT INTO audit_log (workspace_id, actor_type, actor_id, action, entity_type)
-			 VALUES ($1, 'human', 'human:test', 'create', 'person') RETURNING id`, ws).Scan(&id)
+			// entity_id is NOT NULL since 0075 (audit_log is record-mutations-only).
+			`INSERT INTO audit_log (workspace_id, actor_type, actor_id, action, entity_type, entity_id)
+			 VALUES ($1, 'human', 'human:test', 'create', 'person', uuidv7()) RETURNING id`, ws).Scan(&id)
 	}); err != nil {
 		t.Fatalf("seeding an audit row: %v", err)
 	}

--- a/backend/tableownership_test.go
+++ b/backend/tableownership_test.go
@@ -128,10 +128,13 @@ var tableOwners = map[string]string{
 	"brief_run":       "internal/compose/briefs",
 	"brief_item":      "internal/compose/briefs",
 	// platform: the audit+outbox pair has ONE sanctioned writer, and the
-	// shared field-provenance layer (B-E02.12) is spelled once next to it
+	// shared field-provenance layer (B-E02.12) is spelled once next to it.
+	// system_log is the non-entity operational ledger written through
+	// storekit.LogSystem, the same storekit-owned posture as audit_log.
 	"audit_log":        storekitOwned,
 	"event_outbox":     storekitOwned,
 	"field_provenance": storekitOwned,
+	"system_log":       storekitOwned,
 }
 
 // crossStoreWrites are the ratified writes outside the writer's own tables,
@@ -189,9 +192,16 @@ var crossStoreWrites = map[string]string{
 	// direct audit_log/event_outbox writers: storekit.Audit stamps
 	// captured_by from an authenticated principal, which these paths do
 	// not have or which need columns storekit's writer does not carry.
-	"internal/modules/identity:audit_log":     "login, failed-login and passport audits fire before/without an authenticated principal for storekit.Audit to stamp; identity appends the same append-only rows itself",
+	"internal/modules/identity:audit_log":     "the passport-mint audit stamps its actor from the granting human identity just resolved (not the request principal storekit.Audit would read); identity appends the append-only row itself",
 	"internal/modules/approvals:audit_log":    "approval evidence stamps passport_id/on_behalf_of, columns storekit's writer does not carry; same append-only table, this module's own writer",
 	"internal/modules/approvals:event_outbox": "approvals stages its events with the full envelope (passport actor fields) storekit.Emit does not carry; still outbox-only publishing",
+
+	// identity owns login/failed-login, which land in system_log (a login
+	// mutates no record). They fire before/without an authenticated
+	// principal for storekit.LogSystem to stamp — bootstrap and failed
+	// logins have no session yet — so identity appends the append-only rows
+	// directly, the same reason it writes its own audit_log rows above.
+	"internal/modules/identity:system_log": "login and failed-login land in system_log but fire before/without an authenticated principal for storekit.LogSystem to stamp; identity appends the append-only rows itself",
 }
 
 // sqlWriteTargets extracts write-statement table names from one SQL (or

--- a/backend/writeshape_test.go
+++ b/backend/writeshape_test.go
@@ -86,7 +86,9 @@ var auditOnlyWrites = map[string]string{
 	"internal/compose/briefs:SnapshotRun":                "the brief read model is ratified audit-only \u2014 the closed catalog (events.md \u00a75) defines no brief.* type and the closed-verb law forbids inventing one build-side",
 	"internal/compose/briefs:markItem":                   "the brief read model is ratified audit-only \u2014 the closed catalog (events.md \u00a75) defines no brief.* type and the closed-verb law forbids inventing one build-side",
 	"internal/compose/briefs:resurfaceExpiredSnoozes":    "the brief read model is ratified audit-only \u2014 the closed catalog (events.md \u00a75) defines no brief.* type and the closed-verb law forbids inventing one build-side",
-	"internal/compose:WriteFiltered":                     "filtered export is a read whose only write IS the audit row \u2014 the closed catalog (events.md \u00a75) defines no export type (the same ratification as AssembleSAR)",
+	// WriteFiltered no longer belongs here: the bulk export is a non-entity
+	// operational event, so it moved from storekit.Audit to storekit.LogSystem
+	// (system_log, 0074) \u2014 it writes no audit_log row at all now.
 }
 
 func TestEveryAuditedMutationEmitsAnEvent(t *testing.T) {

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -4771,10 +4771,13 @@ export interface components {
              */
             on_behalf_of?: string | null;
             /** @enum {string} */
-            action: "create" | "update" | "archive" | "merge" | "promote" | "demote" | "disqualify" | "restore" | "export" | "erase" | "anonymize" | "login" | "assign" | "advance_stage" | "send_email" | "consent_grant" | "consent_withdraw" | "approve" | "reject" | "record_share" | "record_unshare" | "activity_relink" | "import" | "import_undo";
+            action: "create" | "update" | "archive" | "merge" | "promote" | "demote" | "disqualify" | "restore" | "export" | "erase" | "anonymize" | "assign" | "advance_stage" | "send_email" | "consent_grant" | "consent_withdraw" | "approve" | "reject" | "record_share" | "record_unshare" | "activity_relink" | "import" | "import_undo";
             entity_type: string;
-            /** Format: uuid */
-            entity_id?: string | null;
+            /**
+             * Format: uuid
+             * @description Every audit_log row names the record it mutated (NOT NULL since 0075).
+             */
+            entity_id: string;
             before?: {
                 [key: string]: unknown;
             } | null;


### PR DESCRIPTION
## What

Introduces **`system_log`** — a dedicated append-only ledger for SYSTEM / non-entity operational events — and an **entity-less "pipeline-event" class** in the bus envelope. This unblocks the held RC-2 personal-mail work (PR #74): `capture.skipped` needs no fabricated entity and no synthetic v5 id.

## Why

`audit_log` is the P12 ledger of **record mutations** — "who changed this record" — so every row names an entity. `login`, failed-login, and bulk filtered export mutate **no** record; forcing them into `audit_log` is exactly what kept `entity_id` nullable there. This gives those events their own home and tightens the audit spine to record-mutations-only.

## Changes

- **Migration `0074_system_log`** — LEAN table (no `entity_type`/`id`, no before/after), workspace-scoped, RLS `ENABLE`+`FORCE`+tenant-isolation (mirrors `connector_connection`), append-only trigger (mirrors `audit_log`), composite `on_behalf_of` FK (0019 pattern). Passes the RLS-coverage, composite-FK, and reverse-reapply fitness tests.
- **`storekit.LogSystem(ctx, tx, action, detail)`** — writes one append-only `system_log` row; actor + workspace derived from the principal exactly like `Audit`. Returns the row id for the event trace link.
- **Envelope pipeline-event class** — `Validate()` allows an **empty `Entity`** for `capture.{received,normalized,failed,skipped}`; the ledger trace link stays required. `Trace.AuditLogID` repurposed to a generic "ledger row id" (`audit_log` **or** `system_log`) — field + wire key unchanged.
- **Migrated login/export** — identity's login/failed-login writers (no principal at login time → direct writer) and the bulk filtered export (via `LogSystem`) now write `system_log`.
- **Migration `0075_audit_log_entity_required`** — drops `login` from `audit_log_action_check` (`export` **stays** — the DSR person export is entity-bound) and `ALTER entity_id SET NOT NULL`. Contract (`crm.yaml`), `api_gen.go`, and frontend `schema.d.ts` regenerated.
- **Fitness/tests reconciled** — `tableownership` (system_log owner + identity waiver), `writeshape` (`WriteFiltered` no longer audit-only), and the login/export integration assertions now read `system_log`.

## Decisions (confirmed)

1. Migrated login + bulk export in this same PR (the consistency payoff).
2. Repurposed `Trace.AuditLogID` to "ledger row id" (no field rename, no wire break).
3. Tightened `audit_log.entity_id` to NOT NULL now.

## Gates run locally

`go build`/`vet`/unit suite + root fitness · `golangci-lint run ./...` **and** `--config .golangci.strict.yml ./...` (0 issues) · `check-go-file-length.sh` · craft static (0 findings) · contract regen (no drift once committed) · schema fitness (RLS/composite-FK/reverse-reapply) · `TestAuditLogIsAppendOnly` · `LogSystem` + `filteredexport` + `outbox` + identity login/lockout integration.

> Note: the `internal/compose/integration` package (~345 tests) hits the harness's hardcoded 300s per-package timeout on my local machine even in isolation — a pre-existing package-size limit, not a regression (the 2 new tests add ~1.4s; all 345 that ran passed, 0 `--- FAIL`). CI hardware clears it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added operational system logging for login attempts, lockouts, and bulk/filtered exports.
  * Introduced support for pipeline events that may be entity-less while preserving traceability.

* **Updates**
  * Audit log entries are now record-mutation focused: each audit row includes a non-null entity identifier, and login-coded audit events are no longer emitted there.
  * Login/failed-login outcomes are now surfaced via system logs (not record audit logs).
  * System log entries are enforced as append-only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->