### PR TITLE
feat(onboarding): conversational voice act + voice-builder robustness

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -22,6 +22,28 @@ The merge gate (`make check`), the real-Postgres integration lane
 
 ## Recently landed
 
+**The conversational onboarding (flagged) + the honest voice corpus.**
+Onboarding is becoming ONE Margince conversation. Landed so far: the
+corpus honesty layer (server speaker preview, kept-vs-discarded ingest
+stats, diarizer/timestamp transcript parsing — only the owner's words
+ever count), the conversation primitives (pure act/phase machine with
+run-correlated events, poll-delta narration with a paced queue,
+thread/entry components), and the conversational COMPANY act behind the
+`conv` flag (`#/onboarding?conv` or localStorage `margince.conv`):
+narrated site read, deterministic clarify questions (legal entity /
+registered address / human-conflict) whose answered option is
+server-verified before it authorizes exactly that change, the proposal
+read (`GET /onboarding/company/proposal`), and the in-thread confirm
+card. The voice act joins in `feat/onboarding-voice-act` (upload-in-chat,
+speaker question, build narration) together with three builder fixes a
+live corpus surfaced: validator-rejected completions evict from the
+result cache, the builder prompt enumerates citable sample ids with
+fabricated supplementary citations dropped, and the worker logs the real
+build error. Classic wizard remains the default; flip is planned after
+the results/connect acts + restore (plan:
+`~/.claude/plans/while-you-are-waiting-snug-horizon.md` Phases 5-7 —
+restore must also stop deriving member-path from "company exists").
+
 **The CI integration lane is sharded per test across twelve runners.** The
 single-runner lane took ~6.5 minutes and floored at `compose/integration`
 (minutes of serial tests), so package-level parallelism could not shorten

--- a/backend/internal/compose/voicebuild.go
+++ b/backend/internal/compose/voicebuild.go
@@ -184,6 +184,9 @@ func (w *voiceBuildWorker) Work(ctx context.Context, job *river.Job[VoiceBuildAr
 			}
 			return nil
 		}
+		// The row carries only the safe detail; the OPERATOR needs the real
+		// cause or a repeated invalid_output is undiagnosable from any log.
+		w.log.WarnContext(ctx, "voice build error", "build", buildID.String(), "err", err)
 		return w.fail(terminal, buildID, claimedAt, failureStatusCode(err), ai.SafeVoiceBuildFailure(err))
 	}
 	return nil

--- a/backend/internal/compose/voicebuild_integration_test.go
+++ b/backend/internal/compose/voicebuild_integration_test.go
@@ -594,3 +594,28 @@ func TestReplyDraftFallsBackAndRecordsRejectionWhenTheFloorHolds(t *testing.T) {
 		t.Fatalf("rejected signals = %d, want the floor failure recorded", summary.Rejected)
 	}
 }
+
+func TestVoiceBuildWorkRecordsAnInvalidModelAnswerAsFailed(t *testing.T) {
+	env, build := seedVoiceBuild(t, "A quote the brain will not honor.", 6)
+	worker := newVoiceBuildWorker(env.e.Pool, brainFunc(func(context.Context, model.Request) (model.Response, error) {
+		return model.Response{Text: "not the requested JSON object"}, nil
+	}), slog.New(slog.DiscardHandler))
+
+	if err := worker.Work(context.Background(), voiceBuildJob(env, build)); err != nil {
+		t.Fatalf("Work must own the failure on the row, not error the job: %v", err)
+	}
+	finished, err := env.store.GetBuild(env.owner, env.profile.ID, build.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if finished.Status != "failed" || finished.StatusCode == nil || *finished.StatusCode != "invalid_output" {
+		t.Fatalf("build = %+v, want failed/invalid_output", finished)
+	}
+}
+
+// brainFunc adapts a function into the completer seam.
+type brainFunc func(context.Context, model.Request) (model.Response, error)
+
+func (f brainFunc) Complete(ctx context.Context, req model.Request) (model.Response, error) {
+	return f(ctx, req)
+}

--- a/backend/internal/modules/ai/resultcache.go
+++ b/backend/internal/modules/ai/resultcache.go
@@ -62,6 +62,16 @@ func (c *resultCache) put(key string, wsID ids.WorkspaceID, resp model.Response,
 	c.entries[key] = cacheEntry{workspaceID: wsID, resp: resp, tier: tier, expires: c.now().Add(c.ttl)}
 }
 
+// forget drops one request's cached completion. The structured-output
+// pipeline calls this when a response fails validation: an invalid answer
+// must never be replayed to a future identical request — the retry's whole
+// value is a fresh roll of the model.
+func (c *resultCache) forget(key string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.entries, key)
+}
+
 // makeRoomLocked frees at least one slot: first a full sweep of expired
 // entries (the only global reap — get only deletes the key it reads),
 // then, if every entry is still live, the soonest-to-expire one goes —

--- a/backend/internal/modules/ai/structured.go
+++ b/backend/internal/modules/ai/structured.go
@@ -88,6 +88,10 @@ func (r *Router) forgetCached(ctx context.Context, task Task, req model.Request)
 	}
 	key, err := cacheKey(ids.From[ids.WorkspaceKind](rawWS), task, req)
 	if err != nil {
+		// The serve path derived this same key moments ago, so a failure
+		// here is a real anomaly: an unevicted invalid answer would replay
+		// on retry, which must not stay invisible to the operator.
+		r.log.WarnContext(ctx, "ai: cache eviction skipped", "task", string(task), "err", err)
 		return
 	}
 	r.cache.forget(key)

--- a/backend/internal/modules/ai/structured.go
+++ b/backend/internal/modules/ai/structured.go
@@ -13,6 +13,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/model"
 )
 
@@ -47,6 +49,7 @@ func (r *Router) CompleteStructured(ctx context.Context, task Task, req model.Re
 	if firstErr == nil {
 		return resp, info, nil
 	}
+	r.forgetCached(ctx, task, req)
 
 	retry := withValidatorFeedback(req, resp.Text, firstErr)
 	resp, info, err = r.serveAttempt(ctx, lc, task, ladder, retry, attemptReasonSchemaInvalid)
@@ -57,6 +60,7 @@ func (r *Router) CompleteStructured(ctx context.Context, task Task, req model.Re
 	if secondErr == nil {
 		return resp, info, nil
 	}
+	r.forgetCached(ctx, task, retry)
 
 	escalated := withValidatorFeedback(req, resp.Text, secondErr)
 	resp, info, err = r.completeEscalated(ctx, lc, task, escalated)
@@ -64,11 +68,29 @@ func (r *Router) CompleteStructured(ctx context.Context, task Task, req model.Re
 		return model.Response{}, info, err
 	}
 	if finalErr := validate(resp.Text); finalErr != nil {
+		r.forgetCached(ctx, task, escalated)
 		return model.Response{}, info, fmt.Errorf(
 			"ai: %s output failed validation after retry and escalation: %w", task, finalErr,
 		)
 	}
 	return resp, info, nil
+}
+
+// forgetCached evicts the cached completion for exactly this request: a
+// response the validator rejected must not be replayed to a future
+// identical call. Without this, a retried BUILD with an unchanged corpus
+// deterministically replays its own failure from the cache until the TTL
+// expires. Best-effort — a request outside a workspace has no cache row.
+func (r *Router) forgetCached(ctx context.Context, task Task, req model.Request) {
+	rawWS, ok := principal.WorkspaceID(ctx)
+	if !ok {
+		return
+	}
+	key, err := cacheKey(ids.From[ids.WorkspaceKind](rawWS), task, req)
+	if err != nil {
+		return
+	}
+	r.cache.forget(key)
 }
 
 // withValidatorFeedback appends the failed output and its validation

--- a/backend/internal/modules/ai/structured_forget_test.go
+++ b/backend/internal/modules/ai/structured_forget_test.go
@@ -8,6 +8,7 @@ package ai
 // deterministically replay its own failure until the TTL expired.
 
 import (
+	"context"
 	"testing"
 
 	"github.com/gradionhq/margince/backend/internal/shared/ports/model"
@@ -37,4 +38,23 @@ func TestValidationFailureEvictsTheCachedAnswer(t *testing.T) {
 	if calls := len(cheap.Calls()); calls != 3 {
 		t.Fatalf("cheap served %d calls, want 3 - the second logical call must miss the cache", calls)
 	}
+}
+
+func TestSecondAttemptFailureAlsoEvictsItsCachedAnswer(t *testing.T) {
+	cheap := NewFakeClient().Script("not json", "still not json", `{"ok":true}`)
+	premium := NewFakeClient().Script(`{"ok":true}`)
+	r := testRouter(map[Tier]model.Client{TierCheapCloud: cheap, TierPremium: premium},
+		&memMeter{}, DefaultMonthlyTokens, ProfileEUHosted)
+	resp, _, err := r.CompleteStructured(wsContext(t), TaskColdStart, structuredReq(), jsonObjectValidator)
+	if err != nil || resp.Text != `{"ok":true}` {
+		t.Fatalf("escalated success: %v %q", err, resp.Text)
+	}
+}
+
+func TestForgetCachedToleratesAMissingWorkspace(t *testing.T) {
+	r := testRouter(map[Tier]model.Client{TierCheapCloud: NewFakeClient().Script("x")},
+		&memMeter{}, DefaultMonthlyTokens, ProfileEUHosted)
+	// Outside a workspace there is no cache row to evict; the helper must
+	// simply return rather than derive a key it cannot scope.
+	r.forgetCached(context.Background(), TaskColdStart, structuredReq())
 }

--- a/backend/internal/modules/ai/structured_forget_test.go
+++ b/backend/internal/modules/ai/structured_forget_test.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package ai
+
+// A validator-rejected completion must never be replayed from the result
+// cache: a retried build with an unchanged corpus would otherwise
+// deterministically replay its own failure until the TTL expired.
+
+import (
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/ports/model"
+)
+
+func TestValidationFailureEvictsTheCachedAnswer(t *testing.T) {
+	cheap := NewFakeClient().Script("not json", "still not json", `{"ok":true}`)
+	premium := NewFakeClient().Script("also not json")
+	r := testRouter(map[Tier]model.Client{TierCheapCloud: cheap, TierPremium: premium},
+		&memMeter{}, DefaultMonthlyTokens, ProfileEUHosted)
+	ctx := wsContext(t)
+
+	// The first logical call burns retry and escalation on invalid output.
+	if _, _, err := r.CompleteStructured(ctx, TaskColdStart, structuredReq(), jsonObjectValidator); err == nil {
+		t.Fatal("three invalid completions must fail the logical call")
+	}
+
+	// The IDENTICAL second call must reach the model again instead of
+	// replaying the cached invalid answer - and now the model answers validly.
+	resp, _, err := r.CompleteStructured(ctx, TaskColdStart, structuredReq(), jsonObjectValidator)
+	if err != nil {
+		t.Fatalf("retry after eviction: %v", err)
+	}
+	if resp.Text != `{"ok":true}` {
+		t.Fatalf("resp = %q - the cached invalid answer was replayed", resp.Text)
+	}
+	if calls := len(cheap.Calls()); calls != 3 {
+		t.Fatalf("cheap served %d calls, want 3 - the second logical call must miss the cache", calls)
+	}
+}

--- a/backend/internal/modules/ai/voicebuilder.go
+++ b/backend/internal/modules/ai/voicebuilder.go
@@ -162,6 +162,7 @@ func DeriveVoice(ctx context.Context, brain voiceBrain, personality, sourceHash 
 	if err := json.Unmarshal([]byte(Unfence(resp.Text)), &inference); err != nil {
 		return VoiceArtifact{}, fmt.Errorf("voice build returned invalid JSON: %w", err)
 	}
+	inference.Evidence = knownEvidenceOnly(inference.Evidence, selected)
 	exemplars := SelectExemplars(selected, stats)
 	return VoiceArtifact{
 		Markdown:   compileVoiceMarkdown(inference, stats),
@@ -194,7 +195,14 @@ func voicePrompt(personality string, stats VoiceStats, samples []VoiceSample) (s
 		fmt.Fprintf(&prompt, "<sample id=%q kind=%q register=%q>\n%s\n</sample>\n",
 			sample.ID, sample.Kind, sample.Register, EscapeUntrustedTags(sample.Text))
 	}
-	prompt.WriteString("\nCite supporting sample ids in evidence and on every signature move. Do not quote or reproduce topic facts in the profile.")
+	prompt.WriteString("\nValid sample ids: ")
+	for i, sample := range samples {
+		if i > 0 {
+			prompt.WriteString(", ")
+		}
+		prompt.WriteString(sample.ID)
+	}
+	prompt.WriteString(".\nevidence and every signature move sample_id must be one of these ids, copied exactly. Do not quote or reproduce topic facts in the profile.")
 	return prompt.String(), nil
 }
 
@@ -237,11 +245,6 @@ func validateVoiceInference(inference VoiceInference, samples []VoiceSample) err
 	known := make(map[string]string, len(samples))
 	for _, sample := range samples {
 		known[sample.ID] = sample.Text
-	}
-	for _, evidence := range inference.Evidence {
-		if _, ok := known[evidence]; !ok {
-			return fmt.Errorf("voice build cited unknown sample %q", evidence)
-		}
 	}
 	for _, sig := range inference.SignatureMoves {
 		if strings.TrimSpace(sig.Move) == "" {
@@ -309,4 +312,24 @@ func writeVoiceList(out *strings.Builder, title string, values []string) {
 			out.WriteString("- " + trimmed + "\n")
 		}
 	}
+}
+
+// knownEvidenceOnly keeps only citations that name a real sample. The
+// evidence list is supplementary (the artifact never renders it), and
+// models reliably slip descriptions into it despite feedback — dropping
+// the fabrications beats failing an otherwise-valid build over them. The
+// load-bearing citations (signature move sample_id + verbatim quote)
+// stay strictly validated.
+func knownEvidenceOnly(evidence []string, samples []VoiceSample) []string {
+	known := make(map[string]bool, len(samples))
+	for _, sample := range samples {
+		known[sample.ID] = true
+	}
+	kept := evidence[:0]
+	for _, id := range evidence {
+		if known[id] {
+			kept = append(kept, id)
+		}
+	}
+	return kept
 }

--- a/backend/internal/modules/ai/voicebuilder_test.go
+++ b/backend/internal/modules/ai/voicebuilder_test.go
@@ -148,10 +148,9 @@ func TestDeriveVoicePrefersTheValidatedPipeline(t *testing.T) {
 
 func TestDeriveVoiceRejectsFabricatedEvidence(t *testing.T) {
 	cases := map[string]func(*VoiceInference){
-		"unknown evidence sample": func(v *VoiceInference) { v.Evidence = []string{"s-invented"} },
-		"unknown move sample":     func(v *VoiceInference) { v.SignatureMoves[0].SampleID = "s-invented" },
-		"non-verbatim quote":      func(v *VoiceInference) { v.SignatureMoves[0].Quote = "words the author never wrote" },
-		"empty thinking pattern":  func(v *VoiceInference) { v.ThinkingPattern = " " },
+		"unknown move sample":    func(v *VoiceInference) { v.SignatureMoves[0].SampleID = "s-invented" },
+		"non-verbatim quote":     func(v *VoiceInference) { v.SignatureMoves[0].Quote = "words the author never wrote" },
+		"empty thinking pattern": func(v *VoiceInference) { v.ThinkingPattern = " " },
 	}
 	for name, corrupt := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -184,5 +183,28 @@ func TestContainsNormalizedFoldsWhitespaceOnly(t *testing.T) {
 	}
 	if containsNormalized("anything", "  ") {
 		t.Fatal("an empty quote is not evidence")
+	}
+}
+
+func TestFabricatedEvidenceCitationsAreDroppedNotFatal(t *testing.T) {
+	inference := validInference()
+	inference.Evidence = []string{"s-email", "a prose sentence pretending to be a citation"}
+	brain := &stubVoiceBrain{inference: inference}
+	artifact, err := DeriveVoice(context.Background(), brain, "", "h", builderSamples())
+	if err != nil {
+		t.Fatalf("a fabricated supplementary citation must not fail the build: %v", err)
+	}
+	if len(artifact.Inference.Evidence) != 1 || artifact.Inference.Evidence[0] != "s-email" {
+		t.Fatalf("evidence = %v, want only the real sample id kept", artifact.Inference.Evidence)
+	}
+}
+
+func TestVoicePromptNamesTheValidSampleIDs(t *testing.T) {
+	brain := &stubVoiceBrain{inference: validInference()}
+	if _, err := DeriveVoice(context.Background(), brain, "", "h", builderSamples()); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(brain.prompt, "Valid sample ids: s-email, s-spoken") {
+		t.Fatal("the prompt must enumerate the exact ids the model may cite")
 	}
 }

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1336,6 +1336,61 @@ export const de = {
   "ob.conv.voice.uploadAdded": "{name} hinzugefügt.",
   "ob.conv.voice.speakerQuestion":
     "Dieses Transkript hat mehrere Sprecher. Wer davon bist du? Nur deine eigenen Worte zählen.",
+  "ob.conv.voice.speakerOptionDetail": "Worte: {words} · Beiträge: {turns}",
+  "ob.conv.voice.collectAsk":
+    "Schick mir Texte, die du geschrieben hast. Gesprächs-Transkripte sind am besten: .vtt, .srt, .json oder Text mit Sprecher-Labels. Einfache Dokumente gehen auch, und unten kannst du Text einfügen.",
+  "ob.conv.voice.composer": "Füge einen eigenen Text ein oder hänge Dateien an",
+  "ob.conv.voice.attach": "Dateien anhängen",
+  "ob.conv.voice.dropHint":
+    "Du kannst Dateien auch überall in dieses Gespräch ziehen.",
+  "ob.conv.voice.fileSkipped":
+    "Ich kann {name} nicht lesen. Ich nehme .txt, .md, .vtt, .srt oder .json.",
+  "ob.conv.voice.fileEmpty":
+    "In {name} stehen keine Worte, also wurde nichts gezählt.",
+  "ob.conv.voice.reactionTranscript":
+    "Behaltene Worte: {kept} von {total}. Nur deine Beiträge zählen, und gesprochene Sprache schärft deine Stimme am meisten.",
+  "ob.conv.voice.reactionDocument":
+    "Gezählte Worte: {words}. Jedes Wort hier ist deins, also zählen alle.",
+  "ob.conv.voice.refusalUnattributed":
+    "Das sieht nach einem Gespräch aus, aber ich kann nicht erkennen, welche Worte deine sind. Ich habe nichts gezählt, denn ich zähle nur Worte, die nachweislich von dir stammen.",
+  "ob.conv.voice.refusalSpeaker":
+    "Ich konnte diesen Sprecher im Transkript nicht finden. Nichts wurde gezählt.",
+  "ob.conv.voice.refusalUnsupported":
+    "Ich konnte diese Datei weder als Text noch als Transkript lesen. Nichts wurde gezählt.",
+  "ob.conv.voice.ingestFailed":
+    "Ich konnte diese Quelle nicht hinzufügen: {detail}",
+  "ob.conv.voice.pasteOffer":
+    "Das liest sich wie Stimm-Material. Soll ich es deinem Korpus hinzufügen?",
+  "ob.conv.voice.pasteAdd": "Ja, in meinen Korpus.",
+  "ob.conv.voice.pasteDiscard": "Nein, verwerfen.",
+  "ob.conv.voice.pasteTooShort":
+    "Das ist zu kurz, um viel zu lernen. Hänge Dateien an oder füge einen längeren eigenen Text ein.",
+  "ob.conv.voice.pasteSource": "Eingefügter Text",
+  "ob.conv.voice.buildFloor":
+    "Eigene Worte bisher: {words}. Ich brauche mindestens {min}, bevor ich bauen kann.",
+  "ob.conv.voice.buildNudge":
+    "Ich habe genug zum Bauen. Mehr Material hilft trotzdem: Ab 4.000 Worten wird deine Stimme deutlich schärfer.",
+  "ob.conv.voice.buildChip": "Mein Stimmprofil bauen",
+  "ob.conv.voice.retryBuild": "Aufbau erneut versuchen",
+  "ob.conv.voice.statusBuilding": "Dein Stimmprofil entsteht",
+  "ob.conv.voice.resultTitle":
+    "Das ist deine Stimme, in deinen eigenen Worten.",
+  "ob.conv.voice.resultLoading": "Ich lade, was der Aufbau gelernt hat.",
+  "ob.conv.voice.resultEmpty":
+    "Der Aufbau ist fertig, aber es gibt noch nichts zu zeigen. Du kannst ihn in den Einstellungen prüfen.",
+  "ob.conv.voice.candidateNote":
+    "Diese Version braucht deine Prüfung, bevor sie aktiv wird. Freigeben kannst du sie in den Einstellungen.",
+  "ob.conv.voice.artifactTitle": "Stimm-Korpus",
+  "ob.conv.voice.artifactBody":
+    "Hier zählen nur deine eigenen Worte. Jede Zahl kommt vom Server, nach dem Sprecher-Filter.",
+  "ob.conv.voice.artifactEmpty":
+    "Noch nichts gesammelt. Hänge ein Transkript oder einen eigenen Text an.",
+  "ob.conv.voice.meterWords": "Eigene Worte: {words} von {target}",
+  "ob.conv.voice.meterBand": "Qualität: {band}",
+  "ob.conv.voice.manifestKept": "{kept} von {total} Worten behalten",
+  "ob.conv.voice.manifestWords": "{words} Worte",
+  "ob.conv.voice.registerMix": "Register: {mix}",
+  "ob.conv.voice.stageTitle": "Aufbau-Fortschritt",
   "ob.conv.corpus.words": "Eigene Worte jetzt im Korpus: {words}.",
   "ob.conv.corpus.band": "Korpusqualität ist jetzt {band}.",
   "ob.conv.build.snapshot": "Ich friere deinen Korpus ein.",
@@ -1379,9 +1434,6 @@ export const de = {
     "Ich konnte noch nicht speichern: {detail} Korrigiere das und übernimm erneut.",
   "ob.conv.artifact.empty":
     "Noch nichts gelesen. Nenn mir eine Website und dieses Panel füllt sich mit belegten Funden.",
-  "ob.conv.voice.stubBody":
-    "Stimm-Uploads laufen vorerst im klassischen Schritt weiter. Dieses Gespräch übernimmt sie in einer späteren Version.",
-  "ob.conv.voice.openClassic": "Klassischen Stimm-Schritt öffnen",
   "ob.conv.results.continue": "Weiter",
   "ob.conv.connect.stubBody":
     "Die Postfach-Verbindung läuft vorerst im klassischen Schritt. Ohne deine Freigabe wird nichts erfasst.",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1336,7 +1336,7 @@ export const de = {
   "ob.conv.voice.uploadAdded": "{name} hinzugefügt.",
   "ob.conv.voice.speakerQuestion":
     "Dieses Transkript hat mehrere Sprecher. Wer davon bist du? Nur deine eigenen Worte zählen.",
-  "ob.conv.voice.speakerOptionDetail": "Worte: {words} · Beiträge: {turns}",
+  "ob.conv.voice.speakerOptionDetail": "Wörter: {words} · Beiträge: {turns}",
   "ob.conv.voice.collectAsk":
     "Schick mir Texte, die du geschrieben hast. Gesprächs-Transkripte sind am besten: .vtt, .srt, .json oder Text mit Sprecher-Labels. Einfache Dokumente gehen auch, und unten kannst du Text einfügen.",
   "ob.conv.voice.composer": "Füge einen eigenen Text ein oder hänge Dateien an",
@@ -1346,13 +1346,13 @@ export const de = {
   "ob.conv.voice.fileSkipped":
     "Ich kann {name} nicht lesen. Ich nehme .txt, .md, .vtt, .srt oder .json.",
   "ob.conv.voice.fileEmpty":
-    "In {name} stehen keine Worte, also wurde nichts gezählt.",
+    "In {name} stehen keine Wörter, also wurde nichts gezählt.",
   "ob.conv.voice.reactionTranscript":
-    "Behaltene Worte: {kept} von {total}. Nur deine Beiträge zählen, und gesprochene Sprache schärft deine Stimme am meisten.",
+    "Behaltene Wörter: {kept} von {total}. Nur deine Beiträge zählen, und gesprochene Sprache schärft deine Stimme am meisten.",
   "ob.conv.voice.reactionDocument":
-    "Gezählte Worte: {words}. Jedes Wort hier ist deins, also zählen alle.",
+    "Gezählte Wörter: {words}. Jedes Wort hier ist deins, also zählen alle.",
   "ob.conv.voice.refusalUnattributed":
-    "Das sieht nach einem Gespräch aus, aber ich kann nicht erkennen, welche Worte deine sind. Ich habe nichts gezählt, denn ich zähle nur Worte, die nachweislich von dir stammen.",
+    "Das sieht nach einem Gespräch aus, aber ich kann nicht erkennen, welche Wörter deine sind. Ich habe nichts gezählt, denn ich zähle nur Wörter, die nachweislich von dir stammen.",
   "ob.conv.voice.refusalSpeaker":
     "Ich konnte diesen Sprecher im Transkript nicht finden. Nichts wurde gezählt.",
   "ob.conv.voice.refusalUnsupported":
@@ -1367,11 +1367,13 @@ export const de = {
     "Das ist zu kurz, um viel zu lernen. Hänge Dateien an oder füge einen längeren eigenen Text ein.",
   "ob.conv.voice.pasteSource": "Eingefügter Text",
   "ob.conv.voice.buildFloor":
-    "Eigene Worte bisher: {words}. Ich brauche mindestens {min}, bevor ich bauen kann.",
+    "Eigene Wörter bisher: {words}. Ich brauche mindestens {min}, bevor ich bauen kann.",
   "ob.conv.voice.buildNudge":
-    "Ich habe genug zum Bauen. Mehr Material hilft trotzdem: Ab 4.000 Worten wird deine Stimme deutlich schärfer.",
+    "Ich habe genug zum Bauen. Mehr Material hilft trotzdem: Ab 4.000 Wörtern wird deine Stimme deutlich schärfer.",
   "ob.conv.voice.buildChip": "Mein Stimmprofil bauen",
   "ob.conv.voice.retryBuild": "Aufbau erneut versuchen",
+  "ob.conv.voice.buildPollFailed":
+    "Ich habe die Verbindung während des Aufbaus verloren. Deine Texte bleiben erhalten, versuche den Aufbau erneut.",
   "ob.conv.voice.statusBuilding": "Dein Stimmprofil entsteht",
   "ob.conv.voice.resultTitle":
     "Das ist deine Stimme, in deinen eigenen Worten.",
@@ -1382,13 +1384,13 @@ export const de = {
     "Diese Version braucht deine Prüfung, bevor sie aktiv wird. Freigeben kannst du sie in den Einstellungen.",
   "ob.conv.voice.artifactTitle": "Stimm-Korpus",
   "ob.conv.voice.artifactBody":
-    "Hier zählen nur deine eigenen Worte. Jede Zahl kommt vom Server, nach dem Sprecher-Filter.",
+    "Hier zählen nur deine eigenen Wörter. Jede Zahl kommt vom Server, nach dem Sprecher-Filter.",
   "ob.conv.voice.artifactEmpty":
     "Noch nichts gesammelt. Hänge ein Transkript oder einen eigenen Text an.",
-  "ob.conv.voice.meterWords": "Eigene Worte: {words} von {target}",
+  "ob.conv.voice.meterWords": "Eigene Wörter: {words} von {target}",
   "ob.conv.voice.meterBand": "Qualität: {band}",
-  "ob.conv.voice.manifestKept": "{kept} von {total} Worten behalten",
-  "ob.conv.voice.manifestWords": "{words} Worte",
+  "ob.conv.voice.manifestKept": "{kept} von {total} Wörtern behalten",
+  "ob.conv.voice.manifestWords": "{words} Wörter",
   "ob.conv.voice.registerMix": "Register: {mix}",
   "ob.conv.voice.stageTitle": "Aufbau-Fortschritt",
   "ob.conv.corpus.words": "Eigene Worte jetzt im Korpus: {words}.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1312,6 +1312,59 @@ export const en = {
   "ob.conv.voice.uploadAdded": "Added {name}.",
   "ob.conv.voice.speakerQuestion":
     "This transcript has several speakers. Which one is you? Only your own words count.",
+  "ob.conv.voice.speakerOptionDetail": "words: {words} · turns: {turns}",
+  "ob.conv.voice.collectAsk":
+    "Send me things you wrote. Call transcripts are best: .vtt, .srt, .json, or text with speaker labels. Plain documents work too, and you can paste text below.",
+  "ob.conv.voice.composer": "Paste a text you wrote, or attach files",
+  "ob.conv.voice.attach": "Attach files",
+  "ob.conv.voice.dropHint":
+    "You can also drop files anywhere in this conversation.",
+  "ob.conv.voice.fileSkipped":
+    "I can not read {name}. I take .txt, .md, .vtt, .srt, or .json.",
+  "ob.conv.voice.fileEmpty":
+    "There are no words in {name}, so nothing was counted.",
+  "ob.conv.voice.reactionTranscript":
+    "Words kept: {kept} of {total}. Only your turns count, and spoken register is exactly what sharpens your voice.",
+  "ob.conv.voice.reactionDocument":
+    "Words counted: {words}. Every word here is yours, so all of them count.",
+  "ob.conv.voice.refusalUnattributed":
+    "That looks like a conversation, but I can not tell which words are yours. I counted nothing, because I only count words that are provably yours.",
+  "ob.conv.voice.refusalSpeaker":
+    "I could not find that speaker in the transcript. Nothing was counted.",
+  "ob.conv.voice.refusalUnsupported":
+    "I could not parse that file as text or a transcript. Nothing was counted.",
+  "ob.conv.voice.ingestFailed": "I could not add that source: {detail}",
+  "ob.conv.voice.pasteOffer":
+    "That reads like voice material. Should I add it to your corpus?",
+  "ob.conv.voice.pasteAdd": "Yes, add it to my corpus.",
+  "ob.conv.voice.pasteDiscard": "No, discard it.",
+  "ob.conv.voice.pasteTooShort":
+    "That is too short to teach me much. Attach files, or paste a longer text you wrote.",
+  "ob.conv.voice.pasteSource": "Pasted text",
+  "ob.conv.voice.buildFloor":
+    "Own words so far: {words}. I need at least {min} before I can build.",
+  "ob.conv.voice.buildNudge":
+    "I have enough to build. More material still helps: 4,000 or more words make your voice noticeably sharper.",
+  "ob.conv.voice.buildChip": "Build my voice profile",
+  "ob.conv.voice.retryBuild": "Try the build again",
+  "ob.conv.voice.statusBuilding": "Building your voice profile",
+  "ob.conv.voice.resultTitle": "Here is your voice, in your own words.",
+  "ob.conv.voice.resultLoading": "Loading what the build learned.",
+  "ob.conv.voice.resultEmpty":
+    "The build finished, but there is nothing to show yet. You can review it in Settings.",
+  "ob.conv.voice.candidateNote":
+    "This version needs your review before it goes live. You can approve it in Settings.",
+  "ob.conv.voice.artifactTitle": "Voice corpus",
+  "ob.conv.voice.artifactBody":
+    "Only your own words count here. Every number comes from the server after speaker filtering.",
+  "ob.conv.voice.artifactEmpty":
+    "Nothing collected yet. Attach a transcript or a text you wrote.",
+  "ob.conv.voice.meterWords": "Own words: {words} of {target}",
+  "ob.conv.voice.meterBand": "Quality: {band}",
+  "ob.conv.voice.manifestKept": "Kept {kept} of {total} words",
+  "ob.conv.voice.manifestWords": "{words} words",
+  "ob.conv.voice.registerMix": "Registers: {mix}",
+  "ob.conv.voice.stageTitle": "Build progress",
   "ob.conv.corpus.words": "Own words in your corpus now: {words}.",
   "ob.conv.corpus.band": "Corpus quality moved to {band}.",
   "ob.conv.build.snapshot": "Locking in your corpus.",
@@ -1351,9 +1404,6 @@ export const en = {
     "I could not save that yet: {detail} Fix it and accept again.",
   "ob.conv.artifact.empty":
     "Nothing read yet. Give me a website and this panel fills with sourced findings.",
-  "ob.conv.voice.stubBody":
-    "Voice uploads continue in the classic step for now. This conversation picks them up in a later release.",
-  "ob.conv.voice.openClassic": "Open the classic voice step",
   "ob.conv.results.continue": "Continue",
   "ob.conv.connect.stubBody":
     "Connecting your inbox continues in the classic step for now. Nothing is captured until you allow it there.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1347,6 +1347,8 @@ export const en = {
     "I have enough to build. More material still helps: 4,000 or more words make your voice noticeably sharper.",
   "ob.conv.voice.buildChip": "Build my voice profile",
   "ob.conv.voice.retryBuild": "Try the build again",
+  "ob.conv.voice.buildPollFailed":
+    "I lost the connection during the build. Your texts are kept; try the build again.",
   "ob.conv.voice.statusBuilding": "Building your voice profile",
   "ob.conv.voice.resultTitle": "Here is your voice, in your own words.",
   "ob.conv.voice.resultLoading": "Loading what the build learned.",

--- a/frontend/src/screens/onboarding-conversation/acts-stub.tsx
+++ b/frontend/src/screens/onboarding-conversation/acts-stub.tsx
@@ -15,7 +15,7 @@ import { ConversationThread } from "./thread";
 import type { WizardPersistInput } from "./use-wizard-state";
 import { ConversationWorkbench } from "./workbench";
 
-// Honest placeholders for the acts after company: the machine already knows
+// Honest placeholders for the acts after voice: the machine already knows
 // them, but their full conversational UI lands in later phases. Until then
 // each act says so plainly and offers the classic step, instead of
 // pretending a flow that does not exist yet. The controls render INSIDE the
@@ -47,64 +47,6 @@ export function ActStubs({ state, dispatch, persist }: ActStubsProps) {
         </ConversationThread>
       </div>
     </ConversationWorkbench>
-  );
-}
-
-function VoiceInvite({ dispatch }: Pick<ActStubsProps, "dispatch">) {
-  const t = useT();
-  return (
-    <>
-      <NarrationBubble
-        entry={{
-          kind: "narration",
-          id: "voice:invite",
-          i18nKey: "ob.conv.voice.invite",
-        }}
-      />
-      <div className="ob-conv-chips">
-        <Button
-          small
-          variant="primary"
-          onClick={() => dispatch({ type: "VOICE_OPT_IN" })}
-        >
-          {t("ob.conv.voice.optIn")}
-        </Button>
-        <Button
-          small
-          variant="ghost"
-          onClick={() => dispatch({ type: "VOICE_SKIPPED" })}
-        >
-          {t("ob.conv.voice.skipped")}
-        </Button>
-      </div>
-    </>
-  );
-}
-
-function VoiceCollecting({ dispatch }: Pick<ActStubsProps, "dispatch">) {
-  const t = useT();
-  return (
-    <>
-      <NarrationBubble
-        entry={{
-          kind: "narration",
-          id: "voice:stub",
-          i18nKey: "ob.conv.voice.stubBody",
-        }}
-      />
-      <div className="ob-conv-chips">
-        <Button small onClick={() => exitToClassicOnboarding()}>
-          {t("ob.conv.voice.openClassic")}
-        </Button>
-        <Button
-          small
-          variant="ghost"
-          onClick={() => dispatch({ type: "VOICE_SKIPPED" })}
-        >
-          {t("ob.conv.voice.skipped")}
-        </Button>
-      </div>
-    </>
   );
 }
 
@@ -176,12 +118,6 @@ function ConnectConsent({ state, dispatch, persist }: ActStubsProps) {
 function StubControls({ state, dispatch, persist }: ActStubsProps) {
   const t = useT();
   switch (state.phase) {
-    case "vo.invite":
-      return <VoiceInvite dispatch={dispatch} />;
-    case "vo.collecting":
-      return <VoiceCollecting dispatch={dispatch} />;
-    case "vo.skipped":
-    case "vo.result":
     case "re.recap":
       return (
         <div className="ob-conv-chips">

--- a/frontend/src/screens/onboarding-conversation/conversation.css
+++ b/frontend/src/screens/onboarding-conversation/conversation.css
@@ -232,6 +232,152 @@
   font: 400 0.9375rem / 1.5 var(--f-body);
 }
 
+/* ---- Phase 4: voice act pieces ---- */
+
+/* The whole thread is a drop target while collecting; the ring says so. */
+.ob-conv-dragover {
+  outline: 2px dashed var(--aiMed);
+  outline-offset: calc(-1 * var(--space-1));
+  border-radius: var(--r-md);
+}
+
+.ob-conv-manifest {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.ob-conv-manifest li {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-2);
+}
+
+.ob-conv-manifest li svg {
+  flex: none;
+  inline-size: var(--space-4);
+  block-size: var(--space-4);
+  color: var(--success);
+}
+
+.ob-conv-manifest li span {
+  display: flex;
+  flex-direction: column;
+}
+
+.ob-conv-manifest strong {
+  color: var(--textPrimary);
+  font: 500 0.875rem / 1.4 var(--f-body);
+  overflow-wrap: anywhere;
+}
+
+.ob-conv-manifest small {
+  color: var(--textSecondary);
+}
+
+.ob-conv-meter {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.ob-conv-meter-top {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: var(--space-2);
+  color: var(--textPrimary);
+  font: 500 0.875rem / 1.4 var(--f-body);
+}
+
+.ob-conv-meter-bar {
+  block-size: var(--space-2);
+  border-radius: var(--r-full);
+  background: var(--bgCard);
+  overflow: hidden;
+}
+
+.ob-conv-meter-bar span {
+  display: block;
+  block-size: 100%;
+  border-radius: var(--r-full);
+  background: var(--aiMed);
+}
+
+.ob-conv-meter small {
+  color: var(--textSecondary);
+}
+
+.ob-conv-stages {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.ob-conv-stages li {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  color: var(--textSecondary);
+  font: 400 0.875rem / 1.4 var(--f-body);
+}
+
+.ob-conv-stages li svg {
+  flex: none;
+  inline-size: var(--space-4);
+  block-size: var(--space-4);
+}
+
+.ob-conv-stages li[data-state="done"] svg {
+  color: var(--success);
+}
+
+.ob-conv-stages li[data-state="current"] {
+  color: var(--textPrimary);
+  font-weight: 500;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .ob-conv-stages li[data-state="current"] svg.spin {
+    animation: ob-conv-spin 1.2s linear infinite;
+  }
+}
+
+@keyframes ob-conv-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.ob-conv-voice-result {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  max-width: 44rem;
+  padding: var(--space-4);
+  border: 1px solid var(--borderSubtle);
+  border-radius: var(--r-md);
+  background: var(--bgElevated);
+}
+
+.ob-conv-voice-result h2 {
+  margin: 0;
+  color: var(--textPrimary);
+  font: 600 1rem / 1.3 var(--f-display);
+}
+
+.ob-conv-voice-result p {
+  margin: 0;
+  color: var(--textContent);
+  font: 400 0.9375rem / 1.5 var(--f-body);
+}
+
 /* A finding the narration just named lights its dossier card briefly. */
 .ob-conv-pulse {
   animation: ob-conv-pulse 1.6s ease-out;

--- a/frontend/src/screens/onboarding-conversation/index.tsx
+++ b/frontend/src/screens/onboarding-conversation/index.tsx
@@ -9,6 +9,7 @@ import {
   initialConversationState,
 } from "./conversation-machine";
 import { useWizardStatePersist } from "./use-wizard-state";
+import { VoiceAct } from "./voice-act";
 
 // The conversational onboarding shell: one pure machine owns where the
 // conversation is, and each act renders inside the shared Margince
@@ -58,14 +59,16 @@ export function OnboardingConversationScreen() {
 
   return (
     <div className="ob-page ob-conv-page">
-      {state.act === "company" ? (
+      {state.act === "company" && (
         <CompanyAct
           state={state}
           dispatch={dispatch}
           profile={existing.data ?? null}
           persist={persist}
         />
-      ) : (
+      )}
+      {state.act === "voice" && <VoiceAct state={state} dispatch={dispatch} />}
+      {state.act !== "company" && state.act !== "voice" && (
         <ActStubs state={state} dispatch={dispatch} persist={persist} />
       )}
     </div>

--- a/frontend/src/screens/onboarding-conversation/narration.ts
+++ b/frontend/src/screens/onboarding-conversation/narration.ts
@@ -182,7 +182,10 @@ export function diffVoiceBuild(
   return [];
 }
 
-const bandLabelKeys: Record<VoiceCorpusSummary["quality_band"], MessageKey> = {
+export const bandLabelKeys: Record<
+  VoiceCorpusSummary["quality_band"],
+  MessageKey
+> = {
   thin: "settings.voice.bandThin",
   good: "settings.voice.bandGood",
   rich: "settings.voice.bandRich",

--- a/frontend/src/screens/onboarding-conversation/use-voice-build.ts
+++ b/frontend/src/screens/onboarding-conversation/use-voice-build.ts
@@ -1,0 +1,160 @@
+import { useMutation, useQuery } from "@tanstack/react-query";
+import type { Dispatch } from "react";
+import { useEffect, useRef, useState } from "react";
+import { api } from "../../api/client";
+import type { components } from "../../api/schema";
+import { problemMessage } from "../common";
+import { pickBuiltVersion } from "../onboarding";
+import type {
+  BuildStage,
+  BuildTerminalStatus,
+  ConversationEvent,
+} from "./conversation-machine";
+import type { VoiceBuildSnapshot } from "./narration";
+import { diffVoiceBuild, useNarrationQueue } from "./narration";
+
+// The voice build lifecycle as one hook: start the build, poll its durable
+// row, narrate stage deltas, and conclude with a correlated terminal event.
+// diffVoiceBuild computes what is new per snapshot; its stage events ride
+// the paced queue and are re-dispatched as BUILD_STAGE machine events, so
+// the machine's correlation guard (stale build ids, deferred resume from
+// vo.result) stays the single authority on what may speak.
+
+type VoiceBuild = components["schemas"]["VoiceBuild"];
+type VoiceProfileVersion = components["schemas"]["VoiceProfileVersion"];
+
+const POLL_MS = 1200;
+const DEFERRED_POLL_MS = 60_000;
+
+// Type-honest narrowing of a polled status to the machine's terminal union;
+// queued/running are not terminals and map to null.
+function terminalOf(status: VoiceBuild["status"]): BuildTerminalStatus | null {
+  return status === "succeeded" || status === "failed" || status === "deferred"
+    ? status
+    : null;
+}
+
+const BUILD_STAGES: readonly BuildStage[] = [
+  "snapshot",
+  "extract",
+  "evaluate",
+  "activate",
+];
+
+type UseVoiceBuildArgs = Readonly<{
+  dispatch: Dispatch<ConversationEvent>;
+  /** The corpus hook's single-flight profile resolution. */
+  sharedProfileId: () => Promise<string>;
+}>;
+
+export function useVoiceBuild({
+  dispatch,
+  sharedProfileId,
+}: UseVoiceBuildArgs) {
+  const [profileId, setProfileId] = useState<string | null>(null);
+  const [buildId, setBuildId] = useState<string | null>(null);
+  const prevSnapshot = useRef<VoiceBuildSnapshot | null>(null);
+
+  const queue = useNarrationQueue({
+    onEmit: (event) => {
+      // diffVoiceBuild only says stages, under `<buildId>:stage:<stage>` ids
+      // (a build id is a UUID, so the first colon splits it off cleanly).
+      const [runId, , stagePart] = event.id.split(":");
+      const stage = BUILD_STAGES.find((known) => known === stagePart);
+      if (runId !== undefined && stage !== undefined) {
+        dispatch({ type: "BUILD_STAGE", buildId: runId, stage });
+      }
+    },
+  });
+
+  const start = useMutation({
+    mutationFn: async (): Promise<{ profileId: string; buildId: string }> => {
+      const id = await sharedProfileId();
+      const { data, error } = await api.POST("/voice-profiles/{id}/builds", {
+        params: { path: { id } },
+        body: { reason: "onboarding" },
+      });
+      if (error) {
+        throw new Error(problemMessage(error));
+      }
+      return { profileId: id, buildId: data.id };
+    },
+    onSuccess: ({ profileId: profile, buildId: build }) => {
+      prevSnapshot.current = null;
+      setProfileId(profile);
+      setBuildId(build);
+      dispatch({ type: "BUILD_STARTED", buildId: build });
+    },
+  });
+
+  const poll = useQuery({
+    queryKey: ["voice-build", profileId, buildId],
+    enabled: profileId !== null && buildId !== null,
+    queryFn: async (): Promise<VoiceBuild> => {
+      const { data, error } = await api.GET(
+        "/voice-profiles/{id}/builds/{buildId}",
+        { params: { path: { id: profileId ?? "", buildId: buildId ?? "" } } },
+      );
+      if (error) {
+        throw new Error(problemMessage(error));
+      }
+      return data;
+    },
+    refetchInterval: (query) => {
+      const status = query.state.data?.status;
+      if (status === "queued" || status === "running") {
+        return POLL_MS;
+      }
+      // A deferred build resumes on its own (budget window); keep a slow
+      // poll so the resume re-enters vo.building without a reload.
+      return status === "deferred" ? DEFERRED_POLL_MS : false;
+    },
+  });
+
+  useEffect(() => {
+    const next = poll.data;
+    if (!next) {
+      return;
+    }
+    const snapshot: VoiceBuildSnapshot = {
+      id: next.id,
+      status: next.status,
+      stage: next.stage,
+    };
+    const events = diffVoiceBuild(prevSnapshot.current, snapshot);
+    prevSnapshot.current = snapshot;
+    const flushed = events.some((event) => event.kind === "flush");
+    // Stage narration first (the flush drains it), then the terminal — so
+    // progress always lands before the outcome.
+    queue.push(events);
+    const terminal = terminalOf(next.status);
+    if (flushed && terminal !== null) {
+      dispatch({ type: "BUILD_TERMINAL", buildId: next.id, status: terminal });
+    }
+  }, [poll.data, queue, dispatch]);
+
+  // What the finished build produced: the just-built version carries the
+  // structured insights (candidate when it awaits review). A failed version
+  // read degrades the result card to its honest empty line, never blocks.
+  const builtVersion = useQuery({
+    queryKey: ["voice-built-version", profileId, buildId],
+    enabled: profileId !== null && poll.data?.status === "succeeded",
+    queryFn: async (): Promise<VoiceProfileVersion | null> => {
+      const { data, error } = await api.GET("/voice-profiles/{id}/versions", {
+        params: { path: { id: profileId ?? "" } },
+      });
+      if (error) {
+        throw new Error(problemMessage(error));
+      }
+      return pickBuiltVersion(data.data);
+    },
+  });
+
+  return {
+    /** Starts (or after a failure, restarts) a build. */
+    start,
+    /** Current build stage for the artifact tracker; null outside a run. */
+    stage: poll.data?.status === "running" ? (poll.data.stage ?? null) : null,
+    builtVersion,
+  };
+}

--- a/frontend/src/screens/onboarding-conversation/use-voice-build.ts
+++ b/frontend/src/screens/onboarding-conversation/use-voice-build.ts
@@ -9,6 +9,7 @@ import type {
   BuildStage,
   BuildTerminalStatus,
   ConversationEvent,
+  ConversationState,
 } from "./conversation-machine";
 import type { VoiceBuildSnapshot } from "./narration";
 import { diffVoiceBuild, useNarrationQueue } from "./narration";
@@ -43,12 +44,15 @@ const BUILD_STAGES: readonly BuildStage[] = [
 
 type UseVoiceBuildArgs = Readonly<{
   dispatch: Dispatch<ConversationEvent>;
+  /** Live view of the machine, for the poll-failure fallback guards. */
+  machine: Readonly<{ current: ConversationState }>;
   /** The corpus hook's single-flight profile resolution. */
   sharedProfileId: () => Promise<string>;
 }>;
 
 export function useVoiceBuild({
   dispatch,
+  machine,
   sharedProfileId,
 }: UseVoiceBuildArgs) {
   const [profileId, setProfileId] = useState<string | null>(null);
@@ -132,6 +136,34 @@ export function useVoiceBuild({
       dispatch({ type: "BUILD_TERMINAL", buildId: next.id, status: terminal });
     }
   }, [poll.data, queue, dispatch]);
+
+  // A persistently failing poll must not strand the act in vo.building:
+  // isError flips only after react-query exhausted its retries (a transient
+  // error that recovers never lands here), and only the still-active,
+  // still-building run is concluded — a run whose real terminal already
+  // moved the machine to vo.result (or a superseded build id) keeps its
+  // recorded outcome. The failed conclusion re-arms the retry chip; the
+  // durable build keeps running server-side either way.
+  useEffect(() => {
+    if (!poll.isError || buildId === null) {
+      return;
+    }
+    const { phase, activeBuildId } = machine.current;
+    if (phase !== "vo.building" || activeBuildId !== buildId) {
+      return;
+    }
+    queue.flush();
+    dispatch({
+      type: "NARRATION",
+      buildId,
+      entry: {
+        kind: "narration",
+        id: `${buildId}:poll-failed`,
+        i18nKey: "ob.conv.voice.buildPollFailed",
+      },
+    });
+    dispatch({ type: "BUILD_TERMINAL", buildId, status: "failed" });
+  }, [poll.isError, buildId, machine, queue, dispatch]);
 
   // What the finished build produced: the just-built version carries the
   // structured insights (candidate when it awaits review). A failed version

--- a/frontend/src/screens/onboarding-conversation/use-voice-corpus.ts
+++ b/frontend/src/screens/onboarding-conversation/use-voice-corpus.ts
@@ -58,6 +58,31 @@ const refusalKeys: Record<string, MessageKey> = {
   unsupported_format: "ob.conv.voice.refusalUnsupported",
 };
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+// Every stable machine code an RFC 7807 body carries: the top-level `code`
+// plus any per-field `details.errors[].code`.
+function problemCodes(problem: unknown): string[] {
+  if (!isRecord(problem)) {
+    return [];
+  }
+  const codes: string[] = [];
+  if (typeof problem.code === "string") {
+    codes.push(problem.code);
+  }
+  const details = problem.details;
+  if (isRecord(details) && Array.isArray(details.errors)) {
+    for (const raw of details.errors) {
+      if (isRecord(raw) && typeof raw.code === "string") {
+        codes.push(raw.code);
+      }
+    }
+  }
+  return codes;
+}
+
 // The 422's stable machine code (top-level or per-field in details.errors)
 // picks the honest refusal line; an unknown code falls back to the server's
 // safe detail.
@@ -65,23 +90,9 @@ function refusalEntry(
   ref: string,
   problem: unknown,
 ): Extract<ConversationEvent, { type: "NARRATION" }>["entry"] {
-  const codes: string[] = [];
-  if (problem && typeof problem === "object") {
-    const record = problem as Record<string, unknown>;
-    if (typeof record.code === "string") {
-      codes.push(record.code);
-    }
-    const details = record.details as Record<string, unknown> | undefined;
-    if (details && Array.isArray(details.errors)) {
-      for (const raw of details.errors) {
-        const code = (raw as Record<string, unknown> | null)?.code;
-        if (typeof code === "string") {
-          codes.push(code);
-        }
-      }
-    }
-  }
-  const known = codes.find((code) => refusalKeys[code] !== undefined);
+  const known = problemCodes(problem).find(
+    (code) => refusalKeys[code] !== undefined,
+  );
   if (known !== undefined) {
     return {
       kind: "narration",
@@ -170,8 +181,17 @@ export function useVoiceCorpus({ state, dispatch }: UseVoiceCorpusArgs) {
     return profileIdInFlight.current;
   }, []);
 
+  // Concurrent ingests can settle out of order; each request is stamped at
+  // issue time and only the newest-by-request-order summary may drive the
+  // meter and the word-growth narration. Every response's summary is
+  // authoritative for the corpus AT that request — a stale one arriving
+  // late must not roll the displayed totals (and the build gate) backwards.
+  const ingestSeq = useRef(0);
+  const appliedSummarySeq = useRef(0);
+
   const recordIngest = useCallback(
     (
+      seq: number,
       entry: CorpusManifestEntry,
       stats: IngestStats,
       next: CorpusSummary,
@@ -189,6 +209,10 @@ export function useVoiceCorpus({ state, dispatch }: UseVoiceCorpusArgs) {
         total: stats.input_words,
         words: stats.kept_words,
       });
+      if (seq <= appliedSummarySeq.current) {
+        return;
+      }
+      appliedSummarySeq.current = seq;
       queue.push(diffCorpus(summaryRef.current, next));
       summaryRef.current = next;
       setSummary(next);
@@ -202,6 +226,8 @@ export function useVoiceCorpus({ state, dispatch }: UseVoiceCorpusArgs) {
       transcript: boolean,
       reactionKey: MessageKey,
     ): Promise<void> => {
+      ingestSeq.current += 1;
+      const seq = ingestSeq.current;
       const profileId = await sharedProfileId();
       const { data, error } = await api.POST("/voice-profiles/{id}/sources", {
         params: { path: { id: profileId } },
@@ -217,6 +243,7 @@ export function useVoiceCorpus({ state, dispatch }: UseVoiceCorpusArgs) {
         return;
       }
       recordIngest(
+        seq,
         {
           ref: body.source_ref,
           label: body.source_label,

--- a/frontend/src/screens/onboarding-conversation/use-voice-corpus.ts
+++ b/frontend/src/screens/onboarding-conversation/use-voice-corpus.ts
@@ -1,0 +1,471 @@
+import type { Dispatch } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { api } from "../../api/client";
+import type { components } from "../../api/schema";
+import type { MessageKey } from "../../i18n/en";
+import { problemMessage } from "../common";
+import { ACCEPTED_CORPUS_FILE, TRANSCRIPT_EXT } from "../onboarding";
+import type {
+  ConversationEvent,
+  ConversationState,
+} from "./conversation-machine";
+import { diffCorpus, useNarrationQueue } from "./narration";
+
+// The voice corpus of the conversational shell as one hook: intake (files
+// and pasted text), the preview probe that decides what a source honestly
+// IS, the speaker question for conversational material, and ingestion at
+// add-time. Every count the conversation shows is a server number — the
+// preview's per-speaker words, the ingest's kept-of-total stats, and the
+// corpus summary the meter renders. Client-side word counting only
+// pre-gates empty files; it never reaches the thread.
+
+type CorpusPreview = components["schemas"]["VoiceCorpusPreviewResult"];
+type CorpusSummary = components["schemas"]["VoiceCorpusSummary"];
+type IngestStats = components["schemas"]["VoiceIngestStats"];
+type IngestRequest = components["schemas"]["IngestVoiceCorpusSourceRequest"];
+
+// A .txt is treated as a transcript when the preview attributes at least
+// this share of its spoken words to labelled speakers.
+const ATTRIBUTED_SHARE = 0.8;
+
+export type CorpusManifestEntry = Readonly<{
+  ref: string;
+  label: string;
+  /** Server-counted words that survived the speaker filter. */
+  keptWords: number;
+  /** Server-counted words of the whole source before filtering. */
+  inputWords: number;
+  /** Kept-of-total is shown only where filtering actually discarded turns. */
+  transcript: boolean;
+}>;
+
+type SpeakerAsk = Readonly<{
+  ref: string;
+  label: string;
+  content: string;
+  preview: CorpusPreview;
+}>;
+
+type UseVoiceCorpusArgs = Readonly<{
+  state: ConversationState;
+  dispatch: Dispatch<ConversationEvent>;
+}>;
+
+const refusalKeys: Record<string, MessageKey> = {
+  unattributed_transcript: "ob.conv.voice.refusalUnattributed",
+  speaker_label_required: "ob.conv.voice.refusalUnattributed",
+  speaker_not_found: "ob.conv.voice.refusalSpeaker",
+  unsupported_format: "ob.conv.voice.refusalUnsupported",
+};
+
+// The 422's stable machine code (top-level or per-field in details.errors)
+// picks the honest refusal line; an unknown code falls back to the server's
+// safe detail.
+function refusalEntry(
+  ref: string,
+  problem: unknown,
+): Extract<ConversationEvent, { type: "NARRATION" }>["entry"] {
+  const codes: string[] = [];
+  if (problem && typeof problem === "object") {
+    const record = problem as Record<string, unknown>;
+    if (typeof record.code === "string") {
+      codes.push(record.code);
+    }
+    const details = record.details as Record<string, unknown> | undefined;
+    if (details && Array.isArray(details.errors)) {
+      for (const raw of details.errors) {
+        const code = (raw as Record<string, unknown> | null)?.code;
+        if (typeof code === "string") {
+          codes.push(code);
+        }
+      }
+    }
+  }
+  const known = codes.find((code) => refusalKeys[code] !== undefined);
+  if (known !== undefined) {
+    return {
+      kind: "narration",
+      id: `refuse:${ref}`,
+      i18nKey: refusalKeys[known],
+    };
+  }
+  return {
+    kind: "narration",
+    id: `refuse:${ref}`,
+    i18nKey: "ob.conv.voice.ingestFailed",
+    params: { detail: problemMessage(problem) },
+  };
+}
+
+// What one previewed file honestly IS: a conversational source needs the
+// speaker answer first; a transcript-shaped file nobody is attributable in
+// is refused whole (none of it can be proven the owner's own words); and
+// single-author prose ingests directly.
+function routePreview(
+  name: string,
+  preview: CorpusPreview,
+): "ask-speaker" | "refuse" | "document" {
+  const attributedWords = preview.speakers.reduce(
+    (sum, speaker) => sum + speaker.words,
+    0,
+  );
+  const conversational =
+    TRANSCRIPT_EXT.test(name) ||
+    attributedWords >= preview.total_words * ATTRIBUTED_SHARE;
+  if (conversational && preview.ingestible_as_transcript) {
+    return "ask-speaker";
+  }
+  return TRANSCRIPT_EXT.test(name) ? "refuse" : "document";
+}
+
+export function useVoiceCorpus({ state, dispatch }: UseVoiceCorpusArgs) {
+  const [summary, setSummary] = useState<CorpusSummary | null>(null);
+  const [manifest, setManifest] = useState<readonly CorpusManifestEntry[]>([]);
+  const [asks, setAsks] = useState<readonly SpeakerAsk[]>([]);
+  const [probesInFlight, setProbesInFlight] = useState(0);
+  const summaryRef = useRef<CorpusSummary | null>(null);
+  const pasteSeq = useRef(0);
+  const mounted = useRef(true);
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+
+  // Corpus growth narrates as a run-agnostic monotonic counter: the queue's
+  // pacing keeps a multi-file burst readable, and the machine replaces the
+  // words bubble in place per its stable id.
+  const queue = useNarrationQueue({
+    onEmit: (event) => {
+      const { kind: _kind, ...entry } = event;
+      dispatch({ type: "NARRATION", entry: { kind: "narration", ...entry } });
+    },
+  });
+
+  const say = useCallback(
+    (
+      id: string,
+      i18nKey: MessageKey,
+      params?: Record<string, string | number>,
+    ) => {
+      dispatch({
+        type: "NARRATION",
+        entry: { kind: "narration", id, i18nKey, params },
+      });
+    },
+    [dispatch],
+  );
+
+  // Parallel uploads share ONE profile resolution: concurrent creates would
+  // race into the server's one-live-profile conflict. A failed resolution
+  // clears the slot so the next intake retries instead of inheriting a dead
+  // promise.
+  const profileIdInFlight = useRef<Promise<string> | null>(null);
+  const sharedProfileId = useCallback((): Promise<string> => {
+    profileIdInFlight.current ??= ensureProfileId().catch((err: unknown) => {
+      profileIdInFlight.current = null;
+      throw err;
+    });
+    return profileIdInFlight.current;
+  }, []);
+
+  const recordIngest = useCallback(
+    (
+      entry: CorpusManifestEntry,
+      stats: IngestStats,
+      next: CorpusSummary,
+      reactionKey: MessageKey,
+    ) => {
+      if (!mounted.current) {
+        return;
+      }
+      setManifest((prev) => [
+        ...prev.filter((existing) => existing.ref !== entry.ref),
+        entry,
+      ]);
+      say(`react:${entry.ref}`, reactionKey, {
+        kept: stats.kept_words,
+        total: stats.input_words,
+        words: stats.kept_words,
+      });
+      queue.push(diffCorpus(summaryRef.current, next));
+      summaryRef.current = next;
+      setSummary(next);
+    },
+    [queue, say],
+  );
+
+  const ingest = useCallback(
+    async (
+      body: IngestRequest,
+      transcript: boolean,
+      reactionKey: MessageKey,
+    ): Promise<void> => {
+      const profileId = await sharedProfileId();
+      const { data, error } = await api.POST("/voice-profiles/{id}/sources", {
+        params: { path: { id: profileId } },
+        body,
+      });
+      if (error) {
+        if (mounted.current) {
+          dispatch({
+            type: "NARRATION",
+            entry: refusalEntry(body.source_ref, error),
+          });
+        }
+        return;
+      }
+      recordIngest(
+        {
+          ref: body.source_ref,
+          label: body.source_label,
+          keptWords: data.ingest_stats.kept_words,
+          inputWords: data.ingest_stats.input_words,
+          transcript,
+        },
+        data.ingest_stats,
+        data.summary,
+        reactionKey,
+      );
+    },
+    [dispatch, recordIngest, sharedProfileId],
+  );
+
+  // Preview one accepted file and act on what it honestly IS (routePreview);
+  // the empty pre-gate is the only client-side counting anywhere.
+  const classifyUpload = useCallback(
+    async (name: string, text: string): Promise<void> => {
+      const ref = `onboarding:upload:${name}`;
+      if (text.split(/\s+/).filter(Boolean).length === 0) {
+        say(`skip:${name}`, "ob.conv.voice.fileEmpty", { name });
+        return;
+      }
+      const profileId = await sharedProfileId();
+      const { data, error } = await api.POST(
+        "/voice-profiles/{id}/sources/preview",
+        {
+          params: { path: { id: profileId } },
+          body: { format: "transcript", content: text },
+        },
+      );
+      if (error) {
+        if (mounted.current) {
+          dispatch({ type: "NARRATION", entry: refusalEntry(ref, error) });
+        }
+        return;
+      }
+      if (!mounted.current) {
+        return;
+      }
+      const route = routePreview(name, data);
+      if (route === "ask-speaker") {
+        // A re-upload under the same name supersedes its pending question;
+        // the ingest itself is idempotent on source_ref server-side.
+        setAsks((prev) => [
+          ...prev.filter((ask) => ask.ref !== ref),
+          { ref, label: name, content: text, preview: data },
+        ]);
+        return;
+      }
+      if (route === "refuse") {
+        say(`refuse:${ref}`, "ob.conv.voice.refusalUnattributed");
+        return;
+      }
+      await ingest(
+        {
+          kind: "document",
+          register: "general",
+          weight: 1,
+          source_label: name,
+          source_ref: ref,
+          format: "text",
+          speaker_label: null,
+          content: text,
+        },
+        false,
+        "ob.conv.voice.reactionDocument",
+      );
+    },
+    [dispatch, ingest, say, sharedProfileId],
+  );
+
+  // One intake for all three entry paths: the attach button, a drop onto the
+  // thread, and (via addPaste) the composer. V1 corpus is text only;
+  // anything else is refused by name.
+  const addFiles = useCallback(
+    (files: readonly File[]) => {
+      for (const file of files) {
+        if (!ACCEPTED_CORPUS_FILE.test(file.name)) {
+          say(`skip:${file.name}`, "ob.conv.voice.fileSkipped", {
+            name: file.name,
+          });
+          continue;
+        }
+        dispatch({
+          type: "UPLOAD_ADDED",
+          id: `onboarding:upload:${file.name}`,
+          name: file.name,
+        });
+        setProbesInFlight((count) => count + 1);
+        file
+          .text()
+          .then((text) => classifyUpload(file.name, text))
+          .catch((err: unknown) => {
+            if (mounted.current) {
+              say(
+                `refuse:onboarding:upload:${file.name}`,
+                "ob.conv.voice.ingestFailed",
+                {
+                  detail: err instanceof Error ? err.message : String(err),
+                },
+              );
+            }
+          })
+          .finally(() => {
+            if (mounted.current) {
+              setProbesInFlight((count) => count - 1);
+            }
+          });
+      }
+    },
+    [classifyUpload, dispatch, say],
+  );
+
+  const addPaste = useCallback(
+    (text: string, label: string) => {
+      pasteSeq.current += 1;
+      const ref = `onboarding:paste:${pasteSeq.current}`;
+      dispatch({ type: "UPLOAD_ADDED", id: ref, name: label });
+      setProbesInFlight((count) => count + 1);
+      void ingest(
+        {
+          kind: "other",
+          register: "general",
+          weight: 1,
+          source_label: label,
+          source_ref: ref,
+          format: "text",
+          speaker_label: null,
+          content: text,
+        },
+        false,
+        "ob.conv.voice.reactionDocument",
+      )
+        .catch((err: unknown) => {
+          if (mounted.current) {
+            say(`refuse:${ref}`, "ob.conv.voice.ingestFailed", {
+              detail: err instanceof Error ? err.message : String(err),
+            });
+          }
+        })
+        .finally(() => {
+          if (mounted.current) {
+            setProbesInFlight((count) => count - 1);
+          }
+        });
+    },
+    [dispatch, ingest, say],
+  );
+
+  // The machine holds ONE pending question, so speaker asks queue here and
+  // step forward whenever the conversation is back in vo.collecting. A
+  // duplicate dispatch (StrictMode, a re-render race) is inert: the machine
+  // rejects SPEAKER_NEEDED outside vo.collecting.
+  const nextAsk = asks[0];
+  useEffect(() => {
+    if (
+      nextAsk === undefined ||
+      state.phase !== "vo.collecting" ||
+      state.pendingQuestion !== null
+    ) {
+      return;
+    }
+    dispatch({
+      type: "SPEAKER_NEEDED",
+      question: {
+        id: `speaker:${nextAsk.ref}`,
+        i18nKey: "ob.conv.voice.speakerQuestion",
+        options: nextAsk.preview.speakers.map((speaker) => ({
+          value: speaker.label,
+          label: speaker.label,
+          detailKey: "ob.conv.voice.speakerOptionDetail" as const,
+          params: { words: speaker.words, turns: speaker.turns },
+        })),
+      },
+    });
+  }, [nextAsk, state.phase, state.pendingQuestion, dispatch]);
+
+  // The owner named themselves: ingest with the speaker filter, so only that
+  // speaker's server-counted words ever reach the meter.
+  const answerSpeaker = useCallback(
+    (questionId: string, value: string) => {
+      const ask = asks.find(
+        (candidate) => `speaker:${candidate.ref}` === questionId,
+      );
+      if (!ask) {
+        return;
+      }
+      setAsks((prev) => prev.filter((candidate) => candidate.ref !== ask.ref));
+      setProbesInFlight((count) => count + 1);
+      void ingest(
+        {
+          kind: "transcript",
+          register: "spoken",
+          weight: 1,
+          source_label: ask.label,
+          source_ref: ask.ref,
+          format: "transcript",
+          speaker_label: value,
+          content: ask.content,
+        },
+        true,
+        "ob.conv.voice.reactionTranscript",
+      )
+        .catch((err: unknown) => {
+          if (mounted.current) {
+            say(`refuse:${ask.ref}`, "ob.conv.voice.ingestFailed", {
+              detail: err instanceof Error ? err.message : String(err),
+            });
+          }
+        })
+        .finally(() => {
+          if (mounted.current) {
+            setProbesInFlight((count) => count - 1);
+          }
+        });
+    },
+    [asks, ingest, say],
+  );
+
+  return {
+    summary,
+    manifest,
+    addFiles,
+    addPaste,
+    answerSpeaker,
+    sharedProfileId,
+    /** True while any probe, ingest, or speaker question is still open —
+     * a build starting now would misrepresent what the voice is made of. */
+    busy: probesInFlight > 0 || asks.length > 0,
+  };
+}
+
+// Reuse the owner's single profile (the list caps at one) or mint it.
+async function ensureProfileId(): Promise<string> {
+  const list = await api.GET("/voice-profiles");
+  if (list.error) {
+    throw new Error(problemMessage(list.error));
+  }
+  const existing = list.data.data[0]?.id;
+  if (existing) {
+    return existing;
+  }
+  const created = await api.POST("/voice-profiles", {
+    body: { personality_md: "" },
+  });
+  if (created.error) {
+    throw new Error(problemMessage(created.error));
+  }
+  return created.data.id;
+}

--- a/frontend/src/screens/onboarding-conversation/voice-act.test.tsx
+++ b/frontend/src/screens/onboarding-conversation/voice-act.test.tsx
@@ -1,0 +1,430 @@
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  cleanup,
+  render as rtlRender,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { useReducer } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { components } from "../../api/schema";
+import { LocaleProvider } from "../../i18n";
+import type { ConversationState } from "./conversation-machine";
+import {
+  conversationReducer,
+  initialConversationState,
+} from "./conversation-machine";
+import { run } from "./test-fixtures";
+import { VoiceAct } from "./voice-act";
+
+type CorpusPreview = components["schemas"]["VoiceCorpusPreviewResult"];
+type CorpusSummary = components["schemas"]["VoiceCorpusSummary"];
+type IngestStats = components["schemas"]["VoiceIngestStats"];
+
+const PROFILE_ID = "018f3a1b-0000-7000-8000-0000000000d1";
+const BUILD_IDS = [
+  "018f3a1b-0000-7000-8000-0000000000e1",
+  "018f3a1b-0000-7000-8000-0000000000e2",
+];
+
+function summaryOf(totalWords: number): CorpusSummary {
+  return {
+    total_words: totalWords,
+    target_words: 30000,
+    maturity: "collecting",
+    quality_band: totalWords >= 800 ? "good" : "thin",
+    source_count: 1,
+    register_words: { spoken: totalWords },
+  };
+}
+
+const conversationalPreview: CorpusPreview = {
+  detected_format: "vtt",
+  total_words: 5400,
+  speakers: [
+    { label: "Speaker 1", turns: 12, words: 1240 },
+    { label: "Speaker 2", turns: 14, words: 4160 },
+  ],
+  unattributed_words: 0,
+  ingestible_as_transcript: true,
+};
+
+const unattributedPreview: CorpusPreview = {
+  detected_format: "vtt",
+  total_words: 5400,
+  speakers: [],
+  unattributed_words: 5400,
+  ingestible_as_transcript: false,
+};
+
+const documentPreview: CorpusPreview = {
+  detected_format: "txt",
+  total_words: 900,
+  speakers: [],
+  unattributed_words: 900,
+  ingestible_as_transcript: false,
+};
+
+const transcriptStats: IngestStats = {
+  input_words: 5400,
+  kept_words: 1240,
+  kept_turns: 12,
+  discarded_turns: 14,
+  speakers_seen: ["Speaker 1", "Speaker 2"],
+};
+
+const documentStats: IngestStats = {
+  input_words: 900,
+  kept_words: 900,
+  kept_turns: 1,
+  discarded_turns: 0,
+  speakers_seen: [],
+};
+
+// Build poll rows: only the fields the hook reads; the stub serves them as
+// plain JSON exactly like the server would.
+type BuildRow = { id: string; status: string; stage: string | null };
+
+const candidateVersion = {
+  profile_version: 3,
+  status: "candidate",
+  model_name: "test-model",
+  profile_json: {
+    inference: { identity_summary: "Direct, concrete, first person." },
+  },
+  stats_json: { word_count: 1240 },
+};
+
+type StubOptions = {
+  preview?: CorpusPreview;
+  /** Ingest responses in order: each carries its stats + resulting summary. */
+  ingests?: readonly { stats: IngestStats; summary: CorpusSummary }[];
+  /** Poll snapshots per build id, consumed one per GET (last one repeats). */
+  builds?: Readonly<Record<string, BuildRow[]>>;
+};
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function stubApi(options: StubOptions = {}) {
+  const calls: Request[] = [];
+  let ingestIndex = 0;
+  let buildIndex = 0;
+  const buildPolls = new Map<string, BuildRow[]>(
+    Object.entries(options.builds ?? {}),
+  );
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (request: Request) => {
+      calls.push(request);
+      const path = new URL(request.url).pathname;
+      if (path.endsWith("/ai/profile")) {
+        return jsonResponse({
+          name: "Margince",
+          kind: "ai",
+          state: "configured",
+          inference_mode: "cloud",
+          providers: ["gemini"],
+          configured_models: [
+            {
+              tier: "cheap_cloud",
+              provider: "gemini",
+              model: "gemini-3.5-flash",
+            },
+          ],
+        });
+      }
+      if (path.endsWith("/voice-profiles") && request.method === "GET") {
+        return jsonResponse({
+          data: [{ id: PROFILE_ID }],
+          page: { next_cursor: null },
+        });
+      }
+      if (path.endsWith("/sources/preview")) {
+        return jsonResponse(options.preview ?? documentPreview);
+      }
+      if (path.endsWith("/sources") && request.method === "POST") {
+        const ingest = (options.ingests ?? [])[ingestIndex];
+        if (!ingest) {
+          throw new Error("unexpected ingest: no fixture left");
+        }
+        ingestIndex += 1;
+        return jsonResponse(
+          {
+            source: { id: `source-${ingestIndex}` },
+            summary: ingest.summary,
+            ingest_stats: ingest.stats,
+          },
+          201,
+        );
+      }
+      if (path.endsWith("/builds") && request.method === "POST") {
+        const id = BUILD_IDS[buildIndex];
+        buildIndex += 1;
+        return jsonResponse({ id, status: "queued", stage: null }, 202);
+      }
+      if (path.includes("/builds/") && request.method === "GET") {
+        const buildId = path.slice(path.lastIndexOf("/") + 1);
+        const polls = buildPolls.get(buildId) ?? [];
+        const row = polls.length > 1 ? polls.shift() : polls[0];
+        if (!row) {
+          throw new Error(`unstubbed build poll: ${buildId}`);
+        }
+        return jsonResponse(row);
+      }
+      if (path.endsWith("/versions") && request.method === "GET") {
+        return jsonResponse({
+          data: [candidateVersion],
+          page: { next_cursor: null },
+        });
+      }
+      throw new Error(`unstubbed request: ${request.method} ${request.url}`);
+    }),
+  );
+  return calls;
+}
+
+function collectingState(): ConversationState {
+  return { ...initialConversationState, act: "voice", phase: "vo.collecting" };
+}
+
+function VoiceHarness({ initial }: Readonly<{ initial: ConversationState }>) {
+  const [state, dispatch] = useReducer(conversationReducer, initial);
+  return <VoiceAct state={state} dispatch={dispatch} />;
+}
+
+function render(ui: ReactNode) {
+  return rtlRender(
+    <QueryClientProvider
+      client={
+        new QueryClient({ defaultOptions: { queries: { retry: false } } })
+      }
+    >
+      <LocaleProvider initial="en">{ui}</LocaleProvider>
+    </QueryClientProvider>,
+  );
+}
+
+async function uploadFile(name: string, content: string) {
+  const input = document.querySelector<HTMLInputElement>('input[type="file"]');
+  expect(input).not.toBeNull();
+  if (input) {
+    await userEvent.upload(
+      input,
+      new File([content], name, { type: "text/plain" }),
+    );
+  }
+}
+
+// Path-suffix matching so "/sources" never also counts "/sources/preview".
+function requestsTo(calls: Request[], path: string, method: string) {
+  return calls.filter(
+    (request) =>
+      new URL(request.url).pathname.endsWith(path) && request.method === method,
+  );
+}
+
+beforeEach(() => {
+  vi.stubGlobal("scrollTo", vi.fn());
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("the conversational voice act", () => {
+  it("asks the speaker question for a conversational file and ingests with the chosen speaker_label", async () => {
+    const calls = stubApi({
+      preview: conversationalPreview,
+      ingests: [{ stats: transcriptStats, summary: summaryOf(1240) }],
+    });
+    render(<VoiceHarness initial={collectingState()} />);
+
+    await uploadFile("call.vtt", "WEBVTT transcript content");
+
+    // The attachment turn lands, then the server-derived speaker options.
+    expect(await screen.findByText("Added call.vtt.")).toBeTruthy();
+    expect(
+      await screen.findByText(/Which one is you\? Only your own words count/),
+    ).toBeTruthy();
+    expect(screen.getByText("words: 1240 · turns: 12")).toBeTruthy();
+    expect(screen.getByText("words: 4160 · turns: 14")).toBeTruthy();
+
+    await userEvent.click(screen.getByRole("button", { name: /Speaker 1/ }));
+
+    await waitFor(() => {
+      expect(requestsTo(calls, "/sources", "POST").length).toBe(1);
+    });
+    const body = (await requestsTo(calls, "/sources", "POST")[0]
+      .clone()
+      .json()) as Record<string, unknown>;
+    expect(body.format).toBe("transcript");
+    expect(body.speaker_label).toBe("Speaker 1");
+    expect(body.register).toBe("spoken");
+
+    // The reaction speaks the server's kept-of-total stats, nothing else.
+    expect(
+      await screen.findByText(/Words kept: 1240 of 5400\. Only your turns/),
+    ).toBeTruthy();
+    expect(await screen.findByText(/Kept 1240 of 5400 words/)).toBeTruthy();
+  });
+
+  it("ingests a document directly and reacts with the server word count", async () => {
+    const calls = stubApi({
+      preview: documentPreview,
+      ingests: [{ stats: documentStats, summary: summaryOf(900) }],
+    });
+    render(<VoiceHarness initial={collectingState()} />);
+
+    await uploadFile("notes.md", "Plain prose I wrote myself.");
+
+    expect(await screen.findByText(/Words counted: 900\./)).toBeTruthy();
+    const body = (await requestsTo(calls, "/sources", "POST")[0]
+      .clone()
+      .json()) as Record<string, unknown>;
+    expect(body.format).toBe("text");
+    expect(body.speaker_label).toBeNull();
+    // No speaker question was ever asked for single-author prose.
+    expect(screen.queryByText(/Which one is you/)).toBeNull();
+  });
+
+  it("refuses an unattributed transcript honestly and counts nothing", async () => {
+    const calls = stubApi({ preview: unattributedPreview });
+    render(<VoiceHarness initial={collectingState()} />);
+
+    await uploadFile("raw.vtt", "unlabelled transcript text");
+
+    expect(
+      await screen.findByText(/I counted nothing, because I only count words/),
+    ).toBeTruthy();
+    expect(requestsTo(calls, "/sources", "POST").length).toBe(0);
+    expect(screen.queryByText(/Own words:/)).toBeNull();
+  });
+
+  it("offers the build only at the server floor of 800 words", async () => {
+    stubApi({
+      preview: documentPreview,
+      ingests: [
+        { stats: documentStats, summary: summaryOf(500) },
+        { stats: documentStats, summary: summaryOf(820) },
+      ],
+    });
+    render(<VoiceHarness initial={collectingState()} />);
+
+    await uploadFile("one.md", "First document.");
+    expect(
+      await screen.findByText(/Own words so far: 500\. I need at least 800/),
+    ).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: /Build my voice profile/ }),
+    ).toBeNull();
+
+    await uploadFile("two.md", "Second document.");
+    expect(
+      await screen.findByRole("button", { name: /Build my voice profile/ }),
+    ).toBeTruthy();
+    expect(screen.queryByText(/I need at least 800/)).toBeNull();
+  });
+
+  it("narrates build stages and lands the succeeded result card with the candidate note", async () => {
+    stubApi({
+      preview: documentPreview,
+      ingests: [{ stats: documentStats, summary: summaryOf(820) }],
+      builds: {
+        [BUILD_IDS[0]]: [
+          { id: BUILD_IDS[0], status: "running", stage: "extract" },
+          { id: BUILD_IDS[0], status: "succeeded", stage: null },
+        ],
+      },
+    });
+    render(<VoiceHarness initial={collectingState()} />);
+
+    await uploadFile("one.md", "Enough material.");
+    await userEvent.click(
+      await screen.findByRole("button", { name: /Build my voice profile/ }),
+    );
+
+    expect(
+      await screen.findByText(/Finding your signature moves/, undefined, {
+        timeout: 4000,
+      }),
+    ).toBeTruthy();
+    expect(
+      await screen.findByText(/Your voice profile is ready\./, undefined, {
+        timeout: 4000,
+      }),
+    ).toBeTruthy();
+    expect(
+      await screen.findByText(/Here is your voice, in your own words\./),
+    ).toBeTruthy();
+    expect(
+      await screen.findByText(/needs your review before it goes live/),
+    ).toBeTruthy();
+    expect(await screen.findByText(/Direct, concrete/)).toBeTruthy();
+  });
+
+  it("offers a retry after a failed build and a second build proceeds", async () => {
+    const calls = stubApi({
+      preview: documentPreview,
+      ingests: [{ stats: documentStats, summary: summaryOf(820) }],
+      builds: {
+        [BUILD_IDS[0]]: [{ id: BUILD_IDS[0], status: "failed", stage: null }],
+        [BUILD_IDS[1]]: [
+          { id: BUILD_IDS[1], status: "succeeded", stage: null },
+        ],
+      },
+    });
+    render(<VoiceHarness initial={collectingState()} />);
+
+    await uploadFile("one.md", "Enough material.");
+    await userEvent.click(
+      await screen.findByRole("button", { name: /Build my voice profile/ }),
+    );
+
+    expect(
+      await screen.findByText(/The build did not finish/, undefined, {
+        timeout: 4000,
+      }),
+    ).toBeTruthy();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /Try the build again/ }),
+    );
+
+    expect(
+      await screen.findByText(/Your voice profile is ready\./, undefined, {
+        timeout: 4000,
+      }),
+    ).toBeTruthy();
+    expect(requestsTo(calls, "/builds", "POST").length).toBe(2);
+  });
+
+  it("keeps late events from a superseded build inert after the retry", () => {
+    // Machine-level correlation, reusing the shared fold helper: once build
+    // two is the active run, build one's late terminal changes nothing.
+    const retried = run(
+      [
+        { type: "BUILD_STARTED", buildId: BUILD_IDS[0] },
+        { type: "BUILD_TERMINAL", buildId: BUILD_IDS[0], status: "failed" },
+        { type: "BUILD_STARTED", buildId: BUILD_IDS[1] },
+      ],
+      collectingState(),
+    );
+    expect(retried.phase).toBe("vo.building");
+
+    const afterStale = conversationReducer(retried, {
+      type: "BUILD_TERMINAL",
+      buildId: BUILD_IDS[0],
+      status: "succeeded",
+    });
+    expect(afterStale).toBe(retried);
+  });
+});

--- a/frontend/src/screens/onboarding-conversation/voice-act.test.tsx
+++ b/frontend/src/screens/onboarding-conversation/voice-act.test.tsx
@@ -98,13 +98,30 @@ const candidateVersion = {
   stats_json: { word_count: 1240 },
 };
 
+type IngestFixture = {
+  stats: IngestStats;
+  summary: CorpusSummary;
+  /** Response latency, to force out-of-order settlement in tests. */
+  delayMs?: number;
+};
+
 type StubOptions = {
   preview?: CorpusPreview;
   /** Ingest responses in order: each carries its stats + resulting summary. */
-  ingests?: readonly { stats: IngestStats; summary: CorpusSummary }[];
+  ingests?: readonly IngestFixture[];
+  /** Ingest responses keyed by source_label; wins over the ordered list. */
+  ingestsBySource?: Readonly<Record<string, IngestFixture>>;
   /** Poll snapshots per build id, consumed one per GET (last one repeats). */
   builds?: Readonly<Record<string, BuildRow[]>>;
+  /** Error status for the build poll GET (resilience tests). */
+  buildPollStatus?: number;
 };
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    globalThis.setTimeout(resolve, ms);
+  });
+}
 
 function jsonResponse(body: unknown, status = 200) {
   return new Response(JSON.stringify(body), {
@@ -151,11 +168,18 @@ function stubApi(options: StubOptions = {}) {
         return jsonResponse(options.preview ?? documentPreview);
       }
       if (path.endsWith("/sources") && request.method === "POST") {
-        const ingest = (options.ingests ?? [])[ingestIndex];
+        const body = (await request.clone().json()) as Record<string, unknown>;
+        const label =
+          typeof body.source_label === "string" ? body.source_label : "";
+        const bySource = options.ingestsBySource?.[label];
+        const ingest = bySource ?? (options.ingests ?? [])[ingestIndex];
         if (!ingest) {
           throw new Error("unexpected ingest: no fixture left");
         }
         ingestIndex += 1;
+        if (ingest.delayMs !== undefined) {
+          await delay(ingest.delayMs);
+        }
         return jsonResponse(
           {
             source: { id: `source-${ingestIndex}` },
@@ -171,6 +195,12 @@ function stubApi(options: StubOptions = {}) {
         return jsonResponse({ id, status: "queued", stage: null }, 202);
       }
       if (path.includes("/builds/") && request.method === "GET") {
+        if (options.buildPollStatus !== undefined) {
+          return jsonResponse(
+            { detail: "build fetch failed" },
+            options.buildPollStatus,
+          );
+        }
         const buildId = path.slice(path.lastIndexOf("/") + 1);
         const polls = buildPolls.get(buildId) ?? [];
         const row = polls.length > 1 ? polls.shift() : polls[0];
@@ -405,6 +435,62 @@ describe("the conversational voice act", () => {
       }),
     ).toBeTruthy();
     expect(requestsTo(calls, "/builds", "POST").length).toBe(2);
+  });
+
+  it("keeps the newest-by-request-order summary when ingest responses settle out of order", async () => {
+    stubApi({
+      preview: documentPreview,
+      // The first upload's response is held back past the second's: the
+      // stale 500-word summary settles last and must not roll the meter
+      // (or the build gate) back below the floor.
+      ingestsBySource: {
+        "one.md": {
+          stats: documentStats,
+          summary: summaryOf(500),
+          delayMs: 150,
+        },
+        "two.md": { stats: documentStats, summary: summaryOf(820) },
+      },
+    });
+    render(<VoiceHarness initial={collectingState()} />);
+
+    await uploadFile("one.md", "First document.");
+    await uploadFile("two.md", "Second document.");
+
+    // Both per-source reactions land regardless of settlement order.
+    await waitFor(() => {
+      expect(screen.getAllByText(/Words counted: 900\./).length).toBe(2);
+    });
+    expect(await screen.findByText("Own words: 820 of 30000")).toBeTruthy();
+    expect(
+      await screen.findByRole("button", { name: /Build my voice profile/ }),
+    ).toBeTruthy();
+    expect(screen.queryByText(/I need at least 800/)).toBeNull();
+    expect(screen.queryByText("Own words: 500 of 30000")).toBeNull();
+  });
+
+  it("concludes as failed with the retry chip when the build poll keeps erroring", async () => {
+    stubApi({
+      preview: documentPreview,
+      ingests: [{ stats: documentStats, summary: summaryOf(820) }],
+      buildPollStatus: 500,
+    });
+    render(<VoiceHarness initial={collectingState()} />);
+
+    await uploadFile("one.md", "Enough material.");
+    await userEvent.click(
+      await screen.findByRole("button", { name: /Build my voice profile/ }),
+    );
+
+    // The act never sits silent in vo.building: one honest correlated turn,
+    // the failed outcome, and the retry chip back on offer.
+    expect(
+      await screen.findByText(/I lost the connection during the build/),
+    ).toBeTruthy();
+    expect(await screen.findByText(/The build did not finish/)).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: /Try the build again/ }),
+    ).toBeTruthy();
   });
 
   it("keeps late events from a superseded build inert after the retry", () => {

--- a/frontend/src/screens/onboarding-conversation/voice-act.tsx
+++ b/frontend/src/screens/onboarding-conversation/voice-act.tsx
@@ -50,9 +50,12 @@ function corePresence(state: ConversationState): MarginceCoreState {
 
 export function VoiceAct({ state, dispatch }: VoiceActProps) {
   const t = useT();
+  const machine = useRef(state);
+  machine.current = state;
   const corpus = useVoiceCorpus({ state, dispatch });
   const build = useVoiceBuild({
     dispatch,
+    machine,
     sharedProfileId: corpus.sharedProfileId,
   });
   const [draft, setDraft] = useState("");

--- a/frontend/src/screens/onboarding-conversation/voice-act.tsx
+++ b/frontend/src/screens/onboarding-conversation/voice-act.tsx
@@ -1,0 +1,424 @@
+import { Paperclip, Send, Sparkles } from "lucide-react";
+import type { ChangeEvent, Dispatch, DragEvent } from "react";
+import { useRef, useState } from "react";
+import { Button } from "../../design-system/atoms";
+import type { MarginceCoreState } from "../../design-system/margince-core";
+import { useT } from "../../i18n";
+import { ACCEPTED_CORPUS_ATTR, VOICE_MIN_WORDS } from "../onboarding";
+import { parseVoiceInsights, VoiceInsights } from "../voice-insights";
+import type {
+  ConversationEvent,
+  ConversationState,
+} from "./conversation-machine";
+import { NarrationBubble } from "./entries";
+import { ConversationThread } from "./thread";
+import { useVoiceBuild } from "./use-voice-build";
+import { useVoiceCorpus } from "./use-voice-corpus";
+import { VoiceActArtifact } from "./voice-artifact";
+import { ConversationWorkbench } from "./workbench";
+
+// The voice act driver: intake and ingestion live in useVoiceCorpus, the
+// build lifecycle in useVoiceBuild; this component owns the composer (paste
+// offer), the drop target, and the chips — all expressed as machine events,
+// so the pure reducer stays the single truth about where the act is.
+
+// Below this many client-counted words a composer submit is a message, not
+// corpus material; the client count only routes the offer, the server
+// counts what is ingested.
+const PASTE_OFFER_MIN_WORDS = 40;
+
+type VoiceActProps = Readonly<{
+  state: ConversationState;
+  dispatch: Dispatch<ConversationEvent>;
+}>;
+
+function corePresence(state: ConversationState): MarginceCoreState {
+  if (state.phase === "vo.building") {
+    return "working";
+  }
+  if (state.phase === "vo.invite" || state.phase === "vo.speaker") {
+    return "attention";
+  }
+  if (state.phase === "vo.result") {
+    if (state.lastBuildStatus === "succeeded") {
+      return "success";
+    }
+    return state.lastBuildStatus === "failed" ? "error" : "quiet";
+  }
+  return "listening";
+}
+
+export function VoiceAct({ state, dispatch }: VoiceActProps) {
+  const t = useT();
+  const corpus = useVoiceCorpus({ state, dispatch });
+  const build = useVoiceBuild({
+    dispatch,
+    sharedProfileId: corpus.sharedProfileId,
+  });
+  const [draft, setDraft] = useState("");
+  const [pendingPaste, setPendingPaste] = useState<string | null>(null);
+  const [dragOver, setDragOver] = useState(false);
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  const collecting =
+    state.phase === "vo.collecting" || state.phase === "vo.speaker";
+  const serverWords = corpus.summary?.total_words ?? 0;
+  const canBuild =
+    state.phase === "vo.collecting" &&
+    serverWords >= VOICE_MIN_WORDS &&
+    !corpus.busy &&
+    !build.start.isPending;
+
+  const onFiles = (event: ChangeEvent<HTMLInputElement>) => {
+    corpus.addFiles(Array.from(event.target.files ?? []));
+    event.target.value = "";
+  };
+
+  // The whole thread is a drop target while collecting; preventDefault on
+  // dragover is what makes it legal — without it the browser navigates to
+  // the dropped file.
+  const dropProps = collecting
+    ? {
+        onDragOver: (event: DragEvent<HTMLDivElement>) => {
+          event.preventDefault();
+          setDragOver(true);
+        },
+        onDragLeave: () => setDragOver(false),
+        onDrop: (event: DragEvent<HTMLDivElement>) => {
+          event.preventDefault();
+          setDragOver(false);
+          corpus.addFiles(Array.from(event.dataTransfer.files));
+        },
+      }
+    : {};
+
+  const submitComposer = () => {
+    const text = draft.trim();
+    if (text === "" || state.phase !== "vo.collecting") {
+      return;
+    }
+    if (text.split(/\s+/).length >= PASTE_OFFER_MIN_WORDS) {
+      setPendingPaste(text);
+    } else {
+      setPendingPaste(null);
+      dispatch({
+        type: "NARRATION",
+        entry: {
+          kind: "narration",
+          id: "paste:short",
+          i18nKey: "ob.conv.voice.pasteTooShort",
+        },
+      });
+    }
+    setDraft("");
+  };
+
+  const handleAnswer = (questionId: string, value: string) => {
+    dispatch({ type: "QUESTION_ANSWERED", questionId, value });
+    corpus.answerSpeaker(questionId, value);
+  };
+
+  return (
+    <ConversationWorkbench
+      core={corePresence(state)}
+      status={t(
+        state.phase === "vo.building"
+          ? "ob.conv.voice.statusBuilding"
+          : "ob.ai.ready",
+      )}
+      artifact={
+        <VoiceActArtifact
+          summary={corpus.summary}
+          manifest={corpus.manifest}
+          stage={build.stage}
+          building={state.phase === "vo.building"}
+        />
+      }
+    >
+      <div
+        className={`mw-thread${dragOver ? " ob-conv-dragover" : ""}`}
+        {...dropProps}
+      >
+        <ConversationThread
+          entries={state.thread}
+          pendingQuestionId={state.pendingQuestion?.id ?? null}
+          onAnswer={handleAnswer}
+        >
+          {state.phase === "vo.invite" && <InviteChips dispatch={dispatch} />}
+          {state.phase === "vo.collecting" && (
+            <CollectingControls
+              dispatch={dispatch}
+              serverWords={serverWords}
+              canBuild={canBuild}
+              startPending={build.start.isPending}
+              onBuild={() => build.start.mutate()}
+              startError={
+                build.start.isError ? build.start.error.message : null
+              }
+            />
+          )}
+          {pendingPaste !== null && state.phase === "vo.collecting" && (
+            <PasteOffer
+              onAdd={() => {
+                corpus.addPaste(pendingPaste, t("ob.conv.voice.pasteSource"));
+                setPendingPaste(null);
+              }}
+              onDiscard={() => setPendingPaste(null)}
+            />
+          )}
+          {state.phase === "vo.result" && (
+            <ResultControls state={state} dispatch={dispatch} build={build} />
+          )}
+          {state.phase === "vo.skipped" && (
+            <div className="ob-conv-chips">
+              <Button
+                small
+                variant="primary"
+                onClick={() => dispatch({ type: "RESULTS_CONTINUE" })}
+              >
+                {t("ob.conv.results.continue")}
+              </Button>
+            </div>
+          )}
+        </ConversationThread>
+      </div>
+      {collecting && (
+        <div className="mw-composer">
+          <input
+            ref={fileRef}
+            type="file"
+            multiple
+            hidden
+            accept={ACCEPTED_CORPUS_ATTR}
+            onChange={onFiles}
+          />
+          <Button
+            aria-label={t("ob.conv.voice.attach")}
+            onClick={() => fileRef.current?.click()}
+          >
+            <Paperclip aria-hidden />
+          </Button>
+          <textarea
+            value={draft}
+            maxLength={100_000}
+            rows={2}
+            placeholder={t("ob.conv.voice.composer")}
+            aria-label={t("ob.conv.voice.composer")}
+            onChange={(event) => setDraft(event.target.value)}
+            onKeyDown={(event) => {
+              if (
+                event.key === "Enter" &&
+                !event.shiftKey &&
+                !event.nativeEvent.isComposing
+              ) {
+                event.preventDefault();
+                submitComposer();
+              }
+            }}
+          />
+          <Button
+            variant="primary"
+            aria-label={t("ob.ai.send")}
+            disabled={!draft.trim()}
+            onClick={submitComposer}
+          >
+            <Send aria-hidden />
+          </Button>
+          <small>{t("ob.conv.voice.dropHint")}</small>
+        </div>
+      )}
+    </ConversationWorkbench>
+  );
+}
+
+function InviteChips({
+  dispatch,
+}: Readonly<{ dispatch: Dispatch<ConversationEvent> }>) {
+  const t = useT();
+  return (
+    <>
+      <NarrationBubble
+        entry={{
+          kind: "narration",
+          id: "voice:invite",
+          i18nKey: "ob.conv.voice.invite",
+        }}
+      />
+      <div className="ob-conv-chips">
+        <Button
+          small
+          variant="primary"
+          onClick={() => dispatch({ type: "VOICE_OPT_IN" })}
+        >
+          {t("ob.conv.voice.optIn")}
+        </Button>
+        <Button
+          small
+          variant="ghost"
+          onClick={() => dispatch({ type: "VOICE_SKIPPED" })}
+        >
+          {t("ob.conv.voice.skipped")}
+        </Button>
+      </div>
+    </>
+  );
+}
+
+function CollectingControls({
+  dispatch,
+  serverWords,
+  canBuild,
+  startPending,
+  onBuild,
+  startError,
+}: Readonly<{
+  dispatch: Dispatch<ConversationEvent>;
+  serverWords: number;
+  canBuild: boolean;
+  startPending: boolean;
+  onBuild: () => void;
+  startError: string | null;
+}>) {
+  const t = useT();
+  return (
+    <>
+      <NarrationBubble
+        entry={{
+          kind: "narration",
+          id: "voice:collect",
+          i18nKey: "ob.conv.voice.collectAsk",
+        }}
+      />
+      {serverWords > 0 && serverWords < VOICE_MIN_WORDS && (
+        <NarrationBubble
+          entry={{
+            kind: "narration",
+            id: "voice:floor",
+            i18nKey: "ob.conv.voice.buildFloor",
+            params: { words: serverWords, min: VOICE_MIN_WORDS },
+          }}
+        />
+      )}
+      {canBuild && (
+        <NarrationBubble
+          entry={{
+            kind: "narration",
+            id: "voice:nudge",
+            i18nKey: "ob.conv.voice.buildNudge",
+          }}
+        />
+      )}
+      {startError !== null && (
+        <p className="mw-send-error" role="alert">
+          {startError}
+        </p>
+      )}
+      <div className="ob-conv-chips">
+        {(canBuild || startPending) && (
+          <Button
+            small
+            variant="primary"
+            disabled={startPending}
+            onClick={onBuild}
+          >
+            <Sparkles aria-hidden /> {t("ob.conv.voice.buildChip")}
+          </Button>
+        )}
+        <Button
+          small
+          variant="ghost"
+          onClick={() => dispatch({ type: "VOICE_SKIPPED" })}
+        >
+          {t("ob.conv.voice.skipped")}
+        </Button>
+      </div>
+    </>
+  );
+}
+
+function PasteOffer({
+  onAdd,
+  onDiscard,
+}: Readonly<{ onAdd: () => void; onDiscard: () => void }>) {
+  const t = useT();
+  return (
+    <>
+      <NarrationBubble
+        entry={{
+          kind: "narration",
+          id: "paste:offer",
+          i18nKey: "ob.conv.voice.pasteOffer",
+        }}
+      />
+      <div className="ob-conv-chips">
+        <Button small variant="primary" onClick={onAdd}>
+          {t("ob.conv.voice.pasteAdd")}
+        </Button>
+        <Button small variant="ghost" onClick={onDiscard}>
+          {t("ob.conv.voice.pasteDiscard")}
+        </Button>
+      </div>
+    </>
+  );
+}
+
+// The result of the act: a succeeded build shows what it learned (with the
+// candidate-review note when the version awaits approval), a failed one
+// offers the retry the machine permits, a deferred one has already said so
+// honestly in its outcome — all continue onward the same way.
+function ResultControls({
+  state,
+  dispatch,
+  build,
+}: Readonly<{
+  state: ConversationState;
+  dispatch: Dispatch<ConversationEvent>;
+  build: ReturnType<typeof useVoiceBuild>;
+}>) {
+  const t = useT();
+  const version = build.builtVersion.data ?? null;
+  return (
+    <>
+      {state.lastBuildStatus === "succeeded" && (
+        <div className="ob-conv-voice-result">
+          <h2>{t("ob.conv.voice.resultTitle")}</h2>
+          {build.builtVersion.isPending && (
+            <p>{t("ob.conv.voice.resultLoading")}</p>
+          )}
+          {!build.builtVersion.isPending && version === null && (
+            <p>{t("ob.conv.voice.resultEmpty")}</p>
+          )}
+          {version !== null && (
+            <>
+              {version.status === "candidate" && (
+                <p className="t-small">{t("ob.conv.voice.candidateNote")}</p>
+              )}
+              <VoiceInsights
+                data={parseVoiceInsights(version)}
+                profileVersion={version.profile_version}
+              />
+            </>
+          )}
+        </div>
+      )}
+      <div className="ob-conv-chips">
+        {state.lastBuildStatus === "failed" && (
+          <Button
+            small
+            disabled={build.start.isPending}
+            onClick={() => build.start.mutate()}
+          >
+            {t("ob.conv.voice.retryBuild")}
+          </Button>
+        )}
+        <Button
+          small
+          variant="primary"
+          onClick={() => dispatch({ type: "RESULTS_CONTINUE" })}
+        >
+          {t("ob.conv.results.continue")}
+        </Button>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/screens/onboarding-conversation/voice-artifact.tsx
+++ b/frontend/src/screens/onboarding-conversation/voice-artifact.tsx
@@ -1,0 +1,150 @@
+import { Check, Loader } from "lucide-react";
+import type { components } from "../../api/schema";
+import { useT } from "../../i18n";
+import type { BuildStage } from "./conversation-machine";
+import { bandLabelKeys } from "./narration";
+import type { CorpusManifestEntry } from "./use-voice-corpus";
+
+// The right panel of the voice act: the corpus manifest, the honest meter,
+// and the build stage tracker. Every number rendered here is a server
+// number — the summary the last ingest returned and the per-source
+// kept-of-total stats. Removing a source is deliberately absent for now;
+// the classic settings voice card covers removal.
+
+type CorpusSummary = components["schemas"]["VoiceCorpusSummary"];
+
+const BUILD_STAGES: readonly BuildStage[] = [
+  "snapshot",
+  "extract",
+  "evaluate",
+  "activate",
+];
+
+const stageLabelKeys = {
+  snapshot: "ob.conv.build.snapshot",
+  extract: "ob.conv.build.extract",
+  evaluate: "ob.conv.build.evaluate",
+  activate: "ob.conv.build.activate",
+} as const;
+
+type VoiceActArtifactProps = Readonly<{
+  summary: CorpusSummary | null;
+  manifest: readonly CorpusManifestEntry[];
+  /** The live build stage; null outside a running build. */
+  stage: BuildStage | null;
+  /** Whether a build is in flight (queued counts: the tracker shows). */
+  building: boolean;
+}>;
+
+export function VoiceActArtifact({
+  summary,
+  manifest,
+  stage,
+  building,
+}: VoiceActArtifactProps) {
+  const t = useT();
+  return (
+    <div className="mw-review ob-conv-artifact">
+      <div className="mw-review-heading">
+        <span>{t("ob.ai.liveArtifact")}</span>
+        <h2>{t("ob.conv.voice.artifactTitle")}</h2>
+        <p>{t("ob.conv.voice.artifactBody")}</p>
+      </div>
+      {summary === null && manifest.length === 0 ? (
+        <p className="ob-conv-artifact-empty">
+          {t("ob.conv.voice.artifactEmpty")}
+        </p>
+      ) : (
+        <>
+          {summary !== null && <CorpusMeter summary={summary} />}
+          {manifest.length > 0 && (
+            <ul className="ob-conv-manifest">
+              {manifest.map((entry) => (
+                <li key={entry.ref}>
+                  <Check aria-hidden />
+                  <span>
+                    <strong>{entry.label}</strong>
+                    <small>
+                      {entry.transcript
+                        ? t("ob.conv.voice.manifestKept", {
+                            kept: entry.keptWords,
+                            total: entry.inputWords,
+                          })
+                        : t("ob.conv.voice.manifestWords", {
+                            words: entry.keptWords,
+                          })}
+                    </small>
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </>
+      )}
+      {building && <BuildTracker stage={stage} />}
+    </div>
+  );
+}
+
+function CorpusMeter({ summary }: Readonly<{ summary: CorpusSummary }>) {
+  const t = useT();
+  const percent = Math.min(
+    100,
+    (summary.total_words / summary.target_words) * 100,
+  );
+  const registers = Object.entries(summary.register_words)
+    .filter(([, words]) => words > 0)
+    .map(([register, words]) => `${register}: ${words}`)
+    .join(" · ");
+  return (
+    <div className="ob-conv-meter">
+      <div className="ob-conv-meter-top">
+        <span>
+          {t("ob.conv.voice.meterWords", {
+            words: summary.total_words,
+            target: summary.target_words,
+          })}
+        </span>
+        <span>
+          {t("ob.conv.voice.meterBand", {
+            band: t(bandLabelKeys[summary.quality_band]),
+          })}
+        </span>
+      </div>
+      {/* Purely decorative: the words-of-target line above already carries
+          the same numbers as text, so the bar stays out of the a11y tree. */}
+      <div className="ob-conv-meter-bar" aria-hidden>
+        <span style={{ width: `${percent}%` }} />
+      </div>
+      {registers !== "" && (
+        <small>{t("ob.conv.voice.registerMix", { mix: registers })}</small>
+      )}
+    </div>
+  );
+}
+
+// The four fixed pipeline stages; the current one carries the spinner, the
+// ones before it a check. A queued build shows the full untouched ladder.
+function BuildTracker({ stage }: Readonly<{ stage: BuildStage | null }>) {
+  const t = useT();
+  const reached = stage === null ? -1 : BUILD_STAGES.indexOf(stage);
+  return (
+    <ol className="ob-conv-stages" aria-label={t("ob.conv.voice.stageTitle")}>
+      {BUILD_STAGES.map((name, index) => (
+        <li
+          key={name}
+          data-state={
+            index < reached ? "done" : index === reached ? "current" : "todo"
+          }
+        >
+          {index < reached ? (
+            <Check aria-hidden />
+          ) : (
+            <Loader aria-hidden className={index === reached ? "spin" : ""} />
+          )}
+          <span>{t(stageLabelKeys[name])}</span>
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/frontend/src/screens/onboarding.tsx
+++ b/frontend/src/screens/onboarding.tsx
@@ -1883,8 +1883,8 @@ const SOURCES: Source[] = [
 
 // The accepted corpus formats, mirroring the contract's format enum
 // (crm.yaml IngestVoiceCorpusSourceRequest.format: txt/md/vtt/srt/json).
-const ACCEPTED_CORPUS_FILE = /\.(txt|md|vtt|srt|json)$/i;
-const ACCEPTED_CORPUS_ATTR = ".txt,.md,.vtt,.srt,.json";
+export const ACCEPTED_CORPUS_FILE = /\.(txt|md|vtt|srt|json)$/i;
+export const ACCEPTED_CORPUS_ATTR = ".txt,.md,.vtt,.srt,.json";
 
 type VoicePiece = {
   ref: string;
@@ -1913,20 +1913,20 @@ type SpeakerAsk = {
   preview: CorpusPreview;
 };
 
-const TRANSCRIPT_EXT = /\.(vtt|srt|json)$/i;
+export const TRANSCRIPT_EXT = /\.(vtt|srt|json)$/i;
 
 // The corpus meter is honest: it counts only the real words the owner uploaded
 // or pasted here (the build ingests exactly these). Presets below are examples
 // of what will feed the voice once connected — never fabricated word counts.
 // 800 mirrors the server's build floor ("at least 800 eligible own-authored
 // words"): gating the button here turns that 422 into a clear, up-front ask.
-const VOICE_MIN_WORDS = 800;
+export const VOICE_MIN_WORDS = 800;
 const PASTE_REF = "onboarding:paste";
 
 // pickBuiltVersion names the version the build just produced: the highest
 // numbered active-or-candidate row — active when it auto-activated,
 // candidate when it awaits review.
-function pickBuiltVersion(
+export function pickBuiltVersion(
   items: components["schemas"]["VoiceProfileVersion"][],
 ): components["schemas"]["VoiceProfileVersion"] | null {
   let built: components["schemas"]["VoiceProfileVersion"] | null = null;


### PR DESCRIPTION
Phase 4 of the conversational onboarding, plus three voice-builder fixes surfaced by live testing with a real bilingual corpus.

## The voice act (behind the same `conv` flag)
Opting in enters a collecting conversation: the composer attaches files and the whole thread is a drop target; every upload is probed server-side, transcripts get the "Which speaker are you?" question with per-speaker word/turn counts, and the reaction narrates the honest kept-of-total story ("Only your turns count"). Long pasted text is offered with explicit chips. The build chip appears at the 800-word server floor with a 4,000+ nudge, stages narrate through the paced queue, deferred builds resume on their own correlated events, failed ones offer retry, and success lands the Voice DNA insights card with the candidate-review note. No machine/legality changes were needed — the correlation architecture absorbed the whole act.

## Builder fixes (root causes found live)
- **Result-cache poisoning**: a validator-rejected completion is evicted from the result cache at every failure, so a retried build with an unchanged corpus reaches the model again instead of deterministically replaying its own failure until the TTL expired. Pinned with a two-logical-call scripted test.
- **Fabricated evidence citations**: the model reliably slips prose descriptions into the supplementary `evidence` array despite validator feedback, on both tiers. The prompt now enumerates the exact citable sample ids, and unknown supplementary citations drop after parsing — while the load-bearing signature-move citations (sample id + verbatim quote) stay strictly validated. The corpus that failed 3 consecutive builds now builds successfully (verified live).
- **Observability**: the worker logs the real build error at warn level alongside the safe row detail — a repeated `invalid_output` was previously undiagnosable from any log.

## Verified live (Playwright, real stack)
Company act (manual path) → voice opt-in → attached the real two-speaker meeting transcript + LinkedIn posts → speaker question with true per-speaker counts → "kept 3,327 of 7,540" reaction → "Corpus quality moved to good" → build offer → and the previously always-failing build now succeeds (candidate under review).

688 frontend tests; full backend gates green. STATUS.md updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the conversational voice onboarding act behind the `conv` flag: upload-in-chat with honest, server-counted corpus and a guided build with stage narration and a result card. Also improves robustness by concluding on build‑poll failures with a retry and preventing out‑of‑order ingests from rolling the meter back.

- **New Features**
  - Voice act in conversation: attach or drop files and paste text; each upload is probed server‑side and ingested with honest kept‑of‑total stats (“only your turns count”). Transcripts ask “Which speaker are you?” with per‑speaker words/turns; single‑author documents ingest directly.
  - Build flow: chip appears at the 800‑word server floor with a 4,000+ nudge; stages narrate (snapshot, extract, evaluate, activate); deferred runs auto‑resume; failures offer retry; success shows the Voice DNA insights card with the candidate‑review note.
  - Artifact panel: corpus manifest, server‑number meter, and live stage tracker. English and German copy for the new flow.

- **Bug Fixes**
  - Structured‑output cache entry is evicted on validation failure so identical retries hit the model instead of replaying invalid output.
  - Voice builder prompt lists valid sample IDs; unknown supplementary evidence is dropped, while signature‑move citations remain strictly validated.
  - Worker logs the real build error at warn level alongside the safe row detail; invalid model answers are recorded as failed builds.
  - Resilience: a failing build poll now concludes with a retry offer, and ingest summaries apply latest‑by‑request‑order to avoid meter/gate rollbacks; refusal handling is type‑safe and German copy uses “Wörter” where appropriate.
  - Tests cover cache‑eviction paths and the invalid‑answer failure path to pin the behavior.

<sup>Written for commit 1b7460ff81c59f09cd38fe1f3b394346f2a1d854. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added conversational voice onboarding with file uploads, pasted text, speaker attribution, corpus progress, quality indicators, and build-stage updates.
  * Added voice profile results with insights, artifact details, and retry support after build failures.
  * Added English and German interface text for the new onboarding experience.

* **Bug Fixes**
  * Invalid structured AI results are no longer reused from cache.
  * Unrecognized evidence citations are filtered out, improving the reliability of generated voice profiles.
  * Build failures now provide clearer diagnostic logging for support and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->