### PR TITLE
feat(extensions): serve a governed agent tool — the yogi reference unit (ADR-0069 §7)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ coverage.out
 !/extensions/.gitkeep
 !/extensions/approvals.lock
 !/extensions/de
+!/extensions/yogi
 
 # Compiled cmd binaries left in the module dir by `go build ./cmd/<role>`
 # (anchored so they never match the cmd/<role> source directories; the api

--- a/backend/internal/compose/extensions.go
+++ b/backend/internal/compose/extensions.go
@@ -29,6 +29,14 @@ func RegisterExtensions(exts []extension.Extension) error {
 			jurisdiction.Register(p)
 		}
 	}
+	// Adapt the handler-bearing tools to the core seam and stash them for
+	// every registry compose builds. Mapping failures are impossible after
+	// preflightTools, but stay fail-closed: a bad mapping aborts the boot.
+	tools, err := buildExtensionTools(exts)
+	if err != nil {
+		return err
+	}
+	setComposedTools(tools)
 	return nil
 }
 

--- a/backend/internal/compose/extensions.go
+++ b/backend/internal/compose/extensions.go
@@ -24,17 +24,19 @@ func RegisterExtensions(exts []extension.Extension) error {
 	if err := validateExtensionSet(exts); err != nil {
 		return err
 	}
+	// Do every fallible step before applying anything, so the whole
+	// reconciliation stays validate-then-apply: adapting the handler-bearing
+	// tools to the core seam can (in principle — preflightTools already
+	// precludes it, but this stays fail-closed) fail, and it must not fail
+	// with a jurisdiction pack already half-applied.
+	tools, err := buildExtensionTools(exts)
+	if err != nil {
+		return err
+	}
 	for _, e := range exts {
 		for _, p := range e.Jurisdictions {
 			jurisdiction.Register(p)
 		}
-	}
-	// Adapt the handler-bearing tools to the core seam and stash them for
-	// every registry compose builds. Mapping failures are impossible after
-	// preflightTools, but stay fail-closed: a bad mapping aborts the boot.
-	tools, err := buildExtensionTools(exts)
-	if err != nil {
-		return err
 	}
 	setComposedTools(tools)
 	return nil

--- a/backend/internal/compose/extensiontools.go
+++ b/backend/internal/compose/extensiontools.go
@@ -90,9 +90,9 @@ func registerComposedTools(registry *agents.Registry) {
 func mcpTier(t extension.Tier) (mcp.RiskTier, error) {
 	switch t {
 	case extension.TierAutoExecute:
-		return mcp.TierGreen, nil
+		return mcp.TierAutoExecute, nil
 	case extension.TierConfirmationRequired:
-		return mcp.TierYellow, nil
+		return mcp.TierConfirmationRequired, nil
 	}
 	return 0, fmt.Errorf("tier %q has no core mapping", string(t))
 }

--- a/backend/internal/compose/extensiontools.go
+++ b/backend/internal/compose/extensiontools.go
@@ -32,6 +32,15 @@ var composedTools struct {
 // Tiers and scopes were already grammar-checked by preflightTools; the
 // mappings below re-check them so a bad value fails the boot rather than
 // registering a mis-tiered tool.
+//
+// TRUST MODEL: every composed unit's handler-bearing tools are served at
+// their declared tier. There is no per-capability operator resolution yet
+// (an approvals record binding a decision to each tool's digest is a later
+// governance step), so the composed set IS the trust boundary: the vanilla
+// tree ships only first-party units, and an installation adds a unit
+// deliberately — the same trust a jurisdiction pack rides when it ships
+// enabled. A distributed, less-trusted unit is not the model until that
+// resolution lands.
 func buildExtensionTools(exts []extension.Extension) ([]mcp.Tool, error) {
 	var tools []mcp.Tool
 	for _, e := range exts {
@@ -43,9 +52,24 @@ func buildExtensionTools(exts []extension.Extension) ([]mcp.Tool, error) {
 			if err != nil {
 				return nil, fmt.Errorf("compose: extension %q, tool %q: %w", e.Name, tool.Name, err)
 			}
+			// A served 🟡 tool would be refused on every call: the admission
+			// gate stages a confirm-first approval only for tools that
+			// implement the registry's staging seam, which this data-only
+			// adapter cannot. Serving one is a dead capability, so reject it
+			// until the staging seam is wired. A handler-LESS 🟡 tool is fine
+			// — it is a manifest request, not served.
+			if tier == mcp.TierConfirmationRequired {
+				return nil, fmt.Errorf("compose: extension %q, tool %q: a served confirmation-required tool is not yet supported (its approvals could never be staged)", e.Name, tool.Name)
+			}
 			scope, err := mcpScope(tool.RequestedScope)
 			if err != nil {
 				return nil, fmt.Errorf("compose: extension %q, tool %q: %w", e.Name, tool.Name, err)
+			}
+			input := tool.InputSchema
+			if input == nil {
+				// MCP requires every tool to advertise an object input schema;
+				// a tool that takes no arguments still needs one.
+				input = json.RawMessage(`{"type":"object"}`)
 			}
 			tools = append(tools, extensionTool{
 				spec: mcp.ToolSpec{
@@ -53,8 +77,11 @@ func buildExtensionTools(exts []extension.Extension) ([]mcp.Tool, error) {
 					Version:       tool.Version,
 					RequiredScope: scope,
 					Tier:          tier,
-					InputSchema:   tool.InputSchema,
+					InputSchema:   input,
 					OutputSchema:  tool.OutputSchema,
+					// A tool requesting the send scope reaches outside the
+					// workspace — surface that in the operator inventory.
+					Egress: scope == principal.ScopeSend,
 				},
 				handle: tool.Handle,
 			})

--- a/backend/internal/compose/extensiontools.go
+++ b/backend/internal/compose/extensiontools.go
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/gradionhq/margince/backend/internal/modules/agents"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/mcp"
+	"github.com/gradionhq/margince/backend/pkg/extension"
+)
+
+// composedTools holds the handler-bearing tools of the composed extension
+// set, built once by RegisterExtensions at boot and registered into every
+// agents.Registry compose constructs — the same reconcile-at-boot shape a
+// jurisdiction pack follows (Register once, consulted by every engine).
+// It is written before any registry is built; the mutex guards the
+// read/write ordering, not concurrent registrations.
+var composedTools struct {
+	mu    sync.RWMutex
+	tools []mcp.Tool
+}
+
+// buildExtensionTools adapts every handler-bearing tool in the composed
+// set to the core mcp.Tool seam. A tool without a handler is inert (it
+// appears in the manifest but serves nothing), so it is skipped here.
+// Tiers and scopes were already grammar-checked by preflightTools; the
+// mappings below re-check them so a bad value fails the boot rather than
+// registering a mis-tiered tool.
+func buildExtensionTools(exts []extension.Extension) ([]mcp.Tool, error) {
+	var tools []mcp.Tool
+	for _, e := range exts {
+		for _, tool := range e.Tools {
+			if tool.Handle == nil {
+				continue
+			}
+			tier, err := mcpTier(tool.Tier)
+			if err != nil {
+				return nil, fmt.Errorf("compose: extension %q, tool %q: %w", e.Name, tool.Name, err)
+			}
+			scope, err := mcpScope(tool.RequestedScope)
+			if err != nil {
+				return nil, fmt.Errorf("compose: extension %q, tool %q: %w", e.Name, tool.Name, err)
+			}
+			tools = append(tools, extensionTool{
+				spec: mcp.ToolSpec{
+					Name:          tool.Name,
+					Version:       tool.Version,
+					RequiredScope: scope,
+					Tier:          tier,
+					InputSchema:   tool.InputSchema,
+					OutputSchema:  tool.OutputSchema,
+				},
+				handle: tool.Handle,
+			})
+		}
+	}
+	return tools, nil
+}
+
+// setComposedTools records the boot's tool set. Called once by
+// RegisterExtensions before any registry is built.
+func setComposedTools(tools []mcp.Tool) {
+	composedTools.mu.Lock()
+	defer composedTools.mu.Unlock()
+	composedTools.tools = tools
+}
+
+// registerComposedTools registers every composed extension tool into a
+// freshly built registry, so the MCP transport, the tool listing, and the
+// Surface-B runner all serve the same governed set. A tool whose name
+// collides with a core tool panics in Register — a genuine boot-time
+// wiring conflict, surfaced the same way a duplicate core tool is.
+func registerComposedTools(registry *agents.Registry) {
+	composedTools.mu.RLock()
+	defer composedTools.mu.RUnlock()
+	for _, t := range composedTools.tools {
+		registry.Register(t)
+	}
+}
+
+// mcpTier maps a published request tier to the core RiskTier. Only the two
+// static tiers are requestable — a dynamic tier needs a resolver, which a
+// static declaration cannot carry (extension.Tier.Validate enforces this).
+func mcpTier(t extension.Tier) (mcp.RiskTier, error) {
+	switch t {
+	case extension.TierAutoExecute:
+		return mcp.TierGreen, nil
+	case extension.TierConfirmationRequired:
+		return mcp.TierYellow, nil
+	}
+	return 0, fmt.Errorf("tier %q has no core mapping", string(t))
+}
+
+// mcpScope maps a published request scope to the core Passport scope.
+func mcpScope(s extension.Scope) (principal.Scope, error) {
+	switch s {
+	case extension.ScopeRead:
+		return principal.ScopeRead, nil
+	case extension.ScopeDraft:
+		return principal.ScopeDraft, nil
+	case extension.ScopeWrite:
+		return principal.ScopeWrite, nil
+	case extension.ScopeSend:
+		return principal.ScopeSend, nil
+	case extension.ScopeEnrich:
+		return principal.ScopeEnrich, nil
+	}
+	return "", fmt.Errorf("scope %q has no core mapping", string(s))
+}
+
+// extensionTool adapts a published tool declaration to the core mcp.Tool
+// seam: the derived spec drives the admission gate exactly as a core
+// tool's does, and Handle runs only after admission.
+type extensionTool struct {
+	spec   mcp.ToolSpec
+	handle extension.ToolHandler
+}
+
+func (t extensionTool) Spec() mcp.ToolSpec { return t.spec }
+
+func (t extensionTool) Handle(ctx context.Context, in json.RawMessage) (json.RawMessage, error) {
+	return t.handle(ctx, in)
+}

--- a/backend/internal/compose/extensiontools_test.go
+++ b/backend/internal/compose/extensiontools_test.go
@@ -59,7 +59,7 @@ func TestBuildExtensionToolsAdaptsHandlerBearingTools(t *testing.T) {
 		t.Fatalf("want 1 served tool (the inert one skipped), got %d", len(tools))
 	}
 	spec := tools[0].Spec()
-	if spec.Name != "served" || spec.Tier != mcp.TierGreen || spec.RequiredScope != principal.ScopeRead {
+	if spec.Name != "served" || spec.Tier != mcp.TierAutoExecute || spec.RequiredScope != principal.ScopeRead {
 		t.Fatalf("bad mapping: name=%q tier=%v scope=%v", spec.Name, spec.Tier, spec.RequiredScope)
 	}
 	if string(spec.InputSchema) != `{"type":"object"}` {

--- a/backend/internal/compose/extensiontools_test.go
+++ b/backend/internal/compose/extensiontools_test.go
@@ -67,6 +67,49 @@ func TestBuildExtensionToolsAdaptsHandlerBearingTools(t *testing.T) {
 	}
 }
 
+// TestBuildExtensionToolsRejectsServedConfirmationRequired: a
+// handler-bearing 🟡 tool cannot be served — the gate would refuse it on
+// every call with no way to stage an approval — so building the set fails
+// closed rather than registering a dead capability. (A handler-less 🟡
+// tool is a manifest request, not served, and is fine.)
+func TestBuildExtensionToolsRejectsServedConfirmationRequired(t *testing.T) {
+	_, err := buildExtensionTools([]extension.Extension{{
+		Name: "demo", Version: "1.0.0",
+		Tools: []extension.Tool{{
+			Name: "archive", Version: "1.0.0",
+			Tier: extension.TierConfirmationRequired, RequestedScope: extension.ScopeWrite,
+			Handle: func(context.Context, json.RawMessage) (json.RawMessage, error) { return nil, nil },
+		}},
+	}})
+	if err == nil || !strings.Contains(err.Error(), "confirmation-required tool is not yet supported") {
+		t.Fatalf("err = %v, want the served-🟡 rejection", err)
+	}
+}
+
+// TestBuildExtensionToolsDerivesEgressAndDefaultsSchema: a send-scoped tool
+// is marked egress, and a tool that omits an input schema still advertises
+// an object one (MCP requires it).
+func TestBuildExtensionToolsDerivesEgressAndDefaultsSchema(t *testing.T) {
+	tools, err := buildExtensionTools([]extension.Extension{{
+		Name: "demo", Version: "1.0.0",
+		Tools: []extension.Tool{{
+			Name: "push_webhook", Version: "1.0.0",
+			Tier: extension.TierAutoExecute, RequestedScope: extension.ScopeSend,
+			Handle: func(context.Context, json.RawMessage) (json.RawMessage, error) { return nil, nil },
+		}},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	spec := tools[0].Spec()
+	if !spec.Egress {
+		t.Error("a send-scoped tool must be marked egress")
+	}
+	if string(spec.InputSchema) != `{"type":"object"}` {
+		t.Errorf("a tool without a declared input schema must advertise an object one, got %s", spec.InputSchema)
+	}
+}
+
 // TestComposedToolServesThroughAdmission is the end-to-end proof: a
 // composed 🟢/read tool registers into the same registry and admission
 // gate as core tools, and Invoke reaches its handler.

--- a/backend/internal/compose/extensiontools_test.go
+++ b/backend/internal/compose/extensiontools_test.go
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/modules/agents"
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/authz"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/mcp"
+	"github.com/gradionhq/margince/backend/pkg/extension"
+)
+
+// fullSeat is a permissive gate authority: a full seat and empty RBAC, so
+// admission turns purely on the tool's tier and requested scope — enough
+// to exercise a 🟢 read tool end to end without a database.
+type fullSeat struct{}
+
+func (fullSeat) EffectiveRBAC(context.Context, ids.UUID, ids.UUID) (authz.RBAC, error) {
+	return authz.RBAC{}, nil
+}
+func (fullSeat) SeatType(context.Context, ids.UUID, ids.UUID) (principal.SeatType, error) {
+	return principal.SeatFull, nil
+}
+
+// TestBuildExtensionToolsAdaptsHandlerBearingTools: a tool with a handler
+// becomes an mcp.Tool with the mapped tier/scope and its declared schemas;
+// a handler-less (inert) tool is skipped — declared in the manifest, not
+// served.
+func TestBuildExtensionToolsAdaptsHandlerBearingTools(t *testing.T) {
+	exts := []extension.Extension{{
+		Name:    "demo",
+		Version: "1.0.0",
+		Tools: []extension.Tool{
+			{
+				Name: "served", Version: "1.0.0",
+				Tier: extension.TierAutoExecute, RequestedScope: extension.ScopeRead,
+				InputSchema: json.RawMessage(`{"type":"object"}`),
+				Handle: func(context.Context, json.RawMessage) (json.RawMessage, error) {
+					return json.RawMessage(`{"ok":true}`), nil
+				},
+			},
+			{Name: "inert", Version: "1.0.0", Tier: extension.TierConfirmationRequired, RequestedScope: extension.ScopeWrite},
+		},
+	}}
+	tools, err := buildExtensionTools(exts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tools) != 1 {
+		t.Fatalf("want 1 served tool (the inert one skipped), got %d", len(tools))
+	}
+	spec := tools[0].Spec()
+	if spec.Name != "served" || spec.Tier != mcp.TierGreen || spec.RequiredScope != principal.ScopeRead {
+		t.Fatalf("bad mapping: name=%q tier=%v scope=%v", spec.Name, spec.Tier, spec.RequiredScope)
+	}
+	if string(spec.InputSchema) != `{"type":"object"}` {
+		t.Fatalf("declared InputSchema not carried to the served spec: %s", spec.InputSchema)
+	}
+}
+
+// TestComposedToolServesThroughAdmission is the end-to-end proof: a
+// composed 🟢/read tool registers into the same registry and admission
+// gate as core tools, and Invoke reaches its handler.
+func TestComposedToolServesThroughAdmission(t *testing.T) {
+	tools, err := buildExtensionTools([]extension.Extension{{
+		Name:    "demo",
+		Version: "1.0.0",
+		Tools: []extension.Tool{{
+			Name: "give_quote", Version: "1.0.0",
+			Tier: extension.TierAutoExecute, RequestedScope: extension.ScopeRead,
+			Handle: func(context.Context, json.RawMessage) (json.RawMessage, error) {
+				return json.RawMessage(`{"quote":"it ain't over"}`), nil
+			},
+		}},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := agents.NewRegistry(nil, auth.NewGate(fullSeat{}))
+	for _, tool := range tools {
+		r.Register(tool)
+	}
+	ctx := principal.WithWorkspaceID(context.Background(), ids.NewV7())
+	ctx = principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalAgent, ID: "agent:t", OnBehalfOf: ids.NewV7(),
+		Scopes: principal.NewScopeSet(principal.ScopeRead),
+	})
+	out, err := r.Invoke(ctx, "give_quote", json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("a 🟢 read tool held by a read-scoped principal must admit: %v", err)
+	}
+	if !strings.Contains(string(out), "quote") {
+		t.Fatalf("handler result not returned: %s", out)
+	}
+}
+
+// TestComposedReadToolRequiresTheScope: admission is real — the same tool
+// is refused when the principal lacks the requested scope.
+func TestComposedReadToolRequiresTheScope(t *testing.T) {
+	tools, err := buildExtensionTools([]extension.Extension{{
+		Name: "demo", Version: "1.0.0",
+		Tools: []extension.Tool{{
+			Name: "give_quote", Version: "1.0.0",
+			Tier: extension.TierAutoExecute, RequestedScope: extension.ScopeRead,
+			Handle: func(context.Context, json.RawMessage) (json.RawMessage, error) {
+				return json.RawMessage(`{}`), nil
+			},
+		}},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := agents.NewRegistry(nil, auth.NewGate(fullSeat{}))
+	for _, tool := range tools {
+		r.Register(tool)
+	}
+	ctx := principal.WithWorkspaceID(context.Background(), ids.NewV7())
+	ctx = principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalAgent, ID: "agent:t", OnBehalfOf: ids.NewV7(),
+		Scopes: principal.NewScopeSet(), // no read scope
+	})
+	if _, err := r.Invoke(ctx, "give_quote", json.RawMessage(`{}`)); err == nil {
+		t.Fatal("a scopeless principal must not reach the handler")
+	}
+}

--- a/backend/internal/compose/extensiontools_test.go
+++ b/backend/internal/compose/extensiontools_test.go
@@ -26,6 +26,7 @@ type fullSeat struct{}
 func (fullSeat) EffectiveRBAC(context.Context, ids.UUID, ids.UUID) (authz.RBAC, error) {
 	return authz.RBAC{}, nil
 }
+
 func (fullSeat) SeatType(context.Context, ids.UUID, ids.UUID) (principal.SeatType, error) {
 	return principal.SeatFull, nil
 }

--- a/backend/internal/compose/registry.go
+++ b/backend/internal/compose/registry.go
@@ -75,6 +75,11 @@ func registryWithGate(pool *pgxpool.Pool, gate *auth.Gate, drafter activities.Em
 		gate:  consent.NewGate(consent.NewStore(pool)),
 		draft: drafter,
 	})
+	// The composed extension set's governed tools ride the same registry
+	// and admission gate as the core tools, registered last so a name that
+	// collides with a core verb fails loudly (RegisterExtensions stashed
+	// them at boot, before this ran).
+	registerComposedTools(registry)
 	return registry
 }
 

--- a/backend/internal/modules/agents/stdio.go
+++ b/backend/internal/modules/agents/stdio.go
@@ -146,11 +146,21 @@ func (s *StdioServer) toolList() []map[string]any {
 		case mcp.TierDynamic:
 			tier = "auto_execute, except moves that close a deal require human approval"
 		}
-		tools = append(tools, map[string]any{
+		desc := fmt.Sprintf("Autonomy: %s. Requires passport scope %q.", tier, spec.RequiredScope)
+		if spec.OpenAPIOp != "" {
+			// Extension tools map to no crm.yaml operation; only append the
+			// clause when there is one, rather than rendering "Maps to .".
+			desc += fmt.Sprintf(" Maps to %s.", spec.OpenAPIOp)
+		}
+		tool := map[string]any{
 			"name":        spec.Name,
-			"description": fmt.Sprintf("Autonomy: %s. Requires passport scope %q. Maps to %s.", tier, spec.RequiredScope, spec.OpenAPIOp),
+			"description": desc,
 			"inputSchema": spec.InputSchema,
-		})
+		}
+		if spec.OutputSchema != nil {
+			tool["outputSchema"] = spec.OutputSchema
+		}
+		tools = append(tools, tool)
 	}
 	return tools
 }

--- a/backend/pkg/extension/tool.go
+++ b/backend/pkg/extension/tool.go
@@ -4,9 +4,22 @@
 package extension
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"regexp"
 )
+
+// ToolHandler runs a governed tool after admission. It is the extension's
+// BEHAVIOR — the one part of a Tool that is not static declaration — so
+// the manifest generator skips it (behavior cannot be derived from the
+// AST, and the manifest records only the governed request). A tool
+// declared without a handler is inert: it appears in the manifest but the
+// boot registers only handler-bearing tools into the live surface. The
+// signature mirrors the core mcp.Tool.Handle the boot adapts it to;
+// arguments and result are the raw JSON the tool's own typed decode
+// validates.
+type ToolHandler func(ctx context.Context, in json.RawMessage) (json.RawMessage, error)
 
 // Tier is the risk tier an extension REQUESTS for a governed tool:
 // auto-execute runs without confirmation, confirmation-
@@ -95,6 +108,22 @@ type Tool struct {
 	// resolves into an effective grant, not a fact; once effective, a call
 	// admits only when the granting principal holds it.
 	RequestedScope Scope
+
+	// InputSchema and OutputSchema are the JSON Schema documents the served
+	// tool advertises through tools/list (mapped onto mcp.ToolSpec). They
+	// are client-facing DOCUMENTATION: the agent reads them to shape a
+	// call, but the tool's own typed decode — not a generic schema check —
+	// enforces its invariants. Optional, and both must be valid JSON when
+	// set. They are not part of the §5 governance descriptor, so the
+	// manifest generator does not read them.
+	InputSchema  json.RawMessage
+	OutputSchema json.RawMessage
+
+	// Handle is the tool's behavior. It is optional: a nil Handle declares
+	// the tool (it still appears in the manifest as a governed request) but
+	// leaves it inert; boot serves only handler-bearing tools. The manifest
+	// generator does not read it — behavior is not a static declaration.
+	Handle ToolHandler
 }
 
 // Validate enforces the tool's grammar and vocabularies. Boot
@@ -112,6 +141,12 @@ func (t Tool) Validate() error {
 	}
 	if err := t.RequestedScope.Validate(); err != nil {
 		return fmt.Errorf("tool %q: %w", t.Name, err)
+	}
+	if t.InputSchema != nil && !json.Valid(t.InputSchema) {
+		return fmt.Errorf("tool %q: InputSchema is not valid JSON", t.Name)
+	}
+	if t.OutputSchema != nil && !json.Valid(t.OutputSchema) {
+		return fmt.Errorf("tool %q: OutputSchema is not valid JSON", t.Name)
 	}
 	return nil
 }

--- a/backend/pkg/extension/tool.go
+++ b/backend/pkg/extension/tool.go
@@ -87,13 +87,15 @@ var toolNameGrammar = regexp.MustCompile(`^[a-z][a-z0-9]*(_[a-z0-9]+)*$`)
 
 // Tool is a governed agent tool the unit contributes to the agent
 // surface: a named operation running at a requested risk Tier and
-// requiring Scopes. It is a GOVERNED capability — its tier and scopes are
-// requests an operator resolves, recorded in the unit manifest.
+// requiring a Scope, both recorded in the unit manifest.
 //
-// Declaring a tool records the request; SERVING it — registration into
-// the agent surface behind the operator-approval gate — arrives in a
-// later slice. Until then a declared tool is inert: present in the
-// manifest, not yet callable.
+// A handler-bearing tool is SERVED — registered into the same agent
+// registry and admission gate as the core tools, callable at its declared
+// tier. A handler-less tool is inert: it still appears in the manifest as
+// a governed request, but nothing runs. Resolving a requested tier against
+// a durable operator decision is a later governance step; today a composed
+// first-party unit serves at its declared tier, the way the jurisdiction
+// packs ship enabled.
 type Tool struct {
 	// Name is the tool verb, lower snake_case, unique within the unit.
 	Name string
@@ -126,9 +128,11 @@ type Tool struct {
 	Handle ToolHandler
 }
 
-// Validate enforces the tool's grammar and vocabularies. Boot
-// registration refuses the composed set on a violation, and the manifest
-// generator raises the same error at gen time.
+// Validate enforces the tool's grammar and vocabularies. The name, tier,
+// and scope checks run at BOTH gen time (the manifest generator) and boot;
+// the schema checks run only at boot, because the manifest does not carry
+// the schemas (the generator never reads them). Boot registration refuses
+// the composed set on any violation.
 func (t Tool) Validate() error {
 	if !toolNameGrammar.MatchString(t.Name) {
 		return fmt.Errorf("tool name %q is not a valid verb (lower snake_case, e.g. qualify_lead)", t.Name)
@@ -142,11 +146,29 @@ func (t Tool) Validate() error {
 	if err := t.RequestedScope.Validate(); err != nil {
 		return fmt.Errorf("tool %q: %w", t.Name, err)
 	}
-	if t.InputSchema != nil && !json.Valid(t.InputSchema) {
-		return fmt.Errorf("tool %q: InputSchema is not valid JSON", t.Name)
+	if err := validateSchemaObject("InputSchema", t.InputSchema); err != nil {
+		return fmt.Errorf("tool %q: %w", t.Name, err)
 	}
-	if t.OutputSchema != nil && !json.Valid(t.OutputSchema) {
-		return fmt.Errorf("tool %q: OutputSchema is not valid JSON", t.Name)
+	if err := validateSchemaObject("OutputSchema", t.OutputSchema); err != nil {
+		return fmt.Errorf("tool %q: %w", t.Name, err)
+	}
+	return nil
+}
+
+// validateSchemaObject checks a declared schema, when present, is a JSON
+// object rooted at `"type": "object"` — the shape MCP requires of a tool's
+// input/output schema in tools/list. Absent (nil) is allowed: the served
+// spec defaults a missing input schema to an empty object.
+func validateSchemaObject(field string, raw json.RawMessage) error {
+	if raw == nil {
+		return nil
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return fmt.Errorf("%s must be a JSON object", field)
+	}
+	if doc["type"] != "object" {
+		return fmt.Errorf(`%s must be a JSON Schema object rooted at "type":"object"`, field)
 	}
 	return nil
 }

--- a/backend/pkg/extension/tool.go
+++ b/backend/pkg/extension/tool.go
@@ -114,7 +114,7 @@ type Tool struct {
 	// are client-facing DOCUMENTATION: the agent reads them to shape a
 	// call, but the tool's own typed decode — not a generic schema check —
 	// enforces its invariants. Optional, and both must be valid JSON when
-	// set. They are not part of the §5 governance descriptor, so the
+	// set. They are not part of the governance descriptor, so the
 	// manifest generator does not read them.
 	InputSchema  json.RawMessage
 	OutputSchema json.RawMessage

--- a/backend/pkg/extension/tool_test.go
+++ b/backend/pkg/extension/tool_test.go
@@ -3,7 +3,10 @@
 
 package extension
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
 
 func TestTierValidate(t *testing.T) {
 	for _, valid := range []Tier{TierAutoExecute, TierConfirmationRequired} {
@@ -49,6 +52,9 @@ func TestToolValidate(t *testing.T) {
 		{"tier not requestable", Tool{Name: "ping", Version: "1.0.0", Tier: "dynamic", RequestedScope: ScopeRead}},
 		{"scope outside vocabulary", Tool{Name: "ping", Version: "1.0.0", Tier: TierAutoExecute, RequestedScope: "admin"}},
 		{"missing scope", Tool{Name: "ping", Version: "1.0.0", Tier: TierAutoExecute}},
+		{"non-object input schema", Tool{Name: "ping", Version: "1.0.0", Tier: TierAutoExecute, RequestedScope: ScopeRead, InputSchema: json.RawMessage(`"scalar"`)}},
+		{"input schema not type object", Tool{Name: "ping", Version: "1.0.0", Tier: TierAutoExecute, RequestedScope: ScopeRead, InputSchema: json.RawMessage(`{"type":"array"}`)}},
+		{"malformed output schema", Tool{Name: "ping", Version: "1.0.0", Tier: TierAutoExecute, RequestedScope: ScopeRead, OutputSchema: json.RawMessage(`{bad`)}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/backend/tools/gen-composition/astreader.go
+++ b/backend/tools/gen-composition/astreader.go
@@ -209,6 +209,10 @@ func (r *unitReader) readTool(elt ast.Expr, ext string) (riskTierRequest, error)
 			tier, err = r.constValue(kv.Value, ext)
 		case "RequestedScope":
 			scope, err = r.constValue(kv.Value, ext)
+		case "Handle", "InputSchema", "OutputSchema":
+			// Behavior and client-facing I/O docs — recognized and skipped.
+			// The manifest records the §5 governance descriptor, not the
+			// tool's code or its advertised schemas.
 		default:
 			err = r.errAt(kv, "Tool field %s is not derivable by this generator", key.Name)
 		}

--- a/backend/tools/gen-composition/astreader.go
+++ b/backend/tools/gen-composition/astreader.go
@@ -211,7 +211,7 @@ func (r *unitReader) readTool(elt ast.Expr, ext string) (riskTierRequest, error)
 			scope, err = r.constValue(kv.Value, ext)
 		case "Handle", "InputSchema", "OutputSchema":
 			// Behavior and client-facing I/O docs — recognized and skipped.
-			// The manifest records the §5 governance descriptor, not the
+			// The manifest records the governance descriptor, not the
 			// tool's code or its advertised schemas.
 		default:
 			err = r.errAt(kv, "Tool field %s is not derivable by this generator", key.Name)

--- a/extensions/yogi/go.mod
+++ b/extensions/yogi/go.mod
@@ -1,0 +1,3 @@
+module github.com/gradionhq/margince/extensions/yogi
+
+go 1.26.5

--- a/extensions/yogi/manifest.generated.json
+++ b/extensions/yogi/manifest.generated.json
@@ -2,7 +2,7 @@
   "schema": 1,
   "name": "yogi",
   "version": "1.0.0",
-  "autonomy_tiers": [
+  "risk_tiers": [
     {
       "id": "tool/yogi_quote",
       "operation": "agent.tool.invoke",

--- a/extensions/yogi/manifest.generated.json
+++ b/extensions/yogi/manifest.generated.json
@@ -1,0 +1,16 @@
+{
+  "schema": 1,
+  "name": "yogi",
+  "version": "1.0.0",
+  "autonomy_tiers": [
+    {
+      "id": "tool/yogi_quote",
+      "operation": "agent.tool.invoke",
+      "scopes": [
+        "read"
+      ],
+      "tier": "green",
+      "digest": "sha256:d24318cb19acc99cc603b0e2022fd53f01b59e928b165631acc3abdd5d69836e"
+    }
+  ]
+}

--- a/extensions/yogi/yogi.go
+++ b/extensions/yogi/yogi.go
@@ -3,7 +3,7 @@
 
 // Package yogi is a first-party reference extension shipping one governed
 // agent tool: yogi_quote returns a random Yogi Berra quote. It exercises
-// the whole served-tool path (ADR-0069) — the published Tool declaration,
+// the whole served-tool path — the published Tool declaration,
 // the manifest's autonomy-tier request, and boot registration into the
 // same MCP registry and admission gate the core tools ride. The tool is
 // read-only with no arguments, so it requests the 🟢 auto-execute tier and
@@ -18,7 +18,7 @@ import (
 	"github.com/gradionhq/margince/backend/pkg/extension"
 )
 
-// New returns the unit's declaration (the ADR-0069 §4 constructor
+// New returns the unit's declaration (the constructor
 // contract the generated composition calls).
 func New() extension.Extension {
 	return extension.Extension{

--- a/extensions/yogi/yogi.go
+++ b/extensions/yogi/yogi.go
@@ -29,9 +29,19 @@ func New() extension.Extension {
 			Version:        "1.0.0",
 			Tier:           extension.TierAutoExecute,
 			RequestedScope: extension.ScopeRead,
-			InputSchema:    json.RawMessage(`{"type":"object","additionalProperties":false}`),
-			OutputSchema:   json.RawMessage(`{"type":"object","properties":{"quote":{"type":"string"}},"required":["quote"],"additionalProperties":false}`),
-			Handle:         quote,
+			InputSchema: json.RawMessage(`{
+  "type": "object",
+  "additionalProperties": false
+}`),
+			OutputSchema: json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "quote": {"type": "string"}
+  },
+  "required": ["quote"],
+  "additionalProperties": false
+}`),
+			Handle: quote,
 		}},
 	}
 }

--- a/extensions/yogi/yogi.go
+++ b/extensions/yogi/yogi.go
@@ -4,7 +4,7 @@
 // Package yogi is a first-party reference extension shipping one governed
 // agent tool: yogi_quote returns a random Yogi Berra quote. It exercises
 // the whole served-tool path — the published Tool declaration,
-// the manifest's autonomy-tier request, and boot registration into the
+// the manifest's risk-tier request, and boot registration into the
 // same MCP registry and admission gate the core tools ride. The tool is
 // read-only with no arguments, so it requests the 🟢 auto-execute tier and
 // the read scope: nothing to confirm, nothing to mutate.

--- a/extensions/yogi/yogi.go
+++ b/extensions/yogi/yogi.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// Package yogi is a first-party reference extension shipping one governed
+// agent tool: yogi_quote returns a random Yogi Berra quote. It exercises
+// the whole served-tool path (ADR-0069) — the published Tool declaration,
+// the manifest's autonomy-tier request, and boot registration into the
+// same MCP registry and admission gate the core tools ride. The tool is
+// read-only with no arguments, so it requests the 🟢 auto-execute tier and
+// the read scope: nothing to confirm, nothing to mutate.
+package yogi
+
+import (
+	"context"
+	"encoding/json"
+	"math/rand/v2"
+
+	"github.com/gradionhq/margince/backend/pkg/extension"
+)
+
+// New returns the unit's declaration (the ADR-0069 §4 constructor
+// contract the generated composition calls).
+func New() extension.Extension {
+	return extension.Extension{
+		Name:    "yogi",
+		Version: "1.0.0",
+		Tools: []extension.Tool{{
+			Name:           "yogi_quote",
+			Version:        "1.0.0",
+			Tier:           extension.TierAutoExecute,
+			RequestedScope: extension.ScopeRead,
+			InputSchema:    json.RawMessage(`{"type":"object","additionalProperties":false}`),
+			OutputSchema:   json.RawMessage(`{"type":"object","properties":{"quote":{"type":"string"}},"required":["quote"],"additionalProperties":false}`),
+			Handle:         quote,
+		}},
+	}
+}
+
+// quotes are attributed to Yogi Berra. A short fixed set keeps the tool
+// self-contained — no store, no network, nothing to govern beyond read.
+var quotes = []string{
+	"It ain't over till it's over.",
+	"When you come to a fork in the road, take it.",
+	"It's like déjà vu all over again.",
+	"No one goes there nowadays, it's too crowded.",
+	"You can observe a lot by just watching.",
+	"The future ain't what it used to be.",
+	"We made too many wrong mistakes.",
+	"You've got to be very careful if you don't know where you are going, because you might not get there.",
+	"Always go to other people's funerals, otherwise they won't come to yours.",
+	"If the world were perfect, it wouldn't be.",
+}
+
+// quoteOut is the tool's result shape (mirrors OutputSchema).
+type quoteOut struct {
+	Quote string `json:"quote"`
+}
+
+// quote returns a random quote. It takes no arguments — the input is
+// ignored rather than decoded — so there is nothing to validate and
+// nothing that can fail but the JSON encode.
+func quote(_ context.Context, _ json.RawMessage) (json.RawMessage, error) {
+	return json.Marshal(quoteOut{Quote: quotes[rand.IntN(len(quotes))]})
+}

--- a/extensions/yogi/yogi_test.go
+++ b/extensions/yogi/yogi_test.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package yogi
+
+import (
+	"context"
+	"encoding/json"
+	"slices"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/pkg/extension"
+)
+
+// TestNewDeclaresAServedTool: the unit declares exactly one governed tool,
+// it passes the published grammar, and it carries a handler (so boot
+// serves it rather than leaving it inert).
+func TestNewDeclaresAServedTool(t *testing.T) {
+	ext := New()
+	if len(ext.Tools) != 1 {
+		t.Fatalf("want one tool, got %d", len(ext.Tools))
+	}
+	tool := ext.Tools[0]
+	if err := tool.Validate(); err != nil {
+		t.Fatalf("declared tool must validate: %v", err)
+	}
+	if tool.Handle == nil {
+		t.Fatal("a served tool must carry a handler")
+	}
+	if tool.Tier != extension.TierAutoExecute || tool.RequestedScope != extension.ScopeRead {
+		t.Fatalf("a read-only quote tool should request 🟢/read, got tier=%q scope=%q", tool.Tier, tool.RequestedScope)
+	}
+	if !json.Valid(tool.OutputSchema) {
+		t.Fatal("OutputSchema must be valid JSON")
+	}
+}
+
+// TestQuoteReturnsAKnownQuote: the handler ignores its input and returns
+// one of the declared quotes, shaped as the OutputSchema promises.
+func TestQuoteReturnsAKnownQuote(t *testing.T) {
+	out, err := New().Tools[0].Handle(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got quoteOut
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("result is not the declared shape: %v", err)
+	}
+	if !slices.Contains(quotes, got.Quote) {
+		t.Fatalf("handler returned an unknown quote: %q", got.Quote)
+	}
+}


### PR DESCRIPTION
**Stacked on #231** (the manifest slice — this branches off `feat/ext-manifest`, so review #231 first; the diff here is just the serving work). Rebases onto the base as it moves.

First *served* governed capability: an extension tool that is actually callable through the same MCP registry and admission gate the core tools ride.

## What
- **Published handler seam** — `extension.Tool` gains `Handle` (behavior) and `InputSchema`/`OutputSchema` (client-facing docs advertised via `tools/list`), all stdlib-typed so the published surface stays off `internal/`. The manifest reader **skips** them — behavior and I/O docs aren't part of the §5 governance descriptor.
- **compose adapter + registration** — each handler-bearing tool is adapted to the core `mcp.Tool` seam (mapping the published `Tier`/`Scope` → `RiskTier`/`principal.Scope`) and registered in `registryWithGate`, the one chokepoint every registry (HTTP MCP transport, stdio, runner) funnels through. So extension tools are governed **identically** to core tools.
- **Governance scope** — first-party units serve at their declared tier, exactly as `de`'s jurisdiction ships enabled. Third-party `approvals.lock` (§7 operator resolution) stays a later slice; a handler-less tool remains inert (declared in the manifest, not served).
- **`extensions/yogi`** — a read-only 🟢 tool returning a random Yogi Berra quote, enabled by default: the reference served extension.

## Verification
`make check` green. Tests: adapter mapping + inert-tool skip; **end-to-end `Invoke` through the real admission gate** (admitted with the scope, refused without); the yogi handler returns a known quote.

## Notes
- Serving without full §7 resolution is the deliberate first-party path (matches `de`), not an oversight.
- `InputSchema`/`OutputSchema` are hand-written here; struct-reflected schemas (invopop/jsonschema) compose cleanly since the manifest skips these fields — deferred to keep the published surface stdlib-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serve governed extension tools through the same MCP registry and admission gate as core tools, and add `extensions/yogi`, a read-only tool that returns a random Yogi Berra quote.

- **New Features**
  - `extension.Tool`: added `Handle`, `InputSchema`, `OutputSchema` (stdlib-typed); manifest/generator skip these fields.
  - Compose adapts handler-bearing tools to `mcp.Tool` and registers them via the single `agents.Registry` chokepoint; handler-less tools are inert; name collisions with core verbs fail at boot.
  - `extensions/yogi`: `yogi_quote` (auto-execute/read) with multiline schemas and a simple handler. Tests cover mapping and admission allow/deny.

- **Bug Fixes**
  - Reject serving confirmation-required tools until approval staging is supported.
  - Derive `Egress` from the send scope; default a missing input schema to `{"type":"object"}`; require declared schemas be JSON objects rooted at `type: "object"`. MCP `tools/list` now includes `outputSchema` and omits an empty “Maps to …” clause.
  - Boot now validate-then-apply: build tool adapters before applying jurisdiction packs to avoid half-applied state on failure. Removed remaining spec/ADR citations from extension comments.

<sup>Written for commit c980d79db63b6791af32952362a161982ea7d10e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

