### PR TITLE
feat(capture): Gmail Pub/Sub push webhook (CAP-WIRE-N-4)

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -11,8 +11,6 @@ package main
 import (
 	// Embedded tzdata: workspace timezones must resolve on scratch
 	// containers that ship no zoneinfo.
-	_ "time/tzdata"
-
 	"context"
 	"errors"
 	"flag"
@@ -26,6 +24,7 @@ import (
 	"sync"
 	"syscall"
 	"time"
+	_ "time/tzdata"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
@@ -146,33 +145,11 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 		opts = append(opts, busReady)
 	}
 
-	coldStart, err := coldStartOptions(cfg.routingPath, cfg.fakeBrain, pool)
+	aiAndPushOpts, err := aiAndPushComposeOptions(cfg, pool, logger, stdout)
 	if err != nil {
 		return err
 	}
-	opts = append(opts, coldStart...)
-
-	offerDraft, err := offerDraftOptions(cfg.routingPath, cfg.fakeBrain, pool)
-	if err != nil {
-		return err
-	}
-	opts = append(opts, offerDraft...)
-
-	pushCfg := compose.GmailPushConfig{
-		Audience:       cfg.gmailPushAudience,
-		ServiceAccount: cfg.gmailPushSA,
-		JWKSURL:        cfg.gmailJWKSURL,
-	}
-	if pushCfg.Audience != "" && pushCfg.ServiceAccount != "" {
-		inserter, err := jobs.NewInserter(pool, logger)
-		if err != nil {
-			return fmt.Errorf("api: gmail push inserter: %w", err)
-		}
-		opts = append(opts, compose.WithGmailPush(inserter, pushCfg))
-		_, _ = fmt.Fprintln(stdout, "api gmail Pub/Sub push webhook enabled (POST /hooks/gmail/push)")
-	} else if cfg.gmailPushAudience != "" || cfg.gmailPushSA != "" {
-		_, _ = fmt.Fprintln(stdout, "api gmail push webhook configured but INCOMPLETE — needs both --gmail-push-audience and --gmail-push-service-account; surface stays 501")
-	}
+	opts = append(opts, aiAndPushOpts...)
 
 	srv := &http.Server{
 		Addr:              cfg.addr,
@@ -207,6 +184,64 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 	case <-ctx.Done():
 		return stopAll(stopHTTP())
 	}
+}
+
+// aiAndPushComposeOptions assembles the boot-optional compose.Options that
+// depend on the AI routing switches (the cold-start read-back, the
+// AI-drafted offer regeneration) plus the Gmail push webhook wiring — all
+// three share the "declared routing / --ai-fake / neither" or
+// "both-set/one-set/neither" self-gating shape, so bundling their
+// call+err-check+append triples here (instead of inline in run()) is what
+// keeps run() inside the file's long-func budget.
+func aiAndPushComposeOptions(cfg apiConfig, pool *pgxpool.Pool, logger *slog.Logger, stdout io.Writer) ([]compose.Option, error) {
+	var opts []compose.Option
+
+	coldStart, err := coldStartOptions(cfg.routingPath, cfg.fakeBrain, pool)
+	if err != nil {
+		return nil, err
+	}
+	opts = append(opts, coldStart...)
+
+	offerDraft, err := offerDraftOptions(cfg.routingPath, cfg.fakeBrain, pool)
+	if err != nil {
+		return nil, err
+	}
+	opts = append(opts, offerDraft...)
+
+	pushOpts, err := gmailPushOptions(cfg, pool, logger, stdout)
+	if err != nil {
+		return nil, err
+	}
+	opts = append(opts, pushOpts...)
+
+	return opts, nil
+}
+
+// gmailPushOptions builds the Gmail Pub/Sub push webhook compose option when
+// both the audience and push service account are configured; INCOMPLETE (only
+// one set) logs and returns no option (the route stays 501). Mirrors
+// blobstoreOptions/keyvaultOptions's slice-returning shape rather than a bare
+// compose.Option so an absent wiring is a nil slice, not a nilable func
+// return. Split out of run() so that function stays inside the file's
+// long-func budget.
+func gmailPushOptions(cfg apiConfig, pool *pgxpool.Pool, logger *slog.Logger, stdout io.Writer) ([]compose.Option, error) {
+	pushCfg := compose.GmailPushConfig{
+		Audience:       cfg.gmailPushAudience,
+		ServiceAccount: cfg.gmailPushSA,
+		JWKSURL:        cfg.gmailJWKSURL,
+	}
+	if pushCfg.Audience != "" && pushCfg.ServiceAccount != "" {
+		inserter, err := jobs.NewInserter(pool, logger)
+		if err != nil {
+			return nil, fmt.Errorf("api: gmail push inserter: %w", err)
+		}
+		_, _ = fmt.Fprintln(stdout, "api gmail Pub/Sub push webhook enabled (POST /hooks/gmail/push)")
+		return []compose.Option{compose.WithGmailPush(inserter, pushCfg)}, nil
+	}
+	if cfg.gmailPushAudience != "" || cfg.gmailPushSA != "" {
+		_, _ = fmt.Fprintln(stdout, "api gmail push webhook configured but INCOMPLETE — needs both --gmail-push-audience and --gmail-push-service-account; surface stays 501")
+	}
+	return nil, nil
 }
 
 // baseComposeOptions assembles the boot-optional compose.Options that

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -40,6 +40,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/events"
 	"github.com/gradionhq/margince/backend/internal/platform/httpserver"
+	"github.com/gradionhq/margince/backend/internal/platform/jobs"
 	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
 )
 
@@ -69,6 +70,9 @@ type apiConfig struct {
 	gmailClientID     string
 	gmailClientSecret string
 	connectorStateKey string
+	gmailPushAudience string
+	gmailPushSA       string
+	gmailJWKSURL      string
 }
 
 // parseAPIFlags parses and validates the boot flags; the DSN is the one
@@ -91,6 +95,9 @@ func parseAPIFlags(args []string) (apiConfig, error) {
 	fs.StringVar(&cfg.gmailClientSecret, "gmail-client-secret", os.Getenv("MARGINCE_GMAIL_CLIENT_SECRET"), "Google OAuth client secret for the Gmail capture connector")
 	fs.StringVar(&cfg.apiBaseURL, "api-base-url", os.Getenv("MARGINCE_API_BASE_URL"), "the api's externally-reachable base for the OAuth callback redirect_uri; defaults to --public-base-url (same-origin deployments), set only when the api is on a different origin than the SPA (e.g. dev)")
 	fs.StringVar(&cfg.connectorStateKey, "connector-state-key", os.Getenv("MARGINCE_CONNECTOR_STATE_KEY"), "HMAC key (>=32 bytes) signing the OAuth connect `state`; required for the Gmail connect flow")
+	fs.StringVar(&cfg.gmailPushAudience, "gmail-push-audience", os.Getenv("MARGINCE_GMAIL_PUSH_AUDIENCE"), "OIDC audience the Gmail Pub/Sub push subscription mints tokens for (this endpoint's public URL); with --gmail-push-service-account, enables POST /hooks/gmail/push")
+	fs.StringVar(&cfg.gmailPushSA, "gmail-push-service-account", os.Getenv("MARGINCE_GMAIL_PUSH_SERVICE_ACCOUNT"), "the Google push service account email that signs Pub/Sub push OIDC tokens; verified as the token's email claim")
+	fs.StringVar(&cfg.gmailJWKSURL, "gmail-jwks-url", os.Getenv("MARGINCE_GMAIL_JWKS_URL"), "override Google's OIDC JWKS URL (default https://www.googleapis.com/oauth2/v3/certs); test/dev only")
 	if err := fs.Parse(args); err != nil {
 		return apiConfig{}, err
 	}
@@ -150,6 +157,22 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 		return err
 	}
 	opts = append(opts, offerDraft...)
+
+	pushCfg := compose.GmailPushConfig{
+		Audience:       cfg.gmailPushAudience,
+		ServiceAccount: cfg.gmailPushSA,
+		JWKSURL:        cfg.gmailJWKSURL,
+	}
+	if pushCfg.Audience != "" && pushCfg.ServiceAccount != "" {
+		inserter, err := jobs.NewInserter(pool, logger)
+		if err != nil {
+			return fmt.Errorf("api: gmail push inserter: %w", err)
+		}
+		opts = append(opts, compose.WithGmailPush(inserter, pushCfg))
+		_, _ = fmt.Fprintln(stdout, "api gmail Pub/Sub push webhook enabled (POST /hooks/gmail/push)")
+	} else if cfg.gmailPushAudience != "" || cfg.gmailPushSA != "" {
+		_, _ = fmt.Fprintln(stdout, "api gmail push webhook configured but INCOMPLETE — needs both --gmail-push-audience and --gmail-push-service-account; surface stays 501")
+	}
 
 	srv := &http.Server{
 		Addr:              cfg.addr,

--- a/backend/internal/compose/gmailpush.go
+++ b/backend/internal/compose/gmailpush.go
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The Gmail Pub/Sub push webhook (CAP-WIRE-N-4, ADR-0062): an operational,
+// session-less edge Google POSTs a change notification to. It is NOT a CRM
+// write surface (CAP-WIRE-N-1 holds) — it OIDC-verifies Google's push token,
+// decodes {emailAddress}, and enqueues an incremental sync the worker runs;
+// no CRM data comes from the request body. The pushed historyId is ignored
+// (SyncOnce owns the cursor). Unconfigured, it answers the repo's standard 501.
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/gradionhq/margince/backend/internal/platform/httperr"
+	"github.com/gradionhq/margince/backend/internal/platform/jobs"
+)
+
+// GmailPushConfig is the deployment's Pub/Sub push identity: the audience the
+// subscription mints its OIDC token for (this endpoint's public URL) and the
+// push service account that signs it. JWKSURL defaults to Google's when empty.
+type GmailPushConfig struct {
+	Audience       string
+	ServiceAccount string
+	JWKSURL        string
+}
+
+func (c GmailPushConfig) configured() bool {
+	return c.Audience != "" && c.ServiceAccount != ""
+}
+
+// gmailPushHandler verifies then enqueues. enqueue is a seam so the transport
+// is unit-testable without a DB; WithGmailPush fills it with the River inserter.
+type gmailPushHandler struct {
+	verifier *googleOIDCVerifier
+	enqueue  func(ctx context.Context, email string) error
+}
+
+func (h gmailPushHandler) wired() bool { return h.verifier != nil && h.enqueue != nil }
+
+func (h gmailPushHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if !h.wired() {
+		httperr.NotImplemented(w, r, "gmailPush")
+		return
+	}
+	ctx := r.Context()
+	if err := h.verifier.Verify(ctx, bearerToken(r.Header.Get("Authorization"))); err != nil {
+		slog.WarnContext(ctx, "gmail push: verification failed", "err", err)
+		httperr.Write(w, r, &httperr.DetailedError{
+			Status: http.StatusUnauthorized,
+			Code:   "unauthorized",
+			Detail: "push verification failed",
+		})
+		return
+	}
+	email, err := decodePushEmail(r.Body)
+	if err != nil {
+		// An authentic Google envelope we can't decode won't parse on retry
+		// either — ack so Pub/Sub stops redelivering, and log for ops.
+		slog.WarnContext(ctx, "gmail push: undecodable payload", "err", err)
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	if email == "" {
+		w.WriteHeader(http.StatusOK) // nothing to sync
+		return
+	}
+	if err := h.enqueue(ctx, email); err != nil {
+		// A durable-enqueue failure SHOULD be retried by Pub/Sub.
+		httperr.Write(w, r, err)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+// bearerToken extracts the token from an "Authorization: Bearer <t>" header,
+// or "" when the scheme is absent/wrong.
+func bearerToken(header string) string {
+	const prefix = "Bearer "
+	if len(header) > len(prefix) && strings.EqualFold(header[:len(prefix)], prefix) {
+		return header[len(prefix):]
+	}
+	return ""
+}
+
+// pushEnvelope is the Pub/Sub push wrapper; data is base64 of the Gmail
+// notification payload.
+type pushEnvelope struct {
+	Message struct {
+		Data string `json:"data"`
+	} `json:"message"`
+}
+
+type pushPayload struct {
+	EmailAddress string `json:"emailAddress"` //nolint:tagliatelle // Gmail's wire format (camelCase)
+}
+
+// decodePushEmail reads the Pub/Sub push envelope and returns the notified
+// mailbox address. The data field is standard (not URL-safe) base64.
+func decodePushEmail(body io.Reader) (string, error) {
+	var env pushEnvelope
+	if err := json.NewDecoder(io.LimitReader(body, 1<<20)).Decode(&env); err != nil {
+		return "", fmt.Errorf("gmail push: decoding envelope: %w", err)
+	}
+	raw, err := base64.StdEncoding.DecodeString(env.Message.Data)
+	if err != nil {
+		return "", fmt.Errorf("gmail push: decoding message data: %w", err)
+	}
+	var p pushPayload
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return "", fmt.Errorf("gmail push: decoding notification: %w", err)
+	}
+	return p.EmailAddress, nil
+}
+
+// WithGmailPush wires the Gmail Pub/Sub push webhook (api role). It requires
+// the push config (audience + service account) and a River inserter; absent
+// either, the /hooks/gmail/push route keeps its declared 501 by omission.
+func WithGmailPush(inserter *jobs.Runner, c GmailPushConfig) Option {
+	return func(s *Server, _ *pgxpool.Pool) {
+		if !c.configured() || inserter == nil {
+			return
+		}
+		s.gmailPush = gmailPushHandler{
+			verifier: newGoogleOIDCVerifier(c.JWKSURL, c.Audience, c.ServiceAccount),
+			enqueue: func(ctx context.Context, email string) error {
+				return inserter.Insert(ctx, GmailPushArgs{EmailAddress: email}, gmailPushInsertOpts())
+			},
+		}
+	}
+}

--- a/backend/internal/compose/gmailpush_test.go
+++ b/backend/internal/compose/gmailpush_test.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+const testPushEmail = "rep@ws.example"
+
+func pushBody(t *testing.T) []byte {
+	t.Helper()
+	data, _ := json.Marshal(map[string]any{"emailAddress": testPushEmail, "historyId": 12345})
+	env := map[string]any{
+		"message":      map[string]any{"data": base64.StdEncoding.EncodeToString(data)},
+		"subscription": "projects/p/subscriptions/s",
+	}
+	b, _ := json.Marshal(env)
+	return b
+}
+
+func TestDecodePushEmail(t *testing.T) {
+	email, err := decodePushEmail(bytes.NewReader(pushBody(t)))
+	if err != nil {
+		t.Fatalf("decodePushEmail: %v", err)
+	}
+	if email != testPushEmail {
+		t.Errorf("email = %q, want %s", email, testPushEmail)
+	}
+}
+
+func TestDecodePushEmailMalformed(t *testing.T) {
+	if _, err := decodePushEmail(bytes.NewReader([]byte("not json"))); err == nil {
+		t.Fatal("decodePushEmail(garbage) = nil error, want error")
+	}
+}
+
+func TestBearerToken(t *testing.T) {
+	if got := bearerToken("Bearer abc.def.ghi"); got != "abc.def.ghi" {
+		t.Errorf("bearerToken = %q, want abc.def.ghi", got)
+	}
+	if got := bearerToken("Basic xyz"); got != "" {
+		t.Errorf("bearerToken(Basic) = %q, want empty", got)
+	}
+}
+
+func TestPushHandlerUnwiredReturns501(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/hooks/gmail/push", bytes.NewReader(pushBody(t)))
+	gmailPushHandler{}.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotImplemented {
+		t.Fatalf("status = %d, want 501", rec.Code)
+	}
+}
+
+func TestPushHandlerRejectsBadToken(t *testing.T) {
+	rig := newOIDCTestRig(t)
+	h := gmailPushHandler{
+		verifier: newTestVerifier(rig),
+		enqueue:  func(context.Context, string) error { t.Fatal("must not enqueue on bad token"); return nil },
+	}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/hooks/gmail/push", bytes.NewReader(pushBody(t)))
+	req.Header.Set("Authorization", "Bearer not.a.validtoken")
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+}
+
+func TestPushHandlerEnqueuesOnValidToken(t *testing.T) {
+	rig := newOIDCTestRig(t)
+	tok := rig.mint(t, testKID, "RS256", nil)
+	var got string
+	h := gmailPushHandler{
+		verifier: newTestVerifier(rig),
+		enqueue:  func(_ context.Context, email string) error { got = email; return nil },
+	}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/hooks/gmail/push", bytes.NewReader(pushBody(t)))
+	req.Header.Set("Authorization", "Bearer "+tok)
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got != testPushEmail {
+		t.Errorf("enqueued email = %q, want %s", got, testPushEmail)
+	}
+}

--- a/backend/internal/compose/integration/gmail_push_integration_test.go
+++ b/backend/internal/compose/integration/gmail_push_integration_test.go
@@ -11,9 +11,14 @@ package integration
 // can drive SyncOnce (CAP-DDL-2, CAP-WIRE-N-4, ADR-0062).
 
 import (
+	"bytes"
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"io"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -190,5 +195,47 @@ func TestGmailPushJobSyncsAndRedeliveryIsNoop(t *testing.T) {
 	awaitWatchKindCompleted(waitCtx2, t, sub, compose.GmailPushArgs{}.Kind())
 	if got := countActivities(t, e); got != after {
 		t.Fatalf("redelivery changed activity count: before=%d after=%d (want no-op)", after, got)
+	}
+}
+
+// pushBodyInt builds the Pub/Sub push envelope body. It is a local copy of
+// compose's unexported pushBody helper (gmailpush_test.go) — that helper
+// lives in package compose and isn't visible from this integration package.
+func pushBodyInt(t *testing.T, email string) []byte {
+	t.Helper()
+	data, err := json.Marshal(map[string]any{"emailAddress": email})
+	if err != nil {
+		t.Fatalf("marshal push payload: %v", err)
+	}
+	env := map[string]any{
+		"message":      map[string]any{"data": base64.StdEncoding.EncodeToString(data)},
+		"subscription": "projects/p/subscriptions/s",
+	}
+	b, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("marshal push envelope: %v", err)
+	}
+	return b
+}
+
+// TestPushRouteMountedReturns501WhenUnconfigured proves the route survives
+// the real mux (session middleware, panic recovery, secure headers) and
+// still answers the repo's standard 501 when the server is built with no
+// push config — the wired verify→enqueue→sync path is covered by Task 7's
+// job test and Task 8's handler unit tests (CAP-WIRE-N-4, ADR-0062).
+func TestPushRouteMountedReturns501WhenUnconfigured(t *testing.T) {
+	e := setupSearch(t)
+	quiet := slog.New(slog.NewTextHandler(io.Discard, nil))
+	h := compose.New(e.Pool, quiet) // no compose.WithGmailPush option: unconfigured.
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/hooks/gmail/push", "application/json", bytes.NewReader(pushBodyInt(t, "rep@ws.example")))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotImplemented {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusNotImplemented)
 	}
 }

--- a/backend/internal/compose/integration/gmail_push_integration_test.go
+++ b/backend/internal/compose/integration/gmail_push_integration_test.go
@@ -166,7 +166,9 @@ func TestGmailPushJobSyncsAndRedeliveryIsNoop(t *testing.T) {
 	defer func() {
 		stopCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
-		_ = runner.Stop(stopCtx)
+		if err := runner.Stop(stopCtx); err != nil {
+			t.Errorf("Stop: %v", err)
+		}
 	}()
 
 	ins, err := jobs.NewInserter(e.Pool, quiet)

--- a/backend/internal/compose/integration/gmail_push_integration_test.go
+++ b/backend/internal/compose/integration/gmail_push_integration_test.go
@@ -12,12 +12,17 @@ package integration
 
 import (
 	"context"
+	"io"
+	"log/slog"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/gradionhq/margince/backend/internal/compose"
 	"github.com/gradionhq/margince/backend/internal/modules/capture/gmail"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/platform/jobs"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
@@ -98,5 +103,92 @@ func TestResolveByAccountEmailFindsConnected(t *testing.T) {
 	}
 	if len(empty) != 0 {
 		t.Fatalf("ResolveByAccountEmail(empty) = %+v, want empty", empty)
+	}
+}
+
+func countActivities(t *testing.T, e *searchEnv) int {
+	t.Helper()
+	var n int
+	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(), `SELECT count(*) FROM activity`).Scan(&n)
+	})
+	if err != nil {
+		t.Fatalf("counting activity: %v", err)
+	}
+	return n
+}
+
+// TestGmailPushJobSyncsAndRedeliveryIsNoop proves the api-enqueues/worker-executes
+// split end to end: an inserter (standing in for the push webhook) enqueues a
+// GmailPushArgs job, the worker resolves the mailbox and runs SyncOnce, and a
+// second, identical push (Pub/Sub's at-least-once redelivery) leaves the
+// activity count unchanged — SyncOnce's capture key + cursor make the resync a
+// no-op (ADR-0062, CAP-WIRE-N-4).
+func TestGmailPushJobSyncsAndRedeliveryIsNoop(t *testing.T) {
+	e := setupSearch(t)
+	applyRiverSchema(t)
+	const owner = "rep@ws.example"
+
+	stub := gmailStub(t, owner)
+	oauth := gmail.NewOAuth(gmail.OAuthConfig{ClientID: "cid", ClientSecret: "sec", TokenURL: stub.URL + "/token"})
+	api := gmail.NewAPI(stub.Client(), stub.URL)
+	registry := newTestCaptureRegistry(e, newTestKeyvault(t, e))
+	registry.Register(gmail.New(oauth, api))
+
+	grantCtx := e.humanWithScopes(e.Rep1, []principal.Scope{principal.ScopeRead})
+	authReq, err := gmail.AuthRequestFrom("the-code", "https://app.test/v1/connectors/gmail/callback")
+	if err != nil {
+		t.Fatal(err)
+	}
+	auth, err := gmail.New(oauth, api).Authenticate(context.Background(), authReq)
+	if err != nil {
+		t.Fatalf("Authenticate: %v", err)
+	}
+	if _, err := registry.Connect(grantCtx, "gmail", auth); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+
+	quiet := slog.New(slog.NewTextHandler(io.Discard, nil))
+	runner, err := compose.NewJobRunner(e.Pool, quiet, time.Hour, time.Hour, registry, time.Hour, compose.GmailWatchConfig{})
+	if err != nil {
+		t.Fatalf("NewJobRunner: %v", err)
+	}
+	sub, cancelSub := runner.SubscribeCompleted()
+	defer cancelSub()
+	if err := runner.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		_ = runner.Stop(stopCtx)
+	}()
+
+	ins, err := jobs.NewInserter(e.Pool, quiet)
+	if err != nil {
+		t.Fatalf("NewInserter: %v", err)
+	}
+
+	// First push: the job runs SyncOnce and captures the stubbed mailbox.
+	if err := ins.Insert(context.Background(), compose.GmailPushArgs{EmailAddress: owner}, nil); err != nil {
+		t.Fatalf("Insert push job: %v", err)
+	}
+	waitCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	awaitWatchKindCompleted(waitCtx, t, sub, compose.GmailPushArgs{}.Kind())
+	after := countActivities(t, e)
+	if after == 0 {
+		t.Fatalf("first push captured nothing; want >0 activities")
+	}
+
+	// Redelivery: a second push over the same window creates no new rows.
+	if err := ins.Insert(context.Background(), compose.GmailPushArgs{EmailAddress: owner}, nil); err != nil {
+		t.Fatalf("Insert redelivery job: %v", err)
+	}
+	waitCtx2, cancel2 := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel2()
+	awaitWatchKindCompleted(waitCtx2, t, sub, compose.GmailPushArgs{}.Kind())
+	if got := countActivities(t, e); got != after {
+		t.Fatalf("redelivery changed activity count: before=%d after=%d (want no-op)", after, got)
 	}
 }

--- a/backend/internal/compose/integration/gmail_push_integration_test.go
+++ b/backend/internal/compose/integration/gmail_push_integration_test.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The Gmail Pub/Sub push resolution path against a stubbed Google: Connect
+// stamps account_email from the connector's AccountIdentifier seam, and
+// ResolveByAccountEmail finds the connected connection cross-tenant so a push
+// can drive SyncOnce (CAP-DDL-2, CAP-WIRE-N-4, ADR-0062).
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/modules/capture/gmail"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+func connectGmailForPush(t *testing.T, e *searchEnv, owner string) ids.UUID {
+	t.Helper()
+	stub := gmailStub(t, owner)
+	oauth := gmail.NewOAuth(gmail.OAuthConfig{ClientID: "cid", ClientSecret: "sec", TokenURL: stub.URL + "/token"})
+	api := gmail.NewAPI(stub.Client(), stub.URL)
+	registry := newTestCaptureRegistry(e, newTestKeyvault(t, e))
+	registry.Register(gmail.New(oauth, api))
+	grantCtx := e.humanWithScopes(e.Rep1, []principal.Scope{principal.ScopeRead})
+	authReq, err := gmail.AuthRequestFrom("the-code", "https://app.test/v1/connectors/gmail/callback")
+	if err != nil {
+		t.Fatal(err)
+	}
+	auth, err := gmail.New(oauth, api).Authenticate(context.Background(), authReq)
+	if err != nil {
+		t.Fatalf("Authenticate: %v", err)
+	}
+	connID, err := registry.Connect(grantCtx, "gmail", auth)
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	return connID
+}
+
+func readAccountEmail(t *testing.T, e *searchEnv, connID ids.UUID) *string {
+	t.Helper()
+	var email *string
+	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT account_email FROM capture_connection WHERE id = $1`, connID).Scan(&email)
+	})
+	if err != nil {
+		t.Fatalf("reading account_email: %v", err)
+	}
+	return email
+}
+
+func TestConnectStampsAccountEmail(t *testing.T) {
+	e := setupSearch(t)
+	const owner = "rep@ws.example"
+	connID := connectGmailForPush(t, e, owner)
+	got := readAccountEmail(t, e, connID)
+	if got == nil || *got != owner {
+		t.Fatalf("account_email = %v, want %q", got, owner)
+	}
+}

--- a/backend/internal/compose/integration/gmail_push_integration_test.go
+++ b/backend/internal/compose/integration/gmail_push_integration_test.go
@@ -67,3 +67,36 @@ func TestConnectStampsAccountEmail(t *testing.T) {
 		t.Fatalf("account_email = %v, want %q", got, owner)
 	}
 }
+
+func TestResolveByAccountEmailFindsConnected(t *testing.T) {
+	e := setupSearch(t)
+	const owner = "rep@ws.example"
+	connID := connectGmailForPush(t, e, owner)
+
+	registry := newTestCaptureRegistry(e, newTestKeyvault(t, e))
+	due, err := registry.ResolveByAccountEmail(context.Background(), "gmail", owner)
+	if err != nil {
+		t.Fatalf("ResolveByAccountEmail: %v", err)
+	}
+	if len(due) != 1 || due[0].ID != connID {
+		t.Fatalf("ResolveByAccountEmail = %+v, want the one connection %s", due, connID)
+	}
+
+	// An unknown mailbox resolves to nothing.
+	none, err := registry.ResolveByAccountEmail(context.Background(), "gmail", "stranger@nowhere.test")
+	if err != nil {
+		t.Fatalf("ResolveByAccountEmail(unknown): %v", err)
+	}
+	if len(none) != 0 {
+		t.Fatalf("ResolveByAccountEmail(unknown) = %+v, want empty", none)
+	}
+
+	// An empty email is a no-op, not a fleet scan.
+	empty, err := registry.ResolveByAccountEmail(context.Background(), "gmail", "")
+	if err != nil {
+		t.Fatalf("ResolveByAccountEmail(empty): %v", err)
+	}
+	if len(empty) != 0 {
+		t.Fatalf("ResolveByAccountEmail(empty) = %+v, want empty", empty)
+	}
+}

--- a/backend/internal/compose/jobs.go
+++ b/backend/internal/compose/jobs.go
@@ -164,17 +164,19 @@ type gmailPushWorker struct {
 }
 
 func (w *gmailPushWorker) Work(ctx context.Context, job *river.Job[GmailPushArgs]) error {
+	// ResolveByAccountEmail walks the whole fleet and returns the connections
+	// it did resolve ALONGSIDE any joined per-workspace error — so a fault in
+	// an unrelated workspace must not skip the mailbox this push named. Drain
+	// the resolved set first, then surface the enumeration error for River to
+	// retry (mirrors gmailSyncWorker); the poll backstops either way.
 	due, enumErr := w.registry.ResolveByAccountEmail(ctx, "gmail", job.Args.EmailAddress)
-	if enumErr != nil {
-		return enumErr
-	}
 	for _, d := range due {
 		wsCtx := principal.WithWorkspaceID(ctx, d.Workspace.UUID)
 		if err := w.registry.SyncOnce(wsCtx, d.ID); err != nil {
 			w.log.WarnContext(ctx, "gmail push sync failed", "connection", d.ID.String(), "err", err)
 		}
 	}
-	return nil
+	return enumErr
 }
 
 // activeSweepStates is the uniqueness window for the periodic passes: a new

--- a/backend/internal/compose/jobs.go
+++ b/backend/internal/compose/jobs.go
@@ -133,6 +133,50 @@ func (w *gmailWatchWorker) Work(ctx context.Context, _ *river.Job[GmailWatchArgs
 	return enumErr
 }
 
+// GmailPushArgs schedules one targeted incremental sync for every connection
+// bound to a mailbox a Gmail Pub/Sub push named. Inserted by the api role's
+// push webhook (gmailpush.go); executed here in the worker — the same
+// api-enqueues/worker-executes split the poll uses (CAP-WIRE-N-4).
+type GmailPushArgs struct {
+	EmailAddress string `json:"email_address"`
+}
+
+// Kind is the stable job identifier River persists in river_job.
+func (GmailPushArgs) Kind() string { return "gmail_push_sync" }
+
+// gmailPushInsertOpts coalesces redeliveries: while a push-sync for the same
+// mailbox is queued or running, an identical push is a no-op (Pub/Sub is
+// at-least-once). Not a correctness guard — SyncOnce is already idempotent on
+// the capture key — but it keeps a notification burst from fanning out.
+func gmailPushInsertOpts() *river.InsertOpts {
+	return &river.InsertOpts{UniqueOpts: river.UniqueOpts{ByArgs: true, ByState: activeSweepStates}}
+}
+
+// gmailPushWorker resolves the pushed mailbox to its connection(s) across the
+// fleet and runs one SyncOnce each under the connection's workspace. A single
+// connection's failure is logged and skipped; only a fleet-enumeration failure
+// is returned (River then retries the job). The pushed historyId is ignored —
+// SyncOnce owns the cursor.
+type gmailPushWorker struct {
+	river.WorkerDefaults[GmailPushArgs]
+	registry *capture.Registry
+	log      *slog.Logger
+}
+
+func (w *gmailPushWorker) Work(ctx context.Context, job *river.Job[GmailPushArgs]) error {
+	due, enumErr := w.registry.ResolveByAccountEmail(ctx, "gmail", job.Args.EmailAddress)
+	if enumErr != nil {
+		return enumErr
+	}
+	for _, d := range due {
+		wsCtx := principal.WithWorkspaceID(ctx, d.Workspace.UUID)
+		if err := w.registry.SyncOnce(wsCtx, d.ID); err != nil {
+			w.log.WarnContext(ctx, "gmail push sync failed", "connection", d.ID.String(), "err", err)
+		}
+	}
+	return nil
+}
+
 // activeSweepStates is the uniqueness window for the periodic passes: a new
 // tick is suppressed only while a prior run is still in flight (available,
 // pending, running, scheduled, retryable) — reproducing the old ticker's
@@ -184,6 +228,7 @@ func NewJobRunner(pool *pgxpool.Pool, log *slog.Logger, closeDateInterval, recon
 
 	if gmailReg != nil {
 		river.AddWorker(workers, &gmailSyncWorker{registry: gmailReg, log: log})
+		river.AddWorker(workers, &gmailPushWorker{registry: gmailReg, log: log})
 		periodic = append(periodic, river.NewPeriodicJob(
 			river.PeriodicInterval(gmailInterval),
 			func() (river.JobArgs, *river.InsertOpts) { return GmailSyncArgs{}, sweepInsertOpts() },

--- a/backend/internal/compose/jobs_test.go
+++ b/backend/internal/compose/jobs_test.go
@@ -16,6 +16,29 @@ func TestJobKindsAreStable(t *testing.T) {
 	if got := (FollowUpReconcileArgs{}).Kind(); got != "follow_up_reconcile" {
 		t.Errorf("FollowUpReconcileArgs.Kind() = %q, want follow_up_reconcile", got)
 	}
+	if got := (GmailPushArgs{}).Kind(); got != "gmail_push_sync" {
+		t.Errorf("GmailPushArgs.Kind() = %q, want gmail_push_sync", got)
+	}
+}
+
+// TestGmailPushInsertOptsDedupesByArgs is the load-bearing invariant for the
+// push webhook (Task 8, gmailpush.go): a Pub/Sub redelivery for the same
+// mailbox while a prior push-sync is in flight must be suppressed (ByArgs),
+// over the same in-flight window the periodic sweeps use — never including
+// completed, so a finished push-sync does not block the next one.
+func TestGmailPushInsertOptsDedupesByArgs(t *testing.T) {
+	opts := gmailPushInsertOpts()
+	if !opts.UniqueOpts.ByArgs {
+		t.Error("gmailPushInsertOpts: ByArgs = false, want true (dedupe redeliveries for the same mailbox)")
+	}
+	if len(opts.UniqueOpts.ByState) != len(activeSweepStates) {
+		t.Fatalf("gmailPushInsertOpts: ByState = %v, want activeSweepStates", opts.UniqueOpts.ByState)
+	}
+	for i, s := range activeSweepStates {
+		if opts.UniqueOpts.ByState[i] != s {
+			t.Errorf("gmailPushInsertOpts: ByState[%d] = %v, want %v", i, opts.UniqueOpts.ByState[i], s)
+		}
+	}
 }
 
 // TestUniquenessWindowExcludesCompleted is the load-bearing invariant: the

--- a/backend/internal/compose/oidcverify.go
+++ b/backend/internal/compose/oidcverify.go
@@ -304,6 +304,7 @@ func verifyRS256(key *rsa.PublicKey, signingInput, sigB64 string) error {
 	return rsa.VerifyPKCS1v15(key, crypto.SHA256, h[:], sig)
 }
 
+//craft:ignore naked-any out is the caller-supplied decode target — header vs claims, so its concrete type varies per call
 func decodeSegment(seg string, out any) error {
 	b, err := base64.RawURLEncoding.DecodeString(seg)
 	if err != nil {

--- a/backend/internal/compose/oidcverify.go
+++ b/backend/internal/compose/oidcverify.go
@@ -1,0 +1,271 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// A hand-rolled verifier for the Google-signed OIDC ID token that Google
+// Pub/Sub attaches to a push request (Authorization: Bearer <jwt>). RS256
+// only; keys are fetched from Google's JWKS endpoint and cached per its
+// Cache-Control max-age. It checks the signature and the iss/aud/email/
+// email_verified/exp/iat claims. No new module dependency — crypto/rsa +
+// net/http, mirroring gmail/client.go's hand-rolled provider I/O. Every
+// rejection collapses to one opaque error; the caller answers 401 and logs
+// the detail server-side (never echoed to the client).
+
+import (
+	"context"
+	"crypto"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const googleJWKSURL = "https://www.googleapis.com/oauth2/v3/certs"
+
+// oidcSkew tolerates small clock differences on exp/iat.
+const oidcSkew = 2 * time.Minute
+
+// errOIDCRejected is the single opaque failure the verifier returns; the
+// wrapped cause is for server-side logs only.
+var errOIDCRejected = errors.New("oidc: push token rejected")
+
+type googleOIDCVerifier struct {
+	jwksURL        string
+	audience       string
+	serviceAccount string
+	client         *http.Client
+	now            func() time.Time
+
+	mu      sync.Mutex
+	keys    map[string]*rsa.PublicKey
+	expires time.Time
+}
+
+func newGoogleOIDCVerifier(jwksURL, audience, serviceAccount string) *googleOIDCVerifier {
+	if jwksURL == "" {
+		jwksURL = googleJWKSURL
+	}
+	return &googleOIDCVerifier{
+		jwksURL:        jwksURL,
+		audience:       audience,
+		serviceAccount: serviceAccount,
+		client:         &http.Client{Timeout: 30 * time.Second},
+		now:            time.Now,
+	}
+}
+
+func (v *googleOIDCVerifier) withHTTPClient(c *http.Client) *googleOIDCVerifier {
+	v.client = c
+	return v
+}
+
+func (v *googleOIDCVerifier) withClock(now func() time.Time) *googleOIDCVerifier {
+	v.now = now
+	return v
+}
+
+type oidcHeader struct {
+	Alg string `json:"alg"`
+	Kid string `json:"kid"`
+}
+
+type oidcClaims struct {
+	Iss           string `json:"iss"`
+	Aud           string `json:"aud"`
+	Email         string `json:"email"`
+	EmailVerified bool   `json:"email_verified"`
+	Exp           int64  `json:"exp"`
+	Iat           int64  `json:"iat"`
+}
+
+// Verify returns nil only for a well-formed, correctly-signed Google push
+// token whose claims match the configured audience and push service account.
+func (v *googleOIDCVerifier) Verify(ctx context.Context, bearer string) error {
+	if bearer == "" {
+		return fmt.Errorf("%w: empty bearer", errOIDCRejected)
+	}
+	parts := strings.Split(bearer, ".")
+	if len(parts) != 3 {
+		return fmt.Errorf("%w: not a JWT", errOIDCRejected)
+	}
+	var hdr oidcHeader
+	if err := decodeSegment(parts[0], &hdr); err != nil {
+		return fmt.Errorf("%w: header: %v", errOIDCRejected, err)
+	}
+	if hdr.Alg != "RS256" {
+		return fmt.Errorf("%w: alg %q not RS256", errOIDCRejected, hdr.Alg)
+	}
+	key, err := v.key(ctx, hdr.Kid)
+	if err != nil {
+		return fmt.Errorf("%w: key: %v", errOIDCRejected, err)
+	}
+	if err := verifyRS256(key, parts[0]+"."+parts[1], parts[2]); err != nil {
+		return fmt.Errorf("%w: signature: %v", errOIDCRejected, err)
+	}
+	var claims oidcClaims
+	if err := decodeSegment(parts[1], &claims); err != nil {
+		return fmt.Errorf("%w: claims: %v", errOIDCRejected, err)
+	}
+	return v.checkClaims(claims)
+}
+
+func (v *googleOIDCVerifier) checkClaims(c oidcClaims) error {
+	if c.Iss != "accounts.google.com" && c.Iss != "https://accounts.google.com" {
+		return fmt.Errorf("%w: iss %q", errOIDCRejected, c.Iss)
+	}
+	if c.Aud != v.audience {
+		return fmt.Errorf("%w: aud mismatch", errOIDCRejected)
+	}
+	if c.Email != v.serviceAccount {
+		return fmt.Errorf("%w: email mismatch", errOIDCRejected)
+	}
+	if !c.EmailVerified {
+		return fmt.Errorf("%w: email not verified", errOIDCRejected)
+	}
+	now := v.now()
+	if c.Exp == 0 || now.After(time.Unix(c.Exp, 0).Add(oidcSkew)) {
+		return fmt.Errorf("%w: expired", errOIDCRejected)
+	}
+	if c.Iat != 0 && now.Add(oidcSkew).Before(time.Unix(c.Iat, 0)) {
+		return fmt.Errorf("%w: issued in the future", errOIDCRejected)
+	}
+	return nil
+}
+
+// key returns the cached public key for kid, refreshing the JWKS once if the
+// cache is empty, expired, or missing the kid (a rotation).
+func (v *googleOIDCVerifier) key(ctx context.Context, kid string) (*rsa.PublicKey, error) {
+	if kid == "" {
+		return nil, errors.New("no kid")
+	}
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if k, ok := v.keys[kid]; ok && v.now().Before(v.expires) {
+		return k, nil
+	}
+	if err := v.refreshLocked(ctx); err != nil {
+		return nil, err
+	}
+	k, ok := v.keys[kid]
+	if !ok {
+		return nil, fmt.Errorf("unknown kid %q", kid)
+	}
+	return k, nil
+}
+
+type jwk struct {
+	Kid string `json:"kid"`
+	Kty string `json:"kty"`
+	N   string `json:"n"`
+	E   string `json:"e"`
+}
+
+func (v *googleOIDCVerifier) refreshLocked(ctx context.Context) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, v.jwksURL, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := v.client.Do(req)
+	if err != nil {
+		return err
+	}
+	//craft:ignore swallowed-errors best-effort close of the JWKS response body — the decoded keys are what matter
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("jwks: status %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return err
+	}
+	var set struct {
+		Keys []jwk `json:"keys"`
+	}
+	if err := json.Unmarshal(body, &set); err != nil {
+		return err
+	}
+	keys := make(map[string]*rsa.PublicKey, len(set.Keys))
+	for _, k := range set.Keys {
+		if k.Kty != "RSA" || k.Kid == "" {
+			continue
+		}
+		pub, err := rsaPublicKey(k.N, k.E)
+		if err != nil {
+			continue
+		}
+		keys[k.Kid] = pub
+	}
+	if len(keys) == 0 {
+		return errors.New("jwks: no usable RSA keys")
+	}
+	v.keys = keys
+	v.expires = v.now().Add(cacheTTL(resp.Header.Get("Cache-Control")))
+	return nil
+}
+
+// cacheTTL reads max-age from a Cache-Control header, clamped to [1m, 24h]
+// with a 1h default when absent — the JWKS is safe to reuse between rotations.
+func cacheTTL(cacheControl string) time.Duration {
+	ttl := time.Hour
+	for _, part := range strings.Split(cacheControl, ",") {
+		part = strings.TrimSpace(part)
+		if v, ok := strings.CutPrefix(part, "max-age="); ok {
+			if secs, err := strconv.Atoi(v); err == nil {
+				ttl = time.Duration(secs) * time.Second
+			}
+		}
+	}
+	if ttl < time.Minute {
+		ttl = time.Minute
+	}
+	if ttl > 24*time.Hour {
+		ttl = 24 * time.Hour
+	}
+	return ttl
+}
+
+func rsaPublicKey(nB64, eB64 string) (*rsa.PublicKey, error) {
+	nBytes, err := base64.RawURLEncoding.DecodeString(nB64)
+	if err != nil {
+		return nil, err
+	}
+	eBytes, err := base64.RawURLEncoding.DecodeString(eB64)
+	if err != nil {
+		return nil, err
+	}
+	e := 0
+	for _, b := range eBytes {
+		e = e<<8 | int(b)
+	}
+	if e == 0 {
+		return nil, errors.New("jwk: zero exponent")
+	}
+	return &rsa.PublicKey{N: new(big.Int).SetBytes(nBytes), E: e}, nil
+}
+
+func verifyRS256(key *rsa.PublicKey, signingInput, sigB64 string) error {
+	sig, err := base64.RawURLEncoding.DecodeString(sigB64)
+	if err != nil {
+		return err
+	}
+	h := sha256.Sum256([]byte(signingInput))
+	return rsa.VerifyPKCS1v15(key, crypto.SHA256, h[:], sig)
+}
+
+func decodeSegment(seg string, out any) error {
+	b, err := base64.RawURLEncoding.DecodeString(seg)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(b, out)
+}

--- a/backend/internal/compose/oidcverify.go
+++ b/backend/internal/compose/oidcverify.go
@@ -35,6 +35,13 @@ const googleJWKSURL = "https://www.googleapis.com/oauth2/v3/certs"
 // oidcSkew tolerates small clock differences on exp/iat.
 const oidcSkew = 2 * time.Minute
 
+// jwksRefreshCooldown bounds JWKS refreshes across calls, not just within
+// one: the header's alg/kid are read before any signature check, so an
+// unauthenticated caller can force a cache miss on every request just by
+// sending a never-seen kid. Without this cooldown, a burst of such tokens
+// would drive one outbound HTTPS fetch (and one hold of v.mu) per request.
+const jwksRefreshCooldown = time.Minute
+
 // errOIDCRejected is the single opaque failure the verifier returns; the
 // wrapped cause is for server-side logs only.
 var errOIDCRejected = errors.New("oidc: push token rejected")
@@ -46,9 +53,10 @@ type googleOIDCVerifier struct {
 	client         *http.Client
 	now            func() time.Time
 
-	mu      sync.Mutex
-	keys    map[string]*rsa.PublicKey
-	expires time.Time
+	mu          sync.Mutex
+	keys        map[string]*rsa.PublicKey
+	expires     time.Time
+	nextRefresh time.Time
 }
 
 func newGoogleOIDCVerifier(jwksURL, audience, serviceAccount string) *googleOIDCVerifier {
@@ -142,25 +150,35 @@ func (v *googleOIDCVerifier) checkClaims(c oidcClaims) error {
 	return nil
 }
 
-// key returns the cached public key for kid, refreshing the JWKS once if the
-// cache is empty, expired, or missing the kid (a rotation).
+// key returns the cached public key for kid, refreshing the JWKS if the
+// cache is empty, expired, or missing the kid (a rotation) — subject to
+// jwksRefreshCooldown throttling refreshes across calls.
 func (v *googleOIDCVerifier) key(ctx context.Context, kid string) (*rsa.PublicKey, error) {
 	if kid == "" {
 		return nil, errors.New("no kid")
 	}
-	v.mu.Lock()
-	defer v.mu.Unlock()
-	if k, ok := v.keys[kid]; ok && v.now().Before(v.expires) {
+	if k, ok := v.lookupKey(kid); ok {
 		return k, nil
 	}
-	if err := v.refreshLocked(ctx); err != nil {
+	if err := v.refresh(ctx); err != nil {
 		return nil, err
 	}
-	k, ok := v.keys[kid]
+	k, ok := v.lookupKey(kid)
 	if !ok {
 		return nil, fmt.Errorf("unknown kid %q", kid)
 	}
 	return k, nil
+}
+
+// lookupKey reports the cached key for kid, if any, and whether the cache
+// (as a whole) is still within its TTL.
+func (v *googleOIDCVerifier) lookupKey(kid string) (*rsa.PublicKey, bool) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if k, ok := v.keys[kid]; ok && v.now().Before(v.expires) {
+		return k, true
+	}
+	return nil, false
 }
 
 type jwk struct {
@@ -170,29 +188,55 @@ type jwk struct {
 	E   string `json:"e"`
 }
 
-func (v *googleOIDCVerifier) refreshLocked(ctx context.Context) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, v.jwksURL, nil)
+// refresh throttles JWKS fetches to at most one per jwksRefreshCooldown
+// across all callers, and performs the network fetch without holding v.mu —
+// only the cooldown decision and the eventual cache swap are locked.
+func (v *googleOIDCVerifier) refresh(ctx context.Context) error {
+	v.mu.Lock()
+	now := v.now()
+	if now.Before(v.nextRefresh) {
+		v.mu.Unlock()
+		return errors.New("jwks: refresh throttled")
+	}
+	v.nextRefresh = now.Add(jwksRefreshCooldown)
+	v.mu.Unlock()
+
+	keys, expires, err := v.fetchJWKS(ctx)
 	if err != nil {
 		return err
 	}
+	v.mu.Lock()
+	v.keys = keys
+	v.expires = expires
+	v.mu.Unlock()
+	return nil
+}
+
+// fetchJWKS performs the outbound HTTPS GET and parses the key set. It takes
+// no lock: it is called from refresh with v.mu already released.
+func (v *googleOIDCVerifier) fetchJWKS(ctx context.Context) (map[string]*rsa.PublicKey, time.Time, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, v.jwksURL, nil)
+	if err != nil {
+		return nil, time.Time{}, err
+	}
 	resp, err := v.client.Do(req)
 	if err != nil {
-		return err
+		return nil, time.Time{}, err
 	}
 	//craft:ignore swallowed-errors best-effort close of the JWKS response body — the decoded keys are what matter
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("jwks: status %d", resp.StatusCode)
+		return nil, time.Time{}, fmt.Errorf("jwks: status %d", resp.StatusCode)
 	}
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
-		return err
+		return nil, time.Time{}, err
 	}
 	var set struct {
 		Keys []jwk `json:"keys"`
 	}
 	if err := json.Unmarshal(body, &set); err != nil {
-		return err
+		return nil, time.Time{}, err
 	}
 	keys := make(map[string]*rsa.PublicKey, len(set.Keys))
 	for _, k := range set.Keys {
@@ -206,11 +250,9 @@ func (v *googleOIDCVerifier) refreshLocked(ctx context.Context) error {
 		keys[k.Kid] = pub
 	}
 	if len(keys) == 0 {
-		return errors.New("jwks: no usable RSA keys")
+		return nil, time.Time{}, errors.New("jwks: no usable RSA keys")
 	}
-	v.keys = keys
-	v.expires = v.now().Add(cacheTTL(resp.Header.Get("Cache-Control")))
-	return nil
+	return keys, v.now().Add(cacheTTL(resp.Header.Get("Cache-Control"))), nil
 }
 
 // cacheTTL reads max-age from a Cache-Control header, clamped to [1m, 24h]

--- a/backend/internal/compose/oidcverify_test.go
+++ b/backend/internal/compose/oidcverify_test.go
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+const (
+	testAud = "https://api.test/hooks/gmail/push"
+	testSA  = "gmail-push@margince.iam.gserviceaccount.com"
+	testKID = "test-key-1"
+)
+
+// oidcTestRig serves a JWKS for one RSA key and mints signed tokens against it.
+type oidcTestRig struct {
+	key *rsa.PrivateKey
+	srv *httptest.Server
+}
+
+func newOIDCTestRig(t *testing.T) *oidcTestRig {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rig := &oidcTestRig{key: key}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/certs", func(w http.ResponseWriter, _ *http.Request) {
+		n := base64.RawURLEncoding.EncodeToString(key.N.Bytes())
+		e := base64.RawURLEncoding.EncodeToString(big.NewInt(int64(key.E)).Bytes())
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"keys": []map[string]string{
+				{"kid": testKID, "kty": "RSA", "alg": "RS256", "use": "sig", "n": n, "e": e},
+			},
+		})
+	})
+	rig.srv = httptest.NewServer(mux)
+	t.Cleanup(rig.srv.Close)
+	return rig
+}
+
+func (r *oidcTestRig) jwksURL() string { return r.srv.URL + "/certs" }
+
+// mint builds a signed JWT. Pass kid="" to sign without a kid header; alg
+// overrides RS256; claims are merged over a valid default.
+func (r *oidcTestRig) mint(t *testing.T, kid, alg string, claims map[string]any) string {
+	t.Helper()
+	if alg == "" {
+		alg = "RS256"
+	}
+	header := map[string]any{"alg": alg, "typ": "JWT"}
+	if kid != "" {
+		header["kid"] = kid
+	}
+	base := map[string]any{
+		"iss":            "https://accounts.google.com",
+		"aud":            testAud,
+		"email":          testSA,
+		"email_verified": true,
+		"exp":            time.Now().Add(time.Hour).Unix(),
+		"iat":            time.Now().Add(-time.Minute).Unix(),
+	}
+	for k, v := range claims {
+		base[k] = v
+	}
+	seg := func(v any) string {
+		b, _ := json.Marshal(v)
+		return base64.RawURLEncoding.EncodeToString(b)
+	}
+	signingInput := seg(header) + "." + seg(base)
+	h := sha256.Sum256([]byte(signingInput))
+	sig, err := rsa.SignPKCS1v15(rand.Reader, r.key, crypto.SHA256, h[:])
+	if err != nil {
+		t.Fatal(err)
+	}
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(sig)
+}
+
+func newTestVerifier(rig *oidcTestRig) *googleOIDCVerifier {
+	return newGoogleOIDCVerifier(rig.jwksURL(), testAud, testSA).withHTTPClient(rig.srv.Client())
+}
+
+func TestOIDCVerifyAcceptsValidToken(t *testing.T) {
+	rig := newOIDCTestRig(t)
+	tok := rig.mint(t, testKID, "RS256", nil)
+	if err := newTestVerifier(rig).Verify(context.Background(), tok); err != nil {
+		t.Fatalf("Verify(valid) = %v, want nil", err)
+	}
+}
+
+func TestOIDCVerifyRejects(t *testing.T) {
+	rig := newOIDCTestRig(t)
+	other, _ := rsa.GenerateKey(rand.Reader, 2048)
+
+	cases := []struct {
+		name string
+		tok  func() string
+	}{
+		{"empty", func() string { return "" }},
+		{"not-three-segments", func() string { return "a.b" }},
+		{"alg-none", func() string { return rig.mint(t, testKID, "none", nil) }},
+		{"unknown-kid", func() string { return rig.mint(t, "nope", "RS256", nil) }},
+		{"wrong-aud", func() string { return rig.mint(t, testKID, "RS256", map[string]any{"aud": "https://evil.test"}) }},
+		{"wrong-email", func() string { return rig.mint(t, testKID, "RS256", map[string]any{"email": "attacker@evil.test"}) }},
+		{"email-unverified", func() string { return rig.mint(t, testKID, "RS256", map[string]any{"email_verified": false}) }},
+		{"wrong-iss", func() string { return rig.mint(t, testKID, "RS256", map[string]any{"iss": "https://evil.test"}) }},
+		{"expired", func() string {
+			return rig.mint(t, testKID, "RS256", map[string]any{"exp": time.Now().Add(-time.Hour).Unix()})
+		}},
+		{"future-iat", func() string {
+			return rig.mint(t, testKID, "RS256", map[string]any{"iat": time.Now().Add(time.Hour).Unix()})
+		}},
+		{"bad-signature", func() string {
+			// A token signed by a DIFFERENT key but advertising the served kid.
+			evil := &oidcTestRig{key: other, srv: rig.srv}
+			return evil.mint(t, testKID, "RS256", nil)
+		}},
+	}
+	v := newTestVerifier(rig)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := v.Verify(context.Background(), tc.tok()); err == nil {
+				t.Fatalf("Verify(%s) = nil, want an error", tc.name)
+			}
+		})
+	}
+}
+
+// TestOIDCVerifyHonorsInjectedClock exercises the withClock test seam: the
+// same token accepted "now" is rejected once the injected clock is moved
+// past exp+skew, and rejected again when moved before iat-skew.
+func TestOIDCVerifyHonorsInjectedClock(t *testing.T) {
+	rig := newOIDCTestRig(t)
+	iat := time.Now()
+	exp := iat.Add(time.Hour)
+	tok := rig.mint(t, testKID, "RS256", map[string]any{
+		"iat": iat.Unix(),
+		"exp": exp.Unix(),
+	})
+
+	atIssue := newTestVerifier(rig).withClock(func() time.Time { return iat })
+	if err := atIssue.Verify(context.Background(), tok); err != nil {
+		t.Fatalf("Verify(at issue) = %v, want nil", err)
+	}
+
+	longAfterExpiry := newTestVerifier(rig).withClock(func() time.Time { return exp.Add(time.Hour) })
+	if err := longAfterExpiry.Verify(context.Background(), tok); err == nil {
+		t.Fatal("Verify(long after exp) = nil, want an error")
+	}
+
+	longBeforeIssue := newTestVerifier(rig).withClock(func() time.Time { return iat.Add(-time.Hour) })
+	if err := longBeforeIssue.Verify(context.Background(), tok); err == nil {
+		t.Fatal("Verify(long before iat) = nil, want an error")
+	}
+}

--- a/backend/internal/compose/oidcverify_test.go
+++ b/backend/internal/compose/oidcverify_test.go
@@ -14,6 +14,7 @@ import (
 	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -24,10 +25,13 @@ const (
 	testKID = "test-key-1"
 )
 
-// oidcTestRig serves a JWKS for one RSA key and mints signed tokens against it.
+// oidcTestRig serves a JWKS for one RSA key and mints signed tokens against
+// it. certsHits counts how many times the /certs endpoint was actually hit,
+// for asserting refresh-throttling behavior.
 type oidcTestRig struct {
-	key *rsa.PrivateKey
-	srv *httptest.Server
+	key       *rsa.PrivateKey
+	srv       *httptest.Server
+	certsHits atomic.Int32
 }
 
 func newOIDCTestRig(t *testing.T) *oidcTestRig {
@@ -39,6 +43,7 @@ func newOIDCTestRig(t *testing.T) *oidcTestRig {
 	rig := &oidcTestRig{key: key}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/certs", func(w http.ResponseWriter, _ *http.Request) {
+		rig.certsHits.Add(1)
 		n := base64.RawURLEncoding.EncodeToString(key.N.Bytes())
 		e := base64.RawURLEncoding.EncodeToString(big.NewInt(int64(key.E)).Bytes())
 		w.Header().Set("Content-Type", "application/json")
@@ -54,6 +59,8 @@ func newOIDCTestRig(t *testing.T) *oidcTestRig {
 }
 
 func (r *oidcTestRig) jwksURL() string { return r.srv.URL + "/certs" }
+
+func (r *oidcTestRig) certsHitCount() int32 { return r.certsHits.Load() }
 
 // mint builds a signed JWT. Pass kid="" to sign without a kid header; alg
 // overrides RS256; claims are merged over a valid default.
@@ -165,5 +172,46 @@ func TestOIDCVerifyHonorsInjectedClock(t *testing.T) {
 	longBeforeIssue := newTestVerifier(rig).withClock(func() time.Time { return iat.Add(-time.Hour) })
 	if err := longBeforeIssue.Verify(context.Background(), tok); err == nil {
 		t.Fatal("Verify(long before iat) = nil, want an error")
+	}
+}
+
+// TestOIDCVerifyThrottlesJWKSRefresh proves the cross-call refresh bound: an
+// unauthenticated caller can force a cache miss on every request just by
+// sending a never-seen kid (no valid signature required to reach the key
+// lookup), so refreshes must be throttled regardless of how many distinct
+// kids arrive within the cooldown.
+func TestOIDCVerifyThrottlesJWKSRefresh(t *testing.T) {
+	rig := newOIDCTestRig(t)
+	now := time.Now()
+	v := newTestVerifier(rig).withClock(func() time.Time { return now })
+
+	tok1 := rig.mint(t, "unknown-kid-1", "RS256", nil)
+	tok2 := rig.mint(t, "unknown-kid-2", "RS256", nil)
+
+	if err := v.Verify(context.Background(), tok1); err == nil {
+		t.Fatal("Verify(unknown kid 1) = nil, want an error")
+	}
+	if err := v.Verify(context.Background(), tok2); err == nil {
+		t.Fatal("Verify(unknown kid 2) = nil, want an error")
+	}
+	if got := rig.certsHitCount(); got != 1 {
+		t.Fatalf("certs hits after two distinct unknown kids within cooldown = %d, want 1", got)
+	}
+
+	// Advance the injected clock past the cooldown: the next unknown-kid
+	// attempt must trigger a second fetch.
+	now = now.Add(jwksRefreshCooldown)
+	tok3 := rig.mint(t, "unknown-kid-3", "RS256", nil)
+	if err := v.Verify(context.Background(), tok3); err == nil {
+		t.Fatal("Verify(unknown kid 3) = nil, want an error")
+	}
+	if got := rig.certsHitCount(); got != 2 {
+		t.Fatalf("certs hits after cooldown elapsed = %d, want 2", got)
+	}
+
+	// The accept path for a real, cached kid still works after all this.
+	valid := rig.mint(t, testKID, "RS256", nil)
+	if err := v.Verify(context.Background(), valid); err != nil {
+		t.Fatalf("Verify(valid) = %v, want nil", err)
 	}
 }

--- a/backend/internal/compose/oidcverify_test.go
+++ b/backend/internal/compose/oidcverify_test.go
@@ -47,6 +47,7 @@ func newOIDCTestRig(t *testing.T) *oidcTestRig {
 		n := base64.RawURLEncoding.EncodeToString(key.N.Bytes())
 		e := base64.RawURLEncoding.EncodeToString(big.NewInt(int64(key.E)).Bytes())
 		w.Header().Set("Content-Type", "application/json")
+		//craft:ignore swallowed-errors best-effort test JWKS response encode
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"keys": []map[string]string{
 				{"kid": testKID, "kty": "RSA", "alg": "RS256", "use": "sig", "n": n, "e": e},

--- a/backend/internal/compose/server.go
+++ b/backend/internal/compose/server.go
@@ -68,6 +68,7 @@ type Server struct {
 	scrapeHandlers
 	imapConnectHandlers
 	connectorHandlers
+	gmailPush gmailPushHandler
 	captureExclusionHandlers
 	filteredExportHandlers
 	orgRollupHandlers
@@ -429,6 +430,10 @@ func operationalMux(srv Server, pool *pgxpool.Pool, log *slog.Logger, authH auth
 	mux.HandleFunc("/metrics", httpserver.Metrics(pool,
 		func(ctx context.Context) (int64, error) { return events.OutboxBacklog(ctx, pool) },
 		events.PublishedTotal))
+	// The Gmail Pub/Sub push webhook (CAP-WIRE-N-4): a session-less machine
+	// edge outside /v1 — it self-verifies Google's OIDC token. Unwired, the
+	// handler answers 501 (declared-but-absent by omission).
+	mux.Handle("/hooks/gmail/push", srv.gmailPush)
 	// The anonymous public edges sit between the session middleware (which
 	// lets /v1/public/ through without session or workspace) and the
 	// router: each resolves its own token/slug → tenant, throttles, and

--- a/backend/internal/modules/capture/gmail/gmail.go
+++ b/backend/internal/modules/capture/gmail/gmail.go
@@ -52,8 +52,9 @@ type Connector struct {
 func New(oauth OAuth, api API) *Connector { return &Connector{oauth: oauth, api: api} }
 
 var (
-	_ connector.Connector = (*Connector)(nil)
-	_ connector.Watcher   = (*Connector)(nil)
+	_ connector.Connector         = (*Connector)(nil)
+	_ connector.Watcher           = (*Connector)(nil)
+	_ connector.AccountIdentifier = (*Connector)(nil)
 )
 
 // authState is the persisted credential bundle (the opaque connector.Auth).
@@ -284,6 +285,17 @@ func (c *Connector) HealthCheck(ctx context.Context, auth connector.Auth) error 
 		return err
 	}
 	return nil
+}
+
+// AccountID returns the mailbox owner recorded in the sealed auth bundle —
+// the emailAddress a Gmail Pub/Sub push carries. Pure: it only reads the
+// already-resolved Auth, so the registry can stamp account_email at Connect.
+func (c *Connector) AccountID(auth connector.Auth) (string, error) {
+	var st authState
+	if err := json.Unmarshal(auth, &st); err != nil {
+		return "", fmt.Errorf("gmail: malformed auth state: %w", err)
+	}
+	return st.Owner, nil
 }
 
 // parseCursor reads the stored watermark. An empty cursor means a genuinely

--- a/backend/internal/modules/capture/gmail/gmail_test.go
+++ b/backend/internal/modules/capture/gmail/gmail_test.go
@@ -291,3 +291,24 @@ func TestNormalizeSkipsAutomatedMail(t *testing.T) {
 		t.Fatalf("want 1 record gmail:keep@acme.com, got %+v", recs)
 	}
 }
+
+func TestAccountIDReturnsOwner(t *testing.T) {
+	c := New(nil, nil)
+	auth, err := json.Marshal(authState{RefreshToken: "r", Owner: "rep@ws.example", Scopes: []string{"read"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := c.AccountID(auth)
+	if err != nil {
+		t.Fatalf("AccountID: %v", err)
+	}
+	if got != "rep@ws.example" {
+		t.Errorf("AccountID = %q, want rep@ws.example", got)
+	}
+}
+
+func TestAccountIDRejectsMalformedAuth(t *testing.T) {
+	if _, err := New(nil, nil).AccountID([]byte("not json")); err == nil {
+		t.Fatal("AccountID(malformed) = nil error, want an error")
+	}
+}

--- a/backend/internal/modules/capture/gmail/gmail_test.go
+++ b/backend/internal/modules/capture/gmail/gmail_test.go
@@ -294,6 +294,7 @@ func TestNormalizeSkipsAutomatedMail(t *testing.T) {
 
 func TestAccountIDReturnsOwner(t *testing.T) {
 	c := New(nil, nil)
+	//nolint:gosec,nolintlint // G117: test fixture refresh token, not a real credential (the strict config excludes gosec on _test.go, so nolintlint would otherwise call this directive unused there)
 	auth, err := json.Marshal(authState{RefreshToken: "r", Owner: "rep@ws.example", Scopes: []string{"read"}})
 	if err != nil {
 		t.Fatal(err)

--- a/backend/internal/modules/capture/registry.go
+++ b/backend/internal/modules/capture/registry.go
@@ -114,6 +114,15 @@ func (r *Registry) Connect(ctx context.Context, name string, auth connector.Auth
 	for _, s := range c.Descriptor().Scopes {
 		scopes = append(scopes, string(s))
 	}
+	// The mailbox address, if this connector names one (AccountIdentifier),
+	// so an inbound provider push can resolve account -> connection. A
+	// connector without the seam leaves account_email NULL (CAP-DDL-2).
+	var accountEmail *string
+	if ident, ok := c.(connector.AccountIdentifier); ok {
+		if id, err := ident.AccountID(auth); err == nil && id != "" {
+			accountEmail = &id
+		}
+	}
 	ws, ok := principal.WorkspaceID(ctx)
 	if !ok {
 		return ids.Nil, errors.New("capture: connector grant outside workspace context")
@@ -133,12 +142,12 @@ func (r *Registry) Connect(ctx context.Context, name string, auth connector.Auth
 	var id ids.UUID
 	err = database.WithWorkspaceTx(ctx, r.pool, func(tx pgx.Tx) error {
 		return tx.QueryRow(ctx, `
-			INSERT INTO capture_connection (workspace_id, provider, user_id, scopes, credential_ref, status)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3, $4, 'connected')
+			INSERT INTO capture_connection (workspace_id, provider, user_id, scopes, credential_ref, status, account_email)
+			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3, $4, 'connected', $5)
 			ON CONFLICT (workspace_id, user_id, provider)
-			DO UPDATE SET credential_ref = EXCLUDED.credential_ref, auth = NULL, status = 'connected', archived_at = NULL
+			DO UPDATE SET credential_ref = EXCLUDED.credential_ref, auth = NULL, status = 'connected', archived_at = NULL, account_email = EXCLUDED.account_email
 			RETURNING id`,
-			name, actor.UserID, scopes, string(ref)).Scan(&id)
+			name, actor.UserID, scopes, string(ref), accountEmail).Scan(&id)
 	})
 	if err != nil {
 		return ids.Nil, fmt.Errorf("capture: storing connection: %w", err)

--- a/backend/internal/modules/capture/registry_connections.go
+++ b/backend/internal/modules/capture/registry_connections.go
@@ -111,6 +111,31 @@ func (r *Registry) DueConnections(ctx context.Context, name string) ([]DueConnec
 	})
 }
 
+// ResolveByAccountEmail lists every connected connection for provider name
+// whose account_email matches, across the whole fleet — the reverse lookup an
+// inbound provider push needs (it carries the mailbox address, not the
+// workspace). It reuses the RLS fleet-walk collectDue shares with the poll and
+// the watch scan: capture_connection is RLS-scoped, so the walk enters each
+// workspace's own GUC before selecting, tagging each hit with its workspace so
+// the caller can drive SyncOnce under the right tenant. An empty email is a
+// no-op (never a full scan). The same mailbox connected in more than one
+// workspace resolves to the full set — each connection has its own cursor.
+func (r *Registry) ResolveByAccountEmail(ctx context.Context, name, accountEmail string) ([]DueConnection, error) {
+	if accountEmail == "" {
+		return nil, nil
+	}
+	return r.collectDue(ctx, func(ctx context.Context, tx pgx.Tx) ([]ids.UUID, error) {
+		rows, err := tx.Query(ctx, `
+			SELECT id FROM capture_connection
+			WHERE provider = $1 AND account_email = $2 AND status = 'connected' AND archived_at IS NULL`,
+			name, accountEmail)
+		if err != nil {
+			return nil, err
+		}
+		return pgx.CollectRows(rows, pgx.RowTo[ids.UUID])
+	})
+}
+
 // collectDue is the RLS fleet-walk the poll (DueConnections) and the watch scan
 // (DueWatches) share: it enumerates every live workspace, enters each one's own
 // GUC, and appends the connection ids the per-workspace selector returns, tagged

--- a/backend/internal/platform/jobs/jobs.go
+++ b/backend/internal/platform/jobs/jobs.go
@@ -49,6 +49,28 @@ func New(pool *pgxpool.Pool, cfg Config, log *slog.Logger) (*Runner, error) {
 	return &Runner{client: client}, nil
 }
 
+// NewInserter builds an INSERT-ONLY River client over the pool — no queues,
+// no workers, never Started. It is for a process role (the api) that enqueues
+// jobs another role (the worker) executes: Insert writes the river_job row and
+// the worker's leader-elected client picks it up by Kind. The pool must
+// outlive the returned Runner.
+func NewInserter(pool *pgxpool.Pool, log *slog.Logger) (*Runner, error) {
+	client, err := river.NewClient(riverpgxv5.New(pool), &river.Config{Logger: log})
+	if err != nil {
+		return nil, fmt.Errorf("jobs: new inserter: %w", err)
+	}
+	return &Runner{client: client}, nil
+}
+
+// Insert enqueues one job. Safe from an insert-only Runner (NewInserter): the
+// row is durable the moment Insert returns, independent of any worker running.
+func (r *Runner) Insert(ctx context.Context, args river.JobArgs, opts *river.InsertOpts) error {
+	if _, err := r.client.Insert(ctx, args, opts); err != nil {
+		return fmt.Errorf("jobs: insert %s: %w", args.Kind(), err)
+	}
+	return nil
+}
+
 // Start begins working the configured queues and returns once startup
 // completes; the client keeps running until Stop. Leadership is elected
 // cluster-wide, so periodic jobs fire exactly once across all replicas.

--- a/backend/internal/platform/jobs/jobs_test.go
+++ b/backend/internal/platform/jobs/jobs_test.go
@@ -118,3 +118,38 @@ func TestRunnerStartsAndStopsCleanlyAsAppRole(t *testing.T) {
 		t.Fatalf("Stop: %v", err)
 	}
 }
+
+// TestInserterInsertsAJobRow proves the insert-only client (the api role's
+// shape: no queues, no workers, never Started) can still durably enqueue a
+// row the worker's client would pick up by Kind. migratedAppPool applies the
+// River schema and grants first; a second app-role pool is opened here to
+// drive the inserter and to read back the row without widening Runner's API
+// with a Client() accessor.
+func TestInserterInsertsAJobRow(t *testing.T) {
+	migratedAppPool(t) // migrates schema + grants on the test DB as a side effect
+	ctx := t.Context()
+
+	appDSN := os.Getenv("MARGINCE_TEST_APP_DSN")
+	appPool, err := database.NewPool(ctx, appDSN)
+	if err != nil {
+		t.Fatalf("opening app pool: %v", err)
+	}
+	t.Cleanup(appPool.Close)
+
+	ins, err := jobs.NewInserter(appPool, quietLogger())
+	if err != nil {
+		t.Fatalf("NewInserter: %v", err)
+	}
+	if err := ins.Insert(ctx, noopArgs{}, nil); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	var n int
+	if err := appPool.QueryRow(ctx,
+		`SELECT count(*) FROM river_job WHERE kind = 'noop'`).Scan(&n); err != nil {
+		t.Fatalf("counting river_job: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("river_job noop count = %d, want 1", n)
+	}
+}

--- a/backend/internal/shared/ports/connector/connector.go
+++ b/backend/internal/shared/ports/connector/connector.go
@@ -73,6 +73,19 @@ type WatchResult struct {
 	ExpiresAt time.Time
 }
 
+// AccountIdentifier is the OPTIONAL seam a connector implements when its
+// persisted Auth names a provider account (a mailbox address for mail
+// connectors) — the key an inbound provider push carries to say which
+// account changed. The registry type-asserts for it at Connect time and
+// stores the id in capture_connection.account_email (CAP-DDL-2), which the
+// Gmail Pub/Sub push resolves against. A connector that has no such account
+// (the one-shot IMAP puller) does not implement it.
+type AccountIdentifier interface {
+	// AccountID returns the provider account this Auth belongs to. It is pure
+	// (no I/O) — it reads only the already-resolved Auth bundle.
+	AccountID(auth Auth) (string, error)
+}
+
 // Descriptor — declared capabilities; ⊆ the granting human's scopes.
 type Descriptor struct {
 	Name     string // stable id: "gmail", "gcal", "hubspot", "coldstart-scrape"

--- a/backend/migrations/core/0079_capture_connection_account_email.down.sql
+++ b/backend/migrations/core/0079_capture_connection_account_email.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_capture_connection_account;
+ALTER TABLE capture_connection DROP COLUMN IF EXISTS account_email;

--- a/backend/migrations/core/0079_capture_connection_account_email.up.sql
+++ b/backend/migrations/core/0079_capture_connection_account_email.up.sql
@@ -1,0 +1,11 @@
+-- 0079: capture_connection.account_email — the provider account (mailbox
+-- address) an inbound Gmail Pub/Sub push carries, so a push can resolve
+-- emailAddress -> connection (+ workspace) cross-tenant (CAP-DDL-2, ADR-0062).
+-- Populated at Connect from the connector's AccountIdentifier seam; NULL for a
+-- connection made before this column existed (it stays on the poll until a
+-- re-connect). The partial index serves the push lookup.
+
+ALTER TABLE capture_connection ADD COLUMN account_email text NULL;
+
+CREATE INDEX idx_capture_connection_account ON capture_connection (provider, account_email)
+  WHERE account_email IS NOT NULL AND archived_at IS NULL;


### PR DESCRIPTION
Turns a Gmail `users.watch` Pub/Sub push into an incremental capture sync — closing the loop the watch register+renew lifecycle (#92) opened. A registered watch was dark until now; capture becomes near-real-time instead of poll-only.

**Spec:** gradionhq/margince-foundation#1079 (ADR-0062 + capture.md CAP-WIRE-N-4 / CAP-DDL-2 `account_email`). Chain rule — merge the spec first.

## What it does
- **Operational route** `POST /hooks/gmail/push`, mounted in `operationalMux` **outside `/v1`, the session middleware, and the agent gate** — not a `crm.yaml` op (CAP-WIRE-N-1 holds). No contract change, no regen.
- **Hand-rolled Google OIDC verification** (`oidcverify.go`, stdlib crypto, no new dependency): RS256 against Google's JWKS (`kid`-selected), `iss`/`aud`/`email`/`email_verified`/`exp`/`iat`; `alg != RS256` rejected before any signature work; single opaque error (no oracle); JWKS refresh throttled across calls and lock dropped during the fetch (unknown-`kid` amplification defense).
- **api enqueues, worker executes** — the same split the poll uses. The handler verifies → decodes `{emailAddress}` → enqueues a `gmail_push_sync` River job (insert-only `Runner`); the worker resolves `emailAddress → capture_connection(s)` cross-tenant via the RLS fleet-walk (`ResolveByAccountEmail`) and runs the existing `SyncOnce` per connection. The pushed `historyId` is ignored (SyncOnce owns the cursor).
- **`account_email`** (migration 0079, nullable + partial index) stamped at `Connect` via a new optional `connector.AccountIdentifier` seam; a connector without it stays on the poll.
- **Idempotent:** redelivery is a no-op via the capture key + cursor (proven end-to-end by running two jobs that both execute).
- **Graceful degradation:** unconfigured (no push audience/service-account) → 501 everywhere.

## Ack semantics
401 verify-fail (Pub/Sub retries) · 200 for an authentic-but-undecodable envelope (retry won't fix) · 200 no-op empty email · 500 enqueue failure (retry) · 200 success.

## Testing
Unit: OIDC accept + 11 reject cases + throttle; handler 501/401/200 + decode; `AccountID`; insert-only Runner; insert-opts dedupe. Integration (DB-gated): `Connect` stamps `account_email`; `ResolveByAccountEmail` cross-tenant; push job → SyncOnce + **redelivery no-op**; route mounts + 501s unconfigured. Full gate green: `golangci-lint` default+strict 0, craft gate 0/0/0, file-length OK.

## Scope
Gmail Pub/Sub push + verification + sync-trigger only. No Graph/M365, gcal, WhatsApp/Telegram, or OAuth-app posture change. `connectors.go` untouched; `server.go` edit is one route line + a struct field (minimal, to avoid fighting the parallel gcal branch). If gcal merges 0079 first, expect a trivial migration renumber.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Gmail Pub/Sub push notifications to trigger incremental mailbox synchronization.
  * Added secure webhook authentication and handling for valid Gmail push requests.
  * Added mailbox account identification to support resolving connected Gmail accounts.
  * Duplicate push notifications are automatically deduplicated.

* **Bug Fixes**
  * Invalid webhook requests are rejected, while malformed notifications are safely acknowledged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->