### PR TITLE
fix(overlay): page HubSpot v4 associations to completion (A7 slice 1)

### DIFF
--- a/backend/internal/modules/overlay/hubspot/client_test.go
+++ b/backend/internal/modules/overlay/hubspot/client_test.go
@@ -277,6 +277,27 @@ func TestClientAssociationsFollowsPaging(t *testing.T) {
 	}
 }
 
+func TestClientAssociationsFailsFastOnNonAdvancingCursor(t *testing.T) {
+	// A server that always echoes the same next cursor must be caught on the
+	// first repeat, not spun to the page cap.
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		mustWrite(t, w, `{"results":[{"toObjectId":1,"associationTypes":[]}],"paging":{"next":{"after":"stuck"}}}`)
+	}))
+	defer srv.Close()
+
+	c := hubspot.NewClient("us", "test-token", hubspot.WithBaseURL(srv.URL))
+	if _, err := c.Associations(t.Context(), "deals", "123", "companies"); err == nil {
+		t.Fatal("Associations with a non-advancing cursor: want an error, got nil")
+	}
+	// One page with a real cursor, then one more that repeats it → caught.
+	if calls != 2 {
+		t.Fatalf("server calls = %d, want 2 (fail fast on the first repeated cursor, not spin to the cap)", calls)
+	}
+}
+
 func TestClientOwnerParsesEmail(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/crm/v3/owners/1197833249" {

--- a/backend/internal/modules/overlay/hubspot/client_test.go
+++ b/backend/internal/modules/overlay/hubspot/client_test.go
@@ -241,6 +241,42 @@ func TestClientAssociationsParsesTypes(t *testing.T) {
 	}
 }
 
+func TestClientAssociationsFollowsPaging(t *testing.T) {
+	// Two pages: the first carries paging.next.after, the second does not.
+	// Every edge across both pages must be collected — a single-page read
+	// would silently lose the >500th edge — and page two must carry the
+	// cursor as ?after=.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Query().Get("after") {
+		case "":
+			mustWrite(t, w, `{
+				"results": [ { "toObjectId": 111, "associationTypes": [ {"category":"HUBSPOT_DEFINED","typeId":5,"label":"Primary"} ] } ],
+				"paging": { "next": { "after": "page2" } }
+			}`)
+		case "page2":
+			mustWrite(t, w, `{
+				"results": [ { "toObjectId": 222, "associationTypes": [ {"category":"HUBSPOT_DEFINED","typeId":5,"label":null} ] } ]
+			}`)
+		default:
+			t.Errorf("unexpected after cursor %q", r.URL.Query().Get("after"))
+		}
+	}))
+	defer srv.Close()
+
+	c := hubspot.NewClient("us", "test-token", hubspot.WithBaseURL(srv.URL))
+	assocs, err := c.Associations(t.Context(), "deals", "123", "companies")
+	if err != nil {
+		t.Fatalf("Associations: unexpected error: %v", err)
+	}
+	if len(assocs) != 2 {
+		t.Fatalf("len(assocs) = %d, want 2 (both pages collected)", len(assocs))
+	}
+	if assocs[0].ToObjectID != "111" || assocs[1].ToObjectID != "222" {
+		t.Fatalf("ToObjectIDs = [%q %q], want [111 222]", assocs[0].ToObjectID, assocs[1].ToObjectID)
+	}
+}
+
 func TestClientOwnerParsesEmail(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/crm/v3/owners/1197833249" {

--- a/backend/internal/modules/overlay/hubspot/records.go
+++ b/backend/internal/modules/overlay/hubspot/records.go
@@ -146,24 +146,51 @@ type wireAssociation struct {
 // Associations lists the v4 association edges from fromID (of fromClass)
 // to every linked record of toClass (design §11).
 func (c *Client) Associations(ctx context.Context, fromClass, fromID, toClass string) ([]Association, error) {
-	var out struct {
-		Results []wireAssociation `json:"results"`
-	}
-	path := "/crm/v4/objects/" + url.PathEscape(fromClass) + "/" + url.PathEscape(fromID) +
+	var assocs []Association
+	base := "/crm/v4/objects/" + url.PathEscape(fromClass) + "/" + url.PathEscape(fromID) +
 		"/associations/" + url.PathEscape(toClass)
-	if err := c.do(ctx, http.MethodGet, path, nil, &out); err != nil {
-		return nil, err
-	}
-	assocs := make([]Association, 0, len(out.Results))
-	for _, r := range out.Results {
-		types := make([]AssociationType, 0, len(r.Types))
-		for _, t := range r.Types {
-			types = append(types, AssociationType{Category: t.Category, TypeID: t.TypeID, Label: t.Label})
+	after := ""
+	// The v4 associations list is paged (paging.next.after): a record with
+	// more than one page of edges (HubSpot returns up to 500 per page) would
+	// silently lose every edge past the first page if we read only page one.
+	// Termination guard, same shape as Owners: a buggy/adversarial API that
+	// echoes a non-advancing cursor would otherwise spin forever.
+	for page := 0; page < associationsMaxPages; page++ {
+		q := url.Values{}
+		q.Set("limit", "500")
+		if after != "" {
+			q.Set("after", after)
 		}
-		assocs = append(assocs, Association{ToObjectID: r.ToObjectID.String(), Types: types})
+		var out struct {
+			Results []wireAssociation `json:"results"`
+			Paging  struct {
+				Next struct {
+					After string `json:"after"`
+				} `json:"next"`
+			} `json:"paging"`
+		}
+		if err := c.do(ctx, http.MethodGet, base+"?"+q.Encode(), nil, &out); err != nil {
+			return nil, err
+		}
+		for _, r := range out.Results {
+			types := make([]AssociationType, 0, len(r.Types))
+			for _, t := range r.Types {
+				types = append(types, AssociationType{Category: t.Category, TypeID: t.TypeID, Label: t.Label})
+			}
+			assocs = append(assocs, Association{ToObjectID: r.ToObjectID.String(), Types: types})
+		}
+		if out.Paging.Next.After == "" {
+			return assocs, nil
+		}
+		after = out.Paging.Next.After
 	}
-	return assocs, nil
+	return nil, fmt.Errorf("hubspot: associations %s/%s->%s did not terminate within %d pages — the API is echoing a non-advancing cursor", fromClass, fromID, toClass, associationsMaxPages)
 }
+
+// associationsMaxPages bounds Associations' pagination: 10k pages × 500/page
+// = five million edges from a single record, far above any real portal, so
+// it only trips on a cursor that never advances.
+const associationsMaxPages = 10_000
 
 // Owner resolves ownerID via the CRM Owners API (design §4.3:
 // crm.objects.owners.read — required for mirror_user_map's

--- a/backend/internal/modules/overlay/hubspot/records.go
+++ b/backend/internal/modules/overlay/hubspot/records.go
@@ -182,9 +182,15 @@ func (c *Client) Associations(ctx context.Context, fromClass, fromID, toClass st
 		if out.Paging.Next.After == "" {
 			return assocs, nil
 		}
+		// A cursor that does not advance would otherwise spin to the page cap,
+		// firing thousands of duplicate requests and accumulating duplicate
+		// edges — catch it on the first repeat instead.
+		if out.Paging.Next.After == after {
+			return nil, fmt.Errorf("hubspot: associations %s/%s->%s returned a non-advancing paging cursor %q", fromClass, fromID, toClass, after)
+		}
 		after = out.Paging.Next.After
 	}
-	return nil, fmt.Errorf("hubspot: associations %s/%s->%s did not terminate within %d pages — the API is echoing a non-advancing cursor", fromClass, fromID, toClass, associationsMaxPages)
+	return nil, fmt.Errorf("hubspot: associations %s/%s->%s did not terminate within %d pages", fromClass, fromID, toClass, associationsMaxPages)
 }
 
 // associationsMaxPages bounds Associations' pagination: 10k pages × 500/page
@@ -248,9 +254,14 @@ func (c *Client) Owners(ctx context.Context) ([]Owner, error) {
 		if out.Paging.Next.After == "" {
 			return owners, nil
 		}
+		// Catch a non-advancing cursor on the first repeat rather than
+		// spinning to the page cap (the same guard Associations uses).
+		if out.Paging.Next.After == after {
+			return nil, fmt.Errorf("hubspot: owners directory returned a non-advancing paging cursor %q", after)
+		}
 		after = out.Paging.Next.After
 	}
-	return nil, fmt.Errorf("hubspot: owners directory did not terminate within %d pages — the API is echoing a non-advancing cursor", ownersMaxPages)
+	return nil, fmt.Errorf("hubspot: owners directory did not terminate within %d pages", ownersMaxPages)
 }
 
 // ownersMaxPages bounds Owners' pagination: 10k pages × 100/page = a


### PR DESCRIPTION
## What & why

`Client.Associations` read only the **first page** of the HubSpot v4 associations list (`/crm/v4/objects/{type}/{id}/associations/{toType}`). HubSpot returns up to 500 edges per page with `paging.next.after`; a record with more than one page of associations **silently lost every edge past the first** — a real mirror-fidelity data loss for any heavily-associated record (a company with hundreds of contacts/deals, etc.).

It now follows `paging.next.after` to completion, with the same non-advancing-cursor termination guard `Owners`/`List` already use.

## Scope

This is **A7 slice 1**. The larger **slice 2** — incremental association *re-sync* (reconcile re-syncing a modified record's association *set*: upsert new + prune removed, rather than backfilling edges only once) — is deliberately separate: it needs a set-replace store method, per-record metering threaded through the reconcile path, and carries a documented residual (an association-only change that doesn't bump the record's `lastmodified` isn't signalled by the Modified feed — that half rides with webhook-as-signal).

## Tests

Added `TestClientAssociationsFollowsPaging`: two pages (first carries `paging.next.after`, second doesn't); asserts every edge across both pages is collected and page two carries the cursor as `?after=`. Local `make check-backend` green; diff-scoped `craft static` = 0 findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pages HubSpot v4 associations to completion and fails fast on a repeated cursor to prevent data loss and runaway requests. Adds the same cursor guard to owners and improves error handling.

- **Bug Fixes**
  - `Client.Associations`: follow `paging.next.after` with `limit=500` until done; cap at 10,000 pages; error immediately on a non-advancing cursor.
  - `Client.Owners`: add non-advancing-cursor guard; simplify cap-exhaustion error message.
  - Tests: add `TestClientAssociationsFollowsPaging` and `TestClientAssociationsFailsFastOnNonAdvancingCursor`.

<sup>Written for commit 60fb88289589fda8952353e0c7c04eda04a6cbfd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * HubSpot association results now include entries from all available pages instead of only the first page.
  * Added safeguards to prevent incomplete or unbounded retrieval when pagination does not progress correctly.
* **Tests**
  * Added coverage verifying that associations from multiple pages are returned together.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->