### PR TITLE
fix(ai): cloud-provider review findings — honest stream terminals, wire hygiene, key-matched dev routing

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -22,6 +22,18 @@ The merge gate (`make check`), the real-Postgres integration lane
 
 ## Recently landed
 
+**Cloud-provider review remediation (PR #102)** — the top-10 correctness
+findings from the post-merge review of the cloud model providers (#96):
+streams surface failure/truncation terminals instead of clean EOF (openai
+`response.failed`/`incomplete`/`error`, gemini mid-stream error objects +
+abnormal `finishReason`, applied to `Complete` too), one shared SSE
+scanner with a 4MiB line cap, cache keys cover model override + response
+schema, `OutputTokens` is reasoning-inclusive on every adapter (gemini
+normalized), Responses API `store:false` pinned, `dimensions` omitted on
+the generic OpenAI wire, canonical `models/…` ids accepted, vLLM
+top-level errors decoded, and `make dev` enables real routing only when
+every bound cloud provider's key is present.
+
 **Single-organization installation (ADR-0061/A107, PR #90)** — the
 ratified single-org concept, end to end. One installation serves one
 organization: bootstrap moved off the public wire into a strict
@@ -349,7 +361,10 @@ Implementation follow-ups deferred from this change (honest floors shipped now):
   row so the lane can change without a full re-embed, or make the column width
   configurable) is a separate PR. Until then, switching the embed binding means
   wiping the store (as the module comment already notes). Filed upstream as
-  foundation #1074.
+  foundation #1074. Truncation applies to native `openai`/`gemini` only:
+  the generic `openai_compatible`/`vllm` wire omits the `dimensions` knob
+  entirely (vLLM rejects it on non-matryoshka models), so a model bound
+  there must natively emit the store's width.
 - **Native tool-use mapping for `openai`/`gemini`.** The tasks run in JSON mode
   today, so no caller sets `req.Tools`; the native adapters currently **reject**
   a non-empty `Tools` (loud, not a silent drop) rather than map it. Mapping to

--- a/backend/internal/modules/ai/anthropic.go
+++ b/backend/internal/modules/ai/anthropic.go
@@ -113,7 +113,7 @@ func (c *anthropicClient) Stream(ctx context.Context, req model.Request) (model.
 	if err != nil {
 		return nil, err
 	}
-	return &anthropicStream{body: body, scanner: bufio.NewScanner(body)}, nil
+	return &anthropicStream{body: body, scanner: sseScanner(body)}, nil
 }
 
 // Embed is a different lane, not a chat-tier capability: Anthropic

--- a/backend/internal/modules/ai/anthropic.go
+++ b/backend/internal/modules/ai/anthropic.go
@@ -222,8 +222,8 @@ func anthropicError(resp *http.Response) error {
 			Message string `json:"message"`
 		} `json:"error"`
 	}
-	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-	if json.Unmarshal(raw, &apiErr) == nil && apiErr.Error.Type != "" {
+	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if readErr == nil && json.Unmarshal(raw, &apiErr) == nil && apiErr.Error.Type != "" {
 		return fmt.Errorf("ai: anthropic: %s: %s (http %d)", apiErr.Error.Type, apiErr.Error.Message, resp.StatusCode)
 	}
 	return fmt.Errorf("ai: anthropic: http %d", resp.StatusCode)

--- a/backend/internal/modules/ai/anthropic.go
+++ b/backend/internal/modules/ai/anthropic.go
@@ -113,7 +113,7 @@ func (c *anthropicClient) Stream(ctx context.Context, req model.Request) (model.
 	if err != nil {
 		return nil, err
 	}
-	return &anthropicStream{body: body, scanner: sseScanner(body)}, nil
+	return &anthropicStream{body: body, scanner: streamLineScanner(body)}, nil
 }
 
 // Embed is a different lane, not a chat-tier capability: Anthropic

--- a/backend/internal/modules/ai/attachments_test.go
+++ b/backend/internal/modules/ai/attachments_test.go
@@ -56,7 +56,7 @@ func TestEveryProviderMapsOrRejectsAttachmentsNeverSilentlyDrops(t *testing.T) {
 func TestAttachmentBytesXorURIEnforced(t *testing.T) {
 	t.Setenv("OPENAI_API_KEY", "k")
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(`{"id":"r","output":[{"type":"message","content":[{"type":"output_text","text":"ok"}]}]}`))
+		_, _ = w.Write([]byte(`{"id":"r","status":"completed","output":[{"type":"message","content":[{"type":"output_text","text":"ok"}]}]}`))
 	}))
 	defer srv.Close()
 	client, err := SelectBrain(ProviderConfig{Provider: "openai", BaseURL: srv.URL, Model: "m"})
@@ -85,10 +85,10 @@ func TestNativeCloudProvidersCarryPDFAttachments(t *testing.T) {
 	t.Setenv("GEMINI_API_KEY", "k")
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.Contains(r.URL.Path, ":generateContent") {
-			_, _ = w.Write([]byte(`{"candidates":[{"content":{"parts":[{"text":"ok"}]}}]}`))
+			_, _ = w.Write([]byte(`{"candidates":[{"content":{"parts":[{"text":"ok"}]},"finishReason":"STOP"}]}`))
 			return
 		}
-		_, _ = w.Write([]byte(`{"id":"r","output":[{"type":"message","content":[{"type":"output_text","text":"ok"}]}]}`))
+		_, _ = w.Write([]byte(`{"id":"r","status":"completed","output":[{"type":"message","content":[{"type":"output_text","text":"ok"}]}]}`))
 	}))
 	defer srv.Close()
 

--- a/backend/internal/modules/ai/gemini.go
+++ b/backend/internal/modules/ai/gemini.go
@@ -135,6 +135,12 @@ func (c *geminiClient) Complete(ctx context.Context, req model.Request) (model.R
 	if err := geminiResponseError(out); err != nil {
 		return model.Response{}, err
 	}
+	// A non-stream response is terminal by definition, so it must say STOP —
+	// a candidate with no finishReason is a truncated or non-Responses body,
+	// not a complete answer.
+	if !geminiSawStop(out) {
+		return model.Response{}, fmt.Errorf("ai: gemini: response carries no terminal STOP")
+	}
 	var text strings.Builder
 	var signatures []string
 	for _, cand := range out.Candidates {
@@ -381,6 +387,18 @@ func geminiResponseError(out geminiResponse) error {
 	return nil
 }
 
+// geminiSawStop reports whether any candidate finished with the clean STOP
+// terminal. Intermediate stream chunks legitimately carry no finishReason —
+// only the final chunk (and every non-stream response) does.
+func geminiSawStop(out geminiResponse) bool {
+	for _, cand := range out.Candidates {
+		if cand.FinishReason == "STOP" {
+			return true
+		}
+	}
+	return false
+}
+
 // geminiError surfaces the API's error status and message only, so a logged
 // failure can never echo the request (or the key).
 func geminiError(resp *http.Response) error {
@@ -390,19 +408,22 @@ func geminiError(resp *http.Response) error {
 			Message string `json:"message"`
 		} `json:"error"`
 	}
-	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-	if json.Unmarshal(raw, &apiErr) == nil && apiErr.Error.Status != "" {
+	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if readErr == nil && json.Unmarshal(raw, &apiErr) == nil && apiErr.Error.Status != "" {
 		return fmt.Errorf("ai: gemini: %s: %s (http %d)", apiErr.Error.Status, apiErr.Error.Message, resp.StatusCode)
 	}
 	return fmt.Errorf("ai: gemini: http %d", resp.StatusCode)
 }
 
 // geminiStream reads the :streamGenerateContent?alt=sse stream. There is no
-// [DONE] sentinel — the stream simply closes; text arrives at
-// candidates[0].content.parts[].text on each chunk.
+// [DONE] sentinel — the final chunk carries finishReason STOP and then the
+// stream closes; text arrives at candidates[0].content.parts[].text on each
+// chunk. sawStop remembers the terminal so an EOF without one (a connection
+// dropped mid-generation) surfaces as an error, not a complete answer.
 type geminiStream struct {
 	body    io.ReadCloser
 	scanner *bufio.Scanner
+	sawStop bool
 }
 
 func (s *geminiStream) Next(ctx context.Context) (string, bool, error) {
@@ -425,6 +446,9 @@ func (s *geminiStream) Next(ctx context.Context) (string, bool, error) {
 		if err := geminiResponseError(ev); err != nil {
 			return "", false, err
 		}
+		if geminiSawStop(ev) {
+			s.sawStop = true
+		}
 		var chunk strings.Builder
 		for _, cand := range ev.Candidates {
 			for _, part := range cand.Content.Parts {
@@ -437,6 +461,10 @@ func (s *geminiStream) Next(ctx context.Context) (string, bool, error) {
 	}
 	if err := s.scanner.Err(); err != nil {
 		return "", false, fmt.Errorf("ai: gemini: stream: %w", err)
+	}
+	if !s.sawStop {
+		// EOF before the STOP terminal: the connection dropped mid-generation.
+		return "", false, fmt.Errorf("ai: gemini: stream ended without a terminal STOP")
 	}
 	return "", false, nil
 }

--- a/backend/internal/modules/ai/gemini.go
+++ b/backend/internal/modules/ai/gemini.go
@@ -102,7 +102,17 @@ type geminiOptions struct {
 type geminiResponse struct {
 	Candidates []struct {
 		Content geminiContent `json:"content"`
+		// FinishReason names why generation stopped; "STOP" is the only clean
+		// finish. SAFETY / MAX_TOKENS / RECITATION / … must surface as errors —
+		// a filtered or truncated answer must never read as a complete one.
+		FinishReason string `json:"finishReason"` //nolint:tagliatelle // Google's wire format (camelCase)
 	} `json:"candidates"`
+	// Error is Google's mid-stream/in-body error object (a 200 stream can
+	// still deliver {"error":{…}} as a chunk).
+	Error struct {
+		Status  string `json:"status"`
+		Message string `json:"message"`
+	} `json:"error"`
 	UsageMetadata struct {
 		PromptTokenCount        int `json:"promptTokenCount"`        //nolint:tagliatelle // Google's wire format (camelCase)
 		CandidatesTokenCount    int `json:"candidatesTokenCount"`    //nolint:tagliatelle // Google's wire format (camelCase)
@@ -122,6 +132,9 @@ func (c *geminiClient) Complete(ctx context.Context, req model.Request) (model.R
 	if err := json.NewDecoder(body).Decode(&out); err != nil {
 		return model.Response{}, fmt.Errorf("ai: gemini: decode response: %w", err)
 	}
+	if err := geminiResponseError(out); err != nil {
+		return model.Response{}, err
+	}
 	var text strings.Builder
 	var signatures []string
 	for _, cand := range out.Candidates {
@@ -133,9 +146,12 @@ func (c *geminiClient) Complete(ctx context.Context, req model.Request) (model.R
 		}
 	}
 	resp := model.Response{
-		Text:            text.String(),
-		InputTokens:     out.UsageMetadata.PromptTokenCount,
-		OutputTokens:    out.UsageMetadata.CandidatesTokenCount,
+		Text:        text.String(),
+		InputTokens: out.UsageMetadata.PromptTokenCount,
+		// candidatesTokenCount EXCLUDES thinking tokens, but the port's
+		// OutputTokens invariant is reasoning-inclusive (model.Response) so the
+		// budget meter charges true spend on every provider — add them here.
+		OutputTokens:    out.UsageMetadata.CandidatesTokenCount + out.UsageMetadata.ThoughtsTokenCount,
 		CachedTokens:    out.UsageMetadata.CachedContentTokenCount,
 		ReasoningTokens: out.UsageMetadata.ThoughtsTokenCount,
 	}
@@ -153,11 +169,14 @@ func (c *geminiClient) Stream(ctx context.Context, req model.Request) (model.Tok
 	if err != nil {
 		return nil, err
 	}
-	return &geminiStream{body: body, scanner: bufio.NewScanner(body)}, nil
+	return &geminiStream{body: body, scanner: sseScanner(body)}, nil
 }
 
 func (c *geminiClient) Embed(ctx context.Context, req model.EmbedRequest) (model.Embeddings, error) {
-	embedModel := req.Model
+	// Accept both the bare id and Google's canonical "models/…" form — the
+	// path and wire body add the prefix themselves, so a canonical id would
+	// otherwise double it (/models/models/… → 404).
+	embedModel := strings.TrimPrefix(req.Model, "models/")
 	if embedModel == "" {
 		embedModel = geminiEmbedModel
 	}
@@ -219,9 +238,11 @@ func (c *geminiClient) generate(ctx context.Context, req model.Request, stream b
 	if len(req.Tools) > 0 {
 		return nil, fmt.Errorf("ai: gemini: native tool-use is not implemented yet (request set %d tool(s))", len(req.Tools))
 	}
-	genModel := req.Model
+	// Same id normalization as Embed: the ":generateContent" path adds the
+	// "models/" prefix, so trim a canonical "models/…" id.
+	genModel := strings.TrimPrefix(req.Model, "models/")
 	if genModel == "" {
-		genModel = c.defaultModel
+		genModel = strings.TrimPrefix(c.defaultModel, "models/")
 	}
 	opts, err := geminiReadOptions(req.ProviderOptions)
 	if err != nil {
@@ -344,6 +365,22 @@ func (c *geminiClient) post(ctx context.Context, path string, payload []byte) (i
 	return resp.Body, nil
 }
 
+// geminiResponseError maps an in-body error object or an abnormal
+// finishReason to an error. STOP (and absent — a non-final stream chunk) is
+// the only clean state; SAFETY, MAX_TOKENS, RECITATION, … otherwise pass for
+// a complete answer because Gemini delivers them inside a 200 body.
+func geminiResponseError(out geminiResponse) error {
+	if out.Error.Message != "" || out.Error.Status != "" {
+		return fmt.Errorf("ai: gemini: %s: %s", out.Error.Status, out.Error.Message)
+	}
+	for _, cand := range out.Candidates {
+		if cand.FinishReason != "" && cand.FinishReason != "STOP" {
+			return fmt.Errorf("ai: gemini: generation stopped: %s", cand.FinishReason)
+		}
+	}
+	return nil
+}
+
 // geminiError surfaces the API's error status and message only, so a logged
 // failure can never echo the request (or the key).
 func geminiError(resp *http.Response) error {
@@ -381,6 +418,12 @@ func (s *geminiStream) Next(ctx context.Context) (string, bool, error) {
 		var ev geminiResponse
 		if err := json.Unmarshal([]byte(data), &ev); err != nil {
 			return "", false, fmt.Errorf("ai: gemini: stream event: %w", err)
+		}
+		// A mid-stream error object or an abnormal finishReason (SAFETY,
+		// MAX_TOKENS, …) arrives inside a 200 chunk — surface it instead of
+		// letting a zero-text chunk fall through to a clean-looking EOF.
+		if err := geminiResponseError(ev); err != nil {
+			return "", false, err
 		}
 		var chunk strings.Builder
 		for _, cand := range ev.Candidates {

--- a/backend/internal/modules/ai/gemini.go
+++ b/backend/internal/modules/ai/gemini.go
@@ -169,7 +169,7 @@ func (c *geminiClient) Stream(ctx context.Context, req model.Request) (model.Tok
 	if err != nil {
 		return nil, err
 	}
-	return &geminiStream{body: body, scanner: sseScanner(body)}, nil
+	return &geminiStream{body: body, scanner: streamLineScanner(body)}, nil
 }
 
 func (c *geminiClient) Embed(ctx context.Context, req model.EmbedRequest) (model.Embeddings, error) {

--- a/backend/internal/modules/ai/gemini_test.go
+++ b/backend/internal/modules/ai/gemini_test.go
@@ -43,7 +43,9 @@ func TestGeminiCompleteMapsNativeWireAndUsage(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if resp.Text != "answer" || resp.InputTokens != 10 || resp.OutputTokens != 5 || resp.CachedTokens != 6 || resp.ReasoningTokens != 4 {
+	// OutputTokens is reasoning-inclusive (the port invariant): Gemini reports
+	// candidates (5) and thoughts (4) separately, so the adapter sums them.
+	if resp.Text != "answer" || resp.InputTokens != 10 || resp.OutputTokens != 9 || resp.CachedTokens != 6 || resp.ReasoningTokens != 4 {
 		t.Fatalf("mapping wrong: %+v", resp)
 	}
 	var wire struct {
@@ -289,5 +291,108 @@ func TestGeminiThoughtSignatureRoundTrips(t *testing.T) {
 	}
 	if !bytes.Contains(reqBody, []byte(`"thoughtSignature":"SIG-abc"`)) {
 		t.Fatalf("thought signature not echoed onto the model turn: %s", reqBody)
+	}
+}
+
+// SAFETY / MAX_TOKENS / RECITATION arrive inside a 200 body — an abnormal
+// finishReason must surface as an error, never as a clean (truncated) answer.
+func TestGeminiAbnormalFinishReasonIsAnError(t *testing.T) {
+	client := newGeminiForTest(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"candidates":[{"content":{"parts":[{"text":"trunc"}]},"finishReason":"MAX_TOKENS"}]}`))
+	})
+	_, err := client.Complete(context.Background(), model.Request{Messages: []model.Message{{Role: "user", Content: "q"}}})
+	if err == nil || !strings.Contains(err.Error(), "MAX_TOKENS") {
+		t.Fatalf("want error naming MAX_TOKENS, got %v", err)
+	}
+}
+
+// A mid-stream error object and an abnormal finishReason both ride 200 SSE
+// chunks; either passing for EOF would report a failed call as complete.
+func TestGeminiStreamSurfacesErrorChunkAndAbnormalFinish(t *testing.T) {
+	cases := map[string]struct {
+		chunk string
+		want  string
+	}{
+		"error object":  {`data: {"error":{"status":"RESOURCE_EXHAUSTED","message":"quota"}}`, "RESOURCE_EXHAUSTED"},
+		"safety finish": {`data: {"candidates":[{"content":{"parts":[]},"finishReason":"SAFETY"}]}`, "SAFETY"},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			client := newGeminiForTest(t, func(w http.ResponseWriter, r *http.Request) {
+				_, _ = io.WriteString(w, `data: {"candidates":[{"content":{"parts":[{"text":"he"}]}}]}`+"\n\n")
+				_, _ = io.WriteString(w, tc.chunk+"\n\n")
+			})
+			stream, err := client.Stream(context.Background(), model.Request{Messages: []model.Message{{Role: "user", Content: "hi"}}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() {
+				if err := stream.Close(); err != nil {
+					t.Errorf("closing stream: %v", err)
+				}
+			}()
+			if chunk, ok, err := stream.Next(context.Background()); err != nil || !ok || chunk != "he" {
+				t.Fatalf("first chunk: %q %v %v", chunk, ok, err)
+			}
+			_, _, err = stream.Next(context.Background())
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("want error naming %q, got %v", tc.want, err)
+			}
+		})
+	}
+}
+
+// A final chunk finishing with STOP is the clean terminal — it must not be
+// mistaken for an abnormal finish.
+func TestGeminiStreamCleanStopIsNotAnError(t *testing.T) {
+	client := newGeminiForTest(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `data: {"candidates":[{"content":{"parts":[{"text":"done"}]},"finishReason":"STOP"}]}`+"\n\n")
+	})
+	stream, err := client.Stream(context.Background(), model.Request{Messages: []model.Message{{Role: "user", Content: "hi"}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := stream.Close(); err != nil {
+			t.Errorf("closing stream: %v", err)
+		}
+	}()
+	if chunk, ok, err := stream.Next(context.Background()); err != nil || !ok || chunk != "done" {
+		t.Fatalf("STOP chunk must deliver its text: %q %v %v", chunk, ok, err)
+	}
+	if _, ok, err := stream.Next(context.Background()); ok || err != nil {
+		t.Fatalf("stream after STOP must end cleanly: %v %v", ok, err)
+	}
+}
+
+// Config may carry Google's canonical "models/…" id form; the adapter adds the
+// prefix itself, so it must trim a canonical id rather than double it
+// (/models/models/… → 404).
+func TestGeminiAcceptsCanonicalModelsPrefixedIDs(t *testing.T) {
+	var paths []string
+	client := newGeminiForTest(t, func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		if strings.Contains(r.URL.Path, ":embedContent") {
+			_, _ = w.Write([]byte(`{"embedding":{"values":[0.1]}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"candidates":[{"content":{"parts":[{"text":"ok"}]}}]}`))
+	})
+	if _, err := client.Embed(context.Background(), model.EmbedRequest{Model: "models/gemini-embedding-001", Inputs: []string{"a"}}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.Complete(context.Background(), model.Request{Model: "models/gemini-x", Messages: []model.Message{{Role: "user", Content: "q"}}}); err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range paths {
+		if strings.Contains(p, "/models/models/") {
+			t.Fatalf("canonical id double-prefixed: %s", p)
+		}
+	}
+	if paths[0] != "/models/gemini-embedding-001:embedContent" {
+		t.Fatalf("embed path wrong: %s", paths[0])
+	}
+	if paths[1] != "/models/gemini-x:generateContent" {
+		t.Fatalf("generate path wrong: %s", paths[1])
 	}
 }

--- a/backend/internal/modules/ai/gemini_test.go
+++ b/backend/internal/modules/ai/gemini_test.go
@@ -33,7 +33,7 @@ func TestGeminiCompleteMapsNativeWireAndUsage(t *testing.T) {
 			t.Errorf("api key header %q", r.Header.Get("x-goog-api-key"))
 		}
 		body = readBody(t, r.Body)
-		_, _ = w.Write([]byte(`{"candidates":[{"content":{"role":"model","parts":[{"text":"answer"}]}}],
+		_, _ = w.Write([]byte(`{"candidates":[{"content":{"role":"model","parts":[{"text":"answer"}]},"finishReason":"STOP"}],
 			"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":5,"cachedContentTokenCount":6,"thoughtsTokenCount":4}}`))
 	})
 	resp, err := client.Complete(context.Background(), model.Request{
@@ -77,7 +77,7 @@ func TestGeminiStructuredOutputUsesResponseJSONSchema(t *testing.T) {
 	var body []byte
 	client := newGeminiForTest(t, func(w http.ResponseWriter, r *http.Request) {
 		body = readBody(t, r.Body)
-		_, _ = w.Write([]byte(`{"candidates":[{"content":{"parts":[{"text":"{}"}]}}]}`))
+		_, _ = w.Write([]byte(`{"candidates":[{"content":{"parts":[{"text":"{}"}]},"finishReason":"STOP"}]}`))
 	})
 	if _, err := client.Complete(context.Background(), model.Request{
 		Messages:       []model.Message{{Role: "user", Content: "hi"}},
@@ -106,7 +106,7 @@ func TestGeminiThinkingLevelFromProviderOptions(t *testing.T) {
 	var body []byte
 	client := newGeminiForTest(t, func(w http.ResponseWriter, r *http.Request) {
 		body = readBody(t, r.Body)
-		_, _ = w.Write([]byte(`{"candidates":[{"content":{"parts":[{"text":"ok"}]}}]}`))
+		_, _ = w.Write([]byte(`{"candidates":[{"content":{"parts":[{"text":"ok"}]},"finishReason":"STOP"}]}`))
 	})
 	if _, err := client.Complete(context.Background(), model.Request{
 		Messages:        []model.Message{{Role: "user", Content: "hi"}},
@@ -123,7 +123,7 @@ func TestGeminiMapsImageAndPDFAttachmentsToInlineData(t *testing.T) {
 	var body []byte
 	client := newGeminiForTest(t, func(w http.ResponseWriter, r *http.Request) {
 		body = readBody(t, r.Body)
-		_, _ = w.Write([]byte(`{"candidates":[{"content":{"parts":[{"text":"ok"}]}}]}`))
+		_, _ = w.Write([]byte(`{"candidates":[{"content":{"parts":[{"text":"ok"}]},"finishReason":"STOP"}]}`))
 	})
 	if _, err := client.Complete(context.Background(), model.Request{
 		Messages: []model.Message{{Role: "user", Content: "read these"}},
@@ -143,7 +143,7 @@ func TestGeminiStripsSecretsFromWire(t *testing.T) {
 	var body []byte
 	client := newGeminiForTest(t, func(w http.ResponseWriter, r *http.Request) {
 		body = readBody(t, r.Body)
-		_, _ = w.Write([]byte(`{"candidates":[{"content":{"parts":[{"text":"ok"}]}}]}`))
+		_, _ = w.Write([]byte(`{"candidates":[{"content":{"parts":[{"text":"ok"}]},"finishReason":"STOP"}]}`))
 	})
 	if _, err := client.Complete(context.Background(), model.Request{
 		Messages:       []model.Message{{Role: "user", Content: "with password=verysecretpw inside"}},
@@ -201,7 +201,7 @@ func TestGeminiStreamYieldsPartTextChunks(t *testing.T) {
 			t.Errorf("stream path/query wrong: %s?%s", r.URL.Path, r.URL.RawQuery)
 		}
 		_, _ = io.WriteString(w, `data: {"candidates":[{"content":{"parts":[{"text":"he"}]}}]}`+"\n\n")
-		_, _ = io.WriteString(w, `data: {"candidates":[{"content":{"parts":[{"text":"llo"}]}}]}`+"\n\n")
+		_, _ = io.WriteString(w, `data: {"candidates":[{"content":{"parts":[{"text":"llo"}]},"finishReason":"STOP"}]}`+"\n\n")
 	})
 	stream, err := client.Stream(context.Background(), model.Request{Messages: []model.Message{{Role: "user", Content: "hi"}}})
 	if err != nil {
@@ -246,7 +246,7 @@ func TestGeminiMapsAttachmentByURIToFileData(t *testing.T) {
 	var body []byte
 	client := newGeminiForTest(t, func(w http.ResponseWriter, r *http.Request) {
 		body = readBody(t, r.Body)
-		_, _ = w.Write([]byte(`{"candidates":[{"content":{"parts":[{"text":"ok"}]}}]}`))
+		_, _ = w.Write([]byte(`{"candidates":[{"content":{"parts":[{"text":"ok"}]},"finishReason":"STOP"}]}`))
 	})
 	if _, err := client.Complete(context.Background(), model.Request{
 		Messages:    []model.Message{{Role: "user", Content: "look"}},
@@ -265,7 +265,7 @@ func TestGeminiThoughtSignatureRoundTrips(t *testing.T) {
 	client := newGeminiForTest(t, func(w http.ResponseWriter, r *http.Request) {
 		reqBody = readBody(t, r.Body)
 		_, _ = w.Write([]byte(`{"candidates":[{"content":{"role":"model","parts":[
-			{"text":"answer","thoughtSignature":"SIG-abc"}]}}],
+			{"text":"answer","thoughtSignature":"SIG-abc"}]},"finishReason":"STOP"}],
 			"usageMetadata":{"promptTokenCount":3,"candidatesTokenCount":2}}`))
 	})
 	resp, err := client.Complete(context.Background(), model.Request{Messages: []model.Message{{Role: "user", Content: "q1"}}})
@@ -376,7 +376,7 @@ func TestGeminiAcceptsCanonicalModelsPrefixedIDs(t *testing.T) {
 			_, _ = w.Write([]byte(`{"embedding":{"values":[0.1]}}`))
 			return
 		}
-		_, _ = w.Write([]byte(`{"candidates":[{"content":{"parts":[{"text":"ok"}]}}]}`))
+		_, _ = w.Write([]byte(`{"candidates":[{"content":{"parts":[{"text":"ok"}]},"finishReason":"STOP"}]}`))
 	})
 	if _, err := client.Embed(context.Background(), model.EmbedRequest{Model: "models/gemini-embedding-001", Inputs: []string{"a"}}); err != nil {
 		t.Fatal(err)
@@ -394,5 +394,40 @@ func TestGeminiAcceptsCanonicalModelsPrefixedIDs(t *testing.T) {
 	}
 	if paths[1] != "/models/gemini-x:generateContent" {
 		t.Fatalf("generate path wrong: %s", paths[1])
+	}
+}
+
+// A non-stream response is terminal by definition — a candidate with no
+// finishReason is a truncated or foreign body, never a complete answer.
+func TestGeminiCompleteWithoutTerminalStopIsAnError(t *testing.T) {
+	client := newGeminiForTest(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"candidates":[{"content":{"parts":[{"text":"partial"}]}}]}`))
+	})
+	_, err := client.Complete(context.Background(), model.Request{Messages: []model.Message{{Role: "user", Content: "q"}}})
+	if err == nil || !strings.Contains(err.Error(), "STOP") {
+		t.Fatalf("missing finishReason must be an error, got %v", err)
+	}
+}
+
+// A stream that closes before the STOP terminal dropped mid-generation — EOF
+// alone must not read as a finished answer.
+func TestGeminiStreamEOFWithoutStopIsAnError(t *testing.T) {
+	client := newGeminiForTest(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `data: {"candidates":[{"content":{"parts":[{"text":"partial"}]}}]}`+"\n\n")
+	})
+	stream, err := client.Stream(context.Background(), model.Request{Messages: []model.Message{{Role: "user", Content: "hi"}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := stream.Close(); err != nil {
+			t.Errorf("closing stream: %v", err)
+		}
+	}()
+	if chunk, ok, err := stream.Next(context.Background()); err != nil || !ok || chunk != "partial" {
+		t.Fatalf("first chunk: %q %v %v", chunk, ok, err)
+	}
+	if _, _, err := stream.Next(context.Background()); err == nil || !strings.Contains(err.Error(), "STOP") {
+		t.Fatalf("EOF without STOP must be an error, got %v", err)
 	}
 }

--- a/backend/internal/modules/ai/ollama.go
+++ b/backend/internal/modules/ai/ollama.go
@@ -177,7 +177,10 @@ func (c *ollamaClient) post(ctx context.Context, path string, payload []byte) (i
 	if resp.StatusCode != http.StatusOK {
 		//craft:ignore swallowed-errors best-effort close on the error path — the API status error is the answer
 		defer func() { _ = resp.Body.Close() }()
-		raw, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		raw, readErr := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		if readErr != nil {
+			return nil, fmt.Errorf("ai: ollama: http %d", resp.StatusCode)
+		}
 		return nil, fmt.Errorf("ai: ollama: http %d: %s", resp.StatusCode, bytes.TrimSpace(raw))
 	}
 	return resp.Body, nil

--- a/backend/internal/modules/ai/ollama.go
+++ b/backend/internal/modules/ai/ollama.go
@@ -82,7 +82,7 @@ func (c *ollamaClient) Stream(ctx context.Context, req model.Request) (model.Tok
 	if err != nil {
 		return nil, err
 	}
-	return &ollamaStream{body: body, scanner: sseScanner(body)}, nil
+	return &ollamaStream{body: body, scanner: streamLineScanner(body)}, nil
 }
 
 func (c *ollamaClient) Embed(ctx context.Context, req model.EmbedRequest) (model.Embeddings, error) {

--- a/backend/internal/modules/ai/ollama.go
+++ b/backend/internal/modules/ai/ollama.go
@@ -82,7 +82,7 @@ func (c *ollamaClient) Stream(ctx context.Context, req model.Request) (model.Tok
 	if err != nil {
 		return nil, err
 	}
-	return &ollamaStream{body: body, scanner: bufio.NewScanner(body)}, nil
+	return &ollamaStream{body: body, scanner: sseScanner(body)}, nil
 }
 
 func (c *ollamaClient) Embed(ctx context.Context, req model.EmbedRequest) (model.Embeddings, error) {

--- a/backend/internal/modules/ai/openai.go
+++ b/backend/internal/modules/ai/openai.go
@@ -42,6 +42,11 @@ type openaiWire struct {
 	Text            *openaiText       `json:"text,omitempty"`
 	Reasoning       *openaiReasoning  `json:"reasoning,omitempty"`
 	Stream          bool              `json:"stream,omitempty"`
+	// Store is pinned false (no omitempty — the field must be on the wire):
+	// the Responses API defaults to store:true, which retains prompts — CRM
+	// record content — server-side for ~30 days. BYOK egress sends the
+	// request for inference only, never for vendor-side retention.
+	Store bool `json:"store"`
 }
 
 type openaiInputItem struct {
@@ -87,7 +92,19 @@ type openaiOptions struct {
 }
 
 type openaiResponse struct {
-	ID     string `json:"id"`
+	ID string `json:"id"`
+	// Status is the terminal response state: "completed" is the only success;
+	// "failed" carries Error, "incomplete" carries IncompleteDetails (e.g.
+	// max_output_tokens, content_filter). Anything else must surface as an
+	// error — a truncated or filtered answer must never read as a clean one.
+	Status string `json:"status"`
+	Error  struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	} `json:"error"`
+	IncompleteDetails struct {
+		Reason string `json:"reason"`
+	} `json:"incomplete_details"`
 	Output []struct {
 		Type    string `json:"type"`
 		Content []struct {
@@ -118,6 +135,9 @@ func (c *openaiClient) Complete(ctx context.Context, req model.Request) (model.R
 	var out openaiResponse
 	if err := json.NewDecoder(body).Decode(&out); err != nil {
 		return model.Response{}, fmt.Errorf("ai: openai: decode response: %w", err)
+	}
+	if err := openaiTerminalStatus(out); err != nil {
+		return model.Response{}, err
 	}
 	// Walk output[]: a type:"reasoning" item can precede the message, and a
 	// type:"refusal" part is a first-class outcome — never output[0].content[0].
@@ -156,7 +176,7 @@ func (c *openaiClient) Stream(ctx context.Context, req model.Request) (model.Tok
 	if err != nil {
 		return nil, err
 	}
-	return &openaiStream{body: body, scanner: bufio.NewScanner(body)}, nil
+	return &openaiStream{body: body, scanner: sseScanner(body)}, nil
 }
 
 func (c *openaiClient) Embed(ctx context.Context, req model.EmbedRequest) (model.Embeddings, error) {
@@ -321,8 +341,26 @@ func openaiError(resp *http.Response) error {
 	return fmt.Errorf("ai: openai: http %d", resp.StatusCode)
 }
 
+// openaiTerminalStatus maps a non-completed Responses object to an error: a
+// failed call carries the API's error, an incomplete one names why generation
+// stopped (max_output_tokens, content_filter). Either read as a clean answer
+// would silently hand the caller a truncated or filtered result.
+func openaiTerminalStatus(out openaiResponse) error {
+	switch out.Status {
+	case "", "completed":
+		return nil
+	case "failed":
+		return fmt.Errorf("ai: openai: response failed: %s: %s", out.Error.Code, out.Error.Message)
+	case "incomplete":
+		return fmt.Errorf("ai: openai: response incomplete: %s", out.IncompleteDetails.Reason)
+	default:
+		return fmt.Errorf("ai: openai: response ended with status %q", out.Status)
+	}
+}
+
 // openaiStream parses the Responses SSE stream, yielding text deltas from
-// response.output_text.delta events.
+// response.output_text.delta events. response.completed is the ONLY clean
+// terminal — failed/incomplete/error events surface as errors, never as EOF.
 type openaiStream struct {
 	body    io.ReadCloser
 	scanner *bufio.Scanner
@@ -339,8 +377,12 @@ func (s *openaiStream) Next(ctx context.Context) (string, bool, error) {
 			continue
 		}
 		var ev struct {
-			Type  string `json:"type"`
-			Delta string `json:"delta"`
+			Type     string         `json:"type"`
+			Delta    string         `json:"delta"`
+			Response openaiResponse `json:"response"`
+			// Code/Message are the top-level `error` event's shape.
+			Code    string `json:"code"`
+			Message string `json:"message"`
 		}
 		if err := json.Unmarshal([]byte(data), &ev); err != nil {
 			return "", false, fmt.Errorf("ai: openai: stream event: %w", err)
@@ -352,12 +394,22 @@ func (s *openaiStream) Next(ctx context.Context) (string, bool, error) {
 			}
 		case "response.completed":
 			return "", false, nil
+		case "response.failed", "response.incomplete":
+			if err := openaiTerminalStatus(ev.Response); err != nil {
+				return "", false, err
+			}
+			// The embedded response object omitted its status — the event
+			// type itself is still the authority that this is a failure.
+			return "", false, fmt.Errorf("ai: openai: stream ended with %s", ev.Type)
+		case "error":
+			return "", false, fmt.Errorf("ai: openai: stream error: %s: %s", ev.Code, ev.Message)
 		}
 	}
 	if err := s.scanner.Err(); err != nil {
 		return "", false, fmt.Errorf("ai: openai: stream: %w", err)
 	}
-	return "", false, nil
+	// EOF without response.completed: the connection dropped mid-generation.
+	return "", false, fmt.Errorf("ai: openai: stream ended without a terminal event")
 }
 
 func (s *openaiStream) Close() error { return s.body.Close() }

--- a/backend/internal/modules/ai/openai.go
+++ b/backend/internal/modules/ai/openai.go
@@ -176,7 +176,7 @@ func (c *openaiClient) Stream(ctx context.Context, req model.Request) (model.Tok
 	if err != nil {
 		return nil, err
 	}
-	return &openaiStream{body: body, scanner: sseScanner(body)}, nil
+	return &openaiStream{body: body, scanner: streamLineScanner(body)}, nil
 }
 
 func (c *openaiClient) Embed(ctx context.Context, req model.EmbedRequest) (model.Embeddings, error) {

--- a/backend/internal/modules/ai/openai.go
+++ b/backend/internal/modules/ai/openai.go
@@ -334,8 +334,8 @@ func openaiError(resp *http.Response) error {
 			Message string `json:"message"`
 		} `json:"error"`
 	}
-	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-	if json.Unmarshal(raw, &apiErr) == nil && apiErr.Error.Type != "" {
+	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if readErr == nil && json.Unmarshal(raw, &apiErr) == nil && apiErr.Error.Type != "" {
 		return fmt.Errorf("ai: openai: %s: %s (http %d)", apiErr.Error.Type, apiErr.Error.Message, resp.StatusCode)
 	}
 	return fmt.Errorf("ai: openai: http %d", resp.StatusCode)
@@ -343,16 +343,20 @@ func openaiError(resp *http.Response) error {
 
 // openaiTerminalStatus maps a non-completed Responses object to an error: a
 // failed call carries the API's error, an incomplete one names why generation
-// stopped (max_output_tokens, content_filter). Either read as a clean answer
-// would silently hand the caller a truncated or filtered result.
+// stopped (max_output_tokens, content_filter), and a missing status means the
+// body was not a terminal Responses object at all. Any of them read as a clean
+// answer would silently hand the caller a truncated or filtered result —
+// "completed" is the only success.
 func openaiTerminalStatus(out openaiResponse) error {
 	switch out.Status {
-	case "", "completed":
+	case "completed":
 		return nil
 	case "failed":
 		return fmt.Errorf("ai: openai: response failed: %s: %s", out.Error.Code, out.Error.Message)
 	case "incomplete":
 		return fmt.Errorf("ai: openai: response incomplete: %s", out.IncompleteDetails.Reason)
+	case "":
+		return fmt.Errorf("ai: openai: response carries no terminal status")
 	default:
 		return fmt.Errorf("ai: openai: response ended with status %q", out.Status)
 	}

--- a/backend/internal/modules/ai/openai_test.go
+++ b/backend/internal/modules/ai/openai_test.go
@@ -283,3 +283,130 @@ func TestOpenAIWireBaseDefaultsAreVersionless(t *testing.T) {
 		}
 	}
 }
+
+// The Responses API defaults to store:true — vendor-side retention of CRM
+// record content. The wire must pin store:false on every request.
+func TestOpenAIWirePinsStoreFalse(t *testing.T) {
+	var body []byte
+	client := newOpenAIForTest(t, func(w http.ResponseWriter, r *http.Request) {
+		body = readBody(t, r.Body)
+		_, _ = w.Write([]byte(`{"id":"r","status":"completed","output":[{"type":"message","content":[{"type":"output_text","text":"ok"}]}]}`))
+	})
+	if _, err := client.Complete(context.Background(), model.Request{Messages: []model.Message{{Role: "user", Content: "q"}}}); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(body, []byte(`"store":false`)) {
+		t.Fatalf("store:false missing from the wire — the vendor would retain the prompt: %s", body)
+	}
+}
+
+// A failed or incomplete terminal status must never read as a clean answer —
+// the caller would treat a content-filter abort or a max-token truncation as
+// the model's full reply.
+func TestOpenAICompleteNonCompletedStatusIsAnError(t *testing.T) {
+	cases := map[string]struct {
+		body string
+		want string
+	}{
+		"failed":     {`{"id":"r","status":"failed","error":{"code":"server_error","message":"boom"}}`, "server_error"},
+		"incomplete": {`{"id":"r","status":"incomplete","incomplete_details":{"reason":"max_output_tokens"}}`, "max_output_tokens"},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			client := newOpenAIForTest(t, func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte(tc.body))
+			})
+			_, err := client.Complete(context.Background(), model.Request{Messages: []model.Message{{Role: "user", Content: "q"}}})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("want error naming %q, got %v", tc.want, err)
+			}
+		})
+	}
+}
+
+// Mid-stream failure events must surface as errors, not fall through the event
+// switch into a clean-looking EOF.
+func TestOpenAIStreamSurfacesFailureEvents(t *testing.T) {
+	cases := map[string]struct {
+		event string
+		want  string
+	}{
+		"failed":     {`data: {"type":"response.failed","response":{"status":"failed","error":{"code":"server_error","message":"boom"}}}`, "server_error"},
+		"incomplete": {`data: {"type":"response.incomplete","response":{"status":"incomplete","incomplete_details":{"reason":"content_filter"}}}`, "content_filter"},
+		"error":      {`data: {"type":"error","code":"rate_limit_exceeded","message":"slow down"}`, "rate_limit_exceeded"},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			client := newOpenAIForTest(t, func(w http.ResponseWriter, r *http.Request) {
+				_, _ = io.WriteString(w, `data: {"type":"response.output_text.delta","delta":"partial"}`+"\n\n")
+				_, _ = io.WriteString(w, tc.event+"\n\n")
+			})
+			stream, err := client.Stream(context.Background(), model.Request{Messages: []model.Message{{Role: "user", Content: "hi"}}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() {
+				if err := stream.Close(); err != nil {
+					t.Errorf("closing stream: %v", err)
+				}
+			}()
+			if chunk, ok, err := stream.Next(context.Background()); err != nil || !ok || chunk != "partial" {
+				t.Fatalf("first delta: %q %v %v", chunk, ok, err)
+			}
+			_, _, err = stream.Next(context.Background())
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("want error naming %q, got %v", tc.want, err)
+			}
+		})
+	}
+}
+
+// A connection that drops before response.completed is a failed call: EOF
+// without a terminal event must not read as a finished answer.
+func TestOpenAIStreamEOFWithoutTerminalEventIsAnError(t *testing.T) {
+	client := newOpenAIForTest(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `data: {"type":"response.output_text.delta","delta":"partial"}`+"\n\n")
+	})
+	stream, err := client.Stream(context.Background(), model.Request{Messages: []model.Message{{Role: "user", Content: "hi"}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := stream.Close(); err != nil {
+			t.Errorf("closing stream: %v", err)
+		}
+	}()
+	if chunk, ok, err := stream.Next(context.Background()); err != nil || !ok || chunk != "partial" {
+		t.Fatalf("first delta: %q %v %v", chunk, ok, err)
+	}
+	if _, _, err := stream.Next(context.Background()); err == nil || !strings.Contains(err.Error(), "terminal") {
+		t.Fatalf("EOF without response.completed must be an error, got %v", err)
+	}
+}
+
+// One SSE data line can far exceed bufio.Scanner's 64KB default (a structured
+// output echoed as a single delta) — the shared scanner must deliver it, not
+// abort with ErrTooLong after the tokens were paid for.
+func TestOpenAIStreamCarriesOversizedSSELines(t *testing.T) {
+	big := strings.Repeat("x", 300*1024)
+	client := newOpenAIForTest(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `data: {"type":"response.output_text.delta","delta":"`+big+`"}`+"\n\n")
+		_, _ = io.WriteString(w, `data: {"type":"response.completed"}`+"\n\n")
+	})
+	stream, err := client.Stream(context.Background(), model.Request{Messages: []model.Message{{Role: "user", Content: "hi"}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := stream.Close(); err != nil {
+			t.Errorf("closing stream: %v", err)
+		}
+	}()
+	chunk, ok, err := stream.Next(context.Background())
+	if err != nil || !ok || len(chunk) != len(big) {
+		t.Fatalf("oversized delta not delivered: len=%d ok=%v err=%v", len(chunk), ok, err)
+	}
+	if _, ok, err := stream.Next(context.Background()); ok || err != nil {
+		t.Fatalf("expected clean completion after the big delta: %v %v", ok, err)
+	}
+}

--- a/backend/internal/modules/ai/openai_test.go
+++ b/backend/internal/modules/ai/openai_test.go
@@ -34,7 +34,7 @@ func TestOpenAICompleteMapsResponsesAPIUsageAndReasoning(t *testing.T) {
 		}
 		body = readBody(t, r.Body)
 		// Leading reasoning item BEFORE the message — the parser must walk output[].
-		_, _ = w.Write([]byte(`{"id":"resp_1","output":[
+		_, _ = w.Write([]byte(`{"id":"resp_1","status":"completed","output":[
 			{"type":"reasoning","summary":[]},
 			{"type":"message","role":"assistant","content":[{"type":"output_text","text":"hi"}]}],
 			"usage":{"input_tokens":10,"output_tokens":5,
@@ -68,7 +68,7 @@ func TestOpenAISendsStrictJSONSchemaUnderTextFormat(t *testing.T) {
 	var body []byte
 	client := newOpenAIForTest(t, func(w http.ResponseWriter, r *http.Request) {
 		body = readBody(t, r.Body)
-		_, _ = w.Write([]byte(`{"id":"r","output":[{"type":"message","content":[{"type":"output_text","text":"{}"}]}]}`))
+		_, _ = w.Write([]byte(`{"id":"r","status":"completed","output":[{"type":"message","content":[{"type":"output_text","text":"{}"}]}]}`))
 	})
 	if _, err := client.Complete(context.Background(), model.Request{
 		Messages:       []model.Message{{Role: "user", Content: "hi"}},
@@ -101,7 +101,7 @@ func TestOpenAIStripsSecretsFromWire(t *testing.T) {
 	var body []byte
 	client := newOpenAIForTest(t, func(w http.ResponseWriter, r *http.Request) {
 		body = readBody(t, r.Body)
-		_, _ = w.Write([]byte(`{"id":"r","output":[{"type":"message","content":[{"type":"output_text","text":"ok"}]}]}`))
+		_, _ = w.Write([]byte(`{"id":"r","status":"completed","output":[{"type":"message","content":[{"type":"output_text","text":"ok"}]}]}`))
 	})
 	if _, err := client.Complete(context.Background(), model.Request{
 		Messages:       []model.Message{{Role: "user", Content: "with password=verysecretpw inside"}},
@@ -118,7 +118,7 @@ func TestOpenAIMapsPDFAttachmentToInputFilePart(t *testing.T) {
 	var body []byte
 	client := newOpenAIForTest(t, func(w http.ResponseWriter, r *http.Request) {
 		body = readBody(t, r.Body)
-		_, _ = w.Write([]byte(`{"id":"r","output":[{"type":"message","content":[{"type":"output_text","text":"ok"}]}]}`))
+		_, _ = w.Write([]byte(`{"id":"r","status":"completed","output":[{"type":"message","content":[{"type":"output_text","text":"ok"}]}]}`))
 	})
 	if _, err := client.Complete(context.Background(), model.Request{
 		Messages:    []model.Message{{Role: "user", Content: "read this"}},
@@ -135,7 +135,7 @@ func TestOpenAIRoutesHTTPSPdfURIToFileURL(t *testing.T) {
 	var body []byte
 	client := newOpenAIForTest(t, func(w http.ResponseWriter, r *http.Request) {
 		body = readBody(t, r.Body)
-		_, _ = w.Write([]byte(`{"id":"r","output":[{"type":"message","content":[{"type":"output_text","text":"ok"}]}]}`))
+		_, _ = w.Write([]byte(`{"id":"r","status":"completed","output":[{"type":"message","content":[{"type":"output_text","text":"ok"}]}]}`))
 	})
 	if _, err := client.Complete(context.Background(), model.Request{
 		Messages:    []model.Message{{Role: "user", Content: "read"}},
@@ -150,7 +150,7 @@ func TestOpenAIRoutesHTTPSPdfURIToFileURL(t *testing.T) {
 
 func TestOpenAIMalformedProviderOptionsError(t *testing.T) {
 	client := newOpenAIForTest(t, func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(`{"id":"r","output":[]}`))
+		_, _ = w.Write([]byte(`{"id":"r","status":"completed","output":[]}`))
 	})
 	_, err := client.Complete(context.Background(), model.Request{
 		Messages:        []model.Message{{Role: "user", Content: "x"}},
@@ -163,7 +163,7 @@ func TestOpenAIMalformedProviderOptionsError(t *testing.T) {
 
 func TestOpenAIRefusalIsAnError(t *testing.T) {
 	client := newOpenAIForTest(t, func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(`{"id":"r","output":[{"type":"message","content":[{"type":"refusal","refusal":"cannot help"}]}]}`))
+		_, _ = w.Write([]byte(`{"id":"r","status":"completed","output":[{"type":"message","content":[{"type":"refusal","refusal":"cannot help"}]}]}`))
 	})
 	_, err := client.Complete(context.Background(), model.Request{Messages: []model.Message{{Role: "user", Content: "x"}}})
 	if err == nil || !strings.Contains(err.Error(), "refus") {
@@ -254,7 +254,7 @@ func TestOpenAIMapsAttachmentsByURIToFileIDAndImageURL(t *testing.T) {
 	var body []byte
 	client := newOpenAIForTest(t, func(w http.ResponseWriter, r *http.Request) {
 		body = readBody(t, r.Body)
-		_, _ = w.Write([]byte(`{"id":"r","output":[{"type":"message","content":[{"type":"output_text","text":"ok"}]}]}`))
+		_, _ = w.Write([]byte(`{"id":"r","status":"completed","output":[{"type":"message","content":[{"type":"output_text","text":"ok"}]}]}`))
 	})
 	if _, err := client.Complete(context.Background(), model.Request{
 		Messages: []model.Message{{Role: "user", Content: "look"}},
@@ -310,6 +310,7 @@ func TestOpenAICompleteNonCompletedStatusIsAnError(t *testing.T) {
 	}{
 		"failed":     {`{"id":"r","status":"failed","error":{"code":"server_error","message":"boom"}}`, "server_error"},
 		"incomplete": {`{"id":"r","status":"incomplete","incomplete_details":{"reason":"max_output_tokens"}}`, "max_output_tokens"},
+		"missing":    {`{"id":"r","output":[{"type":"message","content":[{"type":"output_text","text":"ok"}]}]}`, "no terminal status"},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/backend/internal/modules/ai/openaicompat.go
+++ b/backend/internal/modules/ai/openaicompat.go
@@ -99,7 +99,7 @@ func (c *openAICompatClient) Stream(ctx context.Context, req model.Request) (mod
 	if err != nil {
 		return nil, err
 	}
-	return &openAICompatStream{body: body, scanner: sseScanner(body)}, nil
+	return &openAICompatStream{body: body, scanner: streamLineScanner(body)}, nil
 }
 
 func (c *openAICompatClient) Embed(ctx context.Context, req model.EmbedRequest) (model.Embeddings, error) {

--- a/backend/internal/modules/ai/openaicompat.go
+++ b/backend/internal/modules/ai/openaicompat.go
@@ -99,10 +99,15 @@ func (c *openAICompatClient) Stream(ctx context.Context, req model.Request) (mod
 	if err != nil {
 		return nil, err
 	}
-	return &openAICompatStream{body: body, scanner: bufio.NewScanner(body)}, nil
+	return &openAICompatStream{body: body, scanner: sseScanner(body)}, nil
 }
 
 func (c *openAICompatClient) Embed(ctx context.Context, req model.EmbedRequest) (model.Embeddings, error) {
+	// `dimensions` is OpenAI's matryoshka-truncation knob; the generic wire
+	// gives no way to know whether the server honors it, and vLLM rejects it
+	// outright on models that aren't MRL-trained (a 400 on every embed call).
+	// Omit it — the store's width check catches a genuinely mismatched model.
+	req.Dimensions = 0
 	return openAIWireEmbed(ctx, c.post, c.defaultModel, req)
 }
 
@@ -201,20 +206,29 @@ func (c *openAICompatClient) post(ctx context.Context, path string, payload []by
 	return resp.Body, nil
 }
 
-// openAICompatError surfaces the vendor's structured error type/message only —
+// openAICompatError surfaces the vendor's structured error message only —
 // never the raw response body, which may be unstructured HTML/text — so a logged
 // failure can't echo the request or leak provider internals (the anthropic /
-// openai pattern). The read error on this already-failed path is not actionable.
+// openai pattern). Two structured shapes exist on this generic wire: OpenAI's
+// nested {"error":{type,message}} and vLLM's top-level {"object":"error",
+// type, message}. The read error on this already-failed path is not actionable.
 func openAICompatError(resp *http.Response) error {
 	var apiErr struct {
-		Error struct {
+		Type    string `json:"type"`
+		Message string `json:"message"`
+		Error   struct {
 			Type    string `json:"type"`
 			Message string `json:"message"`
 		} `json:"error"`
 	}
 	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-	if json.Unmarshal(raw, &apiErr) == nil && apiErr.Error.Message != "" {
-		return fmt.Errorf("ai: openai-compat: %s: %s (http %d)", apiErr.Error.Type, apiErr.Error.Message, resp.StatusCode)
+	if json.Unmarshal(raw, &apiErr) == nil {
+		if apiErr.Error.Message != "" {
+			return fmt.Errorf("ai: openai-compat: %s: %s (http %d)", apiErr.Error.Type, apiErr.Error.Message, resp.StatusCode)
+		}
+		if apiErr.Message != "" {
+			return fmt.Errorf("ai: openai-compat: %s: %s (http %d)", apiErr.Type, apiErr.Message, resp.StatusCode)
+		}
 	}
 	return fmt.Errorf("ai: openai-compat: http %d", resp.StatusCode)
 }

--- a/backend/internal/modules/ai/openaicompat.go
+++ b/backend/internal/modules/ai/openaicompat.go
@@ -211,7 +211,7 @@ func (c *openAICompatClient) post(ctx context.Context, path string, payload []by
 // failure can't echo the request or leak provider internals (the anthropic /
 // openai pattern). Two structured shapes exist on this generic wire: OpenAI's
 // nested {"error":{type,message}} and vLLM's top-level {"object":"error",
-// type, message}. The read error on this already-failed path is not actionable.
+// type, message}; a body that can't be read falls back to the HTTP status.
 func openAICompatError(resp *http.Response) error {
 	var apiErr struct {
 		Type    string `json:"type"`
@@ -221,8 +221,8 @@ func openAICompatError(resp *http.Response) error {
 			Message string `json:"message"`
 		} `json:"error"`
 	}
-	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-	if json.Unmarshal(raw, &apiErr) == nil {
+	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if readErr == nil && json.Unmarshal(raw, &apiErr) == nil {
 		if apiErr.Error.Message != "" {
 			return fmt.Errorf("ai: openai-compat: %s: %s (http %d)", apiErr.Error.Type, apiErr.Error.Message, resp.StatusCode)
 		}

--- a/backend/internal/modules/ai/openaicompat_test.go
+++ b/backend/internal/modules/ai/openaicompat_test.go
@@ -4,6 +4,7 @@
 package ai
 
 import (
+	"bytes"
 	"context"
 	"net/http"
 	"net/http/httptest"
@@ -73,4 +74,39 @@ func newJSONServer(t *testing.T, body string) string {
 	}))
 	t.Cleanup(srv.Close)
 	return srv.URL
+}
+
+// vLLM emits its error at the TOP level ({"object":"error",type,message}), not
+// under OpenAI's nested {"error":{…}} — the operator must still see the
+// message, not a bare "http 400".
+func TestOpenAICompatErrorDecodesVLLMTopLevelShape(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"object":"error","type":"BadRequestError","message":"dimensions is not supported"}`))
+	}))
+	defer srv.Close()
+	client := &openAICompatClient{http: &http.Client{}, baseURL: srv.URL, localOnly: true, defaultModel: "m"}
+	_, err := client.Complete(context.Background(), model.Request{Messages: []model.Message{{Role: "user", Content: "q"}}})
+	if err == nil || !strings.Contains(err.Error(), "dimensions is not supported") || !strings.Contains(err.Error(), "BadRequestError") {
+		t.Fatalf("want vLLM's top-level type+message, got %v", err)
+	}
+}
+
+// The generic wire gives no way to know whether the server honors OpenAI's
+// `dimensions` matryoshka knob, and vLLM 400s on models that aren't MRL-trained
+// — the adapter must not put it on the wire even when the caller pins a width.
+func TestOpenAICompatEmbedOmitsDimensions(t *testing.T) {
+	var body []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body = readBody(t, r.Body)
+		_, _ = w.Write([]byte(`{"data":[{"embedding":[0.1,0.2]}]}`))
+	}))
+	defer srv.Close()
+	client := &openAICompatClient{http: &http.Client{}, baseURL: srv.URL, localOnly: true, defaultModel: "bge-m3"}
+	if _, err := client.Embed(context.Background(), model.EmbedRequest{Inputs: []string{"a"}, Dimensions: 1024}); err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(body, []byte(`"dimensions"`)) {
+		t.Fatalf("dimensions must not reach an openai-compatible/vllm server: %s", body)
+	}
 }

--- a/backend/internal/modules/ai/outbound.go
+++ b/backend/internal/modules/ai/outbound.go
@@ -4,6 +4,7 @@
 package ai
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -11,6 +12,21 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/shared/ports/model"
 )
+
+// sseMaxLineBytes caps one SSE data line. bufio.Scanner's 64KB default is too
+// small for real provider events — a structured-output echo or a thought
+// signature can exceed it, and ErrTooLong after the tokens were already paid
+// for is the worst failure shape. 4MiB comfortably covers every provider's
+// per-event maximum while still bounding a misbehaving stream.
+const sseMaxLineBytes = 4 * 1024 * 1024
+
+// sseScanner is the one way every adapter wraps a streaming response body:
+// line-split with the raised cap above.
+func sseScanner(body io.Reader) *bufio.Scanner {
+	scanner := bufio.NewScanner(body)
+	scanner.Buffer(make([]byte, 0, 64*1024), sseMaxLineBytes)
+	return scanner
+}
 
 // Message-role vocabulary shared across adapters — one spelling each so an
 // adapter can't drift "assistant" vs "assistants". roleModel is Gemini's

--- a/backend/internal/modules/ai/outbound.go
+++ b/backend/internal/modules/ai/outbound.go
@@ -13,18 +13,19 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/ports/model"
 )
 
-// sseMaxLineBytes caps one SSE data line. bufio.Scanner's 64KB default is too
+// streamMaxLineBytes caps one stream line — an SSE data line or an NDJSON
+// object (ollama). bufio.Scanner's 64KB default is too
 // small for real provider events — a structured-output echo or a thought
 // signature can exceed it, and ErrTooLong after the tokens were already paid
 // for is the worst failure shape. 4MiB comfortably covers every provider's
 // per-event maximum while still bounding a misbehaving stream.
-const sseMaxLineBytes = 4 * 1024 * 1024
+const streamMaxLineBytes = 4 * 1024 * 1024
 
-// sseScanner is the one way every adapter wraps a streaming response body:
+// streamLineScanner is the one way every adapter wraps a streaming response body:
 // line-split with the raised cap above.
-func sseScanner(body io.Reader) *bufio.Scanner {
+func streamLineScanner(body io.Reader) *bufio.Scanner {
 	scanner := bufio.NewScanner(body)
-	scanner.Buffer(make([]byte, 0, 64*1024), sseMaxLineBytes)
+	scanner.Buffer(make([]byte, 0, 64*1024), streamMaxLineBytes)
 	return scanner
 }
 

--- a/backend/internal/modules/ai/router.go
+++ b/backend/internal/modules/ai/router.go
@@ -244,8 +244,9 @@ func embedTokenEstimate(inputs []string) int {
 	return total
 }
 
-// cacheKey covers EVERY completion-shaping input (system, messages, tools, max
-// tokens, attachments, and provider options) via a collision-resistant digest,
+// cacheKey covers EVERY completion-shaping input (model override, system,
+// messages, tools, max tokens, response schema, attachments, and provider
+// options) via a collision-resistant digest,
 // prefixed with the plaintext workspace id: a hash collision may spoil a cache
 // hit but can never cross a tenant boundary, because the workspace segment is
 // compared literally (and re-checked against the stored entry on read).
@@ -254,13 +255,15 @@ func embedTokenEstimate(inputs []string) int {
 // reasoning/thinking knob) collide, and the second is served the first's answer.
 func cacheKey(wsID ids.WorkspaceID, task Task, req model.Request) (string, error) {
 	material, err := json.Marshal(struct {
+		Model           string                     `json:"model"`
 		System          string                     `json:"system"`
 		Messages        []model.Message            `json:"messages"`
 		Tools           []model.ToolDef            `json:"tools"`
 		MaxTokens       int                        `json:"max_tokens"`
+		ResponseSchema  json.RawMessage            `json:"response_schema"`
 		Attachments     []model.Attachment         `json:"attachments"`
 		ProviderOptions map[string]json.RawMessage `json:"provider_options"`
-	}{req.System, req.Messages, req.Tools, req.MaxTokens, req.Attachments, req.ProviderOptions})
+	}{req.Model, req.System, req.Messages, req.Tools, req.MaxTokens, req.ResponseSchema, req.Attachments, req.ProviderOptions})
 	if err != nil {
 		// A ProviderOptions namespace carrying invalid JSON would otherwise
 		// marshal to nil and collapse every such request onto one cache key —

--- a/backend/internal/modules/ai/router_test.go
+++ b/backend/internal/modules/ai/router_test.go
@@ -294,3 +294,29 @@ func TestRouterRequiresWorkspaceContext(t *testing.T) {
 		t.Fatalf("workspace-less call must fail, got %v", err)
 	}
 }
+
+// Two calls differing only in the explicit model override or the response
+// schema shape different completions — serving one from the other's cache
+// entry hands the caller an answer shaped by the wrong schema/model.
+func TestRouterCacheKeyDistinguishesModelAndResponseSchema(t *testing.T) {
+	base := model.Request{Messages: []model.Message{{Role: "user", Content: "same prompt"}}}
+	withModel := base
+	withModel.Model = "other-model"
+	withSchema := base
+	withSchema.ResponseSchema = []byte(`{"type":"object"}`)
+
+	wsID := ids.New[ids.WorkspaceKind]()
+	baseKey, err := cacheKey(wsID, TaskSummarize, base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, req := range map[string]model.Request{"model override": withModel, "response schema": withSchema} {
+		key, err := cacheKey(wsID, TaskSummarize, req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if key == baseKey {
+			t.Fatalf("%s must change the cache key", name)
+		}
+	}
+}

--- a/backend/internal/shared/ports/model/model.go
+++ b/backend/internal/shared/ports/model/model.go
@@ -102,12 +102,18 @@ type ToolDef struct {
 }
 
 type Response struct {
-	Text         string
-	InputTokens  int
+	Text        string
+	InputTokens int
+	// OutputTokens is the TOTAL billed output, reasoning/thinking tokens
+	// INCLUDED — every adapter must normalize to this (Gemini reports them
+	// separately; its adapter adds them back), so tokens_in+tokens_out is
+	// true spend on every provider and the budget bands can't be leaked past
+	// by thinking-heavy calls.
 	OutputTokens int
 	// CachedTokens / ReasoningTokens are the itemized usage a native provider
-	// returns (prompt-cache reads, reasoning/thinking tokens). Flat, alongside
-	// InputTokens/OutputTokens; an adapter with no such figure leaves them 0.
+	// returns (prompt-cache reads, reasoning/thinking tokens). ReasoningTokens
+	// is a breakdown WITHIN OutputTokens, never additive to it; an adapter
+	// with no such figure leaves them 0.
 	CachedTokens    int
 	ReasoningTokens int
 	// ProviderMetadata carries vendor-only outputs namespaced by provider key

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -153,9 +153,31 @@ up)
   if [[ -f .env.local ]]; then
     set -a; . ./.env.local; set +a
   fi
-  if [[ -n "${ANTHROPIC_API_KEY:-}${OPENAI_API_KEY:-}${GEMINI_API_KEY:-}${OPENAI_COMPATIBLE_API_KEY:-}" ]]; then
+  # Real routing needs the key for EVERY cloud provider the routing file
+  # actually binds — SelectBrain fails closed at boot on the first bound
+  # provider whose env key is missing, so "any key present" is not enough
+  # (e.g. an anthropic-only .env.local against the gemini-bound template
+  # would refuse to start). Comments are stripped before scanning so the
+  # template's commented alternatives don't count as bindings.
+  bound_providers=$(sed 's/#.*//' "$routing_src" | grep -Eo 'provider:[[:space:]]*[a-z_]+' | awk -F': *' '{print $2}' | sort -u || true)
+  missing_keys=""
+  for _p in $bound_providers; do
+    _env=""
+    case "$_p" in
+      anthropic)         _env="ANTHROPIC_API_KEY" ;;
+      openai)            _env="OPENAI_API_KEY" ;;
+      gemini)            _env="GEMINI_API_KEY" ;;
+      openai_compatible) _env="OPENAI_COMPATIBLE_API_KEY" ;;
+    esac
+    if [[ -n "$_env" && -z "${!_env:-}" ]]; then
+      missing_keys="$missing_keys $_env"
+    fi
+  done
+  if [[ -n "${ANTHROPIC_API_KEY:-}${OPENAI_API_KEY:-}${GEMINI_API_KEY:-}${OPENAI_COMPATIBLE_API_KEY:-}" && -z "$missing_keys" ]]; then
     ai_flag=(--ai-routing "$routing_src")
     echo "dev: using a real cloud model for the cold-start read-back (BYOK key from .env.local env)"
+  elif [[ -n "$missing_keys" ]]; then
+    echo "dev: $routing_src binds provider(s) whose key is not set (${missing_keys# }) — cold-start runs on the offline fake; set the key(s) in .env.local or rebind the provider in $routing_src"
   else
     echo "dev: no cloud API key in .env.local (GEMINI_API_KEY/OPENAI_API_KEY/ANTHROPIC_API_KEY/OPENAI_COMPATIBLE_API_KEY) — cold-start runs on the offline fake"
   fi

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -173,13 +173,14 @@ up)
       missing_keys="$missing_keys $_env"
     fi
   done
-  if [[ -n "${ANTHROPIC_API_KEY:-}${OPENAI_API_KEY:-}${GEMINI_API_KEY:-}${OPENAI_COMPATIBLE_API_KEY:-}" && -z "$missing_keys" ]]; then
+  # Real routing whenever every bound provider is satisfied — cloud providers
+  # need their key; local ones (ollama/vllm/fake) need none, so a local-only
+  # routing file gets --ai-routing without any key in the environment.
+  if [[ -z "$missing_keys" ]]; then
     ai_flag=(--ai-routing "$routing_src")
-    echo "dev: using a real cloud model for the cold-start read-back (BYOK key from .env.local env)"
-  elif [[ -n "$missing_keys" ]]; then
-    echo "dev: $routing_src binds provider(s) whose key is not set (${missing_keys# }) — cold-start runs on the offline fake; set the key(s) in .env.local or rebind the provider in $routing_src"
+    echo "dev: using $routing_src for the cold-start read-back (bound providers: $(echo $bound_providers | tr '\n' ' '))"
   else
-    echo "dev: no cloud API key in .env.local (GEMINI_API_KEY/OPENAI_API_KEY/ANTHROPIC_API_KEY/OPENAI_COMPATIBLE_API_KEY) — cold-start runs on the offline fake"
+    echo "dev: $routing_src binds provider(s) whose key is not set (${missing_keys# }) — cold-start runs on the offline fake; set the key(s) in .env.local or rebind the provider in $routing_src"
   fi
 
   # Gmail capture connector: when .env.local supplies a Google OAuth app, pass


### PR DESCRIPTION
## Summary

Implements the top-10 correctness findings from the high-effort review of the merged cloud-provider work (#96). Full findings list lived in the session review doc; each item below is CONFIRMED-severity.

1. **openai stream failure events** — `response.failed`, `response.incomplete`, and `error` SSE events now surface as errors; previously they fell through the switch and a content-filter abort read as a clean completion. EOF without a terminal event is also an error now.
2. **gemini stream error chunks + finishReason** — mid-stream `{"error":…}` objects and abnormal `finishReason` (SAFETY, MAX_TOKENS, RECITATION, …) surface as errors instead of a normal EOF. Applied to `Complete` as well (fix the invariant, not the call site).
3. **cacheKey covers Model + ResponseSchema** — calls differing only in schema or explicit model override no longer collide onto one cache entry.
4. **reasoning-token metering semantic** — `model.Response.OutputTokens` is now documented as reasoning-INCLUSIVE; the gemini adapter adds `thoughtsTokenCount` back in (OpenAI/Anthropic already include it), so the §1.3 budget bands meter true spend.
5. **Responses API `store:false`** — pinned on every request (no omitempty); the API defaults to store:true, retaining CRM prompt content vendor-side ~30 days.
6. **embed `dimensions` capability-gated** — openai_compatible/vllm omit it (vLLM 400s on non-matryoshka models, regressing every embed call vs merge-base); native openai keeps it, gemini keeps `outputDimensionality`.
7. **dev.sh key/provider match** — `--ai-routing` is enabled only when every cloud provider actually bound in `config/ai-routing.yaml` has its env key; an anthropic-only `.env.local` against the gemini-bound template now falls back to `--ai-fake` with an actionable message instead of a fail-closed boot.
8. **shared SSE scanner (4MiB line cap)** — one `sseScanner` helper replaces the five bare `bufio.NewScanner` calls; the 64KB default line cap died with `ErrTooLong` on oversized deltas after tokens were paid for.
9. **gemini canonical model ids** — `models/…`-prefixed ids are trimmed before path/wire join (`/models/models/…` → 404), in Embed and generate.
10. **vLLM top-level error shape** — `{"object":"error",type,message}` is decoded as a fallback to the nested OpenAI shape, so operators see the message, not a bare `http 400`.

## Test plan

- New unit tests per finding: stream failure events (both adapters), clean-STOP non-error, EOF-without-terminal, oversized SSE line delivery, store:false on the wire, non-completed Complete statuses, cache-key model/schema divergence, dimensions omission, vLLM top-level error decode, canonical-id paths.
- `make check-backend` green; `craft static` PASS (0 findings) on push.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cloud AI error reporting for failed, incomplete, interrupted, or unsafe responses.
  * Fixed model identifier handling and token accounting across supported providers.
  * Prevented cache collisions when model or response format settings differ.
  * Improved compatibility with vLLM-style errors and embedding requests.

* **Reliability**
  * Large streaming responses up to 4 MiB are now handled correctly.
  * Cloud routing is enabled only when all required provider credentials are available.

* **Documentation**
  * Updated provider compatibility and embedding behavior guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->