### PR TITLE
fix(extensions): review hardening — composed mcp/live-boot, empty-set CI proof, floor anchor, Period.Validate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,11 @@ jobs:
               - 'backend/**'
               - 'frontend/**'
               - 'infra/**'
+              # live-boot boots COMPOSED (ADR-0069): the enabled extension
+              # tree and the composition inputs shape the binary under test.
+              - 'extensions/**'
+              - 'fixtures/**'
+              - 'composition/**'
 
   # Every commit in a PR carries a Developer Certificate of Origin sign-off.
   # PR-only: the direct-to-main workflow signs off at push time, and history
@@ -546,8 +551,10 @@ jobs:
         run: |
           # Composed boot (ADR-0069): a plain `go run` would resolve the
           # vanilla composition stub and this lane would never boot with
-          # the enabled extensions (extensions/de ships by default).
-          go run ./tools/gen-composition
+          # the enabled extensions (extensions/de ships by default). The
+          # generator itself pins the ROOT workspace (the tool is its own
+          # module — a stray GOWORK would break its resolution).
+          GOWORK="$PWD/../go.work" go run ./tools/gen-composition
           GOWORK="$PWD/../build/composition/go.work" \
             go run ./cmd/api --dsn "postgres://margince_app:margince_app_dev@localhost:55432/margince" \
             --config "$RUNNER_TEMP/margince.yaml" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,22 @@ jobs:
           cache-dependency-path: backend/go.sum
       # working-directory: . on the root-level steps — the workflow default
       # (backend) would resolve fixtures/ and extensions/ under backend/.
+      #
+      # The EMPTY installation stays a supported, proven state: with the
+      # tracked first-party units (extensions/de) moved aside, the
+      # composed wiring must be byte-identical to the committed vanilla
+      # stub and the composed build must pass — otherwise a regression
+      # that only breaks "remove the directory to disable" could merge,
+      # since the normal gates always see {de}.
+      - name: Vanilla lane (empty extensions/)
+        working-directory: .
+        run: |
+          stash="$RUNNER_TEMP/ext-stash"
+          mkdir -p "$stash"
+          find extensions -mindepth 1 -maxdepth 1 -type d -exec mv {} "$stash"/ \;
+          make -C backend composition build
+          cmp build/composition/backend/extensions_gen.go composition/extensions_gen.go
+          find "$stash" -mindepth 1 -maxdepth 1 -exec mv {} extensions/ \;
       - name: Enable the reference extension
         working-directory: .
         run: cp -R fixtures/extensions/crm-hello extensions/
@@ -528,7 +544,12 @@ jobs:
         env:
           MARGINCE_ENV: dev
         run: |
-          go run ./cmd/api --dsn "postgres://margince_app:margince_app_dev@localhost:55432/margince" \
+          # Composed boot (ADR-0069): a plain `go run` would resolve the
+          # vanilla composition stub and this lane would never boot with
+          # the enabled extensions (extensions/de ships by default).
+          go run ./tools/gen-composition
+          GOWORK="$PWD/../build/composition/go.work" \
+            go run ./cmd/api --dsn "postgres://margince_app:margince_app_dev@localhost:55432/margince" \
             --config "$RUNNER_TEMP/margince.yaml" \
             > "$RUNNER_TEMP/api.log" 2>&1 &
           for _ in $(seq 1 60); do

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -53,8 +53,11 @@ help: ## List targets with their descriptions (the default goal)
 
 check: build vet lint arch-lint test test-extensions drift check-composition ## The merge gate: everything a PR must pass
 
+# gen-composition runs pinned to the ROOT workspace: the tool lives in
+# the separate backend/tools module, so a caller-exported GOWORK (off, or
+# an unrelated workspace) would break resolution before anything builds.
 composition: ## Materialize build/composition/ from the enabled set under extensions/ (every build lane depends on this)
-	@$(GO) run ./tools/gen-composition
+	@GOWORK=$(abspath ../go.work) $(GO) run ./tools/gen-composition
 
 check-composition: composition ## Reproducibility gate: a clean regeneration must reproduce composition.json byte-for-byte
 	@$(GO) run ./tools/gen-composition -verify
@@ -206,7 +209,7 @@ gen: ## Regenerate everything derived from the contract
 	$(GO) run ./tools/gen-stubs
 	$(GO) run ./tools/gen-agentpolicy -in api/crm.yaml -out internal/compose/agentpolicy_gen.go
 	$(GO) run ./tools/gen-aitasks -contract api/ai-tasks.yaml -out-go internal/modules/ai/tasks_gen.go -out-schema ../config/ai-routing.schema.json
-	$(GO) run ./tools/gen-composition
+	GOWORK=$(abspath ../go.work) $(GO) run ./tools/gen-composition
 
 drift: gen ## Fail when any generated file drifted from the contract
 	git diff --exit-code -- '*_gen.go' internal/contracts/ ../config/ai-routing.schema.json

--- a/backend/internal/compose/extensions.go
+++ b/backend/internal/compose/extensions.go
@@ -78,6 +78,9 @@ func preflightJurisdictions(e extension.Extension, packCodes map[jurisdiction.Co
 				if err := class.Name.Validate(); err != nil {
 					return fmt.Errorf("compose: extension %q, jurisdiction %q: %w", e.Name, code, err)
 				}
+				if err := class.Keep.Validate(); err != nil {
+					return fmt.Errorf("compose: extension %q, jurisdiction %q, class %q: %w", e.Name, code, class.Name, err)
+				}
 			}
 		}
 		packCodes[code] = e.Name

--- a/backend/internal/compose/extensions_test.go
+++ b/backend/internal/compose/extensions_test.go
@@ -104,6 +104,26 @@ func TestRegisterExtensionsRejectsAnUnknownRetentionClass(t *testing.T) {
 	}
 }
 
+// TestRegisterExtensionsRejectsANegativePeriod: a negative floor would
+// anchor its cutoff in the future and silently shrink statutory
+// protection — the boot refuses the set.
+func TestRegisterExtensionsRejectsANegativePeriod(t *testing.T) {
+	err := RegisterExtensions([]extension.Extension{{
+		Name:    "future-floor",
+		Version: "0.0.1",
+		Jurisdictions: []jurisdiction.Pack{fakePack{
+			code:    "zt",
+			classes: []jurisdiction.RetentionClass{{Name: jurisdiction.CommercialCorrespondence, Keep: jurisdiction.Period{Years: -6}}},
+		}},
+	}})
+	if err == nil || !strings.Contains(err.Error(), "negative component") {
+		t.Fatalf("err = %v, want the negative-component rejection", err)
+	}
+	if _, ok := jurisdiction.For("zt"); ok {
+		t.Fatal("the pack landed although its floor failed validation")
+	}
+}
+
 // TestNoCapabilityAppliesWhenTheSetIsInvalid: validation and application
 // are separate phases — a clean unit's capabilities must not land when a
 // later unit fails validation, or a crash-looping process would leave

--- a/backend/internal/modules/privacy/retention.go
+++ b/backend/internal/modules/privacy/retention.go
@@ -174,6 +174,11 @@ func (s *RetentionService) evaluateWorkspace(ctx context.Context) error {
 		return err
 	}
 
+	// ONE reference instant per workspace pass: the strictest-floor
+	// comparison anchors mixed-unit periods at a timestamp, so a fresh
+	// time.Now() per policy could order the floors differently between
+	// two activity policies of the same run.
+	ref := time.Now()
 	for _, pol := range policies {
 		scope := pol.ObjectType + "/"
 		if pol.Category != nil {
@@ -189,7 +194,7 @@ func (s *RetentionService) evaluateWorkspace(ctx context.Context) error {
 		if pol.ObjectType == "activity" {
 			floor := jurisdiction.Period{}
 			if pol.Action != "archive" {
-				floor = statutoryCorrespondenceFloor(time.Now())
+				floor = statutoryCorrespondenceFloor(ref)
 			}
 			args = append(args, floor.String())
 		}

--- a/backend/pkg/extension/jurisdiction/jurisdiction.go
+++ b/backend/pkg/extension/jurisdiction/jurisdiction.go
@@ -68,6 +68,19 @@ func (p Period) Cutoff(ref time.Time) time.Time {
 	return ref.AddDate(-p.Years, -p.Months, -p.Days)
 }
 
+// Validate refuses negative components. The fields stay signed ints (Go
+// convention: unsigned would trade this check for silent wraparound),
+// so the guard lives here: a negative component renders as a
+// Postgres-parseable interval ("P-6Y") whose cutoff lies in the FUTURE —
+// it would silently SHRINK a statutory floor, the exact failure class
+// this type exists to prevent. The boot preflight refuses it.
+func (p Period) Validate() error {
+	if p.Years < 0 || p.Months < 0 || p.Days < 0 {
+		return fmt.Errorf("period %s carries a negative component — a retention floor reaches back, never forward", p)
+	}
+	return nil
+}
+
 // Pack is one jurisdiction's compiled-in behavior set. Retention is the
 // only obligation packs carry today; the further ADR-0042 contributions
 // (FiscalFormatter, ConformityRegime, …) return when a work package pays

--- a/backend/pkg/extension/jurisdiction/jurisdiction_test.go
+++ b/backend/pkg/extension/jurisdiction/jurisdiction_test.go
@@ -39,6 +39,22 @@ func TestPeriodStringIsAnISO8601DateInterval(t *testing.T) {
 	}
 }
 
+// TestPeriodValidateRefusesNegativeComponents: a negative component
+// renders as a Postgres-parseable interval whose cutoff lies in the
+// future — it would silently shrink a statutory floor.
+func TestPeriodValidateRefusesNegativeComponents(t *testing.T) {
+	for _, valid := range []Period{{}, {Years: 6}, {Years: 1, Months: 6, Days: 15}} {
+		if err := valid.Validate(); err != nil {
+			t.Errorf("Period%+v.Validate() = %v, want nil", valid, err)
+		}
+	}
+	for _, invalid := range []Period{{Years: -6}, {Months: -1}, {Days: -30}, {Years: 6, Days: -1}} {
+		if err := invalid.Validate(); err == nil {
+			t.Errorf("Period%+v.Validate() = nil, want the negative-component rejection", invalid)
+		}
+	}
+}
+
 // TestPeriodCutoffIsCalendarCorrect: the reason Period exists — six
 // calendar years anchored after a leap day reach exactly six years back,
 // not 2190 days (which would land ~1.5 days short and let destructive

--- a/composition/go.mod
+++ b/composition/go.mod
@@ -1,3 +1,11 @@
+// The committed vanilla composition stub (ADR-0069): bare go builds
+// resolve this module through backend/go.mod's replace; make lanes
+// override it with the generated module under build/composition/. The
+// sibling go.sum is EMPTY by construction — the single require is a
+// directory replace (no remote hashes exist to lock) and the stub
+// imports only the stdlib-only published surface. It is committed so
+// module-mode builds verify hashes the moment a real dependency ever
+// appears, instead of silently resolving unverified.
 module github.com/gradionhq/margince/composition
 
 go 1.26.5

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -290,7 +290,7 @@ up)
     # The composed workspace (ADR-0069): materialize build/composition/
     # and build the role binaries against it, so an enabled extension set
     # under extensions/ reaches the dev stack; vanilla composes empty.
-    ( cd backend && go run ./tools/gen-composition )
+    ( cd backend && GOWORK="$PWD/../go.work" go run ./tools/gen-composition )
     ( cd backend && GOWORK="$PWD/../build/composition/go.work" go build -o ../bin/api ./cmd/api )
     echo "=== servers ==="
   } >>"$log" 2>&1

--- a/scripts/mcp-inspector.sh
+++ b/scripts/mcp-inspector.sh
@@ -71,7 +71,7 @@ echo "mcp-inspector: building bin/mcp…"
 # The composed workspace (ADR-0069): a plain `go build` would resolve the
 # vanilla composition stub and serve the tool surface WITHOUT the enabled
 # extensions — the mcp role composes like api and worker do in dev.sh.
-(cd backend && go run ./tools/gen-composition)
+(cd backend && GOWORK="$PWD/../go.work" go run ./tools/gen-composition)
 (cd backend && GOWORK="$PWD/../build/composition/go.work" go build -o ../bin/mcp ./cmd/mcp)
 
 echo "mcp-inspector: launching Inspector → workspace '${workspace}', database '${db}'"

--- a/scripts/mcp-inspector.sh
+++ b/scripts/mcp-inspector.sh
@@ -68,7 +68,11 @@ APP_DSN="${APP_DSN:-postgres://margince_app:margince_app_dev@localhost:55432/mar
 dsn="${APP_DSN%/*}/${db}"
 
 echo "mcp-inspector: building bin/mcp…"
-(cd backend && go build -o ../bin/mcp ./cmd/mcp)
+# The composed workspace (ADR-0069): a plain `go build` would resolve the
+# vanilla composition stub and serve the tool surface WITHOUT the enabled
+# extensions — the mcp role composes like api and worker do in dev.sh.
+(cd backend && go run ./tools/gen-composition)
+(cd backend && GOWORK="$PWD/../build/composition/go.work" go build -o ../bin/mcp ./cmd/mcp)
 
 echo "mcp-inspector: launching Inspector → workspace '${workspace}', database '${db}'"
 # Token + DSN in the environment only (never argv): a passport is a bearer


### PR DESCRIPTION
Four review findings, one theme — seams quietly diverging from the composed reality:

- **mcp-inspector + live-boot built uncomposed**: plain `go build`/`go run` resolves the vanilla stub, so the MCP tool surface and the boot-verified api ran without `extensions/de`. Both now compose like dev.sh.
- **Empty-set proof restored**: with `extensions/de` tracked, CI only ever saw `{de}` and `{de, crm-hello}` — the extension-reference job gains a vanilla lane (stash units → wiring byte-identical to stub → build → restore).
- **One floor anchor per retention pass**: per-policy `time.Now()` could order mixed-unit statutory floors differently within one run.
- **`Period.Validate`** (no negative components, preflight-enforced): fields stay signed per Go convention — the guard is a check, not wraparound — and a negative component is a future-anchored cutoff that silently shrinks a statutory floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened extension composition and retention behavior to match the composed dev setup. Builds now use the composed workspace; generation is pinned to the root `GOWORK`; retention floors are anchored and validated; the vanilla composition stub ships an empty `go.sum` for hash verification.

- **Bug Fixes**
  - Compose `mcp` and live-boot CI: pin `gen-composition` to the root `GOWORK`, generate composition, and run/build with the composed workspace; e2e change filter includes `extensions/**`, `fixtures/**`, and `composition/**`.
  - Add CI vanilla lane: stash `extensions/`, verify generated wiring equals the stub, build, then restore.
  - Use one reference time per retention pass for consistent floor ordering.
  - Add `Period.Validate()` (no negative components) and enforce at boot; tests cover validation and preflight refusal.
  - Commit empty `composition/go.sum` so module-mode builds verify hashes when dependencies appear.

<sup>Written for commit c9f30d10aa0f46715448488e15a953d2797408e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Retention settings now reject negative duration values with clearer validation errors.
  * Retention calculations use a consistent reference time within each evaluation.
  * Invalid jurisdiction configurations are rejected before registration.

* **Improvements**
  * API and MCP builds now include the configured extension composition.
  * Automated checks verify builds remain unchanged when no extensions are enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->