### PR TITLE
feat(overlay): leads via real Leads API props + contact association (OVA-MAP-5)

### DIFF
--- a/backend/internal/modules/overlay/backfill.go
+++ b/backend/internal/modules/overlay/backfill.go
@@ -45,6 +45,10 @@ type MirrorSink interface {
 var backfillAssocTargets = func() map[string][]string {
 	m := map[string][]string{
 		IncumbentClassDeals: {IncumbentClassCompanies},
+		// A lead's required contact association (OVA-MAP-5): the edge is stored,
+		// and the adapter denormalizes the contact's email/company_name onto
+		// the lead record from the same association.
+		IncumbentClassLeads: {IncumbentClassContacts},
 	}
 	for _, engagement := range incumbentEngagementClasses {
 		m[engagement] = []string{IncumbentClassContacts, IncumbentClassCompanies, IncumbentClassDeals, IncumbentClassLeads}

--- a/backend/internal/modules/overlay/backfill.go
+++ b/backend/internal/modules/overlay/backfill.go
@@ -45,11 +45,14 @@ type MirrorSink interface {
 var backfillAssocTargets = func() map[string][]string {
 	m := map[string][]string{
 		IncumbentClassDeals: {IncumbentClassCompanies},
-		// A lead's required contact association (OVA-MAP-5): the edge is stored,
-		// and the adapter denormalizes the contact's email/company_name onto
-		// the lead record from the same association.
-		IncumbentClassLeads: {IncumbentClassContacts},
 	}
+	// A lead's contact association is NOT stored as an edge here: the adapter
+	// denormalizes the contact's email/company_name onto the lead record
+	// (adapter.enrichLeads, OVA-MAP-5), and there is no read-time association
+	// join over the edge yet — storing it would double the leads→contacts API
+	// lookup (enrichLeads already resolves it) and leave a stale edge on a
+	// later reassociation for no current reader. When a context-graph read
+	// over lead↔contact lands, persist the edge there.
 	for _, engagement := range incumbentEngagementClasses {
 		m[engagement] = []string{IncumbentClassContacts, IncumbentClassCompanies, IncumbentClassDeals, IncumbentClassLeads}
 	}

--- a/backend/internal/modules/overlay/hubspot/adapter.go
+++ b/backend/internal/modules/overlay/hubspot/adapter.go
@@ -15,6 +15,7 @@ package hubspot
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/gradionhq/margince/backend/internal/modules/overlay"
@@ -78,6 +79,10 @@ func (a *Adapter) Backfill(ctx context.Context, objectClass, cursor string) (ove
 	if err != nil {
 		return overlay.Page{}, err
 	}
+	records, err = a.enrichLeads(ctx, objectClass, records)
+	if err != nil {
+		return overlay.Page{}, err
+	}
 	return overlay.Page{Records: records, NextCursor: page.NextAfter}, nil
 }
 
@@ -98,6 +103,10 @@ func (a *Adapter) Modified(ctx context.Context, objectClass string, since time.T
 		return overlay.Page{}, err
 	}
 	records, err := mapRecords(m, objectClass, page.Results)
+	if err != nil {
+		return overlay.Page{}, err
+	}
+	records, err = a.enrichLeads(ctx, objectClass, records)
 	if err != nil {
 		return overlay.Page{}, err
 	}
@@ -207,6 +216,67 @@ func (a *Adapter) Associations(ctx context.Context, fromClass, fromID, toClass s
 		}
 	}
 	return out, nil
+}
+
+// leadContactProps are the associated contact's properties a lead
+// denormalizes (OVA-MAP-5): email and the free-text company name.
+var leadContactProps = []string{"email", "company"}
+
+// enrichLeads denormalizes each lead's email and company_name from the
+// contact reached through its REQUIRED contact association (OVA-MAP-5) — the
+// Leads object carries neither. It is a no-op for any other object class. A
+// lead with no contact association keeps both absent, so the wire surfaces
+// null rather than an invented value.
+//
+// It resolves one association per lead (leads are low-volume; the
+// per-lead association lookup is bounded by the page size) and then batch-
+// reads the distinct contacts in a single call.
+func (a *Adapter) enrichLeads(ctx context.Context, objectClass string, records []overlay.Record) ([]overlay.Record, error) {
+	if objectClass != objectClassLeads || len(records) == 0 {
+		return records, nil
+	}
+	contactByLead := make(map[string]string, len(records))
+	seen := make(map[string]bool)
+	var contactIDs []string
+	for _, rec := range records {
+		assocs, err := a.client.Associations(ctx, objectClassLeads, rec.ExternalID, objectClassContacts)
+		if err != nil {
+			return nil, fmt.Errorf("hubspot: resolving the contact association for lead %s: %w", rec.ExternalID, err)
+		}
+		if len(assocs) == 0 {
+			continue // no contact association — email/company_name stay null
+		}
+		cid := assocs[0].ToObjectID
+		contactByLead[rec.ExternalID] = cid
+		if !seen[cid] {
+			seen[cid] = true
+			contactIDs = append(contactIDs, cid)
+		}
+	}
+	if len(contactIDs) == 0 {
+		return records, nil
+	}
+	contacts, err := a.client.BatchRead(ctx, objectClassContacts, contactIDs, leadContactProps)
+	if err != nil {
+		return nil, fmt.Errorf("hubspot: batch-reading the contacts leads are associated to: %w", err)
+	}
+	byID := make(map[string]ObjectRecord, len(contacts))
+	for _, c := range contacts {
+		byID[c.ID] = c
+	}
+	for i := range records {
+		c, ok := byID[contactByLead[records[i].ExternalID]]
+		if !ok {
+			continue
+		}
+		if email := strings.ToLower(strings.TrimSpace(c.Properties["email"])); email != "" {
+			records[i].Fields["email"] = email
+		}
+		if company := strings.TrimSpace(c.Properties["company"]); company != "" {
+			records[i].Fields["company_name"] = company
+		}
+	}
+	return records, nil
 }
 
 // OwnerEmail resolves a HubSpot owner id to its email via the Owners API

--- a/backend/internal/modules/overlay/hubspot/adapter.go
+++ b/backend/internal/modules/overlay/hubspot/adapter.go
@@ -169,7 +169,19 @@ func (a *Adapter) Get(ctx context.Context, objectClass, externalID string) (over
 	if len(recs) == 0 {
 		return overlay.Record{}, fmt.Errorf("hubspot: no %s record with external id %s", objectClass, externalID)
 	}
-	return mapRecord(m, objectClass, recs[0])
+	rec, err := mapRecord(m, objectClass, recs[0])
+	if err != nil {
+		return overlay.Record{}, err
+	}
+	// A force-fresh single-record read must return the SAME shape as backfill
+	// / incremental (OVA-MAP-5): a lead's email/company_name are denormalized
+	// from its contact association, so enrich here too rather than returning a
+	// bare lead missing them.
+	enriched, err := a.enrichLeads(ctx, objectClass, []overlay.Record{rec})
+	if err != nil {
+		return overlay.Record{}, err
+	}
+	return enriched[0], nil
 }
 
 // Associations lists the v4 association edges from fromID (of fromClass)
@@ -231,6 +243,16 @@ var leadContactProps = []string{"email", "company"}
 // It resolves one association per lead (leads are low-volume; the
 // per-lead association lookup is bounded by the page size) and then batch-
 // reads the distinct contacts in a single call.
+//
+// Staleness bound (denormalization, not a live join): these fields refresh
+// when the LEAD is next swept — its own Modified watermark, or a backfill.
+// A contact-only email/company change (the lead's watermark unchanged) is
+// not observed until then, because the incremental sweep is per-object and
+// there is no contact→lead dependency propagation yet. That propagation
+// (re-ingesting a contact's associated leads when the contact changes) is
+// tracked with the incremental-association-sync work (A7), not built here;
+// a read-time association join, once it lands, would remove the bound
+// entirely.
 func (a *Adapter) enrichLeads(ctx context.Context, objectClass string, records []overlay.Record) ([]overlay.Record, error) {
 	if objectClass != objectClassLeads || len(records) == 0 {
 		return records, nil

--- a/backend/internal/modules/overlay/hubspot/adapter_test.go
+++ b/backend/internal/modules/overlay/hubspot/adapter_test.go
@@ -249,6 +249,83 @@ func TestAdapterGetNoResultsErrorsCleanly(t *testing.T) {
 	}
 }
 
+// TestAdapterEnrichLeadsDerivesContactFields is the OVA-MAP-5 golden proof:
+// a lead's full_name comes from the real hs_lead_name property, and its
+// email/company_name are denormalized from the contact reached through the
+// lead's required contact association — never from non-existent lead
+// properties.
+func TestAdapterEnrichLeadsDerivesContactFields(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/crm/v3/objects/leads":
+			_, _ = w.Write([]byte(`{"results":[{"id":"7701","properties":{
+				"hs_object_id":"7701","hs_lastmodifieddate":"2026-06-03T00:00:00.000Z",
+				"hs_lead_name":"Erika Musterfrau","hubspot_owner_id":"owner-3"}}]}`))
+		case "/crm/v4/objects/leads/7701/associations/contacts":
+			_, _ = w.Write([]byte(`{"results":[{"toObjectId":"555","associationTypes":[{"category":"HUBSPOT_DEFINED","typeId":1}]}]}`))
+		case "/crm/v3/objects/contacts/batch/read":
+			_, _ = w.Write([]byte(`{"results":[{"id":"555","properties":{
+				"email":"Erika@Example.DE","company":"Musterfrau Consulting"}}]}`))
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	adapter := hubspot.NewAdapter(hubspot.NewClient("us", "test-token", hubspot.WithBaseURL(srv.URL)))
+	page, err := adapter.Backfill(t.Context(), "leads", "")
+	if err != nil {
+		t.Fatalf("Backfill(leads): %v", err)
+	}
+	if len(page.Records) != 1 {
+		t.Fatalf("len(records) = %d, want 1", len(page.Records))
+	}
+	f := page.Records[0].Fields
+	if f["full_name"] != "Erika Musterfrau" {
+		t.Errorf("full_name = %v, want Erika Musterfrau (from hs_lead_name)", f["full_name"])
+	}
+	if f["email"] != "erika@example.de" {
+		t.Errorf("email = %v, want erika@example.de (lowercased, from the associated contact)", f["email"])
+	}
+	if f["company_name"] != "Musterfrau Consulting" {
+		t.Errorf("company_name = %v, want the associated contact's company", f["company_name"])
+	}
+}
+
+// TestAdapterEnrichLeadsLeavesFieldsAbsentWithoutAssociation proves a lead
+// with no contact association keeps email/company_name absent (OVA-MAP-5:
+// null rather than invented), and never calls the contact batch-read.
+func TestAdapterEnrichLeadsLeavesFieldsAbsentWithoutAssociation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/crm/v3/objects/leads":
+			_, _ = w.Write([]byte(`{"results":[{"id":"7702","properties":{"hs_object_id":"7702","hs_lastmodifieddate":"2026-06-03T00:00:00.000Z","hs_lead_name":"No Contact"}}]}`))
+		case r.URL.Path == "/crm/v4/objects/leads/7702/associations/contacts":
+			_, _ = w.Write([]byte(`{"results":[]}`))
+		case strings.HasSuffix(r.URL.Path, "/batch/read"):
+			t.Errorf("batch/read must not be called when a lead has no contact association")
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	adapter := hubspot.NewAdapter(hubspot.NewClient("us", "test-token", hubspot.WithBaseURL(srv.URL)))
+	page, err := adapter.Backfill(t.Context(), "leads", "")
+	if err != nil {
+		t.Fatalf("Backfill(leads): %v", err)
+	}
+	f := page.Records[0].Fields
+	if _, present := f["email"]; present {
+		t.Errorf("email = %v, want absent for a lead with no contact association", f["email"])
+	}
+	if _, present := f["company_name"]; present {
+		t.Errorf("company_name = %v, want absent for a lead with no contact association", f["company_name"])
+	}
+}
+
 // TestAdapterAssociationsNamespacesEngagementEndpoints proves an
 // engagement-to-engagement edge namespaces BOTH endpoints (OVA-MAP-7): the
 // stored edge references the namespaced mirror ids so it joins/purges with

--- a/backend/internal/modules/overlay/hubspot/adapter_test.go
+++ b/backend/internal/modules/overlay/hubspot/adapter_test.go
@@ -293,6 +293,39 @@ func TestAdapterEnrichLeadsDerivesContactFields(t *testing.T) {
 	}
 }
 
+// TestAdapterGetEnrichesLeadContactFields proves the force-fresh single-record
+// path returns the SAME shape as backfill (OVA-MAP-5): Get("leads", ...) also
+// denormalizes the associated contact's email/company_name, not a bare lead.
+func TestAdapterGetEnrichesLeadContactFields(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/crm/v3/objects/leads/batch/read":
+			_, _ = w.Write([]byte(`{"results":[{"id":"7701","properties":{
+				"hs_object_id":"7701","hs_lastmodifieddate":"2026-06-03T00:00:00.000Z","hs_lead_name":"Erika Musterfrau"}}]}`))
+		case "/crm/v4/objects/leads/7701/associations/contacts":
+			_, _ = w.Write([]byte(`{"results":[{"toObjectId":"555","associationTypes":[{"category":"HUBSPOT_DEFINED","typeId":1}]}]}`))
+		case "/crm/v3/objects/contacts/batch/read":
+			_, _ = w.Write([]byte(`{"results":[{"id":"555","properties":{"email":"erika@example.de","company":"Musterfrau Consulting"}}]}`))
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	adapter := hubspot.NewAdapter(hubspot.NewClient("us", "test-token", hubspot.WithBaseURL(srv.URL)))
+	rec, err := adapter.Get(t.Context(), "leads", "7701")
+	if err != nil {
+		t.Fatalf("Get(leads): %v", err)
+	}
+	if rec.Fields["email"] != "erika@example.de" {
+		t.Errorf("email = %v, want the associated contact's email (force-fresh must enrich like backfill)", rec.Fields["email"])
+	}
+	if rec.Fields["company_name"] != "Musterfrau Consulting" {
+		t.Errorf("company_name = %v, want the associated contact's company", rec.Fields["company_name"])
+	}
+}
+
 // TestAdapterEnrichLeadsLeavesFieldsAbsentWithoutAssociation proves a lead
 // with no contact association keeps email/company_name absent (OVA-MAP-5:
 // null rather than invented), and never calls the contact batch-read.

--- a/backend/internal/modules/overlay/hubspot/mapping_hs.go
+++ b/backend/internal/modules/overlay/hubspot/mapping_hs.go
@@ -349,12 +349,15 @@ var tasksMapping = overlay.ObjectMapping{
 // derived from the lead's REQUIRED contact association (adapter.enrichLeads),
 // with company_name staying free text (never an org FK, per the Lead schema).
 //
-// Two deliberate deferrals, both flagged (surfaced via Apply's unmapped list
-// or left at the wire default), never invented:
-//   - `hs_lead_label` → lead.status: mapping HubSpot's free-form label into
-//     the fixed status enum needs an enum-remapping transform not in the
-//     closed registry — the same "flag, don't invent" deferral the
-//     email-direction / meeting-status remaps take, pending a real capture.
+// Two deliberate deferrals, never invented:
+//   - `hs_lead_label` → lead.status: the raw label is REQUESTED and preserved
+//     in raw (under its own incumbent key), so it actually rides the mirror
+//     record rather than being silently dropped; the typed status enum remap
+//     still waits on a documented transform + a real capture, the same
+//     "flag, don't invent" deferral the email-direction / meeting-status
+//     remaps take. (A comment-only claim of "surfaced" would be false: a
+//     property no FieldMapping names is never requested from HubSpot, so it
+//     would never appear — mapping it to raw is what makes the deferral real.)
 //   - a lead with NO contact association keeps email/company_name null rather
 //     than inventing them.
 var leadsMapping = overlay.ObjectMapping{
@@ -365,6 +368,7 @@ var leadsMapping = overlay.ObjectMapping{
 	UnmappedPolicy: unmappedPolicyFlag,
 	Fields: []overlay.FieldMapping{
 		{From: []string{"hs_lead_name"}, To: targetFullName, Kind: overlay.TargetColumn},
+		{From: []string{"hs_lead_label"}, To: "hs_lead_label", Kind: overlay.TargetColumn},
 		ownerIDField,
 	},
 }

--- a/backend/internal/modules/overlay/hubspot/mapping_hs.go
+++ b/backend/internal/modules/overlay/hubspot/mapping_hs.go
@@ -341,16 +341,22 @@ var tasksMapping = overlay.ObjectMapping{
 	},
 }
 
-// leadsMapping is the design.md §9 leads→lead subset (portals with the
-// Leads object). `status` is a deliberate target-side gap: §9 calls for
-// mapping HubSpot's free-form lead status into the fixed
-// new/working/promoted/disqualified enum, which needs an enum-remapping
-// transform NOT in the closed registry ({lowercase, uppercase,
-// ms_to_seconds, full_name, amount_minor_by_currency,
-// employees_to_size_band, address_json}) — per the "flag, don't invent"
-// rule this slice does not add one (the real Leads API mapping, OVA-MAP-5,
-// is a later slice). status is left unconsumed so Apply's unmapped []string
-// surfaces it, exactly like companies' domain.
+// leadsMapping is the leads→lead subset via the REAL HubSpot Leads object
+// properties (OVA-MAP-5): a standard lead carries its own `hs_lead_name`
+// (→ full_name), never the `name`/`email`/`company` a contact carries — those
+// property names do not exist on the Leads object and were the prior mapping's
+// invention. A lead's email and company_name are NOT lead properties: they are
+// derived from the lead's REQUIRED contact association (adapter.enrichLeads),
+// with company_name staying free text (never an org FK, per the Lead schema).
+//
+// Two deliberate deferrals, both flagged (surfaced via Apply's unmapped list
+// or left at the wire default), never invented:
+//   - `hs_lead_label` → lead.status: mapping HubSpot's free-form label into
+//     the fixed status enum needs an enum-remapping transform not in the
+//     closed registry — the same "flag, don't invent" deferral the
+//     email-direction / meeting-status remaps take, pending a real capture.
+//   - a lead with NO contact association keeps email/company_name null rather
+//     than inventing them.
 var leadsMapping = overlay.ObjectMapping{
 	Source:         objectClassLeads,
 	Target:         "lead",
@@ -358,8 +364,7 @@ var leadsMapping = overlay.ObjectMapping{
 	Baseline:       baselineHSLastModifiedDate,
 	UnmappedPolicy: unmappedPolicyFlag,
 	Fields: []overlay.FieldMapping{
-		{From: []string{propName}, To: targetFullName, Kind: overlay.TargetColumn},
-		{From: []string{propEmail}, To: propEmail, Kind: overlay.TargetColumn},
-		{From: []string{"company"}, To: "company_name", Kind: overlay.TargetColumn},
+		{From: []string{"hs_lead_name"}, To: targetFullName, Kind: overlay.TargetColumn},
+		ownerIDField,
 	},
 }

--- a/backend/internal/modules/overlay/hubspot/mapping_hs_test.go
+++ b/backend/internal/modules/overlay/hubspot/mapping_hs_test.go
@@ -470,10 +470,14 @@ func TestHubSpotLeadMapping(t *testing.T) {
 		t.Errorf("company_name = %v, want absent from Apply (contact-association-derived)", out["company_name"])
 	}
 
-	// hs_lead_label → status needs an enum-remapping transform outside the
-	// closed registry — flagged (surfaced as unmapped), not invented.
-	if !containsString(unmapped, "hs_lead_label") {
-		t.Errorf("unmapped = %v, want it to contain %q (status enum remap deferred)", unmapped, "hs_lead_label")
+	// hs_lead_label is REQUESTED and preserved in raw under its incumbent key
+	// (so the deferral is real, not comment-only); the typed status enum remap
+	// is what's deferred, and the wire keeps status at its default until then.
+	if got := out["hs_lead_label"]; got != "NEW" {
+		t.Errorf("hs_lead_label = %v, want the raw incumbent label NEW preserved in the record", got)
+	}
+	if containsString(unmapped, "hs_lead_label") {
+		t.Errorf("unmapped = %v, must NOT contain hs_lead_label (it is mapped to raw, not dropped)", unmapped)
 	}
 }
 

--- a/backend/internal/modules/overlay/hubspot/mapping_hs_test.go
+++ b/backend/internal/modules/overlay/hubspot/mapping_hs_test.go
@@ -427,15 +427,18 @@ func TestHubSpotTaskTimestampFidelity(t *testing.T) {
 	}
 }
 
-// rawLead is a §9-shaped HubSpot lead properties map.
+// rawLead is a HubSpot Leads-object properties map using the REAL Leads API
+// property names (OVA-MAP-5) — hs_lead_name / hs_lead_label — never the
+// name/email/company a contact carries (those do not exist on the Leads
+// object). email and company_name are NOT lead properties: they come from
+// the associated contact (see TestAdapterEnrichLeadsDerivesContactFields).
 func rawLead() map[string]any {
 	return map[string]any{
 		"hs_object_id":        "7701",
 		"hs_lastmodifieddate": "2026-06-03T00:00:00.000Z",
-		"name":                "Erika Musterfrau",
-		"email":               "erika@example.de",
-		"company":             "Musterfrau Consulting",
-		"status":              "NEW",
+		"hs_lead_name":        "Erika Musterfrau",
+		"hs_lead_label":       "NEW",
+		"hubspot_owner_id":    "owner-3",
 	}
 }
 
@@ -450,20 +453,27 @@ func TestHubSpotLeadMapping(t *testing.T) {
 		t.Fatalf("Apply returned an error: %v", err)
 	}
 
+	// full_name comes from the real hs_lead_name property (OVA-MAP-5).
 	if got := out["full_name"]; got != "Erika Musterfrau" {
-		t.Errorf("full_name = %v, want Erika Musterfrau", got)
+		t.Errorf("full_name = %v, want Erika Musterfrau (from hs_lead_name)", got)
 	}
-	if got := out["email"]; got != "erika@example.de" {
-		t.Errorf("email = %v, want erika@example.de", got)
+	// The lead maps its owner (visibility), like every other class.
+	if got := out["owner_id"]; got != "owner-3" {
+		t.Errorf("owner_id = %v, want owner-3", got)
 	}
-	if got := out["company_name"]; got != "Musterfrau Consulting" {
-		t.Errorf("company_name = %v, want Musterfrau Consulting", got)
+	// email / company_name are NOT lead properties — Apply leaves them absent;
+	// they are denormalized from the associated contact by the adapter.
+	if _, present := out["email"]; present {
+		t.Errorf("email = %v, want absent from Apply (it is contact-association-derived, not a lead property)", out["email"])
+	}
+	if _, present := out["company_name"]; present {
+		t.Errorf("company_name = %v, want absent from Apply (contact-association-derived)", out["company_name"])
 	}
 
-	// status needs an enum-remapping transform outside the closed
-	// registry (mapping_hs.go doc comment) — flagged, not invented.
-	if !containsString(unmapped, "status") {
-		t.Errorf("unmapped = %v, want it to contain %q", unmapped, "status")
+	// hs_lead_label → status needs an enum-remapping transform outside the
+	// closed registry — flagged (surfaced as unmapped), not invented.
+	if !containsString(unmapped, "hs_lead_label") {
+		t.Errorf("unmapped = %v, want it to contain %q (status enum remap deferred)", unmapped, "hs_lead_label")
 	}
 }
 


### PR DESCRIPTION
## What (OVA-MAP-5)

The lead mapping relied on `name`/`email`/`company` — property names the HubSpot **Leads** object doesn't carry (those are a *contact's*). This fixes it to the real Leads API shape:

- **`full_name`** ← the real `hs_lead_name` property (invented `name`/`email`/`company` mappings removed).
- **`email` / `company_name`** ← the lead's **required contact association**: the adapter resolves each lead's contact (`leads→contacts` added to the backfill association targets), batch-reads that contact's `email`+`company`, and denormalizes them onto the lead record. No association → both stay **null** (never invented); email lowercased to match the contact mapping.
- **owner** field added to leads (`ownerIDField`) — they were ingesting **invisible**, the same defect the engagement split fixed.
- **`hs_lead_label` → status**: a flagged deferral (enum remap needs a documented transform + a real capture, like the email-direction/meeting-status gaps), surfaced via `unmapped` rather than invented.

## Tests
- Mapping test: `full_name` from `hs_lead_name`, owner mapped, `email`/`company_name` absent from `Apply` (they're association-derived).
- Adapter golden: `TestAdapterEnrichLeadsDerivesContactFields` (email/company resolve through the associated contact, lowercased) and `TestAdapterEnrichLeadsLeavesFieldsAbsentWithoutAssociation` (null + never calls the contact batch-read).
- `make check-backend` + overlay/compose integration lanes green.

## Note
HubSpot Leads is a newer object with no captured wire sample; the pinned property names (`hs_lead_name`, `hs_lead_label`) come from the spec (OVA-MAP-5), and anything unverified is flagged, not invented. The per-lead association lookup is bounded by page size (leads are low-volume) + a single batched contact read.

## Scope
A6.4 (OVA-MAP-6 null pipeline/stage) is the remaining A6 slice — next PR (the contract-nullable change + native-deals ripple, per your go-ahead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches leads to the real HubSpot Leads schema and derives `email`/`company_name` from the associated contact (OVA-MAP-5). Aligns single-record `Get` with backfill, preserves `hs_lead_label` in raw, and removes the unused leads→contacts backfill edge.

- **New Features**
  - Enrichment: resolve the required contact association and batch-read contacts to denormalize `email` (lowercased) and `company`→`company_name`. Null when no association.
  - `Get("leads")` now returns the same enriched shape as backfill/incremental.
  - Leads now include `owner_id`.

- **Bug Fixes**
  - `full_name` maps from `hs_lead_name`. Removed invented lead `name`/`email`/`company` props.
  - `hs_lead_label` is requested and preserved in raw; typed `status` enum remains deferred.
  - Dropped the leads→contacts backfill edge to avoid double lookups and stale edges.

<sup>Written for commit a0aa8e02f697c48b6671868bca8c96714c966dab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

