### PR TITLE
docs(status): the email-ingestion pipeline and its deferred pieces

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -22,6 +22,52 @@ The merge gate (`make check`), the real-Postgres integration lane
 
 ## Recently landed
 
+**Email ingestion — from fragment to nightly, every-user pipeline
+(ADR-0063, 2026-07-19)** — capture was operationally fragile (one 429
+permanently killed a connection) and mail never became a person. It is
+now a production feature: connect a mailbox, a bounded backfill fills the
+CRM under a preview-before-spend estimate, and a continuous + nightly
+pipeline grows it — persons, companies, employment edges, timeline
+activities, AI classification and signature enrichment, all deduped
+through one resolver. Landed across ten PRs:
+
+- **Sync hardening** (#106): a transient failure never kills a
+  connection — the `capture_sync_state` sidecar, the error taxonomy
+  (429/Retry-After, unreachable backoff, auth→reauth), the per-connection
+  dispatcher; `error` is degraded-and-probed-daily, never a tombstone.
+- **Gmail** — one-click connect (#107), the Pub/Sub push webhook (#110)
+  with Google **OIDC** token verification (#113, salvaged + credited from
+  a duplicate community PR).
+- **IMAP** as a standing connection (#112): UID cursor bound to its
+  mailbox, vault-sealed credentials, bounded incremental fetch.
+- **Bounded backfill** (#117): 3/6/12-month widen-only windows, the
+  ADR-0020 estimate-before-spend, per-page cursor commits with honest
+  resume, cancel keeps captured rows; the M2 window→estimate→activation
+  UI.
+- **Auto-create + core AI** (#120): every captured mail ensures its
+  counterparty through the **ONE dedupe chokepoint** (PO-F-1/PO-F-2) —
+  exact reuses, fuzzy creates-and-records; person + domain-named company
+  + employment edge + person-only activity link, owner-visibility until a
+  human promotes, punycode/impersonation quarantine, erased addresses
+  stay dead (A13); `engagement.reply` (CAP-FORMULA-1) enters the event
+  catalog. The §2.8 **classify** batch (commitment/meeting/noise, per-call
+  commit, budget-clean stop), §2.9 evidence-or-omit **signature enrich**
+  (`person_profile_field`, fill-only-empty, never overwrites a human),
+  the DH-EXT-1/2 **dedupe review queue** (+ the M4 screen) executing the
+  one merge verb, the CAP-DDL-6 morning **digest** (+ `GET /digest` + home
+  card) and `GET /ai/usage`.
+- **Manual creates** meet the same chokepoint (#118): exact still 409s,
+  fuzzy creates and records the near-match.
+- **Microsoft Graph** connector (#119): delta-cursor sync with 410
+  re-anchor, bounded backfill, one-click connect — sharing the extracted
+  `capture/oauthflow` handshake with Gmail (the OAuth2 flow lives once,
+  not mirrored).
+
+The spec package landed first, contract-first, in the sibling
+`margince-foundation` repo (ADR-0063 + the capture / people-and-orgs /
+ai-operational / data-hygiene chapter amendments); this code is built
+from it.
+
 **Deep read v3 — reference evidence + page-parallel lanes (founder
 target ≤15 s, 2026-07-18)** — v2's one corpus call hit the output-token
 wall (~9k quoted-evidence tokens ≈ 150 s). v3 makes the model *read*
@@ -306,6 +352,32 @@ tooling and gate suite the baseline needs. Merged so far:
 ## Pick up here
 
 Open work, roughly in priority order:
+
+- **Email ingestion — deferred pieces of ADR-0063** (the pipeline is
+  live; these were scoped out, not missed):
+  - **Graph webhook (PR-7b)** — the connector is poll-only; the
+    change-notification subscription (validationToken handshake,
+    clientState, ≤3-day renewal riding the existing watch sweep) is
+    unbuilt, so Outlook latency is the poll interval, not the 60s p95.
+  - **Graph refresh-token rotation** — Microsoft rotates the refresh
+    token on each redemption; the stored original works within its
+    ~90-day confidential-client window (active mailboxes never reauth),
+    but persisting the rotated token needs a **credential-update seam**
+    (Sync surfacing an updated credential for the registry to re-seal) that
+    `connector.Connector` does not have — a cross-connector follow-up.
+  - **Dedupe undo of a *merged* pair** answers `409 not_undoable` — the
+    merge verb's reversibility (PO-AC-M6) is not built; dismissals undo
+    fine.
+  - **Nightly dispatcher consolidation** — classify, enrich and digest run
+    as their own daily River jobs (run-on-start); the ADR-0063 staggered
+    coordinator (catch-up → classify → reconcile → enrich → dedupe sweep →
+    digest, one ordered pass) is not yet a single dispatcher, and the
+    `capture_reconcile` sweep over link-less connector activities is
+    unbuilt.
+  - **`ai_usage` RBAC object** — `GET /ai/usage` is gated on the
+    admin-held `automation:update` permission (no `ai_usage` noun exists
+    in the closed RBAC object set); a dedicated object should be pinned
+    upstream (spec-repo reconciliation).
 
 - **Deep-read durability-hardening pass** (from the #103 review, deferred
   as cross-cutting rather than rushed per-effect) — the redeem-then-execute


### PR DESCRIPTION
Session write-up: records the email-ingestion arc under *Recently landed* and its deferred ADR-0063 pieces under *Pick up here*. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)