### PR TITLE
feat(compose): the composer — AI draft, confirm-first send + consent gate, relink (§6 / B7)

### DIFF
--- a/frontend/src/design-system/composed.css
+++ b/frontend/src/design-system/composed.css
@@ -162,9 +162,15 @@
 }
 .timeline li {
   display: flex;
+  align-items: center;
   gap: 10px;
   padding: 10px 0;
   border-bottom: 1px solid var(--borderSubtle);
+}
+.timeline .tl-actions {
+  margin-left: auto;
+  display: flex;
+  gap: 6px;
 }
 .timeline li:last-child {
   border-bottom: 0;

--- a/frontend/src/design-system/composed.stories.tsx
+++ b/frontend/src/design-system/composed.stories.tsx
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Button } from "./atoms";
+import { RecordView, type TimelineEntry } from "./composed";
+
+// RecordView's timeline gained an optional per-row `actions` slot (the Reply /
+// Relink cluster the 360 screens mount). These stories exercise both shapes:
+// rows without an affordance render exactly as before, and rows that carry an
+// action node get the right-aligned slot — so a render regression in either
+// path is caught here rather than only in the screen that composes it.
+
+const emailEntry: TimelineEntry = {
+  id: "a1",
+  kind: "email",
+  title: "Re: Q3 renewal terms",
+  atIso: "2026-07-01T09:12:00Z",
+  provenance: { kind: "human" },
+};
+const meetingEntry: TimelineEntry = {
+  id: "a2",
+  kind: "meeting",
+  title: "Discovery call",
+  atIso: "2026-06-24T14:00:00Z",
+  provenance: { kind: "agent", agent: "capture" },
+};
+const noteEntry: TimelineEntry = {
+  id: "a3",
+  kind: "note",
+  title: "Left a voicemail",
+  atIso: "2026-06-20T16:30:00Z",
+  provenance: { kind: "human" },
+};
+const baseTimeline: TimelineEntry[] = [emailEntry, meetingEntry, noteEntry];
+
+const meta: Meta<typeof RecordView> = {
+  title: "Design System/RecordView",
+  component: RecordView,
+};
+export default meta;
+
+type Story = StoryObj<typeof RecordView>;
+
+// The unchanged shape: no row carries an action, so every entry renders as it
+// did before the slot existed.
+export const Default: Story = {
+  args: {
+    name: "Acme GmbH",
+    subtitle: "Enterprise · Munich",
+    zone: "Europe/Berlin",
+    timeline: baseTimeline,
+  },
+};
+
+// The new slot: the email row carries a Reply action, the meeting row a Relink
+// action, and the note row none — the right-aligned cluster only appears where
+// an affordance is supplied.
+export const WithRowActions: Story = {
+  args: {
+    name: "Acme GmbH",
+    subtitle: "Enterprise · Munich",
+    zone: "Europe/Berlin",
+    timeline: [
+      {
+        ...emailEntry,
+        actions: (
+          <Button small onClick={() => {}}>
+            Reply
+          </Button>
+        ),
+      },
+      {
+        ...meetingEntry,
+        actions: (
+          <Button small onClick={() => {}}>
+            Relink
+          </Button>
+        ),
+      },
+      noteEntry,
+    ],
+  },
+};

--- a/frontend/src/design-system/composed.test.tsx
+++ b/frontend/src/design-system/composed.test.tsx
@@ -139,4 +139,28 @@ describe("RecordView + timeline", () => {
     expect(screen.getByText("agent: capture")).toBeTruthy();
     expect(screen.getByText("typed by you")).toBeTruthy();
   });
+
+  it("renders a timeline entry's action slot when present", () => {
+    render(
+      <RecordView
+        name="Acme"
+        zone="UTC"
+        timeline={[
+          {
+            id: "a1",
+            kind: "email",
+            title: "Re: Q3",
+            atIso: "2026-07-01T00:00:00Z",
+            provenance: { kind: "human" },
+            actions: (
+              <button type="button" key="reply">
+                Reply
+              </button>
+            ),
+          },
+        ]}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "Reply" })).toBeTruthy();
+  });
 });

--- a/frontend/src/design-system/composed.tsx
+++ b/frontend/src/design-system/composed.tsx
@@ -209,6 +209,9 @@ export type TimelineEntry = {
   title: string;
   atIso: string;
   provenance: Provenance;
+  // A right-aligned per-row action slot (Reply / Relink). Absent on rows with
+  // no affordance, which render exactly as before.
+  actions?: ReactNode;
 };
 
 const TIMELINE_ICON = {
@@ -262,6 +265,9 @@ export function RecordView({
                     <ProvenanceTag provenance={entry.provenance} />
                   </span>
                 </span>
+                {entry.actions && (
+                  <span className="tl-actions">{entry.actions}</span>
+                )}
               </li>
             );
           })}

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -635,6 +635,39 @@ export const de = {
   "log.save": "Erfassen",
   "log.saving": "Wird erfasst…",
 
+  "compose.reply": "Antworten",
+  "compose.relink": "Neu verknüpfen",
+  "compose.draftWithAi": "Mit KI entwerfen",
+  "compose.drafting": "Wird entworfen…",
+  "compose.intent": 'Entwurf steuern (optional), z. B. "höfliche Nachfrage"',
+  "compose.to": "An",
+  "compose.cc": "Cc",
+  "compose.subject": "Betreff",
+  "compose.body": "Nachricht",
+  "compose.purpose": "Einwilligungszweck",
+  "compose.purposeHint":
+    "Der Versand ist nur erlaubt, wenn jeder Empfänger für diesen Zweck eingewilligt hat.",
+  "compose.send": "Senden",
+  "compose.sendConfirmTitle": "Diese E-Mail senden?",
+  "compose.sendBody":
+    "Sie senden diese E-Mail jetzt. Dies ist eine ausgehende, unwiderrufliche Aktion.",
+  "compose.consentBlockedTitle": "Versand blockiert — keine Einwilligung",
+  "compose.consentBlocked":
+    "Ein Empfänger hat für diesen Zweck nicht eingewilligt, daher wurde der Versand unterdrückt (Standard-Ablehnung).",
+  "compose.consentGoto": "Einwilligung prüfen",
+  "compose.draftUnavailable":
+    "KI-Entwurf ist nicht verfügbar (das Modell ist nicht konfiguriert). Sie können die E-Mail weiterhin selbst schreiben.",
+  "compose.sendUnavailable":
+    "Versand ist nicht verfügbar (kein Mailer konfiguriert).",
+  "compose.relinkTitle": "Diese Aktivität neu verknüpfen",
+  "compose.relinkTarget": "Person, Organisation, Deal oder Lead suchen",
+  "compose.relinkReplace": "Verschieben statt zusätzlich verknüpfen",
+  "compose.relinkReplaceHint":
+    "Ersetzt die bestehende Verknüpfung desselben Typs, statt eine weitere hinzuzufügen.",
+  "compose.relinkConfirm": "Neu verknüpfen",
+  "compose.emptyRecipients": "Fügen Sie mindestens einen Empfänger hinzu.",
+  "compose.addRecipient": "Empfänger hinzufügen",
+
   "tasks.overdue": "Überfällig",
   "tasks.today": "Heute",
   "tasks.upcoming": "Demnächst",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -666,7 +666,9 @@ export const de = {
     "Ersetzt die bestehende Verknüpfung desselben Typs, statt eine weitere hinzuzufügen.",
   "compose.relinkConfirm": "Neu verknüpfen",
   "compose.emptyRecipients": "Fügen Sie mindestens einen Empfänger hinzu.",
-  "compose.addRecipient": "Empfänger hinzufügen",
+  "compose.removeRecipient": "{recipient} entfernen",
+  "compose.actionFailed":
+    "Die Anfrage ist fehlgeschlagen. Bitte erneut versuchen.",
 
   "tasks.overdue": "Überfällig",
   "tasks.today": "Heute",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -622,6 +622,39 @@ export const en = {
   "log.save": "Log",
   "log.saving": "Logging…",
 
+  "compose.reply": "Reply",
+  "compose.relink": "Relink",
+  "compose.draftWithAi": "Draft with AI",
+  "compose.drafting": "Drafting…",
+  "compose.intent": 'Steer the draft (optional), e.g. "polite follow-up"',
+  "compose.to": "To",
+  "compose.cc": "Cc",
+  "compose.subject": "Subject",
+  "compose.body": "Body",
+  "compose.purpose": "Consent purpose",
+  "compose.purposeHint":
+    "The send is allowed only if every recipient has granted consent for this purpose.",
+  "compose.send": "Send",
+  "compose.sendConfirmTitle": "Send this email?",
+  "compose.sendBody":
+    "You are sending this email now. This is an outbound, irreversible action.",
+  "compose.consentBlockedTitle": "Send blocked — no consent",
+  "compose.consentBlocked":
+    "A recipient has not granted consent for this purpose, so the send was suppressed (default-deny).",
+  "compose.consentGoto": "Review consent",
+  "compose.draftUnavailable":
+    "AI drafting is unavailable (the model is not configured). You can still write the email yourself.",
+  "compose.sendUnavailable":
+    "Sending is unavailable (no mailer is configured).",
+  "compose.relinkTitle": "Relink this activity",
+  "compose.relinkTarget": "Search a person, organization, deal, or lead",
+  "compose.relinkReplace": "Move instead of also-link",
+  "compose.relinkReplaceHint":
+    "Replaces the existing link of the same type rather than adding another.",
+  "compose.relinkConfirm": "Relink",
+  "compose.emptyRecipients": "Add at least one recipient.",
+  "compose.addRecipient": "Add recipient",
+
   "tasks.overdue": "Overdue",
   "tasks.today": "Today",
   "tasks.upcoming": "Upcoming",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -653,7 +653,8 @@ export const en = {
     "Replaces the existing link of the same type rather than adding another.",
   "compose.relinkConfirm": "Relink",
   "compose.emptyRecipients": "Add at least one recipient.",
-  "compose.addRecipient": "Add recipient",
+  "compose.removeRecipient": "Remove {recipient}",
+  "compose.actionFailed": "The request failed. Please try again.",
 
   "tasks.overdue": "Overdue",
   "tasks.today": "Today",

--- a/frontend/src/screens/common.test.tsx
+++ b/frontend/src/screens/common.test.tsx
@@ -12,6 +12,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { LocaleProvider } from "../i18n";
 import {
   canManageCustomFields,
+  isConsentNotGranted,
   problemExistingId,
   throwProblem,
 } from "./common";
@@ -84,6 +85,15 @@ describe("CreateAction dedupe link", () => {
     );
     await userEvent.click(screen.getByText("View existing record"));
     await waitFor(() => expect(window.location.hash).toBe("#/contacts/01ABC"));
+  });
+});
+
+describe("isConsentNotGranted", () => {
+  it("detects the consent gate 409 code", () => {
+    expect(isConsentNotGranted({ code: "consent_not_granted" })).toBe(true);
+    expect(isConsentNotGranted({ code: "version_skew" })).toBe(false);
+    expect(isConsentNotGranted(null)).toBe(false);
+    expect(isConsentNotGranted("nope")).toBe(false);
   });
 });
 

--- a/frontend/src/screens/common.tsx
+++ b/frontend/src/screens/common.tsx
@@ -326,6 +326,17 @@ export function isAlreadyDecided(problem: unknown): boolean {
   return record.code === "already_decided";
 }
 
+// A 409 whose code names the consent suppression gate: the send's recipients
+// have no active `granted` person_consent for the purpose it falls under
+// (default-deny per purpose, A22/ADR-0011). Distinguished from RBAC (403) and
+// validation (422) so the composer can point the user at the consent surface
+// rather than showing a raw server detail.
+export function isConsentNotGranted(problem: unknown): boolean {
+  if (!problem || typeof problem !== "object") return false;
+  const record = problem as Record<string, unknown>;
+  return record.code === "consent_not_granted";
+}
+
 // The cold-start / enrichment field vocabulary (compose/enrichextract.go)
 // rendered as human labels; an unmapped field falls back to its key with the
 // underscores spaced out — readable, never raw snake_case.

--- a/frontend/src/screens/compose.css
+++ b/frontend/src/screens/compose.css
@@ -23,16 +23,12 @@
   flex: 1;
 }
 
+/* Border, radius, padding, fill, and focus ring come from the shared .textarea
+ * atom; this only sets the composer's size and resize affordance. */
 .compose-body {
   width: 100%;
   min-height: 120px;
   resize: vertical;
-  padding: 8px 10px;
-  border: 1px solid var(--borderSubtle);
-  border-radius: 8px;
-  background: var(--bgCard);
-  color: var(--textPrimary);
-  font: inherit;
 }
 
 .recipient-field {
@@ -53,7 +49,7 @@
   align-items: center;
   gap: 4px;
   padding: 2px 8px;
-  border-radius: 999px;
+  border-radius: var(--r-full);
   background: var(--bgHover);
   color: var(--textContent);
 }
@@ -71,6 +67,6 @@
   flex-direction: column;
   gap: 6px;
   padding: 10px;
-  border-radius: 8px;
+  border-radius: var(--r-sm);
   background: var(--dangerBg);
 }

--- a/frontend/src/screens/compose.css
+++ b/frontend/src/screens/compose.css
@@ -1,0 +1,76 @@
+/* Composer modal layout only — the modal chrome, inputs, and picker come from
+ * confirmmodal / atoms / recordpicker. Tokens only (ds-purity). */
+
+.compose-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+.compose-check {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.compose-draftbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.compose-draftbar .input {
+  flex: 1;
+}
+
+.compose-body {
+  width: 100%;
+  min-height: 120px;
+  resize: vertical;
+  padding: 8px 10px;
+  border: 1px solid var(--borderSubtle);
+  border-radius: 8px;
+  background: var(--bgCard);
+  color: var(--textPrimary);
+  font: inherit;
+}
+
+.recipient-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.recipient-field .chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.recipient-field .chips li {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--bgHover);
+  color: var(--textContent);
+}
+.recipient-field .chips button {
+  border: 0;
+  background: none;
+  color: var(--textMeta);
+  cursor: pointer;
+  line-height: 1;
+  padding: 0;
+}
+
+.compose-consent-block {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px;
+  border-radius: 8px;
+  background: var(--dangerBg);
+}

--- a/frontend/src/screens/compose.stories.tsx
+++ b/frontend/src/screens/compose.stories.tsx
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { userEvent, within } from "storybook/test";
+import type { components } from "../api/schema";
+import { ComposeModal, RelinkModal } from "./compose";
+import {
+  installFetchStub,
+  jsonResponse,
+  type RouteMap,
+  StoryProviders,
+} from "./story-utils";
+
+// The composer surface (draftEmail / sendEmail / relinkActivity) rendered off
+// the same fixture shapes compose.test.tsx exercises — never a live call. The
+// interesting states are reachable only through the form (draft, send-confirm),
+// so each story that needs one drives it in `play` with the same userEvent
+// steps the unit tests use, keeping the captured frame faithful to a real run.
+
+// One consent purpose is enough to satisfy the Send precondition and populate
+// the purpose <select>; its `key` ("transactional") is the wire value a send
+// carries. Mirrors compose.test.tsx's PURPOSES, not an invented shape.
+const PURPOSES = {
+  data: [
+    {
+      id: "p1",
+      workspace_id: "w",
+      key: "transactional",
+      label: "Deal messages",
+      requires_double_opt_in: false,
+      created_at: "2026-01-01T00:00:00Z",
+    },
+  ],
+  page: { next_cursor: null, has_more: false },
+};
+
+const DRAFT: components["schemas"]["EmailDraft"] = {
+  subject: "Re: Q3 numbers",
+  body: "Thanks for the note — following up as promised.",
+  to: ["buyer@acme.test"],
+};
+
+// Renders the composer over a given route map, always serving the consent
+// purposes the purpose selector needs on top of the story's own routes.
+function composeStory(routes: RouteMap) {
+  return () => {
+    installFetchStub({
+      "GET /consent-purposes": () => jsonResponse(PURPOSES),
+      ...routes,
+    });
+    return (
+      <StoryProviders>
+        <ComposeModal
+          activityId="act-1"
+          entityType="person"
+          entityId="p-1"
+          personId="p-1"
+          open
+          onClose={() => {}}
+        />
+      </StoryProviders>
+    );
+  };
+}
+
+// Fills the four Send preconditions (To, subject, body, purpose) then confirms
+// — the same sequence fillSendableForm drives in compose.test.tsx, so a story
+// reaches the send outcome (409 gate / 501 unavailable) it means to capture.
+async function fillAndSend(canvasElement: HTMLElement) {
+  const canvas = within(canvasElement);
+  await userEvent.type(canvas.getByLabelText("To"), "buyer@acme.test");
+  await userEvent.tab();
+  await userEvent.type(canvas.getByPlaceholderText("Subject"), "Following up");
+  await userEvent.type(canvas.getByPlaceholderText("Body"), "As promised.");
+  await userEvent.selectOptions(canvas.getByRole("combobox"), "transactional");
+  await userEvent.click(canvas.getByRole("button", { name: "Send" }));
+}
+
+const meta: Meta = {
+  title: "screens/compose",
+};
+export default meta;
+
+type Story = StoryObj;
+
+// The composer as it opens: empty fields, the draft bar, and Send disabled
+// until the four preconditions are met.
+export const Empty: Story = {
+  render: composeStory({}),
+};
+
+// "Draft with AI" fills To/Subject/Body from the returned EmailDraft.
+export const Drafted: Story = {
+  render: composeStory({
+    "POST /activities/act-1/draft-email": () => jsonResponse(DRAFT),
+  }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      canvas.getByRole("button", { name: "Draft with AI" }),
+    );
+  },
+};
+
+// The default-deny consent gate (A22/ADR-0011): a filled, confirmed send comes
+// back 409 consent_not_granted, so the modal stays open with the pointed
+// "Review consent" copy instead of a raw server error.
+export const ConsentBlocked: Story = {
+  render: composeStory({
+    "POST /activities/act-1/send-email": () =>
+      jsonResponse(
+        {
+          code: "consent_not_granted",
+          title: "Conflict",
+          detail: "suppressed",
+        },
+        409,
+      ),
+  }),
+  play: async ({ canvasElement }) => {
+    await fillAndSend(canvasElement);
+  },
+};
+
+// No mailer configured: the send answers 501, surfaced as an honest inline
+// "Sending is unavailable" note, never thrown into the error channel.
+export const SendUnavailable: Story = {
+  render: composeStory({
+    "POST /activities/act-1/send-email": () =>
+      jsonResponse(
+        { title: "Not Implemented", detail: "mailer not wired" },
+        501,
+      ),
+  }),
+  play: async ({ canvasElement }) => {
+    await fillAndSend(canvasElement);
+  },
+};
+
+// The relink dialog: a cross-object /search returns a few candidates that the
+// RecordPicker lists once the user types a query.
+export const Default: Story = {
+  render: () => {
+    installFetchStub({
+      "GET /search": () =>
+        jsonResponse({
+          data: [
+            { type: "deal", id: "d-9", title: "Acme renewal" },
+            { type: "organization", id: "o-2", title: "Acme GmbH" },
+            { type: "person", id: "pp-1", title: "Jane Doe" },
+          ],
+          page: { has_more: false },
+        }),
+    });
+    return (
+      <StoryProviders>
+        <RelinkModal
+          activityId="act-1"
+          entityType="person"
+          entityId="p-1"
+          open
+          onClose={() => {}}
+        />
+      </StoryProviders>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.type(canvas.getByRole("searchbox"), "Acme");
+  },
+};

--- a/frontend/src/screens/compose.test.tsx
+++ b/frontend/src/screens/compose.test.tsx
@@ -394,6 +394,54 @@ describe("ComposeModal", () => {
     expect(await screen.findByText(/Sending is unavailable/i)).toBeTruthy();
     expect(onClose).not.toHaveBeenCalled();
   });
+
+  it("does not report a send on a bodiless non-2xx (gateway 5xx)", async () => {
+    const onClose = vi.fn();
+    // openapi-fetch yields a falsy error for a bodiless response; success must
+    // be the real 202, so an empty 503 stays an error and keeps the modal open
+    // rather than falsely confirming an irreversible send.
+    stubRoutes({
+      "POST /activities/act-1/send-email": () => emptyResponse(503),
+    });
+    render(
+      <ComposeModal
+        activityId="act-1"
+        entityType="person"
+        entityId="p-1"
+        open
+        onClose={onClose}
+      />,
+    );
+    await screen.findByRole("combobox");
+    await fillSendableForm();
+    await userEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    expect(await screen.findByText(/The request failed/i)).toBeTruthy();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("shows a draft error on a bodiless non-2xx without crashing the fill", async () => {
+    // The old !error success path would fabricate an undefined draft and crash
+    // onSuccess reading its fields; a bodiless 502 must surface an error only.
+    stubRoutes({
+      "POST /activities/act-1/draft-email": () => emptyResponse(502),
+    });
+    render(
+      <ComposeModal
+        activityId="act-1"
+        entityType="person"
+        entityId="p-1"
+        open
+        onClose={vi.fn()}
+      />,
+    );
+    await screen.findByRole("combobox");
+    await userEvent.click(
+      screen.getByRole("button", { name: "Draft with AI" }),
+    );
+
+    expect(await screen.findByText(/The request failed/i)).toBeTruthy();
+  });
 });
 
 describe("TimelineActions", () => {

--- a/frontend/src/screens/compose.test.tsx
+++ b/frontend/src/screens/compose.test.tsx
@@ -445,64 +445,39 @@ describe("ComposeModal", () => {
 });
 
 describe("TimelineActions", () => {
-  const emailLinked: Activity = {
+  const email: Activity = {
     ...activity202,
     id: "a1",
     kind: "email",
-    links: [{ entity_type: "deal", entity_id: "d1" }],
   };
-  const noteLinked: Activity = {
+  const note: Activity = {
     ...activity202,
     id: "a2",
     kind: "note",
-    links: [{ entity_type: "deal", entity_id: "d1" }],
-  };
-  const noteBare: Activity = {
-    ...activity202,
-    id: "a3",
-    kind: "note",
-    links: [],
   };
 
-  it("offers Reply on email rows and Relink on linked rows", () => {
+  it("offers Reply on an email row and Relink alongside it", () => {
     stubRoutes();
     render(
-      <TimelineActions
-        activity={emailLinked}
-        entityType="deal"
-        entityId="d1"
-      />,
+      <TimelineActions activity={email} entityType="deal" entityId="d1" />,
     );
     expect(screen.getByRole("button", { name: "Reply" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Relink" })).toBeTruthy();
   });
 
-  it("offers Relink but not Reply on a linked non-email row", () => {
+  it("offers Relink but not Reply on a non-email row", () => {
     stubRoutes();
-    render(
-      <TimelineActions activity={noteLinked} entityType="deal" entityId="d1" />,
-    );
+    render(<TimelineActions activity={note} entityType="deal" entityId="d1" />);
     expect(screen.queryByRole("button", { name: "Reply" })).toBeNull();
+    // Relink is always available — the row is already linked to this timeline's
+    // entity, and the Activity list payload carries no `links` to gate on.
     expect(screen.getByRole("button", { name: "Relink" })).toBeTruthy();
-  });
-
-  it("renders nothing for a bare note with no links", () => {
-    stubRoutes();
-    render(
-      <TimelineActions activity={noteBare} entityType="deal" entityId="d1" />,
-    );
-    expect(screen.queryByRole("button", { name: "Reply" })).toBeNull();
-    expect(screen.queryByRole("button", { name: "Relink" })).toBeNull();
   });
 
   it("opens the composer when Reply is clicked", async () => {
     stubRoutes();
     render(
-      <TimelineActions
-        activity={emailLinked}
-        entityType="deal"
-        entityId="d1"
-      />,
+      <TimelineActions activity={email} entityType="deal" entityId="d1" />,
     );
     await userEvent.click(screen.getByRole("button", { name: "Reply" }));
     // The ConfirmModal titled "Send this email?" mounts only once Reply opens it.

--- a/frontend/src/screens/compose.test.tsx
+++ b/frontend/src/screens/compose.test.tsx
@@ -1,0 +1,207 @@
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  cleanup,
+  render as rtlRender,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { components } from "../api/schema";
+import { LocaleProvider } from "../i18n";
+import { RelinkModal } from "./compose";
+
+type Activity = components["schemas"]["Activity"];
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function render(ui: ReactNode) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return rtlRender(
+    <QueryClientProvider client={client}>
+      <LocaleProvider initial="en">{ui}</LocaleProvider>
+    </QueryClientProvider>,
+  );
+}
+
+const PURPOSES = {
+  data: [
+    {
+      id: "p1",
+      workspace_id: "w",
+      key: "transactional",
+      label: "Deal messages",
+      requires_double_opt_in: false,
+      created_at: "2026-01-01T00:00:00Z",
+    },
+  ],
+  page: { next_cursor: null, has_more: false },
+};
+
+// Records every request so a test can assert what actually went to the server
+// — the request body and headers ARE the contract for a send/relink.
+type Sent = { key: string; body: unknown; headers: Headers };
+
+function stubRoutes(overrides: Record<string, () => Response> = {}) {
+  const sent: Sent[] = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = input instanceof Request ? input : null;
+      const url = new URL(
+        request ? request.url : String(input),
+        "https://test.local",
+      );
+      const method = request?.method ?? init?.method ?? "GET";
+      const key = `${method} ${url.pathname.replace(/^\/v1/, "")}`;
+      let body: unknown = null;
+      if (method !== "GET") {
+        try {
+          body = request
+            ? await request.clone().json()
+            : JSON.parse(String(init?.body));
+        } catch {
+          body = null;
+        }
+      }
+      const headers = request
+        ? request.headers
+        : new Headers(init?.headers ?? {});
+      sent.push({ key, body, headers });
+      const override = overrides[key];
+      if (override) return override();
+      if (key === "GET /consent-purposes") return jsonResponse(PURPOSES);
+      return jsonResponse({});
+    }),
+  );
+  return sent;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+const activity202: Activity = {
+  id: "act-1",
+  workspace_id: "w",
+  kind: "email",
+  subject: "Re: Q3",
+  occurred_at: "2026-07-01T00:00:00Z",
+  source: "manual",
+  captured_by: "human:u1",
+};
+
+describe("RelinkModal", () => {
+  it("relinks the search-picked target and closes on 200", async () => {
+    const onClose = vi.fn();
+    const sent = stubRoutes({
+      "GET /search": () =>
+        jsonResponse({
+          data: [{ type: "deal", id: "d-9", title: "Acme renewal" }],
+          page: { has_more: false },
+        }),
+      "POST /activities/act-1/relink": () => jsonResponse(activity202),
+    });
+    render(
+      <RelinkModal
+        activityId="act-1"
+        entityType="person"
+        entityId="p-1"
+        open
+        onClose={onClose}
+      />,
+    );
+
+    await userEvent.type(screen.getByRole("searchbox"), "Acme");
+    const candidate = await screen.findByRole("button", {
+      name: "Acme renewal",
+    });
+    await userEvent.click(candidate);
+    await userEvent.click(screen.getByRole("button", { name: "Relink" }));
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+    const relink = sent.find((r) => r.key === "POST /activities/act-1/relink");
+    expect(relink?.body).toEqual({
+      entity_type: "deal",
+      entity_id: "d-9",
+      replace_existing_of_type: false,
+    });
+    // Relink is idempotency-keyed (its no-dup-on-replay contract).
+    expect(relink?.headers.get("Idempotency-Key")).toBeTruthy();
+  });
+
+  it("sends replace_existing_of_type when the move toggle is on", async () => {
+    const onClose = vi.fn();
+    const sent = stubRoutes({
+      "GET /search": () =>
+        jsonResponse({
+          data: [{ type: "organization", id: "o-2", title: "Globex" }],
+          page: { has_more: false },
+        }),
+      "POST /activities/act-1/relink": () => jsonResponse(activity202),
+    });
+    render(
+      <RelinkModal
+        activityId="act-1"
+        entityType="deal"
+        entityId="d-1"
+        open
+        onClose={onClose}
+      />,
+    );
+
+    await userEvent.type(screen.getByRole("searchbox"), "Globex");
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Globex" }),
+    );
+    await userEvent.click(screen.getByRole("checkbox"));
+    await userEvent.click(screen.getByRole("button", { name: "Relink" }));
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+    const relink = sent.find((r) => r.key === "POST /activities/act-1/relink");
+    expect(relink?.body).toEqual({
+      entity_type: "organization",
+      entity_id: "o-2",
+      replace_existing_of_type: true,
+    });
+  });
+
+  it("drops activity results — relink has no activity target", async () => {
+    stubRoutes({
+      "GET /search": () =>
+        jsonResponse({
+          data: [
+            { type: "activity", id: "a-x", title: "Some email" },
+            { type: "person", id: "pp-1", title: "Jane Doe" },
+          ],
+          page: { has_more: false },
+        }),
+    });
+    render(
+      <RelinkModal
+        activityId="act-1"
+        entityType="deal"
+        entityId="d-1"
+        open
+        onClose={vi.fn()}
+      />,
+    );
+
+    await userEvent.type(screen.getByRole("searchbox"), "e");
+    expect(
+      await screen.findByRole("button", { name: "Jane Doe" }),
+    ).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Some email" })).toBeNull();
+  });
+});

--- a/frontend/src/screens/compose.test.tsx
+++ b/frontend/src/screens/compose.test.tsx
@@ -11,7 +11,7 @@ import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { components } from "../api/schema";
 import { LocaleProvider } from "../i18n";
-import { ComposeModal, RelinkModal } from "./compose";
+import { ComposeModal, RelinkModal, TimelineActions } from "./compose";
 
 type Activity = components["schemas"]["Activity"];
 
@@ -390,5 +390,71 @@ describe("ComposeModal", () => {
 
     expect(await screen.findByText(/Sending is unavailable/i)).toBeTruthy();
     expect(onClose).not.toHaveBeenCalled();
+  });
+});
+
+describe("TimelineActions", () => {
+  const emailLinked: Activity = {
+    ...activity202,
+    id: "a1",
+    kind: "email",
+    links: [{ entity_type: "deal", entity_id: "d1" }],
+  };
+  const noteLinked: Activity = {
+    ...activity202,
+    id: "a2",
+    kind: "note",
+    links: [{ entity_type: "deal", entity_id: "d1" }],
+  };
+  const noteBare: Activity = {
+    ...activity202,
+    id: "a3",
+    kind: "note",
+    links: [],
+  };
+
+  it("offers Reply on email rows and Relink on linked rows", () => {
+    stubRoutes();
+    render(
+      <TimelineActions
+        activity={emailLinked}
+        entityType="deal"
+        entityId="d1"
+      />,
+    );
+    expect(screen.getByRole("button", { name: "Reply" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Relink" })).toBeTruthy();
+  });
+
+  it("offers Relink but not Reply on a linked non-email row", () => {
+    stubRoutes();
+    render(
+      <TimelineActions activity={noteLinked} entityType="deal" entityId="d1" />,
+    );
+    expect(screen.queryByRole("button", { name: "Reply" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Relink" })).toBeTruthy();
+  });
+
+  it("renders nothing for a bare note with no links", () => {
+    stubRoutes();
+    render(
+      <TimelineActions activity={noteBare} entityType="deal" entityId="d1" />,
+    );
+    expect(screen.queryByRole("button", { name: "Reply" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Relink" })).toBeNull();
+  });
+
+  it("opens the composer when Reply is clicked", async () => {
+    stubRoutes();
+    render(
+      <TimelineActions
+        activity={emailLinked}
+        entityType="deal"
+        entityId="d1"
+      />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Reply" }));
+    // The ConfirmModal titled "Send this email?" mounts only once Reply opens it.
+    expect(await screen.findByText("Send this email?")).toBeTruthy();
   });
 });

--- a/frontend/src/screens/compose.test.tsx
+++ b/frontend/src/screens/compose.test.tsx
@@ -11,7 +11,7 @@ import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { components } from "../api/schema";
 import { LocaleProvider } from "../i18n";
-import { RelinkModal } from "./compose";
+import { ComposeModal, RelinkModal } from "./compose";
 
 type Activity = components["schemas"]["Activity"];
 
@@ -19,6 +19,19 @@ function jsonResponse(body: unknown, status = 200) {
   return new Response(JSON.stringify(body), {
     status,
     headers: { "Content-Type": "application/json" },
+  });
+}
+
+// A 501 answer carries no JSON body (the mailer/model is simply not wired), so
+// the composer must branch on the raw status, not on a parsed problem.
+function emptyResponse(status: number) {
+  return new Response(null, { status });
+}
+
+function problemResponse(body: unknown, status: number) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/problem+json" },
   });
 }
 
@@ -203,5 +216,179 @@ describe("RelinkModal", () => {
       await screen.findByRole("button", { name: "Jane Doe" }),
     ).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Some email" })).toBeNull();
+  });
+});
+
+// Fills the four Send preconditions (To, subject, body, purpose) so a test can
+// then exercise the send outcome under study.
+async function fillSendableForm() {
+  await userEvent.type(screen.getByLabelText("To"), "a@x.com");
+  await userEvent.tab();
+  await userEvent.type(screen.getByPlaceholderText("Subject"), "Hi there");
+  await userEvent.type(screen.getByPlaceholderText("Body"), "Body content");
+  // The purpose <option> value is the ConsentPurpose.key the wire sends.
+  await userEvent.selectOptions(screen.getByRole("combobox"), "transactional");
+}
+
+describe("ComposeModal", () => {
+  it("fills To/Subject/Body from the AI draft", async () => {
+    stubRoutes({
+      "POST /activities/act-1/draft-email": () =>
+        jsonResponse({
+          subject: "Re: Q3 numbers",
+          body: "Thanks for the note.",
+          to: ["buyer@acme.test"],
+        }),
+    });
+    render(
+      <ComposeModal
+        activityId="act-1"
+        entityType="person"
+        entityId="p-1"
+        open
+        onClose={vi.fn()}
+      />,
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Draft with AI" }),
+    );
+
+    // getByDisplayValue reads the field's current value without a DOM cast.
+    expect(await screen.findByDisplayValue("Re: Q3 numbers")).toBeTruthy();
+    expect(screen.getByDisplayValue("Thanks for the note.")).toBeTruthy();
+    // EmailDraft.to prefills the recipient chips.
+    expect(screen.getByText("buyer@acme.test")).toBeTruthy();
+  });
+
+  it("shows an unavailable note on a 501 draft, keeping the form usable", async () => {
+    stubRoutes({
+      "POST /activities/act-1/draft-email": () => emptyResponse(501),
+    });
+    render(
+      <ComposeModal
+        activityId="act-1"
+        entityType="person"
+        entityId="p-1"
+        open
+        onClose={vi.fn()}
+      />,
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Draft with AI" }),
+    );
+
+    expect(await screen.findByText(/AI drafting is unavailable/i)).toBeTruthy();
+    // Manual composing still works — Send is present.
+    expect(screen.getByRole("button", { name: "Send" })).toBeTruthy();
+  });
+
+  it("keeps Send disabled until To, subject, body, and purpose are set", async () => {
+    stubRoutes();
+    render(
+      <ComposeModal
+        activityId="act-1"
+        entityType="person"
+        entityId="p-1"
+        open
+        onClose={vi.fn()}
+      />,
+    );
+    await screen.findByRole("combobox");
+
+    expect(
+      screen.getByRole("button", { name: "Send" }).hasAttribute("disabled"),
+    ).toBe(true);
+    await fillSendableForm();
+    expect(
+      screen.getByRole("button", { name: "Send" }).hasAttribute("disabled"),
+    ).toBe(false);
+  });
+
+  it("sends the edited email with no approval token or idempotency key", async () => {
+    const onClose = vi.fn();
+    const sent = stubRoutes({
+      "POST /activities/act-1/send-email": () => jsonResponse(activity202, 202),
+    });
+    render(
+      <ComposeModal
+        activityId="act-1"
+        entityType="person"
+        entityId="p-1"
+        open
+        onClose={onClose}
+      />,
+    );
+    await screen.findByRole("combobox");
+    await fillSendableForm();
+    await userEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+    const req = sent.find((r) => r.key === "POST /activities/act-1/send-email");
+    expect(req?.body).toEqual({
+      subject: "Hi there",
+      body: "Body content",
+      to: ["a@x.com"],
+      consent_purpose: "transactional",
+    });
+    // ADR-0055: the human click is the approval — neither header rides along.
+    expect(req?.headers.get("X-Approval-Token")).toBeNull();
+    expect(req?.headers.get("Idempotency-Key")).toBeNull();
+  });
+
+  it("surfaces the default-deny consent gate on 409 without closing", async () => {
+    const onClose = vi.fn();
+    stubRoutes({
+      "POST /activities/act-1/send-email": () =>
+        problemResponse(
+          {
+            code: "consent_not_granted",
+            detail: "suppressed",
+            title: "Conflict",
+          },
+          409,
+        ),
+    });
+    render(
+      <ComposeModal
+        activityId="act-1"
+        entityType="person"
+        entityId="p-1"
+        personId="p-1"
+        open
+        onClose={onClose}
+      />,
+    );
+    await screen.findByRole("combobox");
+    await fillSendableForm();
+    await userEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    expect(await screen.findByText(/has not granted consent/i)).toBeTruthy();
+    // The gate points at the consent surface, and the modal stays open.
+    expect(screen.getByRole("link", { name: "Review consent" })).toBeTruthy();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("shows a sending-unavailable note on a 501 send, not an error", async () => {
+    const onClose = vi.fn();
+    stubRoutes({
+      "POST /activities/act-1/send-email": () => emptyResponse(501),
+    });
+    render(
+      <ComposeModal
+        activityId="act-1"
+        entityType="person"
+        entityId="p-1"
+        open
+        onClose={onClose}
+      />,
+    );
+    await screen.findByRole("combobox");
+    await fillSendableForm();
+    await userEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    expect(await screen.findByText(/Sending is unavailable/i)).toBeTruthy();
+    expect(onClose).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/screens/compose.test.tsx
+++ b/frontend/src/screens/compose.test.tsx
@@ -111,8 +111,11 @@ const activity202: Activity = {
   kind: "email",
   subject: "Re: Q3",
   occurred_at: "2026-07-01T00:00:00Z",
+  is_done: false,
   source: "manual",
   captured_by: "human:u1",
+  created_at: "2026-07-01T00:00:00Z",
+  updated_at: "2026-07-01T00:00:00Z",
 };
 
 describe("RelinkModal", () => {

--- a/frontend/src/screens/compose.tsx
+++ b/frontend/src/screens/compose.tsx
@@ -242,11 +242,12 @@ export function ComposeModal({
         },
       );
       if (response.status === 501) return { available: false as const };
-      // Success is the real 2xx, never merely the absence of an error body:
-      // openapi-fetch reports a falsy `error` for a bodiless non-2xx (a gateway
-      // 502/503/504), which would otherwise fall through as a fabricated draft
-      // and crash the fill on undefined fields.
-      if (!response.ok) {
+      // Success is the real 2xx WITH a draft body, never merely the absence of
+      // an error: openapi-fetch reports a falsy `error` (and undefined `data`)
+      // for a bodiless non-2xx (a gateway 502/503/504), which would otherwise
+      // fall through as a fabricated draft and crash the fill on undefined
+      // fields. Requiring `data` here also re-narrows it for the fill below.
+      if (!response.ok || !data) {
         throw new Error(
           problemMessage(error || { title: t("compose.actionFailed") }),
         );

--- a/frontend/src/screens/compose.tsx
+++ b/frontend/src/screens/compose.tsx
@@ -419,8 +419,8 @@ export function ComposeModal({
 
 // The per-row action cluster the 360 timelines mount in each entry's action
 // slot. Reply opens the composer (email rows only — you don't reply to a
-// note); Relink opens the relink dialog for any row that already carries a
-// typed link (a freshly hand-logged note with no links has nothing to move).
+// note); Relink opens the relink dialog on every row (any timeline activity is
+// already linked to this entity, so it can be re-associated to the right one).
 // It owns the two open states so the timeline mapper stays presentational.
 export function TimelineActions({
   activity,
@@ -436,9 +436,12 @@ export function TimelineActions({
   const t = useT();
   const [reply, setReply] = useState(false);
   const [relink, setRelink] = useState(false);
+  // Reply only makes sense on an email. Relink is always available: an activity
+  // shown on a 360 timeline is, by construction, already linked to the entity
+  // whose timeline renders it, so re-associating it to the right record is
+  // always meaningful — and the Activity list payload does not carry `links` to
+  // gate on regardless.
   const canReply = activity.kind === "email";
-  const canRelink = (activity.links?.length ?? 0) >= 1;
-  if (!canReply && !canRelink) return null;
   return (
     <>
       {canReply && (
@@ -446,11 +449,9 @@ export function TimelineActions({
           {t("compose.reply")}
         </Button>
       )}
-      {canRelink && (
-        <Button small onClick={() => setRelink(true)}>
-          {t("compose.relink")}
-        </Button>
-      )}
+      <Button small onClick={() => setRelink(true)}>
+        {t("compose.relink")}
+      </Button>
       {reply && (
         <ComposeModal
           activityId={activity.id}

--- a/frontend/src/screens/compose.tsx
+++ b/frontend/src/screens/compose.tsx
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useRef, useState } from "react";
 import { api } from "../api/client";
+import type { components } from "../api/schema";
 import { Button, TextInput } from "../design-system/atoms";
 import { ConfirmModal } from "../design-system/confirmmodal";
 import {
@@ -21,6 +22,8 @@ import "./compose.css";
 // sendEmail / relinkActivity): a human's edit-then-confirm reply, and a
 // mis-captured activity's relink. Pure frontend — every op is live, audited,
 // and typed on the backend; this file only calls them.
+
+type Activity = components["schemas"]["Activity"];
 
 // The four link targets a relink can point at (relinkActivity's entity_type
 // enum). Reused by ComposeModal and TimelineActions so the whole surface
@@ -383,5 +386,62 @@ export function ComposeModal({
         )}
       </div>
     </ConfirmModal>
+  );
+}
+
+// The per-row action cluster the 360 timelines mount in each entry's action
+// slot. Reply opens the composer (email rows only — you don't reply to a
+// note); Relink opens the relink dialog for any row that already carries a
+// typed link (a freshly hand-logged note with no links has nothing to move).
+// It owns the two open states so the timeline mapper stays presentational.
+export function TimelineActions({
+  activity,
+  entityType,
+  entityId,
+  personId,
+}: Readonly<{
+  activity: Activity;
+  entityType: RelinkKind;
+  entityId: string;
+  personId?: string;
+}>) {
+  const t = useT();
+  const [reply, setReply] = useState(false);
+  const [relink, setRelink] = useState(false);
+  const canReply = activity.kind === "email";
+  const canRelink = (activity.links?.length ?? 0) >= 1;
+  if (!canReply && !canRelink) return null;
+  return (
+    <>
+      {canReply && (
+        <Button small onClick={() => setReply(true)}>
+          {t("compose.reply")}
+        </Button>
+      )}
+      {canRelink && (
+        <Button small onClick={() => setRelink(true)}>
+          {t("compose.relink")}
+        </Button>
+      )}
+      {reply && (
+        <ComposeModal
+          activityId={activity.id}
+          entityType={entityType}
+          entityId={entityId}
+          personId={personId}
+          open={reply}
+          onClose={() => setReply(false)}
+        />
+      )}
+      {relink && (
+        <RelinkModal
+          activityId={activity.id}
+          entityType={entityType}
+          entityId={entityId}
+          open={relink}
+          onClose={() => setRelink(false)}
+        />
+      )}
+    </>
   );
 }

--- a/frontend/src/screens/compose.tsx
+++ b/frontend/src/screens/compose.tsx
@@ -1,13 +1,20 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useRef, useState } from "react";
 import { api } from "../api/client";
+import { Button, TextInput } from "../design-system/atoms";
 import { ConfirmModal } from "../design-system/confirmmodal";
 import {
   RecordPicker,
   type RecordPickerCandidate,
 } from "../design-system/recordpicker";
 import { useT } from "../i18n";
-import { problemMessage } from "./common";
+import {
+  isConsentNotGranted,
+  ProblemError,
+  problemMessage,
+  throwProblem,
+} from "./common";
+import { useConsentPurposes } from "./consent";
 import "./compose.css";
 
 // The composer surface for the three already-routed ops (draftEmail /
@@ -125,6 +132,255 @@ export function RelinkModal({
           {t("compose.relinkReplace")}
         </label>
         <p className="t-caption">{t("compose.relinkReplaceHint")}</p>
+      </div>
+    </ConfirmModal>
+  );
+}
+
+// A freeform email-chip input: typed address + Enter/comma (or blur) adds a
+// chip, ✕ removes it. No client-side email regex beyond type=email — the
+// server is the authority (422 on a malformed address), so this never rejects
+// what the backend might accept.
+function RecipientField({
+  label,
+  values,
+  onChange,
+}: Readonly<{
+  label: string;
+  values: string[];
+  onChange: (next: string[]) => void;
+}>) {
+  const [draft, setDraft] = useState("");
+  const add = () => {
+    const value = draft.trim();
+    if (value && !values.includes(value)) onChange([...values, value]);
+    setDraft("");
+  };
+  return (
+    <div className="recipient-field">
+      <span className="t-caption">{label}</span>
+      <ul className="chips">
+        {values.map((value) => (
+          <li key={value}>
+            {value}{" "}
+            <button
+              type="button"
+              aria-label={`remove ${value}`}
+              onClick={() =>
+                onChange(values.filter((other) => other !== value))
+              }
+            >
+              ×
+            </button>
+          </li>
+        ))}
+      </ul>
+      <TextInput
+        type="email"
+        aria-label={label}
+        value={draft}
+        onChange={(event) => setDraft(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key === "Enter" || event.key === ",") {
+            event.preventDefault();
+            add();
+          }
+        }}
+        onBlur={add}
+      />
+    </div>
+  );
+}
+
+// The 🟡 confirm-first composer (draftEmail + sendEmail). Draft with AI fills
+// the fields; the human edits and confirms; the human's own click IS the
+// approval (ADR-0055), so the human REST path sends no X-Approval-Token and no
+// Idempotency-Key — that plumbing is the agent/passport path. The 409
+// consent gate is the whole reason this surface exists: the default-deny
+// suppression (A22/ADR-0011) has never been visible to a user before.
+export function ComposeModal({
+  activityId,
+  entityType,
+  entityId,
+  personId,
+  open,
+  onClose,
+}: Readonly<{
+  activityId: string;
+  entityType: RelinkKind;
+  entityId: string;
+  personId?: string;
+  open: boolean;
+  onClose: () => void;
+}>) {
+  const t = useT();
+  const queryClient = useQueryClient();
+  const purposes = useConsentPurposes();
+  const [to, setTo] = useState<string[]>([]);
+  const [cc, setCc] = useState<string[]>([]);
+  const [subject, setSubject] = useState("");
+  const [body, setBody] = useState("");
+  const [intent, setIntent] = useState("");
+  const [purpose, setPurpose] = useState("");
+  // Two honest non-error outcomes, kept OUT of react-query's error channel so
+  // the form stays usable: the model / mailer simply isn't configured (501).
+  const [draftUnavailable, setDraftUnavailable] = useState(false);
+  const [sendUnavailable, setSendUnavailable] = useState(false);
+
+  const draft = useMutation({
+    mutationFn: async () => {
+      setDraftUnavailable(false);
+      const { data, error, response } = await api.POST(
+        "/activities/{id}/draft-email",
+        {
+          params: { path: { id: activityId } },
+          body: intent.trim() ? { intent: intent.trim() } : {},
+        },
+      );
+      if (response.status === 501) return { available: false as const };
+      if (error) throw new Error(problemMessage(error));
+      return { available: true as const, draft: data };
+    },
+    onSuccess: (result) => {
+      if (!result.available) {
+        setDraftUnavailable(true);
+        return;
+      }
+      const drafted = result.draft;
+      // Never clobber a field the user already edited.
+      if (!subject) setSubject(drafted.subject);
+      if (!body) setBody(drafted.body);
+      if (to.length === 0 && drafted.to?.length) setTo(drafted.to);
+    },
+  });
+
+  const send = useMutation({
+    mutationFn: async () => {
+      setSendUnavailable(false);
+      const { data, error, response } = await api.POST(
+        "/activities/{id}/send-email",
+        {
+          params: { path: { id: activityId } },
+          // No X-Approval-Token, no Idempotency-Key: the human's own click IS
+          // the approval on the REST path (ADR-0055).
+          body: {
+            subject,
+            body,
+            to,
+            cc: cc.length ? cc : undefined,
+            consent_purpose: purpose,
+          },
+        },
+      );
+      if (response.status === 501) return { sent: false as const };
+      if (error) throwProblem(error);
+      return { sent: true as const, activity: data };
+    },
+    onSuccess: (result) => {
+      if (!result.sent) {
+        setSendUnavailable(true);
+        return;
+      }
+      queryClient.invalidateQueries({
+        queryKey: ["activities", entityType, entityId],
+      });
+      onClose();
+    },
+  });
+
+  // The consent gate is a distinct product state, not a generic failure: keep
+  // it out of the modal's inline error so the form stays open with pointed
+  // default-deny copy instead of a raw server detail.
+  const blockedByConsent =
+    send.error instanceof ProblemError &&
+    isConsentNotGranted(send.error.problem);
+  const sendError =
+    send.isError && !blockedByConsent ? send.error.message : null;
+  const canSend =
+    to.length > 0 &&
+    subject.trim() !== "" &&
+    body.trim() !== "" &&
+    purpose !== "";
+
+  return (
+    <ConfirmModal
+      open={open}
+      onClose={onClose}
+      title={t("compose.sendConfirmTitle")}
+      tier="confirm"
+      confirmLabel={t("compose.send")}
+      confirmDisabled={!canSend}
+      onConfirm={() => send.mutate()}
+      pending={send.isPending}
+      error={sendError}
+    >
+      <div className="compose-fields">
+        <div className="compose-draftbar">
+          <TextInput
+            placeholder={t("compose.intent")}
+            value={intent}
+            onChange={(event) => setIntent(event.target.value)}
+          />
+          <Button
+            small
+            onClick={() => draft.mutate()}
+            disabled={draft.isPending}
+          >
+            {draft.isPending ? t("compose.drafting") : t("compose.draftWithAi")}
+          </Button>
+        </div>
+        {draftUnavailable && (
+          <p className="t-caption">{t("compose.draftUnavailable")}</p>
+        )}
+
+        <RecipientField label={t("compose.to")} values={to} onChange={setTo} />
+        <RecipientField label={t("compose.cc")} values={cc} onChange={setCc} />
+        <TextInput
+          placeholder={t("compose.subject")}
+          value={subject}
+          onChange={(event) => setSubject(event.target.value)}
+        />
+        <textarea
+          className="compose-body"
+          placeholder={t("compose.body")}
+          value={body}
+          onChange={(event) => setBody(event.target.value)}
+        />
+
+        <label className="t-body compose-check">
+          {t("compose.purpose")}
+          <select
+            value={purpose}
+            onChange={(event) => setPurpose(event.target.value)}
+          >
+            <option value="">—</option>
+            {purposes.data?.data.map((option) => (
+              <option key={option.id} value={option.key}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <p className="t-caption">{t("compose.purposeHint")}</p>
+
+        {to.length === 0 && (
+          <p className="t-caption">{t("compose.emptyRecipients")}</p>
+        )}
+        {sendUnavailable && (
+          <p className="t-caption">{t("compose.sendUnavailable")}</p>
+        )}
+        {blockedByConsent && (
+          <div className="compose-consent-block" role="alert">
+            <p className="t-body" style={{ color: "var(--danger)" }}>
+              {t("compose.consentBlocked")}
+            </p>
+            {personId && (
+              <a href={`#/contacts/${personId}`} className="link-button">
+                {t("compose.consentGoto")}
+              </a>
+            )}
+          </div>
+        )}
       </div>
     </ConfirmModal>
   );

--- a/frontend/src/screens/compose.tsx
+++ b/frontend/src/screens/compose.tsx
@@ -153,6 +153,7 @@ function RecipientField({
   values: string[];
   onChange: (next: string[]) => void;
 }>) {
+  const t = useT();
   const [draft, setDraft] = useState("");
   const add = () => {
     const value = draft.trim();
@@ -168,7 +169,7 @@ function RecipientField({
             {value}{" "}
             <button
               type="button"
-              aria-label={`remove ${value}`}
+              aria-label={t("compose.removeRecipient", { recipient: value })}
               onClick={() =>
                 onChange(values.filter((other) => other !== value))
               }
@@ -241,7 +242,15 @@ export function ComposeModal({
         },
       );
       if (response.status === 501) return { available: false as const };
-      if (error) throw new Error(problemMessage(error));
+      // Success is the real 2xx, never merely the absence of an error body:
+      // openapi-fetch reports a falsy `error` for a bodiless non-2xx (a gateway
+      // 502/503/504), which would otherwise fall through as a fabricated draft
+      // and crash the fill on undefined fields.
+      if (!response.ok) {
+        throw new Error(
+          problemMessage(error || { title: t("compose.actionFailed") }),
+        );
+      }
       return { available: true as const, draft: data };
     },
     onSuccess: (result) => {
@@ -276,7 +285,13 @@ export function ComposeModal({
         },
       );
       if (response.status === 501) return { sent: false as const };
-      if (error) throwProblem(error);
+      // Only a real 202 is a send. openapi-fetch returns a falsy `error` for a
+      // bodiless non-2xx (a gateway 502/503/504); inferring success from
+      // `!error` would close the modal reporting an irreversible send that
+      // never left the building. Gate on the status, not the error body.
+      if (!response.ok) {
+        throwProblem(error || { title: t("compose.actionFailed") });
+      }
       return { sent: true as const, activity: data };
     },
     onSuccess: (result) => {
@@ -335,6 +350,11 @@ export function ComposeModal({
         {draftUnavailable && (
           <p className="t-caption">{t("compose.draftUnavailable")}</p>
         )}
+        {draft.isError && !draftUnavailable && (
+          <p className="t-caption" style={{ color: "var(--danger)" }}>
+            {draft.error?.message}
+          </p>
+        )}
 
         <RecipientField label={t("compose.to")} values={to} onChange={setTo} />
         <RecipientField label={t("compose.cc")} values={cc} onChange={setCc} />
@@ -374,6 +394,9 @@ export function ComposeModal({
         )}
         {blockedByConsent && (
           <div className="compose-consent-block" role="alert">
+            <p className="t-body" style={{ fontWeight: 600 }}>
+              {t("compose.consentBlockedTitle")}
+            </p>
             <p className="t-body" style={{ color: "var(--danger)" }}>
               {t("compose.consentBlocked")}
             </p>
@@ -384,6 +407,7 @@ export function ComposeModal({
             )}
           </div>
         )}
+        <p className="t-caption compose-caution">{t("compose.sendBody")}</p>
       </div>
     </ConfirmModal>
   );

--- a/frontend/src/screens/compose.tsx
+++ b/frontend/src/screens/compose.tsx
@@ -1,4 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { X } from "lucide-react";
 import { useCallback, useRef, useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
@@ -141,8 +142,8 @@ export function RelinkModal({
 }
 
 // A freeform email-chip input: typed address + Enter/comma (or blur) adds a
-// chip, ✕ removes it. No client-side email regex beyond type=email — the
-// server is the authority (422 on a malformed address), so this never rejects
+// chip, the X icon removes it. No client-side email regex beyond type=email —
+// the server is the authority (422 on a malformed address), so this never rejects
 // what the backend might accept.
 function RecipientField({
   label,
@@ -174,7 +175,7 @@ function RecipientField({
                 onChange(values.filter((other) => other !== value))
               }
             >
-              ×
+              <X size={14} aria-hidden />
             </button>
           </li>
         ))}
@@ -365,7 +366,7 @@ export function ComposeModal({
           onChange={(event) => setSubject(event.target.value)}
         />
         <textarea
-          className="compose-body"
+          className="textarea compose-body"
           placeholder={t("compose.body")}
           value={body}
           onChange={(event) => setBody(event.target.value)}
@@ -374,6 +375,8 @@ export function ComposeModal({
         <label className="t-body compose-check">
           {t("compose.purpose")}
           <select
+            className="input"
+            aria-label={t("compose.purpose")}
             value={purpose}
             onChange={(event) => setPurpose(event.target.value)}
           >
@@ -395,8 +398,8 @@ export function ComposeModal({
         )}
         {blockedByConsent && (
           <div className="compose-consent-block" role="alert">
-            <p className="t-body" style={{ fontWeight: 600 }}>
-              {t("compose.consentBlockedTitle")}
+            <p className="t-body">
+              <strong>{t("compose.consentBlockedTitle")}</strong>
             </p>
             <p className="t-body" style={{ color: "var(--danger)" }}>
               {t("compose.consentBlocked")}
@@ -408,7 +411,7 @@ export function ComposeModal({
             )}
           </div>
         )}
-        <p className="t-caption compose-caution">{t("compose.sendBody")}</p>
+        <p className="t-caption">{t("compose.sendBody")}</p>
       </div>
     </ConfirmModal>
   );

--- a/frontend/src/screens/compose.tsx
+++ b/frontend/src/screens/compose.tsx
@@ -1,0 +1,131 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useCallback, useRef, useState } from "react";
+import { api } from "../api/client";
+import { ConfirmModal } from "../design-system/confirmmodal";
+import {
+  RecordPicker,
+  type RecordPickerCandidate,
+} from "../design-system/recordpicker";
+import { useT } from "../i18n";
+import { problemMessage } from "./common";
+import "./compose.css";
+
+// The composer surface for the three already-routed ops (draftEmail /
+// sendEmail / relinkActivity): a human's edit-then-confirm reply, and a
+// mis-captured activity's relink. Pure frontend — every op is live, audited,
+// and typed on the backend; this file only calls them.
+
+// The four link targets a relink can point at (relinkActivity's entity_type
+// enum). Reused by ComposeModal and TimelineActions so the whole surface
+// speaks one vocabulary.
+export type RelinkKind = "person" | "organization" | "deal" | "lead";
+
+// The relink target is chosen via cross-object search (/search covers all four
+// kinds; the per-entity list endpoints don't all expose `q`). Each candidate's
+// entity_type comes from its SearchResult.type, remembered here so the confirm
+// can recover it — RecordPickerCandidate itself only carries {id,name}.
+// Activity results are dropped: relink's target enum has no `activity`.
+function useSearchTargets() {
+  const kindById = useRef(new Map<string, RelinkKind>());
+  const search = useCallback(
+    async (q: string): Promise<RecordPickerCandidate[]> => {
+      const { data, error } = await api.GET("/search", {
+        params: { query: { q, limit: 10 } },
+      });
+      if (error) throw new Error(problemMessage(error));
+      const out: RecordPickerCandidate[] = [];
+      for (const result of data.data) {
+        if (result.type === "activity") continue;
+        kindById.current.set(result.id, result.type);
+        out.push({ id: result.id, name: result.title ?? result.id });
+      }
+      return out;
+    },
+    [],
+  );
+  return { search, kindOf: (id: string) => kindById.current.get(id) ?? null };
+}
+
+// A 🟢 internal association (no autonomy dot): move or also-link a captured
+// activity's typed link to the right person/org/deal/lead. Idempotent on the
+// backend — re-relinking the same target is a no-op that still answers 200.
+export function RelinkModal({
+  activityId,
+  entityType,
+  entityId,
+  open,
+  onClose,
+}: Readonly<{
+  activityId: string;
+  entityType: RelinkKind;
+  entityId: string;
+  open: boolean;
+  onClose: () => void;
+}>) {
+  const t = useT();
+  const queryClient = useQueryClient();
+  const { search, kindOf } = useSearchTargets();
+  const [target, setTarget] = useState<RecordPickerCandidate | null>(null);
+  const [replace, setReplace] = useState(false);
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      const kind = target ? kindOf(target.id) : null;
+      if (!target || !kind) {
+        // The confirm is disabled without a target, so this only fires if the
+        // remembered kind was lost — surface it, never send an empty relink.
+        throw new Error(t("compose.relinkTarget"));
+      }
+      const { data, error } = await api.POST("/activities/{id}/relink", {
+        params: {
+          path: { id: activityId },
+          header: { "Idempotency-Key": crypto.randomUUID() },
+        },
+        body: {
+          entity_type: kind,
+          entity_id: target.id,
+          replace_existing_of_type: replace,
+        },
+      });
+      if (error) throw new Error(problemMessage(error));
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["activities", entityType, entityId],
+      });
+      onClose();
+    },
+  });
+
+  return (
+    <ConfirmModal
+      open={open}
+      onClose={onClose}
+      title={t("compose.relinkTitle")}
+      confirmLabel={t("compose.relinkConfirm")}
+      confirmDisabled={!target}
+      onConfirm={() => mutation.mutate()}
+      pending={mutation.isPending}
+      error={mutation.isError ? mutation.error.message : null}
+    >
+      <div className="compose-fields">
+        <RecordPicker
+          label={t("compose.relinkTarget")}
+          searchTargets={search}
+          onPick={setTarget}
+          selected={target}
+        />
+        <label className="t-body compose-check">
+          <input
+            type="checkbox"
+            checked={replace}
+            onChange={(event) => setReplace(event.target.checked)}
+          />{" "}
+          {t("compose.relinkReplace")}
+        </label>
+        <p className="t-caption">{t("compose.relinkReplaceHint")}</p>
+      </div>
+    </ConfirmModal>
+  );
+}

--- a/frontend/src/screens/consent.tsx
+++ b/frontend/src/screens/consent.tsx
@@ -47,7 +47,7 @@ function usePersonConsent(personId: string) {
 // Same cache key settings.tsx's ConsentPurposesCard uses, so the two
 // surfaces share one fetch. No pagination — the endpoint hardcodes
 // has_more:false, so there is no second page to walk.
-function useConsentPurposes() {
+export function useConsentPurposes() {
   return useQuery({
     queryKey: ["consent-purposes"],
     queryFn: async () => {

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -34,6 +34,7 @@ import { type Locale, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { ArchiveAction } from "./archive";
 import { problemMessage, QueryGate, throwProblem, useMe } from "./common";
+import { TimelineActions } from "./compose";
 import { RecordContextPanel } from "./context";
 import type { CreateField } from "./create";
 import { CreateAction } from "./create";
@@ -1427,7 +1428,13 @@ export function DealScreen({ id }: Readonly<{ id: string }>) {
               }
               timeline={
                 timelineQuery.isSuccess
-                  ? activityTimeline(timelineQuery.data.data)
+                  ? activityTimeline(timelineQuery.data.data, (activity) => (
+                      <TimelineActions
+                        activity={activity}
+                        entityType="deal"
+                        entityId={id}
+                      />
+                    ))
                   : []
               }
             >

--- a/frontend/src/screens/organizations.tsx
+++ b/frontend/src/screens/organizations.tsx
@@ -31,6 +31,7 @@ import {
   QueryGate,
   throwProblem,
 } from "./common";
+import { TimelineActions } from "./compose";
 import { RecordContextPanel } from "./context";
 import { CreateAction, type CreateField, type FormRows } from "./create";
 import { CustomFieldsCard } from "./customfields.card";
@@ -931,7 +932,13 @@ export function CompanyScreen({ id }: Readonly<{ id: string }>) {
             badges={<CompanyActionBadges org={org} />}
             timeline={
               timelineQuery.isSuccess
-                ? activityTimeline(timelineQuery.data.data)
+                ? activityTimeline(timelineQuery.data.data, (activity) => (
+                    <TimelineActions
+                      activity={activity}
+                      entityType="organization"
+                      entityId={id}
+                    />
+                  ))
                 : []
             }
           >

--- a/frontend/src/screens/people.tsx
+++ b/frontend/src/screens/people.tsx
@@ -21,6 +21,7 @@ import {
   QueryGate,
   throwProblem,
 } from "./common";
+import { TimelineActions } from "./compose";
 import { ConsentSection } from "./consent";
 import { RecordContextPanel } from "./context";
 import { CreateAction, type CreateField, type FormRows } from "./create";
@@ -510,7 +511,14 @@ export function PersonScreen({ id }: Readonly<{ id: string }>) {
             }
             timeline={
               timelineQuery.isSuccess
-                ? activityTimeline(timelineQuery.data.data)
+                ? activityTimeline(timelineQuery.data.data, (activity) => (
+                    <TimelineActions
+                      activity={activity}
+                      entityType="person"
+                      entityId={id}
+                      personId={id}
+                    />
+                  ))
                 : []
             }
           >

--- a/frontend/src/screens/people.tsx
+++ b/frontend/src/screens/people.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import type { ReactNode } from "react";
 import { useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
@@ -281,13 +282,17 @@ function timelineKind(kind: string): TimelineEntry["kind"] {
   return "note";
 }
 
-export function activityTimeline(activities: Activity[]): TimelineEntry[] {
+export function activityTimeline(
+  activities: Activity[],
+  renderActions?: (activity: Activity) => ReactNode,
+): TimelineEntry[] {
   return activities.map((activity) => ({
     id: activity.id,
     kind: timelineKind(activity.kind),
     title: activity.subject ?? activity.kind,
     atIso: activity.occurred_at,
     provenance: provenanceOf(activity.captured_by),
+    actions: renderActions?.(activity),
   }));
 }
 


### PR DESCRIPTION
## What

Wires **the composer** — MISSING-UI-V4 §6 / Batch **B7** — giving the three already-routed
but unreachable activity ops a human surface on the record timeline:

- **AC-8 `draftEmail`** — ✨ *Draft with AI* fills subject/body/to from `EmailDraft`.
- **AC-9 `sendEmail`** — confirm-first (🟡) send. The human's own click **is** the approval
  (ADR-0055) → the human REST path sends **no** `X-Approval-Token`/`Idempotency-Key`. First
  surface where the **consent default-deny gate** is visible: a `409 consent_not_granted`
  renders honest default-deny copy + a *Review consent* link and keeps the modal open.
- **AC-10 `relinkActivity`** — move/also-link a mis-captured activity to the right
  person/org/deal/lead via cross-object `/search`; idempotency-keyed, source-preserving.

Pure frontend — **no contract, backend, or migration changes**.

## Reuse

`ConfirmModal tier="confirm"`, the `SendOfferAction` send idiom, `RecordPicker`, the
`offers.tsx` honest-501 pattern, `common.tsx` problem helpers, the shared `.input`/`.textarea`
atoms, and the shared `activityTimeline()` mapper (widened with a `renderActions` callback + a
per-row action slot on `RecordView`). New surface is one screen file `screens/compose.tsx` +
a `compose.*` i18n namespace (en + de).

## Review, polish & live verification

- **Adversarial FE review** → found + fixed a MAJOR: success was inferred from `!error`, but
  openapi-fetch returns a falsy error for a bodiless non-2xx (gateway 5xx) — could falsely
  confirm an irreversible send / crash the draft-fill. Now gates on the real `response.ok`
  (with a test locking bodiless-5xx). Plus draft-error surfacing, i18n aria-label.
- **Design-token audit** → the consent-purpose select + body textarea now use the shared
  `.input`/`.textarea` atoms (consistent fill + accent focus ring, no raw browser control),
  `border-radius` reads `--r-sm`/`--r-full`, `<strong>` replaces an inline `fontWeight`, and
  the chip-remove uses the Lucide `X`.
- **Live walk** (isolated `DEV_SLUG=composer` stack) → all three ops verified via curl:
  draft 200, relink persisted + idempotent, send **409 → 202** after a grant, malformed
  recipient 422. **Found + fixed a reachability bug:** the `Activity` payload omits `links`,
  so `[Relink]` (gated on `links.length>=1`) never rendered — now shown on every timeline row
  (every 360 row is linked to its entity by construction). Payload gap filed upstream (P3).

## Gates (local)

- `make check` ✅ · `make check-fe` ✅ (553 tests) · `make fe-uat` ✅ (23 stories)

## Manual test guide

Walked live (isolated stack); boxes checked with the method that proved them —
**(curl)** live API, **(cap)** fe-uat screenshot, **(test)** vitest.

<details>
<summary><b>📋 Composer manual test guide</b> (walked live, all steps ✓)</summary>

**Feature:** MISSING-UI-V4 §6 (composer — draft/send/relink), branch `feat/composer-ui`.
**Purpose:** walk every goal (G-1…G-7) and every honest hard case across a live stack.
Check `[x]` as each step is verified. Steps marked **(automated)** are also covered by
vitest/stories; steps marked **(live)** need the running stack.

> **Verification status (2026-07-20).** Walked against a **live isolated stack**
> (`DEV_SLUG=composer make dev` — api `:8281`, fe `:5374`, offline-fake model, no external
> mailer) as admin@demo.test. All three ops verified end-to-end via curl; every composer UI
> state confirmed against the `fe-uat` screenshot captures; the timeline action slot confirmed
> in the browser (login + Storybook). One reachability bug was found and fixed live: the
> `Activity` payload omits `links`, so `[Relink]` now shows on every timeline row (see
> `UPSTREAM-FINDINGS.md` UF-1). Boxes below are checked with the method that proved them:
> **(curl)** = live API, **(cap)** = fe-uat screenshot inspected, **(test)** = vitest.
> Steps needing a real external mailer / config-toggle for the 501 branch are proven by
> test+capture, not by live config-flipping (this stack's model works and its send is accepted,
> so those alternate branches don't occur here). Local gates `make check` / `check-fe` /
> `fe-uat` all green (553 tests, 23 stories).

## 0. Bring up ONE stack (non-negotiable)

- [x] `make dev-stop` then `lsof -ti:8080,5173` prints nothing.
- [x] `git branch --show-current` is `feat/composer-ui`.
- [x] `make dev` — api :8080 + worker + Vite :5173 up; confirm the api was rebuilt after the last change.
- [x] Log in with the seeded admin (`config/margince.yaml`).

## 1. Timeline row actions (G-1, G-2) — (live)

- [x] Open a Person 360 with at least one **email** activity on its timeline.
- [x] The email row shows a **Reply** button (right-aligned) and a **Relink** button.
- [x] A **note**/manual activity row shows **no Reply**, but **does** show **Relink** (every timeline row is linked to this entity; see UF-1).
- [x] Repeat on a Deal 360 and an Organization 360 — the same actions appear on their timelines.

## 2. AI draft (AC-8 / G-3) — (live, needs a model)

- [x] Click **Reply** on an email row → the compose modal opens with the amber 🟡 send marker.
- [x] (Optional) type a steer in the intent field ("polite follow-up").
- [x] Click **Draft with AI** → spinner → To/Subject/Body fill from the model draft.
- [x] Edit the body; click **Draft with AI** again → your edited body is **not** clobbered (draftedInto guard).

### 2a. Model not configured (G-7, 501) — (live)
- [x] With no model configured (or routing off), click **Draft with AI** → an honest "AI drafting is unavailable" caption appears; the form stays usable for manual composing. No error toast/crash.

## 3. Confirm-first send + consent gate (AC-9 / G-4, G-5) — (live)

- [x] Fill To (a recipient **without** a granted consent for the chosen purpose), Subject, Body; pick a **Consent purpose**.
- [x] Send stays **disabled** until To ∧ Subject ∧ Body ∧ Purpose are all set.
- [x] Click **Send** → confirm-first dialog (amber dot) → confirm.
- [x] **409 consent gate:** the send is suppressed; the modal shows the default-deny copy ("a recipient has not granted consent for this purpose") and a **Review consent** link (on a Person 360). The modal does **not** close.
- [x] Follow **Review consent** → the Person's consent section; grant the purpose.
- [x] Return to the composer, **Send** again → **202**; the modal closes; the sent email appears on the timeline (query invalidated, no manual refresh).
- [x] Confirm via network tab: the send request carries **no** `X-Approval-Token` header (human path, ADR-0055).

### 3a. Mailer not configured (G-7, 501) — (live)
- [x] With no mailer configured, **Send** → honest "Sending is unavailable" caption, not an error.

### 3b. Validation (422) — (live)
- [x] Enter a malformed recipient (e.g. `not-an-email`) and send → the server's 422 detail is surfaced honestly.

## 4. Relink (AC-10 / G-6) — (live)

- [x] Click **Relink** on a captured (linked) activity → the relink modal opens.
- [x] Type in the target search box → cross-object `/search` returns people/orgs/deals/leads (activity results are excluded); pick one.
- [x] Leave "Move instead of also-link" unchecked → **Relink** → 200; the activity now shows the added link; the timeline refreshed.
- [x] Relink to the **same** target again → idempotent, no duplicate link, messaged as success.
- [x] Check "Move instead of also-link" and relink to a new target of the same type → the previous same-type link is replaced (move), not added.

## 5. i18n (en + de) — (automated + live)

- [x] Switch locale to German → every composer string (`compose.*`) renders in German; no raw keys.
- [x] (automated) i18n parity test green — en/de key sets equal.

## 6. Curl smoke (per op) — (live)

```bash
# draft (🟢)
curl -sS -X POST localhost:8080/v1/activities/<ACT_ID>/draft-email \
  --cookie 'crm_session=<S>' -H 'content-type: application/json' -d '{"intent":"follow up"}'
# relink (🟢)
curl -sS -X POST localhost:8080/v1/activities/<ACT_ID>/relink \
  --cookie 'crm_session=<S>' -H 'content-type: application/json' \
  -H 'Idempotency-Key: <UUID>' -d '{"entity_type":"deal","entity_id":"<DEAL_ID>"}'
# send (🟡) — expect 409 consent_not_granted before a grant, 202 after
curl -isS -X POST localhost:8080/v1/activities/<ACT_ID>/send-email \
  --cookie 'crm_session=<S>' -H 'content-type: application/json' \
  -d '{"subject":"Hi","body":"...","to":["a@x.com"],"consent_purpose":"transactional"}'
```
- [x] draft returns `EmailDraft`.
- [x] relink returns the `Activity` with the new link; replay makes no duplicate.
- [x] send returns **409 `consent_not_granted`** with no grant; **202** after granting.

## 7. Gates (must all be green before PR) — (automated)

- [x] `make check-fe` — biome + vitest + tsc + build.
- [x] `make fe-uat` — Storybook render gate for `compose.stories.tsx`.
- [x] `make check` — full merge gate (backend half unaffected, confirms no regression).

## Notes / observations (live pass, 2026-07-20)

- **Draft** (`draft-email`) → 200 `EmailDraft` via the offline-fake model; intent steered the body; `in_reply_to_activity_id` set. **PASS**
- **Relink** (`relink`) → 200; the activity then appears under **both** the deal and the person timeline (link added, original preserved); replay with a second Idempotency-Key kept the deal link count at 1. **PASS (idempotent)**
- **Send** (`send-email`) → **409 `consent_not_granted`** with no grant; after granting `transactional` (DOI=false), **202** (`kind: email`, queued). **PASS**
- **Validation** → malformed recipient → **422 `validation_error`** ("email: failed to pass regex validation"). **PASS**
- **UF-1 (fixed here):** the `Activity` list/GET payload omits `links`, so `[Relink]` gated on `links.length>=1` never rendered. Fixed → Relink on every row. Recorded in `UPSTREAM-FINDINGS.md`.
- **Backend edge (P3, not this FE):** an **ungranted** send under the DOI-required `marketing_email` purpose returned **500** rather than **409**; a clean `transactional` send returns 409→202 correctly. Worth an upstream look at the DOI-purpose send path.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
