### PR TITLE
fix(overlay): meter the webhook re-fetch against the OVB budget

### DIFF
--- a/backend/internal/compose/jobs.go
+++ b/backend/internal/compose/jobs.go
@@ -468,7 +468,7 @@ func NewJobRunner(pool *pgxpool.Pool, log *slog.Logger, cfg JobRunnerConfig) (*j
 		// record through the same store the poller uses. Registered whenever
 		// the overlay vault is present (the receiver only enqueues when the api
 		// role has the app secret wired).
-		river.AddWorker(workers, &overlayRefetchWorker{pool: pool, vault: cfg.OverlayVault, ms: ms, log: log, newIncumbent: overlayIncumbentFactory(cfg.OverlayBackfillLimit)})
+		river.AddWorker(workers, &overlayRefetchWorker{pool: pool, vault: cfg.OverlayVault, ms: ms, meter: meter, log: log, newIncumbent: overlayIncumbentFactory(cfg.OverlayBackfillLimit)})
 		periodic = append(periodic, river.NewPeriodicJob(
 			river.PeriodicInterval(cfg.OverlayInterval),
 			func() (river.JobArgs, *river.InsertOpts) { return OverlayReconcileArgs{}, sweepInsertOpts() },

--- a/backend/internal/compose/jobs_overlay.go
+++ b/backend/internal/compose/jobs_overlay.go
@@ -58,14 +58,17 @@ type overlayRefetchWorker struct {
 	pool  *pgxpool.Pool
 	vault keyvault.Vault
 	ms    *overlay.MirrorStore
-	// meter is the OVB budget (fail-closed when unconfigured). A webhook
-	// re-fetch is a live single-record REST read-through — the same traffic
-	// category the force-fresh source meters (both charge the REST window; the
-	// poller charges the search window), so it reserves against SourceForceFresh
-	// before the incumbent read and SHEDS to the poller when the budget is spent.
-	// Without this, a burst of signals would spend incumbent REST quota the OVB
-	// budget never sees. A dedicated webhook source (admin-breakdown granularity)
-	// would be an OVB-AC-5 spec change — a tracked follow-up, not needed for the
+	// meter is the OVB budget. A webhook re-fetch is a live single-record REST
+	// read-through — the same traffic category force-fresh meters, so it
+	// reserves against SourceForceFresh before the incumbent read and SHEDS to
+	// the poller when the budget is spent. A single-record GET is GATE-able
+	// against the REST window (reserve/shed); the poller's Modified sweep, by
+	// contrast, is a Search-API call PACED by the per-second search window with
+	// its REST spend consumed unconditionally on SourcePoller — so reserve/shed
+	// is the right shape here, force-fresh's shape, not the poller's. Without
+	// this, a burst of signals would spend incumbent REST quota the OVB budget
+	// never sees. A dedicated webhook source (admin-breakdown granularity) would
+	// be an OVB-AC-5 spec change — a tracked follow-up, not needed for the
 	// "account for every live call" invariant this closes.
 	meter        *overlaybudget.Meter
 	log          *slog.Logger
@@ -113,9 +116,12 @@ func (w *overlayRefetchWorker) Work(ctx context.Context, job *river.Job[OverlayR
 	inc := w.newIncumbent(conn.Region, string(token))
 	// Reserve one REST unit BEFORE the live read (OVB-AC-2/AC-5), so the
 	// webhook lane's incumbent calls are accounted for like every other. On
-	// shed (budget spent, or fail-closed with no meter) skip the re-fetch — the
-	// signal is an optimization, and the poller heals within its interval; never
-	// spend live quota we cannot account for. A meter error is transient — retry.
+	// shed skip the re-fetch — the signal is an optimization, and the poller
+	// heals within its interval; never spend live quota we cannot account for.
+	// A role wired without a configured meter gets the fail-closed placeholder
+	// (nil Redis client) here, which sheds every reservation — so an
+	// unaccountable read is skipped, never made. A meter error is transient —
+	// retry.
 	if allowed, err := w.meter.ReserveREST(wsCtx, conn.Incumbent, overlaybudget.SourceForceFresh, 1); err != nil {
 		return fmt.Errorf("overlay refetch: reserving the incumbent budget: %w", err)
 	} else if !allowed {

--- a/backend/internal/compose/jobs_overlay.go
+++ b/backend/internal/compose/jobs_overlay.go
@@ -55,9 +55,19 @@ func (OverlayRefetchArgs) Kind() string { return "overlay_refetch" }
 // on one mirror state. The poller still heals any gap a signal misses.
 type overlayRefetchWorker struct {
 	river.WorkerDefaults[OverlayRefetchArgs]
-	pool         *pgxpool.Pool
-	vault        keyvault.Vault
-	ms           *overlay.MirrorStore
+	pool  *pgxpool.Pool
+	vault keyvault.Vault
+	ms    *overlay.MirrorStore
+	// meter is the OVB budget (fail-closed when unconfigured). A webhook
+	// re-fetch is a live single-record REST read-through — the same traffic
+	// category the force-fresh source meters (both charge the REST window; the
+	// poller charges the search window), so it reserves against SourceForceFresh
+	// before the incumbent read and SHEDS to the poller when the budget is spent.
+	// Without this, a burst of signals would spend incumbent REST quota the OVB
+	// budget never sees. A dedicated webhook source (admin-breakdown granularity)
+	// would be an OVB-AC-5 spec change — a tracked follow-up, not needed for the
+	// "account for every live call" invariant this closes.
+	meter        *overlaybudget.Meter
 	log          *slog.Logger
 	newIncumbent func(region, token string) overlay.Incumbent
 }
@@ -101,6 +111,18 @@ func (w *overlayRefetchWorker) Work(ctx context.Context, job *river.Job[OverlayR
 		return fmt.Errorf("overlay refetch: resolving the vaulted token: %w", err)
 	}
 	inc := w.newIncumbent(conn.Region, string(token))
+	// Reserve one REST unit BEFORE the live read (OVB-AC-2/AC-5), so the
+	// webhook lane's incumbent calls are accounted for like every other. On
+	// shed (budget spent, or fail-closed with no meter) skip the re-fetch — the
+	// signal is an optimization, and the poller heals within its interval; never
+	// spend live quota we cannot account for. A meter error is transient — retry.
+	if allowed, err := w.meter.ReserveREST(wsCtx, conn.Incumbent, overlaybudget.SourceForceFresh, 1); err != nil {
+		return fmt.Errorf("overlay refetch: reserving the incumbent budget: %w", err)
+	} else if !allowed {
+		w.log.InfoContext(wsCtx, "overlay refetch: incumbent budget shed, deferring to the poller",
+			"workspace", job.Args.Workspace, "class", job.Args.IncumbentClass, "id", job.Args.ExternalID)
+		return nil
+	}
 	rec, err := inc.Get(wsCtx, job.Args.IncumbentClass, job.Args.ExternalID)
 	if err != nil {
 		// A connection-level failure (rate-limit/auth/unreachable) is retryable

--- a/backend/internal/compose/jobs_overlay_worker_integration_test.go
+++ b/backend/internal/compose/jobs_overlay_worker_integration_test.go
@@ -674,19 +674,38 @@ func TestOverlayRefetchWorkerShedsWhenBudgetExhausted(t *testing.T) {
 	rec.ModifiedAt = time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
 	inc.Seed(overlay.IncumbentClassContacts, rec)
 
+	// Spy on the incumbent so the test proves the live READ was skipped, not
+	// merely that nothing was ingested (the reserve gates before inc.Get).
+	spy := &getCountingIncumbent{Adapter: inc}
 	// failClosedOverlayMeter sheds every reservation (no window to account into).
 	w := &overlayRefetchWorker{
 		pool: e.Pool, vault: vault, ms: ms, meter: failClosedOverlayMeter(),
 		log:          slog.New(slog.DiscardHandler),
-		newIncumbent: func(_, _ string) overlay.Incumbent { return inc },
+		newIncumbent: func(_, _ string) overlay.Incumbent { return spy },
 	}
 	if err := w.Work(context.Background(), &river.Job[OverlayRefetchArgs]{
 		Args: OverlayRefetchArgs{Workspace: e.WS.String(), IncumbentClass: overlay.IncumbentClassContacts, ExternalID: "c-1"},
 	}); err != nil {
 		t.Fatalf("refetch Work (shed): %v", err)
 	}
-	// Shed → skipped the read → nothing mirrored (the poller heals later).
+	// Shed → the incumbent read was never made (the whole point of the gate)...
+	if spy.gets != 0 {
+		t.Errorf("a shed re-fetch must not read the incumbent, got %d Get call(s)", spy.gets)
+	}
+	// ...and so nothing was mirrored (the poller heals later).
 	if _, err := ms.Get(overlayReaderCtx(e.WS, e.Rep1), "person", "c-1"); !errors.Is(err, apperrors.ErrNotFound) {
 		t.Errorf("a shed re-fetch must ingest nothing, got: %v", err)
 	}
+}
+
+// getCountingIncumbent counts Get calls so a test can assert the incumbent read
+// was (not) made — e.g. that a budget shed skipped the read entirely.
+type getCountingIncumbent struct {
+	*fake.Adapter
+	gets int
+}
+
+func (g *getCountingIncumbent) Get(ctx context.Context, objectClass, externalID string) (overlay.Record, error) {
+	g.gets++
+	return g.Adapter.Get(ctx, objectClass, externalID)
 }

--- a/backend/internal/compose/jobs_overlay_worker_integration_test.go
+++ b/backend/internal/compose/jobs_overlay_worker_integration_test.go
@@ -595,10 +595,13 @@ func TestOverlayRefetchWorkerFreshensTheMirrorRecord(t *testing.T) {
 		inc.Seed(overlay.IncumbentClassContacts, rec)
 		return inc
 	}
+	// A HubSpot-configured meter so the refetch's ReserveREST (against the
+	// connection's "hubspot" incumbent) is allowed rather than shed.
+	restMeter := budgettest.Meter(t, budgettest.SmallConfig("hubspot"))
 	runRefetch := func(inc *fake.Adapter) {
 		t.Helper()
 		w := &overlayRefetchWorker{
-			pool: e.Pool, vault: vault, ms: ms,
+			pool: e.Pool, vault: vault, ms: ms, meter: restMeter,
 			log:          slog.New(slog.DiscardHandler),
 			newIncumbent: func(_, _ string) overlay.Incumbent { return inc },
 		}
@@ -636,5 +639,54 @@ func TestOverlayRefetchWorkerFreshensTheMirrorRecord(t *testing.T) {
 	runRefetch(version("Stale", base))
 	if got := firstname(); got != "Ada Lovelace" {
 		t.Fatalf("a stale re-fetch must not regress the mirror; firstname = %v, want Ada Lovelace", got)
+	}
+}
+
+// TestOverlayRefetchWorkerShedsWhenBudgetExhausted proves the OVB gate: when the
+// meter sheds (here a fail-closed meter with no window), the worker skips the
+// incumbent read entirely — nothing is ingested, and the poller heals the gap.
+// This is the "never spend live quota we cannot account for" invariant for the
+// webhook lane.
+func TestOverlayRefetchWorkerShedsWhenBudgetExhausted(t *testing.T) {
+	e := integration.Setup(t)
+	vault := keyvault.NewMemory()
+	ms := overlay.NewMirrorStore(e.Pool, unresolvedOwnerEmails{})
+
+	adminCtx := overlayAdminCtx(e.WS, e.Rep1)
+	if _, err := overlay.NewService(e.Pool, vault, ms).
+		Connect(adminCtx, overlay.ConnectInput{Incumbent: "hubspot", Region: "eu1", Token: "tok"}); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	dir := fake.New()
+	dir.SeedOwner("owner-1", "a@authz.test")
+	if err := ms.WithResolver(dir).SeedUserMap(adminCtx, incumbentHubSpot,
+		[]overlay.OwnerRef{{ExternalID: "owner-1", Email: "a@authz.test"}}); err != nil {
+		t.Fatalf("SeedUserMap: %v", err)
+	}
+
+	// The incumbent HAS the record — so a non-shed run would ingest it; the
+	// record's absence afterward proves the shed skipped the read, not a miss.
+	inc := fake.New()
+	inc.SeedOwner("owner-1", "a@authz.test")
+	rec := fake.Rec("c-1", map[string]any{"firstname": "Ada"})
+	rec.ObjectClass = "person"
+	rec.OwnerExternalID = "owner-1"
+	rec.ModifiedAt = time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	inc.Seed(overlay.IncumbentClassContacts, rec)
+
+	// failClosedOverlayMeter sheds every reservation (no window to account into).
+	w := &overlayRefetchWorker{
+		pool: e.Pool, vault: vault, ms: ms, meter: failClosedOverlayMeter(),
+		log:          slog.New(slog.DiscardHandler),
+		newIncumbent: func(_, _ string) overlay.Incumbent { return inc },
+	}
+	if err := w.Work(context.Background(), &river.Job[OverlayRefetchArgs]{
+		Args: OverlayRefetchArgs{Workspace: e.WS.String(), IncumbentClass: overlay.IncumbentClassContacts, ExternalID: "c-1"},
+	}); err != nil {
+		t.Fatalf("refetch Work (shed): %v", err)
+	}
+	// Shed → skipped the read → nothing mirrored (the poller heals later).
+	if _, err := ms.Get(overlayReaderCtx(e.WS, e.Rep1), "person", "c-1"); !errors.Is(err, apperrors.ErrNotFound) {
+		t.Errorf("a shed re-fetch must ingest nothing, got: %v", err)
 	}
 }


### PR DESCRIPTION
## What

Closes a governance gap the webhook-as-signal review flagged: the re-fetch worker read the incumbent (`inc.Get`) **without charging the OVB budget meter**, so a burst of signals could spend incumbent REST quota the accounting never saw — breaking the *"never spend live quota we cannot account for"* invariant that the force-fresh and poller paths already hold.

## Change
- `overlayRefetchWorker` gains the OVB meter (wired from the same `JobRunnerConfig.OverlayMeter` the poller uses — one shared Redis window — with the fail-closed fallback).
- Before the live `inc.Get`, it **reserves one REST unit**; on **shed** (budget spent, or a fail-closed meter with no window) it skips the re-fetch and defers to the poller (the signal is an optimization; the poller heals within its interval).

## Source attribution (no spec change)
A webhook re-fetch is a live single-record **REST read-through** — mechanically the same as force-fresh (both charge the REST window; the poller charges the search window). It's attributed to `SourceForceFresh`, keeping **OVB-AC-5**'s fixed three-source breakdown (force-fresh / poller / capture) intact and summing correctly. A *dedicated* webhook source (for admin-breakdown granularity) would be an OVB-AC-5 spec change — tracked as an upstream follow-up, not needed for the accounting invariant this closes.

## Tests
- The worker **sheds** (ingests nothing; poller heals) under a fail-closed meter — proven by the record's absence when the incumbent *has* it.
- The worker **freshens** normally under a HubSpot-configured meter (the existing end-to-end test, now metered).

Follow-up to the merged webhook-as-signal arc (#232, #236); part of the branch-2 governance track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Meter webhook re-fetches against the OVB budget so incumbent REST reads are fully accounted. If the budget is exhausted or fail-closed, the worker skips the live read and lets the poller heal.

- **Bug Fixes**
  - Connect `overlayRefetchWorker` to the shared OVB meter (`JobRunnerConfig.OverlayMeter`).
  - Reserve 1 REST unit before `inc.Get`; shed and defer to the poller on deny or fail-closed.
  - Attribute usage to `SourceForceFresh`; add tests for shed and allowed paths, and assert the incumbent read is skipped on shed.

- **Refactors**
  - Clarified metering comments: the poller also spends REST (unconditional), and a fail-closed placeholder meter sheds every reservation; no logic changes.

<sup>Written for commit 88135f9c8576589ccd22701257a6b2438fad1901. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Overlay record refreshes now respect REST request budgets.
  * When the budget is unavailable, refreshes are deferred instead of proceeding, helping prevent excessive API usage.
  * Added coverage for successful refreshes and budget-exhaustion scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->