### PR TITLE
feat(frontend): login UI/UX spec — typed auth boundary, session notices, deep-link restore, login polish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,10 +137,6 @@ jobs:
         env:
           # In CI a missing base ref is a broken checkout, never a skip.
           CONTRACT_BREAKING_REQUIRE_BASE: "1"
-          # Deliberate spec re-sync (A107/ADR-0061): POST /workspaces and the
-          # tenant-selection surface leave the contract. Advisory for THIS
-          # change only — revert to the default (stable) right after merge.
-          CONTRACT_STABILITY: "pre-live"
         run: make check-backend
 
   # The code-craftsmanship gate (ADR-0045) runs only after the deterministic

--- a/STATUS.md
+++ b/STATUS.md
@@ -22,6 +22,28 @@ The merge gate (`make check`), the real-Postgres integration lane
 
 ## Recently landed
 
+**Single-organization installation (ADR-0061/A107, PR #90)** — the
+ratified single-org concept, end to end. One installation serves one
+organization: bootstrap moved off the public wire into a strict
+`margince.yaml` deployment file (`platform/deployconfig`) consumed at
+API boot under a pg advisory lock — organization + first admin + system
+roles + configurable seeds (pipeline stages, consent purposes, starter
+automations, booking page) in one transaction; 0 workspaces → create,
+1 → bind, >1 → refuse for an operator-led migration (boot-enforced,
+deliberately NOT a schema constraint so the cross-tenant RLS suites keep
+proving isolation). `POST /workspaces`, the `{workspace}` subdomain
+template, and every tenant selector (`X-Workspace-Slug`, MCP
+`--workspace`) are gone; pre-bootstrap requests answer 503
+(availability, never auth). The A74 account-recovery pair is live:
+`auth_token` (0081), a STARTTLS-required SMTP mailer behind the
+`email:` config section, enumeration-resistant forgot/reset (the whole
+account-dependent path runs off-request), and `migrate reset-password`
+as the operator recovery. Anonymous `GET /auth/capabilities` drives the
+login UI, which is now a login-first single column (no signup mode, no
+hero, no slug field) with capability-gated forgot/reset screens.
+Spec-side: margince-foundation ADR-0061 + DECISIONS A107 + ADR-0043
+Amendment 2 (merged there first, contract-first).
+
 **Craft gate de-vendored** — `cli/craft` is now a first-class, locally-owned
 part of this repo rather than a hash-pinned vendored copy: the
 `craft-manifest.sha256` hash pin, the `craft-drift`/`craft-sync` targets,

--- a/backend/migrations/core/0081_auth_token.down.sql
+++ b/backend/migrations/core/0081_auth_token.down.sql
@@ -1,2 +1,2 @@
--- Reverse 0079.
+-- Reverse 0081.
 DROP TABLE IF EXISTS auth_token;

--- a/backend/migrations/core/0081_auth_token.up.sql
+++ b/backend/migrations/core/0081_auth_token.up.sql
@@ -1,4 +1,4 @@
--- 0079: auth_token — single-use emailed credentials (A74/ADR-0056;
+-- 0081: auth_token — single-use emailed credentials (A74/ADR-0056;
 -- AUTH-DDL-1). Password reset first; the same table carries email
 -- verification and invite activation when those flows land. Only the
 -- token's hash persists (the no-raw-credential-at-rest rule the session

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -146,3 +146,74 @@ describe("locale switch", () => {
     expect(screen.queryByRole("link", { name: "Contacts" })).toBeNull();
   });
 });
+
+describe("auth boundary states (login spec §4)", () => {
+  const mount = () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    render(
+      <QueryClientProvider client={client}>
+        <LocaleProvider initial="en">
+          <App />
+        </LocaleProvider>
+      </QueryClientProvider>,
+    );
+  };
+  const probe = (status: number) =>
+    vi.fn(async (input: Request | string | URL) => {
+      const url = String(input instanceof Request ? input.url : input);
+      if (url.endsWith("/v1/me")) {
+        return new Response(JSON.stringify({ code: "x" }), {
+          status,
+          headers: { "Content-Type": "application/problem+json" },
+        });
+      }
+      return new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+  it("renders login on 401 — not signed in is an authentication state", async () => {
+    vi.stubGlobal("fetch", probe(401));
+    mount();
+    expect(
+      await screen.findByRole("heading", { name: "Sign in to Margince" }),
+    ).toBeTruthy();
+  });
+
+  it("renders the connection problem on 5xx — an outage is never a login", async () => {
+    vi.stubGlobal("fetch", probe(500));
+    mount();
+    expect(
+      await screen.findByText("Margince couldn't be reached"),
+    ).toBeTruthy();
+    expect(screen.queryByLabelText("Email address")).toBeNull();
+  });
+
+  it("renders installation-unavailable on 503 and retry re-probes /me", async () => {
+    const fetchMock = probe(503);
+    vi.stubGlobal("fetch", fetchMock);
+    mount();
+    expect(await screen.findByText("Installation not ready")).toBeTruthy();
+    const before = fetchMock.mock.calls.length;
+    await userEvent.click(screen.getByRole("button", { name: "Try again" }));
+    await waitFor(() =>
+      expect(fetchMock.mock.calls.length).toBeGreaterThan(before),
+    );
+  });
+
+  it("renders the connection problem when the probe cannot reach the API at all", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new TypeError("network down");
+      }),
+    );
+    mount();
+    expect(
+      await screen.findByText("Margince couldn't be reached"),
+    ).toBeTruthy();
+  });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,10 @@
-import { type ReactNode, useCallback, useState } from "react";
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { AskFab } from "./app/fab";
 import {
   CommandPalette,
@@ -9,11 +15,15 @@ import { Shell, useRoute } from "./app/shell";
 import { EmptyState } from "./design-system/atoms";
 import { useT } from "./i18n";
 import { AskAiScreen } from "./screens/ai";
-import { AuthScreen } from "./screens/auth";
+import {
+  type AuthNotice,
+  AuthScreen,
+  AvailabilityScreen,
+} from "./screens/auth";
 import { AutomationsScreen } from "./screens/automations";
 import { BookingScreen } from "./screens/book";
 import { ClientSurfaceScreen } from "./screens/client";
-import { useMe } from "./screens/common";
+import { AuthProbeError, consumeAuthExitNotice, useMe } from "./screens/common";
 import { CustomFieldsScreen } from "./screens/customfields";
 import { DealScreen, DealsScreen } from "./screens/deals";
 import { DesignScreen } from "./screens/design";
@@ -159,14 +169,41 @@ export function App() {
   return <AuthedApp route={route} />;
 }
 
-// AuthGate: everything behind the session probes GET /v1/me. A first-time user
-// has no session (and maybe no workspace slug) — either way /me is not 200, so
-// we show the signup/login screen. On success the screen refetches and the app
-// renders. No redirect races: the gate owns the authenticated/not decision.
+// AuthGate: everything behind the session probes GET /v1/me, and the
+// boundary branches on the TYPED failure (§4 of the login spec):
+// 401 → login, network/5xx → connection problem, 503 → installation
+// unavailable. Authentication and availability are different product
+// states — a server outage must never read as "wrong password". On login
+// success the screen refetches and the app renders at the route the user
+// originally asked for. No redirect races: the gate owns the decision.
 function AuthedApp({
   route,
 }: Readonly<{ route: ReturnType<typeof useRoute> }>) {
   const me = useMe();
+  // A 401 after a previously live session is an expiry (or a deliberate
+  // sign-out, which useLogout marks); a 401 on first load is just "not
+  // signed in" and carries no notice.
+  const hadSession = useRef(false);
+  const [notice, setNotice] = useState<AuthNotice>(null);
+  useEffect(() => {
+    if (me.data) {
+      hadSession.current = true;
+      setNotice(null);
+      return;
+    }
+    if (
+      me.error instanceof AuthProbeError &&
+      me.error.kind === "unauthorized"
+    ) {
+      const exit = consumeAuthExitNotice();
+      if (exit) {
+        setNotice(exit);
+      } else if (hadSession.current) {
+        setNotice("session-expired");
+      }
+      hadSession.current = false;
+    }
+  }, [me.data, me.error]);
 
   const [paletteOpen, setPaletteOpen] = useState(false);
   const commands = useBuiltinCommands();
@@ -180,9 +217,18 @@ function AuthedApp({
     );
   }
   if (me.isError) {
+    const kind =
+      me.error instanceof AuthProbeError ? me.error.kind : "connection";
+    if (kind !== "unauthorized") {
+      return (
+        <RaillessFrame>
+          <AvailabilityScreen kind={kind} onRetry={() => me.refetch()} />
+        </RaillessFrame>
+      );
+    }
     return (
       <RaillessFrame>
-        <AuthScreen onAuthed={() => me.refetch()} />
+        <AuthScreen onAuthed={() => me.refetch()} notice={notice} />
       </RaillessFrame>
     );
   }

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -958,8 +958,10 @@ export const de = {
 
   "auth.title": "Margince",
   "auth.checking": "Sitzung wird geprüft…",
+  "auth.pageTitle": "Anmelden · Margince",
   "auth.loginTitle": "Bei Margince anmelden",
-  "auth.email": "E-Mail",
+  "auth.email": "E-Mail-Adresse",
+  "auth.emailPlaceholder": "name@beispiel.de",
   "auth.password": "Passwort",
   "auth.passwordHint": "mindestens 12 Zeichen",
   "auth.showPassword": "Anzeigen",
@@ -968,6 +970,22 @@ export const de = {
   "auth.signIn": "Anmelden",
   "auth.signingIn": "Anmeldung läuft…",
   "auth.failed": "Das hat nicht geklappt",
+  "auth.errCredentials":
+    "Die Anmeldung war nicht möglich. Prüfe E-Mail-Adresse und Passwort und versuche es erneut.",
+  "auth.errRateLimited":
+    "Zu viele Anmeldeversuche. Warte einen Moment und versuche es erneut.",
+  "auth.errUnreachable":
+    "Margince ist nicht erreichbar. Prüfe deine Verbindung und versuche es erneut.",
+  "auth.retry": "Erneut versuchen",
+  "auth.noticeSignedOut": "Du wurdest abgemeldet.",
+  "auth.noticeSessionExpired":
+    "Deine Sitzung ist abgelaufen. Melde dich erneut an, um fortzufahren.",
+  "auth.connectionTitle": "Margince ist nicht erreichbar",
+  "auth.connectionBody":
+    "Prüfe deine Verbindung und versuche es erneut. Besteht das Problem weiter, startet der Server womöglich gerade neu.",
+  "auth.unavailableTitle": "Installation nicht bereit",
+  "auth.unavailableBody":
+    "Diese Margince-Installation kann dich noch nicht anmelden. Ein Operator muss die Einrichtung abschließen oder reparieren.",
   "auth.forgotLink": "Passwort vergessen?",
   "auth.forgotTitle": "Passwort zurücksetzen",
   "auth.forgotSub":
@@ -986,6 +1004,8 @@ export const de = {
   "auth.resetDoneBody":
     "Dein Passwort ist geändert und alle anderen Sitzungen sind abgemeldet. Melde dich mit dem neuen Passwort an.",
   "auth.backToLogin": "Zurück zur Anmeldung",
+  "auth.langDeutsch": "Deutsch",
+  "auth.langEnglish": "English",
   "auth.signOut": "Abmelden",
 
   "client.back": "Zurück zu Margince",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -936,8 +936,10 @@ export const en = {
 
   "auth.title": "Margince",
   "auth.checking": "Checking your session…",
+  "auth.pageTitle": "Sign in · Margince",
   "auth.loginTitle": "Sign in to Margince",
-  "auth.email": "Email",
+  "auth.email": "Email address",
+  "auth.emailPlaceholder": "name@example.com",
   "auth.password": "Password",
   "auth.passwordHint": "at least 12 characters",
   "auth.showPassword": "Show",
@@ -946,6 +948,22 @@ export const en = {
   "auth.signIn": "Sign in",
   "auth.signingIn": "Signing in…",
   "auth.failed": "That didn't work",
+  "auth.errCredentials":
+    "We couldn't sign you in. Check your email and password and try again.",
+  "auth.errRateLimited":
+    "Too many sign-in attempts. Wait a moment and try again.",
+  "auth.errUnreachable":
+    "Margince couldn't be reached. Check your connection and try again.",
+  "auth.retry": "Try again",
+  "auth.noticeSignedOut": "You have been signed out.",
+  "auth.noticeSessionExpired":
+    "Your session expired. Sign in again to continue.",
+  "auth.connectionTitle": "Margince couldn't be reached",
+  "auth.connectionBody":
+    "Check your connection and try again. If the problem persists, the server may be restarting.",
+  "auth.unavailableTitle": "Installation not ready",
+  "auth.unavailableBody":
+    "This Margince installation isn't ready to sign you in. An operator needs to complete or repair the setup.",
   "auth.forgotLink": "Forgot password?",
   "auth.forgotTitle": "Reset your password",
   "auth.forgotSub":
@@ -964,6 +982,8 @@ export const en = {
   "auth.resetDoneBody":
     "Your password is changed and every other session is signed out. Sign in with the new password.",
   "auth.backToLogin": "Back to sign in",
+  "auth.langDeutsch": "Deutsch",
+  "auth.langEnglish": "English",
   "auth.signOut": "Sign out",
 
   "client.back": "Back to Margince",

--- a/frontend/src/screens/auth.css
+++ b/frontend/src/screens/auth.css
@@ -11,7 +11,14 @@
   display: grid;
   place-items: center;
   padding: 40px 24px;
+  padding-bottom: max(40px, env(safe-area-inset-bottom));
   background: var(--bgPage);
+}
+@media (max-width: 480px) {
+  .auth-page {
+    padding-left: 16px;
+    padding-right: 16px;
+  }
 }
 .auth-column {
   width: 100%;
@@ -161,4 +168,36 @@
   color: var(--textSecondary);
   margin-top: 3px;
   line-height: 1.45;
+}
+
+.auth-notice {
+  text-align: center;
+  font-size: 13px;
+  color: var(--textSecondary);
+  background: var(--bgElevated);
+  border: 1px solid var(--borderSubtle);
+  border-radius: var(--r-sm);
+  padding: 10px 13px;
+}
+.auth-error:focus-visible {
+  outline: 2px solid var(--danger);
+  outline-offset: 2px;
+}
+.auth-footer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  color: var(--textTertiary);
+  margin-top: 10px;
+}
+.auth-footer .auth-link[aria-pressed="true"] {
+  color: var(--textPrimary);
+  font-weight: 600;
+}
+
+@supports (min-height: 100dvh) {
+  .auth-page {
+    min-height: 100dvh;
+  }
 }

--- a/frontend/src/screens/auth.test.tsx
+++ b/frontend/src/screens/auth.test.tsx
@@ -10,7 +10,7 @@ import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { LocaleProvider } from "../i18n";
-import { AuthScreen } from "./auth";
+import { AuthScreen, AvailabilityScreen } from "./auth";
 
 // The unauthenticated surface (A107/ADR-0061 §12): login is the default —
 // no signup mode, no workspace field, no tenant selector on the wire — and
@@ -75,7 +75,10 @@ describe("AuthScreen login", () => {
     expect(screen.queryByLabelText(/workspace/i)).toBeNull();
     expect(screen.queryByText(/create/i)).toBeNull();
 
-    await userEvent.type(screen.getByLabelText("Email"), "ada@example.com");
+    await userEvent.type(
+      screen.getByLabelText("Email address"),
+      "ada@example.com",
+    );
     // Enter inside the real <form> submits — no button click needed.
     await userEvent.type(
       screen.getByLabelText("Password"),
@@ -88,7 +91,7 @@ describe("AuthScreen login", () => {
     expect(request?.headers.has("X-Workspace-Slug")).toBe(false);
   });
 
-  it("keeps the entered email after a failed attempt and announces the error", async () => {
+  it("answers bad credentials with the one non-enumerating message, keeps the email, clears the password", async () => {
     stubApi({ password: true, password_reset: false }, () =>
       ok(401, {
         title: "unauthorized",
@@ -97,20 +100,96 @@ describe("AuthScreen login", () => {
     );
     render(<AuthScreen onAuthed={vi.fn()} />);
 
-    await userEvent.type(screen.getByLabelText("Email"), "ada@example.com");
+    await userEvent.type(
+      screen.getByLabelText("Email address"),
+      "ada@example.com",
+    );
     await userEvent.type(screen.getByLabelText("Password"), "wrong{enter}");
 
-    await waitFor(() => expect(screen.getByRole("alert")).toBeTruthy());
-    expect(screen.getByLabelText("Email")).toHaveProperty(
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain(
+      "We couldn't sign you in. Check your email and password and try again.",
+    );
+    expect(screen.getByLabelText("Email address")).toHaveProperty(
       "value",
       "ada@example.com",
     );
+    // §9.2: a rejected credential clears the password for the retry.
+    expect(screen.getByLabelText("Password")).toHaveProperty("value", "");
+  });
+
+  it("presents rate limiting as its own actionable state, never a credential error", async () => {
+    stubApi({ password: true, password_reset: false }, () =>
+      ok(429, { title: "budget exceeded" }),
+    );
+    render(<AuthScreen onAuthed={vi.fn()} />);
+
+    await userEvent.type(
+      screen.getByLabelText("Email address"),
+      "ada@example.com",
+    );
+    await userEvent.type(screen.getByLabelText("Password"), "whatever{enter}");
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain(
+      "Too many sign-in attempts. Wait a moment and try again.",
+    );
+  });
+
+  it("presents a server outage as connectivity, not wrong credentials", async () => {
+    stubApi({ password: true, password_reset: false }, () =>
+      ok(500, { title: "boom" }),
+    );
+    render(<AuthScreen onAuthed={vi.fn()} />);
+
+    await userEvent.type(
+      screen.getByLabelText("Email address"),
+      "ada@example.com",
+    );
+    await userEvent.type(screen.getByLabelText("Password"), "whatever{enter}");
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain("Margince couldn't be reached");
+  });
+
+  it("restores a deep link after login instead of forcing home", async () => {
+    stubApi({ password: true, password_reset: false }, () =>
+      ok(200, { user: {}, roles: [], teams: [] }),
+    );
+    window.location.hash = "#/deals/d-42";
+    render(<AuthScreen onAuthed={vi.fn()} />);
+
+    await userEvent.type(
+      screen.getByLabelText("Email address"),
+      "ada@example.com",
+    );
+    await userEvent.type(
+      screen.getByLabelText("Password"),
+      "correct-horse-battery{enter}",
+    );
+
+    await waitFor(() => expect(window.location.hash).toBe("#/deals/d-42"));
+  });
+
+  it("renders the session notices the boundary hands it", async () => {
+    stubApi({ password: true, password_reset: false }, () => ok(200));
+    render(<AuthScreen onAuthed={vi.fn()} notice="session-expired" />);
+    expect(
+      await screen.findByText(
+        "Your session expired. Sign in again to continue.",
+      ),
+    ).toBeTruthy();
+    cleanup();
+
+    stubApi({ password: true, password_reset: false }, () => ok(200));
+    render(<AuthScreen onAuthed={vi.fn()} notice="signed-out" />);
+    expect(await screen.findByText("You have been signed out.")).toBeTruthy();
   });
 
   it("hides the forgot-password link when the capability is off, shows it when on", async () => {
     stubApi({ password: true, password_reset: false }, () => ok(200));
     render(<AuthScreen onAuthed={vi.fn()} />);
-    await screen.findByLabelText("Email");
+    await screen.findByLabelText("Email address");
     expect(screen.queryByText("Forgot password?")).toBeNull();
     cleanup();
 
@@ -129,7 +208,7 @@ describe("AuthScreen forgot password", () => {
 
     await userEvent.click(await screen.findByText("Forgot password?"));
     await userEvent.type(
-      screen.getByLabelText("Email"),
+      screen.getByLabelText("Email address"),
       "ada@example.com{enter}",
     );
 
@@ -183,5 +262,21 @@ describe("AuthScreen reset deep link", () => {
       await screen.findByText("That reset link is invalid, used, or expired."),
     ).toBeTruthy();
     expect(screen.getByText("Request a new link")).toBeTruthy();
+  });
+});
+
+describe("AvailabilityScreen", () => {
+  it("presents connectivity and installation problems as availability with a retry", async () => {
+    const onRetry = vi.fn();
+    render(<AvailabilityScreen kind="connection" onRetry={onRetry} />);
+    expect(screen.getByText("Margince couldn't be reached")).toBeTruthy();
+    await userEvent.click(screen.getByRole("button", { name: "Try again" }));
+    expect(onRetry).toHaveBeenCalled();
+    cleanup();
+
+    render(<AvailabilityScreen kind="installation" onRetry={vi.fn()} />);
+    expect(screen.getByText("Installation not ready")).toBeTruthy();
+    // No credential fields: this is not a login problem.
+    expect(screen.queryByLabelText("Email address")).toBeNull();
   });
 });

--- a/frontend/src/screens/auth.tsx
+++ b/frontend/src/screens/auth.tsx
@@ -1,9 +1,17 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { type FormEvent, type ReactNode, useId, useState } from "react";
+import {
+  type FormEvent,
+  type ReactNode,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from "react";
 import { api } from "../api/client";
 import { navigate } from "../app/router";
 import { Button } from "../design-system/atoms";
-import { useT } from "../i18n";
+import { useLocale, useT } from "../i18n";
+import type { MessageKey } from "../i18n/en";
 import { problemMessage } from "./common";
 import "./auth.css";
 
@@ -14,6 +22,11 @@ import "./auth.css";
 // and only the authentication methods the capabilities probe reports as
 // operational: the forgot-password flow renders exactly when the server can
 // complete it.
+
+// AuthNotice is the boundary's transient context for the login screen: a
+// deliberate sign-out or an expired session — informational, never danger
+// styling (§9.5: the user has nothing to correct).
+export type AuthNotice = "signed-out" | "session-expired" | null;
 
 type View =
   | { kind: "login" }
@@ -42,12 +55,16 @@ function resetTokenFromLocation(): string | null {
   return token;
 }
 
-export function AuthScreen({ onAuthed }: Readonly<{ onAuthed: () => void }>) {
+export function AuthScreen({
+  onAuthed,
+  notice = null,
+}: Readonly<{ onAuthed: () => void; notice?: AuthNotice }>) {
   const t = useT();
   const [view, setView] = useState<View>(() => {
     const token = resetTokenFromLocation();
     return token ? { kind: "reset", token } : { kind: "login" };
   });
+  usePageTitle(t("auth.pageTitle"));
 
   // The anonymous capability probe drives what the screen offers — a dead
   // "Forgot password?" link is a misleading affordance, so it renders only
@@ -74,11 +91,22 @@ export function AuthScreen({ onAuthed }: Readonly<{ onAuthed: () => void }>) {
           {t("auth.title")}
         </span>
         {view.kind === "login" && (
-          <LoginForm
-            onAuthed={onAuthed}
-            resetAvailable={resetAvailable}
-            onForgot={() => setView({ kind: "forgot" })}
-          />
+          <>
+            {notice && (
+              <p className="auth-notice" role="status">
+                {t(
+                  notice === "signed-out"
+                    ? "auth.noticeSignedOut"
+                    : "auth.noticeSessionExpired",
+                )}
+              </p>
+            )}
+            <LoginForm
+              onAuthed={onAuthed}
+              resetAvailable={resetAvailable}
+              onForgot={() => setView({ kind: "forgot" })}
+            />
+          </>
         )}
         {view.kind === "forgot" && (
           <ForgotForm
@@ -109,9 +137,116 @@ export function AuthScreen({ onAuthed }: Readonly<{ onAuthed: () => void }>) {
             onAction={() => setView({ kind: "login" })}
           />
         )}
+        <LocaleFooter />
       </main>
     </div>
   );
+}
+
+// AvailabilityScreen is the boundary's non-authentication half (§4): the
+// API cannot be reached (network / 5xx) or the installation is not ready
+// (503 — pre-bootstrap, or a violated singleton invariant). A server
+// outage must never read as "wrong password".
+export function AvailabilityScreen({
+  kind,
+  onRetry,
+}: Readonly<{ kind: "connection" | "installation"; onRetry: () => void }>) {
+  const t = useT();
+  usePageTitle(t("auth.pageTitle"));
+  return (
+    <div className="auth-page">
+      <main className="auth-column">
+        <span className="auth-wordmark">
+          <span className="mk">M</span>
+          {t("auth.title")}
+        </span>
+        <section className="auth-card" role="alert">
+          <h1>
+            {t(
+              kind === "connection"
+                ? "auth.connectionTitle"
+                : "auth.unavailableTitle",
+            )}
+          </h1>
+          <p className="card-sub">
+            {t(
+              kind === "connection"
+                ? "auth.connectionBody"
+                : "auth.unavailableBody",
+            )}
+          </p>
+          <div className="auth-actions">
+            <Button variant="primary" onClick={onRetry}>
+              {t("auth.retry")}
+            </Button>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}
+
+// usePageTitle stamps the document title for the unauthenticated surface
+// (§7.1) and restores the product name on unmount.
+function usePageTitle(title: string) {
+  useEffect(() => {
+    const previous = document.title;
+    document.title = title;
+    return () => {
+      document.title = previous;
+    };
+  }, [title]);
+}
+
+// LocaleFooter is the one footer utility that actually works today (§3.3
+// honesty: no Privacy/Help links exist yet, so none render). Language
+// names are proper nouns, deliberately not translated.
+function LocaleFooter() {
+  const t = useT();
+  const { locale, setLocale } = useLocale();
+  return (
+    <div className="auth-footer">
+      <button
+        type="button"
+        className="auth-link"
+        aria-pressed={locale === "de"}
+        onClick={() => setLocale("de")}
+      >
+        {t("auth.langDeutsch")}
+      </button>
+      <span aria-hidden>·</span>
+      <button
+        type="button"
+        className="auth-link"
+        aria-pressed={locale === "en"}
+        onClick={() => setLocale("en")}
+      >
+        {t("auth.langEnglish")}
+      </button>
+    </div>
+  );
+}
+
+// loginFailureKind maps the login response status onto its UX state (§9):
+// one non-enumerating message for bad credentials, an actionable one for
+// rate limiting, and connectivity presented as connectivity — never parsed
+// from human-readable detail strings.
+type LoginFailure = "credentials" | "rate-limited" | "unreachable";
+
+class LoginError extends Error {
+  readonly failure: LoginFailure;
+  constructor(failure: LoginFailure) {
+    super(failure);
+    this.name = "LoginError";
+    this.failure = failure;
+  }
+}
+
+function loginErrorKey(error: unknown): MessageKey {
+  const failure = error instanceof LoginError ? error.failure : "unreachable";
+  if (failure === "credentials") return "auth.errCredentials";
+  if (failure === "rate-limited") return "auth.errRateLimited";
+  return "auth.errUnreachable";
 }
 
 function LoginForm({
@@ -130,20 +265,51 @@ function LoginForm({
   const [password, setPassword] = useState("");
   const [showPassword, setShowPassword] = useState(false);
   const [capsLock, setCapsLock] = useState(false);
+  const emailRef = useRef<HTMLInputElement>(null);
+  const errorRef = useRef<HTMLDivElement>(null);
+
+  // Focus lands on email at render (§8.2) — programmatic rather than the
+  // autoFocus attribute, so the a11y lint's blanket rule stays intact and
+  // the login page keeps the one justified exception.
+  useEffect(() => {
+    emailRef.current?.focus();
+  }, []);
 
   const login = useMutation({
     mutationFn: async () => {
-      const { data, error } = await api.POST("/auth/login", {
-        body: { email: email.trim(), password },
-      });
+      const result = await api
+        .POST("/auth/login", { body: { email: email.trim(), password } })
+        .catch(() => null);
+      if (!result) {
+        throw new LoginError("unreachable");
+      }
+      const { data, error, response } = result;
       if (error) {
+        if (response.status === 401) throw new LoginError("credentials");
+        if (response.status === 429) throw new LoginError("rate-limited");
+        if (response.status >= 500) throw new LoginError("unreachable");
         throw new Error(problemMessage(error));
       }
       return data;
     },
     onSuccess: () => {
       onAuthed();
-      navigate({ screen: "home" });
+      // Restore the originally requested route (§8.5): a deep link the
+      // user followed stays; only a bare entry lands on home.
+      const hash = globalThis.location?.hash ?? "";
+      if (!hash || hash === "#" || hash === "#/") {
+        navigate({ screen: "home" });
+      }
+    },
+    onError: (error) => {
+      if (error instanceof LoginError && error.failure === "credentials") {
+        // A rejected credential clears the password (§9.2); the email
+        // stays for the retry.
+        setPassword("");
+      }
+      // The error summary is announced and receives focus; tab order then
+      // leads back into the fields.
+      requestAnimationFrame(() => errorRef.current?.focus());
     },
   });
 
@@ -162,9 +328,11 @@ function LoginForm({
         <Field id={emailId} label={t("auth.email")}>
           <input
             id={emailId}
+            ref={emailRef}
             className="auth-input"
             type="email"
-            autoComplete="email"
+            autoComplete="username"
+            placeholder={t("auth.emailPlaceholder")}
             value={email}
             onChange={(event) => setEmail(event.target.value)}
           />
@@ -205,9 +373,9 @@ function LoginForm({
         </Field>
       </div>
       {login.isError && (
-        <ErrorNote
-          message={login.error instanceof Error ? login.error.message : null}
-        />
+        <div className="auth-error" role="alert" tabIndex={-1} ref={errorRef}>
+          <p className="ae-t">{t(loginErrorKey(login.error))}</p>
+        </div>
       )}
       <div className="auth-actions">
         <Button
@@ -260,7 +428,8 @@ function ForgotForm({
             id={emailId}
             className="auth-input"
             type="email"
-            autoComplete="email"
+            autoComplete="username"
+            placeholder={t("auth.emailPlaceholder")}
             value={email}
             onChange={(event) => setEmail(event.target.value)}
           />

--- a/frontend/src/screens/common.tsx
+++ b/frontend/src/screens/common.tsx
@@ -10,6 +10,43 @@ import type { MessageKey } from "../i18n/en";
 // state matrix), the captured_by → provenance mapping every list reuses, and
 // the ONE /me query the auth gate and every role-aware surface share.
 
+// Authentication and availability are different product states: a failed
+// session probe is typed so the auth boundary can render login (401), the
+// connection-problem screen (network/5xx), or the installation-unavailable
+// screen (503 — pre-bootstrap or a violated singleton invariant) instead of
+// collapsing every error into login.
+export type AuthProbeKind = "unauthorized" | "connection" | "installation";
+
+export class AuthProbeError extends Error {
+  readonly kind: AuthProbeKind;
+  constructor(kind: AuthProbeKind, message: string) {
+    super(message);
+    this.name = "AuthProbeError";
+    this.kind = kind;
+  }
+}
+
+// probeKindFor maps a /me response status onto the boundary state. 503 is
+// the middleware's installation-not-ready answer; any other 5xx (or a
+// rejected fetch) is a connectivity problem; everything else reads as "no
+// session" — the login screen.
+function probeKindFor(status: number): AuthProbeKind {
+  if (status === 503) return "installation";
+  if (status >= 500) return "connection";
+  return "unauthorized";
+}
+
+// authExitNotice marks a DELIBERATE sign-out so the boundary's next 401
+// reads as "signed out", not "session expired". Module-scoped: exactly one
+// boundary consumes it.
+let authExitNotice: "signed-out" | null = null;
+
+export function consumeAuthExitNotice(): "signed-out" | null {
+  const notice = authExitNotice;
+  authExitNotice = null;
+  return notice;
+}
+
 // The session principal (GET /v1/me): identity + effective role keys. One
 // spelling, one ["me"] cache entry — the App auth gate, the settings identity
 // card, and role-aware affordances all read the same probe. The server binds
@@ -20,14 +57,23 @@ export function useMe() {
     queryKey: ["me"],
     retry: false,
     queryFn: async () => {
-      const { data, error } = await api.GET("/me");
+      const result = await api.GET("/me").catch(() => null);
+      if (!result) {
+        throw new AuthProbeError("connection", "the API could not be reached");
+      }
+      const { data, error, response } = result;
       if (error) {
-        throw new Error(problemMessage(error));
+        throw new AuthProbeError(
+          probeKindFor(response.status),
+          problemMessage(error),
+        );
       }
       if (!data?.user) {
         // The contract makes user required on MeResponse — a payload
-        // without it is not a session, whatever the status code said.
-        throw new Error("malformed /me response");
+        // without it is not a session, whatever the status code said; a
+        // server answering garbage is an availability problem, not a
+        // credentials one.
+        throw new AuthProbeError("connection", "malformed /me response");
       }
       return data;
     },
@@ -54,6 +100,9 @@ export function useLogout() {
       if (error) throw new Error(problemMessage(error));
     },
     onSuccess: async () => {
+      // The next 401 at the boundary is this deliberate exit, not an
+      // expired session — the login screen greets it accordingly.
+      authExitNotice = "signed-out";
       queryClient.removeQueries({
         predicate: (query) => query.queryKey[0] !== "me",
       });


### PR DESCRIPTION
Implements the login UI/UX implementation spec (Downloads: margince-login-ui-ux-implementation-spec.md) on top of the merged single-organization surface (#90 / ADR-0061-A107).

## Spec review notes (deviations, both deliberate)

- **§19 'password reset — deferred' is outdated**: the reset flow shipped server-side in #90, so the capability-gated forgot/reset UI stays — it satisfies §3.3 (every visible action works) *better* than deferral.
- **§8.2 initial email focus vs the a11y lint**: implemented as programmatic focus so biome's `noAutofocus` rule stays intact; the login page is the one justified case.
- **'Having trouble signing in?' / Privacy / Help omitted**: no such routes exist yet — §3.3 honesty. The Deutsch/English switcher IS functional, so it renders.

## What's new

- **Typed auth boundary (§4/§14.3)**: `useMe` throws `AuthProbeError{kind}`; App branches — 401 → login, network/5xx → connection-problem screen, 503 → installation-unavailable screen, each with Try-again re-probing /me. A server outage never reads as 'wrong password'.
- **Session notices (§9.5)**: deliberate sign-out → 'You have been signed out.'; 401 after a live session → 'Your session expired.' — informational, `role=status`.
- **Login polish (§6–§9)**: page title, 'Email address' + placeholder, `autocomplete=username`, status-code-mapped errors (one non-enumerating credentials message; distinct 429 copy; connectivity as connectivity — no detail-string parsing, §15), rejected credentials clear the password + focus the announced alert, deep-link restore after login (§8.5), `100dvh` + safe-area, functional locale switcher.
- **Riding along**: `ci.yml` `CONTRACT_STABILITY` reverted to **stable** (the deliberate re-sync merged in #90; this branch passes the gate on stable), STATUS.md updated, 0081 migration header comment fixed.

## Verification

`make check` green (contract gate back on stable); frontend 503/503 incl. new §16.1/§16.2 tests: boundary states (401/500/503/network + retry), notices, deep-link restore, credential/429/outage copy, password-clearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)