### PR TITLE
fix(onboarding): the company act adopts its active read — remounts and reloads reach the review

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1361,6 +1361,14 @@ export const de = {
     "Du hast das Stimmprofil übersprungen. Entwürfe nutzen eine neutrale Startstimme.",
   "ob.conv.recap.corpus":
     "Dein Korpus enthält bereits {words} deiner eigenen Wörter.",
+  "ob.conv.recap.readTerminal":
+    "Willkommen zurück. Ich habe {host} bereits fertig gelesen: {count} belegte Funde. Deine Durchsicht ist unten bereit.",
+  "ob.conv.recap.readReading":
+    "Willkommen zurück. Ich lese {host} noch. Seiten bisher: {pages}.",
+  "ob.conv.recap.readFailed":
+    "Willkommen zurück. Mein früherer Lesevorgang von {host} wurde nicht fertig. Nenn mir wieder eine Website oder erzähl es mir direkt.",
+  "ob.conv.recap.readDeferred":
+    "Willkommen zurück. Mein Lesevorgang von {host} pausiert gerade. Nenn mir wieder eine Website oder erzähl es mir direkt.",
   "ob.conv.connect.pick":
     "Wähle einen Anbieter, um genau zu sehen, was das Verbinden tut. Oder überspringe es und verbinde später in den Einstellungen.",
   "ob.conv.connect.skip": "Verbinden vorerst überspringen",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1332,6 +1332,14 @@ export const en = {
     "You skipped the voice profile. Drafts use a neutral starter voice.",
   "ob.conv.recap.corpus":
     "Your corpus already holds {words} of your own words.",
+  "ob.conv.recap.readTerminal":
+    "Welcome back. I already finished reading {host}: {count} findings with sources. Your review is ready below.",
+  "ob.conv.recap.readReading":
+    "Welcome back. I am still reading {host}. Pages so far: {pages}.",
+  "ob.conv.recap.readFailed":
+    "Welcome back. My earlier read of {host} did not finish. Give me a website again, or tell me directly.",
+  "ob.conv.recap.readDeferred":
+    "Welcome back. My read of {host} is paused for now. Give me a website again, or tell me directly.",
   "ob.conv.connect.pick":
     "Pick a provider to see exactly what connecting does, or skip and connect later in Settings.",
   "ob.conv.connect.skip": "Skip connecting for now",

--- a/frontend/src/screens/onboarding-conversation/company-act.tsx
+++ b/frontend/src/screens/onboarding-conversation/company-act.tsx
@@ -60,6 +60,9 @@ type CompanyActProps = Readonly<{
    * confirmation can never erase stored fields the read did not rediscover. */
   profile: CompanyProfile | null;
   persist: (input: WizardPersistInput) => Promise<boolean>;
+  /** The restored snapshot of the machine's already-active read (reload
+   * adoption); null in a live session. */
+  adoptedRead?: CompanySiteRead | null;
 }>;
 
 function initialDraft(profile: CompanyProfile | null): CompanyDraft {
@@ -74,6 +77,7 @@ export function CompanyAct({
   dispatch,
   profile,
   persist,
+  adoptedRead = null,
 }: CompanyActProps) {
   const t = useT();
   const { locale } = useLocale();
@@ -95,9 +99,12 @@ export function CompanyAct({
   const [selectedFactKeys, setSelectedFactKeys] = useState<string[]>([]);
   const [artifactMode, setArtifactMode] = useState<ArtifactMode>("dossier");
   const [applied, setApplied] = useState<ReadonlySet<string>>(new Set());
+  // A run the machine already owns at mount was persisted when it started
+  // (that is how restore found it), so its wizard-state join is already in
+  // place; a fresh session joins when its own read starts.
   const [proposalJoin, setProposalJoin] = useState<
     "pending" | "ready" | "failed"
-  >("pending");
+  >(() => (state.activeReadId !== null ? "ready" : "pending"));
   const machine = useRef(state);
   machine.current = state;
 
@@ -157,6 +164,7 @@ export function CompanyAct({
     answers: clarify.answers,
     onReadStarted,
     proposalJoin,
+    adoptedRead,
   });
   proposalRef.current = proposal.data;
 

--- a/frontend/src/screens/onboarding-conversation/index.tsx
+++ b/frontend/src/screens/onboarding-conversation/index.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import type { Dispatch } from "react";
 import { useEffect, useReducer, useRef } from "react";
 import { api } from "../../api/client";
 import type { components } from "../../api/schema";
@@ -10,7 +11,9 @@ import { EMPTY_DRAFT, pickBuiltVersion, useCompany } from "../onboarding";
 import { CompanyAct } from "./company-act";
 import { ConnectAct } from "./connect-act";
 import {
+  type ConversationEvent,
   type ConversationPhase,
+  type ConversationState,
   conversationReducer,
   initialConversationState,
 } from "./conversation-machine";
@@ -28,6 +31,7 @@ import { VoiceAct } from "./voice-act";
 // the fallback when no state row exists.
 
 type OnboardingState = components["schemas"]["OnboardingState"];
+type CompanySiteRead = components["schemas"]["CompanySiteRead"];
 
 // The wizard steps whose restore needs the voice server truth (built
 // versions, corpus meter); the member path never does.
@@ -140,16 +144,16 @@ function RestoreGate({ lookups }: Readonly<{ lookups: RestoreLookup[] }>) {
   );
 }
 
-export function OnboardingConversationScreen() {
-  const route = useRoute();
-  const [state, dispatch] = useReducer(
-    conversationReducer,
-    initialConversationState,
-  );
-  const { persist } = useWizardStatePersist();
-  // GET /company 404s until a human saved one; only a SETTLED lookup may
-  // route — a transient error must not send an existing member down the
-  // creator flow (nor a returning creator down the member flow).
+// The restore lookups and the one START/RESUME dispatch, as a hook: the
+// server truth (wizard state, company, voice, persisted read) is read once,
+// and only a SETTLED set of lookups may route — a transient error must not
+// send an existing member down the creator flow (nor a returning creator
+// down the member flow).
+function useRestore(
+  state: ConversationState,
+  dispatch: Dispatch<ConversationEvent>,
+  routeConnect: boolean,
+) {
   const existing = useCompany(true);
   const wizard = useQuery({
     queryKey: ["onboarding-conv-state"],
@@ -164,10 +168,40 @@ export function OnboardingConversationScreen() {
     queryFn: probeVoice,
     enabled: voiceNeeded,
   });
+  // The persisted read is only worth fetching while the company act is
+  // still open: a reload must reattach a running or finished read instead
+  // of stranding the user's work behind a fresh intro.
+  const persistedReadId =
+    wizard.data != null &&
+    (wizard.data.step === "read" || wizard.data.step === "confirm")
+      ? (wizard.data.site_read_id ?? null)
+      : null;
+  const persistedRead = useQuery({
+    queryKey: ["onboarding-conv-read", persistedReadId],
+    enabled: persistedReadId !== null,
+    queryFn: async (): Promise<CompanySiteRead | null> => {
+      const { data, error, response } = await api.GET(
+        "/company/site-reads/{readId}",
+        { params: { path: { readId: persistedReadId ?? "" } } },
+      );
+      if (error) {
+        // A read the server no longer serves is not a restore failure; the
+        // company act simply reopens fresh.
+        if (response.status === 404) {
+          return null;
+        }
+        throw new Error(problemMessage(error));
+      }
+      return data;
+    },
+  });
 
   const restored = useRef(false);
   const settled =
-    existing.isSuccess && wizard.isSuccess && (!voiceNeeded || voice.isSuccess);
+    existing.isSuccess &&
+    wizard.isSuccess &&
+    (!voiceNeeded || voice.isSuccess) &&
+    (persistedReadId === null || persistedRead.isSuccess);
   useEffect(() => {
     if (restored.current || state.act !== "welcome" || !settled) {
       return;
@@ -177,7 +211,8 @@ export function OnboardingConversationScreen() {
       state: wizard.data ?? null,
       profile: existing.data ?? null,
       voice: voice.data ?? null,
-      routeConnect: route.id === "connect",
+      read: persistedRead.data ?? null,
+      routeConnect,
     });
     if (plan.kind === "complete") {
       navigate({ screen: "home" });
@@ -189,10 +224,45 @@ export function OnboardingConversationScreen() {
       companyConfirmed: plan.companyConfirmed,
       recap: plan.recap,
     });
+    // Reattaching happens through the ordinary machine event, so legality
+    // and correlation hold exactly as for a live read.
+    if (plan.adoptRead !== null) {
+      dispatch({ type: "READ_STARTED", readId: plan.adoptRead.id });
+    }
     if (plan.companyConfirmed && plan.resumeTarget !== null) {
       dispatch({ type: "RESUME", target: plan.resumeTarget });
     }
-  }, [state.act, settled, wizard.data, existing.data, voice.data, route.id]);
+  }, [
+    state.act,
+    settled,
+    wizard.data,
+    existing.data,
+    voice.data,
+    persistedRead.data,
+    routeConnect,
+    dispatch,
+  ]);
+
+  return {
+    existing,
+    voice,
+    persistedRead,
+    lookups: [existing, wizard, voice, persistedRead],
+  };
+}
+
+export function OnboardingConversationScreen() {
+  const route = useRoute();
+  const [state, dispatch] = useReducer(
+    conversationReducer,
+    initialConversationState,
+  );
+  const { persist } = useWizardStatePersist();
+  const { existing, voice, persistedRead, lookups } = useRestore(
+    state,
+    dispatch,
+    route.id === "connect",
+  );
 
   // Act-transition checkpoints: the server remembers where the journey is,
   // so a mid-onboarding reload restores to the right act with recap. Only
@@ -218,7 +288,7 @@ export function OnboardingConversationScreen() {
   }, [state.phase, state.lastBuildStatus, persist]);
 
   if (state.act === "welcome") {
-    return <RestoreGate lookups={[existing, wizard, voice]} />;
+    return <RestoreGate lookups={lookups} />;
   }
 
   const voiceBuilt =
@@ -232,6 +302,12 @@ export function OnboardingConversationScreen() {
           dispatch={dispatch}
           profile={existing.data ?? null}
           persist={persist}
+          adoptedRead={
+            persistedRead.data != null &&
+            persistedRead.data.id === state.activeReadId
+              ? persistedRead.data
+              : null
+          }
         />
       )}
       {state.act === "voice" && (

--- a/frontend/src/screens/onboarding-conversation/onboarding-restore.test.tsx
+++ b/frontend/src/screens/onboarding-conversation/onboarding-restore.test.tsx
@@ -20,6 +20,74 @@ import { OnboardingScreen } from "../onboarding";
 // completion BEFORE any navigation.
 
 type OnboardingState = components["schemas"]["OnboardingState"];
+type CompanySiteRead = components["schemas"]["CompanySiteRead"];
+type Proposal = components["schemas"]["OnboardingCompanyProposal"];
+
+const READ_ID = "018f3a1b-0000-7000-8000-0000000000c3";
+
+function readRow(
+  status: CompanySiteRead["status"],
+  pages = 12,
+): CompanySiteRead {
+  return {
+    id: READ_ID,
+    target_kind: "onboarding",
+    organization_id: null,
+    root_url: "https://gradion.com",
+    status,
+    status_code: null,
+    status_detail: null,
+    next_attempt_at: null,
+    phase: status === "reading" ? "crawling" : null,
+    pages_read: pages,
+    pages: [],
+    profile_fields: [
+      {
+        field: "legal_name",
+        value: "Gradion GmbH",
+        evidence_snippet: "© 2026 Gradion GmbH",
+        source_kind: "url",
+        source_url: "https://gradion.com",
+        confidence: 0.9,
+      },
+      {
+        field: "display_name",
+        value: "Gradion",
+        evidence_snippet: "Gradion",
+        source_kind: "url",
+        source_url: "https://gradion.com",
+        confidence: 0.9,
+      },
+    ],
+    facts: [],
+    comparisons: [],
+    people: [],
+    legal_entities: [],
+    warnings: [],
+    draft_version: 2,
+    proposal_hash: "proposal-2",
+    created_at: "2026-07-22T08:00:00Z",
+    updated_at: "2026-07-22T08:10:00Z",
+  };
+}
+
+function proposalFor(read: CompanySiteRead): Proposal {
+  return {
+    ready: true,
+    fields: read.profile_fields.map((field) => ({
+      field: field.field,
+      value: field.value,
+      confidence: field.confidence,
+      evidence_snippet: field.evidence_snippet,
+      source_url: field.source_url ?? "https://gradion.com",
+    })),
+    facts: [],
+    open_questions: [],
+    remaining_required_fields: [],
+    draft_version: read.draft_version,
+    proposal_hash: read.proposal_hash,
+  };
+}
 
 const savedProfile = {
   organization_id: "018f3a1b-0000-7000-8000-0000000000a1",
@@ -59,6 +127,10 @@ type StubOptions = {
   corpusWords?: number;
   /** Mutable: set to make PUT /onboarding/state fail with this status. */
   putStatus?: number;
+  /** GET /company/site-reads/{id} snapshots, served in order (last one
+   * repeats): the restore fetch first, then the resumed poll. */
+  reads?: CompanySiteRead[];
+  proposal?: Proposal;
 };
 
 function jsonResponse(body: unknown, status = 200) {
@@ -71,6 +143,7 @@ function jsonResponse(body: unknown, status = 200) {
 function stubApi(options: StubOptions = {}) {
   const calls: Request[] = [];
   let version = options.state?.version ?? 0;
+  let readPoll = 0;
   vi.stubGlobal(
     "fetch",
     vi.fn(async (request: Request) => {
@@ -112,6 +185,50 @@ function stubApi(options: StubOptions = {}) {
           completed_at: null,
           created_at: "2026-07-22T08:00:00Z",
           updated_at: "2026-07-22T09:01:00Z",
+        });
+      }
+      if (path.includes("/company/site-reads/") && request.method === "GET") {
+        const reads = options.reads ?? [];
+        const snapshot = reads[Math.min(readPoll, reads.length - 1)];
+        readPoll += 1;
+        return snapshot === undefined
+          ? jsonResponse({ detail: "read not found" }, 404)
+          : jsonResponse(snapshot);
+      }
+      if (path.endsWith("/onboarding/company/proposal")) {
+        return jsonResponse(
+          options.proposal ?? proposalFor(readRow("partial")),
+        );
+      }
+      if (
+        path.endsWith("/onboarding/company/messages") &&
+        request.method === "POST"
+      ) {
+        const body = (await request.clone().json()) as {
+          selected_option?: { field: string; value: string };
+        };
+        // The authorization round trip: exactly the selected field+value
+        // comes back as the confirmed change.
+        return jsonResponse({
+          kind: "clarification",
+          act: "company",
+          message: "Recorded.",
+          proposed_changes: body.selected_option
+            ? [{ ...body.selected_option, reason: "You chose this." }]
+            : [],
+          citations: [],
+          remaining_required_fields: [],
+          available_action: "confirm_company",
+          ai_runtime: {
+            currency: "USD",
+            call_attempts: 1,
+            tokens_in: 100,
+            tokens_out: 20,
+            latency_ms: 500,
+            estimated_cost_microusd: 0,
+            unpriced_calls: 0,
+            models: [],
+          },
         });
       }
       if (path.endsWith("/company") && request.method === "GET") {
@@ -291,6 +408,116 @@ describe("restore into the conversational shell", () => {
     await waitFor(() => {
       expect(window.location.hash).toBe("#/home");
     });
+  });
+});
+
+describe("reload adoption of a persisted read", () => {
+  it("a reload after the terminal lands in the review with the confirm card, without replaying narration", async () => {
+    stubApi({
+      state: stateRow({ step: "confirm", site_read_id: READ_ID }),
+      reads: [readRow("partial", 40)],
+    });
+    render(<OnboardingScreen />);
+
+    expect(
+      await screen.findByText(/I already finished reading gradion\.com/),
+    ).toBeTruthy();
+    // The terminal outcome and the review arrive through the normal
+    // conclude path; the per-field narration is recap, never a replay.
+    expect(await screen.findByText(/I could not read everything/)).toBeTruthy();
+    expect(
+      await screen.findByRole("button", { name: /Accept all/ }),
+    ).toBeTruthy();
+    expect(screen.queryByText(/Learned/)).toBeNull();
+  });
+
+  it("a reload after the terminal still asks the proposal's open question first", async () => {
+    const partial = readRow("partial", 40);
+    stubApi({
+      state: stateRow({ step: "confirm", site_read_id: READ_ID }),
+      reads: [partial],
+      proposal: {
+        ...proposalFor(partial),
+        open_questions: [
+          {
+            id: "clarify:legal_name:2",
+            question: "Which legal entity is this installation for?",
+            field: "legal_name",
+            options: [
+              {
+                value: "Gradion GmbH",
+                label: "Gradion GmbH",
+                evidence_url: "https://gradion.com/impressum",
+                evidence_snippet: "Gradion GmbH, Berlin",
+                detail: null,
+              },
+              {
+                value: "Gradion Holding GmbH",
+                label: "Gradion Holding GmbH",
+                evidence_url: "https://gradion.com/impressum",
+                evidence_snippet: "Gradion Holding GmbH, Berlin",
+                detail: null,
+              },
+            ],
+            allow_free_text: false,
+          },
+        ],
+      },
+    });
+    render(<OnboardingScreen />);
+
+    expect(
+      await screen.findByText(/Which legal entity is this installation for\?/),
+    ).toBeTruthy();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /Gradion Holding GmbH/ }),
+    );
+
+    expect(
+      await screen.findByRole("button", { name: /Accept all/ }),
+    ).toBeTruthy();
+  });
+
+  it("a reload mid-crawl resumes polling into the review", async () => {
+    stubApi({
+      state: stateRow({ step: "read", site_read_id: READ_ID }),
+      reads: [
+        readRow("reading", 12),
+        readRow("reading", 30),
+        readRow("partial", 40),
+      ],
+    });
+    render(<OnboardingScreen />);
+
+    expect(
+      await screen.findByText(/I am still reading gradion\.com/),
+    ).toBeTruthy();
+    expect(
+      await screen.findByRole(
+        "button",
+        { name: /Accept all/ },
+        {
+          timeout: 8000,
+        },
+      ),
+    ).toBeTruthy();
+  }, 20000);
+
+  it("a failed read reopens fresh with an honest line", async () => {
+    stubApi({
+      state: stateRow({ step: "read", site_read_id: READ_ID }),
+      reads: [readRow("failed")],
+    });
+    render(<OnboardingScreen />);
+
+    expect(
+      await screen.findByText(/My earlier read of gradion\.com did not finish/),
+    ).toBeTruthy();
+    expect(
+      await screen.findByRole("textbox", { name: /Type your website address/ }),
+    ).toBeTruthy();
+    expect(screen.queryByText(/Accept all/)).toBeNull();
   });
 });
 

--- a/frontend/src/screens/onboarding-conversation/read-conclusion.test.tsx
+++ b/frontend/src/screens/onboarding-conversation/read-conclusion.test.tsx
@@ -1,0 +1,295 @@
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render as rtlRender, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { components } from "../../api/schema";
+import { LocaleProvider } from "../../i18n";
+import { OnboardingScreen } from "../onboarding";
+
+type CompanySiteRead = components["schemas"]["CompanySiteRead"];
+type Proposal = components["schemas"]["OnboardingCompanyProposal"];
+type ColdField = components["schemas"]["ColdStartField"];
+
+const READ_ID = "018f3a1b-0000-7000-8000-0000000000c3";
+
+function grounded(
+  field: ColdField["field"],
+  value: string,
+  snippet: string,
+): ColdField {
+  return {
+    field,
+    value,
+    evidence_snippet: snippet,
+    source_kind: "url",
+    source_url: "https://gradion.com",
+    confidence: 0.9,
+  };
+}
+
+const baseRead = {
+  id: READ_ID,
+  target_kind: "onboarding",
+  organization_id: null,
+  root_url: "https://gradion.com",
+  status: "reading",
+  status_code: null,
+  status_detail: null,
+  next_attempt_at: null,
+  phase: "crawling",
+  pages_read: 1,
+  pages: [{ url: "https://gradion.com", status: "fetched", kind: "home" }],
+  profile_fields: [
+    grounded("legal_name", "Gradion GmbH", "© 2026 Gradion GmbH"),
+  ],
+  facts: [],
+  comparisons: [],
+  people: [],
+  legal_entities: [],
+  warnings: [],
+  draft_version: 1,
+  proposal_hash: "proposal-1",
+  created_at: "2026-07-22T08:00:00Z",
+  updated_at: "2026-07-22T08:00:01Z",
+} as const satisfies CompanySiteRead;
+
+const midRead: CompanySiteRead = {
+  ...baseRead,
+  pages_read: 20,
+  draft_version: 2,
+  profile_fields: [
+    grounded("legal_name", "Gradion GmbH", "© 2026 Gradion GmbH"),
+    grounded("display_name", "Gradion", "Gradion"),
+  ],
+};
+
+const partialRead: CompanySiteRead = {
+  ...baseRead,
+  status: "partial",
+  phase: null,
+  pages_read: 40,
+  draft_version: 3,
+  proposal_hash: "proposal-3",
+  profile_fields: [
+    grounded("legal_name", "Gradion GmbH", "© 2026 Gradion GmbH"),
+    grounded("display_name", "Gradion", "Gradion"),
+    grounded(
+      "offer_summary",
+      "Revenue software for manufacturers",
+      "We build revenue software",
+    ),
+    grounded("icp", "Mid-market manufacturers", "We serve manufacturers"),
+  ],
+};
+
+function proposalFor(read: CompanySiteRead): Proposal {
+  return {
+    ready: true,
+    fields: read.profile_fields.map((field) => ({
+      field: field.field,
+      value: field.value,
+      confidence: field.confidence,
+      evidence_snippet: field.evidence_snippet,
+      source_url: field.source_url ?? "https://gradion.com",
+    })),
+    facts: [],
+    open_questions: [],
+    remaining_required_fields: [],
+    draft_version: read.draft_version,
+    proposal_hash: read.proposal_hash,
+  };
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function stubApi(pollSequence: (CompanySiteRead | number)[]) {
+  const calls: Request[] = [];
+  let version = 0;
+  let poll = 0;
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (request: Request) => {
+      calls.push(request);
+      const path = new URL(request.url).pathname;
+      if (path.endsWith("/ai/profile")) {
+        return jsonResponse({
+          name: "Margince",
+          kind: "ai",
+          state: "configured",
+          inference_mode: "cloud",
+          providers: ["gemini"],
+          configured_models: [],
+        });
+      }
+      if (path.endsWith("/company/context/capabilities")) {
+        return jsonResponse({
+          onboarding_enabled: true,
+          read_enabled: true,
+          rollout: "ga",
+        });
+      }
+      if (path.endsWith("/onboarding/state") && request.method === "GET") {
+        return jsonResponse({ detail: "not started" }, 404);
+      }
+      if (path.endsWith("/onboarding/state") && request.method === "PUT") {
+        const body = (await request.clone().json()) as Record<string, unknown>;
+        version += 1;
+        return jsonResponse({
+          ...body,
+          path: "creator",
+          version,
+          completed_at: null,
+          created_at: "2026-07-22T08:00:00Z",
+          updated_at: "2026-07-22T08:01:00Z",
+        });
+      }
+      if (path.endsWith("/onboarding/company/proposal")) {
+        return jsonResponse(proposalFor(partialRead));
+      }
+      if (
+        path.endsWith("/onboarding/company/messages") &&
+        request.method === "POST"
+      ) {
+        return jsonResponse({
+          kind: "answer",
+          act: "company",
+          message: "Noted.",
+          proposed_changes: [],
+          citations: [],
+          remaining_required_fields: [],
+          available_action: "confirm_company",
+          ai_runtime: {
+            currency: "USD",
+            call_attempts: 1,
+            tokens_in: 100,
+            tokens_out: 20,
+            latency_ms: 500,
+            estimated_cost_microusd: 0,
+            unpriced_calls: 0,
+            models: [],
+          },
+        });
+      }
+      if (path.endsWith("/company/site-reads") && request.method === "POST") {
+        return jsonResponse(baseRead, 202);
+      }
+      if (path.includes("/company/site-reads/") && request.method === "GET") {
+        const snapshot = pollSequence[Math.min(poll, pollSequence.length - 1)];
+        poll += 1;
+        // A number in the sequence is an error status for that poll.
+        if (typeof snapshot === "number") {
+          return jsonResponse({ detail: "poll blew up" }, snapshot);
+        }
+        return jsonResponse(snapshot);
+      }
+      if (path.endsWith("/company") && request.method === "GET") {
+        return jsonResponse({ detail: "no company yet" }, 404);
+      }
+      throw new Error(`unstubbed request: ${request.method} ${request.url}`);
+    }),
+  );
+  return calls;
+}
+
+function render(ui: ReactNode) {
+  return rtlRender(
+    <QueryClientProvider
+      client={
+        new QueryClient({ defaultOptions: { queries: { retry: false } } })
+      }
+    >
+      <LocaleProvider initial="en">{ui}</LocaleProvider>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.stubGlobal("scrollTo", vi.fn());
+  window.localStorage.setItem("margince.conv", "1");
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  window.localStorage.removeItem("margince.conv");
+  window.location.hash = "";
+});
+
+// Pins the read-conclusion ordering contract end to end (see the conclude
+// effect in use-company-read.ts): a completed read whose proposal has ZERO
+// open questions must always reach co.review with the confirm card — via
+// multi-snapshot polling, with chat interleaved, and across a poll failure
+// that recovers into the terminal (the round-2 re-arm).
+describe("the read conclusion ordering contract", () => {
+  it("a multi-poll partial terminal with zero open questions reaches the confirm card", async () => {
+    stubApi([midRead, midRead, partialRead]);
+    render(<OnboardingScreen />);
+    const composer = await screen.findByRole("textbox", {
+      name: /Type your website address/,
+    });
+    await userEvent.type(composer, "gradion.com{Enter}");
+
+    expect(
+      await screen.findByText(/I could not read everything/, undefined, {
+        timeout: 8000,
+      }),
+    ).toBeTruthy();
+    expect(
+      await screen.findByRole(
+        "button",
+        { name: /Accept all/ },
+        {
+          timeout: 8000,
+        },
+      ),
+    ).toBeTruthy();
+  }, 20000);
+
+  it("chat during the read does not stall the conclusion", async () => {
+    stubApi([midRead, midRead, midRead, midRead, partialRead]);
+    render(<OnboardingScreen />);
+    const composer = await screen.findByRole("textbox", {
+      name: /Type your website address/,
+    });
+    await userEvent.type(composer, "gradion.com{Enter}");
+    await screen.findByText(/Reading gradion\.com now/);
+    await userEvent.type(composer, "what did you find so far?{Enter}");
+    expect(await screen.findByText("Noted.")).toBeTruthy();
+
+    expect(
+      await screen.findByRole(
+        "button",
+        { name: /Accept all/ },
+        {
+          timeout: 8000,
+        },
+      ),
+    ).toBeTruthy();
+  }, 20000);
+
+  it("a poll error mid-read that recovers into the terminal still reaches review", async () => {
+    stubApi([midRead, 500, partialRead]);
+    render(<OnboardingScreen />);
+    const composer = await screen.findByRole("textbox", {
+      name: /Type your website address/,
+    });
+    await userEvent.type(composer, "gradion.com{Enter}");
+
+    expect(
+      await screen.findByRole(
+        "button",
+        { name: /Accept all/ },
+        {
+          timeout: 8000,
+        },
+      ),
+    ).toBeTruthy();
+  }, 20000);
+});

--- a/frontend/src/screens/onboarding-conversation/restore.test.ts
+++ b/frontend/src/screens/onboarding-conversation/restore.test.ts
@@ -9,6 +9,42 @@ import { restorePlan } from "./restore";
 
 type OnboardingState = components["schemas"]["OnboardingState"];
 type CompanyProfile = components["schemas"]["CompanyProfile"];
+type CompanySiteRead = components["schemas"]["CompanySiteRead"];
+
+function readRow(status: CompanySiteRead["status"]): CompanySiteRead {
+  return {
+    id: "018f3a1b-0000-7000-8000-0000000000c3",
+    target_kind: "onboarding",
+    organization_id: null,
+    root_url: "https://gradion.com",
+    status,
+    status_code: null,
+    status_detail: null,
+    next_attempt_at: null,
+    phase: null,
+    pages_read: 12,
+    pages: [],
+    profile_fields: [
+      {
+        field: "legal_name",
+        value: "Gradion GmbH",
+        evidence_snippet: "© 2026 Gradion GmbH",
+        source_kind: "url",
+        source_url: "https://gradion.com",
+        confidence: 0.9,
+      },
+    ],
+    facts: [],
+    comparisons: [],
+    people: [],
+    legal_entities: [],
+    warnings: [],
+    draft_version: 2,
+    proposal_hash: "proposal-2",
+    created_at: "2026-07-22T08:00:00Z",
+    updated_at: "2026-07-22T08:10:00Z",
+  };
+}
 
 function stateRow(overrides: Partial<OnboardingState> = {}): OnboardingState {
   return {
@@ -57,6 +93,7 @@ describe("restorePlan", () => {
         state: null,
         profile: null,
         voice: null,
+        read: null,
         routeConnect: false,
       }),
     ).toEqual({
@@ -64,13 +101,20 @@ describe("restorePlan", () => {
       memberPath: false,
       companyConfirmed: false,
       resumeTarget: null,
+      adoptRead: null,
       recap: [],
     });
   });
 
   it("falls back to company-exists as the member signal ONLY without a state row", () => {
     expect(
-      restorePlan({ state: null, profile, voice: null, routeConnect: false }),
+      restorePlan({
+        state: null,
+        profile,
+        voice: null,
+        read: null,
+        routeConnect: false,
+      }),
     ).toMatchObject({ memberPath: true });
     // A returning creator has both a saved company and a state row saying
     // creator; the profile must not demote them to the member path.
@@ -79,6 +123,7 @@ describe("restorePlan", () => {
         state: stateRow({ step: "voice" }),
         profile,
         voice: emptyVoice,
+        read: null,
         routeConnect: false,
       }),
     ).toMatchObject({ memberPath: false, resumeTarget: "vo.invite" });
@@ -90,6 +135,7 @@ describe("restorePlan", () => {
         state: stateRow({ path: "member", step: "connect" }),
         profile,
         voice: null,
+        read: null,
         routeConnect: false,
       }),
     ).toMatchObject({
@@ -106,6 +152,7 @@ describe("restorePlan", () => {
           state: stateRow({ step }),
           profile: null,
           voice: null,
+          read: null,
           routeConnect: false,
         }),
       ).toMatchObject({
@@ -121,6 +168,7 @@ describe("restorePlan", () => {
       state: stateRow({ step: "voice" }),
       profile,
       voice: words(1240),
+      read: null,
       routeConnect: false,
     });
     expect(plan).toMatchObject({ resumeTarget: "vo.collecting" });
@@ -141,6 +189,7 @@ describe("restorePlan", () => {
         state: stateRow({ step: "voice", voice_skipped: true }),
         profile,
         voice: emptyVoice,
+        read: null,
         routeConnect: false,
       }),
     ).toMatchObject({ resumeTarget: "vo.skipped" });
@@ -148,6 +197,7 @@ describe("restorePlan", () => {
       state: stateRow({ step: "results", voice_skipped: true }),
       profile,
       voice: emptyVoice,
+      read: null,
       routeConnect: false,
     });
     expect(results).toMatchObject({ resumeTarget: "re.recap" });
@@ -164,6 +214,7 @@ describe("restorePlan", () => {
       state: stateRow({ step: "connect" }),
       profile: null,
       voice: { ...words(2000), built: true },
+      read: null,
       routeConnect: false,
     });
     expect(plan).toMatchObject({ resumeTarget: "cn.consent" });
@@ -183,9 +234,77 @@ describe("restorePlan", () => {
         state: stateRow({ step: "voice" }),
         profile,
         voice: emptyVoice,
+        read: null,
         routeConnect: true,
       }),
     ).toMatchObject({ resumeTarget: "cn.consent" });
+  });
+
+  it("adopts a persisted terminal read so the finished review stays reachable", () => {
+    for (const status of ["ready", "partial"] as const) {
+      const plan = restorePlan({
+        state: stateRow({ step: "confirm" }),
+        profile: null,
+        voice: null,
+        read: readRow(status),
+        routeConnect: false,
+      });
+      expect(plan).toMatchObject({
+        companyConfirmed: false,
+        adoptRead: { id: readRow(status).id },
+      });
+      if (plan.kind !== "start") {
+        throw new Error("expected a start plan");
+      }
+      expect(plan.recap).toContainEqual(
+        expect.objectContaining({
+          i18nKey: "ob.conv.recap.readTerminal",
+          params: { host: "gradion.com", count: 1 },
+        }),
+      );
+    }
+  });
+
+  it("adopts a still-running read so polling resumes", () => {
+    const plan = restorePlan({
+      state: stateRow(),
+      profile: null,
+      voice: null,
+      read: readRow("reading"),
+      routeConnect: false,
+    });
+    expect(plan).toMatchObject({ adoptRead: { id: readRow("reading").id } });
+    if (plan.kind !== "start") {
+      throw new Error("expected a start plan");
+    }
+    expect(plan.recap).toContainEqual(
+      expect.objectContaining({
+        i18nKey: "ob.conv.recap.readReading",
+        params: { host: "gradion.com", pages: 12 },
+      }),
+    );
+  });
+
+  it("reopens fresh with an honest line for a failed or deferred read", () => {
+    for (const [status, key] of [
+      ["failed", "ob.conv.recap.readFailed"],
+      ["deferred", "ob.conv.recap.readDeferred"],
+    ] as const) {
+      const plan = restorePlan({
+        state: stateRow(),
+        profile: null,
+        voice: null,
+        read: readRow(status),
+        routeConnect: false,
+      });
+      expect(plan).toMatchObject({ adoptRead: null });
+      if (plan.kind !== "start") {
+        throw new Error("expected a start plan");
+      }
+      expect(plan.recap).toContainEqual(
+        expect.objectContaining({ i18nKey: key }),
+      );
+    }
   });
 
   it("a completed journey leaves onboarding", () => {
@@ -194,6 +313,7 @@ describe("restorePlan", () => {
         state: stateRow({ step: "complete" }),
         profile,
         voice: null,
+        read: null,
         routeConnect: false,
       }),
     ).toEqual({ kind: "complete" });

--- a/frontend/src/screens/onboarding-conversation/restore.ts
+++ b/frontend/src/screens/onboarding-conversation/restore.ts
@@ -12,6 +12,7 @@ import type { NarrationEntry, ResumePoint } from "./conversation-types";
 type OnboardingState = components["schemas"]["OnboardingState"];
 type CompanyProfile = components["schemas"]["CompanyProfile"];
 type CorpusSummary = components["schemas"]["VoiceCorpusSummary"];
+type CompanySiteRead = components["schemas"]["CompanySiteRead"];
 
 export type VoiceRestoreProbe = Readonly<{
   /** An active or candidate version exists: the voice was actually built. */
@@ -28,6 +29,9 @@ export type RestoreInputs = Readonly<{
   /** Voice server truth; null when the probe was not needed (member path,
    * or the journey has not reached the voice act). */
   voice: VoiceRestoreProbe | null;
+  /** The read the persisted site_read_id points at (only fetched while the
+   * company act is still open); null when none was persisted or it is gone. */
+  read: CompanySiteRead | null;
   /** The OAuth return deep link (#/onboarding/connect/...) lands mid-journey
    * and must reopen the connect act, exactly like the classic coordinator. */
   routeConnect: boolean;
@@ -41,8 +45,69 @@ export type RestorePlan =
       companyConfirmed: boolean;
       /** Where RESUME lands; null means the company act is still open. */
       resumeTarget: ResumePoint | null;
+      /** A persisted read worth reattaching: terminal ready/partial (its
+       * review is one proposal fetch away) or still running (polling
+       * resumes). The shell dispatches READ_STARTED for it so the finished
+       * work is reachable again instead of stranded behind a reload. */
+      adoptRead: CompanySiteRead | null;
       recap: readonly NarrationEntry[];
     };
+
+// The read states a reload reattaches to. failed/deferred reopen fresh with
+// an honest recap line instead (a failed run has nothing to review, and a
+// deferred one restarts cleanly when the user re-submits); confirmed and
+// abandoned are post-outcome lifecycle states with nothing left to do here.
+const adoptableReadStates = new Set<CompanySiteRead["status"]>([
+  "ready",
+  "partial",
+  "queued",
+  "reading",
+]);
+
+function readRecap(read: CompanySiteRead): NarrationEntry[] {
+  const host = new URL(read.root_url).hostname;
+  if (read.status === "ready" || read.status === "partial") {
+    return [
+      {
+        kind: "narration",
+        id: "recap:read-terminal",
+        i18nKey: "ob.conv.recap.readTerminal",
+        params: { host, count: read.profile_fields.length },
+      },
+    ];
+  }
+  if (read.status === "queued" || read.status === "reading") {
+    return [
+      {
+        kind: "narration",
+        id: "recap:read-reading",
+        i18nKey: "ob.conv.recap.readReading",
+        params: { host, pages: read.pages_read ?? 0 },
+      },
+    ];
+  }
+  if (read.status === "failed") {
+    return [
+      {
+        kind: "narration",
+        id: "recap:read-failed",
+        i18nKey: "ob.conv.recap.readFailed",
+        params: { host },
+      },
+    ];
+  }
+  if (read.status === "deferred") {
+    return [
+      {
+        kind: "narration",
+        id: "recap:read-deferred",
+        i18nKey: "ob.conv.recap.readDeferred",
+        params: { host },
+      },
+    ];
+  }
+  return [];
+}
 
 // The wizard step values that mean the company confirmation already
 // happened (the classic coordinator only advances past step "read"/"confirm"
@@ -125,7 +190,7 @@ function recapEntries(
 }
 
 export function restorePlan(inputs: RestoreInputs): RestorePlan {
-  const { state, profile, voice, routeConnect } = inputs;
+  const { state, profile, voice, read, routeConnect } = inputs;
   if (state?.step === "complete") {
     return { kind: "complete" };
   }
@@ -133,14 +198,17 @@ export function restorePlan(inputs: RestoreInputs): RestorePlan {
     state !== null ? state.path === "member" : profile !== null;
   const companyConfirmed = state !== null && confirmedSteps.has(state.step);
   if (state === null || !companyConfirmed) {
-    // Fresh, or the company act is still open (step read/confirm): the act
-    // restarts and re-derives its review from the server; no recap yet.
+    // The company act is still open (fresh, or step read/confirm). A
+    // persisted read reattaches so its progress or finished review is
+    // reachable; a failed or deferred one reopens fresh with an honest line.
     return {
       kind: "start",
       memberPath,
       companyConfirmed: false,
       resumeTarget: null,
-      recap: [],
+      adoptRead:
+        read !== null && adoptableReadStates.has(read.status) ? read : null,
+      recap: read !== null ? readRecap(read) : [],
     };
   }
   const target: ResumePoint =
@@ -150,6 +218,7 @@ export function restorePlan(inputs: RestoreInputs): RestorePlan {
     memberPath,
     companyConfirmed: true,
     resumeTarget: target,
+    adoptRead: null,
     recap: recapEntries(inputs, memberPath, target),
   };
 }

--- a/frontend/src/screens/onboarding-conversation/use-company-read.ts
+++ b/frontend/src/screens/onboarding-conversation/use-company-read.ts
@@ -44,6 +44,10 @@ type UseCompanyReadArgs = Readonly<{
    * proposal is fetched only when "ready" (a stale join would serve the
    * previous read's proposal) and falls back to the snapshot on "failed". */
   proposalJoin: "pending" | "ready" | "failed";
+  /** The restored snapshot of the machine's already-active run: primed as
+   * the diff baseline (its findings recap upstream instead of replaying)
+   * and, when already terminal, concluded straight into the review path. */
+  adoptedRead?: CompanySiteRead | null;
 }>;
 
 export function useCompanyRead({
@@ -54,11 +58,17 @@ export function useCompanyRead({
   answers,
   onReadStarted,
   proposalJoin,
+  adoptedRead = null,
 }: UseCompanyReadArgs) {
-  const [readId, setReadId] = useState<string | null>(null);
+  // A run the machine already owns at mount (a restore, or this act
+  // remounting mid-read) is adopted: polling resumes for the machine's
+  // active run instead of stranding it with no poller.
+  const [readId, setReadId] = useState<string | null>(
+    machine.current.activeReadId,
+  );
   // Mirrors the readId state for callbacks: the poll effect must ignore
   // snapshots of a run this hook no longer intends (a superseded URL).
-  const readIdRef = useRef<string | null>(null);
+  const readIdRef = useRef<string | null>(machine.current.activeReadId);
   const [proposalArmed, setProposalArmed] = useState(false);
   const prevSnapshot = useRef<CompanySiteRead | null>(null);
   const appliedReadVersion = useRef(0);
@@ -153,6 +163,32 @@ export function useCompanyRead({
       setSelectedFactKeys,
     ],
   );
+
+  // Reload adoption: the restored snapshot becomes the diff baseline (the
+  // recap upstream already summarized it — a reload summarizes, never
+  // replays), the draft prefills from it, and a snapshot that is already
+  // terminal concludes through the SAME pending-terminal path a live poll
+  // takes: proposal first, clarify question if any, then the terminal
+  // outcome and review.
+  const adopted = useRef(false);
+  useEffect(() => {
+    if (adopted.current || adoptedRead === null) {
+      return;
+    }
+    adopted.current = true;
+    prevSnapshot.current = adoptedRead;
+    appliedReadVersion.current = adoptedRead.draft_version;
+    setDraft((current) => prefill(current, adoptedRead.profile_fields));
+    setSelectedFactKeys(
+      [...new Set(adoptedRead.facts.map((fact) => fact.value_key))].slice(
+        0,
+        MAX_SELECTED_FACTS,
+      ),
+    );
+    if (adoptedRead.status === "ready" || adoptedRead.status === "partial") {
+      concludeFreshTerminal(adoptedRead);
+    }
+  }, [adoptedRead, concludeFreshTerminal, setDraft, setSelectedFactKeys]);
 
   const startRead = useMutation({
     mutationFn: async (url: string): Promise<CompanySiteRead> => {
@@ -278,6 +314,13 @@ export function useCompanyRead({
   // with no questions left the review opens straight away. A proposal
   // failure must never stall the act: the outcome still lands and the
   // review builds from the site-read snapshot, after one honest turn.
+  //
+  // The ordering contract with the machine: CLARIFY and READ_TERMINAL are
+  // run-correlated and must precede the retirement READ_TERMINAL performs;
+  // REVIEW_READY deliberately carries NO run id — its guard is the recorded
+  // readCompleted flag, so review stays reachable after the run retires.
+  // Reordering these dispatches, or correlating REVIEW_READY, would strand
+  // a completed read one event short of its review.
   useEffect(() => {
     const terminal = pendingTerminal.current;
     if (!terminal) {


### PR DESCRIPTION
Live failure (Lars): a completed read whose act remounted — or whose page reloaded — kept its thread and chat but silently lost the poller and the conclude path, so the confirm card never appeared. The machine held the active run while the driver mounted with no read id.

- The driver now seeds from the machine's active run (adoption), with the proposal join treated as already established for an adopted run.
- Restore adopts a persisted read outright: a terminal snapshot concludes through the same pending-terminal path a live poll takes (proposal → clarify if any → outcome → review), a mid-crawl read resumes polling narrating only new progress, failed/deferred reads reopen fresh behind an honest recap line ("Welcome back. I already finished reading {host}: {count} findings with sources.").
- The suspected correlation-drop of REVIEW_READY was investigated and refuted; driver-level tests now pin the zero-open-questions conclude path, and the conclude ordering contract is documented.

Verified live against the actual stuck session: reload → welcome-back recap → questions → review card with Accept-all gating.

733 frontend tests (10 new across read-conclusion, restore adoption, and the restore matrix); full gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where onboarding reloads/remounts lost the active site-read poller and never showed the confirm card. The company act now adopts the active read so progress and reviews survive reloads.

- **Bug Fixes**
  - On mount, the company act seeds from the machine’s `activeReadId` and treats the proposal join as ready when adopting.
  - Restore fetches the persisted `site_read_id` and adopts it: `ready/partial` conclude into review, `queued/reading` resume polling, `failed/deferred` reopen fresh with an honest recap. Adds new recap i18n strings in `en`/`de`.
  - Adopted reads prime the draft and facts from the snapshot; terminal snapshots follow the same conclude path (proposal → clarify if any → outcome → review) so the confirm card appears without replaying narration.

- **Refactors**
  - Extracted `useRestore` to perform one-time lookups (wizard, company, voice, persisted read) and dispatch `READ_STARTED`/`RESUME`.
  - Documented and pinned the conclude ordering contract; added tests for read conclusion, restore adoption, and the restore matrix.

<sup>Written for commit 0a4eafe41be7bde3ee1eee0d5b029357ecb8b509. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved onboarding restoration for interrupted company-site reads.
  - Resumes active reads after reload, including ongoing polling and terminal results.
  - Restores completed read findings, draft content, and selected facts.
  - Provides clearer status messages for completed, ongoing, failed, and paused reads.
  - Preserves the correct review and confirmation flow after restoration.

- **Bug Fixes**
  - Prevents read progress from being lost during page reloads or temporary polling errors.
  - Ensures failed or deferred reads reopen with accurate guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->