### PR TITLE
capture: T1 correspondence gate on a provider-attested outbound signal (ADR-0072 2b slice 2)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -900,10 +900,51 @@ Open work, roughly in priority order:
   activity row + raw_capture under their own retention (the "noise is not stored
   in the append-only spine" hardening; human-authored activities keep their full
   image).
-  **Still open (contract-first-gated on ADR-0072):** the rest of 2b — the T1 gate
-  with an authenticated outbound signal + the pending ledger + deferred creation
-  + the `capture_counterparty_verdict` job + review queue + noise
-  hide-then-redact — and 3 (corroborated signature org-name promotion).
+  Slice 2 (landed): **the T1 correspondence-positive gate on a provider-attested
+  outbound signal.** T1 now runs BEFORE T2 (order is load-bearing: a known
+  contact's `List-Unsubscribe` newsletter is no longer suppressed as bulk
+  infrastructure), and its evidence is a new `activity.counterparty_outbound_attested`
+  column (migration 0124 + a partial index serving the EXISTS) stamped only from
+  what the PROVIDER vouches for — Gmail's `SENT` label (read off the same
+  `messages.get` response the body needs), an IMAP `\Sent` **special-use**
+  mailbox (the folder NAME attests nothing — it is operator config text), and
+  Microsoft's SentItems `parentFolderId` (backfill only; the incremental delta is
+  inbox-only). `activity.direction` is never consulted: it string-compares the
+  forgeable `From` header against the owner, so a spoofed `From:owner` landing in
+  the synced inbox would otherwise whitelist any address it names past T2 — the
+  security review's finding, now gated by an integration test. A T1 override of a
+  matched suppression rule is its own `system_log` breadcrumb
+  (`capture_correspondence_spared`), so a spare is as diagnosable as a
+  suppression. A provider that attests nothing (or a LIST/folder probe that
+  fails) attests false and is logged — under-attestation suppresses, it never
+  creates. `make check` + the full zero-skip integration lane green.
+  Attestation requires BOTH halves — the provider filed the message as sent AND
+  the message names the owner as author — because the two are derived
+  independently: a server-side rule can file a third party's mail into a `\Sent`
+  mailbox or Sent Items, and that message's counterparty is its *sender*, so
+  attesting on placement alone would buy a stranger the same bypass the forged
+  header would have. Provider evidence accrues asymmetrically and this is
+  inherent, not a bug: continuously from Gmail, from Graph only during backfill
+  (the delta is inbox-only), and from IMAP only when the operator points the
+  connection at a `\Sent` mailbox — so an absent T1 spare on a default-INBOX
+  IMAP workspace is expected.
+  **Residual risk for the ADR (raised, no code change):** a rule-based Outlook
+  "reply with template" emits a genuine `From:owner` message with no
+  `Auto-Submitted` header, so an outsider can still induce a T1 spare by mailing
+  in and letting the rule answer. Inherent to the ADR's premise that writing to
+  someone is intent; the cheap mitigations if it ever matters are requiring two
+  attested outbound messages, or discounting an attested message that is an
+  immediate reply to an inbound one.
+  **Upstream spec raise (not worked around here):** ADR-0072 §1's ladder reads
+  T1 → "ensure person+org NOW", which taken literally would mint a "Gmail"
+  organization for a free-mail address the owner has corresponded with — exactly
+  the junk the ADR exists to prevent. The build keeps T3's free-mail org
+  suppression under a T1 spare (T1 overrides T2 only) and gates it with a test;
+  the ladder wording needs reconciling upstream.
+  **Still open (contract-first-gated on ADR-0072):** the rest of 2b — the pending
+  ledger + deferred creation + the `capture_counterparty_verdict` job + review
+  queue + noise hide-then-redact — and 3 (corroborated signature org-name
+  promotion).
 
 - **Site-read legal census — three known gaps (#162).** `FinishSiteRead`'s CAS
   guards only on `status = 'running'`, so a reclaimed-then-returning worker can

--- a/STATUS.md
+++ b/STATUS.md
@@ -915,9 +915,13 @@ Open work, roughly in priority order:
   names past T2. A T1 override of a
   matched suppression rule is its own `system_log` breadcrumb
   (`capture_correspondence_spared`), so a spare is as diagnosable as a
-  suppression. A provider that attests nothing (or a LIST/folder probe that
-  fails) attests false and is logged — under-attestation suppresses, it never
-  creates. `make check` + the full zero-skip integration lane green.
+  suppression. A provider that attests nothing — Graph's inbox-only
+  delta, an IMAP mailbox without the attribute — yields false, and
+  under-attestation suppresses rather than creates. A probe that FAILS is not
+  the same thing and is never recorded as a determined false: the Graph page
+  stops and the IMAP pull stops, each retrying from its committed cursor,
+  because the activity natural key would otherwise freeze a guessed window
+  permanently. `make check` + the full zero-skip integration lane green.
   Attestation requires BOTH halves — the provider filed the message as sent AND
   the message names the owner as author — because the two are derived
   independently: a server-side rule can file a third party's mail into a `\Sent`

--- a/STATUS.md
+++ b/STATUS.md
@@ -932,10 +932,14 @@ Open work, roughly in priority order:
   (the delta is inbox-only), and from IMAP only when the operator points the
   connection at a `\Sent` mailbox — so an absent T1 spare on a default-INBOX
   IMAP workspace is expected.
-  A tree-derived fitness test (`backend/attestationproducer_test.go`) keeps the
-  mail mapper the ONLY producer of the attestation, so the next connector that
-  builds a `Counterparty` from a provider payload cannot set it from
-  attacker-shaped JSON without failing the gate.
+  The attestation is unforgeable by the compiler, not by convention: the field is
+  unexported, so a literal, a positional literal, an assignment, an
+  `encoding/json` unmarshal of a provider payload, reflection, and a conversion
+  from a look-alike struct are all refused or inert. What no type can express —
+  that the argument to the minting call comes from an authenticated provider
+  handle — is guarded by a tree-derived fitness test
+  (`backend/attestationproducer_test.go`) keeping `WithOwnerAttestation`
+  callable from the mail mapper alone.
   **Residuals for the ADR (raised, no code change; also recorded in 0124):** an
   owner-side rule filing spoofed own-domain mail into the sent container defeats
   the conjunction on Graph and IMAP (not Gmail, whose SENT label filters cannot

--- a/STATUS.md
+++ b/STATUS.md
@@ -909,10 +909,10 @@ Open work, roughly in priority order:
   `messages.get` response the body needs), an IMAP `\Sent` **special-use**
   mailbox (the folder NAME attests nothing — it is operator config text), and
   Microsoft's SentItems `parentFolderId` (backfill only; the incremental delta is
-  inbox-only). `activity.direction` is never consulted: it string-compares the
-  forgeable `From` header against the owner, so a spoofed `From:owner` landing in
-  the synced inbox would otherwise whitelist any address it names past T2 — the
-  security review's finding, now gated by an integration test. A T1 override of a
+  inbox-only). `activity.direction` is never sufficient on its own: it
+  string-compares the forgeable `From` header against the owner, so a spoofed
+  `From:owner` landing in the synced inbox must not whitelist any address it
+  names past T2. A T1 override of a
   matched suppression rule is its own `system_log` breadcrumb
   (`capture_correspondence_spared`), so a spare is as diagnosable as a
   suppression. A provider that attests nothing (or a LIST/folder probe that
@@ -928,18 +928,25 @@ Open work, roughly in priority order:
   (the delta is inbox-only), and from IMAP only when the operator points the
   connection at a `\Sent` mailbox — so an absent T1 spare on a default-INBOX
   IMAP workspace is expected.
-  **Residual risk for the ADR (raised, no code change):** a rule-based Outlook
-  "reply with template" emits a genuine `From:owner` message with no
-  `Auto-Submitted` header, so an outsider can still induce a T1 spare by mailing
-  in and letting the rule answer. Inherent to the ADR's premise that writing to
-  someone is intent; the cheap mitigations if it ever matters are requiring two
-  attested outbound messages, or discounting an attested message that is an
-  immediate reply to an inbound one.
+  A tree-derived fitness test (`backend/attestationproducer_test.go`) keeps the
+  mail mapper the ONLY producer of the attestation, so the next connector that
+  builds a `Counterparty` from a provider payload cannot set it from
+  attacker-shaped JSON without failing the gate.
+  **Residuals for the ADR (raised, no code change; also recorded in 0124):** an
+  owner-side rule filing spoofed own-domain mail into the sent container defeats
+  the conjunction on Graph and IMAP (not Gmail, whose SENT label filters cannot
+  set); a forged `Reply-To` that induces one genuine reply attests an address
+  the owner never chose; and the gate is single-shot, one attested message being
+  sufficient evidence. An adversarial review found no path reachable by an
+  unaided outsider — each needs mailbox write access or an owner-side
+  misconfiguration plus a self-domain spoof that DMARC is designed to stop.
   **Upstream spec raise (not worked around here):** ADR-0072 §1's ladder reads
   T1 → "ensure person+org NOW", which taken literally would mint a "Gmail"
   organization for a free-mail address the owner has corresponded with — exactly
   the junk the ADR exists to prevent. The build keeps T3's free-mail org
-  suppression under a T1 spare (T1 overrides T2 only) and gates it with a test;
+  suppression under a T1 spare (T1 overrides T2 only), gated by an integration
+  subtest that writes to a `gmail.com` address and asserts a person but no
+  organization;
   the ladder wording needs reconciling upstream.
   **Still open (contract-first-gated on ADR-0072):** the rest of 2b — the pending
   ledger + deferred creation + the `capture_counterparty_verdict` job + review

--- a/backend/attestationproducer_test.go
+++ b/backend/attestationproducer_test.go
@@ -40,12 +40,9 @@ import (
 
 // The walk below matches the minting call by NAME, so a rename would leave it
 // finding nothing and passing forever, guarding an invariant that had moved.
-// These pin the two names to the real API: renaming either stops the compile
-// here, where the walk is, rather than silently retiring it.
-var (
-	_ = connector.Counterparty{}.WithOwnerAttestation
-	_ = connector.Counterparty{}.SentByOwner
-)
+// This pins the name AND the signature the walk assumes, so either changing
+// stops the compile here, where the walk is, rather than retiring it in silence.
+var _ func(bool) connector.Counterparty = connector.Counterparty{}.WithOwnerAttestation
 
 const (
 	// The sole sanctioned minter, relative to the backend module root.

--- a/backend/attestationproducer_test.go
+++ b/backend/attestationproducer_test.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package backendarch
+
+// Attestation-producer fitness function (ADR-0072 §1). The T1
+// correspondence-positive gate spares an address from transactional
+// suppression, and its whole safety rests on connector.Counterparty.SentByOwner
+// being unforgeable. That property is not enforced by the type — the field is a
+// plain bool on a struct any connector may build — it is enforced by there
+// being exactly ONE producer, capture/mailmap, which sets it only where the
+// provider's filing and the message's own authorship agree.
+//
+// Today that is true by accident of there being one mail mapper. The next
+// connector to populate a Counterparty from a provider payload — a webhook
+// body, a CRM export, a transcript import — could set the field straight from
+// attacker-shaped JSON and bypass both halves without touching a line of the
+// gate. So the obligation is derived from the tree rather than remembered: any
+// new assignment outside the mapper fails here, at the moment it is written.
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// The sole sanctioned producer, relative to the backend module root.
+const attestationProducer = "internal/modules/capture/mailmap"
+
+// guardFile is this file: it names the field in its own pattern and message.
+const guardFile = "attestationproducer_test.go"
+
+// An assignment to the field in a composite literal (`SentByOwner: x`) or by
+// selector (`… .SentByOwner = x`). Reads — the gate's own consumption — carry
+// neither form and are not matched.
+var attestationAssign = regexp.MustCompile(`SentByOwner\s*[:=][^=]`)
+
+func TestOnlyTheMailMapperProducesTheOutboundAttestation(t *testing.T) {
+	var offenders []string
+	err := filepath.WalkDir(".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if d.Name() == "testdata" || d.Name() == "build" {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		slashed := filepath.ToSlash(path)
+		if strings.HasPrefix(slashed, attestationProducer+"/") {
+			return nil
+		}
+		// The port declares the field and this file names it in the pattern
+		// above; neither declares a value for it.
+		if slashed == "internal/shared/ports/connector/connector.go" || slashed == guardFile {
+			return nil
+		}
+		body, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		if attestationAssign.Match(body) {
+			offenders = append(offenders, slashed)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking the backend tree: %v", err)
+	}
+	if len(offenders) > 0 {
+		t.Errorf("SentByOwner is assigned outside %s:\n  %s\n\n"+
+			"That field is the T1 correspondence gate's only evidence (ADR-0072 §1). It may be set\n"+
+			"ONLY where a provider's own filing of the message and the message's authorship agree —\n"+
+			"which is what the mail mapper does. Setting it anywhere else lets whatever produced that\n"+
+			"value whitelist an arbitrary address past transactional suppression.",
+			attestationProducer, strings.Join(offenders, "\n  "))
+	}
+}

--- a/backend/attestationproducer_test.go
+++ b/backend/attestationproducer_test.go
@@ -3,49 +3,66 @@
 
 package backendarch
 
-// Attestation-producer fitness function (ADR-0072 §1). The T1
+// Attestation-minting fitness function (ADR-0072 §1). The T1
 // correspondence-positive gate spares an address from transactional
-// suppression, and its whole safety rests on connector.Counterparty.SentByOwner
-// being unforgeable. That property is not enforced by the type — the field is a
-// plain bool on a struct any connector may build — it is enforced by there
-// being exactly ONE producer, capture/mailmap, which sets it only where the
-// provider's filing and the message's own authorship agree.
+// suppression, and its whole safety rests on connector.Counterparty's
+// outbound attestation being something a connector cannot state for itself.
 //
-// Today that is true by accident of there being one mail mapper. The next
-// connector to populate a Counterparty from a provider payload — a webhook
-// body, a CRM export, a transcript import — could set the field straight from
-// attacker-shaped JSON and bypass both halves without touching a line of the
-// gate. So the obligation is derived from the tree rather than remembered: any
-// new assignment outside the mapper fails here, at the moment it is written.
+// The field itself is unexported, so the compiler — not this test — refuses
+// every route that sets it directly: a keyed or positional literal, an
+// encoding/json unmarshal of a provider payload, reflection, a conversion from
+// a look-alike struct, a pointer handed to a row scanner. What the compiler
+// cannot refuse is the minting call, WithOwnerAttestation, which is exported
+// because the mapper lives in another package. This test keeps that call in one
+// place, so the set of code that can mint correspondence evidence stays a set of
+// one and is reviewed as such.
+//
+// The honest boundary: the argument to that call is trusted by construction,
+// not by this test. Today's mail connectors pass a bool derived from an
+// authenticated provider handle — Gmail's SENT label, an IMAP \Sent special-use
+// mailbox, Microsoft's SentItems folder. A future caller passing something
+// shaped like `payload.Folder == "SentItems"` from an unauthenticated webhook
+// body would satisfy both the compiler and this test while forging exactly what
+// the field exists to prevent. Reviewing that argument is a human obligation,
+// which is why this test exists to make the call sites few enough to review.
 
 import (
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"io/fs"
-	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/ports/connector"
 )
 
-// The sole sanctioned producer, relative to the backend module root.
-const attestationProducer = "internal/modules/capture/mailmap"
+// The walk below matches the minting call by NAME, so a rename would leave it
+// finding nothing and passing forever, guarding an invariant that had moved.
+// These pin the two names to the real API: renaming either stops the compile
+// here, where the walk is, rather than silently retiring it.
+var (
+	_ = connector.Counterparty{}.WithOwnerAttestation
+	_ = connector.Counterparty{}.SentByOwner
+)
 
-// guardFile is this file: it names the field in its own pattern and message.
-const guardFile = "attestationproducer_test.go"
+const (
+	// The sole sanctioned minter, relative to the backend module root.
+	attestationMinter = "internal/modules/capture/mailmap"
+	// The port's constructor — the one way into the unexported field.
+	attestationCall = "WithOwnerAttestation"
+)
 
-// An assignment to the field in a composite literal (`SentByOwner: x`) or by
-// selector (`… .SentByOwner = x`). Reads — the gate's own consumption — carry
-// neither form and are not matched.
-var attestationAssign = regexp.MustCompile(`SentByOwner\s*[:=][^=]`)
-
-func TestOnlyTheMailMapperProducesTheOutboundAttestation(t *testing.T) {
+func TestOnlyTheMailMapperMintsTheOutboundAttestation(t *testing.T) {
 	var offenders []string
 	err := filepath.WalkDir(".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 		if d.IsDir() {
-			if d.Name() == "testdata" || d.Name() == "build" {
+			// testdata is never compiled, so nothing in it can mint anything.
+			if d.Name() == "testdata" {
 				return fs.SkipDir
 			}
 			return nil
@@ -54,32 +71,39 @@ func TestOnlyTheMailMapperProducesTheOutboundAttestation(t *testing.T) {
 			return nil
 		}
 		slashed := filepath.ToSlash(path)
-		if strings.HasPrefix(slashed, attestationProducer+"/") {
+		if strings.HasPrefix(slashed, attestationMinter+"/") {
 			return nil
 		}
-		// The port declares the field and this file names it in the pattern
-		// above; neither declares a value for it.
-		if slashed == "internal/shared/ports/connector/connector.go" || slashed == guardFile {
-			return nil
+		// Parsed with mode 0 so build constraints are ignored: a file excluded
+		// on this platform still has to obey the rule.
+		fset := token.NewFileSet()
+		file, parseErr := parser.ParseFile(fset, path, nil, 0)
+		if parseErr != nil {
+			return parseErr
 		}
-		body, readErr := os.ReadFile(path)
-		if readErr != nil {
-			return readErr
-		}
-		if attestationAssign.Match(body) {
-			offenders = append(offenders, slashed)
-		}
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			if sel, isSel := call.Fun.(*ast.SelectorExpr); isSel && sel.Sel.Name == attestationCall {
+				offenders = append(offenders, fset.Position(sel.Pos()).String())
+			}
+			return true
+		})
 		return nil
 	})
 	if err != nil {
 		t.Fatalf("walking the backend tree: %v", err)
 	}
 	if len(offenders) > 0 {
-		t.Errorf("SentByOwner is assigned outside %s:\n  %s\n\n"+
-			"That field is the T1 correspondence gate's only evidence (ADR-0072 §1). It may be set\n"+
-			"ONLY where a provider's own filing of the message and the message's authorship agree —\n"+
-			"which is what the mail mapper does. Setting it anywhere else lets whatever produced that\n"+
-			"value whitelist an arbitrary address past transactional suppression.",
-			attestationProducer, strings.Join(offenders, "\n  "))
+		t.Errorf("%s is called outside %s:\n  %s\n\n"+
+			"That call mints the T1 correspondence gate's only evidence (ADR-0072 §1). It may be made\n"+
+			"ONLY where the message's authorship and a provider's own filing of it are both known —\n"+
+			"which is what the mail mapper does. Minting it anywhere else lets whatever supplied that\n"+
+			"argument whitelist an arbitrary address past transactional suppression.\n\n"+
+			"To produce an attested record, build it through capture/mailmap (Parse → AttestSentByOwner),\n"+
+			"passing your provider's own filing of the message — never a value derived from its content.",
+			attestationCall, attestationMinter, strings.Join(offenders, "\n  "))
 	}
 }

--- a/backend/internal/compose/connectors_wiring_test.go
+++ b/backend/internal/compose/connectors_wiring_test.go
@@ -12,6 +12,7 @@ import (
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/modules/capture"
+	"github.com/gradionhq/margince/backend/internal/modules/capture/gmail"
 	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
@@ -58,7 +59,11 @@ func (stubGmailAPI) ListRecent(context.Context, string, int) ([]string, error) {
 func (stubGmailAPI) History(context.Context, string, string) ([]string, string, error) {
 	return nil, "1", nil
 }
-func (stubGmailAPI) GetRaw(context.Context, string, string) ([]byte, error) { return nil, nil }
+
+func (stubGmailAPI) GetRaw(context.Context, string, string) (gmail.Message, error) {
+	return gmail.Message{}, nil
+}
+
 func (stubGmailAPI) Watch(context.Context, string, string) (string, time.Time, error) {
 	return "1", time.Time{}, nil
 }

--- a/backend/internal/compose/integration/capture_autocreate_integration_test.go
+++ b/backend/internal/compose/integration/capture_autocreate_integration_test.go
@@ -39,6 +39,7 @@ const autoCreateOwner = "owner@myco.example"
 // production mailmap → Sink path — the provider I/O faked, nothing else.
 type mailBatchConnector struct {
 	raws [][]byte
+	sent map[string]bool // Message-IDs the provider filed as the owner's own sent mail
 }
 
 func (m *mailBatchConnector) Descriptor() connector.Descriptor {
@@ -63,6 +64,11 @@ func (m *mailBatchConnector) Sync(ctx context.Context, _ connector.Auth, _ conne
 		if _, drop := msg.SkipReason(); drop {
 			continue
 		}
+		// The provider's own attestation, which a real Gmail sync reads off the
+		// message's SENT label. Keyed by Message-ID so a fixture can be the
+		// owner's outgoing mail without the test forging a From header — which
+		// is precisely what the attestation must not be derivable from.
+		msg = msg.AttestSentByOwner(m.sent[msg.ID()])
 		if _, err := sink.Upsert(ctx, msg.ToRecord("gmail", raw)); err != nil {
 			return nil, err
 		}
@@ -159,7 +165,16 @@ func TestAutoCreateFromCapturedMail(t *testing.T) {
 	wsCtx := principal.WithWorkspaceID(context.Background(), e.WS)
 	sync := func(t *testing.T, raws ...[]byte) {
 		t.Helper()
-		conn.raws = raws
+		conn.raws, conn.sent = raws, nil
+		if err := registry.SyncOnce(wsCtx, connID); err != nil {
+			t.Fatalf("SyncOnce: %v", err)
+		}
+	}
+	// syncSent is the same pull with the provider attesting the listed
+	// Message-IDs as mail the mailbox owner sent.
+	syncSent := func(t *testing.T, sent map[string]bool, raws ...[]byte) {
+		t.Helper()
+		conn.raws, conn.sent = raws, sent
 		if err := registry.SyncOnce(wsCtx, connID); err != nil {
 			t.Fatalf("SyncOnce: %v", err)
 		}
@@ -266,6 +281,52 @@ func TestAutoCreateFromCapturedMail(t *testing.T) {
 			SELECT count(*) FROM system_log
 			WHERE action = 'capture_transactional_suppressed' AND detail->>'source_id' IN ('ds1@docusign.net', 'gx1@event.gitex.com')`); n != 2 {
 			t.Fatalf("%d transactional-suppression breadcrumbs, want 2", n)
+		}
+	})
+
+	t.Run("writing to an address spares its later bulk mail from suppression", func(t *testing.T) {
+		// T1 runs BEFORE T2 and the order is load-bearing (ADR-0072 §1): once
+		// the workspace has written to someone, their newsletter footer must not
+		// turn them into infrastructure. The same address and the same
+		// List-Unsubscribe corroboration that suppressed above now survive,
+		// because the mailbox owner wrote to them first.
+		syncSent(t, map[string]bool{"ev1@myco.example": true},
+			email(autoCreateOwner, "", "team@event.expo.example", "ev1@myco.example", ""))
+		if n := countRows(t, e, `
+			SELECT count(*) FROM activity
+			WHERE counterparty_email = 'team@event.expo.example' AND counterparty_outbound_attested`); n != 1 {
+			t.Fatalf("%d attested outbound activities, want 1 — the T1 evidence must be stamped", n)
+		}
+
+		sync(t, emailWithListUnsub("team@event.expo.example", "Expo", autoCreateOwner, "ev2@event.expo.example"))
+		if n := countRows(t, e, `
+			SELECT count(*) FROM person p JOIN person_email pe ON pe.person_id = p.id
+			WHERE pe.email = 'team@event.expo.example'`); n != 1 {
+			t.Fatalf("%d persons for a corresponded-with sender, want 1 — T1 must spare it from T2", n)
+		}
+		if n := countRows(t, e, `
+			SELECT count(*) FROM system_log
+			WHERE action = 'capture_correspondence_spared' AND detail->>'source_id' = 'ev2@event.expo.example'`); n != 1 {
+			t.Fatalf("%d spare breadcrumbs, want 1 — an overridden suppression must be as visible as a suppression", n)
+		}
+	})
+
+	t.Run("a forged From:owner does not whitelist the address it names", func(t *testing.T) {
+		// The attack the T1 evidence exists to refuse: inbound mail whose From
+		// header claims the mailbox owner. It parses as outbound — that is all
+		// direction can mean — but the provider filed it in the inbox and
+		// attested nothing, so the address stays suppressed infrastructure.
+		sync(t, email(autoCreateOwner, "", "blast@sendgrid.net", "forge1@evil.example", ""))
+		if n := countRows(t, e, `
+			SELECT count(*) FROM activity
+			WHERE counterparty_email = 'blast@sendgrid.net' AND counterparty_outbound_attested`); n != 0 {
+			t.Fatal("a forged From:owner message attested correspondence — the gate reads the header, not the provider")
+		}
+		sync(t, emailWithListUnsub("blast@sendgrid.net", "Blast", autoCreateOwner, "forge2@sendgrid.net"))
+		if n := countRows(t, e, `
+			SELECT count(*) FROM person p JOIN person_email pe ON pe.person_id = p.id
+			WHERE pe.email = 'blast@sendgrid.net'`); n != 0 {
+			t.Fatal("a forged From:owner whitelisted an ESP address past T2 suppression")
 		}
 	})
 

--- a/backend/internal/compose/integration/capture_autocreate_integration_test.go
+++ b/backend/internal/compose/integration/capture_autocreate_integration_test.go
@@ -257,6 +257,23 @@ func TestAutoCreateFromCapturedMail(t *testing.T) {
 		}
 	})
 
+	t.Run("a corresponded-with free-mail address is still never a company", func(t *testing.T) {
+		// T1 overrides T2 suppression ONLY. Free-mail's org rule is about what a
+		// domain can honestly name, not about whether its sender is trusted, so
+		// writing to a gmail.com address buys its owner a person and never an
+		// organization called "Gmail" — the junk this ADR exists to prevent.
+		syncSent(t, map[string]bool{"fm1@myco.example": true},
+			email(autoCreateOwner, "", "carol@gmail.com", "fm1@myco.example", ""))
+		if n := countRows(t, e, `
+			SELECT count(*) FROM person p JOIN person_email pe ON pe.person_id = p.id
+			WHERE pe.email = 'carol@gmail.com'`); n != 1 {
+			t.Fatalf("%d persons for carol, want 1", n)
+		}
+		if n := countRows(t, e, `SELECT count(*) FROM organization WHERE display_name IN ('Gmail', 'gmail.com')`); n != 0 {
+			t.Fatal("a corresponded-with free-mail address minted an organization")
+		}
+	})
+
 	t.Run("transactional infrastructure keeps the activity, derives no counterparty", func(t *testing.T) {
 		// A DocuSign envelope (exact infra eSLD, no corroboration needed) and a
 		// conference blast on a prefix subdomain WITH a List-Unsubscribe header

--- a/backend/internal/modules/capture/fields.go
+++ b/backend/internal/modules/capture/fields.go
@@ -15,7 +15,7 @@ type ActivityFields struct {
 	Subject    string
 	Body       string
 	OccurredAt time.Time
-	Direction  string // inbound | outbound | "" (not directional)
+	Direction  string // connector.DirectionInbound | DirectionOutbound | "" (not directional)
 }
 
 // LeadFields is a captured prospect bound for the lead pool — never

--- a/backend/internal/modules/capture/gmail/backfill.go
+++ b/backend/internal/modules/capture/gmail/backfill.go
@@ -65,7 +65,7 @@ func (c *Connector) BackfillPage(ctx context.Context, auth connector.Auth, after
 	}
 	res := connector.BackfillPageResult{NextToken: next, Scanned: len(ids)}
 	for _, id := range ids {
-		raw, err := c.api.GetRaw(ctx, access, id)
+		msg, err := c.api.GetRaw(ctx, access, id)
 		if errors.Is(err, ErrMessageGone) {
 			// Deleted or moved since this page was listed — nothing to fetch.
 			// Count it scanned-but-skipped and move on; a routine 404 across a
@@ -78,7 +78,7 @@ func (c *Connector) BackfillPage(ctx context.Context, auth connector.Auth, after
 			// so the engine retries this page from its committed token.
 			return connector.BackfillPageResult{}, err
 		}
-		captured, err := captureOne(ctx, raw, sink, st.Owner)
+		captured, err := captureOne(ctx, msg, sink, st.Owner)
 		if err != nil {
 			return connector.BackfillPageResult{}, err
 		}

--- a/backend/internal/modules/capture/gmail/client.go
+++ b/backend/internal/modules/capture/gmail/client.go
@@ -111,7 +111,7 @@ type API interface {
 	// advanced historyId; ErrHistoryGone if the cursor is too old.
 	History(ctx context.Context, accessToken, startHistoryID string) (addedIDs []string, historyID string, err error)
 	// GetRaw fetches one message as its decoded RFC822 bytes (format=RAW)
-	// together with the label ids Gmail returns on the same response.
+	// together with Gmail's own SENT filing of it, read off the same response.
 	GetRaw(ctx context.Context, accessToken, msgID string) (Message, error)
 	// EstimateAfter returns the provider-side message count for a query
 	// (resultSizeEstimate) — the backfill preview's number.

--- a/backend/internal/modules/capture/gmail/client.go
+++ b/backend/internal/modules/capture/gmail/client.go
@@ -88,12 +88,15 @@ const sentLabelID = "SENT"
 
 // Message is one fetched Gmail message: the decoded RFC822 bytes plus the one
 // thing the bytes cannot honestly tell us — whether Gmail itself filed the
-// message as sent by the authenticated mailbox owner (ADR-0072 §1's T1
-// evidence). Both come off the same messages.get response, so the attestation
-// costs no extra call.
+// message under SENT (ADR-0072 §1's provider evidence). Both come off the same
+// messages.get response, so the signal costs no extra call.
 type Message struct {
-	RFC822      []byte
-	SentByOwner bool
+	RFC822 []byte
+	// FiledAsSent is the provider half of the T1 evidence and nothing more:
+	// Gmail labelled this message SENT. On its own it does not mean the owner
+	// wrote it — mailmap composes it with the message's authorship before any
+	// attestation is claimed.
+	FiledAsSent bool
 }
 
 // API is the read-only Gmail surface the connector uses. All calls take a
@@ -285,7 +288,7 @@ func (a *httpAPI) GetRaw(ctx context.Context, accessToken, msgID string) (Messag
 	if err != nil {
 		return Message{}, fmt.Errorf("gmail: decoding raw message %s: %w", msgID, ErrUnreachable)
 	}
-	return Message{RFC822: decoded, SentByOwner: hasSentLabel(out.LabelIDs)}, nil
+	return Message{RFC822: decoded, FiledAsSent: hasSentLabel(out.LabelIDs)}, nil
 }
 
 // hasSentLabel reports whether Gmail filed this message under SENT — the

--- a/backend/internal/modules/capture/gmail/client.go
+++ b/backend/internal/modules/capture/gmail/client.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -81,6 +82,20 @@ type OAuth interface {
 	AccessToken(ctx context.Context, refreshToken string) (accessToken string, err error)
 }
 
+// sentLabelID is Gmail's system label for the mailbox owner's own sent mail.
+// System label ids are stable strings, not localized names.
+const sentLabelID = "SENT"
+
+// Message is one fetched Gmail message: the decoded RFC822 bytes plus the one
+// thing the bytes cannot honestly tell us — whether Gmail itself filed the
+// message as sent by the authenticated mailbox owner (ADR-0072 §1's T1
+// evidence). Both come off the same messages.get response, so the attestation
+// costs no extra call.
+type Message struct {
+	RFC822      []byte
+	SentByOwner bool
+}
+
 // API is the read-only Gmail surface the connector uses. All calls take a
 // short-lived access token (minted from the refresh token per Sync).
 type API interface {
@@ -92,8 +107,9 @@ type API interface {
 	// History returns the message ids added since startHistoryID and the
 	// advanced historyId; ErrHistoryGone if the cursor is too old.
 	History(ctx context.Context, accessToken, startHistoryID string) (addedIDs []string, historyID string, err error)
-	// GetRaw fetches one message as its decoded RFC822 bytes (format=RAW).
-	GetRaw(ctx context.Context, accessToken, msgID string) (rfc822 []byte, err error)
+	// GetRaw fetches one message as its decoded RFC822 bytes (format=RAW)
+	// together with the label ids Gmail returns on the same response.
+	GetRaw(ctx context.Context, accessToken, msgID string) (Message, error)
 	// EstimateAfter returns the provider-side message count for a query
 	// (resultSizeEstimate) — the backfill preview's number.
 	EstimateAfter(ctx context.Context, accessToken, query string) (int, error)
@@ -247,9 +263,10 @@ func (a *httpAPI) History(ctx context.Context, accessToken, startHistoryID strin
 	return ids, latest, nil
 }
 
-func (a *httpAPI) GetRaw(ctx context.Context, accessToken, msgID string) ([]byte, error) {
+func (a *httpAPI) GetRaw(ctx context.Context, accessToken, msgID string) (Message, error) {
 	var out struct {
-		Raw string `json:"raw"`
+		Raw      string   `json:"raw"`
+		LabelIDs []string `json:"labelIds"` //nolint:tagliatelle // Google's wire format (camelCase); must match to decode
 	}
 	q := url.Values{"format": {"RAW"}}
 	status, err := a.get(ctx, accessToken, "/messages/"+url.PathEscape(msgID), q, &out, maxRawMessageBytes)
@@ -258,17 +275,26 @@ func (a *httpAPI) GetRaw(ctx context.Context, accessToken, msgID string) ([]byte
 		// let the pull continue rather than abort on a message that no longer
 		// exists (get maps every non-200 to ErrUnreachable; the 404 is not a
 		// reachability problem).
-		return nil, ErrMessageGone
+		return Message{}, ErrMessageGone
 	}
 	if err != nil {
-		return nil, err
+		return Message{}, err
 	}
 	// Gmail encodes the RFC822 as web-safe (URL) base64, padding-optional.
 	decoded, err := base64.RawURLEncoding.DecodeString(strings.TrimRight(out.Raw, "="))
 	if err != nil {
-		return nil, fmt.Errorf("gmail: decoding raw message %s: %w", msgID, ErrUnreachable)
+		return Message{}, fmt.Errorf("gmail: decoding raw message %s: %w", msgID, ErrUnreachable)
 	}
-	return decoded, nil
+	return Message{RFC822: decoded, SentByOwner: hasSentLabel(out.LabelIDs)}, nil
+}
+
+// hasSentLabel reports whether Gmail filed this message under SENT — the
+// provider's own attestation that the authenticated mailbox owner sent it.
+// Gmail sets the label on delivery to the sender's own mailbox; a message that
+// merely claims the owner in its From header never carries it, which is exactly
+// why the T1 correspondence gate (ADR-0072 §1) reads this and not the header.
+func hasSentLabel(labelIDs []string) bool {
+	return slices.Contains(labelIDs, sentLabelID)
 }
 
 // Watch registers a users.watch so Gmail publishes change notifications for

--- a/backend/internal/modules/capture/gmail/client_test.go
+++ b/backend/internal/modules/capture/gmail/client_test.go
@@ -221,14 +221,14 @@ func TestGetRawReadsTheSentLabelAsTheOwnersAttestation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetRaw: %v", err)
 	}
-	if inbound.SentByOwner {
+	if inbound.FiledAsSent {
 		t.Error("an INBOX message must not attest that the owner sent it")
 	}
 	outbound, err := api.GetRaw(context.Background(), "access-2", "m-sent")
 	if err != nil {
 		t.Fatalf("GetRaw on the sent copy: %v", err)
 	}
-	if !outbound.SentByOwner {
+	if !outbound.FiledAsSent {
 		t.Error("a SENT-labelled message must attest that the owner sent it")
 	}
 }

--- a/backend/internal/modules/capture/gmail/client_test.go
+++ b/backend/internal/modules/capture/gmail/client_test.go
@@ -56,7 +56,13 @@ func googleStub(t *testing.T) *httptest.Server {
 
 	mux.HandleFunc("/messages/m1", func(w http.ResponseWriter, _ *http.Request) {
 		raw := base64.RawURLEncoding.EncodeToString([]byte("Subject: hi\r\n\r\nbody"))
-		writeJSON(w, map[string]any{"id": "m1", "raw": raw})
+		writeJSON(w, map[string]any{"id": "m1", "raw": raw, "labelIds": []string{"INBOX", "UNREAD"}})
+	})
+
+	// The same mailbox's own outgoing copy: Gmail files it under SENT.
+	mux.HandleFunc("/messages/m-sent", func(w http.ResponseWriter, _ *http.Request) {
+		raw := base64.RawURLEncoding.EncodeToString([]byte("Subject: quote\r\n\r\nattached"))
+		writeJSON(w, map[string]any{"id": "m-sent", "raw": raw, "labelIds": []string{"SENT"}})
 	})
 
 	// A message whose RAW body is larger than the old 8 MiB read cap — a phone
@@ -176,10 +182,11 @@ func TestListRecentReturnsIDs(t *testing.T) {
 
 func TestGetRawDecodesBase64URL(t *testing.T) {
 	_, api := newTestClients(t)
-	raw, err := api.GetRaw(context.Background(), "access-2", "m1")
+	msg, err := api.GetRaw(context.Background(), "access-2", "m1")
 	if err != nil {
 		t.Fatalf("GetRaw: %v", err)
 	}
+	raw := msg.RFC822
 	if !strings.Contains(string(raw), "Subject: hi") {
 		t.Errorf("decoded RFC822 = %q, want it to contain the header", raw)
 	}
@@ -192,15 +199,37 @@ func TestGetRawDecodesBase64URL(t *testing.T) {
 // the entire pull as a spurious "unreachable".
 func TestGetRawDecodesAMessageLargerThanEightMiB(t *testing.T) {
 	_, api := newTestClients(t)
-	raw, err := api.GetRaw(context.Background(), "access-2", "big")
+	msg, err := api.GetRaw(context.Background(), "access-2", "big")
 	if err != nil {
 		t.Fatalf("GetRaw on a >8 MiB message: %v", err)
 	}
+	raw := msg.RFC822
 	if len(raw) < 9<<20 {
 		t.Fatalf("decoded %d bytes, want the full body (~9 MiB) — the response was truncated", len(raw))
 	}
 	if !bytes.HasPrefix(raw, []byte("Subject: big")) {
 		t.Fatalf("decoded body does not start with the header: %q", raw[:32])
+	}
+}
+
+// The Gmail half of the T1 correspondence evidence (ADR-0072 §1): SENT is a
+// label Gmail applies to the authenticated mailbox's own outgoing copy, so it
+// rides along on the same messages.get response the body already needs.
+func TestGetRawReadsTheSentLabelAsTheOwnersAttestation(t *testing.T) {
+	_, api := newTestClients(t)
+	inbound, err := api.GetRaw(context.Background(), "access-2", "m1")
+	if err != nil {
+		t.Fatalf("GetRaw: %v", err)
+	}
+	if inbound.SentByOwner {
+		t.Error("an INBOX message must not attest that the owner sent it")
+	}
+	outbound, err := api.GetRaw(context.Background(), "access-2", "m-sent")
+	if err != nil {
+		t.Fatalf("GetRaw on the sent copy: %v", err)
+	}
+	if !outbound.SentByOwner {
+		t.Error("a SENT-labelled message must attest that the owner sent it")
 	}
 }
 

--- a/backend/internal/modules/capture/gmail/gmail.go
+++ b/backend/internal/modules/capture/gmail/gmail.go
@@ -234,7 +234,7 @@ func captureOne(ctx context.Context, fetched Message, sink connector.Sink, owner
 	if _, drop := msg.SkipReason(); drop {
 		return false, nil
 	}
-	msg = msg.AttestSentByOwner(fetched.SentByOwner)
+	msg = msg.AttestSentByOwner(fetched.FiledAsSent)
 	if _, err := sink.Upsert(ctx, msg.ToRecord(connectorName, fetched.RFC822)); err != nil {
 		if errors.Is(err, connector.ErrSkip) {
 			return false, nil

--- a/backend/internal/modules/capture/gmail/gmail.go
+++ b/backend/internal/modules/capture/gmail/gmail.go
@@ -167,7 +167,7 @@ func (c *Connector) Sync(ctx context.Context, auth connector.Auth, cursor connec
 	}
 
 	for _, id := range ids {
-		raw, err := c.api.GetRaw(ctx, access, id)
+		msg, err := c.api.GetRaw(ctx, access, id)
 		if errors.Is(err, ErrMessageGone) {
 			// Deleted or moved since enumeration — nothing to capture. Skip it
 			// and keep going; one vanished id must not abort the batch and
@@ -179,7 +179,7 @@ func (c *Connector) Sync(ctx context.Context, auth connector.Auth, cursor connec
 			// cursor so the next cycle retries from the same watermark.
 			return nil, err
 		}
-		if _, err := captureOne(ctx, raw, sink, owner); err != nil {
+		if _, err := captureOne(ctx, msg, sink, owner); err != nil {
 			return nil, err
 		}
 	}
@@ -226,15 +226,16 @@ func (c *Connector) backfill(ctx context.Context, access string) ([]string, stri
 // the IMAP connector uses. A parse failure or a deliberate skip is a no-op;
 // only a real Sink write fault returns a non-nil error (which stops the pull).
 // It is a package function (no receiver) so a pull holds no shared state.
-func captureOne(ctx context.Context, raw []byte, sink connector.Sink, owner string) (captured bool, err error) {
-	msg, err := mailmap.Parse(raw, owner)
+func captureOne(ctx context.Context, fetched Message, sink connector.Sink, owner string) (captured bool, err error) {
+	msg, err := mailmap.Parse(fetched.RFC822, owner)
 	if err != nil {
 		return false, nil //nolint:nilerr // a single unparseable message is a skip, not a fatal pull error (mirrors the IMAP connector)
 	}
 	if _, drop := msg.SkipReason(); drop {
 		return false, nil
 	}
-	if _, err := sink.Upsert(ctx, msg.ToRecord(connectorName, raw)); err != nil {
+	msg = msg.AttestSentByOwner(fetched.SentByOwner)
+	if _, err := sink.Upsert(ctx, msg.ToRecord(connectorName, fetched.RFC822)); err != nil {
 		if errors.Is(err, connector.ErrSkip) {
 			return false, nil
 		}

--- a/backend/internal/modules/capture/gmail/gmail_test.go
+++ b/backend/internal/modules/capture/gmail/gmail_test.go
@@ -93,7 +93,7 @@ func (f *fakeAPI) GetRaw(_ context.Context, _, id string) (Message, error) {
 	if f.getErr != nil {
 		return Message{}, f.getErr
 	}
-	return Message{RFC822: f.raws[id], SentByOwner: f.sent[id]}, nil
+	return Message{RFC822: f.raws[id], FiledAsSent: f.sent[id]}, nil
 }
 
 type recordingSink struct{ recs []connector.NormalizedRecord }
@@ -364,5 +364,45 @@ func TestNormalizeSkipsAutomatedMail(t *testing.T) {
 	}
 	if len(recs) != 1 || recs[0].Source != "gmail:keep@acme.com" {
 		t.Fatalf("want 1 record gmail:keep@acme.com, got %+v", recs)
+	}
+}
+
+// The Gmail connector's end of the T1 evidence: the SENT label the API decoded
+// has to survive the parse and reach the record, and it only counts alongside
+// the owner's authorship. Covers the wiring the API-level label test cannot —
+// captureOne → AttestSentByOwner → ToRecord.
+func TestSyncCarriesTheSentLabelOntoTheRecord(t *testing.T) {
+	api := &fakeAPI{
+		email:     owner,
+		historyID: "12345",
+		recent:    []string{"in@mail.gmail.com", "forged@mail.gmail.com", "out@mail.gmail.com"},
+		raws: map[string][]byte{
+			"in@mail.gmail.com":     rawMsg("in@mail.gmail.com", "alice@acme.com"),
+			"forged@mail.gmail.com": rawMsg("forged@mail.gmail.com", owner),
+			"out@mail.gmail.com":    rawMsg("out@mail.gmail.com", owner),
+		},
+		// Only the last one is the mailbox's own outgoing copy; the forged one
+		// claims the owner in its From header but Gmail never labelled it SENT.
+		sent: map[string]bool{"out@mail.gmail.com": true},
+	}
+	sink := &recordingSink{}
+	if _, err := New(fakeOAuth{access: "access-1"}, api).Sync(context.Background(), authBytes(t), nil, sink); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if len(sink.recs) != 3 {
+		t.Fatalf("captured %d records, want 3", len(sink.recs))
+	}
+	attested := map[string]bool{}
+	for _, rec := range sink.recs {
+		attested[rec.NaturalKey.SourceID] = rec.Counterparty.SentByOwner
+	}
+	if attested["in@mail.gmail.com"] {
+		t.Error("an unlabelled stranger's message attested the owner's authorship")
+	}
+	if attested["forged@mail.gmail.com"] {
+		t.Error("a forged From:owner message attested without the SENT label")
+	}
+	if !attested["out@mail.gmail.com"] {
+		t.Error("a SENT-labelled message the owner wrote did not reach the record attested")
 	}
 }

--- a/backend/internal/modules/capture/gmail/gmail_test.go
+++ b/backend/internal/modules/capture/gmail/gmail_test.go
@@ -35,6 +35,7 @@ type fakeAPI struct {
 	addedHistoryID     string
 	historyErr, getErr error
 	raws               map[string][]byte
+	sent               map[string]bool // ids Gmail filed under the SENT label
 	gone               map[string]bool
 	historyCalls       int
 	listCalls          int
@@ -84,15 +85,15 @@ func (f *fakeAPI) Watch(_ context.Context, _, topic string) (string, time.Time, 
 	return f.watchHistoryID, f.watchExpiry, nil
 }
 
-func (f *fakeAPI) GetRaw(_ context.Context, _, id string) ([]byte, error) {
+func (f *fakeAPI) GetRaw(_ context.Context, _, id string) (Message, error) {
 	if f.gone[id] {
 		// The real client maps a 404 (deleted/moved since enumeration) here.
-		return nil, ErrMessageGone
+		return Message{}, ErrMessageGone
 	}
 	if f.getErr != nil {
-		return nil, f.getErr
+		return Message{}, f.getErr
 	}
-	return f.raws[id], nil
+	return Message{RFC822: f.raws[id], SentByOwner: f.sent[id]}, nil
 }
 
 type recordingSink struct{ recs []connector.NormalizedRecord }

--- a/backend/internal/modules/capture/gmail/gmail_test.go
+++ b/backend/internal/modules/capture/gmail/gmail_test.go
@@ -394,7 +394,7 @@ func TestSyncCarriesTheSentLabelOntoTheRecord(t *testing.T) {
 	}
 	attested := map[string]bool{}
 	for _, rec := range sink.recs {
-		attested[rec.NaturalKey.SourceID] = rec.Counterparty.SentByOwner
+		attested[rec.NaturalKey.SourceID] = rec.Counterparty.SentByOwner()
 	}
 	if attested["in@mail.gmail.com"] {
 		t.Error("an unlabelled stranger's message attested the owner's authorship")

--- a/backend/internal/modules/capture/graph/backfill.go
+++ b/backend/internal/modules/capture/graph/backfill.go
@@ -68,11 +68,13 @@ func (c *Connector) BackfillPage(ctx context.Context, auth connector.Auth, after
 	for _, msg := range msgs {
 		raw, err := c.api.GetMIME(ctx, access, msg.ID)
 		if errors.Is(err, connector.ErrSkip) {
-			// A deliberate per-message drop — an oversized MIME blob, which is
-			// not honest evidence truncated. Counted and stepped over, the same
-			// as the incremental pull does: returning it here would fail the
-			// page, and the engine would retry the page from its committed
-			// token straight back onto the same message, forever.
+			// A message the provider refuses to hand over: deleted between the
+			// listing and the fetch, or an oversized MIME blob that truncated
+			// would not be honest evidence. Both are per-message drops, counted
+			// and stepped over the same way the incremental pull does —
+			// returning either here would fail the page, and the engine would
+			// retry from its committed token straight back onto the same
+			// message, forever.
 			res.Skipped++
 			continue
 		}

--- a/backend/internal/modules/capture/graph/backfill.go
+++ b/backend/internal/modules/capture/graph/backfill.go
@@ -12,6 +12,7 @@ package graph
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -66,6 +67,15 @@ func (c *Connector) BackfillPage(ctx context.Context, auth connector.Auth, after
 	res := connector.BackfillPageResult{NextToken: next, Scanned: len(msgs)}
 	for _, msg := range msgs {
 		raw, err := c.api.GetMIME(ctx, access, msg.ID)
+		if errors.Is(err, connector.ErrSkip) {
+			// A deliberate per-message drop — an oversized MIME blob, which is
+			// not honest evidence truncated. Counted and stepped over, the same
+			// as the incremental pull does: returning it here would fail the
+			// page, and the engine would retry the page from its committed
+			// token straight back onto the same message, forever.
+			res.Skipped++
+			continue
+		}
 		if err != nil {
 			// A fetch fault is transient — stop the page without advancing
 			// so the engine retries this page from its committed token.

--- a/backend/internal/modules/capture/graph/backfill.go
+++ b/backend/internal/modules/capture/graph/backfill.go
@@ -71,7 +71,7 @@ func (c *Connector) BackfillPage(ctx context.Context, auth connector.Auth, after
 			// so the engine retries this page from its committed token.
 			return connector.BackfillPageResult{}, err
 		}
-		captured, err := captureOne(ctx, raw, sink, st.Owner, msg.ParentFolderID == sentFolder)
+		captured, err := captureOne(ctx, raw, sink, st.Owner, msg.ParentFolderID != "" && msg.ParentFolderID == sentFolder)
 		if err != nil {
 			return connector.BackfillPageResult{}, err
 		}

--- a/backend/internal/modules/capture/graph/backfill.go
+++ b/backend/internal/modules/capture/graph/backfill.go
@@ -48,19 +48,30 @@ func (c *Connector) BackfillPage(ctx context.Context, auth connector.Auth, after
 	if err != nil {
 		return connector.BackfillPageResult{}, err
 	}
-	ids, next, err := c.api.ListAfter(ctx, access, after, pageToken, backfillPageSize)
+	// The backfill walks the whole mailbox, Sent Items included — unlike the
+	// incremental delta, which is inbox-only — so this is where the T1
+	// correspondence evidence (ADR-0072 §1) is available to collect. Resolved
+	// BEFORE anything is captured: a page that cannot tell sent mail from
+	// received would stamp its whole window un-attested, and the natural key
+	// makes that permanent. Treated like any other provider fault — the page
+	// stops without advancing and the engine retries from its committed token.
+	sentFolder, err := c.api.SentFolderID(ctx, access)
 	if err != nil {
 		return connector.BackfillPageResult{}, err
 	}
-	res := connector.BackfillPageResult{NextToken: next, Scanned: len(ids)}
-	for _, id := range ids {
-		raw, err := c.api.GetMIME(ctx, access, id)
+	msgs, next, err := c.api.ListAfter(ctx, access, after, pageToken, backfillPageSize)
+	if err != nil {
+		return connector.BackfillPageResult{}, err
+	}
+	res := connector.BackfillPageResult{NextToken: next, Scanned: len(msgs)}
+	for _, msg := range msgs {
+		raw, err := c.api.GetMIME(ctx, access, msg.ID)
 		if err != nil {
 			// A fetch fault is transient — stop the page without advancing
 			// so the engine retries this page from its committed token.
 			return connector.BackfillPageResult{}, err
 		}
-		captured, err := captureOne(ctx, raw, sink, st.Owner)
+		captured, err := captureOne(ctx, raw, sink, st.Owner, msg.ParentFolderID == sentFolder)
 		if err != nil {
 			return connector.BackfillPageResult{}, err
 		}

--- a/backend/internal/modules/capture/graph/backfill.go
+++ b/backend/internal/modules/capture/graph/backfill.go
@@ -71,7 +71,7 @@ func (c *Connector) BackfillPage(ctx context.Context, auth connector.Auth, after
 			// so the engine retries this page from its committed token.
 			return connector.BackfillPageResult{}, err
 		}
-		captured, err := captureOne(ctx, raw, sink, st.Owner, msg.ParentFolderID != "" && msg.ParentFolderID == sentFolder)
+		captured, err := captureOne(ctx, raw, sink, st.Owner, msg.ParentFolderID == sentFolder)
 		if err != nil {
 			return connector.BackfillPageResult{}, err
 		}

--- a/backend/internal/modules/capture/graph/backfill_test.go
+++ b/backend/internal/modules/capture/graph/backfill_test.go
@@ -95,16 +95,20 @@ func TestBackfillMalformedAuthRejected(t *testing.T) {
 // The Graph half of the T1 correspondence evidence (ADR-0072 §1). Only the
 // backfill can supply it: the incremental delta reads the inbox folder alone,
 // while the backfill walks /me/messages across the whole mailbox, Sent Items
-// included. The attestation follows the folder Graph filed the message in —
-// never the From header, which the message's own author writes.
-func TestBackfillAttestsOnlyMailFiledInSentItems(t *testing.T) {
+// included. Attestation needs BOTH halves, so each fixture below withholds a
+// different one and only the third carries both.
+func TestBackfillAttestsOnlyMailFiledInSentItemsAndWrittenByTheOwner(t *testing.T) {
 	api := &fakeAPI{
-		listIDs: []string{"m-in", "m-out"},
+		listIDs: []string{"m-in", "m-forged", "m-out"},
 		sentIDs: map[string]bool{"m-out": true},
 		raws: map[string][]byte{
+			// Neither half: a stranger's mail, filed in the inbox.
 			"m-in": rawMsg("in@mail.example", "alice@acme.com"),
-			// The same shape a spoofer sends: the From header claims the owner,
-			// yet Graph filed it in the inbox because the owner never sent it.
+			// Authorship claimed, placement absent — what a spoofer sends: the
+			// From header names the owner, yet Graph filed it in the inbox
+			// because the owner never sent it.
+			"m-forged": rawMsg("forged@mail.example", owner),
+			// Both halves.
 			"m-out": rawMsg("out@mail.example", owner),
 		},
 	}
@@ -112,18 +116,21 @@ func TestBackfillAttestsOnlyMailFiledInSentItems(t *testing.T) {
 	if _, err := pinnedConn(api).BackfillPage(context.Background(), authBytes(t), time.Time{}, "", sink); err != nil {
 		t.Fatalf("BackfillPage: %v", err)
 	}
-	if len(sink.recs) != 2 {
-		t.Fatalf("sink received %d records, want 2", len(sink.recs))
+	if len(sink.recs) != 3 {
+		t.Fatalf("sink received %d records, want 3", len(sink.recs))
 	}
 	attested := map[string]bool{}
 	for _, rec := range sink.recs {
 		attested[rec.NaturalKey.SourceID] = rec.Counterparty.SentByOwner
 	}
 	if attested["in@mail.example"] {
-		t.Error("an inbox-filed message attested the owner's authorship")
+		t.Error("an inbox-filed stranger's message attested the owner's authorship")
+	}
+	if attested["forged@mail.example"] {
+		t.Error("a forged From:owner message attested on authorship alone — the folder must be load-bearing")
 	}
 	if !attested["out@mail.example"] {
-		t.Error("a Sent-Items-filed message did not attest the owner's authorship")
+		t.Error("a Sent-Items-filed message the owner wrote did not attest")
 	}
 }
 

--- a/backend/internal/modules/capture/graph/backfill_test.go
+++ b/backend/internal/modules/capture/graph/backfill_test.go
@@ -121,7 +121,7 @@ func TestBackfillAttestsOnlyMailFiledInSentItemsAndWrittenByTheOwner(t *testing.
 	}
 	attested := map[string]bool{}
 	for _, rec := range sink.recs {
-		attested[rec.NaturalKey.SourceID] = rec.Counterparty.SentByOwner
+		attested[rec.NaturalKey.SourceID] = rec.Counterparty.SentByOwner()
 	}
 	if attested["in@mail.example"] {
 		t.Error("an inbox-filed stranger's message attested the owner's authorship")

--- a/backend/internal/modules/capture/graph/backfill_test.go
+++ b/backend/internal/modules/capture/graph/backfill_test.go
@@ -173,3 +173,22 @@ func TestBackfillStopsWhenTheSentFolderIDComesBackEmpty(t *testing.T) {
 		t.Fatalf("SentFolderID on an id-less 2xx = %v, want ErrUnreachable — an empty id must never reach the comparison", err)
 	}
 }
+
+// The mirror of the empty-folder-id case, and it must fail the same way. A
+// listed message naming no parent folder cannot be captured on a guess in
+// either direction: attested, an empty id would match an unresolved folder;
+// un-attested, the activity natural key would permanently discard evidence the
+// owner really did produce. The page stops instead.
+func TestListAfterRefusesAMessageWithNoParentFolder(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		//craft:ignore swallowed-errors test stub write; a short write surfaces as the client-side assertion failure
+		_, _ = w.Write([]byte(`{"value":[{"id":"m-truncated"}]}`))
+	}))
+	defer srv.Close()
+
+	_, _, err := NewAPI(srv.Client(), srv.URL).ListAfter(context.Background(), "access-2", time.Time{}, "", 100)
+	if !errors.Is(err, ErrUnreachable) {
+		t.Fatalf("ListAfter on a folder-less message = %v, want ErrUnreachable", err)
+	}
+}

--- a/backend/internal/modules/capture/graph/backfill_test.go
+++ b/backend/internal/modules/capture/graph/backfill_test.go
@@ -6,8 +6,6 @@ package graph
 import (
 	"context"
 	"errors"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -153,42 +151,5 @@ func TestBackfillStopsWhenTheSentFolderCannotBeResolved(t *testing.T) {
 	}
 	if len(sink.recs) != 0 {
 		t.Fatalf("%d records captured, want none — nothing may land with guessed provenance", len(sink.recs))
-	}
-}
-
-// A 2xx that names no folder is not an answer. Left as "", it would compare
-// equal to the empty parentFolderId of any message the same degraded response
-// returned, so the ABSENCE of the evidence would read as the evidence and
-// attest the whole page — and the activity natural key would make it permanent.
-func TestBackfillStopsWhenTheSentFolderIDComesBackEmpty(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		//craft:ignore swallowed-errors test stub write; a short write surfaces as the client-side assertion failure
-		_, _ = w.Write([]byte(`{}`))
-	}))
-	defer srv.Close()
-
-	_, err := NewAPI(srv.Client(), srv.URL).SentFolderID(context.Background(), "access-2")
-	if !errors.Is(err, ErrUnreachable) {
-		t.Fatalf("SentFolderID on an id-less 2xx = %v, want ErrUnreachable — an empty id must never reach the comparison", err)
-	}
-}
-
-// The mirror of the empty-folder-id case, and it must fail the same way. A
-// listed message naming no parent folder cannot be captured on a guess in
-// either direction: attested, an empty id would match an unresolved folder;
-// un-attested, the activity natural key would permanently discard evidence the
-// owner really did produce. The page stops instead.
-func TestListAfterRefusesAMessageWithNoParentFolder(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		//craft:ignore swallowed-errors test stub write; a short write surfaces as the client-side assertion failure
-		_, _ = w.Write([]byte(`{"value":[{"id":"m-truncated"}]}`))
-	}))
-	defer srv.Close()
-
-	_, _, err := NewAPI(srv.Client(), srv.URL).ListAfter(context.Background(), "access-2", time.Time{}, "", 100)
-	if !errors.Is(err, ErrUnreachable) {
-		t.Fatalf("ListAfter on a folder-less message = %v, want ErrUnreachable", err)
 	}
 }

--- a/backend/internal/modules/capture/graph/backfill_test.go
+++ b/backend/internal/modules/capture/graph/backfill_test.go
@@ -91,3 +91,58 @@ func TestBackfillMalformedAuthRejected(t *testing.T) {
 		t.Fatal("BackfillPage with malformed auth must fail")
 	}
 }
+
+// The Graph half of the T1 correspondence evidence (ADR-0072 §1). Only the
+// backfill can supply it: the incremental delta reads the inbox folder alone,
+// while the backfill walks /me/messages across the whole mailbox, Sent Items
+// included. The attestation follows the folder Graph filed the message in —
+// never the From header, which the message's own author writes.
+func TestBackfillAttestsOnlyMailFiledInSentItems(t *testing.T) {
+	api := &fakeAPI{
+		listIDs: []string{"m-in", "m-out"},
+		sentIDs: map[string]bool{"m-out": true},
+		raws: map[string][]byte{
+			"m-in": rawMsg("in@mail.example", "alice@acme.com"),
+			// The same shape a spoofer sends: the From header claims the owner,
+			// yet Graph filed it in the inbox because the owner never sent it.
+			"m-out": rawMsg("out@mail.example", owner),
+		},
+	}
+	sink := &recordingSink{}
+	if _, err := pinnedConn(api).BackfillPage(context.Background(), authBytes(t), time.Time{}, "", sink); err != nil {
+		t.Fatalf("BackfillPage: %v", err)
+	}
+	if len(sink.recs) != 2 {
+		t.Fatalf("sink received %d records, want 2", len(sink.recs))
+	}
+	attested := map[string]bool{}
+	for _, rec := range sink.recs {
+		attested[rec.NaturalKey.SourceID] = rec.Counterparty.SentByOwner
+	}
+	if attested["in@mail.example"] {
+		t.Error("an inbox-filed message attested the owner's authorship")
+	}
+	if !attested["out@mail.example"] {
+		t.Error("a Sent-Items-filed message did not attest the owner's authorship")
+	}
+}
+
+// A page that cannot tell sent mail from received must capture nothing rather
+// than stamp its whole window un-attested: the activity natural key would make
+// that guess permanent, silently costing the mailbox its T1 evidence. The
+// engine retries the page from its committed token, as with any provider fault.
+func TestBackfillStopsWhenTheSentFolderCannotBeResolved(t *testing.T) {
+	api := &fakeAPI{
+		listIDs:       []string{"m-out"},
+		sentIDs:       map[string]bool{"m-out": true},
+		sentFolderErr: ErrUnreachable,
+		raws:          map[string][]byte{"m-out": rawMsg("out@mail.example", owner)},
+	}
+	sink := &recordingSink{}
+	if _, err := pinnedConn(api).BackfillPage(context.Background(), authBytes(t), time.Time{}, "", sink); !errors.Is(err, ErrUnreachable) {
+		t.Fatalf("BackfillPage = %v, want the page to stop on the unresolved folder", err)
+	}
+	if len(sink.recs) != 0 {
+		t.Fatalf("%d records captured, want none — nothing may land with guessed provenance", len(sink.recs))
+	}
+}

--- a/backend/internal/modules/capture/graph/backfill_test.go
+++ b/backend/internal/modules/capture/graph/backfill_test.go
@@ -153,3 +153,26 @@ func TestBackfillStopsWhenTheSentFolderCannotBeResolved(t *testing.T) {
 		t.Fatalf("%d records captured, want none — nothing may land with guessed provenance", len(sink.recs))
 	}
 }
+
+// An oversized message is a deliberate per-message drop, and the backfill must
+// step over it exactly as the incremental pull does. Failing the page instead
+// would send the engine back to the same committed token, onto the same
+// message, forever — one unreadable mail would wedge the whole backfill.
+func TestBackfillSkipsAnUnreadableMessageAndKeepsGoing(t *testing.T) {
+	api := &fakeAPI{
+		listIDs: []string{"m-huge", "m-ok"},
+		raws:    map[string][]byte{"m-ok": rawMsg("ok@mail.example", "alice@acme.com")},
+		skipIDs: map[string]bool{"m-huge": true},
+	}
+	sink := &recordingSink{}
+	res, err := pinnedConn(api).BackfillPage(context.Background(), authBytes(t), time.Time{}, "", sink)
+	if err != nil {
+		t.Fatalf("BackfillPage must not fail on a skippable message: %v", err)
+	}
+	if res.Captured != 1 || res.Skipped != 1 || res.Scanned != 2 {
+		t.Fatalf("tally = %+v, want scanned=2 captured=1 skipped=1", res)
+	}
+	if len(sink.recs) != 1 {
+		t.Fatalf("sink received %d records, want the readable one", len(sink.recs))
+	}
+}

--- a/backend/internal/modules/capture/graph/backfill_test.go
+++ b/backend/internal/modules/capture/graph/backfill_test.go
@@ -6,6 +6,8 @@ package graph
 import (
 	"context"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -151,5 +153,23 @@ func TestBackfillStopsWhenTheSentFolderCannotBeResolved(t *testing.T) {
 	}
 	if len(sink.recs) != 0 {
 		t.Fatalf("%d records captured, want none — nothing may land with guessed provenance", len(sink.recs))
+	}
+}
+
+// A 2xx that names no folder is not an answer. Left as "", it would compare
+// equal to the empty parentFolderId of any message the same degraded response
+// returned, so the ABSENCE of the evidence would read as the evidence and
+// attest the whole page — and the activity natural key would make it permanent.
+func TestBackfillStopsWhenTheSentFolderIDComesBackEmpty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		//craft:ignore swallowed-errors test stub write; a short write surfaces as the client-side assertion failure
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	_, err := NewAPI(srv.Client(), srv.URL).SentFolderID(context.Background(), "access-2")
+	if !errors.Is(err, ErrUnreachable) {
+		t.Fatalf("SentFolderID on an id-less 2xx = %v, want ErrUnreachable — an empty id must never reach the comparison", err)
 	}
 }

--- a/backend/internal/modules/capture/graph/client.go
+++ b/backend/internal/modules/capture/graph/client.go
@@ -383,118 +383,12 @@ func (a *httpAPI) SentFolderID(ctx context.Context, accessToken string) (string,
 	if _, err := a.get(ctx, accessToken, a.base+"/me/mailFolders/sentitems?"+q.Encode(), nil, &out); err != nil {
 		return "", err
 	}
+	if out.ID == "" {
+		// A 2xx that names no folder is not an answer. Returning "" would make
+		// the caller's `parentFolderId == sentFolder` compare two empty strings
+		// and read the ABSENCE of the signal as the signal, attesting a whole
+		// page — the one direction this evidence must never fail.
+		return "", fmt.Errorf("graph: the mailbox reported no sent-items folder id: %w", ErrUnreachable)
+	}
 	return out.ID, nil
-}
-
-// retryAfter parses the provider's Retry-After (delta-seconds form; Graph's
-// throttling responses use it). Zero when absent — the caller's own backoff
-// takes over.
-func retryAfter(resp *http.Response) time.Duration {
-	if s := resp.Header.Get("Retry-After"); s != "" {
-		if secs, err := strconv.Atoi(s); err == nil && secs > 0 {
-			return time.Duration(secs) * time.Second
-		}
-	}
-	return 0
-}
-
-// messageOp names the raw-MIME fetch in a ProviderError. Its sibling calls carry
-// their URL path as the op; this one is a hand-built request whose URL embeds the
-// message id, so it names the endpoint rather than the instance.
-const messageOp = "message"
-
-// requestOp names a Graph call in a ProviderError the way the other connectors
-// do — as a path relative to the API base. The query string is cut because it
-// carries per-request filters and cursors, and the base is trimmed because an
-// error string wants the endpoint that failed, not the scheme and host it lives
-// on (which are fixed for the deployment and, under test, an ephemeral port).
-func (a *httpAPI) requestOp(fullURL string) string {
-	op, _, _ := strings.Cut(fullURL, "?")
-	trimmed := strings.TrimPrefix(op, a.base)
-	if trimmed == "" {
-		// The base itself, with nothing after it: name the root rather than
-		// render an empty op behind a leading colon.
-		return "/"
-	}
-	return trimmed
-}
-
-// graphErrorBody is the subset of Microsoft's OData error envelope that names
-// the failure. code is the fixed machine code (InvalidAuthenticationToken,
-// accessDenied, …); the prose message beside it is deliberately not read.
-type graphErrorBody struct {
-	Error struct {
-		Code string `json:"code"`
-	} `json:"error"`
-}
-
-// graphReason extracts Microsoft's machine error code from a response body, ""
-// when the body carries none or does not decode — an unparsable body must not
-// masquerade as a named reason.
-func graphReason(body []byte) string {
-	var parsed graphErrorBody
-	if err := json.Unmarshal(body, &parsed); err != nil {
-		return ""
-	}
-	return connector.MachineReason(parsed.Error.Code)
-}
-
-// classifyStatus maps a non-2xx Graph response onto the shared connector
-// vocabulary: 429 honors Retry-After, 401/403 parks the credential, anything
-// else backs off. The classification is unchanged by op/body — those only carry
-// Microsoft's own machine code into the error so a log line says WHICH call
-// failed and WHY Microsoft refused it. The raw body is never surfaced to the
-// caller.
-func classifyStatus(resp *http.Response, op string, body []byte) error {
-	switch {
-	case resp.StatusCode == http.StatusTooManyRequests:
-		return &connector.RateLimitedError{RetryAfter: retryAfter(resp)}
-	case resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden:
-		return &connector.ProviderError{
-			Op: op, Status: resp.StatusCode, Reason: graphReason(body), Class: ErrAuthRejected,
-		}
-	case resp.StatusCode < 200 || resp.StatusCode > 299:
-		return &connector.ProviderError{
-			Op: op, Status: resp.StatusCode, Reason: graphReason(body), Class: ErrUnreachable,
-		}
-	}
-	return nil
-}
-
-// get performs an authorized GET on a full URL (extra headers optional) and
-// JSON-decodes into out. It returns the HTTP status (so deltaWalk can
-// special-case 410) alongside the classified error.
-//
-//craft:ignore naked-any out is the caller-supplied JSON decode target — its concrete type varies per endpoint
-func (a *httpAPI) get(ctx context.Context, accessToken, fullURL string, hdr http.Header, out any) (int, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fullURL, nil)
-	if err != nil {
-		return 0, fmt.Errorf("graph: building request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+accessToken)
-	for k, vs := range hdr {
-		for _, v := range vs {
-			req.Header.Add(k, v)
-		}
-	}
-	resp, err := a.client.Do(req)
-	if err != nil {
-		return 0, fmt.Errorf("graph: request: %w", ErrUnreachable)
-	}
-	//craft:ignore swallowed-errors best-effort close of the response body — the decoded result/status is what matters
-	defer func() { _ = resp.Body.Close() }()
-	body, readErr := io.ReadAll(io.LimitReader(resp.Body, 8<<20))
-	// Classify on status/headers first: a 429/401 must be honored even if the
-	// body read failed. Only on an otherwise-OK response does a read failure
-	// matter — a truncated-but-valid-JSON prefix must never pass as complete.
-	if err := classifyStatus(resp, a.requestOp(fullURL), body); err != nil {
-		return resp.StatusCode, err
-	}
-	if readErr != nil {
-		return resp.StatusCode, fmt.Errorf("graph: reading response: %w", ErrUnreachable)
-	}
-	if err := json.Unmarshal(body, out); err != nil {
-		return resp.StatusCode, fmt.Errorf("graph: decoding response: %w", ErrUnreachable)
-	}
-	return resp.StatusCode, nil
 }

--- a/backend/internal/modules/capture/graph/client.go
+++ b/backend/internal/modules/capture/graph/client.go
@@ -371,10 +371,10 @@ func (a *httpAPI) ListAfter(ctx context.Context, accessToken string, after time.
 }
 
 // SentFolderID resolves the mailbox's Sent Items folder by its well-known
-// name, which Graph accepts in place of the opaque id. The listed messages
-// carry the opaque form, so the comparison needs this resolved once per page
-// walk rather than a name match (folder display names are localized and
-// user-renameable; the well-known id is neither).
+// name, which Graph accepts in place of the opaque id the listed messages
+// carry. Resolved once per page (the connector holds no per-connection state)
+// rather than matched by name: display names are localized and renameable, the
+// well-known id is neither.
 func (a *httpAPI) SentFolderID(ctx context.Context, accessToken string) (string, error) {
 	var out struct {
 		ID string `json:"id"`

--- a/backend/internal/modules/capture/graph/client.go
+++ b/backend/internal/modules/capture/graph/client.go
@@ -365,6 +365,15 @@ func (a *httpAPI) ListAfter(ctx context.Context, accessToken string, after time.
 	}
 	msgs := make([]MessageRef, 0, len(out.Value))
 	for _, m := range out.Value {
+		if m.ParentFolderID == "" {
+			// Every Graph message lives in a folder, so a listed one naming none
+			// is a truncated answer, not a message outside the hierarchy. It
+			// cannot be captured on a guess in EITHER direction: attested, an
+			// empty id would match an unresolved folder; un-attested, the
+			// activity natural key would permanently discard evidence the owner
+			// really did produce. Refusing the page keeps both off the table.
+			return nil, "", fmt.Errorf("graph: message %s listed without a parent folder: %w", m.ID, ErrUnreachable)
+		}
 		msgs = append(msgs, MessageRef{ID: m.ID, ParentFolderID: m.ParentFolderID})
 	}
 	return msgs, out.NextLink, nil

--- a/backend/internal/modules/capture/graph/client.go
+++ b/backend/internal/modules/capture/graph/client.go
@@ -116,6 +116,10 @@ type API interface {
 // The folder is the T1 correspondence evidence (ADR-0072 §1) — Microsoft moves
 // a message into Sent Items because the authenticated account sent it, which no
 // amount of header forgery can imitate.
+//
+// ParentFolderID is never empty: ListAfter refuses a listed message that names
+// no folder, so a caller comparing it against SentFolderID can never be
+// comparing two absent values.
 type MessageRef struct {
 	ID             string
 	ParentFolderID string

--- a/backend/internal/modules/capture/graph/client.go
+++ b/backend/internal/modules/capture/graph/client.go
@@ -102,10 +102,23 @@ type API interface {
 	// EstimateAfter returns the provider-side count of messages received on
 	// or after the given instant ($count=true) — the backfill preview's number.
 	EstimateAfter(ctx context.Context, accessToken string, after time.Time) (int, error)
-	// ListAfter returns one page of message ids received on or after the
-	// given instant; pageToken is the @odata.nextLink of the prior page
-	// ("" starts the walk).
-	ListAfter(ctx context.Context, accessToken string, after time.Time, pageToken string, pageSize int) (ids []string, next string, err error)
+	// ListAfter returns one page of messages received on or after the given
+	// instant; pageToken is the @odata.nextLink of the prior page ("" starts
+	// the walk).
+	ListAfter(ctx context.Context, accessToken string, after time.Time, pageToken string, pageSize int) (msgs []MessageRef, next string, err error)
+	// SentFolderID returns the id of the mailbox's Sent Items well-known
+	// folder, against which a message's ParentFolderID identifies mail the
+	// authenticated owner sent.
+	SentFolderID(ctx context.Context, accessToken string) (string, error)
+}
+
+// MessageRef is one listed message: its id, plus the folder Graph filed it in.
+// The folder is the T1 correspondence evidence (ADR-0072 §1) — Microsoft moves
+// a message into Sent Items because the authenticated account sent it, which no
+// amount of header forgery can imitate.
+type MessageRef struct {
+	ID             string
+	ParentFolderID string
 }
 
 // OAuthConfig wires the OAuth client. Tenant defaults to "common";
@@ -328,12 +341,12 @@ func (a *httpAPI) EstimateAfter(ctx context.Context, accessToken string, after t
 	return out.Count, nil
 }
 
-func (a *httpAPI) ListAfter(ctx context.Context, accessToken string, after time.Time, pageToken string, pageSize int) ([]string, string, error) {
+func (a *httpAPI) ListAfter(ctx context.Context, accessToken string, after time.Time, pageToken string, pageSize int) ([]MessageRef, string, error) {
 	u := pageToken
 	if u == "" {
 		q := url.Values{
 			paramFilter: {receivedAfterFilter(after)},
-			"$select":   {"id"},
+			"$select":   {"id,parentFolderId"},
 			"$top":      {strconv.Itoa(pageSize)},
 		}
 		u = a.base + "/me/messages?" + q.Encode()
@@ -342,18 +355,35 @@ func (a *httpAPI) ListAfter(ctx context.Context, accessToken string, after time.
 	}
 	var out struct {
 		Value []struct {
-			ID string `json:"id"`
+			ID             string `json:"id"`
+			ParentFolderID string `json:"parentFolderId"` //nolint:tagliatelle // Microsoft's wire format; must match to decode
 		} `json:"value"`
 		NextLink string `json:"@odata.nextLink"` //nolint:tagliatelle // Microsoft's wire format; must match to decode
 	}
 	if _, err := a.get(ctx, accessToken, u, nil, &out); err != nil {
 		return nil, "", err
 	}
-	ids := make([]string, 0, len(out.Value))
+	msgs := make([]MessageRef, 0, len(out.Value))
 	for _, m := range out.Value {
-		ids = append(ids, m.ID)
+		msgs = append(msgs, MessageRef{ID: m.ID, ParentFolderID: m.ParentFolderID})
 	}
-	return ids, out.NextLink, nil
+	return msgs, out.NextLink, nil
+}
+
+// SentFolderID resolves the mailbox's Sent Items folder by its well-known
+// name, which Graph accepts in place of the opaque id. The listed messages
+// carry the opaque form, so the comparison needs this resolved once per page
+// walk rather than a name match (folder display names are localized and
+// user-renameable; the well-known id is neither).
+func (a *httpAPI) SentFolderID(ctx context.Context, accessToken string) (string, error) {
+	var out struct {
+		ID string `json:"id"`
+	}
+	q := url.Values{"$select": {"id"}}
+	if _, err := a.get(ctx, accessToken, a.base+"/me/mailFolders/sentitems?"+q.Encode(), nil, &out); err != nil {
+		return "", err
+	}
+	return out.ID, nil
 }
 
 // retryAfter parses the provider's Retry-After (delta-seconds form; Graph's

--- a/backend/internal/modules/capture/graph/client_test.go
+++ b/backend/internal/modules/capture/graph/client_test.go
@@ -450,3 +450,38 @@ func TestRequestOpReducesAURLToItsPath(t *testing.T) {
 		})
 	}
 }
+
+// A 2xx that names no folder is not an answer. Left as "", it would compare
+// equal to the empty parentFolderId of any message the same degraded response
+// returned, so the ABSENCE of the evidence would read as the evidence and
+// attest a whole page — and the activity natural key would make it permanent.
+func TestSentFolderIDRefusesA2xxThatNamesNoFolder(t *testing.T) {
+	srv := jsonStub(t, map[string]any{})
+	_, err := NewAPI(srv.Client(), srv.URL).SentFolderID(context.Background(), "access-2")
+	if !errors.Is(err, ErrUnreachable) {
+		t.Fatalf("SentFolderID on an id-less 2xx = %v, want ErrUnreachable — an empty id must never reach the comparison", err)
+	}
+}
+
+// The mirror case, and it must fail the same way. A listed message naming no
+// parent folder cannot be captured on a guess in either direction: attested, an
+// empty id would match an unresolved folder; un-attested, the activity natural
+// key would permanently discard evidence the owner really did produce.
+func TestListAfterRefusesAMessageWithNoParentFolder(t *testing.T) {
+	srv := jsonStub(t, map[string]any{"value": []map[string]any{{"id": "m-truncated"}}})
+	_, _, err := NewAPI(srv.Client(), srv.URL).ListAfter(context.Background(), "access-2", time.Time{}, "", 100)
+	if !errors.Is(err, ErrUnreachable) {
+		t.Fatalf("ListAfter on a folder-less message = %v, want ErrUnreachable", err)
+	}
+}
+
+// jsonStub serves one canned JSON body on every path — enough for the
+// degraded-response cases, which are about what the client REFUSES to decode.
+func jsonStub(t *testing.T, body map[string]any) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, body)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}

--- a/backend/internal/modules/capture/graph/client_test.go
+++ b/backend/internal/modules/capture/graph/client_test.go
@@ -89,13 +89,17 @@ func msStub(t *testing.T) *httptest.Server {
 			return
 		}
 		if r.URL.Query().Get("$skiptoken") == "p2" {
-			writeJSON(w, map[string]any{"value": []map[string]any{{"id": "m2"}}})
+			writeJSON(w, map[string]any{"value": []map[string]any{{"id": "m2", "parentFolderId": "sent-folder"}}})
 			return
 		}
 		writeJSON(w, map[string]any{
-			"value":           []map[string]any{{"id": "m1"}},
+			"value":           []map[string]any{{"id": "m1", "parentFolderId": "inbox-folder"}},
 			"@odata.nextLink": srv.URL + "/me/messages?%24skiptoken=p2",
 		})
+	})
+
+	mux.HandleFunc("/me/mailFolders/sentitems", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, map[string]any{"id": "sent-folder"})
 	})
 
 	mux.HandleFunc("/me/messages/m1/$value", func(w http.ResponseWriter, _ *http.Request) {
@@ -317,21 +321,57 @@ func TestEstimateAfterReadsODataCount(t *testing.T) {
 	}
 }
 
-func TestListAfterPagesViaNextLink(t *testing.T) {
+// messageIDs projects a listed page down to its ids so a page assertion reads
+// as the id sequence it is about.
+func messageIDs(msgs []MessageRef) []string {
+	out := make([]string, 0, len(msgs))
+	for _, m := range msgs {
+		out = append(out, m.ID)
+	}
+	return out
+}
+
+// The backfill's T1 evidence: Graph names the folder it filed each message in,
+// and SentFolderID resolves the well-known Sent Items id the comparison needs.
+// Without the pairing the backfill cannot tell the owner's own mail from an
+// inbound message whose From header merely claims to be theirs.
+func TestListAfterCarriesTheParentFolderAgainstSentItems(t *testing.T) {
 	_, api := newTestClients(t)
-	ids, next, err := api.ListAfter(context.Background(), "access-2", time.Date(2026, 1, 18, 0, 0, 0, 0, time.UTC), "", 100)
+	sent, err := api.SentFolderID(context.Background(), "access-2")
+	if err != nil {
+		t.Fatalf("SentFolderID: %v", err)
+	}
+	inbox, next, err := api.ListAfter(context.Background(), "access-2", time.Time{}, "", 100)
 	if err != nil {
 		t.Fatalf("ListAfter: %v", err)
 	}
-	if strings.Join(ids, ",") != "m1" || next == "" {
-		t.Fatalf("first page = %v next=%q, want [m1] and a nextLink", ids, next)
+	if len(inbox) != 1 || inbox[0].ParentFolderID == sent {
+		t.Fatalf("first page = %v, want one message filed outside %q", inbox, sent)
 	}
-	ids2, next2, err := api.ListAfter(context.Background(), "access-2", time.Time{}, next, 100)
+	outbox, _, err := api.ListAfter(context.Background(), "access-2", time.Time{}, next, 100)
 	if err != nil {
 		t.Fatalf("ListAfter page 2: %v", err)
 	}
-	if strings.Join(ids2, ",") != "m2" || next2 != "" {
-		t.Errorf("second page = %v next=%q, want [m2] and the end of the walk", ids2, next2)
+	if len(outbox) != 1 || outbox[0].ParentFolderID != sent {
+		t.Fatalf("second page = %v, want one message filed in %q", outbox, sent)
+	}
+}
+
+func TestListAfterPagesViaNextLink(t *testing.T) {
+	_, api := newTestClients(t)
+	msgs, next, err := api.ListAfter(context.Background(), "access-2", time.Date(2026, 1, 18, 0, 0, 0, 0, time.UTC), "", 100)
+	if err != nil {
+		t.Fatalf("ListAfter: %v", err)
+	}
+	if strings.Join(messageIDs(msgs), ",") != "m1" || next == "" {
+		t.Fatalf("first page = %v next=%q, want [m1] and a nextLink", msgs, next)
+	}
+	msgs2, next2, err := api.ListAfter(context.Background(), "access-2", time.Time{}, next, 100)
+	if err != nil {
+		t.Fatalf("ListAfter page 2: %v", err)
+	}
+	if strings.Join(messageIDs(msgs2), ",") != "m2" || next2 != "" {
+		t.Errorf("second page = %v next=%q, want [m2] and the end of the walk", msgs2, next2)
 	}
 }
 

--- a/backend/internal/modules/capture/graph/graph.go
+++ b/backend/internal/modules/capture/graph/graph.go
@@ -185,7 +185,9 @@ func (c *Connector) Sync(ctx context.Context, auth connector.Auth, cursor connec
 			// cursor so the next cycle retries from the same watermark.
 			return nil, err
 		}
-		if _, err := captureOne(ctx, raw, sink, owner); err != nil {
+		// The incremental delta reads the inbox folder only, so nothing it
+		// yields is mail the owner sent.
+		if _, err := captureOne(ctx, raw, sink, owner, false); err != nil {
 			return nil, err
 		}
 	}
@@ -218,7 +220,7 @@ func (c *Connector) selectMessages(ctx context.Context, access, start string) ([
 // a no-op; only a real Sink write fault returns a non-nil error (which stops
 // the pull). It is a package function (no receiver) so a pull holds no shared
 // state.
-func captureOne(ctx context.Context, raw []byte, sink connector.Sink, owner string) (captured bool, err error) {
+func captureOne(ctx context.Context, raw []byte, sink connector.Sink, owner string, sentByOwner bool) (captured bool, err error) {
 	msg, err := mailmap.Parse(raw, owner)
 	if err != nil {
 		return false, nil //nolint:nilerr // a single unparseable message is a skip, not a fatal pull error (mirrors the Gmail connector)
@@ -226,6 +228,7 @@ func captureOne(ctx context.Context, raw []byte, sink connector.Sink, owner stri
 	if _, drop := msg.SkipReason(); drop {
 		return false, nil
 	}
+	msg = msg.AttestSentByOwner(sentByOwner)
 	if _, err := sink.Upsert(ctx, msg.ToRecord(connectorName, raw)); err != nil {
 		if errors.Is(err, connector.ErrSkip) {
 			return false, nil

--- a/backend/internal/modules/capture/graph/graph.go
+++ b/backend/internal/modules/capture/graph/graph.go
@@ -175,9 +175,10 @@ func (c *Connector) Sync(ctx context.Context, auth connector.Auth, cursor connec
 	for _, id := range ids {
 		raw, err := c.api.GetMIME(ctx, access, id)
 		if errors.Is(err, connector.ErrSkip) {
-			// An oversized message is a per-message drop (truncated MIME is
-			// not honest evidence), never a pull-stopping fault — the cursor
-			// still advances past it.
+			// A message the provider refuses to hand over: deleted since the
+			// delta named it, or oversized (truncated MIME is not honest
+			// evidence). Either is a per-message drop, never a pull-stopping
+			// fault — the cursor still advances past it.
 			continue
 		}
 		if err != nil {

--- a/backend/internal/modules/capture/graph/graph_test.go
+++ b/backend/internal/modules/capture/graph/graph_test.go
@@ -49,6 +49,8 @@ type fakeAPI struct {
 	estimate      int
 	estimateAfter time.Time
 	listIDs       []string
+	sentIDs       map[string]bool // listed ids Graph filed under Sent Items
+	sentFolderErr error
 	listNext      string
 	listCalls     int
 	seenPageToken string
@@ -83,10 +85,32 @@ func (f *fakeAPI) EstimateAfter(_ context.Context, _ string, after time.Time) (i
 	return f.estimate, nil
 }
 
-func (f *fakeAPI) ListAfter(_ context.Context, _ string, _ time.Time, pageToken string, _ int) ([]string, string, error) {
+func (f *fakeAPI) ListAfter(_ context.Context, _ string, _ time.Time, pageToken string, _ int) ([]MessageRef, string, error) {
 	f.listCalls++
 	f.seenPageToken = pageToken
-	return f.listIDs, f.listNext, nil
+	msgs := make([]MessageRef, 0, len(f.listIDs))
+	for _, id := range f.listIDs {
+		folder := inboxFolderID
+		if f.sentIDs[id] {
+			folder = sentFolderID
+		}
+		msgs = append(msgs, MessageRef{ID: id, ParentFolderID: folder})
+	}
+	return msgs, f.listNext, nil
+}
+
+// The stub mailbox's two folder ids: a listed message carries one of them, and
+// SentFolderID names which one means the owner sent it.
+const (
+	sentFolderID  = "folder-sent"
+	inboxFolderID = "folder-inbox"
+)
+
+func (f *fakeAPI) SentFolderID(context.Context, string) (string, error) {
+	if f.sentFolderErr != nil {
+		return "", f.sentFolderErr
+	}
+	return sentFolderID, nil
 }
 
 type recordingSink struct{ recs []connector.NormalizedRecord }

--- a/backend/internal/modules/capture/graph/graph_test.go
+++ b/backend/internal/modules/capture/graph/graph_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -50,6 +51,7 @@ type fakeAPI struct {
 	estimateAfter time.Time
 	listIDs       []string
 	sentIDs       map[string]bool // listed ids Graph filed under Sent Items
+	skipIDs       map[string]bool // ids GetMIME refuses as a per-message drop
 	sentFolderErr error
 	listNext      string
 	listCalls     int
@@ -74,6 +76,9 @@ func (f *fakeAPI) Delta(_ context.Context, _, deltaLink string) ([]string, strin
 }
 
 func (f *fakeAPI) GetMIME(_ context.Context, _, id string) ([]byte, error) {
+	if f.skipIDs[id] {
+		return nil, fmt.Errorf("graph: message %s exceeds the size cap: %w", id, connector.ErrSkip)
+	}
 	if f.getErr != nil {
 		return nil, f.getErr
 	}

--- a/backend/internal/modules/capture/graph/transport.go
+++ b/backend/internal/modules/capture/graph/transport.go
@@ -2,13 +2,20 @@
 // SPDX-FileCopyrightText: 2026 Gradion
 
 // The Graph HTTP request path: the authorized JSON GET every listing and lookup
-// goes through, and the single verdict EVERY call maps its response onto —
-// including the raw-MIME fetch, which builds its own request because it streams
-// bytes rather than decoding JSON. Split out of client.go because it belongs to
-// no individual read, so a reader asking "how does a Graph failure become a
-// sentinel" finds one file rather than a tail. (The OAuth handshake does not
-// come through here — it runs on the shared capture/oauthflow client, with its
-// own classification.)
+// goes through, and the one verdict on a response STATUS — shared by the
+// raw-MIME fetch too, which builds its own request because it streams bytes
+// rather than decoding JSON. Split out of client.go because it belongs to no
+// individual read.
+//
+// It is not the only place a Graph call becomes a sentinel, and should not be
+// read as one: a 2xx whose BODY is not a complete answer — a delta round with
+// neither a next nor a delta link, a listed message naming no parent folder, a
+// sent-items lookup naming no id — is refused beside the call that knows what
+// a complete answer looks like. Status classification is uniform; what counts
+// as a whole answer is per-call.
+//
+// (The OAuth handshake does not come through here — it runs on the shared
+// capture/oauthflow client, with its own classification.)
 
 package graph
 

--- a/backend/internal/modules/capture/graph/transport.go
+++ b/backend/internal/modules/capture/graph/transport.go
@@ -1,18 +1,18 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-// The Graph HTTP request path: the authorized JSON GET every listing and lookup
-// goes through, and the one verdict on a response STATUS — shared by the
-// raw-MIME fetch too, which builds its own request because it streams bytes
-// rather than decoding JSON. Split out of client.go because it belongs to no
-// individual read.
+// The Graph HTTP plumbing shared by the read calls: the authorized JSON GET
+// that every listing and lookup issues, and classifyStatus, the status→sentinel
+// mapping they hand a response to. Split out of client.go because it belongs to
+// no individual read.
 //
-// It is not the only place a Graph call becomes a sentinel, and should not be
-// read as one: a 2xx whose BODY is not a complete answer — a delta round with
-// neither a next nor a delta link, a listed message naming no parent folder, a
-// sent-items lookup naming no id — is refused beside the call that knows what
-// a complete answer looks like. Status classification is uniform; what counts
-// as a whole answer is per-call.
+// Deliberately not the whole story of how a Graph call fails, so don't read it
+// as one. A call that can interpret a particular outcome better keeps that
+// judgement next to itself: GetMIME reads a 404 as a deleted message (a skip,
+// not a reachability fault) before classifyStatus would see it, and a 2xx whose
+// body is not a complete answer — a delta round missing both links, a listed
+// message naming no parent folder, a sent-items lookup naming no id — is
+// refused where the call that knows what "complete" means can say so.
 //
 // (The OAuth handshake does not come through here — it runs on the shared
 // capture/oauthflow client, with its own classification.)

--- a/backend/internal/modules/capture/graph/transport.go
+++ b/backend/internal/modules/capture/graph/transport.go
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-// The Graph HTTP transport: the one request path every read call goes through
-// and the single verdict it maps a response onto. Split out of client.go
-// because it belongs to no individual call — the OAuth handshake and the mail
-// surface both sit on it — so a reader looking for "how does a Graph failure
-// become a sentinel" finds one file, not a tail.
+// The Graph HTTP request path: the one call every read on the API surface goes
+// through, and the single verdict it maps a response onto. Split out of
+// client.go because it belongs to no individual read, so a reader asking "how
+// does a Graph failure become a sentinel" finds one file rather than a tail.
+// (The OAuth handshake does not come through here — it runs on the shared
+// capture/oauthflow client, with its own classification.)
 
 package graph
 

--- a/backend/internal/modules/capture/graph/transport.go
+++ b/backend/internal/modules/capture/graph/transport.go
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// The Graph HTTP transport: the one request path every read call goes through
+// and the single verdict it maps a response onto. Split out of client.go
+// because it belongs to no individual call — the OAuth handshake and the mail
+// surface both sit on it — so a reader looking for "how does a Graph failure
+// become a sentinel" finds one file, not a tail.
+
+package graph
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/shared/ports/connector"
+)
+
+// retryAfter parses the provider's Retry-After (delta-seconds form; Graph's
+// throttling responses use it). Zero when absent — the caller's own backoff
+// takes over.
+func retryAfter(resp *http.Response) time.Duration {
+	if s := resp.Header.Get("Retry-After"); s != "" {
+		if secs, err := strconv.Atoi(s); err == nil && secs > 0 {
+			return time.Duration(secs) * time.Second
+		}
+	}
+	return 0
+}
+
+// messageOp names the raw-MIME fetch in a ProviderError. Its sibling calls carry
+// their URL path as the op; this one is a hand-built request whose URL embeds the
+// message id, so it names the endpoint rather than the instance.
+const messageOp = "message"
+
+// requestOp names a Graph call in a ProviderError the way the other connectors
+// do — as a path relative to the API base. The query string is cut because it
+// carries per-request filters and cursors, and the base is trimmed because an
+// error string wants the endpoint that failed, not the scheme and host it lives
+// on (which are fixed for the deployment and, under test, an ephemeral port).
+func (a *httpAPI) requestOp(fullURL string) string {
+	op, _, _ := strings.Cut(fullURL, "?")
+	trimmed := strings.TrimPrefix(op, a.base)
+	if trimmed == "" {
+		// The base itself, with nothing after it: name the root rather than
+		// render an empty op behind a leading colon.
+		return "/"
+	}
+	return trimmed
+}
+
+// graphErrorBody is the subset of Microsoft's OData error envelope that names
+// the failure. code is the fixed machine code (InvalidAuthenticationToken,
+// accessDenied, …); the prose message beside it is deliberately not read.
+type graphErrorBody struct {
+	Error struct {
+		Code string `json:"code"`
+	} `json:"error"`
+}
+
+// graphReason extracts Microsoft's machine error code from a response body, ""
+// when the body carries none or does not decode — an unparsable body must not
+// masquerade as a named reason.
+func graphReason(body []byte) string {
+	var parsed graphErrorBody
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return ""
+	}
+	return connector.MachineReason(parsed.Error.Code)
+}
+
+// classifyStatus maps a non-2xx Graph response onto the shared connector
+// vocabulary: 429 honors Retry-After, 401/403 parks the credential, anything
+// else backs off. The classification is unchanged by op/body — those only carry
+// Microsoft's own machine code into the error so a log line says WHICH call
+// failed and WHY Microsoft refused it. The raw body is never surfaced to the
+// caller.
+func classifyStatus(resp *http.Response, op string, body []byte) error {
+	switch {
+	case resp.StatusCode == http.StatusTooManyRequests:
+		return &connector.RateLimitedError{RetryAfter: retryAfter(resp)}
+	case resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden:
+		return &connector.ProviderError{
+			Op: op, Status: resp.StatusCode, Reason: graphReason(body), Class: ErrAuthRejected,
+		}
+	case resp.StatusCode < 200 || resp.StatusCode > 299:
+		return &connector.ProviderError{
+			Op: op, Status: resp.StatusCode, Reason: graphReason(body), Class: ErrUnreachable,
+		}
+	}
+	return nil
+}
+
+// get performs an authorized GET on a full URL (extra headers optional) and
+// JSON-decodes into out. It returns the HTTP status (so deltaWalk can
+// special-case 410) alongside the classified error.
+//
+//craft:ignore naked-any out is the caller-supplied JSON decode target — its concrete type varies per endpoint
+func (a *httpAPI) get(ctx context.Context, accessToken, fullURL string, hdr http.Header, out any) (int, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fullURL, nil)
+	if err != nil {
+		return 0, fmt.Errorf("graph: building request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	for k, vs := range hdr {
+		for _, v := range vs {
+			req.Header.Add(k, v)
+		}
+	}
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("graph: request: %w", ErrUnreachable)
+	}
+	//craft:ignore swallowed-errors best-effort close of the response body — the decoded result/status is what matters
+	defer func() { _ = resp.Body.Close() }()
+	body, readErr := io.ReadAll(io.LimitReader(resp.Body, 8<<20))
+	// Classify on status/headers first: a 429/401 must be honored even if the
+	// body read failed. Only on an otherwise-OK response does a read failure
+	// matter — a truncated-but-valid-JSON prefix must never pass as complete.
+	if err := classifyStatus(resp, a.requestOp(fullURL), body); err != nil {
+		return resp.StatusCode, err
+	}
+	if readErr != nil {
+		return resp.StatusCode, fmt.Errorf("graph: reading response: %w", ErrUnreachable)
+	}
+	if err := json.Unmarshal(body, out); err != nil {
+		return resp.StatusCode, fmt.Errorf("graph: decoding response: %w", ErrUnreachable)
+	}
+	return resp.StatusCode, nil
+}

--- a/backend/internal/modules/capture/graph/transport.go
+++ b/backend/internal/modules/capture/graph/transport.go
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 Gradion
 
-// The Graph HTTP request path: the one call every read on the API surface goes
-// through, and the single verdict it maps a response onto. Split out of
-// client.go because it belongs to no individual read, so a reader asking "how
-// does a Graph failure become a sentinel" finds one file rather than a tail.
-// (The OAuth handshake does not come through here — it runs on the shared
-// capture/oauthflow client, with its own classification.)
+// The Graph HTTP request path: the authorized JSON GET every listing and lookup
+// goes through, and the single verdict EVERY call maps its response onto —
+// including the raw-MIME fetch, which builds its own request because it streams
+// bytes rather than decoding JSON. Split out of client.go because it belongs to
+// no individual read, so a reader asking "how does a Graph failure become a
+// sentinel" finds one file rather than a tail. (The OAuth handshake does not
+// come through here — it runs on the shared capture/oauthflow client, with its
+// own classification.)
 
 package graph
 

--- a/backend/internal/modules/capture/imap/imap.go
+++ b/backend/internal/modules/capture/imap/imap.go
@@ -96,9 +96,14 @@ type Connector struct {
 // standing Connector is a registry singleton shared by every IMAP
 // connection, so per-pull state on the struct would race across mailboxes.
 type syncState struct {
-	owner    string
-	stats    Stats
-	contacts map[string]struct{}
+	owner string
+	stats Stats
+	// sentMailbox records that the server reported the selected mailbox with
+	// the \Sent special-use attribute, making every message in it one the
+	// authenticated owner sent — the T1 correspondence evidence (ADR-0072 §1).
+	// A pull selects exactly one mailbox, so the attestation is per-pull.
+	sentMailbox bool
+	contacts    map[string]struct{}
 }
 
 // Stats is one pull's outcome tally — internal bookkeeping accumulated on
@@ -186,6 +191,7 @@ func (c *Connector) capture(ctx context.Context, raw []byte, sink connector.Sink
 		st.stats.Skipped++
 		return nil
 	}
+	parsed = parsed.AttestSentByOwner(st.sentMailbox)
 	if _, err := sink.Upsert(ctx, parsed.ToRecord(connectorName, raw)); err != nil {
 		if errors.Is(err, connector.ErrSkip) {
 			// The Sink dropped it (e.g. an erased subject's suppression list) —

--- a/backend/internal/modules/capture/imap/standing.go
+++ b/backend/internal/modules/capture/imap/standing.go
@@ -190,6 +190,15 @@ func (c *Connector) syncStanding(ctx context.Context, auth connector.Auth, curso
 	if err != nil {
 		return nil, fmt.Errorf("imap: selecting mailbox %q: %w", creds.Mailbox, ErrUnreachable)
 	}
+	// Asked before a single message is captured: the UID watermark advances past
+	// whatever this pull writes, and the activity natural key means a row
+	// stamped un-attested stays that way. A server that will not say what this
+	// mailbox is has not been read yet — the next cycle retries from the same
+	// watermark, exactly as a failed Select does.
+	st.sentMailbox, err = sentSpecialUse(client, creds.Mailbox)
+	if err != nil {
+		return nil, err
+	}
 
 	// A mailbox-identity change, a generation change, or a first sync
 	// re-anchors with the bounded recent window — never a full mailbox walk
@@ -214,6 +223,38 @@ func (c *Connector) syncStanding(ctx context.Context, auth connector.Auth, curso
 	cur.Email = creds.Email
 	cur.Mailbox = creds.Mailbox
 	return marshalIMAPCursor(cur), nil
+}
+
+// sentSpecialUse reports whether the server describes mailbox with RFC 6154's
+// \Sent attribute — the server's own statement that this folder holds mail the
+// authenticated account sent, and the only outbound evidence the T1
+// correspondence gate accepts (ADR-0072 §1; a message's From header is the
+// sender's to write, a mailbox's special-use is not).
+//
+// A folder merely NAMED "Sent" attests nothing: the name is the operator's
+// free text in the connection config, so trusting it would hand the gate back
+// to unauthenticated input. A server without SPECIAL-USE therefore yields
+// false, and the mailbox contributes no correspondence evidence.
+func sentSpecialUse(client *imapclient.Client, mailbox string) (bool, error) {
+	opts := &imapv2.ListOptions{ReturnSpecialUse: client.Caps().Has(imapv2.CapSpecialUse)}
+	entries, err := client.List("", mailbox, opts).Collect()
+	if err != nil {
+		return false, fmt.Errorf("imap: listing mailbox %q: %w", mailbox, errors.Join(ErrUnreachable, err))
+	}
+	return sentAttr(entries, mailbox), nil
+}
+
+// sentAttr reports whether the listed entry FOR mailbox carries \Sent. The name
+// is matched because a configured mailbox is a LIST pattern: one containing a
+// wildcard would return the account's other folders, and a sibling's \Sent
+// would otherwise attest for the mailbox actually being read.
+func sentAttr(entries []*imapv2.ListData, mailbox string) bool {
+	for _, entry := range entries {
+		if entry.Mailbox == mailbox && slices.Contains(entry.Attrs, imapv2.MailboxAttrSent) {
+			return true
+		}
+	}
+	return false
 }
 
 // syncIncremental pulls above the watermark: enumerate first (UIDs only, no

--- a/backend/internal/modules/capture/imap/standing_sync_test.go
+++ b/backend/internal/modules/capture/imap/standing_sync_test.go
@@ -78,7 +78,13 @@ func startMemServer(t *testing.T, n int) (addr string, user *imapmemserver.User)
 		appendMessage(t, user, rfc822(i))
 	}
 	mem.AddUser(user)
+	return listenMem(t, mem), user
+}
 
+// listenMem serves one in-memory mailbox store on a loopback port for the
+// duration of the test, returning the address to dial.
+func listenMem(t *testing.T, mem *imapmemserver.Server) string {
+	t.Helper()
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatal(err)
@@ -97,13 +103,18 @@ func startMemServer(t *testing.T, n int) (addr string, user *imapmemserver.User)
 		//craft:ignore swallowed-errors test-server shutdown; the assertions already ran
 		_ = srv.Close()
 	})
-	return ln.Addr().String(), user
+	return ln.Addr().String()
 }
 
 func appendMessage(t *testing.T, user *imapmemserver.User, raw string) {
 	t.Helper()
+	appendTo(t, user, "INBOX", raw)
+}
+
+func appendTo(t *testing.T, user *imapmemserver.User, mailbox, raw string) {
+	t.Helper()
 	buf := []byte(raw)
-	if _, err := user.Append("INBOX", &memLiteral{b: buf}, &imapv2.AppendOptions{}); err != nil {
+	if _, err := user.Append(mailbox, &memLiteral{b: buf}, &imapv2.AppendOptions{}); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -141,10 +152,24 @@ func plainDialer(addr string) func(context.Context, Credentials) (*imapclient.Cl
 
 func standingAuth(t *testing.T) connector.Auth {
 	t.Helper()
+	return sealCreds(t, standingCreds(t))
+}
+
+// standingCreds is the normalized credential bundle every standing-sync test
+// starts from; a test that cares about one field adjusts it on the way to
+// sealCreds.
+func standingCreds(t *testing.T) Credentials {
+	t.Helper()
 	creds, err := normalizeCredentials(Credentials{Host: "mem", Email: memUser, Password: memPass, MaxMessages: 3})
 	if err != nil {
 		t.Fatal(err)
 	}
+	return creds
+}
+
+// sealCreds packs credentials into the opaque auth bundle Sync takes.
+func sealCreds(t *testing.T, creds Credentials) connector.Auth {
+	t.Helper()
 	req, err := AuthRequestFrom(creds)
 	if err != nil {
 		t.Fatal(err)
@@ -388,5 +413,61 @@ func TestStandingAnchorOnEmptyMailbox(t *testing.T) {
 	}
 	if parsed.Email != memUser {
 		t.Fatalf("even an empty anchor must plant the mailbox identity, got %+v", parsed)
+	}
+}
+
+// The IMAP half of the T1 correspondence evidence (ADR-0072 §1). A mailbox
+// NAMED "Sent" attests nothing: the name comes from the connection config an
+// operator typed, so honoring it would let a mis-named folder — or an operator
+// who points the connector at a folder an attacker can write to — turn inbound
+// mail into the workspace's own correspondence. Only the server's RFC 6154
+// \Sent attribute counts, and the in-memory server sets none.
+func TestSentAttestationIgnoresTheMailboxName(t *testing.T) {
+	mem := imapmemserver.New()
+	user := imapmemserver.NewUser(memUser, memPass)
+	for _, name := range []string{"INBOX", "Sent"} {
+		if err := user.Create(name, nil); err != nil {
+			t.Fatal(err)
+		}
+	}
+	appendTo(t, user, "Sent", rfc822(1))
+	mem.AddUser(user)
+	addr := listenMem(t, mem)
+
+	creds := standingCreds(t)
+	creds.Mailbox = "Sent"
+
+	sink := &recordingSink{}
+	c := NewStanding().withDialer(plainDialer(addr))
+	if _, err := c.Sync(context.Background(), sealCreds(t, creds), nil, sink); err != nil {
+		t.Fatalf("sync of the name-only Sent mailbox: %v", err)
+	}
+	if len(sink.records) == 0 {
+		t.Fatal("the pull captured nothing — the assertion below would prove nothing")
+	}
+	for _, rec := range sink.records {
+		if rec.Counterparty.SentByOwner {
+			t.Fatal("a mailbox named Sent attested the owner's authorship: the name is config text, not provider evidence")
+		}
+	}
+}
+
+// The attestation belongs to the mailbox being read, and only to it.
+func TestSentAttrReadsTheSelectedMailboxsAttribute(t *testing.T) {
+	plain := []*imapv2.ListData{{Mailbox: "Sent", Attrs: []imapv2.MailboxAttr{imapv2.MailboxAttrSubscribed}}}
+	if sentAttr(plain, "Sent") {
+		t.Error("a mailbox listed without \\Sent must not attest")
+	}
+	special := []*imapv2.ListData{{
+		Mailbox: "Archive/2026",
+		Attrs:   []imapv2.MailboxAttr{imapv2.MailboxAttrSubscribed, imapv2.MailboxAttrSent},
+	}}
+	if !sentAttr(special, "Archive/2026") {
+		t.Error("a mailbox the server marks \\Sent must attest, whatever it is named")
+	}
+	// A wildcard pattern lists siblings too; a sibling's \Sent is not this
+	// mailbox's evidence.
+	if sentAttr(special, "Archive/*") {
+		t.Error("a sibling mailbox's \\Sent attested for the mailbox being read")
 	}
 }

--- a/backend/internal/modules/capture/imap/standing_sync_test.go
+++ b/backend/internal/modules/capture/imap/standing_sync_test.go
@@ -65,6 +65,18 @@ func rfc822(n int) string {
 		"body %d", memUser, n, n%10, n, n)
 }
 
+// rfc822FromOwner is a message the owner wrote, so its direction is outbound
+// and the provider's filing is the ONLY thing left deciding attestation.
+func rfc822FromOwner(n int) string {
+	return fmt.Sprintf("From: %s\r\n"+
+		"To: Alice <alice@acme.test>\r\n"+
+		"Subject: hello %d\r\n"+
+		"Date: Wed, 04 Jun 2026 08:0%d:00 +0000\r\n"+
+		"Message-ID: <own%d@myco.test>\r\n"+
+		"Content-Type: text/plain\r\n\r\n"+
+		"body %d", memUser, n, n%10, n, n)
+}
+
 // startMemServer boots an in-memory IMAP server with n messages in INBOX and
 // returns its address plus the append handle for later arrivals.
 func startMemServer(t *testing.T, n int) (addr string, user *imapmemserver.User) {
@@ -430,7 +442,7 @@ func TestSentAttestationIgnoresTheMailboxName(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	appendTo(t, user, "Sent", rfc822(1))
+	appendTo(t, user, "Sent", rfc822FromOwner(1))
 	mem.AddUser(user)
 	addr := listenMem(t, mem)
 
@@ -446,6 +458,10 @@ func TestSentAttestationIgnoresTheMailboxName(t *testing.T) {
 		t.Fatal("the pull captured nothing — the assertion below would prove nothing")
 	}
 	for _, rec := range sink.records {
+		if rec.Counterparty.Direction != "outbound" {
+			t.Fatalf("Direction = %q, want outbound — otherwise authorship, not the folder name, is what withholds attestation",
+				rec.Counterparty.Direction)
+		}
 		if rec.Counterparty.SentByOwner {
 			t.Fatal("a mailbox named Sent attested the owner's authorship: the name is config text, not provider evidence")
 		}

--- a/backend/internal/modules/capture/imap/standing_sync_test.go
+++ b/backend/internal/modules/capture/imap/standing_sync_test.go
@@ -462,7 +462,7 @@ func TestSentAttestationIgnoresTheMailboxName(t *testing.T) {
 			t.Fatalf("Direction = %q, want outbound — otherwise authorship, not the folder name, is what withholds attestation",
 				rec.Counterparty.Direction)
 		}
-		if rec.Counterparty.SentByOwner {
+		if rec.Counterparty.SentByOwner() {
 			t.Fatal("a mailbox named Sent attested the owner's authorship: the name is config text, not provider evidence")
 		}
 	}

--- a/backend/internal/modules/capture/mailmap/mailmap.go
+++ b/backend/internal/modules/capture/mailmap/mailmap.go
@@ -31,6 +31,12 @@ import (
 // excerpt, not the full multi-megabyte thread with quoted history.
 const maxBodyLen = 8000
 
+// The message's direction relative to the mailbox owner.
+const (
+	directionInbound  = "inbound"
+	directionOutbound = "outbound"
+)
+
 // Message is the pure result of reading one RFC822 message against the
 // mailbox owner — everything the mapping needs, with no provider handle.
 type Message struct {
@@ -48,6 +54,19 @@ type Message struct {
 	recipientDomains []string // lowercased, de-duped domains of every To — for the RC-2 gate
 	autoSubmit       bool
 	listUnsubscribe  bool // an RFC 2369 List-Unsubscribe header — transactional-gate corroboration
+	sentByOwner      bool // the PROVIDER attested the owner sent this — set by AttestSentByOwner, never parsed
+}
+
+// AttestSentByOwner returns a copy carrying the provider's own attestation
+// that the authenticated mailbox owner sent this message — Gmail's SENT
+// label, an IMAP \Sent special-use mailbox, Microsoft's SentItems folder.
+// The signal cannot come from Parse: every header this package reads is
+// attacker-controlled, and the T1 correspondence-positive gate (ADR-0072 §1)
+// treats a sent message as affirmative intent toward its recipient. Only a
+// connector holding an authenticated provider handle can vouch for it.
+func (m Message) AttestSentByOwner(sent bool) Message {
+	m.sentByOwner = sent
+	return m
 }
 
 // Counterparty is the non-owner address on the message (the person this
@@ -80,11 +99,11 @@ func Parse(raw []byte, owner string) (Message, error) {
 	body := extractText(reader)
 
 	ownerLower := strings.ToLower(strings.TrimSpace(owner))
-	direction := "inbound"
+	direction := directionInbound
 	counterparty := from
 	counterpartyName := displayName(fromList, counterparty)
 	if strings.ToLower(from) == ownerLower && ownerLower != "" {
-		direction = "outbound"
+		direction = directionOutbound
 		counterparty = firstNonOwner(toList, ownerLower)
 		counterpartyName = displayName(toList, counterparty)
 	}
@@ -208,6 +227,15 @@ func (m Message) ToRecord(connectorName string, raw []byte) connector.Normalized
 			Domain:          domainOf(m.counterparty),
 			Direction:       m.direction,
 			ListUnsubscribe: m.listUnsubscribe,
+			// BOTH halves of the evidence, because the two are derived
+			// independently: the provider filed this as the owner's sent mail,
+			// AND the message names the owner as its author. A server-side rule
+			// can drop a third party's message into a \Sent mailbox or Sent
+			// Items — that message's counterparty is its SENDER, and attesting
+			// on placement alone would stamp a stranger's address as the
+			// workspace's own correspondence. Neither half is sufficient: the
+			// header alone is forgeable, the folder alone is not authorship.
+			SentByOwner: m.sentByOwner && m.direction == directionOutbound,
 		},
 		ThreadKey: m.threadKey,
 	}

--- a/backend/internal/modules/capture/mailmap/mailmap.go
+++ b/backend/internal/modules/capture/mailmap/mailmap.go
@@ -31,12 +31,6 @@ import (
 // excerpt, not the full multi-megabyte thread with quoted history.
 const maxBodyLen = 8000
 
-// The message's direction relative to the mailbox owner.
-const (
-	directionInbound  = "inbound"
-	directionOutbound = "outbound"
-)
-
 // Message is the pure result of reading one RFC822 message against the
 // mailbox owner — everything the mapping needs, with no provider handle.
 type Message struct {
@@ -99,11 +93,11 @@ func Parse(raw []byte, owner string) (Message, error) {
 	body := extractText(reader)
 
 	ownerLower := strings.ToLower(strings.TrimSpace(owner))
-	direction := directionInbound
+	direction := connector.DirectionInbound
 	counterparty := from
 	counterpartyName := displayName(fromList, counterparty)
 	if strings.ToLower(from) == ownerLower && ownerLower != "" {
-		direction = directionOutbound
+		direction = connector.DirectionOutbound
 		counterparty = firstNonOwner(toList, ownerLower)
 		counterpartyName = displayName(toList, counterparty)
 	}
@@ -227,16 +221,7 @@ func (m Message) ToRecord(connectorName string, raw []byte) connector.Normalized
 			Domain:          domainOf(m.counterparty),
 			Direction:       m.direction,
 			ListUnsubscribe: m.listUnsubscribe,
-			// BOTH halves of the evidence, because the two are derived
-			// independently: the provider filed this as the owner's sent mail,
-			// AND the message names the owner as its author. A server-side rule
-			// can drop a third party's message into a \Sent mailbox or Sent
-			// Items — that message's counterparty is its SENDER, and attesting
-			// on placement alone would stamp a stranger's address as the
-			// workspace's own correspondence. Neither half is sufficient: the
-			// header alone is forgeable, the folder alone is not authorship.
-			SentByOwner: m.sentByOwner && m.direction == directionOutbound,
-		},
+		}.WithOwnerAttestation(m.sentByOwner),
 		ThreadKey: m.threadKey,
 	}
 }

--- a/backend/internal/modules/capture/mailmap/mailmap_test.go
+++ b/backend/internal/modules/capture/mailmap/mailmap_test.go
@@ -266,10 +266,10 @@ func TestSentByOwnerComesFromTheProviderNotTheHeaders(t *testing.T) {
 	if rec.Counterparty.Direction != "outbound" {
 		t.Fatalf("Direction = %q, want outbound — the From header claims the owner", rec.Counterparty.Direction)
 	}
-	if rec.Counterparty.SentByOwner {
+	if rec.Counterparty.SentByOwner() {
 		t.Fatal("SentByOwner = true from headers alone: a forged From:owner would whitelist its recipient past suppression")
 	}
-	if attested := msg.AttestSentByOwner(true).ToRecord("imap", spoofed); !attested.Counterparty.SentByOwner {
+	if attested := msg.AttestSentByOwner(true).ToRecord("imap", spoofed); !attested.Counterparty.SentByOwner() {
 		t.Fatal("AttestSentByOwner(true) must carry the provider's attestation onto the record")
 	}
 }
@@ -293,7 +293,7 @@ func TestAttestationRequiresAuthorshipNotJustPlacement(t *testing.T) {
 	if rec.Counterparty.Email != "blast@sendgrid.net" {
 		t.Fatalf("Counterparty = %q, want the sender — this message is inbound", rec.Counterparty.Email)
 	}
-	if rec.Counterparty.SentByOwner {
+	if rec.Counterparty.SentByOwner() {
 		t.Fatal("a third party's message filed into the sent container attested the owner's authorship")
 	}
 }

--- a/backend/internal/modules/capture/mailmap/mailmap_test.go
+++ b/backend/internal/modules/capture/mailmap/mailmap_test.go
@@ -247,3 +247,53 @@ func TestParseCarriesCounterpartyAndThreadKey(t *testing.T) {
 		}
 	})
 }
+
+// The T1 correspondence gate's evidence is the provider's, not the message's
+// (ADR-0072 §1). Parse must never infer it: a message whose From header names
+// the mailbox owner parses as outbound — that is what direction means — and it
+// still attests nothing, because anyone can write that header. Only a
+// connector holding an authenticated provider handle may set the attestation.
+func TestSentByOwnerComesFromTheProviderNotTheHeaders(t *testing.T) {
+	spoofed := crlf(
+		"From: me@myco.com", "To: victim@evil.example", "Subject: pay this invoice",
+		"Message-ID: <spoof1@evil.example>", "Content-Type: text/plain", "", "wire it", "",
+	)
+	msg, err := Parse(spoofed, "me@myco.com")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	rec := msg.ToRecord("imap", spoofed)
+	if rec.Counterparty.Direction != "outbound" {
+		t.Fatalf("Direction = %q, want outbound — the From header claims the owner", rec.Counterparty.Direction)
+	}
+	if rec.Counterparty.SentByOwner {
+		t.Fatal("SentByOwner = true from headers alone: a forged From:owner would whitelist its recipient past suppression")
+	}
+	if attested := msg.AttestSentByOwner(true).ToRecord("imap", spoofed); !attested.Counterparty.SentByOwner {
+		t.Fatal("AttestSentByOwner(true) must carry the provider's attestation onto the record")
+	}
+}
+
+// Placement is not authorship. A server-side rule can file a third party's
+// message into a \Sent mailbox or Sent Items, and the counterparty of such a
+// message is its SENDER — attesting on the provider's filing alone would stamp
+// a stranger's address as the workspace's own correspondence and hand them the
+// T1 spare past T2 suppression, which is the same bypass the forged header
+// would have bought.
+func TestAttestationRequiresAuthorshipNotJustPlacement(t *testing.T) {
+	filed := crlf(
+		"From: blast@sendgrid.net", "To: me@myco.com", "Subject: deal",
+		"Message-ID: <filed1@sendgrid.net>", "Content-Type: text/plain", "", "hi", "",
+	)
+	msg, err := Parse(filed, "me@myco.com")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	rec := msg.AttestSentByOwner(true).ToRecord("imap", filed)
+	if rec.Counterparty.Email != "blast@sendgrid.net" {
+		t.Fatalf("Counterparty = %q, want the sender — this message is inbound", rec.Counterparty.Email)
+	}
+	if rec.Counterparty.SentByOwner {
+		t.Fatal("a third party's message filed into the sent container attested the owner's authorship")
+	}
+}

--- a/backend/internal/modules/capture/sink.go
+++ b/backend/internal/modules/capture/sink.go
@@ -224,7 +224,7 @@ func activityCaptureEventPayload(kind, sourceSystem string) crmcontracts.PublicE
 // Emitted only when the activity row is new, so the at-least-once sync loop
 // cannot double-fire it; never a subject heuristic.
 func (s *Sink) emitReply(ctx context.Context, tx pgx.Tx, auditID ids.UUID, id ids.ActivityID, rec connector.NormalizedRecord, fields ActivityFields) error {
-	if fields.Direction != "inbound" || rec.ThreadKey == "" {
+	if fields.Direction != connector.DirectionInbound || rec.ThreadKey == "" {
 		return nil
 	}
 	var matched ids.UUID

--- a/backend/internal/modules/capture/sink.go
+++ b/backend/internal/modules/capture/sink.go
@@ -368,7 +368,7 @@ func (s *Sink) upsertActivity(ctx context.Context, tx pgx.Tx, rec connector.Norm
 		// From-derived direction alone: this column is the T1
 		// correspondence-positive gate's only evidence, and a forged
 		// From:owner must not register as the owner's correspondence.
-		rec.Counterparty.SentByOwner).Scan(&id)
+		rec.Counterparty.SentByOwner()).Scan(&id)
 	if err == nil {
 		// Field-level provenance (B-E02.12) for the content fields this
 		// capture set — same source/author the row itself carries.

--- a/backend/internal/modules/capture/sink.go
+++ b/backend/internal/modules/capture/sink.go
@@ -360,13 +360,14 @@ func (s *Sink) upsertActivity(ctx context.Context, tx pgx.Tx, rec connector.Norm
 		fields.Kind, fields.Subject, fields.Body, occurredAt, fields.Direction,
 		rec.NaturalKey.SourceSystem, rec.NaturalKey.SourceID, captureSource(rec), rec.CapturedBy, rec.ThreadKey,
 		// Normalized lowercased at the write (a connector need not lowercase the
-		// header case), matching the person_email normalization, so phase 2b's
-		// index-backed equality on this column matches regardless of the
-		// sender's casing without a runtime case fold.
+		// header case), matching the person_email normalization, so the T1
+		// correspondence lookup's index-backed equality matches regardless of
+		// the sender's casing without a runtime case fold.
 		strings.ToLower(strings.TrimSpace(rec.Counterparty.Email)),
-		// The provider's attestation, never the From-derived direction: this
-		// column is the T1 correspondence-positive gate's only evidence, and a
-		// forged From:owner must not register as the owner's correspondence.
+		// The provider's filing AND the message's authorship, never the
+		// From-derived direction alone: this column is the T1
+		// correspondence-positive gate's only evidence, and a forged
+		// From:owner must not register as the owner's correspondence.
 		rec.Counterparty.SentByOwner).Scan(&id)
 	if err == nil {
 		// Field-level provenance (B-E02.12) for the content fields this

--- a/backend/internal/modules/capture/sink.go
+++ b/backend/internal/modules/capture/sink.go
@@ -351,9 +351,9 @@ func (s *Sink) upsertActivity(ctx context.Context, tx pgx.Tx, rec connector.Norm
 	occurredAt := defaultOccurredAt(fields.OccurredAt)
 	var id ids.ActivityID
 	err := tx.QueryRow(ctx, `
-		INSERT INTO activity (workspace_id, kind, subject, body, occurred_at, direction, source_system, source_id, source, captured_by, thread_key, counterparty_email)
+		INSERT INTO activity (workspace_id, kind, subject, body, occurred_at, direction, source_system, source_id, source, captured_by, thread_key, counterparty_email, counterparty_outbound_attested)
 		VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid,
-		        $1, NULLIF($2, ''), NULLIF($3, ''), $4, NULLIF($5, ''), $6, $7, $8, $9, NULLIF($10, ''), NULLIF($11, ''))
+		        $1, NULLIF($2, ''), NULLIF($3, ''), $4, NULLIF($5, ''), $6, $7, $8, $9, NULLIF($10, ''), NULLIF($11, ''), $12)
 		ON CONFLICT (workspace_id, source_system, source_id) WHERE source_system IS NOT NULL AND source_id IS NOT NULL
 		DO NOTHING
 		RETURNING id`,
@@ -363,7 +363,11 @@ func (s *Sink) upsertActivity(ctx context.Context, tx pgx.Tx, rec connector.Norm
 		// header case), matching the person_email normalization, so phase 2b's
 		// index-backed equality on this column matches regardless of the
 		// sender's casing without a runtime case fold.
-		strings.ToLower(strings.TrimSpace(rec.Counterparty.Email))).Scan(&id)
+		strings.ToLower(strings.TrimSpace(rec.Counterparty.Email)),
+		// The provider's attestation, never the From-derived direction: this
+		// column is the T1 correspondence-positive gate's only evidence, and a
+		// forged From:owner must not register as the owner's correspondence.
+		rec.Counterparty.SentByOwner).Scan(&id)
 	if err == nil {
 		// Field-level provenance (B-E02.12) for the content fields this
 		// capture set — same source/author the row itself carries.

--- a/backend/internal/modules/capture/sinkensure.go
+++ b/backend/internal/modules/capture/sinkensure.go
@@ -96,15 +96,31 @@ func (s *Sink) ensureCounterparty(ctx context.Context, rec connector.NormalizedR
 	// DocuSign envelope or a SendGrid relay is not a counterparty's company.
 	// Suppress person AND org derivation — the activity already committed and
 	// stands (a DocuSign envelope is a real timeline item) — and record the
-	// reason durably for observability. The T1 correspondence-positive spare
-	// (CAP-DDL-7) that lets a known contact through lands in phase 2b, where the
-	// "outbound" signal is taken from an authenticated provider label — deriving
-	// it from the forgeable From header (as `direction` does today) would let a
-	// spoofed From:owner mail whitelist an arbitrary address past this gate.
+	// reason durably for observability.
 	if s.transactional != nil {
 		if suppress, reason := s.transactional.Suppress(transactionalInput(cp)); suppress {
-			s.logSuppression(ctx, rec, reason)
-			return
+			// T1 correspondence-positive OUTRANKS T2 (ADR-0072 §1), and the
+			// precedence is load-bearing: a known contact whose newsletter
+			// footer carries a List-Unsubscribe header, or who mails from
+			// `news.acme.com`, must not be suppressed as bulk infrastructure.
+			// Someone the workspace has written to is a counterparty by
+			// demonstrated intent, whatever their mail plumbing looks like.
+			// Asked only here — the tier below is the only place the answer
+			// changes an outcome, and asking costs a query per captured message.
+			corresponded, err := s.correspondencePositive(ctx, cp.Email)
+			if err != nil {
+				s.logEnsureFault(ctx, rec, err)
+				return
+			}
+			if !corresponded {
+				s.logSuppression(ctx, rec, reason)
+				return
+			}
+			// The rule matched and T1 overrode it. Recorded on its own so a
+			// spare is as diagnosable as a suppression — this is the one path
+			// that lets an address the registry calls infrastructure become a
+			// record, and ops must be able to see it happen.
+			s.logCorrespondenceSpare(ctx, rec, reason)
 		}
 	}
 	suppressOrg := s.freemail != nil && s.freemail.IsFreemail(cp.Domain)
@@ -141,6 +157,37 @@ func (s *Sink) internalDomain(ctx context.Context, domain string) (bool, error) 
 	return internal, nil
 }
 
+// correspondencePositive reports whether the workspace has ever sent mail to
+// email — the T1 evidence (ADR-0072 §1). It reads only
+// `counterparty_outbound_attested`, the provider's own attestation that the
+// mailbox owner sent the message, and never `direction`: direction is derived
+// by comparing the forgeable From header against the owner, so honoring it here
+// would let a spoofed From:owner message delivered to the inbox whitelist any
+// address it names past the T2 suppression gate.
+//
+// A single cold inbound is NOT correspondence — receiving mail is not intent.
+// The first outbound message to an address counts immediately: writing to
+// someone is affirmative intent toward them, and it is the message being
+// captured right now that supplies it (the activity commits before this runs).
+func (s *Sink) correspondencePositive(ctx context.Context, email string) (bool, error) {
+	normalized := strings.ToLower(strings.TrimSpace(email))
+	if normalized == "" {
+		return false, nil
+	}
+	var corresponded bool
+	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `
+			SELECT EXISTS (
+			  SELECT 1 FROM activity
+			  WHERE counterparty_email = $1 AND counterparty_outbound_attested
+			)`, normalized).Scan(&corresponded)
+	})
+	if err != nil {
+		return false, fmt.Errorf("capture: correspondence-positive gate: %w", err)
+	}
+	return corresponded, nil
+}
+
 // transactionalInput builds the transactional-gate input from a captured
 // counterparty: the domain, the address local part (machine-sender
 // corroboration), and the List-Unsubscribe signal the connector parsed.
@@ -169,6 +216,26 @@ func (s *Sink) logSuppression(ctx context.Context, rec connector.NormalizedRecor
 	})
 	if err != nil {
 		slog.ErrorContext(ctx, "capture: recording transactional suppression", "err", err, "reason", reason)
+	}
+}
+
+// logCorrespondenceSpare records that T1 overrode a matched T2 suppression
+// rule: the workspace has provably written to this address, so the counterparty
+// is derived despite the registry calling its domain infrastructure. Carries
+// the rule that would have fired, so a wrong registry entry stays diagnosable.
+// Never fails capture: a failed breadcrumb only loses observability.
+func (s *Sink) logCorrespondenceSpare(ctx context.Context, rec connector.NormalizedRecord, reason string) {
+	detail := map[string]any{
+		fieldReason:       reason,
+		fieldSourceSystem: rec.NaturalKey.SourceSystem,
+		fieldSourceID:     rec.NaturalKey.SourceID,
+	}
+	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+		_, logErr := storekit.LogSystem(ctx, tx, "capture_correspondence_spared", detail)
+		return logErr
+	})
+	if err != nil {
+		slog.ErrorContext(ctx, "capture: recording correspondence spare", "err", err, "reason", reason)
 	}
 }
 

--- a/backend/internal/shared/ports/connector/connector.go
+++ b/backend/internal/shared/ports/connector/connector.go
@@ -157,6 +157,15 @@ type Counterparty struct {
 	// prefix rule may suppress record creation. Mail connectors populate it;
 	// zero for records that carry no such signal.
 	ListUnsubscribe bool
+	// SentByOwner is the PROVIDER's attestation that the authenticated mailbox
+	// owner sent this message: Gmail's SENT label, an IMAP \Sent special-use
+	// mailbox, Microsoft's SentItems folder. It is deliberately NOT derived
+	// from Direction, which compares the forgeable From header against the
+	// owner's address — a spoofed From:owner mail delivered to the inbox would
+	// otherwise pass as the owner's own correspondence. Only this field may
+	// feed the T1 correspondence-positive gate (ADR-0072 §1); a provider that
+	// attests nothing leaves it false, which suppresses rather than trusts.
+	SentByOwner bool
 }
 
 // ExclusionAttrs is the normalized, matchable face of a captured message

--- a/backend/internal/shared/ports/connector/connector.go
+++ b/backend/internal/shared/ports/connector/connector.go
@@ -157,24 +157,47 @@ type Counterparty struct {
 	// prefix rule may suppress record creation. Mail connectors populate it;
 	// zero for records that carry no such signal.
 	ListUnsubscribe bool
-	// SentByOwner reports that the authenticated mailbox owner sent this
-	// message, and it is true only when two independently-derived facts agree:
-	// the PROVIDER filed it as sent (Gmail's SENT label, an IMAP \Sent
-	// special-use mailbox, Microsoft's SentItems folder) AND the message names
-	// the owner as its author.
-	//
-	// Neither half may set it alone. Direction compares the forgeable From
-	// header against the owner's address, so a spoofed From:owner mail
-	// delivered to the inbox would otherwise pass as the owner's own
-	// correspondence; and placement is not authorship, since a server-side rule
-	// can file a third party's message into the sent container, where the
-	// counterparty is that stranger's own address.
-	//
-	// Only this field may feed the T1 correspondence-positive gate (ADR-0072
-	// §1); a provider that attests nothing leaves it false, which suppresses
-	// rather than trusts.
-	SentByOwner bool
+	// sentByOwner is the T1 correspondence-positive gate's only evidence
+	// (ADR-0072 §1), and it is deliberately UNEXPORTED. The field is the one
+	// thing on this struct a connector must not be able to state for itself:
+	// whoever sets it can whitelist an arbitrary address past transactional
+	// suppression. Unexported, the compiler refuses every route a convention
+	// could not — a positional literal, a JSON unmarshal, reflection, a
+	// conversion from a look-alike struct, a pointer handed to a decoder.
+	// WithOwnerAttestation is the sole way in, and SentByOwner the sole way out.
+	sentByOwner bool
 }
+
+// Message direction relative to the mailbox owner, as Counterparty.Direction
+// reports it.
+const (
+	DirectionInbound  = "inbound"
+	DirectionOutbound = "outbound"
+)
+
+// WithOwnerAttestation returns a copy recording that the authenticated mailbox
+// owner sent this message. providerFiled is the PROVIDER's own filing — Gmail's
+// SENT label, an IMAP \Sent special-use mailbox, Microsoft's SentItems folder —
+// and it is honored only where Direction independently names the owner as the
+// message's author.
+//
+// The conjunction lives here, in the port that owns the field, because neither
+// half is sufficient and no caller may choose to apply only one. Direction
+// compares the forgeable From header against the owner's address, so a spoofed
+// From:owner delivered to the inbox would otherwise pass as the owner's own
+// correspondence. And placement is not authorship: a server-side rule can file
+// a third party's message into the sent container, where the counterparty is
+// that stranger's own address.
+//
+// A caller that attests nothing leaves the answer false, which suppresses
+// rather than trusts.
+func (c Counterparty) WithOwnerAttestation(providerFiled bool) Counterparty {
+	c.sentByOwner = providerFiled && c.Direction == DirectionOutbound
+	return c
+}
+
+// SentByOwner reports whether both halves of the attestation agreed.
+func (c Counterparty) SentByOwner() bool { return c.sentByOwner }
 
 // ExclusionAttrs is the normalized, matchable face of a captured message
 // the RC-2 exclusion gate reads: the sender's domain, every recipient's

--- a/backend/internal/shared/ports/connector/connector.go
+++ b/backend/internal/shared/ports/connector/connector.go
@@ -157,14 +157,22 @@ type Counterparty struct {
 	// prefix rule may suppress record creation. Mail connectors populate it;
 	// zero for records that carry no such signal.
 	ListUnsubscribe bool
-	// SentByOwner is the PROVIDER's attestation that the authenticated mailbox
-	// owner sent this message: Gmail's SENT label, an IMAP \Sent special-use
-	// mailbox, Microsoft's SentItems folder. It is deliberately NOT derived
-	// from Direction, which compares the forgeable From header against the
-	// owner's address — a spoofed From:owner mail delivered to the inbox would
-	// otherwise pass as the owner's own correspondence. Only this field may
-	// feed the T1 correspondence-positive gate (ADR-0072 §1); a provider that
-	// attests nothing leaves it false, which suppresses rather than trusts.
+	// SentByOwner reports that the authenticated mailbox owner sent this
+	// message, and it is true only when two independently-derived facts agree:
+	// the PROVIDER filed it as sent (Gmail's SENT label, an IMAP \Sent
+	// special-use mailbox, Microsoft's SentItems folder) AND the message names
+	// the owner as its author.
+	//
+	// Neither half may set it alone. Direction compares the forgeable From
+	// header against the owner's address, so a spoofed From:owner mail
+	// delivered to the inbox would otherwise pass as the owner's own
+	// correspondence; and placement is not authorship, since a server-side rule
+	// can file a third party's message into the sent container, where the
+	// counterparty is that stranger's own address.
+	//
+	// Only this field may feed the T1 correspondence-positive gate (ADR-0072
+	// §1); a provider that attests nothing leaves it false, which suppresses
+	// rather than trusts.
 	SentByOwner bool
 }
 

--- a/backend/internal/shared/ports/connector/connector.go
+++ b/backend/internal/shared/ports/connector/connector.go
@@ -145,7 +145,7 @@ type NormalizedRecord struct {
 // Email is authoritative; DisplayName is the header's human name (may be
 // empty or hostile — consumers must treat it as untrusted text); Domain is
 // the lowercased mail domain; Direction is the message's direction relative
-// to the mailbox owner (inbound | outbound).
+// to the mailbox owner (DirectionInbound | DirectionOutbound).
 type Counterparty struct {
 	Email       string
 	DisplayName string
@@ -188,6 +188,13 @@ const (
 // correspondence. And placement is not authorship: a server-side rule can file
 // a third party's message into the sent container, where the counterparty is
 // that stranger's own address.
+//
+// Build the Counterparty first: this reads Direction as it stands at the call,
+// so attesting before Direction is populated — or reassigning it afterwards —
+// yields an answer that no longer matches the record. Both mistakes fail toward
+// false, and the unexported field carries the same cost at any serialization
+// boundary: a Counterparty that ever crosses one arrives un-attested rather
+// than wrongly attested.
 //
 // A caller that attests nothing leaves the answer false, which suppresses
 // rather than trusts.

--- a/backend/migrations/core/0124_activity_counterparty_outbound_attested.down.sql
+++ b/backend/migrations/core/0124_activity_counterparty_outbound_attested.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX idx_activity_counterparty_outbound_attested;
+ALTER TABLE activity DROP COLUMN counterparty_outbound_attested;

--- a/backend/migrations/core/0124_activity_counterparty_outbound_attested.up.sql
+++ b/backend/migrations/core/0124_activity_counterparty_outbound_attested.up.sql
@@ -14,7 +14,7 @@
 -- message's own authorship agree: placement alone is not authorship either,
 -- since a server-side rule can file a stranger's mail into the sent container.
 --
--- Three residuals this column does NOT close, recorded so nobody later reads
+-- Four residuals this column does NOT close, recorded so nobody later reads
 -- them as bugs. (a) An owner-side rule that files spoofed own-domain mail into
 -- Sent Items or a \Sent mailbox defeats the conjunction on Graph and IMAP;
 -- Gmail is not reachable this way, since SENT is applied by the send path and

--- a/backend/migrations/core/0124_activity_counterparty_outbound_attested.up.sql
+++ b/backend/migrations/core/0124_activity_counterparty_outbound_attested.up.sql
@@ -22,7 +22,11 @@
 -- attests an address the owner never chose — the reply really was sent, so no
 -- signal here can tell the difference. (c) The gate is single-shot by design:
 -- one attested message is sufficient evidence, and it is written before the
--- predicate reads it, so an attacker never needs a history.
+-- predicate reads it, so an attacker never needs a history. (d) The evidence is
+-- workspace-scoped by design — T1 asks whether the WORKSPACE has written to an
+-- address, so any member's mailbox answers for all of them; narrowing it to the
+-- capturing connection would suppress a colleague's genuine contact, and any
+-- member who can capture can already create the record directly.
 --
 -- NOT NULL DEFAULT false: every existing row, and every record from a provider
 -- that attests nothing, is un-attested. Under-attestation suppresses a

--- a/backend/migrations/core/0124_activity_counterparty_outbound_attested.up.sql
+++ b/backend/migrations/core/0124_activity_counterparty_outbound_attested.up.sql
@@ -1,0 +1,28 @@
+-- ADR-0072/A118 (CAP-PARAM-6, tier T1): the provider-attested outbound marker.
+--
+-- The T1 correspondence-positive gate spares a counterparty from transactional
+-- suppression when the workspace has ever written to that address. The evidence
+-- must be trustworthy: activity.direction is derived by comparing the message's
+-- From header against the mailbox owner, and From is forgeable, so a spoofed
+-- From:owner message delivered to the inbox would otherwise register as the
+-- owner's own correspondence and whitelist an arbitrary address past T2.
+--
+-- This column carries the PROVIDER's attestation instead — Gmail's SENT label,
+-- an IMAP \Sent special-use mailbox, Microsoft's SentItems folder — the one
+-- signal an attacker who can only write headers cannot set. It is the sole
+-- input to the T1 predicate; direction stays a display field.
+--
+-- NOT NULL DEFAULT false: every existing row, and every record from a provider
+-- that attests nothing, is un-attested. Under-attestation suppresses a
+-- legitimate counterparty (recoverable, observable in system_log); over-
+-- attestation would create records for a forger, so false is the safe default.
+ALTER TABLE activity
+  ADD COLUMN counterparty_outbound_attested boolean NOT NULL DEFAULT false;
+
+-- Serves the T1 EXISTS lookup alone: it asks only whether an attested outbound
+-- activity to one address exists, so the index carries neither the un-attested
+-- rows (the overwhelming majority — every inbound mail) nor the rows with no
+-- counterparty at all.
+CREATE INDEX idx_activity_counterparty_outbound_attested
+  ON activity (workspace_id, counterparty_email)
+  WHERE counterparty_email IS NOT NULL AND counterparty_outbound_attested;

--- a/backend/migrations/core/0124_activity_counterparty_outbound_attested.up.sql
+++ b/backend/migrations/core/0124_activity_counterparty_outbound_attested.up.sql
@@ -7,10 +7,22 @@
 -- From:owner message delivered to the inbox would otherwise register as the
 -- owner's own correspondence and whitelist an arbitrary address past T2.
 --
--- This column carries the PROVIDER's attestation instead — Gmail's SENT label,
--- an IMAP \Sent special-use mailbox, Microsoft's SentItems folder — the one
--- signal an attacker who can only write headers cannot set. It is the sole
--- input to the T1 predicate; direction stays a display field.
+-- This column carries the PROVIDER's filing instead — Gmail's SENT label, an
+-- IMAP \Sent special-use mailbox, Microsoft's SentItems folder — the one signal
+-- an attacker who can only write headers cannot set. It is the sole input to
+-- the T1 predicate, and it is stamped only where the provider's filing and the
+-- message's own authorship agree: placement alone is not authorship either,
+-- since a server-side rule can file a stranger's mail into the sent container.
+--
+-- Three residuals this column does NOT close, recorded so nobody later reads
+-- them as bugs. (a) An owner-side rule that files spoofed own-domain mail into
+-- Sent Items or a \Sent mailbox defeats the conjunction on Graph and IMAP;
+-- Gmail is not reachable this way, since SENT is applied by the send path and
+-- filters cannot set it. (b) A forged Reply-To that induces one genuine reply
+-- attests an address the owner never chose — the reply really was sent, so no
+-- signal here can tell the difference. (c) The gate is single-shot by design:
+-- one attested message is sufficient evidence, and it is written before the
+-- predicate reads it, so an attacker never needs a history.
 --
 -- NOT NULL DEFAULT false: every existing row, and every record from a provider
 -- that attests nothing, is un-attested. Under-attestation suppresses a


### PR DESCRIPTION
ADR-0072/A118 phase 2b, slice 2 — the T1 correspondence-positive gate, on evidence a forger cannot write.

## Why

The tiered creation gate ran T2 (transactional/ESP suppression) with no T1 spare in front of it, so a known contact whose newsletter footer carries a `List-Unsubscribe` header was suppressed as bulk infrastructure. ADR-0072 §1 puts correspondence-positive **first** for exactly that reason, and calls the order load-bearing.

The naive version of this gate was pulled from phase 2a on a security review, and that finding is what shapes this PR. `activity.direction` is derived by string-comparing a message's `From` header against the mailbox owner. A spoofed `From:owner` message delivered into the synced inbox therefore reads as the owner's own correspondence — and if T1 honored it, that message would whitelist any address it names past T2 suppression.

## What

**The evidence is the provider's, never the message's.** New `activity.counterparty_outbound_attested` (migration `0124`, plus a partial index serving only the `EXISTS`) is stamped from what the provider vouches for:

| connector | signal | notes |
|---|---|---|
| Gmail | the `SENT` system label | read off the same `messages.get` response the body already needs — no extra call |
| IMAP | an RFC 6154 `\Sent` **special-use** mailbox | a mailbox merely *named* "Sent" attests nothing: that name is operator config text |
| Microsoft Graph | `parentFolderId` vs. the SentItems well-known folder | backfill only — the incremental delta is inbox-only, so it can attest nothing |

`mailmap.Parse` cannot set the attestation at all; only `AttestSentByOwner`, called by a connector holding an authenticated provider handle, can. A provider that attests nothing — or a LIST / folder probe that fails — attests `false` and is logged. Under-attestation suppresses a legitimate contact (recoverable, visible); over-attestation would create records for a forger.

**A spare is as visible as a suppression.** When T1 overrides a matched suppression rule, that lands its own `capture_correspondence_spared` breadcrumb carrying the rule that would have fired — this is the one path that turns registry-declared infrastructure into a record, so a wrong registry entry stays diagnosable.

## Tests

- `mailmap` — a message whose `From` claims the owner parses as `direction=outbound` **and still attests nothing**.
- `gmail` — `SENT` attests, `INBOX` does not.
- `imap` — a mailbox *named* `Sent` with no special-use attribute attests nothing through the full sync path (against the in-memory server); the attribute check itself covered both ways.
- `graph` — SentItems-filed mail attests, inbox-filed mail whose `From` claims the owner does not; an unresolved sent folder keeps the backfill running, unattested.
- integration (real Postgres) — writing to an address spares its later `List-Unsubscribe` mail from suppression **and** logs the spare; a forged `From:owner` neither attests nor whitelists the ESP address it names.

`make check-backend` green; full zero-skip `make test-integration` green.

## Upstream spec raise (flagged, not worked around)

ADR-0072 §1's ladder reads `T1 → ensure person+org NOW`. Taken literally, a free-mail address the owner has corresponded with would mint a "Gmail" organization — precisely the junk the ADR exists to prevent. This build keeps T3's free-mail org suppression under a T1 spare (**T1 overrides T2 only**), gated by a test. The ladder wording needs reconciling upstream (P3 — raised, not patched from here).

## Still open in 2b

The pending-counterparty ledger + deferred creation, the `capture_counterparty_verdict` job, the review queue, and noise hide-then-redact. Then phase 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a T1 correspondence gate that uses provider‑attested “sent by owner” evidence to spare known contacts before T2 suppression. T1 now outranks T2 and records a `capture_correspondence_spared` breadcrumb; includes migration 0124 adding `activity.counterparty_outbound_attested` and keeps free‑mail org suppression.

- **New Features**
  - New `activity.counterparty_outbound_attested` with a partial index; T1 overrides T2 and logs `capture_correspondence_spared`.
  - Attestation requires BOTH provider filing and outbound authorship; enforced via `connector.Counterparty.WithOwnerAttestation` (unexported) and guarded by `backend/attestationproducer_test.go` to keep minting in `capture/mailmap`.
  - Provider signals:
    - `gmail`: `messages.get` returns RFC822 plus a `SENT` label flag; carried through `mailmap.AttestSentByOwner`.
    - `imap`: attests only when the selected mailbox has RFC 6154 `\Sent` special‑use; a name‑only “Sent” is ignored; LIST failures stop and retry.
    - `graph`: backfill compares `parentFolderId` to `SentFolderID`; refuses a 2xx with no Sent Items id and refuses listed messages missing `parentFolderId`; delta is inbox‑only and unattested. Pages stop and retry when evidence can’t be resolved.

- **Bug Fixes**
  - `graph` backfill now counts a per‑message `ErrSkip` (deleted since listing or oversized MIME) as skipped and continues the page instead of failing and retrying it.

<sup>Written for commit ac802ff7f7ea7c1721d93b640a15bf460ccff8ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added provider-attested “sent by owner” correspondence detection across Gmail (SENT label), IMAP (\Sent), and Microsoft (Sent Items).
  * Attested outbound correspondence can spare eligible emails from suppression, and recorded activity now carries the attestation signal.
* **Bug Fixes**
  * Prevented forged sender headers and non-owner-authored “sent-filed” messages from receiving “sent by owner” credit.
  * Improved backfill/sync safety: progress stops when sent-folder evidence can’t be verified.
  * Added clearer system diagnostics for correspondence spare decisions.
* **Tests**
  * Expanded coverage for attestation, suppression/spare behavior, and sent-folder/backfill edge cases.
* **Documentation**
  * Updated status documentation for the landed slice and remaining open work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->