### PR TITLE
feat(voice): honest corpus intake — speaker preview, kept-vs-discarded stats, diarizer labels

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -5412,13 +5412,20 @@ paths:
             application/json:
               schema:
                 type: object
-                required: [source, summary]
+                required: [source, summary, ingest_stats]
                 properties:
                   source: { $ref: '#/components/schemas/VoiceCorpusSource' }
                   summary: { $ref: '#/components/schemas/VoiceCorpusSummary' }
                   ingest_stats: { $ref: '#/components/schemas/VoiceIngestStats' }
         '404': { $ref: '#/components/responses/NotFound' }
-        '422': { $ref: '#/components/responses/ValidationError' }
+        '422':
+          description: |
+            Unusable input. details.errors[].code is stable and voiceable:
+            unattributed_transcript, speaker_label_required, speaker_not_found,
+            unsupported_format, or the generic invalid.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Problem' }
 
   /voice-profiles/{id}/sources/preview:
     parameters:
@@ -5439,12 +5446,21 @@ paths:
             schema: { $ref: '#/components/schemas/VoiceCorpusPreviewRequest' }
       responses:
         '200':
-          description: Detected shape, per-speaker word counts, and transcript eligibility.
+          description: |
+            Detected shape and per-speaker word counts. Word totals count spoken
+            text only - timestamps, cue counters, speaker labels and JSON keys are
+            serialization, never words.
           content:
             application/json:
               schema: { $ref: '#/components/schemas/VoiceCorpusPreviewResult' }
         '404': { $ref: '#/components/responses/NotFound' }
-        '422': { $ref: '#/components/responses/ValidationError' }
+        '422':
+          description: |
+            Unusable input. details.errors[].code is stable and voiceable:
+            unsupported_format, or the generic invalid.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Problem' }
 
   /voice-profiles/{id}/sources/{sourceId}:
     parameters:
@@ -11132,7 +11148,13 @@ components:
       type: object
       required: [format, content]
       properties:
-        format: { type: string, enum: [text, transcript] }
+        format:
+          type: string
+          enum: [text, transcript]
+          description: |
+            Send transcript for anything conversational - the server detects the
+            concrete shape (vtt, srt, transcript JSON, or labelled plain text).
+            text skips speaker detection entirely.
         content: { type: string, minLength: 1, maxLength: 1000000, writeOnly: true }
 
     VoiceCorpusPreviewResult:

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -5416,6 +5416,33 @@ paths:
                 properties:
                   source: { $ref: '#/components/schemas/VoiceCorpusSource' }
                   summary: { $ref: '#/components/schemas/VoiceCorpusSummary' }
+                  ingest_stats: { $ref: '#/components/schemas/VoiceIngestStats' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '422': { $ref: '#/components/responses/ValidationError' }
+
+  /voice-profiles/{id}/sources/preview:
+    parameters:
+      - $ref: '#/components/parameters/Id'
+    post:
+      tags: [Voice]
+      operationId: previewVoiceCorpusSource
+      security: [ { cookieAuth: [] } ]
+      x-agent-access: human-only
+      summary: Dry-run one candidate source; detect its shape and speakers without storing anything.
+      description: |
+        Answers "who is speaking in this file?" before ingest, so the owner can be asked
+        which speaker they are. Pure inspection - no persistence, no model call.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/VoiceCorpusPreviewRequest' }
+      responses:
+        '200':
+          description: Detected shape, per-speaker word counts, and transcript eligibility.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/VoiceCorpusPreviewResult' }
         '404': { $ref: '#/components/responses/NotFound' }
         '422': { $ref: '#/components/responses/ValidationError' }
 
@@ -11072,7 +11099,13 @@ components:
         weight: { type: number, minimum: 0, maximum: 2, default: 1 }
         source_label: { type: string, minLength: 1, maxLength: 255 }
         source_ref: { type: string, minLength: 1, maxLength: 512 }
-        format: { type: string, enum: [text, transcript] }
+        format:
+          type: string
+          enum: [text, transcript]
+          description: |
+            Send `transcript` for anything conversational — .vtt, .srt, transcript JSON,
+            and speaker-labelled plain text ("Name: …" lines) alike; the server detects
+            the concrete shape. `text` is for single-author prose only.
         speaker_label: { type: [string, 'null'], description: Required for transcript format; only this speaker is retained. }
         occurred_at: { type: [string, 'null'], format: date-time }
         content: { type: string, minLength: 1, maxLength: 1000000, writeOnly: true }
@@ -11083,6 +11116,43 @@ components:
       properties:
         included: { type: boolean }
         weight: { type: number, minimum: 0, maximum: 2 }
+
+    VoiceIngestStats:
+      type: object
+      description: What the speaker filter did to one ingested source; kept words are the only words that count.
+      required: [input_words, kept_words, kept_turns, discarded_turns, speakers_seen]
+      properties:
+        input_words: { type: integer, minimum: 0 }
+        kept_words: { type: integer, minimum: 0 }
+        kept_turns: { type: integer, minimum: 0 }
+        discarded_turns: { type: integer, minimum: 0 }
+        speakers_seen: { type: array, items: { type: string } }
+
+    VoiceCorpusPreviewRequest:
+      type: object
+      required: [format, content]
+      properties:
+        format: { type: string, enum: [text, transcript] }
+        content: { type: string, minLength: 1, maxLength: 1000000, writeOnly: true }
+
+    VoiceCorpusPreviewResult:
+      type: object
+      description: Dry-run inspection of a candidate source; nothing is stored.
+      required: [detected_format, total_words, speakers, unattributed_words, ingestible_as_transcript]
+      properties:
+        detected_format: { type: string, enum: [txt, vtt, srt, json] }
+        total_words: { type: integer, minimum: 0 }
+        speakers:
+          type: array
+          items:
+            type: object
+            required: [label, turns, words]
+            properties:
+              label: { type: string }
+              turns: { type: integer, minimum: 0 }
+              words: { type: integer, minimum: 0 }
+        unattributed_words: { type: integer, minimum: 0 }
+        ingestible_as_transcript: { type: boolean }
 
     VoiceCorpusSummary:
       type: object

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -5424,7 +5424,7 @@ paths:
             unattributed_transcript, speaker_label_required, speaker_not_found,
             unsupported_format, or the generic invalid.
           content:
-            application/json:
+            application/problem+json:
               schema: { $ref: '#/components/schemas/Problem' }
 
   /voice-profiles/{id}/sources/preview:
@@ -5459,7 +5459,7 @@ paths:
             Unusable input. details.errors[].code is stable and voiceable:
             unsupported_format, or the generic invalid.
           content:
-            application/json:
+            application/problem+json:
               schema: { $ref: '#/components/schemas/Problem' }
 
   /voice-profiles/{id}/sources/{sourceId}:

--- a/backend/internal/compose/agentpolicy_gen.go
+++ b/backend/internal/compose/agentpolicy_gen.go
@@ -153,6 +153,7 @@ var agentPolicies = map[string]agentPolicy{
 	"POST /v1/voice-profiles/{id}/corpus/clear":                          {Op: "clearVoiceCorpus", Access: "human-only", Tool: "", RecordType: "", Tier: ""},
 	"POST /v1/voice-profiles/{id}/draft-rejections":                      {Op: "rejectVoiceDraft", Access: "human-only", Tool: "", RecordType: "", Tier: ""},
 	"POST /v1/voice-profiles/{id}/sources":                               {Op: "ingestVoiceCorpusSource", Access: "human-only", Tool: "", RecordType: "", Tier: ""},
+	"POST /v1/voice-profiles/{id}/sources/preview":                       {Op: "previewVoiceCorpusSource", Access: "human-only", Tool: "", RecordType: "", Tier: ""},
 	"POST /v1/voice-profiles/{id}/versions/{profileVersion}/apply":       {Op: "applyVoiceProfileVersion", Access: "human-only", Tool: "", RecordType: "", Tier: ""},
 	"POST /v1/voice-profiles/{id}/versions/{profileVersion}/reject":      {Op: "rejectVoiceProfileVersion", Access: "human-only", Tool: "", RecordType: "", Tier: ""},
 	"POST /v1/voice-profiles/{id}/versions/{profileVersion}/rollback":    {Op: "rollbackVoiceProfileVersion", Access: "human-only", Tool: "", RecordType: "", Tier: ""},

--- a/backend/internal/compose/integration/voicepreview_http_integration_test.go
+++ b/backend/internal/compose/integration/voicepreview_http_integration_test.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The corpus dry-run over HTTP: the preview names each speaker with their
+// SPOKEN word counts before anything is stored, the ingest 201 tells the
+// kept-versus-discarded story, and every refusal carries its stable
+// machine code — the surface a conversational client narrates from.
+
+import (
+	"net/http"
+	"testing"
+)
+
+type voicePreviewWire struct {
+	DetectedFormat string `json:"detected_format"`
+	TotalWords     int    `json:"total_words"`
+	Speakers       []struct {
+		Label string `json:"label"`
+		Turns int    `json:"turns"`
+		Words int    `json:"words"`
+	} `json:"speakers"`
+	UnattributedWords      int  `json:"unattributed_words"`
+	IngestibleAsTranscript bool `json:"ingestible_as_transcript"`
+}
+
+type problemWire struct {
+	Details struct {
+		Errors []struct {
+			Field   string `json:"field"`
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"errors"`
+	} `json:"details"`
+}
+
+const previewMeetingTranscript = "00:00:00 Lars Jankowfsky\n" +
+	"My own words carry the voice signal here.\n" +
+	"00:00:07 Anna Schmidt\n" +
+	"Her words must never enter the corpus.\n" +
+	"00:00:12 Lars Jankowfsky\n" +
+	"And a second turn of mine."
+
+func TestVoiceCorpusPreviewAndIngestStatsHTTP(t *testing.T) {
+	e := setup(t)
+	e.bootstrapWorkspace(t)
+	created := createVoiceProfile(t, e)
+	base := "/v1/voice-profiles/" + created.ID
+
+	var preview voicePreviewWire
+	if status := e.call(t, "POST", base+"/sources/preview",
+		anyMap{"format": "transcript", "content": previewMeetingTranscript},
+		nil, &preview); status != http.StatusOK {
+		t.Fatalf("preview → %d", status)
+	}
+	if preview.DetectedFormat != "srt" || !preview.IngestibleAsTranscript {
+		t.Fatalf("preview = %+v, want a speaker-attributed srt shape", preview)
+	}
+	if len(preview.Speakers) != 2 {
+		t.Fatalf("speakers = %+v, want both meeting participants", preview.Speakers)
+	}
+	lars := preview.Speakers[0]
+	if lars.Label != "Lars Jankowfsky" || lars.Turns != 2 || lars.Words != 14 {
+		t.Fatalf("lars = %+v, want 14 spoken words over 2 turns", lars)
+	}
+	if preview.TotalWords != 21 || preview.UnattributedWords != 0 {
+		t.Fatalf("totals = %d/%d — spoken words only, headers are never words",
+			preview.TotalWords, preview.UnattributedWords)
+	}
+
+	var refused problemWire
+	if status := e.call(t, "POST", base+"/sources/preview",
+		anyMap{"format": "docx", "content": "binary"}, nil, &refused); status != http.StatusUnprocessableEntity {
+		t.Fatalf("unknown format preview → %d, want 422", status)
+	}
+	if len(refused.Details.Errors) != 1 || refused.Details.Errors[0].Code != "unsupported_format" {
+		t.Fatalf("refusal = %+v, want the stable unsupported_format code", refused)
+	}
+
+	var ingested struct {
+		voiceIngestResponse
+		IngestStats struct {
+			InputWords     int      `json:"input_words"`
+			KeptWords      int      `json:"kept_words"`
+			KeptTurns      int      `json:"kept_turns"`
+			DiscardedTurns int      `json:"discarded_turns"`
+			SpeakersSeen   []string `json:"speakers_seen"`
+		} `json:"ingest_stats"`
+	}
+	if status := e.call(t, "POST", base+"/sources", anyMap{
+		"kind": "transcript", "register": "spoken", "source_label": "Meeting",
+		"source_ref": "meeting-1", "format": "transcript",
+		"speaker_label": "Lars Jankowfsky", "content": previewMeetingTranscript,
+	}, nil, &ingested); status != http.StatusCreated {
+		t.Fatalf("transcript ingest → %d", status)
+	}
+	if ingested.Source.WordCount != 14 {
+		t.Fatalf("stored word_count = %d, want only the owner's 14 words", ingested.Source.WordCount)
+	}
+	stats := ingested.IngestStats
+	if stats.InputWords != 21 || stats.KeptWords != 14 || stats.KeptTurns != 2 || stats.DiscardedTurns != 1 {
+		t.Fatalf("ingest_stats = %+v — the kept-versus-discarded story must match the filter", stats)
+	}
+	if len(stats.SpeakersSeen) != 2 {
+		t.Fatalf("speakers_seen = %v", stats.SpeakersSeen)
+	}
+
+	var unlabeled problemWire
+	if status := e.call(t, "POST", base+"/sources", anyMap{
+		"kind": "transcript", "register": "spoken", "source_label": "Meeting",
+		"source_ref": "meeting-2", "format": "transcript",
+		"content": previewMeetingTranscript,
+	}, nil, &unlabeled); status != http.StatusUnprocessableEntity {
+		t.Fatalf("labelled transcript without speaker_label → %d, want 422", status)
+	}
+	if len(unlabeled.Details.Errors) != 1 || unlabeled.Details.Errors[0].Code != "speaker_label_required" {
+		t.Fatalf("refusal = %+v, want speaker_label_required", unlabeled)
+	}
+}

--- a/backend/internal/compose/integration/voicepreview_http_integration_test.go
+++ b/backend/internal/compose/integration/voicepreview_http_integration_test.go
@@ -11,6 +11,8 @@ package integration
 // machine code — the surface a conversational client narrates from.
 
 import (
+	"bytes"
+	"encoding/json"
 	"net/http"
 	"testing"
 )
@@ -62,19 +64,43 @@ func TestVoiceCorpusPreviewAndIngestStatsHTTP(t *testing.T) {
 	if len(preview.Speakers) != 2 {
 		t.Fatalf("speakers = %+v, want both meeting participants", preview.Speakers)
 	}
-	lars := preview.Speakers[0]
+	lars, anna := preview.Speakers[0], preview.Speakers[1]
 	if lars.Label != "Lars Jankowfsky" || lars.Turns != 2 || lars.Words != 14 {
 		t.Fatalf("lars = %+v, want 14 spoken words over 2 turns", lars)
+	}
+	if anna.Label != "Anna Schmidt" || anna.Turns != 1 || anna.Words != 7 {
+		t.Fatalf("anna = %+v, want her 7 words in 1 turn", anna)
 	}
 	if preview.TotalWords != 21 || preview.UnattributedWords != 0 {
 		t.Fatalf("totals = %d/%d — spoken words only, headers are never words",
 			preview.TotalWords, preview.UnattributedWords)
 	}
 
+	// The raw request keeps the response headers: the refusal contract is
+	// the 422 body AND its problem+json media type.
+	rawBody, err := json.Marshal(anyMap{"format": "docx", "content": "binary"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req, err := http.NewRequest("POST", e.ts.URL+base+"/sources/preview", bytes.NewReader(rawBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := e.client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeBody(t, resp)
+	if resp.StatusCode != http.StatusUnprocessableEntity {
+		t.Fatalf("unknown format preview → %d, want 422", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "application/problem+json" {
+		t.Fatalf("refusal media type = %q, want application/problem+json", ct)
+	}
 	var refused problemWire
-	if status := e.call(t, "POST", base+"/sources/preview",
-		anyMap{"format": "docx", "content": "binary"}, nil, &refused); status != http.StatusUnprocessableEntity {
-		t.Fatalf("unknown format preview → %d, want 422", status)
+	if err := json.NewDecoder(resp.Body).Decode(&refused); err != nil {
+		t.Fatal(err)
 	}
 	if len(refused.Details.Errors) != 1 || refused.Details.Errors[0].Code != "unsupported_format" {
 		t.Fatalf("refusal = %+v, want the stable unsupported_format code", refused)
@@ -104,8 +130,8 @@ func TestVoiceCorpusPreviewAndIngestStatsHTTP(t *testing.T) {
 	if stats.InputWords != 21 || stats.KeptWords != 14 || stats.KeptTurns != 2 || stats.DiscardedTurns != 1 {
 		t.Fatalf("ingest_stats = %+v — the kept-versus-discarded story must match the filter", stats)
 	}
-	if len(stats.SpeakersSeen) != 2 {
-		t.Fatalf("speakers_seen = %v", stats.SpeakersSeen)
+	if len(stats.SpeakersSeen) != 2 || stats.SpeakersSeen[0] != "Lars Jankowfsky" || stats.SpeakersSeen[1] != "Anna Schmidt" {
+		t.Fatalf("speakers_seen = %v, want both participants in first-seen order", stats.SpeakersSeen)
 	}
 
 	var unlabeled problemWire

--- a/backend/internal/compose/integration/voicestore_integration_test.go
+++ b/backend/internal/compose/integration/voicestore_integration_test.go
@@ -101,7 +101,7 @@ func TestVoiceProfileAndCorpusAreOwnerPrivate(t *testing.T) {
 	if _, _, err := voice.ListSources(outsider, created.ID); !errors.Is(err, apperrors.ErrNotFound) {
 		t.Fatalf("outsider manifest → %v, want ErrNotFound", err)
 	}
-	if _, _, err := voice.IngestSource(outsider, created.ID, ai.IngestSourceInput{
+	if _, _, _, err := voice.IngestSource(outsider, created.ID, ai.IngestSourceInput{
 		Kind: "linkedin", SourceLabel: "poison", Content: "not my voice",
 	}); !errors.Is(err, apperrors.ErrNotFound) {
 		t.Fatalf("outsider ingest → %v, want ErrNotFound", err)
@@ -117,7 +117,7 @@ func TestVoiceProfileAndCorpusAreOwnerPrivate(t *testing.T) {
 		RowScope: principal.RowScopeAll,
 	})
 	for who, ctx := range map[string]context.Context{"teammate": teammate, "admin": admin} {
-		if _, _, err := voice.IngestSource(ctx, created.ID, ai.IngestSourceInput{
+		if _, _, _, err := voice.IngestSource(ctx, created.ID, ai.IngestSourceInput{
 			Kind: "linkedin", SourceLabel: "poison", Content: "words in another's mouth",
 		}); !errors.Is(err, apperrors.ErrNotFound) {
 			t.Fatalf("%s ingest into a personal profile → %v, want ErrNotFound", who, err)
@@ -131,7 +131,7 @@ func TestVoiceProfileAndCorpusAreOwnerPrivate(t *testing.T) {
 		}
 	}
 	// The owner's own path is untouched.
-	if _, _, err := voice.IngestSource(owner, created.ID, ai.IngestSourceInput{
+	if _, _, _, err := voice.IngestSource(owner, created.ID, ai.IngestSourceInput{
 		Kind: "linkedin", SourceLabel: "mine", Content: "my own words, my own voice",
 	}); err != nil {
 		t.Fatalf("owner ingest: %v", err)
@@ -202,13 +202,13 @@ func TestVoiceDerivedRebuildVersionsArtifactAndPreservesIdentity(t *testing.T) {
 
 	// The fixture corpus ingests deterministically: registers tagged per
 	// kind, the transcript speaker-filtered to the owner.
-	post, _, err := voice.IngestSource(owner, created.ID, ai.IngestSourceInput{
+	post, _, _, err := voice.IngestSource(owner, created.ID, ai.IngestSourceInput{
 		Kind: "linkedin", SourceLabel: "post", SourceRef: "fixture-post", Content: voiceFixturePost,
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	call, summary, err := voice.IngestSource(owner, created.ID, ai.IngestSourceInput{
+	call, summary, _, err := voice.IngestSource(owner, created.ID, ai.IngestSourceInput{
 		Kind: "transcript", SourceLabel: "call", SourceRef: "fixture-call",
 		Format: "vtt", SpeakerLabel: "Ada Admin", Content: voiceFixtureVTT,
 	})
@@ -256,7 +256,7 @@ func TestVoiceDerivedRebuildVersionsArtifactAndPreservesIdentity(t *testing.T) {
 
 	// New eligible corpus never destroys the known-good artifact. It marks
 	// the control row stale until a later build succeeds.
-	if _, _, err := voice.IngestSource(owner, created.ID, ai.IngestSourceInput{
+	if _, _, _, err := voice.IngestSource(owner, created.ID, ai.IngestSourceInput{
 		Kind: "email", SourceLabel: "new note", SourceRef: "fixture-note",
 		Content: "A new note changes the evidence without changing the active artifact.",
 	}); err != nil {
@@ -356,7 +356,7 @@ func TestVoiceCandidateTransitionsUseCandidateConcurrencyAndForwardRollback(t *t
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := voice.IngestSource(owner, profile.ID, ai.IngestSourceInput{
+	if _, _, _, err := voice.IngestSource(owner, profile.ID, ai.IngestSourceInput{
 		Kind: "document", SourceLabel: "seed", SourceRef: "seed", Content: strings.Repeat("word ", 800),
 	}); err != nil {
 		t.Fatal(err)
@@ -416,7 +416,7 @@ func TestVoiceConcurrentBuildRequestsConvergeOnOneDurableRow(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := voice.IngestSource(owner, profile.ID, ai.IngestSourceInput{
+	if _, _, _, err := voice.IngestSource(owner, profile.ID, ai.IngestSourceInput{
 		Kind: "document", SourceLabel: "seed", SourceRef: "seed", Content: strings.Repeat("word ", 800),
 	}); err != nil {
 		t.Fatal(err)

--- a/backend/internal/compose/stubs_gen.go
+++ b/backend/internal/compose/stubs_gen.go
@@ -976,6 +976,10 @@ func (stubs) IngestVoiceCorpusSource(w nethttp.ResponseWriter, r *nethttp.Reques
 	httperr.NotImplemented(w, r, "IngestVoiceCorpusSource")
 }
 
+func (stubs) PreviewVoiceCorpusSource(w nethttp.ResponseWriter, r *nethttp.Request, id crmcontracts.Id) {
+	httperr.NotImplemented(w, r, "PreviewVoiceCorpusSource")
+}
+
 func (stubs) DeleteVoiceCorpusSource(w nethttp.ResponseWriter, r *nethttp.Request, id crmcontracts.Id, sourceId openapi_types.UUID, params crmcontracts.DeleteVoiceCorpusSourceParams) {
 	httperr.NotImplemented(w, r, "DeleteVoiceCorpusSource")
 }

--- a/backend/internal/compose/voicebuild_integration_test.go
+++ b/backend/internal/compose/voicebuild_integration_test.go
@@ -165,7 +165,7 @@ func seedVoiceBuild(t *testing.T, quote string, sourceCount int) (*voiceBuildEnv
 		if i == 0 {
 			content = quote + " " + content
 		}
-		if _, _, err := store.IngestSource(owner, profile.ID, ai.IngestSourceInput{
+		if _, _, _, err := store.IngestSource(owner, profile.ID, ai.IngestSourceInput{
 			Kind: "email", Register: register, SourceLabel: fmt.Sprintf("source-%d", i+1), Content: content,
 		}); err != nil {
 			t.Fatal(err)
@@ -245,7 +245,7 @@ func TestVoiceBuildRunsToAnActiveVersion(t *testing.T) {
 
 func TestVoiceBuildFailsWhenTheCorpusChangedSinceQueueing(t *testing.T) {
 	env, build := seedVoiceBuild(t, "A quote that will survive.", 6)
-	if _, _, err := env.store.IngestSource(env.owner, env.profile.ID, ai.IngestSourceInput{
+	if _, _, _, err := env.store.IngestSource(env.owner, env.profile.ID, ai.IngestSourceInput{
 		Kind: "other", SourceLabel: "late addition", Content: "text arriving after the snapshot was taken",
 	}); err != nil {
 		t.Fatal(err)

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -2879,16 +2879,16 @@ func (e FieldHistoryEntryEntityType) Valid() bool {
 
 // Defines values for FilteredExportRequestFormat.
 const (
-	Csv  FilteredExportRequestFormat = "csv"
-	Json FilteredExportRequestFormat = "json"
+	FilteredExportRequestFormatCsv  FilteredExportRequestFormat = "csv"
+	FilteredExportRequestFormatJson FilteredExportRequestFormat = "json"
 )
 
 // Valid indicates whether the value is a known member of the FilteredExportRequestFormat enum.
 func (e FilteredExportRequestFormat) Valid() bool {
 	switch e {
-	case Csv:
+	case FilteredExportRequestFormatCsv:
 		return true
-	case Json:
+	case FilteredExportRequestFormatJson:
 		return true
 	default:
 		return false
@@ -5292,6 +5292,48 @@ func (e VoiceBuildStatusCode) Valid() bool {
 	}
 }
 
+// Defines values for VoiceCorpusPreviewRequestFormat.
+const (
+	VoiceCorpusPreviewRequestFormatText       VoiceCorpusPreviewRequestFormat = "text"
+	VoiceCorpusPreviewRequestFormatTranscript VoiceCorpusPreviewRequestFormat = "transcript"
+)
+
+// Valid indicates whether the value is a known member of the VoiceCorpusPreviewRequestFormat enum.
+func (e VoiceCorpusPreviewRequestFormat) Valid() bool {
+	switch e {
+	case VoiceCorpusPreviewRequestFormatText:
+		return true
+	case VoiceCorpusPreviewRequestFormatTranscript:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for VoiceCorpusPreviewResultDetectedFormat.
+const (
+	VoiceCorpusPreviewResultDetectedFormatJson VoiceCorpusPreviewResultDetectedFormat = "json"
+	VoiceCorpusPreviewResultDetectedFormatSrt  VoiceCorpusPreviewResultDetectedFormat = "srt"
+	VoiceCorpusPreviewResultDetectedFormatTxt  VoiceCorpusPreviewResultDetectedFormat = "txt"
+	VoiceCorpusPreviewResultDetectedFormatVtt  VoiceCorpusPreviewResultDetectedFormat = "vtt"
+)
+
+// Valid indicates whether the value is a known member of the VoiceCorpusPreviewResultDetectedFormat enum.
+func (e VoiceCorpusPreviewResultDetectedFormat) Valid() bool {
+	switch e {
+	case VoiceCorpusPreviewResultDetectedFormatJson:
+		return true
+	case VoiceCorpusPreviewResultDetectedFormatSrt:
+		return true
+	case VoiceCorpusPreviewResultDetectedFormatTxt:
+		return true
+	case VoiceCorpusPreviewResultDetectedFormatVtt:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for VoiceCorpusSourceKind.
 const (
 	VoiceCorpusSourceKindDocument   VoiceCorpusSourceKind = "document"
@@ -5660,31 +5702,31 @@ func (e CaptureProvider) Valid() bool {
 
 // Defines values for ListActivitiesParamsKind.
 const (
-	ListActivitiesParamsKindCall     ListActivitiesParamsKind = "call"
-	ListActivitiesParamsKindEmail    ListActivitiesParamsKind = "email"
-	ListActivitiesParamsKindMeeting  ListActivitiesParamsKind = "meeting"
-	ListActivitiesParamsKindNote     ListActivitiesParamsKind = "note"
-	ListActivitiesParamsKindTask     ListActivitiesParamsKind = "task"
-	ListActivitiesParamsKindTelegram ListActivitiesParamsKind = "telegram"
-	ListActivitiesParamsKindWhatsapp ListActivitiesParamsKind = "whatsapp"
+	Call     ListActivitiesParamsKind = "call"
+	Email    ListActivitiesParamsKind = "email"
+	Meeting  ListActivitiesParamsKind = "meeting"
+	Note     ListActivitiesParamsKind = "note"
+	Task     ListActivitiesParamsKind = "task"
+	Telegram ListActivitiesParamsKind = "telegram"
+	Whatsapp ListActivitiesParamsKind = "whatsapp"
 )
 
 // Valid indicates whether the value is a known member of the ListActivitiesParamsKind enum.
 func (e ListActivitiesParamsKind) Valid() bool {
 	switch e {
-	case ListActivitiesParamsKindCall:
+	case Call:
 		return true
-	case ListActivitiesParamsKindEmail:
+	case Email:
 		return true
-	case ListActivitiesParamsKindMeeting:
+	case Meeting:
 		return true
-	case ListActivitiesParamsKindNote:
+	case Note:
 		return true
-	case ListActivitiesParamsKindTask:
+	case Task:
 		return true
-	case ListActivitiesParamsKindTelegram:
+	case Telegram:
 		return true
-	case ListActivitiesParamsKindWhatsapp:
+	case Whatsapp:
 		return true
 	default:
 		return false
@@ -8724,7 +8766,11 @@ type ImapConnectResult struct {
 
 // IngestVoiceCorpusSourceRequest defines model for IngestVoiceCorpusSourceRequest.
 type IngestVoiceCorpusSourceRequest struct {
-	Content     *string                                `json:"content,omitempty"`
+	Content *string `json:"content,omitempty"`
+
+	// Format Send `transcript` for anything conversational — .vtt, .srt, transcript JSON,
+	// and speaker-labelled plain text ("Name: …" lines) alike; the server detects
+	// the concrete shape. `text` is for single-author prose only.
 	Format      IngestVoiceCorpusSourceRequestFormat   `json:"format"`
 	Kind        IngestVoiceCorpusSourceRequestKind     `json:"kind"`
 	OccurredAt  *time.Time                             `json:"occurred_at,omitempty"`
@@ -8737,7 +8783,9 @@ type IngestVoiceCorpusSourceRequest struct {
 	Weight       *float32 `json:"weight,omitempty"`
 }
 
-// IngestVoiceCorpusSourceRequestFormat defines model for IngestVoiceCorpusSourceRequest.Format.
+// IngestVoiceCorpusSourceRequestFormat Send `transcript` for anything conversational — .vtt, .srt, transcript JSON,
+// and speaker-labelled plain text ("Name: …" lines) alike; the server detects
+// the concrete shape. `text` is for single-author prose only.
 type IngestVoiceCorpusSourceRequestFormat string
 
 // IngestVoiceCorpusSourceRequestKind defines model for IngestVoiceCorpusSourceRequest.Kind.
@@ -10968,6 +11016,31 @@ type VoiceBuildStatus string
 // VoiceBuildStatusCode defines model for VoiceBuild.StatusCode.
 type VoiceBuildStatusCode string
 
+// VoiceCorpusPreviewRequest defines model for VoiceCorpusPreviewRequest.
+type VoiceCorpusPreviewRequest struct {
+	Content *string                         `json:"content,omitempty"`
+	Format  VoiceCorpusPreviewRequestFormat `json:"format"`
+}
+
+// VoiceCorpusPreviewRequestFormat defines model for VoiceCorpusPreviewRequest.Format.
+type VoiceCorpusPreviewRequestFormat string
+
+// VoiceCorpusPreviewResult Dry-run inspection of a candidate source; nothing is stored.
+type VoiceCorpusPreviewResult struct {
+	DetectedFormat         VoiceCorpusPreviewResultDetectedFormat `json:"detected_format"`
+	IngestibleAsTranscript bool                                   `json:"ingestible_as_transcript"`
+	Speakers               []struct {
+		Label string `json:"label"`
+		Turns int    `json:"turns"`
+		Words int    `json:"words"`
+	} `json:"speakers"`
+	TotalWords        int `json:"total_words"`
+	UnattributedWords int `json:"unattributed_words"`
+}
+
+// VoiceCorpusPreviewResultDetectedFormat defines model for VoiceCorpusPreviewResult.DetectedFormat.
+type VoiceCorpusPreviewResultDetectedFormat string
+
 // VoiceCorpusSource Privacy-safe source manifest. Retained source text is deliberately not returned.
 type VoiceCorpusSource struct {
 	ArchivedAt       *time.Time                `json:"archived_at"`
@@ -11018,6 +11091,15 @@ type VoiceCorpusSummaryMaturity string
 
 // VoiceCorpusSummaryQualityBand defines model for VoiceCorpusSummary.QualityBand.
 type VoiceCorpusSummaryQualityBand string
+
+// VoiceIngestStats What the speaker filter did to one ingested source; kept words are the only words that count.
+type VoiceIngestStats struct {
+	DiscardedTurns int      `json:"discarded_turns"`
+	InputWords     int      `json:"input_words"`
+	KeptTurns      int      `json:"kept_turns"`
+	KeptWords      int      `json:"kept_words"`
+	SpeakersSeen   []string `json:"speakers_seen"`
+}
 
 // VoiceLearningSummary defines model for VoiceLearningSummary.
 type VoiceLearningSummary struct {
@@ -13649,6 +13731,9 @@ type RejectVoiceDraftJSONRequestBody = RejectVoiceDraftRequest
 
 // IngestVoiceCorpusSourceJSONRequestBody defines body for IngestVoiceCorpusSource for application/json ContentType.
 type IngestVoiceCorpusSourceJSONRequestBody = IngestVoiceCorpusSourceRequest
+
+// PreviewVoiceCorpusSourceJSONRequestBody defines body for PreviewVoiceCorpusSource for application/json ContentType.
+type PreviewVoiceCorpusSourceJSONRequestBody = VoiceCorpusPreviewRequest
 
 // UpdateVoiceCorpusSourceJSONRequestBody defines body for UpdateVoiceCorpusSource for application/json ContentType.
 type UpdateVoiceCorpusSourceJSONRequestBody = UpdateVoiceCorpusSourceRequest
@@ -19229,6 +19314,9 @@ type ServerInterface interface {
 	// Ingest or replace one manual own-authored text source.
 	// (POST /voice-profiles/{id}/sources)
 	IngestVoiceCorpusSource(w http.ResponseWriter, r *http.Request, id Id, params IngestVoiceCorpusSourceParams)
+	// Dry-run one candidate source; detect its shape and speakers without storing anything.
+	// (POST /voice-profiles/{id}/sources/preview)
+	PreviewVoiceCorpusSource(w http.ResponseWriter, r *http.Request, id Id)
 	// Permanently remove one retained source and mark any active artifact stale.
 	// (DELETE /voice-profiles/{id}/sources/{sourceId})
 	DeleteVoiceCorpusSource(w http.ResponseWriter, r *http.Request, id Id, sourceId openapi_types.UUID, params DeleteVoiceCorpusSourceParams)
@@ -20708,6 +20796,12 @@ func (_ Unimplemented) ListVoiceCorpusSources(w http.ResponseWriter, r *http.Req
 // Ingest or replace one manual own-authored text source.
 // (POST /voice-profiles/{id}/sources)
 func (_ Unimplemented) IngestVoiceCorpusSource(w http.ResponseWriter, r *http.Request, id Id, params IngestVoiceCorpusSourceParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Dry-run one candidate source; detect its shape and speakers without storing anything.
+// (POST /voice-profiles/{id}/sources/preview)
+func (_ Unimplemented) PreviewVoiceCorpusSource(w http.ResponseWriter, r *http.Request, id Id) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -32082,6 +32176,38 @@ func (siw *ServerInterfaceWrapper) IngestVoiceCorpusSource(w http.ResponseWriter
 	handler.ServeHTTP(w, r)
 }
 
+// PreviewVoiceCorpusSource operation middleware
+func (siw *ServerInterfaceWrapper) PreviewVoiceCorpusSource(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id Id
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", chi.URLParam(r, "id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.PreviewVoiceCorpusSource(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // DeleteVoiceCorpusSource operation middleware
 func (siw *ServerInterfaceWrapper) DeleteVoiceCorpusSource(w http.ResponseWriter, r *http.Request) {
 
@@ -33685,6 +33811,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/voice-profiles/{id}/sources", wrapper.IngestVoiceCorpusSource)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/voice-profiles/{id}/sources/preview", wrapper.PreviewVoiceCorpusSource)
 	})
 	r.Group(func(r chi.Router) {
 		r.Delete(options.BaseURL+"/voice-profiles/{id}/sources/{sourceId}", wrapper.DeleteVoiceCorpusSource)

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -11018,11 +11018,17 @@ type VoiceBuildStatusCode string
 
 // VoiceCorpusPreviewRequest defines model for VoiceCorpusPreviewRequest.
 type VoiceCorpusPreviewRequest struct {
-	Content *string                         `json:"content,omitempty"`
-	Format  VoiceCorpusPreviewRequestFormat `json:"format"`
+	Content *string `json:"content,omitempty"`
+
+	// Format Send transcript for anything conversational - the server detects the
+	// concrete shape (vtt, srt, transcript JSON, or labelled plain text).
+	// text skips speaker detection entirely.
+	Format VoiceCorpusPreviewRequestFormat `json:"format"`
 }
 
-// VoiceCorpusPreviewRequestFormat defines model for VoiceCorpusPreviewRequest.Format.
+// VoiceCorpusPreviewRequestFormat Send transcript for anything conversational - the server detects the
+// concrete shape (vtt, srt, transcript JSON, or labelled plain text).
+// text skips speaker detection entirely.
 type VoiceCorpusPreviewRequestFormat string
 
 // VoiceCorpusPreviewResult Dry-run inspection of a candidate source; nothing is stored.

--- a/backend/internal/modules/ai/handlers_voice.go
+++ b/backend/internal/modules/ai/handlers_voice.go
@@ -182,12 +182,53 @@ func (h Handlers) IngestVoiceCorpusSource(w http.ResponseWriter, r *http.Request
 		in.SpeakerLabel = *req.SpeakerLabel
 	}
 	in.OccurredAt = req.OccurredAt
-	source, summary, err := h.voice.IngestSource(r.Context(), ids.UUID(id), in)
+	source, summary, stats, err := h.voice.IngestSource(r.Context(), ids.UUID(id), in)
 	if err != nil {
 		writeVoiceErr(w, r, err)
 		return
 	}
-	httperr.WriteJSON(w, http.StatusCreated, wireSourceWithSummary(source, summary))
+	wire := wireSourceWithSummary(source, summary)
+	wireStats := wireIngestStats(stats)
+	wire.IngestStats = &wireStats
+	httperr.WriteJSON(w, http.StatusCreated, wire)
+}
+
+// PreviewVoiceCorpusSource implements (POST /voice-profiles/{id}/sources/preview):
+// the dry-run "who speaks in this file?" answer the speaker question rests
+// on — pure inspection, nothing stored.
+func (h Handlers) PreviewVoiceCorpusSource(w http.ResponseWriter, r *http.Request, id crmcontracts.Id) {
+	var req crmcontracts.VoiceCorpusPreviewRequest
+	if !httperr.Decode(w, r, &req) {
+		return
+	}
+	content := ""
+	if req.Content != nil {
+		content = *req.Content
+	}
+	preview, err := h.voice.PreviewSource(r.Context(), ids.UUID(id), string(req.Format), content)
+	if err != nil {
+		writeVoiceErr(w, r, err)
+		return
+	}
+	speakers := make([]struct {
+		Label string `json:"label"`
+		Turns int    `json:"turns"`
+		Words int    `json:"words"`
+	}, 0, len(preview.Speakers))
+	for _, speaker := range preview.Speakers {
+		speakers = append(speakers, struct {
+			Label string `json:"label"`
+			Turns int    `json:"turns"`
+			Words int    `json:"words"`
+		}{Label: speaker.Label, Turns: speaker.Turns, Words: speaker.Words})
+	}
+	httperr.WriteJSON(w, http.StatusOK, crmcontracts.VoiceCorpusPreviewResult{
+		DetectedFormat:         crmcontracts.VoiceCorpusPreviewResultDetectedFormat(preview.DetectedFormat),
+		TotalWords:             preview.TotalWords,
+		Speakers:               speakers,
+		UnattributedWords:      preview.UnattributedWords,
+		IngestibleAsTranscript: preview.IngestibleAsTranscript,
+	})
 }
 
 // UpdateVoiceCorpusSource implements (PATCH /voice-profiles/{id}/sources/{sourceId}).
@@ -230,7 +271,11 @@ func (h Handlers) DeleteVoiceCorpusSource(w http.ResponseWriter, r *http.Request
 func writeVoiceErr(w http.ResponseWriter, r *http.Request, err error) {
 	var ingest *CorpusIngestError
 	if errors.As(err, &ingest) {
-		httperr.Write(w, r, httperr.Validation(ingest.Field, "invalid", ingest.Reason))
+		code := ingest.Code
+		if code == "" {
+			code = "invalid"
+		}
+		httperr.Write(w, r, httperr.Validation(ingest.Field, code, ingest.Reason))
 		return
 	}
 	httperr.Write(w, r, err)
@@ -332,10 +377,25 @@ func updatedAt(created time.Time, updated *time.Time) time.Time {
 // manifest row plus the refreshed meter, so the funnel updates its bar
 // without a second round trip.
 type sourceWithSummary struct {
-	Source  crmcontracts.VoiceCorpusSource  `json:"source"`
-	Summary crmcontracts.VoiceCorpusSummary `json:"summary"`
+	Source      crmcontracts.VoiceCorpusSource  `json:"source"`
+	Summary     crmcontracts.VoiceCorpusSummary `json:"summary"`
+	IngestStats *crmcontracts.VoiceIngestStats  `json:"ingest_stats,omitempty"`
 }
 
 func wireSourceWithSummary(source VoiceCorpusSource, summary CorpusSummary) sourceWithSummary {
 	return sourceWithSummary{Source: wireVoiceSource(source), Summary: wireCorpusSummary(summary)}
+}
+
+func wireIngestStats(stats CorpusIngestStats) crmcontracts.VoiceIngestStats {
+	speakers := stats.SpeakersSeen
+	if speakers == nil {
+		speakers = []string{}
+	}
+	return crmcontracts.VoiceIngestStats{
+		InputWords:     stats.InputWords,
+		KeptWords:      stats.KeptWords,
+		KeptTurns:      stats.KeptTurns,
+		DiscardedTurns: stats.DiscardedTurns,
+		SpeakersSeen:   speakers,
+	}
 }

--- a/backend/internal/modules/ai/voice_source_store.go
+++ b/backend/internal/modules/ai/voice_source_store.go
@@ -21,13 +21,13 @@ import (
 // register-tag → count) and upserts the manifest row by source_ref:
 // re-ingesting a source replaces it — the meter never double-counts —
 // and re-adding an excluded source is an explicit opt back in.
-func (s *VoiceStore) IngestSource(ctx context.Context, profileID ids.UUID, in IngestSourceInput) (VoiceCorpusSource, CorpusSummary, error) {
+func (s *VoiceStore) IngestSource(ctx context.Context, profileID ids.UUID, in IngestSourceInput) (VoiceCorpusSource, CorpusSummary, CorpusIngestStats, error) {
 	if err := auth.Require(ctx, "voice_profile", principal.ActionUpdate); err != nil {
-		return VoiceCorpusSource{}, CorpusSummary{}, err
+		return VoiceCorpusSource{}, CorpusSummary{}, CorpusIngestStats{}, err
 	}
 	prepared, err := prepareSource(in)
 	if err != nil {
-		return VoiceCorpusSource{}, CorpusSummary{}, err
+		return VoiceCorpusSource{}, CorpusSummary{}, CorpusIngestStats{}, err
 	}
 
 	var (
@@ -40,9 +40,24 @@ func (s *VoiceStore) IngestSource(ctx context.Context, profileID ids.UUID, in In
 		return err
 	})
 	if err != nil {
-		return VoiceCorpusSource{}, CorpusSummary{}, err
+		return VoiceCorpusSource{}, CorpusSummary{}, CorpusIngestStats{}, err
 	}
-	return source, summary, nil
+	return source, summary, prepared.Stats, nil
+}
+
+// PreviewSource dry-runs one candidate source under the owner gate:
+// detected shape and per-speaker word counts, nothing stored.
+func (s *VoiceStore) PreviewSource(ctx context.Context, profileID ids.UUID, format, content string) (CorpusPreview, error) {
+	if err := auth.Require(ctx, "voice_profile", principal.ActionUpdate); err != nil {
+		return CorpusPreview{}, err
+	}
+	if err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+		_, err := s.visibleProfile(ctx, tx, profileID)
+		return err
+	}); err != nil {
+		return CorpusPreview{}, err
+	}
+	return PreviewCorpusText(format, content)
 }
 
 type priorVoiceSource struct {

--- a/backend/internal/modules/ai/voicecorpus.go
+++ b/backend/internal/modules/ai/voicecorpus.go
@@ -17,6 +17,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"unicode"
 )
 
 // CorpusMeterVersion versions the meter thresholds below: the quality
@@ -68,11 +69,22 @@ func QualityBand(totalWords int) string {
 }
 
 // CorpusIngestError reports an unusable ingest input; the transport maps
-// it to a 422 with the field and reason intact.
+// it to a 422 with the field and reason intact. Code, when set, is the
+// stable machine-readable refusal class a conversational client can voice
+// without parsing prose (empty falls back to the generic "invalid").
 type CorpusIngestError struct {
 	Field  string
+	Code   string
 	Reason string
 }
+
+// The stable refusal codes for conversational corpus input.
+const (
+	CorpusErrUnattributedTranscript = "unattributed_transcript"
+	CorpusErrSpeakerLabelRequired   = "speaker_label_required"
+	CorpusErrSpeakerNotFound        = "speaker_not_found"
+	CorpusErrUnsupportedFormat      = "unsupported_format"
+)
 
 func (e *CorpusIngestError) Error() string {
 	return fmt.Sprintf("voice corpus %s: %s", e.Field, e.Reason)
@@ -107,6 +119,15 @@ func SourceRefForContent(content string) string {
 	return "sha256:" + hex.EncodeToString(sum[:])
 }
 
+// The concrete corpus text formats the pipeline parses.
+const (
+	corpusFormatTxt  = "txt"
+	corpusFormatMd   = "md"
+	corpusFormatVTT  = "vtt"
+	corpusFormatSRT  = "srt"
+	corpusFormatJSON = "json"
+)
+
 // speakerTurn is one attributed stretch of transcript text; Speaker is
 // empty when the format carries no attribution.
 type speakerTurn struct {
@@ -124,30 +145,42 @@ type speakerTurn struct {
 // only when attribution is not required (a pasted memo, a
 // single-speaker dictation).
 func NormalizeCorpusText(format, content, speakerLabel string, requireAttribution bool) (string, error) {
-	var turns []speakerTurn
-	switch format {
-	case "txt", "md":
+	turns, plain, err := corpusTurns(format, content)
+	if err != nil {
+		return "", err
+	}
+	if plain {
 		return content, nil
-	case "vtt":
-		turns = parseVTT(content)
-	case "srt":
-		turns = parseSRT(content)
-	case "json":
+	}
+	return filterOwnTurns(turns, speakerLabel, requireAttribution)
+}
+
+// corpusTurns parses one raw source into speaker turns; plain formats
+// (txt/md) carry no turn structure and pass through whole.
+func corpusTurns(format, content string) (turns []speakerTurn, plain bool, err error) {
+	switch format {
+	case corpusFormatTxt, corpusFormatMd:
+		return nil, true, nil
+	case corpusFormatVTT:
+		return parseVTT(content), false, nil
+	case corpusFormatSRT:
+		return parseSRT(content), false, nil
+	case corpusFormatJSON:
 		parsed, err := parseTranscriptJSON(content)
 		if err != nil {
-			return "", err
+			return nil, false, err
 		}
-		turns = parsed
+		return parsed, false, nil
 	default:
 		// The V1 corpus is text only (ADR-0058, features/09 §B1.1): a
 		// binary document (.docx/.pdf) has no honest word count without
 		// real extraction, so it is refused, never estimated from bytes.
-		return "", &CorpusIngestError{
+		return nil, false, &CorpusIngestError{
 			Field:  voiceKeyFormat,
+			Code:   CorpusErrUnsupportedFormat,
 			Reason: "the corpus is text only — must be one of txt, md, vtt, srt, json; convert a binary document or paste its text",
 		}
 	}
-	return filterOwnTurns(turns, speakerLabel, requireAttribution)
 }
 
 // filterOwnTurns applies the §B1.2 speaker filter over parsed turns.
@@ -164,6 +197,7 @@ func filterOwnTurns(turns []speakerTurn, speakerLabel string, requireAttribution
 		if requireAttribution {
 			return "", &CorpusIngestError{
 				Field:  voiceKeyContent,
+				Code:   CorpusErrUnattributedTranscript,
 				Reason: "a conversational source needs speaker-attributed turns; an unlabelled transcript cannot be filtered to the owner's own words",
 			}
 		}
@@ -175,6 +209,7 @@ func filterOwnTurns(turns []speakerTurn, speakerLabel string, requireAttribution
 	if strings.TrimSpace(speakerLabel) == "" {
 		return "", &CorpusIngestError{
 			Field:  voiceKeySpeakerLabel,
+			Code:   CorpusErrSpeakerLabelRequired,
 			Reason: "this transcript attributes its turns to speakers; name the owner's label so only their own words are modeled",
 		}
 	}
@@ -271,8 +306,10 @@ func parseSRT(content string) []speakerTurn {
 }
 
 // splitSpeakerLine extracts attribution from one cue line: a WebVTT
-// `<v Name>text</v>` voice tag, or the `Name: text` convention (a short,
-// digitless prefix — a URL or clock time is not a speaker).
+// `<v Name>text</v>` voice tag, or the `Name: text` convention. A name is
+// letters-first with at most a short trailing number — that admits the
+// "Speaker 1" / "Sprecher 2" labels diarizers emit while a URL or clock
+// time is still never a speaker.
 func splitSpeakerLine(line string) (speaker, text string) {
 	if strings.HasPrefix(line, "<v ") {
 		if end := strings.Index(line, ">"); end > 3 {
@@ -281,13 +318,34 @@ func splitSpeakerLine(line string) (speaker, text string) {
 			return speaker, text
 		}
 	}
-	if idx := strings.Index(line, ":"); idx > 0 && idx <= 40 {
-		candidate := line[:idx]
-		if !strings.ContainsAny(candidate, "0123456789/<>") {
-			return strings.TrimSpace(candidate), strings.TrimSpace(line[idx+1:])
+	if idx := strings.Index(line, ":"); idx > 0 && idx <= 40 && !strings.HasPrefix(line[idx+1:], "//") {
+		if candidate := speakerCandidate(line[:idx]); candidate != "" {
+			return candidate, strings.TrimSpace(line[idx+1:])
 		}
 	}
 	return "", strings.TrimSpace(line)
+}
+
+// speakerCandidate accepts a name-shaped prefix: it must start with a
+// letter, carry digits only as one trailing run of at most three (the
+// diarizer convention), and contain no markup or path characters.
+func speakerCandidate(prefix string) string {
+	candidate := strings.TrimSpace(prefix)
+	if candidate == "" || strings.ContainsAny(candidate, "/<>") {
+		return ""
+	}
+	stem := strings.TrimSpace(strings.TrimRight(candidate, "0123456789"))
+	if len(candidate)-len(stem) > 4 || stem == "" {
+		// TrimSpace may drop the separator space too, so allow digits+space.
+		return ""
+	}
+	if strings.ContainsAny(stem, "0123456789") {
+		return ""
+	}
+	if first := []rune(stem)[0]; !unicode.IsLetter(first) {
+		return ""
+	}
+	return candidate
 }
 
 // transcriptItem is the common shape of one turn across the JSON

--- a/backend/internal/modules/ai/voicecorpus.go
+++ b/backend/internal/modules/ai/voicecorpus.go
@@ -338,7 +338,14 @@ func timestampSpeakerLine(line string) (speaker string, ok bool) {
 	if !found || !clockTime(clock) {
 		return "", false
 	}
-	name := speakerCandidate(strings.TrimSpace(rest))
+	rest = strings.TrimSpace(rest)
+	// A header carries ONLY a name after the clock: short, few words. A
+	// dialogue line that happens to open with a time ("00:12 Great point
+	// everyone, let's continue") stays dialogue.
+	if len(rest) > 40 || len(strings.Fields(rest)) > 4 {
+		return "", false
+	}
+	name := speakerCandidate(rest)
 	if name == "" {
 		return "", false
 	}

--- a/backend/internal/modules/ai/voicecorpus.go
+++ b/backend/internal/modules/ai/voicecorpus.go
@@ -294,6 +294,10 @@ func parseSRT(content string) []speakerTurn {
 		case strings.Contains(trimmed, "-->") || isCueIdentifier(trimmed):
 			continue
 		}
+		if speaker, ok := timestampSpeakerLine(trimmed); ok {
+			current = speaker
+			continue
+		}
 		speaker, text := splitSpeakerLine(trimmed)
 		if speaker != "" {
 			current = speaker
@@ -324,6 +328,40 @@ func splitSpeakerLine(line string) (speaker, text string) {
 		}
 	}
 	return "", strings.TrimSpace(line)
+}
+
+// timestampSpeakerLine recognizes the "00:03:12 Name" header line the
+// meeting exporters (Fathom, Teams, Otter) emit: a leading clock time,
+// then the speaker whose turn follows on the next lines.
+func timestampSpeakerLine(line string) (speaker string, ok bool) {
+	clock, rest, found := strings.Cut(line, " ")
+	if !found || !clockTime(clock) {
+		return "", false
+	}
+	name := speakerCandidate(strings.TrimSpace(rest))
+	if name == "" {
+		return "", false
+	}
+	return name, true
+}
+
+// clockTime matches mm:ss or hh:mm:ss with 1-2 digit groups.
+func clockTime(s string) bool {
+	parts := strings.Split(s, ":")
+	if len(parts) < 2 || len(parts) > 3 {
+		return false
+	}
+	for _, part := range parts {
+		if part == "" || len(part) > 2 {
+			return false
+		}
+		for _, r := range part {
+			if r < '0' || r > '9' {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 // speakerCandidate accepts a name-shaped prefix: it must start with a

--- a/backend/internal/modules/ai/voicecorpus_test.go
+++ b/backend/internal/modules/ai/voicecorpus_test.go
@@ -371,6 +371,10 @@ func TestPreviewReportsSpeakersWithoutStoringAnything(t *testing.T) {
 	if lars.Label != "Lars" || lars.Turns != 2 || lars.Words != 5 {
 		t.Fatalf("lars = %+v", lars)
 	}
+	if preview.TotalWords != 9 || preview.UnattributedWords != 0 {
+		t.Fatalf("totals = %d/%d — word totals count spoken text only, never timestamps or headers",
+			preview.TotalWords, preview.UnattributedWords)
+	}
 	if anna.Label != "Anna" || anna.Turns != 1 || anna.Words != 4 {
 		t.Fatalf("anna = %+v", anna)
 	}
@@ -402,8 +406,8 @@ func TestIngestStatsTellTheKeptVersusDiscardedStory(t *testing.T) {
 	if stats.KeptWords != 4 || stats.KeptTurns != 2 || stats.DiscardedTurns != 1 {
 		t.Fatalf("stats = %+v", stats)
 	}
-	if stats.InputWords <= stats.KeptWords {
-		t.Fatalf("input %d must exceed kept %d — the counterparty's words were seen but not counted", stats.InputWords, stats.KeptWords)
+	if stats.InputWords != 8 {
+		t.Fatalf("input = %d, want 8 — spoken words only, labels are not words", stats.InputWords)
 	}
 	if len(stats.SpeakersSeen) != 2 {
 		t.Fatalf("speakers seen = %v", stats.SpeakersSeen)
@@ -461,5 +465,35 @@ func TestTimestampHeaderTranscriptsAttributeTheFollowingLines(t *testing.T) {
 	}
 	if strings.Contains(text, "erreiche") || !strings.Contains(text, "Bangkok") {
 		t.Fatalf("kept %q — only Lars's turns may survive", text)
+	}
+}
+
+func TestWrappedCueLinesFoldIntoOneTurn(t *testing.T) {
+	content := "Lars: first line of one turn\ncontinues on a wrapped line\nAnna: her reply"
+	preview, err := PreviewCorpusText("transcript", content)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if preview.Speakers[0].Turns != 1 {
+		t.Fatalf("lars turns = %d, want 1 — a wrapped cue is one turn, not two", preview.Speakers[0].Turns)
+	}
+}
+
+func TestClockOpenedDialogueIsNotASpeakerHeader(t *testing.T) {
+	content := "00:00:03 Lars Jankowfsky\n00:12 Great point everyone, let us continue with the plan today.\nMore of the same turn."
+	preview, err := PreviewCorpusText("transcript", content)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(preview.Speakers) != 1 || preview.Speakers[0].Label != "Lars Jankowfsky" {
+		t.Fatalf("speakers = %+v — a long clock-opened dialogue line is not a header", preview.Speakers)
+	}
+}
+
+func TestPreviewRefusesAnUnknownWireFormat(t *testing.T) {
+	_, err := PreviewCorpusText("docx", "binary blob")
+	var ingest *CorpusIngestError
+	if !errors.As(err, &ingest) || ingest.Code != CorpusErrUnsupportedFormat {
+		t.Fatalf("err = %v, want unsupported_format", err)
 	}
 }

--- a/backend/internal/modules/ai/voicecorpus_test.go
+++ b/backend/internal/modules/ai/voicecorpus_test.go
@@ -302,3 +302,146 @@ func TestConversationalKindsDemandAttributableInput(t *testing.T) {
 		t.Fatal("an unlabelled conversational transcript passed whole — attribution is required to filter it")
 	}
 }
+
+func TestSpeakerPrefixAcceptsDiarizerNumberedLabels(t *testing.T) {
+	cases := map[string]struct {
+		line    string
+		speaker string
+	}{
+		"plain name":            {"Lars: we ship on Monday", "Lars"},
+		"numbered diarizer":     {"Speaker 1: we ship on Monday", "Speaker 1"},
+		"german diarizer":       {"Sprecher 2: wir liefern am Montag", "Sprecher 2"},
+		"attached number":       {"Speaker2: we ship", "Speaker2"},
+		"clock time":            {"12:30 we ship", ""},
+		"url":                   {"https://example.test/page", ""},
+		"timestamp with colons": {"00:01:02: hello", ""},
+		"long number run":       {"Speaker 12345: hello", ""},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			speaker, _ := splitSpeakerLine(tc.line)
+			if speaker != tc.speaker {
+				t.Fatalf("speaker = %q, want %q", speaker, tc.speaker)
+			}
+		})
+	}
+}
+
+func TestNumberedSpeakerTranscriptFiltersToTheOwnersTurns(t *testing.T) {
+	content := "Speaker 1: my words here today\nSpeaker 2: their words never counted at all"
+	text, err := NormalizeCorpusText("srt", content, "Speaker 1", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if text != "my words here today" {
+		t.Fatalf("kept %q — only Speaker 1's turns may survive", text)
+	}
+}
+
+func TestBracketOpenedLabelledTextIsNotMistakenForJSON(t *testing.T) {
+	content := "[10:03] intro\nLars: my own words\nAnna: her words"
+	if format := transcriptCorpusFormat(content); format != "srt" {
+		t.Fatalf("sniffed %q, want srt — a bracket-opened labelled transcript is not JSON", format)
+	}
+	prepared, err := prepareSource(IngestSourceInput{
+		Kind: "transcript", SourceLabel: "call", Format: "transcript",
+		SpeakerLabel: "Lars", Content: content,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if prepared.Text != "my own words" {
+		t.Fatalf("kept %q, want only Lars's turn", prepared.Text)
+	}
+}
+
+func TestPreviewReportsSpeakersWithoutStoringAnything(t *testing.T) {
+	content := "WEBVTT\n\n00:00.000 --> 00:04.000\n<v Lars>one two three\n\n00:04.000 --> 00:08.000\n<v Anna>four five six seven\n\n00:08.000 --> 00:10.000\n<v Lars>eight nine"
+	preview, err := PreviewCorpusText("transcript", content)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if preview.DetectedFormat != "vtt" || !preview.IngestibleAsTranscript {
+		t.Fatalf("detected %q ingestible=%v", preview.DetectedFormat, preview.IngestibleAsTranscript)
+	}
+	if len(preview.Speakers) != 2 {
+		t.Fatalf("speakers = %+v, want Lars and Anna", preview.Speakers)
+	}
+	lars, anna := preview.Speakers[0], preview.Speakers[1]
+	if lars.Label != "Lars" || lars.Turns != 2 || lars.Words != 5 {
+		t.Fatalf("lars = %+v", lars)
+	}
+	if anna.Label != "Anna" || anna.Turns != 1 || anna.Words != 4 {
+		t.Fatalf("anna = %+v", anna)
+	}
+}
+
+func TestPreviewOfPlainProseCarriesNoSpeakers(t *testing.T) {
+	preview, err := PreviewCorpusText("text", "just my own six words of prose")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if preview.DetectedFormat != "txt" || preview.IngestibleAsTranscript || len(preview.Speakers) != 0 {
+		t.Fatalf("preview = %+v — plain prose has no transcript structure", preview)
+	}
+	if preview.TotalWords != 7 {
+		t.Fatalf("total = %d, want 7", preview.TotalWords)
+	}
+}
+
+func TestIngestStatsTellTheKeptVersusDiscardedStory(t *testing.T) {
+	content := "Lars: one two three\nAnna: four five six seven\nLars: eight"
+	prepared, err := prepareSource(IngestSourceInput{
+		Kind: "transcript", SourceLabel: "call", Format: "transcript",
+		SpeakerLabel: "lars", Content: content,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	stats := prepared.Stats
+	if stats.KeptWords != 4 || stats.KeptTurns != 2 || stats.DiscardedTurns != 1 {
+		t.Fatalf("stats = %+v", stats)
+	}
+	if stats.InputWords <= stats.KeptWords {
+		t.Fatalf("input %d must exceed kept %d — the counterparty's words were seen but not counted", stats.InputWords, stats.KeptWords)
+	}
+	if len(stats.SpeakersSeen) != 2 {
+		t.Fatalf("speakers seen = %v", stats.SpeakersSeen)
+	}
+}
+
+func TestCorpusRefusalsCarryStableMachineCodes(t *testing.T) {
+	cases := map[string]struct {
+		run  func() error
+		code string
+	}{
+		"unattributed transcript": {func() error {
+			_, err := NormalizeCorpusText("json", `[{"text": "hello there"}]`, "", true)
+			return err
+		}, CorpusErrUnattributedTranscript},
+		"missing speaker label": {func() error {
+			_, err := NormalizeCorpusText("srt", "Lars: hello", "", false)
+			return err
+		}, CorpusErrSpeakerLabelRequired},
+		"speaker not found": {func() error {
+			_, err := prepareSource(IngestSourceInput{
+				Kind: "transcript", SourceLabel: "call",
+				Format: "transcript", SpeakerLabel: "Nobody", Content: "Lars: hello there",
+			})
+			return err
+		}, CorpusErrSpeakerNotFound},
+		"unsupported format": {func() error {
+			_, _, err := corpusTurns("docx", "binary")
+			return err
+		}, CorpusErrUnsupportedFormat},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			err := tc.run()
+			var ingest *CorpusIngestError
+			if !errors.As(err, &ingest) || ingest.Code != tc.code {
+				t.Fatalf("err = %v, want code %q", err, tc.code)
+			}
+		})
+	}
+}

--- a/backend/internal/modules/ai/voicecorpus_test.go
+++ b/backend/internal/modules/ai/voicecorpus_test.go
@@ -445,3 +445,21 @@ func TestCorpusRefusalsCarryStableMachineCodes(t *testing.T) {
 		})
 	}
 }
+
+func TestTimestampHeaderTranscriptsAttributeTheFollowingLines(t *testing.T) {
+	content := "00:00:00 Daniel Pohlmann\nEbenso, wo erreiche ich dich?\n00:00:03 Lars Jankowfsky\nDu, ich bin heute in Bangkok.\n00:00:38 Lars Jankowfsky\nUnd dann war ich einen Tag unterwegs.\n00:00:49 Daniel Pohlmann\nDann machen wir das entspannt."
+	preview, err := PreviewCorpusText("transcript", content)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(preview.Speakers) != 2 {
+		t.Fatalf("speakers = %+v, want the two meeting participants", preview.Speakers)
+	}
+	text, err := NormalizeCorpusText("srt", content, "Lars Jankowfsky", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(text, "erreiche") || !strings.Contains(text, "Bangkok") {
+		t.Fatalf("kept %q — only Lars's turns may survive", text)
+	}
+}

--- a/backend/internal/modules/ai/voicecorpuspreview.go
+++ b/backend/internal/modules/ai/voicecorpuspreview.go
@@ -13,6 +13,10 @@ package ai
 
 import "strings"
 
+// corpusWireFormatText is the wire-level format discriminator (ingest and
+// preview requests): plain single-author prose, no speaker structure.
+const corpusWireFormatText = "text"
+
 // CorpusSpeaker aggregates one detected speaker in a previewed source.
 // Turns counts logical turns: consecutive lines of the same speaker (a
 // wrapped cue) fold into one.
@@ -44,7 +48,7 @@ func PreviewCorpusText(format, content string) (CorpusPreview, error) {
 	}
 	var concrete string
 	switch format {
-	case "", "text":
+	case "", corpusWireFormatText:
 		concrete = corpusFormatTxt
 	case voiceSourceKindTranscript:
 		concrete = transcriptCorpusFormat(content)
@@ -65,7 +69,6 @@ func PreviewCorpusText(format, content string) (CorpusPreview, error) {
 	preview := CorpusPreview{DetectedFormat: concrete}
 	index := map[string]int{}
 	previousSpeaker := ""
-	newRun := true
 	for _, turn := range turns {
 		words := WordCount(turn.Text)
 		preview.TotalWords += words
@@ -75,7 +78,7 @@ func PreviewCorpusText(format, content string) (CorpusPreview, error) {
 			continue
 		}
 		key := normalizeSpeaker(turn.Speaker)
-		newRun = key != previousSpeaker
+		newRun := key != previousSpeaker
 		previousSpeaker = key
 		at, seen := index[key]
 		if !seen {

--- a/backend/internal/modules/ai/voicecorpuspreview.go
+++ b/backend/internal/modules/ai/voicecorpuspreview.go
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package ai
+
+// The corpus dry-run and honesty surface (§B1.2's user-facing half): the
+// speaker preview that lets the owner be asked "which of these is you?"
+// BEFORE any words are committed, and the kept-versus-discarded ingest
+// stats the conversational meter narrates from. Pure functions over the
+// same parsers the ingest pipeline commits with.
+
+import "strings"
+
+// CorpusSpeaker aggregates one detected speaker in a previewed source.
+type CorpusSpeaker struct {
+	Label string
+	Turns int
+	Words int
+}
+
+// CorpusPreview is the dry-run answer to "who speaks in this file?" —
+// computed without storing anything, so the owner can be asked which
+// speaker they are BEFORE any words enter the corpus.
+type CorpusPreview struct {
+	DetectedFormat         string
+	TotalWords             int
+	Speakers               []CorpusSpeaker
+	UnattributedWords      int
+	IngestibleAsTranscript bool
+}
+
+// PreviewCorpusText inspects one candidate source in its wire format
+// (text | transcript, mirroring ingest). Pure — no persistence, no model.
+func PreviewCorpusText(format, content string) (CorpusPreview, error) {
+	if strings.TrimSpace(content) == "" {
+		return CorpusPreview{}, &CorpusIngestError{Field: voiceKeyContent, Reason: voiceValidationNotEmpty}
+	}
+	if len(content) > maxCorpusSourceBytes {
+		return CorpusPreview{}, &CorpusIngestError{Field: voiceKeyContent, Reason: "one source is capped at 1 MiB of text — split the upload"}
+	}
+	concrete := corpusFormatTxt
+	if format == voiceSourceKindTranscript {
+		concrete = transcriptCorpusFormat(content)
+	}
+	turns, plain, err := corpusTurns(concrete, content)
+	if err != nil {
+		return CorpusPreview{}, err
+	}
+	preview := CorpusPreview{DetectedFormat: concrete, TotalWords: WordCount(content)}
+	if plain {
+		return preview, nil
+	}
+	index := map[string]int{}
+	for _, turn := range turns {
+		words := WordCount(turn.Text)
+		if turn.Speaker == "" {
+			preview.UnattributedWords += words
+			continue
+		}
+		key := normalizeSpeaker(turn.Speaker)
+		at, seen := index[key]
+		if !seen {
+			at = len(preview.Speakers)
+			index[key] = at
+			preview.Speakers = append(preview.Speakers, CorpusSpeaker{Label: turn.Speaker})
+		}
+		preview.Speakers[at].Turns++
+		preview.Speakers[at].Words += words
+	}
+	preview.IngestibleAsTranscript = len(preview.Speakers) > 0
+	return preview, nil
+}
+
+// CorpusIngestStats reports what the §B1.2 speaker filter did to one
+// ingested source — the honest kept-versus-discarded story the meter's
+// numbers rest on.
+type CorpusIngestStats struct {
+	InputWords     int
+	KeptWords      int
+	KeptTurns      int
+	DiscardedTurns int
+	SpeakersSeen   []string
+}
+
+func ingestStats(content string, turns []speakerTurn, plain bool, keptText, speakerLabel string) CorpusIngestStats {
+	stats := CorpusIngestStats{InputWords: WordCount(content), KeptWords: WordCount(keptText)}
+	if plain {
+		stats.KeptTurns = 1
+		return stats
+	}
+	labelled := false
+	for _, turn := range turns {
+		if turn.Speaker != "" {
+			labelled = true
+			break
+		}
+	}
+	// Mirrors filterOwnTurns exactly: in a labelled transcript only the
+	// owner's turns survive (an unattributed stray is discarded); a fully
+	// unlabelled one passes whole when it was allowed through at all.
+	want := normalizeSpeaker(speakerLabel)
+	seen := map[string]bool{}
+	for _, turn := range turns {
+		if turn.Speaker != "" && !seen[normalizeSpeaker(turn.Speaker)] {
+			seen[normalizeSpeaker(turn.Speaker)] = true
+			stats.SpeakersSeen = append(stats.SpeakersSeen, turn.Speaker)
+		}
+		kept := !labelled || normalizeSpeaker(turn.Speaker) == want
+		if kept {
+			stats.KeptTurns++
+		} else {
+			stats.DiscardedTurns++
+		}
+	}
+	return stats
+}

--- a/backend/internal/modules/ai/voicecorpuspreview.go
+++ b/backend/internal/modules/ai/voicecorpuspreview.go
@@ -7,11 +7,15 @@ package ai
 // speaker preview that lets the owner be asked "which of these is you?"
 // BEFORE any words are committed, and the kept-versus-discarded ingest
 // stats the conversational meter narrates from. Pure functions over the
-// same parsers the ingest pipeline commits with.
+// same parsers the ingest pipeline commits with. Every word total here
+// sums SPOKEN text only — timestamps, cue counters, speaker labels and
+// JSON keys are serialization, not words, and never inflate a count.
 
 import "strings"
 
 // CorpusSpeaker aggregates one detected speaker in a previewed source.
+// Turns counts logical turns: consecutive lines of the same speaker (a
+// wrapped cue) fold into one.
 type CorpusSpeaker struct {
 	Label string
 	Turns int
@@ -38,33 +42,50 @@ func PreviewCorpusText(format, content string) (CorpusPreview, error) {
 	if len(content) > maxCorpusSourceBytes {
 		return CorpusPreview{}, &CorpusIngestError{Field: voiceKeyContent, Reason: "one source is capped at 1 MiB of text — split the upload"}
 	}
-	concrete := corpusFormatTxt
-	if format == voiceSourceKindTranscript {
+	var concrete string
+	switch format {
+	case "", "text":
+		concrete = corpusFormatTxt
+	case voiceSourceKindTranscript:
 		concrete = transcriptCorpusFormat(content)
+	default:
+		return CorpusPreview{}, &CorpusIngestError{
+			Field:  voiceKeyFormat,
+			Code:   CorpusErrUnsupportedFormat,
+			Reason: "must be text or transcript",
+		}
 	}
 	turns, plain, err := corpusTurns(concrete, content)
 	if err != nil {
 		return CorpusPreview{}, err
 	}
-	preview := CorpusPreview{DetectedFormat: concrete, TotalWords: WordCount(content)}
 	if plain {
-		return preview, nil
+		return CorpusPreview{DetectedFormat: concrete, TotalWords: WordCount(content)}, nil
 	}
+	preview := CorpusPreview{DetectedFormat: concrete}
 	index := map[string]int{}
+	previousSpeaker := ""
+	newRun := true
 	for _, turn := range turns {
 		words := WordCount(turn.Text)
+		preview.TotalWords += words
 		if turn.Speaker == "" {
 			preview.UnattributedWords += words
+			previousSpeaker = ""
 			continue
 		}
 		key := normalizeSpeaker(turn.Speaker)
+		newRun = key != previousSpeaker
+		previousSpeaker = key
 		at, seen := index[key]
 		if !seen {
 			at = len(preview.Speakers)
 			index[key] = at
 			preview.Speakers = append(preview.Speakers, CorpusSpeaker{Label: turn.Speaker})
 		}
-		preview.Speakers[at].Turns++
+		if newRun {
+			preview.Speakers[at].Turns++
+		}
 		preview.Speakers[at].Words += words
 	}
 	preview.IngestibleAsTranscript = len(preview.Speakers) > 0
@@ -73,7 +94,8 @@ func PreviewCorpusText(format, content string) (CorpusPreview, error) {
 
 // CorpusIngestStats reports what the §B1.2 speaker filter did to one
 // ingested source — the honest kept-versus-discarded story the meter's
-// numbers rest on.
+// numbers rest on. InputWords counts the SPOKEN words of every turn (not
+// serialization); turn counts fold wrapped same-speaker lines into one.
 type CorpusIngestStats struct {
 	InputWords     int
 	KeptWords      int
@@ -83,8 +105,9 @@ type CorpusIngestStats struct {
 }
 
 func ingestStats(content string, turns []speakerTurn, plain bool, keptText, speakerLabel string) CorpusIngestStats {
-	stats := CorpusIngestStats{InputWords: WordCount(content), KeptWords: WordCount(keptText)}
+	stats := CorpusIngestStats{KeptWords: WordCount(keptText)}
 	if plain {
+		stats.InputWords = WordCount(content)
 		stats.KeptTurns = 1
 		return stats
 	}
@@ -100,17 +123,25 @@ func ingestStats(content string, turns []speakerTurn, plain bool, keptText, spea
 	// unlabelled one passes whole when it was allowed through at all.
 	want := normalizeSpeaker(speakerLabel)
 	seen := map[string]bool{}
+	previousSpeaker := ""
+	previousKept := false
 	for _, turn := range turns {
+		stats.InputWords += WordCount(turn.Text)
 		if turn.Speaker != "" && !seen[normalizeSpeaker(turn.Speaker)] {
 			seen[normalizeSpeaker(turn.Speaker)] = true
 			stats.SpeakersSeen = append(stats.SpeakersSeen, turn.Speaker)
 		}
-		kept := !labelled || normalizeSpeaker(turn.Speaker) == want
-		if kept {
-			stats.KeptTurns++
-		} else {
-			stats.DiscardedTurns++
+		key := normalizeSpeaker(turn.Speaker)
+		kept := !labelled || key == want
+		if key != previousSpeaker || kept != previousKept {
+			if kept {
+				stats.KeptTurns++
+			} else {
+				stats.DiscardedTurns++
+			}
 		}
+		previousSpeaker = key
+		previousKept = kept
 	}
 	return stats
 }

--- a/backend/internal/modules/ai/voicesources.go
+++ b/backend/internal/modules/ai/voicesources.go
@@ -146,7 +146,7 @@ func prepareSource(in IngestSourceInput) (preparedSource, error) {
 	}
 	format := in.Format
 	switch format {
-	case "", "text":
+	case "", corpusWireFormatText:
 		format = corpusFormatTxt
 	case voiceSourceKindTranscript:
 		format = transcriptCorpusFormat(in.Content)

--- a/backend/internal/modules/ai/voicesources.go
+++ b/backend/internal/modules/ai/voicesources.go
@@ -105,6 +105,7 @@ type preparedSource struct {
 	Text       string
 	Words      int
 	OccurredAt time.Time
+	Stats      CorpusIngestStats
 }
 
 // prepareSource runs the pure half of the §B1 pipeline: field
@@ -146,7 +147,7 @@ func prepareSource(in IngestSourceInput) (preparedSource, error) {
 	format := in.Format
 	switch format {
 	case "", "text":
-		format = "txt"
+		format = corpusFormatTxt
 	case voiceSourceKindTranscript:
 		format = transcriptCorpusFormat(in.Content)
 	}
@@ -154,19 +155,28 @@ func prepareSource(in IngestSourceInput) (preparedSource, error) {
 	// the §B1.2 filter is what keeps a counterparty's words out of the
 	// corpus, and a plain-text conversation would walk straight past it —
 	// the Art. 17 posture of this table rests on this refusal.
-	if in.Kind == voiceSourceKindTranscript && (format == "txt" || format == "md") {
+	if in.Kind == voiceSourceKindTranscript && (format == corpusFormatTxt || format == corpusFormatMd) {
 		return preparedSource{}, &CorpusIngestError{
 			Field:  voiceKeyFormat,
+			Code:   CorpusErrUnattributedTranscript,
 			Reason: "a " + in.Kind + " source must be a speaker-attributed transcript (vtt, srt, or json) so only the owner's own words are modeled",
 		}
 	}
-	text, err := NormalizeCorpusText(format, in.Content, in.SpeakerLabel, in.Kind == voiceSourceKindTranscript)
+	turns, plain, err := corpusTurns(format, in.Content)
 	if err != nil {
 		return preparedSource{}, err
+	}
+	text := in.Content
+	if !plain {
+		text, err = filterOwnTurns(turns, in.SpeakerLabel, in.Kind == voiceSourceKindTranscript)
+		if err != nil {
+			return preparedSource{}, err
+		}
 	}
 	if in.Kind == voiceSourceKindTranscript && strings.TrimSpace(text) == "" {
 		return preparedSource{}, &CorpusIngestError{
 			Field:  voiceKeySpeakerLabel,
+			Code:   CorpusErrSpeakerNotFound,
 			Reason: "no turns belong to this speaker label — nothing of the owner's own words to ingest",
 		}
 	}
@@ -182,6 +192,7 @@ func prepareSource(in IngestSourceInput) (preparedSource, error) {
 		Kind: in.Kind, Register: register, Weight: weight,
 		Label: in.SourceLabel, SourceRef: sourceRef,
 		Text: text, Words: WordCount(text), OccurredAt: occurredAt,
+		Stats: ingestStats(in.Content, turns, plain, text, in.SpeakerLabel),
 	}, nil
 }
 
@@ -189,10 +200,16 @@ func transcriptCorpusFormat(content string) string {
 	trimmed := strings.TrimSpace(content)
 	switch {
 	case strings.HasPrefix(trimmed, "WEBVTT"):
-		return "vtt"
+		return corpusFormatVTT
 	case strings.HasPrefix(trimmed, "[") || strings.HasPrefix(trimmed, "{"):
-		return "json"
+		// Commit to JSON only when it decodes as transcript turns: a
+		// speaker-labelled plain transcript can legitimately open with a
+		// bracket ("[10:03] Lars: ..."), and that is SRT-shaped, not JSON.
+		if _, err := decodeTranscriptItems(content); err == nil {
+			return corpusFormatJSON
+		}
+		return corpusFormatSRT
 	default:
-		return "srt"
+		return corpusFormatSRT
 	}
 }

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -15684,7 +15684,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["Problem"];
+                    "application/problem+json": components["schemas"]["Problem"];
                 };
             };
         };
@@ -15728,7 +15728,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["Problem"];
+                    "application/problem+json": components["schemas"]["Problem"];
                 };
             };
         };

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -3231,6 +3231,30 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/voice-profiles/{id}/sources/preview": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Dry-run one candidate source; detect its shape and speakers without storing anything.
+         * @description Answers "who is speaking in this file?" before ingest, so the owner can be asked
+         *     which speaker they are. Pure inspection - no persistence, no model call.
+         */
+        post: operations["previewVoiceCorpusSource"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/voice-profiles/{id}/sources/{sourceId}": {
         parameters: {
             query?: never;
@@ -8200,7 +8224,12 @@ export interface components {
             weight: number;
             source_label: string;
             source_ref: string;
-            /** @enum {string} */
+            /**
+             * @description Send `transcript` for anything conversational — .vtt, .srt, transcript JSON,
+             *     and speaker-labelled plain text ("Name: …" lines) alike; the server detects
+             *     the concrete shape. `text` is for single-author prose only.
+             * @enum {string}
+             */
             format: "text" | "transcript";
             /** @description Required for transcript format; only this speaker is retained. */
             speaker_label?: string | null;
@@ -8211,6 +8240,32 @@ export interface components {
         UpdateVoiceCorpusSourceRequest: {
             included?: boolean;
             weight?: number;
+        };
+        /** @description What the speaker filter did to one ingested source; kept words are the only words that count. */
+        VoiceIngestStats: {
+            input_words: number;
+            kept_words: number;
+            kept_turns: number;
+            discarded_turns: number;
+            speakers_seen: string[];
+        };
+        VoiceCorpusPreviewRequest: {
+            /** @enum {string} */
+            format: "text" | "transcript";
+            content: string;
+        };
+        /** @description Dry-run inspection of a candidate source; nothing is stored. */
+        VoiceCorpusPreviewResult: {
+            /** @enum {string} */
+            detected_format: "txt" | "vtt" | "srt" | "json";
+            total_words: number;
+            speakers: {
+                label: string;
+                turns: number;
+                words: number;
+            }[];
+            unattributed_words: number;
+            ingestible_as_transcript: boolean;
         };
         VoiceCorpusSummary: {
             total_words: number;
@@ -15609,7 +15664,37 @@ export interface operations {
                     "application/json": {
                         source: components["schemas"]["VoiceCorpusSource"];
                         summary: components["schemas"]["VoiceCorpusSummary"];
+                        ingest_stats?: components["schemas"]["VoiceIngestStats"];
                     };
+                };
+            };
+            404: components["responses"]["NotFound"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    previewVoiceCorpusSource: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque resource id (UUID; ordering semantics are not exposed). */
+                id: components["parameters"]["Id"];
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["VoiceCorpusPreviewRequest"];
+            };
+        };
+        responses: {
+            /** @description Detected shape, per-speaker word counts, and transcript eligibility. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["VoiceCorpusPreviewResult"];
                 };
             };
             404: components["responses"]["NotFound"];

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -8250,7 +8250,12 @@ export interface components {
             speakers_seen: string[];
         };
         VoiceCorpusPreviewRequest: {
-            /** @enum {string} */
+            /**
+             * @description Send transcript for anything conversational - the server detects the
+             *     concrete shape (vtt, srt, transcript JSON, or labelled plain text).
+             *     text skips speaker detection entirely.
+             * @enum {string}
+             */
             format: "text" | "transcript";
             content: string;
         };
@@ -15664,12 +15669,24 @@ export interface operations {
                     "application/json": {
                         source: components["schemas"]["VoiceCorpusSource"];
                         summary: components["schemas"]["VoiceCorpusSummary"];
-                        ingest_stats?: components["schemas"]["VoiceIngestStats"];
+                        ingest_stats: components["schemas"]["VoiceIngestStats"];
                     };
                 };
             };
             404: components["responses"]["NotFound"];
-            422: components["responses"]["ValidationError"];
+            /**
+             * @description Unusable input. details.errors[].code is stable and voiceable:
+             *     unattributed_transcript, speaker_label_required, speaker_not_found,
+             *     unsupported_format, or the generic invalid.
+             */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Problem"];
+                };
+            };
         };
     };
     previewVoiceCorpusSource: {
@@ -15688,7 +15705,11 @@ export interface operations {
             };
         };
         responses: {
-            /** @description Detected shape, per-speaker word counts, and transcript eligibility. */
+            /**
+             * @description Detected shape and per-speaker word counts. Word totals count spoken
+             *     text only - timestamps, cue counters, speaker labels and JSON keys are
+             *     serialization, never words.
+             */
             200: {
                 headers: {
                     [name: string]: unknown;
@@ -15698,7 +15719,18 @@ export interface operations {
                 };
             };
             404: components["responses"]["NotFound"];
-            422: components["responses"]["ValidationError"];
+            /**
+             * @description Unusable input. details.errors[].code is stable and voiceable:
+             *     unsupported_format, or the generic invalid.
+             */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Problem"];
+                };
+            };
         };
     };
     deleteVoiceCorpusSource: {

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1106,6 +1106,12 @@ export const de = {
     ".txt .md .vtt .srt .json · nur Text · wir behalten nur deine Redeanteile",
   "ob.s2.dropSkipped":
     "{files} übersprungen — kein Textformat. Als .txt/.md konvertieren oder den Text direkt einfügen.",
+  "ob.s2.speakerAsk": "Wer bist du in {file}?",
+  "ob.s2.speakerOption": "{name} · {words} Wörter in {turns} Redeanteilen",
+  "ob.s2.keptOnly":
+    "{kept} von {total} Wörtern behalten (nur die Redeanteile von {speaker})",
+  "ob.s2.unattributed":
+    "In {file} kann ich nicht erkennen, wer was sagt — deshalb zählt nichts davon. Ergänze Sprecher-Labels oder füge nur deine eigenen Worte ein.",
   "ob.reg.spoken": "gesprochen",
   "ob.reg.written": "geschrieben",
   "ob.reg.casual": "locker",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1298,6 +1298,60 @@ export const de = {
   "ob.s4.connectFailed": "Dieses Postfach ließ sich nicht verbinden",
   "ob.s4.skipLater": "Erstmal überspringen — später verbinden",
 
+  "ob.conv.threadLabel": "Einrichtungsgespräch",
+  "ob.conv.welcome":
+    "Hallo, ich bin Margince. Ich richte dein CRM ein, indem ich lese, was über dein Unternehmen bereits belegt ist, und zeige zu allem eine Quelle.",
+  "ob.conv.welcomeMember":
+    "Hallo, ich bin Margince. Dein Team ist schon eingerichtet. Zwei kurze Schritte, dann bist du drin.",
+  "ob.conv.askUrl":
+    "Wo soll ich mit dem Lesen beginnen? Deine Website eignet sich am besten.",
+  "ob.conv.read.started": "Ich lese jetzt {host}. Ich sage dir, was ich finde.",
+  "ob.conv.read.pages": "Bisher {pages} Seiten gelesen.",
+  "ob.conv.read.learnedField": "Gelernt {field}: {value}",
+  "ob.conv.read.extracting":
+    "Das Durchsuchen ist fertig. Jetzt werte ich aus, was die Website über dein Geschäft sagt.",
+  "ob.conv.read.warning": "Hinweis: {warning}",
+  "ob.conv.read.done":
+    "Fertig gelesen. {count} Funde, jeder mit seiner Quelle.",
+  "ob.conv.read.partial":
+    "Ich konnte nicht alles lesen, habe aber {count} belegte Angaben gefunden.",
+  "ob.conv.read.failed":
+    "Ich konnte diese Website nicht lesen. Probiere eine andere URL oder sag es mir direkt.",
+  "ob.conv.read.deferred":
+    "Das Einlesen pausiert gerade. Ich setze es automatisch fort.",
+  "ob.conv.clarify.intro":
+    "Eine Sache musst du entscheiden. Die Website ist hier nicht eindeutig.",
+  "ob.conv.clarify.entity":
+    "Die Website nennt mehr als eine juristische Person. Welche gehört zu dieser Installation?",
+  "ob.conv.review.ready":
+    "Ich habe die Zuordnung vorbereitet. Prüfe sie und bestätige, was stimmt.",
+  "ob.conv.company.confirmed":
+    "Firmenprofil bestätigt. Alles Gespeicherte trägt seine Quelle.",
+  "ob.conv.manual.chosen": "Ich tippe es selbst ein.",
+  "ob.conv.voice.invite":
+    "Soll ich lernen, wie du schreibst? Teile ein paar eigene Texte, dann klingen Entwürfe nach dir.",
+  "ob.conv.voice.optIn": "Ja, lerne meine Stimme.",
+  "ob.conv.voice.skipped": "Stimme erstmal überspringen.",
+  "ob.conv.voice.uploadAdded": "{name} hinzugefügt.",
+  "ob.conv.voice.speakerQuestion":
+    "Dieses Transkript hat mehrere Sprecher. Wer davon bist du? Nur deine eigenen Worte zählen.",
+  "ob.conv.corpus.words": "Dein Korpus enthält jetzt {words} eigene Worte.",
+  "ob.conv.corpus.band": "Korpusqualität ist jetzt {band}.",
+  "ob.conv.build.snapshot": "Ich friere deinen Korpus ein.",
+  "ob.conv.build.extract": "Ich suche deine typischen Formulierungen.",
+  "ob.conv.build.evaluate": "Ich teste Entwürfe gegen zurückgehaltene Proben.",
+  "ob.conv.build.activate": "Ich aktiviere dein Stimmprofil.",
+  "ob.conv.build.succeeded": "Dein Stimmprofil ist fertig.",
+  "ob.conv.build.deferred":
+    "Der Aufbau wartet auf Budget. Er läuft automatisch an.",
+  "ob.conv.build.failed":
+    "Der Aufbau wurde nicht fertig. Deine Texte bleiben erhalten, du kannst es jederzeit erneut versuchen.",
+  "ob.conv.recap":
+    "Das weiß dein CRM jetzt, mit einer Quelle zu jedem Eintrag.",
+  "ob.conv.consent":
+    "Letzter Schritt: Was darf ich erfassen, und zu welchem Zweck? Nichts ist standardmäßig aktiv.",
+  "ob.conv.done": "Einrichtung abgeschlossen. Dein CRM ist bereit.",
+
   "auth.title": "Margince",
   "auth.checking": "Sitzung wird geprüft…",
   "auth.pageTitle": "Anmelden · Margince",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1107,9 +1107,8 @@ export const de = {
   "ob.s2.dropSkipped":
     "{files} übersprungen — kein Textformat. Als .txt/.md konvertieren oder den Text direkt einfügen.",
   "ob.s2.speakerAsk": "Wer bist du in {file}?",
-  "ob.s2.speakerOption": "{name} · {words} Wörter in {turns} Redeanteilen",
-  "ob.s2.keptOnly":
-    "{kept} von {total} Wörtern behalten (nur die Redeanteile von {speaker})",
+  "ob.s2.speakerOption": "{name} · Wörter: {words} · Redeanteile: {turns}",
+  "ob.s2.keptOnly": "{kept} von {total} gezählt — nur was {speaker} gesagt hat",
   "ob.s2.unattributed":
     "In {file} kann ich nicht erkennen, wer was sagt — deshalb zählt nichts davon. Ergänze Sprecher-Labels oder füge nur deine eigenen Worte ein.",
   "ob.reg.spoken": "gesprochen",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1306,15 +1306,14 @@ export const de = {
   "ob.conv.askUrl":
     "Wo soll ich mit dem Lesen beginnen? Deine Website eignet sich am besten.",
   "ob.conv.read.started": "Ich lese jetzt {host}. Ich sage dir, was ich finde.",
-  "ob.conv.read.pages": "Bisher {pages} Seiten gelesen.",
-  "ob.conv.read.learnedField": "Gelernt {field}: {value}",
+  "ob.conv.read.pages": "Bisher gelesene Seiten: {pages}.",
+  "ob.conv.read.learnedField": "{field} gelernt: {value}",
   "ob.conv.read.extracting":
     "Das Durchsuchen ist fertig. Jetzt werte ich aus, was die Website über dein Geschäft sagt.",
   "ob.conv.read.warning": "Hinweis: {warning}",
-  "ob.conv.read.done":
-    "Fertig gelesen. {count} Funde, jeder mit seiner Quelle.",
+  "ob.conv.read.done": "Fertig gelesen. Belegte Funde: {count}.",
   "ob.conv.read.partial":
-    "Ich konnte nicht alles lesen, habe aber {count} belegte Angaben gefunden.",
+    "Ich konnte nicht alles lesen. Belegte Funde: {count}.",
   "ob.conv.read.failed":
     "Ich konnte diese Website nicht lesen. Probiere eine andere URL oder sag es mir direkt.",
   "ob.conv.read.deferred":
@@ -1322,7 +1321,7 @@ export const de = {
   "ob.conv.clarify.intro":
     "Eine Sache musst du entscheiden. Die Website ist hier nicht eindeutig.",
   "ob.conv.clarify.entity":
-    "Die Website nennt mehr als eine juristische Person. Welche gehört zu dieser Installation?",
+    "Die Website nennt mehr als eine juristische Person. Für welche ist diese Installation?",
   "ob.conv.review.ready":
     "Ich habe die Zuordnung vorbereitet. Prüfe sie und bestätige, was stimmt.",
   "ob.conv.company.confirmed":
@@ -1335,7 +1334,7 @@ export const de = {
   "ob.conv.voice.uploadAdded": "{name} hinzugefügt.",
   "ob.conv.voice.speakerQuestion":
     "Dieses Transkript hat mehrere Sprecher. Wer davon bist du? Nur deine eigenen Worte zählen.",
-  "ob.conv.corpus.words": "Dein Korpus enthält jetzt {words} eigene Worte.",
+  "ob.conv.corpus.words": "Eigene Worte jetzt im Korpus: {words}.",
   "ob.conv.corpus.band": "Korpusqualität ist jetzt {band}.",
   "ob.conv.build.snapshot": "Ich friere deinen Korpus ein.",
   "ob.conv.build.extract": "Ich suche deine typischen Formulierungen.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1086,6 +1086,11 @@ export const en = {
     ".txt .md .vtt .srt .json · text only · we keep only your turns",
   "ob.s2.dropSkipped":
     "Skipped {files} — not a text format. Convert to .txt/.md or paste the text instead.",
+  "ob.s2.speakerAsk": "Which speaker are you in {file}?",
+  "ob.s2.speakerOption": "{name} · {words} words in {turns} turns",
+  "ob.s2.keptOnly": "kept {kept} of {total} words ({speaker}'s turns only)",
+  "ob.s2.unattributed":
+    "I can't tell who says what in {file}, so none of it is counted. Add speaker labels, or paste only your own words.",
   "ob.reg.spoken": "spoken",
   "ob.reg.written": "written",
   "ob.reg.casual": "casual",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1087,8 +1087,8 @@ export const en = {
   "ob.s2.dropSkipped":
     "Skipped {files} — not a text format. Convert to .txt/.md or paste the text instead.",
   "ob.s2.speakerAsk": "Which speaker are you in {file}?",
-  "ob.s2.speakerOption": "{name} · {words} words in {turns} turns",
-  "ob.s2.keptOnly": "kept {kept} of {total} words ({speaker}'s turns only)",
+  "ob.s2.speakerOption": "{name} · words: {words} · turns: {turns}",
+  "ob.s2.keptOnly": "counted {kept} of {total} — only what {speaker} said",
   "ob.s2.unattributed":
     "I can't tell who says what in {file}, so none of it is counted. Add speaker labels, or paste only your own words.",
   "ob.reg.spoken": "spoken",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1282,15 +1282,14 @@ export const en = {
     "Hi, I am Margince. Your team is already set up. Two short steps and you are in.",
   "ob.conv.askUrl": "Where should I start reading? Your website works best.",
   "ob.conv.read.started": "Reading {host} now. I will tell you what I find.",
-  "ob.conv.read.pages": "Read {pages} pages so far.",
+  "ob.conv.read.pages": "Pages read so far: {pages}.",
   "ob.conv.read.learnedField": "Learned {field}: {value}",
   "ob.conv.read.extracting":
     "Done crawling. Now extracting what the site says about your business.",
   "ob.conv.read.warning": "Heads up: {warning}",
-  "ob.conv.read.done":
-    "Finished reading. {count} findings, each with its source.",
+  "ob.conv.read.done": "Finished reading. Findings with sources: {count}.",
   "ob.conv.read.partial":
-    "I could not read everything, but I found {count} things with sources.",
+    "I could not read everything. Findings with sources: {count}.",
   "ob.conv.read.failed":
     "I could not read that site. Try another URL, or tell me directly.",
   "ob.conv.read.deferred":
@@ -1298,7 +1297,7 @@ export const en = {
   "ob.conv.clarify.intro":
     "One thing I need you to decide. The site is ambiguous here.",
   "ob.conv.clarify.entity":
-    "The site names more than one legal entity. Which one is this installation?",
+    "The site names more than one legal entity. Which one is this installation for?",
   "ob.conv.review.ready":
     "I prepared the mapping. Review it and confirm what is right.",
   "ob.conv.company.confirmed":
@@ -1311,17 +1310,17 @@ export const en = {
   "ob.conv.voice.uploadAdded": "Added {name}.",
   "ob.conv.voice.speakerQuestion":
     "This transcript has several speakers. Which one is you? Only your own words count.",
-  "ob.conv.corpus.words": "Your corpus now holds {words} of your own words.",
+  "ob.conv.corpus.words": "Own words in your corpus now: {words}.",
   "ob.conv.corpus.band": "Corpus quality moved to {band}.",
   "ob.conv.build.snapshot": "Locking in your corpus.",
   "ob.conv.build.extract": "Finding your signature moves.",
-  "ob.conv.build.evaluate": "Testing drafts against held out samples.",
+  "ob.conv.build.evaluate": "Testing drafts against held-out samples.",
   "ob.conv.build.activate": "Activating your voice profile.",
   "ob.conv.build.succeeded": "Your voice profile is ready.",
   "ob.conv.build.deferred":
     "The build is queued behind budget. It will run automatically.",
   "ob.conv.build.failed":
-    "The build did not finish. Your texts are kept, you can retry anytime.",
+    "The build did not finish. Your texts are kept and you can retry anytime.",
   "ob.conv.recap":
     "Here is what your CRM knows now, with a source for every item.",
   "ob.conv.consent":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1275,6 +1275,59 @@ export const en = {
   "ob.s4.connectFailed": "Couldn't connect that mailbox",
   "ob.s4.skipLater": "Skip for now — I'll connect later",
 
+  "ob.conv.threadLabel": "Onboarding conversation",
+  "ob.conv.welcome":
+    "Hi, I am Margince. I set up your CRM by reading what is already true about your business, and I show a source for everything I keep.",
+  "ob.conv.welcomeMember":
+    "Hi, I am Margince. Your team is already set up. Two short steps and you are in.",
+  "ob.conv.askUrl": "Where should I start reading? Your website works best.",
+  "ob.conv.read.started": "Reading {host} now. I will tell you what I find.",
+  "ob.conv.read.pages": "Read {pages} pages so far.",
+  "ob.conv.read.learnedField": "Learned {field}: {value}",
+  "ob.conv.read.extracting":
+    "Done crawling. Now extracting what the site says about your business.",
+  "ob.conv.read.warning": "Heads up: {warning}",
+  "ob.conv.read.done":
+    "Finished reading. {count} findings, each with its source.",
+  "ob.conv.read.partial":
+    "I could not read everything, but I found {count} things with sources.",
+  "ob.conv.read.failed":
+    "I could not read that site. Try another URL, or tell me directly.",
+  "ob.conv.read.deferred":
+    "The read is paused for now. I will pick it up again automatically.",
+  "ob.conv.clarify.intro":
+    "One thing I need you to decide. The site is ambiguous here.",
+  "ob.conv.clarify.entity":
+    "The site names more than one legal entity. Which one is this installation?",
+  "ob.conv.review.ready":
+    "I prepared the mapping. Review it and confirm what is right.",
+  "ob.conv.company.confirmed":
+    "Company profile confirmed. Everything I stored carries its source.",
+  "ob.conv.manual.chosen": "I will type it in myself.",
+  "ob.conv.voice.invite":
+    "Want me to learn how you write? Share a few texts you wrote and drafts will sound like you.",
+  "ob.conv.voice.optIn": "Yes, learn my voice.",
+  "ob.conv.voice.skipped": "Skip voice for now.",
+  "ob.conv.voice.uploadAdded": "Added {name}.",
+  "ob.conv.voice.speakerQuestion":
+    "This transcript has several speakers. Which one is you? Only your own words count.",
+  "ob.conv.corpus.words": "Your corpus now holds {words} of your own words.",
+  "ob.conv.corpus.band": "Corpus quality moved to {band}.",
+  "ob.conv.build.snapshot": "Locking in your corpus.",
+  "ob.conv.build.extract": "Finding your signature moves.",
+  "ob.conv.build.evaluate": "Testing drafts against held out samples.",
+  "ob.conv.build.activate": "Activating your voice profile.",
+  "ob.conv.build.succeeded": "Your voice profile is ready.",
+  "ob.conv.build.deferred":
+    "The build is queued behind budget. It will run automatically.",
+  "ob.conv.build.failed":
+    "The build did not finish. Your texts are kept, you can retry anytime.",
+  "ob.conv.recap":
+    "Here is what your CRM knows now, with a source for every item.",
+  "ob.conv.consent":
+    "Last step: what may I capture, and for which purpose? Nothing is on by default.",
+  "ob.conv.done": "Setup complete. Your CRM is ready.",
+
   "auth.title": "Margince",
   "auth.checking": "Checking your session…",
   "auth.pageTitle": "Sign in · Margince",

--- a/frontend/src/screens/common.tsx
+++ b/frontend/src/screens/common.tsx
@@ -397,3 +397,9 @@ export function coldFieldLabel(
   const key = COLD_FIELD_LABELS[field];
   return key ? t(key) : field.replace(/_/g, " ");
 }
+
+// For pure (non-rendering) callers that carry the label key until a component
+// translates it — same map, same fallback contract as coldFieldLabel.
+export function coldFieldLabelKey(field: string): MessageKey | undefined {
+  return COLD_FIELD_LABELS[field];
+}

--- a/frontend/src/screens/onboarding-conversation/conversation-machine.test.ts
+++ b/frontend/src/screens/onboarding-conversation/conversation-machine.test.ts
@@ -1,0 +1,268 @@
+import { describe, expect, it } from "vitest";
+import {
+  type ConversationEvent,
+  type ConversationQuestion,
+  type ConversationState,
+  conversationReducer,
+  initialConversationState,
+  THREAD_CAP,
+} from "./conversation-machine";
+
+// The reducer is the whole conversation: these tests walk the transition
+// table end to end, prove illegal events are inert, and pin the member path
+// and the thread cap.
+
+function run(
+  events: readonly ConversationEvent[],
+  from: ConversationState = initialConversationState,
+): ConversationState {
+  return events.reduce(conversationReducer, from);
+}
+
+const entityQuestion: ConversationQuestion = {
+  id: "clarify-entity",
+  i18nKey: "ob.conv.clarify.entity",
+  options: [
+    { value: "acme-gmbh", label: "Acme GmbH" },
+    { value: "acme-holding", label: "Acme Holding SE" },
+  ],
+};
+
+const speakerQuestion: ConversationQuestion = {
+  id: "speaker",
+  i18nKey: "ob.conv.voice.speakerQuestion",
+  options: [
+    { value: "Speaker 1", label: "Speaker 1" },
+    { value: "Speaker 2", label: "Speaker 2" },
+  ],
+};
+
+describe("conversationReducer happy path", () => {
+  it("walks the creator journey across all five acts", () => {
+    let state = run([{ type: "START", memberPath: false }]);
+    expect(state).toMatchObject({ act: "company", phase: "co.intro" });
+
+    state = run(
+      [
+        { type: "URL_SUBMITTED", url: "https://acme.example" },
+        { type: "READ_STARTED" },
+        {
+          type: "NARRATION",
+          entry: {
+            kind: "narration",
+            id: "pages:3",
+            i18nKey: "ob.conv.read.pages",
+            params: { pages: 3 },
+          },
+        },
+      ],
+      state,
+    );
+    expect(state.phase).toBe("co.reading");
+    expect(state.thread.map((entry) => entry.kind)).toEqual([
+      "user",
+      "narration",
+    ]);
+
+    state = run([{ type: "CLARIFY", question: entityQuestion }], state);
+    expect(state.phase).toBe("co.clarify");
+    expect(state.pendingQuestion?.id).toBe("clarify-entity");
+
+    state = run(
+      [
+        {
+          type: "QUESTION_ANSWERED",
+          questionId: "clarify-entity",
+          value: "acme-gmbh",
+        },
+      ],
+      state,
+    );
+    expect(state.phase).toBe("co.reading");
+    expect(state.pendingQuestion).toBeNull();
+    expect(state.thread.at(-1)).toMatchObject({
+      kind: "user",
+      text: "Acme GmbH",
+    });
+
+    state = run(
+      [
+        { type: "READ_TERMINAL", status: "ready" },
+        { type: "REVIEW_READY" },
+        { type: "COMPANY_CONFIRMED" },
+      ],
+      state,
+    );
+    expect(state).toMatchObject({ act: "voice", phase: "vo.invite" });
+    expect(state.thread.at(-1)).toMatchObject({
+      kind: "outcome",
+      i18nKey: "ob.conv.company.confirmed",
+    });
+
+    state = run(
+      [
+        { type: "VOICE_OPT_IN" },
+        { type: "UPLOAD_ADDED", id: "u1", name: "call.vtt" },
+        { type: "SPEAKER_NEEDED", question: speakerQuestion },
+        {
+          type: "QUESTION_ANSWERED",
+          questionId: "speaker",
+          value: "Speaker 1",
+        },
+        { type: "BUILD_STARTED" },
+        { type: "BUILD_STAGE", stage: "snapshot" },
+        { type: "BUILD_STAGE", stage: "extract" },
+        { type: "BUILD_STAGE", stage: "evaluate" },
+        { type: "BUILD_STAGE", stage: "activate" },
+        { type: "BUILD_TERMINAL", status: "succeeded" },
+      ],
+      state,
+    );
+    expect(state).toMatchObject({ act: "voice", phase: "vo.result" });
+    expect(state.thread.at(-1)).toMatchObject({
+      kind: "outcome",
+      i18nKey: "ob.conv.build.succeeded",
+    });
+
+    state = run([{ type: "RESULTS_CONTINUE" }], state);
+    expect(state).toMatchObject({ act: "results", phase: "re.recap" });
+
+    state = run(
+      [{ type: "RESULTS_CONTINUE" }, { type: "CONNECT_DONE" }],
+      state,
+    );
+    expect(state).toMatchObject({ act: "done", phase: "cn.done" });
+  });
+
+  it("records a failed read as an outcome and allows the manual path out", () => {
+    let state = run([
+      { type: "START", memberPath: false },
+      { type: "READ_STARTED" },
+      { type: "READ_TERMINAL", status: "failed" },
+    ]);
+    expect(state.phase).toBe("co.reading");
+    expect(state.thread.at(-1)).toMatchObject({
+      kind: "outcome",
+      i18nKey: "ob.conv.read.failed",
+    });
+
+    state = run(
+      [{ type: "MANUAL_CHOSEN" }, { type: "COMPANY_CONFIRMED" }],
+      state,
+    );
+    expect(state).toMatchObject({ act: "voice", phase: "vo.invite" });
+  });
+
+  it("lets the voice act be skipped and still reach the recap", () => {
+    const state = run([
+      { type: "START", memberPath: false },
+      { type: "READ_STARTED" },
+      { type: "REVIEW_READY" },
+      { type: "COMPANY_CONFIRMED" },
+      { type: "VOICE_SKIPPED" },
+      { type: "RESULTS_CONTINUE" },
+    ]);
+    expect(state).toMatchObject({ act: "results", phase: "re.recap" });
+    expect(
+      state.thread.some(
+        (entry) =>
+          entry.kind === "user" && entry.i18nKey === "ob.conv.voice.skipped",
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("illegal events are ignored, never thrown", () => {
+  it("returns the identical state for events outside the current phase", () => {
+    const started = run([{ type: "START", memberPath: false }]);
+    const illegal: ConversationEvent[] = [
+      { type: "BUILD_TERMINAL", status: "succeeded" },
+      { type: "COMPANY_CONFIRMED" },
+      { type: "VOICE_OPT_IN" },
+      { type: "CONNECT_DONE" },
+      { type: "REVIEW_READY" },
+      { type: "START", memberPath: true },
+    ];
+    for (const event of illegal) {
+      expect(conversationReducer(started, event)).toBe(started);
+    }
+  });
+
+  it("ignores an answer to a question that is not pending", () => {
+    const state = run([
+      { type: "START", memberPath: false },
+      { type: "READ_STARTED" },
+      { type: "CLARIFY", question: entityQuestion },
+    ]);
+    const answered = conversationReducer(state, {
+      type: "QUESTION_ANSWERED",
+      questionId: "some-other-question",
+      value: "acme-gmbh",
+    });
+    expect(answered).toBe(state);
+  });
+});
+
+describe("member path", () => {
+  it("confirming company jumps straight to consent, skipping voice and results", () => {
+    const state = run([
+      { type: "START", memberPath: true },
+      { type: "READ_STARTED" },
+      { type: "REVIEW_READY" },
+      { type: "COMPANY_CONFIRMED" },
+    ]);
+    expect(state).toMatchObject({ act: "connect", phase: "cn.consent" });
+  });
+
+  it("ignores every creator-only event", () => {
+    const state = run([
+      { type: "START", memberPath: true },
+      { type: "READ_STARTED" },
+      { type: "REVIEW_READY" },
+      { type: "COMPANY_CONFIRMED" },
+    ]);
+    const creatorOnly: ConversationEvent[] = [
+      { type: "VOICE_OPT_IN" },
+      { type: "VOICE_SKIPPED" },
+      { type: "UPLOAD_ADDED", id: "u1", name: "notes.txt" },
+      { type: "SPEAKER_NEEDED", question: speakerQuestion },
+      { type: "BUILD_STARTED" },
+      { type: "BUILD_STAGE", stage: "snapshot" },
+      { type: "BUILD_TERMINAL", status: "succeeded" },
+      { type: "RESULTS_CONTINUE" },
+    ];
+    for (const event of creatorOnly) {
+      expect(conversationReducer(state, event)).toBe(state);
+    }
+    const done = conversationReducer(state, { type: "CONNECT_DONE" });
+    expect(done).toMatchObject({ act: "done", phase: "cn.done" });
+  });
+});
+
+describe("thread cap", () => {
+  it("caps the thread and drops the oldest narration before anything else", () => {
+    let state = run([
+      { type: "START", memberPath: false },
+      { type: "URL_SUBMITTED", url: "https://acme.example" },
+      { type: "READ_STARTED" },
+    ]);
+    for (let index = 0; index < THREAD_CAP + 20; index += 1) {
+      state = conversationReducer(state, {
+        type: "NARRATION",
+        entry: {
+          kind: "narration",
+          id: `n:${index}`,
+          i18nKey: "ob.conv.read.pages",
+          params: { pages: index },
+        },
+      });
+    }
+    expect(state.thread.length).toBe(THREAD_CAP);
+    // The user's URL turn survives; the oldest narrations are gone.
+    expect(state.thread[0]).toMatchObject({ kind: "user" });
+    expect(
+      state.thread.some((entry) => entry.id === "n:0" || entry.id === "n:19"),
+    ).toBe(false);
+    expect(state.thread.at(-1)?.id).toBe(`n:${THREAD_CAP + 19}`);
+  });
+});

--- a/frontend/src/screens/onboarding-conversation/conversation-machine.test.ts
+++ b/frontend/src/screens/onboarding-conversation/conversation-machine.test.ts
@@ -9,8 +9,8 @@ import {
 } from "./conversation-machine";
 
 // The reducer is the whole conversation: these tests walk the transition
-// table end to end, prove illegal events are inert, and pin the member path
-// and the thread cap.
+// table end to end, prove illegal and stale events are inert, and pin the
+// member path, the retry semantics, and the thread cap.
 
 function run(
   events: readonly ConversationEvent[],
@@ -45,9 +45,10 @@ describe("conversationReducer happy path", () => {
     state = run(
       [
         { type: "URL_SUBMITTED", url: "https://acme.example" },
-        { type: "READ_STARTED" },
+        { type: "READ_STARTED", readId: "r1" },
         {
           type: "NARRATION",
+          readId: "r1",
           entry: {
             kind: "narration",
             id: "pages:3",
@@ -59,12 +60,16 @@ describe("conversationReducer happy path", () => {
       state,
     );
     expect(state.phase).toBe("co.reading");
+    expect(state.activeReadId).toBe("r1");
     expect(state.thread.map((entry) => entry.kind)).toEqual([
       "user",
       "narration",
     ]);
 
-    state = run([{ type: "CLARIFY", question: entityQuestion }], state);
+    state = run(
+      [{ type: "CLARIFY", readId: "r1", question: entityQuestion }],
+      state,
+    );
     expect(state.phase).toBe("co.clarify");
     expect(state.pendingQuestion?.id).toBe("clarify-entity");
 
@@ -87,7 +92,7 @@ describe("conversationReducer happy path", () => {
 
     state = run(
       [
-        { type: "READ_TERMINAL", status: "ready" },
+        { type: "READ_TERMINAL", readId: "r1", status: "ready", findings: 6 },
         { type: "REVIEW_READY" },
         { type: "COMPANY_CONFIRMED" },
       ],
@@ -97,7 +102,12 @@ describe("conversationReducer happy path", () => {
     expect(state.thread.at(-1)).toMatchObject({
       kind: "outcome",
       i18nKey: "ob.conv.company.confirmed",
+      tone: "success",
     });
+    const readOutcome = state.thread.find(
+      (entry) => entry.kind === "outcome" && entry.id.endsWith("read:ready"),
+    );
+    expect(readOutcome).toMatchObject({ params: { count: 6 } });
 
     state = run(
       [
@@ -122,6 +132,7 @@ describe("conversationReducer happy path", () => {
     expect(state.thread.at(-1)).toMatchObject({
       kind: "outcome",
       i18nKey: "ob.conv.build.succeeded",
+      tone: "success",
     });
 
     state = run([{ type: "RESULTS_CONTINUE" }], state);
@@ -134,16 +145,17 @@ describe("conversationReducer happy path", () => {
     expect(state).toMatchObject({ act: "done", phase: "cn.done" });
   });
 
-  it("records a failed read as an outcome and allows the manual path out", () => {
+  it("records a failed read as a failure outcome and allows the manual path out", () => {
     let state = run([
       { type: "START", memberPath: false },
-      { type: "READ_STARTED" },
-      { type: "READ_TERMINAL", status: "failed" },
+      { type: "READ_STARTED", readId: "r1" },
+      { type: "READ_TERMINAL", readId: "r1", status: "failed", findings: 0 },
     ]);
     expect(state.phase).toBe("co.reading");
     expect(state.thread.at(-1)).toMatchObject({
       kind: "outcome",
       i18nKey: "ob.conv.read.failed",
+      tone: "failure",
     });
 
     state = run(
@@ -156,7 +168,7 @@ describe("conversationReducer happy path", () => {
   it("lets the voice act be skipped and still reach the recap", () => {
     const state = run([
       { type: "START", memberPath: false },
-      { type: "READ_STARTED" },
+      { type: "READ_STARTED", readId: "r1" },
       { type: "REVIEW_READY" },
       { type: "COMPANY_CONFIRMED" },
       { type: "VOICE_SKIPPED" },
@@ -172,34 +184,235 @@ describe("conversationReducer happy path", () => {
   });
 });
 
-describe("illegal events are ignored, never thrown", () => {
-  it("returns the identical state for events outside the current phase", () => {
-    const started = run([{ type: "START", memberPath: false }]);
-    const illegal: ConversationEvent[] = [
-      { type: "BUILD_TERMINAL", status: "succeeded" },
+describe("the welcome act", () => {
+  it("rejects every event except START", () => {
+    const notStart: ConversationEvent[] = [
+      { type: "URL_SUBMITTED", url: "https://acme.example" },
+      { type: "READ_STARTED", readId: "r1" },
+      { type: "MANUAL_CHOSEN" },
       { type: "COMPANY_CONFIRMED" },
-      { type: "VOICE_OPT_IN" },
+      { type: "RESUME" },
       { type: "CONNECT_DONE" },
-      { type: "REVIEW_READY" },
-      { type: "START", memberPath: true },
     ];
-    for (const event of illegal) {
-      expect(conversationReducer(started, event)).toBe(started);
+    for (const event of notStart) {
+      expect(conversationReducer(initialConversationState, event)).toBe(
+        initialConversationState,
+      );
+    }
+  });
+});
+
+describe("read-run correlation", () => {
+  const midRead = () =>
+    run([
+      { type: "START", memberPath: false },
+      { type: "READ_STARTED", readId: "r1" },
+      { type: "URL_SUBMITTED", url: "https://other.example" },
+      { type: "READ_STARTED", readId: "r2" },
+    ]);
+
+  it("ignores terminal, clarify, and narration events from a superseded read", () => {
+    const state = midRead();
+    expect(state.activeReadId).toBe("r2");
+    const stale: ConversationEvent[] = [
+      { type: "READ_TERMINAL", readId: "r1", status: "ready", findings: 4 },
+      { type: "CLARIFY", readId: "r1", question: entityQuestion },
+      {
+        type: "NARRATION",
+        readId: "r1",
+        entry: {
+          kind: "narration",
+          id: "pages:9",
+          i18nKey: "ob.conv.read.pages",
+          params: { pages: 9 },
+        },
+      },
+    ];
+    for (const event of stale) {
+      expect(conversationReducer(state, event)).toBe(state);
     }
   });
 
+  it("still accepts the active read's events and run-agnostic narration", () => {
+    const state = midRead();
+    const advanced = conversationReducer(state, {
+      type: "READ_TERMINAL",
+      readId: "r2",
+      status: "ready",
+      findings: 2,
+    });
+    expect(advanced).not.toBe(state);
+    const narrated = conversationReducer(state, {
+      type: "NARRATION",
+      entry: { kind: "narration", id: "recap", i18nKey: "ob.conv.recap" },
+    });
+    expect(narrated.thread.length).toBe(state.thread.length + 1);
+  });
+});
+
+describe("clarify interplay with read terminals", () => {
+  const clarifying = () =>
+    run([
+      { type: "START", memberPath: false },
+      { type: "READ_STARTED", readId: "r1" },
+      { type: "CLARIFY", readId: "r1", question: entityQuestion },
+    ]);
+
+  it("a finished read never strands the pending question: co.clarify holds, outcome queues", () => {
+    let state = conversationReducer(clarifying(), {
+      type: "READ_TERMINAL",
+      readId: "r1",
+      status: "ready",
+      findings: 3,
+    });
+    expect(state.phase).toBe("co.clarify");
+    expect(state.pendingQuestion?.id).toBe("clarify-entity");
+    expect(state.thread.at(-1)).toMatchObject({
+      kind: "outcome",
+      i18nKey: "ob.conv.read.done",
+    });
+
+    state = conversationReducer(state, {
+      type: "QUESTION_ANSWERED",
+      questionId: "clarify-entity",
+      value: "acme-holding",
+    });
+    expect(state.phase).toBe("co.reading");
+    expect(state.pendingQuestion).toBeNull();
+  });
+
+  it("a failed read moots the question explicitly", () => {
+    const state = conversationReducer(clarifying(), {
+      type: "READ_TERMINAL",
+      readId: "r1",
+      status: "failed",
+      findings: 0,
+    });
+    expect(state.phase).toBe("co.reading");
+    expect(state.pendingQuestion).toBeNull();
+    expect(state.thread.at(-1)).toMatchObject({ tone: "failure" });
+  });
+});
+
+describe("question answering guards", () => {
   it("ignores an answer to a question that is not pending", () => {
     const state = run([
       { type: "START", memberPath: false },
-      { type: "READ_STARTED" },
-      { type: "CLARIFY", question: entityQuestion },
+      { type: "READ_STARTED", readId: "r1" },
+      { type: "CLARIFY", readId: "r1", question: entityQuestion },
     ]);
-    const answered = conversationReducer(state, {
-      type: "QUESTION_ANSWERED",
-      questionId: "some-other-question",
-      value: "acme-gmbh",
+    expect(
+      conversationReducer(state, {
+        type: "QUESTION_ANSWERED",
+        questionId: "some-other-question",
+        value: "acme-gmbh",
+      }),
+    ).toBe(state);
+  });
+
+  it("ignores a value outside the pending question's options", () => {
+    const state = run([
+      { type: "START", memberPath: false },
+      { type: "READ_STARTED", readId: "r1" },
+      { type: "CLARIFY", readId: "r1", question: entityQuestion },
+    ]);
+    expect(
+      conversationReducer(state, {
+        type: "QUESTION_ANSWERED",
+        questionId: "clarify-entity",
+        value: "not-an-option",
+      }),
+    ).toBe(state);
+  });
+});
+
+describe("entry identity", () => {
+  it("stamps every appended entry uniquely, so a retried URL never collides", () => {
+    const state = run([
+      { type: "START", memberPath: false },
+      { type: "URL_SUBMITTED", url: "https://acme.example" },
+      { type: "READ_STARTED", readId: "r1" },
+      { type: "READ_TERMINAL", readId: "r1", status: "failed", findings: 0 },
+      { type: "URL_SUBMITTED", url: "https://acme.example" },
+      { type: "READ_STARTED", readId: "r2" },
+      { type: "READ_TERMINAL", readId: "r2", status: "failed", findings: 0 },
+    ]);
+    const ids = state.thread.map((entry) => entry.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(
+      ids.filter((id) => id.endsWith(":url:https://acme.example")),
+    ).toHaveLength(2);
+    expect(ids.filter((id) => id.endsWith(":read:failed"))).toHaveLength(2);
+  });
+});
+
+describe("voice build", () => {
+  const built = (status: "succeeded" | "failed" | "deferred") =>
+    run([
+      { type: "START", memberPath: false },
+      { type: "READ_STARTED", readId: "r1" },
+      { type: "REVIEW_READY" },
+      { type: "COMPANY_CONFIRMED" },
+      { type: "VOICE_OPT_IN" },
+      { type: "BUILD_STARTED" },
+      { type: "BUILD_STAGE", stage: "snapshot" },
+      { type: "BUILD_TERMINAL", status },
+    ]);
+
+  it("dedupes a repeated stage poll", () => {
+    const state = run([
+      { type: "START", memberPath: false },
+      { type: "READ_STARTED", readId: "r1" },
+      { type: "REVIEW_READY" },
+      { type: "COMPANY_CONFIRMED" },
+      { type: "VOICE_OPT_IN" },
+      { type: "BUILD_STARTED" },
+      { type: "BUILD_STAGE", stage: "snapshot" },
+    ]);
+    expect(
+      conversationReducer(state, { type: "BUILD_STAGE", stage: "snapshot" }),
+    ).toBe(state);
+    const advanced = conversationReducer(state, {
+      type: "BUILD_STAGE",
+      stage: "extract",
     });
-    expect(answered).toBe(state);
+    expect(advanced.thread.length).toBe(state.thread.length + 1);
+  });
+
+  it("allows retrying only a FAILED build from the result phase", () => {
+    const failed = built("failed");
+    const retried = conversationReducer(failed, { type: "BUILD_STARTED" });
+    expect(retried.phase).toBe("vo.building");
+
+    const succeeded = built("succeeded");
+    expect(conversationReducer(succeeded, { type: "BUILD_STARTED" })).toBe(
+      succeeded,
+    );
+    const deferred = built("deferred");
+    expect(conversationReducer(deferred, { type: "BUILD_STARTED" })).toBe(
+      deferred,
+    );
+  });
+});
+
+describe("restore normalization out of co.confirmed", () => {
+  const restored = (memberPath: boolean): ConversationState => ({
+    ...initialConversationState,
+    act: "company",
+    phase: "co.confirmed",
+    memberPath,
+  });
+
+  it("routes a restored creator to the voice invite", () => {
+    expect(
+      conversationReducer(restored(false), { type: "RESUME" }),
+    ).toMatchObject({ act: "voice", phase: "vo.invite" });
+  });
+
+  it("routes a restored member to consent", () => {
+    expect(
+      conversationReducer(restored(true), { type: "RESUME" }),
+    ).toMatchObject({ act: "connect", phase: "cn.consent" });
   });
 });
 
@@ -207,7 +420,7 @@ describe("member path", () => {
   it("confirming company jumps straight to consent, skipping voice and results", () => {
     const state = run([
       { type: "START", memberPath: true },
-      { type: "READ_STARTED" },
+      { type: "READ_STARTED", readId: "r1" },
       { type: "REVIEW_READY" },
       { type: "COMPANY_CONFIRMED" },
     ]);
@@ -217,7 +430,7 @@ describe("member path", () => {
   it("ignores every creator-only event", () => {
     const state = run([
       { type: "START", memberPath: true },
-      { type: "READ_STARTED" },
+      { type: "READ_STARTED", readId: "r1" },
       { type: "REVIEW_READY" },
       { type: "COMPANY_CONFIRMED" },
     ]);
@@ -244,11 +457,12 @@ describe("thread cap", () => {
     let state = run([
       { type: "START", memberPath: false },
       { type: "URL_SUBMITTED", url: "https://acme.example" },
-      { type: "READ_STARTED" },
+      { type: "READ_STARTED", readId: "r1" },
     ]);
     for (let index = 0; index < THREAD_CAP + 20; index += 1) {
       state = conversationReducer(state, {
         type: "NARRATION",
+        readId: "r1",
         entry: {
           kind: "narration",
           id: `n:${index}`,
@@ -261,8 +475,12 @@ describe("thread cap", () => {
     // The user's URL turn survives; the oldest narrations are gone.
     expect(state.thread[0]).toMatchObject({ kind: "user" });
     expect(
-      state.thread.some((entry) => entry.id === "n:0" || entry.id === "n:19"),
+      state.thread.some(
+        (entry) => entry.id.endsWith(":n:0") || entry.id.endsWith(":n:19"),
+      ),
     ).toBe(false);
-    expect(state.thread.at(-1)?.id).toBe(`n:${THREAD_CAP + 19}`);
+    expect(state.thread.at(-1)?.id.endsWith(`:n:${THREAD_CAP + 19}`)).toBe(
+      true,
+    );
   });
 });

--- a/frontend/src/screens/onboarding-conversation/conversation-machine.ts
+++ b/frontend/src/screens/onboarding-conversation/conversation-machine.ts
@@ -1,0 +1,409 @@
+import type { MessageKey } from "../../i18n/en";
+
+// The onboarding conversation as a pure reducer. Every legal move lives in
+// the transition table below; an event that is not legal in the current
+// phase returns the state unchanged, so a stale poll or a double click can
+// never corrupt the conversation. React effects hold no hidden state: the
+// thread, the pending question, and the act/phase pair ARE the conversation.
+
+export type ConversationAct =
+  | "welcome"
+  | "company"
+  | "voice"
+  | "results"
+  | "connect"
+  | "done";
+
+export type ConversationPhase =
+  | "co.intro"
+  | "co.reading"
+  | "co.clarify"
+  | "co.review"
+  | "co.manual"
+  // Reserved for the restore path: a returning session whose company is
+  // already confirmed re-enters here. Live confirmation advances straight
+  // to the next act because a reducer cannot self-advance out of a
+  // momentary state.
+  | "co.confirmed"
+  | "vo.invite"
+  | "vo.collecting"
+  | "vo.speaker"
+  | "vo.building"
+  | "vo.result"
+  | "vo.skipped"
+  | "re.recap"
+  | "cn.consent"
+  | "cn.done";
+
+export type QuestionOption = {
+  value: string;
+  labelKey?: MessageKey;
+  label?: string;
+  detailKey?: MessageKey;
+  params?: Record<string, string | number>;
+};
+
+export type ConversationQuestion = {
+  id: string;
+  i18nKey: MessageKey;
+  params?: Record<string, string | number>;
+  options: QuestionOption[];
+};
+
+export type ThreadEntry =
+  | {
+      kind: "narration";
+      id: string;
+      i18nKey: MessageKey;
+      params?: Record<string, string | number>;
+      findingIds?: string[];
+    }
+  | { kind: "question"; id: string; question: ConversationQuestion }
+  | {
+      kind: "user";
+      id: string;
+      i18nKey?: MessageKey;
+      text?: string;
+      params?: Record<string, string | number>;
+    }
+  | {
+      kind: "outcome";
+      id: string;
+      i18nKey: MessageKey;
+      params?: Record<string, string | number>;
+    };
+
+export type NarrationEntry = Extract<ThreadEntry, { kind: "narration" }>;
+
+export type ConversationState = {
+  act: ConversationAct;
+  phase: ConversationPhase;
+  memberPath: boolean;
+  pendingQuestion: ConversationQuestion | null;
+  thread: ThreadEntry[];
+};
+
+export type ReadTerminalStatus = "ready" | "partial" | "failed" | "deferred";
+export type BuildStage = "snapshot" | "extract" | "evaluate" | "activate";
+export type BuildTerminalStatus = "succeeded" | "failed" | "deferred";
+
+export type ConversationEvent =
+  | { type: "START"; memberPath: boolean }
+  | { type: "URL_SUBMITTED"; url: string }
+  | { type: "READ_STARTED" }
+  | { type: "NARRATION"; entry: NarrationEntry }
+  | { type: "READ_TERMINAL"; status: ReadTerminalStatus }
+  | { type: "CLARIFY"; question: ConversationQuestion }
+  | { type: "QUESTION_ANSWERED"; questionId: string; value: string }
+  | { type: "REVIEW_READY" }
+  | { type: "MANUAL_CHOSEN" }
+  | { type: "COMPANY_CONFIRMED" }
+  | { type: "VOICE_OPT_IN" }
+  | { type: "VOICE_SKIPPED" }
+  | { type: "UPLOAD_ADDED"; id: string; name: string }
+  | { type: "SPEAKER_NEEDED"; question: ConversationQuestion }
+  | { type: "BUILD_STARTED" }
+  | { type: "BUILD_STAGE"; stage: BuildStage }
+  | { type: "BUILD_TERMINAL"; status: BuildTerminalStatus }
+  | { type: "RESULTS_CONTINUE" }
+  | { type: "CONNECT_DONE" };
+
+export const initialConversationState: ConversationState = {
+  act: "welcome",
+  phase: "co.intro",
+  memberPath: false,
+  pendingQuestion: null,
+  thread: [],
+};
+
+// A member joining an existing installation only confirms company context and
+// consent; voice and results events belong to the creator path exclusively.
+const creatorOnlyEvents = new Set<ConversationEvent["type"]>([
+  "VOICE_OPT_IN",
+  "VOICE_SKIPPED",
+  "UPLOAD_ADDED",
+  "SPEAKER_NEEDED",
+  "BUILD_STARTED",
+  "BUILD_STAGE",
+  "BUILD_TERMINAL",
+  "RESULTS_CONTINUE",
+]);
+
+// Narration streams only while the machine is actively reading or building;
+// a late poll after a phase moved on is dropped, not displayed out of order.
+const narrationPhases = new Set<ConversationPhase>([
+  "co.reading",
+  "co.clarify",
+  "co.review",
+  "vo.collecting",
+  "vo.speaker",
+  "vo.building",
+]);
+
+const readTerminalKeys: Record<ReadTerminalStatus, MessageKey> = {
+  ready: "ob.conv.read.done",
+  partial: "ob.conv.read.partial",
+  failed: "ob.conv.read.failed",
+  deferred: "ob.conv.read.deferred",
+};
+
+const buildStageKeys: Record<BuildStage, MessageKey> = {
+  snapshot: "ob.conv.build.snapshot",
+  extract: "ob.conv.build.extract",
+  evaluate: "ob.conv.build.evaluate",
+  activate: "ob.conv.build.activate",
+};
+
+const buildTerminalKeys: Record<BuildTerminalStatus, MessageKey> = {
+  succeeded: "ob.conv.build.succeeded",
+  failed: "ob.conv.build.failed",
+  deferred: "ob.conv.build.deferred",
+};
+
+export const THREAD_CAP = 200;
+
+// The thread is a working transcript, not an archive. Past the cap the oldest
+// narration goes first: questions, answers, and outcomes carry decisions and
+// must outlive ambient progress chatter.
+function appendEntries(
+  thread: readonly ThreadEntry[],
+  entries: readonly ThreadEntry[],
+): ThreadEntry[] {
+  const next = [...thread, ...entries];
+  while (next.length > THREAD_CAP) {
+    const oldestNarration = next.findIndex(
+      (entry) => entry.kind === "narration",
+    );
+    next.splice(oldestNarration === -1 ? 0 : oldestNarration, 1);
+  }
+  return next;
+}
+
+function withEntries(
+  state: ConversationState,
+  patch: Partial<Omit<ConversationState, "thread">>,
+  entries: readonly ThreadEntry[] = [],
+): ConversationState {
+  return {
+    ...state,
+    ...patch,
+    thread: entries.length
+      ? appendEntries(state.thread, entries)
+      : state.thread,
+  };
+}
+
+// The transition table: the phases in which each event is legal. Two events
+// carry an extra guard in isLegal — START also requires the welcome act, and
+// QUESTION_ANSWERED must name the pending question. Everything else is
+// purely phase-scoped; an event outside its row is ignored.
+const legalPhases: Record<
+  ConversationEvent["type"],
+  ReadonlySet<ConversationPhase>
+> = {
+  START: new Set(["co.intro"]),
+  URL_SUBMITTED: new Set(["co.intro", "co.reading"]),
+  READ_STARTED: new Set(["co.intro", "co.reading"]),
+  NARRATION: narrationPhases,
+  READ_TERMINAL: new Set(["co.reading", "co.clarify"]),
+  CLARIFY: new Set(["co.reading", "co.review"]),
+  QUESTION_ANSWERED: new Set(["co.clarify", "vo.speaker"]),
+  REVIEW_READY: new Set(["co.reading"]),
+  MANUAL_CHOSEN: new Set(["co.intro", "co.reading", "co.review"]),
+  COMPANY_CONFIRMED: new Set(["co.review", "co.manual"]),
+  VOICE_OPT_IN: new Set(["vo.invite"]),
+  VOICE_SKIPPED: new Set(["vo.invite", "vo.collecting"]),
+  UPLOAD_ADDED: new Set(["vo.collecting"]),
+  SPEAKER_NEEDED: new Set(["vo.collecting"]),
+  BUILD_STARTED: new Set(["vo.collecting"]),
+  BUILD_STAGE: new Set(["vo.building"]),
+  BUILD_TERMINAL: new Set(["vo.building"]),
+  RESULTS_CONTINUE: new Set(["vo.result", "vo.skipped", "re.recap"]),
+  CONNECT_DONE: new Set(["cn.consent"]),
+};
+
+function isLegal(state: ConversationState, event: ConversationEvent): boolean {
+  if (state.memberPath && creatorOnlyEvents.has(event.type)) {
+    return false;
+  }
+  if (event.type === "START" && state.act !== "welcome") {
+    return false;
+  }
+  if (
+    event.type === "QUESTION_ANSWERED" &&
+    state.pendingQuestion?.id !== event.questionId
+  ) {
+    return false;
+  }
+  return legalPhases[event.type].has(state.phase);
+}
+
+export function conversationReducer(
+  state: ConversationState,
+  event: ConversationEvent,
+): ConversationState {
+  return isLegal(state, event) ? applyEvent(state, event) : state;
+}
+
+// Legality is already settled: every branch below only computes the next
+// state for an event the table admitted in the current phase.
+function applyEvent(
+  state: ConversationState,
+  event: ConversationEvent,
+): ConversationState {
+  switch (event.type) {
+    case "START":
+      return withEntries(state, {
+        act: "company",
+        phase: "co.intro",
+        memberPath: event.memberPath,
+      });
+    case "URL_SUBMITTED":
+      return withEntries(state, {}, [
+        { kind: "user", id: `url:${event.url}`, text: event.url },
+      ]);
+    case "READ_STARTED":
+      return withEntries(state, { phase: "co.reading" });
+    case "NARRATION":
+      return withEntries(state, {}, [event.entry]);
+    case "READ_TERMINAL":
+      return withEntries(
+        state,
+        // Any terminal read lands back in co.reading: a failed or deferred
+        // read waits there for a new URL or the manual path (its clarify, if
+        // any, is moot), a finished read waits there for REVIEW_READY.
+        {
+          phase: "co.reading",
+          pendingQuestion:
+            event.status === "ready" || event.status === "partial"
+              ? state.pendingQuestion
+              : null,
+        },
+        [
+          {
+            kind: "outcome",
+            id: `read:${event.status}`,
+            i18nKey: readTerminalKeys[event.status],
+          },
+        ],
+      );
+    case "CLARIFY":
+      return withEntries(
+        state,
+        { phase: "co.clarify", pendingQuestion: event.question },
+        [
+          {
+            kind: "question",
+            id: `question:${event.question.id}`,
+            question: event.question,
+          },
+        ],
+      );
+    case "QUESTION_ANSWERED": {
+      const option = state.pendingQuestion?.options.find(
+        (candidate) => candidate.value === event.value,
+      );
+      return withEntries(
+        state,
+        {
+          phase: state.phase === "vo.speaker" ? "vo.collecting" : "co.reading",
+          pendingQuestion: null,
+        },
+        [
+          {
+            kind: "user",
+            id: `answer:${event.questionId}`,
+            i18nKey: option?.labelKey,
+            text: option?.labelKey ? undefined : (option?.label ?? event.value),
+            params: option?.params,
+          },
+        ],
+      );
+    }
+    case "REVIEW_READY":
+      return withEntries(state, { phase: "co.review" });
+    case "MANUAL_CHOSEN":
+      return withEntries(state, { phase: "co.manual", pendingQuestion: null }, [
+        { kind: "user", id: "manual:chosen", i18nKey: "ob.conv.manual.chosen" },
+      ]);
+    case "COMPANY_CONFIRMED":
+      return withEntries(
+        state,
+        state.memberPath
+          ? { act: "connect", phase: "cn.consent" }
+          : { act: "voice", phase: "vo.invite" },
+        [
+          {
+            kind: "outcome",
+            id: "company:confirmed",
+            i18nKey: "ob.conv.company.confirmed",
+          },
+        ],
+      );
+    case "VOICE_OPT_IN":
+      return withEntries(state, { phase: "vo.collecting" }, [
+        { kind: "user", id: "voice:optin", i18nKey: "ob.conv.voice.optIn" },
+      ]);
+    case "VOICE_SKIPPED":
+      return withEntries(
+        state,
+        { phase: "vo.skipped", pendingQuestion: null },
+        [
+          {
+            kind: "user",
+            id: "voice:skipped",
+            i18nKey: "ob.conv.voice.skipped",
+          },
+        ],
+      );
+    case "UPLOAD_ADDED":
+      return withEntries(state, {}, [
+        {
+          kind: "user",
+          id: `upload:${event.id}`,
+          i18nKey: "ob.conv.voice.uploadAdded",
+          params: { name: event.name },
+        },
+      ]);
+    case "SPEAKER_NEEDED":
+      return withEntries(
+        state,
+        { phase: "vo.speaker", pendingQuestion: event.question },
+        [
+          {
+            kind: "question",
+            id: `question:${event.question.id}`,
+            question: event.question,
+          },
+        ],
+      );
+    case "BUILD_STARTED":
+      return withEntries(state, { phase: "vo.building" });
+    case "BUILD_STAGE":
+      return withEntries(state, {}, [
+        {
+          kind: "narration",
+          id: `stage:${event.stage}`,
+          i18nKey: buildStageKeys[event.stage],
+        },
+      ]);
+    case "BUILD_TERMINAL":
+      return withEntries(state, { phase: "vo.result" }, [
+        {
+          kind: "outcome",
+          id: `build:${event.status}`,
+          i18nKey: buildTerminalKeys[event.status],
+        },
+      ]);
+    case "RESULTS_CONTINUE":
+      return state.phase === "re.recap"
+        ? withEntries(state, { act: "connect", phase: "cn.consent" })
+        : withEntries(state, { act: "results", phase: "re.recap" }, [
+            { kind: "narration", id: "recap", i18nKey: "ob.conv.recap" },
+          ]);
+    case "CONNECT_DONE":
+      return withEntries(state, { act: "done", phase: "cn.done" }, [
+        { kind: "outcome", id: "connect:done", i18nKey: "ob.conv.done" },
+      ]);
+  }
+}

--- a/frontend/src/screens/onboarding-conversation/conversation-machine.ts
+++ b/frontend/src/screens/onboarding-conversation/conversation-machine.ts
@@ -1,112 +1,37 @@
 import type { MessageKey } from "../../i18n/en";
+import type {
+  BuildStage,
+  BuildTerminalStatus,
+  ConversationEvent,
+  ConversationPhase,
+  ConversationState,
+  OutcomeTone,
+  ReadTerminalStatus,
+  ThreadEntry,
+} from "./conversation-types";
 
 // The onboarding conversation as a pure reducer. Every legal move lives in
 // the transition table below; an event that is not legal in the current
 // phase returns the state unchanged, so a stale poll or a double click can
 // never corrupt the conversation. React effects hold no hidden state: the
 // thread, the pending question, and the act/phase pair ARE the conversation.
+// The vocabulary (acts, phases, entries, events) lives in
+// conversation-types.ts and is re-exported here so callers have one import.
 
-export type ConversationAct =
-  | "welcome"
-  | "company"
-  | "voice"
-  | "results"
-  | "connect"
-  | "done";
-
-export type ConversationPhase =
-  | "co.intro"
-  | "co.reading"
-  | "co.clarify"
-  | "co.review"
-  | "co.manual"
-  // Reserved for the restore path: a returning session whose company is
-  // already confirmed re-enters here. Live confirmation advances straight
-  // to the next act because a reducer cannot self-advance out of a
-  // momentary state.
-  | "co.confirmed"
-  | "vo.invite"
-  | "vo.collecting"
-  | "vo.speaker"
-  | "vo.building"
-  | "vo.result"
-  | "vo.skipped"
-  | "re.recap"
-  | "cn.consent"
-  | "cn.done";
-
-export type QuestionOption = {
-  value: string;
-  labelKey?: MessageKey;
-  label?: string;
-  detailKey?: MessageKey;
-  params?: Record<string, string | number>;
-};
-
-export type ConversationQuestion = {
-  id: string;
-  i18nKey: MessageKey;
-  params?: Record<string, string | number>;
-  options: QuestionOption[];
-};
-
-export type ThreadEntry =
-  | {
-      kind: "narration";
-      id: string;
-      i18nKey: MessageKey;
-      params?: Record<string, string | number>;
-      findingIds?: string[];
-    }
-  | { kind: "question"; id: string; question: ConversationQuestion }
-  | {
-      kind: "user";
-      id: string;
-      i18nKey?: MessageKey;
-      text?: string;
-      params?: Record<string, string | number>;
-    }
-  | {
-      kind: "outcome";
-      id: string;
-      i18nKey: MessageKey;
-      params?: Record<string, string | number>;
-    };
-
-export type NarrationEntry = Extract<ThreadEntry, { kind: "narration" }>;
-
-export type ConversationState = {
-  act: ConversationAct;
-  phase: ConversationPhase;
-  memberPath: boolean;
-  pendingQuestion: ConversationQuestion | null;
-  thread: ThreadEntry[];
-};
-
-export type ReadTerminalStatus = "ready" | "partial" | "failed" | "deferred";
-export type BuildStage = "snapshot" | "extract" | "evaluate" | "activate";
-export type BuildTerminalStatus = "succeeded" | "failed" | "deferred";
-
-export type ConversationEvent =
-  | { type: "START"; memberPath: boolean }
-  | { type: "URL_SUBMITTED"; url: string }
-  | { type: "READ_STARTED" }
-  | { type: "NARRATION"; entry: NarrationEntry }
-  | { type: "READ_TERMINAL"; status: ReadTerminalStatus }
-  | { type: "CLARIFY"; question: ConversationQuestion }
-  | { type: "QUESTION_ANSWERED"; questionId: string; value: string }
-  | { type: "REVIEW_READY" }
-  | { type: "MANUAL_CHOSEN" }
-  | { type: "COMPANY_CONFIRMED" }
-  | { type: "VOICE_OPT_IN" }
-  | { type: "VOICE_SKIPPED" }
-  | { type: "UPLOAD_ADDED"; id: string; name: string }
-  | { type: "SPEAKER_NEEDED"; question: ConversationQuestion }
-  | { type: "BUILD_STARTED" }
-  | { type: "BUILD_STAGE"; stage: BuildStage }
-  | { type: "BUILD_TERMINAL"; status: BuildTerminalStatus }
-  | { type: "RESULTS_CONTINUE" }
-  | { type: "CONNECT_DONE" };
+export type {
+  BuildStage,
+  BuildTerminalStatus,
+  ConversationAct,
+  ConversationEvent,
+  ConversationPhase,
+  ConversationQuestion,
+  ConversationState,
+  NarrationEntry,
+  OutcomeTone,
+  QuestionOption,
+  ReadTerminalStatus,
+  ThreadEntry,
+} from "./conversation-types";
 
 export const initialConversationState: ConversationState = {
   act: "welcome",
@@ -114,6 +39,10 @@ export const initialConversationState: ConversationState = {
   memberPath: false,
   pendingQuestion: null,
   thread: [],
+  seq: 0,
+  activeReadId: null,
+  lastBuildStage: null,
+  lastBuildStatus: null,
 };
 
 // A member joining an existing installation only confirms company context and
@@ -160,6 +89,12 @@ const buildTerminalKeys: Record<BuildTerminalStatus, MessageKey> = {
   deferred: "ob.conv.build.deferred",
 };
 
+const buildTerminalTones: Record<BuildTerminalStatus, OutcomeTone> = {
+  succeeded: "success",
+  failed: "failure",
+  deferred: "deferred",
+};
+
 export const THREAD_CAP = 200;
 
 // The thread is a working transcript, not an archive. Past the cap the oldest
@@ -181,22 +116,29 @@ function appendEntries(
 
 function withEntries(
   state: ConversationState,
-  patch: Partial<Omit<ConversationState, "thread">>,
+  patch: Partial<Omit<ConversationState, "thread" | "seq">>,
   entries: readonly ThreadEntry[] = [],
 ): ConversationState {
+  if (entries.length === 0) {
+    return { ...state, ...patch };
+  }
+  const stamped = entries.map((entry, offset) => ({
+    ...entry,
+    id: `${state.seq + offset}:${entry.id}`,
+  }));
   return {
     ...state,
     ...patch,
-    thread: entries.length
-      ? appendEntries(state.thread, entries)
-      : state.thread,
+    seq: state.seq + entries.length,
+    thread: appendEntries(state.thread, stamped),
   };
 }
 
-// The transition table: the phases in which each event is legal. Two events
-// carry an extra guard in isLegal — START also requires the welcome act, and
-// QUESTION_ANSWERED must name the pending question. Everything else is
-// purely phase-scoped; an event outside its row is ignored.
+// The transition table: the phases in which each event is legal. On top of
+// this, isLegal rejects everything but START in the welcome act and
+// eventGuards adds the per-event conditions (read-run identity, pending
+// question identity, build retry/dedupe). An event outside its row is
+// ignored.
 const legalPhases: Record<
   ConversationEvent["type"],
   ReadonlySet<ConversationPhase>
@@ -211,11 +153,12 @@ const legalPhases: Record<
   REVIEW_READY: new Set(["co.reading"]),
   MANUAL_CHOSEN: new Set(["co.intro", "co.reading", "co.review"]),
   COMPANY_CONFIRMED: new Set(["co.review", "co.manual"]),
+  RESUME: new Set(["co.confirmed"]),
   VOICE_OPT_IN: new Set(["vo.invite"]),
   VOICE_SKIPPED: new Set(["vo.invite", "vo.collecting"]),
   UPLOAD_ADDED: new Set(["vo.collecting"]),
   SPEAKER_NEEDED: new Set(["vo.collecting"]),
-  BUILD_STARTED: new Set(["vo.collecting"]),
+  BUILD_STARTED: new Set(["vo.collecting", "vo.result"]),
   BUILD_STAGE: new Set(["vo.building"]),
   BUILD_TERMINAL: new Set(["vo.building"]),
   RESULTS_CONTINUE: new Set(["vo.result", "vo.skipped", "re.recap"]),
@@ -223,19 +166,54 @@ const legalPhases: Record<
 };
 
 function isLegal(state: ConversationState, event: ConversationEvent): boolean {
+  // The welcome act admits exactly one move: starting the conversation.
+  if (state.act === "welcome") {
+    return event.type === "START";
+  }
+  if (event.type === "START") {
+    return false;
+  }
   if (state.memberPath && creatorOnlyEvents.has(event.type)) {
     return false;
   }
-  if (event.type === "START" && state.act !== "welcome") {
+  if (!legalPhases[event.type].has(state.phase)) {
     return false;
   }
-  if (
-    event.type === "QUESTION_ANSWERED" &&
-    state.pendingQuestion?.id !== event.questionId
-  ) {
-    return false;
+  return eventGuards(state, event);
+}
+
+function eventGuards(
+  state: ConversationState,
+  event: ConversationEvent,
+): boolean {
+  switch (event.type) {
+    // A read event from a superseded run must never advance or mis-record
+    // the current one; only the active run's events count.
+    case "READ_TERMINAL":
+    case "CLARIFY":
+      return event.readId === state.activeReadId;
+    case "NARRATION":
+      // Narration without a run id (voice corpus, build) is run-agnostic.
+      return event.readId === undefined || event.readId === state.activeReadId;
+    case "QUESTION_ANSWERED":
+      // Both the question and the chosen option must be the pending ones; an
+      // unknown value is never echoed into the thread.
+      return (
+        state.pendingQuestion?.id === event.questionId &&
+        state.pendingQuestion.options.some(
+          (option) => option.value === event.value,
+        )
+      );
+    case "BUILD_STARTED":
+      // From vo.result only a FAILED build may be retried; a succeeded or
+      // deferred build is not restartable from here.
+      return state.phase !== "vo.result" || state.lastBuildStatus === "failed";
+    case "BUILD_STAGE":
+      // A poll repeating the current stage narrates nothing new.
+      return event.stage !== state.lastBuildStage;
+    default:
+      return true;
   }
-  return legalPhases[event.type].has(state.phase);
 }
 
 export function conversationReducer(
@@ -243,6 +221,36 @@ export function conversationReducer(
   event: ConversationEvent,
 ): ConversationState {
   return isLegal(state, event) ? applyEvent(state, event) : state;
+}
+
+function applyReadTerminal(
+  state: ConversationState,
+  event: Extract<ConversationEvent, { type: "READ_TERMINAL" }>,
+): ConversationState {
+  const done = event.status === "ready" || event.status === "partial";
+  if (done) {
+    // A pending clarify question is never stranded: the outcome queues into
+    // the thread while co.clarify stays put until the question is answered.
+    return withEntries(state, {}, [
+      {
+        kind: "outcome",
+        id: `read:${event.status}`,
+        i18nKey: readTerminalKeys[event.status],
+        params: { count: event.findings },
+        tone: "success",
+      },
+    ]);
+  }
+  // A failed or deferred read moots its clarify question and waits in
+  // co.reading for a new URL or the manual path.
+  return withEntries(state, { phase: "co.reading", pendingQuestion: null }, [
+    {
+      kind: "outcome",
+      id: `read:${event.status}`,
+      i18nKey: readTerminalKeys[event.status],
+      tone: event.status === "deferred" ? "deferred" : "failure",
+    },
+  ]);
 }
 
 // Legality is already settled: every branch below only computes the next
@@ -263,30 +271,14 @@ function applyEvent(
         { kind: "user", id: `url:${event.url}`, text: event.url },
       ]);
     case "READ_STARTED":
-      return withEntries(state, { phase: "co.reading" });
+      return withEntries(state, {
+        phase: "co.reading",
+        activeReadId: event.readId,
+      });
     case "NARRATION":
       return withEntries(state, {}, [event.entry]);
     case "READ_TERMINAL":
-      return withEntries(
-        state,
-        // Any terminal read lands back in co.reading: a failed or deferred
-        // read waits there for a new URL or the manual path (its clarify, if
-        // any, is moot), a finished read waits there for REVIEW_READY.
-        {
-          phase: "co.reading",
-          pendingQuestion:
-            event.status === "ready" || event.status === "partial"
-              ? state.pendingQuestion
-              : null,
-        },
-        [
-          {
-            kind: "outcome",
-            id: `read:${event.status}`,
-            i18nKey: readTerminalKeys[event.status],
-          },
-        ],
-      );
+      return applyReadTerminal(state, event);
     case "CLARIFY":
       return withEntries(
         state,
@@ -337,8 +329,18 @@ function applyEvent(
             kind: "outcome",
             id: "company:confirmed",
             i18nKey: "ob.conv.company.confirmed",
+            tone: "success",
           },
         ],
+      );
+    case "RESUME":
+      // Restore normalization out of co.confirmed: the same routing the live
+      // confirmation takes, without repeating the confirmation outcome.
+      return withEntries(
+        state,
+        state.memberPath
+          ? { act: "connect", phase: "cn.consent" }
+          : { act: "voice", phase: "vo.invite" },
       );
     case "VOICE_OPT_IN":
       return withEntries(state, { phase: "vo.collecting" }, [
@@ -378,9 +380,13 @@ function applyEvent(
         ],
       );
     case "BUILD_STARTED":
-      return withEntries(state, { phase: "vo.building" });
+      return withEntries(state, {
+        phase: "vo.building",
+        lastBuildStage: null,
+        lastBuildStatus: null,
+      });
     case "BUILD_STAGE":
-      return withEntries(state, {}, [
+      return withEntries(state, { lastBuildStage: event.stage }, [
         {
           kind: "narration",
           id: `stage:${event.stage}`,
@@ -388,13 +394,18 @@ function applyEvent(
         },
       ]);
     case "BUILD_TERMINAL":
-      return withEntries(state, { phase: "vo.result" }, [
-        {
-          kind: "outcome",
-          id: `build:${event.status}`,
-          i18nKey: buildTerminalKeys[event.status],
-        },
-      ]);
+      return withEntries(
+        state,
+        { phase: "vo.result", lastBuildStatus: event.status },
+        [
+          {
+            kind: "outcome",
+            id: `build:${event.status}`,
+            i18nKey: buildTerminalKeys[event.status],
+            tone: buildTerminalTones[event.status],
+          },
+        ],
+      );
     case "RESULTS_CONTINUE":
       return state.phase === "re.recap"
         ? withEntries(state, { act: "connect", phase: "cn.consent" })
@@ -403,7 +414,12 @@ function applyEvent(
           ]);
     case "CONNECT_DONE":
       return withEntries(state, { act: "done", phase: "cn.done" }, [
-        { kind: "outcome", id: "connect:done", i18nKey: "ob.conv.done" },
+        {
+          kind: "outcome",
+          id: "connect:done",
+          i18nKey: "ob.conv.done",
+          tone: "success",
+        },
       ]);
   }
 }

--- a/frontend/src/screens/onboarding-conversation/conversation-types.ts
+++ b/frontend/src/screens/onboarding-conversation/conversation-types.ts
@@ -1,0 +1,131 @@
+import type { MessageKey } from "../../i18n/en";
+
+// The vocabulary of the onboarding conversation: acts, phases, thread
+// entries, and the event union the reducer in conversation-machine.ts
+// consumes. Types only — behaviour lives with the transition table.
+
+export type ConversationAct =
+  | "welcome"
+  | "company"
+  | "voice"
+  | "results"
+  | "connect"
+  | "done";
+
+export type ConversationPhase =
+  | "co.intro"
+  | "co.reading"
+  | "co.clarify"
+  | "co.review"
+  | "co.manual"
+  // The restore landing spot: a returning session whose company is already
+  // confirmed is reconstructed here, and RESUME routes it onward. Live
+  // confirmation advances straight to the next act because a reducer cannot
+  // self-advance out of a momentary state.
+  | "co.confirmed"
+  | "vo.invite"
+  | "vo.collecting"
+  | "vo.speaker"
+  | "vo.building"
+  | "vo.result"
+  | "vo.skipped"
+  | "re.recap"
+  | "cn.consent"
+  | "cn.done";
+
+export type QuestionOption = {
+  value: string;
+  labelKey?: MessageKey;
+  label?: string;
+  detailKey?: MessageKey;
+  params?: Record<string, string | number>;
+};
+
+export type ConversationQuestion = {
+  id: string;
+  i18nKey: MessageKey;
+  params?: Record<string, string | number>;
+  options: QuestionOption[];
+};
+
+export type OutcomeTone = "success" | "deferred" | "failure";
+
+// Entries enter the reducer with a semantic id (`read:ready`, `stage:extract`);
+// withEntries stamps each appended entry with the state's monotonic sequence
+// (`17:read:ready`), so a retried URL or a rebuilt stage never collides with
+// an earlier occurrence as a React key.
+export type ThreadEntry =
+  | {
+      kind: "narration";
+      id: string;
+      i18nKey: MessageKey;
+      params?: Record<string, string | number>;
+      /** Params that are i18n keys themselves; the renderer translates them. */
+      paramKeys?: Record<string, MessageKey>;
+      findingIds?: string[];
+    }
+  | { kind: "question"; id: string; question: ConversationQuestion }
+  | {
+      kind: "user";
+      id: string;
+      i18nKey?: MessageKey;
+      text?: string;
+      params?: Record<string, string | number>;
+    }
+  | {
+      kind: "outcome";
+      id: string;
+      i18nKey: MessageKey;
+      params?: Record<string, string | number>;
+      tone: OutcomeTone;
+    };
+
+export type NarrationEntry = Extract<ThreadEntry, { kind: "narration" }>;
+
+export type ConversationState = {
+  act: ConversationAct;
+  phase: ConversationPhase;
+  memberPath: boolean;
+  pendingQuestion: ConversationQuestion | null;
+  thread: ThreadEntry[];
+  /** Monotonic entry-id sequence; see ThreadEntry. */
+  seq: number;
+  /** The read run whose events are current; stale runs are ignored. */
+  activeReadId: string | null;
+  /** Last narrated build stage, so a repeated stage poll appends nothing. */
+  lastBuildStage: BuildStage | null;
+  /** How the last voice build ended; only a failed build may be retried. */
+  lastBuildStatus: BuildTerminalStatus | null;
+};
+
+export type ReadTerminalStatus = "ready" | "partial" | "failed" | "deferred";
+export type BuildStage = "snapshot" | "extract" | "evaluate" | "activate";
+export type BuildTerminalStatus = "succeeded" | "failed" | "deferred";
+
+export type ConversationEvent =
+  | { type: "START"; memberPath: boolean }
+  | { type: "URL_SUBMITTED"; url: string }
+  | { type: "READ_STARTED"; readId: string }
+  | { type: "NARRATION"; readId?: string; entry: NarrationEntry }
+  | {
+      type: "READ_TERMINAL";
+      readId: string;
+      status: ReadTerminalStatus;
+      /** Server-side finding count for the outcome copy; 0 when none. */
+      findings: number;
+    }
+  | { type: "CLARIFY"; readId: string; question: ConversationQuestion }
+  | { type: "QUESTION_ANSWERED"; questionId: string; value: string }
+  | { type: "REVIEW_READY" }
+  | { type: "MANUAL_CHOSEN" }
+  | { type: "COMPANY_CONFIRMED" }
+  | { type: "RESUME" }
+  | { type: "VOICE_OPT_IN" }
+  | { type: "VOICE_SKIPPED" }
+  | { type: "UPLOAD_ADDED"; id: string; name: string }
+  | { type: "SPEAKER_NEEDED"; question: ConversationQuestion }
+  | { type: "BUILD_STARTED" }
+  | { type: "BUILD_STAGE"; stage: BuildStage }
+  | { type: "BUILD_TERMINAL"; status: BuildTerminalStatus }
+  | { type: "RESULTS_CONTINUE" }
+  | { type: "CONNECT_DONE" };

--- a/frontend/src/screens/onboarding-conversation/conversation.css
+++ b/frontend/src/screens/onboarding-conversation/conversation.css
@@ -113,8 +113,30 @@
   flex-direction: column;
   align-items: flex-start;
   gap: var(--space-1);
+  /* Long or translated labels wrap inside a bounded chip instead of forcing
+   * the thread to scroll horizontally. */
+  white-space: normal;
+  text-align: start;
+  max-width: 24rem;
+  height: auto;
 }
 
 .ob-conv-option small {
   color: var(--textSecondary);
+}
+
+.ob-conv-outcome[data-tone="deferred"] {
+  border-inline-start-color: var(--warnBorder);
+}
+
+.ob-conv-outcome[data-tone="deferred"] svg {
+  color: var(--warn);
+}
+
+.ob-conv-outcome[data-tone="failure"] {
+  border-inline-start-color: var(--danger);
+}
+
+.ob-conv-outcome[data-tone="failure"] svg {
+  color: var(--danger);
 }

--- a/frontend/src/screens/onboarding-conversation/conversation.css
+++ b/frontend/src/screens/onboarding-conversation/conversation.css
@@ -1,0 +1,120 @@
+/* Conversation thread pieces. Colours and spacing read tokens only. */
+
+.ob-conv-thread {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  overflow-y: auto;
+  padding: var(--space-4);
+}
+
+.ob-conv-narration {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-2);
+  max-width: 44rem;
+}
+
+.ob-conv-narration p {
+  margin: 0;
+  padding: var(--space-2) var(--space-3);
+  background: var(--bgCard);
+  border-radius: var(--r-md);
+  color: var(--textContent);
+  font: 400 0.9375rem / 1.5 var(--f-body);
+}
+
+.ob-conv-speaker {
+  flex: none;
+  display: grid;
+  place-items: center;
+  inline-size: var(--space-6);
+  block-size: var(--space-6);
+  border-radius: var(--r-full);
+  background: var(--aiLight);
+  color: var(--aiText);
+  font: 600 0.75rem / 1 var(--f-display);
+}
+
+.ob-conv-user {
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-end;
+  gap: var(--space-2);
+  align-self: flex-end;
+  max-width: 40rem;
+  color: var(--textSecondary);
+}
+
+.ob-conv-user p {
+  margin: 0;
+  padding: var(--space-2) var(--space-3);
+  background: var(--accentLight);
+  border-radius: var(--r-md);
+  color: var(--textPrimary);
+  font: 400 0.9375rem / 1.5 var(--f-body);
+}
+
+.ob-conv-user svg {
+  flex: none;
+  inline-size: var(--space-4);
+  block-size: var(--space-4);
+  margin-block-start: var(--space-2);
+}
+
+.ob-conv-outcome {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  border: 1px solid var(--borderSubtle);
+  border-inline-start: var(--space-1) solid var(--success);
+  border-radius: var(--r-sm);
+  background: var(--bgElevated);
+  color: var(--textPrimary);
+}
+
+.ob-conv-outcome p {
+  margin: 0;
+  font: 500 0.9375rem / 1.4 var(--f-body);
+}
+
+.ob-conv-outcome svg {
+  flex: none;
+  inline-size: var(--space-4);
+  block-size: var(--space-4);
+  color: var(--success);
+}
+
+.ob-conv-question {
+  margin: 0;
+  padding: var(--space-3);
+  border: 1px solid var(--aiMed);
+  border-radius: var(--r-md);
+  background: var(--aiLight);
+  max-width: 44rem;
+}
+
+.ob-conv-question legend {
+  padding-inline: var(--space-1);
+  color: var(--textPrimary);
+  font: 500 0.9375rem / 1.4 var(--f-body);
+}
+
+.ob-conv-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-block-start: var(--space-2);
+}
+
+.ob-conv-option {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-1);
+}
+
+.ob-conv-option small {
+  color: var(--textSecondary);
+}

--- a/frontend/src/screens/onboarding-conversation/entries.stories.tsx
+++ b/frontend/src/screens/onboarding-conversation/entries.stories.tsx
@@ -1,0 +1,101 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { LocaleProvider } from "../../i18n";
+import type { ThreadEntry } from "./conversation-machine";
+import {
+  NarrationBubble,
+  OutcomeCard,
+  QuestionCard,
+  UserTurn,
+} from "./entries";
+import { ConversationThread } from "./thread";
+
+const meta: Meta = {
+  title: "Screens/OnboardingConversation/Entries",
+  decorators: [
+    (Story) => (
+      <LocaleProvider initial="en">
+        <Story />
+      </LocaleProvider>
+    ),
+  ],
+};
+export default meta;
+type Story = StoryObj;
+
+const narration: Extract<ThreadEntry, { kind: "narration" }> = {
+  kind: "narration",
+  id: "field:industry",
+  i18nKey: "ob.conv.read.learnedField",
+  params: { field: "industry", value: "Industrial robotics" },
+  findingIds: ["industry"],
+};
+
+const question: Extract<ThreadEntry, { kind: "question" }> = {
+  kind: "question",
+  id: "question:clarify-entity",
+  question: {
+    id: "clarify-entity",
+    i18nKey: "ob.conv.clarify.entity",
+    options: [
+      { value: "acme-gmbh", label: "Acme GmbH" },
+      { value: "acme-holding", label: "Acme Holding SE" },
+    ],
+  },
+};
+
+const userTurn: Extract<ThreadEntry, { kind: "user" }> = {
+  kind: "user",
+  id: "answer:clarify-entity",
+  text: "Acme GmbH",
+};
+
+const outcome: Extract<ThreadEntry, { kind: "outcome" }> = {
+  kind: "outcome",
+  id: "company:confirmed",
+  i18nKey: "ob.conv.company.confirmed",
+};
+
+export const Narration: Story = {
+  render: () => <NarrationBubble entry={narration} />,
+};
+
+export const Question: Story = {
+  render: () => (
+    <QuestionCard question={question.question} onAnswer={() => {}} />
+  ),
+};
+
+export const QuestionAnswered: Story = {
+  render: () => (
+    <QuestionCard question={question.question} answered onAnswer={() => {}} />
+  ),
+};
+
+export const User: Story = {
+  render: () => <UserTurn entry={userTurn} />,
+};
+
+export const Outcome: Story = {
+  render: () => <OutcomeCard entry={outcome} />,
+};
+
+export const Thread: Story = {
+  render: () => (
+    <ConversationThread
+      entries={[
+        {
+          kind: "narration",
+          id: "pages:5",
+          i18nKey: "ob.conv.read.pages",
+          params: { pages: 5 },
+        },
+        narration,
+        question,
+        userTurn,
+        outcome,
+      ]}
+      pendingQuestionId={null}
+      onAnswer={() => {}}
+    />
+  ),
+};

--- a/frontend/src/screens/onboarding-conversation/entries.stories.tsx
+++ b/frontend/src/screens/onboarding-conversation/entries.stories.tsx
@@ -24,9 +24,10 @@ type Story = StoryObj;
 
 const narration: Extract<ThreadEntry, { kind: "narration" }> = {
   kind: "narration",
-  id: "field:industry",
+  id: "1:field:industry",
   i18nKey: "ob.conv.read.learnedField",
-  params: { field: "industry", value: "Industrial robotics" },
+  params: { value: "Industrial robotics" },
+  paramKeys: { field: "ob.field.industry" },
   findingIds: ["industry"],
 };
 
@@ -51,8 +52,23 @@ const userTurn: Extract<ThreadEntry, { kind: "user" }> = {
 
 const outcome: Extract<ThreadEntry, { kind: "outcome" }> = {
   kind: "outcome",
-  id: "company:confirmed",
+  id: "4:company:confirmed",
   i18nKey: "ob.conv.company.confirmed",
+  tone: "success",
+};
+
+const deferredOutcome: Extract<ThreadEntry, { kind: "outcome" }> = {
+  kind: "outcome",
+  id: "5:build:deferred",
+  i18nKey: "ob.conv.build.deferred",
+  tone: "deferred",
+};
+
+const failureOutcome: Extract<ThreadEntry, { kind: "outcome" }> = {
+  kind: "outcome",
+  id: "6:read:failed",
+  i18nKey: "ob.conv.read.failed",
+  tone: "failure",
 };
 
 export const Narration: Story = {
@@ -79,13 +95,21 @@ export const Outcome: Story = {
   render: () => <OutcomeCard entry={outcome} />,
 };
 
+export const OutcomeDeferred: Story = {
+  render: () => <OutcomeCard entry={deferredOutcome} />,
+};
+
+export const OutcomeFailure: Story = {
+  render: () => <OutcomeCard entry={failureOutcome} />,
+};
+
 export const Thread: Story = {
   render: () => (
     <ConversationThread
       entries={[
         {
           kind: "narration",
-          id: "pages:5",
+          id: "0:pages:5",
           i18nKey: "ob.conv.read.pages",
           params: { pages: 5 },
         },

--- a/frontend/src/screens/onboarding-conversation/entries.tsx
+++ b/frontend/src/screens/onboarding-conversation/entries.tsx
@@ -1,0 +1,93 @@
+import { CircleCheck, CircleUserRound } from "lucide-react";
+import { Button } from "../../design-system/atoms";
+import { useT } from "../../i18n";
+import type { ConversationQuestion, ThreadEntry } from "./conversation-machine";
+import "./conversation.css";
+
+// Presentational pieces for the conversation thread. Copy always resolves
+// through the i18n catalogs; server-derived values (option labels, params)
+// arrive as data and render verbatim.
+
+type NarrationEntry = Extract<ThreadEntry, { kind: "narration" }>;
+type UserEntry = Extract<ThreadEntry, { kind: "user" }>;
+type OutcomeEntry = Extract<ThreadEntry, { kind: "outcome" }>;
+
+export function NarrationBubble({
+  entry,
+}: Readonly<{ entry: NarrationEntry }>) {
+  const t = useT();
+  return (
+    <div
+      className="ob-conv-narration"
+      data-finding-ids={entry.findingIds?.join(" ")}
+    >
+      <span
+        className="ob-conv-speaker"
+        role="img"
+        aria-label={t("ob.ai.speakerName")}
+      >
+        <span aria-hidden>{t("ob.ai.speaker")}</span>
+      </span>
+      <p>{t(entry.i18nKey, entry.params)}</p>
+    </div>
+  );
+}
+
+export function UserTurn({ entry }: Readonly<{ entry: UserEntry }>) {
+  const t = useT();
+  return (
+    <div className="ob-conv-user">
+      <p>{entry.i18nKey ? t(entry.i18nKey, entry.params) : entry.text}</p>
+      <CircleUserRound aria-hidden />
+    </div>
+  );
+}
+
+export function OutcomeCard({ entry }: Readonly<{ entry: OutcomeEntry }>) {
+  const t = useT();
+  return (
+    <div className="ob-conv-outcome" role="status">
+      <CircleCheck aria-hidden />
+      <p>{t(entry.i18nKey, entry.params)}</p>
+    </div>
+  );
+}
+
+type QuestionCardProps = Readonly<{
+  question: ConversationQuestion;
+  /** Set after the question is answered; options stay visible but inert. */
+  answered?: boolean;
+  onAnswer: (questionId: string, value: string) => void;
+}>;
+
+export function QuestionCard({
+  question,
+  answered = false,
+  onAnswer,
+}: QuestionCardProps) {
+  const t = useT();
+  return (
+    <fieldset className="ob-conv-question" disabled={answered}>
+      <legend>{t(question.i18nKey, question.params)}</legend>
+      <div className="ob-conv-options">
+        {question.options.map((option) => (
+          <Button
+            key={option.value}
+            small
+            className="ob-conv-option"
+            onClick={() => onAnswer(question.id, option.value)}
+          >
+            <span>
+              {option.labelKey
+                ? t(option.labelKey, option.params)
+                : option.label}
+            </span>
+            {option.detailKey && (
+              <small>{t(option.detailKey, option.params)}</small>
+            )}
+          </Button>
+        ))}
+      </div>
+    </fieldset>
+  );
+}

--- a/frontend/src/screens/onboarding-conversation/entries.tsx
+++ b/frontend/src/screens/onboarding-conversation/entries.tsx
@@ -1,16 +1,35 @@
-import { CircleCheck, CircleUserRound } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { CircleAlert, CircleCheck, CircleUserRound, Clock } from "lucide-react";
 import { Button } from "../../design-system/atoms";
 import { useT } from "../../i18n";
-import type { ConversationQuestion, ThreadEntry } from "./conversation-machine";
+import type { MessageKey } from "../../i18n/en";
+import type {
+  ConversationQuestion,
+  OutcomeTone,
+  ThreadEntry,
+} from "./conversation-machine";
 import "./conversation.css";
 
 // Presentational pieces for the conversation thread. Copy always resolves
 // through the i18n catalogs; server-derived values (option labels, params)
-// arrive as data and render verbatim.
+// arrive as data and render verbatim, while paramKeys are translated here.
 
 type NarrationEntry = Extract<ThreadEntry, { kind: "narration" }>;
 type UserEntry = Extract<ThreadEntry, { kind: "user" }>;
 type OutcomeEntry = Extract<ThreadEntry, { kind: "outcome" }>;
+
+type Translate = ReturnType<typeof useT>;
+
+function resolvedParams(
+  t: Translate,
+  params: Record<string, string | number> | undefined,
+  paramKeys: Record<string, MessageKey> | undefined,
+): Record<string, string | number> {
+  const translated = Object.fromEntries(
+    Object.entries(paramKeys ?? {}).map(([name, key]) => [name, t(key)]),
+  );
+  return { ...params, ...translated };
+}
 
 export function NarrationBubble({
   entry,
@@ -28,7 +47,9 @@ export function NarrationBubble({
       >
         <span aria-hidden>{t("ob.ai.speaker")}</span>
       </span>
-      <p>{t(entry.i18nKey, entry.params)}</p>
+      <p>
+        {t(entry.i18nKey, resolvedParams(t, entry.params, entry.paramKeys))}
+      </p>
     </div>
   );
 }
@@ -43,11 +64,20 @@ export function UserTurn({ entry }: Readonly<{ entry: UserEntry }>) {
   );
 }
 
+const outcomeIcons: Record<OutcomeTone, LucideIcon> = {
+  success: CircleCheck,
+  deferred: Clock,
+  failure: CircleAlert,
+};
+
+// No live-region role here: the surrounding thread is the announcing log,
+// and a nested one would double-announce every outcome.
 export function OutcomeCard({ entry }: Readonly<{ entry: OutcomeEntry }>) {
   const t = useT();
+  const Icon = outcomeIcons[entry.tone];
   return (
-    <div className="ob-conv-outcome" role="status">
-      <CircleCheck aria-hidden />
+    <div className="ob-conv-outcome" data-tone={entry.tone}>
+      <Icon aria-hidden />
       <p>{t(entry.i18nKey, entry.params)}</p>
     </div>
   );

--- a/frontend/src/screens/onboarding-conversation/narration.test.ts
+++ b/frontend/src/screens/onboarding-conversation/narration.test.ts
@@ -8,7 +8,9 @@ import {
   diffSiteRead,
   diffVoiceBuild,
   type NarrationEvent,
+  type NarrationSayEvent,
   useNarrationQueue,
+  type VoiceBuildSnapshot,
 } from "./narration";
 
 type CompanySiteRead = components["schemas"]["CompanySiteRead"];
@@ -16,8 +18,11 @@ type ColdStartField = components["schemas"]["ColdStartField"];
 type VoiceCorpusSummary = components["schemas"]["VoiceCorpusSummary"];
 
 // The diffs are the honesty layer: every narration event must trace back to
-// a server snapshot delta. These tests pin the deltas and the queue's pacing
-// and urgent-flush behaviour with fake timers only.
+// a server snapshot delta, and terminal copy belongs to the reducer alone —
+// the diffs only signal a flush. These tests pin the deltas and the queue's
+// pacing and flush behaviour with fake timers only.
+
+const READ_ID = "8b6e2a34-0000-4000-8000-000000000001";
 
 function field(name: ColdStartField["field"], value: string): ColdStartField {
   return {
@@ -31,7 +36,7 @@ function field(name: ColdStartField["field"], value: string): ColdStartField {
 
 function read(overrides: Partial<CompanySiteRead>): CompanySiteRead {
   return {
-    id: "8b6e2a34-0000-4000-8000-000000000001",
+    id: READ_ID,
     target_kind: "onboarding",
     root_url: "https://acme.example",
     status: "reading",
@@ -70,18 +75,36 @@ describe("diffSiteRead", () => {
     const events = diffSiteRead(prev, next);
     expect(events).toEqual([
       {
-        id: "pages:5",
+        kind: "say",
+        id: `${READ_ID}:pages:5`,
         i18nKey: "ob.conv.read.pages",
         params: { pages: 5 },
       },
-      { id: "phase:extracting", i18nKey: "ob.conv.read.extracting" },
       {
-        id: "field:industry",
+        kind: "say",
+        id: `${READ_ID}:phase:extracting`,
+        i18nKey: "ob.conv.read.extracting",
+      },
+      {
+        kind: "say",
+        id: `${READ_ID}:field:industry`,
         i18nKey: "ob.conv.read.learnedField",
-        params: { field: "industry", value: "Robotics" },
+        params: { value: "Robotics" },
+        paramKeys: { field: "ob.field.industry" },
         findingIds: ["industry"],
       },
     ]);
+  });
+
+  it("carries field labels as i18n keys, never raw backend tokens", () => {
+    const events = diffSiteRead(
+      null,
+      read({ profile_fields: [field("offer_summary", "Robots as a service")] }),
+    );
+    expect(events[0]).toMatchObject({
+      paramKeys: { field: "ob.field.offer_summary" },
+      params: { value: "Robots as a service" },
+    });
   });
 
   it("emits one event per field on the first snapshot and none on a repeat", () => {
@@ -92,14 +115,16 @@ describe("diffSiteRead", () => {
     expect(diffSiteRead(snapshot, snapshot)).toEqual([]);
   });
 
-  it("truncates long field values to the 80-character preview", () => {
-    const long = "x".repeat(120);
+  it("truncates long field values by code points to the 80-glyph preview", () => {
+    const long = "🜁".repeat(120);
     const events = diffSiteRead(
       null,
       read({ profile_fields: [field("history", long)] }),
     );
-    const value = String(events[0]?.params?.value);
-    expect(value.length).toBe(80);
+    const first = events[0];
+    if (first?.kind !== "say") throw new Error("expected a say event");
+    const value = String(first.params?.value);
+    expect(Array.from(value)).toHaveLength(80);
     expect(value.endsWith("…")).toBe(true);
   });
 
@@ -110,68 +135,85 @@ describe("diffSiteRead", () => {
     });
     expect(diffSiteRead(prev, next)).toEqual([
       {
-        id: "warning:sitemap missing",
+        kind: "say",
+        id: `${READ_ID}:warning:sitemap missing`,
         i18nKey: "ob.conv.read.warning",
         params: { warning: "sitemap missing" },
       },
     ]);
   });
 
-  it("flags terminal statuses urgent, with the server-side finding count", () => {
-    const prev = read({
-      status: "reading",
-      profile_fields: [field("display_name", "Acme")],
-    });
-    const next = read({
-      status: "ready",
-      profile_fields: [field("display_name", "Acme")],
-    });
-    const events = diffSiteRead(prev, next);
-    expect(events).toEqual([
-      {
-        id: "status:ready",
-        i18nKey: "ob.conv.read.done",
-        params: { count: 1 },
-        urgent: true,
-      },
+  it("signals a flush on a fresh terminal instead of narrating it", () => {
+    const prev = read({ status: "reading" });
+    const next = read({ status: "ready" });
+    expect(diffSiteRead(prev, next)).toEqual([
+      { kind: "flush", id: `${READ_ID}:flush:ready` },
     ]);
     // Polling the same terminal snapshot again stays silent.
     expect(diffSiteRead(next, next)).toEqual([]);
+    for (const status of ["partial", "failed", "deferred"] as const) {
+      expect(diffSiteRead(prev, read({ status }))).toEqual([
+        { kind: "flush", id: `${READ_ID}:flush:${status}` },
+      ]);
+    }
   });
 
-  it("narrates failed and deferred reads as urgent too", () => {
-    expect(diffSiteRead(read({}), read({ status: "failed" }))[0]).toMatchObject(
-      { i18nKey: "ob.conv.read.failed", urgent: true },
-    );
+  it("stays silent on post-outcome lifecycle transitions (confirmed, abandoned)", () => {
     expect(
-      diffSiteRead(read({}), read({ status: "deferred" }))[0],
-    ).toMatchObject({ i18nKey: "ob.conv.read.deferred", urgent: true });
+      diffSiteRead(read({ status: "ready" }), read({ status: "confirmed" })),
+    ).toEqual([]);
+    expect(
+      diffSiteRead(read({ status: "failed" }), read({ status: "abandoned" })),
+    ).toEqual([]);
   });
 });
 
 describe("diffVoiceBuild", () => {
-  it("narrates each stage change exactly once", () => {
-    expect(diffVoiceBuild(null, "snapshot", "running")).toEqual([
-      { id: "stage:snapshot", i18nKey: "ob.conv.build.snapshot" },
-    ]);
-    expect(diffVoiceBuild("snapshot", "extract", "running")).toEqual([
-      { id: "stage:extract", i18nKey: "ob.conv.build.extract" },
-    ]);
-    expect(diffVoiceBuild("extract", "extract", "running")).toEqual([]);
-  });
+  const snap = (
+    status: VoiceBuildSnapshot["status"],
+    stage: VoiceBuildSnapshot["stage"],
+  ): VoiceBuildSnapshot => ({ id: "b1", status, stage });
 
-  it("terminal statuses win over stage changes and are urgent", () => {
-    expect(diffVoiceBuild("evaluate", "activate", "succeeded")).toEqual([
+  it("narrates each stage change exactly once", () => {
+    expect(diffVoiceBuild(null, snap("running", "snapshot"))).toEqual([
       {
-        id: "build:succeeded",
-        i18nKey: "ob.conv.build.succeeded",
-        urgent: true,
+        kind: "say",
+        id: "b1:stage:snapshot",
+        i18nKey: "ob.conv.build.snapshot",
       },
     ]);
-    expect(diffVoiceBuild(null, null, "failed")[0]).toMatchObject({
-      i18nKey: "ob.conv.build.failed",
-      urgent: true,
-    });
+    expect(
+      diffVoiceBuild(snap("running", "snapshot"), snap("running", "extract")),
+    ).toEqual([
+      { kind: "say", id: "b1:stage:extract", i18nKey: "ob.conv.build.extract" },
+    ]);
+    expect(
+      diffVoiceBuild(snap("running", "extract"), snap("running", "extract")),
+    ).toEqual([]);
+  });
+
+  it("signals a flush on a fresh terminal, never narrating terminal copy", () => {
+    expect(
+      diffVoiceBuild(
+        snap("running", "evaluate"),
+        snap("succeeded", "activate"),
+      ),
+    ).toEqual([{ kind: "flush", id: "b1:flush:succeeded" }]);
+    expect(diffVoiceBuild(null, snap("failed", null))).toEqual([
+      { kind: "flush", id: "b1:flush:failed" },
+    ]);
+  });
+
+  it("does not re-announce an unchanged terminal on repeated polls", () => {
+    expect(
+      diffVoiceBuild(
+        snap("succeeded", "activate"),
+        snap("succeeded", "activate"),
+      ),
+    ).toEqual([]);
+    expect(diffVoiceBuild(snap("failed", null), snap("failed", null))).toEqual(
+      [],
+    );
   });
 });
 
@@ -188,17 +230,19 @@ describe("diffCorpus", () => {
     register_words: {},
   });
 
-  it("narrates word growth and band changes from server numbers only", () => {
+  it("narrates word growth and band changes, band as an i18n label key", () => {
     expect(diffCorpus(summary(400, "thin"), summary(1240, "good"))).toEqual([
       {
+        kind: "say",
         id: "words:1240",
         i18nKey: "ob.conv.corpus.words",
         params: { words: 1240 },
       },
       {
+        kind: "say",
         id: "band:good",
         i18nKey: "ob.conv.corpus.band",
-        params: { band: "good" },
+        paramKeys: { band: "settings.voice.bandGood" },
       },
     ]);
     expect(diffCorpus(summary(1240, "good"), summary(1240, "good"))).toEqual(
@@ -215,25 +259,30 @@ describe("useNarrationQueue", () => {
     vi.useRealTimers();
   });
 
-  const event = (id: string, urgent?: boolean): NarrationEvent => ({
+  const say = (id: string): NarrationSayEvent => ({
+    kind: "say",
     id,
     i18nKey: "ob.conv.read.pages",
     params: { pages: 1 },
-    ...(urgent ? { urgent } : {}),
   });
+  const flush = (id: string): NarrationEvent => ({ kind: "flush", id });
 
   it("emits the first event immediately and then one per pace window", () => {
     const onEmit = vi.fn();
     const { result } = renderHook(() => useNarrationQueue({ onEmit }));
 
-    result.current.push([event("a"), event("b"), event("c")]);
-    expect(onEmit.mock.calls.map(([e]) => e.id)).toEqual(["a"]);
+    result.current.push([say("a"), say("b"), say("c")]);
+    expect(onEmit.mock.calls.map(([event]) => event.id)).toEqual(["a"]);
 
     vi.advanceTimersByTime(DEFAULT_PACE_MS);
-    expect(onEmit.mock.calls.map(([e]) => e.id)).toEqual(["a", "b"]);
+    expect(onEmit.mock.calls.map(([event]) => event.id)).toEqual(["a", "b"]);
 
     vi.advanceTimersByTime(DEFAULT_PACE_MS);
-    expect(onEmit.mock.calls.map(([e]) => e.id)).toEqual(["a", "b", "c"]);
+    expect(onEmit.mock.calls.map(([event]) => event.id)).toEqual([
+      "a",
+      "b",
+      "c",
+    ]);
   });
 
   it("keeps pacing across separate pushes inside the same window", () => {
@@ -241,36 +290,32 @@ describe("useNarrationQueue", () => {
     const { result } = renderHook(() =>
       useNarrationQueue({ onEmit, paceMs: 1000 }),
     );
-    result.current.push([event("a")]);
-    result.current.push([event("b")]);
+    result.current.push([say("a")]);
+    result.current.push([say("b")]);
     expect(onEmit).toHaveBeenCalledTimes(1);
     vi.advanceTimersByTime(1000);
     expect(onEmit).toHaveBeenCalledTimes(2);
   });
 
-  it("flushes everything queued the moment an urgent event arrives", () => {
+  it("drains everything queued the moment a flush event arrives, emitting no terminal copy itself", () => {
     const onEmit = vi.fn();
     const { result } = renderHook(() => useNarrationQueue({ onEmit }));
 
-    result.current.push([event("a"), event("b")]);
+    result.current.push([say("a"), say("b")]);
     expect(onEmit).toHaveBeenCalledTimes(1);
 
-    result.current.push([event("terminal", true)]);
-    expect(onEmit.mock.calls.map(([e]) => e.id)).toEqual([
-      "a",
-      "b",
-      "terminal",
-    ]);
+    result.current.push([flush("terminal")]);
+    expect(onEmit.mock.calls.map(([event]) => event.id)).toEqual(["a", "b"]);
 
-    // Nothing left ticking afterwards.
+    // Nothing left ticking afterwards, and the flush itself emitted nothing.
     vi.advanceTimersByTime(DEFAULT_PACE_MS * 3);
-    expect(onEmit).toHaveBeenCalledTimes(3);
+    expect(onEmit).toHaveBeenCalledTimes(2);
   });
 
   it("cancels the pending timer on unmount", () => {
     const onEmit = vi.fn();
     const { result, unmount } = renderHook(() => useNarrationQueue({ onEmit }));
-    result.current.push([event("a"), event("b")]);
+    result.current.push([say("a"), say("b")]);
     unmount();
     vi.advanceTimersByTime(DEFAULT_PACE_MS * 2);
     expect(onEmit).toHaveBeenCalledTimes(1);

--- a/frontend/src/screens/onboarding-conversation/narration.test.ts
+++ b/frontend/src/screens/onboarding-conversation/narration.test.ts
@@ -1,0 +1,278 @@
+/** @vitest-environment jsdom */
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { components } from "../../api/schema";
+import {
+  DEFAULT_PACE_MS,
+  diffCorpus,
+  diffSiteRead,
+  diffVoiceBuild,
+  type NarrationEvent,
+  useNarrationQueue,
+} from "./narration";
+
+type CompanySiteRead = components["schemas"]["CompanySiteRead"];
+type ColdStartField = components["schemas"]["ColdStartField"];
+type VoiceCorpusSummary = components["schemas"]["VoiceCorpusSummary"];
+
+// The diffs are the honesty layer: every narration event must trace back to
+// a server snapshot delta. These tests pin the deltas and the queue's pacing
+// and urgent-flush behaviour with fake timers only.
+
+function field(name: ColdStartField["field"], value: string): ColdStartField {
+  return {
+    field: name,
+    value,
+    evidence_snippet: `snippet for ${name}`,
+    source_kind: "url",
+    confidence: 0.8,
+  };
+}
+
+function read(overrides: Partial<CompanySiteRead>): CompanySiteRead {
+  return {
+    id: "8b6e2a34-0000-4000-8000-000000000001",
+    target_kind: "onboarding",
+    root_url: "https://acme.example",
+    status: "reading",
+    status_code: null,
+    status_detail: null,
+    next_attempt_at: null,
+    pages: [],
+    profile_fields: [],
+    facts: [],
+    comparisons: [],
+    people: [],
+    warnings: [],
+    draft_version: 1,
+    proposal_hash: "h1",
+    created_at: "2026-07-22T09:00:00Z",
+    updated_at: "2026-07-22T09:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("diffSiteRead", () => {
+  it("narrates page growth, new fields, and the crawl-to-extract handover", () => {
+    const prev = read({
+      pages_read: 2,
+      phase: "crawling",
+      profile_fields: [field("display_name", "Acme")],
+    });
+    const next = read({
+      pages_read: 5,
+      phase: "extracting",
+      profile_fields: [
+        field("display_name", "Acme"),
+        field("industry", "Robotics"),
+      ],
+    });
+    const events = diffSiteRead(prev, next);
+    expect(events).toEqual([
+      {
+        id: "pages:5",
+        i18nKey: "ob.conv.read.pages",
+        params: { pages: 5 },
+      },
+      { id: "phase:extracting", i18nKey: "ob.conv.read.extracting" },
+      {
+        id: "field:industry",
+        i18nKey: "ob.conv.read.learnedField",
+        params: { field: "industry", value: "Robotics" },
+        findingIds: ["industry"],
+      },
+    ]);
+  });
+
+  it("emits one event per field on the first snapshot and none on a repeat", () => {
+    const snapshot = read({
+      profile_fields: [field("display_name", "Acme"), field("icp", "SMB ops")],
+    });
+    expect(diffSiteRead(null, snapshot)).toHaveLength(2);
+    expect(diffSiteRead(snapshot, snapshot)).toEqual([]);
+  });
+
+  it("truncates long field values to the 80-character preview", () => {
+    const long = "x".repeat(120);
+    const events = diffSiteRead(
+      null,
+      read({ profile_fields: [field("history", long)] }),
+    );
+    const value = String(events[0]?.params?.value);
+    expect(value.length).toBe(80);
+    expect(value.endsWith("…")).toBe(true);
+  });
+
+  it("narrates new warnings but never repeats known ones", () => {
+    const prev = read({ warnings: ["robots.txt blocked /careers"] });
+    const next = read({
+      warnings: ["robots.txt blocked /careers", "sitemap missing"],
+    });
+    expect(diffSiteRead(prev, next)).toEqual([
+      {
+        id: "warning:sitemap missing",
+        i18nKey: "ob.conv.read.warning",
+        params: { warning: "sitemap missing" },
+      },
+    ]);
+  });
+
+  it("flags terminal statuses urgent, with the server-side finding count", () => {
+    const prev = read({
+      status: "reading",
+      profile_fields: [field("display_name", "Acme")],
+    });
+    const next = read({
+      status: "ready",
+      profile_fields: [field("display_name", "Acme")],
+    });
+    const events = diffSiteRead(prev, next);
+    expect(events).toEqual([
+      {
+        id: "status:ready",
+        i18nKey: "ob.conv.read.done",
+        params: { count: 1 },
+        urgent: true,
+      },
+    ]);
+    // Polling the same terminal snapshot again stays silent.
+    expect(diffSiteRead(next, next)).toEqual([]);
+  });
+
+  it("narrates failed and deferred reads as urgent too", () => {
+    expect(diffSiteRead(read({}), read({ status: "failed" }))[0]).toMatchObject(
+      { i18nKey: "ob.conv.read.failed", urgent: true },
+    );
+    expect(
+      diffSiteRead(read({}), read({ status: "deferred" }))[0],
+    ).toMatchObject({ i18nKey: "ob.conv.read.deferred", urgent: true });
+  });
+});
+
+describe("diffVoiceBuild", () => {
+  it("narrates each stage change exactly once", () => {
+    expect(diffVoiceBuild(null, "snapshot", "running")).toEqual([
+      { id: "stage:snapshot", i18nKey: "ob.conv.build.snapshot" },
+    ]);
+    expect(diffVoiceBuild("snapshot", "extract", "running")).toEqual([
+      { id: "stage:extract", i18nKey: "ob.conv.build.extract" },
+    ]);
+    expect(diffVoiceBuild("extract", "extract", "running")).toEqual([]);
+  });
+
+  it("terminal statuses win over stage changes and are urgent", () => {
+    expect(diffVoiceBuild("evaluate", "activate", "succeeded")).toEqual([
+      {
+        id: "build:succeeded",
+        i18nKey: "ob.conv.build.succeeded",
+        urgent: true,
+      },
+    ]);
+    expect(diffVoiceBuild(null, null, "failed")[0]).toMatchObject({
+      i18nKey: "ob.conv.build.failed",
+      urgent: true,
+    });
+  });
+});
+
+describe("diffCorpus", () => {
+  const summary = (
+    total_words: number,
+    quality_band: VoiceCorpusSummary["quality_band"],
+  ): VoiceCorpusSummary => ({
+    total_words,
+    target_words: 30000,
+    maturity: "collecting",
+    quality_band,
+    source_count: 1,
+    register_words: {},
+  });
+
+  it("narrates word growth and band changes from server numbers only", () => {
+    expect(diffCorpus(summary(400, "thin"), summary(1240, "good"))).toEqual([
+      {
+        id: "words:1240",
+        i18nKey: "ob.conv.corpus.words",
+        params: { words: 1240 },
+      },
+      {
+        id: "band:good",
+        i18nKey: "ob.conv.corpus.band",
+        params: { band: "good" },
+      },
+    ]);
+    expect(diffCorpus(summary(1240, "good"), summary(1240, "good"))).toEqual(
+      [],
+    );
+  });
+});
+
+describe("useNarrationQueue", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const event = (id: string, urgent?: boolean): NarrationEvent => ({
+    id,
+    i18nKey: "ob.conv.read.pages",
+    params: { pages: 1 },
+    ...(urgent ? { urgent } : {}),
+  });
+
+  it("emits the first event immediately and then one per pace window", () => {
+    const onEmit = vi.fn();
+    const { result } = renderHook(() => useNarrationQueue({ onEmit }));
+
+    result.current.push([event("a"), event("b"), event("c")]);
+    expect(onEmit.mock.calls.map(([e]) => e.id)).toEqual(["a"]);
+
+    vi.advanceTimersByTime(DEFAULT_PACE_MS);
+    expect(onEmit.mock.calls.map(([e]) => e.id)).toEqual(["a", "b"]);
+
+    vi.advanceTimersByTime(DEFAULT_PACE_MS);
+    expect(onEmit.mock.calls.map(([e]) => e.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("keeps pacing across separate pushes inside the same window", () => {
+    const onEmit = vi.fn();
+    const { result } = renderHook(() =>
+      useNarrationQueue({ onEmit, paceMs: 1000 }),
+    );
+    result.current.push([event("a")]);
+    result.current.push([event("b")]);
+    expect(onEmit).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(1000);
+    expect(onEmit).toHaveBeenCalledTimes(2);
+  });
+
+  it("flushes everything queued the moment an urgent event arrives", () => {
+    const onEmit = vi.fn();
+    const { result } = renderHook(() => useNarrationQueue({ onEmit }));
+
+    result.current.push([event("a"), event("b")]);
+    expect(onEmit).toHaveBeenCalledTimes(1);
+
+    result.current.push([event("terminal", true)]);
+    expect(onEmit.mock.calls.map(([e]) => e.id)).toEqual([
+      "a",
+      "b",
+      "terminal",
+    ]);
+
+    // Nothing left ticking afterwards.
+    vi.advanceTimersByTime(DEFAULT_PACE_MS * 3);
+    expect(onEmit).toHaveBeenCalledTimes(3);
+  });
+
+  it("cancels the pending timer on unmount", () => {
+    const onEmit = vi.fn();
+    const { result, unmount } = renderHook(() => useNarrationQueue({ onEmit }));
+    result.current.push([event("a"), event("b")]);
+    unmount();
+    vi.advanceTimersByTime(DEFAULT_PACE_MS * 2);
+    expect(onEmit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/screens/onboarding-conversation/narration.ts
+++ b/frontend/src/screens/onboarding-conversation/narration.ts
@@ -61,18 +61,19 @@ function newFieldEvents(
   const known = new Set((prev?.profile_fields ?? []).map((f) => f.field));
   return next.profile_fields
     .filter((field) => !known.has(field.field))
-    .map((field) => {
+    .map((field): NarrationEvent => {
       const labelKey = coldFieldLabelKey(field.field);
+      const params: Record<string, string | number> = {
+        value: previewValue(field.value),
+      };
+      if (!labelKey) {
+        params.field = field.field.replace(/_/g, " ");
+      }
       return {
-        kind: "say" as const,
+        kind: "say",
         id: `${next.id}:field:${field.field}`,
-        i18nKey: "ob.conv.read.learnedField" as const,
-        params: labelKey
-          ? { value: previewValue(field.value) }
-          : {
-              field: field.field.replace(/_/g, " "),
-              value: previewValue(field.value),
-            },
+        i18nKey: "ob.conv.read.learnedField",
+        params,
         ...(labelKey ? { paramKeys: { field: labelKey } } : {}),
         findingIds: [field.field],
       };

--- a/frontend/src/screens/onboarding-conversation/narration.ts
+++ b/frontend/src/screens/onboarding-conversation/narration.ts
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useRef } from "react";
 import type { components } from "../../api/schema";
 import type { MessageKey } from "../../i18n/en";
-import type { BuildStage, BuildTerminalStatus } from "./conversation-machine";
+import { coldFieldLabelKey } from "../common";
+import type { BuildStage } from "./conversation-machine";
 
 type CompanySiteRead = components["schemas"]["CompanySiteRead"];
 type VoiceCorpusSummary = components["schemas"]["VoiceCorpusSummary"];
@@ -10,42 +11,95 @@ type VoiceBuildStatus = components["schemas"]["VoiceBuild"]["status"];
 // Narration is derived, never invented: every event below is a delta between
 // two server snapshots, and every parameter it carries comes from the server
 // payload. The queue paces delivery so a burst of findings reads like a
-// conversation, but terminal states always flush immediately; pacing may
-// delay honesty, never withhold it.
+// conversation.
+//
+// Terminal copy has ONE owner: the reducer's READ_TERMINAL / BUILD_TERMINAL
+// outcome entries. The diffs never narrate a terminal state themselves — on
+// a fresh terminal they emit a "flush" event, which drains all queued
+// progress narration immediately. Wiring contract for the shell: push the
+// diff output into the queue first (the flush drains it), THEN dispatch the
+// terminal machine event, so progress always lands before the outcome.
 
-export type NarrationEvent = {
-  /** Stable across repeated diffs of the same snapshot pair. */
+export type NarrationSayEvent = {
+  kind: "say";
+  /** Scoped to the run/operation, stable across repeated diffs. */
   id: string;
   i18nKey: MessageKey;
   params?: Record<string, string | number>;
+  /** Params that are i18n keys themselves; the renderer translates them. */
+  paramKeys?: Record<string, MessageKey>;
   findingIds?: string[];
-  /** Terminal states bypass pacing; the queue flushes everything queued. */
-  urgent?: boolean;
 };
+
+export type NarrationFlushEvent = { kind: "flush"; id: string };
+
+export type NarrationEvent = NarrationSayEvent | NarrationFlushEvent;
 
 const VALUE_PREVIEW_LIMIT = 80;
 
+// Truncates by Unicode code points so a surrogate pair is never split.
 function previewValue(value: string): string {
-  if (value.length <= VALUE_PREVIEW_LIMIT) return value;
-  return `${value.slice(0, VALUE_PREVIEW_LIMIT - 1)}…`;
+  const points = Array.from(value);
+  if (points.length <= VALUE_PREVIEW_LIMIT) return value;
+  return `${points.slice(0, VALUE_PREVIEW_LIMIT - 1).join("")}…`;
 }
 
-const readTerminalEvents: Partial<
-  Record<CompanySiteRead["status"], MessageKey>
-> = {
-  ready: "ob.conv.read.done",
-  confirmed: "ob.conv.read.done",
-  partial: "ob.conv.read.partial",
-  failed: "ob.conv.read.failed",
-  abandoned: "ob.conv.read.failed",
-  deferred: "ob.conv.read.deferred",
-};
+// The four states a running read can freshly end in. `confirmed` and
+// `abandoned` are post-outcome lifecycle states (the human already acted on
+// a terminal read) — transitioning into them announces nothing new.
+const freshReadTerminals = new Set<CompanySiteRead["status"]>([
+  "ready",
+  "partial",
+  "failed",
+  "deferred",
+]);
+
+function newFieldEvents(
+  prev: CompanySiteRead | null,
+  next: CompanySiteRead,
+): NarrationEvent[] {
+  const known = new Set((prev?.profile_fields ?? []).map((f) => f.field));
+  return next.profile_fields
+    .filter((field) => !known.has(field.field))
+    .map((field) => {
+      const labelKey = coldFieldLabelKey(field.field);
+      return {
+        kind: "say" as const,
+        id: `${next.id}:field:${field.field}`,
+        i18nKey: "ob.conv.read.learnedField" as const,
+        params: labelKey
+          ? { value: previewValue(field.value) }
+          : {
+              field: field.field.replace(/_/g, " "),
+              value: previewValue(field.value),
+            },
+        ...(labelKey ? { paramKeys: { field: labelKey } } : {}),
+        findingIds: [field.field],
+      };
+    });
+}
+
+function newWarningEvents(
+  prev: CompanySiteRead | null,
+  next: CompanySiteRead,
+): NarrationEvent[] {
+  const known = new Set(prev?.warnings ?? []);
+  return next.warnings
+    .filter((warning) => !known.has(warning))
+    .map((warning) => ({
+      kind: "say" as const,
+      id: `${next.id}:warning:${warning}`,
+      i18nKey: "ob.conv.read.warning" as const,
+      params: { warning },
+    }));
+}
 
 export function diffSiteRead(
   prev: CompanySiteRead | null,
   next: CompanySiteRead,
 ): NarrationEvent[] {
   const events: NarrationEvent[] = [];
+  const run = next.id;
 
   // Page progress coalesces: one event per poll that saw growth, carrying the
   // running total rather than one bubble per page.
@@ -53,49 +107,25 @@ export function diffSiteRead(
   const nextPages = next.pages_read ?? 0;
   if (nextPages > prevPages) {
     events.push({
-      id: `pages:${nextPages}`,
+      kind: "say",
+      id: `${run}:pages:${nextPages}`,
       i18nKey: "ob.conv.read.pages",
       params: { pages: nextPages },
     });
   }
 
   if (next.phase === "extracting" && prev?.phase !== "extracting") {
-    events.push({ id: "phase:extracting", i18nKey: "ob.conv.read.extracting" });
-  }
-
-  const knownFields = new Set(
-    (prev?.profile_fields ?? []).map((field) => field.field),
-  );
-  for (const field of next.profile_fields) {
-    if (knownFields.has(field.field)) continue;
     events.push({
-      id: `field:${field.field}`,
-      i18nKey: "ob.conv.read.learnedField",
-      params: { field: field.field, value: previewValue(field.value) },
-      findingIds: [field.field],
+      kind: "say",
+      id: `${run}:phase:extracting`,
+      i18nKey: "ob.conv.read.extracting",
     });
   }
 
-  const knownWarnings = new Set(prev?.warnings ?? []);
-  for (const warning of next.warnings) {
-    if (knownWarnings.has(warning)) continue;
-    events.push({
-      id: `warning:${warning}`,
-      i18nKey: "ob.conv.read.warning",
-      params: { warning },
-    });
-  }
+  events.push(...newFieldEvents(prev, next), ...newWarningEvents(prev, next));
 
-  const terminalKey = readTerminalEvents[next.status];
-  if (terminalKey && prev?.status !== next.status) {
-    events.push({
-      id: `status:${next.status}`,
-      i18nKey: terminalKey,
-      params: {
-        count: next.profile_fields.length + next.facts.length,
-      },
-      urgent: true,
-    });
+  if (freshReadTerminals.has(next.status) && prev?.status !== next.status) {
+    events.push({ kind: "flush", id: `${run}:flush:${next.status}` });
   }
 
   return events;
@@ -108,32 +138,46 @@ const buildStageEvents: Record<BuildStage, MessageKey> = {
   activate: "ob.conv.build.activate",
 };
 
-const buildTerminalEvents: Partial<Record<VoiceBuildStatus, MessageKey>> = {
-  succeeded: "ob.conv.build.succeeded",
-  failed: "ob.conv.build.failed",
-  deferred: "ob.conv.build.deferred",
+const buildTerminals = new Set<VoiceBuildStatus>([
+  "succeeded",
+  "failed",
+  "deferred",
+]);
+
+export type VoiceBuildSnapshot = {
+  id: string;
+  status: VoiceBuildStatus;
+  stage: BuildStage | null;
 };
 
 export function diffVoiceBuild(
-  prevStage: BuildStage | null,
-  nextStage: BuildStage | null,
-  status: VoiceBuildStatus,
+  prev: VoiceBuildSnapshot | null,
+  next: VoiceBuildSnapshot,
 ): NarrationEvent[] {
-  const terminalKey = buildTerminalEvents[status];
-  if (terminalKey) {
+  if (buildTerminals.has(next.status)) {
+    // A poll repeating an already-seen terminal announces nothing.
+    return prev?.status === next.status
+      ? []
+      : [{ kind: "flush", id: `${next.id}:flush:${next.status}` }];
+  }
+  if (next.stage && next.stage !== prev?.stage) {
     return [
       {
-        id: `build:${status as BuildTerminalStatus}`,
-        i18nKey: terminalKey,
-        urgent: true,
+        kind: "say",
+        id: `${next.id}:stage:${next.stage}`,
+        i18nKey: buildStageEvents[next.stage],
       },
     ];
   }
-  if (nextStage && nextStage !== prevStage) {
-    return [{ id: `stage:${nextStage}`, i18nKey: buildStageEvents[nextStage] }];
-  }
   return [];
 }
+
+const bandLabelKeys: Record<VoiceCorpusSummary["quality_band"], MessageKey> = {
+  thin: "settings.voice.bandThin",
+  good: "settings.voice.bandGood",
+  rich: "settings.voice.bandRich",
+  sharp: "settings.voice.bandSharp",
+};
 
 export function diffCorpus(
   prev: VoiceCorpusSummary | null,
@@ -143,6 +187,7 @@ export function diffCorpus(
   const prevWords = prev?.total_words ?? 0;
   if (next.total_words > prevWords) {
     events.push({
+      kind: "say",
       id: `words:${next.total_words}`,
       i18nKey: "ob.conv.corpus.words",
       params: { words: next.total_words },
@@ -150,9 +195,10 @@ export function diffCorpus(
   }
   if (prev && next.quality_band !== prev.quality_band) {
     events.push({
+      kind: "say",
       id: `band:${next.quality_band}`,
       i18nKey: "ob.conv.corpus.band",
-      params: { band: next.quality_band },
+      paramKeys: { band: bandLabelKeys[next.quality_band] },
     });
   }
   return events;
@@ -161,18 +207,18 @@ export function diffCorpus(
 export const DEFAULT_PACE_MS = 1800;
 
 type NarrationQueueOptions = {
-  onEmit: (event: NarrationEvent) => void;
+  onEmit: (event: NarrationSayEvent) => void;
   paceMs?: number;
 };
 
-// Paces narration to one bubble per paceMs so bursts stay readable. An urgent
-// event (a terminal state) drains the whole queue synchronously; the user is
-// never left watching a paced trickle after the outcome is already known.
+// Paces narration to one bubble per paceMs so bursts stay readable. A flush
+// event drains the whole queue synchronously; the user is never left
+// watching a paced trickle after the outcome is already known.
 export function useNarrationQueue({
   onEmit,
   paceMs = DEFAULT_PACE_MS,
 }: NarrationQueueOptions) {
-  const queue = useRef<NarrationEvent[]>([]);
+  const queue = useRef<NarrationSayEvent[]>([]);
   const timer = useRef<ReturnType<typeof globalThis.setTimeout> | null>(null);
   const emit = useRef(onEmit);
   emit.current = onEmit;
@@ -204,9 +250,15 @@ export function useNarrationQueue({
 
   const push = useCallback(
     (events: readonly NarrationEvent[]) => {
-      if (events.length === 0) return;
-      queue.current.push(...events);
-      if (events.some((event) => event.urgent)) {
+      let sawFlush = false;
+      for (const event of events) {
+        if (event.kind === "flush") {
+          sawFlush = true;
+        } else {
+          queue.current.push(event);
+        }
+      }
+      if (sawFlush) {
         flush();
         return;
       }

--- a/frontend/src/screens/onboarding-conversation/narration.ts
+++ b/frontend/src/screens/onboarding-conversation/narration.ts
@@ -1,0 +1,229 @@
+import { useCallback, useEffect, useRef } from "react";
+import type { components } from "../../api/schema";
+import type { MessageKey } from "../../i18n/en";
+import type { BuildStage, BuildTerminalStatus } from "./conversation-machine";
+
+type CompanySiteRead = components["schemas"]["CompanySiteRead"];
+type VoiceCorpusSummary = components["schemas"]["VoiceCorpusSummary"];
+type VoiceBuildStatus = components["schemas"]["VoiceBuild"]["status"];
+
+// Narration is derived, never invented: every event below is a delta between
+// two server snapshots, and every parameter it carries comes from the server
+// payload. The queue paces delivery so a burst of findings reads like a
+// conversation, but terminal states always flush immediately; pacing may
+// delay honesty, never withhold it.
+
+export type NarrationEvent = {
+  /** Stable across repeated diffs of the same snapshot pair. */
+  id: string;
+  i18nKey: MessageKey;
+  params?: Record<string, string | number>;
+  findingIds?: string[];
+  /** Terminal states bypass pacing; the queue flushes everything queued. */
+  urgent?: boolean;
+};
+
+const VALUE_PREVIEW_LIMIT = 80;
+
+function previewValue(value: string): string {
+  if (value.length <= VALUE_PREVIEW_LIMIT) return value;
+  return `${value.slice(0, VALUE_PREVIEW_LIMIT - 1)}…`;
+}
+
+const readTerminalEvents: Partial<
+  Record<CompanySiteRead["status"], MessageKey>
+> = {
+  ready: "ob.conv.read.done",
+  confirmed: "ob.conv.read.done",
+  partial: "ob.conv.read.partial",
+  failed: "ob.conv.read.failed",
+  abandoned: "ob.conv.read.failed",
+  deferred: "ob.conv.read.deferred",
+};
+
+export function diffSiteRead(
+  prev: CompanySiteRead | null,
+  next: CompanySiteRead,
+): NarrationEvent[] {
+  const events: NarrationEvent[] = [];
+
+  // Page progress coalesces: one event per poll that saw growth, carrying the
+  // running total rather than one bubble per page.
+  const prevPages = prev?.pages_read ?? 0;
+  const nextPages = next.pages_read ?? 0;
+  if (nextPages > prevPages) {
+    events.push({
+      id: `pages:${nextPages}`,
+      i18nKey: "ob.conv.read.pages",
+      params: { pages: nextPages },
+    });
+  }
+
+  if (next.phase === "extracting" && prev?.phase !== "extracting") {
+    events.push({ id: "phase:extracting", i18nKey: "ob.conv.read.extracting" });
+  }
+
+  const knownFields = new Set(
+    (prev?.profile_fields ?? []).map((field) => field.field),
+  );
+  for (const field of next.profile_fields) {
+    if (knownFields.has(field.field)) continue;
+    events.push({
+      id: `field:${field.field}`,
+      i18nKey: "ob.conv.read.learnedField",
+      params: { field: field.field, value: previewValue(field.value) },
+      findingIds: [field.field],
+    });
+  }
+
+  const knownWarnings = new Set(prev?.warnings ?? []);
+  for (const warning of next.warnings) {
+    if (knownWarnings.has(warning)) continue;
+    events.push({
+      id: `warning:${warning}`,
+      i18nKey: "ob.conv.read.warning",
+      params: { warning },
+    });
+  }
+
+  const terminalKey = readTerminalEvents[next.status];
+  if (terminalKey && prev?.status !== next.status) {
+    events.push({
+      id: `status:${next.status}`,
+      i18nKey: terminalKey,
+      params: {
+        count: next.profile_fields.length + next.facts.length,
+      },
+      urgent: true,
+    });
+  }
+
+  return events;
+}
+
+const buildStageEvents: Record<BuildStage, MessageKey> = {
+  snapshot: "ob.conv.build.snapshot",
+  extract: "ob.conv.build.extract",
+  evaluate: "ob.conv.build.evaluate",
+  activate: "ob.conv.build.activate",
+};
+
+const buildTerminalEvents: Partial<Record<VoiceBuildStatus, MessageKey>> = {
+  succeeded: "ob.conv.build.succeeded",
+  failed: "ob.conv.build.failed",
+  deferred: "ob.conv.build.deferred",
+};
+
+export function diffVoiceBuild(
+  prevStage: BuildStage | null,
+  nextStage: BuildStage | null,
+  status: VoiceBuildStatus,
+): NarrationEvent[] {
+  const terminalKey = buildTerminalEvents[status];
+  if (terminalKey) {
+    return [
+      {
+        id: `build:${status as BuildTerminalStatus}`,
+        i18nKey: terminalKey,
+        urgent: true,
+      },
+    ];
+  }
+  if (nextStage && nextStage !== prevStage) {
+    return [{ id: `stage:${nextStage}`, i18nKey: buildStageEvents[nextStage] }];
+  }
+  return [];
+}
+
+export function diffCorpus(
+  prev: VoiceCorpusSummary | null,
+  next: VoiceCorpusSummary,
+): NarrationEvent[] {
+  const events: NarrationEvent[] = [];
+  const prevWords = prev?.total_words ?? 0;
+  if (next.total_words > prevWords) {
+    events.push({
+      id: `words:${next.total_words}`,
+      i18nKey: "ob.conv.corpus.words",
+      params: { words: next.total_words },
+    });
+  }
+  if (prev && next.quality_band !== prev.quality_band) {
+    events.push({
+      id: `band:${next.quality_band}`,
+      i18nKey: "ob.conv.corpus.band",
+      params: { band: next.quality_band },
+    });
+  }
+  return events;
+}
+
+export const DEFAULT_PACE_MS = 1800;
+
+type NarrationQueueOptions = {
+  onEmit: (event: NarrationEvent) => void;
+  paceMs?: number;
+};
+
+// Paces narration to one bubble per paceMs so bursts stay readable. An urgent
+// event (a terminal state) drains the whole queue synchronously; the user is
+// never left watching a paced trickle after the outcome is already known.
+export function useNarrationQueue({
+  onEmit,
+  paceMs = DEFAULT_PACE_MS,
+}: NarrationQueueOptions) {
+  const queue = useRef<NarrationEvent[]>([]);
+  const timer = useRef<ReturnType<typeof globalThis.setTimeout> | null>(null);
+  const emit = useRef(onEmit);
+  emit.current = onEmit;
+
+  const flush = useCallback(() => {
+    if (timer.current !== null) {
+      globalThis.clearTimeout(timer.current);
+      timer.current = null;
+    }
+    const pending = queue.current;
+    queue.current = [];
+    for (const event of pending) {
+      emit.current(event);
+    }
+  }, []);
+
+  const pump = useCallback(() => {
+    if (timer.current !== null) return;
+    const next = queue.current.shift();
+    if (!next) return;
+    emit.current(next);
+    // The timer arms even when the queue is now empty: it is the pacing
+    // window for whatever arrives next, not just for the current backlog.
+    timer.current = globalThis.setTimeout(() => {
+      timer.current = null;
+      pump();
+    }, paceMs);
+  }, [paceMs]);
+
+  const push = useCallback(
+    (events: readonly NarrationEvent[]) => {
+      if (events.length === 0) return;
+      queue.current.push(...events);
+      if (events.some((event) => event.urgent)) {
+        flush();
+        return;
+      }
+      pump();
+    },
+    [flush, pump],
+  );
+
+  useEffect(
+    () => () => {
+      if (timer.current !== null) {
+        globalThis.clearTimeout(timer.current);
+        timer.current = null;
+      }
+    },
+    [],
+  );
+
+  return { push, flush };
+}

--- a/frontend/src/screens/onboarding-conversation/thread.tsx
+++ b/frontend/src/screens/onboarding-conversation/thread.tsx
@@ -10,8 +10,9 @@ import {
 
 // The conversation transcript: a polite live region so a screen reader hears
 // new turns without stealing focus, auto-scrolled so the newest entry stays
-// in view. Question interactivity is delegated upward; the thread itself
-// holds no state.
+// in view — but only while the reader is already near the bottom; someone
+// reading upthread is never yanked down. Question interactivity is delegated
+// upward; the thread itself holds no conversation state.
 
 type ConversationThreadProps = Readonly<{
   entries: readonly ThreadEntry[];
@@ -20,26 +21,65 @@ type ConversationThreadProps = Readonly<{
   onAnswer: (questionId: string, value: string) => void;
 }>;
 
+// How close (in device pixels) to the bottom edge still counts as "following
+// the conversation" for auto-scroll purposes.
+const FOLLOW_THRESHOLD_PX = 96;
+
+// The pending question can share its logical id with an earlier occurrence
+// (a re-asked clarify after a re-read); only the LAST matching card is live.
+function activeQuestionEntryId(
+  entries: readonly ThreadEntry[],
+  pendingQuestionId: string | null,
+): string | null {
+  if (pendingQuestionId === null) return null;
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const entry = entries[index];
+    if (entry.kind === "question" && entry.question.id === pendingQuestionId) {
+      return entry.id;
+    }
+  }
+  return null;
+}
+
 export function ConversationThread({
   entries,
   pendingQuestionId,
   onAnswer,
 }: ConversationThreadProps) {
   const t = useT();
+  const log = useRef<HTMLDivElement>(null);
   const end = useRef<HTMLDivElement>(null);
+  const following = useRef(true);
 
+  const lastEntryId = entries.at(-1)?.id;
   useEffect(() => {
-    if (entries.length === 0) return;
+    if (lastEntryId === undefined || !following.current) return;
+    const reduceMotion =
+      globalThis.matchMedia?.("(prefers-reduced-motion: reduce)").matches ??
+      false;
     // jsdom has no scrollIntoView; in the browser it always exists.
-    end.current?.scrollIntoView?.({ block: "end", behavior: "smooth" });
-  }, [entries.length]);
+    end.current?.scrollIntoView?.({
+      block: "end",
+      behavior: reduceMotion ? "auto" : "smooth",
+    });
+  }, [lastEntryId]);
+
+  const liveQuestionEntryId = activeQuestionEntryId(entries, pendingQuestionId);
 
   return (
     <div
+      ref={log}
       className="ob-conv-thread"
       role="log"
       aria-live="polite"
       aria-label={t("ob.conv.threadLabel")}
+      onScroll={() => {
+        const node = log.current;
+        if (!node) return;
+        following.current =
+          node.scrollHeight - node.scrollTop - node.clientHeight <
+          FOLLOW_THRESHOLD_PX;
+      }}
     >
       {entries.map((entry) => {
         if (entry.kind === "narration") {
@@ -50,7 +90,7 @@ export function ConversationThread({
             <QuestionCard
               key={entry.id}
               question={entry.question}
-              answered={entry.question.id !== pendingQuestionId}
+              answered={entry.id !== liveQuestionEntryId}
               onAnswer={onAnswer}
             />
           );

--- a/frontend/src/screens/onboarding-conversation/thread.tsx
+++ b/frontend/src/screens/onboarding-conversation/thread.tsx
@@ -1,0 +1,66 @@
+import { useEffect, useRef } from "react";
+import { useT } from "../../i18n";
+import type { ThreadEntry } from "./conversation-machine";
+import {
+  NarrationBubble,
+  OutcomeCard,
+  QuestionCard,
+  UserTurn,
+} from "./entries";
+
+// The conversation transcript: a polite live region so a screen reader hears
+// new turns without stealing focus, auto-scrolled so the newest entry stays
+// in view. Question interactivity is delegated upward; the thread itself
+// holds no state.
+
+type ConversationThreadProps = Readonly<{
+  entries: readonly ThreadEntry[];
+  /** The one question still awaiting an answer; older ones render inert. */
+  pendingQuestionId: string | null;
+  onAnswer: (questionId: string, value: string) => void;
+}>;
+
+export function ConversationThread({
+  entries,
+  pendingQuestionId,
+  onAnswer,
+}: ConversationThreadProps) {
+  const t = useT();
+  const end = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (entries.length === 0) return;
+    // jsdom has no scrollIntoView; in the browser it always exists.
+    end.current?.scrollIntoView?.({ block: "end", behavior: "smooth" });
+  }, [entries.length]);
+
+  return (
+    <div
+      className="ob-conv-thread"
+      role="log"
+      aria-live="polite"
+      aria-label={t("ob.conv.threadLabel")}
+    >
+      {entries.map((entry) => {
+        if (entry.kind === "narration") {
+          return <NarrationBubble key={entry.id} entry={entry} />;
+        }
+        if (entry.kind === "question") {
+          return (
+            <QuestionCard
+              key={entry.id}
+              question={entry.question}
+              answered={entry.question.id !== pendingQuestionId}
+              onAnswer={onAnswer}
+            />
+          );
+        }
+        if (entry.kind === "user") {
+          return <UserTurn key={entry.id} entry={entry} />;
+        }
+        return <OutcomeCard key={entry.id} entry={entry} />;
+      })}
+      <div ref={end} aria-hidden />
+    </div>
+  );
+}

--- a/frontend/src/screens/onboarding.tsx
+++ b/frontend/src/screens/onboarding.tsx
@@ -2035,6 +2035,19 @@ function VoiceStep({ onBuilt }: Readonly<{ onBuilt: () => void }>) {
     setPieces((prev) => [...prev.filter((p) => p.ref !== piece.ref), piece]);
   };
 
+  // Parallel uploads share ONE profile resolution: concurrent
+  // ensureProfileId calls would race each other into the server's
+  // one-live-profile conflict. A failed resolution clears the slot so the
+  // next upload can retry rather than inheriting a dead promise.
+  const profileIdInFlight = useRef<Promise<string> | null>(null);
+  const sharedProfileId = () => {
+    profileIdInFlight.current ??= ensureProfileId().catch((err: unknown) => {
+      profileIdInFlight.current = null;
+      throw err;
+    });
+    return profileIdInFlight.current;
+  };
+
   // classifyUpload decides what one file honestly IS before anything counts:
   // the server preview detects transcript structure and counts each
   // speaker's words, so a conversation never enters the meter whole — the
@@ -2045,7 +2058,7 @@ function VoiceStep({ onBuilt }: Readonly<{ onBuilt: () => void }>) {
       return;
     }
     const ref = `onboarding:upload:${name}`;
-    const profileId = await ensureProfileId();
+    const profileId = await sharedProfileId();
     const { data, error } = await api.POST(
       "/voice-profiles/{id}/sources/preview",
       {
@@ -2286,7 +2299,7 @@ function VoiceStep({ onBuilt }: Readonly<{ onBuilt: () => void }>) {
     setBuilding(true);
     setBuildError(null);
     try {
-      const profileId = await ensureProfileId();
+      const profileId = await sharedProfileId();
       await ingestCorpus(profileId);
       const outcome = await pollBuild(profileId, await startBuild(profileId));
       if (mounted.current) {

--- a/frontend/src/screens/onboarding.tsx
+++ b/frontend/src/screens/onboarding.tsx
@@ -1985,7 +1985,10 @@ function VoiceStep({ onBuilt }: Readonly<{ onBuilt: () => void }>) {
   const [paste, setPaste] = useState("");
   const [skipped, setSkipped] = useState<string[]>([]);
   const [speakerAsks, setSpeakerAsks] = useState<SpeakerAsk[]>([]);
-  const [probeError, setProbeError] = useState<string | null>(null);
+  // Per-file refusals: a corrected re-upload clears its own entry instead
+  // of one file's failure masking another's.
+  const [probeErrors, setProbeErrors] = useState<Record<string, string>>({});
+  const [probesInFlight, setProbesInFlight] = useState(0);
   const [dragOver, setDragOver] = useState(false);
   const [built, setBuilt] = useState(false);
   const [building, setBuilding] = useState(false);
@@ -2050,11 +2053,11 @@ function VoiceStep({ onBuilt }: Readonly<{ onBuilt: () => void }>) {
 
   // classifyUpload decides what one file honestly IS before anything counts:
   // the server preview detects transcript structure and counts each
-  // speaker's words, so a conversation never enters the meter whole — the
-  // owner is asked which speaker they are first (features/09 §B1.2).
+  // speaker's SPOKEN words (labels and timestamps are never words), so a
+  // conversation never enters the meter whole — the owner is asked which
+  // speaker they are first (features/09 §B1.2).
   async function classifyUpload(name: string, text: string) {
-    const totalWords = text.split(/\s+/).filter(Boolean).length;
-    if (totalWords === 0) {
+    if (text.split(/\s+/).filter(Boolean).length === 0) {
       return;
     }
     const ref = `onboarding:upload:${name}`;
@@ -2072,33 +2075,52 @@ function VoiceStep({ onBuilt }: Readonly<{ onBuilt: () => void }>) {
     if (!mounted.current) {
       return;
     }
+    setProbeErrors((prev) => {
+      const { [ref]: _cleared, ...rest } = prev;
+      return rest;
+    });
     const attributedWords = data.speakers.reduce(
       (sum, speaker) => sum + speaker.words,
       0,
     );
     // A .txt can be a pasted transcript too: treat it as one when the
-    // preview attributes most of its words to labelled speakers.
+    // preview attributes most of its spoken words to labelled speakers.
     const conversational =
       TRANSCRIPT_EXT.test(name) ||
-      (data.ingestible_as_transcript && attributedWords >= totalWords * 0.8);
+      (data.ingestible_as_transcript &&
+        attributedWords >= data.total_words * 0.8);
     if (conversational && data.ingestible_as_transcript) {
+      // A re-upload replaces any previously counted piece under this ref:
+      // nothing may stay in the meter while its replacement awaits the
+      // speaker answer.
+      setPieces((prev) => prev.filter((p) => p.ref !== ref));
       setSpeakerAsks((prev) => [
         ...prev.filter((ask) => ask.ref !== ref),
-        { ref, label: name, content: text, totalWords, preview: data },
+        {
+          ref,
+          label: name,
+          content: text,
+          totalWords: data.total_words,
+          preview: data,
+        },
       ]);
       return;
     }
     if (TRANSCRIPT_EXT.test(name)) {
       // Transcript-shaped but nobody is attributable: none of it can be
       // proven the owner's own words, so none of it is counted.
-      setProbeError(t("ob.s2.unattributed", { file: name }));
+      setPieces((prev) => prev.filter((p) => p.ref !== ref));
+      setProbeErrors((prev) => ({
+        ...prev,
+        [ref]: t("ob.s2.unattributed", { file: name }),
+      }));
       return;
     }
     addPiece({
       ref,
       label: name,
-      words: totalWords,
-      totalWords,
+      words: data.total_words,
+      totalWords: data.total_words,
       content: text,
       register: "general",
       kind: "document",
@@ -2116,12 +2138,22 @@ function VoiceStep({ onBuilt }: Readonly<{ onBuilt: () => void }>) {
         rejected.push(file.name);
         continue;
       }
+      setProbesInFlight((n) => n + 1);
       file
         .text()
         .then((text) => classifyUpload(file.name, text))
         .catch((err: unknown) => {
           if (mounted.current) {
-            setProbeError(err instanceof Error ? err.message : String(err));
+            setProbeErrors((prev) => ({
+              ...prev,
+              [`onboarding:upload:${file.name}`]:
+                err instanceof Error ? err.message : String(err),
+            }));
+          }
+        })
+        .finally(() => {
+          if (mounted.current) {
+            setProbesInFlight((n) => n - 1);
           }
         });
     }
@@ -2154,7 +2186,14 @@ function VoiceStep({ onBuilt }: Readonly<{ onBuilt: () => void }>) {
   };
 
   const quality = corpusQuality(corpus.total);
-  const canBuild = corpus.total >= VOICE_MIN_WORDS && !building;
+  // Building must wait for every upload to finish classifying and every
+  // speaker question to be answered — a build that silently omitted a file
+  // still being probed would misrepresent what the voice was made from.
+  const canBuild =
+    corpus.total >= VOICE_MIN_WORDS &&
+    !building &&
+    probesInFlight === 0 &&
+    speakerAsks.length === 0;
 
   async function ingest(profileId: string, piece: VoicePiece) {
     const { error } = await api.POST("/voice-profiles/{id}/sources", {
@@ -2459,14 +2498,15 @@ function VoiceStep({ onBuilt }: Readonly<{ onBuilt: () => void }>) {
             ))}
           </ul>
         )}
-        {probeError && (
+        {Object.entries(probeErrors).map(([ref, message]) => (
           <output
+            key={ref}
             className="ob-sub"
             style={{ display: "block", marginTop: "var(--space-2)" }}
           >
-            {probeError}
+            {message}
           </output>
-        )}
+        ))}
 
         <div className="field" style={{ marginTop: "var(--space-3)" }}>
           <label className="t-label" htmlFor="voice-paste">

--- a/frontend/src/screens/onboarding.tsx
+++ b/frontend/src/screens/onboarding.tsx
@@ -1880,11 +1880,31 @@ const ACCEPTED_CORPUS_ATTR = ".txt,.md,.vtt,.srt,.json";
 type VoicePiece = {
   ref: string;
   label: string;
+  // words is what actually counts toward the voice: for a transcript, the
+  // server-computed word count of ONLY the owner's turns; totalWords is the
+  // whole file, kept so the honest "kept X of Y" line can be shown.
   words: number;
+  totalWords: number;
   content: string;
   register: components["schemas"]["IngestVoiceCorpusSourceRequest"]["register"];
   kind: components["schemas"]["IngestVoiceCorpusSourceRequest"]["kind"];
+  format: components["schemas"]["IngestVoiceCorpusSourceRequest"]["format"];
+  speakerLabel?: string;
 };
+
+type CorpusPreview = components["schemas"]["VoiceCorpusPreviewResult"];
+
+// A transcript whose speakers are known but whose owner is not yet: the
+// step asks "which of these is you?" before a single word is counted.
+type SpeakerAsk = {
+  ref: string;
+  label: string;
+  content: string;
+  totalWords: number;
+  preview: CorpusPreview;
+};
+
+const TRANSCRIPT_EXT = /\.(vtt|srt|json)$/i;
 
 // The corpus meter is honest: it counts only the real words the owner uploaded
 // or pasted here (the build ingests exactly these). Presets below are examples
@@ -1964,6 +1984,8 @@ function VoiceStep({ onBuilt }: Readonly<{ onBuilt: () => void }>) {
   const [pieces, setPieces] = useState<VoicePiece[]>([]);
   const [paste, setPaste] = useState("");
   const [skipped, setSkipped] = useState<string[]>([]);
+  const [speakerAsks, setSpeakerAsks] = useState<SpeakerAsk[]>([]);
+  const [probeError, setProbeError] = useState<string | null>(null);
   const [dragOver, setDragOver] = useState(false);
   const [built, setBuilt] = useState(false);
   const [building, setBuilding] = useState(false);
@@ -2009,43 +2031,108 @@ function VoiceStep({ onBuilt }: Readonly<{ onBuilt: () => void }>) {
     };
   }, [pieces, pasteWords]);
 
+  const addPiece = (piece: VoicePiece) => {
+    setPieces((prev) => [...prev.filter((p) => p.ref !== piece.ref), piece]);
+  };
+
+  // classifyUpload decides what one file honestly IS before anything counts:
+  // the server preview detects transcript structure and counts each
+  // speaker's words, so a conversation never enters the meter whole — the
+  // owner is asked which speaker they are first (features/09 §B1.2).
+  async function classifyUpload(name: string, text: string) {
+    const totalWords = text.split(/\s+/).filter(Boolean).length;
+    if (totalWords === 0) {
+      return;
+    }
+    const ref = `onboarding:upload:${name}`;
+    const profileId = await ensureProfileId();
+    const { data, error } = await api.POST(
+      "/voice-profiles/{id}/sources/preview",
+      {
+        params: { path: { id: profileId } },
+        body: { format: "transcript", content: text },
+      },
+    );
+    if (error) {
+      throw new Error(problemMessage(error));
+    }
+    if (!mounted.current) {
+      return;
+    }
+    const attributedWords = data.speakers.reduce(
+      (sum, speaker) => sum + speaker.words,
+      0,
+    );
+    // A .txt can be a pasted transcript too: treat it as one when the
+    // preview attributes most of its words to labelled speakers.
+    const conversational =
+      TRANSCRIPT_EXT.test(name) ||
+      (data.ingestible_as_transcript && attributedWords >= totalWords * 0.8);
+    if (conversational && data.ingestible_as_transcript) {
+      setSpeakerAsks((prev) => [
+        ...prev.filter((ask) => ask.ref !== ref),
+        { ref, label: name, content: text, totalWords, preview: data },
+      ]);
+      return;
+    }
+    if (TRANSCRIPT_EXT.test(name)) {
+      // Transcript-shaped but nobody is attributable: none of it can be
+      // proven the owner's own words, so none of it is counted.
+      setProbeError(t("ob.s2.unattributed", { file: name }));
+      return;
+    }
+    addPiece({
+      ref,
+      label: name,
+      words: totalWords,
+      totalWords,
+      content: text,
+      register: "general",
+      kind: "document",
+      format: "text",
+    });
+  }
+
   // One intake for both entry paths — the file picker and a drag&drop onto
-  // the dropzone feed the exact same corpus pipeline.
+  // the dropzone feed the exact same corpus pipeline. V1 corpus is text only
+  // (features/09 §B1.1); binary documents (.docx/.pdf) are refused.
   const addFiles = (files: File[]) => {
     const rejected: string[] = [];
     for (const file of files) {
-      // V1 corpus is text only (features/09 §B1.1): the meter counts the real
-      // words of what was read — never an estimate — and the text is KEPT so
-      // the real build can ingest it. Binary documents (.docx/.pdf) are
-      // refused; deferred: B-E07.5c (server-side extraction).
       if (!ACCEPTED_CORPUS_FILE.test(file.name)) {
         rejected.push(file.name);
         continue;
       }
-      file.text().then((text) => {
-        if (!mounted.current) {
-          return;
-        }
-        const words = text.split(/\s+/).filter(Boolean).length;
-        if (words === 0) {
-          return;
-        }
-        const spoken = /\.(vtt|srt)$/i.test(file.name);
-        const ref = `onboarding:upload:${file.name}`;
-        setPieces((prev) => [
-          ...prev.filter((p) => p.ref !== ref),
-          {
-            ref,
-            label: file.name,
-            words,
-            content: text,
-            register: spoken ? "spoken" : "general",
-            kind: spoken ? "transcript" : "document",
-          },
-        ]);
-      });
+      file
+        .text()
+        .then((text) => classifyUpload(file.name, text))
+        .catch((err: unknown) => {
+          if (mounted.current) {
+            setProbeError(err instanceof Error ? err.message : String(err));
+          }
+        });
     }
     setSkipped(rejected);
+  };
+
+  // The owner named themselves: only THAT speaker's server-counted words
+  // enter the meter; the rest of the conversation contributes zero.
+  const resolveSpeaker = (
+    ask: SpeakerAsk,
+    speaker: CorpusPreview["speakers"][number],
+  ) => {
+    setSpeakerAsks((prev) => prev.filter((p) => p.ref !== ask.ref));
+    addPiece({
+      ref: ask.ref,
+      label: ask.label,
+      words: speaker.words,
+      totalWords: ask.totalWords,
+      content: ask.content,
+      register: "spoken",
+      kind: "transcript",
+      format: "transcript",
+      speakerLabel: speaker.label,
+    });
   };
 
   const onFiles = (e: ChangeEvent<HTMLInputElement>) => {
@@ -2065,7 +2152,8 @@ function VoiceStep({ onBuilt }: Readonly<{ onBuilt: () => void }>) {
         weight: 1,
         source_label: piece.label,
         source_ref: piece.ref,
-        format: "text",
+        format: piece.format,
+        speaker_label: piece.speakerLabel ?? null,
         content: piece.content,
       },
     });
@@ -2134,9 +2222,11 @@ function VoiceStep({ onBuilt }: Readonly<{ onBuilt: () => void }>) {
         ref: PASTE_REF,
         label: t("ob.s2.pasteSource"),
         words: pasteWords,
+        totalWords: pasteWords,
         content: paste,
         register: "general",
         kind: "other",
+        format: "text",
       });
     }
   }
@@ -2300,14 +2390,69 @@ function VoiceStep({ onBuilt }: Readonly<{ onBuilt: () => void }>) {
           accept={ACCEPTED_CORPUS_ATTR}
           onChange={onFiles}
         />
+        {speakerAsks.map((ask) => (
+          <fieldset
+            key={ask.ref}
+            className="card"
+            style={{
+              marginTop: "var(--space-2)",
+              padding: "var(--space-3)",
+              border: 0,
+            }}
+          >
+            <legend style={{ fontWeight: 600 }}>
+              {t("ob.s2.speakerAsk", { file: ask.label })}
+            </legend>
+            <div
+              style={{
+                display: "flex",
+                gap: "var(--space-2)",
+                flexWrap: "wrap",
+                marginTop: "var(--space-2)",
+              }}
+            >
+              {ask.preview.speakers.map((speaker) => (
+                <Button
+                  small
+                  key={speaker.label}
+                  onClick={() => resolveSpeaker(ask, speaker)}
+                >
+                  {t("ob.s2.speakerOption", {
+                    name: speaker.label,
+                    words: speaker.words.toLocaleString(),
+                    turns: speaker.turns,
+                  })}
+                </Button>
+              ))}
+            </div>
+          </fieldset>
+        ))}
         {pieces.length > 0 && (
           <ul className="vp-list" style={{ marginTop: 10 }}>
             {pieces.map((p) => (
               <li key={p.ref}>
                 <Check aria-hidden /> {p.label} · {p.words.toLocaleString()}
+                {p.speakerLabel && (
+                  <span className="t-small">
+                    {" "}
+                    {t("ob.s2.keptOnly", {
+                      kept: p.words.toLocaleString(),
+                      total: p.totalWords.toLocaleString(),
+                      speaker: p.speakerLabel,
+                    })}
+                  </span>
+                )}
               </li>
             ))}
           </ul>
+        )}
+        {probeError && (
+          <output
+            className="ob-sub"
+            style={{ display: "block", marginTop: "var(--space-2)" }}
+          >
+            {probeError}
+          </output>
         )}
 
         <div className="field" style={{ marginTop: "var(--space-3)" }}>


### PR DESCRIPTION
Phase 0 (backend half) of the onboarding honesty work: the server-side enablers the voice step needs to stop counting other people's words.

## What's new

- **`POST /voice-profiles/{id}/sources/preview`** — dry-run inspection of a candidate source: detected shape (txt/vtt/srt/json) and per-speaker turn/word counts, so the UI can ask "which of these speakers is you?" before anything is committed. Pure read, nothing stored, no model call, human-only.
- **`ingest_stats` on the ingest 201** — input vs kept words, kept/discarded turns, speakers seen: the honest "kept only your turns: 1,240 of 5,400 words" story.
- **Diarizer labels parse now** — `Speaker 1:` / `Sprecher 2:` previously made every Zoom/Teams transcript unattributed (and thus refused whole). Letters-first with a short trailing number is a speaker; a clock time, long number run, or URL still is not (the `https:` prefix hole is closed too).
- **Bracket-opened labelled text is not JSON** — `[10:03] Lars: …` used to sniff as JSON and 422; the sniffer now commits to JSON only when the content decodes as transcript turns.
- **Stable refusal codes** (`unattributed_transcript`, `speaker_label_required`, `speaker_not_found`, `unsupported_format`) so a conversational client can voice a refusal without parsing prose.

## Verification

- New unit tests: speaker-prefix matrix, numbered-label filtering, sniffer fallback, preview aggregates, ingest-stats story, refusal-code matrix.
- `make check-backend` green; voice integration packages green on throwaway DBs (`test-integration-one.sh`).

Frontend half (send transcripts as transcripts + the speaker question + server-count meter) follows in the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds honest voice corpus intake end-to-end: server-side preview detects speakers and counts spoken words only, and onboarding asks “which speaker are you?” so only the owner’s turns count. Ingest now returns kept-vs-discarded stats, and the PR seeds a small conversation framework to narrate progress.

- **New Features**
  - `POST /voice-profiles/{id}/sources/preview`: dry-run detection of shape (`txt`, `vtt`, `srt`, `json`) and per-speaker turns/word counts; totals are spoken text only; no storage or model calls.
  - Ingest 201 includes `ingest_stats` (spoken `input_words`, `kept_words`, kept/discarded turns, `speakers_seen`); 422s return `application/problem+json` with stable codes: `unattributed_transcript`, `speaker_label_required`, `speaker_not_found`, `unsupported_format`.
  - Onboarding probes uploads via preview; conversational files prompt speaker selection, the meter shows “kept X of Y,” building waits for all probes and answers, and ingest uses `format=transcript` + `speaker_label`. Adds conversation primitives (pure reducer, diff-paced narration queue, thread UI) behind a flag.

- **Bug Fixes**
  - Better transcript parsing: accepts diarizer labels like “Speaker 1:”/“Sprecher 2:”, supports timestamp-header transcripts (`00:03:12 Name` with following lines), and stops treating `[10:03] Name: …` text as JSON.
  - Honest counting: wrapped cue lines fold into one turn; clock-opened long dialogue is not mistaken for a speaker header; preview refuses unknown wire formats; word totals count spoken text only.
  - Conversation primitives hardened: stale/illegal events are ignored, answers are validated, duplicate build stages are deduped; narration flushes on terminals and outcomes carry a tone; thread auto-scrolls only near the bottom and honors reduced motion.
  - Parallel uploads share one `ensureProfileId` resolution to avoid the one-live-profile race.
  - TypeScript build: learned-field narration params are assembled imperatively to satisfy `exactOptionalPropertyTypes` (no undefined member).

<sup>Written for commit 47837b06792fa152a0823ee89257c48ce0c760a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dry-run preview endpoint for voice corpus sources, returning detected format, speaker activity, word counts, and whether the source is ingestible—without saving.
  * Voice corpus ingestion/response now includes detailed ingest statistics (kept vs discarded, turn/word counts, speakers).

* **Improvements**
  * Improved transcript handling for conversational vs prose inputs, including stricter speaker-attribution requirements.
  * Validation errors now return stable, machine-readable refusal codes (e.g., unsupported format, unattributed transcript, missing speaker label).
  * Onboarding conversation UI updated with new speaker-attribution steps and counters.

* **Tests**
  * Added/updated coverage for preview, ingest stats, and conversation state behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->