### PR TITLE
fix(rates): rate-proposal precondition + supersede + effective-today diff

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -22,6 +22,20 @@ The merge gate (`make check`), the real-Postgres integration lane
 
 ## Recently landed
 
+**Rate-proposal precondition + supersede (#225, `fix/rate-proposal-precondition`).**
+The three deferred P1s from the rates-refresh review, fixed on BOTH refresh
+paths (fx and model-cost): a proposal now carries the prior value it was
+diffed against and the apply effect re-reads inside the redeem-and-apply
+transaction, refusing with `ErrVersionSkew` when the sheet moved (the
+approval stays approved-unconsumed; the remedy is a fresh refresh); staging
+gained a logical-identity mode (`approvals.StageInput.Identity`) so a fresher
+diff force-expires the stale pending proposal for the same currency/model
+instead of competing with it in the inbox; and producers diff against the
+effective-as-of-today rate (`ListEffectiveFxRates` / `ListEffectiveModelRates`),
+not the sheet head, so a future-scheduled row neither masks nor manufactures
+proposals. No contract, migration, or status-enum change — supersession is
+forced expiry with the audit row carrying the survivor.
+
 **The Rates & costs editor (Phase 1, `feat/rates-costs`).** Admin/ops can now
 view and update the two effective-dated price sheets — `fx_rate` (deals) and
 `ai_model_rate` (ai) — from a new Settings "Rates & costs" tab. Strict

--- a/backend/internal/compose/fxrefresh.go
+++ b/backend/internal/compose/fxrefresh.go
@@ -5,6 +5,7 @@ package compose
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 
@@ -63,7 +64,7 @@ func (f fxRefresh) run(ctx context.Context) error {
 	}
 	current, err := f.store.ListLatestFxRates(ctx)
 	if err != nil {
-		return fmt.Errorf("fx refresh: read current rates: %w", err)
+		return fmt.Errorf("fx refresh: read tracked currencies: %w", err)
 	}
 	if len(current) == 0 {
 		f.log.Info("fx rate refresh: no tracked currencies to refresh")
@@ -71,10 +72,19 @@ func (f fxRefresh) run(ctx context.Context) error {
 	}
 	base := current[0].ToCurrency
 	symbols := make([]string, 0, len(current))
-	currentRate := make(map[string]string, len(current))
 	for _, r := range current {
 		symbols = append(symbols, r.FromCurrency)
-		currentRate[r.FromCurrency] = r.Rate
+	}
+	// Diff against what is in force TODAY, not the sheet head: approval writes
+	// effective today, so a future-scheduled row must neither mask a real
+	// change nor manufacture an ineffective proposal.
+	effective, err := f.store.ListEffectiveFxRates(ctx)
+	if err != nil {
+		return fmt.Errorf("fx refresh: read effective rates: %w", err)
+	}
+	priorRate := make(map[string]string, len(effective))
+	for _, r := range effective {
+		priorRate[r.FromCurrency] = r.Rate
 	}
 
 	fetched, err := f.client.LatestRates(ctx, base, symbols)
@@ -84,12 +94,21 @@ func (f fxRefresh) run(ctx context.Context) error {
 	ws := storekit.MustWorkspace(ctx)
 	staged := 0
 	for cur, newRate := range fetched {
-		if newRate == currentRate[cur] {
-			continue // unchanged
+		prior := priorRate[cur]
+		if prior != "" && sameRate(newRate, prior) {
+			continue // unchanged vs the rate in force
 		}
-		summary := fmt.Sprintf("%s → %s %s (was %s)", cur, base, newRate, currentRate[cur])
+		was := prior
+		if was == "" {
+			was = "none in force today"
+		}
+		summary := fmt.Sprintf("%s → %s %s (was %s)", cur, base, newRate, was)
+		identity, err := json.Marshal(map[string]string{"from_currency": cur})
+		if err != nil {
+			return fmt.Errorf("fx refresh: identity %s: %w", cur, err)
+		}
 		if err := stageRateProposal(ctx, f.svc, fxRateProposalKind, fxRateTargetType, ws,
-			fxRateProposal{FromCurrency: cur, Rate: newRate}, summary); err != nil {
+			fxRateProposal{FromCurrency: cur, Rate: newRate, ExpectedPriorRate: prior}, identity, summary); err != nil {
 			return fmt.Errorf("fx refresh: stage %s: %w", cur, err)
 		}
 		staged++

--- a/backend/internal/compose/fxrefresh_integration_test.go
+++ b/backend/internal/compose/fxrefresh_integration_test.go
@@ -72,3 +72,87 @@ func TestFxRefreshStagesChangedRates(t *testing.T) {
 		t.Fatalf("after re-run staged %d, want still 1 (JoinPending dedupe)", n)
 	}
 }
+
+func seedFx(t *testing.T, ctx context.Context, store *deals.Store, cur, rate string, eff time.Time) {
+	t.Helper()
+	if _, err := store.SetFxRate(ctx, deals.SetFxRateInput{FromCurrency: cur, Rate: rate, EffectiveDate: eff}); err != nil {
+		t.Fatalf("seed %s@%s: %v", cur, rate, err)
+	}
+}
+
+func fxServer(t *testing.T, body string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if _, err := w.Write([]byte(body)); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+}
+
+// The diff base is the rate in force TODAY, not the sheet head: a
+// future-scheduled row must neither trigger a proposal when today's rate
+// already matches the source, nor mask a real change to today's rate.
+func TestFxRefreshDiffsAgainstEffectiveTodayNotSheetHead(t *testing.T) {
+	e := integration.Setup(t)
+	adminCtx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
+	store := deals.NewStore(e.Pool)
+	tomorrow := time.Now().UTC().Add(24 * time.Hour)
+
+	// USD: today matches the source; a future row differs (must NOT propose).
+	seedFx(t, adminCtx, store, "USD", "0.8", time.Time{})
+	seedFx(t, adminCtx, store, "USD", "0.95", tomorrow)
+	// CHF: today differs from the source; a future row matches (MUST propose).
+	seedFx(t, adminCtx, store, "CHF", "2.0", time.Time{})
+	seedFx(t, adminCtx, store, "CHF", "0.5", tomorrow)
+
+	// 1/1.25 = USD->EUR 0.8000000000 (matches today), 1/2 = CHF->EUR 0.5.
+	srv := fxServer(t, `{"base":"EUR","rates":{"USD":1.25,"CHF":2}}`)
+	defer srv.Close()
+	f := fxRefresh{store: store, svc: approvals.NewService(e.Pool),
+		client: fxsource.New(srv.URL, srv.Client()), log: quietLog()}
+	if err := f.run(rateRefreshWorkerCtx(context.Background(), e.WS, e.Rep1.String())); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	if n := e.WsCount(t, `SELECT count(*) FROM approval WHERE kind='fx_rate_proposal' AND status='pending' AND expires_at > now()`); n != 1 {
+		t.Fatalf("live proposals = %d, want 1 (CHF only: USD unchanged today, future row ignored)", n)
+	}
+	if n := e.WsCount(t, `SELECT count(*) FROM approval WHERE kind='fx_rate_proposal'
+			AND proposed_change->>'from_currency'='CHF'
+			AND proposed_change->>'expected_prior_rate'='2.0000000000'`); n != 1 {
+		t.Fatal("CHF proposal must carry today's effective rate as expected_prior_rate")
+	}
+}
+
+// A second refresh with a different fetched rate replaces the first pending
+// proposal for that currency instead of stacking a competitor whose late
+// approval would restore the stale rate.
+func TestFxRefreshSupersedesStalePendingProposal(t *testing.T) {
+	e := integration.Setup(t)
+	adminCtx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
+	store := deals.NewStore(e.Pool)
+	seedFx(t, adminCtx, store, "USD", "0.9", time.Time{})
+
+	svc := approvals.NewService(e.Pool)
+	wctx := rateRefreshWorkerCtx(context.Background(), e.WS, e.Rep1.String())
+	for _, body := range []string{
+		`{"base":"EUR","rates":{"USD":1.25}}`, // -> 0.8000000000
+		`{"base":"EUR","rates":{"USD":1}}`,    // -> 1.0000000000
+	} {
+		srv := fxServer(t, body)
+		f := fxRefresh{store: store, svc: svc, client: fxsource.New(srv.URL, srv.Client()), log: quietLog()}
+		err := f.run(wctx)
+		srv.Close()
+		if err != nil {
+			t.Fatalf("run %s: %v", body, err)
+		}
+	}
+
+	if n := e.WsCount(t, `SELECT count(*) FROM approval WHERE kind='fx_rate_proposal' AND status='pending' AND expires_at > now()`); n != 1 {
+		t.Fatalf("live proposals = %d, want 1 (fresh diff supersedes the stale one)", n)
+	}
+	if n := e.WsCount(t, `SELECT count(*) FROM approval WHERE kind='fx_rate_proposal' AND status='pending' AND expires_at > now()
+			AND proposed_change->>'rate'='1.0000000000'`); n != 1 {
+		t.Fatal("the surviving proposal must be the fresher fetched rate")
+	}
+}

--- a/backend/internal/compose/fxrefresh_integration_test.go
+++ b/backend/internal/compose/fxrefresh_integration_test.go
@@ -73,7 +73,7 @@ func TestFxRefreshStagesChangedRates(t *testing.T) {
 	}
 }
 
-func seedFx(t *testing.T, ctx context.Context, store *deals.Store, cur, rate string, eff time.Time) {
+func seedFx(ctx context.Context, t *testing.T, store *deals.Store, cur, rate string, eff time.Time) {
 	t.Helper()
 	if _, err := store.SetFxRate(ctx, deals.SetFxRateInput{FromCurrency: cur, Rate: rate, EffectiveDate: eff}); err != nil {
 		t.Fatalf("seed %s@%s: %v", cur, rate, err)
@@ -99,17 +99,19 @@ func TestFxRefreshDiffsAgainstEffectiveTodayNotSheetHead(t *testing.T) {
 	tomorrow := time.Now().UTC().Add(24 * time.Hour)
 
 	// USD: today matches the source; a future row differs (must NOT propose).
-	seedFx(t, adminCtx, store, "USD", "0.8", time.Time{})
-	seedFx(t, adminCtx, store, "USD", "0.95", tomorrow)
+	seedFx(adminCtx, t, store, "USD", "0.8", time.Time{})
+	seedFx(adminCtx, t, store, "USD", "0.95", tomorrow)
 	// CHF: today differs from the source; a future row matches (MUST propose).
-	seedFx(t, adminCtx, store, "CHF", "2.0", time.Time{})
-	seedFx(t, adminCtx, store, "CHF", "0.5", tomorrow)
+	seedFx(adminCtx, t, store, "CHF", "2.0", time.Time{})
+	seedFx(adminCtx, t, store, "CHF", "0.5", tomorrow)
 
 	// 1/1.25 = USD->EUR 0.8000000000 (matches today), 1/2 = CHF->EUR 0.5.
 	srv := fxServer(t, `{"base":"EUR","rates":{"USD":1.25,"CHF":2}}`)
 	defer srv.Close()
-	f := fxRefresh{store: store, svc: approvals.NewService(e.Pool),
-		client: fxsource.New(srv.URL, srv.Client()), log: quietLog()}
+	f := fxRefresh{
+		store: store, svc: approvals.NewService(e.Pool),
+		client: fxsource.New(srv.URL, srv.Client()), log: quietLog(),
+	}
 	if err := f.run(rateRefreshWorkerCtx(context.Background(), e.WS, e.Rep1.String())); err != nil {
 		t.Fatalf("run: %v", err)
 	}
@@ -131,7 +133,7 @@ func TestFxRefreshSupersedesStalePendingProposal(t *testing.T) {
 	e := integration.Setup(t)
 	adminCtx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
 	store := deals.NewStore(e.Pool)
-	seedFx(t, adminCtx, store, "USD", "0.9", time.Time{})
+	seedFx(adminCtx, t, store, "USD", "0.9", time.Time{})
 
 	svc := approvals.NewService(e.Pool)
 	wctx := rateRefreshWorkerCtx(context.Background(), e.WS, e.Rep1.String())

--- a/backend/internal/compose/modelraterefresh.go
+++ b/backend/internal/compose/modelraterefresh.go
@@ -130,9 +130,9 @@ func (m modelCostRefresh) run(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("model refresh: read effective rates: %w", err)
 	}
-	currentByKey := make(map[string]ai.ModelRateRow, len(current))
+	currentByKey := make(map[modelIdentity]ai.ModelRateRow, len(current))
 	for _, r := range current {
-		currentByKey[r.Provider+"/"+r.ModelID] = r
+		currentByKey[modelIdentity{r.Provider, r.ModelID}] = r
 	}
 
 	ws := storekit.MustWorkspace(ctx)
@@ -230,10 +230,15 @@ func (m modelCostRefresh) extract(ctx context.Context, src pricingSource) ([]ext
 	return kept, nil
 }
 
+// modelIdentity keys the effective-sheet map by the composite identity as a
+// struct — a concatenated string key would let a provider containing "/"
+// alias another model's entry and attach the wrong expected prior.
+type modelIdentity struct{ provider, modelID string }
+
 // diffModel returns (currentInputForSummary, proposal, changed?) — changed is
 // true when the extracted model is new or any of its four µUSD buckets differ
 // from the sheet. An extracted price that fails validation drops the model.
-func diffModel(em extractedModel, current map[string]ai.ModelRateRow) (string, aiModelRateProposal, bool) {
+func diffModel(em extractedModel, current map[modelIdentity]ai.ModelRateRow) (string, aiModelRateProposal, bool) {
 	newMicro, ok := allMicro(em)
 	if !ok {
 		return "", aiModelRateProposal{}, false
@@ -243,7 +248,7 @@ func diffModel(em extractedModel, current map[string]ai.ModelRateRow) (string, a
 		InputUsd: em.InputUsd, OutputUsd: em.OutputUsd,
 		CacheReadUsd: em.CacheReadUsd, CacheWriteUsd: em.CacheWriteUsd,
 	}
-	cur, found := current[em.Provider+"/"+em.ModelID]
+	cur, found := current[modelIdentity{em.Provider, em.ModelID}]
 	if !found {
 		return "(new)", prop, true
 	}

--- a/backend/internal/compose/modelraterefresh.go
+++ b/backend/internal/compose/modelraterefresh.go
@@ -156,7 +156,11 @@ func (m modelCostRefresh) run(ctx context.Context) error {
 				continue
 			}
 			summary := fmt.Sprintf("%s/%s input %s (was %s)", em.Provider, em.ModelID, prop.InputUsd, changed)
-			if err := stageRateProposal(ctx, m.svc, aiModelRateProposalKind, aiModelRateTargetType, ws, prop, summary); err != nil {
+			identity, err := json.Marshal(map[string]string{"provider": em.Provider, "model_id": em.ModelID})
+			if err != nil {
+				return fmt.Errorf("model refresh: identity %s/%s: %w", em.Provider, em.ModelID, err)
+			}
+			if err := stageRateProposal(ctx, m.svc, aiModelRateProposalKind, aiModelRateTargetType, ws, prop, identity, summary); err != nil {
 				return fmt.Errorf("model refresh: stage %s/%s: %w", em.Provider, em.ModelID, err)
 			}
 			staged++

--- a/backend/internal/compose/modelraterefresh.go
+++ b/backend/internal/compose/modelraterefresh.go
@@ -123,9 +123,12 @@ func (m modelCostRefresh) run(ctx context.Context) error {
 		m.log.Info("model-cost refresh skipped: no sources or brain configured")
 		return nil
 	}
-	current, err := m.rates.ListLatestModelRates(ctx)
+	// Diff against what is in force TODAY, not the sheet head: approval writes
+	// effective today, so a future-scheduled row must neither mask a real
+	// change nor manufacture an ineffective proposal.
+	current, err := m.rates.ListEffectiveModelRates(ctx)
 	if err != nil {
-		return fmt.Errorf("model refresh: read current rates: %w", err)
+		return fmt.Errorf("model refresh: read effective rates: %w", err)
 	}
 	currentByKey := make(map[string]ai.ModelRateRow, len(current))
 	for _, r := range current {
@@ -250,6 +253,10 @@ func diffModel(em extractedModel, current map[string]ai.ModelRateRow) (string, a
 	})
 	if ok && newMicro == curMicro {
 		return "", aiModelRateProposal{}, false // unchanged
+	}
+	prop.ExpectedPrior = &aiModelRatePrior{
+		InputUsd: cur.InputUsd, OutputUsd: cur.OutputUsd,
+		CacheReadUsd: cur.CacheReadUsd, CacheWriteUsd: cur.CacheWriteUsd,
 	}
 	return cur.InputUsd, prop, true
 }

--- a/backend/internal/compose/modelraterefresh_integration_test.go
+++ b/backend/internal/compose/modelraterefresh_integration_test.go
@@ -77,3 +77,73 @@ func TestModelCostRefreshStagesChangedAndDropsUngrounded(t *testing.T) {
 		t.Fatalf("producer wrote %d sheet rows, want 0 (stage-only)", n)
 	}
 }
+
+func seedModelRate(t *testing.T, ctx context.Context, rates *ai.RateStore, provider, modelID, inputUsd string, eff time.Time) {
+	t.Helper()
+	if _, err := rates.SetModelRate(ctx, ai.SetModelRateInput{
+		Provider: provider, ModelID: modelID,
+		InputUsd: inputUsd, OutputUsd: "25", CacheReadUsd: "0", CacheWriteUsd: "0",
+		EffectiveDate: eff,
+	}); err != nil {
+		t.Fatalf("seed %s/%s@%s: %v", provider, modelID, inputUsd, err)
+	}
+}
+
+func extractionFixture(provider, modelID, inputUsd string) string {
+	return `{"models":[{"provider":"` + provider + `","model_id":"` + modelID +
+		`","input_per_mtok":"` + inputUsd +
+		`","output_per_mtok":"25","cache_read_per_mtok":"0","cache_write_per_mtok":"0","evidence":"s0","confidence":"0.95"}]}`
+}
+
+func runModelRefresh(t *testing.T, e *integration.Env, extraction string) {
+	t.Helper()
+	m := modelCostRefresh{
+		rates:   ai.NewRateStore(e.Pool),
+		svc:     approvals.NewService(e.Pool),
+		fetcher: fakeFetcher{text: "pricing page text"},
+		brain:   fakeBrain{text: extraction},
+		sources: []pricingSource{{Provider: "acme", URL: "https://prices.test/pricing"}},
+		log:     quietLog(),
+	}
+	if err := m.run(rateRefreshWorkerCtx(context.Background(), e.WS, e.Rep1.String())); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+}
+
+// The diff base is the price in force TODAY: a future-scheduled row must not
+// mask a change to today's price, the proposal carries today's buckets as
+// expected_prior, and a re-run extracting a different price supersedes the
+// first pending proposal instead of competing with it.
+func TestModelRefreshDiffsAgainstEffectiveTodayAndSupersedes(t *testing.T) {
+	e := integration.Setup(t)
+	adminCtx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
+	rates := ai.NewRateStore(e.Pool)
+	tomorrow := time.Now().UTC().Add(24 * time.Hour)
+
+	// Today the model costs input=5; tomorrow a scheduled row already says 6.
+	seedModelRate(t, adminCtx, rates, "acme", "m1", "5", time.Time{})
+	seedModelRate(t, adminCtx, rates, "acme", "m1", "6", tomorrow)
+
+	// The page states input=6: equal to the future row, but a diff vs TODAY.
+	runModelRefresh(t, e, extractionFixture("acme", "m1", "6"))
+	livePending := func() int {
+		return e.WsCount(t, `SELECT count(*) FROM approval WHERE kind='ai_model_rate_proposal' AND status='pending' AND expires_at > now()`)
+	}
+	if livePending() != 1 {
+		t.Fatalf("live proposals = %d, want 1 (future row must not mask today's diff)", livePending())
+	}
+	if n := e.WsCount(t, `SELECT count(*) FROM approval WHERE kind='ai_model_rate_proposal'
+			AND proposed_change#>>'{expected_prior,input_per_mtok}'='5'`); n != 1 {
+		t.Fatal("proposal must carry today's price as expected_prior")
+	}
+
+	// A later run extracts input=7: the fresher diff replaces the pending 6.
+	runModelRefresh(t, e, extractionFixture("acme", "m1", "7"))
+	if livePending() != 1 {
+		t.Fatalf("live proposals after re-run = %d, want 1 (stale diff superseded)", livePending())
+	}
+	if n := e.WsCount(t, `SELECT count(*) FROM approval WHERE kind='ai_model_rate_proposal' AND status='pending' AND expires_at > now()
+			AND proposed_change->>'input_per_mtok'='7'`); n != 1 {
+		t.Fatal("the surviving proposal must be the fresher extraction")
+	}
+}

--- a/backend/internal/compose/modelraterefresh_integration_test.go
+++ b/backend/internal/compose/modelraterefresh_integration_test.go
@@ -78,7 +78,7 @@ func TestModelCostRefreshStagesChangedAndDropsUngrounded(t *testing.T) {
 	}
 }
 
-func seedModelRate(t *testing.T, ctx context.Context, rates *ai.RateStore, provider, modelID, inputUsd string, eff time.Time) {
+func seedModelRate(ctx context.Context, t *testing.T, rates *ai.RateStore, provider, modelID, inputUsd string, eff time.Time) {
 	t.Helper()
 	if _, err := rates.SetModelRate(ctx, ai.SetModelRateInput{
 		Provider: provider, ModelID: modelID,
@@ -121,8 +121,8 @@ func TestModelRefreshDiffsAgainstEffectiveTodayAndSupersedes(t *testing.T) {
 	tomorrow := time.Now().UTC().Add(24 * time.Hour)
 
 	// Today the model costs input=5; tomorrow a scheduled row already says 6.
-	seedModelRate(t, adminCtx, rates, "acme", "m1", "5", time.Time{})
-	seedModelRate(t, adminCtx, rates, "acme", "m1", "6", tomorrow)
+	seedModelRate(adminCtx, t, rates, "acme", "m1", "5", time.Time{})
+	seedModelRate(adminCtx, t, rates, "acme", "m1", "6", tomorrow)
 
 	// The page states input=6: equal to the future row, but a diff vs TODAY.
 	runModelRefresh(t, e, extractionFixture("acme", "m1", "6"))

--- a/backend/internal/compose/modelraterefresh_integration_test.go
+++ b/backend/internal/compose/modelraterefresh_integration_test.go
@@ -78,14 +78,16 @@ func TestModelCostRefreshStagesChangedAndDropsUngrounded(t *testing.T) {
 	}
 }
 
-func seedModelRate(ctx context.Context, t *testing.T, rates *ai.RateStore, provider, modelID, inputUsd string, eff time.Time) {
+// seedModelRate seeds one effective-dated price for a model of the test
+// provider "acme" (the provider every refresh fixture crawls).
+func seedModelRate(ctx context.Context, t *testing.T, rates *ai.RateStore, modelID, inputUsd string, eff time.Time) {
 	t.Helper()
 	if _, err := rates.SetModelRate(ctx, ai.SetModelRateInput{
-		Provider: provider, ModelID: modelID,
+		Provider: "acme", ModelID: modelID,
 		InputUsd: inputUsd, OutputUsd: "25", CacheReadUsd: "0", CacheWriteUsd: "0",
 		EffectiveDate: eff,
 	}); err != nil {
-		t.Fatalf("seed %s/%s@%s: %v", provider, modelID, inputUsd, err)
+		t.Fatalf("seed acme/%s@%s: %v", modelID, inputUsd, err)
 	}
 }
 
@@ -121,8 +123,8 @@ func TestModelRefreshDiffsAgainstEffectiveTodayAndSupersedes(t *testing.T) {
 	tomorrow := time.Now().UTC().Add(24 * time.Hour)
 
 	// Today the model costs input=5; tomorrow a scheduled row already says 6.
-	seedModelRate(adminCtx, t, rates, "acme", "m1", "5", time.Time{})
-	seedModelRate(adminCtx, t, rates, "acme", "m1", "6", tomorrow)
+	seedModelRate(adminCtx, t, rates, "m1", "5", time.Time{})
+	seedModelRate(adminCtx, t, rates, "m1", "6", tomorrow)
 
 	// The page states input=6: equal to the future row, but a diff vs TODAY.
 	runModelRefresh(t, e, extractionFixture("acme", "m1", "6"))

--- a/backend/internal/compose/rateproposals.go
+++ b/backend/internal/compose/rateproposals.go
@@ -9,6 +9,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"math/big"
 
 	"github.com/jackc/pgx/v5"
 
@@ -37,25 +38,51 @@ const (
 type fxRateProposal struct {
 	FromCurrency string `json:"from_currency"`
 	Rate         string `json:"rate"`
+	// ExpectedPriorRate is the rate in force (as of the staging day) the diff
+	// was computed against; empty = no rate was in force. The apply effect
+	// re-reads and refuses on mismatch (ErrVersionSkew) so an old proposal can
+	// never overwrite a newer manual or approved rate.
+	ExpectedPriorRate string `json:"expected_prior_rate,omitempty"`
 }
 
-type aiModelRateProposal struct {
-	Provider      string `json:"provider"`
-	ModelID       string `json:"model_id"`
+// aiModelRatePrior carries the four per-MTok USD buckets in force (as of the
+// staging day) a model-price diff was computed against; the apply effect
+// re-reads and must match. Absent = the model was unpriced when diffed.
+type aiModelRatePrior struct {
 	InputUsd      string `json:"input_per_mtok"`
 	OutputUsd     string `json:"output_per_mtok"`
 	CacheReadUsd  string `json:"cache_read_per_mtok"`
 	CacheWriteUsd string `json:"cache_write_per_mtok"`
 }
 
+type aiModelRateProposal struct {
+	Provider      string            `json:"provider"`
+	ModelID       string            `json:"model_id"`
+	InputUsd      string            `json:"input_per_mtok"`
+	OutputUsd     string            `json:"output_per_mtok"`
+	CacheReadUsd  string            `json:"cache_read_per_mtok"`
+	CacheWriteUsd string            `json:"cache_write_per_mtok"`
+	ExpectedPrior *aiModelRatePrior `json:"expected_prior,omitempty"`
+}
+
+// sameRate reports numeric equality of two decimal strings — numeric(20,10)
+// text and a source's text may spell one value at different scales.
+func sameRate(a, b string) bool {
+	ra, okA := new(big.Rat).SetString(a)
+	rb, okB := new(big.Rat).SetString(b)
+	return okA && okB && ra.Cmp(rb) == 0
+}
+
 // stageRateProposal marshals a proposal, computes its identity-bearing diff
 // hash (sha256 over the payload, per the scrape.go shape), and stages it under
-// JoinPending — the atomic advisory-locked path that collapses an identical
-// live proposal to a no-op. Two workers racing the same diff cannot both
-// insert (the pre-check-then-stage window a plain HasPendingFor left open).
+// JoinPending with the sheet row's logical identity — the atomic
+// advisory-locked path that collapses an identical live proposal to a no-op
+// AND withdraws a stale pending diff for the same identity (two refreshes
+// fetching different values must not leave competing proposals whose late
+// approval restores the older value).
 //
 //craft:ignore naked-any payload is any JSON-marshalable proposal struct (fx or model); the concrete type rides through json.Marshal
-func stageRateProposal(ctx context.Context, svc *approvals.Service, kind, targetType string, ws ids.UUID, payload any, summary string) error {
+func stageRateProposal(ctx context.Context, svc *approvals.Service, kind, targetType string, ws ids.UUID, payload any, identity json.RawMessage, summary string) error {
 	raw, err := json.Marshal(payload)
 	if err != nil {
 		return fmt.Errorf("compose: marshal %s: %w", kind, err)
@@ -65,7 +92,7 @@ func stageRateProposal(ctx context.Context, svc *approvals.Service, kind, target
 	_, err = svc.Stage(ctx, approvals.StageInput{
 		Kind: kind, ProposedChange: raw, DiffHash: hash,
 		TargetType: targetType, TargetID: ws, Summary: summary,
-		JoinPending: true,
+		JoinPending: true, Identity: identity,
 	})
 	return err
 }

--- a/backend/internal/compose/rateproposals.go
+++ b/backend/internal/compose/rateproposals.go
@@ -181,7 +181,17 @@ func aiModelRateAcceptEffect(svc *approvals.Service, rates *ai.RateStore) approv
 		// failed write keeps the approval redeemable. Zero EffectiveDate ⇒
 		// effective today, derived inside the store's write transaction.
 		return svc.RedeemAndApply(ctx, approvalID, aiModelRateProposalKind, diffHash, func(tx pgx.Tx) error {
-			_, err := rates.SetModelRateInTx(execCtx, tx, ai.SetModelRateInput{
+			// Same precondition as the fx effect: the price in force must still
+			// be the one the diff was computed against, or applying restores a
+			// stale value — refuse and roll back, keep the decision on record.
+			cur, err := rates.EffectiveModelRateInTx(execCtx, tx, p.Provider, p.ModelID)
+			if err != nil {
+				return err
+			}
+			if err := modelPriorMatches(p, cur); err != nil {
+				return err
+			}
+			_, err = rates.SetModelRateInTx(execCtx, tx, ai.SetModelRateInput{
 				Provider: p.Provider, ModelID: p.ModelID,
 				InputUsd: p.InputUsd, OutputUsd: p.OutputUsd,
 				CacheReadUsd: p.CacheReadUsd, CacheWriteUsd: p.CacheWriteUsd,
@@ -189,4 +199,35 @@ func aiModelRateAcceptEffect(svc *approvals.Service, rates *ai.RateStore) approv
 			return err
 		})
 	}
+}
+
+// modelPriorMatches enforces the proposal's precondition against the price in
+// force now, comparing in µUSD (the sheet's storage unit) so wire-scale
+// differences cannot false-skew. A nil ExpectedPrior asserts "unpriced" —
+// also how a payload staged before the precondition existed reads, so such a
+// proposal fails closed onto a re-diff once the model is priced.
+func modelPriorMatches(p aiModelRateProposal, cur *ai.ModelRate) error {
+	moved := fmt.Errorf("compose: the %s/%s price changed since the proposal was diffed — re-run the refresh: %w",
+		p.Provider, p.ModelID, apperrors.ErrVersionSkew)
+	if p.ExpectedPrior == nil {
+		if cur != nil {
+			return moved
+		}
+		return nil
+	}
+	if cur == nil {
+		return moved
+	}
+	in, e1 := ai.UsdPerMTokToMicroUSD("input_per_mtok", p.ExpectedPrior.InputUsd)
+	out, e2 := ai.UsdPerMTokToMicroUSD("output_per_mtok", p.ExpectedPrior.OutputUsd)
+	cr, e3 := ai.UsdPerMTokToMicroUSD("cache_read_per_mtok", p.ExpectedPrior.CacheReadUsd)
+	cw, e4 := ai.UsdPerMTokToMicroUSD("cache_write_per_mtok", p.ExpectedPrior.CacheWriteUsd)
+	if e1 != nil || e2 != nil || e3 != nil || e4 != nil {
+		return moved // an unparseable expected prior can never match — fail closed onto a re-diff
+	}
+	if in != cur.InputPerMTokMicroUSD || out != cur.OutputPerMTokMicroUSD ||
+		cr != cur.CacheReadPerMTokMicroUSD || cw != cur.CacheWritePerMTokMicroUSD {
+		return moved
+	}
+	return nil
 }

--- a/backend/internal/compose/rateproposals.go
+++ b/backend/internal/compose/rateproposals.go
@@ -159,10 +159,10 @@ func fxPriorMatches(p fxRateProposal, prior string, found bool) error {
 	case found && p.ExpectedPriorRate != "" && sameRate(prior, p.ExpectedPriorRate):
 		return nil
 	case !found:
-		return fmt.Errorf("compose: the %s rate the proposal was diffed against is no longer in force — re-run the refresh: %w",
+		return fmt.Errorf("the %s rate the proposal was diffed against is no longer in force — re-run the refresh: %w",
 			p.FromCurrency, apperrors.ErrVersionSkew)
 	default:
-		return fmt.Errorf("compose: the %s rate changed since the proposal was diffed (now %s) — re-run the refresh: %w",
+		return fmt.Errorf("the %s rate changed since the proposal was diffed (now %s) — re-run the refresh: %w",
 			p.FromCurrency, prior, apperrors.ErrVersionSkew)
 	}
 }
@@ -207,7 +207,7 @@ func aiModelRateAcceptEffect(svc *approvals.Service, rates *ai.RateStore) approv
 // also how a payload staged before the precondition existed reads, so such a
 // proposal fails closed onto a re-diff once the model is priced.
 func modelPriorMatches(p aiModelRateProposal, cur *ai.ModelRate) error {
-	moved := fmt.Errorf("compose: the %s/%s price changed since the proposal was diffed — re-run the refresh: %w",
+	moved := fmt.Errorf("the %s/%s price changed since the proposal was diffed — re-run the refresh: %w",
 		p.Provider, p.ModelID, apperrors.ErrVersionSkew)
 	if p.ExpectedPrior == nil {
 		if cur != nil {

--- a/backend/internal/compose/rateproposals.go
+++ b/backend/internal/compose/rateproposals.go
@@ -124,9 +124,9 @@ func fxRateAcceptEffect(svc *approvals.Service, store *deals.Store) approvals.Ap
 		// Redeem the authority object and apply the sheet write in ONE
 		// transaction: a failed write leaves the approval unconsumed and the
 		// job retryable, never permanently consumed with the sheet unchanged.
-		// A zero EffectiveDate applies the rate effective today, derived inside
-		// the store's write transaction (a cross-midnight approval must not
-		// miss the past-date guard).
+		// The precondition read returns the day it sampled and the write is
+		// pinned to that SAME day, so a cross-midnight apply fails the
+		// past-date guard rather than overwriting the new day's scheduled row.
 		return svc.RedeemAndApply(ctx, approvalID, fxRateProposalKind, diffHash, func(tx pgx.Tx) error {
 			// The diff was computed against the rate then in force; if the sheet
 			// moved since (manual write, competing approval), applying would
@@ -182,8 +182,10 @@ func aiModelRateAcceptEffect(svc *approvals.Service, rates *ai.RateStore) approv
 			return err
 		}
 		// Single-transaction redeem-and-apply (see fxRateAcceptEffect): a
-		// failed write keeps the approval redeemable. Zero EffectiveDate ⇒
-		// effective today, derived inside the store's write transaction.
+		// failed write keeps the approval redeemable. The write is pinned to
+		// the day the precondition read sampled (asOf below), so a cross-
+		// midnight apply fails the past-date guard rather than overwriting the
+		// new day's scheduled row.
 		return svc.RedeemAndApply(ctx, approvalID, aiModelRateProposalKind, diffHash, func(tx pgx.Tx) error {
 			// Same precondition as the fx effect: the price in force must still
 			// be the one the diff was computed against, or applying restores a

--- a/backend/internal/compose/rateproposals.go
+++ b/backend/internal/compose/rateproposals.go
@@ -132,7 +132,11 @@ func fxRateAcceptEffect(svc *approvals.Service, store *deals.Store) approvals.Ap
 			// moved since (manual write, competing approval), applying would
 			// silently restore a stale value — refuse and roll back instead. The
 			// decision itself stays on record; the remedy is a fresh refresh.
-			prior, found, err := store.EffectiveFxRateInTx(execCtx, tx, p.FromCurrency)
+			// The read holds the currency's write-identity lock and the write is
+			// pinned to the SAME sampled day, so neither a concurrent standalone
+			// write nor a UTC-midnight crossing can slip between check and apply
+			// (the past-date guard refuses the crossed-midnight case honestly).
+			prior, asOf, found, err := store.EffectiveFxRateInTx(execCtx, tx, p.FromCurrency)
 			if err != nil {
 				return err
 			}
@@ -140,7 +144,7 @@ func fxRateAcceptEffect(svc *approvals.Service, store *deals.Store) approvals.Ap
 				return err
 			}
 			_, err = store.SetFxRateInTx(execCtx, tx, deals.SetFxRateInput{
-				FromCurrency: p.FromCurrency, Rate: p.Rate,
+				FromCurrency: p.FromCurrency, Rate: p.Rate, EffectiveDate: asOf,
 			})
 			return err
 		})
@@ -184,7 +188,8 @@ func aiModelRateAcceptEffect(svc *approvals.Service, rates *ai.RateStore) approv
 			// Same precondition as the fx effect: the price in force must still
 			// be the one the diff was computed against, or applying restores a
 			// stale value — refuse and roll back, keep the decision on record.
-			cur, err := rates.EffectiveModelRateInTx(execCtx, tx, p.Provider, p.ModelID)
+			// Lock + same-day pinning as the fx effect (see fxRateAcceptEffect).
+			cur, asOf, err := rates.EffectiveModelRateInTx(execCtx, tx, p.Provider, p.ModelID)
 			if err != nil {
 				return err
 			}
@@ -195,6 +200,7 @@ func aiModelRateAcceptEffect(svc *approvals.Service, rates *ai.RateStore) approv
 				Provider: p.Provider, ModelID: p.ModelID,
 				InputUsd: p.InputUsd, OutputUsd: p.OutputUsd,
 				CacheReadUsd: p.CacheReadUsd, CacheWriteUsd: p.CacheWriteUsd,
+				EffectiveDate: asOf,
 			})
 			return err
 		})

--- a/backend/internal/compose/rateproposals.go
+++ b/backend/internal/compose/rateproposals.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/ai"
 	"github.com/gradionhq/margince/backend/internal/modules/approvals"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
@@ -127,11 +128,42 @@ func fxRateAcceptEffect(svc *approvals.Service, store *deals.Store) approvals.Ap
 		// the store's write transaction (a cross-midnight approval must not
 		// miss the past-date guard).
 		return svc.RedeemAndApply(ctx, approvalID, fxRateProposalKind, diffHash, func(tx pgx.Tx) error {
-			_, err := store.SetFxRateInTx(execCtx, tx, deals.SetFxRateInput{
+			// The diff was computed against the rate then in force; if the sheet
+			// moved since (manual write, competing approval), applying would
+			// silently restore a stale value — refuse and roll back instead. The
+			// decision itself stays on record; the remedy is a fresh refresh.
+			prior, found, err := store.EffectiveFxRateInTx(execCtx, tx, p.FromCurrency)
+			if err != nil {
+				return err
+			}
+			if err := fxPriorMatches(p, prior, found); err != nil {
+				return err
+			}
+			_, err = store.SetFxRateInTx(execCtx, tx, deals.SetFxRateInput{
 				FromCurrency: p.FromCurrency, Rate: p.Rate,
 			})
 			return err
 		})
+	}
+}
+
+// fxPriorMatches enforces the proposal's precondition: the rate in force now
+// must be exactly the one the diff was computed against (numerically — the
+// sheet stores scale-10 text). An empty ExpectedPriorRate asserts "none was
+// in force", which is also how a payload staged before the precondition
+// existed reads — such a proposal fails closed onto a re-diff.
+func fxPriorMatches(p fxRateProposal, prior string, found bool) error {
+	switch {
+	case !found && p.ExpectedPriorRate == "":
+		return nil
+	case found && p.ExpectedPriorRate != "" && sameRate(prior, p.ExpectedPriorRate):
+		return nil
+	case !found:
+		return fmt.Errorf("compose: the %s rate the proposal was diffed against is no longer in force — re-run the refresh: %w",
+			p.FromCurrency, apperrors.ErrVersionSkew)
+	default:
+		return fmt.Errorf("compose: the %s rate changed since the proposal was diffed (now %s) — re-run the refresh: %w",
+			p.FromCurrency, prior, apperrors.ErrVersionSkew)
 	}
 }
 

--- a/backend/internal/compose/rateproposals_integration_test.go
+++ b/backend/internal/compose/rateproposals_integration_test.go
@@ -16,12 +16,14 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/gradionhq/margince/backend/internal/compose/integration"
 	"github.com/gradionhq/margince/backend/internal/modules/ai"
 	"github.com/gradionhq/margince/backend/internal/modules/approvals"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -116,5 +118,76 @@ func TestFxRateProposalEditBeforeApprove(t *testing.T) {
 	}
 	if n := e.WsCount(t, `SELECT count(*) FROM fx_rate WHERE from_currency='CHF' AND rate=1.5`); n != 1 {
 		t.Fatalf("CHF@1.5 rows = %d, want 1 (edit-before-approve applied)", n)
+	}
+}
+
+// The staged diff was computed against a prior rate; if the sheet moved
+// since (manual write, competing approval), applying would restore a stale
+// value — the effect must refuse with version skew, leave the approval
+// approved-unconsumed, and write nothing.
+func TestFxRateProposalApplyRefusesWhenPriorMoved(t *testing.T) {
+	e := integration.Setup(t)
+	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
+	svc := rateSvc(e)
+	store := deals.NewStore(e.Pool)
+
+	if _, err := store.SetFxRate(ctx, deals.SetFxRateInput{FromCurrency: "GBP", Rate: "1.0"}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	id := stageProposal(ctx, t, svc, fxRateProposalKind, fxRateTargetType, e.WS,
+		map[string]string{"from_currency": "GBP", "rate": "1.2", "expected_prior_rate": "1.0"}, "GBP")
+	// The sheet moves after the diff was staged.
+	if _, err := store.SetFxRate(ctx, deals.SetFxRateInput{FromCurrency: "GBP", Rate: "1.1"}); err != nil {
+		t.Fatalf("move: %v", err)
+	}
+
+	_, err := svc.Decide(ctx, id, true, nil)
+	if !errors.Is(err, apperrors.ErrVersionSkew) {
+		t.Fatalf("approve err = %v, want ErrVersionSkew", err)
+	}
+	if n := e.WsCount(t, `SELECT count(*) FROM fx_rate WHERE from_currency='GBP' AND rate=1.2`); n != 0 {
+		t.Fatal("stale proposal applied despite moved prior")
+	}
+	if n := e.WsCount(t,
+		`SELECT count(*) FROM approval WHERE id=$1 AND status='approved' AND consumed_at IS NULL`, id); n != 1 {
+		t.Fatal("approval must stay approved-unconsumed after a refused apply")
+	}
+}
+
+// A proposal diffed when NO rate was in force (expected_prior_rate empty —
+// also the shape of any pre-existing pending payload without the field)
+// must refuse once a rate exists: the world it diffed against is gone.
+func TestFxRateProposalApplyRefusesWhenPriorAppeared(t *testing.T) {
+	e := integration.Setup(t)
+	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
+	svc := rateSvc(e)
+
+	id := stageProposal(ctx, t, svc, fxRateProposalKind, fxRateTargetType, e.WS,
+		map[string]string{"from_currency": "NOK", "rate": "0.09"}, "NOK")
+	if _, err := deals.NewStore(e.Pool).SetFxRate(ctx, deals.SetFxRateInput{FromCurrency: "NOK", Rate: "0.088"}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if _, err := svc.Decide(ctx, id, true, nil); !errors.Is(err, apperrors.ErrVersionSkew) {
+		t.Fatalf("approve err = %v, want ErrVersionSkew", err)
+	}
+}
+
+// The precondition is scale-blind: "1.0" diffed against a stored
+// numeric(20,10) ("1.0000000000") still matches, and the apply proceeds.
+func TestFxRateProposalApplyMatchingPriorApplies(t *testing.T) {
+	e := integration.Setup(t)
+	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
+	svc := rateSvc(e)
+
+	if _, err := deals.NewStore(e.Pool).SetFxRate(ctx, deals.SetFxRateInput{FromCurrency: "DKK", Rate: "0.134"}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	id := stageProposal(ctx, t, svc, fxRateProposalKind, fxRateTargetType, e.WS,
+		map[string]string{"from_currency": "DKK", "rate": "0.135", "expected_prior_rate": "0.134"}, "DKK")
+	if _, err := svc.Decide(ctx, id, true, nil); err != nil {
+		t.Fatalf("approve: %v", err)
+	}
+	if n := e.WsCount(t, `SELECT count(*) FROM fx_rate WHERE from_currency='DKK' AND rate=0.135`); n != 1 {
+		t.Fatal("matching-prior proposal must apply")
 	}
 }

--- a/backend/internal/compose/rateproposals_integration_test.go
+++ b/backend/internal/compose/rateproposals_integration_test.go
@@ -327,8 +327,8 @@ func TestModelRateProposalApplyRefusesAcrossMidnight(t *testing.T) {
 	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
 	seed := ai.NewRateStore(e.Pool)
 	tomorrow := time.Now().UTC().Add(24 * time.Hour)
-	seedModelRate(ctx, t, seed, "acme", "mx", "5", time.Time{})
-	seedModelRate(ctx, t, seed, "acme", "mx", "9", tomorrow)
+	seedModelRate(ctx, t, seed, "mx", "5", time.Time{})
+	seedModelRate(ctx, t, seed, "mx", "9", tomorrow)
 
 	calls := 0
 	crossing := ai.NewRateStore(e.Pool).WithClock(func() time.Time {

--- a/backend/internal/compose/rateproposals_integration_test.go
+++ b/backend/internal/compose/rateproposals_integration_test.go
@@ -191,3 +191,93 @@ func TestFxRateProposalApplyMatchingPriorApplies(t *testing.T) {
 		t.Fatal("matching-prior proposal must apply")
 	}
 }
+
+// The model-rate mirror of the fx precondition: a proposal whose diffed-
+// against price moved refuses with version skew, leaves the approval
+// approved-unconsumed, and writes nothing.
+func TestModelRateProposalApplyRefusesWhenPriorMoved(t *testing.T) {
+	e := integration.Setup(t)
+	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
+	svc := rateSvc(e)
+	rates := ai.NewRateStore(e.Pool)
+
+	if _, err := rates.SetModelRate(ctx, ai.SetModelRateInput{
+		Provider: "acme", ModelID: "m", InputUsd: "5", OutputUsd: "25", CacheReadUsd: "0", CacheWriteUsd: "0",
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	id := stageProposal(ctx, t, svc, aiModelRateProposalKind, aiModelRateTargetType, e.WS,
+		map[string]any{
+			"provider": "acme", "model_id": "m",
+			"input_per_mtok": "6", "output_per_mtok": "25", "cache_read_per_mtok": "0", "cache_write_per_mtok": "0",
+			"expected_prior": map[string]string{
+				"input_per_mtok": "5", "output_per_mtok": "25", "cache_read_per_mtok": "0", "cache_write_per_mtok": "0",
+			},
+		}, "acme/m")
+	// The sheet moves after the diff was staged.
+	if _, err := rates.SetModelRate(ctx, ai.SetModelRateInput{
+		Provider: "acme", ModelID: "m", InputUsd: "5.5", OutputUsd: "25", CacheReadUsd: "0", CacheWriteUsd: "0",
+	}); err != nil {
+		t.Fatalf("move: %v", err)
+	}
+	if _, err := svc.Decide(ctx, id, true, nil); !errors.Is(err, apperrors.ErrVersionSkew) {
+		t.Fatalf("approve err = %v, want ErrVersionSkew", err)
+	}
+	if n := e.WsCount(t, `SELECT count(*) FROM ai_model_rate WHERE provider='acme' AND model_id='m' AND input_per_mtok_microusd=6000000`); n != 0 {
+		t.Fatal("stale model proposal applied despite moved prior")
+	}
+	if n := e.WsCount(t,
+		`SELECT count(*) FROM approval WHERE id=$1 AND status='approved' AND consumed_at IS NULL`, id); n != 1 {
+		t.Fatal("approval must stay approved-unconsumed after a refused apply")
+	}
+}
+
+// A new-model proposal (no expected_prior — also the shape of a pre-existing
+// pending payload) refuses once the model gets priced before approval.
+func TestModelRateProposalApplyRefusesWhenPriorAppeared(t *testing.T) {
+	e := integration.Setup(t)
+	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
+	svc := rateSvc(e)
+
+	id := stageProposal(ctx, t, svc, aiModelRateProposalKind, aiModelRateTargetType, e.WS,
+		map[string]string{
+			"provider": "acme", "model_id": "new",
+			"input_per_mtok": "3", "output_per_mtok": "15", "cache_read_per_mtok": "0", "cache_write_per_mtok": "0",
+		}, "acme/new")
+	if _, err := ai.NewRateStore(e.Pool).SetModelRate(ctx, ai.SetModelRateInput{
+		Provider: "acme", ModelID: "new", InputUsd: "2", OutputUsd: "10", CacheReadUsd: "0", CacheWriteUsd: "0",
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if _, err := svc.Decide(ctx, id, true, nil); !errors.Is(err, apperrors.ErrVersionSkew) {
+		t.Fatalf("approve err = %v, want ErrVersionSkew", err)
+	}
+}
+
+// The precondition compares in µUSD: a wire-scale spelling of the same prior
+// ("5" vs a re-rendered "5.00") still matches, and the apply proceeds.
+func TestModelRateProposalApplyMatchingPriorApplies(t *testing.T) {
+	e := integration.Setup(t)
+	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
+	svc := rateSvc(e)
+
+	if _, err := ai.NewRateStore(e.Pool).SetModelRate(ctx, ai.SetModelRateInput{
+		Provider: "acme", ModelID: "m2", InputUsd: "5", OutputUsd: "25", CacheReadUsd: "0", CacheWriteUsd: "0",
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	id := stageProposal(ctx, t, svc, aiModelRateProposalKind, aiModelRateTargetType, e.WS,
+		map[string]any{
+			"provider": "acme", "model_id": "m2",
+			"input_per_mtok": "6", "output_per_mtok": "25", "cache_read_per_mtok": "0", "cache_write_per_mtok": "0",
+			"expected_prior": map[string]string{
+				"input_per_mtok": "5.00", "output_per_mtok": "25", "cache_read_per_mtok": "0", "cache_write_per_mtok": "0",
+			},
+		}, "acme/m2")
+	if _, err := svc.Decide(ctx, id, true, nil); err != nil {
+		t.Fatalf("approve: %v", err)
+	}
+	if n := e.WsCount(t, `SELECT count(*) FROM ai_model_rate WHERE provider='acme' AND model_id='m2' AND input_per_mtok_microusd=6000000`); n != 1 {
+		t.Fatal("matching-prior model proposal must apply")
+	}
+}

--- a/backend/internal/compose/rateproposals_integration_test.go
+++ b/backend/internal/compose/rateproposals_integration_test.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/gradionhq/margince/backend/internal/compose/integration"
 	"github.com/gradionhq/margince/backend/internal/modules/ai"
@@ -279,5 +280,82 @@ func TestModelRateProposalApplyMatchingPriorApplies(t *testing.T) {
 	}
 	if n := e.WsCount(t, `SELECT count(*) FROM ai_model_rate WHERE provider='acme' AND model_id='m2' AND input_per_mtok_microusd=6000000`); n != 1 {
 		t.Fatal("matching-prior model proposal must apply")
+	}
+}
+
+// An apply that crosses UTC midnight between the precondition read and the
+// write must refuse (the write is pinned to the day the precondition
+// sampled, so the append-forward guard fires) — never overwrite the new
+// day's already-scheduled row.
+func TestFxRateProposalApplyRefusesAcrossMidnight(t *testing.T) {
+	e := integration.Setup(t)
+	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
+	seed := deals.NewStore(e.Pool)
+	tomorrow := time.Now().UTC().Add(24 * time.Hour)
+	seedFx(ctx, t, seed, "SEK", "1.0", time.Time{})
+	seedFx(ctx, t, seed, "SEK", "9.9", tomorrow)
+
+	// The effect store's clock crosses midnight right after the precondition
+	// read: first sample = today, every later sample = the next day.
+	calls := 0
+	crossing := deals.NewStore(e.Pool).WithClock(func() time.Time {
+		calls++
+		if calls == 1 {
+			return time.Now().UTC()
+		}
+		return time.Now().UTC().Add(24 * time.Hour)
+	})
+	svc := approvals.NewService(e.Pool)
+	svc.WithEffect(fxRateProposalKind, fxRateAcceptEffect(svc, crossing))
+
+	id := stageProposal(ctx, t, svc, fxRateProposalKind, fxRateTargetType, e.WS,
+		map[string]string{"from_currency": "SEK", "rate": "1.2", "expected_prior_rate": "1.0"}, "SEK")
+	if _, err := svc.Decide(ctx, id, true, nil); err == nil {
+		t.Fatal("cross-midnight apply succeeded, want append-forward refusal")
+	}
+	if n := e.WsCount(t, `SELECT count(*) FROM fx_rate WHERE from_currency='SEK' AND rate=9.9`); n != 1 {
+		t.Fatal("the next day's scheduled row must survive a cross-midnight apply")
+	}
+	if n := e.WsCount(t, `SELECT count(*) FROM fx_rate WHERE from_currency='SEK' AND rate=1.2`); n != 0 {
+		t.Fatal("a cross-midnight apply must write nothing")
+	}
+}
+
+// The model-rate mirror of the cross-midnight refusal.
+func TestModelRateProposalApplyRefusesAcrossMidnight(t *testing.T) {
+	e := integration.Setup(t)
+	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
+	seed := ai.NewRateStore(e.Pool)
+	tomorrow := time.Now().UTC().Add(24 * time.Hour)
+	seedModelRate(ctx, t, seed, "acme", "mx", "5", time.Time{})
+	seedModelRate(ctx, t, seed, "acme", "mx", "9", tomorrow)
+
+	calls := 0
+	crossing := ai.NewRateStore(e.Pool).WithClock(func() time.Time {
+		calls++
+		if calls == 1 {
+			return time.Now().UTC()
+		}
+		return time.Now().UTC().Add(24 * time.Hour)
+	})
+	svc := approvals.NewService(e.Pool)
+	svc.WithEffect(aiModelRateProposalKind, aiModelRateAcceptEffect(svc, crossing))
+
+	id := stageProposal(ctx, t, svc, aiModelRateProposalKind, aiModelRateTargetType, e.WS,
+		map[string]any{
+			"provider": "acme", "model_id": "mx",
+			"input_per_mtok": "6", "output_per_mtok": "25", "cache_read_per_mtok": "0", "cache_write_per_mtok": "0",
+			"expected_prior": map[string]string{
+				"input_per_mtok": "5", "output_per_mtok": "25", "cache_read_per_mtok": "0", "cache_write_per_mtok": "0",
+			},
+		}, "acme/mx")
+	if _, err := svc.Decide(ctx, id, true, nil); err == nil {
+		t.Fatal("cross-midnight apply succeeded, want append-forward refusal")
+	}
+	if n := e.WsCount(t, `SELECT count(*) FROM ai_model_rate WHERE provider='acme' AND model_id='mx' AND input_per_mtok_microusd=9000000`); n != 1 {
+		t.Fatal("the next day's scheduled row must survive a cross-midnight apply")
+	}
+	if n := e.WsCount(t, `SELECT count(*) FROM ai_model_rate WHERE provider='acme' AND model_id='mx' AND input_per_mtok_microusd=6000000`); n != 0 {
+		t.Fatal("a cross-midnight apply must write nothing")
 	}
 }

--- a/backend/internal/compose/ratesupersede_integration_test.go
+++ b/backend/internal/compose/ratesupersede_integration_test.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package compose
+
+// Identity-keyed staging over real Postgres: a fresher diff for one logical
+// identity supersedes the stale pending proposal (forced expiry, audited, no
+// longer decidable), an identical re-stage still joins, and other identities
+// are untouched.
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration"
+	"github.com/gradionhq/margince/backend/internal/modules/approvals"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+func stageFxIdentity(ctx context.Context, t *testing.T, svc *approvals.Service, ws ids.UUID, cur, rate, prior string) ids.ApprovalID {
+	t.Helper()
+	raw, err := json.Marshal(map[string]string{"from_currency": cur, "rate": rate, "expected_prior_rate": prior})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	identity, err := json.Marshal(map[string]string{"from_currency": cur})
+	if err != nil {
+		t.Fatalf("marshal identity: %v", err)
+	}
+	digest := sha256.Sum256(raw)
+	id, err := svc.Stage(ctx, approvals.StageInput{
+		Kind: fxRateProposalKind, ProposedChange: raw, DiffHash: hex.EncodeToString(digest[:]),
+		TargetType: fxRateTargetType, TargetID: ws, Summary: cur,
+		JoinPending: true, Identity: identity,
+	})
+	if err != nil {
+		t.Fatalf("stage %s@%s: %v", cur, rate, err)
+	}
+	return id
+}
+
+func TestIdentityStagingSupersedesStalePending(t *testing.T) {
+	e := integration.Setup(t)
+	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AdminPerms)
+	svc := rateSvc(e)
+
+	stale := stageFxIdentity(ctx, t, svc, e.WS, "GBP", "1.1", "1.0")
+	other := stageFxIdentity(ctx, t, svc, e.WS, "USD", "0.9", "0.8")
+	fresh := stageFxIdentity(ctx, t, svc, e.WS, "GBP", "1.2", "1.0")
+	if stale == fresh {
+		t.Fatal("distinct diffs must stage distinct approvals")
+	}
+
+	live := func(id ids.ApprovalID) int {
+		return e.WsCount(t,
+			`SELECT count(*) FROM approval WHERE id = $1 AND status = 'pending' AND expires_at > now()`, id)
+	}
+	if live(stale) != 0 {
+		t.Fatal("stale GBP proposal still live, want superseded (forced expiry)")
+	}
+	if live(fresh) != 1 || live(other) != 1 {
+		t.Fatalf("fresh GBP live=%d, USD live=%d, want 1 and 1", live(fresh), live(other))
+	}
+	if n := e.WsCount(t,
+		`SELECT count(*) FROM audit_log WHERE entity_type='approval' AND entity_id=$1 AND evidence->>'superseded_by'=$2`,
+		stale.UUID, fresh.UUID.String()); n != 1 {
+		t.Fatalf("superseded audit rows = %d, want 1", n)
+	}
+	// The withdrawn authority is dead: deciding it reads as already-expired.
+	if _, err := svc.Decide(ctx, stale, true, nil); err == nil {
+		t.Fatal("deciding a superseded proposal succeeded, want expired rejection")
+	}
+	// An identical re-stage still joins the survivor instead of duplicating it.
+	if again := stageFxIdentity(ctx, t, svc, e.WS, "GBP", "1.2", "1.0"); again != fresh {
+		t.Fatalf("identical re-stage created %s, want join of %s", again, fresh)
+	}
+}

--- a/backend/internal/compose/ratesupersede_integration_test.go
+++ b/backend/internal/compose/ratesupersede_integration_test.go
@@ -68,7 +68,7 @@ func TestIdentityStagingSupersedesStalePending(t *testing.T) {
 	}
 	if n := e.WsCount(t,
 		`SELECT count(*) FROM audit_log WHERE entity_type='approval' AND entity_id=$1 AND evidence->>'superseded_by'=$2`,
-		stale.UUID, fresh.UUID.String()); n != 1 {
+		stale.UUID, fresh.String()); n != 1 {
 		t.Fatalf("superseded audit rows = %d, want 1", n)
 	}
 	// The withdrawn authority is dead: deciding it reads as already-expired.

--- a/backend/internal/modules/ai/ratelockkey_test.go
+++ b/backend/internal/modules/ai/ratelockkey_test.go
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package ai
+
+import "testing"
+
+// The advisory-lock key must be injective: two distinct (provider, model_id)
+// identities that a naive "provider/model_id" join would collide onto one key
+// ("a/b","c") vs ("a","b/c") must map to different lock strings, or unrelated
+// rows would serialize against each other.
+func TestModelRateLockKeyIsInjective(t *testing.T) {
+	pairs := [][2]string{{"a/b", "c"}, {"a", "b/c"}, {"a", "bc"}, {"ab", "c"}}
+	seen := make(map[string][2]string, len(pairs))
+	for _, p := range pairs {
+		key := modelRateLockKey(p[0], p[1])
+		if prev, ok := seen[key]; ok {
+			t.Fatalf("collision: %v and %v both map to %q", prev, p, key)
+		}
+		seen[key] = p
+	}
+}

--- a/backend/internal/modules/ai/ratestore.go
+++ b/backend/internal/modules/ai/ratestore.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
@@ -60,17 +61,30 @@ func (s *RateStore) RateFor(ctx context.Context, provider, modelID string, day t
 	return rate, nil
 }
 
-// EffectiveModelRateInTx resolves the price in force TODAY (store clock) for
-// one model through a caller-owned transaction — the approval-effect
-// precondition read, which must see the same state the apply writes into.
-// (nil, nil) = unpriced, mirroring RateFor. Admin/ops read gate, matching the
-// fx sibling (EffectiveFxRateInTx): the precondition reads must gate
-// identically so the invariant survives a future caller.
-func (s *RateStore) EffectiveModelRateInTx(ctx context.Context, tx pgx.Tx, provider, modelID string) (*ModelRate, error) {
+// EffectiveModelRateInTx resolves the price in force for one model through a
+// caller-owned transaction — the approval-effect precondition read, which
+// must see the same state the apply writes into. It takes the model's
+// write-identity lock (so no standalone write can commit between this read
+// and the dependent write) and returns the day it sampled: the caller pins
+// its write to that SAME day, so a transaction that crosses UTC midnight
+// fails the append-forward guard instead of overwriting the new day's
+// scheduled row. A nil rate = unpriced, mirroring RateFor. Admin/ops read
+// gate, matching the fx sibling (EffectiveFxRateInTx): the precondition
+// reads must gate identically so the invariant survives a future caller.
+func (s *RateStore) EffectiveModelRateInTx(ctx context.Context, tx pgx.Tx, provider, modelID string) (*ModelRate, time.Time, error) {
 	if err := auth.Require(ctx, "ai_model_rate", principal.ActionRead); err != nil {
-		return nil, err
+		return nil, time.Time{}, err
 	}
-	return rateForInTx(ctx, tx, strings.TrimSpace(provider), strings.TrimSpace(modelID), s.todayUTC())
+	provider, modelID = strings.TrimSpace(provider), strings.TrimSpace(modelID)
+	if err := storekit.LockWriteIdentity(ctx, tx, "ai_model_rate", provider+"/"+modelID); err != nil {
+		return nil, time.Time{}, err
+	}
+	asOf := s.todayUTC()
+	rate, err := rateForInTx(ctx, tx, provider, modelID, asOf)
+	if err != nil {
+		return nil, time.Time{}, err
+	}
+	return rate, asOf, nil
 }
 
 func rateForInTx(ctx context.Context, tx pgx.Tx, provider, modelID string, day time.Time) (*ModelRate, error) {

--- a/backend/internal/modules/ai/ratestore.go
+++ b/backend/internal/modules/ai/ratestore.go
@@ -13,7 +13,9 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
 // RateStore is the ai_model_rate price sheet — the fx_rate-style
@@ -61,8 +63,13 @@ func (s *RateStore) RateFor(ctx context.Context, provider, modelID string, day t
 // EffectiveModelRateInTx resolves the price in force TODAY (store clock) for
 // one model through a caller-owned transaction — the approval-effect
 // precondition read, which must see the same state the apply writes into.
-// (nil, nil) = unpriced, mirroring RateFor.
+// (nil, nil) = unpriced, mirroring RateFor. Admin/ops read gate, matching the
+// fx sibling (EffectiveFxRateInTx): the precondition reads must gate
+// identically so the invariant survives a future caller.
 func (s *RateStore) EffectiveModelRateInTx(ctx context.Context, tx pgx.Tx, provider, modelID string) (*ModelRate, error) {
+	if err := auth.Require(ctx, "ai_model_rate", principal.ActionRead); err != nil {
+		return nil, err
+	}
 	return rateForInTx(ctx, tx, strings.TrimSpace(provider), strings.TrimSpace(modelID), s.todayUTC())
 }
 

--- a/backend/internal/modules/ai/ratestore.go
+++ b/backend/internal/modules/ai/ratestore.go
@@ -76,7 +76,7 @@ func (s *RateStore) EffectiveModelRateInTx(ctx context.Context, tx pgx.Tx, provi
 		return nil, time.Time{}, err
 	}
 	provider, modelID = strings.TrimSpace(provider), strings.TrimSpace(modelID)
-	if err := storekit.LockWriteIdentity(ctx, tx, "ai_model_rate", provider+"/"+modelID); err != nil {
+	if err := storekit.LockWriteIdentity(ctx, tx, "ai_model_rate", modelRateLockKey(provider, modelID)); err != nil {
 		return nil, time.Time{}, err
 	}
 	asOf := s.todayUTC()

--- a/backend/internal/modules/ai/ratestore.go
+++ b/backend/internal/modules/ai/ratestore.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -45,18 +46,37 @@ func (s *RateStore) WithClock(clock func() time.Time) *RateStore {
 // signal from a 0 price (price-on-read; never fabricate a price), so the
 // caller gets (nil, nil) and decides what "unpriced" means to it.
 func (s *RateStore) RateFor(ctx context.Context, provider, modelID string, day time.Time) (*ModelRate, error) {
-	var rate ModelRate
+	var rate *ModelRate
 	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
-		return tx.QueryRow(ctx, `
-			SELECT provider, model_id, input_per_mtok_microusd, output_per_mtok_microusd,
-			       cache_read_per_mtok_microusd, cache_write_per_mtok_microusd, effective_date
-			FROM ai_model_rate
-			WHERE provider = $1 AND model_id = $2 AND effective_date <= $3
-			ORDER BY effective_date DESC LIMIT 1`,
-			provider, modelID, day).Scan(
-			&rate.Provider, &rate.ModelID, &rate.InputPerMTokMicroUSD, &rate.OutputPerMTokMicroUSD,
-			&rate.CacheReadPerMTokMicroUSD, &rate.CacheWritePerMTokMicroUSD, &rate.EffectiveDate)
+		var e error
+		rate, e = rateForInTx(ctx, tx, provider, modelID, day)
+		return e
 	})
+	if err != nil {
+		return nil, err
+	}
+	return rate, nil
+}
+
+// EffectiveModelRateInTx resolves the price in force TODAY (store clock) for
+// one model through a caller-owned transaction — the approval-effect
+// precondition read, which must see the same state the apply writes into.
+// (nil, nil) = unpriced, mirroring RateFor.
+func (s *RateStore) EffectiveModelRateInTx(ctx context.Context, tx pgx.Tx, provider, modelID string) (*ModelRate, error) {
+	return rateForInTx(ctx, tx, strings.TrimSpace(provider), strings.TrimSpace(modelID), s.todayUTC())
+}
+
+func rateForInTx(ctx context.Context, tx pgx.Tx, provider, modelID string, day time.Time) (*ModelRate, error) {
+	var rate ModelRate
+	err := tx.QueryRow(ctx, `
+		SELECT provider, model_id, input_per_mtok_microusd, output_per_mtok_microusd,
+		       cache_read_per_mtok_microusd, cache_write_per_mtok_microusd, effective_date
+		FROM ai_model_rate
+		WHERE provider = $1 AND model_id = $2 AND effective_date <= $3
+		ORDER BY effective_date DESC LIMIT 1`,
+		provider, modelID, day).Scan(
+		&rate.Provider, &rate.ModelID, &rate.InputPerMTokMicroUSD, &rate.OutputPerMTokMicroUSD,
+		&rate.CacheReadPerMTokMicroUSD, &rate.CacheWritePerMTokMicroUSD, &rate.EffectiveDate)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil //nolint:nilnil // no matching rate row IS the "unpriced" answer, not an error — price-on-read never fabricates a price
 	}

--- a/backend/internal/modules/ai/ratewrite.go
+++ b/backend/internal/modules/ai/ratewrite.go
@@ -141,6 +141,12 @@ func (s *RateStore) prepareModelRate(ctx context.Context, in SetModelRateInput) 
 // stays true at write time), then upsert the append-forward row and audit — all
 // in the caller-owned tx.
 func (s *RateStore) writeModelRate(ctx context.Context, tx pgx.Tx, p preparedModelRate, effectiveDate time.Time) (ModelRateRow, error) {
+	// Serialize writers of this model's sheet identity BEFORE sampling the
+	// clock: a write that waited here for a precondition-holding transaction
+	// must judge append-forward against the day it actually runs.
+	if err := storekit.LockWriteIdentity(ctx, tx, "ai_model_rate", p.provider+"/"+p.modelID); err != nil {
+		return ModelRateRow{}, err
+	}
 	today := s.todayUTC()
 	if effectiveDate.IsZero() {
 		effectiveDate = today

--- a/backend/internal/modules/ai/ratewrite.go
+++ b/backend/internal/modules/ai/ratewrite.go
@@ -222,6 +222,35 @@ func (s *RateStore) ListLatestModelRates(ctx context.Context) ([]ModelRateRow, e
 	return rows, err
 }
 
+// ListEffectiveModelRates returns the price in force TODAY per (provider,
+// model_id) — the latest row with effective_date <= today (store clock), the
+// list form of RateFor's as-of resolution. Deliberately distinct from
+// ListLatestModelRates (sheet head, which may be future-scheduled): a refresh
+// diff compares against what is in force, not what is scheduled. Admin/ops
+// read gate.
+func (s *RateStore) ListEffectiveModelRates(ctx context.Context) ([]ModelRateRow, error) {
+	if err := auth.Require(ctx, "ai_model_rate", principal.ActionRead); err != nil {
+		return nil, err
+	}
+	today := s.todayUTC()
+	var rows []ModelRateRow
+	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+		r, err := tx.Query(ctx, `
+			SELECT DISTINCT ON (provider, model_id)
+			       provider, model_id, input_per_mtok_microusd, output_per_mtok_microusd,
+			       cache_read_per_mtok_microusd, cache_write_per_mtok_microusd, effective_date
+			FROM ai_model_rate WHERE effective_date <= $1
+			ORDER BY provider, model_id, effective_date DESC`, today)
+		if err != nil {
+			return fmt.Errorf("list effective ai_model_rate: %w", err)
+		}
+		defer r.Close()
+		rows, err = scanModelRateRows(r)
+		return err
+	})
+	return rows, err
+}
+
 // ModelRateHistory returns every effective-dated row for one model, newest
 // first (read-only history). Admin/ops read gate.
 func (s *RateStore) ModelRateHistory(ctx context.Context, provider, modelID string) ([]ModelRateRow, error) {

--- a/backend/internal/modules/ai/ratewrite.go
+++ b/backend/internal/modules/ai/ratewrite.go
@@ -238,15 +238,16 @@ func (s *RateStore) ListEffectiveModelRates(ctx context.Context) ([]ModelRateRow
 	if err := auth.Require(ctx, "ai_model_rate", principal.ActionRead); err != nil {
 		return nil, err
 	}
-	today := s.todayUTC()
 	var rows []ModelRateRow
 	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+		// Sample "today" inside the transaction: a wait for a pooled
+		// connection across UTC midnight must not list yesterday's cutoff.
 		r, err := tx.Query(ctx, `
 			SELECT DISTINCT ON (provider, model_id)
 			       provider, model_id, input_per_mtok_microusd, output_per_mtok_microusd,
 			       cache_read_per_mtok_microusd, cache_write_per_mtok_microusd, effective_date
 			FROM ai_model_rate WHERE effective_date <= $1
-			ORDER BY provider, model_id, effective_date DESC`, today)
+			ORDER BY provider, model_id, effective_date DESC`, s.todayUTC())
 		if err != nil {
 			return fmt.Errorf("list effective ai_model_rate: %w", err)
 		}

--- a/backend/internal/modules/ai/ratewrite.go
+++ b/backend/internal/modules/ai/ratewrite.go
@@ -49,6 +49,15 @@ func (s *RateStore) todayUTC() time.Time {
 	return s.clock().UTC().Truncate(24 * time.Hour)
 }
 
+// modelRateLockKey encodes (provider, model_id) into ONE injective advisory-
+// lock string. A plain "provider/model_id" join is ambiguous — ("a/b","c")
+// and ("a","b/c") would collide onto one lock and serialize two unrelated
+// rows — so the provider is length-prefixed, which no concatenation of a
+// different split can reproduce.
+func modelRateLockKey(provider, modelID string) string {
+	return fmt.Sprintf("%d:%s%s", len(provider), provider, modelID)
+}
+
 // modelRateMicroUSD converts the four USD/MTok string buckets to µUSD, failing
 // on the first invalid one (all typed 422s).
 func modelRateMicroUSD(in SetModelRateInput) (input, output, cacheRead, cacheWrite int64, err error) {
@@ -144,7 +153,7 @@ func (s *RateStore) writeModelRate(ctx context.Context, tx pgx.Tx, p preparedMod
 	// Serialize writers of this model's sheet identity BEFORE sampling the
 	// clock: a write that waited here for a precondition-holding transaction
 	// must judge append-forward against the day it actually runs.
-	if err := storekit.LockWriteIdentity(ctx, tx, "ai_model_rate", p.provider+"/"+p.modelID); err != nil {
+	if err := storekit.LockWriteIdentity(ctx, tx, "ai_model_rate", modelRateLockKey(p.provider, p.modelID)); err != nil {
 		return ModelRateRow{}, err
 	}
 	today := s.todayUTC()

--- a/backend/internal/modules/approvals/service_test.go
+++ b/backend/internal/modules/approvals/service_test.go
@@ -53,36 +53,44 @@ func TestStageIdentityValidation(t *testing.T) {
 	}
 }
 
-// A null-valued identity field must not validate against a payload that omits
-// the field: jsonb containment treats {"k":null} as present-and-null, so such
-// an identity would pass and then never containment-match — silently
-// disabling supersession. And a large-integer identity must survive
-// validation digit-for-digit rather than round through float64.
-func TestCanonicalIdentityRejectsNullAndPreservesBigNumbers(t *testing.T) {
-	// Null field the payload omits: refused as not-carried.
+// Identity values must be strings, a null field the payload omits must be
+// refused, and trailing data past the object must be rejected — each edge, if
+// admitted, would let a lock key and jsonb containment disagree and leave
+// competing live proposals for one logical identity.
+func TestCanonicalIdentityRejectsNonStringNullAndTrailingData(t *testing.T) {
+	// A numeric identity value is refused: 1, 1.0 and 1e0 hash to different
+	// lock keys but jsonb containment sees one number, so a numeric identity
+	// could bypass the per-identity lock. Strings have no such spelling gap.
+	if _, err := canonicalIdentity(
+		json.RawMessage(`{"seq":1}`),
+		json.RawMessage(`{"seq":1}`),
+	); err == nil || !strings.Contains(err.Error(), "must be a string") {
+		t.Fatalf("numeric identity: err = %v, want must-be-a-string refusal", err)
+	}
+	// A null field the payload omits is refused (not silently passed).
 	if _, err := canonicalIdentity(
 		json.RawMessage(`{"k":null}`),
 		json.RawMessage(`{"other":"v"}`),
-	); err == nil || !strings.Contains(err.Error(), "not carried by ProposedChange") {
-		t.Fatalf("null-vs-omitted: err = %v, want not-carried refusal", err)
-	}
-	// A large integer that would round under float64: exact match validates,
-	// and the canonical form preserves the digits (no rounding, no quoting).
-	big := `{"seq":12345678901234567890}`
-	canonical, err := canonicalIdentity(json.RawMessage(big), json.RawMessage(`{"seq":12345678901234567890,"x":"y"}`))
-	if err != nil {
-		t.Fatalf("big-int identity: %v", err)
-	}
-	if string(canonical) != `{"seq":12345678901234567890}` {
-		t.Fatalf("canonical = %s, want the exact integer preserved", canonical)
-	}
-	// A payload whose value rounds to the same float64 but differs exactly is
-	// still rejected (lossless comparison).
-	if _, err := canonicalIdentity(
-		json.RawMessage(`{"seq":12345678901234567890}`),
-		json.RawMessage(`{"seq":12345678901234567891}`),
 	); err == nil {
-		t.Fatal("near-equal big integers validated, want exact-mismatch refusal")
+		t.Fatal("null-vs-omitted identity validated, want refusal")
+	}
+	// Trailing data after the object is rejected: Identity is ONE object.
+	if _, err := canonicalIdentity(
+		json.RawMessage(`{"from_currency":"GBP"} {"x":"y"}`),
+		json.RawMessage(`{"from_currency":"GBP"}`),
+	); err == nil {
+		t.Fatal("trailing data after identity validated, want refusal")
+	}
+	// A string identity carried by the payload validates and canonicalizes.
+	canonical, err := canonicalIdentity(
+		json.RawMessage(`{"from_currency":"GBP"}`),
+		json.RawMessage(`{"from_currency":"GBP","rate":"1.1"}`),
+	)
+	if err != nil {
+		t.Fatalf("valid string identity: %v", err)
+	}
+	if string(canonical) != `{"from_currency":"GBP"}` {
+		t.Fatalf("canonical = %s, want {\"from_currency\":\"GBP\"}", canonical)
 	}
 }
 

--- a/backend/internal/modules/approvals/service_test.go
+++ b/backend/internal/modules/approvals/service_test.go
@@ -53,6 +53,39 @@ func TestStageIdentityValidation(t *testing.T) {
 	}
 }
 
+// A null-valued identity field must not validate against a payload that omits
+// the field: jsonb containment treats {"k":null} as present-and-null, so such
+// an identity would pass and then never containment-match — silently
+// disabling supersession. And a large-integer identity must survive
+// validation digit-for-digit rather than round through float64.
+func TestCanonicalIdentityRejectsNullAndPreservesBigNumbers(t *testing.T) {
+	// Null field the payload omits: refused as not-carried.
+	if _, err := canonicalIdentity(
+		json.RawMessage(`{"k":null}`),
+		json.RawMessage(`{"other":"v"}`),
+	); err == nil || !strings.Contains(err.Error(), "not carried by ProposedChange") {
+		t.Fatalf("null-vs-omitted: err = %v, want not-carried refusal", err)
+	}
+	// A large integer that would round under float64: exact match validates,
+	// and the canonical form preserves the digits (no rounding, no quoting).
+	big := `{"seq":12345678901234567890}`
+	canonical, err := canonicalIdentity(json.RawMessage(big), json.RawMessage(`{"seq":12345678901234567890,"x":"y"}`))
+	if err != nil {
+		t.Fatalf("big-int identity: %v", err)
+	}
+	if string(canonical) != `{"seq":12345678901234567890}` {
+		t.Fatalf("canonical = %s, want the exact integer preserved", canonical)
+	}
+	// A payload whose value rounds to the same float64 but differs exactly is
+	// still rejected (lossless comparison).
+	if _, err := canonicalIdentity(
+		json.RawMessage(`{"seq":12345678901234567890}`),
+		json.RawMessage(`{"seq":12345678901234567891}`),
+	); err == nil {
+		t.Fatal("near-equal big integers validated, want exact-mismatch refusal")
+	}
+}
+
 // Two spellings of one identity (key order, spacing) must canonicalize to the
 // same bytes: the advisory lock hashes those bytes, so a spelling difference
 // would let two stagers of one identity race past the per-identity section.

--- a/backend/internal/modules/approvals/service_test.go
+++ b/backend/internal/modules/approvals/service_test.go
@@ -42,6 +42,33 @@ func TestStageIdentityValidation(t *testing.T) {
 			t.Fatalf("identity %s: err = %v, want non-empty-object refusal", identity, err)
 		}
 	}
+	// An identity the payload does not carry could never containment-match a
+	// stored proposed_change — supersession would be silently disabled.
+	if _, err := svc.Stage(context.Background(), StageInput{
+		Kind: "fx_rate_proposal", DiffHash: "h", JoinPending: true,
+		ProposedChange: json.RawMessage(`{"from_currency":"USD","rate":"1"}`),
+		Identity:       json.RawMessage(`{"from_currency":"GBP"}`),
+	}); err == nil || !strings.Contains(err.Error(), "not carried by ProposedChange") {
+		t.Fatalf("mismatched identity: err = %v, want not-carried refusal", err)
+	}
+}
+
+// Two spellings of one identity (key order, spacing) must canonicalize to the
+// same bytes: the advisory lock hashes those bytes, so a spelling difference
+// would let two stagers of one identity race past the per-identity section.
+func TestCanonicalIdentityNormalizesSpelling(t *testing.T) {
+	payload := json.RawMessage(`{"provider":"a","model_id":"m","rate":"1"}`)
+	a, err := canonicalIdentity(json.RawMessage(`{ "model_id":"m", "provider":"a" }`), payload)
+	if err != nil {
+		t.Fatalf("canonicalize a: %v", err)
+	}
+	b, err := canonicalIdentity(json.RawMessage(`{"provider":"a","model_id":"m"}`), payload)
+	if err != nil {
+		t.Fatalf("canonicalize b: %v", err)
+	}
+	if string(a) != string(b) {
+		t.Fatalf("canonical forms differ: %s vs %s", a, b)
+	}
 }
 
 // A pending staging past its expiry reads as expired everywhere — there

--- a/backend/internal/modules/approvals/service_test.go
+++ b/backend/internal/modules/approvals/service_test.go
@@ -24,14 +24,23 @@ import (
 
 // Identity is only meaningful under JoinPending — without it there is no
 // serialized per-identity section, so a supersede could race a plain
-// insert. The combination is refused before any transaction is opened.
-func TestStageIdentityRequiresJoinPending(t *testing.T) {
+// insert. And because the supersede match is JSONB containment (every object
+// contains {}), an empty or non-object identity would withdraw EVERY live
+// pending proposal of the kind+target — both are refused before any
+// transaction is opened.
+func TestStageIdentityValidation(t *testing.T) {
 	svc := NewService(nil)
-	_, err := svc.Stage(context.Background(), StageInput{
+	if _, err := svc.Stage(context.Background(), StageInput{
 		Kind: "fx_rate_proposal", DiffHash: "h", Identity: json.RawMessage(`{"from_currency":"GBP"}`),
-	})
-	if err == nil || !strings.Contains(err.Error(), "JoinPending") {
+	}); err == nil || !strings.Contains(err.Error(), "JoinPending") {
 		t.Fatalf("err = %v, want identity-requires-JoinPending error", err)
+	}
+	for _, identity := range []string{`{}`, `[]`, `"x"`, `null`} {
+		if _, err := svc.Stage(context.Background(), StageInput{
+			Kind: "fx_rate_proposal", DiffHash: "h", JoinPending: true, Identity: json.RawMessage(identity),
+		}); err == nil || !strings.Contains(err.Error(), "non-empty JSON object") {
+			t.Fatalf("identity %s: err = %v, want non-empty-object refusal", identity, err)
+		}
 	}
 }
 

--- a/backend/internal/modules/approvals/service_test.go
+++ b/backend/internal/modules/approvals/service_test.go
@@ -11,7 +11,9 @@ package approvals
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -19,6 +21,19 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
+
+// Identity is only meaningful under JoinPending — without it there is no
+// serialized per-identity section, so a supersede could race a plain
+// insert. The combination is refused before any transaction is opened.
+func TestStageIdentityRequiresJoinPending(t *testing.T) {
+	svc := NewService(nil)
+	_, err := svc.Stage(context.Background(), StageInput{
+		Kind: "fx_rate_proposal", DiffHash: "h", Identity: json.RawMessage(`{"from_currency":"GBP"}`),
+	})
+	if err == nil || !strings.Contains(err.Error(), "JoinPending") {
+		t.Fatalf("err = %v, want identity-requires-JoinPending error", err)
+	}
+}
 
 // A pending staging past its expiry reads as expired everywhere — there
 // is no sweeper, so this fold IS the pending→expired transition; a

--- a/backend/internal/modules/approvals/staging.go
+++ b/backend/internal/modules/approvals/staging.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -70,13 +71,11 @@ func (s *Service) Stage(ctx context.Context, in StageInput) (ids.ApprovalID, err
 		if !in.JoinPending {
 			return ids.ApprovalID{}, errors.New("crmapprovals: Identity staging requires JoinPending")
 		}
-		// The supersede match is JSONB containment, and every object contains
-		// {} — an empty (or non-object) identity would withdraw EVERY live
-		// pending proposal of the kind+target, so refuse it up front.
-		var identity map[string]json.RawMessage
-		if err := json.Unmarshal(in.Identity, &identity); err != nil || len(identity) == 0 {
-			return ids.ApprovalID{}, errors.New("crmapprovals: Identity must be a non-empty JSON object")
+		canonical, err := canonicalIdentity(in.Identity, in.ProposedChange)
+		if err != nil {
+			return ids.ApprovalID{}, err
 		}
+		in.Identity = canonical
 	}
 	var id ids.ApprovalID
 	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
@@ -89,6 +88,37 @@ func (s *Service) Stage(ctx context.Context, in StageInput) (ids.ApprovalID, err
 		return err
 	})
 	return id, err
+}
+
+// canonicalIdentity validates and canonicalizes a staging identity. It must
+// be a non-empty JSON object — the supersede match is JSONB containment and
+// every object contains {}, so an empty (or non-object) identity would
+// withdraw EVERY live pending proposal of the kind+target — and each of its
+// fields must equal the same field of ProposedChange, because an identity
+// the payload does not carry could never containment-match and would
+// silently disable supersession for its proposals. Re-marshaling
+// canonicalizes key order and spacing, so the advisory lock (which hashes
+// the identity bytes) and the containment agree on what "same identity"
+// means across callers.
+func canonicalIdentity(identity, proposedChange json.RawMessage) (json.RawMessage, error) {
+	var idFields map[string]any
+	if err := json.Unmarshal(identity, &idFields); err != nil || len(idFields) == 0 {
+		return nil, errors.New("crmapprovals: Identity must be a non-empty JSON object")
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(proposedChange, &payload); err != nil {
+		return nil, errors.New("crmapprovals: Identity staging requires a JSON-object ProposedChange")
+	}
+	for field, want := range idFields {
+		if !reflect.DeepEqual(payload[field], want) {
+			return nil, fmt.Errorf("crmapprovals: Identity field %q is not carried by ProposedChange", field)
+		}
+	}
+	canonical, err := json.Marshal(idFields)
+	if err != nil {
+		return nil, fmt.Errorf("crmapprovals: canonicalize Identity: %w", err)
+	}
+	return canonical, nil
 }
 
 // stageOrJoinPendingInTx serializes one proposal identity and returns its live
@@ -148,8 +178,11 @@ func (s *Service) supersedePendingInTx(ctx context.Context, tx pgx.Tx, wsID ids.
 	if !ok {
 		return errors.New("crmapprovals: no actor bound to context")
 	}
+	// Backdating a full day (not a second) keeps the row expired under the
+	// APP clock too: effectiveStatus judges expiry with the service clock,
+	// which may trail the database by ordinary NTP skew — never by a day.
 	rows, err := tx.Query(ctx, `
-		UPDATE approval SET expires_at = now() - interval '1 second'
+		UPDATE approval SET expires_at = now() - interval '1 day'
 		WHERE workspace_id = $1 AND kind = $2 AND target_entity_id = $3
 		  AND status = 'pending' AND expires_at > now()
 		  AND id <> $4 AND proposed_change @> $5

--- a/backend/internal/modules/approvals/staging.go
+++ b/backend/internal/modules/approvals/staging.go
@@ -66,8 +66,17 @@ type AnnouncedEvent struct {
 // emits approval.requested. It runs in the write shape every mutation
 // uses: approval row + audit row + event in one transaction.
 func (s *Service) Stage(ctx context.Context, in StageInput) (ids.ApprovalID, error) {
-	if len(in.Identity) > 0 && !in.JoinPending {
-		return ids.ApprovalID{}, errors.New("crmapprovals: Identity staging requires JoinPending")
+	if len(in.Identity) > 0 {
+		if !in.JoinPending {
+			return ids.ApprovalID{}, errors.New("crmapprovals: Identity staging requires JoinPending")
+		}
+		// The supersede match is JSONB containment, and every object contains
+		// {} — an empty (or non-object) identity would withdraw EVERY live
+		// pending proposal of the kind+target, so refuse it up front.
+		var identity map[string]json.RawMessage
+		if err := json.Unmarshal(in.Identity, &identity); err != nil || len(identity) == 0 {
+			return ids.ApprovalID{}, errors.New("crmapprovals: Identity must be a non-empty JSON object")
+		}
 	}
 	var id ids.ApprovalID
 	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {

--- a/backend/internal/modules/approvals/staging.go
+++ b/backend/internal/modules/approvals/staging.go
@@ -9,7 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"reflect"
+	"io"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -92,15 +92,18 @@ func (s *Service) Stage(ctx context.Context, in StageInput) (ids.ApprovalID, err
 }
 
 // canonicalIdentity validates and canonicalizes a staging identity. It must
-// be a non-empty JSON object — the supersede match is JSONB containment and
-// every object contains {}, so an empty (or non-object) identity would
-// withdraw EVERY live pending proposal of the kind+target — and each of its
-// fields must equal the same field of ProposedChange, because an identity
-// the payload does not carry could never containment-match and would
-// silently disable supersession for its proposals. Re-marshaling
-// canonicalizes key order and spacing, so the advisory lock (which hashes
-// the identity bytes) and the containment agree on what "same identity"
-// means across callers.
+// be a non-empty JSON object whose values are all STRINGS — the logical key
+// of a sheet row is always a string (currency code, provider/model id), and
+// restricting to strings sidesteps JSON number ambiguity entirely: 1, 1.0,
+// 1e0 and a 40-digit integer would each hash to a different advisory lock
+// while PostgreSQL jsonb containment compares them as one numeric value, so a
+// numeric identity could bypass the per-identity lock yet still supersede by
+// value. Strings have no such gap — exact bytes both places. Every field must
+// also equal (present, same string) the corresponding field of
+// ProposedChange, since an identity the payload does not carry could never
+// containment-match and would silently disable supersession. Re-marshaling
+// canonicalizes key order and spacing so the lock and the containment agree
+// on what "same identity" means across callers.
 func canonicalIdentity(identity, proposedChange json.RawMessage) (json.RawMessage, error) {
 	idFields, err := decodeJSONObject(identity)
 	if err != nil || len(idFields) == 0 {
@@ -110,30 +113,35 @@ func canonicalIdentity(identity, proposedChange json.RawMessage) (json.RawMessag
 	if err != nil {
 		return nil, errors.New("crmapprovals: Identity staging requires a JSON-object ProposedChange")
 	}
+	canonical := make(map[string]string, len(idFields))
 	for field, want := range idFields {
-		// Membership must be checked separately from value equality: a missing
-		// key and an explicit null both read back as a nil any, but jsonb
-		// containment treats {"k":null} as present-and-null — an identity
-		// asserting a field the payload omits would pass here yet never
-		// containment-match, silently disabling supersession.
+		wantStr, ok := want.(string)
+		if !ok {
+			return nil, fmt.Errorf("crmapprovals: Identity field %q must be a string", field)
+		}
+		// Membership is checked separately from value: a missing key and an
+		// explicit null both read back as a nil any, but jsonb containment
+		// treats {"k":null} as present-and-null — an identity asserting a field
+		// the payload omits would pass and then never containment-match.
 		got, ok := payload[field]
-		if !ok || !reflect.DeepEqual(got, want) {
+		if !ok || got != want {
 			return nil, fmt.Errorf("crmapprovals: Identity field %q is not carried by ProposedChange", field)
 		}
+		canonical[field] = wantStr
 	}
-	canonical, err := json.Marshal(idFields)
+	raw, err := json.Marshal(canonical)
 	if err != nil {
 		return nil, fmt.Errorf("crmapprovals: canonicalize Identity: %w", err)
 	}
-	return canonical, nil
+	return raw, nil
 }
 
-// decodeJSONObject unmarshals a JSON object with lossless numbers: UseNumber
-// keeps every numeric value as its exact decimal text rather than a float64,
-// so a large-integer identity is compared and re-marshaled digit-for-digit.
-// A float64 round would let a mismatched value pass validation and then fail
-// the jsonb containment supersede against the payload's exact number. A
-// non-object (array, scalar, null) is not an object and returns an error.
+// decodeJSONObject unmarshals exactly one JSON object with lossless numbers
+// (UseNumber keeps a numeric value as its exact decimal text, not a float64).
+// A non-object (array, scalar, null) is an error, and so is any trailing data
+// after the object — Identity/ProposedChange is ONE object, not a stream, and
+// silently reading only the first of several values would validate against a
+// payload the rest of the input contradicts.
 func decodeJSONObject(raw json.RawMessage) (map[string]any, error) {
 	dec := json.NewDecoder(bytes.NewReader(raw))
 	dec.UseNumber()
@@ -143,6 +151,9 @@ func decodeJSONObject(raw json.RawMessage) (map[string]any, error) {
 	}
 	if m == nil {
 		return nil, errors.New("not a JSON object")
+	}
+	if _, err := dec.Token(); !errors.Is(err, io.EOF) {
+		return nil, errors.New("unexpected trailing data after JSON object")
 	}
 	return m, nil
 }

--- a/backend/internal/modules/approvals/staging.go
+++ b/backend/internal/modules/approvals/staging.go
@@ -4,6 +4,7 @@
 package approvals
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -101,16 +102,22 @@ func (s *Service) Stage(ctx context.Context, in StageInput) (ids.ApprovalID, err
 // the identity bytes) and the containment agree on what "same identity"
 // means across callers.
 func canonicalIdentity(identity, proposedChange json.RawMessage) (json.RawMessage, error) {
-	var idFields map[string]any
-	if err := json.Unmarshal(identity, &idFields); err != nil || len(idFields) == 0 {
+	idFields, err := decodeJSONObject(identity)
+	if err != nil || len(idFields) == 0 {
 		return nil, errors.New("crmapprovals: Identity must be a non-empty JSON object")
 	}
-	var payload map[string]any
-	if err := json.Unmarshal(proposedChange, &payload); err != nil {
+	payload, err := decodeJSONObject(proposedChange)
+	if err != nil {
 		return nil, errors.New("crmapprovals: Identity staging requires a JSON-object ProposedChange")
 	}
 	for field, want := range idFields {
-		if !reflect.DeepEqual(payload[field], want) {
+		// Membership must be checked separately from value equality: a missing
+		// key and an explicit null both read back as a nil any, but jsonb
+		// containment treats {"k":null} as present-and-null — an identity
+		// asserting a field the payload omits would pass here yet never
+		// containment-match, silently disabling supersession.
+		got, ok := payload[field]
+		if !ok || !reflect.DeepEqual(got, want) {
 			return nil, fmt.Errorf("crmapprovals: Identity field %q is not carried by ProposedChange", field)
 		}
 	}
@@ -119,6 +126,25 @@ func canonicalIdentity(identity, proposedChange json.RawMessage) (json.RawMessag
 		return nil, fmt.Errorf("crmapprovals: canonicalize Identity: %w", err)
 	}
 	return canonical, nil
+}
+
+// decodeJSONObject unmarshals a JSON object with lossless numbers: UseNumber
+// keeps every numeric value as its exact decimal text rather than a float64,
+// so a large-integer identity is compared and re-marshaled digit-for-digit.
+// A float64 round would let a mismatched value pass validation and then fail
+// the jsonb containment supersede against the payload's exact number. A
+// non-object (array, scalar, null) is not an object and returns an error.
+func decodeJSONObject(raw json.RawMessage) (map[string]any, error) {
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	var m map[string]any
+	if err := dec.Decode(&m); err != nil {
+		return nil, err
+	}
+	if m == nil {
+		return nil, errors.New("not a JSON object")
+	}
+	return m, nil
 }
 
 // stageOrJoinPendingInTx serializes one proposal identity and returns its live

--- a/backend/internal/modules/approvals/staging.go
+++ b/backend/internal/modules/approvals/staging.go
@@ -135,10 +135,14 @@ func (s *Service) stageOrJoinPendingInTx(ctx context.Context, tx pgx.Tx, in Stag
 }
 
 // supersedePendingInTx withdraws every OTHER live pending proposal of the same
-// kind+target carrying the same logical identity. Withdrawal is forced expiry:
-// the row reads expired everywhere exactly like lazy TTL expiry (which also
-// emits no event) — the status CHECK and the public ApprovalStatus enum stay
-// closed — and the audit row carries the why and the survivor.
+// kind+target carrying the same logical identity. Withdrawal is forced expiry,
+// audited but deliberately event-free: the closed event catalog (contract-first,
+// P3) defines no approval-withdrawn type, and expiry is already invisible on the
+// bus — a subscriber cannot observe TTL expiry either, so folding supersession
+// into expiry changes nothing a consumer could rely on, while the pull-based
+// inbox reads the row as expired on every surface (effectiveStatus, decide,
+// redeem). The status CHECK and the public ApprovalStatus enum stay closed; the
+// audit row carries the why and the survivor.
 func (s *Service) supersedePendingInTx(ctx context.Context, tx pgx.Tx, wsID ids.UUID, in StageInput, survivor ids.ApprovalID) error {
 	p, ok := principal.Actor(ctx)
 	if !ok {

--- a/backend/internal/modules/approvals/staging.go
+++ b/backend/internal/modules/approvals/staging.go
@@ -40,6 +40,14 @@ type StageInput struct {
 	// transaction lock. It is for at-least-once worker paths whose retries
 	// must return the existing approval instead of multiplying inbox rows.
 	JoinPending bool
+	// Identity is the proposal's logical identity — a JSON object contained
+	// in ProposedChange (e.g. {"from_currency":"GBP"}). Requires JoinPending:
+	// staging then serializes per identity instead of per diff hash, and any
+	// OTHER live pending proposal of the same kind+target carrying this
+	// identity is withdrawn (forced expiry, audited) — a fresher diff for one
+	// identity supersedes a stale one instead of competing with it in the
+	// inbox, where approving stale-after-fresh would restore an outdated value.
+	Identity json.RawMessage
 	// Announce is an optional kind-specific domain event (e.g.
 	// coldstart.read_back_proposed) emitted in the SAME transaction as
 	// approval.requested, linked to the same audit row.
@@ -58,6 +66,9 @@ type AnnouncedEvent struct {
 // emits approval.requested. It runs in the write shape every mutation
 // uses: approval row + audit row + event in one transaction.
 func (s *Service) Stage(ctx context.Context, in StageInput) (ids.ApprovalID, error) {
+	if len(in.Identity) > 0 && !in.JoinPending {
+		return ids.ApprovalID{}, errors.New("crmapprovals: Identity staging requires JoinPending")
+	}
 	var id ids.ApprovalID
 	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
 		var err error
@@ -81,22 +92,70 @@ func (s *Service) stageOrJoinPendingInTx(ctx context.Context, tx pgx.Tx, in Stag
 	if !ok {
 		return ids.ApprovalID{}, errors.New("crmapprovals: no workspace bound to context")
 	}
+	// The lock serializes one proposal identity: the diff hash by default, the
+	// logical Identity when set — two workers proposing DIFFERENT diffs for one
+	// identity must not interleave between the join-check and the supersede.
+	discriminator := in.DiffHash
+	if len(in.Identity) > 0 {
+		discriminator = string(in.Identity)
+	}
 	if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock(hashtextextended(
 			'approval_pending:' || $1::text || ':' || $2 || ':' || $3::text || ':' || $4, 0))`,
-		wsID, in.Kind, in.TargetID, in.DiffHash); err != nil {
+		wsID, in.Kind, in.TargetID, discriminator); err != nil {
 		return ids.ApprovalID{}, fmt.Errorf("lock pending approval identity: %w", err)
 	}
 	err := tx.QueryRow(ctx, `SELECT id FROM approval
 			WHERE workspace_id = $1 AND kind = $2 AND target_entity_id = $3 AND diff_hash = $4
 			  AND status = 'pending' AND expires_at > now()
 			ORDER BY created_at DESC LIMIT 1`, wsID, in.Kind, in.TargetID, in.DiffHash).Scan(&id)
-	if err == nil {
-		return id, nil
-	}
-	if !errors.Is(err, pgx.ErrNoRows) {
+	switch {
+	case err == nil:
+	case errors.Is(err, pgx.ErrNoRows):
+		if id, err = s.StageInTx(ctx, tx, in); err != nil {
+			return ids.ApprovalID{}, err
+		}
+	default:
 		return ids.ApprovalID{}, fmt.Errorf("find pending approval identity: %w", err)
 	}
-	return s.StageInTx(ctx, tx, in)
+	if len(in.Identity) > 0 {
+		if err := s.supersedePendingInTx(ctx, tx, wsID, in, id); err != nil {
+			return ids.ApprovalID{}, err
+		}
+	}
+	return id, nil
+}
+
+// supersedePendingInTx withdraws every OTHER live pending proposal of the same
+// kind+target carrying the same logical identity. Withdrawal is forced expiry:
+// the row reads expired everywhere exactly like lazy TTL expiry (which also
+// emits no event) — the status CHECK and the public ApprovalStatus enum stay
+// closed — and the audit row carries the why and the survivor.
+func (s *Service) supersedePendingInTx(ctx context.Context, tx pgx.Tx, wsID ids.UUID, in StageInput, survivor ids.ApprovalID) error {
+	p, ok := principal.Actor(ctx)
+	if !ok {
+		return errors.New("crmapprovals: no actor bound to context")
+	}
+	rows, err := tx.Query(ctx, `
+		UPDATE approval SET expires_at = now() - interval '1 second'
+		WHERE workspace_id = $1 AND kind = $2 AND target_entity_id = $3
+		  AND status = 'pending' AND expires_at > now()
+		  AND id <> $4 AND proposed_change @> $5
+		RETURNING id`, wsID, in.Kind, in.TargetID, survivor, in.Identity)
+	if err != nil {
+		return fmt.Errorf("supersede pending approvals: %w", err)
+	}
+	superseded, err := pgx.CollectRows(rows, pgx.RowTo[ids.UUID])
+	if err != nil {
+		return fmt.Errorf("collect superseded approvals: %w", err)
+	}
+	for _, old := range superseded {
+		if _, err := s.audit(ctx, tx, p, "update", old, map[string]any{
+			approvalKeyKind: in.Kind, "superseded": true, "superseded_by": survivor.UUID,
+		}); err != nil {
+			return fmt.Errorf("audit superseded approval: %w", err)
+		}
+	}
+	return nil
 }
 
 // StageInTx records a proposal through a caller-owned transaction. Compose

--- a/backend/internal/modules/deals/fxrate_store.go
+++ b/backend/internal/modules/deals/fxrate_store.go
@@ -235,13 +235,14 @@ func (s *Store) ListEffectiveFxRates(ctx context.Context) ([]FxRateRow, error) {
 	if err := auth.Require(ctx, "fx_rate", principal.ActionRead); err != nil {
 		return nil, err
 	}
-	today := s.todayUTC()
 	var rows []FxRateRow
 	err := s.tx(ctx, func(tx pgx.Tx) error {
+		// Sample "today" inside the transaction: a wait for a pooled
+		// connection across UTC midnight must not list yesterday's cutoff.
 		r, err := tx.Query(ctx, `
 			SELECT DISTINCT ON (from_currency) from_currency, to_currency, rate::text, rate_date
 			FROM fx_rate WHERE rate_date <= $1
-			ORDER BY from_currency, rate_date DESC`, today)
+			ORDER BY from_currency, rate_date DESC`, s.todayUTC())
 		if err != nil {
 			return fmt.Errorf("list effective fx_rate: %w", err)
 		}

--- a/backend/internal/modules/deals/fxrate_store.go
+++ b/backend/internal/modules/deals/fxrate_store.go
@@ -5,6 +5,7 @@ package deals
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"strings"
@@ -216,6 +217,57 @@ func (s *Store) ListLatestFxRates(ctx context.Context) ([]FxRateRow, error) {
 		return err
 	})
 	return rows, err
+}
+
+// ListEffectiveFxRates returns the rate in force TODAY per foreign currency —
+// the latest row with rate_date <= today (store clock), the list form of
+// freezeFx's as-of resolution. Deliberately distinct from ListLatestFxRates
+// (sheet head, which may be future-scheduled): a refresh diff and an apply
+// precondition compare against what is in force, not what is scheduled.
+// Admin/ops read gate.
+func (s *Store) ListEffectiveFxRates(ctx context.Context) ([]FxRateRow, error) {
+	if err := auth.Require(ctx, "fx_rate", principal.ActionRead); err != nil {
+		return nil, err
+	}
+	today := s.todayUTC()
+	var rows []FxRateRow
+	err := s.tx(ctx, func(tx pgx.Tx) error {
+		r, err := tx.Query(ctx, `
+			SELECT DISTINCT ON (from_currency) from_currency, to_currency, rate::text, rate_date
+			FROM fx_rate WHERE rate_date <= $1
+			ORDER BY from_currency, rate_date DESC`, today)
+		if err != nil {
+			return fmt.Errorf("list effective fx_rate: %w", err)
+		}
+		defer r.Close()
+		rows, err = scanFxRows(r)
+		return err
+	})
+	return rows, err
+}
+
+// EffectiveFxRateInTx resolves the rate in force TODAY (store clock) for one
+// currency through a caller-owned transaction — the approval-effect
+// precondition read, which must see the same state the apply writes into.
+// found=false means no rate is in force, a materially different answer from
+// any value. Admin/ops read gate.
+func (s *Store) EffectiveFxRateInTx(ctx context.Context, tx pgx.Tx, fromCurrency string) (string, bool, error) {
+	if err := auth.Require(ctx, "fx_rate", principal.ActionRead); err != nil {
+		return "", false, err
+	}
+	from := strings.ToUpper(strings.TrimSpace(fromCurrency))
+	var rate string
+	err := tx.QueryRow(ctx, `
+		SELECT rate::text FROM fx_rate
+		WHERE from_currency = $1 AND rate_date <= $2
+		ORDER BY rate_date DESC LIMIT 1`, from, s.todayUTC()).Scan(&rate)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, fmt.Errorf("effective fx_rate for %s: %w", from, err)
+	}
+	return rate, true, nil
 }
 
 // FxRateHistory returns every effective-dated row for one pair, newest

--- a/backend/internal/modules/deals/fxrate_store.go
+++ b/backend/internal/modules/deals/fxrate_store.go
@@ -124,6 +124,12 @@ func (s *Store) prepareFxRate(ctx context.Context, in SetFxRateInput) (from stri
 // stays true at write time), resolve the workspace base, reject from == base,
 // upsert the append-forward row, and audit — all in the caller-owned tx.
 func (s *Store) writeFxRate(ctx context.Context, tx pgx.Tx, from string, in SetFxRateInput) (FxRateRow, error) {
+	// Serialize writers of this currency's sheet identity BEFORE sampling the
+	// clock: a write that waited here for a precondition-holding transaction
+	// must judge append-forward against the day it actually runs.
+	if err := storekit.LockWriteIdentity(ctx, tx, "fx_rate", from); err != nil {
+		return FxRateRow{}, err
+	}
 	today := s.todayUTC()
 	eff := in.EffectiveDate
 	if eff.IsZero() {
@@ -246,28 +252,35 @@ func (s *Store) ListEffectiveFxRates(ctx context.Context) ([]FxRateRow, error) {
 	return rows, err
 }
 
-// EffectiveFxRateInTx resolves the rate in force TODAY (store clock) for one
-// currency through a caller-owned transaction — the approval-effect
-// precondition read, which must see the same state the apply writes into.
-// found=false means no rate is in force, a materially different answer from
-// any value. Admin/ops read gate.
-func (s *Store) EffectiveFxRateInTx(ctx context.Context, tx pgx.Tx, fromCurrency string) (string, bool, error) {
+// EffectiveFxRateInTx resolves the rate in force for one currency through a
+// caller-owned transaction — the approval-effect precondition read, which
+// must see the same state the apply writes into. It takes the currency's
+// write-identity lock (so no standalone write can commit between this read
+// and the dependent write) and returns the day it sampled: the caller pins
+// its write to that SAME day, so a transaction that crosses UTC midnight
+// fails the append-forward guard instead of overwriting the new day's
+// scheduled row. found=false means no rate is in force, a materially
+// different answer from any value. Admin/ops read gate.
+func (s *Store) EffectiveFxRateInTx(ctx context.Context, tx pgx.Tx, fromCurrency string) (rate string, asOf time.Time, found bool, err error) {
 	if err := auth.Require(ctx, "fx_rate", principal.ActionRead); err != nil {
-		return "", false, err
+		return "", time.Time{}, false, err
 	}
 	from := strings.ToUpper(strings.TrimSpace(fromCurrency))
-	var rate string
-	err := tx.QueryRow(ctx, `
+	if err := storekit.LockWriteIdentity(ctx, tx, "fx_rate", from); err != nil {
+		return "", time.Time{}, false, err
+	}
+	asOf = s.todayUTC()
+	err = tx.QueryRow(ctx, `
 		SELECT rate::text FROM fx_rate
 		WHERE from_currency = $1 AND rate_date <= $2
-		ORDER BY rate_date DESC LIMIT 1`, from, s.todayUTC()).Scan(&rate)
+		ORDER BY rate_date DESC LIMIT 1`, from, asOf).Scan(&rate)
 	if errors.Is(err, pgx.ErrNoRows) {
-		return "", false, nil
+		return "", asOf, false, nil
 	}
 	if err != nil {
-		return "", false, fmt.Errorf("effective fx_rate for %s: %w", from, err)
+		return "", time.Time{}, false, fmt.Errorf("effective fx_rate for %s: %w", from, err)
 	}
-	return rate, true, nil
+	return rate, asOf, true, nil
 }
 
 // FxRateHistory returns every effective-dated row for one pair, newest

--- a/backend/internal/platform/database/storekit/storekit.go
+++ b/backend/internal/platform/database/storekit/storekit.go
@@ -265,6 +265,22 @@ func MustWorkspace(ctx context.Context) ids.UUID {
 	return wsID
 }
 
+// LockWriteIdentity serializes every writer of one logical record identity
+// for the transaction (workspace-scoped pg advisory xact lock). A
+// precondition read and its dependent write must both run under it — READ
+// COMMITTED alone leaves a window where a concurrent standalone write
+// commits between the two statements and is silently overwritten. The lock
+// is reentrant within one transaction, so a caller that locked at its
+// precondition read may write through the same store path without deadlock.
+func LockWriteIdentity(ctx context.Context, tx pgx.Tx, entityType, identity string) error {
+	if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock(hashtextextended(
+		$1 || ':' || $2::text || ':' || $3, 0))`,
+		entityType+"_write", MustWorkspace(ctx), identity); err != nil {
+		return fmt.Errorf("lock %s write identity: %w", entityType, err)
+	}
+	return nil
+}
+
 // JSONArg marshals a map for a jsonb parameter, passing NULL for nil.
 //
 //craft:ignore naked-any a jsonb bind parameter is either SQL NULL (nil) or raw bytes — pgx accepts both only as any


### PR DESCRIPTION
## Rate-proposal precondition + supersede (prevent stale-rate restore)

Fixes #225 — the three deferred P1s from the #223 review, fixed on **both** refresh paths (fx and model-cost, per the fix-the-invariant rule).

### 1. Prior-value precondition at apply (no stale overwrite)
- `fx_rate_proposal` payloads now carry `expected_prior_rate` (empty = no rate in force when diffed); `ai_model_rate_proposal` carries `expected_prior` (the four per-MTok buckets; absent = unpriced).
- The accept effects re-read the **effective-as-of-today** value inside the `RedeemAndApply` transaction (`deals.EffectiveFxRateInTx`, `ai.EffectiveModelRateInTx` — both RBAC-gated) and refuse with **`ErrVersionSkew` (409)** on mismatch. The decision stays on record, the approval stays approved-unconsumed, the sheet is untouched; the message tells the admin to re-run the refresh.
- Comparison is scale-blind (big.Rat for fx, µUSD for model prices). A pre-existing pending payload without the field reads as "expected none" and **fails closed** onto a re-diff (bounded by the 24 h staging TTL).

### 2. Supersede: one live proposal per logical identity
- `approvals.StageInput` gains `Identity` (a JSON object contained in the payload; requires `JoinPending`, must be a non-empty object). The advisory lock now serializes per identity, an identical re-stage still joins, and any **other** live pending proposal of the same kind+target carrying the identity is withdrawn by forced expiry — audited with the survivor's id, no new status/contract/migration (mirrors lazy TTL expiry, which is also event-free).
- Producers stage with `{"from_currency"}` / `{"provider","model_id"}` identities, so two refreshes fetching different values converge to exactly one live pending (the fresher), in any approval order.

### 3. Diff against the rate in force, not the sheet head
- New `ListEffectiveFxRates` / `ListEffectiveModelRates` (`rate_date/effective_date <= today`); `ListLatest*` remains only to enumerate the tracked set. A future-scheduled row no longer masks a real today-diff nor manufactures repeated ineffective proposals.

### Reviews & gates
- **Craft-reviewed**: clean; the event-free supersede is a deliberate choice (closed event catalog, pull-based inbox), the `compose:` prefix on user-facing skew messages was dropped.
- **Security-redteamed**: no exploitable findings; both hardening notes applied (read gate on the model precondition read; empty/non-object `Identity` refused — `{}` would contain-match every proposal of the kind).
- `make check-backend` green; full lane green: `OK: integration passed with 0 skips (24 packages, parallel)`. 12 new tests: supersede semantics, precondition refusal/appeared/matching (fx + model), effective-vs-sheet-head diffs, identity validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents stale or racy rate writes by enforcing prior-value checks, identity-keyed supersede, and diffing against rates effective today. Adds per-identity writer locks, string-only canonical identity validation, an injective model lock key, and pins applies to the sampled day to avoid cross‑midnight and read/write races. Fixes #225.

- **Bug Fixes**
  - Prior-value preconditions on approval: FX proposals carry `expected_prior_rate`; model proposals carry `expected_prior`. Approvals re-read today’s in-force via `deals.EffectiveFxRateInTx` and `ai.EffectiveModelRateInTx`, run under `storekit.LockWriteIdentity`, and pin the write to that sampled day; refuse with `ErrVersionSkew` on mismatch (FX compares numerically; model in µUSD). Cross‑midnight applies now fail the append‑forward guard; approvals stay approved‑unconsumed on refusal.
  - Identity-based supersede with canonical identities: `approvals.StageInput.Identity` requires `JoinPending`, must be a non-empty JSON object with string values that is a subset of `ProposedChange`, is canonicalized, and rejects null/non-object identities and trailing data. Staging serializes per identity, withdraws other live pending proposals via forced expiry backdated one day (event-free; audit row records the survivor), and still dedupes identical re-stages. The model advisory-lock key is injective to prevent lock collisions.
  - Diff against rates effective today, not the sheet head: refresh uses `ListEffectiveFxRates` and `ListEffectiveModelRates` (sample “today” inside the transaction) so future-dated rows neither mask real changes nor create ineffective proposals. Model diffs key by a `(provider, model_id)` struct to avoid string-aliasing.

<sup>Written for commit 41e2227be9e0f6467e2ce870111e55105ffe1d46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rate refreshes now diff against the rates currently effective today for both FX and model costs, ensuring future-dated rows don’t hide changes.
  * Pending rate-proposal staging is identity-aware and newer diffs automatically supersede older pending proposals for the same target.

* **Bug Fixes**
  * Applying a rate approval now re-checks the “expected prior” state and refuses with a version-skew error if the underlying rates changed (including around UTC day boundaries).
  * When rejected for version skew, the approval remains available for review and no new rate row is written.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->