### PR TITLE
feat(overlay): currency/duration/full-name mapping fidelity (OVA-MAP-2/3/4)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -755,14 +755,28 @@ Open work, roughly in priority order:
     ~4h48m effective + rate-limit floor) + `DueOverlayConnections` due-gate +
     `reconcileConnection` distinguishing connection-level (abort+backoff) from
     per-object (log+skip) failures.
-  - **A5 disconnect-race fencing** — IN FLIGHT #166
-    (`fix/overlay-disconnect-fencing`). Opt-in `MirrorStore.WithFence()`: a
-    `FOR SHARE` assert on the active `incumbent_connection` row (fail-closed)
-    on every resurrection-risk write, contending with Disconnect's FOR UPDATE
-    so a mid-sweep write either commits-then-purged or aborts with
-    `ErrConnectionGone`; the sweep treats that as a clean stop. Covers the
-    tables the mirror tombstone cannot (associations, checkpoints, user-map)
-    + a tombstone-less new row. `mirrorcheckpoints.go` split out.
+  - **A5 disconnect-race fencing** — MERGED #166 (`d103080`). Opt-in
+    `MirrorStore.WithFence()`: a `FOR SHARE` assert on the active
+    `incumbent_connection` row (fail-closed) on every resurrection-risk write
+    (incl. `RecordSweep*`), contending with Disconnect's FOR UPDATE so a
+    mid-sweep write either commits-then-purged or aborts with
+    `ErrConnectionGone`; the sweep + worker treat that as a clean stop. Covers
+    the tables the mirror tombstone cannot (associations, checkpoints,
+    user-map, sync-state) + a tombstone-less new row. `mirrorcheckpoints.go`
+    split out.
+  - **A6.1 mapping-fidelity (value-level rules)** — IN FLIGHT
+    (`feat/overlay-mapping-fidelity-values`). OVA-MAP-2 (`hs_call_duration`
+    ms→seconds), OVA-MAP-3 (`full_name` assembled firstname+lastname → email
+    local part → placeholder, never empty; new `AlwaysEmit` assembler flag),
+    OVA-MAP-4 (deal `amount`→`amount_minor` scaled by the ISO-4217 exponent of
+    `deal_currency_code`, not a blanket ×100; null when no currency). New
+    transforms `uppercase`/`ms_to_seconds`/`full_name`/`amount_minor_by_currency`
+    (replacing `amount_to_minor`); golden OVA-AC-4 cases. Spec: foundation
+    #1124 (merged). **A6 remaining slices** (own PRs, structural):
+    OVA-MAP-1 engagement-class split (calls/meetings/emails/notes/tasks — needs
+    the IncumbentClassFor 5→activity disambiguation), OVA-MAP-5 leads via real
+    Leads API props + contact association, OVA-MAP-6 null overlay pipeline/stage
+    + `raw` + stage→`semantic` for advance-tier.
 
   Still open in 1b (the next branches, roughly in priority order):
   - **A3b** — token-bucket burst limiter (HubSpot 100–250/10s); shared

--- a/backend/internal/modules/overlay/hubspot/mapping_hs.go
+++ b/backend/internal/modules/overlay/hubspot/mapping_hs.go
@@ -35,11 +35,12 @@ const unmappedPolicyFlag = "flag"
 // named once so the mappings below select a value rather than retyping
 // the same literal, and so a future rename touches one declaration.
 const (
-	propEmail     = "email"
-	propName      = "name"
-	targetAddress = "address"
-	targetSubject = "subject"
-	targetBody    = "body"
+	propEmail      = "email"
+	propName       = "name"
+	targetAddress  = "address"
+	targetSubject  = "subject"
+	targetBody     = "body"
+	targetFullName = "full_name"
 )
 
 // Mapping returns the ObjectMapping for one HubSpot object class. An
@@ -87,28 +88,20 @@ func IncumbentClassFor(canonical string) (string, bool) {
 	return "", false
 }
 
-// contactsMapping is the design.md §9 contacts→person subset this task
-// ships. Two §9 fields are deferred because no closed-registry
-// transform covers them yet, and this task does not invent one — but
-// they are NOT equivalent gaps, and a caller must not treat them alike:
+// contactsMapping is the design.md §9 contacts→person subset. full_name is
+// assembled from firstname/lastname (falling back to the email local part,
+// then a stable placeholder) by the full_name transform, declared AlwaysEmit
+// so a required display field is never left empty (OVA-MAP-3). first_name and
+// last_name are still mapped through as-is (nullable), and email is still
+// consumed by person_email.email — the assembler is an ADDITIONAL reader of
+// those keys, so it adds no unmapped entry.
 //
-//   - social links (jsonb): its source properties are consumed by no
-//     other FieldMapping, so Apply's unmapped []string surfaces them —
-//     the "flag, never silently drop" policy (design §4.8) holds.
-//   - full_name (an N:1 assembler over firstname/lastname/email): its
-//     source keys (firstname, lastname, email) ARE already consumed by
-//     the first_name/last_name/person_email.email FieldMappings below.
-//     Omitting the assembler therefore produces NO unmapped key —
-//     person.full_name is silently left unpopulated with zero runtime
-//     signal. This is a target-side gap, invisible to the unmapped-key
-//     mechanism. TestHubSpotContactMapping asserts "full_name" is
-//     absent from Apply's output today so a future change that adds a
-//     full_name transform without updating that test fails loudly,
-//     rather than this comment being the only record of the gap.
-//
-// The phone/mobilephone properties (design §9: "phone→no column
-// (x_phone custom)") are the ordinary case: unmapped/flagged until the
-// x_ custom column lands.
+// One §9 field remains a deliberate gap: social links (jsonb) has no
+// closed-registry transform yet, and its source properties are consumed by
+// no FieldMapping, so Apply's unmapped []string surfaces them — the "flag,
+// never silently drop" policy (design §4.8) holds. The phone/mobilephone
+// properties (design §9: "phone→no column (x_phone custom)") are the same
+// ordinary case: unmapped/flagged until the x_ custom column lands.
 var contactsMapping = overlay.ObjectMapping{
 	Source:         objectClassContacts,
 	Target:         "person",
@@ -118,6 +111,13 @@ var contactsMapping = overlay.ObjectMapping{
 	Fields: []overlay.FieldMapping{
 		{From: []string{"firstname"}, To: "first_name", Kind: overlay.TargetColumn},
 		{From: []string{"lastname"}, To: "last_name", Kind: overlay.TargetColumn},
+		{
+			From:       []string{"firstname", "lastname", propEmail},
+			To:         targetFullName,
+			Kind:       overlay.TargetAssembler,
+			Transform:  "full_name",
+			AlwaysEmit: true,
+		},
 		{From: []string{"jobtitle"}, To: "title", Kind: overlay.TargetColumn},
 		{
 			From:      []string{propEmail},
@@ -190,13 +190,11 @@ var companiesMapping = overlay.ObjectMapping{
 //     deals→companies associations directly; there is no properties-map
 //     key for it, so it never appears in Apply's unmapped list either.
 //
-// amount_to_minor is wired here as a straight cents conversion (§9 calls
-// for "decimal→minor by currency exponent" — a currency-aware exponent
-// table, e.g. JPY has none, KWD has three — which is NOT in the closed
-// transform registry). Using the existing cents-only transform is a
-// known simplification for portals trading in two-decimal currencies;
-// a currency-aware transform is a reconciliation item for the spec, not
-// invented here.
+// amount_minor is assembled from amount + deal_currency_code and scaled by
+// the currency's ISO-4217 minor-unit exponent (OVA-MAP-4) — JPY ×1, EUR/USD
+// ×100, BHD ×1000 — never a blanket ×100; a deal with no currency code maps
+// amount_minor to null rather than guessing an exponent. currency carries the
+// code itself, uppercased.
 var dealsMapping = overlay.ObjectMapping{
 	Source:         objectClassDeals,
 	Target:         "deal",
@@ -206,12 +204,12 @@ var dealsMapping = overlay.ObjectMapping{
 	Fields: []overlay.FieldMapping{
 		{From: []string{"dealname"}, To: "name", Kind: overlay.TargetColumn},
 		{
-			From:      []string{"amount"},
+			From:      []string{"amount", "deal_currency_code"},
 			To:        "amount_minor",
-			Kind:      overlay.TargetColumn,
-			Transform: "amount_to_minor",
+			Kind:      overlay.TargetAssembler,
+			Transform: "amount_minor_by_currency",
 		},
-		{From: []string{"deal_currency_code"}, To: "currency", Kind: overlay.TargetColumn},
+		{From: []string{"deal_currency_code"}, To: "currency", Kind: overlay.TargetColumn, Transform: "uppercase"},
 		{From: []string{"pipeline"}, To: "pipeline_id", Kind: overlay.TargetColumn},
 		{From: []string{"dealstage"}, To: "stage_id", Kind: overlay.TargetColumn},
 		{From: []string{"closedate"}, To: "expected_close_date", Kind: overlay.TargetColumn},
@@ -253,7 +251,7 @@ var engagementsMapping = overlay.ObjectMapping{
 		{From: []string{"text"}, To: targetBody, Kind: overlay.TargetColumn},
 		{From: []string{"hs_timestamp"}, To: "occurred_at", Kind: overlay.TargetColumn},
 		{From: []string{"direction"}, To: "direction", Kind: overlay.TargetColumn},
-		{From: []string{"hs_call_duration"}, To: "duration_seconds", Kind: overlay.TargetColumn},
+		{From: []string{"hs_call_duration"}, To: "duration_seconds", Kind: overlay.TargetColumn, Transform: "ms_to_seconds"},
 		{From: []string{"hs_meeting_outcome"}, To: "meeting_status", Kind: overlay.TargetColumn},
 	},
 }
@@ -262,10 +260,12 @@ var engagementsMapping = overlay.ObjectMapping{
 // Leads object). `status` is a deliberate target-side gap: §9 calls for
 // mapping HubSpot's free-form lead status into the fixed
 // new/working/promoted/disqualified enum, which needs an enum-remapping
-// transform NOT in the closed registry ({lowercase, amount_to_minor,
+// transform NOT in the closed registry ({lowercase, uppercase,
+// ms_to_seconds, full_name, amount_minor_by_currency,
 // employees_to_size_band, address_json}) — per the "flag, don't invent"
-// rule this task does not add one. status is left unconsumed so Apply's
-// unmapped []string surfaces it, exactly like companies' domain.
+// rule this slice does not add one (the real Leads API mapping, OVA-MAP-5,
+// is a later slice). status is left unconsumed so Apply's unmapped []string
+// surfaces it, exactly like companies' domain.
 var leadsMapping = overlay.ObjectMapping{
 	Source:         objectClassLeads,
 	Target:         "lead",
@@ -273,7 +273,7 @@ var leadsMapping = overlay.ObjectMapping{
 	Baseline:       baselineHSLastModifiedDate,
 	UnmappedPolicy: unmappedPolicyFlag,
 	Fields: []overlay.FieldMapping{
-		{From: []string{propName}, To: "full_name", Kind: overlay.TargetColumn},
+		{From: []string{propName}, To: targetFullName, Kind: overlay.TargetColumn},
 		{From: []string{propEmail}, To: propEmail, Kind: overlay.TargetColumn},
 		{From: []string{"company"}, To: "company_name", Kind: overlay.TargetColumn},
 	},

--- a/backend/internal/modules/overlay/hubspot/mapping_hs_test.go
+++ b/backend/internal/modules/overlay/hubspot/mapping_hs_test.go
@@ -305,6 +305,17 @@ func TestHubSpotDealAmountCurrencyFidelity(t *testing.T) {
 	if v, present := out["amount_minor"]; present && v != nil {
 		t.Errorf("amount_minor with no currency code = %#v, want null (absent or nil), never a guessed ×100", v)
 	}
+
+	// A currency present but the amount explicitly null (HubSpot's JSON null
+	// for an unset property) also maps to null — not an error, not a coined
+	// zero. It is "no amount", exactly like an absent one.
+	out, _, err = overlay.Apply(m, map[string]any{"hs_object_id": "3", "amount": nil, "deal_currency_code": "EUR"})
+	if err != nil {
+		t.Fatalf("Apply (nil amount): %v — a null amount must map to null, never error", err)
+	}
+	if v, present := out["amount_minor"]; present && v != nil {
+		t.Errorf("amount_minor for a nil amount = %#v, want null (absent or nil)", v)
+	}
 }
 
 // rawEngagement is a HubSpot engagement properties map using the

--- a/backend/internal/modules/overlay/hubspot/mapping_hs_test.go
+++ b/backend/internal/modules/overlay/hubspot/mapping_hs_test.go
@@ -97,14 +97,53 @@ func TestHubSpotContactMapping(t *testing.T) {
 		t.Errorf("UnmappedPolicy = %q, want %q", m.UnmappedPolicy, "flag")
 	}
 
-	// full_name is a target-side gap (mapping_hs.go doc comment): its
-	// source keys (firstname/lastname/email) are already consumed by
-	// other FieldMappings, so it produces no unmapped key — the only
-	// way to catch a silent drop is to pin the current absence here. A
-	// future full_name assembler must update this assertion, not just
-	// the doc comment.
-	if _, ok := out["full_name"]; ok {
-		t.Errorf("full_name = %v, want absent (no full_name assembler is declared yet)", out["full_name"])
+	// full_name is assembled from firstname + lastname, trimmed (OVA-MAP-3):
+	// a required, always-present display field, never left empty.
+	if got := out["full_name"]; got != "Christian Muller" {
+		t.Errorf("full_name = %v, want %q (assembled firstname + lastname)", got, "Christian Muller")
+	}
+}
+
+// TestHubSpotContactFullNameFidelity is the OVA-MAP-3 golden case set: a
+// mirrored contact's full_name is never empty. It is assembled from
+// firstname + lastname (trimmed), falling back to the primary email's local
+// part, and only then to a stable non-empty placeholder.
+func TestHubSpotContactFullNameFidelity(t *testing.T) {
+	m, ok := hubspot.Mapping("contacts")
+	if !ok {
+		t.Fatal("Mapping(contacts): want a declared mapping")
+	}
+	cases := []struct {
+		name string
+		raw  map[string]any
+		want string
+	}{
+		{"both names", map[string]any{"hs_object_id": "1", "firstname": "Ada", "lastname": "Lovelace"}, "Ada Lovelace"},
+		{"only lastname", map[string]any{"hs_object_id": "2", "firstname": "", "lastname": "Lovelace"}, "Lovelace"},
+		{"only firstname", map[string]any{"hs_object_id": "3", "firstname": "Ada", "lastname": ""}, "Ada"},
+		{"neither name, email present", map[string]any{"hs_object_id": "4", "firstname": "", "lastname": "", "email": "grace.hopper@navy.mil"}, "grace.hopper"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, _, err := overlay.Apply(m, tc.raw)
+			if err != nil {
+				t.Fatalf("Apply: %v", err)
+			}
+			if got := out["full_name"]; got != tc.want {
+				t.Errorf("full_name = %v, want %q", got, tc.want)
+			}
+		})
+	}
+
+	// Neither name nor email: full_name must still be non-empty (a stable
+	// placeholder), never absent or "".
+	out, _, err := overlay.Apply(m, map[string]any{"hs_object_id": "9999"})
+	if err != nil {
+		t.Fatalf("Apply (nameless, emailless): %v", err)
+	}
+	got, ok := out["full_name"].(string)
+	if !ok || got == "" {
+		t.Errorf("full_name for a nameless, emailless contact = %#v, want a non-empty placeholder string", out["full_name"])
 	}
 }
 
@@ -167,7 +206,7 @@ func TestHubSpotCompanyMapping(t *testing.T) {
 }
 
 // rawDeal is a §9-shaped HubSpot deal properties map, carrying a
-// negative amount to exercise the amount_to_minor transform's
+// negative amount to exercise the amount_minor_by_currency transform's
 // round-half-away-from-zero fix on the mapping path (not just Apply
 // unit-tested directly in overlay/mapping_test.go).
 func rawDeal() map[string]any {
@@ -226,6 +265,48 @@ func TestHubSpotDealMapping(t *testing.T) {
 	}
 }
 
+// TestHubSpotDealAmountCurrencyFidelity is the OVA-MAP-4 golden case set: a
+// deal amount is scaled to minor units by the ISO-4217 minor-unit exponent
+// of its deal_currency_code — never a blanket ×100. A ×100-everywhere
+// implementation fails on JPY (exponent 0) and BHD (exponent 3) by
+// construction. A deal with no currency code maps amount_minor to null.
+func TestHubSpotDealAmountCurrencyFidelity(t *testing.T) {
+	m, ok := hubspot.Mapping("deals")
+	if !ok {
+		t.Fatal("Mapping(deals): want a declared mapping")
+	}
+	cases := []struct {
+		name, amount, code string
+		want               int64
+	}{
+		{"JPY exponent 0", "1000", "JPY", 1000},
+		{"EUR exponent 2", "10.00", "EUR", 1000},
+		{"BHD exponent 3", "1.500", "BHD", 1500},
+		{"lowercase code uppercased", "10.00", "usd", 1000},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, _, err := overlay.Apply(m, map[string]any{"hs_object_id": "1", "amount": tc.amount, "deal_currency_code": tc.code})
+			if err != nil {
+				t.Fatalf("Apply: %v", err)
+			}
+			if got, ok := out["amount_minor"].(int64); !ok || got != tc.want {
+				t.Errorf("amount_minor for %s %s = %#v, want int64(%d)", tc.amount, tc.code, out["amount_minor"], tc.want)
+			}
+		})
+	}
+
+	// A deal amount with no currency code maps amount_minor to null (never a
+	// guessed exponent), per OVA-MAP-4.
+	out, _, err := overlay.Apply(m, map[string]any{"hs_object_id": "2", "amount": "10.00"})
+	if err != nil {
+		t.Fatalf("Apply (no currency): %v", err)
+	}
+	if v, present := out["amount_minor"]; present && v != nil {
+		t.Errorf("amount_minor with no currency code = %#v, want null (absent or nil), never a guessed ×100", v)
+	}
+}
+
 // rawEngagement is a HubSpot engagement properties map using the
 // property names design.md §9 names literally (no §11 spike capture
 // exists for engagements — see the engagementsMapping doc comment).
@@ -260,14 +341,34 @@ func TestHubSpotEngagementMapping(t *testing.T) {
 	if got := out["direction"]; got != "OUTBOUND" {
 		t.Errorf("direction = %v, want OUTBOUND", got)
 	}
-	if got := out["duration_seconds"]; got != "180000" {
-		t.Errorf("duration_seconds = %v, want the raw hs_call_duration", got)
+	if got, ok := out["duration_seconds"].(int64); !ok || got != 180 {
+		t.Errorf("duration_seconds = %#v, want int64(180) — hs_call_duration is milliseconds, divided to seconds (OVA-MAP-2)", out["duration_seconds"])
 	}
 	if got := out["external_id"]; got != "5501" {
 		t.Errorf("external_id = %v, want 5501", got)
 	}
 	if len(unmapped) != 0 {
 		t.Errorf("unmapped = %v, want none (every rawEngagement property is declared)", unmapped)
+	}
+}
+
+// TestHubSpotCallDurationFidelity is the OVA-MAP-2 golden case: hs_call_duration
+// is HubSpot milliseconds and must be divided to integer seconds before it
+// lands in duration_seconds — storing the raw millisecond value inflates
+// durations ×1000.
+func TestHubSpotCallDurationFidelity(t *testing.T) {
+	m, ok := hubspot.Mapping("engagements")
+	if !ok {
+		t.Fatal("Mapping(engagements): want a declared mapping")
+	}
+	out, _, err := overlay.Apply(m, map[string]any{
+		"hs_object_id": "1", "hs_engagement_type": "CALL", "hs_call_duration": "90000",
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if got, ok := out["duration_seconds"].(int64); !ok || got != 90 {
+		t.Errorf("duration_seconds = %#v, want int64(90) for hs_call_duration=90000ms", out["duration_seconds"])
 	}
 }
 

--- a/backend/internal/modules/overlay/hubspot/mapping_hs_test.go
+++ b/backend/internal/modules/overlay/hubspot/mapping_hs_test.go
@@ -142,8 +142,8 @@ func TestHubSpotContactFullNameFidelity(t *testing.T) {
 		t.Fatalf("Apply (nameless, emailless): %v", err)
 	}
 	got, ok := out["full_name"].(string)
-	if !ok || got == "" {
-		t.Errorf("full_name for a nameless, emailless contact = %#v, want a non-empty placeholder string", out["full_name"])
+	if !ok || got != "(unnamed contact)" {
+		t.Errorf("full_name for a nameless, emailless contact = %#v, want the stable placeholder %q", out["full_name"], "(unnamed contact)")
 	}
 }
 
@@ -282,6 +282,7 @@ func TestHubSpotDealAmountCurrencyFidelity(t *testing.T) {
 		{"JPY exponent 0", "1000", "JPY", 1000},
 		{"EUR exponent 2", "10.00", "EUR", 1000},
 		{"BHD exponent 3", "1.500", "BHD", 1500},
+		{"CLF exponent 4", "1.5000", "CLF", 15000},
 		{"lowercase code uppercased", "10.00", "usd", 1000},
 	}
 	for _, tc := range cases {

--- a/backend/internal/modules/overlay/mapping.go
+++ b/backend/internal/modules/overlay/mapping.go
@@ -200,7 +200,10 @@ func transformAmountMinorByCurrency(v any) (any, error) {
 	}
 	code := strings.ToUpper(strings.TrimSpace(stringField(fields, "deal_currency_code")))
 	amountRaw, hasAmount := fields["amount"]
-	if hasAmount && code != "" {
+	// A nil amount (HubSpot's JSON null for an unset property) is "no amount",
+	// exactly like an absent one — not a type violation. Only a present,
+	// non-nil, non-string amount is the malformed case worth surfacing.
+	if hasAmount && amountRaw != nil && code != "" {
 		amountStr, ok := amountRaw.(string)
 		if !ok {
 			return nil, fmt.Errorf("overlay: amount_minor_by_currency: amount expects a string, got %T", amountRaw)

--- a/backend/internal/modules/overlay/mapping.go
+++ b/backend/internal/modules/overlay/mapping.go
@@ -78,6 +78,13 @@ type FieldMapping struct {
 	Kind      TargetKind
 	Transform string
 	Resolve   string
+	// AlwaysEmit forces a TargetAssembler field to run its Transform even
+	// when the incumbent record carried NONE of its From properties, so the
+	// transform can synthesize a value from nothing — the shape a required,
+	// always-present display field with a fallback needs (person.full_name,
+	// OVA-MAP-3: never left empty). It is meaningless on the other kinds,
+	// whose absence-is-a-no-op behavior is exactly right.
+	AlwaysEmit bool
 }
 
 // ObjectMapping is the code-declared, test-guarded field map for one
@@ -108,10 +115,13 @@ type ObjectMapping struct {
 // lines (returning a typed error on mismatch). The `any` is the data
 // boundary itself, not a missing type — hence the per-transform waivers.
 var transforms = map[string]func(any) (any, error){
-	"lowercase":              transformLowercase,
-	"amount_to_minor":        transformAmountToMinor,
-	"employees_to_size_band": transformEmployeesToSizeBand,
-	"address_json":           transformAddressJSON,
+	"lowercase":                transformLowercase,
+	"uppercase":                transformUppercase,
+	"ms_to_seconds":            transformMsToSeconds,
+	"full_name":                transformFullName,
+	"amount_minor_by_currency": transformAmountMinorByCurrency,
+	"employees_to_size_band":   transformEmployeesToSizeBand,
+	"address_json":             transformAddressJSON,
 }
 
 //craft:ignore naked-any transform seam over untyped incoming JSON property values; asserts concrete type within
@@ -123,10 +133,127 @@ func transformLowercase(v any) (any, error) {
 	return strings.ToLower(s), nil
 }
 
-// transformAmountToMinor parses a HubSpot decimal-string amount (e.g.
-// "1234.5") into integer minor units, rounding half away from zero.
-// HubSpot always renders numeric properties as strings; valueFor already
-// treats an empty string as an absent property, so this never sees "".
+//craft:ignore naked-any transform seam over untyped incoming JSON property values; asserts concrete type within
+func transformUppercase(v any) (any, error) {
+	s, ok := v.(string)
+	if !ok {
+		return nil, fmt.Errorf("overlay: uppercase transform expects a string, got %T", v)
+	}
+	return strings.ToUpper(s), nil
+}
+
+// transformMsToSeconds divides a HubSpot millisecond duration string
+// (hs_call_duration) into integer seconds (OVA-MAP-2). Storing the raw
+// millisecond value inflates durations ×1000. valueFor already treats an
+// empty string as an absent property, so this never sees "".
+//
+//craft:ignore naked-any transform seam over untyped incoming JSON property values; asserts concrete type within
+func transformMsToSeconds(v any) (any, error) {
+	s, ok := v.(string)
+	if !ok {
+		return nil, fmt.Errorf("overlay: ms_to_seconds transform expects a string, got %T", v)
+	}
+	ms, err := strconv.ParseInt(strings.TrimSpace(s), 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("overlay: ms_to_seconds could not parse %q as integer milliseconds: %w", s, err)
+	}
+	return ms / 1000, nil
+}
+
+// transformFullName assembles the required, always-present person.full_name
+// display field (OVA-MAP-3) from a gathered {firstname, lastname, email}
+// property set: firstname + ' ' + lastname trimmed of surrounding
+// whitespace, falling back to the primary email's local part, and only then
+// to a stable non-empty placeholder — a mirrored contact must never surface
+// with an empty full_name. Declared AlwaysEmit so it produces the placeholder
+// even for a contact that carried no name and no email at all.
+//
+//craft:ignore naked-any transform seam over untyped incoming JSON property values; asserts concrete type within
+func transformFullName(v any) (any, error) {
+	fields, ok := v.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("overlay: full_name transform expects a property map, got %T", v)
+	}
+	if name := strings.TrimSpace(stringField(fields, "firstname") + " " + stringField(fields, "lastname")); name != "" {
+		return name, nil
+	}
+	if email := strings.TrimSpace(stringField(fields, "email")); email != "" {
+		if local, _, found := strings.Cut(email, "@"); found && local != "" {
+			return local, nil
+		}
+		return email, nil
+	}
+	return "(unnamed contact)", nil
+}
+
+// transformAmountMinorByCurrency scales a HubSpot decimal-string deal amount
+// to integer minor units by the ISO-4217 minor-unit exponent of its
+// deal_currency_code (OVA-MAP-4) — never a blanket ×100. A deal with no
+// currency code (or no amount) maps amount_minor to null rather than guessing
+// an exponent. The currency column itself is mapped separately (uppercased).
+//
+//craft:ignore naked-any transform seam over untyped incoming JSON property values; asserts concrete type within
+func transformAmountMinorByCurrency(v any) (any, error) {
+	fields, ok := v.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("overlay: amount_minor_by_currency transform expects a property map, got %T", v)
+	}
+	code := strings.ToUpper(strings.TrimSpace(stringField(fields, "deal_currency_code")))
+	amountRaw, hasAmount := fields["amount"]
+	if hasAmount && code != "" {
+		amountStr, ok := amountRaw.(string)
+		if !ok {
+			return nil, fmt.Errorf("overlay: amount_minor_by_currency: amount expects a string, got %T", amountRaw)
+		}
+		if amount := strings.TrimSpace(amountStr); amount != "" {
+			scale := int64(1)
+			for i := 0; i < iso4217MinorUnitExponent(code); i++ {
+				scale *= 10
+			}
+			minor, err := decimalStringToMinor(amount, scale)
+			if err != nil {
+				return nil, fmt.Errorf("overlay: amount_minor_by_currency could not convert %q (%s): %w", amount, code, err)
+			}
+			return minor, nil
+		}
+	}
+	// No amount, no currency code to choose an exponent, or an empty amount:
+	// map amount_minor to null rather than guess a scale (OVA-MAP-4). A nil
+	// value with a nil error is exactly that "null, and not an error" —
+	// applyTransform lands it as a JSON null on the column.
+	return nil, nil //nolint:nilnil // deliberate: null amount_minor is a valid, non-error mapping result
+}
+
+// iso4217MinorUnitExponent returns a currency's minor-unit exponent. Two is
+// ISO-4217's own default and covers the vast majority; the exceptions are the
+// zero-decimal and three-decimal currencies enumerated here. Choosing the
+// exponent from the code — not a blanket ×100 — is what the money model
+// (data-semantics §1 / DM-CONV-9) requires.
+func iso4217MinorUnitExponent(code string) int {
+	switch code {
+	case "BIF", "CLP", "DJF", "GNF", "ISK", "JPY", "KMF", "KRW", "PYG", "RWF", "UGX", "VND", "VUV", "XAF", "XOF", "XPF":
+		return 0
+	case "BHD", "IQD", "JOD", "KWD", "LYD", "OMR", "TND":
+		return 3
+	default:
+		return 2
+	}
+}
+
+// stringField reads a string-valued property from a gathered assembler map,
+// answering "" for an absent or non-string value — the transforms above
+// treat "" as "not provided".
+//
+//craft:ignore naked-any gathered assembler values are decoded incumbent JSON, read by conventional key name
+func stringField(fields map[string]any, key string) string {
+	s, _ := fields[key].(string)
+	return s
+}
+
+// decimalStringToMinor converts an exact decimal string into integer minor
+// units at the given per-major-unit scale (100 for a two-decimal currency,
+// 1 for a zero-decimal currency, 1000 for a three-decimal one — chosen by
+// the caller from the deal's currency code), rounding half away from zero.
 //
 // The conversion is exact (math/big.Rat), NOT via float64: strconv.ParseFloat
 // introduces binary rounding error before the scale — "1.005" parses to
@@ -135,31 +262,6 @@ func transformLowercase(v any) (any, error) {
 // precisely. big.Rat.SetString also rejects non-finite tokens ("NaN",
 // "Inf") that a float parse would accept, and IsInt64 fences an amount too
 // large for the mirror column.
-//
-// Minor units are computed at the two-decimal (×100) exponent. Currencies
-// whose minor unit is not 1/100 (JPY has none, BHD/KWD use 1/1000) are
-// mirrored at the wrong magnitude; correcting that needs the deal's
-// currency code, which this value-level transform seam does not carry —
-// tracked for upstream reconciliation (the ×100 assumption is stated here,
-// never hidden).
-//
-//craft:ignore naked-any transform seam over untyped incoming JSON property values; asserts concrete type within
-func transformAmountToMinor(v any) (any, error) {
-	s, ok := v.(string)
-	if !ok {
-		return nil, fmt.Errorf("overlay: amount_to_minor transform expects a string, got %T", v)
-	}
-	minor, err := decimalStringToMinor(strings.TrimSpace(s), 100)
-	if err != nil {
-		return nil, fmt.Errorf("overlay: amount_to_minor could not convert %q: %w", s, err)
-	}
-	return minor, nil
-}
-
-// decimalStringToMinor converts an exact decimal string into integer minor
-// units at the given per-major-unit scale (100 for a two-decimal currency),
-// rounding half away from zero. It works on big.Rat so no binary float
-// error is ever introduced, and rejects a value that overflows int64.
 func decimalStringToMinor(s string, scale int64) (int64, error) {
 	if len(s) > maxAmountLen {
 		return 0, fmt.Errorf("amount too long")
@@ -341,7 +443,7 @@ func valueFor(f FieldMapping, raw map[string]any) (any, bool, error) {
 				present = true
 			}
 		}
-		if !present {
+		if !present && !f.AlwaysEmit {
 			return nil, false, nil
 		}
 		return applyTransform(f, gathered)

--- a/backend/internal/modules/overlay/mapping.go
+++ b/backend/internal/modules/overlay/mapping.go
@@ -174,7 +174,12 @@ func transformFullName(v any) (any, error) {
 	if !ok {
 		return nil, fmt.Errorf("overlay: full_name transform expects a property map, got %T", v)
 	}
-	if name := strings.TrimSpace(stringField(fields, "firstname") + " " + stringField(fields, "lastname")); name != "" {
+	// Trim each component before joining so a property carrying boundary
+	// whitespace ("Ada ") does not leave a doubled internal space after the
+	// join, while a genuine internal space ("Mary Jane") is preserved.
+	firstName := strings.TrimSpace(stringField(fields, "firstname"))
+	lastName := strings.TrimSpace(stringField(fields, "lastname"))
+	if name := strings.TrimSpace(firstName + " " + lastName); name != "" {
 		return name, nil
 	}
 	if email := strings.TrimSpace(stringField(fields, "email")); email != "" {
@@ -234,10 +239,12 @@ func transformAmountMinorByCurrency(v any) (any, error) {
 // (data-semantics §1 / DM-CONV-9) requires.
 func iso4217MinorUnitExponent(code string) int {
 	switch code {
-	case "BIF", "CLP", "DJF", "GNF", "ISK", "JPY", "KMF", "KRW", "PYG", "RWF", "UGX", "VND", "VUV", "XAF", "XOF", "XPF":
+	case "BIF", "CLP", "DJF", "GNF", "ISK", "JPY", "KMF", "KRW", "PYG", "RWF", "UGX", "UYI", "VND", "VUV", "XAF", "XOF", "XPF":
 		return 0
 	case "BHD", "IQD", "JOD", "KWD", "LYD", "OMR", "TND":
 		return 3
+	case "CLF", "UYW":
+		return 4
 	default:
 		return 2
 	}

--- a/backend/internal/modules/overlay/mapping_test.go
+++ b/backend/internal/modules/overlay/mapping_test.go
@@ -179,13 +179,13 @@ func TestTransformLowercaseRejectsNonString(t *testing.T) {
 func TestTransformAmountToMinorRejectsNonStringAndUnparsable(t *testing.T) {
 	m := overlay.ObjectMapping{
 		Source: "deals", Target: "deal",
-		Fields: []overlay.FieldMapping{{From: []string{"amount"}, To: "amount_minor", Kind: overlay.TargetColumn, Transform: "amount_to_minor"}},
+		Fields: []overlay.FieldMapping{{From: []string{"amount", "deal_currency_code"}, To: "amount_minor", Kind: overlay.TargetAssembler, Transform: "amount_minor_by_currency"}},
 	}
-	if _, _, err := overlay.Apply(m, map[string]any{"amount": 12.5}); err == nil {
-		t.Fatal("Apply: want an error for amount_to_minor applied to a non-string value")
+	if _, _, err := overlay.Apply(m, map[string]any{"amount": 12.5, "deal_currency_code": "EUR"}); err == nil {
+		t.Fatal("Apply: want an error for amount_minor_by_currency applied to a non-string amount")
 	}
-	if _, _, err := overlay.Apply(m, map[string]any{"amount": "not-a-number"}); err == nil {
-		t.Fatal("Apply: want an error for amount_to_minor applied to an unparsable string")
+	if _, _, err := overlay.Apply(m, map[string]any{"amount": "not-a-number", "deal_currency_code": "EUR"}); err == nil {
+		t.Fatal("Apply: want an error for amount_minor_by_currency applied to an unparsable amount")
 	}
 }
 
@@ -278,7 +278,7 @@ func TestApplyRejectsUnknownTransform(t *testing.T) {
 }
 
 // TestApplyAmountToMinorRoundsNegativeHalfAwayFromZero pins the fix for
-// the amount_to_minor rounding bug: the old "int64(f*100+0.5)" idiom
+// the round-half-away-from-zero conversion (decimalStringToMinor): the old "int64(f*100+0.5)" idiom
 // rounds a NEGATIVE amount toward zero (truncation, not rounding),
 // understating the minor-unit magnitude of a deal's amount whenever the
 // source carries a refund/credit (negative) value. -12.567 minor-scaled
@@ -289,11 +289,11 @@ func TestApplyAmountToMinorRoundsNegativeHalfAwayFromZero(t *testing.T) {
 		Source: "deals",
 		Target: "deal",
 		Fields: []overlay.FieldMapping{
-			{From: []string{"amount"}, To: "amount_minor", Kind: overlay.TargetColumn, Transform: "amount_to_minor"},
+			{From: []string{"amount", "deal_currency_code"}, To: "amount_minor", Kind: overlay.TargetAssembler, Transform: "amount_minor_by_currency"},
 		},
 	}
 
-	out, _, err := overlay.Apply(m, map[string]any{"amount": "-12.567"})
+	out, _, err := overlay.Apply(m, map[string]any{"amount": "-12.567", "deal_currency_code": "EUR"})
 	if err != nil {
 		t.Fatalf("Apply returned an error: %v", err)
 	}
@@ -316,10 +316,10 @@ func TestApplyAmountToMinorIsExactNotFloat(t *testing.T) {
 		Source: "deals",
 		Target: "deal",
 		Fields: []overlay.FieldMapping{
-			{From: []string{"amount"}, To: "amount_minor", Kind: overlay.TargetColumn, Transform: "amount_to_minor"},
+			{From: []string{"amount", "deal_currency_code"}, To: "amount_minor", Kind: overlay.TargetAssembler, Transform: "amount_minor_by_currency"},
 		},
 	}
-	out, _, err := overlay.Apply(m, map[string]any{"amount": "1.005"})
+	out, _, err := overlay.Apply(m, map[string]any{"amount": "1.005", "deal_currency_code": "EUR"})
 	if err != nil {
 		t.Fatalf("Apply returned an error: %v", err)
 	}
@@ -336,7 +336,7 @@ func TestApplyAmountToMinorRejectsNonFiniteAndOverflow(t *testing.T) {
 		Source: "deals",
 		Target: "deal",
 		Fields: []overlay.FieldMapping{
-			{From: []string{"amount"}, To: "amount_minor", Kind: overlay.TargetColumn, Transform: "amount_to_minor"},
+			{From: []string{"amount", "deal_currency_code"}, To: "amount_minor", Kind: overlay.TargetAssembler, Transform: "amount_minor_by_currency"},
 		},
 	}
 	// Non-finite, non-numeric, overflow, AND the big.Rat forms that are not
@@ -349,7 +349,7 @@ func TestApplyAmountToMinorRejectsNonFiniteAndOverflow(t *testing.T) {
 		// big.Rat.SetString allocates for it (a resource-exhaustion guard).
 		"1e-1000000", "1e1000000", strings.Repeat("9", 100),
 	} {
-		if _, _, err := overlay.Apply(m, map[string]any{"amount": bad}); err == nil {
+		if _, _, err := overlay.Apply(m, map[string]any{"amount": bad, "deal_currency_code": "EUR"}); err == nil {
 			t.Errorf("Apply(amount=%q): want an error, got none", bad)
 		}
 	}


### PR DESCRIPTION
## What

The first, **value-level** slice of HubSpot mapping-fidelity (spec foundation #1124, OVA-MAP-1..6). Three "silent data corruption" rules the declarative mapping IR carries without touching the adapter/backfill/read-projection seams:

| Rule | Before | After |
|---|---|---|
| **OVA-MAP-2** call duration | `hs_call_duration` stored raw (ms) → durations inflated ×1000 | `ms_to_seconds` transform ÷1000 (90000ms → 90s) |
| **OVA-MAP-3** `full_name` | absent (silently unpopulated) | assembled `firstname + lastname` → email local part → stable placeholder; **never empty** |
| **OVA-MAP-4** deal amount | blanket ×100 (wrong for JPY/BHD) | scaled by the ISO-4217 exponent of `deal_currency_code` (JPY ×1, EUR ×100, BHD ×1000); null when no currency |

## How

- New closed-registry transforms: `uppercase`, `ms_to_seconds`, `full_name`, `amount_minor_by_currency` (replacing `amount_to_minor`; its exact big.Rat core `decimalStringToMinor` stays).
- New `AlwaysEmit` flag on `FieldMapping` so a required-with-fallback assembler (`full_name`) runs even when the record carried none of its source properties — the honest way to guarantee OVA-MAP-3's "never empty".
- ISO-4217 minor-unit exponent table (exp-0 and exp-3 currencies; 2 is the ISO default) — not a guess.

## Tests

Golden **OVA-AC-4** cases pin each rule (`mapping_hs_test.go`): the five call-duration/full-name/currency cases plus the "no currency → null amount_minor" case. A ×100-everywhere, raw-ms, or empty-`full_name` implementation fails by construction. The migrated `amount_minor_by_currency` tests preserve the exact-decimal/rounding/overflow assertions (EUR = ×100). Full `make check-backend` + overlay/compose integration lanes green.

## Scope

This slice is the value-level mapping rules only. The **structural** rules are tracked as follow-on PRs (STATUS.md + backlog):
- **OVA-MAP-1** engagement-class split (calls/meetings/emails/notes/tasks → activity `kind`) — needs the `IncumbentClassFor` 5→`activity` disambiguation.
- **OVA-MAP-5** leads via real Leads API props + contact-association-derived email/company.
- **OVA-MAP-6** null overlay `pipeline_id`/`stage_id` + `raw` + stage→`semantic` for advance-tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves HubSpot overlay mapping fidelity to prevent silent data issues. Converts call durations to seconds, assembles a trimmed and always-present `full_name`, and scales deal amounts by the correct ISO-4217 exponent (now including UYI and CLF/UYW), with nil amounts mapped to null.

- **New Features**
  - OVA-MAP-2: Convert `hs_call_duration` (ms) to `duration_seconds` via `ms_to_seconds` (90000 → 90).
  - OVA-MAP-3: Assemble `full_name` from trimmed `firstname`/`lastname`, falling back to email local part, then a placeholder; `AlwaysEmit` ensures it’s never empty.
  - OVA-MAP-4: Build `amount_minor` via `amount_minor_by_currency` using `deal_currency_code`’s ISO-4217 exponent (JPY ×1, EUR/USD ×100, BHD ×1000, UYI ×1, CLF/UYW ×10000); `currency` is uppercased; null when no currency.

- **Bug Fixes**
  - A present-but-nil deal `amount` now maps `amount_minor` to null, not an error.

<sup>Written for commit 2ef4589e5466a717dd85bd76a45bebb554fed0d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved HubSpot contact name mapping, including reliable fallback values when name fields are unavailable.
  * Added currency-aware deal amount conversion for accurate minor-unit values across currencies.
  * Added automatic conversion of call durations from milliseconds to seconds.

* **Bug Fixes**
  * Corrected handling of missing currencies, invalid amounts, and incomplete contact details.
  * Improved consistency and reliability of derived HubSpot field values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->