### PR TITLE
fix(onboarding): the journey cannot dead-end — answered stays answered, every gate has a human exit

### DIFF
--- a/backend/internal/compose/onboardingacts_test.go
+++ b/backend/internal/compose/onboardingacts_test.go
@@ -227,6 +227,36 @@ func TestCompanyActClarificationCarriesTheDetectedQuestion(t *testing.T) {
 	}
 }
 
+func TestCompanyActClarificationSkipsQuestionsTheDraftAnswers(t *testing.T) {
+	readID := ids.NewV7()
+	brain := &validatedOnboardingBrainStub{response: model.Response{Text: `{
+		"kind":"clarification","message":"One address question remains.","proposed_changes":[],"source_ids":[]}`}}
+	assistant := onboardingCompanyAssistant{
+		state: onboardingStateReaderStub{state: identity.OnboardingState{ID: ids.NewV7(), SiteReadID: &readID}},
+		people: onboardingSiteReadReaderStub{read: people.SiteRead{ID: readID, Status: siteReadWireStatusDone, DraftVersion: 3, LegalEntities: []people.SiteReadLegalEntity{
+			{Name: "Acme GmbH", RegisteredAddress: "Berlin 1", SourceURL: "https://acme.example/legal"},
+			{Name: "Acme Holding AG", RegisteredAddress: "Zug 2", SourceURL: "https://acme.example/legal"},
+		}}},
+		brain: brain, runtime: &onboardingRuntimeStub{summary: ai.RunSummary{Currency: "USD"}},
+	}
+	// The live draft already answers the legal-name question with an
+	// exact option value, so the chat re-asks only the address.
+	recorder := onboardingCompanyRequest(&assistant, `{
+		"message":"What is still unclear?","locale":"en",
+		"company_draft":{"legal_name":"Acme GmbH"}}`)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	var reply crmcontracts.OnboardingCompanyMessageReply
+	if err := json.Unmarshal(recorder.Body.Bytes(), &reply); err != nil {
+		t.Fatalf("decode reply: %v", err)
+	}
+	if reply.Clarify == nil || reply.Clarify.Field != fieldRegisteredAddress ||
+		reply.Clarify.Id != "clarify:registered_address:3" {
+		t.Fatalf("clarify = %+v", reply.Clarify)
+	}
+}
+
 func TestVoiceActAnswersFromServerCorpusNumbersOnly(t *testing.T) {
 	brain := &validatedOnboardingBrainStub{response: model.Response{Text: `{
 		"kind":"answer","message":"Your corpus holds 1240 of your own words.","proposed_changes":[],"source_ids":[]}`}}

--- a/backend/internal/compose/onboardingclarify.go
+++ b/backend/internal/compose/onboardingclarify.go
@@ -16,9 +16,11 @@ package compose
 
 import (
 	"fmt"
+	"log/slog"
 	"strings"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/modules/people"
 	"github.com/gradionhq/margince/backend/internal/platform/httperr"
 )
@@ -78,10 +80,69 @@ func verifySelectedOption(selection crmcontracts.OnboardingClarifySelection, rea
 
 // onboardingClarifies runs every detector over the read and its
 // comparisons, in a stable order: entity identity first (it decides who
-// the company IS), then per-field conflicts.
+// the company IS), then per-field conflicts. This is the FULL set —
+// selection verification checks against it so an already-answered
+// question's option can still be re-picked; presentation paths use
+// openOnboardingClarifies to stop re-asking what the draft resolved.
 func onboardingClarifies(read people.SiteRead, comparisons []people.SiteReadComparison, locale string) []crmcontracts.OnboardingClarify {
 	out := entityClarifies(read, locale)
 	return append(out, conflictClarifies(read.DraftVersion, comparisons, locale)...)
+}
+
+// openOnboardingClarifies drops every question the persisted draft has
+// already answered: a question is resolved ONLY when the draft's value
+// for its field exactly equals one of the question's option values
+// (post-trim) — that match is provably an earlier authorized selection
+// or an accepted value, so re-deriving the question from site evidence
+// alone must not forget it on restore. A hand-typed value that matches
+// no option deliberately leaves the question open: the server cannot
+// distinguish a human's overriding edit from a read-prefilled draft, so
+// only the provable case resolves.
+func openOnboardingClarifies(read people.SiteRead, comparisons []people.SiteReadComparison, locale string, draft identity.OnboardingCompanyDraft) []crmcontracts.OnboardingClarify {
+	values := onboardingDraftValues(draft)
+	all := onboardingClarifies(read, comparisons, locale)
+	open := make([]crmcontracts.OnboardingClarify, 0, len(all))
+	for _, clarify := range all {
+		if clarifyAnsweredByDraft(clarify, values) {
+			continue
+		}
+		open = append(open, clarify)
+	}
+	return open
+}
+
+func clarifyAnsweredByDraft(clarify crmcontracts.OnboardingClarify, values map[string]*string) bool {
+	value := values[clarify.Field]
+	if value == nil {
+		return false
+	}
+	answer := strings.TrimSpace(*value)
+	if answer == "" {
+		return false
+	}
+	for _, option := range clarify.Options {
+		if option.Value == answer {
+			return true
+		}
+	}
+	return false
+}
+
+// onboardingDraftValues maps each clarifiable profile field to its draft
+// value. Fact-conflict questions carry composite keys with no draft
+// counterpart, so they never resolve through the draft — their answers
+// live in the confirm call's resolutions.
+func onboardingDraftValues(draft identity.OnboardingCompanyDraft) map[string]*string {
+	return map[string]*string{
+		fieldDisplayName: draft.DisplayName, fieldOfferSummary: draft.OfferSummary,
+		fieldICP: draft.ICP, fieldValueProposition: draft.ValueProposition,
+		fieldUSP: draft.USP, fieldCustomerPains: draft.CustomerPains,
+		fieldDesiredOutcomes: draft.DesiredOutcomes, fieldBuyingCenter: draft.BuyingCenter,
+		fieldBuyingIntents: draft.BuyingIntents, fieldCommonObjections: draft.CommonObjections,
+		fieldSalesMotion: draft.SalesMotion, fieldLegalName: draft.LegalName,
+		fieldRegisteredAddress: draft.RegisteredAddress, fieldRegisterVat: draft.RegisterVAT,
+		fieldIndustry: draft.Industry, fieldHistory: draft.History,
+	}
 }
 
 // onboardingClarifyID is stable per read draft version, so a re-poll of
@@ -91,11 +152,30 @@ func onboardingClarifyID(field string, draftVersion int) string {
 	return fmt.Sprintf("clarify:%s:%d", field, draftVersion)
 }
 
+// The clarify plausibility bounds: a legal name or address a human is
+// asked to pick must LOOK like one. Values beyond these caps, spanning
+// lines, or shaped like navigation chrome are extraction debris — an
+// unanswerable option must never gate the save.
+const (
+	clarifyNameMaxRunes    = 120
+	clarifyAddressMaxRunes = 160
+	// A token printed this often inside ONE candidate is menu chrome, not
+	// a printed identity.
+	clarifyTokenRepeatLimit = 3
+	// An "address" running past this many words with neither a comma nor
+	// a digit is a scraped link trail, not a postal address.
+	clarifyAddressMaxPlainWords = 6
+)
+
 // entityClarifies asks which printed legal entity (and which printed
 // registered address) the installation belongs to when the legal notice
-// names more than one. Option values are the exact printed strings; free
-// text is off — the census question is a pick among what the site
-// states, and the manual edit path stays available elsewhere.
+// names more than one. Option values are the plausible printed strings
+// (whitespace-collapsed); free text is off — the census question is a
+// pick among what the site states, and the manual edit path stays
+// available elsewhere. A question exists ONLY when at least two
+// plausible options survive the filter: one survivor means there is no
+// ambiguity worth blocking a save on. Filtered candidates are logged at
+// debug for operator diagnosability, never shown.
 func entityClarifies(read people.SiteRead, locale string) []crmcontracts.OnboardingClarify {
 	if len(read.LegalEntities) < 2 {
 		return nil
@@ -105,15 +185,30 @@ func entityClarifies(read people.SiteRead, locale string) []crmcontracts.Onboard
 	seenName := map[string]bool{}
 	addresses := make([]crmcontracts.OnboardingClarifyOption, 0, len(read.LegalEntities))
 	seenAddress := map[string]bool{}
+	var dropped []string
 	for _, entity := range read.LegalEntities {
-		if name := strings.TrimSpace(entity.Name); name != "" && !seenName[name] {
+		// An implausible half yields "" — the other half's option then
+		// simply carries no detail rather than showing the debris.
+		name, nameOK := plausibleClarifyValue(entity.Name, clarifyNameMaxRunes, false)
+		address, addressOK := plausibleClarifyValue(entity.RegisteredAddress, clarifyAddressMaxRunes, true)
+		if !nameOK && strings.TrimSpace(entity.Name) != "" {
+			dropped = append(dropped, boundedRunes(entity.Name, clarifyNameMaxRunes))
+		}
+		if !addressOK && strings.TrimSpace(entity.RegisteredAddress) != "" {
+			dropped = append(dropped, boundedRunes(entity.RegisteredAddress, clarifyAddressMaxRunes))
+		}
+		if nameOK && !seenName[name] {
 			seenName[name] = true
-			names = append(names, entityOption(name, name, entity, entity.RegisteredAddress))
+			names = append(names, entityOption(name, name, entity, address))
 		}
-		if address := strings.TrimSpace(entity.RegisteredAddress); address != "" && !seenAddress[address] {
+		if addressOK && !seenAddress[address] {
 			seenAddress[address] = true
-			addresses = append(addresses, entityOption(address, address, entity, entity.Name))
+			addresses = append(addresses, entityOption(address, address, entity, name))
 		}
+	}
+	if len(dropped) > 0 {
+		slog.Debug("onboarding clarify candidates filtered as implausible",
+			"read_id", read.ID, "dropped", dropped)
 	}
 	if len(names) > 1 {
 		out = append(out, crmcontracts.OnboardingClarify{
@@ -132,6 +227,35 @@ func entityClarifies(read people.SiteRead, locale string) []crmcontracts.Onboard
 		})
 	}
 	return out
+}
+
+// plausibleClarifyValue normalizes one candidate and decides whether a
+// human could answer with it: trimmed, single-line, whitespace-collapsed,
+// inside the length cap, no token repeated to the chrome threshold, and
+// (for addresses) not a long word trail with neither comma nor digit.
+// Every presentation and verification path shares this one builder, so
+// what can be picked is exactly what was shown.
+func plausibleClarifyValue(raw string, maxRunes int, addressShaped bool) (string, bool) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" || strings.ContainsAny(trimmed, "\n\r") {
+		return "", false
+	}
+	value := strings.Join(strings.Fields(trimmed), " ")
+	if len([]rune(value)) > maxRunes {
+		return "", false
+	}
+	words := strings.Fields(strings.ToLower(value))
+	counts := make(map[string]int, len(words))
+	for _, word := range words {
+		counts[word]++
+		if counts[word] >= clarifyTokenRepeatLimit {
+			return "", false
+		}
+	}
+	if addressShaped && len(words) > clarifyAddressMaxPlainWords && !strings.ContainsAny(value, ",0123456789") {
+		return "", false
+	}
+	return value, true
 }
 
 func entityOption(value, label string, entity people.SiteReadLegalEntity, detail string) crmcontracts.OnboardingClarifyOption {

--- a/backend/internal/compose/onboardingclarify_test.go
+++ b/backend/internal/compose/onboardingclarify_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/modules/people"
 )
 
@@ -92,6 +94,88 @@ func TestEntityClarifyOptionsAreCappedAtTheContractLimit(t *testing.T) {
 	}
 }
 
+// The live-data failure this pins: a census row whose "name" is the page's
+// navigation chrome and whose "address" is a mis-paired link trail must not
+// mint unanswerable options that block the save.
+func TestEntityClarifiesFilterImplausibleCensusDebris(t *testing.T) {
+	chromeName := "Gradion Pte. Ltd.Solutions Products Industries About Careers Contact English Deutsch Solutions Products Industries About Careers Contact English Deutsch"
+	chromeAddress := "Solutions Products Industries About Careers Contact English Deutsch"
+	clean := people.SiteReadLegalEntity{Name: "Gradion Pte. Ltd.", RegisteredAddress: "10 Anson Road #22-02, Singapore 079903", SourceURL: "https://gradion.example/legal"}
+
+	t.Run("one plausible survivor means no question at all", func(t *testing.T) {
+		read := people.SiteRead{DraftVersion: 1, LegalEntities: []people.SiteReadLegalEntity{
+			clean,
+			{Name: chromeName, RegisteredAddress: chromeAddress, SourceURL: "https://gradion.example/legal"},
+		}}
+		if got := onboardingClarifies(read, nil, "en"); len(got) != 0 {
+			t.Fatalf("debris minted a question: %+v", got)
+		}
+	})
+
+	t.Run("two plausible survivors ask with only the plausible options", func(t *testing.T) {
+		read := people.SiteRead{DraftVersion: 1, LegalEntities: []people.SiteReadLegalEntity{
+			clean,
+			{Name: "Gradion GmbH", RegisteredAddress: "Musterstraße 1, 10115 Berlin", SourceURL: "https://gradion.example/de/legal"},
+			{Name: chromeName, RegisteredAddress: chromeAddress, SourceURL: "https://gradion.example/legal"},
+		}}
+		clarifies := onboardingClarifies(read, nil, "en")
+		if len(clarifies) != 2 {
+			t.Fatalf("clarifies = %+v", clarifies)
+		}
+		for _, clarify := range clarifies {
+			if len(clarify.Options) != 2 {
+				t.Fatalf("%s options = %+v", clarify.Field, clarify.Options)
+			}
+			for _, option := range clarify.Options {
+				if strings.Contains(option.Value, "Solutions Products") {
+					t.Fatalf("chrome survived the filter: %+v", option)
+				}
+			}
+		}
+	})
+
+	t.Run("the verify gate accepts exactly the surviving set", func(t *testing.T) {
+		read := &people.SiteRead{DraftVersion: 1, LegalEntities: []people.SiteReadLegalEntity{
+			clean,
+			{Name: "Gradion GmbH", RegisteredAddress: "Musterstraße 1, 10115 Berlin", SourceURL: "https://gradion.example/de/legal"},
+			{Name: chromeName, RegisteredAddress: chromeAddress, SourceURL: "https://gradion.example/legal"},
+		}}
+		surviving := crmcontracts.OnboardingClarifySelection{ClarifyId: "clarify:legal_name:1", Field: "legal_name", Value: "Gradion GmbH"}
+		if err := verifySelectedOption(surviving, read, nil, "en"); err != nil {
+			t.Fatalf("surviving option refused: %v", err)
+		}
+		filtered := crmcontracts.OnboardingClarifySelection{ClarifyId: "clarify:legal_name:1", Field: "legal_name", Value: chromeName}
+		if err := verifySelectedOption(filtered, read, nil, "en"); err == nil {
+			t.Fatal("a filtered-out debris value was accepted as a selection")
+		}
+	})
+}
+
+func TestPlausibleClarifyValueBounds(t *testing.T) {
+	tests := map[string]struct {
+		raw          string
+		maxRunes     int
+		addressShape bool
+		want         string
+		wantOK       bool
+	}{
+		"clean name passes and collapses whitespace": {raw: "  Acme   GmbH ", maxRunes: clarifyNameMaxRunes, want: "Acme GmbH", wantOK: true},
+		"multi-line scrape rejected":                 {raw: "Acme GmbH\nMusterstraße 1", maxRunes: clarifyNameMaxRunes},
+		"over-cap name rejected":                     {raw: strings.Repeat("Gradion Solutions ", 8), maxRunes: clarifyNameMaxRunes},
+		"token repeated three times rejected":        {raw: "Home Home Home GmbH", maxRunes: clarifyNameMaxRunes},
+		"long plain word trail is no address":        {raw: "Solutions Products Industries About Careers Contact English", maxRunes: clarifyAddressMaxRunes, addressShape: true},
+		"real address with digits passes":            {raw: "10 Anson Road #22-02, Singapore 079903", maxRunes: clarifyAddressMaxRunes, addressShape: true, want: "10 Anson Road #22-02, Singapore 079903", wantOK: true},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, ok := plausibleClarifyValue(tc.raw, tc.maxRunes, tc.addressShape)
+			if ok != tc.wantOK || got != tc.want {
+				t.Fatalf("plausibleClarifyValue(%q) = %q, %v; want %q, %v", tc.raw, got, ok, tc.want, tc.wantOK)
+			}
+		})
+	}
+}
+
 func TestConflictClarifiesMapOntoTheResolutionContract(t *testing.T) {
 	current, source := "Acme Software", "human"
 	comparisons := []people.SiteReadComparison{
@@ -116,6 +200,68 @@ func TestConflictClarifiesMapOntoTheResolutionContract(t *testing.T) {
 	if conflict.Options[0].Detail == nil || !strings.Contains(*conflict.Options[0].Detail, "keep_current") ||
 		conflict.Options[1].Detail == nil || !strings.Contains(*conflict.Options[1].Detail, "accept_proposal") {
 		t.Fatalf("conflict option provenance = %+v", conflict.Options)
+	}
+}
+
+func TestOpenClarifiesSkipQuestionsTheDraftAlreadyAnswers(t *testing.T) {
+	current := "Acme Software"
+	read := people.SiteRead{DraftVersion: 5, LegalEntities: []people.SiteReadLegalEntity{
+		{Name: "Acme GmbH", RegisteredAddress: "Berlin 1", SourceURL: "https://acme.example/legal"},
+		{Name: "Acme Holding AG", RegisteredAddress: "Zug 2", SourceURL: "https://acme.example/legal"},
+	}}
+	comparisons := []people.SiteReadComparison{{Key: "display_name", Classification: "human_conflict", CurrentValue: &current, ProposedValue: "Acme GmbH"}}
+	openFields := func(draft identity.OnboardingCompanyDraft) []string {
+		open := openOnboardingClarifies(read, comparisons, "en", draft)
+		fields := make([]string, 0, len(open))
+		for _, clarify := range open {
+			fields = append(fields, clarify.Field)
+		}
+		return fields
+	}
+
+	tests := map[string]struct {
+		draft identity.OnboardingCompanyDraft
+		want  []string
+	}{
+		"empty draft keeps every question open": {
+			want: []string{fieldLegalName, fieldRegisteredAddress, fieldDisplayName},
+		},
+		"an answered entity question is not re-asked": {
+			draft: identity.OnboardingCompanyDraft{LegalName: stringPtr("Acme GmbH")},
+			want:  []string{fieldRegisteredAddress, fieldDisplayName},
+		},
+		"a selection echo with surrounding whitespace still resolves": {
+			draft: identity.OnboardingCompanyDraft{RegisteredAddress: stringPtr("  Berlin 1  ")},
+			want:  []string{fieldLegalName, fieldDisplayName},
+		},
+		"a resolved conflict is not re-asked (either option value)": {
+			draft: identity.OnboardingCompanyDraft{DisplayName: stringPtr("Acme Software")},
+			want:  []string{fieldLegalName, fieldRegisteredAddress},
+		},
+		// The documented boundary: only an exact option-value match is
+		// provably an answer. A hand-typed different value could equally
+		// be a read prefill, so the question stays open.
+		"a hand-typed non-option value keeps the question open": {
+			draft: identity.OnboardingCompanyDraft{LegalName: stringPtr("Acme Worldwide Ltd")},
+			want:  []string{fieldLegalName, fieldRegisteredAddress, fieldDisplayName},
+		},
+		"a blank draft value keeps the question open": {
+			draft: identity.OnboardingCompanyDraft{LegalName: stringPtr("   ")},
+			want:  []string{fieldLegalName, fieldRegisteredAddress, fieldDisplayName},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := openFields(tc.draft)
+			if len(got) != len(tc.want) {
+				t.Fatalf("open fields = %v, want %v", got, tc.want)
+			}
+			for i := range tc.want {
+				if got[i] != tc.want[i] {
+					t.Fatalf("open fields = %v, want %v", got, tc.want)
+				}
+			}
+		})
 	}
 }
 

--- a/backend/internal/compose/onboardingcompanymessage.go
+++ b/backend/internal/compose/onboardingcompanymessage.go
@@ -166,11 +166,13 @@ func (a *onboardingCompanyAssistant) converse(ctx context.Context, req crmcontra
 		if err != nil {
 			return companyReadModelReply{}, nil, nil, err
 		}
-		// A clarification carries the server-detected question when one
-		// exists: the model's prose stays, the options are never its own.
+		// A clarification carries the first STILL-OPEN server-detected
+		// question: the model's prose stays, the options are never its
+		// own, and a question the current draft already answers with an
+		// exact option value is not re-asked.
 		var clarify *crmcontracts.OnboardingClarify
 		if answer.Kind == "clarification" && read != nil {
-			if questions := onboardingClarifies(*read, comparisons, locale); len(questions) > 0 {
+			if questions := openOnboardingClarifies(*read, comparisons, locale, conversation.CurrentDraft); len(questions) > 0 {
 				clarify = &questions[0]
 			}
 		}

--- a/backend/internal/compose/onboardingproposal.go
+++ b/backend/internal/compose/onboardingproposal.go
@@ -97,7 +97,10 @@ func onboardingCompanyProposal(read people.SiteRead, comparisons []people.SiteRe
 			Confidence: fact.Confidence,
 		})
 	}
-	openQuestions := onboardingClarifies(read, comparisons, locale)
+	// Only still-open questions ship: one the draft already answers with
+	// an exact option value was resolved by an earlier authorized
+	// selection and must not be re-asked on restore.
+	openQuestions := openOnboardingClarifies(read, comparisons, locale, draft)
 	if openQuestions == nil {
 		openQuestions = []crmcontracts.OnboardingClarify{}
 	}

--- a/backend/internal/compose/onboardingproposal_test.go
+++ b/backend/internal/compose/onboardingproposal_test.go
@@ -88,6 +88,37 @@ func TestOnboardingProposalServesTheDeterministicMapping(t *testing.T) {
 	}
 }
 
+func TestOnboardingProposalDoesNotReAskAnsweredQuestions(t *testing.T) {
+	readID := ids.NewV7()
+	engine := &onboardingProposalEngine{
+		state: onboardingStateReaderStub{state: identity.OnboardingState{
+			ID: ids.NewV7(), SiteReadID: &readID,
+			// The persisted draft carries an earlier authorized selection:
+			// exactly one option value of the legal-entity question.
+			CompanyDraft: identity.OnboardingCompanyDraft{LegalName: stringPtr("Acme GmbH")},
+		}},
+		people: onboardingSiteReadReaderStub{read: people.SiteRead{ID: readID, Status: siteReadWireStatusDone, LegalEntities: []people.SiteReadLegalEntity{
+			{Name: "Acme GmbH", RegisteredAddress: "Berlin 1", SourceURL: "https://acme.example/legal"},
+			{Name: "Acme Holding AG", RegisteredAddress: "Zug 2", SourceURL: "https://acme.example/legal"},
+		}}},
+		rollout: companyContextRolloutOnboarding,
+	}
+	recorder := onboardingProposalRequest(engine, nil)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	var proposal crmcontracts.OnboardingCompanyProposal
+	if err := json.Unmarshal(recorder.Body.Bytes(), &proposal); err != nil {
+		t.Fatalf("decode proposal: %v", err)
+	}
+	// The answered legal-name question is gone; the untouched address
+	// question stays open.
+	if proposal.OpenQuestions == nil || len(*proposal.OpenQuestions) != 1 ||
+		(*proposal.OpenQuestions)[0].Field != fieldRegisteredAddress {
+		t.Fatalf("open questions = %+v", proposal.OpenQuestions)
+	}
+}
+
 func TestOnboardingProposalSpeaksTheRequestedLocale(t *testing.T) {
 	readID := ids.NewV7()
 	engine := &onboardingProposalEngine{

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1316,6 +1316,10 @@ export const de = {
   "ob.conv.tellInstead": "Ich erzähle es dir lieber direkt",
   "ob.conv.clarify.question": "{question}",
   "ob.conv.clarify.optionDetail": "{detail}",
+  "ob.conv.clarify.dismiss": "Überspringen - ich trage es selbst ein",
+  "ob.conv.clarify.keepMine": "Meinen Wert behalten",
+  "ob.conv.review.skipped":
+    "Du hast übersprungen: {fields}. Du kannst sie jederzeit bearbeiten.",
   "ob.conv.clarify.applyFailed":
     "Ich konnte diese Wahl nicht übernehmen: {detail} Wähle bitte erneut.",
   "ob.conv.clarify.applyMissing":
@@ -1375,6 +1379,10 @@ export const de = {
   "ob.conv.connect.artifactTitle": "Postfach-Verbindung",
   "ob.conv.connect.artifactEmpty":
     "Wähle im Gespräch einen Anbieter, dann öffnet sich hier sein Verbindungs-Panel.",
+  "ob.conv.next.decisionOne": "1 Entscheidung offen",
+  "ob.conv.next.decisionMany": "{count} Entscheidungen offen",
+  "ob.conv.next.review": "Deine Durchsicht ist bereit",
+  "ob.conv.next.build": "Bereit, deine Stimme zu bauen",
 
   "auth.title": "Margince",
   "auth.checking": "Sitzung wird geprüft…",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1291,6 +1291,9 @@ export const en = {
   "ob.conv.tellInstead": "I would rather tell you directly",
   "ob.conv.clarify.question": "{question}",
   "ob.conv.clarify.optionDetail": "{detail}",
+  "ob.conv.clarify.dismiss": "Skip this - I will set it myself",
+  "ob.conv.clarify.keepMine": "Keep my value",
+  "ob.conv.review.skipped": "You skipped: {fields}. Edit them any time.",
   "ob.conv.clarify.applyFailed":
     "I could not record that choice: {detail} Pick it again.",
   "ob.conv.clarify.applyMissing":
@@ -1346,6 +1349,10 @@ export const en = {
   "ob.conv.connect.artifactTitle": "Inbox connection",
   "ob.conv.connect.artifactEmpty":
     "Pick a provider in the conversation and its connection panel opens here.",
+  "ob.conv.next.decisionOne": "1 decision open",
+  "ob.conv.next.decisionMany": "{count} decisions open",
+  "ob.conv.next.review": "Your review is ready",
+  "ob.conv.next.build": "Ready to build your voice",
 
   "auth.title": "Margince",
   "auth.checking": "Checking your session…",

--- a/frontend/src/screens/onboarding-conversation/clarify-dismiss.test.tsx
+++ b/frontend/src/screens/onboarding-conversation/clarify-dismiss.test.tsx
@@ -1,0 +1,402 @@
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render as rtlRender, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { components } from "../../api/schema";
+import { LocaleProvider } from "../../i18n";
+import { OnboardingScreen } from "../onboarding";
+import { resolutionsFromAnswers } from "./company-proposal";
+import type { ConversationState } from "./conversation-machine";
+import {
+  conversationReducer,
+  initialConversationState,
+} from "./conversation-machine";
+import { QuestionCard } from "./entries";
+
+// Humans outrank the reader: every clarify carries a local dismiss escape,
+// so an implausible question (page chrome glued into entity names) can never
+// become an unanswerable gate in front of Accept all. Dismissal writes
+// nothing; a human_conflict dismissal still sends the explicit keep_current
+// resolution the server requires, while a census dismissal sends none.
+
+type CompanySiteRead = components["schemas"]["CompanySiteRead"];
+type Comparison = components["schemas"]["CompanySiteReadComparison"];
+type Proposal = components["schemas"]["OnboardingCompanyProposal"];
+type ColdField = components["schemas"]["ColdStartField"];
+
+const conflictComparison: Comparison = {
+  key: "legal_name",
+  value_kind: "profile_field",
+  classification: "human_conflict",
+  current_value: "My Own GmbH",
+  current_source: "human",
+  proposed_value: "Gradion GmbH",
+};
+
+describe("resolutionsFromAnswers with dismissals", () => {
+  it("maps a dismissed human_conflict to the explicit keep_current the server requires", () => {
+    expect(
+      resolutionsFromAnswers(
+        [conflictComparison],
+        [
+          {
+            clarifyId: "clarify:legal_name:1",
+            field: "legal_name",
+            value: "",
+            dismissed: true,
+          },
+        ],
+      ),
+    ).toEqual([{ key: "legal_name", action: "keep_current" }]);
+  });
+
+  it("sends NO resolution for a dismissed census question — the server rejects non-conflict keys", () => {
+    expect(
+      resolutionsFromAnswers(
+        [],
+        [
+          {
+            clarifyId: "clarify:legal_name:1",
+            field: "legal_name",
+            value: "",
+            dismissed: true,
+          },
+        ],
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe("the machine's dismissal path", () => {
+  const clarifying: ConversationState = {
+    ...initialConversationState,
+    act: "company",
+    phase: "co.clarify",
+    readCompleted: true,
+    pendingQuestion: {
+      id: "clarify-entity",
+      i18nKey: "ob.conv.clarify.question",
+      params: { question: "Which entity?" },
+      dismissLabelKey: "ob.conv.clarify.dismiss",
+      options: [{ value: "a", label: "Acme GmbH" }],
+    },
+  };
+
+  it("clears the pending question through the ordinary answer path and notes the dismissal", () => {
+    const next = conversationReducer(clarifying, {
+      type: "QUESTION_ANSWERED",
+      questionId: "clarify-entity",
+      value: "",
+      dismissed: true,
+    });
+    expect(next.pendingQuestion).toBeNull();
+    expect(next.phase).toBe("co.review");
+    expect(next.thread.at(-1)).toMatchObject({
+      kind: "user",
+      i18nKey: "ob.conv.clarify.dismiss",
+    });
+  });
+
+  it("rejects a dismissal of a question that offers no escape", () => {
+    const speakerAsk: ConversationState = {
+      ...clarifying,
+      act: "voice",
+      phase: "vo.speaker",
+      pendingQuestion: {
+        id: "speaker",
+        i18nKey: "ob.conv.voice.speakerQuestion",
+        options: [{ value: "Speaker 1", label: "Speaker 1" }],
+      },
+    };
+    expect(
+      conversationReducer(speakerAsk, {
+        type: "QUESTION_ANSWERED",
+        questionId: "speaker",
+        value: "",
+        dismissed: true,
+      }),
+    ).toBe(speakerAsk);
+  });
+});
+
+describe("option chip clamping", () => {
+  it("is presentation-only: the full value stays the accessible name and title", () => {
+    const garbage =
+      "Gradion GmbH Imprint Privacy Cookie Settings Accept All Continue Reading Hauptstrasse 1";
+    rtlRender(
+      <LocaleProvider initial="en">
+        <QuestionCard
+          question={{
+            id: "q",
+            i18nKey: "ob.conv.clarify.question",
+            params: { question: "Which entity?" },
+            options: [{ value: "g", label: garbage }],
+          }}
+          onAnswer={() => undefined}
+        />
+      </LocaleProvider>,
+    );
+    const chip = screen.getByRole("button", { name: garbage });
+    expect(chip.title).toBe(garbage);
+    expect(chip.className).toContain("ob-conv-option");
+  });
+});
+
+// ---- integration through the real company act ------------------------------
+
+const READ_ID = "018f3a1b-0000-7000-8000-0000000000c3";
+
+function grounded(
+  field: ColdField["field"],
+  value: string,
+  snippet: string,
+): ColdField {
+  return {
+    field,
+    value,
+    evidence_snippet: snippet,
+    source_kind: "url",
+    source_url: "https://gradion.com",
+    confidence: 0.9,
+  };
+}
+
+function readyRead(comparisons: Comparison[]): CompanySiteRead {
+  return {
+    id: READ_ID,
+    target_kind: "onboarding",
+    organization_id: null,
+    root_url: "https://gradion.com",
+    status: "ready",
+    status_code: null,
+    status_detail: null,
+    next_attempt_at: null,
+    phase: null,
+    pages_read: 3,
+    pages: [],
+    profile_fields: [
+      grounded("legal_name", "Gradion GmbH", "© 2026 Gradion GmbH"),
+      grounded("display_name", "Gradion", "Gradion"),
+      grounded(
+        "offer_summary",
+        "Revenue software",
+        "We build revenue software",
+      ),
+      grounded("icp", "Mid-market manufacturers", "We serve manufacturers"),
+    ],
+    facts: [],
+    comparisons,
+    people: [],
+    legal_entities: [],
+    warnings: [],
+    draft_version: 2,
+    proposal_hash: "proposal-2",
+    created_at: "2026-07-22T08:00:00Z",
+    updated_at: "2026-07-22T08:00:01Z",
+  };
+}
+
+function proposalWithQuestion(read: CompanySiteRead): Proposal {
+  return {
+    ready: true,
+    fields: read.profile_fields.map((field) => ({
+      field: field.field,
+      value: field.value,
+      confidence: field.confidence,
+      evidence_snippet: field.evidence_snippet,
+      source_url: field.source_url ?? "https://gradion.com",
+    })),
+    facts: [],
+    open_questions: [
+      {
+        id: "clarify:legal_name:1",
+        question: "Which legal entity is this installation for?",
+        field: "legal_name",
+        options: [
+          {
+            value: "Gradion GmbH Imprint Privacy Cookie Settings",
+            label: "Gradion GmbH Imprint Privacy Cookie Settings",
+            evidence_url: "https://gradion.com/impressum",
+            evidence_snippet: "chrome glued into the entity name",
+            detail: null,
+          },
+        ],
+        allow_free_text: false,
+      },
+    ],
+    remaining_required_fields: [],
+    draft_version: read.draft_version,
+    proposal_hash: read.proposal_hash,
+  };
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function stubApi(read: CompanySiteRead, proposal: Proposal) {
+  const calls: Request[] = [];
+  let version = 0;
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (request: Request) => {
+      calls.push(request);
+      const path = new URL(request.url).pathname;
+      if (path.endsWith("/ai/profile")) {
+        return jsonResponse({
+          name: "Margince",
+          kind: "ai",
+          state: "configured",
+          inference_mode: "cloud",
+          providers: ["gemini"],
+          configured_models: [],
+        });
+      }
+      if (path.endsWith("/company/context/capabilities")) {
+        return jsonResponse({
+          onboarding_enabled: true,
+          read_enabled: true,
+          rollout: "ga",
+        });
+      }
+      if (path.endsWith("/onboarding/state") && request.method === "GET") {
+        return jsonResponse({ detail: "not started" }, 404);
+      }
+      if (path.endsWith("/onboarding/state") && request.method === "PUT") {
+        const body = (await request.clone().json()) as Record<string, unknown>;
+        version += 1;
+        return jsonResponse({
+          ...body,
+          path: "creator",
+          version,
+          completed_at: null,
+          created_at: "2026-07-22T08:00:00Z",
+          updated_at: "2026-07-22T08:01:00Z",
+        });
+      }
+      if (path.endsWith("/onboarding/company/proposal")) {
+        return jsonResponse(proposal);
+      }
+      if (path.includes("/company/site-reads/") && path.endsWith("/confirm")) {
+        return jsonResponse({
+          organization_id: "018f3a1b-0000-7000-8000-0000000000a1",
+          display_name: "Gradion",
+        });
+      }
+      if (path.endsWith("/company/site-reads") && request.method === "POST") {
+        return jsonResponse(read, 202);
+      }
+      if (path.includes("/company/site-reads/") && request.method === "GET") {
+        return jsonResponse(read);
+      }
+      if (path.endsWith("/company") && request.method === "GET") {
+        return jsonResponse({ detail: "no company yet" }, 404);
+      }
+      throw new Error(`unstubbed request: ${request.method} ${request.url}`);
+    }),
+  );
+  return calls;
+}
+
+function render(ui: ReactNode) {
+  return rtlRender(
+    <QueryClientProvider
+      client={
+        new QueryClient({ defaultOptions: { queries: { retry: false } } })
+      }
+    >
+      <LocaleProvider initial="en">{ui}</LocaleProvider>
+    </QueryClientProvider>,
+  );
+}
+
+async function submitWebsite() {
+  const composer = await screen.findByRole("textbox", {
+    name: /Type your website address/,
+  });
+  await userEvent.type(composer, "gradion.com{Enter}");
+}
+
+async function confirmBody(calls: Request[]): Promise<Record<string, unknown>> {
+  const writes = calls.filter(
+    (request) => request.url.includes("/confirm") && request.method === "POST",
+  );
+  expect(writes.length).toBe(1);
+  return (await writes[0].clone().json()) as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  vi.stubGlobal("scrollTo", vi.fn());
+  window.localStorage.setItem("margince.conv", "1");
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  window.localStorage.removeItem("margince.conv");
+  window.location.hash = "";
+});
+
+describe("dismissing a clarify in the company act", () => {
+  it("unblocks Accept all and the next-step bar, and the census confirm sends no resolution", async () => {
+    const read = readyRead([]);
+    const calls = stubApi(read, proposalWithQuestion(read));
+    render(<OnboardingScreen />);
+
+    await submitWebsite();
+    expect(
+      await screen.findByText(/Which legal entity is this installation for\?/),
+    ).toBeTruthy();
+    expect(
+      await screen.findByRole("button", { name: "1 decision open" }),
+    ).toBeTruthy();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Skip this - I will set it myself" }),
+    );
+
+    // The dismissal is noted, the gate opens, nothing was written.
+    const accept = (await screen.findByRole("button", {
+      name: /Accept all/,
+    })) as HTMLButtonElement;
+    expect(accept.disabled).toBe(false);
+    expect(
+      await screen.findByRole("button", { name: "Your review is ready" }),
+    ).toBeTruthy();
+    expect(screen.getByText(/You skipped: Registered legal name/)).toBeTruthy();
+
+    await userEvent.click(accept);
+    const body = await confirmBody(calls);
+    expect(body.resolutions).toEqual([]);
+    expect(await screen.findByText(/Company profile confirmed/)).toBeTruthy();
+  });
+
+  it("labels a human_conflict dismissal as keeping the value and sends keep_current", async () => {
+    const read = readyRead([conflictComparison]);
+    const calls = stubApi(read, proposalWithQuestion(read));
+    render(<OnboardingScreen />);
+
+    await submitWebsite();
+    await screen.findByText(/Which legal entity is this installation for\?/);
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Keep my value" }),
+    );
+
+    const accept = (await screen.findByRole("button", {
+      name: /Accept all/,
+    })) as HTMLButtonElement;
+    expect(accept.disabled).toBe(false);
+    await userEvent.click(accept);
+
+    const body = await confirmBody(calls);
+    expect(body.resolutions).toEqual([
+      { key: "legal_name", action: "keep_current" },
+    ]);
+  });
+});

--- a/frontend/src/screens/onboarding-conversation/company-act.tsx
+++ b/frontend/src/screens/onboarding-conversation/company-act.tsx
@@ -35,6 +35,7 @@ import type {
   ConversationState,
 } from "./conversation-machine";
 import { NarrationBubble } from "./entries";
+import { NextStepBar } from "./next-step-bar";
 import { presenceFor } from "./presence";
 import { ConversationThread } from "./thread";
 import { useClarifyAnswers } from "./use-clarify-answers";
@@ -176,6 +177,22 @@ export function CompanyAct({
     [dispatch, clarify.answerClarify],
   );
 
+  // Humans outrank the reader: dismissing a clarify resolves it locally —
+  // the machine's pending question clears through the ordinary answer path
+  // and the recorded dismissal stops it counting as an open decision.
+  const handleDismiss = useCallback(
+    (questionId: string) => {
+      dispatch({
+        type: "QUESTION_ANSWERED",
+        questionId,
+        value: "",
+        dismissed: true,
+      });
+      clarify.dismissClarify(questionId);
+    },
+    [dispatch, clarify.dismissClarify],
+  );
+
   const confirm = useMutation({
     mutationFn: async (): Promise<CompanyProfile> => {
       const values = draftRef.current.values;
@@ -308,6 +325,41 @@ export function CompanyAct({
     return null;
   }, [lastEntry]);
 
+  // The pinned next-step line: open decisions first — the pending thread
+  // question plus the proposal's still-unanswered ones — then the ready
+  // review. The bar renders only while a decision affordance is actually
+  // on the page (the live question card, or the review's clarify list), so
+  // it can always scroll to what it names.
+  const pendingId = state.pendingQuestion?.id ?? null;
+  const decisionCount =
+    (pendingId !== null ? 1 : 0) +
+    (reviewProposal?.open_questions ?? []).filter(
+      (question) =>
+        question.id !== pendingId &&
+        !clarify.answers.some((answer) => answer.clarifyId === question.id),
+    ).length;
+  let nextStep: { label: string; selector: string } | null = null;
+  if (
+    decisionCount > 0 &&
+    (pendingId !== null || state.phase === "co.review")
+  ) {
+    nextStep = {
+      label:
+        decisionCount === 1
+          ? t("ob.conv.next.decisionOne")
+          : t("ob.conv.next.decisionMany", { count: decisionCount }),
+      selector:
+        pendingId !== null
+          ? "fieldset.ob-conv-question:not([disabled])"
+          : ".ob-conv-confirm",
+    };
+  } else if (state.phase === "co.review" && reviewProposal !== null) {
+    nextStep = {
+      label: t("ob.conv.next.review"),
+      selector: ".ob-conv-confirm",
+    };
+  }
+
   // The manual path stays offered before any read and again whenever the
   // machine parked back in co.reading with the run retired (failed,
   // deferred, or the poll-failure fallback) — never while a POST is in
@@ -382,6 +434,7 @@ export function CompanyAct({
           entries={state.thread}
           pendingQuestionId={state.pendingQuestion?.id ?? null}
           onAnswer={handleAnswer}
+          onDismiss={handleDismiss}
         >
           <ConversationEntries
             entries={conversation.entries}
@@ -435,11 +488,13 @@ export function CompanyAct({
               proposal={reviewProposal}
               draft={draft}
               answers={clarify.answers}
+              comparisons={read?.comparisons ?? []}
               pendingQuestionId={state.pendingQuestion?.id ?? null}
               selectedFactKeys={selectedFactKeys}
               setSelectedFactKeys={setSelectedFactKeys}
               missingRequired={missing}
               onAnswerClarify={clarify.answerClarify}
+              onDismissClarify={clarify.dismissClarify}
               onAcceptAll={() => confirm.mutate()}
               pending={confirm.isPending}
               authorizing={clarify.authorizing}
@@ -449,6 +504,13 @@ export function CompanyAct({
           )}
         </ConversationThread>
       </div>
+      {nextStep !== null && (
+        <NextStepBar
+          label={nextStep.label}
+          targetSelector={nextStep.selector}
+          revision={state.seq}
+        />
+      )}
       <div className="mw-composer">
         <textarea
           ref={composer}

--- a/frontend/src/screens/onboarding-conversation/company-proposal.ts
+++ b/frontend/src/screens/onboarding-conversation/company-proposal.ts
@@ -22,18 +22,41 @@ export type ClarifyAnswer = {
   clarifyId: string;
   field: string;
   value: string;
+  /** The human declined the question (humans outrank the reader): nothing
+   * is written to the field, and it stops counting as an open decision. */
+  dismissed?: boolean;
 };
+
+// Whether a clarify sits over a human_conflict comparison: dismissing one of
+// those still needs an explicit server resolution (keep_current), so its
+// dismiss action is labeled "keep my value" instead of "skip".
+export function isConflictClarify(
+  field: string,
+  comparisons: readonly Comparison[] | undefined,
+): boolean {
+  return (comparisons ?? []).some(
+    (comparison) =>
+      comparison.key === field &&
+      comparison.classification === "human_conflict",
+  );
+}
 
 // A server clarify becomes a machine question: the deterministic server copy
 // rides verbatim as params through passthrough catalog keys, so the renderer
 // keeps its i18n-only contract without paraphrasing what the server asked.
+// Every clarify is dismissible — an implausible question must never become
+// an unanswerable gate.
 export function toMachineQuestion(
   clarify: OnboardingClarify,
+  comparisons?: readonly Comparison[],
 ): ConversationQuestion {
   return {
     id: clarify.id,
     i18nKey: "ob.conv.clarify.question",
     params: { question: clarify.question },
+    dismissLabelKey: isConflictClarify(clarify.field, comparisons)
+      ? "ob.conv.clarify.keepMine"
+      : "ob.conv.clarify.dismiss",
     options: clarify.options.map((option) => {
       const detail = option.detail ?? option.evidence_snippet ?? null;
       return {
@@ -106,7 +129,10 @@ export function missingRequiredFields(values: CompanyForm): CompanyFieldName[] {
 
 // A clarify answered over a human_conflict comparison maps 1:1 onto the
 // confirm request's resolution vocabulary. Other clarifies (the legal-entity
-// choice) resolve through the profile values themselves and produce none.
+// choice) resolve through the profile values themselves and produce none —
+// the server rejects a resolution whose key is not a current human conflict,
+// and requires one for every conflict, so a dismissed conflict maps to
+// keep_current while a dismissed census question sends nothing.
 export function resolutionsFromAnswers(
   comparisons: readonly Comparison[],
   answers: readonly ClarifyAnswer[],
@@ -121,7 +147,9 @@ export function resolutionsFromAnswers(
     if (!conflict) {
       continue;
     }
-    if (answer.value === conflict.proposed_value) {
+    if (answer.dismissed === true) {
+      resolutions.push({ key: conflict.key, action: "keep_current" });
+    } else if (answer.value === conflict.proposed_value) {
       resolutions.push({ key: conflict.key, action: "accept_proposal" });
     } else if (answer.value === (conflict.current_value ?? "")) {
       resolutions.push({ key: conflict.key, action: "keep_current" });

--- a/frontend/src/screens/onboarding-conversation/confirm-card.tsx
+++ b/frontend/src/screens/onboarding-conversation/confirm-card.tsx
@@ -22,17 +22,23 @@ import { NarrationBubble, QuestionCard } from "./entries";
 
 type Proposal = components["schemas"]["OnboardingCompanyProposal"];
 type ProposalField = components["schemas"]["OnboardingCompanyProposalField"];
+type Comparison = components["schemas"]["CompanySiteReadComparison"];
 
 type CompanyConfirmCardProps = Readonly<{
   proposal: Proposal;
   draft: CompanyDraft;
   answers: readonly ClarifyAnswer[];
+  /** The site-read comparisons, so a conflict question's dismiss action is
+   * labeled as keeping the human's value (the server still gets its
+   * keep_current resolution). */
+  comparisons: readonly Comparison[];
   /** The machine's live in-thread question; the card must not repeat it. */
   pendingQuestionId: string | null;
   selectedFactKeys: readonly string[];
   setSelectedFactKeys: (keys: string[]) => void;
   missingRequired: readonly CompanyFieldName[];
   onAnswerClarify: (clarifyId: string, value: string) => void;
+  onDismissClarify: (clarifyId: string) => void;
   onAcceptAll: () => void;
   pending: boolean;
   /** A clarify authorization is still in flight; accepting must wait for it. */
@@ -65,6 +71,12 @@ export function CompanyConfirmCard(props: CompanyConfirmCardProps) {
     props.draft,
     new Set(fields.map((field) => field.field)),
   );
+  // Dismissed questions are named honestly: nothing was written, the field
+  // stays the human's to edit — never silently swallowed.
+  const dismissedLabels = props.answers
+    .filter((answer) => answer.dismissed === true)
+    .map((answer) => coldFieldLabel(answer.field, t))
+    .join(", ");
   const missingLabels = props.missingRequired
     .map((field) => coldFieldLabel(field, t))
     .join(", ");
@@ -93,10 +105,19 @@ export function CompanyConfirmCard(props: CompanyConfirmCardProps) {
           {openQuestions.map((question) => (
             <QuestionCard
               key={question.id}
-              question={toMachineQuestion(question)}
+              question={toMachineQuestion(question, props.comparisons)}
               onAnswer={props.onAnswerClarify}
+              onDismiss={props.onDismissClarify}
             />
           ))}
+        </div>
+      )}
+      {dismissedLabels !== "" && (
+        <div className="ob-conv-confirm-skipped">
+          <p>{t("ob.conv.review.skipped", { fields: dismissedLabels })}</p>
+          <Button small variant="ghost" onClick={props.onEditDirectly}>
+            {t("ob.conv.review.editDirectly")}
+          </Button>
         </div>
       )}
       {facts.length > 0 && (

--- a/frontend/src/screens/onboarding-conversation/conversation-legality.ts
+++ b/frontend/src/screens/onboarding-conversation/conversation-legality.ts
@@ -135,12 +135,17 @@ function eventGuards(
       return state.readCompleted;
     case "QUESTION_ANSWERED":
       // Both the question and the chosen option must be the pending ones; an
-      // unknown value is never echoed into the thread.
-      return (
-        state.pendingQuestion?.id === event.questionId &&
-        state.pendingQuestion.options.some(
-          (option) => option.value === event.value,
-        )
+      // unknown value is never echoed into the thread. A dismissal carries
+      // no option value and is legal exactly when the pending question
+      // offers the dismiss escape.
+      if (state.pendingQuestion?.id !== event.questionId) {
+        return false;
+      }
+      if (event.dismissed === true) {
+        return state.pendingQuestion.dismissLabelKey !== undefined;
+      }
+      return state.pendingQuestion.options.some(
+        (option) => option.value === event.value,
       );
     case "BUILD_STARTED":
       // From vo.result only a FAILED build may be retried; a succeeded or

--- a/frontend/src/screens/onboarding-conversation/conversation-machine.ts
+++ b/frontend/src/screens/onboarding-conversation/conversation-machine.ts
@@ -199,6 +199,44 @@ function applyResume(
   return withEntries(state, { act: resumeActs[phase], phase });
 }
 
+// The answered question leaves the thread as the user's own turn: the
+// chosen option's label, or — for a dismissal — the dismiss action the human
+// clicked (legality already required the pending question to carry it).
+function applyAnswer(
+  state: ConversationState,
+  event: Extract<ConversationEvent, { type: "QUESTION_ANSWERED" }>,
+): ConversationState {
+  const option = state.pendingQuestion?.options.find(
+    (candidate) => candidate.value === event.value,
+  );
+  const answerId = `answer:${event.questionId}`;
+  const dismissed: ThreadEntry = {
+    kind: "user",
+    id: answerId,
+    i18nKey:
+      state.pendingQuestion?.dismissLabelKey ?? "ob.conv.clarify.dismiss",
+  };
+  const chosen: ThreadEntry =
+    option?.labelKey !== undefined
+      ? {
+          kind: "user",
+          id: answerId,
+          i18nKey: option.labelKey,
+          params: option.params,
+        }
+      : {
+          kind: "user",
+          id: answerId,
+          text: option?.label ?? event.value,
+          params: option?.params,
+        };
+  return withEntries(
+    state,
+    { phase: answeredPhase(state), pendingQuestion: null },
+    [event.dismissed === true ? dismissed : chosen],
+  );
+}
+
 // Legality is already settled: every branch below only computes the next
 // state for an event the table admitted in the current phase.
 function applyEvent(
@@ -262,34 +300,8 @@ function applyEvent(
           },
         ],
       );
-    case "QUESTION_ANSWERED": {
-      const option = state.pendingQuestion?.options.find(
-        (candidate) => candidate.value === event.value,
-      );
-      const answerId = `answer:${event.questionId}`;
-      const answered: ThreadEntry =
-        option?.labelKey !== undefined
-          ? {
-              kind: "user",
-              id: answerId,
-              i18nKey: option.labelKey,
-              params: option.params,
-            }
-          : {
-              kind: "user",
-              id: answerId,
-              text: option?.label ?? event.value,
-              params: option?.params,
-            };
-      return withEntries(
-        state,
-        {
-          phase: answeredPhase(state),
-          pendingQuestion: null,
-        },
-        [answered],
-      );
-    }
+    case "QUESTION_ANSWERED":
+      return applyAnswer(state, event);
     case "REVIEW_READY":
       return withEntries(state, { phase: "co.review" });
     case "MANUAL_CHOSEN":

--- a/frontend/src/screens/onboarding-conversation/conversation-types.ts
+++ b/frontend/src/screens/onboarding-conversation/conversation-types.ts
@@ -49,6 +49,10 @@ export type ConversationQuestion = {
   i18nKey: MessageKey;
   params?: Record<string, string | number>;
   options: QuestionOption[];
+  /** The subordinate local-dismiss action's label (humans outrank the
+   * reader: a clarify is never an unanswerable gate). Absent on questions
+   * that genuinely need an answer to proceed (the speaker ask). */
+  dismissLabelKey?: MessageKey;
 };
 
 export type OutcomeTone = "success" | "deferred" | "failure";
@@ -158,7 +162,14 @@ export type ConversationEvent =
       findings: number;
     }
   | { type: "CLARIFY"; readId: string; question: ConversationQuestion }
-  | { type: "QUESTION_ANSWERED"; questionId: string; value: string }
+  // dismissed: the human declined the question locally (nothing written,
+  // nothing asked again); legal only for questions carrying a dismiss label.
+  | {
+      type: "QUESTION_ANSWERED";
+      questionId: string;
+      value: string;
+      dismissed?: boolean;
+    }
   | { type: "REVIEW_READY" }
   | { type: "MANUAL_CHOSEN" }
   | { type: "COMPANY_CONFIRMED" }

--- a/frontend/src/screens/onboarding-conversation/conversation.css
+++ b/frontend/src/screens/onboarding-conversation/conversation.css
@@ -158,6 +158,49 @@
   color: var(--textSecondary);
 }
 
+/* Visual clamp only: garbage-length values stay two lines per part; the
+   full text remains the accessible name (content) and the hover title. */
+.ob-conv-option span,
+.ob-conv-option small {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  overflow: hidden;
+}
+
+/* The subordinate escape under the options: present, never competing. */
+.ob-conv-question-dismiss {
+  margin-block-start: var(--space-2);
+  color: var(--textSecondary);
+}
+
+/* A resolved card is fully inert: no hover affordance, no pointer — its
+   moment passed and the recorded choice below is the only live thing. */
+.ob-conv-question[disabled] .btn {
+  pointer-events: none;
+  cursor: default;
+}
+
+/* The choice a resolved card recorded stays visible on the card itself. */
+.ob-conv-option-selected {
+  border-color: var(--success);
+  box-shadow: inset 0 0 0 1px var(--success);
+}
+
+.ob-conv-confirm-skipped {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+.ob-conv-confirm-skipped p {
+  margin: 0;
+  color: var(--textSecondary);
+  font: 400 0.875rem / 1.5 var(--f-body);
+}
+
 .ob-conv-outcome[data-tone="deferred"] {
   border-inline-start-color: var(--warnBorder);
 }
@@ -403,6 +446,28 @@
   margin: 0;
   color: var(--textContent);
   font: 400 0.9375rem / 1.5 var(--f-body);
+}
+
+/* The pinned next-step line between the thread and the composer: one slim
+   button naming the blocking affordance that is scrolled out of view. */
+.ob-conv-nextstep {
+  display: flex;
+  justify-content: center;
+  padding: var(--space-1) var(--space-4);
+}
+
+.ob-conv-nextstep button {
+  border: 1px solid var(--aiMed);
+  border-radius: var(--r-full);
+  background: var(--aiLight);
+  color: var(--aiText);
+  padding: var(--space-1) var(--space-3);
+  font: 500 0.8125rem / 1.4 var(--f-body);
+  cursor: pointer;
+}
+
+.ob-conv-nextstep button:hover {
+  background: var(--aiMed);
 }
 
 /* The connect act's per-purpose consent list, rendered with the thread. */

--- a/frontend/src/screens/onboarding-conversation/entries.tsx
+++ b/frontend/src/screens/onboarding-conversation/entries.tsx
@@ -129,21 +129,39 @@ export function OutcomeCard({ entry }: Readonly<{ entry: OutcomeEntry }>) {
   );
 }
 
+/** What a resolved card recorded: the chosen option, or the dismissal. */
+export type QuestionSelection =
+  | { kind: "option"; value: string }
+  | { kind: "dismissed" };
+
 type QuestionCardProps = Readonly<{
   question: ConversationQuestion;
-  /** Set after the question is answered; options stay visible but inert. */
+  /**
+   * Set for every card that is NOT the machine's current pending question
+   * instance (answered, dismissed, or superseded). Inertness is stamped on
+   * EVERY control, not just the fieldset: a fieldset-only disable leaves the
+   * options looking and, in some engines, acting live — a zombie card that
+   * eats clicks the machine then rightly ignores.
+   */
   answered?: boolean;
+  /** The recorded choice, shown on the inert card when one exists. */
+  selection?: QuestionSelection | null;
   /** The card is the one live question: keyboard focus moves to its first
    * option — unless the human is mid-thought in a text field. */
   focusFirstOption?: boolean;
   onAnswer: (questionId: string, value: string) => void;
+  /** The local-dismiss escape; rendered only when the question carries a
+   * dismiss label AND the surface wires a handler. */
+  onDismiss?: (questionId: string) => void;
 }>;
 
 export function QuestionCard({
   question,
   answered = false,
+  selection = null,
   focusFirstOption = false,
   onAnswer,
+  onDismiss,
 }: QuestionCardProps) {
   const t = useT();
   const card = useRef<HTMLFieldSetElement>(null);
@@ -178,24 +196,46 @@ export function QuestionCard({
     <fieldset ref={card} className="ob-conv-question" disabled={answered}>
       <legend>{t(question.i18nKey, question.params)}</legend>
       <div className="ob-conv-options">
-        {question.options.map((option) => (
-          <Button
-            key={option.value}
-            small
-            className="ob-conv-option"
-            onClick={() => onAnswer(question.id, option.value)}
-          >
-            <span>
-              {option.labelKey
-                ? t(option.labelKey, option.params)
-                : option.label}
-            </span>
-            {option.detailKey && (
-              <small>{t(option.detailKey, option.params)}</small>
-            )}
-          </Button>
-        ))}
+        {question.options.map((option) => {
+          const label = option.labelKey
+            ? t(option.labelKey, option.params)
+            : option.label;
+          const chosen =
+            selection?.kind === "option" && selection.value === option.value;
+          return (
+            <Button
+              key={option.value}
+              small
+              className={`ob-conv-option${chosen ? " ob-conv-option-selected" : ""}`}
+              // The chip clamps long values visually (CSS line-clamp); the
+              // full text stays the accessible name via content and here as
+              // the hover title.
+              title={label}
+              disabled={answered}
+              aria-pressed={selection === null ? undefined : chosen}
+              onClick={() => onAnswer(question.id, option.value)}
+            >
+              <span>{label}</span>
+              {option.detailKey && (
+                <small>{t(option.detailKey, option.params)}</small>
+              )}
+            </Button>
+          );
+        })}
       </div>
+      {question.dismissLabelKey !== undefined && onDismiss !== undefined && (
+        <Button
+          small
+          variant="ghost"
+          className={`ob-conv-question-dismiss${
+            selection?.kind === "dismissed" ? " ob-conv-option-selected" : ""
+          }`}
+          disabled={answered}
+          onClick={() => onDismiss(question.id)}
+        >
+          {t(question.dismissLabelKey)}
+        </Button>
+      )}
     </fieldset>
   );
 }

--- a/frontend/src/screens/onboarding-conversation/next-step-bar.test.tsx
+++ b/frontend/src/screens/onboarding-conversation/next-step-bar.test.tsx
@@ -1,0 +1,310 @@
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  cleanup,
+  render as rtlRender,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { components } from "../../api/schema";
+import { LocaleProvider } from "../../i18n";
+import { OnboardingScreen } from "../onboarding";
+import { NextStepBar } from "./next-step-bar";
+
+// The pinned next-step bar: it exists exactly while the current act has a
+// blocking affordance out of view, one click brings that affordance back
+// and focuses it, and it disappears when the observer reports the target
+// visible. The integration half drives the real company act to the states
+// the bar names.
+
+type CompanySiteRead = components["schemas"]["CompanySiteRead"];
+type Proposal = components["schemas"]["OnboardingCompanyProposal"];
+type ColdField = components["schemas"]["ColdStartField"];
+
+function render(ui: ReactNode) {
+  return rtlRender(
+    <QueryClientProvider
+      client={
+        new QueryClient({ defaultOptions: { queries: { retry: false } } })
+      }
+    >
+      <LocaleProvider initial="en">{ui}</LocaleProvider>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.stubGlobal("scrollTo", vi.fn());
+  window.localStorage.setItem("margince.conv", "1");
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  window.localStorage.removeItem("margince.conv");
+  window.location.hash = "";
+});
+
+describe("NextStepBar", () => {
+  function mountTarget(): { card: HTMLElement; option: HTMLButtonElement } {
+    const card = document.createElement("fieldset");
+    card.className = "ob-conv-question";
+    const option = document.createElement("button");
+    option.textContent = "Acme GmbH";
+    card.append(option);
+    document.body.append(card);
+    return { card, option };
+  }
+
+  it("scrolls the target into view and focuses its first option on click", async () => {
+    const { card, option } = mountTarget();
+    const scrolled = vi.fn();
+    card.scrollIntoView = scrolled;
+    render(
+      <NextStepBar
+        label="1 decision open"
+        targetSelector="fieldset.ob-conv-question:not([disabled])"
+        revision={1}
+      />,
+    );
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "1 decision open" }),
+    );
+
+    expect(scrolled).toHaveBeenCalledWith(
+      expect.objectContaining({ block: "center" }),
+    );
+    expect(document.activeElement).toBe(option);
+    card.remove();
+  });
+
+  it("hides itself while the observer reports the target visible", async () => {
+    const { card } = mountTarget();
+    class VisibleObserver {
+      constructor(
+        private readonly callback: (
+          entries: { isIntersecting: boolean }[],
+        ) => void,
+      ) {}
+      observe() {
+        this.callback([{ isIntersecting: true }]);
+      }
+      disconnect() {}
+    }
+    vi.stubGlobal("IntersectionObserver", VisibleObserver);
+    render(
+      <NextStepBar
+        label="1 decision open"
+        targetSelector="fieldset.ob-conv-question:not([disabled])"
+        revision={1}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByRole("status")).toBeNull();
+    });
+    card.remove();
+  });
+});
+
+// ---- integration through the real company act ------------------------------
+
+const READ_ID = "018f3a1b-0000-7000-8000-0000000000c3";
+
+function grounded(
+  field: ColdField["field"],
+  value: string,
+  snippet: string,
+): ColdField {
+  return {
+    field,
+    value,
+    evidence_snippet: snippet,
+    source_kind: "url",
+    source_url: "https://gradion.com",
+    confidence: 0.9,
+  };
+}
+
+const readyRead = {
+  id: READ_ID,
+  target_kind: "onboarding",
+  organization_id: null,
+  root_url: "https://gradion.com",
+  status: "ready",
+  status_code: null,
+  status_detail: null,
+  next_attempt_at: null,
+  phase: null,
+  pages_read: 3,
+  pages: [],
+  profile_fields: [
+    grounded("legal_name", "Gradion GmbH", "© 2026 Gradion GmbH"),
+    grounded("display_name", "Gradion", "Gradion"),
+    grounded("offer_summary", "Revenue software", "We build revenue software"),
+    grounded("icp", "Mid-market manufacturers", "We serve manufacturers"),
+  ],
+  facts: [],
+  comparisons: [],
+  people: [],
+  legal_entities: [],
+  warnings: [],
+  draft_version: 2,
+  proposal_hash: "proposal-2",
+  created_at: "2026-07-22T08:00:00Z",
+  updated_at: "2026-07-22T08:00:01Z",
+} as const satisfies CompanySiteRead;
+
+function proposalFor(read: CompanySiteRead): Proposal {
+  return {
+    ready: true,
+    fields: read.profile_fields.map((field) => ({
+      field: field.field,
+      value: field.value,
+      confidence: field.confidence,
+      evidence_snippet: field.evidence_snippet,
+      source_url: field.source_url ?? "https://gradion.com",
+    })),
+    facts: [],
+    open_questions: [],
+    remaining_required_fields: [],
+    draft_version: read.draft_version,
+    proposal_hash: read.proposal_hash,
+  };
+}
+
+function clarifyQuestion(id: string, question: string) {
+  return {
+    id,
+    question,
+    field: "legal_name",
+    options: [
+      {
+        value: "Gradion GmbH",
+        label: "Gradion GmbH",
+        evidence_url: "https://gradion.com/impressum",
+        evidence_snippet: "Gradion GmbH, Berlin",
+        detail: null,
+      },
+      {
+        value: "Gradion Holding GmbH",
+        label: "Gradion Holding GmbH",
+        evidence_url: "https://gradion.com/impressum",
+        evidence_snippet: "Gradion Holding GmbH, Berlin",
+        detail: null,
+      },
+    ],
+    allow_free_text: false,
+  };
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function stubApi(proposal: Proposal) {
+  let version = 0;
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (request: Request) => {
+      const path = new URL(request.url).pathname;
+      if (path.endsWith("/ai/profile")) {
+        return jsonResponse({
+          name: "Margince",
+          kind: "ai",
+          state: "configured",
+          inference_mode: "cloud",
+          providers: ["gemini"],
+          configured_models: [],
+        });
+      }
+      if (path.endsWith("/company/context/capabilities")) {
+        return jsonResponse({
+          onboarding_enabled: true,
+          read_enabled: true,
+          rollout: "ga",
+        });
+      }
+      if (path.endsWith("/onboarding/state") && request.method === "GET") {
+        return jsonResponse({ detail: "not started" }, 404);
+      }
+      if (path.endsWith("/onboarding/state") && request.method === "PUT") {
+        const body = (await request.clone().json()) as Record<string, unknown>;
+        version += 1;
+        return jsonResponse({
+          ...body,
+          path: "creator",
+          version,
+          completed_at: null,
+          created_at: "2026-07-22T08:00:00Z",
+          updated_at: "2026-07-22T08:01:00Z",
+        });
+      }
+      if (path.endsWith("/onboarding/company/proposal")) {
+        return jsonResponse(proposal);
+      }
+      if (path.endsWith("/company/site-reads") && request.method === "POST") {
+        return jsonResponse(readyRead, 202);
+      }
+      if (path.includes("/company/site-reads/") && request.method === "GET") {
+        return jsonResponse(readyRead);
+      }
+      if (path.endsWith("/company") && request.method === "GET") {
+        return jsonResponse({ detail: "no company yet" }, 404);
+      }
+      throw new Error(`unstubbed request: ${request.method} ${request.url}`);
+    }),
+  );
+}
+
+async function submitWebsite() {
+  const composer = await screen.findByRole("textbox", {
+    name: /Type your website address/,
+  });
+  await userEvent.type(composer, "gradion.com{Enter}");
+}
+
+describe("the next-step bar in the company act", () => {
+  it("is absent while nothing blocks", async () => {
+    stubApi(proposalFor(readyRead));
+    render(<OnboardingScreen />);
+
+    await screen.findByText(/Where should I start reading\?/);
+    expect(document.querySelector(".ob-conv-nextstep")).toBeNull();
+  });
+
+  it("announces the ready review when the proposal has no open questions", async () => {
+    stubApi(proposalFor(readyRead));
+    render(<OnboardingScreen />);
+
+    await submitWebsite();
+
+    expect(
+      await screen.findByRole("button", { name: "Your review is ready" }),
+    ).toBeTruthy();
+  });
+
+  it("counts the pending question plus the proposal's other open one", async () => {
+    stubApi({
+      ...proposalFor(readyRead),
+      open_questions: [
+        clarifyQuestion("clarify:legal_name:1", "Which legal entity?"),
+        clarifyQuestion("clarify:address:2", "Which registered address?"),
+      ],
+    });
+    render(<OnboardingScreen />);
+
+    await submitWebsite();
+
+    expect(
+      await screen.findByRole("button", { name: "2 decisions open" }),
+    ).toBeTruthy();
+  });
+});

--- a/frontend/src/screens/onboarding-conversation/next-step-bar.tsx
+++ b/frontend/src/screens/onboarding-conversation/next-step-bar.tsx
@@ -1,0 +1,83 @@
+import { useEffect, useState } from "react";
+import "./conversation.css";
+
+// The pinned next-step bar between the thread and the composer: whenever
+// the current act has a blocking affordance (an open decision, the ready
+// review, the enabled build chip) that sits scrolled out of view, one slim
+// line names it and one click brings it back. The bar disappears the moment
+// the affordance itself is visible — it points at the next step, it never
+// duplicates it. It lives OUTSIDE the thread's log region on purpose: a
+// status wrapper nested in the live log would be announced twice.
+
+type NextStepBarProps = Readonly<{
+  /** Short factual line, already translated; doubles as the button label. */
+  label: string;
+  /** Where the affordance lives in the document; re-resolved per render
+   * cycle because the card mounts in the same commit as the bar. */
+  targetSelector: string;
+  /** A counter that moves when the thread changes (the machine's entry
+   * seq), so the target re-resolves after cards mount or retire. */
+  revision: number;
+}>;
+
+const FOCUSABLE =
+  "button:not([disabled]), [href], input:not([disabled]), textarea, select";
+
+function scrollToTarget(target: HTMLElement): void {
+  const reduceMotion =
+    globalThis.matchMedia?.("(prefers-reduced-motion: reduce)").matches ??
+    false;
+  // jsdom has no scrollIntoView; in the browser it always exists.
+  target.scrollIntoView?.({
+    block: "center",
+    behavior: reduceMotion ? "auto" : "smooth",
+  });
+  const focusable = target.matches(FOCUSABLE)
+    ? target
+    : target.querySelector<HTMLElement>(FOCUSABLE);
+  focusable?.focus();
+}
+
+export function NextStepBar({
+  label,
+  targetSelector,
+  revision,
+}: NextStepBarProps) {
+  const [target, setTarget] = useState<HTMLElement | null>(null);
+  const [targetInView, setTargetInView] = useState(false);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: revision is a deliberate re-resolution trigger — the card can mount a commit after the bar under the same selector
+  useEffect(() => {
+    const found = document.querySelector<HTMLElement>(targetSelector);
+    setTarget(found);
+    // Without observer support the bar stays visible: for a discoverability
+    // aid, pointing at an already-visible card beats hiding a missed one.
+    if (found === null || typeof IntersectionObserver === "undefined") {
+      setTargetInView(false);
+      return;
+    }
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          setTargetInView(entry.isIntersecting);
+        }
+      },
+      // Root: the thread scroll container the card lives in (viewport when
+      // detached); half-visible still counts as needing the pointer.
+      { root: found.closest(".ob-conv-thread"), threshold: 0.5 },
+    );
+    observer.observe(found);
+    return () => observer.disconnect();
+  }, [targetSelector, revision]);
+
+  if (target === null || targetInView) {
+    return null;
+  }
+  return (
+    <div role="status" className="ob-conv-nextstep">
+      <button type="button" onClick={() => scrollToTarget(target)}>
+        {label}
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/screens/onboarding-conversation/thread.test.tsx
+++ b/frontend/src/screens/onboarding-conversation/thread.test.tsx
@@ -1,14 +1,18 @@
 /** @vitest-environment jsdom */
 import { cleanup, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { LocaleProvider } from "../../i18n";
 import type { ThreadEntry } from "./conversation-machine";
 import { entityQuestion } from "./test-fixtures";
 import { ConversationThread } from "./thread";
 
 // The thread's presentation duties: live narration reveals word by word
-// while restored entries render instantly, and the one live question card
-// claims keyboard focus only when no text field has a better claim.
+// while restored entries render instantly, the one live question card
+// claims keyboard focus only when no text field has a better claim, and a
+// question card is interactive IF AND ONLY IF it is the machine's current
+// pending question instance — every other card is fully inert, with its
+// recorded choice shown.
 
 afterEach(cleanup);
 
@@ -35,6 +39,8 @@ type ThreadProps = Readonly<{
   entries: readonly ThreadEntry[];
   pendingQuestionId?: string | null;
   composerValue?: string;
+  onAnswer?: (questionId: string, value: string) => void;
+  onDismiss?: (questionId: string) => void;
 }>;
 
 // The composer guard walks the DOM the workbench provides: the panel class
@@ -43,6 +49,8 @@ function Harness({
   entries,
   pendingQuestionId = null,
   composerValue = "",
+  onAnswer = () => {},
+  onDismiss,
 }: ThreadProps) {
   return (
     <LocaleProvider initial="en">
@@ -50,7 +58,8 @@ function Harness({
         <ConversationThread
           entries={entries}
           pendingQuestionId={pendingQuestionId}
-          onAnswer={() => {}}
+          onAnswer={onAnswer}
+          onDismiss={onDismiss}
         />
         <div className="mw-composer">
           <textarea aria-label="composer" defaultValue={composerValue} />
@@ -124,5 +133,105 @@ describe("live question focus", () => {
     render(<Harness entries={[questionEntry]} pendingQuestionId={null} />);
     const first = screen.getByRole("button", { name: "Acme GmbH" });
     expect(document.activeElement).not.toBe(first);
+  });
+});
+
+describe("question card interactivity", () => {
+  const dismissibleQuestion = {
+    ...entityQuestion,
+    dismissLabelKey: "ob.conv.clarify.dismiss" as const,
+  };
+  const dismissibleEntry: ThreadEntry = {
+    kind: "question",
+    id: "2:question:clarify-entity",
+    question: dismissibleQuestion,
+  };
+
+  it("a card that is no longer pending is fully inert: every control disabled, clicks change nothing", async () => {
+    const onAnswer = vi.fn();
+    const onDismiss = vi.fn();
+    // The machine advanced (a dismissal or answer cleared the pending
+    // question); the card's moment passed even though no answer turn for it
+    // exists in the thread.
+    render(
+      <Harness
+        entries={[dismissibleEntry]}
+        pendingQuestionId={null}
+        onAnswer={onAnswer}
+        onDismiss={onDismiss}
+      />,
+    );
+
+    const option = screen.getByRole("button", {
+      name: "Acme GmbH",
+    }) as HTMLButtonElement;
+    const dismiss = screen.getByRole("button", {
+      name: "Skip this - I will set it myself",
+    }) as HTMLButtonElement;
+    expect(option.disabled).toBe(true);
+    expect(dismiss.disabled).toBe(true);
+    await userEvent.click(option);
+    await userEvent.click(dismiss);
+    expect(onAnswer).not.toHaveBeenCalled();
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it("the live pending card stays interactive and answering works", async () => {
+    const onAnswer = vi.fn();
+    render(
+      <Harness
+        entries={[dismissibleEntry]}
+        pendingQuestionId={entityQuestion.id}
+        onAnswer={onAnswer}
+      />,
+    );
+
+    const option = screen.getByRole("button", {
+      name: "Acme GmbH",
+    }) as HTMLButtonElement;
+    expect(option.disabled).toBe(false);
+    await userEvent.click(option);
+    expect(onAnswer).toHaveBeenCalledWith(entityQuestion.id, "acme-gmbh");
+  });
+
+  it("a resolved card shows the recorded option choice", () => {
+    const answerTurn: ThreadEntry = {
+      kind: "user",
+      id: "3:answer:clarify-entity",
+      text: "Acme GmbH",
+    };
+    render(
+      <Harness
+        entries={[questionEntry, answerTurn]}
+        pendingQuestionId={null}
+      />,
+    );
+
+    const chosen = screen.getAllByRole("button", { name: "Acme GmbH" })[0];
+    expect(chosen.getAttribute("aria-pressed")).toBe("true");
+    expect(chosen.className).toContain("ob-conv-option-selected");
+    const other = screen.getByRole("button", { name: "Acme Holding SE" });
+    expect(other.getAttribute("aria-pressed")).toBe("false");
+  });
+
+  it("a dismissed card marks the dismissal as its recorded choice", () => {
+    const dismissTurn: ThreadEntry = {
+      kind: "user",
+      id: "3:answer:clarify-entity",
+      i18nKey: "ob.conv.clarify.dismiss",
+    };
+    render(
+      <Harness
+        entries={[dismissibleEntry, dismissTurn]}
+        pendingQuestionId={null}
+        onDismiss={() => {}}
+      />,
+    );
+
+    const dismiss = screen.getByRole("button", {
+      name: "Skip this - I will set it myself",
+    }) as HTMLButtonElement;
+    expect(dismiss.disabled).toBe(true);
+    expect(dismiss.className).toContain("ob-conv-option-selected");
   });
 });

--- a/frontend/src/screens/onboarding-conversation/thread.tsx
+++ b/frontend/src/screens/onboarding-conversation/thread.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import { useEffect, useRef } from "react";
 import { useT } from "../../i18n";
 import type { ThreadEntry } from "./conversation-machine";
+import type { QuestionSelection } from "./entries";
 import {
   NarrationBubble,
   OutcomeCard,
@@ -20,6 +21,8 @@ type ConversationThreadProps = Readonly<{
   /** The one question still awaiting an answer; older ones render inert. */
   pendingQuestionId: string | null;
   onAnswer: (questionId: string, value: string) => void;
+  /** Local-dismiss for dismissible questions; absent = no escape offered. */
+  onDismiss?: (questionId: string) => void;
   /**
    * Conversation content that lives OUTSIDE the machine's thread (chat
    * replies, review cards, act controls) but must share the same scroll
@@ -53,10 +56,54 @@ function activeQuestionEntryId(
   return null;
 }
 
+// The choice a resolved card recorded, read back from the thread itself:
+// the answer turn the reducer appended right after (`<seq>:answer:<id>`).
+// A dismissal echoes the question's dismiss label; an option answer carries
+// the option's label (key or text). A later re-ask of the same id owns the
+// answers that follow it, so the scan stops at the next same-id question.
+function selectionFor(
+  entries: readonly ThreadEntry[],
+  index: number,
+): QuestionSelection | null {
+  const entry = entries[index];
+  if (entry.kind !== "question") {
+    return null;
+  }
+  const suffix = `:answer:${entry.question.id}`;
+  for (let later = index + 1; later < entries.length; later += 1) {
+    const candidate = entries[later];
+    if (
+      candidate.kind === "question" &&
+      candidate.question.id === entry.question.id
+    ) {
+      return null;
+    }
+    if (candidate.kind !== "user" || !candidate.id.endsWith(suffix)) {
+      continue;
+    }
+    if (
+      candidate.i18nKey !== undefined &&
+      candidate.i18nKey === entry.question.dismissLabelKey
+    ) {
+      return { kind: "dismissed" };
+    }
+    const chosen = entry.question.options.find((option) =>
+      candidate.i18nKey !== undefined
+        ? option.labelKey === candidate.i18nKey
+        : option.label === candidate.text,
+    );
+    return chosen === undefined
+      ? null
+      : { kind: "option", value: chosen.value };
+  }
+  return null;
+}
+
 export function ConversationThread({
   entries,
   pendingQuestionId,
   onAnswer,
+  onDismiss,
   children,
 }: ConversationThreadProps) {
   const t = useT();
@@ -130,7 +177,7 @@ export function ConversationThread({
         scrollingProgrammatically.current = false;
       }}
     >
-      {entries.map((entry) => {
+      {entries.map((entry, index) => {
         if (entry.kind === "narration") {
           return (
             <NarrationBubble
@@ -141,13 +188,19 @@ export function ConversationThread({
           );
         }
         if (entry.kind === "question") {
+          // Interactive IFF this entry is the machine's current pending
+          // question instance; every other card is fully inert with its
+          // recorded choice shown — a superseded card must never look like
+          // it still takes clicks the machine will ignore.
           return (
             <QuestionCard
               key={entry.id}
               question={entry.question}
               answered={entry.id !== liveQuestionEntryId}
+              selection={selectionFor(entries, index)}
               focusFirstOption={entry.id === liveQuestionEntryId}
               onAnswer={onAnswer}
+              onDismiss={onDismiss}
             />
           );
         }

--- a/frontend/src/screens/onboarding-conversation/use-clarify-answers.ts
+++ b/frontend/src/screens/onboarding-conversation/use-clarify-answers.ts
@@ -132,9 +132,31 @@ export function useClarifyAnswers({
     [proposalRef, selectOption],
   );
 
+  // Dismissal is a LOCAL decision, no authorization round trip: nothing is
+  // written to the field, so there is nothing for the server to confirm.
+  // Recording it as an answer stops the question from counting as an open
+  // decision; the confirm resolutions map it per its comparison kind.
+  const dismissClarify = useCallback(
+    (clarifyId: string) => {
+      const clarify = (proposalRef.current?.open_questions ?? []).find(
+        (question) => question.id === clarifyId,
+      );
+      if (!clarify) {
+        return;
+      }
+      setFailure(null);
+      setAnswers((current) => [
+        ...current.filter((answer) => answer.clarifyId !== clarifyId),
+        { clarifyId, field: clarify.field, value: "", dismissed: true },
+      ]);
+    },
+    [proposalRef],
+  );
+
   return {
     answers,
     answerClarify,
+    dismissClarify,
     authorizing: selectOption.isPending,
     failure,
   };

--- a/frontend/src/screens/onboarding-conversation/use-company-read.ts
+++ b/frontend/src/screens/onboarding-conversation/use-company-read.ts
@@ -6,7 +6,7 @@ import type { components } from "../../api/schema";
 import { useLocale } from "../../i18n";
 import { problemMessage } from "../common";
 import type { CompanyDraft } from "../onboarding";
-import { MAX_SELECTED_FACTS, prefill } from "../onboarding";
+import { changeDraftField, MAX_SELECTED_FACTS, prefill } from "../onboarding";
 import type { ClarifyAnswer } from "./company-proposal";
 import { toMachineQuestion } from "./company-proposal";
 import type {
@@ -178,7 +178,16 @@ export function useCompanyRead({
     adopted.current = true;
     prevSnapshot.current = adoptedRead;
     appliedReadVersion.current = adoptedRead.draft_version;
-    setDraft((current) => prefill(current, adoptedRead.profile_fields));
+    setDraft((current) => {
+      const prefilled = prefill(current, adoptedRead.profile_fields);
+      // The confirm contract requires the website; a draft persisted before
+      // the composer wrote URLs into it (or wiped by an old client) heals
+      // from the adopted read's own root - the one URL this read IS.
+      if (prefilled.values.website.trim() !== "") {
+        return prefilled;
+      }
+      return changeDraftField(prefilled, "website", adoptedRead.root_url);
+    });
     setSelectedFactKeys(
       [...new Set(adoptedRead.facts.map((fact) => fact.value_key))].slice(
         0,
@@ -357,7 +366,7 @@ export function useCompanyRead({
       dispatch({
         type: "CLARIFY",
         readId: terminal.readId,
-        question: toMachineQuestion(first),
+        question: toMachineQuestion(first, prevSnapshot.current?.comparisons),
       });
     }
     dispatch({ type: "READ_TERMINAL", ...terminal });

--- a/frontend/src/screens/onboarding-conversation/voice-act.tsx
+++ b/frontend/src/screens/onboarding-conversation/voice-act.tsx
@@ -11,6 +11,7 @@ import type {
   ConversationState,
 } from "./conversation-machine";
 import { NarrationBubble } from "./entries";
+import { NextStepBar } from "./next-step-bar";
 import { presenceFor } from "./presence";
 import { ConversationThread } from "./thread";
 import { useVoiceBuild } from "./use-voice-build";
@@ -181,6 +182,7 @@ export function VoiceAct({ state, dispatch, initialSummary }: VoiceActProps) {
           )}
         </ConversationThread>
       </div>
+      <VoiceNextStep state={state} canBuild={canBuild} />
       {collecting && (
         <div className="mw-composer">
           <input
@@ -229,6 +231,34 @@ export function VoiceAct({ state, dispatch, initialSummary }: VoiceActProps) {
       )}
     </ConversationWorkbench>
   );
+}
+
+// The pinned next-step line of the voice act: the open speaker decision
+// outranks the build chip once the server corpus clears the floor.
+function VoiceNextStep({
+  state,
+  canBuild,
+}: Readonly<{ state: ConversationState; canBuild: boolean }>) {
+  const t = useT();
+  if (state.pendingQuestion !== null) {
+    return (
+      <NextStepBar
+        label={t("ob.conv.next.decisionOne")}
+        targetSelector="fieldset.ob-conv-question:not([disabled])"
+        revision={state.seq}
+      />
+    );
+  }
+  if (canBuild) {
+    return (
+      <NextStepBar
+        label={t("ob.conv.next.build")}
+        targetSelector=".ob-conv-build-chip"
+        revision={state.seq}
+      />
+    );
+  }
+  return null;
 }
 
 function InviteChips({
@@ -318,6 +348,7 @@ function CollectingControls({
           <Button
             small
             variant="primary"
+            className="ob-conv-build-chip"
             disabled={startPending}
             onClick={onBuild}
           >


### PR DESCRIPTION
One coherent round fixing every way the founder's live run found the conversation could strand its human:

- **Zombie question cards** (the worst one): a card no longer holding the machine's live question rendered clickable and silently swallowed clicks. Interactivity is now strictly the current pending instance; every other card is fully inert and shows its recorded choice.
- **Unanswerable gates**: page-chrome-polluted extraction minted clarify options nobody could honestly pick, and the save blocked on them. Candidates pass a plausibility filter (applied symmetrically to presentation and the selection grant), a question needs two surviving options to exist, and every clarify carries a human exit — "Skip this — I will set it myself" (human-conflict questions map to an explicit keep-my-value resolution). The review names skipped fields honestly beside the edit hatch.
- **Forgotten answers**: the proposal and chat serve only still-open questions; a draft value exactly matching an option is a proven earlier answer and never re-asked (hand-typed non-option values deliberately keep the question open — boundary documented and pinned).
- **Invisible next steps**: a pinned bar above the composer names the blocking affordance (decisions open / review ready / voice ready to build); one click scrolls to the card and focuses its first option; hidden while the card is in view.
- **Stale-draft heal**: an adopted read seeds the draft website from its own root URL when a pre-fix client left it blank.

**Verified end to end by hand on the founder's real session**: restore → live-card answer → dismissal of the garbage question → Accept all → "Company profile confirmed. Everything I stored carries its source." → voice invitation.

749 frontend tests; backend suites, lint, craft, jurisdiction, and contract gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents dead-ends in onboarding: already-answered questions aren’t re-asked, every clarify can be dismissed, and the UI always points to the next step. Filters bad entity candidates so “Accept all” never blocks on impossible choices, and fills a blank website from the read’s root URL.

- Bug Fixes
  - No more “zombie” cards: only the current pending question is interactive; others are inert and show the recorded choice.
  - Stop re-asking resolved clarifies: server now serves only still-open questions (draft must exactly match an option to count).
  - Plausibility filter for entity labels/addresses (single-line, length-capped, no token chants, address shape) and require at least two survivors; filtered values are never shown or accepted.

- New Features
  - Every clarify has a human exit: “Skip this — I will set it myself” for census, “Keep my value” for human_conflict. Review lists skipped fields; human_conflict dismissals send keep_current; census dismissals send no resolution.
  - Pinned “next step” bar: shows decisions open/review ready/build ready; one click scrolls to the target and focuses it; hides when in view.
  - Heal stale drafts: if website is blank, seed it from the read’s root URL.

<sup>Written for commit 09f978bb25ce64cee3e7cf4c2530adc9a7569710. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

