### PR TITLE
docs(overlay): correct the write-back test path — MCP update_record, not REST PATCH

### DIFF
--- a/docs/how-to/test-overlay-locally.md
+++ b/docs/how-to/test-overlay-locally.md
@@ -91,14 +91,35 @@ Or just open **http://localhost:8080** and log in — the SPA renders the mirror
 `last_synced_at` freshness affordance.
 
 ### Test write-back (mutates the test portal only)
+
+Write-back goes through the **agent/MCP tool seam**, NOT the REST record endpoints. In overlay
+mode a direct `PATCH /v1/deals/{id}` (or any native REST create/update/archive) is refused with
+`422 unsupported_by_sor` for **every** principal — human *and* passport — because those handlers
+write the empty native tables and bypass the write-back seam (`overlayWriteGuard`). Routing the REST
+handlers to write-back is a declared follow-up; today you exercise write-back through the
+`update_record` tool:
+
 ```sh
-DEAL=$(curl -sS 'http://localhost:8080/v1/deals?limit=1' -b cookies.txt | jq -r '.data[0].id')
-curl -sS -X PATCH "http://localhost:8080/v1/deals/$DEAL" -b cookies.txt \
-  -H 'content-type: application/json' -d '{"name":"[fixture] Acme Renewal (edited)"}'
+# 1. Mint a passport with write scope (session-authed)
+TOKEN=$(curl -sS -X POST http://localhost:18080/v1/passports -b cookies.txt \
+  -H 'content-type: application/json' \
+  -d '{"label":"write-back test","scopes":["read","write"]}' | jq -r .token)
+
+# 2. Call update_record over the MCP stdio server. It needs the app-role DSN and the SAME
+#    keyvault root key the running api uses (it unseals the sealed HubSpot token); in dev that
+#    key lives in .env.local as MARGINCE_KEYVAULT_ROOT_KEY.
+DEAL=$(curl -sS 'http://localhost:18080/v1/deals?limit=1' -b cookies.txt | jq -r '.data[0].id')
+printf '%s\n%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"wb","version":"0"}}}' \
+  "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"update_record\",\"arguments\":{\"record_type\":\"deal\",\"id\":\"$DEAL\",\"fields\":{\"name\":\"[fixture] Acme Renewal (edited)\"}}}}" \
+  | ( cd backend && MARGINCE_PASSPORT_TOKEN="$TOKEN" \
+      MARGINCE_DSN='postgres://margince_app:margince_app_dev@localhost:55432/margince' \
+      MARGINCE_KEYVAULT_ROOT_KEY="$(grep -E '^MARGINCE_KEYVAULT_ROOT_KEY=' ../.env.local | cut -d= -f2-)" \
+      go run ./cmd/mcp )
 ```
-It writes to HubSpot **first**, then re-mirrors — confirm the rename in the test account's HubSpot UI.
-(`advance-deal`, `merge`, and `promote-lead` still answer `unsupported_by_sor` — they're not wired for
-overlay yet.)
+The tool result echoes the re-mirrored record; it writes to HubSpot **first**, then re-mirrors —
+confirm the rename in the test account's HubSpot UI. (`advance_deal`, `merge_records`, and
+`promote_lead` answer `unsupported_by_sor` — not wired for overlay yet.)
 
 ### Disconnect + teardown
 ```sh


### PR DESCRIPTION
## What
Running the write-back check live against real HubSpot revealed the write-back section of `test-overlay-locally.md` (added in #245) was **wrong**: it told users to `PATCH /v1/deals/{id}`, which in overlay mode is refused with `422 unsupported_by_sor` for **every** principal — human *and* passport — by `overlayWriteGuard` (those native REST handlers write the empty native tables and bypass the write-back seam; routing them to write-back is a declared in-code follow-up).

The section now documents the path that actually works and is **verified end-to-end**: mint a passport with `write` scope → call the `update_record` tool over the `cmd/mcp` stdio server (it routes through the agent tool registry → dispatcher → `overlay.Update` → HubSpot).

## Verified
Ran it against the live developer portal: `update_record` renamed a fixture deal, and HubSpot's own API confirmed the change (margince → HubSpot-first → re-mirror). One gotcha now captured in the doc: the MCP process needs the api's **keyvault root key** (`.env.local`) to unseal the sealed incumbent token — without it the write-back fails with `keyvault: secret could not be decrypted`.

Docs-only; no code change. (The overlay write-back *engine* is correct and unit-tested — #224 — this only fixes how to reach it.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects overlay write-back docs: use MCP `update_record` over `cmd/mcp`, not REST `PATCH /v1/deals/{id}` (blocked by `overlayWriteGuard`). Adds steps to mint a write-scoped passport and required envs (`MARGINCE_DSN`, `MARGINCE_KEYVAULT_ROOT_KEY`), verified end-to-end against HubSpot.

<sup>Written for commit 8701a9c01a7c77db8d9d246090816419c9ca3ac4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated local overlay testing instructions to use the `update_record` tool for write-back operations.
  * Clarified that direct REST updates are rejected when they bypass the supported write-back flow.
  * Added guidance for authenticating, resolving records, and invoking the MCP tool locally.
  * Documented expected re-mirroring behavior and unsupported tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->