### PR TITLE
refactor(gen-composition): the two verify bools become one mode enum

### DIFF
--- a/backend/tools/gen-composition/main.go
+++ b/backend/tools/gen-composition/main.go
@@ -33,9 +33,27 @@ var (
 	verifyInputs = flag.Bool("verify-inputs", false, "recompute input digests only and compare against composition.json; write nothing")
 )
 
+// genMode is the tool's three mutually exclusive operations; when both
+// verify flags are set, the full compare wins (it subsumes the input
+// probe).
+type genMode int
+
+const (
+	modeGenerate     genMode = iota
+	modeVerify               // regenerate in memory, compare manifest + files on disk
+	modeVerifyInputs         // recompute input digests only — the fast staleness probe
+)
+
 func main() {
 	flag.Parse()
-	if err := run(*rootPath, *verify, *verifyInputs); err != nil {
+	mode := modeGenerate
+	switch {
+	case *verify:
+		mode = modeVerify
+	case *verifyInputs:
+		mode = modeVerifyInputs
+	}
+	if err := run(*rootPath, mode); err != nil {
 		fmt.Fprintln(os.Stderr, "gen-composition:", err)
 		os.Exit(1)
 	}
@@ -72,29 +90,29 @@ type manifestExtRow struct {
 	Tree string `json:"tree"`
 }
 
-func run(root string, verifyAll, verifyIn bool) error {
+func run(root string, mode genMode) error {
 	root, err := filepath.Abs(root)
 	if err != nil {
 		return err
 	}
-	if verifyIn || verifyAll {
-		recorded, err := readManifest(root)
-		if err != nil {
-			return fmt.Errorf("%w — run 'make gen'", err)
-		}
-		current, err := computeInputs(root)
-		if err != nil {
-			return err
-		}
-		if err := compareInputs(recorded.Inputs, current); err != nil {
-			return fmt.Errorf("composition stale: %w — run 'make gen'", err)
-		}
-		if !verifyAll {
-			return nil
-		}
-		return verifyOutputs(root, recorded)
+	if mode == modeGenerate {
+		return generate(root)
 	}
-	return generate(root)
+	recorded, err := readManifest(root)
+	if err != nil {
+		return fmt.Errorf("%w — run 'make gen'", err)
+	}
+	current, err := computeInputs(root)
+	if err != nil {
+		return err
+	}
+	if err := compareInputs(recorded.Inputs, current); err != nil {
+		return fmt.Errorf("composition stale: %w — run 'make gen'", err)
+	}
+	if mode == modeVerifyInputs {
+		return nil
+	}
+	return verifyOutputs(root, recorded)
 }
 
 // generate rebuilds build/composition/ from scratch: deterministic


### PR DESCRIPTION
The one craft-static MAJOR the arc actually introduced (the other five findings on the sweep pre-exist on main's backlog): `run(root string, verifyAll, verifyIn bool)` is a boolean trap. The two flags encode three mutually exclusive operations, so the signature now carries a `genMode` enum (generate / verify / verify-inputs); full verify subsumes the input probe when both flags are set, exactly as before.

No behavior change: all three modes exercised locally, tool tests + `make check-composition` green, craft static clean on the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactor `gen-composition` to replace the two verify booleans with a single `genMode` enum covering generate, verify, and verify-inputs. Behavior is unchanged; full verify wins when both flags are set.

- **Refactors**
  - Added `genMode` with modes: generate, verify, verify-inputs.
  - Updated `run(root string, verifyAll, verifyIn bool)` to `run(root string, mode genMode)`.
  - Simplified flag handling so `-verify` takes precedence over `-verify-inputs`.

<sup>Written for commit da65b74fc5472e9a741732bf763fa23fcdb572b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

