### PR TITLE
feat(overlay): shared PG-backed OVB budget meter (branch 1b, A3b)

### DIFF
--- a/backend/internal/compose/integration/overlay_acceptance_test.go
+++ b/backend/internal/compose/integration/overlay_acceptance_test.go
@@ -467,7 +467,7 @@ func TestAcceptance_AC_OV_3_MirrorReadMeetsBudget(t *testing.T) {
 	liveRec.ObjectClass = overlay.IncumbentClassContacts
 	fakeInc.Seed(overlay.IncumbentClassContacts, liveRec)
 
-	meter := overlay.NewMeterWithClock(acceptanceMeterConfig(), time.Now)
+	meter := overlay.NewMeterWithClock(e.Pool, acceptanceMeterConfig(), time.Now)
 	ff := overlay.NewFreshnessReader(func(context.Context) (overlay.Incumbent, error) { return fakeInc, nil }, mirror, meter, contactsTranslator)
 	fullProvider := overlay.NewProvider(mirror, ff)
 
@@ -533,7 +533,7 @@ func TestAcceptance_AC_OV_7_ForceFreshDegrades(t *testing.T) {
 	liveRec.ObjectClass = overlay.IncumbentClassContacts
 	fakeInc.Seed(overlay.IncumbentClassContacts, liveRec)
 
-	meter := overlay.NewMeterWithClock(acceptanceMeterConfig(), time.Now)
+	meter := overlay.NewMeterWithClock(e.Pool, acceptanceMeterConfig(), time.Now)
 	// Push the window to shed (limit 10, shed at 8) via the POLLER lane —
 	// proving Band is a total across lanes, never reachable by a
 	// force-fresh spend alone.
@@ -652,7 +652,7 @@ func TestAcceptance_AC_OV_8_IncumbentWinsConflict(t *testing.T) {
 	reverseRec.OwnerExternalID = "owner-1"
 	fakeInc.Seed(overlay.IncumbentClassCompanies, reverseRec)
 
-	meter := overlay.NewMeterWithClock(acceptanceMeterConfig(), time.Now)
+	meter := overlay.NewMeterWithClock(e.Pool, acceptanceMeterConfig(), time.Now)
 	since := oldBaseline.Add(-time.Second)
 	if _, err := overlay.Reconcile(ctx, fakeInc, mirror, meter, overlay.IncumbentClassCompanies, since); err != nil {
 		t.Fatalf("Reconcile: %v", err)
@@ -774,7 +774,7 @@ func TestAcceptance_AC_OV_11_FailClosedVisibility_ReadSubset(t *testing.T) {
 
 	t.Run("an unmapped user sees zero rows through the composed dispatcher (existence-hiding)", func(t *testing.T) {
 		unmappedCtx := overlayActorCtx(ws, seedUnmappedAppUser(t, ws))
-		d := compose.NewDispatcher(compose.NewProvider(e.Pool), compose.NewOverlayProvider(e.Pool, compose.NewOverlayMeter(), nil), e.Pool)
+		d := compose.NewDispatcher(compose.NewProvider(e.Pool), compose.NewOverlayProvider(e.Pool, compose.NewOverlayMeter(e.Pool), nil), e.Pool)
 		if _, err := d.Search(unmappedCtx, datasource.SearchQuery{EntityTypes: []datasource.EntityType{datasource.EntityPerson}, Limit: 10}); !errors.Is(err, apperrors.ErrNotFound) {
 			t.Fatalf("dispatched Search for an unmapped user = %v, want apperrors.ErrNotFound (existence-hiding, zero rows)", err)
 		}
@@ -867,7 +867,7 @@ func TestAcceptance_OVA_AC_1_TeardownPurges(t *testing.T) {
 		t.Fatalf("fixture is broken: seeded mirror=%d association=%d, want both > 0", seededMirror, seededAssoc)
 	}
 
-	dispatcher := compose.NewDispatcher(compose.NewProvider(pool), compose.NewOverlayProvider(pool, compose.NewOverlayMeter(), nil), pool)
+	dispatcher := compose.NewDispatcher(compose.NewProvider(pool), compose.NewOverlayProvider(pool, compose.NewOverlayMeter(pool), nil), pool)
 	preTeardown, err := dispatcher.Search(adminCtx, datasource.SearchQuery{EntityTypes: []datasource.EntityType{datasource.EntityDeal}, Limit: 10})
 	if err != nil || len(preTeardown.Records) != 1 {
 		t.Fatalf("expected the mapped admin to see the one backfilled deal before disconnect: err=%v records=%d", err, len(preTeardown.Records))
@@ -924,7 +924,7 @@ func TestAcceptance_OVA_AC_1_TeardownPurges(t *testing.T) {
 		principal.WithCorrelationID(principal.WithWorkspaceID(context.Background(), wsID), ids.NewV7()),
 		principal.Principal{Type: principal.PrincipalHuman, ID: "human:" + adminID.String(), UserID: adminID, Permissions: AdminPerms},
 	)
-	postDisconnectDispatcher := compose.NewDispatcher(compose.NewProvider(pool), compose.NewOverlayProvider(pool, compose.NewOverlayMeter(), nil), pool)
+	postDisconnectDispatcher := compose.NewDispatcher(compose.NewProvider(pool), compose.NewOverlayProvider(pool, compose.NewOverlayMeter(pool), nil), pool)
 	postTeardown, err := postDisconnectDispatcher.Search(adminNativeCtx, datasource.SearchQuery{EntityTypes: []datasource.EntityType{datasource.EntityDeal}, Limit: 10})
 	if err != nil {
 		t.Fatalf("post-disconnect dispatched Search: %v", err)

--- a/backend/internal/compose/integration/overlay_acceptance_test.go
+++ b/backend/internal/compose/integration/overlay_acceptance_test.go
@@ -867,10 +867,26 @@ func TestAcceptance_OVA_AC_1_TeardownPurges(t *testing.T) {
 		t.Fatalf("fixture is broken: seeded mirror=%d association=%d, want both > 0", seededMirror, seededAssoc)
 	}
 
-	dispatcher := compose.NewDispatcher(compose.NewProvider(pool), compose.NewOverlayProvider(pool, compose.NewOverlayMeter(pool), nil), pool)
+	meter := compose.NewOverlayMeter(pool)
+	dispatcher := compose.NewDispatcher(compose.NewProvider(pool), compose.NewOverlayProvider(pool, meter, nil), pool)
 	preTeardown, err := dispatcher.Search(adminCtx, datasource.SearchQuery{EntityTypes: []datasource.EntityType{datasource.EntityDeal}, Limit: 10})
 	if err != nil || len(preTeardown.Records) != 1 {
 		t.Fatalf("expected the mapped admin to see the one backfilled deal before disconnect: err=%v records=%d", err, len(preTeardown.Records))
+	}
+
+	// Spend a budget unit so overlay_budget_window holds a row for this
+	// workspace BEFORE disconnect — otherwise the post-teardown "budget
+	// window is empty" assertion below would pass vacuously (no row to
+	// purge) and could not catch a budget that survives into a reconnect.
+	if err := meter.Consume(adminCtx, overlay.LanePoller, 1); err != nil {
+		t.Fatalf("seeding the overlay budget window: %v", err)
+	}
+	var seededBudget int
+	if err := e.owner.QueryRow(context.Background(), `SELECT count(*) FROM overlay_budget_window WHERE workspace_id = $1`, wsIDStr).Scan(&seededBudget); err != nil {
+		t.Fatalf("counting the seeded budget window row: %v", err)
+	}
+	if seededBudget != 1 {
+		t.Fatalf("fixture is broken: seeded budget window rows=%d, want 1", seededBudget)
 	}
 
 	if code := e.call(t, "DELETE", "/v1/overlay/connection", nil, nil, nil); code != http.StatusAccepted {
@@ -881,7 +897,7 @@ func TestAcceptance_OVA_AC_1_TeardownPurges(t *testing.T) {
 	// genuinely converged it (done=true) — a cursor surviving disconnect
 	// would short-circuit the next connection's initial mirror load.
 	counts := map[string]int{}
-	for _, table := range []string{"overlay_mirror", "overlay_association", "mirror_visibility", "mirror_user_map", "overlay_backfill_cursor", "overlay_reconcile_watermark"} {
+	for _, table := range []string{"overlay_mirror", "overlay_association", "mirror_visibility", "mirror_user_map", "overlay_backfill_cursor", "overlay_reconcile_watermark", "overlay_budget_window"} {
 		var n int
 		if err := e.owner.QueryRow(context.Background(), fmt.Sprintf(`SELECT count(*) FROM %s WHERE workspace_id = $1`, table), wsIDStr).Scan(&n); err != nil {
 			t.Fatalf("counting %s: %v", table, err)

--- a/backend/internal/compose/integration/overlay_dispatch_integration_test.go
+++ b/backend/internal/compose/integration/overlay_dispatch_integration_test.go
@@ -37,7 +37,7 @@ func TestDispatcherRoutesNativeWorkspaceReadsToTheNativeProvider(t *testing.T) {
 	e := Setup(t)
 	personID := e.SeedPerson(t, "Ada Native", nil)
 
-	d := compose.NewDispatcher(compose.NewProvider(e.Pool), compose.NewOverlayProvider(e.Pool, compose.NewOverlayMeter(), nil), e.Pool)
+	d := compose.NewDispatcher(compose.NewProvider(e.Pool), compose.NewOverlayProvider(e.Pool, compose.NewOverlayMeter(e.Pool), nil), e.Pool)
 
 	rec, err := d.Read(e.Admin(), datasource.EntityRef{Type: datasource.EntityPerson, ID: personID})
 	if err != nil {
@@ -73,7 +73,7 @@ func TestDispatcherRoutesOverlayWorkspaceReadsToTheOverlayProvider(t *testing.T)
 		t.Fatalf("ingesting the overlay fixture record: %v", err)
 	}
 
-	d := compose.NewDispatcher(compose.NewProvider(e.Pool), compose.NewOverlayProvider(e.Pool, compose.NewOverlayMeter(), nil), e.Pool)
+	d := compose.NewDispatcher(compose.NewProvider(e.Pool), compose.NewOverlayProvider(e.Pool, compose.NewOverlayMeter(e.Pool), nil), e.Pool)
 
 	searchRes, err := d.Search(ctx, datasource.SearchQuery{
 		EntityTypes: []datasource.EntityType{datasource.EntityPerson},

--- a/backend/internal/compose/integration/overlay_e2e_test.go
+++ b/backend/internal/compose/integration/overlay_e2e_test.go
@@ -228,7 +228,7 @@ func TestOverlayReadAndSyncEndToEnd(t *testing.T) {
 	// the REAL composed dispatcher path (compose.Dispatcher — the exact
 	// seam every native GET/read_record call rides in production),
 	// carries TrustTier=external + Authoritative=false ---
-	dispatcher := compose.NewDispatcher(compose.NewProvider(pool), compose.NewOverlayProvider(pool, compose.NewOverlayMeter(), nil), pool)
+	dispatcher := compose.NewDispatcher(compose.NewProvider(pool), compose.NewOverlayProvider(pool, compose.NewOverlayMeter(pool), nil), pool)
 	searchRes, err := dispatcher.Search(adminCtx, datasource.SearchQuery{
 		EntityTypes: []datasource.EntityType{datasource.EntityPerson}, Limit: 10,
 	})

--- a/backend/internal/compose/jobs.go
+++ b/backend/internal/compose/jobs.go
@@ -392,7 +392,10 @@ func NewJobRunner(pool *pgxpool.Pool, log *slog.Logger, cfg JobRunnerConfig) (*j
 
 	if cfg.OverlayVault != nil {
 		ms := overlay.NewMirrorStore(pool, unresolvedOwnerEmails{})
-		meter := overlay.NewMeter(pool, overlay.DefaultMeterConfig())
+		// The SAME construction helper the REST/MCP/workflow surfaces use,
+		// so the poller lane can never drift onto a different meter config
+		// or backing than the rest of this process's overlay surfaces.
+		meter := NewOverlayMeter(pool)
 		river.AddWorker(workers, &overlayReconcileWorker{pool: pool, vault: cfg.OverlayVault, ms: ms, meter: meter, log: log, newIncumbent: overlayIncumbentFactory(cfg.OverlayBackfillLimit)})
 		periodic = append(periodic, river.NewPeriodicJob(
 			river.PeriodicInterval(cfg.OverlayInterval),

--- a/backend/internal/compose/jobs.go
+++ b/backend/internal/compose/jobs.go
@@ -392,7 +392,7 @@ func NewJobRunner(pool *pgxpool.Pool, log *slog.Logger, cfg JobRunnerConfig) (*j
 
 	if cfg.OverlayVault != nil {
 		ms := overlay.NewMirrorStore(pool, unresolvedOwnerEmails{})
-		meter := overlay.NewMeter(overlay.DefaultMeterConfig())
+		meter := overlay.NewMeter(pool, overlay.DefaultMeterConfig())
 		river.AddWorker(workers, &overlayReconcileWorker{pool: pool, vault: cfg.OverlayVault, ms: ms, meter: meter, log: log, newIncumbent: overlayIncumbentFactory(cfg.OverlayBackfillLimit)})
 		periodic = append(periodic, river.NewPeriodicJob(
 			river.PeriodicInterval(cfg.OverlayInterval),

--- a/backend/internal/compose/jobs_overlay_worker_integration_test.go
+++ b/backend/internal/compose/jobs_overlay_worker_integration_test.go
@@ -73,7 +73,7 @@ func TestOverlayReconcileWorkerWorkNoOpsOverAnEmptyFleet(t *testing.T) {
 		pool:  e.Pool,
 		vault: keyvault.NewMemory(),
 		ms:    overlay.NewMirrorStore(e.Pool, unresolvedOwnerEmails{}),
-		meter: overlay.NewMeter(overlay.DefaultMeterConfig()),
+		meter: overlay.NewMeter(e.Pool, overlay.DefaultMeterConfig()),
 		log:   slog.New(slog.DiscardHandler),
 	}
 
@@ -148,7 +148,7 @@ func TestWorkerBacksOffAConnectionLevelFailure(t *testing.T) {
 
 	w := &overlayReconcileWorker{
 		pool: e.Pool, vault: vault, ms: ms,
-		meter:        overlay.NewMeter(overlay.DefaultMeterConfig()),
+		meter:        overlay.NewMeter(e.Pool, overlay.DefaultMeterConfig()),
 		log:          slog.New(slog.DiscardHandler),
 		newIncumbent: func(_, _ string) overlay.Incumbent { return authFailingIncumbent{Adapter: fake.New()} },
 	}
@@ -217,7 +217,7 @@ func TestReconcileConnectionBackfillsAndSeedsViaFakeIncumbent(t *testing.T) {
 	}
 
 	sweepCtx := reconcileWorkerCtx(context.Background(), ids.From[ids.WorkspaceKind](e.WS))
-	if err := reconcileConnection(sweepCtx, vault, ms, overlay.NewMeter(overlay.DefaultMeterConfig()),
+	if err := reconcileConnection(sweepCtx, vault, ms, overlay.NewMeter(e.Pool, overlay.DefaultMeterConfig()),
 		slog.New(slog.DiscardHandler), d, func(_, _ string) overlay.Incumbent { return fakeInc }); err != nil {
 		t.Fatalf("reconcileConnection: %v", err)
 	}
@@ -291,7 +291,7 @@ func TestReconcileConnectionStopsCleanlyWhenDisconnectedMidSweep(t *testing.T) {
 	}
 
 	sweepCtx := reconcileWorkerCtx(context.Background(), ids.From[ids.WorkspaceKind](e.WS))
-	err = reconcileConnection(sweepCtx, vault, ms, overlay.NewMeter(overlay.DefaultMeterConfig()),
+	err = reconcileConnection(sweepCtx, vault, ms, overlay.NewMeter(e.Pool, overlay.DefaultMeterConfig()),
 		slog.New(slog.DiscardHandler), d, func(_, _ string) overlay.Incumbent { return fakeInc })
 	if !errors.Is(err, overlay.ErrConnectionGone) {
 		t.Fatalf("reconcileConnection over a revoked connection = %v, want overlay.ErrConnectionGone (clean stop)", err)
@@ -358,7 +358,7 @@ func TestWorkerCleanStopsOnMidSweepDisconnect(t *testing.T) {
 
 	w := &overlayReconcileWorker{
 		pool: e.Pool, vault: vault, ms: ms,
-		meter: overlay.NewMeter(overlay.DefaultMeterConfig()),
+		meter: overlay.NewMeter(e.Pool, overlay.DefaultMeterConfig()),
 		log:   slog.New(slog.DiscardHandler),
 		newIncumbent: func(_, _ string) overlay.Incumbent {
 			return &revokeOnOwnersIncumbent{Incumbent: fakeInc, pool: e.Pool}
@@ -406,7 +406,7 @@ func TestOnDemandReconcileRacingDisconnectAnswersModeNotOverlay(t *testing.T) {
 
 	r := overlayReconciler{
 		pool: e.Pool, vault: vault, ms: ms,
-		meter: overlay.NewMeter(overlay.DefaultMeterConfig()),
+		meter: overlay.NewMeter(e.Pool, overlay.DefaultMeterConfig()),
 		log:   slog.New(slog.DiscardHandler),
 		newIncumbent: func(_, _ string) overlay.Incumbent {
 			return &revokeOnOwnersIncumbent{Incumbent: fakeInc, pool: e.Pool}
@@ -456,7 +456,7 @@ func TestReconcileConnectionPurgesIncumbentDeletedRecord(t *testing.T) {
 
 	sweepCtx := reconcileWorkerCtx(context.Background(), ids.From[ids.WorkspaceKind](e.WS))
 	newInc := func(_, _ string) overlay.Incumbent { return fakeInc }
-	meter := overlay.NewMeter(overlay.DefaultMeterConfig())
+	meter := overlay.NewMeter(e.Pool, overlay.DefaultMeterConfig())
 
 	// First sweep mirrors the live record; the mapped reader can see it.
 	if err := reconcileConnection(sweepCtx, vault, ms, meter, slog.New(slog.DiscardHandler), d, newInc); err != nil {

--- a/backend/internal/compose/overlay.go
+++ b/backend/internal/compose/overlay.go
@@ -31,23 +31,19 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
-// NewOverlayMeter constructs one OVB (overlay budget) meter. A process
-// role that wires BOTH a Dispatcher's overlay.Provider (force-fresh
-// reads consume against it) AND overlay.Handlers' GetOverlayBudget
-// (reads its Snapshot) MUST pass the SAME instance to both — a Service
-// or Provider built with a separate meter would silently report a
-// window nothing ever fed. server.go does this by constructing one
-// meter per Server and threading it through both wiring points;
-// registry.go/workflows.go each still mint their OWN independent meter
-// for their own Dispatcher instances (the MCP tool surface and the
-// workflow engine each spend against a different in-process counter than
-// the REST surface does) — a known, pre-existing fragmentation
-// budgetmeter.go's own doc already names ("per-PROCESS... even with a
-// single replica") and is not closed end-to-end here; fixing it fully
-// needs the shared PG/Redis counter budgetmeter.go's own pending item
-// already tracks.
-func NewOverlayMeter() *overlay.Meter {
-	return overlay.NewMeter(overlay.DefaultMeterConfig())
+// NewOverlayMeter constructs one OVB (overlay budget) meter backed by
+// pool. The meter's window now lives in Postgres (overlay_budget_window,
+// ONE row per workspace), so every meter instance over the same pool —
+// this REST surface's, the MCP tool surface's (registry.go), the
+// workflow engine's (workflows.go), and cmd/worker's poller (jobs.go) —
+// reads and advances the SAME per-workspace count. Threading the same
+// *instance* through a Server's Provider and Handlers is therefore no
+// longer load-bearing for correctness (they'd share the count either
+// way); server.go still does it, and there is no cost to it. The
+// per-process fragmentation this doc used to warn about is closed by the
+// shared counter, not by careful instance threading.
+func NewOverlayMeter(pool *pgxpool.Pool) *overlay.Meter {
+	return overlay.NewMeter(pool, overlay.DefaultMeterConfig())
 }
 
 // NewOverlayHandlers builds the overlay module's connection-lifecycle

--- a/backend/internal/compose/overlay_test.go
+++ b/backend/internal/compose/overlay_test.go
@@ -9,8 +9,6 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/modules/overlay"
 	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
-	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
-	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
 // TestUnresolvedOwnerEmailsIsHonestlyUnwired proves the compose-level
@@ -59,14 +57,23 @@ func TestOverlayMetricsSectionPresentWithAVault(t *testing.T) {
 }
 
 // TestNewOverlayMeterUsesTheDefaultConfig proves NewOverlayMeter wires
-// budgetmeter.go's own DefaultMeterConfig rather than an ad hoc literal
-// — a Snapshot against a fresh meter must answer that config's Limit.
+// budgetmeter.go's own DefaultMeterConfig rather than an ad hoc literal.
+// The meter's window lives in Postgres now, so the real metered path
+// needs a DB (exercised by the overlay integration suite); this unit
+// lane reads the config through the fail-closed Snapshot instead: with
+// no workspace bound, Snapshot short-circuits before touching the pool
+// (WithWorkspaceTx returns ErrNoWorkspace) yet still reports Limit from
+// the wired config — so a wrong config here is still caught, without a
+// database. A nil pool is safe precisely because that path never begins
+// a transaction.
 func TestNewOverlayMeterUsesTheDefaultConfig(t *testing.T) {
-	m := NewOverlayMeter()
-	ctx := principal.WithWorkspaceID(context.Background(), ids.NewV7())
-	snap := m.Snapshot(ctx)
+	m := NewOverlayMeter(nil)
+	snap := m.Snapshot(context.Background()) // no workspace bound → fail-closed, no DB touched
 	want := overlay.DefaultMeterConfig()
 	if snap.Limit != want.Limit {
 		t.Fatalf("Snapshot().Limit = %d, want %d (DefaultMeterConfig)", snap.Limit, want.Limit)
+	}
+	if snap.Band != overlay.BandShed {
+		t.Fatalf("Snapshot().Band with no workspace bound = %q, want %q (fail closed)", snap.Band, overlay.BandShed)
 	}
 }

--- a/backend/internal/compose/registry.go
+++ b/backend/internal/compose/registry.go
@@ -45,11 +45,12 @@ func registryWithGate(pool *pgxpool.Pool, gate *auth.Gate, drafter activities.Em
 	// Provider exactly as before, an overlay-mode workspace's reads land
 	// on the mirror (design.md §4.2/§4.6) — chosen per call from
 	// ctx, never fixed at registry construction time. This registry's own
-	// OVB meter is independent of the REST surface's (NewOverlayMeter's
-	// doc note): the MCP tool surface spends against its own in-process
-	// counter, not the one contractAPI's Dispatcher and GetOverlayBudget
-	// share.
-	provider := NewDispatcher(NewProvider(pool), NewOverlayProvider(pool, NewOverlayMeter(), nil), pool)
+	// OVB meter shares the REST surface's per-workspace count — the
+	// window lives in Postgres now (NewOverlayMeter's doc), so the MCP
+	// tool surface's force-fresh spend and contractAPI's Dispatcher's
+	// draw on the SAME budget rather than each on a private in-process
+	// counter.
+	provider := NewDispatcher(NewProvider(pool), NewOverlayProvider(pool, NewOverlayMeter(pool), nil), pool)
 	registry := agents.NewRegistry(approvalsAdapter{svc: approvals.NewService(pool)}, gate)
 	agents.RegisterCoreTools(registry, provider, provider, provider, fieldOwnership{pool: pool})
 	agents.RegisterReportTool(registry, reportToolRunner(newReportEngine(pool)))

--- a/backend/internal/compose/registry.go
+++ b/backend/internal/compose/registry.go
@@ -45,11 +45,13 @@ func registryWithGate(pool *pgxpool.Pool, gate *auth.Gate, drafter activities.Em
 	// Provider exactly as before, an overlay-mode workspace's reads land
 	// on the mirror (design.md §4.2/§4.6) — chosen per call from
 	// ctx, never fixed at registry construction time. This registry's own
-	// OVB meter shares the REST surface's per-workspace count — the
-	// window lives in Postgres now (NewOverlayMeter's doc), so the MCP
-	// tool surface's force-fresh spend and contractAPI's Dispatcher's
-	// draw on the SAME budget rather than each on a private in-process
-	// counter.
+	// OVB meter is backed by the SAME shared per-workspace window as
+	// contractAPI's Dispatcher (the window lives in Postgres now —
+	// NewOverlayMeter's doc), not a private in-process counter. The MCP
+	// overlay provider carries no live-incumbent resolver (the nil below)
+	// and agent tools never call the freshness path, so this surface
+	// incurs no force-fresh spend of its own today; the shared backing is
+	// what matters if it ever does.
 	provider := NewDispatcher(NewProvider(pool), NewOverlayProvider(pool, NewOverlayMeter(pool), nil), pool)
 	registry := agents.NewRegistry(approvalsAdapter{svc: approvals.NewService(pool)}, gate)
 	agents.RegisterCoreTools(registry, provider, provider, provider, fieldOwnership{pool: pool})

--- a/backend/internal/compose/server.go
+++ b/backend/internal/compose/server.go
@@ -143,11 +143,14 @@ type Server struct {
 	aiMetrics func(io.Writer)
 	aiState   string // the /readyz AI line (aistate.go); never a readiness gate
 
-	// overlayMeter is the ONE OVB meter this Server's REST surface
-	// spends against (contractAPI's Dispatcher force-fresh reads) and
-	// reports through (GetOverlayBudget, once WithKeyvault rebuilds
-	// overlayHandlers over it) — see compose/overlay.go's
-	// NewOverlayMeter doc on why these two must share an instance.
+	// overlayMeter is this Server's REST-surface OVB meter — what
+	// contractAPI's Dispatcher force-fresh reads spend against and what
+	// GetOverlayBudget reports (once WithKeyvault rebuilds
+	// overlayHandlers over it). Its window lives in Postgres now, so it
+	// shares a per-workspace count with every other meter over the same
+	// pool (see compose/overlay.go's NewOverlayMeter doc); threading this
+	// one instance through both wiring points is convention, no longer a
+	// correctness requirement.
 	// Always non-nil (newServer constructs it unconditionally): a
 	// workspace never in overlay mode never spends against it, and a
 	// role with no vault simply never reaches GetOverlayBudget's 501.
@@ -279,7 +282,7 @@ func newServer(pool *pgxpool.Pool, log *slog.Logger, authH authHandlers, dealsH 
 		// second one, and contractAPI's Dispatcher spends force-fresh
 		// reads against it too (see compose/overlay.go's NewOverlayMeter
 		// doc).
-		overlayMeter: NewOverlayMeter(),
+		overlayMeter: NewOverlayMeter(pool),
 	}
 	// The overlay read dispatch is built with a nil live-incumbent resolver
 	// here (force-fresh degrades to the mirror). WithKeyvault injects the

--- a/backend/internal/compose/workflows.go
+++ b/backend/internal/compose/workflows.go
@@ -57,10 +57,10 @@ func workflowEngineWithDrafter(pool *pgxpool.Pool, drafter activities.EmailDraft
 	// datasource consumer: a starter firing for an overlay-mode
 	// workspace reads/writes through the overlay seam, not silently
 	// against the native tables that workspace no longer owns. This
-	// engine's own OVB meter is independent of the REST surface's
-	// (NewOverlayMeter's doc note).
+	// engine's own OVB meter shares the REST surface's per-workspace
+	// count through the Postgres-backed window (NewOverlayMeter's doc).
 	ex := automation.Executors{
-		Provider:  NewDispatcher(NewProvider(pool), NewOverlayProvider(pool, NewOverlayMeter(), nil), pool),
+		Provider:  NewDispatcher(NewProvider(pool), NewOverlayProvider(pool, NewOverlayMeter(pool), nil), pool),
 		Approvals: automationApprovalsAdapter{svc: approvals.NewService(pool)},
 		Lists:     listsAdapter{store: collections.NewStore(pool)},
 		Comms: commsAdapter{

--- a/backend/internal/modules/overlay/budgetmeter.go
+++ b/backend/internal/modules/overlay/budgetmeter.go
@@ -16,10 +16,18 @@ package overlay
 // row per workspace. ADR-0054/A69 runs cmd/api (this meter's force_fresh
 // caller) and cmd/worker (the poller caller) as two DISTINCT OS processes;
 // both read and advance the SAME row, so a workspace's combined spend against
-// its ONE real HubSpot quota is bounded by Limit — not (process count)×Limit,
-// the "don't starve the shared quota" hole a per-process in-memory counter
-// had by construction — and GET /overlay/budget reflects the poller's spend,
-// not just the reading process's.
+// its ONE real HubSpot quota is measured against ONE shared Limit — not
+// (process count)×Limit, the "don't starve the shared quota" hole a
+// per-process in-memory counter had by construction — and GET /overlay/budget
+// reflects the poller's spend, not just the reading process's.
+//
+// "Measured", not hard-capped: force_fresh reads Reserve (they shed once the
+// shared window crosses the threshold), but the poller lane Consumes
+// unconditionally — an incumbent it must mirror is not something to refuse
+// partway. So the shared count bounds what force_fresh will SPEND, and
+// reports how close the poller is to the ceiling, but it does not itself cap
+// the poller; a hard poller cap (a token bucket over this same shared row) is
+// the coupled follow-up.
 //
 // The window is fixed (window_start + Window duration), not sliding: a
 // consume/reserve whose clock reads past window_start+Window rolls the window

--- a/backend/internal/modules/overlay/budgetmeter.go
+++ b/backend/internal/modules/overlay/budgetmeter.go
@@ -12,44 +12,39 @@ package overlay
 // whether a force-fresh read is affordable; Snapshot() answers the
 // GET /overlay/budget read surface.
 //
-// Storage: in-memory, per-PROCESS, per-workspace. ADR-0054/A69 already
-// runs FOUR separate cmd/<role> binaries in normal operation — cmd/api (this
-// meter's force_fresh caller) and cmd/worker (the poller
-// caller) are two DISTINCT OS processes today, each with
-// its OWN Meter instance and its OWN in-memory counters, even with a
-// single replica of each. They do NOT share this counter. So the
-// combined spend against the ONE real HubSpot quota a workspace holds
-// is bounded by (process count) x Limit, not by Limit — exactly the
-// "don't starve the shared quota" property this meter exists to
-// protect, undercut by construction the moment more than one role
-// process reads/writes for the same workspace. This is not a
-// multi-replica-only concern; it is true right now, with one replica
-// of each of the two roles.
+// Storage: a shared, cross-process PG counter (overlay_budget_window), ONE
+// row per workspace. ADR-0054/A69 runs cmd/api (this meter's force_fresh
+// caller) and cmd/worker (the poller caller) as two DISTINCT OS processes;
+// both read and advance the SAME row, so a workspace's combined spend against
+// its ONE real HubSpot quota is bounded by Limit — not (process count)×Limit,
+// the "don't starve the shared quota" hole a per-process in-memory counter
+// had by construction — and GET /overlay/budget reflects the poller's spend,
+// not just the reading process's.
 //
-// TODO(branch-1b/pre-GA, design.md#5.1): replace this per-process counter
-// with a shared PG/Redis counter before customer-GA — required so
-// api+worker don't each spend a full budget against the shared incumbent
-// quota (OVA-PARAM-8/9). Gated the same way design.md §5.1 gates the
-// branch-1b visibility floor: "no customer-GA until [the gate] pass[es]."
-// Not built now because OVA-PARAM-8/9's own numeric values are still
-// unpinned upstream (see DefaultMeterConfig's doc) — a shared counter
-// with unspecified capacity/threshold parameters would be premature
-// machinery, not a fix.
+// The window is fixed (window_start + Window duration), not sliding: a
+// consume/reserve whose clock reads past window_start+Window rolls the window
+// (resets window_start and consumed) in the SAME statement, so a stale window
+// can never over-count. It mirrors an incumbent's own fixed quota-reset
+// cadence, which this build has no visibility into.
 //
-// The window itself is fixed (start, then reset after Window elapses),
-// not sliding — good enough to protect a per-process slice of the quota
-// without the bookkeeping a sliding window needs, and it mirrors an
-// incumbent's own quota-reset cadence (a fixed per-hour/per-day window),
-// which this build has no visibility into.
+// "now" is the meter's injected clock, threaded into every statement as a
+// parameter rather than SQL now(): window expiry stays a property tests
+// assert by advancing the clock, never by sleeping (T11).
+//
+// OVA-PARAM-8/9 (the OVB numeric capacity/thresholds) are still unpinned
+// upstream — DefaultMeterConfig's numbers are this build's honest placeholder
+// (see its doc), now enforced by a shared counter rather than a per-process
+// one.
 
 import (
 	"context"
 	"fmt"
-	"sync"
 	"time"
 
-	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
-	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/gradionhq/margince/backend/internal/platform/database"
 )
 
 // Lane names Consume's caller declares — the fixed lane set this
@@ -117,86 +112,99 @@ type Budget struct {
 	Band     string
 }
 
-// windowState is one workspace's current fixed window: when it started
-// and how much each lane has spent inside it.
-type windowState struct {
-	start  time.Time
-	byLane map[string]int
-	total  int
-}
-
-// Meter is the OVB consumption meter: Consume records spend, Band
-// answers the current degradation band, Snapshot answers the read
-// surface. The zero value is not usable; construct with NewMeter or
-// NewMeterWithClock.
+// Meter is the OVB consumption meter: Consume records spend, Reserve
+// atomically band-checks then records, Band answers the current
+// degradation band, Snapshot answers the read surface. Every operation
+// reads/advances the ONE overlay_budget_window row for ctx's workspace,
+// so the count is shared across processes. The zero value is not usable;
+// construct with NewMeter or NewMeterWithClock.
 type Meter struct {
-	cfg MeterConfig
-	now func() time.Time
-
-	mu      sync.Mutex
-	windows map[ids.UUID]*windowState
+	cfg  MeterConfig
+	pool *pgxpool.Pool
+	now  func() time.Time
 }
 
-// NewMeter constructs a Meter over cfg using the real wall clock.
-func NewMeter(cfg MeterConfig) *Meter {
-	return NewMeterWithClock(cfg, time.Now)
+// NewMeter constructs a Meter over cfg backed by pool, using the real
+// wall clock.
+func NewMeter(pool *pgxpool.Pool, cfg MeterConfig) *Meter {
+	return NewMeterWithClock(pool, cfg, time.Now)
 }
 
 // NewMeterWithClock takes the clock as a dependency so window expiry is
 // a property tests assert by advancing time, not by sleeping against
-// it (T11) — the same discipline platform/ratelimit.NewWithClock uses.
-func NewMeterWithClock(cfg MeterConfig, now func() time.Time) *Meter {
-	return &Meter{cfg: cfg, now: now, windows: make(map[ids.UUID]*windowState)}
+// it (T11): the clock's reading is threaded into every statement as the
+// $now parameter (rather than SQL now()), so a test rolls the window by
+// handing the meter a later time, deterministically.
+func NewMeterWithClock(pool *pgxpool.Pool, cfg MeterConfig, now func() time.Time) *Meter {
+	return &Meter{cfg: cfg, pool: pool, now: now}
 }
 
-// withState resolves ctx's workspace's current window (resetting it
-// first if the prior window has expired) and runs fn against it WHILE
-// STILL HOLDING m.mu — the whole read-or-modify operation is one
-// critical section. This is load-bearing, not defensive style: an
-// earlier version resolved the window under the lock, released it, and
-// let Consume/Band/Snapshot re-acquire separately to read/mutate — a
-// window that expired and got replaced in the gap between those two
-// lock sections would silently lose a spend the caller believed it had
-// recorded. A ctx with no workspace bound is a programming error (every
-// operation context binds one — the HTTP middleware, or a job's own
-// operation scope); it never runs fn against an empty workspace key.
-func (m *Meter) withState(ctx context.Context, fn func(st *windowState)) error {
-	wsID, ok := principal.WorkspaceID(ctx)
-	if !ok {
-		return fmt.Errorf("overlay: budget meter requires a workspace-bound context")
-	}
-	now := m.now()
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	st, ok := m.windows[wsID]
-	if !ok || now.Sub(st.start) >= m.cfg.Window {
-		st = &windowState{start: now, byLane: make(map[string]int)}
-		m.windows[wsID] = st
-	}
-	fn(st)
-	return nil
-}
+// windowSeconds is the configured window as float seconds, the shape the
+// SQL's make_interval(secs => $2) wants. Threading the window as a
+// parameter (not a literal) keeps the roll condition — "now minus
+// window_start has reached a full window" — identical across every
+// statement below.
+func (m *Meter) windowSeconds() float64 { return m.cfg.Window.Seconds() }
 
-// Consume records n spend units against lane for ctx's workspace's
-// current window.
+// upsertRollAdd is the shared upsert every WRITE runs: insert a fresh
+// window (consumed = $3) if the workspace has none, else — in the SAME
+// statement — roll the window when $now has reached window_start + Window
+// (reset window_start to $now and consumed to $3) or otherwise ADD $3 to
+// the running total. Because the roll and the add are one statement, a
+// window that has just expired can never be added onto: it is reset
+// first, atomically. $1=now, $2=window seconds, $3=units to add.
+const upsertRollAdd = `
+	INSERT INTO overlay_budget_window (workspace_id, window_start, consumed, updated_at)
+	VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $3, $1)
+	ON CONFLICT (workspace_id) DO UPDATE SET
+		window_start = CASE WHEN $1 - overlay_budget_window.window_start >= make_interval(secs => $2)
+			THEN $1 ELSE overlay_budget_window.window_start END,
+		consumed = CASE WHEN $1 - overlay_budget_window.window_start >= make_interval(secs => $2)
+			THEN $3 ELSE overlay_budget_window.consumed + $3 END,
+		updated_at = $1`
+
+// effectiveConsumed is the shared READ: the workspace's consumed count,
+// but ZERO when the stored window has already expired ($now has reached
+// window_start + Window) or no row exists yet. It never mutates, so a
+// read of an expired window reports 0 without rolling it — the next write
+// does the reset. $1=now, $2=window seconds.
+const effectiveConsumed = `
+	SELECT COALESCE((
+		SELECT CASE WHEN $1 - window_start >= make_interval(secs => $2) THEN 0 ELSE consumed END
+		FROM overlay_budget_window
+		WHERE workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid
+	), 0)`
+
+// Consume records n spend units for ctx's workspace's current window
+// (rolling the window first if it has expired). A non-positive n is a
+// no-op — the poller call site passes len(page.Records), which is 0 for
+// an empty page, and an empty page spent no quota to record. The write
+// runs inside WithWorkspaceTx so RLS binds it to ctx's workspace and the
+// GUC the SQL reads is set.
 func (m *Meter) Consume(ctx context.Context, lane string, n int) error {
-	return m.withState(ctx, func(st *windowState) {
-		st.byLane[lane] += n
-		st.total += n
+	if n <= 0 {
+		return nil
+	}
+	return database.WithWorkspaceTx(ctx, m.pool, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, upsertRollAdd, m.now(), m.windowSeconds(), n); err != nil {
+			return fmt.Errorf("overlay: recording %d %s budget units: %w", n, lane, err)
+		}
+		return nil
 	})
 }
 
 // Reserve atomically checks ctx's workspace band and, if it is NOT shed,
 // records n spend units and returns allowed=true; if the band is already
-// shed it records nothing and returns allowed=false. Doing the band check
-// and the record under ONE lock is the whole point: FreshnessReader must
-// reserve its force-fresh unit BEFORE the live incumbent call, or N
-// concurrent force-fresh reads would all observe a non-shed band, all
-// reach the incumbent (each spending real quota), and only then record
-// consumption — collectively overshooting the budget. Reserving up front
-// also means a live read that later FAILS still counts (its HTTP call
-// spent quota all the same), unlike a Consume placed after the call that a
-// failure path skips.
+// shed it records nothing and returns allowed=false. The check and the
+// record are ONE transaction holding the row lock the whole time: an
+// earlier ROLL-and-lock upsert takes the row's write lock (and returns
+// the post-roll consumed), the band is judged on that locked count, and
+// the conditional add commits under the same lock — so N concurrent
+// force-fresh reservations serialize through the row rather than all
+// observing a non-shed band, all reaching the incumbent, and only then
+// recording. Reserving BEFORE the live call also means a read that later
+// FAILS still counts (its HTTP call spent quota all the same), unlike a
+// Consume placed after the call that a failure path skips.
 func (m *Meter) Reserve(ctx context.Context, lane string, n int) (bool, error) {
 	if n <= 0 {
 		// A non-positive reservation would either weaken enforcement (n=0
@@ -206,13 +214,28 @@ func (m *Meter) Reserve(ctx context.Context, lane string, n int) (bool, error) {
 		return false, fmt.Errorf("overlay: budget reserve requires a positive unit count, got %d", n)
 	}
 	allowed := false
-	err := m.withState(ctx, func(st *windowState) {
-		if m.cfg.band(st.total) == BandShed {
-			return
+	err := database.WithWorkspaceTx(ctx, m.pool, func(tx pgx.Tx) error {
+		// Roll-if-expired and take the row's write lock, returning the
+		// current (post-roll) consumed. A 0-unit upsert here does not
+		// advance the count — it exists only to create/roll the row and
+		// hold its lock for the band decision below.
+		var consumed int
+		if err := tx.QueryRow(ctx, upsertRollAdd+`
+			RETURNING consumed`, m.now(), m.windowSeconds(), 0).Scan(&consumed); err != nil {
+			return fmt.Errorf("overlay: locking the budget window to reserve %d %s units: %w", n, lane, err)
 		}
-		st.byLane[lane] += n
-		st.total += n
+		if m.cfg.band(consumed) == BandShed {
+			return nil // allowed stays false; nothing recorded
+		}
+		if _, err := tx.Exec(ctx, `
+			UPDATE overlay_budget_window
+			SET consumed = consumed + $1, updated_at = $2
+			WHERE workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid`,
+			n, m.now()); err != nil {
+			return fmt.Errorf("overlay: recording the reserved %d %s units: %w", n, lane, err)
+		}
 		allowed = true
+		return nil
 	})
 	if err != nil {
 		return false, err
@@ -238,26 +261,27 @@ func (cfg MeterConfig) band(consumed int) string {
 	}
 }
 
-// Band reports ctx's workspace's current degradation band. A ctx with
-// no workspace bound answers shed — the fail-closed direction: Band's
-// only caller inside this package (FreshnessReader.Read) uses it to
-// decide whether a force-fresh spend is affordable, and an unknown
-// budget must never be read as "spend freely."
+// Band reports ctx's workspace's current degradation band. A read error
+// — including a ctx with no workspace bound, which makes WithWorkspaceTx
+// fail — answers shed, the fail-closed direction: Band's only caller
+// inside this package (FreshnessReader.Read) uses it to decide whether a
+// force-fresh spend is affordable, and an unknown budget must never be
+// read as "spend freely."
 func (m *Meter) Band(ctx context.Context) string {
-	var consumed int
-	if err := m.withState(ctx, func(st *windowState) { consumed = st.total }); err != nil {
+	consumed, err := m.readConsumed(ctx)
+	if err != nil {
 		return BandShed
 	}
 	return m.cfg.band(consumed)
 }
 
 // Snapshot answers the current window's consumption for ctx's
-// workspace — the shape GetOverlayBudget reads. A ctx with no
-// workspace bound answers the same fail-closed shed band Band does,
-// with zero consumption (there is no window to report on).
+// workspace — the shape GetOverlayBudget reads. A read error answers the
+// same fail-closed shed band Band does, with zero consumption (there is
+// no window it can trust to report on).
 func (m *Meter) Snapshot(ctx context.Context) Budget {
-	var consumed int
-	if err := m.withState(ctx, func(st *windowState) { consumed = st.total }); err != nil {
+	consumed, err := m.readConsumed(ctx)
+	if err != nil {
 		return Budget{Window: m.cfg.Window.String(), Consumed: 0, Limit: m.cfg.Limit, Band: BandShed}
 	}
 	return Budget{
@@ -266,4 +290,19 @@ func (m *Meter) Snapshot(ctx context.Context) Budget {
 		Limit:    m.cfg.Limit,
 		Band:     m.cfg.band(consumed),
 	}
+}
+
+// readConsumed runs the read-only effectiveConsumed query for ctx's
+// workspace (0 for an expired or absent window). Both read surfaces
+// (Band, Snapshot) go through it so the "expired reads as 0, never
+// rolls" rule lives in one place.
+func (m *Meter) readConsumed(ctx context.Context) (int, error) {
+	var consumed int
+	err := database.WithWorkspaceTx(ctx, m.pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, effectiveConsumed, m.now(), m.windowSeconds()).Scan(&consumed)
+	})
+	if err != nil {
+		return 0, err
+	}
+	return consumed, nil
 }

--- a/backend/internal/modules/overlay/budgetmeter.go
+++ b/backend/internal/modules/overlay/budgetmeter.go
@@ -24,9 +24,14 @@ package overlay
 // "Measured", not hard-capped: force_fresh reads Reserve (they shed once the
 // shared window crosses the threshold), but the poller lane Consumes
 // unconditionally — an incumbent it must mirror is not something to refuse
-// partway. So the shared count bounds what force_fresh will SPEND, and
-// reports how close the poller is to the ceiling, but it does not itself cap
-// the poller; a hard poller cap (a token bucket over this same shared row) is
+// partway. So the shared count bounds what force_fresh will SPEND against the
+// window; the poller only records its own accounting units into it, and those
+// units are approximate — reconcile.go Consumes len(page.Records)/
+// len(page.Deletions) (a per-record count), whereas real HubSpot quota is
+// spent per REQUEST (a page fetch, plus any enrichment calls). So the poller's
+// contribution tracks work done, not requests made, and can diverge from the
+// true quota ceiling. It does not itself cap the poller; a hard poller cap
+// with request-level metering (a token bucket over this same shared row) is
 // the coupled follow-up.
 //
 // The window is fixed (window_start + Window duration), not sliding: a

--- a/backend/internal/modules/overlay/budgetmeter_test.go
+++ b/backend/internal/modules/overlay/budgetmeter_test.go
@@ -1,28 +1,34 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-package overlay_test
+//go:build integration
 
-// Meter's unit-level proof: the ok/warn/shed band arithmetic, the
+package overlay
+
+// Meter's contract against the real, shared Postgres window
+// (overlay_budget_window): the ok/warn/shed band arithmetic, the
 // per-workspace fixed-window reset (via NewMeterWithClock's injected
-// clock — T11, no time.Sleep), and the fail-closed answers a
-// context with no workspace bound gets from Band/Snapshot. Consume's
-// lane-crossing accumulation and the meter's use from a real caller
-// (reconcile.go, freshness.go) are proven by their own tests; this file
-// is the meter's own contract in isolation.
+// clock — T11, no time.Sleep), Reserve's cross-transaction atomicity
+// (the property that makes the counter safe to share between cmd/api and
+// cmd/worker), and the fail-closed answers a context with no workspace
+// bound gets from Band/Snapshot. The counter lives in the database now,
+// so this is an integration test, not a pure-unit one: the row-lock that
+// serializes concurrent Reserves is a Postgres row lock, provable only
+// against Postgres. Consume's use from a real caller (reconcile.go,
+// freshness.go) is proven by their own tests.
+//
+// Each test mints its OWN workspace via testWorkspaceCtx, so one test's
+// consumption can never leak into another's band assertion (and the FK
+// to workspace(id) the counter carries is satisfied by a real row).
 
 import (
-	"context"
 	"sync"
 	"testing"
 	"time"
-
-	"github.com/gradionhq/margince/backend/internal/modules/overlay"
-	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
-func testMeterCfg() overlay.MeterConfig {
-	return overlay.MeterConfig{Window: time.Hour, Limit: 100, WarnFraction: 0.7, ShedFraction: 0.9}
+func testMeterCfg() MeterConfig {
+	return MeterConfig{Window: time.Hour, Limit: 100, WarnFraction: 0.7, ShedFraction: 0.9}
 }
 
 // fixedClock is a stable clock for the meter tests that assert band
@@ -34,30 +40,15 @@ func fixedClock() func() time.Time {
 	return func() time.Time { return now }
 }
 
-func wsCtx() context.Context {
-	return principal.WithWorkspaceID(context.Background(), mustWorkspaceID())
-}
-
-// mustWorkspaceID mints a fresh workspace id for a test's own isolated
-// meter state — tests never share a workspace id, so one test's
-// consumption can never leak into another's band assertion.
-func mustWorkspaceID() (id [16]byte) {
-	// A fixed, non-zero id is enough here: each test constructs its own
-	// Meter instance, so there is no cross-test window state to collide
-	// with even if two tests reused the same workspace id.
-	id[0] = 1
-	return id
-}
-
 // TestMeterReserveRecordsOnlyWhenNotShed proves the atomic check-and-record
 // FreshnessReader relies on: under budget Reserve allows and records the
 // spend; once shed it refuses AND records nothing — the two decided under
-// one lock so concurrent force-fresh reads can't collectively overshoot.
+// one row lock so concurrent force-fresh reads can't collectively overshoot.
 func TestMeterReserveRecordsOnlyWhenNotShed(t *testing.T) {
-	m := overlay.NewMeterWithClock(testMeterCfg(), fixedClock()) // Limit 100, shed 0.9
-	ctx := wsCtx()
+	ctx, pool, _ := testWorkspaceCtx(t)
+	m := NewMeterWithClock(pool, testMeterCfg(), fixedClock()) // Limit 100, shed 0.9
 
-	allowed, err := m.Reserve(ctx, overlay.LaneForceFresh, 1)
+	allowed, err := m.Reserve(ctx, LaneForceFresh, 1)
 	if err != nil {
 		t.Fatalf("Reserve (under budget): %v", err)
 	}
@@ -70,11 +61,11 @@ func TestMeterReserveRecordsOnlyWhenNotShed(t *testing.T) {
 
 	// Push total to the shed threshold (>= 0.9*100), then Reserve must
 	// refuse and record nothing.
-	if err := m.Consume(ctx, overlay.LanePoller, 89); err != nil { // total 90 >= 90
+	if err := m.Consume(ctx, LanePoller, 89); err != nil { // total 90 >= 90
 		t.Fatalf("Consume to shed: %v", err)
 	}
 	before := m.Snapshot(ctx).Consumed
-	allowed, err = m.Reserve(ctx, overlay.LaneForceFresh, 1)
+	allowed, err = m.Reserve(ctx, LaneForceFresh, 1)
 	if err != nil {
 		t.Fatalf("Reserve (shed): %v", err)
 	}
@@ -87,16 +78,18 @@ func TestMeterReserveRecordsOnlyWhenNotShed(t *testing.T) {
 }
 
 // TestMeterReserveIsAtomicUnderConcurrency proves Reserve's whole point:
-// the band check and the spend record happen under one lock, so a burst of
-// concurrent force-fresh reservations near the shed threshold cannot
-// collectively overshoot the budget. Primed at 88/100 (shed at 90), 20
-// concurrent Reserves must allow EXACTLY 2 (88→89, 89→90, then shed) and
-// leave the total at 90 — a non-atomic band-then-record would let several
-// goroutines all observe 88/89 and push the total past the threshold.
+// the band check and the spend record happen under one Postgres row lock,
+// so a burst of concurrent force-fresh reservations near the shed
+// threshold cannot collectively overshoot the budget — the property that
+// makes the counter safe to share across cmd/api and cmd/worker. Primed at
+// 88/100 (shed at 90), 20 concurrent Reserves — each its own transaction
+// over the pool — must allow EXACTLY 2 (88→89, 89→90, then shed) and leave
+// the total at 90. A non-atomic band-then-record would let several
+// transactions all observe 88/89 and push the total past the threshold.
 func TestMeterReserveIsAtomicUnderConcurrency(t *testing.T) {
-	m := overlay.NewMeterWithClock(testMeterCfg(), fixedClock()) // Limit 100, shed 0.9 → shed at 90
-	ctx := wsCtx()
-	if err := m.Consume(ctx, overlay.LanePoller, 88); err != nil {
+	ctx, pool, _ := testWorkspaceCtx(t)
+	m := NewMeterWithClock(pool, testMeterCfg(), fixedClock()) // Limit 100, shed 0.9 → shed at 90
+	if err := m.Consume(ctx, LanePoller, 88); err != nil {
 		t.Fatalf("priming the window to 88: %v", err)
 	}
 
@@ -104,12 +97,14 @@ func TestMeterReserveIsAtomicUnderConcurrency(t *testing.T) {
 	var wg sync.WaitGroup
 	var mu sync.Mutex
 	allowed := 0
+	errs := make(chan error, goroutines)
 	for i := 0; i < goroutines; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			ok, err := m.Reserve(ctx, overlay.LaneForceFresh, 1)
+			ok, err := m.Reserve(ctx, LaneForceFresh, 1)
 			if err != nil {
+				errs <- err
 				return
 			}
 			if ok {
@@ -120,6 +115,10 @@ func TestMeterReserveIsAtomicUnderConcurrency(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatalf("concurrent Reserve errored: %v", err)
+	}
 
 	if allowed != 2 {
 		t.Fatalf("allowed concurrent reservations = %d, want exactly 2 (88→89→90, then shed)", allowed)
@@ -130,90 +129,93 @@ func TestMeterReserveIsAtomicUnderConcurrency(t *testing.T) {
 }
 
 func TestMeterBandStartsOK(t *testing.T) {
-	m := overlay.NewMeterWithClock(testMeterCfg(), fixedClock())
-	ctx := wsCtx()
+	ctx, pool, _ := testWorkspaceCtx(t)
+	m := NewMeterWithClock(pool, testMeterCfg(), fixedClock())
 
-	if got := m.Band(ctx); got != overlay.BandOK {
-		t.Fatalf("Band() on an untouched window = %q, want %q", got, overlay.BandOK)
+	if got := m.Band(ctx); got != BandOK {
+		t.Fatalf("Band() on an untouched window = %q, want %q", got, BandOK)
 	}
 }
 
 func TestMeterBandCrossesWarnAndShedThresholds(t *testing.T) {
-	m := overlay.NewMeterWithClock(testMeterCfg(), fixedClock()) // Limit 100, warn 0.7, shed 0.9
-	ctx := wsCtx()
+	ctx, pool, _ := testWorkspaceCtx(t)
+	m := NewMeterWithClock(pool, testMeterCfg(), fixedClock()) // Limit 100, warn 0.7, shed 0.9
 
-	if err := m.Consume(ctx, overlay.LaneForceFresh, 65); err != nil {
+	if err := m.Consume(ctx, LaneForceFresh, 65); err != nil {
 		t.Fatalf("Consume: %v", err)
 	}
-	if got := m.Band(ctx); got != overlay.BandOK {
-		t.Fatalf("Band() at 65/100 = %q, want %q", got, overlay.BandOK)
+	if got := m.Band(ctx); got != BandOK {
+		t.Fatalf("Band() at 65/100 = %q, want %q", got, BandOK)
 	}
 
-	if err := m.Consume(ctx, overlay.LanePoller, 10); err != nil { // total 75 >= 70
+	if err := m.Consume(ctx, LanePoller, 10); err != nil { // total 75 >= 70
 		t.Fatalf("Consume: %v", err)
 	}
-	if got := m.Band(ctx); got != overlay.BandWarn {
-		t.Fatalf("Band() at 75/100 = %q, want %q", got, overlay.BandWarn)
+	if got := m.Band(ctx); got != BandWarn {
+		t.Fatalf("Band() at 75/100 = %q, want %q", got, BandWarn)
 	}
 
-	if err := m.Consume(ctx, overlay.LanePoller, 20); err != nil { // total 95 >= 90
+	if err := m.Consume(ctx, LanePoller, 20); err != nil { // total 95 >= 90
 		t.Fatalf("Consume: %v", err)
 	}
-	if got := m.Band(ctx); got != overlay.BandShed {
-		t.Fatalf("Band() at 95/100 = %q, want %q", got, overlay.BandShed)
+	if got := m.Band(ctx); got != BandShed {
+		t.Fatalf("Band() at 95/100 = %q, want %q", got, BandShed)
 	}
 }
 
 func TestMeterNonPositiveLimitAlwaysSheds(t *testing.T) {
-	m := overlay.NewMeterWithClock(overlay.MeterConfig{Window: time.Hour, Limit: 0, WarnFraction: 0.7, ShedFraction: 0.9}, fixedClock())
-	ctx := wsCtx()
+	ctx, pool, _ := testWorkspaceCtx(t)
+	m := NewMeterWithClock(pool, MeterConfig{Window: time.Hour, Limit: 0, WarnFraction: 0.7, ShedFraction: 0.9}, fixedClock())
 
-	if got := m.Band(ctx); got != overlay.BandShed {
-		t.Fatalf("Band() with a non-positive Limit = %q, want %q (fail closed)", got, overlay.BandShed)
+	if got := m.Band(ctx); got != BandShed {
+		t.Fatalf("Band() with a non-positive Limit = %q, want %q (fail closed)", got, BandShed)
 	}
 }
 
 func TestMeterBandAndSnapshotFailClosedWithNoWorkspaceBound(t *testing.T) {
-	m := overlay.NewMeterWithClock(testMeterCfg(), fixedClock())
-	ctx := context.Background() // no workspace bound
+	_, pool, _ := testWorkspaceCtx(t)
+	m := NewMeterWithClock(pool, testMeterCfg(), fixedClock())
+	ctx := t.Context() // no workspace bound → WithWorkspaceTx fails
 
-	if got := m.Band(ctx); got != overlay.BandShed {
-		t.Fatalf("Band() with no workspace bound = %q, want %q (fail closed)", got, overlay.BandShed)
+	if got := m.Band(ctx); got != BandShed {
+		t.Fatalf("Band() with no workspace bound = %q, want %q (fail closed)", got, BandShed)
 	}
 	snap := m.Snapshot(ctx)
-	if snap.Band != overlay.BandShed || snap.Consumed != 0 {
+	if snap.Band != BandShed || snap.Consumed != 0 {
 		t.Fatalf("Snapshot() with no workspace bound = %+v, want Band=shed Consumed=0", snap)
 	}
 }
 
 func TestMeterConsumeRequiresAWorkspaceBoundContext(t *testing.T) {
-	m := overlay.NewMeterWithClock(testMeterCfg(), fixedClock())
-	if err := m.Consume(context.Background(), overlay.LaneForceFresh, 1); err == nil {
+	_, pool, _ := testWorkspaceCtx(t)
+	m := NewMeterWithClock(pool, testMeterCfg(), fixedClock())
+	if err := m.Consume(t.Context(), LaneForceFresh, 1); err == nil {
 		t.Fatal("Consume with no workspace bound: want an error, got nil")
 	}
 }
 
 // TestMeterWindowResetsAfterExpiry proves the FIXED window reset: once
 // the injected clock advances past cfg.Window, the next Consume/Band
-// call starts a brand-new window rather than accumulating against the
-// stale one — proven deterministically via NewMeterWithClock, never by
-// sleeping against the real clock (T11).
+// call rolls into a brand-new window rather than accumulating against the
+// stale one — proven deterministically via NewMeterWithClock (the clock's
+// reading is the SQL $now parameter), never by sleeping against the real
+// clock (T11).
 func TestMeterWindowResetsAfterExpiry(t *testing.T) {
+	ctx, pool, _ := testWorkspaceCtx(t)
 	now := time.Date(2026, 7, 17, 12, 0, 0, 0, time.UTC)
 	clock := func() time.Time { return now }
-	m := overlay.NewMeterWithClock(testMeterCfg(), clock)
-	ctx := wsCtx()
+	m := NewMeterWithClock(pool, testMeterCfg(), clock)
 
-	if err := m.Consume(ctx, overlay.LaneForceFresh, 95); err != nil {
+	if err := m.Consume(ctx, LaneForceFresh, 95); err != nil {
 		t.Fatalf("Consume: %v", err)
 	}
-	if got := m.Band(ctx); got != overlay.BandShed {
-		t.Fatalf("Band() at 95/100 = %q, want %q", got, overlay.BandShed)
+	if got := m.Band(ctx); got != BandShed {
+		t.Fatalf("Band() at 95/100 = %q, want %q", got, BandShed)
 	}
 
 	now = now.Add(testMeterCfg().Window + time.Second) // advance past the window
-	if got := m.Band(ctx); got != overlay.BandOK {
-		t.Fatalf("Band() after window expiry = %q, want %q (a fresh window)", got, overlay.BandOK)
+	if got := m.Band(ctx); got != BandOK {
+		t.Fatalf("Band() after window expiry = %q, want %q (a fresh window)", got, BandOK)
 	}
 	snap := m.Snapshot(ctx)
 	if snap.Consumed != 0 {
@@ -221,14 +223,36 @@ func TestMeterWindowResetsAfterExpiry(t *testing.T) {
 	}
 }
 
+// TestMeterWindowResetOnWriteAfterExpiry proves the reset is a WRITE-path
+// roll, not only a read-path zeroing: after the window expires, a Consume
+// starts a fresh window at exactly the units it records (not stale + new),
+// so the shared row a later reader sees reflects the new window alone.
+func TestMeterWindowResetOnWriteAfterExpiry(t *testing.T) {
+	ctx, pool, _ := testWorkspaceCtx(t)
+	now := time.Date(2026, 7, 17, 12, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+	m := NewMeterWithClock(pool, testMeterCfg(), clock)
+
+	if err := m.Consume(ctx, LaneForceFresh, 80); err != nil {
+		t.Fatalf("Consume (first window): %v", err)
+	}
+	now = now.Add(testMeterCfg().Window + time.Second) // expire the window
+	if err := m.Consume(ctx, LanePoller, 5); err != nil {
+		t.Fatalf("Consume (rolled window): %v", err)
+	}
+	if got := m.Snapshot(ctx).Consumed; got != 5 {
+		t.Fatalf("consumed after a post-expiry Consume = %d, want 5 (fresh window, not 85)", got)
+	}
+}
+
 // TestMeterSnapshotReportsWindowLimitAndBand proves Snapshot's full
 // shape — the GetOverlayBudget wire read's own source of truth.
 func TestMeterSnapshotReportsWindowLimitAndBand(t *testing.T) {
+	ctx, pool, _ := testWorkspaceCtx(t)
 	cfg := testMeterCfg()
-	m := overlay.NewMeterWithClock(cfg, fixedClock())
-	ctx := wsCtx()
+	m := NewMeterWithClock(pool, cfg, fixedClock())
 
-	if err := m.Consume(ctx, overlay.LaneForceFresh, 42); err != nil {
+	if err := m.Consume(ctx, LaneForceFresh, 42); err != nil {
 		t.Fatalf("Consume: %v", err)
 	}
 	snap := m.Snapshot(ctx)
@@ -241,8 +265,52 @@ func TestMeterSnapshotReportsWindowLimitAndBand(t *testing.T) {
 	if snap.Window != cfg.Window.String() {
 		t.Fatalf("Snapshot().Window = %q, want %q", snap.Window, cfg.Window.String())
 	}
-	if snap.Band != overlay.BandOK {
-		t.Fatalf("Snapshot().Band = %q, want %q", snap.Band, overlay.BandOK)
+	if snap.Band != BandOK {
+		t.Fatalf("Snapshot().Band = %q, want %q", snap.Band, BandOK)
+	}
+}
+
+// TestMeterConsumeIsSharedAcrossInstances proves the point of the whole
+// change: two SEPARATE Meter instances over the same pool (as cmd/api's
+// force_fresh meter and cmd/worker's poller meter are two distinct
+// instances in two processes) share ONE per-workspace count — a spend
+// through one is visible to the other, so they cannot each burn a full
+// budget against the shared incumbent quota.
+func TestMeterConsumeIsSharedAcrossInstances(t *testing.T) {
+	ctx, pool, _ := testWorkspaceCtx(t)
+	clock := fixedClock()
+	apiMeter := NewMeterWithClock(pool, testMeterCfg(), clock)
+	workerMeter := NewMeterWithClock(pool, testMeterCfg(), clock)
+
+	if err := workerMeter.Consume(ctx, LanePoller, 75); err != nil { // worker spends
+		t.Fatalf("worker Consume: %v", err)
+	}
+	// The api-side meter, a different instance, must see the worker's spend.
+	if got := apiMeter.Snapshot(ctx).Consumed; got != 75 {
+		t.Fatalf("api meter sees consumed = %d, want 75 (the worker's spend on the shared window)", got)
+	}
+	if got := apiMeter.Band(ctx); got != BandWarn { // 75/100 >= 70
+		t.Fatalf("api meter Band = %q, want %q — it must reflect the shared count", got, BandWarn)
+	}
+}
+
+// TestMeterWorkspacesAreIsolated proves the count is per-workspace: a
+// spend in one workspace never moves another's band, even through meters
+// over the same pool.
+func TestMeterWorkspacesAreIsolated(t *testing.T) {
+	ctxA, pool, _ := testWorkspaceCtx(t)
+	ctxB, poolB, _ := testWorkspaceCtx(t)
+	m := NewMeterWithClock(pool, testMeterCfg(), fixedClock())
+	mB := NewMeterWithClock(poolB, testMeterCfg(), fixedClock())
+
+	if err := m.Consume(ctxA, LaneForceFresh, 95); err != nil { // A into shed
+		t.Fatalf("workspace A Consume: %v", err)
+	}
+	if got := m.Band(ctxA); got != BandShed {
+		t.Fatalf("workspace A Band = %q, want %q", got, BandShed)
+	}
+	if got := mB.Band(ctxB); got != BandOK {
+		t.Fatalf("workspace B Band = %q, want %q — A's spend must not leak into B", got, BandOK)
 	}
 }
 
@@ -251,7 +319,7 @@ func TestMeterSnapshotReportsWindowLimitAndBand(t *testing.T) {
 // own doc) — a regression here silently changes production behavior with
 // no test signal otherwise.
 func TestDefaultMeterConfigShape(t *testing.T) {
-	cfg := overlay.DefaultMeterConfig()
+	cfg := DefaultMeterConfig()
 	if cfg.Window != time.Hour {
 		t.Fatalf("DefaultMeterConfig().Window = %v, want 1h", cfg.Window)
 	}

--- a/backend/internal/modules/overlay/deletion_integration_test.go
+++ b/backend/internal/modules/overlay/deletion_integration_test.go
@@ -113,7 +113,7 @@ func TestReconcileDeletionsPurgesMirroredRecordAndEmits(t *testing.T) {
 	inc := &sweptRecords{deletions: []Deletion{{
 		ObjectClass: objectClass, ExternalID: externalID, DeletedAt: deletedAt,
 	}}}
-	meter := NewMeterWithClock(testMeterConfig(), time.Now)
+	meter := NewMeterWithClock(pool, testMeterConfig(), time.Now)
 
 	if err := ReconcileDeletions(ctx, inc, ms, meter, objectClass); err != nil {
 		t.Fatalf("ReconcileDeletions: %v", err)
@@ -176,7 +176,7 @@ func TestReconcileDeletionsForUnmirroredRecordIsANoOp(t *testing.T) {
 	inc := &sweptRecords{deletions: []Deletion{{
 		ObjectClass: objectClass, ExternalID: externalID, DeletedAt: deletedAt,
 	}}}
-	meter := NewMeterWithClock(testMeterConfig(), time.Now)
+	meter := NewMeterWithClock(pool, testMeterConfig(), time.Now)
 
 	if err := ReconcileDeletions(ctx, inc, ms, meter, objectClass); err != nil {
 		t.Fatalf("ReconcileDeletions: %v", err)

--- a/backend/internal/modules/overlay/freshness_integration_test.go
+++ b/backend/internal/modules/overlay/freshness_integration_test.go
@@ -184,7 +184,7 @@ func TestFreshnessReaderUnderThresholdReadsLiveAndSpends(t *testing.T) {
 
 	inc := seedMirrorAndLiveFixture(ctx, t, ms, externalID, mirrorTime, liveTime)
 
-	meter := NewMeterWithClock(testMeterConfig(), time.Now)
+	meter := NewMeterWithClock(pool, testMeterConfig(), time.Now)
 	fr := NewFreshnessReader(func(context.Context) (Incumbent, error) { return inc, nil }, ms, meter, translatorFor(false))
 
 	id, err := externalIDToUUID(externalID)
@@ -232,7 +232,7 @@ func TestFreshnessReaderFailedLiveReadStillSpendsAndDegrades(t *testing.T) {
 	inc := seedMirrorAndLiveFixture(ctx, t, ms, externalID, mirrorTime, mirrorTime.Add(time.Hour))
 	inc.getErr = fmt.Errorf("hubspot: unreachable")
 
-	meter := NewMeterWithClock(testMeterConfig(), time.Now)
+	meter := NewMeterWithClock(pool, testMeterConfig(), time.Now)
 	fr := NewFreshnessReader(func(context.Context) (Incumbent, error) { return inc, nil }, ms, meter, translatorFor(false))
 
 	id, err := externalIDToUUID(externalID)
@@ -274,7 +274,7 @@ func TestFreshnessReaderNoIncumbentClassMappingDegradesHonestly(t *testing.T) {
 
 	inc := seedMirrorAndLiveFixture(ctx, t, ms, externalID, mirrorTime, liveTime)
 
-	meter := NewMeterWithClock(testMeterConfig(), time.Now)
+	meter := NewMeterWithClock(pool, testMeterConfig(), time.Now)
 	fr := NewFreshnessReader(func(context.Context) (Incumbent, error) { return inc, nil }, ms, meter, translatorFor(true)) // every canonical type misses
 
 	id, err := externalIDToUUID(externalID)
@@ -333,7 +333,7 @@ func TestFreshnessReaderShedDegradesToMirrorAndEmitsBudgetDegraded(t *testing.T)
 
 	inc := seedMirrorAndLiveFixture(ctx, t, ms, externalID, mirrorTime, liveTime)
 
-	meter := NewMeterWithClock(testMeterConfig(), time.Now)
+	meter := NewMeterWithClock(pool, testMeterConfig(), time.Now)
 	// Push the window straight to the shed band (limit 10, shed at 8)
 	// via a different lane — proving the meter's band is a total across
 	// lanes, not a per-lane count force_fresh alone would never reach.

--- a/backend/internal/modules/overlay/reconcile_integration_test.go
+++ b/backend/internal/modules/overlay/reconcile_integration_test.go
@@ -161,7 +161,7 @@ func TestReconcileOverwritesDivergedNonDirtyRowAndEmitsConflict(t *testing.T) {
 		Fields:     map[string]any{"display_name": "New Name"},
 		ModifiedAt: newBaseline,
 	}}}
-	meter := NewMeterWithClock(testMeterConfig(), time.Now)
+	meter := NewMeterWithClock(pool, testMeterConfig(), time.Now)
 
 	watermark, err := Reconcile(ctx, inc, ms, meter, objectClass, oldBaseline.Add(-time.Second))
 	if err != nil {
@@ -226,7 +226,7 @@ func TestReconcileNeverClobbersADirtyRow(t *testing.T) {
 		Fields:     map[string]any{"display_name": "Incumbent Overwrite Attempt"},
 		ModifiedAt: newBaseline,
 	}}}
-	meter := NewMeterWithClock(testMeterConfig(), time.Now)
+	meter := NewMeterWithClock(pool, testMeterConfig(), time.Now)
 
 	if _, err := Reconcile(ctx, inc, ms, meter, objectClass, oldBaseline.Add(-time.Second)); err != nil {
 		t.Fatalf("Reconcile: %v", err)

--- a/backend/internal/modules/overlay/syncstatus_integration_test.go
+++ b/backend/internal/modules/overlay/syncstatus_integration_test.go
@@ -76,7 +76,7 @@ func TestBackfillCompleteForRequiresEveryEngagementClass(t *testing.T) {
 func TestSyncStatusAndBudgetRefuseANativeModeWorkspace(t *testing.T) {
 	ctx, pool, _ := testWorkspaceCtx(t) // never flips to overlay mode
 	svc := NewService(pool, keyvault.NewMemory(), NewMirrorStore(pool, noOwnerEmails{})).
-		WithBudgetMeter(NewMeter(DefaultMeterConfig()))
+		WithBudgetMeter(NewMeter(pool, DefaultMeterConfig()))
 
 	if _, err := svc.SyncStatus(ctx); !errors.Is(err, apperrors.ErrModeNotOverlay) {
 		t.Errorf("SyncStatus err = %v, want errors.Is(_, ErrModeNotOverlay)", err)

--- a/backend/internal/modules/overlay/teardown.go
+++ b/backend/internal/modules/overlay/teardown.go
@@ -162,7 +162,13 @@ func revokeConnection(ctx context.Context, tx pgx.Tx) (credentialRef string, err
 // mirror load outright, and a stale watermark resumes the incremental
 // sweep past everything it never saw. A disconnected workspace's sync
 // state must read exactly as a never-connected one's does ("", not
-// started, epoch). No embeddings/context-graph/FTS tables exist
+// started, epoch). The OVB budget window (overlay_budget_window) purges
+// for that same read-exactly-as-never-connected reason: it is spend
+// against the incumbent's quota, and a workspace with no incumbent has
+// no such spend — a retained window would misreport a disconnected
+// workspace as mid-consumption and, on a later reconnect, shed
+// force-fresh reads against a budget the prior connection spent. No
+// embeddings/context-graph/FTS tables exist
 // yet in this build (the search module's retrieval store is a later
 // work package) — nothing here to purge on their behalf until that
 // lands.
@@ -206,6 +212,9 @@ func purgeMirror(ctx context.Context, tx pgx.Tx) error {
 	}
 	if _, err := tx.Exec(ctx, `DELETE FROM overlay_sync_state`); err != nil {
 		return fmt.Errorf("overlay: purging the sweep backoff state: %w", err)
+	}
+	if _, err := tx.Exec(ctx, `DELETE FROM overlay_budget_window`); err != nil {
+		return fmt.Errorf("overlay: purging the budget window: %w", err)
 	}
 	return nil
 }

--- a/backend/migrations/custom/20260722100000_overlay_budget_window.down.sql
+++ b/backend/migrations/custom/20260722100000_overlay_budget_window.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS overlay_budget_window;

--- a/backend/migrations/custom/20260722100000_overlay_budget_window.up.sql
+++ b/backend/migrations/custom/20260722100000_overlay_budget_window.up.sql
@@ -1,0 +1,31 @@
+-- 20260722100000_overlay_budget_window: the OVB (overlay budget) meter's
+-- shared, cross-process fixed-window counter (branch 1b, A3b).
+--
+-- The meter was per-PROCESS in-memory: cmd/api (the force_fresh lane) and
+-- cmd/worker (the poller lane) are two distinct OS processes (ADR-0054/A69),
+-- each with its OWN counter, so a workspace's combined spend against the ONE
+-- real HubSpot quota was bounded by (process count)×Limit, not Limit — the
+-- "don't starve the shared quota" property undercut by construction. This
+-- table makes the window shared: both lanes, in both processes, read and
+-- advance ONE row per workspace, and GET /overlay/budget reflects the poller's
+-- spend, not just the reading process's.
+--
+-- The window is fixed (not sliding): window_start plus a configured Window
+-- duration; a consume/reserve whose "now" is past window_start+Window rolls
+-- the window (resets window_start and consumed) in the same statement, so a
+-- stale window can never over-count. "now" is supplied by the caller (the
+-- meter's injected clock), not SQL now(), so window expiry stays testable
+-- without sleeping. consumed is the total across lanes (the band the meter
+-- reports is a function of the total); per-lane detail is not persisted.
+CREATE TABLE overlay_budget_window (
+  workspace_id uuid PRIMARY KEY REFERENCES workspace(id) ON DELETE RESTRICT,
+  window_start timestamptz NOT NULL,
+  consumed     int NOT NULL DEFAULT 0 CHECK (consumed >= 0),
+  updated_at   timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE overlay_budget_window ENABLE ROW LEVEL SECURITY;
+ALTER TABLE overlay_budget_window FORCE ROW LEVEL SECURITY;
+CREATE POLICY overlay_budget_window_tenant_isolation ON overlay_budget_window
+  USING (workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid)
+  WITH CHECK (workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid);

--- a/backend/tableownership_test.go
+++ b/backend/tableownership_test.go
@@ -155,6 +155,7 @@ var tableOwners = map[string]string{
 	"overlay_backfill_cursor":     "internal/modules/overlay",
 	"overlay_reconcile_watermark": "internal/modules/overlay",
 	"overlay_sync_state":          "internal/modules/overlay",
+	"overlay_budget_window":       "internal/modules/overlay",
 	// compose (HTTP replay protection is transport plumbing, not domain;
 	// the brief read model is the cross-module ranker's own snapshot —
 	// deals + people strength + activities compose only here)


### PR DESCRIPTION
## What

The overlay budget (OVB) meter was **per-process in-memory**. Under ADR-0054/A69, `cmd/api` (the `force_fresh` lane) and `cmd/worker` (the poller lane) are two distinct OS processes, each with its own counter — so a workspace's combined spend against the ONE real HubSpot quota was bounded by `(process count)×Limit`, not `Limit`. That's the "don't starve the shared quota" property the meter exists to protect, undercut by construction. `GET /overlay/budget` also reflected only the reading process's spend, never the poller's.

This moves the window into Postgres so both lanes, in both processes, read and advance **one** per-workspace count.

## How

- **New table `overlay_budget_window`** — one row per workspace, `window_start`/`consumed`, FORCE RLS + tenant-isolation policy (migration `20260722100000`).
- **`Meter` rewritten** to PG SQL over that row: `Consume` / `Reserve` / `Band` / `Snapshot`.
  - **Fixed window, in-statement roll**: a consume/reserve whose clock reads past `window_start+Window` resets `window_start` and `consumed` in the *same* statement — a stale window can never be added onto.
  - **Clock stays injected**: `now` is threaded as a SQL parameter, not SQL `now()`, so window expiry is asserted by advancing the clock, never by sleeping (T11).
  - **`Reserve` is atomic across transactions**: a roll-and-lock upsert takes the row's write lock and returns the post-roll `consumed`; the band is judged on that locked count and the conditional add commits under the same lock. Concurrent force-fresh reservations serialize through the row instead of all observing a non-shed band.
  - **Band/Snapshot fail closed** (shed, 0 consumed) on any read error, including a workspace-less context.
- **Teardown** purges `overlay_budget_window` (a disconnected workspace reads exactly as a never-connected one); table registered to the overlay module in `tableownership_test.go`.
- **`NewOverlayMeter` / `NewMeter[WithClock]` gain a `*pgxpool.Pool`**; all call sites updated (compose wiring + worker + integration tests). The old "must thread one instance through both wiring points" concern is now moot — the shared PG row is the source of truth — and the stale comments saying so are corrected.

## Tests

The unit meter tests become **PG-backed integration tests** — the row lock that makes `Reserve` safe to share is a Postgres lock, provable only against Postgres. New coverage: cross-instance sharing (two `Meter` instances over one pool share a count) and per-workspace isolation. Concurrency-atomicity test drives 20 concurrent `Reserve`s and asserts exactly the threshold is respected.

Local: `make check-backend` green; overlay module + compose overlay integration suites green; diff-scoped `craft static` = 0 blockers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the overlay budget meter to a shared Postgres window so `cmd/api` and `cmd/worker` share one per‑workspace count. Force_fresh is gated by the shared band while the poller records per‑record units unconditionally, and GET `/overlay/budget` shows total spend.

- **New Features**
  - Added `overlay_budget_window` (one row per workspace, RLS/tenant isolation).
  - Rewrote meter to SQL: `Consume`, `Reserve`, `Band`, `Snapshot` operate on the shared row.
    - Fixed window with in‑statement roll on expiry; clock injected as a SQL param.
    - `Reserve` is atomic across transactions (row lock); reads fail closed on errors or no workspace.
  - Teardown purges `overlay_budget_window`; acceptance seeds a row pre‑disconnect and asserts it is deleted.
  - All surfaces reuse the same helper: the worker uses `compose.NewOverlayMeter(pool)`; MCP/workflows share the same backing even if they don’t trigger force_fresh today.
  - Clarified metering units: the poller records per‑record work, not per‑request quota; the shared count bounds force_fresh and reports headroom, it doesn’t hard‑cap the poller.

- **Migration**
  - Apply migration `20260722100000_overlay_budget_window`.
  - Update wiring to `NewOverlayMeter(pool)` / `NewMeter(pool, cfg)` or `NewMeterWithClock(pool, cfg, now)`.
  - Ensure calls run with a workspace‑bound context (GUC set via `WithWorkspaceTx`).

<sup>Written for commit 4383e2dfd76cc7724f3914d021444b45843b0f2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Overlay budget tracking is now shared across server processes and application surfaces.
  * Budget usage is persisted per workspace, ensuring consistent limits across REST, workflows, MCP, and background processing.
  * Disconnected workspaces have their budget state fully cleared.

* **Bug Fixes**
  * Improved atomicity and consistency for concurrent budget reservations.
  * Budget checks now fail safely when usage data cannot be read.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->