### PR TITLE
fix(onboarding): make the Voice DNA step survive first contact

### DIFF
--- a/backend/internal/modules/ai/voicebuilder.go
+++ b/backend/internal/modules/ai/voicebuilder.go
@@ -53,6 +53,32 @@ type voiceBrain interface {
 	Complete(context.Context, model.Request) (model.Response, error)
 }
 
+// validatedVoiceBrain is the optional §5.2 structured-output seam a routed
+// brain also satisfies (compose routerBrain.CompleteValidated): validate →
+// retry with the validator's error fed back → escalate one tier. The builder
+// prefers it because a single stochastic slip — one hallucinated quote or a
+// malformed JSON body — must cost a retry, not the whole build.
+type validatedVoiceBrain interface {
+	CompleteValidated(context.Context, model.Request, Validator) (model.Response, error)
+}
+
+// completeVoiceInference runs the builder call and returns a response whose
+// text already passed validate. A Complete-only brain (the offline fake, unit
+// fixtures) keeps the single-shot path with the same validation applied.
+func completeVoiceInference(ctx context.Context, brain voiceBrain, req model.Request, validate Validator) (model.Response, error) {
+	if validated, ok := brain.(validatedVoiceBrain); ok {
+		return validated.CompleteValidated(ctx, req, validate)
+	}
+	resp, err := brain.Complete(ctx, req)
+	if err != nil {
+		return model.Response{}, err
+	}
+	if err := validate(resp.Text); err != nil {
+		return model.Response{}, err
+	}
+	return resp, nil
+}
+
 // EscapeUntrustedTags neutralizes closing-tag sequences inside corpus or
 // draft text before it enters a delimited prompt block: embedded text can
 // then never end its evidence container and pose as instructions.
@@ -112,7 +138,14 @@ func DeriveVoice(ctx context.Context, brain voiceBrain, personality, sourceHash 
 	if err != nil {
 		return VoiceArtifact{}, err
 	}
-	resp, err := brain.Complete(ctx, model.Request{
+	validate := func(text string) error {
+		var candidate VoiceInference
+		if err := json.Unmarshal([]byte(Unfence(text)), &candidate); err != nil {
+			return fmt.Errorf("voice build returned invalid JSON: %w", err)
+		}
+		return validateVoiceInference(candidate, selected)
+	}
+	resp, err := completeVoiceInference(ctx, brain, model.Request{
 		System:   voiceSystemPrompt,
 		Messages: []model.Message{{Role: roleUser, Content: prompt}},
 		// The shared reasoning cap: a routed reasoning model spends output
@@ -120,16 +153,14 @@ func DeriveVoice(ctx context.Context, brain voiceBrain, personality, sourceHash 
 		MaxTokens:      ReasoningOutputMaxTokens,
 		ResponseSchema: voiceInferenceSchema(),
 		SecretStripper: NewSecretStripper(),
-	})
+	}, validate)
 	if err != nil {
 		return VoiceArtifact{}, fmt.Errorf("voice build model call: %w", err)
 	}
+	// validate already accepted this text; a parse here can no longer fail.
 	var inference VoiceInference
 	if err := json.Unmarshal([]byte(Unfence(resp.Text)), &inference); err != nil {
 		return VoiceArtifact{}, fmt.Errorf("voice build returned invalid JSON: %w", err)
-	}
-	if err := validateVoiceInference(inference, selected); err != nil {
-		return VoiceArtifact{}, err
 	}
 	exemplars := SelectExemplars(selected, stats)
 	return VoiceArtifact{

--- a/backend/internal/modules/ai/voicebuilder_test.go
+++ b/backend/internal/modules/ai/voicebuilder_test.go
@@ -83,6 +83,69 @@ func TestDeriveVoiceBuildsAValidatedArtifact(t *testing.T) {
 	}
 }
 
+// validatedStubBrain also satisfies the optional CompleteValidated seam. It
+// exercises the validator the way the router does: the first candidate is
+// malformed, the second fabricates a quote, the third is the real answer —
+// so the test proves the builder both selects the validated pipeline and
+// hands it a validator that actually rejects bad output.
+type validatedStubBrain struct {
+	stubVoiceBrain
+	completeCalls  int
+	validatedCalls int
+	rejections     []error
+}
+
+func (s *validatedStubBrain) Complete(ctx context.Context, req model.Request) (model.Response, error) {
+	s.completeCalls++
+	return s.stubVoiceBrain.Complete(ctx, req)
+}
+
+func (s *validatedStubBrain) CompleteValidated(ctx context.Context, req model.Request, validate Validator) (model.Response, error) {
+	s.validatedCalls++
+	if err := validate("not json at all"); err != nil {
+		s.rejections = append(s.rejections, err)
+	}
+	fabricated := s.inference
+	fabricated.SignatureMoves = []VoiceSignatureMove{{
+		Move: "invented", Quote: "words the author never wrote", SampleID: "s-email",
+	}}
+	payload, err := json.Marshal(fabricated)
+	if err != nil {
+		return model.Response{}, err
+	}
+	if err := validate(string(payload)); err != nil {
+		s.rejections = append(s.rejections, err)
+	}
+	// The embedded stub is called directly: it is this fake's answer supply,
+	// not a routed Complete attempt, so completeCalls stays untouched.
+	resp, err := s.stubVoiceBrain.Complete(ctx, req)
+	if err != nil {
+		return model.Response{}, err
+	}
+	if err := validate(resp.Text); err != nil {
+		return model.Response{}, err
+	}
+	return resp, nil
+}
+
+func TestDeriveVoicePrefersTheValidatedPipeline(t *testing.T) {
+	brain := &validatedStubBrain{stubVoiceBrain: stubVoiceBrain{inference: validInference()}}
+	artifact, err := DeriveVoice(context.Background(), brain, "", "hash-1", builderSamples())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if brain.validatedCalls != 1 || brain.completeCalls != 0 {
+		t.Fatalf("validated=%d complete=%d — a validated brain must be driven only through CompleteValidated",
+			brain.validatedCalls, brain.completeCalls)
+	}
+	if len(brain.rejections) != 2 {
+		t.Fatalf("rejections = %d, want 2 — the supplied validator must refuse malformed JSON and a fabricated quote", len(brain.rejections))
+	}
+	if artifact.ModelName != "stub-model-1" {
+		t.Fatalf("artifact model = %q", artifact.ModelName)
+	}
+}
+
 func TestDeriveVoiceRejectsFabricatedEvidence(t *testing.T) {
 	cases := map[string]func(*VoiceInference){
 		"unknown evidence sample": func(v *VoiceInference) { v.Evidence = []string{"s-invented"} },

--- a/frontend/src/screens/onboarding.css
+++ b/frontend/src/screens/onboarding.css
@@ -697,7 +697,8 @@
   transition: 0.15s;
 }
 .dropzone:hover,
-.dropzone:focus-visible {
+.dropzone:focus-visible,
+.dropzone.dragover {
   border-color: var(--accent);
   background: var(--accentLight);
 }

--- a/frontend/src/screens/onboarding.tsx
+++ b/frontend/src/screens/onboarding.tsx
@@ -1110,6 +1110,7 @@ function OnboardingCoordinator() {
             step={step}
             go={go}
             memberPath={memberPath}
+            voiceBuilt={voiceBuilt}
             onSkipVoice={() => {
               setVoiceSkipped(true);
               const next = memberPath ? 3 : 2;
@@ -1129,11 +1130,13 @@ function Footer({
   step,
   go,
   memberPath,
+  voiceBuilt,
   onSkipVoice,
 }: Readonly<{
   step: number;
   go: (n: number, persist?: boolean) => void;
   memberPath: boolean;
+  voiceBuilt: boolean;
   onSkipVoice: () => void;
 }>) {
   const t = useT();
@@ -1157,16 +1160,19 @@ function Footer({
         <span />
       )}
       <span className="grow" />
-      {step === 1 && (
-        <>
-          <button type="button" className="wiz-later" onClick={onSkipVoice}>
-            {t("ob.skipStep")}
-          </button>
+      {/* The forward action tells the truth about the step's outcome: only a
+          built (or honestly deferred) voice earns "Continue" — without one the
+          way forward IS skipping, and the button says so. */}
+      {step === 1 &&
+        (voiceBuilt ? (
           <Button variant="primary" onClick={() => go(memberPath ? 3 : 2)}>
             {t("ob.next")} <ArrowRight aria-hidden />
           </Button>
-        </>
-      )}
+        ) : (
+          <Button variant="ghost" onClick={onSkipVoice}>
+            {t("ob.skipStep")} <ArrowRight aria-hidden />
+          </Button>
+        ))}
       {step === 2 && (
         <Button variant="primary" onClick={() => go(3)}>
           {t("ob.s3.cta")} <ArrowRight aria-hidden />
@@ -1925,6 +1931,7 @@ function VoiceStep({ onBuilt }: Readonly<{ onBuilt: () => void }>) {
   const [pieces, setPieces] = useState<VoicePiece[]>([]);
   const [paste, setPaste] = useState("");
   const [skipped, setSkipped] = useState<string[]>([]);
+  const [dragOver, setDragOver] = useState(false);
   const [built, setBuilt] = useState(false);
   const [building, setBuilding] = useState(false);
   const [deferred, setDeferred] = useState(false);
@@ -1969,8 +1976,9 @@ function VoiceStep({ onBuilt }: Readonly<{ onBuilt: () => void }>) {
     };
   }, [pieces, pasteWords]);
 
-  const onFiles = (e: ChangeEvent<HTMLInputElement>) => {
-    const files = Array.from(e.target.files ?? []);
+  // One intake for both entry paths — the file picker and a drag&drop onto
+  // the dropzone feed the exact same corpus pipeline.
+  const addFiles = (files: File[]) => {
     const rejected: string[] = [];
     for (const file of files) {
       // V1 corpus is text only (features/09 §B1.1): the meter counts the real
@@ -2005,6 +2013,10 @@ function VoiceStep({ onBuilt }: Readonly<{ onBuilt: () => void }>) {
       });
     }
     setSkipped(rejected);
+  };
+
+  const onFiles = (e: ChangeEvent<HTMLInputElement>) => {
+    addFiles(Array.from(e.target.files ?? []));
     e.target.value = "";
   };
 
@@ -2226,8 +2238,20 @@ function VoiceStep({ onBuilt }: Readonly<{ onBuilt: () => void }>) {
 
         <button
           type="button"
-          className="dropzone"
+          className={`dropzone${dragOver ? " dragover" : ""}`}
           onClick={() => fileRef.current?.click()}
+          // preventDefault on dragover is what makes the zone a legal drop
+          // target — without it the browser navigates to the dropped file.
+          onDragOver={(e) => {
+            e.preventDefault();
+            setDragOver(true);
+          }}
+          onDragLeave={() => setDragOver(false)}
+          onDrop={(e) => {
+            e.preventDefault();
+            setDragOver(false);
+            addFiles(Array.from(e.dataTransfer.files));
+          }}
         >
           <span className="dz-ic">
             <UploadCloud aria-hidden />

--- a/frontend/src/screens/onboarding.tsx
+++ b/frontend/src/screens/onboarding.tsx
@@ -574,6 +574,39 @@ function OnboardingCoordinator() {
     [draft.values.website],
   );
 
+  // A page refresh must not forget a durable build: the profile's version
+  // list is the server truth (active when it auto-activated, candidate when
+  // it awaits review), so the voice step's forward action reflects what
+  // actually exists instead of this mount's local memory.
+  const voiceBuiltProbe = useQuery({
+    queryKey: ["onboarding-voice-built"],
+    queryFn: async (): Promise<boolean> => {
+      const list = await api.GET("/voice-profiles");
+      if (list.error) {
+        throw new Error(problemMessage(list.error));
+      }
+      const profileId = list.data.data[0]?.id;
+      if (!profileId) {
+        return false;
+      }
+      const versions = await api.GET("/voice-profiles/{id}/versions", {
+        params: { path: { id: profileId } },
+      });
+      if (versions.error) {
+        throw new Error(problemMessage(versions.error));
+      }
+      return versions.data.data.some(
+        (version) =>
+          version.status === "active" || version.status === "candidate",
+      );
+    },
+  });
+  useEffect(() => {
+    if (voiceBuiltProbe.data) {
+      setVoiceBuilt(true);
+    }
+  }, [voiceBuiltProbe.data]);
+
   const existing = useCompany(true);
   const wizardState = useQuery({
     queryKey: ["onboarding-state"],


### PR DESCRIPTION
## What broke (reported walking the real onboarding)

1. **Drag & drop was dead.** The dropzone advertised "Drag & drop files here" but registered no drag handlers — the browser navigated to the dropped file instead.
2. **The build failed on one model slip.** `DeriveVoice` called the model raw: a single hallucinated quote or malformed JSON from the cheap tier (`gemini-3.1-flash-lite`) failed the entire build with `invalid_output` on attempt 1, even though the §5.2 structured-output retry pipeline already existed.
3. **The footer said "Continue" with nothing built.** Skipping the step and completing it looked identical.

## The fix

- One `addFiles` intake feeds both the file picker and a real `onDrop`/`onDragOver` pair, with a `dragover` visual state.
- The builder pass now rides `CompleteValidated` (validate → retry with the validator's error fed back → escalate one tier) when the brain provides it; Complete-only brains (offline fake, unit fixtures) keep the single-shot path with identical validation.
- The step-2 forward action is honest: **Skip this step** until a build (or honest deferral) lands, **Continue** only after.

## Verified live (Playwright, fresh `make dev-fresh` stack, real Gemini routing)

- Dropped a file onto the dropzone → piece listed, meter counted.
- Uploaded a real 25,390-word corpus (LinkedIn posts, emails, two transcripts) → build **succeeded**; the worker log shows `attempts=2` on the builder call — attempt 1 flunked validation, the feedback retry passed, exactly the failure mode that used to kill the build.
- Footer showed Skip before the build, Continue after; step 3 rendered the truthful built-voice card.

`make check` green (backend + 627 FE tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Voice DNA onboarding step so users can drag-and-drop files, the voice build survives bad model output, and the footer shows the right action even after a refresh. Prevents accidental navigation, reduces failed builds, and keeps progress accurate.

- Bug Fixes
  - Enabled real drag & drop: added drop/dragover handlers with a visual state; picker and drop both use one `addFiles` path.
  - Made the voice builder robust: prefers the validated retry path (validate → retry with feedback → escalate) when available; Complete-only brains keep single-shot; parse only after validation.
  - Footer reflects server truth: hydrates the built-voice flag from profile versions so refreshes don’t regress; shows Skip until a voice is built or deferred, Continue only after.

<sup>Written for commit 35b471b959efaa33117fa60ea0fedbcb294c11ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

