### PR TITLE
feat(overlay): null overlay deal pipeline_id/stage_id (OVA-MAP-6)

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -8068,8 +8068,8 @@ components:
         currency: { type: [string, 'null'], pattern: '^[A-Z]{3}$' }
         fx_rate_to_base: { type: [string, 'null'], description: 'Native→base, frozen at close (null while open). Decimal-as-string to avoid float rounding of the 10-dp rate.' }
         fx_rate_date: { type: [string, 'null'], format: date }
-        pipeline_id: { type: string, format: uuid }
-        stage_id: { type: string, format: uuid, description: Must belong to pipeline_id. }
+        pipeline_id: { type: [string, 'null'], format: uuid, description: 'Native mode: always a non-null pipeline FK. Overlay mode: NULL — an overlay-mirror deal has no native Margince pipeline row; the incumbent''s own pipeline id rides `raw` and the code-declared stage→semantic mapping drives tier resolution (overlay-augmentation OVA-MAP-6). A zero/placeholder UUID here is forbidden (dangling FK).' }
+        stage_id: { type: [string, 'null'], format: uuid, description: 'Native mode: always a non-null stage FK; must belong to pipeline_id. Overlay mode: NULL (see pipeline_id; the incumbent dealstage id rides `raw`, OVA-MAP-6).' }
         organization_id: { type: [string, 'null'], format: uuid, description: Primary org; never a raw lead. }
         partner_org_id: { type: [string, 'null'], format: uuid, description: 'Deal registration/attribution to a partner org (A38/A41/ADR-0032). The org must have a `partner` row.' }
         owner_id: { type: [string, 'null'], format: uuid }

--- a/backend/internal/compose/overlaywire.go
+++ b/backend/internal/compose/overlaywire.go
@@ -135,14 +135,14 @@ func overlayWireOrganization(ctx context.Context, rec datasource.Record) (crmcon
 }
 
 // overlayWireDeal assembles the contract Deal from a mirror record.
-// pipeline_id/stage_id are REQUIRED as row UUIDs by the contract, but
-// the mirror holds the incumbent's own string identifiers (HubSpot
-// pipeline/stage keys) that reference no native row — they ride raw,
-// and the UUID slots stay zero: an honest "no native pipeline/stage row
-// exists in overlay mode", never a fabricated reference. status is
-// derived from HubSpot's canonical closed-stage keys (closedwon/
-// closedlost); a custom pipeline's closed stages answer open until the
-// design §9 stage-semantic derivation lands with the write path.
+// pipeline_id/stage_id are NULL in overlay mode (OVA-MAP-6): the contract
+// makes them nullable ([string,'null']), and an overlay-mirror deal has no
+// native Margince pipeline/stage row to reference — so the wire leaves both
+// nil (never a fabricated/zero UUID, a forbidden dangling FK). The
+// incumbent's own pipeline/dealstage identifiers ride raw. status is derived
+// from HubSpot's canonical closed-stage keys (closedwon/closedlost); a custom
+// pipeline's closed stages answer open until the stage-semantic derivation
+// lands with the write path (branch 2).
 func overlayWireDeal(ctx context.Context, rec datasource.Record) (crmcontracts.Deal, error) {
 	fields, err := overlayRecordFields(rec)
 	if err != nil {

--- a/backend/internal/compose/overlaywire_test.go
+++ b/backend/internal/compose/overlaywire_test.go
@@ -113,6 +113,30 @@ func TestOverlayWireDealParsesAmountAndCloseDate(t *testing.T) {
 	}
 }
 
+// TestOverlayWireDealNullsPipelineAndStage is the OVA-MAP-6 contract proof:
+// an overlay-mirror deal reads with NULL pipeline_id/stage_id (never a
+// fabricated/zero UUID — a forbidden dangling FK), while the incumbent's own
+// pipeline/dealstage identifiers ride raw.
+func TestOverlayWireDealNullsPipelineAndStage(t *testing.T) {
+	rec := wireRecord(t, datasource.EntityDeal, map[string]any{
+		"name": "Acme", "pipeline_id": "default", "stage_id": "appointmentscheduled",
+	})
+	deal, err := overlayWireDeal(wireCtx(), rec)
+	if err != nil {
+		t.Fatalf("overlayWireDeal: %v", err)
+	}
+	if deal.PipelineId != nil {
+		t.Errorf("PipelineId = %v, want nil (overlay has no native pipeline row — OVA-MAP-6)", *deal.PipelineId)
+	}
+	if deal.StageId != nil {
+		t.Errorf("StageId = %v, want nil (overlay has no native stage row — OVA-MAP-6)", *deal.StageId)
+	}
+	// The incumbent identifiers ride raw, never lost.
+	if deal.Raw == nil || (*deal.Raw)["pipeline_id"] != "default" || (*deal.Raw)["stage_id"] != "appointmentscheduled" {
+		t.Errorf("raw = %v, want the incumbent pipeline/dealstage identifiers preserved", deal.Raw)
+	}
+}
+
 func TestFieldInt64RejectsNonIntegralNumbers(t *testing.T) {
 	for name, v := range map[string]any{
 		"fractional": 1.5, "huge": 1e19, "nan": math.NaN(), "inf": math.Inf(1), "text": "12.5",

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -7778,13 +7778,15 @@ type Deal struct {
 	OwnerId        *openapi_types.UUID `json:"owner_id,omitempty"`
 
 	// PartnerOrgId Deal registration/attribution to a partner org (A38/A41/ADR-0032). The org must have a `partner` row.
-	PartnerOrgId *openapi_types.UUID     `json:"partner_org_id,omitempty"`
-	PipelineId   openapi_types.UUID      `json:"pipeline_id"`
-	Raw          *map[string]interface{} `json:"raw,omitempty"`
-	Source       string                  `json:"source"`
+	PartnerOrgId *openapi_types.UUID `json:"partner_org_id,omitempty"`
 
-	// StageId Must belong to pipeline_id.
-	StageId openapi_types.UUID `json:"stage_id"`
+	// PipelineId Native mode: always a non-null pipeline FK. Overlay mode: NULL — an overlay-mirror deal has no native Margince pipeline row; the incumbent's own pipeline id rides `raw` and the code-declared stage→semantic mapping drives tier resolution (overlay-augmentation OVA-MAP-6). A zero/placeholder UUID here is forbidden (dangling FK).
+	PipelineId *openapi_types.UUID     `json:"pipeline_id"`
+	Raw        *map[string]interface{} `json:"raw,omitempty"`
+	Source     string                  `json:"source"`
+
+	// StageId Native mode: always a non-null stage FK; must belong to pipeline_id. Overlay mode: NULL (see pipeline_id; the incumbent dealstage id rides `raw`, OVA-MAP-6).
+	StageId *openapi_types.UUID `json:"stage_id"`
 
 	// Stalled Derived — no activity past the threshold (absolute duration).
 	Stalled   *bool      `json:"stalled,omitempty"`

--- a/backend/internal/modules/deals/deal_advance.go
+++ b/backend/internal/modules/deals/deal_advance.go
@@ -73,6 +73,15 @@ func (s *Store) AdvanceDeal(ctx context.Context, id ids.DealID, in AdvanceDealIn
 		if err != nil {
 			return fmt.Errorf("read deal before advance: %w", err)
 		}
+		// pipeline_id/stage_id became nullable for overlay-mirror deals
+		// (OVA-MAP-6), but a NATIVE deal — the only kind this native advance
+		// path ever runs against — always carries both (NOT NULL columns).
+		// Refuse a deal missing them rather than nil-deref below: an overlay
+		// deal cannot reach here (advance_deal is unsupported in overlay mode),
+		// so a nil is corruption, not a valid transition.
+		if current.StageId == nil || current.PipelineId == nil {
+			return fmt.Errorf("advance deal %s: deal has no native pipeline/stage", id)
+		}
 
 		semantic, winProbability, err := resolveAdvanceTarget(ctx, tx, in.ToStageID, current)
 		if err != nil {
@@ -95,7 +104,7 @@ func (s *Store) AdvanceDeal(ctx context.Context, id ids.DealID, in AdvanceDealIn
 		if _, err := tx.Exec(ctx,
 			`INSERT INTO deal_stage_history (workspace_id, deal_id, from_stage_id, to_stage_id, changed_by, amount_minor_at_change, currency_at_change, win_probability_at_change)
 			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
-			storekit.MustWorkspace(ctx), id, ids.UUID(current.StageId), in.ToStageID, by,
+			storekit.MustWorkspace(ctx), id, ids.UUID(*current.StageId), in.ToStageID, by,
 			current.AmountMinor, current.Currency, winProbability); err != nil {
 			return fmt.Errorf("record stage history: %w", err)
 		}
@@ -140,7 +149,7 @@ func resolveAdvanceTarget(ctx context.Context, tx pgx.Tx, toStage ids.StageID, c
 	if err != nil {
 		return "", 0, fmt.Errorf("resolve target stage: %w", err)
 	}
-	if stagePipeline.UUID != ids.UUID(current.PipelineId) {
+	if stagePipeline.UUID != ids.UUID(*current.PipelineId) {
 		return "", 0, &StagePipelineMismatchError{StageID: toStage}
 	}
 	return semantic, winProbability, nil

--- a/backend/internal/modules/deals/deal_read.go
+++ b/backend/internal/modules/deals/deal_read.go
@@ -275,8 +275,10 @@ func scanDeal(row pgx.Row, active []fieldcatalog.Column, extra ...any) (crmcontr
 
 	d.Id = openapi_types.UUID(id)
 	d.WorkspaceId = openapi_types.UUID(wsID)
-	d.PipelineId = openapi_types.UUID(pipelineID)
-	d.StageId = openapi_types.UUID(stageID)
+	pid := openapi_types.UUID(pipelineID)
+	d.PipelineId = &pid
+	sid := openapi_types.UUID(stageID)
+	d.StageId = &sid
 	d.OrganizationId = uuidPtr(orgID)
 	d.OwnerId = uuidPtr(ownerID)
 	d.PartnerOrgId = uuidPtr(partnerID)

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -5066,13 +5066,16 @@ export interface components {
             fx_rate_to_base?: string | null;
             /** Format: date */
             fx_rate_date?: string | null;
-            /** Format: uuid */
-            pipeline_id: string;
             /**
              * Format: uuid
-             * @description Must belong to pipeline_id.
+             * @description Native mode: always a non-null pipeline FK. Overlay mode: NULL — an overlay-mirror deal has no native Margince pipeline row; the incumbent's own pipeline id rides `raw` and the code-declared stage→semantic mapping drives tier resolution (overlay-augmentation OVA-MAP-6). A zero/placeholder UUID here is forbidden (dangling FK).
              */
-            stage_id: string;
+            pipeline_id: string | null;
+            /**
+             * Format: uuid
+             * @description Native mode: always a non-null stage FK; must belong to pipeline_id. Overlay mode: NULL (see pipeline_id; the incumbent dealstage id rides `raw`, OVA-MAP-6).
+             */
+            stage_id: string | null;
             /**
              * Format: uuid
              * @description Primary org; never a raw lead.

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -117,7 +117,7 @@ type DealFilters = {
   // pipeline/stage/owner/org filters) with a 422 — so in overlay we send none
   // of them and let the deals list come back flat. The screen forces the table
   // view and hides the pickers to match (a stage-keyed board cannot place a
-  // mirror deal, whose pipeline/stage is the zero UUID).
+  // mirror deal, whose pipeline/stage is null in overlay, OVA-MAP-6).
   overlay: boolean;
 };
 
@@ -125,7 +125,7 @@ type DealFilters = {
 // every dial except the two the cache can honor, so overlay mode sends only
 // those and the list comes back flat (the screen forces the table view and
 // hides the pickers to match — a stage-keyed board cannot place a mirror deal,
-// whose pipeline/stage is the zero UUID).
+// whose pipeline/stage is null in overlay, OVA-MAP-6).
 function dealsQueryParams(f: DealFilters) {
   const base = { limit: 100, include_archived: f.includeArchived || undefined };
   if (f.overlay) {
@@ -559,7 +559,7 @@ export function DealsScreen({
     overlay,
   });
   // A stage-keyed board cannot place a mirror deal (its pipeline/stage is the
-  // zero UUID), so overlay mode opens on the flat table and hides the toggle
+  // null pipeline/stage), so overlay mode opens on the flat table and hides the toggle
   // (below) — the mode is fixed for the page's life, so a static initial value
   // is enough.
   const [view, setView] = useState<"board" | "table">(
@@ -928,7 +928,10 @@ function DealTable({
           {
             key: "stage",
             header: t("deals.stage"),
-            render: (deal: Deal) => stageName.get(deal.stage_id) ?? "",
+            // stage_id is null for an overlay-mirror deal (OVA-MAP-6) — no
+            // native stage row to name; a native deal always has one.
+            render: (deal: Deal) =>
+              deal.stage_id ? (stageName.get(deal.stage_id) ?? "") : "",
           },
           {
             key: "amount",

--- a/scripts/contract-breaking-allowlist.txt
+++ b/scripts/contract-breaking-allowlist.txt
@@ -1,2 +1,3 @@
 # old-contract-git-blob new-contract-git-blob reason
 17ff04c6106719e22ddf0ae5997b7e46584a7242 5ae682d3d4fa64045888d4aa7da7cdf6272417bd ratified-adr-0066-progressive-voice-lifecycle
+1edeaf7a9dda5e28b020b6b733fcf516796eb646 669ee1b68234bfa7062f5f4033a246d814a7ae3f ratified-ova-map-6-overlay-deal-nullable-pipeline-stage-id


### PR DESCRIPTION
## What (OVA-MAP-6)

An overlay-mirror deal has **no native Margince pipeline/stage row**, yet the wire emitted **zero-UUIDs** for `pipeline_id`/`stage_id` — a forbidden dangling FK. This syncs poc-v1's contract to the merged pin (foundation #1124) and nulls them:

- **`crm.yaml`**: `Deal.pipeline_id`/`stage_id` → `[string,'null']` format uuid (non-null in native mode, NULL in overlay). Write-request schemas stay non-null. Regenerated → the fields are `*openapi_types.UUID`.
- **Overlay wire**: leaves both `nil` (null); the incumbent's own pipeline/dealstage identifiers ride `raw`.
- **Native deals** absorb the pointer type (bounded ripple): `deal_read` projects `&pid`/`&sid` (native is always non-null); `deal_advance` derefs behind an explicit native-invariant guard (a nil is corruption, not a valid transition — overlay's `advance_deal` is unsupported, so it never reaches that path).
- The deliberate nullable widening is recorded in the **contract-breaking allowlist** (ratified pre-live re-sync) so CI's stable gate passes; any later contract edit restores the stable gate automatically.

## Tests
`TestOverlayWireDealNullsPipelineAndStage` (nil `pipeline_id`/`stage_id` + incumbent ids preserved in `raw`); native deal read/advance suites green with the pointer type; full `make check-backend` + deals/compose integration lanes green.

## Scope
The stage→`semantic` mapping OVA-MAP-6 also mentions is write-path-adjacent (advance-tier resolution / `StageSemantic`), which stays unsupported in overlay until branch-2 write-back — the read-path null-identity is this PR's deliverable. With A6.3 (#179), this is the last A6 mapping-fidelity slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Overlay deals now return null for `pipeline_id` and `stage_id` to meet OVA-MAP-6 and prevent dangling UUIDs. Native deals stay non-null; overlay keeps incumbent pipeline/stage identifiers in `raw`. Frontend deals table now safely handles a null `stage_id`.

- **Migration**
  - `Deal.pipeline_id` and `Deal.stage_id` are nullable on reads (pointer UUIDs). Handle `null` for overlay; native advance path validates and dereferences.
  - Write request schemas remain non-null. No changes needed for writes.
  - Frontend `schema.d.ts` regenerated; both fields are `string | null`.

- **Bug Fixes**
  - Deals table guards null `stage_id` when resolving the stage name; overlay rows render blank.

<sup>Written for commit 0431eb5f0f1b0907071afb1c65375d5053884b46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Overlay deals now support nullable pipeline and stage identifiers while preserving incumbent values in raw data.
  - Native deal transitions require valid pipeline and stage information.

- **Bug Fixes**
  - Prevented fabricated placeholder identifiers for overlay deals.
  - Added validation to fail safely when required native deal relationships are missing.

- **Tests**
  - Added coverage confirming overlay pipeline and stage identifiers remain null and original values are preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->