### PR TITLE
fix(overlay): a disconnect commits even if credential cleanup fails (A5b)

### DIFF
--- a/backend/internal/modules/overlay/teardown.go
+++ b/backend/internal/modules/overlay/teardown.go
@@ -90,20 +90,18 @@ func (s *Service) Disconnect(ctx context.Context) error {
 	}
 	s.notifyModeFlip(ws)
 
-	// The disconnect is ALREADY committed and authoritative here (connection
+	// The disconnect is already committed and authoritative here (connection
 	// revoked, mirror purged, workspace flipped to native) — deleting the
-	// sealed credential is a best-effort cleanup AFTER that commit, not part
-	// of it. Failing the whole Disconnect on a transient vault error would be
-	// doubly wrong: it misreports a disconnect that DID happen, and it strands
-	// the caller — a retry finds no active connection (revokeConnection →
-	// ErrNotFound) and could never re-attempt this delete. So on failure, log
-	// the orphaned credential ref at ERROR for operational cleanup and return
-	// success. The blob is inert: a revoked, unreferenced, encrypted-at-rest
-	// secret, not an active exposure. A durable retry — an outbox consumer
-	// keyed off the incumbent.disconnected event already emitted in the tx
-	// above — is the tracked follow-up (A5b) that would remove even the manual
-	// step; the ref (a vault key, never the secret) is logged so ops can purge
-	// it meanwhile.
+	// sealed credential is best-effort cleanup AFTER that commit, not part of
+	// it. Failing Disconnect on a vault error would be doubly wrong: it
+	// misreports a disconnect that DID happen, and it strands the caller — a
+	// retry finds no active connection (revokeConnection → ErrNotFound) and
+	// could never re-attempt this delete. So on failure, log the orphaned
+	// credential ref at ERROR for operational cleanup and return success. The
+	// blob is inert: a revoked, unreferenced, encrypted-at-rest secret, not an
+	// active exposure. The ref is a vault key, never the secret (safe to log).
+	// A durable outbox-driven retry keyed off the incumbent.disconnected event
+	// emitted above would remove even the manual step.
 	if err := s.vault.Delete(ctx, ids.From[ids.WorkspaceKind](ws), keyvault.Ref(ref)); err != nil {
 		s.log.ErrorContext(ctx, "overlay: disconnect committed, but deleting the sealed incumbent credential failed — the orphaned (revoked, inert) blob needs cleanup",
 			"workspace", ws.String(), "credential_ref", ref, "err", err)

--- a/backend/internal/modules/overlay/teardown.go
+++ b/backend/internal/modules/overlay/teardown.go
@@ -90,8 +90,23 @@ func (s *Service) Disconnect(ctx context.Context) error {
 	}
 	s.notifyModeFlip(ws)
 
+	// The disconnect is ALREADY committed and authoritative here (connection
+	// revoked, mirror purged, workspace flipped to native) — deleting the
+	// sealed credential is a best-effort cleanup AFTER that commit, not part
+	// of it. Failing the whole Disconnect on a transient vault error would be
+	// doubly wrong: it misreports a disconnect that DID happen, and it strands
+	// the caller — a retry finds no active connection (revokeConnection →
+	// ErrNotFound) and could never re-attempt this delete. So on failure, log
+	// the orphaned credential ref at ERROR for operational cleanup and return
+	// success. The blob is inert: a revoked, unreferenced, encrypted-at-rest
+	// secret, not an active exposure. A durable retry — an outbox consumer
+	// keyed off the incumbent.disconnected event already emitted in the tx
+	// above — is the tracked follow-up (A5b) that would remove even the manual
+	// step; the ref (a vault key, never the secret) is logged so ops can purge
+	// it meanwhile.
 	if err := s.vault.Delete(ctx, ids.From[ids.WorkspaceKind](ws), keyvault.Ref(ref)); err != nil {
-		return fmt.Errorf("overlay: deleting the sealed incumbent credential: %w", err)
+		s.log.ErrorContext(ctx, "overlay: disconnect committed, but deleting the sealed incumbent credential failed — the orphaned (revoked, inert) blob needs cleanup",
+			"workspace", ws.String(), "credential_ref", ref, "err", err)
 	}
 	return nil
 }

--- a/backend/internal/modules/overlay/teardown_integration_test.go
+++ b/backend/internal/modules/overlay/teardown_integration_test.go
@@ -321,6 +321,58 @@ func TestFencedSyncWritesAbortOnceTheConnectionIsRevoked(t *testing.T) {
 	}
 }
 
+// deleteFailingVault wraps a real vault but fails every Delete — the
+// transient-vault-failure the A5b guard handles. Put/Get delegate, so
+// Connect still seals + the connection is real; only the disconnect-time
+// credential cleanup fails.
+type deleteFailingVault struct {
+	keyvault.Vault
+	err error
+}
+
+func (v deleteFailingVault) Delete(context.Context, ids.WorkspaceID, keyvault.Ref) error {
+	return v.err
+}
+
+// TestDisconnectCommitsEvenWhenVaultDeleteFails proves A5b: the disconnect is
+// committed and authoritative once its tx lands, so a failure deleting the
+// (now-inert) sealed credential afterward must NOT report the disconnect as
+// failed — it succeeded — nor strand the caller (a retry would find no active
+// connection). The DB teardown stands; the orphaned blob is logged, not
+// surfaced as an error.
+func TestDisconnectCommitsEvenWhenVaultDeleteFails(t *testing.T) {
+	ctx, pool, ws := testWorkspaceCtx(t)
+	vault := deleteFailingVault{Vault: keyvault.NewMemory(), err: errors.New("vault unreachable")}
+	store := NewMirrorStore(pool, noOwnerEmails{})
+	svc := NewService(pool, vault, store)
+
+	if _, err := svc.Connect(ctx, ConnectInput{Incumbent: "hubspot", Region: "eu1", Token: "pat-a5b"}); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+
+	// Disconnect must SUCCEED despite the vault delete failing.
+	if err := svc.Disconnect(ctx); err != nil {
+		t.Fatalf("Disconnect returned %v, want nil — a failed credential cleanup must not fail an already-committed disconnect", err)
+	}
+
+	// The authoritative teardown committed: connection revoked, mode native.
+	var status, sorMode string
+	queryRowWS(ctx, t, pool,
+		`SELECT status FROM incumbent_connection WHERE workspace_id = $1`, []any{ws}, &status)
+	queryRowWS(ctx, t, pool,
+		`SELECT x_sor_mode FROM workspace WHERE id = $1`, []any{ws}, &sorMode)
+	if status != "revoked" || sorMode != "native" {
+		t.Errorf("after disconnect: connection status=%q, sor_mode=%q — want revoked/native (the teardown must commit regardless of vault cleanup)", status, sorMode)
+	}
+
+	// A retry answers ErrNotFound (already disconnected) — proving the vault
+	// failure did not leave the connection re-disconnectable, which is exactly
+	// why the delete cannot be a fatal, retry-driven step.
+	if err := svc.Disconnect(ctx); !errors.Is(err, apperrors.ErrNotFound) {
+		t.Errorf("second Disconnect = %v, want ErrNotFound (the first one committed)", err)
+	}
+}
+
 func TestDisconnectWithNoActiveConnectionAnswersNotFound(t *testing.T) {
 	ctx, pool, _ := testWorkspaceCtx(t)
 	vault := keyvault.NewMemory()

--- a/backend/internal/modules/overlay/teardown_integration_test.go
+++ b/backend/internal/modules/overlay/teardown_integration_test.go
@@ -11,10 +11,13 @@ package overlay
 // exactly like a passing one.
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -344,15 +347,34 @@ func TestDisconnectCommitsEvenWhenVaultDeleteFails(t *testing.T) {
 	ctx, pool, ws := testWorkspaceCtx(t)
 	vault := deleteFailingVault{Vault: keyvault.NewMemory(), err: errors.New("vault unreachable")}
 	store := NewMirrorStore(pool, noOwnerEmails{})
-	svc := NewService(pool, vault, store)
+	// Capture ERROR logs: the cleanup ERROR is the ONLY recovery signal for
+	// the orphaned blob while a durable retry is deferred, so the test must
+	// verify it fires with the attributes ops needs (level ERROR filters out
+	// Connect's best-effort WARN seeding, leaving just the cleanup record).
+	var logbuf bytes.Buffer
+	svc := NewService(pool, vault, store).
+		WithLogger(slog.New(slog.NewTextHandler(&logbuf, &slog.HandlerOptions{Level: slog.LevelError})))
 
 	if _, err := svc.Connect(ctx, ConnectInput{Incumbent: "hubspot", Region: "eu1", Token: "pat-a5b"}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
+	var credentialRef string
+	queryRowWS(ctx, t, pool,
+		`SELECT credential_ref FROM incumbent_connection WHERE workspace_id = $1`, []any{ws}, &credentialRef)
 
 	// Disconnect must SUCCEED despite the vault delete failing.
 	if err := svc.Disconnect(ctx); err != nil {
 		t.Fatalf("Disconnect returned %v, want nil — a failed credential cleanup must not fail an already-committed disconnect", err)
+	}
+
+	// The cleanup failure is surfaced at ERROR with the workspace + credential
+	// ref — without this, the orphaned blob is invisible to ops.
+	logged := logbuf.String()
+	if !strings.Contains(logged, "level=ERROR") {
+		t.Errorf("no ERROR log for the failed credential cleanup — the orphaned blob would be invisible to ops; got: %q", logged)
+	}
+	if !strings.Contains(logged, ws.String()) || !strings.Contains(logged, credentialRef) {
+		t.Errorf("the cleanup ERROR log must carry workspace + credential_ref for manual purge; got: %q", logged)
 	}
 
 	// The authoritative teardown committed: connection revoked, mode native.


### PR DESCRIPTION
## What (A5b)

`Disconnect`'s teardown tx (revoke + purge + flip to native) is the **authoritative, committed** operation; deleting the sealed credential runs *after* it as best-effort cleanup. Failing the whole `Disconnect` on a transient vault error was doubly wrong:
1. it **misreported** a disconnect that *did* happen, and
2. it **stranded** the caller — a retry finds no active connection (`revokeConnection` → `ErrNotFound`) and could never re-attempt the delete.

Now a vault-delete failure is **logged at ERROR** with the orphaned credential ref (a vault key, never the secret — the `Ref` type is documented safe to log) and `Disconnect` returns success: the DB teardown stands, and the blob left behind is inert (revoked, unreferenced, encrypted at rest — not an active exposure).

## Test
`TestDisconnectCommitsEvenWhenVaultDeleteFails`: a Delete-failing vault → `Disconnect` succeeds, connection is `revoked` + workspace flipped to `native`, and a retry answers `ErrNotFound`.

## Follow-up (tracked)
A fully **durable** retry — an outbox consumer keyed off the `incumbent.disconnected` event already emitted in the teardown tx — would remove even the manual cleanup step. That's real infra (a new consumer + vault access in the worker), tracked rather than built here; this PR fixes the misleading-failure bug that was the actual defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `overlay` `Disconnect` succeed even if `keyvault` credential deletion fails. Log an ERROR with the safe `credential_ref` for ops cleanup; avoids false failures and retry dead-ends (A5b).

- **Bug Fixes**
  - Treat credential delete as best-effort after the committed teardown (revoke + purge + flip to native); on failure, log and do not fail `Disconnect`.
  - The orphaned blob is inert (revoked, unreferenced, encrypted at rest).
  - Strengthened `TestDisconnectCommitsEvenWhenVaultDeleteFails`: simulate a delete-failing vault, capture ERROR logs and assert they include workspace and `credential_ref`; also verifies revoked/native state and that a second `Disconnect` returns `ErrNotFound`; trimmed a leftover teardown comment.

<sup>Written for commit f826569fb992df5aa294b41308d0f8bbcb95aeba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

