### PR TITLE
fix(siteread): locale-variant dedupe + full legal abstention on multi-entity domains

### DIFF
--- a/backend/internal/compose/deepread.go
+++ b/backend/internal/compose/deepread.go
@@ -189,7 +189,7 @@ func (w *siteDeepReadWorker) run(ctx context.Context, args SiteDeepReadArgs) err
 	if modelErr == nil {
 		// The site-level synthesis rides the same brain; when the model
 		// lane already died there is nothing healthy to reconcile with.
-		mergedFields = synthesizeSiteFields(ctx, w.extract, crawl.Pages[:len(perPage)], mergedFields)
+		mergedFields = synthesizeSiteFields(ctx, w.extract, crawl.Pages[:len(perPage)], mergedFields, legalConflict)
 	}
 	mergedFacts := mergeCategoryFacts(perPage)
 	mergedPeople := mergeTeamPeople(perPage)

--- a/backend/internal/compose/deepreadmerge.go
+++ b/backend/internal/compose/deepreadmerge.go
@@ -65,9 +65,25 @@ func mergeCrawlFields(pages []pageFields) (merged []evidencedField, legalConflic
 		seed = mergeSiteFields(seed, p.fields)
 	}
 	if len(legalNames) > 1 {
-		return seed, true
+		// Full abstention, not just a dropped override: with the entity
+		// in dispute, a legal_name quoted off a marketing page is as
+		// untrustworthy as the losing legal page's — the read proposes NO
+		// legal identity and the human resolves it.
+		return withoutLegalTrio(seed), true
 	}
 	return mergeSiteFields(seed, legal), false
+}
+
+// withoutLegalTrio strips the legal-identity fields from a field set —
+// the multi-entity abstention applied to whatever side survives.
+func withoutLegalTrio(fields []evidencedField) []evidencedField {
+	kept := fields[:0]
+	for _, f := range fields {
+		if !legalPageFields[f.Field] {
+			kept = append(kept, f)
+		}
+	}
+	return kept
 }
 
 // fillMissingFields appends only the fields `have` lacks — no override

--- a/backend/internal/compose/deepreadmerge_test.go
+++ b/backend/internal/compose/deepreadmerge_test.go
@@ -60,11 +60,15 @@ func TestMergeCrawlFieldsDeepLegalPathHasNoOverridePower(t *testing.T) {
 	}
 }
 
-func TestMergeCrawlFieldsDisagreeingLegalPagesCancelTheOverride(t *testing.T) {
+func TestMergeCrawlFieldsDisagreeingLegalPagesAbstainFromTheWholeLegalTrio(t *testing.T) {
+	seedFields := []evidencedField{
+		legalNameField("Acme Robotics", seedURL),
+		{Field: string(crmcontracts.DisplayName), Value: "Acme", EvidenceSnippet: "Acme", SourceURL: seedURL, Confidence: 0.9},
+	}
 	merged, conflict := mergeCrawlFields([]pageFields{
 		{
 			url: seedURL, kind: crmcontracts.SiteReadPageKindHome,
-			fields: []evidencedField{legalNameField("Acme Robotics", seedURL)},
+			fields: seedFields,
 		},
 		{
 			url: seedURL + "/impressum", kind: crmcontracts.SiteReadPageKindImpressum,
@@ -78,8 +82,11 @@ func TestMergeCrawlFieldsDisagreeingLegalPagesCancelTheOverride(t *testing.T) {
 	if !conflict {
 		t.Fatal("two disagreeing legal names must flag the multi-entity domain")
 	}
-	if len(merged) != 1 || merged[0].Value != "Acme Robotics" {
-		t.Fatalf("with the override cancelled the seed answer must stand: %+v", merged)
+	// With the entity in dispute, NO legal identity is proposed — not the
+	// losing legal page's, and not a marketing page's either. Non-legal
+	// fields survive untouched.
+	if len(merged) != 1 || merged[0].Field != string(crmcontracts.DisplayName) {
+		t.Fatalf("the abstention must strip the legal trio and keep the rest: %+v", merged)
 	}
 }
 

--- a/backend/internal/compose/deepreadsynthesis.go
+++ b/backend/internal/compose/deepreadsynthesis.go
@@ -93,8 +93,11 @@ func synthesisSchema(pageURLs []string) json.RawMessage {
 
 // synthesizeSiteFields runs the one synthesis call and folds its gated
 // corrections over the merged per-page fields. Any failure — the call,
-// the parse — logs and returns the merged input unchanged.
-func synthesizeSiteFields(ctx context.Context, x evidenceExtractor, pages []crawlPage, merged []evidencedField) []evidencedField {
+// the parse — logs and returns the merged input unchanged. legalConflict
+// carries mergeCrawlFields' multi-entity verdict: when the site's legal
+// pages disagree on the entity, the merge dropped the legal trio, and
+// the synthesis pass must not reintroduce it from the same pages.
+func synthesizeSiteFields(ctx context.Context, x evidenceExtractor, pages []crawlPage, merged []evidencedField, legalConflict bool) []evidencedField {
 	excerpts := synthesisExcerpts(pages)
 	if len(excerpts) == 0 || len(merged) == 0 {
 		// Nothing to reconcile against (or nothing extracted at all —
@@ -134,6 +137,20 @@ func synthesizeSiteFields(ctx context.Context, x evidenceExtractor, pages []craw
 	}
 
 	corrections, dropped := gateSynthesis(resp.Text, excerpts)
+	if legalConflict {
+		kept := corrections[:0]
+		for _, c := range corrections {
+			if legalPageFields[c.Field] {
+				dropped = append(dropped, droppedFinding{
+					Lane: laneSynthesis, Field: c.Field, Value: c.Value,
+					EvidenceSnippet: c.EvidenceSnippet, Reason: dropLegalConflict,
+				})
+				continue
+			}
+			kept = append(kept, c)
+		}
+		corrections = kept
+	}
 	x.reportDrops(ctx, laneSynthesis, dropped)
 	return applySynthesis(merged, corrections)
 }

--- a/backend/internal/compose/deepreadsynthesis_test.go
+++ b/backend/internal/compose/deepreadsynthesis_test.go
@@ -43,7 +43,7 @@ func TestSynthesisCorrectsAndFillsOnlyWithOnPageEvidence(t *testing.T) {
 
 	var dropped []droppedFinding
 	x := evidenceExtractor{brain: brain, drops: func(_ string, d droppedFinding) { dropped = append(dropped, d) }}
-	got := synthesizeSiteFields(context.Background(), x, synthesisFixturePages(), merged)
+	got := synthesizeSiteFields(context.Background(), x, synthesisFixturePages(), merged, false)
 
 	byField := map[string]evidencedField{}
 	for _, f := range got {
@@ -74,9 +74,43 @@ func TestSynthesisFailureKeepsThePerPageMerge(t *testing.T) {
 	merged := []evidencedField{
 		{Field: "legal_name", Value: "Acme Robotics GmbH", EvidenceSnippet: "Acme Robotics GmbH", SourceURL: seedURL + "/impressum", Confidence: 0.7},
 	}
-	got := synthesizeSiteFields(context.Background(), evidenceExtractor{brain: failingBrain{}}, synthesisFixturePages(), merged)
+	got := synthesizeSiteFields(context.Background(), evidenceExtractor{brain: failingBrain{}}, synthesisFixturePages(), merged, false)
 	if len(got) != 1 || got[0].Value != "Acme Robotics GmbH" {
 		t.Fatalf("a synthesis failure cost the read its merged fields: %+v", got)
+	}
+}
+
+func TestSynthesisUnderALegalConflictCannotReintroduceTheLegalTrio(t *testing.T) {
+	merged := []evidencedField{
+		{Field: "display_name", Value: "Acme", EvidenceSnippet: "Acme ships robots", SourceURL: seedURL, Confidence: 0.9},
+	}
+	// The reply corrects display_name (allowed) and tries to fill
+	// legal_name with perfectly valid on-page evidence — which the
+	// multi-entity conflict must still refuse.
+	brain := ai.NewFakeClient().Script(`{"fields":[
+		{"field":"display_name","value":"Acme Robotics","evidence_snippet":"Acme Robotics GmbH","source_url":"` + seedURL + `/impressum","confidence":0.9},
+		{"field":"legal_name","value":"Acme Robotics GmbH","evidence_snippet":"Acme Robotics GmbH","source_url":"` + seedURL + `/impressum","confidence":0.9}]}`)
+
+	var dropped []droppedFinding
+	x := evidenceExtractor{brain: brain, drops: func(_ string, d droppedFinding) { dropped = append(dropped, d) }}
+	got := synthesizeSiteFields(context.Background(), x, synthesisFixturePages(), merged, true)
+
+	for _, f := range got {
+		if f.Field == "legal_name" {
+			t.Fatalf("the legal conflict was overridden by synthesis: %+v", f)
+		}
+	}
+	if len(got) != 1 || got[0].Value != "Acme Robotics" {
+		t.Fatalf("the non-legal correction should still apply: %+v", got)
+	}
+	var conflictDrop bool
+	for _, d := range dropped {
+		if d.Field == "legal_name" && d.Reason == dropLegalConflict {
+			conflictDrop = true
+		}
+	}
+	if !conflictDrop {
+		t.Fatalf("the refused legal_name left no legal_conflict drop record: %+v", dropped)
 	}
 }
 
@@ -84,7 +118,7 @@ func TestSynthesisSkipsWhenNothingWasExtracted(t *testing.T) {
 	// An empty merge means the per-page gate evidenced nothing; the
 	// synthesis call must not run and become a second extraction pass.
 	brain := ai.NewFakeClient()
-	got := synthesizeSiteFields(context.Background(), evidenceExtractor{brain: brain}, synthesisFixturePages(), nil)
+	got := synthesizeSiteFields(context.Background(), evidenceExtractor{brain: brain}, synthesisFixturePages(), nil, false)
 	if got != nil {
 		t.Fatalf("synthesis over an empty merge returned %+v", got)
 	}

--- a/backend/internal/compose/evidencematch.go
+++ b/backend/internal/compose/evidencematch.go
@@ -88,6 +88,10 @@ const (
 	dropNameRoleUnlinked  = "name_role_not_in_snippet"
 	dropEmptyValueKey     = "empty_value_key"
 	dropUnparseableReply  = "unparseable_reply"
+	// dropLegalConflict marks a legal-trio claim refused because the
+	// site's legal pages disagree on the entity: with no trustworthy
+	// override, no lane may smuggle one back in.
+	dropLegalConflict = "legal_conflict_no_override"
 )
 
 // droppedFinding is one gate rejection, kept for the drop sink instead

--- a/backend/internal/compose/sitecrawl.go
+++ b/backend/internal/compose/sitecrawl.go
@@ -237,6 +237,7 @@ type crawlRun struct {
 	queue         []crawlCandidate
 	visited       map[string]bool
 	seenText      map[string]bool
+	canonicalDone map[string]bool
 	probeKindDone map[crmcontracts.SiteReadPageKind]bool
 	totalBytes    int
 }
@@ -257,6 +258,7 @@ func newCrawlRun(c *siteCrawler, pacer crawlPacer, seedURL string, seedPage webr
 		},
 		visited:       visited,
 		seenText:      map[string]bool{seedPage.Text: true},
+		canonicalDone: map[string]bool{localeCanonical(seedURL): true},
 		probeKindDone: map[crmcontracts.SiteReadPageKind]bool{},
 		totalBytes:    seedPage.Bytes,
 	}
@@ -297,6 +299,21 @@ func (r *crawlRun) visit(ctx context.Context, cand crawlCandidate) {
 		// entry — the path was our guess, not a page the site offered.
 		return
 	}
+	kind := cand.kind
+	if kind == "" {
+		kind = classifyKind(candURL)
+	}
+	if kind != crmcontracts.SiteReadPageKindImpressum && r.canonicalDone[localeCanonical(candURL)] {
+		// A locale variant of a page already read (/de/about after
+		// /about): a translation restates the same document, and exact-
+		// text dedupe cannot see that. Fetching every language would burn
+		// the page budget on repeats — one language per document. Legal
+		// pages are EXEMPT from the collapse: the multi-entity conflict
+		// guard (mergeCrawlFields) can only count entities on the legal
+		// pages it actually reads, and a domain that mounts different
+		// entities under locale-variant legal paths must still trip it.
+		return
+	}
 	if strings.HasSuffix(strings.ToLower(candURL), ".xml") {
 		// A sitemapindex's <loc>s are child sitemaps; the crawl deliberately
 		// does not recurse into them (bounded discovery), and an XML file is
@@ -311,13 +328,13 @@ func (r *crawlRun) visit(ctx context.Context, cand crawlCandidate) {
 		return
 	}
 
-	r.fetchAndRecord(ctx, cand, candURL)
+	r.fetchAndRecord(ctx, cand, candURL, kind)
 }
 
 // fetchAndRecord is visit's tail once the candidate is admissible (same-site,
 // not a duplicate probe, not an XML index): fetch it, and either record a skip
 // with its reason or append the page and enqueue its links.
-func (r *crawlRun) fetchAndRecord(ctx context.Context, cand crawlCandidate, candURL string) {
+func (r *crawlRun) fetchAndRecord(ctx context.Context, cand crawlCandidate, candURL string, kind crmcontracts.SiteReadPageKind) {
 	fetchStart := time.Now()
 	page, err := r.crawler.fetchPaced(ctx, r.pacer, candURL)
 	fetchDur := time.Since(fetchStart)
@@ -357,11 +374,8 @@ func (r *crawlRun) fetchAndRecord(ctx context.Context, cand crawlCandidate, cand
 	}
 
 	r.seenText[page.Text] = true
+	r.canonicalDone[localeCanonical(candURL)] = true
 	r.totalBytes += page.Bytes
-	kind := cand.kind
-	if kind == "" {
-		kind = classifyKind(candURL)
-	}
 	if cand.probe {
 		r.probeKindDone[cand.kind] = true
 	}

--- a/backend/internal/compose/sitecrawl_test.go
+++ b/backend/internal/compose/sitecrawl_test.go
@@ -366,6 +366,43 @@ func TestCrawlSpendsAScarcePageBudgetOnFactPagesBeforeBlogLinks(t *testing.T) {
 	}
 }
 
+func TestCrawlReadsOneLanguagePerDocumentButEveryLegalPage(t *testing.T) {
+	site := &fakeSite{pages: seedOnly()}
+	// The same three documents mounted under four locales, plus one page
+	// that exists ONLY under a locale prefix — that one must still be
+	// read. Legal pages are exempt from the collapse: the multi-entity
+	// conflict guard can only count what it reads, so every locale's
+	// imprint is fetched.
+	for _, path := range []string{"/about", "/imprint", "/pricing"} {
+		site.sitemap = append(site.sitemap, seedURL+path)
+		site.pages[seedURL+path] = fakeSitePage{text: readable("en " + path)}
+		for _, locale := range []string{"/de", "/vi", "/th"} {
+			site.sitemap = append(site.sitemap, seedURL+locale+path)
+			site.pages[seedURL+locale+path] = fakeSitePage{text: readable(locale + path)}
+		}
+	}
+	site.sitemap = append(site.sitemap, seedURL+"/de/karriere")
+	site.pages[seedURL+"/de/karriere"] = fakeSitePage{text: readable("/de/karriere")}
+
+	crawl, err := testSiteCrawler(site).Crawl(context.Background(), seedURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got []string
+	for _, page := range crawl.Pages {
+		got = append(got, page.URL)
+	}
+	want := []string{
+		seedURL,
+		seedURL + "/imprint", seedURL + "/about", // the probes lead
+		seedURL + "/de/imprint", seedURL + "/vi/imprint", seedURL + "/th/imprint",
+		seedURL + "/pricing", seedURL + "/de/karriere",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("wrong collapse: locale variants must dedupe EXCEPT legal pages:\n got %v\nwant %v", got, want)
+	}
+}
+
 func TestNormalizeCandidateStripsTrackingParamsSoVariantsDedupe(t *testing.T) {
 	plain, ok := normalizeCandidate(seedURL + "/about")
 	if !ok {

--- a/backend/internal/compose/sitecrawlrank.go
+++ b/backend/internal/compose/sitecrawlrank.go
@@ -48,6 +48,41 @@ func candidatePriority(cand crawlCandidate) int {
 	return priOther
 }
 
+// localePrefixes are the path-leading language tags multilingual sites
+// mount translations under. Deliberately an allowlist of common tags,
+// not a generic two-letter pattern: a generic match would eat real
+// pages like /go or /ai. Ambiguity remains possible (/it can be a
+// language or an IT-services page) — the dedupe below only fires when
+// the SAME path without the prefix was already read, which keeps the
+// false-positive to sites that pair such a page with an identical
+// unprefixed one.
+var localePrefixes = map[string]bool{
+	"en": true, "de": true, "fr": true, "es": true, "it": true, "pt": true,
+	"nl": true, "pl": true, "cs": true, "sv": true, "da": true, "no": true,
+	"fi": true, "ru": true, "uk": true, "tr": true, "ar": true, "he": true,
+	"ja": true, "ko": true, "th": true, "vi": true, "id": true, "ms": true,
+	"zh": true, "hi": true, "el": true, "ro": true, "hu": true, "bg": true,
+	"en-us": true, "en-gb": true, "de-de": true, "de-at": true, "de-ch": true,
+	"zh-cn": true, "zh-tw": true, "pt-br": true, "es-mx": true, "fr-ca": true,
+}
+
+// localeCanonical reduces a URL to its language-independent identity:
+// the host plus the path with one leading locale segment stripped (and
+// the query kept — it may address a distinct document). A URL with no
+// locale prefix is its own canonical form.
+func localeCanonical(rawURL string) string {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	segments := strings.Split(strings.TrimPrefix(parsed.Path, "/"), "/")
+	if len(segments) > 0 && localePrefixes[strings.ToLower(segments[0])] {
+		parsed.Path = "/" + strings.Join(segments[1:], "/")
+	}
+	parsed.Fragment = ""
+	return parsed.String()
+}
+
 // boilerplatePath spots archive-shaped URLs (blogs, news, tag/category
 // listings, paginated indexes, dated posts) whose pages rarely state
 // company facts.

--- a/backend/internal/compose/sitereaddebug.go
+++ b/backend/internal/compose/sitereaddebug.go
@@ -120,7 +120,7 @@ func siteReadDebugRun(ctx context.Context, opts SiteReadDebugOptions, crawler *s
 	}
 	if report.ModelLaneError == "" {
 		rec.page = laneSynthesis
-		mergedFields = synthesizeSiteFields(ctx, extract, crawl.Pages[:len(perPage)], mergedFields)
+		mergedFields = synthesizeSiteFields(ctx, extract, crawl.Pages[:len(perPage)], mergedFields, legalConflict)
 	}
 	mergedFacts := mergeCategoryFacts(perPage)
 	mergedPeople := mergeTeamPeople(perPage)


### PR DESCRIPTION
## Why

Live debugging against gradion.com (via `worker siteread`, #111) showed three defects: **31 of 40 crawl slots** were the same about pages re-fetched under `/de /vi /th /ar /ja` while the entire consulting catalog fell off the page cap; the synthesis pass **reintroduced a legal_name** the multi-entity guard had just refused; and with the override cancelled, **marketing-copy claims filled the legal fields** (`registered_address: "Zurich and Ho Chi Minh City"` off a consulting page).

## What

- **Locale-variant dedupe** — `localeCanonical` (allowlist of language tags, deliberately not a regex) + `canonicalDone` skip pre-fetch: one language per document. A page existing only under a locale prefix is still read. **Legal pages are exempt** — the multi-entity conflict guard can only count entities on pages it actually reads (security-review finding, fixed + tested).
- **Full legal abstention** — a legal-entity conflict now strips the legal trio from the surviving side too: no legal identity is proposed at all; the human resolves it.
- **Synthesis honors the verdict** — under a conflict, legal-trio corrections from the synthesis call are refused and recorded as `legal_conflict_no_override` drops.

## Verification

- `make check-backend` green; compose unit tests cover the collapse, the exemption, the abstention, and the synthesis refusal.
- Live on gradion.com (40 pages): products 15 / services 4 / team 4 / about 9 / impressum 6 (was about 31, catalog cut); facts 62→82; conflict warning surfaced; zero wrong-entity legal fields; verified on both Haiku and Sonnet.
- Craft + security review subagents ran twice (initial + delta); all findings applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)