### PR TITLE
fix(overlay): make HubSpot sync work against a real portal (4 live-found bugs)

### DIFF
--- a/backend/internal/compose/jobs_overlay.go
+++ b/backend/internal/compose/jobs_overlay.go
@@ -153,17 +153,6 @@ func (w *overlayRefetchWorker) Work(ctx context.Context, job *river.Job[OverlayR
 	return nil
 }
 
-// overlayObjectClasses are the HubSpot object classes design.md §9 maps —
-// the poller sweeps each, per due connection, resuming each object class's
-// own persisted watermark. The five engagement classes
-// (calls/meetings/emails/notes/tasks) are swept separately: HubSpot v3 has
-// no generic engagements object, and each maps to its own activity kind
-// (OVA-MAP-1).
-var overlayObjectClasses = append([]string{
-	overlay.IncumbentClassContacts, overlay.IncumbentClassCompanies,
-	overlay.IncumbentClassDeals, overlay.IncumbentClassLeads,
-}, overlay.IncumbentEngagementClasses()...)
-
 // overlayReconcileWorker walks every overlay-mode workspace's active
 // incumbent connection (overlay.DueOverlayConnections — the same
 // fleet-walk shape gmailSyncWorker drives via capture.Registry.
@@ -397,12 +386,24 @@ func reconcileConnection(ctx context.Context, pool *pgxpool.Pool, vault keyvault
 	}
 
 	for _, objectClass := range overlayObjectClasses {
-		// A connection-level failure sweeping any class aborts the whole
-		// sweep (the caller backs the connection off); a per-object failure
-		// was already logged inside sweepObjectClass and skips only that
-		// class, so the loop moves on.
+		// A connection-level failure sweeping a SCOPE-BACKED class
+		// (contacts/companies/deals) aborts the whole sweep (the caller backs
+		// the connection off); a per-object failure was already logged inside
+		// sweepObjectClass and skips only that class. leads and the engagement
+		// classes are swept best-effort with no requested scope, so a portal
+		// that gates one of them (a 403/404 for that object alone) skips just
+		// that class here — overlaySweepAborts encodes the distinction.
 		if err := sweepObjectClass(ctx, inc, ms, meter, log, d.Workspace.String(), objectClass); err != nil {
-			return err
+			if overlaySweepAborts(objectClass, err) {
+				return err
+			}
+			// A best-effort class (leads/engagements, swept with no requested
+			// scope) failed on a per-object condition — a missing scope, an
+			// absent object, or a portal-shaped validation error. Log the full
+			// err (the cause varies) and move on; it never breaks the
+			// scope-backed classes.
+			log.WarnContext(ctx, "overlay reconcile: best-effort object class sweep failed, skipping it",
+				"workspace", d.Workspace.String(), "object_class", objectClass, "err", err)
 		}
 	}
 	return nil

--- a/backend/internal/compose/jobs_test.go
+++ b/backend/internal/compose/jobs_test.go
@@ -11,7 +11,9 @@ import (
 	"github.com/riverqueue/river/rivertype"
 
 	"github.com/gradionhq/margince/backend/internal/modules/overlay"
+	"github.com/gradionhq/margince/backend/internal/modules/overlay/hubspot"
 	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
@@ -31,6 +33,42 @@ func TestJobKindsAreStable(t *testing.T) {
 	}
 	if got := (TimeScanArgs{}).Kind(); got != "time_scan" {
 		t.Errorf("TimeScanArgs.Kind() = %q, want time_scan", got)
+	}
+}
+
+// TestOverlaySweepAbortsToleratesBestEffortClassInaccessibility pins the
+// connection sweep's abort-vs-skip decision. The overlay requests read scope
+// for exactly contacts/companies/deals (connection.go
+// leastPrivilegeHubSpotScopes), so a permission/absence error sweeping one of
+// THOSE is a real connection-level failure (token revoked or downscoped) and
+// aborts the whole sweep. leads and the engagement classes are swept
+// best-effort with no requested scope; a portal that gates one of them
+// (HubSpot 403s leads and emails on a starter portal, confirmed against a live
+// developer account) must skip only that class, never abort the classes we do
+// hold scope for. A portal-wide failure (an outage or quota exhaustion) still
+// aborts even a best-effort class.
+func TestOverlaySweepAbortsToleratesBestEffortClassInaccessibility(t *testing.T) {
+	cases := []struct {
+		name        string
+		objectClass string
+		err         error
+		wantAbort   bool
+	}{
+		{"required class, permission denied -> abort", overlay.IncumbentClassContacts, apperrors.ErrPermissionDenied, true},
+		{"required class, not found -> abort", overlay.IncumbentClassCompanies, apperrors.ErrNotFound, true},
+		{"required class, permission denied -> abort (deals)", overlay.IncumbentClassDeals, apperrors.ErrPermissionDenied, true},
+		{"best-effort leads, permission denied -> skip", overlay.IncumbentClassLeads, apperrors.ErrPermissionDenied, false},
+		{"best-effort leads, not found -> skip", overlay.IncumbentClassLeads, apperrors.ErrNotFound, false},
+		{"best-effort engagement (emails), permission denied -> skip", "emails", apperrors.ErrPermissionDenied, false},
+		{"best-effort engagement (meetings), validation 400/unreachable -> skip", "meetings", hubspot.ErrUnreachable, false},
+		{"best-effort leads, outage/unreachable -> skip (scope-backed classes swept first)", overlay.IncumbentClassLeads, hubspot.ErrUnreachable, false},
+		{"best-effort leads, budget exhausted -> abort (connection-wide quota)", overlay.IncumbentClassLeads, apperrors.ErrIncumbentBudgetExhausted, true},
+		{"best-effort leads, connection gone -> abort (disconnect race, connection-wide)", overlay.IncumbentClassLeads, overlay.ErrConnectionGone, true},
+	}
+	for _, tc := range cases {
+		if got := overlaySweepAborts(tc.objectClass, tc.err); got != tc.wantAbort {
+			t.Errorf("%s: overlaySweepAborts(%q, %v) = %v, want %v", tc.name, tc.objectClass, tc.err, got, tc.wantAbort)
+		}
 	}
 }
 

--- a/backend/internal/compose/overlay.go
+++ b/backend/internal/compose/overlay.go
@@ -179,35 +179,37 @@ type overlayReconciler struct {
 }
 
 func (r overlayReconciler) Reconcile(ctx context.Context) error {
-	wsID, ok := principal.WorkspaceID(ctx)
-	if !ok {
+	if _, ok := principal.WorkspaceID(ctx); !ok {
 		return fmt.Errorf("compose: reconcile called outside a workspace context")
 	}
-	// DueOverlayConnections is a fleet-wide, rls-exempt enumerator (it has
-	// to be: workspace is not itself workspace-scoped) — filtered down to
-	// the ONE connection this request's own workspace owns, rather than
-	// sweeping every tenant on an admin's single-workspace request.
-	due, err := overlay.DueOverlayConnections(ctx, r.pool)
+	// An explicit "sync my workspace now" resolves THIS workspace's active
+	// connection DIRECTLY via ActiveConnection — never the poller's
+	// DueOverlayConnections, whose next_sweep_at backoff gate would make a
+	// connection the poller recently swept (or one still backed off from an
+	// earlier failure) silently answer "not due". Routing the on-demand call
+	// through that gate turned a squarely-in-overlay-mode workspace into a
+	// misleading mode_not_overlay whenever the poller had just run — an admin
+	// pressing "sync now" must not be told the workspace is not in overlay
+	// mode. The backoff is the poller's own concern, not the human's.
+	d, err := overlay.ActiveConnection(ctx, r.pool)
 	if err != nil {
-		return fmt.Errorf("compose: reconcile: listing overlay-mode workspaces: %w", err)
-	}
-	for _, d := range due {
-		if d.Workspace.UUID == wsID {
-			err := reconcileConnection(ctx, r.pool, r.vault, r.ms, r.meter, r.log, d, r.newIncumbent)
-			if errors.Is(err, overlay.ErrConnectionGone) {
-				// The connection was revoked between the due-scan above and the
-				// sweep's first fenced write (a disconnect racing this on-demand
-				// reconcile). That is the same mode-question the fallthrough
-				// below answers — not an opaque 500 — so collapse it here.
-				return apperrors.ErrModeNotOverlay
-			}
-			return err
+		if errors.Is(err, apperrors.ErrNotFound) {
+			// No active connection for THIS workspace — the same mode-question
+			// GetSyncStatus/GetBudget answer with ErrModeNotOverlay, since a
+			// reconcile sweep is meaningless without one.
+			return apperrors.ErrModeNotOverlay
 		}
+		return fmt.Errorf("compose: reconcile: resolving the active overlay connection: %w", err)
 	}
-	// No active connection for THIS workspace — the same mode-question
-	// GetSyncStatus/GetBudget answer with ErrModeNotOverlay, since a
-	// reconcile sweep is meaningless without one.
-	return apperrors.ErrModeNotOverlay
+	err = reconcileConnection(ctx, r.pool, r.vault, r.ms, r.meter, r.log, d, r.newIncumbent)
+	if errors.Is(err, overlay.ErrConnectionGone) {
+		// The connection was revoked between the resolve above and the sweep's
+		// first fenced write (a disconnect racing this on-demand reconcile).
+		// That is the same mode-question ErrNotFound answers above — not an
+		// opaque 500 — so collapse it here.
+		return apperrors.ErrModeNotOverlay
+	}
+	return err
 }
 
 // overlayMetricsSection answers the /metrics overlay section for srv,

--- a/backend/internal/compose/overlay_sweep_policy.go
+++ b/backend/internal/compose/overlay_sweep_policy.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// This file is the overlay reconcile sweep's object-class policy: which
+// HubSpot classes the poller sweeps, and — for each — whether a failure
+// sweeping it must abort the whole connection sweep or is tolerated as a
+// best-effort miss. Kept beside jobs_overlay.go's sweep loop (its only
+// caller) but in its own file so that loop stays focused on orchestration.
+
+import (
+	"errors"
+
+	"github.com/gradionhq/margince/backend/internal/modules/overlay"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+)
+
+// overlayObjectClasses are the HubSpot object classes design.md §9 maps —
+// the poller sweeps each, per due connection, resuming each object class's
+// own persisted watermark. The five engagement classes
+// (calls/meetings/emails/notes/tasks) are swept separately: HubSpot v3 has
+// no generic engagements object, and each maps to its own activity kind
+// (OVA-MAP-1).
+var overlayObjectClasses = append([]string{
+	overlay.IncumbentClassContacts, overlay.IncumbentClassCompanies,
+	overlay.IncumbentClassDeals, overlay.IncumbentClassLeads,
+}, overlay.IncumbentEngagementClasses()...)
+
+// scopeBackedOverlayClass reports whether the overlay connection requests a
+// read scope for objectClass. connection.go's leastPrivilegeHubSpotScopes
+// covers exactly contacts/companies/deals; leads and the engagement classes
+// are swept best-effort with no requested scope. Kept in lockstep with that
+// scope list — a class added there must be added here.
+func scopeBackedOverlayClass(objectClass string) bool {
+	switch objectClass {
+	case overlay.IncumbentClassContacts, overlay.IncumbentClassCompanies, overlay.IncumbentClassDeals:
+		return true
+	default:
+		return false
+	}
+}
+
+// overlaySweepAborts decides whether a connection-level sweep error for
+// objectClass must abort the whole connection sweep. A scope-backed class
+// (contacts/companies/deals) always aborts on a connection-level error — a
+// 403/404 there means the token we DO hold scope with was revoked or
+// downscoped. A best-effort class (leads and the engagement classes, swept
+// with no requested scope) never breaks the classes we can sync — but it still
+// aborts on a CONNECTION-WIDE condition: budget exhaustion (continuing to spend
+// against an exhausted quota is pointless) or ErrConnectionGone (a disconnect
+// racing the sweep — the connection no longer exists, so the on-demand
+// reconciler must see this to collapse it to ErrModeNotOverlay, and the poller
+// must not reset backoff on a dead connection). Every per-OBJECT failure — a
+// missing scope (403), an absent object (404), or a validation 400 on an
+// engagement endpoint this portal shapes differently — is skipped for a
+// best-effort class, because these were swept without validation against every
+// portal shape and a scope-backed outage would already have aborted earlier in
+// the loop (the scope-backed classes are swept first).
+func overlaySweepAborts(objectClass string, err error) bool {
+	if scopeBackedOverlayClass(objectClass) {
+		return true
+	}
+	return errors.Is(err, apperrors.ErrIncumbentBudgetExhausted) ||
+		errors.Is(err, overlay.ErrConnectionGone)
+}

--- a/backend/internal/modules/overlay/hubspot/adapter_internal_test.go
+++ b/backend/internal/modules/overlay/hubspot/adapter_internal_test.go
@@ -25,3 +25,24 @@ func TestWatermarkPropertyPerObject(t *testing.T) {
 		}
 	}
 }
+
+// TestEveryMappingProjectsOwnerVisibility is the OVA-MAP fitness function
+// behind ownerIDField's own doc: every mirrored object class MUST map
+// hubspot_owner_id → owner_id, because ProjectOwnerVisibility grants the
+// owner's seats their visibility from that field — a class that omits it
+// ingests rows no one can ever see. Derived from objectMappings so a
+// newly-added class is covered without editing this test.
+func TestEveryMappingProjectsOwnerVisibility(t *testing.T) {
+	for _, m := range objectMappings {
+		var found bool
+		for _, f := range m.Fields {
+			if f.To == "owner_id" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("object mapping %q (target %q) does not map to owner_id; every mirrored class must, or its rows are invisible (see ownerIDField's doc)", m.Source, m.Target)
+		}
+	}
+}

--- a/backend/internal/modules/overlay/hubspot/adapter_test.go
+++ b/backend/internal/modules/overlay/hubspot/adapter_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -134,6 +135,26 @@ func TestAdapterModifiedUsesLastModifiedDateWatermarkForContacts(t *testing.T) {
 	sort0, _ := sorts[0].(map[string]any)
 	if sort0["propertyName"] != "lastmodifieddate" {
 		t.Fatalf("sorts[0].propertyName = %v, want lastmodifieddate (design §7's contacts watermark)", sort0["propertyName"])
+	}
+
+	// The watermark filter value must be epoch MILLISECONDS, not an RFC 3339
+	// string: HubSpot's Search API rejects a datetime filter given an RFC 3339
+	// value with a 400, so an RFC-formatted sweep never returns a record.
+	groups, _ := gotBody["filterGroups"].([]any)
+	if len(groups) != 1 {
+		t.Fatalf("filterGroups = %#v, want exactly one group", gotBody["filterGroups"])
+	}
+	filters, _ := groups[0].(map[string]any)["filters"].([]any)
+	if len(filters) != 1 {
+		t.Fatalf("filterGroups[0].filters = %#v, want exactly one filter", groups[0])
+	}
+	f0, _ := filters[0].(map[string]any)
+	if f0["propertyName"] != "lastmodifieddate" || f0["operator"] != "GTE" {
+		t.Fatalf("filter = %#v, want lastmodifieddate GTE", f0)
+	}
+	wantValue := strconv.FormatInt(since.UnixMilli(), 10)
+	if f0["value"] != wantValue {
+		t.Fatalf("filter value = %v, want epoch-millis %q (HubSpot 400s on an RFC 3339 datetime value)", f0["value"], wantValue)
 	}
 
 	if page.NextCursor != "2" {

--- a/backend/internal/modules/overlay/hubspot/mapping_hs.go
+++ b/backend/internal/modules/overlay/hubspot/mapping_hs.go
@@ -266,6 +266,7 @@ var dealsMapping = overlay.ObjectMapping{
 		{From: []string{"pipeline"}, To: "pipeline_id", Kind: overlay.TargetColumn},
 		{From: []string{"dealstage"}, To: "stage_id", Kind: overlay.TargetColumn},
 		{From: []string{"closedate"}, To: "expected_close_date", Kind: overlay.TargetColumn},
+		ownerIDField,
 	},
 }
 

--- a/backend/internal/modules/overlay/hubspot/search.go
+++ b/backend/internal/modules/overlay/hubspot/search.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"net/http"
 	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -40,11 +41,24 @@ func (c *Client) SearchModified(
 			Filters: []searchFilter{{
 				PropertyName: watermarkProperty,
 				Operator:     "GTE",
-				Value:        since.UTC().Format(time.RFC3339Nano),
+				Value:        hsMillis(since),
 			}},
 		}},
 	}
 	return c.search(ctx, objectClass, body)
+}
+
+// hsMillis renders t as the epoch-millisecond string HubSpot's Search API
+// requires for a datetime property filter — an RFC 3339 string is rejected
+// with a 400, so the watermark sweep must send millis. A zero/pre-epoch
+// watermark (the first sweep after a fresh connect) floors to "0" so the
+// GTE filter means "everything", never a negative epoch HubSpot would reject.
+func hsMillis(t time.Time) string {
+	ms := t.UnixMilli()
+	if ms < 0 {
+		ms = 0
+	}
+	return strconv.FormatInt(ms, 10)
 }
 
 // searchSort is one entry of a Search request's sorts array. HubSpot

--- a/docs/how-to/test-overlay-locally.md
+++ b/docs/how-to/test-overlay-locally.md
@@ -73,8 +73,12 @@ curl -sS -X POST http://localhost:8080/v1/overlay/connection -b cookies.txt \
   -H 'content-type: application/json' \
   -d '{"incumbent":"hubspot","region":"us","privateAppToken":"pat-XXXX"}'
 
-# 4. Trigger the initial backfill now (else it runs on the poller interval)
-curl -sS -X POST http://localhost:8080/v1/overlay/reconcile -b cookies.txt
+# 4. Trigger the initial backfill now (else it runs on the poller interval).
+#    Call the API DIRECTLY on :18080, not the :8080 Vite proxy: the first
+#    sweep is synchronous and can run ~30s+, and the dev proxy hangs up long
+#    requests (you'd see a spurious 500 / "socket hang up" even though the API
+#    returns 202). The background poller also runs it every ~2min regardless.
+curl -sS -X POST http://localhost:18080/v1/overlay/reconcile -b cookies.txt
 
 # 5. Watch it hydrate, then read the fixture back FROM THE MIRROR
 curl -sS http://localhost:8080/v1/overlay/sync-status -b cookies.txt | jq '.objects'
@@ -112,9 +116,13 @@ HUBSPOT_TOKEN=pat-XXXX scripts/overlay-hubspot-fixture.sh whoami  # print the ow
 
 - **Connected but the mirror is empty.** The owner-email rule above — your margince admin email must
   equal the fixture owner's email. Re-check with `… whoami`; fix `config/margince.yaml` + `make dev-fresh`.
-- **A whole object class stays empty / a `403` in the `make dev` worker logs.** A missing read scope on
-  the token. Leads are best-effort — if `crm.objects.leads.read` is absent (or the object isn't
-  enabled) only leads are skipped; contacts/companies/deals still mirror.
+- **`leads`/`emails`/engagement `403`/`400` skips in the `make dev` worker logs.** Expected, not a
+  failure. The overlay requests read scope only for contacts/companies/deals; leads and the engagement
+  classes (calls/meetings/emails/notes/tasks) are swept **best-effort** with no requested scope, so a
+  portal that gates one of them (HubSpot 403s leads/emails, 400s some engagement endpoints on a starter
+  portal) logs a "best-effort object class not accessible … skipping" line and moves on. The
+  scope-backed classes (contacts/companies/deals → person/organization/deal) still mirror fully. A `403`
+  on one of *those* three, by contrast, is a real token/scope problem and aborts the sweep.
 - **`sync-status` shows `pending`/`stale`.** Give the poller a beat or `POST /overlay/reconcile` again;
   `backfillComplete: true` + `state: "fresh"` per class means it's caught up.
 - **`budget.band` is `shed`.** Force-fresh reads are degrading to the mirror rather than spending live

--- a/scripts/overlay-hubspot-fixture.sh
+++ b/scripts/overlay-hubspot-fixture.sh
@@ -33,7 +33,8 @@ else
   TOKEN="${1:-}"; SUBCMD="${2:-}"
 fi
 # Markers that identify OUR fixture records (and nothing else).
-EMAIL_DOMAIN="overlay-fixture.test"     # contact emails end with @overlay-fixture.test
+EMAIL_DOMAIN="overlay-fixture.example.com"  # contact emails end here; a valid TLD
+                                        # (HubSpot rejects the reserved .test TLD as INVALID_EMAIL)
 NAME_PREFIX="[fixture] "                # company/deal/lead names start with this
 
 if [ -z "${TOKEN}" ]; then
@@ -100,16 +101,19 @@ associate() {
 }
 
 # archive_marked OBJECT SEARCH_JSON — search fixtures by marker, batch-archive
-# ONLY those. Paginates until the search is exhausted.
+# ONLY those. Paginates until the search is exhausted. A failed search (e.g. an
+# object not enabled on the account) propagates as a non-zero return so the
+# caller's best-effort guard can skip it — never a spurious "archived" line.
 archive_marked() {
-  local object="$1" search="$2" ids after resp
+  local object="$1" search="$2" ids count after resp
   while :; do
-    resp="$(hs POST "/crm/v3/objects/${object}/search" "$(printf '%s' "$search" | jq --arg a "${after:-}" '. + (if $a=="" then {} else {after:$a} end)')")"
-    ids="$(printf '%s' "$resp" | jq -r '[.results[].id] | @json')"
-    if [ "$ids" != "[]" ]; then
+    resp="$(hs POST "/crm/v3/objects/${object}/search" "$(printf '%s' "$search" | jq --arg a "${after:-}" '. + (if $a=="" then {} else {after:$a} end)')")" || return 1
+    count="$(printf '%s' "$resp" | jq -r '.results | length')"
+    if [ "${count:-0}" -gt 0 ]; then
+      ids="$(printf '%s' "$resp" | jq -c '[.results[].id]')"
       hs POST "/crm/v3/objects/${object}/batch/archive" \
-        "$(printf '%s' "$ids" | jq '{inputs: [ .[] | {id: .} ]}')" >/dev/null
-      echo "  archived $(printf '%s' "$ids" | jq 'length') ${object}"
+        "$(printf '%s' "$ids" | jq '{inputs: [ .[] | {id: .} ]}')" >/dev/null || return 1
+      echo "  archived ${count} ${object}"
     fi
     after="$(printf '%s' "$resp" | jq -r '.paging.next.after // empty')"
     [ -n "$after" ] || break
@@ -138,14 +142,14 @@ cmd_seed() {
 
   # Companies
   local acme globex
-  acme="$(create companies "$(jq -n --arg o "$OWNER_ID" '{properties:{name:"[fixture] Acme Overlay",domain:"acme.overlay-fixture.test",hubspot_owner_id:$o}}')")"
-  globex="$(create companies "$(jq -n --arg o "$OWNER_ID" '{properties:{name:"[fixture] Globex Overlay",domain:"globex.overlay-fixture.test",hubspot_owner_id:$o}}')")"
+  acme="$(create companies "$(jq -n --arg o "$OWNER_ID" '{properties:{name:"[fixture] Acme Overlay",domain:"acme.overlay-fixture.example.com",hubspot_owner_id:$o}}')")"
+  globex="$(create companies "$(jq -n --arg o "$OWNER_ID" '{properties:{name:"[fixture] Globex Overlay",domain:"globex.overlay-fixture.example.com",hubspot_owner_id:$o}}')")"
 
   # Contacts
   local ada grace linus
-  ada="$(create contacts "$(jq -n --arg o "$OWNER_ID" '{properties:{email:"ada.fixture@overlay-fixture.test",firstname:"Ada",lastname:"Lovelace",hubspot_owner_id:$o}}')")"
-  grace="$(create contacts "$(jq -n --arg o "$OWNER_ID" '{properties:{email:"grace.fixture@overlay-fixture.test",firstname:"Grace",lastname:"Hopper",hubspot_owner_id:$o}}')")"
-  linus="$(create contacts "$(jq -n --arg o "$OWNER_ID" '{properties:{email:"linus.fixture@overlay-fixture.test",firstname:"Linus",lastname:"Torvalds",hubspot_owner_id:$o}}')")"
+  ada="$(create contacts "$(jq -n --arg o "$OWNER_ID" '{properties:{email:"ada.fixture@overlay-fixture.example.com",firstname:"Ada",lastname:"Lovelace",hubspot_owner_id:$o}}')")"
+  grace="$(create contacts "$(jq -n --arg o "$OWNER_ID" '{properties:{email:"grace.fixture@overlay-fixture.example.com",firstname:"Grace",lastname:"Hopper",hubspot_owner_id:$o}}')")"
+  linus="$(create contacts "$(jq -n --arg o "$OWNER_ID" '{properties:{email:"linus.fixture@overlay-fixture.example.com",firstname:"Linus",lastname:"Torvalds",hubspot_owner_id:$o}}')")"
   associate contacts "$ada" companies "$acme"
   associate contacts "$grace" companies "$acme"
   associate contacts "$linus" companies "$globex"


### PR DESCRIPTION
## Context
Validated the overlay end-to-end against a **real HubSpot developer account** (the setup #245 added). Four defects surfaced that the fake-incumbent unit tests structurally could not catch — each fixed with a regression or fitness test, all confirmed live (deals, people, organizations now mirror and are visible).

## The four bugs

1. **Watermark filter format** (`search.go`) — the incremental modified-records sweep sent the `hs_lastmodifieddate` `GTE` value as an RFC 3339 string; HubSpot's Search API requires **epoch milliseconds** and 400s otherwise, which blocked *all* continuous sync. `hsMillis` now emits epoch-millis (flooring a zero/pre-epoch watermark to `"0"`). The fake test server accepted any value, hiding it — `adapter_test.go` now asserts the epoch-millis value.

2. **Deals invisible** (`mapping_hs.go`) — `dealsMapping` was the *only* object mapping missing `ownerIDField`, so deals ingested owner-less and received **no `mirror_visibility` rows** → invisible to everyone. Added `ownerIDField` + `TestEveryMappingProjectsOwnerVisibility`, a fitness test derived from `objectMappings` that fails if any future mapping omits the owner.

3. **Best-effort classes aborting the whole sweep** (`overlay_sweep_policy.go` + `jobs_overlay.go`) — leads + engagement classes are swept but their read scopes are never requested (`leastPrivilegeHubSpotScopes` covers only contacts/companies/deals), so a real portal 403s leads/emails and 400s some engagement endpoints, aborting the entire sync. `overlaySweepAborts` now skips a best-effort class on a per-object failure while still aborting on a **connection-wide** condition (budget exhaustion or `ErrConnectionGone`); scope-backed classes still abort on any connection-level error. Extracted to its own file to keep `jobs_overlay.go` under the 500-line cap.

4. **On-demand reconcile 404** (`overlay.go`) — `POST /overlay/reconcile` filtered the poller's backoff-gated `DueOverlayConnections`, so a recently-swept/backed-off connection made "sync now" wrongly answer `mode_not_overlay`. Now resolves the caller's connection directly via `ActiveConnection` (ignores backoff; RLS-scoped, *tighter* than the old fleet-walk filter).

Plus: the fixture script uses a valid-TLD marker domain (HubSpot rejects `.test` emails) with a hardened `archive_marked`; `test-overlay-locally.md` documents calling reconcile on `:18080` (the dev proxy hangs up the long synchronous first sweep) and the expected best-effort skip logs.

## Review
Backend merge gate green; `craft static` 0 blockers. Reviewed by craft-reviewer + security-redteam (two rounds): craft's one blocking finding (`overlaySweepAborts` swallowed `ErrConnectionGone` for best-effort classes, defeating the disconnect-race collapse) is fixed with a test; security found no exploitable issues and confirmed the `ActiveConnection` switch tightens tenant isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes four live-found bugs so HubSpot continuous sync runs, deals are visible, best‑effort classes don’t abort sweeps, and on‑demand reconcile works even during backoff.

- **Bug Fixes**
  - Watermark filter uses epoch milliseconds (not RFC 3339) to avoid 400s and unblock incremental sync; adds `hsMillis` and an assertion test.
  - Deals mapping includes `owner_id`, restoring visibility; adds a fitness test to ensure every mapping projects owner visibility.
  - Leads/engagements are treated as best‑effort: per‑object 403/404/400 skips no longer abort the sweep; still abort on connection‑wide errors (budget exhausted, `ErrConnectionGone`); adds a policy helper + unit test to pin abort vs skip.
  - `POST /overlay/reconcile` resolves the caller’s `ActiveConnection` directly (ignores poller backoff) and collapses a disconnect race to `mode_not_overlay`.

- **Docs & Scripts**
  - Fixture uses `overlay-fixture.example.com` and hardens `archive_marked` to reflect failed searches accurately.
  - Local guide: call reconcile on `:18080` to avoid proxy timeouts and expect best‑effort skip logs for leads/engagements on limited portals.

<sup>Written for commit 3e1f53a14d19cb4f1bac24c6dd28381270c75ff2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/247?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

