### PR TITLE
perf(integration-tests): migrate compose/integration schema once per process

### DIFF
--- a/backend/integrationmigrateonce_test.go
+++ b/backend/integrationmigrateonce_test.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package backendarch
+
+// Migrate-once discipline for the compose/integration suites as a fitness
+// function. The package migrates the schema exactly once per test process
+// (internal/platform/testdb.EnsureSchema) and resets between tests with a fast
+// TRUNCATE (testdb.Truncate); a suite that instead runs its own DROP SCHEMA +
+// dbmigrate.Up on every setup silently reintroduces the ~0.8s-per-test migrate
+// that once dominated the lane. The obligation is derived from the tree — any
+// new *_test.go in the package that calls dbmigrate.Up is caught here — so the
+// pattern cannot creep back one copy-pasted setup at a time.
+//
+// perfbench is the one sanctioned exception: it seeds a large volume and asserts
+// query-latency SLOs, so it wants pristine physical tables (no bloat or stale
+// planner stats from prior TRUNCATE cycles) and pays a genuine fresh migrate. It
+// runs once, so the cost it opts back into is negligible.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The directory whose integration suites must ride the shared migrate-once
+// harness, and the one file allowed to migrate inline within it.
+const (
+	integrationSuiteDir    = "internal/compose/integration"
+	perfbenchExceptionFile = "perfbench_integration_test.go"
+)
+
+func TestComposeIntegrationSuitesMigrateOncePerProcess(t *testing.T) {
+	entries, err := os.ReadDir(integrationSuiteDir)
+	if err != nil {
+		t.Fatalf("reading %s: %v", integrationSuiteDir, err)
+	}
+	var offenders []string
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, "_test.go") || name == perfbenchExceptionFile {
+			continue
+		}
+		path := filepath.Join(integrationSuiteDir, name)
+		b, err := os.ReadFile(path) // #nosec G304 -- path is a *_test.go file from the trusted source tree
+		if err != nil {
+			t.Fatalf("reading %s: %v", path, err)
+		}
+		// dbmigrate.Up is the migrate entry point; a call to it (open paren,
+		// never prose) in a suite setup is an inline per-test migration.
+		if strings.Contains(string(b), "dbmigrate.Up(") {
+			offenders = append(offenders, name)
+		}
+	}
+	if len(offenders) > 0 {
+		t.Errorf("%d compose/integration suite(s) migrate inline instead of riding testdb.EnsureSchema — "+
+			"replace the DROP SCHEMA + dbmigrate.Up block with testdb.EnsureSchema + testdb.Truncate (see harness.go):\n\t%s",
+			len(offenders), strings.Join(offenders, "\n\t"))
+	}
+
+	// The allowlist must stay live: if perfbench is ever converted to the
+	// shared harness too, its carve-out here becomes dead config that would
+	// silently re-admit an inline migrator. Fail so the exception is removed
+	// rather than left to rot (rule 2 — derive the obligation from the system).
+	perfbench, err := os.ReadFile(filepath.Join(integrationSuiteDir, perfbenchExceptionFile)) // #nosec G304 -- fixed in-tree source path
+	if err != nil {
+		t.Fatalf("reading %s: %v", perfbenchExceptionFile, err)
+	}
+	if !strings.Contains(string(perfbench), "dbmigrate.Up(") {
+		t.Errorf("%s no longer migrates inline — drop it from the migrate-once allowlist (perfbenchExceptionFile)", perfbenchExceptionFile)
+	}
+}

--- a/backend/internal/compose/integration/ai_meter_integration_test.go
+++ b/backend/internal/compose/integration/ai_meter_integration_test.go
@@ -20,14 +20,14 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/modules/ai"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
-	"github.com/gradionhq/margince/backend/internal/platform/dbmigrate"
+	"github.com/gradionhq/margince/backend/internal/platform/testdb"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
-	"github.com/gradionhq/margince/backend/migrations"
 )
 
-// meterFreshDatabase resets and migrates the schema through the owner
-// role, returning the owner connection and the RLS-bound app DSN.
+// meterFreshDatabase resets the data to a clean slate and ensures the schema is
+// migrated (once per process, then a fast TRUNCATE — see package testdb),
+// returning the owner connection and the RLS-bound app DSN.
 func meterFreshDatabase(t *testing.T, ctx context.Context) (*pgx.Conn, string) {
 	t.Helper()
 	ownerDSN := os.Getenv("MARGINCE_TEST_DSN")
@@ -44,19 +44,11 @@ func meterFreshDatabase(t *testing.T, ctx context.Context) (*pgx.Conn, string) {
 			t.Errorf("closing owner connection: %v", err)
 		}
 	})
-	if _, err := owner.Exec(ctx, `DROP SCHEMA public CASCADE; CREATE SCHEMA public; GRANT USAGE ON SCHEMA public TO margince_app`); err != nil {
-		t.Fatalf("resetting schema: %v", err)
+	if err := testdb.EnsureSchema(ctx, owner); err != nil {
+		t.Fatalf("migrating schema: %v", err)
 	}
-	core, err := migrations.Core()
-	if err != nil {
-		t.Fatal(err)
-	}
-	custom, err := migrations.Custom()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, err := dbmigrate.Up(ctx, owner, core, custom); err != nil {
-		t.Fatalf("migrating: %v", err)
+	if err := testdb.Truncate(ctx, owner); err != nil {
+		t.Fatalf("resetting database: %v", err)
 	}
 	return owner, appDSN
 }

--- a/backend/internal/compose/integration/e2e_integration_test.go
+++ b/backend/internal/compose/integration/e2e_integration_test.go
@@ -28,8 +28,7 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/compose"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
-	"github.com/gradionhq/margince/backend/internal/platform/dbmigrate"
-	"github.com/gradionhq/margince/backend/migrations"
+	"github.com/gradionhq/margince/backend/internal/platform/testdb"
 )
 
 type env struct {
@@ -72,19 +71,11 @@ func setupWithOptions(t *testing.T, opts ...compose.Option) *env {
 		}
 	})
 
-	if _, err := owner.Exec(ctx, `DROP SCHEMA public CASCADE; CREATE SCHEMA public; GRANT USAGE ON SCHEMA public TO margince_app`); err != nil {
-		t.Fatalf("resetting schema: %v", err)
+	if err := testdb.EnsureSchema(ctx, owner); err != nil {
+		t.Fatalf("migrating schema: %v", err)
 	}
-	core, err := migrations.Core()
-	if err != nil {
-		t.Fatalf("loading migrations: %v", err)
-	}
-	custom, err := migrations.Custom()
-	if err != nil {
-		t.Fatalf("loading custom migrations: %v", err)
-	}
-	if _, err := dbmigrate.Up(ctx, owner, core, custom); err != nil {
-		t.Fatalf("migrating: %v", err)
+	if err := testdb.Truncate(ctx, owner); err != nil {
+		t.Fatalf("resetting database: %v", err)
 	}
 
 	pool, err := database.NewPool(ctx, appDSN)

--- a/backend/internal/compose/integration/passports_integration_test.go
+++ b/backend/internal/compose/integration/passports_integration_test.go
@@ -21,10 +21,9 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
-	"github.com/gradionhq/margince/backend/internal/platform/dbmigrate"
+	"github.com/gradionhq/margince/backend/internal/platform/testdb"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
-	"github.com/gradionhq/margince/backend/migrations"
 )
 
 type passportsEnv struct {
@@ -52,18 +51,10 @@ func setupPassports(t *testing.T) *passportsEnv {
 			t.Errorf("closing owner connection: %v", err)
 		}
 	})
-	if _, err := owner.Exec(ctx, `DROP SCHEMA public CASCADE; CREATE SCHEMA public; GRANT USAGE ON SCHEMA public TO margince_app`); err != nil {
+	if err := testdb.EnsureSchema(ctx, owner); err != nil {
 		t.Fatal(err)
 	}
-	core, err := migrations.Core()
-	if err != nil {
-		t.Fatal(err)
-	}
-	custom, err := migrations.Custom()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, err := dbmigrate.Up(ctx, owner, core, custom); err != nil {
+	if err := testdb.Truncate(ctx, owner); err != nil {
 		t.Fatal(err)
 	}
 

--- a/backend/internal/compose/integration/perfbench_integration_test.go
+++ b/backend/internal/compose/integration/perfbench_integration_test.go
@@ -56,8 +56,15 @@ var benchTiers = map[search.BenchTier]benchTierSpec{
 	},
 }
 
-// benchDatabase connects as owner, resets the schema, and migrates —
-// the fresh-database arrange step the benchmark shares with setup.
+// benchDatabase connects as owner, resets the schema, and migrates. This is
+// the ONE compose/integration suite that migrates inline instead of riding the
+// shared migrate-once harness (testdb.EnsureSchema + Truncate) — it seeds a
+// large volume and asserts query-latency SLOs, so it wants pristine physical
+// tables (fresh relfilenodes, no bloat or stale planner stats a prior TRUNCATE
+// cycle would leave) and pays a genuine fresh migrate. It runs once per tier, so
+// the cost is negligible. The migrate-once guard
+// (TestComposeIntegrationSuitesMigrateOncePerProcess) allowlists this file for
+// exactly that reason; no other suite may follow suit.
 func benchDatabase(t *testing.T) *pgx.Conn {
 	t.Helper()
 	ownerDSN := os.Getenv("MARGINCE_TEST_DSN")

--- a/backend/internal/compose/integration/rls_coverage_integration_test.go
+++ b/backend/internal/compose/integration/rls_coverage_integration_test.go
@@ -19,13 +19,13 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
-	"github.com/gradionhq/margince/backend/internal/platform/dbmigrate"
-	"github.com/gradionhq/margince/backend/migrations"
+	"github.com/gradionhq/margince/backend/internal/platform/testdb"
 )
 
-// freshlyMigratedOwner connects as owner, resets the schema, and
-// migrates — the schema-derivation arrange step, needing only the owner
-// DSN (no app pool is involved in a coverage sweep).
+// freshlyMigratedOwner connects as owner and returns a clean, migrated schema
+// (migrated once per process, then reset with a fast TRUNCATE — see package
+// testdb) — the schema-derivation arrange step, needing only the owner DSN (no
+// app pool is involved in a coverage sweep).
 func freshlyMigratedOwner(t *testing.T) *pgx.Conn {
 	t.Helper()
 	ownerDSN := os.Getenv("MARGINCE_TEST_DSN")
@@ -42,19 +42,11 @@ func freshlyMigratedOwner(t *testing.T) *pgx.Conn {
 			t.Errorf("closing owner connection: %v", err)
 		}
 	})
-	if _, err := owner.Exec(ctx, `DROP SCHEMA public CASCADE; CREATE SCHEMA public; GRANT USAGE ON SCHEMA public TO margince_app`); err != nil {
-		t.Fatalf("resetting schema: %v", err)
+	if err := testdb.EnsureSchema(ctx, owner); err != nil {
+		t.Fatalf("migrating schema: %v", err)
 	}
-	core, err := migrations.Core()
-	if err != nil {
-		t.Fatal(err)
-	}
-	custom, err := migrations.Custom()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, err := dbmigrate.Up(ctx, owner, core, custom); err != nil {
-		t.Fatalf("migrating: %v", err)
+	if err := testdb.Truncate(ctx, owner); err != nil {
+		t.Fatalf("resetting database: %v", err)
 	}
 	return owner
 }

--- a/backend/internal/compose/integration/search_integration_test.go
+++ b/backend/internal/compose/integration/search_integration_test.go
@@ -23,10 +23,9 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/modules/search"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
-	"github.com/gradionhq/margince/backend/internal/platform/dbmigrate"
+	"github.com/gradionhq/margince/backend/internal/platform/testdb"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
-	"github.com/gradionhq/margince/backend/migrations"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -58,18 +57,10 @@ func setupSearch(t *testing.T) *searchEnv {
 			t.Errorf("closing owner connection: %v", err)
 		}
 	})
-	if _, err := owner.Exec(ctx, `DROP SCHEMA public CASCADE; CREATE SCHEMA public; GRANT USAGE ON SCHEMA public TO margince_app`); err != nil {
+	if err := testdb.EnsureSchema(ctx, owner); err != nil {
 		t.Fatal(err)
 	}
-	core, err := migrations.Core()
-	if err != nil {
-		t.Fatal(err)
-	}
-	custom, err := migrations.Custom()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, err := dbmigrate.Up(ctx, owner, core, custom); err != nil {
+	if err := testdb.Truncate(ctx, owner); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
## What

The `compose/integration` suites re-migrated the schema (`DROP SCHEMA` + full `dbmigrate.Up`, ~0.8s) on **every** setup call — roughly 120 migrations that dominated the package and, since it's the slowest package in the lane, the whole integration lane's critical path.

This routes the five inline migrators (`e2e`, `search`, `passports`, `ai_meter`, `rls_coverage`) through the shared migrate-once helper `testdb.EnsureSchema` + `testdb.Truncate` that `harness.go` already uses: **one** migrate per process, then a millisecond `TRUNCATE` per test.

`perfbench` keeps its own inline migrate as a documented carve-out — its query-latency SLO wants pristine physical tables (fresh relfilenodes, no planner-stat bloat from prior `TRUNCATE` cycles), and it runs once so the cost is negligible.

## Guard

A `backendarch` fitness test (`TestComposeIntegrationSuitesMigrateOncePerProcess`) fails if any integration suite reintroduces inline `dbmigrate.Up`, and also fails if `perfbench` stops migrating inline — so the allowlist entry can't rot into dead config. It runs in the fast `make check` lane (no DB needed).

## Correctness

`Truncate` ≡ fresh-migrate for these suites: no migration seeds test-relevant data (the only data-touching migration is a `person_social` backfill that's a no-op on an empty table), and leaked `cf_` columns are dropped on reset. This is the same guarantee the existing shared harness already relied on. RLS policies/FORCE flags and `workspace_id` columns are schema DDL that `TRUNCATE` never touches, so `rls_coverage`'s FORCE-RLS fitness assertion and `ai_meter`'s cross-tenant invisibility assertion keep their full teeth.

## Measured

`compose/integration` on a throwaway clone: **101s → 64s (~37% faster)**.

## Local gates (all green)

- `make check-backend` — build, vet, lint, arch-lint, unit + fitness, contract drift, root script gates
- `make test-integration` — `OK: integration passed with 0 skips (15 packages, parallel)`
- `craft static` (pre-push), gofmt/license (pre-commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved integration test setup by reusing shared database preparation and reset utilities.
  * Added coverage to ensure integration suites perform database migrations only once per test process.
  * Preserved benchmark-specific migration behavior with an explicit validation and explanation.
  * Existing integration test scenarios and assertions remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->