### PR TITLE
fix(overlay): govern the write-back path — audit, capability, and mode safety

### DIFF
--- a/backend/internal/compose/dispatcher.go
+++ b/backend/internal/compose/dispatcher.go
@@ -58,6 +58,12 @@ type Dispatcher struct {
 	overlay *overlay.Provider
 	pool    *pgxpool.Pool
 	now     func() time.Time
+	// queryMode reads one workspace's x_sor_mode from the workspace row.
+	// Injected for the same reason now is (T11: no real dependency in a
+	// cache-behaviour test) — it is the seam that lets a unit test prove the
+	// write path ignores the cache, which is precisely the property that
+	// cannot be observed by seeding the cache and reading the answer back.
+	queryMode func(context.Context, ids.UUID) (bool, error)
 
 	mu    sync.Mutex
 	cache map[ids.UUID]sorModeCacheEntry
@@ -83,10 +89,12 @@ func NewDispatcher(native *Provider, overlayProvider *overlay.Provider, pool *pg
 // package's own tests to exercise the TTL boundary without a
 // time.Sleep.
 func newDispatcherWithClock(native *Provider, overlayProvider *overlay.Provider, pool *pgxpool.Pool, now func() time.Time) *Dispatcher {
-	return &Dispatcher{
+	d := &Dispatcher{
 		native: native, overlay: overlayProvider, pool: pool, now: now,
 		cache: make(map[ids.UUID]sorModeCacheEntry),
 	}
+	d.queryMode = d.queryOverlayMode
+	return d
 }
 
 var _ datasource.SystemOfRecordProvider = (*Dispatcher)(nil)
@@ -105,6 +113,40 @@ func (d *Dispatcher) isOverlay(ctx context.Context) (bool, error) {
 		return false, nil
 	}
 	return d.overlayModeFor(ctx, wsID)
+}
+
+// isOverlayForWrite answers the same question as isOverlay, but never from
+// the cache: it reads workspace.x_sor_mode fresh and refreshes the cached
+// entry with what it found.
+//
+// A cached answer is fine for a read — serving one request's list from the
+// pre-flip system of record for a moment costs a stale screen, and the next
+// request corrects it. A WRITE has no such second chance. The cache is
+// per-process and Invalidate only reaches the process that committed the
+// flip, so a second api replica (or a worker) can still hold 'native' for
+// the rest of the TTL after a workspace connects. A mutation dispatched on
+// that stale answer commits to a native table no overlay read ever serves
+// and that never reaches the incumbent — silent divergence, not a stale
+// screen. So every mutation boundary pays one workspace-row read to be sure.
+//
+// This narrows the window to the request's own duration; it does not erase
+// it, because the mode read and the mutation cannot share a transaction (on
+// the overlay side the canonical write commits at the incumbent, outside
+// any database of ours). What closes the remainder is the disconnect fence
+// on the overlay side and this check on the native side.
+func (d *Dispatcher) isOverlayForWrite(ctx context.Context) (bool, error) {
+	wsID, ok := principal.WorkspaceID(ctx)
+	if !ok {
+		return false, nil
+	}
+	isOverlay, err := d.queryMode(ctx, wsID)
+	if err != nil {
+		return false, err
+	}
+	d.mu.Lock()
+	d.cache[wsID] = sorModeCacheEntry{overlay: isOverlay, expiresAt: d.now().Add(sorModeCacheTTL)}
+	d.mu.Unlock()
+	return isOverlay, nil
 }
 
 // Invalidate drops one workspace's cached x_sor_mode answer — called by
@@ -130,7 +172,7 @@ func (d *Dispatcher) overlayModeFor(ctx context.Context, wsID ids.UUID) (bool, e
 		return entry.overlay, nil
 	}
 
-	isOverlay, err := d.queryOverlayMode(ctx, wsID)
+	isOverlay, err := d.queryMode(ctx, wsID)
 	if err != nil {
 		return false, err
 	}
@@ -239,7 +281,7 @@ func (d *Dispatcher) StageSemantic(ctx context.Context, stageID ids.UUID) (strin
 // ctx's workspace.x_sor_mode; overlay has no write-back path yet and
 // always answers apperrors.ErrUnsupportedBySoR until branch 2 lands it.
 func (d *Dispatcher) Create(ctx context.Context, in datasource.CreateInput) (datasource.EntityRef, error) {
-	ov, err := d.isOverlay(ctx)
+	ov, err := d.isOverlayForWrite(ctx)
 	if err != nil {
 		return datasource.EntityRef{}, err
 	}
@@ -252,7 +294,7 @@ func (d *Dispatcher) Create(ctx context.Context, in datasource.CreateInput) (dat
 // Update dispatches to the overlay mirror or the native SoR modules per
 // ctx's workspace.x_sor_mode; see Create's doc on overlay's write gap.
 func (d *Dispatcher) Update(ctx context.Context, in datasource.UpdateInput) (datasource.EntityRef, error) {
-	ov, err := d.isOverlay(ctx)
+	ov, err := d.isOverlayForWrite(ctx)
 	if err != nil {
 		return datasource.EntityRef{}, err
 	}
@@ -266,7 +308,7 @@ func (d *Dispatcher) Update(ctx context.Context, in datasource.UpdateInput) (dat
 // modules per ctx's workspace.x_sor_mode; see Create's doc on overlay's
 // write gap.
 func (d *Dispatcher) AdvanceDeal(ctx context.Context, in datasource.AdvanceDealInput) (datasource.EntityRef, error) {
-	ov, err := d.isOverlay(ctx)
+	ov, err := d.isOverlayForWrite(ctx)
 	if err != nil {
 		return datasource.EntityRef{}, err
 	}
@@ -280,7 +322,7 @@ func (d *Dispatcher) AdvanceDeal(ctx context.Context, in datasource.AdvanceDealI
 // per ctx's workspace.x_sor_mode; see Create's doc on overlay's write
 // gap.
 func (d *Dispatcher) Archive(ctx context.Context, ref datasource.EntityRef) (datasource.EntityRef, error) {
-	ov, err := d.isOverlay(ctx)
+	ov, err := d.isOverlayForWrite(ctx)
 	if err != nil {
 		return datasource.EntityRef{}, err
 	}
@@ -293,7 +335,7 @@ func (d *Dispatcher) Archive(ctx context.Context, ref datasource.EntityRef) (dat
 // Merge dispatches to the overlay mirror or the native SoR modules per
 // ctx's workspace.x_sor_mode; see Create's doc on overlay's write gap.
 func (d *Dispatcher) Merge(ctx context.Context, in datasource.MergeInput) (datasource.EntityRef, error) {
-	ov, err := d.isOverlay(ctx)
+	ov, err := d.isOverlayForWrite(ctx)
 	if err != nil {
 		return datasource.EntityRef{}, err
 	}
@@ -307,7 +349,7 @@ func (d *Dispatcher) Merge(ctx context.Context, in datasource.MergeInput) (datas
 // modules per ctx's workspace.x_sor_mode; see Create's doc on overlay's
 // write gap.
 func (d *Dispatcher) PromoteLead(ctx context.Context, id ids.UUID, trigger string, evidenceNote *string) (datasource.EntityRef, bool, error) {
-	ov, err := d.isOverlay(ctx)
+	ov, err := d.isOverlayForWrite(ctx)
 	if err != nil {
 		return datasource.EntityRef{}, false, err
 	}

--- a/backend/internal/compose/dispatcher.go
+++ b/backend/internal/compose/dispatcher.go
@@ -301,6 +301,19 @@ func (d *Dispatcher) Update(ctx context.Context, in datasource.UpdateInput) (dat
 	if err != nil {
 		return datasource.EntityRef{}, err
 	}
+	return d.updateInMode(ctx, ov, in)
+}
+
+// updateInMode is Update for a caller that has ALREADY paid the fresh
+// isOverlayForWrite read for this request — the REST write shadow, which must
+// resolve the mode itself to choose between the native module handler and the
+// overlay path before it can dispatch at all.
+//
+// Without it that shadow would read workspace.x_sor_mode twice per mutation:
+// once to route, once inside this dispatch. Both reads are fresh, so the
+// second is not a correctness gain, only a second round trip — and
+// isOverlayForWrite's own contract is that a mutation boundary pays ONE.
+func (d *Dispatcher) updateInMode(ctx context.Context, ov bool, in datasource.UpdateInput) (datasource.EntityRef, error) {
 	if ov {
 		return d.overlay.Update(ctx, in)
 	}
@@ -329,6 +342,12 @@ func (d *Dispatcher) Archive(ctx context.Context, ref datasource.EntityRef) (dat
 	if err != nil {
 		return datasource.EntityRef{}, err
 	}
+	return d.archiveInMode(ctx, ov, ref)
+}
+
+// archiveInMode is Archive for a caller that already resolved the mode this
+// request — see updateInMode.
+func (d *Dispatcher) archiveInMode(ctx context.Context, ov bool, ref datasource.EntityRef) (datasource.EntityRef, error) {
 	if ov {
 		return d.overlay.Archive(ctx, ref)
 	}

--- a/backend/internal/compose/dispatcher.go
+++ b/backend/internal/compose/dispatcher.go
@@ -278,8 +278,11 @@ func (d *Dispatcher) StageSemantic(ctx context.Context, stageID ids.UUID) (strin
 }
 
 // Create dispatches to the overlay mirror or the native SoR modules per
-// ctx's workspace.x_sor_mode; overlay has no write-back path yet and
-// always answers apperrors.ErrUnsupportedBySoR until branch 2 lands it.
+// ctx's workspace.x_sor_mode. The mutating verbs here — and only these —
+// resolve the mode UNCACHED (isOverlayForWrite); see its doc for why a write
+// cannot take the cached answer a read happily takes. Overlay serves update
+// and archive; every other write verb it declares unsupported and refuses at
+// the provider (overlay.SupportsWrite).
 func (d *Dispatcher) Create(ctx context.Context, in datasource.CreateInput) (datasource.EntityRef, error) {
 	ov, err := d.isOverlayForWrite(ctx)
 	if err != nil {
@@ -292,7 +295,7 @@ func (d *Dispatcher) Create(ctx context.Context, in datasource.CreateInput) (dat
 }
 
 // Update dispatches to the overlay mirror or the native SoR modules per
-// ctx's workspace.x_sor_mode; see Create's doc on overlay's write gap.
+// ctx's workspace.x_sor_mode; see Create's doc on the uncached mode read.
 func (d *Dispatcher) Update(ctx context.Context, in datasource.UpdateInput) (datasource.EntityRef, error) {
 	ov, err := d.isOverlayForWrite(ctx)
 	if err != nil {
@@ -305,8 +308,8 @@ func (d *Dispatcher) Update(ctx context.Context, in datasource.UpdateInput) (dat
 }
 
 // AdvanceDeal dispatches to the overlay mirror or the native SoR
-// modules per ctx's workspace.x_sor_mode; see Create's doc on overlay's
-// write gap.
+// modules per ctx's workspace.x_sor_mode; see Create's doc on the uncached
+// mode read.
 func (d *Dispatcher) AdvanceDeal(ctx context.Context, in datasource.AdvanceDealInput) (datasource.EntityRef, error) {
 	ov, err := d.isOverlayForWrite(ctx)
 	if err != nil {
@@ -333,7 +336,7 @@ func (d *Dispatcher) Archive(ctx context.Context, ref datasource.EntityRef) (dat
 }
 
 // Merge dispatches to the overlay mirror or the native SoR modules per
-// ctx's workspace.x_sor_mode; see Create's doc on overlay's write gap.
+// ctx's workspace.x_sor_mode; see Create's doc on the uncached mode read.
 func (d *Dispatcher) Merge(ctx context.Context, in datasource.MergeInput) (datasource.EntityRef, error) {
 	ov, err := d.isOverlayForWrite(ctx)
 	if err != nil {
@@ -346,8 +349,8 @@ func (d *Dispatcher) Merge(ctx context.Context, in datasource.MergeInput) (datas
 }
 
 // PromoteLead dispatches to the overlay mirror or the native SoR
-// modules per ctx's workspace.x_sor_mode; see Create's doc on overlay's
-// write gap.
+// modules per ctx's workspace.x_sor_mode; see Create's doc on the uncached
+// mode read.
 func (d *Dispatcher) PromoteLead(ctx context.Context, id ids.UUID, trigger string, evidenceNote *string) (datasource.EntityRef, bool, error) {
 	ov, err := d.isOverlayForWrite(ctx)
 	if err != nil {

--- a/backend/internal/compose/dispatcher_test.go
+++ b/backend/internal/compose/dispatcher_test.go
@@ -42,7 +42,7 @@ func overlaySeededDispatcher(wsID ids.UUID, now time.Time) *Dispatcher {
 	return d
 }
 
-func TestDispatcherRoutesEveryVerbToTheOverlayProviderWhenCached(t *testing.T) {
+func TestDispatcherRoutesEveryReadVerbToTheOverlayProviderWhenCached(t *testing.T) {
 	wsID := ids.NewV7()
 	now := dispatcherFixedNow
 	d := overlaySeededDispatcher(wsID, now)
@@ -67,28 +67,9 @@ func TestDispatcherRoutesEveryVerbToTheOverlayProviderWhenCached(t *testing.T) {
 	if _, _, err := d.StageSemantic(ctx, ids.NewV7()); err == nil {
 		t.Error("StageSemantic: want ErrUnsupportedBySoR, got nil")
 	}
-	// Create/Update/Archive are supported write-back verbs now, so their
-	// error here is the overlay provider's own (object-RBAC/nil-store), not
-	// ErrUnsupportedBySoR — the assertion still proves the verb routed to the
-	// overlay provider rather than the (nil) native one.
-	if _, err := d.Create(ctx, datasource.CreateInput{EntityType: datasource.EntityPerson}); err == nil {
-		t.Error("Create: want the overlay provider's error, got nil")
-	}
-	if _, err := d.Update(ctx, datasource.UpdateInput{Ref: ref}); err == nil {
-		t.Error("Update: want the overlay provider's error, got nil")
-	}
-	if _, err := d.AdvanceDeal(ctx, datasource.AdvanceDealInput{}); err == nil {
-		t.Error("AdvanceDeal: want ErrUnsupportedBySoR, got nil")
-	}
-	if _, err := d.Archive(ctx, ref); err == nil {
-		t.Error("Archive: want the overlay provider's error, got nil")
-	}
-	if _, err := d.Merge(ctx, datasource.MergeInput{Type: datasource.EntityPerson}); err == nil {
-		t.Error("Merge: want ErrUnsupportedBySoR, got nil")
-	}
-	if _, _, err := d.PromoteLead(ctx, ids.NewV7(), "manual", nil); err == nil {
-		t.Error("PromoteLead: want ErrUnsupportedBySoR, got nil")
-	}
+	// The WRITE verbs are deliberately absent here: they never consult this
+	// cache (isOverlayForWrite), so seeding it would prove nothing about where
+	// they route. TestDispatcherWriteVerbsIgnoreAStaleCachedMode covers them.
 	if _, err := d.Freshness(ctx, ref); err == nil {
 		t.Error("Freshness: want the overlay provider's nil-mirror-store error, got nil")
 	}

--- a/backend/internal/compose/dispatcherwritemode_test.go
+++ b/backend/internal/compose/dispatcherwritemode_test.go
@@ -94,6 +94,40 @@ func TestDispatcherWriteVerbsIgnoreAStaleCachedMode(t *testing.T) {
 	}
 }
 
+// TestOverlayWriteShadowResolvesTheModeOnce pins isOverlayForWrite's own
+// contract — a mutation boundary pays ONE workspace-row read.
+//
+// The REST write shadow has to resolve the mode itself to choose between the
+// native module handler and the overlay path, so a shadow that then called
+// the exported Dispatcher.Update would read the same row a second time. Both
+// reads are fresh, so the second buys no correctness — it is a round trip per
+// write, and it makes the doc above false.
+func TestOverlayWriteShadowResolvesTheModeOnce(t *testing.T) {
+	wsID := ids.NewV7()
+	d, calls := cachedModeDispatcher(wsID, false /* cached: native */, true /* stored: overlay */)
+	ctx := principal.WithWorkspaceID(context.Background(), wsID)
+	ref := datasource.EntityRef{Type: datasource.EntityPerson, ID: ids.NewV7()}
+
+	// What the shadow does: resolve once, then dispatch with that answer.
+	ov, err := d.isOverlayForWrite(ctx)
+	if err != nil {
+		t.Fatalf("resolving the write mode: %v", err)
+	}
+	if !ov {
+		t.Fatal("the workspace row says overlay; the write mode resolved native")
+	}
+	if _, err := d.updateInMode(ctx, ov, datasource.UpdateInput{Ref: ref}); err == nil {
+		t.Error("updateInMode: want the overlay provider's own error, got nil")
+	}
+	if _, err := d.archiveInMode(ctx, ov, ref); err == nil {
+		t.Error("archiveInMode: want the overlay provider's own error, got nil")
+	}
+
+	if *calls != 1 {
+		t.Errorf("the shadow's update+archive path read workspace.x_sor_mode %d times, want exactly 1", *calls)
+	}
+}
+
 // TestDispatcherReadVerbsStillUseTheCachedMode is the other half of the
 // trade: reads keep the cache, because paying a workspace-row read on every
 // Read/Search is the cost the cache exists to avoid, and a read served from

--- a/backend/internal/compose/dispatcherwritemode_test.go
+++ b/backend/internal/compose/dispatcherwritemode_test.go
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/modules/overlay"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+)
+
+// cachedModeDispatcher builds a Dispatcher whose cache already answers
+// `cached` for wsID while the workspace ROW (what queryMode reads) answers
+// `stored`. Passing cached=false with stored=true reproduces the second api
+// replica in the connect race: the process that committed the flip
+// invalidated only its OWN cache, so this one still holds the pre-flip mode.
+//
+// queryMode counts its calls, so a test can assert not just where a verb
+// routed but whether the mode was actually re-read or served from the entry
+// seeded below. The native provider is left nil: a verb that wrongly routes
+// native panics rather than quietly passing.
+func cachedModeDispatcher(wsID ids.UUID, cached, stored bool) (*Dispatcher, *int) {
+	calls := 0
+	now := dispatcherFixedNow
+	d := newDispatcherWithClock(nil, overlay.NewProvider(nil, nil), nil, func() time.Time { return now })
+	d.queryMode = func(context.Context, ids.UUID) (bool, error) {
+		calls++
+		return stored, nil
+	}
+	d.cache[wsID] = sorModeCacheEntry{overlay: cached, expiresAt: now.Add(time.Hour)}
+	return d, &calls
+}
+
+// TestDispatcherWriteVerbsIgnoreAStaleCachedMode is the regression gate for
+// the silent-divergence window: an api replica holding a pre-flip 'native'
+// answer must not route a MUTATION to the native modules after the workspace
+// has been connected to an incumbent elsewhere.
+//
+// The damaging direction is native → overlay. A mutation taking the stale
+// 'native' branch commits to a native table that no overlay read ever serves
+// and that never reaches the incumbent: the write appears to succeed, the
+// record never changes, and nothing anywhere reports a failure. Cache TTL
+// alone cannot close it, because Invalidate reaches only the process that
+// committed the flip.
+//
+// The native provider here is nil, so a verb that wrongly routed native would
+// panic rather than quietly pass — the assertion is that none of them do.
+func TestDispatcherWriteVerbsIgnoreAStaleCachedMode(t *testing.T) {
+	wsID := ids.NewV7()
+	d, calls := cachedModeDispatcher(wsID, false /* cached: native */, true /* stored: overlay */)
+	ctx := principal.WithWorkspaceID(context.Background(), wsID)
+	ref := datasource.EntityRef{Type: datasource.EntityPerson, ID: ids.NewV7()}
+
+	writes := map[string]func() error{
+		"Create": func() error {
+			_, err := d.Create(ctx, datasource.CreateInput{EntityType: datasource.EntityPerson})
+			return err
+		},
+		"Update": func() error {
+			_, err := d.Update(ctx, datasource.UpdateInput{Ref: ref})
+			return err
+		},
+		"Archive": func() error {
+			_, err := d.Archive(ctx, ref)
+			return err
+		},
+		"AdvanceDeal": func() error {
+			_, err := d.AdvanceDeal(ctx, datasource.AdvanceDealInput{})
+			return err
+		},
+		"Merge": func() error {
+			_, err := d.Merge(ctx, datasource.MergeInput{Type: datasource.EntityPerson})
+			return err
+		},
+		"PromoteLead": func() error {
+			_, _, err := d.PromoteLead(ctx, ids.NewV7(), "manual", nil)
+			return err
+		},
+	}
+
+	for name, call := range writes {
+		before := *calls
+		if err := call(); err == nil {
+			t.Errorf("%s: want the overlay provider's own error, got nil — the verb did not reach a provider", name)
+		}
+		if *calls == before {
+			t.Errorf("%s: answered from the cached mode; a mutation must re-read workspace.x_sor_mode", name)
+		}
+	}
+}
+
+// TestDispatcherReadVerbsStillUseTheCachedMode is the other half of the
+// trade: reads keep the cache, because paying a workspace-row read on every
+// Read/Search is the cost the cache exists to avoid, and a read served from
+// the pre-flip mode costs a stale screen that the next request corrects —
+// not a divergent write.
+func TestDispatcherReadVerbsStillUseTheCachedMode(t *testing.T) {
+	wsID := ids.NewV7()
+	d, calls := cachedModeDispatcher(wsID, true /* cached: overlay */, true /* stored: overlay */)
+	ctx := principal.WithWorkspaceID(context.Background(), wsID)
+
+	if _, err := d.Read(ctx, datasource.EntityRef{Type: datasource.EntityPerson, ID: ids.NewV7()}); err == nil {
+		t.Fatal("Read: want the overlay provider's nil-mirror-store error, got nil")
+	}
+	if _, err := d.Search(ctx, datasource.SearchQuery{EntityTypes: []datasource.EntityType{datasource.EntityPerson}}); err == nil {
+		t.Fatal("Search: want the overlay provider's nil-mirror-store error, got nil")
+	}
+	if *calls != 0 {
+		t.Errorf("cached reads re-queried workspace.x_sor_mode %d time(s); avoiding that on every read is the whole reason the cache exists", *calls)
+	}
+}

--- a/backend/internal/compose/integration/overlay_acceptance_test.go
+++ b/backend/internal/compose/integration/overlay_acceptance_test.go
@@ -430,20 +430,28 @@ func TestAcceptance_AC_OV_2_BoundedEquivalence_ReadSubset(t *testing.T) {
 		}
 	})
 
-	t.Run("Create + Update + Archive are supported write-back verbs, not declared unsupported_by_sor", func(t *testing.T) {
-		// Write-back is incumbent-first (OVA-MAP-W); these verbs must NOT
-		// answer the unsupported sentinel. This overlayProvider is built
-		// without a write incumbent resolver, so they surface a clear
-		// configuration/permission error instead — anything but
-		// ErrUnsupportedBySoR proves they are recognized, supported verbs.
-		if _, err := overlayProvider.Create(ctx, datasource.CreateInput{EntityType: datasource.EntityPerson}); errors.Is(err, apperrors.ErrUnsupportedBySoR) {
-			t.Errorf("Create must be a supported write-back verb, got ErrUnsupportedBySoR")
-		}
+	t.Run("write-back verbs answer their declared capability, never a silent break", func(t *testing.T) {
+		// AC-OV-2's bounded equivalence: each op either passes identically or
+		// returns a DECLARED unsupported_by_sor — the provider's answer must
+		// match SupportsWrite exactly, whichever way that falls.
+		//
+		// This overlayProvider is built without a write incumbent resolver, so
+		// a verb it DOES serve surfaces a clear configuration error instead —
+		// anything but ErrUnsupportedBySoR proves it is a recognized verb.
 		if _, err := overlayProvider.Update(ctx, datasource.UpdateInput{Ref: datasource.EntityRef{Type: datasource.EntityPerson}}); errors.Is(err, apperrors.ErrUnsupportedBySoR) {
 			t.Errorf("Update must be a supported write-back verb, got ErrUnsupportedBySoR")
 		}
 		if _, err := overlayProvider.Archive(ctx, datasource.EntityRef{Type: datasource.EntityPerson}); errors.Is(err, apperrors.ErrUnsupportedBySoR) {
 			t.Errorf("Archive must be a supported write-back verb, got ErrUnsupportedBySoR")
+		}
+		// Create is declared unsupported for every type (SupportsWrite): the
+		// write mapping leaves owner_id read-only, so a created incumbent
+		// record would be unowned and the NULL-OWNER rule would hide it from
+		// everyone including its author. The DECLARED refusal is the correct
+		// bounded-equivalence answer, and it must hold at the provider — not
+		// only at the REST guard, which the agent and automation seams bypass.
+		if _, err := overlayProvider.Create(ctx, datasource.CreateInput{EntityType: datasource.EntityPerson}); !errors.Is(err, apperrors.ErrUnsupportedBySoR) {
+			t.Errorf("Create = %v, want the declared ErrUnsupportedBySoR", err)
 		}
 	})
 }

--- a/backend/internal/compose/integration/overlay_write_audit_integration_test.go
+++ b/backend/internal/compose/integration/overlay_write_audit_integration_test.go
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The write-back GOVERNANCE story, proven over the real HTTP surface and a
+// real migrated Postgres: a human write against a workspace in overlay mode
+// leaves the same attributable trail a native write leaves.
+//
+// This is the repo's non-negotiable write shape applied to a system of
+// record we do not own. The canonical row lives at the incumbent, so the
+// literal "domain row + audit_log + event_outbox in ONE transaction" is not
+// available — but everything that IS local commits together, and a mutation
+// never lands with no record of who made it. Without that, the overlay path
+// would be the one mutation surface in this build where "who changed this
+// record" has no answer, and the audit screen and exports could not replay
+// what happened.
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+)
+
+// auditRow is one audit_log row's governance-relevant columns.
+type auditRow struct {
+	action     string
+	entityType string
+	actorType  string
+	actorID    string
+	evidence   []byte
+}
+
+// auditRowsFor reads every audit_log row recorded for one entity, newest
+// last. It reads through the owner pool deliberately: the assertion is that
+// the row EXISTS and names the right principal, which must not depend on the
+// reader's own row scope.
+func auditRowsFor(t *testing.T, e *env, entityType, entityID string) []auditRow {
+	t.Helper()
+	rows, err := e.owner.Query(context.Background(), `
+		SELECT action, entity_type, actor_type, actor_id, coalesce(evidence, '{}'::jsonb)
+		  FROM audit_log
+		 WHERE entity_type = $1 AND entity_id = $2
+		 ORDER BY id`, entityType, entityID)
+	if err != nil {
+		t.Fatalf("reading audit_log for %s/%s: %v", entityType, entityID, err)
+	}
+	defer rows.Close()
+
+	var out []auditRow
+	for rows.Next() {
+		var r auditRow
+		if err := rows.Scan(&r.action, &r.entityType, &r.actorType, &r.actorID, &r.evidence); err != nil {
+			t.Fatalf("scanning an audit_log row: %v", err)
+		}
+		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterating audit_log rows: %v", err)
+	}
+	return out
+}
+
+// outboxTypesFor reads the event types staged for one entity.
+func outboxTypesFor(t *testing.T, e *env, entityType, entityID string) []string {
+	t.Helper()
+	rows, err := e.owner.Query(context.Background(), `
+		SELECT envelope->>'type'
+		  FROM event_outbox
+		 WHERE envelope->'entity'->>'type' = $1 AND envelope->'entity'->>'id' = $2
+		 ORDER BY created_at, id`, entityType, entityID)
+	if err != nil {
+		t.Fatalf("reading event_outbox for %s/%s: %v", entityType, entityID, err)
+	}
+	defer rows.Close()
+
+	var out []string
+	for rows.Next() {
+		var eventType string
+		if err := rows.Scan(&eventType); err != nil {
+			t.Fatalf("scanning an event_outbox row: %v", err)
+		}
+		out = append(out, eventType)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterating event_outbox rows: %v", err)
+	}
+	return out
+}
+
+// TestOverlayUpdateWritesTheAuditTrail proves an ordinary REST update in
+// overlay mode records the mutation: an audit_log row attributed to the
+// authenticated human, and the same public event a native update emits.
+func TestOverlayUpdateWritesTheAuditTrail(t *testing.T) {
+	e := setupOverlayWrite(t)
+	e.seed(t, "deal", "9201", map[string]any{"name": "Acme Renewal", "currency": "USD"})
+	id := firstListedID(t, e.env, "/v1/deals")
+
+	var deal crmcontracts.Deal
+	if status := e.call(t, "PATCH", "/v1/deals/"+id, anyMap{"name": "Acme Renewal — Q3"}, nil, &deal); status != http.StatusOK {
+		t.Fatalf("PATCH /v1/deals/%s = %d", id, status)
+	}
+
+	audits := auditRowsFor(t, e.env, "deal", id)
+	if len(audits) != 1 {
+		t.Fatalf("audit_log rows for the updated deal = %d, want exactly 1 — an overlay write must leave the same trail a native write leaves", len(audits))
+	}
+	got := audits[0]
+	if got.action != "update" {
+		t.Errorf("audit action = %q, want %q", got.action, "update")
+	}
+	if got.actorType != "human" {
+		t.Errorf("audit actor_type = %q, want %q — the write must be attributed to the authenticated principal, never to a connector or the mirror", got.actorType, "human")
+	}
+	if got.actorID == "" {
+		t.Error("audit actor_id is empty — the row cannot answer who made the change")
+	}
+	// The incumbent's own record id rides evidence, not the field images:
+	// it is context ABOUT the mutation, and a field-history projection
+	// reading it out of before/after would report a change that never
+	// happened on the record.
+	if !containsJSONKey(got.evidence, "external_id") {
+		t.Errorf("audit evidence = %s, want it to name the incumbent record the write landed on", got.evidence)
+	}
+
+	if types := outboxTypesFor(t, e.env, "deal", id); len(types) != 1 || types[0] != "deal.updated" {
+		t.Errorf("staged events = %v, want exactly [deal.updated] — a subscriber must not need to know which system of record served the write", types)
+	}
+}
+
+// TestOverlayArchiveWritesTheAuditTrail proves the archive verb records the
+// mutation too. It matters more here than for update, not less: the record
+// is destroyed in the customer's own CRM, and the mirror purge that follows
+// writes only a derived-cache health event.
+func TestOverlayArchiveWritesTheAuditTrail(t *testing.T) {
+	e := setupOverlayWrite(t)
+	e.seed(t, "person", "9202", map[string]any{"first_name": "Ada", "last_name": "Overlay"})
+	id := firstListedID(t, e.env, "/v1/people")
+
+	if status := e.call(t, "DELETE", "/v1/people/"+id, nil, nil, nil); status != http.StatusOK {
+		t.Fatalf("DELETE /v1/people/%s = %d", id, status)
+	}
+
+	audits := auditRowsFor(t, e.env, "person", id)
+	if len(audits) != 1 {
+		t.Fatalf("audit_log rows for the archived person = %d, want exactly 1 — a record removed from the customer's CRM with no audit row has no answer to who removed it", len(audits))
+	}
+	if audits[0].action != "archive" {
+		t.Errorf("audit action = %q, want %q", audits[0].action, "archive")
+	}
+	if audits[0].actorType != "human" {
+		t.Errorf("audit actor_type = %q, want %q", audits[0].actorType, "human")
+	}
+
+	types := outboxTypesFor(t, e.env, "person", id)
+	if !containsString(types, "person.archived") {
+		t.Errorf("staged events = %v, want them to include person.archived", types)
+	}
+}
+
+// TestOverlayRefusedWriteLeavesNoAuditTrail is the other half of the
+// invariant: the trail records what HAPPENED. A write the provider refuses
+// never reached the incumbent, so it must leave no audit row claiming it
+// did — an audit log that records attempts as changes is worse than none.
+func TestOverlayRefusedWriteLeavesNoAuditTrail(t *testing.T) {
+	e := setupOverlayWrite(t)
+	e.seed(t, "lead", "9203", map[string]any{"full_name": "Refused Lead"})
+	id := firstListedID(t, e.env, "/v1/leads")
+
+	// Archive is not a verb the mirror serves for a lead.
+	if status := e.call(t, "DELETE", "/v1/leads/"+id, nil, nil, nil); status != http.StatusUnprocessableEntity {
+		t.Fatalf("DELETE /v1/leads/%s = %d, want 422 unsupported_by_sor", id, status)
+	}
+	if audits := auditRowsFor(t, e.env, "lead", id); len(audits) != 0 {
+		t.Errorf("audit_log rows after a refused archive = %d, want 0 — a refusal is not a mutation", len(audits))
+	}
+}
+
+// containsJSONKey reports whether a jsonb column names key at its top level.
+func containsJSONKey(raw []byte, key string) bool {
+	var obj map[string]any
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return false
+	}
+	_, ok := obj[key]
+	return ok
+}
+
+// containsString reports whether values contains want.
+func containsString(values []string, want string) bool {
+	for _, v := range values {
+		if v == want {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/compose/integration/overlay_write_audit_integration_test.go
+++ b/backend/internal/compose/integration/overlay_write_audit_integration_test.go
@@ -106,6 +106,13 @@ func TestOverlayUpdateWritesTheAuditTrail(t *testing.T) {
 		t.Fatalf("PATCH /v1/deals/%s = %d", id, status)
 	}
 
+	// captured_by is required on every entity schema. An overlay-served body
+	// that omits it is schema-invalid, and a validating client rejects it —
+	// so the write response is as good a place to pin it as the read.
+	if deal.CapturedBy == nil || *deal.CapturedBy == "" {
+		t.Errorf("overlay deal body captured_by = %v, want the required provenance value", deal.CapturedBy)
+	}
+
 	audits := auditRowsFor(t, e.env, "deal", id)
 	if len(audits) != 1 {
 		t.Fatalf("audit_log rows for the updated deal = %d, want exactly 1 — an overlay write must leave the same trail a native write leaves", len(audits))

--- a/backend/internal/compose/integration/overlay_write_shadow_integration_test.go
+++ b/backend/internal/compose/integration/overlay_write_shadow_integration_test.go
@@ -180,6 +180,11 @@ func TestOverlayUpdateDealWritesBackAndReturnsTheMirroredRow(t *testing.T) {
 // the contract's own 200-with-body (never a bare 204 for a domain row,
 // matching every native ArchivePerson/ArchiveOrganization/ArchiveDeal), and
 // the incumbent — not just the mirror — loses the record.
+//
+// The body must describe the record as it is AFTER the call: the contract
+// defines the archive response as one that "now carries a non-null
+// archived_at", and a body reporting the record as live is a write reported
+// as not having happened.
 func TestOverlayArchivePersonWritesBack(t *testing.T) {
 	e := setupOverlayWrite(t)
 	e.seed(t, "person", "9101", map[string]any{"first_name": "Ada", "last_name": "Overlay"})
@@ -192,10 +197,19 @@ func TestOverlayArchivePersonWritesBack(t *testing.T) {
 	if person.FullName != "Ada Overlay" {
 		t.Fatalf("archived person body FullName = %q, want the pre-archive %q", person.FullName, "Ada Overlay")
 	}
+	if person.ArchivedAt == nil {
+		t.Fatal("archived person body carries archived_at: null — the response claims a record the incumbent just archived is still live")
+	}
 
 	if _, err := e.fake.Get(context.Background(), "person", "9101"); err == nil {
 		t.Fatal("the fake incumbent still holds the archived person — the archive never reached the seam")
 	}
+	// The contract also promises an archived row stays fetchable by id. It is
+	// not, on this path: an incumbent archive stops serving the object, so the
+	// mirror purges rather than flags it. Pinned as the KNOWN divergence it is
+	// — the upstream question is what archive means when the system of record
+	// is an incumbent, and this assertion is what will fail loudly the day
+	// that answer lands.
 	if status := e.call(t, "GET", "/v1/people/"+id, nil, nil, nil); status != http.StatusNotFound {
 		t.Fatalf("GET the archived person = %d, want 404 (the mirror row is purged by the archive itself)", status)
 	}

--- a/backend/internal/compose/overlayread.go
+++ b/backend/internal/compose/overlayread.go
@@ -303,18 +303,21 @@ var overlayMirroredTypes = func() map[string]bool {
 	return set
 }()
 
-// overlaySearchDefaultLimit caps an overlay search page when the request
-// names no limit — the contract's documented default page size.
-const overlaySearchDefaultLimit = 25
+// overlaySearchDefaultLimit sizes an overlay search page when the request
+// names no limit — the shared Limit parameter's own default (crm.yaml's
+// components.parameters.Limit: default 50), which /search refs like every
+// other paged op. Overlay pages the same way native does or the two modes
+// answer different pages for one query.
+const overlaySearchDefaultLimit = 50
 
-// overlaySearchMaxLimit is the contract's SearchParams ceiling (crm.yaml:
-// limit maximum 100). A bound integer that slips past request validation
-// (a negative or oversized ?limit=) must never reach a slice capacity, so
-// the value is clamped here before it sizes any allocation.
-const overlaySearchMaxLimit = 100
+// overlaySearchMaxLimit is that same shared parameter's ceiling (maximum
+// 200). A bound integer that slips past request validation (a negative or
+// oversized ?limit=) must never reach a slice capacity, so the value is
+// clamped here before it sizes any allocation.
+const overlaySearchMaxLimit = 200
 
-// clampOverlaySearchLimit maps a caller-supplied limit onto the contract's
-// 1..100 range so it is safe to use as an allocation size.
+// clampOverlaySearchLimit maps a caller-supplied limit onto the shared
+// parameter's 1..200 range so it is safe to use as an allocation size.
 func clampOverlaySearchLimit(v int) int {
 	switch {
 	case v < 1:

--- a/backend/internal/compose/overlayread_test.go
+++ b/backend/internal/compose/overlayread_test.go
@@ -7,8 +7,9 @@ import "testing"
 
 // TestClampOverlaySearchLimit pins the guard on the overlay search limit:
 // a bound integer that slips past request validation (a negative or an
-// oversized ?limit=) must never reach a slice capacity, so it is clamped
-// to the contract's 1..100 range before it sizes any allocation.
+// oversized ?limit=) must never reach a slice capacity, so it is clamped to
+// the SHARED Limit parameter's 1..200 range — the same range /search
+// declares in native mode — before it sizes any allocation.
 func TestClampOverlaySearchLimit(t *testing.T) {
 	cases := []struct{ in, want int }{
 		{-1, 1},
@@ -16,7 +17,8 @@ func TestClampOverlaySearchLimit(t *testing.T) {
 		{1, 1},
 		{25, 25},
 		{100, 100},
-		{101, overlaySearchMaxLimit},
+		{200, 200},
+		{201, overlaySearchMaxLimit},
 		{1 << 30, overlaySearchMaxLimit},
 	}
 	for _, c := range cases {

--- a/backend/internal/compose/overlaywire.go
+++ b/backend/internal/compose/overlaywire.go
@@ -41,6 +41,24 @@ const overlaySource = "overlay"
 // fabricated one would be worse than a labeled absence.
 const overlayUnnamed = "Unnamed"
 
+// overlayCapturedByValue is the Provenance captured_by every mirror-assembled
+// wire struct carries. captured_by is a REQUIRED field on all five entity
+// schemas, so omitting it made every overlay-served body schema-invalid.
+//
+// The vocabulary is `human:<uuid> | agent:<id> | connector:<name>`, and the
+// producer of a mirrored row is neither a human nor an agent of ours — it is
+// the incumbent mirror. The name stays "overlay" rather than the specific
+// incumbent because a mirror record carries no incumbent identity for the
+// mapper to read, and naming one it cannot verify would be a guess.
+const overlayCapturedByValue = "connector:overlay"
+
+// overlayCapturedBy yields a fresh pointer per call, so no wire struct can
+// alias (or mutate) another's provenance.
+func overlayCapturedBy() *string {
+	v := overlayCapturedByValue
+	return &v
+}
+
 // overlayRecordFields decodes a mirror record's canonical jsonb payload.
 // A record the overlay provider served always carries an object payload;
 // a decode failure is a real defect (the provider marshaled this very
@@ -90,6 +108,7 @@ func overlayWirePerson(ctx context.Context, rec datasource.Record) (crmcontracts
 		Id:          openapi_types.UUID(rec.Ref.ID),
 		WorkspaceId: wsID,
 		Source:      overlaySource,
+		CapturedBy:  overlayCapturedBy(),
 		FullName:    fullName,
 		FirstName:   fieldStringPtr(fields, "first_name"),
 		LastName:    fieldStringPtr(fields, "last_name"),
@@ -122,6 +141,7 @@ func overlayWireOrganization(ctx context.Context, rec datasource.Record) (crmcon
 		Id:          openapi_types.UUID(rec.Ref.ID),
 		WorkspaceId: wsID,
 		Source:      overlaySource,
+		CapturedBy:  overlayCapturedBy(),
 		DisplayName: displayName,
 		Industry:    fieldStringPtr(fields, "industry"),
 		CreatedAt:   syncedAt,
@@ -161,6 +181,7 @@ func overlayWireDeal(ctx context.Context, rec datasource.Record) (crmcontracts.D
 		Id:          openapi_types.UUID(rec.Ref.ID),
 		WorkspaceId: wsID,
 		Source:      overlaySource,
+		CapturedBy:  overlayCapturedBy(),
 		Name:        name,
 		Currency:    fieldStringPtr(fields, "currency"),
 		Status:      overlayDealStatus(fieldString(fields, "stage_id")),
@@ -209,6 +230,7 @@ func overlayWireLead(ctx context.Context, rec datasource.Record) (crmcontracts.L
 		Id:          openapi_types.UUID(rec.Ref.ID),
 		WorkspaceId: wsID,
 		Source:      overlaySource,
+		CapturedBy:  overlayCapturedBy(),
 		FullName:    fieldStringPtr(fields, "full_name"),
 		CompanyName: fieldStringPtr(fields, "company_name"),
 		Score:       0,
@@ -256,6 +278,7 @@ func overlayWireActivity(ctx context.Context, rec datasource.Record) (crmcontrac
 		Id:          openapi_types.UUID(rec.Ref.ID),
 		WorkspaceId: wsID,
 		Source:      overlaySource,
+		CapturedBy:  overlayCapturedBy(),
 		Kind:        kind,
 		Subject:     fieldStringPtr(fields, "subject"),
 		Body:        fieldStringPtr(fields, "body"),

--- a/backend/internal/compose/overlaywire.go
+++ b/backend/internal/compose/overlaywire.go
@@ -52,13 +52,6 @@ const overlayUnnamed = "Unnamed"
 // mapper to read, and naming one it cannot verify would be a guess.
 const overlayCapturedByValue = "connector:overlay"
 
-// overlayCapturedBy yields a fresh pointer per call, so no wire struct can
-// alias (or mutate) another's provenance.
-func overlayCapturedBy() *string {
-	v := overlayCapturedByValue
-	return &v
-}
-
 // overlayRecordFields decodes a mirror record's canonical jsonb payload.
 // A record the overlay provider served always carries an object payload;
 // a decode failure is a real defect (the provider marshaled this very
@@ -108,7 +101,7 @@ func overlayWirePerson(ctx context.Context, rec datasource.Record) (crmcontracts
 		Id:          openapi_types.UUID(rec.Ref.ID),
 		WorkspaceId: wsID,
 		Source:      overlaySource,
-		CapturedBy:  overlayCapturedBy(),
+		CapturedBy:  ptrString(overlayCapturedByValue),
 		FullName:    fullName,
 		FirstName:   fieldStringPtr(fields, "first_name"),
 		LastName:    fieldStringPtr(fields, "last_name"),
@@ -141,7 +134,7 @@ func overlayWireOrganization(ctx context.Context, rec datasource.Record) (crmcon
 		Id:          openapi_types.UUID(rec.Ref.ID),
 		WorkspaceId: wsID,
 		Source:      overlaySource,
-		CapturedBy:  overlayCapturedBy(),
+		CapturedBy:  ptrString(overlayCapturedByValue),
 		DisplayName: displayName,
 		Industry:    fieldStringPtr(fields, "industry"),
 		CreatedAt:   syncedAt,
@@ -181,7 +174,7 @@ func overlayWireDeal(ctx context.Context, rec datasource.Record) (crmcontracts.D
 		Id:          openapi_types.UUID(rec.Ref.ID),
 		WorkspaceId: wsID,
 		Source:      overlaySource,
-		CapturedBy:  overlayCapturedBy(),
+		CapturedBy:  ptrString(overlayCapturedByValue),
 		Name:        name,
 		Currency:    fieldStringPtr(fields, "currency"),
 		Status:      overlayDealStatus(fieldString(fields, "stage_id")),
@@ -230,7 +223,7 @@ func overlayWireLead(ctx context.Context, rec datasource.Record) (crmcontracts.L
 		Id:          openapi_types.UUID(rec.Ref.ID),
 		WorkspaceId: wsID,
 		Source:      overlaySource,
-		CapturedBy:  overlayCapturedBy(),
+		CapturedBy:  ptrString(overlayCapturedByValue),
 		FullName:    fieldStringPtr(fields, "full_name"),
 		CompanyName: fieldStringPtr(fields, "company_name"),
 		Score:       0,
@@ -278,7 +271,7 @@ func overlayWireActivity(ctx context.Context, rec datasource.Record) (crmcontrac
 		Id:          openapi_types.UUID(rec.Ref.ID),
 		WorkspaceId: wsID,
 		Source:      overlaySource,
-		CapturedBy:  overlayCapturedBy(),
+		CapturedBy:  ptrString(overlayCapturedByValue),
 		Kind:        kind,
 		Subject:     fieldStringPtr(fields, "subject"),
 		Body:        fieldStringPtr(fields, "body"),

--- a/backend/internal/compose/overlaywrite.go
+++ b/backend/internal/compose/overlaywrite.go
@@ -79,16 +79,16 @@ var overlayRecordWriteTools = map[string]bool{
 }
 
 // overlayModeChecker resolves whether the request's workspace is in overlay
-// mode. It is the Dispatcher's own resolver, kept as a one-method interface
-// so the guard is unit-testable without the full dispatch. NOTE: the answer
-// rides the Dispatcher's short TTL cache, so a non-connecting process can
-// serve the pre-flip mode for up to that TTL after a mode change on another
-// instance (the connecting process invalidates its own cache). Closing that
-// last window needs an uncached, in-transaction mode read on the write path
-// and lands with the branch-2 write-back work; this guard closes the far
-// larger hole — that human/static writes were not mode-checked at all.
+// mode. It is the Dispatcher's own write-path resolver, kept as a one-method
+// interface so the guard is unit-testable without the full dispatch.
+//
+// It is deliberately the UNCACHED resolver (dispatcher.go's
+// isOverlayForWrite), not the read path's cached one: this guard runs only on
+// mutating requests, and a mutation routed on a stale mode is the silent
+// divergence the guard exists to prevent — see isOverlayForWrite's own doc
+// for what that costs and what it still cannot promise.
 type overlayModeChecker interface {
-	isOverlay(ctx context.Context) (bool, error)
+	isOverlayForWrite(ctx context.Context) (bool, error)
 }
 
 // overlayWriteGuard refuses a mutating REST request whose native module
@@ -102,8 +102,16 @@ type overlayModeChecker interface {
 // since its native table is the live one in overlay mode too. The guarded set
 // is keyed off the generated agentPolicies table (the contract's own
 // op→tool classification), so it never drifts from the contract. It runs for
-// every principal — the reason it is a standalone middleware rather than part
-// of the agent-only gate.
+// every principal on the REST surface — the reason it is a standalone
+// middleware rather than part of the agent-only gate.
+//
+// REST is the limit of its reach, and deliberately so: the MCP tool registry
+// and the automation engine call the same seam verbs without passing through
+// any router. The declaration those callers are held to is the provider's own
+// (overlay.SupportsWrite, enforced by requireSupportedWrite inside each write
+// verb). This guard exists on top of that because it can refuse BEFORE a
+// native module handler writes its own table, which the provider — never
+// reached on the native path — cannot do.
 func overlayWriteGuard(mode overlayModeChecker) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -129,7 +137,7 @@ func overlayWriteGuard(mode overlayModeChecker) func(http.Handler) http.Handler 
 				next.ServeHTTP(w, r)
 				return
 			}
-			inOverlay, err := mode.isOverlay(r.Context())
+			inOverlay, err := mode.isOverlayForWrite(r.Context())
 			if err != nil {
 				httperr.Write(w, r, err)
 				return

--- a/backend/internal/compose/overlaywrite_test.go
+++ b/backend/internal/compose/overlaywrite_test.go
@@ -26,7 +26,7 @@ type fakeMode struct {
 	err     error
 }
 
-func (f fakeMode) isOverlay(context.Context) (bool, error) { return f.overlay, f.err }
+func (f fakeMode) isOverlayForWrite(context.Context) (bool, error) { return f.overlay, f.err }
 
 // guardRequest builds a request carrying the chi route pattern the guard
 // keys on — the same shape the contract router populates before running

--- a/backend/internal/compose/overlaywriteshadow.go
+++ b/backend/internal/compose/overlaywriteshadow.go
@@ -128,6 +128,17 @@ func respondWithMirroredRecord[Res any](s Server, w http.ResponseWriter, r *http
 	httperr.WriteJSON(w, http.StatusOK, body)
 }
 
+// archiveWire pairs the two per-entity pieces an archive shadow needs: the
+// mapper that assembles the contract body from a mirror record, and the
+// setter that stamps the archive instant onto it. They travel together
+// because neither is meaningful without the other — assembling a body and
+// then forgetting to mark it archived is exactly the bug the stamp exists to
+// fix.
+type archiveWire[Res any] struct {
+	assemble     func(context.Context, datasource.Record) (Res, error)
+	markArchived func(*Res, time.Time)
+}
+
 // overlayArchive serves one archive shadow: the native module handler off
 // overlay mode, otherwise a dispatched seam Archive answered with the
 // archived row's last-known state — the contract's own archive response
@@ -167,9 +178,7 @@ func respondWithMirroredRecord[Res any](s Server, w http.ResponseWriter, r *http
 // window — an incumbent update landing in that gap is not reflected —
 // whereas the native path reads and archives in one transaction.
 func overlayArchive[Res any](s Server, w http.ResponseWriter, r *http.Request,
-	et datasource.EntityType, id crmcontracts.Id, native func(),
-	wire func(context.Context, datasource.Record) (Res, error),
-	markArchived func(*Res, time.Time),
+	et datasource.EntityType, id crmcontracts.Id, native func(), wire archiveWire[Res],
 ) {
 	ov, ok := s.overlayWriteMode(w, r)
 	if !ok {
@@ -189,12 +198,12 @@ func overlayArchive[Res any](s Server, w http.ResponseWriter, r *http.Request,
 		httperr.Write(w, r, err)
 		return
 	}
-	body, err := wire(r.Context(), rec)
+	body, err := wire.assemble(r.Context(), rec)
 	if err != nil {
 		httperr.Write(w, r, err)
 		return
 	}
-	markArchived(&body, time.Now().UTC())
+	wire.markArchived(&body, time.Now().UTC())
 	httperr.WriteJSON(w, http.StatusOK, body)
 }
 
@@ -207,8 +216,10 @@ func (s Server) UpdatePerson(w http.ResponseWriter, r *http.Request, id crmcontr
 // ArchivePerson shadows the person archive.
 func (s Server) ArchivePerson(w http.ResponseWriter, r *http.Request, id crmcontracts.Id) {
 	overlayArchive(s, w, r, datasource.EntityPerson, id,
-		func() { s.peopleHandlers.ArchivePerson(w, r, id) }, overlayWirePerson,
-		func(p *crmcontracts.Person, at time.Time) { p.ArchivedAt = &at })
+		func() { s.peopleHandlers.ArchivePerson(w, r, id) }, archiveWire[crmcontracts.Person]{
+			assemble:     overlayWirePerson,
+			markArchived: func(p *crmcontracts.Person, at time.Time) { p.ArchivedAt = &at },
+		})
 }
 
 // UpdateOrganization shadows the organization update.
@@ -220,8 +231,10 @@ func (s Server) UpdateOrganization(w http.ResponseWriter, r *http.Request, id cr
 // ArchiveOrganization shadows the organization archive.
 func (s Server) ArchiveOrganization(w http.ResponseWriter, r *http.Request, id crmcontracts.Id) {
 	overlayArchive(s, w, r, datasource.EntityOrganization, id,
-		func() { s.peopleHandlers.ArchiveOrganization(w, r, id) }, overlayWireOrganization,
-		func(o *crmcontracts.Organization, at time.Time) { o.ArchivedAt = &at })
+		func() { s.peopleHandlers.ArchiveOrganization(w, r, id) }, archiveWire[crmcontracts.Organization]{
+			assemble:     overlayWireOrganization,
+			markArchived: func(o *crmcontracts.Organization, at time.Time) { o.ArchivedAt = &at },
+		})
 }
 
 // UpdateDeal shadows the deal update.
@@ -233,8 +246,10 @@ func (s Server) UpdateDeal(w http.ResponseWriter, r *http.Request, id crmcontrac
 // ArchiveDeal shadows the deal archive.
 func (s Server) ArchiveDeal(w http.ResponseWriter, r *http.Request, id crmcontracts.Id) {
 	overlayArchive(s, w, r, datasource.EntityDeal, id,
-		func() { s.dealsHandlers.ArchiveDeal(w, r, id) }, overlayWireDeal,
-		func(d *crmcontracts.Deal, at time.Time) { d.ArchivedAt = &at })
+		func() { s.dealsHandlers.ArchiveDeal(w, r, id) }, archiveWire[crmcontracts.Deal]{
+			assemble:     overlayWireDeal,
+			markArchived: func(d *crmcontracts.Deal, at time.Time) { d.ArchivedAt = &at },
+		})
 }
 
 // UpdateLead shadows the lead update. Lead has no archive shadow: it is not

--- a/backend/internal/compose/overlaywriteshadow.go
+++ b/backend/internal/compose/overlaywriteshadow.go
@@ -23,12 +23,30 @@ package compose
 import (
 	"context"
 	"net/http"
+	"time"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/platform/httperr"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
 )
+
+// overlayWriteMode answers whether this MUTATING request dispatches to the
+// mirror, resolved uncached (dispatcher.go's isOverlayForWrite) rather than
+// through the read path's TTL cache. A write shadow that took the cached
+// answer could hand a mutation to the native module handler for the rest of
+// the TTL after another process flipped the workspace into overlay — a
+// commit to a native table no overlay read ever serves, which never reaches
+// the incumbent. A mode-resolution failure is written to w (ok=false), the
+// same fail-closed posture overlayReadMode takes.
+func (s Server) overlayWriteMode(w http.ResponseWriter, r *http.Request) (overlayMode, ok bool) {
+	ov, err := s.sorDispatch.isOverlayForWrite(r.Context())
+	if err != nil {
+		httperr.Write(w, r, err)
+		return false, false
+	}
+	return ov, true
+}
 
 // restWriteSource is the provenance Source every human REST write carries
 // into the seam. CapturedBy stays unset: overlay's write-back never reads it
@@ -55,7 +73,7 @@ func overlayUpdate[Req any, Res any](s Server, w http.ResponseWriter, r *http.Re
 	et datasource.EntityType, id crmcontracts.Id, native func(),
 	wire func(context.Context, datasource.Record) (Res, error),
 ) {
-	ov, ok := s.overlayReadMode(w, r)
+	ov, ok := s.overlayWriteMode(w, r)
 	if !ok {
 		return
 	}
@@ -114,23 +132,32 @@ func respondWithMirroredRecord[Res any](s Server, w http.ResponseWriter, r *http
 // (Provider.Read's own auth.Require), just ordered before rather than after
 // the write.
 //
-// Two honest divergences from the native path follow from that ordering,
-// both acceptable because a mirror row has no archived STATE to report in
-// the first place (it is purged, never flagged archived):
-//   - the body can be stale by the width of the pre-read-then-archive
-//     window — an incumbent update landing in that gap is not reflected —
-//     whereas the native path reads and archives in one transaction; and
-//   - the body carries no archived marker (no ArchivedAt, unlike a native
-//     archived row), since it is exactly the pre-archive record, unchanged.
+// markArchived stamps the archive instant onto the assembled body, so the
+// 200 describes the record as it is AFTER the call rather than as it was
+// before. Without it the response says archived_at: null about a record the
+// incumbent has just archived — the contract's archive response is defined
+// as "now carries a non-null archived_at", and answering otherwise reports
+// the write as not having happened.
 //
-// Both are read-only, display-only gaps: the incumbent-first Archive call
-// itself is what actually gates and executes the archive, so neither
-// affects whether the record is genuinely archived.
+// The contract's other archive promise — that the archived row stays
+// fetchable by id — is NOT met here, and cannot be by this transport: the
+// mirror row is purged, so the following GET answers 404. An incumbent
+// archive stops serving the object at the source, so the mirror has no
+// archived state to keep; honoring that promise needs an archived-row
+// substrate and a settled answer to what archive MEANS when the system of
+// record is an incumbent. Both are upstream contract questions, tracked
+// against the spec — this shadow does not paper over the gap by pretending
+// the record is still there.
+//
+// The body can also be stale by the width of the pre-read-then-archive
+// window — an incumbent update landing in that gap is not reflected —
+// whereas the native path reads and archives in one transaction.
 func overlayArchive[Res any](s Server, w http.ResponseWriter, r *http.Request,
 	et datasource.EntityType, id crmcontracts.Id, native func(),
 	wire func(context.Context, datasource.Record) (Res, error),
+	markArchived func(*Res, time.Time),
 ) {
-	ov, ok := s.overlayReadMode(w, r)
+	ov, ok := s.overlayWriteMode(w, r)
 	if !ok {
 		return
 	}
@@ -153,6 +180,7 @@ func overlayArchive[Res any](s Server, w http.ResponseWriter, r *http.Request,
 		httperr.Write(w, r, err)
 		return
 	}
+	markArchived(&body, time.Now().UTC())
 	httperr.WriteJSON(w, http.StatusOK, body)
 }
 
@@ -165,7 +193,8 @@ func (s Server) UpdatePerson(w http.ResponseWriter, r *http.Request, id crmcontr
 // ArchivePerson shadows the person archive.
 func (s Server) ArchivePerson(w http.ResponseWriter, r *http.Request, id crmcontracts.Id) {
 	overlayArchive(s, w, r, datasource.EntityPerson, id,
-		func() { s.peopleHandlers.ArchivePerson(w, r, id) }, overlayWirePerson)
+		func() { s.peopleHandlers.ArchivePerson(w, r, id) }, overlayWirePerson,
+		func(p *crmcontracts.Person, at time.Time) { p.ArchivedAt = &at })
 }
 
 // UpdateOrganization shadows the organization update.
@@ -177,7 +206,8 @@ func (s Server) UpdateOrganization(w http.ResponseWriter, r *http.Request, id cr
 // ArchiveOrganization shadows the organization archive.
 func (s Server) ArchiveOrganization(w http.ResponseWriter, r *http.Request, id crmcontracts.Id) {
 	overlayArchive(s, w, r, datasource.EntityOrganization, id,
-		func() { s.peopleHandlers.ArchiveOrganization(w, r, id) }, overlayWireOrganization)
+		func() { s.peopleHandlers.ArchiveOrganization(w, r, id) }, overlayWireOrganization,
+		func(o *crmcontracts.Organization, at time.Time) { o.ArchivedAt = &at })
 }
 
 // UpdateDeal shadows the deal update.
@@ -189,7 +219,8 @@ func (s Server) UpdateDeal(w http.ResponseWriter, r *http.Request, id crmcontrac
 // ArchiveDeal shadows the deal archive.
 func (s Server) ArchiveDeal(w http.ResponseWriter, r *http.Request, id crmcontracts.Id) {
 	overlayArchive(s, w, r, datasource.EntityDeal, id,
-		func() { s.dealsHandlers.ArchiveDeal(w, r, id) }, overlayWireDeal)
+		func() { s.dealsHandlers.ArchiveDeal(w, r, id) }, overlayWireDeal,
+		func(d *crmcontracts.Deal, at time.Time) { d.ArchivedAt = &at })
 }
 
 // UpdateLead shadows the lead update. Lead has no archive shadow: it is not

--- a/backend/internal/compose/overlaywriteshadow.go
+++ b/backend/internal/compose/overlaywriteshadow.go
@@ -94,7 +94,9 @@ func overlayUpdate[Req any, Res any](s Server, w http.ResponseWriter, r *http.Re
 	if !httperr.Decode(w, r, &req) {
 		return
 	}
-	ref, err := s.sorDispatch.Update(r.Context(), datasource.UpdateInput{
+	// ov is already the fresh answer overlayWriteMode just read, so dispatch
+	// with it rather than making the Dispatcher re-read the same row.
+	ref, err := s.sorDispatch.updateInMode(r.Context(), bool(ov), datasource.UpdateInput{
 		Ref:    datasource.EntityRef{Type: et, ID: ids.UUID(id)},
 		Patch:  &req,
 		Source: restWriteSource,
@@ -194,7 +196,7 @@ func overlayArchive[Res any](s Server, w http.ResponseWriter, r *http.Request,
 		httperr.Write(w, r, err)
 		return
 	}
-	if _, err := s.sorDispatch.Archive(r.Context(), ref); err != nil {
+	if _, err := s.sorDispatch.archiveInMode(r.Context(), bool(ov), ref); err != nil {
 		httperr.Write(w, r, err)
 		return
 	}

--- a/backend/internal/compose/overlaywriteshadow.go
+++ b/backend/internal/compose/overlaywriteshadow.go
@@ -60,12 +60,21 @@ const restWriteSource = "api"
 // (the shape overlay.SupportsWrite's writeContractTarget validates against)
 // and a dispatched seam Update, answered with the re-mirrored row.
 //
-// If-Match is deliberately not evaluated here: a mirror row carries no
-// version (overlay/provider.go's recordFromRow), so a caller-supplied
-// If-Match has nothing honest to compare against on this path — the
-// concurrency guard in overlay is the provider's own incumbent
+// If-Match is NOT evaluated here, and the caller is not told: a mirror row
+// carries no version (overlay/provider.go's recordFromRow), so a
+// caller-supplied If-Match has nothing to compare against on this path, and
+// the header is accepted and discarded. State the consequence plainly rather
+// than only the cause — a client that sends If-Match believing it has
+// optimistic concurrency has none here, and gets no signal saying so.
+//
+// What overlay does guard is a DIFFERENT clock: the provider's incumbent
 // stored-baseline drift check (provider_writes.go's Update), applied
-// unconditionally inside the seam call below.
+// unconditionally inside the seam call below. It closes the mirror↔incumbent
+// gap, not the caller↔mirror gap the header is about, so it is not a
+// substitute. Closing that gap needs a version (or baseline echo) the caller
+// can pin, which is a contract question — RowVersion's own text says version
+// semantics apply "not only overlay mode" — and is raised upstream rather
+// than decided here.
 //
 // Go forbids type parameters on methods, so this is a plain function
 // taking Server as its first argument rather than a method.
@@ -134,10 +143,14 @@ func respondWithMirroredRecord[Res any](s Server, w http.ResponseWriter, r *http
 //
 // markArchived stamps the archive instant onto the assembled body, so the
 // 200 describes the record as it is AFTER the call rather than as it was
-// before. Without it the response says archived_at: null about a record the
-// incumbent has just archived — the contract's archive response is defined
-// as "now carries a non-null archived_at", and answering otherwise reports
-// the write as not having happened.
+// before. Without it the response carries archived_at: null about a record
+// the incumbent has just archived — the contract defines the archive
+// response as one that "now carries a non-null archived_at", and answering
+// otherwise reports the write as not having happened.
+//
+// The instant is this server's own: the incumbent acks the archive without
+// reporting when it applied it, so the honest available value is when we
+// observed it, accurate to the width of the call.
 //
 // The contract's other archive promise — that the archived row stays
 // fetchable by id — is NOT met here, and cannot be by this transport: the
@@ -145,9 +158,10 @@ func respondWithMirroredRecord[Res any](s Server, w http.ResponseWriter, r *http
 // archive stops serving the object at the source, so the mirror has no
 // archived state to keep; honoring that promise needs an archived-row
 // substrate and a settled answer to what archive MEANS when the system of
-// record is an incumbent. Both are upstream contract questions, tracked
-// against the spec — this shadow does not paper over the gap by pretending
-// the record is still there.
+// record is an incumbent. Both are upstream contract questions against
+// margince-foundation's overlay chapter; this shadow does not paper over the
+// gap by pretending the record is still there, and the integration test
+// asserts the 404 so the day that answer lands, it fails loudly.
 //
 // The body can also be stale by the width of the pre-read-then-archive
 // window — an incumbent update landing in that gap is not reflected —

--- a/backend/internal/modules/overlay/hubspot/mapwrite.go
+++ b/backend/internal/modules/overlay/hubspot/mapwrite.go
@@ -182,10 +182,11 @@ func copyDirect(fields map[string]any, table []directWriteField, forUpdate bool)
 // overlay (null per OVA-MAP-6/W4) and never written.
 //
 // amount and currency are a PAIR: a caller must supply currency to write
-// amount (the exponent chooses the decimal point), so the write-back engine
-// combines a partial deal patch with the mirror's current amount_minor/
-// currency BEFORE calling mapWrite (Provider.Update) — here, an amount_minor
-// with no currency writes no amount rather than guess an exponent.
+// amount (the exponent chooses the decimal point). Provider.Update refuses a
+// patch carrying one without the other before ever reaching this mapping, so
+// the half-pair never arrives here; the guard below is the second line —
+// an amount_minor with no currency writes no amount rather than guess an
+// exponent.
 //
 //craft:ignore naked-any fields is the JSON-decoded canonical bag; the any is inherent to the decoded shape
 func mapWriteDeal(fields map[string]any, forUpdate bool) (writeMapping, error) {

--- a/backend/internal/modules/overlay/mirrordeletion.go
+++ b/backend/internal/modules/overlay/mirrordeletion.go
@@ -53,58 +53,11 @@ func mirrorDeletedPayload(objectClass, externalID string, deletedAt time.Time) c
 // must be free to re-mirror; the tombstone is reserved for privacy erasure,
 // which owns its own suppression path.
 func (s *MirrorStore) PurgeRecord(ctx context.Context, del Deletion) (bool, error) {
-	if del.ObjectClass == "" || del.ExternalID == "" {
-		return false, fmt.Errorf("overlay: purge requires a non-empty object class and external id")
-	}
-	id, err := externalIDToUUID(del.ExternalID)
-	if err != nil {
-		return false, fmt.Errorf("overlay: purging %s/%s: %w", del.ObjectClass, del.ExternalID, err)
-	}
-
 	var existed bool
-	err = database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
-		tag, err := tx.Exec(ctx,
-			`DELETE FROM overlay_mirror WHERE object_class = $1 AND external_id = $2`,
-			del.ObjectClass, del.ExternalID)
-		if err != nil {
-			return fmt.Errorf("overlay: purging the mirror row %s/%s: %w", del.ObjectClass, del.ExternalID, err)
-		}
-		existed = tag.RowsAffected() > 0
-
-		if _, err := tx.Exec(ctx, `
-			DELETE FROM overlay_association
-			WHERE (from_type = $1 AND from_id = $2) OR (to_type = $1 AND to_id = $2)`,
-			del.ObjectClass, del.ExternalID); err != nil {
-			return fmt.Errorf("overlay: purging the association edges of %s/%s: %w", del.ObjectClass, del.ExternalID, err)
-		}
-		if _, err := tx.Exec(ctx,
-			`DELETE FROM mirror_visibility WHERE object_class = $1 AND external_id = $2`,
-			del.ObjectClass, del.ExternalID); err != nil {
-			return fmt.Errorf("overlay: purging the visibility projection of %s/%s: %w", del.ObjectClass, del.ExternalID, err)
-		}
-
-		// Emit only when the mirror actually held the row, and in THIS
-		// transaction so the event commits with the purge or not at all.
-		// The ledger trace is a system_log row (not audit_log): a mirror
-		// purge is a derived-cache health event, the same posture Ingest and
-		// mirror.conflict take (mirrorstore.go / reconcile.go).
-		if !existed {
-			return nil
-		}
-		detail := map[string]any{
-			"object_class": del.ObjectClass,
-			"external_id":  del.ExternalID,
-			"deleted_at":   del.DeletedAt,
-		}
-		logID, err := storekit.LogSystem(ctx, tx, "mirror.deleted", detail)
-		if err != nil {
-			return fmt.Errorf("overlay: logging the mirror.deleted system event: %w", err)
-		}
-		if err := storekit.EmitEventForEntity(ctx, tx, logID, del.ObjectClass, id,
-			mirrorDeletedPayload(del.ObjectClass, del.ExternalID, del.DeletedAt)); err != nil {
-			return fmt.Errorf("overlay: emitting mirror.deleted: %w", err)
-		}
-		return nil
+	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+		var err error
+		existed, err = s.purgeRecordTx(ctx, tx, del)
+		return err
 	})
 	if err != nil {
 		return false, err
@@ -115,4 +68,74 @@ func (s *MirrorStore) PurgeRecord(ctx context.Context, del Deletion) (bool, erro
 		mirrorDeletedTotal.Add(1)
 	}
 	return existed, nil
+}
+
+// purgeRecordTx is PurgeRecord's body, taking the transaction rather than
+// opening one, so a caller that must commit MORE than the purge in the same
+// transaction can. The write-back path is that caller: a human archive's
+// audit_log and event_outbox rows commit with the purge they describe, or
+// neither lands (writeaudit.go).
+func (s *MirrorStore) purgeRecordTx(ctx context.Context, tx pgx.Tx, del Deletion) (bool, error) {
+	if del.ObjectClass == "" || del.ExternalID == "" {
+		return false, fmt.Errorf("overlay: purge requires a non-empty object class and external id")
+	}
+	// A purge only deletes, so it can never resurrect incumbent-derived data
+	// — but it DOES emit mirror.deleted, and emitting an overlay event into a
+	// workspace that has already gone back to native is the same
+	// post-disconnect write the fence exists to stop. Every other mutation on
+	// this store asserts the connection; so does this one, when fenced.
+	if s.fenced {
+		if err := assertActiveConnection(ctx, tx); err != nil {
+			return false, err
+		}
+	}
+	id, err := externalIDToUUID(del.ExternalID)
+	if err != nil {
+		return false, fmt.Errorf("overlay: purging %s/%s: %w", del.ObjectClass, del.ExternalID, err)
+	}
+
+	tag, err := tx.Exec(ctx,
+		`DELETE FROM overlay_mirror WHERE object_class = $1 AND external_id = $2`,
+		del.ObjectClass, del.ExternalID)
+	if err != nil {
+		return false, fmt.Errorf("overlay: purging the mirror row %s/%s: %w", del.ObjectClass, del.ExternalID, err)
+	}
+	existed := tag.RowsAffected() > 0
+
+	if _, err := tx.Exec(ctx, `
+		DELETE FROM overlay_association
+		WHERE (from_type = $1 AND from_id = $2) OR (to_type = $1 AND to_id = $2)`,
+		del.ObjectClass, del.ExternalID); err != nil {
+		return false, fmt.Errorf("overlay: purging the association edges of %s/%s: %w", del.ObjectClass, del.ExternalID, err)
+	}
+	if _, err := tx.Exec(ctx,
+		`DELETE FROM mirror_visibility WHERE object_class = $1 AND external_id = $2`,
+		del.ObjectClass, del.ExternalID); err != nil {
+		return false, fmt.Errorf("overlay: purging the visibility projection of %s/%s: %w", del.ObjectClass, del.ExternalID, err)
+	}
+
+	// Emit only when the mirror actually held the row, and in THIS
+	// transaction so the event commits with the purge or not at all.
+	// The ledger trace is a system_log row (not audit_log): a mirror
+	// purge is a derived-cache health event, the same posture Ingest and
+	// mirror.conflict take (mirrorstore.go / reconcile.go). A HUMAN archive
+	// riding this same transaction adds its own audit_log row on top
+	// (writeaudit.go) — that one IS a domain mutation.
+	if !existed {
+		return false, nil
+	}
+	detail := map[string]any{
+		"object_class": del.ObjectClass,
+		keyExternalID:  del.ExternalID,
+		"deleted_at":   del.DeletedAt,
+	}
+	logID, err := storekit.LogSystem(ctx, tx, "mirror.deleted", detail)
+	if err != nil {
+		return false, fmt.Errorf("overlay: logging the mirror.deleted system event: %w", err)
+	}
+	if err := storekit.EmitEventForEntity(ctx, tx, logID, del.ObjectClass, id,
+		mirrorDeletedPayload(del.ObjectClass, del.ExternalID, del.DeletedAt)); err != nil {
+		return false, fmt.Errorf("overlay: emitting mirror.deleted: %w", err)
+	}
+	return true, nil
 }

--- a/backend/internal/modules/overlay/mirrorstore.go
+++ b/backend/internal/modules/overlay/mirrorstore.go
@@ -150,60 +150,21 @@ ON CONFLICT (workspace_id, object_class, external_id) DO UPDATE
 // re-validates that owner's email-sourced mirror_user_map row before
 // projecting (design.md §4.6 rule 5).
 func (s *MirrorStore) Ingest(ctx context.Context, rec Record) error {
-	if rec.ObjectClass == "" || rec.ExternalID == "" {
-		return fmt.Errorf("overlay: ingest requires a non-empty object class and external id")
-	}
-	var ownerArg any
-	if rec.OwnerExternalID != "" {
-		ownerArg = rec.OwnerExternalID
-	}
+	_, err := s.ingestReporting(ctx, rec)
+	return err
+}
+
+// ingestReporting is Ingest, additionally reporting whether the upsert
+// actually landed a row — false when one of the in-SQL guards
+// (tombstone/staleness/no-clobber-dirty) held it back. The reconcile sweep
+// needs that answer: it decides whether an incumbent change DIVERGED from
+// what the mirror held, and only a landed row can have.
+func (s *MirrorStore) ingestReporting(ctx context.Context, rec Record) (bool, error) {
 	var landed bool
 	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
-		if s.fenced {
-			if err := assertActiveConnection(ctx, tx); err != nil {
-				return err
-			}
-		}
-		// Ingest's owner projection (ProjectOwnerVisibility, and the
-		// owner-change revalidation) mutates mirror_visibility, so it takes
-		// the same per-workspace visibility lock every other mutator takes —
-		// serializing an owner reassignment against a concurrent manual remap
-		// so a record transitioning between owners can never leave a stale
-		// grant. Overlay ingest is driven by the single leader-elected
-		// poller, so this lock is uncontended on the hot path.
-		if err := lockWorkspaceVisibility(ctx, tx); err != nil {
-			return err
-		}
-		var priorOwner string
-		if err := tx.QueryRow(
-			ctx,
-			`SELECT coalesce(owner_external_id, '') FROM overlay_mirror WHERE object_class = $1 AND external_id = $2`,
-			rec.ObjectClass, rec.ExternalID,
-		).Scan(&priorOwner); err != nil && !errors.Is(err, pgx.ErrNoRows) {
-			return fmt.Errorf("overlay: reading the prior owner of %s/%s: %w", rec.ObjectClass, rec.ExternalID, err)
-		}
-
-		tag, err := tx.Exec(
-			ctx, ingestSQL,
-			rec.ObjectClass, rec.ExternalID, rec.Fields, rec.ModifiedAt, ownerArg,
-		)
-		if err != nil {
-			return fmt.Errorf("overlay: ingesting %s/%s: %w", rec.ObjectClass, rec.ExternalID, err)
-		}
-		if tag.RowsAffected() == 0 {
-			// Held back by a guard (tombstone/staleness/dirty) — the
-			// mirror row did not change, so there is nothing to
-			// re-project.
-			return nil
-		}
-		landed = true
-
-		if rec.OwnerExternalID != "" && rec.OwnerExternalID != priorOwner {
-			if err := s.revalidateEmailMapping(ctx, tx, s.emails, rec.OwnerExternalID); err != nil {
-				return err
-			}
-		}
-		return ProjectOwnerVisibility(ctx, tx, rec.ObjectClass, rec.ExternalID, rec.OwnerExternalID)
+		var err error
+		landed, err = s.ingestTx(ctx, tx, rec)
+		return err
 	})
 	if err == nil && landed {
 		// Count only a COMMITTED landing toward the inbound sync-rate
@@ -213,7 +174,71 @@ func (s *MirrorStore) Ingest(ctx context.Context, rec Record) error {
 		// the metric ahead of what overlay_mirror actually holds.
 		mirrorSyncedTotal.Add(1)
 	}
-	return err
+	return landed && err == nil, err
+}
+
+// ingestTx is Ingest's body, taking the transaction rather than opening
+// one, so a caller that must commit MORE than the cache refresh in the
+// same transaction can. The write-back path is that caller: a human
+// mutation's audit_log and event_outbox rows commit with the mirror
+// refresh they describe, or neither lands (writeaudit.go). It reports
+// whether the upsert actually landed a row, so the caller can hold the
+// sync metric until its own commit succeeds.
+func (s *MirrorStore) ingestTx(ctx context.Context, tx pgx.Tx, rec Record) (bool, error) {
+	if rec.ObjectClass == "" || rec.ExternalID == "" {
+		return false, fmt.Errorf("overlay: ingest requires a non-empty object class and external id")
+	}
+	var ownerArg any
+	if rec.OwnerExternalID != "" {
+		ownerArg = rec.OwnerExternalID
+	}
+	if s.fenced {
+		if err := assertActiveConnection(ctx, tx); err != nil {
+			return false, err
+		}
+	}
+	// Ingest's owner projection (ProjectOwnerVisibility, and the
+	// owner-change revalidation) mutates mirror_visibility, so it takes
+	// the same per-workspace visibility lock every other mutator takes —
+	// serializing an owner reassignment against a concurrent manual remap
+	// so a record transitioning between owners can never leave a stale
+	// grant. Overlay ingest is driven by the single leader-elected
+	// poller, so this lock is uncontended on the hot path.
+	if err := lockWorkspaceVisibility(ctx, tx); err != nil {
+		return false, err
+	}
+	var priorOwner string
+	if err := tx.QueryRow(
+		ctx,
+		`SELECT coalesce(owner_external_id, '') FROM overlay_mirror WHERE object_class = $1 AND external_id = $2`,
+		rec.ObjectClass, rec.ExternalID,
+	).Scan(&priorOwner); err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return false, fmt.Errorf("overlay: reading the prior owner of %s/%s: %w", rec.ObjectClass, rec.ExternalID, err)
+	}
+
+	tag, err := tx.Exec(
+		ctx, ingestSQL,
+		rec.ObjectClass, rec.ExternalID, rec.Fields, rec.ModifiedAt, ownerArg,
+	)
+	if err != nil {
+		return false, fmt.Errorf("overlay: ingesting %s/%s: %w", rec.ObjectClass, rec.ExternalID, err)
+	}
+	if tag.RowsAffected() == 0 {
+		// Held back by a guard (tombstone/staleness/dirty) — the
+		// mirror row did not change, so there is nothing to
+		// re-project.
+		return false, nil
+	}
+
+	if rec.OwnerExternalID != "" && rec.OwnerExternalID != priorOwner {
+		if err := s.revalidateEmailMapping(ctx, tx, s.emails, rec.OwnerExternalID); err != nil {
+			return false, err
+		}
+	}
+	if err := ProjectOwnerVisibility(ctx, tx, rec.ObjectClass, rec.ExternalID, rec.OwnerExternalID); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // upsertAssocSQL keeps the direction/label/category refresh together

--- a/backend/internal/modules/overlay/mirrorstore.go
+++ b/backend/internal/modules/overlay/mirrorstore.go
@@ -174,7 +174,12 @@ func (s *MirrorStore) ingestReporting(ctx context.Context, rec Record) (bool, er
 		// the metric ahead of what overlay_mirror actually holds.
 		mirrorSyncedTotal.Add(1)
 	}
-	return landed && err == nil, err
+	if err != nil {
+		// A guard-passed upsert that then failed to commit did not land: the
+		// caller must not read "landed" off a rolled-back transaction.
+		return false, err
+	}
+	return landed, nil
 }
 
 // ingestTx is Ingest's body, taking the transaction rather than opening

--- a/backend/internal/modules/overlay/mirrorstore.go
+++ b/backend/internal/modules/overlay/mirrorstore.go
@@ -182,13 +182,33 @@ func (s *MirrorStore) ingestReporting(ctx context.Context, rec Record) (bool, er
 	return landed, nil
 }
 
-// ingestTx is Ingest's body, taking the transaction rather than opening
-// one, so a caller that must commit MORE than the cache refresh in the
-// same transaction can. The write-back path is that caller: a human
-// mutation's audit_log and event_outbox rows commit with the mirror
-// refresh they describe, or neither lands (writeaudit.go). It reports
-// whether the upsert actually landed a row, so the caller can hold the
-// sync metric until its own commit succeeds.
+// priorOwnerOf reads the owner a mirror row currently records, before an
+// ingest overwrites it — the one signal Ingest ever sees that an incumbent
+// user's identity is newly relevant (a Record carries an owner id, never an
+// owner email).
+func (s *MirrorStore) priorOwnerOf(ctx context.Context, tx pgx.Tx, objectClass, externalID string) (string, error) {
+	var owner string
+	err := tx.QueryRow(
+		ctx,
+		`SELECT coalesce(owner_external_id, '') FROM overlay_mirror WHERE object_class = $1 AND external_id = $2`,
+		objectClass, externalID,
+	).Scan(&owner)
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return "", fmt.Errorf("overlay: reading the prior owner of %s/%s: %w", objectClass, externalID, err)
+	}
+	// No row yet is not an error: a first ingest has no prior owner, which
+	// reads as the empty string and makes the owner-change check below true
+	// exactly when the incoming record names one.
+	return owner, nil
+}
+
+// ingestTx is Ingest's body, taking the transaction rather than opening one,
+// so a caller that must commit MORE than the cache refresh in the same
+// transaction can. The write-back path is that caller: a human mutation's
+// audit_log and event_outbox rows commit with the mirror refresh they
+// describe, or neither lands (writeaudit.go). It reports whether the upsert
+// actually landed a row, so the caller can hold the sync metric until its
+// own commit succeeds.
 func (s *MirrorStore) ingestTx(ctx context.Context, tx pgx.Tx, rec Record) (bool, error) {
 	if rec.ObjectClass == "" || rec.ExternalID == "" {
 		return false, fmt.Errorf("overlay: ingest requires a non-empty object class and external id")
@@ -212,13 +232,9 @@ func (s *MirrorStore) ingestTx(ctx context.Context, tx pgx.Tx, rec Record) (bool
 	if err := lockWorkspaceVisibility(ctx, tx); err != nil {
 		return false, err
 	}
-	var priorOwner string
-	if err := tx.QueryRow(
-		ctx,
-		`SELECT coalesce(owner_external_id, '') FROM overlay_mirror WHERE object_class = $1 AND external_id = $2`,
-		rec.ObjectClass, rec.ExternalID,
-	).Scan(&priorOwner); err != nil && !errors.Is(err, pgx.ErrNoRows) {
-		return false, fmt.Errorf("overlay: reading the prior owner of %s/%s: %w", rec.ObjectClass, rec.ExternalID, err)
+	priorOwner, err := s.priorOwnerOf(ctx, tx, rec.ObjectClass, rec.ExternalID)
+	if err != nil {
+		return false, err
 	}
 
 	tag, err := tx.Exec(

--- a/backend/internal/modules/overlay/provider.go
+++ b/backend/internal/modules/overlay/provider.go
@@ -6,8 +6,9 @@ package overlay
 // This file implements the frozen datasource.SystemOfRecordProvider seam
 // (interfaces.md §3, design.md §4.5) over the overlay mirror: reads are
 // served from MirrorStore (visibility-joined, T2-labelled honest —
-// Authoritative is always false); every write verb plus RunReport is
-// declared unsupported until branch 2 lands the write-back path.
+// Authoritative is always false). The write verbs live in
+// provider_writes.go; RunReport has no incumbent analogue and is declared
+// unsupported here.
 
 import (
 	"context"

--- a/backend/internal/modules/overlay/provider.go
+++ b/backend/internal/modules/overlay/provider.go
@@ -377,7 +377,16 @@ func (p *Provider) RunReport(_ context.Context, _ datasource.ReportPlan) (dataso
 // Freshness delegates to ff (the metered force-fresh reader) when
 // configured; otherwise it falls back to the mirror row's own
 // freshness, so a Provider built with ff==nil never nil-panics.
+//
+// Anything that returns a record is a read, and a force-fresh Freshness
+// spends a real incumbent call against the record: it carries the same
+// object-RBAC gate Read/Search/ListFields carry, for the same reason they
+// carry it — the MCP path reaches this provider without any transport gate
+// in front of it.
 func (p *Provider) Freshness(ctx context.Context, ref datasource.EntityRef) (datasource.FreshnessInfo, error) {
+	if err := auth.Require(ctx, string(ref.Type), principal.ActionRead); err != nil {
+		return datasource.FreshnessInfo{}, err
+	}
 	if p.ff != nil {
 		return p.ff.Read(ctx, ref)
 	}

--- a/backend/internal/modules/overlay/provider_test.go
+++ b/backend/internal/modules/overlay/provider_test.go
@@ -65,8 +65,11 @@ func TestProviderWriteVerbsObjectGateBeforeTheIncumbent(t *testing.T) {
 	})
 	ref := datasource.EntityRef{Type: datasource.EntityPerson, ID: ids.NewV7()}
 
-	if _, err := p.Create(ctx, datasource.CreateInput{EntityType: datasource.EntityPerson}); !errors.Is(err, apperrors.ErrPermissionDenied) {
-		t.Errorf("Create without a person create grant: err = %v, want ErrPermissionDenied", err)
+	// Create is not gated on the grant at all: the provider declares the verb
+	// unsupported for every type (SupportsWrite), and a capability the mirror
+	// does not have is refused before any principal is consulted.
+	if _, err := p.Create(ctx, datasource.CreateInput{EntityType: datasource.EntityPerson}); !errors.Is(err, apperrors.ErrUnsupportedBySoR) {
+		t.Errorf("Create in overlay: err = %v, want ErrUnsupportedBySoR", err)
 	}
 	if _, err := p.Update(ctx, datasource.UpdateInput{Ref: ref}); !errors.Is(err, apperrors.ErrPermissionDenied) {
 		t.Errorf("Update without a person update grant: err = %v, want ErrPermissionDenied", err)
@@ -79,8 +82,8 @@ func TestProviderWriteVerbsObjectGateBeforeTheIncumbent(t *testing.T) {
 // TestProviderWriteWithoutIncumbentResolver proves a permitted write
 // against a Provider with no incumbent write resolver wired fails with a
 // clear configuration error — never a nil-pointer panic and never a
-// misleading ErrUnsupportedBySoR (Create/Update/Archive ARE supported
-// verbs; the resolver is simply absent).
+// misleading ErrUnsupportedBySoR (update IS a supported verb; the resolver
+// is simply absent).
 func TestProviderWriteWithoutIncumbentResolver(t *testing.T) {
 	p := NewProvider(&MirrorStore{}, nil)
 	ctx := principal.WithActor(context.Background(), principal.Principal{
@@ -90,9 +93,11 @@ func TestProviderWriteWithoutIncumbentResolver(t *testing.T) {
 			RowScope: principal.RowScopeAll,
 		},
 	})
-	_, err := p.Create(ctx, datasource.CreateInput{EntityType: datasource.EntityPerson})
+	_, err := p.Update(ctx, datasource.UpdateInput{
+		Ref: datasource.EntityRef{Type: datasource.EntityPerson, ID: ids.NewV7()},
+	})
 	if err == nil || errors.Is(err, apperrors.ErrUnsupportedBySoR) {
-		t.Fatalf("Create with no resolver: err = %v, want a clear configuration error", err)
+		t.Fatalf("Update with no resolver: err = %v, want a clear configuration error", err)
 	}
 }
 

--- a/backend/internal/modules/overlay/provider_test.go
+++ b/backend/internal/modules/overlay/provider_test.go
@@ -128,6 +128,12 @@ func TestProviderReadVerbsObjectGateBeforeTheMirror(t *testing.T) {
 	if _, err := p.ListFields(ctx, datasource.EntityPerson); !errors.Is(err, apperrors.ErrPermissionDenied) {
 		t.Errorf("ListFields without a person read grant: err = %v, want ErrPermissionDenied", err)
 	}
+	// Freshness belongs in this list: a force-fresh answer spends a real
+	// incumbent call against the record, so it is as much a read as the three
+	// above and reaches the provider by the same ungated MCP path.
+	if _, err := p.Freshness(ctx, ref); !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Errorf("Freshness without a person read grant: err = %v, want ErrPermissionDenied", err)
+	}
 }
 
 func TestProviderRunReportUnsupported(t *testing.T) {

--- a/backend/internal/modules/overlay/provider_writeback_integration_test.go
+++ b/backend/internal/modules/overlay/provider_writeback_integration_test.go
@@ -15,7 +15,6 @@ package overlay
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"log/slog"
 	"testing"
@@ -46,6 +45,7 @@ type writeBackIncumbent struct {
 	incClass    string            // IncumbentClass the write reports (defaults to "contacts" when unset)
 	archiveErr  error
 	archived    bool
+	created     bool
 }
 
 func (w *writeBackIncumbent) Name() string { return "writeback-double" }
@@ -75,6 +75,7 @@ func (w *writeBackIncumbent) OwnerEmail(context.Context, string) (string, error)
 func (w *writeBackIncumbent) Owners(context.Context) ([]OwnerRef, error) { return nil, nil }
 
 func (w *writeBackIncumbent) Create(context.Context, string, map[string]any) (WriteResult, error) {
+	w.created = true
 	if w.createErr != nil {
 		return WriteResult{}, w.createErr
 	}
@@ -146,10 +147,19 @@ func mapActorToOwner(ctx context.Context, t *testing.T, ms *MirrorStore) {
 	}
 }
 
-// TestProviderCreateMirrorsIncumbentResult: Create is incumbent-first — the
-// incumbent's returned state is ingested into the mirror so a follow-up
-// read sees the record, and the returned ref round-trips to it.
-func TestProviderCreateMirrorsIncumbentResult(t *testing.T) {
+// TestProviderCreateIsRefusedBeforeReachingTheIncumbent: create is declared
+// unsupported for every mirrored type (SupportsWrite) because the write
+// mapping leaves owner_id read-only — a created incumbent record would be
+// unowned, and the NULL-OWNER rule then writes no visibility row, so the
+// record would exist in the customer's CRM and be invisible to everyone
+// including its author.
+//
+// The refusal must live in the PROVIDER, not only in the REST guard: the
+// agent tool surface and the automation engine reach this verb through the
+// datasource seam with no router in between, and create_record is an
+// auto-execute tool — an unattended loop retrying a create that appears to
+// fail would mint a new invisible record every attempt.
+func TestProviderCreateIsRefusedBeforeReachingTheIncumbent(t *testing.T) {
 	ctx, pool, _ := testWorkspaceCtx(t)
 	ms := NewMirrorStore(pool, noOwnerEmails{})
 	mapActorToOwner(ctx, t, ms)
@@ -158,35 +168,21 @@ func TestProviderCreateMirrorsIncumbentResult(t *testing.T) {
 	inc := &writeBackIncumbent{createRec: Record{
 		ObjectClass:     "person",
 		ExternalID:      "555",
-		Fields:          map[string]any{"first_name": "Ada", "full_name": "Ada Lovelace"},
+		Fields:          map[string]any{"first_name": "Ada"},
 		ModifiedAt:      time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
 		OwnerExternalID: writebackOwner,
 	}}
 	p := providerFor(ms, inc)
 
-	ref, err := p.Create(ctx, datasource.CreateInput{
+	_, err := p.Create(ctx, datasource.CreateInput{
 		EntityType: datasource.EntityPerson,
 		Fields:     map[string]any{"first_name": "Ada", "last_name": "Lovelace"},
 	})
-	if err != nil {
-		t.Fatalf("Create: %v", err)
+	if !errors.Is(err, apperrors.ErrUnsupportedBySoR) {
+		t.Fatalf("Create = %v, want the declared ErrUnsupportedBySoR", err)
 	}
-	rec, err := p.Read(ctx, ref)
-	if err != nil {
-		t.Fatalf("Read after Create: %v", err)
-	}
-	// The incumbent's returned state must actually be ingested — assert the
-	// field content, not just that a row exists.
-	var fields map[string]any
-	if err := json.Unmarshal(rec.Fields, &fields); err != nil {
-		t.Fatalf("decoding read-back fields: %v", err)
-	}
-	if fields["first_name"] != "Ada" {
-		t.Errorf("mirrored first_name = %v, want 'Ada' (the incumbent's created state)", fields["first_name"])
-	}
-	// A mirror read is never authoritative — the incumbent stays the SoR.
-	if rec.Freshness.Authoritative {
-		t.Error("a mirrored write result must not claim incumbent authority (T2, AC-OV-5)")
+	if inc.created {
+		t.Error("the refused create still reached the incumbent — a declared-unsupported verb must never leave the process")
 	}
 }
 
@@ -200,8 +196,17 @@ func TestProviderWriteOpensEchoLedgerEntries(t *testing.T) {
 	mapActorToOwner(ctx, t, ms)
 	seedActiveConnection(ctx, t, pool)
 
+	if err := ms.Ingest(ctx, Record{
+		ObjectClass:     "person",
+		ExternalID:      "555",
+		Fields:          map[string]any{"first_name": "Grace"},
+		ModifiedAt:      time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+		OwnerExternalID: writebackOwner,
+	}); err != nil {
+		t.Fatalf("seeding mirror: %v", err)
+	}
 	inc := &writeBackIncumbent{
-		createRec: Record{
+		updateRec: Record{
 			ObjectClass:     "person",
 			ExternalID:      "555",
 			Fields:          map[string]any{"first_name": "Ada"},
@@ -210,18 +215,22 @@ func TestProviderWriteOpensEchoLedgerEntries(t *testing.T) {
 		},
 		// The incumbent reports the HubSpot properties it wrote — the ledger keys
 		// on exactly these, as the echo webhook will present them.
-		createProps: map[string]string{"firstname": "Ada"},
+		updateProps: map[string]string{"firstname": "Ada"},
 		incClass:    "contacts",
 	}
 	ledger := NewWriteLedger(pool)
 	p := providerFor(ms, inc)
 	p.SetWriteLedger(ledger, slog.New(slog.DiscardHandler))
 
-	if _, err := p.Create(ctx, datasource.CreateInput{
-		EntityType: datasource.EntityPerson,
-		Fields:     map[string]any{"first_name": "Ada"},
+	id, err := externalIDToUUID("555")
+	if err != nil {
+		t.Fatalf("resolving the seeded record's ref: %v", err)
+	}
+	if _, err := p.Update(ctx, datasource.UpdateInput{
+		Ref:   datasource.EntityRef{Type: datasource.EntityPerson, ID: id},
+		Patch: map[string]any{"first_name": "Ada"},
 	}); err != nil {
-		t.Fatalf("Create: %v", err)
+		t.Fatalf("Update: %v", err)
 	}
 
 	// The write's echo — a propertyChange for contacts/555.firstname="Ada" — now

--- a/backend/internal/modules/overlay/provider_writes.go
+++ b/backend/internal/modules/overlay/provider_writes.go
@@ -5,12 +5,14 @@ package overlay
 
 // This file is the overlay Provider's write half: the datasource
 // SystemOfRecordProvider write verbs over the incumbent-first write-back
-// path (design.md §4.5, OVA-MAP-W). Create/Update/Archive project the
-// canonical write onto the incumbent BELOW the seam (the adapter's
-// mapWrite), write incumbent-first, and re-mirror the incumbent's returned
-// state; the drift check (AC-OV-4) lives in the adapter's Update/Archive.
-// Merge, PromoteLead, and AdvanceDeal stay unsupported (OVA-MAP-W6 + the
-// missing overlay stage-map) — see each method.
+// path (design.md §4.5, OVA-MAP-W). Update and Archive project the canonical
+// write onto the incumbent BELOW the seam (the adapter's mapWrite), write
+// incumbent-first, and re-mirror the incumbent's returned state; the drift
+// check (AC-OV-4) lives in the adapter's Update/Archive, and the governance
+// half — audit_log + event_outbox, committed with the mirror write — lives in
+// writeaudit.go. Create, Merge, PromoteLead, and AdvanceDeal are declared
+// unsupported (SupportsWrite, OVA-MAP-W6, and the missing overlay stage-map)
+// and refused at the verb — see each method.
 
 import (
 	"bytes"
@@ -33,7 +35,7 @@ import (
 // when the Provider has no incumbent write resolver wired, or the resolver
 // reports no active incumbent (disconnect/config race) — a clear, actionable
 // error rather than a nil-pointer panic, and NOT ErrUnsupportedBySoR
-// (Create/Update/Archive are supported verbs; the incumbent is just absent).
+// (update and archive ARE supported verbs; the incumbent is just absent).
 func errNoWriteIncumbent() error {
 	return fmt.Errorf("overlay: provider has no incumbent write resolver configured")
 }
@@ -160,55 +162,29 @@ func rejectExtraProperties(target any) error {
 	return &datasource.FieldDecodeError{Cause: fmt.Errorf("unknown field(s): %v", keys)}
 }
 
-// Create writes a new record to the incumbent (incumbent-first, AC-OV-4)
-// and mirrors the incumbent's returned state. The object RBAC gate runs
-// FIRST — the same MCP-bypass closure the read verbs carry, since the MCP
-// write path reaches the provider directly. The canonical write is
-// projected onto incumbent properties BELOW the seam (the adapter's
-// mapWrite, OVA-MAP-W); the Provider stays incumbent-agnostic.
+// Create is refused for every mirrored type — SupportsWrite declares the
+// verb unsupported, and requireSupportedWrite is what makes that declaration
+// bind on every caller rather than only on the REST transport.
 //
-// V1 retry-safety limitation: HubSpot's v3 object-create is a bare POST
-// with no caller-supplied idempotency key (no hs_unique_creation_key), so a
-// caller that retries after a mirror-write failure — the incumbent create
-// already committed, the follow-up ingest did not — can mint a second
-// incumbent object. The orphaned first object is not lost (the reconcile
-// poller mirrors it on its next sweep), but a retried Create is NOT
-// idempotent in V1. Retry-safe create (search-before-create or an
-// alternate-key upsert, per S-E19.3/S-E20.3) is the prerequisite for ever
-// declaring this verb supported.
-func (p *Provider) Create(ctx context.Context, in datasource.CreateInput) (datasource.EntityRef, error) {
-	if err := requireSupportedWrite(WriteCreate, in.EntityType); err != nil {
-		return datasource.EntityRef{}, err
-	}
-	if err := auth.Require(ctx, string(in.EntityType), principal.ActionCreate); err != nil {
-		return datasource.EntityRef{}, err
-	}
-	if p.ms == nil {
-		return datasource.EntityRef{}, errNoMirrorStore()
-	}
-	inc, err := p.writeIncumbent(ctx)
-	if err != nil {
-		return datasource.EntityRef{}, err
-	}
-	fields, err := decodeCanonical(in.EntityType, false, in.Fields)
-	if err != nil {
-		return datasource.EntityRef{}, err
-	}
-	res, err := inc.Create(ctx, string(in.EntityType), fields)
-	if err != nil {
-		return datasource.EntityRef{}, err
-	}
-	if err := p.mirrorWriteResult(ctx, inc, res.Record); err != nil {
-		return datasource.EntityRef{}, err
-	}
-	// After the mirror write, never before — see openWriteLedger on why the
-	// two orderings are not symmetric.
-	p.openWriteLedger(ctx, res)
-	id, err := externalIDToUUID(res.Record.ExternalID)
-	if err != nil {
-		return datasource.EntityRef{}, err
-	}
-	return datasource.EntityRef{Type: in.EntityType, ID: id}, nil
+// Two things must land before this verb can be implemented, and neither is a
+// transport concern:
+//
+//   - Owner-on-create. The write mapping declares owner_id read-only, so a
+//     created incumbent record is unowned, and the NULL-OWNER RULE
+//     (visibility.go) writes no visibility row for an unowned record — the
+//     create would succeed at the incumbent and then be invisible to
+//     everyone, including its author.
+//   - Retry-safe create. HubSpot's v3 object-create is a bare POST with no
+//     caller-supplied idempotency key (no hs_unique_creation_key), so a
+//     caller retrying after a failed local half can mint a second incumbent
+//     object. Search-before-create or an alternate-key upsert
+//     (S-E19.3/S-E20.3) is the answer.
+//
+// Whatever implements it then owes the write-back governance shape every
+// other write verb carries (writeaudit.go's commitUpdateWriteBack): the
+// audit_log row and the outbox event committing with the mirror refresh.
+func (p *Provider) Create(_ context.Context, in datasource.CreateInput) (datasource.EntityRef, error) {
+	return datasource.EntityRef{}, requireSupportedWrite(WriteCreate, in.EntityType)
 }
 
 // Update applies a patch incumbent-first after the stored-baseline drift
@@ -391,10 +367,7 @@ func requireSupportedWrite(verb WriteVerb, et datasource.EntityType) error {
 // its author. Owner-on-create is the prerequisite, and it is a mapping
 // decision, not a transport one.
 //
-// Two obligations come with ever flipping WriteCreate to true, both already
-// carried by the verbs that ARE supported: retry-safe create (Create's own
-// doc) and the write-back audit shape (writeaudit.go's commitUpdateWriteBack,
-// which Create does not call because it cannot run).
+// Create's own doc names the two prerequisites for ever flipping it to true.
 func SupportsWrite(verb WriteVerb, et datasource.EntityType) bool {
 	switch verb {
 	case WriteCreate:
@@ -452,23 +425,6 @@ func (p *Provider) Archive(ctx context.Context, r datasource.EntityRef) (datasou
 		return datasource.EntityRef{}, writePathError(err)
 	}
 	return r, nil
-}
-
-// mirrorWriteResult ingests the incumbent's post-write state into the mirror
-// so a follow-up read sees the write without waiting for the sync poller.
-// It binds the store to the LIVE incumbent (WithResolver) so Ingest's owner
-// re-validation resolves against the real adapter — not the read-path
-// placeholder that always fails — and engages the disconnect fence
-// (WithFence) so a write landing after a Disconnect cannot repopulate the
-// purged mirror (it aborts with ErrConnectionGone). Ingest's staleness guard
-// admits the row (the write bumped the incumbent's baseline past the
-// mirror's), and the mirror stays non-authoritative (T2) — the incumbent
-// remains the system of record.
-func (p *Provider) mirrorWriteResult(ctx context.Context, inc Incumbent, rec Record) error {
-	if p.ms == nil {
-		return errNoMirrorStore()
-	}
-	return p.ms.WithResolver(inc).WithFence().Ingest(ctx, rec)
 }
 
 // AdvanceDeal is unsupported in overlay V1: advancing an overlay deal

--- a/backend/internal/modules/overlay/provider_writes.go
+++ b/backend/internal/modules/overlay/provider_writes.go
@@ -170,15 +170,16 @@ func rejectExtraProperties(target any) error {
 // V1 retry-safety limitation: HubSpot's v3 object-create is a bare POST
 // with no caller-supplied idempotency key (no hs_unique_creation_key), so a
 // caller that retries after a mirror-write failure — the incumbent create
-// already committed, the follow-up Ingest did not — can mint a second
+// already committed, the follow-up ingest did not — can mint a second
 // incumbent object. The orphaned first object is not lost (the reconcile
 // poller mirrors it on its next sweep), but a retried Create is NOT
 // idempotent in V1. Retry-safe create (search-before-create or an
-// alternate-key upsert, per S-E19.3/S-E20.3) is a fast-follow; overlay
-// write-back today is reached only through the 🟡 confirm-first agent path
-// (AC-OV-5), whose approval is human-gated and audited, so an unattended
-// retry storm is not the live exposure.
+// alternate-key upsert, per S-E19.3/S-E20.3) is the prerequisite for ever
+// declaring this verb supported.
 func (p *Provider) Create(ctx context.Context, in datasource.CreateInput) (datasource.EntityRef, error) {
+	if err := requireSupportedWrite(WriteCreate, in.EntityType); err != nil {
+		return datasource.EntityRef{}, err
+	}
 	if err := auth.Require(ctx, string(in.EntityType), principal.ActionCreate); err != nil {
 		return datasource.EntityRef{}, err
 	}
@@ -197,14 +198,12 @@ func (p *Provider) Create(ctx context.Context, in datasource.CreateInput) (datas
 	if err != nil {
 		return datasource.EntityRef{}, err
 	}
-	// Open the echo-ledger entries BEFORE mirroring so the entry is visible as
-	// early as possible after the incumbent commit — narrowing the window in
-	// which our own echo could arrive before the ledger recognizes it. Never
-	// fails the write (fail-open — see openWriteLedger).
-	p.openWriteLedger(ctx, res)
 	if err := p.mirrorWriteResult(ctx, inc, res.Record); err != nil {
 		return datasource.EntityRef{}, err
 	}
+	// After the mirror write, never before — see openWriteLedger on why the
+	// two orderings are not symmetric.
+	p.openWriteLedger(ctx, res)
 	id, err := externalIDToUUID(res.Record.ExternalID)
 	if err != nil {
 		return datasource.EntityRef{}, err
@@ -215,7 +214,7 @@ func (p *Provider) Create(ctx context.Context, in datasource.CreateInput) (datas
 // Update applies a patch incumbent-first after the stored-baseline drift
 // check (AC-OV-4): the mirror row supplies the baseline captured at
 // mirror-read, and the adapter refuses with ErrVersionSkew (surfaced as a
-// 412 by the transport) if the incumbent moved since — never a blind
+// 409 version_skew by the transport) if the incumbent moved since — never a blind
 // overwrite. On success the incumbent's returned state is re-mirrored.
 //
 // Overlay's optimistic concurrency IS this incumbent stored-baseline drift
@@ -223,6 +222,9 @@ func (p *Provider) Create(ctx context.Context, in datasource.CreateInput) (datas
 // Version (recordFromRow), so in.IfVersion has nothing to compare against
 // here and the incumbent's own record clock is the authority (design.md §4.5).
 func (p *Provider) Update(ctx context.Context, in datasource.UpdateInput) (datasource.EntityRef, error) {
+	if err := requireSupportedWrite(WriteUpdate, in.Ref.Type); err != nil {
+		return datasource.EntityRef{}, err
+	}
 	if err := auth.Require(ctx, string(in.Ref.Type), principal.ActionUpdate); err != nil {
 		return datasource.EntityRef{}, err
 	}
@@ -248,14 +250,23 @@ func (p *Provider) Update(ctx context.Context, in datasource.UpdateInput) (datas
 	if err := p.completeWritePatch(in.Ref.Type, fields, row); err != nil {
 		return datasource.EntityRef{}, err
 	}
+	// The before image is read off the SAME mirror row that supplied the
+	// drift baseline, so the audit trail's before/after pair describes the
+	// exact state the drift check licensed this write against.
+	before := beforeImage(row, fields)
 	res, err := inc.Update(ctx, string(in.Ref.Type), externalID, fields, row.UpdatedAtBaseline)
 	if err != nil {
 		return datasource.EntityRef{}, err
 	}
-	p.openWriteLedger(ctx, res) // fail-open, before mirroring (see Create)
-	if err := p.mirrorWriteResult(ctx, inc, res.Record); err != nil {
-		return datasource.EntityRef{}, err
+	// The incumbent has committed. Everything past this line is the local
+	// half, and it runs on a context that outlives the caller (see
+	// afterIncumbentCommit).
+	localCtx, cancel := afterIncumbentCommit(ctx)
+	defer cancel()
+	if err := p.commitUpdateWriteBack(localCtx, inc, res.Record, in.Ref, before, fields); err != nil {
+		return datasource.EntityRef{}, writePathError(err)
 	}
+	p.openWriteLedger(localCtx, res)
 	return in.Ref, nil
 }
 
@@ -269,6 +280,16 @@ func (p *Provider) Update(ctx context.Context, in datasource.UpdateInput) (datas
 // costs a redundant re-fetch when the echo arrives (idempotent, poller-healed),
 // so the failure is logged and swallowed here. No ledger wired (the write-verb
 // unit tests) or a read-only-fields write (no WrittenProps) is a no-op.
+//
+// It runs AFTER the mirror write commits, never before. Opening earlier would
+// narrow the window in which our own echo outruns its ledger entry — but it
+// makes the far worse failure possible: entries committed, mirror write
+// failed. The echo webhook is then classified as ours and DROPPED, so the one
+// signal that would have healed the mirror is suppressed, the mirror serves
+// the pre-write value behind a pre-write baseline, and every retry answers
+// 409 version_skew against our own write until the next poller sweep. The
+// costs are not symmetric: opening late costs one redundant re-fetch, opening
+// early costs a frozen record. So the ledger follows the commit.
 func (p *Provider) openWriteLedger(ctx context.Context, res WriteResult) {
 	if p.ledger == nil || len(res.WrittenProps) == 0 {
 		return
@@ -334,11 +355,34 @@ const (
 	WriteArchive WriteVerb = "archive"
 )
 
+// requireSupportedWrite refuses a verb SupportsWrite does not declare for
+// et — the ONE enforcement point for that declaration, applied inside each
+// write verb rather than at any one transport.
+//
+// The transports are not enough on their own: the composition layer's HTTP
+// write guard (compose/overlaywrite.go) covers REST, but the agent tool
+// surface and the automation engine reach these verbs through the datasource
+// seam directly, with no guard in between. A capability declared unsupported
+// that a seam caller can still execute is not declared at all, so the refusal
+// belongs where every caller passes.
+func requireSupportedWrite(verb WriteVerb, et datasource.EntityType) error {
+	if SupportsWrite(verb, et) {
+		return nil
+	}
+	if _, err := writeContractTarget(et, verb == WriteUpdate); err != nil {
+		// An entity the mirror does not carry at all — the honest answer is
+		// "no such entity here", not "this verb is unsupported".
+		return &datasource.UnsupportedEntityError{Type: string(et)}
+	}
+	return apperrors.ErrUnsupportedBySoR
+}
+
 // SupportsWrite reports whether the overlay provider can serve verb for et.
-// It is the provider's own capability, read by the composition layer's write
-// guard and by the write shadows, so the two cannot disagree about what the
-// mirror can do — a disagreement would let an unsupported write fall through
-// to a native handler and commit to the empty native table.
+// It is the provider's own capability, enforced by requireSupportedWrite
+// inside every write verb and read by the composition layer's write guard and
+// write shadows, so no transport can disagree with it about what the mirror
+// can do — a disagreement would let an unsupported write fall through to a
+// native handler and commit to the empty native table.
 //
 // Create is unsupported for every type: the write mapping declares owner_id
 // read-only, so a created incumbent record is unowned, and the NULL-OWNER RULE
@@ -346,6 +390,11 @@ const (
 // would succeed at the incumbent and then be invisible to everyone, including
 // its author. Owner-on-create is the prerequisite, and it is a mapping
 // decision, not a transport one.
+//
+// Two obligations come with ever flipping WriteCreate to true, both already
+// carried by the verbs that ARE supported: retry-safe create (Create's own
+// doc) and the write-back audit shape (writeaudit.go's commitUpdateWriteBack,
+// which Create does not call because it cannot run).
 func SupportsWrite(verb WriteVerb, et datasource.EntityType) bool {
 	switch verb {
 	case WriteCreate:
@@ -364,8 +413,8 @@ func SupportsWrite(verb WriteVerb, et datasource.EntityType) bool {
 // the stored-baseline drift check, then purges the mirror row so it stops
 // being readable rather than lingering visible until the next sync.
 func (p *Provider) Archive(ctx context.Context, r datasource.EntityRef) (datasource.EntityRef, error) {
-	if !archivableTypes[r.Type] {
-		return datasource.EntityRef{}, &datasource.UnsupportedEntityError{Type: string(r.Type)}
+	if err := requireSupportedWrite(WriteArchive, r.Type); err != nil {
+		return datasource.EntityRef{}, err
 	}
 	if err := auth.Require(ctx, string(r.Type), principal.ActionDelete); err != nil {
 		return datasource.EntityRef{}, err
@@ -387,10 +436,20 @@ func (p *Provider) Archive(ctx context.Context, r datasource.EntityRef) (datasou
 	if err := inc.Archive(ctx, string(r.Type), externalID, row.UpdatedAtBaseline); err != nil {
 		return datasource.EntityRef{}, err
 	}
-	// Purge through the disconnect fence so a teardown racing the archive
-	// cannot leave the row readable, matching the sync path.
-	if _, err := p.ms.WithFence().PurgeRecord(ctx, Deletion{ObjectClass: string(r.Type), ExternalID: externalID}); err != nil {
-		return datasource.EntityRef{}, err
+	// The incumbent has archived the record; the local half runs detached
+	// from the caller (afterIncumbentCommit) because a closed tab must not
+	// leave a record that no longer exists at the incumbent still listed and
+	// still readable here until the next full reconcile sweep.
+	//
+	// The purge goes through the disconnect fence so a teardown racing the
+	// archive cannot leave the row readable, matching the sync path — and the
+	// archive's audit_log and event_outbox rows commit in that same
+	// transaction, so a record removed from the customer's own CRM can never
+	// be missing from the ledger that answers who removed it.
+	localCtx, cancel := afterIncumbentCommit(ctx)
+	defer cancel()
+	if err := p.commitArchiveWriteBack(localCtx, Deletion{ObjectClass: string(r.Type), ExternalID: externalID}, r); err != nil {
+		return datasource.EntityRef{}, writePathError(err)
 	}
 	return r, nil
 }

--- a/backend/internal/modules/overlay/reconcile.go
+++ b/backend/internal/modules/overlay/reconcile.go
@@ -159,17 +159,25 @@ func reconcileOne(ctx context.Context, ms *MirrorStore, rec Record) error {
 		return fmt.Errorf("overlay: reconcile: reading the prior mirror state of %s/%s: %w", rec.ObjectClass, rec.ExternalID, priorErr)
 	}
 
-	if err := ms.Ingest(ctx, rec); err != nil {
+	landed, err := ms.ingestReporting(ctx, rec)
+	if err != nil {
 		return fmt.Errorf("overlay: reconcile: ingesting %s/%s: %w", rec.ObjectClass, rec.ExternalID, err)
 	}
 
 	// A divergence worth surfacing requires: the row already existed, it
 	// was NOT protected as dirty (pending_sync — Ingest's own no-clobber
 	// guard already held THAT case back with no write at all), and the
-	// incoming value actually landed (strictly newer than the stored
-	// baseline — the same predicate Ingest's staleness guard applies, so
-	// this never emits a conflict for a stale page that changed nothing).
-	if existed && prior.SyncState != syncStatePendingSync && rec.ModifiedAt.After(prior.UpdatedAtBaseline) {
+	// incoming value ACTUALLY landed.
+	//
+	// That last condition is the ingest's own answer, not a re-derivation of
+	// its predicate. Re-deriving it against `prior` compares pre-ingest data:
+	// a write-back committing a newer baseline between the getRaw above and
+	// the ingest makes the staleness guard hold the incoming row back
+	// (nothing changed) while `rec.ModifiedAt.After(prior.UpdatedAtBaseline)`
+	// is still true — announcing a conflict for an overwrite that never
+	// happened, carrying an incumbent timestamp older than what the mirror
+	// now holds.
+	if landed && existed && prior.SyncState != syncStatePendingSync {
 		if err := emitMirrorConflict(ctx, ms, rec, prior); err != nil {
 			return err
 		}

--- a/backend/internal/modules/overlay/writeaudit.go
+++ b/backend/internal/modules/overlay/writeaudit.go
@@ -1,0 +1,292 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package overlay
+
+// The write-back path's governance half: the audit_log row and the outbox
+// event every overlay Update/Archive commits, alongside the mirror refresh
+// that same write produced.
+//
+// Why this file exists at all. The mirror is a derived cache, and its sync
+// writes are deliberately audit-free (mirrorstore.go's Ingest doc) — a
+// poller refresh is not a domain mutation and auditing it would retain
+// incumbent PII in audit_log for no compliance purpose. A HUMAN or agent
+// write-back is the opposite case: it IS a domain mutation, made by an
+// identified principal, against the record the incumbent holds. It carries
+// the same attributable audit trail every native module write carries, or
+// the overlay path would be the one mutation surface in this build where
+// "who changed this record" has no answer.
+//
+// The ordering this shape can and cannot promise. The incumbent commits
+// FIRST (design.md §4.5: incumbent-first, so a refusal upstream never
+// leaves a local row claiming a write HubSpot never took), so the canonical
+// row and our audit row cannot share one transaction — the canonical row is
+// not in our database. What DOES commit atomically is the entire local half:
+// the mirror refresh, the audit_log row, and the event_outbox row land in
+// ONE transaction or none of them do. A caller therefore never sees a
+// refreshed mirror row with no audit trail, nor an announced event whose
+// audit row rolled back.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+)
+
+// The audit actions a write-back records, spelled the same way the native
+// module stores spell them (people/person.go, deals/deal.go) so one audit
+// query answers "who changed this person" across both systems of record.
+const (
+	auditActionUpdate  = "update"
+	auditActionArchive = "archive"
+)
+
+// auditWriteBack records one write-back as a governed mutation: the
+// audit_log row naming the principal, and the record's own public event,
+// both on tx.
+//
+// before/after carry the record's field images restricted to the fields
+// this write actually touched — the same discipline the native update path
+// keeps (people/lead_update.go's patch Before()/After()), and the reason a
+// write-back audit row does not become a full copy of an incumbent record
+// in audit_log. externalID travels as evidence rather than in those images:
+// it is context ABOUT the mutation (which incumbent record it landed on),
+// and folding it into the field images would make a field-history
+// projection read it as a field change that never happened.
+func auditWriteBack(ctx context.Context, tx pgx.Tx, action string, ref datasource.EntityRef,
+	externalID string, before, after map[string]any,
+) error {
+	auditID, err := storekit.AuditWithEvidence(ctx, tx, action, string(ref.Type), ref.ID, before, after,
+		map[string]any{"system_of_record": "incumbent", keyExternalID: externalID})
+	if err != nil {
+		return fmt.Errorf("overlay: auditing the %s write-back of %s %s: %w", action, ref.Type, externalID, err)
+	}
+	if err := emitWriteBack(ctx, tx, auditID, action, ref, after); err != nil {
+		return fmt.Errorf("overlay: announcing the %s write-back of %s %s: %w", action, ref.Type, externalID, err)
+	}
+	return nil
+}
+
+// emitWriteBack stages the record's own public event for a write-back —
+// the SAME event type the native path emits for the same verb, because a
+// subscriber must not have to know which system of record served the write
+// to recognize that a person changed.
+//
+// A verb/type pair with no case here is a programming error rather than a
+// silent no-op: the write verbs refuse everything SupportsWrite does not
+// declare (provider_writes.go), so an unhandled pair means the two have
+// drifted, and an un-announced mutation is exactly the silence this file
+// exists to prevent.
+func emitWriteBack(ctx context.Context, tx pgx.Tx, auditID ids.UUID, action string,
+	ref datasource.EntityRef, after map[string]any,
+) error {
+	switch action {
+	case auditActionArchive:
+		return emitWriteBackArchived(ctx, tx, auditID, ref)
+	case auditActionUpdate:
+		return emitWriteBackUpdated(ctx, tx, auditID, ref, after)
+	default:
+		return fmt.Errorf("no write-back event for action %q on %s", action, ref.Type)
+	}
+}
+
+// emitWriteBackArchived stages the archived event for the three types
+// Archive supports (archivableTypes).
+func emitWriteBackArchived(ctx context.Context, tx pgx.Tx, auditID ids.UUID, ref datasource.EntityRef) error {
+	switch ref.Type {
+	case datasource.EntityPerson:
+		return storekit.EmitEvent(ctx, tx, auditID, ref.ID, crmcontracts.PublicEventPersonArchived{})
+	case datasource.EntityOrganization:
+		return storekit.EmitEvent(ctx, tx, auditID, ref.ID, crmcontracts.PublicEventOrganizationArchived{})
+	case datasource.EntityDeal:
+		return storekit.EmitEvent(ctx, tx, auditID, ref.ID, crmcontracts.PublicEventDealArchived{})
+	default:
+		return fmt.Errorf("no archived event for %s", ref.Type)
+	}
+}
+
+// emitWriteBackUpdated stages the updated event for the five types Update
+// supports, carrying the fields the write touched as changed_fields.
+func emitWriteBackUpdated(ctx context.Context, tx pgx.Tx, auditID ids.UUID,
+	ref datasource.EntityRef, after map[string]any,
+) error {
+	switch ref.Type {
+	case datasource.EntityPerson:
+		return storekit.EmitEvent(ctx, tx, auditID, ref.ID, crmcontracts.PublicEventPersonUpdated{ChangedFields: after})
+	case datasource.EntityOrganization:
+		return storekit.EmitEvent(ctx, tx, auditID, ref.ID, crmcontracts.PublicEventOrganizationUpdated{ChangedFields: after})
+	case datasource.EntityDeal:
+		return storekit.EmitEvent(ctx, tx, auditID, ref.ID, crmcontracts.PublicEventDealUpdated{ChangedFields: after})
+	case datasource.EntityLead:
+		return storekit.EmitEvent(ctx, tx, auditID, ref.ID, crmcontracts.PublicEventLeadUpdated{ChangedFields: after})
+	case datasource.EntityActivity:
+		changed, err := activityChangedFields(after)
+		if err != nil {
+			return err
+		}
+		return storekit.EmitEvent(ctx, tx, auditID, ref.ID, crmcontracts.PublicEventActivityUpdated{ChangedFields: changed})
+	default:
+		return fmt.Errorf("no updated event for %s", ref.Type)
+	}
+}
+
+// activityChangedFields projects an activity patch onto activity.updated's
+// BOUNDED delta. Unlike person/organization/deal/lead.updated — whose
+// changed_fields is a genuinely open map — this event's key set is fixed and
+// typed, so the patch has to be narrowed rather than passed through.
+//
+// The projection is a JSON round-trip rather than a field-by-field copy
+// because both sides are generated from the SAME contract: the patch keys
+// are UpdateActivityRequest's json tags, and the delta's keys are those same
+// names by construction, so a hand-written mapping would only be a second
+// place for them to drift. Keys outside the delta's schema drop out, which
+// is what "bounded" means.
+//
+// body is the one deliberate exception: the delta carries a PRESENCE FLAG,
+// never the content ("bodies can be large and are never echoed onto the
+// wire"), so it is removed before the round-trip and re-stated as a bool.
+func activityChangedFields(patch map[string]any) (crmcontracts.PublicEventActivityChangedFields, error) {
+	narrowed := make(map[string]any, len(patch))
+	for k, v := range patch {
+		if k == "body" {
+			continue
+		}
+		narrowed[k] = v
+	}
+	raw, err := json.Marshal(narrowed)
+	if err != nil {
+		return crmcontracts.PublicEventActivityChangedFields{}, fmt.Errorf("encoding the activity delta: %w", err)
+	}
+	var changed crmcontracts.PublicEventActivityChangedFields
+	if err := json.Unmarshal(raw, &changed); err != nil {
+		return crmcontracts.PublicEventActivityChangedFields{}, fmt.Errorf("projecting the activity delta: %w", err)
+	}
+	if _, touched := patch["body"]; touched {
+		bodyTouched := true
+		changed.Body = &bodyTouched
+	}
+	return changed, nil
+}
+
+// writeBackLocalTimeout bounds the local half of a write-back once it is
+// detached from the caller's cancellation. Detached work without a deadline
+// of its own would hang a request worker on a stalled database indefinitely
+// — the same pairing the vault cleanup makes (connection.go).
+const writeBackLocalTimeout = 10 * time.Second
+
+// afterIncumbentCommit returns the context the local half of a write-back
+// runs on: DETACHED from the caller's cancellation, under its own deadline.
+//
+// Past the incumbent's commit there is no longer a request to abandon. The
+// canonical row has already changed in the customer's CRM, and everything
+// still owed — the mirror refresh, the audit_log row, the outbox event, the
+// echo-ledger entries — describes a change that HAS happened. Letting a
+// closed browser tab cancel that work is what turns a completed archive into
+// a record still listed and still readable, with no audit trail, until the
+// next full reconcile sweep. So the caller can walk away; the bookkeeping
+// cannot.
+func afterIncumbentCommit(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.WithoutCancel(ctx), writeBackLocalTimeout)
+}
+
+// writePathError translates the fence's internal control signal into a
+// sentinel a transport can answer with.
+//
+// ErrConnectionGone is deliberately not an apperrors sentinel — it is the
+// sweep's clean STOP, and its own doc says it "never crosses an HTTP/MCP
+// boundary" because the on-demand reconcile path collapses it first. The
+// human write path is the second boundary that needs the same collapse: a
+// disconnect racing an in-flight write leaves the fenced local half aborting
+// with it, and an unmapped control signal reaching httperr is an opaque 500
+// for what is really "this workspace no longer reads from an incumbent" —
+// 404 mode_not_overlay, exactly as every other post-disconnect request
+// answers. Any other error passes through untouched.
+func writePathError(err error) error {
+	if errors.Is(err, ErrConnectionGone) {
+		return apperrors.ErrModeNotOverlay
+	}
+	return err
+}
+
+// commitUpdateWriteBack lands the LOCAL half of a completed create/update
+// write-back in one transaction: the mirror refresh that carries the
+// incumbent's post-write state, plus the audit_log and event_outbox rows
+// that record who made it. See this file's header on what that atomicity
+// does and does not promise.
+//
+// The store is bound to the LIVE incumbent (WithResolver) so the ingest's
+// owner re-validation resolves against the real adapter rather than the
+// read-path placeholder that always fails, and the disconnect fence is
+// engaged (WithFence) so a write landing after a Disconnect cannot
+// repopulate the purged mirror.
+func (p *Provider) commitUpdateWriteBack(ctx context.Context, inc Incumbent, rec Record,
+	ref datasource.EntityRef, before, after map[string]any,
+) error {
+	if p.ms == nil {
+		return errNoMirrorStore()
+	}
+	ms := p.ms.WithResolver(inc).WithFence()
+	var landed bool
+	err := database.WithWorkspaceTx(ctx, ms.pool, func(tx pgx.Tx) error {
+		var ingestErr error
+		if landed, ingestErr = ms.ingestTx(ctx, tx, rec); ingestErr != nil {
+			return ingestErr
+		}
+		return auditWriteBack(ctx, tx, auditActionUpdate, ref, rec.ExternalID, before, after)
+	})
+	if err == nil && landed {
+		mirrorSyncedTotal.Add(1)
+	}
+	return err
+}
+
+// commitArchiveWriteBack is commitUpdateWriteBack for the archive verb: the
+// mirror purge that stops the record being readable, plus the archive's own
+// audit_log and event_outbox rows, in one transaction.
+//
+// No resolver binding here, unlike the update path: a purge writes no owner
+// projection, so there is no owner email to re-validate.
+func (p *Provider) commitArchiveWriteBack(ctx context.Context, del Deletion, ref datasource.EntityRef) error {
+	if p.ms == nil {
+		return errNoMirrorStore()
+	}
+	ms := p.ms.WithFence()
+	var existed bool
+	err := database.WithWorkspaceTx(ctx, ms.pool, func(tx pgx.Tx) error {
+		var purgeErr error
+		if existed, purgeErr = ms.purgeRecordTx(ctx, tx, del); purgeErr != nil {
+			return purgeErr
+		}
+		// before/after stay nil, matching the native archive audit rows
+		// (people/person.go, deals/deal.go): an archive changes no field
+		// values, it retires the record.
+		return auditWriteBack(ctx, tx, auditActionArchive, ref, del.ExternalID, nil, nil)
+	})
+	if err == nil && existed {
+		mirrorDeletedTotal.Add(1)
+	}
+	return err
+}
+
+// beforeImage reads the pre-write values of exactly the fields a patch
+// touches, out of the mirror row that supplied the write's drift baseline.
+// A field the mirror never held reads as nil, which is the honest before
+// value for a field the incumbent had not set.
+func beforeImage(row Row, patch map[string]any) map[string]any {
+	before := make(map[string]any, len(patch))
+	for k := range patch {
+		before[k] = row.Fields[k]
+	}
+	return before
+}

--- a/backend/internal/modules/overlay/writeaudit.go
+++ b/backend/internal/modules/overlay/writeaudit.go
@@ -60,14 +60,16 @@ const (
 // this write actually touched — the same discipline the native update path
 // keeps (people/lead_update.go's patch Before()/After()), and the reason a
 // write-back audit row does not become a full copy of an incumbent record
-// in audit_log. externalID travels as evidence rather than in those images:
-// it is context ABOUT the mutation (which incumbent record it landed on),
-// and folding it into the field images would make a field-history
-// projection read it as a field change that never happened.
+// in audit_log. Both images are narrowed by minimizeAuditImage first.
+// externalID travels as evidence rather than in those images: it is context
+// ABOUT the mutation (which incumbent record it landed on), and folding it
+// into the field images would make a field-history projection read it as a
+// field change that never happened.
 func auditWriteBack(ctx context.Context, tx pgx.Tx, action string, ref datasource.EntityRef,
 	externalID string, before, after map[string]any,
 ) error {
-	auditID, err := storekit.AuditWithEvidence(ctx, tx, action, string(ref.Type), ref.ID, before, after,
+	auditID, err := storekit.AuditWithEvidence(ctx, tx, action, string(ref.Type), ref.ID,
+		minimizeAuditImage(ref.Type, before), minimizeAuditImage(ref.Type, after),
 		map[string]any{"system_of_record": "incumbent", keyExternalID: externalID})
 	if err != nil {
 		return fmt.Errorf("overlay: auditing the %s write-back of %s %s: %w", action, ref.Type, externalID, err)
@@ -277,6 +279,49 @@ func (p *Provider) commitArchiveWriteBack(ctx context.Context, del Deletion, ref
 		mirrorDeletedTotal.Add(1)
 	}
 	return err
+}
+
+// contentFreeAuditFields names, per entity type, the fields whose VALUE never
+// enters an audit image — only the fact that the write touched them.
+//
+// An activity body is the one such field today, and the rule is the native
+// path's, not a new one: activities/lifecycle.go records `body: true` rather
+// than the text, because bodies are large and are the message content itself.
+// It binds harder on the overlay path than on the native one. A mirrored
+// body is INCUMBENT-sourced — customer correspondence synced out of HubSpot —
+// and audit_log is append-only, sits under the retention floor, and is served
+// verbatim to unbounded compliance readers. Copying that text there would put
+// incumbent message content in the one store neither Art. 17 erasure nor
+// disconnect teardown reaches, which is the opposite of what this file's own
+// header gives as the reason not to audit mirror sync.
+var contentFreeAuditFields = map[datasource.EntityType]map[string]bool{
+	datasource.EntityActivity: {"body": true},
+}
+
+// minimizeAuditImage replaces a content-free field's value with the presence
+// flag `true`, leaving every other field as-is. A nil image stays nil: an
+// archive audits no field values at all, and an empty object would read as
+// "these fields changed to nothing".
+//
+// It is applied inside auditWriteBack rather than at each call site so every
+// verb — and every verb added later — inherits it.
+func minimizeAuditImage(et datasource.EntityType, image map[string]any) map[string]any {
+	if image == nil {
+		return nil
+	}
+	contentFree := contentFreeAuditFields[et]
+	if len(contentFree) == 0 {
+		return image
+	}
+	out := make(map[string]any, len(image))
+	for k, v := range image {
+		if contentFree[k] {
+			out[k] = true
+			continue
+		}
+		out[k] = v
+	}
+	return out
 }
 
 // beforeImage reads the pre-write values of exactly the fields a patch

--- a/backend/internal/modules/overlay/writegovernance_test.go
+++ b/backend/internal/modules/overlay/writegovernance_test.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package overlay
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+)
+
+// writableEntityTypes are the five types the mirror carries. Spelled here
+// rather than derived from a production list on purpose: a test that reads
+// the same list the code under test reads cannot notice the list changing.
+var writableEntityTypes = []datasource.EntityType{
+	datasource.EntityPerson,
+	datasource.EntityOrganization,
+	datasource.EntityDeal,
+	datasource.EntityLead,
+	datasource.EntityActivity,
+}
+
+// fullyGrantedActor is a principal holding every object grant on every
+// mirrored type, with unrestricted row scope — so a refusal in the tests
+// below can only come from the capability gate, never from authorization.
+func fullyGrantedActor() context.Context {
+	objects := make(map[string]principal.ObjectGrant, len(writableEntityTypes))
+	for _, et := range writableEntityTypes {
+		objects[string(et)] = principal.ObjectGrant{Create: true, Update: true, Delete: true, Read: true}
+	}
+	return principal.WithActor(context.Background(), principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:fully-granted",
+		Permissions: principal.Permissions{Objects: objects, RowScope: principal.RowScopeAll},
+	})
+}
+
+// TestWriteVerbsRefuseExactlyWhatSupportsWriteDenies derives the obligation
+// from the declaration instead of restating it: for EVERY (verb, entity)
+// pair, the provider's own write method must refuse precisely when
+// SupportsWrite says it cannot serve that pair.
+//
+// This is the invariant the composition layer's REST guard and the write
+// shadows both READ. Before this gate existed the declaration was enforced
+// only by that guard, so the agent tool surface and the automation engine —
+// which reach these verbs through the datasource seam with no router in
+// between — could execute a verb the mirror declares impossible. A capability
+// only one transport honors is not a capability.
+//
+// A refused pair must never touch the incumbent: the Provider here has no
+// incumbent resolver wired, so any verb that got past the gate would fail
+// with the resolver error instead — a distinct, recognizable failure.
+func TestWriteVerbsRefuseExactlyWhatSupportsWriteDenies(t *testing.T) {
+	p := NewProvider(&MirrorStore{}, nil)
+	ctx := fullyGrantedActor()
+
+	for _, et := range writableEntityTypes {
+		for _, verb := range []WriteVerb{WriteCreate, WriteUpdate, WriteArchive} {
+			ref := datasource.EntityRef{Type: et, ID: ids.NewV7()}
+			var err error
+			switch verb {
+			case WriteCreate:
+				_, err = p.Create(ctx, datasource.CreateInput{EntityType: et})
+			case WriteUpdate:
+				_, err = p.Update(ctx, datasource.UpdateInput{Ref: ref})
+			case WriteArchive:
+				_, err = p.Archive(ctx, ref)
+			}
+
+			refused := errors.Is(err, apperrors.ErrUnsupportedBySoR)
+			if want := SupportsWrite(verb, et); want == refused {
+				t.Errorf("%s %s: SupportsWrite=%v but the verb %s (err = %v)",
+					verb, et, want, refusalWord(refused), err)
+			}
+			if refused {
+				continue
+			}
+			// A pair the provider DOES serve must have reached the incumbent
+			// resolver — proof the gate let it through rather than refusing it
+			// under some other error.
+			if err == nil || errors.Is(err, apperrors.ErrPermissionDenied) {
+				t.Errorf("%s %s is declared supported but did not reach the incumbent: err = %v", verb, et, err)
+			}
+		}
+	}
+}
+
+// refusalWord renders the observed outcome for a failure message.
+func refusalWord(refused bool) string {
+	if refused {
+		return "refused it as unsupported"
+	}
+	return "did not refuse it"
+}
+
+// TestUnsupportedWriteNamesTheEntityWhenTheMirrorDoesNotCarryIt proves the
+// two refusals are distinguishable: a verb the mirror cannot serve for a type
+// it DOES carry is "unsupported by this system of record", while a type the
+// mirror does not carry at all is an unsupported ENTITY — a caller told the
+// wrong one would chase the wrong fix.
+func TestUnsupportedWriteNamesTheEntityWhenTheMirrorDoesNotCarryIt(t *testing.T) {
+	p := NewProvider(&MirrorStore{}, nil)
+	ctx := fullyGrantedActor()
+
+	// A carried type, an unservable verb.
+	if _, err := p.Archive(ctx, datasource.EntityRef{Type: datasource.EntityLead, ID: ids.NewV7()}); !errors.Is(err, apperrors.ErrUnsupportedBySoR) {
+		t.Errorf("archiving a lead: err = %v, want ErrUnsupportedBySoR", err)
+	}
+
+	// A type the mirror never carries.
+	var unsupported *datasource.UnsupportedEntityError
+	_, err := p.Update(ctx, datasource.UpdateInput{
+		Ref: datasource.EntityRef{Type: datasource.EntityType("pipeline"), ID: ids.NewV7()},
+	})
+	if !errors.As(err, &unsupported) {
+		t.Errorf("updating a pipeline: err = %v, want UnsupportedEntityError", err)
+	}
+}

--- a/backend/internal/modules/overlay/writegovernance_test.go
+++ b/backend/internal/modules/overlay/writegovernance_test.go
@@ -6,6 +6,7 @@ package overlay
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
@@ -95,6 +96,103 @@ func refusalWord(refused bool) string {
 		return "refused it as unsupported"
 	}
 	return "did not refuse it"
+}
+
+// TestAuditImagesNeverCarryContentFreeFieldValues is the data-minimization
+// gate on the write-back audit trail: a field declared content-free must
+// reach audit_log as a presence flag, never as its value.
+//
+// It matters more here than on the native path. A mirrored activity body is
+// INCUMBENT-sourced customer correspondence, and audit_log is append-only,
+// retained under the compliance floor, and served verbatim to unbounded
+// readers — so a value copied there survives both Art. 17 erasure and
+// disconnect teardown, neither of which reaches audit_log.
+//
+// The obligation is derived from contentFreeAuditFields rather than restated,
+// so declaring a new content-free field gates it automatically.
+func TestAuditImagesNeverCarryContentFreeFieldValues(t *testing.T) {
+	for et, contentFree := range contentFreeAuditFields {
+		for field := range contentFree {
+			image := map[string]any{
+				field:   "the incumbent's own message text",
+				"other": "kept as-is",
+			}
+			got := minimizeAuditImage(et, image)
+
+			if got[field] != true {
+				t.Errorf("%s %s in an audit image = %v, want the presence flag true — the value must never reach audit_log",
+					et, field, got[field])
+			}
+			if got["other"] != "kept as-is" {
+				t.Errorf("%s: minimizing dropped an unrelated field (%v); only content-free fields are narrowed", et, got["other"])
+			}
+			if image[field] != "the incumbent's own message text" {
+				t.Errorf("%s: minimizing mutated the caller's map — the patch is still needed downstream for the incumbent write", et)
+			}
+		}
+	}
+}
+
+// TestAfterIncumbentCommitOutlivesACancelledCaller pins the property the
+// local half of a write-back depends on: once the incumbent has committed,
+// the caller going away must not abandon the bookkeeping.
+//
+// Without it, a user who fires an archive and closes the tab leaves a record
+// that no longer exists at the incumbent still listed, still readable, and
+// with no audit row — until the next full reconcile sweep. The context must
+// also keep carrying its values, since the workspace binding the RLS GUC and
+// the audit attribution both read lives there.
+func TestAfterIncumbentCommitOutlivesACancelledCaller(t *testing.T) {
+	type ctxKey string
+	const bound ctxKey = "workspace"
+
+	parent, cancel := context.WithCancel(context.WithValue(context.Background(), bound, "ws-1"))
+	local, release := afterIncumbentCommit(parent)
+	defer release()
+
+	cancel() // the caller hangs up
+
+	if err := local.Err(); err != nil {
+		t.Errorf("the local half's context died with its caller: %v — the incumbent write it describes has already committed", err)
+	}
+	if got := local.Value(bound); got != "ws-1" {
+		t.Errorf("the local half lost its context values (workspace = %v); the RLS binding and audit attribution both read from there", got)
+	}
+	if _, hasDeadline := local.Deadline(); !hasDeadline {
+		t.Error("the local half has no deadline of its own — detached work without one hangs a request worker on a stalled database")
+	}
+}
+
+// TestWritePathErrorCollapsesTheFenceSignal proves the disconnect fence's
+// internal control signal does not escape the write path as an opaque 500.
+// A disconnect racing an in-flight write is "this workspace no longer reads
+// from an incumbent" — the same 404 every other post-disconnect request
+// answers — not a server fault. Anything else passes through untouched, so
+// a real failure is never masked as a routing answer.
+func TestWritePathErrorCollapsesTheFenceSignal(t *testing.T) {
+	if err := writePathError(ErrConnectionGone); !errors.Is(err, apperrors.ErrModeNotOverlay) {
+		t.Errorf("writePathError(ErrConnectionGone) = %v, want ErrModeNotOverlay", err)
+	}
+	if err := writePathError(fmt.Errorf("wrapped: %w", ErrConnectionGone)); !errors.Is(err, apperrors.ErrModeNotOverlay) {
+		t.Errorf("writePathError on a wrapped fence signal = %v, want ErrModeNotOverlay", err)
+	}
+	other := errors.New("the database went away")
+	if err := writePathError(other); !errors.Is(err, other) {
+		t.Errorf("writePathError(%v) = %v, want it passed through — collapsing it would hide a real failure behind a 404", other, err)
+	}
+	if writePathError(nil) != nil {
+		t.Error("writePathError(nil) must stay nil")
+	}
+}
+
+// TestArchiveAuditImagesStayNil proves an archive's images survive
+// minimization as nil. An archive changes no field values — the native
+// archive audits (nil, nil) — and an empty object in their place would read
+// as "every field changed to nothing" in a field-history projection.
+func TestArchiveAuditImagesStayNil(t *testing.T) {
+	if got := minimizeAuditImage(datasource.EntityActivity, nil); got != nil {
+		t.Errorf("minimizing a nil audit image = %v, want nil", got)
+	}
 }
 
 // TestUnsupportedWriteNamesTheEntityWhenTheMirrorDoesNotCarryIt proves the

--- a/backend/internal/platform/httperr/httperr.go
+++ b/backend/internal/platform/httperr/httperr.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/values"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
 )
 
 const problemTypeBase = "https://errors.gradion.com/"
@@ -57,6 +58,65 @@ var mapping = []struct {
 	{apperrors.ErrIncumbentBudgetExhausted, http.StatusServiceUnavailable, "incumbent_budget_exhausted"},
 }
 
+// clientInputValidation maps the typed errors that mean "the CALLER got the
+// request wrong" onto their contract validation shape — each carrying its own
+// field and machine code, so the client is told which input to fix rather than
+// being handed a generic 422. It reports false for anything else, leaving the
+// sentinel table (and ultimately the opaque 500) to answer.
+//
+// They are collected in one place because they share a single decision: none
+// of them is a server fault, so none of them may reach the unhandled-error
+// branch — a client mistake answered as a 500 sends the caller looking for an
+// outage that is not there.
+func clientInputValidation(err error) (error, bool) {
+	// The keyset cursor is client input: a token that fails to decode is
+	// the caller's fault, same 422 shape as every other bad query input.
+	var badCursor *storekit.MalformedCursorError
+	if errors.As(err, &badCursor) {
+		return Validation("cursor", "malformed_cursor", "cursor is not a valid page token"), true
+	}
+
+	// A cursor that decodes but was minted under a different sort carries
+	// the contract's dedicated code — the caller re-issues the query
+	// without the cursor (or under the sort it was minted with).
+	var cursorMismatch *storekit.CursorSortMismatchError
+	if errors.As(err, &cursorMismatch) {
+		return Validation("cursor", "cursor_param_mismatch",
+			"cursor was minted under a different sort; re-issue the query without the cursor"), true
+	}
+
+	// The list vocabularies' typed refusals (data-model §13.5): a sort
+	// spec or filter leaf outside the resource's closed vocabulary carries
+	// its own field and machine code — one wire mapping, like the cursor's.
+	var badSort *storekit.SortError
+	if errors.As(err, &badSort) {
+		return Validation("sort", badSort.Code, badSort.Message), true
+	}
+	var badPredicate *storekit.PredicateError
+	if errors.As(err, &badPredicate) {
+		return Validation(badPredicate.Field, badPredicate.Code, badPredicate.Message), true
+	}
+
+	// A value object refused to parse: client input in the wrong format,
+	// carrying its own field and machine code — the parse-don't-validate
+	// seam's single wire mapping.
+	var badValue *values.ParseError
+	if errors.As(err, &badValue) {
+		return Validation(badValue.Field, badValue.Code, badValue.Message), true
+	}
+
+	// A write payload the datasource seam refused to decode — an unknown or
+	// misspelled field, or a value of the wrong type. datasource's own doc
+	// states it maps to 422 on every surface; this is the branch that makes
+	// that true for HTTP rather than letting it fall through to the 500.
+	var badFields *datasource.FieldDecodeError
+	if errors.As(err, &badFields) {
+		return Validation("fields", "invalid_field", badFields.Cause.Error()), true
+	}
+
+	return nil, false
+}
+
 // Write maps err onto the wire. Unknown errors become an opaque 500 — the
 // cause is logged server-side, never leaked to the client.
 func Write(w http.ResponseWriter, r *http.Request, err error) {
@@ -71,44 +131,8 @@ func Write(w http.ResponseWriter, r *http.Request, err error) {
 		return
 	}
 
-	// The keyset cursor is client input: a token that fails to decode is
-	// the caller's fault, same 422 shape as every other bad query input.
-	var badCursor *storekit.MalformedCursorError
-	if errors.As(err, &badCursor) {
-		Write(w, r, Validation("cursor", "malformed_cursor", "cursor is not a valid page token"))
-		return
-	}
-
-	// A cursor that decodes but was minted under a different sort carries
-	// the contract's dedicated code — the caller re-issues the query
-	// without the cursor (or under the sort it was minted with).
-	var cursorMismatch *storekit.CursorSortMismatchError
-	if errors.As(err, &cursorMismatch) {
-		Write(w, r, Validation("cursor", "cursor_param_mismatch",
-			"cursor was minted under a different sort; re-issue the query without the cursor"))
-		return
-	}
-
-	// The list vocabularies' typed refusals (data-model §13.5): a sort
-	// spec or filter leaf outside the resource's closed vocabulary carries
-	// its own field and machine code — one wire mapping, like the cursor's.
-	var badSort *storekit.SortError
-	if errors.As(err, &badSort) {
-		Write(w, r, Validation("sort", badSort.Code, badSort.Message))
-		return
-	}
-	var badPredicate *storekit.PredicateError
-	if errors.As(err, &badPredicate) {
-		Write(w, r, Validation(badPredicate.Field, badPredicate.Code, badPredicate.Message))
-		return
-	}
-
-	// A value object refused to parse: client input in the wrong format,
-	// carrying its own field and machine code — the parse-don't-validate
-	// seam's single wire mapping.
-	var badValue *values.ParseError
-	if errors.As(err, &badValue) {
-		Write(w, r, Validation(badValue.Field, badValue.Code, badValue.Message))
+	if v, ok := clientInputValidation(err); ok {
+		Write(w, r, v)
 		return
 	}
 

--- a/backend/internal/platform/httperr/httperr.go
+++ b/backend/internal/platform/httperr/httperr.go
@@ -108,10 +108,17 @@ func clientInputValidation(err error) (error, bool) {
 	// A write payload the datasource seam refused to decode — an unknown or
 	// misspelled field, or a value of the wrong type. datasource's own doc
 	// states it maps to 422 on every surface; this is the branch that makes
-	// that true for HTTP rather than letting it fall through to the 500.
+	// that true for HTTP rather than letting it fall through to the 500 a
+	// pure client mistake must never answer with.
+	//
+	// The cause names which field and why, matching what httperr.Decode
+	// already puts on the wire for the same class from the native path; the
+	// sentence after it is what the caller should DO, which a decoder message
+	// on its own never says.
 	var badFields *datasource.FieldDecodeError
 	if errors.As(err, &badFields) {
-		return Validation("fields", "invalid_field", badFields.Cause.Error()), true
+		return Validation("fields", "invalid_field",
+			badFields.Cause.Error()+" — check the field names and value types against this operation's request schema"), true
 	}
 
 	return nil, false

--- a/frontend/src/app/options.ts
+++ b/frontend/src/app/options.ts
@@ -1,0 +1,25 @@
+/**
+ * Narrowing for `<select>` values.
+ *
+ * A change handler receives `event.target.value` as a plain `string`. The
+ * union the state setter wants (`Region`, `Role`, `DsrKind`, …) is narrower,
+ * and asserting across that gap with `as` is an unchecked claim: it holds only
+ * as long as the rendered options and the union stay in step, and nothing
+ * checks that they do. Browser autofill, an extension, a replayed form post,
+ * or simply an option list that drifts from its type all produce a value the
+ * assertion swears is impossible, and the bad value then flows into state and
+ * out to the API unexamined.
+ *
+ * `isOption` closes it with an actual runtime check, so callers narrow by
+ * evidence instead of by assertion.
+ */
+export function isOption<T extends string>(
+  value: string,
+  options: readonly T[],
+): value is T {
+  // The one cast here WIDENS T[] to string[] — the provably safe direction,
+  // since T extends string. It exists only because Array.includes types its
+  // argument as the element type, which would reject the very string we are
+  // testing.
+  return (options as readonly string[]).includes(value);
+}

--- a/frontend/src/screens/leads.tsx
+++ b/frontend/src/screens/leads.tsx
@@ -3,6 +3,7 @@ import { useId, useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { ifMatch } from "../api/version";
+import { isOption } from "../app/options";
 import { navigate } from "../app/router";
 import {
   Badge,
@@ -634,9 +635,11 @@ function LeadOverviewPane({
                     className="input"
                     aria-label={t("lead.trigger")}
                     value={trigger}
-                    onChange={(event) =>
-                      setTrigger(event.target.value as PromoteTrigger)
-                    }
+                    onChange={(event) => {
+                      const value = event.target.value;
+                      const triggers = PROMOTE_TRIGGERS.map((o) => o.value);
+                      if (isOption(value, triggers)) setTrigger(value);
+                    }}
                   >
                     {PROMOTE_TRIGGERS.map((option) => (
                       <option key={option.value} value={option.value}>

--- a/frontend/src/screens/overlay.tsx
+++ b/frontend/src/screens/overlay.tsx
@@ -6,6 +6,7 @@ import { Plug } from "lucide-react";
 import { useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
+import { isOption } from "../app/options";
 import {
   Badge,
   Button,
@@ -123,7 +124,10 @@ function OverlayConnectForm({
           id="overlay-region"
           className="input"
           value={region}
-          onChange={(event) => setRegion(event.target.value as Region)}
+          onChange={(event) => {
+            const value = event.target.value;
+            if (isOption(value, REGIONS)) setRegion(value);
+          }}
         >
           {REGIONS.map((r) => (
             <option key={r} value={r}>

--- a/frontend/src/screens/privacy.tsx
+++ b/frontend/src/screens/privacy.tsx
@@ -45,6 +45,7 @@ import {
   nextStatuses,
 } from "./privacy.logic";
 import "./privacy.css";
+import { isOption } from "../app/options";
 
 type DataSubjectRequest = components["schemas"]["DataSubjectRequest"];
 type CreateDataSubjectRequest =
@@ -350,7 +351,10 @@ function NewDsrForm({ onDone }: Readonly<{ onDone: () => void }>) {
             id={kindId}
             className="input"
             value={kind}
-            onChange={(event) => changeKind(event.target.value as DsrKind)}
+            onChange={(event) => {
+              const value = event.target.value;
+              if (isOption(value, DSR_KINDS)) changeKind(value);
+            }}
           >
             {DSR_KINDS.map((value) => (
               <option key={value} value={value}>

--- a/frontend/src/screens/relationships.tsx
+++ b/frontend/src/screens/relationships.tsx
@@ -7,6 +7,7 @@ import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { ifMatch } from "../api/version";
 import type { EntityKind } from "../app/entity";
+import { isOption } from "../app/options";
 import {
   Badge,
   Button,
@@ -370,9 +371,11 @@ function AddRelationshipAction({
               id={`${headingId}-kind`}
               className="input"
               value={kind}
-              onChange={(event) =>
-                selectKind(event.target.value as RelationshipKind)
-              }
+              onChange={(event) => {
+                const value = event.target.value;
+                const kinds = options.map((o) => o.kind);
+                if (isOption(value, kinds)) selectKind(value);
+              }}
             >
               {options.map((option) => (
                 <option key={option.kind} value={option.kind}>

--- a/frontend/src/screens/users-admin.tsx
+++ b/frontend/src/screens/users-admin.tsx
@@ -14,6 +14,7 @@ import { ConfirmModal } from "../design-system/confirmmodal";
 import { useT } from "../i18n";
 import { problemMessage, QueryGate, useMe } from "./common";
 import "./users-admin.css";
+import { isOption } from "../app/options";
 
 type User = components["schemas"]["User"];
 type Role = components["schemas"]["ChangeUserRoleRequest"]["role"];
@@ -141,7 +142,10 @@ function InviteForm() {
         className="input"
         aria-label={t("users.roleLabel")}
         value={role}
-        onChange={(e) => setRole(e.target.value as Role)}
+        onChange={(e) => {
+          const value = e.target.value;
+          if (isOption(value, ROLES)) setRole(value);
+        }}
       >
         {ROLES.map((r) => (
           <option key={r} value={r}>
@@ -235,8 +239,9 @@ function MemberRow({ member }: Readonly<{ member: User }>) {
         value=""
         disabled={pending}
         onChange={(e) => {
-          if (e.target.value) {
-            setRole.mutate(e.target.value as Role);
+          const value = e.target.value;
+          if (isOption(value, ROLES)) {
+            setRole.mutate(value);
           }
         }}
       >


### PR DESCRIPTION
## Why

PR #258 exposed overlay write-back on the REST surface. Three accommodations that were defensible while the mirror was a background derived cache stopped being defensible the moment a human mutation rode the same path. A code review of #258 found them; three independent adversarial reviews of the same surface found six more, plus one that was directly exploitable.

## The three that motivated this

**No audit trail on a canonical write.** `Provider.Update`/`Archive` performed the incumbent write and refreshed the mirror with no `storekit.Audit` or `Emit` anywhere. The mirror's own ingest is deliberately audit-free — a poller refresh is not a domain mutation — but nothing added the domain-mutation half back for a human write. A user could change or archive a record in the customer's HubSpot through `/v1` and leave no attributable record of who did it, so the audit screen and exports could not replay it.

The write-back now commits its `audit_log` row and its public event in the **same transaction** as the mirror refresh (`writeaudit.go`). The canonical row lives at the incumbent, so the literal "domain row + audit + outbox in ONE transaction" is not available; what *is* local commits together, and a caller never sees a refreshed mirror row with no audit trail. The event is the same `person.updated` / `person.archived` a native write emits, so no subscriber needs to know which system of record served it.

**A capability only one transport honored** — the exploitable one. `SupportsWrite` declares create unsupported for every type: the write mapping leaves `owner_id` read-only, so a created incumbent record is unowned, and the NULL-OWNER rule then writes no visibility row — the record exists in the customer's CRM and is invisible to everyone, including its author. Only the REST guard consulted that declaration. The agent tool surface (`create_record`, `log_activity` — both **auto-execute**, no confirm-first staging) and the automation engine reach the verbs through the datasource seam with no router in between. The read-back after such a create hits the visibility deny-join and answers not-found, which reads to an agent as a failure worth retrying, and HubSpot's v3 create has no idempotency key. An unattended loop could mint unbounded invisible records. `requireSupportedWrite` now enforces the declaration inside each write verb, where every caller passes.

**Mode resolved from a stale cache at the mutation boundary.** `x_sor_mode` rode a 5s process-local cache whose invalidation reaches only the process that committed the flip. A second api replica could route a `PATCH` to the native module handler for the rest of the TTL after a workspace connected — committing to a native table no overlay read serves and that never reaches HubSpot. That is silent divergence, not a stale screen. Every mutation boundary now re-reads the workspace row; reads keep the cache, which is the whole reason it exists. The code already carried a note deferring this "to the branch-2 write-back work" — that work is what #258 shipped.

## Also fixed, from the adversarial reviews

- **Archive answered 200 with a body reporting the record as live.** It now carries `archived_at`.
- **Echo ledger opened before the mirror write.** Entries committed + mirror write failed meant the healing webhook was classified as our own echo and dropped, freezing a stale row behind permanent 409s until the next poller sweep. The ledger now follows the commit — the costs are not symmetric (opening late costs one redundant re-fetch; opening early costs a frozen record).
- **Post-commit work rode the request context**, so a closed tab left an archived record listed and readable until the next full sweep. The local half now outlives the caller under its own deadline.
- **`PurgeRecord` ignored the fence it was invoked through**, so a post-disconnect purge could still emit `mirror.deleted` into a workspace already back in native mode.
- **`ErrConnectionGone` escaped the write path as a 500** instead of the 404 `mode_not_overlay` every other post-disconnect request answers.
- **`reconcileOne` re-derived the ingest's staleness predicate against pre-ingest data**, announcing `mirror.conflict` for overwrites that never landed.
- **`Provider.Freshness` skipped the object-RBAC gate** its sibling read verbs all apply.
- **`FieldDecodeError` had no `httperr` branch** — a misspelled write field answered 500 where its own doc promises "422 on every surface".
- **Every overlay-served body omitted `captured_by`**, which all five entity schemas mark required.
- **Overlay search paged 25 / max 100** against the shared `Limit` parameter's default 50 / max 200, citing a ceiling that belongs to a different operation.
- **`event.target.value as Region`** narrowed by assertion. Fixed as a shared `isOption` helper across all six `<select>` sites, not just the one under review.

## Tests

- `overlay_write_audit_integration_test.go` — the audit row and outbox event on update and archive, attributed to the authenticated human; and **no** audit row after a refused write (the trail records what happened, not what was attempted).
- `writegovernance_test.go` — a fitness test binding every `(verb, entity)` pair's refusal to `SupportsWrite`, so the declaration and the enforcement cannot drift; plus that the two refusal shapes stay distinguishable.
- `dispatcherwritemode_test.go` — a dispatcher whose cache is poisoned with `native` cannot route a write natively after the flip, and reads still answer from the cache.

`make check`, `make test-integration` (`0 skips`), and `craft static` (0 blockers) are green locally.

## Deliberately NOT in this PR

Both are real, both are pinned by existing tests as deliberate, and both need a decision I should not make inside a fix PR:

1. **Caller↔mirror lost update.** The AC-OV-4 drift check compares HubSpot against the mirror baseline read *at write time*, which closes the mirror↔incumbent gap and leaves the caller↔mirror gap open: a user loads a record, a third party edits it in HubSpot, the poller mirrors that edit, and the user's stale PATCH now passes the drift check and overwrites it. `If-Match` is declared on all five update ops and ignored on this path. Fixing it needs a version (or baseline echo) on mirror rows — and the contract is itself ambiguous, since `RowVersion` says version semantics apply "not only overlay mode". **This is the most important follow-up.**
2. **Contract-writable fields the mapping silently drops.** `owner_id` on every type, deal `status`, lead `score`, activity `is_done` and others are declared patchable but absent from the write mapping; a patch of only such fields answers 200 with the record unchanged. The contract's own overlay clause forbids exactly this ("never a silent break"). The honest fix is a 422 naming the unwritable fields, which changes what the SPA's edit form gets back in overlay mode.

Several smaller contract divergences (undeclared 409s on some ops, the ad-hoc `unsupported_in_overlay_mode` code, fabricated `Lead.score`/`status`, timestamps served as `last_synced_at`) are spec-reconciliation items for `margince-foundation` under P3, not workarounds to apply here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Secures the overlay write-back path with full audit and safer routing, and reduces redundant mode lookups on REST writes. Also minimizes sensitive data in audit images, tightens error handling, RBAC, paging, and select inputs, and includes small refactors.

- **New Features**
  - Audit row and public event committed with the mirror refresh in one transaction (`writeaudit.go`).
  - Enforce declared write capability inside each verb (`SupportsWrite`) for all transports.
  - Writes re-read workspace mode uncached; reads keep the cache.

- **Bug Fixes**
  - Audit images minimize sensitive content; activity `body` is recorded as presence only.
  - Archive responses include `archived_at`; overlay bodies include `captured_by`.
  - Proper error codes: 422 for field decode; 404 `mode_not_overlay` after disconnect.
  - `Freshness` enforces object RBAC; reconcile uses landed ingest result; echo ledger opens after mirror commit.
  - Post-commit work runs under its own deadline; `PurgeRecord` honors the overlay fence.
  - Overlay search defaults to 50 and clamps to 200; frontend `<select>`s validate with `isOption`.
  - Performance: one workspace-mode read per REST write; tests pin the count.
  - Refactor: archive wiring bundled as `archiveWire`; prior owner read split into `priorOwnerOf` to lower complexity.

<sup>Written for commit 101673e669d4e273336fe7c4e74924028de4aab5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Overlay writes now use the latest workspace mode, reducing routing errors caused by stale settings.
  * Overlay updates and archives record audit activity and stage corresponding events.
  * Overlay search supports larger result pages, up to 200 items.
  * Overlay records now include capture-source information.
* **Bug Fixes**
  * Unsupported write actions are rejected consistently before processing.
  * Archived responses now correctly show the archived state.
  * Freshness checks now enforce read permissions.
  * Selection controls reject invalid values instead of storing them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->