### PR TITLE
feat(overlay): HubSpot webhook-as-signal — portal binding + receiver + coalesced re-fetch (branch 1b)

### DIFF
--- a/backend/cmd/api/config.go
+++ b/backend/cmd/api/config.go
@@ -33,6 +33,7 @@ type apiConfig struct {
 	graphClientID        string
 	graphClientSecret    string
 	graphTenant          string
+	hubspotAppSecret     string
 	connectorStateKey    string
 	webhookKey           string
 	webhookRetryInterval time.Duration
@@ -65,6 +66,7 @@ func parseAPIFlags(args []string) (apiConfig, error) {
 	fs.StringVar(&cfg.graphClientID, "graph-client-id", os.Getenv("MARGINCE_GRAPH_CLIENT_ID"), "Microsoft (Entra) application id for the Outlook/M365 capture connector; with the secret, state key and public-base-url, enables /connectors/graph/*")
 	fs.StringVar(&cfg.graphClientSecret, "graph-client-secret", os.Getenv("MARGINCE_GRAPH_CLIENT_SECRET"), "Microsoft client secret for the Outlook/M365 capture connector")
 	fs.StringVar(&cfg.graphTenant, "graph-tenant", os.Getenv("MARGINCE_GRAPH_TENANT"), "Microsoft identity tenant for the consent endpoint (default: common — any organization)")
+	fs.StringVar(&cfg.hubspotAppSecret, "hubspot-app-secret", os.Getenv("MARGINCE_HUBSPOT_APP_SECRET"), "HubSpot app client secret; verifies inbound overlay webhook v3 signatures and, when set, mounts /webhooks/hubspot (absent otherwise)")
 	fs.StringVar(&cfg.apiBaseURL, "api-base-url", os.Getenv("MARGINCE_API_BASE_URL"), "the api's externally-reachable base for the OAuth callback redirect_uri; defaults to --public-base-url (same-origin deployments), set only when the api is on a different origin than the SPA (e.g. dev)")
 	fs.StringVar(&cfg.connectorStateKey, "connector-state-key", os.Getenv("MARGINCE_CONNECTOR_STATE_KEY"), "HMAC key (>=32 bytes) signing the OAuth connect `state`; required for the Gmail and Graph connect flows")
 	fs.StringVar(&cfg.webhookKey, "webhook-key", os.Getenv("MARGINCE_WEBHOOK_KEY"), "base64 32-byte key sealing outbound-webhook signing secrets; enables the mutating /webhook-subscriptions surface, and (with --inline-relay) the cg:webhooks delivery consumer + retry sweep. Empty = those paths answer 503 and no inline delivery runs.")

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -37,6 +37,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/deployconfig"
 	"github.com/gradionhq/margince/backend/internal/platform/httpserver"
+	"github.com/gradionhq/margince/backend/internal/platform/jobs"
 	"github.com/gradionhq/margince/backend/internal/platform/mailer"
 	"github.com/gradionhq/margince/backend/internal/platform/overlaybudget"
 )
@@ -137,6 +138,20 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 	}()
 	overlayMeter := overlaybudget.New(overlayRDB, compose.OverlayBudgetConfig(deployCfg.EffectiveOverlayBudget()))
 	opts = append(opts, compose.WithOverlayMeter(overlayMeter))
+
+	// The HubSpot webhook-as-signal receiver (OVA-WIRE-10) mounts only when the
+	// app client secret is configured — it verifies the inbound v3 signature
+	// and enqueues coalesced re-fetches on an insert-only River client (the
+	// worker runs the overlayRefetchWorker). Absent the secret, /webhooks/hubspot
+	// is not mounted at all.
+	if cfg.hubspotAppSecret != "" {
+		webhookInserter, werr := jobs.NewInserter(pool, logger)
+		if werr != nil {
+			return werr
+		}
+		opts = append(opts, compose.WithOverlayWebhook(webhookInserter, cfg.hubspotAppSecret))
+		_, _ = fmt.Fprintln(stdout, "api overlay webhook receiver enabled (/webhooks/hubspot)")
+	}
 
 	stopRelay := func() {
 		// No inline relay to stop unless --inline-relay wires one below.

--- a/backend/internal/compose/jobs.go
+++ b/backend/internal/compose/jobs.go
@@ -463,6 +463,12 @@ func NewJobRunner(pool *pgxpool.Pool, log *slog.Logger, cfg JobRunnerConfig) (*j
 			meter = failClosedOverlayMeter()
 		}
 		river.AddWorker(workers, &overlayReconcileWorker{pool: pool, vault: cfg.OverlayVault, ms: ms, meter: meter, log: log, newIncumbent: overlayIncumbentFactory(cfg.OverlayBackfillLimit)})
+		// The webhook-as-signal re-fetch worker (OVA-WIRE-10): consumes the
+		// coalesced OverlayRefetchArgs the receiver enqueues, refreshing one
+		// record through the same store the poller uses. Registered whenever
+		// the overlay vault is present (the receiver only enqueues when the api
+		// role has the app secret wired).
+		river.AddWorker(workers, &overlayRefetchWorker{pool: pool, vault: cfg.OverlayVault, ms: ms, log: log, newIncumbent: overlayIncumbentFactory(cfg.OverlayBackfillLimit)})
 		periodic = append(periodic, river.NewPeriodicJob(
 			river.PeriodicInterval(cfg.OverlayInterval),
 			func() (river.JobArgs, *river.InsertOpts) { return OverlayReconcileArgs{}, sweepInsertOpts() },

--- a/backend/internal/compose/jobs_overlay.go
+++ b/backend/internal/compose/jobs_overlay.go
@@ -81,7 +81,7 @@ func (w *overlayRefetchWorker) Work(ctx context.Context, job *river.Job[OverlayR
 		}
 		return fmt.Errorf("overlay refetch: reading the active connection: %w", err)
 	}
-	if conn.Incumbent != "hubspot" {
+	if conn.Incumbent != incumbentHubSpot {
 		return nil
 	}
 	token, err := w.vault.Get(wsCtx, conn.Workspace, conn.CredentialRef)
@@ -259,7 +259,7 @@ func isConnectionLevelIncumbentError(err error) bool {
 // backoff (overlay_sync_state) so a dead or throttled connection is not
 // re-swept hot every tick.
 func reconcileConnection(ctx context.Context, vault keyvault.Vault, ms *overlay.MirrorStore, meter *overlaybudget.Meter, log *slog.Logger, d overlay.DueOverlayConnection, newIncumbent func(region, token string) overlay.Incumbent) error {
-	if d.Incumbent != "hubspot" {
+	if d.Incumbent != incumbentHubSpot {
 		// Branch 1 wires only HubSpot (design.md §2 D2/D3) — a connection
 		// row naming any other incumbent has no adapter here; an honest,
 		// named gap, never a guessed adapter.

--- a/backend/internal/compose/jobs_overlay.go
+++ b/backend/internal/compose/jobs_overlay.go
@@ -185,7 +185,7 @@ func (w *overlayReconcileWorker) Work(ctx context.Context, _ *river.Job[OverlayR
 	recMS := w.ms.WithFence()
 	for _, d := range due {
 		wsCtx := reconcileWorkerCtx(ctx, d.Workspace)
-		err := reconcileConnection(wsCtx, w.vault, w.ms, w.meter, w.log, d, w.newIncumbent)
+		err := reconcileConnection(wsCtx, w.pool, w.vault, w.ms, w.meter, w.log, d, w.newIncumbent)
 		// Record the sweep outcome so a connection-level failure backs the
 		// next sweep off (overlay_sync_state), instead of re-sweeping a
 		// revoked/rate-limited/unreachable connection hot every tick; one
@@ -258,7 +258,7 @@ func isConnectionLevelIncumbentError(err error) bool {
 // sweep and returns an error, which the periodic caller records as a
 // backoff (overlay_sync_state) so a dead or throttled connection is not
 // re-swept hot every tick.
-func reconcileConnection(ctx context.Context, vault keyvault.Vault, ms *overlay.MirrorStore, meter *overlaybudget.Meter, log *slog.Logger, d overlay.DueOverlayConnection, newIncumbent func(region, token string) overlay.Incumbent) error {
+func reconcileConnection(ctx context.Context, pool *pgxpool.Pool, vault keyvault.Vault, ms *overlay.MirrorStore, meter *overlaybudget.Meter, log *slog.Logger, d overlay.DueOverlayConnection, newIncumbent func(region, token string) overlay.Incumbent) error {
 	if d.Incumbent != incumbentHubSpot {
 		// Branch 1 wires only HubSpot (design.md §2 D2/D3) — a connection
 		// row naming any other incumbent has no adapter here; an honest,
@@ -274,6 +274,16 @@ func reconcileConnection(ctx context.Context, vault keyvault.Vault, ms *overlay.
 	// the whole sweep is drivable against a fake incumbent in a test,
 	// rather than reaching a real HubSpot over the network.
 	inc := newIncumbent(d.Region, string(token))
+	// Self-heal the webhook tenant binding (OVA-DDL-3): if the connect-time
+	// portal fetch failed (best-effort, left null), fill it from this sweep's
+	// live adapter so the webhook lane can bind that portal — a transient
+	// connect-time blip no longer permanently disables push refresh. Gated on
+	// the binding being unset, so a bound connection pays no per-sweep call.
+	// Best-effort: a failure here never aborts the record sweep below.
+	if err := overlay.BackfillPortalBinding(ctx, pool, inc); err != nil {
+		log.WarnContext(ctx, "overlay reconcile: backfilling the webhook portal binding failed",
+			"workspace", d.Workspace.String(), "err", err)
+	}
 	// Bind the store to THIS connection's live adapter so seeding,
 	// UpsertUserMap's email re-verification, and Ingest's owner-change
 	// revalidation all resolve against the incumbent's CURRENT owner

--- a/backend/internal/compose/jobs_overlay.go
+++ b/backend/internal/compose/jobs_overlay.go
@@ -31,6 +31,88 @@ type OverlayReconcileArgs struct{}
 // Kind is the stable job identifier River persists in river_job.
 func (OverlayReconcileArgs) Kind() string { return "overlay_reconcile" }
 
+// OverlayRefetchArgs is the webhook-as-signal targeted re-fetch (OVA-WIRE-10):
+// a validly-signed, portal-bound webhook enqueues one of these to refresh the
+// named record through the same idempotent ingest the poller uses. The args
+// ARE the coalescing key — River's unique-by-args (OVA-PARAM-10, scheduled a
+// short window ahead) collapses a record edited rapidly in the incumbent to
+// ONE re-fetch rather than N. IncumbentClass is the HubSpot object class
+// (contacts/companies/deals/leads); ExternalID is the mirror external id.
+type OverlayRefetchArgs struct {
+	Workspace      string `json:"workspace"`
+	IncumbentClass string `json:"incumbent_class"`
+	ExternalID     string `json:"external_id"`
+}
+
+// Kind is the stable job identifier River persists in river_job.
+func (OverlayRefetchArgs) Kind() string { return "overlay_refetch" }
+
+// overlayRefetchWorker executes one webhook-driven single-record re-fetch: it
+// resolves the workspace's active connection, builds a live incumbent adapter
+// over its vaulted token, reads the one record, and ingests it through the
+// fenced, resolver-bound store — the SAME idempotent, owner-revalidating path
+// the reconcile sweep uses, so a webhook refresh and a poller sweep converge
+// on one mirror state. The poller still heals any gap a signal misses.
+type overlayRefetchWorker struct {
+	river.WorkerDefaults[OverlayRefetchArgs]
+	pool         *pgxpool.Pool
+	vault        keyvault.Vault
+	ms           *overlay.MirrorStore
+	log          *slog.Logger
+	newIncumbent func(region, token string) overlay.Incumbent
+}
+
+func (w *overlayRefetchWorker) Work(ctx context.Context, job *river.Job[OverlayRefetchArgs]) error {
+	wsID, err := ids.ParseAs[ids.WorkspaceKind](job.Args.Workspace)
+	if err != nil {
+		// A malformed workspace id is a permanent defect, not a transient
+		// failure — return nil so River does not retry an unfixable job.
+		w.log.ErrorContext(ctx, "overlay refetch: unparseable workspace id in job args",
+			"workspace", job.Args.Workspace, "err", err)
+		return nil
+	}
+	wsCtx := reconcileWorkerCtx(ctx, wsID)
+	conn, err := overlay.ActiveConnection(wsCtx, w.pool)
+	if err != nil {
+		if errors.Is(err, apperrors.ErrNotFound) {
+			// The workspace disconnected since the signal arrived — nothing to
+			// refresh, and teardown owns the mirror. Not a retryable failure.
+			return nil
+		}
+		return fmt.Errorf("overlay refetch: reading the active connection: %w", err)
+	}
+	if conn.Incumbent != "hubspot" {
+		return nil
+	}
+	token, err := w.vault.Get(wsCtx, conn.Workspace, conn.CredentialRef)
+	if err != nil {
+		return fmt.Errorf("overlay refetch: resolving the vaulted token: %w", err)
+	}
+	inc := w.newIncumbent(conn.Region, string(token))
+	rec, err := inc.Get(wsCtx, job.Args.IncumbentClass, job.Args.ExternalID)
+	if err != nil {
+		// A connection-level failure (rate-limit/auth/unreachable) is retryable
+		// — return it so River backs off and retries. A record that is simply
+		// gone or unmappable is not retryable: the deletion feed / poller
+		// reconciles it, so log and drop rather than retry forever.
+		if isConnectionLevelIncumbentError(err) {
+			return fmt.Errorf("overlay refetch: reading %s/%s: %w", job.Args.IncumbentClass, job.Args.ExternalID, err)
+		}
+		w.log.WarnContext(wsCtx, "overlay refetch: record read failed (not retryable), leaving it to the poller",
+			"workspace", job.Args.Workspace, "class", job.Args.IncumbentClass, "id", job.Args.ExternalID, "err", err)
+		return nil
+	}
+	if err := w.ms.WithResolver(inc).WithFence().Ingest(wsCtx, rec); err != nil {
+		if errors.Is(err, overlay.ErrConnectionGone) {
+			// Disconnected mid-refetch — the fence aborted the write, nothing
+			// resurrected into a now-native workspace. Clean stop.
+			return nil
+		}
+		return fmt.Errorf("overlay refetch: ingesting %s/%s: %w", job.Args.IncumbentClass, job.Args.ExternalID, err)
+	}
+	return nil
+}
+
 // overlayObjectClasses are the HubSpot object classes design.md §9 maps —
 // the poller sweeps each, per due connection, resuming each object class's
 // own persisted watermark. The five engagement classes

--- a/backend/internal/compose/jobs_overlay_worker_integration_test.go
+++ b/backend/internal/compose/jobs_overlay_worker_integration_test.go
@@ -230,7 +230,7 @@ func TestReconcileConnectionBackfillsAndSeedsViaFakeIncumbent(t *testing.T) {
 	}
 
 	sweepCtx := reconcileWorkerCtx(context.Background(), ids.From[ids.WorkspaceKind](e.WS))
-	if err := reconcileConnection(sweepCtx, vault, ms, workerBudgetMeter(t),
+	if err := reconcileConnection(sweepCtx, e.Pool, vault, ms, workerBudgetMeter(t),
 		slog.New(slog.DiscardHandler), d, func(_, _ string) overlay.Incumbent { return fakeInc }); err != nil {
 		t.Fatalf("reconcileConnection: %v", err)
 	}
@@ -304,7 +304,7 @@ func TestReconcileConnectionStopsCleanlyWhenDisconnectedMidSweep(t *testing.T) {
 	}
 
 	sweepCtx := reconcileWorkerCtx(context.Background(), ids.From[ids.WorkspaceKind](e.WS))
-	err = reconcileConnection(sweepCtx, vault, ms, workerBudgetMeter(t),
+	err = reconcileConnection(sweepCtx, e.Pool, vault, ms, workerBudgetMeter(t),
 		slog.New(slog.DiscardHandler), d, func(_, _ string) overlay.Incumbent { return fakeInc })
 	if !errors.Is(err, overlay.ErrConnectionGone) {
 		t.Fatalf("reconcileConnection over a revoked connection = %v, want overlay.ErrConnectionGone (clean stop)", err)
@@ -472,7 +472,7 @@ func TestReconcileConnectionPurgesIncumbentDeletedRecord(t *testing.T) {
 	meter := workerBudgetMeter(t)
 
 	// First sweep mirrors the live record; the mapped reader can see it.
-	if err := reconcileConnection(sweepCtx, vault, ms, meter, slog.New(slog.DiscardHandler), d, newInc); err != nil {
+	if err := reconcileConnection(sweepCtx, e.Pool, vault, ms, meter, slog.New(slog.DiscardHandler), d, newInc); err != nil {
 		t.Fatalf("first sweep: %v", err)
 	}
 	if _, err := ms.Get(overlayReaderCtx(e.WS, e.Rep1), "person", "990009"); err != nil {
@@ -484,11 +484,66 @@ func TestReconcileConnectionPurgesIncumbentDeletedRecord(t *testing.T) {
 	fakeInc.SeedDeletion(overlay.IncumbentClassContacts, overlay.Deletion{
 		ExternalID: "990009", ObjectClass: "person", DeletedAt: rec.ModifiedAt.Add(time.Hour),
 	})
-	if err := reconcileConnection(sweepCtx, vault, ms, meter, slog.New(slog.DiscardHandler), d, newInc); err != nil {
+	if err := reconcileConnection(sweepCtx, e.Pool, vault, ms, meter, slog.New(slog.DiscardHandler), d, newInc); err != nil {
 		t.Fatalf("second sweep: %v", err)
 	}
 	if _, err := ms.Get(overlayReaderCtx(e.WS, e.Rep1), "person", "990009"); !errors.Is(err, apperrors.ErrNotFound) {
 		t.Fatalf("Rep1 must NOT see the record after it was deleted incumbent-side, got: %v", err)
+	}
+}
+
+// TestReconcileConnectionBackfillsTheWebhookPortalBinding proves the
+// self-healing portal binding (OVA-DDL-3): a connection whose connect-time
+// portal fetch was skipped/failed starts with a NULL incumbent_account_id (so a
+// webhook for that portal resolves to nothing), and the next reconcile sweep
+// fills it from the live adapter's account id — after which the portal binds to
+// the workspace. This is the retry path that keeps a transient connect-time
+// blip from permanently disabling webhook refresh.
+func TestReconcileConnectionBackfillsTheWebhookPortalBinding(t *testing.T) {
+	e := integration.Setup(t)
+	vault := keyvault.NewMemory()
+	ms := overlay.NewMirrorStore(e.Pool, unresolvedOwnerEmails{})
+
+	// Connect with NO incumbent factory: fetchPortalID is skipped, so the
+	// binding starts NULL — the exact state the backfill exists to heal.
+	if _, err := overlay.NewService(e.Pool, vault, ms).
+		Connect(overlayAdminCtx(e.WS, e.Rep1), overlay.ConnectInput{Incumbent: "hubspot", Region: "eu1", Token: "tok"}); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	// Initially unbound: a webhook for the portal resolves to nothing.
+	if _, err := overlay.WorkspaceForPortal(context.Background(), e.Pool, "hubspot", "portal-X"); !errors.Is(err, apperrors.ErrNotFound) {
+		t.Fatalf("before backfill: WorkspaceForPortal = %v, want ErrNotFound (binding still null)", err)
+	}
+
+	due, err := overlay.DueOverlayConnections(overlayAdminCtx(e.WS, e.Rep1), e.Pool)
+	if err != nil {
+		t.Fatalf("DueOverlayConnections: %v", err)
+	}
+	var d overlay.DueOverlayConnection
+	for _, c := range due {
+		if c.Workspace.UUID == e.WS {
+			d = c
+		}
+	}
+	if d.Incumbent == "" {
+		t.Fatal("no due overlay connection for the workspace after connect")
+	}
+
+	fakeInc := fake.New()
+	fakeInc.SeedAccountID("portal-X")
+	sweepCtx := reconcileWorkerCtx(context.Background(), ids.From[ids.WorkspaceKind](e.WS))
+	if err := reconcileConnection(sweepCtx, e.Pool, vault, ms, workerBudgetMeter(t),
+		slog.New(slog.DiscardHandler), d, func(_, _ string) overlay.Incumbent { return fakeInc }); err != nil {
+		t.Fatalf("reconcileConnection: %v", err)
+	}
+
+	// The sweep backfilled the binding: the portal now resolves to this workspace.
+	got, err := overlay.WorkspaceForPortal(context.Background(), e.Pool, "hubspot", "portal-X")
+	if err != nil {
+		t.Fatalf("after backfill: WorkspaceForPortal(portal-X): %v", err)
+	}
+	if got.UUID != e.WS {
+		t.Errorf("WorkspaceForPortal(portal-X) = %s, want the swept workspace %s", got.UUID, e.WS)
 	}
 }
 

--- a/backend/internal/compose/jobs_overlay_worker_integration_test.go
+++ b/backend/internal/compose/jobs_overlay_worker_integration_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/riverqueue/river"
 
 	"github.com/gradionhq/margince/backend/internal/compose/integration"
 	"github.com/gradionhq/margince/backend/internal/modules/overlay"
@@ -488,5 +489,97 @@ func TestReconcileConnectionPurgesIncumbentDeletedRecord(t *testing.T) {
 	}
 	if _, err := ms.Get(overlayReaderCtx(e.WS, e.Rep1), "person", "990009"); !errors.Is(err, apperrors.ErrNotFound) {
 		t.Fatalf("Rep1 must NOT see the record after it was deleted incumbent-side, got: %v", err)
+	}
+}
+
+// TestOverlayRefetchWorkerFreshensTheMirrorRecord is the webhook-signal
+// re-fetch worker's real-Postgres proof (OVA-WIRE-10): given an active HubSpot
+// overlay whose owner map the poller has already seeded, one Work call Gets a
+// single record from the incumbent and ingests it through the same fenced,
+// resolver-bound store the poller uses. So a first signal CREATES the mirror
+// row a seed-mapped user can read; a fresher signal FRESHENS it in place; and
+// an out-of-order (stale) signal is held back by the ingest staleness guard,
+// never regressing the mirror. This is the receiver's payoff — a change in
+// HubSpot reaches the mirror without waiting for the next poll.
+func TestOverlayRefetchWorkerFreshensTheMirrorRecord(t *testing.T) {
+	e := integration.Setup(t)
+	vault := keyvault.NewMemory()
+	ms := overlay.NewMirrorStore(e.Pool, unresolvedOwnerEmails{})
+
+	adminCtx := overlayAdminCtx(e.WS, e.Rep1)
+	if _, err := overlay.NewService(e.Pool, vault, ms).
+		Connect(adminCtx, overlay.ConnectInput{Incumbent: "hubspot", Region: "eu1", Token: "tok"}); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	// The poller's sweep would have seeded the owner map from the directory;
+	// seed it directly (through a directory-bound resolver, exactly as the
+	// sweep does) so this test isolates the re-fetch worker's Get→Ingest rather
+	// than re-exercising the backfill lane. owner-1's directory email is Rep1's
+	// (a@authz.test — the shared harness seeds Rep1 as a@authz.test).
+	dir := fake.New()
+	dir.SeedOwner("owner-1", "a@authz.test")
+	if err := ms.WithResolver(dir).SeedUserMap(adminCtx, incumbentHubSpot,
+		[]overlay.OwnerRef{{ExternalID: "owner-1", Email: "a@authz.test"}}); err != nil {
+		t.Fatalf("SeedUserMap: %v", err)
+	}
+
+	// version builds a fresh single-record incumbent for one signal. baseline
+	// is set explicitly (never the wall clock) so the staleness ordering under
+	// test is deterministic.
+	base := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	version := func(firstname string, modified time.Time) *fake.Adapter {
+		inc := fake.New()
+		// A live adapter resolves the record's owner email; the fake must too,
+		// or ingest's owner-set revalidation would drop the seeded mapping as
+		// unconfirmable (fail-closed) and hide the record.
+		inc.SeedOwner("owner-1", "a@authz.test")
+		rec := fake.Rec("c-1", map[string]any{"firstname": firstname})
+		rec.ObjectClass = "person" // canonical — the mapping adapter's own translation, simulated
+		rec.OwnerExternalID = "owner-1"
+		rec.ModifiedAt = modified
+		inc.Seed(overlay.IncumbentClassContacts, rec)
+		return inc
+	}
+	runRefetch := func(inc *fake.Adapter) {
+		t.Helper()
+		w := &overlayRefetchWorker{
+			pool: e.Pool, vault: vault, ms: ms,
+			log:          slog.New(slog.DiscardHandler),
+			newIncumbent: func(_, _ string) overlay.Incumbent { return inc },
+		}
+		if err := w.Work(context.Background(), &river.Job[OverlayRefetchArgs]{
+			Args: OverlayRefetchArgs{Workspace: e.WS.String(), IncumbentClass: overlay.IncumbentClassContacts, ExternalID: "c-1"},
+		}); err != nil {
+			t.Fatalf("refetch Work: %v", err)
+		}
+	}
+	firstname := func() any {
+		t.Helper()
+		row, err := ms.Get(overlayReaderCtx(e.WS, e.Rep1), "person", "c-1")
+		if err != nil {
+			t.Fatalf("Rep1 must see the re-fetched record: %v", err)
+		}
+		return row.Fields["firstname"]
+	}
+
+	// First signal: the record is not in the mirror yet — the worker creates
+	// it, and the seed-mapped Rep1 can read it.
+	runRefetch(version("Ada", base))
+	if got := firstname(); got != "Ada" {
+		t.Fatalf("firstname after first re-fetch = %v, want Ada", got)
+	}
+
+	// A fresher signal (newer baseline) freshens the same row in place.
+	runRefetch(version("Ada Lovelace", base.Add(time.Minute)))
+	if got := firstname(); got != "Ada Lovelace" {
+		t.Fatalf("firstname after freshen = %v, want Ada Lovelace", got)
+	}
+
+	// A stale re-fetch (older baseline than the mirror already holds) is held
+	// back by the ingest staleness guard — an out-of-order signal never
+	// regresses the mirror.
+	runRefetch(version("Stale", base))
+	if got := firstname(); got != "Ada Lovelace" {
+		t.Fatalf("a stale re-fetch must not regress the mirror; firstname = %v, want Ada Lovelace", got)
 	}
 }

--- a/backend/internal/compose/jobs_test.go
+++ b/backend/internal/compose/jobs_test.go
@@ -45,7 +45,7 @@ func TestReconcileConnectionRejectsANonHubSpotIncumbent(t *testing.T) {
 		Workspace: ids.WorkspaceID{UUID: ids.NewV7()},
 		Incumbent: "salesforce",
 	}
-	err := reconcileConnection(context.Background(), nil, nil, nil, nil, d, nil)
+	err := reconcileConnection(context.Background(), nil, nil, nil, nil, nil, d, nil)
 	if err == nil {
 		t.Fatal("reconcileConnection: want an error for a non-HubSpot incumbent, got nil")
 	}
@@ -73,7 +73,7 @@ func TestReconcileConnectionSurfacesAVaultResolutionFailure(t *testing.T) {
 		Incumbent: "hubspot",
 		Region:    "eu1",
 	}
-	err := reconcileConnection(context.Background(), failingVault{}, nil, nil, nil, d, nil)
+	err := reconcileConnection(context.Background(), nil, failingVault{}, nil, nil, nil, d, nil)
 	if err == nil {
 		t.Fatal("reconcileConnection: want an error when the vaulted token fails to resolve, got nil")
 	}

--- a/backend/internal/compose/overlay.go
+++ b/backend/internal/compose/overlay.go
@@ -33,6 +33,12 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
+// incumbentHubSpot is the connection.Incumbent discriminator for HubSpot —
+// the one spelling the reconcile poller, the re-fetch worker, the webhook
+// binder, and the human-read shadow all gate on, so a role never routes an
+// overlay connection to the wrong adapter by a mistyped literal.
+const incumbentHubSpot = "hubspot"
+
 // failClosedOverlayMeter is the OVB meter a surface with no Redis-backed
 // meter uses: nil client, so every band sheds and every reservation is
 // declined (a role never spends live quota it cannot account for). The

--- a/backend/internal/compose/overlay.go
+++ b/backend/internal/compose/overlay.go
@@ -190,7 +190,7 @@ func (r overlayReconciler) Reconcile(ctx context.Context) error {
 	}
 	for _, d := range due {
 		if d.Workspace.UUID == wsID {
-			err := reconcileConnection(ctx, r.vault, r.ms, r.meter, r.log, d, r.newIncumbent)
+			err := reconcileConnection(ctx, r.pool, r.vault, r.ms, r.meter, r.log, d, r.newIncumbent)
 			if errors.Is(err, overlay.ErrConnectionGone) {
 				// The connection was revoked between the due-scan above and the
 				// sweep's first fenced write (a disconnect racing this on-demand

--- a/backend/internal/compose/overlaywebhook.go
+++ b/backend/internal/compose/overlaywebhook.go
@@ -150,7 +150,7 @@ func (h *hubspotWebhookHandler) resolveWorkspace(r *http.Request, cache map[stri
 	if ws, seen := cache[portal]; seen {
 		return ws, ws != ""
 	}
-	ws, err := h.bind(r.Context(), "hubspot", portal)
+	ws, err := h.bind(r.Context(), incumbentHubSpot, portal)
 	if err != nil {
 		// ErrNotFound (unbound portal) OR a lookup error both mean "do not
 		// ingest": cache the miss so a batch of events for the same unbound

--- a/backend/internal/compose/overlaywebhook.go
+++ b/backend/internal/compose/overlaywebhook.go
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// The HubSpot webhook receiver (OVA-WIRE-10): the incumbent push lane that
+// turns a change in HubSpot into a targeted mirror re-fetch. It is
+// authenticated NOT by session but by HubSpot's v3 request signature (HMAC
+// over our app secret — proving the sender) AND the payload's portalId bound
+// to an active connection (OVA-DDL-3 — proving the tenant); the signature
+// authenticates our one app across every portal it is installed on, so the
+// portal binding is what stops cross-tenant mis-attribution. A bad signature
+// or an unbound portal is rejected fail-closed, never ingested. The route is
+// mounted only when the overlay app secret is configured (like the Gmail push
+// webhook), never an open unverified endpoint. The receiver returns 2xx fast
+// and does the re-fetch async (a coalesced River job); the body is a minimal
+// invalidation signal, not trusted content — nothing from it is written
+// directly, only a re-fetch of the named record through the idempotent ingest.
+
+package compose
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/riverqueue/river"
+
+	"github.com/gradionhq/margince/backend/internal/modules/overlay"
+	"github.com/gradionhq/margince/backend/internal/modules/overlay/hubspot"
+	"github.com/gradionhq/margince/backend/internal/platform/jobs"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// webhookMaxSkew rejects a request whose timestamp is too far from now — the
+// replay guard HubSpot's v3 scheme pairs with the signature (the timestamp is
+// part of the signed basis, so an attacker cannot backdate a captured request
+// without breaking the HMAC, but a stale-but-valid replay is still refused).
+const webhookMaxSkew = 5 * time.Minute
+
+// webhookCoalesceWindow is OVA-PARAM-10: multiple signals for the same
+// (workspace, object_class, external_id) within this window collapse to ONE
+// re-fetch. The re-fetch job is scheduled this far ahead with unique-by-args,
+// so a burst of edits to one record enqueues once (the later signals hit the
+// still-scheduled unique job) instead of N reads against the shared budget.
+const webhookCoalesceWindow = 5 * time.Second
+
+// portalBinder resolves a webhook's portalId to the workspace whose active
+// connection recorded it (OVA-DDL-3), or ErrNotFound fail-closed. A seam so
+// the handler is unit-testable without the fleet-walk's Postgres.
+type portalBinder func(ctx context.Context, incumbent, portalID string) (ids.WorkspaceID, error)
+
+// refetchEnqueuer schedules the coalesced re-fetch job. *jobs.Runner satisfies
+// it; a test substitutes a capturing fake.
+type refetchEnqueuer interface {
+	Enqueue(ctx context.Context, args river.JobArgs, opts *river.InsertOpts) error
+}
+
+type hubspotWebhookHandler struct {
+	bind         portalBinder
+	enqueue      refetchEnqueuer
+	clientSecret string
+	log          *slog.Logger
+}
+
+// WithOverlayWebhook mounts POST /webhooks/hubspot. An empty client secret (or
+// no inserter) leaves the route absent — never an open, unverified endpoint.
+func WithOverlayWebhook(inserter *jobs.Runner, clientSecret string) Option {
+	return func(s *Server, pool *pgxpool.Pool) {
+		if clientSecret == "" || inserter == nil {
+			return
+		}
+		s.overlayWebhook = &hubspotWebhookHandler{
+			bind: func(ctx context.Context, incumbent, portalID string) (ids.WorkspaceID, error) {
+				return overlay.WorkspaceForPortal(ctx, pool, incumbent, portalID)
+			},
+			enqueue:      inserter,
+			clientSecret: clientSecret,
+			log:          s.log,
+		}
+	}
+}
+
+func (h *hubspotWebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	// Replay guard: the timestamp is part of the signed basis, so reject a
+	// stale one before spending an HMAC on it. 401 (not 400) so a transient
+	// clock blip is retried by HubSpot rather than dropped.
+	ts := r.Header.Get("X-HubSpot-Request-Timestamp")
+	if !freshTimestamp(ts) {
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+	// Verify against the URL HubSpot signed: it always POSTs https to a public
+	// host (webhooks require https), so the basis is https://<host><uri>.
+	uri := "https://" + r.Host + r.URL.RequestURI()
+	if !hubspot.VerifyWebhookSignature(h.clientSecret, http.MethodPost, uri, body, ts, r.Header.Get("X-HubSpot-Signature-v3")) {
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+
+	var events []hubspot.WebhookEvent
+	if err := json.Unmarshal(body, &events); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	// Resolve each distinct portal once (the fleet-walk is not free), then
+	// enqueue a coalesced re-fetch per bound, mapped event. A portal bound to
+	// no active connection is skipped fail-closed — nothing ingested, no
+	// cross-tenant write; an unmapped subscription type is likewise dropped.
+	// A per-event enqueue failure answers 500 so HubSpot redelivers (the
+	// enqueue is unique-by-args, so a redelivery cannot double-run).
+	portalWS := map[string]string{} // portalId → workspace id ("" = unbound)
+	for _, ev := range events {
+		wsID, ok := h.resolveWorkspace(r, portalWS, ev)
+		if !ok {
+			continue
+		}
+		class, ok := hubspot.ObjectClassForSubscription(ev.SubscriptionType)
+		if !ok {
+			continue
+		}
+		if err := h.enqueueRefetch(r, wsID, class, ev.ObjectIDString()); err != nil {
+			h.log.ErrorContext(r.Context(), "overlay webhook: enqueueing re-fetch",
+				"workspace", wsID, "class", class, "id", ev.ObjectIDString(), "err", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// resolveWorkspace returns the workspace bound to the event's portal (via the
+// per-request cache), or ok=false when the portal maps to no active connection
+// (fail-closed) or the lookup errored.
+func (h *hubspotWebhookHandler) resolveWorkspace(r *http.Request, cache map[string]string, ev hubspot.WebhookEvent) (string, bool) {
+	portal := ev.PortalIDString()
+	if ws, seen := cache[portal]; seen {
+		return ws, ws != ""
+	}
+	ws, err := h.bind(r.Context(), "hubspot", portal)
+	if err != nil {
+		// ErrNotFound (unbound portal) OR a lookup error both mean "do not
+		// ingest": cache the miss so a batch of events for the same unbound
+		// portal costs one fleet-walk, and never treat an unbound portal as a
+		// tenant.
+		cache[portal] = ""
+		h.log.WarnContext(r.Context(), "overlay webhook: portal not bound to an active connection, ignoring",
+			"portal", portal, "err", err)
+		return "", false
+	}
+	cache[portal] = ws.String()
+	return ws.String(), true
+}
+
+// enqueueRefetch schedules the coalesced re-fetch job.
+func (h *hubspotWebhookHandler) enqueueRefetch(r *http.Request, workspace, class, externalID string) error {
+	return h.enqueue.Enqueue(r.Context(), OverlayRefetchArgs{
+		Workspace:      workspace,
+		IncumbentClass: class,
+		ExternalID:     externalID,
+	}, &river.InsertOpts{
+		ScheduledAt: time.Now().Add(webhookCoalesceWindow),
+		UniqueOpts:  river.UniqueOpts{ByArgs: true, ByState: activeSweepStates},
+	})
+}
+
+// freshTimestamp reports whether the millis-epoch request timestamp is within
+// webhookMaxSkew of now. A missing or unparseable timestamp is not fresh.
+func freshTimestamp(ts string) bool {
+	ms, err := strconv.ParseInt(ts, 10, 64)
+	if err != nil {
+		return false
+	}
+	delta := time.Since(time.UnixMilli(ms))
+	if delta < 0 {
+		delta = -delta
+	}
+	return delta <= webhookMaxSkew
+}

--- a/backend/internal/compose/overlaywebhook.go
+++ b/backend/internal/compose/overlaywebhook.go
@@ -20,6 +20,7 @@ package compose
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
@@ -32,8 +33,15 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/overlay"
 	"github.com/gradionhq/margince/backend/internal/modules/overlay/hubspot"
 	"github.com/gradionhq/margince/backend/internal/platform/jobs"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
+
+// webhookMaxBody caps the request body the receiver reads: HubSpot batches are
+// small, so anything past this is not a legitimate delivery. It is enforced
+// with a MaxBytesReader so an oversized body is a distinct 413 (below), never a
+// silent truncation that then mis-reports as a bad signature.
+const webhookMaxBody = 1 << 20
 
 // webhookMaxSkew rejects a request whose timestamp is too far from now — the
 // replay guard HubSpot's v3 scheme pairs with the signature (the timestamp is
@@ -89,8 +97,18 @@ func (h *hubspotWebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		w.WriteHeader(http.StatusMethodNotAllowed)
 		return
 	}
-	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+	// MaxBytesReader (not a bare LimitReader): an over-cap body surfaces as a
+	// read error we answer 413 for, rather than being silently truncated and
+	// then mis-rejected as a bad signature (which would make a valid oversized
+	// batch retry forever against the wrong reason).
+	r.Body = http.MaxBytesReader(w, r.Body, webhookMaxBody)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
+		var tooLarge *http.MaxBytesError
+		if errors.As(err, &tooLarge) {
+			w.WriteHeader(http.StatusRequestEntityTooLarge)
+			return
+		}
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
@@ -124,7 +142,17 @@ func (h *hubspotWebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	// enqueue is unique-by-args, so a redelivery cannot double-run).
 	portalWS := map[string]string{} // portalId → workspace id ("" = unbound)
 	for _, ev := range events {
-		wsID, ok := h.resolveWorkspace(r, portalWS, ev)
+		wsID, ok, err := h.resolveWorkspace(r, portalWS, ev)
+		if err != nil {
+			// A transient binding failure (DB/transaction) is NOT an unbound
+			// portal: answer 500 so HubSpot redelivers rather than dropping the
+			// signal on the floor (the coalesced enqueue is unique-by-args, so a
+			// redelivery cannot double-run the re-fetch).
+			h.log.ErrorContext(r.Context(), "overlay webhook: resolving the portal binding",
+				"portal", ev.PortalIDString(), "err", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
 		if !ok {
 			continue
 		}
@@ -143,26 +171,31 @@ func (h *hubspotWebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 }
 
 // resolveWorkspace returns the workspace bound to the event's portal (via the
-// per-request cache), or ok=false when the portal maps to no active connection
-// (fail-closed) or the lookup errored.
-func (h *hubspotWebhookHandler) resolveWorkspace(r *http.Request, cache map[string]string, ev hubspot.WebhookEvent) (string, bool) {
+// per-request cache). ok=false with a nil error is a genuinely unbound portal
+// (fail-closed — skip, ingest nothing); a non-nil error is a transient lookup
+// failure the caller turns into a 500 so the signal is redelivered rather than
+// lost. Only ErrNotFound is treated as unbound; every other error propagates.
+func (h *hubspotWebhookHandler) resolveWorkspace(r *http.Request, cache map[string]string, ev hubspot.WebhookEvent) (string, bool, error) {
 	portal := ev.PortalIDString()
 	if ws, seen := cache[portal]; seen {
-		return ws, ws != ""
+		return ws, ws != "", nil
 	}
 	ws, err := h.bind(r.Context(), incumbentHubSpot, portal)
 	if err != nil {
-		// ErrNotFound (unbound portal) OR a lookup error both mean "do not
-		// ingest": cache the miss so a batch of events for the same unbound
-		// portal costs one fleet-walk, and never treat an unbound portal as a
-		// tenant.
+		if !errors.Is(err, apperrors.ErrNotFound) {
+			// Transient failure — do NOT cache it (a redelivery must re-probe)
+			// and do NOT treat it as unbound; propagate so the caller 500s.
+			return "", false, err
+		}
+		// A genuinely unbound portal: cache the miss so a batch of events for
+		// the same portal costs one fleet-walk, and never treat it as a tenant.
 		cache[portal] = ""
 		h.log.WarnContext(r.Context(), "overlay webhook: portal not bound to an active connection, ignoring",
-			"portal", portal, "err", err)
-		return "", false
+			"portal", portal)
+		return "", false, nil
 	}
 	cache[portal] = ws.String()
-	return ws.String(), true
+	return ws.String(), true, nil
 }
 
 // enqueueRefetch schedules the coalesced re-fetch job.

--- a/backend/internal/compose/overlaywebhook_test.go
+++ b/backend/internal/compose/overlaywebhook_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
@@ -29,9 +30,13 @@ import (
 type capturingEnqueuer struct {
 	jobs []OverlayRefetchArgs
 	opts []*river.InsertOpts
+	err  error // when set, Enqueue fails with it (the redelivery path)
 }
 
 func (c *capturingEnqueuer) Enqueue(_ context.Context, args river.JobArgs, opts *river.InsertOpts) error {
+	if c.err != nil {
+		return c.err
+	}
 	c.jobs = append(c.jobs, args.(OverlayRefetchArgs))
 	c.opts = append(c.opts, opts)
 	return nil
@@ -163,5 +168,131 @@ func TestOverlayRefetchWorkerRejectsMalformedWorkspace(t *testing.T) {
 	})
 	if err != nil {
 		t.Errorf("a malformed workspace id must return nil (not retryable), got %v", err)
+	}
+}
+
+// TestWebhookReceiverRejectsNonPOST: only POST is a webhook delivery; any other
+// method is 405 before any body/signature work.
+func TestWebhookReceiverRejectsNonPOST(t *testing.T) {
+	h := newTestWebhookHandler(&capturingEnqueuer{}, ids.New[ids.WorkspaceKind]())
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/webhooks/hubspot", nil))
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", rec.Code)
+	}
+}
+
+// TestWebhookReceiverRejectsStaleOrMissingTimestamp (replay guard): a missing or
+// too-old X-HubSpot-Request-Timestamp is 401 before the signature is even
+// checked, and nothing is enqueued.
+func TestWebhookReceiverRejectsStaleOrMissingTimestamp(t *testing.T) {
+	enq := &capturingEnqueuer{}
+	h := newTestWebhookHandler(enq, ids.New[ids.WorkspaceKind]())
+
+	// No timestamp header at all.
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/webhooks/hubspot", strings.NewReader(`[]`)))
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("missing timestamp: status = %d, want 401", rec.Code)
+	}
+
+	// A timestamp older than the skew window is a refused replay.
+	stale := httptest.NewRequest(http.MethodPost, "/webhooks/hubspot", strings.NewReader(`[]`))
+	stale.Header.Set("X-HubSpot-Request-Timestamp", strconv.FormatInt(time.Now().Add(-10*time.Minute).UnixMilli(), 10))
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, stale)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("stale timestamp: status = %d, want 401", rec.Code)
+	}
+	if len(enq.jobs) != 0 {
+		t.Errorf("a rejected request must enqueue nothing, got %d", len(enq.jobs))
+	}
+}
+
+// TestWebhookReceiverAnswers500OnEnqueueFailure: a transient enqueue failure
+// answers 500 so HubSpot redelivers — safe because the enqueue is
+// unique-by-args, so a redelivery cannot double-run the re-fetch.
+func TestWebhookReceiverAnswers500OnEnqueueFailure(t *testing.T) {
+	enq := &capturingEnqueuer{err: errors.New("river unavailable")}
+	h := newTestWebhookHandler(enq, ids.New[ids.WorkspaceKind]())
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, signedWebhookRequest(t, `[{"portalId":777,"objectId":42,"subscriptionType":"contact.propertyChange"}]`))
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500 so HubSpot redelivers", rec.Code)
+	}
+}
+
+// TestWebhookReceiverBindsOncePerPortalInABatch: a batch of events for the same
+// bound portal costs ONE fleet-walk (the per-request cache) yet enqueues a
+// re-fetch for each distinct mapped event.
+func TestWebhookReceiverBindsOncePerPortalInABatch(t *testing.T) {
+	var binds int
+	ws := ids.New[ids.WorkspaceKind]()
+	enq := &capturingEnqueuer{}
+	h := &hubspotWebhookHandler{
+		clientSecret: testAppSecret,
+		enqueue:      enq,
+		log:          slog.New(slog.NewTextHandler(io.Discard, nil)),
+		bind: func(_ context.Context, _, portalID string) (ids.WorkspaceID, error) {
+			binds++
+			if portalID == boundPortal {
+				return ws, nil
+			}
+			return ids.WorkspaceID{}, apperrors.ErrNotFound
+		},
+	}
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, signedWebhookRequest(t,
+		`[{"portalId":777,"objectId":1,"subscriptionType":"contact.creation"},{"portalId":777,"objectId":2,"subscriptionType":"deal.propertyChange"}]`))
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", rec.Code)
+	}
+	if binds != 1 {
+		t.Errorf("a batch for one portal must bind once (cached), got %d binds", binds)
+	}
+	if len(enq.jobs) != 2 {
+		t.Fatalf("two mapped events must enqueue two re-fetches, got %d", len(enq.jobs))
+	}
+}
+
+// TestFreshTimestamp exercises the replay-window predicate directly: now is
+// fresh, a slightly-future timestamp is fresh (clock skew is symmetric), a
+// too-old one is stale, and a missing/unparseable one is never fresh.
+func TestFreshTimestamp(t *testing.T) {
+	now := time.Now()
+	fresh := map[string]string{
+		"now":           strconv.FormatInt(now.UnixMilli(), 10),
+		"future within": strconv.FormatInt(now.Add(time.Minute).UnixMilli(), 10),
+	}
+	for name, ts := range fresh {
+		if !freshTimestamp(ts) {
+			t.Errorf("%s (%s) must be fresh", name, ts)
+		}
+	}
+	stale := map[string]string{
+		"too old":       strconv.FormatInt(now.Add(-10*time.Minute).UnixMilli(), 10),
+		"too far ahead": strconv.FormatInt(now.Add(10*time.Minute).UnixMilli(), 10),
+		"empty":         "",
+		"non-numeric":   "not-a-timestamp",
+	}
+	for name, ts := range stale {
+		if freshTimestamp(ts) {
+			t.Errorf("%s (%q) must not be fresh", name, ts)
+		}
+	}
+}
+
+// TestWithOverlayWebhookAbsentWithoutSecretOrInserter: the route is mounted only
+// when BOTH an app secret and an inserter are present — never an open,
+// unverified endpoint.
+func TestWithOverlayWebhookAbsentWithoutSecretOrInserter(t *testing.T) {
+	s := &Server{}
+	WithOverlayWebhook(nil, "")(s, nil)
+	if s.overlayWebhook != nil {
+		t.Error("no app secret must leave the webhook route unmounted")
+	}
+	WithOverlayWebhook(nil, "a-secret")(s, nil)
+	if s.overlayWebhook != nil {
+		t.Error("a nil inserter must leave the webhook route unmounted")
 	}
 }

--- a/backend/internal/compose/overlaywebhook_test.go
+++ b/backend/internal/compose/overlaywebhook_test.go
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/riverqueue/river"
+
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// capturingEnqueuer records the re-fetch jobs the handler enqueues, standing in
+// for the real River inserter so the handler's verify→bind→enqueue decision is
+// unit-testable without River or Postgres.
+type capturingEnqueuer struct {
+	jobs []OverlayRefetchArgs
+	opts []*river.InsertOpts
+}
+
+func (c *capturingEnqueuer) Enqueue(_ context.Context, args river.JobArgs, opts *river.InsertOpts) error {
+	c.jobs = append(c.jobs, args.(OverlayRefetchArgs)) //nolint:forcetypeassert // the handler only ever enqueues OverlayRefetchArgs
+	c.opts = append(c.opts, opts)
+	return nil
+}
+
+const testAppSecret = "test-app-secret"
+
+// signedWebhookRequest builds a POST with a valid HubSpot v3 signature over the
+// body — the same basis the handler reconstructs (https://<host><uri>).
+func signedWebhookRequest(t *testing.T, body string) *http.Request {
+	t.Helper()
+	r := httptest.NewRequest(http.MethodPost, "/webhooks/hubspot", strings.NewReader(body))
+	ts := strconv.FormatInt(time.Now().UnixMilli(), 10)
+	uri := "https://" + r.Host + r.URL.RequestURI()
+	mac := hmac.New(sha256.New, []byte(testAppSecret))
+	mac.Write([]byte(http.MethodPost))
+	mac.Write([]byte(uri))
+	mac.Write([]byte(body))
+	mac.Write([]byte(ts))
+	r.Header.Set("X-HubSpot-Request-Timestamp", ts)
+	r.Header.Set("X-HubSpot-Signature-v3", base64.StdEncoding.EncodeToString(mac.Sum(nil)))
+	return r
+}
+
+func newTestWebhookHandler(enq *capturingEnqueuer, boundPortal string, boundWS ids.WorkspaceID) *hubspotWebhookHandler {
+	return &hubspotWebhookHandler{
+		clientSecret: testAppSecret,
+		enqueue:      enq,
+		log:          slog.New(slog.NewTextHandler(io.Discard, nil)),
+		bind: func(_ context.Context, _, portalID string) (ids.WorkspaceID, error) {
+			if portalID == boundPortal {
+				return boundWS, nil
+			}
+			return ids.WorkspaceID{}, apperrors.ErrNotFound
+		},
+	}
+}
+
+// TestWebhookReceiverBoundSignalEnqueuesCoalescedRefetch (AC-OV-13 a/d): a
+// validly-signed, portal-bound signal enqueues ONE re-fetch of the named
+// record with coalescing opts (unique-by-args, scheduled a window ahead).
+func TestWebhookReceiverBoundSignalEnqueuesCoalescedRefetch(t *testing.T) {
+	enq := &capturingEnqueuer{}
+	ws := ids.New[ids.WorkspaceKind]()
+	h := newTestWebhookHandler(enq, "777", ws)
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, signedWebhookRequest(t, `[{"portalId":777,"objectId":42,"subscriptionType":"contact.propertyChange"}]`))
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", rec.Code)
+	}
+	if len(enq.jobs) != 1 {
+		t.Fatalf("enqueued %d jobs, want 1", len(enq.jobs))
+	}
+	if enq.jobs[0] != (OverlayRefetchArgs{Workspace: ws.String(), IncumbentClass: "contacts", ExternalID: "42"}) {
+		t.Errorf("enqueued %+v, want contacts/42 for the bound workspace", enq.jobs[0])
+	}
+	// Coalescing (OVA-PARAM-10): unique-by-args + scheduled a window ahead so a
+	// burst of edits to the same record collapses to one re-fetch.
+	if !enq.opts[0].UniqueOpts.ByArgs || enq.opts[0].ScheduledAt.Before(time.Now()) {
+		t.Errorf("enqueue opts = %+v, want ByArgs unique + a future ScheduledAt", enq.opts[0])
+	}
+}
+
+// TestWebhookReceiverRejectsUnboundPortal (AC-OV-13 b): a signal whose portal
+// maps to no active connection ingests nothing (fail-closed, no cross-tenant).
+func TestWebhookReceiverRejectsUnboundPortal(t *testing.T) {
+	enq := &capturingEnqueuer{}
+	h := newTestWebhookHandler(enq, "777", ids.New[ids.WorkspaceKind]())
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, signedWebhookRequest(t, `[{"portalId":999,"objectId":42,"subscriptionType":"contact.propertyChange"}]`))
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204 (accepted-but-ignored)", rec.Code)
+	}
+	if len(enq.jobs) != 0 {
+		t.Errorf("an unbound portal must enqueue nothing, got %d jobs", len(enq.jobs))
+	}
+}
+
+// TestWebhookReceiverRejectsBadSignature (AC-OV-13 c): a bad v3 signature is
+// rejected, nothing ingested.
+func TestWebhookReceiverRejectsBadSignature(t *testing.T) {
+	enq := &capturingEnqueuer{}
+	h := newTestWebhookHandler(enq, "777", ids.New[ids.WorkspaceKind]())
+
+	r := signedWebhookRequest(t, `[{"portalId":777,"objectId":42,"subscriptionType":"contact.propertyChange"}]`)
+	r.Header.Set("X-HubSpot-Signature-v3", "deadbeef") // tamper
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, r)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+	if len(enq.jobs) != 0 {
+		t.Errorf("a bad signature must enqueue nothing, got %d jobs", len(enq.jobs))
+	}
+}
+
+// TestWebhookReceiverDropsUnmappedSubscription: a subscription type the mirror
+// does not model is dropped (no guessed class), still 204.
+func TestWebhookReceiverDropsUnmappedSubscription(t *testing.T) {
+	enq := &capturingEnqueuer{}
+	h := newTestWebhookHandler(enq, "777", ids.New[ids.WorkspaceKind]())
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, signedWebhookRequest(t, `[{"portalId":777,"objectId":42,"subscriptionType":"ticket.creation"}]`))
+
+	if rec.Code != http.StatusNoContent || len(enq.jobs) != 0 {
+		t.Errorf("an unmapped subscription must be dropped (204, no enqueue), got %d / %d jobs", rec.Code, len(enq.jobs))
+	}
+}
+
+// TestOverlayRefetchWorkerRejectsMalformedWorkspace: a job carrying an
+// unparseable workspace id is a permanent defect — the worker returns nil (no
+// retry) rather than looping on an unfixable arg. This exercises the guard
+// before any DB access.
+func TestOverlayRefetchWorkerRejectsMalformedWorkspace(t *testing.T) {
+	w := &overlayRefetchWorker{log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	err := w.Work(context.Background(), &river.Job[OverlayRefetchArgs]{
+		Args: OverlayRefetchArgs{Workspace: "not-a-uuid", IncumbentClass: "contacts", ExternalID: "1"},
+	})
+	if err != nil {
+		t.Errorf("a malformed workspace id must return nil (not retryable), got %v", err)
+	}
+}

--- a/backend/internal/compose/overlaywebhook_test.go
+++ b/backend/internal/compose/overlaywebhook_test.go
@@ -32,12 +32,17 @@ type capturingEnqueuer struct {
 }
 
 func (c *capturingEnqueuer) Enqueue(_ context.Context, args river.JobArgs, opts *river.InsertOpts) error {
-	c.jobs = append(c.jobs, args.(OverlayRefetchArgs)) //nolint:forcetypeassert // the handler only ever enqueues OverlayRefetchArgs
+	c.jobs = append(c.jobs, args.(OverlayRefetchArgs))
 	c.opts = append(c.opts, opts)
 	return nil
 }
 
 const testAppSecret = "test-app-secret"
+
+// boundPortal is the portalId every test payload carries ("portalId":777) and
+// the one newTestWebhookHandler's bind resolves to a workspace — a foreign
+// portal returns ErrNotFound (fail-closed).
+const boundPortal = "777"
 
 // signedWebhookRequest builds a POST with a valid HubSpot v3 signature over the
 // body — the same basis the handler reconstructs (https://<host><uri>).
@@ -56,7 +61,7 @@ func signedWebhookRequest(t *testing.T, body string) *http.Request {
 	return r
 }
 
-func newTestWebhookHandler(enq *capturingEnqueuer, boundPortal string, boundWS ids.WorkspaceID) *hubspotWebhookHandler {
+func newTestWebhookHandler(enq *capturingEnqueuer, boundWS ids.WorkspaceID) *hubspotWebhookHandler {
 	return &hubspotWebhookHandler{
 		clientSecret: testAppSecret,
 		enqueue:      enq,
@@ -76,7 +81,7 @@ func newTestWebhookHandler(enq *capturingEnqueuer, boundPortal string, boundWS i
 func TestWebhookReceiverBoundSignalEnqueuesCoalescedRefetch(t *testing.T) {
 	enq := &capturingEnqueuer{}
 	ws := ids.New[ids.WorkspaceKind]()
-	h := newTestWebhookHandler(enq, "777", ws)
+	h := newTestWebhookHandler(enq, ws)
 
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, signedWebhookRequest(t, `[{"portalId":777,"objectId":42,"subscriptionType":"contact.propertyChange"}]`))
@@ -101,7 +106,7 @@ func TestWebhookReceiverBoundSignalEnqueuesCoalescedRefetch(t *testing.T) {
 // maps to no active connection ingests nothing (fail-closed, no cross-tenant).
 func TestWebhookReceiverRejectsUnboundPortal(t *testing.T) {
 	enq := &capturingEnqueuer{}
-	h := newTestWebhookHandler(enq, "777", ids.New[ids.WorkspaceKind]())
+	h := newTestWebhookHandler(enq, ids.New[ids.WorkspaceKind]())
 
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, signedWebhookRequest(t, `[{"portalId":999,"objectId":42,"subscriptionType":"contact.propertyChange"}]`))
@@ -118,7 +123,7 @@ func TestWebhookReceiverRejectsUnboundPortal(t *testing.T) {
 // rejected, nothing ingested.
 func TestWebhookReceiverRejectsBadSignature(t *testing.T) {
 	enq := &capturingEnqueuer{}
-	h := newTestWebhookHandler(enq, "777", ids.New[ids.WorkspaceKind]())
+	h := newTestWebhookHandler(enq, ids.New[ids.WorkspaceKind]())
 
 	r := signedWebhookRequest(t, `[{"portalId":777,"objectId":42,"subscriptionType":"contact.propertyChange"}]`)
 	r.Header.Set("X-HubSpot-Signature-v3", "deadbeef") // tamper
@@ -137,7 +142,7 @@ func TestWebhookReceiverRejectsBadSignature(t *testing.T) {
 // does not model is dropped (no guessed class), still 204.
 func TestWebhookReceiverDropsUnmappedSubscription(t *testing.T) {
 	enq := &capturingEnqueuer{}
-	h := newTestWebhookHandler(enq, "777", ids.New[ids.WorkspaceKind]())
+	h := newTestWebhookHandler(enq, ids.New[ids.WorkspaceKind]())
 
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, signedWebhookRequest(t, `[{"portalId":777,"objectId":42,"subscriptionType":"ticket.creation"}]`))

--- a/backend/internal/compose/overlaywebhook_test.go
+++ b/backend/internal/compose/overlaywebhook_test.go
@@ -50,11 +50,21 @@ const testAppSecret = "test-app-secret"
 const boundPortal = "777"
 
 // signedWebhookRequest builds a POST with a valid HubSpot v3 signature over the
-// body — the same basis the handler reconstructs (https://<host><uri>).
+// body at the current time.
 func signedWebhookRequest(t *testing.T, body string) *http.Request {
 	t.Helper()
+	return signedWebhookRequestAt(t, body, time.Now())
+}
+
+// signedWebhookRequestAt is signedWebhookRequest with an explicit signing
+// timestamp, so a test can present a validly-signed request at a chosen time —
+// e.g. a correctly-signed but stale one, isolating the replay guard from the
+// signature check. The signature covers the same basis the handler
+// reconstructs (https://<host><uri> + body + timestamp).
+func signedWebhookRequestAt(t *testing.T, body string, at time.Time) *http.Request {
+	t.Helper()
 	r := httptest.NewRequest(http.MethodPost, "/webhooks/hubspot", strings.NewReader(body))
-	ts := strconv.FormatInt(time.Now().UnixMilli(), 10)
+	ts := strconv.FormatInt(at.UnixMilli(), 10)
 	uri := "https://" + r.Host + r.URL.RequestURI()
 	mac := hmac.New(sha256.New, []byte(testAppSecret))
 	mac.Write([]byte(http.MethodPost))
@@ -196,9 +206,11 @@ func TestWebhookReceiverRejectsStaleOrMissingTimestamp(t *testing.T) {
 		t.Fatalf("missing timestamp: status = %d, want 401", rec.Code)
 	}
 
-	// A timestamp older than the skew window is a refused replay.
-	stale := httptest.NewRequest(http.MethodPost, "/webhooks/hubspot", strings.NewReader(`[]`))
-	stale.Header.Set("X-HubSpot-Request-Timestamp", strconv.FormatInt(time.Now().Add(-10*time.Minute).UnixMilli(), 10))
+	// A correctly-signed but too-old request is a refused replay. Signing it
+	// with the stale timestamp isolates the replay guard from the signature
+	// check — the 401 can only come from the timestamp being stale, so this
+	// regresses the guard's wiring, not merely the shared 401.
+	stale := signedWebhookRequestAt(t, `[]`, time.Now().Add(-10*time.Minute))
 	rec = httptest.NewRecorder()
 	h.ServeHTTP(rec, stale)
 	if rec.Code != http.StatusUnauthorized {
@@ -252,6 +264,18 @@ func TestWebhookReceiverBindsOncePerPortalInABatch(t *testing.T) {
 	}
 	if len(enq.jobs) != 2 {
 		t.Fatalf("two mapped events must enqueue two re-fetches, got %d", len(enq.jobs))
+	}
+	// Each event re-fetches its OWN record under its own class — a regression
+	// that enqueued the same args twice, or mapped the deal event to the wrong
+	// class, must fail here (not merely miscount).
+	want := []OverlayRefetchArgs{
+		{Workspace: ws.String(), IncumbentClass: "contacts", ExternalID: "1"},
+		{Workspace: ws.String(), IncumbentClass: "deals", ExternalID: "2"},
+	}
+	for i, w := range want {
+		if enq.jobs[i] != w {
+			t.Errorf("job[%d] = %+v, want %+v", i, enq.jobs[i], w)
+		}
 	}
 }
 

--- a/backend/internal/compose/routes.go
+++ b/backend/internal/compose/routes.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The HTTP mux assembly: contractAPI builds the generated /v1 surface with
+// its admission/idempotency/overlay-guard middleware stack, and
+// operationalMux mounts that surface next to the operational edges (health
+// probes, metrics, the anonymous public paths, the A2 authorization server,
+// and the provider push webhooks). server.go owns the Server inventory and
+// its wiring options; this file owns how those handlers become one mux.
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/modules/activities"
+	"github.com/gradionhq/margince/backend/internal/modules/approvals"
+	"github.com/gradionhq/margince/backend/internal/modules/consent"
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/platform/events"
+	"github.com/gradionhq/margince/backend/internal/platform/httpserver"
+)
+
+// contractAPI builds the generated contract router with the ADR-0055
+// admission layer, idempotency, and the overlay-mode write guard wrapped
+// around it (outermost last — see the wrap-order note inline).
+func contractAPI(srv Server, pool *pgxpool.Pool, identitySvc *identity.Service) http.Handler {
+	gate := auth.NewGate(identitySvc)
+	registry := registryWithGate(pool, gate, srv.replyDrafter, srv.resolveOverlayIncumbent(pool))
+	// The ADR-0055 admission layer and the MCP tool surface share one
+	// provider seam: agentGate's StageResolver dispatches per workspace
+	// exactly like the MCP registry's tools do — and the overlay-mode
+	// human read shadows (overlayread.go) ride this same instance.
+	provider := srv.sorDispatch
+	staging := approvalsAdapter{svc: approvals.NewService(pool)}
+	// Wrap order: the generated router applies the slice left-to-right
+	// around the handler, so the LAST entry is outermost — idempotency
+	// must sit outside the agent gate so a staged-approval refusal is
+	// never recorded as "the" response for a key (the approved retry is
+	// the same request under the same key).
+	api := crmcontracts.HandlerWithOptions(srv, crmcontracts.ChiServerOptions{
+		BaseURL: "/v1",
+		Middlewares: []crmcontracts.MiddlewareFunc{
+			agentGate(registry, staging, provider, fieldOwnership{pool: pool}, gate),
+			idempotency(pool),
+			// Outermost: an overlay-mode SoR write is refused before it can
+			// be recorded under an idempotency key or staged as an agent
+			// approval — the honest unsupported_by_sor, for every principal.
+			overlayWriteGuard(srv.sorDispatch),
+		},
+		// Keep query/path/header parse failures on the problem+json path:
+		// the generated default writes err.Error() as text/plain, an
+		// off-contract shape that also leaks the parser's internal text.
+		ErrorHandlerFunc: paramParseError,
+	})
+	return api
+}
+
+// operationalMux mounts the contract surface next to the operational
+// edges: health probes, metrics, the anonymous public paths, and the A2
+// authorization server.
+func operationalMux(srv Server, pool *pgxpool.Pool, log *slog.Logger, authH authHandlers, api http.Handler) *http.ServeMux {
+	// Only /v1 rides the session middleware; the health probes and the
+	// other operational edges are unauthenticated by design.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", httpserver.Healthz)
+	mux.HandleFunc("/readyz", httpserver.Readyz(srv.aiStateOrDefault(), srv.readyzEmbedState(), srv.readinessChecks(pool.Ping)...))
+	mux.HandleFunc("/metrics", httpserver.Metrics(pool,
+		func(ctx context.Context) (int64, error) { return events.OutboxBacklog(ctx, pool) },
+		events.PublishedTotal,
+		srv.writeAIMetrics,
+		overlayMetricsSection(srv, pool)))
+	// The anonymous public edges sit between the session middleware (which
+	// lets /v1/public/ through without session or workspace) and the
+	// router: each resolves its own token/slug → tenant, throttles, and
+	// binds a confined system principal. The preference edge wraps the
+	// booking edge — each passes a non-matching path straight through.
+	publicEdge := publicPreferences(consent.NewStore(pool), newPublicPreferenceLimiters())(
+		publicBooking(activities.NewStore(pool), newPublicBookingLimiters())(api),
+	)
+	mux.Handle("/v1/", httpserver.Correlate(httpserver.AccessLog(log, authH.Middleware(publicEdge))))
+	// The A2 authorization server (ADR-0013): AS endpoints live outside
+	// the generated resource surface but behind the same workspace and
+	// session middleware; the discovery documents are static.
+	mux.Handle("/oauth/", httpserver.Correlate(httpserver.AccessLog(log, authH.Middleware(authH.OAuthRouter()))))
+	mux.HandleFunc("/.well-known/oauth-authorization-server", identity.OAuthServerMetadata)
+	mux.HandleFunc("/.well-known/oauth-protected-resource", identity.ProtectedResourceMetadata)
+	// Provider push webhooks: unauthenticated by nature (the provider is the
+	// caller), each verified by its own mechanism inside the handler; mounted
+	// only when configured — the route is absent otherwise.
+	if srv.gmailPush != nil {
+		mux.Handle("/webhooks/gmail-push", httpserver.Correlate(httpserver.AccessLog(log, srv.gmailPush)))
+	}
+	if srv.overlayWebhook != nil {
+		mux.Handle("/webhooks/hubspot", httpserver.Correlate(httpserver.AccessLog(log, srv.overlayWebhook)))
+	}
+	return mux
+}

--- a/backend/internal/compose/routes.go
+++ b/backend/internal/compose/routes.go
@@ -66,8 +66,10 @@ func contractAPI(srv Server, pool *pgxpool.Pool, identitySvc *identity.Service) 
 // edges: health probes, metrics, the anonymous public paths, and the A2
 // authorization server.
 func operationalMux(srv Server, pool *pgxpool.Pool, log *slog.Logger, authH authHandlers, api http.Handler) *http.ServeMux {
-	// Only /v1 rides the session middleware; the health probes and the
-	// other operational edges are unauthenticated by design.
+	// The session middleware (authH.Middleware) fronts BOTH /v1 and the /oauth/
+	// authorization server (/oauth/authorize requires a live session); the
+	// health probes, metrics, discovery documents, and the provider push
+	// webhooks are unauthenticated by design (each webhook verifies itself).
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", httpserver.Healthz)
 	mux.HandleFunc("/readyz", httpserver.Readyz(srv.aiStateOrDefault(), srv.readyzEmbedState(), srv.readinessChecks(pool.Ping)...))

--- a/backend/internal/compose/server.go
+++ b/backend/internal/compose/server.go
@@ -24,7 +24,6 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/activities"
 	"github.com/gradionhq/margince/backend/internal/modules/agents"
 	"github.com/gradionhq/margince/backend/internal/modules/ai"
-	"github.com/gradionhq/margince/backend/internal/modules/approvals"
 	"github.com/gradionhq/margince/backend/internal/modules/automation"
 	"github.com/gradionhq/margince/backend/internal/modules/capture"
 	"github.com/gradionhq/margince/backend/internal/modules/collections"
@@ -38,9 +37,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/quotas"
 	"github.com/gradionhq/margince/backend/internal/modules/search"
 	"github.com/gradionhq/margince/backend/internal/modules/signals"
-	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/blobstore"
-	"github.com/gradionhq/margince/backend/internal/platform/events"
 	"github.com/gradionhq/margince/backend/internal/platform/httperr"
 	"github.com/gradionhq/margince/backend/internal/platform/httpserver"
 	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
@@ -367,7 +364,7 @@ func OverlayIncumbentResolver(pool *pgxpool.Pool, vault keyvault.Vault) func(con
 			}
 			return nil, err
 		}
-		if conn.Incumbent != "hubspot" {
+		if conn.Incumbent != incumbentHubSpot {
 			return nil, nil
 		}
 		token, err := vault.Get(ctx, conn.Workspace, conn.CredentialRef)
@@ -382,79 +379,6 @@ func OverlayIncumbentResolver(pool *pgxpool.Pool, vault keyvault.Vault) func(con
 // admission layer, which rides INSIDE the router (it needs the matched
 // route pattern) and shares the MCP surface's tier table, approvals
 // staging, and live-authority gate — one gate, two transports.
-func contractAPI(srv Server, pool *pgxpool.Pool, identitySvc *identity.Service) http.Handler {
-	gate := auth.NewGate(identitySvc)
-	registry := registryWithGate(pool, gate, srv.replyDrafter, srv.resolveOverlayIncumbent(pool))
-	// The ADR-0055 admission layer and the MCP tool surface share one
-	// provider seam: agentGate's StageResolver dispatches per workspace
-	// exactly like the MCP registry's tools do — and the overlay-mode
-	// human read shadows (overlayread.go) ride this same instance.
-	provider := srv.sorDispatch
-	staging := approvalsAdapter{svc: approvals.NewService(pool)}
-	// Wrap order: the generated router applies the slice left-to-right
-	// around the handler, so the LAST entry is outermost — idempotency
-	// must sit outside the agent gate so a staged-approval refusal is
-	// never recorded as "the" response for a key (the approved retry is
-	// the same request under the same key).
-	api := crmcontracts.HandlerWithOptions(srv, crmcontracts.ChiServerOptions{
-		BaseURL: "/v1",
-		Middlewares: []crmcontracts.MiddlewareFunc{
-			agentGate(registry, staging, provider, fieldOwnership{pool: pool}, gate),
-			idempotency(pool),
-			// Outermost: an overlay-mode SoR write is refused before it can
-			// be recorded under an idempotency key or staged as an agent
-			// approval — the honest unsupported_by_sor, for every principal.
-			overlayWriteGuard(srv.sorDispatch),
-		},
-		// Keep query/path/header parse failures on the problem+json path:
-		// the generated default writes err.Error() as text/plain, an
-		// off-contract shape that also leaks the parser's internal text.
-		ErrorHandlerFunc: paramParseError,
-	})
-	return api
-}
-
-// operationalMux mounts the contract surface next to the operational
-// edges: health probes, metrics, the anonymous public paths, and the A2
-// authorization server.
-func operationalMux(srv Server, pool *pgxpool.Pool, log *slog.Logger, authH authHandlers, api http.Handler) *http.ServeMux {
-	// Only /v1 rides the session middleware; the health probes and the
-	// other operational edges are unauthenticated by design.
-	mux := http.NewServeMux()
-	mux.HandleFunc("/healthz", httpserver.Healthz)
-	mux.HandleFunc("/readyz", httpserver.Readyz(srv.aiStateOrDefault(), srv.readyzEmbedState(), srv.readinessChecks(pool.Ping)...))
-	mux.HandleFunc("/metrics", httpserver.Metrics(pool,
-		func(ctx context.Context) (int64, error) { return events.OutboxBacklog(ctx, pool) },
-		events.PublishedTotal,
-		srv.writeAIMetrics,
-		overlayMetricsSection(srv, pool)))
-	// The anonymous public edges sit between the session middleware (which
-	// lets /v1/public/ through without session or workspace) and the
-	// router: each resolves its own token/slug → tenant, throttles, and
-	// binds a confined system principal. The preference edge wraps the
-	// booking edge — each passes a non-matching path straight through.
-	publicEdge := publicPreferences(consent.NewStore(pool), newPublicPreferenceLimiters())(
-		publicBooking(activities.NewStore(pool), newPublicBookingLimiters())(api),
-	)
-	mux.Handle("/v1/", httpserver.Correlate(httpserver.AccessLog(log, authH.Middleware(publicEdge))))
-	// The A2 authorization server (ADR-0013): AS endpoints live outside
-	// the generated resource surface but behind the same workspace and
-	// session middleware; the discovery documents are static.
-	mux.Handle("/oauth/", httpserver.Correlate(httpserver.AccessLog(log, authH.Middleware(authH.OAuthRouter()))))
-	mux.HandleFunc("/.well-known/oauth-authorization-server", identity.OAuthServerMetadata)
-	mux.HandleFunc("/.well-known/oauth-protected-resource", identity.ProtectedResourceMetadata)
-	// Provider push webhooks: unauthenticated by nature (the provider is the
-	// caller), each verified by its own mechanism inside the handler; mounted
-	// only when configured — the route is absent otherwise.
-	if srv.gmailPush != nil {
-		mux.Handle("/webhooks/gmail-push", httpserver.Correlate(httpserver.AccessLog(log, srv.gmailPush)))
-	}
-	if srv.overlayWebhook != nil {
-		mux.Handle("/webhooks/hubspot", httpserver.Correlate(httpserver.AccessLog(log, srv.overlayWebhook)))
-	}
-	return mux
-}
-
 // readyzEmbedState builds /readyz's embed-status closure (Task 17) over
 // whatever embed lane this process role already wired via
 // WithEmbedReindex — the SAME store and embedder embedReindexHandlers'

--- a/backend/internal/compose/server.go
+++ b/backend/internal/compose/server.go
@@ -92,6 +92,12 @@ type Server struct {
 	// otherwise, never open.
 	gmailPush *gmailPushHandler
 
+	// overlayWebhook is the HubSpot webhook-as-signal receiver (OVA-WIRE-10),
+	// injected by WithOverlayWebhook only when the overlay app secret is
+	// configured — the route is absent otherwise, never an open unverified
+	// endpoint.
+	overlayWebhook http.Handler
+
 	// busReady is the /readyz bus probe, injected only by the process
 	// role that runs the inline relay — a split deployment's api answers
 	// ready on Postgres alone.
@@ -442,6 +448,9 @@ func operationalMux(srv Server, pool *pgxpool.Pool, log *slog.Logger, authH auth
 	// only when configured — the route is absent otherwise.
 	if srv.gmailPush != nil {
 		mux.Handle("/webhooks/gmail-push", httpserver.Correlate(httpserver.AccessLog(log, srv.gmailPush)))
+	}
+	if srv.overlayWebhook != nil {
+		mux.Handle("/webhooks/hubspot", httpserver.Correlate(httpserver.AccessLog(log, srv.overlayWebhook)))
 	}
 	return mux
 }

--- a/backend/internal/modules/overlay/connection.go
+++ b/backend/internal/modules/overlay/connection.go
@@ -250,11 +250,20 @@ func (s *Service) Connect(ctx context.Context, in ConnectInput) (Connection, err
 
 	out, err := s.insertConnection(ctx, in, ref, accountID)
 	if err != nil {
-		// The seal succeeded but the insert did not persist — clean up the
-		// just-sealed ref on EVERY failure path (a lost unique race, a cancelled
-		// context, a DB error), not only the unique violation, so a sealed token
-		// is never left unreferenced.
-		return Connection{}, s.cleanupOrphanedRef(ctx, ws, ref, err)
+		// Clean up the just-sealed ref ONLY on the unique-violation path: a lost
+		// concurrent-connect race is the one insert failure that guarantees the
+		// row did NOT persist, so the ref is definitely orphaned and safe to
+		// delete. For any other error the commit outcome can be ambiguous (a row
+		// may have persisted before the client observed the failure) — deleting
+		// the ref then would strand a live connection's token. The portal fetch
+		// already moved ABOVE vault.Put, so the sealed-token window spans no
+		// network call; the residual orphan on a rare non-unique pre-commit error
+		// is inert (nothing references it) and preferable to deleting a
+		// possibly-live token.
+		if storekit.IsUniqueViolation(err) {
+			return Connection{}, s.cleanupOrphanedRef(ctx, ws, ref)
+		}
+		return Connection{}, err
 	}
 	s.notifyModeFlip(ws)
 	s.seedUserMapOnConnect(ctx, in)
@@ -350,22 +359,19 @@ func incumbentConnectedPayload(incumbent, region string, scopes []string, status
 // database.WithWorkspaceTx.
 func (s *Service) insertConnection(ctx context.Context, in ConnectInput, ref keyvault.Ref, accountID string) (Connection, error) {
 	var out Connection
-	// A blank account id (the portal fetch failed or the incumbent exposes no
-	// account accessor) stores NULL — "not bindable yet", never an empty-string
-	// portal a webhook could spuriously match.
-	var accountArg any
-	if accountID != "" {
-		accountArg = accountID
-	}
 	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
 		var id ids.UUID
 		var connectedAt time.Time
+		// NULLIF($5,'') stores a blank account id (the portal fetch failed or the
+		// incumbent exposes no account accessor) as NULL — "not bindable yet",
+		// never an empty-string portal a webhook could spuriously match — so the
+		// nullable binding needs no `any` at the call site.
 		if scanErr := tx.QueryRow(
 			ctx, `
 			INSERT INTO incumbent_connection (workspace_id, incumbent, region, credential_ref, scopes, incumbent_account_id)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3, $4, $5)
+			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3, $4, NULLIF($5, ''))
 			RETURNING id, connected_at`,
-			in.Incumbent, in.Region, string(ref), leastPrivilegeHubSpotScopes, accountArg,
+			in.Incumbent, in.Region, string(ref), leastPrivilegeHubSpotScopes, accountID,
 		).Scan(&id, &connectedAt); scanErr != nil {
 			return scanErr
 		}
@@ -407,22 +413,22 @@ func (s *Service) insertConnection(ctx context.Context, in ConnectInput, ref key
 	return out, nil
 }
 
-// cleanupOrphanedRef deletes a vault ref this Connect attempt sealed but whose
-// INSERT did not persist (a lost UNIQUE(workspace_id) race, a cancelled
-// context, or a DB error) — Delete is idempotent, so this is safe to retry. The
-// delete runs on a context detached from ctx's cancellation (context.WithoutCancel)
-// so a cancelled/timed-out Connect still removes what it sealed. It maps the
-// concurrent-race unique violation to ErrIncumbentAlreadyConnected (the error
-// the caller needs) and surfaces any other cause verbatim; a cleanup failure is
-// joined in rather than masked.
-func (s *Service) cleanupOrphanedRef(ctx context.Context, ws ids.UUID, ref keyvault.Ref, cause error) error {
-	if delErr := s.vault.Delete(context.WithoutCancel(ctx), ids.From[ids.WorkspaceKind](ws), ref); delErr != nil {
-		return fmt.Errorf("overlay: connect failed to persist and could not clean up its orphaned vault entry: %w", errors.Join(cause, delErr))
+// cleanupOrphanedRef deletes a vault ref this Connect attempt sealed but lost
+// the UNIQUE(workspace_id) race to persist (the INSERT hit the unique
+// constraint after vault.Put already ran) — the row definitively did not
+// persist, so nothing references the ref. Delete is idempotent. It runs on a
+// context DETACHED from ctx's cancellation (context.WithoutCancel) so a
+// cancelled/timed-out Connect still removes what it sealed, but with its OWN
+// short deadline so a stalled vault cannot hang the request worker
+// indefinitely. A cleanup failure is surfaced rather than masked, but never
+// shadows the ErrIncumbentAlreadyConnected the caller actually needs.
+func (s *Service) cleanupOrphanedRef(ctx context.Context, ws ids.UUID, ref keyvault.Ref) error {
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer cancel()
+	if delErr := s.vault.Delete(cleanupCtx, ids.From[ids.WorkspaceKind](ws), ref); delErr != nil {
+		return fmt.Errorf("overlay: connect lost a concurrent race (already connected) and failed to clean up its orphaned vault entry: %w", delErr)
 	}
-	if storekit.IsUniqueViolation(cause) {
-		return apperrors.ErrIncumbentAlreadyConnected
-	}
-	return cause
+	return apperrors.ErrIncumbentAlreadyConnected
 }
 
 // hasConnection reports whether the workspace already has an

--- a/backend/internal/modules/overlay/connection.go
+++ b/backend/internal/modules/overlay/connection.go
@@ -233,25 +233,28 @@ func (s *Service) Connect(ctx context.Context, in ConnectInput) (Connection, err
 		return Connection{}, apperrors.ErrIncumbentAlreadyConnected
 	}
 
+	// Fetch the incumbent's portal id BEFORE sealing the token (it is a network
+	// call — never held inside a DB transaction, and kept OUT of the
+	// sealed-token window so a cancel/timeout here cannot orphan a vault entry)
+	// so the webhook-as-signal tenant binding is recorded at connect
+	// (OVA-DDL-3). Best-effort: a fetch failure or an incumbent with no account
+	// accessor leaves it null (the connection still works; the reconcile poller
+	// backfills the binding on its next sweep — see reconcileConnection) rather
+	// than failing the connect.
+	accountID := s.fetchPortalID(ctx, in)
+
 	ref, err := s.vault.Put(ctx, ids.From[ids.WorkspaceKind](ws), []byte(in.Token))
 	if err != nil {
 		return Connection{}, fmt.Errorf("overlay: sealing the incumbent credential: %w", err)
 	}
 
-	// Fetch the incumbent's portal id BEFORE the insert tx (it is a network
-	// call — never held inside a DB transaction) so the webhook-as-signal
-	// tenant binding is recorded at connect (OVA-DDL-3). Best-effort: a fetch
-	// failure or an incumbent with no account accessor leaves it null (the
-	// connection still works; the webhook lane simply cannot bind that portal
-	// until a reconnect/backfill fills it) rather than failing the connect.
-	accountID := s.fetchPortalID(ctx, in)
-
 	out, err := s.insertConnection(ctx, in, ref, accountID)
 	if err != nil {
-		if storekit.IsUniqueViolation(err) {
-			return Connection{}, s.cleanupOrphanedRef(ctx, ws, ref)
-		}
-		return Connection{}, err
+		// The seal succeeded but the insert did not persist — clean up the
+		// just-sealed ref on EVERY failure path (a lost unique race, a cancelled
+		// context, a DB error), not only the unique violation, so a sealed token
+		// is never left unreferenced.
+		return Connection{}, s.cleanupOrphanedRef(ctx, ws, ref, err)
 	}
 	s.notifyModeFlip(ws)
 	s.seedUserMapOnConnect(ctx, in)
@@ -404,16 +407,22 @@ func (s *Service) insertConnection(ctx context.Context, in ConnectInput, ref key
 	return out, nil
 }
 
-// cleanupOrphanedRef deletes a vault ref this Connect attempt sealed but
-// lost the race to persist (the INSERT hit UNIQUE(workspace_id) after
-// vault.Put already ran) — Delete is idempotent, so this is safe to
-// retry. A cleanup failure is surfaced rather than masked, but never
-// shadows the ErrIncumbentAlreadyConnected the caller actually needs.
-func (s *Service) cleanupOrphanedRef(ctx context.Context, ws ids.UUID, ref keyvault.Ref) error {
-	if delErr := s.vault.Delete(ctx, ids.From[ids.WorkspaceKind](ws), ref); delErr != nil {
-		return fmt.Errorf("overlay: connect lost a concurrent race (already connected) and failed to clean up its orphaned vault entry: %w", delErr)
+// cleanupOrphanedRef deletes a vault ref this Connect attempt sealed but whose
+// INSERT did not persist (a lost UNIQUE(workspace_id) race, a cancelled
+// context, or a DB error) — Delete is idempotent, so this is safe to retry. The
+// delete runs on a context detached from ctx's cancellation (context.WithoutCancel)
+// so a cancelled/timed-out Connect still removes what it sealed. It maps the
+// concurrent-race unique violation to ErrIncumbentAlreadyConnected (the error
+// the caller needs) and surfaces any other cause verbatim; a cleanup failure is
+// joined in rather than masked.
+func (s *Service) cleanupOrphanedRef(ctx context.Context, ws ids.UUID, ref keyvault.Ref, cause error) error {
+	if delErr := s.vault.Delete(context.WithoutCancel(ctx), ids.From[ids.WorkspaceKind](ws), ref); delErr != nil {
+		return fmt.Errorf("overlay: connect failed to persist and could not clean up its orphaned vault entry: %w", errors.Join(cause, delErr))
 	}
-	return apperrors.ErrIncumbentAlreadyConnected
+	if storekit.IsUniqueViolation(cause) {
+		return apperrors.ErrIncumbentAlreadyConnected
+	}
+	return cause
 }
 
 // hasConnection reports whether the workspace already has an

--- a/backend/internal/modules/overlay/connection.go
+++ b/backend/internal/modules/overlay/connection.go
@@ -238,7 +238,15 @@ func (s *Service) Connect(ctx context.Context, in ConnectInput) (Connection, err
 		return Connection{}, fmt.Errorf("overlay: sealing the incumbent credential: %w", err)
 	}
 
-	out, err := s.insertConnection(ctx, in, ref)
+	// Fetch the incumbent's portal id BEFORE the insert tx (it is a network
+	// call — never held inside a DB transaction) so the webhook-as-signal
+	// tenant binding is recorded at connect (OVA-DDL-3). Best-effort: a fetch
+	// failure or an incumbent with no account accessor leaves it null (the
+	// connection still works; the webhook lane simply cannot bind that portal
+	// until a reconnect/backfill fills it) rather than failing the connect.
+	accountID := s.fetchPortalID(ctx, in)
+
+	out, err := s.insertConnection(ctx, in, ref, accountID)
 	if err != nil {
 		if storekit.IsUniqueViolation(err) {
 			return Connection{}, s.cleanupOrphanedRef(ctx, ws, ref)
@@ -248,6 +256,35 @@ func (s *Service) Connect(ctx context.Context, in ConnectInput) (Connection, err
 	s.notifyModeFlip(ws)
 	s.seedUserMapOnConnect(ctx, in)
 	return out, nil
+}
+
+// incumbentAccountReader is the optional accessor an incumbent adapter exposes
+// to report its account/portal id (HubSpot's portalId). It is a narrow
+// type-assertion rather than a method on the Incumbent seam so the many
+// read-only test doubles that never need it take on no obligation.
+type incumbentAccountReader interface {
+	AccountID(ctx context.Context) (string, error)
+}
+
+// fetchPortalID best-effort resolves the incumbent's portal id for the
+// webhook tenant binding. It returns "" (→ stored NULL) when no incumbent
+// factory is wired, the adapter exposes no account accessor, or the fetch
+// fails — the connect still succeeds.
+func (s *Service) fetchPortalID(ctx context.Context, in ConnectInput) string {
+	if s.incumbent == nil {
+		return ""
+	}
+	acct, ok := s.incumbent(in.Region, in.Token).(incumbentAccountReader)
+	if !ok {
+		return ""
+	}
+	id, err := acct.AccountID(ctx)
+	if err != nil {
+		s.log.WarnContext(ctx, "overlay connect: fetching the incumbent portal id failed; webhook binding deferred",
+			"incumbent", in.Incumbent, "err", err)
+		return ""
+	}
+	return id
 }
 
 // seedUserMapOnConnect populates mirror_user_map from the incumbent's
@@ -308,17 +345,24 @@ func incumbentConnectedPayload(incumbent, region string, scopes []string, status
 // insertConnection runs Connect's write-shape transaction: the domain
 // row + Audit + Emit + the workspace mode flip, all in one
 // database.WithWorkspaceTx.
-func (s *Service) insertConnection(ctx context.Context, in ConnectInput, ref keyvault.Ref) (Connection, error) {
+func (s *Service) insertConnection(ctx context.Context, in ConnectInput, ref keyvault.Ref, accountID string) (Connection, error) {
 	var out Connection
+	// A blank account id (the portal fetch failed or the incumbent exposes no
+	// account accessor) stores NULL — "not bindable yet", never an empty-string
+	// portal a webhook could spuriously match.
+	var accountArg any
+	if accountID != "" {
+		accountArg = accountID
+	}
 	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
 		var id ids.UUID
 		var connectedAt time.Time
 		if scanErr := tx.QueryRow(
 			ctx, `
-			INSERT INTO incumbent_connection (workspace_id, incumbent, region, credential_ref, scopes)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3, $4)
+			INSERT INTO incumbent_connection (workspace_id, incumbent, region, credential_ref, scopes, incumbent_account_id)
+			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3, $4, $5)
 			RETURNING id, connected_at`,
-			in.Incumbent, in.Region, string(ref), leastPrivilegeHubSpotScopes,
+			in.Incumbent, in.Region, string(ref), leastPrivilegeHubSpotScopes, accountArg,
 		).Scan(&id, &connectedAt); scanErr != nil {
 			return scanErr
 		}

--- a/backend/internal/modules/overlay/connection_test.go
+++ b/backend/internal/modules/overlay/connection_test.go
@@ -13,8 +13,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/jackc/pgx/v5/pgconn"
-
 	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -30,10 +28,9 @@ func TestCleanupOrphanedRefDeletesAndAnswersAlreadyConnected(t *testing.T) {
 		t.Fatalf("seeding a vault ref: %v", err)
 	}
 
-	// The concurrent-race cause is a UNIQUE(workspace_id) violation; cleanup
-	// deletes the orphaned ref and maps that cause to ErrIncumbentAlreadyConnected.
-	uniqueViolation := &pgconn.PgError{Code: "23505"}
-	err = svc.cleanupOrphanedRef(context.Background(), ws, ref, uniqueViolation)
+	// cleanupOrphanedRef deletes the orphaned ref (the lost-race path) and
+	// answers ErrIncumbentAlreadyConnected.
+	err = svc.cleanupOrphanedRef(context.Background(), ws, ref)
 	if !errors.Is(err, apperrors.ErrIncumbentAlreadyConnected) {
 		t.Fatalf("cleanupOrphanedRef err = %v, want errors.Is(_, ErrIncumbentAlreadyConnected)", err)
 	}
@@ -43,34 +40,6 @@ func TestCleanupOrphanedRefDeletesAndAnswersAlreadyConnected(t *testing.T) {
 	// no-op that happens to return the right sentinel.
 	if _, getErr := vault.Get(context.Background(), ids.From[ids.WorkspaceKind](ws), ref); !errors.Is(getErr, keyvault.ErrNotFound) {
 		t.Fatalf("vault.Get after cleanup = %v, want ErrNotFound (the orphaned ref must be deleted)", getErr)
-	}
-}
-
-// TestCleanupOrphanedRefSurfacesANonUniqueCause proves the other cleanup path:
-// when the insert failed for a reason OTHER than the concurrent-race unique
-// violation (a DB error, a cancelled context), cleanup still deletes the sealed
-// ref but surfaces the original cause verbatim rather than the misleading
-// "already connected".
-func TestCleanupOrphanedRefSurfacesANonUniqueCause(t *testing.T) {
-	vault := keyvault.NewMemory()
-	svc := NewService(nil, vault, NewMirrorStore(nil, noOwnerEmailsForUnitTest{}))
-
-	ws := ids.NewV7()
-	ref, err := vault.Put(context.Background(), ids.From[ids.WorkspaceKind](ws), []byte("pat-secret-token"))
-	if err != nil {
-		t.Fatalf("seeding a vault ref: %v", err)
-	}
-
-	cause := errors.New("insert failed: context canceled")
-	err = svc.cleanupOrphanedRef(context.Background(), ws, ref, cause)
-	if !errors.Is(err, cause) {
-		t.Fatalf("cleanupOrphanedRef err = %v, want the original cause surfaced", err)
-	}
-	if errors.Is(err, apperrors.ErrIncumbentAlreadyConnected) {
-		t.Error("a non-unique cause must NOT be mapped to ErrIncumbentAlreadyConnected")
-	}
-	if _, getErr := vault.Get(context.Background(), ids.From[ids.WorkspaceKind](ws), ref); !errors.Is(getErr, keyvault.ErrNotFound) {
-		t.Fatalf("vault.Get after cleanup = %v, want ErrNotFound (the ref must be deleted on every failure path)", getErr)
 	}
 }
 

--- a/backend/internal/modules/overlay/connection_test.go
+++ b/backend/internal/modules/overlay/connection_test.go
@@ -13,6 +13,8 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/jackc/pgx/v5/pgconn"
+
 	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -28,7 +30,10 @@ func TestCleanupOrphanedRefDeletesAndAnswersAlreadyConnected(t *testing.T) {
 		t.Fatalf("seeding a vault ref: %v", err)
 	}
 
-	err = svc.cleanupOrphanedRef(context.Background(), ws, ref)
+	// The concurrent-race cause is a UNIQUE(workspace_id) violation; cleanup
+	// deletes the orphaned ref and maps that cause to ErrIncumbentAlreadyConnected.
+	uniqueViolation := &pgconn.PgError{Code: "23505"}
+	err = svc.cleanupOrphanedRef(context.Background(), ws, ref, uniqueViolation)
 	if !errors.Is(err, apperrors.ErrIncumbentAlreadyConnected) {
 		t.Fatalf("cleanupOrphanedRef err = %v, want errors.Is(_, ErrIncumbentAlreadyConnected)", err)
 	}
@@ -38,6 +43,34 @@ func TestCleanupOrphanedRefDeletesAndAnswersAlreadyConnected(t *testing.T) {
 	// no-op that happens to return the right sentinel.
 	if _, getErr := vault.Get(context.Background(), ids.From[ids.WorkspaceKind](ws), ref); !errors.Is(getErr, keyvault.ErrNotFound) {
 		t.Fatalf("vault.Get after cleanup = %v, want ErrNotFound (the orphaned ref must be deleted)", getErr)
+	}
+}
+
+// TestCleanupOrphanedRefSurfacesANonUniqueCause proves the other cleanup path:
+// when the insert failed for a reason OTHER than the concurrent-race unique
+// violation (a DB error, a cancelled context), cleanup still deletes the sealed
+// ref but surfaces the original cause verbatim rather than the misleading
+// "already connected".
+func TestCleanupOrphanedRefSurfacesANonUniqueCause(t *testing.T) {
+	vault := keyvault.NewMemory()
+	svc := NewService(nil, vault, NewMirrorStore(nil, noOwnerEmailsForUnitTest{}))
+
+	ws := ids.NewV7()
+	ref, err := vault.Put(context.Background(), ids.From[ids.WorkspaceKind](ws), []byte("pat-secret-token"))
+	if err != nil {
+		t.Fatalf("seeding a vault ref: %v", err)
+	}
+
+	cause := errors.New("insert failed: context canceled")
+	err = svc.cleanupOrphanedRef(context.Background(), ws, ref, cause)
+	if !errors.Is(err, cause) {
+		t.Fatalf("cleanupOrphanedRef err = %v, want the original cause surfaced", err)
+	}
+	if errors.Is(err, apperrors.ErrIncumbentAlreadyConnected) {
+		t.Error("a non-unique cause must NOT be mapped to ErrIncumbentAlreadyConnected")
+	}
+	if _, getErr := vault.Get(context.Background(), ids.From[ids.WorkspaceKind](ws), ref); !errors.Is(getErr, keyvault.ErrNotFound) {
+		t.Fatalf("vault.Get after cleanup = %v, want ErrNotFound (the ref must be deleted on every failure path)", getErr)
 	}
 }
 

--- a/backend/internal/modules/overlay/connectionreads.go
+++ b/backend/internal/modules/overlay/connectionreads.go
@@ -103,10 +103,16 @@ func DueOverlayConnections(ctx context.Context, pool *pgxpool.Pool) ([]DueOverla
 // no session/tenant, so this is the fleet-walk counterpart the receiver needs:
 // it enumerates every overlay-mode workspace and probes each under its own GUC
 // for an active connection carrying that portal (the same rls-exempt shape
-// DueOverlayConnections uses — never a raw cross-tenant read). Fail-closed: a
-// portal matching NO active connection returns apperrors.ErrNotFound, so the
-// receiver rejects it and never ingests cross-tenant; a blank portal (a
-// connection that recorded none yet) is likewise unbindable.
+// DueOverlayConnections uses — never a raw cross-tenant read).
+//
+// Fail-closed on BOTH "no match" AND "more than one match": the schema does not
+// make the portal globally unique (a shared/duplicate portal is an operator
+// concern, not a connect-blocking constraint), so a portal claimed by two
+// active connections is AMBIGUOUS — binding it to whichever the walk happened
+// to reach first would mis-attribute one tenant's signal to another. Both zero
+// and ambiguous resolve to apperrors.ErrNotFound, so the receiver ingests
+// nothing and the poller heals both workspaces; only exactly one match binds. A
+// blank portal (a connection that recorded none yet) is likewise unbindable.
 func WorkspaceForPortal(ctx context.Context, pool *pgxpool.Pool, incumbent, incumbentAccountID string) (ids.WorkspaceID, error) {
 	if incumbentAccountID == "" {
 		return ids.WorkspaceID{}, apperrors.ErrNotFound
@@ -120,6 +126,9 @@ func WorkspaceForPortal(ctx context.Context, pool *pgxpool.Pool, incumbent, incu
 	if err != nil {
 		return ids.WorkspaceID{}, fmt.Errorf("overlay: collecting workspace ids for portal binding: %w", err)
 	}
+	// Collect ALL matches rather than returning on the first — one match binds,
+	// zero or many are both fail-closed (see the ambiguity note above).
+	var matches []ids.UUID
 	for _, wsID := range workspaces {
 		wsCtx := principal.WithWorkspaceID(ctx, wsID)
 		var found bool
@@ -141,10 +150,68 @@ func WorkspaceForPortal(ctx context.Context, pool *pgxpool.Pool, incumbent, incu
 			return ids.WorkspaceID{}, fmt.Errorf("overlay: probing workspace %s for portal binding: %w", wsID, walkErr)
 		}
 		if found {
-			return ids.From[ids.WorkspaceKind](wsID), nil
+			matches = append(matches, wsID)
 		}
 	}
-	return ids.WorkspaceID{}, apperrors.ErrNotFound
+	if len(matches) != 1 {
+		// Zero → unbound; more than one → ambiguous. Either way, ingest nothing.
+		return ids.WorkspaceID{}, apperrors.ErrNotFound
+	}
+	return ids.From[ids.WorkspaceKind](matches[0]), nil
+}
+
+// BackfillPortalBinding fills a NULL incumbent_account_id (OVA-DDL-3) on the
+// workspace's active connection from the live adapter's account id — the retry
+// path for a connection whose connect-time portal fetch failed (best-effort, so
+// it left the binding null and the webhook lane could not bind that portal).
+// Run once per reconcile sweep with the sweep's own live adapter, it makes the
+// binding self-healing: a transient connect-time blip no longer permanently
+// disables webhook refresh for an otherwise-healthy connection.
+//
+// It is gated on the binding being unset (a cheap check first) so an
+// already-bound connection costs no per-sweep network call. Like the sibling
+// sweep checkpoints (overlay_sync_state, backfill cursors), this operational
+// binding metadata is a plain UPDATE, not a domain mutation through the
+// audit+outbox write shape. It never CHANGES an existing binding — only fills a
+// null — so it cannot silently re-point a portal. An adapter exposing no
+// account accessor, or a transient AccountID failure, is a no-op (the next
+// sweep retries); ctx is the caller's already-workspace-scoped sweep context.
+func BackfillPortalBinding(ctx context.Context, pool *pgxpool.Pool, inc Incumbent) error {
+	reader, ok := inc.(incumbentAccountReader)
+	if !ok {
+		return nil // this incumbent reports no account id — nothing to bind
+	}
+	var alreadyBound bool
+	if err := database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
+		scanErr := tx.QueryRow(ctx, `
+			SELECT incumbent_account_id IS NOT NULL FROM incumbent_connection
+			WHERE status = $1`, statusActive).Scan(&alreadyBound)
+		if errors.Is(scanErr, pgx.ErrNoRows) {
+			alreadyBound = true // no active connection to bind — treat as done
+			return nil
+		}
+		return scanErr
+	}); err != nil {
+		return fmt.Errorf("overlay: checking the portal binding: %w", err)
+	}
+	if alreadyBound {
+		return nil
+	}
+	accountID, err := reader.AccountID(ctx)
+	if err != nil {
+		return fmt.Errorf("overlay: resolving the incumbent account id for portal binding: %w", err)
+	}
+	if accountID == "" {
+		return nil // still unresolvable — leave null, the next sweep retries
+	}
+	return database.WithWorkspaceTx(ctx, pool, func(tx pgx.Tx) error {
+		// WHERE incumbent_account_id IS NULL: only fill, never overwrite — a
+		// concurrent connect/reconnect that already set it wins.
+		_, execErr := tx.Exec(ctx, `
+			UPDATE incumbent_connection SET incumbent_account_id = $2
+			WHERE status = $1 AND incumbent_account_id IS NULL`, statusActive, accountID)
+		return execErr
+	})
 }
 
 // ActiveConnection reads ctx's workspace's ACTIVE incumbent connection —

--- a/backend/internal/modules/overlay/connectionreads.go
+++ b/backend/internal/modules/overlay/connectionreads.go
@@ -97,6 +97,56 @@ func DueOverlayConnections(ctx context.Context, pool *pgxpool.Pool) ([]DueOverla
 	return due, errs
 }
 
+// WorkspaceForPortal resolves the workspace whose ACTIVE incumbent connection
+// recorded incumbentAccountID (an inbound webhook's portalId) — the
+// webhook-as-signal tenant binding (OVA-DDL-3, OVA-WIRE-10). A webhook carries
+// no session/tenant, so this is the fleet-walk counterpart the receiver needs:
+// it enumerates every overlay-mode workspace and probes each under its own GUC
+// for an active connection carrying that portal (the same rls-exempt shape
+// DueOverlayConnections uses — never a raw cross-tenant read). Fail-closed: a
+// portal matching NO active connection returns apperrors.ErrNotFound, so the
+// receiver rejects it and never ingests cross-tenant; a blank portal (a
+// connection that recorded none yet) is likewise unbindable.
+func WorkspaceForPortal(ctx context.Context, pool *pgxpool.Pool, incumbent, incumbentAccountID string) (ids.WorkspaceID, error) {
+	if incumbentAccountID == "" {
+		return ids.WorkspaceID{}, apperrors.ErrNotFound
+	}
+	// rls-exempt: fleet enumeration — the workspace table is not workspace-scoped; this reads every tenant before entering each workspace's own GUC to probe its connection.
+	rows, err := pool.Query(ctx, `SELECT id FROM workspace WHERE archived_at IS NULL AND x_sor_mode = 'overlay'`)
+	if err != nil {
+		return ids.WorkspaceID{}, fmt.Errorf("overlay: listing overlay-mode workspaces for portal binding: %w", err)
+	}
+	workspaces, err := pgx.CollectRows(rows, pgx.RowTo[ids.UUID])
+	if err != nil {
+		return ids.WorkspaceID{}, fmt.Errorf("overlay: collecting workspace ids for portal binding: %w", err)
+	}
+	for _, wsID := range workspaces {
+		wsCtx := principal.WithWorkspaceID(ctx, wsID)
+		var found bool
+		if walkErr := database.WithWorkspaceTx(wsCtx, pool, func(tx pgx.Tx) error {
+			var one int
+			scanErr := tx.QueryRow(wsCtx, `
+				SELECT 1 FROM incumbent_connection
+				WHERE status = $1 AND incumbent = $2 AND incumbent_account_id = $3`,
+				statusActive, incumbent, incumbentAccountID).Scan(&one)
+			if errors.Is(scanErr, pgx.ErrNoRows) {
+				return nil
+			}
+			if scanErr != nil {
+				return scanErr
+			}
+			found = true
+			return nil
+		}); walkErr != nil {
+			return ids.WorkspaceID{}, fmt.Errorf("overlay: probing workspace %s for portal binding: %w", wsID, walkErr)
+		}
+		if found {
+			return ids.From[ids.WorkspaceKind](wsID), nil
+		}
+	}
+	return ids.WorkspaceID{}, apperrors.ErrNotFound
+}
+
 // ActiveConnection reads ctx's workspace's ACTIVE incumbent connection —
 // the per-request counterpart to DueOverlayConnections' fleet walk. The
 // read path (FreshnessReader's live force-fresh resolver, wired in

--- a/backend/internal/modules/overlay/connectionreads.go
+++ b/backend/internal/modules/overlay/connectionreads.go
@@ -173,9 +173,14 @@ func WorkspaceForPortal(ctx context.Context, pool *pgxpool.Pool, incumbent, incu
 // sweep checkpoints (overlay_sync_state, backfill cursors), this operational
 // binding metadata is a plain UPDATE, not a domain mutation through the
 // audit+outbox write shape. It never CHANGES an existing binding — only fills a
-// null — so it cannot silently re-point a portal. An adapter exposing no
-// account accessor, or a transient AccountID failure, is a no-op (the next
-// sweep retries); ctx is the caller's already-workspace-scoped sweep context.
+// null — so it cannot silently re-point a portal.
+//
+// Error contract: an adapter exposing no account accessor, or an already-bound
+// connection, or an adapter that resolves an empty id, is a silent no-op
+// (returns nil). A FAILED AccountID call (or the gating read) is SURFACED to the
+// caller — the reconcile sweep treats it as best-effort (logs and continues, so
+// the next sweep retries), but the error is returned rather than swallowed here
+// so a future caller can decide. ctx is the caller's workspace-scoped context.
 func BackfillPortalBinding(ctx context.Context, pool *pgxpool.Pool, inc Incumbent) error {
 	reader, ok := inc.(incumbentAccountReader)
 	if !ok {

--- a/backend/internal/modules/overlay/fake/adapter.go
+++ b/backend/internal/modules/overlay/fake/adapter.go
@@ -27,6 +27,7 @@ type Adapter struct {
 	assocs    map[assocKey][]overlay.Assoc
 	owners    map[string]string
 	deletions map[string][]overlay.Deletion
+	accountID string // the portal/account id AccountID reports (empty = unset)
 	// writeSeq drives deterministic Create ids and modified-at stamps for the
 	// write seam — a monotonic counter, never a real clock, so a test
 	// exercising write-back never flakes on wall-time (T11).
@@ -57,6 +58,16 @@ func New() *Adapter {
 func (a *Adapter) SeedOwner(ownerExternalID, email string) {
 	a.owners[ownerExternalID] = email
 }
+
+// SeedAccountID sets the portal/account id AccountID reports — the value the
+// webhook portal-binding backfill (overlay.BackfillPortalBinding) persists.
+func (a *Adapter) SeedAccountID(id string) { a.accountID = id }
+
+// AccountID reports the seeded portal/account id (OVA-DDL-3), letting the fake
+// stand in for hubspot.Adapter's incumbentAccountReader in the portal-binding
+// backfill path. An unset id returns "" with no error — the same "no account to
+// bind" no-op a real adapter with no accessor would produce.
+func (a *Adapter) AccountID(context.Context) (string, error) { return a.accountID, nil }
 
 // Rec builds an overlay.Record for externalID carrying fields, stamped
 // with the current time as ModifiedAt.

--- a/backend/internal/modules/overlay/hubspot/adapter_writes.go
+++ b/backend/internal/modules/overlay/hubspot/adapter_writes.go
@@ -144,3 +144,10 @@ func incumbentClassFor(canonicalClass, externalID string) (string, error) {
 	}
 	return classes[0], nil
 }
+
+// AccountID returns the HubSpot portal id for this connection's token — the
+// incumbent account identity recorded at connect (OVA-DDL-3) for the
+// webhook-as-signal tenant binding.
+func (a *Adapter) AccountID(ctx context.Context) (string, error) {
+	return a.client.AccountID(ctx)
+}

--- a/backend/internal/modules/overlay/hubspot/client_test.go
+++ b/backend/internal/modules/overlay/hubspot/client_test.go
@@ -500,3 +500,55 @@ func TestNewClientRecordsRegion(t *testing.T) {
 		t.Fatalf("BaseURL() = %q, want https://api.hubapi.com", c.BaseURL())
 	}
 }
+
+func TestClientAccountIDParsesPortalID(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		mustWrite(t, w, `{"portalId": 24193752, "timeZone": "US/Eastern"}`)
+	}))
+	defer srv.Close()
+
+	c := hubspot.NewClient("us", "test-token", hubspot.WithBaseURL(srv.URL))
+	id, err := c.AccountID(t.Context())
+	if err != nil {
+		t.Fatalf("AccountID: %v", err)
+	}
+	// portalId arrives as a JSON number, returned as its decimal string so it
+	// matches the webhook payload's own portalId rendering (the binding key).
+	if id != "24193752" {
+		t.Errorf("AccountID = %q, want 24193752", id)
+	}
+	if gotPath != "/account-info/v3/details" {
+		t.Errorf("path = %q, want /account-info/v3/details", gotPath)
+	}
+}
+
+func TestClientAccountIDRejectsMissingPortalID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		mustWrite(t, w, `{"timeZone": "US/Eastern"}`) // no portalId
+	}))
+	defer srv.Close()
+
+	c := hubspot.NewClient("us", "test-token", hubspot.WithBaseURL(srv.URL))
+	// Fail closed: never bind a webhook to an empty portal.
+	if _, err := c.AccountID(t.Context()); err == nil {
+		t.Error("a response with no portalId must error, not return an empty portal")
+	}
+}
+
+func TestClientAccountIDSurfacesUpstreamFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := hubspot.NewClient("us", "test-token", hubspot.WithBaseURL(srv.URL))
+	// An upstream failure must surface (the connect-time fetch treats it as
+	// best-effort, but the client itself must not mask it as an empty portal).
+	if _, err := c.AccountID(t.Context()); err == nil {
+		t.Error("an upstream 500 must surface as an error")
+	}
+}

--- a/backend/internal/modules/overlay/hubspot/mapping_hs.go
+++ b/backend/internal/modules/overlay/hubspot/mapping_hs.go
@@ -27,9 +27,18 @@ const (
 	objectClassTasks    = "tasks"
 )
 
-// activityTarget is the canonical Margince type all five engagement classes
-// map onto.
-const activityTarget = "activity"
+// The canonical Margince record types (OVA-MAP-*): the ObjectMapping Targets
+// below, the mapWrite switch (mapwrite.go), and the webhook subscription map
+// (webhook.go) all select from this one set, so a canonical class name never
+// drifts across the read/write/signal call sites. activityTarget is the type
+// all five engagement classes map onto.
+const (
+	personTarget       = "person"
+	organizationTarget = "organization"
+	dealTarget         = "deal"
+	leadTarget         = "lead"
+	activityTarget     = "activity"
+)
 
 // baselineHSLastModifiedDate is the watermark property every object
 // class but contacts uses (design.md §7, spike-confirmed) — shared with
@@ -158,7 +167,7 @@ var ownerIDField = overlay.FieldMapping{
 // ordinary case: unmapped/flagged until the x_ custom column lands.
 var contactsMapping = overlay.ObjectMapping{
 	Source:         objectClassContacts,
-	Target:         "person",
+	Target:         personTarget,
 	ExternalKey:    propHSObjectID,
 	Baseline:       "lastmodifieddate",
 	UnmappedPolicy: unmappedPolicyFlag,
@@ -195,7 +204,7 @@ var contactsMapping = overlay.ObjectMapping{
 // "flag, never silently drop" treatment contacts' phone gets.
 var companiesMapping = overlay.ObjectMapping{
 	Source:         objectClassCompanies,
-	Target:         "organization",
+	Target:         organizationTarget,
 	ExternalKey:    propHSObjectID,
 	Baseline:       baselineHSLastModifiedDate,
 	UnmappedPolicy: unmappedPolicyFlag,
@@ -241,7 +250,7 @@ var companiesMapping = overlay.ObjectMapping{
 // code itself, uppercased.
 var dealsMapping = overlay.ObjectMapping{
 	Source:         objectClassDeals,
-	Target:         "deal",
+	Target:         dealTarget,
 	ExternalKey:    propHSObjectID,
 	Baseline:       baselineHSLastModifiedDate,
 	UnmappedPolicy: unmappedPolicyFlag,
@@ -383,7 +392,7 @@ var tasksMapping = overlay.ObjectMapping{
 //     than inventing them.
 var leadsMapping = overlay.ObjectMapping{
 	Source:         objectClassLeads,
-	Target:         "lead",
+	Target:         leadTarget,
 	ExternalKey:    propHSObjectID,
 	Baseline:       baselineHSLastModifiedDate,
 	UnmappedPolicy: unmappedPolicyFlag,

--- a/backend/internal/modules/overlay/hubspot/mapwrite.go
+++ b/backend/internal/modules/overlay/hubspot/mapwrite.go
@@ -49,16 +49,16 @@ type writeMapping struct {
 //craft:ignore naked-any fields is the JSON-decoded canonical bag from the frozen datasource seam; the any is inherent to the decoded shape
 func mapWrite(canonicalClass string, fields map[string]any, forUpdate bool) (writeMapping, error) {
 	switch canonicalClass {
-	case "person":
+	case personTarget:
 		props, err := copyDirect(fields, personWriteFields, forUpdate)
 		return writeMapping{ObjectClass: objectClassContacts, Props: props}, err
-	case "organization":
+	case organizationTarget:
 		props, err := copyDirect(fields, organizationWriteFields, forUpdate)
 		return writeMapping{ObjectClass: objectClassCompanies, Props: props}, err
-	case "lead":
+	case leadTarget:
 		props, err := copyDirect(fields, leadWriteFields, forUpdate)
 		return writeMapping{ObjectClass: objectClassLeads, Props: props}, err
-	case "deal":
+	case dealTarget:
 		return mapWriteDeal(fields, forUpdate)
 	case activityTarget:
 		return mapWriteActivity(fields, forUpdate)

--- a/backend/internal/modules/overlay/hubspot/records.go
+++ b/backend/internal/modules/overlay/hubspot/records.go
@@ -286,3 +286,21 @@ func toObjectRecords(in []wireObject) []ObjectRecord {
 	}
 	return out
 }
+
+// AccountID returns the HubSpot portal (hub) id for the connected private-app
+// token — the incumbent account identity recorded at connect (OVA-DDL-3) so an
+// inbound webhook's portalId binds to this workspace. portalId arrives as a
+// JSON number; it is returned as its decimal string, matching the webhook
+// payload's own portalId rendering.
+func (c *Client) AccountID(ctx context.Context) (string, error) {
+	var out struct {
+		PortalID json.Number `json:"portalId"` //nolint:tagliatelle // HubSpot's wire format (camelCase); must match to decode
+	}
+	if err := c.do(ctx, http.MethodGet, "/account-info/v3/details", nil, &out); err != nil {
+		return "", err
+	}
+	if out.PortalID.String() == "" {
+		return "", fmt.Errorf("hubspot: account-info returned no portalId")
+	}
+	return out.PortalID.String(), nil
+}

--- a/backend/internal/modules/overlay/hubspot/webhook.go
+++ b/backend/internal/modules/overlay/hubspot/webhook.go
@@ -68,28 +68,40 @@ const (
 	subPrefixDeal    = "deal"
 	subPrefixLead    = "lead"
 	subPrefixHSLead  = "hs_lead"
-	// subActionDeletion is the one action this signal lane deliberately does
-	// NOT act on: a re-fetch of a deleted record 404s and would leave the
-	// mirror row lingering (a doomed job that looks handled). Incumbent-side
-	// deletions are the poller's deletion-feed's job (it tombstones), so a
-	// deletion subscription is dropped here rather than enqueued.
-	subActionDeletion = "deletion"
+	// The deletion-family actions this signal lane deliberately does NOT act on:
+	// a re-fetch of a deleted record 404s and would leave the mirror row
+	// lingering (a doomed job that looks handled). Incumbent-side deletions are
+	// the poller's deletion-feed's job, so a deletion subscription is dropped
+	// here rather than enqueued. subActionPrivacyDeletion is HubSpot's GDPR
+	// hard-delete (contact.privacyDeletion) — the SAME "must not enter the
+	// re-fetch lane" rule, and MORE important to not mishandle (the mirror must
+	// not resurrect a privacy-deleted record); active purge of it belongs to the
+	// deletion/erasure path, not this re-fetch lane.
+	subActionDeletion        = "deletion"
+	subActionPrivacyDeletion = "privacyDeletion"
 )
+
+// isDeletionAction reports whether a subscription action is a deletion-family
+// one this lane drops (never re-fetches).
+func isDeletionAction(action string) bool {
+	return action == subActionDeletion || action == subActionPrivacyDeletion
+}
 
 // ObjectClassForSubscription maps a HubSpot subscriptionType (e.g.
 // "contact.propertyChange", "deal.creation") to the incumbent object class the
 // mirror re-fetches through — the prefix before the first dot names the object
 // type. ok=false means "not re-fetchable through this lane": either an
 // unrecognized object type (a type the mirror does not model — dropped, never
-// guessed) OR a deletion action (owned by the poller's deletion feed, not a
-// re-fetch). V1 covers the object types HubSpot webhooks deliver for
-// (contact/company/deal/lead); the five engagement classes have no standard
-// webhook subscription and are healed by the poller.
+// guessed) OR a deletion-family action (deletion / privacyDeletion — owned by
+// the poller's deletion/erasure path, not a re-fetch). V1 covers the object
+// types HubSpot webhooks deliver for (contact/company/deal/lead); the five
+// engagement classes have no standard webhook subscription and are healed by
+// the poller.
 func ObjectClassForSubscription(subscriptionType string) (string, bool) {
 	prefix, action, _ := strings.Cut(subscriptionType, ".")
-	if action == subActionDeletion {
+	if isDeletionAction(action) {
 		// Presented honestly as NOT handled by the re-fetch lane; the poller's
-		// deletion feed tombstones incumbent-deleted records.
+		// deletion feed / erasure path owns removing incumbent-deleted records.
 		return "", false
 	}
 	switch prefix {

--- a/backend/internal/modules/overlay/hubspot/webhook.go
+++ b/backend/internal/modules/overlay/hubspot/webhook.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package hubspot
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"strconv"
+	"strings"
+)
+
+// This file is the HubSpot webhook protocol: the v3 request-signature check
+// and the minimal invalidation-signal payload the overlay receiver
+// (OVA-WIRE-10) consumes. It lives in the hubspot package because it is
+// HubSpot's own wire format — the compose receiver stays incumbent-agnostic
+// about the protocol, the same split the read/write adapters keep.
+
+// WebhookEvent is one HubSpot webhook notification — the minimal invalidation
+// signal, NOT trusted content (OVA-WIRE-10). portalId binds the tenant,
+// subscriptionType selects the object class, objectId names the record.
+// occurredAt orders the change (epoch millis).
+type WebhookEvent struct {
+	PortalID         int64  `json:"portalId"`         //nolint:tagliatelle // HubSpot's wire format (camelCase)
+	ObjectID         int64  `json:"objectId"`         //nolint:tagliatelle // HubSpot's wire format (camelCase)
+	SubscriptionType string `json:"subscriptionType"` //nolint:tagliatelle // HubSpot's wire format (camelCase)
+	OccurredAt       int64  `json:"occurredAt"`       //nolint:tagliatelle // HubSpot's wire format (camelCase)
+}
+
+// PortalIDString renders the portalId as the decimal string the connection's
+// incumbent_account_id (OVA-DDL-3) is stored as, for the tenant binding.
+func (e WebhookEvent) PortalIDString() string { return strconv.FormatInt(e.PortalID, 10) }
+
+// ObjectIDString renders the objectId as the decimal-string external id the
+// mirror keys records by.
+func (e WebhookEvent) ObjectIDString() string { return strconv.FormatInt(e.ObjectID, 10) }
+
+// VerifyWebhookSignature checks HubSpot's v3 request signature: the header is
+// base64(HMAC-SHA256(clientSecret, method + uri + body + timestamp)). It is a
+// constant-time compare — a mismatch means the request is not from HubSpot (or
+// was tampered) and is rejected fail-closed. The caller separately rejects a
+// stale timestamp (replay).
+func VerifyWebhookSignature(clientSecret, method, uri string, body []byte, timestamp, provided string) bool {
+	if clientSecret == "" || provided == "" {
+		return false
+	}
+	mac := hmac.New(sha256.New, []byte(clientSecret))
+	mac.Write([]byte(method))
+	mac.Write([]byte(uri))
+	mac.Write(body)
+	mac.Write([]byte(timestamp))
+	expected := base64.StdEncoding.EncodeToString(mac.Sum(nil))
+	// hmac.Equal is constant-time; both operands are fixed-length base64 of a
+	// 32-byte digest, so it leaks neither content nor length.
+	return hmac.Equal([]byte(expected), []byte(provided))
+}
+
+// ObjectClassForSubscription maps a HubSpot subscriptionType (e.g.
+// "contact.propertyChange", "deal.creation") to the incumbent object class the
+// mirror re-fetches through — the prefix before the first dot names the object
+// type. An unrecognized subscription (a type the mirror does not model) is
+// ok=false: the receiver drops it as an out-of-scope signal rather than
+// guessing a class. V1 covers the object types HubSpot webhooks deliver for
+// (contact/company/deal/lead); the five engagement classes have no standard
+// webhook subscription and are healed by the poller.
+func ObjectClassForSubscription(subscriptionType string) (string, bool) {
+	prefix, _, _ := strings.Cut(subscriptionType, ".")
+	switch prefix {
+	case "contact":
+		return objectClassContacts, true
+	case "company":
+		return objectClassCompanies, true
+	case "deal":
+		return objectClassDeals, true
+	case "lead", "hs_lead":
+		return objectClassLeads, true
+	default:
+		return "", false
+	}
+}

--- a/backend/internal/modules/overlay/hubspot/webhook.go
+++ b/backend/internal/modules/overlay/hubspot/webhook.go
@@ -71,9 +71,9 @@ func ObjectClassForSubscription(subscriptionType string) (string, bool) {
 		return objectClassContacts, true
 	case "company":
 		return objectClassCompanies, true
-	case "deal":
+	case dealTarget:
 		return objectClassDeals, true
-	case "lead", "hs_lead":
+	case leadTarget, "hs_lead":
 		return objectClassLeads, true
 	default:
 		return "", false

--- a/backend/internal/modules/overlay/hubspot/webhook.go
+++ b/backend/internal/modules/overlay/hubspot/webhook.go
@@ -56,24 +56,50 @@ func VerifyWebhookSignature(clientSecret, method, uri string, body []byte, times
 	return hmac.Equal([]byte(expected), []byte(provided))
 }
 
+// HubSpot's webhook subscriptionType vocabulary: the object-type prefix before
+// the first dot, and the actions we act on. These are HubSpot's OWN wire names,
+// deliberately kept distinct from the canonical *Target constants
+// (mapping_hs.go) even where the spelling coincides — a future rename of a
+// canonical Margince type must never silently drop webhook routing, so the two
+// domains never share a constant.
+const (
+	subPrefixContact = "contact"
+	subPrefixCompany = "company"
+	subPrefixDeal    = "deal"
+	subPrefixLead    = "lead"
+	subPrefixHSLead  = "hs_lead"
+	// subActionDeletion is the one action this signal lane deliberately does
+	// NOT act on: a re-fetch of a deleted record 404s and would leave the
+	// mirror row lingering (a doomed job that looks handled). Incumbent-side
+	// deletions are the poller's deletion-feed's job (it tombstones), so a
+	// deletion subscription is dropped here rather than enqueued.
+	subActionDeletion = "deletion"
+)
+
 // ObjectClassForSubscription maps a HubSpot subscriptionType (e.g.
 // "contact.propertyChange", "deal.creation") to the incumbent object class the
 // mirror re-fetches through — the prefix before the first dot names the object
-// type. An unrecognized subscription (a type the mirror does not model) is
-// ok=false: the receiver drops it as an out-of-scope signal rather than
-// guessing a class. V1 covers the object types HubSpot webhooks deliver for
+// type. ok=false means "not re-fetchable through this lane": either an
+// unrecognized object type (a type the mirror does not model — dropped, never
+// guessed) OR a deletion action (owned by the poller's deletion feed, not a
+// re-fetch). V1 covers the object types HubSpot webhooks deliver for
 // (contact/company/deal/lead); the five engagement classes have no standard
 // webhook subscription and are healed by the poller.
 func ObjectClassForSubscription(subscriptionType string) (string, bool) {
-	prefix, _, _ := strings.Cut(subscriptionType, ".")
+	prefix, action, _ := strings.Cut(subscriptionType, ".")
+	if action == subActionDeletion {
+		// Presented honestly as NOT handled by the re-fetch lane; the poller's
+		// deletion feed tombstones incumbent-deleted records.
+		return "", false
+	}
 	switch prefix {
-	case "contact":
+	case subPrefixContact:
 		return objectClassContacts, true
-	case "company":
+	case subPrefixCompany:
 		return objectClassCompanies, true
-	case dealTarget:
+	case subPrefixDeal:
 		return objectClassDeals, true
-	case leadTarget, "hs_lead":
+	case subPrefixLead, subPrefixHSLead:
 		return objectClassLeads, true
 	default:
 		return "", false

--- a/backend/internal/modules/overlay/hubspot/webhook_test.go
+++ b/backend/internal/modules/overlay/hubspot/webhook_test.go
@@ -50,7 +50,7 @@ func TestObjectClassForSubscription(t *testing.T) {
 	cases := map[string]string{
 		"contact.propertyChange": objectClassContacts,
 		"company.creation":       objectClassCompanies,
-		"deal.deletion":          objectClassDeals,
+		"deal.creation":          objectClassDeals,
 		"lead.propertyChange":    objectClassLeads,
 		"hs_lead.creation":       objectClassLeads,
 	}
@@ -62,5 +62,13 @@ func TestObjectClassForSubscription(t *testing.T) {
 	}
 	if _, ok := ObjectClassForSubscription("ticket.creation"); ok {
 		t.Error("an unmodeled subscription type must be ok=false (dropped, not guessed)")
+	}
+	// A deletion is NOT re-fetchable through this lane — the poller's deletion
+	// feed tombstones it; presenting it as handled would enqueue a doomed Get.
+	if _, ok := ObjectClassForSubscription("deal.deletion"); ok {
+		t.Error("a deletion subscription must be ok=false (poller deletion feed owns it, not a re-fetch)")
+	}
+	if _, ok := ObjectClassForSubscription("contact.deletion"); ok {
+		t.Error("a contact deletion must be ok=false too (dropped from the re-fetch lane)")
 	}
 }

--- a/backend/internal/modules/overlay/hubspot/webhook_test.go
+++ b/backend/internal/modules/overlay/hubspot/webhook_test.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package hubspot
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"testing"
+)
+
+// sign reproduces HubSpot's v3 basis so a test can present a valid signature.
+func sign(secret, method, uri string, body []byte, ts string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(method))
+	mac.Write([]byte(uri))
+	mac.Write(body)
+	mac.Write([]byte(ts))
+	return base64.StdEncoding.EncodeToString(mac.Sum(nil))
+}
+
+func TestVerifyWebhookSignature(t *testing.T) {
+	const secret, method, uri, ts = "app-secret", "POST", "https://x.example/webhooks/hubspot", "1700000000000"
+	body := []byte(`[{"portalId":123}]`)
+	good := sign(secret, method, uri, body, ts)
+
+	if !VerifyWebhookSignature(secret, method, uri, body, ts, good) {
+		t.Error("a correctly-signed request must verify")
+	}
+	// Any deviation in secret, body, uri, or timestamp breaks the HMAC.
+	if VerifyWebhookSignature("wrong-secret", method, uri, body, ts, good) {
+		t.Error("a wrong app secret must not verify")
+	}
+	if VerifyWebhookSignature(secret, method, uri, []byte(`[{"portalId":999}]`), ts, good) {
+		t.Error("a tampered body must not verify")
+	}
+	if VerifyWebhookSignature(secret, method, uri, body, "1700000009999", good) {
+		t.Error("a swapped timestamp must not verify")
+	}
+	if VerifyWebhookSignature(secret, method, uri, body, ts, "") {
+		t.Error("an empty signature must not verify")
+	}
+	if VerifyWebhookSignature("", method, uri, body, ts, good) {
+		t.Error("an unconfigured secret must not verify (fail-closed)")
+	}
+}
+
+func TestObjectClassForSubscription(t *testing.T) {
+	cases := map[string]string{
+		"contact.propertyChange": objectClassContacts,
+		"company.creation":       objectClassCompanies,
+		"deal.deletion":          objectClassDeals,
+		"lead.propertyChange":    objectClassLeads,
+		"hs_lead.creation":       objectClassLeads,
+	}
+	for sub, want := range cases {
+		got, ok := ObjectClassForSubscription(sub)
+		if !ok || got != want {
+			t.Errorf("ObjectClassForSubscription(%q) = (%q, %v), want (%q, true)", sub, got, ok, want)
+		}
+	}
+	if _, ok := ObjectClassForSubscription("ticket.creation"); ok {
+		t.Error("an unmodeled subscription type must be ok=false (dropped, not guessed)")
+	}
+}

--- a/backend/internal/modules/overlay/hubspot/webhook_test.go
+++ b/backend/internal/modules/overlay/hubspot/webhook_test.go
@@ -71,4 +71,10 @@ func TestObjectClassForSubscription(t *testing.T) {
 	if _, ok := ObjectClassForSubscription("contact.deletion"); ok {
 		t.Error("a contact deletion must be ok=false too (dropped from the re-fetch lane)")
 	}
+	// HubSpot's GDPR hard-delete must ALSO be dropped from the re-fetch lane —
+	// re-fetching a privacy-deleted contact would 404 and leave its mirrored PII
+	// behind; the erasure path owns removing it, never a re-fetch.
+	if _, ok := ObjectClassForSubscription("contact.privacyDeletion"); ok {
+		t.Error("a privacyDeletion must be ok=false (never re-fetched; erasure path owns it)")
+	}
 }

--- a/backend/internal/modules/overlay/usermapseed_integration_test.go
+++ b/backend/internal/modules/overlay/usermapseed_integration_test.go
@@ -24,7 +24,20 @@ import (
 // owners to users, it never sweeps records. It lives inline (not
 // overlay/fake) because a package-overlay test cannot import a package
 // that imports overlay.
-type seedIncumbent struct{ owners map[string]string }
+type seedIncumbent struct {
+	owners   map[string]string
+	portalID string
+}
+
+// AccountID lets Connect record the portal binding (OVA-DDL-3) via its
+// incumbentAccountReader type-assertion; a blank portalID reports no account
+// (Connect stores NULL).
+func (s seedIncumbent) AccountID(context.Context) (string, error) {
+	if s.portalID == "" {
+		return "", fmt.Errorf("seedIncumbent: no portal id fixtured")
+	}
+	return s.portalID, nil
+}
 
 func (seedIncumbent) Name() string { return "hubspot" }
 func (seedIncumbent) Backfill(context.Context, string, string) (Page, error) {

--- a/backend/internal/modules/overlay/webhook_binding_integration_test.go
+++ b/backend/internal/modules/overlay/webhook_binding_integration_test.go
@@ -12,8 +12,11 @@ package overlay
 // cross-tenant), which is what makes the receiver refuse it.
 
 import (
+	"context"
 	"errors"
 	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
@@ -50,5 +53,30 @@ func TestWorkspaceForPortalBindsAndFailsClosed(t *testing.T) {
 	// A blank portal is likewise unbindable.
 	if _, err := WorkspaceForPortal(ctx, pool, "hubspot", ""); !errors.Is(err, apperrors.ErrNotFound) {
 		t.Errorf("WorkspaceForPortal(\"\"): err = %v, want ErrNotFound", err)
+	}
+}
+
+// TestWorkspaceForPortalIsFailClosedUnderAmbiguity connects TWO workspaces
+// carrying the same portal id (the schema does not make it globally unique), and
+// asserts the binding is fail-closed: an ambiguous portal binds to NEITHER
+// workspace (ErrNotFound), so a webhook for it is never mis-attributed to an
+// arbitrary tenant. Uses a portal id no other test connects, so only these two
+// workspaces match in the DB-wide fleet walk.
+func TestWorkspaceForPortalIsFailClosedUnderAmbiguity(t *testing.T) {
+	const shared = "portal-ambiguity-test"
+	connect := func() *pgxpool.Pool {
+		ctx, pool, _ := testWorkspaceCtx(t)
+		svc := NewService(pool, keyvault.NewMemory(), NewMirrorStore(pool, noOwnerEmails{})).
+			WithIncumbentFactory(func(_, _ string) Incumbent { return seedIncumbent{portalID: shared} })
+		if _, err := svc.Connect(ctx, ConnectInput{Incumbent: "hubspot", Region: "eu1", Token: "tok"}); err != nil {
+			t.Fatalf("Connect: %v", err)
+		}
+		return pool
+	}
+	pool := connect()
+	connect() // a second active connection carrying the SAME portal → ambiguous
+
+	if _, err := WorkspaceForPortal(context.Background(), pool, "hubspot", shared); !errors.Is(err, apperrors.ErrNotFound) {
+		t.Errorf("an ambiguous portal (two active connections) must fail closed (ErrNotFound), got %v", err)
 	}
 }

--- a/backend/internal/modules/overlay/webhook_binding_integration_test.go
+++ b/backend/internal/modules/overlay/webhook_binding_integration_test.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package overlay
+
+// The webhook-as-signal tenant binding's real-Postgres proof (OVA-DDL-3 /
+// OVA-WIRE-10 / AC-OV-13 a–b): Connect records the incumbent portal id, and
+// WorkspaceForPortal resolves ONLY the workspace whose active connection
+// carries that portal — an unbound portal is ErrNotFound (fail-closed, no
+// cross-tenant), which is what makes the receiver refuse it.
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+)
+
+// TestWorkspaceForPortalBindsAndFailsClosed connects a workspace with a portal
+// id, then asserts the binding resolves it — and that a foreign/unknown portal
+// resolves to nothing (fail-closed).
+func TestWorkspaceForPortalBindsAndFailsClosed(t *testing.T) {
+	ctx, pool, ws := testWorkspaceCtx(t)
+	store := NewMirrorStore(pool, noOwnerEmails{})
+	svc := NewService(pool, keyvault.NewMemory(), store).
+		WithIncumbentFactory(func(_, _ string) Incumbent {
+			return seedIncumbent{portalID: "portal-A"}
+		})
+
+	if _, err := svc.Connect(ctx, ConnectInput{Incumbent: "hubspot", Region: "eu1", Token: "tok"}); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+
+	got, err := WorkspaceForPortal(ctx, pool, "hubspot", "portal-A")
+	if err != nil {
+		t.Fatalf("WorkspaceForPortal(portal-A): %v", err)
+	}
+	if got.UUID != ws {
+		t.Errorf("WorkspaceForPortal(portal-A) = %s, want the connected workspace %s", got.UUID, ws)
+	}
+
+	// A portal bound to no active connection resolves fail-closed — the
+	// receiver rejects it, never ingesting cross-tenant.
+	if _, err := WorkspaceForPortal(ctx, pool, "hubspot", "portal-UNKNOWN"); !errors.Is(err, apperrors.ErrNotFound) {
+		t.Errorf("WorkspaceForPortal(unknown portal): err = %v, want ErrNotFound", err)
+	}
+	// A blank portal is likewise unbindable.
+	if _, err := WorkspaceForPortal(ctx, pool, "hubspot", ""); !errors.Is(err, apperrors.ErrNotFound) {
+		t.Errorf("WorkspaceForPortal(\"\"): err = %v, want ErrNotFound", err)
+	}
+}

--- a/backend/migrations/custom/20260723120000_overlay_incumbent_account_id.down.sql
+++ b/backend/migrations/custom/20260723120000_overlay_incumbent_account_id.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_incumbent_connection_account;
+ALTER TABLE incumbent_connection DROP COLUMN IF EXISTS incumbent_account_id;

--- a/backend/migrations/custom/20260723120000_overlay_incumbent_account_id.up.sql
+++ b/backend/migrations/custom/20260723120000_overlay_incumbent_account_id.up.sql
@@ -1,0 +1,20 @@
+-- 20260723120000_overlay_incumbent_account_id (OVA-DDL-3): record the
+-- incumbent's own account/portal id on the connection so an inbound webhook's
+-- portalId binds to THIS workspace (the webhook-as-signal tenant binding). The
+-- signature proves the sender (one app secret across all portals); the portal
+-- binding proves the tenant. Nullable because connections made before this
+-- column exist until they reconnect (or a backfill fills it); a webhook whose
+-- portal matches no active connection carrying it is rejected fail-closed, so a
+-- null here simply means "not bindable yet", never a cross-tenant leak.
+ALTER TABLE incumbent_connection ADD COLUMN IF NOT EXISTS incumbent_account_id text;
+
+-- The receiver resolves the workspace from an inbound portalId; a partial index
+-- over active connections that carry one keeps that per-workspace lookup a
+-- point read. NOT unique: enforcing global portal uniqueness would let one
+-- workspace's connect quietly fail because another workspace already recorded
+-- the same portal — the fail-closed binding handles a shared/duplicate portal
+-- by matching the active connection, and a genuine collision is an operator
+-- concern surfaced elsewhere, not a connect-blocking constraint here.
+CREATE INDEX IF NOT EXISTS idx_incumbent_connection_account
+  ON incumbent_connection (incumbent, incumbent_account_id)
+  WHERE status = 'active' AND incumbent_account_id IS NOT NULL;


### PR DESCRIPTION
## What

The HubSpot **webhook-as-signal** lane (OVA-WIRE-10): a change in HubSpot pushes a
signal that invalidates the affected mirror record and triggers a targeted re-fetch —
so an edit reaches the mirror without waiting for the next poll. Overlay stays a
governed *cached mirror*; the webhook is an **invalidation signal, never trusted
content** (the payload names *what* changed; the re-fetch reads the authoritative value
back through the normal read path).

Delivers **AC-OV-13 (a)–(d)**. The echo-suppression ledger (AC-OV-13 e / OVA-AC-3) is
the documented next slice — safe to land after this because re-fetching our own write is
a *read*, and reads fire no webhook, so no echo loop exists yet (the ledger removes the
redundant fetch, it is not a correctness gate for this slice).

## Slices in this PR

**Slice 1 — portal binding (OVA-DDL-3).** `Connect` records the incumbent `portalId`
(`incumbent_account_id`, nullable, best-effort via `/account-info/v3/details`).
`WorkspaceForPortal` resolves a portal → workspace through the sanctioned **rls-exempt
fleet-walk** (enumerate `x_sor_mode='overlay'` workspaces, probe each under its own GUC
for an *active* connection carrying that portal). An unbound/unknown/blank portal is
`ErrNotFound` — **fail-closed, no cross-tenant ingest**.

**Slice 2 — receiver + re-fetch worker.**
- `POST /webhooks/hubspot`: verify the **v3 request signature** (HMAC-SHA256 over
  `method+uri+body+timestamp`, constant-time), reject a **stale timestamp** (replay),
  bind `portalId`→workspace fail-closed, then enqueue a **coalesced** re-fetch per bound,
  mapped event (OVA-PARAM-10: unique-by-args, scheduled a 5s window ahead, so a burst of
  edits to one record collapses to one re-fetch). Mounted **only when the app secret is
  configured** (`--hubspot-app-secret`) — the route is absent otherwise, never an open
  unverified endpoint (the Gmail-push precedent).
- `overlayRefetchWorker`: resolves the workspace's active connection, builds a live
  adapter over its vaulted token, `Get`s the one record, and ingests it through the same
  **fenced, resolver-bound** store the poller uses (idempotent; the poller heals any gap).

## Write shape / safety
- No new mutation path bypasses the storekit shape; the worker rides the existing fenced
  `MirrorStore.Ingest` (tombstone / staleness / no-clobber-dirty guards intact).
- The receiver depends on small seams (`portalBinder` + `refetchEnqueuer`), so its
  verify→bind→enqueue decision is unit-tested with no Postgres or River.

## Tests
- Unit: v3 signature (secret/body/uri/timestamp tamper + fail-closed empty), subscription
  → object-class map (unmodeled dropped, not guessed); receiver verify→bind→enqueue incl.
  unbound-portal fail-closed, bad-signature 401, unmapped-drop, coalescing opts; worker
  malformed-workspace parse guard.
- Integration (real Postgres): `WorkspaceForPortal` binds + fails closed; **refetch worker
  end-to-end** — first signal creates the mirror row a mapped user reads, a fresher signal
  freshens it in place, a stale (out-of-order) signal is held back by the ingest staleness
  guard.

## Migration
`20260723120000_overlay_incumbent_account_id` — additive `ADD COLUMN incumbent_account_id`
+ partial index on active connections carrying a portal.

## Follow-ups (next slices)
- Echo-suppression ledger (OVA-DDL-6): our-write producer + echo-drop consumer +
  value-hash collision halt → AC-OV-13(e) / OVA-AC-3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds HubSpot webhook-as-signal so HubSpot changes trigger a signed, portal-bound, coalesced re-fetch that updates the overlay mirror within seconds. Delivers AC-OV-13 (a–d) for OVA-WIRE-10; drops deletion/privacyDeletion signals and fails closed on ambiguous portals.

- **New Features**
  - Portal binding: Connect fetches `portalId` before sealing the token and stores `incumbent_account_id` (nullable). `WorkspaceForPortal` binds portal→workspace and fails closed when none or ambiguous. The reconcile sweep backfills a NULL binding from the live adapter.
  - Webhook receiver: `POST /webhooks/hubspot` verifies v3 signature and a fresh timestamp, 413s oversized bodies, binds portal, drops deletions/unmapped, and enqueues a coalesced `overlay_refetch` (unique-by-args, 5s window). Mounted only with `WithOverlayWebhook`; 500 on transient bind/enqueue failures so HubSpot redelivers.
  - Refetch worker: `overlay_refetch` resolves the active connection, reads one record, and ingests via the fenced, resolver-bound store. Retries connection-level errors; staleness guard prevents regress. Registered in River; canonical class and `incumbentHubSpot` constants added.

- **Migration**
  - Adds `incumbent_connection.incumbent_account_id` (nullable) and partial index `idx_incumbent_connection_account` over active connections to support portal binding.

<sup>Written for commit 2c22db0066a576e20381596ac7c44b0b052f04d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HubSpot webhook support for securely receiving events and refreshing synced records.
  * Added automatic workspace binding using HubSpot portal IDs.
  * Added self-healing for missing portal bindings during reconciliation.
  * Improved connection setup and cleanup when retrieving HubSpot account details.

* **Bug Fixes**
  * Prevented stale, invalid, ambiguous, or unmapped webhook events from triggering updates.
  * Improved handling of connection failures and orphaned credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->