### PR TITLE
fix(extensions): one retention floor per class — reject intra-pack duplicates at preflight

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -289,7 +289,7 @@ The `backend/internal/{modules,platform,shared}` triad — the DAG is
   jurisdiction pack — GoBD calendar-year retention floors), first-party
   and enabled by default. `make composition` (run by every build lane)
   generates the ignored `build/composition/` wiring; `composition/` at
-  the root is the committed vanilla stub bare go commands resolve.
+  the root is the committed vanilla stub so bare go commands resolve.
 
 ## DO NOT TOUCH
 

--- a/backend/internal/compose/extensions.go
+++ b/backend/internal/compose/extensions.go
@@ -83,15 +83,22 @@ func preflightJurisdictions(e extension.Extension, packCodes map[jurisdiction.Co
 }
 
 // preflightRetentionClasses validates one pack's declared floors: class
-// name, period, and anchor each carry their own published grammar.
+// name, period, and anchor each carry their own published grammar, and a
+// class may be declared once — two floors for the same class with
+// different Keep/Anchor would leave the engine picking one silently.
 func preflightRetentionClasses(unit extension.Name, code jurisdiction.Code, ret jurisdiction.Retention) error {
 	if ret == nil {
 		return nil
 	}
+	seen := make(map[jurisdiction.RetentionClassName]bool)
 	for _, class := range ret.Classes() {
 		if err := class.Name.Validate(); err != nil {
 			return fmt.Errorf("compose: extension %q, jurisdiction %q: %w", unit, code, err)
 		}
+		if seen[class.Name] {
+			return fmt.Errorf("compose: extension %q, jurisdiction %q declares retention class %q twice", unit, code, class.Name)
+		}
+		seen[class.Name] = true
 		if err := class.Keep.Validate(); err != nil {
 			return fmt.Errorf("compose: extension %q, jurisdiction %q, class %q: %w", unit, code, class.Name, err)
 		}

--- a/backend/internal/compose/extensions_test.go
+++ b/backend/internal/compose/extensions_test.go
@@ -144,6 +144,29 @@ func TestRegisterExtensionsRejectsAnUnknownAnchor(t *testing.T) {
 	}
 }
 
+// TestRegisterExtensionsRejectsADuplicateRetentionClass: one class, one
+// floor — a pack declaring the same class twice with different
+// Keep/Anchor values would leave the engine picking one silently.
+func TestRegisterExtensionsRejectsADuplicateRetentionClass(t *testing.T) {
+	err := RegisterExtensions([]extension.Extension{{
+		Name:    "double-floor",
+		Version: "0.0.1",
+		Jurisdictions: []jurisdiction.Pack{fakePack{
+			code: "zr",
+			classes: []jurisdiction.RetentionClass{
+				{Name: jurisdiction.CommercialCorrespondence, Keep: jurisdiction.Period{Years: 6}},
+				{Name: jurisdiction.CommercialCorrespondence, Keep: jurisdiction.Period{Years: 8}, Anchor: jurisdiction.AnchorCalendarYearEnd},
+			},
+		}},
+	}})
+	if err == nil || !strings.Contains(err.Error(), `declares retention class "commercial_correspondence" twice`) {
+		t.Fatalf("err = %v, want the duplicate-class rejection", err)
+	}
+	if _, ok := jurisdiction.For("zr"); ok {
+		t.Fatal("the pack landed although its retention classes failed validation")
+	}
+}
+
 // TestNoCapabilityAppliesWhenTheSetIsInvalid: validation and application
 // are separate phases — a clean unit's capabilities must not land when a
 // later unit fails validation, or a crash-looping process would leave


### PR DESCRIPTION
CodeRabbit wave on #191, validated one by one:

1. **Fixed — duplicate retention class within one pack.** `preflightRetentionClasses` validated each class's name/period/anchor but accepted the same class declared twice with different `Keep`/`Anchor` values, leaving the engine to pick one silently. The preflight now rejects the set at boot, with a test.
2. **Fixed — CLAUDE.md sentence drift.** The extension-tier sentence dropped a "so" that its AGENTS.md mirror carries; the two files are mandated to stay in sync.
3. **Rebutted — dev.sh worker build allegedly missing gen-composition.** Both role builds sit in the same `up` case branch and run strictly sequentially in one invocation: gen-composition (line 293) → api build → worker build (line 450). Nothing mutates `extensions/` in between, so the worker always builds against the composition generated that run. Replied on the comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject duplicate retention class definitions within a jurisdiction pack during preflight to enforce one floor per class and prevent silent conflicts. Adds a unit test that ensures duplicate classes block registration with a clear error. Also syncs a sentence in `CLAUDE.md` with its `AGENTS.md` mirror.

<sup>Written for commit 3864534f8666d2e0020b672ce9c3f984f65004af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

