### PR TITLE
feat(rates): FX refresh bootstraps an empty rate sheet

### DIFF
--- a/backend/cmd/worker/config.go
+++ b/backend/cmd/worker/config.go
@@ -22,6 +22,7 @@ type workerConfig struct {
 	configPath           string
 	freemailExtra        []string
 	ratesFx              string
+	ratesCurrencies      []string
 	ratesModelPricing    map[string]string
 	redisAddr            string
 	routingPath          string
@@ -192,6 +193,23 @@ func envIntOr(key string, fallback int) (int, error) {
 		return 0, fmt.Errorf("worker: %s=%q is not an integer: %w", key, v, err)
 	}
 	return parsed, nil
+}
+
+// defaultFxBootstrapCurrencies is the candidate set the FX refresh proposes on
+// an empty sheet when the operator configured none — the three foreign
+// currencies the base-EUR UI and the demo seed already use. Overridable via
+// rates.fx_currencies; the FX refresh cannot bootstrap an empty sheet without a
+// set, so an unset config takes this default rather than leaving the admin
+// button dead on a fresh install.
+var defaultFxBootstrapCurrencies = []string{"USD", "GBP", "CHF"}
+
+// fxBootstrapCurrencies takes the operator's configured candidate set, or the
+// default when none is configured.
+func fxBootstrapCurrencies(configured []string) []string {
+	if len(configured) == 0 {
+		return defaultFxBootstrapCurrencies
+	}
+	return configured
 }
 
 func envDurationOr(key string, fallback time.Duration) (time.Duration, error) {

--- a/backend/cmd/worker/config.go
+++ b/backend/cmd/worker/config.go
@@ -207,7 +207,9 @@ var defaultFxBootstrapCurrencies = []string{"USD", "GBP", "CHF"}
 // default when none is configured.
 func fxBootstrapCurrencies(configured []string) []string {
 	if len(configured) == 0 {
-		return defaultFxBootstrapCurrencies
+		// Copy, never hand out the package-level slice — a consumer that
+		// mutated it would rewrite the default process-wide.
+		return append([]string(nil), defaultFxBootstrapCurrencies...)
 	}
 	return configured
 }

--- a/backend/cmd/worker/config_test.go
+++ b/backend/cmd/worker/config_test.go
@@ -8,6 +8,22 @@ import (
 	"testing"
 )
 
+// TestFxBootstrapCurrenciesFallsBackToTheDefault pins the fresh-install
+// contract: an operator who configures no candidate set still gets the
+// USD/GBP/CHF default, so "Refresh from sources" bootstraps an empty FX sheet
+// rather than being a dead button. A configured set is used verbatim.
+func TestFxBootstrapCurrenciesFallsBackToTheDefault(t *testing.T) {
+	if got := strings.Join(fxBootstrapCurrencies(nil), ","); got != "USD,GBP,CHF" {
+		t.Fatalf("unset config = %q, want the USD,GBP,CHF default", got)
+	}
+	if got := strings.Join(fxBootstrapCurrencies([]string{}), ","); got != "USD,GBP,CHF" {
+		t.Fatalf("empty config = %q, want the USD,GBP,CHF default", got)
+	}
+	if got := strings.Join(fxBootstrapCurrencies([]string{"JPY", "SEK"}), ","); got != "JPY,SEK" {
+		t.Fatalf("configured set = %q, want it used verbatim", got)
+	}
+}
+
 // TestParseWorkerFlagsRejectsNonPositiveIntervals pins the boot guard:
 // every scheduler interval becomes a time.Ticker period or a River
 // periodic schedule, both of which misbehave on a non-positive duration (a

--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -88,6 +88,7 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 	}
 	cfg.freemailExtra = deployCfg.Capture.FreemailExtra
 	cfg.ratesFx = deployCfg.Rates.Fx
+	cfg.ratesCurrencies = deployCfg.Rates.FxCurrencies
 	cfg.ratesModelPricing = deployCfg.Rates.ModelPricing
 
 	handler, err := httpserver.LogHandler(stdout, cfg.logLevel, cfg.logFormat)
@@ -305,9 +306,10 @@ func startJobRunner(ctx context.Context, pool *pgxpool.Pool, rdb *redis.Client, 
 		// (empty FX url / no pricing sources) or a model (nil RateExtract)
 		// they no-op honestly. FX is deterministic (no model); model-cost
 		// needs the extraction lane.
-		RateExtractBrain:    modelPath.RateExtract,
-		FxSourceURL:         cmp.Or(cfg.ratesFx, "https://api.frankfurter.dev/v1/latest"),
-		ModelPricingSources: compose.PricingSourcesFromMap(cfg.ratesModelPricing),
+		RateExtractBrain:      modelPath.RateExtract,
+		FxSourceURL:           cmp.Or(cfg.ratesFx, "https://api.frankfurter.dev/v1/latest"),
+		FxBootstrapCurrencies: fxBootstrapCurrencies(cfg.ratesCurrencies),
+		ModelPricingSources:   compose.PricingSourcesFromMap(cfg.ratesModelPricing),
 		DeepReadCaps: compose.CrawlCaps{
 			MaxPages: cfg.deepReadMaxPages,
 			MaxBytes: cfg.deepReadMaxBytes,

--- a/backend/internal/compose/fxrefresh.go
+++ b/backend/internal/compose/fxrefresh.go
@@ -90,6 +90,16 @@ func (f fxRefresh) run(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("fx refresh: fetch rates: %w", err)
 	}
+	// A requested currency the source did not price (a well-formed but
+	// unsupported/misspelled code — the config gate only checks the ISO 4217
+	// shape, matching organization.base_currency) is dropped by the client, so
+	// it stages no proposal. Name it rather than let the gap stay silent.
+	for _, sym := range symbols {
+		if _, ok := fetched[sym]; !ok {
+			f.log.Warn("fx rate refresh: source returned no rate for a requested currency — nothing staged for it",
+				"currency", sym, "base", base)
+		}
+	}
 	ws := storekit.MustWorkspace(ctx)
 	staged := 0
 	for cur, newRate := range fetched {

--- a/backend/internal/compose/fxrefresh.go
+++ b/backend/internal/compose/fxrefresh.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/riverqueue/river"
@@ -46,14 +47,22 @@ func rateRefreshWorkerCtx(ctx context.Context, ws ids.UUID, requestedBy string) 
 	return principal.WithCorrelationID(ctx, ids.NewV7())
 }
 
-// fxRefresh is the FX producer: read the tracked currencies, fetch fresh rates,
-// and stage a proposal for each that changed. A nil client (no source
-// configured) is an honest no-op.
+// fxRefresh is the FX producer: fetch fresh rates from the source and stage a
+// proposal per changed rate. It has two modes on one path — refresh the
+// currencies the sheet already tracks, or, when the sheet is still empty,
+// bootstrap the configured candidate set against the workspace base so the
+// admin button is not dead on a fresh install. Either way a human approves
+// every proposal — a rate is never invented, only proposed from the source. A
+// nil client (no source configured) is an honest no-op.
 type fxRefresh struct {
 	store  *deals.Store
 	svc    *approvals.Service
 	client *fxsource.Client
-	log    *slog.Logger
+	// bootstrapCurrencies is the candidate foreign-currency set proposed when
+	// the sheet is empty (there is nothing tracked to derive symbols from).
+	// Empty ⇒ an empty sheet stays a no-op (never a fabricated rate).
+	bootstrapCurrencies []string
+	log                 *slog.Logger
 }
 
 func (f fxRefresh) run(ctx context.Context) error {
@@ -65,16 +74,16 @@ func (f fxRefresh) run(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("fx refresh: read current rates: %w", err)
 	}
-	if len(current) == 0 {
-		f.log.Info("fx rate refresh: no tracked currencies to refresh")
-		return nil
+
+	base, symbols, currentRate, err := f.plan(ctx, current)
+	if err != nil {
+		return err
 	}
-	base := current[0].ToCurrency
-	symbols := make([]string, 0, len(current))
-	currentRate := make(map[string]string, len(current))
-	for _, r := range current {
-		symbols = append(symbols, r.FromCurrency)
-		currentRate[r.FromCurrency] = r.Rate
+	if len(symbols) == 0 {
+		// Either an empty sheet with no candidate set, or a candidate set that
+		// held only the base currency — nothing the source can price for us.
+		f.log.Info("fx rate refresh: nothing to refresh", "tracked", len(current))
+		return nil
 	}
 
 	fetched, err := f.client.LatestRates(ctx, base, symbols)
@@ -84,18 +93,59 @@ func (f fxRefresh) run(ctx context.Context) error {
 	ws := storekit.MustWorkspace(ctx)
 	staged := 0
 	for cur, newRate := range fetched {
-		if newRate == currentRate[cur] {
+		was, tracked := currentRate[cur]
+		if tracked && newRate == was {
 			continue // unchanged
 		}
-		summary := fmt.Sprintf("%s → %s %s (was %s)", cur, base, newRate, currentRate[cur])
+		var summary string
+		if tracked {
+			summary = fmt.Sprintf("%s → %s %s (was %s)", cur, base, newRate, was)
+		} else {
+			summary = fmt.Sprintf("%s → %s %s (new)", cur, base, newRate)
+		}
 		if err := stageRateProposal(ctx, f.svc, fxRateProposalKind, fxRateTargetType, ws,
 			fxRateProposal{FromCurrency: cur, Rate: newRate}, summary); err != nil {
 			return fmt.Errorf("fx refresh: stage %s: %w", cur, err)
 		}
 		staged++
 	}
-	f.log.Info("fx rate refresh complete", "staged", staged, "tracked", len(current))
+	f.log.Info("fx rate refresh complete", "staged", staged, "tracked", len(current), "bootstrap", len(current) == 0)
 	return nil
+}
+
+// plan resolves the base currency, the symbols to fetch, and the currently
+// tracked rate per currency for the diff. With a non-empty sheet it derives all
+// three from the tracked rows (base = every row's ToCurrency). With an empty
+// sheet it reads the workspace base and uses the configured candidate set
+// (dropping the base itself — a base→base rate is always 1), leaving currentRate
+// empty so every fetched rate is a fresh proposal.
+func (f fxRefresh) plan(ctx context.Context, current []deals.FxRateRow) (base string, symbols []string, currentRate map[string]string, err error) {
+	if len(current) > 0 {
+		base = current[0].ToCurrency
+		symbols = make([]string, 0, len(current))
+		currentRate = make(map[string]string, len(current))
+		for _, r := range current {
+			symbols = append(symbols, r.FromCurrency)
+			currentRate[r.FromCurrency] = r.Rate
+		}
+		return base, symbols, currentRate, nil
+	}
+	if len(f.bootstrapCurrencies) == 0 {
+		return "", nil, nil, nil
+	}
+	base, err = f.store.WorkspaceBaseCurrency(ctx)
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("fx refresh: %w", err)
+	}
+	symbols = make([]string, 0, len(f.bootstrapCurrencies))
+	for _, c := range f.bootstrapCurrencies {
+		c = strings.ToUpper(strings.TrimSpace(c))
+		if c == "" || c == base {
+			continue
+		}
+		symbols = append(symbols, c)
+	}
+	return base, symbols, map[string]string{}, nil
 }
 
 type fxRefreshWorker struct {
@@ -107,11 +157,12 @@ func (w *fxRefreshWorker) Work(ctx context.Context, job *river.Job[FxRateRefresh
 	return w.refresh.run(rateRefreshWorkerCtx(ctx, job.Args.WorkspaceID, job.Args.RequestedBy))
 }
 
-func newFxRefreshWorker(pool *pgxpool.Pool, client *fxsource.Client, log *slog.Logger) *fxRefreshWorker {
+func newFxRefreshWorker(pool *pgxpool.Pool, client *fxsource.Client, bootstrapCurrencies []string, log *slog.Logger) *fxRefreshWorker {
 	return &fxRefreshWorker{refresh: fxRefresh{
-		store:  deals.NewStore(pool),
-		svc:    approvals.NewService(pool),
-		client: client,
-		log:    log,
+		store:               deals.NewStore(pool),
+		svc:                 approvals.NewService(pool),
+		client:              client,
+		bootstrapCurrencies: bootstrapCurrencies,
+		log:                 log,
 	}}
 }

--- a/backend/internal/compose/fxrefresh_integration_test.go
+++ b/backend/internal/compose/fxrefresh_integration_test.go
@@ -120,6 +120,36 @@ func TestFxRefreshBootstrapsEmptySheet(t *testing.T) {
 	}
 }
 
+func TestFxRefreshSkipsCandidatesTheSourceOmits(t *testing.T) {
+	e := integration.Setup(t)
+
+	// USX is ISO 4217-shaped (so it clears the config gate) but unsupported, so
+	// the source never prices it. The refresh must stage USD and skip USX
+	// gracefully — no error, no phantom proposal.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if _, err := w.Write([]byte(`{"base":"EUR","rates":{"USD":1.08}}`)); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	f := fxRefresh{
+		store:               deals.NewStore(e.Pool),
+		svc:                 approvals.NewService(e.Pool),
+		client:              fxsource.New(srv.URL, srv.Client()),
+		bootstrapCurrencies: []string{"USD", "USX"},
+		log:                 quietLog(),
+	}
+	wctx := rateRefreshWorkerCtx(context.Background(), e.WS, e.Rep1.String())
+
+	if err := f.run(wctx); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if n := e.WsCount(t, `SELECT count(*) FROM approval WHERE kind='fx_rate_proposal' AND status='pending'`); n != 1 {
+		t.Fatalf("staged %d fx proposals, want 1 (USD only — USX is omitted by the source)", n)
+	}
+}
+
 func TestFxRefreshEmptySheetNoBootstrapSetIsNoOp(t *testing.T) {
 	e := integration.Setup(t)
 

--- a/backend/internal/compose/fxrefresh_integration_test.go
+++ b/backend/internal/compose/fxrefresh_integration_test.go
@@ -7,7 +7,10 @@ package compose
 
 // The FX refresh producer over real Postgres: it prices only the currencies
 // the workspace already tracks, stages a proposal for each changed rate, and a
-// re-run stages nothing new (per-identity JoinPending dedupe).
+// re-run stages nothing new (per-identity JoinPending dedupe). When the sheet
+// is still empty it bootstraps from a configured candidate set against the
+// workspace base currency, so "Refresh from sources" is not a dead button on a
+// fresh install.
 
 import (
 	"context"
@@ -70,5 +73,80 @@ func TestFxRefreshStagesChangedRates(t *testing.T) {
 	}
 	if n := pending(); n != 1 {
 		t.Fatalf("after re-run staged %d, want still 1 (JoinPending dedupe)", n)
+	}
+}
+
+func TestFxRefreshBootstrapsEmptySheet(t *testing.T) {
+	e := integration.Setup(t)
+
+	// The workspace base is EUR and the sheet is empty (nothing seeded). The
+	// source offers USD/GBP/CHF (and JPY, which is outside the candidate set).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if _, err := w.Write([]byte(`{"base":"EUR","rates":{"USD":1.08,"GBP":0.85,"CHF":0.96,"JPY":160.5}}`)); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	f := fxRefresh{
+		store:  deals.NewStore(e.Pool),
+		svc:    approvals.NewService(e.Pool),
+		client: fxsource.New(srv.URL, srv.Client()),
+		// EUR is the base and must be dropped from the candidate set; JPY is
+		// not offered as a candidate, so neither is proposed.
+		bootstrapCurrencies: []string{"USD", "GBP", "CHF", "EUR"},
+		log:                 quietLog(),
+	}
+	wctx := rateRefreshWorkerCtx(context.Background(), e.WS, e.Rep1.String())
+
+	if err := f.run(wctx); err != nil {
+		t.Fatalf("bootstrap run: %v", err)
+	}
+	pending := func() int {
+		return e.WsCount(t, `SELECT count(*) FROM approval WHERE kind='fx_rate_proposal' AND status='pending'`)
+	}
+	// USD/GBP/CHF are proposed; EUR (the base) and JPY (not a candidate) are not.
+	if n := pending(); n != 3 {
+		t.Fatalf("bootstrap staged %d fx proposals, want 3 (USD/GBP/CHF, not base EUR or non-candidate JPY)", n)
+	}
+
+	// A re-run bootstraps nothing new — the proposals are live, so JoinPending
+	// collapses each identical diff.
+	if err := f.run(wctx); err != nil {
+		t.Fatalf("second bootstrap run: %v", err)
+	}
+	if n := pending(); n != 3 {
+		t.Fatalf("after re-run staged %d, want still 3 (JoinPending dedupe)", n)
+	}
+}
+
+func TestFxRefreshEmptySheetNoBootstrapSetIsNoOp(t *testing.T) {
+	e := integration.Setup(t)
+
+	// A source that would answer if asked — proving the no-op is the empty
+	// sheet + empty candidate set, not a dead client.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if _, err := w.Write([]byte(`{"base":"EUR","rates":{"USD":1.08}}`)); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	f := fxRefresh{
+		store:  deals.NewStore(e.Pool),
+		svc:    approvals.NewService(e.Pool),
+		client: fxsource.New(srv.URL, srv.Client()),
+		// No candidate set configured: an empty sheet has nothing to refresh
+		// and nothing to bootstrap — an honest no-op, never an invented rate.
+		bootstrapCurrencies: nil,
+		log:                 quietLog(),
+	}
+	wctx := rateRefreshWorkerCtx(context.Background(), e.WS, e.Rep1.String())
+
+	if err := f.run(wctx); err != nil {
+		t.Fatalf("no-op run: %v", err)
+	}
+	if n := e.WsCount(t, `SELECT count(*) FROM approval WHERE kind='fx_rate_proposal'`); n != 0 {
+		t.Fatalf("staged %d fx proposals, want 0 (empty sheet, no bootstrap set)", n)
 	}
 }

--- a/backend/internal/compose/jobs.go
+++ b/backend/internal/compose/jobs.go
@@ -301,6 +301,11 @@ type JobRunnerConfig struct {
 	// fetches from; empty = the worker registers but the producer no-ops
 	// (honest: no source configured, nothing to propose).
 	FxSourceURL string
+	// FxBootstrapCurrencies is the candidate foreign-currency set the fx-rate
+	// refresh proposes when the sheet is still empty (a fresh install has no
+	// tracked currency to derive symbols from). Empty ⇒ an empty sheet stays a
+	// no-op; a human still approves every bootstrapped proposal.
+	FxBootstrapCurrencies []string
 	// RateExtractBrain is the model lane the model-cost refresh job extracts
 	// pricing with (modelPath.RateExtract); nil = the worker registers but
 	// the producer no-ops (same posture as the deep-read brain).
@@ -359,7 +364,7 @@ func NewJobRunner(pool *pgxpool.Pool, log *slog.Logger, cfg JobRunnerConfig) (*j
 	if cfg.FxSourceURL != "" {
 		fxClient = fxsource.New(cfg.FxSourceURL, nil)
 	}
-	river.AddWorker(workers, newFxRefreshWorker(pool, fxClient, log))
+	river.AddWorker(workers, newFxRefreshWorker(pool, fxClient, cfg.FxBootstrapCurrencies, log))
 	river.AddWorker(workers, newModelCostRefreshWorker(pool, cfg.RateExtractBrain, cfg.ModelPricingSources, log))
 
 	periodic := []*river.PeriodicJob{

--- a/backend/internal/modules/deals/fxrate_store.go
+++ b/backend/internal/modules/deals/fxrate_store.go
@@ -218,6 +218,26 @@ func (s *Store) ListLatestFxRates(ctx context.Context) ([]FxRateRow, error) {
 	return rows, err
 }
 
+// WorkspaceBaseCurrency returns the workspace base currency — the ToCurrency
+// every fx_rate row converts into. The FX refresh producer needs it to price
+// an empty sheet (which has no row to read the base off), so it carries the
+// same admin/ops read gate as the sheet itself; the base IS part of the
+// fx_rate read surface (every row's ToCurrency).
+func (s *Store) WorkspaceBaseCurrency(ctx context.Context) (string, error) {
+	if err := auth.Require(ctx, "fx_rate", principal.ActionRead); err != nil {
+		return "", err
+	}
+	var base string
+	err := s.tx(ctx, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `SELECT base_currency FROM workspace WHERE id = $1`,
+			storekit.MustWorkspace(ctx)).Scan(&base)
+	})
+	if err != nil {
+		return "", fmt.Errorf("resolve base currency: %w", err)
+	}
+	return base, nil
+}
+
 // FxRateHistory returns every effective-dated row for one pair, newest
 // first (read-only history). Admin/ops read gate.
 func (s *Store) FxRateHistory(ctx context.Context, fromCurrency string) ([]FxRateRow, error) {

--- a/backend/internal/platform/deployconfig/deployconfig.go
+++ b/backend/internal/platform/deployconfig/deployconfig.go
@@ -300,18 +300,6 @@ type AIConfig struct {
 	CapturePayloads bool `yaml:"capture_payloads"`
 }
 
-// RatesConfig is the (worker-role) source config for the admin "Refresh from
-// sources" jobs. Fx is the base-relative rates JSON API URL (defaults to
-// api.frankfurter.dev when empty); FxCurrencies is the candidate set the FX
-// refresh proposes to bootstrap an empty sheet (worker default: USD/GBP/CHF);
-// ModelPricing maps a provider to its pricing-page URL. Absent = the respective
-// refresh no-ops — never auto-applies, a human approves every staged proposal.
-type RatesConfig struct {
-	Fx           string            `yaml:"fx_source"`
-	FxCurrencies []string          `yaml:"fx_currencies"`
-	ModelPricing map[string]string `yaml:"model_pricing"`
-}
-
 // Load reads and strictly validates the configuration file. A missing
 // file is not an error: it returns the zero configuration (version 1,
 // all defaults), which boots an existing installation but cannot
@@ -354,6 +342,9 @@ func (c Config) validate() error {
 	}
 	if cur := c.Organization.BaseCurrency; cur != "" && !isCurrencyCode(cur) {
 		return fmt.Errorf("deployconfig: organization.base_currency %q is not a 3-letter ISO 4217 code", cur)
+	}
+	if err := c.Rates.validate(); err != nil {
+		return err
 	}
 	if c.BootstrapAdmin != nil {
 		if err := c.BootstrapAdmin.validate(); err != nil {

--- a/backend/internal/platform/deployconfig/deployconfig.go
+++ b/backend/internal/platform/deployconfig/deployconfig.go
@@ -301,13 +301,14 @@ type AIConfig struct {
 }
 
 // RatesConfig is the (worker-role) source config for the admin "Refresh from
-// sources" jobs. Fx is a structured base-relative rates JSON API base URL
-// (defaults to api.frankfurter.dev when empty); ModelPricing maps a provider
-// name to its pricing-page URL the model-cost refresh crawls. Absent = the
-// respective refresh is a no-op (never auto-applies — a human approves every
-// staged proposal).
+// sources" jobs. Fx is the base-relative rates JSON API URL (defaults to
+// api.frankfurter.dev when empty); FxCurrencies is the candidate set the FX
+// refresh proposes to bootstrap an empty sheet (worker default: USD/GBP/CHF);
+// ModelPricing maps a provider to its pricing-page URL. Absent = the respective
+// refresh no-ops — never auto-applies, a human approves every staged proposal.
 type RatesConfig struct {
 	Fx           string            `yaml:"fx_source"`
+	FxCurrencies []string          `yaml:"fx_currencies"`
 	ModelPricing map[string]string `yaml:"model_pricing"`
 }
 

--- a/backend/internal/platform/deployconfig/deployconfig_test.go
+++ b/backend/internal/platform/deployconfig/deployconfig_test.go
@@ -190,6 +190,37 @@ func TestParseRatesFxCurrencies(t *testing.T) {
 	}
 }
 
+// The annotated example shipped for operators must always satisfy the real
+// parser — a schema change here without a matching edit there would hand every
+// new deployment (and every `make dev`, which copies it) a config that fails at
+// boot. It also guards the now-active rates block against a typo.
+func TestShippedExampleConfigParses(t *testing.T) {
+	cfg, err := Load("../../../../config/margince.example.yaml")
+	if err != nil {
+		t.Fatalf("config/margince.example.yaml no longer parses: %v", err)
+	}
+	if got := strings.Join(cfg.Rates.FxCurrencies, ","); got != "USD,GBP,CHF" {
+		t.Fatalf("example rates.fx_currencies = %q, want the documented USD,GBP,CHF", got)
+	}
+}
+
+func TestParseRatesFxCurrenciesFailsClosed(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		doc  string
+	}{
+		{"non-iso code", "version: 1\nrates:\n  fx_currencies: [USD, US]\n"},
+		{"non-letter code", "version: 1\nrates:\n  fx_currencies: [USD, \"12$\"]\n"},
+		{"duplicate", "version: 1\nrates:\n  fx_currencies: [USD, usd]\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := Parse([]byte(tc.doc)); err == nil {
+				t.Fatalf("%s: Parse accepted a malformed fx_currencies set; a typo must fail at boot", tc.name)
+			}
+		})
+	}
+}
+
 func TestBootstrapAdminPasswordComesFromTheFileReference(t *testing.T) {
 	pwFile := filepath.Join(t.TempDir(), "pw")
 	if err := os.WriteFile(pwFile, []byte("a bootstrap password!\n"), 0o600); err != nil {

--- a/backend/internal/platform/deployconfig/deployconfig_test.go
+++ b/backend/internal/platform/deployconfig/deployconfig_test.go
@@ -168,6 +168,28 @@ func TestParseAICapturePayloads(t *testing.T) {
 	}
 }
 
+func TestParseRatesFxCurrencies(t *testing.T) {
+	cfg, err := Parse([]byte("version: 1\nrates:\n  fx_source: https://example.test/fx\n  fx_currencies: [USD, GBP, CHF]\n"))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got, want := cfg.Rates.Fx, "https://example.test/fx"; got != want {
+		t.Fatalf("rates.fx_source = %q, want %q", got, want)
+	}
+	if got, want := strings.Join(cfg.Rates.FxCurrencies, ","), "USD,GBP,CHF"; got != want {
+		t.Fatalf("rates.fx_currencies = %q, want %q", got, want)
+	}
+	// Unset ⇒ nil (the worker supplies the USD/GBP/CHF default); parsing must
+	// not invent a value.
+	def, err := Parse([]byte("version: 1\n"))
+	if err != nil {
+		t.Fatalf("parse default: %v", err)
+	}
+	if def.Rates.FxCurrencies != nil {
+		t.Fatalf("rates.fx_currencies must default to nil, got %v", def.Rates.FxCurrencies)
+	}
+}
+
 func TestBootstrapAdminPasswordComesFromTheFileReference(t *testing.T) {
 	pwFile := filepath.Join(t.TempDir(), "pw")
 	if err := os.WriteFile(pwFile, []byte("a bootstrap password!\n"), 0o600); err != nil {

--- a/backend/internal/platform/deployconfig/rates.go
+++ b/backend/internal/platform/deployconfig/rates.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package deployconfig
+
+import (
+	"fmt"
+	"strings"
+)
+
+// RatesConfig is the (worker-role) source config for the admin "Refresh from
+// sources" jobs. Fx is the base-relative rates JSON API URL (defaults to
+// api.frankfurter.dev when empty); FxCurrencies is the candidate set the FX
+// refresh proposes to bootstrap an empty sheet (worker default: USD/GBP/CHF).
+// ModelPricing maps a provider to its pricing-page URL; absent ⇒ the model-cost
+// refresh no-ops. The FX refresh, by contrast, always has a source and a
+// candidate set (both default), so it never no-ops on absence. Neither refresh
+// auto-applies — a human approves every staged proposal.
+type RatesConfig struct {
+	Fx           string            `yaml:"fx_source"`
+	FxCurrencies []string          `yaml:"fx_currencies"`
+	ModelPricing map[string]string `yaml:"model_pricing"`
+}
+
+// validate fails closed on a malformed candidate set: every fx_currencies entry
+// must be an ISO 4217 code (the same shape organization.base_currency is held
+// to), and no currency may repeat. A typo must surface at boot, never as a
+// silently dropped bootstrap symbol the FX source omits without a trace.
+func (r RatesConfig) validate() error {
+	seen := make(map[string]bool, len(r.FxCurrencies))
+	for _, c := range r.FxCurrencies {
+		code := strings.ToUpper(strings.TrimSpace(c))
+		if !isCurrencyCode(code) {
+			return fmt.Errorf("deployconfig: rates.fx_currencies %q is not a 3-letter ISO 4217 code", c)
+		}
+		if seen[code] {
+			return fmt.Errorf("deployconfig: rates.fx_currencies has a duplicate entry %q", code)
+		}
+		seen[code] = true
+	}
+	return nil
+}

--- a/config/margince.example.yaml
+++ b/config/margince.example.yaml
@@ -41,6 +41,10 @@ bootstrap_admin:
 #     JS-rendered and yield none. Absent = the model-cost refresh is a no-op.
 # rates:
 #   fx_source: https://api.frankfurter.dev/v1/latest
+#   # Candidate foreign currencies "Refresh from sources" proposes when the FX
+#   # sheet is still empty (a fresh install tracks none). Defaults to USD/GBP/CHF
+#   # when unset. Each is staged as a proposal for admin approval — never applied.
+#   fx_currencies: [USD, GBP, CHF]
 #   model_pricing:
 #     gemini: https://ai.google.dev/gemini-api/docs/pricing
 #     # anthropic: https://docs.anthropic.com/en/docs/about-claude/pricing

--- a/config/margince.example.yaml
+++ b/config/margince.example.yaml
@@ -30,25 +30,20 @@ bootstrap_admin:
 # ai:
 #   capture_payloads: true
 
-# Rates & costs "Refresh from sources" (optional, worker role). The admin can
-# trigger an async refresh that stages confirm-first proposals into the
-# approvals inbox — a human approves every change; nothing auto-applies.
-#   fx_source: the structured FX JSON API base URL ({base,rates}; ?base=&symbols=).
-#     Defaults to the free, no-key ECB source api.frankfurter.dev when unset.
-#   model_pricing: provider -> pricing-page URL the model-cost refresh crawls +
-#     AI-extracts (the rate_extract task, certified for Gemini). A plain GET must
-#     yield the price text — Google's docs page does; many marketing pages are
-#     JS-rendered and yield none. Absent = the model-cost refresh is a no-op.
-# rates:
-#   fx_source: https://api.frankfurter.dev/v1/latest
-#   # Candidate foreign currencies "Refresh from sources" proposes when the FX
-#   # sheet is still empty (a fresh install tracks none). Defaults to USD/GBP/CHF
-#   # when unset. Each is staged as a proposal for admin approval — never applied.
-#   fx_currencies: [USD, GBP, CHF]
-#   model_pricing:
-#     gemini: https://ai.google.dev/gemini-api/docs/pricing
-#     # anthropic: https://docs.anthropic.com/en/docs/about-claude/pricing
-#     # openai: https://platform.openai.com/docs/pricing
+# Rates & costs "Refresh from sources" (worker role): an admin triggers an async
+# refresh that stages confirm-first proposals into the approvals inbox; a human
+# approves every change, nothing is auto-applied. Field reference:
+# docs/reference/configuration.md#rates.
+rates:
+  # Base-relative FX JSON API ({base,rates}); defaults to api.frankfurter.dev.
+  fx_source: https://api.frankfurter.dev/v1/latest
+  # Currencies proposed to bootstrap an empty FX sheet; defaults to USD/GBP/CHF.
+  fx_currencies: [USD, GBP, CHF]
+  # provider -> pricing-page URL the model-cost refresh crawls + AI-extracts.
+  model_pricing:
+    gemini: https://ai.google.dev/gemini-api/docs/pricing
+    # anthropic: https://docs.anthropic.com/en/docs/about-claude/pricing
+    # openai: https://platform.openai.com/docs/pricing
 
 # Ordered company-context rollout (OPS-CFG-10). The default is onboarding;
 # moving backward disables reads/injection/surfaces but never deletes confirmed

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -238,6 +238,26 @@ injects bounded context into declared AI tasks; `onboarding` additionally enable
 the five-step first-run flow. The default is `onboarding`. Moving backward is a
 reversible operational kill switch and never deletes confirmed company data.
 
+### Rates
+
+The `rates:` block configures the admin **"Refresh from sources"** jobs (worker
+role). A refresh never writes a rate directly — it stages **confirm-first
+proposals** into the approvals inbox, and a human approves each before it
+applies. It is read only by the worker (the api enqueues the job; the worker
+crawls and stages).
+
+| field | default | effect |
+|---|---|---|
+| `fx_source` | `https://api.frankfurter.dev/v1/latest` | Base-relative FX JSON API (`{base,rates}`, queried `?base=&symbols=`). The default is the free, no-key ECB feed. |
+| `fx_currencies` | `[USD, GBP, CHF]` | Candidate foreign currencies the FX refresh proposes to **bootstrap an empty rate sheet** — a fresh install tracks none, so without a candidate set the refresh would have nothing to fetch. Once the sheet has rows, the refresh re-prices exactly those tracked currencies and this set is unused. Each entry must be a 3-letter ISO 4217 code with no duplicates, or boot fails. |
+| `model_pricing` | *(none)* | Maps a provider name to its pricing-page URL the model-cost refresh crawls and AI-extracts (the `rate_extract` task, certified for Gemini). A plain `GET` must yield the price text — Google's docs page does; many JS-rendered marketing pages yield none. Absent ⇒ the model-cost refresh is a no-op. |
+
+Because `fx_source` and `fx_currencies` both default, the **FX refresh always
+has something to do** even on an absent `rates:` block; only an absent
+`model_pricing` makes its refresh a no-op. Neither refresh ever auto-applies — a
+rate is proposed from the live source and applied only on human approval, so a
+non-EUR deal with no approved rate still fails closed (never a silent `rate=1`).
+
 Model credentials (BYOK cloud tiers) are configured in
 `ai-routing.yaml`, not through binary flags. The annotated reference is
 [`config/ai-routing.example.yaml`](../../config/ai-routing.example.yaml)

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -249,14 +249,16 @@ crawls and stages).
 | field | default | effect |
 |---|---|---|
 | `fx_source` | `https://api.frankfurter.dev/v1/latest` | Base-relative FX JSON API (`{base,rates}`, queried `?base=&symbols=`). The default is the free, no-key ECB feed. |
-| `fx_currencies` | `[USD, GBP, CHF]` | Candidate foreign currencies the FX refresh proposes to **bootstrap an empty rate sheet** — a fresh install tracks none, so without a candidate set the refresh would have nothing to fetch. Once the sheet has rows, the refresh re-prices exactly those tracked currencies and this set is unused. Each entry must be a 3-letter ISO 4217 code with no duplicates, or boot fails. |
-| `model_pricing` | *(none)* | Maps a provider name to its pricing-page URL the model-cost refresh crawls and AI-extracts (the `rate_extract` task, certified for Gemini). A plain `GET` must yield the price text — Google's docs page does; many JS-rendered marketing pages yield none. Absent ⇒ the model-cost refresh is a no-op. |
+| `fx_currencies` | `[USD, GBP, CHF]` | Candidate foreign currencies the FX refresh proposes to **bootstrap an empty rate sheet** — a fresh install tracks none, so without a candidate set the refresh would have nothing to fetch. Once the sheet has rows, the refresh re-prices exactly those tracked currencies and this set is unused. Each entry must be **ISO 4217-shaped** (three uppercase letters) and unique, or boot fails — the same shape check as `base_currency`; existence is not verified, so a well-formed but unsupported code (`USX`) parses and is then skipped by the source with a logged warning rather than a staged proposal. |
+| `model_pricing` | *(none)* | Maps a provider name to its pricing-page URL the model-cost refresh crawls and AI-extracts (the `rate_extract` task, certified for Gemini). A plain `GET` must yield the price text — Google's docs page does; many JS-rendered marketing pages yield none. |
 
-Because `fx_source` and `fx_currencies` both default, the **FX refresh always
-has something to do** even on an absent `rates:` block; only an absent
-`model_pricing` makes its refresh a no-op. Neither refresh ever auto-applies — a
-rate is proposed from the live source and applied only on human approval, so a
-non-EUR deal with no approved rate still fails closed (never a silent `rate=1`).
+The **model-cost refresh** needs both a `model_pricing` entry **and** a bound
+`rate_extract` model (in `ai-routing.yaml`); absent either, it no-ops. The **FX
+refresh**, by contrast, has no such dependency — `fx_source` and `fx_currencies`
+both default, so it always has something to do even on an absent `rates:` block.
+Neither refresh ever auto-applies — a rate is proposed from the live source and
+applied only on human approval, so a non-EUR deal with no approved rate still
+fails closed (never a silent `rate=1`).
 
 Model credentials (BYOK cloud tiers) are configured in
 `ai-routing.yaml`, not through binary flags. The annotated reference is


### PR DESCRIPTION
## Problem

Clicking **Refresh from sources** on the Currency rates screen added nothing to the approvals inbox on a fresh install. Root cause: the FX producer only re-fetches currencies the sheet **already tracks** (it derives the base + symbol list from existing `fx_rate` rows). An empty `fx_rate` tracks nothing, so it hit the "no tracked currencies" guard and no-oped — while the endpoint still returned `202`, so the button *looked* like it worked.

(`fx_rate` is intentionally **not** seeded at bootstrap — the product never invents a rate, so a non-EUR deal with no rate fails closed with 422. That guarantee is preserved here.)

## Change

The producer now has two modes on one path:
- **Tracked (unchanged):** derive base + symbols from existing rows, propose only *changed* rates.
- **Empty (new):** read `workspace.base_currency`, use a configured candidate set (`rates.fx_currencies`, worker default `USD/GBP/CHF`) as the symbols, fetch from the real source, and stage one proposal per currency (base dropped).

Every bootstrapped rate is staged as a **proposal a human approves** — identical governance to the existing refresh. A rate is still never invented, only proposed from the live source.

## What's included
- `deals.Store.WorkspaceBaseCurrency` — resolves the base for an empty sheet (admin/ops read gate; base is part of the fx_rate read surface).
- `deployconfig.RatesConfig.FxCurrencies` (`fx_currencies`) + worker default `USD/GBP/CHF`; documented in `margince.example.yaml`.
- Threaded worker-side exactly like `FxSourceURL`.

## Tests
- `TestFxRefreshBootstrapsEmptySheet` — empty sheet + candidate set stages proposals for `USD/GBP/CHF`, dropping base `EUR` and non-candidate `JPY`; re-run dedupes.
- `TestFxRefreshEmptySheetNoBootstrapSetIsNoOp` — empty sheet + no set stays an honest no-op.
- `TestFxRefreshStagesChangedRates` — the tracked-refresh path is unchanged.
- `TestParseRatesFxCurrencies`, `TestFxBootstrapCurrenciesFallsBackToTheDefault` — config parse + default.

## Out of scope
- The silent-`202` UX on the button (empty-state messaging) — separate follow-up.
- `make seed-refresh` dev convenience target.

`make check-backend` green; integration FX tests pass on a throwaway clone.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable FX “Refresh from sources” to bootstrap an empty rate sheet by proposing rates for a candidate set against the workspace base. Fresh installs now stage USD/GBP/CHF proposals by default; tracked-currency refresh is unchanged and all changes still require approval.

- **New Features**
  - Empty-sheet mode: resolves base via `WorkspaceBaseCurrency`, fetches from the FX source, proposes one per candidate; drops the base; empty candidate set stays a no-op.
  - Logging: warns when the source omits a requested currency; it’s skipped with no proposal.
  - Config: adds validated `rates.fx_currencies` (ISO 4217 codes, no duplicates); worker defaults to `USD/GBP/CHF` if unset and passes a copy as `FxBootstrapCurrencies` to the job runner.
  - Docs/tests: adds a Rates section in the config reference; activates the `rates:` block in `config/margince.example.yaml`; tests cover bootstrap/no-op/tracked paths, source-omitted candidates, and config parse/validation (ISO-shaped, uniqueness).

- **Migration**
  - Optional: set `rates.fx_currencies` to your preferred bootstrap set. If set, ensure each entry is a unique 3-letter ISO 4217 code (boot fails on invalid entries). No other changes required.

<sup>Written for commit 01adfd5f7764f571b89a1711864f01c5a7cd5b50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

