### PR TITLE
feat(connectors): connect-initiate — add-a-connection in Settings + Microsoft in onboarding

### DIFF
--- a/docs/explanation/capture-connectors.md
+++ b/docs/explanation/capture-connectors.md
@@ -221,8 +221,10 @@ flag/env table is [reference/configuration.md → Capture connector OAuth](../re
 
 ## The connect UI
 
-Two entry points, both hitting the same API, and both now able to *start* every backend-live connector —
-the connect-initiate gap the roster used to have (a connection with no way to add it) is closed:
+Two entry points, both hitting the same API, and between them able to *start* every backend-live
+connector — the connect-initiate gap the roster used to have (a connection with no way to add it) is
+closed: onboarding starts Gmail, Microsoft, and IMAP; Settings adds those three plus Google Calendar,
+which has no onboarding chip and so is Settings-only.
 
 - **Onboarding → connect step** (`onboarding-connect-panels.tsx`) — where a fresh install *adds* a
   connection. `OAuthConnectPanel` is parametrized by provider (`gmail` or `graph`): a full-page OAuth
@@ -247,7 +249,7 @@ Per [STATUS.md](../../STATUS.md) — the pipeline is live; these were scoped out
 - **No onboarding chip for Calendar.** `gcal` is a fully wired OAuth connector (same
   `connect`/`callback`/`disconnect` + sync as Gmail/Graph); Settings' **Add a connection** footer starts
   one, but the onboarding connect step's three chips (Google, Microsoft, IMAP) don't include it — adding
-  Calendar during first-run onboarding still means a trip to Settings afterwards.
+  Calendar during first-run onboarding still means a trip to Settings afterward.
 - **Graph is poll-only.** The change-notification subscription (validationToken handshake, `clientState`,
   ≤3-day renewal) is unbuilt, so Outlook latency is the poll interval. (The Gmail push-watch renewal runs,
   but the poll remains the active sync path even for Gmail today.)

--- a/docs/explanation/capture-connectors.md
+++ b/docs/explanation/capture-connectors.md
@@ -149,7 +149,7 @@ differences that matter:
 | Cursor | `historyId` | — | `deltaLink` | `syncToken` |
 | Push | Pub/Sub 7-day | — | — (poll) | — (poll) |
 | Backfill | ✔ | — | ✔ | — |
-| Connect UI | ✔ | ✔ | ✘ (curl) | ✘ (curl) |
+| Connect UI | onboarding + Settings | onboarding + Settings | onboarding + Settings | Settings only |
 
 ### Gmail — standing OAuth, push-capable
 
@@ -158,8 +158,9 @@ walks the **history API** from a `historyId` watermark; a stale watermark (`ErrH
 expires it ~weekly) degrades to a bounded re-list, not a full re-scan. It implements **both** optional
 seams: a `Watcher` (the Pub/Sub 7-day push watch, renewed by the worker every `6h`, `48h` ahead of
 expiry) and a `Backfiller` (3/6/12-month widen-only windows). **To run:** a Google OAuth app + the vault
-key; a Pub/Sub topic is optional (without it, capture runs on the 2-minute poll). **UI:** the onboarding
-"Connect Google" button + the backfill panel; the Settings roster reconnects/disconnects.
+key; a Pub/Sub topic is optional (without it, capture runs on the 2-minute poll). **UI:** a first-connect
+affordance from both the onboarding **Google** chip and the Settings **Add a connection** footer, plus the
+backfill panel; the Settings roster reconnects/disconnects.
 
 ### IMAP — one-shot pull, nothing persisted
 
@@ -169,8 +170,9 @@ capture each; to capture more, run it again. There is no cursor, no push, no bac
 needed**. The dialer is **SSRF-guarded** (`netguard.RefusePrivate`, checked post-DNS on the concrete IP),
 so it refuses private/loopback hosts — you cannot point it at a localhost mailserver. **To run:** the
 host + port + email + an **app-password** (both Gmail and Outlook block basic-auth IMAP with a normal
-password; an app-password satisfies the provider requirement). **UI:** the onboarding IMAP form → a
-captured/contacts/skipped tally.
+password; an app-password satisfies the provider requirement). **UI:** the same inline form is reachable from both
+the onboarding **IMAP** chip and the Settings **Add a connection** footer → a captured/contacts/skipped
+tally.
 
 > A *standing* IMAP connection (a UID-watermark cursor, a vault-sealed credential) exists in the backend,
 > but the exposed connect route is the one-shot; there is no reachable path to create the standing one
@@ -182,8 +184,9 @@ OAuth2 to the Microsoft identity platform with delegated scopes `offline_access 
 (tenant defaults to `common`). Incremental sync walks a **delta query** from a `deltaLink`; a stale link
 (`ErrDeltaGone`, HTTP 410) re-anchors to a bounded 7-day window. It is a `Backfiller` but **not** a
 `Watcher` — there is no change-notification subscription built, so Outlook latency is the poll interval,
-not a push p95. **To run:** a Microsoft Entra (Azure AD) app + tenant + the vault key. **UI:** none to
-*initiate* yet — connect via `curl`; the roster manages an existing connection. Note Microsoft **rotates
+not a push p95. **To run:** a Microsoft Entra (Azure AD) app + tenant + the vault key. **UI:** a
+first-connect affordance from both the onboarding **Microsoft** chip and the Settings **Add a connection**
+footer; the roster manages an existing connection. Note Microsoft **rotates
 the refresh token on every redemption** and Margince does not yet persist the rotated value: the stored
 original typically keeps working up to Microsoft's default **90-day inactive lifetime** for a confidential
 client (an actively-syncing mailbox stays inside it), **but it can be revoked or expire earlier** (a
@@ -198,7 +201,8 @@ OAuth2 to Google with `calendar.readonly`. It **reuses the same Google OAuth app
 mail-read grant never bleeds into this credential). Incremental sync uses a `syncToken`; a stale token
 (`ErrSyncTokenGone`) re-anchors. No push, no backfill. **To run:** the *same* Google app as Gmail, with
 the calendar scope enabled and a `/connectors/gcal/callback` redirect URI added, + the vault key. **UI:**
-none to *initiate* yet — connect via `curl`; the roster manages an existing connection.
+Settings **Add a connection** starts it (no onboarding chip for Calendar — Gmail, Microsoft, and IMAP are
+the three onboarding chips); the roster manages an existing connection.
 
 ## Where each piece runs
 
@@ -217,26 +221,33 @@ flag/env table is [reference/configuration.md → Capture connector OAuth](../re
 
 ## The connect UI
 
-Two entry points, both hitting the same API:
+Two entry points, both hitting the same API, and both now able to *start* every backend-live connector —
+the connect-initiate gap the roster used to have (a connection with no way to add it) is closed:
 
-- **Onboarding → connect step** (`onboarding-connect-panels.tsx`) — where you *add* a connection.
-  `GoogleConnectPanel` does a full-page OAuth redirect, proves the connection, and renders the
-  `BackfillPanel` (window → estimate → start → live progress). `ImapConnectPanel` is a form that runs the
-  one-shot pull and shows the tally. The **Microsoft chip is disabled ("Soon")**, and there is no gcal
-  affordance at all.
+- **Onboarding → connect step** (`onboarding-connect-panels.tsx`) — where a fresh install *adds* a
+  connection. `OAuthConnectPanel` is parametrized by provider (`gmail` or `graph`): a full-page OAuth
+  redirect, then it proves the connection and renders the `BackfillPanel` (window → estimate → start →
+  live progress) for the ones that support it. `ImapConnectPanel` is a form that runs the one-shot pull
+  and shows the tally. The connect step (`connect-act.tsx`) offers three live chips — **Google**,
+  **Microsoft**, and **IMAP** — Microsoft included; there is still no onboarding chip for Calendar.
 - **Settings → Integrations** (`connectors.tsx`, `ConnectorsCard`) — the standing-connection roster: a
   status badge (`connected` / `reauth_required` / `error`) + last-synced per connection, a **reconnect**
-  action for a `reauth_required` OAuth connection, and a confirm-gated **disconnect**. It sits next to
-  the `WebhooksCard` (the egress side).
+  action for a `reauth_required` OAuth connection, and a confirm-gated **disconnect**. Below the roster
+  (or in the empty state, when nothing is connected) sits an always-present **"Add a connection"**
+  affordance offering whichever of **Gmail**, **Google Calendar**, **Microsoft**, and **IMAP** aren't
+  already connected — an OAuth pick redirects to that provider's consent screen directly from Settings; an
+  IMAP pick opens the same inline form. A provider whose backend app isn't configured answers its declared
+  `501`, and the panel renders "{provider} isn't configured in this deployment" rather than a raw error.
+  It sits next to the `WebhooksCard` (the egress side).
 
 ## Honest limitations
 
 Per [STATUS.md](../../STATUS.md) — the pipeline is live; these were scoped out, not missed:
 
-- **No first-connect UI for Graph or Calendar.** Both `graph` and `gcal` are fully wired OAuth connectors
-  (same `connect`/`callback`/`disconnect` + sync as Gmail), and the roster shows/reconnects/disconnects an
-  *existing* connection — but nothing in the UI *starts* one. Both are pure-FE follow-ups
-  (`.tmp/MISSING-UI-V4.md` §8a); the backend is ready.
+- **No onboarding chip for Calendar.** `gcal` is a fully wired OAuth connector (same
+  `connect`/`callback`/`disconnect` + sync as Gmail/Graph); Settings' **Add a connection** footer starts
+  one, but the onboarding connect step's three chips (Google, Microsoft, IMAP) don't include it — adding
+  Calendar during first-run onboarding still means a trip to Settings afterwards.
 - **Graph is poll-only.** The change-notification subscription (validationToken handshake, `clientState`,
   ≤3-day renewal) is unbuilt, so Outlook latency is the poll interval. (The Gmail push-watch renewal runs,
   but the poll remains the active sync path even for Gmail today.)
@@ -246,9 +257,9 @@ Per [STATUS.md](../../STATUS.md) — the pipeline is live; these were scoped out
   credential-update seam the `Connector` interface lacks.
 - **Standing IMAP is latent.** The one-shot pull is the exposed IMAP path; the UID-watermark standing
   connection exists in the backend but isn't wired to a reachable route.
-- **No UI for exclusions or connector-health.** The personal-mail exclusion CRUD and the digest's
-  `connectors[]` health rows are live on the API but have no screen yet (`.tmp/MISSING-UI-V4.md`
-  §8 CN-3/CN-4).
+- **No dedicated connector-health screen.** The digest's `connectors[]` health rows surface as a single
+  summary link on the home digest card (the worst-offending connection's error class, linking to Settings)
+  rather than a per-connector health screen.
 
 ## Rules of thumb
 
@@ -286,7 +297,7 @@ Per [STATUS.md](../../STATUS.md) — the pipeline is live; these were scoped out
 | Background jobs (dispatcher, sync, backfill, watch renewal, digest) | `internal/compose/jobs.go`, `capturejobs.go`; `backend/cmd/worker/main.go` |
 | The tables + RLS | `raw_capture, capture_connection, capture_exclusion_rule, capture_sync_state, capture_backfill, workspace_email_domain, capture_digest` |
 | The REST contract | `backend/api/crm.yaml` (`/connectors*`, `/capture/exclusions`, `/digest`) |
-| The connect UI (Settings + onboarding) | `frontend/src/screens/connectors.tsx`, `onboarding-connect-panels.tsx`, `backfill.tsx` |
+| The connect UI (Settings + onboarding) | `frontend/src/screens/connectors.tsx`, `onboarding-connect-panels.tsx`, `onboarding-conversation/connect-act.tsx`, `backfill.tsx` |
 
 ## Where to go next
 

--- a/docs/how-to/connect-a-mailbox.md
+++ b/docs/how-to/connect-a-mailbox.md
@@ -303,8 +303,11 @@ curl -X POST http://localhost:8080/v1/connectors/gcal/connect \
 
 ## Current UI gaps
 
-The connect/roster/backfill UI is now live for all four connectors: Gmail, Google Calendar, Graph, and
-IMAP each have a first-connect affordance from **Settings → Integrations**, and Gmail, Microsoft, and
-IMAP have one from **onboarding** too (Google Calendar is Settings-only — there's no onboarding chip for
-it). See [explanation/capture-connectors.md → Honest limitations](../explanation/capture-connectors.md#honest-limitations)
+The connect UI is now live for all four connectors: Gmail, Google Calendar, Graph, and IMAP each have a
+first-connect affordance from **Settings → Integrations**, and Gmail, Microsoft, and IMAP have one from
+**onboarding** too (Google Calendar is Settings-only — there's no onboarding chip for it). The roster and
+backfill panel, though, only apply to Gmail and Graph: IMAP is a one-shot pull with no standing
+connection to roster and no backfill to run, and Google Calendar has no backfill (it syncs forward from
+connect time only — see the [Calendar section](#d2-connect-from-the-ui) above). See
+[explanation/capture-connectors.md → Honest limitations](../explanation/capture-connectors.md#honest-limitations)
 for what's still scoped out of the pipeline overall.

--- a/docs/how-to/connect-a-mailbox.md
+++ b/docs/how-to/connect-a-mailbox.md
@@ -2,12 +2,13 @@
 
 Connect a mailbox so Margince captures its mail onto the timeline — creating people, organizations, and
 activities through the one dedupe chokepoint. This guide is **UI-first**: you drive it from the app,
-with the equivalent `curl` shown alongside for scripting and verification. It covers the two paths you
-can drive from the **UI** — **Gmail over OAuth** (a standing connection with background sync + backfill)
-and **IMAP one-shot pull** (a transient capture, which is how you reach a **Gmail** or **Outlook /
-Microsoft 365** mailbox with an app-password) — plus a **Graph** (`curl`-only) path for Outlook (Path C).
-For the mental model — the connector seam, the one Sink, the three
-ingestion modes, credential custody — read
+with the equivalent `curl` shown alongside for scripting and verification. It covers the three paths you
+can drive from the **UI** — **Gmail over OAuth** (a standing connection with background sync + backfill),
+**IMAP one-shot pull** (a transient capture, which is how you reach a **Gmail** or **Outlook /
+Microsoft 365** mailbox with an app-password), and **Graph OAuth** for Outlook / Microsoft 365 (a standing
+connection, Path C) — plus **Google Calendar (`gcal`)**, a separate standing connection you add
+alongside Gmail from the same Settings surface (Path D). For the mental model — the connector seam, the
+one Sink, the three ingestion modes, credential custody — read
 [explanation/capture-connectors.md](../explanation/capture-connectors.md) first.
 
 > **Single-organization installation (ADR-0061/A107).** One installation serves one organization; the
@@ -20,11 +21,17 @@ Two entry points, both hitting the same API:
 
 - **Settings → Integrations** (`ConnectorsCard`) — the standing-connection roster: each live connection
   with a status badge (`connected` / `reauth_required` / `error`) and last-synced time, a **reconnect**
-  action for a `reauth_required` OAuth connection, and a confirm-gated **disconnect**. When empty it
-  shows a **Connect** button that takes you to the connect step below.
-- **Onboarding → connect step** — where you *add* a connection: a **Connect Google** button (OAuth) and
-  an **IMAP form**. On a fresh install this is step in the first-run flow; afterwards, reach it from the
-  Settings → Integrations **Connect** button (or the `onboarding / connect` command).
+  action for a `reauth_required` OAuth connection, and a confirm-gated **disconnect**. Below the roster
+  (or in its place, when nothing is connected yet) sits an always-present **"Add a connection"**
+  affordance offering whichever of **Gmail**, **Google Calendar**, **Microsoft 365**, and **IMAP** aren't
+  already connected. Picking an OAuth provider (Gmail / Calendar / Microsoft) redirects straight to that
+  provider's consent screen from Settings — no detour through onboarding; picking IMAP opens the inline
+  connect form right there. If a provider's backend app isn't configured, the button click surfaces
+  **"{provider} isn't configured in this deployment"** instead of a raw error.
+- **Onboarding → connect step** — the same connect step, reached on a fresh install (or via the
+  `onboarding / connect` command): chips for **Google**, **Microsoft**, and **IMAP** (Google Calendar has
+  no onboarding chip — add it from Settings). All three chips are live; Microsoft opens the same Graph
+  OAuth redirect Settings does.
 
 > **Restart after backend config.** The api is a compiled binary — changing an OAuth env var (below)
 > needs `make dev` again to take effect; Vite hot-reloads the SPA but not the Go api.
@@ -36,7 +43,8 @@ Two entry points, both hitting the same API:
 | **Gmail** | OAuth standing connection | Yes | Yes (+ Pub/Sub push) | a Google OAuth app + the vault key |
 | **Gmail** | IMAP one-shot pull | No | No (re-run to capture more) | a Google **app-password** |
 | **Outlook / M365** | IMAP one-shot pull | No | No | an Outlook **app-password** |
-| **Outlook / M365** | Graph OAuth standing connection | Yes | Sync + backfill (poll-only) | a Microsoft Entra app + the vault key (no first-connect UI yet) |
+| **Outlook / M365** | Graph OAuth standing connection | Yes | Sync + backfill (poll-only) | a Microsoft Entra app + the vault key |
+| **Google Calendar** | `gcal` OAuth standing connection (separate from Gmail) | Yes | Sync only (poll-only, no backfill) | the same Google app as Gmail, with the calendar scope + redirect URI added |
 
 Start with **IMAP one-shot** if you just want to see capture work against a real mailbox from the UI — it
 needs no OAuth app and no deployment config. Use **Gmail OAuth** to exercise the standing connection,
@@ -71,15 +79,16 @@ export MARGINCE_PUBLIC_BASE_URL="http://localhost:8080"         # post-consent l
 ```
 
 Without the client id/secret + state key + public base URL, `/connectors/gmail/*` stays its declared
-`501` and the **Connect Google** button will land on an error. The full table is
+`501` and clicking **Gmail** in the Add-a-connection panel shows "Gmail isn't configured in this
+deployment" instead of redirecting. The full table is
 [reference/configuration.md → Capture connector OAuth](../reference/configuration.md).
 
 ### A2. Connect from the UI
 
-1. Open the app, go to **Settings → Integrations**, and click **Connect** (or complete the onboarding
-   connect step on a fresh install).
-2. Click **Connect Google**. The page redirects to Google — sign in and consent to the read-only Gmail
-   scope.
+1. Open the app, go to **Settings → Integrations**, and click **Gmail** in the **Add a connection**
+   footer or empty state (or click the **Google** chip on the onboarding connect step, on a fresh
+   install).
+2. The page redirects to Google — sign in and consent to the read-only Gmail scope.
 3. Google returns you to the app; the panel **proves** the connection by re-reading `GET /connectors`
    and shows a trust pill for the live `gmail` connection. Back in **Settings → Integrations** you'll now
    see a `gmail` row with a **connected** badge.
@@ -152,7 +161,8 @@ Basic-auth IMAP with your normal password is blocked by both providers — you n
 
 ### B2. Pull from the UI
 
-1. **Settings → Integrations → Connect** (or the onboarding connect step) → choose the **IMAP** option.
+1. **Settings → Integrations** → click **IMAP mailbox** in the **Add a connection** footer or empty state
+   (or the **IMAP** chip on the onboarding connect step).
 2. Fill the form: **host** (`imap.gmail.com` or `outlook.office365.com`), **email** (the mailbox
    address / login), **password** (the app-password), **mailbox** (`INBOX`), **max messages** (default
    `30`, capped at `200`).
@@ -193,11 +203,13 @@ mailbox is easiest). This is a security guard, not a bug.
 
 ---
 
-## Path C — Outlook / Microsoft 365 over Graph (standing connection, no UI yet)
+## Path C — Outlook / Microsoft 365 over Graph (standing connection)
 
 Graph is the richer Outlook path — a standing connection with delta-cursor sync and backfill — but it is
-**poll-only** (no push) and has **no first-connect UI yet** (the onboarding Microsoft chip is disabled,
-"Soon"), so today you connect it by `curl`. The shape mirrors Path A:
+**poll-only** (no push subscription built yet). The shape mirrors Path A, and it now has the same
+first-connect UI: an onboarding **Microsoft** chip and a Settings **Add a connection** button.
+
+### C1. Prerequisites (operator config)
 
 ```sh
 export MARGINCE_GRAPH_CLIENT_ID="<entra-app-id>"
@@ -207,23 +219,73 @@ export MARGINCE_GRAPH_TENANT="common"   # or a specific tenant id
 ```
 
 Register a Microsoft Entra (Azure AD) app with delegated scopes `offline_access User.Read Mail.Read` and
-a redirect URI of `<api-base>/v1/connectors/graph/callback`, then get the consent URL and open it:
+a redirect URI of `<api-base>/v1/connectors/graph/callback`, then `make dev` to pick up the env.
+
+### C2. Connect from the UI
+
+1. Either click the **Microsoft** chip on the onboarding connect step, or go to **Settings →
+   Integrations** and click **Microsoft** in the **Add a connection** footer (or empty state).
+2. The page redirects to Microsoft — sign in and consent to `offline_access User.Read Mail.Read`.
+3. Microsoft returns you to the app; **Settings → Integrations** shows a `graph` row with a **connected**
+   badge, reconnect/disconnect actions, and the backfill panel.
+
+<details><summary>Same thing via <code>curl</code></summary>
 
 ```sh
 curl -X POST http://localhost:8080/v1/connectors/graph/connect \
   --cookie 'crm_session=<session>' -H 'Content-Type: application/json' -d '{}' | jq -r '.authorize_url'
 ```
 
-Consent in the browser; the callback seals the refresh token and the worker syncs it. Backfill
-(`/connectors/graph/backfill*`) works exactly as in A3. Once connected, the `graph` row **does** appear
-in the Settings → Integrations roster and can be reconnected/disconnected there.
+Consent in the browser; the callback seals the refresh token and the worker syncs it.
+</details>
+
+### C3. Backfill
+
+Backfill (`/connectors/graph/backfill*`) works exactly as in [A3](#a3-backfill-existing-mail-preview-before-spend) —
+same window/preview/progress panel, just on the `graph` connection.
+
+---
+
+## Path D — Google Calendar over OAuth (standing connection, separate from Gmail)
+
+Google Calendar (`gcal`) is a **second, independent** standing connection, not a mode of the Gmail one.
+It reuses the same Google OAuth app as Path A but requests only `calendar.readonly` as its own
+authorization (deliberately never `include_granted_scopes`), so the calendar grant never inherits — and
+never bleeds into — the Gmail mail-read grant. **Connecting both means signing two separate Google
+consent screens** — a deliberate least-privilege split, not a rough edge.
+
+### D1. Prerequisites (operator config)
+
+Same env vars as [A1](#a1-prerequisites-operator-config) (`MARGINCE_GMAIL_CLIENT_ID/SECRET`,
+`MARGINCE_CONNECTOR_STATE_KEY`, `MARGINCE_KEYVAULT_ROOT_KEY`, `MARGINCE_PUBLIC_BASE_URL`) — Calendar rides
+the same Google OAuth app as Gmail. On that app's Google Cloud project, additionally enable the
+**Calendar API** and add `<api-base>/v1/connectors/gcal/callback` (dev:
+`http://localhost:8080/v1/connectors/gcal/callback`) as an authorized redirect URI.
+
+### D2. Connect from the UI
+
+1. Go to **Settings → Integrations** and click **Google Calendar** in the **Add a connection** footer (or
+   empty state) — there is no onboarding chip for Calendar, so Settings is the only first-connect path.
+2. The page redirects to Google — sign in and consent to the read-only Calendar scope (a separate consent
+   screen from Gmail's, even if you're already connected to Gmail).
+3. Google returns you to the app; **Settings → Integrations** shows a `gcal` row with a **connected**
+   badge. There is no backfill panel for Calendar — it syncs forward from connect time only.
+
+<details><summary>Same thing via <code>curl</code></summary>
+
+```sh
+curl -X POST http://localhost:8080/v1/connectors/gcal/connect \
+  --cookie 'crm_session=<session>' -H 'Content-Type: application/json' -d '{}' \
+  | jq -r '.authorize_url'
+```
+</details>
 
 ---
 
 ## Verify end-to-end
 
-1. **The mailbox connected.** For Gmail/Graph, **Settings → Integrations** shows a `connected` row (or
-   `GET /connectors`); for IMAP, the result panel shows `connected` with a non-zero **captured**.
+1. **The mailbox connected.** For Gmail/Graph/gcal, **Settings → Integrations** shows a `connected` row
+   (or `GET /connectors`); for IMAP, the result panel shows `connected` with a non-zero **captured**.
 2. **Mail became timeline activities.** Open a captured counterparty's timeline (or `GET /activities`)
    and confirm each message is an email activity, provenance-stamped `connector:<name>`.
 3. **People and organizations were auto-created.** A new external counterparty becomes a person (and, for
@@ -241,9 +303,8 @@ in the Settings → Integrations roster and can be reconnected/disconnected ther
 
 ## Current UI gaps
 
-The connect/roster/backfill UI is live; a few capture surfaces are still API-only (tracked in
-`.tmp/MISSING-UI-V4.md` §8): **no Microsoft first-connect** (connect Graph via `curl`), **no
-personal-mail exclusions screen** (`/capture/exclusions` is API-only), and **adding a new Outlook/IMAP
-connection or re-running a backfill from Settings** still routes through the onboarding connect step.
-See [explanation/capture-connectors.md → Honest limitations](../explanation/capture-connectors.md#honest-limitations)
-for the full list.
+The connect/roster/backfill UI is now live for all four connectors: Gmail, Google Calendar, Graph, and
+IMAP each have a first-connect affordance from **Settings → Integrations**, and Gmail, Microsoft, and
+IMAP have one from **onboarding** too (Google Calendar is Settings-only — there's no onboarding chip for
+it). See [explanation/capture-connectors.md → Honest limitations](../explanation/capture-connectors.md#honest-limitations)
+for what's still scoped out of the pipeline overall.

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1235,6 +1235,15 @@ export const de = {
     "Die Verbindung konnte nicht hergestellt werden — bitte versuchen Sie es erneut.",
   "connectors.dismissOutcome": "Schließen",
 
+  // Das immer sichtbare "Verbindung hinzufügen"-Element (Task 1): der
+  // Leerzustand und die Fußzeile der Liste teilen sich dieselben Buttons für
+  // noch nicht verbundene Anbieter.
+  "connectors.addConnection": "Verbindung hinzufügen",
+  "connectors.googleSeparateNote":
+    "Gmail und Google Kalender werden separat verbunden.",
+  "connectors.providerNotConfigured":
+    "{provider} ist in dieser Installation nicht konfiguriert.",
+
   // Das eingebettete IMAP-Verbindungsformular (Task 6).
   "connectors.imapConnectCta": "IMAP-Postfach verbinden",
   "connectors.imapModalTitle": "IMAP-Postfach verbinden",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1110,6 +1110,23 @@ export const de = {
   "ob.s4.provGoogle": "Google",
   "ob.s4.provMicrosoft": "Microsoft",
   "ob.s4.provImap": "Beliebiges Postfach (IMAP)",
+  "ob.s4.microsoftBtn": "Microsoft verbinden",
+  "ob.s4.microsoftHint":
+    "Nur-Lese-Zugriff auf E-Mails. Du kannst die Verbindung jederzeit in den Einstellungen trennen.",
+  "ob.s4.microsoftUnverified":
+    "Eventuell erscheint ein Hinweis „nicht verifizierte App“ — das ist diese selbstgehostete Installation, kein Dritter.",
+  "ob.s4.microsoftFailed":
+    "Die Microsoft-Verbindung wurde nicht abgeschlossen.",
+  "ob.s4.connectOkTitle": "Verbunden",
+  "ob.s4.connectOkBody":
+    "Dein Postfach ist verknüpft. Die Erfassung startet beim nächsten Sync.",
+  "ob.s4.connectVerifying": "Verbindung wird bestätigt…",
+  "ob.s4.connectLive": "Aktiv und erfassend",
+  "ob.s4.connectConfirmFailed": "Die Verbindung konnte nicht bestätigt werden.",
+  "ob.s4.connectRetry":
+    "Öffne Einstellungen → Integrationen, um es erneut zu versuchen.",
+  "ob.s4.connectDenied":
+    "Du hast den Zugriff abgelehnt — es wurde nichts verbunden.",
   "ob.s4.googleBtn": "Mit Google fortfahren",
   "ob.s4.soon": "Bald",
   "ob.s4.googleHint":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1088,6 +1088,21 @@ export const en = {
   "ob.s4.provGoogle": "Google",
   "ob.s4.provMicrosoft": "Microsoft",
   "ob.s4.provImap": "Any inbox (IMAP)",
+  "ob.s4.microsoftBtn": "Connect Microsoft",
+  "ob.s4.microsoftHint":
+    "Read-only mail access. You can disconnect any time from Settings.",
+  "ob.s4.microsoftUnverified":
+    'You may see an "unverified app" notice — that\'s this self-hosted install, not a third party.',
+  "ob.s4.microsoftFailed": "The Microsoft connection didn't complete.",
+  "ob.s4.connectOkTitle": "You're connected",
+  "ob.s4.connectOkBody":
+    "Your mailbox is linked. Capture begins on the next sync.",
+  "ob.s4.connectVerifying": "Confirming the connection…",
+  "ob.s4.connectLive": "Live and capturing",
+  "ob.s4.connectConfirmFailed": "We couldn't confirm the connection.",
+  "ob.s4.connectRetry":
+    "Head to Settings → Integrations to try connecting again.",
+  "ob.s4.connectDenied": "You declined access — nothing was connected.",
   "ob.s4.googleBtn": "Continue with Google",
   "ob.s4.soon": "Soon",
   "ob.s4.googleHint":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1212,6 +1212,15 @@ export const en = {
     "The connection couldn't be completed — please try again.",
   "connectors.dismissOutcome": "Dismiss",
 
+  // The always-present "Add a connection" affordance (Task 1): the empty
+  // state and the roster footer share the same not-yet-connected provider
+  // buttons, so the copy that names them lives once here.
+  "connectors.addConnection": "Add a connection",
+  "connectors.googleSeparateNote":
+    "Gmail and Google Calendar connect separately.",
+  "connectors.providerNotConfigured":
+    "{provider} isn't configured in this deployment.",
+
   // The inline IMAP connect form (Task 6): first-connect and reconnect for
   // the one credential provider, done in Settings instead of bouncing to
   // onboarding.

--- a/frontend/src/screens/connect-panels.test.tsx
+++ b/frontend/src/screens/connect-panels.test.tsx
@@ -1,14 +1,26 @@
 /** @vitest-environment jsdom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, render as rtlRender, screen } from "@testing-library/react";
+import {
+  cleanup,
+  render as rtlRender,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { LocaleProvider } from "../i18n";
-import { GoogleConnectPanel } from "./onboarding-connect-panels";
+import {
+  OAuthConnectPanel,
+  OAuthReturnPanel,
+} from "./onboarding-connect-panels";
+import { installFetchStub, jsonResponse } from "./story-utils";
 
 // The Google panel's pre-connect state must reassure a first-time user before
 // the redirect: an unverified dev app shows Google's "unverified app" notice,
-// and without a heads-up a founder abandons the flow there.
+// and without a heads-up a founder abandons the flow there. Both the OAuth
+// connect panel (provider-parametrized) and the provider-agnostic return
+// view share this file's harness.
 
 function render(ui: ReactNode) {
   return rtlRender(
@@ -29,11 +41,54 @@ afterEach(() => {
 
 describe("the Google connect panel", () => {
   it("warns about the unverified-app notice and how to get past it", () => {
-    render(<GoogleConnectPanel onComplete={async () => {}} />);
+    render(<OAuthConnectPanel provider="gmail" onComplete={async () => {}} />);
     expect(
       screen.getByText(/unverified app.*Advanced.*Continue/i),
     ).toBeTruthy();
     // The reassurance is honest about scope: read-only, never sends.
     expect(screen.getByText(/only ever reads/i)).toBeTruthy();
   });
+});
+
+it("OAuthConnectPanel posts the given provider and redirects", async () => {
+  const assign = vi.fn();
+  vi.stubGlobal("location", { ...globalThis.location, assign });
+  installFetchStub({
+    "POST /connectors/graph/connect": () =>
+      jsonResponse({ authorize_url: "https://login.microsoftonline/x" }),
+  });
+  render(<OAuthConnectPanel provider="graph" onComplete={vi.fn()} />);
+  await userEvent.click(
+    screen.getByRole("button", { name: "Connect Microsoft" }),
+  );
+  await waitFor(() =>
+    expect(assign).toHaveBeenCalledWith("https://login.microsoftonline/x"),
+  );
+});
+
+it("OAuthReturnPanel shows the live OAuth mailbox after consent", async () => {
+  installFetchStub({
+    "GET /connectors": () =>
+      jsonResponse({
+        data: [
+          {
+            id: "g1",
+            provider: "graph",
+            status: "connected",
+            scopes: ["read"],
+            backfill: { state: "done" },
+          },
+        ],
+      }),
+  });
+  render(<OAuthReturnPanel outcome="ok" onComplete={vi.fn()} />);
+  expect(await screen.findByText("Live and capturing")).toBeTruthy();
+});
+
+it("OAuthReturnPanel reports a confirm-failure when no connection came back", async () => {
+  installFetchStub({ "GET /connectors": () => jsonResponse({ data: [] }) });
+  render(<OAuthReturnPanel outcome="ok" onComplete={vi.fn()} />);
+  expect(
+    await screen.findByText("We couldn't confirm the connection."),
+  ).toBeTruthy();
 });

--- a/frontend/src/screens/connectors.stories.tsx
+++ b/frontend/src/screens/connectors.stories.tsx
@@ -117,6 +117,26 @@ export const Empty: Story = {
   render: cardStory([]),
 };
 
+// The "Add a connection" affordance (Task 1): the empty state offers all
+// four providers, and once one is connected the roster grows a footer
+// offering only the ones still missing.
+export const EmptyStateAllProviders: Story = {
+  render: () => {
+    installFetchStub({
+      "GET /connectors": () => jsonResponse({ data: [] }),
+    });
+    return (
+      <StoryProviders>
+        <ConnectorsCard />
+      </StoryProviders>
+    );
+  },
+};
+
+export const OneConnectedWithFooter: Story = {
+  render: cardStory([gmailConnected]),
+};
+
 export const LoadFailed: Story = {
   render: () => {
     installFetchStub({

--- a/frontend/src/screens/connectors.test.tsx
+++ b/frontend/src/screens/connectors.test.tsx
@@ -5,6 +5,7 @@ import {
   render as rtlRender,
   screen,
   waitFor,
+  within,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
@@ -71,7 +72,11 @@ function stubApi(connections: CaptureConnection[], opts: StubOpts = {}) {
           authorize_url: "https://accounts.google/x",
         };
         if ("status" in c) {
-          return jsonResponse({ detail: "connect failed" }, c.status);
+          const body =
+            c.status === 501
+              ? { code: "not_implemented", detail: "capture not wired" }
+              : { detail: "connect failed" };
+          return jsonResponse(body, c.status);
         }
         return jsonResponse(c);
       }
@@ -125,16 +130,14 @@ describe("the connected-inboxes card", () => {
     stubApi([]);
     render(<ConnectorsCard />);
     expect(await screen.findByText(/No inbox is connected yet/)).toBeTruthy();
-    expect(
-      screen.getByRole("button", { name: /Connect an inbox/ }),
-    ).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Gmail" })).toBeTruthy();
   });
 
   it("opens the inline IMAP form from the empty state instead of bouncing to onboarding", async () => {
     stubApi([]);
     render(<ConnectorsCard />);
     await userEvent.click(
-      await screen.findByRole("button", { name: /Connect an IMAP mailbox/ }),
+      await screen.findByRole("button", { name: "IMAP mailbox" }),
     );
     expect(
       screen.getByRole("dialog", { name: "Connect an IMAP mailbox" }),
@@ -386,5 +389,68 @@ describe("the OAuth return outcome", () => {
     await screen.findByText(/you declined access/i);
     await userEvent.click(screen.getByRole("button", { name: /dismiss/i }));
     expect(screen.queryByText(/you declined access/i)).toBeNull();
+  });
+});
+
+// The always-present "Add a connection" affordance (Task 1): the empty
+// state and the roster footer share the same not-yet-connected provider
+// buttons, an OAuth pick connects+redirects, IMAP opens the inline form, and
+// a 501 from a specific provider's connect renders an honest named note.
+describe("add a connection", () => {
+  it("offers only not-yet-connected providers when one is connected", async () => {
+    stubApi([gmailConnected]);
+    render(<ConnectorsCard />);
+    await screen.findByText("Add a connection");
+    const add = screen.getByText("Add a connection").closest(".connector-add");
+    expect(add).not.toBeNull();
+    const panel = add as HTMLElement;
+    expect(within(panel).queryByRole("button", { name: "Gmail" })).toBeNull();
+    expect(
+      within(panel).getByRole("button", { name: "Google Calendar" }),
+    ).toBeTruthy();
+    expect(
+      within(panel).getByRole("button", { name: "Microsoft" }),
+    ).toBeTruthy();
+    expect(
+      within(panel).getByRole("button", { name: "IMAP mailbox" }),
+    ).toBeTruthy();
+  });
+
+  it("redirects the browser when an OAuth provider is chosen", async () => {
+    const assign = vi.fn();
+    vi.stubGlobal("location", { ...globalThis.location, assign });
+    stubApi([gmailConnected], {
+      connect: { authorize_url: "https://accounts.google/cal" },
+    });
+    render(<ConnectorsCard />);
+    await screen.findByText("Add a connection");
+    await userEvent.click(
+      screen.getByRole("button", { name: "Google Calendar" }),
+    );
+    await waitFor(() =>
+      expect(assign).toHaveBeenCalledWith("https://accounts.google/cal"),
+    );
+  });
+
+  it("shows an honest note when a provider is not configured (501)", async () => {
+    stubApi([gmailConnected], { connect: { status: 501 } });
+    render(<ConnectorsCard />);
+    await screen.findByText("Add a connection");
+    await userEvent.click(screen.getByRole("button", { name: "Microsoft" }));
+    expect(
+      await screen.findByText("Microsoft isn't configured in this deployment."),
+    ).toBeTruthy();
+  });
+
+  it("hides the footer when all four providers are connected", async () => {
+    stubApi([
+      gmailConnected,
+      { ...gmailConnected, id: "c2", provider: "gcal" },
+      { ...gmailConnected, id: "c3", provider: "graph" },
+      { ...gmailConnected, id: "c4", provider: "imap" },
+    ]);
+    render(<ConnectorsCard />);
+    await screen.findByText("Google Calendar"); // a roster row label
+    expect(screen.queryByText("Add a connection")).toBeNull();
   });
 });

--- a/frontend/src/screens/connectors.tsx
+++ b/frontend/src/screens/connectors.tsx
@@ -397,12 +397,14 @@ export function ConnectorsCard() {
           ))}
         </ul>
       )}
-      {!notConfigured && rows.length > 0 && addable.length > 0 && (
-        <div className="connector-add">
-          <SectionHeader title={t("connectors.addConnection")} />
-          {addPanel}
-        </div>
-      )}
+      {!notConfigured &&
+        rows.length > 0 &&
+        (addable.length > 0 || notConfigured501) && (
+          <div className="connector-add">
+            <SectionHeader title={t("connectors.addConnection")} />
+            {addPanel}
+          </div>
+        )}
       {connect.isError && (
         <p className="t-small" style={{ color: "var(--danger)" }}>
           {connect.error.message}

--- a/frontend/src/screens/connectors.tsx
+++ b/frontend/src/screens/connectors.tsx
@@ -268,7 +268,12 @@ export function ConnectorsCard() {
       pending={connect.isPending}
       notConfigured501={notConfigured501}
       onConnect={(p) => connect.mutate(p)}
-      onImap={() => setImapConnectOpen(true)}
+      onImap={() => {
+        // A stale "X isn't configured" note from an earlier OAuth attempt
+        // must not linger once the user pivots to the IMAP form instead.
+        setNotConfigured501(null);
+        setImapConnectOpen(true);
+      }}
     />
   );
 

--- a/frontend/src/screens/connectors.tsx
+++ b/frontend/src/screens/connectors.tsx
@@ -41,6 +41,11 @@ const providerLabel: Record<Provider, MessageKey> = {
 // a credential provider never redirects.
 const OAUTH_PROVIDERS = new Set<Provider>(["gmail", "gcal", "graph"]);
 
+// The full connector roster the "Add a connection" affordance offers from —
+// the empty state shows all four, the footer shows whichever aren't already
+// present in GET /connectors.
+const ALL_PROVIDERS: Provider[] = ["gmail", "gcal", "graph", "imap"];
+
 // Disconnecting an OAuth connection deletes OUR stored credential; it does
 // not reach out to the vendor to revoke the grant on their side (there is no
 // such API call here), so the confirm names the vendor-specific place a
@@ -121,6 +126,60 @@ function OAuthOutcomeNote() {
   );
 }
 
+// The "Add a connection" affordance (Task 1): shared between the empty
+// state and the roster footer — an OAuth pick connects+redirects, IMAP
+// opens the inline form, and a provider-specific 501 renders a provider-
+// named note. Split out of ConnectorsCard so this branching stays off that
+// function's complexity budget (same reasoning as OAuthOutcomeNote above).
+function ConnectorAddPanel({
+  addable,
+  pending,
+  notConfigured501,
+  onConnect,
+  onImap,
+}: Readonly<{
+  addable: Provider[];
+  pending: boolean;
+  notConfigured501: Provider | null;
+  onConnect: (provider: Provider) => void;
+  onImap: () => void;
+}>) {
+  const t = useT();
+  return (
+    <>
+      {(addable.includes("gcal") || addable.includes("gmail")) && (
+        <p className="t-small">{t("connectors.googleSeparateNote")}</p>
+      )}
+      <div className="connector-add-actions">
+        {addable.map((p) =>
+          p === "imap" ? (
+            <Button key={p} small onClick={onImap}>
+              <Mail aria-hidden /> {t(providerLabel[p])}
+            </Button>
+          ) : (
+            <Button
+              key={p}
+              small
+              variant={p === "gmail" ? "primary" : undefined}
+              disabled={pending}
+              onClick={() => onConnect(p)}
+            >
+              <Plug aria-hidden /> {t(providerLabel[p])}
+            </Button>
+          ),
+        )}
+      </div>
+      {notConfigured501 && (
+        <p className="t-small" style={{ color: "var(--danger)" }}>
+          {t("connectors.providerNotConfigured", {
+            provider: t(providerLabel[notConfigured501]),
+          })}
+        </p>
+      )}
+    </>
+  );
+}
+
 export function ConnectorsCard() {
   const t = useT();
   const { locale } = useLocale();
@@ -129,6 +188,9 @@ export function ConnectorsCard() {
     null,
   );
   const [imapConnectOpen, setImapConnectOpen] = useState(false);
+  const [notConfigured501, setNotConfigured501] = useState<Provider | null>(
+    null,
+  );
 
   const connectors = useQuery({
     queryKey: ["connectors"],
@@ -144,21 +206,32 @@ export function ConnectorsCard() {
     },
   });
 
-  const reconnect = useMutation({
+  const connect = useMutation({
     mutationFn: async (provider: Provider) => {
-      const { data, error } = await api.POST("/connectors/{provider}/connect", {
-        params: { path: { provider } },
-        // Lands the post-consent redirect back on Settings (Task 2's
-        // contract field) rather than the default onboarding landing.
-        body: { return_to: "settings" },
-      });
+      setNotConfigured501(null);
+      const { data, error, response } = await api.POST(
+        "/connectors/{provider}/connect",
+        {
+          params: { path: { provider } },
+          // Lands the post-consent redirect back on Settings (Task 2's
+          // contract field) rather than the default onboarding landing.
+          body: { return_to: "settings" },
+        },
+      );
+      // A deployment that never wired this specific provider answers 501
+      // code:not_implemented — a calm, provider-named state, never a claim
+      // dressed up as a generic failure.
+      if (response.status === 501 && problemCode(error) === "not_implemented") {
+        setNotConfigured501(provider);
+        return null;
+      }
       if (error) {
         throw new Error(problemMessage(error));
       }
       return data;
     },
     onSuccess: (data) => {
-      if (data.authorize_url) {
+      if (data?.authorize_url) {
         globalThis.location.assign(data.authorize_url);
       }
     },
@@ -187,6 +260,18 @@ export function ConnectorsCard() {
     ? OAUTH_DISCONNECT_NOTE[pendingDisconnect]
     : undefined;
 
+  const present = new Set(rows.map((r) => r.provider));
+  const addable = ALL_PROVIDERS.filter((p) => !present.has(p));
+  const addPanel = (
+    <ConnectorAddPanel
+      addable={addable}
+      pending={connect.isPending}
+      notConfigured501={notConfigured501}
+      onConnect={(p) => connect.mutate(p)}
+      onImap={() => setImapConnectOpen(true)}
+    />
+  );
+
   return (
     <Card>
       <SectionHeader title={t("connectors.title")} sub={t("connectors.sub")} />
@@ -209,26 +294,7 @@ export function ConnectorsCard() {
       {connectors.isSuccess && !notConfigured && rows.length === 0 && (
         <EmptyState>
           <p>{t("connectors.empty")}</p>
-          <div
-            style={{
-              display: "flex",
-              gap: "var(--space-2)",
-              justifyContent: "center",
-              flexWrap: "wrap",
-            }}
-          >
-            <Button
-              small
-              variant="primary"
-              disabled={reconnect.isPending}
-              onClick={() => reconnect.mutate("gmail")}
-            >
-              <Plug aria-hidden /> {t("connectors.connectCta")}
-            </Button>
-            <Button small onClick={() => setImapConnectOpen(true)}>
-              <Mail aria-hidden /> {t("connectors.imapConnectCta")}
-            </Button>
-          </div>
+          {addable.length > 0 && addPanel}
         </EmptyState>
       )}
       {!notConfigured && rows.length > 0 && (
@@ -296,8 +362,8 @@ export function ConnectorsCard() {
                   (OAUTH_PROVIDERS.has(conn.provider) ? (
                     <Button
                       small
-                      disabled={reconnect.isPending}
-                      onClick={() => reconnect.mutate(conn.provider)}
+                      disabled={connect.isPending}
+                      onClick={() => connect.mutate(conn.provider)}
                     >
                       <RefreshCw aria-hidden /> {t("connectors.reconnect")}
                     </Button>
@@ -326,9 +392,15 @@ export function ConnectorsCard() {
           ))}
         </ul>
       )}
-      {reconnect.isError && (
+      {!notConfigured && rows.length > 0 && addable.length > 0 && (
+        <div className="connector-add">
+          <SectionHeader title={t("connectors.addConnection")} />
+          {addPanel}
+        </div>
+      )}
+      {connect.isError && (
         <p className="t-small" style={{ color: "var(--danger)" }}>
-          {reconnect.error.message}
+          {connect.error.message}
         </p>
       )}
       <ConfirmModal

--- a/frontend/src/screens/onboarding-connect-panels.stories.tsx
+++ b/frontend/src/screens/onboarding-connect-panels.stories.tsx
@@ -4,15 +4,17 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { userEvent, within } from "storybook/test";
 import {
-  GoogleConnectPanel,
   ImapConnectPanel,
+  OAuthConnectPanel,
+  OAuthReturnPanel,
 } from "./onboarding-connect-panels";
 import { installFetchStub, jsonResponse, StoryProviders } from "./story-utils";
 
 // The onboarding connect panels for the fe-uat render gate (G-10): the
 // idle IMAP form, its post-connect state (the honest "building itself"
 // framing — no fabricated capture counts), and its rejected-login error;
-// plus the Google panel's pre-consent idle state.
+// plus the provider-parametrized OAuth panel's pre-consent idle state
+// (Gmail and Microsoft) and the provider-agnostic post-consent return view.
 
 const meta: Meta<typeof ImapConnectPanel> = {
   title: "screens/onboarding-connect-panels",
@@ -97,8 +99,46 @@ export const GoogleIdle: Story = {
     installFetchStub({});
     return (
       <StoryProviders>
-        <GoogleConnectPanel onComplete={async () => {}} />
+        <OAuthConnectPanel provider="gmail" onComplete={async () => {}} />
       </StoryProviders>
     );
+  },
+};
+
+export const MicrosoftIdle: Story = {
+  render: () => {
+    installFetchStub({});
+    return (
+      <StoryProviders>
+        <OAuthConnectPanel provider="graph" onComplete={async () => {}} />
+      </StoryProviders>
+    );
+  },
+};
+
+export const OAuthReturnLive: Story = {
+  render: () => {
+    installFetchStub({
+      "GET /connectors": () =>
+        jsonResponse({
+          data: [
+            {
+              id: "g1",
+              provider: "graph",
+              status: "connected",
+              scopes: ["read"],
+              backfill: { state: "done" },
+            },
+          ],
+        }),
+    });
+    return (
+      <StoryProviders>
+        <OAuthReturnPanel outcome="ok" onComplete={async () => {}} />
+      </StoryProviders>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    await within(canvasElement).findByText(/live and capturing/i);
   },
 };

--- a/frontend/src/screens/onboarding-connect-panels.tsx
+++ b/frontend/src/screens/onboarding-connect-panels.tsx
@@ -11,6 +11,7 @@ import { useState } from "react";
 import { api } from "../api/client";
 import { Button } from "../design-system/atoms";
 import { useT } from "../i18n";
+import type { MessageKey } from "../i18n/en";
 import { BackfillPanel } from "./backfill";
 import { problemMessage, throwProblem } from "./common";
 import { imapErrorMessage } from "./imap-connect-form";
@@ -35,21 +36,47 @@ function ConnectWarn({ title, body }: { title: string; body: string }) {
   );
 }
 
-// Google: the server mints the consent URL (and the signed state + CSRF
-// cookie that guard the callback); the browser just goes. The return deep
-// link lands back here with the outcome in the route.
-export function GoogleConnectPanel({
-  outcome,
+type OAuthProvider = "gmail" | "graph";
+
+const OAUTH_COPY: Record<
+  OAuthProvider,
+  {
+    btn: MessageKey;
+    hint: MessageKey;
+    unverified: MessageKey;
+    failed: MessageKey;
+  }
+> = {
+  gmail: {
+    btn: "ob.s4.googleBtn",
+    hint: "ob.s4.googleHint",
+    unverified: "ob.s4.googleUnverified",
+    failed: "ob.s4.googleFailed",
+  },
+  graph: {
+    btn: "ob.s4.microsoftBtn",
+    hint: "ob.s4.microsoftHint",
+    unverified: "ob.s4.microsoftUnverified",
+    failed: "ob.s4.microsoftFailed",
+  },
+};
+
+// Pre-consent: the server mints the consent URL (and the signed state + CSRF
+// cookie that guard the callback); the browser just goes. One panel serves
+// every OAuth provider — only the copy and the POST path vary.
+export function OAuthConnectPanel({
+  provider,
   onComplete,
 }: Readonly<{
-  outcome?: string;
+  provider: OAuthProvider;
   onComplete: (skipped: boolean) => Promise<void>;
 }>) {
   const t = useT();
-  const google = useMutation({
+  const copy = OAUTH_COPY[provider];
+  const connect = useMutation({
     mutationFn: async () => {
       const { data, error } = await api.POST("/connectors/{provider}/connect", {
-        params: { path: { provider: "gmail" } },
+        params: { path: { provider } },
         body: {},
       });
       if (error) {
@@ -63,9 +90,53 @@ export function GoogleConnectPanel({
       }
     },
   });
+  return (
+    <>
+      {connect.isError && (
+        <ConnectWarn title={t(copy.failed)} body={connect.error.message} />
+      )}
+      <p
+        className="spoken-hint"
+        style={{ maxWidth: 460, margin: "4px auto 0" }}
+      >
+        <ShieldCheck aria-hidden /> {t(copy.hint)}
+      </p>
+      <p className="t-small ob-google-unverified">{t(copy.unverified)}</p>
+      <div className="connect-acts">
+        <Button
+          variant="primary"
+          disabled={connect.isPending}
+          onClick={() => connect.mutate()}
+        >
+          {connect.isPending ? (
+            <>
+              <span className="ob-spinner" /> {t("ob.s4.connecting")}
+            </>
+          ) : (
+            <>
+              <Mail aria-hidden /> {t(copy.btn)}
+            </>
+          )}
+        </Button>
+        <Button onClick={() => void onComplete(true)}>
+          <SkipForward aria-hidden /> {t("ob.s4.skipLater")}
+        </Button>
+      </div>
+    </>
+  );
+}
 
-  // After a successful return, show the live connection rather than a
-  // static claim — the row IS the proof (never a fake-populated screen).
+// Post-consent: the callback route carries no provider, so this reads the
+// roster and shows whichever OAuth mailbox is now live. The row IS the proof
+// — never a static claim the server hasn't confirmed.
+export function OAuthReturnPanel({
+  outcome,
+  onComplete,
+}: Readonly<{
+  outcome?: string;
+  onComplete: (skipped: boolean) => Promise<void>;
+}>) {
+  const t = useT();
   const connections = useQuery({
     queryKey: ["connectors"],
     enabled: outcome === "ok",
@@ -77,100 +148,63 @@ export function GoogleConnectPanel({
       return data;
     },
   });
-  const gmailConnected =
-    connections.data?.data.some(
-      (c) => c.provider === "gmail" && c.status === "connected",
-    ) ?? false;
+  const live = connections.data?.data.find(
+    (c) =>
+      (c.provider === "gmail" || c.provider === "graph") &&
+      c.status === "connected",
+  );
 
-  if (outcome === "ok") {
+  if (outcome === "denied") {
     return (
-      <div className="connect-result">
-        <div className="cr-h">
-          <CheckCircle2 aria-hidden /> {t("ob.s4.googleOkTitle")}
-        </div>
-        <p className="ob-sub" style={{ margin: "8px auto 0", maxWidth: 460 }}>
-          {t("ob.s4.googleOkBody")}
-        </p>
-        {connections.isPending && (
-          <p className="t-small" style={{ marginTop: "var(--space-3)" }}>
-            {t("ob.s4.googleVerifying")}
-          </p>
-        )}
-        {gmailConnected && (
-          <>
-            <span className="trustpill" style={{ marginTop: "var(--space-3)" }}>
-              <ShieldCheck aria-hidden /> {t("ob.s4.googleLive")}
-            </span>
-            <BackfillPanel provider="gmail" />
-          </>
-        )}
-        {!connections.isPending && !gmailConnected && (
-          <ConnectWarn
-            title={t("ob.s4.googleFailed")}
-            body={t("ob.s4.googleRetry")}
-          />
-        )}
-        <Button
-          variant="primary"
-          style={{ marginTop: "var(--space-4)" }}
-          onClick={() => void onComplete(false)}
-        >
-          {t("ob.s4.enterCrm")} <ArrowRight aria-hidden />
-        </Button>
-      </div>
+      <ConnectWarn
+        title={t("ob.s4.connectDenied")}
+        body={t("ob.s4.connectRetry")}
+      />
     );
   }
-
+  if (outcome !== "ok") {
+    return (
+      <ConnectWarn
+        title={t("ob.s4.connectConfirmFailed")}
+        body={t("ob.s4.connectRetry")}
+      />
+    );
+  }
   return (
-    <>
-      {outcome === "denied" && (
-        <ConnectWarn
-          title={t("ob.s4.googleDenied")}
-          body={t("ob.s4.googleRetry")}
-        />
-      )}
-      {outcome === "error" && (
-        <ConnectWarn
-          title={t("ob.s4.googleFailed")}
-          body={t("ob.s4.googleRetry")}
-        />
-      )}
-      {google.isError && (
-        <ConnectWarn
-          title={t("ob.s4.googleFailed")}
-          body={google.error.message}
-        />
-      )}
-      <p
-        className="spoken-hint"
-        style={{ maxWidth: 460, margin: "4px auto 0" }}
-      >
-        <ShieldCheck aria-hidden /> {t("ob.s4.googleHint")}
-      </p>
-      <p className="t-small ob-google-unverified">
-        {t("ob.s4.googleUnverified")}
-      </p>
-      <div className="connect-acts">
-        <Button
-          variant="primary"
-          disabled={google.isPending}
-          onClick={() => google.mutate()}
-        >
-          {google.isPending ? (
-            <>
-              <span className="ob-spinner" /> {t("ob.s4.connecting")}
-            </>
-          ) : (
-            <>
-              <Mail aria-hidden /> {t("ob.s4.googleBtn")}
-            </>
-          )}
-        </Button>
-        <Button onClick={() => void onComplete(true)}>
-          <SkipForward aria-hidden /> {t("ob.s4.skipLater")}
-        </Button>
+    <div className="connect-result">
+      <div className="cr-h">
+        <CheckCircle2 aria-hidden /> {t("ob.s4.connectOkTitle")}
       </div>
-    </>
+      <p className="ob-sub" style={{ margin: "8px auto 0", maxWidth: 460 }}>
+        {t("ob.s4.connectOkBody")}
+      </p>
+      {connections.isPending && (
+        <p className="t-small" style={{ marginTop: "var(--space-3)" }}>
+          {t("ob.s4.connectVerifying")}
+        </p>
+      )}
+      {live && (
+        <>
+          <span className="trustpill" style={{ marginTop: "var(--space-3)" }}>
+            <ShieldCheck aria-hidden /> {t("ob.s4.connectLive")}
+          </span>
+          <BackfillPanel provider={live.provider} />
+        </>
+      )}
+      {!connections.isPending && !live && (
+        <ConnectWarn
+          title={t("ob.s4.connectConfirmFailed")}
+          body={t("ob.s4.connectRetry")}
+        />
+      )}
+      <Button
+        variant="primary"
+        style={{ marginTop: "var(--space-4)" }}
+        onClick={() => void onComplete(false)}
+      >
+        {t("ob.s4.enterCrm")} <ArrowRight aria-hidden />
+      </Button>
+    </div>
   );
 }
 

--- a/frontend/src/screens/onboarding-conversation/connect-act.test.tsx
+++ b/frontend/src/screens/onboarding-conversation/connect-act.test.tsx
@@ -1,0 +1,73 @@
+/** @vitest-environment jsdom */
+import "@testing-library/jest-dom/vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { LocaleProvider } from "../../i18n";
+import { installFetchStub, jsonResponse } from "../story-utils";
+import { ConnectAct } from "./connect-act";
+import { initialConversationState } from "./conversation-machine";
+
+// The Microsoft chip must open the SAME live OAuth panel as Google (no more
+// disabled "Soon" badge), and the post-consent return view no longer depends
+// on which chip was open when the redirect left — it reads the roster fresh.
+
+function renderConnectAct(outcome?: string) {
+  const state = {
+    ...initialConversationState,
+    act: "connect" as const,
+    phase: "cn.consent" as const,
+  };
+  return render(
+    <QueryClientProvider
+      client={
+        new QueryClient({ defaultOptions: { queries: { retry: false } } })
+      }
+    >
+      <LocaleProvider initial="en">
+        <ConnectAct
+          state={state}
+          dispatch={vi.fn()}
+          persist={vi.fn(async () => true)}
+          outcome={outcome}
+        />
+      </LocaleProvider>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.stubGlobal("scrollTo", vi.fn());
+});
+afterEach(() => vi.unstubAllGlobals());
+
+it("offers Microsoft as a live chip and opens its connect panel", async () => {
+  installFetchStub({ "GET /connectors": () => jsonResponse({ data: [] }) });
+  renderConnectAct();
+  const ms = screen.getByRole("button", { name: "Microsoft" });
+  expect(ms).not.toBeDisabled();
+  await userEvent.click(ms);
+  expect(
+    await screen.findByRole("button", { name: "Connect Microsoft" }),
+  ).toBeTruthy();
+});
+
+it("renders the provider-agnostic return view on OAuth return", async () => {
+  installFetchStub({
+    "GET /connectors": () =>
+      jsonResponse({
+        data: [
+          {
+            id: "g1",
+            provider: "graph",
+            status: "connected",
+            scopes: ["read"],
+            backfill: { state: "done" },
+          },
+        ],
+      }),
+  });
+  renderConnectAct("ok");
+  expect(await screen.findByText("Live and capturing")).toBeTruthy();
+});

--- a/frontend/src/screens/onboarding-conversation/connect-act.tsx
+++ b/frontend/src/screens/onboarding-conversation/connect-act.tsx
@@ -7,8 +7,9 @@ import { useT } from "../../i18n";
 import type { MessageKey } from "../../i18n/en";
 import { EMPTY_DRAFT } from "../onboarding";
 import {
-  GoogleConnectPanel,
   ImapConnectPanel,
+  OAuthConnectPanel,
+  OAuthReturnPanel,
 } from "../onboarding-connect-panels";
 import type {
   ConversationEvent,
@@ -45,7 +46,7 @@ type ConnectActProps = Readonly<{
   state: ConversationState;
   dispatch: Dispatch<ConversationEvent>;
   persist: (input: WizardPersistInput) => Promise<boolean>;
-  /** The Google consent return's outcome from the deep-link route. */
+  /** The OAuth consent return's outcome from the deep-link route. */
   outcome?: string;
 }>;
 
@@ -56,11 +57,10 @@ export function ConnectAct({
   outcome,
 }: ConnectActProps) {
   const t = useT();
-  // Returning from the Google consent lands here with an outcome in the
-  // route; the Google panel is then the one that explains what happened.
-  const [provider, setProvider] = useState<Provider | null>(
-    outcome !== undefined ? "google" : null,
-  );
+  // The OAuth return view no longer depends on which chip was open when the
+  // consent redirect left this screen — it reads the connector roster fresh,
+  // so `provider` only tracks which pre-consent panel is open right now.
+  const [provider, setProvider] = useState<Provider | null>(null);
   const [finishing, setFinishing] = useState(false);
   const [finishFailed, setFinishFailed] = useState(false);
 
@@ -95,15 +95,24 @@ export function ConnectAct({
             <h2>{t("ob.conv.connect.artifactTitle")}</h2>
             <p>{t("ob.s4.sub")}</p>
           </div>
-          {provider === null && (
-            <p className="ob-conv-artifact-empty">
-              {t("ob.conv.connect.artifactEmpty")}
-            </p>
+          {outcome !== undefined ? (
+            <OAuthReturnPanel outcome={outcome} onComplete={finish} />
+          ) : (
+            <>
+              {provider === null && (
+                <p className="ob-conv-artifact-empty">
+                  {t("ob.conv.connect.artifactEmpty")}
+                </p>
+              )}
+              {provider === "google" && (
+                <OAuthConnectPanel provider="gmail" onComplete={finish} />
+              )}
+              {provider === "microsoft" && (
+                <OAuthConnectPanel provider="graph" onComplete={finish} />
+              )}
+              {provider === "imap" && <ImapConnectPanel onComplete={finish} />}
+            </>
           )}
-          {provider === "google" && (
-            <GoogleConnectPanel outcome={outcome} onComplete={finish} />
-          )}
-          {provider === "imap" && <ImapConnectPanel onComplete={finish} />}
         </div>
       }
     >
@@ -150,26 +159,16 @@ export function ConnectAct({
                 </div>
               )}
               <div className="ob-conv-chips">
-                {(Object.keys(providerLabels) as Provider[]).map((key) => {
-                  // Microsoft has no live OAuth path yet: the chip is disabled
-                  // and badged "Soon" in place, so it can never open a dead
-                  // panel — an honest not-yet, not a cosmetic label.
-                  const soon = key === "microsoft";
-                  return (
-                    <Button
-                      key={key}
-                      small
-                      variant={provider === key ? "primary" : undefined}
-                      disabled={soon}
-                      onClick={soon ? undefined : () => setProvider(key)}
-                    >
-                      {t(providerLabels[key])}
-                      {soon && (
-                        <span className="ob-chip-soon">{t("ob.s4.soon")}</span>
-                      )}
-                    </Button>
-                  );
-                })}
+                {(Object.keys(providerLabels) as Provider[]).map((key) => (
+                  <Button
+                    key={key}
+                    small
+                    variant={provider === key ? "primary" : undefined}
+                    onClick={() => setProvider(key)}
+                  >
+                    {t(providerLabels[key])}
+                  </Button>
+                ))}
                 <Button
                   small
                   variant="ghost"

--- a/frontend/src/screens/onboarding-conversation/onboarding-restore.test.tsx
+++ b/frontend/src/screens/onboarding-conversation/onboarding-restore.test.tsx
@@ -1,4 +1,5 @@
 /** @vitest-environment jsdom */
+import "@testing-library/jest-dom/vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,
@@ -359,10 +360,8 @@ describe("restore into the conversational shell", () => {
     expect(screen.getByRole("button", { name: /Google/ })).toBeTruthy();
     // Microsoft is a live OAuth path now — the chip opens the same connect
     // panel Google does, no "Soon" placeholder, and is never disabled.
-    const microsoft = screen.getByRole("button", {
-      name: "Microsoft",
-    }) as HTMLButtonElement;
-    expect(microsoft.disabled).toBe(false);
+    const microsoft = screen.getByRole("button", { name: "Microsoft" });
+    expect(microsoft).not.toBeDisabled();
     expect(screen.queryByText(/Want me to learn how you write\?/)).toBeNull();
     // A member restore never probes the voice surface.
     expect(requestsTo(calls, "/voice-profiles", "GET").length).toBe(0);

--- a/frontend/src/screens/onboarding-conversation/onboarding-restore.test.tsx
+++ b/frontend/src/screens/onboarding-conversation/onboarding-restore.test.tsx
@@ -357,11 +357,12 @@ describe("restore into the conversational shell", () => {
       await screen.findByText(/Last step: what may I capture/),
     ).toBeTruthy();
     expect(screen.getByRole("button", { name: /Google/ })).toBeTruthy();
-    // Microsoft has no live path yet: its chip is badged "Soon" in place, so
-    // it can never lead a first-time user into a dead panel.
-    expect(
-      screen.getByRole("button", { name: /Microsoft/ }).textContent,
-    ).toMatch(/Soon/);
+    // Microsoft is a live OAuth path now — the chip opens the same connect
+    // panel Google does, no "Soon" placeholder, and is never disabled.
+    const microsoft = screen.getByRole("button", {
+      name: "Microsoft",
+    }) as HTMLButtonElement;
+    expect(microsoft.disabled).toBe(false);
     expect(screen.queryByText(/Want me to learn how you write\?/)).toBeNull();
     // A member restore never probes the voice surface.
     expect(requestsTo(calls, "/voice-profiles", "GET").length).toBe(0);

--- a/frontend/src/screens/settings.css
+++ b/frontend/src/screens/settings.css
@@ -417,3 +417,18 @@
   flex-basis: 100%;
   margin-top: var(--space-2);
 }
+
+/* "Add a connection" affordance: shared by the empty state and the roster
+   footer. In the footer it sits below the roster with clear separation; the
+   button row itself always wraps horizontally with the connector-row gap. */
+.connector-add {
+  margin-top: var(--space-4);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--borderSubtle);
+}
+.connector-add-actions {
+  display: flex;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+  justify-content: center;
+}


### PR DESCRIPTION
## What & why

Completes the connector **connect-initiate** gap from the UI audit (`.tmp/MISSING-UI-V4.md` §8 CN-5/CN-6 + §8a): a user can now **start** a connection to any supported provider — Gmail, Google Calendar (`gcal`), Microsoft 365 (`graph`), IMAP — from **Settings → Integrations** regardless of what's already connected, and **Microsoft is live in onboarding** (no more disabled "Soon" chip).

Pure frontend over already-routed, audited endpoints. **No backend / `crm.yaml` / contract change.**

### What shipped
- **Settings → Integrations — "Add a connection"** (`connectors.tsx`): an always-present affordance (empty state *and* a footer under the roster) offering only the providers not already connected. OAuth → consent redirect; IMAP → the existing inline form; a provider whose backend app isn't configured returns 501 and the UI shows an honest *"{provider} isn't configured in this deployment."* note.
- **Onboarding — Microsoft live** (`onboarding-connect-panels.tsx`, `connect-act.tsx`): the Gmail-only panel is generalized to a provider-parametrized `OAuthConnectPanel` + a provider-agnostic `OAuthReturnPanel` (the OAuth callback route carries no provider, so the return view reads `GET /connectors` and shows whichever mailbox is live — strictly better than the old hardcoded-Gmail return).
- **Docs** (`connect-a-mailbox.md`, `capture-connectors.md`): dropped the stale "Graph has no first-connect UI" caveat, documented the Settings add-connection footer and Google Calendar as a separate connection, flipped onboarding Microsoft off "Soon".

### Design note — Google is two connections, on purpose
Gmail and Google Calendar share one Google *app* but are **separate grants** (own `calendar.readonly` consent, own row). This is a deliberate least-privilege split (`gcal/client.go` omits `include_granted_scopes` so a calendar credential never inherits mail-read). This PR keeps that split — connecting both = two Google consent screens, by design. No scope-combining.

## Testing
- Full FE gate green: **93 files / 841 tests**, `tsc -b` clean, `vite build` ok, biome clean.
- New unit tests: the add-affordance offers only not-connected providers, OAuth click redirects, graph-501 renders the not-configured note, footer hidden when all four connected; onboarding Microsoft chip enabled + posts `graph`; the agnostic return view renders the live mailbox.
- Visual UAT via Storybook confirmed all four surfaces render cleanly (empty state, footer, Microsoft panel, return view).

## Manual testing (for the reviewer to run against a local stack)

> OAuth **redirects** need the relevant provider app configured; the IMAP path and the Microsoft-not-configured (501) path are fully testable without one.

**Settings → Integrations (`#/settings/integrations`)**
- [ ] Fresh install: empty state offers **four** buttons (Gmail, Google Calendar, Microsoft 365, IMAP) + "Gmail and Google Calendar connect separately."
- [ ] With Gmail connected: an **"Add a connection"** footer offers only the other three (Gmail not re-offered); buttons wrap and are spaced.
- [ ] All four connected: footer disappears.
- [ ] Click Gmail / Google Calendar → Google consent (separate consents, by design).
- [ ] Click Microsoft with no Entra app → honest *"Microsoft 365 isn't configured in this deployment."* (with `MARGINCE_GRAPH_*` set → redirects instead).
- [ ] Click IMAP → inline IMAP form opens.
- [ ] After a 501 note, switch provider / open IMAP form → stale note clears.
- [ ] Reconnect / disconnect (regression) still work.

**Onboarding (connect step)**
- [ ] Microsoft chip enabled (no "Soon"); Google + IMAP unchanged.
- [ ] Pick Microsoft → "Connect Microsoft" panel + read-only/unverified-app hint.
- [ ] Return from consent (ok) → "You're connected" + "Live and capturing" + backfill; denied/error → honest message.

**Both locales**
- [ ] Repeat in German — all new copy translated (no raw keys).

## Notes
- Known-harmless: a few `ob.s4.google*` / `connectors.connectCta` i18n keys and `.ob-chip-soon` CSS are now orphaned (no unused-key gate; parity holds) — candidate for a follow-up cleanup.
- The onboarding return view shows the first live OAuth mailbox; in normal one-mailbox onboarding that's the just-connected one. Perfect provider disambiguation across the full-page redirect would need a contract change (callback carries no provider) — out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds first-connect UI for all capture providers. Settings now has an “Add a connection” panel for Gmail, Google Calendar, Microsoft 365 (`graph`), and IMAP, and Microsoft is live in onboarding with a shared OAuth flow and provider-agnostic return. Pure frontend; no API or contract changes.

- **New Features**
  - Settings → Integrations: always-visible “Add a connection” shows only not-yet-connected providers; OAuth buttons redirect; IMAP opens the inline form; provider-specific 501 shows “{provider} isn’t configured in this deployment.”; footer hides when all four are connected; Gmail and Google Calendar connect separately.
  - Onboarding: Microsoft chip enabled; new `OAuthConnectPanel` (parametrized for `gmail`/`graph`) and `OAuthReturnPanel` (provider-agnostic, confirms via `GET /connectors`); backfill panel appears for eligible providers; Google Calendar remains Settings-only.

- **Bug Fixes**
  - Styled the add-connection footer (proper spacing/wrapping) and cleared stale “not configured” notes when switching to IMAP.
  - Documentation accuracy and minor test cleanups following review.

<sup>Written for commit d181a27e57850ca5c4ab1f61bda69cb44626cca3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “Add a connection” options in Integrations settings for available providers.
  * Enabled Microsoft account connection during onboarding.
  * Added provider-specific connection status, verification, success, and error messaging.
  * Added Google Calendar connection guidance and clarified forward-only syncing limitations.

* **Documentation**
  * Updated connector setup instructions and UI availability details for Gmail, IMAP, Microsoft Graph, and Google Calendar.
  * Clarified current connection and connector-health limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->