### PR TITLE
capture: metadata-only audit image for captured activities (ADR-0072 2b slice 1)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -894,10 +894,16 @@ Open work, roughly in priority order:
   will take the outbound signal from an authenticated provider label — Gmail
   `SENT` / IMAP `\Sent` — before honoring it as a bypass. Capture-audit
   minimization also moves to 2b.)
-  **Still open (contract-first-gated on ADR-0072):** 2b (the T1 gate with an
-  authenticated outbound signal + the pending ledger + deferred creation + the
-  `capture_counterparty_verdict` job + review queue + noise hide-then-redact +
-  capture-audit minimization), 3 (corroborated signature org-name promotion).
+  **2b is landing in slices.** Slice 1 (landed): **capture-audit minimization** —
+  a connector-captured activity's audit after-image is metadata-only (natural
+  key + kind + direction + timestamp), never the subject/body, which stay on the
+  activity row + raw_capture under their own retention (the "noise is not stored
+  in the append-only spine" hardening; human-authored activities keep their full
+  image).
+  **Still open (contract-first-gated on ADR-0072):** the rest of 2b — the T1 gate
+  with an authenticated outbound signal + the pending ledger + deferred creation
+  + the `capture_counterparty_verdict` job + review queue + noise
+  hide-then-redact — and 3 (corroborated signature org-name promotion).
 
 - **Site-read legal census — three known gaps (#162).** `FinishSiteRead`'s CAS
   guards only on `status = 'running'`, so a reclaimed-then-returning worker can

--- a/backend/internal/compose/integration/capture_autocreate_integration_test.go
+++ b/backend/internal/compose/integration/capture_autocreate_integration_test.go
@@ -294,6 +294,31 @@ func TestAutoCreateFromCapturedMail(t *testing.T) {
 		}
 	})
 
+	t.Run("a captured activity's audit image is metadata-only, never the body", func(t *testing.T) {
+		// Capture-audit minimization (ADR-0072/A118): the connector-captured
+		// activity's audit after-image carries the natural key + kind + direction
+		// + timestamp, but NEVER the subject/body — the message content stays on
+		// the activity row and raw_capture under their own retention, off the
+		// append-only audit spine.
+		var hasBody, hasSubject, hasKind, hasSourceID bool
+		err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
+			return tx.QueryRow(context.Background(), `
+				SELECT after ? 'body', after ? 'subject', after ? 'kind', after ? 'source_id'
+				FROM audit_log
+				WHERE entity_type = 'activity' AND action = 'create'
+				ORDER BY occurred_at LIMIT 1`).Scan(&hasBody, &hasSubject, &hasKind, &hasSourceID)
+		})
+		if err != nil {
+			t.Fatalf("reading the captured-activity audit image: %v", err)
+		}
+		if hasBody || hasSubject {
+			t.Fatalf("captured-activity audit after leaked content (body=%v subject=%v) — must be metadata-only", hasBody, hasSubject)
+		}
+		if !hasKind || !hasSourceID {
+			t.Fatal("captured-activity audit after must keep the metadata (kind, natural key)")
+		}
+	})
+
 	t.Run("the workspace's own domain creates nothing", func(t *testing.T) {
 		sync(t, email("carol@myco.example", "Carol Colleague", autoCreateOwner, "c1@myco.example", ""))
 		if n := countRows(t, e, `

--- a/backend/internal/modules/capture/sink.go
+++ b/backend/internal/modules/capture/sink.go
@@ -196,7 +196,9 @@ func (s *Sink) captureActivity(ctx context.Context, tx pgx.Tx, rec connector.Nor
 	if err := s.linkActivity(ctx, tx, id, rec.Links); err != nil {
 		return datasource.EntityRef{}, false, err
 	}
-	auditID, err := storekit.Audit(ctx, tx, "create", "activity", id.UUID, nil, fields)
+	// Capture-audit minimization (ADR-0072/A118): the after-image is
+	// metadata-only, never the subject/body (capturedActivityAuditImage).
+	auditID, err := storekit.Audit(ctx, tx, "create", "activity", id.UUID, nil, capturedActivityAuditImage(rec, fields))
 	if err != nil {
 		return datasource.EntityRef{}, false, err
 	}

--- a/backend/internal/modules/capture/sinkaudit.go
+++ b/backend/internal/modules/capture/sinkaudit.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package capture
+
+// Capture-audit minimization (ADR-0072/A118): a connector-captured activity's
+// audit after-image is metadata-only — the natural key, kind, direction, and
+// timestamp — never the subject/body. The message content already lives on the
+// activity row and the raw_capture blob under their own retention; duplicating
+// it into the append-only audit spine (which survives an erasure differently,
+// and is special-category-adjacent for mail) is the "noise is not stored" gap
+// this closes. Field/record-history for a captured activity therefore show its
+// metadata, not its body. Human-authored activities (activities.LogActivity)
+// keep their full audit image.
+
+import "github.com/gradionhq/margince/backend/internal/shared/ports/connector"
+
+// capturedActivityAuditImage is the metadata-only after-image for a captured
+// activity's create audit.
+func capturedActivityAuditImage(rec connector.NormalizedRecord, fields ActivityFields) map[string]any {
+	return map[string]any{
+		"kind":            fields.Kind,
+		"direction":       fields.Direction,
+		"occurred_at":     defaultOccurredAt(fields.OccurredAt),
+		fieldSourceSystem: rec.NaturalKey.SourceSystem,
+		fieldSourceID:     rec.NaturalKey.SourceID,
+	}
+}


### PR DESCRIPTION
**Phase 2b, slice 1** of the capture quality-gates arc (ADR-0072/A118 — spec merged; phases 1+4A+4B in #243; 2a identity column in #250). 2b is landing in coherent slices; this one is **capture-audit minimization** — the "noise is not stored in the append-only spine" hardening the earlier security review flagged.

## What it does
A connector-captured activity's audit after-image is now **metadata-only** — natural key + kind + direction + `occurred_at` (`capturedActivityAuditImage`) — never the subject/body. The message content already lives on the `activity` row and the `raw_capture` blob under their own retention; duplicating it into the append-only `audit_log` (which survives an erasure differently, and is special-category-adjacent for mail) was the gap. Field/record-history for a captured activity therefore show its metadata, not its body. **Human-authored activities** (`activities.LogActivity`) keep their full audit image.

## Tests
A captured activity's audit `after` carries `kind` + the natural key but **neither `body` nor `subject`**. `make check` + full `make test-integration` (0 skips) — no field-history / record-history / GDPR-erasure regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make audit images for connector-captured activities metadata-only to keep message content out of the append-only `audit_log` (ADR-0072 phase 2b, slice 1). Human-authored activities are unchanged.

- **New Features**
  - Captured activity create audits now include only: `kind`, `direction`, `occurred_at`, and natural key (`source_system`, `source_id`) — never `subject` or `body`.
  - Implemented via `capturedActivityAuditImage` in the `capture` sink, with an integration test verifying no content fields are stored.

<sup>Written for commit c327e6755676c2baddc92e7b707c8ef9f3564003. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

