### PR TITLE
chore(renovate): floor updates at 7-day minimum release age

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,8 @@
   "postUpdateOptions": ["gomodTidy"],
   "prConcurrentLimit": 5,
   "platformAutomerge": true,
+  "minimumReleaseAge": "7 days",
+  "internalChecksFilter": "strict",
   "packageRules": [
     {
       "matchManagers": ["gomod"],


### PR DESCRIPTION
## Problem

All open Renovate PRs (#167, #168, #171, #172) fail the **frontend** check — not on compatibility, but on our own supply-chain gate. CI runs `pnpm install --frozen-lockfile` under pnpm 11, which enforces a `minimumReleaseAge` policy (~1 day) and rejects any freshly published lockfile entry:

```
[ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION]
  react@19.2.8 was published at 2026-07-21T15:41:27Z,
  within the minimumReleaseAge cutoff (2026-07-21T02:37:22Z)
```

Renovate bumps dependencies within minutes of an npm publish and commits the new lockfile the same night, so pnpm rejects the entry as too fresh. Renovate has no knowledge of the age floor, so it keeps proposing versions CI will refuse.

## Fix

Teach Renovate the same age floor, with margin:

- `minimumReleaseAge: "7 days"` — only propose/keep versions at least 7 days old, comfortably above pnpm's ~1-day gate.
- `internalChecksFilter: "strict"` — hold the PR until the target version clears the age, instead of opening it to fail.

**Security patches are unaffected:** Renovate bypasses `minimumReleaseAge` for `vulnerabilityAlerts` (already configured, `schedule: at any time`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align Renovate with our `pnpm` minimum release age to stop CI from rejecting fresh packages. Renovate now waits 7 days before proposing updates and holds PRs until the age clears; security advisories still bypass this.

- **Dependencies**
  - Set `"minimumReleaseAge": "7 days"` in `renovate.json`.
  - Enabled `"internalChecksFilter": "strict"` to defer PRs until versions meet the age gate.

<sup>Written for commit b1ce4cb8fee5980bcf49567fd2c5400a43105587. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

