### PR TITLE
perf(ci): deterministic-gates uses installed gate binaries + a golangci-lint analysis cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,16 +141,19 @@ jobs:
       # every run — the two lint passes (baseline + strict) were the largest
       # slice of this job. The key ends in the commit SHA so every run saves
       # its refreshed cache; restore-keys matches the newest prior run with
-      # the same toolchain/config prefix, so a PR pays analysis only for the
-      # packages it touched. A dependency or lint-config change shifts the
-      # prefix and starts clean.
+      # the same dependency/config prefix, so a PR pays analysis only for
+      # the packages it touched. A dependency or lint-config change shifts
+      # the prefix and starts clean. The golangci version pin (in
+      # backend/Makefile) is deliberately NOT in the key: golangci versions
+      # its cache entries internally, and hashing the whole Makefile went
+      # cold on every unrelated Makefile edit.
       - name: Cache the golangci-lint analysis cache
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/.cache/golangci-lint
-          key: golangci-analysis-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('backend/go.sum', 'backend/Makefile', 'backend/.golangci.yml', 'backend/.golangci.strict.yml') }}-${{ github.sha }}
+          key: golangci-analysis-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('backend/go.sum', 'backend/.golangci.yml', 'backend/.golangci.strict.yml') }}-${{ github.sha }}
           restore-keys: |
-            golangci-analysis-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('backend/go.sum', 'backend/Makefile', 'backend/.golangci.yml', 'backend/.golangci.strict.yml') }}-
+            golangci-analysis-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('backend/go.sum', 'backend/.golangci.yml', 'backend/.golangci.strict.yml') }}-
       # Install the pinned gate binaries (golangci-lint, go-arch-lint, oasdiff) so
       # `make check` runs golangci and the oasdiff contract gate itself — one run
       # of every gate, instead of the golangci-lint-action + per-gate steps that

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,21 @@ jobs:
         with:
           path: ~/go/bin
           key: gate-binaries-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('backend/go.mod', 'backend/Makefile') }}
+      # golangci-lint's analysis cache (~/.cache/golangci-lint) is separate
+      # from Go's build cache, so without this it recomputes the whole repo
+      # every run — the two lint passes (baseline + strict) were the largest
+      # slice of this job. The key ends in the commit SHA so every run saves
+      # its refreshed cache; restore-keys matches the newest prior run with
+      # the same toolchain/config prefix, so a PR pays analysis only for the
+      # packages it touched. A dependency or lint-config change shifts the
+      # prefix and starts clean.
+      - name: Cache the golangci-lint analysis cache
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: ~/.cache/golangci-lint
+          key: golangci-analysis-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('backend/go.sum', 'backend/Makefile', 'backend/.golangci.yml', 'backend/.golangci.strict.yml') }}-${{ github.sha }}
+          restore-keys: |
+            golangci-analysis-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('backend/go.sum', 'backend/Makefile', 'backend/.golangci.yml', 'backend/.golangci.strict.yml') }}-
       # Install the pinned gate binaries (golangci-lint, go-arch-lint, oasdiff) so
       # `make check` runs golangci and the oasdiff contract gate itself — one run
       # of every gate, instead of the golangci-lint-action + per-gate steps that

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,8 +142,10 @@ jobs:
       # slice of this job. The key ends in the commit SHA so every run saves
       # its refreshed cache; restore-keys matches the newest prior run with
       # the same dependency/config prefix, so a PR pays analysis only for
-      # the packages it touched. A dependency or lint-config change shifts
-      # the prefix and starts clean. The golangci version pin (in
+      # the packages it touched. A toolchain, dependency, or lint-config
+      # change shifts the prefix and starts clean — go.mod is in the hash
+      # because a toolchain bump changes analysis results without
+      # necessarily touching go.sum. The golangci version pin (in
       # backend/Makefile) is deliberately NOT in the key: golangci versions
       # its cache entries internally, and hashing the whole Makefile went
       # cold on every unrelated Makefile edit.
@@ -151,9 +153,9 @@ jobs:
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/.cache/golangci-lint
-          key: golangci-analysis-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('backend/go.sum', 'backend/.golangci.yml', 'backend/.golangci.strict.yml') }}-${{ github.sha }}
+          key: golangci-analysis-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', 'backend/.golangci.yml', 'backend/.golangci.strict.yml') }}-${{ github.sha }}
           restore-keys: |
-            golangci-analysis-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('backend/go.sum', 'backend/.golangci.yml', 'backend/.golangci.strict.yml') }}-
+            golangci-analysis-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', 'backend/.golangci.yml', 'backend/.golangci.strict.yml') }}-
       # Install the pinned gate binaries (golangci-lint, go-arch-lint, oasdiff) so
       # `make check` runs golangci and the oasdiff contract gate itself — one run
       # of every gate, instead of the golangci-lint-action + per-gate steps that

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -178,10 +178,13 @@ lint: ## golangci-lint: repo-wide baseline + new-code strict set
 # which re-downloads and recompiles the tool on every invocation: correct
 # on a fresh machine, waste everywhere else.
 #   $(call resolve-gate-tool,<binary>,<module regex>,<version>,<install path>)
+# The binary branch is emitted pre-quoted: the value lands unquoted in a
+# recipe line, and a GOBIN/GOPATH with spaces must not word-split there.
+# The go run fallback stays bare — it is deliberately multi-word.
 GATE_BIN_DIR := $(or $(shell $(GO) env GOBIN),$(shell $(GO) env GOPATH)/bin)
 resolve-gate-tool = $(shell $(GO) version -m '$(GATE_BIN_DIR)/$(1)' 2>/dev/null \
 	| grep -qE '[[:space:]]mod[[:space:]]+$(2)[[:space:]]+$(3)([[:space:]]|$$)' \
-	&& echo '$(GATE_BIN_DIR)/$(1)' || echo "$(GO) run $(4)@$(3)")
+	&& echo '"$(GATE_BIN_DIR)/$(1)"' || echo "$(GO) run $(4)@$(3)")
 
 # Layer C of the boundary stack — a HARD gate: a forbidden import edge
 # fails `make check`, it is never advisory.

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -40,7 +40,13 @@ export MARGINCE_ENV          ?= dev
 help: ## List targets with their descriptions (the default goal)
 	@grep -hE '^[a-zA-Z][a-zA-Z0-9_-]*:.*## ' $(MAKEFILE_LIST) | awk -F':.*## ' '{printf "  %-18s %s\n", $$1, $$2}'
 
-check: build vet lint arch-lint test drift ## The merge gate: everything a PR must pass
+# The five analysis passes share no outputs and only read the tree — Go's
+# build cache is concurrency-safe — so they fan out together. drift stays
+# behind them: gen REWRITES *_gen.go and internal/contracts/ in place,
+# a write-under-reader race for any pass still compiling those files.
+check: ## The merge gate: everything a PR must pass
+	$(MAKE) -j5 build vet lint arch-lint test
+	$(MAKE) drift
 
 build: ## Compile every package
 	$(GO) build ./...

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -162,9 +162,15 @@ lint: ## golangci-lint: repo-wide baseline + new-code strict set
 
 # Layer C of the boundary stack — a HARD gate: a forbidden import edge
 # fails `make check`, it is never advisory.
+# Same binary resolution as GOLANGCI_LINT above: prefer the pinned install
+# from `make tools` (CI restores it from cache), fall back to a pinned
+# `go run` so a fresh machine still gates — that fallback re-downloads and
+# recompiles the tool on every run, which is exactly what the install avoids.
 GO_ARCH_LINT_VERSION ?= v1.12.0
+GO_ARCH_LINT_BIN := $(shell $(GO) env GOPATH)/bin/go-arch-lint
+GO_ARCH_LINT ?= $(shell test -x $(GO_ARCH_LINT_BIN) && echo $(GO_ARCH_LINT_BIN) || echo "$(GO) run github.com/fe3dback/go-arch-lint@$(GO_ARCH_LINT_VERSION)")
 arch-lint: ## Import-boundary lint (go-arch-lint over .go-arch-lint.yml)
-	$(GO) run github.com/fe3dback/go-arch-lint@$(GO_ARCH_LINT_VERSION) check
+	$(GO_ARCH_LINT) check
 
 # The stub and agent-policy generators run here explicitly (not via
 # `go generate ./...`): internal/compose is generated INTO, and its own
@@ -191,8 +197,10 @@ gen-workflow: ## Scaffold a new workflow.Handler: make gen-workflow NAME=flag_id
 # version is PINNED — `@latest` makes the scan non-reproducible (a tool
 # upgrade could change findings between two runs of the same commit).
 GOVULNCHECK_VERSION ?= v1.1.4
+GOVULNCHECK_BIN := $(shell $(GO) env GOPATH)/bin/govulncheck
+GOVULNCHECK ?= $(shell test -x $(GOVULNCHECK_BIN) && echo $(GOVULNCHECK_BIN) || echo "$(GO) run golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION)")
 vuln: ## Scan dependencies for known vulnerabilities (govulncheck)
-	$(GO) run golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION) ./...
+	$(GOVULNCHECK) ./...
 
 # Fresh-machine bootstrap. golangci-lint is the one gate binary `make check`
 # runs from an install rather than a pinned `go run`; the lint target

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -166,15 +166,22 @@ lint: ## golangci-lint: repo-wide baseline + new-code strict set
 		echo "SKIP strict lint: origin/main not found — fetch it to arm the new-code gate"; \
 	fi
 
+# Gate-tool resolution: prefer the install from `make tools` (CI restores
+# it from cache), but only when its embedded module version (`go version
+# -m`) matches the pin — a stale local install must never gate at a
+# version CI does not run. Anything else falls back to a pinned `go run`,
+# which re-downloads and recompiles the tool on every invocation: correct
+# on a fresh machine, waste everywhere else.
+#   $(call resolve-gate-tool,<binary>,<module regex>,<version>,<install path>)
+GATE_BIN_DIR := $(or $(shell $(GO) env GOBIN),$(shell $(GO) env GOPATH)/bin)
+resolve-gate-tool = $(shell $(GO) version -m '$(GATE_BIN_DIR)/$(1)' 2>/dev/null \
+	| grep -qE '[[:space:]]mod[[:space:]]+$(2)[[:space:]]+$(3)([[:space:]]|$$)' \
+	&& echo '$(GATE_BIN_DIR)/$(1)' || echo "$(GO) run $(4)@$(3)")
+
 # Layer C of the boundary stack — a HARD gate: a forbidden import edge
 # fails `make check`, it is never advisory.
-# Same binary resolution as GOLANGCI_LINT above: prefer the pinned install
-# from `make tools` (CI restores it from cache), fall back to a pinned
-# `go run` so a fresh machine still gates — that fallback re-downloads and
-# recompiles the tool on every run, which is exactly what the install avoids.
 GO_ARCH_LINT_VERSION ?= v1.12.0
-GO_ARCH_LINT_BIN := $(shell $(GO) env GOPATH)/bin/go-arch-lint
-GO_ARCH_LINT ?= $(shell test -x $(GO_ARCH_LINT_BIN) && echo $(GO_ARCH_LINT_BIN) || echo "$(GO) run github.com/fe3dback/go-arch-lint@$(GO_ARCH_LINT_VERSION)")
+GO_ARCH_LINT ?= $(call resolve-gate-tool,go-arch-lint,github\.com/fe3dback/go-arch-lint,$(GO_ARCH_LINT_VERSION),github.com/fe3dback/go-arch-lint)
 arch-lint: ## Import-boundary lint (go-arch-lint over .go-arch-lint.yml)
 	$(GO_ARCH_LINT) check
 
@@ -202,9 +209,10 @@ gen-workflow: ## Scaffold a new workflow.Handler: make gen-workflow NAME=flag_id
 # `make check`, so a missing network never blocks a local build. The
 # version is PINNED — `@latest` makes the scan non-reproducible (a tool
 # upgrade could change findings between two runs of the same commit).
+# govulncheck's module is golang.org/x/vuln; the binary installs from the
+# cmd/ subpath — resolve-gate-tool takes both.
 GOVULNCHECK_VERSION ?= v1.1.4
-GOVULNCHECK_BIN := $(shell $(GO) env GOPATH)/bin/govulncheck
-GOVULNCHECK ?= $(shell test -x $(GOVULNCHECK_BIN) && echo $(GOVULNCHECK_BIN) || echo "$(GO) run golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION)")
+GOVULNCHECK ?= $(call resolve-gate-tool,govulncheck,golang\.org/x/vuln,$(GOVULNCHECK_VERSION),golang.org/x/vuln/cmd/govulncheck)
 vuln: ## Scan dependencies for known vulnerabilities (govulncheck)
 	$(GOVULNCHECK) ./...
 

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -40,12 +40,17 @@ export MARGINCE_ENV          ?= dev
 help: ## List targets with their descriptions (the default goal)
 	@grep -hE '^[a-zA-Z][a-zA-Z0-9_-]*:.*## ' $(MAKEFILE_LIST) | awk -F':.*## ' '{printf "  %-18s %s\n", $$1, $$2}'
 
-# The five analysis passes share no outputs and only read the tree — Go's
-# build cache is concurrency-safe — so they fan out together. drift stays
-# behind them: gen REWRITES *_gen.go and internal/contracts/ in place,
-# a write-under-reader race for any pass still compiling those files.
+# build runs ALONE first: it compiles the dependency graph into the build
+# cache exactly once. Fanning it out with the others makes every pass
+# compile that graph concurrently — the cache does not block a second
+# compiler on an in-flight entry, so parallel-from-cold multiplies the
+# work and LOSES to serial on a small runner (measured in CI). The four
+# analysis passes then fan out as pure readers of the warmed cache. drift
+# stays last and serial: gen REWRITES *_gen.go and internal/contracts/ in
+# place, a write-under-reader race for any pass still compiling them.
 check: ## The merge gate: everything a PR must pass
-	$(MAKE) -j5 build vet lint arch-lint test
+	$(MAKE) build
+	$(MAKE) -j4 vet lint arch-lint test
 	$(MAKE) drift
 
 build: ## Compile every package

--- a/scripts/check-contract-breaking.sh
+++ b/scripts/check-contract-breaking.sh
@@ -19,16 +19,26 @@ CRM_YAML="${CRM_YAML:-backend/api/crm.yaml}"
 BASE_REF="${1:-origin/main}"
 
 # Tool resolution, same order as the backend Makefile's gate binaries:
-# prefer the pinned install from `make tools` (CI restores it from cache —
-# the `go run` fallback re-downloads and recompiles oasdiff on every run),
-# fall back to `go run` at the exact version so a fresh machine still
-# gates. Bump this pin and the Makefile's OASDIFF_VERSION together.
-if [[ -z "${OASDIFF:-}" ]]; then
-  OASDIFF_BIN="$(go env GOPATH)/bin/oasdiff"
-  if [[ -x "$OASDIFF_BIN" ]]; then
-    OASDIFF="$OASDIFF_BIN"
+# prefer the install from `make tools` (CI restores it from cache — the
+# `go run` fallback re-downloads and recompiles oasdiff on every run), but
+# only when its embedded module version (`go version -m`) matches the pin,
+# so a stale local install can never gate at a version CI does not run;
+# anything else falls back to `go run` at the exact version. Bump this pin
+# and the Makefile's OASDIFF_VERSION together. The command is an array —
+# the binary path may contain spaces, the fallback is three words — and
+# an OASDIFF env override still wins, split on words (it names a command,
+# possibly with arguments).
+OASDIFF_VERSION="v1.22.0"
+if [[ -n "${OASDIFF:-}" ]]; then
+  read -r -a OASDIFF_CMD <<< "$OASDIFF"
+else
+  BIN_DIR="$(go env GOBIN)"
+  [[ -n "$BIN_DIR" ]] || BIN_DIR="$(go env GOPATH)/bin"
+  if go version -m "$BIN_DIR/oasdiff" 2>/dev/null \
+      | grep -qE "[[:space:]]mod[[:space:]]+github\.com/oasdiff/oasdiff[[:space:]]+${OASDIFF_VERSION}([[:space:]]|\$)"; then
+    OASDIFF_CMD=("$BIN_DIR/oasdiff")
   else
-    OASDIFF="go run github.com/oasdiff/oasdiff@v1.22.0"
+    OASDIFF_CMD=(go run "github.com/oasdiff/oasdiff@${OASDIFF_VERSION}")
   fi
 fi
 
@@ -81,13 +91,13 @@ if [ "$CONTRACT_STABILITY" = pre-live ] || [ "$ALLOWLISTED_RESYNC" = 1 ]; then
   # Advisory stance: print every change (oasdiff without --fail-on never
   # exits non-zero on findings) so the deliberate breaks stay visible in
   # the log, but do not block.
-  $OASDIFF breaking "$BASE_REF:$CRM_YAML" "$CRM_YAML" -f text
+  "${OASDIFF_CMD[@]}" breaking "$BASE_REF:$CRM_YAML" "$CRM_YAML" -f text
   if [ "$ALLOWLISTED_RESYNC" = 1 ]; then
     echo "contract-breaking-check: advisory — this exact pre-live contract resync is ratified; any later contract edit restores the stable gate"
   else
     echo "contract-breaking-check: advisory (CONTRACT_STABILITY=pre-live) — breaking change(s) printed above, if any, are deliberately permitted for this run"
   fi
-elif $OASDIFF breaking "$BASE_REF:$CRM_YAML" "$CRM_YAML" --fail-on ERR -f text; then
+elif "${OASDIFF_CMD[@]}" breaking "$BASE_REF:$CRM_YAML" "$CRM_YAML" --fail-on ERR -f text; then
   echo "contract-breaking-check: no breaking API changes since $BASE_REF"
 else
   echo "contract-breaking-check: breaking API change(s) since $BASE_REF — deprecate instead of removing, or run a deliberate re-sync with CONTRACT_STABILITY=pre-live" >&2

--- a/scripts/check-contract-breaking.sh
+++ b/scripts/check-contract-breaking.sh
@@ -18,10 +18,19 @@ cd "$ROOT"
 CRM_YAML="${CRM_YAML:-backend/api/crm.yaml}"
 BASE_REF="${1:-origin/main}"
 
-# The pinned tool invocation. `go run` at an exact version keeps the gate
-# reproducible without a PATH install; `make tools` also installs the same
-# version as a binary for direct use — bump both pins together.
-OASDIFF="${OASDIFF:-go run github.com/oasdiff/oasdiff@v1.22.0}"
+# Tool resolution, same order as the backend Makefile's gate binaries:
+# prefer the pinned install from `make tools` (CI restores it from cache —
+# the `go run` fallback re-downloads and recompiles oasdiff on every run),
+# fall back to `go run` at the exact version so a fresh machine still
+# gates. Bump this pin and the Makefile's OASDIFF_VERSION together.
+if [[ -z "${OASDIFF:-}" ]]; then
+  OASDIFF_BIN="$(go env GOPATH)/bin/oasdiff"
+  if [[ -x "$OASDIFF_BIN" ]]; then
+    OASDIFF="$OASDIFF_BIN"
+  else
+    OASDIFF="go run github.com/oasdiff/oasdiff@v1.22.0"
+  fi
+fi
 
 # Stance: 'stable' (default) blocks the merge on any breaking change;
 # 'pre-live' prints them but passes (for a deliberate spec re-sync).


### PR DESCRIPTION
## What

`deterministic-gates` became the slowest CI job (~2m56) after #193 sharded the integration lane. Its own log timestamps break the `make check-backend` step (~2m49) down to:

| Segment | Time | Avoidable |
|---|---|---|
| golangci-lint, baseline + strict passes | **68s** | yes — no analysis cache in CI |
| `go build ./...` | 29s | no |
| go-arch-lint via `go run @v1.12.0` | **22s** | yes — recompiles a tool already on PATH |
| contract-breaking via `go run oasdiff@v1.22.0` | **16s** | yes — same |
| `go test ./...` + uncached fitness tests | 16s | no |
| `go vet ./...` | 10s | no |
| drift + script gates | 8s | no |

Three changes:

- **Gate tools run from the pinned install instead of `go run @version`.** `go run` never short-circuits on an existing binary — it re-downloads the tool's module graph and recompiles against a cold build cache, while the binaries `make tools` installed sit restored on PATH from the gate-binaries cache. `arch-lint` and `vuln` now resolve through one `resolve-gate-tool` macro, and `scripts/check-contract-breaking.sh` does the same for oasdiff. Resolution is hardened per review: the install is trusted only when its embedded module version (`go version -m`) matches the pin — a stale local binary can never gate at a version CI does not run; `go env GOBIN` is probed before `GOPATH/bin`; the script carries the command as an array so a bin dir with spaces does not word-split. Everything else falls back to `go run` at the exact pin, so a fresh machine still gates.
- **The golangci-lint analysis cache is cached in CI** (`~/.cache/golangci-lint` — separate from Go's build cache, so both lint passes recomputed the whole repo every run). SHA-suffixed key so every run saves its refreshed cache; restore-keys on the go.sum + lint-config hash prefix so a PR pays analysis only for the packages it touched. The golangci version pin is deliberately not in the key: golangci versions its cache entries internally, and hashing the whole Makefile went cold on every unrelated Makefile edit.
- **`make check` warms the build cache, then fans out.** `build` runs alone first, then `vet`/`lint`/`arch-lint`/`test` run under `-j4` as pure readers of the warm cache; `drift` stays last and serial because `gen` rewrites `*_gen.go` in place (a write-under-reader race for anything still compiling). The naive `-j5`-everything version measurably **lost** to serial in CI (3m07): from a cold cache every pass compiled the full dependency graph concurrently — Go's build cache does not block a second compiler on an in-flight entry — stretching `go test` from 15s to 2m06. Kept as a measured lesson in the history.

## Measured

- Serial baseline: `check-backend` 2m49 (job ~2m56).
- Tool-resolution fixes alone, cold lint cache: **2m12**.
- Steady state (warm lint cache + parallel readers) lands after merge, when runs stop editing `backend/Makefile` and reseeding the gate-binaries cache; projected **~1m15–1m30** for the job, well off the PR critical path (the sharded integration lane runs ~3m20).

## Verification

- All resolution paths exercised: pinned binary → binary; missing/stale-version binary → pinned `go run`; `GOBIN` honored; oasdiff run from a bin dir containing a space (the pre-fix scalar expansion dies on it); `OASDIFF` env override still wins.
- `make -n arch-lint` / `make -n vuln` confirm the resolved commands under each condition.
- `shellcheck` clean on the script; full `make check-backend` green locally with the final shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speed up the `deterministic-gates` CI job by running installed, pinned gate binaries, caching `golangci-lint`, and fanning out `vet`, `lint`, `arch-lint`, and `test` after a serial `build` warm-up. Expected runtime ~2m56 → ~1m45; `drift` runs after the parallel block to avoid gen write races.

- **Performance**
  - `arch-lint` (`github.com/fe3dback/go-arch-lint`), `vuln` (`golang.org/x/vuln/cmd/govulncheck`), and the contract-breaking gate (`github.com/oasdiff/oasdiff`) resolve installed binaries only when their embedded module version matches the pin; otherwise fall back to pinned `go run`. Resolution prefers `GOBIN` over `GOPATH/bin`, emits pre-quoted binary paths to survive spaces, the `oasdiff` script uses a command array, and the `OASDIFF` env override is respected.
  - Cache `~/.cache/golangci-lint` with a commit-suffixed key and a restore prefix hashing `backend/go.mod`, `backend/go.sum`, `backend/.golangci.yml`, and `backend/.golangci.strict.yml`; the key excludes the Makefile pin (golangci versions entries internally) so PRs re-analyze only changed packages.

<sup>Written for commit 23a2f2686558ad0cbf94e6855b52899780d79dea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Developer Experience**
  * Improved backend validation workflows by running independent checks in parallel while preserving required build and drift-check sequencing.
  * Added more reliable resolution of pinned analysis and security-checking tools.
  * Improved contract compatibility checks when custom tool commands include paths or arguments.

* **Performance**
  * Added caching for lint analysis results to speed up continuous integration runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
