### PR TITLE
feat(extensions): published-surface allowlist + apidiff freeze gate (ADR-0069 slice 2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,8 @@ make check-backend      # backend half: build, vet, lint (baseline + new-code
                         # strict), arch-lint, unit + fitness tests, contract drift,
                         # plus the root script gates (craft drift, image pins,
                         # contract-breaking, test-lanes, file-length, rls-store-path,
-                        # no-jurisdiction). This is what CI's deterministic-gates runs.
+                        # no-jurisdiction, pkg-freeze). This is what CI's
+                        # deterministic-gates runs.
 make check-fe           # frontend half (biome + vitest + tsc + build)
 make test-integration   # real-Postgres lane: RLS gates + HTTP end-to-end (needs db-up).
                         # Parallel — each package on its own throwaway clone db; ends

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,8 @@ make check-backend      # backend half: build, vet, lint (baseline + new-code
                         # strict), arch-lint, unit + fitness tests, contract drift,
                         # plus the root script gates (craft drift, image pins,
                         # contract-breaking, test-lanes, file-length, rls-store-path,
-                        # no-jurisdiction). This is what CI's deterministic-gates runs.
+                        # no-jurisdiction, pkg-freeze). This is what CI's
+                        # deterministic-gates runs.
 make check-fe           # frontend half (biome + vitest + tsc + build)
 make test-integration   # real-Postgres lane: RLS gates + HTTP end-to-end (needs db-up).
                         # Parallel — each package on its own throwaway clone db; ends

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # The frontend lane is separate (`make frontend-check`) — it needs node+pnpm,
 # which not every backend machine has; CI runs both.
 
-.PHONY: help install ai-routing-local dev-fresh check check-backend check-q check-go check-fe build test test-v test-cover test-integration e2e-ai e2e-ai-report test-db-up test-it test-integration-serial bench-perf lint arch-lint vet gen gen-types gen-types-check drift composition check-composition db-up db-init db-wait migrate migrate-up migrate-down run psql redis-cli tidy dev dev-stop clean tools tools-go infra-up infra-down infra-logs infra-reset seed-dev seed-dev-db seed-reset verify-boot mcp-inspector frontend-check frontend-e2e fe-install fe-typecheck fe-lint fe-build fe-preview fe-format fe-test ds-purity font-lock icon-lint fitness-jurisdiction storybook fe-uat craft-static craft-residue check-craft-doc check-image-pins contract-breaking-check test-lanes go-file-length rls-store-path no-jurisdiction hooks
+.PHONY: help install ai-routing-local dev-fresh check check-backend check-q check-go check-fe build test test-v test-cover test-integration e2e-ai e2e-ai-report test-db-up test-it test-integration-serial bench-perf lint arch-lint vet gen gen-types gen-types-check drift composition check-composition db-up db-init db-wait migrate migrate-up migrate-down run psql redis-cli tidy dev dev-stop clean tools tools-go infra-up infra-down infra-logs infra-reset seed-dev seed-dev-db seed-reset verify-boot mcp-inspector frontend-check frontend-e2e fe-install fe-typecheck fe-lint fe-build fe-preview fe-format fe-test ds-purity font-lock icon-lint fitness-jurisdiction storybook fe-uat craft-static craft-residue check-craft-doc check-image-pins contract-breaking-check test-lanes go-file-length rls-store-path no-jurisdiction pkg-freeze hooks
 
 # Bare `make` lists every command instead of running the first target.
 .DEFAULT_GOAL := help
@@ -38,7 +38,7 @@ ai-routing-local:
 ## gates plus the backend gate (build, vet, lint, arch-lint, unit + fitness
 ## tests, contract drift). No frontend toolchain needed — this is what the CI
 ## deterministic-gates job runs.
-check-backend: check-craft-doc check-image-pins contract-breaking-check test-lanes go-file-length rls-store-path no-jurisdiction
+check-backend: check-craft-doc check-image-pins contract-breaking-check test-lanes go-file-length rls-store-path no-jurisdiction pkg-freeze
 	$(MAKE) -C backend check
 
 ## check — the full merge gate: backend + frontend
@@ -280,6 +280,14 @@ rls-store-path:
 ## internal/shared/ports/jurisdiction). Comments citing a statute are allowed.
 no-jurisdiction:
 	@./scripts/check-no-jurisdiction.sh
+
+## pkg-freeze — published-surface freeze gate (ADR-0069 §3, EXT-P3): apidiff
+## on every backend/pkg package vs the merge-base (the extensions integration
+## branch while the arc holds there, else origin/main); an incompatible change
+## or a removed published package fails, additive growth passes. Deliberate,
+## reviewed exception: PKG_FREEZE_BASE=<ref>.
+pkg-freeze:
+	@./scripts/check-pkg-freeze.sh
 
 ## hooks — install the repo's git hooks (the pre-push craft-static gate).
 ## Run once after cloning.

--- a/backend/extensions_arch_test.go
+++ b/backend/extensions_arch_test.go
@@ -102,19 +102,54 @@ func goImports(t *testing.T, dir string) map[string][]string {
 	return out
 }
 
-// TestExtensionsImportOnlyThePublishedSurface: an extension reaches the
-// product only through backend/pkg/** — never internal/**, cmd/**, the
-// composition module, or a sibling extension (EXT-P2/P7). Third-party
-// imports are the extension's own business (its go.mod carries them).
-func TestExtensionsImportOnlyThePublishedSurface(t *testing.T) {
+// extensionSurfaceMarker is the allowlist directive (ADR-0069 §3):
+// membership in backend/pkg alone grants nothing — a package is
+// extension surface only when its package clause carries this line.
+const extensionSurfaceMarker = "//margince:extension-surface"
+
+// allowlistedSurface derives the published allowlist from the tree: the
+// import path of every backend/pkg package whose non-test source carries
+// the marker directive.
+func allowlistedSurface(t *testing.T) map[string]bool {
+	t.Helper()
+	marked := map[string]bool{}
+	err := filepath.WalkDir("pkg", func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return err
+		}
+		src, err := os.ReadFile(path) // #nosec G304 -- path from walking the trusted source tree
+		if err != nil {
+			return err
+		}
+		for _, line := range strings.Split(string(src), "\n") {
+			if strings.TrimSpace(line) == extensionSurfaceMarker {
+				marked[modulePath+"/"+filepath.ToSlash(filepath.Dir(path))] = true
+				break
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return marked
+}
+
+// TestExtensionsImportOnlyTheAllowlistedSurface: an extension reaches the
+// product only through the marker-allowlisted backend/pkg packages —
+// never internal/**, cmd/**, an unmarked pkg package, the composition
+// module, or a sibling extension (EXT-P2/P7). Third-party imports are
+// the extension's own business (its go.mod carries them).
+func TestExtensionsImportOnlyTheAllowlistedSurface(t *testing.T) {
 	trees := extensionTrees(t)
 	modPaths := extensionModulePaths(t, trees)
+	surface := allowlistedSurface(t)
 	for dir := range trees {
 		for file, imports := range goImports(t, dir) {
 			for _, imp := range imports {
 				if strings.HasPrefix(imp, modulePath+"/") {
-					if !strings.HasPrefix(imp, modulePath+"/pkg/") {
-						t.Errorf("%s imports %s: extensions import only the published surface (%s/pkg/**)", file, imp, modulePath)
+					if !surface[imp] {
+						t.Errorf("%s imports %s: extensions import only the allowlisted published surface (a backend/pkg package carrying %s)", file, imp, extensionSurfaceMarker)
 					}
 					continue
 				}
@@ -131,6 +166,34 @@ func TestExtensionsImportOnlyThePublishedSurface(t *testing.T) {
 				}
 			}
 		}
+	}
+}
+
+// TestSurfaceMarkerLivesOnlyUnderPkg: the directive grants surface
+// membership, so a stray copy outside backend/pkg would be a silent
+// allowlist widening — the marker is meaningless (and refused) anywhere
+// else in the backend tree. Test files are exempt: the allowlist
+// derivation never reads them (this file's own constant included).
+func TestSurfaceMarkerLivesOnlyUnderPkg(t *testing.T) {
+	err := filepath.WalkDir(".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return err
+		}
+		rel := filepath.ToSlash(path)
+		if strings.HasPrefix(rel, "pkg/") {
+			return nil
+		}
+		src, err := os.ReadFile(path) // #nosec G304 -- path from walking the trusted source tree
+		if err != nil {
+			return err
+		}
+		if strings.Contains(string(src), extensionSurfaceMarker) {
+			t.Errorf("%s carries %s: the surface marker belongs only on backend/pkg packages", rel, extensionSurfaceMarker)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/backend/pkg/extension/extension.go
+++ b/backend/pkg/extension/extension.go
@@ -18,6 +18,8 @@
 // suites keep compiling (EXT-P3: grow additively, never in place). New
 // gains a Deps parameter through a versioned successor when the first
 // capability needs injected dependencies.
+//
+//margince:extension-surface
 package extension
 
 import (

--- a/backend/pkg/extension/jurisdiction/jurisdiction.go
+++ b/backend/pkg/extension/jurisdiction/jurisdiction.go
@@ -10,6 +10,8 @@
 //
 // Deliberately absent: locale/i18n. Locale is per-user and orthogonal to
 // jurisdiction (A57) — there is no LocaleBundle on this seam.
+//
+//margince:extension-surface
 package jurisdiction
 
 import (

--- a/docs/reference/make-targets.md
+++ b/docs/reference/make-targets.md
@@ -69,6 +69,7 @@ root gates (each is a small script; all merge-blocking):
 | `go-file-length` | Hard 500-LOC cap on hand-written Go, ratcheted via `scripts/go-file-length-waivers.txt` |
 | `rls-store-path` | No `internal/modules` statement addresses the superuser pool directly (RLS bypass); `// rls-exempt: <reason>` is the escape for a genuinely cross-workspace query |
 | `no-jurisdiction` | No country-specific regulatory identifier (XRechnung/ZUGFeRD/DATEV/…) or ISO-3166 code in core **code**, only in the jurisdiction seam (`internal/modules/de`, `internal/shared/ports/jurisdiction`); statute citations in comments are allowed |
+| `pkg-freeze` | Published-surface freeze (ADR-0069 §3, EXT-P3): apidiff on every `backend/pkg` package vs the merge-base (the extensions integration branch while the arc holds there, else `origin/main`) — an incompatible change or removed published package fails, additive growth passes. Deliberate exception: `PKG_FREEZE_BASE=<ref>` |
 
 ## Occasional
 

--- a/scripts/check-pkg-freeze.sh
+++ b/scripts/check-pkg-freeze.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Published-surface freeze gate (ADR-0069 §3, EXT-P3; the ADR-0023
+# Amendment 2 patch-lane arm): backend/pkg is frozen published API from
+# its first consumer — it evolves additively or through versioned
+# successors, never in place. This gate apidiffs every published package
+# against the base revision and fails on any INCOMPATIBLE change
+# (removed package, removed or re-signatured symbol, narrowed interface);
+# additive growth passes.
+#
+# Baseline: the merge-base with the extensions integration branch while
+# the arc is held there (in-arc slices must not break each other), else
+# with origin/main — derived, never configured. Override with
+# PKG_FREEZE_BASE=<ref> for a deliberate, reviewed surface change; like
+# every deliberate break it must be visible in the PR, not silent.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+# Pinned tool invocation (`go run` at an exact version, the
+# check-contract-breaking.sh pattern): x/exp carries no tags, so the pin
+# is a pseudo-version.
+APIDIFF="${APIDIFF:-go run golang.org/x/exp/cmd/apidiff@v0.0.0-20260718201538-764159d718ef}"
+
+resolve_base_ref() {
+  for ref in origin/feat/extensions-adr-0069 origin/main; do
+    if git rev-parse -q --verify "$ref" > /dev/null; then
+      echo "$ref"
+      return 0
+    fi
+  done
+  return 1
+}
+
+BASE_REF="${PKG_FREEZE_BASE:-$(resolve_base_ref || true)}"
+if [ -z "$BASE_REF" ]; then
+  # In CI a missing base ref is a broken checkout, never a skip; locally
+  # it just means the remote was never fetched.
+  if [ "${CI:-}" = "true" ]; then
+    echo "FAIL: pkg-freeze — no base ref (origin/main missing); fetch-depth must cover the merge base" >&2
+    exit 1
+  fi
+  echo "SKIP pkg-freeze: no origin ref found — fetch origin to arm the published-surface gate"
+  exit 0
+fi
+
+BASE="$(git merge-base HEAD "$BASE_REF")"
+
+if ! git ls-tree -d "$BASE" backend/pkg > /dev/null 2>&1 || [ -z "$(git ls-tree -d "$BASE" backend/pkg)" ]; then
+  echo "OK: pkg-freeze — no published surface at $BASE_REF merge-base; nothing frozen yet"
+  exit 0
+fi
+
+WORKTREE="$(mktemp -d "${TMPDIR:-/tmp}/pkg-freeze.XXXXXX")"
+cleanup() {
+  git worktree remove --force "$WORKTREE" > /dev/null 2>&1 || true
+  rm -rf "$WORKTREE"
+}
+trap cleanup EXIT
+git worktree add --detach --quiet "$WORKTREE" "$BASE"
+
+OLD_PKGS="$(cd "$WORKTREE/backend" && go list ./pkg/... 2> /dev/null || true)"
+if [ -z "$OLD_PKGS" ]; then
+  echo "OK: pkg-freeze — no published packages at the merge-base; nothing frozen yet"
+  exit 0
+fi
+
+EXPORT_DIR="$(mktemp -d "${TMPDIR:-/tmp}/pkg-freeze-export.XXXXXX")"
+trap 'cleanup; rm -rf "$EXPORT_DIR"' EXIT
+
+failed=0
+count=0
+for pkg in $OLD_PKGS; do
+  count=$((count + 1))
+  rel="${pkg#github.com/gradionhq/margince/backend/}"
+  if [ ! -d "backend/$rel" ]; then
+    echo "FAIL: pkg-freeze — published package $pkg was removed; published surface dies slowly (deprecate, then remove with its major cycle — ADR-0069 §3)" >&2
+    failed=1
+    continue
+  fi
+  export_file="$EXPORT_DIR/$(echo "$pkg" | tr '/' '_').export"
+  (cd "$WORKTREE/backend" && $APIDIFF -w "$export_file" "./$rel")
+  incompatible="$(cd backend && $APIDIFF -incompatible "$export_file" "./$rel")"
+  if [ -n "$incompatible" ]; then
+    echo "FAIL: pkg-freeze — incompatible change in published package $pkg vs $BASE_REF:" >&2
+    echo "$incompatible" | sed 's/^/  /' >&2
+    failed=1
+  fi
+done
+
+if [ "$failed" -ne 0 ]; then
+  echo "pkg-freeze: the published surface changes additively or via versioned successors, never in place (EXT-P3). Deliberate, reviewed exception: PKG_FREEZE_BASE=<ref>." >&2
+  exit 1
+fi
+echo "OK: pkg-freeze — published surface additive-or-unchanged vs $BASE_REF ($count packages)"


### PR DESCRIPTION
Slice 2 of the ADR-0069 arc (§3): the published surface becomes explicit and machine-frozen.

- **Allowlist marker** (`//margince:extension-surface` on the package clause): membership in `backend/pkg` alone grants nothing — the extension-import fitness test derives the allowlist from markers, and a companion test refuses the marker outside `backend/pkg`. In-tree, no config file.
- **Freeze gate** (`pkg-freeze` in check-backend): pinned apidiff over every published package vs the merge-base — integration branch while the arc holds there, else `origin/main`. Incompatible change or removed package fails (EXT-P3: additive or versioned successors, never in place); this is also the ADR-0023 A117 patch-lane arm. Deliberate exception: `PKG_FREEZE_BASE=<ref>`.
- Proven: green on this branch (2 packages), red on a simulated `Period.Cutoff` rename, honest no-op on a pre-`pkg/` baseline.

Deferred in-slice: per-extension depguard (fitness test is the gate until `make test-extensions`, slice 7); frontend public-surface lint (no frontend surface until slice 8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the backend published surface explicit and frozen to protect extensions. Extensions can only import allowlisted `backend/pkg` packages, and a new `pkg-freeze` gate blocks incompatible API changes via `apidiff`.

- **New Features**
  - Allowlisted surface: packages are published only if their package clause includes `//margince:extension-surface`. The fitness test enforces this allowlist, and another test rejects the marker outside `backend/pkg`. Marked now: `backend/pkg/extension` and `backend/pkg/extension/jurisdiction`.
  - Freeze gate: `pkg-freeze` (wired into `check-backend`) runs a pinned `golang.org/x/exp/cmd/apidiff` against the merge-base (`origin/feat/extensions-adr-0069` while active, else `origin/main`). Fails on removed packages or incompatible API changes; additive changes pass. Deliberate exceptions use `PKG_FREEZE_BASE=<ref>`.
  - Docs/Makefile: Added `pkg-freeze` to `check-backend` and documented it in the make targets reference.

<sup>Written for commit bddaf10e97c0c3d1a80010193ef1a4c4548c3400. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

