### PR TITLE
fix(overlay-fixture): stop HubSpot minting a nameless company from shared contact domain

### DIFF
--- a/scripts/overlay-hubspot-fixture.sh
+++ b/scripts/overlay-hubspot-fixture.sh
@@ -122,8 +122,11 @@ archive_marked() {
 
 cmd_reset() {
   echo "resetting fixture records (marker: @${EMAIL_DOMAIN} / '${NAME_PREFIX}')…"
+  # Match the domain anywhere in the email (not "*@"+domain): contact emails now
+  # carry a per-company subdomain (ada@acme.overlay-fixture.example.com), so the
+  # bare "@domain" anchor would miss them.
   archive_marked contacts "$(jq -n --arg d "$EMAIL_DOMAIN" \
-    '{filterGroups:[{filters:[{propertyName:"email",operator:"CONTAINS_TOKEN",value:("*@"+$d)}]}],properties:["email"],limit:100}')"
+    '{filterGroups:[{filters:[{propertyName:"email",operator:"CONTAINS_TOKEN",value:("*"+$d)}]}],properties:["email"],limit:100}')"
   archive_marked companies "$(jq -n --arg d "$EMAIL_DOMAIN" \
     '{filterGroups:[{filters:[{propertyName:"domain",operator:"CONTAINS_TOKEN",value:("*"+$d)}]}],properties:["domain"],limit:100}')"
   archive_marked deals "$(jq -n --arg p "$NAME_PREFIX" \
@@ -147,9 +150,13 @@ cmd_seed() {
 
   # Contacts
   local ada grace linus
-  ada="$(create contacts "$(jq -n --arg o "$OWNER_ID" '{properties:{email:"ada.fixture@overlay-fixture.example.com",firstname:"Ada",lastname:"Lovelace",hubspot_owner_id:$o}}')")"
-  grace="$(create contacts "$(jq -n --arg o "$OWNER_ID" '{properties:{email:"grace.fixture@overlay-fixture.example.com",firstname:"Grace",lastname:"Hopper",hubspot_owner_id:$o}}')")"
-  linus="$(create contacts "$(jq -n --arg o "$OWNER_ID" '{properties:{email:"linus.fixture@overlay-fixture.example.com",firstname:"Linus",lastname:"Torvalds",hubspot_owner_id:$o}}')")"
+  # Each contact's email domain matches ITS company's domain (acme./globex.),
+  # so HubSpot's "Create and associate companies with contacts" setting
+  # auto-associates the contact to the EXISTING Acme/Globex company instead of
+  # minting a nameless, ownerless company for a shared bare domain.
+  ada="$(create contacts "$(jq -n --arg o "$OWNER_ID" '{properties:{email:"ada.fixture@acme.overlay-fixture.example.com",firstname:"Ada",lastname:"Lovelace",hubspot_owner_id:$o}}')")"
+  grace="$(create contacts "$(jq -n --arg o "$OWNER_ID" '{properties:{email:"grace.fixture@acme.overlay-fixture.example.com",firstname:"Grace",lastname:"Hopper",hubspot_owner_id:$o}}')")"
+  linus="$(create contacts "$(jq -n --arg o "$OWNER_ID" '{properties:{email:"linus.fixture@globex.overlay-fixture.example.com",firstname:"Linus",lastname:"Torvalds",hubspot_owner_id:$o}}')")"
   associate contacts "$ada" companies "$acme"
   associate contacts "$grace" companies "$acme"
   associate contacts "$linus" companies "$globex"


### PR DESCRIPTION
## What
While looking at an overlay-mirrored organization with a `null` name, we traced it to HubSpot — not our data. The seed script gave all three fixture contacts the same **bare** email domain (`@overlay-fixture.example.com`). With the test account's *"Create and associate companies with contacts"* setting on, HubSpot auto-created **one nameless, ownerless company** for that shared domain and linked all three contacts to it. That record then mirrored into margince as an organization with no `display_name` and no owner (so invisible in the app) — easy to mistake for broken data.

## Fix
Give each contact the email domain of **its** company (`ada@acme.overlay-fixture.example.com`, `linus@globex.overlay-fixture.example.com`), so HubSpot's auto-association resolves to the **existing** Acme/Globex company instead of minting a domain company. The contact reset marker moves from `"*@"+domain` to `"*"+domain` so it still matches the per-company-subdomain emails.

## Verified live
Re-seeded against the real developer portal:
- Exactly **2 companies**, both named (`[fixture] Acme Overlay`, `[fixture] Globex Overlay`) — no nameless record.
- Each contact has exactly **1** company association, to its real company.
- The reset marker finds all 3 new contacts (future resets stay clean).

Dev/test script only — no product code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix overlay fixture seeding so HubSpot no longer creates a nameless “domain company”. Contacts now use per-company email subdomains so auto-association links them to the right company.

- **Bug Fixes**
  - Seed contacts use company-specific subdomains (ada@acme…, grace@acme…, linus@globex…).
  - Widened contact reset filter from "*@domain" to "*domain" to match new emails.
  - Verified live: two named companies; each contact correctly linked; no nameless record.

<sup>Written for commit e40c45e700b080ca67abe4025d7b434680e28e27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fixture contact cleanup to include emails using company-specific subdomains.
  * Updated fixture contact creation so contacts are correctly associated with their respective companies.
  * Updated fixture data and guidance to reflect the revised email patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->