### PR TITLE
fix(ai): reasoning-model output cap + cert-export input & UI

### DIFF
--- a/backend/internal/compose/aicert/judge.go
+++ b/backend/internal/compose/aicert/judge.go
@@ -20,16 +20,12 @@ import (
 )
 
 // defaultRunMaxTokens bounds a candidate completion when a scenario
-// names no caps.max_tokens. It carries the same thinking headroom
-// judgeMaxTokens does: a reasoning model (Gemini 2.5, o-series) spends
-// output tokens on internal thinking BEFORE its answer, and that
-// thinking counts against maxOutputTokens — a tight cap starves the
-// answer into a MAX_TOKENS stop with zero visible text. The failure is
-// worst on the premium rung, where a heavier-thinking model (e.g.
-// gemini-2.5-pro) an escalation lands on can burn a small cap entirely
-// on thought. Generous enough for any V1 task's answer plus that
-// thinking, still small enough that a runaway completion terminates.
-const defaultRunMaxTokens = 8192
+// names no caps.max_tokens. It is the shared reasoning-headroom output
+// ceiling (ai.ReasoningOutputMaxTokens): a reasoning model spends output
+// tokens on internal thinking before its answer, so a cap sized for the
+// answer alone starves it into a MAX_TOKENS stop with zero visible text.
+// See that constant's doc for the full rationale.
+const defaultRunMaxTokens = ai.ReasoningOutputMaxTokens
 
 // judgeMaxTokens bounds the judge's own reply. The verdict is one line
 // of JSON, but reasoning models (Gemini 2.5, o-series) spend output

--- a/backend/internal/compose/briefs/briefl2.go
+++ b/backend/internal/compose/briefs/briefl2.go
@@ -41,11 +41,6 @@ type briefL2Ranker struct {
 	log   *slog.Logger
 }
 
-// briefL2MaxTokens bounds the re-order response: a permutation of at most
-// a handful of candidate ids is small, and the cap keeps a runaway model
-// from spending the run's whole budget on this advisory step.
-const briefL2MaxTokens = 1024
-
 // briefL2System instructs the model to re-rank the deterministic
 // candidates and return ONLY their own ids. The bounding step enforces
 // this regardless of what the model returns, so the prompt is guidance,
@@ -93,7 +88,7 @@ func (rk briefL2Ranker) askModel(ctx context.Context, candidates []BriefQueueIte
 	resp, err := rk.brain.Complete(ctx, model.Request{
 		System:         briefL2System,
 		Messages:       []model.Message{{Role: "user", Content: b.String()}},
-		MaxTokens:      briefL2MaxTokens,
+		MaxTokens:      ai.ReasoningOutputMaxTokens,
 		SecretStripper: ai.NewSecretStripper(),
 	})
 	if err != nil {

--- a/backend/internal/compose/captureclassify.go
+++ b/backend/internal/compose/captureclassify.go
@@ -191,7 +191,7 @@ func (c *CaptureClassifier) ask(ctx context.Context, batch []unlabeledMessage) (
 	req := model.Request{
 		System:         classifySystem,
 		Messages:       []model.Message{{Role: chatRoleUser, Content: prompt.String()}},
-		MaxTokens:      1024,
+		MaxTokens:      ai.ReasoningOutputMaxTokens,
 		ResponseSchema: classifySchema(),
 		SecretStripper: ai.NewSecretStripper(),
 	}

--- a/backend/internal/compose/captureenrich.go
+++ b/backend/internal/compose/captureenrich.go
@@ -118,7 +118,7 @@ func (e *CaptureEnricher) enrichOne(ctx context.Context, cand people.SignatureCa
 	req := model.Request{
 		System:         signatureEnrichSystem,
 		Messages:       []model.Message{{Role: chatRoleUser, Content: prompt.String()}},
-		MaxTokens:      512,
+		MaxTokens:      ai.ReasoningOutputMaxTokens,
 		ResponseSchema: signatureEnrichSchema(),
 		SecretStripper: ai.NewSecretStripper(),
 	}

--- a/backend/internal/compose/enrichextract.go
+++ b/backend/internal/compose/enrichextract.go
@@ -365,7 +365,7 @@ func (x evidenceExtractor) extractFields(ctx context.Context, sourceLabel, sourc
 			Role:    "user",
 			Content: fmt.Sprintf("%s:\n<untrusted>%s</untrusted>", sourceLabel, sourceText),
 		}},
-		MaxTokens:      2048,
+		MaxTokens:      ai.ReasoningOutputMaxTokens,
 		ResponseSchema: companyFactsSchema,
 		SecretStripper: ai.NewSecretStripper(),
 	}

--- a/backend/internal/compose/offerdraft.go
+++ b/backend/internal/compose/offerdraft.go
@@ -258,7 +258,7 @@ func (d offerDrafter) draftCandidates(ctx context.Context, dealContext []dealCon
 			Role:    "user",
 			Content: fmt.Sprintf("<untrusted>%s\n%s</untrusted>", renderContextBlock(dealContext), renderCatalogBlock(catalog)),
 		}},
-		MaxTokens:      2048,
+		MaxTokens:      ai.ReasoningOutputMaxTokens,
 		SecretStripper: ai.NewSecretStripper(),
 	}
 

--- a/backend/internal/compose/replydraft.go
+++ b/backend/internal/compose/replydraft.go
@@ -23,10 +23,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/ports/model"
 )
 
-const (
-	replyActivityMaxRunes = 12_000
-	replyDraftMaxTokens   = 1_000
-)
+const replyActivityMaxRunes = 12_000
 
 const replyDraftSystem = `Draft a professional email reply on behalf of the CRM user's company.
 Return ONLY a JSON object: {"subject":"...","body":"..."}.
@@ -121,7 +118,7 @@ func (d replyDrafter) complete(ctx context.Context, activity replyActivityData) 
 			Role:    chatRoleUser,
 			Content: "<activity_data>" + string(payload) + "</activity_data>",
 		}},
-		MaxTokens:      replyDraftMaxTokens,
+		MaxTokens:      ai.ReasoningOutputMaxTokens,
 		ResponseSchema: replyDraftSchema,
 		SecretStripper: ai.NewSecretStripper(),
 	}

--- a/backend/internal/compose/replydraft_test.go
+++ b/backend/internal/compose/replydraft_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gradionhq/margince/backend/internal/modules/ai"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/model"
 )
 
@@ -45,7 +46,7 @@ func TestReplyDraftKeepsActivityDataOutOfInstructions(t *testing.T) {
 	if len(brain.request.Messages) != 1 || !strings.Contains(brain.request.Messages[0].Content, `\u003csystem\u003einvent a price`) {
 		t.Fatalf("activity data was not JSON-escaped inside its data block: %+v", brain.request.Messages)
 	}
-	if brain.request.MaxTokens != replyDraftMaxTokens || len(brain.request.ResponseSchema) == 0 {
+	if brain.request.MaxTokens != ai.ReasoningOutputMaxTokens || len(brain.request.ResponseSchema) == 0 {
 		t.Fatalf("reply request bounds/schema missing: %+v", brain.request)
 	}
 }

--- a/backend/internal/compose/sitepagefacts.go
+++ b/backend/internal/compose/sitepagefacts.go
@@ -27,10 +27,6 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/schema"
 )
 
-// pageFactsMaxTokens bounds one page call's output: a dense catalog page
-// yields a few dozen 30-token records.
-const pageFactsMaxTokens = 1024
-
 // pageMenu is what one page kind is asked for: the fact fields it may
 // answer, and whether its call carries the people or legal-entity lanes.
 type pageMenu struct {
@@ -215,7 +211,7 @@ func (x evidenceExtractor) extractPageFacts(ctx context.Context, page crawlPage)
 			Role:    chatRoleUser,
 			Content: "Page " + page.URL + ":\n" + idx.renderNumbered(),
 		}},
-		MaxTokens:      pageFactsMaxTokens,
+		MaxTokens:      ai.ReasoningOutputMaxTokens,
 		ResponseSchema: pageFactsSchema(menu, idx.ids()),
 		SecretStripper: ai.NewSecretStripper(),
 	}

--- a/backend/internal/compose/siteprofile.go
+++ b/backend/internal/compose/siteprofile.go
@@ -32,8 +32,6 @@ const (
 	// profile in their first passages, and prefill time on this call is
 	// on the read's critical path.
 	profileExcerptBudgetRunes = 18_000
-	// profileMaxTokens bounds the call's output: 11 compact field records.
-	profileMaxTokens = 1024
 	// profileImpressumExcerptRunes caps ONE legal page's excerpt share:
 	// every legal page must be represented (the trio quotes from them),
 	// but a site with many impressum-classified pages must not inflate
@@ -139,7 +137,7 @@ func (x evidenceExtractor) extractProfile(ctx context.Context, pages []crawlPage
 	req := model.Request{
 		System:         profileSystem,
 		Messages:       []model.Message{{Role: chatRoleUser, Content: idx.renderNumbered()}},
-		MaxTokens:      profileMaxTokens,
+		MaxTokens:      ai.ReasoningOutputMaxTokens,
 		ResponseSchema: profileSchema(idx.ids()),
 		SecretStripper: ai.NewSecretStripper(),
 	}

--- a/backend/internal/modules/ai/output.go
+++ b/backend/internal/modules/ai/output.go
@@ -5,6 +5,19 @@ package ai
 
 import "strings"
 
+// ReasoningOutputMaxTokens is the output-token cap every structured
+// model lane sets on a Request. It carries thinking headroom:
+// a reasoning model (Gemini 2.5, o-series) spends output tokens on
+// internal thinking BEFORE its answer, and that thinking counts against
+// maxOutputTokens — so a cap sized for the answer alone starves the
+// answer into a MAX_TOKENS stop with zero visible text. The failure is
+// worst on the premium rung (e.g. gemini-2.5-pro), which every V1 task's
+// ladder can escalate to. This value is generous enough for any V1 lane's
+// answer plus that thinking, still small enough that a runaway completion
+// terminates. The aicert lane's default candidate-completion cap derives
+// from this same constant — one source for the reasoning-headroom ceiling.
+const ReasoningOutputMaxTokens = 8192
+
 // Unfence strips a ```json … ``` code fence some models wrap JSON in, so
 // one reduction defines what every downstream shape check and gate
 // parses — the callers (enrichment extraction, the brief L2 re-order)

--- a/backend/internal/modules/ai/payloadcapture.go
+++ b/backend/internal/modules/ai/payloadcapture.go
@@ -15,6 +15,14 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/ports/model"
 )
 
+// capturedMessage is the ai_call_payload wire shape of one request
+// message: model.Message with the lowercase JSON keys every payload
+// reader expects (the trace UI and the cert-scenario export).
+type capturedMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
 // buildPayload assembles the Layer-3 capture: the request's semantic
 // content (system + messages) run through the SAME secret-stripper that
 // guards egress, and the model's response text — both as JSON. The
@@ -29,14 +37,18 @@ func (r *Router) buildPayload(ctx context.Context, req model.Request, resp model
 	// individually under the field cap.
 	budget := captureBudget{remaining: maxCapturedRequestRunes}
 	system := budget.take(req.System)
-	msgs := make([]model.Message, len(req.Messages))
+	// model.Message carries no JSON tags, so marshaling it directly emits
+	// "Role"/"Content" — out of step with the lowercase "system"/"messages"
+	// envelope keys and with every reader of ai_call_payload (the trace UI
+	// and the cert-scenario export both key on lowercase role/content). Map
+	// to a locally-tagged shape so the stored document is uniformly lowercase.
+	msgs := make([]capturedMessage, len(req.Messages))
 	for i, m := range req.Messages {
-		m.Content = budget.take(m.Content)
-		msgs[i] = m
+		msgs[i] = capturedMessage{Role: m.Role, Content: budget.take(m.Content)}
 	}
 	reqDoc, err := json.Marshal(struct {
-		System   string          `json:"system"`
-		Messages []model.Message `json:"messages"`
+		System   string            `json:"system"`
+		Messages []capturedMessage `json:"messages"`
 	}{system, msgs})
 	if err != nil {
 		return nil, fmt.Errorf("ai: marshal capture request: %w", err)

--- a/frontend/src/design-system/atoms.css
+++ b/frontend/src/design-system/atoms.css
@@ -132,6 +132,11 @@
   max-height: calc(100dvh - 40px);
   overflow-y: auto;
 }
+/* Roomier variant for content-dense dialogs (e.g. the cert-scenario export's
+   YAML + response previews) that read cramped at the compact form width. */
+.modal-wide {
+  width: min(720px, calc(100vw - 40px));
+}
 .modal .actions {
   display: flex;
   justify-content: flex-end;

--- a/frontend/src/design-system/atoms.tsx
+++ b/frontend/src/design-system/atoms.tsx
@@ -156,11 +156,15 @@ export function Modal({
   open,
   onClose,
   labelledBy,
+  size = "default",
   children,
 }: Readonly<{
   open: boolean;
   onClose: () => void;
   labelledBy: string;
+  // "wide" roomier variant for content-dense dialogs (code/YAML previews);
+  // "default" keeps the compact form width every confirm/create modal uses.
+  size?: "default" | "wide";
   children: ReactNode;
 }>) {
   useEffect(() => {
@@ -195,7 +199,7 @@ export function Modal({
         role="dialog"
         aria-modal="true"
         aria-labelledby={labelledBy}
-        className="modal"
+        className={size === "wide" ? "modal modal-wide" : "modal"}
       >
         {children}
       </div>

--- a/frontend/src/design-system/base.css
+++ b/frontend/src/design-system/base.css
@@ -91,3 +91,31 @@
 .t-mono {
   font-family: var(--f-mono);
 }
+
+/* Code / payload preview surface (AI observability: the call-trace panel and
+   the cert-scenario export). Wraps long single-line JSON/YAML and scrolls in
+   place rather than widening its container. */
+.code-block {
+  margin: 0;
+  max-height: 300px;
+  overflow: auto;
+  padding: var(--space-3);
+  border: 1px solid var(--borderSubtle);
+  border-radius: var(--r-sm);
+  background: var(--bgCard);
+  color: var(--textContent);
+  font-family: var(--f-mono);
+  font-size: 12px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+/* Small uppercase label sitting above a code-block or preview section. */
+.code-label {
+  display: block;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--textMeta);
+}

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1514,6 +1514,8 @@ export const de = {
   "aiexport.copyFailed":
     "Kopieren fehlgeschlagen — Vorschau verwenden oder Datei herunterladen.",
   "aiexport.close": "Schließen",
+  "aiexport.previewLabel": "Szenariovorschau",
+  "aiexport.responseLabel": "Modellantwort",
 
   "countdown.minutesSeconds": "{minutes}m {seconds}s",
   "countdown.expired": "Abgelaufen",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1485,6 +1485,8 @@ export const en = {
   "aiexport.download": "Download .yaml",
   "aiexport.copyFailed": "Copy failed — use the preview or download instead.",
   "aiexport.close": "Close",
+  "aiexport.previewLabel": "Scenario preview",
+  "aiexport.responseLabel": "Model response",
 
   "countdown.minutesSeconds": "{minutes}m {seconds}s",
   "countdown.expired": "Expired",

--- a/frontend/src/screens/aicalls.tsx
+++ b/frontend/src/screens/aicalls.tsx
@@ -13,6 +13,12 @@ import { useLocale, useT } from "../i18n";
 import { ExportScenarioDialog } from "./aiexport";
 import { problemMessage, QueryStates } from "./common";
 
+// A string response is shown verbatim (real newlines); an object is
+// pretty-printed. Either way the .code-block surface wraps and scrolls it.
+function payloadText(value: unknown): string {
+  return typeof value === "string" ? value : JSON.stringify(value, null, 2);
+}
+
 export function CallDetailPanel({
   id,
   captureEnabled,
@@ -71,23 +77,32 @@ export function CallDetailPanel({
             <p>{t("aicalls.payload.none")}</p>
           ) : (
             <>
-              <h3>{t("aicalls.detail.request")}</h3>
-              <pre
-                className="t-mono"
-                style={{ maxHeight: 260, overflow: "auto" }}
+              <div
+                className="form-stack"
+                style={{ marginTop: "var(--space-3)" }}
               >
-                {JSON.stringify(query.data.payload.request, null, 2)}
-              </pre>
-              <h3>{t("aicalls.detail.response")}</h3>
-              <pre
-                className="t-mono"
-                style={{ maxHeight: 260, overflow: "auto" }}
-              >
-                {JSON.stringify(query.data.payload.response, null, 2)}
-              </pre>
-              <Button small onClick={() => setExporting(true)}>
-                {t("aiexport.button")}
-              </Button>
+                <div className="field">
+                  <span className="code-label">
+                    {t("aicalls.detail.request")}
+                  </span>
+                  <pre className="code-block">
+                    {payloadText(query.data.payload.request)}
+                  </pre>
+                </div>
+                <div className="field">
+                  <span className="code-label">
+                    {t("aicalls.detail.response")}
+                  </span>
+                  <pre className="code-block">
+                    {payloadText(query.data.payload.response)}
+                  </pre>
+                </div>
+                <div>
+                  <Button small onClick={() => setExporting(true)}>
+                    {t("aiexport.button")}
+                  </Button>
+                </div>
+              </div>
               {exporting && (
                 <ExportScenarioDialog
                   call={query.data}

--- a/frontend/src/screens/aiexport.css
+++ b/frontend/src/screens/aiexport.css
@@ -1,0 +1,26 @@
+/* Cert-scenario export dialog. The body is a form-stack; these classes add
+   the PII callout and the code-preview surfaces the shared atoms don't cover. */
+
+/* PII acknowledgment: a warn-toned callout (not a bare badge) so the gate
+   before copy/download reads as the deliberate review step it is. */
+.aiexport-callout {
+  display: flex;
+  gap: var(--space-2);
+  align-items: flex-start;
+  padding: var(--space-3);
+  border: 1px solid var(--warnBorder);
+  border-radius: var(--r-sm);
+  background: var(--warnBg);
+  color: var(--warn);
+  font-size: 13px;
+  line-height: 1.45;
+}
+.aiexport-callout input {
+  margin-top: 2px;
+  flex: none;
+}
+
+.aiexport-error {
+  color: var(--danger);
+  font-size: 13px;
+}

--- a/frontend/src/screens/aiexport.test.tsx
+++ b/frontend/src/screens/aiexport.test.tsx
@@ -22,19 +22,9 @@ afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
-  Reflect.deleteProperty(HTMLDialogElement.prototype, "showModal");
   Reflect.deleteProperty(URL, "createObjectURL");
   Reflect.deleteProperty(URL, "revokeObjectURL");
 });
-
-function installDialogModal() {
-  Object.defineProperty(HTMLDialogElement.prototype, "showModal", {
-    configurable: true,
-    value: vi.fn(function showModal(this: HTMLDialogElement) {
-      this.open = true;
-    }),
-  });
-}
 
 it("builds an explicitly unreviewed corpus scaffold with safe block scalars", () => {
   const yaml = scenarioYaml(call, "My Run!");
@@ -48,7 +38,6 @@ it("builds an explicitly unreviewed corpus scaffold with safe block scalars", ()
 });
 
 it("requires PII acknowledgment before copying or downloading", async () => {
-  installDialogModal();
   const writeText = vi.fn(async () => undefined);
   Object.defineProperty(navigator, "clipboard", {
     configurable: true,
@@ -83,7 +72,6 @@ it("requires PII acknowledgment before copying or downloading", async () => {
 });
 
 it("surfaces clipboard rejection", async () => {
-  installDialogModal();
   Object.defineProperty(navigator, "clipboard", {
     configurable: true,
     value: {

--- a/frontend/src/screens/aiexport.tsx
+++ b/frontend/src/screens/aiexport.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useRef, useState } from "react";
+import { useId, useState } from "react";
 import type { components } from "../api/schema";
-import { Badge, Button, TextInput } from "../design-system/atoms";
+import { Button, Modal, TextInput } from "../design-system/atoms";
 import { useT } from "../i18n";
+import "./aiexport.css";
 
 export type AiCallDetail = Pick<
   components["schemas"]["AiCall"],
@@ -13,24 +14,31 @@ type CapturedRequest = {
   messages?: { role: string; content: string }[];
 };
 
+// A captured message's keys are read case-insensitively: model.Message
+// carries no JSON tags, so payloads captured before that was fixed stored
+// "Role"/"Content" while current captures store lowercase — both must
+// yield a usable `input`, never a silently empty one.
+function stringField(source: object, ...keys: string[]): string | undefined {
+  for (const key of keys) {
+    if (key in source) {
+      const value = (source as Record<string, unknown>)[key];
+      if (typeof value === "string") return value;
+    }
+  }
+  return undefined;
+}
+
 function capturedRequest(value: unknown): CapturedRequest {
   if (typeof value !== "object" || value === null) return {};
-  const system =
-    "system" in value && typeof value.system === "string"
-      ? value.system
-      : undefined;
+  const system = stringField(value, "system", "System");
   const messages: CapturedRequest["messages"] = [];
   if ("messages" in value && Array.isArray(value.messages)) {
     for (const message of value.messages) {
-      if (
-        typeof message === "object" &&
-        message !== null &&
-        "role" in message &&
-        typeof message.role === "string" &&
-        "content" in message &&
-        typeof message.content === "string"
-      ) {
-        messages.push({ role: message.role, content: message.content });
+      if (typeof message !== "object" || message === null) continue;
+      const role = stringField(message, "role", "Role");
+      const content = stringField(message, "content", "Content");
+      if (role !== undefined && content !== undefined) {
+        messages.push({ role, content });
       }
     }
   }
@@ -76,16 +84,17 @@ export function ExportScenarioDialog({
 }: Readonly<{ call: AiCallDetail; onClose: () => void }>) {
   const t = useT();
   const defaultName = `${call.task}_run_${call.occurred_at.slice(0, 10).replaceAll("-", "")}`;
-  const dialogRef = useRef<HTMLDialogElement>(null);
+  const headingId = useId();
   const [name, setName] = useState(defaultName);
   const [copied, setCopied] = useState(false);
   const [copyFailed, setCopyFailed] = useState(false);
   const [acknowledged, setAcknowledged] = useState(false);
   const yaml = scenarioYaml(call, name);
-
-  useEffect(() => {
-    dialogRef.current?.showModal();
-  }, []);
+  // A string response is shown verbatim (real newlines) rather than as an
+  // escaped JSON string — the reviewer authors `expect:` from this text.
+  const response = call.payload?.response;
+  const responseText =
+    typeof response === "string" ? response : JSON.stringify(response, null, 2);
 
   async function copyYaml() {
     if (!navigator.clipboard) {
@@ -114,44 +123,61 @@ export function ExportScenarioDialog({
   }
 
   return (
-    <dialog ref={dialogRef} aria-label={t("aiexport.title")} onClose={onClose}>
-      <h2>{t("aiexport.title")}</h2>
-      <label htmlFor="cert-scenario-name">
-        {t("aiexport.nameLabel")}
-        <TextInput
-          id="cert-scenario-name"
-          value={name}
-          onChange={(event) => setName(event.target.value)}
-        />
-      </label>
-      <p>
-        <label>
+    <Modal open onClose={onClose} labelledBy={headingId} size="wide">
+      <h2
+        id={headingId}
+        className="t-h2"
+        style={{ marginBottom: "var(--space-3)" }}
+      >
+        {t("aiexport.title")}
+      </h2>
+      <div className="form-stack">
+        <div className="field">
+          <label className="t-label" htmlFor="cert-scenario-name">
+            {t("aiexport.nameLabel")}
+          </label>
+          <TextInput
+            id="cert-scenario-name"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+          />
+        </div>
+        <div className="aiexport-callout">
           <input
+            id="cert-pii-ack"
             type="checkbox"
             checked={acknowledged}
             onChange={(event) => setAcknowledged(event.target.checked)}
           />
-          <Badge tone="warn">{t("aiexport.checklist")}</Badge>
-        </label>
-      </p>
-      <pre className="t-mono" style={{ maxHeight: 320, overflow: "auto" }}>
-        {yaml}
-      </pre>
-      <pre className="t-mono" style={{ maxHeight: 180, overflow: "auto" }}>
-        {JSON.stringify(call.payload?.response, null, 2)}
-      </pre>
-      <div style={{ display: "flex", gap: "var(--space-2)" }}>
+          <label htmlFor="cert-pii-ack">{t("aiexport.checklist")}</label>
+        </div>
+        <div className="field">
+          <span className="code-label">{t("aiexport.previewLabel")}</span>
+          <pre className="code-block">{yaml}</pre>
+        </div>
+        <div className="field">
+          <span className="code-label">{t("aiexport.responseLabel")}</span>
+          <pre className="code-block">{responseText}</pre>
+        </div>
+        {copyFailed && (
+          <p role="alert" className="aiexport-error">
+            {t("aiexport.copyFailed")}
+          </p>
+        )}
+      </div>
+      <div className="actions">
+        <Button onClick={onClose}>{t("aiexport.close")}</Button>
         <Button disabled={!acknowledged} onClick={() => void copyYaml()}>
           {copied ? t("aiexport.copied") : t("aiexport.copy")}
         </Button>
-        <Button disabled={!acknowledged} onClick={downloadYaml}>
+        <Button
+          variant="primary"
+          disabled={!acknowledged}
+          onClick={downloadYaml}
+        >
           {t("aiexport.download")}
         </Button>
-        <Button aria-label={t("aiexport.close")} onClick={onClose}>
-          ×
-        </Button>
       </div>
-      {copyFailed && <p role="alert">{t("aiexport.copyFailed")}</p>}
-    </dialog>
+    </Modal>
   );
 }


### PR DESCRIPTION
Follow-up to #136 (runtime observability / cert export), surfaced while testing the "Read my website" onboarding path.

## Problems fixed

**1. `cold_start` enrichment failed with `MAX_TOKENS` and zero output.**
Gemini 2.5 (and o-series) spend output tokens on internal thinking before the answer, and that counts against `maxOutputTokens`. The structured extraction/draft lanes capped output at 512–2048 (sized for the answer alone), so on a reasoning tier the thinking burned the whole budget → `finishReason=MAX_TOKENS`, `tokens_out=0`, "every bound tier failed for cold_start".

Consolidated the scattered per-lane caps into one documented constant `ai.ReasoningOutputMaxTokens = 8192` (the value the aicert lane already trusts for these models) and routed every lane + the cert candidate default through it.

**2. Cert-scenario export produced an empty, unusable `input:`.**
`model.Message` has no JSON tags, so captured payloads stored `"Role"`/`"Content"`; the trace UI and exporter read lowercase → empty message list.
- Backend: capture messages through a locally-tagged struct so `ai_call_payload` is uniformly lowercase.
- Frontend: the reader tolerates either casing, so already-captured rows also export a populated `input` without a re-run; a string response renders verbatim instead of an escaped JSON string.

Note: `source: run_export` / `sanitized_by: unreviewed` and the absence of a model-output field are **by design** — the export is a review scaffold (`LoadCorpus` requires `hand_authored`), and a Scenario holds expectations, not the recorded output.

**3. Trace/export UI polish (per the design system).**
- Shared `.code-block` / `.code-label` primitives (`base.css`) for wrapping, inset payload previews — fixes the horizontal overflow that widened the trace table.
- Export dialog now uses the shared `Modal` atom (new additive `size="wide"` variant) with a warn-toned PII callout and `form-stack` rhythm, replacing the bare off-style native `<dialog>`.

## Verification
- `make check-backend` — green
- `make check-fe` — green
- Craft-static + craft-reviewer + security-redteam — clean on the backend diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)