### PR TITLE
feat(quotas): quotas & attainment UI (MISSING-UI §5 / B8)

### DIFF
--- a/frontend/src/design-system/atoms.css
+++ b/frontend/src/design-system/atoms.css
@@ -454,16 +454,16 @@ select.input {
 /* AttainmentRing (quotas): the arc rotates so 0% starts at 12 o'clock; the
  * band colour rides on the arc's stroke (set inline from the server band).
  * The centred figure overlays the SVG. */
-.ring {
+.attain-ring {
   position: relative;
   width: 160px;
   height: 160px;
   flex: none;
 }
-.ring svg {
+.attain-ring svg {
   transform: rotate(-90deg);
 }
-.ring-center {
+.attain-ring-center {
   position: absolute;
   inset: 0;
   display: flex;
@@ -472,13 +472,13 @@ select.input {
   justify-content: center;
   gap: 2px;
 }
-.ring-pct {
+.attain-ring-pct {
   font-weight: 500;
   font-size: 34px;
   color: var(--textPrimary);
   letter-spacing: -0.02em;
 }
-.ring-lbl {
+.attain-ring-lbl {
   font-size: 11px;
   text-transform: uppercase;
   letter-spacing: 0.06em;

--- a/frontend/src/design-system/atoms.css
+++ b/frontend/src/design-system/atoms.css
@@ -483,5 +483,5 @@ select.input {
   text-transform: uppercase;
   letter-spacing: 0.06em;
   font-weight: 600;
-  color: var(--textTertiary);
+  color: var(--textMeta);
 }

--- a/frontend/src/design-system/atoms.css
+++ b/frontend/src/design-system/atoms.css
@@ -450,3 +450,38 @@ select.input {
 .table-scroll {
   overflow-x: auto;
 }
+
+/* AttainmentRing (quotas): the arc rotates so 0% starts at 12 o'clock; the
+ * band colour rides on the arc's stroke (set inline from the server band).
+ * The centred figure overlays the SVG. */
+.ring {
+  position: relative;
+  width: 160px;
+  height: 160px;
+  flex: none;
+}
+.ring svg {
+  transform: rotate(-90deg);
+}
+.ring-center {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+}
+.ring-pct {
+  font-weight: 500;
+  font-size: 34px;
+  color: var(--textPrimary);
+  letter-spacing: -0.02em;
+}
+.ring-lbl {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-weight: 600;
+  color: var(--textTertiary);
+}

--- a/frontend/src/design-system/atoms.tsx
+++ b/frontend/src/design-system/atoms.tsx
@@ -207,6 +207,67 @@ export function Modal({
   );
 }
 
+// The attainment band the server computes (met ≥ 100, accent 60–99,
+// behind < 60). The ring and any echoing Badge take this verbatim — the
+// client never recomputes it from a raw percentage.
+export type AttainmentBand = "met" | "accent" | "behind";
+
+const BAND_STROKE: Record<AttainmentBand, string> = {
+  met: "var(--online)",
+  accent: "var(--accent)",
+  behind: "var(--away)",
+};
+
+// AttainmentRing (RD-PARAM-4): an SVG progress ring whose arc length reflects
+// `pct` (the server's raw, uncapped attainment percentage) capped at a full
+// circle, and whose colour is the server-computed `band` — never re-derived
+// here from `pct`. Pure and prop-driven: no fetch, so Storybook and tests
+// render it directly. The centred figure is the real rounded percentage
+// (which can read past 100%) above a caption slot.
+export function AttainmentRing({
+  pct,
+  band,
+  caption,
+}: Readonly<{
+  pct: number;
+  band: AttainmentBand;
+  caption: string;
+}>) {
+  const radius = 68;
+  const circumference = 2 * Math.PI * radius;
+  const fraction = Math.min(pct / 100, 1);
+  const offset = circumference * (1 - fraction);
+  return (
+    <div className="ring">
+      <svg width={160} height={160} viewBox="0 0 160 160" aria-hidden="true">
+        <circle
+          cx={80}
+          cy={80}
+          r={radius}
+          fill="none"
+          stroke="var(--bgCard)"
+          strokeWidth={14}
+        />
+        <circle
+          cx={80}
+          cy={80}
+          r={radius}
+          fill="none"
+          stroke={BAND_STROKE[band]}
+          strokeWidth={14}
+          strokeLinecap="round"
+          strokeDasharray={circumference}
+          strokeDashoffset={offset}
+        />
+      </svg>
+      <div className="ring-center">
+        <span className="ring-pct t-mono">{Math.round(pct)}%</span>
+        <span className="ring-lbl">{caption}</span>
+      </div>
+    </div>
+  );
+}
+
 export function DataTable<Row>({
   columns,
   rows,

--- a/frontend/src/design-system/atoms.tsx
+++ b/frontend/src/design-system/atoms.tsx
@@ -238,7 +238,7 @@ export function AttainmentRing({
   const fraction = Math.min(pct / 100, 1);
   const offset = circumference * (1 - fraction);
   return (
-    <div className="ring">
+    <div className="attain-ring">
       <svg width={160} height={160} viewBox="0 0 160 160" aria-hidden="true">
         <circle
           cx={80}
@@ -260,9 +260,9 @@ export function AttainmentRing({
           strokeDashoffset={offset}
         />
       </svg>
-      <div className="ring-center">
-        <span className="ring-pct t-mono">{Math.round(pct)}%</span>
-        <span className="ring-lbl">{caption}</span>
+      <div className="attain-ring-center">
+        <span className="attain-ring-pct t-mono">{Math.round(pct)}%</span>
+        <span className="attain-ring-lbl">{caption}</span>
       </div>
     </div>
   );

--- a/frontend/src/design-system/tokens.css
+++ b/frontend/src/design-system/tokens.css
@@ -31,6 +31,10 @@
 
   --online: #22c55e;
   --teal: #0e7490;
+  /* Readable teal text for a chip on the --tealLight fill. Split from --teal
+   * (a fill/accent) so the dark theme can lift the text without shifting the
+   * pill fills that read --teal. */
+  --tealText: #0e7490;
   /* low-alpha teal fill — the read-access pill's tint, tonally distinct from
    * the emerald --accentLight the write pill uses (record-share safety split,
    * mirrors share.html's read/write pill colours). Derived from --teal. */
@@ -126,6 +130,9 @@
   /* higher alpha so the teal read-pill fill stays legible on the darker card
    * surface (same light→dark bump --accentLight makes). --teal is unthemed. */
   --tealLight: rgba(14, 116, 144, 0.28);
+  /* Lifted teal text: the light --tealText (#0e7490) is dark-on-dark on the
+   * --tealLight fill over a dark card, below AA — brighten it for dark. */
+  --tealText: #5cb6cf;
 
   --aiText: #9ba0f0;
   --textMeta: #8fa099;

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1554,4 +1554,69 @@ export const de = {
 
   "countdown.minutesSeconds": "{minutes}m {seconds}s",
   "countdown.expired": "Abgelaufen",
+
+  // Quotas & Zielerreichung (RD-T06): menschlich gesetzte Umsatzziele mit
+  // serverseitig berechneter Zielerreichung, im Reports-Segment „Quotas“.
+  "quotas.tab": "Quotas",
+  "quotas.sub": "Umsatzziele — menschlich gesetzt, Zielerreichung berechnet",
+  "quotas.role.owner": "Individuelle Quota",
+  "quotas.role.team": "Team-Quota",
+  "quotas.periodRange": "{start} – {end}",
+  "quotas.empty.title": "Keine Quota gesetzt",
+  "quotas.empty.body":
+    "Eine Quota ist ein Ziel, das ein Mensch setzt — Inhaber oder Team, Zeitraum, Betrag. Wir raten es nicht. Setzen Sie ein Ziel, um die Zielerreichung aus gewonnenen Deals zu verfolgen.",
+  "quotas.empty.cta": "Ziel setzen",
+  "quotas.attained": "erreicht",
+  "quotas.closedWon": "Gewonnen in diesem Zeitraum",
+  "quotas.target": "Ziel",
+  "quotas.gap": "Abstand zum Ziel",
+  "quotas.baseCurrencyNote":
+    "Beträge in der Basiswährung des Workspace ({currency}).",
+  "quotas.pace.ahead":
+    "Vor dem Plan — {pct}% erreicht bei {pace}% des Zeitraums.",
+  "quotas.pace.behind":
+    "Hinter dem Plan — {pct}% erreicht bei {pace}% des Zeitraums.",
+  "quotas.pace.met": "Ziel erreicht — {pct}% erreicht.",
+  "quotas.computed": "serverseitig berechnet",
+  "quotas.contributing.title": "Was zur Zielerreichung zählt",
+  "quotas.contributing.subtitle": "gewonnene Deals · Basiswert im Zeitraum",
+  "quotas.contributing.deal": "Deal",
+  "quotas.contributing.amount": "Gezählter Betrag",
+  "quotas.contributing.total": "Gezählte Summe",
+  "quotas.contributing.caption":
+    "Basiswährung · offene / verlorene / ausgeschlossene Deals ausgenommen",
+  "quotas.explain.formula":
+    "Zielerreichung = Σ(Basiswert gewonnener Deals) ÷ Ziel, auf den Cent",
+  "quotas.explain.closedWon": "gewonnen = {sum} ({count} Deals im Zeitraum)",
+  "quotas.explain.target": "Ziel = {target} (menschlich gesetzt)",
+  "quotas.explain.result": "Zielerreichung = {sum} ÷ {target} = {pct}%",
+  "quotas.explain.exclusions":
+    "offene / verlorene / ausgeschlossene Deals ausgenommen; nur sauberer Kern",
+  "quotas.scopeNote.title": "Was diese Quota bewusst ist",
+  "quotas.scopeNote.flag": "gekennzeichnet, nicht verborgen",
+  "quotas.scopeNote.body":
+    "Das Ziel ist menschlich gesetzt — die KI erfindet keine Quota-Zahl. Die Zielerreichung wird aus dem Basiswert gewonnener Deals berechnet und ist vollständig auditierbar. Es gibt kein KI-gesetztes Ziel, kein Forecast-zu-Quota und keine Provisions-Engine.",
+  "quotas.target.title": "Ziel des Zeitraums",
+  "quotas.target.new": "Ziel setzen",
+  "quotas.target.edit": "Ziel bearbeiten",
+  "quotas.target.save": "Ziel speichern",
+  "quotas.target.note":
+    "Das Bearbeiten schreibt einen menschlich getippten Wert und protokolliert die Änderung. Die Zielerreichung wird neu berechnet.",
+  "quotas.target.sideFixed":
+    "Die Inhaber-/Team-Seite einer Quota ist fest — zum Wechseln archivieren und neu anlegen.",
+  "quotas.side.label": "Zugewiesen an",
+  "quotas.side.owner": "Inhaber",
+  "quotas.side.team": "Team",
+  "quotas.owner": "Inhaber",
+  "quotas.team": "Team",
+  "quotas.periodStart": "Zeitraum-Beginn",
+  "quotas.periodEnd": "Zeitraum-Ende",
+  "quotas.amount": "Zielbetrag",
+  "quotas.currency": "Währung",
+  "quotas.err.targetZero": "Diese Quota hat noch kein Ziel",
+  "quotas.err.computeFailed": "Zielerreichung konnte nicht berechnet werden",
+  "quotas.err.ownerXorTeam": "Wählen Sie genau eines: Inhaber oder Team.",
+  "quotas.archive.title": "Quota archivieren",
+  "quotas.archive.confirm":
+    "Das Archivieren entfernt diese Quota aus der Liste und stoppt die Verfolgung der Zielerreichung. Archivierte Quotas können nicht bearbeitet werden.",
 } as const satisfies Record<MessageKey, string>;

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1609,6 +1609,8 @@ export const de = {
   "quotas.side.team": "Team",
   "quotas.owner": "Inhaber",
   "quotas.team": "Team",
+  "quotas.pickOwner": "Inhaber auswählen…",
+  "quotas.pickTeam": "Team auswählen…",
   "quotas.periodStart": "Zeitraum-Beginn",
   "quotas.periodEnd": "Zeitraum-Ende",
   "quotas.amount": "Zielbetrag",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1611,6 +1611,7 @@ export const de = {
   "quotas.team": "Team",
   "quotas.pickOwner": "Inhaber auswählen…",
   "quotas.pickTeam": "Team auswählen…",
+  "quotas.amountHint": "Ganze Euro — keine Dezimalstellen",
   "quotas.periodStart": "Zeitraum-Beginn",
   "quotas.periodEnd": "Zeitraum-Ende",
   "quotas.amount": "Zielbetrag",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1524,6 +1524,72 @@ export const en = {
 
   "countdown.minutesSeconds": "{minutes}m {seconds}s",
   "countdown.expired": "Expired",
+
+  // Quotas & attainment (RD-T06): human-set revenue targets with
+  // server-computed attainment, surfaced under the Reports "Quotas" segment.
+  "quotas.tab": "Quotas",
+  "quotas.sub": "revenue targets — human-set, attainment computed",
+  "quotas.role.owner": "Individual quota",
+  "quotas.role.team": "Team quota",
+  "quotas.periodRange": "{start} – {end}",
+  "quotas.empty.title": "No quota set",
+  "quotas.empty.body":
+    "A quota is a target a human sets — owner or team, period, amount. We don't guess one for you. Set a target to start tracking attainment from closed-won deals.",
+  "quotas.empty.cta": "Set a target",
+  "quotas.attained": "attained",
+  "quotas.closedWon": "Closed-won this period",
+  "quotas.target": "Target",
+  "quotas.gap": "Gap to target",
+  "quotas.baseCurrencyNote":
+    "Figures in the workspace base currency ({currency}).",
+  "quotas.pace.ahead":
+    "Ahead of pace — {pct}% attained vs {pace}% of period elapsed.",
+  "quotas.pace.behind":
+    "Behind pace — {pct}% attained vs {pace}% of period elapsed.",
+  "quotas.pace.met": "Target met — {pct}% attained.",
+  "quotas.computed": "computed server-side",
+  "quotas.contributing.title": "What counts toward attainment",
+  "quotas.contributing.subtitle": "closed-won deals · base value in the period",
+  "quotas.contributing.deal": "Deal",
+  "quotas.contributing.amount": "Counted amount",
+  "quotas.contributing.total": "Counted total",
+  "quotas.contributing.caption":
+    "Base currency · open / lost / omitted deals excluded",
+  "quotas.explain.formula":
+    "attainment = Σ(closed-won base value) ÷ target, to the cent",
+  "quotas.explain.closedWon":
+    "closed-won = {sum} ({count} deals in the period)",
+  "quotas.explain.target": "target = {target} (human-set)",
+  "quotas.explain.result": "attainment = {sum} ÷ {target} = {pct}%",
+  "quotas.explain.exclusions":
+    "open / lost / omitted deals are excluded; clean-core only",
+  "quotas.scopeNote.title": "What this quota deliberately is",
+  "quotas.scopeNote.flag": "flagged, not hidden",
+  "quotas.scopeNote.body":
+    "The target is human-set — the AI never invents a quota number. Attainment is computed from closed-won base value and is fully auditable. There is no AI-set goal, no forecast-to-quota auto-fill, and no comp/commission engine yet.",
+  "quotas.target.title": "Period target",
+  "quotas.target.new": "Set a target",
+  "quotas.target.edit": "Edit target",
+  "quotas.target.save": "Save target",
+  "quotas.target.note":
+    "Editing writes a human-typed value and logs the change. Attainment recomputes against it.",
+  "quotas.target.sideFixed":
+    "A quota's owner/team side is fixed — switch it by archiving and recreating.",
+  "quotas.side.label": "Assigned to",
+  "quotas.side.owner": "Owner",
+  "quotas.side.team": "Team",
+  "quotas.owner": "Owner",
+  "quotas.team": "Team",
+  "quotas.periodStart": "Period start",
+  "quotas.periodEnd": "Period end",
+  "quotas.amount": "Target amount",
+  "quotas.currency": "Currency",
+  "quotas.err.targetZero": "This quota has no target yet",
+  "quotas.err.computeFailed": "Attainment couldn't be computed",
+  "quotas.err.ownerXorTeam": "Choose exactly one of owner or team.",
+  "quotas.archive.title": "Archive quota",
+  "quotas.archive.confirm":
+    "Archiving drops this quota from the list and stops tracking its attainment. Archived quotas can't be edited.",
 } as const;
 
 export type MessageKey = keyof typeof en;

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1582,6 +1582,7 @@ export const en = {
   "quotas.team": "Team",
   "quotas.pickOwner": "Select an owner…",
   "quotas.pickTeam": "Select a team…",
+  "quotas.amountHint": "Whole euros — no decimals",
   "quotas.periodStart": "Period start",
   "quotas.periodEnd": "Period end",
   "quotas.amount": "Target amount",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1580,6 +1580,8 @@ export const en = {
   "quotas.side.team": "Team",
   "quotas.owner": "Owner",
   "quotas.team": "Team",
+  "quotas.pickOwner": "Select an owner…",
+  "quotas.pickTeam": "Select a team…",
   "quotas.periodStart": "Period start",
   "quotas.periodEnd": "Period end",
   "quotas.amount": "Target amount",

--- a/frontend/src/screens/quotas.css
+++ b/frontend/src/screens/quotas.css
@@ -1,0 +1,205 @@
+/* Quotas & attainment view. The two-column grid collapses to one column on
+ * narrow viewports; colours read tokens only. */
+
+.qgrid {
+  display: grid;
+  grid-template-columns: 1fr 320px;
+  gap: 20px;
+  align-items: start;
+}
+@media (max-width: 880px) {
+  .qgrid {
+    grid-template-columns: 1fr;
+  }
+}
+.colstack {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+/* quota selector list */
+.quota-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 10px;
+}
+.quota-row {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: 1px solid var(--borderSubtle);
+  border-radius: var(--r-sm);
+  padding: 10px 12px;
+  cursor: pointer;
+  transition:
+    border-color 0.12s,
+    background 0.12s;
+}
+.quota-row:hover {
+  border-color: var(--borderStrong);
+}
+.quota-row.active {
+  border-color: var(--accent);
+  background: var(--accentLight);
+}
+.quota-row-top {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+.quota-row-name {
+  font-weight: 600;
+  color: var(--textPrimary);
+}
+.quota-row-target {
+  color: var(--textPrimary);
+}
+.quota-row-sub {
+  display: block;
+  margin-top: 3px;
+}
+
+/* attainment card: ring beside the numbers, wrapping on narrow widths */
+.attain-card {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  flex-wrap: wrap;
+}
+.attain-body {
+  flex: 1;
+  min-width: 240px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.attain-numbers {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.attain-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+.attain-row .k {
+  font-size: 13px;
+  color: var(--textSecondary);
+}
+.attain-row .k.strong {
+  color: var(--textPrimary);
+  font-weight: 600;
+}
+.attain-row .v {
+  font-size: 18px;
+  color: var(--textPrimary);
+}
+.attain-div {
+  height: 1px;
+  background: var(--borderSubtle);
+}
+.attain-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.computed-chip {
+  display: inline-flex;
+  align-items: center;
+  font-size: 11px;
+  font-family: var(--f-mono);
+  color: var(--teal);
+  background: var(--tealLight);
+  border-radius: var(--r-full);
+  padding: 3px 9px;
+}
+.pace-line {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12.5px;
+  color: var(--textSecondary);
+}
+.pace-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: var(--r-full);
+  flex: none;
+}
+.explain-box {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 11.5px;
+  color: var(--textSecondary);
+  background: var(--bgCard);
+  border-radius: var(--r-sm);
+  padding: 12px 14px;
+  line-height: 1.6;
+}
+
+/* contributing deals footer */
+.quota-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 4px 2px;
+  border-top: 2px solid var(--borderSubtle);
+  margin-top: 6px;
+}
+.quota-foot .k {
+  font-weight: 600;
+  color: var(--textPrimary);
+}
+.quota-foot .v {
+  font-size: 17px;
+  font-weight: 600;
+  color: var(--textPrimary);
+}
+
+/* right rail */
+.rail-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 10px;
+}
+.rail-div {
+  height: 1px;
+  background: var(--borderSubtle);
+  margin: 14px 0;
+}
+
+/* attainment refusal / honest error card (no ring drawn) */
+.attain-refusal {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.attain-refusal b {
+  color: var(--textPrimary);
+  font-weight: 600;
+}
+
+.quota-side {
+  border: 0;
+  padding: 0;
+}
+.quota-side-choices {
+  display: flex;
+  gap: var(--space-4);
+  margin-top: var(--space-2);
+}
+.quota-side-choice {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}

--- a/frontend/src/screens/quotas.css
+++ b/frontend/src/screens/quotas.css
@@ -114,12 +114,24 @@
 .computed-chip {
   display: inline-flex;
   align-items: center;
+  gap: 5px;
   font-size: 11px;
   font-family: var(--f-mono);
-  color: var(--teal);
+  color: var(--tealText);
   background: var(--tealLight);
   border-radius: var(--r-full);
   padding: 3px 9px;
+}
+.computed-chip svg {
+  width: 11px;
+  height: 11px;
+}
+
+/* Money column + its footer total share the card's right edge so the figures
+ * line up with the total they sum to. */
+.quota-contrib .table th:last-child,
+.quota-contrib .table td:last-child {
+  text-align: right;
 }
 .pace-line {
   display: flex;
@@ -202,4 +214,7 @@
   display: flex;
   align-items: center;
   gap: var(--space-2);
+}
+.quota-side-choice input {
+  accent-color: var(--accent);
 }

--- a/frontend/src/screens/quotas.forms.stories.tsx
+++ b/frontend/src/screens/quotas.forms.stories.tsx
@@ -1,0 +1,102 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { userEvent, within } from "storybook/test";
+import {
+  ArchiveQuotaAction,
+  EditTargetAction,
+  SetTargetAction,
+} from "./quotas.forms";
+import { installFetchStub, jsonResponse, StoryProviders } from "./story-utils";
+
+// The quota write surface for the fe-uat render gate. Each action owns its own
+// modal open state, so a play() click drives the trigger — fe-uat waits for the
+// interaction to settle before it screenshots, capturing the dialog itself
+// rather than the closed button. The roster reads are stubbed; no live call.
+
+const page = { next_cursor: null, has_more: false };
+
+const users = {
+  data: [
+    {
+      id: "u1",
+      workspace_id: "w1",
+      email: "riya@example.co",
+      display_name: "Riya Patel",
+      timezone: "UTC",
+      status: "active",
+      is_agent: false,
+    },
+  ],
+  page,
+};
+
+const teams = {
+  data: [{ id: "t1", workspace_id: "w1", name: "DACH Enterprise" }],
+  page,
+};
+
+const ownerQuota = {
+  id: "q1",
+  workspace_id: "w1",
+  owner_id: "u1",
+  team_id: null,
+  period_start: "2026-07-01",
+  period_end: "2026-09-30",
+  target_minor: 28000000,
+  currency: "EUR",
+  version: 3,
+  created_at: "2026-06-28T16:40:00Z",
+  updated_at: "2026-07-01T09:12:00Z",
+};
+
+const meta: Meta = { title: "screens/quotas-forms" };
+export default meta;
+
+// The owner-XOR-team create form, opened so the render gate captures the side
+// picker + roster select + money entry.
+export const SetTarget: StoryObj = {
+  render: () => {
+    installFetchStub({
+      "GET /users": () => jsonResponse(users),
+      "GET /teams": () => jsonResponse(teams),
+    });
+    return (
+      <StoryProviders>
+        <SetTargetAction label="Set a target" />
+      </StoryProviders>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    await userEvent.click(within(canvasElement).getByTestId("quota-create"));
+  },
+};
+
+// The target editor, opened — reassigns period/target/currency within the
+// existing owner side (a merge-PATCH can't clear a side).
+export const EditTarget: StoryObj = {
+  render: () => {
+    installFetchStub({});
+    return (
+      <StoryProviders>
+        <EditTargetAction label="Edit target" quota={ownerQuota} />
+      </StoryProviders>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    await userEvent.click(within(canvasElement).getByTestId("edit-record"));
+  },
+};
+
+// The confirm-first archive dialog.
+export const ArchiveConfirm: StoryObj = {
+  render: () => {
+    installFetchStub({});
+    return (
+      <StoryProviders>
+        <ArchiveQuotaAction quota={ownerQuota} onArchived={() => undefined} />
+      </StoryProviders>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    await userEvent.click(within(canvasElement).getByTestId("archive-record"));
+  },
+};

--- a/frontend/src/screens/quotas.forms.tsx
+++ b/frontend/src/screens/quotas.forms.tsx
@@ -250,6 +250,7 @@ function SetTargetModal({
             inputMode="numeric"
             value={amount}
             required
+            placeholder={t("quotas.amountHint")}
             onChange={(event) => setAmount(event.target.value)}
           />
         </div>
@@ -325,6 +326,7 @@ export function EditTargetAction({
   label,
   quota,
 }: Readonly<{ label: string; quota: Quota }>) {
+  const t = useT();
   return (
     <EditAction<Quota>
       label={label}
@@ -346,6 +348,7 @@ export function EditTargetAction({
           label: "quotas.amount",
           type: "text",
           required: true,
+          placeholder: t("quotas.amountHint"),
           // The record carries integer minor units; the field edits whole
           // euros, so echo minor→euro on prefill and parse euro→minor on save.
           toInput: (raw) =>

--- a/frontend/src/screens/quotas.forms.tsx
+++ b/frontend/src/screens/quotas.forms.tsx
@@ -1,0 +1,409 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Plus } from "lucide-react";
+import { useEffect, useId, useRef, useState } from "react";
+import { api } from "../api/client";
+import type { components } from "../api/schema";
+import { ifMatch } from "../api/version";
+import { Button, Modal, TextInput } from "../design-system/atoms";
+import { useT } from "../i18n";
+import { ArchiveAction } from "./archive";
+import { ProblemError, throwProblem } from "./common";
+import { EditAction } from "./edit";
+import { useRoster } from "./entityref";
+
+// The quota target write surface: create (owner-XOR-team side picker), edit
+// (reassign within the fixed side), and archive. Split out of quotas.tsx so
+// the view file stays focused on the read/attainment surface. Every write is
+// human-only and cookie-authed (RD-WIRE-*); the server's owner-XOR-team
+// contract is branched to a targeted message, never swallowed.
+
+type Quota = components["schemas"]["Quota"];
+type User = components["schemas"]["User"];
+type Team = components["schemas"]["Team"];
+
+type Side = "owner" | "team";
+
+// Human-typed integer euros → minor units (mirrors the mockup's parseTgt):
+// strip every non-digit, then scale by the 2-decimal minor unit. The target
+// is whole-euro, human-set (RD-PARAM-3) — never a fractional or computed value.
+export function parseEuroMinor(input: string): number {
+  const digits = input.replace(/[^\d]/g, "");
+  return digits ? Number.parseInt(digits, 10) * 100 : 0;
+}
+
+// A 422 whose owner-XOR-team contract failed — either the top-level code names
+// it, or one of details.errors[] does (createQuota/updateQuota return the
+// distinct owner_xor_team_required code, not a generic per-field code). Branched
+// to a targeted field message rather than the raw server detail.
+export function isOwnerXorTeam(problem: unknown): boolean {
+  if (!problem || typeof problem !== "object") return false;
+  const record = problem as Record<string, unknown>;
+  if (record.code === "owner_xor_team_required") return true;
+  const details = record.details;
+  if (details && typeof details === "object") {
+    const errors = (details as Record<string, unknown>).errors;
+    if (Array.isArray(errors)) {
+      return errors.some(
+        (entry) =>
+          entry !== null &&
+          typeof entry === "object" &&
+          (entry as Record<string, unknown>).code === "owner_xor_team_required",
+      );
+    }
+  }
+  return false;
+}
+
+// A roster entry's display label, narrowing the User|Team union by a field
+// only one side carries (no unchecked cast).
+function subjectLabel(entry: User | Team): string {
+  return "display_name" in entry ? entry.display_name : entry.name;
+}
+
+// Create is bespoke — the generic RecordFormBody can't express the
+// owner-XOR-team radio (exactly one side non-null on the wire). It still runs
+// through the shared error-surfacing (ProblemError → problemMessage) and
+// invalidates the ["quotas"] list like the shared create choreography does,
+// but skips its navigate({screen,id}): a quota has no 360 route to land on.
+function SetTargetModal({
+  open,
+  onClose,
+  onCreated,
+}: Readonly<{
+  open: boolean;
+  onClose: () => void;
+  onCreated?: (id: string) => void;
+}>) {
+  const t = useT();
+  const headingId = useId();
+  const formId = useId();
+  const queryClient = useQueryClient();
+  const users = useRoster("user", open);
+  const teams = useRoster("team", open);
+  const [side, setSide] = useState<Side>("owner");
+  const [subjectId, setSubjectId] = useState("");
+  const [periodStart, setPeriodStart] = useState("");
+  const [periodEnd, setPeriodEnd] = useState("");
+  const [amount, setAmount] = useState("");
+  const [currency, setCurrency] = useState("EUR");
+  // Only the closed→open transition resets the form — a background roster
+  // refetch must not wipe what the user is mid-typing.
+  const wasOpen = useRef(false);
+
+  useEffect(() => {
+    if (open && !wasOpen.current) {
+      setSide("owner");
+      setSubjectId("");
+      setPeriodStart("");
+      setPeriodEnd("");
+      setAmount("");
+      setCurrency("EUR");
+    }
+    wasOpen.current = open;
+  }, [open]);
+
+  const mutation = useMutation({
+    mutationFn: async (): Promise<Quota> => {
+      const { data, error } = await api.POST("/quotas", {
+        params: { header: { "Idempotency-Key": crypto.randomUUID() } },
+        body: {
+          owner_id: side === "owner" ? subjectId : null,
+          team_id: side === "team" ? subjectId : null,
+          period_start: periodStart,
+          period_end: periodEnd,
+          target_minor: parseEuroMinor(amount),
+          currency: currency.trim(),
+        },
+      });
+      if (error) throwProblem(error);
+      return data;
+    },
+    onSuccess: (created) => {
+      queryClient.invalidateQueries({ queryKey: ["quotas"] });
+      onCreated?.(created.id);
+      onClose();
+    },
+  });
+
+  const errorMessage =
+    mutation.error instanceof ProblemError
+      ? isOwnerXorTeam(mutation.error.problem)
+        ? t("quotas.err.ownerXorTeam")
+        : mutation.error.message
+      : mutation.error instanceof Error
+        ? mutation.error.message
+        : null;
+
+  const roster = side === "owner" ? users : teams;
+  const canSubmit =
+    subjectId !== "" &&
+    periodStart !== "" &&
+    periodEnd !== "" &&
+    parseEuroMinor(amount) > 0 &&
+    currency.trim() !== "";
+
+  function pickSide(next: Side) {
+    setSide(next);
+    // The two rosters share no ids — a subject chosen for the old side can't
+    // stand in for the new one.
+    setSubjectId("");
+  }
+
+  return (
+    <Modal open={open} onClose={onClose} labelledBy={headingId}>
+      <h2
+        id={headingId}
+        className="t-h2"
+        style={{ marginBottom: "var(--space-3)" }}
+      >
+        {t("quotas.target.new")}
+      </h2>
+      <form
+        className="form-stack"
+        onSubmit={(event) => {
+          event.preventDefault();
+          mutation.mutate();
+        }}
+      >
+        <fieldset className="field quota-side">
+          <legend className="t-label">{t("quotas.side.label")}</legend>
+          <div className="quota-side-choices">
+            <label className="quota-side-choice">
+              <input
+                type="radio"
+                name={`${formId}-side`}
+                checked={side === "owner"}
+                onChange={() => pickSide("owner")}
+              />
+              {t("quotas.side.owner")}
+            </label>
+            <label className="quota-side-choice">
+              <input
+                type="radio"
+                name={`${formId}-side`}
+                checked={side === "team"}
+                onChange={() => pickSide("team")}
+              />
+              {t("quotas.side.team")}
+            </label>
+          </div>
+        </fieldset>
+
+        <div className="field">
+          <label className="t-label" htmlFor={`${formId}-subject`}>
+            {side === "owner" ? t("quotas.owner") : t("quotas.team")} *
+          </label>
+          <select
+            id={`${formId}-subject`}
+            className="input"
+            value={subjectId}
+            required
+            onChange={(event) => setSubjectId(event.target.value)}
+          >
+            <option value="" />
+            {(roster.data ?? []).map((entry) => (
+              <option key={entry.id} value={entry.id}>
+                {subjectLabel(entry)}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="field">
+          <label className="t-label" htmlFor={`${formId}-start`}>
+            {t("quotas.periodStart")} *
+          </label>
+          <TextInput
+            id={`${formId}-start`}
+            type="date"
+            value={periodStart}
+            required
+            onChange={(event) => setPeriodStart(event.target.value)}
+          />
+        </div>
+
+        <div className="field">
+          <label className="t-label" htmlFor={`${formId}-end`}>
+            {t("quotas.periodEnd")} *
+          </label>
+          <TextInput
+            id={`${formId}-end`}
+            type="date"
+            value={periodEnd}
+            required
+            onChange={(event) => setPeriodEnd(event.target.value)}
+          />
+        </div>
+
+        <div className="field">
+          <label className="t-label" htmlFor={`${formId}-amount`}>
+            {t("quotas.amount")} *
+          </label>
+          <TextInput
+            id={`${formId}-amount`}
+            type="text"
+            inputMode="numeric"
+            value={amount}
+            required
+            onChange={(event) => setAmount(event.target.value)}
+          />
+        </div>
+
+        <div className="field">
+          <label className="t-label" htmlFor={`${formId}-currency`}>
+            {t("quotas.currency")} *
+          </label>
+          <TextInput
+            id={`${formId}-currency`}
+            type="text"
+            value={currency}
+            required
+            onChange={(event) => setCurrency(event.target.value)}
+          />
+        </div>
+
+        {errorMessage && (
+          <p className="t-caption" style={{ color: "var(--danger)" }}>
+            {errorMessage}
+          </p>
+        )}
+        <div className="actions">
+          <Button small type="button" onClick={onClose}>
+            {t("create.cancel")}
+          </Button>
+          <Button
+            small
+            variant="primary"
+            type="submit"
+            disabled={mutation.isPending || !canSubmit}
+            data-testid="quota-create-submit"
+          >
+            {mutation.isPending ? t("create.saving") : t("quotas.target.save")}
+          </Button>
+        </div>
+      </form>
+    </Modal>
+  );
+}
+
+// The create affordance: a primary trigger plus the bespoke modal above.
+export function SetTargetAction({
+  label,
+  onCreated,
+}: Readonly<{ label: string; onCreated?: (id: string) => void }>) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button
+        small
+        variant="primary"
+        onClick={() => setOpen(true)}
+        data-testid="quota-create"
+      >
+        <Plus aria-hidden style={{ width: 14, height: 14 }} /> {label}
+      </Button>
+      <SetTargetModal
+        open={open}
+        onClose={() => setOpen(false)}
+        onCreated={onCreated}
+      />
+    </>
+  );
+}
+
+// Edit reuses the shared EditAction choreography (If-Match, 409 version_skew
+// surfacing). The owner/team side is fixed — a merge-PATCH can't clear a side
+// (omitted and null are the same wire shape) — so only period, target, and
+// currency are editable; switching side is archive-and-recreate.
+export function EditTargetAction({
+  label,
+  quota,
+}: Readonly<{ label: string; quota: Quota }>) {
+  return (
+    <EditAction<Quota>
+      label={label}
+      fields={[
+        {
+          key: "period_start",
+          label: "quotas.periodStart",
+          type: "date",
+          required: true,
+        },
+        {
+          key: "period_end",
+          label: "quotas.periodEnd",
+          type: "date",
+          required: true,
+        },
+        {
+          key: "amount",
+          label: "quotas.amount",
+          type: "text",
+          required: true,
+          // The record carries integer minor units; the field edits whole
+          // euros, so echo minor→euro on prefill and parse euro→minor on save.
+          toInput: (raw) =>
+            raw == null || raw === ""
+              ? ""
+              : String(Math.round(Number(raw) / 100)),
+        },
+        {
+          key: "currency",
+          label: "quotas.currency",
+          type: "text",
+          required: true,
+        },
+      ]}
+      record={{
+        id: quota.id,
+        version: quota.version,
+        period_start: quota.period_start,
+        period_end: quota.period_end,
+        amount: quota.target_minor,
+        currency: quota.currency,
+      }}
+      update={async (values) => {
+        const { data, error } = await api.PATCH("/quotas/{id}", {
+          params: { path: { id: quota.id }, ...ifMatch(quota.version) },
+          body: {
+            period_start: String(values.period_start),
+            period_end: String(values.period_end),
+            target_minor: parseEuroMinor(String(values.amount ?? "")),
+            currency: String(values.currency),
+          },
+        });
+        if (error) throwProblem(error);
+        return data;
+      }}
+      invalidate="quotas"
+      // Recompute this quota's attainment after the target changes — the
+      // attainment query is keyed ["quota-attainment", id].
+      recordKey="quota-attainment"
+    />
+  );
+}
+
+// Archive reuses the shared confirm-first ArchiveAction; on success the
+// ["quotas"] list refetches and the archived quota drops out.
+export function ArchiveQuotaAction({
+  quota,
+  onArchived,
+}: Readonly<{ quota: Quota; onArchived: () => void }>) {
+  const t = useT();
+  return (
+    <ArchiveAction<Quota>
+      label={t("quotas.archive.title")}
+      confirmText={t("quotas.archive.confirm")}
+      archive={async () => {
+        const { data, error } = await api.DELETE("/quotas/{id}", {
+          params: { path: { id: quota.id } },
+        });
+        if (error) throwProblem(error);
+        return data;
+      }}
+      invalidate="quotas"
+      recordKey="quota-attainment"
+      onArchived={onArchived}
+    />
+  );
+}

--- a/frontend/src/screens/quotas.forms.tsx
+++ b/frontend/src/screens/quotas.forms.tsx
@@ -10,6 +10,7 @@ import { ArchiveAction } from "./archive";
 import { ProblemError, throwProblem } from "./common";
 import { EditAction } from "./edit";
 import { useRoster } from "./entityref";
+import "./quotas.css";
 
 // The quota target write surface: create (owner-XOR-team side picker), edit
 // (reassign within the fixed side), and archive. Split out of quotas.tsx so
@@ -112,7 +113,9 @@ function SetTargetModal({
           period_start: periodStart,
           period_end: periodEnd,
           target_minor: parseEuroMinor(amount),
-          currency: currency.trim(),
+          // Currency is a 3-letter uppercase code on the wire (^[A-Z]{3}$);
+          // normalise a lowercase entry rather than bounce it off the server.
+          currency: currency.trim().toUpperCase(),
         },
       });
       if (error) throwProblem(error);
@@ -369,7 +372,7 @@ export function EditTargetAction({
             period_start: String(values.period_start),
             period_end: String(values.period_end),
             target_minor: parseEuroMinor(String(values.amount ?? "")),
-            currency: String(values.currency),
+            currency: String(values.currency).trim().toUpperCase(),
           },
         });
         if (error) throwProblem(error);

--- a/frontend/src/screens/quotas.forms.tsx
+++ b/frontend/src/screens/quotas.forms.tsx
@@ -203,7 +203,9 @@ function SetTargetModal({
             required
             onChange={(event) => setSubjectId(event.target.value)}
           >
-            <option value="" />
+            <option value="" disabled>
+              {side === "owner" ? t("quotas.pickOwner") : t("quotas.pickTeam")}
+            </option>
             {(roster.data ?? []).map((entry) => (
               <option key={entry.id} value={entry.id}>
                 {subjectLabel(entry)}
@@ -261,6 +263,7 @@ function SetTargetModal({
             type="text"
             value={currency}
             required
+            maxLength={3}
             onChange={(event) => setCurrency(event.target.value)}
           />
         </div>

--- a/frontend/src/screens/quotas.stories.tsx
+++ b/frontend/src/screens/quotas.stories.tsx
@@ -1,0 +1,166 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { AttainmentRing } from "../design-system/atoms";
+import { LocaleProvider } from "../i18n";
+import { QuotasView } from "./quotas";
+import { installFetchStub, jsonResponse, StoryProviders } from "./story-utils";
+
+// Quotas & attainment stories for the fe-uat render gate: the honest data
+// states (attainment banded met/accent/behind, empty, and the two 422
+// refusals) render off the same fetch-stub shapes the unit tests exercise —
+// never a live call.
+
+const page = { next_cursor: null, has_more: false };
+
+const ownerQuota = {
+  id: "q1",
+  workspace_id: "w1",
+  owner_id: "u1",
+  team_id: null,
+  period_start: "2026-07-01",
+  period_end: "2026-09-30",
+  target_minor: 28000000,
+  currency: "EUR",
+  version: 3,
+  created_at: "2026-06-28T16:40:00Z",
+  updated_at: "2026-07-01T09:12:00Z",
+};
+
+const users = {
+  data: [
+    {
+      id: "u1",
+      workspace_id: "w1",
+      email: "riya@example.co",
+      display_name: "Riya Patel",
+      timezone: "UTC",
+      status: "active",
+      is_agent: false,
+    },
+  ],
+  page,
+};
+
+const baseAttainment = {
+  quota_id: "q1",
+  target_minor: 28000000,
+  currency: "EUR",
+  as_of_date: "2026-08-15",
+  pace_pct: 64,
+  contributing_deals: [
+    { deal_id: "d1", base_value_minor: 17707200 },
+    { deal_id: "d2", base_value_minor: 9450000 },
+  ],
+};
+
+function attainment(band: "met" | "accent" | "behind") {
+  if (band === "met") {
+    return {
+      ...baseAttainment,
+      closed_won_minor: 31387200,
+      attainment_pct: 113,
+      gap_minor: 3387200,
+      band,
+    };
+  }
+  if (band === "accent") {
+    return {
+      ...baseAttainment,
+      closed_won_minor: 20160000,
+      attainment_pct: 72,
+      gap_minor: -7840000,
+      band,
+    };
+  }
+  return {
+    ...baseAttainment,
+    closed_won_minor: 11480000,
+    attainment_pct: 41,
+    gap_minor: -16520000,
+    band,
+  };
+}
+
+function quotaStory(routes: Record<string, () => Response>) {
+  return () => {
+    installFetchStub(routes);
+    return (
+      <StoryProviders>
+        <QuotasView />
+      </StoryProviders>
+    );
+  };
+}
+
+const withAttainment = (band: "met" | "accent" | "behind") =>
+  quotaStory({
+    "GET /quotas": () => jsonResponse({ data: [ownerQuota], page }),
+    "GET /quotas/q1/attainment": () => jsonResponse(attainment(band)),
+    "GET /users": () => jsonResponse(users),
+    "GET /deals/d1": () =>
+      jsonResponse({ id: "d1", name: "BÄR Pharma — Packaging QA" }),
+    "GET /deals/d2": () =>
+      jsonResponse({ id: "d2", name: "Brandt — Line QA Retrofit" }),
+  });
+
+const meta: Meta<typeof QuotasView> = {
+  title: "screens/quotas",
+  component: QuotasView,
+};
+export default meta;
+type Story = StoryObj<typeof QuotasView>;
+
+export const AttainmentMet: Story = { render: withAttainment("met") };
+export const AttainmentAccent: Story = { render: withAttainment("accent") };
+export const AttainmentBehind: Story = { render: withAttainment("behind") };
+
+export const NoQuota: Story = {
+  render: quotaStory({
+    "GET /quotas": () => jsonResponse({ data: [], page }),
+  }),
+};
+
+export const TargetZero: Story = {
+  render: quotaStory({
+    "GET /quotas": () => jsonResponse({ data: [ownerQuota], page }),
+    "GET /users": () => jsonResponse(users),
+    "GET /quotas/q1/attainment": () =>
+      jsonResponse(
+        {
+          code: "attainment_target_zero",
+          detail: "target is zero — set a target to compute attainment",
+          status: 422,
+        },
+        422,
+      ),
+  }),
+};
+
+export const ComputeError: Story = {
+  render: quotaStory({
+    "GET /quotas": () => jsonResponse({ data: [ownerQuota], page }),
+    "GET /users": () => jsonResponse(users),
+    "GET /quotas/q1/attainment": () =>
+      jsonResponse(
+        {
+          code: "attainment_computation_failed",
+          detail: "the clean-core query timed out",
+          status: 422,
+        },
+        422,
+      ),
+  }),
+};
+
+// The ring atom on its own, banded — the pure visual the attainment card
+// composes (no fetch, no providers beyond the locale).
+export const Ring: StoryObj<typeof AttainmentRing> = {
+  render: () => (
+    <LocaleProvider initial="en">
+      <div style={{ display: "flex", gap: "var(--space-6)" }}>
+        <AttainmentRing pct={113} band="met" caption="attained" />
+        <AttainmentRing pct={72} band="accent" caption="attained" />
+        <AttainmentRing pct={41} band="behind" caption="attained" />
+      </div>
+    </LocaleProvider>
+  ),
+};

--- a/frontend/src/screens/quotas.test.tsx
+++ b/frontend/src/screens/quotas.test.tsx
@@ -1,0 +1,374 @@
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { components } from "../api/schema";
+import { AttainmentRing } from "../design-system/atoms";
+import { LocaleProvider } from "../i18n";
+import { AttainmentNumbers, PaceLine, QuotasView } from "./quotas";
+import { isOwnerXorTeam, parseEuroMinor } from "./quotas.forms";
+
+// Quotas & attainment (RD-T06) acceptance: the ring reflects the server band
+// (never a client recompute), the pace compare is ahead/behind/met, honest 422
+// refusals draw no ring, the owner-XOR-team 422 branches to a targeted message,
+// unresolved deal names fall back to an id, and target entry is integer-euro.
+
+const page = { next_cursor: null, has_more: false };
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+// A method+path router over the same global-fetch seam the app's api client
+// resolves per call. Path patterns use :param wildcards; an unmatched route
+// falls through to an empty page (the honest default for a GET a test ignores).
+type Handler = (ctx: { body: unknown }) => Response;
+function installRouter(routes: Record<string, Handler>) {
+  const compiled = Object.entries(routes).map(([key, handler]) => {
+    const [method, pattern] = key.split(" ");
+    const regex = new RegExp(`^${pattern.replace(/:[^/]+/g, "[^/]+")}$`);
+    return { method, regex, handler };
+  });
+  const fetchMock = vi.fn(
+    async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = input instanceof Request ? input : null;
+      const url = new URL(
+        request ? request.url : String(input),
+        "http://localhost",
+      );
+      const method = (request?.method ?? init?.method ?? "GET").toUpperCase();
+      const path = url.pathname.replace(/^\/v1/, "");
+      let body: unknown = null;
+      if (method !== "GET") {
+        try {
+          body = request
+            ? await request.json()
+            : JSON.parse(String(init?.body));
+        } catch {
+          body = null;
+        }
+      }
+      const match = compiled.find(
+        (route) => route.method === method && route.regex.test(path),
+      );
+      return match ? match.handler({ body }) : jsonResponse({ data: [], page });
+    },
+  );
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+function mount(ui: ReactNode) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <LocaleProvider initial="en">{ui}</LocaleProvider>
+    </QueryClientProvider>,
+  );
+}
+
+function renderPure(ui: ReactNode) {
+  return render(<LocaleProvider initial="en">{ui}</LocaleProvider>);
+}
+
+const ownerQuota = {
+  id: "q1",
+  workspace_id: "w1",
+  owner_id: "u1",
+  team_id: null,
+  period_start: "2026-07-01",
+  period_end: "2026-09-30",
+  target_minor: 28000000,
+  currency: "EUR",
+  version: 3,
+  created_at: "2026-06-28T16:40:00Z",
+  updated_at: "2026-07-01T09:12:00Z",
+};
+
+const users = {
+  data: [
+    {
+      id: "u1",
+      workspace_id: "w1",
+      email: "riya@example.co",
+      display_name: "Riya Patel",
+      timezone: "UTC",
+      status: "active",
+      is_agent: false,
+    },
+  ],
+  page,
+};
+
+const attainmentMet: components["schemas"]["QuotaAttainment"] = {
+  quota_id: "q1",
+  closed_won_minor: 31387200,
+  target_minor: 28000000,
+  currency: "EUR",
+  attainment_pct: 113,
+  gap_minor: 3387200,
+  pace_pct: 64,
+  band: "met",
+  as_of_date: "2026-08-15",
+  contributing_deals: [{ deal_id: "d1", base_value_minor: 17707200 }],
+};
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("AttainmentRing", () => {
+  function arc(container: HTMLElement) {
+    const circles = container.querySelectorAll("circle");
+    // [0] is the background track; [1] is the value arc.
+    return circles[1];
+  }
+  const circumference = 2 * Math.PI * 68;
+
+  it("colours the arc by the server band, not the raw percentage", () => {
+    const met = renderPure(
+      <AttainmentRing pct={113} band="met" caption="attained" />,
+    );
+    expect(arc(met.container).getAttribute("stroke")).toBe("var(--online)");
+    expect(met.getByText("113%")).toBeTruthy();
+    cleanup();
+
+    const accent = renderPure(
+      <AttainmentRing pct={72} band="accent" caption="attained" />,
+    );
+    expect(arc(accent.container).getAttribute("stroke")).toBe("var(--accent)");
+    cleanup();
+
+    const behind = renderPure(
+      <AttainmentRing pct={41} band="behind" caption="attained" />,
+    );
+    expect(arc(behind.container).getAttribute("stroke")).toBe("var(--away)");
+  });
+
+  it("offsets the dash by min(pct/100, 1) and caps a full circle over 100%", () => {
+    const half = renderPure(
+      <AttainmentRing pct={50} band="behind" caption="attained" />,
+    );
+    const halfOffset = Number(
+      arc(half.container).getAttribute("stroke-dashoffset"),
+    );
+    expect(halfOffset).toBeCloseTo(circumference * 0.5, 3);
+    cleanup();
+
+    // 150% attainment caps the arc at a full circle (offset 0) — the centre
+    // still prints the real, uncapped figure.
+    const over = renderPure(
+      <AttainmentRing pct={150} band="met" caption="attained" />,
+    );
+    expect(
+      Number(arc(over.container).getAttribute("stroke-dashoffset")),
+    ).toBeCloseTo(0, 6);
+    expect(over.getByText("150%")).toBeTruthy();
+  });
+});
+
+describe("PaceLine", () => {
+  it("reads met from the band, then compares attainment_pct against pace_pct", () => {
+    const met = renderPure(<PaceLine attainment={attainmentMet} />);
+    expect(met.getByText("Target met — 113% attained.")).toBeTruthy();
+    cleanup();
+
+    const ahead = renderPure(
+      <PaceLine
+        attainment={{
+          ...attainmentMet,
+          band: "accent",
+          attainment_pct: 70,
+          pace_pct: 64,
+        }}
+      />,
+    );
+    expect(
+      ahead.getByText("Ahead of pace — 70% attained vs 64% of period elapsed."),
+    ).toBeTruthy();
+    cleanup();
+
+    const behind = renderPure(
+      <PaceLine
+        attainment={{
+          ...attainmentMet,
+          band: "behind",
+          attainment_pct: 41,
+          pace_pct: 64,
+        }}
+      />,
+    );
+    expect(
+      behind.getByText("Behind pace — 41% attained vs 64% of period elapsed."),
+    ).toBeTruthy();
+  });
+});
+
+describe("AttainmentNumbers", () => {
+  it("prefixes a non-negative gap with '+' and labels base-currency money", () => {
+    const over = renderPure(
+      <AttainmentNumbers attainment={attainmentMet} locale="en" />,
+    );
+    // gap_minor 3387200 is positive once over target → shown with a leading +.
+    expect(over.getByText(/^\+/)).toBeTruthy();
+  });
+});
+
+describe("parseEuroMinor", () => {
+  it("parses grouped integer euros to minor units and round-trips", () => {
+    expect(parseEuroMinor("280.000")).toBe(28000000);
+    expect(parseEuroMinor("1234")).toBe(123400);
+    expect(parseEuroMinor("")).toBe(0);
+    expect(parseEuroMinor("abc")).toBe(0);
+  });
+});
+
+describe("isOwnerXorTeam", () => {
+  it("matches the branchable code at the top level or in details.errors", () => {
+    expect(isOwnerXorTeam({ code: "owner_xor_team_required" })).toBe(true);
+    expect(
+      isOwnerXorTeam({
+        code: "validation_error",
+        details: { errors: [{ code: "owner_xor_team_required" }] },
+      }),
+    ).toBe(true);
+    expect(
+      isOwnerXorTeam({
+        code: "validation_error",
+        details: { errors: [{ code: "period_start_required" }] },
+      }),
+    ).toBe(false);
+    expect(isOwnerXorTeam(null)).toBe(false);
+  });
+});
+
+describe("QuotasView", () => {
+  it("renders the attainment ring, resolved names, and contributing deal", async () => {
+    installRouter({
+      "GET /quotas": () => jsonResponse({ data: [ownerQuota], page }),
+      "GET /quotas/:id/attainment": () => jsonResponse(attainmentMet),
+      "GET /users": () => jsonResponse(users),
+      "GET /teams": () => jsonResponse({ data: [], page }),
+      "GET /deals/:id": () =>
+        jsonResponse({ id: "d1", name: "BÄR Pharma — Packaging QA" }),
+    });
+    mount(<QuotasView />);
+    expect(await screen.findByText("113%")).toBeTruthy();
+    expect(screen.getByText("Target met — 113% attained.")).toBeTruthy();
+    expect(await screen.findByText("Riya Patel")).toBeTruthy();
+    expect(await screen.findByText("BÄR Pharma — Packaging QA")).toBeTruthy();
+  });
+
+  it("shows the empty state with a CTA when no quota is set", async () => {
+    installRouter({ "GET /quotas": () => jsonResponse({ data: [], page }) });
+    mount(<QuotasView />);
+    expect(await screen.findByText("No quota set")).toBeTruthy();
+    expect(screen.getByTestId("quota-create")).toBeTruthy();
+  });
+
+  it("refuses target-zero attainment with the server detail and no ring", async () => {
+    installRouter({
+      "GET /quotas": () => jsonResponse({ data: [ownerQuota], page }),
+      "GET /users": () => jsonResponse(users),
+      "GET /quotas/:id/attainment": () =>
+        jsonResponse(
+          {
+            code: "attainment_target_zero",
+            detail: "target is zero — set a target to compute attainment",
+            status: 422,
+          },
+          422,
+        ),
+    });
+    mount(<QuotasView />);
+    expect(
+      await screen.findByText("This quota has no target yet"),
+    ).toBeTruthy();
+    expect(
+      screen.getByText("target is zero — set a target to compute attainment"),
+    ).toBeTruthy();
+    // No ring is drawn for an un-computable attainment.
+    expect(screen.queryByText("attained")).toBeNull();
+  });
+
+  it("refuses a failed computation with a retry, never a stale ring", async () => {
+    installRouter({
+      "GET /quotas": () => jsonResponse({ data: [ownerQuota], page }),
+      "GET /users": () => jsonResponse(users),
+      "GET /quotas/:id/attainment": () =>
+        jsonResponse(
+          {
+            code: "attainment_computation_failed",
+            detail: "the clean-core query timed out",
+            status: 422,
+          },
+          422,
+        ),
+    });
+    mount(<QuotasView />);
+    expect(
+      await screen.findByText("Attainment couldn't be computed"),
+    ).toBeTruthy();
+    expect(screen.getByText("the clean-core query timed out")).toBeTruthy();
+    expect(screen.getByText("Retry")).toBeTruthy();
+    expect(screen.queryByText("attained")).toBeNull();
+  });
+
+  it("falls back to the deal id when the deal name can't be resolved", async () => {
+    installRouter({
+      "GET /quotas": () => jsonResponse({ data: [ownerQuota], page }),
+      "GET /users": () => jsonResponse(users),
+      "GET /quotas/:id/attainment": () =>
+        jsonResponse({
+          ...attainmentMet,
+          contributing_deals: [{ deal_id: "d2", base_value_minor: 9450000 }],
+        }),
+      "GET /deals/:id": () =>
+        jsonResponse({ code: "not_found", status: 404 }, 404),
+    });
+    mount(<QuotasView />);
+    // The unresolved deal renders its id, never a fabricated name.
+    expect(await screen.findByText("d2")).toBeTruthy();
+  });
+
+  it("branches the owner-XOR-team 422 to a targeted message on create", async () => {
+    installRouter({
+      "GET /quotas": () => jsonResponse({ data: [], page }),
+      "GET /users": () => jsonResponse(users),
+      "GET /teams": () => jsonResponse({ data: [], page }),
+      "POST /quotas": () =>
+        jsonResponse(
+          {
+            code: "validation_error",
+            detail: "validation failed",
+            status: 422,
+            details: { errors: [{ code: "owner_xor_team_required" }] },
+          },
+          422,
+        ),
+    });
+    mount(<QuotasView />);
+    await userEvent.click(await screen.findByTestId("quota-create"));
+    fireEvent.change(await screen.findByRole("combobox"), {
+      target: { value: "u1" },
+    });
+    const dateInputs = document.querySelectorAll('input[type="date"]');
+    fireEvent.change(dateInputs[0], { target: { value: "2026-07-01" } });
+    fireEvent.change(dateInputs[1], { target: { value: "2026-09-30" } });
+    fireEvent.change(screen.getByLabelText(/Target amount/), {
+      target: { value: "280000" },
+    });
+    await userEvent.click(screen.getByTestId("quota-create-submit"));
+    expect(
+      await screen.findByText("Choose exactly one of owner or team."),
+    ).toBeTruthy();
+  });
+});

--- a/frontend/src/screens/quotas.test.tsx
+++ b/frontend/src/screens/quotas.test.tsx
@@ -357,9 +357,11 @@ describe("QuotasView", () => {
     });
     mount(<QuotasView />);
     await userEvent.click(await screen.findByTestId("quota-create"));
-    fireEvent.change(await screen.findByRole("combobox"), {
-      target: { value: "u1" },
-    });
+    const subjectSelect = await screen.findByRole("combobox");
+    // Wait for the roster-fetched option to render — setting .value before the
+    // matching <option> exists silently no-ops (leaving canSubmit false).
+    await screen.findByRole("option", { name: "Riya Patel" });
+    fireEvent.change(subjectSelect, { target: { value: "u1" } });
     const dateInputs = document.querySelectorAll('input[type="date"]');
     fireEvent.change(dateInputs[0], { target: { value: "2026-07-01" } });
     fireEvent.change(dateInputs[1], { target: { value: "2026-09-30" } });

--- a/frontend/src/screens/quotas.tsx
+++ b/frontend/src/screens/quotas.tsx
@@ -1,6 +1,6 @@
 import { type UseQueryResult, useQuery } from "@tanstack/react-query";
 import { Calculator, Server } from "lucide-react";
-import { useState } from "react";
+import { useId, useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
 import {
@@ -153,9 +153,10 @@ export function AttainmentNumbers({
 // verbatim: the counted total is closed_won_minor (never the client sum of
 // contributing_deals, though the contract guarantees they're equal).
 function ExplainBox({
+  id,
   attainment,
   locale,
-}: Readonly<{ attainment: QuotaAttainment; locale: Locale }>) {
+}: Readonly<{ id: string; attainment: QuotaAttainment; locale: Locale }>) {
   const t = useT();
   const currency = attainment.currency;
   const sum = formatMoney(attainment.closed_won_minor, currency, locale);
@@ -163,7 +164,7 @@ function ExplainBox({
   const pct = Math.round(attainment.attainment_pct);
   const count = attainment.contributing_deals.length;
   return (
-    <div className="explain-box">
+    <div className="explain-box" id={id}>
       <span>{t("quotas.explain.formula")}</span>
       <span>{t("quotas.explain.closedWon", { sum, count })}</span>
       <span>{t("quotas.explain.target", { target })}</span>
@@ -179,6 +180,7 @@ function AttainmentCard({
 }: Readonly<{ attainment: QuotaAttainment; locale: Locale }>) {
   const t = useT();
   const [showExplain, setShowExplain] = useState(false);
+  const explainId = useId();
   return (
     <Card className="attain-card">
       <AttainmentRing
@@ -190,7 +192,12 @@ function AttainmentCard({
         <AttainmentNumbers attainment={attainment} locale={locale} />
         <PaceLine attainment={attainment} />
         <div className="attain-meta">
-          <Button small onClick={() => setShowExplain((value) => !value)}>
+          <Button
+            small
+            aria-expanded={showExplain}
+            aria-controls={explainId}
+            onClick={() => setShowExplain((value) => !value)}
+          >
             <Calculator aria-hidden style={{ width: 13, height: 13 }} />
             {t("explain.open")}
           </Button>
@@ -199,7 +206,9 @@ function AttainmentCard({
             {t("quotas.computed")}
           </span>
         </div>
-        {showExplain && <ExplainBox attainment={attainment} locale={locale} />}
+        {showExplain && (
+          <ExplainBox id={explainId} attainment={attainment} locale={locale} />
+        )}
         <p className="t-caption">
           {t("quotas.baseCurrencyNote", { currency: attainment.currency })}
         </p>

--- a/frontend/src/screens/quotas.tsx
+++ b/frontend/src/screens/quotas.tsx
@@ -1,4 +1,5 @@
 import { type UseQueryResult, useQuery } from "@tanstack/react-query";
+import { Calculator, Server } from "lucide-react";
 import { useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
@@ -58,7 +59,8 @@ function useAttainment(quotaId: string) {
         params: { path: { id: quotaId } },
       });
       if (error) {
-        // throwProblem keeps the RFC 7807 body so the code is branchable.
+        // ProblemError carries the RFC 7807 body so the section can branch on
+        // its `code` (target-zero vs computation-failed) rather than a message.
         throw new ProblemError(error);
       }
       return data;
@@ -115,7 +117,8 @@ export function AttainmentNumbers({
   const t = useT();
   const currency = attainment.currency;
   const gap = attainment.gap_minor;
-  const gapText = (gap >= 0 ? "+" : "") + formatMoney(gap, currency, locale);
+  const overTarget = gap >= 0;
+  const gapText = (overTarget ? "+" : "") + formatMoney(gap, currency, locale);
   return (
     <div className="attain-numbers">
       <div className="attain-row">
@@ -133,7 +136,14 @@ export function AttainmentNumbers({
       </div>
       <div className="attain-row">
         <span className="k">{t("quotas.gap")}</span>
-        <span className="v t-mono">{gapText}</span>
+        {/* A gap at/over target reads positive (green); short of target stays
+            neutral — sign alone shouldn't be the only cue (a11y). */}
+        <span
+          className="v t-mono"
+          style={overTarget ? { color: "var(--online)" } : undefined}
+        >
+          {gapText}
+        </span>
       </div>
     </div>
   );
@@ -181,9 +191,13 @@ function AttainmentCard({
         <PaceLine attainment={attainment} />
         <div className="attain-meta">
           <Button small onClick={() => setShowExplain((value) => !value)}>
+            <Calculator aria-hidden style={{ width: 13, height: 13 }} />
             {t("explain.open")}
           </Button>
-          <span className="computed-chip">{t("quotas.computed")}</span>
+          <span className="computed-chip">
+            <Server aria-hidden />
+            {t("quotas.computed")}
+          </span>
         </div>
         {showExplain && <ExplainBox attainment={attainment} locale={locale} />}
         <p className="t-caption">
@@ -210,28 +224,30 @@ export function ContributingDeals({
         <h2>{t("quotas.contributing.title")}</h2>
         <span className="sub">{t("quotas.contributing.subtitle")}</span>
       </div>
-      <DataTable
-        columns={[
-          {
-            key: "deal",
-            header: t("quotas.contributing.deal"),
-            render: (row: QuotaAttainment["contributing_deals"][number]) => (
-              <EntityRef kind="deal" id={row.deal_id} />
-            ),
-          },
-          {
-            key: "amount",
-            header: t("quotas.contributing.amount"),
-            render: (row: QuotaAttainment["contributing_deals"][number]) => (
-              <span className="t-mono">
-                {formatMoney(row.base_value_minor, currency, locale)}
-              </span>
-            ),
-          },
-        ]}
-        rows={attainment.contributing_deals}
-        rowKey={(row) => row.deal_id}
-      />
+      <div className="quota-contrib">
+        <DataTable
+          columns={[
+            {
+              key: "deal",
+              header: t("quotas.contributing.deal"),
+              render: (row: QuotaAttainment["contributing_deals"][number]) => (
+                <EntityRef kind="deal" id={row.deal_id} />
+              ),
+            },
+            {
+              key: "amount",
+              header: t("quotas.contributing.amount"),
+              render: (row: QuotaAttainment["contributing_deals"][number]) => (
+                <span className="t-mono">
+                  {formatMoney(row.base_value_minor, currency, locale)}
+                </span>
+              ),
+            },
+          ]}
+          rows={attainment.contributing_deals}
+          rowKey={(row) => row.deal_id}
+        />
+      </div>
       <div className="quota-foot">
         <span className="k">{t("quotas.contributing.total")}</span>
         <span className="v t-mono">
@@ -437,8 +453,13 @@ function EmptyQuota({
   const t = useT();
   return (
     <EmptyState>
-      <b>{t("quotas.empty.title")}</b>
-      <p className="t-caption" style={{ margin: "8px 0 14px" }}>
+      <b style={{ color: "var(--textPrimary)", fontSize: 14 }}>
+        {t("quotas.empty.title")}
+      </b>
+      <p
+        className="t-caption"
+        style={{ margin: "8px auto 14px", maxWidth: "42ch" }}
+      >
         {t("quotas.empty.body")}
       </p>
       <SetTargetAction label={t("quotas.empty.cta")} onCreated={onCreated} />

--- a/frontend/src/screens/quotas.tsx
+++ b/frontend/src/screens/quotas.tsx
@@ -1,0 +1,507 @@
+import { type UseQueryResult, useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import { api } from "../api/client";
+import type { components } from "../api/schema";
+import {
+  AttainmentRing,
+  Button,
+  Card,
+  DataTable,
+  EmptyState,
+  Skeleton,
+} from "../design-system/atoms";
+import { formatMoney } from "../format/format";
+import { type Locale, useLocale, useT } from "../i18n";
+import { ProblemError, problemMessage, QueryGate } from "./common";
+import { EntityRef } from "./entityref";
+import {
+  ArchiveQuotaAction,
+  EditTargetAction,
+  SetTargetAction,
+} from "./quotas.forms";
+import "./quotas.css";
+
+// Quotas & attainment (RD-T06): a human-set revenue target and its
+// server-computed attainment. Everything numeric — band, attainment_pct,
+// gap_minor, pace_pct, closed_won_minor — arrives from the server verbatim;
+// the only UI computations are the ring's dash-offset (in the atom), the pace
+// ahead/behind compare, and the integer-euro parse on target entry. Money in
+// the attainment view is the WORKSPACE BASE currency (QuotaAttainment.currency),
+// not Quota.currency — labelled as such.
+
+type Quota = components["schemas"]["Quota"];
+type QuotaAttainment = components["schemas"]["QuotaAttainment"];
+
+export function useQuotas() {
+  return useQuery({
+    queryKey: ["quotas"],
+    queryFn: async () => {
+      const { data, error } = await api.GET("/quotas", {
+        params: { query: {} },
+      });
+      if (error) throw new Error(problemMessage(error));
+      return data.data;
+    },
+  });
+}
+
+// Attainment is a separate sub-resource read; a 422 (target zero /
+// computation failed) must surface distinctly, so the error is thrown as a
+// ProblemError carrying the structured body and the section branches on its
+// code rather than collapsing to a generic failure.
+function useAttainment(quotaId: string) {
+  return useQuery({
+    queryKey: ["quota-attainment", quotaId],
+    enabled: quotaId !== "",
+    queryFn: async (): Promise<QuotaAttainment> => {
+      const { data, error } = await api.GET("/quotas/{id}/attainment", {
+        params: { path: { id: quotaId } },
+      });
+      if (error) {
+        // throwProblem keeps the RFC 7807 body so the code is branchable.
+        throw new ProblemError(error);
+      }
+      return data;
+    },
+  });
+}
+
+function problemCode(problem: unknown): string | null {
+  if (problem && typeof problem === "object") {
+    const code = (problem as Record<string, unknown>).code;
+    if (typeof code === "string") return code;
+  }
+  return null;
+}
+
+// Pace is the consumer's compare (the field carries period progress only): a
+// met band reads "target met"; otherwise attainment at or past the elapsed
+// fraction is ahead, short of it is behind. Never recomputes the band.
+type PaceState = "met" | "ahead" | "behind";
+function paceState(attainment: QuotaAttainment): PaceState {
+  if (attainment.band === "met") return "met";
+  return attainment.attainment_pct >= attainment.pace_pct ? "ahead" : "behind";
+}
+
+export function PaceLine({
+  attainment,
+}: Readonly<{ attainment: QuotaAttainment }>) {
+  const t = useT();
+  const state = paceState(attainment);
+  const pct = Math.round(attainment.attainment_pct);
+  const pace = Math.round(attainment.pace_pct);
+  const message =
+    state === "met"
+      ? t("quotas.pace.met", { pct })
+      : state === "ahead"
+        ? t("quotas.pace.ahead", { pct, pace })
+        : t("quotas.pace.behind", { pct, pace });
+  const dotColor = state === "behind" ? "var(--away)" : "var(--online)";
+  return (
+    <div className="pace-line">
+      <span className="pace-dot" style={{ background: dotColor }} />
+      <span>{message}</span>
+    </div>
+  );
+}
+
+// The signed closed-won / target / gap block. The gap is signed on the wire
+// (positive once over target); the display prefixes "+" for a non-negative
+// gap — the negative sign already rides the formatted figure.
+export function AttainmentNumbers({
+  attainment,
+  locale,
+}: Readonly<{ attainment: QuotaAttainment; locale: Locale }>) {
+  const t = useT();
+  const currency = attainment.currency;
+  const gap = attainment.gap_minor;
+  const gapText = (gap >= 0 ? "+" : "") + formatMoney(gap, currency, locale);
+  return (
+    <div className="attain-numbers">
+      <div className="attain-row">
+        <span className="k strong">{t("quotas.closedWon")}</span>
+        <span className="v t-mono">
+          {formatMoney(attainment.closed_won_minor, currency, locale)}
+        </span>
+      </div>
+      <div className="attain-div" />
+      <div className="attain-row">
+        <span className="k">{t("quotas.target")}</span>
+        <span className="v t-mono">
+          {formatMoney(attainment.target_minor, currency, locale)}
+        </span>
+      </div>
+      <div className="attain-row">
+        <span className="k">{t("quotas.gap")}</span>
+        <span className="v t-mono">{gapText}</span>
+      </div>
+    </div>
+  );
+}
+
+// The "Explain this number" decomposition, rendered from the server figures
+// verbatim: the counted total is closed_won_minor (never the client sum of
+// contributing_deals, though the contract guarantees they're equal).
+function ExplainBox({
+  attainment,
+  locale,
+}: Readonly<{ attainment: QuotaAttainment; locale: Locale }>) {
+  const t = useT();
+  const currency = attainment.currency;
+  const sum = formatMoney(attainment.closed_won_minor, currency, locale);
+  const target = formatMoney(attainment.target_minor, currency, locale);
+  const pct = Math.round(attainment.attainment_pct);
+  const count = attainment.contributing_deals.length;
+  return (
+    <div className="explain-box">
+      <span>{t("quotas.explain.formula")}</span>
+      <span>{t("quotas.explain.closedWon", { sum, count })}</span>
+      <span>{t("quotas.explain.target", { target })}</span>
+      <span>{t("quotas.explain.result", { sum, target, pct })}</span>
+      <span className="t-caption">{t("quotas.explain.exclusions")}</span>
+    </div>
+  );
+}
+
+function AttainmentCard({
+  attainment,
+  locale,
+}: Readonly<{ attainment: QuotaAttainment; locale: Locale }>) {
+  const t = useT();
+  const [showExplain, setShowExplain] = useState(false);
+  return (
+    <Card className="attain-card">
+      <AttainmentRing
+        pct={attainment.attainment_pct}
+        band={attainment.band}
+        caption={t("quotas.attained")}
+      />
+      <div className="attain-body">
+        <AttainmentNumbers attainment={attainment} locale={locale} />
+        <PaceLine attainment={attainment} />
+        <div className="attain-meta">
+          <Button small onClick={() => setShowExplain((value) => !value)}>
+            {t("explain.open")}
+          </Button>
+          <span className="computed-chip">{t("quotas.computed")}</span>
+        </div>
+        {showExplain && <ExplainBox attainment={attainment} locale={locale} />}
+        <p className="t-caption">
+          {t("quotas.baseCurrencyNote", { currency: attainment.currency })}
+        </p>
+      </div>
+    </Card>
+  );
+}
+
+// The per-deal breakdown. Deal names resolve best-effort through the shared
+// EntityRef (cached GET /deals/{id}); an unresolved id renders as a mono id,
+// never a fabricated name. The footer total is the authoritative
+// closed_won_minor.
+export function ContributingDeals({
+  attainment,
+  locale,
+}: Readonly<{ attainment: QuotaAttainment; locale: Locale }>) {
+  const t = useT();
+  const currency = attainment.currency;
+  return (
+    <Card>
+      <div className="section-header">
+        <h2>{t("quotas.contributing.title")}</h2>
+        <span className="sub">{t("quotas.contributing.subtitle")}</span>
+      </div>
+      <DataTable
+        columns={[
+          {
+            key: "deal",
+            header: t("quotas.contributing.deal"),
+            render: (row: QuotaAttainment["contributing_deals"][number]) => (
+              <EntityRef kind="deal" id={row.deal_id} />
+            ),
+          },
+          {
+            key: "amount",
+            header: t("quotas.contributing.amount"),
+            render: (row: QuotaAttainment["contributing_deals"][number]) => (
+              <span className="t-mono">
+                {formatMoney(row.base_value_minor, currency, locale)}
+              </span>
+            ),
+          },
+        ]}
+        rows={attainment.contributing_deals}
+        rowKey={(row) => row.deal_id}
+      />
+      <div className="quota-foot">
+        <span className="k">{t("quotas.contributing.total")}</span>
+        <span className="v t-mono">
+          {formatMoney(attainment.closed_won_minor, currency, locale)}
+        </span>
+      </div>
+      <p className="t-caption" style={{ textAlign: "right" }}>
+        {t("quotas.contributing.caption")}
+      </p>
+    </Card>
+  );
+}
+
+// The honest refusal / error card — target-zero and compute-failed render the
+// server detail and deliberately draw NO ring (a guessed figure would be worse
+// than none). A recoverable failure carries a Retry.
+function AttainmentRefusal({
+  title,
+  detail,
+  onRetry,
+}: Readonly<{ title: string; detail: string; onRetry?: () => void }>) {
+  const t = useT();
+  return (
+    <Card>
+      <div className="attain-refusal">
+        <b>{title}</b>
+        <p className="t-caption">{detail}</p>
+        {onRetry && (
+          <Button small onClick={onRetry} style={{ alignSelf: "flex-start" }}>
+            {t("common.retry")}
+          </Button>
+        )}
+      </div>
+    </Card>
+  );
+}
+
+function AttainmentSkeleton() {
+  return (
+    <Card className="attain-card">
+      <Skeleton width={160} height={160} />
+      <div className="attain-body">
+        <Skeleton width="70%" />
+        <Skeleton width="50%" />
+        <Skeleton width="60%" />
+      </div>
+    </Card>
+  );
+}
+
+function AttainmentSection({
+  query,
+  locale,
+}: Readonly<{
+  query: UseQueryResult<QuotaAttainment>;
+  locale: Locale;
+}>) {
+  const t = useT();
+  if (query.isPending) {
+    return <AttainmentSkeleton />;
+  }
+  if (query.isError) {
+    const problem =
+      query.error instanceof ProblemError ? query.error.problem : null;
+    const code = problemCode(problem);
+    const detail =
+      query.error instanceof Error ? query.error.message : t("common.error");
+    if (code === "attainment_target_zero") {
+      return (
+        <AttainmentRefusal title={t("quotas.err.targetZero")} detail={detail} />
+      );
+    }
+    if (code === "attainment_computation_failed") {
+      return (
+        <AttainmentRefusal
+          title={t("quotas.err.computeFailed")}
+          detail={detail}
+          onRetry={() => query.refetch()}
+        />
+      );
+    }
+    return (
+      <AttainmentRefusal
+        title={t("common.error")}
+        detail={detail}
+        onRetry={() => query.refetch()}
+      />
+    );
+  }
+  const attainment = query.data;
+  return (
+    <>
+      <AttainmentCard attainment={attainment} locale={locale} />
+      <ContributingDeals attainment={attainment} locale={locale} />
+    </>
+  );
+}
+
+function QuotaRowLabel({
+  quota,
+  locale,
+}: Readonly<{ quota: Quota; locale: Locale }>) {
+  const t = useT();
+  const isOwner = quota.owner_id != null;
+  const role = isOwner ? t("quotas.role.owner") : t("quotas.role.team");
+  return (
+    <div>
+      <div className="quota-row-top">
+        <span className="quota-row-name">
+          <EntityRef
+            kind={isOwner ? "user" : "team"}
+            id={isOwner ? quota.owner_id : quota.team_id}
+          />
+        </span>
+        <span className="t-mono quota-row-target">
+          {formatMoney(quota.target_minor, quota.currency, locale)}
+        </span>
+      </div>
+      <span className="quota-row-sub t-caption">
+        {role} ·{" "}
+        {t("quotas.periodRange", {
+          start: quota.period_start,
+          end: quota.period_end,
+        })}
+      </span>
+    </div>
+  );
+}
+
+function QuotaSelector({
+  list,
+  activeId,
+  onSelect,
+  onCreated,
+}: Readonly<{
+  list: Quota[];
+  activeId: string;
+  onSelect: (id: string) => void;
+  onCreated: (id: string) => void;
+}>) {
+  const t = useT();
+  const { locale } = useLocale();
+  return (
+    <Card>
+      <div className="section-header">
+        <h2>{t("quotas.tab")}</h2>
+        <SetTargetAction label={t("quotas.target.new")} onCreated={onCreated} />
+      </div>
+      <div className="quota-list">
+        {list.map((quota) => (
+          <button
+            key={quota.id}
+            type="button"
+            className={quota.id === activeId ? "quota-row active" : "quota-row"}
+            aria-pressed={quota.id === activeId}
+            onClick={() => onSelect(quota.id)}
+          >
+            <QuotaRowLabel quota={quota} locale={locale} />
+          </button>
+        ))}
+      </div>
+    </Card>
+  );
+}
+
+export function ScopeNote() {
+  const t = useT();
+  return (
+    <Card>
+      <div className="section-header">
+        <h2>{t("quotas.scopeNote.title")}</h2>
+        <span className="sub">{t("quotas.scopeNote.flag")}</span>
+      </div>
+      <p className="t-caption">{t("quotas.scopeNote.body")}</p>
+    </Card>
+  );
+}
+
+function TargetRail({
+  quota,
+  onArchived,
+}: Readonly<{ quota: Quota; onArchived: () => void }>) {
+  const t = useT();
+  return (
+    <Card>
+      <div className="section-header">
+        <h2>{t("quotas.target.title")}</h2>
+      </div>
+      <div className="rail-actions">
+        <EditTargetAction label={t("quotas.target.edit")} quota={quota} />
+        <p className="t-caption">{t("quotas.target.note")}</p>
+        <p className="t-caption">{t("quotas.target.sideFixed")}</p>
+      </div>
+      <div className="rail-div" />
+      <ArchiveQuotaAction quota={quota} onArchived={onArchived} />
+    </Card>
+  );
+}
+
+function EmptyQuota({
+  onCreated,
+}: Readonly<{ onCreated: (id: string) => void }>) {
+  const t = useT();
+  return (
+    <EmptyState>
+      <b>{t("quotas.empty.title")}</b>
+      <p className="t-caption" style={{ margin: "8px 0 14px" }}>
+        {t("quotas.empty.body")}
+      </p>
+      <SetTargetAction label={t("quotas.empty.cta")} onCreated={onCreated} />
+    </EmptyState>
+  );
+}
+
+function QuotasBody({
+  list,
+  active,
+  onSelect,
+  onCreated,
+  onArchived,
+}: Readonly<{
+  list: Quota[];
+  active: Quota;
+  onSelect: (id: string) => void;
+  onCreated: (id: string) => void;
+  onArchived: () => void;
+}>) {
+  const { locale } = useLocale();
+  const attainment = useAttainment(active.id);
+  return (
+    <div className="qgrid">
+      <div className="colstack">
+        <QuotaSelector
+          list={list}
+          activeId={active.id}
+          onSelect={onSelect}
+          onCreated={onCreated}
+        />
+        <AttainmentSection query={attainment} locale={locale} />
+        <ScopeNote />
+      </div>
+      <div className="colstack">
+        <TargetRail quota={active} onArchived={onArchived} />
+      </div>
+    </div>
+  );
+}
+
+export function QuotasView() {
+  const quotasQuery = useQuotas();
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  return (
+    <QueryGate query={quotasQuery}>
+      {(list) => {
+        if (list.length === 0) {
+          return <EmptyQuota onCreated={setSelectedId} />;
+        }
+        // First quota selected by default; a stale selection (e.g. after an
+        // archive) falls back to the first row rather than a blank detail.
+        const active = list.find((quota) => quota.id === selectedId) ?? list[0];
+        return (
+          <QuotasBody
+            list={list}
+            active={active}
+            onSelect={setSelectedId}
+            onCreated={setSelectedId}
+            onArchived={() => setSelectedId(null)}
+          />
+        );
+      }}
+    </QueryGate>
+  );
+}

--- a/frontend/src/screens/reports.test.tsx
+++ b/frontend/src/screens/reports.test.tsx
@@ -174,6 +174,20 @@ describe("ReportsScreen", () => {
     await waitFor(() => expect(screen.getByText("o1")).toBeTruthy());
   });
 
+  it("the Quotas segment renders the quota surface and skips the report run", async () => {
+    const runKeys: string[] = [];
+    vi.stubGlobal("fetch", reportsStub({ onRun: (key) => runKeys.push(key) }));
+    render(<ReportsScreen />);
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Quotas" }),
+    );
+    // QuotasView owns its own query lifecycle: GET /quotas falls through the
+    // stub to an empty page, so the honest "no quota set" empty state renders.
+    await waitFor(() => expect(screen.getByText("No quota set")).toBeTruthy());
+    // The shared /reports/{report} run is never issued for the quotas segment.
+    expect(runKeys).not.toContain("quotas");
+  });
+
   it("explain fetches the derivation and renders source rows, not raw JSON", async () => {
     const derivationUrls: string[] = [];
     vi.stubGlobal(

--- a/frontend/src/screens/reports.tsx
+++ b/frontend/src/screens/reports.tsx
@@ -12,6 +12,7 @@ import {
 import { formatMoney } from "../format/format";
 import { type Locale, useLocale, useT } from "../i18n";
 import { problemMessage, QueryGate } from "./common";
+import { QuotasView } from "./quotas";
 
 // Reports (B-EP09.12c, D-11): a picker over three reports — deals-by-stage
 // (unweighted next to weighted, unchanged since B-EP09.12c), forecast
@@ -32,6 +33,11 @@ type StageAgg = {
 };
 
 type ReportKey = "deals-by-stage" | "forecast" | "open-deals-per-company";
+
+// The Reports picker adds the human-set quotas surface alongside the three
+// deal reports. Quotas runs its own query lifecycle (no /reports/{report}
+// call), so the report machinery below is gated off while it is active.
+type Segment = ReportKey | "quotas";
 
 const REPORT_GROUP_BY: Record<ReportKey, string> = {
   "deals-by-stage": "stage_id",
@@ -96,10 +102,15 @@ export function ReportsScreen() {
   const t = useT();
   const { locale } = useLocale();
   const [explain, setExplain] = useState(false);
-  const [report, setReport] = useState<ReportKey>("deals-by-stage");
+  const [segment, setSegment] = useState<Segment>("deals-by-stage");
+  // The report machinery needs a valid ReportKey; while "quotas" is active the
+  // report/pipeline queries are disabled, so this fallback key is inert.
+  const report: ReportKey = segment === "quotas" ? "deals-by-stage" : segment;
+  const reportActive = segment !== "quotas";
 
   const pipelineQuery = useQuery({
     queryKey: ["pipelines"],
+    enabled: reportActive,
     queryFn: async () => {
       const { data, error } = await api.GET("/pipelines", {
         params: { query: {} },
@@ -113,6 +124,7 @@ export function ReportsScreen() {
 
   const reportQuery = useQuery({
     queryKey: ["report", report],
+    enabled: reportActive,
     queryFn: async () => {
       const { data, error } = await api.POST("/reports/{report}", {
         params: { path: { report } },
@@ -157,23 +169,50 @@ export function ReportsScreen() {
     },
   });
 
-  return (
-    <div className="wrap narrow">
-      <SectionHeader title={t("nav.reports")} sub={t("reports.sub")} />
+  // Header + segment picker are shared by both the report bodies and the
+  // quotas surface; factored so the report body below stays at one depth
+  // (quotas takes an early return rather than nesting the whole report tree).
+  const header = (
+    <>
+      <SectionHeader
+        title={t("nav.reports")}
+        sub={segment === "quotas" ? t("quotas.sub") : t("reports.sub")}
+      />
       <div className="filter-tabs">
         <SegmentedControl
           options={
-            ["deals-by-stage", "forecast", "open-deals-per-company"] as const
+            [
+              "deals-by-stage",
+              "forecast",
+              "open-deals-per-company",
+              "quotas",
+            ] as const
           }
-          value={report}
-          onChange={setReport}
+          value={segment}
+          onChange={setSegment}
           labels={{
             "deals-by-stage": t("reports.reportDeals"),
             forecast: t("reports.reportForecast"),
             "open-deals-per-company": t("reports.reportOpenByCompany"),
+            quotas: t("quotas.tab"),
           }}
         />
       </div>
+    </>
+  );
+
+  if (segment === "quotas") {
+    return (
+      <div className="wrap narrow">
+        {header}
+        <QuotasView />
+      </div>
+    );
+  }
+
+  return (
+    <div className="wrap narrow">
+      {header}
       <QueryGate query={reportQuery}>
         {(report_) => {
           let body: ReactNode;

--- a/frontend/src/screens/reports.tsx
+++ b/frontend/src/screens/reports.tsx
@@ -149,7 +149,7 @@ export function ReportsScreen() {
   const derivationUrl = reportQuery.data?.derivation_url ?? null;
   const derivationQuery = useQuery({
     queryKey: ["derivation", derivationUrl],
-    enabled: explain && derivationUrl != null,
+    enabled: reportActive && explain && derivationUrl != null,
     queryFn: async () => {
       // parsed carries by/agg PLUS every equality predicate from the handle
       // (group-key values + plan filters). The endpoint treats each extra key


### PR DESCRIPTION
## Quotas & attainment UI — MISSING-UI-V4 §5 / batch B8

Wires the 6 already-routed, audited `modules/quotas` ops (which had **zero** frontend
callers) into a **Quotas** segment on Reports: a human-set owner-XOR-team revenue-target
CRUD plus the server-computed, per-deal-decomposed attainment read.

**Pure frontend — no contract, backend, or migration change.** Every op already exists on
`main`; this is the FE half the module was missing.

### What's in it
- **`AttainmentRing`** atom (SVG, arc banded by the server `band`, capped at a full circle
  ≥100%) + the attainment card: closed-won / base-converted target / signed gap, a pace
  compare (`attainment_pct` vs `pace_pct`), and **"Explain this number"** rendering the
  server decomposition verbatim (never client-summed).
- **Contributing deals** table — names resolved best-effort via the shared `EntityRef`
  (`/deals/{id}`), id-link fallback, amounts right-aligned to the counted total.
- **Set / edit target / archive** — create (`POST /quotas`, owner-XOR-team side picker,
  `Idempotency-Key`), edit (`PATCH` with `If-Match`), archive (confirm-first). The 422
  `owner_xor_team_required` code is branched to a targeted message.
- **Honest states**: empty, `attainment_target_zero`, `attainment_computation_failed`
  (both draw **no ring**), 403, 404 existence-hiding.
- Nests under Reports (9-item rail unchanged); en + de i18n; vitest + Storybook stories.

Design & plan: `.tmp/quotas-ui/{DESIGN,PLAN}.md` (scratch). Known contract gaps recorded
upstream (P3): `QuotaAttainmentDeal` carries no display fields (N deal-name lookups); no
team roll-up read; no per-quota audit read.

### Review gauntlet (all fixed)
- **Security/privacy**: clean — errors go through `problemMessage` only, existence-hiding
  holds, no XSS/IDOR surface.
- **Code/craft**: no blocking issues; applied the minors (gate the report derivation query
  on the active segment; currency length guard; comment).
- **UI design**: fixed a Tailwind `.ring` class collision (stray box around the ring),
  right-aligned money, radio accent-color, AA-safe ring/chip tokens incl. a dark
  `--tealText`, gap-by-sign color, empty-state measure, and calculator/server icons.

### Manual UAT — walked live (isolated `DEV_SLUG=quota` stack, light + dark)
- [x] Quotas segment nested under Reports; empty state
- [x] Create quota (owner) → live **74%** accent ring (37k/50k, server-computed)
- [x] Explain decomposition + contributing deals (real `/deals/{id}` name resolution, right-aligned)
- [x] Edit target €50k→€30k → recompute to **123% met** (full green ring, **+gap in green**)
- [x] Archive → confirm-first → drops to empty state (list refetch)
- [x] Dark theme: ring, numbers, and the "computed server-side" chip all legible
- [x] owner-XOR-team 422 verified via API; target-zero / compute-failed / behind-band via stories
- [x] `make check` (full merge gate) · `make check-fe` · `make fe-uat` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Quotas section for creating, viewing, editing, and archiving sales targets.
  * Added attainment rings, progress details, pacing indicators, contributing-deal breakdowns, and explanations.
  * Added empty, loading, retry, and calculation-error states.
  * Added responsive quota layouts and dark-theme color improvements.
  * Added English and German translations for quota management.

* **Tests**
  * Added coverage for quota displays, calculations, validation, error handling, and report navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->