### PR TITLE
fix(search): fold apostrophes so "oreilly" finds "Tim O'Reilly"

### DIFF
--- a/backend/internal/compose/integration/fts_integration_test.go
+++ b/backend/internal/compose/integration/fts_integration_test.go
@@ -70,6 +70,48 @@ func TestSearchFoldsAccentsAndStemsByLanguage(t *testing.T) {
 	}
 }
 
+func TestSearchFoldsApostrophesInNames(t *testing.T) {
+	e := Setup(t)
+	admin := e.Admin()
+
+	// The typographic apostrophe (U+2019) — what pasted text actually
+	// carries; f_unaccent folds it to ASCII ' before the strip.
+	oreilly, err := e.People.CreatePerson(admin, people.CreatePersonInput{
+		FullName: "Tim O’Reilly", Source: "manual",
+	})
+	if err != nil {
+		t.Fatalf("create person: %v", err)
+	}
+
+	// Global search: the collapsed spelling, the apostrophe spelling,
+	// and the bare surname must all find the row.
+	searchStore := search.NewStore(e.Pool)
+	for _, q := range []string{"oreilly", "o'reilly", "o’reilly", "reilly"} {
+		page, err := searchStore.Search(admin, search.Input{Query: q, Types: []string{"person"}})
+		if err != nil {
+			t.Fatalf("search %q: %v", q, err)
+		}
+		if !hasHit(page, ids.UUID(oreilly.Id)) {
+			t.Errorf("search for %q did not find 'Tim O’Reilly' — apostrophe folding is broken", q)
+		}
+	}
+
+	// List quick-find: the trigram contains-match must fold the same way.
+	persons, _, err := e.People.ListPeople(admin, people.ListPeopleInput{Query: strPtr("oreil")})
+	if err != nil {
+		t.Fatalf("list people: %v", err)
+	}
+	found := false
+	for _, p := range persons {
+		if p.Id == oreilly.Id {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("list q='oreil' did not quick-find 'Tim O’Reilly' — the folded trigram path is broken")
+	}
+}
+
 func hasHit(page search.Page, id ids.UUID) bool {
 	for _, hit := range page.Hits {
 		if hit.ID == id {

--- a/backend/internal/modules/search/store.go
+++ b/backend/internal/modules/search/store.go
@@ -179,13 +179,18 @@ func admittedBranchSQL(ctx context.Context, types []string, qPos int, arg func(a
 			continue
 		}
 		// Name entities parse the query 'simple' (unaccented — Muller
-		// finds Müller); the activity branch additionally ORs the
-		// German/English stemmed parses so "Vertrag" reaches rows whose
-		// tsvector stemmed "Verträge" under their captured language.
-		tsquery := fmt.Sprintf(`websearch_to_tsquery('simple', f_unaccent($%d))`, qPos)
+		// finds Müller), OR-ed with the apostrophe-collapsed parse so
+		// "o'reilly" also reaches a row stored as "OReilly" (the index
+		// side carries the collapsed tokens, migration 0077); the
+		// activity branch additionally ORs the German/English stemmed
+		// parses so "Vertrag" reaches rows whose tsvector stemmed
+		// "Verträge" under their captured language.
+		tsquery := fmt.Sprintf(
+			`(websearch_to_tsquery('simple', f_unaccent($%[1]d)) || websearch_to_tsquery('simple', f_fold_apostrophes($%[1]d)))`,
+			qPos)
 		if branch.entity == "activity" {
 			tsquery = fmt.Sprintf(
-				`(websearch_to_tsquery('simple', f_unaccent($%[1]d)) || websearch_to_tsquery('german', f_unaccent($%[1]d)) || websearch_to_tsquery('english', f_unaccent($%[1]d)))`,
+				`(websearch_to_tsquery('simple', f_unaccent($%[1]d)) || websearch_to_tsquery('simple', f_fold_apostrophes($%[1]d)) || websearch_to_tsquery('german', f_unaccent($%[1]d)) || websearch_to_tsquery('english', f_unaccent($%[1]d)))`,
 				qPos)
 		}
 		sql := fmt.Sprintf(

--- a/backend/internal/platform/database/storekit/pagination.go
+++ b/backend/internal/platform/database/storekit/pagination.go
@@ -96,10 +96,13 @@ func ClampLimit(limit *int) int {
 // (websearch syntax, accent-folded) OR a trigram contains-match on the
 // entity's name expression — the as-you-type quick-find ("Rech" finds
 // "Rechnung GmbH", "Muller" finds "Müller") that token-based tsquery
-// cannot serve. nameExpr must mirror the expression of the entity's
-// *_name_trgm index so the LIKE stays indexed; the query text is a bind
-// parameter (LIKE metacharacters at worst widen the caller's own match).
+// cannot serve. The contains-match folds apostrophes on both sides
+// ("oreilly" finds "Tim O'Reilly"; f_unaccent maps the typographic ’
+// to ' first, so every spelling collapses the same way). nameExpr must
+// mirror the expression of the entity's *_name_trgm index so the LIKE
+// stays indexed; the query text is a bind parameter (LIKE
+// metacharacters at worst widen the caller's own match).
 func QuickFindClause(pos int, nameExpr string) string {
 	return fmt.Sprintf(`(search_tsv @@ websearch_to_tsquery('simple', f_unaccent($%[1]d))
-	   OR f_unaccent(lower(%[2]s)) LIKE '%%' || f_unaccent(lower($%[1]d)) || '%%')`, pos, nameExpr)
+	   OR f_fold_apostrophes(lower(%[2]s)) LIKE '%%' || f_fold_apostrophes(lower($%[1]d)) || '%%')`, pos, nameExpr)
 }

--- a/backend/migrations/core/0077_apostrophe_fold.down.sql
+++ b/backend/migrations/core/0077_apostrophe_fold.down.sql
@@ -1,0 +1,48 @@
+-- Restore the 0052 definitions: unaccented-only tsvectors and
+-- f_unaccent-based trigram expressions.
+
+ALTER TABLE person DROP COLUMN search_tsv;
+ALTER TABLE person ADD COLUMN search_tsv tsvector GENERATED ALWAYS AS (
+  setweight(to_tsvector('simple', f_unaccent(coalesce(full_name,''))), 'A') ||
+  setweight(to_tsvector('simple', f_unaccent(coalesce(title,''))), 'B')
+) STORED;
+CREATE INDEX idx_person_search ON person USING gin (search_tsv);
+DROP INDEX idx_person_name_trgm;
+CREATE INDEX idx_person_name_trgm ON person USING gin (f_unaccent(lower(full_name)) gin_trgm_ops);
+
+ALTER TABLE organization DROP COLUMN search_tsv;
+ALTER TABLE organization ADD COLUMN search_tsv tsvector GENERATED ALWAYS AS (
+  setweight(to_tsvector('simple', f_unaccent(coalesce(display_name,''))), 'A') ||
+  setweight(to_tsvector('simple', f_unaccent(coalesce(legal_name,'') || ' ' || coalesce(industry,''))), 'B')
+) STORED;
+CREATE INDEX idx_org_search ON organization USING gin (search_tsv);
+DROP INDEX idx_org_name_trgm;
+CREATE INDEX idx_org_name_trgm ON organization USING gin (f_unaccent(lower(display_name)) gin_trgm_ops);
+
+ALTER TABLE deal DROP COLUMN search_tsv;
+ALTER TABLE deal ADD COLUMN search_tsv tsvector GENERATED ALWAYS AS (
+  setweight(to_tsvector('simple', f_unaccent(coalesce(name,''))), 'A')
+) STORED;
+CREATE INDEX idx_deal_search ON deal USING gin (search_tsv);
+DROP INDEX idx_deal_name_trgm;
+CREATE INDEX idx_deal_name_trgm ON deal USING gin (f_unaccent(lower(name)) gin_trgm_ops);
+
+ALTER TABLE lead DROP COLUMN search_tsv;
+ALTER TABLE lead ADD COLUMN search_tsv tsvector GENERATED ALWAYS AS (
+  setweight(to_tsvector('simple', f_unaccent(coalesce(full_name,''))), 'A') ||
+  setweight(to_tsvector('simple', f_unaccent(coalesce(company_name,''))), 'B') ||
+  setweight(to_tsvector('simple', f_unaccent(coalesce(title,''))), 'B')
+) STORED;
+CREATE INDEX idx_lead_search ON lead USING gin (search_tsv);
+DROP INDEX idx_lead_name_trgm;
+CREATE INDEX idx_lead_name_trgm ON lead USING gin (f_unaccent(lower(coalesce(full_name,'') || ' ' || coalesce(company_name,''))) gin_trgm_ops);
+
+ALTER TABLE activity DROP COLUMN search_tsv;
+ALTER TABLE activity ADD COLUMN search_tsv tsvector GENERATED ALWAYS AS (
+  setweight(to_tsvector('simple', f_unaccent(coalesce(subject,''))), 'A') ||
+  setweight(to_tsvector(activity_ts_config(language), f_unaccent(coalesce(subject,'') || ' ' || coalesce(body,''))), 'B') ||
+  setweight(to_tsvector('simple', f_unaccent(coalesce(body,''))), 'C')
+) STORED;
+CREATE INDEX idx_activity_search ON activity USING gin (search_tsv);
+
+DROP FUNCTION IF EXISTS f_fold_apostrophes(text);

--- a/backend/migrations/core/0077_apostrophe_fold.up.sql
+++ b/backend/migrations/core/0077_apostrophe_fold.up.sql
@@ -1,0 +1,72 @@
+-- 0074: apostrophe folding in name search. The 'simple' parser splits
+-- "O'Reilly" into the tokens o + reilly, so the natural query "oreilly"
+-- (one token) missed the row in global search, and the quick-find LIKE
+-- compared against the apostrophe-carrying name and missed it too.
+-- f_unaccent already folds the typographic apostrophes (U+2019, U+02BC)
+-- to ASCII ', so stripping ' after unaccent covers every spelling.
+--
+-- Name tsvectors keep their original tokens (a query "reilly" or
+-- "o'reilly" still hits) and additionally carry the collapsed parse
+-- ("oreilly"); the trigram quick-find expressions collapse on both
+-- sides (see storekit.QuickFindClause). Activity folds its subject —
+-- names live there — but not its body: prose apostrophes ("don't") are
+-- the stemmed parses' job, and the collapsed duplicate would double the
+-- body's tsvector for no name-search gain.
+
+CREATE OR REPLACE FUNCTION f_fold_apostrophes(text)
+  RETURNS text
+  LANGUAGE sql IMMUTABLE PARALLEL SAFE STRICT
+  RETURN replace(public.f_unaccent($1), '''', '');
+
+ALTER TABLE person DROP COLUMN search_tsv;
+ALTER TABLE person ADD COLUMN search_tsv tsvector GENERATED ALWAYS AS (
+  setweight(to_tsvector('simple', f_unaccent(coalesce(full_name,''))), 'A') ||
+  setweight(to_tsvector('simple', f_fold_apostrophes(coalesce(full_name,''))), 'A') ||
+  setweight(to_tsvector('simple', f_unaccent(coalesce(title,''))), 'B') ||
+  setweight(to_tsvector('simple', f_fold_apostrophes(coalesce(title,''))), 'B')
+) STORED;
+CREATE INDEX idx_person_search ON person USING gin (search_tsv);
+DROP INDEX idx_person_name_trgm;
+CREATE INDEX idx_person_name_trgm ON person USING gin (f_fold_apostrophes(lower(full_name)) gin_trgm_ops);
+
+ALTER TABLE organization DROP COLUMN search_tsv;
+ALTER TABLE organization ADD COLUMN search_tsv tsvector GENERATED ALWAYS AS (
+  setweight(to_tsvector('simple', f_unaccent(coalesce(display_name,''))), 'A') ||
+  setweight(to_tsvector('simple', f_fold_apostrophes(coalesce(display_name,''))), 'A') ||
+  setweight(to_tsvector('simple', f_unaccent(coalesce(legal_name,'') || ' ' || coalesce(industry,''))), 'B') ||
+  setweight(to_tsvector('simple', f_fold_apostrophes(coalesce(legal_name,'') || ' ' || coalesce(industry,''))), 'B')
+) STORED;
+CREATE INDEX idx_org_search ON organization USING gin (search_tsv);
+DROP INDEX idx_org_name_trgm;
+CREATE INDEX idx_org_name_trgm ON organization USING gin (f_fold_apostrophes(lower(display_name)) gin_trgm_ops);
+
+ALTER TABLE deal DROP COLUMN search_tsv;
+ALTER TABLE deal ADD COLUMN search_tsv tsvector GENERATED ALWAYS AS (
+  setweight(to_tsvector('simple', f_unaccent(coalesce(name,''))), 'A') ||
+  setweight(to_tsvector('simple', f_fold_apostrophes(coalesce(name,''))), 'A')
+) STORED;
+CREATE INDEX idx_deal_search ON deal USING gin (search_tsv);
+DROP INDEX idx_deal_name_trgm;
+CREATE INDEX idx_deal_name_trgm ON deal USING gin (f_fold_apostrophes(lower(name)) gin_trgm_ops);
+
+ALTER TABLE lead DROP COLUMN search_tsv;
+ALTER TABLE lead ADD COLUMN search_tsv tsvector GENERATED ALWAYS AS (
+  setweight(to_tsvector('simple', f_unaccent(coalesce(full_name,''))), 'A') ||
+  setweight(to_tsvector('simple', f_fold_apostrophes(coalesce(full_name,''))), 'A') ||
+  setweight(to_tsvector('simple', f_unaccent(coalesce(company_name,''))), 'B') ||
+  setweight(to_tsvector('simple', f_fold_apostrophes(coalesce(company_name,''))), 'B') ||
+  setweight(to_tsvector('simple', f_unaccent(coalesce(title,''))), 'B') ||
+  setweight(to_tsvector('simple', f_fold_apostrophes(coalesce(title,''))), 'B')
+) STORED;
+CREATE INDEX idx_lead_search ON lead USING gin (search_tsv);
+DROP INDEX idx_lead_name_trgm;
+CREATE INDEX idx_lead_name_trgm ON lead USING gin (f_fold_apostrophes(lower(coalesce(full_name,'') || ' ' || coalesce(company_name,''))) gin_trgm_ops);
+
+ALTER TABLE activity DROP COLUMN search_tsv;
+ALTER TABLE activity ADD COLUMN search_tsv tsvector GENERATED ALWAYS AS (
+  setweight(to_tsvector('simple', f_unaccent(coalesce(subject,''))), 'A') ||
+  setweight(to_tsvector('simple', f_fold_apostrophes(coalesce(subject,''))), 'A') ||
+  setweight(to_tsvector(activity_ts_config(language), f_unaccent(coalesce(subject,'') || ' ' || coalesce(body,''))), 'B') ||
+  setweight(to_tsvector('simple', f_unaccent(coalesce(body,''))), 'C')
+) STORED;
+CREATE INDEX idx_activity_search ON activity USING gin (search_tsv);


### PR DESCRIPTION
The `simple` FTS parser splits "O'Reilly" into the tokens `o` + `reilly`, so the natural one-token query "oreilly" missed the row in global search, and the list quick-find LIKE compared against the apostrophe-carrying name and missed it the same way.

`f_unaccent` already folds the typographic apostrophes (U+2019, U+02BC) to ASCII `'`, so stripping `'` after unaccent covers every spelling:

- migration 0074 adds `f_fold_apostrophes` and rebuilds the `search_tsv` generated columns on person/organization/deal/lead (and activity subject) to carry both the original tokens (a query "reilly" or "o'reilly" still hits) and the collapsed one, and rebuilds the `*_name_trgm` indexes on the folded expression;
- `storekit.QuickFindClause` folds both sides of the trigram contains-match, mirroring the new index expressions;
- the search store ORs the collapsed parse into the tsquery, so "o'reilly" also finds a row stored without an apostrophe.

Integration coverage: `TestSearchFoldsApostrophesInNames` seeds the typographic apostrophe and asserts all three spellings hit through both the global-search and list quick-find paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search matching for names containing typographic apostrophes.
  * Global search now recognizes equivalent apostrophe styles and related name queries.
  * People quick-find now returns matching records when apostrophes are entered differently.
  * Activity search matching is more consistent across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->