### PR TITLE
fix(overlay): prune expired echo-ledger entries on the reconcile sweep

### DIFF
--- a/backend/internal/compose/jobs_overlay.go
+++ b/backend/internal/compose/jobs_overlay.go
@@ -324,6 +324,14 @@ func reconcileConnection(ctx context.Context, pool *pgxpool.Pool, vault keyvault
 		log.WarnContext(ctx, "overlay reconcile: backfilling the webhook portal binding failed",
 			"workspace", d.Workspace.String(), "err", err)
 	}
+	// Prune expired echo-ledger entries (OVA-DDL-6 hygiene): bounds the table's
+	// growth and does not retain a value_canonical past the window. Best-effort
+	// — correctness never depends on it (Classify already filters by the open
+	// window), so a failure never aborts the record sweep.
+	if _, err := overlay.NewWriteLedger(pool).PruneExpired(ctx); err != nil {
+		log.WarnContext(ctx, "overlay reconcile: pruning expired write-ledger entries failed",
+			"workspace", d.Workspace.String(), "err", err)
+	}
 	// Bind the store to THIS connection's live adapter so seeding,
 	// UpsertUserMap's email re-verification, and Ingest's owner-change
 	// revalidation all resolve against the incumbent's CURRENT owner

--- a/backend/internal/modules/overlay/writeledger.go
+++ b/backend/internal/modules/overlay/writeledger.go
@@ -161,6 +161,31 @@ func (l *WriteLedger) Classify(ctx context.Context, objectClass, externalID, pro
 	return result, nil
 }
 
+// PruneExpired deletes ledger entries older than the open window for ctx's
+// workspace — hygiene the reconcile sweep runs so the table cannot grow without
+// bound and a stale value_canonical (a short-lived duplicate of mirrored,
+// same-tenant data) is not retained past the window that could ever suppress
+// against it. Correctness never depends on it — Classify already filters
+// opened_at > now()-window, so an unpruned expired row never suppresses — this
+// only reclaims space. Returns the number of rows removed.
+func (l *WriteLedger) PruneExpired(ctx context.Context) (int64, error) {
+	var removed int64
+	err := database.WithWorkspaceTx(ctx, l.pool, func(tx pgx.Tx) error {
+		tag, execErr := tx.Exec(ctx, `
+			DELETE FROM overlay_write_ledger
+			WHERE opened_at <= now() - make_interval(secs => $1)`, l.window.Seconds())
+		if execErr != nil {
+			return execErr
+		}
+		removed = tag.RowsAffected()
+		return nil
+	})
+	if err != nil {
+		return 0, fmt.Errorf("overlay: pruning expired write-ledger entries: %w", err)
+	}
+	return removed, nil
+}
+
 // haltMirrorTx flags the workspace's mirror as halted within tx (one row per
 // workspace, upserted so a re-detection refreshes the reason/time).
 func haltMirrorTx(ctx context.Context, tx pgx.Tx, reason string) error {

--- a/backend/internal/modules/overlay/writeledger.go
+++ b/backend/internal/modules/overlay/writeledger.go
@@ -171,14 +171,14 @@ func (l *WriteLedger) Classify(ctx context.Context, objectClass, externalID, pro
 func (l *WriteLedger) PruneExpired(ctx context.Context) (int64, error) {
 	var removed int64
 	err := database.WithWorkspaceTx(ctx, l.pool, func(tx pgx.Tx) error {
+		// pgx returns a usable (zero) CommandTag alongside an error, so reading
+		// RowsAffected before returning execErr is safe — on failure removed
+		// stays 0 and the outer guard discards it.
 		tag, execErr := tx.Exec(ctx, `
 			DELETE FROM overlay_write_ledger
 			WHERE opened_at <= now() - make_interval(secs => $1)`, l.window.Seconds())
-		if execErr != nil {
-			return execErr
-		}
 		removed = tag.RowsAffected()
-		return nil
+		return execErr
 	})
 	if err != nil {
 		return 0, fmt.Errorf("overlay: pruning expired write-ledger entries: %w", err)

--- a/backend/internal/modules/overlay/writeledger_integration_test.go
+++ b/backend/internal/modules/overlay/writeledger_integration_test.go
@@ -99,6 +99,35 @@ func TestWriteLedgerKeepsDistinctValuesPerProperty(t *testing.T) {
 	}
 }
 
+// TestWriteLedgerPruneExpired proves the hygiene prune: a fresh entry survives a
+// prune at its own window, while a zero-window prune (everything expired)
+// removes it — after which the same value is a genuine change, not an echo.
+func TestWriteLedgerPruneExpired(t *testing.T) {
+	ctx, pool, _ := testWorkspaceCtx(t)
+	seedActiveConnection(ctx, t, pool)
+
+	l := NewWriteLedger(pool)
+	if err := l.OpenEntries(ctx, "contacts", "42", map[string]string{"firstname": "Ada"}); err != nil {
+		t.Fatalf("OpenEntries: %v", err)
+	}
+	// A prune at the open window removes nothing, and the entry still suppresses.
+	if n, err := l.PruneExpired(ctx); err != nil || n != 0 {
+		t.Errorf("prune of a fresh entry removed %d (err %v), want 0", n, err)
+	}
+	if c, err := l.Classify(ctx, "contacts", "42", "firstname", "Ada"); err != nil || c != ClassEcho {
+		t.Errorf("fresh entry after prune: got (%v, %v), want ClassEcho", c, err)
+	}
+
+	// A zero-window prune treats every entry as expired and reclaims it.
+	expiring := &WriteLedger{pool: pool, window: 0, hash: sha256Hex}
+	if n, err := expiring.PruneExpired(ctx); err != nil || n != 1 {
+		t.Errorf("zero-window prune removed %d (err %v), want 1", n, err)
+	}
+	if c, err := l.Classify(ctx, "contacts", "42", "firstname", "Ada"); err != nil || c != ClassGenuine {
+		t.Errorf("after prune: got (%v, %v), want ClassGenuine (entry reclaimed)", c, err)
+	}
+}
+
 // TestWriteLedgerCollisionHaltsTheMirror drives the F2 collision arm: a value
 // that HASHES like our write but differs is never suppressed — the mirror is
 // flagged and halted. A forced colliding hasher stands in for the

--- a/backend/internal/modules/overlay/writeledger_integration_test.go
+++ b/backend/internal/modules/overlay/writeledger_integration_test.go
@@ -16,6 +16,7 @@ package overlay
 // expired) rather than by faking wall-clock time.
 
 import (
+	"context"
 	"testing"
 )
 
@@ -125,6 +126,17 @@ func TestWriteLedgerPruneExpired(t *testing.T) {
 	}
 	if c, err := l.Classify(ctx, "contacts", "42", "firstname", "Ada"); err != nil || c != ClassGenuine {
 		t.Errorf("after prune: got (%v, %v), want ClassGenuine (entry reclaimed)", c, err)
+	}
+}
+
+// TestWriteLedgerPruneExpiredRequiresWorkspace: the prune runs under
+// WithWorkspaceTx, so a context with no workspace bound fails closed with a
+// surfaced error rather than a cross-tenant or unscoped delete.
+func TestWriteLedgerPruneExpiredRequiresWorkspace(t *testing.T) {
+	_, pool, _ := testWorkspaceCtx(t)
+	l := NewWriteLedger(pool)
+	if _, err := l.PruneExpired(context.Background()); err == nil {
+		t.Error("PruneExpired without a workspace-bound context must error, not run unscoped")
 	}
 }
 


### PR DESCRIPTION
## What
Closes the deferred hygiene follow-up from the echo-ledger PR (#236): the our-write ledger (OVA-DDL-6) had **no reclaimer**, so a long-lived, write-heavy overlay connection accumulated dead rows for its whole lifetime — each retaining a `value_canonical` past the window.

## Change
- `WriteLedger.PruneExpired(ctx)` — `DELETE` entries older than the open window for the workspace (workspace-scoped, DB-clock).
- The reconcile sweep runs it once per connection, **best-effort** (like the portal-binding backfill) — a failure never aborts the record sweep.

**Correctness never depended on it** — `Classify` already filters `opened_at > now()-window`, so an unpruned expired row never suppresses. This only reclaims space and stops retaining a stale `value_canonical` (a short-lived duplicate of already-mirrored, same-tenant data) past the window.

## Test
A fresh entry survives a prune at its own window and still suppresses; a zero-window prune (everything expired) reclaims it, after which the same value classifies as a genuine change.

Follow-up to #236; branch-2 hygiene track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prunes expired write-ledger entries during the reconcile sweep to prevent unbounded table growth and stop retaining stale values past the workspace window. Best-effort hygiene only; no change to classification behavior.

- **Bug Fixes**
  - Added `PruneExpired(ctx)` to delete entries older than the open window; returns rows removed.
  - Runs once per connection in reconcile; failure is logged and does not abort the sweep.
  - Added tests: fresh entries survive a normal prune; zero‑window prune reclaims them (value becomes a genuine change); workspace‑less context fails closed.

- **Refactors**
  - Simplified `PruneExpired` error handling: read RowsAffected, then return the exec error directly (no behavior change).

<sup>Written for commit 28d9c7ed1dea62bb40a8b595b03c6e99fe5c641d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

