### PR TITLE
capture: counterparty-identity column (ADR-0072 phase 2a substrate for 2b)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -881,9 +881,20 @@ Open work, roughly in priority order:
   optimization); per-run crawl caps pinned lower for auto reads (12 pages);
   and `ApplySitePersonFields` (auto-filling an exact/unique-match existing
   person instead of always staging a lead).
-  **Still open (contract-first-gated on ADR-0072):** 2a (counterparty identity +
-  disposition ledger + deferred creation), 2b (the verdict job + review queue +
-  noise disposition), 3 (corroborated signature org-name promotion).
+  **Phase 2a (build, landed):** the counterparty-identity column
+  (`activity.counterparty_email`, migration 0123, index-backed) stamped at
+  capture, and the **T1 correspondence-positive gate** that runs BEFORE the T2
+  transactional suppression — a contact the owner has ever written to (an
+  index-backed EXISTS over outbound activities) is never suppressed as
+  infrastructure, even with a List-Unsubscribe footer. (Re-sliced from the plan:
+  the `capture_pending_counterparty` ledger + deferred creation move to 2b so the
+  deferral lands together with its verdict resolver — landing the deferral alone
+  would leave ambiguous senders in limbo. Capture-audit minimization also moves
+  to 2b, alongside the noise-redaction work it shares a theme with.)
+  **Still open (contract-first-gated on ADR-0072):** 2b (the pending ledger +
+  deferred creation + the `capture_counterparty_verdict` job + review queue +
+  noise hide-then-redact + capture-audit minimization), 3 (corroborated
+  signature org-name promotion).
 
 - **Site-read legal census — three known gaps (#162).** `FinishSiteRead`'s CAS
   guards only on `status = 'running'`, so a reclaimed-then-returning worker can

--- a/STATUS.md
+++ b/STATUS.md
@@ -882,19 +882,22 @@ Open work, roughly in priority order:
   and `ApplySitePersonFields` (auto-filling an exact/unique-match existing
   person instead of always staging a lead).
   **Phase 2a (build, landed):** the counterparty-identity column
-  (`activity.counterparty_email`, migration 0123, index-backed) stamped at
-  capture, and the **T1 correspondence-positive gate** that runs BEFORE the T2
-  transactional suppression — a contact the owner has ever written to (an
-  index-backed EXISTS over outbound activities) is never suppressed as
-  infrastructure, even with a List-Unsubscribe footer. (Re-sliced from the plan:
-  the `capture_pending_counterparty` ledger + deferred creation move to 2b so the
-  deferral lands together with its verdict resolver — landing the deferral alone
-  would leave ambiguous senders in limbo. Capture-audit minimization also moves
-  to 2b, alongside the noise-redaction work it shares a theme with.)
-  **Still open (contract-first-gated on ADR-0072):** 2b (the pending ledger +
-  deferred creation + the `capture_counterparty_verdict` job + review queue +
-  noise hide-then-redact + capture-audit minimization), 3 (corroborated
-  signature org-name promotion).
+  (`activity.counterparty_email`, migration 0123, partial index) stamped
+  (lowercased) at capture — captured from now so the phase-2b correspondence
+  gate has real outbound history the day it ships. (Re-scoped from the plan for
+  two reasons: (1) the `capture_pending_counterparty` ledger + deferred creation
+  move to 2b so the deferral lands together with its verdict resolver — landing
+  the deferral alone would leave ambiguous senders in limbo; (2) the **T1
+  correspondence-positive suppression spare also moves to 2b**: a security review
+  flagged that deriving the "outbound" signal from the forgeable `From` header
+  lets a spoofed `From:owner` mail whitelist an arbitrary address past T2, so 2b
+  will take the outbound signal from an authenticated provider label — Gmail
+  `SENT` / IMAP `\Sent` — before honoring it as a bypass. Capture-audit
+  minimization also moves to 2b.)
+  **Still open (contract-first-gated on ADR-0072):** 2b (the T1 gate with an
+  authenticated outbound signal + the pending ledger + deferred creation + the
+  `capture_counterparty_verdict` job + review queue + noise hide-then-redact +
+  capture-audit minimization), 3 (corroborated signature org-name promotion).
 
 - **Site-read legal census — three known gaps (#162).** `FinishSiteRead`'s CAS
   guards only on `status = 'running'`, so a reclaimed-then-returning worker can

--- a/backend/internal/compose/integration/capture_autocreate_integration_test.go
+++ b/backend/internal/compose/integration/capture_autocreate_integration_test.go
@@ -282,13 +282,13 @@ func TestAutoCreateFromCapturedMail(t *testing.T) {
 
 	t.Run("captured mail stamps the counterparty email on the activity", func(t *testing.T) {
 		// The alice thread above captured inbound + outbound mail with alice;
-		// each activity carries her normalized address, so the correspondence
-		// predicate is an index-backed lookup (CAP-DDL-7).
+		// each activity carries her normalized address, so phase 2b's
+		// correspondence predicate will be an index-backed lookup (CAP-DDL-7).
 		if n := countRows(t, e, `SELECT count(*) FROM activity WHERE counterparty_email = 'alice@acme.example'`); n < 1 {
 			t.Fatal("captured activities must stamp counterparty_email")
 		}
-		// An outbound leg stamps it too — that is what makes a later inbound
-		// correspondence-positive.
+		// An outbound leg stamps it too — the substrate that 2b's
+		// correspondence-positive gate reads.
 		if n := countRows(t, e, `SELECT count(*) FROM activity WHERE counterparty_email = 'alice@acme.example' AND direction = 'outbound'`); n < 1 {
 			t.Fatal("the outbound leg must stamp counterparty_email for the correspondence predicate")
 		}

--- a/backend/internal/compose/integration/capture_autocreate_integration_test.go
+++ b/backend/internal/compose/integration/capture_autocreate_integration_test.go
@@ -294,42 +294,6 @@ func TestAutoCreateFromCapturedMail(t *testing.T) {
 		}
 	})
 
-	t.Run("a correspondence-positive contact is spared transactional suppression", func(t *testing.T) {
-		// A contact the owner has already written to (a seeded outbound activity
-		// carrying their address) sends a newsletter from a prefix subdomain WITH
-		// a List-Unsubscribe footer — which would otherwise be T2-suppressed. T1
-		// spares them: the person and org are created (ADR-0072/A118, CAP-DDL-7).
-		err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
-			_, err := tx.Exec(context.Background(), `
-				INSERT INTO activity (workspace_id, kind, direction, source_system, source_id, source, captured_by, counterparty_email, occurred_at)
-				VALUES ($1, 'email', 'outbound', 'seed', 'seed-known-1', 'seed', 'connector:gmail', 'known@news.realco.example', now())`, e.WS)
-			return err
-		})
-		if err != nil {
-			t.Fatalf("seeding the prior outbound: %v", err)
-		}
-		sync(t, emailWithListUnsub("known@news.realco.example", "Known Contact", autoCreateOwner, "kn1@news.realco.example"))
-		if n := countRows(t, e, `
-			SELECT count(*) FROM person p JOIN person_email pe ON pe.person_id = p.id
-			WHERE pe.email = 'known@news.realco.example'`); n != 1 {
-			t.Fatal("a corresponded-with contact must not be transactionally suppressed")
-		}
-
-		// The control: an identical suppressible inbound from a STRANGER (no
-		// prior outbound) IS suppressed — no person, and a durable breadcrumb.
-		sync(t, emailWithListUnsub("cold@news.stranger.example", "Cold Blast", autoCreateOwner, "cs1@news.stranger.example"))
-		if n := countRows(t, e, `
-			SELECT count(*) FROM person p JOIN person_email pe ON pe.person_id = p.id
-			WHERE pe.email = 'cold@news.stranger.example'`); n != 0 {
-			t.Fatal("a stranger's corroborated prefix blast must be suppressed")
-		}
-		if n := countRows(t, e, `
-			SELECT count(*) FROM system_log
-			WHERE action = 'capture_transactional_suppressed' AND detail->>'source_id' = 'cs1@news.stranger.example'`); n != 1 {
-			t.Fatal("the stranger suppression must leave a breadcrumb")
-		}
-	})
-
 	t.Run("the workspace's own domain creates nothing", func(t *testing.T) {
 		sync(t, email("carol@myco.example", "Carol Colleague", autoCreateOwner, "c1@myco.example", ""))
 		if n := countRows(t, e, `

--- a/backend/internal/compose/integration/capture_autocreate_integration_test.go
+++ b/backend/internal/compose/integration/capture_autocreate_integration_test.go
@@ -280,6 +280,56 @@ func TestAutoCreateFromCapturedMail(t *testing.T) {
 		}
 	})
 
+	t.Run("captured mail stamps the counterparty email on the activity", func(t *testing.T) {
+		// The alice thread above captured inbound + outbound mail with alice;
+		// each activity carries her normalized address, so the correspondence
+		// predicate is an index-backed lookup (CAP-DDL-7).
+		if n := countRows(t, e, `SELECT count(*) FROM activity WHERE counterparty_email = 'alice@acme.example'`); n < 1 {
+			t.Fatal("captured activities must stamp counterparty_email")
+		}
+		// An outbound leg stamps it too — that is what makes a later inbound
+		// correspondence-positive.
+		if n := countRows(t, e, `SELECT count(*) FROM activity WHERE counterparty_email = 'alice@acme.example' AND direction = 'outbound'`); n < 1 {
+			t.Fatal("the outbound leg must stamp counterparty_email for the correspondence predicate")
+		}
+	})
+
+	t.Run("a correspondence-positive contact is spared transactional suppression", func(t *testing.T) {
+		// A contact the owner has already written to (a seeded outbound activity
+		// carrying their address) sends a newsletter from a prefix subdomain WITH
+		// a List-Unsubscribe footer — which would otherwise be T2-suppressed. T1
+		// spares them: the person and org are created (ADR-0072/A118, CAP-DDL-7).
+		err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+			_, err := tx.Exec(context.Background(), `
+				INSERT INTO activity (workspace_id, kind, direction, source_system, source_id, source, captured_by, counterparty_email, occurred_at)
+				VALUES ($1, 'email', 'outbound', 'seed', 'seed-known-1', 'seed', 'connector:gmail', 'known@news.realco.example', now())`, e.WS)
+			return err
+		})
+		if err != nil {
+			t.Fatalf("seeding the prior outbound: %v", err)
+		}
+		sync(t, emailWithListUnsub("known@news.realco.example", "Known Contact", autoCreateOwner, "kn1@news.realco.example"))
+		if n := countRows(t, e, `
+			SELECT count(*) FROM person p JOIN person_email pe ON pe.person_id = p.id
+			WHERE pe.email = 'known@news.realco.example'`); n != 1 {
+			t.Fatal("a corresponded-with contact must not be transactionally suppressed")
+		}
+
+		// The control: an identical suppressible inbound from a STRANGER (no
+		// prior outbound) IS suppressed — no person, and a durable breadcrumb.
+		sync(t, emailWithListUnsub("cold@news.stranger.example", "Cold Blast", autoCreateOwner, "cs1@news.stranger.example"))
+		if n := countRows(t, e, `
+			SELECT count(*) FROM person p JOIN person_email pe ON pe.person_id = p.id
+			WHERE pe.email = 'cold@news.stranger.example'`); n != 0 {
+			t.Fatal("a stranger's corroborated prefix blast must be suppressed")
+		}
+		if n := countRows(t, e, `
+			SELECT count(*) FROM system_log
+			WHERE action = 'capture_transactional_suppressed' AND detail->>'source_id' = 'cs1@news.stranger.example'`); n != 1 {
+			t.Fatal("the stranger suppression must leave a breadcrumb")
+		}
+	})
+
 	t.Run("the workspace's own domain creates nothing", func(t *testing.T) {
 		sync(t, email("carol@myco.example", "Carol Colleague", autoCreateOwner, "c1@myco.example", ""))
 		if n := countRows(t, e, `

--- a/backend/internal/modules/capture/sink.go
+++ b/backend/internal/modules/capture/sink.go
@@ -349,14 +349,15 @@ func (s *Sink) upsertActivity(ctx context.Context, tx pgx.Tx, rec connector.Norm
 	occurredAt := defaultOccurredAt(fields.OccurredAt)
 	var id ids.ActivityID
 	err := tx.QueryRow(ctx, `
-		INSERT INTO activity (workspace_id, kind, subject, body, occurred_at, direction, source_system, source_id, source, captured_by, thread_key)
+		INSERT INTO activity (workspace_id, kind, subject, body, occurred_at, direction, source_system, source_id, source, captured_by, thread_key, counterparty_email)
 		VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid,
-		        $1, NULLIF($2, ''), NULLIF($3, ''), $4, NULLIF($5, ''), $6, $7, $8, $9, NULLIF($10, ''))
+		        $1, NULLIF($2, ''), NULLIF($3, ''), $4, NULLIF($5, ''), $6, $7, $8, $9, NULLIF($10, ''), NULLIF($11, ''))
 		ON CONFLICT (workspace_id, source_system, source_id) WHERE source_system IS NOT NULL AND source_id IS NOT NULL
 		DO NOTHING
 		RETURNING id`,
 		fields.Kind, fields.Subject, fields.Body, occurredAt, fields.Direction,
-		rec.NaturalKey.SourceSystem, rec.NaturalKey.SourceID, captureSource(rec), rec.CapturedBy, rec.ThreadKey).Scan(&id)
+		rec.NaturalKey.SourceSystem, rec.NaturalKey.SourceID, captureSource(rec), rec.CapturedBy, rec.ThreadKey,
+		rec.Counterparty.Email).Scan(&id)
 	if err == nil {
 		// Field-level provenance (B-E02.12) for the content fields this
 		// capture set — same source/author the row itself carries.

--- a/backend/internal/modules/capture/sink.go
+++ b/backend/internal/modules/capture/sink.go
@@ -357,7 +357,11 @@ func (s *Sink) upsertActivity(ctx context.Context, tx pgx.Tx, rec connector.Norm
 		RETURNING id`,
 		fields.Kind, fields.Subject, fields.Body, occurredAt, fields.Direction,
 		rec.NaturalKey.SourceSystem, rec.NaturalKey.SourceID, captureSource(rec), rec.CapturedBy, rec.ThreadKey,
-		rec.Counterparty.Email).Scan(&id)
+		// Stored lowercased to match every reader (correspondencePositive, the
+		// reply-contact lookup, person_email) — a connector need not normalize
+		// the header case, and a mixed-case store would silently miss the
+		// index-backed correspondence EXISTS (a false suppression).
+		strings.ToLower(strings.TrimSpace(rec.Counterparty.Email))).Scan(&id)
 	if err == nil {
 		// Field-level provenance (B-E02.12) for the content fields this
 		// capture set — same source/author the row itself carries.

--- a/backend/internal/modules/capture/sink.go
+++ b/backend/internal/modules/capture/sink.go
@@ -357,10 +357,10 @@ func (s *Sink) upsertActivity(ctx context.Context, tx pgx.Tx, rec connector.Norm
 		RETURNING id`,
 		fields.Kind, fields.Subject, fields.Body, occurredAt, fields.Direction,
 		rec.NaturalKey.SourceSystem, rec.NaturalKey.SourceID, captureSource(rec), rec.CapturedBy, rec.ThreadKey,
-		// Stored lowercased to match every reader (correspondencePositive, the
-		// reply-contact lookup, person_email) — a connector need not normalize
-		// the header case, and a mixed-case store would silently miss the
-		// index-backed correspondence EXISTS (a false suppression).
+		// Normalized lowercased at the write (a connector need not lowercase the
+		// header case), matching the person_email normalization, so phase 2b's
+		// index-backed equality on this column matches regardless of the
+		// sender's casing without a runtime case fold.
 		strings.ToLower(strings.TrimSpace(rec.Counterparty.Email))).Scan(&id)
 	if err == nil {
 		// Field-level provenance (B-E02.12) for the content fields this

--- a/backend/internal/modules/capture/sinkensure.go
+++ b/backend/internal/modules/capture/sinkensure.go
@@ -92,15 +92,25 @@ func (s *Sink) ensureCounterparty(ctx context.Context, rec connector.NormalizedR
 		// creates nothing.
 		return
 	}
+	// T1 correspondence-positive (CAP-DDL-7, ADR-0072): a human the owner has
+	// ever written to is a real contact, never suppressed as infrastructure —
+	// even when their mail carries a List-Unsubscribe footer. This runs BEFORE
+	// the T2 transactional gate, so a known contact's newsletter is spared. The
+	// predicate is an index-backed EXISTS over the owner's outbound activities
+	// to this address (idx_activity_counterparty_email); a fault here is logged
+	// and treated as not-corresponded (fail safe toward the suppression check,
+	// never toward a false suppression — the gate itself still requires
+	// corroboration on the prefix rules).
+	corresponded, err := s.correspondencePositive(ctx, cp.Email)
+	if err != nil {
+		s.logEnsureFault(ctx, rec, err)
+	}
 	// T2 transactional / ESP infrastructure (CAP-PARAM-6, ADR-0072): a
 	// DocuSign envelope or a SendGrid relay is not a counterparty's company.
 	// Suppress person AND org derivation — the activity already committed and
 	// stands (a DocuSign envelope is a real timeline item) — and record the
-	// reason durably for observability. Runs after the internal-domain gate;
-	// the correspondence-positive check that must precede it lands with the
-	// identity column (ADR-0072 phase 2a), and until then the corroboration
-	// requirement on prefix rules keeps a known contact from being suppressed.
-	if s.transactional != nil {
+	// reason durably for observability.
+	if !corresponded && s.transactional != nil {
 		if suppress, reason := s.transactional.Suppress(transactionalInput(cp)); suppress {
 			s.logSuppression(ctx, rec, reason)
 			return
@@ -138,6 +148,30 @@ func (s *Sink) internalDomain(ctx context.Context, domain string) (bool, error) 
 		return false, fmt.Errorf("capture: internal-domain gate: %w", err)
 	}
 	return internal, nil
+}
+
+// correspondencePositive reports whether the owner has ever written to this
+// address — an outbound activity whose counterparty is email exists (CAP-DDL-7).
+// Sending to someone is affirmative intent; the first outbound mail TO an
+// address makes it correspondence-positive immediately (the outbound activity
+// carries counterparty_email). A cold inbound alone does not. The lookup is
+// index-backed (idx_activity_counterparty_email) and RLS-scoped to the
+// workspace.
+func (s *Sink) correspondencePositive(ctx context.Context, email string) (bool, error) {
+	email = strings.ToLower(strings.TrimSpace(email))
+	if email == "" {
+		return false, nil
+	}
+	var corresponded bool
+	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx,
+			`SELECT EXISTS (SELECT 1 FROM activity WHERE counterparty_email = $1 AND direction = 'outbound')`,
+			email).Scan(&corresponded)
+	})
+	if err != nil {
+		return false, fmt.Errorf("capture: correspondence-positive check: %w", err)
+	}
+	return corresponded, nil
 }
 
 // transactionalInput builds the transactional-gate input from a captured

--- a/backend/internal/modules/capture/sinkensure.go
+++ b/backend/internal/modules/capture/sinkensure.go
@@ -92,25 +92,16 @@ func (s *Sink) ensureCounterparty(ctx context.Context, rec connector.NormalizedR
 		// creates nothing.
 		return
 	}
-	// T1 correspondence-positive (CAP-DDL-7, ADR-0072): a human the owner has
-	// ever written to is a real contact, never suppressed as infrastructure —
-	// even when their mail carries a List-Unsubscribe footer. This runs BEFORE
-	// the T2 transactional gate, so a known contact's newsletter is spared. The
-	// predicate is an index-backed EXISTS over the owner's outbound activities
-	// to this address (idx_activity_counterparty_email); a fault here is logged
-	// and treated as not-corresponded (fail safe toward the suppression check,
-	// never toward a false suppression — the gate itself still requires
-	// corroboration on the prefix rules).
-	corresponded, err := s.correspondencePositive(ctx, cp.Email)
-	if err != nil {
-		s.logEnsureFault(ctx, rec, err)
-	}
 	// T2 transactional / ESP infrastructure (CAP-PARAM-6, ADR-0072): a
 	// DocuSign envelope or a SendGrid relay is not a counterparty's company.
 	// Suppress person AND org derivation — the activity already committed and
 	// stands (a DocuSign envelope is a real timeline item) — and record the
-	// reason durably for observability.
-	if !corresponded && s.transactional != nil {
+	// reason durably for observability. The T1 correspondence-positive spare
+	// (CAP-DDL-7) that lets a known contact through lands in phase 2b, where the
+	// "outbound" signal is taken from an authenticated provider label — deriving
+	// it from the forgeable From header (as `direction` does today) would let a
+	// spoofed From:owner mail whitelist an arbitrary address past this gate.
+	if s.transactional != nil {
 		if suppress, reason := s.transactional.Suppress(transactionalInput(cp)); suppress {
 			s.logSuppression(ctx, rec, reason)
 			return
@@ -148,30 +139,6 @@ func (s *Sink) internalDomain(ctx context.Context, domain string) (bool, error) 
 		return false, fmt.Errorf("capture: internal-domain gate: %w", err)
 	}
 	return internal, nil
-}
-
-// correspondencePositive reports whether the owner has ever written to this
-// address — an outbound activity whose counterparty is email exists (CAP-DDL-7).
-// Sending to someone is affirmative intent; the first outbound mail TO an
-// address makes it correspondence-positive immediately (the outbound activity
-// carries counterparty_email). A cold inbound alone does not. The lookup is
-// index-backed (idx_activity_counterparty_email) and RLS-scoped to the
-// workspace.
-func (s *Sink) correspondencePositive(ctx context.Context, email string) (bool, error) {
-	email = strings.ToLower(strings.TrimSpace(email))
-	if email == "" {
-		return false, nil
-	}
-	var corresponded bool
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
-		return tx.QueryRow(ctx,
-			`SELECT EXISTS (SELECT 1 FROM activity WHERE counterparty_email = $1 AND direction = 'outbound')`,
-			email).Scan(&corresponded)
-	})
-	if err != nil {
-		return false, fmt.Errorf("capture: correspondence-positive check: %w", err)
-	}
-	return corresponded, nil
 }
 
 // transactionalInput builds the transactional-gate input from a captured

--- a/backend/internal/modules/capture/transactional.go
+++ b/backend/internal/modules/capture/transactional.go
@@ -19,9 +19,11 @@ package capture
 //   allowlist wins → exact eSLD infra suppresses standalone →
 //   subdomain-prefix rule suppresses ONLY with corroboration → otherwise keep.
 //
-// This is the pure decision only. The Sink runs it AFTER the correspondence-
-// positive check (a known human is never suppressed) and records every
-// suppression durably for observability.
+// This is the pure decision only. The Sink runs it after the internal-domain
+// gate and records every suppression durably for observability. The T1
+// correspondence-positive spare that lets a known contact through lands in
+// phase 2b (ADR-0072), on an authenticated provider outbound signal — the
+// forgeable From header cannot be trusted to grant a suppression bypass.
 
 import (
 	"strings"

--- a/backend/migrations/core/0123_activity_counterparty_email.down.sql
+++ b/backend/migrations/core/0123_activity_counterparty_email.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX idx_activity_counterparty_email;
+ALTER TABLE activity DROP COLUMN counterparty_email;

--- a/backend/migrations/core/0123_activity_counterparty_email.up.sql
+++ b/backend/migrations/core/0123_activity_counterparty_email.up.sql
@@ -1,12 +1,13 @@
 -- ADR-0072/A118 (CAP-DDL-7): the captured-message counterparty identity.
 --
 -- Capture stamps the normalized counterparty address on the activity row, so
--- the correspondence-positive predicate — "has the owner ever written to this
--- address?" — is an index-backed EXISTS over outbound activities instead of an
--- unimplementable scan (the row previously carried no participant email). This
--- is what lets the transactional-suppression gate (CAP-PARAM-6) spare a known
--- contact: a human the owner has corresponded with is never suppressed, even
--- when their mail carries a List-Unsubscribe footer.
+-- the workspace's correspondence — "has this address ever been written to?" —
+-- becomes an index-backed EXISTS instead of an unimplementable scan (the row
+-- previously carried no participant email). The column is captured from NOW so
+-- the correspondence-positive suppression spare (phase 2b, CAP-PARAM-6) has real
+-- outbound history the day it ships; 2b derives the outbound signal from an
+-- authenticated provider label, not the forgeable From header, before honoring
+-- it as a suppression bypass.
 --
 -- Additive and nullable: a non-mail activity (a call, a system note) carries no
 -- counterparty and stores NULL. The partial index serves the EXISTS lookup and

--- a/backend/migrations/core/0123_activity_counterparty_email.up.sql
+++ b/backend/migrations/core/0123_activity_counterparty_email.up.sql
@@ -1,0 +1,18 @@
+-- ADR-0072/A118 (CAP-DDL-7): the captured-message counterparty identity.
+--
+-- Capture stamps the normalized counterparty address on the activity row, so
+-- the correspondence-positive predicate — "has the owner ever written to this
+-- address?" — is an index-backed EXISTS over outbound activities instead of an
+-- unimplementable scan (the row previously carried no participant email). This
+-- is what lets the transactional-suppression gate (CAP-PARAM-6) spare a known
+-- contact: a human the owner has corresponded with is never suppressed, even
+-- when their mail carries a List-Unsubscribe footer.
+--
+-- Additive and nullable: a non-mail activity (a call, a system note) carries no
+-- counterparty and stores NULL. The partial index serves the EXISTS lookup and
+-- skips the NULL rows.
+ALTER TABLE activity ADD COLUMN counterparty_email text;
+
+CREATE INDEX idx_activity_counterparty_email
+  ON activity (workspace_id, counterparty_email)
+  WHERE counterparty_email IS NOT NULL;


### PR DESCRIPTION
**Phase 2a** of the capture quality-gates arc (ADR-0072/A118 — spec merged; phases 1+4A+4B in #243).

## What it does
- **Migration 0123:** `activity.counterparty_email` (normalized/lowercased, nullable) + a partial tenant index. Capture stamps the counterparty address on every mail activity, so the workspace's correspondence becomes an index-backed `EXISTS`.
- **Captured from now on purpose:** the column records the identity immediately so the phase-2b correspondence-positive suppression spare has real outbound history the day it ships (rather than starting empty).

## Re-scope (from the end-of-work review)
- **Security (Medium):** the T1 correspondence-positive spare was going to derive the "outbound" signal from the forgeable `From` header — a spoofed `From:owner` mail could whitelist an arbitrary address past T2 suppression and inject an attacker-chosen contact/org. So the **T1 spare moves to 2b**, where the outbound signal comes from an authenticated provider label (Gmail `SENT` / IMAP `\Sent`) before it can grant a bypass.
- **Coupling:** the `capture_pending_counterparty` ledger + deferred creation also land in 2b (with their verdict resolver), so ambiguous senders are never left in limbo.

This PR is the identity substrate: column + lowercased stamping + the stamping test.

## Gates
`make check` · full `make test-integration` (0 skips, incl. 0123 reverse/reapply). Craft static 0 blockers; craft + security reviews applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)