### PR TITLE
feat(overlay): HubSpot write-back — incumbent-first Create/Update/Archive (OVA-MAP-W)

### DIFF
--- a/backend/cmd/mcp/main.go
+++ b/backend/cmd/mcp/main.go
@@ -53,6 +53,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/httpserver"
+	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
@@ -101,7 +102,18 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 	defer pool.Close()
 
 	auth := identity.NewService(pool)
-	registry := compose.NewRegistry(pool)
+
+	// The overlay write-back path (create/update/archive tools on an
+	// overlay-mode workspace) needs the workspace's own vaulted HubSpot token,
+	// so wire the same FromEnv vault-backed resolver the api server uses onto
+	// this stdio surface's tool registry. Absent a keyvault config the resolver
+	// is nil and write-back degrades to a clean errNoWriteIncumbent (reads and
+	// non-SoR tools are unaffected).
+	vault, _, err := keyvault.FromEnv(pool)
+	if err != nil {
+		return err
+	}
+	registry := compose.NewRegistryWithIncumbent(pool, compose.OverlayIncumbentResolver(pool, vault))
 
 	// Bind the singleton organization before serving anything: an MCP
 	// process against a pre-bootstrap database is an operator error, not

--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -128,7 +128,15 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 	var background sync.WaitGroup
 	if modelPath.Agent != nil {
 		grounding := search.NewRetriever(search.NewStore(pool), modelPath.Embedder)
-		svc := compose.NewRunnerService(pool, modelPath.Agent, modelPath.DraftReply, grounding, logger)
+		// The Surface-B runner's agent tools reach overlay write-back through
+		// the workspace's own vaulted incumbent token; wire the FromEnv
+		// vault-backed resolver so an autonomous run can write back (nil vault
+		// → clean errNoWriteIncumbent, never a crash).
+		runnerVault, _, rverr := keyvault.FromEnv(pool)
+		if rverr != nil {
+			return rverr
+		}
+		svc := compose.NewRunnerService(pool, modelPath.Agent, modelPath.DraftReply, grounding, logger, compose.OverlayIncumbentResolver(pool, runnerVault))
 		_, _ = fmt.Fprintf(stdout, "worker running the Surface-B scheduler every %s\n", cfg.runnerInterval)
 		background.Go(func() { runScheduler(ctx, svc, cfg.runnerInterval, logger) })
 		background.Go(func() { runResumeSubscriber(ctx, rdb, svc, logger) })

--- a/backend/internal/compose/dispatcher_test.go
+++ b/backend/internal/compose/dispatcher_test.go
@@ -67,17 +67,21 @@ func TestDispatcherRoutesEveryVerbToTheOverlayProviderWhenCached(t *testing.T) {
 	if _, _, err := d.StageSemantic(ctx, ids.NewV7()); err == nil {
 		t.Error("StageSemantic: want ErrUnsupportedBySoR, got nil")
 	}
+	// Create/Update/Archive are supported write-back verbs now, so their
+	// error here is the overlay provider's own (object-RBAC/nil-store), not
+	// ErrUnsupportedBySoR — the assertion still proves the verb routed to the
+	// overlay provider rather than the (nil) native one.
 	if _, err := d.Create(ctx, datasource.CreateInput{EntityType: datasource.EntityPerson}); err == nil {
-		t.Error("Create: want ErrUnsupportedBySoR, got nil")
+		t.Error("Create: want the overlay provider's error, got nil")
 	}
 	if _, err := d.Update(ctx, datasource.UpdateInput{Ref: ref}); err == nil {
-		t.Error("Update: want ErrUnsupportedBySoR, got nil")
+		t.Error("Update: want the overlay provider's error, got nil")
 	}
 	if _, err := d.AdvanceDeal(ctx, datasource.AdvanceDealInput{}); err == nil {
 		t.Error("AdvanceDeal: want ErrUnsupportedBySoR, got nil")
 	}
 	if _, err := d.Archive(ctx, ref); err == nil {
-		t.Error("Archive: want ErrUnsupportedBySoR, got nil")
+		t.Error("Archive: want the overlay provider's error, got nil")
 	}
 	if _, err := d.Merge(ctx, datasource.MergeInput{Type: datasource.EntityPerson}); err == nil {
 		t.Error("Merge: want ErrUnsupportedBySoR, got nil")

--- a/backend/internal/compose/integration/overlay_acceptance_test.go
+++ b/backend/internal/compose/integration/overlay_acceptance_test.go
@@ -383,35 +383,38 @@ func TestAcceptance_AC_OV_2_BoundedEquivalence_ReadSubset(t *testing.T) {
 	})
 
 	// The published bounded-capability manifest, derived from the frozen
-	// interface's own method set rather than hand-listed twice.
+	// interface's own method set rather than hand-listed twice. Write-back
+	// (branch 2) split the old "every write is unsupported" partition into
+	// three: the read verbs, the SUPPORTED write-back verbs (Create/Update/
+	// Archive — incumbent-first, OVA-MAP-W), and the still-unsupported verbs
+	// (AdvanceDeal needs the overlay stage-map StageSemantic also lacks;
+	// Merge/PromoteLead have no atomic incumbent projection, OVA-MAP-W6;
+	// RunReport/StageSemantic have no HubSpot analogue).
 	readVerbs := map[string]bool{"Read": true, "Search": true, "ListObjects": true, "ListFields": true, "Freshness": true}
+	writeVerbs := map[string]bool{"Create": true, "Update": true, "Archive": true}
 	unsupportedManifest := map[string]bool{
-		"RunReport": true, "StageSemantic": true, "Create": true, "Update": true,
-		"AdvanceDeal": true, "Archive": true, "Merge": true, "PromoteLead": true,
+		"RunReport": true, "StageSemantic": true, "AdvanceDeal": true, "Merge": true, "PromoteLead": true,
 	}
 	ifaceType := reflect.TypeOf((*datasource.SystemOfRecordProvider)(nil)).Elem()
 	for i := 0; i < ifaceType.NumMethod(); i++ {
 		name := ifaceType.Method(i).Name
-		if readVerbs[name] == unsupportedManifest[name] {
-			t.Fatalf("method %q is classified as both/neither read and unsupported — the manifest partition below is incomplete", name)
+		classified := 0
+		for _, set := range []map[string]bool{readVerbs, writeVerbs, unsupportedManifest} {
+			if set[name] {
+				classified++
+			}
+		}
+		if classified != 1 {
+			t.Fatalf("method %q is in %d manifest categories — it must be in exactly one (read / write / unsupported)", name, classified)
 		}
 	}
-	if got, want := ifaceType.NumMethod(), len(readVerbs)+len(unsupportedManifest); got != want {
+	if got, want := ifaceType.NumMethod(), len(readVerbs)+len(writeVerbs)+len(unsupportedManifest); got != want {
 		t.Fatalf("SystemOfRecordProvider has %d methods but this test's manifest only classifies %d — a verb was added to the frozen seam with no manifest entry here", got, want)
 	}
 
-	t.Run("write verbs + RunReport + StageSemantic declare the published unsupported_by_sor manifest", func(t *testing.T) {
-		if _, err := overlayProvider.Create(ctx, datasource.CreateInput{EntityType: datasource.EntityPerson}); !errors.Is(err, apperrors.ErrUnsupportedBySoR) {
-			t.Errorf("Create = %v, want ErrUnsupportedBySoR", err)
-		}
-		if _, err := overlayProvider.Update(ctx, datasource.UpdateInput{Ref: datasource.EntityRef{Type: datasource.EntityPerson}}); !errors.Is(err, apperrors.ErrUnsupportedBySoR) {
-			t.Errorf("Update = %v, want ErrUnsupportedBySoR", err)
-		}
+	t.Run("AdvanceDeal + Merge + PromoteLead + RunReport + StageSemantic declare the published unsupported_by_sor manifest", func(t *testing.T) {
 		if _, err := overlayProvider.AdvanceDeal(ctx, datasource.AdvanceDealInput{}); !errors.Is(err, apperrors.ErrUnsupportedBySoR) {
 			t.Errorf("AdvanceDeal = %v, want ErrUnsupportedBySoR", err)
-		}
-		if _, err := overlayProvider.Archive(ctx, datasource.EntityRef{Type: datasource.EntityPerson}); !errors.Is(err, apperrors.ErrUnsupportedBySoR) {
-			t.Errorf("Archive = %v, want ErrUnsupportedBySoR", err)
 		}
 		if _, err := overlayProvider.Merge(ctx, datasource.MergeInput{Type: datasource.EntityPerson}); !errors.Is(err, apperrors.ErrUnsupportedBySoR) {
 			t.Errorf("Merge = %v, want ErrUnsupportedBySoR", err)
@@ -424,6 +427,23 @@ func TestAcceptance_AC_OV_2_BoundedEquivalence_ReadSubset(t *testing.T) {
 		}
 		if _, _, err := overlayProvider.StageSemantic(ctx, ids.NewV7()); !errors.Is(err, apperrors.ErrUnsupportedBySoR) {
 			t.Errorf("StageSemantic = %v, want ErrUnsupportedBySoR", err)
+		}
+	})
+
+	t.Run("Create + Update + Archive are supported write-back verbs, not declared unsupported_by_sor", func(t *testing.T) {
+		// Write-back is incumbent-first (OVA-MAP-W); these verbs must NOT
+		// answer the unsupported sentinel. This overlayProvider is built
+		// without a write incumbent resolver, so they surface a clear
+		// configuration/permission error instead — anything but
+		// ErrUnsupportedBySoR proves they are recognized, supported verbs.
+		if _, err := overlayProvider.Create(ctx, datasource.CreateInput{EntityType: datasource.EntityPerson}); errors.Is(err, apperrors.ErrUnsupportedBySoR) {
+			t.Errorf("Create must be a supported write-back verb, got ErrUnsupportedBySoR")
+		}
+		if _, err := overlayProvider.Update(ctx, datasource.UpdateInput{Ref: datasource.EntityRef{Type: datasource.EntityPerson}}); errors.Is(err, apperrors.ErrUnsupportedBySoR) {
+			t.Errorf("Update must be a supported write-back verb, got ErrUnsupportedBySoR")
+		}
+		if _, err := overlayProvider.Archive(ctx, datasource.EntityRef{Type: datasource.EntityPerson}); errors.Is(err, apperrors.ErrUnsupportedBySoR) {
+			t.Errorf("Archive must be a supported write-back verb, got ErrUnsupportedBySoR")
 		}
 	})
 }

--- a/backend/internal/compose/integration/runner_integration_test.go
+++ b/backend/internal/compose/integration/runner_integration_test.go
@@ -98,7 +98,7 @@ func setupRunner(t *testing.T) *runnerEnv {
 	return &runnerEnv{
 		env:        e,
 		pool:       pool,
-		svc:        compose.NewRunnerService(pool, modelPath.Agent, modelPath.DraftReply, nil, logger),
+		svc:        compose.NewRunnerService(pool, modelPath.Agent, modelPath.DraftReply, nil, logger, nil),
 		store:      runner.NewStore(pool),
 		brain:      brain,
 		wsID:       wsID,

--- a/backend/internal/compose/overlay.go
+++ b/backend/internal/compose/overlay.go
@@ -117,7 +117,14 @@ func hubspotIncumbentFactory(region, token string) overlay.Incumbent {
 func NewOverlayProvider(pool *pgxpool.Pool, meter *overlaybudget.Meter, resolveIncumbent func(context.Context) (overlay.Incumbent, error)) *overlay.Provider {
 	ms := overlay.NewMirrorStore(pool, unresolvedOwnerEmails{})
 	ff := overlay.NewFreshnessReader(resolveIncumbent, ms, meter, hubspot.IncumbentClassesFor)
-	return overlay.NewProvider(ms, ff)
+	p := overlay.NewProvider(ms, ff)
+	// Wire the write-back path's incumbent resolver too — NewProvider stores
+	// only ms+ff, so without this the Provider's Create/Update/Archive verbs
+	// answer errNoWriteIncumbent even when a resolver was supplied. A caller
+	// that passes nil (the sorDispatch, which is wired later by WithKeyvault)
+	// leaves it unset here and SetOverlayIncumbentResolver installs it then.
+	p.SetFreshnessIncumbentResolver(resolveIncumbent)
+	return p
 }
 
 // unresolvedOwnerEmails is the construction-time placeholder

--- a/backend/internal/compose/overlaywrite.go
+++ b/backend/internal/compose/overlaywrite.go
@@ -78,14 +78,18 @@ type overlayModeChecker interface {
 	isOverlay(ctx context.Context) (bool, error)
 }
 
-// overlayWriteGuard refuses a mutating request that would write a mirrored
-// entity through the SoR seam when the workspace is in overlay mode,
-// answering the same unsupported_by_sor the Provider's write verbs and the
-// agent-tier dispatch already give. It is keyed off the generated
-// agentPolicies table (the contract's own op→tool classification), so the
-// guarded set never drifts from the contract. It runs for every principal
-// — the reason it is a standalone middleware rather than part of the
-// agent-only gate.
+// overlayWriteGuard refuses a mutating REST request whose native module
+// handler would write a mirrored entity's native table DIRECTLY (bypassing
+// the SoR seam) when the workspace is in overlay mode — those native tables
+// are empty in overlay, so the write would vanish and never reach the
+// incumbent. Write-back to the incumbent happens through the SoR seam
+// (the dispatcher + agent tool registry's Create/Update/Archive verbs), NOT
+// these native REST handlers, so refusing them here is correct; routing the
+// REST handlers to the write-back seam is a separate follow-up. The guarded
+// set is keyed off the generated agentPolicies table (the contract's own
+// op→tool classification), so it never drifts from the contract. It runs for
+// every principal — the reason it is a standalone middleware rather than part
+// of the agent-only gate.
 func overlayWriteGuard(mode overlayModeChecker) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/compose/overlaywrite.go
+++ b/backend/internal/compose/overlaywrite.go
@@ -4,18 +4,21 @@
 package compose
 
 // The overlay-mode write-admission guard. In overlay mode a workspace's
-// records are served from a read-only incumbent mirror; the overlay
-// datasource Provider declares every record write unsupported_by_sor until
-// branch 2 lands the write-back path. But the REST write handlers are the
-// module-owned transports (people.Handlers.CreatePerson, …) — they write
-// their native tables directly and never ride the Dispatcher's write
-// verbs, so nothing consulted x_sor_mode on the write path. A human or a
+// records are served from an incumbent mirror. Write-back (branch 2) routes
+// canonical writes to the incumbent, but ONLY through the SoR seam — the
+// datasource Provider's Create/Update/Archive verbs the Dispatcher and the
+// agent tool registry call. The REST record-write handlers are the
+// module-owned transports (people.Handlers.CreatePerson, …): they write
+// their native tables DIRECTLY and never ride the SoR seam, so nothing on
+// that path consults x_sor_mode or reaches the incumbent. A human or a
 // static-tier agent issuing a create/update/archive/advance/merge/promote
-// against an overlay-mode workspace therefore committed to the EMPTY
-// native tables: the write then vanished from every mirror-backed read and
-// never reached the incumbent. The SPA hides these affordances in overlay,
-// but that cannot bind a direct API caller. This guard is the server-side
-// chokepoint that makes the refusal real for every principal.
+// through a native REST handler against an overlay-mode workspace would
+// therefore commit to the EMPTY native tables: the write then vanishes from
+// every mirror-backed read and never reaches the incumbent. The SPA hides
+// these affordances in overlay, but that cannot bind a direct API caller.
+// This guard is the server-side chokepoint that refuses those seam-bypassing
+// native REST writes for every principal; routing them to the write-back
+// seam instead is a separate follow-up.
 
 import (
 	"context"
@@ -43,13 +46,14 @@ const (
 	accessTool         = "tool"
 )
 
-// overlaySoRWriteTools are the backing MCP tool verbs of the operations the
-// overlay Provider declares unsupported (its Create/Update/AdvanceDeal/
-// Archive/Merge/PromoteLead seam). A mutating route whose generated policy
-// names one of these writes a mirrored entity through the system-of-record
-// seam, so it is refused in overlay mode. Side-service tools (draft/send
-// email, book meeting, relink) and human-only governance are deliberately
-// ABSENT — they are not SoR record writes and remain available in overlay.
+// overlaySoRWriteTools are the backing MCP tool verbs of the record-write
+// operations (Create/Update/AdvanceDeal/Archive/Merge/PromoteLead + log
+// activity). A mutating REST route whose generated policy names one of these
+// is a native module handler writing a mirrored entity's native table
+// directly (bypassing the write-back seam), so it is refused in overlay
+// mode. Side-service tools (draft/send email, book meeting, relink) and
+// human-only governance are deliberately ABSENT — they are not SoR record
+// writes and remain available in overlay.
 var overlaySoRWriteTools = map[string]bool{
 	toolCreateRecord:   true,
 	toolUpdateRecord:   true,

--- a/backend/internal/compose/registry.go
+++ b/backend/internal/compose/registry.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/approvals"
 	"github.com/gradionhq/margince/backend/internal/modules/consent"
 	"github.com/gradionhq/margince/backend/internal/modules/identity"
+	"github.com/gradionhq/margince/backend/internal/modules/overlay"
 	"github.com/gradionhq/margince/backend/internal/modules/search"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -29,17 +30,25 @@ import (
 // seam, which identity implements — injected here so platform/auth never
 // imports a module (ADR-0054 §5).
 func NewRegistry(pool *pgxpool.Pool) *agents.Registry {
-	return registryWithGate(pool, auth.NewGate(identity.NewService(pool)), nil)
+	return registryWithGate(pool, auth.NewGate(identity.NewService(pool)), nil, nil)
 }
 
-func registryWithDraftBrain(pool *pgxpool.Pool, brain completer) *agents.Registry {
+// NewRegistryWithIncumbent is NewRegistry plus the per-workspace live-incumbent
+// resolver the overlay write-back path (Create/Update/Archive) reaches HubSpot
+// through — the wiring a role with a vault (the api server) installs so the MCP
+// tool surface can actually write back, not just answer errNoWriteIncumbent.
+func NewRegistryWithIncumbent(pool *pgxpool.Pool, resolveIncumbent func(context.Context) (overlay.Incumbent, error)) *agents.Registry {
+	return registryWithGate(pool, auth.NewGate(identity.NewService(pool)), nil, resolveIncumbent)
+}
+
+func registryWithDraftBrain(pool *pgxpool.Pool, brain completer, resolveIncumbent func(context.Context) (overlay.Incumbent, error)) *agents.Registry {
 	if brain == nil {
-		return NewRegistry(pool)
+		return registryWithGate(pool, auth.NewGate(identity.NewService(pool)), nil, resolveIncumbent)
 	}
-	return registryWithGate(pool, auth.NewGate(identity.NewService(pool)), newReplyDrafter(pool, brain, nil))
+	return registryWithGate(pool, auth.NewGate(identity.NewService(pool)), newReplyDrafter(pool, brain, nil), resolveIncumbent)
 }
 
-func registryWithGate(pool *pgxpool.Pool, gate *auth.Gate, drafter activities.EmailDrafter) *agents.Registry {
+func registryWithGate(pool *pgxpool.Pool, gate *auth.Gate, drafter activities.EmailDrafter, resolveIncumbent func(context.Context) (overlay.Incumbent, error)) *agents.Registry {
 	// The Dispatcher is the datasource seam every core/slipping tool
 	// rides: a native-mode workspace lands on the composite SoR
 	// Provider exactly as before, an overlay-mode workspace's reads land
@@ -51,7 +60,7 @@ func registryWithGate(pool *pgxpool.Pool, gate *auth.Gate, drafter activities.Em
 	// fail-closed placeholder (no Redis), never charged. When a metered MCP
 	// force-fresh path lands, this becomes a Redis-backed NewOverlayMeter
 	// like the REST surface's, sharing the same per-workspace windows.
-	provider := NewDispatcher(NewProvider(pool), NewOverlayProvider(pool, failClosedOverlayMeter(), nil), pool)
+	provider := NewDispatcher(NewProvider(pool), NewOverlayProvider(pool, failClosedOverlayMeter(), resolveIncumbent), pool)
 	registry := agents.NewRegistry(approvalsAdapter{svc: approvals.NewService(pool)}, gate)
 	agents.RegisterCoreTools(registry, provider, provider, provider, fieldOwnership{pool: pool})
 	agents.RegisterReportTool(registry, reportToolRunner(newReportEngine(pool)))

--- a/backend/internal/compose/replydraft.go
+++ b/backend/internal/compose/replydraft.go
@@ -88,7 +88,7 @@ func WithReplyDraft(brain completer) Option {
 		drafter := newReplyDrafter(pool, brain, s.log)
 		s.replyDrafter = drafter
 		s.activitiesHandlers = s.WithEmailDrafter(drafter)
-		s.toolRegistry = registryWithDraftBrain(pool, brain)
+		s.toolRegistry = registryWithDraftBrain(pool, brain, s.resolveOverlayIncumbent(pool))
 	}
 }
 

--- a/backend/internal/compose/runnerservice.go
+++ b/backend/internal/compose/runnerservice.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/modules/agents/runner"
 	"github.com/gradionhq/margince/backend/internal/modules/identity"
+	"github.com/gradionhq/margince/backend/internal/modules/overlay"
 	kevents "github.com/gradionhq/margince/backend/internal/shared/kernel/events"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -47,12 +48,16 @@ type RunnerService struct {
 // NewRunnerService assembles the runner over the SAME governed registry
 // every other agent surface dispatches through — the two-directions
 // invariant is a property of this constructor: there is no other
-// registry to hand it.
-func NewRunnerService(pool *pgxpool.Pool, brain runner.Brain, draftBrain completer, retriever retrieval.Retriever, log *slog.Logger) *RunnerService {
+// registry to hand it. resolveIncumbent is the per-workspace live-incumbent
+// resolver the overlay write-back path reaches HubSpot through when a
+// Surface-B run's agent tool writes a record; the worker passes a FromEnv
+// vault-backed resolver, and nil degrades write-back to errNoWriteIncumbent
+// (reads and non-SoR tools are unaffected).
+func NewRunnerService(pool *pgxpool.Pool, brain runner.Brain, draftBrain completer, retriever retrieval.Retriever, log *slog.Logger, resolveIncumbent func(context.Context) (overlay.Incumbent, error)) *RunnerService {
 	return &RunnerService{
 		pool:      pool,
 		store:     runner.NewStore(pool),
-		runner:    runner.New(registryWithDraftBrain(pool, draftBrain), brain),
+		runner:    runner.New(registryWithDraftBrain(pool, draftBrain, resolveIncumbent), brain),
 		identity:  identity.NewService(pool),
 		retriever: retriever,
 		log:       log,

--- a/backend/internal/compose/server.go
+++ b/backend/internal/compose/server.go
@@ -291,7 +291,6 @@ func newServer(pool *pgxpool.Pool, log *slog.Logger, authH authHandlers, dealsH 
 		webhooksHandlers: newWebhookHandlers(pool, nil, log),
 		log:              log,
 		dealsStore:       deals.NewStore(pool),
-		toolRegistry:     NewRegistry(pool),
 		// Constructed unconditionally: WithKeyvault rebuilds
 		// overlayHandlers over this SAME instance rather than minting a
 		// second one, and contractAPI's Dispatcher spends force-fresh
@@ -308,6 +307,12 @@ func newServer(pool *pgxpool.Pool, log *slog.Logger, authH authHandlers, dealsH 
 	// boot-time SetOverlayIncumbentResolver reaches the same instance this
 	// field serves reads through.
 	srv.sorDispatch = NewDispatcher(NewProvider(pool), NewOverlayProvider(pool, srv.overlayMeter, nil), pool)
+	// toolRegistry backs ListAgentTools AND the MCP tool transport; it carries
+	// the vault-backed live-incumbent resolver so overlay write-back
+	// (Create/Update/Archive) actually reaches HubSpot from the agent surface.
+	// The closure captures srv and reads srv.vault LAZILY at request time, so
+	// building it here (before WithKeyvault installs the vault) is fine.
+	srv.toolRegistry = NewRegistryWithIncumbent(pool, srv.resolveOverlayIncumbent(pool))
 	// /me reports the workspace's system-of-record mode so the client can
 	// gate its list UI (an overlay mirror refuses sort/filter dials). The
 	// dispatch owns mode resolution; identity never imports overlay.
@@ -328,8 +333,27 @@ func newServer(pool *pgxpool.Pool, log *slog.Logger, authH authHandlers, dealsH 
 // or vault failure surfaces as an error (which FreshnessReader logs and
 // then degrades on, never faking authority).
 func (s *Server) resolveOverlayIncumbent(pool *pgxpool.Pool) func(context.Context) (overlay.Incumbent, error) {
+	// s.vault is read LAZILY (per call) because WithKeyvault installs it after
+	// newServer builds the dispatch — so delegate to OverlayIncumbentResolver
+	// at request time with whatever vault is then wired.
 	return func(ctx context.Context) (overlay.Incumbent, error) {
-		if s.vault == nil {
+		return OverlayIncumbentResolver(pool, s.vault)(ctx)
+	}
+}
+
+// OverlayIncumbentResolver builds the per-request live-incumbent resolver from
+// a KNOWN vault: for the request's workspace it reads the active
+// incumbent_connection and unseals its private-app token, returning a live
+// HubSpot adapter. A nil vault, no active connection (ErrNotFound), or a
+// non-HubSpot incumbent all degrade honestly to a nil adapter (force-fresh
+// falls back to the mirror; write-back answers errNoWriteIncumbent) — never a
+// faked authority. Only a genuine connection-read or vault failure surfaces as
+// an error. The api server passes its (lazily-wired) vault via
+// resolveOverlayIncumbent; the standalone MCP server and the worker's Surface-B
+// runner pass their own FromEnv vault so those agent surfaces reach write-back too.
+func OverlayIncumbentResolver(pool *pgxpool.Pool, vault keyvault.Vault) func(context.Context) (overlay.Incumbent, error) {
+	return func(ctx context.Context) (overlay.Incumbent, error) {
+		if vault == nil {
 			return nil, nil
 		}
 		conn, err := overlay.ActiveConnection(ctx, pool)
@@ -342,7 +366,7 @@ func (s *Server) resolveOverlayIncumbent(pool *pgxpool.Pool) func(context.Contex
 		if conn.Incumbent != "hubspot" {
 			return nil, nil
 		}
-		token, err := s.vault.Get(ctx, conn.Workspace, conn.CredentialRef)
+		token, err := vault.Get(ctx, conn.Workspace, conn.CredentialRef)
 		if err != nil {
 			return nil, err
 		}
@@ -356,7 +380,7 @@ func (s *Server) resolveOverlayIncumbent(pool *pgxpool.Pool) func(context.Contex
 // staging, and live-authority gate — one gate, two transports.
 func contractAPI(srv Server, pool *pgxpool.Pool, identitySvc *identity.Service) http.Handler {
 	gate := auth.NewGate(identitySvc)
-	registry := registryWithGate(pool, gate, srv.replyDrafter)
+	registry := registryWithGate(pool, gate, srv.replyDrafter, srv.resolveOverlayIncumbent(pool))
 	// The ADR-0055 admission layer and the MCP tool surface share one
 	// provider seam: agentGate's StageResolver dispatches per workspace
 	// exactly like the MCP registry's tools do — and the overlay-mode

--- a/backend/internal/modules/overlay/backfill_integration_test.go
+++ b/backend/internal/modules/overlay/backfill_integration_test.go
@@ -83,7 +83,7 @@ func (p *pagingCompanies) Update(context.Context, string, string, map[string]any
 	return Record{}, fmt.Errorf("pagingCompanies: Update is not fixtured")
 }
 
-func (p *pagingCompanies) Archive(context.Context, string, string) error {
+func (p *pagingCompanies) Archive(context.Context, string, string, time.Time) error {
 	return fmt.Errorf("pagingCompanies: Archive is not fixtured")
 }
 

--- a/backend/internal/modules/overlay/backfill_integration_test.go
+++ b/backend/internal/modules/overlay/backfill_integration_test.go
@@ -75,6 +75,17 @@ func (p *pagingCompanies) OwnerEmail(_ context.Context, _ string) (string, error
 }
 
 func (p *pagingCompanies) Owners(context.Context) ([]OwnerRef, error) { return nil, nil }
+func (p *pagingCompanies) Create(context.Context, string, map[string]any) (Record, error) {
+	return Record{}, fmt.Errorf("pagingCompanies: Create is not fixtured")
+}
+
+func (p *pagingCompanies) Update(context.Context, string, string, map[string]any, time.Time) (Record, error) {
+	return Record{}, fmt.Errorf("pagingCompanies: Update is not fixtured")
+}
+
+func (p *pagingCompanies) Archive(context.Context, string, string) error {
+	return fmt.Errorf("pagingCompanies: Archive is not fixtured")
+}
 
 // crashingMirrorSink wraps a REAL *MirrorStore, forcing the failAfter'th
 // Ingest attempt to fail while delegating every other call — including

--- a/backend/internal/modules/overlay/fake/adapter.go
+++ b/backend/internal/modules/overlay/fake/adapter.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/gradionhq/margince/backend/internal/modules/overlay"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 )
 
 // pageSize is the fixed Backfill/Modified page size the fake pages by.
@@ -26,7 +27,16 @@ type Adapter struct {
 	assocs    map[assocKey][]overlay.Assoc
 	owners    map[string]string
 	deletions map[string][]overlay.Deletion
+	// writeSeq drives deterministic Create ids and modified-at stamps for the
+	// write seam — a monotonic counter, never a real clock, so a test
+	// exercising write-back never flakes on wall-time (T11).
+	writeSeq int
 }
+
+// writeEpoch is the base time the fake stamps written records at, advanced one
+// second per write by writeSeq — deterministic and strictly increasing, so a
+// drift check (ModifiedAt vs baseline) has stable, orderable timestamps.
+var writeEpoch = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 
 // assocKey identifies one Associations(fromClass, fromID, toClass) query
 // — the same triple SeedAssoc and Associations key their lookup by.
@@ -247,6 +257,72 @@ func (a *Adapter) Owners(_ context.Context) ([]overlay.OwnerRef, error) {
 		out = append(out, overlay.OwnerRef{ExternalID: id, Email: a.owners[id]})
 	}
 	return out, nil
+}
+
+// Create appends a new record of canonicalClass from the field bag, stamping
+// a deterministic id and modified-at, and returns it — the write seam's
+// canonical-in/canonical-out contract. Records are keyed by canonical class
+// here (not the incumbent bucket the read feeds page by), matching the seam:
+// a real adapter maps the write back through mapRecord before it reaches the
+// mirror, so canonical is what a write returns.
+//
+//craft:ignore naked-any fields is the canonical field bag the seam carries; the any is inherent to the decoded shape
+func (a *Adapter) Create(_ context.Context, canonicalClass string, fields map[string]any) (overlay.Record, error) {
+	a.writeSeq++
+	rec := overlay.Record{
+		ExternalID:  fmt.Sprint(a.writeSeq),
+		ObjectClass: canonicalClass,
+		Fields:      fields,
+		ModifiedAt:  writeEpoch.Add(time.Duration(a.writeSeq) * time.Second),
+	}
+	a.records[canonicalClass] = append(a.records[canonicalClass], rec)
+	return rec, nil
+}
+
+// Update applies the drift check (ModifiedAt vs baseline — incumbent-wins,
+// AC-OV-4), then merges the patch fields onto the stored record and re-stamps
+// its modified-at. A patch of an unknown record is an error; a caller passing
+// no fields gets the record unchanged.
+//
+//craft:ignore naked-any fields is the canonical patch bag the seam carries; the any is inherent to the decoded shape
+func (a *Adapter) Update(_ context.Context, canonicalClass, externalID string, fields map[string]any, baseline time.Time) (overlay.Record, error) {
+	recs := a.records[canonicalClass]
+	for i := range recs {
+		if recs[i].ExternalID != externalID {
+			continue
+		}
+		if len(fields) == 0 {
+			return recs[i], nil
+		}
+		if recs[i].ModifiedAt.After(baseline) {
+			return overlay.Record{}, apperrors.ErrVersionSkew
+		}
+		merged := make(map[string]any, len(recs[i].Fields)+len(fields))
+		for k, v := range recs[i].Fields {
+			merged[k] = v
+		}
+		for k, v := range fields {
+			merged[k] = v
+		}
+		a.writeSeq++
+		recs[i].Fields = merged
+		recs[i].ModifiedAt = writeEpoch.Add(time.Duration(a.writeSeq) * time.Second)
+		return recs[i], nil
+	}
+	return overlay.Record{}, fmt.Errorf("fake: no %s record with external id %s to update", canonicalClass, externalID)
+}
+
+// Archive removes canonicalClass's record for externalID; an unknown record
+// is an error rather than a silent no-op.
+func (a *Adapter) Archive(_ context.Context, canonicalClass, externalID string) error {
+	recs := a.records[canonicalClass]
+	for i := range recs {
+		if recs[i].ExternalID == externalID {
+			a.records[canonicalClass] = append(recs[:i], recs[i+1:]...)
+			return nil
+		}
+	}
+	return fmt.Errorf("fake: no %s record with external id %s to archive", canonicalClass, externalID)
 }
 
 // parseCursor decodes a Backfill/Modified cursor to its index offset;

--- a/backend/internal/modules/overlay/fake/adapter.go
+++ b/backend/internal/modules/overlay/fake/adapter.go
@@ -260,17 +260,25 @@ func (a *Adapter) Owners(_ context.Context) ([]overlay.OwnerRef, error) {
 }
 
 // Create appends a new record of canonicalClass from the field bag, stamping
-// a deterministic id and modified-at, and returns it — the write seam's
-// canonical-in/canonical-out contract. Records are keyed by canonical class
-// here (not the incumbent bucket the read feeds page by), matching the seam:
-// a real adapter maps the write back through mapRecord before it reaches the
-// mirror, so canonical is what a write returns.
+// a collision-free id and a strictly-increasing modified-at, and returns it —
+// the write seam's canonical-in/canonical-out contract. An empty field bag is
+// rejected, matching the real Incumbent.Create contract (a create must carry
+// something writable), so a fake-backed test can never pass on a write the
+// production adapter would reject.
+//
+// Records are keyed by CANONICAL class here (not the incumbent bucket the read
+// feed pages by): the fake cannot know the incumbent class mapping (that lives
+// in the hubspot adapter, which package fake cannot import), so its write
+// methods are canonical-keyed. Write-back integration that needs the incumbent
+// bucketing uses a purpose-built double instead of this fake.
 //
 //craft:ignore naked-any fields is the canonical field bag the seam carries; the any is inherent to the decoded shape
 func (a *Adapter) Create(_ context.Context, canonicalClass string, fields map[string]any) (overlay.Record, error) {
-	a.writeSeq++
+	if len(fields) == 0 {
+		return overlay.Record{}, fmt.Errorf("fake: cannot create a %s with no fields", canonicalClass)
+	}
 	rec := overlay.Record{
-		ExternalID:  fmt.Sprint(a.writeSeq),
+		ExternalID:  a.nextWriteID(),
 		ObjectClass: canonicalClass,
 		Fields:      fields,
 		ModifiedAt:  writeEpoch.Add(time.Duration(a.writeSeq) * time.Second),
@@ -279,10 +287,30 @@ func (a *Adapter) Create(_ context.Context, canonicalClass string, fields map[st
 	return rec, nil
 }
 
+// nextWriteID advances writeSeq to an id no existing record (seeded or
+// written, in any bucket) already uses, so a Create can never collide with a
+// seeded id and be mistaken for the existing row.
+func (a *Adapter) nextWriteID() string {
+	used := make(map[string]bool)
+	for _, recs := range a.records {
+		for _, r := range recs {
+			used[r.ExternalID] = true
+		}
+	}
+	for {
+		a.writeSeq++
+		if id := fmt.Sprint(a.writeSeq); !used[id] {
+			return id
+		}
+	}
+}
+
 // Update applies the drift check (ModifiedAt vs baseline — incumbent-wins,
-// AC-OV-4), then merges the patch fields onto the stored record and re-stamps
-// its modified-at. A patch of an unknown record is an error; a caller passing
-// no fields gets the record unchanged.
+// AC-OV-4), then merges the patch fields onto the stored record and advances
+// its modified-at PAST both the sequence epoch and the record's current stamp
+// (so a re-mirror is never rejected by the mirror's staleness guard for moving
+// the baseline backward). A patch of an unknown record is an error; a caller
+// passing no fields gets the record unchanged.
 //
 //craft:ignore naked-any fields is the canonical patch bag the seam carries; the any is inherent to the decoded shape
 func (a *Adapter) Update(_ context.Context, canonicalClass, externalID string, fields map[string]any, baseline time.Time) (overlay.Record, error) {
@@ -305,19 +333,28 @@ func (a *Adapter) Update(_ context.Context, canonicalClass, externalID string, f
 			merged[k] = v
 		}
 		a.writeSeq++
+		next := writeEpoch.Add(time.Duration(a.writeSeq) * time.Second)
+		if !next.After(recs[i].ModifiedAt) {
+			next = recs[i].ModifiedAt.Add(time.Nanosecond)
+		}
 		recs[i].Fields = merged
-		recs[i].ModifiedAt = writeEpoch.Add(time.Duration(a.writeSeq) * time.Second)
+		recs[i].ModifiedAt = next
 		return recs[i], nil
 	}
 	return overlay.Record{}, fmt.Errorf("fake: no %s record with external id %s to update", canonicalClass, externalID)
 }
 
-// Archive removes canonicalClass's record for externalID; an unknown record
-// is an error rather than a silent no-op.
-func (a *Adapter) Archive(_ context.Context, canonicalClass, externalID string) error {
+// Archive removes canonicalClass's record for externalID after the same
+// baseline drift check the real seam applies (incumbent-wins): a record newer
+// than baseline is not deleted (ErrVersionSkew). An unknown record is an error
+// rather than a silent no-op.
+func (a *Adapter) Archive(_ context.Context, canonicalClass, externalID string, baseline time.Time) error {
 	recs := a.records[canonicalClass]
 	for i := range recs {
 		if recs[i].ExternalID == externalID {
+			if recs[i].ModifiedAt.After(baseline) {
+				return apperrors.ErrVersionSkew
+			}
 			a.records[canonicalClass] = append(recs[:i], recs[i+1:]...)
 			return nil
 		}

--- a/backend/internal/modules/overlay/fake/adapter_test.go
+++ b/backend/internal/modules/overlay/fake/adapter_test.go
@@ -192,3 +192,58 @@ func TestFakeBackfillRejectsAMalformedCursor(t *testing.T) {
 		t.Fatal("Backfill: want an error for a malformed cursor, got nil")
 	}
 }
+
+// TestFakeWriteBackRoundTrip exercises the fake's write seam (Create →
+// Update → Archive) end-to-end, plus the drift-check refusal, so the fake is
+// a faithful in-memory Incumbent for write-back tests.
+func TestFakeWriteBackRoundTrip(t *testing.T) {
+	f := fake.New()
+	ctx := context.Background()
+
+	created, err := f.Create(ctx, "person", map[string]any{"first_name": "Ada"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if created.ExternalID == "" || created.ObjectClass != "person" {
+		t.Fatalf("Create returned %+v, want a stamped person record", created)
+	}
+	if created.Fields["first_name"] != "Ada" {
+		t.Errorf("Create fields = %+v, want first_name=Ada", created.Fields)
+	}
+
+	// A patch older than the stored record's ModifiedAt is refused
+	// (incumbent-wins drift check).
+	if _, err := f.Update(ctx, "person", created.ExternalID, map[string]any{"first_name": "Ada2"}, created.ModifiedAt.Add(-time.Hour)); err == nil {
+		t.Error("Update with a stale baseline must be refused (version skew)")
+	}
+
+	// A patch at or after the record's baseline merges and re-stamps.
+	updated, err := f.Update(ctx, "person", created.ExternalID, map[string]any{"first_name": "Ada2"}, created.ModifiedAt)
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if updated.Fields["first_name"] != "Ada2" {
+		t.Errorf("Update fields = %+v, want first_name=Ada2", updated.Fields)
+	}
+
+	// An empty patch returns the record unchanged.
+	same, err := f.Update(ctx, "person", created.ExternalID, nil, updated.ModifiedAt)
+	if err != nil {
+		t.Fatalf("no-op Update: %v", err)
+	}
+	if same.Fields["first_name"] != "Ada2" {
+		t.Errorf("no-op Update should return the record unchanged, got %+v", same.Fields)
+	}
+
+	if err := f.Archive(ctx, "person", created.ExternalID); err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+	// Archiving a now-absent record is an error, never a silent no-op.
+	if err := f.Archive(ctx, "person", created.ExternalID); err == nil {
+		t.Error("Archive of an already-removed record must error")
+	}
+	// Updating an unknown record is an error too.
+	if _, err := f.Update(ctx, "person", "nope", map[string]any{"first_name": "x"}, fixedModified); err == nil {
+		t.Error("Update of an unknown record must error")
+	}
+}

--- a/backend/internal/modules/overlay/fake/adapter_test.go
+++ b/backend/internal/modules/overlay/fake/adapter_test.go
@@ -5,12 +5,14 @@ package fake_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
 
 	"github.com/gradionhq/margince/backend/internal/modules/overlay"
 	"github.com/gradionhq/margince/backend/internal/modules/overlay/fake"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 )
 
 // fixedModified is a deterministic ModifiedAt for fixtures that don't
@@ -235,11 +237,16 @@ func TestFakeWriteBackRoundTrip(t *testing.T) {
 		t.Errorf("no-op Update should return the record unchanged, got %+v", same.Fields)
 	}
 
-	if err := f.Archive(ctx, "person", created.ExternalID); err != nil {
+	// Archiving with a baseline older than the record is refused (drift).
+	stale := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	if err := f.Archive(ctx, "person", created.ExternalID, stale); !errors.Is(err, apperrors.ErrVersionSkew) {
+		t.Errorf("Archive with a stale baseline: err = %v, want ErrVersionSkew", err)
+	}
+	if err := f.Archive(ctx, "person", created.ExternalID, same.ModifiedAt); err != nil {
 		t.Fatalf("Archive: %v", err)
 	}
 	// Archiving a now-absent record is an error, never a silent no-op.
-	if err := f.Archive(ctx, "person", created.ExternalID); err == nil {
+	if err := f.Archive(ctx, "person", created.ExternalID, same.ModifiedAt); err == nil {
 		t.Error("Archive of an already-removed record must error")
 	}
 	// Updating an unknown record is an error too.

--- a/backend/internal/modules/overlay/freshness_integration_test.go
+++ b/backend/internal/modules/overlay/freshness_integration_test.go
@@ -76,6 +76,17 @@ func (s *stubIncumbent) OwnerEmail(context.Context, string) (string, error) {
 }
 
 func (s *stubIncumbent) Owners(context.Context) ([]OwnerRef, error) { return nil, nil }
+func (s *stubIncumbent) Create(context.Context, string, map[string]any) (Record, error) {
+	return Record{}, fmt.Errorf("stubIncumbent: Create is not fixtured")
+}
+
+func (s *stubIncumbent) Update(context.Context, string, string, map[string]any, time.Time) (Record, error) {
+	return Record{}, fmt.Errorf("stubIncumbent: Update is not fixtured")
+}
+
+func (s *stubIncumbent) Archive(context.Context, string, string) error {
+	return fmt.Errorf("stubIncumbent: Archive is not fixtured")
+}
 
 // Get answers the one fixtured record — proving Read reached the LIVE
 // incumbent, not the mirror — and counts the call so the shed-path test

--- a/backend/internal/modules/overlay/freshness_integration_test.go
+++ b/backend/internal/modules/overlay/freshness_integration_test.go
@@ -33,9 +33,10 @@ import (
 // overlay itself, needed for its unexported helpers (testWorkspaceCtx,
 // externalIDToUUID, noOwnerEmails) — cannot import it back without an
 // import cycle. Only Get is ever exercised by FreshnessReader.Read; the
-// other five Incumbent methods are declared unsupported so a test that
-// accidentally calls them fails loudly rather than returning a
-// fabricated answer.
+// other Incumbent methods (Backfill/Modified/Deletions/Associations/
+// OwnerEmail/Owners + the Create/Update/Archive write seam) are declared
+// unsupported so a test that accidentally calls them fails loudly rather
+// than returning a fabricated answer.
 //
 // stubIncumbent.objectClass is deliberately the INCUMBENT class (e.g.
 // "contacts"), never the canonical Margince name (e.g. "person") — this
@@ -84,7 +85,7 @@ func (s *stubIncumbent) Update(context.Context, string, string, map[string]any, 
 	return Record{}, fmt.Errorf("stubIncumbent: Update is not fixtured")
 }
 
-func (s *stubIncumbent) Archive(context.Context, string, string) error {
+func (s *stubIncumbent) Archive(context.Context, string, string, time.Time) error {
 	return fmt.Errorf("stubIncumbent: Archive is not fixtured")
 }
 

--- a/backend/internal/modules/overlay/hubspot/adapter.go
+++ b/backend/internal/modules/overlay/hubspot/adapter.go
@@ -411,19 +411,7 @@ func mapRecord(m overlay.ObjectMapping, objectClass string, raw ObjectRecord) (o
 
 	modifiedAt, err := parseWatermark(out["last_synced_at"])
 	if err != nil {
-		// A write-back create/update response may carry the object's top-level
-		// updatedAt without echoing the baseline PROPERTY (contacts'
-		// lastmodifieddate, …) in its properties map. Fall back to updatedAt so
-		// the write response maps without a second fetch. A read always requests
-		// the baseline property (propertyNames), so this fallback only fires on
-		// the write path — a read with a genuinely missing watermark still surfaces.
-		if raw.UpdatedAt == "" {
-			return overlay.Record{}, fmt.Errorf("hubspot: %s record %s: %w", objectClass, raw.ID, err)
-		}
-		modifiedAt, err = time.Parse(time.RFC3339Nano, raw.UpdatedAt)
-		if err != nil {
-			return overlay.Record{}, fmt.Errorf("hubspot: %s record %s: parsing updatedAt %q: %w", objectClass, raw.ID, raw.UpdatedAt, err)
-		}
+		return overlay.Record{}, fmt.Errorf("hubspot: %s record %s: %w", objectClass, raw.ID, err)
 	}
 
 	ownerID, _ := out["owner_id"].(string)

--- a/backend/internal/modules/overlay/hubspot/adapter.go
+++ b/backend/internal/modules/overlay/hubspot/adapter.go
@@ -411,7 +411,19 @@ func mapRecord(m overlay.ObjectMapping, objectClass string, raw ObjectRecord) (o
 
 	modifiedAt, err := parseWatermark(out["last_synced_at"])
 	if err != nil {
-		return overlay.Record{}, fmt.Errorf("hubspot: %s record %s: %w", objectClass, raw.ID, err)
+		// A write-back create/update response may carry the object's top-level
+		// updatedAt without echoing the baseline PROPERTY (contacts'
+		// lastmodifieddate, …) in its properties map. Fall back to updatedAt so
+		// the write response maps without a second fetch. A read always requests
+		// the baseline property (propertyNames), so this fallback only fires on
+		// the write path — a read with a genuinely missing watermark still surfaces.
+		if raw.UpdatedAt == "" {
+			return overlay.Record{}, fmt.Errorf("hubspot: %s record %s: %w", objectClass, raw.ID, err)
+		}
+		modifiedAt, err = time.Parse(time.RFC3339Nano, raw.UpdatedAt)
+		if err != nil {
+			return overlay.Record{}, fmt.Errorf("hubspot: %s record %s: parsing updatedAt %q: %w", objectClass, raw.ID, raw.UpdatedAt, err)
+		}
 	}
 
 	ownerID, _ := out["owner_id"].(string)

--- a/backend/internal/modules/overlay/hubspot/adapter_writes.go
+++ b/backend/internal/modules/overlay/hubspot/adapter_writes.go
@@ -28,7 +28,7 @@ import (
 //
 //craft:ignore naked-any fields is the JSON-decoded canonical bag from the datasource seam; the any is inherent to the decoded shape
 func (a *Adapter) Create(ctx context.Context, canonicalClass string, fields map[string]any) (overlay.Record, error) {
-	mw, err := mapWrite(canonicalClass, fields)
+	mw, err := mapWrite(canonicalClass, fields, false)
 	if err != nil {
 		return overlay.Record{}, err
 	}
@@ -58,21 +58,30 @@ func (a *Adapter) Create(ctx context.Context, canonicalClass string, fields map[
 //
 //craft:ignore naked-any fields is the JSON-decoded canonical patch from the datasource seam; the any is inherent to the decoded shape
 func (a *Adapter) Update(ctx context.Context, canonicalClass, externalID string, fields map[string]any, baseline time.Time) (overlay.Record, error) {
-	mw, err := mapWrite(canonicalClass, fields)
+	mw, err := mapWrite(canonicalClass, fields, true)
 	if err != nil {
 		return overlay.Record{}, err
 	}
-	// The current incumbent state is both the drift anchor and the record a
-	// read-only-only patch returns unchanged.
-	current, err := a.Get(ctx, mw.ObjectClass, externalID)
-	if err != nil {
-		return overlay.Record{}, err
+	// An activity's engagement class is fixed by its mirror id's "<class>:"
+	// prefix (OVA-MAP-7); a patch that carried a changed/inconsistent kind
+	// would make mapWrite target a different class than the record's identity.
+	// Refuse that mismatch rather than route a write to meetings/calls:123.
+	if canonicalClass == activityTarget {
+		want, err := incumbentClassFor(canonicalClass, externalID)
+		if err != nil {
+			return overlay.Record{}, err
+		}
+		if mw.ObjectClass != want {
+			return overlay.Record{}, fmt.Errorf("overlay: activity %s is a %s; its kind cannot be changed to a %s on update", externalID, want, mw.ObjectClass)
+		}
 	}
 	if len(mw.Props) == 0 {
-		return current, nil
+		// A read-only-only patch writes nothing; return the current record.
+		// No drift check — a no-op cannot lose a concurrent edit.
+		return a.Get(ctx, mw.ObjectClass, externalID)
 	}
-	if current.ModifiedAt.After(baseline) {
-		return overlay.Record{}, apperrors.ErrVersionSkew
+	if err := a.driftCheck(ctx, mw.ObjectClass, externalID, baseline); err != nil {
+		return overlay.Record{}, err
 	}
 	if _, err := a.client.UpdateObject(ctx, mw.ObjectClass, incumbentActivityID(mw.ObjectClass, externalID), mw.Props); err != nil {
 		return overlay.Record{}, err
@@ -83,16 +92,36 @@ func (a *Adapter) Update(ctx context.Context, canonicalClass, externalID string,
 	return a.Get(ctx, mw.ObjectClass, externalID)
 }
 
-// Archive removes a record from HubSpot via its own archive/delete. For an
-// activity the engagement class is recovered from the mirror id's "<class>:"
-// prefix (OVA-MAP-7); for the other object types it is the single incumbent
-// class the canonical type maps to.
-func (a *Adapter) Archive(ctx context.Context, canonicalClass, externalID string) error {
+// Archive removes a record from HubSpot via its own archive/delete, after the
+// SAME stored-baseline drift check Update applies: a stale mirror must not
+// delete a record a third party changed since it was mirrored (AC-OV-4). For
+// an activity the engagement class is recovered from the mirror id's
+// "<class>:" prefix (OVA-MAP-7); for the other object types it is the single
+// incumbent class the canonical type maps to.
+func (a *Adapter) Archive(ctx context.Context, canonicalClass, externalID string, baseline time.Time) error {
 	hsClass, err := incumbentClassFor(canonicalClass, externalID)
 	if err != nil {
 		return err
 	}
+	if err := a.driftCheck(ctx, hsClass, externalID, baseline); err != nil {
+		return err
+	}
 	return a.client.ArchiveObject(ctx, hsClass, incumbentActivityID(hsClass, externalID))
+}
+
+// driftCheck reads the incumbent's current record and refuses (ErrVersionSkew)
+// if it is newer than baseline — the stored-baseline lost-update guard shared
+// by Update and Archive. It is best-effort (non-atomic) per the Incumbent
+// contract: HubSpot v3 has no If-Match primitive.
+func (a *Adapter) driftCheck(ctx context.Context, hsClass, externalID string, baseline time.Time) error {
+	current, err := a.Get(ctx, hsClass, externalID)
+	if err != nil {
+		return err
+	}
+	if current.ModifiedAt.After(baseline) {
+		return apperrors.ErrVersionSkew
+	}
+	return nil
 }
 
 // incumbentClassFor resolves the HubSpot object class a canonical write

--- a/backend/internal/modules/overlay/hubspot/adapter_writes.go
+++ b/backend/internal/modules/overlay/hubspot/adapter_writes.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package hubspot
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/modules/overlay"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+)
+
+// This file is the adapter's write half (the Incumbent write seam, design.md
+// §4.5): canonical→HubSpot projection (mapWrite) + the transport in writes.go,
+// with the write-back drift check that makes an overlay write incumbent-first
+// (AC-OV-4). It is the inverse of the read methods in adapter.go and returns
+// canonical overlay.Records, mapped back through the same mapRecord the read
+// path uses — so the mirror ingests a write's result exactly as it ingests a
+// sync read.
+
+// Create writes a new record of canonicalClass to HubSpot from the canonical
+// field bag and returns the created record mapped back to canonical. A write
+// whose fields are all read-only/derived (empty projection) cannot create an
+// incumbent object — that is an honest error, never a POST of a blank record.
+//
+//craft:ignore naked-any fields is the JSON-decoded canonical bag from the datasource seam; the any is inherent to the decoded shape
+func (a *Adapter) Create(ctx context.Context, canonicalClass string, fields map[string]any) (overlay.Record, error) {
+	mw, err := mapWrite(canonicalClass, fields)
+	if err != nil {
+		return overlay.Record{}, err
+	}
+	if len(mw.Props) == 0 {
+		return overlay.Record{}, fmt.Errorf("overlay: cannot create a %s in HubSpot — every supplied field is read-only or derived (nothing to write)", canonicalClass)
+	}
+	created, err := a.client.CreateObject(ctx, mw.ObjectClass, mw.Props)
+	if err != nil {
+		return overlay.Record{}, err
+	}
+	return a.mapWriteResult(ctx, mw.ObjectClass, created)
+}
+
+// Update applies a canonical patch to an existing record after the
+// stored-baseline drift check: if HubSpot's CURRENT record is newer than the
+// baseline captured at mirror-read, a third party (or the HubSpot UI) changed
+// it since we mirrored, so the write is refused with ErrVersionSkew and
+// NOTHING is PATCHed (AC-OV-4, incumbent-wins) — never a blind overwrite. A
+// patch of only read-only fields writes nothing and returns the current
+// record unchanged. externalID is the mirror id (namespaced for an activity,
+// OVA-MAP-7).
+//
+//craft:ignore naked-any fields is the JSON-decoded canonical patch from the datasource seam; the any is inherent to the decoded shape
+func (a *Adapter) Update(ctx context.Context, canonicalClass, externalID string, fields map[string]any, baseline time.Time) (overlay.Record, error) {
+	mw, err := mapWrite(canonicalClass, fields)
+	if err != nil {
+		return overlay.Record{}, err
+	}
+	// The current incumbent state is both the drift anchor and the record a
+	// read-only-only patch returns unchanged.
+	current, err := a.Get(ctx, mw.ObjectClass, externalID)
+	if err != nil {
+		return overlay.Record{}, err
+	}
+	if len(mw.Props) == 0 {
+		return current, nil
+	}
+	if current.ModifiedAt.After(baseline) {
+		return overlay.Record{}, apperrors.ErrVersionSkew
+	}
+	updated, err := a.client.UpdateObject(ctx, mw.ObjectClass, incumbentActivityID(mw.ObjectClass, externalID), mw.Props)
+	if err != nil {
+		return overlay.Record{}, err
+	}
+	return a.mapWriteResult(ctx, mw.ObjectClass, updated)
+}
+
+// Archive removes a record from HubSpot via its own archive/delete. For an
+// activity the engagement class is recovered from the mirror id's "<class>:"
+// prefix (OVA-MAP-7); for the other object types it is the single incumbent
+// class the canonical type maps to.
+func (a *Adapter) Archive(ctx context.Context, canonicalClass, externalID string) error {
+	hsClass, err := incumbentClassFor(canonicalClass, externalID)
+	if err != nil {
+		return err
+	}
+	return a.client.ArchiveObject(ctx, hsClass, incumbentActivityID(hsClass, externalID))
+}
+
+// mapWriteResult maps a create/update response object back to a canonical
+// overlay.Record and enriches a lead's association-derived fields, so a
+// write's result is the SAME shape a sync read produces — what the mirror
+// ingests as the record's post-write state.
+func (a *Adapter) mapWriteResult(ctx context.Context, hsClass string, obj ObjectRecord) (overlay.Record, error) {
+	m, err := mappingFor(hsClass)
+	if err != nil {
+		return overlay.Record{}, err
+	}
+	rec, err := mapRecord(m, hsClass, obj)
+	if err != nil {
+		return overlay.Record{}, err
+	}
+	enriched, err := a.enrichLeads(ctx, hsClass, []overlay.Record{rec})
+	if err != nil {
+		return overlay.Record{}, err
+	}
+	return enriched[0], nil
+}
+
+// incumbentClassFor resolves the HubSpot object class a canonical write
+// targets. An activity's mirror id namespaces its source engagement class
+// ("calls:123"); every other canonical type maps to exactly one incumbent
+// class (IncumbentClassesFor). A canonical type with no mapping, or an
+// activity id with no valid class prefix, is an honest error rather than a
+// guessed endpoint.
+func incumbentClassFor(canonicalClass, externalID string) (string, error) {
+	if canonicalClass == activityTarget {
+		class, _, found := strings.Cut(externalID, ":")
+		if !found || !isEngagementClass(class) {
+			return "", fmt.Errorf("overlay: activity mirror id %q carries no valid engagement class prefix (OVA-MAP-7)", externalID)
+		}
+		return class, nil
+	}
+	classes, ok := IncumbentClassesFor(canonicalClass)
+	if !ok || len(classes) != 1 {
+		return "", fmt.Errorf("overlay: canonical class %q does not map to exactly one HubSpot write class", canonicalClass)
+	}
+	return classes[0], nil
+}

--- a/backend/internal/modules/overlay/hubspot/adapter_writes.go
+++ b/backend/internal/modules/overlay/hubspot/adapter_writes.go
@@ -39,7 +39,12 @@ func (a *Adapter) Create(ctx context.Context, canonicalClass string, fields map[
 	if err != nil {
 		return overlay.Record{}, err
 	}
-	return a.mapWriteResult(ctx, mw.ObjectClass, created)
+	// Re-read the created record through the SAME path a sync read uses
+	// (a.Get requests the baseline watermark property), so the mirrored
+	// record's ModifiedAt is the object-specific baseline (lastmodifieddate /
+	// hs_lastmodifieddate / hs_timestamp) the drift check compares against —
+	// never HubSpot's top-level updatedAt, which can diverge from it.
+	return a.Get(ctx, mw.ObjectClass, mirrorActivityExternalID(mw.ObjectClass, created.ID))
 }
 
 // Update applies a canonical patch to an existing record after the
@@ -69,11 +74,13 @@ func (a *Adapter) Update(ctx context.Context, canonicalClass, externalID string,
 	if current.ModifiedAt.After(baseline) {
 		return overlay.Record{}, apperrors.ErrVersionSkew
 	}
-	updated, err := a.client.UpdateObject(ctx, mw.ObjectClass, incumbentActivityID(mw.ObjectClass, externalID), mw.Props)
-	if err != nil {
+	if _, err := a.client.UpdateObject(ctx, mw.ObjectClass, incumbentActivityID(mw.ObjectClass, externalID), mw.Props); err != nil {
 		return overlay.Record{}, err
 	}
-	return a.mapWriteResult(ctx, mw.ObjectClass, updated)
+	// Re-read through the sync-read path so the mirrored ModifiedAt is the
+	// baseline watermark property, consistent with reads and the drift check
+	// (see Create's note).
+	return a.Get(ctx, mw.ObjectClass, externalID)
 }
 
 // Archive removes a record from HubSpot via its own archive/delete. For an
@@ -86,26 +93,6 @@ func (a *Adapter) Archive(ctx context.Context, canonicalClass, externalID string
 		return err
 	}
 	return a.client.ArchiveObject(ctx, hsClass, incumbentActivityID(hsClass, externalID))
-}
-
-// mapWriteResult maps a create/update response object back to a canonical
-// overlay.Record and enriches a lead's association-derived fields, so a
-// write's result is the SAME shape a sync read produces — what the mirror
-// ingests as the record's post-write state.
-func (a *Adapter) mapWriteResult(ctx context.Context, hsClass string, obj ObjectRecord) (overlay.Record, error) {
-	m, err := mappingFor(hsClass)
-	if err != nil {
-		return overlay.Record{}, err
-	}
-	rec, err := mapRecord(m, hsClass, obj)
-	if err != nil {
-		return overlay.Record{}, err
-	}
-	enriched, err := a.enrichLeads(ctx, hsClass, []overlay.Record{rec})
-	if err != nil {
-		return overlay.Record{}, err
-	}
-	return enriched[0], nil
 }
 
 // incumbentClassFor resolves the HubSpot object class a canonical write

--- a/backend/internal/modules/overlay/hubspot/adapter_writes_test.go
+++ b/backend/internal/modules/overlay/hubspot/adapter_writes_test.go
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package hubspot_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/modules/overlay/hubspot"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+)
+
+// TestAdapterCreatePostsMappedProps: a canonical person Create projects onto
+// contacts firstname/lastname (OVA-MAP-W1), POSTs to /crm/v3/objects/contacts,
+// and maps the created record back to canonical.
+func TestAdapterCreatePostsMappedProps(t *testing.T) {
+	var gotBody writeRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/crm/v3/objects/contacts" {
+			t.Fatalf("got %s %s, want POST /crm/v3/objects/contacts", r.Method, r.URL.Path)
+		}
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"555","properties":{"hs_object_id":"555",
+			"firstname":"Ada","lastname":"Lovelace","lastmodifieddate":"2026-05-01T00:00:00Z"}}`))
+	}))
+	defer srv.Close()
+
+	adapter := hubspot.NewAdapter(hubspot.NewClient("us", "tok", hubspot.WithBaseURL(srv.URL)))
+	rec, err := adapter.Create(t.Context(), "person", map[string]any{
+		"first_name": "Ada", "last_name": "Lovelace",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if gotBody.Properties["firstname"] != "Ada" || gotBody.Properties["lastname"] != "Lovelace" {
+		t.Errorf("POSTed properties = %#v, want firstname=Ada lastname=Lovelace", gotBody.Properties)
+	}
+	if rec.ExternalID != "555" || rec.Fields["first_name"] != "Ada" {
+		t.Errorf("mapped record = %+v, want ExternalID 555 + first_name Ada", rec)
+	}
+}
+
+// TestAdapterUpdateRefusesOnBaselineDrift (AC-OV-4): when the incumbent's
+// current record is newer than the stored baseline, the write is refused with
+// ErrVersionSkew and NO PATCH is issued — the incumbent wins, never a blind
+// overwrite.
+func TestAdapterUpdateRefusesOnBaselineDrift(t *testing.T) {
+	var patched bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/crm/v3/objects/contacts/batch/read":
+			w.Header().Set("Content-Type", "application/json")
+			// Current incumbent lastmodifieddate is AFTER the caller's baseline.
+			_, _ = w.Write([]byte(`{"results":[{"id":"555","properties":{"hs_object_id":"555",
+				"lastmodifieddate":"2026-06-01T00:00:00Z"}}]}`))
+		case r.Method == http.MethodPatch:
+			patched = true
+			t.Error("PATCH must not be issued when the baseline has drifted")
+		default:
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	adapter := hubspot.NewAdapter(hubspot.NewClient("us", "tok", hubspot.WithBaseURL(srv.URL)))
+	baseline := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC) // older than the current 2026-06-01
+	_, err := adapter.Update(t.Context(), "person", "555", map[string]any{"first_name": "Ada2"}, baseline)
+	if !errors.Is(err, apperrors.ErrVersionSkew) {
+		t.Fatalf("Update on drift: err = %v, want ErrVersionSkew", err)
+	}
+	if patched {
+		t.Error("a drifted update must not PATCH")
+	}
+}
+
+// TestAdapterUpdateAppliesWhenBaselineFresh: baseline equals the incumbent's
+// current lastmodifieddate (no third-party change) → the PATCH goes through
+// with the mapped changed property.
+func TestAdapterUpdateAppliesWhenBaselineFresh(t *testing.T) {
+	var patchBody writeRequest
+	baseline := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/crm/v3/objects/contacts/batch/read":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"results":[{"id":"555","properties":{"hs_object_id":"555",
+				"lastmodifieddate":"2026-05-01T00:00:00Z"}}]}`))
+		case r.Method == http.MethodPatch && r.URL.Path == "/crm/v3/objects/contacts/555":
+			_ = json.NewDecoder(r.Body).Decode(&patchBody)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"555","properties":{"hs_object_id":"555",
+				"firstname":"Ada2","lastmodifieddate":"2026-06-02T00:00:00Z"}}`))
+		default:
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	adapter := hubspot.NewAdapter(hubspot.NewClient("us", "tok", hubspot.WithBaseURL(srv.URL)))
+	rec, err := adapter.Update(t.Context(), "person", "555", map[string]any{"first_name": "Ada2"}, baseline)
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if patchBody.Properties["firstname"] != "Ada2" {
+		t.Errorf("PATCHed properties = %#v, want firstname=Ada2", patchBody.Properties)
+	}
+	if rec.Fields["first_name"] != "Ada2" {
+		t.Errorf("mapped record first_name = %v, want Ada2", rec.Fields["first_name"])
+	}
+}
+
+// TestAdapterArchiveDeletes: Archive resolves the incumbent class and DELETEs
+// the object.
+func TestAdapterArchiveDeletes(t *testing.T) {
+	var deleted string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			deleted = r.URL.Path
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+	}))
+	defer srv.Close()
+
+	adapter := hubspot.NewAdapter(hubspot.NewClient("us", "tok", hubspot.WithBaseURL(srv.URL)))
+	if err := adapter.Archive(t.Context(), "person", "555"); err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+	if deleted != "/crm/v3/objects/contacts/555" {
+		t.Errorf("DELETE path = %q, want /crm/v3/objects/contacts/555", deleted)
+	}
+}
+
+// TestAdapterArchiveActivityResolvesClassFromNamespacedID: an activity's
+// mirror id is "<class>:<id>" (OVA-MAP-7); Archive recovers the engagement
+// class from the prefix and DELETEs the raw id on that class's endpoint.
+func TestAdapterArchiveActivityResolvesClassFromNamespacedID(t *testing.T) {
+	var deleted string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			deleted = r.URL.Path
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+	}))
+	defer srv.Close()
+
+	adapter := hubspot.NewAdapter(hubspot.NewClient("us", "tok", hubspot.WithBaseURL(srv.URL)))
+	if err := adapter.Archive(t.Context(), "activity", "calls:123"); err != nil {
+		t.Fatalf("Archive activity: %v", err)
+	}
+	if !strings.HasSuffix(deleted, "/crm/v3/objects/calls/123") {
+		t.Errorf("DELETE path = %q, want .../crm/v3/objects/calls/123", deleted)
+	}
+}
+
+// writeRequest is the v3 create/update request envelope, for asserting the
+// properties the adapter POSTed/PATCHed.
+type writeRequest struct {
+	Properties map[string]string `json:"properties"`
+}

--- a/backend/internal/modules/overlay/hubspot/adapter_writes_test.go
+++ b/backend/internal/modules/overlay/hubspot/adapter_writes_test.go
@@ -22,15 +22,21 @@ import (
 func TestAdapterCreatePostsMappedProps(t *testing.T) {
 	var gotBody writeRequest
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost || r.URL.Path != "/crm/v3/objects/contacts" {
-			t.Fatalf("got %s %s, want POST /crm/v3/objects/contacts", r.Method, r.URL.Path)
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/crm/v3/objects/contacts":
+			if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+				t.Errorf("decoding POST body: %v", err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"555"}`))
+		case r.URL.Path == "/crm/v3/objects/contacts/batch/read":
+			// Create re-reads the created record through the sync-read path.
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"results":[{"id":"555","properties":{"hs_object_id":"555",
+				"firstname":"Ada","lastname":"Lovelace","lastmodifieddate":"2026-05-01T00:00:00Z"}}]}`))
+		default:
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
 		}
-		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
-			t.Errorf("decoding POST body: %v", err)
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"id":"555","properties":{"hs_object_id":"555",
-			"firstname":"Ada","lastname":"Lovelace","lastmodifieddate":"2026-05-01T00:00:00Z"}}`))
 	}))
 	defer srv.Close()
 
@@ -87,20 +93,28 @@ func TestAdapterUpdateRefusesOnBaselineDrift(t *testing.T) {
 // with the mapped changed property.
 func TestAdapterUpdateAppliesWhenBaselineFresh(t *testing.T) {
 	var patchBody writeRequest
+	var patched bool
 	baseline := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.URL.Path == "/crm/v3/objects/contacts/batch/read":
+			// First read is the drift anchor (pre-PATCH, first_name absent);
+			// the read AFTER the PATCH re-reads the applied state.
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"results":[{"id":"555","properties":{"hs_object_id":"555",
-				"lastmodifieddate":"2026-05-01T00:00:00Z"}}]}`))
+			if patched {
+				_, _ = w.Write([]byte(`{"results":[{"id":"555","properties":{"hs_object_id":"555",
+					"firstname":"Ada2","lastmodifieddate":"2026-05-01T00:00:00Z"}}]}`))
+			} else {
+				_, _ = w.Write([]byte(`{"results":[{"id":"555","properties":{"hs_object_id":"555",
+					"lastmodifieddate":"2026-05-01T00:00:00Z"}}]}`))
+			}
 		case r.Method == http.MethodPatch && r.URL.Path == "/crm/v3/objects/contacts/555":
 			if err := json.NewDecoder(r.Body).Decode(&patchBody); err != nil {
 				t.Errorf("decoding PATCH body: %v", err)
 			}
+			patched = true
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"id":"555","properties":{"hs_object_id":"555",
-				"firstname":"Ada2","lastmodifieddate":"2026-06-02T00:00:00Z"}}`))
+			_, _ = w.Write([]byte(`{"id":"555"}`))
 		default:
 			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
 		}

--- a/backend/internal/modules/overlay/hubspot/adapter_writes_test.go
+++ b/backend/internal/modules/overlay/hubspot/adapter_writes_test.go
@@ -25,7 +25,9 @@ func TestAdapterCreatePostsMappedProps(t *testing.T) {
 		if r.Method != http.MethodPost || r.URL.Path != "/crm/v3/objects/contacts" {
 			t.Fatalf("got %s %s, want POST /crm/v3/objects/contacts", r.Method, r.URL.Path)
 		}
-		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Errorf("decoding POST body: %v", err)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"id":"555","properties":{"hs_object_id":"555",
 			"firstname":"Ada","lastname":"Lovelace","lastmodifieddate":"2026-05-01T00:00:00Z"}}`))
@@ -93,7 +95,9 @@ func TestAdapterUpdateAppliesWhenBaselineFresh(t *testing.T) {
 			_, _ = w.Write([]byte(`{"results":[{"id":"555","properties":{"hs_object_id":"555",
 				"lastmodifieddate":"2026-05-01T00:00:00Z"}}]}`))
 		case r.Method == http.MethodPatch && r.URL.Path == "/crm/v3/objects/contacts/555":
-			_ = json.NewDecoder(r.Body).Decode(&patchBody)
+			if err := json.NewDecoder(r.Body).Decode(&patchBody); err != nil {
+				t.Errorf("decoding PATCH body: %v", err)
+			}
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"id":"555","properties":{"hs_object_id":"555",
 				"firstname":"Ada2","lastmodifieddate":"2026-06-02T00:00:00Z"}}`))

--- a/backend/internal/modules/overlay/hubspot/adapter_writes_test.go
+++ b/backend/internal/modules/overlay/hubspot/adapter_writes_test.go
@@ -138,22 +138,49 @@ func TestAdapterUpdateAppliesWhenBaselineFresh(t *testing.T) {
 // the object.
 func TestAdapterArchiveDeletes(t *testing.T) {
 	var deleted string
+	baseline := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodDelete {
+		switch {
+		case r.URL.Path == "/crm/v3/objects/contacts/batch/read":
+			// The drift anchor: current lastmodifieddate is at/before baseline.
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"results":[{"id":"555","properties":{"hs_object_id":"555",
+				"lastmodifieddate":"2026-05-01T00:00:00Z"}}]}`))
+		case r.Method == http.MethodDelete:
 			deleted = r.URL.Path
 			w.WriteHeader(http.StatusNoContent)
-			return
+		default:
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
 		}
-		t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
 	}))
 	defer srv.Close()
 
 	adapter := hubspot.NewAdapter(hubspot.NewClient("us", "tok", hubspot.WithBaseURL(srv.URL)))
-	if err := adapter.Archive(t.Context(), "person", "555"); err != nil {
+	if err := adapter.Archive(t.Context(), "person", "555", baseline); err != nil {
 		t.Fatalf("Archive: %v", err)
 	}
 	if deleted != "/crm/v3/objects/contacts/555" {
 		t.Errorf("DELETE path = %q, want /crm/v3/objects/contacts/555", deleted)
+	}
+}
+
+// TestAdapterArchiveRefusesOnDrift: a record changed since the mirror baseline
+// is NOT deleted (incumbent-wins, AC-OV-4).
+func TestAdapterArchiveRefusesOnDrift(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			t.Error("a drifted archive must not DELETE")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"results":[{"id":"555","properties":{"hs_object_id":"555",
+			"lastmodifieddate":"2026-07-01T00:00:00Z"}}]}`))
+	}))
+	defer srv.Close()
+
+	adapter := hubspot.NewAdapter(hubspot.NewClient("us", "tok", hubspot.WithBaseURL(srv.URL)))
+	baseline := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC) // older than current 2026-07-01
+	if err := adapter.Archive(t.Context(), "person", "555", baseline); !errors.Is(err, apperrors.ErrVersionSkew) {
+		t.Fatalf("Archive on drift: err = %v, want ErrVersionSkew", err)
 	}
 }
 
@@ -162,18 +189,24 @@ func TestAdapterArchiveDeletes(t *testing.T) {
 // class from the prefix and DELETEs the raw id on that class's endpoint.
 func TestAdapterArchiveActivityResolvesClassFromNamespacedID(t *testing.T) {
 	var deleted string
+	baseline := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodDelete {
+		switch {
+		case r.URL.Path == "/crm/v3/objects/calls/batch/read":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"results":[{"id":"123","properties":{"hs_object_id":"123",
+				"hs_timestamp":"2026-05-01T00:00:00Z","hs_lastmodifieddate":"2026-05-01T00:00:00Z"}}]}`))
+		case r.Method == http.MethodDelete:
 			deleted = r.URL.Path
 			w.WriteHeader(http.StatusNoContent)
-			return
+		default:
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
 		}
-		t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
 	}))
 	defer srv.Close()
 
 	adapter := hubspot.NewAdapter(hubspot.NewClient("us", "tok", hubspot.WithBaseURL(srv.URL)))
-	if err := adapter.Archive(t.Context(), "activity", "calls:123"); err != nil {
+	if err := adapter.Archive(t.Context(), "activity", "calls:123", baseline); err != nil {
 		t.Fatalf("Archive activity: %v", err)
 	}
 	if !strings.HasSuffix(deleted, "/crm/v3/objects/calls/123") {
@@ -224,7 +257,7 @@ func TestAdapterUpdateNoOpWhenOnlyReadOnlyFields(t *testing.T) {
 // single incumbent write class is an honest error, not a guessed endpoint.
 func TestAdapterArchiveRejectsUnknownClass(t *testing.T) {
 	adapter := hubspot.NewAdapter(hubspot.NewClient("us", "tok"))
-	if err := adapter.Archive(t.Context(), "widget", "1"); err == nil {
+	if err := adapter.Archive(t.Context(), "widget", "1", time.Time{}); err == nil {
 		t.Error("Archive of an unknown canonical class must error")
 	}
 }
@@ -234,7 +267,7 @@ func TestAdapterArchiveRejectsUnknownClass(t *testing.T) {
 // never a guessed class.
 func TestAdapterArchiveRejectsUnprefixedActivityID(t *testing.T) {
 	adapter := hubspot.NewAdapter(hubspot.NewClient("us", "tok"))
-	if err := adapter.Archive(t.Context(), "activity", "123"); err == nil {
+	if err := adapter.Archive(t.Context(), "activity", "123", time.Time{}); err == nil {
 		t.Error("Archive of an un-namespaced activity id must error")
 	}
 }

--- a/backend/internal/modules/overlay/hubspot/adapter_writes_test.go
+++ b/backend/internal/modules/overlay/hubspot/adapter_writes_test.go
@@ -167,6 +167,84 @@ func TestAdapterArchiveActivityResolvesClassFromNamespacedID(t *testing.T) {
 	}
 }
 
+// TestAdapterCreateRejectsAllReadOnlyFields: a create whose every supplied
+// field is read-only/derived (a person with only full_name) cannot create an
+// incumbent object — it errors and never POSTs a blank record.
+func TestAdapterCreateRejectsAllReadOnlyFields(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("no HTTP call expected, got %s %s", r.Method, r.URL.Path)
+	}))
+	defer srv.Close()
+
+	adapter := hubspot.NewAdapter(hubspot.NewClient("us", "tok", hubspot.WithBaseURL(srv.URL)))
+	if _, err := adapter.Create(t.Context(), "person", map[string]any{"full_name": "Ada Lovelace"}); err == nil {
+		t.Error("Create with only read-only fields must error, not POST a blank record")
+	}
+}
+
+// TestAdapterUpdateNoOpWhenOnlyReadOnlyFields: a patch of only read-only
+// fields writes nothing — it returns the current record via the drift-anchor
+// read and never PATCHes.
+func TestAdapterUpdateNoOpWhenOnlyReadOnlyFields(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPatch {
+			t.Error("a read-only-only patch must not PATCH")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"results":[{"id":"555","properties":{"hs_object_id":"555",
+			"firstname":"Ada","lastmodifieddate":"2026-05-01T00:00:00Z"}}]}`))
+	}))
+	defer srv.Close()
+
+	adapter := hubspot.NewAdapter(hubspot.NewClient("us", "tok", hubspot.WithBaseURL(srv.URL)))
+	rec, err := adapter.Update(t.Context(), "person", "555", map[string]any{"full_name": "Ada Renamed"}, time.Now())
+	if err != nil {
+		t.Fatalf("no-op Update: %v", err)
+	}
+	if rec.Fields["first_name"] != "Ada" {
+		t.Errorf("no-op Update should return the current record, got %+v", rec.Fields)
+	}
+}
+
+// TestAdapterArchiveRejectsUnknownClass: a canonical class that maps to no
+// single incumbent write class is an honest error, not a guessed endpoint.
+func TestAdapterArchiveRejectsUnknownClass(t *testing.T) {
+	adapter := hubspot.NewAdapter(hubspot.NewClient("us", "tok"))
+	if err := adapter.Archive(t.Context(), "widget", "1"); err == nil {
+		t.Error("Archive of an unknown canonical class must error")
+	}
+}
+
+// TestAdapterArchiveRejectsUnprefixedActivityID: an activity id with no
+// "<class>:" prefix cannot recover its engagement class (OVA-MAP-7) — error,
+// never a guessed class.
+func TestAdapterArchiveRejectsUnprefixedActivityID(t *testing.T) {
+	adapter := hubspot.NewAdapter(hubspot.NewClient("us", "tok"))
+	if err := adapter.Archive(t.Context(), "activity", "123"); err == nil {
+		t.Error("Archive of an un-namespaced activity id must error")
+	}
+}
+
+// TestAdapterCreateSurfacesIncumbentError: a non-2xx from HubSpot on the
+// create POST surfaces as a clean sentinel (no HubSpot body leaked), the
+// write-transport error path.
+func TestAdapterCreateSurfacesIncumbentError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"boom","category":"INTERNAL"}`))
+	}))
+	defer srv.Close()
+
+	adapter := hubspot.NewAdapter(hubspot.NewClient("us", "tok", hubspot.WithBaseURL(srv.URL)))
+	_, err := adapter.Create(t.Context(), "person", map[string]any{"first_name": "Ada"})
+	if err == nil {
+		t.Fatal("Create against a 5xx incumbent must error")
+	}
+	if strings.Contains(err.Error(), "boom") {
+		t.Errorf("error leaks the HubSpot message: %v", err)
+	}
+}
+
 // writeRequest is the v3 create/update request envelope, for asserting the
 // properties the adapter POSTed/PATCHed.
 type writeRequest struct {

--- a/backend/internal/modules/overlay/hubspot/client.go
+++ b/backend/internal/modules/overlay/hubspot/client.go
@@ -191,10 +191,22 @@ func mapStatus(status int, body []byte) error {
 		return apperrors.ErrIncumbentBudgetExhausted
 	case http.StatusUnauthorized, http.StatusForbidden:
 		return apperrors.ErrPermissionDenied
+	case http.StatusNotFound:
+		// A write to a since-deleted object, or a read of a missing one —
+		// a definite absence, not an incumbent outage.
+		return apperrors.ErrNotFound
+	case http.StatusConflict:
+		// A write rejected on a state/precondition conflict (e.g. a
+		// duplicate-key create) — a caller-actionable conflict, not an outage.
+		return apperrors.ErrConflict
 	default:
 		if env.Category == "RATE_LIMITS" {
 			return apperrors.ErrIncumbentBudgetExhausted
 		}
+		// A 4xx validation (400/422) has no dedicated sentinel in the fixed
+		// registry (interfaces.md §0), so it stays ErrUnreachable for now — a
+		// validation-error sentinel is a contract-first follow-up. A 5xx is a
+		// genuine outage.
 		return fmt.Errorf("hubspot: request failed with status %d: %w", status, ErrUnreachable)
 	}
 }

--- a/backend/internal/modules/overlay/hubspot/mapping_hs.go
+++ b/backend/internal/modules/overlay/hubspot/mapping_hs.go
@@ -47,13 +47,34 @@ const unmappedPolicyFlag = "flag"
 const (
 	propEmail       = "email"
 	propName        = "name"
+	propFirstname   = "firstname"
+	propLastname    = "lastname"
+	propLeadLabel   = "hs_lead_label"
 	targetAddress   = "address"
 	targetSubject   = "subject"
 	targetBody      = "body"
 	targetFullName  = "full_name"
 	targetKind      = "kind"
 	targetOccurred  = "occurred_at"
+	targetDirection = "direction"
 	propHSTimestamp = "hs_timestamp"
+	// industryField is the one spelling shared by companies' HubSpot
+	// `industry` property and the canonical `industry` mirror column — the
+	// same word both sides of the mapping, named once so read and write
+	// select it rather than retype the literal.
+	industryField = "industry"
+)
+
+// The five canonical activity kinds (OVA-MAP-1) — the Const value each
+// engagement read mapping stamps and the key each write spec selects its
+// engagement class by (OVA-MAP-W3). Named once so read and write can never
+// spell a kind differently.
+const (
+	kindCall    = "call"
+	kindMeeting = "meeting"
+	kindEmail   = "email"
+	kindNote    = "note"
+	kindTask    = "task"
 )
 
 // Mapping returns the ObjectMapping for one HubSpot object class. An
@@ -142,10 +163,10 @@ var contactsMapping = overlay.ObjectMapping{
 	Baseline:       "lastmodifieddate",
 	UnmappedPolicy: unmappedPolicyFlag,
 	Fields: []overlay.FieldMapping{
-		{From: []string{"firstname"}, To: "first_name", Kind: overlay.TargetColumn},
-		{From: []string{"lastname"}, To: "last_name", Kind: overlay.TargetColumn},
+		{From: []string{propFirstname}, To: "first_name", Kind: overlay.TargetColumn},
+		{From: []string{propLastname}, To: "last_name", Kind: overlay.TargetColumn},
 		{
-			From:       []string{"firstname", "lastname", propEmail},
+			From:       []string{propFirstname, propLastname, propEmail},
 			To:         targetFullName,
 			Kind:       overlay.TargetAssembler,
 			Transform:  "full_name",
@@ -180,7 +201,7 @@ var companiesMapping = overlay.ObjectMapping{
 	UnmappedPolicy: unmappedPolicyFlag,
 	Fields: []overlay.FieldMapping{
 		{From: []string{propName}, To: "display_name", Kind: overlay.TargetColumn},
-		{From: []string{"industry"}, To: "industry", Kind: overlay.TargetColumn},
+		{From: []string{industryField}, To: industryField, Kind: overlay.TargetColumn},
 		{
 			From:      []string{"numberofemployees"},
 			To:        "size_band",
@@ -263,12 +284,12 @@ var callsMapping = overlay.ObjectMapping{
 	ExternalKey:    propHSObjectID,
 	Baseline:       baselineHSLastModifiedDate,
 	UnmappedPolicy: unmappedPolicyFlag,
-	Const:          map[string]any{targetKind: "call"},
+	Const:          map[string]any{targetKind: kindCall},
 	Fields: []overlay.FieldMapping{
 		{From: []string{"hs_call_title"}, To: targetSubject, Kind: overlay.TargetColumn},
 		{From: []string{"hs_call_body"}, To: targetBody, Kind: overlay.TargetColumn},
 		{From: []string{propHSTimestamp}, To: targetOccurred, Kind: overlay.TargetColumn},
-		{From: []string{"hs_call_direction"}, To: "direction", Kind: overlay.TargetColumn},
+		{From: []string{"hs_call_direction"}, To: targetDirection, Kind: overlay.TargetColumn},
 		{From: []string{"hs_call_duration"}, To: "duration_seconds", Kind: overlay.TargetColumn, Transform: "ms_to_seconds"},
 		ownerIDField,
 	},
@@ -280,7 +301,7 @@ var meetingsMapping = overlay.ObjectMapping{
 	ExternalKey:    propHSObjectID,
 	Baseline:       baselineHSLastModifiedDate,
 	UnmappedPolicy: unmappedPolicyFlag,
-	Const:          map[string]any{targetKind: "meeting"},
+	Const:          map[string]any{targetKind: kindMeeting},
 	Fields: []overlay.FieldMapping{
 		{From: []string{"hs_meeting_title"}, To: targetSubject, Kind: overlay.TargetColumn},
 		{From: []string{"hs_meeting_body"}, To: targetBody, Kind: overlay.TargetColumn},
@@ -296,12 +317,12 @@ var emailsMapping = overlay.ObjectMapping{
 	ExternalKey:    propHSObjectID,
 	Baseline:       baselineHSLastModifiedDate,
 	UnmappedPolicy: unmappedPolicyFlag,
-	Const:          map[string]any{targetKind: "email"},
+	Const:          map[string]any{targetKind: kindEmail},
 	Fields: []overlay.FieldMapping{
 		{From: []string{"hs_email_subject"}, To: targetSubject, Kind: overlay.TargetColumn},
 		{From: []string{"hs_email_text"}, To: targetBody, Kind: overlay.TargetColumn},
 		{From: []string{propHSTimestamp}, To: targetOccurred, Kind: overlay.TargetColumn},
-		{From: []string{"hs_email_direction"}, To: "direction", Kind: overlay.TargetColumn},
+		{From: []string{"hs_email_direction"}, To: targetDirection, Kind: overlay.TargetColumn},
 		ownerIDField,
 	},
 }
@@ -312,7 +333,7 @@ var notesMapping = overlay.ObjectMapping{
 	ExternalKey:    propHSObjectID,
 	Baseline:       baselineHSLastModifiedDate,
 	UnmappedPolicy: unmappedPolicyFlag,
-	Const:          map[string]any{targetKind: "note"},
+	Const:          map[string]any{targetKind: kindNote},
 	Fields: []overlay.FieldMapping{
 		{From: []string{"hs_note_body"}, To: targetBody, Kind: overlay.TargetColumn},
 		{From: []string{propHSTimestamp}, To: targetOccurred, Kind: overlay.TargetColumn},
@@ -331,7 +352,7 @@ var tasksMapping = overlay.ObjectMapping{
 	ExternalKey:    propHSObjectID,
 	Baseline:       baselineHSLastModifiedDate,
 	UnmappedPolicy: unmappedPolicyFlag,
-	Const:          map[string]any{targetKind: "task"},
+	Const:          map[string]any{targetKind: kindTask},
 	Fields: []overlay.FieldMapping{
 		{From: []string{"hs_task_subject"}, To: targetSubject, Kind: overlay.TargetColumn},
 		{From: []string{"hs_task_body"}, To: targetBody, Kind: overlay.TargetColumn},
@@ -368,7 +389,7 @@ var leadsMapping = overlay.ObjectMapping{
 	UnmappedPolicy: unmappedPolicyFlag,
 	Fields: []overlay.FieldMapping{
 		{From: []string{"hs_lead_name"}, To: targetFullName, Kind: overlay.TargetColumn},
-		{From: []string{"hs_lead_label"}, To: "hs_lead_label", Kind: overlay.TargetColumn},
+		{From: []string{propLeadLabel}, To: propLeadLabel, Kind: overlay.TargetColumn},
 		ownerIDField,
 	},
 }

--- a/backend/internal/modules/overlay/hubspot/mapwrite.go
+++ b/backend/internal/modules/overlay/hubspot/mapwrite.go
@@ -90,13 +90,25 @@ var organizationWriteFields = []directWriteField{
 	{Canonical: industryField, HSProp: industryField},
 }
 
-// leadWriteFields — OVA-MAP-W5, restricted to the REAL Leads-object
-// properties. email and company_name are DERIVED through the required contact
-// association (OVA-MAP-5), not Leads-object properties Margince can write, so
-// they are read-only and absent here.
+// leadWriteFields — OVA-MAP-W5's writable Leads-object property that has a
+// clean, transform-free projection: full_name → hs_lead_name.
+//
+// The status ↔ hs_lead_label projection is DEFERRED in both directions, on
+// purpose: the read side (OVA-MAP-5, leadsMapping) keeps hs_lead_label a RAW
+// passthrough and explicitly defers the typed status-enum remap "until a
+// documented transform + a real capture". Writing a canonical status enum
+// token straight into HubSpot's hs_lead_label would be exactly that
+// untransformed projection the read declined as unsafe — and it would not be
+// the inverse of the read (which produces hs_lead_label, never status). So
+// lead status/label write-back waits on a pinned, bidirectional value map;
+// this is a contract-first reconciliation item against OVA-MAP-W5, which
+// currently assumes a transform OVA-MAP-5 has not defined.
+//
+// email and company_name are DERIVED through the required contact association
+// (OVA-MAP-5), not Leads-object properties Margince can write, so they are
+// read-only and absent here too.
 var leadWriteFields = []directWriteField{
 	{Canonical: targetFullName, HSProp: "hs_lead_name"},
-	{Canonical: "status", HSProp: propLeadLabel},
 }
 
 // copyDirect projects the direct 1:1 fields present in the canonical bag onto
@@ -147,9 +159,12 @@ var dealWriteFields = []directWriteField{
 // the write targets (the inverse of OVA-MAP-1's class→kind); each class has
 // its own subject/body/direction property names (mirroring the five read
 // mappings). duration_seconds → hs_call_duration ×1000 (ms, call only); a
-// task's due_at → hs_timestamp (task only). occurred_at is sourced from the
-// incumbent's own creation/occurrence timestamp (OVA-MAP-8) and is read-only —
-// never written.
+// task's due_at → hs_timestamp (task only). occurred_at is NOT written for any
+// class: for a task the read sources it from hs_createdate (a genuine creation
+// stamp, OVA-MAP-8), and for calls/emails/meetings write-back of the
+// occurrence timestamp is a V1 deferral rather than risk moving an event's
+// time on the incumbent from a partial patch — a tracked follow-up, not a
+// nature-of-the-field claim.
 //
 //craft:ignore naked-any fields is the JSON-decoded canonical bag; the any is inherent to the decoded shape
 func mapWriteActivity(fields map[string]any) (writeMapping, error) {
@@ -237,21 +252,17 @@ func writableString(v any) (string, bool) {
 	}
 }
 
-// numericField reads an integer-valued canonical field (JSON numbers decode as
-// float64). A null/absent/non-numeric value is ok=false.
+// numericField reads an integer-valued canonical field. The canonical bag is
+// always JSON-decoded (canonicalFields → json.Unmarshal), so a number arrives
+// as float64; a null/absent/non-numeric value is ok=false.
 //
 //craft:ignore naked-any v is a JSON-decoded canonical value; the any is inherent to the decoded shape
 func numericField(fields map[string]any, key string) (int64, bool) {
-	switch t := fields[key].(type) {
-	case float64:
-		return int64(t), true
-	case int64:
-		return t, true
-	case int:
-		return int64(t), true
-	default:
+	f, ok := fields[key].(float64)
+	if !ok {
 		return 0, false
 	}
+	return int64(f), true
 }
 
 // rfc3339ToMillis parses a canonical RFC3339 timestamp (how a contract

--- a/backend/internal/modules/overlay/hubspot/mapwrite.go
+++ b/backend/internal/modules/overlay/hubspot/mapwrite.go
@@ -1,0 +1,312 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package hubspot
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/modules/overlay"
+)
+
+// This file is the write direction of the HubSpot mapping-as-contract
+// (OVA-MAP-W): the canonical→incumbent projection the write-back engine
+// PATCHes/POSTs to HubSpot. It is pinned SEPARATELY from the read mapping
+// (mapping_hs.go) rather than inferred from it, because the read projection
+// (OVA-MAP-1..8) is not a bijection — several rules are derived or lossy
+// one-way (assembled full_name, currency-scaled amounts, class-derived
+// activity kind, association-derived lead fields, lossy size_band). A
+// canonical field with no writable incumbent counterpart is READ-ONLY: it is
+// never written back, and a write carrying only read-only fields is a no-op
+// the caller is told about (empty Props), never a fabricated incumbent
+// property.
+
+// writeMapping is one canonical→HubSpot write projection: the incumbent
+// object class the write targets and the HubSpot properties to set. Props
+// carries only WRITABLE properties — a canonical field flagged read-only by
+// OVA-MAP-W (full_name, occurred_at, lead email/company_name, deal
+// pipeline_id/stage_id, org size_band) never appears. An empty Props means
+// the write touched only read-only fields: a no-op the Provider surfaces to
+// the caller, never a POST/PATCH of a guessed value.
+type writeMapping struct {
+	ObjectClass string
+	Props       map[string]string
+}
+
+// mapWrite projects a canonical write (the entity type + the canonical field
+// bag, the JSON-decoded contract the frozen datasource seam carries) onto the
+// HubSpot object class and property set per OVA-MAP-W1..6. It is the inverse
+// of mapRecord and pure: no I/O, no transport — the golden write-mapping suite
+// (AC-OV-12) exercises it directly.
+//
+//craft:ignore naked-any fields is the JSON-decoded canonical bag from the frozen datasource seam; the any is inherent to the decoded shape
+func mapWrite(canonicalClass string, fields map[string]any) (writeMapping, error) {
+	switch canonicalClass {
+	case "person":
+		return writeMapping{ObjectClass: objectClassContacts, Props: copyDirect(fields, personWriteFields)}, nil
+	case "organization":
+		return writeMapping{ObjectClass: objectClassCompanies, Props: copyDirect(fields, organizationWriteFields)}, nil
+	case "lead":
+		return writeMapping{ObjectClass: objectClassLeads, Props: copyDirect(fields, leadWriteFields)}, nil
+	case "deal":
+		return mapWriteDeal(fields)
+	case activityTarget:
+		return mapWriteActivity(fields)
+	default:
+		return writeMapping{}, fmt.Errorf("overlay: no HubSpot write mapping for canonical class %q", canonicalClass)
+	}
+}
+
+// directWriteField is one canonical field that projects 1:1 onto a HubSpot
+// property by a straight string copy. The read-only canonical fields simply
+// have no entry — that absence is what makes them never written.
+type directWriteField struct {
+	Canonical string
+	HSProp    string
+}
+
+// personWriteFields — OVA-MAP-W1. full_name is the assembled display field
+// (OVA-MAP-3) and is NOT here: splitting a display string into first/last is
+// ambiguous and lossy, so it is read-only. emails, address, and owner_id are
+// V1 write-back deferrals (the emails child, the structured-address
+// assembler, and the reverse owner user-map resolution have no simple 1:1
+// inverse yet) — read-only for now, surfaced honestly rather than guessed,
+// the same "flag, don't invent" posture the read mapping takes for phone/social.
+var personWriteFields = []directWriteField{
+	{Canonical: "first_name", HSProp: propFirstname},
+	{Canonical: "last_name", HSProp: propLastname},
+	{Canonical: "title", HSProp: "jobtitle"},
+}
+
+// organizationWriteFields — the inverse of companiesMapping's 1:1 columns.
+// size_band is read-only: numberofemployees→size_band is a lossy band bucketing
+// (employees_to_size_band) with no unambiguous inverse. address, domains, and
+// owner_id are the same V1 deferrals as person's.
+var organizationWriteFields = []directWriteField{
+	{Canonical: "display_name", HSProp: propName},
+	{Canonical: industryField, HSProp: industryField},
+}
+
+// leadWriteFields — OVA-MAP-W5, restricted to the REAL Leads-object
+// properties. email and company_name are DERIVED through the required contact
+// association (OVA-MAP-5), not Leads-object properties Margince can write, so
+// they are read-only and absent here.
+var leadWriteFields = []directWriteField{
+	{Canonical: targetFullName, HSProp: "hs_lead_name"},
+	{Canonical: "status", HSProp: propLeadLabel},
+}
+
+// copyDirect projects the direct 1:1 fields present in the canonical bag onto
+// their HubSpot property names. A canonical field that is absent, JSON-null,
+// or empty-string is not written (nothing to set); a field not in the table is
+// read-only and silently skipped (its read-only-ness is the point).
+//
+//craft:ignore naked-any fields is the JSON-decoded canonical bag; the any is inherent to the decoded shape
+func copyDirect(fields map[string]any, table []directWriteField) map[string]string {
+	props := make(map[string]string)
+	for _, f := range table {
+		if s, ok := writableString(fields[f.Canonical]); ok {
+			props[f.HSProp] = s
+		}
+	}
+	return props
+}
+
+// mapWriteDeal — OVA-MAP-W2. name/expected_close_date project directly;
+// amount_minor + currency scale BACK to the decimal amount string by the
+// ISO-4217 minor-unit exponent of currency (never a blanket ÷100), and
+// currency sets deal_currency_code. pipeline_id/stage_id are read-only in
+// overlay (null per OVA-MAP-6/W4) and never written.
+//
+//craft:ignore naked-any fields is the JSON-decoded canonical bag; the any is inherent to the decoded shape
+func mapWriteDeal(fields map[string]any) (writeMapping, error) {
+	props := copyDirect(fields, dealWriteFields)
+	currency := strings.ToUpper(strings.TrimSpace(stringField(fields, "currency")))
+	if currency != "" {
+		props["deal_currency_code"] = currency
+	}
+	// amount_minor + currency → decimal amount string. A null/absent
+	// amount_minor, or no currency to choose an exponent, writes no amount
+	// (never a guessed zero) — the inverse of transformAmountMinorByCurrency's
+	// null-not-guess rule.
+	if minor, ok := numericField(fields, "amount_minor"); ok && currency != "" {
+		props["amount"] = minorToDecimalString(minor, overlay.ISO4217MinorUnitExponent(currency))
+	}
+	return writeMapping{ObjectClass: objectClassDeals, Props: props}, nil
+}
+
+var dealWriteFields = []directWriteField{
+	{Canonical: "name", HSProp: "dealname"},
+	{Canonical: "expected_close_date", HSProp: "closedate"},
+}
+
+// mapWriteActivity — OVA-MAP-W3. kind selects the v3 engagement object class
+// the write targets (the inverse of OVA-MAP-1's class→kind); each class has
+// its own subject/body/direction property names (mirroring the five read
+// mappings). duration_seconds → hs_call_duration ×1000 (ms, call only); a
+// task's due_at → hs_timestamp (task only). occurred_at is sourced from the
+// incumbent's own creation/occurrence timestamp (OVA-MAP-8) and is read-only —
+// never written.
+//
+//craft:ignore naked-any fields is the JSON-decoded canonical bag; the any is inherent to the decoded shape
+func mapWriteActivity(fields map[string]any) (writeMapping, error) {
+	kind := strings.TrimSpace(stringField(fields, "kind"))
+	if kind == "" {
+		return writeMapping{}, fmt.Errorf("overlay: an activity write carries no kind — cannot choose a HubSpot engagement object class")
+	}
+	spec, ok := activityWriteSpecs[kind]
+	if !ok {
+		return writeMapping{}, fmt.Errorf("overlay: activity kind %q has no HubSpot engagement object class", kind)
+	}
+	props := make(map[string]string)
+	// The class's writable string props (subject/body/direction/
+	// meeting_status vary per class) project directly; a canonical field the
+	// class does not carry simply has no spec entry.
+	for canonical, hsProp := range spec.stringProps {
+		if s, ok := writableString(fields[canonical]); ok {
+			props[hsProp] = s
+		}
+	}
+	// duration_seconds → hs_call_duration ×1000 (call only).
+	if spec.hasDuration {
+		if secs, ok := numericField(fields, "duration_seconds"); ok {
+			props["hs_call_duration"] = strconv.FormatInt(secs*1000, 10)
+		}
+	}
+	// due_at → hs_timestamp as epoch millis (task only). occurred_at is never
+	// written for any class.
+	if spec.hasDueAt {
+		ms, ok, err := rfc3339ToMillis(fields["due_at"])
+		if err != nil {
+			return writeMapping{}, err
+		}
+		if ok {
+			props[propHSTimestamp] = ms
+		}
+	}
+	return writeMapping{ObjectClass: spec.objectClass, Props: props}, nil
+}
+
+// activityWriteSpec is one engagement class's write projection — the inverse
+// of the class's read ObjectMapping. stringProps maps each writable
+// canonical activity field to this class's HubSpot property; the two
+// booleans carry the special-cased duration (×1000) and due_at (epoch
+// millis) projections that are not plain string copies.
+type activityWriteSpec struct {
+	objectClass string
+	stringProps map[string]string
+	hasDuration bool
+	hasDueAt    bool
+}
+
+// activityWriteSpecs maps each canonical activity kind to its engagement
+// class's write projection, matching the read property names in
+// mapping_hs.go (calls/meetings/emails/notes/tasks).
+var activityWriteSpecs = map[string]activityWriteSpec{
+	kindCall:    {objectClass: objectClassCalls, stringProps: map[string]string{targetSubject: "hs_call_title", targetBody: "hs_call_body", targetDirection: "hs_call_direction"}, hasDuration: true},
+	kindMeeting: {objectClass: objectClassMeetings, stringProps: map[string]string{targetSubject: "hs_meeting_title", targetBody: "hs_meeting_body", "meeting_status": "hs_meeting_outcome"}},
+	kindEmail:   {objectClass: objectClassEmails, stringProps: map[string]string{targetSubject: "hs_email_subject", targetBody: "hs_email_text", targetDirection: "hs_email_direction"}},
+	kindNote:    {objectClass: objectClassNotes, stringProps: map[string]string{targetBody: "hs_note_body"}},
+	kindTask:    {objectClass: objectClassTasks, stringProps: map[string]string{targetSubject: "hs_task_subject", targetBody: "hs_task_body"}, hasDueAt: true},
+}
+
+// writableString reports a canonical field's string form when it carries a
+// non-empty writable value. An absent, JSON-null, or empty-string value is
+// "nothing to write" (ok=false), so it is never PATCHed. A numeric value is
+// rendered without a trailing ".0" so an integer stays an integer on the wire.
+//
+//craft:ignore naked-any v is a JSON-decoded canonical value; the any is inherent to the decoded shape
+func writableString(v any) (string, bool) {
+	switch t := v.(type) {
+	case nil:
+		return "", false
+	case string:
+		if strings.TrimSpace(t) == "" {
+			return "", false
+		}
+		return t, true
+	case float64:
+		return strconv.FormatFloat(t, 'f', -1, 64), true
+	case bool:
+		return strconv.FormatBool(t), true
+	default:
+		return "", false
+	}
+}
+
+// numericField reads an integer-valued canonical field (JSON numbers decode as
+// float64). A null/absent/non-numeric value is ok=false.
+//
+//craft:ignore naked-any v is a JSON-decoded canonical value; the any is inherent to the decoded shape
+func numericField(fields map[string]any, key string) (int64, bool) {
+	switch t := fields[key].(type) {
+	case float64:
+		return int64(t), true
+	case int64:
+		return t, true
+	case int:
+		return int64(t), true
+	default:
+		return 0, false
+	}
+}
+
+// rfc3339ToMillis parses a canonical RFC3339 timestamp (how a contract
+// time.Time marshals to JSON) into a HubSpot epoch-millis property string. A
+// null/absent value is (._, false, nil) — nothing to write. A present but
+// unparseable value is an error, never a silently dropped timestamp.
+//
+//craft:ignore naked-any v is a JSON-decoded canonical value; the any is inherent to the decoded shape
+func rfc3339ToMillis(v any) (string, bool, error) {
+	s, ok := v.(string)
+	if !ok || strings.TrimSpace(s) == "" {
+		return "", false, nil
+	}
+	ts, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return "", false, fmt.Errorf("overlay: write timestamp %q is not RFC3339: %w", s, err)
+	}
+	return strconv.FormatInt(ts.UnixMilli(), 10), true, nil
+}
+
+// stringField reads a string-valued canonical property, answering "" for an
+// absent, JSON-null, or non-string value — a local convenience for the plain
+// selector fields (currency, kind) mapWrite branches on before deciding a
+// projection.
+//
+//craft:ignore naked-any v is the JSON-decoded canonical bag; the any is inherent to the decoded shape
+func stringField(fields map[string]any, key string) string {
+	if s, ok := fields[key].(string); ok {
+		return s
+	}
+	return ""
+}
+
+// minorToDecimalString is the inverse of decimalStringToMinor: it renders an
+// integer minor-unit amount back to the currency-decimal string HubSpot's
+// `amount` property expects, placing the decimal point by the ISO-4217
+// minor-unit exponent (exponent 0 → no point; 2 → "10.00"; 3 → "1.500"), never
+// a blanket ÷100.
+func minorToDecimalString(minor int64, exponent int) string {
+	if exponent <= 0 {
+		return strconv.FormatInt(minor, 10)
+	}
+	neg := minor < 0
+	if neg {
+		minor = -minor
+	}
+	digits := strconv.FormatInt(minor, 10)
+	// Left-pad so there are at least exponent+1 digits (a leading integer part).
+	for len(digits) <= exponent {
+		digits = "0" + digits
+	}
+	point := len(digits) - exponent
+	out := digits[:point] + "." + digits[point:]
+	if neg {
+		out = "-" + out
+	}
+	return out
+}

--- a/backend/internal/modules/overlay/hubspot/mapwrite.go
+++ b/backend/internal/modules/overlay/hubspot/mapwrite.go
@@ -4,6 +4,7 @@
 package hubspot
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -27,10 +28,11 @@ import (
 // writeMapping is one canonical→HubSpot write projection: the incumbent
 // object class the write targets and the HubSpot properties to set. Props
 // carries only WRITABLE properties — a canonical field flagged read-only by
-// OVA-MAP-W (full_name, occurred_at, lead email/company_name, deal
-// pipeline_id/stage_id, org size_band) never appears. An empty Props means
-// the write touched only read-only fields: a no-op the Provider surfaces to
-// the caller, never a POST/PATCH of a guessed value.
+// OVA-MAP-W (full_name, occurred_at, lead email/company_name/status, deal
+// pipeline_id/stage_id, org size_band, activity meeting_status) never
+// appears. An empty Props on a CREATE means the write touched only read-only
+// fields (the caller is told); on an UPDATE it means the patch changed
+// nothing writable.
 type writeMapping struct {
 	ObjectClass string
 	Props       map[string]string
@@ -38,23 +40,28 @@ type writeMapping struct {
 
 // mapWrite projects a canonical write (the entity type + the canonical field
 // bag, the JSON-decoded contract the frozen datasource seam carries) onto the
-// HubSpot object class and property set per OVA-MAP-W1..6. It is the inverse
-// of mapRecord and pure: no I/O, no transport — the golden write-mapping suite
-// (AC-OV-12) exercises it directly.
+// HubSpot object class and property set per OVA-MAP-W1..6. forUpdate selects
+// clear-semantics: on an update an explicit "" clears the incumbent property
+// (HubSpot's documented clear), while on a create an empty value is simply
+// nothing to set. It is pure: no I/O, no transport — the golden write-mapping
+// suite (AC-OV-12) exercises it directly.
 //
 //craft:ignore naked-any fields is the JSON-decoded canonical bag from the frozen datasource seam; the any is inherent to the decoded shape
-func mapWrite(canonicalClass string, fields map[string]any) (writeMapping, error) {
+func mapWrite(canonicalClass string, fields map[string]any, forUpdate bool) (writeMapping, error) {
 	switch canonicalClass {
 	case "person":
-		return writeMapping{ObjectClass: objectClassContacts, Props: copyDirect(fields, personWriteFields)}, nil
+		props, err := copyDirect(fields, personWriteFields, forUpdate)
+		return writeMapping{ObjectClass: objectClassContacts, Props: props}, err
 	case "organization":
-		return writeMapping{ObjectClass: objectClassCompanies, Props: copyDirect(fields, organizationWriteFields)}, nil
+		props, err := copyDirect(fields, organizationWriteFields, forUpdate)
+		return writeMapping{ObjectClass: objectClassCompanies, Props: props}, err
 	case "lead":
-		return writeMapping{ObjectClass: objectClassLeads, Props: copyDirect(fields, leadWriteFields)}, nil
+		props, err := copyDirect(fields, leadWriteFields, forUpdate)
+		return writeMapping{ObjectClass: objectClassLeads, Props: props}, err
 	case "deal":
-		return mapWriteDeal(fields)
+		return mapWriteDeal(fields, forUpdate)
 	case activityTarget:
-		return mapWriteActivity(fields)
+		return mapWriteActivity(fields, forUpdate)
 	default:
 		return writeMapping{}, fmt.Errorf("overlay: no HubSpot write mapping for canonical class %q", canonicalClass)
 	}
@@ -111,20 +118,61 @@ var leadWriteFields = []directWriteField{
 	{Canonical: targetFullName, HSProp: "hs_lead_name"},
 }
 
-// copyDirect projects the direct 1:1 fields present in the canonical bag onto
-// their HubSpot property names. A canonical field that is absent, JSON-null,
-// or empty-string is not written (nothing to set); a field not in the table is
-// read-only and silently skipped (its read-only-ness is the point).
+// stringProp reads a canonical STRING field's writable value. present reports
+// whether the key is present with a non-null value (an explicit "" is present
+// — the clear-field signal on updates). A present non-string value is a type
+// error, matching the native provider's StrictDecode 422 rather than
+// coercing a number/bool into a HubSpot string property.
 //
 //craft:ignore naked-any fields is the JSON-decoded canonical bag; the any is inherent to the decoded shape
-func copyDirect(fields map[string]any, table []directWriteField) map[string]string {
+func stringProp(fields map[string]any, key string) (val string, present bool, err error) {
+	raw, ok := fields[key]
+	if !ok || raw == nil {
+		return "", false, nil
+	}
+	s, isStr := raw.(string)
+	if !isStr {
+		return "", true, fmt.Errorf("overlay: field %q must be a string, got %T", key, raw)
+	}
+	return s, true, nil
+}
+
+// putString sets props[hsProp] from the canonical string field, honoring the
+// create/update clear-field rule: an explicit "" clears on update (sent) and
+// is skipped on create (nothing to set). Returns an error on a type violation.
+//
+//craft:ignore naked-any fields is the JSON-decoded canonical bag; the any is inherent to the decoded shape
+func putString(props map[string]string, fields map[string]any, canonical, hsProp string, forUpdate bool) error {
+	// An empty hsProp means the object class has no such writable property
+	// (e.g. a note has no subject) — the canonical field is read-only for this
+	// class and skipped, even though it is a valid contract field.
+	if hsProp == "" {
+		return nil
+	}
+	val, present, err := stringProp(fields, canonical)
+	if err != nil {
+		return err
+	}
+	if !present || (val == "" && !forUpdate) {
+		return nil
+	}
+	props[hsProp] = val
+	return nil
+}
+
+// copyDirect projects the direct 1:1 fields onto their HubSpot property names.
+// A canonical field that is absent or JSON-null is not written; an explicit
+// "" clears on update; a field not in the table is read-only and skipped.
+//
+//craft:ignore naked-any fields is the JSON-decoded canonical bag; the any is inherent to the decoded shape
+func copyDirect(fields map[string]any, table []directWriteField, forUpdate bool) (map[string]string, error) {
 	props := make(map[string]string)
 	for _, f := range table {
-		if s, ok := writableString(fields[f.Canonical]); ok {
-			props[f.HSProp] = s
+		if err := putString(props, fields, f.Canonical, f.HSProp, forUpdate); err != nil {
+			return nil, err
 		}
 	}
-	return props
+	return props, nil
 }
 
 // mapWriteDeal — OVA-MAP-W2. name/expected_close_date project directly;
@@ -133,18 +181,27 @@ func copyDirect(fields map[string]any, table []directWriteField) map[string]stri
 // currency sets deal_currency_code. pipeline_id/stage_id are read-only in
 // overlay (null per OVA-MAP-6/W4) and never written.
 //
+// amount and currency are a PAIR: a caller must supply currency to write
+// amount (the exponent chooses the decimal point), so the write-back engine
+// combines a partial deal patch with the mirror's current amount_minor/
+// currency BEFORE calling mapWrite (Provider.Update) — here, an amount_minor
+// with no currency writes no amount rather than guess an exponent.
+//
 //craft:ignore naked-any fields is the JSON-decoded canonical bag; the any is inherent to the decoded shape
-func mapWriteDeal(fields map[string]any) (writeMapping, error) {
-	props := copyDirect(fields, dealWriteFields)
+func mapWriteDeal(fields map[string]any, forUpdate bool) (writeMapping, error) {
+	props, err := copyDirect(fields, dealWriteFields, forUpdate)
+	if err != nil {
+		return writeMapping{}, err
+	}
 	currency := strings.ToUpper(strings.TrimSpace(stringField(fields, "currency")))
 	if currency != "" {
 		props["deal_currency_code"] = currency
 	}
-	// amount_minor + currency → decimal amount string. A null/absent
-	// amount_minor, or no currency to choose an exponent, writes no amount
-	// (never a guessed zero) — the inverse of transformAmountMinorByCurrency's
-	// null-not-guess rule.
-	if minor, ok := numericField(fields, "amount_minor"); ok && currency != "" {
+	minor, ok, err := numericField(fields, "amount_minor")
+	if err != nil {
+		return writeMapping{}, err
+	}
+	if ok && currency != "" {
 		props["amount"] = minorToDecimalString(minor, overlay.ISO4217MinorUnitExponent(currency))
 	}
 	return writeMapping{ObjectClass: objectClassDeals, Props: props}, nil
@@ -157,17 +214,16 @@ var dealWriteFields = []directWriteField{
 
 // mapWriteActivity — OVA-MAP-W3. kind selects the v3 engagement object class
 // the write targets (the inverse of OVA-MAP-1's class→kind); each class has
-// its own subject/body/direction property names (mirroring the five read
-// mappings). duration_seconds → hs_call_duration ×1000 (ms, call only); a
-// task's due_at → hs_timestamp (task only). occurred_at is NOT written for any
-// class: for a task the read sources it from hs_createdate (a genuine creation
-// stamp, OVA-MAP-8), and for calls/emails/meetings write-back of the
-// occurrence timestamp is a V1 deferral rather than risk moving an event's
-// time on the incumbent from a partial patch — a tracked follow-up, not a
-// nature-of-the-field claim.
+// its own subject/body/direction property names. duration_seconds →
+// hs_call_duration ×1000 (ms, call only); a task's due_at → hs_timestamp
+// (task only). occurred_at is read-only (OVA-MAP-8) and never written.
+// meeting_status is read-only: HubSpot's hs_meeting_outcome is a pinned
+// enum vocabulary, not the canonical status string, so — like lead status —
+// it awaits a documented bidirectional value map rather than sending a raw
+// canonical token.
 //
 //craft:ignore naked-any fields is the JSON-decoded canonical bag; the any is inherent to the decoded shape
-func mapWriteActivity(fields map[string]any) (writeMapping, error) {
+func mapWriteActivity(fields map[string]any, forUpdate bool) (writeMapping, error) {
 	kind := strings.TrimSpace(stringField(fields, "kind"))
 	if kind == "" {
 		return writeMapping{}, fmt.Errorf("overlay: an activity write carries no kind — cannot choose a HubSpot engagement object class")
@@ -177,110 +233,79 @@ func mapWriteActivity(fields map[string]any) (writeMapping, error) {
 		return writeMapping{}, fmt.Errorf("overlay: activity kind %q has no HubSpot engagement object class", kind)
 	}
 	props := make(map[string]string)
-	// The class's writable string props (subject/body/direction/
-	// meeting_status vary per class) project directly; a canonical field the
-	// class does not carry simply has no spec entry.
-	for canonical, hsProp := range spec.stringProps {
-		if s, ok := writableString(fields[canonical]); ok {
-			props[hsProp] = s
+	if err := putString(props, fields, targetSubject, spec.subjectProp, forUpdate); err != nil {
+		return writeMapping{}, err
+	}
+	if err := putString(props, fields, targetBody, spec.bodyProp, forUpdate); err != nil {
+		return writeMapping{}, err
+	}
+	if err := applyActivitySpecials(props, fields, spec, forUpdate); err != nil {
+		return writeMapping{}, err
+	}
+	return writeMapping{ObjectClass: spec.objectClass, Props: props}, nil
+}
+
+// applyActivitySpecials projects the per-class activity fields that are not a
+// plain string copy: direction (uppercased to HubSpot's pinned INBOUND/
+// OUTBOUND enum, the inverse of the lowercase canonical token), duration
+// (seconds → milliseconds), and a task's due_at (RFC3339 → epoch millis). A
+// class that does not carry a field has an empty/false spec entry and is
+// skipped.
+//
+//craft:ignore naked-any fields is the JSON-decoded canonical bag; the any is inherent to the decoded shape
+func applyActivitySpecials(props map[string]string, fields map[string]any, spec activityWriteSpec, forUpdate bool) error {
+	if spec.directionProp != "" {
+		val, present, err := stringProp(fields, targetDirection)
+		if err != nil {
+			return err
+		}
+		if present && (val != "" || forUpdate) {
+			props[spec.directionProp] = strings.ToUpper(val)
 		}
 	}
-	// duration_seconds → hs_call_duration ×1000 (call only).
 	if spec.hasDuration {
-		if secs, ok := numericField(fields, "duration_seconds"); ok {
+		secs, ok, err := numericField(fields, "duration_seconds")
+		if err != nil {
+			return err
+		}
+		if ok {
 			props["hs_call_duration"] = strconv.FormatInt(secs*1000, 10)
 		}
 	}
-	// due_at → hs_timestamp as epoch millis (task only). occurred_at is never
-	// written for any class.
 	if spec.hasDueAt {
 		ms, ok, err := rfc3339ToMillis(fields["due_at"])
 		if err != nil {
-			return writeMapping{}, err
+			return err
 		}
 		if ok {
 			props[propHSTimestamp] = ms
 		}
 	}
-	return writeMapping{ObjectClass: spec.objectClass, Props: props}, nil
+	return nil
 }
 
 // activityWriteSpec is one engagement class's write projection — the inverse
-// of the class's read ObjectMapping. stringProps maps each writable
-// canonical activity field to this class's HubSpot property; the two
-// booleans carry the special-cased duration (×1000) and due_at (epoch
-// millis) projections that are not plain string copies.
+// of the class's read ObjectMapping. An empty property name means the class
+// does not carry that field. meeting_status is deliberately absent (deferred,
+// see mapWriteActivity).
 type activityWriteSpec struct {
-	objectClass string
-	stringProps map[string]string
-	hasDuration bool
-	hasDueAt    bool
+	objectClass   string
+	subjectProp   string
+	bodyProp      string
+	directionProp string
+	hasDuration   bool
+	hasDueAt      bool
 }
 
 // activityWriteSpecs maps each canonical activity kind to its engagement
 // class's write projection, matching the read property names in
 // mapping_hs.go (calls/meetings/emails/notes/tasks).
 var activityWriteSpecs = map[string]activityWriteSpec{
-	kindCall:    {objectClass: objectClassCalls, stringProps: map[string]string{targetSubject: "hs_call_title", targetBody: "hs_call_body", targetDirection: "hs_call_direction"}, hasDuration: true},
-	kindMeeting: {objectClass: objectClassMeetings, stringProps: map[string]string{targetSubject: "hs_meeting_title", targetBody: "hs_meeting_body", "meeting_status": "hs_meeting_outcome"}},
-	kindEmail:   {objectClass: objectClassEmails, stringProps: map[string]string{targetSubject: "hs_email_subject", targetBody: "hs_email_text", targetDirection: "hs_email_direction"}},
-	kindNote:    {objectClass: objectClassNotes, stringProps: map[string]string{targetBody: "hs_note_body"}},
-	kindTask:    {objectClass: objectClassTasks, stringProps: map[string]string{targetSubject: "hs_task_subject", targetBody: "hs_task_body"}, hasDueAt: true},
-}
-
-// writableString reports a canonical field's string form when it carries a
-// non-empty writable value. An absent, JSON-null, or empty-string value is
-// "nothing to write" (ok=false), so it is never PATCHed. A numeric value is
-// rendered without a trailing ".0" so an integer stays an integer on the wire.
-//
-//craft:ignore naked-any v is a JSON-decoded canonical value; the any is inherent to the decoded shape
-func writableString(v any) (string, bool) {
-	switch t := v.(type) {
-	case nil:
-		return "", false
-	case string:
-		if strings.TrimSpace(t) == "" {
-			return "", false
-		}
-		return t, true
-	case float64:
-		return strconv.FormatFloat(t, 'f', -1, 64), true
-	case bool:
-		return strconv.FormatBool(t), true
-	default:
-		return "", false
-	}
-}
-
-// numericField reads an integer-valued canonical field. The canonical bag is
-// always JSON-decoded (canonicalFields → json.Unmarshal), so a number arrives
-// as float64; a null/absent/non-numeric value is ok=false.
-//
-//craft:ignore naked-any v is a JSON-decoded canonical value; the any is inherent to the decoded shape
-func numericField(fields map[string]any, key string) (int64, bool) {
-	f, ok := fields[key].(float64)
-	if !ok {
-		return 0, false
-	}
-	return int64(f), true
-}
-
-// rfc3339ToMillis parses a canonical RFC3339 timestamp (how a contract
-// time.Time marshals to JSON) into a HubSpot epoch-millis property string. A
-// null/absent value is (._, false, nil) — nothing to write. A present but
-// unparseable value is an error, never a silently dropped timestamp.
-//
-//craft:ignore naked-any v is a JSON-decoded canonical value; the any is inherent to the decoded shape
-func rfc3339ToMillis(v any) (string, bool, error) {
-	s, ok := v.(string)
-	if !ok || strings.TrimSpace(s) == "" {
-		return "", false, nil
-	}
-	ts, err := time.Parse(time.RFC3339, s)
-	if err != nil {
-		return "", false, fmt.Errorf("overlay: write timestamp %q is not RFC3339: %w", s, err)
-	}
-	return strconv.FormatInt(ts.UnixMilli(), 10), true, nil
+	kindCall:    {objectClass: objectClassCalls, subjectProp: "hs_call_title", bodyProp: "hs_call_body", directionProp: "hs_call_direction", hasDuration: true},
+	kindMeeting: {objectClass: objectClassMeetings, subjectProp: "hs_meeting_title", bodyProp: "hs_meeting_body"},
+	kindEmail:   {objectClass: objectClassEmails, subjectProp: "hs_email_subject", bodyProp: "hs_email_text", directionProp: "hs_email_direction"},
+	kindNote:    {objectClass: objectClassNotes, bodyProp: "hs_note_body"},
+	kindTask:    {objectClass: objectClassTasks, subjectProp: "hs_task_subject", bodyProp: "hs_task_body", hasDueAt: true},
 }
 
 // stringField reads a string-valued canonical property, answering "" for an
@@ -296,28 +321,81 @@ func stringField(fields map[string]any, key string) string {
 	return ""
 }
 
+// numericField reads an integer-valued canonical field WITHOUT the precision
+// loss of a float64 round-trip: the write path decodes the bag with
+// json.Decoder.UseNumber (canonicalFields), so a number arrives as a
+// json.Number and is parsed as a strict, range-checked int64. A plain float64
+// (the unit tests that build the bag directly) is accepted only when it is an
+// exact integer in int64 range — a fractional or out-of-range value is a type
+// error, never a silent truncation. A null/absent value is ok=false, nil error.
+//
+//craft:ignore naked-any v is the JSON-decoded canonical value; the any is inherent to the decoded shape
+func numericField(fields map[string]any, key string) (int64, bool, error) {
+	switch t := fields[key].(type) {
+	case nil:
+		return 0, false, nil
+	case json.Number:
+		n, err := t.Int64()
+		if err != nil {
+			return 0, true, fmt.Errorf("overlay: field %q is not an int64: %w", key, err)
+		}
+		return n, true, nil
+	case int64:
+		return t, true, nil
+	case int:
+		return int64(t), true, nil
+	case float64:
+		if t != float64(int64(t)) {
+			return 0, true, fmt.Errorf("overlay: field %q must be an integer, got %v", key, t)
+		}
+		return int64(t), true, nil
+	default:
+		return 0, true, fmt.Errorf("overlay: field %q must be a number, got %T", key, fields[key])
+	}
+}
+
+// rfc3339ToMillis parses a canonical RFC3339 timestamp (how a contract
+// time.Time marshals to JSON) into a HubSpot epoch-millis property string. A
+// null/absent value is ("", false, nil) — nothing to write. A present but
+// unparseable value is an error, never a silently dropped timestamp.
+//
+//craft:ignore naked-any v is a JSON-decoded canonical value; the any is inherent to the decoded shape
+func rfc3339ToMillis(v any) (string, bool, error) {
+	s, ok := v.(string)
+	if !ok || strings.TrimSpace(s) == "" {
+		return "", false, nil
+	}
+	ts, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return "", false, fmt.Errorf("overlay: write timestamp %q is not RFC3339: %w", s, err)
+	}
+	return strconv.FormatInt(ts.UnixMilli(), 10), true, nil
+}
+
 // minorToDecimalString is the inverse of decimalStringToMinor: it renders an
 // integer minor-unit amount back to the currency-decimal string HubSpot's
 // `amount` property expects, placing the decimal point by the ISO-4217
 // minor-unit exponent (exponent 0 → no point; 2 → "10.00"; 3 → "1.500"), never
 // a blanket ÷100.
 func minorToDecimalString(minor int64, exponent int) string {
-	if exponent <= 0 {
-		return strconv.FormatInt(minor, 10)
-	}
-	neg := minor < 0
+	// FormatInt renders the full magnitude of any int64 — including
+	// math.MinInt64, whose positive is not int64-representable — so the decimal
+	// point is inserted into the digit string with no int64→uint64 conversion
+	// to reason about.
+	s := strconv.FormatInt(minor, 10)
+	neg := strings.HasPrefix(s, "-")
 	if neg {
-		minor = -minor
+		s = s[1:]
 	}
-	digits := strconv.FormatInt(minor, 10)
-	// Left-pad so there are at least exponent+1 digits (a leading integer part).
-	for len(digits) <= exponent {
-		digits = "0" + digits
+	if exponent > 0 {
+		for len(s) <= exponent {
+			s = "0" + s
+		}
+		point := len(s) - exponent
+		s = s[:point] + "." + s[point:]
 	}
-	point := len(digits) - exponent
-	out := digits[:point] + "." + digits[point:]
 	if neg {
-		out = "-" + out
+		s = "-" + s
 	}
-	return out
+	return s
 }

--- a/backend/internal/modules/overlay/hubspot/mapwrite_test.go
+++ b/backend/internal/modules/overlay/hubspot/mapwrite_test.go
@@ -128,12 +128,15 @@ func TestMapWriteActivityTaskDueAtW3(t *testing.T) {
 	}
 }
 
-// OVA-MAP-W5 — lead full_name → hs_lead_name, status → hs_lead_label;
-// email/company_name are association-derived and read-only on a lead write.
+// OVA-MAP-W5 — lead full_name → hs_lead_name; email/company_name are
+// association-derived and read-only on a lead write; and the status ↔
+// hs_lead_label projection is DEFERRED (both directions) pending a pinned
+// value map, matching the read side's raw-passthrough deferral (OVA-MAP-5) —
+// so a raw status enum is never written untransformed into the label.
 func TestMapWriteLeadPropsW5(t *testing.T) {
 	got, err := mapWrite("lead", map[string]any{
 		"full_name":    "Grace Hopper",
-		"status":       "qualified",
+		"status":       "qualified",         // deferred — not written raw
 		"email":        "grace@example.com", // read-only
 		"company_name": "Navy",              // read-only
 	})
@@ -146,8 +149,8 @@ func TestMapWriteLeadPropsW5(t *testing.T) {
 	if got.Props["hs_lead_name"] != "Grace Hopper" {
 		t.Errorf("hs_lead_name = %q, want Grace Hopper", got.Props["hs_lead_name"])
 	}
-	if got.Props["hs_lead_label"] != "qualified" {
-		t.Errorf("hs_lead_label = %q, want qualified", got.Props["hs_lead_label"])
+	if _, ok := got.Props["hs_lead_label"]; ok {
+		t.Error("lead status/label projection is deferred — a raw status enum must not be written to hs_lead_label")
 	}
 	if _, ok := got.Props["email"]; ok {
 		t.Error("lead email is association-derived and read-only — must not be written")

--- a/backend/internal/modules/overlay/hubspot/mapwrite_test.go
+++ b/backend/internal/modules/overlay/hubspot/mapwrite_test.go
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package hubspot
+
+import (
+	"testing"
+	"time"
+)
+
+// The golden write-mapping suite: one assertion group per OVA-MAP-W rule,
+// the inverse of the OVA-AC-4 read suite (AC-OV-12). A ÷100-everywhere,
+// full_name-splitting, native-UUID-stage, or occurred_at-writing
+// implementation fails here by construction.
+
+// OVA-MAP-W1 — person first_name/last_name → firstname/lastname; full_name
+// is the assembled display field and is NEVER written back; a write of only
+// read-only fields sets no incumbent property.
+func TestMapWritePersonNamesW1(t *testing.T) {
+	got, err := mapWrite("person", map[string]any{
+		"first_name": "Ada",
+		"last_name":  "Lovelace",
+	})
+	if err != nil {
+		t.Fatalf("mapWrite person: %v", err)
+	}
+	if got.ObjectClass != objectClassContacts {
+		t.Errorf("object class = %q, want %q", got.ObjectClass, objectClassContacts)
+	}
+	if got.Props["firstname"] != "Ada" || got.Props["lastname"] != "Lovelace" {
+		t.Errorf("props = %#v, want firstname=Ada lastname=Lovelace", got.Props)
+	}
+}
+
+func TestMapWritePersonFullNameIsReadOnlyW1(t *testing.T) {
+	got, err := mapWrite("person", map[string]any{"full_name": "Ada Lovelace"})
+	if err != nil {
+		t.Fatalf("mapWrite person full_name only: %v", err)
+	}
+	if len(got.Props) != 0 {
+		t.Errorf("a write carrying only full_name must set no incumbent property, got %#v", got.Props)
+	}
+}
+
+// OVA-MAP-W2 — amount_minor + currency → amount scaled BACK by the ISO-4217
+// minor-unit exponent (never a blanket ÷100); deal_currency_code from currency.
+func TestMapWriteDealAmountByCurrencyW2(t *testing.T) {
+	cases := []struct {
+		currency string
+		minor    int64
+		want     string
+	}{
+		{"JPY", 1000, "1000"},  // exponent 0 → ÷1
+		{"EUR", 1000, "10.00"}, // exponent 2 → ÷100
+		{"BHD", 1500, "1.500"}, // exponent 3 → ÷1000
+	}
+	for _, c := range cases {
+		got, err := mapWrite("deal", map[string]any{
+			"amount_minor": float64(c.minor), // JSON-decoded numbers are float64
+			"currency":     c.currency,
+		})
+		if err != nil {
+			t.Fatalf("mapWrite deal %s: %v", c.currency, err)
+		}
+		if got.ObjectClass != objectClassDeals {
+			t.Errorf("%s: object class = %q, want %q", c.currency, got.ObjectClass, objectClassDeals)
+		}
+		if got.Props["amount"] != c.want {
+			t.Errorf("%s: amount = %q, want %q", c.currency, got.Props["amount"], c.want)
+		}
+		if got.Props["deal_currency_code"] != c.currency {
+			t.Errorf("%s: deal_currency_code = %q, want %q", c.currency, got.Props["deal_currency_code"], c.currency)
+		}
+	}
+}
+
+func TestMapWriteDealNullAmountWritesNoAmountW2(t *testing.T) {
+	got, err := mapWrite("deal", map[string]any{
+		"amount_minor": nil,
+		"currency":     "EUR",
+	})
+	if err != nil {
+		t.Fatalf("mapWrite deal null amount: %v", err)
+	}
+	if _, ok := got.Props["amount"]; ok {
+		t.Errorf("a null amount_minor must write no amount (never a guessed zero), got %q", got.Props["amount"])
+	}
+}
+
+// OVA-MAP-W3 — activity kind selects the engagement class; duration_seconds →
+// hs_call_duration ×1000 (ms); a task's due_at → hs_timestamp; occurred_at is
+// read-only and never written.
+func TestMapWriteActivityCallDurationW3(t *testing.T) {
+	got, err := mapWrite("activity", map[string]any{
+		"kind":             "call",
+		"duration_seconds": float64(90),
+		"occurred_at":      "2026-01-02T15:04:05Z", // read-only — must not be written
+	})
+	if err != nil {
+		t.Fatalf("mapWrite activity call: %v", err)
+	}
+	if got.ObjectClass != objectClassCalls {
+		t.Errorf("object class = %q, want %q", got.ObjectClass, objectClassCalls)
+	}
+	if got.Props["hs_call_duration"] != "90000" {
+		t.Errorf("hs_call_duration = %q, want 90000 (seconds ×1000)", got.Props["hs_call_duration"])
+	}
+	if _, ok := got.Props[propHSTimestamp]; ok {
+		t.Errorf("occurred_at is read-only and must never be written, got hs_timestamp=%q", got.Props[propHSTimestamp])
+	}
+}
+
+func TestMapWriteActivityTaskDueAtW3(t *testing.T) {
+	due := time.Date(2026, 3, 4, 9, 0, 0, 0, time.UTC)
+	got, err := mapWrite("activity", map[string]any{
+		"kind":   "task",
+		"due_at": due.Format(time.RFC3339),
+	})
+	if err != nil {
+		t.Fatalf("mapWrite activity task: %v", err)
+	}
+	if got.ObjectClass != objectClassTasks {
+		t.Errorf("object class = %q, want %q", got.ObjectClass, objectClassTasks)
+	}
+	wantMillis := "1772614800000" // due.UnixMilli()
+	if got.Props[propHSTimestamp] != wantMillis {
+		t.Errorf("hs_timestamp = %q, want %q (due_at as epoch millis)", got.Props[propHSTimestamp], wantMillis)
+	}
+}
+
+// OVA-MAP-W5 — lead full_name → hs_lead_name, status → hs_lead_label;
+// email/company_name are association-derived and read-only on a lead write.
+func TestMapWriteLeadPropsW5(t *testing.T) {
+	got, err := mapWrite("lead", map[string]any{
+		"full_name":    "Grace Hopper",
+		"status":       "qualified",
+		"email":        "grace@example.com", // read-only
+		"company_name": "Navy",              // read-only
+	})
+	if err != nil {
+		t.Fatalf("mapWrite lead: %v", err)
+	}
+	if got.ObjectClass != objectClassLeads {
+		t.Errorf("object class = %q, want %q", got.ObjectClass, objectClassLeads)
+	}
+	if got.Props["hs_lead_name"] != "Grace Hopper" {
+		t.Errorf("hs_lead_name = %q, want Grace Hopper", got.Props["hs_lead_name"])
+	}
+	if got.Props["hs_lead_label"] != "qualified" {
+		t.Errorf("hs_lead_label = %q, want qualified", got.Props["hs_lead_label"])
+	}
+	if _, ok := got.Props["email"]; ok {
+		t.Error("lead email is association-derived and read-only — must not be written")
+	}
+	if _, ok := got.Props["company_name"]; ok {
+		t.Error("lead company_name is association-derived and read-only — must not be written")
+	}
+}
+
+// An unknown canonical class is an honest error, never a silent empty write.
+func TestMapWriteUnknownClass(t *testing.T) {
+	if _, err := mapWrite("widget", map[string]any{"x": "y"}); err == nil {
+		t.Error("mapWrite of an unknown canonical class must error, not return empty")
+	}
+}
+
+// An activity write with no kind cannot choose an engagement endpoint — an
+// honest error, not a guessed class.
+func TestMapWriteActivityNoKind(t *testing.T) {
+	if _, err := mapWrite("activity", map[string]any{"subject": "hi"}); err == nil {
+		t.Error("an activity write with no kind must error (no endpoint to choose)")
+	}
+}

--- a/backend/internal/modules/overlay/hubspot/mapwrite_test.go
+++ b/backend/internal/modules/overlay/hubspot/mapwrite_test.go
@@ -160,6 +160,71 @@ func TestMapWriteLeadPropsW5(t *testing.T) {
 	}
 }
 
+// OVA-MAP-W: organization display_name→name and industry→industry project
+// directly; size_band is read-only (the numberofemployees→band bucketing has
+// no unambiguous inverse) and is never written.
+func TestMapWriteOrganization(t *testing.T) {
+	got, err := mapWrite("organization", map[string]any{
+		"display_name": "Acme",
+		"industry":     "Manufacturing",
+		"size_band":    "51-200", // read-only — must not be written
+	})
+	if err != nil {
+		t.Fatalf("mapWrite organization: %v", err)
+	}
+	if got.ObjectClass != objectClassCompanies {
+		t.Errorf("object class = %q, want %q", got.ObjectClass, objectClassCompanies)
+	}
+	if got.Props["name"] != "Acme" || got.Props["industry"] != "Manufacturing" {
+		t.Errorf("props = %#v, want name=Acme industry=Manufacturing", got.Props)
+	}
+	if _, ok := got.Props["numberofemployees"]; ok {
+		t.Error("size_band is read-only (lossy inverse) — must not be written")
+	}
+}
+
+// OVA-MAP-W2 at a 3-decimal, negative amount: minor units scale back to the
+// decimal string by the currency exponent, sign preserved.
+func TestMapWriteDealNegativeAmount(t *testing.T) {
+	got, err := mapWrite("deal", map[string]any{"amount_minor": float64(-1500), "currency": "BHD"})
+	if err != nil {
+		t.Fatalf("mapWrite deal negative: %v", err)
+	}
+	if got.Props["amount"] != "-1.500" {
+		t.Errorf("amount = %q, want -1.500", got.Props["amount"])
+	}
+}
+
+// A numeric or boolean canonical value renders to its string form without a
+// trailing ".0" (writableString's non-string branches).
+func TestMapWriteRendersNonStringScalars(t *testing.T) {
+	got, err := mapWrite("person", map[string]any{"first_name": float64(42), "last_name": true})
+	if err != nil {
+		t.Fatalf("mapWrite person scalars: %v", err)
+	}
+	if got.Props["firstname"] != "42" {
+		t.Errorf("firstname = %q, want 42 (no trailing .0)", got.Props["firstname"])
+	}
+	if got.Props["lastname"] != "true" {
+		t.Errorf("lastname = %q, want true", got.Props["lastname"])
+	}
+}
+
+// An activity kind with no engagement class is an honest error.
+func TestMapWriteActivityUnknownKind(t *testing.T) {
+	if _, err := mapWrite("activity", map[string]any{"kind": "sms"}); err == nil {
+		t.Error("an unknown activity kind must error, not pick an arbitrary class")
+	}
+}
+
+// A present but unparseable due_at is an error, never a silently dropped
+// timestamp.
+func TestMapWriteActivityBadDueAt(t *testing.T) {
+	if _, err := mapWrite("activity", map[string]any{"kind": "task", "due_at": "not-a-time"}); err == nil {
+		t.Error("an unparseable task due_at must error")
+	}
+}
+
 // An unknown canonical class is an honest error, never a silent empty write.
 func TestMapWriteUnknownClass(t *testing.T) {
 	if _, err := mapWrite("widget", map[string]any{"x": "y"}); err == nil {

--- a/backend/internal/modules/overlay/hubspot/mapwrite_test.go
+++ b/backend/internal/modules/overlay/hubspot/mapwrite_test.go
@@ -4,23 +4,24 @@
 package hubspot
 
 import (
+	"encoding/json"
+	"strconv"
 	"testing"
 	"time"
 )
 
 // The golden write-mapping suite: one assertion group per OVA-MAP-W rule,
-// the inverse of the OVA-AC-4 read suite (AC-OV-12). A ÷100-everywhere,
-// full_name-splitting, native-UUID-stage, or occurred_at-writing
-// implementation fails here by construction.
+// the inverse of the OVA-AC-4 read suite (AC-OV-12), plus the write-back
+// hardening rules (clear-field create/update semantics, type strictness,
+// enum casing, integer precision). A ÷100-everywhere, full_name-splitting,
+// native-UUID-stage, or occurred_at-writing implementation fails here by
+// construction.
 
-// OVA-MAP-W1 — person first_name/last_name → firstname/lastname; full_name
-// is the assembled display field and is NEVER written back; a write of only
-// read-only fields sets no incumbent property.
+// OVA-MAP-W1 — person first_name/last_name → firstname/lastname; full_name is
+// the assembled display field and is NEVER written back; a create carrying
+// only read-only fields sets no incumbent property.
 func TestMapWritePersonNamesW1(t *testing.T) {
-	got, err := mapWrite("person", map[string]any{
-		"first_name": "Ada",
-		"last_name":  "Lovelace",
-	})
+	got, err := mapWrite("person", map[string]any{"first_name": "Ada", "last_name": "Lovelace"}, false)
 	if err != nil {
 		t.Fatalf("mapWrite person: %v", err)
 	}
@@ -33,12 +34,39 @@ func TestMapWritePersonNamesW1(t *testing.T) {
 }
 
 func TestMapWritePersonFullNameIsReadOnlyW1(t *testing.T) {
-	got, err := mapWrite("person", map[string]any{"full_name": "Ada Lovelace"})
+	got, err := mapWrite("person", map[string]any{"full_name": "Ada Lovelace"}, false)
 	if err != nil {
 		t.Fatalf("mapWrite person full_name only: %v", err)
 	}
 	if len(got.Props) != 0 {
 		t.Errorf("a write carrying only full_name must set no incumbent property, got %#v", got.Props)
+	}
+}
+
+// Clear-field semantics: an explicit "" clears the property on UPDATE (sent to
+// HubSpot) but is nothing to set on CREATE (skipped).
+func TestMapWriteClearFieldOnUpdateOnly(t *testing.T) {
+	upd, err := mapWrite("person", map[string]any{"title": ""}, true)
+	if err != nil {
+		t.Fatalf("mapWrite update clear: %v", err)
+	}
+	if v, ok := upd.Props["jobtitle"]; !ok || v != "" {
+		t.Errorf("update title=\"\" must clear jobtitle (send \"\"), got props %#v", upd.Props)
+	}
+	cre, err := mapWrite("person", map[string]any{"title": ""}, false)
+	if err != nil {
+		t.Fatalf("mapWrite create empty title: %v", err)
+	}
+	if _, ok := cre.Props["jobtitle"]; ok {
+		t.Errorf("create title=\"\" is nothing to set, got props %#v", cre.Props)
+	}
+}
+
+// A non-string value in a string field is a type error (matching the native
+// provider's 422), never coerced into a HubSpot string property.
+func TestMapWriteRejectsNonStringScalar(t *testing.T) {
+	if _, err := mapWrite("person", map[string]any{"first_name": float64(42)}, false); err == nil {
+		t.Error("a numeric value in a string field must be a type error")
 	}
 }
 
@@ -50,20 +78,14 @@ func TestMapWriteDealAmountByCurrencyW2(t *testing.T) {
 		minor    int64
 		want     string
 	}{
-		{"JPY", 1000, "1000"},  // exponent 0 → ÷1
-		{"EUR", 1000, "10.00"}, // exponent 2 → ÷100
-		{"BHD", 1500, "1.500"}, // exponent 3 → ÷1000
+		{"JPY", 1000, "1000"},
+		{"EUR", 1000, "10.00"},
+		{"BHD", 1500, "1.500"},
 	}
 	for _, c := range cases {
-		got, err := mapWrite("deal", map[string]any{
-			"amount_minor": float64(c.minor), // JSON-decoded numbers are float64
-			"currency":     c.currency,
-		})
+		got, err := mapWrite("deal", map[string]any{"amount_minor": json.Number(strconv.FormatInt(c.minor, 10)), "currency": c.currency}, false)
 		if err != nil {
 			t.Fatalf("mapWrite deal %s: %v", c.currency, err)
-		}
-		if got.ObjectClass != objectClassDeals {
-			t.Errorf("%s: object class = %q, want %q", c.currency, got.ObjectClass, objectClassDeals)
 		}
 		if got.Props["amount"] != c.want {
 			t.Errorf("%s: amount = %q, want %q", c.currency, got.Props["amount"], c.want)
@@ -75,27 +97,48 @@ func TestMapWriteDealAmountByCurrencyW2(t *testing.T) {
 }
 
 func TestMapWriteDealNullAmountWritesNoAmountW2(t *testing.T) {
-	got, err := mapWrite("deal", map[string]any{
-		"amount_minor": nil,
-		"currency":     "EUR",
-	})
+	got, err := mapWrite("deal", map[string]any{"amount_minor": nil, "currency": "EUR"}, false)
 	if err != nil {
 		t.Fatalf("mapWrite deal null amount: %v", err)
 	}
 	if _, ok := got.Props["amount"]; ok {
-		t.Errorf("a null amount_minor must write no amount (never a guessed zero), got %q", got.Props["amount"])
+		t.Errorf("a null amount_minor must write no amount, got %q", got.Props["amount"])
+	}
+}
+
+func TestMapWriteDealNegativeAmount(t *testing.T) {
+	got, err := mapWrite("deal", map[string]any{"amount_minor": json.Number("-1500"), "currency": "BHD"}, false)
+	if err != nil {
+		t.Fatalf("mapWrite deal negative: %v", err)
+	}
+	if got.Props["amount"] != "-1.500" {
+		t.Errorf("amount = %q, want -1.500", got.Props["amount"])
+	}
+}
+
+// Large amount_minor must survive without a float64 precision loss (the write
+// path decodes with UseNumber → json.Number → exact int64).
+func TestMapWriteDealLargeAmountPrecise(t *testing.T) {
+	got, err := mapWrite("deal", map[string]any{"amount_minor": json.Number("9007199254740993"), "currency": "JPY"}, false)
+	if err != nil {
+		t.Fatalf("mapWrite deal large: %v", err)
+	}
+	if got.Props["amount"] != "9007199254740993" {
+		t.Errorf("amount = %q, want 9007199254740993 (no float64 rounding)", got.Props["amount"])
 	}
 }
 
 // OVA-MAP-W3 — activity kind selects the engagement class; duration_seconds →
-// hs_call_duration ×1000 (ms); a task's due_at → hs_timestamp; occurred_at is
-// read-only and never written.
-func TestMapWriteActivityCallDurationW3(t *testing.T) {
+// hs_call_duration ×1000; a task's due_at → hs_timestamp; occurred_at is
+// read-only; direction is uppercased to HubSpot's pinned enum; meeting_status
+// is deferred (never written raw).
+func TestMapWriteActivityCallW3(t *testing.T) {
 	got, err := mapWrite("activity", map[string]any{
 		"kind":             "call",
-		"duration_seconds": float64(90),
-		"occurred_at":      "2026-01-02T15:04:05Z", // read-only — must not be written
-	})
+		"duration_seconds": json.Number("90"),
+		"direction":        "outbound",
+		"occurred_at":      "2026-01-02T15:04:05Z",
+	}, false)
 	if err != nil {
 		t.Fatalf("mapWrite activity call: %v", err)
 	}
@@ -103,43 +146,67 @@ func TestMapWriteActivityCallDurationW3(t *testing.T) {
 		t.Errorf("object class = %q, want %q", got.ObjectClass, objectClassCalls)
 	}
 	if got.Props["hs_call_duration"] != "90000" {
-		t.Errorf("hs_call_duration = %q, want 90000 (seconds ×1000)", got.Props["hs_call_duration"])
+		t.Errorf("hs_call_duration = %q, want 90000", got.Props["hs_call_duration"])
+	}
+	if got.Props["hs_call_direction"] != "OUTBOUND" {
+		t.Errorf("hs_call_direction = %q, want OUTBOUND (uppercased enum)", got.Props["hs_call_direction"])
 	}
 	if _, ok := got.Props[propHSTimestamp]; ok {
-		t.Errorf("occurred_at is read-only and must never be written, got hs_timestamp=%q", got.Props[propHSTimestamp])
+		t.Errorf("occurred_at is read-only and must never be written")
+	}
+}
+
+func TestMapWriteActivityMeetingStatusDeferred(t *testing.T) {
+	got, err := mapWrite("activity", map[string]any{"kind": "meeting", "meeting_status": "held"}, false)
+	if err != nil {
+		t.Fatalf("mapWrite meeting: %v", err)
+	}
+	if _, ok := got.Props["hs_meeting_outcome"]; ok {
+		t.Error("meeting_status projection is deferred (pinned enum vocabulary) — must not be written raw")
 	}
 }
 
 func TestMapWriteActivityTaskDueAtW3(t *testing.T) {
 	due := time.Date(2026, 3, 4, 9, 0, 0, 0, time.UTC)
-	got, err := mapWrite("activity", map[string]any{
-		"kind":   "task",
-		"due_at": due.Format(time.RFC3339),
-	})
+	got, err := mapWrite("activity", map[string]any{"kind": "task", "due_at": due.Format(time.RFC3339)}, false)
 	if err != nil {
-		t.Fatalf("mapWrite activity task: %v", err)
+		t.Fatalf("mapWrite task: %v", err)
 	}
 	if got.ObjectClass != objectClassTasks {
 		t.Errorf("object class = %q, want %q", got.ObjectClass, objectClassTasks)
 	}
-	wantMillis := "1772614800000" // due.UnixMilli()
-	if got.Props[propHSTimestamp] != wantMillis {
-		t.Errorf("hs_timestamp = %q, want %q (due_at as epoch millis)", got.Props[propHSTimestamp], wantMillis)
+	if got.Props[propHSTimestamp] != "1772614800000" {
+		t.Errorf("hs_timestamp = %q, want 1772614800000 (due_at millis)", got.Props[propHSTimestamp])
+	}
+}
+
+func TestMapWriteActivityNoKind(t *testing.T) {
+	if _, err := mapWrite("activity", map[string]any{"subject": "hi"}, false); err == nil {
+		t.Error("an activity write with no kind must error")
+	}
+}
+
+func TestMapWriteActivityUnknownKind(t *testing.T) {
+	if _, err := mapWrite("activity", map[string]any{"kind": "sms"}, false); err == nil {
+		t.Error("an unknown activity kind must error")
+	}
+}
+
+func TestMapWriteActivityBadDueAt(t *testing.T) {
+	if _, err := mapWrite("activity", map[string]any{"kind": "task", "due_at": "not-a-time"}, false); err == nil {
+		t.Error("an unparseable task due_at must error")
 	}
 }
 
 // OVA-MAP-W5 — lead full_name → hs_lead_name; email/company_name are
-// association-derived and read-only on a lead write; and the status ↔
-// hs_lead_label projection is DEFERRED (both directions) pending a pinned
-// value map, matching the read side's raw-passthrough deferral (OVA-MAP-5) —
-// so a raw status enum is never written untransformed into the label.
+// association-derived and read-only; status/label is deferred (both directions).
 func TestMapWriteLeadPropsW5(t *testing.T) {
 	got, err := mapWrite("lead", map[string]any{
 		"full_name":    "Grace Hopper",
-		"status":       "qualified",         // deferred — not written raw
-		"email":        "grace@example.com", // read-only
-		"company_name": "Navy",              // read-only
-	})
+		"status":       "qualified",
+		"email":        "grace@example.com",
+		"company_name": "Navy",
+	}, false)
 	if err != nil {
 		t.Fatalf("mapWrite lead: %v", err)
 	}
@@ -149,26 +216,21 @@ func TestMapWriteLeadPropsW5(t *testing.T) {
 	if got.Props["hs_lead_name"] != "Grace Hopper" {
 		t.Errorf("hs_lead_name = %q, want Grace Hopper", got.Props["hs_lead_name"])
 	}
-	if _, ok := got.Props["hs_lead_label"]; ok {
-		t.Error("lead status/label projection is deferred — a raw status enum must not be written to hs_lead_label")
-	}
-	if _, ok := got.Props["email"]; ok {
-		t.Error("lead email is association-derived and read-only — must not be written")
-	}
-	if _, ok := got.Props["company_name"]; ok {
-		t.Error("lead company_name is association-derived and read-only — must not be written")
+	for _, k := range []string{"hs_lead_label", "email", "company_name"} {
+		if _, ok := got.Props[k]; ok {
+			t.Errorf("%s must not be written (deferred/association-derived)", k)
+		}
 	}
 }
 
-// OVA-MAP-W: organization display_name→name and industry→industry project
-// directly; size_band is read-only (the numberofemployees→band bucketing has
-// no unambiguous inverse) and is never written.
+// OVA-MAP-W: organization display_name→name, industry→industry; size_band
+// read-only.
 func TestMapWriteOrganization(t *testing.T) {
 	got, err := mapWrite("organization", map[string]any{
 		"display_name": "Acme",
 		"industry":     "Manufacturing",
-		"size_band":    "51-200", // read-only — must not be written
-	})
+		"size_band":    "51-200",
+	}, false)
 	if err != nil {
 		t.Fatalf("mapWrite organization: %v", err)
 	}
@@ -179,63 +241,12 @@ func TestMapWriteOrganization(t *testing.T) {
 		t.Errorf("props = %#v, want name=Acme industry=Manufacturing", got.Props)
 	}
 	if _, ok := got.Props["numberofemployees"]; ok {
-		t.Error("size_band is read-only (lossy inverse) — must not be written")
+		t.Error("size_band is read-only — must not be written")
 	}
 }
 
-// OVA-MAP-W2 at a 3-decimal, negative amount: minor units scale back to the
-// decimal string by the currency exponent, sign preserved.
-func TestMapWriteDealNegativeAmount(t *testing.T) {
-	got, err := mapWrite("deal", map[string]any{"amount_minor": float64(-1500), "currency": "BHD"})
-	if err != nil {
-		t.Fatalf("mapWrite deal negative: %v", err)
-	}
-	if got.Props["amount"] != "-1.500" {
-		t.Errorf("amount = %q, want -1.500", got.Props["amount"])
-	}
-}
-
-// A numeric or boolean canonical value renders to its string form without a
-// trailing ".0" (writableString's non-string branches).
-func TestMapWriteRendersNonStringScalars(t *testing.T) {
-	got, err := mapWrite("person", map[string]any{"first_name": float64(42), "last_name": true})
-	if err != nil {
-		t.Fatalf("mapWrite person scalars: %v", err)
-	}
-	if got.Props["firstname"] != "42" {
-		t.Errorf("firstname = %q, want 42 (no trailing .0)", got.Props["firstname"])
-	}
-	if got.Props["lastname"] != "true" {
-		t.Errorf("lastname = %q, want true", got.Props["lastname"])
-	}
-}
-
-// An activity kind with no engagement class is an honest error.
-func TestMapWriteActivityUnknownKind(t *testing.T) {
-	if _, err := mapWrite("activity", map[string]any{"kind": "sms"}); err == nil {
-		t.Error("an unknown activity kind must error, not pick an arbitrary class")
-	}
-}
-
-// A present but unparseable due_at is an error, never a silently dropped
-// timestamp.
-func TestMapWriteActivityBadDueAt(t *testing.T) {
-	if _, err := mapWrite("activity", map[string]any{"kind": "task", "due_at": "not-a-time"}); err == nil {
-		t.Error("an unparseable task due_at must error")
-	}
-}
-
-// An unknown canonical class is an honest error, never a silent empty write.
 func TestMapWriteUnknownClass(t *testing.T) {
-	if _, err := mapWrite("widget", map[string]any{"x": "y"}); err == nil {
-		t.Error("mapWrite of an unknown canonical class must error, not return empty")
-	}
-}
-
-// An activity write with no kind cannot choose an engagement endpoint — an
-// honest error, not a guessed class.
-func TestMapWriteActivityNoKind(t *testing.T) {
-	if _, err := mapWrite("activity", map[string]any{"subject": "hi"}); err == nil {
-		t.Error("an activity write with no kind must error (no endpoint to choose)")
+	if _, err := mapWrite("widget", map[string]any{"x": "y"}, false); err == nil {
+		t.Error("mapWrite of an unknown canonical class must error")
 	}
 }

--- a/backend/internal/modules/overlay/hubspot/writes.go
+++ b/backend/internal/modules/overlay/hubspot/writes.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package hubspot
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+)
+
+// This file is the client's write transport: the v3 object create/update/
+// archive endpoints the write-back engine reaches HubSpot through (design.md
+// §4.5). It mirrors records.go's read plumbing — same do/mapStatus error
+// path, same wireObject decode — and returns HubSpot-shaped ObjectRecords
+// only; projecting canonical fields onto HubSpot properties (mapWrite) and
+// mapping the response back is the adapter's job, not this package's.
+
+// writeBody is the v3 object create/update request envelope: HubSpot takes
+// the property set under a "properties" object (design §11).
+type writeBody struct {
+	Properties map[string]string `json:"properties"`
+}
+
+// CreateObject POSTs a new object of objectClass with props and returns the
+// created object (id + stored properties + updatedAt) — the state the mirror
+// ingests as authoritative-on-the-incumbent.
+func (c *Client) CreateObject(ctx context.Context, objectClass string, props map[string]string) (ObjectRecord, error) {
+	path := "/crm/v3/objects/" + url.PathEscape(objectClass)
+	var out wireObject
+	if err := c.do(ctx, http.MethodPost, path, writeBody{Properties: props}, &out); err != nil {
+		return ObjectRecord{}, err
+	}
+	return ObjectRecord(out), nil
+}
+
+// UpdateObject PATCHes props onto the object objectClass/id and returns its
+// updated state. HubSpot v3 has no per-request If-Match primitive, so the
+// write-back drift check is applied by the adapter (a stored-baseline
+// comparison) BEFORE this call — this is the raw transport only.
+func (c *Client) UpdateObject(ctx context.Context, objectClass, id string, props map[string]string) (ObjectRecord, error) {
+	path := "/crm/v3/objects/" + url.PathEscape(objectClass) + "/" + url.PathEscape(id)
+	var out wireObject
+	if err := c.do(ctx, http.MethodPatch, path, writeBody{Properties: props}, &out); err != nil {
+		return ObjectRecord{}, err
+	}
+	return ObjectRecord(out), nil
+}
+
+// ArchiveObject archives (soft-deletes) the object objectClass/id via
+// HubSpot's own DELETE — the incumbent's archive, mirrored by the caller as a
+// removal. A 2xx with no body is success; the do path decodes nothing.
+func (c *Client) ArchiveObject(ctx context.Context, objectClass, id string) error {
+	path := "/crm/v3/objects/" + url.PathEscape(objectClass) + "/" + url.PathEscape(id)
+	return c.do(ctx, http.MethodDelete, path, nil, nil)
+}

--- a/backend/internal/modules/overlay/incumbent.go
+++ b/backend/internal/modules/overlay/incumbent.go
@@ -162,8 +162,19 @@ type Incumbent interface {
 	// blind overwrite). externalID is the mirror id (namespaced for an activity,
 	// OVA-MAP-7). A patch of only read-only fields writes nothing and returns
 	// the current record unchanged.
+	//
+	// The V1 guarantee is BEST-EFFORT, not atomic: HubSpot v3 has no
+	// caller-supplied If-Match/ETag primitive, so the drift check is a
+	// non-atomic read-compare-write and a concurrent incumbent edit landing
+	// inside that window can still be overwritten. A true compare-and-write
+	// waits on the incumbent's own precondition primitive (SF/Dynamics ETag,
+	// S-E19.3/S-E20.3) — a documented fast-follow, not a regression here.
 	Update(ctx context.Context, canonicalClass, externalID string, fields map[string]any, baseline time.Time) (Record, error)
-	// Archive removes a record from the incumbent via its own archive/delete.
-	// externalID is the mirror id (namespaced for an activity).
-	Archive(ctx context.Context, canonicalClass, externalID string) error
+	// Archive removes a record from the incumbent via its own archive/delete,
+	// after the SAME stored-baseline drift check Update applies: archiving from
+	// a stale mirror must not delete a record a third party changed since we
+	// mirrored it (incumbent-wins → apperrors.ErrVersionSkew, nothing deleted).
+	// externalID is the mirror id (namespaced for an activity); baseline is the
+	// mirror row's lost-update baseline.
+	Archive(ctx context.Context, canonicalClass, externalID string, baseline time.Time) error
 }

--- a/backend/internal/modules/overlay/incumbent.go
+++ b/backend/internal/modules/overlay/incumbent.go
@@ -145,4 +145,25 @@ type Incumbent interface {
 	// the population mirror_user_map seeding matches against the
 	// workspace's app_user rows.
 	Owners(ctx context.Context) ([]OwnerRef, error)
+
+	// Create writes a new record of canonicalClass to the incumbent from the
+	// canonical field bag (the JSON-decoded contract the datasource seam
+	// carries) and returns the incumbent's stored state mapped back to
+	// canonical — the state the mirror ingests. A field with no writable
+	// incumbent counterpart (a read-only/derived field, OVA-MAP-W) is not
+	// written; a create whose every field is read-only is an error, never a
+	// blank incumbent record.
+	Create(ctx context.Context, canonicalClass string, fields map[string]any) (Record, error)
+	// Update applies a canonical patch to an existing record after a
+	// stored-baseline drift check (design.md §4.5, AC-OV-4): if the incumbent's
+	// current record is newer than baseline — the mirror's lost-update baseline
+	// captured at mirror-read — the write is refused with
+	// apperrors.ErrVersionSkew and nothing is written (incumbent-wins, never a
+	// blind overwrite). externalID is the mirror id (namespaced for an activity,
+	// OVA-MAP-7). A patch of only read-only fields writes nothing and returns
+	// the current record unchanged.
+	Update(ctx context.Context, canonicalClass, externalID string, fields map[string]any, baseline time.Time) (Record, error)
+	// Archive removes a record from the incumbent via its own archive/delete.
+	// externalID is the mirror id (namespaced for an activity).
+	Archive(ctx context.Context, canonicalClass, externalID string) error
 }

--- a/backend/internal/modules/overlay/provider.go
+++ b/backend/internal/modules/overlay/provider.go
@@ -35,6 +35,13 @@ import (
 type Provider struct {
 	ms *MirrorStore
 	ff *FreshnessReader
+	// resolveIncumbent yields the acting workspace's live incumbent adapter
+	// for the write-back path (design.md §4.5). It is the SAME per-request
+	// resolver the force-fresh reader uses (SetFreshnessIncumbentResolver
+	// wires both), so a write reaches the incumbent exactly as a force-fresh
+	// read does. nil until wired (the write-verb unit tests) — writes then
+	// answer errNoWriteIncumbent rather than nil-panic.
+	resolveIncumbent func(context.Context) (Incumbent, error)
 }
 
 // NewProvider constructs a Provider over ms (mirror reads) and ff
@@ -43,11 +50,13 @@ func NewProvider(ms *MirrorStore, ff *FreshnessReader) *Provider {
 	return &Provider{ms: ms, ff: ff}
 }
 
-// SetFreshnessIncumbentResolver forwards the per-request live-incumbent
-// resolver to the force-fresh reader (boot-time only; see
-// FreshnessReader.SetIncumbentResolver). A Provider built without a
-// force-fresh reader ignores it.
+// SetFreshnessIncumbentResolver wires the per-request live-incumbent
+// resolver used by BOTH the force-fresh reader (force-fresh reads) and the
+// write-back path (Create/Update/Archive) — one resolver, one wiring point
+// (boot-time only; see FreshnessReader.SetIncumbentResolver). A Provider
+// built without a force-fresh reader still records it for the write path.
 func (p *Provider) SetFreshnessIncumbentResolver(resolveIncumbent func(context.Context) (Incumbent, error)) {
+	p.resolveIncumbent = resolveIncumbent
 	if p.ff != nil {
 		p.ff.SetIncumbentResolver(resolveIncumbent)
 	}
@@ -343,36 +352,6 @@ func (p *Provider) StageSemantic(_ context.Context, _ ids.UUID) (string, ids.UUI
 // example) — declared unsupported, not silently stubbed.
 func (p *Provider) RunReport(_ context.Context, _ datasource.ReportPlan) (datasource.ReportResult, error) {
 	return datasource.ReportResult{}, apperrors.ErrUnsupportedBySoR
-}
-
-// Create is unsupported until branch 2's write-back path lands.
-func (p *Provider) Create(_ context.Context, _ datasource.CreateInput) (datasource.EntityRef, error) {
-	return datasource.EntityRef{}, apperrors.ErrUnsupportedBySoR
-}
-
-// Update is unsupported until branch 2's write-back path lands.
-func (p *Provider) Update(_ context.Context, _ datasource.UpdateInput) (datasource.EntityRef, error) {
-	return datasource.EntityRef{}, apperrors.ErrUnsupportedBySoR
-}
-
-// AdvanceDeal is unsupported until branch 2's write-back path lands.
-func (p *Provider) AdvanceDeal(_ context.Context, _ datasource.AdvanceDealInput) (datasource.EntityRef, error) {
-	return datasource.EntityRef{}, apperrors.ErrUnsupportedBySoR
-}
-
-// Archive is unsupported until branch 2's write-back path lands.
-func (p *Provider) Archive(_ context.Context, _ datasource.EntityRef) (datasource.EntityRef, error) {
-	return datasource.EntityRef{}, apperrors.ErrUnsupportedBySoR
-}
-
-// Merge is unsupported until branch 2's write-back path lands.
-func (p *Provider) Merge(_ context.Context, _ datasource.MergeInput) (datasource.EntityRef, error) {
-	return datasource.EntityRef{}, apperrors.ErrUnsupportedBySoR
-}
-
-// PromoteLead is unsupported until branch 2's write-back path lands.
-func (p *Provider) PromoteLead(_ context.Context, _ ids.UUID, _ string, _ *string) (datasource.EntityRef, bool, error) {
-	return datasource.EntityRef{}, false, apperrors.ErrUnsupportedBySoR
 }
 
 // Freshness delegates to ff (the metered force-fresh reader) when

--- a/backend/internal/modules/overlay/provider_test.go
+++ b/backend/internal/modules/overlay/provider_test.go
@@ -14,38 +14,19 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
 )
 
-// TestProviderWriteVerbsUnsupported proves every write verb declares
-// itself unsupported rather than silently no-op or panic — overlay mode
-// has no write-back path until branch 2. NewProvider(nil, nil) is
-// sufficient because none of these verbs touch the mirror store or the
-// freshness reader.
-func TestProviderWriteVerbsUnsupported(t *testing.T) {
+// TestProviderUnsupportedVerbs proves the verbs overlay V1 genuinely
+// cannot project onto a single incumbent-first write declare themselves
+// unsupported rather than silently no-op or panic (OVA-MAP-W6):
+// AdvanceDeal (blocked on the overlay stage-map substrate StageSemantic
+// also lacks), and Merge/PromoteLead (cross-aggregate lifecycle
+// orchestrations with no atomic incumbent projection). Create/Update/
+// Archive ARE supported — see the object-gate and write-back tests below.
+func TestProviderUnsupportedVerbs(t *testing.T) {
 	p := NewProvider(nil, nil)
 	ctx := context.Background()
 
-	t.Run("Create", func(t *testing.T) {
-		_, err := p.Create(ctx, datasource.CreateInput{EntityType: datasource.EntityPerson})
-		if !errors.Is(err, apperrors.ErrUnsupportedBySoR) {
-			t.Fatalf("want ErrUnsupportedBySoR, got %v", err)
-		}
-	})
-
-	t.Run("Update", func(t *testing.T) {
-		_, err := p.Update(ctx, datasource.UpdateInput{Ref: datasource.EntityRef{Type: datasource.EntityPerson}})
-		if !errors.Is(err, apperrors.ErrUnsupportedBySoR) {
-			t.Fatalf("want ErrUnsupportedBySoR, got %v", err)
-		}
-	})
-
 	t.Run("AdvanceDeal", func(t *testing.T) {
 		_, err := p.AdvanceDeal(ctx, datasource.AdvanceDealInput{})
-		if !errors.Is(err, apperrors.ErrUnsupportedBySoR) {
-			t.Fatalf("want ErrUnsupportedBySoR, got %v", err)
-		}
-	})
-
-	t.Run("Archive", func(t *testing.T) {
-		_, err := p.Archive(ctx, datasource.EntityRef{Type: datasource.EntityPerson})
 		if !errors.Is(err, apperrors.ErrUnsupportedBySoR) {
 			t.Fatalf("want ErrUnsupportedBySoR, got %v", err)
 		}
@@ -67,6 +48,52 @@ func TestProviderWriteVerbsUnsupported(t *testing.T) {
 			t.Fatal("an unsupported call must never report merged=true")
 		}
 	})
+}
+
+// TestProviderWriteVerbsObjectGateBeforeTheIncumbent proves the write
+// verbs apply object RBAC (auth.Require) BEFORE reaching the incumbent —
+// the same MCP-bypass closure the read verbs carry: a bound principal
+// whose role grants no write capability is refused with
+// ErrPermissionDenied, and the incumbent is never touched (the nil
+// resolver would otherwise error differently). auth.Require runs first,
+// so this stays a pure unit test.
+func TestProviderWriteVerbsObjectGateBeforeTheIncumbent(t *testing.T) {
+	p := NewProvider(&MirrorStore{}, nil)
+	ctx := principal.WithActor(context.Background(), principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:no-grants",
+		Permissions: principal.Permissions{RoleKeys: []string{"rep"}},
+	})
+	ref := datasource.EntityRef{Type: datasource.EntityPerson, ID: ids.NewV7()}
+
+	if _, err := p.Create(ctx, datasource.CreateInput{EntityType: datasource.EntityPerson}); !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Errorf("Create without a person create grant: err = %v, want ErrPermissionDenied", err)
+	}
+	if _, err := p.Update(ctx, datasource.UpdateInput{Ref: ref}); !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Errorf("Update without a person update grant: err = %v, want ErrPermissionDenied", err)
+	}
+	if _, err := p.Archive(ctx, ref); !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Errorf("Archive without a person delete grant: err = %v, want ErrPermissionDenied", err)
+	}
+}
+
+// TestProviderWriteWithoutIncumbentResolver proves a permitted write
+// against a Provider with no incumbent write resolver wired fails with a
+// clear configuration error — never a nil-pointer panic and never a
+// misleading ErrUnsupportedBySoR (Create/Update/Archive ARE supported
+// verbs; the resolver is simply absent).
+func TestProviderWriteWithoutIncumbentResolver(t *testing.T) {
+	p := NewProvider(&MirrorStore{}, nil)
+	ctx := principal.WithActor(context.Background(), principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:granted",
+		Permissions: principal.Permissions{
+			Objects:  map[string]principal.ObjectGrant{"person": {Create: true, Update: true, Delete: true}},
+			RowScope: principal.RowScopeAll,
+		},
+	})
+	_, err := p.Create(ctx, datasource.CreateInput{EntityType: datasource.EntityPerson})
+	if err == nil || errors.Is(err, apperrors.ErrUnsupportedBySoR) {
+		t.Fatalf("Create with no resolver: err = %v, want a clear configuration error", err)
+	}
 }
 
 // TestProviderRunReportUnsupported proves RunReport declares itself

--- a/backend/internal/modules/overlay/provider_writeback_integration_test.go
+++ b/backend/internal/modules/overlay/provider_writeback_integration_test.go
@@ -1,0 +1,260 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package overlay
+
+// The write-back engine's real-Postgres proof (AC-OV-4): an overlay write
+// is incumbent-first, and the mirror is never marked authoritative ahead of
+// the incumbent's ack. These assert the Provider↔mirror behavior — the
+// incumbent's own drift check is unit-tested at the adapter seam
+// (hubspot.TestAdapterUpdateRefusesOnBaselineDrift). The controllable
+// incumbent double lets each test drive the exact ack/reject the Provider
+// must honor.
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+)
+
+// writeBackIncumbent is a controllable Incumbent for the Provider write
+// tests: read verbs are not fixtured (write-back reads baselines from the
+// mirror, never the incumbent), and each write verb returns exactly what
+// the test configures — so the Provider's incumbent-first contract can be
+// asserted against a known ack or reject.
+type writeBackIncumbent struct {
+	createRec  Record
+	createErr  error
+	updateRec  Record
+	updateErr  error
+	archiveErr error
+	archived   bool
+}
+
+func (w *writeBackIncumbent) Name() string { return "writeback-double" }
+func (w *writeBackIncumbent) Backfill(context.Context, string, string) (Page, error) {
+	return Page{}, errNotFixtured()
+}
+
+func (w *writeBackIncumbent) Modified(context.Context, string, time.Time, string) (Page, error) {
+	return Page{}, errNotFixtured()
+}
+
+func (w *writeBackIncumbent) Deletions(context.Context, string, time.Time, string) (DeletionPage, error) {
+	return DeletionPage{}, errNotFixtured()
+}
+
+func (w *writeBackIncumbent) Get(context.Context, string, string) (Record, error) {
+	return Record{}, errNotFixtured()
+}
+
+func (w *writeBackIncumbent) Associations(context.Context, string, string, string) ([]Assoc, error) {
+	return nil, errNotFixtured()
+}
+
+func (w *writeBackIncumbent) OwnerEmail(context.Context, string) (string, error) {
+	return "", errNotFixtured()
+}
+func (w *writeBackIncumbent) Owners(context.Context) ([]OwnerRef, error) { return nil, nil }
+
+func (w *writeBackIncumbent) Create(context.Context, string, map[string]any) (Record, error) {
+	return w.createRec, w.createErr
+}
+
+func (w *writeBackIncumbent) Update(context.Context, string, string, map[string]any, time.Time) (Record, error) {
+	return w.updateRec, w.updateErr
+}
+
+func (w *writeBackIncumbent) Archive(context.Context, string, string) error {
+	w.archived = true
+	return w.archiveErr
+}
+
+func errNotFixtured() error { return errors.New("writeBackIncumbent: read verb not fixtured") }
+
+// providerFor constructs the Provider the write tests drive: a real
+// MirrorStore over pool plus the controllable incumbent, wired through the
+// production resolver hook.
+func providerFor(ms *MirrorStore, inc Incumbent) *Provider {
+	p := NewProvider(ms, nil)
+	p.SetFreshnessIncumbentResolver(func(context.Context) (Incumbent, error) { return inc, nil })
+	return p
+}
+
+// writebackOwner is the incumbent owner every write-back fixture maps the
+// acting user to — the one spelling shared by mapActorToOwner and each
+// seeded row's OwnerExternalID, so the mirror_visibility deny-join lets the
+// actor see the rows the write verbs operate on.
+const writebackOwner = "owner-1"
+
+// mapActorToOwner maps the acting user to writebackOwner so the
+// mirror_visibility deny-join lets it see rows owned by that owner — the
+// same visibility setup the freshness fixtures use.
+func mapActorToOwner(ctx context.Context, t *testing.T, ms *MirrorStore) {
+	t.Helper()
+	actor, ok := principal.Actor(ctx)
+	if !ok {
+		t.Fatal("no actor bound")
+	}
+	if err := ms.UpsertUserMap(ctx, ids.From[ids.UserKind](actor.UserID), "hubspot", writebackOwner, "manual"); err != nil {
+		t.Fatalf("mapping actor to owner %s: %v", writebackOwner, err)
+	}
+}
+
+// TestProviderCreateMirrorsIncumbentResult: Create is incumbent-first — the
+// incumbent's returned state is ingested into the mirror so a follow-up
+// read sees the record, and the returned ref round-trips to it.
+func TestProviderCreateMirrorsIncumbentResult(t *testing.T) {
+	ctx, pool, _ := testWorkspaceCtx(t)
+	ms := NewMirrorStore(pool, noOwnerEmails{})
+	mapActorToOwner(ctx, t, ms)
+
+	inc := &writeBackIncumbent{createRec: Record{
+		ObjectClass:     "person",
+		ExternalID:      "555",
+		Fields:          map[string]any{"first_name": "Ada", "full_name": "Ada Lovelace"},
+		ModifiedAt:      time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+		OwnerExternalID: writebackOwner,
+	}}
+	p := providerFor(ms, inc)
+
+	ref, err := p.Create(ctx, datasource.CreateInput{
+		EntityType: datasource.EntityPerson,
+		Fields:     map[string]any{"first_name": "Ada", "last_name": "Lovelace"},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	rec, err := p.Read(ctx, ref)
+	if err != nil {
+		t.Fatalf("Read after Create: %v", err)
+	}
+	// A mirror read is never authoritative — the incumbent stays the SoR.
+	if rec.Freshness.Authoritative {
+		t.Error("a mirrored write result must not claim incumbent authority (T2, AC-OV-5)")
+	}
+}
+
+// TestProviderUpdateRejectsIncumbentSkewLeavingMirrorUntouched (AC-OV-4):
+// when the incumbent rejects the write with version skew, the Provider
+// surfaces it to the caller AND leaves the mirror row exactly as it was —
+// the mirror is never advanced ahead of an incumbent ack.
+func TestProviderUpdateRejectsIncumbentSkewLeavingMirrorUntouched(t *testing.T) {
+	ctx, pool, _ := testWorkspaceCtx(t)
+	ms := NewMirrorStore(pool, noOwnerEmails{})
+	mapActorToOwner(ctx, t, ms)
+
+	// Seed the mirror row the caller read (baseline captured here).
+	baseline := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	if err := ms.Ingest(ctx, Record{
+		ObjectClass:     "person",
+		ExternalID:      "555",
+		Fields:          map[string]any{"first_name": "Ada", "full_name": "Ada"},
+		ModifiedAt:      baseline,
+		OwnerExternalID: writebackOwner,
+	}); err != nil {
+		t.Fatalf("seeding mirror: %v", err)
+	}
+
+	inc := &writeBackIncumbent{updateErr: apperrors.ErrVersionSkew}
+	p := providerFor(ms, inc)
+
+	ref := datasource.EntityRef{Type: datasource.EntityPerson}
+	id, err := externalIDToUUID("555")
+	if err != nil {
+		t.Fatalf("bridging id: %v", err)
+	}
+	ref.ID = id
+
+	_, err = p.Update(ctx, datasource.UpdateInput{
+		Ref:   ref,
+		Patch: map[string]any{"first_name": "Changed"},
+	})
+	if !errors.Is(err, apperrors.ErrVersionSkew) {
+		t.Fatalf("Update on incumbent skew: err = %v, want ErrVersionSkew", err)
+	}
+
+	// The mirror row must be untouched — still the original first_name.
+	row, err := ms.Get(ctx, "person", "555")
+	if err != nil {
+		t.Fatalf("re-reading mirror row: %v", err)
+	}
+	if row.Fields["first_name"] != "Ada" {
+		t.Errorf("mirror first_name = %v, want unchanged 'Ada' after a rejected write", row.Fields["first_name"])
+	}
+}
+
+// TestProviderUpdateMirrorsResultOnAck: a successful incumbent update is
+// re-mirrored, so the mirror reflects the acked state.
+func TestProviderUpdateMirrorsResultOnAck(t *testing.T) {
+	ctx, pool, _ := testWorkspaceCtx(t)
+	ms := NewMirrorStore(pool, noOwnerEmails{})
+	mapActorToOwner(ctx, t, ms)
+
+	baseline := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	if err := ms.Ingest(ctx, Record{
+		ObjectClass: "person", ExternalID: "555",
+		Fields:     map[string]any{"first_name": "Ada", "full_name": "Ada"},
+		ModifiedAt: baseline, OwnerExternalID: writebackOwner,
+	}); err != nil {
+		t.Fatalf("seeding mirror: %v", err)
+	}
+
+	inc := &writeBackIncumbent{updateRec: Record{
+		ObjectClass: "person", ExternalID: "555",
+		Fields:     map[string]any{"first_name": "Ada2", "full_name": "Ada2"},
+		ModifiedAt: baseline.Add(time.Hour), OwnerExternalID: writebackOwner,
+	}}
+	p := providerFor(ms, inc)
+
+	id, _ := externalIDToUUID("555")
+	ref := datasource.EntityRef{Type: datasource.EntityPerson, ID: id}
+	if _, err := p.Update(ctx, datasource.UpdateInput{Ref: ref, Patch: map[string]any{"first_name": "Ada2"}}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	row, err := ms.Get(ctx, "person", "555")
+	if err != nil {
+		t.Fatalf("re-reading mirror: %v", err)
+	}
+	if row.Fields["first_name"] != "Ada2" {
+		t.Errorf("mirror first_name = %v, want 'Ada2' after acked write", row.Fields["first_name"])
+	}
+}
+
+// TestProviderArchivePurgesMirror: Archive removes the mirror row after the
+// incumbent archive so it stops being readable.
+func TestProviderArchivePurgesMirror(t *testing.T) {
+	ctx, pool, _ := testWorkspaceCtx(t)
+	ms := NewMirrorStore(pool, noOwnerEmails{})
+	mapActorToOwner(ctx, t, ms)
+
+	if err := ms.Ingest(ctx, Record{
+		ObjectClass: "person", ExternalID: "555",
+		Fields:     map[string]any{"first_name": "Ada", "full_name": "Ada"},
+		ModifiedAt: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC), OwnerExternalID: writebackOwner,
+	}); err != nil {
+		t.Fatalf("seeding mirror: %v", err)
+	}
+
+	inc := &writeBackIncumbent{}
+	p := providerFor(ms, inc)
+
+	id, _ := externalIDToUUID("555")
+	if _, err := p.Archive(ctx, datasource.EntityRef{Type: datasource.EntityPerson, ID: id}); err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+	if !inc.archived {
+		t.Error("Archive must reach the incumbent")
+	}
+	if _, err := ms.Get(ctx, "person", "555"); !errors.Is(err, apperrors.ErrNotFound) {
+		t.Errorf("mirror row after Archive: err = %v, want ErrNotFound (purged)", err)
+	}
+}

--- a/backend/internal/modules/overlay/provider_writeback_integration_test.go
+++ b/backend/internal/modules/overlay/provider_writeback_integration_test.go
@@ -15,6 +15,7 @@ package overlay
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"
@@ -136,6 +137,15 @@ func TestProviderCreateMirrorsIncumbentResult(t *testing.T) {
 	rec, err := p.Read(ctx, ref)
 	if err != nil {
 		t.Fatalf("Read after Create: %v", err)
+	}
+	// The incumbent's returned state must actually be ingested — assert the
+	// field content, not just that a row exists.
+	var fields map[string]any
+	if err := json.Unmarshal(rec.Fields, &fields); err != nil {
+		t.Fatalf("decoding read-back fields: %v", err)
+	}
+	if fields["first_name"] != "Ada" {
+		t.Errorf("mirrored first_name = %v, want 'Ada' (the incumbent's created state)", fields["first_name"])
 	}
 	// A mirror read is never authoritative — the incumbent stays the SoR.
 	if rec.Freshness.Authoritative {

--- a/backend/internal/modules/overlay/provider_writeback_integration_test.go
+++ b/backend/internal/modules/overlay/provider_writeback_integration_test.go
@@ -20,6 +20,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -74,7 +78,7 @@ func (w *writeBackIncumbent) Update(context.Context, string, string, map[string]
 	return w.updateRec, w.updateErr
 }
 
-func (w *writeBackIncumbent) Archive(context.Context, string, string) error {
+func (w *writeBackIncumbent) Archive(context.Context, string, string, time.Time) error {
 	w.archived = true
 	return w.archiveErr
 }
@@ -95,6 +99,21 @@ func providerFor(ms *MirrorStore, inc Incumbent) *Provider {
 // seeded row's OwnerExternalID, so the mirror_visibility deny-join lets the
 // actor see the rows the write verbs operate on.
 const writebackOwner = "owner-1"
+
+// seedActiveConnection inserts the active incumbent_connection a connected
+// overlay workspace has — the row the write-back's disconnect fence
+// (mirrorWriteResult's WithFence) asserts before re-mirroring, so a write on a
+// connected workspace is not spuriously aborted as a teardown race.
+func seedActiveConnection(ctx context.Context, t *testing.T, pool *pgxpool.Pool) {
+	t.Helper()
+	if err := database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `INSERT INTO incumbent_connection (workspace_id, incumbent, region, credential_ref, status)
+			VALUES (current_setting('app.workspace_id')::uuid, 'hubspot', 'eu1', 'ref-writeback', 'active')`)
+		return err
+	}); err != nil {
+		t.Fatalf("seeding active connection: %v", err)
+	}
+}
 
 // mapActorToOwner maps the acting user to writebackOwner so the
 // mirror_visibility deny-join lets it see rows owned by that owner — the
@@ -117,6 +136,7 @@ func TestProviderCreateMirrorsIncumbentResult(t *testing.T) {
 	ctx, pool, _ := testWorkspaceCtx(t)
 	ms := NewMirrorStore(pool, noOwnerEmails{})
 	mapActorToOwner(ctx, t, ms)
+	seedActiveConnection(ctx, t, pool)
 
 	inc := &writeBackIncumbent{createRec: Record{
 		ObjectClass:     "person",
@@ -161,6 +181,7 @@ func TestProviderUpdateRejectsIncumbentSkewLeavingMirrorUntouched(t *testing.T) 
 	ctx, pool, _ := testWorkspaceCtx(t)
 	ms := NewMirrorStore(pool, noOwnerEmails{})
 	mapActorToOwner(ctx, t, ms)
+	seedActiveConnection(ctx, t, pool)
 
 	// Seed the mirror row the caller read (baseline captured here).
 	baseline := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
@@ -208,6 +229,7 @@ func TestProviderUpdateMirrorsResultOnAck(t *testing.T) {
 	ctx, pool, _ := testWorkspaceCtx(t)
 	ms := NewMirrorStore(pool, noOwnerEmails{})
 	mapActorToOwner(ctx, t, ms)
+	seedActiveConnection(ctx, t, pool)
 
 	baseline := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
 	if err := ms.Ingest(ctx, Record{
@@ -245,6 +267,7 @@ func TestProviderArchivePurgesMirror(t *testing.T) {
 	ctx, pool, _ := testWorkspaceCtx(t)
 	ms := NewMirrorStore(pool, noOwnerEmails{})
 	mapActorToOwner(ctx, t, ms)
+	seedActiveConnection(ctx, t, pool)
 
 	if err := ms.Ingest(ctx, Record{
 		ObjectClass: "person", ExternalID: "555",

--- a/backend/internal/modules/overlay/provider_writes.go
+++ b/backend/internal/modules/overlay/provider_writes.go
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package overlay
+
+// This file is the overlay Provider's write half: the datasource
+// SystemOfRecordProvider write verbs over the incumbent-first write-back
+// path (design.md §4.5, OVA-MAP-W). Create/Update/Archive project the
+// canonical write onto the incumbent BELOW the seam (the adapter's
+// mapWrite), write incumbent-first, and re-mirror the incumbent's returned
+// state; the drift check (AC-OV-4) lives in the adapter's Update. Merge,
+// PromoteLead, and AdvanceDeal stay unsupported (OVA-MAP-W6 + the missing
+// overlay stage-map) — see each method.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+)
+
+// errNoWriteIncumbent is the honest answer a supported write verb gives
+// when the Provider has no incumbent write resolver wired (only the
+// write-verb unit tests reach this) — a clear, actionable configuration
+// error rather than a nil-pointer panic, and NOT ErrUnsupportedBySoR
+// (Create/Update/Archive are supported verbs; the resolver is just absent).
+func errNoWriteIncumbent() error {
+	return fmt.Errorf("overlay: provider has no incumbent write resolver configured")
+}
+
+// writeIncumbent resolves the acting workspace's live incumbent for a
+// write. It never returns nil without an error.
+//
+//nolint:ireturn // resolving the incumbent seam interface IS the purpose — the write path is incumbent-agnostic by design (design.md §4.5)
+func (p *Provider) writeIncumbent(ctx context.Context) (Incumbent, error) {
+	if p.resolveIncumbent == nil {
+		return nil, errNoWriteIncumbent()
+	}
+	return p.resolveIncumbent(ctx)
+}
+
+// canonicalFields normalizes the frozen seam's typed write payload
+// (CreateInput.Fields / UpdateInput.Patch — the contract request struct in
+// process, raw agent JSON over MCP) into the canonical field bag the
+// adapter's mapWrite projects onto incumbent properties. The keys are the
+// contract's JSON field names (first_name, amount_minor, kind, …), exactly
+// what mapWrite consumes. An empty payload is an empty bag, not an error —
+// the adapter decides whether a no-writable-field write is a no-op (Update)
+// or an error (Create).
+//
+//craft:ignore naked-any the frozen seam's write payload is declared any (ports/datasource); this normalizes it into the canonical bag
+func canonicalFields(v any) (map[string]any, error) {
+	raw, err := datasource.RawFields(v)
+	if err != nil {
+		return nil, err
+	}
+	fields := map[string]any{}
+	if len(raw) == 0 {
+		return fields, nil
+	}
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return nil, fmt.Errorf("overlay: decoding write fields: %w", err)
+	}
+	return fields, nil
+}
+
+// Create writes a new record to the incumbent (incumbent-first, AC-OV-4)
+// and mirrors the incumbent's returned state. The object RBAC gate runs
+// FIRST — the same MCP-bypass closure the read verbs carry, since the MCP
+// write path reaches the provider directly. The canonical write is
+// projected onto incumbent properties BELOW the seam (the adapter's
+// mapWrite, OVA-MAP-W); the Provider stays incumbent-agnostic.
+func (p *Provider) Create(ctx context.Context, in datasource.CreateInput) (datasource.EntityRef, error) {
+	if err := auth.Require(ctx, string(in.EntityType), principal.ActionCreate); err != nil {
+		return datasource.EntityRef{}, err
+	}
+	inc, err := p.writeIncumbent(ctx)
+	if err != nil {
+		return datasource.EntityRef{}, err
+	}
+	fields, err := canonicalFields(in.Fields)
+	if err != nil {
+		return datasource.EntityRef{}, err
+	}
+	rec, err := inc.Create(ctx, string(in.EntityType), fields)
+	if err != nil {
+		return datasource.EntityRef{}, err
+	}
+	if err := p.mirrorWriteResult(ctx, rec); err != nil {
+		return datasource.EntityRef{}, err
+	}
+	id, err := externalIDToUUID(rec.ExternalID)
+	if err != nil {
+		return datasource.EntityRef{}, err
+	}
+	return datasource.EntityRef{Type: in.EntityType, ID: id}, nil
+}
+
+// Update applies a patch incumbent-first after the stored-baseline drift
+// check (AC-OV-4): the mirror row supplies the baseline captured at
+// mirror-read, and the adapter refuses with ErrVersionSkew (surfaced as a
+// 412 by the transport) if the incumbent moved since — never a blind
+// overwrite. On success the incumbent's returned state is re-mirrored.
+//
+// Overlay's optimistic concurrency IS this incumbent stored-baseline drift
+// check, not a mirror row version: an overlay read carries no integer
+// Version (recordFromRow), so in.IfVersion has nothing to compare against
+// here and the incumbent's own record clock is the authority (design.md
+// §4.5).
+func (p *Provider) Update(ctx context.Context, in datasource.UpdateInput) (datasource.EntityRef, error) {
+	if err := auth.Require(ctx, string(in.Ref.Type), principal.ActionUpdate); err != nil {
+		return datasource.EntityRef{}, err
+	}
+	inc, err := p.writeIncumbent(ctx)
+	if err != nil {
+		return datasource.EntityRef{}, err
+	}
+	if p.ms == nil {
+		return datasource.EntityRef{}, errNoMirrorStore()
+	}
+	externalID := uuidToExternalID(in.Ref.ID)
+	// The mirror row supplies both the row-scope visibility gate (Get is
+	// visibility-joined) and the drift-check baseline. A row the actor
+	// cannot see is ErrNotFound here, exactly as on read.
+	row, err := p.ms.Get(ctx, string(in.Ref.Type), externalID)
+	if err != nil {
+		return datasource.EntityRef{}, err
+	}
+	fields, err := canonicalFields(in.Patch)
+	if err != nil {
+		return datasource.EntityRef{}, err
+	}
+	// An activity patch selects its incumbent engagement class by kind
+	// (OVA-MAP-W3); a partial patch may omit it, so carry the mirror row's
+	// kind forward — it is consistent with the namespaced external_id by
+	// construction (the read mapping set both from the source class).
+	if in.Ref.Type == datasource.EntityActivity {
+		if _, ok := fields["kind"]; !ok {
+			if kind, ok := row.Fields["kind"]; ok {
+				fields["kind"] = kind
+			}
+		}
+	}
+	rec, err := inc.Update(ctx, string(in.Ref.Type), externalID, fields, row.UpdatedAtBaseline)
+	if err != nil {
+		return datasource.EntityRef{}, err
+	}
+	if err := p.mirrorWriteResult(ctx, rec); err != nil {
+		return datasource.EntityRef{}, err
+	}
+	return in.Ref, nil
+}
+
+// Archive removes a record from the incumbent (its own archive/delete) and
+// purges the mirror row so it stops being readable, rather than lingering
+// visible until the next sync.
+func (p *Provider) Archive(ctx context.Context, r datasource.EntityRef) (datasource.EntityRef, error) {
+	if err := auth.Require(ctx, string(r.Type), principal.ActionDelete); err != nil {
+		return datasource.EntityRef{}, err
+	}
+	inc, err := p.writeIncumbent(ctx)
+	if err != nil {
+		return datasource.EntityRef{}, err
+	}
+	if p.ms == nil {
+		return datasource.EntityRef{}, errNoMirrorStore()
+	}
+	externalID := uuidToExternalID(r.ID)
+	// Row-scope gate before the destructive incumbent call: a record the
+	// actor cannot see is ErrNotFound, never archived on their behalf.
+	if _, err := p.ms.Get(ctx, string(r.Type), externalID); err != nil {
+		return datasource.EntityRef{}, err
+	}
+	if err := inc.Archive(ctx, string(r.Type), externalID); err != nil {
+		return datasource.EntityRef{}, err
+	}
+	if _, err := p.ms.PurgeRecord(ctx, Deletion{ObjectClass: string(r.Type), ExternalID: externalID}); err != nil {
+		return datasource.EntityRef{}, err
+	}
+	return r, nil
+}
+
+// mirrorWriteResult ingests the incumbent's post-write state into the
+// mirror so a follow-up read sees the write without waiting for the sync
+// poller. Ingest's staleness guard admits it (the write bumped the
+// incumbent's baseline past the mirror's), and the mirror stays
+// non-authoritative (T2) — the incumbent remains the system of record.
+func (p *Provider) mirrorWriteResult(ctx context.Context, rec Record) error {
+	if p.ms == nil {
+		return errNoMirrorStore()
+	}
+	return p.ms.Ingest(ctx, rec)
+}
+
+// AdvanceDeal is unsupported in overlay V1: advancing an overlay deal
+// resolves its target through the overlay stage-mapping to the incumbent
+// dealstage (OVA-MAP-W4), but that incumbent stage-map substrate does not
+// exist yet — it is the SAME missing source StageSemantic declares
+// unsupported. Implemented together with the stage-map, not faked with a
+// native UUID overlay deals never carry.
+func (p *Provider) AdvanceDeal(_ context.Context, _ datasource.AdvanceDealInput) (datasource.EntityRef, error) {
+	return datasource.EntityRef{}, apperrors.ErrUnsupportedBySoR
+}
+
+// Merge is unsupported in overlay (OVA-MAP-W6): a cross-aggregate
+// lifecycle orchestration with no single incumbent-first projection —
+// staged for V1 rather than a partial, non-atomic incumbent write.
+func (p *Provider) Merge(_ context.Context, _ datasource.MergeInput) (datasource.EntityRef, error) {
+	return datasource.EntityRef{}, apperrors.ErrUnsupportedBySoR
+}
+
+// PromoteLead is unsupported in overlay (OVA-MAP-W6): like Merge, a
+// cross-type materialization with no atomic incumbent-first projection.
+func (p *Provider) PromoteLead(_ context.Context, _ ids.UUID, _ string, _ *string) (datasource.EntityRef, bool, error) {
+	return datasource.EntityRef{}, false, apperrors.ErrUnsupportedBySoR
+}

--- a/backend/internal/modules/overlay/provider_writes.go
+++ b/backend/internal/modules/overlay/provider_writes.go
@@ -8,15 +8,17 @@ package overlay
 // path (design.md §4.5, OVA-MAP-W). Create/Update/Archive project the
 // canonical write onto the incumbent BELOW the seam (the adapter's
 // mapWrite), write incumbent-first, and re-mirror the incumbent's returned
-// state; the drift check (AC-OV-4) lives in the adapter's Update. Merge,
-// PromoteLead, and AdvanceDeal stay unsupported (OVA-MAP-W6 + the missing
-// overlay stage-map) — see each method.
+// state; the drift check (AC-OV-4) lives in the adapter's Update/Archive.
+// Merge, PromoteLead, and AdvanceDeal stay unsupported (OVA-MAP-W6 + the
+// missing overlay stage-map) — see each method.
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -25,45 +27,101 @@ import (
 )
 
 // errNoWriteIncumbent is the honest answer a supported write verb gives
-// when the Provider has no incumbent write resolver wired (only the
-// write-verb unit tests reach this) — a clear, actionable configuration
+// when the Provider has no incumbent write resolver wired, or the resolver
+// reports no active incumbent (disconnect/config race) — a clear, actionable
 // error rather than a nil-pointer panic, and NOT ErrUnsupportedBySoR
-// (Create/Update/Archive are supported verbs; the resolver is just absent).
+// (Create/Update/Archive are supported verbs; the incumbent is just absent).
 func errNoWriteIncumbent() error {
 	return fmt.Errorf("overlay: provider has no incumbent write resolver configured")
 }
 
-// writeIncumbent resolves the acting workspace's live incumbent for a
-// write. It never returns nil without an error.
+// writeIncumbent resolves the acting workspace's live incumbent for a write.
+// It never returns a nil Incumbent without an error: resolveOverlayIncumbent
+// legitimately answers (nil, nil) when the active connection is absent or not
+// HubSpot, which must fail closed here rather than nil-panic downstream.
 //
 //nolint:ireturn // resolving the incumbent seam interface IS the purpose — the write path is incumbent-agnostic by design (design.md §4.5)
 func (p *Provider) writeIncumbent(ctx context.Context) (Incumbent, error) {
 	if p.resolveIncumbent == nil {
 		return nil, errNoWriteIncumbent()
 	}
-	return p.resolveIncumbent(ctx)
+	inc, err := p.resolveIncumbent(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if inc == nil {
+		return nil, errNoWriteIncumbent()
+	}
+	return inc, nil
 }
 
-// canonicalFields normalizes the frozen seam's typed write payload
-// (CreateInput.Fields / UpdateInput.Patch — the contract request struct in
-// process, raw agent JSON over MCP) into the canonical field bag the
-// adapter's mapWrite projects onto incumbent properties. The keys are the
-// contract's JSON field names (first_name, amount_minor, kind, …), exactly
-// what mapWrite consumes. An empty payload is an empty bag, not an error —
-// the adapter decides whether a no-writable-field write is a no-op (Update)
-// or an error (Create).
-//
-//craft:ignore naked-any the frozen seam's write payload is declared any (ports/datasource); this normalizes it into the canonical bag
-func canonicalFields(v any) (map[string]any, error) {
+// writeContractTarget returns a fresh pointer to the contract request struct
+// for (entityType, forUpdate) — the type StrictDecode validates the write
+// payload against.
+func writeContractTarget(entityType datasource.EntityType, forUpdate bool) (any, error) {
+	switch entityType {
+	case datasource.EntityPerson:
+		if forUpdate {
+			return &crmcontracts.UpdatePersonRequest{}, nil
+		}
+		return &crmcontracts.CreatePersonRequest{}, nil
+	case datasource.EntityOrganization:
+		if forUpdate {
+			return &crmcontracts.UpdateOrganizationRequest{}, nil
+		}
+		return &crmcontracts.CreateOrganizationRequest{}, nil
+	case datasource.EntityDeal:
+		if forUpdate {
+			return &crmcontracts.UpdateDealRequest{}, nil
+		}
+		return &crmcontracts.CreateDealRequest{}, nil
+	case datasource.EntityLead:
+		if forUpdate {
+			return &crmcontracts.UpdateLeadRequest{}, nil
+		}
+		return &crmcontracts.CreateLeadRequest{}, nil
+	case datasource.EntityActivity:
+		if forUpdate {
+			return &crmcontracts.UpdateActivityRequest{}, nil
+		}
+		return &crmcontracts.CreateActivityRequest{}, nil
+	default:
+		return nil, &datasource.UnsupportedEntityError{Type: string(entityType)}
+	}
+}
+
+// decodeCanonical validates the frozen seam's typed write payload against the
+// entity's contract request struct and normalizes it into the canonical field
+// bag mapWrite consumes. StrictDecode rejects an unknown/misspelled field and
+// a wrong-typed value with an actionable 422 (the same guard the native
+// providers apply), rather than letting a typo silently no-op. The validated
+// struct is then re-marshalled and decoded with UseNumber, so a large
+// amount_minor survives as an exact integer instead of a lossy float64
+// round-trip. The result is always a non-nil map (a JSON-null patch decodes
+// to an empty struct → {}), so callers can inject fields without a nil-map
+// panic.
+func decodeCanonical(entityType datasource.EntityType, forUpdate bool, v any) (map[string]any, error) {
 	raw, err := datasource.RawFields(v)
 	if err != nil {
 		return nil, err
 	}
-	fields := map[string]any{}
-	if len(raw) == 0 {
-		return fields, nil
+	target, err := writeContractTarget(entityType, forUpdate)
+	if err != nil {
+		return nil, err
 	}
-	if err := json.Unmarshal(raw, &fields); err != nil {
+	if len(raw) > 0 {
+		if err := datasource.StrictDecode(raw, target); err != nil {
+			return nil, err
+		}
+	}
+	reencoded, err := json.Marshal(target)
+	if err != nil {
+		return nil, fmt.Errorf("overlay: re-encoding validated write payload: %w", err)
+	}
+	dec := json.NewDecoder(bytes.NewReader(reencoded))
+	dec.UseNumber()
+	fields := map[string]any{}
+	if err := dec.Decode(&fields); err != nil {
 		return nil, fmt.Errorf("overlay: decoding write fields: %w", err)
 	}
 	return fields, nil
@@ -91,17 +149,14 @@ func (p *Provider) Create(ctx context.Context, in datasource.CreateInput) (datas
 	if err := auth.Require(ctx, string(in.EntityType), principal.ActionCreate); err != nil {
 		return datasource.EntityRef{}, err
 	}
+	if p.ms == nil {
+		return datasource.EntityRef{}, errNoMirrorStore()
+	}
 	inc, err := p.writeIncumbent(ctx)
 	if err != nil {
 		return datasource.EntityRef{}, err
 	}
-	// Assert the mirror store up front — like Update/Archive — so a mis-wired
-	// provider fails BEFORE POSTing to the incumbent, never leaving an
-	// orphaned incumbent record that was never mirrored.
-	if p.ms == nil {
-		return datasource.EntityRef{}, errNoMirrorStore()
-	}
-	fields, err := canonicalFields(in.Fields)
+	fields, err := decodeCanonical(in.EntityType, false, in.Fields)
 	if err != nil {
 		return datasource.EntityRef{}, err
 	}
@@ -109,7 +164,7 @@ func (p *Provider) Create(ctx context.Context, in datasource.CreateInput) (datas
 	if err != nil {
 		return datasource.EntityRef{}, err
 	}
-	if err := p.mirrorWriteResult(ctx, rec); err != nil {
+	if err := p.mirrorWriteResult(ctx, inc, rec); err != nil {
 		return datasource.EntityRef{}, err
 	}
 	id, err := externalIDToUUID(rec.ExternalID)
@@ -128,18 +183,17 @@ func (p *Provider) Create(ctx context.Context, in datasource.CreateInput) (datas
 // Overlay's optimistic concurrency IS this incumbent stored-baseline drift
 // check, not a mirror row version: an overlay read carries no integer
 // Version (recordFromRow), so in.IfVersion has nothing to compare against
-// here and the incumbent's own record clock is the authority (design.md
-// §4.5).
+// here and the incumbent's own record clock is the authority (design.md §4.5).
 func (p *Provider) Update(ctx context.Context, in datasource.UpdateInput) (datasource.EntityRef, error) {
 	if err := auth.Require(ctx, string(in.Ref.Type), principal.ActionUpdate); err != nil {
 		return datasource.EntityRef{}, err
 	}
+	if p.ms == nil {
+		return datasource.EntityRef{}, errNoMirrorStore()
+	}
 	inc, err := p.writeIncumbent(ctx)
 	if err != nil {
 		return datasource.EntityRef{}, err
-	}
-	if p.ms == nil {
-		return datasource.EntityRef{}, errNoMirrorStore()
 	}
 	externalID := uuidToExternalID(in.Ref.ID)
 	// The mirror row supplies both the row-scope visibility gate (Get is
@@ -149,70 +203,114 @@ func (p *Provider) Update(ctx context.Context, in datasource.UpdateInput) (datas
 	if err != nil {
 		return datasource.EntityRef{}, err
 	}
-	fields, err := canonicalFields(in.Patch)
+	fields, err := decodeCanonical(in.Ref.Type, true, in.Patch)
 	if err != nil {
 		return datasource.EntityRef{}, err
 	}
-	// An activity patch selects its incumbent engagement class by kind
-	// (OVA-MAP-W3); a partial patch may omit it, so carry the mirror row's
-	// kind forward — it is consistent with the namespaced external_id by
-	// construction (the read mapping set both from the source class).
-	if in.Ref.Type == datasource.EntityActivity {
+	if err := p.completeWritePatch(in.Ref.Type, fields, row); err != nil {
+		return datasource.EntityRef{}, err
+	}
+	rec, err := inc.Update(ctx, string(in.Ref.Type), externalID, fields, row.UpdatedAtBaseline)
+	if err != nil {
+		return datasource.EntityRef{}, err
+	}
+	if err := p.mirrorWriteResult(ctx, inc, rec); err != nil {
+		return datasource.EntityRef{}, err
+	}
+	return in.Ref, nil
+}
+
+// completeWritePatch fills in the cross-field context a partial patch needs to
+// project correctly:
+//   - Deal money is a PAIR — amount_minor scales to the incumbent's decimal
+//     `amount` only under its currency's exponent. A patch that carries one
+//     without the other is rejected rather than silently dropping the money
+//     change or reinterpreting the stored amount under a new exponent
+//     (both present, or neither).
+//   - An activity's kind is immutable and never in the patch (UpdateActivity
+//     has no kind field), so mapWriteActivity's class selector is carried
+//     forward from the mirror row — consistent with the namespaced external_id
+//     by construction (the read mapping set both from the source class).
+func (p *Provider) completeWritePatch(t datasource.EntityType, fields map[string]any, row Row) error {
+	switch t {
+	case datasource.EntityDeal:
+		_, hasAmount := fields["amount_minor"]
+		_, hasCurrency := fields["currency"]
+		if hasAmount != hasCurrency {
+			return fmt.Errorf("%w: a deal amount change must set amount_minor and currency together (the currency's exponent scales the amount)", apperrors.ErrConflict)
+		}
+	case datasource.EntityActivity:
 		if _, ok := fields["kind"]; !ok {
 			if kind, ok := row.Fields["kind"]; ok {
 				fields["kind"] = kind
 			}
 		}
 	}
-	rec, err := inc.Update(ctx, string(in.Ref.Type), externalID, fields, row.UpdatedAtBaseline)
-	if err != nil {
-		return datasource.EntityRef{}, err
-	}
-	if err := p.mirrorWriteResult(ctx, rec); err != nil {
-		return datasource.EntityRef{}, err
-	}
-	return in.Ref, nil
+	return nil
 }
 
-// Archive removes a record from the incumbent (its own archive/delete) and
-// purges the mirror row so it stops being readable, rather than lingering
-// visible until the next sync.
+// archivableTypes are the entity types overlay Archive supports — the same
+// set the native provider archives (person/organization/deal). A lead is
+// retired through its own lifecycle verbs, and an activity is not archivable
+// through this seam; both are refused before any incumbent call, matching the
+// frozen contract rather than issuing a destructive write the native path
+// would reject.
+var archivableTypes = map[datasource.EntityType]bool{
+	datasource.EntityPerson:       true,
+	datasource.EntityOrganization: true,
+	datasource.EntityDeal:         true,
+}
+
+// Archive removes a record from the incumbent (its own archive/delete) after
+// the stored-baseline drift check, then purges the mirror row so it stops
+// being readable rather than lingering visible until the next sync.
 func (p *Provider) Archive(ctx context.Context, r datasource.EntityRef) (datasource.EntityRef, error) {
-	if err := auth.Require(ctx, string(r.Type), principal.ActionDelete); err != nil {
-		return datasource.EntityRef{}, err
+	if !archivableTypes[r.Type] {
+		return datasource.EntityRef{}, &datasource.UnsupportedEntityError{Type: string(r.Type)}
 	}
-	inc, err := p.writeIncumbent(ctx)
-	if err != nil {
+	if err := auth.Require(ctx, string(r.Type), principal.ActionDelete); err != nil {
 		return datasource.EntityRef{}, err
 	}
 	if p.ms == nil {
 		return datasource.EntityRef{}, errNoMirrorStore()
 	}
+	inc, err := p.writeIncumbent(ctx)
+	if err != nil {
+		return datasource.EntityRef{}, err
+	}
 	externalID := uuidToExternalID(r.ID)
-	// Row-scope gate before the destructive incumbent call: a record the
-	// actor cannot see is ErrNotFound, never archived on their behalf.
-	if _, err := p.ms.Get(ctx, string(r.Type), externalID); err != nil {
+	// Row-scope gate + drift baseline: a record the actor cannot see is
+	// ErrNotFound, never archived on their behalf.
+	row, err := p.ms.Get(ctx, string(r.Type), externalID)
+	if err != nil {
 		return datasource.EntityRef{}, err
 	}
-	if err := inc.Archive(ctx, string(r.Type), externalID); err != nil {
+	if err := inc.Archive(ctx, string(r.Type), externalID, row.UpdatedAtBaseline); err != nil {
 		return datasource.EntityRef{}, err
 	}
-	if _, err := p.ms.PurgeRecord(ctx, Deletion{ObjectClass: string(r.Type), ExternalID: externalID}); err != nil {
+	// Purge through the disconnect fence so a teardown racing the archive
+	// cannot leave the row readable, matching the sync path.
+	if _, err := p.ms.WithFence().PurgeRecord(ctx, Deletion{ObjectClass: string(r.Type), ExternalID: externalID}); err != nil {
 		return datasource.EntityRef{}, err
 	}
 	return r, nil
 }
 
-// mirrorWriteResult ingests the incumbent's post-write state into the
-// mirror so a follow-up read sees the write without waiting for the sync
-// poller. Ingest's staleness guard admits it (the write bumped the
-// incumbent's baseline past the mirror's), and the mirror stays
-// non-authoritative (T2) — the incumbent remains the system of record.
-func (p *Provider) mirrorWriteResult(ctx context.Context, rec Record) error {
+// mirrorWriteResult ingests the incumbent's post-write state into the mirror
+// so a follow-up read sees the write without waiting for the sync poller.
+// It binds the store to the LIVE incumbent (WithResolver) so Ingest's owner
+// re-validation resolves against the real adapter — not the read-path
+// placeholder that always fails — and engages the disconnect fence
+// (WithFence) so a write landing after a Disconnect cannot repopulate the
+// purged mirror (it aborts with ErrConnectionGone). Ingest's staleness guard
+// admits the row (the write bumped the incumbent's baseline past the
+// mirror's), and the mirror stays non-authoritative (T2) — the incumbent
+// remains the system of record.
+func (p *Provider) mirrorWriteResult(ctx context.Context, inc Incumbent, rec Record) error {
 	if p.ms == nil {
 		return errNoMirrorStore()
 	}
-	return p.ms.Ingest(ctx, rec)
+	return p.ms.WithResolver(inc).WithFence().Ingest(ctx, rec)
 }
 
 // AdvanceDeal is unsupported in overlay V1: advancing an overlay deal

--- a/backend/internal/modules/overlay/provider_writes.go
+++ b/backend/internal/modules/overlay/provider_writes.go
@@ -83,6 +83,12 @@ func (p *Provider) Create(ctx context.Context, in datasource.CreateInput) (datas
 	if err != nil {
 		return datasource.EntityRef{}, err
 	}
+	// Assert the mirror store up front — like Update/Archive — so a mis-wired
+	// provider fails BEFORE POSTing to the incumbent, never leaving an
+	// orphaned incumbent record that was never mirrored.
+	if p.ms == nil {
+		return datasource.EntityRef{}, errNoMirrorStore()
+	}
 	fields, err := canonicalFields(in.Fields)
 	if err != nil {
 		return datasource.EntityRef{}, err

--- a/backend/internal/modules/overlay/provider_writes.go
+++ b/backend/internal/modules/overlay/provider_writes.go
@@ -17,6 +17,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"reflect"
+	"sort"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
@@ -113,6 +115,14 @@ func decodeCanonical(entityType datasource.EntityType, forUpdate bool, v any) (m
 		if err := datasource.StrictDecode(raw, target); err != nil {
 			return nil, err
 		}
+		// A contract request struct with an AdditionalProperties catch-all
+		// absorbs unknown keys instead of letting StrictDecode's
+		// DisallowUnknownFields reject them, so an unknown/misspelled field
+		// would route there and silently no-op. Reject a non-empty catch-all
+		// so a typo is an actionable error, matching the native 422.
+		if err := rejectExtraProperties(target); err != nil {
+			return nil, err
+		}
 	}
 	reencoded, err := json.Marshal(target)
 	if err != nil {
@@ -125,6 +135,28 @@ func decodeCanonical(entityType datasource.EntityType, forUpdate bool, v any) (m
 		return nil, fmt.Errorf("overlay: decoding write fields: %w", err)
 	}
 	return fields, nil
+}
+
+// rejectExtraProperties reports the unknown keys a contract request struct's
+// AdditionalProperties catch-all absorbed (oapi-codegen routes non-schema keys
+// there). An empty or absent catch-all is fine; a non-empty one is a
+// caller-invalid write (a misspelled or unsupported field) surfaced as a
+// FieldDecodeError so the transport answers 422, not a silent no-op.
+func rejectExtraProperties(target any) error {
+	v := reflect.ValueOf(target)
+	if v.Kind() != reflect.Pointer || v.IsNil() {
+		return nil
+	}
+	f := v.Elem().FieldByName("AdditionalProperties")
+	if !f.IsValid() || f.Kind() != reflect.Map || f.Len() == 0 {
+		return nil
+	}
+	keys := make([]string, 0, f.Len())
+	for _, k := range f.MapKeys() {
+		keys = append(keys, k.String())
+	}
+	sort.Strings(keys)
+	return &datasource.FieldDecodeError{Cause: fmt.Errorf("unknown field(s): %v", keys)}
 }
 
 // Create writes a new record to the incumbent (incumbent-first, AC-OV-4)

--- a/backend/internal/modules/overlay/provider_writes.go
+++ b/backend/internal/modules/overlay/provider_writes.go
@@ -75,6 +75,18 @@ func canonicalFields(v any) (map[string]any, error) {
 // write path reaches the provider directly. The canonical write is
 // projected onto incumbent properties BELOW the seam (the adapter's
 // mapWrite, OVA-MAP-W); the Provider stays incumbent-agnostic.
+//
+// V1 retry-safety limitation: HubSpot's v3 object-create is a bare POST
+// with no caller-supplied idempotency key (no hs_unique_creation_key), so a
+// caller that retries after a mirror-write failure — the incumbent create
+// already committed, the follow-up Ingest did not — can mint a second
+// incumbent object. The orphaned first object is not lost (the reconcile
+// poller mirrors it on its next sweep), but a retried Create is NOT
+// idempotent in V1. Retry-safe create (search-before-create or an
+// alternate-key upsert, per S-E19.3/S-E20.3) is a fast-follow; overlay
+// write-back today is reached only through the 🟡 confirm-first agent path
+// (AC-OV-5), whose approval is human-gated and audited, so an unattended
+// retry storm is not the live exposure.
 func (p *Provider) Create(ctx context.Context, in datasource.CreateInput) (datasource.EntityRef, error) {
 	if err := auth.Require(ctx, string(in.EntityType), principal.ActionCreate); err != nil {
 		return datasource.EntityRef{}, err

--- a/backend/internal/modules/overlay/provider_writes_test.go
+++ b/backend/internal/modules/overlay/provider_writes_test.go
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package overlay
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+)
+
+// decodeCanonical validates the write payload against the entity's contract
+// request struct and normalizes it into the canonical bag mapWrite consumes.
+// These pure unit tests cover the per-entity type switch, unknown-field
+// rejection, and the precision-preserving json.Number round-trip without a DB.
+
+func TestDecodeCanonicalValidPerson(t *testing.T) {
+	fields, err := decodeCanonical(datasource.EntityPerson, false, map[string]any{"first_name": "Ada", "last_name": "Lovelace"})
+	if err != nil {
+		t.Fatalf("decodeCanonical: %v", err)
+	}
+	if fields["first_name"] != "Ada" || fields["last_name"] != "Lovelace" {
+		t.Errorf("bag = %#v, want first_name=Ada last_name=Lovelace", fields)
+	}
+}
+
+func TestDecodeCanonicalRejectsUnknownField(t *testing.T) {
+	// A misspelled field must 422 (like the native providers), not silently
+	// no-op — StrictDecode rejects it.
+	if _, err := decodeCanonical(datasource.EntityPerson, false, map[string]any{"frist_name": "Ada"}); err == nil {
+		t.Error("an unknown/misspelled field must be rejected, not silently dropped")
+	}
+}
+
+func TestDecodeCanonicalPreservesLargeIntPrecision(t *testing.T) {
+	// An UpdateDealRequest is a partial patch (no required pipeline/stage UUID),
+	// so it isolates the amount_minor precision round-trip.
+	fields, err := decodeCanonical(datasource.EntityDeal, true, map[string]any{
+		"amount_minor": int64(9007199254740993), "currency": "JPY",
+	})
+	if err != nil {
+		t.Fatalf("decodeCanonical deal: %v", err)
+	}
+	// The value must arrive as a json.Number carrying the exact digits, never a
+	// rounded float64.
+	n, ok := fields["amount_minor"].(json.Number)
+	if !ok || n.String() != "9007199254740993" {
+		t.Errorf("amount_minor = %#v, want json.Number 9007199254740993 (no float64 rounding)", fields["amount_minor"])
+	}
+}
+
+func TestDecodeCanonicalNilPayloadIsEmptyMap(t *testing.T) {
+	fields, err := decodeCanonical(datasource.EntityPerson, true, nil)
+	if err != nil {
+		t.Fatalf("decodeCanonical nil: %v", err)
+	}
+	if fields == nil {
+		t.Error("a nil payload must decode to a non-nil empty map (no nil-map panic downstream)")
+	}
+}
+
+func TestWriteContractTargetCoversEveryEntity(t *testing.T) {
+	for _, et := range []datasource.EntityType{
+		datasource.EntityPerson, datasource.EntityOrganization, datasource.EntityDeal,
+		datasource.EntityLead, datasource.EntityActivity,
+	} {
+		for _, upd := range []bool{false, true} {
+			target, err := writeContractTarget(et, upd)
+			if err != nil || target == nil {
+				t.Errorf("writeContractTarget(%s, upd=%v) = (%v, %v), want a non-nil target", et, upd, target, err)
+			}
+		}
+	}
+	if _, err := writeContractTarget(datasource.EntityType("widget"), false); err == nil {
+		t.Error("writeContractTarget of an unknown entity must error")
+	}
+}
+
+// completeWritePatch rejects a deal money change that carries only one of the
+// amount_minor/currency pair, and carries an activity's immutable kind forward
+// from the mirror row.
+func TestCompleteWritePatchDealMoneyPair(t *testing.T) {
+	p := NewProvider(nil, nil)
+	cases := []struct {
+		name    string
+		fields  map[string]any
+		wantErr bool
+	}{
+		{"amount only", map[string]any{"amount_minor": json.Number("1000")}, true},
+		{"currency only", map[string]any{"currency": "EUR"}, true},
+		{"both", map[string]any{"amount_minor": json.Number("1000"), "currency": "EUR"}, false},
+		{"neither", map[string]any{"name": "Renamed"}, false},
+	}
+	for _, c := range cases {
+		err := p.completeWritePatch(datasource.EntityDeal, c.fields, Row{})
+		if c.wantErr && !errors.Is(err, apperrors.ErrConflict) {
+			t.Errorf("%s: err = %v, want ErrConflict", c.name, err)
+		}
+		if !c.wantErr && err != nil {
+			t.Errorf("%s: unexpected err %v", c.name, err)
+		}
+	}
+}
+
+func TestCompleteWritePatchActivityCarriesKindForward(t *testing.T) {
+	p := NewProvider(nil, nil)
+	fields := map[string]any{"subject": "Follow up"}
+	row := Row{Fields: map[string]any{"kind": "call"}}
+	if err := p.completeWritePatch(datasource.EntityActivity, fields, row); err != nil {
+		t.Fatalf("completeWritePatch activity: %v", err)
+	}
+	if fields["kind"] != "call" {
+		t.Errorf("kind = %v, want 'call' carried forward from the mirror row", fields["kind"])
+	}
+}

--- a/backend/internal/modules/overlay/reconcile_integration_test.go
+++ b/backend/internal/modules/overlay/reconcile_integration_test.go
@@ -97,7 +97,7 @@ func (s *sweptRecords) Update(context.Context, string, string, map[string]any, t
 	return Record{}, fmt.Errorf("sweptRecords: Update is not fixtured")
 }
 
-func (s *sweptRecords) Archive(context.Context, string, string) error {
+func (s *sweptRecords) Archive(context.Context, string, string, time.Time) error {
 	return fmt.Errorf("sweptRecords: Archive is not fixtured")
 }
 

--- a/backend/internal/modules/overlay/reconcile_integration_test.go
+++ b/backend/internal/modules/overlay/reconcile_integration_test.go
@@ -15,6 +15,7 @@ package overlay
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"testing"
 	"time"
@@ -88,6 +89,17 @@ func (s *sweptRecords) OwnerEmail(context.Context, string) (string, error) {
 }
 
 func (s *sweptRecords) Owners(context.Context) ([]OwnerRef, error) { return nil, nil }
+func (s *sweptRecords) Create(context.Context, string, map[string]any) (Record, error) {
+	return Record{}, fmt.Errorf("sweptRecords: Create is not fixtured")
+}
+
+func (s *sweptRecords) Update(context.Context, string, string, map[string]any, time.Time) (Record, error) {
+	return Record{}, fmt.Errorf("sweptRecords: Update is not fixtured")
+}
+
+func (s *sweptRecords) Archive(context.Context, string, string) error {
+	return fmt.Errorf("sweptRecords: Archive is not fixtured")
+}
 
 func errUnusedFixtureMethod(name string) error {
 	return &fixtureMethodError{name: name}

--- a/backend/internal/modules/overlay/testsupport_integration.go
+++ b/backend/internal/modules/overlay/testsupport_integration.go
@@ -94,8 +94,10 @@ func testWorkspaceCtx(t *testing.T) (context.Context, *pgxpool.Pool, ids.UUID) {
 		Permissions: principal.Permissions{
 			RoleKeys: []string{"admin"},
 			// admin's identity/internal/policy default: full CRUD on
-			// overlay_connection plus Read on the mirrored entities —
-			// hand-built here (see overlayAdminObjectGrants) the same way
+			// overlay_connection AND on the mirrored entities (the entity
+			// write grants are what let the write-back verb tests exercise
+			// Create/Update/Archive) — hand-built here (see
+			// overlayAdminObjectGrants) the same way
 			// internal/modules/consent/dsr_integration_test.go's setupDSR
 			// declares its own object's grant, since this fixture builds a
 			// Principal directly rather than running it through policy.Merge.

--- a/backend/internal/modules/overlay/testsupport_integration.go
+++ b/backend/internal/modules/overlay/testsupport_integration.go
@@ -108,21 +108,22 @@ func testWorkspaceCtx(t *testing.T) (context.Context, *pgxpool.Pool, ids.UUID) {
 
 // overlayAdminObjectGrants is the object-capability set the overlay
 // integration fixtures bind for an admin actor: full CRUD on
-// overlay_connection (Connect/Disconnect are admin/ops-only) plus Read on
-// every mirrored entity type. The entity-Read grants are required now that
-// the overlay Provider object-gates its reads like the native stores —
-// without them the fixture actor would be denied the very mirror rows the
-// read tests assert on. The mirrored-entity set is derived from
-// knownEntityTypes (the provider's own list), so a new mirrored type can
-// never silently lack its fixture grant. RowScope stays all; overlay row
-// scope is the store's mirror_visibility deny-join, not the RBAC owner
-// predicate.
+// overlay_connection (Connect/Disconnect are admin/ops-only) plus full CRUD
+// on every mirrored entity type. The entity grants are required now that
+// the overlay Provider object-gates BOTH its reads and its write-back verbs
+// (Create/Update/Archive) like the native stores — without them the fixture
+// actor would be denied the very mirror rows the read tests assert on and
+// the write-back the write tests exercise. The mirrored-entity set is
+// derived from knownEntityTypes (the provider's own list), so a new mirrored
+// type can never silently lack its fixture grant. RowScope stays all;
+// overlay row scope is the store's mirror_visibility deny-join, not the RBAC
+// owner predicate.
 func overlayAdminObjectGrants() map[string]principal.ObjectGrant {
 	grants := map[string]principal.ObjectGrant{
 		overlayConnectionObject: {Create: true, Read: true, Update: true, Delete: true},
 	}
 	for _, et := range knownEntityTypes {
-		grants[string(et)] = principal.ObjectGrant{Read: true}
+		grants[string(et)] = principal.ObjectGrant{Create: true, Read: true, Update: true, Delete: true}
 	}
 	return grants
 }

--- a/backend/internal/modules/overlay/transforms.go
+++ b/backend/internal/modules/overlay/transforms.go
@@ -139,7 +139,7 @@ func transformAmountMinorByCurrency(v any) (any, error) {
 		}
 		if amount := strings.TrimSpace(amountStr); amount != "" {
 			scale := int64(1)
-			for i := 0; i < iso4217MinorUnitExponent(code); i++ {
+			for i := 0; i < ISO4217MinorUnitExponent(code); i++ {
 				scale *= 10
 			}
 			minor, err := decimalStringToMinor(amount, scale)
@@ -156,12 +156,15 @@ func transformAmountMinorByCurrency(v any) (any, error) {
 	return nil, nil //nolint:nilnil // deliberate: null amount_minor is a valid, non-error mapping result
 }
 
-// iso4217MinorUnitExponent returns a currency's minor-unit exponent. Two is
+// ISO4217MinorUnitExponent returns a currency's minor-unit exponent. Two is
 // ISO-4217's own default and covers the vast majority; the exceptions are the
 // zero-decimal and three-decimal currencies enumerated here. Choosing the
 // exponent from the code — not a blanket ×100 — is what the money model
-// (data-semantics §1 / DM-CONV-9) requires.
-func iso4217MinorUnitExponent(code string) int {
+// (data-semantics §1 / DM-CONV-9) requires. Exported so the HubSpot write
+// mapping (hubspot.mapWrite, OVA-MAP-W2) scales amount_minor BACK to a decimal
+// string against the SAME exponent table the read transform scales it in by —
+// one spelling of the ISO fact, never a second copy that could drift.
+func ISO4217MinorUnitExponent(code string) int {
 	switch code {
 	case "BIF", "CLP", "DJF", "GNF", "ISK", "JPY", "KMF", "KRW", "PYG", "RWF", "UGX", "UYI", "VND", "VUV", "XAF", "XOF", "XPF":
 		return 0

--- a/backend/internal/modules/overlay/usermapseed_integration_test.go
+++ b/backend/internal/modules/overlay/usermapseed_integration_test.go
@@ -67,7 +67,7 @@ func (seedIncumbent) Update(context.Context, string, string, map[string]any, tim
 	return Record{}, fmt.Errorf("seedIncumbent: Update is not fixtured")
 }
 
-func (seedIncumbent) Archive(context.Context, string, string) error {
+func (seedIncumbent) Archive(context.Context, string, string, time.Time) error {
 	return fmt.Errorf("seedIncumbent: Archive is not fixtured")
 }
 

--- a/backend/internal/modules/overlay/usermapseed_integration_test.go
+++ b/backend/internal/modules/overlay/usermapseed_integration_test.go
@@ -34,6 +34,7 @@ func (seedIncumbent) Backfill(context.Context, string, string) (Page, error) {
 func (seedIncumbent) Modified(context.Context, string, time.Time, string) (Page, error) {
 	return Page{}, nil
 }
+
 func (seedIncumbent) Deletions(context.Context, string, time.Time, string) (DeletionPage, error) {
 	return DeletionPage{}, nil
 }
@@ -56,6 +57,18 @@ func (s seedIncumbent) Owners(context.Context) ([]OwnerRef, error) {
 		out = append(out, OwnerRef{ExternalID: id, Email: email})
 	}
 	return out, nil
+}
+
+func (seedIncumbent) Create(context.Context, string, map[string]any) (Record, error) {
+	return Record{}, fmt.Errorf("seedIncumbent: Create is not fixtured")
+}
+
+func (seedIncumbent) Update(context.Context, string, string, map[string]any, time.Time) (Record, error) {
+	return Record{}, fmt.Errorf("seedIncumbent: Update is not fixtured")
+}
+
+func (seedIncumbent) Archive(context.Context, string, string) error {
+	return fmt.Errorf("seedIncumbent: Archive is not fixtured")
 }
 
 // TestConnectSeedsUserMapFromTheOwnersDirectory proves §6.1's primary


### PR DESCRIPTION
## What

Implements the overlay **write-back engine** (branch 2, S-E18.2): a Margince write in overlay mode goes to the incumbent CRM (HubSpot) first, then re-mirrors the incumbent's returned state — the mirror is never marked authoritative ahead of an incumbent ack (**AC-OV-4**). Builds on the now-merged foundation spec (OVA-MAP-W write mapping).

## How

- **`mapwrite.go`** — the canonical→HubSpot write mapping (**OVA-MAP-W1..6**), pinned separately from the read mapping because the read projection isn't a bijection. Read-only/derived fields are never written (person `full_name`, activity `occurred_at`, deal `pipeline_id`/`stage_id`, org `size_band`, lead `email`/`company_name`); a write of only read-only fields is a no-op. Golden write-mapping suite (**AC-OV-12**), the inverse of the OVA-AC-4 read suite — a ÷100-everywhere or `full_name`-splitting impl fails by construction.
- **`writes.go` / `adapter_writes.go`** — the client create/update/archive transport and the adapter's write half, incl. the **stored-baseline drift check**: if the incumbent moved since we mirrored, the write is refused with `ErrVersionSkew` (→412) and nothing is PATCHed (incumbent-wins, never a blind overwrite).
- **`incumbent.go`** — the Incumbent seam extended with `Create`/`Update`/`Archive`.
- **`provider_writes.go`** — the Provider write verbs: **object-RBAC-gated first** (closes the MCP direct-to-provider bypass), incumbent-first, re-mirrored. The write resolver reuses the existing force-fresh incumbent resolver, so production wiring is unchanged.
- **`AdvanceDeal`** stays unsupported (needs the overlay stage-map that `StageSemantic` also lacks — a genuine substrate gap, not a fake); **`Merge`/`PromoteLead`** stay unsupported (OVA-MAP-W6 — no atomic incumbent projection).

## Tests

- Golden write-mapping suite (AC-OV-12), adapter transport + drift-check unit tests, provider write-verb unit tests (RBAC-before-incumbent, no-resolver config error).
- Real-Postgres integration lane (AC-OV-4): incumbent skew leaves the mirror untouched; a successful write re-mirrors; archive purges the mirror row.
- Full `make check-backend` + overlay & compose integration lanes green. Adversarial security review (tenant isolation, RBAC, version-skew, error-leakage, egress-injection) and craft review both incorporated.

## Deliberate scope

The echo-suppression **our-write ledger** (OVA-DDL-6) is **not** in this PR. Its only consumer is webhook echo-suppression (no receiver exists yet, so no echo can occur), and producer + consumer must share one key convention matched to the webhook payload — so the ledger lands coherently with the webhook lane next, where the suppression behavior is end-to-end testable.

Two contract-first reconciliation items surfaced for upstream (noted, not worked around): lead `status`↔`hs_lead_label` needs a pinned bidirectional value map (OVA-MAP-5 defers it, OVA-MAP-W5 assumes it) — deferred in both directions here; and `AdvanceDeal`'s overlay stage-map substrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enabled overlay write-back for creating, updating, and archiving mirrored records, with read-after-write mirror refresh.
  - Added HubSpot write support for mapped record types (including activity duration and task due dates).
  - Enforced capability and object-level permission checks before write-back is attempted.
- **Bug Fixes**
  - Added stale-data/version-skew protection to prevent lost updates.
  - Improved mapping and validation for amounts, durations, and read-only/clear-on-update fields.
  - Standardized third-party error handling (e.g., 404/409) without leaking sensitive details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds incumbent‑first write‑back for HubSpot in overlay mode with Create/Update/Archive routed through the SoR seam, re‑reading and re‑mirroring after incumbent ack. Unknown write fields are now rejected even when request structs allow additional properties.

- **New Features**
  - Overlay provider supports Create, Update, and Archive via the incumbent seam with object RBAC; after each write we re‑read the record and re‑mirror the incumbent’s stored state. V1 creates are not idempotent due to HubSpot limits.
  - Canonical→HubSpot write mapping added; read‑only/derived fields are skipped. Create with only read‑only fields is rejected; Update with only read‑only fields is a no‑op with a stored‑baseline drift check (412). AdvanceDeal, Merge, and PromoteLead remain unsupported.

- **Bug Fixes**
  - Reachability: MCP, API tool registries, and the runner now pass the vault‑backed incumbent resolver; `NewOverlayProvider` wires the write resolver so write‑back no longer returns errNoWriteIncumbent.
  - Validation and field handling: strict decode of request bodies with unknown‑field rejection (including catch‑all structs); empty string clears on Update (skipped on Create); `direction` uppercased; lead and meeting status deferred.
  - Correctness and safety: `amount_minor` parsed with full precision; deal updates require `amount_minor` and `currency` together (409); after Create/Update we re‑read to source `ModifiedAt` from the same watermark used by reads/drift checks; Archive drift‑checks against the mirror baseline; re‑mirror runs with a disconnect fence; guards for nil incumbent resolver and JSON‑null patches; errors map 404→NotFound and 409→Conflict and do not leak HubSpot bodies.

<sup>Written for commit db556fff7900b7a91d82282c818c14c7921af450. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

