### PR TITLE
feat(overlay): echo-suppression our-write ledger (OVA-DDL-6 / AC-OV-13e) — final webhook slice

### DIFF
--- a/backend/internal/compose/jobs_overlay.go
+++ b/backend/internal/compose/jobs_overlay.go
@@ -84,6 +84,18 @@ func (w *overlayRefetchWorker) Work(ctx context.Context, job *river.Job[OverlayR
 	if conn.Incumbent != incumbentHubSpot {
 		return nil
 	}
+	// A mirror halted by a ledger value-hash collision (OVA-AC-3) refuses all
+	// sync until an operator clears it — do not spend an incumbent read or
+	// ingest against a mirror we no longer trust. This closes the gap where a
+	// re-fetch enqueued before the halt (coalesced 5s ahead) would otherwise
+	// still run: the halt is re-checked here, at execution.
+	if halted, err := overlay.NewWriteLedger(w.pool).Halted(wsCtx); err != nil {
+		return fmt.Errorf("overlay refetch: reading the mirror-halt flag: %w", err)
+	} else if halted {
+		w.log.WarnContext(wsCtx, "overlay refetch: mirror is halted (ledger collision), skipping",
+			"workspace", job.Args.Workspace, "class", job.Args.IncumbentClass, "id", job.Args.ExternalID)
+		return nil
+	}
 	token, err := w.vault.Get(wsCtx, conn.Workspace, conn.CredentialRef)
 	if err != nil {
 		return fmt.Errorf("overlay refetch: resolving the vaulted token: %w", err)

--- a/backend/internal/compose/jobs_overlay.go
+++ b/backend/internal/compose/jobs_overlay.go
@@ -85,10 +85,10 @@ func (w *overlayRefetchWorker) Work(ctx context.Context, job *river.Job[OverlayR
 		return nil
 	}
 	// A mirror halted by a ledger value-hash collision (OVA-AC-3) refuses all
-	// sync until an operator clears it — do not spend an incumbent read or
-	// ingest against a mirror we no longer trust. This closes the gap where a
-	// re-fetch enqueued before the halt (coalesced 5s ahead) would otherwise
-	// still run: the halt is re-checked here, at execution.
+	// sync — do not spend an incumbent read or ingest against a mirror we no
+	// longer trust (the halt is cleared by disconnect today). This closes the
+	// gap where a re-fetch enqueued before the halt (coalesced 5s ahead) would
+	// otherwise still run: the halt is re-checked here, at execution.
 	if halted, err := overlay.NewWriteLedger(w.pool).Halted(wsCtx); err != nil {
 		return fmt.Errorf("overlay refetch: reading the mirror-halt flag: %w", err)
 	} else if halted {

--- a/backend/internal/compose/overlay.go
+++ b/backend/internal/compose/overlay.go
@@ -130,6 +130,9 @@ func NewOverlayProvider(pool *pgxpool.Pool, meter *overlaybudget.Meter, resolveI
 	// that passes nil (the sorDispatch, which is wired later by WithKeyvault)
 	// leaves it unset here and SetOverlayIncumbentResolver installs it then.
 	p.SetFreshnessIncumbentResolver(resolveIncumbent)
+	// Wire the echo-suppression ledger's producer half (OVA-DDL-6): each
+	// write-back opens ledger entries so the webhook receiver can drop its echo.
+	p.SetWriteLedger(overlay.NewWriteLedger(pool))
 	return p
 }
 

--- a/backend/internal/compose/overlay.go
+++ b/backend/internal/compose/overlay.go
@@ -132,7 +132,7 @@ func NewOverlayProvider(pool *pgxpool.Pool, meter *overlaybudget.Meter, resolveI
 	p.SetFreshnessIncumbentResolver(resolveIncumbent)
 	// Wire the echo-suppression ledger's producer half (OVA-DDL-6): each
 	// write-back opens ledger entries so the webhook receiver can drop its echo.
-	p.SetWriteLedger(overlay.NewWriteLedger(pool))
+	p.SetWriteLedger(overlay.NewWriteLedger(pool), slog.Default())
 	return p
 }
 

--- a/backend/internal/compose/overlaywebhook.go
+++ b/backend/internal/compose/overlaywebhook.go
@@ -222,7 +222,8 @@ func (h *hubspotWebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 			case verdict == overlay.ClassCollision:
 				// The mirror was just halted inside Classify. Reflect it in the
 				// per-request cache so the rest of the batch is skipped, and do
-				// NOT re-fetch — an operator must review before sync resumes.
+				// NOT re-fetch — the mirror stays halted (cleared by disconnect
+				// today) rather than risk mis-suppressing on state we distrust.
 				haltByWS[wsID.String()] = true
 				h.log.ErrorContext(wsCtx, "overlay webhook: write-ledger value-hash collision — mirror halted",
 					"workspace", wsID.String(), "id", ev.ObjectIDString(), "property", ev.PropertyName)

--- a/backend/internal/compose/overlaywebhook.go
+++ b/backend/internal/compose/overlaywebhook.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/jobs"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
 // webhookMaxBody caps the request body the receiver reads: HubSpot batches are
@@ -67,11 +68,25 @@ type refetchEnqueuer interface {
 	Enqueue(ctx context.Context, args river.JobArgs, opts *river.InsertOpts) error
 }
 
+// echoClassifier classifies one inbound propertyChange against the our-write
+// ledger (OVA-DDL-6). overlay.WriteLedger.Classify satisfies it; a seam so the
+// receiver's suppression decision is unit-testable without Postgres.
+type echoClassifier func(ctx context.Context, objectClass, externalID, property, value string) (overlay.Classification, error)
+
+// haltChecker reports whether a workspace's mirror is halted (a ledger collision
+// tripped the fail-safe). overlay.WriteLedger.Halted satisfies it.
+type haltChecker func(ctx context.Context) (bool, error)
+
 type hubspotWebhookHandler struct {
 	bind         portalBinder
 	enqueue      refetchEnqueuer
 	clientSecret string
 	log          *slog.Logger
+	// classify and halted are the echo-suppression ledger seams (OVA-DDL-6).
+	// Both nil when no ledger is wired — the receiver then skips suppression and
+	// the halt gate (the receiver still functions; it just cannot drop echoes).
+	classify echoClassifier
+	halted   haltChecker
 }
 
 // WithOverlayWebhook mounts POST /webhooks/hubspot. An empty client secret (or
@@ -81,6 +96,7 @@ func WithOverlayWebhook(inserter *jobs.Runner, clientSecret string) Option {
 		if clientSecret == "" || inserter == nil {
 			return
 		}
+		ledger := overlay.NewWriteLedger(pool)
 		s.overlayWebhook = &hubspotWebhookHandler{
 			bind: func(ctx context.Context, incumbent, portalID string) (ids.WorkspaceID, error) {
 				return overlay.WorkspaceForPortal(ctx, pool, incumbent, portalID)
@@ -88,6 +104,8 @@ func WithOverlayWebhook(inserter *jobs.Runner, clientSecret string) Option {
 			enqueue:      inserter,
 			clientSecret: clientSecret,
 			log:          s.log,
+			classify:     ledger.Classify,
+			halted:       ledger.Halted,
 		}
 	}
 }
@@ -140,9 +158,9 @@ func (h *hubspotWebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	// cross-tenant write; an unmapped subscription type is likewise dropped.
 	// A per-event enqueue failure answers 500 so HubSpot redelivers (the
 	// enqueue is unique-by-args, so a redelivery cannot double-run).
-	portalWS := map[string]string{} // portalId → workspace id ("" = unbound)
+	cache := map[string]portalResolution{}
 	for _, ev := range events {
-		wsID, ok, err := h.resolveWorkspace(r, portalWS, ev)
+		wsID, ok, err := h.resolveWorkspace(r, cache, ev)
 		if err != nil {
 			// A transient binding failure (DB/transaction) is NOT an unbound
 			// portal: answer 500 so HubSpot redelivers rather than dropping the
@@ -156,13 +174,54 @@ func (h *hubspotWebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		if !ok {
 			continue
 		}
+		// Every ledger read/write is workspace-scoped (RLS): bind the resolved
+		// tenant onto the context for the halt gate and the echo classification.
+		wsCtx := principal.WithWorkspaceID(r.Context(), wsID.UUID)
+		// Halt gate (OVA-AC-3 fail-safe): a mirror halted by a prior ledger
+		// collision refuses further signals until an operator clears it, rather
+		// than risk mis-suppressing on a mirror we no longer trust.
+		if h.halted != nil {
+			halted, err := h.halted(wsCtx)
+			if err != nil {
+				h.log.ErrorContext(wsCtx, "overlay webhook: reading the mirror-halt flag", "err", err)
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			if halted {
+				h.log.WarnContext(wsCtx, "overlay webhook: mirror is halted (ledger collision), ignoring the signal",
+					"workspace", wsID.String())
+				continue
+			}
+		}
 		class, ok := hubspot.ObjectClassForSubscription(ev.SubscriptionType)
 		if !ok {
 			continue
 		}
-		if err := h.enqueueRefetch(r, wsID, class, ev.ObjectIDString()); err != nil {
+		// Echo suppression (OVA-DDL-6): a propertyChange carrying a property we
+		// just wrote (same value, inside the open window) is our own echo — drop
+		// it so the overlay does not re-fetch its own write. A collision halts
+		// the mirror (inside Classify) and is never silently suppressed.
+		if h.classify != nil && ev.PropertyName != "" {
+			switch verdict, err := h.classify(wsCtx, class, ev.ObjectIDString(), ev.PropertyName, ev.PropertyValue); {
+			case err != nil:
+				h.log.ErrorContext(wsCtx, "overlay webhook: classifying against the write ledger",
+					"workspace", wsID.String(), "id", ev.ObjectIDString(), "property", ev.PropertyName, "err", err)
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			case verdict == overlay.ClassEcho:
+				continue // our own write-back echoing — suppress, no re-fetch
+			case verdict == overlay.ClassCollision:
+				// The mirror was just halted inside Classify. Do NOT suppress and
+				// do NOT re-fetch: the next iteration's halt gate skips the rest;
+				// an operator must review before sync resumes.
+				h.log.ErrorContext(wsCtx, "overlay webhook: write-ledger value-hash collision — mirror halted",
+					"workspace", wsID.String(), "id", ev.ObjectIDString(), "property", ev.PropertyName)
+				continue
+			}
+		}
+		if err := h.enqueueRefetch(r, wsID.String(), class, ev.ObjectIDString()); err != nil {
 			h.log.ErrorContext(r.Context(), "overlay webhook: enqueueing re-fetch",
-				"workspace", wsID, "class", class, "id", ev.ObjectIDString(), "err", err)
+				"workspace", wsID.String(), "class", class, "id", ev.ObjectIDString(), "err", err)
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
@@ -170,32 +229,40 @@ func (h *hubspotWebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	w.WriteHeader(http.StatusNoContent)
 }
 
+// portalResolution is the per-request cache entry for one portal id: the
+// resolved workspace and whether the portal is bound at all (an unbound portal
+// is cached so a batch of its events costs one fleet-walk, never re-probed).
+type portalResolution struct {
+	ws    ids.WorkspaceID
+	bound bool
+}
+
 // resolveWorkspace returns the workspace bound to the event's portal (via the
 // per-request cache). ok=false with a nil error is a genuinely unbound portal
 // (fail-closed — skip, ingest nothing); a non-nil error is a transient lookup
 // failure the caller turns into a 500 so the signal is redelivered rather than
 // lost. Only ErrNotFound is treated as unbound; every other error propagates.
-func (h *hubspotWebhookHandler) resolveWorkspace(r *http.Request, cache map[string]string, ev hubspot.WebhookEvent) (string, bool, error) {
+func (h *hubspotWebhookHandler) resolveWorkspace(r *http.Request, cache map[string]portalResolution, ev hubspot.WebhookEvent) (ids.WorkspaceID, bool, error) {
 	portal := ev.PortalIDString()
-	if ws, seen := cache[portal]; seen {
-		return ws, ws != "", nil
+	if got, seen := cache[portal]; seen {
+		return got.ws, got.bound, nil
 	}
 	ws, err := h.bind(r.Context(), incumbentHubSpot, portal)
 	if err != nil {
 		if !errors.Is(err, apperrors.ErrNotFound) {
 			// Transient failure — do NOT cache it (a redelivery must re-probe)
 			// and do NOT treat it as unbound; propagate so the caller 500s.
-			return "", false, err
+			return ids.WorkspaceID{}, false, err
 		}
 		// A genuinely unbound portal: cache the miss so a batch of events for
 		// the same portal costs one fleet-walk, and never treat it as a tenant.
-		cache[portal] = ""
+		cache[portal] = portalResolution{}
 		h.log.WarnContext(r.Context(), "overlay webhook: portal not bound to an active connection, ignoring",
 			"portal", portal)
-		return "", false, nil
+		return ids.WorkspaceID{}, false, nil
 	}
-	cache[portal] = ws.String()
-	return ws.String(), true, nil
+	cache[portal] = portalResolution{ws: ws, bound: true}
+	return ws, true, nil
 }
 
 // enqueueRefetch schedules the coalesced re-fetch job.

--- a/backend/internal/compose/overlaywebhook.go
+++ b/backend/internal/compose/overlaywebhook.go
@@ -159,6 +159,7 @@ func (h *hubspotWebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	// A per-event enqueue failure answers 500 so HubSpot redelivers (the
 	// enqueue is unique-by-args, so a redelivery cannot double-run).
 	cache := map[string]portalResolution{}
+	haltByWS := map[string]bool{} // per-request halt cache (workspace → halted)
 	for _, ev := range events {
 		wsID, ok, err := h.resolveWorkspace(r, cache, ev)
 		if err != nil {
@@ -174,28 +175,36 @@ func (h *hubspotWebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		if !ok {
 			continue
 		}
+		// Recognize what this lane handles BEFORE any ledger transaction: an
+		// unmapped object type or a deletion-family action is dropped here, so a
+		// dropped event never opens a halt/ledger transaction or risks a 500.
+		class, ok := hubspot.ObjectClassForSubscription(ev.SubscriptionType)
+		if !ok {
+			continue
+		}
 		// Every ledger read/write is workspace-scoped (RLS): bind the resolved
 		// tenant onto the context for the halt gate and the echo classification.
 		wsCtx := principal.WithWorkspaceID(r.Context(), wsID.UUID)
 		// Halt gate (OVA-AC-3 fail-safe): a mirror halted by a prior ledger
-		// collision refuses further signals until an operator clears it, rather
-		// than risk mis-suppressing on a mirror we no longer trust.
+		// collision refuses further signals. Cached per workspace per request so
+		// a batch reads the flag once; a mid-batch collision flips the cache
+		// immediately so the rest of the batch is skipped without re-querying.
 		if h.halted != nil {
-			halted, err := h.halted(wsCtx)
-			if err != nil {
-				h.log.ErrorContext(wsCtx, "overlay webhook: reading the mirror-halt flag", "err", err)
-				w.WriteHeader(http.StatusInternalServerError)
-				return
+			halted, cached := haltByWS[wsID.String()]
+			if !cached {
+				halted, err = h.halted(wsCtx)
+				if err != nil {
+					h.log.ErrorContext(wsCtx, "overlay webhook: reading the mirror-halt flag", "err", err)
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+				haltByWS[wsID.String()] = halted
 			}
 			if halted {
 				h.log.WarnContext(wsCtx, "overlay webhook: mirror is halted (ledger collision), ignoring the signal",
 					"workspace", wsID.String())
 				continue
 			}
-		}
-		class, ok := hubspot.ObjectClassForSubscription(ev.SubscriptionType)
-		if !ok {
-			continue
 		}
 		// Echo suppression (OVA-DDL-6): a propertyChange carrying a property we
 		// just wrote (same value, inside the open window) is our own echo — drop
@@ -211,9 +220,10 @@ func (h *hubspotWebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 			case verdict == overlay.ClassEcho:
 				continue // our own write-back echoing — suppress, no re-fetch
 			case verdict == overlay.ClassCollision:
-				// The mirror was just halted inside Classify. Do NOT suppress and
-				// do NOT re-fetch: the next iteration's halt gate skips the rest;
-				// an operator must review before sync resumes.
+				// The mirror was just halted inside Classify. Reflect it in the
+				// per-request cache so the rest of the batch is skipped, and do
+				// NOT re-fetch — an operator must review before sync resumes.
+				haltByWS[wsID.String()] = true
 				h.log.ErrorContext(wsCtx, "overlay webhook: write-ledger value-hash collision — mirror halted",
 					"workspace", wsID.String(), "id", ev.ObjectIDString(), "property", ev.PropertyName)
 				continue

--- a/backend/internal/compose/overlaywebhook_test.go
+++ b/backend/internal/compose/overlaywebhook_test.go
@@ -71,23 +71,52 @@ func TestWebhookReceiverIngestsGenuineChange(t *testing.T) {
 	}
 }
 
-// TestWebhookReceiverCollisionEnqueuesNothing (OVA-AC-3 collision half): a
-// propertyChange the ledger flags as a value-hash collision halts the mirror
-// (inside Classify) and enqueues NO re-fetch — never silently suppressed, never
-// blindly re-fetched against a mirror we no longer trust.
-func TestWebhookReceiverCollisionEnqueuesNothing(t *testing.T) {
+// TestWebhookReceiverCollisionHaltsTheRestOfTheBatch (OVA-AC-3 collision + halt
+// gate): a value-hash collision enqueues nothing AND — because Classify halts
+// the mirror — every later event in the same batch is skipped by the halt gate,
+// so a genuine change riding behind a collision is not ingested against a mirror
+// we no longer trust. The classify seam flips the (real-ledger) halt state that
+// the halted seam then reports, mirroring production.
+func TestWebhookReceiverCollisionHaltsTheRestOfTheBatch(t *testing.T) {
 	enq := &capturingEnqueuer{}
 	h := newTestWebhookHandler(enq, ids.New[ids.WorkspaceKind]())
+	halted := false
 	h.classify = func(context.Context, string, string, string, string) (overlay.Classification, error) {
+		halted = true // Classify halts the mirror on a collision
 		return overlay.ClassCollision, nil
 	}
+	h.halted = func(context.Context) (bool, error) { return halted, nil }
+
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, signedWebhookRequest(t, propertyChangePayload))
+	// Two propertyChange events for the same record: the first collides (halts),
+	// the second is a would-be genuine change that must be skipped.
+	h.ServeHTTP(rec, signedWebhookRequest(t,
+		`[{"portalId":777,"objectId":42,"subscriptionType":"contact.propertyChange","propertyName":"firstname","propertyValue":"Ada"},`+
+			`{"portalId":777,"objectId":43,"subscriptionType":"contact.propertyChange","propertyName":"lastname","propertyValue":"Lovelace"}]`))
 	if rec.Code != http.StatusNoContent {
 		t.Fatalf("status = %d, want 204", rec.Code)
 	}
 	if len(enq.jobs) != 0 {
-		t.Errorf("a collision must enqueue nothing (mirror halted), got %d jobs", len(enq.jobs))
+		t.Errorf("a collision must enqueue nothing and halt the rest of the batch, got %d jobs", len(enq.jobs))
+	}
+}
+
+// TestWebhookReceiverAnswers500OnClassifyError (safety-critical seam): a ledger
+// classification failure (DB/store trouble) answers 500 so HubSpot redelivers,
+// and enqueues nothing — never guessing echo-vs-genuine on a failed lookup.
+func TestWebhookReceiverAnswers500OnClassifyError(t *testing.T) {
+	enq := &capturingEnqueuer{}
+	h := newTestWebhookHandler(enq, ids.New[ids.WorkspaceKind]())
+	h.classify = func(context.Context, string, string, string, string) (overlay.Classification, error) {
+		return overlay.ClassGenuine, errors.New("ledger unavailable")
+	}
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, signedWebhookRequest(t, propertyChangePayload))
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500 so HubSpot redelivers", rec.Code)
+	}
+	if len(enq.jobs) != 0 {
+		t.Errorf("a classify failure must enqueue nothing, got %d jobs", len(enq.jobs))
 	}
 }
 

--- a/backend/internal/compose/overlaywebhook_test.go
+++ b/backend/internal/compose/overlaywebhook_test.go
@@ -20,9 +20,93 @@ import (
 
 	"github.com/riverqueue/river"
 
+	"github.com/gradionhq/margince/backend/internal/modules/overlay"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
+
+// propertyChangePayload is a validly-shaped propertyChange webhook body for the
+// bound portal, carrying the property fields the echo ledger keys on.
+const propertyChangePayload = `[{"portalId":777,"objectId":42,"subscriptionType":"contact.propertyChange","propertyName":"firstname","propertyValue":"Ada"}]`
+
+// TestWebhookReceiverSuppressesEcho (AC-OV-13 e / OVA-AC-3 echo-drop): a
+// propertyChange the ledger classifies as our own write-back echo enqueues NO
+// re-fetch — the overlay does not sync-loop on its own write.
+func TestWebhookReceiverSuppressesEcho(t *testing.T) {
+	enq := &capturingEnqueuer{}
+	h := newTestWebhookHandler(enq, ids.New[ids.WorkspaceKind]())
+	h.classify = func(context.Context, string, string, string, string) (overlay.Classification, error) {
+		return overlay.ClassEcho, nil
+	}
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, signedWebhookRequest(t, propertyChangePayload))
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", rec.Code)
+	}
+	if len(enq.jobs) != 0 {
+		t.Errorf("an echo must be suppressed (no re-fetch), got %d jobs", len(enq.jobs))
+	}
+}
+
+// TestWebhookReceiverIngestsGenuineChange (OVA-AC-3 non-echo-ingest): a
+// propertyChange the ledger classifies as a genuine third-party change is NOT
+// dropped — it enqueues a re-fetch.
+func TestWebhookReceiverIngestsGenuineChange(t *testing.T) {
+	enq := &capturingEnqueuer{}
+	ws := ids.New[ids.WorkspaceKind]()
+	h := newTestWebhookHandler(enq, ws)
+	h.classify = func(context.Context, string, string, string, string) (overlay.Classification, error) {
+		return overlay.ClassGenuine, nil
+	}
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, signedWebhookRequest(t, propertyChangePayload))
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", rec.Code)
+	}
+	if len(enq.jobs) != 1 {
+		t.Fatalf("a genuine change must enqueue one re-fetch, got %d", len(enq.jobs))
+	}
+	if enq.jobs[0].Workspace != ws.String() || enq.jobs[0].IncumbentClass != "contacts" {
+		t.Errorf("enqueued %+v, want a contacts re-fetch for the bound workspace", enq.jobs[0])
+	}
+}
+
+// TestWebhookReceiverCollisionEnqueuesNothing (OVA-AC-3 collision half): a
+// propertyChange the ledger flags as a value-hash collision halts the mirror
+// (inside Classify) and enqueues NO re-fetch — never silently suppressed, never
+// blindly re-fetched against a mirror we no longer trust.
+func TestWebhookReceiverCollisionEnqueuesNothing(t *testing.T) {
+	enq := &capturingEnqueuer{}
+	h := newTestWebhookHandler(enq, ids.New[ids.WorkspaceKind]())
+	h.classify = func(context.Context, string, string, string, string) (overlay.Classification, error) {
+		return overlay.ClassCollision, nil
+	}
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, signedWebhookRequest(t, propertyChangePayload))
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", rec.Code)
+	}
+	if len(enq.jobs) != 0 {
+		t.Errorf("a collision must enqueue nothing (mirror halted), got %d jobs", len(enq.jobs))
+	}
+}
+
+// TestWebhookReceiverRefusesHaltedMirror (OVA-AC-3 halt gate): once the mirror
+// is halted, the receiver ingests nothing for that workspace — the fail-safe
+// holds across signals until an operator clears it.
+func TestWebhookReceiverRefusesHaltedMirror(t *testing.T) {
+	enq := &capturingEnqueuer{}
+	h := newTestWebhookHandler(enq, ids.New[ids.WorkspaceKind]())
+	h.halted = func(context.Context) (bool, error) { return true, nil }
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, signedWebhookRequest(t, propertyChangePayload))
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204 (accepted-but-ignored)", rec.Code)
+	}
+	if len(enq.jobs) != 0 {
+		t.Errorf("a halted mirror must ingest nothing, got %d jobs", len(enq.jobs))
+	}
+}
 
 // capturingEnqueuer records the re-fetch jobs the handler enqueues, standing in
 // for the real River inserter so the handler's verify→bind→enqueue decision is

--- a/backend/internal/modules/overlay/backfill_integration_test.go
+++ b/backend/internal/modules/overlay/backfill_integration_test.go
@@ -75,12 +75,12 @@ func (p *pagingCompanies) OwnerEmail(_ context.Context, _ string) (string, error
 }
 
 func (p *pagingCompanies) Owners(context.Context) ([]OwnerRef, error) { return nil, nil }
-func (p *pagingCompanies) Create(context.Context, string, map[string]any) (Record, error) {
-	return Record{}, fmt.Errorf("pagingCompanies: Create is not fixtured")
+func (p *pagingCompanies) Create(context.Context, string, map[string]any) (WriteResult, error) {
+	return WriteResult{}, fmt.Errorf("pagingCompanies: Create is not fixtured")
 }
 
-func (p *pagingCompanies) Update(context.Context, string, string, map[string]any, time.Time) (Record, error) {
-	return Record{}, fmt.Errorf("pagingCompanies: Update is not fixtured")
+func (p *pagingCompanies) Update(context.Context, string, string, map[string]any, time.Time) (WriteResult, error) {
+	return WriteResult{}, fmt.Errorf("pagingCompanies: Update is not fixtured")
 }
 
 func (p *pagingCompanies) Archive(context.Context, string, string, time.Time) error {

--- a/backend/internal/modules/overlay/fake/adapter.go
+++ b/backend/internal/modules/overlay/fake/adapter.go
@@ -284,9 +284,9 @@ func (a *Adapter) Owners(_ context.Context) ([]overlay.OwnerRef, error) {
 // bucketing uses a purpose-built double instead of this fake.
 //
 //craft:ignore naked-any fields is the canonical field bag the seam carries; the any is inherent to the decoded shape
-func (a *Adapter) Create(_ context.Context, canonicalClass string, fields map[string]any) (overlay.Record, error) {
+func (a *Adapter) Create(_ context.Context, canonicalClass string, fields map[string]any) (overlay.WriteResult, error) {
 	if len(fields) == 0 {
-		return overlay.Record{}, fmt.Errorf("fake: cannot create a %s with no fields", canonicalClass)
+		return overlay.WriteResult{}, fmt.Errorf("fake: cannot create a %s with no fields", canonicalClass)
 	}
 	rec := overlay.Record{
 		ExternalID:  a.nextWriteID(),
@@ -295,7 +295,11 @@ func (a *Adapter) Create(_ context.Context, canonicalClass string, fields map[st
 		ModifiedAt:  writeEpoch.Add(time.Duration(a.writeSeq) * time.Second),
 	}
 	a.records[canonicalClass] = append(a.records[canonicalClass], rec)
-	return rec, nil
+	// The fake does no incumbent mapping, so its "written properties" are the
+	// canonical fields stringified and its object class is the canonical one —
+	// a producer/consumer pair driven by the fake stays internally consistent
+	// (the real adapter uses HubSpot names on both sides).
+	return overlay.WriteResult{Record: rec, IncumbentClass: canonicalClass, WrittenProps: stringifyProps(fields)}, nil
 }
 
 // nextWriteID advances writeSeq to an id no existing record (seeded or
@@ -324,17 +328,18 @@ func (a *Adapter) nextWriteID() string {
 // passing no fields gets the record unchanged.
 //
 //craft:ignore naked-any fields is the canonical patch bag the seam carries; the any is inherent to the decoded shape
-func (a *Adapter) Update(_ context.Context, canonicalClass, externalID string, fields map[string]any, baseline time.Time) (overlay.Record, error) {
+func (a *Adapter) Update(_ context.Context, canonicalClass, externalID string, fields map[string]any, baseline time.Time) (overlay.WriteResult, error) {
 	recs := a.records[canonicalClass]
 	for i := range recs {
 		if recs[i].ExternalID != externalID {
 			continue
 		}
 		if len(fields) == 0 {
-			return recs[i], nil
+			// Read-only-only patch: nothing written, so no ledger entry.
+			return overlay.WriteResult{Record: recs[i], IncumbentClass: canonicalClass}, nil
 		}
 		if recs[i].ModifiedAt.After(baseline) {
-			return overlay.Record{}, apperrors.ErrVersionSkew
+			return overlay.WriteResult{}, apperrors.ErrVersionSkew
 		}
 		merged := make(map[string]any, len(recs[i].Fields)+len(fields))
 		for k, v := range recs[i].Fields {
@@ -350,9 +355,20 @@ func (a *Adapter) Update(_ context.Context, canonicalClass, externalID string, f
 		}
 		recs[i].Fields = merged
 		recs[i].ModifiedAt = next
-		return recs[i], nil
+		return overlay.WriteResult{Record: recs[i], IncumbentClass: canonicalClass, WrittenProps: stringifyProps(fields)}, nil
 	}
-	return overlay.Record{}, fmt.Errorf("fake: no %s record with external id %s to update", canonicalClass, externalID)
+	return overlay.WriteResult{}, fmt.Errorf("fake: no %s record with external id %s to update", canonicalClass, externalID)
+}
+
+// stringifyProps renders a canonical field bag as the property→value string map
+// the write ledger records — the fake's stand-in for an adapter's mapped
+// incumbent properties.
+func stringifyProps(fields map[string]any) map[string]string {
+	props := make(map[string]string, len(fields))
+	for k, v := range fields {
+		props[k] = fmt.Sprintf("%v", v)
+	}
+	return props
 }
 
 // Archive removes canonicalClass's record for externalID after the same

--- a/backend/internal/modules/overlay/fake/adapter_test.go
+++ b/backend/internal/modules/overlay/fake/adapter_test.go
@@ -202,15 +202,20 @@ func TestFakeWriteBackRoundTrip(t *testing.T) {
 	f := fake.New()
 	ctx := context.Background()
 
-	created, err := f.Create(ctx, "person", map[string]any{"first_name": "Ada"})
+	createRes, err := f.Create(ctx, "person", map[string]any{"first_name": "Ada"})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
+	created := createRes.Record
 	if created.ExternalID == "" || created.ObjectClass != "person" {
 		t.Fatalf("Create returned %+v, want a stamped person record", created)
 	}
 	if created.Fields["first_name"] != "Ada" {
 		t.Errorf("Create fields = %+v, want first_name=Ada", created.Fields)
+	}
+	// The write reports the properties it wrote (the echo-ledger producer input).
+	if createRes.WrittenProps["first_name"] != "Ada" {
+		t.Errorf("Create WrittenProps = %+v, want first_name=Ada", createRes.WrittenProps)
 	}
 
 	// A patch older than the stored record's ModifiedAt is refused
@@ -220,21 +225,29 @@ func TestFakeWriteBackRoundTrip(t *testing.T) {
 	}
 
 	// A patch at or after the record's baseline merges and re-stamps.
-	updated, err := f.Update(ctx, "person", created.ExternalID, map[string]any{"first_name": "Ada2"}, created.ModifiedAt)
+	updateRes, err := f.Update(ctx, "person", created.ExternalID, map[string]any{"first_name": "Ada2"}, created.ModifiedAt)
 	if err != nil {
 		t.Fatalf("Update: %v", err)
 	}
+	updated := updateRes.Record
 	if updated.Fields["first_name"] != "Ada2" {
 		t.Errorf("Update fields = %+v, want first_name=Ada2", updated.Fields)
 	}
+	if updateRes.WrittenProps["first_name"] != "Ada2" {
+		t.Errorf("Update WrittenProps = %+v, want first_name=Ada2", updateRes.WrittenProps)
+	}
 
-	// An empty patch returns the record unchanged.
-	same, err := f.Update(ctx, "person", created.ExternalID, nil, updated.ModifiedAt)
+	// An empty patch returns the record unchanged and writes nothing (no ledger).
+	sameRes, err := f.Update(ctx, "person", created.ExternalID, nil, updated.ModifiedAt)
 	if err != nil {
 		t.Fatalf("no-op Update: %v", err)
 	}
+	same := sameRes.Record
 	if same.Fields["first_name"] != "Ada2" {
 		t.Errorf("no-op Update should return the record unchanged, got %+v", same.Fields)
+	}
+	if len(sameRes.WrittenProps) != 0 {
+		t.Errorf("a read-only-only Update must write nothing, got WrittenProps %+v", sameRes.WrittenProps)
 	}
 
 	// Archiving with a baseline older than the record is refused (drift).

--- a/backend/internal/modules/overlay/fake/adapter_test.go
+++ b/backend/internal/modules/overlay/fake/adapter_test.go
@@ -247,7 +247,7 @@ func TestFakeWriteBackRoundTrip(t *testing.T) {
 		t.Errorf("no-op Update should return the record unchanged, got %+v", same.Fields)
 	}
 	if len(sameRes.WrittenProps) != 0 {
-		t.Errorf("a read-only-only Update must write nothing, got WrittenProps %+v", sameRes.WrittenProps)
+		t.Errorf("a read-only-fields Update must write nothing, got WrittenProps %+v", sameRes.WrittenProps)
 	}
 
 	// Archiving with a baseline older than the record is refused (drift).

--- a/backend/internal/modules/overlay/freshness_integration_test.go
+++ b/backend/internal/modules/overlay/freshness_integration_test.go
@@ -77,12 +77,12 @@ func (s *stubIncumbent) OwnerEmail(context.Context, string) (string, error) {
 }
 
 func (s *stubIncumbent) Owners(context.Context) ([]OwnerRef, error) { return nil, nil }
-func (s *stubIncumbent) Create(context.Context, string, map[string]any) (Record, error) {
-	return Record{}, fmt.Errorf("stubIncumbent: Create is not fixtured")
+func (s *stubIncumbent) Create(context.Context, string, map[string]any) (WriteResult, error) {
+	return WriteResult{}, fmt.Errorf("stubIncumbent: Create is not fixtured")
 }
 
-func (s *stubIncumbent) Update(context.Context, string, string, map[string]any, time.Time) (Record, error) {
-	return Record{}, fmt.Errorf("stubIncumbent: Update is not fixtured")
+func (s *stubIncumbent) Update(context.Context, string, string, map[string]any, time.Time) (WriteResult, error) {
+	return WriteResult{}, fmt.Errorf("stubIncumbent: Update is not fixtured")
 }
 
 func (s *stubIncumbent) Archive(context.Context, string, string, time.Time) error {

--- a/backend/internal/modules/overlay/hubspot/adapter_writes.go
+++ b/backend/internal/modules/overlay/hubspot/adapter_writes.go
@@ -27,24 +27,30 @@ import (
 // incumbent object — that is an honest error, never a POST of a blank record.
 //
 //craft:ignore naked-any fields is the JSON-decoded canonical bag from the datasource seam; the any is inherent to the decoded shape
-func (a *Adapter) Create(ctx context.Context, canonicalClass string, fields map[string]any) (overlay.Record, error) {
+func (a *Adapter) Create(ctx context.Context, canonicalClass string, fields map[string]any) (overlay.WriteResult, error) {
 	mw, err := mapWrite(canonicalClass, fields, false)
 	if err != nil {
-		return overlay.Record{}, err
+		return overlay.WriteResult{}, err
 	}
 	if len(mw.Props) == 0 {
-		return overlay.Record{}, fmt.Errorf("overlay: cannot create a %s in HubSpot — every supplied field is read-only or derived (nothing to write)", canonicalClass)
+		return overlay.WriteResult{}, fmt.Errorf("overlay: cannot create a %s in HubSpot — every supplied field is read-only or derived (nothing to write)", canonicalClass)
 	}
 	created, err := a.client.CreateObject(ctx, mw.ObjectClass, mw.Props)
 	if err != nil {
-		return overlay.Record{}, err
+		return overlay.WriteResult{}, err
 	}
 	// Re-read the created record through the SAME path a sync read uses
 	// (a.Get requests the baseline watermark property), so the mirrored
 	// record's ModifiedAt is the object-specific baseline (lastmodifieddate /
 	// hs_lastmodifieddate / hs_timestamp) the drift check compares against —
 	// never HubSpot's top-level updatedAt, which can diverge from it.
-	return a.Get(ctx, mw.ObjectClass, mirrorActivityExternalID(mw.ObjectClass, created.ID))
+	rec, err := a.Get(ctx, mw.ObjectClass, mirrorActivityExternalID(mw.ObjectClass, created.ID))
+	if err != nil {
+		return overlay.WriteResult{}, err
+	}
+	// WrittenProps carries the exact HubSpot properties+values written so the
+	// echo-suppression ledger (OVA-DDL-6) recognizes this write's echo webhook.
+	return overlay.WriteResult{Record: rec, IncumbentClass: mw.ObjectClass, WrittenProps: mw.Props}, nil
 }
 
 // Update applies a canonical patch to an existing record after the
@@ -57,10 +63,10 @@ func (a *Adapter) Create(ctx context.Context, canonicalClass string, fields map[
 // OVA-MAP-7).
 //
 //craft:ignore naked-any fields is the JSON-decoded canonical patch from the datasource seam; the any is inherent to the decoded shape
-func (a *Adapter) Update(ctx context.Context, canonicalClass, externalID string, fields map[string]any, baseline time.Time) (overlay.Record, error) {
+func (a *Adapter) Update(ctx context.Context, canonicalClass, externalID string, fields map[string]any, baseline time.Time) (overlay.WriteResult, error) {
 	mw, err := mapWrite(canonicalClass, fields, true)
 	if err != nil {
-		return overlay.Record{}, err
+		return overlay.WriteResult{}, err
 	}
 	// An activity's engagement class is fixed by its mirror id's "<class>:"
 	// prefix (OVA-MAP-7); a patch that carried a changed/inconsistent kind
@@ -69,27 +75,36 @@ func (a *Adapter) Update(ctx context.Context, canonicalClass, externalID string,
 	if canonicalClass == activityTarget {
 		want, err := incumbentClassFor(canonicalClass, externalID)
 		if err != nil {
-			return overlay.Record{}, err
+			return overlay.WriteResult{}, err
 		}
 		if mw.ObjectClass != want {
-			return overlay.Record{}, fmt.Errorf("overlay: activity %s is a %s; its kind cannot be changed to a %s on update", externalID, want, mw.ObjectClass)
+			return overlay.WriteResult{}, fmt.Errorf("overlay: activity %s is a %s; its kind cannot be changed to a %s on update", externalID, want, mw.ObjectClass)
 		}
 	}
 	if len(mw.Props) == 0 {
-		// A read-only-only patch writes nothing; return the current record.
-		// No drift check — a no-op cannot lose a concurrent edit.
-		return a.Get(ctx, mw.ObjectClass, externalID)
+		// A read-only-only patch writes nothing; return the current record with
+		// no written properties. No drift check — a no-op cannot lose a
+		// concurrent edit, and no ledger entry is opened (nothing was written).
+		rec, err := a.Get(ctx, mw.ObjectClass, externalID)
+		if err != nil {
+			return overlay.WriteResult{}, err
+		}
+		return overlay.WriteResult{Record: rec, IncumbentClass: mw.ObjectClass}, nil
 	}
 	if err := a.driftCheck(ctx, mw.ObjectClass, externalID, baseline); err != nil {
-		return overlay.Record{}, err
+		return overlay.WriteResult{}, err
 	}
 	if _, err := a.client.UpdateObject(ctx, mw.ObjectClass, incumbentActivityID(mw.ObjectClass, externalID), mw.Props); err != nil {
-		return overlay.Record{}, err
+		return overlay.WriteResult{}, err
 	}
 	// Re-read through the sync-read path so the mirrored ModifiedAt is the
 	// baseline watermark property, consistent with reads and the drift check
 	// (see Create's note).
-	return a.Get(ctx, mw.ObjectClass, externalID)
+	rec, err := a.Get(ctx, mw.ObjectClass, externalID)
+	if err != nil {
+		return overlay.WriteResult{}, err
+	}
+	return overlay.WriteResult{Record: rec, IncumbentClass: mw.ObjectClass, WrittenProps: mw.Props}, nil
 }
 
 // Archive removes a record from HubSpot via its own archive/delete, after the

--- a/backend/internal/modules/overlay/hubspot/adapter_writes.go
+++ b/backend/internal/modules/overlay/hubspot/adapter_writes.go
@@ -82,7 +82,7 @@ func (a *Adapter) Update(ctx context.Context, canonicalClass, externalID string,
 		}
 	}
 	if len(mw.Props) == 0 {
-		// A read-only-only patch writes nothing; return the current record with
+		// A read-only-fields patch writes nothing; return the current record with
 		// no written properties. No drift check — a no-op cannot lose a
 		// concurrent edit, and no ledger entry is opened (nothing was written).
 		rec, err := a.Get(ctx, mw.ObjectClass, externalID)

--- a/backend/internal/modules/overlay/hubspot/adapter_writes_test.go
+++ b/backend/internal/modules/overlay/hubspot/adapter_writes_test.go
@@ -244,7 +244,7 @@ func TestAdapterCreateRejectsAllReadOnlyFields(t *testing.T) {
 func TestAdapterUpdateNoOpWhenOnlyReadOnlyFields(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPatch {
-			t.Error("a read-only-only patch must not PATCH")
+			t.Error("a read-only-fields patch must not PATCH")
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"results":[{"id":"555","properties":{"hs_object_id":"555",
@@ -253,16 +253,16 @@ func TestAdapterUpdateNoOpWhenOnlyReadOnlyFields(t *testing.T) {
 	defer srv.Close()
 
 	adapter := hubspot.NewAdapter(hubspot.NewClient("us", "tok", hubspot.WithBaseURL(srv.URL)))
-	res, err := adapter.Update(t.Context(), "person", "555", map[string]any{"full_name": "Ada Renamed"}, time.Now())
+	res, err := adapter.Update(t.Context(), "person", "555", map[string]any{"full_name": "Ada Renamed"}, time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC))
 	if err != nil {
 		t.Fatalf("no-op Update: %v", err)
 	}
 	if res.Record.Fields["first_name"] != "Ada" {
 		t.Errorf("no-op Update should return the current record, got %+v", res.Record.Fields)
 	}
-	// A read-only-only patch wrote nothing, so it opens no ledger entry.
+	// A read-only-fields patch wrote nothing, so it opens no ledger entry.
 	if len(res.WrittenProps) != 0 {
-		t.Errorf("a read-only-only Update must report no written props, got %#v", res.WrittenProps)
+		t.Errorf("a read-only-fields Update must report no written props, got %#v", res.WrittenProps)
 	}
 }
 

--- a/backend/internal/modules/overlay/hubspot/adapter_writes_test.go
+++ b/backend/internal/modules/overlay/hubspot/adapter_writes_test.go
@@ -41,7 +41,7 @@ func TestAdapterCreatePostsMappedProps(t *testing.T) {
 	defer srv.Close()
 
 	adapter := hubspot.NewAdapter(hubspot.NewClient("us", "tok", hubspot.WithBaseURL(srv.URL)))
-	rec, err := adapter.Create(t.Context(), "person", map[string]any{
+	res, err := adapter.Create(t.Context(), "person", map[string]any{
 		"first_name": "Ada", "last_name": "Lovelace",
 	})
 	if err != nil {
@@ -50,8 +50,14 @@ func TestAdapterCreatePostsMappedProps(t *testing.T) {
 	if gotBody.Properties["firstname"] != "Ada" || gotBody.Properties["lastname"] != "Lovelace" {
 		t.Errorf("POSTed properties = %#v, want firstname=Ada lastname=Lovelace", gotBody.Properties)
 	}
-	if rec.ExternalID != "555" || rec.Fields["first_name"] != "Ada" {
-		t.Errorf("mapped record = %+v, want ExternalID 555 + first_name Ada", rec)
+	if res.Record.ExternalID != "555" || res.Record.Fields["first_name"] != "Ada" {
+		t.Errorf("mapped record = %+v, want ExternalID 555 + first_name Ada", res.Record)
+	}
+	// WrittenProps carries the HubSpot properties actually written — the
+	// echo-suppression ledger's producer input (OVA-DDL-6), keyed as the echo
+	// webhook will present them.
+	if res.IncumbentClass != "contacts" || res.WrittenProps["firstname"] != "Ada" || res.WrittenProps["lastname"] != "Lovelace" {
+		t.Errorf("WriteResult = {class:%q props:%#v}, want contacts + firstname/lastname", res.IncumbentClass, res.WrittenProps)
 	}
 }
 
@@ -122,15 +128,18 @@ func TestAdapterUpdateAppliesWhenBaselineFresh(t *testing.T) {
 	defer srv.Close()
 
 	adapter := hubspot.NewAdapter(hubspot.NewClient("us", "tok", hubspot.WithBaseURL(srv.URL)))
-	rec, err := adapter.Update(t.Context(), "person", "555", map[string]any{"first_name": "Ada2"}, baseline)
+	res, err := adapter.Update(t.Context(), "person", "555", map[string]any{"first_name": "Ada2"}, baseline)
 	if err != nil {
 		t.Fatalf("Update: %v", err)
 	}
 	if patchBody.Properties["firstname"] != "Ada2" {
 		t.Errorf("PATCHed properties = %#v, want firstname=Ada2", patchBody.Properties)
 	}
-	if rec.Fields["first_name"] != "Ada2" {
-		t.Errorf("mapped record first_name = %v, want Ada2", rec.Fields["first_name"])
+	if res.Record.Fields["first_name"] != "Ada2" {
+		t.Errorf("mapped record first_name = %v, want Ada2", res.Record.Fields["first_name"])
+	}
+	if res.WrittenProps["firstname"] != "Ada2" {
+		t.Errorf("Update WrittenProps = %#v, want firstname=Ada2", res.WrittenProps)
 	}
 }
 
@@ -244,12 +253,16 @@ func TestAdapterUpdateNoOpWhenOnlyReadOnlyFields(t *testing.T) {
 	defer srv.Close()
 
 	adapter := hubspot.NewAdapter(hubspot.NewClient("us", "tok", hubspot.WithBaseURL(srv.URL)))
-	rec, err := adapter.Update(t.Context(), "person", "555", map[string]any{"full_name": "Ada Renamed"}, time.Now())
+	res, err := adapter.Update(t.Context(), "person", "555", map[string]any{"full_name": "Ada Renamed"}, time.Now())
 	if err != nil {
 		t.Fatalf("no-op Update: %v", err)
 	}
-	if rec.Fields["first_name"] != "Ada" {
-		t.Errorf("no-op Update should return the current record, got %+v", rec.Fields)
+	if res.Record.Fields["first_name"] != "Ada" {
+		t.Errorf("no-op Update should return the current record, got %+v", res.Record.Fields)
+	}
+	// A read-only-only patch wrote nothing, so it opens no ledger entry.
+	if len(res.WrittenProps) != 0 {
+		t.Errorf("a read-only-only Update must report no written props, got %#v", res.WrittenProps)
 	}
 }
 

--- a/backend/internal/modules/overlay/hubspot/webhook.go
+++ b/backend/internal/modules/overlay/hubspot/webhook.go
@@ -26,6 +26,13 @@ type WebhookEvent struct {
 	ObjectID         int64  `json:"objectId"`         //nolint:tagliatelle // HubSpot's wire format (camelCase)
 	SubscriptionType string `json:"subscriptionType"` //nolint:tagliatelle // HubSpot's wire format (camelCase)
 	OccurredAt       int64  `json:"occurredAt"`       //nolint:tagliatelle // HubSpot's wire format (camelCase)
+	// PropertyName / PropertyValue are present on a propertyChange event — the
+	// property that changed and its new value. The echo-suppression ledger
+	// (OVA-DDL-6) keys on them to recognize the echo of our own write-back;
+	// they are empty for creation/deletion events (which carry no single
+	// property), and such events fall through to a normal re-fetch.
+	PropertyName  string `json:"propertyName"`  //nolint:tagliatelle // HubSpot's wire format (camelCase)
+	PropertyValue string `json:"propertyValue"` //nolint:tagliatelle // HubSpot's wire format (camelCase)
 }
 
 // PortalIDString renders the portalId as the decimal string the connection's

--- a/backend/internal/modules/overlay/incumbent.go
+++ b/backend/internal/modules/overlay/incumbent.go
@@ -61,6 +61,20 @@ type Record struct {
 	OwnerExternalID string
 }
 
+// WriteResult is what a write through the Incumbent seam (Create/Update)
+// returns: the incumbent's post-write state mapped back to canonical (Record,
+// which the mirror ingests) plus the echo-suppression ledger's producer inputs
+// (OVA-DDL-6). IncumbentClass is the incumbent object class the write targeted
+// (e.g. "contacts") and WrittenProps maps each incumbent property actually
+// written to its canonicalized value — keyed exactly as an echo webhook for the
+// same record will present them, so the receiver can recognize our own write.
+// WrittenProps is empty when a patch of only read-only fields wrote nothing.
+type WriteResult struct {
+	Record         Record
+	IncumbentClass string
+	WrittenProps   map[string]string
+}
+
 // Deletion is one incumbent-CRM record reported deleted or archived
 // through the Incumbent seam. Continuous sync purges its mirrored cache
 // row — with its association edges and visibility projection — on
@@ -149,11 +163,12 @@ type Incumbent interface {
 	// Create writes a new record of canonicalClass to the incumbent from the
 	// canonical field bag (the JSON-decoded contract the datasource seam
 	// carries) and returns the incumbent's stored state mapped back to
-	// canonical — the state the mirror ingests. A field with no writable
-	// incumbent counterpart (a read-only/derived field, OVA-MAP-W) is not
-	// written; a create whose every field is read-only is an error, never a
-	// blank incumbent record.
-	Create(ctx context.Context, canonicalClass string, fields map[string]any) (Record, error)
+	// canonical — the state the mirror ingests — together with the incumbent
+	// properties actually written (the echo-suppression ledger's producer
+	// inputs, OVA-DDL-6). A field with no writable incumbent counterpart (a
+	// read-only/derived field, OVA-MAP-W) is not written; a create whose every
+	// field is read-only is an error, never a blank incumbent record.
+	Create(ctx context.Context, canonicalClass string, fields map[string]any) (WriteResult, error)
 	// Update applies a canonical patch to an existing record after a
 	// stored-baseline drift check (design.md §4.5, AC-OV-4): if the incumbent's
 	// current record is newer than baseline — the mirror's lost-update baseline
@@ -161,7 +176,7 @@ type Incumbent interface {
 	// apperrors.ErrVersionSkew and nothing is written (incumbent-wins, never a
 	// blind overwrite). externalID is the mirror id (namespaced for an activity,
 	// OVA-MAP-7). A patch of only read-only fields writes nothing and returns
-	// the current record unchanged.
+	// the current record unchanged with no written properties.
 	//
 	// The V1 guarantee is BEST-EFFORT, not atomic: HubSpot v3 has no
 	// caller-supplied If-Match/ETag primitive, so the drift check is a
@@ -169,7 +184,7 @@ type Incumbent interface {
 	// inside that window can still be overwritten. A true compare-and-write
 	// waits on the incumbent's own precondition primitive (SF/Dynamics ETag,
 	// S-E19.3/S-E20.3) — a documented fast-follow, not a regression here.
-	Update(ctx context.Context, canonicalClass, externalID string, fields map[string]any, baseline time.Time) (Record, error)
+	Update(ctx context.Context, canonicalClass, externalID string, fields map[string]any, baseline time.Time) (WriteResult, error)
 	// Archive removes a record from the incumbent via its own archive/delete,
 	// after the SAME stored-baseline drift check Update applies: archiving from
 	// a stale mirror must not delete a record a third party changed since we

--- a/backend/internal/modules/overlay/provider.go
+++ b/backend/internal/modules/overlay/provider.go
@@ -42,6 +42,13 @@ type Provider struct {
 	// read does. nil until wired (the write-verb unit tests) — writes then
 	// answer errNoWriteIncumbent rather than nil-panic.
 	resolveIncumbent func(context.Context) (Incumbent, error)
+	// ledger is the echo-suppression our-write ledger (OVA-DDL-6): each
+	// successful write-back opens an entry per property written so the
+	// webhook receiver can drop the write's own echo. nil until wired (the
+	// write-verb unit tests) — opening entries is then a no-op, which only
+	// costs a redundant re-fetch when the echo webhook later arrives, never a
+	// correctness loss (the poller heals and the re-ingest is idempotent).
+	ledger *WriteLedger
 }
 
 // NewProvider constructs a Provider over ms (mirror reads) and ff
@@ -49,6 +56,10 @@ type Provider struct {
 func NewProvider(ms *MirrorStore, ff *FreshnessReader) *Provider {
 	return &Provider{ms: ms, ff: ff}
 }
+
+// SetWriteLedger wires the echo-suppression ledger's producer half (OVA-DDL-6)
+// into the write path. Boot-time only, like SetFreshnessIncumbentResolver.
+func (p *Provider) SetWriteLedger(l *WriteLedger) { p.ledger = l }
 
 // SetFreshnessIncumbentResolver wires the per-request live-incumbent
 // resolver used by BOTH the force-fresh reader (force-fresh reads) and the

--- a/backend/internal/modules/overlay/provider.go
+++ b/backend/internal/modules/overlay/provider.go
@@ -15,6 +15,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"slices"
 	"sort"
 	"strconv"
@@ -49,6 +50,9 @@ type Provider struct {
 	// costs a redundant re-fetch when the echo webhook later arrives, never a
 	// correctness loss (the poller heals and the re-ingest is idempotent).
 	ledger *WriteLedger
+	// log records a ledger-open failure without failing the already-committed
+	// write. nil falls back to slog.Default().
+	log *slog.Logger
 }
 
 // NewProvider constructs a Provider over ms (mirror reads) and ff
@@ -58,8 +62,13 @@ func NewProvider(ms *MirrorStore, ff *FreshnessReader) *Provider {
 }
 
 // SetWriteLedger wires the echo-suppression ledger's producer half (OVA-DDL-6)
-// into the write path. Boot-time only, like SetFreshnessIncumbentResolver.
-func (p *Provider) SetWriteLedger(l *WriteLedger) { p.ledger = l }
+// into the write path, with the logger a ledger-open failure is reported
+// through (the write itself never fails on it). Boot-time only, like
+// SetFreshnessIncumbentResolver.
+func (p *Provider) SetWriteLedger(l *WriteLedger, log *slog.Logger) {
+	p.ledger = l
+	p.log = log
+}
 
 // SetFreshnessIncumbentResolver wires the per-request live-incumbent
 // resolver used by BOTH the force-fresh reader (force-fresh reads) and the

--- a/backend/internal/modules/overlay/provider_writeback_integration_test.go
+++ b/backend/internal/modules/overlay/provider_writeback_integration_test.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"testing"
 	"time"
 
@@ -214,7 +215,7 @@ func TestProviderWriteOpensEchoLedgerEntries(t *testing.T) {
 	}
 	ledger := NewWriteLedger(pool)
 	p := providerFor(ms, inc)
-	p.SetWriteLedger(ledger)
+	p.SetWriteLedger(ledger, slog.New(slog.DiscardHandler))
 
 	if _, err := p.Create(ctx, datasource.CreateInput{
 		EntityType: datasource.EntityPerson,

--- a/backend/internal/modules/overlay/provider_writeback_integration_test.go
+++ b/backend/internal/modules/overlay/provider_writeback_integration_test.go
@@ -36,12 +36,15 @@ import (
 // the test configures — so the Provider's incumbent-first contract can be
 // asserted against a known ack or reject.
 type writeBackIncumbent struct {
-	createRec  Record
-	createErr  error
-	updateRec  Record
-	updateErr  error
-	archiveErr error
-	archived   bool
+	createRec   Record
+	createErr   error
+	createProps map[string]string // WrittenProps the Create reports (echo-ledger producer input)
+	updateRec   Record
+	updateErr   error
+	updateProps map[string]string // WrittenProps the Update reports
+	incClass    string            // IncumbentClass the write reports (defaults to "contacts" when unset)
+	archiveErr  error
+	archived    bool
 }
 
 func (w *writeBackIncumbent) Name() string { return "writeback-double" }
@@ -70,12 +73,25 @@ func (w *writeBackIncumbent) OwnerEmail(context.Context, string) (string, error)
 }
 func (w *writeBackIncumbent) Owners(context.Context) ([]OwnerRef, error) { return nil, nil }
 
-func (w *writeBackIncumbent) Create(context.Context, string, map[string]any) (Record, error) {
-	return w.createRec, w.createErr
+func (w *writeBackIncumbent) Create(context.Context, string, map[string]any) (WriteResult, error) {
+	if w.createErr != nil {
+		return WriteResult{}, w.createErr
+	}
+	return WriteResult{Record: w.createRec, IncumbentClass: w.incumbentClass(), WrittenProps: w.createProps}, nil
 }
 
-func (w *writeBackIncumbent) Update(context.Context, string, string, map[string]any, time.Time) (Record, error) {
-	return w.updateRec, w.updateErr
+func (w *writeBackIncumbent) Update(context.Context, string, string, map[string]any, time.Time) (WriteResult, error) {
+	if w.updateErr != nil {
+		return WriteResult{}, w.updateErr
+	}
+	return WriteResult{Record: w.updateRec, IncumbentClass: w.incumbentClass(), WrittenProps: w.updateProps}, nil
+}
+
+func (w *writeBackIncumbent) incumbentClass() string {
+	if w.incClass != "" {
+		return w.incClass
+	}
+	return "contacts"
 }
 
 func (w *writeBackIncumbent) Archive(context.Context, string, string, time.Time) error {
@@ -170,6 +186,47 @@ func TestProviderCreateMirrorsIncumbentResult(t *testing.T) {
 	// A mirror read is never authoritative — the incumbent stays the SoR.
 	if rec.Freshness.Authoritative {
 		t.Error("a mirrored write result must not claim incumbent authority (T2, AC-OV-5)")
+	}
+}
+
+// TestProviderWriteOpensEchoLedgerEntries (OVA-DDL-6 producer): a successful
+// write-back opens an our-write ledger entry per property written, keyed
+// exactly as the echo webhook will present it — so the entry the receiver later
+// classifies against actually exists. Proves the producer half end to end.
+func TestProviderWriteOpensEchoLedgerEntries(t *testing.T) {
+	ctx, pool, _ := testWorkspaceCtx(t)
+	ms := NewMirrorStore(pool, noOwnerEmails{})
+	mapActorToOwner(ctx, t, ms)
+	seedActiveConnection(ctx, t, pool)
+
+	inc := &writeBackIncumbent{
+		createRec: Record{
+			ObjectClass:     "person",
+			ExternalID:      "555",
+			Fields:          map[string]any{"first_name": "Ada"},
+			ModifiedAt:      time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+			OwnerExternalID: writebackOwner,
+		},
+		// The incumbent reports the HubSpot properties it wrote — the ledger keys
+		// on exactly these, as the echo webhook will present them.
+		createProps: map[string]string{"firstname": "Ada"},
+		incClass:    "contacts",
+	}
+	ledger := NewWriteLedger(pool)
+	p := providerFor(ms, inc)
+	p.SetWriteLedger(ledger)
+
+	if _, err := p.Create(ctx, datasource.CreateInput{
+		EntityType: datasource.EntityPerson,
+		Fields:     map[string]any{"first_name": "Ada"},
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// The write's echo — a propertyChange for contacts/555.firstname="Ada" — now
+	// classifies as our own write, exactly what suppresses the sync loop.
+	if c, err := ledger.Classify(ctx, "contacts", "555", "firstname", "Ada"); err != nil || c != ClassEcho {
+		t.Errorf("after write, the echo of firstname=Ada must classify ClassEcho, got (%v, %v)", c, err)
 	}
 }
 

--- a/backend/internal/modules/overlay/provider_writes.go
+++ b/backend/internal/modules/overlay/provider_writes.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"reflect"
 	"sort"
 
@@ -196,10 +197,12 @@ func (p *Provider) Create(ctx context.Context, in datasource.CreateInput) (datas
 	if err != nil {
 		return datasource.EntityRef{}, err
 	}
+	// Open the echo-ledger entries BEFORE mirroring so the entry is visible as
+	// early as possible after the incumbent commit — narrowing the window in
+	// which our own echo could arrive before the ledger recognizes it. Never
+	// fails the write (fail-open — see openWriteLedger).
+	p.openWriteLedger(ctx, res)
 	if err := p.mirrorWriteResult(ctx, inc, res.Record); err != nil {
-		return datasource.EntityRef{}, err
-	}
-	if err := p.openWriteLedger(ctx, res); err != nil {
 		return datasource.EntityRef{}, err
 	}
 	id, err := externalIDToUUID(res.Record.ExternalID)
@@ -249,10 +252,8 @@ func (p *Provider) Update(ctx context.Context, in datasource.UpdateInput) (datas
 	if err != nil {
 		return datasource.EntityRef{}, err
 	}
+	p.openWriteLedger(ctx, res) // fail-open, before mirroring (see Create)
 	if err := p.mirrorWriteResult(ctx, inc, res.Record); err != nil {
-		return datasource.EntityRef{}, err
-	}
-	if err := p.openWriteLedger(ctx, res); err != nil {
 		return datasource.EntityRef{}, err
 	}
 	return in.Ref, nil
@@ -260,16 +261,26 @@ func (p *Provider) Update(ctx context.Context, in datasource.UpdateInput) (datas
 
 // openWriteLedger records the echo-suppression ledger entries for a completed
 // write (OVA-DDL-6) — one per property the incumbent write actually sent, keyed
-// so the webhook receiver recognizes this write's own echo. It runs right after
-// mirrorWriteResult and is surfaced the same way: a failure returns to the
-// caller (it is a local write against the same pool the mirror ingest just used,
-// so a failure here signals the same local-store trouble). No ledger wired (the
-// write-verb unit tests) or a read-only-only write (no WrittenProps) is a no-op.
-func (p *Provider) openWriteLedger(ctx context.Context, res WriteResult) error {
+// so the webhook receiver recognizes this write's own echo.
+//
+// It is FAIL-OPEN: the incumbent write has already committed, so a ledger
+// failure must never propagate as a write failure — a caller told the write
+// failed could retry and mint a duplicate incumbent record. A missed entry only
+// costs a redundant re-fetch when the echo arrives (idempotent, poller-healed),
+// so the failure is logged and swallowed here. No ledger wired (the write-verb
+// unit tests) or a read-only-fields write (no WrittenProps) is a no-op.
+func (p *Provider) openWriteLedger(ctx context.Context, res WriteResult) {
 	if p.ledger == nil || len(res.WrittenProps) == 0 {
-		return nil
+		return
 	}
-	return p.ledger.OpenEntries(ctx, res.IncumbentClass, res.Record.ExternalID, res.WrittenProps)
+	if err := p.ledger.OpenEntries(ctx, res.IncumbentClass, res.Record.ExternalID, res.WrittenProps); err != nil {
+		log := p.log
+		if log == nil {
+			log = slog.Default()
+		}
+		log.WarnContext(ctx, "overlay: opening echo-suppression ledger entries failed; the write's echo may cost a redundant re-fetch",
+			"class", res.IncumbentClass, "external_id", res.Record.ExternalID, "err", err)
+	}
 }
 
 // completeWritePatch fills in the cross-field context a partial patch needs to

--- a/backend/internal/modules/overlay/provider_writes.go
+++ b/backend/internal/modules/overlay/provider_writes.go
@@ -192,14 +192,17 @@ func (p *Provider) Create(ctx context.Context, in datasource.CreateInput) (datas
 	if err != nil {
 		return datasource.EntityRef{}, err
 	}
-	rec, err := inc.Create(ctx, string(in.EntityType), fields)
+	res, err := inc.Create(ctx, string(in.EntityType), fields)
 	if err != nil {
 		return datasource.EntityRef{}, err
 	}
-	if err := p.mirrorWriteResult(ctx, inc, rec); err != nil {
+	if err := p.mirrorWriteResult(ctx, inc, res.Record); err != nil {
 		return datasource.EntityRef{}, err
 	}
-	id, err := externalIDToUUID(rec.ExternalID)
+	if err := p.openWriteLedger(ctx, res); err != nil {
+		return datasource.EntityRef{}, err
+	}
+	id, err := externalIDToUUID(res.Record.ExternalID)
 	if err != nil {
 		return datasource.EntityRef{}, err
 	}
@@ -242,14 +245,31 @@ func (p *Provider) Update(ctx context.Context, in datasource.UpdateInput) (datas
 	if err := p.completeWritePatch(in.Ref.Type, fields, row); err != nil {
 		return datasource.EntityRef{}, err
 	}
-	rec, err := inc.Update(ctx, string(in.Ref.Type), externalID, fields, row.UpdatedAtBaseline)
+	res, err := inc.Update(ctx, string(in.Ref.Type), externalID, fields, row.UpdatedAtBaseline)
 	if err != nil {
 		return datasource.EntityRef{}, err
 	}
-	if err := p.mirrorWriteResult(ctx, inc, rec); err != nil {
+	if err := p.mirrorWriteResult(ctx, inc, res.Record); err != nil {
+		return datasource.EntityRef{}, err
+	}
+	if err := p.openWriteLedger(ctx, res); err != nil {
 		return datasource.EntityRef{}, err
 	}
 	return in.Ref, nil
+}
+
+// openWriteLedger records the echo-suppression ledger entries for a completed
+// write (OVA-DDL-6) — one per property the incumbent write actually sent, keyed
+// so the webhook receiver recognizes this write's own echo. It runs right after
+// mirrorWriteResult and is surfaced the same way: a failure returns to the
+// caller (it is a local write against the same pool the mirror ingest just used,
+// so a failure here signals the same local-store trouble). No ledger wired (the
+// write-verb unit tests) or a read-only-only write (no WrittenProps) is a no-op.
+func (p *Provider) openWriteLedger(ctx context.Context, res WriteResult) error {
+	if p.ledger == nil || len(res.WrittenProps) == 0 {
+		return nil
+	}
+	return p.ledger.OpenEntries(ctx, res.IncumbentClass, res.Record.ExternalID, res.WrittenProps)
 }
 
 // completeWritePatch fills in the cross-field context a partial patch needs to

--- a/backend/internal/modules/overlay/reconcile_integration_test.go
+++ b/backend/internal/modules/overlay/reconcile_integration_test.go
@@ -89,12 +89,12 @@ func (s *sweptRecords) OwnerEmail(context.Context, string) (string, error) {
 }
 
 func (s *sweptRecords) Owners(context.Context) ([]OwnerRef, error) { return nil, nil }
-func (s *sweptRecords) Create(context.Context, string, map[string]any) (Record, error) {
-	return Record{}, fmt.Errorf("sweptRecords: Create is not fixtured")
+func (s *sweptRecords) Create(context.Context, string, map[string]any) (WriteResult, error) {
+	return WriteResult{}, fmt.Errorf("sweptRecords: Create is not fixtured")
 }
 
-func (s *sweptRecords) Update(context.Context, string, string, map[string]any, time.Time) (Record, error) {
-	return Record{}, fmt.Errorf("sweptRecords: Update is not fixtured")
+func (s *sweptRecords) Update(context.Context, string, string, map[string]any, time.Time) (WriteResult, error) {
+	return WriteResult{}, fmt.Errorf("sweptRecords: Update is not fixtured")
 }
 
 func (s *sweptRecords) Archive(context.Context, string, string, time.Time) error {

--- a/backend/internal/modules/overlay/teardown.go
+++ b/backend/internal/modules/overlay/teardown.go
@@ -226,5 +226,15 @@ func purgeMirror(ctx context.Context, tx pgx.Tx) error {
 	if _, err := tx.Exec(ctx, `DELETE FROM overlay_sync_state`); err != nil {
 		return fmt.Errorf("overlay: purging the sweep backoff state: %w", err)
 	}
+	// The our-write ledger holds incumbent property values (OVA-DDL-6); purge it
+	// with the rest so teardown leaves no mirrored incumbent data behind. Its
+	// producer (OpenEntries) is disconnect-fenced, so an in-flight write cannot
+	// repopulate it after this delete commits (the fence aborts that write).
+	if _, err := tx.Exec(ctx, `DELETE FROM overlay_write_ledger`); err != nil {
+		return fmt.Errorf("overlay: purging the write ledger: %w", err)
+	}
+	if _, err := tx.Exec(ctx, `DELETE FROM overlay_mirror_halt`); err != nil {
+		return fmt.Errorf("overlay: purging the mirror-halt flag: %w", err)
+	}
 	return nil
 }

--- a/backend/internal/modules/overlay/usermapseed_integration_test.go
+++ b/backend/internal/modules/overlay/usermapseed_integration_test.go
@@ -72,12 +72,12 @@ func (s seedIncumbent) Owners(context.Context) ([]OwnerRef, error) {
 	return out, nil
 }
 
-func (seedIncumbent) Create(context.Context, string, map[string]any) (Record, error) {
-	return Record{}, fmt.Errorf("seedIncumbent: Create is not fixtured")
+func (seedIncumbent) Create(context.Context, string, map[string]any) (WriteResult, error) {
+	return WriteResult{}, fmt.Errorf("seedIncumbent: Create is not fixtured")
 }
 
-func (seedIncumbent) Update(context.Context, string, string, map[string]any, time.Time) (Record, error) {
-	return Record{}, fmt.Errorf("seedIncumbent: Update is not fixtured")
+func (seedIncumbent) Update(context.Context, string, string, map[string]any, time.Time) (WriteResult, error) {
+	return WriteResult{}, fmt.Errorf("seedIncumbent: Update is not fixtured")
 }
 
 func (seedIncumbent) Archive(context.Context, string, string, time.Time) error {

--- a/backend/internal/modules/overlay/writeledger.go
+++ b/backend/internal/modules/overlay/writeledger.go
@@ -12,6 +12,14 @@ package overlay
 // loop), a genuine change is ingested, and a value-hash collision HALTS the
 // mirror rather than silently mis-suppressing a real change. The open window is
 // bounded (OVA-PARAM-3) and the value hash is SHA-256 (OVA-PARAM-4).
+//
+// The ledger key is (object_class, external_id, property, value-hash) exactly as
+// the spec pins it: multiple values for one property coexist, so a rapid A→B
+// write-back keeps A's entry open until A's (possibly delayed) echo is
+// recognized rather than being clobbered by B's. The window is measured against
+// the DATABASE clock for both the entry's opened_at and the expiry comparison,
+// so a producer process and a receiver process can never disagree on the
+// boundary by their wall-clock skew.
 
 import (
 	"context"
@@ -46,12 +54,12 @@ const (
 	ClassCollision
 )
 
-// WriteLedger is the our-write ledger store. now/window/hash are injectable so a
+// WriteLedger is the our-write ledger store. window and hash are injectable so a
 // test can exercise the window boundary and the (astronomically improbable in
-// production) hash-collision path deterministically without a real collision.
+// production) hash-collision path deterministically without a real collision;
+// the open/expiry clock itself is always the database's, never a wall clock.
 type WriteLedger struct {
 	pool   *pgxpool.Pool
-	now    func() time.Time
 	window time.Duration
 	hash   func(string) string
 }
@@ -59,7 +67,7 @@ type WriteLedger struct {
 // NewWriteLedger builds the production ledger: SHA-256 value hashing and the
 // default 24h open window.
 func NewWriteLedger(pool *pgxpool.Pool) *WriteLedger {
-	return &WriteLedger{pool: pool, now: time.Now, window: DefaultLedgerWindow, hash: sha256Hex}
+	return &WriteLedger{pool: pool, window: DefaultLedgerWindow, hash: sha256Hex}
 }
 
 // sha256Hex is OVA-PARAM-4's pinned value hash: SHA-256 over the canonicalized
@@ -76,22 +84,26 @@ func sha256Hex(s string) string {
 // recognized. object_class + property naming is the adapter's own vocabulary
 // (HubSpot property names for the real adapter); the ledger is agnostic to it
 // as long as the producer and the consumer agree, which they do per adapter.
-// Re-writing a property overwrites its entry (one open value per property).
+// Distinct values for one property coexist (keyed by value-hash); re-writing
+// the SAME value refreshes its open window. The write is fenced against a
+// racing disconnect (assertActiveConnection) so a write landing after teardown
+// cannot repopulate a purged ledger.
 func (l *WriteLedger) OpenEntries(ctx context.Context, objectClass, externalID string, props map[string]string) error {
 	if len(props) == 0 {
 		return nil
 	}
 	return database.WithWorkspaceTx(ctx, l.pool, func(tx pgx.Tx) error {
+		if err := assertActiveConnection(ctx, tx); err != nil {
+			return err
+		}
 		for prop, val := range props {
 			if _, err := tx.Exec(ctx, `
 				INSERT INTO overlay_write_ledger
-					(workspace_id, object_class, external_id, property, value_hash, value_canonical, opened_at)
-				VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3, $4, $5, $6)
-				ON CONFLICT (workspace_id, object_class, external_id, property)
-				DO UPDATE SET value_hash = EXCLUDED.value_hash,
-				              value_canonical = EXCLUDED.value_canonical,
-				              opened_at = EXCLUDED.opened_at`,
-				objectClass, externalID, prop, l.hash(val), val, l.now(),
+					(workspace_id, object_class, external_id, property, value_hash, value_canonical)
+				VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3, $4, $5)
+				ON CONFLICT (workspace_id, object_class, external_id, property, value_hash)
+				DO UPDATE SET value_canonical = EXCLUDED.value_canonical, opened_at = now()`,
+				objectClass, externalID, prop, l.hash(val), val,
 			); err != nil {
 				return fmt.Errorf("overlay: opening write-ledger entry for %s/%s.%s: %w", objectClass, externalID, prop, err)
 			}
@@ -101,57 +113,72 @@ func (l *WriteLedger) OpenEntries(ctx context.Context, objectClass, externalID s
 }
 
 // Classify decides whether an inbound property change is our own echo, a
-// genuine external change, or a hash collision — the consumer half. An entry
-// only counts when it is still inside the open window (OVA-PARAM-3). A hash
-// match is CONFIRMED against the stored value: equal ⇒ echo (suppress);
+// genuine external change, or a hash collision — the consumer half. It looks up
+// the entry keyed by the inbound value's hash within the open window (DB clock).
+// A hash hit is CONFIRMED against the stored value: equal ⇒ echo (suppress);
 // different ⇒ collision ⇒ the mirror is halted (OVA-AC-3 fail-safe) and
-// ClassCollision returned, so the change is never silently dropped.
+// ClassCollision returned, so the change is never silently dropped. On a
+// genuine change (no live entry for the inbound value) every open entry for that
+// property is invalidated: the incumbent now holds a value we did not write, so
+// our earlier written values are superseded and must not later suppress a
+// genuine change back to one of them.
 func (l *WriteLedger) Classify(ctx context.Context, objectClass, externalID, property, value string) (Classification, error) {
 	incomingHash := l.hash(value)
-	cutoff := l.now().Add(-l.window)
-	var storedHash, storedValue string
+	var result Classification
 	err := database.WithWorkspaceTx(ctx, l.pool, func(tx pgx.Tx) error {
-		return tx.QueryRow(ctx, `
-			SELECT value_hash, value_canonical FROM overlay_write_ledger
-			WHERE object_class = $1 AND external_id = $2 AND property = $3 AND opened_at > $4`,
-			objectClass, externalID, property, cutoff).Scan(&storedHash, &storedValue)
+		var storedValue string
+		scanErr := tx.QueryRow(ctx, `
+			SELECT value_canonical FROM overlay_write_ledger
+			WHERE object_class = $1 AND external_id = $2 AND property = $3 AND value_hash = $4
+			  AND opened_at > now() - make_interval(secs => $5)`,
+			objectClass, externalID, property, incomingHash, l.window.Seconds()).Scan(&storedValue)
+		switch {
+		case errors.Is(scanErr, pgx.ErrNoRows):
+			// No live entry for this value: a genuine change. Invalidate our
+			// now-superseded entries for this property so a later change back to
+			// a previously-written value is not mis-suppressed as an echo.
+			result = ClassGenuine
+			_, delErr := tx.Exec(ctx, `
+				DELETE FROM overlay_write_ledger
+				WHERE object_class = $1 AND external_id = $2 AND property = $3`,
+				objectClass, externalID, property)
+			return delErr
+		case scanErr != nil:
+			return scanErr
+		case storedValue == value:
+			result = ClassEcho // our own write echoing back — suppress
+			return nil
+		default:
+			// Hash matched but the value differs: a SHA-256 collision. Never
+			// suppress — halt the mirror (fail-safe) in this same transaction.
+			result = ClassCollision
+			return haltMirrorTx(ctx, tx, fmt.Sprintf("write-ledger value-hash collision on %s/%s.%s", objectClass, externalID, property))
+		}
 	})
-	if errors.Is(err, pgx.ErrNoRows) {
-		return ClassGenuine, nil // no open entry (or expired) — a genuine change
-	}
 	if err != nil {
 		return ClassGenuine, fmt.Errorf("overlay: classifying an inbound change against the write ledger: %w", err)
 	}
-	if storedHash != incomingHash {
-		return ClassGenuine, nil // we wrote a different value — a genuine change
-	}
-	if storedValue == value {
-		return ClassEcho, nil // our own write echoing back — suppress
-	}
-	// Hash matched but the value differs: a SHA-256 collision. Never suppress —
-	// halt the mirror (fail-safe) and surface it.
-	if haltErr := l.haltMirror(ctx, fmt.Sprintf("write-ledger value-hash collision on %s/%s.%s", objectClass, externalID, property)); haltErr != nil {
-		return ClassCollision, fmt.Errorf("overlay: recording the mirror halt on a ledger collision failed: %w", haltErr)
-	}
-	return ClassCollision, nil
+	return result, nil
 }
 
-// haltMirror flags the workspace's mirror as halted (one row per workspace,
-// upserted so a re-detection refreshes the reason/time).
-func (l *WriteLedger) haltMirror(ctx context.Context, reason string) error {
-	return database.WithWorkspaceTx(ctx, l.pool, func(tx pgx.Tx) error {
-		_, err := tx.Exec(ctx, `
-			INSERT INTO overlay_mirror_halt (workspace_id, reason, detected_at)
-			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2)
-			ON CONFLICT (workspace_id) DO UPDATE SET reason = EXCLUDED.reason, detected_at = EXCLUDED.detected_at`,
-			reason, l.now())
-		return err
-	})
+// haltMirrorTx flags the workspace's mirror as halted within tx (one row per
+// workspace, upserted so a re-detection refreshes the reason/time).
+func haltMirrorTx(ctx context.Context, tx pgx.Tx, reason string) error {
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO overlay_mirror_halt (workspace_id, reason)
+		VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1)
+		ON CONFLICT (workspace_id) DO UPDATE SET reason = EXCLUDED.reason, detected_at = now()`,
+		reason); err != nil {
+		return fmt.Errorf("overlay: recording the mirror halt: %w", err)
+	}
+	return nil
 }
 
-// Halted reports whether ctx's workspace mirror is halted — the receiver refuses
-// to process further signals for a halted workspace until an operator clears the
-// flag, so a collision-detected mirror never silently mis-suppresses.
+// Halted reports whether ctx's workspace mirror is halted — a ledger collision
+// tripped the fail-safe. The receiver refuses to enqueue re-fetches and the
+// re-fetch worker refuses to read/ingest for a halted workspace until an
+// operator clears the flag, so a mirror we no longer trust never
+// mis-suppresses or serves through.
 func (l *WriteLedger) Halted(ctx context.Context) (bool, error) {
 	var halted bool
 	err := database.WithWorkspaceTx(ctx, l.pool, func(tx pgx.Tx) error {

--- a/backend/internal/modules/overlay/writeledger.go
+++ b/backend/internal/modules/overlay/writeledger.go
@@ -176,9 +176,11 @@ func haltMirrorTx(ctx context.Context, tx pgx.Tx, reason string) error {
 
 // Halted reports whether ctx's workspace mirror is halted — a ledger collision
 // tripped the fail-safe. The receiver refuses to enqueue re-fetches and the
-// re-fetch worker refuses to read/ingest for a halted workspace until an
-// operator clears the flag, so a mirror we no longer trust never
-// mis-suppresses or serves through.
+// re-fetch worker refuses to read/ingest for a halted workspace, so a mirror we
+// no longer trust never mis-suppresses or serves through. The flag is cleared
+// today only by disconnect/teardown (which purges the whole overlay); an
+// operator-facing unhalt is a tracked follow-up — acceptable because the sole
+// trigger is a SHA-256 value-hash collision, which does not occur in practice.
 func (l *WriteLedger) Halted(ctx context.Context) (bool, error) {
 	var halted bool
 	err := database.WithWorkspaceTx(ctx, l.pool, func(tx pgx.Tx) error {

--- a/backend/internal/modules/overlay/writeledger.go
+++ b/backend/internal/modules/overlay/writeledger.go
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package overlay
+
+// The echo-suppression our-write ledger (OVA-DDL-6 / OVA-AC-3): HubSpot webhooks
+// carry no trustworthy source-app discriminator, so the echo of our OWN
+// write-back is indistinguishable from a genuine third-party change by the
+// signal alone. The write-back path opens one ledger entry per property it
+// writes (OpenEntries); the webhook receiver classifies each inbound property
+// change against the open entries (Classify) — our echo is suppressed (no sync
+// loop), a genuine change is ingested, and a value-hash collision HALTS the
+// mirror rather than silently mis-suppressing a real change. The open window is
+// bounded (OVA-PARAM-3) and the value hash is SHA-256 (OVA-PARAM-4).
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+)
+
+// DefaultLedgerWindow is OVA-PARAM-3: how long an our-write ledger entry stays
+// open. An inbound change matching an entry inside this window is our echo;
+// anything older is treated as a genuine change (the entry has expired).
+const DefaultLedgerWindow = 24 * time.Hour
+
+// Classification is the verdict Classify returns for one inbound property change.
+type Classification int
+
+const (
+	// ClassGenuine is not our write (no open entry, an expired one, or a
+	// different value) — ingest it as a real external change.
+	ClassGenuine Classification = iota
+	// ClassEcho is the echo of our own write-back — suppress it (no sync loop).
+	ClassEcho
+	// ClassCollision is an inbound value that HASHES like our write but is not
+	// equal — a SHA-256 collision. The mirror is halted; never suppressed.
+	ClassCollision
+)
+
+// WriteLedger is the our-write ledger store. now/window/hash are injectable so a
+// test can exercise the window boundary and the (astronomically improbable in
+// production) hash-collision path deterministically without a real collision.
+type WriteLedger struct {
+	pool   *pgxpool.Pool
+	now    func() time.Time
+	window time.Duration
+	hash   func(string) string
+}
+
+// NewWriteLedger builds the production ledger: SHA-256 value hashing and the
+// default 24h open window.
+func NewWriteLedger(pool *pgxpool.Pool) *WriteLedger {
+	return &WriteLedger{pool: pool, now: time.Now, window: DefaultLedgerWindow, hash: sha256Hex}
+}
+
+// sha256Hex is OVA-PARAM-4's pinned value hash: SHA-256 over the canonicalized
+// value, hex-encoded.
+func sha256Hex(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:])
+}
+
+// OpenEntries records one ledger entry per property actually written back
+// (the producer half). props maps the written property name to its
+// canonicalized value — exactly the properties the incumbent write sent, so an
+// echo webhook carrying the same (object, external_id, property, value) is
+// recognized. object_class + property naming is the adapter's own vocabulary
+// (HubSpot property names for the real adapter); the ledger is agnostic to it
+// as long as the producer and the consumer agree, which they do per adapter.
+// Re-writing a property overwrites its entry (one open value per property).
+func (l *WriteLedger) OpenEntries(ctx context.Context, objectClass, externalID string, props map[string]string) error {
+	if len(props) == 0 {
+		return nil
+	}
+	return database.WithWorkspaceTx(ctx, l.pool, func(tx pgx.Tx) error {
+		for prop, val := range props {
+			if _, err := tx.Exec(ctx, `
+				INSERT INTO overlay_write_ledger
+					(workspace_id, object_class, external_id, property, value_hash, value_canonical, opened_at)
+				VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3, $4, $5, $6)
+				ON CONFLICT (workspace_id, object_class, external_id, property)
+				DO UPDATE SET value_hash = EXCLUDED.value_hash,
+				              value_canonical = EXCLUDED.value_canonical,
+				              opened_at = EXCLUDED.opened_at`,
+				objectClass, externalID, prop, l.hash(val), val, l.now(),
+			); err != nil {
+				return fmt.Errorf("overlay: opening write-ledger entry for %s/%s.%s: %w", objectClass, externalID, prop, err)
+			}
+		}
+		return nil
+	})
+}
+
+// Classify decides whether an inbound property change is our own echo, a
+// genuine external change, or a hash collision — the consumer half. An entry
+// only counts when it is still inside the open window (OVA-PARAM-3). A hash
+// match is CONFIRMED against the stored value: equal ⇒ echo (suppress);
+// different ⇒ collision ⇒ the mirror is halted (OVA-AC-3 fail-safe) and
+// ClassCollision returned, so the change is never silently dropped.
+func (l *WriteLedger) Classify(ctx context.Context, objectClass, externalID, property, value string) (Classification, error) {
+	incomingHash := l.hash(value)
+	cutoff := l.now().Add(-l.window)
+	var storedHash, storedValue string
+	err := database.WithWorkspaceTx(ctx, l.pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `
+			SELECT value_hash, value_canonical FROM overlay_write_ledger
+			WHERE object_class = $1 AND external_id = $2 AND property = $3 AND opened_at > $4`,
+			objectClass, externalID, property, cutoff).Scan(&storedHash, &storedValue)
+	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return ClassGenuine, nil // no open entry (or expired) — a genuine change
+	}
+	if err != nil {
+		return ClassGenuine, fmt.Errorf("overlay: classifying an inbound change against the write ledger: %w", err)
+	}
+	if storedHash != incomingHash {
+		return ClassGenuine, nil // we wrote a different value — a genuine change
+	}
+	if storedValue == value {
+		return ClassEcho, nil // our own write echoing back — suppress
+	}
+	// Hash matched but the value differs: a SHA-256 collision. Never suppress —
+	// halt the mirror (fail-safe) and surface it.
+	if haltErr := l.haltMirror(ctx, fmt.Sprintf("write-ledger value-hash collision on %s/%s.%s", objectClass, externalID, property)); haltErr != nil {
+		return ClassCollision, fmt.Errorf("overlay: recording the mirror halt on a ledger collision failed: %w", haltErr)
+	}
+	return ClassCollision, nil
+}
+
+// haltMirror flags the workspace's mirror as halted (one row per workspace,
+// upserted so a re-detection refreshes the reason/time).
+func (l *WriteLedger) haltMirror(ctx context.Context, reason string) error {
+	return database.WithWorkspaceTx(ctx, l.pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `
+			INSERT INTO overlay_mirror_halt (workspace_id, reason, detected_at)
+			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2)
+			ON CONFLICT (workspace_id) DO UPDATE SET reason = EXCLUDED.reason, detected_at = EXCLUDED.detected_at`,
+			reason, l.now())
+		return err
+	})
+}
+
+// Halted reports whether ctx's workspace mirror is halted — the receiver refuses
+// to process further signals for a halted workspace until an operator clears the
+// flag, so a collision-detected mirror never silently mis-suppresses.
+func (l *WriteLedger) Halted(ctx context.Context) (bool, error) {
+	var halted bool
+	err := database.WithWorkspaceTx(ctx, l.pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `SELECT EXISTS(SELECT 1 FROM overlay_mirror_halt)`).Scan(&halted)
+	})
+	if err != nil {
+		return false, fmt.Errorf("overlay: reading the mirror-halt flag: %w", err)
+	}
+	return halted, nil
+}

--- a/backend/internal/modules/overlay/writeledger_integration_test.go
+++ b/backend/internal/modules/overlay/writeledger_integration_test.go
@@ -7,21 +7,24 @@ package overlay
 
 // The echo-suppression ledger's real-Postgres proof (OVA-AC-3 / OVA-DDL-6 /
 // OVA-PARAM-3/4): an entry opened by a write-back suppresses that write's echo,
-// a different or expired value is a genuine change (ingested, not dropped), and
-// a value-hash collision halts the mirror rather than mis-suppressing.
+// a different or expired value is a genuine change (ingested, not dropped), a
+// superseding genuine change invalidates the stale entry, and a value-hash
+// collision halts the mirror rather than mis-suppressing.
+//
+// The open/expiry clock is the database's; only the window duration is a test
+// seam, so the boundary is exercised by a zero window (every entry immediately
+// expired) rather than by faking wall-clock time.
 
 import (
 	"testing"
-	"time"
 )
 
-// TestWriteLedgerClassifiesEchoGenuineAndWindow drives the echo / non-echo /
+// TestWriteLedgerClassifiesEchoGenuineAndWindow drives the echo, non-echo, and
 // window-boundary arms with the production SHA-256 hash.
 func TestWriteLedgerClassifiesEchoGenuineAndWindow(t *testing.T) {
 	ctx, pool, _ := testWorkspaceCtx(t)
-	base := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	seedActiveConnection(ctx, t, pool) // OpenEntries is disconnect-fenced
 	l := NewWriteLedger(pool)
-	l.now = func() time.Time { return base } // deterministic window, never the wall clock
 
 	// The producer opened an entry for contacts/42.firstname = "Ada".
 	if err := l.OpenEntries(ctx, "contacts", "42", map[string]string{"firstname": "Ada"}); err != nil {
@@ -32,20 +35,67 @@ func TestWriteLedgerClassifiesEchoGenuineAndWindow(t *testing.T) {
 	if c, err := l.Classify(ctx, "contacts", "42", "firstname", "Ada"); err != nil || c != ClassEcho {
 		t.Errorf("echo: got (%v, %v), want ClassEcho", c, err)
 	}
-	// Genuine (different value): we wrote "Ada"; an inbound "Bob" is a real change.
-	if c, err := l.Classify(ctx, "contacts", "42", "firstname", "Bob"); err != nil || c != ClassGenuine {
-		t.Errorf("different value: got (%v, %v), want ClassGenuine", c, err)
-	}
-	// Genuine (no entry for this property).
+	// Genuine (no live entry for this value / property).
 	if c, err := l.Classify(ctx, "contacts", "42", "lastname", "Lovelace"); err != nil || c != ClassGenuine {
 		t.Errorf("no entry: got (%v, %v), want ClassGenuine", c, err)
 	}
 
-	// Window boundary (OVA-PARAM-3): advance now past the open window so the
-	// entry has expired — the SAME value is now a genuine change, not an echo.
-	l.now = func() time.Time { return base.Add(DefaultLedgerWindow + time.Minute) }
+	// Window boundary (OVA-PARAM-3): a zero window means the entry — opened an
+	// instant ago against the DB clock — is already outside the strict
+	// opened_at > now()-window comparison, so the SAME value is now genuine.
+	expired := &WriteLedger{pool: pool, window: 0, hash: sha256Hex}
+	if err := expired.OpenEntries(ctx, "contacts", "77", map[string]string{"firstname": "Grace"}); err != nil {
+		t.Fatalf("OpenEntries (expired case): %v", err)
+	}
+	if c, err := expired.Classify(ctx, "contacts", "77", "firstname", "Grace"); err != nil || c != ClassGenuine {
+		t.Errorf("zero-window entry: got (%v, %v), want ClassGenuine (outside the open window)", c, err)
+	}
+}
+
+// TestWriteLedgerGenuineChangeInvalidatesStaleEntry (OVA-AC-3 / E4): after the
+// incumbent genuinely moves off our written value, a later change BACK to that
+// value must not be mis-suppressed — observing the genuine change invalidates
+// our now-superseded entry.
+func TestWriteLedgerGenuineChangeInvalidatesStaleEntry(t *testing.T) {
+	ctx, pool, _ := testWorkspaceCtx(t)
+	seedActiveConnection(ctx, t, pool)
+	l := NewWriteLedger(pool)
+
+	// We wrote firstname="Ada".
+	if err := l.OpenEntries(ctx, "contacts", "42", map[string]string{"firstname": "Ada"}); err != nil {
+		t.Fatalf("OpenEntries: %v", err)
+	}
+	// A third party changes it to "Bob": genuine, and it supersedes our entry.
+	if c, err := l.Classify(ctx, "contacts", "42", "firstname", "Bob"); err != nil || c != ClassGenuine {
+		t.Fatalf("third-party change: got (%v, %v), want ClassGenuine", c, err)
+	}
+	// A change back to "Ada" is now a GENUINE change too — our stale entry was
+	// invalidated, so it is ingested, not wrongly suppressed as our echo.
 	if c, err := l.Classify(ctx, "contacts", "42", "firstname", "Ada"); err != nil || c != ClassGenuine {
-		t.Errorf("expired entry: got (%v, %v), want ClassGenuine (outside the open window)", c, err)
+		t.Errorf("change back to Ada: got (%v, %v), want ClassGenuine (stale entry invalidated)", c, err)
+	}
+}
+
+// TestWriteLedgerKeepsDistinctValuesPerProperty (OVA-DDL-6 key): a rapid A→B
+// write-back keeps BOTH entries open, so A's (delayed) echo is still recognized
+// rather than clobbered by B's entry.
+func TestWriteLedgerKeepsDistinctValuesPerProperty(t *testing.T) {
+	ctx, pool, _ := testWorkspaceCtx(t)
+	seedActiveConnection(ctx, t, pool)
+	l := NewWriteLedger(pool)
+
+	if err := l.OpenEntries(ctx, "contacts", "42", map[string]string{"firstname": "Ada"}); err != nil {
+		t.Fatalf("OpenEntries A: %v", err)
+	}
+	if err := l.OpenEntries(ctx, "contacts", "42", map[string]string{"firstname": "Bob"}); err != nil {
+		t.Fatalf("OpenEntries B: %v", err)
+	}
+	// Both our writes' echoes are recognized, in either order.
+	if c, err := l.Classify(ctx, "contacts", "42", "firstname", "Bob"); err != nil || c != ClassEcho {
+		t.Errorf("echo B: got (%v, %v), want ClassEcho", c, err)
+	}
+	if c, err := l.Classify(ctx, "contacts", "42", "firstname", "Ada"); err != nil || c != ClassEcho {
+		t.Errorf("echo A (not clobbered by B): got (%v, %v), want ClassEcho", c, err)
 	}
 }
 
@@ -55,10 +105,8 @@ func TestWriteLedgerClassifiesEchoGenuineAndWindow(t *testing.T) {
 // astronomically improbable real SHA-256 collision (production keeps sha256Hex).
 func TestWriteLedgerCollisionHaltsTheMirror(t *testing.T) {
 	ctx, pool, _ := testWorkspaceCtx(t)
-	base := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
-	l := NewWriteLedger(pool)
-	l.now = func() time.Time { return base }
-	l.hash = func(string) string { return "COLLIDE" } // every value hashes the same
+	seedActiveConnection(ctx, t, pool)
+	l := &WriteLedger{pool: pool, window: DefaultLedgerWindow, hash: func(string) string { return "COLLIDE" }}
 
 	if err := l.OpenEntries(ctx, "contacts", "42", map[string]string{"firstname": "Ada"}); err != nil {
 		t.Fatalf("OpenEntries: %v", err)

--- a/backend/internal/modules/overlay/writeledger_integration_test.go
+++ b/backend/internal/modules/overlay/writeledger_integration_test.go
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package overlay
+
+// The echo-suppression ledger's real-Postgres proof (OVA-AC-3 / OVA-DDL-6 /
+// OVA-PARAM-3/4): an entry opened by a write-back suppresses that write's echo,
+// a different or expired value is a genuine change (ingested, not dropped), and
+// a value-hash collision halts the mirror rather than mis-suppressing.
+
+import (
+	"testing"
+	"time"
+)
+
+// TestWriteLedgerClassifiesEchoGenuineAndWindow drives the echo / non-echo /
+// window-boundary arms with the production SHA-256 hash.
+func TestWriteLedgerClassifiesEchoGenuineAndWindow(t *testing.T) {
+	ctx, pool, _ := testWorkspaceCtx(t)
+	base := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	l := NewWriteLedger(pool)
+	l.now = func() time.Time { return base } // deterministic window, never the wall clock
+
+	// The producer opened an entry for contacts/42.firstname = "Ada".
+	if err := l.OpenEntries(ctx, "contacts", "42", map[string]string{"firstname": "Ada"}); err != nil {
+		t.Fatalf("OpenEntries: %v", err)
+	}
+
+	// Echo: the same value inside the window is our own write-back.
+	if c, err := l.Classify(ctx, "contacts", "42", "firstname", "Ada"); err != nil || c != ClassEcho {
+		t.Errorf("echo: got (%v, %v), want ClassEcho", c, err)
+	}
+	// Genuine (different value): we wrote "Ada"; an inbound "Bob" is a real change.
+	if c, err := l.Classify(ctx, "contacts", "42", "firstname", "Bob"); err != nil || c != ClassGenuine {
+		t.Errorf("different value: got (%v, %v), want ClassGenuine", c, err)
+	}
+	// Genuine (no entry for this property).
+	if c, err := l.Classify(ctx, "contacts", "42", "lastname", "Lovelace"); err != nil || c != ClassGenuine {
+		t.Errorf("no entry: got (%v, %v), want ClassGenuine", c, err)
+	}
+
+	// Window boundary (OVA-PARAM-3): advance now past the open window so the
+	// entry has expired — the SAME value is now a genuine change, not an echo.
+	l.now = func() time.Time { return base.Add(DefaultLedgerWindow + time.Minute) }
+	if c, err := l.Classify(ctx, "contacts", "42", "firstname", "Ada"); err != nil || c != ClassGenuine {
+		t.Errorf("expired entry: got (%v, %v), want ClassGenuine (outside the open window)", c, err)
+	}
+}
+
+// TestWriteLedgerCollisionHaltsTheMirror drives the F2 collision arm: a value
+// that HASHES like our write but differs is never suppressed — the mirror is
+// flagged and halted. A forced colliding hasher stands in for the
+// astronomically improbable real SHA-256 collision (production keeps sha256Hex).
+func TestWriteLedgerCollisionHaltsTheMirror(t *testing.T) {
+	ctx, pool, _ := testWorkspaceCtx(t)
+	base := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	l := NewWriteLedger(pool)
+	l.now = func() time.Time { return base }
+	l.hash = func(string) string { return "COLLIDE" } // every value hashes the same
+
+	if err := l.OpenEntries(ctx, "contacts", "42", map[string]string{"firstname": "Ada"}); err != nil {
+		t.Fatalf("OpenEntries: %v", err)
+	}
+	if halted, err := l.Halted(ctx); err != nil || halted {
+		t.Fatalf("mirror must not be halted before any collision: halted=%v err=%v", halted, err)
+	}
+
+	// Inbound "Bob" hashes to the same "COLLIDE" but is not "Ada": a collision.
+	// It must NOT be suppressed as an echo — the mirror halts instead.
+	if c, err := l.Classify(ctx, "contacts", "42", "firstname", "Bob"); err != nil || c != ClassCollision {
+		t.Errorf("collision: got (%v, %v), want ClassCollision", c, err)
+	}
+	if halted, err := l.Halted(ctx); err != nil || !halted {
+		t.Errorf("the mirror must be halted after a collision: halted=%v err=%v", halted, err)
+	}
+}

--- a/backend/migrations/custom/20260724120000_overlay_write_ledger_activate.down.sql
+++ b/backend/migrations/custom/20260724120000_overlay_write_ledger_activate.down.sql
@@ -1,4 +1,3 @@
-DROP INDEX IF EXISTS idx_overlay_write_ledger_opened_at;
 DROP TABLE IF EXISTS overlay_mirror_halt;
 ALTER TABLE overlay_write_ledger DROP CONSTRAINT overlay_write_ledger_pkey;
 ALTER TABLE overlay_write_ledger

--- a/backend/migrations/custom/20260724120000_overlay_write_ledger_activate.down.sql
+++ b/backend/migrations/custom/20260724120000_overlay_write_ledger_activate.down.sql
@@ -1,3 +1,6 @@
 DROP INDEX IF EXISTS idx_overlay_write_ledger_opened_at;
 DROP TABLE IF EXISTS overlay_mirror_halt;
+ALTER TABLE overlay_write_ledger DROP CONSTRAINT overlay_write_ledger_pkey;
+ALTER TABLE overlay_write_ledger
+  ADD PRIMARY KEY (workspace_id, object_class, external_id, property);
 ALTER TABLE overlay_write_ledger DROP COLUMN IF EXISTS value_canonical;

--- a/backend/migrations/custom/20260724120000_overlay_write_ledger_activate.down.sql
+++ b/backend/migrations/custom/20260724120000_overlay_write_ledger_activate.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS idx_overlay_write_ledger_opened_at;
+DROP TABLE IF EXISTS overlay_mirror_halt;
+ALTER TABLE overlay_write_ledger DROP COLUMN IF EXISTS value_canonical;

--- a/backend/migrations/custom/20260724120000_overlay_write_ledger_activate.up.sql
+++ b/backend/migrations/custom/20260724120000_overlay_write_ledger_activate.up.sql
@@ -37,7 +37,8 @@ CREATE POLICY overlay_mirror_halt_tenant_isolation ON overlay_mirror_halt
   USING (workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid)
   WITH CHECK (workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid);
 
--- The consumer looks entries up by their full identity within the open window;
--- opened_at supports the window filter (OVA-PARAM-3) and eventual pruning.
-CREATE INDEX IF NOT EXISTS idx_overlay_write_ledger_opened_at
-  ON overlay_write_ledger (workspace_id, opened_at);
+-- No opened_at index: the consumer's Classify looks up by the full primary key
+-- (workspace_id, object_class, external_id, property, value_hash) and then
+-- narrows on opened_at on that single row, and the genuine-change DELETE hits
+-- the PK prefix — both served by the PK index. A window-scan index belongs with
+-- the periodic pruner that would use it (a tracked follow-up), not ahead of it.

--- a/backend/migrations/custom/20260724120000_overlay_write_ledger_activate.up.sql
+++ b/backend/migrations/custom/20260724120000_overlay_write_ledger_activate.up.sql
@@ -13,6 +13,14 @@
 -- same-tenant data — no new PII category — purged with the mirror on teardown.
 ALTER TABLE overlay_write_ledger ADD COLUMN IF NOT EXISTS value_canonical text NOT NULL DEFAULT '';
 
+-- The spec keys the ledger on (object, external_id, property, value-hash): a
+-- rapid A→B write-back must keep A's entry open (until A's echo is recognized)
+-- rather than clobbering it, so value_hash joins the primary key. The reserved
+-- table's PK omitted it; widen it here (the table has never been populated).
+ALTER TABLE overlay_write_ledger DROP CONSTRAINT overlay_write_ledger_pkey;
+ALTER TABLE overlay_write_ledger
+  ADD PRIMARY KEY (workspace_id, object_class, external_id, property, value_hash);
+
 -- overlay_mirror_halt is the fail-safe the collision guard sets (OVA-AC-3 /
 -- UC-E18-02 F2): a detected value-hash collision flags the workspace's mirror as
 -- halted, and the webhook receiver refuses to process further signals for it

--- a/backend/migrations/custom/20260724120000_overlay_write_ledger_activate.up.sql
+++ b/backend/migrations/custom/20260724120000_overlay_write_ledger_activate.up.sql
@@ -1,0 +1,35 @@
+-- 20260724120000_overlay_write_ledger_activate (OVA-DDL-6 / OVA-AC-3): wire the
+-- reserved overlay_write_ledger for echo suppression, and add the mirror-halt
+-- flag the value-hash collision guard raises.
+--
+-- The ledger stores, per property we wrote back, the SHA-256 value-hash
+-- (OVA-PARAM-4 — the fast index/identity of the written value) AND the
+-- canonicalized value itself. The value is required, not redundant: a hash
+-- collision is by definition two DIFFERENT values sharing one hash, so hash-only
+-- storage cannot detect one — the stored value is what lets the consumer confirm
+-- an inbound value that HASHES like our write actually EQUALS it (echo) versus
+-- differs (a collision ⇒ flag + halt, never a silent mis-suppression). It is a
+-- 24h-bounded (OVA-PARAM-3), workspace-scoped duplicate of already-mirrored
+-- same-tenant data — no new PII category — purged with the mirror on teardown.
+ALTER TABLE overlay_write_ledger ADD COLUMN IF NOT EXISTS value_canonical text NOT NULL DEFAULT '';
+
+-- overlay_mirror_halt is the fail-safe the collision guard sets (OVA-AC-3 /
+-- UC-E18-02 F2): a detected value-hash collision flags the workspace's mirror as
+-- halted, and the webhook receiver refuses to process further signals for it
+-- until an operator clears the row — never silently mis-suppressing a real
+-- external change. One row per workspace (the halt is workspace-wide).
+CREATE TABLE overlay_mirror_halt (
+  workspace_id uuid PRIMARY KEY REFERENCES workspace(id) ON DELETE RESTRICT,
+  reason text NOT NULL,
+  detected_at timestamptz NOT NULL DEFAULT now()
+);
+ALTER TABLE overlay_mirror_halt ENABLE ROW LEVEL SECURITY;
+ALTER TABLE overlay_mirror_halt FORCE ROW LEVEL SECURITY;
+CREATE POLICY overlay_mirror_halt_tenant_isolation ON overlay_mirror_halt
+  USING (workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid)
+  WITH CHECK (workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid);
+
+-- The consumer looks entries up by their full identity within the open window;
+-- opened_at supports the window filter (OVA-PARAM-3) and eventual pruning.
+CREATE INDEX IF NOT EXISTS idx_overlay_write_ledger_opened_at
+  ON overlay_write_ledger (workspace_id, opened_at);

--- a/backend/migrations/custom/20260724120000_overlay_write_ledger_activate.up.sql
+++ b/backend/migrations/custom/20260724120000_overlay_write_ledger_activate.up.sql
@@ -23,9 +23,11 @@ ALTER TABLE overlay_write_ledger
 
 -- overlay_mirror_halt is the fail-safe the collision guard sets (OVA-AC-3 /
 -- UC-E18-02 F2): a detected value-hash collision flags the workspace's mirror as
--- halted, and the webhook receiver refuses to process further signals for it
--- until an operator clears the row — never silently mis-suppressing a real
--- external change. One row per workspace (the halt is workspace-wide).
+-- halted, and both the webhook receiver and the re-fetch worker then refuse to
+-- process further signals for it — never silently mis-suppressing a real
+-- external change. The flag is cleared today only by disconnect/teardown (which
+-- purges the whole overlay); an operator-facing unhalt is a tracked follow-up.
+-- One row per workspace (the halt is workspace-wide).
 CREATE TABLE overlay_mirror_halt (
   workspace_id uuid PRIMARY KEY REFERENCES workspace(id) ON DELETE RESTRICT,
   reason text NOT NULL,

--- a/backend/tableownership_test.go
+++ b/backend/tableownership_test.go
@@ -154,6 +154,7 @@ var tableOwners = map[string]string{
 	"mirror_user_map":             "internal/modules/overlay",
 	"mirror_visibility":           "internal/modules/overlay",
 	"overlay_write_ledger":        "internal/modules/overlay",
+	"overlay_mirror_halt":         "internal/modules/overlay",
 	"overlay_tombstone":           "internal/modules/overlay",
 	"overlay_backfill_cursor":     "internal/modules/overlay",
 	"overlay_reconcile_watermark": "internal/modules/overlay",


### PR DESCRIPTION
## What

The final slice of the HubSpot webhook arc: the **echo-suppression our-write ledger** (OVA-DDL-6), delivering **AC-OV-13 (e)** and **OVA-AC-3**.

HubSpot webhooks carry no trustworthy source-app discriminator, so the echo of *our own* write-back is indistinguishable from a genuine third-party change by the signal alone. The ledger records what we wrote and lets the receiver drop the echo — closing the write→webhook→re-fetch loop.

## Producer (write path)
- The `Incumbent.Create/Update` seam now returns a **`WriteResult`** (record + incumbent object class + the properties actually written). The HubSpot adapter fills it from `mapWrite`'s output; the fake stringifies its fields.
- `Provider.Create/Update` open one ledger entry per written property (`WriteLedger.OpenEntries`), keyed exactly as the echo webhook will present it: `(object_class, external_id, property, value-hash)` with the canonical value stored alongside.

## Consumer (webhook receiver)
- `WebhookEvent` gains `propertyName`/`propertyValue` (present on `propertyChange`).
- The receiver classifies each `propertyChange` against the ledger:
  - **echo** (same value inside the OVA-PARAM-3 24h window) → **dropped**, no re-fetch, no sync loop;
  - **genuine** or **expired** → ingested (never mis-dropped, E4);
  - **value-hash collision** (OVA-PARAM-4 SHA-256) → the mirror is **halted** (flag + `overlay_mirror_halt`), never silently mis-suppressed (F2).
- A mirror halted by a prior collision refuses further signals until an operator clears the flag.

## Why the ledger stores the value, not just the hash
A hash collision is by definition two different values sharing one hash, so hash-only storage *cannot* detect one — the stored canonical value is the disambiguator that makes "never silently mis-suppress" true. In production SHA-256 makes the halt path unreachable; the ledger's window/hash are injectable so the window-boundary and collision arms are tested deterministically (no real collision needed).

## Migration
Activates the reserved `overlay_write_ledger` (adds `value_canonical`) and adds `overlay_mirror_halt` (RLS + FORCE RLS). Both owned by the overlay module (tableownership gate updated).

## Tests
- **Integration (real Postgres)**: `WriteLedger` echo / genuine / window-boundary + collision→halt; a provider write opens entries a follow-up `Classify` recognizes as an echo.
- **Unit**: receiver suppress / ingest / collision / halt-gate decisions (injected seams, no DB/River); the `Create/Update` `WriteResult` contract on the adapter + fake; `privacyDeletion` stays out of the re-fetch lane.

## Scope note
This completes the webhook-as-signal arc (branch 1b). Remaining overlay follow-ups (webhook `Get` budget metering, `mirror.conflict` emission, overlay→native flip) are tracked in the branch-2 backlog and are out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an echo-suppression write ledger for HubSpot webhooks to stop re-fetch loops caused by our own writes, and halts the mirror on value-hash collisions. Completes AC-OV-13e / OVA-AC-3 with halt enforcement in both the webhook receiver and the refetch worker.

- **New Features**
  - Producer: `Incumbent.Create/Update` now return `WriteResult` (record + `IncumbentClass` + `WrittenProps`); `Provider` opens one ledger entry per written property before mirroring (fail-open if the ledger write fails).
  - Consumer: receiver reads `propertyName`/`propertyValue`, classifies with `WriteLedger.Classify`, drops echoes, and halts on value-hash collision; per-workspace halt is cached per request; refetch worker re-checks the halt gate at execution.
  - Ledger: 24h DB-clock window, SHA-256 value hash, canonical value stored to confirm echoes; PK widened so distinct values coexist; genuine changes invalidate stale entries; teardown purges the ledger and halt flag.

- **Migration**
  - Adds `value_canonical` and widens the `overlay_write_ledger` primary key to `(workspace_id, object_class, external_id, property, value_hash)`.
  - Creates `overlay_mirror_halt` (RLS + FORCE RLS); halt clears only on disconnect/teardown; no `opened_at` index (deferred to a future pruner). No manual steps beyond running migrations.

<sup>Written for commit 4eb096ec68100481e7d46c29164ce8efb9967598. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added echo suppression for webhook updates caused by recent write-backs.
  * Detects conflicting changes and halts mirroring to prevent silent data loss.
  * Tracks written properties to distinguish genuine external changes from write echoes.
  * Added support for property names and values in property-change webhook events.

* **Bug Fixes**
  * Prevents duplicate re-fetch jobs for echoed updates.
  * Safely ignores events while a mirror is halted.

* **Tests**
  * Added coverage for echoes, genuine changes, collisions, and halted mirrors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->