### PR TITLE
feat(capture): Gmail push-watch register + renewal (CAP-DDL-2)

### DIFF
--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -57,19 +57,22 @@ func main() {
 
 // workerConfig is the parsed boot configuration of the worker process.
 type workerConfig struct {
-	dsn               string
-	redisAddr         string
-	routingPath       string
-	fakeBrain         bool
-	runnerInterval    time.Duration
-	retentionInterval time.Duration
-	closeDateInterval time.Duration
-	reconcileInterval time.Duration
-	gmailClientID     string
-	gmailClientSecret string
-	gmailSyncInterval time.Duration
-	logLevel          string
-	logFormat         string
+	dsn                string
+	redisAddr          string
+	routingPath        string
+	fakeBrain          bool
+	runnerInterval     time.Duration
+	retentionInterval  time.Duration
+	closeDateInterval  time.Duration
+	reconcileInterval  time.Duration
+	gmailClientID      string
+	gmailClientSecret  string
+	gmailSyncInterval  time.Duration
+	gmailPubsubTopic   string
+	gmailWatchInterval time.Duration
+	gmailWatchRenew    time.Duration
+	logLevel           string
+	logFormat          string
 }
 
 // parseWorkerFlags parses and validates the boot flags; the DSN is the
@@ -89,6 +92,9 @@ func parseWorkerFlags(args []string) (workerConfig, error) {
 	fs.StringVar(&cfg.gmailClientID, "gmail-client-id", os.Getenv("MARGINCE_GMAIL_CLIENT_ID"), "Google OAuth client id for the Gmail capture connector; enables the background Gmail sync poll")
 	fs.StringVar(&cfg.gmailClientSecret, "gmail-client-secret", os.Getenv("MARGINCE_GMAIL_CLIENT_SECRET"), "Google OAuth client secret for the Gmail capture connector")
 	fs.DurationVar(&cfg.gmailSyncInterval, "gmail-sync-interval", 2*time.Minute, "Gmail incremental-sync poll interval")
+	fs.StringVar(&cfg.gmailPubsubTopic, "gmail-pubsub-topic", os.Getenv("MARGINCE_GMAIL_PUBSUB_TOPIC"), "Gmail Pub/Sub topic (projects/<p>/topics/<t>); enables the push-watch register+renew job. Empty leaves capture on the poll.")
+	fs.DurationVar(&cfg.gmailWatchInterval, "gmail-watch-interval", 6*time.Hour, "Gmail push-watch maintenance scan interval")
+	fs.DurationVar(&cfg.gmailWatchRenew, "gmail-watch-renew-within", 48*time.Hour, "renew a Gmail watch this far ahead of its 7-day expiry")
 	fs.StringVar(&cfg.logLevel, "log-level", envOr("MARGINCE_LOG_LEVEL", "info"), "log level: debug|info|warn|error")
 	fs.StringVar(&cfg.logFormat, "log-format", envOr("MARGINCE_LOG_FORMAT", "text"), "log format: text|json")
 	if err := fs.Parse(args); err != nil {
@@ -232,7 +238,16 @@ func startJobRunner(ctx context.Context, pool *pgxpool.Pool, logger *slog.Logger
 			ClientSecret: cfg.gmailClientSecret,
 		})
 	}
-	runner, err := compose.NewJobRunner(pool, logger, cfg.closeDateInterval, cfg.reconcileInterval, gmailReg, cfg.gmailSyncInterval)
+	watchCfg := compose.GmailWatchConfig{
+		Interval:    cfg.gmailWatchInterval,
+		RenewWithin: cfg.gmailWatchRenew,
+	}
+	// The watch job only runs where a Pub/Sub topic is configured AND the Gmail
+	// app is wired (gmailReg != nil); otherwise capture stays on the poll.
+	if gmailReg != nil {
+		watchCfg.Topic = cfg.gmailPubsubTopic
+	}
+	runner, err := compose.NewJobRunner(pool, logger, cfg.closeDateInterval, cfg.reconcileInterval, gmailReg, cfg.gmailSyncInterval, watchCfg)
 	if err != nil {
 		return nil, err
 	}
@@ -240,8 +255,11 @@ func startJobRunner(ctx context.Context, pool *pgxpool.Pool, logger *slog.Logger
 		return nil, err
 	}
 	gmailNote := "gmail sync off (unconfigured)"
-	if gmailReg != nil {
-		gmailNote = fmt.Sprintf("gmail sync every %s", cfg.gmailSyncInterval)
+	switch {
+	case gmailReg != nil && watchCfg.Topic != "":
+		gmailNote = fmt.Sprintf("gmail sync every %s, watch renew every %s", cfg.gmailSyncInterval, cfg.gmailWatchInterval)
+	case gmailReg != nil:
+		gmailNote = fmt.Sprintf("gmail sync every %s (watch off: no pubsub topic)", cfg.gmailSyncInterval)
 	}
 	_, _ = fmt.Fprintf(stdout, "worker running River jobs (close-date every %s, reconcile every %s, %s)\n",
 		cfg.closeDateInterval, cfg.reconcileInterval, gmailNote)

--- a/backend/internal/compose/connectors_wiring_test.go
+++ b/backend/internal/compose/connectors_wiring_test.go
@@ -53,6 +53,9 @@ func (stubGmailAPI) History(context.Context, string, string) ([]string, string, 
 	return nil, "1", nil
 }
 func (stubGmailAPI) GetRaw(context.Context, string, string) ([]byte, error) { return nil, nil }
+func (stubGmailAPI) Watch(context.Context, string, string) (string, time.Time, error) {
+	return "1", time.Time{}, nil
+}
 
 // The account-linking-CSRF defence: the callback must have the oauth_csrf
 // cookie matching the nonce in the signed state before it exchanges the code.

--- a/backend/internal/compose/integration/gmail_connector_integration_test.go
+++ b/backend/internal/compose/integration/gmail_connector_integration_test.go
@@ -18,7 +18,9 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 
@@ -46,6 +48,12 @@ func gmailStub(t *testing.T, owner string) *httptest.Server {
 	})
 	mux.HandleFunc("/messages", func(w http.ResponseWriter, _ *http.Request) {
 		writeJSON(w, map[string]any{"messages": []map[string]string{{"id": "m1"}}})
+	})
+	mux.HandleFunc("/watch", func(w http.ResponseWriter, _ *http.Request) {
+		// A watch that expires 7 days out (Gmail's cap), as the ms-since-epoch
+		// string Gmail returns — so a renewed connection is no longer "due".
+		exp := time.Now().Add(7 * 24 * time.Hour).UnixMilli()
+		writeJSON(w, map[string]any{"historyId": "1001", "expiration": strconv.FormatInt(exp, 10)})
 	})
 	mux.HandleFunc("/messages/m1", func(w http.ResponseWriter, _ *http.Request) {
 		rfc822 := "From: Alice <alice@acme.com>\r\n" +

--- a/backend/internal/compose/integration/gmail_watch_integration_test.go
+++ b/backend/internal/compose/integration/gmail_watch_integration_test.go
@@ -109,7 +109,11 @@ func TestGmailWatchRegistersRenewsAndLeavesCursor(t *testing.T) {
 	if err := registry.Disconnect(grantCtx, "gmail"); err != nil {
 		t.Fatalf("Disconnect: %v", err)
 	}
-	if d, _ := registry.DueWatches(context.Background(), "gmail", 365*24*time.Hour); len(d) != 0 {
+	d, err := registry.DueWatches(context.Background(), "gmail", 365*24*time.Hour)
+	if err != nil {
+		t.Fatalf("DueWatches after disconnect: %v", err)
+	}
+	if len(d) != 0 {
 		t.Fatalf("DueWatches after disconnect = %+v, want empty", d)
 	}
 }

--- a/backend/internal/compose/integration/gmail_watch_integration_test.go
+++ b/backend/internal/compose/integration/gmail_watch_integration_test.go
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The Gmail push-watch lifecycle against a stubbed Google: the registry's
+// fleet-wide DueWatches scan selects a connection whose watch is missing or
+// nearing expiry, and RenewWatch registers a users.watch and stores the
+// returned expiration in capture_connection.watch_expires_at (CAP-DDL-2). It
+// asserts the two boundary decisions of the slice: the renewal writes the
+// deadline the scan keys on, and it does NOT disturb the sync_cursor (which
+// SyncOnce owns — anchoring it from the watch would suppress the first-sync
+// backfill).
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/riverqueue/river"
+
+	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/modules/capture/gmail"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/platform/jobs"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+const gmailPushTopic = "projects/margince/topics/gmail-push"
+
+func TestGmailWatchRegistersRenewsAndLeavesCursor(t *testing.T) {
+	e := setupSearch(t)
+	const owner = "rep@ws.example"
+	stub := gmailStub(t, owner)
+
+	oauth := gmail.NewOAuth(gmail.OAuthConfig{ClientID: "cid", ClientSecret: "sec", TokenURL: stub.URL + "/token"})
+	api := gmail.NewAPI(stub.Client(), stub.URL)
+
+	registry := newTestCaptureRegistry(e, newTestKeyvault(t, e))
+	registry.Register(gmail.New(oauth, api))
+
+	grantCtx := e.humanWithScopes(e.Rep1, []principal.Scope{principal.ScopeRead})
+
+	authReq, err := gmail.AuthRequestFrom("the-code", "https://app.test/v1/connectors/gmail/callback")
+	if err != nil {
+		t.Fatal(err)
+	}
+	auth, err := gmail.New(oauth, api).Authenticate(context.Background(), authReq)
+	if err != nil {
+		t.Fatalf("Authenticate: %v", err)
+	}
+	connID, err := registry.Connect(grantCtx, "gmail", auth)
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+
+	// A sync first, so the connection carries a real cursor the watch must not
+	// clobber.
+	if err := registry.SyncOnce(grantCtx, connID); err != nil {
+		t.Fatalf("SyncOnce: %v", err)
+	}
+	cursorBefore := readCursor(t, e, connID)
+	if len(cursorBefore) == 0 {
+		t.Fatalf("precondition: expected a cursor after the first sync, got none")
+	}
+
+	// A just-connected connection has watch_expires_at NULL, so it is due for
+	// an initial watch regardless of the renewal threshold.
+	due, err := registry.DueWatches(context.Background(), "gmail", 48*time.Hour)
+	if err != nil {
+		t.Fatalf("DueWatches: %v", err)
+	}
+	if len(due) != 1 || due[0].ID != connID {
+		t.Fatalf("DueWatches (never-watched) = %+v, want the one connection %s", due, connID)
+	}
+
+	// Register the watch: it must store the expiration and leave the cursor.
+	if err := registry.RenewWatch(grantCtx, connID, gmailPushTopic); err != nil {
+		t.Fatalf("RenewWatch: %v", err)
+	}
+	exp := readWatchExpiry(t, e, connID)
+	if exp == nil {
+		t.Fatalf("watch_expires_at was not stored")
+	}
+	if !exp.After(time.Now()) {
+		t.Errorf("watch_expires_at = %v, want a future deadline", exp)
+	}
+	if got := readCursor(t, e, connID); string(got) != string(cursorBefore) {
+		t.Errorf("sync_cursor changed by the watch: before=%q after=%q (watch must not touch the cursor)", cursorBefore, got)
+	}
+
+	// A watch renewed 7 days out is no longer within a 48h renewal window.
+	due2, err := registry.DueWatches(context.Background(), "gmail", 48*time.Hour)
+	if err != nil {
+		t.Fatalf("DueWatches after renewal: %v", err)
+	}
+	if len(due2) != 0 {
+		t.Fatalf("DueWatches after renewal = %+v, want empty (watch not near expiry)", due2)
+	}
+
+	// A disconnected connection is never selected (the scan mirrors the poll).
+	if err := registry.Disconnect(grantCtx, "gmail"); err != nil {
+		t.Fatalf("Disconnect: %v", err)
+	}
+	if d, _ := registry.DueWatches(context.Background(), "gmail", 365*24*time.Hour); len(d) != 0 {
+		t.Fatalf("DueWatches after disconnect = %+v, want empty", d)
+	}
+}
+
+// TestGmailWatchJobRenewsOnSchedule proves the wiring end to end: booting the
+// worker's River job runner with a Pub/Sub topic configured registers/renews
+// the watch on RunOnStart and writes watch_expires_at — the scheduled path,
+// not a direct RenewWatch call.
+func TestGmailWatchJobRenewsOnSchedule(t *testing.T) {
+	e := setupSearch(t)
+	applyRiverSchema(t)
+	const owner = "rep@ws.example"
+	stub := gmailStub(t, owner)
+
+	oauth := gmail.NewOAuth(gmail.OAuthConfig{ClientID: "cid", ClientSecret: "sec", TokenURL: stub.URL + "/token"})
+	api := gmail.NewAPI(stub.Client(), stub.URL)
+
+	registry := newTestCaptureRegistry(e, newTestKeyvault(t, e))
+	registry.Register(gmail.New(oauth, api))
+
+	grantCtx := e.humanWithScopes(e.Rep1, []principal.Scope{principal.ScopeRead})
+	authReq, err := gmail.AuthRequestFrom("the-code", "https://app.test/v1/connectors/gmail/callback")
+	if err != nil {
+		t.Fatal(err)
+	}
+	auth, err := gmail.New(oauth, api).Authenticate(context.Background(), authReq)
+	if err != nil {
+		t.Fatalf("Authenticate: %v", err)
+	}
+	connID, err := registry.Connect(grantCtx, "gmail", auth)
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+
+	quiet := slog.New(slog.NewTextHandler(io.Discard, nil))
+	runner, err := compose.NewJobRunner(e.Pool, quiet, time.Hour, time.Hour, registry, time.Hour,
+		compose.GmailWatchConfig{Topic: gmailPushTopic, Interval: time.Hour, RenewWithin: 48 * time.Hour})
+	if err != nil {
+		t.Fatalf("NewJobRunner: %v", err)
+	}
+	sub, cancelSub := runner.SubscribeCompleted()
+	defer cancelSub()
+
+	ctx := context.Background()
+	if err := runner.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := runner.Stop(stopCtx); err != nil {
+			t.Errorf("Stop: %v", err)
+		}
+	}()
+
+	waitCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	awaitWatchKindCompleted(waitCtx, t, sub, compose.GmailWatchArgs{}.Kind())
+
+	if exp := readWatchExpiry(t, e, connID); exp == nil || !exp.After(time.Now()) {
+		t.Fatalf("scheduled watch job did not set a future watch_expires_at: %v", exp)
+	}
+}
+
+// applyRiverSchema layers River's schema onto the harness-migrated database,
+// exactly as cmd/migrate does after core+custom.
+func applyRiverSchema(t *testing.T) {
+	t.Helper()
+	ownerDSN := os.Getenv("MARGINCE_TEST_DSN")
+	if ownerDSN == "" {
+		t.Fatal("MARGINCE_TEST_DSN not set — run `make db-up`")
+	}
+	ctx := context.Background()
+	ownerPool, err := database.NewPool(ctx, ownerDSN)
+	if err != nil {
+		t.Fatalf("opening owner pool: %v", err)
+	}
+	defer ownerPool.Close()
+	if _, err := jobs.Migrate(ctx, ownerPool); err != nil {
+		t.Fatalf("applying river schema: %v", err)
+	}
+}
+
+// awaitWatchKindCompleted blocks until a job of the given kind reports
+// completion, or the context deadline fires. No polling, no sleep.
+func awaitWatchKindCompleted(ctx context.Context, t *testing.T, sub <-chan *river.Event, kind string) {
+	t.Helper()
+	for {
+		select {
+		case <-ctx.Done():
+			t.Fatalf("timed out waiting for %q to complete: %v", kind, ctx.Err())
+		case ev := <-sub:
+			if ev != nil && ev.Job != nil && ev.Job.Kind == kind {
+				return
+			}
+		}
+	}
+}
+
+func readCursor(t *testing.T, e *searchEnv, connID ids.UUID) []byte {
+	t.Helper()
+	var cursor []byte
+	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT sync_cursor FROM capture_connection WHERE id = $1`, connID).Scan(&cursor)
+	})
+	if err != nil {
+		t.Fatalf("reading sync_cursor: %v", err)
+	}
+	return cursor
+}
+
+func readWatchExpiry(t *testing.T, e *searchEnv, connID ids.UUID) *time.Time {
+	t.Helper()
+	var exp *time.Time
+	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT watch_expires_at FROM capture_connection WHERE id = $1`, connID).Scan(&exp)
+	})
+	if err != nil {
+		t.Fatalf("reading watch_expires_at: %v", err)
+	}
+	return exp
+}

--- a/backend/internal/compose/jobs.go
+++ b/backend/internal/compose/jobs.go
@@ -58,6 +58,16 @@ func (w *followUpReconcileWorker) Work(ctx context.Context, _ *river.Job[FollowU
 	return w.reconciler.Reconcile(ctx)
 }
 
+// GmailWatchConfig configures the Gmail push-watch maintenance pass. Topic is
+// the Pub/Sub topic Gmail publishes change notifications to (empty disables the
+// pass entirely — capture stays on the poll); Interval is the scan cadence; and
+// RenewWithin is how far ahead of a watch's expiry it is re-registered.
+type GmailWatchConfig struct {
+	Topic       string
+	Interval    time.Duration
+	RenewWithin time.Duration
+}
+
 // GmailSyncArgs schedules one incremental-sync pass over every active Gmail
 // connection (capture.md CAP-WIRE-N-1: capture rides provider delta, driven
 // here by a poll rather than a push watch in this slice).
@@ -82,6 +92,42 @@ func (w *gmailSyncWorker) Work(ctx context.Context, _ *river.Job[GmailSyncArgs])
 		wsCtx := principal.WithWorkspaceID(ctx, d.Workspace.UUID)
 		if err := w.registry.SyncOnce(wsCtx, d.ID); err != nil {
 			w.log.WarnContext(ctx, "gmail connection sync failed", "connection", d.ID.String(), "err", err)
+		}
+	}
+	return enumErr
+}
+
+// GmailWatchArgs schedules one push-watch maintenance pass: register a Gmail
+// users.watch for every active connection that has none yet and renew any
+// nearing its 7-day expiry (capture.md CAP-DDL-2). Scheduled only when a
+// Pub/Sub topic is configured; without one, no watch job runs and capture stays
+// on the poll (GmailSyncArgs).
+type GmailWatchArgs struct{}
+
+// Kind is the stable job identifier River persists in river_job.
+func (GmailWatchArgs) Kind() string { return "gmail_watch_renew" }
+
+// gmailWatchWorker walks the fleet's active Gmail connections whose watch is
+// missing or nearing expiry and registers/renews each against the configured
+// Pub/Sub topic, advancing watch_expires_at. One connection's failure is logged
+// and skipped (a revoked mailbox must not force the whole pass to retry); only a
+// fleet-enumeration failure is returned (so River retries the tick). It mirrors
+// gmailSyncWorker — the same DueConnections-shaped walk, keyed on the renewal
+// deadline instead of the sync cursor.
+type gmailWatchWorker struct {
+	river.WorkerDefaults[GmailWatchArgs]
+	registry    *capture.Registry
+	topic       string
+	renewWithin time.Duration
+	log         *slog.Logger
+}
+
+func (w *gmailWatchWorker) Work(ctx context.Context, _ *river.Job[GmailWatchArgs]) error {
+	due, enumErr := w.registry.DueWatches(ctx, "gmail", w.renewWithin)
+	for _, d := range due {
+		wsCtx := principal.WithWorkspaceID(ctx, d.Workspace.UUID)
+		if err := w.registry.RenewWatch(wsCtx, d.ID, w.topic); err != nil {
+			w.log.WarnContext(ctx, "gmail watch renewal failed", "connection", d.ID.String(), "err", err)
 		}
 	}
 	return enumErr
@@ -114,8 +160,11 @@ func sweepInsertOpts() *river.InsertOpts {
 //
 // When gmailReg is non-nil (the deployment configured the Gmail OAuth app),
 // a Gmail incremental-sync poll is added on gmailInterval — leader-elected
-// like the sweeps, so replicas never double-poll.
-func NewJobRunner(pool *pgxpool.Pool, log *slog.Logger, closeDateInterval, reconcileInterval time.Duration, gmailReg *capture.Registry, gmailInterval time.Duration) (*jobs.Runner, error) {
+// like the sweeps, so replicas never double-poll. When a Pub/Sub topic is also
+// configured (watch.Topic != ""), a push-watch maintenance pass is added on
+// watch.Interval that registers/renews Gmail watches nearing expiry; without a
+// topic the watch job is absent by omission and capture stays on the poll.
+func NewJobRunner(pool *pgxpool.Pool, log *slog.Logger, closeDateInterval, reconcileInterval time.Duration, gmailReg *capture.Registry, gmailInterval time.Duration, watch GmailWatchConfig) (*jobs.Runner, error) {
 	workers := river.NewWorkers()
 	river.AddWorker(workers, &closeDateSweepWorker{corrector: NewCloseDateCorrector(pool, log)})
 	river.AddWorker(workers, &followUpReconcileWorker{reconciler: NewFollowUpReconciler(pool, log)})
@@ -140,6 +189,16 @@ func NewJobRunner(pool *pgxpool.Pool, log *slog.Logger, closeDateInterval, recon
 			func() (river.JobArgs, *river.InsertOpts) { return GmailSyncArgs{}, sweepInsertOpts() },
 			&river.PeriodicJobOpts{RunOnStart: true},
 		))
+		if watch.Topic != "" {
+			river.AddWorker(workers, &gmailWatchWorker{
+				registry: gmailReg, topic: watch.Topic, renewWithin: watch.RenewWithin, log: log,
+			})
+			periodic = append(periodic, river.NewPeriodicJob(
+				river.PeriodicInterval(watch.Interval),
+				func() (river.JobArgs, *river.InsertOpts) { return GmailWatchArgs{}, sweepInsertOpts() },
+				&river.PeriodicJobOpts{RunOnStart: true},
+			))
+		}
 	}
 
 	return jobs.New(pool, jobs.Config{

--- a/backend/internal/compose/jobs_integration_test.go
+++ b/backend/internal/compose/jobs_integration_test.go
@@ -70,7 +70,7 @@ func TestRiverCloseDateSweepStagesSameProvisionalAsDirectSweep(t *testing.T) {
 	id := e.seedSweepDeal(t, "Commit slipped", e.late, stringp("commit"), intp(-10), 3)
 
 	quiet := slog.New(slog.NewTextHandler(io.Discard, nil))
-	runner, err := NewJobRunner(e.Pool, quiet, time.Hour, time.Hour, nil, 0)
+	runner, err := NewJobRunner(e.Pool, quiet, time.Hour, time.Hour, nil, 0, GmailWatchConfig{})
 	if err != nil {
 		t.Fatalf("NewJobRunner: %v", err)
 	}

--- a/backend/internal/modules/capture/gmail/client.go
+++ b/backend/internal/modules/capture/gmail/client.go
@@ -11,6 +11,7 @@
 package gmail
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -75,6 +76,10 @@ type API interface {
 	History(ctx context.Context, accessToken, startHistoryID string) (addedIDs []string, historyID string, err error)
 	// GetRaw fetches one message as its decoded RFC822 bytes (format=RAW).
 	GetRaw(ctx context.Context, accessToken, msgID string) (rfc822 []byte, err error)
+	// Watch registers (or renews) a users.watch against the given Pub/Sub
+	// topic and returns the mailbox's historyId at watch time plus the watch's
+	// expiration (Gmail caps a watch at 7 days).
+	Watch(ctx context.Context, accessToken, topic string) (historyID string, expiration time.Time, err error)
 }
 
 // OAuthConfig wires the OAuth client. AuthURL/TokenURL default to Google's
@@ -302,6 +307,50 @@ func (a *httpAPI) GetRaw(ctx context.Context, accessToken, msgID string) ([]byte
 		return nil, fmt.Errorf("gmail: decoding raw message %s: %w", msgID, ErrUnreachable)
 	}
 	return decoded, nil
+}
+
+// Watch registers a users.watch so Gmail publishes change notifications for
+// the mailbox to the Pub/Sub topic. Gmail returns the mailbox's current
+// historyId and an expiration as a string of milliseconds since the epoch;
+// re-calling watch renews it (Gmail keeps one watch per mailbox). A 401/403
+// maps to ErrAuthRejected, anything else to ErrUnreachable — Google's raw body
+// never reaches the caller.
+func (a *httpAPI) Watch(ctx context.Context, accessToken, topic string) (string, time.Time, error) {
+	reqBody, err := json.Marshal(map[string]string{"topicName": topic})
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("gmail: encoding watch request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, a.base+"/watch", bytes.NewReader(reqBody))
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("gmail: building watch request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("gmail: watch: %w", ErrUnreachable)
+	}
+	//craft:ignore swallowed-errors best-effort close of the watch response body — the decoded result/status is what matters
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return "", time.Time{}, ErrAuthRejected
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", time.Time{}, ErrUnreachable
+	}
+	var out struct {
+		HistoryID  string `json:"historyId"`  //nolint:tagliatelle // Google's wire format (camelCase); must match to decode
+		Expiration string `json:"expiration"` // ms since epoch, as a string
+	}
+	if err := json.Unmarshal(body, &out); err != nil {
+		return "", time.Time{}, fmt.Errorf("gmail: decoding watch response: %w", ErrUnreachable)
+	}
+	ms, err := strconv.ParseInt(out.Expiration, 10, 64)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("gmail: unparseable watch expiration %q: %w", out.Expiration, ErrUnreachable)
+	}
+	return out.HistoryID, time.UnixMilli(ms), nil
 }
 
 // get performs an authorized GET and JSON-decodes into out. It returns the

--- a/backend/internal/modules/capture/gmail/client_test.go
+++ b/backend/internal/modules/capture/gmail/client_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 // googleStub routes the handful of Google/Gmail endpoints the client calls
@@ -53,6 +54,12 @@ func googleStub(t *testing.T) *httptest.Server {
 	mux.HandleFunc("/messages/m1", func(w http.ResponseWriter, _ *http.Request) {
 		raw := base64.RawURLEncoding.EncodeToString([]byte("Subject: hi\r\n\r\nbody"))
 		writeJSON(w, map[string]any{"id": "m1", "raw": raw})
+	})
+
+	mux.HandleFunc("/watch", func(w http.ResponseWriter, _ *http.Request) {
+		// Gmail's users.watch returns the mailbox historyId and an expiration
+		// given as a string of milliseconds since the epoch.
+		writeJSON(w, map[string]any{"historyId": "99999", "expiration": "1431990098200"})
 	})
 
 	mux.HandleFunc("/history", func(w http.ResponseWriter, r *http.Request) {
@@ -185,5 +192,21 @@ func TestHistoryTooOldMapsGoneSentinel(t *testing.T) {
 	_, api := newTestClients(t)
 	if _, _, err := api.History(context.Background(), "access-2", "0"); !errors.Is(err, ErrHistoryGone) {
 		t.Fatalf("want ErrHistoryGone for a stale cursor, got %v", err)
+	}
+}
+
+func TestWatchRegistersAndParsesMillisecondExpiration(t *testing.T) {
+	_, api := newTestClients(t)
+	hist, exp, err := api.Watch(context.Background(), "access-2", "projects/p/topics/gmail-push")
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+	if hist != "99999" {
+		t.Errorf("historyId = %q, want 99999", hist)
+	}
+	// The string "1431990098200" ms must parse to that instant, not be truncated
+	// to seconds or read as nanos.
+	if want := time.UnixMilli(1431990098200); !exp.Equal(want) {
+		t.Errorf("expiration = %v, want %v", exp, want)
 	}
 }

--- a/backend/internal/modules/capture/gmail/gmail.go
+++ b/backend/internal/modules/capture/gmail/gmail.go
@@ -51,7 +51,10 @@ type Connector struct {
 // New returns a Gmail connector over the given OAuth + API surfaces.
 func New(oauth OAuth, api API) *Connector { return &Connector{oauth: oauth, api: api} }
 
-var _ connector.Connector = (*Connector)(nil)
+var (
+	_ connector.Connector = (*Connector)(nil)
+	_ connector.Watcher   = (*Connector)(nil)
+)
 
 // authState is the persisted credential bundle (the opaque connector.Auth).
 // The refresh token is the durable secret; the short-lived access token is
@@ -242,6 +245,28 @@ func (c *Connector) Normalize(_ context.Context, raw connector.RawRecord) ([]con
 		return nil, fmt.Errorf("gmail: dropping %s (%s): %w", msg.ID(), reason, connector.ErrSkip)
 	}
 	return []connector.NormalizedRecord{msg.ToRecord(connectorName, raw)}, nil
+}
+
+// Watch registers a Gmail users.watch against the Pub/Sub topic so Gmail
+// publishes change notifications for the mailbox, returning the mailbox's
+// historyId at watch time and when the watch expires (Gmail caps it at 7 days).
+// Re-calling it renews the watch. Like Sync, it mints a fresh access token from
+// the stored refresh token; it never touches the CRM or the connection row —
+// the registry persists the expiration into capture_connection.watch_expires_at.
+func (c *Connector) Watch(ctx context.Context, auth connector.Auth, topic string) (connector.WatchResult, error) {
+	var st authState
+	if err := json.Unmarshal(auth, &st); err != nil {
+		return connector.WatchResult{}, fmt.Errorf("gmail: malformed auth state: %w", err)
+	}
+	access, err := c.oauth.AccessToken(ctx, st.RefreshToken)
+	if err != nil {
+		return connector.WatchResult{}, err
+	}
+	historyID, expiration, err := c.api.Watch(ctx, access, topic)
+	if err != nil {
+		return connector.WatchResult{}, err
+	}
+	return connector.WatchResult{HistoryID: historyID, ExpiresAt: expiration}, nil
 }
 
 // HealthCheck confirms the stored credential still mints a token and the

--- a/backend/internal/modules/capture/gmail/gmail_test.go
+++ b/backend/internal/modules/capture/gmail/gmail_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/connector"
@@ -36,6 +37,11 @@ type fakeAPI struct {
 	raws               map[string][]byte
 	historyCalls       int
 	listCalls          int
+	watchHistoryID     string
+	watchExpiry        time.Time
+	watchErr           error
+	watchCalls         int
+	watchTopic         string
 }
 
 func (f *fakeAPI) Profile(context.Context, string) (string, string, error) {
@@ -53,6 +59,15 @@ func (f *fakeAPI) History(context.Context, string, string) ([]string, string, er
 		return nil, "", f.historyErr
 	}
 	return f.added, f.addedHistoryID, nil
+}
+
+func (f *fakeAPI) Watch(_ context.Context, _, topic string) (string, time.Time, error) {
+	f.watchCalls++
+	f.watchTopic = topic
+	if f.watchErr != nil {
+		return "", time.Time{}, f.watchErr
+	}
+	return f.watchHistoryID, f.watchExpiry, nil
 }
 
 func (f *fakeAPI) GetRaw(_ context.Context, _, id string) ([]byte, error) {
@@ -220,6 +235,41 @@ func TestSyncHistoryGoneFallsBackToList(t *testing.T) {
 		t.Errorf("cursor should re-anchor at profile historyId 55555, got %q", hid)
 	}
 }
+
+func TestWatchRegistersAndReturnsExpiry(t *testing.T) {
+	exp := time.UnixMilli(1431990098200)
+	api := &fakeAPI{watchHistoryID: "99999", watchExpiry: exp}
+	c := New(fakeOAuth{access: "access-1"}, api)
+
+	res, err := c.Watch(context.Background(), authBytes(t), "projects/p/topics/gmail-push")
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+	if res.HistoryID != "99999" {
+		t.Errorf("HistoryID = %q, want 99999", res.HistoryID)
+	}
+	if !res.ExpiresAt.Equal(exp) {
+		t.Errorf("ExpiresAt = %v, want %v", res.ExpiresAt, exp)
+	}
+	if api.watchTopic != "projects/p/topics/gmail-push" {
+		t.Errorf("topic passed to Gmail = %q, want the configured topic", api.watchTopic)
+	}
+	if api.watchCalls != 1 {
+		t.Errorf("watch called %d times, want 1", api.watchCalls)
+	}
+}
+
+func TestWatchPropagatesProviderError(t *testing.T) {
+	api := &fakeAPI{watchErr: ErrAuthRejected}
+	c := New(fakeOAuth{access: "access-1"}, api)
+	if _, err := c.Watch(context.Background(), authBytes(t), "projects/p/topics/gmail-push"); !errors.Is(err, ErrAuthRejected) {
+		t.Fatalf("want ErrAuthRejected propagated, got %v", err)
+	}
+}
+
+// The Gmail connector satisfies the optional push-watch seam the registry's
+// renewal scan invokes.
+var _ connector.Watcher = (*Connector)(nil)
 
 func TestNormalizeSkipsAutomatedMail(t *testing.T) {
 	c := New(fakeOAuth{}, &fakeAPI{})

--- a/backend/internal/modules/capture/registry_connections.go
+++ b/backend/internal/modules/capture/registry_connections.go
@@ -98,13 +98,29 @@ type DueConnection struct {
 // DueConnections lists every connected connection for provider name across the
 // whole fleet, so the background poller can drive one SyncOnce per
 // connection. capture_connection is RLS-scoped, so this walks each
-// workspace under its own GUC — the same fleet-walk shape as
-// BackfillCredentials. One workspace's failure does not starve the rest.
+// workspace under its own GUC. One workspace's failure does not starve the rest.
 func (r *Registry) DueConnections(ctx context.Context, name string) ([]DueConnection, error) {
+	return r.collectDue(ctx, func(ctx context.Context, tx pgx.Tx) ([]ids.UUID, error) {
+		rows, err := tx.Query(ctx, `
+			SELECT id FROM capture_connection
+			WHERE provider = $1 AND status = 'connected' AND archived_at IS NULL`, name)
+		if err != nil {
+			return nil, err
+		}
+		return pgx.CollectRows(rows, pgx.RowTo[ids.UUID])
+	})
+}
+
+// collectDue is the RLS fleet-walk the poll (DueConnections) and the watch scan
+// (DueWatches) share: it enumerates every live workspace, enters each one's own
+// GUC, and appends the connection ids the per-workspace selector returns, tagged
+// with their workspace. Per-workspace errors are joined so one workspace's
+// failure never starves the rest of the fleet.
+func (r *Registry) collectDue(ctx context.Context, selector func(ctx context.Context, tx pgx.Tx) ([]ids.UUID, error)) ([]DueConnection, error) {
 	// rls-exempt: fleet enumeration — the workspace table is not workspace-scoped; this reads every tenant before entering each workspace's own GUC.
 	rows, err := r.pool.Query(ctx, `SELECT id FROM workspace WHERE archived_at IS NULL ORDER BY created_at`)
 	if err != nil {
-		return nil, fmt.Errorf("capture: listing workspaces for the %s poll: %w", name, err)
+		return nil, fmt.Errorf("capture: listing workspaces for the fleet walk: %w", err)
 	}
 	workspaces, err := pgx.CollectRows(rows, pgx.RowTo[ids.UUID])
 	if err != nil {
@@ -116,24 +132,17 @@ func (r *Registry) DueConnections(ctx context.Context, name string) ([]DueConnec
 		wsCtx := principal.WithWorkspaceID(ctx, wsID)
 		ws := ids.From[ids.WorkspaceKind](wsID)
 		err := database.WithWorkspaceTx(wsCtx, r.pool, func(tx pgx.Tx) error {
-			rows, err := tx.Query(wsCtx, `
-				SELECT id FROM capture_connection
-				WHERE provider = $1 AND status = 'connected' AND archived_at IS NULL`, name)
+			selected, err := selector(wsCtx, tx)
 			if err != nil {
 				return err
 			}
-			defer rows.Close()
-			for rows.Next() {
-				var id ids.UUID
-				if err := rows.Scan(&id); err != nil {
-					return err
-				}
+			for _, id := range selected {
 				due = append(due, DueConnection{Workspace: ws, ID: id})
 			}
-			return rows.Err()
+			return nil
 		})
 		if err != nil {
-			errs = errors.Join(errs, fmt.Errorf("capture: listing %s connections in workspace %s: %w", name, wsID, err))
+			errs = errors.Join(errs, fmt.Errorf("capture: fleet walk in workspace %s: %w", wsID, err))
 		}
 	}
 	return due, errs

--- a/backend/internal/modules/capture/registry_watch.go
+++ b/backend/internal/modules/capture/registry_watch.go
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package capture
+
+// The Gmail Pub/Sub push-watch lifecycle for the persisted connectors: the
+// fleet-wide scan that finds connections whose watch is missing or nearing
+// expiry (DueWatches), and the per-connection register/renew that stores the
+// new deadline in capture_connection.watch_expires_at (RenewWatch). It reads/
+// writes only watch_expires_at (CAP-DDL-2, idx_capture_watch_renew); the
+// sync_cursor stays owned by SyncOnce (registry.go). The register+renew
+// mechanics live here; the connect/sync/disconnect lifecycle is in registry.go
+// and registry_connections.go.
+//
+// This is only the watch subscription's renewal, not its consumption: the
+// public Pub/Sub push webhook that turns a notification back into a sync is a
+// separate, security-sensitive surface (CAP-WIRE-N-1; EP05.4a/.8) and is not
+// built here. Until it lands, the poll (DueConnections → SyncOnce) remains the
+// active sync path; a registered watch is dark.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/connector"
+)
+
+// DueWatches lists every connected connection for provider name across the
+// whole fleet whose push watch needs (re)registering — either it has none yet
+// (watch_expires_at IS NULL) or it expires within the renewal window. It walks
+// each workspace under its own GUC, the same RLS fleet-walk shape as
+// DueConnections; the near-expiry branch is served by idx_capture_watch_renew.
+// One workspace's failure does not starve the rest.
+func (r *Registry) DueWatches(ctx context.Context, name string, within time.Duration) ([]DueConnection, error) {
+	threshold := time.Now().Add(within)
+	// rls-exempt: fleet enumeration — the workspace table is not workspace-scoped; this reads every tenant before entering each workspace's own GUC.
+	rows, err := r.pool.Query(ctx, `SELECT id FROM workspace WHERE archived_at IS NULL ORDER BY created_at`)
+	if err != nil {
+		return nil, fmt.Errorf("capture: listing workspaces for the %s watch scan: %w", name, err)
+	}
+	workspaces, err := pgx.CollectRows(rows, pgx.RowTo[ids.UUID])
+	if err != nil {
+		return nil, err
+	}
+	var due []DueConnection
+	var errs error
+	for _, wsID := range workspaces {
+		wsCtx := principal.WithWorkspaceID(ctx, wsID)
+		ws := ids.From[ids.WorkspaceKind](wsID)
+		err := database.WithWorkspaceTx(wsCtx, r.pool, func(tx pgx.Tx) error {
+			rows, err := tx.Query(wsCtx, `
+				SELECT id FROM capture_connection
+				WHERE provider = $1 AND status = 'connected' AND archived_at IS NULL
+				  AND (watch_expires_at IS NULL OR watch_expires_at < $2)`, name, threshold)
+			if err != nil {
+				return err
+			}
+			defer rows.Close()
+			for rows.Next() {
+				var id ids.UUID
+				if err := rows.Scan(&id); err != nil {
+					return err
+				}
+				due = append(due, DueConnection{Workspace: ws, ID: id})
+			}
+			return rows.Err()
+		})
+		if err != nil {
+			errs = errors.Join(errs, fmt.Errorf("capture: scanning %s watches in workspace %s: %w", name, wsID, err))
+		}
+	}
+	return due, errs
+}
+
+// RenewWatch registers (or renews) the push watch for one connection against
+// topic and stores the returned expiration in watch_expires_at. It resolves the
+// credential and builds the connector principal exactly like SyncOnce, then
+// calls the connector's Watcher seam. It deliberately does NOT touch
+// sync_cursor: the watch's historyId would suppress the first-sync backfill on
+// a fresh connection, so the cursor stays SyncOnce's. The status guard keeps a
+// watch that races a concurrent Disconnect from writing a deadline onto a
+// no-longer-connected row.
+func (r *Registry) RenewWatch(ctx context.Context, connectionID ids.UUID, topic string) error {
+	var (
+		name          string
+		grantedBy     ids.UserID
+		credentialRef *string
+		authBytes     []byte
+	)
+	err := database.WithWorkspaceTx(ctx, r.pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `
+			SELECT provider, user_id, credential_ref, auth FROM capture_connection
+			WHERE id = $1 AND status = 'connected'`, connectionID).
+			Scan(&name, &grantedBy, &credentialRef, &authBytes)
+	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return fmt.Errorf("capture: connection %s: %w", connectionID, apperrors.ErrNotFound)
+	}
+	if err != nil {
+		return err
+	}
+	c, err := r.connector(name)
+	if err != nil {
+		return err
+	}
+	watcher, ok := c.(connector.Watcher)
+	if !ok {
+		return fmt.Errorf("capture: connector %q does not support push-watch renewal", name)
+	}
+	auth, err := r.resolveCredential(ctx, credentialRef, authBytes)
+	if err != nil {
+		return err
+	}
+	runCtx, err := r.connectorContext(ctx, name, grantedBy)
+	if err != nil {
+		return err
+	}
+	res, err := watcher.Watch(runCtx, auth, topic)
+	if err != nil {
+		return err
+	}
+	return database.WithWorkspaceTx(ctx, r.pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `
+			UPDATE capture_connection SET watch_expires_at = $2
+			WHERE id = $1 AND status = 'connected' AND archived_at IS NULL`,
+			connectionID, res.ExpiresAt)
+		return err
+	})
+}

--- a/backend/internal/modules/capture/registry_watch.go
+++ b/backend/internal/modules/capture/registry_watch.go
@@ -29,7 +29,6 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
-	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/connector"
 )
 
@@ -41,43 +40,19 @@ import (
 // One workspace's failure does not starve the rest.
 func (r *Registry) DueWatches(ctx context.Context, name string, within time.Duration) ([]DueConnection, error) {
 	threshold := time.Now().Add(within)
-	// rls-exempt: fleet enumeration — the workspace table is not workspace-scoped; this reads every tenant before entering each workspace's own GUC.
-	rows, err := r.pool.Query(ctx, `SELECT id FROM workspace WHERE archived_at IS NULL ORDER BY created_at`)
-	if err != nil {
-		return nil, fmt.Errorf("capture: listing workspaces for the %s watch scan: %w", name, err)
-	}
-	workspaces, err := pgx.CollectRows(rows, pgx.RowTo[ids.UUID])
-	if err != nil {
-		return nil, err
-	}
-	var due []DueConnection
-	var errs error
-	for _, wsID := range workspaces {
-		wsCtx := principal.WithWorkspaceID(ctx, wsID)
-		ws := ids.From[ids.WorkspaceKind](wsID)
-		err := database.WithWorkspaceTx(wsCtx, r.pool, func(tx pgx.Tx) error {
-			rows, err := tx.Query(wsCtx, `
-				SELECT id FROM capture_connection
-				WHERE provider = $1 AND status = 'connected' AND archived_at IS NULL
-				  AND (watch_expires_at IS NULL OR watch_expires_at < $2)`, name, threshold)
-			if err != nil {
-				return err
-			}
-			defer rows.Close()
-			for rows.Next() {
-				var id ids.UUID
-				if err := rows.Scan(&id); err != nil {
-					return err
-				}
-				due = append(due, DueConnection{Workspace: ws, ID: id})
-			}
-			return rows.Err()
-		})
+	return r.collectDue(ctx, func(ctx context.Context, tx pgx.Tx) ([]ids.UUID, error) {
+		// The near-expiry branch is served by idx_capture_watch_renew; a
+		// never-watched row (watch_expires_at IS NULL) is due for an initial
+		// registration.
+		rows, err := tx.Query(ctx, `
+			SELECT id FROM capture_connection
+			WHERE provider = $1 AND status = 'connected' AND archived_at IS NULL
+			  AND (watch_expires_at IS NULL OR watch_expires_at < $2)`, name, threshold)
 		if err != nil {
-			errs = errors.Join(errs, fmt.Errorf("capture: scanning %s watches in workspace %s: %w", name, wsID, err))
+			return nil, err
 		}
-	}
-	return due, errs
+		return pgx.CollectRows(rows, pgx.RowTo[ids.UUID])
+	})
 }
 
 // RenewWatch registers (or renews) the push watch for one connection against

--- a/backend/internal/shared/ports/connector/connector.go
+++ b/backend/internal/shared/ports/connector/connector.go
@@ -13,6 +13,7 @@ package connector
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
@@ -46,6 +47,30 @@ type Connector interface {
 	// HealthCheck feeds the ops surface; an outage degrades capture but
 	// never blocks core CRM (capture is async on the job queue).
 	HealthCheck(ctx context.Context, auth Auth) error
+}
+
+// Watcher is the OPTIONAL push-watch seam a connector implements when its
+// provider delivers change notifications through a subscription that must be
+// renewed before it lapses (Gmail Pub/Sub's 7-day watch, Graph's ≤3-day
+// subscription). It is separate from Connector because a provider without a
+// renewable push subscription (the one-shot IMAP puller) does not implement it;
+// the registry's watch-renewal scan type-asserts for it and skips a connector
+// that is not a Watcher.
+type Watcher interface {
+	// Watch registers (or, on a repeat call, renews) the provider push
+	// subscription against topic and returns the watermark to resume from plus
+	// the new expiration deadline. It performs provider I/O like Sync; it never
+	// touches the CRM or the connection row (the registry persists the result).
+	Watch(ctx context.Context, auth Auth, topic string) (WatchResult, error)
+}
+
+// WatchResult is the outcome of registering/renewing a provider push watch:
+// the historyId/delta anchor at watch time and when the watch expires. The
+// registry stores ExpiresAt in capture_connection.watch_expires_at, which the
+// renewal scan keys on (CAP-DDL-2, idx_capture_watch_renew).
+type WatchResult struct {
+	HistoryID string
+	ExpiresAt time.Time
 }
 
 // Descriptor — declared capabilities; ⊆ the granting human's scopes.


### PR DESCRIPTION
## What

Builds the Gmail Pub/Sub **watch lifecycle** keyed on `capture_connection.watch_expires_at` — the column + `idx_capture_watch_renew` index that PR #88 (CAP-DDL-2) added but left inert. Today the Gmail connector syncs by polling (`DueConnections → SyncOnce` via the History API); this slice adds the real-time push path's **register + renew** half.

## Scope

**In:** register a Gmail `users.watch` against a configured Pub/Sub topic, and renew it before its 7-day expiry.

- `connector.Watcher` / `WatchResult` — an *optional* push-watch seam on the port, separate from `Connector` (the one-shot IMAP puller doesn't implement it).
- `gmail`: `API.Watch` (`POST /watch`, parses the ms-since-epoch expiration string) + `Connector.Watch`, mirroring `Sync`'s token-mint discipline.
- `capture`: `DueWatches` (fleet-wide RLS scan for connections whose watch is missing or nearing expiry — mirrors `DueConnections`) + `RenewWatch` (register/renew one watch, storing `watch_expires_at`).
- `worker`: a `gmail_watch_renew` River periodic job, scheduled **only when a Pub/Sub topic is configured** (`--gmail-pubsub-topic`); absent by omission otherwise, so capture stays on the poll. One unified scan both registers (`watch_expires_at IS NULL`) and renews (nearing expiry).

**Two deliberate boundary calls:**
- **`RenewWatch` does not touch `sync_cursor`** — anchoring it from the watch's `historyId` would suppress the first-sync backfill on a fresh connection. The cursor stays `SyncOnce`'s.
- **Watches are registered "dark"** ahead of the consumer. The public Pub/Sub **push webhook** — the security-sensitive surface tangled in the unresolved webhook-verification + OAuth-app-posture decisions (EP05.4a/.8), and against CAP-WIRE-N-1's "no public ingestion endpoint" stance — is a **separate follow-up**. Until it lands, the poll remains the active sync path.

**Out:** the push webhook, gcal/Graph subscriptions, WhatsApp/Telegram, the OAuth-app posture.

## Contract

No change. `watch_expires_at` is already an exposed read-only field on `CaptureConnection`; the watch is internal (CAP-WIRE-N-1).

## Tests (TDD)

- Unit: `Connector.Watch` + `API.Watch` (httptest; the ms-string expiration parse and 401/403→ErrAuthRejected / 5xx→ErrUnreachable mapping).
- Integration (`//go:build integration`): `RenewWatch`/`DueWatches` select only connected + due rows, write `watch_expires_at`, skip already-fresh rows, and leave `sync_cursor` untouched; plus a River-driven end-to-end proof that the scheduled `gmail_watch_renew` job renews on `RunOnStart`.

## Local gates

`golangci-lint` (default + strict) 0 issues · `go build/vet/test` green · `check-go-file-length` OK · craft static **0 blockers** · integration tests pass via `scripts/test-integration-one.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Gmail push-watch registration and automatic renewal.
  * Gmail watches can now be configured with a Pub/Sub topic, maintenance interval, and renewal window.
  * Gmail continues to use polling when push-watch settings are not configured.

* **Reliability**
  * Watch renewal safely updates active connections and handles individual renewal failures without stopping the maintenance process.

* **Tests**
  * Added coverage for Gmail watch registration, expiration handling, renewal scheduling, and error propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->