### PR TITLE
docs(ai-runtime): clarify the Cost and Certification sections

### DIFF
--- a/docs/explanation/ai-runtime.md
+++ b/docs/explanation/ai-runtime.md
@@ -200,51 +200,54 @@ model-call hot path.
                                             cache_write · output                          + cache_write×write + out×out
 ```
 
-- **The rate table (`ai_model_rate`, ADR-0067).** Workspace-scoped, keyed by
-  `(provider, model, effective_date)` — the *concrete served model*, not the tier, so
-  rates survive a tier rebinding. Four integer **micro-USD-per-MTok** components. Resolution
-  is the `fx_rate` shape (DM-FX-5): the latest row on or before the call's day wins; a price
-  change is a *new* row, never an update. Seeded per workspace from a source-constant sheet,
-  **including explicit all-zero rows for local providers** so a local call prices as an
-  honest `0`. **Unpriced ≠ free:** a call whose model has no rate row is *unpriced* (counted,
-  surfaced), a materially different signal from a genuine `$0`. To change a price, insert a
-  newer effective-dated row — no rebuild (an admin surface / scheduled fetch is the same
-  table's later evolution).
-- **Two readers, one pricer.** `PriceCall` (the four-bucket formula) is the only
-  money-aware component. `/ai/usage` sums it over the window's `ai_call` rows (**actuals**,
-  phase 1). The backfill preview asks it for a **pre-flight estimate** (phase 2, ADR-0068).
-- **The pre-flight estimate (`compose/costestimate`, ADR-0068).** For *N* messages the
-  backfill preview shows `Σ_task (per-unit cost × expected units)`: per-unit cost comes from
-  the trailing-7-day `ai_call` history grouped by the concrete `(task, tier, provider,
-  model)`, **priced at the model that will actually serve** — the served model if still
-  bound, else that slice's own tier's *current* binding (keyed on `ai_call.tier`, never the
-  ladder head) — so a rebind re-prices instantly. Expected units come from the connection's
-  completed `capture_backfill` yields (classify per labeled message, enrich per person,
-  embeddings per entity). An **unpriced** whole preview *suppresses* the cost field (never a
-  silent `0`); a new `estimate_quality` (`observed` | `heuristic`) labels the source; and a
-  first connect with no history falls back to a priced **work-shape floor**. Cost read
-  failures **degrade** the preview to a message-count-only number — they never block the
-  consent flow. The cold-start embed floor counts **message-embeds only** — person/org
-  embeds are omitted from the floor (the floor prices every unit at a full-email size, so
-  charging name-sized person embeds at that size would overquote on the cheapest, input-only
-  lane; the observed path still counts them via yields). *(Current limitation: the
-  `capture_backfill` people/org counters are not yet populated by the backfill loop, so the
-  enrich line floors — honest `heuristic` — rather than pricing per person; a tracked
-  follow-up.)*
+- **The rate table (`ai_model_rate`).** One row per `(provider, model,
+  effective_date)` — keyed on the *concrete model that served*, not the tier, so
+  rebinding a tier keeps its rates. Each row is four integer
+  **micro-USD-per-MTok** prices: input, cache-read, cache-write, output. Lookup
+  works like `fx_rate` — the latest row dated on or before the call's day wins,
+  and a price change is a *new* row, never an edit. Local providers get explicit
+  all-zero rows, so a local call prices as an honest `0`. **Unpriced ≠ free:** a
+  call whose model has no rate row is *unpriced* — still counted and surfaced,
+  just flagged as a different thing from a real `$0`. Changing a price is a single
+  insert; no rebuild.
+- **One pricer, two readers.** `PriceCall` is the only function that touches
+  money. `/ai/usage` runs it over the window's `ai_call` rows to report
+  **actuals**; the backfill preview runs it ahead of time for a **pre-flight
+  estimate**. Same formula, two callers.
+- **The pre-flight estimate (`compose/costestimate`).** Before a backfill runs,
+  the preview estimates its cost as `Σ per-task (per-unit cost × expected units)`:
+  - **Per-unit cost** comes from the last 7 days of `ai_call` history, grouped by
+    `(task, tier, provider, model)` and priced at whichever model *will* serve —
+    the model that served last if it's still bound, otherwise the tier's current
+    binding (keyed on the tier, never the ladder head). So a rebind re-prices
+    instantly.
+  - **Expected units** come from the connection's completed backfill yields:
+    messages to classify, people to enrich, entities to embed.
+  - **When there's nothing to price from, the preview says so instead of
+    guessing.** With no history it falls back to a priced **work-shape floor** and
+    labels the estimate `heuristic` (vs `observed`). If the whole preview would be
+    unpriced it *hides* the cost field rather than show a misleading `0`, and a
+    cost-read failure degrades it to a plain message count — never a block on the
+    consent flow.
+
+  *(Two known rough edges, both tracked: the cold-start floor counts message
+  embeds only — person/org embeds would over-quote at the floor's full-email size,
+  so they ride the observed path instead; and the people/org unit counters aren't
+  wired into the backfill loop yet, so the enrich line still floors as
+  `heuristic`.)*
 
 ## Certification — proving a binding is good enough
 
-Because a task names a contract and a binding is swappable, you can **certify a
-model against a task before you trust it**. The lane (`compose/aicert`) drives a
-hand-authored scenario corpus through a candidate, scores each answer with a
-pinned rubric judge on its *own* `cert_judge` binding (never the candidate's),
-folds N odd cache-off runs into a `certified` / `supported_degraded` /
-`not_supported` verdict, and commits the result as JSON. This is how you compare
-gemini-2.5-flash against a cheaper swap on the same rubric before changing the
-routing file. When a verdict needs explaining, the lane can dump every
-candidate and judge call's request/response — the *same* post-stripper
-`ai_call_payload` shape — to a local JSONL trace for tuning (on by default,
-gitignored). Full walkthrough:
+Because a task names a contract and the model behind it is swappable, you can
+**certify a model against a task before you trust it**. The cert lane
+(`compose/aicert`) runs a hand-authored scenario corpus through a candidate
+model, scores each answer with a fixed rubric judge on its *own* `cert_judge`
+binding (never the candidate's), and folds several cache-off runs into one
+verdict — `certified` / `supported_degraded` / `not_supported` — saved as JSON.
+That's how you compare, say, gemini-2.5-flash against a cheaper swap on the same
+rubric *before* editing the routing file. To debug a verdict, the lane can dump
+every candidate and judge call to a local JSONL trace — the *same* secret-stripped
+`ai_call_payload` shape (on by default, gitignored). Full walkthrough:
 [how-to/certify-an-ai-model.md](../how-to/certify-an-ai-model.md).
 
 ## Reference

--- a/docs/explanation/ai-runtime.md
+++ b/docs/explanation/ai-runtime.md
@@ -200,9 +200,10 @@ model-call hot path.
                                             cache_write · output                          + cache_write×write + out×out
 ```
 
-- **The rate table (`ai_model_rate`).** One row per `(provider, model,
-  effective_date)` — keyed on the *concrete model that served*, not the tier, so
-  rebinding a tier keeps its rates. Each row is four integer
+- **The rate table (`ai_model_rate`).** Workspace-scoped, one row per
+  `(provider, model, effective_date)` — keyed on the *concrete model that
+  served*, not the tier, so rebinding a tier keeps its rates. Each row is four
+  integer
   **micro-USD-per-MTok** prices: input, cache-read, cache-write, output. Lookup
   works like `fx_rate` — the latest row dated on or before the call's day wins,
   and a price change is a *new* row, never an edit. Local providers get explicit
@@ -210,17 +211,19 @@ model-call hot path.
   call whose model has no rate row is *unpriced* — still counted and surfaced,
   just flagged as a different thing from a real `$0`. Changing a price is a single
   insert; no rebuild.
-- **One pricer, two readers.** `PriceCall` is the only function that touches
-  money. `/ai/usage` runs it over the window's `ai_call` rows to report
-  **actuals**; the backfill preview runs it ahead of time for a **pre-flight
-  estimate**. Same formula, two callers.
+- **One formula, three consumers.** The four-bucket price arithmetic is written
+  once as `PriceCall`. `/ai/usage` reports **actuals** through
+  `RateStore.CostReport` — SQL that mirrors that same arithmetic row-for-row, to
+  price a whole window in one round-trip — while the backfill preview and the
+  certification record both call `PriceCall` directly, for a **pre-flight
+  estimate** and a per-run cost stamp. One formula, so the numbers can't drift.
 - **The pre-flight estimate (`compose/costestimate`).** Before a backfill runs,
   the preview estimates its cost as `Σ per-task (per-unit cost × expected units)`:
-  - **Per-unit cost** comes from the last 7 days of `ai_call` history, grouped by
-    `(task, tier, provider, model)` and priced at whichever model *will* serve —
-    the model that served last if it's still bound, otherwise the tier's current
-    binding (keyed on the tier, never the ladder head). So a rebind re-prices
-    instantly.
+  - **Per-unit cost** comes from the last 7 days of `ai_call` history, grouped
+    into `(task, tier, provider, model)` slices. Each slice is priced at whichever
+    model *will* serve it now: the model that served it if that's still bound,
+    else its own tier's current binding (so a rebind re-prices instantly), else
+    the ladder head if that tier is now unbound.
   - **Expected units** come from the connection's completed backfill yields:
     messages to classify, people to enrich, entities to embed.
   - **When there's nothing to price from, the preview says so instead of
@@ -230,11 +233,12 @@ model-call hot path.
     cost-read failure degrades it to a plain message count — never a block on the
     consent flow.
 
-  *(Two known rough edges, both tracked: the cold-start floor counts message
-  embeds only — person/org embeds would over-quote at the floor's full-email size,
-  so they ride the observed path instead; and the people/org unit counters aren't
-  wired into the backfill loop yet, so the enrich line still floors as
-  `heuristic`.)*
+  *(Known rough edge, tracked: the backfill loop doesn't populate the people/org
+  unit counters yet, so anything keyed on them under-counts today — the enrich
+  line floors as `heuristic`, and the embed estimate counts captured-message
+  embeds only, under-counting person/org entities. The cold-start floor also
+  counts message embeds by design: person/org embeds would over-quote at its
+  full-email unit size.)*
 
 ## Certification — proving a binding is good enough
 


### PR DESCRIPTION
## What

Rewrites the two densest blocks in `docs/explanation/ai-runtime.md` — the three **Cost** bullets (rate table, pricer, pre-flight estimate) and the **Certification** paragraph — for easier contributor catch-up. Content-only, no behavior claims changed.

## Why

The pre-flight estimate bullet had grown into a single wall-of-text sentence, and the section leaned on ADR/DM cross-references (`ADR-0067`, `DM-FX-5`, `ADR-0068`) that add noise for a first-time reader.

## Changes

- **Rate table** — spell the four price components inline (input, cache-read, cache-write, output); drop `ADR-0067` / `DM-FX-5` and the admin-surface evolution aside.
- **Pricer** — trim to "one function that touches money, two callers"; drop phase 1/2 framing.
- **Pre-flight estimate** — break the one giant sentence into three sub-bullets (per-unit cost → expected units → no-history behavior); demote the embed-floor edge cases + counter limitation into one short aside.
- **Certification** — same content, one pass shorter; plainer phrasing.

The load-bearing invariants are preserved: rebind re-prices, `unpriced ≠ free`, hide-vs-`0`, degrade-never-block. ADR numbers still live in the reference table at the bottom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the Cost and Certification sections in `docs/explanation/ai-runtime.md` for easier onboarding. Content-only; preserves existing behavior and invariants.

- **Refactors**
  - Rate table: workspace-scoped `ai_model_rate` keyed on concrete `(provider, model, effective_date)`; four micro-USD-per-MTok components; `fx_rate`-style lookup with insert-only updates; explicit zero rates for local; unpriced ≠ free; rebinding a tier keeps its rates.
  - Pricing flow: one four-bucket formula `PriceCall`; three consumers — `/ai/usage` via `RateStore.CostReport` (SQL mirror for window pricing), `compose/costestimate` (pre-flight), and certification runs (per-run cost stamp).
  - Pre-flight estimate: per-unit cost from last 7 days of `ai_call` grouped by `(task, tier, provider, model)`, priced at the model that will serve now (served-if-still-bound → tier’s current binding → ladder head if unbound); expected units from backfill yields; no-history priced work-shape floor labeled `heuristic`; hide cost when unpriced; degrade to message count, never block. Current limitation: people/org counters are unwired, so enrich under-counts; cold-start floor counts message-embeds only.
  - Certification: `compose/aicert` runs a corpus through a candidate, judges via its own `cert_judge` binding, folds cache-off runs into a verdict JSON, stamps cost, and can emit secret-stripped JSONL traces.

<sup>Written for commit ed3d9bd91f9d20e4815966aa3f591fa5ec1333e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

