### PR TITLE
fix(ai,compose): capture embed payloads; recover panics in site-extraction fan-out

### DIFF
--- a/backend/internal/compose/siteextract.go
+++ b/backend/internal/compose/siteextract.go
@@ -13,6 +13,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
+	"runtime/debug"
 	"slices"
 	"sort"
 	"sync"
@@ -154,6 +156,12 @@ func crawlAndExtract(ctx context.Context, crawler *siteCrawler, x evidenceExtrac
 func safeExtractPageFacts(ctx context.Context, x evidenceExtractor, page crawlPage) (res pageFactsResult, err error) {
 	defer func() {
 		if p := recover(); p != nil {
+			// recover() suppresses the runtime's own stack dump, so this is
+			// the only place that trace still exists — capture it into the
+			// internal log now, before it's gone; the returned error stays
+			// a short, stack-free line since it can surface on a dossier's
+			// warnings, not just internal diagnostics.
+			slog.ErrorContext(ctx, "extraction panic recovered", "lane", "page_facts", "url", page.URL, "panic", p, "stack", string(debug.Stack()))
 			err = fmt.Errorf("panic: %v", p)
 		}
 	}()
@@ -165,6 +173,7 @@ func safeExtractPageFacts(ctx context.Context, x evidenceExtractor, page crawlPa
 func safeExtractProfile(ctx context.Context, x evidenceExtractor, pages []crawlPage) (fields []evidencedField, err error) {
 	defer func() {
 		if p := recover(); p != nil {
+			slog.ErrorContext(ctx, "extraction panic recovered", "lane", "profile", "panic", p, "stack", string(debug.Stack()))
 			err = fmt.Errorf("panic: %v", p)
 		}
 	}()

--- a/backend/internal/compose/siteextract.go
+++ b/backend/internal/compose/siteextract.go
@@ -80,7 +80,7 @@ func crawlAndExtract(ctx context.Context, crawler *siteCrawler, x evidenceExtrac
 			profileWg.Add(1)
 			go func() {
 				defer profileWg.Done()
-				out.fields, profileErr = x.extractProfile(ctx, snapshot)
+				out.fields, profileErr = safeExtractProfile(ctx, x, snapshot)
 			}()
 		})
 	}
@@ -99,7 +99,7 @@ func crawlAndExtract(ctx context.Context, crawler *siteCrawler, x evidenceExtrac
 		go func() {
 			defer wg.Done()
 			defer func() { <-sem }()
-			res, err := x.extractPageFacts(ctx, page)
+			res, err := safeExtractPageFacts(ctx, x, page)
 			mu.Lock()
 			if err != nil {
 				failed = append(failed, fmt.Errorf("page %s: %w", page.URL, err))
@@ -142,6 +142,33 @@ func crawlAndExtract(ctx context.Context, crawler *siteCrawler, x evidenceExtrac
 	out.merged = mergeInCommitOrder(crawl, results)
 	out.err = errors.Join(failed...)
 	return crawl, out, nil
+}
+
+// safeExtractPageFacts recovers a panic from extractPageFacts into an
+// ordinary error. Both crawlAndExtract and extractSite run this lane
+// from its own goroutine among up to pageExtractConcurrency siblings: an
+// unrecovered panic in any one of them kills the whole process — this
+// file's own "one page's failure costs that page's findings, never the
+// whole fan-out" contract must hold even when the failure is a panic,
+// not a returned error.
+func safeExtractPageFacts(ctx context.Context, x evidenceExtractor, page crawlPage) (res pageFactsResult, err error) {
+	defer func() {
+		if p := recover(); p != nil {
+			err = fmt.Errorf("panic: %v", p)
+		}
+	}()
+	return x.extractPageFacts(ctx, page)
+}
+
+// safeExtractProfile is safeExtractPageFacts' counterpart for the profile
+// lane, which runs concurrently with the same page-fact fan-out.
+func safeExtractProfile(ctx context.Context, x evidenceExtractor, pages []crawlPage) (fields []evidencedField, err error) {
+	defer func() {
+		if p := recover(); p != nil {
+			err = fmt.Errorf("panic: %v", p)
+		}
+	}()
+	return x.extractProfile(ctx, pages)
 }
 
 func snapshotCrawlPages(mu *sync.Mutex, pages *[]crawlPage) []crawlPage {
@@ -201,7 +228,7 @@ func extractSite(ctx context.Context, x evidenceExtractor, pages []crawlPage, on
 		go func() {
 			defer wg.Done()
 			defer func() { <-sem }()
-			results[i], errs[i] = x.extractPageFacts(ctx, page)
+			results[i], errs[i] = safeExtractPageFacts(ctx, x, page)
 			report()
 		}()
 	}
@@ -210,7 +237,7 @@ func extractSite(ctx context.Context, x evidenceExtractor, pages []crawlPage, on
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		out.fields, profileErr = x.extractProfile(ctx, pages)
+		out.fields, profileErr = safeExtractProfile(ctx, x, pages)
 	}()
 	wg.Wait()
 

--- a/backend/internal/compose/siteextract_test.go
+++ b/backend/internal/compose/siteextract_test.go
@@ -28,16 +28,26 @@ type laneFake struct {
 	profileReply string
 	pageReplies  map[string]string // page URL → reply
 	failFor      map[string]error  // page URL → error
+	panicFor     map[string]bool   // page URL → panic instead of erroring
+	panicProfile bool              // profile lane panics instead of replying
 }
 
 func (f laneFake) Complete(_ context.Context, req model.Request) (model.Response, error) {
 	if req.System == profileSystem {
+		if f.panicProfile {
+			panic("laneFake: profile lane panic")
+		}
 		return model.Response{Text: f.profileReply}, nil
 	}
 	if len(req.Messages) == 0 {
 		return model.Response{}, errors.New("laneFake: no message")
 	}
 	content := req.Messages[0].Content
+	for url := range f.panicFor {
+		if strings.HasPrefix(content, "Page "+url+":") {
+			panic("laneFake: page " + url + " panic")
+		}
+	}
 	for url, err := range f.failFor {
 		if strings.HasPrefix(content, "Page "+url+":") {
 			return model.Response{}, err
@@ -118,6 +128,53 @@ func TestExtractSiteOnePageFailureDegradesNotDiscards(t *testing.T) {
 	}
 	if len(got.fields) != 1 {
 		t.Fatalf("the profile lane must survive a page failure: %+v", got.fields)
+	}
+}
+
+// TestExtractSitePageFactPanicDegradesNotCrashes proves safeExtractPageFacts:
+// a panic in one page's fact lane — a goroutine among up to
+// pageExtractConcurrency siblings — must degrade like any other page
+// failure, not take the whole process down with it.
+func TestExtractSitePageFactPanicDegradesNotCrashes(t *testing.T) {
+	brain := laneFake{
+		profileReply: `{"fields":[{"f":"display_name","v":"Acme","e":"s0","c":0.9}]}`,
+		pageReplies: map[string]string{
+			seedURL + "/services": `{"facts":[{"f":"service","v":"Cloud Cost Audit — line-by-line review","e":"s0"}]}`,
+		},
+		panicFor: map[string]bool{seedURL + "/impressum": true},
+	}
+	got := extractSite(context.Background(), evidenceExtractor{brain: brain, factBrain: brain}, extractFixturePages(), nil)
+	if got.err == nil || !strings.Contains(got.err.Error(), "panic") {
+		t.Fatalf("the panicking page must surface as an ordinary error naming the panic: %v", got.err)
+	}
+	if len(got.merged.facts) != 1 {
+		t.Fatalf("the surviving page's fact must be kept: %+v", got.merged.facts)
+	}
+	if len(got.fields) != 1 {
+		t.Fatalf("the profile lane must survive a sibling page's panic: %+v", got.fields)
+	}
+}
+
+// TestExtractSiteProfilePanicDegradesNotCrashes is
+// TestExtractSitePageFactPanicDegradesNotCrashes' counterpart for the
+// profile lane (safeExtractProfile): its panic must not crash the process
+// either, and the page-fact lane it runs alongside must still complete.
+func TestExtractSiteProfilePanicDegradesNotCrashes(t *testing.T) {
+	brain := laneFake{
+		panicProfile: true,
+		pageReplies: map[string]string{
+			seedURL + "/services": `{"facts":[{"f":"service","v":"Cloud Cost Audit — line-by-line review","e":"s0"}]}`,
+		},
+	}
+	got := extractSite(context.Background(), evidenceExtractor{brain: brain, factBrain: brain}, extractFixturePages(), nil)
+	if got.err == nil || !strings.Contains(got.err.Error(), "panic") {
+		t.Fatalf("the panicking profile lane must surface as an ordinary error naming the panic: %v", got.err)
+	}
+	if got.fields != nil {
+		t.Fatalf("a panicking profile lane must yield no fields, got %+v", got.fields)
+	}
+	if len(got.merged.facts) != 1 {
+		t.Fatalf("the page-fact lane must survive the profile lane's panic: %+v", got.merged.facts)
 	}
 }
 

--- a/backend/internal/modules/ai/payloadcapture.go
+++ b/backend/internal/modules/ai/payloadcapture.go
@@ -71,6 +71,39 @@ func (r *Router) buildPayload(ctx context.Context, req model.Request, resp model
 	return &Payload{Request: json.RawMessage(stripped), Response: json.RawMessage(strippedResp)}, nil
 }
 
+// buildEmbedPayload assembles the embed lane's Layer-3 capture: which
+// inputs were embedded and a summary of what came back — the raw
+// vectors are opaque floats, not reviewable content, so the response
+// side records shape (how many, how wide) rather than every coordinate.
+// Unlike buildPayload, this does NOT re-run the stripper: it is a
+// private, single-caller method, and Embed's own stripping loop
+// (router.go) runs unconditionally on every path that reaches this call,
+// so req.Inputs is always already scrubbed by the time it gets here —
+// re-stripping would only repeat that same pass. This load-bearing
+// ordering — capture must run strictly after Embed's strip — is what to
+// re-check if Embed is ever restructured.
+func (r *Router) buildEmbedPayload(req model.EmbedRequest, res model.Embeddings) (*Payload, error) {
+	budget := captureBudget{remaining: maxCapturedRequestRunes}
+	inputs := make([]string, len(req.Inputs))
+	for i, in := range req.Inputs {
+		inputs[i] = budget.take(in)
+	}
+	reqDoc, err := json.Marshal(struct {
+		Inputs []string `json:"inputs"`
+	}{inputs})
+	if err != nil {
+		return nil, fmt.Errorf("ai: marshal capture request: %w", err)
+	}
+	respDoc, err := json.Marshal(struct {
+		VectorCount int `json:"vector_count"`
+		Dims        int `json:"dims"`
+	}{len(res.Vectors), res.Dims})
+	if err != nil {
+		return nil, fmt.Errorf("ai: marshal capture response: %w", err)
+	}
+	return &Payload{Request: json.RawMessage(reqDoc), Response: json.RawMessage(respDoc)}, nil
+}
+
 // maxCapturedPayloadRunes caps each captured content field. 16k runes holds a
 // generous prompt or response while keeping any single ai_call_payload row
 // bounded; it is a rune count (not bytes) so a multi-byte script never inflates

--- a/backend/internal/modules/ai/payloadcapture.go
+++ b/backend/internal/modules/ai/payloadcapture.go
@@ -71,10 +71,28 @@ func (r *Router) buildPayload(ctx context.Context, req model.Request, resp model
 	return &Payload{Request: json.RawMessage(stripped), Response: json.RawMessage(strippedResp)}, nil
 }
 
+// maxCapturedEmbedInputs bounds the embed capture by INPUT COUNT, not just
+// content: the rune budget alone cannot cap a batch of many short or empty
+// inputs (each costs ~0 of the budget, so a large batch could still swell
+// the captured array's own JSON overhead without ever tripping the content
+// cap). Every caller today embeds exactly one input per call (search's
+// indexing and query lanes both do), so 200 is a defensive ceiling, not a
+// tight fit to real traffic — generous enough for a real future batch
+// caller while still keeping one captured row's array bounded regardless
+// of how that batch is shaped. inputs_truncated on the wire tells a reader
+// the array was cut, the same honesty captureTruncationMarker gives a cut
+// field.
+const maxCapturedEmbedInputs = 200
+
 // buildEmbedPayload assembles the embed lane's Layer-3 capture: which
-// inputs were embedded and a summary of what came back — the raw
-// vectors are opaque floats, not reviewable content, so the response
-// side records shape (how many, how wide) rather than every coordinate.
+// inputs were embedded and a summary of what came back — the raw vectors
+// are opaque floats, not reviewable content, so the response side
+// records shape (how many, how wide) rather than every coordinate. Both
+// marshaled shapes are strings/ints/bools only, which json.Marshal
+// cannot fail on — so unlike buildPayload (which strips through a
+// fallible SecretStripper), this returns *Payload directly rather than
+// advertising an error path that can never run.
+//
 // Unlike buildPayload, this does NOT re-run the stripper: it is a
 // private, single-caller method, and Embed's own stripping loop
 // (router.go) runs unconditionally on every path that reaches this call,
@@ -82,26 +100,26 @@ func (r *Router) buildPayload(ctx context.Context, req model.Request, resp model
 // re-stripping would only repeat that same pass. This load-bearing
 // ordering — capture must run strictly after Embed's strip — is what to
 // re-check if Embed is ever restructured.
-func (r *Router) buildEmbedPayload(req model.EmbedRequest, res model.Embeddings) (*Payload, error) {
+func (r *Router) buildEmbedPayload(req model.EmbedRequest, res model.Embeddings) *Payload {
 	budget := captureBudget{remaining: maxCapturedRequestRunes}
-	inputs := make([]string, len(req.Inputs))
-	for i, in := range req.Inputs {
-		inputs[i] = budget.take(in)
+	n := len(req.Inputs)
+	truncatedInputs := n > maxCapturedEmbedInputs
+	if truncatedInputs {
+		n = maxCapturedEmbedInputs
 	}
-	reqDoc, err := json.Marshal(struct {
-		Inputs []string `json:"inputs"`
-	}{inputs})
-	if err != nil {
-		return nil, fmt.Errorf("ai: marshal capture request: %w", err)
+	inputs := make([]string, n)
+	for i := 0; i < n; i++ {
+		inputs[i] = budget.take(req.Inputs[i])
 	}
-	respDoc, err := json.Marshal(struct {
+	reqDoc, _ := json.Marshal(struct {
+		Inputs          []string `json:"inputs"`
+		InputsTruncated bool     `json:"inputs_truncated,omitempty"`
+	}{inputs, truncatedInputs})
+	respDoc, _ := json.Marshal(struct {
 		VectorCount int `json:"vector_count"`
 		Dims        int `json:"dims"`
 	}{len(res.Vectors), res.Dims})
-	if err != nil {
-		return nil, fmt.Errorf("ai: marshal capture response: %w", err)
-	}
-	return &Payload{Request: json.RawMessage(reqDoc), Response: json.RawMessage(respDoc)}, nil
+	return &Payload{Request: json.RawMessage(reqDoc), Response: json.RawMessage(respDoc)}
 }
 
 // maxCapturedPayloadRunes caps each captured content field. 16k runes holds a
@@ -121,15 +139,22 @@ const maxCapturedRequestRunes = 48_000
 // each take is also held to the per-field cap.
 type captureBudget struct{ remaining int }
 
+// take scans s rune-by-rune up to its allowance rather than converting the
+// whole string to []rune first — a caller can hand it an input far larger
+// than any cap it will ever keep (a full document sent to embed, say), and
+// this must cost work proportional to what's KEPT, not to len(s).
 func (b *captureBudget) take(s string) string {
 	limit := min(maxCapturedPayloadRunes, b.remaining)
-	runes := []rune(s)
-	if len(runes) <= limit {
-		b.remaining -= len(runes)
-		return s
+	n := 0
+	for i := range s {
+		if n == limit {
+			b.remaining -= limit
+			return s[:i] + captureTruncationMarker
+		}
+		n++
 	}
-	b.remaining -= limit
-	return string(runes[:limit]) + captureTruncationMarker
+	b.remaining -= n
+	return s
 }
 
 // captureTruncationMarker tells a trace reader the stored text is not the

--- a/backend/internal/modules/ai/router.go
+++ b/backend/internal/modules/ai/router.go
@@ -289,11 +289,7 @@ func (r *Router) Embed(ctx context.Context, req model.EmbedRequest) (model.Embed
 	// tier's configured binding.
 	trace.ServedModel, trace.ServedIdentitySource = servedIdentity(trace.Provider, trace.ModelID, "")
 	if r.capturePayloads && trace.ErrorSentinel == "" {
-		if p, perr := r.buildEmbedPayload(req, res); perr != nil {
-			r.log.WarnContext(ctx, "ai: payload capture failed", "err", perr)
-		} else {
-			trace.Payload = p
-		}
+		trace.Payload = r.buildEmbedPayload(req, res)
 	}
 	lc := newLogicalCall()
 	lc.append(trace)

--- a/backend/internal/modules/ai/router.go
+++ b/backend/internal/modules/ai/router.go
@@ -288,6 +288,13 @@ func (r *Router) Embed(ctx context.Context, req model.EmbedRequest) (model.Embed
 	// one for the embed lane today), so this always falls back to the
 	// tier's configured binding.
 	trace.ServedModel, trace.ServedIdentitySource = servedIdentity(trace.Provider, trace.ModelID, "")
+	if r.capturePayloads && trace.ErrorSentinel == "" {
+		if p, perr := r.buildEmbedPayload(req, res); perr != nil {
+			r.log.WarnContext(ctx, "ai: payload capture failed", "err", perr)
+		} else {
+			trace.Payload = p
+		}
+	}
 	lc := newLogicalCall()
 	lc.append(trace)
 	r.flushDetached(ctx, lc)

--- a/backend/internal/modules/ai/router_attempts_test.go
+++ b/backend/internal/modules/ai/router_attempts_test.go
@@ -240,6 +240,38 @@ func TestEmbedTraceStaysZeroUsageOnFailure(t *testing.T) {
 	}
 }
 
+// TestEmbedCapturesPayloadWhenEnabled proves the embed lane honors
+// capturePayloads like every other lane. The captured request names
+// which inputs were embedded (already secret-stripped by Embed's own
+// enforcement point); the raw vectors are opaque floats, not reviewable
+// content, so the captured response records shape instead.
+func TestEmbedCapturesPayloadWhenEnabled(t *testing.T) {
+	fcs := &fakeCallStore{}
+	embedder := NewFakeClient()
+	r := assembleRouter(
+		map[Tier]model.Client{}, embedder, ProfileEUHosted, &memMeter{}, DefaultMonthlyTokens, fcs,
+		map[Tier]routeMeta{TierEmbedLane: {provider: "fake", model: "fake-embed"}},
+		true, nil, // capturePayloads = true
+	)
+	inputs := []string{"embed this note", "my key sk-ABCDEF0123456789 leaks"}
+	if _, err := r.Embed(wsCtx(), model.EmbedRequest{Inputs: inputs}); err != nil {
+		t.Fatalf("embed: %v", err)
+	}
+	if len(fcs.recorded) != 1 || fcs.recorded[0].Payload == nil {
+		t.Fatalf("expected a captured payload; got %+v", fcs.recorded)
+	}
+	payload := fcs.recorded[0].Payload
+	if !strings.Contains(string(payload.Request), "embed this note") {
+		t.Fatalf("captured request payload missing the embedded input: %s", payload.Request)
+	}
+	if strings.Contains(string(payload.Request), "sk-ABCDEF0123456789") {
+		t.Fatal("captured request payload still contains the secret")
+	}
+	if !strings.Contains(string(payload.Response), `"vector_count":2`) {
+		t.Fatalf("captured response payload missing the vector-count summary: %s", payload.Response)
+	}
+}
+
 // TestMetricsCountOneCallPerLogicalCallNotPerAttempt is the Prometheus half
 // of the grain change: margince_ai_calls_total must bump once per served-or-
 // failed decision, not once per ladder rung it took to get there — a

--- a/backend/internal/modules/ai/router_attempts_test.go
+++ b/backend/internal/modules/ai/router_attempts_test.go
@@ -10,6 +10,7 @@ package ai
 // terminal tracing this behavior builds on.
 
 import (
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -267,8 +268,51 @@ func TestEmbedCapturesPayloadWhenEnabled(t *testing.T) {
 	if strings.Contains(string(payload.Request), "sk-ABCDEF0123456789") {
 		t.Fatal("captured request payload still contains the secret")
 	}
+	if strings.Contains(string(payload.Request), "inputs_truncated") {
+		t.Fatalf("a small batch must not be marked truncated: %s", payload.Request)
+	}
 	if !strings.Contains(string(payload.Response), `"vector_count":2`) {
 		t.Fatalf("captured response payload missing the vector-count summary: %s", payload.Response)
+	}
+}
+
+// TestEmbedPayloadCapsInputCountWhenBatchExceedsTheLimit proves the
+// count cap: a batch of many short inputs costs almost nothing against
+// the content budget (each well under maxCapturedPayloadRunes), so
+// without a separate count cap the captured array could grow with the
+// batch size regardless of maxCapturedRequestRunes. inputs_truncated on
+// the wire tells a reader the array itself was cut, the same honesty
+// captureTruncationMarker gives a cut field.
+func TestEmbedPayloadCapsInputCountWhenBatchExceedsTheLimit(t *testing.T) {
+	fcs := &fakeCallStore{}
+	embedder := NewFakeClient()
+	r := assembleRouter(
+		map[Tier]model.Client{}, embedder, ProfileEUHosted, &memMeter{}, DefaultMonthlyTokens, fcs,
+		map[Tier]routeMeta{TierEmbedLane: {provider: "fake", model: "fake-embed"}},
+		true, nil, // capturePayloads = true
+	)
+	inputs := make([]string, maxCapturedEmbedInputs+50)
+	for i := range inputs {
+		inputs[i] = "x"
+	}
+	if _, err := r.Embed(wsCtx(), model.EmbedRequest{Inputs: inputs}); err != nil {
+		t.Fatalf("embed: %v", err)
+	}
+	if len(fcs.recorded) != 1 || fcs.recorded[0].Payload == nil {
+		t.Fatalf("expected a captured payload; got %+v", fcs.recorded)
+	}
+	var captured struct {
+		Inputs          []string `json:"inputs"`
+		InputsTruncated bool     `json:"inputs_truncated"`
+	}
+	if err := json.Unmarshal(fcs.recorded[0].Payload.Request, &captured); err != nil {
+		t.Fatalf("unmarshal captured request: %v", err)
+	}
+	if !captured.InputsTruncated {
+		t.Fatal("a batch over the cap must be marked truncated")
+	}
+	if len(captured.Inputs) != maxCapturedEmbedInputs {
+		t.Fatalf("captured inputs = %d, want exactly the cap (%d)", len(captured.Inputs), maxCapturedEmbedInputs)
 	}
 }
 


### PR DESCRIPTION
## Summary
- **`Router.Embed` never captured a payload.** Every other AI lane (completions, structured calls) captures request/response into `ai_call_payload` when `ai.capture_payloads` is on; the embed lane built its trace with no `buildPayload`-equivalent call at all, so its trace UI always read "no payload captured" regardless of the config setting. Added `buildEmbedPayload`, which captures the embedded inputs and a `{vector_count, dims}` summary for the response (raw vectors are opaque floats, not reviewable content).
- **Unrecovered panics in the site-extraction fan-out could crash the whole worker process.** `crawlAndExtract`/`extractSite` run the profile lane and up to 40 concurrent per-page fact lanes, each in its own goroutine, none panic-recovered — a panic in any one of them kills the entire process instantly, including any other lane mid-flight on its own model call and trace write. Added `safeExtractPageFacts`/`safeExtractProfile`, thin wrappers that recover a panic into an ordinary error so one lane's panic degrades like any other lane failure (the file's own "collect-don't-cancel" contract), instead of taking the whole fan-out down.

Both fixes came out of investigating a user-reported gap where `site_extract` AI calls appeared in the usage-summary table but not in the call-trace table. That specific historical gap did not reproduce live during investigation (a fresh deep-read against the same organizations traced correctly), so it's not fixed by this PR — but the panic-recovery gap is a real, independently valid hardening fix found along the way, and the embed-payload gap is an unrelated, fully-diagnosed bug in the same UI area (screenshotted by the reporter).

## Test plan
- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./internal/modules/ai/... ./internal/compose/...` green, including two new tests proving the panic wrappers degrade instead of crashing the test process, and one new test proving the embed payload captures inputs (with a secret stripped) and a vector-count summary
- [x] `craft static` (diff-scoped): 0 blocker, 2 pre-existing MAJOR (unrelated line-count debt in functions this diff doesn't restructure)
- [x] Two independent rounds of `craft-reviewer` + `security-redteam` subagent review, all findings applied (fixed a double-prefixed panic error message, clarified a load-bearing comment on the embed-payload stripping-order invariant, removed fix-narration from test comments)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Capture payloads for embed calls and harden site extraction by recovering panics so a single page or profile failure doesn’t crash the process. Add a count cap to embed capture and log stack traces for recovered panics.

- **Bug Fixes**
  - Embedding: capture request inputs and a response summary (vector_count, dims) when payload capture is on; secrets are stripped and raw vectors are not stored; add a 200-input cap with `inputs_truncated`, and speed up truncation by scanning runes without large allocations.
  - Site extraction: recover panics in page-fact and profile goroutines, converting them to errors so other work continues; also record the stack in internal logs for diagnosis.

<sup>Written for commit d74e8b3b7e5427328483e8e8bd3dfdaf4a8728d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved extraction reliability by preventing isolated processing failures from crashing the application.
  - Other page and profile results now continue processing when one extraction task fails.

- **New Features**
  - Added payload capture for embedding requests when call tracing is enabled.
  - Captured embedding details include sanitized inputs and summary information about generated vectors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->