### PR TITLE
Harden website ingestion and redesign onboarding

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -22,6 +22,37 @@ The merge gate (`make check`), the real-Postgres integration lane
 
 ## Recently landed
 
+**Website-ingestion quality and the Core research stage.** The onboarding
+read was benchmarked against Stripe, Notion, Linear, Personio, DeepL, Celonis,
+Contentful, Forto, GetYourGuide, and Miro, then tuned against the same corpus.
+The systemic failure was page selection: any URL containing `legal` became an
+imprint, policy libraries consumed most of the 40-page budget, and the one-shot
+company profile fired after twelve pages even when all twelve were legal. Legal
+identity paths are now narrow and path-shaped, the crawler probes publisher and
+regional legal routes plus one bounded policy fallback, guide/template slugs no
+longer masquerade as Team/Product pages, the profile waits for commercial
+evidence and takes a kind-diverse corpus, and home/about pages can state
+offerings and markets. The legal census folds punctuation-only company variants
+and bare brand aliases; it carries a legal block across one safe passage
+boundary and reuses already-gated single-entity address/register fields. Focused
+live proofs recovered the full name/address/register blocks for Celonis SE,
+Contentful GmbH, and Forto SE; Linear's policy-only contracting entity is
+recovered without inventing an absent address. Personio consistently returns
+HTTP 429 to the root and legal notice, so that site remains an honest failure;
+Notion's commercial profile is strong but its unlinked, unique-slug German
+imprint remains undiscoverable without a search-engine dependency.
+
+The run also found and fixed the apparent forever-reading failure: a commit
+could discover new links in the same wave that hit the byte/deadline cap, then
+the skip reporter indexed the new queue with the old selection bitmap. The
+boundary is regression-tested, and the worker ownership boundary now closes a
+dossier as failed on any future unexpected panic instead of leaving a zombie.
+The onboarding Core is a vertically centred research stage with a live progress
+halo, legal → offer → customer track, grounded counters, ambient field, and
+first-person English/German copy. Browser passes covered intro, URL entry, live
+progress and completed evidence; `make check` and the 18-package real-Postgres
+lane pass with zero skips.
+
 **Cold-start dev stack, the machine sweep, and the legal-entity census
 (#151, #156).** Three things that were wrong together.
 

--- a/backend/internal/compose/deepread.go
+++ b/backend/internal/compose/deepread.go
@@ -188,6 +188,7 @@ func (w *siteDeepReadWorker) run(ctx context.Context, args SiteDeepReadArgs) err
 		return deferErr
 	}
 	mergedFields, legalConflict, legalDrops := applyLegalGate(extraction.fields, extraction.merged.entities, pageKindsOf(crawl.Pages), extraction.legalCensusIncomplete)
+	extraction.merged.entities = enrichLegalEntitiesFromProfile(extraction.merged.entities, mergedFields)
 	w.extract.reportDrops(ctx, laneLegal, legalDrops)
 	if legalConflict {
 		w.log.WarnContext(ctx, legalWarningMultipleEntities,

--- a/backend/internal/compose/deepreadbudget.go
+++ b/backend/internal/compose/deepreadbudget.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime/debug"
 	"time"
 
 	"github.com/riverqueue/river"
@@ -15,8 +16,23 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
-func (w *siteDeepReadWorker) Work(ctx context.Context, job *river.Job[SiteDeepReadArgs]) error {
-	err := w.run(ctx, job.Args)
+func (w *siteDeepReadWorker) Work(ctx context.Context, job *river.Job[SiteDeepReadArgs]) (workErr error) {
+	// River recovers a worker panic, but it cannot close this module's
+	// claimed dossier. Recover at the ownership boundary so an unexpected
+	// provider/parser panic becomes a terminal failed read instead of a row
+	// that tells the browser "reading" forever.
+	workCtx := deepReadWorkerCtx(ctx, job.Args)
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			cause := fmt.Errorf("site deep read panic: %v", recovered)
+			if w.log != nil {
+				w.log.ErrorContext(workCtx, "site deep read panic recovered",
+					"read", job.Args.SiteReadID.String(), "panic", recovered, "stack", string(debug.Stack()))
+			}
+			workErr = w.fail(workCtx, job.Args.SiteReadID, cause)
+		}
+	}()
+	err := w.run(workCtx, job.Args)
 	var deferral *ai.BudgetDeferralError
 	if !errors.As(err, &deferral) {
 		return err

--- a/backend/internal/compose/sitecorpuslegal.go
+++ b/backend/internal/compose/sitecorpuslegal.go
@@ -11,6 +11,7 @@ package compose
 import (
 	"net/url"
 	"strings"
+	"unicode"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 )
@@ -52,7 +53,7 @@ func dedupeLegalEntities(entities []corpusLegalEntity) []corpusLegalEntity {
 			out[at] = entity
 		}
 	}
-	return out
+	return removeBrandOnlyLegalAliases(out)
 }
 
 // matchingLegalEntity joins locale variants without collapsing genuinely
@@ -61,10 +62,10 @@ func dedupeLegalEntities(entities []corpusLegalEntity) []corpusLegalEntity {
 // When both sightings carry different register numbers, the registry
 // identities win and the entities remain separate even if their names match.
 func matchingLegalEntity(existing []corpusLegalEntity, candidate corpusLegalEntity) int {
-	candidateName := normalizeEvidence(candidate.Name)
+	candidateName := legalEntityNameKey(candidate.Name)
 	candidateRegister := normalizeEvidence(candidate.RegisterNumber)
 	for i, entity := range existing {
-		name := normalizeEvidence(entity.Name)
+		name := legalEntityNameKey(entity.Name)
 		register := normalizeEvidence(entity.RegisterNumber)
 		sameRegister := candidateRegister != "" && register != "" && candidateRegister == register
 		compatibleName := candidateName != "" && candidateName == name &&
@@ -74,6 +75,73 @@ func matchingLegalEntity(existing []corpusLegalEntity, candidate corpusLegalEnti
 		}
 	}
 	return -1
+}
+
+// legalEntityNameKey treats punctuation-only legal-form variants as the
+// same printed company: "B.V." and "BV", or a comma before "Inc.", do
+// not create separate entities. Letters and digits remain authoritative;
+// distinct registry numbers still prevent a fold in matchingLegalEntity.
+func legalEntityNameKey(name string) string {
+	return strings.Join(strings.FieldsFunc(strings.ToLower(name), func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+	}), " ")
+}
+
+// removeBrandOnlyLegalAliases drops a bare brand label only when the same
+// census also contains a richer registered name that includes that label
+// and the bare row has no legal detail. This preserves sole traders and
+// unusual legal names when they are the only identity the page states.
+func removeBrandOnlyLegalAliases(entities []corpusLegalEntity) []corpusLegalEntity {
+	kept := make([]corpusLegalEntity, 0, len(entities))
+	for i, candidate := range entities {
+		key := legalEntityNameKey(candidate.Name)
+		dropAlias := false
+		if legalEntityDetail(candidate) == 0 && len(strings.Fields(key)) == 1 {
+			for j, richer := range entities {
+				if i == j || legalEntityNameKey(richer.Name) == key {
+					continue
+				}
+				for _, token := range strings.Fields(legalEntityNameKey(richer.Name)) {
+					if token == key {
+						dropAlias = true
+						break
+					}
+				}
+				if dropAlias {
+					break
+				}
+			}
+		}
+		if !dropAlias {
+			kept = append(kept, candidate)
+		}
+	}
+	return kept
+}
+
+// enrichLegalEntitiesFromProfile shares already-gated legal trio values
+// with the single legal choice shown to the human. Both lanes cite shallow
+// legal pages and the census has established that there is only one entity;
+// this avoids asking the user to retype a VAT number one lane recovered when
+// the entity lane's 300-rune block ended between the address and identifier.
+func enrichLegalEntitiesFromProfile(entities []corpusLegalEntity, fields []evidencedField) []corpusLegalEntity {
+	if len(entities) != 1 {
+		return entities
+	}
+	out := append([]corpusLegalEntity(nil), entities...)
+	for _, field := range fields {
+		switch field.Field {
+		case string(crmcontracts.ColdStartFieldFieldRegisteredAddress):
+			if out[0].RegisteredAddress == "" {
+				out[0].RegisteredAddress = field.Value
+			}
+		case string(crmcontracts.ColdStartFieldFieldRegisterVat):
+			if out[0].RegisterNumber == "" {
+				out[0].RegisterNumber = field.Value
+			}
+		}
+	}
+	return out
 }
 
 // legalEntityDetail counts how much of an entity block was actually
@@ -100,7 +168,7 @@ const legalWarningMultipleEntities = "disagreeing legal pages: the domain hosts 
 func applyLegalGate(fields []evidencedField, entities []corpusLegalEntity, pageKind map[string]crmcontracts.SiteReadPageKind, censusIncomplete bool) ([]evidencedField, bool, []droppedFinding) {
 	distinct := map[string]bool{}
 	for _, e := range entities {
-		distinct[normalizeEvidence(e.Name)] = true
+		distinct[legalEntityNameKey(e.Name)] = true
 	}
 	var dropped []droppedFinding
 	if censusIncomplete || len(distinct) > 1 {

--- a/backend/internal/compose/sitecorpuslegal_test.go
+++ b/backend/internal/compose/sitecorpuslegal_test.go
@@ -47,6 +47,48 @@ func TestDedupeLegalEntitiesKeepsSameNameWithDistinctRegisters(t *testing.T) {
 	}
 }
 
+func TestDedupeLegalEntitiesFoldsPunctuationVariantsAndDropsBareBrand(t *testing.T) {
+	entities := []corpusLegalEntity{
+		{Name: "RealtimeBoard, Inc. dba Miro", RegisteredAddress: "San Francisco", SourceURL: seedURL + "/legal"},
+		{Name: "RealtimeBoard Inc dba Miro", SourceURL: seedURL + "/imprint"},
+		{Name: "RealtimeBoard B.V.", RegisterNumber: "123", SourceURL: seedURL + "/legal"},
+		{Name: "RealtimeBoard BV", RegisterNumber: "123", SourceURL: seedURL + "/imprint"},
+		{Name: "Miro", SourceURL: seedURL + "/legal"},
+	}
+	got := dedupeLegalEntities(entities)
+	if len(got) != 2 {
+		t.Fatalf("punctuation variants and a bare brand must not become legal choices: %+v", got)
+	}
+	if got[0].RegisteredAddress != "San Francisco" || got[1].RegisterNumber != "123" {
+		t.Fatalf("the richest registered sightings must survive: %+v", got)
+	}
+}
+
+func TestDedupeLegalEntitiesKeepsTheOnlyBareLegalName(t *testing.T) {
+	got := dedupeLegalEntities([]corpusLegalEntity{{Name: "Miro", SourceURL: seedURL + "/legal"}})
+	if len(got) != 1 {
+		t.Fatalf("an unusual legal name must survive when no richer registered alias exists: %+v", got)
+	}
+}
+
+func TestEnrichSingleLegalEntityFromGatedProfile(t *testing.T) {
+	entities := []corpusLegalEntity{{Name: "Acme GmbH", SourceURL: seedURL + "/imprint"}}
+	fields := []evidencedField{
+		{Field: "registered_address", Value: "Deliusstrasse 7, 24114 Kiel"},
+		{Field: "register_vat", Value: "HRB 123456"},
+	}
+	got := enrichLegalEntitiesFromProfile(entities, fields)
+	if got[0].RegisteredAddress == "" || got[0].RegisterNumber != "HRB 123456" {
+		t.Fatalf("the single legal choice must reuse the already-gated trio: %+v", got)
+	}
+	if entities[0].RegisteredAddress != "" {
+		t.Fatal("enrichment must not mutate the source slice")
+	}
+	if many := enrichLegalEntitiesFromProfile(append(entities, corpusLegalEntity{Name: "Acme Inc."}), fields); many[0].RegisterNumber != "" {
+		t.Fatal("profile values must never be assigned across a multi-entity census")
+	}
+}
+
 // Without a register number there is nothing authoritative to fold on, so
 // the name is the identity — two genuinely different names stay two.
 func TestDedupeLegalEntitiesFallsBackToTheNameWithoutARegisterNumber(t *testing.T) {

--- a/backend/internal/compose/sitecrawl.go
+++ b/backend/internal/compose/sitecrawl.go
@@ -142,6 +142,17 @@ var wellKnownProbes = []struct {
 	{"/imprint", crmcontracts.SiteReadPageKindImpressum},
 	{"/de/impressum", crmcontracts.SiteReadPageKindImpressum},
 	{"/legal-notice", crmcontracts.SiteReadPageKindImpressum},
+	{"/de/publisher", crmcontracts.SiteReadPageKindImpressum},
+	{"/publisher", crmcontracts.SiteReadPageKindImpressum},
+	{"/de/legal", crmcontracts.SiteReadPageKindImpressum},
+	{"/c/legal", crmcontracts.SiteReadPageKindImpressum},
+	{"/legal", crmcontracts.SiteReadPageKindImpressum},
+	// Some sites publish no identity page; one policy document is the
+	// bounded fallback because its publisher block still identifies the
+	// contracting entity. Probe one only — never crawl the whole library.
+	{"/legal/terms", crmcontracts.SiteReadPageKindImpressum},
+	{"/legal/terms-of-service", crmcontracts.SiteReadPageKindImpressum},
+	{"/legal/aup", crmcontracts.SiteReadPageKindImpressum},
 	{"/about", crmcontracts.SiteReadPageKindAbout},
 	{"/ueber-uns", crmcontracts.SiteReadPageKindAbout},
 	{"/team", crmcontracts.SiteReadPageKindTeam},
@@ -274,7 +285,10 @@ func selectWave(queue []crawlCandidate, priority []int, taken []bool, waveMax in
 func untakenCandidates(queue []crawlCandidate, taken []bool) []crawlCandidate {
 	var rest []crawlCandidate
 	for i, cand := range queue {
-		if !taken[i] {
+		// A commit can discover new links and hit the byte/deadline cap in
+		// the same wave. Those links have joined queue but the next loop-head
+		// has not extended taken yet; they are necessarily untaken.
+		if i >= len(taken) || !taken[i] {
 			rest = append(rest, cand)
 		}
 	}

--- a/backend/internal/compose/sitecrawlrank.go
+++ b/backend/internal/compose/sitecrawlrank.go
@@ -24,6 +24,7 @@ const (
 	priProbe       = 100
 	priBoilerplate = 1
 	priOther       = 10
+	companyWord    = "company"
 )
 
 var kindPriority = map[crmcontracts.SiteReadPageKind]int{
@@ -78,6 +79,41 @@ func candidatePriority(cand crawlCandidate) int {
 	// A deep page still outranks a blog archive: boilerplate is the only
 	// band below everything, and depth alone never demotes into it.
 	return priBoilerplate + 1
+}
+
+// legalIdentityPath recognizes pages that can plausibly state the
+// operator's registered identity. A broad "contains legal" rule turns a
+// product page such as /teams/legal into an imprint and lets whole policy
+// libraries consume the crawl and profile budgets. Keep this deliberately
+// path-shaped: named imprint/publisher pages, a shallow /legal landing, and
+// the two observed shallow site conventions that mount it one level down.
+func legalIdentityPath(rawURL string) bool {
+	parsed, err := url.Parse(localeCanonical(rawURL))
+	if err != nil {
+		return false
+	}
+	segments := pathSegments(parsed.Path)
+	if len(segments) == 0 {
+		return false
+	}
+	last := segments[len(segments)-1]
+	if containsAny(last, "impressum", "imprint") || last == "legal-notice" || last == "publisher" {
+		return true
+	}
+	if last != "legal" {
+		return false
+	}
+	return len(segments) == 1 || (len(segments) == 2 && (segments[0] == "c" || segments[0] == companyWord))
+}
+
+func pathSegments(path string) []string {
+	var out []string
+	for _, segment := range strings.Split(strings.ToLower(path), "/") {
+		if segment != "" {
+			out = append(out, segment)
+		}
+	}
+	return out
 }
 
 // localePrefixes are the path-leading language tags multilingual sites
@@ -175,19 +211,27 @@ func classifyKind(rawURL string) crmcontracts.SiteReadPageKind {
 	if err != nil {
 		return crmcontracts.SiteReadPageKindOther
 	}
-	path := strings.ToLower(parsed.Path)
+	segments := pathSegments(parsed.Path)
+	if len(segments) > 0 && localePrefixes[segments[0]] {
+		segments = segments[1:]
+	}
+	first := ""
+	if len(segments) > 0 {
+		first = segments[0]
+	}
+	shallow := len(segments) <= 2
 	switch {
-	case containsAny(path, "impressum", "imprint", "legal"):
+	case legalIdentityPath(rawURL):
 		return crmcontracts.SiteReadPageKindImpressum
-	case containsAny(path, "about", "ueber"):
+	case shallow && containsAny(first, "about", "ueber"):
 		return crmcontracts.SiteReadPageKindAbout
-	case strings.Contains(path, "team"):
+	case shallow && containsAny(first, "team", "leadership"):
 		return crmcontracts.SiteReadPageKindTeam
-	case containsAny(path, "kontakt", "contact"):
+	case shallow && containsAny(first, "kontakt", "contact"):
 		return crmcontracts.SiteReadPageKindContact
-	case containsAny(path, "service", "leistung", "solution", "loesung", "lösung"):
+	case containsAny(first, "service", "leistung", "solution", "loesung", "lösung"):
 		return crmcontracts.SiteReadPageKindServices
-	case containsAny(path, "produkt", "product"):
+	case containsAny(first, "produkt", "product"):
 		return crmcontracts.SiteReadPageKindProducts
 	default:
 		return crmcontracts.SiteReadPageKindOther

--- a/backend/internal/compose/sitecrawlrank_test.go
+++ b/backend/internal/compose/sitecrawlrank_test.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+import (
+	"strings"
+	"testing"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+)
+
+func TestClassifyKindSeparatesLegalIdentityFromLegalProductsAndPolicies(t *testing.T) {
+	for _, rawURL := range []string{
+		"https://example.com/imprint",
+		"https://example.com/de/publisher",
+		"https://example.com/de/legal",
+		"https://example.com/c/legal",
+		"https://example.com/legal/miro-imprint",
+	} {
+		if got := classifyKind(rawURL); got != crmcontracts.SiteReadPageKindImpressum {
+			t.Errorf("classifyKind(%q) = %q, want impressum", rawURL, got)
+		}
+	}
+	for _, rawURL := range []string{
+		"https://example.com/teams/legal",
+		"https://example.com/legal/privacy-at-example",
+		"https://example.com/legal/terms-of-service",
+	} {
+		if got := classifyKind(rawURL); got == crmcontracts.SiteReadPageKindImpressum {
+			t.Errorf("classifyKind(%q) = impressum; a product or policy page must not consume legal-identity budget", rawURL)
+		}
+	}
+}
+
+func TestClassifyKindDoesNotPromoteGuidesBecauseTheirSlugsMentionTeamsOrProducts(t *testing.T) {
+	for _, rawURL := range []string{
+		"https://example.com/guides/how-teams-use-comments",
+		"https://example.com/help/guides/building-a-product-requirement-document",
+		"https://example.com/product/ai/use-cases/chat-about-anything",
+	} {
+		got := classifyKind(rawURL)
+		if strings.Contains(rawURL, "/product/") {
+			if got != crmcontracts.SiteReadPageKindProducts {
+				t.Errorf("classifyKind(%q) = %q, want products from the leading path family", rawURL, got)
+			}
+			continue
+		}
+		if got != crmcontracts.SiteReadPageKindOther {
+			t.Errorf("classifyKind(%q) = %q, want other", rawURL, got)
+		}
+	}
+}
+
+func TestProfileEvidenceReadyRequiresCommercialPages(t *testing.T) {
+	pages := make([]crawlPage, profileTriggerNonLegalPages+12)
+	for i := range pages {
+		pages[i].Kind = crmcontracts.SiteReadPageKindImpressum
+	}
+	if profileEvidenceReady(pages) {
+		t.Fatal("legal pages alone must not fire the one-shot profile lane")
+	}
+	for i := 0; i < profileTriggerNonLegalPages; i++ {
+		pages[i].Kind = crmcontracts.SiteReadPageKindAbout
+	}
+	if !profileEvidenceReady(pages) {
+		t.Fatal("the commercial evidence threshold must fire the profile lane")
+	}
+}
+
+func TestUntakenCandidatesIncludesLinksDiscoveredByAStoppingCommit(t *testing.T) {
+	queue := []crawlCandidate{{url: seedURL + "/selected"}, {url: seedURL + "/discovered-at-cap"}}
+	got := untakenCandidates(queue, []bool{true})
+	if len(got) != 1 || got[0].url != seedURL+"/discovered-at-cap" {
+		t.Fatalf("new queue entries without a taken slot are untaken, got %+v", got)
+	}
+}

--- a/backend/internal/compose/siteextract.go
+++ b/backend/internal/compose/siteextract.go
@@ -48,11 +48,21 @@ type siteExtraction struct {
 	crawlMs int64
 }
 
-// profileTriggerPages is how many committed pages the profile lane
-// waits for before firing: commits arrive in selection order, so the
-// first dozen ARE the identity-dense excerpt set — waiting for the whole
-// crawl would put the crawl's slow tail on the profile's critical path.
-const profileTriggerPages = 12
+// profileTriggerNonLegalPages is how much commercial evidence the profile
+// lane waits for before firing. A raw page-count trigger can be satisfied
+// entirely by legal pages on policy-heavy sites, permanently producing a
+// legal-only profile because the lane intentionally runs once.
+const profileTriggerNonLegalPages = 8
+
+func profileEvidenceReady(pages []crawlPage) bool {
+	nonLegal := 0
+	for _, page := range pages {
+		if page.Kind != crmcontracts.SiteReadPageKindImpressum {
+			nonLegal++
+		}
+	}
+	return nonLegal >= profileTriggerNonLegalPages
+}
 
 // The read's two live phases, spelled as the site_read store accepts them
 // (people.Store.UpdateSiteReadProgress rejects anything else): the crawl
@@ -104,12 +114,13 @@ func crawlAndExtract(ctx context.Context, crawler *siteCrawler, x evidenceExtrac
 		committedMu.Lock()
 		committed = append(committed, page)
 		count := len(committed)
+		profileReady := profileEvidenceReady(committed)
 		committedMu.Unlock()
 		// Report the page the moment it commits, not when its extraction
 		// returns: "pages read" is a count of pages fetched, and the hook
 		// runs serially in commit order, so the number only ever climbs.
 		progress(sitePhaseCrawling, count)
-		if count >= profileTriggerPages {
+		if profileReady {
 			fireProfile()
 		}
 		wg.Add(1)

--- a/backend/internal/compose/siteextract_test.go
+++ b/backend/internal/compose/siteextract_test.go
@@ -197,7 +197,7 @@ func streamFixtureSite(n int) *fakeSite {
 // on a small one — and the merge is commit-ordered regardless of
 // completion scheduling.
 func TestCrawlAndExtractStreamsDeterministicallyAndFiresProfileOnce(t *testing.T) {
-	for _, pages := range []int{profileTriggerPages + 4, 3} {
+	for _, pages := range []int{profileTriggerNonLegalPages + 4, 3} {
 		site := streamFixtureSite(pages)
 		var profileCalls atomic.Int32
 		brain := countingLaneFake{

--- a/backend/internal/compose/sitepageentities.go
+++ b/backend/internal/compose/sitepageentities.go
@@ -10,6 +10,7 @@ package compose
 // kind does, and its rules are about attribution rather than evidence.
 
 import (
+	"fmt"
 	"slices"
 	"strings"
 	"unicode"
@@ -48,9 +49,9 @@ func gatePageEntities(parsed pageFactsReply, page crawlPage, idx snippetIndex, d
 			// across passages), but a DETAIL must come from the entity's own
 			// block or it belongs to a sibling company.
 			blockNorm := ""
-			if ref, ok := idx.resolve(e.E); ok {
-				entity.EvidenceSnippet = ref.passage
-				blockNorm = ref.norm
+			if block, ok := legalEvidenceBlock(idx, e.E, name); ok {
+				entity.EvidenceSnippet = block
+				blockNorm = normalizeEvidence(block)
 			}
 			// The block's details carry the same no-guess rule as the name:
 			// printed on this page, or absent. A dropped detail costs one
@@ -72,6 +73,51 @@ func gatePageEntities(parsed pageFactsReply, page crawlPage, idx snippetIndex, d
 		}
 	}
 	return out
+}
+
+// legalEvidenceBlock forgives a passage boundary inside one entity's legal
+// block. Addresses and registry lines commonly follow the company name in
+// the next 300-rune passage. Adjacent text joins only while it does not look
+// like a different registered company, preserving the sibling-entity gate.
+func legalEvidenceBlock(idx snippetIndex, id, currentName string) (string, bool) {
+	ref, ok := idx.resolve(id)
+	if !ok {
+		return "", false
+	}
+	var n int
+	if _, err := fmt.Sscanf(id, "s%d", &n); err != nil {
+		return ref.passage, true
+	}
+	parts := []string{ref.passage}
+	for _, adjacent := range []int{n - 1, n + 1} {
+		if adjacent < 0 || adjacent >= len(idx.refs) || idx.refs[adjacent].pageURL != ref.pageURL {
+			continue
+		}
+		if looksLikeDifferentLegalEntity(idx.refs[adjacent].norm, currentName) {
+			continue
+		}
+		if adjacent < n {
+			parts = append([]string{idx.refs[adjacent].passage}, parts...)
+		} else {
+			parts = append(parts, idx.refs[adjacent].passage)
+		}
+	}
+	return strings.Join(parts, " "), true
+}
+
+func looksLikeDifferentLegalEntity(passageNorm, currentName string) bool {
+	if strings.Contains(passageNorm, normalizeEvidence(currentName)) {
+		return false
+	}
+	for _, form := range []string{
+		" gmbh", " ag ", " se ", " inc ", " llc", " ltd", " limited", " bv ", " b v ",
+		" pte ", " plc", " sarl", " s a r l", " sas ", " oy ", " ab ", " sp z o o",
+	} {
+		if strings.Contains(" "+passageNorm+" ", form) {
+			return true
+		}
+	}
+	return false
 }
 
 // groundedDetail keeps a claimed value only when the text it is judged

--- a/backend/internal/compose/sitepagefacts.go
+++ b/backend/internal/compose/sitepagefacts.go
@@ -40,21 +40,30 @@ type pageMenu struct {
 // makes NO call (boilerplate and unclassified pages state few facts and
 // their calls would dominate cost, not quality).
 func menuForKind(kind crmcontracts.SiteReadPageKind) (pageMenu, bool) {
-	company := people.OrganizationFactFields["company"]
+	company := people.OrganizationFactFields[companyWord]
+	offeringAndMarket := factFields("offering", "market")
 	switch kind {
 	case crmcontracts.SiteReadPageKindImpressum:
 		return pageMenu{factFields: company, entities: true}, true
 	case crmcontracts.SiteReadPageKindContact:
 		return pageMenu{factFields: company}, true
 	case crmcontracts.SiteReadPageKindServices, crmcontracts.SiteReadPageKindProducts:
-		return pageMenu{factFields: append(append([]string{}, people.OrganizationFactFields["offering"]...), "technology")}, true
+		return pageMenu{factFields: append(offeringAndMarket, people.FactTechnology)}, true
 	case crmcontracts.SiteReadPageKindHome, crmcontracts.SiteReadPageKindAbout:
-		return pageMenu{factFields: append(append([]string{}, people.OrganizationFactFields["signal"]...), "location"), people: true}, true
+		return pageMenu{factFields: append(factFields("offering", "market", "signal"), people.FactLocation), people: true}, true
 	case crmcontracts.SiteReadPageKindTeam:
 		return pageMenu{people: true}, true
 	default:
 		return pageMenu{}, false
 	}
+}
+
+func factFields(categories ...string) []string {
+	var out []string
+	for _, category := range categories {
+		out = append(out, people.OrganizationFactFields[category]...)
+	}
+	return out
 }
 
 // factCategoryByField inverts the closed vocabulary: fact field names
@@ -98,6 +107,7 @@ func pageFactsSystem(menu pageMenu) string {
 	if menu.entities {
 		b.WriteString("entities — EVERY distinct legal entity this legal page names: {\"n\":entity name,\"a\":registered address,\"r\":registration/VAT/tax number,\"e\":passage id}. " +
 			"A legal notice states each entity as a block: give the address and the registration number printed WITH that entity's name, copied exactly as printed. " +
+			"For r copy ONE complete legal identifier exactly as printed, preferring a commercial-register number over a VAT/tax number; never combine several identifiers. " +
 			"a and r are ALWAYS present in your answer — use an empty string when the page states none for that entity, and never carry one entity's detail onto another. " +
 			"A market, office or brand label (\"Acme Singapore\", \"DACH\") is NOT an entity: the entity is the registered company name printed under that label (\"Acme Pte. Ltd.\"). List every entity.\n")
 	}
@@ -112,7 +122,7 @@ func menuGuidance(fields []string) string {
 		present[f] = true
 	}
 	var parts []string
-	for _, category := range []string{"company", "offering", "signal"} {
+	for _, category := range []string{companyWord, "offering", "signal"} {
 		for _, f := range people.OrganizationFactFields[category] {
 			if present[f] {
 				parts = append(parts, categoryGuidance[category])

--- a/backend/internal/compose/sitepagefacts_test.go
+++ b/backend/internal/compose/sitepagefacts_test.go
@@ -9,6 +9,7 @@ package compose
 // pages, and every refusal recorded with its reason.
 
 import (
+	"slices"
 	"strings"
 	"testing"
 
@@ -67,6 +68,15 @@ func TestMenuForKindRoutesFactBearingKindsOnly(t *testing.T) {
 	}
 	if !found {
 		t.Fatal("catalog pages must be allowed to name technologies")
+	}
+	for _, expected := range []string{people.FactService, people.FactProduct, people.FactServedIndustry} {
+		if !slices.Contains(menu.factFields, expected) {
+			t.Fatalf("catalog menu must include %q: %+v", expected, menu.factFields)
+		}
+	}
+	home, ok := menuForKind(crmcontracts.SiteReadPageKindHome)
+	if !ok || !slices.Contains(home.factFields, people.FactProduct) || !slices.Contains(home.factFields, people.FactCompanySize) {
+		t.Fatalf("home pages must capture headline offers and markets: %+v", home)
 	}
 }
 
@@ -322,5 +332,19 @@ func TestGatePageEntitiesRefusesASiblingBlocksAddress(t *testing.T) {
 	}
 	if dropReasons(dropped)[fieldRegisteredAddress] != dropValueNotInSnippet {
 		t.Errorf("the cross-block grab must be reported: %+v", dropped)
+	}
+}
+
+func TestGatePageEntitiesJoinsALegalBlockContinuation(t *testing.T) {
+	first := "Acme GmbH, Deliusstrasse 7, 24114 Kiel, Germany. " + strings.Repeat("Represented by management. ", 9)
+	continuation := "Commercial register Amtsgericht Kiel, HRB 123456. VAT ID DE123456789. " + strings.Repeat("Legal notice detail. ", 7)
+	page, menu, idx := pageFixture(crmcontracts.SiteReadPageKindImpressum, seedURL+"/imprint", first+"\n"+continuation)
+	if len(idx.refs) < 2 {
+		t.Fatalf("fixture must create a name and continuation passage: %d", len(idx.refs))
+	}
+	reply := `{"facts":[],"entities":[{"n":"Acme GmbH","a":"Deliusstrasse 7, 24114 Kiel, Germany","r":"HRB 123456","e":"s0"}]}`
+	res, _ := gatePageEntities2(t, reply, page, menu, idx)
+	if len(res) != 1 || res[0].RegisterNumber != "HRB 123456" {
+		t.Fatalf("a legal block's adjacent register line must survive: %+v", res)
 	}
 }

--- a/backend/internal/compose/siteprofile.go
+++ b/backend/internal/compose/siteprofile.go
@@ -32,11 +32,15 @@ const (
 	// profile in their first passages, and prefill time on this call is
 	// on the read's critical path.
 	profileExcerptBudgetRunes = 18_000
-	// profileImpressumExcerptRunes caps ONE legal page's excerpt share:
-	// every legal page must be represented (the trio quotes from them),
-	// but a site with many impressum-classified pages must not inflate
-	// the one profile prompt past its budget.
-	profileImpressumExcerptRunes = 4_000
+	// Each page receives a bounded share so the profile sees a balanced
+	// cross-section instead of one unusually long About or legal page.
+	profilePageExcerptRunes = 2_500
+	// Legal identity is represented, but the separate entity census reads
+	// every legal page. The profile lane only needs enough legal evidence
+	// for the trio and must reserve most of its corpus for what the company
+	// sells and whom it serves.
+	profileImpressumExcerptRunes = 2_500
+	profileMaxImpressumPages     = 1
 )
 
 // profileSystem is the profile call's prompt.
@@ -93,35 +97,62 @@ func profileSchema(snippetIDs []string) json.RawMessage {
 	))
 }
 
-// profileExcerptPages picks the excerpt corpus: every impressum page
-// (the census needs each), then the remaining pages by corpusRank until
-// the budget is spent. Deterministic: stable order, greedy cut.
+// profileExcerptPages picks a balanced, identity-dense corpus under one
+// total budget. The legal census is a separate page-fact lane, so the
+// profile prompt represents at most one legal page and reserves room for
+// About, services, products, home, contact, and team evidence.
 func profileExcerptPages(pages []crawlPage) []crawlPage {
 	ranked := make([]crawlPage, len(pages))
 	copy(ranked, pages)
 	sortPagesByCorpusRank(ranked)
 	var out []crawlPage
 	used := 0
-	for _, page := range ranked {
+	legalPages := 0
+	selected := map[string]bool{}
+	addPage := func(page crawlPage) bool {
+		capRunes := profilePageExcerptRunes
 		if page.Kind == crmcontracts.SiteReadPageKindImpressum {
-			// Legal pages always join, each on a capped share.
-			if runes := []rune(page.Text); len(runes) > profileImpressumExcerptRunes {
-				page.Text = string(runes[:profileImpressumExcerptRunes])
+			if legalPages >= profileMaxImpressumPages {
+				return false
 			}
-			out = append(out, page)
-			used += len([]rune(page.Text))
-			continue
+			capRunes = profileImpressumExcerptRunes
 		}
-		runes := len([]rune(page.Text))
-		if runes > maxExtractionText {
-			runes = maxExtractionText
-			page.Text = string([]rune(page.Text)[:maxExtractionText])
+		pageRunes := []rune(page.Text)
+		if len(pageRunes) > capRunes {
+			pageRunes = pageRunes[:capRunes]
+			page.Text = string(pageRunes)
 		}
-		if used+runes > profileExcerptBudgetRunes {
-			continue
+		if used+len(pageRunes) > profileExcerptBudgetRunes {
+			return false
 		}
 		out = append(out, page)
-		used += runes
+		used += len(pageRunes)
+		selected[page.URL] = true
+		if page.Kind == crmcontracts.SiteReadPageKindImpressum {
+			legalPages++
+		}
+		return true
+	}
+
+	// First pass buys breadth: one legal, About, team, home, contact,
+	// services, and products page before another locale or another team
+	// page can spend the profile's entire prompt budget.
+	seenKind := map[crmcontracts.SiteReadPageKind]bool{}
+	for _, page := range ranked {
+		if seenKind[page.Kind] {
+			continue
+		}
+		if addPage(page) {
+			seenKind[page.Kind] = true
+		}
+	}
+	// A small site may not publish every kind. Spend any room that remains
+	// on the next-best pages without weakening the one-legal-page bound.
+	for _, page := range ranked {
+		if selected[page.URL] {
+			continue
+		}
+		addPage(page)
 	}
 	return out
 }

--- a/backend/internal/compose/siteprofile_test.go
+++ b/backend/internal/compose/siteprofile_test.go
@@ -98,39 +98,40 @@ func TestGateProfileRefusesUnknownIdsAndBadConfidence(t *testing.T) {
 	}
 }
 
-func TestProfileExcerptPagesAlwaysCarryEveryImpressum(t *testing.T) {
+func TestProfileExcerptPagesBoundLegalPagesAndReserveCommercialEvidence(t *testing.T) {
 	var pages []crawlPage
-	// Enough non-legal bulk to blow the excerpt budget…
-	for i := 0; i < 6; i++ {
+	for i := 0; i < 8; i++ {
 		pages = append(pages, crawlPage{
 			URL: seedURL + "/about" + string(rune('a'+i)), Kind: crmcontracts.SiteReadPageKindAbout,
 			Text: string(make([]byte, 0)) + string(bytesOfRunes('a', 9000)),
 		})
 	}
-	// …and two imprints at the end of crawl order.
-	pages = append(
-		pages,
-		crawlPage{URL: seedURL + "/impressum", Kind: crmcontracts.SiteReadPageKindImpressum, Text: "Impressum eins."},
-		crawlPage{URL: seedURL + "/de/impressum", Kind: crmcontracts.SiteReadPageKindImpressum, Text: "Impressum zwei."},
-	)
+	for i := 0; i < 6; i++ {
+		pages = append(pages, crawlPage{
+			URL: seedURL + "/legal" + string(rune('a'+i)), Kind: crmcontracts.SiteReadPageKindImpressum,
+			Text: string(bytesOfRunes('l', 9000)),
+		})
+	}
 	excerpts := profileExcerptPages(pages)
 	imprints := 0
-	for _, page := range excerpts {
-		if page.Kind == crmcontracts.SiteReadPageKindImpressum {
-			imprints++
-		}
-	}
-	if imprints != 2 {
-		t.Fatalf("every imprint must be excerpted whatever the budget, got %d", imprints)
-	}
+	commercial := 0
 	total := 0
 	for _, page := range excerpts {
-		if page.Kind != crmcontracts.SiteReadPageKindImpressum {
-			total += len([]rune(page.Text))
+		total += len([]rune(page.Text))
+		if page.Kind == crmcontracts.SiteReadPageKindImpressum {
+			imprints++
+		} else {
+			commercial++
 		}
 	}
+	if imprints != profileMaxImpressumPages {
+		t.Fatalf("legal excerpts = %d, want bounded share %d", imprints, profileMaxImpressumPages)
+	}
+	if commercial < 3 {
+		t.Fatalf("the profile must retain a useful commercial cross-section, got %d pages", commercial)
+	}
 	if total > profileExcerptBudgetRunes {
-		t.Fatalf("non-legal excerpts exceed the budget: %d runes", total)
+		t.Fatalf("all excerpts exceed the budget: %d runes", total)
 	}
 }
 

--- a/backend/internal/compose/sitereaddebug.go
+++ b/backend/internal/compose/sitereaddebug.go
@@ -130,6 +130,7 @@ func siteReadDebugRun(ctx context.Context, opts SiteReadDebugOptions, crawler *s
 	report.Crawl = debugCrawl(crawl, crawl.Pages, opts.IncludePageText, crawlMs)
 
 	mergedFields, legalConflict, legalDrops := applyLegalGate(extraction.fields, extraction.merged.entities, pageKindsOf(crawl.Pages), extraction.legalCensusIncomplete)
+	extraction.merged.entities = enrichLegalEntitiesFromProfile(extraction.merged.entities, mergedFields)
 	extract.reportDrops(ctx, laneLegal, legalDrops)
 	if legalConflict {
 		report.Warnings = append(report.Warnings, legalWarningMultipleEntities)

--- a/backend/internal/compose/sitereadvocab.go
+++ b/backend/internal/compose/sitereadvocab.go
@@ -29,10 +29,11 @@ const (
 // "Name — short description" value spelling NormalizeFactValueKey
 // dedupes on.
 var categoryGuidance = map[string]string{
-	"company": "founded_year is the year the company was founded; employee_range a stated headcount or range; " +
+	companyWord: "founded_year is the year the company was founded; employee_range a stated headcount or range; " +
 		"phone and contact_email the company's own contact details; location one entry per office or site the " +
 		"company states (city and country as printed).",
 	"offering": "service and product name what THIS company sells, at the level it sells them — the page's own subject, as a buyer would name it on an order. " +
+		"A product is software or a repeatable packaged good the buyer uses; a service is work this company performs for the buyer. Use capability when the page states an ability but does not sell it as a named offer. " +
 		"A method, technique, step, phase or deliverable USED TO DELIVER one offering is not itself an offering: on a page about a research service, " +
 		"the service is what the page is about, while workshops, interviews, mapping and synthesis are how it is done — omit those. " +
 		"A product, platform or vendor made by SOMEONE ELSE that this company integrates, migrates, partners on or builds upon is technology, NEVER product or service, " +

--- a/frontend/src/design-system/margince-core.css
+++ b/frontend/src/design-system/margince-core.css
@@ -13,6 +13,28 @@
   position: absolute;
   inset: 0;
 }
+.margince-core-progress {
+  position: absolute;
+  z-index: 1;
+  inset: -2px;
+  width: calc(100% + 4px);
+  height: calc(100% + 4px);
+  overflow: visible;
+  pointer-events: none;
+  transform: rotate(-90deg);
+}
+.margince-core-progress circle {
+  fill: none;
+  stroke: var(--railHover);
+  stroke-width: 0.7;
+}
+.margince-core-progress .margince-core-progress-value {
+  stroke: var(--aiText);
+  stroke-width: 1.15;
+  stroke-linecap: round;
+  filter: drop-shadow(0 0 4px var(--aiText));
+  transition: stroke-dasharray 700ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
 .margince-core-glow {
   position: absolute;
   inset: 26%;
@@ -253,6 +275,7 @@
   .margince-core-orbit,
   .margince-core-thread,
   .margince-core-mark-shell,
+  .margince-core-progress .margince-core-progress-value,
   .margince-core-scene {
     animation: none;
   }

--- a/frontend/src/design-system/margince-core.stories.tsx
+++ b/frontend/src/design-system/margince-core.stories.tsx
@@ -18,7 +18,7 @@ export const Idle: Story = {
 };
 
 export const Working: Story = {
-  args: { state: "working" },
+  args: { state: "working", progress: 0.58 },
 };
 
 export const Success: Story = {

--- a/frontend/src/design-system/margince-core.tsx
+++ b/frontend/src/design-system/margince-core.tsx
@@ -13,10 +13,12 @@ export type MarginceCoreState =
 
 export function MarginceCoreScene({
   state = "idle",
+  progress,
   children,
   className = "",
 }: Readonly<{
   state?: MarginceCoreState;
+  progress?: number;
   children?: ReactNode;
   className?: string;
 }>) {
@@ -25,6 +27,23 @@ export function MarginceCoreScene({
       className={`margince-core-scene ${children ? "has-content" : ""} ${className}`}
       data-core-state={state}
     >
+      {progress !== undefined && (
+        <svg
+          className="margince-core-progress"
+          viewBox="0 0 100 100"
+          aria-hidden="true"
+        >
+          <circle cx="50" cy="50" r="48.5" pathLength="100" />
+          <circle
+            className="margince-core-progress-value"
+            cx="50"
+            cy="50"
+            r="48.5"
+            pathLength="100"
+            strokeDasharray={`${Math.max(0, Math.min(1, progress)) * 100} 100`}
+          />
+        </svg>
+      )}
       <div className="margince-core-visual" aria-hidden="true">
         <div className="margince-core-glow" />
         <div className="margince-core-orbit margince-core-orbit-context">

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -872,6 +872,11 @@ export const de = {
   "ob.coreIntroBody":
     "Ich brauche rechtliche Identität, Anschrift und USt-IdNr./UID oder Registerdaten. Danach lerne ich, was ihr verkauft, wen ihr bedient und wie ihr Geschäft gewinnt.",
   "ob.coreLegalKicker": "Ich beginne mit der rechtlichen Identität",
+  "ob.corePathLabel": "Was ich lerne",
+  "ob.corePathLegal": "Rechtliche Identität",
+  "ob.corePathOffer": "Angebot",
+  "ob.corePathCustomer": "Kunden",
+  "ob.coreReadingPage": "Ich lese gerade",
   "ob.coreWebsiteTitle": "Welche Website soll ich lesen?",
   "ob.coreWebsiteBody":
     "Ich suche zuerst das Impressum und lese danach Produkte, Idealkunden, Positionierung und Vertriebsansatz.",
@@ -888,7 +893,7 @@ export const de = {
     "Ich habe noch nichts gespeichert. Bitte prüfe zuerst die rechtliche Identität, danach Angebot und Idealkunden.",
   "ob.coreDeferredBody": "Ich setze das Einlesen automatisch fort.",
   "ob.coreFailedBody":
-    "Ich konnte auf dieser Seite nicht genug belegen und habe deshalb aufgehört, statt zu raten. Du kannst mir dieselben Angaben selbst geben.",
+    "Ich konnte diese Website nicht zuverlässig öffnen oder belegen und habe deshalb aufgehört, statt zu raten. Du kannst mir dieselben Angaben selbst geben.",
   "ob.coreFindingsTitle": "Was ich gefunden habe und belegen kann",
   "ob.coreFindingsBody":
     "Ich hänge an jeden Wert den öffentlichen Wortlaut seiner Quelle. Was ich rechtlich nicht belegen kann, lasse ich leer.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -855,6 +855,11 @@ export const en = {
   "ob.coreIntroBody":
     "I need its legal identity, address and VAT or registration details. Then I'll learn what you sell, who you serve, and how you win business.",
   "ob.coreLegalKicker": "I start with legal identity",
+  "ob.corePathLabel": "What I'll learn",
+  "ob.corePathLegal": "Legal identity",
+  "ob.corePathOffer": "Offer",
+  "ob.corePathCustomer": "Customers",
+  "ob.coreReadingPage": "I'm reading",
   "ob.coreWebsiteTitle": "Which website should I read?",
   "ob.coreWebsiteBody":
     "I'll find the legal notice first, then I’ll read your products, ideal customers, positioning and sales approach.",
@@ -871,7 +876,7 @@ export const en = {
     "I haven't saved anything yet. Please review the legal identity first, then the offer and ideal customer.",
   "ob.coreDeferredBody": "I'll resume this read automatically.",
   "ob.coreFailedBody":
-    "I couldn't ground enough from this site, so I stopped instead of guessing. You can tell me the same information yourself.",
+    "I couldn't reliably access or ground this website, so I stopped instead of guessing. You can tell me the same information yourself.",
   "ob.coreFindingsTitle": "What I found and can support",
   "ob.coreFindingsBody":
     "I attach the public wording behind every value. If I couldn't verify a legal detail, I leave it empty.",

--- a/frontend/src/screens/onboarding-read.tsx
+++ b/frontend/src/screens/onboarding-read.tsx
@@ -1,12 +1,15 @@
 import {
   ArrowRight,
+  Building2,
   Check,
   Circle,
   FileSearch,
   Globe2,
   Info,
+  PackageSearch,
   PenLine,
   ShieldCheck,
+  UsersRound,
 } from "lucide-react";
 import type { ReactNode } from "react";
 import type { components } from "../api/schema";
@@ -84,6 +87,19 @@ function presenceState(
   return props.mode ? "listening" : "idle";
 }
 
+function coreProgress(read: CompanySiteRead | null): number | undefined {
+  if (!read) {
+    return undefined;
+  }
+  if (terminalStatuses.has(read.status)) {
+    return 1;
+  }
+  if (read.phase === "extracting") {
+    return 0.84;
+  }
+  return Math.max(0.08, Math.min(0.78, (read.pages_read ?? 0) / 40));
+}
+
 // The Core owns conversation and honest progress. Dense evidence stays directly
 // below it, where quotes and controls remain readable instead of being squeezed
 // into a decorative shape.
@@ -100,6 +116,7 @@ export function ReadCompanyStep(props: ReadCompanyStepProps) {
     <section className="ob-panel ob-read-panel">
       <MarginceCoreScene
         state={presenceState(props, running)}
+        progress={coreProgress(props.read)}
         className="ob-core-scene"
       >
         {props.mode === null && (
@@ -159,6 +176,7 @@ function CoreIntroduction({
       <div className="ob-core-kicker">{t("ob.readKick")}</div>
       <h1>{t("ob.coreIntroTitle")}</h1>
       <p>{t("ob.coreIntroBody")}</p>
+      <CoreJourney active={0} />
       <div className="ob-core-choices">
         <button type="button" onClick={onWebsite}>
           <Globe2 aria-hidden />
@@ -195,6 +213,7 @@ function WebsitePrompt(
       <div className="ob-core-kicker">{t("ob.coreLegalKicker")}</div>
       <h1>{t("ob.coreWebsiteTitle")}</h1>
       <p>{t("ob.coreWebsiteBody")}</p>
+      <CoreJourney active={0} />
       <div
         className={`ob-core-url ${props.website && !props.norm.ok ? "invalid" : ""}`}
       >
@@ -272,27 +291,8 @@ function CoreReadProgress({
   const findings = read.profile_fields.length + read.facts.length;
   const host = new URL(read.root_url).hostname;
   const phase = read.phase ?? (read.status === "queued" ? "crawling" : null);
-
-  let title = t("ob.corePreparing", { host });
-  let body = t("ob.coreLegalReadingBody");
-  if (read.status === "deferred") {
-    title = t("ob.coreDeferredBody");
-    body = read.status_detail ?? t("ob.coreDeferredBody");
-  } else if (failedStatuses.has(read.status)) {
-    title = t("ob.failTitle");
-    body = t("ob.coreFailedBody");
-  } else if (successfulStatuses.has(read.status)) {
-    title = t("ob.coreReady", { count: findings });
-    body = t("ob.coreReadyBody");
-  } else if (read.status === "partial") {
-    title = t("ob.corePartial", { count: findings });
-    body = t("ob.coreReadyBody");
-  } else if (phase === "extracting") {
-    title = t("ob.coreBusinessReading");
-    body = t("ob.coreBusinessReadingBody");
-  } else if (phase === "crawling") {
-    title = t("ob.coreLegalReading", { host });
-  }
+  const latestPage = latestFetchedPage(read);
+  const presentation = coreReadPresentation(read, phase, host, findings, t);
 
   return (
     <div className="ob-core-dialog" aria-live="polite">
@@ -302,8 +302,17 @@ function CoreReadProgress({
         )}
         {t(`ob.readStatus.${read.status}`)}
       </div>
-      <h1>{title}</h1>
-      <p>{body}</p>
+      <h1>{presentation.title}</h1>
+      <p>{presentation.body}</p>
+      <CoreJourney active={presentation.journeyStage} />
+      {latestPage && read.status === "reading" && (
+        <div className="ob-core-activity">
+          <FileSearch aria-hidden />
+          <span>
+            {t("ob.coreReadingPage")} <b>{readablePage(latestPage.url)}</b>
+          </span>
+        </div>
+      )}
       {read.status === "deferred" && read.next_attempt_at && (
         <p className="ob-core-detail">
           {t("deepread.resumesAt", {
@@ -332,6 +341,96 @@ function CoreReadProgress({
       )}
     </div>
   );
+}
+
+type Translator = ReturnType<typeof useT>;
+
+function latestFetchedPage(read: CompanySiteRead) {
+  return [...read.pages].reverse().find((page) => page.status === "fetched");
+}
+
+function coreReadPresentation(
+  read: CompanySiteRead,
+  phase: string | null,
+  host: string,
+  findings: number,
+  t: Translator,
+) {
+  if (read.status === "deferred") {
+    return {
+      title: t("ob.coreDeferredBody"),
+      body: read.status_detail ?? t("ob.coreDeferredBody"),
+      journeyStage: 0,
+    };
+  }
+  if (failedStatuses.has(read.status)) {
+    return {
+      title: t("ob.failTitle"),
+      body: t("ob.coreFailedBody"),
+      journeyStage: 0,
+    };
+  }
+  if (successfulStatuses.has(read.status)) {
+    return {
+      title: t("ob.coreReady", { count: findings }),
+      body: t("ob.coreReadyBody"),
+      journeyStage: 3,
+    };
+  }
+  if (read.status === "partial") {
+    return {
+      title: t("ob.corePartial", { count: findings }),
+      body: t("ob.coreReadyBody"),
+      journeyStage: 3,
+    };
+  }
+  if (phase === "extracting") {
+    return {
+      title: t("ob.coreBusinessReading"),
+      body: t("ob.coreBusinessReadingBody"),
+      journeyStage: 1,
+    };
+  }
+  return {
+    title:
+      phase === "crawling"
+        ? t("ob.coreLegalReading", { host })
+        : t("ob.corePreparing", { host }),
+    body: t("ob.coreLegalReadingBody"),
+    journeyStage: 0,
+  };
+}
+
+function CoreJourney({ active }: Readonly<{ active: number }>) {
+  const t = useT();
+  const stages = [
+    { icon: Building2, label: t("ob.corePathLegal") },
+    { icon: PackageSearch, label: t("ob.corePathOffer") },
+    { icon: UsersRound, label: t("ob.corePathCustomer") },
+  ];
+  return (
+    <ol className="ob-core-journey" aria-label={t("ob.corePathLabel")}>
+      {stages.map((stage, index) => {
+        const Icon = stage.icon;
+        const state =
+          index < active ? "done" : index === active ? "active" : "waiting";
+        return (
+          <li key={stage.label} data-state={state}>
+            <i>
+              {state === "done" ? <Check aria-hidden /> : <Icon aria-hidden />}
+            </i>
+            {stage.label}
+          </li>
+        );
+      })}
+    </ol>
+  );
+}
+
+function readablePage(rawURL: string) {
+  const pageURL = new URL(rawURL);
+  const path = pageURL.pathname.replace(/\/$/, "");
+  return path === "" ? pageURL.hostname : `${pageURL.hostname}${path}`;
 }
 
 function ReadEvidence({ read }: Readonly<{ read: CompanySiteRead }>) {

--- a/frontend/src/screens/onboarding.css
+++ b/frontend/src/screens/onboarding.css
@@ -1203,6 +1203,39 @@
     linear-gradient(145deg, var(--railTop), var(--railBottom));
   box-shadow: var(--shadow-pop);
 }
+.ob-read-panel {
+  position: relative;
+  display: flex;
+  min-height: calc(100vh - 176px);
+  flex-direction: column;
+  justify-content: center;
+  isolation: isolate;
+}
+.ob-read-panel::before {
+  position: absolute;
+  z-index: -1;
+  width: min(940px, 118vw);
+  aspect-ratio: 1.75;
+  left: 50%;
+  top: 48%;
+  content: "";
+  pointer-events: none;
+  transform: translate(-50%, -50%);
+  background:
+    radial-gradient(circle at center, var(--accentLight), transparent 47%),
+    repeating-radial-gradient(
+      ellipse at center,
+      transparent 0 72px,
+      color-mix(in srgb, var(--accent) 8%, transparent) 73px,
+      transparent 74px 112px
+    );
+  mask-image: linear-gradient(
+    to right,
+    transparent,
+    black 18% 82%,
+    transparent
+  );
+}
 .ob-core-scene .margince-core-content {
   width: 78%;
   padding-top: 58px;
@@ -1245,6 +1278,61 @@
   color: var(--railIconHover);
   font-size: 13.5px;
   line-height: 1.5;
+}
+.ob-core-journey {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 4px;
+  margin-top: 16px;
+  padding: 0;
+  list-style: none;
+}
+.ob-core-journey::before {
+  position: absolute;
+  top: 13px;
+  right: 15%;
+  left: 15%;
+  height: 1px;
+  content: "";
+  background: var(--railHover);
+}
+.ob-core-journey > li {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  justify-items: center;
+  gap: 5px;
+  color: var(--railIconHover);
+  font-family: var(--f-mono);
+  font-size: 8.5px;
+  line-height: 1.2;
+}
+.ob-core-journey i {
+  display: grid;
+  width: 27px;
+  height: 27px;
+  place-items: center;
+  color: var(--railIconHover);
+  border: 1px solid var(--railHover);
+  border-radius: var(--r-full);
+  background: var(--railActive);
+}
+.ob-core-journey svg {
+  width: 12px;
+}
+.ob-core-journey [data-state="active"] {
+  color: var(--railIconActive);
+}
+.ob-core-journey [data-state="active"] i {
+  color: var(--aiText);
+  border-color: var(--aiText);
+  box-shadow: 0 0 16px var(--aiMed);
+}
+.ob-core-journey [data-state="done"] i {
+  color: var(--textOnAccent);
+  border-color: var(--online);
+  background: var(--online);
 }
 .ob-core-choices {
   display: grid;
@@ -1394,18 +1482,48 @@
   box-shadow: 0 0 12px var(--aiText);
   animation: ob-core-live 1.4s ease-in-out infinite;
 }
-.ob-core-metrics {
+.ob-core-activity {
   display: flex;
-  justify-content: center;
-  gap: 12px;
+  align-items: center;
+  gap: 7px;
+  min-width: 0;
+  margin-top: 12px;
+  padding: 8px 10px;
+  color: var(--railIconHover);
+  border: 1px solid var(--railHover);
+  border-radius: var(--r-sm);
+  background: color-mix(in srgb, var(--railActive) 72%, transparent);
+  font-family: var(--f-mono);
+  font-size: 9px;
+  text-align: left;
+}
+.ob-core-activity svg {
+  width: 13px;
+  flex: none;
+  color: var(--aiText);
+}
+.ob-core-activity span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ob-core-activity b {
+  color: var(--railIconActive);
+  font-weight: 600;
+}
+.ob-core-metrics {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
   margin-top: 15px;
   color: var(--railIconHover);
   font-family: var(--f-mono);
   font-size: 9px;
 }
 .ob-core-metrics span {
-  padding: 6px 8px;
-  border-radius: var(--r-full);
+  padding: 7px 8px;
+  border-radius: var(--r-sm);
   background: var(--railHover);
 }
 .ob-core-metrics b {
@@ -1814,6 +1932,9 @@
     width: min(560px, calc(100vw - 32px));
     min-width: 0;
   }
+  .ob-read-panel {
+    min-height: calc(100vh - 150px);
+  }
   .ob-core-scene .margince-core-content {
     width: 74%;
   }
@@ -1859,6 +1980,6 @@
     font-size: 24px;
   }
   .ob-core-metrics {
-    flex-wrap: wrap;
+    grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
## What changed

- turns the cold-start website read into a first-person Margince research experience, with live progress, evidence counters, and the reusable Core animation acting as the status surface
- improves crawl prioritization and bounded legal-page fallbacks for imprints, publishers, legal notices, and terms pages
- increases profile coverage while preserving a bounded evidence corpus and balancing legal, company, product, service, and market sources
- consolidates legal entities more accurately, joins adjacent address/register evidence, and enriches the primary legal card with independently gated profile facts
- makes website reads fail safely if a worker panics instead of leaving an organization permanently stuck in `running`

## Why

The prior onboarding separated status from the Margince animation and did not make the AI's activity feel coherent. More importantly, real-company testing exposed inconsistent legal identity discovery, duplicated legal names, weak product/service distinction, and one crawler bookkeeping panic that could leave a read unfinished.

## User impact

Admins now see Margince explain in the first person what it needs, watch its progress within the animated Core, and receive a more complete reviewable organization profile: legal identity, registered address, VAT/register identifiers where published, products/services, ICP and market context, signals, technologies, and people.

## Validation

- `make check`
- `make test-integration` — 18 packages, 0 skips
- browser-tested the cold-start intro, live Gradion crawl, progress animation, and completed evidence review
- benchmarked Stripe, Notion, Linear, Personio, DeepL, Celonis, Contentful, Forto, GetYourGuide, and Miro; used the failures and weak fields to drive the crawler and extraction changes

External limitations observed during the benchmark are explicit: Personio returned HTTP 429 for the root and legal pages, and Notion's German imprint uses an unlinked opaque URL that a generic bounded crawler cannot discover. The final additional runs exhausted the configured Anthropic account's credit balance; deterministic and integration validation remain green.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened website ingestion and rebuilt onboarding into a first‑person research stage with live progress, better legal identity discovery, and safer failure handling. This improves profile quality and prevents reads from getting stuck.

- **New Features**
  - New onboarding Core: progress halo, “legal → offer → customers” journey, and “I’m reading …” page indicator with EN/DE copy.
  - Smarter crawl probes and ranking: detect true legal-identity paths (`/imprint`, `/publisher`, shallow `/legal`, `/c/legal`), add one bounded policy fallback, and ignore guide/template slugs.
  - Profile quality: fire profile only after enough non‑legal pages; cap per‑page runes and allow max one legal page in the profile excerpt to preserve commercial evidence.
  - Legal entity accuracy: fold punctuation‑only variants, drop bare brand aliases when a richer registered name exists, join adjacent legal block passages, and enrich the single chosen entity with already‑gated address/register fields.

- **Bug Fixes**
  - No more “forever reading”: recover worker panics at the ownership boundary and mark the read failed; fix queue indexing when new links land at the byte/deadline cap.
  - Tighter page classification: separate legal identity from product/policy pages; limit locale influence to the first path segment.
  - Tests added for crawl selection, legal dedupe/enrichment, profile triggers, and passage joins.

<sup>Written for commit 4d2aa101355ecf33a926022a6c482f0c9871cad4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a redesigned onboarding research stage with live progress indicators, journey steps, activity updates, and responsive layouts.
  * Added English and German labels for legal identity, offers, customers, and research progress.
* **Bug Fixes**
  * Improved detection and consolidation of legal identity information across website pages.
  * Reduced incorrect page classification and improved coverage of publisher and legal pages.
  * Fixed cases where website reads could remain stuck or fail to complete cleanly.
* **Documentation**
  * Updated status information with recent website-ingestion and onboarding milestones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->