### PR TITLE
fix(dev): inject the BYOK key into block-style ai-routing tiers

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -144,8 +144,22 @@ up)
     set -a; . ./.env.local; set +a
   fi
   if [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
-    sed "s#provider: anthropic, model: \([^ }]*\)#provider: anthropic, model: \1, api_key: ${ANTHROPIC_API_KEY}#g" \
-      "$routing_src" > "$routing"
+    if grep -qE '^[[:space:]]*api_key:' "$routing_src"; then
+      # The engineer bound their own literal keys — their file wins verbatim
+      # (injecting on top would duplicate the api_key mapping key).
+      cp "$routing_src" "$routing"
+    else
+      # Stamp the key under each anthropic tier's model line, at the tier's own
+      # indentation (the block-style shape config/ai-routing.example.yaml ships).
+      awk -v key="${ANTHROPIC_API_KEY}" '
+        { print }
+        /^[[:space:]]*provider:[[:space:]]*anthropic[[:space:]]*$/ { anthropic = 1 }
+        anthropic && /^[[:space:]]*model:/ {
+          print substr($0, 1, index($0, "model:") - 1) "api_key: " key
+          anthropic = 0
+        }
+      ' "$routing_src" > "$routing"
+    fi
     ai_flag=(--ai-routing "$routing")
     echo "dev: using real Anthropic model for the cold-start read-back (key from .env.local)"
   else


### PR DESCRIPTION
## Problem

`make dev` with an `ANTHROPIC_API_KEY` in `.env.local` boots a dead api: the key-injection `sed` in `scripts/dev.sh` only matches inline flow-style tiers (`{provider: anthropic, model: x}`), but the `config/ai-routing.example.yaml` it seeds from ships block-style tiers. The injection silently misses and the api exits with `ai: provider anthropic needs an api key (BYOK — we provide no inference)`.

## Fix

Replace the sed with an awk that stamps `api_key` under each anthropic tier's `model:` line at the tier's own indentation. If the engineer's `config/ai-routing.yaml` already carries a literal `api_key`, it is copied verbatim instead — injecting on top would duplicate the YAML mapping key.

## Verified

- awk output places the key under both anthropic tiers of the shipped example.
- End to end: generated a scratch routing from `config/ai-routing.example.yaml` with a real key and booted `cmd/api` against it — `/readyz` 200 (the exact path that previously died at boot).
- Backend gate green locally; the frontend vitest lane fails on this machine on unmodified `main` too (local Node 26 vs CI's Node 22 — `localStorage` global), unrelated to this script-only diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)