### PR TITLE
fix(overlay): checkpoint monotonicity + 503 on a canceled reconcile (A4b)

### DIFF
--- a/backend/internal/modules/overlay/handlers.go
+++ b/backend/internal/modules/overlay/handlers.go
@@ -226,11 +226,16 @@ func (h Handlers) ReconcileOverlay(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(ctx, reconcileTimeout)
 	defer cancel()
 	if err := h.reconciler.Reconcile(ctx); err != nil {
-		if errors.Is(err, context.DeadlineExceeded) {
+		// Any context cancellation — our own reconcileTimeout (DeadlineExceeded)
+		// OR the caller abandoning the request (Canceled) — is a "cut off, retry"
+		// availability outcome, not an internal error: answer 503, never a
+		// misleading 500. Per-object-class progress already landed is retained,
+		// so a retry continues rather than restarts.
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
 			httperr.Write(w, r, &httperr.DetailedError{
 				Status: http.StatusServiceUnavailable,
 				Code:   "overlay_reconcile_timeout",
-				Detail: fmt.Sprintf("the mirror reconciliation sweep did not finish within %s and was cut off; per-object-class progress already landed is retained, retry to continue", reconcileTimeout),
+				Detail: fmt.Sprintf("the mirror reconciliation sweep was cut off before finishing (timeout %s or the request was canceled); per-object-class progress already landed is retained, retry to continue", reconcileTimeout),
 			})
 			return
 		}

--- a/backend/internal/modules/overlay/handlers_test.go
+++ b/backend/internal/modules/overlay/handlers_test.go
@@ -107,6 +107,21 @@ func TestReconcileOverlayMapsATimedOutSweepToServiceUnavailable(t *testing.T) {
 	}
 }
 
+// TestReconcileOverlayMapsACanceledSweepToServiceUnavailable proves a
+// caller-abandoned sweep (context.Canceled) is also an availability outcome
+// (503, "cut off, retry"), not a misleading opaque 500 (A4b).
+func TestReconcileOverlayMapsACanceledSweepToServiceUnavailable(t *testing.T) {
+	reconciler := &fakeReconciler{err: context.Canceled}
+	h := NewHandlers(nil).WithReconciler(reconciler)
+	w := httptest.NewRecorder()
+
+	h.ReconcileOverlay(w, requestAs(principal.ObjectGrant{Read: true, Update: true}))
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want %d for a canceled sweep", w.Code, http.StatusServiceUnavailable)
+	}
+}
+
 // TestReconcileOverlaySurfacesANonTimeoutReconcileError proves an
 // ordinary reconcile failure (e.g. apperrors.ErrModeNotOverlay when the
 // workspace has no active connection) still rides the normal sentinel

--- a/backend/internal/modules/overlay/mirrorcheckpoints.go
+++ b/backend/internal/modules/overlay/mirrorcheckpoints.go
@@ -31,11 +31,20 @@ import (
 // as ingestSQL/upsertAssocSQL so a caller with no workspace GUC set
 // fails the NOT NULL constraint rather than checkpointing under a null
 // tenant.
+// done is sticky-true (done = old.done OR excluded.done): a converged
+// backfill must never be knocked back to pending by an out-of-order save
+// from a slower concurrent pass (the periodic poller racing an on-demand
+// reconcile) — that would re-list the whole incumbent. Within one
+// connection's life done only ever goes false→true (a reconnect purges the
+// row and starts fresh), so OR-ing is monotonic, never sticky at the wrong
+// value.
 const upsertBackfillCursorSQL = `
 INSERT INTO overlay_backfill_cursor (workspace_id, object_class, cursor, done, updated_at)
 VALUES (NULLIF(current_setting('app.workspace_id',true),'')::uuid, $1, $2, $3, now())
 ON CONFLICT (workspace_id, object_class) DO UPDATE
-   SET cursor = EXCLUDED.cursor, done = EXCLUDED.done, updated_at = now()`
+   SET cursor = EXCLUDED.cursor,
+       done = overlay_backfill_cursor.done OR EXCLUDED.done,
+       updated_at = now()`
 
 // SaveBackfillCursor persists Backfill's (overlay/backfill.go) list
 // cursor for objectClass after each page — the checkpoint a restart
@@ -86,11 +95,17 @@ func (s *MirrorStore) LoadBackfillCursor(ctx context.Context, objectClass string
 // timestamp the incremental sweep keeps advancing forever, so it lives
 // in its own table (overlay_reconcile_watermark) rather than overloading
 // the backfill cursor's "cursor" column with a second meaning.
+// The watermark only ever advances (WHERE excluded.watermark > current): an
+// older pass committing after a newer one must not move it backward, which
+// would re-sweep the window between and, worse, risk re-ingesting records a
+// newer pass already saw. The same monotonic-progress discipline ingestSQL's
+// staleness guard applies to a mirror row (mirrorstore.go).
 const upsertReconcileWatermarkSQL = `
 INSERT INTO overlay_reconcile_watermark (workspace_id, object_class, watermark, updated_at)
 VALUES (NULLIF(current_setting('app.workspace_id',true),'')::uuid, $1, $2, now())
 ON CONFLICT (workspace_id, object_class) DO UPDATE
-   SET watermark = EXCLUDED.watermark, updated_at = now()`
+   SET watermark = EXCLUDED.watermark, updated_at = now()
+   WHERE EXCLUDED.watermark > overlay_reconcile_watermark.watermark`
 
 // SaveReconcileWatermark persists Reconcile's new watermark for
 // objectClass after a sweep pass — the checkpoint the next scheduled

--- a/backend/internal/modules/overlay/mirrorcheckpoints_integration_test.go
+++ b/backend/internal/modules/overlay/mirrorcheckpoints_integration_test.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package overlay
+
+import (
+	"testing"
+	"time"
+)
+
+// TestSaveReconcileWatermarkOnlyAdvances proves the watermark never moves
+// backward (A4b): an older pass committing after a newer one — the periodic
+// poller racing an on-demand reconcile — must not regress the checkpoint,
+// which would re-sweep the window between and risk re-ingesting records the
+// newer pass already saw.
+func TestSaveReconcileWatermarkOnlyAdvances(t *testing.T) {
+	ctx, pool, _ := testWorkspaceCtx(t)
+	store := NewMirrorStore(pool, noOwnerEmails{})
+
+	newer := time.Date(2026, 7, 2, 0, 0, 0, 0, time.UTC)
+	older := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+
+	if err := store.SaveReconcileWatermark(ctx, "contacts", newer); err != nil {
+		t.Fatalf("save newer watermark: %v", err)
+	}
+	// An older save must be a no-op — not a regression.
+	if err := store.SaveReconcileWatermark(ctx, "contacts", older); err != nil {
+		t.Fatalf("save older watermark: %v", err)
+	}
+	got, err := store.LoadReconcileWatermark(ctx, "contacts")
+	if err != nil {
+		t.Fatalf("load watermark: %v", err)
+	}
+	if !got.Equal(newer) {
+		t.Errorf("watermark = %v, want it to stay at the newer %v (an older pass must never move it back)", got, newer)
+	}
+
+	// A genuinely newer save still advances.
+	newest := time.Date(2026, 7, 3, 0, 0, 0, 0, time.UTC)
+	if err := store.SaveReconcileWatermark(ctx, "contacts", newest); err != nil {
+		t.Fatalf("save newest watermark: %v", err)
+	}
+	if got, _ := store.LoadReconcileWatermark(ctx, "contacts"); !got.Equal(newest) {
+		t.Errorf("watermark = %v, want it to advance to %v", got, newest)
+	}
+}
+
+// TestSaveBackfillCursorDoneIsSticky proves a converged backfill is never
+// knocked back to pending (A4b): once done=true, an out-of-order save with
+// done=false (a slower concurrent pass) must not re-open it, which would
+// re-list the whole incumbent.
+func TestSaveBackfillCursorDoneIsSticky(t *testing.T) {
+	ctx, pool, _ := testWorkspaceCtx(t)
+	store := NewMirrorStore(pool, noOwnerEmails{})
+
+	if err := store.SaveBackfillCursor(ctx, "contacts", "", true); err != nil {
+		t.Fatalf("save done cursor: %v", err)
+	}
+	// A stale done=false save must not re-open the converged backfill.
+	if err := store.SaveBackfillCursor(ctx, "contacts", "cur-stale", false); err != nil {
+		t.Fatalf("save stale cursor: %v", err)
+	}
+	_, done, err := store.LoadBackfillCursor(ctx, "contacts")
+	if err != nil {
+		t.Fatalf("load cursor: %v", err)
+	}
+	if !done {
+		t.Error("backfill cursor done = false after a stale out-of-order save, want it to stay done=true (sticky)")
+	}
+}

--- a/backend/internal/modules/overlay/mirrorcheckpoints_integration_test.go
+++ b/backend/internal/modules/overlay/mirrorcheckpoints_integration_test.go
@@ -42,7 +42,11 @@ func TestSaveReconcileWatermarkOnlyAdvances(t *testing.T) {
 	if err := store.SaveReconcileWatermark(ctx, "contacts", newest); err != nil {
 		t.Fatalf("save newest watermark: %v", err)
 	}
-	if got, _ := store.LoadReconcileWatermark(ctx, "contacts"); !got.Equal(newest) {
+	got, err = store.LoadReconcileWatermark(ctx, "contacts")
+	if err != nil {
+		t.Fatalf("reload watermark after advance: %v", err)
+	}
+	if !got.Equal(newest) {
 		t.Errorf("watermark = %v, want it to advance to %v", got, newest)
 	}
 }


### PR DESCRIPTION
## What (A4b reconcile-robustness deferrals)

- **Watermark only advances**: `SaveReconcileWatermark`'s `ON CONFLICT ... DO UPDATE` gains `WHERE excluded.watermark > current`. An older pass committing after a newer one (the periodic poller racing an on-demand reconcile) no longer moves the checkpoint backward — which would re-sweep the window and risk re-ingesting records the newer pass already saw. (Closes the cubic finding deferred from A5.)
- **Backfill `done` is sticky-true**: `done = old.done OR excluded.done`. A converged backfill is never knocked back to pending by an out-of-order `done=false` save, which would re-list the whole incumbent. Within a connection's life `done` only goes false→true (reconnect purges the row), so OR is monotonic. (Closes the other deferred cubic finding.)
- **Canceled reconcile → 503**: the on-demand `/overlay/reconcile` handler maps `context.Canceled` (caller abandoned the request) to 503 like the existing `DeadlineExceeded` timeout, not a misleading opaque 500 — both are "cut off, retry" outcomes with per-object progress retained.

## Tests
`TestSaveReconcileWatermarkOnlyAdvances`, `TestSaveBackfillCursorDoneIsSticky` (integration); `TestReconcileOverlayMapsACanceledSweepToServiceUnavailable`. Full gate + overlay integration green.

## Still open in A4b (not this PR)
The composite keyset watermark for a >10k same-timestamp block (needs an upstream seam spike to signal mode-switch), atomic ingest+`mirror.conflict` in one row-locked tx, and read-time **sync staleness** — which is really the OVA-PARAM-5/6 per-object-class freshness-SLO feature (+ the 2×SLO fail-closed floor), a Track-1 compliance item, not a cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make overlay checkpoints monotonic and return 503 when an on-demand reconcile is canceled to prevent reprocessing and give clear retry signals.

- **Bug Fixes**
  - Reconcile watermark only advances via SQL upsert with WHERE `EXCLUDED.watermark > overlay_reconcile_watermark.watermark`, preventing backward moves during concurrent passes.
  - Backfill cursor `done` is sticky-true by OR-ing existing and new values, so a slower pass can’t reopen a completed backfill.
  - `/overlay/reconcile` maps context cancellation (timeout or caller abort) to 503 Service Unavailable; progress is retained for retry.

<sup>Written for commit 4ea9fb7de5886a2eca44f60775e6dd7cd33c4161. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Canceled overlay reconciliation requests now return a retryable service-unavailable response, consistent with timed-out requests.
  - Overlay synchronization checkpoints no longer move backward during concurrent or out-of-order updates.
  - Completed backfill progress remains marked as complete after subsequent updates.

- **Tests**
  - Added coverage for canceled reconciliation handling and checkpoint consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->