### PR TITLE
refactor(extensions): Sonar advisories on the merged slice

### DIFF
--- a/backend/internal/compose/extensions.go
+++ b/backend/internal/compose/extensions.go
@@ -21,6 +21,22 @@ import (
 // emission (ADR-0069 §5) and the approval filtering (§7) slot in: both
 // operate on the declared set before anything is applied.
 func RegisterExtensions(exts []extension.Extension) error {
+	if err := validateExtensionSet(exts); err != nil {
+		return err
+	}
+	for _, e := range exts {
+		for _, p := range e.Jurisdictions {
+			jurisdiction.Register(p)
+		}
+	}
+	return nil
+}
+
+// validateExtensionSet preflights every unit and every capability —
+// against the declared set AND the live registries — so the apply phase
+// cannot fail halfway: a mid-apply abort would leave an earlier unit's
+// capabilities registered while the boot reports failure.
+func validateExtensionSet(exts []extension.Extension) error {
 	seen := make(map[extension.Name]bool, len(exts))
 	packCodes := make(map[jurisdiction.Code]extension.Name, len(exts))
 	for _, e := range exts {
@@ -34,28 +50,28 @@ func RegisterExtensions(exts []extension.Extension) error {
 		if err := e.Version.Validate(); err != nil {
 			return fmt.Errorf("compose: extension %q: %w", e.Name, err)
 		}
-		// Every capability is preflighted here, against the declared set
-		// AND the live registry, so the apply loop below cannot fail
-		// halfway: a mid-apply abort would leave an earlier unit's packs
-		// registered while the boot reports failure.
-		for _, p := range e.Jurisdictions {
-			code := p.Code()
-			if err := code.Validate(); err != nil {
-				return fmt.Errorf("compose: extension %q: %w", e.Name, err)
-			}
-			if owner, dup := packCodes[code]; dup {
-				return fmt.Errorf("compose: extensions %q and %q both declare jurisdiction %q", owner, e.Name, code)
-			}
-			if _, taken := jurisdiction.For(code); taken {
-				return fmt.Errorf("compose: extension %q declares jurisdiction %q, which a core pack already registers", e.Name, code)
-			}
-			packCodes[code] = e.Name
+		if err := preflightJurisdictions(e, packCodes); err != nil {
+			return err
 		}
 	}
-	for _, e := range exts {
-		for _, p := range e.Jurisdictions {
-			jurisdiction.Register(p)
+	return nil
+}
+
+// preflightJurisdictions checks one unit's declared packs for grammar,
+// duplicates within the composed set, and collisions with core packs.
+func preflightJurisdictions(e extension.Extension, packCodes map[jurisdiction.Code]extension.Name) error {
+	for _, p := range e.Jurisdictions {
+		code := p.Code()
+		if err := code.Validate(); err != nil {
+			return fmt.Errorf("compose: extension %q: %w", e.Name, err)
 		}
+		if owner, dup := packCodes[code]; dup {
+			return fmt.Errorf("compose: extensions %q and %q both declare jurisdiction %q", owner, e.Name, code)
+		}
+		if _, taken := jurisdiction.For(code); taken {
+			return fmt.Errorf("compose: extension %q declares jurisdiction %q, which a core pack already registers", e.Name, code)
+		}
+		packCodes[code] = e.Name
 	}
 	return nil
 }

--- a/backend/tools/gen-composition/emit.go
+++ b/backend/tools/gen-composition/emit.go
@@ -62,7 +62,7 @@ func composedFiles(root string) (map[string][]byte, error) {
 		return nil, err
 	}
 	return map[string][]byte{
-		"go.work":                    work,
+		goWorkFile:                   work,
 		"backend/go.mod":             composedGoMod(goVersion),
 		"backend/extensions_gen.go":  wiring,
 		"frontend/extensions.gen.ts": frontendGen(),
@@ -94,11 +94,11 @@ func canonicalGoSource(name string, src []byte) ([]byte, error) {
 // composition module, and each enabled extension module — sorted, paths
 // relative to build/composition/go.work.
 func composedWork(root string, units []extensionUnit) ([]byte, string, error) {
-	raw, err := os.ReadFile(filepath.Join(root, "go.work"))
+	raw, err := os.ReadFile(filepath.Join(root, goWorkFile))
 	if err != nil {
 		return nil, "", err
 	}
-	rootWork, err := modfile.ParseWork("go.work", raw, nil)
+	rootWork, err := modfile.ParseWork(goWorkFile, raw, nil)
 	if err != nil {
 		return nil, "", fmt.Errorf("root go.work: %w", err)
 	}

--- a/backend/tools/gen-composition/main.go
+++ b/backend/tools/gen-composition/main.go
@@ -41,6 +41,14 @@ func main() {
 	}
 }
 
+// The composition's fixed artifact names, spelled once — they appear as
+// output keys, on-disk paths, and gate messages alike.
+const (
+	manifestFile  = "composition.json"
+	goWorkFile    = "go.work"
+	goWorkSumFile = "go.work.sum"
+)
+
 // manifest is composition.json: the digest binding that replaces the
 // committed-file drift gate for ignored composition output (the ADR's
 // "regenerate-don't-merge" rule made checkable).
@@ -125,7 +133,7 @@ func generate(root string) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(filepath.Join(outRoot, "composition.json"), encoded, 0o644) // #nosec G306 -- generated build artifact
+	return os.WriteFile(filepath.Join(outRoot, manifestFile), encoded, 0o644) // #nosec G306 -- generated build artifact
 }
 
 // currentManifest assembles composition.json content for the given
@@ -139,11 +147,11 @@ func currentManifest(root string, files map[string][]byte) (manifest, error) {
 	for rel, content := range files {
 		outputs[rel] = digestBytes(content)
 	}
-	sumDigest, err := digestFileOrEmpty(filepath.Join(root, "build", "composition", "go.work.sum"))
+	sumDigest, err := digestFileOrEmpty(filepath.Join(root, "build", "composition", goWorkSumFile))
 	if err != nil {
 		return manifest{}, err
 	}
-	outputs["go.work.sum"] = sumDigest
+	outputs[goWorkSumFile] = sumDigest
 	return manifest{Schema: 1, Toolchain: runtime.Version(), Inputs: inputs, Outputs: outputs}, nil
 }
 
@@ -161,7 +169,7 @@ func materializeWorkSum(root, outRoot string) error {
 	}
 	cmd := exec.Command(filepath.Join(goRoot, "bin", "go"), "list", "-m", "all")
 	cmd.Dir = root
-	cmd.Env = append(os.Environ(), "GOWORK="+filepath.Join(outRoot, "go.work"))
+	cmd.Env = append(os.Environ(), "GOWORK="+filepath.Join(outRoot, goWorkFile))
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("resolving the composed workspace (go list -m all): %v\n%s", err, out)
 	}
@@ -182,7 +190,7 @@ func verifyOutputs(root string, recorded manifest) error {
 		return err
 	}
 	if recorded.Schema != 1 {
-		return fmt.Errorf("composition.json carries schema %d, this tool writes schema 1 — run 'make gen'", recorded.Schema)
+		return fmt.Errorf("%s carries schema %d, this tool writes schema 1 — run 'make gen'", manifestFile, recorded.Schema)
 	}
 	files, err := composedFiles(root)
 	if err != nil {
@@ -195,6 +203,19 @@ func verifyOutputs(root string, recorded manifest) error {
 	if current.Toolchain != recorded.Toolchain {
 		return fmt.Errorf("composition built with %s, verifying with %s — run 'make gen'", recorded.Toolchain, current.Toolchain)
 	}
+	if err := verifyRecordedOutputs(root, current, recorded); err != nil {
+		return err
+	}
+	if err := verifyManifestBytes(root, current); err != nil {
+		return err
+	}
+	return verifyNoExtraFiles(root, current.Outputs)
+}
+
+// verifyRecordedOutputs holds every regenerated output against the
+// recorded hash AND the bytes on disk (go.work.sum only against the
+// record — regeneration does not re-run the go command).
+func verifyRecordedOutputs(root string, current, recorded manifest) error {
 	names := make([]string, 0, len(current.Outputs))
 	for rel := range current.Outputs {
 		names = append(names, rel)
@@ -208,25 +229,33 @@ func verifyOutputs(root string, recorded manifest) error {
 		if err != nil {
 			return err
 		}
-		if rel != "go.work.sum" && onDisk != current.Outputs[rel] {
+		if rel != goWorkSumFile && onDisk != current.Outputs[rel] {
 			return fmt.Errorf("output %s on disk differs from its regeneration — hand-edited? run 'make gen'", rel)
 		}
 	}
-	if extra := len(recorded.Outputs) - len(current.Outputs); extra != 0 {
-		return fmt.Errorf("composition.json records %d outputs, regeneration produced %d — run 'make gen'", len(recorded.Outputs), len(current.Outputs))
+	if len(recorded.Outputs) != len(current.Outputs) {
+		return fmt.Errorf("%s records %d outputs, regeneration produced %d — run 'make gen'", manifestFile, len(recorded.Outputs), len(current.Outputs))
 	}
+	return nil
+}
+
+// verifyManifestBytes requires the on-disk composition.json to be
+// byte-identical to the regenerated manifest's encoding — a hand edit,
+// an unknown field, or a foreign encoder fails even when the semantic
+// content agrees.
+func verifyManifestBytes(root string, current manifest) error {
 	encoded, err := encodeManifest(current)
 	if err != nil {
 		return err
 	}
-	raw, err := os.ReadFile(filepath.Join(root, "build", "composition", "composition.json"))
+	raw, err := os.ReadFile(filepath.Join(root, "build", "composition", manifestFile))
 	if err != nil {
 		return err
 	}
 	if !bytes.Equal(raw, encoded) {
-		return fmt.Errorf("composition.json on disk differs from its re-encoding — hand-edited? run 'make gen'")
+		return fmt.Errorf("%s on disk differs from its re-encoding — hand-edited? run 'make gen'", manifestFile)
 	}
-	return verifyNoExtraFiles(root, current.Outputs)
+	return nil
 }
 
 // verifyNoExtraFiles walks build/composition/ and rejects anything the
@@ -234,7 +263,7 @@ func verifyOutputs(root string, recorded manifest) error {
 // regular files.
 func verifyNoExtraFiles(root string, outputs map[string]string) error {
 	outRoot := filepath.Join(root, "build", "composition")
-	expected := map[string]bool{"composition.json": true}
+	expected := map[string]bool{manifestFile: true}
 	for rel := range outputs {
 		expected[rel] = true
 	}
@@ -276,7 +305,7 @@ func stubMatchesVanilla(root string) error {
 }
 
 func readManifest(root string) (manifest, error) {
-	raw, err := os.ReadFile(filepath.Join(root, "build", "composition", "composition.json"))
+	raw, err := os.ReadFile(filepath.Join(root, "build", "composition", manifestFile))
 	if err != nil {
 		return manifest{}, fmt.Errorf("no composition manifest (%v)", err)
 	}


### PR DESCRIPTION
Follow-up to #185: the quality gate passed but left seven advisories on the merged code. Six applied, one declined:

- `compose.RegisterExtensions` → `validateExtensionSet` + `preflightJurisdictions` (cognitive complexity 21 → under the 15 cap); phases and errors unchanged.
- `gen-composition`: `verifyOutputs` → `verifyRecordedOutputs` + `verifyManifestBytes` (18 → under cap); `composition.json` / `go.work` / `go.work.sum` become one constant block; the redundant `extra :=` binding folds into a length comparison.
- **Declined** (godre:S8196): renaming the published `jurisdiction.Retention` interface to the single-method `-er` convention ("Classer") trades a domain name on a frozen seam (EXT-P3) for a lint aesthetic — domain names win (T4).

Full backend gate + composition reproducibility green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors reduce cognitive complexity in extension registration and the `gen-composition` tool without changing behavior. One Sonar naming advisory is intentionally left to preserve the published `jurisdiction.Retention` domain term.

- **Refactors**
  - Split `compose.RegisterExtensions` into `validateExtensionSet` and `preflightJurisdictions`; validate everything first, then register, to avoid partial apply; same errors as before.
  - In `gen-composition`, split `verifyOutputs` into `verifyRecordedOutputs` and `verifyManifestBytes`; adds a strict byte-for-byte manifest check.
  - Centralized artifact names via `manifestFile`, `goWorkFile`, and `goWorkSumFile`; replaced string literals (incl. `GOWORK`) and removed a redundant variable.

<sup>Written for commit 7191c46b1480e3290fa940926be8a92a7b8360fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

