### PR TITLE
feat(onboarding): the polish pass — reveal, orb choreography, pulse, focus

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1276,7 +1276,7 @@ export const de = {
   "ob.conv.voice.buildChip": "Mein Stimmprofil bauen",
   "ob.conv.voice.retryBuild": "Aufbau erneut versuchen",
   "ob.conv.voice.buildPollFailed":
-    "Ich habe die Verbindung während des Aufbaus verloren. Deine Texte bleiben erhalten, versuche den Aufbau erneut.",
+    "Ich habe die Verbindung während des Aufbaus verloren. Deine Texte bleiben erhalten. Versuche den Aufbau erneut.",
   "ob.conv.voice.statusBuilding": "Dein Stimmprofil entsteht",
   "ob.conv.voice.resultTitle":
     "Das ist deine Stimme, in deinen eigenen Worten.",
@@ -1296,7 +1296,7 @@ export const de = {
   "ob.conv.voice.manifestWords": "{words} Wörter",
   "ob.conv.voice.registerMix": "Register: {mix}",
   "ob.conv.voice.stageTitle": "Aufbau-Fortschritt",
-  "ob.conv.corpus.words": "Eigene Worte jetzt im Korpus: {words}.",
+  "ob.conv.corpus.words": "Eigene Wörter jetzt im Korpus: {words}.",
   "ob.conv.corpus.band": "Korpusqualität ist jetzt {band}.",
   "ob.conv.build.snapshot": "Ich friere deinen Korpus ein.",
   "ob.conv.build.extract": "Ich suche deine typischen Formulierungen.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1224,7 +1224,7 @@ export const en = {
   "ob.conv.voice.dropHint":
     "You can also drop files anywhere in this conversation.",
   "ob.conv.voice.fileSkipped":
-    "I can not read {name}. I take .txt, .md, .vtt, .srt, or .json.",
+    "I cannot read {name}. I take .txt, .md, .vtt, .srt, or .json.",
   "ob.conv.voice.fileEmpty":
     "There are no words in {name}, so nothing was counted.",
   "ob.conv.voice.reactionTranscript":
@@ -1232,7 +1232,7 @@ export const en = {
   "ob.conv.voice.reactionDocument":
     "Words counted: {words}. Every word here is yours, so all of them count.",
   "ob.conv.voice.refusalUnattributed":
-    "That looks like a conversation, but I can not tell which words are yours. I counted nothing, because I only count words that are provably yours.",
+    "That looks like a conversation, but I cannot tell which words are yours. I counted nothing, because I only count words that are provably yours.",
   "ob.conv.voice.refusalSpeaker":
     "I could not find that speaker in the transcript. Nothing was counted.",
   "ob.conv.voice.refusalUnsupported":

--- a/frontend/src/screens/onboarding-conversation/artifact.tsx
+++ b/frontend/src/screens/onboarding-conversation/artifact.tsx
@@ -24,7 +24,8 @@ export type FindingHighlight = Readonly<{
   ids: readonly string[];
 }>;
 
-const PULSE_MS = 1600;
+// Matches the ob-conv-pulse animation length in conversation.css.
+const PULSE_MS = 1200;
 
 type CompanyActArtifactProps = Readonly<{
   mode: ArtifactMode;
@@ -48,7 +49,33 @@ type CompanyActArtifactProps = Readonly<{
 export function CompanyActArtifact(props: CompanyActArtifactProps) {
   const t = useT();
   const container = useRef<HTMLDivElement>(null);
+  // Mirrors the thread's follow-the-bottom discipline: while the pointer is
+  // over the dossier the human owns its scroll position, and a pulse must
+  // not yank it.
+  const hovered = useRef(false);
   const { highlight } = props;
+
+  // Native listeners (not JSX handlers): the panel stays a static, purely
+  // presentational element — hover is an input to the pulse effect, not an
+  // interaction of its own.
+  useEffect(() => {
+    const root = container.current;
+    if (!root) {
+      return;
+    }
+    const enter = () => {
+      hovered.current = true;
+    };
+    const leave = () => {
+      hovered.current = false;
+    };
+    root.addEventListener("mouseenter", enter);
+    root.addEventListener("mouseleave", leave);
+    return () => {
+      root.removeEventListener("mouseenter", enter);
+      root.removeEventListener("mouseleave", leave);
+    };
+  }, []);
 
   useEffect(() => {
     if (!highlight) {
@@ -66,6 +93,17 @@ export function CompanyActArtifact(props: CompanyActArtifactProps) {
     );
     for (const node of nodes) {
       node.classList.add("ob-conv-pulse");
+    }
+    const first = nodes[0];
+    if (first !== undefined && !hovered.current) {
+      const reduceMotion =
+        globalThis.matchMedia?.("(prefers-reduced-motion: reduce)").matches ??
+        false;
+      // jsdom has no scrollIntoView; in the browser it always exists.
+      first.scrollIntoView?.({
+        block: "nearest",
+        behavior: reduceMotion ? "auto" : "smooth",
+      });
     }
     const timer = globalThis.setTimeout(() => {
       for (const node of nodes) {

--- a/frontend/src/screens/onboarding-conversation/company-act.tsx
+++ b/frontend/src/screens/onboarding-conversation/company-act.tsx
@@ -5,7 +5,6 @@ import { useCallback, useMemo, useRef, useState } from "react";
 import { api } from "../../api/client";
 import type { components } from "../../api/schema";
 import { Button } from "../../design-system/atoms";
-import type { MarginceCoreState } from "../../design-system/margince-core";
 import { useLocale, useT } from "../../i18n";
 import { problemMessage } from "../common";
 import type { CompanyDraft } from "../onboarding";
@@ -36,6 +35,7 @@ import type {
   ConversationState,
 } from "./conversation-machine";
 import { NarrationBubble } from "./entries";
+import { presenceFor } from "./presence";
 import { ConversationThread } from "./thread";
 import { useClarifyAnswers } from "./use-clarify-answers";
 import { useCompanyRead } from "./use-company-read";
@@ -61,32 +61,6 @@ type CompanyActProps = Readonly<{
   profile: CompanyProfile | null;
   persist: (input: WizardPersistInput) => Promise<boolean>;
 }>;
-
-function corePresence(
-  state: ConversationState,
-  read: CompanySiteRead | null,
-  failed: boolean,
-): MarginceCoreState {
-  if (failed || read?.status === "failed") {
-    return "error";
-  }
-  if (read?.status === "deferred") {
-    return "quiet";
-  }
-  if (
-    state.phase === "co.reading" &&
-    (read?.status === "queued" || read?.status === "reading")
-  ) {
-    return "working";
-  }
-  if (state.phase === "co.clarify") {
-    return "attention";
-  }
-  if (state.phase === "co.review" || state.phase === "co.confirmed") {
-    return "success";
-  }
-  return "listening";
-}
 
 function initialDraft(profile: CompanyProfile | null): CompanyDraft {
   return profile
@@ -256,11 +230,15 @@ export function CompanyAct({
     },
   });
 
+  const composer = useRef<HTMLTextAreaElement>(null);
   const submitComposer = () => {
     const text = conversation.draft.trim();
     if (text === "" || startRead.isPending || conversation.send.isPending) {
       return;
     }
+    // Sending must not strand focus on the send button: the composer stays
+    // the keyboard home while the conversation continues.
+    composer.current?.focus();
     const norm = normalizeUrl(text);
     if (
       norm.ok &&
@@ -331,9 +309,12 @@ export function CompanyAct({
     (state.phase === "co.intro" ||
       (state.phase === "co.reading" && state.activeReadId === null));
 
+  const presence = presenceFor(state, { read, readBroken });
+
   return (
     <ConversationWorkbench
-      core={corePresence(state, read, readBroken)}
+      core={presence.core}
+      progress={presence.progress}
       status={
         readBroken
           ? t("ob.readStatus.failed")
@@ -462,6 +443,7 @@ export function CompanyAct({
       </div>
       <div className="mw-composer">
         <textarea
+          ref={composer}
           value={conversation.draft}
           maxLength={2000}
           rows={2}

--- a/frontend/src/screens/onboarding-conversation/connect-act.tsx
+++ b/frontend/src/screens/onboarding-conversation/connect-act.tsx
@@ -16,6 +16,7 @@ import type {
   ConversationState,
 } from "./conversation-machine";
 import { NarrationBubble } from "./entries";
+import { presenceFor } from "./presence";
 import { ConversationThread } from "./thread";
 import type { WizardPersistInput } from "./use-wizard-state";
 import { ConversationWorkbench } from "./workbench";
@@ -86,7 +87,7 @@ export function ConnectAct({
 
   return (
     <ConversationWorkbench
-      core={state.act === "done" ? "success" : "listening"}
+      core={presenceFor(state).core}
       status={t("ob.ai.ready")}
       artifact={
         <div className="mw-review ob-conv-artifact">

--- a/frontend/src/screens/onboarding-conversation/conversation.css
+++ b/frontend/src/screens/onboarding-conversation/conversation.css
@@ -41,6 +41,33 @@
   font: 600 0.75rem / 1 var(--f-display);
 }
 
+/* Live narration reveals word by word. The animated copy is aria-hidden
+ * presentation; the full sentence sits alongside it visually hidden so
+ * assistive tech hears one coherent string. Under reduced motion the media
+ * query below never applies and the words are simply there. */
+.ob-conv-reveal-source {
+  position: absolute;
+  inline-size: 1px;
+  block-size: 1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .ob-conv-reveal span {
+    display: inline-block;
+    animation: ob-conv-reveal-word 0.3s ease-out backwards;
+  }
+}
+
+@keyframes ob-conv-reveal-word {
+  from {
+    opacity: 0;
+    transform: translateY(0.25em);
+  }
+}
+
 .ob-conv-user {
   display: flex;
   align-items: flex-start;
@@ -402,9 +429,18 @@
   align-self: center;
 }
 
+/* Keyboard focus on option chips and chip rows reads the same accent-token
+ * ring as the atom inputs, not the browser's off-palette native outline. */
+.ob-conv-option:focus-visible,
+.ob-conv-chips .btn:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+  box-shadow: 0 0 0 3px var(--accentLight);
+}
+
 /* A finding the narration just named lights its dossier card briefly. */
 .ob-conv-pulse {
-  animation: ob-conv-pulse 1.6s ease-out;
+  animation: ob-conv-pulse 1.2s ease-out;
 }
 
 @keyframes ob-conv-pulse {

--- a/frontend/src/screens/onboarding-conversation/entries.stories.tsx
+++ b/frontend/src/screens/onboarding-conversation/entries.stories.tsx
@@ -1,12 +1,18 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { MarginceCoreScene } from "../../design-system/margince-core";
 import { LocaleProvider } from "../../i18n";
-import type { ThreadEntry } from "./conversation-machine";
+import {
+  type ConversationState,
+  initialConversationState,
+  type ThreadEntry,
+} from "./conversation-machine";
 import {
   NarrationBubble,
   OutcomeCard,
   QuestionCard,
   UserTurn,
 } from "./entries";
+import { presenceFor } from "./presence";
 import { ConversationThread } from "./thread";
 
 const meta: Meta = {
@@ -73,6 +79,85 @@ const failureOutcome: Extract<ThreadEntry, { kind: "outcome" }> = {
 
 export const Narration: Story = {
   render: () => <NarrationBubble entry={narration} />,
+};
+
+// The live-arrival treatment: words stagger in (capped total duration);
+// under prefers-reduced-motion the sentence is simply there.
+export const NarrationRevealed: Story = {
+  render: () => <NarrationBubble entry={narration} reveal />,
+};
+
+// The orb choreography at a glance: one presence per conversation moment,
+// derived through the same presenceFor mapping the acts use.
+const choreography: ReadonlyArray<{
+  label: string;
+  state: ConversationState;
+  read?: Parameters<typeof presenceFor>[1];
+}> = [
+  {
+    label: "co.intro",
+    state: { ...initialConversationState, act: "company", phase: "co.intro" },
+  },
+  {
+    label: "co.reading",
+    state: { ...initialConversationState, act: "company", phase: "co.reading" },
+    read: { read: { status: "reading", phase: "crawling", pages_read: 14 } },
+  },
+  {
+    label: "co.clarify",
+    state: { ...initialConversationState, act: "company", phase: "co.clarify" },
+  },
+  {
+    label: "co.review",
+    state: { ...initialConversationState, act: "company", phase: "co.review" },
+  },
+  {
+    label: "vo.building",
+    state: {
+      ...initialConversationState,
+      act: "voice",
+      phase: "vo.building",
+      lastBuildStage: "evaluate",
+    },
+  },
+  {
+    label: "vo.result failed",
+    state: {
+      ...initialConversationState,
+      act: "voice",
+      phase: "vo.result",
+      lastBuildStatus: "failed",
+    },
+  },
+  {
+    label: "cn.done",
+    state: { ...initialConversationState, act: "done", phase: "cn.done" },
+  },
+];
+
+export const OrbChoreography: Story = {
+  render: () => (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "repeat(4, 1fr)",
+        gap: "var(--space-4)",
+      }}
+    >
+      {choreography.map((moment) => {
+        const presence = presenceFor(moment.state, moment.read);
+        return (
+          <figure key={moment.label} style={{ margin: 0, textAlign: "center" }}>
+            <MarginceCoreScene
+              state={presence.core}
+              progress={presence.progress}
+            />
+            <figcaption className="t-small">{moment.label}</figcaption>
+          </figure>
+        );
+      })}
+    </div>
+  ),
 };
 
 export const Question: Story = {

--- a/frontend/src/screens/onboarding-conversation/entries.tsx
+++ b/frontend/src/screens/onboarding-conversation/entries.tsx
@@ -1,5 +1,6 @@
 import type { LucideIcon } from "lucide-react";
 import { CircleAlert, CircleCheck, CircleUserRound, Clock } from "lucide-react";
+import { Fragment, useEffect, useRef } from "react";
 import { Button } from "../../design-system/atoms";
 import { useT } from "../../i18n";
 import type { MessageKey } from "../../i18n/en";
@@ -31,10 +32,57 @@ function resolvedParams(
   return { ...params, ...translated };
 }
 
+// Word-by-word reveal for narration that arrives LIVE — speech gets a beat,
+// factual cards (questions, outcomes, user turns) never do. The animated copy
+// is presentation only (aria-hidden, per-word spans); the full sentence rides
+// along visually hidden so assistive tech and text queries always see one
+// coherent string. The stagger shrinks with word count so a long sentence
+// finishes inside the same cap as a short one; prefers-reduced-motion
+// collapses the animation entirely (conversation.css).
+
+const REVEAL_WORD_STEP_MS = 90;
+const REVEAL_TOTAL_CAP_MS = 1200;
+
+export function RevealText({ text }: Readonly<{ text: string }>) {
+  const words = text.split(/\s+/).filter((word) => word !== "");
+  const step = Math.min(
+    REVEAL_WORD_STEP_MS,
+    REVEAL_TOTAL_CAP_MS / Math.max(1, words.length),
+  );
+  // Repeated words need distinct keys; an occurrence counter keeps them
+  // stable without keying on the array index.
+  const seen = new Map<string, number>();
+  return (
+    <>
+      <span className="ob-conv-reveal-source">{text}</span>
+      <span className="ob-conv-reveal" aria-hidden>
+        {words.map((word, position) => {
+          const occurrence = (seen.get(word) ?? 0) + 1;
+          seen.set(word, occurrence);
+          return (
+            <Fragment key={`${word}:${occurrence}`}>
+              <span
+                style={{ animationDelay: `${Math.round(position * step)}ms` }}
+              >
+                {word}
+              </span>{" "}
+            </Fragment>
+          );
+        })}
+      </span>
+    </>
+  );
+}
+
 export function NarrationBubble({
   entry,
-}: Readonly<{ entry: NarrationEntry }>) {
+  reveal = false,
+}: Readonly<{ entry: NarrationEntry; reveal?: boolean }>) {
   const t = useT();
+  const text = t(
+    entry.i18nKey,
+    resolvedParams(t, entry.params, entry.paramKeys),
+  );
   return (
     <div
       className="ob-conv-narration"
@@ -47,9 +95,7 @@ export function NarrationBubble({
       >
         <span aria-hidden>{t("ob.ai.speaker")}</span>
       </span>
-      <p>
-        {t(entry.i18nKey, resolvedParams(t, entry.params, entry.paramKeys))}
-      </p>
+      <p>{reveal ? <RevealText text={text} /> : text}</p>
     </div>
   );
 }
@@ -87,17 +133,49 @@ type QuestionCardProps = Readonly<{
   question: ConversationQuestion;
   /** Set after the question is answered; options stay visible but inert. */
   answered?: boolean;
+  /** The card is the one live question: keyboard focus moves to its first
+   * option — unless the human is mid-thought in a text field. */
+  focusFirstOption?: boolean;
   onAnswer: (questionId: string, value: string) => void;
 }>;
 
 export function QuestionCard({
   question,
   answered = false,
+  focusFirstOption = false,
   onAnswer,
 }: QuestionCardProps) {
   const t = useT();
+  const card = useRef<HTMLFieldSetElement>(null);
+
+  useEffect(() => {
+    if (!focusFirstOption || answered) {
+      return;
+    }
+    const button = card.current?.querySelector("button");
+    if (button == null) {
+      return;
+    }
+    // Never steal focus from someone typing: any focused text field wins,
+    // and a composer still holding a draft keeps its claim even unfocused.
+    const active = button.ownerDocument.activeElement;
+    if (
+      active instanceof HTMLTextAreaElement ||
+      active instanceof HTMLInputElement
+    ) {
+      return;
+    }
+    const composer = button
+      .closest(".ob-workbench-panel")
+      ?.querySelector<HTMLTextAreaElement>(".mw-composer textarea");
+    if (composer != null && composer.value !== "") {
+      return;
+    }
+    button.focus();
+  }, [focusFirstOption, answered]);
+
   return (
-    <fieldset className="ob-conv-question" disabled={answered}>
+    <fieldset ref={card} className="ob-conv-question" disabled={answered}>
       <legend>{t(question.i18nKey, question.params)}</legend>
       <div className="ob-conv-options">
         {question.options.map((option) => (

--- a/frontend/src/screens/onboarding-conversation/presence.test.ts
+++ b/frontend/src/screens/onboarding-conversation/presence.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+import {
+  type ConversationState,
+  initialConversationState,
+} from "./conversation-machine";
+import { presenceFor } from "./presence";
+
+// The orb choreography as a spec: for every phase the conversation can be
+// in, exactly one presence — and a progress ring only while a read or build
+// is actually running, fed by server counters, never invented.
+
+function state(patch: Partial<ConversationState>): ConversationState {
+  return { ...initialConversationState, ...patch };
+}
+
+const reading = state({ act: "company", phase: "co.reading" });
+
+describe("presenceFor: welcome and company act", () => {
+  it("idles before the restore settles", () => {
+    expect(presenceFor(initialConversationState)).toEqual({ core: "idle" });
+  });
+
+  it("listens while the human owes the URL", () => {
+    expect(presenceFor(state({ act: "company", phase: "co.intro" }))).toEqual({
+      core: "listening",
+    });
+  });
+
+  it("works with a pages-driven ring while the read runs", () => {
+    const presence = presenceFor(reading, {
+      read: { status: "reading", phase: "crawling", pages_read: 10 },
+    });
+    expect(presence.core).toBe("working");
+    expect(presence.progress).toBeCloseTo(0.25);
+  });
+
+  it("keeps the ring inside its honest band: floor, crawl cap, extracting", () => {
+    const floor = presenceFor(reading, {
+      read: { status: "queued", phase: null, pages_read: 0 },
+    });
+    expect(floor.progress).toBeCloseTo(0.08);
+    const capped = presenceFor(reading, {
+      read: { status: "reading", phase: "crawling", pages_read: 400 },
+    });
+    expect(capped.progress).toBeCloseTo(0.78);
+    const extracting = presenceFor(reading, {
+      read: { status: "reading", phase: "extracting", pages_read: 400 },
+    });
+    expect(extracting.progress).toBeCloseTo(0.84);
+  });
+
+  it("asks for attention while a clarify question waits", () => {
+    expect(
+      presenceFor(state({ act: "company", phase: "co.clarify" })).core,
+    ).toBe("attention");
+  });
+
+  it("marks review and confirmed as success", () => {
+    expect(
+      presenceFor(state({ act: "company", phase: "co.review" })).core,
+    ).toBe("success");
+    expect(
+      presenceFor(state({ act: "company", phase: "co.confirmed" })).core,
+    ).toBe("success");
+  });
+
+  it("shows error on a broken or failed read, quiet on deferred", () => {
+    expect(presenceFor(reading, { readBroken: true }).core).toBe("error");
+    expect(
+      presenceFor(reading, {
+        read: { status: "failed", phase: null, pages_read: 3 },
+      }).core,
+    ).toBe("error");
+    expect(
+      presenceFor(reading, {
+        read: { status: "deferred", phase: null, pages_read: 3 },
+      }).core,
+    ).toBe("quiet");
+  });
+});
+
+describe("presenceFor: voice, results, connect", () => {
+  it("rings the build stages as quarters while building", () => {
+    const base = state({ act: "voice", phase: "vo.building" });
+    expect(presenceFor(base)).toEqual({ core: "working", progress: 0.08 });
+    expect(
+      presenceFor({ ...base, lastBuildStage: "snapshot" }).progress,
+    ).toBeCloseTo(0.25);
+    expect(
+      presenceFor({ ...base, lastBuildStage: "activate" }).progress,
+    ).toBeCloseTo(1);
+  });
+
+  it("asks for attention on the invite and the speaker question", () => {
+    expect(presenceFor(state({ act: "voice", phase: "vo.invite" })).core).toBe(
+      "attention",
+    );
+    expect(presenceFor(state({ act: "voice", phase: "vo.speaker" })).core).toBe(
+      "attention",
+    );
+  });
+
+  it("maps the build result to its honest presence", () => {
+    const result = state({ act: "voice", phase: "vo.result" });
+    expect(presenceFor({ ...result, lastBuildStatus: "succeeded" }).core).toBe(
+      "success",
+    );
+    expect(presenceFor({ ...result, lastBuildStatus: "failed" }).core).toBe(
+      "error",
+    );
+    expect(presenceFor({ ...result, lastBuildStatus: "deferred" }).core).toBe(
+      "quiet",
+    );
+  });
+
+  it("listens while collecting and after a skip", () => {
+    expect(
+      presenceFor(state({ act: "voice", phase: "vo.collecting" })).core,
+    ).toBe("listening");
+    expect(presenceFor(state({ act: "voice", phase: "vo.skipped" })).core).toBe(
+      "listening",
+    );
+  });
+
+  it("celebrates the recap, listens through consent, succeeds on done", () => {
+    expect(presenceFor(state({ act: "results", phase: "re.recap" }))).toEqual({
+      core: "success",
+    });
+    expect(presenceFor(state({ act: "connect", phase: "cn.consent" }))).toEqual(
+      { core: "listening" },
+    );
+    expect(presenceFor(state({ act: "done", phase: "cn.done" }))).toEqual({
+      core: "success",
+    });
+  });
+});

--- a/frontend/src/screens/onboarding-conversation/presence.ts
+++ b/frontend/src/screens/onboarding-conversation/presence.ts
@@ -1,0 +1,125 @@
+import type { components } from "../../api/schema";
+import type { MarginceCoreState } from "../../design-system/margince-core";
+import type { BuildStage, ConversationState } from "./conversation-machine";
+
+// How the Margince orb accompanies the conversation: ONE pure mapping from
+// machine state to the Core scene's presence and progress ring, shared by
+// every act so the choreography reads as one performer. The company read's
+// live snapshot rides in as an extra argument because the machine holds only
+// run identity, never poll payloads.
+//
+// The grammar: listening while the human owes the next move, working (with a
+// progress ring) while a read or build runs, attention when a question card
+// waits, success on completions, error/quiet on failed/deferred runs.
+
+type ReadSnapshot = Pick<
+  components["schemas"]["CompanySiteRead"],
+  "status" | "phase" | "pages_read"
+>;
+
+export type OrbPresence = Readonly<{
+  core: MarginceCoreState;
+  progress?: number;
+}>;
+
+// Mirrors the classic read screen's ring: a soft cap keeps the ring honest —
+// it advances with pages but never claims completion the server has not
+// reported, and the extracting phase parks near (not at) the end.
+const READ_PAGES_SOFT_CAP = 40;
+const READ_RING_FLOOR = 0.08;
+const READ_RING_CRAWL_MAX = 0.78;
+const READ_RING_EXTRACTING = 0.84;
+
+const buildStageOrder: readonly BuildStage[] = [
+  "snapshot",
+  "extract",
+  "evaluate",
+  "activate",
+];
+
+function readProgress(read: ReadSnapshot): number {
+  if (read.phase === "extracting") {
+    return READ_RING_EXTRACTING;
+  }
+  return Math.max(
+    READ_RING_FLOOR,
+    Math.min(READ_RING_CRAWL_MAX, (read.pages_read ?? 0) / READ_PAGES_SOFT_CAP),
+  );
+}
+
+function companyPresence(
+  state: ConversationState,
+  read: ReadSnapshot | null,
+  readBroken: boolean,
+): OrbPresence {
+  if (readBroken || read?.status === "failed") {
+    return { core: "error" };
+  }
+  if (read?.status === "deferred") {
+    return { core: "quiet" };
+  }
+  if (
+    state.phase === "co.reading" &&
+    read !== null &&
+    (read.status === "queued" || read.status === "reading")
+  ) {
+    return { core: "working", progress: readProgress(read) };
+  }
+  if (state.phase === "co.clarify") {
+    return { core: "attention" };
+  }
+  if (state.phase === "co.review" || state.phase === "co.confirmed") {
+    return { core: "success" };
+  }
+  return { core: "listening" };
+}
+
+function voicePresence(state: ConversationState): OrbPresence {
+  if (state.phase === "vo.building") {
+    const stage = state.lastBuildStage;
+    return {
+      core: "working",
+      progress:
+        stage === null
+          ? READ_RING_FLOOR
+          : (buildStageOrder.indexOf(stage) + 1) / buildStageOrder.length,
+    };
+  }
+  if (state.phase === "vo.invite" || state.phase === "vo.speaker") {
+    return { core: "attention" };
+  }
+  if (state.phase === "vo.result") {
+    if (state.lastBuildStatus === "succeeded") {
+      return { core: "success" };
+    }
+    return { core: state.lastBuildStatus === "failed" ? "error" : "quiet" };
+  }
+  return { core: "listening" };
+}
+
+export function presenceFor(
+  state: ConversationState,
+  company: Readonly<{
+    read?: ReadSnapshot | null;
+    readBroken?: boolean;
+  }> = {},
+): OrbPresence {
+  switch (state.act) {
+    case "welcome":
+      return { core: "idle" };
+    case "company":
+      return companyPresence(
+        state,
+        company.read ?? null,
+        company.readBroken ?? false,
+      );
+    case "voice":
+      return voicePresence(state);
+    case "results":
+      return { core: "success" };
+    case "connect":
+      return { core: "listening" };
+    case "done":
+      return { core: "success" };
+  }
+}

--- a/frontend/src/screens/onboarding-conversation/results-act.tsx
+++ b/frontend/src/screens/onboarding-conversation/results-act.tsx
@@ -8,6 +8,7 @@ import type {
   ConversationState,
 } from "./conversation-machine";
 import { NarrationBubble } from "./entries";
+import { presenceFor } from "./presence";
 import { ConversationThread } from "./thread";
 import { ConversationWorkbench } from "./workbench";
 
@@ -35,7 +36,7 @@ export function ResultsAct({
   const t = useT();
   return (
     <ConversationWorkbench
-      core="success"
+      core={presenceFor(state).core}
       status={t("ob.ai.ready")}
       artifact={
         <div className="mw-review ob-conv-artifact">

--- a/frontend/src/screens/onboarding-conversation/thread.test.tsx
+++ b/frontend/src/screens/onboarding-conversation/thread.test.tsx
@@ -1,0 +1,128 @@
+/** @vitest-environment jsdom */
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { LocaleProvider } from "../../i18n";
+import type { ThreadEntry } from "./conversation-machine";
+import { entityQuestion } from "./test-fixtures";
+import { ConversationThread } from "./thread";
+
+// The thread's presentation duties: live narration reveals word by word
+// while restored entries render instantly, and the one live question card
+// claims keyboard focus only when no text field has a better claim.
+
+afterEach(cleanup);
+
+const restoredNarration: ThreadEntry = {
+  kind: "narration",
+  id: "0:recap",
+  i18nKey: "ob.conv.recap.back",
+};
+
+const liveNarration: ThreadEntry = {
+  kind: "narration",
+  id: "1:read:started",
+  i18nKey: "ob.conv.read.started",
+  params: { host: "gradion.com" },
+};
+
+const questionEntry: ThreadEntry = {
+  kind: "question",
+  id: "2:question:clarify-entity",
+  question: entityQuestion,
+};
+
+type ThreadProps = Readonly<{
+  entries: readonly ThreadEntry[];
+  pendingQuestionId?: string | null;
+  composerValue?: string;
+}>;
+
+// The composer guard walks the DOM the workbench provides: the panel class
+// around the thread and the composer beside it.
+function Harness({
+  entries,
+  pendingQuestionId = null,
+  composerValue = "",
+}: ThreadProps) {
+  return (
+    <LocaleProvider initial="en">
+      <section className="ob-workbench-panel">
+        <ConversationThread
+          entries={entries}
+          pendingQuestionId={pendingQuestionId}
+          onAnswer={() => {}}
+        />
+        <div className="mw-composer">
+          <textarea aria-label="composer" defaultValue={composerValue} />
+        </div>
+      </section>
+    </LocaleProvider>
+  );
+}
+
+describe("word-by-word reveal", () => {
+  it("renders entries present at mount instantly, without reveal markup", () => {
+    const { container } = render(<Harness entries={[restoredNarration]} />);
+    expect(container.querySelector(".ob-conv-reveal")).toBeNull();
+    expect(screen.getByText(/Welcome back\./)).toBeTruthy();
+  });
+
+  it("reveals narration that arrives after mount, keeping the full sentence readable", () => {
+    const { container, rerender } = render(
+      <Harness entries={[restoredNarration]} />,
+    );
+    rerender(<Harness entries={[restoredNarration, liveNarration]} />);
+    const reveal = container.querySelector(".ob-conv-reveal");
+    expect(reveal).not.toBeNull();
+    // The animated copy is presentation only; the coherent sentence is the
+    // visually hidden source next to it.
+    expect(reveal?.getAttribute("aria-hidden")).toBe("true");
+    expect(screen.getByText(/Reading gradion\.com now/)).toBeTruthy();
+    // The restored entry stays plain.
+    const bubbles = container.querySelectorAll(".ob-conv-narration");
+    expect(bubbles[0]?.querySelector(".ob-conv-reveal")).toBeNull();
+  });
+});
+
+describe("live question focus", () => {
+  it("moves focus to the live question's first option when the composer is idle", () => {
+    render(
+      <Harness
+        entries={[questionEntry]}
+        pendingQuestionId={entityQuestion.id}
+      />,
+    );
+    const first = screen.getByRole("button", { name: "Acme GmbH" });
+    expect(document.activeElement).toBe(first);
+  });
+
+  it("leaves focus alone while the composer holds a draft", () => {
+    render(
+      <Harness
+        entries={[questionEntry]}
+        pendingQuestionId={entityQuestion.id}
+        composerValue="https://gradion"
+      />,
+    );
+    const first = screen.getByRole("button", { name: "Acme GmbH" });
+    expect(document.activeElement).not.toBe(first);
+  });
+
+  it("leaves focus alone while a text field is focused", () => {
+    const { rerender } = render(<Harness entries={[]} />);
+    screen.getByLabelText("composer").focus();
+    rerender(
+      <Harness
+        entries={[questionEntry]}
+        pendingQuestionId={entityQuestion.id}
+      />,
+    );
+    expect(document.activeElement).toBe(screen.getByLabelText("composer"));
+  });
+
+  it("never focuses an answered card", () => {
+    render(<Harness entries={[questionEntry]} pendingQuestionId={null} />);
+    const first = screen.getByRole("button", { name: "Acme GmbH" });
+    expect(document.activeElement).not.toBe(first);
+  });
+});

--- a/frontend/src/screens/onboarding-conversation/thread.tsx
+++ b/frontend/src/screens/onboarding-conversation/thread.tsx
@@ -63,6 +63,14 @@ export function ConversationThread({
   const log = useRef<HTMLDivElement>(null);
   const end = useRef<HTMLDivElement>(null);
   const following = useRef(true);
+  // Entries already present when the thread mounted (a restored recap, an
+  // act switch) render instantly; only narration that ARRIVES live reveals
+  // word by word. Membership is fixed at mount — an entry that revealed once
+  // keeps its reveal markup, so a re-render never snaps it to plain text.
+  const preRendered = useRef<ReadonlySet<string> | null>(null);
+  if (preRendered.current === null) {
+    preRendered.current = new Set(entries.map((entry) => entry.id));
+  }
   // A programmatic smooth scroll fires intermediate scroll events; while it
   // runs, they must not be read as the user scrolling away.
   const scrollingProgrammatically = useRef(false);
@@ -124,7 +132,13 @@ export function ConversationThread({
     >
       {entries.map((entry) => {
         if (entry.kind === "narration") {
-          return <NarrationBubble key={entry.id} entry={entry} />;
+          return (
+            <NarrationBubble
+              key={entry.id}
+              entry={entry}
+              reveal={!preRendered.current?.has(entry.id)}
+            />
+          );
         }
         if (entry.kind === "question") {
           return (
@@ -132,6 +146,7 @@ export function ConversationThread({
               key={entry.id}
               question={entry.question}
               answered={entry.id !== liveQuestionEntryId}
+              focusFirstOption={entry.id === liveQuestionEntryId}
               onAnswer={onAnswer}
             />
           );

--- a/frontend/src/screens/onboarding-conversation/voice-act.tsx
+++ b/frontend/src/screens/onboarding-conversation/voice-act.tsx
@@ -3,7 +3,6 @@ import type { ChangeEvent, Dispatch, DragEvent } from "react";
 import { useRef, useState } from "react";
 import type { components } from "../../api/schema";
 import { Button } from "../../design-system/atoms";
-import type { MarginceCoreState } from "../../design-system/margince-core";
 import { useT } from "../../i18n";
 import { ACCEPTED_CORPUS_ATTR, VOICE_MIN_WORDS } from "../onboarding";
 import { parseVoiceInsights, VoiceInsights } from "../voice-insights";
@@ -12,6 +11,7 @@ import type {
   ConversationState,
 } from "./conversation-machine";
 import { NarrationBubble } from "./entries";
+import { presenceFor } from "./presence";
 import { ConversationThread } from "./thread";
 import { useVoiceBuild } from "./use-voice-build";
 import { useVoiceCorpus } from "./use-voice-corpus";
@@ -37,22 +37,6 @@ type VoiceActProps = Readonly<{
   initialSummary?: CorpusSummary | null;
 }>;
 
-function corePresence(state: ConversationState): MarginceCoreState {
-  if (state.phase === "vo.building") {
-    return "working";
-  }
-  if (state.phase === "vo.invite" || state.phase === "vo.speaker") {
-    return "attention";
-  }
-  if (state.phase === "vo.result") {
-    if (state.lastBuildStatus === "succeeded") {
-      return "success";
-    }
-    return state.lastBuildStatus === "failed" ? "error" : "quiet";
-  }
-  return "listening";
-}
-
 export function VoiceAct({ state, dispatch, initialSummary }: VoiceActProps) {
   const t = useT();
   const machine = useRef(state);
@@ -67,6 +51,7 @@ export function VoiceAct({ state, dispatch, initialSummary }: VoiceActProps) {
   const [pendingPaste, setPendingPaste] = useState<string | null>(null);
   const [dragOver, setDragOver] = useState(false);
   const fileRef = useRef<HTMLInputElement>(null);
+  const composer = useRef<HTMLTextAreaElement>(null);
 
   const collecting =
     state.phase === "vo.collecting" || state.phase === "vo.speaker";
@@ -105,6 +90,9 @@ export function VoiceAct({ state, dispatch, initialSummary }: VoiceActProps) {
     if (text === "" || state.phase !== "vo.collecting") {
       return;
     }
+    // Sending must not strand focus on the send button: the composer stays
+    // the keyboard home while the conversation continues.
+    composer.current?.focus();
     if (text.split(/\s+/).length >= PASTE_OFFER_MIN_WORDS) {
       setPendingPaste(text);
     } else {
@@ -126,9 +114,12 @@ export function VoiceAct({ state, dispatch, initialSummary }: VoiceActProps) {
     corpus.answerSpeaker(questionId, value);
   };
 
+  const presence = presenceFor(state);
+
   return (
     <ConversationWorkbench
-      core={corePresence(state)}
+      core={presence.core}
+      progress={presence.progress}
       status={t(
         state.phase === "vo.building"
           ? "ob.conv.voice.statusBuilding"
@@ -207,6 +198,7 @@ export function VoiceAct({ state, dispatch, initialSummary }: VoiceActProps) {
             <Paperclip aria-hidden />
           </Button>
           <textarea
+            ref={composer}
             value={draft}
             maxLength={100_000}
             rows={2}


### PR DESCRIPTION
Phase 7, the final phase of the conversational-onboarding plan. Restrained by design:

- **RevealText**: narration bubbles reveal word by word on their first live render only (~90ms/word, capped 1.2s). Restored threads render instantly; screen readers always see one coherent sentence; reduced motion disables the animation entirely. Question cards, outcomes, and user turns never animate — factual content is not theatre.
- **Orb choreography**: one pure `presenceFor` mapping drives the Margince Core across all four acts — listening at questions, working with an honest progress ring (crawl band, build-stage quarters), attention reserved for decisions awaiting the human, success where the machine naturally rests, error for hard failures. 12 tests pin the mapping.
- **Finding pulse**: tokens-consistent 1.2s ease-out; the pulsed dossier card scrolls into view only when the reader isn't in the panel.
- **Focus discipline**: the live question card focuses its first option without ever stealing from a mid-typing composer; the composer keeps focus after sending; chips carry visible focus rings.
- Four micro-copy fixes across the locales.

Deliberate restraint documented in the commit (no fake success flashes, no invented animation tokens, no theatre on ambient bubbles).

Verified live on a fresh install: sign-in lands in the conversation, narration reveals, the counter updates in place, the crawl narrates.

723 frontend tests (3 consecutive full runs); full `make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polish pass for conversational onboarding: adds accessible, reduced‑motion narration reveal; unifies the orb’s presence and progress across acts; smooths pulse and focus behavior. Improves clarity, prevents focus theft, and locks behavior with tests and stories.

- New Features
  - Narration reveal: words animate only on first live render, capped at 1.2s; screen readers get a single full sentence; reduced motion disables animation.
  - Orb choreography: one `presenceFor` mapping drives `Margince Core` across acts with honest progress (read: floor/crawl cap/extract; build: stage quarters). Used in company, voice, results, and connect acts.
  - Pulse: dossier cards pulse for 1.2s ease‑out and auto‑scroll into view only when the panel isn’t hovered; respects reduced motion.
  - Focus discipline: live question focuses its first option unless a text field is active or the composer holds a draft; composer retains focus after send; chips show visible focus rings.
  - Micro‑copy: small fixes in `en` (“cannot”) and `de` (“Wörter”, punctuation).

- Refactors
  - Added `presenceFor` with 12 tests; added thread reveal/focus tests; Storybook scenes for narration reveal and orb choreography.
  - Synced pulse timing: constant and CSS use the same 1.2s token.

<sup>Written for commit 87fba053f95d97539b8ce918f4f91deaeb35434a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

