### PR TITLE
build: pin oapi-codegen generator @v2.7.1 + renovate DCO sign-off

### DIFF
--- a/backend/internal/contracts/gen.go
+++ b/backend/internal/contracts/gen.go
@@ -5,5 +5,10 @@ package crmcontracts
 // the committed, drift-gated output. `make gen` runs both steps;
 // `make drift` fails the merge on any divergence.
 
+// The generator is pinned to an exact version: its output is drift-gated, so an
+// unpinned `go run` would float to the latest oapi-codegen and rewrite api_gen.go
+// (v2.8.0 renames the enum constants), turning any backend PR red on drift the
+// author never touched. Bump this deliberately, regenerating in the same change.
+
 //go:generate go run github.com/gradionhq/margince/backend/tools/contract-overlay -in ../../api/crm.yaml -out .build/openapi30.yaml
-//go:generate go run github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen --config oapi.yaml .build/openapi30.yaml
+//go:generate go run github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@v2.7.1 --config oapi.yaml .build/openapi30.yaml

--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
   "timezone": "Asia/Ho_Chi_Minh",
   "schedule": ["after 2am and before 6am"],
   "labels": ["dependencies"],
+  "commitBody": "Signed-off-by: renovate[bot] <29139614+renovate[bot]@users.noreply.github.com>",
   "postUpdateOptions": ["gomodTidy"],
   "prConcurrentLimit": 5,
   "platformAutomerge": true,


### PR DESCRIPTION
## Why

Two latent CI-hygiene issues surfaced while triaging the open Renovate PRs (#109, #122, #123, #124, #125).

### 1. `deterministic-gates` drift is a time bomb on every backend PR
`internal/contracts/gen.go` invoked the code generator with an **unpinned** `go run github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen`. Because `api_gen.go` is drift-gated, this floats to whatever oapi-codegen version resolves at run time. v2.8.0 renames the generated enum constants (e.g. `Ready` → `VoiceProfileStatusReady`), so **main already drifts on regeneration today** — any PR touching `backend/` (e.g. #124) fails the drift check on code its author never touched.

Fix: pin the generator to **v2.7.1** — the exact version that produced the committed `api_gen.go`. Verified `make drift` is clean with the pin. (Upgrading to v2.8.0 is a separate, deliberate migration that must regenerate + update every enum-constant reference.)

### 2. Every Renovate PR fails `dco`
Renovate's commits carry no `Signed-off-by` trailer, so `scripts/check-dco.sh` rejects all of them. Added a `commitBody` to `renovate.json` with the trailer matching Renovate's own git identity, so future dependency PRs clear the DCO gate without a manual amend.

## Changes
- `backend/internal/contracts/gen.go` — pin generator `@v2.7.1` (+ a comment on why it must stay pinned)
- `renovate.json` — `commitBody: "Signed-off-by: renovate[bot] <…>"`

## Verification
- `make check-backend` green (build, vet, lint, arch-lint, unit + fitness, drift)
- `make drift` clean with the pinned generator

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins `oapi-codegen` to `v2.7.1` to make backend codegen deterministic and prevent drift failures. Adds a DCO `Signed-off-by` to Renovate commits so dependency PRs pass CI.

- **Bug Fixes**
  - Pin `github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@v2.7.1` in `backend/internal/contracts/gen.go` (with a note on why) to stabilize `api_gen.go`.
  - Add `"commitBody": "Signed-off-by: renovate[bot] <29139614+renovate[bot]@users.noreply.github.com>"` in `renovate.json` to satisfy DCO.

<sup>Written for commit 4061acb544852de6a6375af269b7a81d276566e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

