### PR TITLE
fix(onboarding): voice drops land anywhere, build outcomes always record

### DIFF
--- a/backend/internal/compose/voicebuild.go
+++ b/backend/internal/compose/voicebuild.go
@@ -166,17 +166,15 @@ func (w *voiceBuildWorker) Work(ctx context.Context, job *river.Job[VoiceBuildAr
 			return nil
 		}
 	}
-	// Terminal transitions run on a detached context: a job timeout must
-	// never cancel the write that records the outcome (deep-read precedent).
-	terminal, cancel := terminalCtx(ctx)
-	defer cancel()
 	claimedAt := claimTime(input)
 	if w.brain == nil {
-		return w.fail(terminal, buildID, claimedAt, "model_unavailable",
+		return w.fail(ctx, buildID, claimedAt, "model_unavailable",
 			"Voice building is unavailable until an AI provider is configured on the worker role.")
 	}
-	if err := w.run(ctx, terminal, buildID, input); err != nil {
+	if err := w.run(ctx, buildID, input); err != nil {
 		if errors.Is(err, ai.ErrBudgetDeferred) {
+			terminal, cancel := terminalCtx(ctx)
+			defer cancel()
 			if deferErr := w.store.DeferBuild(terminal, buildID, claimedAt,
 				"The monthly AI budget is exhausted; the build resumes in the next window.",
 				w.deferralDeadline(err)); deferErr != nil {
@@ -187,7 +185,7 @@ func (w *voiceBuildWorker) Work(ctx context.Context, job *river.Job[VoiceBuildAr
 		// The row carries only the safe detail; the OPERATOR needs the real
 		// cause or a repeated invalid_output is undiagnosable from any log.
 		w.log.WarnContext(ctx, "voice build error", "build", buildID.String(), "err", err)
-		return w.fail(terminal, buildID, claimedAt, failureStatusCode(err), ai.SafeVoiceBuildFailure(err))
+		return w.fail(ctx, buildID, claimedAt, failureStatusCode(err), ai.SafeVoiceBuildFailure(err))
 	}
 	return nil
 }
@@ -236,9 +234,12 @@ func (w *voiceBuildWorker) deferralDeadline(err error) time.Time {
 	return w.now().Add(voiceBuildDeferral)
 }
 
-// run drives extract → evaluate → activate on a claimed build; terminal is
-// the detached context the completing write uses.
-func (w *voiceBuildWorker) run(ctx, terminal context.Context, buildID ids.UUID, input ai.VoiceBuildInput) error {
+// run drives extract → evaluate → activate on a claimed build. Every
+// terminal write below mints its detached context AT write time (deep-read
+// precedent): a context minted before the model calls would carry a deadline
+// the run itself already spent, and the outcome could then never be
+// recorded — the build would sit "running" until reclaim, forever retrying.
+func (w *voiceBuildWorker) run(ctx context.Context, buildID ids.UUID, input ai.VoiceBuildInput) error {
 	heldOut, buildSamples := splitVoiceHeldOut(input.Samples, input.Build.SourceHash)
 	if err := w.store.SetBuildStage(ctx, buildID, "extract"); err != nil {
 		w.log.WarnContext(ctx, "voice build stage update failed", "build", buildID.String(), "err", err)
@@ -264,6 +265,10 @@ func (w *voiceBuildWorker) run(ctx, terminal context.Context, buildID ids.UUID, 
 	if err := w.store.SetBuildStage(ctx, buildID, "activate"); err != nil {
 		w.log.WarnContext(ctx, "voice build stage update failed", "build", buildID.String(), "err", err)
 	}
+	// The completing write must outlive a job timeout that fires mid-run: a
+	// canceled work context must never strand a finished artifact unrecorded.
+	terminal, cancel := terminalCtx(ctx)
+	defer cancel()
 	_, err = w.store.CompleteBuild(terminal, buildID, claimTime(input), ai.VoiceBuildOutcome{
 		Artifact:     artifact,
 		Evaluation:   evaluated.Evaluation,
@@ -286,9 +291,12 @@ func (w *voiceBuildWorker) run(ctx, terminal context.Context, buildID ids.UUID, 
 }
 
 // fail records the terminal failure on the row; the job itself succeeds —
-// the row owns retry policy, not River.
+// the row owns retry policy, not River. The write runs on its own detached
+// context so it lands even when the work context is already dead.
 func (w *voiceBuildWorker) fail(ctx context.Context, buildID ids.UUID, claimedAt time.Time, statusCode, detail string) error {
-	if err := w.store.FailBuild(ctx, buildID, claimedAt, statusCode, detail); err != nil {
+	terminal, cancel := terminalCtx(ctx)
+	defer cancel()
+	if err := w.store.FailBuild(terminal, buildID, claimedAt, statusCode, detail); err != nil {
 		return fmt.Errorf("voice_build %s: record failure: %w", buildID.String(), err)
 	}
 	w.log.WarnContext(ctx, "voice build failed", "build", buildID.String(), "status_code", statusCode, "detail", detail)

--- a/backend/internal/compose/voicebuild_integration_test.go
+++ b/backend/internal/compose/voicebuild_integration_test.go
@@ -203,7 +203,7 @@ func TestVoiceBuildRunsToAnActiveVersion(t *testing.T) {
 	if err != nil || !claimed {
 		t.Fatalf("claim: %v claimed=%v", err, claimed)
 	}
-	if err := worker.run(ctx, ctx, build.ID, input); err != nil {
+	if err := worker.run(ctx, build.ID, input); err != nil {
 		t.Fatalf("run: %v", err)
 	}
 
@@ -275,7 +275,7 @@ func TestVoiceBuildDefersOnBudgetAndTheSweepFindsItWhenDue(t *testing.T) {
 	if err != nil || !claimed {
 		t.Fatalf("claim: %v claimed=%v", err, claimed)
 	}
-	runErr := worker.run(ctx, ctx, build.ID, input)
+	runErr := worker.run(ctx, build.ID, input)
 	if !errors.Is(runErr, ai.ErrBudgetDeferred) {
 		t.Fatalf("run under budget exhaustion = %v, want the sentinel", runErr)
 	}
@@ -310,7 +310,7 @@ func TestVoiceBuildDefersOnBudgetAndTheSweepFindsItWhenDue(t *testing.T) {
 	if err != nil || !claimed {
 		t.Fatalf("re-claim: %v claimed=%v", err, claimed)
 	}
-	if err := healthy.run(ctx, ctx, build.ID, input); err != nil {
+	if err := healthy.run(ctx, build.ID, input); err != nil {
 		t.Fatalf("resumed run: %v", err)
 	}
 	finished, err := env.store.GetBuild(env.owner, env.profile.ID, build.ID)
@@ -319,6 +319,33 @@ func TestVoiceBuildDefersOnBudgetAndTheSweepFindsItWhenDue(t *testing.T) {
 	}
 	if finished.Status != "succeeded" {
 		t.Fatalf("resumed build = %+v, want succeeded", finished)
+	}
+}
+
+// The terminal failure write mints its own detached deadline AT write time:
+// a work context the model calls already spent must still record the
+// outcome, or the build sits "running" until reclaim and retries forever
+// while the UI polls a row that never concludes.
+func TestVoiceBuildRecordsFailureEvenWhenTheWorkContextIsSpent(t *testing.T) {
+	env, build := seedVoiceBuild(t, "Spent-context quote.", 6)
+	ctx := env.workerCtx(t)
+	worker := newVoiceBuildWorker(env.e.Pool, nil, slog.New(slog.DiscardHandler))
+
+	input, claimed, err := env.store.ClaimBuild(ctx, env.profile.ID, build.ID, time.Minute)
+	if err != nil || !claimed {
+		t.Fatalf("claim: %v claimed=%v", err, claimed)
+	}
+	spent, cancelSpent := context.WithDeadline(ctx, time.Now().Add(-time.Second))
+	defer cancelSpent()
+	if err := worker.fail(spent, build.ID, *input.Build.StartedAt, "internal", "the run outlived its work context"); err != nil {
+		t.Fatalf("fail on a spent work context: %v", err)
+	}
+	finished, err := env.store.GetBuild(env.owner, env.profile.ID, build.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if finished.Status != "failed" || finished.StatusCode == nil || *finished.StatusCode != "internal" {
+		t.Fatalf("build after spent-context failure = %+v, want failed/internal", finished)
 	}
 }
 
@@ -332,7 +359,7 @@ func TestVoiceBuildStarterCorpusActivatesUnevaluated(t *testing.T) {
 	if err != nil || !claimed {
 		t.Fatalf("claim: %v claimed=%v", err, claimed)
 	}
-	if err := worker.run(ctx, ctx, build.ID, input); err != nil {
+	if err := worker.run(ctx, build.ID, input); err != nil {
 		t.Fatalf("run: %v", err)
 	}
 	finished, err := env.store.GetBuild(env.owner, env.profile.ID, build.ID)
@@ -452,7 +479,7 @@ func TestVoiceDraftReadsAndLearningSignals(t *testing.T) {
 	if err != nil || !claimed {
 		t.Fatalf("claim: %v claimed=%v", err, claimed)
 	}
-	if err := worker.run(ctx, ctx, build.ID, input); err != nil {
+	if err := worker.run(ctx, build.ID, input); err != nil {
 		t.Fatalf("run: %v", err)
 	}
 

--- a/backend/internal/compose/voicebuild_integration_test.go
+++ b/backend/internal/compose/voicebuild_integration_test.go
@@ -335,7 +335,7 @@ func TestVoiceBuildRecordsFailureEvenWhenTheWorkContextIsSpent(t *testing.T) {
 	if err != nil || !claimed {
 		t.Fatalf("claim: %v claimed=%v", err, claimed)
 	}
-	spent, cancelSpent := context.WithDeadline(ctx, time.Now().Add(-time.Second))
+	spent, cancelSpent := context.WithDeadline(ctx, time.Unix(0, 0))
 	defer cancelSpent()
 	if err := worker.fail(spent, build.ID, *input.Build.StartedAt, "internal", "the run outlived its work context"); err != nil {
 		t.Fatalf("fail on a spent work context: %v", err)

--- a/frontend/src/screens/onboarding-conversation/voice-act.test.tsx
+++ b/frontend/src/screens/onboarding-conversation/voice-act.test.tsx
@@ -326,6 +326,55 @@ describe("the conversational voice act", () => {
     expect(screen.queryByText(/Which one is you/)).toBeNull();
   });
 
+  it("accepts a drop anywhere in the window — composer, artifact, gaps included — and neutralizes the browser default", async () => {
+    const calls = stubApi({
+      preview: documentPreview,
+      ingests: [{ stats: documentStats, summary: summaryOf(900) }],
+    });
+    render(<VoiceHarness initial={collectingState()} />);
+
+    // The drop lands on window, NOT on the thread div: the hint promises
+    // "anywhere in this conversation", and an unhandled drop would navigate
+    // the browser to the file, destroying the onboarding session.
+    const drop = new Event("drop", { bubbles: true, cancelable: true });
+    Object.defineProperty(drop, "dataTransfer", {
+      value: {
+        files: [
+          new File(["Plain prose I wrote myself."], "notes.md", {
+            type: "text/plain",
+          }),
+        ],
+      },
+    });
+    window.dispatchEvent(drop);
+
+    expect(drop.defaultPrevented).toBe(true);
+    expect(await screen.findByText(/Words counted: 900\./)).toBeTruthy();
+    expect(requestsTo(calls, "/sources", "POST").length).toBe(1);
+  });
+
+  it("neutralizes a stray drop outside the collecting phases without ingesting", () => {
+    const calls = stubApi({});
+    render(
+      <VoiceHarness
+        initial={{
+          ...initialConversationState,
+          act: "voice",
+          phase: "vo.invite",
+        }}
+      />,
+    );
+
+    const drop = new Event("drop", { bubbles: true, cancelable: true });
+    Object.defineProperty(drop, "dataTransfer", {
+      value: { files: [new File(["text"], "stray.txt")] },
+    });
+    window.dispatchEvent(drop);
+
+    expect(drop.defaultPrevented).toBe(true);
+    expect(requestsTo(calls, "/sources", "POST").length).toBe(0);
+  });
+
   it("refuses an unattributed transcript honestly and counts nothing", async () => {
     const calls = stubApi({ preview: unattributedPreview });
     render(<VoiceHarness initial={collectingState()} />);

--- a/frontend/src/screens/onboarding-conversation/voice-act.test.tsx
+++ b/frontend/src/screens/onboarding-conversation/voice-act.test.tsx
@@ -339,6 +339,7 @@ describe("the conversational voice act", () => {
     const drop = new Event("drop", { bubbles: true, cancelable: true });
     Object.defineProperty(drop, "dataTransfer", {
       value: {
+        types: ["Files"],
         files: [
           new File(["Plain prose I wrote myself."], "notes.md", {
             type: "text/plain",
@@ -351,6 +352,15 @@ describe("the conversational voice act", () => {
     expect(drop.defaultPrevented).toBe(true);
     expect(await screen.findByText(/Words counted: 900\./)).toBeTruthy();
     expect(requestsTo(calls, "/sources", "POST").length).toBe(1);
+
+    // A text-selection drag is NOT claimed: the composer's native
+    // drag-to-insert must keep working.
+    const textDrag = new Event("drop", { bubbles: true, cancelable: true });
+    Object.defineProperty(textDrag, "dataTransfer", {
+      value: { types: ["text/plain"], files: [] },
+    });
+    window.dispatchEvent(textDrag);
+    expect(textDrag.defaultPrevented).toBe(false);
   });
 
   it("neutralizes a stray drop outside the collecting phases without ingesting", () => {
@@ -367,7 +377,7 @@ describe("the conversational voice act", () => {
 
     const drop = new Event("drop", { bubbles: true, cancelable: true });
     Object.defineProperty(drop, "dataTransfer", {
-      value: { files: [new File(["text"], "stray.txt")] },
+      value: { types: ["Files"], files: [new File(["text"], "stray.txt")] },
     });
     window.dispatchEvent(drop);
 

--- a/frontend/src/screens/onboarding-conversation/voice-act.tsx
+++ b/frontend/src/screens/onboarding-conversation/voice-act.tsx
@@ -1,6 +1,6 @@
 import { Paperclip, Send, Sparkles } from "lucide-react";
-import type { ChangeEvent, Dispatch, DragEvent } from "react";
-import { useRef, useState } from "react";
+import type { ChangeEvent, Dispatch } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { components } from "../../api/schema";
 import { Button } from "../../design-system/atoms";
 import { useT } from "../../i18n";
@@ -68,23 +68,41 @@ export function VoiceAct({ state, dispatch, initialSummary }: VoiceActProps) {
     event.target.value = "";
   };
 
-  // The whole thread is a drop target while collecting; preventDefault on
-  // dragover is what makes it legal — without it the browser navigates to
-  // the dropped file.
-  const dropProps = collecting
-    ? {
-        onDragOver: (event: DragEvent<HTMLDivElement>) => {
-          event.preventDefault();
-          setDragOver(true);
-        },
-        onDragLeave: () => setDragOver(false),
-        onDrop: (event: DragEvent<HTMLDivElement>) => {
-          event.preventDefault();
-          setDragOver(false);
-          corpus.addFiles(Array.from(event.dataTransfer.files));
-        },
+  // The hint promises "drop files anywhere in this conversation", so the
+  // WHOLE window is the drop target — a file landing on the composer, the
+  // artifact panel, or a layout gap must feed the corpus, and outside the
+  // collecting phases a stray drop must still be neutralized: the browser's
+  // default is to NAVIGATE to the dropped file, which would tear the user
+  // out of the onboarding mid-act.
+  const { addFiles } = corpus;
+  useEffect(() => {
+    const onDragOver = (event: globalThis.DragEvent) => {
+      event.preventDefault();
+      setDragOver(collecting);
+    };
+    const onDragLeave = (event: globalThis.DragEvent) => {
+      // relatedTarget is null only when the drag exits the window; moving
+      // between elements inside it must not flicker the affordance off.
+      if (event.relatedTarget === null) {
+        setDragOver(false);
       }
-    : {};
+    };
+    const onDrop = (event: globalThis.DragEvent) => {
+      event.preventDefault();
+      setDragOver(false);
+      if (collecting) {
+        addFiles(Array.from(event.dataTransfer?.files ?? []));
+      }
+    };
+    window.addEventListener("dragover", onDragOver);
+    window.addEventListener("dragleave", onDragLeave);
+    window.addEventListener("drop", onDrop);
+    return () => {
+      window.removeEventListener("dragover", onDragOver);
+      window.removeEventListener("dragleave", onDragLeave);
+      window.removeEventListener("drop", onDrop);
+    };
+  }, [collecting, addFiles]);
 
   const submitComposer = () => {
     const text = draft.trim();
@@ -135,10 +153,7 @@ export function VoiceAct({ state, dispatch, initialSummary }: VoiceActProps) {
         />
       }
     >
-      <div
-        className={`mw-thread${dragOver ? " ob-conv-dragover" : ""}`}
-        {...dropProps}
-      >
+      <div className={`mw-thread${dragOver ? " ob-conv-dragover" : ""}`}>
         <ConversationThread
           entries={state.thread}
           pendingQuestionId={state.pendingQuestion?.id ?? null}

--- a/frontend/src/screens/onboarding-conversation/voice-act.tsx
+++ b/frontend/src/screens/onboarding-conversation/voice-act.tsx
@@ -76,7 +76,14 @@ export function VoiceAct({ state, dispatch, initialSummary }: VoiceActProps) {
   // out of the onboarding mid-act.
   const { addFiles } = corpus;
   useEffect(() => {
+    // Only FILE drags are claimed: dragging selected text into the composer
+    // is a native interaction this act must not swallow.
+    const isFileDrag = (event: globalThis.DragEvent) =>
+      event.dataTransfer?.types.includes("Files") ?? false;
     const onDragOver = (event: globalThis.DragEvent) => {
+      if (!isFileDrag(event)) {
+        return;
+      }
       event.preventDefault();
       setDragOver(collecting);
     };
@@ -88,6 +95,9 @@ export function VoiceAct({ state, dispatch, initialSummary }: VoiceActProps) {
       }
     };
     const onDrop = (event: globalThis.DragEvent) => {
+      if (!isFileDrag(event)) {
+        return;
+      }
       event.preventDefault();
       setDragOver(false);
       if (collecting) {


### PR DESCRIPTION
Two defects from walking the onboarding voice act live:

**Drop area rejected files (again).** The drop handlers lived only on the thread column, while the composer hint promises "drop files anywhere in this conversation" — a file landing on the composer, the artifact panel, the next-step bar, or any layout gap hit the browser default and navigated to the file, tearing down the onboarding. Same defect class as the wizard-era dropzone fix (#203). The whole window is now the drop target while collecting, and a stray drop in any other voice phase is still neutralized (preventDefault, no ingest). Covered by two new vitest cases (window-level drop ingests; non-collecting drop is inert but neutralized).

**"Activating your voice profile" hung for minutes with no outcome.** The voice-build worker minted its detached terminal context — `terminalCtx`, a fresh 15-second deadline — at the START of `Work`, before the multi-minute model run. Any run longer than 15s therefore could never record its outcome: `CompleteBuild` failed with `context deadline exceeded`, the fallback `FailBuild` died the same way (`voice_build …: record failure: pg: begin: context deadline exceeded` in the worker log), the row sat `running` until the 11-minute reclaim, and the reclaimed rerun repeated the identical failure — an unbounded loop the UI experiences as an eternal "Activating…". Terminal contexts are now minted AT write time (`run`'s completing write, `fail`, the defer branch), matching the deep-read precedent the helper was borrowed from. Regression test: `TestVoiceBuildRecordsFailureEvenWhenTheWorkContextIsSpent` fails a build through a work context whose deadline is already spent and asserts the row still lands `failed/internal`.

Local gates: `make check` green (backend + fe), `make test-it DIR=backend/internal/compose RUN=TestVoiceBuild` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two onboarding issues: file drops in the voice conversation now work anywhere without navigating away, and long-running voice builds always record an outcome. This stops accidental page navigation on drop and ends the endless “Activating your voice profile” state.

- **Bug Fixes**
  - Window-wide file drops: The window accepts file drops while collecting and neutralizes drops in other phases; non-file drags (like selected text) are ignored so the composer keeps native behavior; added tests.
  - Reliable build outcomes: Terminal contexts are minted at write time for completes, failures, and deferrals so results record even if the work context is spent; updated run flow and added a spent-context regression test.

<sup>Written for commit d65b77031b43a6b2db406af4548ff0c3dff2fa9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved onboarding file drop handling across the conversation screen.
  * Prevented dropped files from triggering unintended browser navigation.
  * Ensured files are ingested only during the appropriate onboarding phase.
  * Improved reliability when recording failed voice builds, including after a work session expires.
* **Tests**
  * Added coverage for drag-and-drop behavior and failure recording scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->