### PR TITLE
fix(frontend): rebind jsdom Web Storage over the Node >=23 global stub

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -26,6 +26,8 @@ export default defineConfig({
   },
   test: {
     environment: "node",
+    // Rebinds jsdom's Web Storage over the Node ≥23 global stub — see the file.
+    setupFiles: ["./vitest.setup.ts"],
     // Playwright owns e2e/ — vitest must not collect its specs
     exclude: ["**/node_modules/**", "e2e/**"],
   },

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -1,0 +1,23 @@
+// Node ≥23 ships its own global Web Storage: a `localStorage` getter that
+// yields undefined unless the process was started with --localstorage-file.
+// Because the key already exists on the Node global, vitest's populateGlobal
+// keeps it instead of copying jsdom's Storage onto the test global (only keys
+// on vitest's own KEYS allowlist override an existing global, and the storage
+// keys are not on it). Tests in the jsdom environment then see undefined —
+// while a runtime without the Node global (Node 22, today's CI) gets jsdom's
+// working Storage and passes. Rebind the real jsdom Storage whenever the test
+// global disagrees with the jsdom window, so both runtimes behave like CI.
+const jsdomHost: { jsdom?: { window?: Record<string, unknown> } } = globalThis;
+const jsdomWindow = jsdomHost.jsdom?.window;
+
+if (jsdomWindow) {
+	for (const key of ["localStorage", "sessionStorage"]) {
+		const testGlobal: Record<string, unknown> = globalThis;
+		if (testGlobal[key] !== jsdomWindow[key]) {
+			Object.defineProperty(globalThis, key, {
+				get: () => jsdomWindow[key],
+				configurable: true,
+			});
+		}
+	}
+}


### PR DESCRIPTION
## Problem

The frontend vitest lane fails with 138 test failures on any machine running Node ≥23 (`localStorage is undefined`), while CI's Node 22 is green — so local `make check` can't go green on a current Node.

Root cause: Node ≥23 ships a global `localStorage` getter that yields undefined unless the process runs with `--localstorage-file`. Because the key already exists on the Node global, vitest's `populateGlobal` keeps it instead of copying jsdom's Storage onto the test global — only keys on vitest's hardcoded KEYS allowlist may override an existing global, and the storage keys are not on it (and the jsdom environment doesn't plumb `additionalKeys` through). Every `@vitest-environment jsdom` test touching `localStorage` then reads Node's undefined stub.

## Fix

A vitest `setupFiles` shim that rebinds the real jsdom window's Storage onto the test global whenever the two disagree. On a runtime where vitest already copied jsdom's Storage (Node 22 CI) it is a no-op; in the node environment (no jsdom global) it is a no-op.

## Verified

- Full suite 500/500 green under Node 26.4 **and** Node 22.23 (CI runtime).
- `make frontend-check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test reliability by ensuring browser-style local and session storage work consistently across supported Node.js runtimes.
  * Prevented conflicts between the test environment and built-in Node.js storage implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->