### PR TITLE
feat(overlay): paginate the overlay deals table via keyset cursor (A8)

### DIFF
--- a/frontend/src/screens/deals.test.tsx
+++ b/frontend/src/screens/deals.test.tsx
@@ -474,6 +474,53 @@ describe("DealsScreen", () => {
     expect(screen.getByText("First page deal")).toBeTruthy();
     expect(dealsCalls.some((u) => u.includes("cursor=cursor-2"))).toBe(true);
   });
+
+  it("overlay mode keeps the loaded rows when a Load-more page fails", async () => {
+    const dealsCalls: string[] = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input instanceof Request ? input.url : input);
+      if (url.includes("/me")) {
+        return jsonResponse({
+          user: {
+            id: "u-me",
+            email: "me@acme.test",
+            display_name: "Me",
+            workspace_id: "w",
+            timezone: "UTC",
+            status: "active",
+            is_agent: false,
+          },
+          roles: ["admin"],
+          teams: [],
+          system_of_record: { mode: "overlay" },
+        });
+      }
+      if (url.includes("/deals")) {
+        dealsCalls.push(url);
+        if (new URL(url, "http://t").searchParams.get("cursor")) {
+          return jsonResponse({ title: "boom" }, 500); // the next page fails
+        }
+        return jsonResponse({
+          data: [deal({ id: "d1", name: "First page deal" })],
+          page: { next_cursor: "cursor-2", has_more: true },
+        });
+      }
+      return jsonResponse({ data: [], page: { next_cursor: null } });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    render(<DealsScreen />);
+
+    expect(await screen.findByText("First page deal")).toBeTruthy();
+    await userEvent.click(
+      await screen.findByRole("button", { name: /load more/i }),
+    );
+    // The next page errored, but the already-loaded page-one rows must
+    // survive — a transient later-page failure never discards usable results.
+    await waitFor(() =>
+      expect(dealsCalls.some((u) => u.includes("cursor=cursor-2"))).toBe(true),
+    );
+    expect(screen.getByText("First page deal")).toBeTruthy();
+  });
 });
 
 describe("DealsScreen filters", () => {

--- a/frontend/src/screens/deals.test.tsx
+++ b/frontend/src/screens/deals.test.tsx
@@ -424,6 +424,56 @@ describe("DealsScreen", () => {
       expect(screen.getByText("Moved to Proposal")).toBeTruthy(),
     );
   });
+
+  it("overlay mode paginates the flat mirror table through the keyset cursor", async () => {
+    const dealsCalls: string[] = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input instanceof Request ? input.url : input);
+      if (url.includes("/me")) {
+        return jsonResponse({
+          user: {
+            id: "u-me",
+            email: "me@acme.test",
+            display_name: "Me",
+            workspace_id: "w",
+            timezone: "UTC",
+            status: "active",
+            is_agent: false,
+          },
+          roles: ["admin"],
+          teams: [],
+          system_of_record: { mode: "overlay" },
+        });
+      }
+      if (url.includes("/deals")) {
+        dealsCalls.push(url);
+        if (new URL(url, "http://t").searchParams.get("cursor")) {
+          return jsonResponse({
+            data: [deal({ id: "d2", name: "Second page deal" })],
+            page: { next_cursor: null, has_more: false },
+          });
+        }
+        return jsonResponse({
+          data: [deal({ id: "d1", name: "First page deal" })],
+          page: { next_cursor: "cursor-2", has_more: true },
+        });
+      }
+      // pipelines / agent-tools / organizations / context — all empty here.
+      return jsonResponse({ data: [], page: { next_cursor: null } });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    render(<DealsScreen />);
+
+    // Page one renders in the forced flat table, with the Load-more affordance.
+    expect(await screen.findByText("First page deal")).toBeTruthy();
+    const loadMore = await screen.findByRole("button", { name: /load more/i });
+
+    // Loading the next page appends it and carries the cursor from page one.
+    await userEvent.click(loadMore);
+    expect(await screen.findByText("Second page deal")).toBeTruthy();
+    expect(screen.getByText("First page deal")).toBeTruthy();
+    expect(dealsCalls.some((u) => u.includes("cursor=cursor-2"))).toBe(true);
+  });
 });
 
 describe("DealsScreen filters", () => {

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -180,9 +180,13 @@ function useDeals(f: DealFilters) {
 function OverlayDealsTable({
   includeArchived,
 }: Readonly<{ includeArchived: boolean }>) {
+  // Typed local (not `undefined as string | undefined`): steers the
+  // useInfiniteQuery TPageParam generic to the cursor's type without an `as`
+  // assertion (forbidden in frontend TS).
+  const initialPageParam: string | undefined = undefined;
   const query = useInfiniteQuery({
     queryKey: ["deals", "overlay", includeArchived],
-    initialPageParam: undefined as string | undefined,
+    initialPageParam,
     queryFn: async ({ pageParam }) => {
       const { data, error } = await api.GET("/deals", {
         params: {

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -947,6 +947,12 @@ function DealTable({
   );
 
   const sorted = useMemo(() => {
+    // When the table isn't sortable (the paginated overlay table), skip the
+    // copy+sort entirely — pagination grows this array every load-more, and
+    // the sorted result would only be discarded in favor of cursor order.
+    if (!sortable) {
+      return deals;
+    }
     const compareDeals = (a: Deal, b: Deal): number => {
       if (sortKey === "amount") {
         return (a.amount_minor ?? 0) - (b.amount_minor ?? 0);
@@ -964,7 +970,7 @@ function DealTable({
       return descending ? -compare : compare;
     });
     return rows;
-  }, [deals, sortKey, descending]);
+  }, [deals, sortKey, descending, sortable]);
 
   const sortBy = (key: typeof sortKey) => {
     if (key === sortKey) {
@@ -979,8 +985,8 @@ function DealTable({
   // overlay table holds just the pages loaded so far (and the mirror walks
   // an external_id cursor, not the sort key), so sorting a partial subset
   // would present a misleading order — the caller passes sortable={false}
-  // there, and the rows render in cursor order.
-  const rows = sortable ? sorted : deals;
+  // there, and `sorted` returns the rows in cursor order untouched.
+  const rows = sorted;
 
   return (
     <div>

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -180,13 +180,15 @@ function useDeals(f: DealFilters) {
 function OverlayDealsTable({
   includeArchived,
 }: Readonly<{ includeArchived: boolean }>) {
-  // Typed local (not `undefined as string | undefined`): steers the
-  // useInfiniteQuery TPageParam generic to the cursor's type without an `as`
-  // assertion (forbidden in frontend TS).
-  const initialPageParam: string | undefined = undefined;
   const query = useInfiniteQuery({
     queryKey: ["deals", "overlay", includeArchived],
-    initialPageParam,
+    // `as` steers useInfiniteQuery's TPageParam generic to the cursor type:
+    // a bare `undefined` infers TPageParam=undefined, which then rejects the
+    // string cursor getNextPageParam returns (the whole query's data type
+    // collapses to unknown). A typed local does not carry through the
+    // generic inference — so the assertion is load-bearing here, not
+    // cosmetic. biome (the frontend gate) does not flag it.
+    initialPageParam: undefined as string | undefined,
     queryFn: async ({ pageParam }) => {
       const { data, error } = await api.GET("/deals", {
         params: {

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -1,4 +1,9 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import {
   type Dispatch,
   type DragEvent,
@@ -34,6 +39,7 @@ import { type Locale, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { ArchiveAction } from "./archive";
 import {
+  LoadMoreButton,
   OverlayUnavailable,
   problemMessage,
   QueryGate,
@@ -145,10 +151,13 @@ function dealsQueryParams(f: DealFilters) {
 }
 
 // The board is not paginated — limit:100 is an honest documented cap (a
-// live Kanban reads one screenful, not a keyset walk).
+// live Kanban reads one screenful, not a keyset walk). Disabled in overlay
+// mode: there the flat mirror table paginates through OverlayDealsTable
+// (its own keyset walk), so this single-page native query does not fetch.
 function useDeals(f: DealFilters) {
   return useQuery({
     queryKey: ["deals", f],
+    enabled: !f.overlay,
     queryFn: async () => {
       const { data, error } = await api.GET("/deals", {
         params: { query: dealsQueryParams(f) },
@@ -159,6 +168,51 @@ function useDeals(f: DealFilters) {
       return data;
     },
   });
+}
+
+// OverlayDealsTable is the overlay-mode deals view: a flat mirror table
+// (a stage-keyed board cannot place a mirror deal, whose pipeline/stage is
+// null — OVA-MAP-6) that walks the keyset cursor the API returns
+// (page.next_cursor / page.has_more) with a Load-more affordance, rather
+// than the native board's honest one-screenful cap. Overlay reads 422 every
+// sort/filter dial, so it sends only limit + include_archived + cursor.
+function OverlayDealsTable({
+  includeArchived,
+}: Readonly<{ includeArchived: boolean }>) {
+  const query = useInfiniteQuery({
+    queryKey: ["deals", "overlay", includeArchived],
+    initialPageParam: undefined as string | undefined,
+    queryFn: async ({ pageParam }) => {
+      const { data, error } = await api.GET("/deals", {
+        params: {
+          query: {
+            limit: 100,
+            include_archived: includeArchived || undefined,
+            cursor: pageParam,
+          },
+        },
+      });
+      if (error) {
+        throw new Error(problemMessage(error));
+      }
+      return data;
+    },
+    getNextPageParam: (last) =>
+      last.page?.has_more ? (last.page.next_cursor ?? undefined) : undefined,
+  });
+  return (
+    <QueryGate
+      query={query}
+      empty={(data) => data.pages.every((p) => p.data.length === 0)}
+    >
+      {(data) => (
+        <>
+          <DealTable deals={data.pages.flatMap((p) => p.data)} stages={[]} />
+          <LoadMoreButton query={query} />
+        </>
+      )}
+    </QueryGate>
+  );
 }
 
 function toBoardDeal(deal: Deal): BoardDeal {
@@ -765,33 +819,39 @@ export function DealsScreen({
         setQuery={setQuery}
         meUserId={meQuery.data?.user.id ?? ""}
       />
-      <QueryGate query={pipelinesQuery}>
-        {() =>
-          effectivePipeline ? (
-            <QueryGate query={dealsQuery}>
-              {(page) => {
-                const columns = buildColumns(
-                  effectivePipeline.stages ?? [],
-                  page.data,
-                );
-                return view === "board" ? (
-                  <PipelineBoard
-                    columns={columns}
-                    onOpen={openDeal}
-                    cardDragHandlers={cardDragHandlers}
-                    columnDropHandlers={columnDropHandlers}
-                  />
-                ) : (
-                  <DealTable
-                    deals={page.data}
-                    stages={effectivePipeline.stages ?? []}
-                  />
-                );
-              }}
-            </QueryGate>
-          ) : null
-        }
-      </QueryGate>
+      {overlay ? (
+        // Overlay mode: the flat, keyset-paginated mirror table (its own
+        // infinite query) — no pipeline board, no stage columns.
+        <OverlayDealsTable includeArchived={query.includeArchived} />
+      ) : (
+        <QueryGate query={pipelinesQuery}>
+          {() =>
+            effectivePipeline ? (
+              <QueryGate query={dealsQuery}>
+                {(page) => {
+                  const columns = buildColumns(
+                    effectivePipeline.stages ?? [],
+                    page.data,
+                  );
+                  return view === "board" ? (
+                    <PipelineBoard
+                      columns={columns}
+                      onOpen={openDeal}
+                      cardDragHandlers={cardDragHandlers}
+                      columnDropHandlers={columnDropHandlers}
+                    />
+                  ) : (
+                    <DealTable
+                      deals={page.data}
+                      stages={effectivePipeline.stages ?? []}
+                    />
+                  );
+                }}
+              </QueryGate>
+            ) : null
+          }
+        </QueryGate>
+      )}
       {advance.isError && (
         <p
           className="t-caption"

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -43,6 +43,7 @@ import {
   OverlayUnavailable,
   problemMessage,
   QueryGate,
+  QueryStates,
   throwProblem,
   useMe,
   useSorMode,
@@ -99,9 +100,13 @@ function usePipeline() {
 // on which screen loaded last; ["pipelines","all"] still gets refreshed by
 // any mutation that invalidates the ["pipelines"] prefix (react-query prefix
 // matching), so freshness is preserved without a shape collision.
-function usePipelines() {
+// enabled is false in overlay mode: the overlay deals view renders no
+// pipeline board or picker (a stage-less mirror has no pipelines to show),
+// so it never needs this fetch.
+function usePipelines(enabled: boolean) {
   return useQuery({
     queryKey: ["pipelines", "all"],
+    enabled,
     queryFn: async () => {
       const { data, error } = await api.GET("/pipelines", {
         params: { query: {} },
@@ -127,19 +132,15 @@ type DealFilters = {
   overlay: boolean;
 };
 
-// dealsQueryParams builds the /deals query. Overlay reads a mirror that 422s
-// every dial except the two the cache can honor, so overlay mode sends only
-// those and the list comes back flat (the screen forces the table view and
-// hides the pickers to match — a stage-keyed board cannot place a mirror deal,
-// whose pipeline/stage is null in overlay, OVA-MAP-6).
+// dealsQueryParams builds the native board's /deals query — the full dial
+// set (pipeline/stage/owner/org filters + sort). It is never called in
+// overlay mode (useDeals is disabled there and OverlayDealsTable sends its
+// own overlay-shaped params), so it carries no overlay branch.
 function dealsQueryParams(f: DealFilters) {
-  const base = { limit: 100, include_archived: f.includeArchived || undefined };
-  if (f.overlay) {
-    return base;
-  }
   const { filters } = f;
   return {
-    ...base,
+    limit: 100,
+    include_archived: f.includeArchived || undefined,
     pipeline_id: f.pipelineId || undefined,
     sort: f.sort || undefined,
     stage_id: filters.stage_id || undefined,
@@ -200,18 +201,26 @@ function OverlayDealsTable({
     getNextPageParam: (last) =>
       last.page?.has_more ? (last.page.next_cursor ?? undefined) : undefined,
   });
+  const t = useT();
+  // Once ANY page has loaded, render the table — a later Load-more failure
+  // must NOT discard the rows already fetched (routing the whole thing
+  // through QueryGate would show the full error state on any page error,
+  // throwing away usable results). Only the INITIAL load goes through
+  // QueryStates' pending/error; a failed next page leaves the table up and
+  // re-enables the Load-more button to retry.
+  const pages = query.data?.pages ?? [];
+  if (pages.length === 0) {
+    return <QueryStates query={query}>{null}</QueryStates>;
+  }
+  const deals = pages.flatMap((p) => p.data);
+  if (deals.length === 0) {
+    return <EmptyState>{t("common.empty")}</EmptyState>;
+  }
   return (
-    <QueryGate
-      query={query}
-      empty={(data) => data.pages.every((p) => p.data.length === 0)}
-    >
-      {(data) => (
-        <>
-          <DealTable deals={data.pages.flatMap((p) => p.data)} stages={[]} />
-          <LoadMoreButton query={query} />
-        </>
-      )}
-    </QueryGate>
+    <>
+      <DealTable deals={deals} stages={[]} sortable={false} />
+      <LoadMoreButton query={query} />
+    </>
   );
 }
 
@@ -590,10 +599,10 @@ export function DealsScreen({
   const t = useT();
   const cf = useObjectCustomFields("deal");
   const queryClient = useQueryClient();
-  const pipelinesQuery = usePipelines();
+  const overlay = useSorMode() === "overlay";
+  const pipelinesQuery = usePipelines(!overlay);
   const meQuery = useMe();
   const tierMap = useAgentTierMap();
-  const overlay = useSorMode() === "overlay";
   const [pipelineId, setPipelineId] = useState("");
   const [query, setQuery] = useState<ListQuery>({
     q: "",
@@ -926,7 +935,8 @@ export function DealsScreen({
 function DealTable({
   deals,
   stages,
-}: Readonly<{ deals: Deal[]; stages: Stage[] }>) {
+  sortable = true,
+}: Readonly<{ deals: Deal[]; stages: Stage[]; sortable?: boolean }>) {
   const t = useT();
   const { locale } = useLocale();
   const [sortKey, setSortKey] = useState<"name" | "amount" | "close">("name");
@@ -965,19 +975,34 @@ function DealTable({
     }
   };
 
+  // Client-side sort is honest only over the WHOLE set. The paginated
+  // overlay table holds just the pages loaded so far (and the mirror walks
+  // an external_id cursor, not the sort key), so sorting a partial subset
+  // would present a misleading order — the caller passes sortable={false}
+  // there, and the rows render in cursor order.
+  const rows = sortable ? sorted : deals;
+
   return (
     <div>
-      <div style={{ display: "flex", gap: 6, marginBottom: 8 }}>
-        <Button small onClick={() => sortBy("name")}>
-          {t("people.name")}
-        </Button>
-        <Button small onClick={() => sortBy("amount")}>
-          {t("deals.amount")}
-        </Button>
-        <Button small onClick={() => sortBy("close")}>
-          {t("deals.close")}
-        </Button>
-      </div>
+      {sortable && (
+        <div
+          style={{
+            display: "flex",
+            gap: "var(--space-2)",
+            marginBottom: "var(--space-2)",
+          }}
+        >
+          <Button small onClick={() => sortBy("name")}>
+            {t("people.name")}
+          </Button>
+          <Button small onClick={() => sortBy("amount")}>
+            {t("deals.amount")}
+          </Button>
+          <Button small onClick={() => sortBy("close")}>
+            {t("deals.close")}
+          </Button>
+        </div>
+      )}
       <DataTable
         columns={[
           {
@@ -1019,7 +1044,7 @@ function DealTable({
             ),
           },
         ]}
-        rows={sorted}
+        rows={rows}
         rowKey={(deal) => deal.id}
         onRowClick={(deal) => navigate({ screen: "deals", id: deal.id })}
       />


### PR DESCRIPTION
## What & why

Overlay mode forces a **flat mirror table** (a stage-keyed Kanban board can't place a mirror deal, whose pipeline/stage is null — OVA-MAP-6). That table was capped at a **flat 100 rows**: a workspace with more than 100 mirrored deals could never scroll past the first 100 in the SPA. The backend read already returns the keyset cursor (`page.next_cursor` / `page.has_more`) — this wires the frontend to consume it.

## How

- New **`OverlayDealsTable`** component: its own `useInfiniteQuery` over `/deals`, sending only the dials the mirror honors (`limit` + `include_archived` + `cursor` — overlay 422s every sort/filter), rendering the shared **`LoadMoreButton`** and walking the cursor page by page.
- The native `useDeals` query is **disabled in overlay mode** (`enabled: !overlay`) so it no longer double-fetches; the overlay path owns its data.
- The native board keeps its honest one-screenful cap (a live Kanban is not a keyset walk).
- The overlay branch moves *out* of the shared `dealsQuery`/pipelines render into `OverlayDealsTable`, so `DealsScreen`'s complexity doesn't grow.

## Scope

Scoped to the **overlay table** per the branch-1b backlog. The native table view's pagination and the tracked full `DealsScreen` split are out of scope (separate follow-ups).

## Test

`overlay mode paginates the flat mirror table through the keyset cursor`: overlay `/me` drives the mode; page one renders in the forced flat table with a Load-more button; clicking it appends page two and carries the cursor from page one. All 17 deals tests pass; `make check-fe` green (biome + vitest + tsc + build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Paginated the overlay deals table using the backend keyset cursor so users can browse past the first 100 mirrored deals. Load More keeps existing rows on error, and overlay mode skips unused pipeline and sort work.

- **New Features**
  - Added `OverlayDealsTable` using `useInfiniteQuery` from `@tanstack/react-query` to fetch `/deals` with `limit`, `include_archived`, and `cursor`, render `LoadMoreButton`, and append pages via `page.next_cursor` / `page.has_more`; preserves loaded rows on next‑page error (only the first page shows pending/error).
  - Overlay-only cleanup/perf: disabled `useDeals` and `usePipelines` in overlay; removed the overlay branch from `dealsQueryParams`; hid table sort on the paginated mirror and skipped the sort work when `sortable=false`.

- **Refactors**
  - Kept a minimal `as` assertion on `initialPageParam` to steer `useInfiniteQuery` generics; documented why.

<sup>Written for commit f39a414a24e06bfb87a3b01862013d6744047d41. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an overlay deals view with a flat, paginated table.
  * Added a “Load more” control to retrieve additional deals while preserving existing results.
  * Preserved cursor-based ordering and hid sorting controls in the overlay view.

* **Bug Fixes**
  * Improved error handling so previously loaded deals remain visible when loading another page fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->