### PR TITLE
feat(overlay): back off a failing incumbent sweep instead of re-sweeping hot (branch 1b)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -688,14 +688,16 @@ Open work, roughly in priority order:
     cross-process meter (PG/Redis) so `/overlay/budget` reflects the worker
     poller; **and the force-fresh CALLER** (the surface that invokes the now-live
     Freshness verb) — without it A3's live read is latent infra.
-  - **A4 reconcile robustness** — budget-pace/`Retry-After` backoff on a
-    failing connection (today it re-sweeps hot every tick, no per-connection
-    error/backoff state — mirror capture's `sync_state` pattern; likely a
-    migration + poller error taxonomy + due-filtering in DueOverlayConnections);
-    composite keyset watermark (a >10k same-timestamp block wedges the sweep —
-    disclosed in reconcile.go; the seam can't signal mode-switch, an
-    upstream-tracked spike). Branch `fix/overlay-reconcile-robustness` created,
-    not yet implemented.
+  - **A4 reconcile robustness** — the **failing-connection backoff is DONE in
+    this PR**: `overlay_sync_state` sidecar + `RecordSweepFailure`/`Success`
+    (classify + 2min·2^n-cap-4h jittered ladder + rate-limit floor) +
+    `DueOverlayConnections` due-gate + `reconcileConnection` distinguishing
+    connection-level (abort+backoff) from per-object (log+skip) failures. Still
+    open (**A4b**): the composite keyset watermark for a >10k same-timestamp
+    block (the seam can't signal mode-switch — an upstream spike); atomic
+    ingest+`mirror.conflict` in one row-locked tx; propagate aggregate/`ctx.Err()`
+    to handlers.go's 503 path; derive sync staleness (`syncstatus.go` never
+    marks stale).
   - **A5 disconnect-race fencing**; **A7 assoc/backfill fidelity**;
     **webhook-as-signal** (only WITH portal-id→workspace binding in the HMAC
     basis — the unmounted receiver was deleted, not fixed); a **reconnect flow**

--- a/STATUS.md
+++ b/STATUS.md
@@ -690,7 +690,8 @@ Open work, roughly in priority order:
     Freshness verb) — without it A3's live read is latent infra.
   - **A4 reconcile robustness** — the **failing-connection backoff is DONE in
     this PR**: `overlay_sync_state` sidecar + `RecordSweepFailure`/`Success`
-    (classify + 2min·2^n-cap-4h jittered ladder + rate-limit floor) +
+    (classify + a 2min·2^n ladder capped at 4h *before* ±20% jitter, so
+    ~4h48m effective + rate-limit floor) +
     `DueOverlayConnections` due-gate + `reconcileConnection` distinguishing
     connection-level (abort+backoff) from per-object (log+skip) failures. Still
     open (**A4b**): the composite keyset watermark for a >10k same-timestamp

--- a/STATUS.md
+++ b/STATUS.md
@@ -674,20 +674,28 @@ Open work, roughly in priority order:
     by every visibility mutator; distinct-owner-set ambiguity + late-ambiguity
     revoke; GUC-unset fails closed.
 
+  - **A3 live force-fresh + atomic budget reserve** — MERGED #161 (`fbeea10`).
+    Per-request vault-backed `resolveIncumbent` wired into FreshnessReader
+    (force-fresh reaches HubSpot per workspace, no longer `inc:nil`); atomic
+    `Meter.Reserve` + reserve-before-`inc.Get` (review #56); `ActiveConnection`
+    per-workspace read (split into `connectionreads.go`). NOTE the
+    `datasource.Freshness` verb still has **no production caller** — A3
+    completed the seam; a "refresh"/🟡-action surface that INVOKES force-fresh
+    is a tracked follow-up (see the backlog memory).
+
   Still open in 1b (the next branches, roughly in priority order):
-  - **A3 budget metering + live freshness** — wire a live per-workspace
-    incumbent into the force-fresh read path (`NewOverlayProvider` still wires
-    `inc: nil` at compose/overlay.go — FreshnessReader needs a per-request
-    `resolveIncumbent(ctx)` reading the connection + vault + building the
-    adapter, reusing jobs_overlay's factory); atomic reserve-before-`inc.Get`
-    (review #56); meter in the HTTP transport (not per-record-count);
-    token-bucket burst limiter; one budget meter per deployment, not
-    per-process (shared PG/Redis state) — combined spend can exceed the
-    HubSpot quota N×. Branch `fix/overlay-budget-metering` started.
+  - **A3b** — token-bucket burst limiter (HubSpot 100–250/10s); shared
+    cross-process meter (PG/Redis) so `/overlay/budget` reflects the worker
+    poller; **and the force-fresh CALLER** (the surface that invokes the now-live
+    Freshness verb) — without it A3's live read is latent infra.
   - **A4 reconcile robustness** — budget-pace/`Retry-After` backoff on a
-    failing connection (today it re-sweeps hot every tick); composite keyset
-    watermark (a >10k same-timestamp block wedges the sweep — disclosed in
-    reconcile.go).
+    failing connection (today it re-sweeps hot every tick, no per-connection
+    error/backoff state — mirror capture's `sync_state` pattern; likely a
+    migration + poller error taxonomy + due-filtering in DueOverlayConnections);
+    composite keyset watermark (a >10k same-timestamp block wedges the sweep —
+    disclosed in reconcile.go; the seam can't signal mode-switch, an
+    upstream-tracked spike). Branch `fix/overlay-reconcile-robustness` created,
+    not yet implemented.
   - **A5 disconnect-race fencing**; **A7 assoc/backfill fidelity**;
     **webhook-as-signal** (only WITH portal-id→workspace binding in the HMAC
     basis — the unmounted receiver was deleted, not fixed); a **reconnect flow**

--- a/backend/internal/compose/jobs_overlay.go
+++ b/backend/internal/compose/jobs_overlay.go
@@ -5,14 +5,18 @@ package compose
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/riverqueue/river"
 
 	"github.com/gradionhq/margince/backend/internal/modules/overlay"
+	"github.com/gradionhq/margince/backend/internal/modules/overlay/hubspot"
 	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
@@ -87,12 +91,42 @@ func (w *overlayReconcileWorker) Work(ctx context.Context, _ *river.Job[OverlayR
 	due, enumErr := overlay.DueOverlayConnections(ctx, w.pool)
 	for _, d := range due {
 		wsCtx := reconcileWorkerCtx(ctx, d.Workspace)
-		if err := reconcileConnection(wsCtx, w.vault, w.ms, w.meter, w.log, d, w.newIncumbent); err != nil {
+		err := reconcileConnection(wsCtx, w.vault, w.ms, w.meter, w.log, d, w.newIncumbent)
+		// Record the sweep outcome so a connection-level failure backs the
+		// next sweep off (overlay_sync_state), instead of re-sweeping a
+		// revoked/rate-limited/unreachable connection hot every tick; one
+		// clean sweep resets the backoff. Only the periodic poller schedules
+		// backoff — the on-demand /overlay/reconcile handler returns its
+		// error to the admin without touching the schedule.
+		if err != nil {
 			w.log.WarnContext(wsCtx, "overlay reconcile: sweeping this workspace's connection failed",
 				"workspace", d.Workspace.String(), "err", err)
+			if recErr := w.ms.RecordSweepFailure(wsCtx, err, time.Now()); recErr != nil {
+				w.log.WarnContext(wsCtx, "overlay reconcile: recording the sweep-failure backoff failed",
+					"workspace", d.Workspace.String(), "err", recErr)
+			}
+			continue
+		}
+		if recErr := w.ms.RecordSweepSuccess(wsCtx, time.Now()); recErr != nil {
+			w.log.WarnContext(wsCtx, "overlay reconcile: resetting the sweep backoff after success failed",
+				"workspace", d.Workspace.String(), "err", recErr)
 		}
 	}
 	return enumErr
+}
+
+// isConnectionLevelIncumbentError reports whether err is a WHOLE-connection
+// incumbent health failure — a rate limit, an auth rejection, or an
+// unreachable incumbent — as opposed to one object class's mapping/data
+// defect. Only connection-level failures abort the sweep and back the
+// connection off; a per-object failure is logged and the sweep moves on, so
+// one bad object never quarantines a whole workspace. It lives in compose,
+// not overlay, because it names hubspot.ErrUnreachable, which the overlay
+// package cannot import without a cycle.
+func isConnectionLevelIncumbentError(err error) bool {
+	return errors.Is(err, apperrors.ErrIncumbentBudgetExhausted) ||
+		errors.Is(err, apperrors.ErrPermissionDenied) ||
+		errors.Is(err, hubspot.ErrUnreachable)
 }
 
 // reconcileConnection builds a live incumbent adapter over d's vaulted
@@ -110,10 +144,13 @@ func (w *overlayReconcileWorker) Work(ctx context.Context, _ *river.Job[OverlayR
 // calling admin's own principal for the on-demand one) — reconcileConnection
 // itself makes no assumption about which. A per-object-class failure
 // (unreadable watermark, a failed sweep page, a failed watermark save)
-// is logged and skipped, never aborting the rest of the classes; only an
-// unsupported incumbent or a failed vault resolution — both mean there is
-// no adapter to sweep ANYTHING with — stop this connection's sweep
-// entirely and return an error to the caller.
+// is logged and skipped, never aborting the rest of the classes. A
+// CONNECTION-level failure — an unsupported incumbent, a failed vault
+// resolution, or an incumbent call that comes back rate-limited / auth-
+// rejected / unreachable (isConnectionLevelIncumbentError) — stops the
+// sweep and returns an error, which the periodic caller records as a
+// backoff (overlay_sync_state) so a dead or throttled connection is not
+// re-swept hot every tick.
 func reconcileConnection(ctx context.Context, vault keyvault.Vault, ms *overlay.MirrorStore, meter *overlay.Meter, log *slog.Logger, d overlay.DueOverlayConnection, newIncumbent func(region, token string) overlay.Incumbent) error {
 	if d.Incumbent != "hubspot" {
 		// Branch 1 wires only HubSpot (design.md §2 D2/D3) — a connection
@@ -148,6 +185,15 @@ func reconcileConnection(ctx context.Context, vault keyvault.Vault, ms *overlay.
 	// sweep below — an unseeded mapping is a fail-closed-eventually gap
 	// (the NEXT sweep retries), never a reason to stop syncing records.
 	if owners, err := inc.Owners(ctx); err != nil {
+		// The owners fetch is the sweep's first incumbent call. A
+		// connection-level failure here (auth revoked, rate-limited,
+		// unreachable) means every later call fails too, so abort and let
+		// the caller back the connection off rather than hammering it. A
+		// non-connection-level error stays best-effort (seeding is; the
+		// record sweep can still proceed).
+		if isConnectionLevelIncumbentError(err) {
+			return fmt.Errorf("overlay reconcile: owners directory fetch failed: %w", err)
+		}
 		log.WarnContext(ctx, "overlay reconcile: fetching the owners directory to seed mirror_user_map failed",
 			"workspace", d.Workspace.String(), "err", err)
 	} else if err := ms.SeedUserMap(ctx, d.Incumbent, owners); err != nil {
@@ -166,12 +212,21 @@ func reconcileConnection(ctx context.Context, vault keyvault.Vault, ms *overlay.
 	// mapping is a fail-closed-eventually gap (the NEXT sweep tries
 	// again), not a reason to stop syncing records this tick.
 	if err := ms.RevalidateEmailMappings(ctx, inc); err != nil {
+		if isConnectionLevelIncumbentError(err) {
+			return fmt.Errorf("overlay reconcile: email-mapping revalidation failed: %w", err)
+		}
 		log.WarnContext(ctx, "overlay reconcile: periodic email-mapping revalidation failed",
 			"workspace", d.Workspace.String(), "err", err)
 	}
 
 	for _, objectClass := range overlayObjectClasses {
-		sweepObjectClass(ctx, inc, ms, meter, log, d.Workspace.String(), objectClass)
+		// A connection-level failure sweeping any class aborts the whole
+		// sweep (the caller backs the connection off); a per-object failure
+		// was already logged inside sweepObjectClass and skips only that
+		// class, so the loop moves on.
+		if err := sweepObjectClass(ctx, inc, ms, meter, log, d.Workspace.String(), objectClass); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -186,7 +241,13 @@ func reconcileConnection(ctx context.Context, vault keyvault.Vault, ms *overlay.
 // stringified id, for logging only. Extracted from reconcileConnection so
 // the per-class sequence reads as one unit and the connection-level loop
 // stays short.
-func sweepObjectClass(ctx context.Context, inc overlay.Incumbent, ms *overlay.MirrorStore, meter *overlay.Meter, log *slog.Logger, workspace, objectClass string) {
+// It returns a non-nil error ONLY for a connection-level incumbent failure
+// (isConnectionLevelIncumbentError) — the signal reconcileConnection
+// propagates to abort the sweep and back the connection off. A per-object
+// failure (a mapping/data defect, a DB read/write blip) is logged and skips
+// the rest of THIS class with a nil return, so the connection-level loop
+// moves on to the next class.
+func sweepObjectClass(ctx context.Context, inc overlay.Incumbent, ms *overlay.MirrorStore, meter *overlay.Meter, log *slog.Logger, workspace, objectClass string) error {
 	// Initial full load before the incremental sweep: Backfill lists the
 	// object class id-cursor style AND fetches its associations (design.md
 	// §4.4), checkpointing overlay_backfill_cursor so SyncStatus's
@@ -196,21 +257,30 @@ func sweepObjectClass(ctx context.Context, inc overlay.Incumbent, ms *overlay.Mi
 	// on-demand through POST /overlay/reconcile) does the load, the rest
 	// ride the watermark.
 	if err := overlay.Backfill(ctx, inc, ms, objectClass); err != nil {
+		if isConnectionLevelIncumbentError(err) {
+			return err
+		}
 		log.WarnContext(ctx, "overlay reconcile: backfill pass failed, skipping this object class this tick",
 			"workspace", workspace, "object_class", objectClass, "err", err)
-		return
+		return nil
 	}
 	since, err := ms.LoadReconcileWatermark(ctx, objectClass)
 	if err != nil {
+		// A watermark read is a local DB call, not an incumbent one — a blip
+		// here is not a connection-level failure, so skip this class rather
+		// than back the whole connection off.
 		log.WarnContext(ctx, "overlay reconcile: loading the persisted watermark failed, skipping this object class",
 			"workspace", workspace, "object_class", objectClass, "err", err)
-		return
+		return nil
 	}
 	newWatermark, err := overlay.Reconcile(ctx, inc, ms, meter, objectClass, since)
 	if err != nil {
+		if isConnectionLevelIncumbentError(err) {
+			return err
+		}
 		log.WarnContext(ctx, "overlay reconcile sweep failed",
 			"workspace", workspace, "object_class", objectClass, "err", err)
-		return
+		return nil
 	}
 	if newWatermark.After(since) {
 		if err := ms.SaveReconcileWatermark(ctx, objectClass, newWatermark); err != nil {
@@ -227,11 +297,14 @@ func sweepObjectClass(ctx context.Context, inc overlay.Incumbent, ms *overlay.Mi
 	// Modified/Search feed, so the two do not fight over the same row. The
 	// sweep full-scans the archived feed each pass and purges idempotently
 	// (ReconcileDeletions' own doc explains why a watermark would be unsound
-	// over HubSpot's unordered archived feed). A failure is logged and skips
-	// only this class's deletion pass this tick.
+	// over HubSpot's unordered archived feed).
 	if err := overlay.ReconcileDeletions(ctx, inc, ms, meter, objectClass); err != nil {
+		if isConnectionLevelIncumbentError(err) {
+			return err
+		}
 		log.WarnContext(ctx, "overlay reconcile: deletion sweep failed",
 			"workspace", workspace, "object_class", objectClass, "err", err)
-		return
+		return nil
 	}
+	return nil
 }

--- a/backend/internal/compose/jobs_overlay_worker_integration_test.go
+++ b/backend/internal/compose/jobs_overlay_worker_integration_test.go
@@ -117,6 +117,53 @@ func TestResolveOverlayIncumbentBuildsALiveAdapterFromTheVault(t *testing.T) {
 	}
 }
 
+// authFailingIncumbent is a fake whose owners-directory fetch fails with a
+// connection-level auth error (the first incumbent call a sweep makes),
+// standing in for a revoked/insufficient HubSpot token. Every other method
+// delegates to the embedded fake (unused by this test's path).
+type authFailingIncumbent struct{ *fake.Adapter }
+
+func (authFailingIncumbent) Owners(context.Context) ([]overlay.OwnerRef, error) {
+	return nil, apperrors.ErrPermissionDenied
+}
+
+// TestWorkerBacksOffAConnectionLevelFailure proves the branch-1b backoff
+// end to end through the poller: a sweep that fails at the connection level
+// (auth here) records a backoff, so DueOverlayConnections stops selecting
+// that workspace on the next tick — no more re-sweeping a dead connection
+// hot. Work itself returns nil (a single connection's failure never aborts
+// the fleet pass).
+func TestWorkerBacksOffAConnectionLevelFailure(t *testing.T) {
+	e := integration.Setup(t)
+	vault := keyvault.NewMemory()
+	ms := overlay.NewMirrorStore(e.Pool, unresolvedOwnerEmails{})
+	if _, err := overlay.NewService(e.Pool, vault, ms).
+		Connect(overlayAdminCtx(e.WS, e.Rep1), overlay.ConnectInput{Incumbent: "hubspot", Region: "eu1", Token: "tok"}); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+
+	w := &overlayReconcileWorker{
+		pool: e.Pool, vault: vault, ms: ms,
+		meter:        overlay.NewMeter(overlay.DefaultMeterConfig()),
+		log:          slog.New(slog.DiscardHandler),
+		newIncumbent: func(_, _ string) overlay.Incumbent { return authFailingIncumbent{Adapter: fake.New()} },
+	}
+	if err := w.Work(e.Admin(), nil); err != nil {
+		t.Fatalf("Work must not error on a single connection's failure: %v", err)
+	}
+
+	// The workspace is now backed off — no longer due.
+	due, err := overlay.DueOverlayConnections(e.Admin(), e.Pool)
+	if err != nil {
+		t.Fatalf("DueOverlayConnections: %v", err)
+	}
+	for _, d := range due {
+		if d.Workspace.UUID == e.WS {
+			t.Fatal("the workspace must be backed off after a connection-level sweep failure, but it is still due")
+		}
+	}
+}
+
 // TestReconcileConnectionBackfillsAndSeedsViaFakeIncumbent proves the
 // §6.2 sweep end to end against a fake incumbent (the seam the factory
 // injection now enables — before it, reconcileConnection hardcoded a real

--- a/backend/internal/modules/overlay/connectionreads.go
+++ b/backend/internal/modules/overlay/connectionreads.go
@@ -63,14 +63,23 @@ func DueOverlayConnections(ctx context.Context, pool *pgxpool.Pool) ([]DueOverla
 		ws := ids.From[ids.WorkspaceKind](wsID)
 		err := database.WithWorkspaceTx(wsCtx, pool, func(tx pgx.Tx) error {
 			var incumbent, region, ref string
+			// The LEFT JOIN + next_sweep_at gate is the backoff (branch-1b):
+			// a workspace whose last sweep failed carries an overlay_sync_state
+			// row with a future next_sweep_at, so it is NOT selected until due
+			// — no more re-sweeping a revoked/rate-limited/unreachable
+			// connection hot every tick. No row (never swept, or reset by a
+			// success) is due immediately (COALESCE to now()).
 			scanErr := tx.QueryRow(wsCtx, `
-				SELECT incumbent, region, credential_ref FROM incumbent_connection
-				WHERE status = $1`, statusActive).Scan(&incumbent, &region, &ref)
+				SELECT c.incumbent, c.region, c.credential_ref
+				FROM incumbent_connection c
+				LEFT JOIN overlay_sync_state s ON s.workspace_id = c.workspace_id
+				WHERE c.status = $1 AND COALESCE(s.next_sweep_at, now()) <= now()`,
+				statusActive).Scan(&incumbent, &region, &ref)
 			if errors.Is(scanErr, pgx.ErrNoRows) {
-				// x_sor_mode='overlay' with no active connection row is a
-				// transient state (mid-teardown, or a row inserted but not
-				// yet committed) — the poller simply has nothing to sweep
-				// for this workspace this tick, not an error.
+				// Either x_sor_mode='overlay' with no active connection row (a
+				// transient mid-teardown state), or an active connection that
+				// is backed off and not yet due — in both cases the poller has
+				// nothing to sweep for this workspace this tick, not an error.
 				return nil
 			}
 			if scanErr != nil {

--- a/backend/internal/modules/overlay/syncbackoff.go
+++ b/backend/internal/modules/overlay/syncbackoff.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package overlay
+
+// The overlay poller's per-connection scheduling backoff (branch 1b,
+// mirroring capture's ADR-0063 sync-state): a sweep that fails at the
+// CONNECTION level — a revoked token, a rate-limit, an unreachable
+// incumbent — must not be re-swept hot every tick. RecordSweepFailure
+// backs the next sweep off (2min·2^n capped at 4h, jittered; a rate-limit
+// honors a longer floor), and RecordSweepSuccess resets it. The row lives
+// in overlay_sync_state and is read by DueOverlayConnections' due-scan;
+// error DETAIL goes to system_log, the row carries only the class.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand/v2"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+)
+
+const (
+	// sweepBackoffBase..sweepBackoffCap bound the transient-failure ladder:
+	// 2min·2^n capped at 4h, jittered ±20% so a fleet that failed together
+	// (one HubSpot outage) does not retry in lockstep.
+	sweepBackoffBase = 2 * time.Minute
+	sweepBackoffCap  = 4 * time.Hour
+
+	// rateLimitedFloor is the minimum backoff for a rate-limited sweep — a
+	// 429 means "you are already over quota", so retrying on the short
+	// transient ladder would just burn more of the same budget. A precise
+	// Retry-After (surfaced by the incumbent client) would refine this; the
+	// floor is the conservative default until then.
+	rateLimitedFloor = 10 * time.Minute
+)
+
+// sweepErrorClass is the schedulable classification overlay can derive from
+// the apperrors sentinels a sweep surfaces (see the migration's CHECK on
+// why transport-unreachable collapses into internal here).
+type sweepErrorClass string
+
+const (
+	classSweepRateLimited sweepErrorClass = "rate_limited"
+	classSweepAuth        sweepErrorClass = "auth"
+	classSweepInternal    sweepErrorClass = "internal"
+)
+
+// classifySweepError maps a sweep failure onto the schedulable vocabulary.
+// A rate-limit and an auth denial are the two the scheduler treats
+// specially; anything else is internal (a transient the ladder retries).
+func classifySweepError(err error) sweepErrorClass {
+	switch {
+	case errors.Is(err, apperrors.ErrIncumbentBudgetExhausted):
+		return classSweepRateLimited
+	case errors.Is(err, apperrors.ErrPermissionDenied):
+		return classSweepAuth
+	default:
+		return classSweepInternal
+	}
+}
+
+// sweepBackoffDelay is the transient-failure ladder for consecutiveFailures
+// prior failures: 2min·2^n capped at 4h, with ±20% jitter.
+func sweepBackoffDelay(consecutiveFailures int) time.Duration {
+	d := sweepBackoffBase
+	for i := 0; i < consecutiveFailures && d < sweepBackoffCap; i++ {
+		d *= 2
+	}
+	if d > sweepBackoffCap {
+		d = sweepBackoffCap
+	}
+	jitter := 0.8 + 0.4*rand.Float64() //nolint:gosec // G404: scheduling jitter, not key material — de-syncs a fleet that failed together
+	return time.Duration(float64(d) * jitter)
+}
+
+// RecordSweepSuccess resets the backoff for ctx's workspace: the next
+// sweep is due immediately and the failure ladder is cleared. One clean
+// sweep heals a backed-off connection.
+func (s *MirrorStore) RecordSweepSuccess(ctx context.Context, now time.Time) error {
+	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `
+			INSERT INTO overlay_sync_state (workspace_id, next_sweep_at, consecutive_failures, last_success_at, last_error_class, updated_at)
+			VALUES (NULLIF(current_setting('app.workspace_id',true),'')::uuid, $1, 0, $1, NULL, now())
+			ON CONFLICT (workspace_id) DO UPDATE SET
+			  next_sweep_at = EXCLUDED.next_sweep_at,
+			  consecutive_failures = 0,
+			  last_success_at = EXCLUDED.last_success_at,
+			  last_error_class = NULL,
+			  updated_at = now()`,
+			now)
+		return err
+	})
+}
+
+// RecordSweepFailure classifies sweepErr, increments the failure ladder,
+// and pushes the next sweep out by the backoff (a rate-limit honors the
+// longer floor) — so a failing connection stops re-sweeping hot. It never
+// tombstones: the connection stays selectable, just paced. The error
+// detail is logged to system_log; the sidecar row carries only the class.
+func (s *MirrorStore) RecordSweepFailure(ctx context.Context, sweepErr error, now time.Time) error {
+	class := classifySweepError(sweepErr)
+	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+		var failures int
+		if err := tx.QueryRow(ctx, `
+			INSERT INTO overlay_sync_state (workspace_id, next_sweep_at, consecutive_failures, last_error_class, last_failure_at, updated_at)
+			VALUES (NULLIF(current_setting('app.workspace_id',true),'')::uuid, $1, 1, $2, $1, now())
+			ON CONFLICT (workspace_id) DO UPDATE SET
+			  consecutive_failures = overlay_sync_state.consecutive_failures + 1,
+			  last_error_class = EXCLUDED.last_error_class,
+			  last_failure_at = EXCLUDED.last_failure_at,
+			  updated_at = now()
+			RETURNING consecutive_failures`,
+			now, string(class)).Scan(&failures); err != nil {
+			return fmt.Errorf("overlay: recording the sweep failure: %w", err)
+		}
+
+		next := now.Add(sweepBackoffDelay(failures))
+		if class == classSweepRateLimited && next.Sub(now) < rateLimitedFloor {
+			next = now.Add(rateLimitedFloor)
+		}
+		if _, err := tx.Exec(ctx, `UPDATE overlay_sync_state SET next_sweep_at = $1 WHERE workspace_id = NULLIF(current_setting('app.workspace_id',true),'')::uuid`,
+			next); err != nil {
+			return fmt.Errorf("overlay: pacing the next sweep after failure: %w", err)
+		}
+
+		if _, err := storekit.LogSystem(ctx, tx, "overlay.sweep_error", map[string]any{
+			"class":    string(class),
+			"failures": failures,
+			"detail":   sweepErr.Error(),
+		}); err != nil {
+			return fmt.Errorf("overlay: logging the sweep-error system event: %w", err)
+		}
+		return nil
+	})
+}

--- a/backend/internal/modules/overlay/syncbackoff_integration_test.go
+++ b/backend/internal/modules/overlay/syncbackoff_integration_test.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package overlay
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+)
+
+// TestSweepBackoffGatesDueOverlayConnections proves the backoff end to
+// end: a freshly connected workspace is due; a connection-level failure
+// backs it off so DueOverlayConnections stops selecting it (no more
+// hot re-sweeping a dead/throttled connection); and one successful sweep
+// resets the backoff so it is due again. now() is the real clock because
+// the due-scan compares next_sweep_at against the DATABASE's now() — a
+// backoff is always minutes in the future, a reset is always now-or-past,
+// so the OUTCOME is deterministic without any sleep.
+func TestSweepBackoffGatesDueOverlayConnections(t *testing.T) {
+	ctx, pool, ws := testWorkspaceCtx(t)
+	vault := keyvault.NewMemory()
+	store := NewMirrorStore(pool, noOwnerEmails{})
+	if _, err := NewService(pool, vault, store).
+		Connect(ctx, ConnectInput{Incumbent: "hubspot", Region: "eu1", Token: "tok"}); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+
+	isDue := func() bool {
+		due, err := DueOverlayConnections(ctx, pool)
+		if err != nil {
+			t.Fatalf("DueOverlayConnections: %v", err)
+		}
+		for _, d := range due {
+			if d.Workspace.UUID == ws {
+				return true
+			}
+		}
+		return false
+	}
+
+	if !isDue() {
+		t.Fatal("a freshly connected workspace (no sync-state row) must be due immediately")
+	}
+
+	// A connection-level failure backs the sweep off into the future.
+	if err := store.RecordSweepFailure(ctx, apperrors.ErrIncumbentBudgetExhausted, time.Now()); err != nil {
+		t.Fatalf("RecordSweepFailure: %v", err)
+	}
+	if isDue() {
+		t.Fatal("a backed-off workspace must NOT be due until next_sweep_at")
+	}
+
+	// One clean sweep resets the backoff — due again.
+	if err := store.RecordSweepSuccess(ctx, time.Now()); err != nil {
+		t.Fatalf("RecordSweepSuccess: %v", err)
+	}
+	if !isDue() {
+		t.Fatal("after a successful sweep the workspace must be due again")
+	}
+}

--- a/backend/internal/modules/overlay/syncbackoff_test.go
+++ b/backend/internal/modules/overlay/syncbackoff_test.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package overlay
+
+// The sweep-backoff pure logic in isolation: the error classification and
+// the retry-ladder bounds. The DB-backed RecordSweep* round trip and the
+// DueOverlayConnections due-gate are proven in the integration lane.
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+)
+
+func TestClassifySweepError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want sweepErrorClass
+	}{
+		{"rate limit", apperrors.ErrIncumbentBudgetExhausted, classSweepRateLimited},
+		{"wrapped rate limit", fmt.Errorf("sweeping: %w", apperrors.ErrIncumbentBudgetExhausted), classSweepRateLimited},
+		{"auth", apperrors.ErrPermissionDenied, classSweepAuth},
+		{"wrapped auth", fmt.Errorf("owners: %w", apperrors.ErrPermissionDenied), classSweepAuth},
+		{"anything else", errors.New("boom"), classSweepInternal},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := classifySweepError(c.err); got != c.want {
+				t.Errorf("classifySweepError = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+// TestSweepBackoffDelayStaysWithinTheJitteredLadder pins the ladder
+// bounds without depending on the ±20% jitter: delay(n) sits within ±20%
+// of min(base·2^n, cap), so it grows with n and never exceeds the cap by
+// more than the jitter. Asserting bounds (not an exact value) keeps the
+// test deterministic despite the randomised jitter (T11).
+func TestSweepBackoffDelayStaysWithinTheJitteredLadder(t *testing.T) {
+	within := func(t *testing.T, got, center time.Duration) {
+		t.Helper()
+		lo := time.Duration(float64(center) * 0.8)
+		hi := time.Duration(float64(center) * 1.2)
+		if got < lo || got > hi {
+			t.Fatalf("backoff = %v, want within ±20%% of %v ([%v, %v])", got, center, lo, hi)
+		}
+	}
+	within(t, sweepBackoffDelay(0), sweepBackoffBase)   // 2m
+	within(t, sweepBackoffDelay(1), 2*sweepBackoffBase) // 4m
+	within(t, sweepBackoffDelay(3), 8*sweepBackoffBase) // 16m
+	within(t, sweepBackoffDelay(100), sweepBackoffCap)  // capped at 4h
+	if got := sweepBackoffDelay(100); got > time.Duration(float64(sweepBackoffCap)*1.2) {
+		t.Fatalf("backoff at a huge failure count = %v, must never exceed cap·1.2 (%v)", got, sweepBackoffCap)
+	}
+}

--- a/backend/internal/modules/overlay/teardown.go
+++ b/backend/internal/modules/overlay/teardown.go
@@ -141,7 +141,7 @@ func revokeConnection(ctx context.Context, tx pgx.Tx) (credentialRef string, err
 // (the HubSpot owner id), so it is exactly the "no incumbent-derived
 // data remains queryable" surface OVA-AC-1 names, even though it holds
 // no mirror row itself. The sync checkpoints (overlay_backfill_cursor +
-// overlay_reconcile_watermark) purge for the same reason plus a
+// overlay_reconcile_watermark + overlay_sync_state's sweep backoff) purge for the same reason plus a
 // behavioral one: each is a position into the incumbent's own record
 // stream, so a checkpoint that survived disconnect would make a later
 // connection resume mid-stream — a retained done backfill cursor
@@ -190,6 +190,9 @@ func purgeMirror(ctx context.Context, tx pgx.Tx) error {
 	}
 	if _, err := tx.Exec(ctx, `DELETE FROM overlay_reconcile_watermark`); err != nil {
 		return fmt.Errorf("overlay: purging the reconcile watermarks: %w", err)
+	}
+	if _, err := tx.Exec(ctx, `DELETE FROM overlay_sync_state`); err != nil {
+		return fmt.Errorf("overlay: purging the sweep backoff state: %w", err)
 	}
 	return nil
 }

--- a/backend/migrations/custom/20260721140000_overlay_sync_state.down.sql
+++ b/backend/migrations/custom/20260721140000_overlay_sync_state.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS overlay_sync_state;

--- a/backend/migrations/custom/20260721140000_overlay_sync_state.up.sql
+++ b/backend/migrations/custom/20260721140000_overlay_sync_state.up.sql
@@ -1,0 +1,37 @@
+-- 20260721140000_overlay_sync_state: the overlay poller's per-workspace
+-- scheduling sidecar (branch 1b, mirroring capture's CAP-DDL-5 sync-state).
+-- Without it a workspace whose incumbent sweep keeps failing — a revoked
+-- token, an unreachable HubSpot, a rate-limit — is re-selected by
+-- DueOverlayConnections every tick and re-swept hot, hammering a dead or
+-- throttled connection. This row gates the next sweep: a failing sweep
+-- backs off (2min·2^n capped at 4h, jittered; rate-limits honor a longer
+-- floor), and one clean sweep resets it. Scheduling state has a live reader
+-- (the due-scan), so it earns columns; error DETAIL stays in system_log —
+-- the row carries only the class.
+--
+-- Keyed on workspace_id, not connection_id: an overlay has exactly one
+-- active incumbent_connection per workspace (incumbent_connection's
+-- UNIQUE(workspace_id)), and disconnect teardown purges this row, so a
+-- reconnect always starts fresh (no stale backoff carried across).
+CREATE TABLE overlay_sync_state (
+  workspace_id uuid PRIMARY KEY REFERENCES workspace(id) ON DELETE RESTRICT,
+  next_sweep_at timestamptz NOT NULL DEFAULT now(),
+  consecutive_failures int NOT NULL DEFAULT 0,
+  -- rate_limited (honor a longer floor) and auth (persistent — needs its
+  -- human) are the schedulable distinctions the overlay package can detect
+  -- from the apperrors sentinels a sweep surfaces; every other transient
+  -- failure (including transport-unreachable, which is a hubspot-package
+  -- sentinel this package cannot import without a cycle) is internal.
+  last_error_class text NULL CHECK (last_error_class IS NULL OR
+    last_error_class IN ('rate_limited','auth','internal')),
+  last_success_at timestamptz NULL,
+  last_failure_at timestamptz NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_overlay_sync_due ON overlay_sync_state (next_sweep_at);
+
+ALTER TABLE overlay_sync_state ENABLE ROW LEVEL SECURITY;
+ALTER TABLE overlay_sync_state FORCE ROW LEVEL SECURITY;
+CREATE POLICY overlay_sync_state_tenant_isolation ON overlay_sync_state
+  USING (workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid)
+  WITH CHECK (workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid);

--- a/backend/tableownership_test.go
+++ b/backend/tableownership_test.go
@@ -154,6 +154,7 @@ var tableOwners = map[string]string{
 	"overlay_tombstone":           "internal/modules/overlay",
 	"overlay_backfill_cursor":     "internal/modules/overlay",
 	"overlay_reconcile_watermark": "internal/modules/overlay",
+	"overlay_sync_state":          "internal/modules/overlay",
 	// compose (HTTP replay protection is transport plumbing, not domain;
 	// the brief read model is the cross-module ranker's own snapshot —
 	// deals + people strength + activities compose only here)


### PR DESCRIPTION
## What & why
A workspace whose incumbent sweep kept failing — revoked token, rate-limit, unreachable HubSpot — was re-selected by `DueOverlayConnections` and re-swept **every poller tick**, hammering a dead/throttled connection (STATUS's "a failed connection re-sweeps hot every tick"). This adds a per-connection scheduling backoff, mirroring capture's ADR-0063 `sync_state`.

## How
- **`overlay_sync_state`** sidecar (workspace-keyed — one connection per workspace; purged by disconnect teardown so a reconnect starts fresh) carrying `next_sweep_at` + the failure ladder + last error class.
- **`RecordSweepFailure`** classifies (`rate_limited` / `auth` / `internal` from the `apperrors` sentinels overlay can see) and pushes `next_sweep_at` out on the `2min·2^n`-capped-`4h` jittered ladder; a rate-limit honors a longer floor (a 429 is already-over-quota). **`RecordSweepSuccess`** resets it — one clean sweep heals a backed-off connection. Never tombstones.
- **`DueOverlayConnections`** gates on `COALESCE(next_sweep_at, now()) <= now()`.
- **`reconcileConnection`** distinguishes a **connection-level** failure (`isConnectionLevelIncumbentError`: rate-limit / auth / `hubspot.ErrUnreachable` — checked in compose, which can import hubspot) from a per-object mapping/data defect: the former aborts the sweep and the poller records the backoff; the latter is still logged and skips only that object class, so one bad object never quarantines a workspace. Only the periodic poller schedules backoff — the on-demand `/overlay/reconcile` handler returns its error to the admin untouched.

## Deferred (upstream-tracked)
The composite keyset watermark for a >10k same-timestamp block — the `Incumbent` seam can't signal a mode-switch to the id-keyset fallback (a documented spike).

## Tests / gates
- `classifySweepError` + backoff-ladder-bounds units; a DB round-trip (failure backs off `DueOverlayConnections`, success resets); an **end-to-end worker test** (an auth-failing incumbent leaves the workspace not-due).
- `make check-backend` green; overlay integration **99**, compose **35**; `craft static` clean; teardown + table-ownership updated.

Follows the merged branch-1b hardening (#159 deletion feed, #160 visibility concurrency, #161 live force-fresh).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add per-workspace sweep backoff so failing overlay connections aren’t re-swept every tick. This reduces load on dead/throttled HubSpot connections and improves reconcile stability.

- **New Features**
  - Added `overlay_sync_state` to track `next_sweep_at`, consecutive failures, and last error class; `DueOverlayConnections` now LEFT JOINs and gates on `COALESCE(next_sweep_at, now()) <= now()`.
  - Worker records outcomes: `RecordSweepFailure` classifies (`rate_limited` / `auth` / `internal`) and schedules `next_sweep_at` via 2m·2^n backoff with ±20% jitter (capped at 4h pre‑jitter; rate limits honor a 10m floor); `RecordSweepSuccess` resets the backoff.
  - `reconcileConnection` aborts and backs off on connection-level errors (rate limit/budget, auth, or `hubspot.ErrUnreachable`) from owners, email revalidation, backfill/sweep/deletions; per‑object issues are logged and skipped so one bad class doesn’t quarantine a workspace.
  - Only the periodic poller schedules backoff; on‑demand `/overlay/reconcile` returns errors unchanged. Backoff state is purged on disconnect.

- **Migration**
  - New table `overlay_sync_state` (RLS enabled; index on `next_sweep_at`).

<sup>Written for commit f349f288d2b325e60d2a8c0908a8e0942a260236. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic backoff scheduling for overlay synchronization after connection-level failures.
  * Added failure classification and retry delays for rate limits, authorization issues, and internal errors.
  * Successful sweeps now reset backoff state and allow connections to be scheduled again.
  * Disconnecting an overlay now removes its synchronization scheduling state.

* **Bug Fixes**
  * Connection-level failures now stop the affected sweep while allowing other connections and object classes to continue processing.
  * Overlay synchronization only selects connections whose backoff period has elapsed.

* **Documentation**
  * Updated status tracking for merged live freshness and budget-reservation work, with remaining follow-ups noted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->