### PR TITLE
feat(capture): sync hardening — a transient failure never kills a connection (ADR-0063)

### DIFF
--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -238,7 +238,7 @@ func startJobRunner(ctx context.Context, pool *pgxpool.Pool, logger *slog.Logger
 		gmailReg = compose.GmailPollRegistry(pool, vault, compose.GmailConfig{
 			ClientID:     cfg.gmailClientID,
 			ClientSecret: cfg.gmailClientSecret,
-		})
+		}).WithSyncInterval(cfg.gmailSyncInterval)
 	}
 	watchCfg := compose.GmailWatchConfig{
 		Interval:    cfg.gmailWatchInterval,
@@ -254,8 +254,8 @@ func startJobRunner(ctx context.Context, pool *pgxpool.Pool, logger *slog.Logger
 		ReconcileInterval: cfg.reconcileInterval,
 		TimeScanInterval:  cfg.timeScanInterval,
 		GmailRegistry:     gmailReg,
-		GmailInterval:     cfg.gmailSyncInterval,
-		GmailWatch:        watchCfg,
+
+		GmailWatch: watchCfg,
 		// The deep-read worker registers regardless: without a model path
 		// (nil ColdStart) it fails a picked-up read honestly rather than
 		// leaving it queued behind a job no one can work.

--- a/backend/internal/compose/integration/capture_syncstate_integration_test.go
+++ b/backend/internal/compose/integration/capture_syncstate_integration_test.go
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The ADR-0063 scheduling state machine over a real migrated Postgres: a
+// transient failure backs off but never kills the connection, a rate limit
+// honors Retry-After, persistent failure degrades to a daily probe that one
+// success heals, and an auth failure parks the row for its human — with the
+// error DETAIL landing in system_log and only the class on the sidecar row.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/connector"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/mcp"
+)
+
+// moodyConnector fails or succeeds on command — the provider weather dial.
+type moodyConnector struct {
+	name string
+	err  error
+}
+
+func (m *moodyConnector) Descriptor() connector.Descriptor {
+	return connector.Descriptor{
+		Name: m.name, Version: "1",
+		Scopes:   []principal.Scope{principal.ScopeRead},
+		RiskTier: mcp.TierGreen,
+		Produces: []datasource.EntityType{datasource.EntityActivity},
+	}
+}
+
+func (m *moodyConnector) Authenticate(context.Context, connector.AuthRequest) (connector.Auth, error) {
+	return connector.Auth("token"), nil
+}
+
+func (m *moodyConnector) Sync(_ context.Context, _ connector.Auth, cursor connector.Cursor, _ connector.Sink) (connector.Cursor, error) {
+	if m.err != nil {
+		return cursor, m.err
+	}
+	return connector.Cursor(`{"n":1}`), nil
+}
+
+func (m *moodyConnector) Normalize(context.Context, connector.RawRecord) ([]connector.NormalizedRecord, error) {
+	return nil, connector.ErrSkip
+}
+
+func (m *moodyConnector) HealthCheck(context.Context, connector.Auth) error { return nil }
+
+type syncStateRow struct {
+	next     time.Time
+	failures int
+	class    *string
+}
+
+func readSyncState(t *testing.T, e *searchEnv, connID ids.UUID) (string, syncStateRow) {
+	t.Helper()
+	var status string
+	var row syncStateRow
+	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		if err := tx.QueryRow(context.Background(),
+			`SELECT status FROM capture_connection WHERE id = $1`, connID).Scan(&status); err != nil {
+			return err
+		}
+		return tx.QueryRow(context.Background(), `
+			SELECT next_sync_at, consecutive_failures, last_error_class
+			FROM capture_sync_state WHERE connection_id = $1`, connID).
+			Scan(&row.next, &row.failures, &row.class)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return status, row
+}
+
+func TestSyncFailureNeverKillsAConnection(t *testing.T) {
+	e := setupSearch(t)
+	moody := &moodyConnector{name: "gmail"}
+	registry := newTestCaptureRegistry(e, newTestKeyvault(t, e))
+	registry.Register(moody)
+
+	grantCtx := e.humanWithScopes(e.Rep1, []principal.Scope{principal.ScopeRead})
+	connID, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh"))
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	wsCtx := principal.WithWorkspaceID(context.Background(), e.WS)
+
+	t.Run("rate limit honors Retry-After and stays connected", func(t *testing.T) {
+		moody.err = &connector.RateLimitedError{RetryAfter: 30 * time.Minute}
+		if err := registry.SyncOnce(wsCtx, connID); err == nil {
+			t.Fatal("SyncOnce must surface the sync error")
+		}
+		status, row := readSyncState(t, e, connID)
+		if status != "connected" {
+			t.Fatalf("status = %s, want connected — a rate limit is weather, not death", status)
+		}
+		if row.class == nil || *row.class != "rate_limited" {
+			t.Fatalf("class = %v, want rate_limited", row.class)
+		}
+		if until := time.Until(row.next); until < 25*time.Minute {
+			t.Fatalf("next_sync_at only %s out, want ≥ the provider's 30m Retry-After (minus slack)", until)
+		}
+	})
+
+	t.Run("transient failure backs off, success heals and paces", func(t *testing.T) {
+		moody.err = connector.ErrUnreachable
+		if err := registry.SyncOnce(wsCtx, connID); err == nil {
+			t.Fatal("SyncOnce must surface the sync error")
+		}
+		status, row := readSyncState(t, e, connID)
+		if status != "connected" || row.failures != 2 {
+			t.Fatalf("status=%s failures=%d, want connected/2", status, row.failures)
+		}
+
+		moody.err = nil
+		forceDue(t, e, connID)
+		if err := registry.SyncOnce(wsCtx, connID); err != nil {
+			t.Fatalf("healthy SyncOnce: %v", err)
+		}
+		status, row = readSyncState(t, e, connID)
+		if status != "connected" || row.failures != 0 || row.class != nil {
+			t.Fatalf("after success: status=%s failures=%d class=%v, want a clean slate", status, row.failures, row.class)
+		}
+		if !row.next.After(time.Now()) {
+			t.Fatal("a successful sync must pace the next one into the future")
+		}
+	})
+
+	t.Run("persistent failure degrades to a daily probe that heals", func(t *testing.T) {
+		// Fast-forward the ladder to the brink instead of failing 20 times.
+		err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+			_, err := tx.Exec(context.Background(),
+				`UPDATE capture_sync_state SET consecutive_failures = 19 WHERE connection_id = $1`, connID)
+			return err
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		moody.err = connector.ErrUnreachable
+		if err := registry.SyncOnce(wsCtx, connID); err == nil {
+			t.Fatal("SyncOnce must surface the sync error")
+		}
+		status, row := readSyncState(t, e, connID)
+		if status != "error" {
+			t.Fatalf("status = %s, want error after 20 consecutive failures", status)
+		}
+		if until := time.Until(row.next); until < 20*time.Hour {
+			t.Fatalf("degraded probe only %s out, want ~daily", until)
+		}
+
+		// Degraded is NOT dead: forced due, the error row is still swept…
+		forceDue(t, e, connID)
+		due, err := registry.DueConnections(context.Background(), "gmail")
+		if err != nil {
+			t.Fatalf("DueConnections: %v", err)
+		}
+		if len(due) != 1 || due[0].ID != connID {
+			t.Fatalf("DueConnections = %+v, want the degraded connection — error is probed, never tombstoned", due)
+		}
+		// …and one success flips it back to connected.
+		moody.err = nil
+		if err := registry.SyncOnce(wsCtx, connID); err != nil {
+			t.Fatalf("healing SyncOnce: %v", err)
+		}
+		if status, _ := readSyncState(t, e, connID); status != "connected" {
+			t.Fatalf("status = %s, want connected — one success heals", status)
+		}
+	})
+
+	t.Run("auth failure parks the connection for its human", func(t *testing.T) {
+		moody.err = connector.ErrAuthRejected
+		forceDue(t, e, connID)
+		if err := registry.SyncOnce(wsCtx, connID); err == nil {
+			t.Fatal("SyncOnce must surface the sync error")
+		}
+		status, row := readSyncState(t, e, connID)
+		if status != "reauth_required" {
+			t.Fatalf("status = %s, want reauth_required — auth needs the human, not a retry", status)
+		}
+		if row.class == nil || *row.class != "auth" {
+			t.Fatalf("class = %v, want auth", row.class)
+		}
+		forceDue(t, e, connID)
+		if due, _ := registry.DueConnections(context.Background(), "gmail"); len(due) != 0 {
+			t.Fatalf("DueConnections = %+v, want none — a parked connection is not swept", due)
+		}
+
+		// Reconnect (the OAuth callback path) un-parks it with a clean ladder.
+		if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("fresh")); err != nil {
+			t.Fatalf("reconnect: %v", err)
+		}
+		status, row = readSyncState(t, e, connID)
+		if status != "connected" || row.failures != 0 {
+			t.Fatalf("after reconnect: status=%s failures=%d, want connected/0", status, row.failures)
+		}
+	})
+
+	// The detail landed in the ledger; the row never carries it.
+	var ledger int
+	err = database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT count(*) FROM system_log WHERE action = 'capture_sync_error'`).Scan(&ledger)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ledger < 3 {
+		t.Fatalf("system_log capture_sync_error rows = %d, want one per recorded failure", ledger)
+	}
+}
+
+// forceDue moves the connection's pacing clock into the past.
+func forceDue(t *testing.T, e *searchEnv, connID ids.UUID) {
+	t.Helper()
+	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(context.Background(),
+			`UPDATE capture_sync_state SET next_sync_at = now() - interval '1 second' WHERE connection_id = $1`, connID)
+		return err
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/backend/internal/compose/integration/gmail_connector_integration_test.go
+++ b/backend/internal/compose/integration/gmail_connector_integration_test.go
@@ -154,12 +154,31 @@ func TestGmailConnectorSyncsAnActivity(t *testing.T) {
 		t.Fatalf("Connections = %+v, want one connected gmail", views)
 	}
 
+	// Pacing (ADR-0063): the sync that just succeeded scheduled the next one
+	// an interval out, so the connection is NOT due right now — a frequent
+	// dispatcher scan never means frequent provider calls.
 	due, err := registry.DueConnections(context.Background(), "gmail")
 	if err != nil {
 		t.Fatalf("DueConnections: %v", err)
 	}
+	if len(due) != 0 {
+		t.Fatalf("DueConnections right after a successful sync = %+v, want none (paced out)", due)
+	}
+	// Once the pacing clock passes, the same connection is due again.
+	err = database.WithWorkspaceTx(grantCtx, e.Pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(context.Background(),
+			`UPDATE capture_sync_state SET next_sync_at = now() - interval '1 second' WHERE connection_id = $1`, connID)
+		return err
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	due, err = registry.DueConnections(context.Background(), "gmail")
+	if err != nil {
+		t.Fatalf("DueConnections: %v", err)
+	}
 	if len(due) != 1 || due[0].ID != connID {
-		t.Fatalf("DueConnections = %+v, want the one connection %s", due, connID)
+		t.Fatalf("DueConnections past the pacing clock = %+v, want the one connection %s", due, connID)
 	}
 
 	if err := registry.Disconnect(grantCtx, "gmail"); err != nil {

--- a/backend/internal/compose/integration/gmail_watch_integration_test.go
+++ b/backend/internal/compose/integration/gmail_watch_integration_test.go
@@ -152,7 +152,6 @@ func TestGmailWatchJobRenewsOnSchedule(t *testing.T) {
 		ReconcileInterval: time.Hour,
 		TimeScanInterval:  time.Hour,
 		GmailRegistry:     registry,
-		GmailInterval:     time.Hour,
 		GmailWatch:        compose.GmailWatchConfig{Topic: gmailPushTopic, Interval: time.Hour, RenewWithin: 48 * time.Hour},
 	})
 	if err != nil {

--- a/backend/internal/compose/jobs.go
+++ b/backend/internal/compose/jobs.go
@@ -12,9 +12,11 @@ package compose
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/riverqueue/river"
 	"github.com/riverqueue/river/rivertype"
@@ -24,6 +26,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/capture"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
 	"github.com/gradionhq/margince/backend/internal/platform/jobs"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
@@ -60,6 +63,11 @@ func (w *followUpReconcileWorker) Work(ctx context.Context, _ *river.Job[FollowU
 	return w.reconciler.Reconcile(ctx)
 }
 
+// dispatchScanInterval is the due-scan cadence — an indexed one-row-per-due
+// query, deliberately decoupled from per-connection pacing (the sidecar's
+// next_sync_at owns that).
+const dispatchScanInterval = 30 * time.Second
+
 // GmailWatchConfig configures the Gmail push-watch maintenance pass. Topic is
 // the Pub/Sub topic Gmail publishes change notifications to (empty disables the
 // pass entirely — capture stays on the poll); Interval is the scan cadence; and
@@ -70,18 +78,19 @@ type GmailWatchConfig struct {
 	RenewWithin time.Duration
 }
 
-// GmailSyncArgs schedules one incremental-sync pass over every active Gmail
-// connection (capture.md CAP-WIRE-N-1: capture rides provider delta, driven
-// here by a poll rather than a push watch in this slice).
+// GmailSyncArgs schedules one DISPATCH pass: scan the fleet for due Gmail
+// connections (the sidecar's backoff/pacing gate, ADR-0063) and enqueue one
+// CaptureSyncArgs job per connection. The dispatcher never syncs inline —
+// per-connection jobs isolate failures and kill head-of-line blocking.
 type GmailSyncArgs struct{}
 
 // Kind is the stable job identifier River persists in river_job.
 func (GmailSyncArgs) Kind() string { return "gmail_sync" }
 
-// gmailSyncWorker walks the fleet's active Gmail connections and runs one
-// incremental SyncOnce per connection under that connection's workspace. A
-// single connection's failure is logged and skipped, never aborting the pass;
-// only a fleet-enumeration failure is returned (so River retries the tick).
+// gmailSyncWorker is the dispatcher: due-scan, then one insert per
+// connection. Uniqueness on the connection id means a still-running or
+// already-queued sync is not double-enqueued; only a fleet-enumeration
+// failure is returned (so River retries the tick).
 type gmailSyncWorker struct {
 	river.WorkerDefaults[GmailSyncArgs]
 	registry *capture.Registry
@@ -90,13 +99,57 @@ type gmailSyncWorker struct {
 
 func (w *gmailSyncWorker) Work(ctx context.Context, _ *river.Job[GmailSyncArgs]) error {
 	due, enumErr := w.registry.DueConnections(ctx, "gmail")
+	client := river.ClientFromContext[pgx.Tx](ctx)
 	for _, d := range due {
-		wsCtx := principal.WithWorkspaceID(ctx, d.Workspace.UUID)
-		if err := w.registry.SyncOnce(wsCtx, d.ID); err != nil {
-			w.log.WarnContext(ctx, "gmail connection sync failed", "connection", d.ID.String(), "err", err)
+		if _, err := client.Insert(ctx, CaptureSyncArgs{
+			Workspace:    d.Workspace.String(),
+			ConnectionID: d.ID.String(),
+			Provider:     "gmail",
+		}, &river.InsertOpts{
+			UniqueOpts: river.UniqueOpts{ByArgs: true, ByState: activeSweepStates},
+		}); err != nil {
+			w.log.WarnContext(ctx, "capture sync enqueue failed", "connection", d.ID.String(), "err", err)
 		}
 	}
 	return enumErr
+}
+
+// CaptureSyncArgs syncs ONE connection. Unique by args while incomplete, so
+// the dispatcher and the (future) push webhook can both enqueue without
+// double-running a mailbox.
+type CaptureSyncArgs struct {
+	Workspace    string `json:"workspace"`
+	ConnectionID string `json:"connection_id"`
+	Provider     string `json:"provider"`
+}
+
+// Kind is the stable job identifier River persists in river_job.
+func (CaptureSyncArgs) Kind() string { return "capture_sync" }
+
+// captureSyncWorker runs one SyncOnce under the connection's workspace. A
+// sync failure returns nil after the registry has recorded it: the sidecar's
+// backoff owns the retry cadence (ADR-0063) — a River retry would bypass it.
+type captureSyncWorker struct {
+	river.WorkerDefaults[CaptureSyncArgs]
+	registry *capture.Registry
+	log      *slog.Logger
+}
+
+func (w *captureSyncWorker) Work(ctx context.Context, job *river.Job[CaptureSyncArgs]) error {
+	ws, err := ids.Parse(job.Args.Workspace)
+	if err != nil {
+		return fmt.Errorf("capture_sync: workspace id: %w", err)
+	}
+	conn, err := ids.Parse(job.Args.ConnectionID)
+	if err != nil {
+		return fmt.Errorf("capture_sync: connection id: %w", err)
+	}
+	wsCtx := principal.WithWorkspaceID(ctx, ws)
+	if err := w.registry.SyncOnce(wsCtx, conn); err != nil {
+		w.log.WarnContext(ctx, "capture connection sync failed",
+			"connection", job.Args.ConnectionID, "provider", job.Args.Provider, "err", err)
+	}
+	return nil
 }
 
 // TimeScanArgs schedules one clock-trigger scan pass (Task 14a): the
@@ -186,7 +239,6 @@ type JobRunnerConfig struct {
 	ReconcileInterval time.Duration
 	TimeScanInterval  time.Duration
 	GmailRegistry     *capture.Registry
-	GmailInterval     time.Duration
 	GmailWatch        GmailWatchConfig
 	// DeepReadBrain is the model lane the site deep-read job extracts with
 	// (the worker's modelPath.ColdStart — the same lane the api's quick
@@ -203,8 +255,11 @@ type JobRunnerConfig struct {
 // the old ticker's boot-time first pass.
 //
 // When cfg.GmailRegistry is non-nil (the deployment configured the Gmail
-// OAuth app), a Gmail incremental-sync poll is added on cfg.GmailInterval —
-// leader-elected like the sweeps, so replicas never double-poll. When a
+// OAuth app), the sync DISPATCHER is added on a fixed 30s scan — a cheap
+// indexed due-scan enqueueing one per-connection job per due row; the
+// per-connection pacing (--gmail-sync-interval) lives in the registry's
+// scheduling sidecar, so a frequent scan never means frequent provider
+// calls. Leader-elected like the sweeps, so replicas never double-poll. When a
 // Pub/Sub topic is also configured (cfg.GmailWatch.Topic != ""), a push-watch
 // maintenance pass is added on cfg.GmailWatch.Interval that registers/renews
 // Gmail watches nearing expiry; without a topic the watch job is absent by
@@ -238,8 +293,12 @@ func NewJobRunner(pool *pgxpool.Pool, log *slog.Logger, cfg JobRunnerConfig) (*j
 
 	if cfg.GmailRegistry != nil {
 		river.AddWorker(workers, &gmailSyncWorker{registry: cfg.GmailRegistry, log: log})
+		river.AddWorker(workers, &captureSyncWorker{registry: cfg.GmailRegistry, log: log})
+		// The dispatcher tick is a cheap indexed due-scan; per-connection
+		// pacing lives in the sidecar (next_sync_at = success + interval),
+		// so a frequent scan does not mean frequent provider calls.
 		periodic = append(periodic, river.NewPeriodicJob(
-			river.PeriodicInterval(cfg.GmailInterval),
+			river.PeriodicInterval(dispatchScanInterval),
 			func() (river.JobArgs, *river.InsertOpts) { return GmailSyncArgs{}, sweepInsertOpts() },
 			&river.PeriodicJobOpts{RunOnStart: true},
 		))

--- a/backend/internal/modules/capture/gmail/client.go
+++ b/backend/internal/modules/capture/gmail/client.go
@@ -15,7 +15,6 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -23,6 +22,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/gradionhq/margince/backend/internal/shared/ports/connector"
 )
 
 // httpTimeout bounds every Google call so a stalled OAuth/Gmail request can't
@@ -41,18 +42,22 @@ const (
 	paramClientID = "client_id"
 )
 
+// The package sentinels wrap the shared connector vocabulary (ADR-0063) so
+// the registry classifies failures without knowing this provider: auth parks
+// the connection, a rate limit honors Retry-After, unreachable backs off.
+
 // ErrAuthRejected marks an OAuth failure Google reported (bad/expired code,
 // revoked refresh). The transport maps it to a 422 without echoing the raw
 // provider error.
-var ErrAuthRejected = errors.New("gmail: the authorization was rejected")
+var ErrAuthRejected = fmt.Errorf("gmail: the authorization was rejected: %w", connector.ErrAuthRejected)
 
 // ErrUnreachable marks a transport-level failure reaching Google (DNS, TCP,
 // TLS, timeout, 5xx). The transport maps it to a 502.
-var ErrUnreachable = errors.New("gmail: could not reach Google")
+var ErrUnreachable = fmt.Errorf("gmail: could not reach Google: %w", connector.ErrUnreachable)
 
 // ErrHistoryGone marks a startHistoryId Gmail no longer has (it expires
 // after ~a week); Sync falls back to a bounded re-list rather than failing.
-var ErrHistoryGone = errors.New("gmail: history cursor too old")
+var ErrHistoryGone = fmt.Errorf("gmail: history cursor too old: %w", connector.ErrCursorGone)
 
 // OAuth is the OAuth2 handshake surface: build the consent URL, exchange the
 // authorization code for a refresh token, and mint a fresh access token from
@@ -358,7 +363,20 @@ func (a *httpAPI) Watch(ctx context.Context, accessToken, topic string) (string,
 // ErrAuthRejected and any other non-2xx/transport failure to ErrUnreachable.
 // Google's raw body is never surfaced to the caller.
 //
+// retryAfter parses the provider's Retry-After (delta-seconds form; Google
+// does not send HTTP-dates here). Zero when absent — the caller's own backoff
+// takes over.
+//
 //craft:ignore naked-any out is the caller-supplied JSON decode target — its concrete type varies per endpoint
+func retryAfter(resp *http.Response) time.Duration {
+	if s := resp.Header.Get("Retry-After"); s != "" {
+		if secs, err := strconv.Atoi(s); err == nil && secs > 0 {
+			return time.Duration(secs) * time.Second
+		}
+	}
+	return 0
+}
+
 func (a *httpAPI) get(ctx context.Context, accessToken, path string, q url.Values, out any) (int, error) {
 	u := a.base + path
 	if len(q) > 0 {
@@ -376,6 +394,14 @@ func (a *httpAPI) get(ctx context.Context, accessToken, path string, q url.Value
 	//craft:ignore swallowed-errors best-effort close of the response body — the decoded result/status is what matters
 	defer func() { _ = resp.Body.Close() }()
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 8<<20))
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return resp.StatusCode, &connector.RateLimitedError{RetryAfter: retryAfter(resp)}
+	}
+	if resp.StatusCode == http.StatusForbidden && bytes.Contains(body, []byte("ateLimitExceeded")) {
+		// Google reports per-user quota as 403 with reason rateLimitExceeded /
+		// userRateLimitExceeded — a pacing problem, not an authorization one.
+		return resp.StatusCode, &connector.RateLimitedError{RetryAfter: retryAfter(resp)}
+	}
 	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
 		return resp.StatusCode, ErrAuthRejected
 	}

--- a/backend/internal/modules/capture/gmail/errors_test.go
+++ b/backend/internal/modules/capture/gmail/errors_test.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package gmail
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/ports/connector"
+)
+
+// The registry schedules by the shared vocabulary; a package sentinel that
+// stops answering it silently turns a parkable auth failure into a
+// backoff-retried one (or worse).
+func TestPackageSentinelsSpeakTheSharedVocabulary(t *testing.T) {
+	if !errors.Is(ErrAuthRejected, connector.ErrAuthRejected) {
+		t.Fatal("ErrAuthRejected must wrap connector.ErrAuthRejected")
+	}
+	if !errors.Is(ErrUnreachable, connector.ErrUnreachable) {
+		t.Fatal("ErrUnreachable must wrap connector.ErrUnreachable")
+	}
+	if !errors.Is(ErrHistoryGone, connector.ErrCursorGone) {
+		t.Fatal("ErrHistoryGone must wrap connector.ErrCursorGone")
+	}
+}

--- a/backend/internal/modules/capture/imap/errors_test.go
+++ b/backend/internal/modules/capture/imap/errors_test.go
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package imap
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/ports/connector"
+)
+
+// The registry schedules by the shared vocabulary; a package sentinel that
+// stops answering it silently turns a parkable auth failure into a
+// backoff-retried one (or worse).
+func TestPackageSentinelsSpeakTheSharedVocabulary(t *testing.T) {
+	if !errors.Is(ErrLoginRejected, connector.ErrAuthRejected) {
+		t.Fatal("ErrLoginRejected must wrap connector.ErrAuthRejected")
+	}
+	if !errors.Is(ErrUnreachable, connector.ErrUnreachable) {
+		t.Fatal("ErrUnreachable must wrap connector.ErrUnreachable")
+	}
+}

--- a/backend/internal/modules/capture/imap/imap.go
+++ b/backend/internal/modules/capture/imap/imap.go
@@ -130,13 +130,14 @@ func AuthRequestFrom(creds Credentials) (connector.AuthRequest, error) {
 
 // ErrLoginRejected marks an authentication failure the server reported
 // (bad user/password/host). The transport maps it to an actionable 422
-// without echoing the provider's raw message.
-var ErrLoginRejected = errors.New("imap: the mailbox rejected these credentials")
+// without echoing the provider's raw message. Wraps the shared connector
+// vocabulary so the registry parks, not retries (ADR-0063).
+var ErrLoginRejected = fmt.Errorf("imap: the mailbox rejected these credentials: %w", connector.ErrAuthRejected)
 
 // ErrUnreachable marks a transport-level failure reaching the server
 // (DNS, TCP, TLS, timeout). The transport maps it to a 502 without
-// leaking the underlying network detail.
-var ErrUnreachable = errors.New("imap: could not reach the mail server")
+// leaking the underlying network detail; the registry backs off and retries.
+var ErrUnreachable = fmt.Errorf("imap: could not reach the mail server: %w", connector.ErrUnreachable)
 
 func (c *Connector) Descriptor() connector.Descriptor {
 	return connector.Descriptor{

--- a/backend/internal/modules/capture/registry.go
+++ b/backend/internal/modules/capture/registry.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"sort"
 	"sync"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -42,7 +43,17 @@ type Registry struct {
 	// whose credential lives in the vault — a not-yet-backfilled legacy row
 	// still resolves from its auth column with no vault.
 	vault keyvault.Vault
+
+	// The scheduling state machine's knobs (ADR-0063): now is injected so
+	// the backoff/pacing arithmetic is testable; syncInterval paces a
+	// healthy connection (next_sync_at = success + interval).
+	now          func() time.Time
+	syncInterval time.Duration
 }
+
+// defaultSyncInterval paces a healthy connection between syncs; the push
+// webhook (when live) makes this the safety net, not the latency floor.
+const defaultSyncInterval = 2 * time.Minute
 
 // NewRegistry builds the connector registry over the pool, the capture Sink,
 // the live-authority resolver, and the keyvault that seals/resolves each
@@ -50,12 +61,23 @@ type Registry struct {
 // transient one-shot pull (which persists no credential).
 func NewRegistry(pool *pgxpool.Pool, sink *Sink, authority authz.Resolver, vault keyvault.Vault) *Registry {
 	return &Registry{
-		connectors: map[string]connector.Connector{},
-		pool:       pool,
-		sink:       sink,
-		authority:  authority,
-		vault:      vault,
+		connectors:   map[string]connector.Connector{},
+		pool:         pool,
+		sink:         sink,
+		authority:    authority,
+		vault:        vault,
+		now:          time.Now,
+		syncInterval: defaultSyncInterval,
 	}
+}
+
+// WithSyncInterval overrides the healthy-connection pacing (the worker's
+// --gmail-sync-interval flag lands here).
+func (r *Registry) WithSyncInterval(d time.Duration) *Registry {
+	if d > 0 {
+		r.syncInterval = d
+	}
+	return r
 }
 
 // Register adds one connector at composition time.
@@ -91,9 +113,9 @@ func (r *Registry) Connectors() []connector.Descriptor {
 // the granting human does not hold is refused at grant time, not
 // discovered at 3am mid-sync.
 //
-// note: the returned id (and the connectionID threaded through SyncOnce /
-// markError) names a capture_connection row, which the kernel does not
-// model as a first-class entity — no kind exists for it, so it stays
+// note: the returned id (and the connectionID threaded through SyncOnce and
+// the sync-state recording) names a capture_connection row, which the kernel
+// does not model as a first-class entity — no kind exists for it, so it stays
 // ids.UUID rather than inventing one.
 func (r *Registry) Connect(ctx context.Context, name string, auth connector.Auth) (ids.UUID, error) {
 	c, err := r.connector(name)
@@ -132,13 +154,23 @@ func (r *Registry) Connect(ctx context.Context, name string, auth connector.Auth
 	}
 	var id ids.UUID
 	err = database.WithWorkspaceTx(ctx, r.pool, func(tx pgx.Tx) error {
-		return tx.QueryRow(ctx, `
+		if err := tx.QueryRow(ctx, `
 			INSERT INTO capture_connection (workspace_id, provider, user_id, scopes, credential_ref, status)
 			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3, $4, 'connected')
 			ON CONFLICT (workspace_id, user_id, provider)
 			DO UPDATE SET credential_ref = EXCLUDED.credential_ref, auth = NULL, status = 'connected', archived_at = NULL
 			RETURNING id`,
-			name, actor.UserID, scopes, string(ref)).Scan(&id)
+			name, actor.UserID, scopes, string(ref)).Scan(&id); err != nil {
+			return err
+		}
+		// A (re)connect starts the scheduling ladder clean: a row parked by
+		// reauth_required or degraded by backoff is due immediately with a
+		// fresh credential (ADR-0063).
+		_, err = tx.Exec(ctx, `
+			UPDATE capture_sync_state
+			SET next_sync_at = now(), consecutive_failures = 0, last_error_class = NULL
+			WHERE connection_id = $1`, id)
+		return err
 	})
 	if err != nil {
 		return ids.Nil, fmt.Errorf("capture: storing connection: %w", err)
@@ -188,9 +220,13 @@ func (r *Registry) SyncOnce(ctx context.Context, connectionID ids.UUID) error {
 		cursor        []byte
 	)
 	err := database.WithWorkspaceTx(ctx, r.pool, func(tx pgx.Tx) error {
+		// 'error' is syncable by design (ADR-0063): the daily probe of a
+		// degraded connection runs through this same path, and its success
+		// is what flips the row back to connected. Only 'disconnected' and
+		// 'reauth_required' park a connection.
 		return tx.QueryRow(ctx, `
 			SELECT provider, user_id, credential_ref, auth, sync_cursor FROM capture_connection
-			WHERE id = $1 AND status = 'connected'`, connectionID).
+			WHERE id = $1 AND status IN ('connected','error')`, connectionID).
 			Scan(&name, &grantedBy, &credentialRef, &authBytes, &cursor)
 	})
 	if errors.Is(err, pgx.ErrNoRows) {
@@ -203,23 +239,32 @@ func (r *Registry) SyncOnce(ctx context.Context, connectionID ids.UUID) error {
 	if err != nil {
 		return err
 	}
-	auth, err := r.resolveCredential(ctx, credentialRef, authBytes)
-	if err != nil {
-		return err
-	}
-
+	// The connector principal is built before credential resolution so every
+	// failure past this point records into the scheduling state under an
+	// actor-bearing context (the sidecar's system_log line needs one).
 	runCtx, err := r.connectorContext(ctx, name, grantedBy)
 	if err != nil {
 		return err
 	}
+	auth, err := r.resolveCredential(ctx, credentialRef, authBytes)
+	if err != nil {
+		if recErr := r.recordSyncFailure(runCtx, connectionID, err); recErr != nil {
+			return errors.Join(err, recErr)
+		}
+		return err
+	}
+
 	next, syncErr := c.Sync(runCtx, auth, connector.Cursor(cursor), r.sink)
 	if syncErr != nil {
-		if markErr := r.markError(ctx, connectionID); markErr != nil {
-			return errors.Join(syncErr, markErr)
+		// A transient failure never kills the connection (ADR-0063): the
+		// state machine classifies, backs off, degrades to a daily probe at
+		// worst — and auth parks the row for its human.
+		if recErr := r.recordSyncFailure(runCtx, connectionID, syncErr); recErr != nil {
+			return errors.Join(syncErr, recErr)
 		}
 		return syncErr
 	}
-	return database.WithWorkspaceTx(ctx, r.pool, func(tx pgx.Tx) error {
+	err = database.WithWorkspaceTx(ctx, r.pool, func(tx pgx.Tx) error {
 		// sync_cursor is jsonb; the connector's watermark is already JSON. A
 		// connector that yields no cursor writes NULL, never an empty jsonb.
 		var cur []byte
@@ -231,6 +276,10 @@ func (r *Registry) SyncOnce(ctx context.Context, connectionID ids.UUID) error {
 			WHERE id = $1`, connectionID, cur)
 		return err
 	})
+	if err != nil {
+		return err
+	}
+	return r.recordSyncSuccess(ctx, connectionID)
 }
 
 // resolveCredential turns a stored connection's credential into the opaque
@@ -384,23 +433,6 @@ func (r *Registry) connectorContext(ctx context.Context, name string, grantedBy 
 	}
 	runCtx := principal.WithActor(ctx, p)
 	return principal.WithCorrelationID(runCtx, ids.NewV7()), nil
-}
-
-// markError flips a connection to the 'error' status so the poller stops
-// selecting it (DueConnections filters on 'connected'). The failing sync's
-// error is returned to the caller by SyncOnce; capture_connection no longer
-// keeps a diagnostic column (CAP-DDL-2), so operational detail rides the
-// system_log ledger, not this row. The guard keeps a sync failure that races a
-// concurrent Disconnect from resurrecting the user's 'disconnected' choice into
-// 'error' — only a still-connected, live row transitions.
-func (r *Registry) markError(ctx context.Context, connectionID ids.UUID) error {
-	return database.WithWorkspaceTx(ctx, r.pool, func(tx pgx.Tx) error {
-		_, err := tx.Exec(ctx, `
-			UPDATE capture_connection SET status = 'error'
-			WHERE id = $1 AND status = 'connected' AND archived_at IS NULL`,
-			connectionID)
-		return err
-	})
 }
 
 func (r *Registry) connector(name string) (connector.Connector, error) {

--- a/backend/internal/modules/capture/registry_connections.go
+++ b/backend/internal/modules/capture/registry_connections.go
@@ -95,15 +95,22 @@ type DueConnection struct {
 	ID        ids.UUID
 }
 
-// DueConnections lists every connected connection for provider name across the
-// whole fleet, so the background poller can drive one SyncOnce per
-// connection. capture_connection is RLS-scoped, so this walks each
-// workspace under its own GUC. One workspace's failure does not starve the rest.
+// DueConnections lists every DUE connection for provider name across the
+// whole fleet, so the background dispatcher can enqueue one sync per
+// connection. Due means: live, in a syncable status, and past its
+// next_sync_at (ADR-0063 — the sidecar's backoff/pacing gate; a connection
+// with no sidecar row yet is due immediately). Status 'error' stays in the
+// scan — degraded connections are probed on their daily cadence, never
+// tombstoned; only 'disconnected' and 'reauth_required' park a row.
+// capture_connection is RLS-scoped, so this walks each workspace under its
+// own GUC. One workspace's failure does not starve the rest.
 func (r *Registry) DueConnections(ctx context.Context, name string) ([]DueConnection, error) {
 	return r.collectDue(ctx, func(ctx context.Context, tx pgx.Tx) ([]ids.UUID, error) {
 		rows, err := tx.Query(ctx, `
-			SELECT id FROM capture_connection
-			WHERE provider = $1 AND status = 'connected' AND archived_at IS NULL`, name)
+			SELECT c.id FROM capture_connection c
+			LEFT JOIN capture_sync_state s ON s.connection_id = c.id
+			WHERE c.provider = $1 AND c.status IN ('connected','error') AND c.archived_at IS NULL
+			  AND COALESCE(s.next_sync_at, now()) <= now()`, name)
 		if err != nil {
 			return nil, err
 		}

--- a/backend/internal/modules/capture/syncstate.go
+++ b/backend/internal/modules/capture/syncstate.go
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// The per-connection scheduling state machine (ADR-0063, CAP-DDL-5): a
+// transient failure never kills a connection. Rate limits honor Retry-After,
+// other transient errors back off exponentially, persistent failure degrades
+// the connection to a daily probe — and one success heals everything. Error
+// DETAIL goes to system_log; the sidecar row carries only the class.
+
+package capture
+
+import (
+	"context"
+	"errors"
+	"math/rand/v2"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/connector"
+)
+
+const (
+	// backoffBase..backoffCap bound the transient-failure retry ladder:
+	// 2min·2^n capped at 4h, jittered ±20% so a fleet that failed together
+	// does not retry together.
+	backoffBase = 2 * time.Minute
+	backoffCap  = 4 * time.Hour
+
+	// degradeAfterFailures flips a connection to status 'error' — which means
+	// "degraded, probed daily", never a tombstone: the due-scan keeps
+	// selecting it at errProbeInterval and one success flips it back.
+	degradeAfterFailures = 20
+	errProbeInterval     = 24 * time.Hour
+)
+
+// errorClass is the CAP-DDL-5 vocabulary. The class is schedulable
+// information; the underlying detail is system_log's.
+type errorClass string
+
+const (
+	classRateLimited errorClass = "rate_limited"
+	classUnreachable errorClass = "unreachable"
+	classAuth        errorClass = "auth"
+	classHistoryGone errorClass = "history_gone"
+	classInternal    errorClass = "internal"
+)
+
+// classifySyncError maps a connector failure onto the shared vocabulary. Any
+// error outside it is internal: our bug, not the provider's weather.
+func classifySyncError(err error) errorClass {
+	switch {
+	case errors.Is(err, connector.ErrRateLimited):
+		return classRateLimited
+	case errors.Is(err, connector.ErrAuthRejected):
+		return classAuth
+	case errors.Is(err, connector.ErrUnreachable):
+		return classUnreachable
+	case errors.Is(err, connector.ErrCursorGone):
+		return classHistoryGone
+	default:
+		return classInternal
+	}
+}
+
+// backoffDelay is the transient-failure ladder: 2min·2^n capped at 4h, with
+// ±20% jitter.
+func backoffDelay(consecutiveFailures int) time.Duration {
+	d := backoffBase
+	for i := 0; i < consecutiveFailures && d < backoffCap; i++ {
+		d *= 2
+	}
+	if d > backoffCap {
+		d = backoffCap
+	}
+	jitter := 0.8 + 0.4*rand.Float64() //nolint:gosec // G404: scheduling jitter, not key material — de-syncs a fleet that failed together
+	return time.Duration(float64(d) * jitter)
+}
+
+// syncStateWorkspace names the workspace the sidecar row belongs to; the
+// scheduling calls only run under the fleet walk's per-workspace ctx.
+func syncStateWorkspace(ctx context.Context) (ids.UUID, error) {
+	ws, ok := principal.WorkspaceID(ctx)
+	if !ok {
+		return ids.Nil, errors.New("capture: sync-state recording outside workspace context")
+	}
+	return ws, nil
+}
+
+// recordSyncSuccess resets the ladder, paces the next sync one interval out,
+// and — the auto-recovery path — flips a degraded connection back to
+// connected. One success heals everything.
+func (r *Registry) recordSyncSuccess(ctx context.Context, connectionID ids.UUID) error {
+	ws, err := syncStateWorkspace(ctx)
+	if err != nil {
+		return err
+	}
+	return database.WithWorkspaceTx(ctx, r.pool, func(tx pgx.Tx) error {
+		now := r.now()
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO capture_sync_state (connection_id, workspace_id, next_sync_at,
+			                                consecutive_failures, last_synced_at, last_success_at, last_error_class)
+			VALUES ($1, $2, $3, 0, $4, $4, NULL)
+			ON CONFLICT (connection_id) DO UPDATE SET
+			  next_sync_at = EXCLUDED.next_sync_at,
+			  consecutive_failures = 0,
+			  last_synced_at = EXCLUDED.last_synced_at,
+			  last_success_at = EXCLUDED.last_success_at,
+			  last_error_class = NULL`,
+			connectionID, ws, now.Add(r.syncInterval), now); err != nil {
+			return err
+		}
+		_, err := tx.Exec(ctx, `
+			UPDATE capture_connection SET status = 'connected'
+			WHERE id = $1 AND status = 'error' AND archived_at IS NULL`, connectionID)
+		return err
+	})
+}
+
+// recordSyncFailure classifies, schedules the retry, and degrades — never
+// tombstones. Auth parks the connection as reauth_required until its human
+// reconnects (the OAuth callback resets both rows).
+func (r *Registry) recordSyncFailure(ctx context.Context, connectionID ids.UUID, syncErr error) error {
+	class := classifySyncError(syncErr)
+	ws, err := syncStateWorkspace(ctx)
+	if err != nil {
+		return err
+	}
+	return database.WithWorkspaceTx(ctx, r.pool, func(tx pgx.Tx) error {
+		now := r.now()
+
+		var failures int
+		if err := tx.QueryRow(ctx, `
+			INSERT INTO capture_sync_state (connection_id, workspace_id, next_sync_at,
+			                                consecutive_failures, last_synced_at, last_error_class)
+			VALUES ($1, $2, $3, 1, $4, $5)
+			ON CONFLICT (connection_id) DO UPDATE SET
+			  consecutive_failures = capture_sync_state.consecutive_failures + 1,
+			  last_synced_at = EXCLUDED.last_synced_at,
+			  last_error_class = EXCLUDED.last_error_class
+			RETURNING consecutive_failures`,
+			connectionID, ws, now.Add(backoffDelay(0)), now, string(class)).Scan(&failures); err != nil {
+			return err
+		}
+
+		next := now.Add(backoffDelay(failures))
+		switch class {
+		case classAuth:
+			// The connection needs its human, not a retry: park it. The
+			// due-scan only selects connected/error, so no next_sync_at
+			// gymnastics are needed.
+			if _, err := tx.Exec(ctx, `
+				UPDATE capture_connection SET status = 'reauth_required'
+				WHERE id = $1 AND status IN ('connected','error') AND archived_at IS NULL`, connectionID); err != nil {
+				return err
+			}
+		case classRateLimited:
+			var rl *connector.RateLimitedError
+			if errors.As(syncErr, &rl) && rl.RetryAfter > next.Sub(now) {
+				next = now.Add(rl.RetryAfter)
+			}
+		default:
+		}
+
+		if failures >= degradeAfterFailures {
+			// Degraded, probed daily — never a tombstone. One success in the
+			// daily probe flips the status back (recordSyncSuccess).
+			next = now.Add(errProbeInterval)
+			if _, err := tx.Exec(ctx, `
+				UPDATE capture_connection SET status = 'error'
+				WHERE id = $1 AND status = 'connected' AND archived_at IS NULL`, connectionID); err != nil {
+				return err
+			}
+		}
+
+		if _, err := tx.Exec(ctx, `
+			UPDATE capture_sync_state SET next_sync_at = $2 WHERE connection_id = $1`,
+			connectionID, next); err != nil {
+			return err
+		}
+
+		// The class is on the row; the detail belongs to the operational
+		// ledger (0078's rationale, kept).
+		if _, err := storekit.LogSystem(ctx, tx, "capture_sync_error", map[string]any{
+			"connection_id": connectionID.String(),
+			"class":         string(class),
+			"failures":      failures,
+			"detail":        syncErr.Error(),
+		}); err != nil {
+			return err
+		}
+		return nil
+	})
+}

--- a/backend/internal/modules/capture/syncstate_test.go
+++ b/backend/internal/modules/capture/syncstate_test.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package capture
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/shared/ports/connector"
+)
+
+// The classifier is what stands between a provider hiccup and a dead
+// connection: each class schedules differently, so a misclassification is a
+// scheduling bug, not a cosmetic one. (That each provider's package errors
+// answer the shared vocabulary is the provider packages' own tests.)
+func TestClassifySyncError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want errorClass
+	}{
+		{"rate limit carries its class", &connector.RateLimitedError{RetryAfter: time.Minute}, classRateLimited},
+		{"auth parks", fmt.Errorf("provider: %w", connector.ErrAuthRejected), classAuth},
+		{"unreachable backs off", fmt.Errorf("provider: %w", connector.ErrUnreachable), classUnreachable},
+		{"cursor gone is its own class", fmt.Errorf("provider: %w", connector.ErrCursorGone), classHistoryGone},
+		{"anything else is our bug", errors.New("nil map write"), classInternal},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := classifySyncError(tc.err); got != tc.want {
+				t.Fatalf("classify(%v) = %s, want %s", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBackoffDelayLadder(t *testing.T) {
+	// 2min·2^n with ±20% jitter: assert the envelope, not the die roll.
+	for n, base := range map[int]time.Duration{
+		0: 2 * time.Minute,
+		1: 4 * time.Minute,
+		3: 16 * time.Minute,
+	} {
+		got := backoffDelay(n)
+		lo, hi := time.Duration(float64(base)*0.8), time.Duration(float64(base)*1.2)
+		if got < lo || got > hi {
+			t.Fatalf("backoffDelay(%d) = %s, want within [%s, %s]", n, got, lo, hi)
+		}
+	}
+	// The cap: past the ladder's top every delay stays inside the jittered
+	// 4h envelope — a 20th failure must not schedule next year.
+	got := backoffDelay(30)
+	if hi := time.Duration(float64(backoffCap) * 1.2); got > hi {
+		t.Fatalf("backoffDelay(30) = %s, exceeds the jittered cap %s", got, hi)
+	}
+	if lo := time.Duration(float64(backoffCap) * 0.8); got < lo {
+		t.Fatalf("backoffDelay(30) = %s, below the jittered cap floor %s", got, lo)
+	}
+}
+
+func TestRateLimitedErrorSpeaksTheSharedVocabulary(t *testing.T) {
+	err := fmt.Errorf("gmail: messages.get: %w", &connector.RateLimitedError{RetryAfter: 30 * time.Second})
+	if !errors.Is(err, connector.ErrRateLimited) {
+		t.Fatal("a wrapped RateLimitedError must answer errors.Is(ErrRateLimited)")
+	}
+	var rl *connector.RateLimitedError
+	if !errors.As(err, &rl) || rl.RetryAfter != 30*time.Second {
+		t.Fatalf("Retry-After lost through the wrap: %v", rl)
+	}
+}

--- a/backend/internal/shared/ports/connector/errors.go
+++ b/backend/internal/shared/ports/connector/errors.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package connector
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+// The shared sync-failure vocabulary (ADR-0063). Providers wrap their own
+// package errors with these so the registry can schedule without knowing any
+// provider: auth parks the connection until its human reconnects, a rate
+// limit honors Retry-After, everything else backs off — and no class ever
+// tombstones a connection.
+
+// ErrAuthRejected marks a credential the provider refused: expired, revoked,
+// or insufficient. The connection needs its human, not a retry.
+var ErrAuthRejected = errors.New("connector: authorization rejected")
+
+// ErrUnreachable marks a transient provider/network failure worth backing
+// off and retrying.
+var ErrUnreachable = errors.New("connector: provider unreachable")
+
+// ErrCursorGone marks a stored sync watermark the provider no longer honors
+// (e.g. Gmail 404 on an old historyId): the connector recovers with its
+// bounded re-list; the registry records the class, nothing more.
+var ErrCursorGone = errors.New("connector: sync cursor no longer valid")
+
+// ErrRateLimited is the errors.Is target for RateLimitedError.
+var ErrRateLimited = errors.New("connector: provider rate limit")
+
+// RateLimitedError carries the provider's Retry-After. RetryAfter zero means
+// the provider named no delay — the caller falls back to its own backoff.
+type RateLimitedError struct {
+	RetryAfter time.Duration
+}
+
+func (e *RateLimitedError) Error() string {
+	if e.RetryAfter > 0 {
+		return fmt.Sprintf("connector: provider rate limit (retry after %s)", e.RetryAfter)
+	}
+	return "connector: provider rate limit"
+}
+
+// Is makes every RateLimitedError answer errors.Is(err, ErrRateLimited), so
+// callers classify on the sentinel and read Retry-After via errors.As.
+func (e *RateLimitedError) Is(target error) bool { return target == ErrRateLimited }

--- a/backend/migrations/core/0087_capture_sync_state.down.sql
+++ b/backend/migrations/core/0087_capture_sync_state.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS capture_sync_state;

--- a/backend/migrations/core/0087_capture_sync_state.down.sql
+++ b/backend/migrations/core/0087_capture_sync_state.down.sql
@@ -1,1 +1,2 @@
 DROP TABLE IF EXISTS capture_sync_state;
+ALTER TABLE capture_connection DROP CONSTRAINT IF EXISTS uq_capture_connection_ws_id;

--- a/backend/migrations/core/0087_capture_sync_state.up.sql
+++ b/backend/migrations/core/0087_capture_sync_state.up.sql
@@ -1,0 +1,40 @@
+-- CAP-DDL-5 (ADR-0063): the sweep's per-connection scheduling sidecar.
+-- Scheduling state has a live reader (the dispatcher's due-scan) so it earns
+-- columns; error DETAIL still belongs to system_log — the row carries only the
+-- class (narrowing, not reversing, 0078's no-diagnostics rationale on
+-- capture_connection). Rows are upserted lazily on a connection's first sync;
+-- a connection with no row is due immediately.
+
+CREATE TABLE capture_sync_state (
+  connection_id uuid PRIMARY KEY REFERENCES capture_connection(id) ON DELETE CASCADE,
+  workspace_id  uuid NOT NULL REFERENCES workspace(id) ON DELETE RESTRICT,
+
+  -- The due-scan key. Rate limits honor Retry-After; other transient errors
+  -- back off 2min·2^n capped at 4h, jittered. A connection in status 'error'
+  -- is probed daily — degraded, never tombstoned (one success flips it back).
+  next_sync_at  timestamptz NOT NULL DEFAULT now(),
+
+  consecutive_failures int NOT NULL DEFAULT 0,
+  last_synced_at   timestamptz NULL,
+  last_success_at  timestamptz NULL,
+  last_error_class text NULL CHECK (last_error_class IS NULL OR
+    last_error_class IN ('rate_limited','unreachable','auth','history_gone','internal')),
+
+  -- Politeness flag while a backfill pages the same mailbox: the sweep widens
+  -- its jitter. Correctness needs nothing — the two cursors are disjoint.
+  backfill_active boolean NOT NULL DEFAULT false,
+
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  updated_at    timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_capture_sync_due ON capture_sync_state (next_sync_at);
+
+CREATE TRIGGER trg_capture_sync_state_updated BEFORE UPDATE ON capture_sync_state
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+ALTER TABLE capture_sync_state ENABLE ROW LEVEL SECURITY;
+ALTER TABLE capture_sync_state FORCE ROW LEVEL SECURITY;
+CREATE POLICY capture_sync_state_tenant_isolation ON capture_sync_state
+  USING (workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid)
+  WITH CHECK (workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid);

--- a/backend/migrations/core/0087_capture_sync_state.up.sql
+++ b/backend/migrations/core/0087_capture_sync_state.up.sql
@@ -5,9 +5,17 @@
 -- capture_connection). Rows are upserted lazily on a connection's first sync;
 -- a connection with no row is due immediately.
 
+-- The composite-FK convention (0019): a tenant-local reference carries
+-- workspace_id so a cross-workspace target is rejected by the database
+-- itself, not just by RLS.
+ALTER TABLE capture_connection ADD CONSTRAINT uq_capture_connection_ws_id UNIQUE (workspace_id, id);
+
 CREATE TABLE capture_sync_state (
-  connection_id uuid PRIMARY KEY REFERENCES capture_connection(id) ON DELETE CASCADE,
+  connection_id uuid PRIMARY KEY,
   workspace_id  uuid NOT NULL REFERENCES workspace(id) ON DELETE RESTRICT,
+  CONSTRAINT capture_sync_state_connection_id_fkey
+    FOREIGN KEY (workspace_id, connection_id)
+    REFERENCES capture_connection (workspace_id, id) ON DELETE CASCADE,
 
   -- The due-scan key. Rate limits honor Retry-After; other transient errors
   -- back off 2min·2^n capped at 4h, jittered. A connection in status 'error'

--- a/backend/tableownership_test.go
+++ b/backend/tableownership_test.go
@@ -98,6 +98,7 @@ var tableOwners = map[string]string{
 	"raw_capture":            "internal/modules/capture",
 	"capture_connection":     "internal/modules/capture",
 	"capture_exclusion_rule": "internal/modules/capture",
+	"capture_sync_state":     "internal/modules/capture",
 	// search
 	"embedding": "internal/modules/search",
 	// ai (voice DNA: the derived profile artifact + corpus manifest)


### PR DESCRIPTION
## What

Build PR-1 of the email-ingestion plan (spec: ADR-0063/A109, landed upstream). The operational foundation "every user, every night" stands on:

- **Shared failure vocabulary** (`ports/connector/errors.go`): auth parks (`reauth_required`), rate limits honor Retry-After, transient errors back off 2min·2ⁿ capped 4h jittered, cursor-gone is recorded not punished. Gmail maps 429 + 403-rateLimitExceeded to rate limits; gmail/imap sentinels wrap the port vocabulary (pinned by per-provider tests).
- **`capture_sync_state` sidecar** (CAP-DDL-5, migration 0087): per-connection pacing + failure ladder; error *detail* stays in system_log, the row carries only the class (0078's rationale kept).
- **`error` = degraded-probed-daily, never a tombstone**: ≥20 consecutive failures degrade to a daily probe; one success heals everything. Previously a single 429 silently killed a mailbox forever.
- **Dispatcher pattern**: the 2m inline fleet loop becomes a 30s indexed due-scan enqueueing one `capture_sync` River job per due connection (unique-by-args) — per-connection isolation, no head-of-line blocking; the sidecar owns retry cadence, not River.

## Found by the tests

SyncOnce's row-read still demanded `status='connected'` — the daily probe of a degraded connection could never have run. The new integration test (`capture_syncstate_integration_test.go`) pins all four transitions (rate-limit/backoff-heal/degrade-probe-heal/auth-park-reconnect) against real Postgres and caught it before merge.

## Verification

`make check-backend` green; full `compose/integration` package green on a throwaway clone DB (incl. the updated pacing semantics in the Gmail connector test).

Next in sequence: PR-2 Gmail Pub/Sub webhook, PR-3 Gmail UI wiring (M1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)