### PR TITLE
feat(siteread): the read-back reads the site — Impressum probe, robots honor, design-system form

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -8049,7 +8049,7 @@ components:
         ONLY for `source_kind=url` (nullable otherwise — text/self-description evidence has no URL).
       required: [field, value, evidence_snippet, source_kind, confidence]
       properties:
-        field: { type: string, enum: [icp, buying_center, value_proposition, usp, buying_intents, legal_name, registered_address, register_vat, industry, history] }
+        field: { type: string, enum: [icp, buying_center, value_proposition, usp, buying_intents, legal_name, registered_address, register_vat, industry, history, display_name] }
         value: { type: string }
         evidence_snippet: { type: string, minLength: 1, description: 'Verbatim source text (from the page, the pasted text, or the user''s own words) — non-empty or the field is absent.' }
         source_kind: { type: string, enum: [url, text, self_description], description: 'Where evidence_snippet came from. For self_description the "evidence" is the user''s own statement — a self-declared ICP is grounded in that statement (B-E01.13), not fabricated.' }

--- a/backend/internal/compose/coldstart_test.go
+++ b/backend/internal/compose/coldstart_test.go
@@ -14,20 +14,6 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/ai"
 )
 
-func TestStripTagsSurvivesUnicodeCaseFolding(t *testing.T) {
-	// U+212A (KELVIN SIGN) lowercases to a 1-byte "k": an index into a
-	// lowered copy of the document would drift off the source bytes and
-	// slice out of range. The stripper must work on the original bytes.
-	kelvin := strings.Repeat("\u212a", 3)
-	got := stripTags(kelvin + "<p>hello</p><script>evil()</script> world")
-	if !strings.HasSuffix(got, "hello world") {
-		t.Fatalf("stripTags = %q", got)
-	}
-	if stripTags("<SCRIPT>x</SCRIPT>visible<STYLE>y</STYLE>") != "visible" {
-		t.Fatal("case-insensitive script/style stripping broke")
-	}
-}
-
 // The contract's oneOf: EXACTLY ONE of url|text|self_description. Zero or
 // several inputs are a 422 whose details carry how many were populated —
 // before any fetch, model call or staging happens.

--- a/backend/internal/compose/enrichextract.go
+++ b/backend/internal/compose/enrichextract.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/url"
 	"strings"
 	"time"
@@ -240,12 +241,25 @@ func (x evidenceExtractor) extract(ctx context.Context, rawURL string, accept fu
 // and returns the first page that reads as a real, DISTINCT document. Sites
 // that answer every path with the same page (SPA catch-alls — and fixtures)
 // yield the seed text again; treating that as a legal page would double every
-// model call for nothing, so identical text is a miss. Failures are silent by
-// design: the probe's absence is normal, and the robots gate's refusal is the
-// site's answer.
+// model call for nothing, so identical text is a miss.
+//
+// The probe fires ONLY when the seed is the host root: on a path-hosted site
+// (sites.example.com/company/), the host root's /impressum belongs to a
+// DIFFERENT party, and the merge's legal-page preference would let whoever
+// controls the root override the company's legal identity. A root seed and
+// its /impressum are the same party by construction.
+//
+// A miss is normal (absence, a robots refusal — the site's answer — or a
+// same-page duplicate) and stays silent; any OTHER failure is logged, because
+// "the Impressum probe kept timing out" must be findable when legal fields
+// come back thin, even though the seed page alone still yields an honest
+// (thinner) read.
 func (x evidenceExtractor) probeLegalPage(ctx context.Context, seedURL, seedText string) (string, string) {
 	parsed, err := url.Parse(seedURL)
 	if err != nil || parsed.Host == "" {
+		return "", ""
+	}
+	if parsed.Path != "" && parsed.Path != "/" {
 		return "", ""
 	}
 	origin := parsed.Scheme + "://" + parsed.Host
@@ -256,7 +270,13 @@ func (x evidenceExtractor) probeLegalPage(ctx context.Context, seedURL, seedText
 		probeCtx, cancel := context.WithTimeout(ctx, perProbeTimeout)
 		text, err := x.fetch.Fetch(probeCtx, origin+path)
 		cancel()
-		if err != nil || len([]rune(text)) < minReadableRunes || text == seedText {
+		if err != nil {
+			if !errors.Is(err, webread.ErrRobotsDisallowed) && !errors.Is(probeCtx.Err(), context.DeadlineExceeded) {
+				slog.WarnContext(ctx, "legal-page probe failed", "url", origin+path, "err", err)
+			}
+			continue
+		}
+		if len([]rune(text)) < minReadableRunes || text == seedText {
 			continue
 		}
 		return origin + path, text

--- a/backend/internal/compose/enrichextract.go
+++ b/backend/internal/compose/enrichextract.go
@@ -19,26 +19,23 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
-	"net"
-	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/modules/agents/runner"
 	"github.com/gradionhq/margince/backend/internal/modules/ai"
-	"github.com/gradionhq/margince/backend/internal/platform/netguard"
+	"github.com/gradionhq/margince/backend/internal/platform/webread"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/model"
 	"github.com/gradionhq/margince/backend/internal/shared/schema"
 )
 
-// Fetch limits: a landing page that needs more than this is not going to
-// yield better evidence, and the cap bounds what one request can pull into
-// the process.
+// Extraction limits: a page that reduced below the rune floor is not worth a
+// model call, and the ceiling bounds what one call hands the model. The fetch
+// side's own limits (timeout, byte cap) live with the fetcher in
+// platform/webread.
 const (
-	fetchTimeout      = 10 * time.Second
-	maxFetchBytes     = 1 << 20 // 1 MiB
 	minReadableRunes  = 80
 	maxExtractionText = 24_000 // runes handed to the model
 )
@@ -95,6 +92,7 @@ type extractedField struct {
 // slice to iterate, so this direction can't be auto-gated — KEEP IN SYNC with
 // the ColdStartField enum whenever a field is added to it.
 var extractionFieldNames = []string{
+	string(crmcontracts.DisplayName),
 	string(crmcontracts.Icp),
 	string(crmcontracts.BuyingCenter),
 	string(crmcontracts.ValueProposition),
@@ -168,13 +166,43 @@ type evidenceExtractor struct {
 	brain runner.Brain
 }
 
-// extract fetches rawURL, asks the model for company facts, and returns only
-// the evidence-grounded fields whose name passes `accept`. It returns
-// *unreadableError (wrapping the real cause) when the page reads too little OR
-// no field survives the gate —
-// honest degradation, zero fabricated fields (ADR-0006 §2/§4).
+// impressumProbePaths are the well-known locations of the legal-notice page,
+// German forms first: an Impressum is legally mandatory in this product's home
+// market and is where legal_name / registered_address / register_vat actually
+// live — the landing page almost never states them. The paths are derived from
+// the OPERATOR's input (same host), never from page content, which keeps this
+// inside ADR-0006's fetch-a-given-URL posture (founder ratification R1).
+var impressumProbePaths = []string{
+	"/impressum",
+	"/imprint",
+	"/de/impressum",
+	"/impressum.html",
+	"/legal-notice",
+}
+
+// perProbeTimeout bounds one legal-notice probe; a slow host must not eat the
+// interactive read's whole budget hunting for a page that may not exist.
+const perProbeTimeout = 2500 * time.Millisecond
+
+// legalPageFields prefer the legal-notice page in the merge: a register entry
+// quoted from the Impressum beats one guessed off the landing page, whatever
+// the model's confidence numbers claim — specificity of the SOURCE outranks
+// self-reported confidence.
+var legalPageFields = map[string]bool{
+	string(crmcontracts.LegalName):         true,
+	string(crmcontracts.RegisteredAddress): true,
+	string(crmcontracts.RegisterVat):       true,
+}
+
+// extract reads the SITE the URL names — the given page plus, when the site
+// publishes one at a well-known path, its legal-notice page — and returns the
+// evidence-grounded fields whose name passes `accept`, merged across pages
+// (legal facts prefer the legal page, everything else the given page). It
+// returns *unreadableError (wrapping the real cause) when the seed page reads
+// too little OR no field survives the gate on any page — honest degradation,
+// zero fabricated fields (ADR-0006 §2/§4).
 func (x evidenceExtractor) extract(ctx context.Context, rawURL string, accept func(string) bool) ([]evidencedField, error) {
-	pageText, err := x.fetch.Fetch(ctx, rawURL)
+	seedText, err := x.fetch.Fetch(ctx, rawURL)
 	if err != nil {
 		return nil, &unreadableError{cause: fmt.Errorf("fetch %s: %w", rawURL, err)}
 	}
@@ -182,20 +210,96 @@ func (x evidenceExtractor) extract(ctx context.Context, rawURL string, accept fu
 	// nav-crumbs is not worth a model call. Text a human supplied
 	// deliberately (paste / self-description) skips it — the evidence gate
 	// below still refuses to fabricate from thin input.
-	if n := len([]rune(pageText)); n < minReadableRunes {
+	if n := len([]rune(seedText)); n < minReadableRunes {
 		return nil, &unreadableError{cause: fmt.Errorf("page read %d runes, below the %d-rune floor", n, minReadableRunes)}
 	}
-	return x.extractGrounded(ctx, "Page "+rawURL, pageText, rawURL, accept)
+
+	seedFields, err := x.extractFields(ctx, "Page "+rawURL, seedText, rawURL, accept)
+	if err != nil {
+		return nil, err
+	}
+
+	var legalFields []evidencedField
+	if legalURL, legalText := x.probeLegalPage(ctx, rawURL, seedText); legalText != "" {
+		// A probe failure is a page that does not exist, not a broken read:
+		// the seed page alone is still an honest (if thinner) answer.
+		legalFields, err = x.extractFields(ctx, "Legal notice page "+legalURL, legalText, legalURL, accept)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	merged := mergeSiteFields(seedFields, legalFields)
+	if len(merged) == 0 {
+		return nil, &unreadableError{cause: errors.New("no field survived the no-guess evidence gate")}
+	}
+	return merged, nil
 }
 
-// extractGrounded is the model+gate half of the seam, shared by every
-// input kind (fetched page, pasted text, self-description): it asks the
-// routed model for company facts over already-obtained source text and
-// keeps only the fields whose evidence is VERBATIM in that text. An
-// empty gate result is *unreadableError — honest degradation, zero
-// fabricated fields. sourceURL is stamped onto the surviving fields and
-// is empty for the non-URL kinds.
-func (x evidenceExtractor) extractGrounded(ctx context.Context, sourceLabel, sourceText, sourceURL string, accept func(string) bool) ([]evidencedField, error) {
+// probeLegalPage tries the well-known legal-notice paths on the seed's host
+// and returns the first page that reads as a real, DISTINCT document. Sites
+// that answer every path with the same page (SPA catch-alls — and fixtures)
+// yield the seed text again; treating that as a legal page would double every
+// model call for nothing, so identical text is a miss. Failures are silent by
+// design: the probe's absence is normal, and the robots gate's refusal is the
+// site's answer.
+func (x evidenceExtractor) probeLegalPage(ctx context.Context, seedURL, seedText string) (string, string) {
+	parsed, err := url.Parse(seedURL)
+	if err != nil || parsed.Host == "" {
+		return "", ""
+	}
+	origin := parsed.Scheme + "://" + parsed.Host
+	for _, path := range impressumProbePaths {
+		if ctx.Err() != nil {
+			return "", ""
+		}
+		probeCtx, cancel := context.WithTimeout(ctx, perProbeTimeout)
+		text, err := x.fetch.Fetch(probeCtx, origin+path)
+		cancel()
+		if err != nil || len([]rune(text)) < minReadableRunes || text == seedText {
+			continue
+		}
+		return origin + path, text
+	}
+	return "", ""
+}
+
+// mergeSiteFields folds the per-page results into one answer per field: the
+// legal-notice page wins the legal facts, the seed page everything else, and
+// the non-preferred page only fills what the preferred one could not ground.
+// Order follows the seed page's fields, then legal-page extras — deterministic
+// output for a deterministic gate.
+func mergeSiteFields(seed, legal []evidencedField) []evidencedField {
+	byField := map[string]evidencedField{}
+	var order []string
+	for _, f := range seed {
+		byField[f.Field] = f
+		order = append(order, f.Field)
+	}
+	for _, f := range legal {
+		_, present := byField[f.Field]
+		if present && !legalPageFields[f.Field] {
+			// The seed page holds non-legal fields it grounded; a positioning
+			// claim belongs to the page that makes it.
+			continue
+		}
+		if !present {
+			order = append(order, f.Field)
+		}
+		byField[f.Field] = f
+	}
+	out := make([]evidencedField, 0, len(order))
+	for _, name := range order {
+		out = append(out, byField[name])
+	}
+	return out
+}
+
+// extractFields is the model+gate step for ONE page: an empty result is a
+// page with nothing to quote — a normal answer during a multi-page read, not
+// an error. extractGrounded keeps the empty-is-unreadable contract for the
+// single-source inputs (paste, self-description).
+func (x evidenceExtractor) extractFields(ctx context.Context, sourceLabel, sourceText, sourceURL string, accept func(string) bool) ([]evidencedField, error) {
 	if runes := []rune(sourceText); len(runes) > maxExtractionText {
 		sourceText = string(runes[:maxExtractionText])
 	}
@@ -220,8 +324,20 @@ func (x evidenceExtractor) extractGrounded(ctx context.Context, sourceLabel, sou
 	if err != nil {
 		return nil, err
 	}
+	return gateEvidence(resp.Text, sourceText, sourceURL, accept), nil
+}
 
-	fields := gateEvidence(resp.Text, sourceText, sourceURL, accept)
+// extractGrounded is the single-source wrapper over extractFields, shared by
+// the input kinds that have exactly one text (pasted text, self-description —
+// and each page of a site read is extracted the same way underneath): an empty
+// gate result here IS the answer "nothing could be evidenced", so it surfaces
+// as *unreadableError rather than an empty list. sourceURL is stamped onto the
+// surviving fields and is empty for the non-URL kinds.
+func (x evidenceExtractor) extractGrounded(ctx context.Context, sourceLabel, sourceText, sourceURL string, accept func(string) bool) ([]evidencedField, error) {
+	fields, err := x.extractFields(ctx, sourceLabel, sourceText, sourceURL, accept)
+	if err != nil {
+		return nil, err
+	}
 	if len(fields) == 0 {
 		return nil, &unreadableError{cause: errors.New("no field survived the no-guess evidence gate")}
 	}
@@ -268,98 +384,10 @@ func gateEvidence(modelText, pageText, sourceURL string, accept func(string) boo
 	return out
 }
 
-// webFetcher is the production PageFetcher: plain GET with a byte cap, a crude
-// tag strip, and an SSRF guard — a tenant-supplied URL must not become a probe
-// of the deployment's own network.
-type webFetcher struct{ client *http.Client }
-
 // NewWebFetcher builds the egress fetcher used by cmd/api for both the
-// read-back and enrichment.
+// read-back and enrichment. The HTTP mechanics (SSRF guard, robots.txt honor,
+// the tag strip whose output evidence is matched against) live in
+// platform/webread; this seam only narrows it to the PageFetcher interface.
 func NewWebFetcher() PageFetcher {
-	dialer := &net.Dialer{Timeout: fetchTimeout}
-	transport := &http.Transport{
-		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-			conn, err := dialer.DialContext(ctx, network, addr)
-			if err != nil {
-				return nil, err
-			}
-			// Checked post-dial so DNS answers cannot bypass the guard.
-			if tcp, ok := conn.RemoteAddr().(*net.TCPAddr); ok && !netguard.PublicIP(tcp.IP) {
-				//craft:ignore swallowed-errors best-effort close of a connection being refused — the SSRF refusal below is the error that matters
-				_ = conn.Close()
-				return nil, fmt.Errorf("enrich: refusing non-public address %s", tcp.IP)
-			}
-			return conn, nil
-		},
-	}
-	return webFetcher{client: &http.Client{
-		Timeout:   fetchTimeout,
-		Transport: transport,
-		// Every redirect hop re-enters the guarded dialer; the cap just
-		// bounds how long a redirect chain can hold the request.
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			if len(via) >= 5 {
-				return errors.New("enrich: too many redirects")
-			}
-			return nil
-		},
-	}}
-}
-
-func (f webFetcher) Fetch(ctx context.Context, rawURL string) (string, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
-	if err != nil {
-		return "", err
-	}
-	req.Header.Set("User-Agent", "margince-enrich/1.0")
-	resp, err := f.client.Do(req)
-	if err != nil {
-		return "", err
-	}
-	//craft:ignore swallowed-errors best-effort close: the capped read below may leave the body mid-stream, so a close error carries no signal for the fetch result
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("enrich: page answered %d", resp.StatusCode)
-	}
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxFetchBytes))
-	if err != nil {
-		return "", err
-	}
-	return stripTags(string(body)), nil
-}
-
-// stripTags reduces HTML to whitespace-normalized text. Deliberately crude:
-// evidence snippets are matched against THIS text, so the same reduction
-// defines both what the model sees and what counts as verbatim.
-func stripTags(html string) string {
-	var b strings.Builder
-	inTag, inScript := false, false
-	for i, r := range html {
-		switch {
-		case inScript:
-			if r == '<' && (foldPrefix(html[i:], "</script") || foldPrefix(html[i:], "</style")) {
-				inScript, inTag = false, true
-			}
-		case r == '<':
-			if foldPrefix(html[i:], "<script") || foldPrefix(html[i:], "<style") {
-				inScript = true
-			} else {
-				inTag = true
-			}
-		case r == '>':
-			inTag = false
-			b.WriteRune(' ')
-		case !inTag:
-			b.WriteRune(r)
-		}
-	}
-	return strings.Join(strings.Fields(b.String()), " ")
-}
-
-// foldPrefix is an ASCII case-insensitive prefix test on the ORIGINAL bytes.
-// Lowercasing the whole document first is not an option: Unicode case mapping
-// changes byte lengths (U+212A → "k"), so indexes into a lowered copy drift
-// off the source and can slice out of range.
-func foldPrefix(s, prefix string) bool {
-	return len(s) >= len(prefix) && strings.EqualFold(s[:len(prefix)], prefix)
+	return webread.New()
 }

--- a/backend/internal/compose/profilefieldvocab_integration_test.go
+++ b/backend/internal/compose/profilefieldvocab_integration_test.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// The extraction vocabulary lives in FOUR copies: the contract ColdStartField
+// enum, extractionFieldNames, the gate predicate, and the
+// organization_profile_field CHECK constraint. The first three are pinned to
+// each other in Go; this test pins the fourth — a field the model can emit
+// but the database refuses would pass every unit gate and then fail at the
+// accept-write, in production, on the first site that grounds it.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+func TestEveryExtractionFieldIsAccepted_ByTheLiveCheckConstraint(t *testing.T) {
+	e := integration.Setup(t)
+	ctx := e.Admin()
+
+	err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
+		orgID := ids.New[ids.OrganizationKind]()
+		if _, err := tx.Exec(context.Background(),
+			`INSERT INTO organization (id, workspace_id, display_name, source, captured_by)
+			 VALUES ($1, $2, 'Vocab Probe', 'manual', 'human:test')`,
+			orgID, e.WS); err != nil {
+			return err
+		}
+		for _, field := range extractionFieldNames {
+			if _, err := tx.Exec(context.Background(),
+				`INSERT INTO organization_profile_field
+				   (workspace_id, organization_id, field, value, evidence_snippet, source_url, confidence, captured_by)
+				 VALUES ($1, $2, $3, 'v', 'e', '', 0.9, 'agent:test')`,
+				e.WS, orgID, field); err != nil {
+				t.Errorf("the live CHECK constraint refuses extraction field %q — widen it with the vocabulary (see 0084's pattern)", field)
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil && !t.Failed() {
+		t.Fatal(err)
+	}
+}

--- a/backend/internal/compose/siteread_test.go
+++ b/backend/internal/compose/siteread_test.go
@@ -68,8 +68,8 @@ func TestExtractReadsTheImpressumForLegalFacts(t *testing.T) {
 		t.Fatalf("legal_name = %q from %s, want the Impressum's value", legal.Value, legal.SourceURL)
 	}
 	// A fact only the Impressum grounds arrives with the Impressum's URL.
-	if vat := byName[string(crmcontracts.RegisterVat)]; vat.Value != "DE811234567" {
-		t.Fatalf("register_vat = %q, want the Impressum's", vat.Value)
+	if vat := byName[string(crmcontracts.RegisterVat)]; vat.Value != "DE811234567" || vat.SourceURL != "https://acme.example/impressum" {
+		t.Fatalf("register_vat = %q from %s, want the Impressum's value WITH its provenance", vat.Value, vat.SourceURL)
 	}
 	// A positioning fact stays the landing page's.
 	if icp := byName[string(crmcontracts.Icp)]; icp.SourceURL != "https://acme.example" {
@@ -171,5 +171,29 @@ func TestExtractSurfacesALegalPageModelFailure(t *testing.T) {
 	x := evidenceExtractor{fetch: fetch, brain: brain}
 	if _, err := x.extract(context.Background(), "https://acme.example", coldStartFieldValid); err == nil {
 		t.Fatal("a failed legal-page extraction was silently swallowed — the read reported success on half its input")
+	}
+}
+
+func TestExtractNeverProbesFromAPathHostedSeed(t *testing.T) {
+	// On a path-hosted site (sites.example.com/company/) the HOST ROOT's
+	// /impressum belongs to a different party — and the merge's legal-page
+	// preference would let whoever controls it override the company's legal
+	// identity. A non-root seed therefore reads single-page.
+	seed := "https://sites.example/company/"
+	fetch := hostPages{
+		seed: strings.Repeat("Company page text. ", 10),
+		// The attacker-controlled root impressum: reachable, never fetched.
+		"https://sites.example/impressum": strings.Repeat("Evil Corp Ltd. ", 10),
+	}
+	brain := ai.NewFakeClient().Script(
+		`{"fields":[{"field":"icp","value":"x","evidence_snippet":"Company page text.","confidence":0.8}]}`,
+	)
+	x := evidenceExtractor{fetch: fetch, brain: brain}
+
+	if _, err := x.extract(context.Background(), seed, coldStartFieldValid); err != nil {
+		t.Fatal(err)
+	}
+	if calls := len(brain.Calls()); calls != 1 {
+		t.Fatalf("model called %d times for a path-hosted seed, want 1 — the root probe must not fire", calls)
 	}
 }

--- a/backend/internal/compose/siteread_test.go
+++ b/backend/internal/compose/siteread_test.go
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The quick site read: the given page plus the well-known legal-notice page,
+// merged so legal facts come from the page that legally states them. German
+// sites keep legal_name/VAT/address on the Impressum — a read that never
+// leaves the landing page cannot ground them.
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/modules/ai"
+)
+
+// hostPages serves a distinct fixture per URL — the multi-page twin of
+// fixturePage. Unknown paths 404 like a real site.
+type hostPages map[string]string
+
+func (p hostPages) Fetch(_ context.Context, rawURL string) (string, error) {
+	if text, ok := p[rawURL]; ok {
+		return text, nil
+	}
+	return "", errNotFound
+}
+
+var errNotFound = errors.New("fixture: no such page")
+
+func TestExtractReadsTheImpressumForLegalFacts(t *testing.T) {
+	home := strings.Repeat("Acme builds robots. ", 10) + "Built for RevOps leaders."
+	impressum := strings.Repeat("Impressum. ", 10) + "Acme Robotics GmbH, Werkstr. 1, 70435 Stuttgart. USt-IdNr. DE811234567."
+
+	fetch := hostPages{
+		"https://acme.example":           home,
+		"https://acme.example/impressum": impressum,
+	}
+	// Call order is deterministic (seed first, then the found probe), so the
+	// scripted queue addresses each page's extraction in turn.
+	brain := ai.NewFakeClient().Script(
+		`{"fields":[
+			{"field":"icp","value":"RevOps leaders","evidence_snippet":"Built for RevOps leaders","confidence":0.8},
+			{"field":"legal_name","value":"Acme (guessed)","evidence_snippet":"Acme builds robots.","confidence":0.95}]}`,
+		`{"fields":[
+			{"field":"legal_name","value":"Acme Robotics GmbH","evidence_snippet":"Acme Robotics GmbH","confidence":0.7},
+			{"field":"register_vat","value":"DE811234567","evidence_snippet":"USt-IdNr. DE811234567","confidence":0.9}]}`,
+	)
+	x := evidenceExtractor{fetch: fetch, brain: brain}
+
+	fields, err := x.extract(context.Background(), "https://acme.example", coldStartFieldValid)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	byName := map[string]evidencedField{}
+	for _, f := range fields {
+		byName[f.Field] = f
+	}
+	// The Impressum wins the legal facts even at LOWER model confidence: the
+	// page that legally states a fact outranks a landing-page guess.
+	legal := byName[string(crmcontracts.LegalName)]
+	if legal.Value != "Acme Robotics GmbH" || legal.SourceURL != "https://acme.example/impressum" {
+		t.Fatalf("legal_name = %q from %s, want the Impressum's value", legal.Value, legal.SourceURL)
+	}
+	// A fact only the Impressum grounds arrives with the Impressum's URL.
+	if vat := byName[string(crmcontracts.RegisterVat)]; vat.Value != "DE811234567" {
+		t.Fatalf("register_vat = %q, want the Impressum's", vat.Value)
+	}
+	// A positioning fact stays the landing page's.
+	if icp := byName[string(crmcontracts.Icp)]; icp.SourceURL != "https://acme.example" {
+		t.Fatalf("icp came from %s, want the landing page", icp.SourceURL)
+	}
+}
+
+func TestExtractWithoutAnImpressumStaysASinglePageRead(t *testing.T) {
+	home := strings.Repeat("Acme builds robots. ", 10)
+	fetch := hostPages{"https://acme.example": home}
+	brain := ai.NewFakeClient().Script(
+		`{"fields":[{"field":"icp","value":"x","evidence_snippet":"Acme builds robots.","confidence":0.8}]}`,
+	)
+	x := evidenceExtractor{fetch: fetch, brain: brain}
+
+	fields, err := x.extract(context.Background(), "https://acme.example", coldStartFieldValid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fields) != 1 || len(brain.Calls()) != 1 {
+		t.Fatalf("fields=%d model calls=%d, want 1/1 — a missing legal page must not cost a second call", len(fields), len(brain.Calls()))
+	}
+}
+
+func TestExtractSkipsAProbeServingTheSamePage(t *testing.T) {
+	// SPA catch-alls answer every path with the landing page; extracting that
+	// twice would double the model spend for zero new evidence.
+	home := strings.Repeat("Acme builds robots. ", 10)
+	fetch := hostPages{
+		"https://acme.example":           home,
+		"https://acme.example/impressum": home,
+	}
+	brain := ai.NewFakeClient().Script(
+		`{"fields":[{"field":"icp","value":"x","evidence_snippet":"Acme builds robots.","confidence":0.8}]}`,
+	)
+	x := evidenceExtractor{fetch: fetch, brain: brain}
+
+	if _, err := x.extract(context.Background(), "https://acme.example", coldStartFieldValid); err != nil {
+		t.Fatal(err)
+	}
+	if calls := len(brain.Calls()); calls != 1 {
+		t.Fatalf("model called %d times, want 1 — the duplicate page must be skipped", calls)
+	}
+}
+
+func TestExtractOffersDisplayNameToTheModel(t *testing.T) {
+	// The most obvious form field must be fillable by the read-back: the
+	// vocabulary handed to the model (and its schema enum) includes
+	// display_name, and a grounded one survives the gate.
+	home := strings.Repeat("Filler text. ", 10) + "Acme — robots for the mid-market."
+	fetch := hostPages{"https://acme.example": home}
+	brain := ai.NewFakeClient().Script(
+		`{"fields":[{"field":"display_name","value":"Acme","evidence_snippet":"Acme — robots for the mid-market.","confidence":0.9}]}`,
+	)
+	x := evidenceExtractor{fetch: fetch, brain: brain}
+
+	fields, err := x.extract(context.Background(), "https://acme.example", coldStartFieldValid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fields) != 1 || fields[0].Field != string(crmcontracts.DisplayName) {
+		t.Fatalf("fields = %+v, want the grounded display_name", fields)
+	}
+	if !strings.Contains(string(brain.Calls()[0].Payload), "display_name") {
+		t.Fatal("the extraction prompt never offered display_name to the model")
+	}
+}

--- a/backend/internal/compose/siteread_test.go
+++ b/backend/internal/compose/siteread_test.go
@@ -16,6 +16,7 @@ import (
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/modules/ai"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/model"
 )
 
 // hostPages serves a distinct fixture per URL — the multi-page twin of
@@ -134,5 +135,41 @@ func TestExtractOffersDisplayNameToTheModel(t *testing.T) {
 	}
 	if !strings.Contains(string(brain.Calls()[0].Payload), "display_name") {
 		t.Fatal("the extraction prompt never offered display_name to the model")
+	}
+}
+
+// failsAfter yields scripted responses, then errors: the legal-page extraction
+// failing must surface, not silently reduce the read to one page.
+type failsAfter struct {
+	inner *ai.FakeClient
+	calls int
+	limit int
+}
+
+func (f *failsAfter) Complete(ctx context.Context, req model.Request) (model.Response, error) {
+	f.calls++
+	if f.calls > f.limit {
+		return model.Response{}, errors.New("model lane down")
+	}
+	return f.inner.Complete(ctx, req)
+}
+
+func TestExtractSurfacesALegalPageModelFailure(t *testing.T) {
+	home := strings.Repeat("Acme builds robots. ", 10)
+	impressum := strings.Repeat("Impressum. ", 10) + "Acme Robotics GmbH."
+	fetch := hostPages{
+		"https://acme.example":           home,
+		"https://acme.example/impressum": impressum,
+	}
+	brain := &failsAfter{
+		inner: ai.NewFakeClient().Script(
+			`{"fields":[{"field":"icp","value":"x","evidence_snippet":"Acme builds robots.","confidence":0.8}]}`,
+		),
+		limit: 1,
+	}
+
+	x := evidenceExtractor{fetch: fetch, brain: brain}
+	if _, err := x.extract(context.Background(), "https://acme.example", coldStartFieldValid); err == nil {
+		t.Fatal("a failed legal-page extraction was silently swallowed — the read reported success on half its input")
 	}
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -619,6 +619,7 @@ func (e CaptureExclusionRuleKind) Valid() bool {
 const (
 	BuyingCenter      ColdStartFieldField = "buying_center"
 	BuyingIntents     ColdStartFieldField = "buying_intents"
+	DisplayName       ColdStartFieldField = "display_name"
 	History           ColdStartFieldField = "history"
 	Icp               ColdStartFieldField = "icp"
 	Industry          ColdStartFieldField = "industry"
@@ -635,6 +636,8 @@ func (e ColdStartFieldField) Valid() bool {
 	case BuyingCenter:
 		return true
 	case BuyingIntents:
+		return true
+	case DisplayName:
 		return true
 	case History:
 		return true

--- a/backend/internal/platform/webread/robots.go
+++ b/backend/internal/platform/webread/robots.go
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package webread
+
+import "strings"
+
+// robotsPolicy is the subset of REP (RFC 9309) this bot needs: the rule group
+// addressed to it (by product token, falling back to *), longest-match wins,
+// Allow beating Disallow at equal length. Crawl-delay/sitemap directives are
+// ignored here — pacing is the crawler's own, stricter policy.
+type robotsPolicy struct {
+	rules []robotsRule
+}
+
+type robotsRule struct {
+	path  string
+	allow bool
+}
+
+// robotsGroup is one User-agent block and its rules.
+type robotsGroup struct {
+	agents []string
+	rules  []robotsRule
+}
+
+// allows reports whether the policy permits fetching path. An empty policy
+// (no robots.txt, or no group addressing us) allows everything.
+func (p robotsPolicy) allows(path string) bool {
+	bestLen := -1
+	allowed := true
+	for _, r := range p.rules {
+		if !strings.HasPrefix(path, r.path) {
+			continue
+		}
+		// Longest match wins; at equal length Allow wins (the REP tiebreak),
+		// which the strict > on a later Disallow of the same length preserves
+		// because the earlier Allow already holds the slot.
+		if len(r.path) > bestLen || (len(r.path) == bestLen && r.allow && !allowed) {
+			bestLen = len(r.path)
+			allowed = r.allow
+		}
+	}
+	return allowed
+}
+
+// parseRobots reads the robots.txt body and keeps the most specific group
+// addressing this bot: a group naming our product token beats the * group;
+// with neither, everything is allowed. Group structure per RFC 9309: one or
+// more User-agent lines, then the rules until the next User-agent block.
+func parseRobots(body string) robotsPolicy {
+	var groups []robotsGroup
+	var current *robotsGroup
+	inAgentRun := false
+
+	for _, raw := range strings.Split(body, "\n") {
+		line := strings.TrimSpace(raw)
+		if i := strings.IndexByte(line, '#'); i >= 0 {
+			line = strings.TrimSpace(line[:i])
+		}
+		if line == "" {
+			continue
+		}
+		key, value, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		key = strings.ToLower(strings.TrimSpace(key))
+		value = strings.TrimSpace(value)
+
+		switch key {
+		case "user-agent":
+			// Consecutive User-agent lines address ONE group; a User-agent
+			// after rules starts the next group.
+			if !inAgentRun {
+				groups = append(groups, robotsGroup{})
+				current = &groups[len(groups)-1]
+				inAgentRun = true
+			}
+			current.agents = append(current.agents, strings.ToLower(value))
+		case "allow", "disallow":
+			inAgentRun = false
+			if current == nil {
+				continue // rules before any User-agent line address nobody
+			}
+			if value == "" {
+				// "Disallow:" (empty) means allow-all — representable as an
+				// empty rule set, so record nothing.
+				continue
+			}
+			current.rules = append(current.rules, robotsRule{path: value, allow: key == "allow"})
+		default:
+			// Sitemap, Crawl-delay, unknown directives: not this policy's job.
+			inAgentRun = false
+		}
+	}
+
+	return selectPolicy(groups)
+}
+
+// selectPolicy picks the group this bot obeys: the one naming its product
+// wins over *, and with neither, everything is allowed.
+func selectPolicy(groups []robotsGroup) robotsPolicy {
+	var wildcard *robotsGroup
+	for i := range groups {
+		for _, agent := range groups[i].agents {
+			if strings.Contains(agent, robotsAgentProduct) {
+				return robotsPolicy{rules: groups[i].rules}
+			}
+			if agent == "*" && wildcard == nil {
+				wildcard = &groups[i]
+			}
+		}
+	}
+	if wildcard != nil {
+		return robotsPolicy{rules: wildcard.rules}
+	}
+	return robotsPolicy{}
+}

--- a/backend/internal/platform/webread/robots.go
+++ b/backend/internal/platform/webread/robots.go
@@ -5,10 +5,12 @@ package webread
 
 import "strings"
 
-// robotsPolicy is the subset of REP (RFC 9309) this bot needs: the rule group
-// addressed to it (by product token, falling back to *), longest-match wins,
-// Allow beating Disallow at equal length. Crawl-delay/sitemap directives are
-// ignored here — pacing is the crawler's own, stricter policy.
+// robotsPolicy is the REP (RFC 9309) rule set this bot obeys: the union of
+// every group addressed to it (by product name, falling back to the union of
+// the * groups), longest-match wins, Allow beating Disallow at equal length,
+// with `*` (any run) and `$` (end anchor) interpreted as REP operators.
+// Crawl-delay/sitemap directives are ignored here — pacing is the crawler's
+// own, stricter policy.
 type robotsPolicy struct {
 	rules []robotsRule
 }
@@ -24,24 +26,77 @@ type robotsGroup struct {
 	rules  []robotsRule
 }
 
-// allows reports whether the policy permits fetching path. An empty policy
-// (no robots.txt, or no group addressing us) allows everything.
-func (p robotsPolicy) allows(path string) bool {
+// allows reports whether the policy permits fetching target — the escaped
+// path INCLUDING the query, because REP rules may match on `?`. An empty
+// policy (no robots.txt, or no group addressing us) allows everything.
+func (p robotsPolicy) allows(target string) bool {
 	bestLen := -1
 	allowed := true
 	for _, r := range p.rules {
-		if !strings.HasPrefix(path, r.path) {
+		if !ruleMatches(r.path, target) {
 			continue
 		}
-		// Longest match wins; at equal length Allow wins (the REP tiebreak),
-		// which the strict > on a later Disallow of the same length preserves
-		// because the earlier Allow already holds the slot.
+		// The longer PATTERN wins (RFC 9309 uses pattern length as
+		// specificity); at equal length Allow wins — the strict > on a later
+		// Disallow of the same length preserves that because the earlier
+		// Allow already holds the slot.
 		if len(r.path) > bestLen || (len(r.path) == bestLen && r.allow && !allowed) {
 			bestLen = len(r.path)
 			allowed = r.allow
 		}
 	}
 	return allowed
+}
+
+// ruleMatches interprets a REP path pattern against the target: literal
+// segments between `*` wildcards must appear in order, the first anchored at
+// the start, and a trailing `$` anchoring the last to the end. A literal
+// prefix rule degenerates to strings.HasPrefix.
+func ruleMatches(pattern, target string) bool {
+	anchored := strings.HasSuffix(pattern, "$")
+	if anchored {
+		pattern = strings.TrimSuffix(pattern, "$")
+	}
+	segments := strings.Split(pattern, "*")
+
+	if anchored {
+		// The LAST literal segment must end the target (a pattern ending in
+		// `*$` — empty last segment — matches any tail). The remaining
+		// segments then match inside what precedes that tail, so a first-
+		// occurrence scan cannot steal bytes the anchor needs.
+		last := segments[len(segments)-1]
+		if !strings.HasSuffix(target, last) {
+			return false
+		}
+		if len(segments) == 1 {
+			// No `*` at all: the whole pattern must BE the whole target.
+			return target == last
+		}
+		return segmentsMatch(segments[:len(segments)-1], target[:len(target)-len(last)])
+	}
+	return segmentsMatch(segments, target)
+}
+
+// segmentsMatch scans the `*`-separated literal segments left to right, the
+// first anchored at the start, each later one at its first occurrence after
+// the previous — first-occurrence is safe here because every later segment
+// only needs SOME occurrence to its right.
+func segmentsMatch(segments []string, target string) bool {
+	if !strings.HasPrefix(target, segments[0]) {
+		return false
+	}
+	pos := len(segments[0])
+	for _, seg := range segments[1:] {
+		if seg == "" {
+			continue // consecutive or trailing * — matches any run, incl. empty
+		}
+		idx := strings.Index(target[pos:], seg)
+		if idx < 0 {
+			return false
+		}
+		pos += idx + len(seg)
+	}
+	return true
 }
 
 // parseRobots reads the robots.txt body and keeps the most specific group
@@ -98,22 +153,30 @@ func parseRobots(body string) robotsPolicy {
 	return selectPolicy(groups)
 }
 
-// selectPolicy picks the group this bot obeys: the one naming its product
-// wins over *, and with neither, everything is allowed.
+// selectPolicy builds the rule set this bot obeys: the UNION of every group
+// naming its product (RFC 9309 §2.2.1 — matching groups combine, so a later
+// Disallow in a second group addressed to us cannot be bypassed by returning
+// only the first), falling back to the union of the * groups, and with
+// neither, everything is allowed.
 func selectPolicy(groups []robotsGroup) robotsPolicy {
-	var wildcard *robotsGroup
+	var named, wildcard []robotsRule
 	for i := range groups {
+		namesUs, isWildcard := false, false
 		for _, agent := range groups[i].agents {
-			if strings.Contains(agent, robotsAgentProduct) {
-				return robotsPolicy{rules: groups[i].rules}
-			}
-			if agent == "*" && wildcard == nil {
-				wildcard = &groups[i]
-			}
+			namesUs = namesUs || strings.Contains(agent, robotsAgentProduct)
+			isWildcard = isWildcard || agent == "*"
+		}
+		// A group listing both our product and * addresses us by name — the
+		// whole agent list decides, not whichever line happens to come first.
+		switch {
+		case namesUs:
+			named = append(named, groups[i].rules...)
+		case isWildcard:
+			wildcard = append(wildcard, groups[i].rules...)
 		}
 	}
-	if wildcard != nil {
-		return robotsPolicy{rules: wildcard.rules}
+	if named != nil {
+		return robotsPolicy{rules: named}
 	}
-	return robotsPolicy{}
+	return robotsPolicy{rules: wildcard}
 }

--- a/backend/internal/platform/webread/striptags.go
+++ b/backend/internal/platform/webread/striptags.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package webread
+
+import "strings"
+
+// StripTags reduces HTML to whitespace-normalized text. Deliberately crude:
+// evidence snippets are matched against THIS text, so the same reduction
+// defines both what the model sees and what counts as verbatim — any change
+// here silently invalidates stored evidence, treat the output as a contract.
+func StripTags(html string) string {
+	var b strings.Builder
+	inTag, inScript := false, false
+	for i, r := range html {
+		switch {
+		case inScript:
+			if r == '<' && (foldPrefix(html[i:], "</script") || foldPrefix(html[i:], "</style")) {
+				inScript, inTag = false, true
+			}
+		case r == '<':
+			if foldPrefix(html[i:], "<script") || foldPrefix(html[i:], "<style") {
+				inScript = true
+			} else {
+				inTag = true
+			}
+		case r == '>':
+			inTag = false
+			b.WriteRune(' ')
+		case !inTag:
+			b.WriteRune(r)
+		}
+	}
+	return strings.Join(strings.Fields(b.String()), " ")
+}
+
+// foldPrefix is an ASCII case-insensitive prefix test on the ORIGINAL bytes.
+// Lowercasing the whole document first is not an option: Unicode case mapping
+// changes byte lengths (U+212A → "k"), so indexes into a lowered copy drift
+// off the source and can slice out of range.
+func foldPrefix(s, prefix string) bool {
+	return len(s) >= len(prefix) && strings.EqualFold(s[:len(prefix)], prefix)
+}

--- a/backend/internal/platform/webread/striptags.go
+++ b/backend/internal/platform/webread/striptags.go
@@ -15,11 +15,11 @@ func StripTags(html string) string {
 	for i, r := range html {
 		switch {
 		case inScript:
-			if r == '<' && (foldPrefix(html[i:], "</script") || foldPrefix(html[i:], "</style")) {
+			if r == '<' && (tagPrefix(html[i:], "</script") || tagPrefix(html[i:], "</style")) {
 				inScript, inTag = false, true
 			}
 		case r == '<':
-			if foldPrefix(html[i:], "<script") || foldPrefix(html[i:], "<style") {
+			if tagPrefix(html[i:], "<script") || tagPrefix(html[i:], "<style") {
 				inScript = true
 			} else {
 				inTag = true
@@ -34,10 +34,23 @@ func StripTags(html string) string {
 	return strings.Join(strings.Fields(b.String()), " ")
 }
 
-// foldPrefix is an ASCII case-insensitive prefix test on the ORIGINAL bytes.
-// Lowercasing the whole document first is not an option: Unicode case mapping
-// changes byte lengths (U+212A → "k"), so indexes into a lowered copy drift
-// off the source and can slice out of range.
-func foldPrefix(s, prefix string) bool {
-	return len(s) >= len(prefix) && strings.EqualFold(s[:len(prefix)], prefix)
+// tagPrefix is an ASCII case-insensitive TAG-NAME test on the ORIGINAL bytes:
+// the name must end at a tag boundary (whitespace, /, or >), so a custom
+// element like <script-loader> is an ordinary tag whose content survives, not
+// a script block to swallow. Lowercasing the whole document first is not an
+// option: Unicode case mapping changes byte lengths (U+212A → "k"), so
+// indexes into a lowered copy drift off the source and can slice out of range.
+func tagPrefix(s, prefix string) bool {
+	if len(s) < len(prefix) || !strings.EqualFold(s[:len(prefix)], prefix) {
+		return false
+	}
+	if len(s) == len(prefix) {
+		return true // tag truncated at end of input — nothing left to protect
+	}
+	switch s[len(prefix)] {
+	case ' ', '\t', '\n', '\r', '/', '>':
+		return true
+	default:
+		return false
+	}
 }

--- a/backend/internal/platform/webread/webread.go
+++ b/backend/internal/platform/webread/webread.go
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// Package webread is the outbound public-web fetcher behind the ADR-0006
+// scrape/enrichment seam: plain GETs of pages a tenant names, reduced to
+// whitespace-normalized text. It owns the HTTP mechanics and nothing else — no
+// extraction, no vocabulary, no discovery policy; those stay with the callers.
+//
+// Three properties hold for every fetch:
+//   - SSRF-guarded: the dialer refuses non-public addresses POST-dial, so a
+//     DNS answer cannot steer a tenant-supplied URL into the deployment's own
+//     network, and every redirect hop re-enters the guard.
+//   - robots.txt honored (the ADR-0006 "robots/ToS respected" promise): a
+//     path the site disallows for us is refused HERE, not left to caller
+//     discipline. An unreachable robots (5xx, network) reads as deny — when a
+//     site cannot say what it permits, we do not guess in our own favor; a
+//     missing one (4xx) reads as allow, the standard.
+//   - attributable: one named User-Agent, so a site operator can identify and
+//     block the bot rather than mistaking it for a browser.
+package webread
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/platform/netguard"
+)
+
+const (
+	fetchTimeout  = 10 * time.Second
+	maxFetchBytes = 1 << 20 // 1 MiB per page
+	// UserAgent names the bot on every request, robots.txt lookups included.
+	UserAgent = "margince-siteread/1.0"
+	// robotsAgentProduct is the product name robots.txt group headers match on
+	// (RFC 9309 calls this the product token).
+	robotsAgentProduct = "margince-siteread"
+	// robotsTTL bounds how long a fetched policy is trusted; a crawl session
+	// asks once, a later session re-asks.
+	robotsTTL = 15 * time.Minute
+)
+
+// ErrRobotsDisallowed marks a fetch the target site's robots.txt refuses for
+// this bot. Callers report it as a skip reason — it is the site's answer, not
+// a failure.
+var ErrRobotsDisallowed = errors.New("webread: robots.txt disallows this path")
+
+// Fetcher is the production fetcher. Safe for concurrent use.
+type Fetcher struct {
+	client *http.Client
+
+	mu     sync.Mutex
+	robots map[string]robotsEntry // per scheme://host
+	now    func() time.Time
+}
+
+type robotsEntry struct {
+	policy  robotsPolicy
+	fetched time.Time
+}
+
+// New builds the guarded fetcher.
+func New() *Fetcher {
+	dialer := &net.Dialer{Timeout: fetchTimeout}
+	transport := &http.Transport{
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			conn, err := dialer.DialContext(ctx, network, addr)
+			if err != nil {
+				return nil, err
+			}
+			// Checked post-dial so DNS answers cannot bypass the guard.
+			if tcp, ok := conn.RemoteAddr().(*net.TCPAddr); ok && !netguard.PublicIP(tcp.IP) {
+				//craft:ignore swallowed-errors best-effort close of a connection being refused — the SSRF refusal below is the error that matters
+				_ = conn.Close()
+				return nil, fmt.Errorf("webread: refusing non-public address %s", tcp.IP)
+			}
+			return conn, nil
+		},
+	}
+	return &Fetcher{
+		client: &http.Client{
+			Timeout:   fetchTimeout,
+			Transport: transport,
+			// Every redirect hop re-enters the guarded dialer; the cap bounds
+			// how long a redirect chain can hold the request.
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				if len(via) >= 5 {
+					return errors.New("webread: too many redirects")
+				}
+				return nil
+			},
+		},
+		robots: map[string]robotsEntry{},
+		now:    time.Now,
+	}
+}
+
+// Fetch retrieves one page as whitespace-normalized text, refusing what the
+// site's robots.txt disallows for this bot.
+func (f *Fetcher) Fetch(ctx context.Context, rawURL string) (string, error) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil || parsed.Host == "" {
+		return "", fmt.Errorf("webread: %q is not a fetchable URL", rawURL)
+	}
+	allowed, err := f.pathAllowed(ctx, parsed)
+	if err != nil {
+		return "", err
+	}
+	if !allowed {
+		return "", fmt.Errorf("%w: %s", ErrRobotsDisallowed, parsed.Path)
+	}
+
+	body, err := f.get(ctx, rawURL)
+	if err != nil {
+		return "", err
+	}
+	return StripTags(body), nil
+}
+
+// get is the raw capped GET both page and robots fetches share.
+func (f *Fetcher) get(ctx context.Context, rawURL string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("User-Agent", UserAgent)
+	resp, err := f.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	//craft:ignore swallowed-errors best-effort close: the capped read below may leave the body mid-stream, so a close error carries no signal for the fetch result
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("webread: page answered %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxFetchBytes))
+	if err != nil {
+		return "", err
+	}
+	return string(body), nil
+}
+
+// pathAllowed resolves the host's robots policy (cached per host) and asks it
+// about the path.
+func (f *Fetcher) pathAllowed(ctx context.Context, page *url.URL) (bool, error) {
+	origin := page.Scheme + "://" + page.Host
+
+	f.mu.Lock()
+	entry, cached := f.robots[origin]
+	fresh := cached && f.now().Sub(entry.fetched) < robotsTTL
+	f.mu.Unlock()
+
+	if !fresh {
+		policy, err := f.fetchRobots(ctx, origin)
+		if err != nil {
+			return false, err
+		}
+		entry = robotsEntry{policy: policy, fetched: f.now()}
+		f.mu.Lock()
+		f.robots[origin] = entry
+		f.mu.Unlock()
+	}
+	path := page.EscapedPath()
+	if path == "" {
+		path = "/"
+	}
+	return entry.policy.allows(path), nil
+}
+
+// fetchRobots retrieves and parses <origin>/robots.txt. A 4xx answer means the
+// site declares no policy — allow-all, the standard reading. A 5xx or network
+// failure is NOT an answer: it reads as deny, because "the site could not say
+// what it permits" must never resolve in our own favor.
+func (f *Fetcher) fetchRobots(ctx context.Context, origin string) (robotsPolicy, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, origin+"/robots.txt", nil)
+	if err != nil {
+		return robotsPolicy{}, err
+	}
+	req.Header.Set("User-Agent", UserAgent)
+	resp, err := f.client.Do(req)
+	if err != nil {
+		return robotsPolicy{}, fmt.Errorf("webread: robots.txt unreachable (refusing to guess what %s permits): %w", origin, err)
+	}
+	//craft:ignore swallowed-errors best-effort close: the capped read below may leave the body mid-stream, so a close error carries no signal for the policy
+	defer func() { _ = resp.Body.Close() }()
+
+	switch {
+	case resp.StatusCode == http.StatusOK:
+		body, err := io.ReadAll(io.LimitReader(resp.Body, maxFetchBytes))
+		if err != nil {
+			return robotsPolicy{}, err
+		}
+		return parseRobots(string(body)), nil
+	case resp.StatusCode >= 400 && resp.StatusCode < 500:
+		return robotsPolicy{}, nil // no policy declared — allow-all
+	default:
+		return robotsPolicy{}, fmt.Errorf("webread: robots.txt answered %d (refusing to guess what %s permits)", resp.StatusCode, origin)
+	}
+}

--- a/backend/internal/platform/webread/webread.go
+++ b/backend/internal/platform/webread/webread.go
@@ -67,38 +67,52 @@ type robotsEntry struct {
 
 // New builds the guarded fetcher.
 func New() *Fetcher {
-	dialer := &net.Dialer{Timeout: fetchTimeout}
-	transport := &http.Transport{
-		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-			conn, err := dialer.DialContext(ctx, network, addr)
-			if err != nil {
-				return nil, err
-			}
-			// Checked post-dial so DNS answers cannot bypass the guard.
-			if tcp, ok := conn.RemoteAddr().(*net.TCPAddr); ok && !netguard.PublicIP(tcp.IP) {
-				//craft:ignore swallowed-errors best-effort close of a connection being refused — the SSRF refusal below is the error that matters
-				_ = conn.Close()
-				return nil, fmt.Errorf("webread: refusing non-public address %s", tcp.IP)
-			}
-			return conn, nil
-		},
-	}
-	return &Fetcher{
-		client: &http.Client{
-			Timeout:   fetchTimeout,
-			Transport: transport,
-			// Every redirect hop re-enters the guarded dialer; the cap bounds
-			// how long a redirect chain can hold the request.
-			CheckRedirect: func(req *http.Request, via []*http.Request) error {
-				if len(via) >= 5 {
-					return errors.New("webread: too many redirects")
-				}
-				return nil
-			},
-		},
+	// netguard.RefusePrivate runs in the socket's Control hook — BEFORE the
+	// connect completes — matching the ratified sibling egress path (the imap
+	// connector). A post-dial check would let the TCP handshake reach an
+	// internal service that acts on connect, and leave connect timing as a
+	// port oracle. The hook sees the literal dial address, so DNS answers
+	// cannot bypass it either.
+	dialer := &net.Dialer{Timeout: fetchTimeout, Control: netguard.RefusePrivate}
+	return newFetcher(&http.Transport{DialContext: dialer.DialContext})
+}
+
+// newFetcher wires the client policy every fetcher shares — the timeout, the
+// redirect cap, and the per-hop robots re-check — over the given transport.
+// Production passes the guarded transport; tests pass an unguarded one (their
+// servers live on loopback, which the guard rightly refuses) and get the SAME
+// redirect/robots behavior, so what the tests prove is what production does.
+func newFetcher(transport http.RoundTripper) *Fetcher {
+	f := &Fetcher{
 		robots: map[string]robotsEntry{},
 		now:    time.Now,
 	}
+	f.client = &http.Client{
+		Timeout:   fetchTimeout,
+		Transport: transport,
+		// Every redirect hop re-enters the transport's dialer, and — because
+		// an allowed path may 30x onto a path (or origin) the site's robots
+		// disallow — every hop re-passes the robots gate too. The robots
+		// fetches themselves are exempt or a redirecting robots.txt would
+		// recurse into its own policy lookup.
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 5 {
+				return errors.New("webread: too many redirects")
+			}
+			if req.URL.Path == "/robots.txt" {
+				return nil
+			}
+			allowed, err := f.pathAllowed(req.Context(), req.URL)
+			if err != nil {
+				return err
+			}
+			if !allowed {
+				return fmt.Errorf("%w: redirect target %s", ErrRobotsDisallowed, req.URL.Path)
+			}
+			return nil
+		},
+	}
+	return f
 }
 
 // Fetch retrieves one page as whitespace-normalized text, refusing what the
@@ -178,11 +192,13 @@ func (f *Fetcher) pathAllowed(ctx context.Context, page *url.URL) (bool, error) 
 // failure is NOT an answer: it reads as deny, because "the site could not say
 // what it permits" must never resolve in our own favor.
 func (f *Fetcher) fetchRobots(ctx context.Context, origin string) (robotsPolicy, error) {
+	//nolint:gosec // G704: fetching tenant-named hosts is this package's purpose; egress is guarded beneath — the dialer's netguard.RefusePrivate control and the per-hop robots gate — not at request construction
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, origin+"/robots.txt", nil)
 	if err != nil {
 		return robotsPolicy{}, err
 	}
 	req.Header.Set("User-Agent", UserAgent)
+	//nolint:gosec // G704: same guard — the transport beneath refuses non-public addresses pre-connect
 	resp, err := f.client.Do(req)
 	if err != nil {
 		return robotsPolicy{}, fmt.Errorf("webread: robots.txt unreachable (refusing to guess what %s permits): %w", origin, err)

--- a/backend/internal/platform/webread/webread_test.go
+++ b/backend/internal/platform/webread/webread_test.go
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package webread
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestStripTagsSurvivesUnicodeCaseFolding(t *testing.T) {
+	// U+212A (KELVIN SIGN) lowercases to a 1-byte "k": an index into a
+	// lowered copy of the document would drift off the source bytes and
+	// slice out of range. The stripper must work on the original bytes.
+	kelvin := strings.Repeat("\u212a", 3)
+	got := StripTags(kelvin + "<p>hello</p><script>evil()</script> world")
+	if !strings.HasSuffix(got, "hello world") {
+		t.Fatalf("StripTags = %q", got)
+	}
+	if StripTags("<SCRIPT>x</SCRIPT>visible<STYLE>y</STYLE>") != "visible" {
+		t.Fatal("case-insensitive script/style stripping broke")
+	}
+}
+
+// The policy reading is REP (RFC 9309): longest match wins, Allow beats
+// Disallow at equal length, the group naming this bot beats *, and an empty
+// Disallow means allow-all.
+func TestRobotsPolicyReading(t *testing.T) {
+	cases := []struct {
+		name    string
+		robots  string
+		path    string
+		allowed bool
+	}{
+		{"no policy at all", "", "/anything", true},
+		{"wildcard disallow all", "User-agent: *\nDisallow: /", "/impressum", false},
+		{"disallow one tree", "User-agent: *\nDisallow: /private/", "/impressum", true},
+		{"disallow that tree", "User-agent: *\nDisallow: /private/", "/private/x", false},
+		{"longest match wins", "User-agent: *\nDisallow: /a/\nAllow: /a/public/", "/a/public/page", true},
+		{"allow wins at equal length", "User-agent: *\nAllow: /a/\nDisallow: /a/", "/a/x", true},
+		{"our group beats wildcard", "User-agent: *\nDisallow: /\n\nUser-agent: margince-siteread\nAllow: /", "/impressum", true},
+		{"our group can also be stricter", "User-agent: *\nAllow: /\n\nUser-agent: margince-siteread\nDisallow: /", "/impressum", false},
+		{"empty disallow is allow-all", "User-agent: *\nDisallow:", "/x", true},
+		{"comments and case ignored", "# hi\nUSER-AGENT: *\nDISALLOW: /x # trailing", "/x/y", false},
+		{"stacked agent lines share one group", "User-agent: otherbot\nUser-agent: *\nDisallow: /x", "/x", false},
+		{"rules before any agent line bind nobody", "Disallow: /\nUser-agent: *\nAllow: /", "/x", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			policy := parseRobots(tc.robots)
+			if got := policy.allows(tc.path); got != tc.allowed {
+				t.Fatalf("allows(%q) = %v, want %v\nrobots:\n%s", tc.path, got, tc.allowed, tc.robots)
+			}
+		})
+	}
+}
+
+// testFetcher builds a Fetcher over an unguarded client: httptest servers live
+// on loopback, which the production SSRF guard rightly refuses — the guard has
+// its own coverage in platform/netguard, this suite covers the robots gate.
+func testFetcher() *Fetcher {
+	return &Fetcher{
+		client: &http.Client{Timeout: time.Second},
+		robots: map[string]robotsEntry{},
+		now:    time.Now,
+	}
+}
+
+func TestFetchHonorsTheSitesRobotsAnswer(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/robots.txt":
+			//craft:ignore swallowed-errors httptest handler write; a failed write fails the test through the assertion below
+			_, _ = w.Write([]byte("User-agent: *\nDisallow: /private/\n"))
+		case "/impressum":
+			//craft:ignore swallowed-errors httptest handler write; a failed write fails the test through the assertion below
+			_, _ = w.Write([]byte("<html><body>Acme GmbH, HRB 12345</body></html>"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	f := testFetcher()
+
+	// An allowed path fetches and strips.
+	text, err := f.Fetch(context.Background(), srv.URL+"/impressum")
+	if err != nil {
+		t.Fatalf("allowed fetch: %v", err)
+	}
+	if text != "Acme GmbH, HRB 12345" {
+		t.Fatalf("stripped text = %q", text)
+	}
+
+	// A disallowed path is refused as the site's answer, not fetched anyway.
+	if _, err := f.Fetch(context.Background(), srv.URL+"/private/report"); !errors.Is(err, ErrRobotsDisallowed) {
+		t.Fatalf("disallowed fetch → %v, want ErrRobotsDisallowed", err)
+	}
+}
+
+func TestFetchWithoutARobotsPolicyProceeds(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/robots.txt" {
+			http.NotFound(w, r) // 4xx: the site declares no policy
+			return
+		}
+		//craft:ignore swallowed-errors httptest handler write; a failed write fails the test through the assertion below
+		_, _ = w.Write([]byte("hello"))
+	}))
+	defer srv.Close()
+
+	text, err := testFetcher().Fetch(context.Background(), srv.URL+"/page")
+	if err != nil || text != "hello" {
+		t.Fatalf("fetch under a 404 robots = %q, %v — a missing policy is allow-all", text, err)
+	}
+}
+
+func TestFetchRefusesWhenRobotsCannotAnswer(t *testing.T) {
+	// A 5xx robots is NOT "no policy": the site could not say what it
+	// permits, and that must never resolve in the bot's own favor.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/robots.txt" {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		//craft:ignore swallowed-errors httptest handler write; unreachable when the test passes
+		_, _ = w.Write([]byte("hello"))
+	}))
+	defer srv.Close()
+
+	if _, err := testFetcher().Fetch(context.Background(), srv.URL+"/page"); err == nil {
+		t.Fatal("fetch proceeded although robots.txt answered 500")
+	}
+}
+
+func TestRobotsPolicyIsCachedPerHost(t *testing.T) {
+	robotsHits := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/robots.txt" {
+			robotsHits++
+			//craft:ignore swallowed-errors httptest handler write; a failed write fails the test through the assertion below
+			_, _ = w.Write([]byte("User-agent: *\nAllow: /\n"))
+			return
+		}
+		//craft:ignore swallowed-errors httptest handler write; a failed write fails the test through the assertion below
+		_, _ = w.Write([]byte("page"))
+	}))
+	defer srv.Close()
+	f := testFetcher()
+
+	for range 3 {
+		if _, err := f.Fetch(context.Background(), srv.URL+"/a"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if robotsHits != 1 {
+		t.Fatalf("robots.txt fetched %d times for one host within the TTL, want 1", robotsHits)
+	}
+}

--- a/backend/internal/platform/webread/webread_test.go
+++ b/backend/internal/platform/webread/webread_test.go
@@ -10,7 +10,6 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
-	"time"
 )
 
 func TestStripTagsSurvivesUnicodeCaseFolding(t *testing.T) {
@@ -49,6 +48,17 @@ func TestRobotsPolicyReading(t *testing.T) {
 		{"comments and case ignored", "# hi\nUSER-AGENT: *\nDISALLOW: /x # trailing", "/x/y", false},
 		{"stacked agent lines share one group", "User-agent: otherbot\nUser-agent: *\nDisallow: /x", "/x", false},
 		{"rules before any agent line bind nobody", "Disallow: /\nUser-agent: *\nAllow: /", "/x", true},
+		{"star wildcard matches any run", "User-agent: *\nDisallow: /*.php", "/a/b.php", false},
+		{"star wildcard does not invent text", "User-agent: *\nDisallow: /*.php", "/a/b.html", true},
+		{"dollar anchors to the end", "User-agent: *\nDisallow: /*.php$", "/a.php.html", true},
+		{"dollar anchored match", "User-agent: *\nDisallow: /*.php$", "/a.php.php", false},
+		{"literal with dollar only", "User-agent: *\nDisallow: /exact$", "/exact", false},
+		{"literal with dollar refuses longer", "User-agent: *\nDisallow: /exact$", "/exactly", true},
+		{"query is matchable", "User-agent: *\nDisallow: /*?sessionid=", "/page?sessionid=1", false},
+		{"query rule leaves plain path alone", "User-agent: *\nDisallow: /*?sessionid=", "/page", true},
+		{"matching groups COMBINE", "User-agent: margince-siteread\nAllow: /a\n\nUser-agent: margince-siteread\nDisallow: /b", "/b", false},
+		{"wildcard groups combine too", "User-agent: *\nDisallow: /a\n\nUser-agent: *\nDisallow: /b", "/b", false},
+		{"group naming us AND star is ours", "User-agent: *\nUser-agent: margince-siteread\nDisallow: /x", "/x", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -64,11 +74,7 @@ func TestRobotsPolicyReading(t *testing.T) {
 // on loopback, which the production SSRF guard rightly refuses — the guard has
 // its own coverage in platform/netguard, this suite covers the robots gate.
 func testFetcher() *Fetcher {
-	return &Fetcher{
-		client: &http.Client{Timeout: time.Second},
-		robots: map[string]robotsEntry{},
-		now:    time.Now,
-	}
+	return newFetcher(http.DefaultTransport)
 }
 
 func TestFetchHonorsTheSitesRobotsAnswer(t *testing.T) {
@@ -173,7 +179,7 @@ func TestProductionFetcherRefusesPrivateAddresses(t *testing.T) {
 	defer srv.Close()
 
 	_, err := New().Fetch(context.Background(), srv.URL+"/page")
-	if err == nil || !strings.Contains(err.Error(), "refusing non-public address") {
+	if err == nil || !strings.Contains(err.Error(), "refusing to dial non-public address") {
 		t.Fatalf("fetch of a loopback URL → %v, want the SSRF refusal", err)
 	}
 }
@@ -181,5 +187,37 @@ func TestProductionFetcherRefusesPrivateAddresses(t *testing.T) {
 func TestFetchRefusesAnUnfetchableURL(t *testing.T) {
 	if _, err := testFetcher().Fetch(context.Background(), "not-a-url"); err == nil {
 		t.Fatal("fetch accepted a URL with no host")
+	}
+}
+
+func TestRedirectTargetsRePassTheRobotsGate(t *testing.T) {
+	// An allowed path 302s onto a disallowed one: following it would fetch
+	// what the site said not to. The redirect hop must fail the gate.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/robots.txt":
+			//craft:ignore swallowed-errors httptest handler write; a failed write fails the test through the assertion below
+			_, _ = w.Write([]byte("User-agent: *\nDisallow: /private/\n"))
+		case "/open":
+			http.Redirect(w, r, "/private/secret", http.StatusFound)
+		case "/private/secret":
+			t.Error("the redirect was followed into a robots-disallowed path")
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	if _, err := testFetcher().Fetch(context.Background(), srv.URL+"/open"); !errors.Is(err, ErrRobotsDisallowed) {
+		t.Fatalf("redirect into a disallowed path → %v, want ErrRobotsDisallowed", err)
+	}
+}
+
+func TestStripTagsKeepsCustomElementsNamedLikeScript(t *testing.T) {
+	// <script-loader> is an ordinary custom element, not a script block; its
+	// content is page text a user can read and evidence can quote.
+	got := StripTags("<script-loader>visible words</script-loader><script>gone()</script>")
+	if got != "visible words" {
+		t.Fatalf("StripTags = %q, want the custom element's content kept and the real script dropped", got)
 	}
 }

--- a/backend/internal/platform/webread/webread_test.go
+++ b/backend/internal/platform/webread/webread_test.go
@@ -161,3 +161,25 @@ func TestRobotsPolicyIsCachedPerHost(t *testing.T) {
 		t.Fatalf("robots.txt fetched %d times for one host within the TTL, want 1", robotsHits)
 	}
 }
+
+func TestProductionFetcherRefusesPrivateAddresses(t *testing.T) {
+	// The REAL constructor, guard included: an httptest server lives on
+	// loopback, which is exactly the address class a tenant-supplied URL must
+	// never reach. The refusal fires on the very first dial — the robots
+	// lookup — so nothing is ever fetched from the private address at all.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("the SSRF guard let a request through to a loopback address")
+	}))
+	defer srv.Close()
+
+	_, err := New().Fetch(context.Background(), srv.URL+"/page")
+	if err == nil || !strings.Contains(err.Error(), "refusing non-public address") {
+		t.Fatalf("fetch of a loopback URL → %v, want the SSRF refusal", err)
+	}
+}
+
+func TestFetchRefusesAnUnfetchableURL(t *testing.T) {
+	if _, err := testFetcher().Fetch(context.Background(), "not-a-url"); err == nil {
+		t.Fatal("fetch accepted a URL with no host")
+	}
+}

--- a/backend/migrations/core/0084_profile_field_display_name.down.sql
+++ b/backend/migrations/core/0084_profile_field_display_name.down.sql
@@ -4,4 +4,5 @@ ALTER TABLE organization_profile_field DROP CONSTRAINT organization_profile_fiel
 ALTER TABLE organization_profile_field
   ADD CONSTRAINT organization_profile_field_field_check
   CHECK (field IN ('icp','buying_center','value_proposition','usp','buying_intents',
-                   'legal_name','registered_address','register_vat','industry','history'));
+                   'legal_name','registered_address','register_vat','industry','history')) NOT VALID;
+ALTER TABLE organization_profile_field VALIDATE CONSTRAINT organization_profile_field_field_check;

--- a/backend/migrations/core/0084_profile_field_display_name.down.sql
+++ b/backend/migrations/core/0084_profile_field_display_name.down.sql
@@ -1,0 +1,7 @@
+-- Reverse 0084.
+DELETE FROM organization_profile_field WHERE field = 'display_name';
+ALTER TABLE organization_profile_field DROP CONSTRAINT organization_profile_field_field_check;
+ALTER TABLE organization_profile_field
+  ADD CONSTRAINT organization_profile_field_field_check
+  CHECK (field IN ('icp','buying_center','value_proposition','usp','buying_intents',
+                   'legal_name','registered_address','register_vat','industry','history'));

--- a/backend/migrations/core/0084_profile_field_display_name.up.sql
+++ b/backend/migrations/core/0084_profile_field_display_name.up.sql
@@ -1,0 +1,12 @@
+-- 0084: admit display_name into the read-back vocabulary. The extraction can
+-- now quote what a company calls itself day to day (the landing page states it
+-- where the register entry does not), and the form's most obvious field stops
+-- being the one the read-back can never fill. Evidence rows land here like
+-- every other read-back field; organization.display_name itself is NOT NULL
+-- and human-owned, so no column fill applies.
+ALTER TABLE organization_profile_field DROP CONSTRAINT organization_profile_field_field_check;
+ALTER TABLE organization_profile_field
+  ADD CONSTRAINT organization_profile_field_field_check
+  CHECK (field IN ('icp','buying_center','value_proposition','usp','buying_intents',
+                   'legal_name','registered_address','register_vat','industry','history',
+                   'display_name'));

--- a/backend/migrations/core/0084_profile_field_display_name.up.sql
+++ b/backend/migrations/core/0084_profile_field_display_name.up.sql
@@ -4,9 +4,14 @@
 -- being the one the read-back can never fill. Evidence rows land here like
 -- every other read-back field; organization.display_name itself is NOT NULL
 -- and human-owned, so no column fill applies.
+--
+-- The CHECK is added NOT VALID and validated separately: the immediate form
+-- scans the table under a write-blocking lock, while VALIDATE takes only
+-- SHARE UPDATE EXCLUSIVE — existing rows all satisfy the widened set anyway.
 ALTER TABLE organization_profile_field DROP CONSTRAINT organization_profile_field_field_check;
 ALTER TABLE organization_profile_field
   ADD CONSTRAINT organization_profile_field_field_check
   CHECK (field IN ('icp','buying_center','value_proposition','usp','buying_intents',
                    'legal_name','registered_address','register_vat','industry','history',
-                   'display_name'));
+                   'display_name')) NOT VALID;
+ALTER TABLE organization_profile_field VALIDATE CONSTRAINT organization_profile_field_field_check;

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -5326,7 +5326,7 @@ export interface components {
          */
         ColdStartField: {
             /** @enum {string} */
-            field: "icp" | "buying_center" | "value_proposition" | "usp" | "buying_intents" | "legal_name" | "registered_address" | "register_vat" | "industry" | "history";
+            field: "icp" | "buying_center" | "value_proposition" | "usp" | "buying_intents" | "legal_name" | "registered_address" | "register_vat" | "industry" | "history" | "display_name";
             value: string;
             /** @description Verbatim source text (from the page, the pasted text, or the user's own words) — non-empty or the field is absent. */
             evidence_snippet: string;

--- a/frontend/src/screens/onboarding.css
+++ b/frontend/src/screens/onboarding.css
@@ -424,48 +424,18 @@
   margin-top: 14px;
 }
 
-/* step 2 confirm fields */
-.ob-field {
-  margin-top: 18px;
+/* The company form rides the design-system atoms (.form-stack/.field/.input —
+   atoms.css owns their look); the only onboarding-specific rule is where the
+   form starts relative to the notices above it. */
+.ob-companyform {
+  margin-top: 22px;
 }
-.ob-field label {
-  display: block;
-  font-size: 11px;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  font-weight: 600;
-  color: var(--textTertiary);
-  margin-bottom: 6px;
-}
-.ob-field .askhint {
-  color: var(--accent);
-  text-transform: none;
-  letter-spacing: 0;
-  font-weight: 500;
-}
-.ob-in {
-  width: 100%;
-  border: 1px solid var(--borderStrong);
-  border-radius: var(--r-sm);
-  padding: 11px 13px;
-  font-family: var(--f-body);
-  font-size: 14px;
-  color: var(--textPrimary);
-  background: var(--bgElevated);
-  outline: 0;
-  line-height: 1.5;
-}
-.ob-in:focus {
-  border-color: var(--accent);
-  box-shadow: 0 0 0 4px var(--accentLight);
-}
-textarea.ob-in {
-  resize: vertical;
-  min-height: 84px;
-}
-.ob-in.askfill {
-  border-color: var(--accent);
-  background: var(--bgElevated);
+/* The trust adornments ride the field label (a .t-label): read-from-site tag
+   right-aligned, everything vertically centered with the label text. */
+.ob-companyform .t-label {
+  display: flex;
+  align-items: center;
+  gap: 7px;
 }
 
 /* step 3 voice corpus */
@@ -917,20 +887,15 @@ textarea.ob-in {
 .imap-form .full {
   grid-column: 1 / -1;
 }
-.imap-form .ob-field {
-  margin-top: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  font-size: 11px;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
+/* The credential fields are design-system .field/.input; the label text here
+   is the label element's own child, so it takes the .t-label look via font
+   rules on the label itself. */
+.imap-form .field {
+  font-size: 12.5px;
   font-weight: 600;
-  color: var(--textTertiary);
+  color: var(--textMeta);
 }
-.imap-form .ob-in {
-  text-transform: none;
-  letter-spacing: normal;
+.imap-form .input {
   font-weight: 400;
 }
 .scopes {

--- a/frontend/src/screens/onboarding.tsx
+++ b/frontend/src/screens/onboarding.tsx
@@ -39,7 +39,7 @@ import {
 import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { navigate } from "../app/router";
-import { Button } from "../design-system/atoms";
+import { Button, TextInput } from "../design-system/atoms";
 import {
   ConfidenceMeter,
   EvidenceChip,
@@ -597,40 +597,41 @@ function CompanyStep({
         </div>
       )}
 
-      <div className="seclabel" style={{ margin: "22px 0 0" }}>
-        {t("ob.s1.identityLabel")}
-      </div>
-      {IDENTITY_FIELDS.map((field) => (
-        <CompanyFormField
-          key={field}
-          field={field}
-          value={draft.values[field]}
-          grounded={groundingOf(draft, field)}
-          edited={draft.edited.has(field)}
-          required={isRequired(field)}
-          error={
-            missingRequired.includes(field) ? t("ob.s1.fieldRequired") : null
-          }
-          onChange={(v) => setField(field, v)}
-        />
-      ))}
+      {/* One .form-stack carries the whole form at the house 8/12 rhythm; the
+          two groups are separated by labeled dividers (the create-form
+          pattern), not by per-field margins. */}
+      <div className="form-stack ob-companyform">
+        <p className="form-divider t-label">{t("ob.s1.identityLabel")}</p>
+        {IDENTITY_FIELDS.map((field) => (
+          <CompanyFormField
+            key={field}
+            field={field}
+            value={draft.values[field]}
+            grounded={groundingOf(draft, field)}
+            edited={draft.edited.has(field)}
+            required={isRequired(field)}
+            error={
+              missingRequired.includes(field) ? t("ob.s1.fieldRequired") : null
+            }
+            onChange={(v) => setField(field, v)}
+          />
+        ))}
 
-      <div className="seclabel" style={{ margin: "26px 0 0" }}>
-        {t("ob.s1.positioningLabel")}
+        <p className="form-divider t-label">{t("ob.s1.positioningLabel")}</p>
+        {POSITIONING_FIELDS.map((field) => (
+          <CompanyFormField
+            key={field}
+            field={field}
+            value={draft.values[field]}
+            grounded={groundingOf(draft, field)}
+            edited={draft.edited.has(field)}
+            required={false}
+            error={null}
+            multiline
+            onChange={(v) => setField(field, v)}
+          />
+        ))}
       </div>
-      {POSITIONING_FIELDS.map((field) => (
-        <CompanyFormField
-          key={field}
-          field={field}
-          value={draft.values[field]}
-          grounded={groundingOf(draft, field)}
-          edited={draft.edited.has(field)}
-          required={false}
-          error={null}
-          multiline
-          onChange={(v) => setField(field, v)}
-        />
-      ))}
     </section>
   );
 }
@@ -754,9 +755,14 @@ function CompanyFormField({
   const t = useT();
   const id = `co-${field}`;
   const level = grounded ? confidenceLevel(grounded.confidence) : null;
+  // The design-system field shape (create.tsx RecordFormBody is the reference):
+  // .field + .t-label + .input/.textarea. The trust adornments (confidence,
+  // read-from-site, typed-by-you) ride the label; the evidence chip sits under
+  // the control. Onboarding gets no bespoke input styling — the form must read
+  // as the same product as every other screen.
   return (
-    <div className="ob-field">
-      <label htmlFor={id}>
+    <div className="field">
+      <label className="t-label" htmlFor={id}>
         {coldFieldLabel(field, t)}
         {required ? " *" : ""} {level && <ConfidenceMeter level={level} />}
         {grounded && (
@@ -769,17 +775,18 @@ function CompanyFormField({
       {multiline ? (
         <textarea
           id={id}
-          className="ob-in"
+          className="textarea"
           value={value}
           required={required}
+          aria-invalid={error ? true : undefined}
           onChange={(e) => onChange(e.target.value)}
         />
       ) : (
-        <input
+        <TextInput
           id={id}
-          className="ob-in"
           value={value}
           required={required}
+          aria-invalid={error ? true : undefined}
           onChange={(e) => onChange(e.target.value)}
         />
       )}
@@ -1431,47 +1438,47 @@ function ConnectStep() {
           </p>
 
           <div className="imap-form">
-            <label className="ob-field full">
+            <label className="field full">
               {t("ob.s4.imapHost")}
               <input
-                className="ob-in"
+                className="input"
                 value={host}
                 placeholder={t("ob.s4.imapHostPlaceholder")}
                 onChange={(e) => setHostVal(e.target.value)}
               />
             </label>
-            <label className="ob-field full">
+            <label className="field full">
               {t("ob.s4.imapEmail")}
               <input
-                className="ob-in"
+                className="input"
                 type="email"
                 autoComplete="email"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
               />
             </label>
-            <label className="ob-field full">
+            <label className="field full">
               {t("ob.s4.imapPassword")}
               <input
-                className="ob-in"
+                className="input"
                 type="password"
                 autoComplete="off"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
               />
             </label>
-            <label className="ob-field">
+            <label className="field">
               {t("ob.s4.imapMailbox")}
               <input
-                className="ob-in"
+                className="input"
                 value={mailbox}
                 onChange={(e) => setMailbox(e.target.value)}
               />
             </label>
-            <label className="ob-field">
+            <label className="field">
               {t("ob.s4.imapMax")}
               <input
-                className="ob-in"
+                className="input"
                 type="number"
                 min={1}
                 max={200}

--- a/frontend/src/screens/onboarding.tsx
+++ b/frontend/src/screens/onboarding.tsx
@@ -114,8 +114,8 @@ const REQUIRED_FIELDS = [
   "industry",
 ] as const satisfies readonly CompanyFieldName[];
 
-// The read-back can only ground the contract's ColdStartField names — website
-// and display_name are always the human's to give.
+// The read-back can only ground the contract's ColdStartField names —
+// website is always the human's to give.
 type Grounded = Partial<Record<ColdField["field"], ColdField>>;
 
 // One state object, because the three parts move together: typing a value


### PR DESCRIPTION
## What this is

PR A of the website-ingestion plan (the crawl engine is PR B). Three things the founder hit testing onboarding:

1. **The ingestion was weak.** One page fetched, so the legal facts — which live on the Impressum, not the landing page — never grounded. On gradion.com: 2 of 12 fields.
2. **The read-back could never fill `display_name`** — it wasn't in the extraction vocabulary at all.
3. **The form looked foreign** — bespoke `.ob-field`/`.ob-in` CSS instead of the design-system atoms every other screen uses.

## The quick read

`extract()` now reads the **site**, not the page: the given URL plus a probe of the well-known legal-notice paths (`/impressum`, `/imprint`, `/de/impressum`, … — German forms first; an Impressum is legally mandatory in this product's home market). Per-page extraction, per-page verbatim gate, deterministic merge: **legal facts prefer the legal page even at lower model confidence** — the page that legally states a fact outranks a landing-page guess — while positioning stays the landing page's. Probe paths are derived from the operator's input, never from page content: inside ADR-0006's fetch-a-given-URL posture (founder ratification R1, recorded in-session 2026-07-17). A probe answered with the seed page again (SPA catch-alls) is a miss, not a second model call.

**Live result on gradion.com: 5 fields instead of 2, with the whole mandatory identity block quoted from `/imprint`** — `legal_name` "Gradion Pte. Ltd." (0.95), `register_vat` "201629357M" (0.9), `registered_address` (0.95). `coldStartPreview`, `coldStartReadback` and `scrapeCompany` all sit on it with zero API-shape change.

`display_name` joins the ColdStartField vocabulary (contract enum + prompt + schema + 0084 CHECK widening). `organization.display_name` stays human-owned — evidence rows only, no column fill.

## platform/webread

The fetcher moves out of compose and starts keeping ADR-0006's promise: **robots.txt honored** (RFC 9309 group selection, longest match, Allow-at-equal-length, our product name beating `*`), under an attributable UA (`margince-siteread/1.0`). A 4xx robots is "no policy" → allow, the standard; a 5xx is **not an answer** — "the site could not say what it permits" never resolves in the bot's own favor. The tag strip moves unchanged: evidence snippets are matched against its output, so its behavior is a contract.

Deviation from the approved plan, deliberate: the pacer and link extraction stay out of this PR — they have **no caller** until PR B's crawler, and the repo's own craft rules forbid speculative code. They land with the crawler.

## The form

`CompanyStep` + the IMAP credential form rebuilt on the house atoms (`.form-stack` / `.field` / `.t-label` / `TextInput`, labeled `.form-divider` group rules — `create.tsx` `RecordFormBody` is the reference). Trust adornments (confidence, read-from-site, typed-by-you, evidence chip) keep their exact places. The bespoke `.ob-field`/`.ob-in` CSS is deleted, not orphaned. The conformance gate never caught this because it checks tokens, not atom usage — worth a follow-up gate.

## Verification

- `make check` exit 0, `make test-integration` 0 skips, both after every change.
- New unit suites: the Impressum merge (legal page wins legal facts at LOWER confidence; ICP stays the landing page's), no-legal-page = single call, same-page probe skipped, `display_name` offered to the model and gated; robots policy reading (12 table cases: longest-match, Allow tiebreak, our-group-beats-wildcard, stacked agent lines, headerless rules bind nobody); fetch-level robots honor incl. 5xx-deny and per-host cache.
- Live against the running stack: the gradion.com numbers above, measured through `POST /v1/coldstart/preview`.

## Known deviation, flagged upstream

The two-page read runs its model calls **sequentially**: 13.3s measured on gradion.com vs ONBOARD-PARAM-1's 8s p95. Concurrency would make the scripted fake-client tests nondeterministic (the consuming queue races). Either re-pin the budget for the two-page read or teach the fake per-page scripting first — flagged in the upstream ratification list.

## For the spec session (founder ratifications R1–R3, recorded in-session 2026-07-17)

- R1: well-known-path probes are within ADR-0006; `display_name` added to ColdStartField
- R3: robots posture (named UA, 4xx-allow / 5xx-deny)
- ONBOARD-PARAM-1 re-pin for the two-page read (above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for capturing company display names during onboarding and site research.
  * Improved site research by combining landing-page information with legal-notice pages.
  * Added robots.txt compliance and safer web-page retrieval.
* **Improvements**
  * Refreshed onboarding company and email form styling for a more consistent experience.
  * Improved handling of unreadable or unavailable websites.
* **Bug Fixes**
  * Prevented duplicate processing when legal-notice pages repeat landing-page content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->