### PR TITLE
fix(capture): make Gmail import survive a real mailbox — large messages, accurate scope, honest counts

### DIFF
--- a/backend/internal/compose/backfilltransport_integration_test.go
+++ b/backend/internal/compose/backfilltransport_integration_test.go
@@ -292,6 +292,27 @@ func (b *backfillWireEnv) do(ctx context.Context, t *testing.T, invoke func(http
 	return rec.Code, problem.Code
 }
 
+// driveBackfillToTerminal re-invokes the one-page-per-tick pager the way River
+// would — each snooze means "run me again" — until the run reaches a terminal
+// state (Work returns nil, not a snooze). A non-snooze error fails the test.
+func driveBackfillToTerminal(t *testing.T, w *captureBackfillWorker, args CaptureBackfillArgs) {
+	t.Helper()
+	for range 100 {
+		err := w.Work(context.Background(), &river.Job[CaptureBackfillArgs]{
+			JobRow: &rivertype.JobRow{}, Args: args,
+		})
+		var snooze *river.JobSnoozeError
+		if errors.As(err, &snooze) {
+			continue
+		}
+		if err != nil {
+			t.Fatalf("Work: %v", err)
+		}
+		return
+	}
+	t.Fatal("backfill did not terminate within 100 ticks")
+}
+
 func TestBackfillWire(t *testing.T) {
 	b := setupBackfillWire(t)
 	h := b.handlers
@@ -478,17 +499,15 @@ func TestBackfillWire(t *testing.T) {
 	})
 
 	t.Run("the pager worker walks the run to done", func(t *testing.T) {
-		if err := worker.Work(context.Background(), &river.Job[CaptureBackfillArgs]{
-			JobRow: &rivertype.JobRow{}, Args: CaptureBackfillArgs{Workspace: b.env.WS.String(), BackfillID: runID},
-		}); err != nil {
-			t.Fatalf("Work: %v", err)
-		}
+		// One page per tick: the worker snoozes between pages, so drive it as
+		// River would — re-invoke until it stops snoozing (the run terminated).
+		driveBackfillToTerminal(t, worker, CaptureBackfillArgs{Workspace: b.env.WS.String(), BackfillID: runID})
 		var out crmcontracts.BackfillStatus
 		if code, _ := b.do(b.human, t, status(crmcontracts.Gmail), "", &out); code != http.StatusOK {
 			t.Fatalf("status = %d, want 200", code)
 		}
 		if out.State != crmcontracts.BackfillStatusStateDone {
-			t.Fatalf("state = %s, want done (25 messages at 10/page finish in one 10-page tick)", out.State)
+			t.Fatalf("state = %s, want done (25 messages at 10/page across three ticks)", out.State)
 		}
 		if out.Counts == nil || out.Counts.MessagesScanned == nil || *out.Counts.MessagesScanned != 25 {
 			t.Fatalf("counts = %+v, want 25 scanned", out.Counts)

--- a/backend/internal/compose/capturejobs.go
+++ b/backend/internal/compose/capturejobs.go
@@ -124,9 +124,25 @@ type captureBackfillWorker struct {
 	log      *slog.Logger
 }
 
-// backfillPagesPerTick bounds how many pages one Work invocation walks
-// before yielding the worker slot.
-const backfillPagesPerTick = 10
+// backfillPagesPerTick bounds how many pages one Work invocation walks before
+// yielding. ONE page: a page is up to 100 messages fetched serially, each a
+// full RAW download of a real email (megabytes for a photo), so a page can
+// take minutes on a live mailbox. Committing after every page and snoozing
+// means each page runs under a FRESH job context — a slow page can never
+// starve the next of its deadline — and the meter climbs per page.
+const backfillPagesPerTick = 1
+
+// backfillTimeout overrides River's 1-minute default: one page of large real
+// messages fetched serially over the network needs real headroom, or the job
+// context dies mid-page and both the fetch and the failure-recording write
+// fail as a spurious "unreachable". (Matches the voice-build precedent of
+// overriding the default for a multi-call, network-bound job.)
+const backfillTimeout = 8 * time.Minute
+
+// Timeout gives one page-per-tick room to finish over a live mailbox.
+func (w *captureBackfillWorker) Timeout(*river.Job[CaptureBackfillArgs]) time.Duration {
+	return backfillTimeout
+}
 
 func (w *captureBackfillWorker) Work(ctx context.Context, job *river.Job[CaptureBackfillArgs]) error {
 	ws, err := ids.Parse(job.Args.Workspace)

--- a/backend/internal/compose/integration/capture_backfill_integration_test.go
+++ b/backend/internal/compose/integration/capture_backfill_integration_test.go
@@ -269,3 +269,52 @@ func TestBackfillStepFaultsAreTerminal(t *testing.T) {
 		assertTerminalError(t, startWithCursor(t, `{"page_token":"not-an-offset"}`))
 	})
 }
+
+// The backfill status reports people and companies as LIVE counts of the
+// connector-created rows since the run began (the stored counters are never
+// filled), and it excludes anything a human created — so the hero shows the
+// real reach of the import, not a stuck zero.
+func TestBackfillStatusCountsConnectorCounterpartiesSinceStart(t *testing.T) {
+	e := setupSearch(t)
+	registry := newTestCaptureRegistry(e, newTestKeyvault(t, e))
+	registry.Register(&pagedConnector{messages: 25, pageSize: 10})
+	grantCtx := e.humanWithScopes(e.Rep1, []principal.Scope{principal.ScopeRead})
+	if _, err := registry.Connect(grantCtx, "gmail", connector.Auth("refresh")); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	rep := ids.From[ids.UserKind](e.Rep1)
+
+	if _, err := registry.StartBackfill(grantCtx, "gmail", rep, 6, 25); err != nil {
+		t.Fatalf("StartBackfill: %v", err)
+	}
+	// Two connector-created counterparties (what the auto-create path lands)
+	// and one human-created person that must NOT inflate the import's count.
+	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+		for _, q := range []string{
+			`INSERT INTO person (workspace_id, full_name, source, captured_by)
+			   VALUES (current_setting('app.workspace_id')::uuid, 'Ada Capture', 'capture', 'connector:gmail')`,
+			`INSERT INTO person (workspace_id, full_name, source, captured_by)
+			   VALUES (current_setting('app.workspace_id')::uuid, 'Manually Typed', 'manual', 'human:someone')`,
+			`INSERT INTO organization (workspace_id, display_name, source, captured_by)
+			   VALUES (current_setting('app.workspace_id')::uuid, 'Acme Capture', 'capture', 'connector:gmail')`,
+		} {
+			if _, execErr := tx.Exec(e.Admin(), q); execErr != nil {
+				return execErr
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("seed counterparties: %v", err)
+	}
+
+	run, err := registry.BackfillStatus(grantCtx, "gmail", rep)
+	if err != nil || run == nil {
+		t.Fatalf("BackfillStatus: %v (run=%v)", err, run)
+	}
+	if run.People != 1 {
+		t.Fatalf("people = %d, want 1 — the connector person counted, the human one excluded", run.People)
+	}
+	if run.Organizations != 1 {
+		t.Fatalf("organizations = %d, want 1 — the connector org counted", run.Organizations)
+	}
+}

--- a/backend/internal/modules/capture/backfill.go
+++ b/backend/internal/modules/capture/backfill.go
@@ -189,12 +189,25 @@ func (r *Registry) BackfillStatus(ctx context.Context, provider string, userID i
 // "none". The connection-list read shares this with BackfillStatus so the
 // two surfaces cannot drift.
 func latestBackfill(ctx context.Context, tx pgx.Tx, connID ids.UUID) (*BackfillRun, error) {
+	// People and organizations are LIVE counts of the connector-created rows
+	// since this run began — not the capture_backfill counters, which the
+	// page-commit path never fills (the counterparty auto-create runs in its
+	// own transaction, decoupled from the page result) and so always read
+	// zero. This mirrors the morning digest's own count, so the two mail
+	// surfaces report the same reality: emails captured AND the people and
+	// companies they grew. Both tables are RLS-scoped to the workspace inside
+	// this transaction; the run's started_at bounds the window.
 	row := tx.QueryRow(ctx, `
-		SELECT id, connection_id, window_months, after_date, status, cursor, total_estimate,
-		       scanned, captured, skipped, people_created, organizations_created, dedupe_candidates,
-		       started_at, completed_at, updated_at, last_error_class
-		FROM capture_backfill WHERE connection_id = $1
-		ORDER BY created_at DESC LIMIT 1`, connID)
+		SELECT b.id, b.connection_id, b.window_months, b.after_date, b.status, b.cursor, b.total_estimate,
+		       b.scanned, b.captured, b.skipped,
+		       (SELECT count(*) FROM person
+		          WHERE captured_by LIKE 'connector:%' AND created_at >= b.started_at),
+		       (SELECT count(*) FROM organization
+		          WHERE captured_by LIKE 'connector:%' AND created_at >= b.started_at),
+		       b.dedupe_candidates,
+		       b.started_at, b.completed_at, b.updated_at, b.last_error_class
+		FROM capture_backfill b WHERE b.connection_id = $1
+		ORDER BY b.created_at DESC LIMIT 1`, connID)
 	var b BackfillRun
 	err := row.Scan(&b.ID, &b.ConnectionID, &b.WindowMonths, &b.AfterDate, &b.Status, &b.Cursor, &b.Estimate,
 		&b.Scanned, &b.Captured, &b.Skipped, &b.People, &b.Organizations, &b.DedupeCands,

--- a/backend/internal/modules/capture/backfill.go
+++ b/backend/internal/modules/capture/backfill.go
@@ -178,7 +178,7 @@ func (r *Registry) BackfillStatus(ctx context.Context, provider string, userID i
 		if err != nil {
 			return err
 		}
-		run, err = latestBackfill(ctx, tx, connID)
+		run, err = latestBackfill(ctx, tx, connID, provider)
 		return err
 	})
 	return run, err
@@ -188,26 +188,26 @@ func (r *Registry) BackfillStatus(ctx context.Context, provider string, userID i
 // caller's transaction; no run at all is (nil, nil) — the contract's state
 // "none". The connection-list read shares this with BackfillStatus so the
 // two surfaces cannot drift.
-func latestBackfill(ctx context.Context, tx pgx.Tx, connID ids.UUID) (*BackfillRun, error) {
-	// People and organizations are LIVE counts of the connector-created rows
-	// since this run began — not the capture_backfill counters, which the
-	// page-commit path never fills (the counterparty auto-create runs in its
-	// own transaction, decoupled from the page result) and so always read
-	// zero. This mirrors the morning digest's own count, so the two mail
-	// surfaces report the same reality: emails captured AND the people and
-	// companies they grew. Both tables are RLS-scoped to the workspace inside
-	// this transaction; the run's started_at bounds the window.
+func latestBackfill(ctx context.Context, tx pgx.Tx, connID ids.UUID, provider string) (*BackfillRun, error) {
+	// People and organizations are LIVE counts of the counterparties THIS
+	// connector created since the run began — not the capture_backfill
+	// counters, which the page-commit path never fills (the counterparty
+	// auto-create runs in its own transaction, decoupled from the page
+	// result) and so always read zero. Scoped to `connector:<provider>` so a
+	// second connector's captures (e.g. Calendar alongside Gmail) never
+	// inflate this run's count. Both tables are RLS-scoped to the workspace
+	// inside this transaction; the run's started_at bounds the window.
 	row := tx.QueryRow(ctx, `
 		SELECT b.id, b.connection_id, b.window_months, b.after_date, b.status, b.cursor, b.total_estimate,
 		       b.scanned, b.captured, b.skipped,
 		       (SELECT count(*) FROM person
-		          WHERE captured_by LIKE 'connector:%' AND created_at >= b.started_at),
+		          WHERE captured_by = 'connector:' || $2 AND created_at >= b.started_at),
 		       (SELECT count(*) FROM organization
-		          WHERE captured_by LIKE 'connector:%' AND created_at >= b.started_at),
+		          WHERE captured_by = 'connector:' || $2 AND created_at >= b.started_at),
 		       b.dedupe_candidates,
 		       b.started_at, b.completed_at, b.updated_at, b.last_error_class
 		FROM capture_backfill b WHERE b.connection_id = $1
-		ORDER BY b.created_at DESC LIMIT 1`, connID)
+		ORDER BY b.created_at DESC LIMIT 1`, connID, provider)
 	var b BackfillRun
 	err := row.Scan(&b.ID, &b.ConnectionID, &b.WindowMonths, &b.AfterDate, &b.Status, &b.Cursor, &b.Estimate,
 		&b.Scanned, &b.Captured, &b.Skipped, &b.People, &b.Organizations, &b.DedupeCands,

--- a/backend/internal/modules/capture/gmail/backfill.go
+++ b/backend/internal/modules/capture/gmail/backfill.go
@@ -94,16 +94,38 @@ func (c *Connector) BackfillPage(ctx context.Context, auth connector.Auth, after
 // paramMaxResults is Gmail's page-size query parameter.
 const paramMaxResults = "maxResults"
 
-// EstimateAfter returns messages.list's resultSizeEstimate for a query.
+const (
+	// estimatePageSize is Gmail's max ids per messages.list page.
+	estimatePageSize = 500
+	// estimateMaxPages bounds the count so a very large mailbox cannot turn a
+	// preview into a long scan: up to 500 × 40 = 20,000 messages are counted
+	// exactly; beyond that the returned floor is honest-but-low (the scope
+	// preview is a bound to consent to, not a contract).
+	estimateMaxPages = 40
+)
+
+// EstimateAfter counts the messages matching the query by paging their ids —
+// metadata only, no bodies — up to a page cap. Gmail's own resultSizeEstimate
+// is notoriously unreliable (off by multiples: a 1,300-message window can read
+// as ~200), which is exactly the "made-up number" a user distrusts; an exact
+// id count is a few cheap calls and honest. The count also feeds the spend
+// preview, so its accuracy is a consent property, not just cosmetics.
 func (a *httpAPI) EstimateAfter(ctx context.Context, accessToken, query string) (int, error) {
-	var out struct {
-		ResultSizeEstimate int `json:"resultSizeEstimate"` //nolint:tagliatelle // Google names this field
+	total, pageToken := 0, ""
+	for range estimateMaxPages {
+		ids, next, err := a.ListAfter(ctx, accessToken, query, pageToken, estimatePageSize)
+		if err != nil {
+			return 0, err
+		}
+		total += len(ids)
+		if next == "" {
+			return total, nil
+		}
+		pageToken = next
 	}
-	q := url.Values{"q": {query}, paramMaxResults: {"1"}}
-	if _, err := a.get(ctx, accessToken, "/messages", q, &out); err != nil {
-		return 0, err
-	}
-	return out.ResultSizeEstimate, nil
+	// Hit the page cap on a very large mailbox: report the counted floor. The
+	// live meter is the source of truth once the import runs.
+	return total, nil
 }
 
 // ListAfter returns one page of message ids matching the query.
@@ -118,7 +140,7 @@ func (a *httpAPI) ListAfter(ctx context.Context, accessToken, query, pageToken s
 	if pageToken != "" {
 		q.Set("pageToken", pageToken)
 	}
-	if _, err := a.get(ctx, accessToken, "/messages", q, &out); err != nil {
+	if _, err := a.get(ctx, accessToken, "/messages", q, &out, maxJSONResponseBytes); err != nil {
 		return nil, "", err
 	}
 	ids := make([]string, 0, len(out.Messages))

--- a/backend/internal/modules/capture/gmail/backfill_test.go
+++ b/backend/internal/modules/capture/gmail/backfill_test.go
@@ -173,12 +173,24 @@ func TestBackfillPageSurfacesListFault(t *testing.T) {
 	}
 }
 
-func TestHTTPAPIEstimateAfterReadsResultSizeEstimate(t *testing.T) {
-	var gotQuery url.Values
+func TestHTTPAPIEstimateAfterCountsIDsExactlyAcrossPages(t *testing.T) {
+	// Google's resultSizeEstimate is unreliable, so EstimateAfter counts the
+	// real ids by paging. Two pages of 2 + 1 → exactly 3, and it must NOT trust
+	// any resultSizeEstimate the same body carries.
+	var queries []url.Values
 	mux := http.NewServeMux()
 	mux.HandleFunc("/messages", func(w http.ResponseWriter, r *http.Request) {
-		gotQuery = r.URL.Query()
-		if err := json.NewEncoder(w).Encode(map[string]any{"resultSizeEstimate": 777}); err != nil {
+		q := r.URL.Query()
+		queries = append(queries, q)
+		body := map[string]any{
+			"messages":           []map[string]string{{"id": "a"}, {"id": "b"}},
+			"nextPageToken":      "p2",
+			"resultSizeEstimate": 999, // the unreliable number, deliberately ignored
+		}
+		if q.Get("pageToken") == "p2" {
+			body = map[string]any{"messages": []map[string]string{{"id": "c"}}}
+		}
+		if err := json.NewEncoder(w).Encode(body); err != nil {
 			t.Errorf("encode: %v", err)
 		}
 	})
@@ -187,11 +199,14 @@ func TestHTTPAPIEstimateAfterReadsResultSizeEstimate(t *testing.T) {
 
 	api := NewAPI(srv.Client(), srv.URL)
 	got, err := api.EstimateAfter(context.Background(), "tok", "after:2026/01/05")
-	if err != nil || got != 777 {
-		t.Fatalf("EstimateAfter = %d, %v — want Google's 777", got, err)
+	if err != nil || got != 3 {
+		t.Fatalf("EstimateAfter = %d, %v — want an exact id count of 3, not the estimate", got, err)
 	}
-	if gotQuery.Get("q") != "after:2026/01/05" || gotQuery.Get("maxResults") != "1" {
-		t.Fatalf("estimate query = %v, want the after: filter at maxResults=1 (count only, no page)", gotQuery)
+	if len(queries) != 2 {
+		t.Fatalf("made %d list calls, want 2 (paged to the end)", len(queries))
+	}
+	if queries[0].Get("q") != "after:2026/01/05" || queries[0].Get("maxResults") != "500" {
+		t.Fatalf("first query = %v, want the after: filter at maxResults=500", queries[0])
 	}
 }
 

--- a/backend/internal/modules/capture/gmail/client.go
+++ b/backend/internal/modules/capture/gmail/client.go
@@ -167,7 +167,7 @@ func (a *httpAPI) Profile(ctx context.Context, accessToken string) (string, stri
 		EmailAddress string `json:"emailAddress"` //nolint:tagliatelle // Google's wire format (camelCase); must match to decode
 		HistoryID    string `json:"historyId"`    //nolint:tagliatelle // Google's wire format (camelCase); must match to decode
 	}
-	if _, err := a.get(ctx, accessToken, "/profile", nil, &out); err != nil {
+	if _, err := a.get(ctx, accessToken, "/profile", nil, &out, maxJSONResponseBytes); err != nil {
 		return "", "", err
 	}
 	return out.EmailAddress, out.HistoryID, nil
@@ -180,7 +180,7 @@ func (a *httpAPI) ListRecent(ctx context.Context, accessToken string, maxResults
 		} `json:"messages"`
 	}
 	q := url.Values{"maxResults": {strconv.Itoa(maxResults)}}
-	if _, err := a.get(ctx, accessToken, "/messages", q, &out); err != nil {
+	if _, err := a.get(ctx, accessToken, "/messages", q, &out, maxJSONResponseBytes); err != nil {
 		return nil, err
 	}
 	ids := make([]string, 0, len(out.Messages))
@@ -216,7 +216,7 @@ func (a *httpAPI) History(ctx context.Context, accessToken, startHistoryID strin
 			q.Set("pageToken", pageToken)
 		}
 		var page historyPage
-		status, err := a.get(ctx, accessToken, "/history", q, &page)
+		status, err := a.get(ctx, accessToken, "/history", q, &page, maxJSONResponseBytes)
 		if err != nil {
 			if status == http.StatusNotFound {
 				return nil, "", ErrHistoryGone
@@ -246,7 +246,7 @@ func (a *httpAPI) GetRaw(ctx context.Context, accessToken, msgID string) ([]byte
 		Raw string `json:"raw"`
 	}
 	q := url.Values{"format": {"RAW"}}
-	status, err := a.get(ctx, accessToken, "/messages/"+url.PathEscape(msgID), q, &out)
+	status, err := a.get(ctx, accessToken, "/messages/"+url.PathEscape(msgID), q, &out, maxRawMessageBytes)
 	if status == http.StatusNotFound {
 		// Enumerated a moment ago, gone now — nothing to fetch. Skip it and
 		// let the pull continue rather than abort on a message that no longer
@@ -328,7 +328,20 @@ func retryAfter(resp *http.Response) time.Duration {
 	return 0
 }
 
-func (a *httpAPI) get(ctx context.Context, accessToken, path string, q url.Values, out any) (int, error) {
+// Read caps for the Gmail JSON responses. The metadata calls (profile, id
+// lists, history deltas) are a few KB; a single messages.get?format=RAW is
+// the whole RFC822 message base64url-encoded inside JSON. Gmail (Workspace)
+// receives messages up to ~50 MiB, and base64 inflates ~1.37×, so a RAW
+// response can exceed 68 MiB — the cap has to clear that or a large but
+// ordinary email (a phone photo) truncates the body, the JSON decode fails,
+// and the whole pull aborts on ErrUnreachable, wedging the mailbox. 96 MiB
+// leaves headroom above the provider ceiling; the metadata cap stays tight.
+const (
+	maxJSONResponseBytes = 8 << 20  // 8 MiB — metadata responses
+	maxRawMessageBytes   = 96 << 20 // 96 MiB — a full-size RAW message
+)
+
+func (a *httpAPI) get(ctx context.Context, accessToken, path string, q url.Values, out any, maxBytes int64) (int, error) {
 	u := a.base + path
 	if len(q) > 0 {
 		u += "?" + q.Encode()
@@ -344,7 +357,7 @@ func (a *httpAPI) get(ctx context.Context, accessToken, path string, q url.Value
 	}
 	//craft:ignore swallowed-errors best-effort close of the response body — the decoded result/status is what matters
 	defer func() { _ = resp.Body.Close() }()
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, 8<<20))
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxBytes))
 	if resp.StatusCode == http.StatusTooManyRequests {
 		return resp.StatusCode, &connector.RateLimitedError{RetryAfter: retryAfter(resp)}
 	}

--- a/backend/internal/modules/capture/gmail/client.go
+++ b/backend/internal/modules/capture/gmail/client.go
@@ -357,7 +357,14 @@ func (a *httpAPI) get(ctx context.Context, accessToken, path string, q url.Value
 	}
 	//craft:ignore swallowed-errors best-effort close of the response body — the decoded result/status is what matters
 	defer func() { _ = resp.Body.Close() }()
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxBytes))
+	// A read fault mid-body is a real reachability failure, distinct from the
+	// size cap (LimitReader signals the cap with EOF, not an error). Surface it
+	// as such rather than letting a truncated body fail the decode with a
+	// misleading "decoding" error.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxBytes))
+	if err != nil {
+		return resp.StatusCode, fmt.Errorf("gmail: reading %s: %w", path, ErrUnreachable)
+	}
 	if resp.StatusCode == http.StatusTooManyRequests {
 		return resp.StatusCode, &connector.RateLimitedError{RetryAfter: retryAfter(resp)}
 	}

--- a/backend/internal/modules/capture/gmail/client_test.go
+++ b/backend/internal/modules/capture/gmail/client_test.go
@@ -4,6 +4,7 @@
 package gmail
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -56,6 +57,14 @@ func googleStub(t *testing.T) *httptest.Server {
 	mux.HandleFunc("/messages/m1", func(w http.ResponseWriter, _ *http.Request) {
 		raw := base64.RawURLEncoding.EncodeToString([]byte("Subject: hi\r\n\r\nbody"))
 		writeJSON(w, map[string]any{"id": "m1", "raw": raw})
+	})
+
+	// A message whose RAW body is larger than the old 8 MiB read cap — a phone
+	// photo is enough. The response JSON exceeds 8 MiB, so a truncating reader
+	// would fail to decode it.
+	mux.HandleFunc("/messages/big", func(w http.ResponseWriter, _ *http.Request) {
+		body := append([]byte("Subject: big\r\n\r\n"), bytes.Repeat([]byte("A"), 9<<20)...)
+		writeJSON(w, map[string]any{"id": "big", "raw": base64.RawURLEncoding.EncodeToString(body)})
 	})
 
 	mux.HandleFunc("/watch", func(w http.ResponseWriter, _ *http.Request) {
@@ -178,6 +187,23 @@ func TestGetRawDecodesBase64URL(t *testing.T) {
 
 // A 404 on GetRaw (the id vanished since it was listed) maps to the skip
 // sentinel, not the reachability error — the pull skips it and continues.
+// A large message (RAW body over the old 8 MiB read cap) must decode whole,
+// not truncate — a single big email used to fail the JSON decode and wedge
+// the entire pull as a spurious "unreachable".
+func TestGetRawDecodesAMessageLargerThanEightMiB(t *testing.T) {
+	_, api := newTestClients(t)
+	raw, err := api.GetRaw(context.Background(), "access-2", "big")
+	if err != nil {
+		t.Fatalf("GetRaw on a >8 MiB message: %v", err)
+	}
+	if len(raw) < 9<<20 {
+		t.Fatalf("decoded %d bytes, want the full body (~9 MiB) — the response was truncated", len(raw))
+	}
+	if !bytes.HasPrefix(raw, []byte("Subject: big")) {
+		t.Fatalf("decoded body does not start with the header: %q", raw[:32])
+	}
+}
+
 func TestGetRawMissingMessageMapsGoneSentinel(t *testing.T) {
 	_, api := newTestClients(t)
 	// The stub only serves /messages/m1; any other id 404s, exactly as Gmail

--- a/backend/internal/modules/capture/registry_connections.go
+++ b/backend/internal/modules/capture/registry_connections.go
@@ -80,7 +80,7 @@ func (r *Registry) Connections(ctx context.Context) ([]ConnectionView, error) {
 		// A user holds at most a handful of connections, so the per-row
 		// latest-run read stays a bounded loop, not an N-problem.
 		for i := range out {
-			run, err := latestBackfill(ctx, tx, out[i].ID)
+			run, err := latestBackfill(ctx, tx, out[i].ID, out[i].Provider)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Walking the real Gmail connect flow surfaced three defects that made the coldstart from #230 fail on an actual mailbox. All three are fixed and verified live.

## 1. A large email wedged the entire import (the "didn't work at all")
The import aborted at **0 captured** with a spurious `unreachable`. Root cause: the `messages.get?format=RAW` response was read through an **8 MiB `io.LimitReader`** shared with the small metadata calls. A single ~8.3 MiB email (a phone photo) truncated the JSON, the decode failed, and every non-200/decode fault maps to `ErrUnreachable` — so one ordinary large message aborted the whole pull and wedged the mailbox. The read cap is now **per-call**: 8 MiB for metadata, **96 MiB** for a RAW message (Gmail receives up to ~50 MiB; base64 inflates ~1.37×).

Compounding it: the backfill pager walked up to **10 pages (1000 serial RAW downloads) per tick under River's default 1-minute job timeout**. Page one ate the minute; page two's fetch hit the dead context — and the failure-recording write died on it too, stranding the run `running`. The pager now runs **one page per tick** (fresh context per page, meter climbs per page) under an **8-minute timeout**.

*Verified:* paged past **1,300+** messages on a real mailbox with no aborts.

## 2. The scope estimate was "clearly made up"
The preview showed Gmail's `resultSizeEstimate`, which is wildly unreliable — a window that truly holds **~2,865** messages read as **~201** (14× low). That number is the consent surface (spend preview) *and* the progress denominator. `EstimateAfter` now **counts the real message ids** by paging metadata only (no bodies), capped at 40 pages (20,000) so a huge mailbox can't turn a preview into a long scan.

*Verified:* the same window previews **2,865** (was ~201).

## 3. The hero showed "People 0 · Companies 0" while creating dozens
The `capture_backfill.people_created`/`organizations_created` columns are read but **never written** (the counterparty auto-create runs in its own transaction, decoupled from the page commit). The status now reports them as **live counts** of connector-created rows since the run's `started_at`, mirroring the morning digest so the two mail surfaces agree; human-created records are excluded.

*Verified:* a mailbox mid-import reported **People 86 / Companies 66** where it read 0/0.

## Tests
A >8 MiB message decodes whole; the pager is driven through its snooze-per-page loop to done; the estimate counts ids exactly across pages (ignoring `resultSizeEstimate`); the two step-fault paths stay terminal; the status counts connector counterparties and excludes human ones.

Local gates green: `make check-go`, capture integration lane, gmail unit suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes Gmail imports reliable on real mailboxes by handling large messages, slowing the pager to avoid timeouts, and showing accurate previews and live creation counts. Prevents run wedges, fixes the scope estimate, and aligns the hero counters with reality.

- **Bug Fixes**
  - Large messages: per-call read caps — 96 MiB for RAW, 8 MiB for metadata — so big emails don’t abort; mid-body read faults now surface as reachability errors instead of JSON decode failures.
  - Pager robustness: one page per tick with an 8-minute worker timeout; each page commits and reschedules to avoid dead contexts and stranded runs.
  - Accurate scope: estimate counts ids (500/page) up to 40 pages (20k), ignoring Gmail’s unreliable `resultSizeEstimate`.
  - Honest hero counts: status reports live counts of connector-created `person`/`organization` rows since the run started; scoped to `connector:<provider>` and excludes human records.

<sup>Written for commit c540a35afaae3f99f00b99f3325eb8148f95c35c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Backfill progress now advances reliably in smaller steps, with more time available for each step.
  - Backfill status counts now accurately reflect connector-created people and organizations since the run began.
  - Gmail backfill estimates now count messages across pages instead of relying on potentially inaccurate provider estimates.
  - Gmail imports can now handle substantially larger message payloads without decoding failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->