### PR TITLE
feat(overlay): expose the budget breakdown, headroom + Search window (OVB-AC-1)

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -8356,7 +8356,38 @@ components:
               backfillComplete: { type: boolean }
     OverlayBudget:
       type: object
-      description: The incumbent API budget window's consumption and degradation band.
+      description: >-
+        The incumbent REST budget window's consumption and degradation band, its
+        per-source breakdown, honest headroom, and the per-second Search window
+        (overlay-budget.md "The budget read (wire shape)", OVB-AC-1/AC-5).
+      properties:
+        window: { type: string }
+        consumed: { type: number }
+        limit: { type: number }
+        band: { type: string, enum: [ok, warn, shed] }
+        sources:
+          type: object
+          description: >-
+            Per-source REST breakdown; the values sum exactly to `consumed`
+            (OVB-AC-5). Absent sources have spent nothing this window.
+          properties:
+            force_fresh: { type: number }
+            poller: { type: number }
+            capture: { type: number }
+        headroom:
+          type: string
+          description: >-
+            Free REST capacity derived from our own counts, or the `~unknown`
+            sentinel (OVB-PARAM-5) when a share cannot be attributed — never a
+            fabricated number (OVB-AC-1).
+        search:
+          $ref: '#/components/schemas/OverlayBudgetSearch'
+
+    OverlayBudgetSearch:
+      type: object
+      description: >-
+        The per-second Search-API window — metered, not gated, in branch 1, so the
+        admin surface sees search pressure alongside REST.
       properties:
         window: { type: string }
         consumed: { type: number }

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -8362,18 +8362,20 @@ components:
         (overlay-budget.md "The budget read (wire shape)", OVB-AC-1/AC-5).
       properties:
         window: { type: string }
-        consumed: { type: number }
-        limit: { type: number }
+        consumed: { type: integer, format: int64 }
+        limit: { type: integer, format: int64 }
         band: { type: string, enum: [ok, warn, shed] }
         sources:
           type: object
           description: >-
             Per-source REST breakdown; the values sum exactly to `consumed`
-            (OVB-AC-5). Absent sources have spent nothing this window.
+            (OVB-AC-5). Absent sources have spent nothing this window. Integer
+            counts, so the per-source sum equals `consumed` exactly (a float
+            would round independently and could break the sum above 2^24).
           properties:
-            force_fresh: { type: number }
-            poller: { type: number }
-            capture: { type: number }
+            force_fresh: { type: integer, format: int64 }
+            poller: { type: integer, format: int64 }
+            capture: { type: integer, format: int64 }
         headroom:
           type: string
           description: >-
@@ -8390,8 +8392,8 @@ components:
         admin surface sees search pressure alongside REST.
       properties:
         window: { type: string }
-        consumed: { type: number }
-        limit: { type: number }
+        consumed: { type: integer, format: int64 }
+        limit: { type: integer, format: int64 }
         band: { type: string, enum: [ok, warn, shed] }
 
     # ---- error (RFC 7807) ----

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -8364,7 +8364,7 @@ components:
         window: { type: string }
         consumed: { type: integer, format: int64 }
         limit: { type: integer, format: int64 }
-        band: { type: string, enum: [ok, warn, shed] }
+        band: { $ref: '#/components/schemas/OverlayBudgetBand' }
         sources:
           type: object
           description: >-
@@ -8394,7 +8394,15 @@ components:
         window: { type: string }
         consumed: { type: integer, format: int64 }
         limit: { type: integer, format: int64 }
-        band: { type: string, enum: [ok, warn, shed] }
+        band: { $ref: '#/components/schemas/OverlayBudgetBand' }
+
+    OverlayBudgetBand:
+      type: string
+      enum: [ok, warn, shed]
+      description: >-
+        The degradation band of a budget window — healthy (`ok`), approaching the
+        cap (`warn`), or at/over the shed threshold (`shed`). Shared by the REST
+        and Search windows so both read the one band vocabulary.
 
     # ---- error (RFC 7807) ----
     Problem:

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -3711,27 +3711,6 @@ func (e OverlayBudgetBand) Valid() bool {
 	}
 }
 
-// Defines values for OverlayBudgetSearchBand.
-const (
-	OverlayBudgetSearchBandOk   OverlayBudgetSearchBand = "ok"
-	OverlayBudgetSearchBandShed OverlayBudgetSearchBand = "shed"
-	OverlayBudgetSearchBandWarn OverlayBudgetSearchBand = "warn"
-)
-
-// Valid indicates whether the value is a known member of the OverlayBudgetSearchBand enum.
-func (e OverlayBudgetSearchBand) Valid() bool {
-	switch e {
-	case OverlayBudgetSearchBandOk:
-		return true
-	case OverlayBudgetSearchBandShed:
-		return true
-	case OverlayBudgetSearchBandWarn:
-		return true
-	default:
-		return false
-	}
-}
-
 // Defines values for OverlayConnectRequestIncumbent.
 const (
 	OverlayConnectRequestIncumbentHubspot OverlayConnectRequestIncumbent = "hubspot"
@@ -5024,19 +5003,19 @@ func (e UpdateOrganizationRequestSizeBand) Valid() bool {
 
 // Defines values for UpdateSignalRequestSeverity.
 const (
-	Info   UpdateSignalRequestSeverity = "info"
-	Urgent UpdateSignalRequestSeverity = "urgent"
-	Warn   UpdateSignalRequestSeverity = "warn"
+	UpdateSignalRequestSeverityInfo   UpdateSignalRequestSeverity = "info"
+	UpdateSignalRequestSeverityUrgent UpdateSignalRequestSeverity = "urgent"
+	UpdateSignalRequestSeverityWarn   UpdateSignalRequestSeverity = "warn"
 )
 
 // Valid indicates whether the value is a known member of the UpdateSignalRequestSeverity enum.
 func (e UpdateSignalRequestSeverity) Valid() bool {
 	switch e {
-	case Info:
+	case UpdateSignalRequestSeverityInfo:
 		return true
-	case Urgent:
+	case UpdateSignalRequestSeverityUrgent:
 		return true
-	case Warn:
+	case UpdateSignalRequestSeverityWarn:
 		return true
 	default:
 		return false
@@ -9790,6 +9769,7 @@ type OrganizationProfileFieldListResponse struct {
 
 // OverlayBudget The incumbent REST budget window's consumption and degradation band, its per-source breakdown, honest headroom, and the per-second Search window (overlay-budget.md "The budget read (wire shape)", OVB-AC-1/AC-5).
 type OverlayBudget struct {
+	// Band The degradation band of a budget window — healthy (`ok`), approaching the cap (`warn`), or at/over the shed threshold (`shed`). Shared by the REST and Search windows so both read the one band vocabulary.
 	Band     *OverlayBudgetBand `json:"band,omitempty"`
 	Consumed *int64             `json:"consumed,omitempty"`
 
@@ -9809,19 +9789,17 @@ type OverlayBudget struct {
 	Window *string `json:"window,omitempty"`
 }
 
-// OverlayBudgetBand defines model for OverlayBudget.Band.
+// OverlayBudgetBand The degradation band of a budget window — healthy (`ok`), approaching the cap (`warn`), or at/over the shed threshold (`shed`). Shared by the REST and Search windows so both read the one band vocabulary.
 type OverlayBudgetBand string
 
 // OverlayBudgetSearch The per-second Search-API window — metered, not gated, in branch 1, so the admin surface sees search pressure alongside REST.
 type OverlayBudgetSearch struct {
-	Band     *OverlayBudgetSearchBand `json:"band,omitempty"`
-	Consumed *int64                   `json:"consumed,omitempty"`
-	Limit    *int64                   `json:"limit,omitempty"`
-	Window   *string                  `json:"window,omitempty"`
+	// Band The degradation band of a budget window — healthy (`ok`), approaching the cap (`warn`), or at/over the shed threshold (`shed`). Shared by the REST and Search windows so both read the one band vocabulary.
+	Band     *OverlayBudgetBand `json:"band,omitempty"`
+	Consumed *int64             `json:"consumed,omitempty"`
+	Limit    *int64             `json:"limit,omitempty"`
+	Window   *string            `json:"window,omitempty"`
 }
-
-// OverlayBudgetSearchBand defines model for OverlayBudgetSearch.Band.
-type OverlayBudgetSearchBand string
 
 // OverlayConnectRequest defines model for OverlayConnectRequest.
 type OverlayConnectRequest struct {

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -9791,20 +9791,20 @@ type OrganizationProfileFieldListResponse struct {
 // OverlayBudget The incumbent REST budget window's consumption and degradation band, its per-source breakdown, honest headroom, and the per-second Search window (overlay-budget.md "The budget read (wire shape)", OVB-AC-1/AC-5).
 type OverlayBudget struct {
 	Band     *OverlayBudgetBand `json:"band,omitempty"`
-	Consumed *float32           `json:"consumed,omitempty"`
+	Consumed *int64             `json:"consumed,omitempty"`
 
 	// Headroom Free REST capacity derived from our own counts, or the `~unknown` sentinel (OVB-PARAM-5) when a share cannot be attributed — never a fabricated number (OVB-AC-1).
-	Headroom *string  `json:"headroom,omitempty"`
-	Limit    *float32 `json:"limit,omitempty"`
+	Headroom *string `json:"headroom,omitempty"`
+	Limit    *int64  `json:"limit,omitempty"`
 
 	// Search The per-second Search-API window — metered, not gated, in branch 1, so the admin surface sees search pressure alongside REST.
 	Search *OverlayBudgetSearch `json:"search,omitempty"`
 
-	// Sources Per-source REST breakdown; the values sum exactly to `consumed` (OVB-AC-5). Absent sources have spent nothing this window.
+	// Sources Per-source REST breakdown; the values sum exactly to `consumed` (OVB-AC-5). Absent sources have spent nothing this window. Integer counts, so the per-source sum equals `consumed` exactly (a float would round independently and could break the sum above 2^24).
 	Sources *struct {
-		Capture    *float32 `json:"capture,omitempty"`
-		ForceFresh *float32 `json:"force_fresh,omitempty"`
-		Poller     *float32 `json:"poller,omitempty"`
+		Capture    *int64 `json:"capture,omitempty"`
+		ForceFresh *int64 `json:"force_fresh,omitempty"`
+		Poller     *int64 `json:"poller,omitempty"`
 	} `json:"sources,omitempty"`
 	Window *string `json:"window,omitempty"`
 }
@@ -9815,8 +9815,8 @@ type OverlayBudgetBand string
 // OverlayBudgetSearch The per-second Search-API window — metered, not gated, in branch 1, so the admin surface sees search pressure alongside REST.
 type OverlayBudgetSearch struct {
 	Band     *OverlayBudgetSearchBand `json:"band,omitempty"`
-	Consumed *float32                 `json:"consumed,omitempty"`
-	Limit    *float32                 `json:"limit,omitempty"`
+	Consumed *int64                   `json:"consumed,omitempty"`
+	Limit    *int64                   `json:"limit,omitempty"`
 	Window   *string                  `json:"window,omitempty"`
 }
 

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -3711,6 +3711,27 @@ func (e OverlayBudgetBand) Valid() bool {
 	}
 }
 
+// Defines values for OverlayBudgetSearchBand.
+const (
+	OverlayBudgetSearchBandOk   OverlayBudgetSearchBand = "ok"
+	OverlayBudgetSearchBandShed OverlayBudgetSearchBand = "shed"
+	OverlayBudgetSearchBandWarn OverlayBudgetSearchBand = "warn"
+)
+
+// Valid indicates whether the value is a known member of the OverlayBudgetSearchBand enum.
+func (e OverlayBudgetSearchBand) Valid() bool {
+	switch e {
+	case OverlayBudgetSearchBandOk:
+		return true
+	case OverlayBudgetSearchBandShed:
+		return true
+	case OverlayBudgetSearchBandWarn:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for OverlayConnectRequestIncumbent.
 const (
 	OverlayConnectRequestIncumbentHubspot OverlayConnectRequestIncumbent = "hubspot"
@@ -5003,19 +5024,19 @@ func (e UpdateOrganizationRequestSizeBand) Valid() bool {
 
 // Defines values for UpdateSignalRequestSeverity.
 const (
-	UpdateSignalRequestSeverityInfo   UpdateSignalRequestSeverity = "info"
-	UpdateSignalRequestSeverityUrgent UpdateSignalRequestSeverity = "urgent"
-	UpdateSignalRequestSeverityWarn   UpdateSignalRequestSeverity = "warn"
+	Info   UpdateSignalRequestSeverity = "info"
+	Urgent UpdateSignalRequestSeverity = "urgent"
+	Warn   UpdateSignalRequestSeverity = "warn"
 )
 
 // Valid indicates whether the value is a known member of the UpdateSignalRequestSeverity enum.
 func (e UpdateSignalRequestSeverity) Valid() bool {
 	switch e {
-	case UpdateSignalRequestSeverityInfo:
+	case Info:
 		return true
-	case UpdateSignalRequestSeverityUrgent:
+	case Urgent:
 		return true
-	case UpdateSignalRequestSeverityWarn:
+	case Warn:
 		return true
 	default:
 		return false
@@ -9767,16 +9788,40 @@ type OrganizationProfileFieldListResponse struct {
 	Data []CompanyProfileField `json:"data"`
 }
 
-// OverlayBudget The incumbent API budget window's consumption and degradation band.
+// OverlayBudget The incumbent REST budget window's consumption and degradation band, its per-source breakdown, honest headroom, and the per-second Search window (overlay-budget.md "The budget read (wire shape)", OVB-AC-1/AC-5).
 type OverlayBudget struct {
 	Band     *OverlayBudgetBand `json:"band,omitempty"`
 	Consumed *float32           `json:"consumed,omitempty"`
-	Limit    *float32           `json:"limit,omitempty"`
-	Window   *string            `json:"window,omitempty"`
+
+	// Headroom Free REST capacity derived from our own counts, or the `~unknown` sentinel (OVB-PARAM-5) when a share cannot be attributed — never a fabricated number (OVB-AC-1).
+	Headroom *string  `json:"headroom,omitempty"`
+	Limit    *float32 `json:"limit,omitempty"`
+
+	// Search The per-second Search-API window — metered, not gated, in branch 1, so the admin surface sees search pressure alongside REST.
+	Search *OverlayBudgetSearch `json:"search,omitempty"`
+
+	// Sources Per-source REST breakdown; the values sum exactly to `consumed` (OVB-AC-5). Absent sources have spent nothing this window.
+	Sources *struct {
+		Capture    *float32 `json:"capture,omitempty"`
+		ForceFresh *float32 `json:"force_fresh,omitempty"`
+		Poller     *float32 `json:"poller,omitempty"`
+	} `json:"sources,omitempty"`
+	Window *string `json:"window,omitempty"`
 }
 
 // OverlayBudgetBand defines model for OverlayBudget.Band.
 type OverlayBudgetBand string
+
+// OverlayBudgetSearch The per-second Search-API window — metered, not gated, in branch 1, so the admin surface sees search pressure alongside REST.
+type OverlayBudgetSearch struct {
+	Band     *OverlayBudgetSearchBand `json:"band,omitempty"`
+	Consumed *float32                 `json:"consumed,omitempty"`
+	Limit    *float32                 `json:"limit,omitempty"`
+	Window   *string                  `json:"window,omitempty"`
+}
+
+// OverlayBudgetSearchBand defines model for OverlayBudgetSearch.Band.
+type OverlayBudgetSearchBand string
 
 // OverlayConnectRequest defines model for OverlayConnectRequest.
 type OverlayConnectRequest struct {

--- a/backend/internal/modules/overlay/handlers.go
+++ b/backend/internal/modules/overlay/handlers.go
@@ -283,7 +283,7 @@ func budgetToWire(b overlaybudget.Budget) crmcontracts.OverlayBudget {
 	searchWindow := b.SearchWindow
 	searchConsumed := int64(b.SearchConsumed)
 	searchLimit := int64(b.SearchLimit)
-	searchBand := crmcontracts.OverlayBudgetSearchBand(b.SearchBand)
+	searchBand := crmcontracts.OverlayBudgetBand(b.SearchBand)
 
 	return crmcontracts.OverlayBudget{
 		Window:   &window,

--- a/backend/internal/modules/overlay/handlers.go
+++ b/backend/internal/modules/overlay/handlers.go
@@ -261,20 +261,48 @@ func (h Handlers) GetOverlayBudget(w http.ResponseWriter, r *http.Request) {
 	httperr.WriteJSON(w, http.StatusOK, budgetToWire(budget))
 }
 
-// budgetToWire maps the domain Budget onto the contract's OverlayBudget
-// shape — Consumed/Limit ride as float32 per the generated schema (an
-// OpenAPI integer-as-number artifact), never fractional in practice. The
-// meter's per-source breakdown and the ~unknown headroom sentinel have no
-// field on this frozen wire shape (the admin budget surface that renders
-// them is a separate, unbuilt surface — overlay-budget chapter §"out of
-// scope"), so the endpoint reports the REST window's total, cap, and band
-// only; the breakdown stays internal to the meter.
+// budgetToWire maps the domain Budget onto the contract's OverlayBudget shape
+// (overlay-budget.md "The budget read (wire shape)", OVB-AC-1/AC-5): the REST
+// window total/cap/band, the per-source breakdown (summing to consumed), the
+// honest headroom (the meter's `~unknown` sentinel is carried through verbatim
+// as a string — never a fabricated number, OVB-AC-1), and the per-second Search
+// window. Consumed/Limit ride as float32 per the generated schema (an OpenAPI
+// integer-as-number artifact), never fractional in practice. A source that
+// spent nothing this window is a map miss (0).
 func budgetToWire(b overlaybudget.Budget) crmcontracts.OverlayBudget {
 	window := b.Window
 	consumed := float32(b.Consumed)
 	limit := float32(b.Limit)
 	band := crmcontracts.OverlayBudgetBand(b.Band)
-	return crmcontracts.OverlayBudget{Window: &window, Consumed: &consumed, Limit: &limit, Band: &band}
+	headroom := b.Headroom
+
+	forceFresh := float32(b.Breakdown[overlaybudget.SourceForceFresh])
+	poller := float32(b.Breakdown[overlaybudget.SourcePoller])
+	capture := float32(b.Breakdown[overlaybudget.SourceCapture])
+
+	searchWindow := b.SearchWindow
+	searchConsumed := float32(b.SearchConsumed)
+	searchLimit := float32(b.SearchLimit)
+	searchBand := crmcontracts.OverlayBudgetSearchBand(b.SearchBand)
+
+	return crmcontracts.OverlayBudget{
+		Window:   &window,
+		Consumed: &consumed,
+		Limit:    &limit,
+		Band:     &band,
+		Headroom: &headroom,
+		Sources: &struct {
+			Capture    *float32 `json:"capture,omitempty"`
+			ForceFresh *float32 `json:"force_fresh,omitempty"`
+			Poller     *float32 `json:"poller,omitempty"`
+		}{Capture: &capture, ForceFresh: &forceFresh, Poller: &poller},
+		Search: &crmcontracts.OverlayBudgetSearch{
+			Window:   &searchWindow,
+			Consumed: &searchConsumed,
+			Limit:    &searchLimit,
+			Band:     &searchBand,
+		},
+	}
 }
 
 // PreflightOverlayFlip dry-runs the read-mode→overlay flip's readiness

--- a/backend/internal/modules/overlay/handlers.go
+++ b/backend/internal/modules/overlay/handlers.go
@@ -266,23 +266,23 @@ func (h Handlers) GetOverlayBudget(w http.ResponseWriter, r *http.Request) {
 // window total/cap/band, the per-source breakdown (summing to consumed), the
 // honest headroom (the meter's `~unknown` sentinel is carried through verbatim
 // as a string — never a fabricated number, OVB-AC-1), and the per-second Search
-// window. Consumed/Limit ride as float32 per the generated schema (an OpenAPI
-// integer-as-number artifact), never fractional in practice. A source that
-// spent nothing this window is a map miss (0).
+// window. Counts ride as int64 (exact — a float would round independently and
+// could break the per-source sum above 2^24). A source that spent nothing this
+// window is a map miss (0).
 func budgetToWire(b overlaybudget.Budget) crmcontracts.OverlayBudget {
 	window := b.Window
-	consumed := float32(b.Consumed)
-	limit := float32(b.Limit)
+	consumed := int64(b.Consumed)
+	limit := int64(b.Limit)
 	band := crmcontracts.OverlayBudgetBand(b.Band)
 	headroom := b.Headroom
 
-	forceFresh := float32(b.Breakdown[overlaybudget.SourceForceFresh])
-	poller := float32(b.Breakdown[overlaybudget.SourcePoller])
-	capture := float32(b.Breakdown[overlaybudget.SourceCapture])
+	forceFresh := int64(b.Breakdown[overlaybudget.SourceForceFresh])
+	poller := int64(b.Breakdown[overlaybudget.SourcePoller])
+	capture := int64(b.Breakdown[overlaybudget.SourceCapture])
 
 	searchWindow := b.SearchWindow
-	searchConsumed := float32(b.SearchConsumed)
-	searchLimit := float32(b.SearchLimit)
+	searchConsumed := int64(b.SearchConsumed)
+	searchLimit := int64(b.SearchLimit)
 	searchBand := crmcontracts.OverlayBudgetSearchBand(b.SearchBand)
 
 	return crmcontracts.OverlayBudget{
@@ -292,9 +292,9 @@ func budgetToWire(b overlaybudget.Budget) crmcontracts.OverlayBudget {
 		Band:     &band,
 		Headroom: &headroom,
 		Sources: &struct {
-			Capture    *float32 `json:"capture,omitempty"`
-			ForceFresh *float32 `json:"force_fresh,omitempty"`
-			Poller     *float32 `json:"poller,omitempty"`
+			Capture    *int64 `json:"capture,omitempty"`
+			ForceFresh *int64 `json:"force_fresh,omitempty"`
+			Poller     *int64 `json:"poller,omitempty"`
 		}{Capture: &capture, ForceFresh: &forceFresh, Poller: &poller},
 		Search: &crmcontracts.OverlayBudgetSearch{
 			Window:   &searchWindow,

--- a/backend/internal/modules/overlay/handlers_test.go
+++ b/backend/internal/modules/overlay/handlers_test.go
@@ -10,10 +10,56 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/platform/overlaybudget"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
+
+// budgetF32 dereferences a generated *float32 wire field, returning -1 for a
+// nil pointer so a missing field fails a numeric assertion loudly.
+func budgetF32(p *float32) float32 {
+	if p == nil {
+		return -1
+	}
+	return *p
+}
+
+// TestBudgetToWireExposesBreakdownHeadroomAndSearch is the OVB-AC-1 admin-surface
+// contract test: the budget read carries the per-source breakdown (summing to
+// consumed, OVB-AC-5), renders unattributable headroom as the `~unknown`
+// sentinel — never a number (OVB-AC-1) — and includes the per-second Search
+// window. An absent source (capture here) spent nothing and reads 0.
+func TestBudgetToWireExposesBreakdownHeadroomAndSearch(t *testing.T) {
+	w := budgetToWire(overlaybudget.Budget{
+		Window: "24h", Consumed: 7, Limit: 10, Band: overlaybudget.BandWarn,
+		Headroom: overlaybudget.UnknownHeadroom,
+		Breakdown: map[overlaybudget.Source]int{
+			overlaybudget.SourceForceFresh: 4,
+			overlaybudget.SourcePoller:     3,
+		},
+		SearchWindow: "1s", SearchConsumed: 2, SearchLimit: 4, SearchBand: overlaybudget.BandOK,
+	})
+
+	if w.Headroom == nil || *w.Headroom != overlaybudget.UnknownHeadroom {
+		t.Errorf("headroom = %v, want the %q sentinel (never a number, OVB-AC-1)", w.Headroom, overlaybudget.UnknownHeadroom)
+	}
+	if w.Sources == nil {
+		t.Fatal("the budget read must carry the per-source breakdown (OVB-AC-1)")
+	}
+	ff, poller, capture := budgetF32(w.Sources.ForceFresh), budgetF32(w.Sources.Poller), budgetF32(w.Sources.Capture)
+	if ff != 4 || poller != 3 || capture != 0 {
+		t.Errorf("breakdown = force_fresh:%v poller:%v capture:%v, want 4/3/0", ff, poller, capture)
+	}
+	if sum := ff + poller + capture; sum != budgetF32(w.Consumed) {
+		t.Errorf("breakdown sum = %v, want consumed %v (OVB-AC-5)", sum, budgetF32(w.Consumed))
+	}
+	if w.Search == nil || budgetF32(w.Search.Consumed) != 2 || budgetF32(w.Search.Limit) != 4 ||
+		w.Search.Band == nil || *w.Search.Band != crmcontracts.OverlayBudgetSearchBandOk {
+		t.Errorf("search window not carried through: %+v", w.Search)
+	}
+}
 
 // fakeReconciler is a Reconciler stub that records whether it ran — the
 // RBAC-deny proof needs to see it was NEVER invoked when the object gate

--- a/backend/internal/modules/overlay/handlers_test.go
+++ b/backend/internal/modules/overlay/handlers_test.go
@@ -57,7 +57,7 @@ func TestBudgetToWireExposesBreakdownHeadroomAndSearch(t *testing.T) {
 	}
 	if w.Search == nil || w.Search.Window == nil || *w.Search.Window != "1s" ||
 		budgetI64(w.Search.Consumed) != 2 || budgetI64(w.Search.Limit) != 4 ||
-		w.Search.Band == nil || *w.Search.Band != crmcontracts.OverlayBudgetSearchBandOk {
+		w.Search.Band == nil || *w.Search.Band != crmcontracts.OverlayBudgetBandOk {
 		t.Errorf("search window not carried through: %+v", w.Search)
 	}
 }

--- a/backend/internal/modules/overlay/handlers_test.go
+++ b/backend/internal/modules/overlay/handlers_test.go
@@ -17,9 +17,9 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
-// budgetF32 dereferences a generated *float32 wire field, returning -1 for a
-// nil pointer so a missing field fails a numeric assertion loudly.
-func budgetF32(p *float32) float32 {
+// budgetI64 dereferences a generated *int64 wire field, returning -1 for a nil
+// pointer so a missing field fails a numeric assertion loudly.
+func budgetI64(p *int64) int64 {
 	if p == nil {
 		return -1
 	}
@@ -48,14 +48,15 @@ func TestBudgetToWireExposesBreakdownHeadroomAndSearch(t *testing.T) {
 	if w.Sources == nil {
 		t.Fatal("the budget read must carry the per-source breakdown (OVB-AC-1)")
 	}
-	ff, poller, capture := budgetF32(w.Sources.ForceFresh), budgetF32(w.Sources.Poller), budgetF32(w.Sources.Capture)
+	ff, poller, capture := budgetI64(w.Sources.ForceFresh), budgetI64(w.Sources.Poller), budgetI64(w.Sources.Capture)
 	if ff != 4 || poller != 3 || capture != 0 {
 		t.Errorf("breakdown = force_fresh:%v poller:%v capture:%v, want 4/3/0", ff, poller, capture)
 	}
-	if sum := ff + poller + capture; sum != budgetF32(w.Consumed) {
-		t.Errorf("breakdown sum = %v, want consumed %v (OVB-AC-5)", sum, budgetF32(w.Consumed))
+	if sum := ff + poller + capture; sum != budgetI64(w.Consumed) {
+		t.Errorf("breakdown sum = %v, want consumed %v (OVB-AC-5)", sum, budgetI64(w.Consumed))
 	}
-	if w.Search == nil || budgetF32(w.Search.Consumed) != 2 || budgetF32(w.Search.Limit) != 4 ||
+	if w.Search == nil || w.Search.Window == nil || *w.Search.Window != "1s" ||
+		budgetI64(w.Search.Consumed) != 2 || budgetI64(w.Search.Limit) != 4 ||
 		w.Search.Band == nil || *w.Search.Band != crmcontracts.OverlayBudgetSearchBandOk {
 		t.Errorf("search window not carried through: %+v", w.Search)
 	}

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -5136,8 +5136,25 @@ export interface components {
                 backfillComplete?: boolean;
             }[];
         };
-        /** @description The incumbent API budget window's consumption and degradation band. */
+        /** @description The incumbent REST budget window's consumption and degradation band, its per-source breakdown, honest headroom, and the per-second Search window (overlay-budget.md "The budget read (wire shape)", OVB-AC-1/AC-5). */
         OverlayBudget: {
+            window?: string;
+            consumed?: number;
+            limit?: number;
+            /** @enum {string} */
+            band?: "ok" | "warn" | "shed";
+            /** @description Per-source REST breakdown; the values sum exactly to `consumed` (OVB-AC-5). Absent sources have spent nothing this window. */
+            sources?: {
+                force_fresh?: number;
+                poller?: number;
+                capture?: number;
+            };
+            /** @description Free REST capacity derived from our own counts, or the `~unknown` sentinel (OVB-PARAM-5) when a share cannot be attributed — never a fabricated number (OVB-AC-1). */
+            headroom?: string;
+            search?: components["schemas"]["OverlayBudgetSearch"];
+        };
+        /** @description The per-second Search-API window — metered, not gated, in branch 1, so the admin surface sees search pressure alongside REST. */
+        OverlayBudgetSearch: {
             window?: string;
             consumed?: number;
             limit?: number;

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -5143,8 +5143,7 @@ export interface components {
             consumed?: number;
             /** Format: int64 */
             limit?: number;
-            /** @enum {string} */
-            band?: "ok" | "warn" | "shed";
+            band?: components["schemas"]["OverlayBudgetBand"];
             /** @description Per-source REST breakdown; the values sum exactly to `consumed` (OVB-AC-5). Absent sources have spent nothing this window. Integer counts, so the per-source sum equals `consumed` exactly (a float would round independently and could break the sum above 2^24). */
             sources?: {
                 /** Format: int64 */
@@ -5165,9 +5164,13 @@ export interface components {
             consumed?: number;
             /** Format: int64 */
             limit?: number;
-            /** @enum {string} */
-            band?: "ok" | "warn" | "shed";
+            band?: components["schemas"]["OverlayBudgetBand"];
         };
+        /**
+         * @description The degradation band of a budget window — healthy (`ok`), approaching the cap (`warn`), or at/over the shed threshold (`shed`). Shared by the REST and Search windows so both read the one band vocabulary.
+         * @enum {string}
+         */
+        OverlayBudgetBand: "ok" | "warn" | "shed";
         /** @description RFC 7807 problem+json with a stable machine `code` and structured `details`. */
         Problem: {
             /**

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -5139,14 +5139,19 @@ export interface components {
         /** @description The incumbent REST budget window's consumption and degradation band, its per-source breakdown, honest headroom, and the per-second Search window (overlay-budget.md "The budget read (wire shape)", OVB-AC-1/AC-5). */
         OverlayBudget: {
             window?: string;
+            /** Format: int64 */
             consumed?: number;
+            /** Format: int64 */
             limit?: number;
             /** @enum {string} */
             band?: "ok" | "warn" | "shed";
-            /** @description Per-source REST breakdown; the values sum exactly to `consumed` (OVB-AC-5). Absent sources have spent nothing this window. */
+            /** @description Per-source REST breakdown; the values sum exactly to `consumed` (OVB-AC-5). Absent sources have spent nothing this window. Integer counts, so the per-source sum equals `consumed` exactly (a float would round independently and could break the sum above 2^24). */
             sources?: {
+                /** Format: int64 */
                 force_fresh?: number;
+                /** Format: int64 */
                 poller?: number;
+                /** Format: int64 */
                 capture?: number;
             };
             /** @description Free REST capacity derived from our own counts, or the `~unknown` sentinel (OVB-PARAM-5) when a share cannot be attributed — never a fabricated number (OVB-AC-1). */
@@ -5156,7 +5161,9 @@ export interface components {
         /** @description The per-second Search-API window — metered, not gated, in branch 1, so the admin surface sees search pressure alongside REST. */
         OverlayBudgetSearch: {
             window?: string;
+            /** Format: int64 */
             consumed?: number;
+            /** Format: int64 */
             limit?: number;
             /** @enum {string} */
             band?: "ok" | "warn" | "shed";


### PR DESCRIPTION
## What
Downstream of **foundation #1181** (which pinned the budget-read wire shape): the overlay-admin budget read now carries what the meter already computes but `budgetToWire` was dropping.

- `sources` — the per-source REST breakdown (`force_fresh` / `poller` / `capture`), summing exactly to `consumed` (**OVB-AC-5**).
- `headroom` — the honest sentinel: the meter's `~unknown` (OVB-PARAM-5) carried through verbatim as a string, **never a fabricated number** (**OVB-AC-1**).
- `search` — the per-second Search-API window (metered-not-gated in branch 1).

## Change
- `crm.yaml` `OverlayBudget` gains `sources` / `headroom` / `search` (+ new `OverlayBudgetSearch`); regenerated `api_gen.go` + the frontend `schema.d.ts`.
- `budgetToWire` maps the domain `Budget`'s `Breakdown` / `Headroom` / `Search*` through.
- **No meter behavior change** — the meter (`overlaybudget.Budget`) already computed all of this; this is purely the surfacing OVB-AC-1's admin-surface contract test needs. Additive contract change (contract-breaking-check passes).

## Test
`TestBudgetToWireExposesBreakdownHeadroomAndSearch` (the OVB-AC-1 admin-surface contract test): the breakdown sums to `consumed`, `headroom` is the `~unknown` sentinel never a number, the Search window is carried through. The existing fail-closed budget test still passes (empty breakdown + `shed` + `~unknown`).

Contract-first: implements the shape merged in foundation #1181. No FE component consumes `OverlayBudget` yet (a rendered admin panel is a separate FE follow-up); this delivers the backend surface + its contract test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose the REST budget breakdown, honest headroom sentinel, and the per‑second Search window in the overlay-admin budget read. Switch all budget counters on the wire to int64 for exact sums; satisfies OVB-AC-1 and OVB-AC-5 with no meter behavior change.

- **New Features**
  - Added `sources`, `headroom`, and `search` to `OverlayBudget` (+ `OverlayBudgetSearch`); per‑source values sum to `consumed` (OVB-AC-5) and headroom forwards the `~unknown` sentinel as a string (OVB-AC-1).
  - Updated `budgetToWire` to pass through Breakdown/Headroom/Search with exact `int64` counters.
  - Regenerated contracts in `api_gen.go` and updated TS types in `frontend/src/api/schema.d.ts`.
  - Added contract test `TestBudgetToWireExposesBreakdownHeadroomAndSearch`.

- **Refactors**
  - Consolidated REST and Search bands to a single `OverlayBudgetBand` enum referenced by both to avoid oapi-codegen collateral and keep unrelated enums stable.

<sup>Written for commit 803989ecb05c716a42d13359a5f9a17e29a9dc16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Overlay budget responses now include per-source consumption details.
  * Added REST headroom information to help indicate remaining capacity.
  * Added Search API budget window details, including consumption, limits, and usage bands.
  * Expanded API documentation to describe the new budget response fields.

* **Bug Fixes**
  * Ensured budget breakdown values and unknown headroom states are represented consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->