### PR TITLE
feat(overlay): fence sync writes against a mid-sweep disconnect (branch 1b)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -683,23 +683,35 @@ Open work, roughly in priority order:
     completed the seam; a "refresh"/🟡-action surface that INVOKES force-fresh
     is a tracked follow-up (see the backlog memory).
 
+  - **A4 reconcile robustness (failing-connection backoff)** — MERGED #165
+    (`9d9dabe`). `overlay_sync_state` sidecar + `RecordSweepFailure`/`Success`
+    (classify + a 2min·2^n ladder capped at 4h *before* ±20% jitter, so
+    ~4h48m effective + rate-limit floor) + `DueOverlayConnections` due-gate +
+    `reconcileConnection` distinguishing connection-level (abort+backoff) from
+    per-object (log+skip) failures.
+  - **A5 disconnect-race fencing** — IN FLIGHT #166
+    (`fix/overlay-disconnect-fencing`). Opt-in `MirrorStore.WithFence()`: a
+    `FOR SHARE` assert on the active `incumbent_connection` row (fail-closed)
+    on every resurrection-risk write, contending with Disconnect's FOR UPDATE
+    so a mid-sweep write either commits-then-purged or aborts with
+    `ErrConnectionGone`; the sweep treats that as a clean stop. Covers the
+    tables the mirror tombstone cannot (associations, checkpoints, user-map)
+    + a tombstone-less new row. `mirrorcheckpoints.go` split out.
+
   Still open in 1b (the next branches, roughly in priority order):
   - **A3b** — token-bucket burst limiter (HubSpot 100–250/10s); shared
     cross-process meter (PG/Redis) so `/overlay/budget` reflects the worker
     poller; **and the force-fresh CALLER** (the surface that invokes the now-live
     Freshness verb) — without it A3's live read is latent infra.
-  - **A4 reconcile robustness** — the **failing-connection backoff is DONE in
-    this PR**: `overlay_sync_state` sidecar + `RecordSweepFailure`/`Success`
-    (classify + a 2min·2^n ladder capped at 4h *before* ±20% jitter, so
-    ~4h48m effective + rate-limit floor) +
-    `DueOverlayConnections` due-gate + `reconcileConnection` distinguishing
-    connection-level (abort+backoff) from per-object (log+skip) failures. Still
-    open (**A4b**): the composite keyset watermark for a >10k same-timestamp
+  - **A4b** — the composite keyset watermark for a >10k same-timestamp
     block (the seam can't signal mode-switch — an upstream spike); atomic
     ingest+`mirror.conflict` in one row-locked tx; propagate aggregate/`ctx.Err()`
     to handlers.go's 503 path; derive sync staleness (`syncstatus.go` never
     marks stale).
-  - **A5 disconnect-race fencing**; **A7 assoc/backfill fidelity**;
+  - **A5b** — teardown.go's post-commit vault-credential delete isn't retryable
+    across a Disconnect retry (inert orphaned sealed blob; branch-1 has no
+    reconnect); needs a durable-cleanup design.
+  - **A7 assoc/backfill fidelity**;
     **webhook-as-signal** (only WITH portal-id→workspace binding in the HMAC
     basis — the unmounted receiver was deleted, not fixed); a **reconnect flow**
     (Connect refuses a workspace with any connection row) that clears teardown

--- a/backend/internal/compose/jobs_overlay.go
+++ b/backend/internal/compose/jobs_overlay.go
@@ -89,6 +89,14 @@ func reconcileWorkerCtx(ctx context.Context, workspaceID ids.WorkspaceID) contex
 
 func (w *overlayReconcileWorker) Work(ctx context.Context, _ *river.Job[OverlayReconcileArgs]) error {
 	due, enumErr := overlay.DueOverlayConnections(ctx, w.pool)
+	// The outcome-recording store is fenced too (WithFence): overlay_sync_state
+	// is one of the tables teardown purges, so recording a backoff or success
+	// against a workspace that disconnected before/after the sweep would
+	// resurrect a purged row — the fence makes the recording abort with
+	// ErrConnectionGone instead. A rate-limit/auth failure leaves the
+	// connection row 'active' (only Disconnect revokes it), so the legitimate
+	// backoff paths still record.
+	recMS := w.ms.WithFence()
 	for _, d := range due {
 		wsCtx := reconcileWorkerCtx(ctx, d.Workspace)
 		err := reconcileConnection(wsCtx, w.vault, w.ms, w.meter, w.log, d, w.newIncumbent)
@@ -112,13 +120,15 @@ func (w *overlayReconcileWorker) Work(ctx context.Context, _ *river.Job[OverlayR
 		if err != nil {
 			w.log.WarnContext(wsCtx, "overlay reconcile: sweeping this workspace's connection failed",
 				"workspace", d.Workspace.String(), "err", err)
-			if recErr := w.ms.RecordSweepFailure(wsCtx, err, time.Now()); recErr != nil {
+			// A fenced ErrConnectionGone here means the connection was revoked
+			// between the sweep and this recording — benign, nothing to pace.
+			if recErr := recMS.RecordSweepFailure(wsCtx, err, time.Now()); recErr != nil && !errors.Is(recErr, overlay.ErrConnectionGone) {
 				w.log.WarnContext(wsCtx, "overlay reconcile: recording the sweep-failure backoff failed",
 					"workspace", d.Workspace.String(), "err", recErr)
 			}
 			continue
 		}
-		if recErr := w.ms.RecordSweepSuccess(wsCtx, time.Now()); recErr != nil {
+		if recErr := recMS.RecordSweepSuccess(wsCtx, time.Now()); recErr != nil && !errors.Is(recErr, overlay.ErrConnectionGone) {
 			w.log.WarnContext(wsCtx, "overlay reconcile: resetting the sweep backoff after success failed",
 				"workspace", d.Workspace.String(), "err", recErr)
 		}
@@ -232,9 +242,9 @@ func reconcileConnection(ctx context.Context, vault keyvault.Vault, ms *overlay.
 	// mapping is a fail-closed-eventually gap (the NEXT sweep tries
 	// again), not a reason to stop syncing records this tick.
 	if err := ms.RevalidateEmailMappings(ctx, inc); err != nil {
-		if errors.Is(err, overlay.ErrConnectionGone) {
-			return err
-		}
+		// RevalidateEmailMappings is intentionally unfenced (it only
+		// revalidates/clears, never resurrects — visibility.go), so it never
+		// surfaces ErrConnectionGone; no clean-stop branch belongs here.
 		if isConnectionLevelIncumbentError(err) {
 			return fmt.Errorf("overlay reconcile: email-mapping revalidation failed: %w", err)
 		}
@@ -264,12 +274,14 @@ func reconcileConnection(ctx context.Context, vault keyvault.Vault, ms *overlay.
 // stringified id, for logging only. Extracted from reconcileConnection so
 // the per-class sequence reads as one unit and the connection-level loop
 // stays short.
-// It returns a non-nil error ONLY for a connection-level incumbent failure
+// It returns a non-nil error only for a connection-level incumbent failure
 // (isConnectionLevelIncumbentError) — the signal reconcileConnection
-// propagates to abort the sweep and back the connection off. A per-object
-// failure (a mapping/data defect, a DB read/write blip) is logged and skips
-// the rest of THIS class with a nil return, so the connection-level loop
-// moves on to the next class.
+// propagates to abort the sweep and back the connection off — or
+// overlay.ErrConnectionGone, the disconnect-race fence's clean-stop signal
+// reconcileConnection turns into a no-backoff stop. A per-object failure (a
+// mapping/data defect, a DB read/write blip) is logged and skips the rest of
+// THIS class with a nil return, so the connection-level loop moves on to the
+// next class.
 func sweepObjectClass(ctx context.Context, inc overlay.Incumbent, ms *overlay.MirrorStore, meter *overlay.Meter, log *slog.Logger, workspace, objectClass string) error {
 	// Initial full load before the incremental sweep: Backfill lists the
 	// object class id-cursor style AND fetches its associations (design.md

--- a/backend/internal/compose/jobs_overlay.go
+++ b/backend/internal/compose/jobs_overlay.go
@@ -98,6 +98,17 @@ func (w *overlayReconcileWorker) Work(ctx context.Context, _ *river.Job[OverlayR
 		// clean sweep resets the backoff. Only the periodic poller schedules
 		// backoff — the on-demand /overlay/reconcile handler returns its
 		// error to the admin without touching the schedule.
+		if errors.Is(err, overlay.ErrConnectionGone) {
+			// The workspace was disconnected mid-sweep: every fenced write
+			// aborted, so nothing was resurrected into the now-native
+			// workspace. This is neither a failure to back off (the revoked
+			// connection is already gone from the next due-scan) nor a success
+			// to checkpoint — the overlay_sync_state row was purged by
+			// teardown. Move on.
+			w.log.DebugContext(wsCtx, "overlay reconcile: connection disconnected mid-sweep, stopping cleanly",
+				"workspace", d.Workspace.String())
+			continue
+		}
 		if err != nil {
 			w.log.WarnContext(wsCtx, "overlay reconcile: sweeping this workspace's connection failed",
 				"workspace", d.Workspace.String(), "err", err)
@@ -173,7 +184,13 @@ func reconcileConnection(ctx context.Context, vault keyvault.Vault, ms *overlay.
 	// emails — the worker-level store carries only the read-path
 	// placeholder resolver (compose/overlay.go), which cannot name an
 	// owner.
-	ms = ms.WithResolver(inc)
+	// WithFence engages the disconnect-race fence for the sweep's writes: if
+	// this workspace is disconnected mid-sweep, every fenced write aborts
+	// with overlay.ErrConnectionGone rather than resurrecting purged
+	// incumbent-derived data into a now-native workspace (overlay's
+	// disconnectfence.go). reconcileConnection and its callees treat that
+	// signal as a clean stop.
+	ms = ms.WithResolver(inc).WithFence()
 
 	// Seed mirror_user_map from the incumbent's owners directory each
 	// sweep: match every incumbent owner's email to an existing workspace
@@ -197,6 +214,9 @@ func reconcileConnection(ctx context.Context, vault keyvault.Vault, ms *overlay.
 		log.WarnContext(ctx, "overlay reconcile: fetching the owners directory to seed mirror_user_map failed",
 			"workspace", d.Workspace.String(), "err", err)
 	} else if err := ms.SeedUserMap(ctx, d.Incumbent, owners); err != nil {
+		if errors.Is(err, overlay.ErrConnectionGone) {
+			return err
+		}
 		log.WarnContext(ctx, "overlay reconcile: seeding mirror_user_map from the owners directory failed",
 			"workspace", d.Workspace.String(), "err", err)
 	}
@@ -212,6 +232,9 @@ func reconcileConnection(ctx context.Context, vault keyvault.Vault, ms *overlay.
 	// mapping is a fail-closed-eventually gap (the NEXT sweep tries
 	// again), not a reason to stop syncing records this tick.
 	if err := ms.RevalidateEmailMappings(ctx, inc); err != nil {
+		if errors.Is(err, overlay.ErrConnectionGone) {
+			return err
+		}
 		if isConnectionLevelIncumbentError(err) {
 			return fmt.Errorf("overlay reconcile: email-mapping revalidation failed: %w", err)
 		}
@@ -257,7 +280,7 @@ func sweepObjectClass(ctx context.Context, inc overlay.Incumbent, ms *overlay.Mi
 	// on-demand through POST /overlay/reconcile) does the load, the rest
 	// ride the watermark.
 	if err := overlay.Backfill(ctx, inc, ms, objectClass); err != nil {
-		if isConnectionLevelIncumbentError(err) {
+		if errors.Is(err, overlay.ErrConnectionGone) || isConnectionLevelIncumbentError(err) {
 			return err
 		}
 		log.WarnContext(ctx, "overlay reconcile: backfill pass failed, skipping this object class this tick",
@@ -275,7 +298,7 @@ func sweepObjectClass(ctx context.Context, inc overlay.Incumbent, ms *overlay.Mi
 	}
 	newWatermark, err := overlay.Reconcile(ctx, inc, ms, meter, objectClass, since)
 	if err != nil {
-		if isConnectionLevelIncumbentError(err) {
+		if errors.Is(err, overlay.ErrConnectionGone) || isConnectionLevelIncumbentError(err) {
 			return err
 		}
 		log.WarnContext(ctx, "overlay reconcile sweep failed",
@@ -284,6 +307,9 @@ func sweepObjectClass(ctx context.Context, inc overlay.Incumbent, ms *overlay.Mi
 	}
 	if newWatermark.After(since) {
 		if err := ms.SaveReconcileWatermark(ctx, objectClass, newWatermark); err != nil {
+			if errors.Is(err, overlay.ErrConnectionGone) {
+				return err
+			}
 			log.WarnContext(ctx, "overlay reconcile: persisting the new watermark failed",
 				"workspace", workspace, "object_class", objectClass, "err", err)
 		}

--- a/backend/internal/compose/jobs_overlay_worker_integration_test.go
+++ b/backend/internal/compose/jobs_overlay_worker_integration_test.go
@@ -23,9 +23,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5"
+
 	"github.com/gradionhq/margince/backend/internal/compose/integration"
 	"github.com/gradionhq/margince/backend/internal/modules/overlay"
 	"github.com/gradionhq/margince/backend/internal/modules/overlay/fake"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -232,6 +235,79 @@ func TestReconcileConnectionBackfillsAndSeedsViaFakeIncumbent(t *testing.T) {
 	// Rep2 matches no owner, so stays hidden (existence-hiding 404).
 	if _, err := ms.Get(overlayReaderCtx(e.WS, e.Rep2), "person", "c-1"); !errors.Is(err, apperrors.ErrNotFound) {
 		t.Fatalf("Rep2 (unmapped) must not see the record, got: %v", err)
+	}
+}
+
+// TestReconcileConnectionStopsCleanlyWhenDisconnectedMidSweep proves the
+// disconnect-race fence end to end through the sweep orchestration: if the
+// connection is revoked after the sweep resolved its token but before its
+// writes land, reconcileConnection aborts with overlay.ErrConnectionGone —
+// the clean-stop signal the worker turns into "skip this workspace, no
+// backoff" — and resurrects nothing into the now-disconnected workspace.
+func TestReconcileConnectionStopsCleanlyWhenDisconnectedMidSweep(t *testing.T) {
+	e := integration.Setup(t)
+	vault := keyvault.NewMemory()
+	ms := overlay.NewMirrorStore(e.Pool, unresolvedOwnerEmails{})
+
+	if _, err := overlay.NewService(e.Pool, vault, ms).
+		Connect(overlayAdminCtx(e.WS, e.Rep1), overlay.ConnectInput{Incumbent: "hubspot", Region: "eu1", Token: "tok"}); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+
+	fakeInc := fake.New()
+	fakeInc.SeedOwner("owner-1", "a@authz.test")
+	rec := fake.Rec("c-1", map[string]any{"firstname": "Ada"})
+	rec.ObjectClass = "person" // canonical
+	rec.OwnerExternalID = "owner-1"
+	fakeInc.Seed(overlay.IncumbentClassContacts, rec)
+
+	adminCtx := overlayAdminCtx(e.WS, e.Rep1)
+	due, err := overlay.DueOverlayConnections(adminCtx, e.Pool)
+	if err != nil {
+		t.Fatalf("DueOverlayConnections: %v", err)
+	}
+	var d overlay.DueOverlayConnection
+	for _, c := range due {
+		if c.Workspace.UUID == e.WS {
+			d = c
+		}
+	}
+	if d.Incumbent == "" {
+		t.Fatal("no due overlay connection for the workspace after connect")
+	}
+
+	// Simulate a disconnect landing AFTER the sweep resolved its token: revoke
+	// the connection row directly (leaving the vaulted token in place, so the
+	// sweep's token resolution still succeeds and it proceeds to its first
+	// fenced write, exactly the mid-sweep race the fence exists for).
+	if err := database.WithWorkspaceTx(adminCtx, e.Pool, func(tx pgx.Tx) error {
+		_, execErr := tx.Exec(adminCtx,
+			`UPDATE incumbent_connection SET status = 'revoked', revoked_at = now()
+			 WHERE workspace_id = current_setting('app.workspace_id')::uuid`)
+		return execErr
+	}); err != nil {
+		t.Fatalf("revoking the connection mid-sweep: %v", err)
+	}
+
+	sweepCtx := reconcileWorkerCtx(context.Background(), ids.From[ids.WorkspaceKind](e.WS))
+	err = reconcileConnection(sweepCtx, vault, ms, overlay.NewMeter(overlay.DefaultMeterConfig()),
+		slog.New(slog.DiscardHandler), d, func(_, _ string) overlay.Incumbent { return fakeInc })
+	if !errors.Is(err, overlay.ErrConnectionGone) {
+		t.Fatalf("reconcileConnection over a revoked connection = %v, want overlay.ErrConnectionGone (clean stop)", err)
+	}
+
+	// The fenced sweep resurrected nothing: no mirror row, no owner mapping.
+	var mirrorRows, userMaps int
+	if qErr := database.WithWorkspaceTx(sweepCtx, e.Pool, func(tx pgx.Tx) error {
+		if err := tx.QueryRow(sweepCtx, `SELECT count(*) FROM overlay_mirror`).Scan(&mirrorRows); err != nil {
+			return err
+		}
+		return tx.QueryRow(sweepCtx, `SELECT count(*) FROM mirror_user_map`).Scan(&userMaps)
+	}); qErr != nil {
+		t.Fatalf("counting resurrected rows: %v", qErr)
+	}
+	if mirrorRows != 0 || userMaps != 0 {
+		t.Errorf("after a fenced sweep over a revoked connection: overlay_mirror=%d mirror_user_map=%d, want 0/0 — the fence must resurrect nothing", mirrorRows, userMaps)
 	}
 }
 

--- a/backend/internal/compose/jobs_overlay_worker_integration_test.go
+++ b/backend/internal/compose/jobs_overlay_worker_integration_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/compose/integration"
 	"github.com/gradionhq/margince/backend/internal/modules/overlay"
@@ -308,6 +309,111 @@ func TestReconcileConnectionStopsCleanlyWhenDisconnectedMidSweep(t *testing.T) {
 	}
 	if mirrorRows != 0 || userMaps != 0 {
 		t.Errorf("after a fenced sweep over a revoked connection: overlay_mirror=%d mirror_user_map=%d, want 0/0 — the fence must resurrect nothing", mirrorRows, userMaps)
+	}
+}
+
+// revokeOnOwnersIncumbent simulates a disconnect landing MID-SWEEP: it
+// revokes the workspace's connection row (leaving the vaulted token in place)
+// the first time the sweep calls Owners — after the due-scan enumerated the
+// connection as active but before the sweep's first fenced write — then
+// delegates to the wrapped fake. It is the deterministic hook that exercises
+// the disconnect-race clean-stop paths (the fence itself is DB state, not an
+// incumbent response, so it cannot be injected through the adapter directly).
+type revokeOnOwnersIncumbent struct {
+	overlay.Incumbent
+	pool *pgxpool.Pool
+	done bool
+}
+
+func (r *revokeOnOwnersIncumbent) Owners(ctx context.Context) ([]overlay.OwnerRef, error) {
+	if !r.done {
+		r.done = true
+		if err := database.WithWorkspaceTx(ctx, r.pool, func(tx pgx.Tx) error {
+			_, execErr := tx.Exec(ctx,
+				`UPDATE incumbent_connection SET status = 'revoked', revoked_at = now()
+				 WHERE workspace_id = current_setting('app.workspace_id')::uuid`)
+			return execErr
+		}); err != nil {
+			return nil, err
+		}
+	}
+	return r.Incumbent.Owners(ctx)
+}
+
+// TestWorkerCleanStopsOnMidSweepDisconnect proves the worker's clean-stop: a
+// connection revoked mid-sweep makes reconcileConnection return
+// ErrConnectionGone, and Work skips the workspace WITHOUT recording a backoff
+// or a success — so the overlay_sync_state row teardown purged is not
+// resurrected, and nothing is re-mirrored into the now-native workspace.
+func TestWorkerCleanStopsOnMidSweepDisconnect(t *testing.T) {
+	e := integration.Setup(t)
+	vault := keyvault.NewMemory()
+	ms := overlay.NewMirrorStore(e.Pool, unresolvedOwnerEmails{})
+	if _, err := overlay.NewService(e.Pool, vault, ms).
+		Connect(overlayAdminCtx(e.WS, e.Rep1), overlay.ConnectInput{Incumbent: "hubspot", Region: "eu1", Token: "tok"}); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	fakeInc := fake.New()
+	fakeInc.SeedOwner("owner-1", "a@authz.test") // matches Rep1, so SeedUserMap reaches a fenced UpsertUserMap
+
+	w := &overlayReconcileWorker{
+		pool: e.Pool, vault: vault, ms: ms,
+		meter: overlay.NewMeter(overlay.DefaultMeterConfig()),
+		log:   slog.New(slog.DiscardHandler),
+		newIncumbent: func(_, _ string) overlay.Incumbent {
+			return &revokeOnOwnersIncumbent{Incumbent: fakeInc, pool: e.Pool}
+		},
+	}
+	if err := w.Work(e.Admin(), nil); err != nil {
+		t.Fatalf("Work must not error on a mid-sweep disconnect: %v", err)
+	}
+
+	// No sweep outcome was recorded: the clean-stop path skipped both
+	// RecordSweepFailure and RecordSweepSuccess, so the purged
+	// overlay_sync_state row stays gone (a resurrected row is exactly the P1
+	// this fences).
+	var syncStateRows, mirrorRows int
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		if err := tx.QueryRow(e.Admin(), `SELECT count(*) FROM overlay_sync_state`).Scan(&syncStateRows); err != nil {
+			return err
+		}
+		return tx.QueryRow(e.Admin(), `SELECT count(*) FROM overlay_mirror`).Scan(&mirrorRows)
+	}); err != nil {
+		t.Fatalf("counting post-sweep rows: %v", err)
+	}
+	if syncStateRows != 0 {
+		t.Errorf("overlay_sync_state has %d row(s) after a mid-sweep disconnect, want 0 — the clean stop must not resurrect the purged backoff row", syncStateRows)
+	}
+	if mirrorRows != 0 {
+		t.Errorf("overlay_mirror has %d row(s) after a mid-sweep disconnect, want 0 — nothing may be re-mirrored into a now-native workspace", mirrorRows)
+	}
+}
+
+// TestOnDemandReconcileRacingDisconnectAnswersModeNotOverlay proves the
+// on-demand /overlay/reconcile boundary translates the disconnect-race
+// sentinel into the same ErrModeNotOverlay a workspace with no active
+// connection already gets — never an opaque 500.
+func TestOnDemandReconcileRacingDisconnectAnswersModeNotOverlay(t *testing.T) {
+	e := integration.Setup(t)
+	vault := keyvault.NewMemory()
+	ms := overlay.NewMirrorStore(e.Pool, unresolvedOwnerEmails{})
+	if _, err := overlay.NewService(e.Pool, vault, ms).
+		Connect(overlayAdminCtx(e.WS, e.Rep1), overlay.ConnectInput{Incumbent: "hubspot", Region: "eu1", Token: "tok"}); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	fakeInc := fake.New()
+	fakeInc.SeedOwner("owner-1", "a@authz.test")
+
+	r := overlayReconciler{
+		pool: e.Pool, vault: vault, ms: ms,
+		meter: overlay.NewMeter(overlay.DefaultMeterConfig()),
+		log:   slog.New(slog.DiscardHandler),
+		newIncumbent: func(_, _ string) overlay.Incumbent {
+			return &revokeOnOwnersIncumbent{Incumbent: fakeInc, pool: e.Pool}
+		},
+	}
+	if err := r.Reconcile(overlayAdminCtx(e.WS, e.Rep1)); !errors.Is(err, apperrors.ErrModeNotOverlay) {
+		t.Fatalf("on-demand reconcile racing a disconnect = %v, want apperrors.ErrModeNotOverlay (not an opaque 500)", err)
 	}
 }
 

--- a/backend/internal/compose/overlay.go
+++ b/backend/internal/compose/overlay.go
@@ -15,6 +15,7 @@ package compose
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -161,7 +162,15 @@ func (r overlayReconciler) Reconcile(ctx context.Context) error {
 	}
 	for _, d := range due {
 		if d.Workspace.UUID == wsID {
-			return reconcileConnection(ctx, r.vault, r.ms, r.meter, r.log, d, r.newIncumbent)
+			err := reconcileConnection(ctx, r.vault, r.ms, r.meter, r.log, d, r.newIncumbent)
+			if errors.Is(err, overlay.ErrConnectionGone) {
+				// The connection was revoked between the due-scan above and the
+				// sweep's first fenced write (a disconnect racing this on-demand
+				// reconcile). That is the same mode-question the fallthrough
+				// below answers — not an opaque 500 — so collapse it here.
+				return apperrors.ErrModeNotOverlay
+			}
+			return err
 		}
 	}
 	// No active connection for THIS workspace — the same mode-question

--- a/backend/internal/modules/overlay/disconnectfence.go
+++ b/backend/internal/modules/overlay/disconnectfence.go
@@ -6,6 +6,7 @@ package overlay
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/jackc/pgx/v5"
 )
@@ -16,9 +17,10 @@ import (
 // that issued the write began. The sweep treats it as a clean STOP, never a
 // failure — there is nothing to sync into a workspace that has left overlay
 // mode, and the revoked connection is already gone from the due-scan. It is
-// a package-internal control signal, deliberately NOT an apperrors sentinel:
-// it never crosses an HTTP/MCP boundary, because the only caller of a fenced
-// store is the background reconcile sweep.
+// exported so compose (the sweep orchestration) can recognize it, but it is
+// deliberately NOT an apperrors sentinel: it is an application-internal
+// control signal that never crosses an HTTP/MCP boundary — the on-demand
+// reconcile path maps it to apperrors.ErrModeNotOverlay before it could.
 var ErrConnectionGone = errors.New("overlay: the incumbent connection was revoked mid-sweep")
 
 // assertActiveConnection is the disconnect-race fence. It takes a SHARED
@@ -56,5 +58,8 @@ func assertActiveConnection(ctx context.Context, tx pgx.Tx) error {
 	if errors.Is(err, pgx.ErrNoRows) {
 		return ErrConnectionGone
 	}
-	return err
+	if err != nil {
+		return fmt.Errorf("overlay: asserting the active incumbent connection: %w", err)
+	}
+	return nil
 }

--- a/backend/internal/modules/overlay/disconnectfence.go
+++ b/backend/internal/modules/overlay/disconnectfence.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package overlay
+
+import (
+	"context"
+	"errors"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// ErrConnectionGone is the sync-write fence's abort signal: a fenced write
+// (MirrorStore.WithFence) found no active incumbent_connection for the
+// workspace, so the connection has been revoked/disconnected since the sweep
+// that issued the write began. The sweep treats it as a clean STOP, never a
+// failure — there is nothing to sync into a workspace that has left overlay
+// mode, and the revoked connection is already gone from the due-scan. It is
+// a package-internal control signal, deliberately NOT an apperrors sentinel:
+// it never crosses an HTTP/MCP boundary, because the only caller of a fenced
+// store is the background reconcile sweep.
+var ErrConnectionGone = errors.New("overlay: the incumbent connection was revoked mid-sweep")
+
+// assertActiveConnection is the disconnect-race fence. It takes a SHARED
+// lock on the workspace's active incumbent_connection row for the calling
+// transaction. Disconnect (teardown.go) takes that same row FOR UPDATE and,
+// in the SAME transaction, purges every incumbent-derived table and flips
+// the workspace back to native. The two lock modes make a fenced sync write
+// and a disconnect mutually exclusive on that row, so an in-flight sweep
+// write either:
+//
+//   - commits BEFORE the disconnect — its row is then purged by the
+//     disconnect that was waiting on the shared lock; or
+//   - runs AFTER the disconnect commits — it finds NO active connection row
+//     and returns ErrConnectionGone, writing nothing.
+//
+// Either way a stray in-flight sweep can never resurrect incumbent-derived
+// data into a disconnected workspace. overlay_mirror ingest is additionally
+// tombstone-guarded in-SQL (mirrorstore.go's ingestSQL), but the association
+// edges, the backfill cursor, the reconcile watermark, and mirror_user_map
+// are not record-keyed and cannot be tombstoned — this fence is what
+// protects THEM (and a brand-new mirror row that has no tombstone yet).
+//
+// The GUC is read WITHOUT missing_ok, exactly as lockWorkspaceVisibility is:
+// a fenced write with app.workspace_id unset RAISEs rather than resolving to
+// NULL and matching no row (or, worse, every row) — the same fail-closed
+// posture the RLS policies take on the same condition. It is only ever
+// reached inside database.WithWorkspaceTx, which sets the GUC.
+func assertActiveConnection(ctx context.Context, tx pgx.Tx) error {
+	var one int
+	err := tx.QueryRow(ctx, `
+		SELECT 1 FROM incumbent_connection
+		WHERE workspace_id = current_setting('app.workspace_id')::uuid
+		  AND status = 'active'
+		FOR SHARE`).Scan(&one)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return ErrConnectionGone
+	}
+	return err
+}

--- a/backend/internal/modules/overlay/mirrorcheckpoints.go
+++ b/backend/internal/modules/overlay/mirrorcheckpoints.go
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package overlay
+
+// This file owns the sync-POSITION checkpoints — a distinct concern from
+// the record cache in mirrorstore.go: where that store holds the mirrored
+// records themselves, these are the two persisted positions into the
+// incumbent's own stream that make continuous sync resumable — the backfill
+// cursor (a one-time list-keyset walk that retires once done) and the
+// reconcile watermark (a timestamp the incremental sweep keeps advancing).
+// Both save paths carry the disconnect-race fence (disconnectfence.go): a
+// checkpoint resurrected after teardown would make a later connection resume
+// mid-stream, so the sweep's fenced store refuses to write one into a
+// disconnected workspace.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+)
+
+// upsertBackfillCursorSQL checkpoints the backfill cursor design.md §4.4
+// requires ("checkpointed, resumable") — one row per (workspace,
+// object_class), reusing the same NULLIF(current_setting(...)) pattern
+// as ingestSQL/upsertAssocSQL so a caller with no workspace GUC set
+// fails the NOT NULL constraint rather than checkpointing under a null
+// tenant.
+const upsertBackfillCursorSQL = `
+INSERT INTO overlay_backfill_cursor (workspace_id, object_class, cursor, done, updated_at)
+VALUES (NULLIF(current_setting('app.workspace_id',true),'')::uuid, $1, $2, $3, now())
+ON CONFLICT (workspace_id, object_class) DO UPDATE
+   SET cursor = EXCLUDED.cursor, done = EXCLUDED.done, updated_at = now()`
+
+// SaveBackfillCursor persists Backfill's (overlay/backfill.go) list
+// cursor for objectClass after each page — the checkpoint a restart
+// resumes from instead of re-listing the incumbent from the start.
+// done retires a converged backfill so a later call is a cheap no-op.
+func (s *MirrorStore) SaveBackfillCursor(ctx context.Context, objectClass, cursor string, done bool) error {
+	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+		if s.fenced {
+			if err := assertActiveConnection(ctx, tx); err != nil {
+				return err
+			}
+		}
+		if _, err := tx.Exec(ctx, upsertBackfillCursorSQL, objectClass, cursor, done); err != nil {
+			return fmt.Errorf("overlay: checkpointing the %s backfill cursor: %w", objectClass, err)
+		}
+		return nil
+	})
+}
+
+// LoadBackfillCursor reads back objectClass's persisted backfill cursor.
+// No row yet (a backfill that has never run) answers the start-of-paging
+// cursor ("") and done=false — an honest "not started", not an error.
+func (s *MirrorStore) LoadBackfillCursor(ctx context.Context, objectClass string) (string, bool, error) {
+	var cursor string
+	var done bool
+	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+		scanErr := tx.QueryRow(
+			ctx,
+			`SELECT cursor, done FROM overlay_backfill_cursor WHERE object_class = $1`,
+			objectClass,
+		).Scan(&cursor, &done)
+		if errors.Is(scanErr, pgx.ErrNoRows) {
+			cursor, done = "", false
+			return nil
+		}
+		return scanErr
+	})
+	if err != nil {
+		return "", false, fmt.Errorf("overlay: loading the %s backfill cursor: %w", objectClass, err)
+	}
+	return cursor, done, nil
+}
+
+// upsertReconcileWatermarkSQL checkpoints Reconcile's (reconcile.go)
+// incremental watermark — a distinct, always-on counterpart to
+// upsertBackfillCursorSQL above: Backfill's cursor is a one-time,
+// list-keyset walk that retires once done; this watermark is a
+// timestamp the incremental sweep keeps advancing forever, so it lives
+// in its own table (overlay_reconcile_watermark) rather than overloading
+// the backfill cursor's "cursor" column with a second meaning.
+const upsertReconcileWatermarkSQL = `
+INSERT INTO overlay_reconcile_watermark (workspace_id, object_class, watermark, updated_at)
+VALUES (NULLIF(current_setting('app.workspace_id',true),'')::uuid, $1, $2, now())
+ON CONFLICT (workspace_id, object_class) DO UPDATE
+   SET watermark = EXCLUDED.watermark, updated_at = now()`
+
+// SaveReconcileWatermark persists Reconcile's new watermark for
+// objectClass after a sweep pass — the checkpoint the next scheduled
+// pass resumes from instead of re-walking every record since epoch.
+func (s *MirrorStore) SaveReconcileWatermark(ctx context.Context, objectClass string, watermark time.Time) error {
+	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+		if s.fenced {
+			if err := assertActiveConnection(ctx, tx); err != nil {
+				return err
+			}
+		}
+		if _, err := tx.Exec(ctx, upsertReconcileWatermarkSQL, objectClass, watermark); err != nil {
+			return fmt.Errorf("overlay: checkpointing the %s reconcile watermark: %w", objectClass, err)
+		}
+		return nil
+	})
+}
+
+// LoadReconcileWatermark reads back objectClass's persisted incremental
+// watermark. No row yet (a sweep that has never run) answers the zero
+// time — an honest "not started", not an error; Reconcile's own caller
+// (jobs.go's worker) treats that as "sweep from the epoch."
+func (s *MirrorStore) LoadReconcileWatermark(ctx context.Context, objectClass string) (time.Time, error) {
+	var watermark time.Time
+	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+		scanErr := tx.QueryRow(
+			ctx,
+			`SELECT watermark FROM overlay_reconcile_watermark WHERE object_class = $1`,
+			objectClass,
+		).Scan(&watermark)
+		if errors.Is(scanErr, pgx.ErrNoRows) {
+			watermark = time.Time{}
+			return nil
+		}
+		return scanErr
+	})
+	if err != nil {
+		return time.Time{}, fmt.Errorf("overlay: loading the %s reconcile watermark: %w", objectClass, err)
+	}
+	return watermark, nil
+}

--- a/backend/internal/modules/overlay/mirrorstore.go
+++ b/backend/internal/modules/overlay/mirrorstore.go
@@ -54,6 +54,14 @@ type Row struct {
 type MirrorStore struct {
 	pool   *pgxpool.Pool
 	emails OwnerEmailResolver
+	// fenced opts this store into the disconnect-race fence
+	// (disconnectfence.go): every mutation that could resurrect
+	// incumbent-derived data first asserts an active incumbent_connection,
+	// returning ErrConnectionGone if the workspace has been disconnected
+	// mid-sweep. Only the background reconcile sweep sets it (WithFence);
+	// the read-path and on-connect stores leave it false so a write outside
+	// a live connection (a test, the seed) is not gated on one.
+	fenced bool
 }
 
 // NewMirrorStore constructs a MirrorStore over pool. emails resolves an
@@ -74,7 +82,22 @@ func NewMirrorStore(pool *pgxpool.Pool, emails OwnerEmailResolver) *MirrorStore 
 // to reach, since a per-workspace credential lookup is not available at
 // server-construction time.
 func (s *MirrorStore) WithResolver(r OwnerEmailResolver) *MirrorStore {
-	return &MirrorStore{pool: s.pool, emails: r}
+	c := *s
+	c.emails = r
+	return &c
+}
+
+// WithFence returns a MirrorStore identical to s with the disconnect-race
+// fence engaged (see the fenced field and disconnectfence.go). The reconcile
+// sweep binds it — ms.WithResolver(inc).WithFence() — so every sync write it
+// issues aborts with ErrConnectionGone the moment the workspace is
+// disconnected, instead of resurrecting purged incumbent-derived data. It is
+// opt-in precisely so the read path and the many unit tests that ingest
+// without standing up a connection are not forced to hold one.
+func (s *MirrorStore) WithFence() *MirrorStore {
+	c := *s
+	c.fenced = true
+	return &c
 }
 
 // ingestSQL is the in-SQL cache-refresh upsert design.md §4.4/§4.9
@@ -136,6 +159,11 @@ func (s *MirrorStore) Ingest(ctx context.Context, rec Record) error {
 	}
 	var landed bool
 	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+		if s.fenced {
+			if err := assertActiveConnection(ctx, tx); err != nil {
+				return err
+			}
+		}
 		// Ingest's owner projection (ProjectOwnerVisibility, and the
 		// owner-change revalidation) mutates mirror_visibility, so it takes
 		// the same per-workspace visibility lock every other mutator takes —
@@ -212,6 +240,11 @@ func (s *MirrorStore) UpsertAssoc(ctx context.Context, a Assoc) error {
 		label = a.Label
 	}
 	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+		if s.fenced {
+			if err := assertActiveConnection(ctx, tx); err != nil {
+				return err
+			}
+		}
 		if _, err := tx.Exec(
 			ctx, upsertAssocSQL,
 			a.FromType, a.FromID, a.ToType, a.ToID, a.TypeID, a.Category, label, a.Direction,
@@ -362,104 +395,6 @@ func (s *MirrorStore) List(ctx context.Context, objectClass, cursor string, limi
 		next = encodeMirrorCursor(rows[len(rows)-1].ExternalID)
 	}
 	return rows, next, nil
-}
-
-// upsertBackfillCursorSQL checkpoints the backfill cursor design.md §4.4
-// requires ("checkpointed, resumable") — one row per (workspace,
-// object_class), reusing the same NULLIF(current_setting(...)) pattern
-// as ingestSQL/upsertAssocSQL so a caller with no workspace GUC set
-// fails the NOT NULL constraint rather than checkpointing under a null
-// tenant.
-const upsertBackfillCursorSQL = `
-INSERT INTO overlay_backfill_cursor (workspace_id, object_class, cursor, done, updated_at)
-VALUES (NULLIF(current_setting('app.workspace_id',true),'')::uuid, $1, $2, $3, now())
-ON CONFLICT (workspace_id, object_class) DO UPDATE
-   SET cursor = EXCLUDED.cursor, done = EXCLUDED.done, updated_at = now()`
-
-// SaveBackfillCursor persists Backfill's (overlay/backfill.go) list
-// cursor for objectClass after each page — the checkpoint a restart
-// resumes from instead of re-listing the incumbent from the start.
-// done retires a converged backfill so a later call is a cheap no-op.
-func (s *MirrorStore) SaveBackfillCursor(ctx context.Context, objectClass, cursor string, done bool) error {
-	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
-		if _, err := tx.Exec(ctx, upsertBackfillCursorSQL, objectClass, cursor, done); err != nil {
-			return fmt.Errorf("overlay: checkpointing the %s backfill cursor: %w", objectClass, err)
-		}
-		return nil
-	})
-}
-
-// LoadBackfillCursor reads back objectClass's persisted backfill cursor.
-// No row yet (a backfill that has never run) answers the start-of-paging
-// cursor ("") and done=false — an honest "not started", not an error.
-func (s *MirrorStore) LoadBackfillCursor(ctx context.Context, objectClass string) (string, bool, error) {
-	var cursor string
-	var done bool
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
-		scanErr := tx.QueryRow(
-			ctx,
-			`SELECT cursor, done FROM overlay_backfill_cursor WHERE object_class = $1`,
-			objectClass,
-		).Scan(&cursor, &done)
-		if errors.Is(scanErr, pgx.ErrNoRows) {
-			cursor, done = "", false
-			return nil
-		}
-		return scanErr
-	})
-	if err != nil {
-		return "", false, fmt.Errorf("overlay: loading the %s backfill cursor: %w", objectClass, err)
-	}
-	return cursor, done, nil
-}
-
-// upsertReconcileWatermarkSQL checkpoints Reconcile's (reconcile.go)
-// incremental watermark — a distinct, always-on counterpart to
-// upsertBackfillCursorSQL above: Backfill's cursor is a one-time,
-// list-keyset walk that retires once done; this watermark is a
-// timestamp the incremental sweep keeps advancing forever, so it lives
-// in its own table (overlay_reconcile_watermark) rather than overloading
-// the backfill cursor's "cursor" column with a second meaning.
-const upsertReconcileWatermarkSQL = `
-INSERT INTO overlay_reconcile_watermark (workspace_id, object_class, watermark, updated_at)
-VALUES (NULLIF(current_setting('app.workspace_id',true),'')::uuid, $1, $2, now())
-ON CONFLICT (workspace_id, object_class) DO UPDATE
-   SET watermark = EXCLUDED.watermark, updated_at = now()`
-
-// SaveReconcileWatermark persists Reconcile's new watermark for
-// objectClass after a sweep pass — the checkpoint the next scheduled
-// pass resumes from instead of re-walking every record since epoch.
-func (s *MirrorStore) SaveReconcileWatermark(ctx context.Context, objectClass string, watermark time.Time) error {
-	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
-		if _, err := tx.Exec(ctx, upsertReconcileWatermarkSQL, objectClass, watermark); err != nil {
-			return fmt.Errorf("overlay: checkpointing the %s reconcile watermark: %w", objectClass, err)
-		}
-		return nil
-	})
-}
-
-// LoadReconcileWatermark reads back objectClass's persisted incremental
-// watermark. No row yet (a sweep that has never run) answers the zero
-// time — an honest "not started", not an error; Reconcile's own caller
-// (jobs.go's worker) treats that as "sweep from the epoch."
-func (s *MirrorStore) LoadReconcileWatermark(ctx context.Context, objectClass string) (time.Time, error) {
-	var watermark time.Time
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
-		scanErr := tx.QueryRow(
-			ctx,
-			`SELECT watermark FROM overlay_reconcile_watermark WHERE object_class = $1`,
-			objectClass,
-		).Scan(&watermark)
-		if errors.Is(scanErr, pgx.ErrNoRows) {
-			watermark = time.Time{}
-			return nil
-		}
-		return scanErr
-	})
-	if err != nil {
-		return time.Time{}, fmt.Errorf("overlay: loading the %s reconcile watermark: %w", objectClass, err)
-	}
-	return watermark, nil
 }
 
 // encodeMirrorCursor/decodeMirrorCursor keep the List cursor opaque to

--- a/backend/internal/modules/overlay/syncbackoff.go
+++ b/backend/internal/modules/overlay/syncbackoff.go
@@ -85,6 +85,11 @@ func sweepBackoffDelay(consecutiveFailures int) time.Duration {
 // sweep heals a backed-off connection.
 func (s *MirrorStore) RecordSweepSuccess(ctx context.Context, now time.Time) error {
 	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+		if s.fenced {
+			if err := assertActiveConnection(ctx, tx); err != nil {
+				return err
+			}
+		}
 		_, err := tx.Exec(ctx, `
 			INSERT INTO overlay_sync_state (workspace_id, next_sweep_at, consecutive_failures, last_success_at, last_error_class, updated_at)
 			VALUES (NULLIF(current_setting('app.workspace_id',true),'')::uuid, $1, 0, $1, NULL, now())
@@ -107,6 +112,11 @@ func (s *MirrorStore) RecordSweepSuccess(ctx context.Context, now time.Time) err
 func (s *MirrorStore) RecordSweepFailure(ctx context.Context, sweepErr error, now time.Time) error {
 	class := classifySweepError(sweepErr)
 	return database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+		if s.fenced {
+			if err := assertActiveConnection(ctx, tx); err != nil {
+				return err
+			}
+		}
 		var failures int
 		if err := tx.QueryRow(ctx, `
 			INSERT INTO overlay_sync_state (workspace_id, next_sweep_at, consecutive_failures, last_error_class, last_failure_at, updated_at)

--- a/backend/internal/modules/overlay/teardown_integration_test.go
+++ b/backend/internal/modules/overlay/teardown_integration_test.go
@@ -236,6 +236,82 @@ func TestDisconnectPurgesTheMirrorTombstonesAndRetainsTheConnectionAudit(t *test
 	}
 }
 
+// TestFencedSyncWritesAbortOnceTheConnectionIsRevoked proves the
+// disconnect-race fence: a MirrorStore bound WithFence (the sweep's store)
+// serializes every sync write against Disconnect on the incumbent_connection
+// row, so once that connection is revoked+purged a stray in-flight sweep
+// write aborts with ErrConnectionGone and resurrects nothing. It closes the
+// backfill.go re-population race (PR #91 review) for the tables the mirror
+// tombstone cannot cover — associations, the backfill cursor, the reconcile
+// watermark, the owner-identity map are not record-keyed — AND for a
+// brand-new mirror row that never had a tombstone at all.
+func TestFencedSyncWritesAbortOnceTheConnectionIsRevoked(t *testing.T) {
+	ctx, pool, ws := testWorkspaceCtx(t)
+	vault := keyvault.NewMemory()
+	store := NewMirrorStore(pool, noOwnerEmails{})
+	svc := NewService(pool, vault, store)
+	if _, err := svc.Connect(ctx, ConnectInput{Incumbent: "hubspot", Region: "eu1", Token: "pat-fence-secret"}); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	fenced := store.WithFence()
+
+	// While the connection is active the fence is transparent: a fenced write
+	// behaves exactly as an unfenced one, so the sweep's normal operation is
+	// unaffected.
+	if err := fenced.SaveBackfillCursor(ctx, "contacts", "cur-live", false); err != nil {
+		t.Fatalf("fenced write on a live connection = %v, want success", err)
+	}
+
+	if err := svc.Disconnect(ctx); err != nil {
+		t.Fatalf("Disconnect: %v", err)
+	}
+
+	actor, ok := principal.Actor(ctx)
+	if !ok {
+		t.Fatal("testWorkspaceCtx did not bind an actor")
+	}
+	// Every fenced sync write now aborts with ErrConnectionGone — the
+	// connection row is revoked, so the FOR SHARE fence finds no active row.
+	// "person/new" was NEVER in the mirror, so no tombstone guards it: only
+	// the fence stops Ingest from landing a fresh incumbent-derived row into
+	// the now-native workspace.
+	fencedWrites := map[string]func() error{
+		"Ingest": func() error {
+			return fenced.Ingest(ctx, Record{ObjectClass: "person", ExternalID: "new", Fields: map[string]any{"firstname": "Nope"}, ModifiedAt: time.Date(2026, 7, 5, 0, 0, 0, 0, time.UTC)})
+		},
+		"UpsertAssoc": func() error {
+			return fenced.UpsertAssoc(ctx, Assoc{FromType: "person", FromID: "new", ToType: "deal", ToID: "1", TypeID: 1, Category: "HUBSPOT_DEFINED", Direction: "forward"})
+		},
+		"SaveBackfillCursor": func() error { return fenced.SaveBackfillCursor(ctx, "contacts", "cur-stray", true) },
+		"SaveReconcileWatermark": func() error {
+			return fenced.SaveReconcileWatermark(ctx, "contacts", time.Date(2026, 7, 6, 0, 0, 0, 0, time.UTC))
+		},
+		"UpsertUserMap": func() error {
+			return fenced.UpsertUserMap(ctx, ids.From[ids.UserKind](actor.UserID), "hubspot", "owner-stray", "manual")
+		},
+	}
+	for name, w := range fencedWrites {
+		if err := w(); !errors.Is(err, ErrConnectionGone) {
+			t.Errorf("fenced %s after disconnect = %v, want ErrConnectionGone", name, err)
+		}
+	}
+
+	// Nothing landed: every incumbent-derived table Disconnect purged is
+	// still empty for the workspace — the fenced writes added nothing back.
+	for _, tbl := range []string{
+		"overlay_mirror", "overlay_association", "overlay_backfill_cursor",
+		"overlay_reconcile_watermark", "mirror_user_map",
+	} {
+		var n int
+		queryRowWS(ctx, t, pool,
+			fmt.Sprintf(`SELECT count(*) FROM %s WHERE workspace_id = $1`, pgx.Identifier{tbl}.Sanitize()),
+			[]any{ws}, &n)
+		if n != 0 {
+			t.Errorf("%s holds %d row(s) after fenced writes on a disconnected workspace, want 0 — the fence must resurrect nothing", tbl, n)
+		}
+	}
+}
+
 func TestDisconnectWithNoActiveConnectionAnswersNotFound(t *testing.T) {
 	ctx, pool, _ := testWorkspaceCtx(t)
 	vault := keyvault.NewMemory()

--- a/backend/internal/modules/overlay/teardown_integration_test.go
+++ b/backend/internal/modules/overlay/teardown_integration_test.go
@@ -289,6 +289,15 @@ func TestFencedSyncWritesAbortOnceTheConnectionIsRevoked(t *testing.T) {
 		"UpsertUserMap": func() error {
 			return fenced.UpsertUserMap(ctx, ids.From[ids.UserKind](actor.UserID), "hubspot", "owner-stray", "manual")
 		},
+		// The sweep outcome recording (overlay_sync_state) is fenced too:
+		// teardown purges that row, so recording a backoff or success after a
+		// disconnect would resurrect it.
+		"RecordSweepSuccess": func() error {
+			return fenced.RecordSweepSuccess(ctx, time.Date(2026, 7, 7, 0, 0, 0, 0, time.UTC))
+		},
+		"RecordSweepFailure": func() error {
+			return fenced.RecordSweepFailure(ctx, errors.New("boom"), time.Date(2026, 7, 7, 0, 0, 0, 0, time.UTC))
+		},
 	}
 	for name, w := range fencedWrites {
 		if err := w(); !errors.Is(err, ErrConnectionGone) {
@@ -300,7 +309,7 @@ func TestFencedSyncWritesAbortOnceTheConnectionIsRevoked(t *testing.T) {
 	// still empty for the workspace — the fenced writes added nothing back.
 	for _, tbl := range []string{
 		"overlay_mirror", "overlay_association", "overlay_backfill_cursor",
-		"overlay_reconcile_watermark", "mirror_user_map",
+		"overlay_reconcile_watermark", "mirror_user_map", "overlay_sync_state",
 	} {
 		var n int
 		queryRowWS(ctx, t, pool,

--- a/backend/internal/modules/overlay/usermapseed.go
+++ b/backend/internal/modules/overlay/usermapseed.go
@@ -101,6 +101,14 @@ func (s *MirrorStore) SeedUserMap(ctx context.Context, incumbent string, owners 
 		for _, appUser := range users {
 			if err := s.UpsertUserMap(ctx, appUser, incumbent, owner.ExternalID, "email"); err != nil {
 				errs = append(errs, fmt.Errorf("overlay: seeding %s to owner %s: %w", appUser, owner.ExternalID, err))
+				if errors.Is(err, ErrConnectionGone) {
+					// The workspace was disconnected mid-seed (fenced store): every
+					// remaining UpsertUserMap would abort the same way after
+					// spending another incumbent email resolution and DB tx. Stop
+					// now and surface the signal for the sweep to treat as a clean
+					// stop.
+					return errors.Join(errs...)
+				}
 			}
 		}
 	}

--- a/backend/internal/modules/overlay/visibility.go
+++ b/backend/internal/modules/overlay/visibility.go
@@ -300,6 +300,16 @@ func (s *MirrorStore) UpsertUserMap(ctx context.Context, appUser ids.UserID, inc
 			}
 		}
 
+		// The disconnect-race fence, taken only for the sweep's store
+		// (WithFence) — after the email resolution above so a slow incumbent
+		// lookup is never held under a lock, before the write below so a
+		// mapping is never resurrected into a disconnected workspace.
+		if s.fenced {
+			if err := assertActiveConnection(ctx, tx); err != nil {
+				return err
+			}
+		}
+
 		// Serialize the read-decide-upsert-recompute sequence against every
 		// other visibility mutation in this workspace (a sibling remap, an
 		// Ingest owner reassignment, the ambiguity revoke). Acquiring the


### PR DESCRIPTION
## What

Closes the disconnect-race resurrection hole from PR #91's review (threads on `backfill.go` re-populating a purged workspace). A reconcile sweep that commits **after** `Disconnect` purges a workspace could resurrect incumbent-derived data into a now-native workspace.

The mirror tombstone already guards `overlay_mirror` re-ingest, but it is record-keyed and does **not** cover:
- `overlay_association` (edges)
- `overlay_backfill_cursor` / `overlay_reconcile_watermark` (sync positions — a resurrected checkpoint makes a later connection resume mid-stream)
- `mirror_user_map` (owner identity)
- a **brand-new** mirror row that never had a tombstone

## How

An opt-in **disconnect-race fence**: `MirrorStore.WithFence()` engages a `FOR SHARE` assert on the workspace's active `incumbent_connection` row at the start of every resurrection-risk write (`Ingest`, `UpsertAssoc`, `SaveBackfillCursor`, `SaveReconcileWatermark`, `UpsertUserMap`). `Disconnect` takes that same row `FOR UPDATE` and purges + flips to native in one tx, so a fenced write either:
- commits **before** the disconnect (and is then purged by the waiting disconnect), or
- runs **after** it commits, finds no active row, and returns `ErrConnectionGone`.

The GUC is read without `missing_ok`, matching `lockWorkspaceVisibility`'s fail-closed posture.

The sweep binds the fenced store (`WithResolver(inc).WithFence()`); `reconcileConnection` and its callees treat `ErrConnectionGone` as a **clean stop**, and the worker skips the workspace without recording a backoff (a revoked connection is already gone from the next due-scan). `RevalidateEmailMappings` / `revokeEmailMappingsForOwners` only delete/clear — they can't resurrect — so they stay unfenced.

The fence is **opt-in** precisely so the read path and the many unit tests that ingest without a connection are not forced to hold one.

Split the sync-position checkpoints into `mirrorcheckpoints.go`, keeping `mirrorstore.go` under the 500-LOC cap.

## Tests
- `TestFencedSyncWritesAbortOnceTheConnectionIsRevoked` (overlay) — every fenced write aborts with `ErrConnectionGone` post-disconnect and lands nothing; verified it genuinely fails without the fence (all 5 tables resurrect, incl. the tombstone-less new row).
- `TestReconcileConnectionStopsCleanlyWhenDisconnectedMidSweep` (compose) — the clean-stop propagates through the sweep orchestration end to end.
- Full `make check-backend` + overlay/compose integration lanes green.

## Deferred (A5b)
The post-commit vault-credential delete in `teardown.go` is not retryable across a `Disconnect` retry — an **inert** orphaned sealed blob (branch-1 has no reconnect path). It needs its own durable-cleanup design, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fences all `overlay` sync writes (including sweep outcome recording) to prevent resurrecting data when a workspace disconnects mid-sweep, and treats a revoked connection as a clean stop with no backoff. Adds `overlay.ErrConnectionGone`; on-demand reconcile maps it to `apperrors.ErrModeNotOverlay`.

- **Bug Fixes**
  - Added `overlay.MirrorStore.WithFence()` to assert an active `incumbent_connection` (`FOR SHARE`); `Disconnect` holds `FOR UPDATE` and purges in the same transaction.
  - Fenced writes: `Ingest`, `UpsertAssoc`, `SaveBackfillCursor`, `SaveReconcileWatermark`, `UpsertUserMap`, `RecordSweepFailure`, `RecordSweepSuccess`. They either land before disconnect and are purged, or return `overlay.ErrConnectionGone`.
  - The sweep binds `ms.WithResolver(inc).WithFence()`; the worker records outcomes through a fenced store and treats `overlay.ErrConnectionGone` as a clean stop (skip workspace, no backoff). On-demand reconcile collapses this to `apperrors.ErrModeNotOverlay`.
  - `SeedUserMap` short-circuits on `overlay.ErrConnectionGone`. `RevalidateEmailMappings` stays unfenced (clear-only). The workspace GUC is read without `missing_ok` to fail closed.

- **Refactors**
  - Moved checkpoint logic to `mirrorcheckpoints.go` to keep `mirrorstore.go` smaller.

<sup>Written for commit 1c74c1dd2f8c62f279028c26242020ba608ff254. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

