### PR TITLE
fix(onboarding): cap website fact selection at the server limit

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -930,7 +930,8 @@ export const de = {
     "Ich habe mehrere Einheiten im Impressum gefunden. Wähle deine und ich trage ihre Daten ein.",
   "ob.factsTitle": "Weitere Fakten, die ich gefunden habe",
   "ob.factsSelected": "{selected} von {total} ausgewählt",
-  "ob.factsSub": "Wähle ab, was nicht Teil des Firmenkontexts werden soll.",
+  "ob.factsSub":
+    "Wähle ab, was nicht Teil des Firmenkontexts werden soll — bis zu 100 Angaben können ausgewählt sein.",
   "ob.nowUnderstands": "Ich verstehe jetzt",
   "ob.contextReady":
     "Ich kann diesen Kontext jetzt für relevante Entwürfe, Suche, Agenten und Voice DNA nutzen — inklusive Herkunft.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -913,7 +913,8 @@ export const en = {
     "I found several entities in the legal notice. Choose yours and I'll fill in its details.",
   "ob.factsTitle": "Other facts I found",
   "ob.factsSelected": "{selected} of {total} selected",
-  "ob.factsSub": "Untick anything that should not become company context.",
+  "ob.factsSub":
+    "Untick anything that should not become company context — up to 100 facts can be selected.",
   "ob.nowUnderstands": "I now understand",
   "ob.contextReady":
     "I can now use this context for relevant drafts, search, agents and Voice DNA — with provenance attached.",

--- a/frontend/src/screens/onboarding.test.tsx
+++ b/frontend/src/screens/onboarding.test.tsx
@@ -108,6 +108,15 @@ const readyRead = {
   updated_at: "2026-07-19T08:00:01Z",
 } as const satisfies CompanySiteRead;
 
+const manyFactsRead = {
+  ...readyRead,
+  facts: Array.from({ length: 101 }, (_, index) => ({
+    ...readyRead.facts[0],
+    value: `Fact ${index}`,
+    value_key: `founded_year:fact-${index}`,
+  })),
+} satisfies CompanySiteRead;
+
 type StubOptions = {
   company?: typeof savedProfile | null;
   state?: Record<string, unknown> | null;
@@ -316,6 +325,59 @@ describe("the optional website path", () => {
       (screen.getByLabelText(/Register \/ VAT ID/) as HTMLInputElement).value,
     ).toBe("HRB 12345 · DE123456789");
     expect(screen.getByText(/founded year/i)).toBeTruthy();
+  });
+
+  it("caps the default fact selection at the server limit", async () => {
+    const calls = stubApi({ read: manyFactsRead });
+    render(<OnboardingScreen />);
+
+    await readWebsite();
+
+    await waitFor(async () => {
+      const stateWrites = calls.filter(
+        (request) =>
+          request.url.includes("/onboarding/state") && request.method === "PUT",
+      );
+      const body = (await stateWrites.at(-1)?.clone().json()) as Record<
+        string,
+        unknown
+      >;
+      expect(body.selected_fact_keys).toHaveLength(100);
+    });
+    expect(
+      (
+        screen.getByRole("button", {
+          name: /Fact 100/,
+          hidden: true,
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(true);
+  });
+
+  it("clears website fact selections when switching to manual entry", async () => {
+    const calls = stubApi();
+    render(<OnboardingScreen />);
+
+    await readWebsite();
+    await userEvent.click(screen.getByRole("button", { name: "Back" }));
+    await userEvent.click(
+      screen
+        .getAllByRole("button", { name: /Tell me instead/ })
+        .at(-1) as HTMLElement,
+    );
+
+    await waitFor(async () => {
+      const stateWrites = calls.filter(
+        (request) =>
+          request.url.includes("/onboarding/state") && request.method === "PUT",
+      );
+      const body = (await stateWrites.at(-1)?.clone().json()) as Record<
+        string,
+        unknown
+      >;
+      expect(body.source_mode).toBe("manual");
+      expect(body.selected_fact_keys).toEqual([]);
+    });
   });
 
   it("keeps manual entry available when the read cannot start", async () => {

--- a/frontend/src/screens/onboarding.tsx
+++ b/frontend/src/screens/onboarding.tsx
@@ -67,6 +67,9 @@ const STEPS = [
 ] as const;
 
 const VOICE_TARGET = 30000;
+// The facts endpoint accepts at most this many selected keys; preselecting
+// more than the API takes would make the default state unsubmittable.
+const MAX_SELECTED_FACTS = 100;
 
 type CompanyProfile = components["schemas"]["CompanyProfile"];
 type ColdField = components["schemas"]["ColdStartField"];
@@ -742,7 +745,12 @@ function OnboardingCoordinator() {
     // both a partner and a named customer — and the API takes a SET of
     // keys, so the selection folds the repeats rather than sending a
     // duplicate it would reject.
-    setSelectedFactKeys([...new Set(read.facts.map((fact) => fact.value_key))]);
+    setSelectedFactKeys(
+      [...new Set(read.facts.map((fact) => fact.value_key))].slice(
+        0,
+        MAX_SELECTED_FACTS,
+      ),
+    );
   }, [siteRead.data]);
 
   const go = (next: number, persist = true) => {
@@ -975,7 +983,12 @@ function OnboardingCoordinator() {
             }}
             onChooseManual={() => {
               setSourceMode("manual");
-              persistState(0, { sourceMode: "manual", siteReadID: null });
+              setSelectedFactKeys([]);
+              persistState(0, {
+                sourceMode: "manual",
+                siteReadID: null,
+                selectedFactKeys: [],
+              });
             }}
             onStart={() => startRead.mutate()}
             onContinue={() => {
@@ -1355,12 +1368,15 @@ function CompanyStep({
           <div className="fact-grid">
             {read.facts.map((fact) => {
               const selected = selectedFactKeys.includes(fact.value_key);
+              const selectionFull =
+                !selected && selectedFactKeys.length >= MAX_SELECTED_FACTS;
               return (
                 <button
                   key={`${fact.field}:${fact.value_key}`}
                   type="button"
                   className={`fact-card ${selected ? "selected" : ""}`}
                   aria-pressed={selected}
+                  disabled={selectionFull}
                   onClick={() =>
                     setSelectedFactKeys(
                       selected


### PR DESCRIPTION
## Summary
- Preselecting every fact from a website read could exceed the 100-key limit the facts endpoint accepts, leaving the default state unsubmittable. The preselection now dedupes and caps at `MAX_SELECTED_FACTS = 100`.
- A fact card that would exceed the cap is disabled instead of silently failing on submit.
- Switching to the manual path clears any website fact selection so a manual profile never carries read facts.
- The facts subtitle in EN/DE states the cap.

## Testing
- `make check-fe` green in a clean worktree; the two new vitest cases cover the cap and the manual-path clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps onboarding website fact preselection at 100 to match the server limit, preventing submit errors. Adds UI guardrails and updates copy so the limit is clear.

- **Bug Fixes**
  - Dedupes and caps selected fact keys at 100.
  - Disables fact cards that would exceed the cap.
  - Clears website fact selections when switching to manual entry.
  - Updates EN/DE i18n subtitles to mention the 100-fact limit.

<sup>Written for commit ecf22f5f196048a43e1e85831b5b8d92a1f6d35e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a limit of 100 selectable company facts during onboarding.
  - Prevented selecting additional facts once the limit is reached while allowing existing selections to be removed.
  - Switching to manual entry now clears previously selected facts.
  - Updated onboarding guidance in English and German to explain the selection limit.

- **Bug Fixes**
  - Ensured selections are deduplicated and capped at 100 before being saved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->