### PR TITLE
feat(capture): Gmail Pub/Sub push webhook — capture becomes push-driven (PR-2)

### DIFF
--- a/backend/cmd/api/gmail.go
+++ b/backend/cmd/api/gmail.go
@@ -31,7 +31,10 @@ func gmailOptions(cfg apiConfig, pool *pgxpool.Pool, logger *slog.Logger, stdout
 		APIBaseURL:    cfg.apiBaseURL,
 	}
 	opts := []compose.Option{compose.WithGmailCapture(gmailCfg)}
-	if gmailCfg.Enabled() && cfg.gmailPushToken != "" {
+	// The push webhook needs only the pool and an insert-only client — not
+	// the OAuth transport — so a configured token mounts it even while the
+	// OAuth app is incomplete (connections synced by the worker still route).
+	if cfg.gmailPushToken != "" {
 		pushInserter, err := jobs.NewInserter(pool, logger)
 		if err != nil {
 			return nil, err

--- a/backend/cmd/api/gmail.go
+++ b/backend/cmd/api/gmail.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/platform/jobs"
+)
+
+// gmailOptions wires the Gmail capture surface: the OAuth
+// connect/callback transport (which rides the vault, so the caller
+// appends these AFTER keyvault options) and, when a subscription token
+// is configured, the Pub/Sub push webhook over an insert-only River
+// client (the deep-read pattern — the api enqueues, the worker works).
+// WithGmailCapture self-gates: absent the client id/secret, state key,
+// or public base URL it is a no-op and /connectors/gmail/* keeps its
+// declared 501.
+func gmailOptions(cfg apiConfig, pool *pgxpool.Pool, logger *slog.Logger, stdout io.Writer) ([]compose.Option, error) {
+	gmailCfg := compose.GmailConfig{
+		ClientID:      cfg.gmailClientID,
+		ClientSecret:  cfg.gmailClientSecret,
+		StateKey:      cfg.connectorStateKey,
+		PublicBaseURL: cfg.publicBaseURL,
+		APIBaseURL:    cfg.apiBaseURL,
+	}
+	opts := []compose.Option{compose.WithGmailCapture(gmailCfg)}
+	if gmailCfg.Enabled() && cfg.gmailPushToken != "" {
+		pushInserter, err := jobs.NewInserter(pool, logger)
+		if err != nil {
+			return nil, err
+		}
+		opts = append(opts, compose.WithGmailPush(pushInserter, cfg.gmailPushToken))
+		_, _ = fmt.Fprintln(stdout, "api gmail push webhook enabled (/webhooks/gmail-push)")
+	}
+	switch {
+	case gmailCfg.Enabled():
+		_, _ = fmt.Fprintln(stdout, "api gmail capture connector enabled (/connectors/gmail/*)")
+	case cfg.gmailClientID != "":
+		_, _ = fmt.Fprintln(stdout, "api gmail capture connector configured but INCOMPLETE — needs client secret, --connector-state-key (>=32B), and --public-base-url; surface stays 501")
+	}
+	return opts, nil
+}

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -72,6 +72,7 @@ type apiConfig struct {
 	apiBaseURL        string
 	gmailClientID     string
 	gmailClientSecret string
+	gmailPushToken    string
 	connectorStateKey string
 }
 
@@ -95,6 +96,7 @@ func parseAPIFlags(args []string) (apiConfig, error) {
 	fs.StringVar(&cfg.publicBaseURL, "public-base-url", os.Getenv("MARGINCE_PUBLIC_BASE_URL"), "canonical external scheme+host for buyer-facing links (RFC 8058 unsubscribe); required to send marketing mail and for the Gmail OAuth callback")
 	fs.StringVar(&cfg.gmailClientID, "gmail-client-id", os.Getenv("MARGINCE_GMAIL_CLIENT_ID"), "Google OAuth client id for the Gmail capture connector; with the secret, state key and public-base-url, enables /connectors/gmail/*")
 	fs.StringVar(&cfg.gmailClientSecret, "gmail-client-secret", os.Getenv("MARGINCE_GMAIL_CLIENT_SECRET"), "Google OAuth client secret for the Gmail capture connector")
+	fs.StringVar(&cfg.gmailPushToken, "gmail-push-token", os.Getenv("MARGINCE_GMAIL_PUSH_TOKEN"), "shared secret on the Pub/Sub push subscription URL; enables POST /webhooks/gmail-push (empty = route absent)")
 	fs.StringVar(&cfg.apiBaseURL, "api-base-url", os.Getenv("MARGINCE_API_BASE_URL"), "the api's externally-reachable base for the OAuth callback redirect_uri; defaults to --public-base-url (same-origin deployments), set only when the api is on a different origin than the SPA (e.g. dev)")
 	fs.StringVar(&cfg.connectorStateKey, "connector-state-key", os.Getenv("MARGINCE_CONNECTOR_STATE_KEY"), "HMAC key (>=32 bytes) signing the OAuth connect `state`; required for the Gmail connect flow")
 	if err := fs.Parse(args); err != nil {
@@ -139,7 +141,7 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 		return err
 	}
 
-	opts, closeSchemaPool, err := baseComposeOptions(ctx, cfg, pool, stdout)
+	opts, closeSchemaPool, err := baseComposeOptions(ctx, cfg, pool, logger, stdout)
 	if err != nil {
 		return err
 	}
@@ -223,7 +225,7 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 // returned close func releases whatever this stage opened (currently
 // only the schema pool) and is always safe to call, even when nothing
 // was opened.
-func baseComposeOptions(ctx context.Context, cfg apiConfig, pool *pgxpool.Pool, stdout io.Writer) ([]compose.Option, func(), error) {
+func baseComposeOptions(ctx context.Context, cfg apiConfig, pool *pgxpool.Pool, logger *slog.Logger, stdout io.Writer) ([]compose.Option, func(), error) {
 	var opts []compose.Option
 	if cfg.publicBaseURL != "" {
 		opts = append(opts, compose.WithPublicBaseURL(cfg.publicBaseURL))
@@ -241,24 +243,13 @@ func baseComposeOptions(ctx context.Context, cfg apiConfig, pool *pgxpool.Pool, 
 	}
 	opts = append(opts, kvOpts...)
 
-	// The Gmail connect/callback transport rides the same vault WithKeyvault
-	// wired, so it must follow kvOpts. WithGmailCapture self-gates: absent the
-	// client id/secret, state key, or public base URL it is a no-op and the
-	// /connectors/gmail/* surface keeps its declared 501.
-	gmailCfg := compose.GmailConfig{
-		ClientID:      cfg.gmailClientID,
-		ClientSecret:  cfg.gmailClientSecret,
-		StateKey:      cfg.connectorStateKey,
-		PublicBaseURL: cfg.publicBaseURL,
-		APIBaseURL:    cfg.apiBaseURL,
+	// The Gmail transport rides the vault WithKeyvault wired, so it must
+	// follow kvOpts.
+	gmailOpts, err := gmailOptions(cfg, pool, logger, stdout)
+	if err != nil {
+		return nil, nil, err
 	}
-	opts = append(opts, compose.WithGmailCapture(gmailCfg))
-	switch {
-	case gmailCfg.Enabled():
-		_, _ = fmt.Fprintln(stdout, "api gmail capture connector enabled (/connectors/gmail/*)")
-	case cfg.gmailClientID != "":
-		_, _ = fmt.Fprintln(stdout, "api gmail capture connector configured but INCOMPLETE — needs client secret, --connector-state-key (>=32B), and --public-base-url; surface stays 501")
-	}
+	opts = append(opts, gmailOpts...)
 
 	schemaOpts, closeSchemaPool, err := schemaPoolOptions(ctx, cfg.schemaDSN, stdout)
 	if err != nil {

--- a/backend/internal/compose/gmailpush.go
+++ b/backend/internal/compose/gmailpush.go
@@ -17,6 +17,7 @@
 package compose
 
 import (
+	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/base64"
 	"encoding/json"
@@ -38,10 +39,12 @@ type pushEnvelope struct {
 	} `json:"message"`
 }
 
-// gmailNotification is Gmail's watch payload inside the envelope.
+// gmailNotification is Gmail's watch payload inside the envelope. Gmail
+// quotes historyId in push payloads, so it decodes as json.Number (either
+// form), not uint64.
 type gmailNotification struct {
-	EmailAddress string `json:"emailAddress"` //nolint:tagliatelle // Google names this field
-	HistoryID    uint64 `json:"historyId"`    //nolint:tagliatelle // Google names this field
+	EmailAddress string      `json:"emailAddress"` //nolint:tagliatelle // Google names this field
+	HistoryID    json.Number `json:"historyId"`    //nolint:tagliatelle // Google names this field
 }
 
 type gmailPushHandler struct {
@@ -69,8 +72,12 @@ func (h *gmailPushHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Wrong/missing token → 403 and Pub/Sub stops delivering to a
-	// misconfigured (or hostile) subscription after its retry budget.
-	if subtle.ConstantTimeCompare([]byte(r.URL.Query().Get("token")), []byte(h.token)) != 1 {
+	// misconfigured (or hostile) subscription after its retry budget. The
+	// digests equalize length first, so the compare leaks neither content
+	// nor token length.
+	got := sha256.Sum256([]byte(r.URL.Query().Get("token")))
+	want := sha256.Sum256([]byte(h.token))
+	if subtle.ConstantTimeCompare(got[:], want[:]) != 1 {
 		w.WriteHeader(http.StatusForbidden)
 		return
 	}

--- a/backend/internal/compose/gmailpush.go
+++ b/backend/internal/compose/gmailpush.go
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// The Gmail Pub/Sub push webhook: the consuming half of the users.watch
+// registration the renewal sweep maintains. A push names a mailbox and a
+// historyId; this endpoint verifies the shared subscription token, bumps the
+// matching connection's pacing clock, and enqueues its sync — making capture
+// push-driven with the poll demoted to a safety net (CAP-PARAM-1's 60s p95
+// is unreachable on a poll alone).
+//
+// Verification is the Pub/Sub push token (constant-time compared, minted by
+// the operator, carried as ?token= on the subscription's push endpoint).
+// The spec leaves per-provider webhook verification an open decision
+// (capture.md CAP-DDL-2 note); the OIDC-token upgrade slots in here without
+// moving the route.
+
+package compose
+
+import (
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/riverqueue/river"
+
+	"github.com/gradionhq/margince/backend/internal/modules/capture"
+	"github.com/gradionhq/margince/backend/internal/platform/jobs"
+)
+
+// pushEnvelope is the Pub/Sub push wrapper; Message.Data is base64 JSON.
+type pushEnvelope struct {
+	Message struct {
+		Data string `json:"data"`
+	} `json:"message"`
+}
+
+// gmailNotification is Gmail's watch payload inside the envelope.
+type gmailNotification struct {
+	EmailAddress string `json:"emailAddress"` //nolint:tagliatelle // Google names this field
+	HistoryID    uint64 `json:"historyId"`    //nolint:tagliatelle // Google names this field
+}
+
+type gmailPushHandler struct {
+	pool     *pgxpool.Pool
+	inserter *jobs.Runner
+	token    string
+	log      *slog.Logger
+}
+
+// WithGmailPush mounts POST /webhooks/gmail-push. token is the shared
+// subscription secret; empty disables the endpoint entirely (the route is
+// absent, not open).
+func WithGmailPush(inserter *jobs.Runner, token string) Option {
+	return func(s *Server, pool *pgxpool.Pool) {
+		if token == "" || inserter == nil {
+			return
+		}
+		s.gmailPush = &gmailPushHandler{pool: pool, inserter: inserter, token: token, log: s.log}
+	}
+}
+
+func (h *gmailPushHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	// Wrong/missing token → 403 and Pub/Sub stops delivering to a
+	// misconfigured (or hostile) subscription after its retry budget.
+	if subtle.ConstantTimeCompare([]byte(r.URL.Query().Get("token")), []byte(h.token)) != 1 {
+		w.WriteHeader(http.StatusForbidden)
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	var env pushEnvelope
+	if err := json.Unmarshal(body, &env); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	data, err := base64.StdEncoding.DecodeString(env.Message.Data)
+	if err != nil {
+		// Pub/Sub may use URL-safe encoding; accept either before refusing.
+		if data, err = base64.URLEncoding.DecodeString(env.Message.Data); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+	}
+	var note gmailNotification
+	if err := json.Unmarshal(data, &note); err != nil || note.EmailAddress == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	// Route by the provider-owned identity in the connector's own cursor;
+	// enqueue directly so the sync starts now, not at the next scan. Failures
+	// here answer 500 so Pub/Sub redelivers — the bump+enqueue is idempotent
+	// (unique-by-args while incomplete), so a redelivery cannot double-run.
+	hits, err := capture.BumpDueByMailbox(r.Context(), h.pool, "gmail", note.EmailAddress)
+	if err != nil {
+		h.log.ErrorContext(r.Context(), "gmail push: routing notification", "err", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	for _, d := range hits {
+		if err := h.inserter.Enqueue(r.Context(), CaptureSyncArgs{
+			Workspace:    d.Workspace.String(),
+			ConnectionID: d.ID.String(),
+			Provider:     "gmail",
+		}, &river.InsertOpts{
+			UniqueOpts: river.UniqueOpts{ByArgs: true, ByState: activeSweepStates},
+		}); err != nil {
+			h.log.ErrorContext(r.Context(), "gmail push: enqueueing sync", "connection", d.ID.String(), "err", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+	}
+	// 204 also for a mailbox nobody connected: nothing here a redelivery
+	// would fix, and Pub/Sub must stop retrying.
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/backend/internal/compose/integration/gmail_push_integration_test.go
+++ b/backend/internal/compose/integration/gmail_push_integration_test.go
@@ -177,6 +177,28 @@ func TestGmailPushWebhookRoutesToTheConnection(t *testing.T) {
 		}
 	})
 
+	t.Run("malformed input is refused, not retried", func(t *testing.T) {
+		if code := post(srv.URL+"/webhooks/gmail-push?token="+token, []byte("not json")); code != http.StatusBadRequest {
+			t.Fatalf("garbage body status = %d, want 400", code)
+		}
+		if code := post(srv.URL+"/webhooks/gmail-push?token="+token, []byte(`{"message":{"data":"%%%not-base64%%%"}}`)); code != http.StatusBadRequest {
+			t.Fatalf("bad base64 status = %d, want 400", code)
+		}
+		empty := base64.StdEncoding.EncodeToString([]byte(`{"historyId":1}`))
+		if code := post(srv.URL+"/webhooks/gmail-push?token="+token, []byte(`{"message":{"data":"`+empty+`"}}`)); code != http.StatusBadRequest {
+			t.Fatalf("missing emailAddress status = %d, want 400", code)
+		}
+		resp, err := http.Get(srv.URL + "/webhooks/gmail-push?token=" + token)
+		if err != nil {
+			t.Fatal(err)
+		}
+		//craft:ignore swallowed-errors test response body close; the status code is the assertion
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusMethodNotAllowed {
+			t.Fatalf("GET status = %d, want 405", resp.StatusCode)
+		}
+	})
+
 	t.Run("an unknown mailbox is a 204 no-op", func(t *testing.T) {
 		if code := post(srv.URL+"/webhooks/gmail-push?token="+token, pushBody(t, "stranger@nowhere.example")); code != http.StatusNoContent {
 			t.Fatalf("status = %d, want 204 — Pub/Sub must stop retrying", code)

--- a/backend/internal/compose/integration/gmail_push_integration_test.go
+++ b/backend/internal/compose/integration/gmail_push_integration_test.go
@@ -59,7 +59,7 @@ func ensureRiverSchema(t *testing.T) {
 
 func pushBody(t *testing.T, email string) []byte {
 	t.Helper()
-	note, err := json.Marshal(map[string]any{"emailAddress": email, "historyId": 4711})
+	note, err := json.Marshal(map[string]string{"emailAddress": email, "historyId": "4711"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -84,6 +84,7 @@ func TestGmailPushWebhookRoutesToTheConnection(t *testing.T) {
 		t.Fatalf("Connect: %v", err)
 	}
 
+	var seededNext time.Time
 	// The connector's cursor carries the provider-owned mailbox identity —
 	// exactly what a real gmail sync writes — and the pacing clock sits in
 	// the future so only the push can make the connection due.
@@ -93,11 +94,11 @@ func TestGmailPushWebhookRoutesToTheConnection(t *testing.T) {
 			connID, fmt.Sprintf(`{"history_id":"1000","email":%q}`, mailbox)); err != nil {
 			return err
 		}
-		_, err := tx.Exec(context.Background(), `
+		return tx.QueryRow(context.Background(), `
 			INSERT INTO capture_sync_state (connection_id, workspace_id, next_sync_at)
-			SELECT id, workspace_id, now() + interval '1 hour' FROM capture_connection WHERE id = $1`,
-			connID)
-		return err
+			SELECT id, workspace_id, now() + interval '1 hour' FROM capture_connection WHERE id = $1
+			RETURNING next_sync_at`,
+			connID).Scan(&seededNext)
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -120,9 +121,11 @@ func TestGmailPushWebhookRoutesToTheConnection(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		//craft:ignore swallowed-errors test response body close; the status code is the assertion
-		defer func() { _ = resp.Body.Close() }()
-		return resp.StatusCode
+		code := resp.StatusCode
+		if err := resp.Body.Close(); err != nil {
+			t.Errorf("closing response body: %v", err)
+		}
+		return code
 	}
 
 	t.Run("wrong token is refused before any work", func(t *testing.T) {
@@ -151,8 +154,8 @@ func TestGmailPushWebhookRoutesToTheConnection(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if next.After(time.Now()) {
-			t.Fatalf("next_sync_at = %s, want zeroed to now — the push must make the connection due", next)
+		if !next.Before(seededNext) {
+			t.Fatalf("next_sync_at = %s, want moved earlier than the seeded %s — the push must make the connection due", next, seededNext)
 		}
 		if jobRows != 1 {
 			t.Fatalf("capture_sync jobs for the connection = %d, want exactly 1", jobRows)
@@ -192,10 +195,12 @@ func TestGmailPushWebhookRoutesToTheConnection(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		//craft:ignore swallowed-errors test response body close; the status code is the assertion
-		defer func() { _ = resp.Body.Close() }()
-		if resp.StatusCode != http.StatusMethodNotAllowed {
-			t.Fatalf("GET status = %d, want 405", resp.StatusCode)
+		code := resp.StatusCode
+		if err := resp.Body.Close(); err != nil {
+			t.Errorf("closing response body: %v", err)
+		}
+		if code != http.StatusMethodNotAllowed {
+			t.Fatalf("GET status = %d, want 405", code)
 		}
 	})
 

--- a/backend/internal/compose/integration/gmail_push_integration_test.go
+++ b/backend/internal/compose/integration/gmail_push_integration_test.go
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The Pub/Sub push webhook end to end over the real mux: a notification for
+// a connected mailbox zeroes its pacing clock and enqueues its sync job; a
+// wrong token is refused before any work; a mailbox nobody connected is a
+// 204 no-op (Pub/Sub must stop retrying — nothing here a redelivery fixes).
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/platform/jobs"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/connector"
+)
+
+// ensureRiverSchema applies River's schema once for this package process —
+// the harness migrates core+custom only, and the enqueue path needs
+// river_job (the same discipline the workqueue suite uses).
+func ensureRiverSchema(t *testing.T) {
+	t.Helper()
+	ctx := context.Background()
+	ownerPool, err := pgxpool.New(ctx, os.Getenv("MARGINCE_TEST_DSN"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ownerPool.Close()
+	var present bool
+	if err := ownerPool.QueryRow(ctx, `SELECT to_regclass('public.river_migration') IS NOT NULL`).Scan(&present); err != nil {
+		t.Fatalf("checking river schema: %v", err)
+	}
+	if present {
+		return
+	}
+	if _, err := jobs.Migrate(ctx, ownerPool); err != nil {
+		t.Fatalf("applying river schema: %v", err)
+	}
+}
+
+func pushBody(t *testing.T, email string) []byte {
+	t.Helper()
+	note, err := json.Marshal(map[string]any{"emailAddress": email, "historyId": 4711})
+	if err != nil {
+		t.Fatal(err)
+	}
+	env, err := json.Marshal(map[string]any{
+		"message": map[string]any{"data": base64.StdEncoding.EncodeToString(note)},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return env
+}
+
+func TestGmailPushWebhookRoutesToTheConnection(t *testing.T) {
+	e := setupSearch(t)
+	const mailbox = "push-owner@ws.example"
+
+	registry := newTestCaptureRegistry(e, newTestKeyvault(t, e))
+	registry.Register(&moodyConnector{name: "gmail"})
+	grantCtx := e.humanWithScopes(e.Rep1, []principal.Scope{principal.ScopeRead})
+	connID, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh"))
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+
+	// The connector's cursor carries the provider-owned mailbox identity —
+	// exactly what a real gmail sync writes — and the pacing clock sits in
+	// the future so only the push can make the connection due.
+	err = database.WithWorkspaceTx(grantCtx, e.Pool, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(context.Background(), `
+			UPDATE capture_connection SET sync_cursor = $2 WHERE id = $1`,
+			connID, fmt.Sprintf(`{"history_id":"1000","email":%q}`, mailbox)); err != nil {
+			return err
+		}
+		_, err := tx.Exec(context.Background(), `
+			INSERT INTO capture_sync_state (connection_id, workspace_id, next_sync_at)
+			SELECT id, workspace_id, now() + interval '1 hour' FROM capture_connection WHERE id = $1`,
+			connID)
+		return err
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ensureRiverSchema(t)
+	quiet := slog.New(slog.NewTextHandler(io.Discard, nil))
+	inserter, err := jobs.NewInserter(e.Pool, quiet)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const token = "push-secret"
+	handler := compose.New(e.Pool, quiet, compose.WithGmailPush(inserter, token))
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	post := func(url string, body []byte) int {
+		t.Helper()
+		resp, err := http.Post(url, "application/json", bytes.NewReader(body))
+		if err != nil {
+			t.Fatal(err)
+		}
+		//craft:ignore swallowed-errors test response body close; the status code is the assertion
+		defer func() { _ = resp.Body.Close() }()
+		return resp.StatusCode
+	}
+
+	t.Run("wrong token is refused before any work", func(t *testing.T) {
+		if code := post(srv.URL+"/webhooks/gmail-push?token=wrong", pushBody(t, mailbox)); code != http.StatusForbidden {
+			t.Fatalf("status = %d, want 403", code)
+		}
+	})
+
+	t.Run("a push zeroes the pacing clock and enqueues the sync", func(t *testing.T) {
+		if code := post(srv.URL+"/webhooks/gmail-push?token="+token, pushBody(t, mailbox)); code != http.StatusNoContent {
+			t.Fatalf("status = %d, want 204", code)
+		}
+		var next time.Time
+		var jobRows int
+		err := database.WithWorkspaceTx(grantCtx, e.Pool, func(tx pgx.Tx) error {
+			if err := tx.QueryRow(context.Background(), `
+				SELECT next_sync_at FROM capture_sync_state WHERE connection_id = $1`, connID).Scan(&next); err != nil {
+				return err
+			}
+			// river_job is not tenant-scoped; count the enqueued sync for
+			// this connection.
+			return tx.QueryRow(context.Background(), `
+				SELECT count(*) FROM river_job
+				WHERE kind = 'capture_sync' AND args->>'connection_id' = $1`, connID.String()).Scan(&jobRows)
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if next.After(time.Now()) {
+			t.Fatalf("next_sync_at = %s, want zeroed to now — the push must make the connection due", next)
+		}
+		if jobRows != 1 {
+			t.Fatalf("capture_sync jobs for the connection = %d, want exactly 1", jobRows)
+		}
+	})
+
+	t.Run("a redelivery cannot double-enqueue", func(t *testing.T) {
+		if code := post(srv.URL+"/webhooks/gmail-push?token="+token, pushBody(t, mailbox)); code != http.StatusNoContent {
+			t.Fatalf("status = %d, want 204", code)
+		}
+		var jobRows int
+		err := database.WithWorkspaceTx(grantCtx, e.Pool, func(tx pgx.Tx) error {
+			return tx.QueryRow(context.Background(), `
+				SELECT count(*) FROM river_job
+				WHERE kind = 'capture_sync' AND args->>'connection_id' = $1`, connID.String()).Scan(&jobRows)
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if jobRows != 1 {
+			t.Fatalf("capture_sync jobs after redelivery = %d, want still 1 (unique while incomplete)", jobRows)
+		}
+	})
+
+	t.Run("an unknown mailbox is a 204 no-op", func(t *testing.T) {
+		if code := post(srv.URL+"/webhooks/gmail-push?token="+token, pushBody(t, "stranger@nowhere.example")); code != http.StatusNoContent {
+			t.Fatalf("status = %d, want 204 — Pub/Sub must stop retrying", code)
+		}
+	})
+}

--- a/backend/internal/compose/server.go
+++ b/backend/internal/compose/server.go
@@ -79,6 +79,11 @@ type Server struct {
 	quotasHandlers
 	attachmentExtractionHandlers
 
+	// gmailPush is the Pub/Sub push webhook, injected by WithGmailPush only
+	// when a subscription token is configured — the route is absent
+	// otherwise, never open.
+	gmailPush *gmailPushHandler
+
 	// busReady is the /readyz bus probe, injected only by the process
 	// role that runs the inline relay — a split deployment's api answers
 	// ready on Postgres alone.
@@ -433,6 +438,12 @@ func operationalMux(srv Server, pool *pgxpool.Pool, log *slog.Logger, authH auth
 	mux.Handle("/oauth/", httpserver.Correlate(httpserver.AccessLog(log, authH.Middleware(authH.OAuthRouter()))))
 	mux.HandleFunc("/.well-known/oauth-authorization-server", identity.OAuthServerMetadata)
 	mux.HandleFunc("/.well-known/oauth-protected-resource", identity.ProtectedResourceMetadata)
+	// Provider push webhooks: unauthenticated by nature (the provider is the
+	// caller), each verified by its own mechanism inside the handler; mounted
+	// only when configured — the route is absent otherwise.
+	if srv.gmailPush != nil {
+		mux.Handle("/webhooks/gmail-push", httpserver.Correlate(httpserver.AccessLog(log, srv.gmailPush)))
+	}
 	return mux
 }
 

--- a/backend/internal/modules/capture/gmail/gmail.go
+++ b/backend/internal/modules/capture/gmail/gmail.go
@@ -65,9 +65,13 @@ type authState struct {
 	Scopes       []string `json:"scopes"`
 }
 
-// cursorState is the persisted incremental watermark: Gmail's historyId.
+// cursorState is the persisted incremental watermark: Gmail's historyId,
+// plus the mailbox address the watermark belongs to — the Pub/Sub push
+// notification names only the mailbox, so the webhook routes on
+// sync_cursor->>'email' without unsealing any credential.
 type cursorState struct {
 	HistoryID string `json:"history_id"`
+	Email     string `json:"email"`
 }
 
 // authPayload is the connect request the transport hands to Authenticate:
@@ -176,7 +180,7 @@ func (c *Connector) Sync(ctx context.Context, auth connector.Auth, cursor connec
 	if nextHistory == "" {
 		nextHistory = start // nothing new; keep the prior watermark
 	}
-	return marshalCursor(nextHistory), nil
+	return marshalCursor(nextHistory, owner), nil
 }
 
 // selectMessages resolves which message ids to pull and the historyId to
@@ -301,9 +305,9 @@ func parseCursor(cur connector.Cursor) (string, error) {
 	return cs.HistoryID, nil
 }
 
-func marshalCursor(historyID string) connector.Cursor {
+func marshalCursor(historyID, email string) connector.Cursor {
 	// cursorState has only string fields, so Marshal cannot fail here.
-	b, _ := json.Marshal(cursorState{HistoryID: historyID}) //nolint:errchkjson // string-only struct never errors
+	b, _ := json.Marshal(cursorState{HistoryID: historyID, Email: email}) //nolint:errchkjson // string-only struct never errors
 	return b
 }
 

--- a/backend/internal/modules/capture/push.go
+++ b/backend/internal/modules/capture/push.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package capture
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// BumpDueByMailbox routes a provider push notification onto the sweep: the
+// notification names only a mailbox address, and the matching connection is
+// found through the provider-owned identity the gmail connector writes into
+// its own cursor (sync_cursor->>'email') — no credential is unsealed, no new
+// column exists. Matching connections have their pacing clock zeroed so the
+// next dispatch picks them up immediately; the returned pairs let the caller
+// enqueue the sync jobs directly rather than waiting for the periodic scan.
+//
+// A mailbox nobody has connected matches nothing and returns empty — a push
+// for a foreign address is a no-op, never an error (Pub/Sub redelivers on
+// errors, and there is nothing here a retry would fix).
+func BumpDueByMailbox(ctx context.Context, pool *pgxpool.Pool, provider, email string) ([]DueConnection, error) {
+	// rls-exempt: fleet enumeration — the workspace table is not workspace-scoped; the push carries no tenant, so every workspace is probed under its own GUC.
+	rows, err := pool.Query(ctx, `SELECT id FROM workspace WHERE archived_at IS NULL`)
+	if err != nil {
+		return nil, fmt.Errorf("capture: listing workspaces for the push walk: %w", err)
+	}
+	workspaces, err := pgx.CollectRows(rows, pgx.RowTo[ids.UUID])
+	if err != nil {
+		return nil, err
+	}
+
+	var hits []DueConnection
+	var errs error
+	for _, wsID := range workspaces {
+		wsCtx := principal.WithWorkspaceID(ctx, wsID)
+		ws := ids.From[ids.WorkspaceKind](wsID)
+		err := database.WithWorkspaceTx(wsCtx, pool, func(tx pgx.Tx) error {
+			// Upsert, not update: a connection that has never synced has no
+			// sidecar row yet — a push for it must still land.
+			rows, err := tx.Query(ctx, `
+				INSERT INTO capture_sync_state (connection_id, workspace_id, next_sync_at)
+				SELECT c.id, c.workspace_id, now()
+				FROM capture_connection c
+				WHERE c.provider = $1
+				  AND c.status IN ('connected','error')
+				  AND c.archived_at IS NULL
+				  AND c.sync_cursor->>'email' = $2
+				ON CONFLICT (connection_id) DO UPDATE SET next_sync_at = now()
+				RETURNING connection_id`, provider, email)
+			if err != nil {
+				return err
+			}
+			matched, err := pgx.CollectRows(rows, pgx.RowTo[ids.UUID])
+			if err != nil {
+				return err
+			}
+			for _, id := range matched {
+				hits = append(hits, DueConnection{Workspace: ws, ID: id})
+			}
+			return nil
+		})
+		if err != nil {
+			errs = errors.Join(errs, fmt.Errorf("capture: push walk in workspace %s: %w", wsID, err))
+		}
+	}
+	return hits, errs
+}


### PR DESCRIPTION
## What

PR-2 of the email-ingestion plan, on top of #106's sync state machine. The watch registration has been "dark" since it shipped — subscriptions renewed, notifications unconsumed; the 2-minute poll was the only live sync path, and CAP-PARAM-1's 60s p95 is unreachable on a poll alone. This is the consuming half:

- `POST /webhooks/gmail-push` — mounted only when `--gmail-push-token` is set (absent otherwise, never open); constant-time token check before any work.
- Routing without unsealing credentials: the gmail connector now writes the mailbox address into its own cursor (`sync_cursor->>'email'`); the webhook upserts the pacing clock by that identity (a never-synced connection still routes) and enqueues `capture_sync` directly — unique-by-args while incomplete, so a Pub/Sub redelivery cannot double-run a mailbox.
- Unknown mailbox → 204 no-op (redelivery fixes nothing); routing/enqueue failure → 500 so Pub/Sub retries.
- api role: `--gmail-push-token` / `MARGINCE_GMAIL_PUSH_TOKEN` + an insert-only River client (the deep-read pattern); gmail wiring extracted to `cmd/api/gmail.go` (the 500-line gate flagged main.go).
- Verification = the shared subscription token; the spec leaves provider webhook verification an open decision (CAP-DDL-2 note) — the OIDC upgrade slots into the same handler.

## Verification

Integration suite drives the real mux end to end: wrong token 403s before any work; a push zeroes `next_sync_at` and enqueues exactly one job; a redelivery stays at one; an unknown mailbox 204s. `make check-backend` green pre- and post-rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Gmail push webhook support for triggering mailbox synchronization.
  * Added secure token validation and handling for Gmail Pub/Sub notifications.
  * Automatically schedules eligible mailbox syncs while preventing duplicate processing.
  * Added optional Gmail push token configuration.

* **Bug Fixes**
  * Improved Gmail sync cursor tracking by associating cursors with mailbox addresses.
  * Invalid, unauthorized, or malformed webhook requests are rejected safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->