### PR TITLE
refactor(scripts): pkg-freeze conditionals use bash [[ ]] (Sonar S7688)

### DIFF
--- a/scripts/check-pkg-freeze.sh
+++ b/scripts/check-pkg-freeze.sh
@@ -35,7 +35,7 @@ indent() { sed 's/^/  /'; }
 # is a pseudo-version.
 APIDIFF="${APIDIFF:-go run golang.org/x/exp/cmd/apidiff@v0.0.0-20260718201538-764159d718ef}"
 
-if [ -n "${PKG_FREEZE_MODE:-}" ]; then
+if [[ -n "${PKG_FREEZE_MODE:-}" ]]; then
   MODE="$PKG_FREEZE_MODE"
 else
   # The first STABLE v1+ release tag arms enforcement — exact release
@@ -59,7 +59,7 @@ case "$MODE" in
 esac
 
 resolve_base_ref() {
-  if [ -n "${GITHUB_BASE_REF:-}" ] && git rev-parse -q --verify "origin/$GITHUB_BASE_REF" > /dev/null; then
+  if [[ -n "${GITHUB_BASE_REF:-}" ]] && git rev-parse -q --verify "origin/$GITHUB_BASE_REF" > /dev/null; then
     echo "origin/$GITHUB_BASE_REF"
     return 0
   fi
@@ -73,10 +73,10 @@ resolve_base_ref() {
 }
 
 BASE_REF="${PKG_FREEZE_BASE:-$(resolve_base_ref || true)}"
-if [ -z "$BASE_REF" ]; then
+if [[ -z "$BASE_REF" ]]; then
   # In CI a missing base ref is a broken checkout, never a skip; locally
   # it just means the remote was never fetched.
-  if [ "${CI:-}" = "true" ]; then
+  if [[ "${CI:-}" = "true" ]]; then
     echo "FAIL: pkg-freeze — no base ref (origin/main missing); fetch-depth must cover the merge base" >&2
     exit 1
   fi
@@ -87,7 +87,7 @@ fi
 BASE="$(git merge-base HEAD "$BASE_REF")"
 BASE12="$(git rev-parse --short=12 "$BASE")"
 
-if ! git ls-tree -d "$BASE" backend/pkg > /dev/null 2>&1 || [ -z "$(git ls-tree -d "$BASE" backend/pkg)" ]; then
+if ! git ls-tree -d "$BASE" backend/pkg > /dev/null 2>&1 || [[ -z "$(git ls-tree -d "$BASE" backend/pkg)" ]]; then
   echo "OK: pkg-freeze ($MODE) — no published surface at $BASE_REF merge-base; nothing frozen yet"
   exit 0
 fi
@@ -116,7 +116,7 @@ if ! OLD_PKGS="$(cd "$WORKTREE/backend" && go list ./pkg/... 2> "$golist_err")";
   fi
 fi
 rm -f "$golist_err"
-if [ -z "$OLD_PKGS" ]; then
+if [[ -z "$OLD_PKGS" ]]; then
   echo "OK: pkg-freeze ($MODE) — no published packages at the merge-base; nothing frozen yet"
   exit 0
 fi
@@ -129,7 +129,7 @@ count=0
 for pkg in $OLD_PKGS; do
   count=$((count + 1))
   rel="${pkg#github.com/gradionhq/margince/backend/}"
-  if [ ! -d "backend/$rel" ]; then
+  if [[ ! -d "backend/$rel" ]]; then
     echo "$pkg: package removed" >> "$removals"
     continue
   fi
@@ -139,8 +139,8 @@ for pkg in $OLD_PKGS; do
     | sed -e 's/^- //' -e "s|^|$pkg: |" >> "$findings"
 done
 
-if [ "$MODE" = "advisory" ]; then
-  if [ -s "$removals" ] || [ -s "$findings" ]; then
+if [[ "$MODE" = "advisory" ]]; then
+  if [[ -s "$removals" ]] || [[ -s "$findings" ]]; then
     echo "ADVISORY: pkg-freeze — incompatible published-surface changes vs $BASE_REF (design-fluid pre-v1.0.0; these HARD-FAIL from the first v1 release tag):"
     cat "$removals" "$findings" | indent
   else
@@ -155,9 +155,9 @@ allowed="$EXPORT_DIR/allowed"
 expired="$EXPORT_DIR/expired"
 : > "$allowed"
 : > "$expired"
-if [ -f "$ALLOWLIST" ]; then
+if [[ -f "$ALLOWLIST" ]]; then
   entries="$(awk '!/^[[:space:]]*(#|$)/' "$ALLOWLIST")"
-  if [ -n "$entries" ]; then
+  if [[ -n "$entries" ]]; then
     printf '%s\n' "$entries" | grep -E "^$BASE12 " | sed "s/^$BASE12 //" > "$allowed" || true
     printf '%s\n' "$entries" | grep -vE "^$BASE12 " > "$expired" || true
   fi
@@ -167,28 +167,28 @@ failed=0
 violations="$(grep -Fxv -f "$allowed" "$findings" || true)"
 unused="$(grep -Fxv -f "$findings" "$allowed" || true)"
 
-if [ -s "$removals" ]; then
+if [[ -s "$removals" ]]; then
   echo "FAIL: pkg-freeze — published package removed (never allowlistable; deprecate, then remove with its major cycle — ADR-0069 §3):" >&2
   indent < "$removals" >&2
   failed=1
 fi
-if [ -n "$violations" ]; then
+if [[ -n "$violations" ]]; then
   echo "FAIL: pkg-freeze — incompatible published-surface change vs $BASE_REF (merge-base $BASE12):" >&2
   echo "$violations" | indent >&2
   echo "A ratified change is recorded in $ALLOWLIST as this exact line (visible in the PR):" >&2
   echo "$violations" | sed "s/^/$BASE12 /" | indent >&2
   failed=1
 fi
-if [ -s "$expired" ]; then
+if [[ -s "$expired" ]]; then
   echo "WARN: pkg-freeze — allowlist entries bound to a superseded baseline (they can license nothing; remove them with the next allowlist edit):"
   indent < "$expired"
 fi
-if [ -n "$unused" ]; then
+if [[ -n "$unused" ]]; then
   echo "WARN: pkg-freeze — allowlist entries bound to the current baseline ($BASE12) match no finding (typo, or the change was reverted — remove them):"
   echo "$unused" | indent
 fi
 
-if [ "$failed" -ne 0 ]; then
+if [[ "$failed" -ne 0 ]]; then
   echo "pkg-freeze: the published surface changes additively or via versioned successors, never in place (EXT-P3)." >&2
   exit 1
 fi


### PR DESCRIPTION
Sonar flagged all 17 single-bracket tests in the new `scripts/check-pkg-freeze.sh` (S7688, MAJOR). The script is bash already, so `[[ ]]` is strictly safer (no word-splitting, no `-a`/`-o` pitfalls) and matches the newer scripts' style.

Mechanical conversion, no behavior change: both regimes exercised locally (`advisory` and `PKG_FREEZE_MODE=enforce`), shellcheck clean.

The remaining PR #191 Sonar finding (S8196, single-method interface `Retention`) stays as-is by decision: domain name on the published seam beats the -er convention, and the indirection keeps growth room for future retention aspects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactor `scripts/check-pkg-freeze.sh` to use bash `[[ ]]` conditionals for safer checks and to satisfy Sonar rule S7688, with no behavior changes.

- **Refactors**
  - Replaced all `[` tests with `[[ ]]` across the script to avoid word-splitting and align with current style.
  - Verified both modes: `advisory` and `PKG_FREEZE_MODE=enforce`.

<sup>Written for commit 2ec7277b008627f3efbaa1d3e0ea5ee9c28dda25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

