### PR TITLE
docs: add extensibility explanation + how-to guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@ maps the codebase and links everything below.
 - [connect-a-hubspot-overlay.md](how-to/connect-a-hubspot-overlay.md) — connect a workspace to a HubSpot portal in overlay (read + continuous sync) mode.
 - [connect-a-cloud-model-provider.md](how-to/connect-a-cloud-model-provider.md) — bind the AI lanes to a BYOK cloud key (Anthropic / OpenAI / Gemini / any OpenAI-compatible vendor).
 - [certify-an-ai-model.md](how-to/certify-an-ai-model.md) — certify a model against a task's scenario corpus and benchmark a candidate swap (`make e2e-ai`).
+- [add-an-extension.md](how-to/add-an-extension.md) — ship a stable-tier extension unit (a jurisdiction pack) under `extensions/`, composed and verified.
 
 ### Reference — look it up
 - [modules.md](reference/modules.md) — the 17 modules: what each owns, its tables, its HTTP surface.
@@ -49,6 +50,7 @@ maps the codebase and links everything below.
 - [custom-fields.md](explanation/custom-fields.md) — the one runtime `ALTER TABLE` chokepoint: the closed type/object sets, the privilege boundary, and the `fieldcatalog` seam.
 - [overlay-augmentation.md](explanation/overlay-augmentation.md) — the two SoR modes, the frozen seam + inner incumbent seam, the mirror-as-cache, fail-closed visibility, and teardown for the HubSpot overlay (branch 1: read + continuous sync).
 - [automation.md](explanation/automation.md) — the closed 7×7 trigger/action catalog: the two vocabularies, the one firing path, the anchor occurrence key, and both permission gates.
+- [extensibility.md](explanation/extensibility.md) — the stable extension tier: the inert compile-time declaration, the marker-allowlisted surface, the composition build, boot reconciliation, and the fitness functions that hold the boundary.
 
 ## Reading order for a new contributor
 

--- a/docs/explanation/extensibility.md
+++ b/docs/explanation/extensibility.md
@@ -102,10 +102,12 @@ A unit may import only `backend/pkg/**`, and only the packages that opt in. Two 
 Membership in `backend/pkg` **grants nothing on its own**. A package is extension surface only when
 its package clause carries the directive `//margince:extension-surface`. The allowlist is *derived
 from the tree* — a fitness test walks `pkg/`, collects every marked package, and treats exactly that
-set as importable — so the published API can never drift from what the gate enforces. Everything on
-the surface is **self-validating value types** (`Name.Validate`, `Period.Validate`, …), and those are
-the same checks boot reconciliation runs — so an author who writes a test against them catches a
-malformed value at test time rather than leaving boot to be the first to reject it.
+set as importable — so the published API can never drift from what the gate enforces. The constrained
+**primitive types** on the surface self-validate (`Name.Validate`, `Period.Validate`,
+`RetentionClassName.Validate`, …) with the same checks boot reconciliation runs, so an author who
+tests against them catches a malformed field at test time. There is no aggregate `Extension.Validate`,
+though: whole-declaration and cross-unit checks (a duplicate name, a code a core pack already holds)
+still first run at boot.
 
 ### 3. The composition build — `gen-composition`
 

--- a/docs/explanation/extensibility.md
+++ b/docs/explanation/extensibility.md
@@ -1,0 +1,191 @@
+# Extensibility — the extension tier
+
+How a bounded add-on lands in this product **without editing a single upstream-owned file**. This is
+the *extension tier*: one named, versioned unit under `extensions/<name>/`, its own Go module,
+reaching the core through one narrow published surface and composed in at build time. The vanilla tree
+already ships one — `extensions/de`, the German jurisdiction pack.
+
+This page is for a contributor who wants the whole idea first, then the detail. Start here; to
+actually *build* a unit, jump to [how-to/add-an-extension.md](../how-to/add-an-extension.md).
+
+## The whole idea in one picture
+
+```text
+extensions/<name>/                 one Go module per unit — its PRESENCE is the enablement
+   │  New() extension.Extension     an inert declaration: plain data, no handle into the core
+   ▼
+make composition ─▶ build/composition/     generated wiring (ignored); an empty extensions/
+   │                                        tree reproduces the committed stub byte-for-byte
+   │  Extensions() []extension.Extension
+   ▼
+cmd/{api,worker,mcp} main ─▶ compose.RegisterExtensions(set)
+   │                              │
+   │                   ① validate the WHOLE set   ─▶  ② apply → core registries
+   │                      (bad unit → boot aborts)      (nothing applies until all valid)
+   ▼
+core consumes the capability        e.g. the retention engine reads a jurisdiction pack's floors
+```
+
+Read top to bottom, that is the entire lifecycle: a unit *declares* a value, the generator *composes*
+the enabled set, each role binary *reconciles* it into the core at boot, and the core *consumes* it.
+Everything below is detail on one of those four steps.
+
+## Purpose — why a whole tier for this
+
+Some behaviour is real but doesn't belong in everyone's build: a country's statutory retention rules,
+a customer-specific add-on. The tier exists so that behaviour can be **added, versioned, and reasoned
+about as its own unit** without forking the core or touching upstream files — and without giving up
+the guarantee that the composed product is wired exactly like the core.
+
+**The rejected alternative names the design.** The obvious way to ship this is a runtime plugin — a
+`.so` loaded at startup, an RPC sidecar, a hook registry a unit mutates in `init()`. All three are
+refused, for one reason: a runtime-loaded unit is a second authority sharing the server's memory while
+being invisible to the compiler, so nothing proves it stayed inside its allowed surface. An extension
+here is a **compile-time unit** instead. Its module path sits *outside* the backend module, so the
+compiler itself makes `internal/**` unreachable — the unit *cannot* reach into the core even if it
+tries. Paying for extensibility with a rebuild is the trade: a composed product is provably wired the
+same way the core is, or the build fails.
+
+## Principles
+
+Four rules hold the whole tier together:
+
+1. **Presence is enablement.** A unit is enabled because a directory for it exists under
+   `extensions/`. No flag, no config list, no registry file to append to. The enabled set is a *fact
+   about the tree*, not a value someone can forget to update.
+2. **A declaration is inert data.** `New()` returns a plain value holding no pointer into the running
+   server. It registers nothing itself; only the boot reconciliation, after the whole set validated,
+   applies anything. Two units share no memory, so one can never reach another's state or the core's.
+3. **Grow additively, never in place.** Capabilities are *fields* on the declaration. A new kind of
+   capability is a new field; a changed contract is a versioned successor, never an edited signature.
+   Existing units keep compiling untouched.
+4. **One narrow surface, and it's enforced.** A unit imports *only* the marker-allowlisted
+   `backend/pkg/**` packages — nothing else in the tree. Fitness tests, not good intentions, hold this.
+
+## The parts
+
+Four moving pieces, matching the four steps in the picture.
+
+### 1. The declaration — what a unit exports
+
+A unit exports one function returning one value:
+
+```go
+func New() extension.Extension {
+	return extension.Extension{
+		Name:          "de",
+		Version:       "1.0.0",
+		Jurisdictions: []jurisdiction.Pack{pack{}},
+	}
+}
+```
+
+That value is the entire contract. `Name` is the canonical unit name (it must equal the directory
+name, obeys `^[a-z0-9]+(-[a-z0-9]+)*$`, ≤32 chars) and keys the unit's namespace everywhere it will
+touch — `x_<name>_<table>` tables, `/x/<name>/` paths, the `x_<name>` database role. `Version` is
+recorded in the boot inventory and carries no authority. **Capabilities are the remaining fields** —
+today just `Jurisdictions`.
+
+### 2. The published surface — and the marker that gates it
+
+A unit may import only `backend/pkg/**`, and only the packages that opt in. Two exist today:
+
+- **`pkg/extension`** — the declaration types (`Extension`, and the self-validating `Name`/`Version`).
+- **`pkg/extension/jurisdiction`** — the jurisdiction-pack contract (`Pack`, `Retention`,
+  `RetentionClass`, the closed class/anchor vocabularies, the calendar `Period`).
+
+Membership in `backend/pkg` **grants nothing on its own**. A package is extension surface only when
+its package clause carries the directive `//margince:extension-surface`. The allowlist is *derived
+from the tree* — a fitness test walks `pkg/`, collects every marked package, and treats exactly that
+set as importable — so the published API can never drift from what the gate enforces. Everything on
+the surface is **self-validating value types**, so an author gets "is this well-formed?" at compile-
+and-test time, never at a customer's boot.
+
+### 3. The composition build — `gen-composition`
+
+The core never imports an extension module. Instead `tools/gen-composition` (run by
+`make composition`, on which every build and test lane depends) scans `extensions/` and materializes
+`build/composition/` — the one ignored root for installation-dependent output: the composed `go.work`,
+a **composition Go module** whose generated `Extensions()` returns the enabled set, and a manifest
+binding input digests to reproducible output hashes. With an *empty* `extensions/` tree the generator
+reproduces the committed `composition/` stub **byte-identically**, so a bare `go build` and a composed
+build provably wire the same thing. `make check-composition` is the drift gate that proves it.
+
+### 4. The boot reconciliation — validate the set, then apply
+
+Each role binary wires the composed set at exactly one place — its `main.go`:
+
+```go
+extensions := composition.Extensions()
+if err := compose.RegisterExtensions(extensions); err != nil { … }
+```
+
+`RegisterExtensions` runs **two separated phases**, and the separation is the invariant. First it
+*validates the whole set* — every name, version, and capability, checked against both the declared set
+and the live core registries (a duplicate name, a jurisdiction code a core pack already holds, a
+retention class outside the closed vocabulary — any of these aborts the boot *before anything
+applies*). Only once the set is known good does it *apply* — registering each capability into its core
+registry. Why two phases: register-as-you-go could fail halfway and leave a half-composed server.
+Validate-then-apply makes "partially registered extension" a state the system cannot reach.
+
+## What an extension can do today — and how that grows
+
+**Today: one capability — jurisdiction packs.** A pack supplies *country-specific policy the core
+consults; it is never an actor*. The core stays country-neutral (a fitness gate fails the build if any
+hand-written core source hard-codes a jurisdiction string). Germany does not live in the core; it
+lives in `extensions/de`, which declares the GoBD/AO statutory **retention floors** — commercial
+correspondence 6 years, accounting records 8 (§147 AO as amended 2025) — each anchored at
+calendar-year end, because §147(4) AO counts every period from the end of the record's calendar year.
+The engine treats a floor as a *minimum*: a workspace may keep longer, never destroy earlier. The
+seam re-exports the pack types as aliases, so the core retention engine consults the *same* constants
+an extension declares.
+
+**How new capabilities arrive.** A new capability kind is a new *field* on `extension.Extension` and a
+new marked `pkg/**` package holding its contract — existing units keep compiling. Two capabilities are
+reserved in the naming scheme but **not yet landed**: a unit owning its own `x_<name>_*` tables (the
+extension-migration namespace — which is why `cmd/migrate` is permitted but not *required* to wire the
+composition today) and its own `/x/<name>/` HTTP surface. The unit name is already validated to the
+full identifier budget so a name chosen today stays valid when those arrive.
+
+## The guardrails — held from the tree
+
+The tier is defended by fitness tests and scripts, so the guarantees can't rot into stale prose:
+
+| Guarantee | Held by |
+|---|---|
+| A unit imports only the marker-allowlisted `pkg/**` surface — never `internal/**`, `cmd/**`, an unmarked `pkg` package, the composition module, or a sibling unit | `backend/extensions_arch_test.go` |
+| The surface marker exists only under `pkg/` — no silent allowlist widening elsewhere | `backend/extensions_arch_test.go` |
+| The composed set is wired only at the role `main.go`s, and each required role actually wires it | `backend/extensions_arch_test.go` |
+| Vanilla composition reproduces the committed stub byte-for-byte | `make check-composition` |
+| The published surface doesn't break compatibility (advisory before the first release tag, enforcing after) | `scripts/check-pkg-freeze.sh` |
+| The core stays jurisdiction-neutral | `scripts/check-no-jurisdiction.sh` |
+
+The compiler does the heaviest lifting for free (an extension's module path is outside the backend
+module, so `internal/**` is unreachable by construction); the tests hold the rest of the contract that
+the compiler alone wouldn't catch, and every extension source dir is enrolled the moment it exists —
+including the CI fixtures under `fixtures/extensions/` (`crm-hello`, the smallest unit that exercises
+the whole path).
+
+## Reference
+
+### Where the code lives
+
+| | |
+|---|---|
+| The declaration type (`Extension`, `Name`, `Version`) | `backend/pkg/extension/extension.go` |
+| The jurisdiction-pack contract | `backend/pkg/extension/jurisdiction/jurisdiction.go` |
+| The core-internal jurisdiction registry (aliases the published types) | `backend/internal/shared/ports/jurisdiction/jurisdiction.go` |
+| Boot reconciliation (validate-then-apply) | `backend/internal/compose/extensions.go` |
+| Role-main wiring | `backend/cmd/{api,worker,mcp}/main.go` |
+| The composition generator | `backend/tools/gen-composition/` |
+| The committed vanilla stub | `composition/extensions_gen.go` |
+| The first-party German pack | `extensions/de/de.go` |
+| The reference fixture | `fixtures/extensions/crm-hello/crmhello.go` |
+| The extension-tier fitness tests | `backend/extensions_arch_test.go` |
+
+### Related docs
+
+- [how-to/add-an-extension.md](../how-to/add-an-extension.md) — build and ship a unit, step by step.
+- [privacy-and-consent.md](privacy-and-consent.md) — the retention engine that consumes a pack.
+- [composition-layer.md](composition-layer.md) — how `compose` boots and wires the composed set.
+- [reference/make-targets.md](../reference/make-targets.md) — `composition`, `check-composition`, `test-extensions`.

--- a/docs/explanation/extensibility.md
+++ b/docs/explanation/extensibility.md
@@ -39,11 +39,13 @@ the guarantee that the composed product is wired exactly like the core.
 
 **The rejected alternative names the design.** The obvious way to ship this is a runtime plugin — a
 `.so` loaded at startup, an RPC sidecar, a hook registry a unit mutates in `init()`. All three are
-refused, for one reason: a runtime-loaded unit is a second authority sharing the server's memory while
-being invisible to the compiler, so nothing proves it stayed inside its allowed surface. An extension
+refused for one reason: they introduce an authority the compiler cannot check — a dynamically loaded
+or separately deployed unit whose reach into the product nothing in the build proves. An extension
 here is a **compile-time unit** instead. Its module path sits *outside* the backend module, so the
-compiler itself makes `internal/**` unreachable — the unit *cannot* reach into the core even if it
-tries. Paying for extensibility with a rebuild is the trade: a composed product is provably wired the
+compiler itself makes `internal/**` unreachable — the unit *cannot* import into the core even if it
+tries — and fitness tests hold the rest of the surface. This is an **import/API boundary, not a
+sandbox**: a unit's `New()` and its capability methods still run as ordinary trusted Go in the role
+process. Paying for extensibility with a rebuild is the trade: a composed product is provably wired the
 same way the core is, or the build fails.
 
 ## Principles
@@ -53,14 +55,17 @@ Four rules hold the whole tier together:
 1. **Presence is enablement.** A unit is enabled because a directory for it exists under
    `extensions/`. No flag, no config list, no registry file to append to. The enabled set is a *fact
    about the tree*, not a value someone can forget to update.
-2. **A declaration is inert data.** `New()` returns a plain value holding no pointer into the running
+2. **A declaration is inert data.** `New()` returns a plain value holding no handle into the running
    server. It registers nothing itself; only the boot reconciliation, after the whole set validated,
-   applies anything. Two units share no memory, so one can never reach another's state or the core's.
+   applies anything. Nothing is wired *through the declaration*, so a unit cannot reach the core or
+   another unit that way — an import/API boundary, not a runtime sandbox.
 3. **Grow additively, never in place.** Capabilities are *fields* on the declaration. A new kind of
    capability is a new field; a changed contract is a versioned successor, never an edited signature.
    Existing units keep compiling untouched.
-4. **One narrow surface, and it's enforced.** A unit imports *only* the marker-allowlisted
-   `backend/pkg/**` packages — nothing else in the tree. Fitness tests, not good intentions, hold this.
+4. **One narrow backend surface, and it's enforced.** A unit reaches the backend *only* through the
+   marker-allowlisted `backend/pkg/**` packages; the gate also rejects the composition module and
+   sibling units. Its other dependencies (stdlib, third-party) are its own business. Fitness tests,
+   not good intentions, hold this.
 
 ## The parts
 
@@ -98,8 +103,9 @@ Membership in `backend/pkg` **grants nothing on its own**. A package is extensio
 its package clause carries the directive `//margince:extension-surface`. The allowlist is *derived
 from the tree* — a fitness test walks `pkg/`, collects every marked package, and treats exactly that
 set as importable — so the published API can never drift from what the gate enforces. Everything on
-the surface is **self-validating value types**, so an author gets "is this well-formed?" at compile-
-and-test time, never at a customer's boot.
+the surface is **self-validating value types** (`Name.Validate`, `Period.Validate`, …), and those are
+the same checks boot reconciliation runs — so an author who writes a test against them catches a
+malformed value at test time rather than leaving boot to be the first to reject it.
 
 ### 3. The composition build — `gen-composition`
 
@@ -131,14 +137,17 @@ Validate-then-apply makes "partially registered extension" a state the system ca
 ## What an extension can do today — and how that grows
 
 **Today: one capability — jurisdiction packs.** A pack supplies *country-specific policy the core
-consults; it is never an actor*. The core stays country-neutral (a fitness gate fails the build if any
-hand-written core source hard-codes a jurisdiction string). Germany does not live in the core; it
-lives in `extensions/de`, which declares the GoBD/AO statutory **retention floors** — commercial
-correspondence 6 years, accounting records 8 (§147 AO as amended 2025) — each anchored at
+consults; it is never an actor*. The core stays country-neutral — a fitness gate
+(`check-no-jurisdiction.sh`) scans hand-written core source for jurisdiction-specific identifiers and
+fails the build on a match. Germany does not live in the core; it lives in `extensions/de`, which
+declares the GoBD/AO statutory **retention floors** — commercial correspondence 6 years, and
+accounting vouchers (*Buchungsbelege* — §147 AO's 8-year class as amended 2025; the 10-year
+books-and-records class is deliberately absent, since a CRM holds no such record) — each anchored at
 calendar-year end, because §147(4) AO counts every period from the end of the record's calendar year.
-The engine treats a floor as a *minimum*: a workspace may keep longer, never destroy earlier. The
-seam re-exports the pack types as aliases, so the core retention engine consults the *same* constants
-an extension declares.
+The engine treats a floor as a *minimum*: a workspace may keep longer, never destroy earlier. Today
+only the correspondence floor actually binds a record; the accounting-vouchers class is declared but
+**inert**, because no in-product invoice yet derives into it. The seam re-exports the pack types as
+aliases, so the core retention engine consults the *same* constants an extension declares.
 
 **How new capabilities arrive.** A new capability kind is a new *field* on `extension.Extension` and a
 new marked `pkg/**` package holding its contract — existing units keep compiling. Two capabilities are

--- a/docs/how-to/add-an-extension.md
+++ b/docs/how-to/add-an-extension.md
@@ -1,0 +1,134 @@
+# Add an extension (a stable-tier unit)
+
+For shipping a bounded add-on — today a **jurisdiction pack** — as a named, versioned unit under
+`extensions/<name>/`, without editing any upstream-owned file. For *why* the seam is a compile-time
+declaration and what the surface guarantees, read
+[explanation/extensibility.md](../explanation/extensibility.md) first. For a country pack
+specifically, the live capability is retention floors; the running example below builds one.
+
+An extension is its own Go module reaching the core through only the marker-allowlisted
+`backend/pkg/**` surface. **Presence under `extensions/` is the enablement** — there is no flag to
+flip. `extensions/de` (Germany) and `fixtures/extensions/crm-hello` (the walking-skeleton reference)
+are the two units to copy from.
+
+## Scaffold the unit
+
+1. **Create the module directory** `extensions/<name>/` — the directory name is the canonical unit
+   name and must match the `Name` you declare. It obeys the grammar `^[a-z0-9]+(-[a-z0-9]+)*$`,
+   ≤32 chars (lower-case segments joined by single hyphens); the name keys SQL identifiers and URL
+   paths, so anything else is refused at boot.
+
+2. **Add its `go.mod`** — its own module, path `github.com/gradionhq/margince/extensions/<name>`:
+   ```
+   module github.com/gradionhq/margince/extensions/<name>
+
+   go 1.26.5
+   ```
+
+3. **Write the declaration** `extensions/<name>/<name>.go`, starting with the BUSL SPDX header (every
+   hand-written `*.go` file carries it). Export `New() extension.Extension` returning an **inert
+   value** — no handle into the core, nothing registered in an `init()`:
+   ```go
+   // SPDX-License-Identifier: BUSL-1.1
+   // SPDX-FileCopyrightText: 2026 Gradion
+
+   package fr
+
+   import (
+   	"github.com/gradionhq/margince/backend/pkg/extension"
+   	"github.com/gradionhq/margince/backend/pkg/extension/jurisdiction"
+   )
+
+   func New() extension.Extension {
+   	return extension.Extension{
+   		Name:          "fr",
+   		Version:       "1.0.0",
+   		Jurisdictions: []jurisdiction.Pack{pack{}},
+   	}
+   }
+
+   type pack struct{}
+
+   func (pack) Code() jurisdiction.Code { return "fr" }
+
+   func (pack) Retention() jurisdiction.Retention { return retention{} }
+
+   type retention struct{}
+
+   func (retention) Classes() []jurisdiction.RetentionClass {
+   	return []jurisdiction.RetentionClass{
+   		{Name: jurisdiction.CommercialCorrespondence, Keep: jurisdiction.Period{Years: 10}, Anchor: jurisdiction.AnchorCalendarYearEnd},
+   	}
+   }
+   ```
+   **Import only `backend/pkg/**` packages carrying `//margince:extension-surface`** — `pkg/extension`
+   and `pkg/extension/jurisdiction` today. Any import of `internal/**`, `cmd/**`, an unmarked `pkg`
+   package, the composition module, or a sibling extension fails the arch test (the compiler already
+   makes `internal/**` unreachable — the test holds the rest).
+
+## Stay inside the declared vocabularies
+
+A jurisdiction pack supplies **policy, never behaviour** — the core retention engine consults it. So
+the values you declare must be ones a core engine already understands:
+
+- **`Code`** is a lower-case ISO 3166-1 alpha-2 code, unique across the composed set. A code the `de`
+  pack (or any other enabled unit) already holds aborts the boot.
+- **`RetentionClassName`** comes from the **closed set** — `commercial_correspondence`,
+  `accounting_records`. You supply a *floor* for a known class; you do not invent a class (adding a
+  new class kind is a deferred capability that hasn't landed yet). A name outside the set is refused.
+- **`Period`** is a calendar span (`{Years: 6}`), never a day count, and every component is
+  non-negative — a floor reaches *back*, never forward.
+- **`Anchor`** is `occurrence` (the zero value) or `calendar_year_end`. Pick `calendar_year_end` only
+  when the statute counts from the year's end (as German §147(4) AO does).
+
+Get the statutory content right — it's legal content, not a default. Pin it with a test (below).
+
+## Write the unit's own test
+
+Each unit is its own Go module, so the backend's `./...` never reaches it — it carries its own tests,
+run by `make test-extensions` on the composed workspace. Pin the statutory content so a changed span
+or class name is a deliberate, reviewed edit (copy the shape from `extensions/de/de_test.go`):
+
+```go
+func TestNewDeclaresTheFloors(t *testing.T) {
+	e := New()
+	if e.Name != "fr" {
+		t.Fatalf("Name = %q, want fr", e.Name)
+	}
+	// … assert the pack code, class names, and calendar spans.
+}
+```
+
+A test with no assertion is noise (T11) — assert the actual floors, not just that `New()` returns.
+
+## Compose and verify
+
+Because presence is enablement, the moment the directory exists it's in the enabled set — you only
+have to regenerate the composition and run the gates:
+
+1. **`make composition`** — regenerates `build/composition/` from `extensions/`; your unit now appears
+   in the generated `Extensions()`. (Every build/test lane depends on this target, so `make check`
+   runs it for you; run it directly when you want to inspect the output.)
+2. **`make check`** — builds the composed workspace, runs the extension-tier fitness tests
+   (import-boundary, marker placement, composition wiring), `make test-extensions` (your unit's own
+   tests), and `make check-composition` (a clean regeneration must reproduce `composition.json`
+   byte-for-byte).
+3. **Boot a role** — `make dev`, then confirm the boot doesn't abort: a duplicate code, an unknown
+   class, or a bad period is caught in `RegisterExtensions`' validate phase *before* any surface
+   serves, and names the offending unit.
+
+The vanilla stub check still passes because it's keyed on the *empty* `extensions/` tree; your unit
+only changes the composed output, never the committed `composition/` stub.
+
+## Ship it
+
+Commit the whole unit together — `extensions/<name>/{go.mod,<name>.go,<name>_test.go}` — and the
+regenerated committed composition **only if it changed** (adding a first-party enabled unit updates
+`build/composition/`, which is ignored; the committed `composition/` stub stays as-is unless you're
+changing the vanilla baseline). Sign off every commit (`git commit -s`), then the usual PR loop
+([CONTRIBUTING.md](../../CONTRIBUTING.md)).
+
+Two things this how-to does **not** yet cover, because those capabilities haven't landed yet: a unit
+owning its own `x_<name>_*` tables (the extension-migration namespace) and its own `/x/<name>/`
+HTTP surface. Today an extension contributes policy the core already knows how to apply — a
+jurisdiction pack. When those capabilities ship, this guide grows the steps for them.

--- a/docs/how-to/add-an-extension.md
+++ b/docs/how-to/add-an-extension.md
@@ -27,9 +27,10 @@ are the two units to copy from.
 
 3. **Write the declaration** `extensions/<name>/<name>.go`, starting with the BUSL SPDX header (every
    hand-written `*.go` file carries it). Export `New() extension.Extension` returning an **inert
-   value** — no handle into the core, nothing registered in an `init()`. Note the Go **package name**
-   is not the unit name when the name is hyphenated: `crm-hello` uses `package crmhello` — only the
-   directory and `Extension.Name` carry the hyphen, since a hyphen is not a legal Go identifier:
+   value** — no handle into the core, nothing registered in an `init()`. When the name is hyphenated,
+   only the Go **package identifier** drops the hyphen: `crm-hello` uses `package crmhello`, but its
+   directory, its module path, and `Extension.Name` all keep the hyphen — a hyphen is illegal in a Go
+   identifier, not in a module path:
    ```go
    // SPDX-License-Identifier: BUSL-1.1
    // SPDX-FileCopyrightText: 2026 Gradion
@@ -130,16 +131,18 @@ output, never the committed `composition/` stub.
 ## Ship it
 
 **A new unit's directory is gitignored.** `.gitignore` ignores `/extensions/*` except an explicit
-allowlist (`!/extensions/de`, …), so a first-party unit you mean to ship in the vanilla tree needs its
-own exception — add `!/extensions/<name>` (or `git add -f`), or the PR opens with **no extension
-files**. (A purely local, per-installation unit is *meant* to stay ignored: its presence in the
-working tree already enables it for that install.)
+allowlist (`!/extensions/de`, …), so a first-party unit you mean to ship in the vanilla tree **must
+add its own exception** — `!/extensions/<name>` — or the PR opens with no extension files, and files
+you add to the unit later are silently ignored too. (`git add -f` stages the files once but leaves the
+directory ignored, so it is not a substitute for the exception.) A purely local, per-installation unit
+is *meant* to stay ignored: its presence in the working tree already enables it for that install.
 
-Then commit **the extension files only** — `extensions/<name>/{go.mod,<name>.go,<name>_test.go}` plus
-the `.gitignore` exception. Do **not** commit `build/composition/` — it is generated and ignored — and
-leave the tracked `composition/` stub unchanged unless you are deliberately changing the vanilla
-baseline. Sign off every commit (`git commit -s`), then the usual PR loop
-([CONTRIBUTING.md](../../CONTRIBUTING.md)); merge only when the gates are green.
+Then commit **the complete unit directory** — every source and test file plus its module metadata
+(`go.mod`, and `go.sum` if it carries third-party dependencies) — together with the `.gitignore`
+exception. Do **not** commit `build/composition/` — it is generated and ignored — and leave the
+tracked `composition/` stub unchanged unless you are deliberately changing the vanilla baseline. Sign
+off every commit (`git commit -s`), then the usual PR loop ([CONTRIBUTING.md](../../CONTRIBUTING.md));
+merge only when the gates are green.
 
 Two things this how-to does **not** yet cover, because those capabilities haven't landed yet: a unit
 owning its own `x_<name>_*` tables (the extension-migration namespace) and its own `/x/<name>/`

--- a/docs/how-to/add-an-extension.md
+++ b/docs/how-to/add-an-extension.md
@@ -19,7 +19,7 @@ are the two units to copy from.
    paths, so anything else is refused at boot.
 
 2. **Add its `go.mod`** — its own module, path `github.com/gradionhq/margince/extensions/<name>`:
-   ```
+   ```text
    module github.com/gradionhq/margince/extensions/<name>
 
    go 1.26.5
@@ -27,7 +27,9 @@ are the two units to copy from.
 
 3. **Write the declaration** `extensions/<name>/<name>.go`, starting with the BUSL SPDX header (every
    hand-written `*.go` file carries it). Export `New() extension.Extension` returning an **inert
-   value** — no handle into the core, nothing registered in an `init()`:
+   value** — no handle into the core, nothing registered in an `init()`. Note the Go **package name**
+   is not the unit name when the name is hyphenated: `crm-hello` uses `package crmhello` — only the
+   directory and `Extension.Name` carry the hyphen, since a hyphen is not a legal Go identifier:
    ```go
    // SPDX-License-Identifier: BUSL-1.1
    // SPDX-FileCopyrightText: 2026 Gradion
@@ -56,8 +58,11 @@ are the two units to copy from.
    type retention struct{}
 
    func (retention) Classes() []jurisdiction.RetentionClass {
+   	// Illustrative values only — a real pack's statutory floors and anchors
+   	// must be legally verified (French correspondance commerciale ≈ 5 years,
+   	// not the German figure).
    	return []jurisdiction.RetentionClass{
-   		{Name: jurisdiction.CommercialCorrespondence, Keep: jurisdiction.Period{Years: 10}, Anchor: jurisdiction.AnchorCalendarYearEnd},
+   		{Name: jurisdiction.CommercialCorrespondence, Keep: jurisdiction.Period{Years: 5}, Anchor: jurisdiction.AnchorOccurrence},
    	}
    }
    ```
@@ -77,7 +82,8 @@ the values you declare must be ones a core engine already understands:
   `accounting_records`. You supply a *floor* for a known class; you do not invent a class (adding a
   new class kind is a deferred capability that hasn't landed yet). A name outside the set is refused.
 - **`Period`** is a calendar span (`{Years: 6}`), never a day count, and every component is
-  non-negative — a floor reaches *back*, never forward.
+  non-negative — a floor reaches *back*, never forward. Implausibly long spans are refused too
+  (`Period.Validate` caps a component at ~1000 years), so a typo can't anchor a cutoff in the far past.
 - **`Anchor`** is `occurrence` (the zero value) or `calendar_year_end`. Pick `calendar_year_end` only
   when the statute counts from the year's end (as German §147(4) AO does).
 
@@ -117,16 +123,23 @@ have to regenerate the composition and run the gates:
    class, or a bad period is caught in `RegisterExtensions`' validate phase *before* any surface
    serves, and names the offending unit.
 
-The vanilla stub check still passes because it's keyed on the *empty* `extensions/` tree; your unit
-only changes the composed output, never the committed `composition/` stub.
+Push only once `make check` is **green** — not red, not still running. The vanilla stub check keeps
+passing because it's keyed on the *empty* `extensions/` tree; your unit only changes the composed
+output, never the committed `composition/` stub.
 
 ## Ship it
 
-Commit the whole unit together — `extensions/<name>/{go.mod,<name>.go,<name>_test.go}` — and the
-regenerated committed composition **only if it changed** (adding a first-party enabled unit updates
-`build/composition/`, which is ignored; the committed `composition/` stub stays as-is unless you're
-changing the vanilla baseline). Sign off every commit (`git commit -s`), then the usual PR loop
-([CONTRIBUTING.md](../../CONTRIBUTING.md)).
+**A new unit's directory is gitignored.** `.gitignore` ignores `/extensions/*` except an explicit
+allowlist (`!/extensions/de`, …), so a first-party unit you mean to ship in the vanilla tree needs its
+own exception — add `!/extensions/<name>` (or `git add -f`), or the PR opens with **no extension
+files**. (A purely local, per-installation unit is *meant* to stay ignored: its presence in the
+working tree already enables it for that install.)
+
+Then commit **the extension files only** — `extensions/<name>/{go.mod,<name>.go,<name>_test.go}` plus
+the `.gitignore` exception. Do **not** commit `build/composition/` — it is generated and ignored — and
+leave the tracked `composition/` stub unchanged unless you are deliberately changing the vanilla
+baseline. Sign off every commit (`git commit -s`), then the usual PR loop
+([CONTRIBUTING.md](../../CONTRIBUTING.md)); merge only when the gates are green.
 
 Two things this how-to does **not** yet cover, because those capabilities haven't landed yet: a unit
 owning its own `x_<name>_*` tables (the extension-migration namespace) and its own `/x/<name>/`


### PR DESCRIPTION
## What

Contributor documentation for the **extension tier** — the two docs the tree was missing for `extensions/`:

- **`docs/explanation/extensibility.md`** — top-down explainer (get the whole idea first): overview → purpose (incl. the rejected-plugin rationale) → four principles → a lifecycle **ASCII diagram** up top → the four parts (declaration, published surface, composition build, boot reconciliation) → what a unit can do today (jurisdiction packs) and how capabilities grow → the guardrail fitness tests → a **Where the code lives** reference table + related-docs links.
- **`docs/how-to/add-an-extension.md`** — task guide: scaffold a unit → stay inside the declared vocabularies → write its test → `make composition` / `make check` → ship.
- **`docs/README.md`** — indexed both in the How-to and Explanation maps.

## Notes

- **Docs-only** — no code, contract, or migration changes.
- Written to match the existing Diátaxis house style (title tagline, path-anchored intro, bold lead-ins, `Where the code lives` table).
- Deliberately references the running code and tree as the source of truth rather than the upstream spec's internal ADR/section identifiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add contributor docs for the compile‑time extension tier and a how‑to for shipping a jurisdiction pack under `extensions/`, linked from the docs index. Clarifies the import/API boundary and marker‑allowlisted `backend/pkg/**` surface; validation timing (primitive type self‑checks, no aggregate `Extension.Validate`, whole‑set checks at boot); and shipping rules (hyphenated names — only the Go package identifier drops the hyphen, `Period` caps, `/extensions/*` gitignore with a required exception, commit the complete unit directory and never `build/composition/`), plus content fixes (inert 8‑year Buchungsbelege; FR example uses an illustrative 5‑year floor).

<sup>Written for commit 0bf9d3cfbf35cec67c4efdd99dcbe26252e5b79d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a guide explaining how to create, validate, test, and ship extensions.
  * Added an explanation of the extension system, including its lifecycle, supported capabilities, and validation rules.
  * Updated documentation navigation to link to the new guide and explanation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->