### PR TITLE
agents: refuse to resume a transcript written before observations were bounded

### DIFF
--- a/backend/internal/modules/agents/runner/runner.go
+++ b/backend/internal/modules/agents/runner/runner.go
@@ -140,10 +140,23 @@ type Pending struct {
 	// with. It travels WITH the window: a resumed run that minted a
 	// fresh marker would be telling the model to honour a boundary its
 	// own stored text does not carry.
-	Fence        promptfence.Fence
-	StepsUsed    int
-	OutputTokens int
+	Fence promptfence.Fence
+	// TranscriptVersion records the rules the stored Window's spans were
+	// written under. The fence alone does not say whether they hold: a
+	// transcript bounded with Wrap rather than WrapAuthored carries a marker
+	// the model was free to close, so it may ALREADY contain prompt-voice
+	// text inside what looks like a span. Absent (zero) means it predates
+	// that fix and cannot be told apart from an escaped one after the fact.
+	TranscriptVersion int
+	StepsUsed         int
+	OutputTokens      int
 }
+
+// neutralisedObservations is the current transcript version: every observation
+// bounded with [promptfence.Fence.WrapAuthored], so nothing the model wrote can
+// end its own span. Bump this whenever a change makes an OLD transcript unsafe
+// to resume — the resume path refuses anything older rather than guessing.
+const neutralisedObservations = 1
 
 type Runner struct {
 	tools Invoker
@@ -173,7 +186,7 @@ type Decision struct {
 // silently changed under an approved diff). Rejected: the refusal is
 // observed and the model re-plans without that action.
 func (r *Runner) Resume(ctx context.Context, job Job, dec Decision) (Result, error) {
-	win, err := windowFromSnapshot(job, r.tools.Specs(), dec.Pending.Window, dec.Pending.Fence)
+	win, err := windowFromSnapshot(job, r.tools.Specs(), dec.Pending.Window, dec.Pending.Fence, dec.Pending.TranscriptVersion)
 	if err != nil {
 		return Result{}, err
 	}
@@ -309,13 +322,14 @@ func suspend(acc Result, approvalID ids.ApprovalID, step modelStep, win *window,
 		Admission: "staged",
 	})
 	acc.Pending = &Pending{
-		ApprovalID:   approvalID,
-		Tool:         step.Tool,
-		Args:         step.Args,
-		Window:       win.snapshot(),
-		Fence:        win.fence,
-		StepsUsed:    acc.StepsUsed,
-		OutputTokens: acc.OutputTokens,
+		ApprovalID:        approvalID,
+		Tool:              step.Tool,
+		Args:              step.Args,
+		Window:            win.snapshot(),
+		Fence:             win.fence,
+		TranscriptVersion: neutralisedObservations,
+		StepsUsed:         acc.StepsUsed,
+		OutputTokens:      acc.OutputTokens,
 	}
 	return acc
 }

--- a/backend/internal/modules/agents/runner/runner_test.go
+++ b/backend/internal/modules/agents/runner/runner_test.go
@@ -191,7 +191,8 @@ func TestResumeApprovedRedeemsWithApprovalID(t *testing.T) {
 	}}
 	brain := &scriptedBrain{texts: []string{`{"final":{"summary":"sent after approval"}}`}}
 	pending := Pending{
-		ApprovalID: approvalID, Tool: "send_email",
+		TranscriptVersion: neutralisedObservations,
+		ApprovalID:        approvalID, Tool: "send_email",
 		Args:      json.RawMessage(`{"to":"a@b.c"}`),
 		Window:    []model.Message{{Role: "user", Content: "Goal: follow up"}},
 		Fence:     promptfence.New(),
@@ -220,7 +221,8 @@ func TestResumeRejectedObservesAndReplans(t *testing.T) {
 	surface := &fakeSurface{}
 	brain := &scriptedBrain{texts: []string{`{"final":{"summary":"skipped the send"}}`}}
 	pending := Pending{
-		ApprovalID: ids.New[ids.ApprovalKind](), Tool: "send_email",
+		TranscriptVersion: neutralisedObservations,
+		ApprovalID:        ids.New[ids.ApprovalKind](), Tool: "send_email",
 		Args:   json.RawMessage(`{"to":"a@b.c"}`),
 		Window: []model.Message{{Role: "user", Content: "Goal: follow up"}},
 		Fence:  promptfence.New(),
@@ -250,7 +252,8 @@ func TestResumeApprovedVersionSkewIsObservedNotFatal(t *testing.T) {
 	}}
 	brain := &scriptedBrain{texts: []string{`{"final":{"summary":"could not apply; reported"}}`}}
 	pending := Pending{
-		ApprovalID: ids.New[ids.ApprovalKind](), Tool: "send_email",
+		TranscriptVersion: neutralisedObservations,
+		ApprovalID:        ids.New[ids.ApprovalKind](), Tool: "send_email",
 		Args:   json.RawMessage(`{"to":"a@b.c"}`),
 		Window: []model.Message{{Role: "user", Content: "Goal: follow up"}},
 		Fence:  promptfence.New(),
@@ -505,7 +508,8 @@ func windowMarker(t *testing.T, system string) string {
 // name a boundary its own stored text does not have, so it is refused.
 func TestResumeRefusesASnapshotWithNoBoundary(t *testing.T) {
 	pending := Pending{
-		ApprovalID: ids.New[ids.ApprovalKind](), Tool: "send_email",
+		TranscriptVersion: neutralisedObservations,
+		ApprovalID:        ids.New[ids.ApprovalKind](), Tool: "send_email",
 		Args:      json.RawMessage(`{"to":"a@b.c"}`),
 		Window:    []model.Message{{Role: "user", Content: "Goal: follow up"}},
 		StepsUsed: 3, OutputTokens: 100,
@@ -586,5 +590,34 @@ func TestADirectiveOnlyObservationCarriesNoSpan(t *testing.T) {
 	}
 	if !strings.Contains(last, "re-plan without it") {
 		t.Fatalf("the directive is missing: %q", last)
+	}
+}
+
+// A run suspended before observations were neutralised may ALREADY carry
+// prompt-voice text inside what looks like a span: its observations were
+// bounded with Wrap, and the model had read the marker since step 1. Nothing
+// downstream can tell such a transcript from a clean one, so resuming it is
+// refused the same way a pre-boundary snapshot is.
+func TestResumeRefusesATranscriptWrittenBeforeObservationsWereNeutralised(t *testing.T) {
+	stale := Pending{
+		ApprovalID: ids.New[ids.ApprovalKind](),
+		Tool:       "send_email",
+		Args:       json.RawMessage(`{"to":"a@b.c"}`),
+		Window:     []model.Message{{Role: "user", Content: "Goal: follow up"}},
+		Fence:      promptfence.New(),
+		// No TranscriptVersion: this is what a row stored by an older build
+		// unmarshals to.
+	}
+
+	surface := &fakeSurface{results: map[string]json.RawMessage{"send_email": json.RawMessage(`{"sent":true}`)}}
+	brain := &scriptedBrain{texts: []string{`{"final":{"summary":"x"}}`}}
+	_, err := New(surface, brain).Resume(
+		context.Background(), Job{Goal: "follow up"}, Decision{Pending: stale, Approved: true})
+
+	if !errors.Is(err, apperrors.ErrConflict) {
+		t.Fatalf("resuming a pre-neutralisation transcript returned %v, want ErrConflict", err)
+	}
+	if !strings.Contains(err.Error(), "start it again") {
+		t.Fatalf("the refusal does not say what to do instead: %v", err)
 	}
 }

--- a/backend/internal/modules/agents/runner/runner_test.go
+++ b/backend/internal/modules/agents/runner/runner_test.go
@@ -621,3 +621,34 @@ func TestResumeRefusesATranscriptWrittenBeforeObservationsWereNeutralised(t *tes
 		t.Fatalf("the refusal does not say what to do instead: %v", err)
 	}
 }
+
+// The round trip the version gate must not break: a run this build suspends is
+// one this build can resume. Asserting the refusal alone would leave a suspend
+// that forgot to stamp the version indistinguishable from a stale transcript —
+// every approval in flight would be refused, and no test would say so.
+func TestARunSuspendedByThisBuildResumes(t *testing.T) {
+	approvalID := ids.New[ids.ApprovalKind]()
+	staging := &fakeSurface{errs: map[string]error{
+		"send_email": &workflow.StagedApprovalError{ApprovalID: approvalID},
+	}}
+	suspended, err := New(staging, &scriptedBrain{
+		texts: []string{`{"tool":"send_email","args":{"to":"a@b.c"}}`},
+	}).Run(context.Background(), Job{Goal: "follow up"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if suspended.Pending == nil {
+		t.Fatalf("expected a suspension: %+v", suspended)
+	}
+
+	// Resume the snapshot the runner itself produced, not one written by hand.
+	redeeming := &fakeSurface{results: map[string]json.RawMessage{"send_email": json.RawMessage(`{"sent":true}`)}}
+	res, err := New(redeeming, &scriptedBrain{texts: []string{`{"final":{"summary":"sent"}}`}}).Resume(
+		context.Background(), Job{Goal: "follow up"}, Decision{Pending: *suspended.Pending, Approved: true})
+	if err != nil {
+		t.Fatalf("a run this build suspended could not be resumed: %v", err)
+	}
+	if res.Outcome != OutcomeCompleted {
+		t.Fatalf("resume did not complete: %+v", res)
+	}
+}

--- a/backend/internal/modules/agents/runner/window.go
+++ b/backend/internal/modules/agents/runner/window.go
@@ -78,12 +78,23 @@ func newWindow(job Job, specs []mcp.ToolSpec) *window {
 // are marked with a fixed marker any captured page or mail could have written,
 // so no marker this build could name would actually bound them. The run is
 // refused rather than continued under a boundary that is not one.
-func windowFromSnapshot(job Job, specs []mcp.ToolSpec, snapshot []model.Message, fence promptfence.Fence) (*window, error) {
+//
+// An older transcriptVersion is refused for the same reason one step later. Its
+// observations were bounded with Wrap, so the model — which had read the marker
+// since step 1 — was free to close its own span, and the stored text may already
+// carry prompt-voice content inside what looks like data. It cannot be told from
+// a clean transcript after the fact: the goal prompt legitimately holds several
+// spans, so "one balanced span per message" is not an invariant to check against,
+// and a `</m>…<m>` injection reads as two well-formed spans either way.
+func windowFromSnapshot(job Job, specs []mcp.ToolSpec, snapshot []model.Message, fence promptfence.Fence, transcriptVersion int) (*window, error) {
 	if len(snapshot) == 0 {
 		return newWindow(job, specs), nil
 	}
 	if !fence.Minted() {
 		return nil, fmt.Errorf("%w: this run was suspended before prompt boundaries were per-run; start it again rather than resuming it", apperrors.ErrConflict)
+	}
+	if transcriptVersion < neutralisedObservations {
+		return nil, fmt.Errorf("%w: this run was suspended before its observations were bounded against the marker the model can read; start it again rather than resuming it", apperrors.ErrConflict)
 	}
 	w := &window{system: systemPrompt(specs, fence), fence: fence, knownSources: sourceVocabulary(specs)}
 	w.msgs = append(w.msgs, snapshot...)


### PR DESCRIPTION
Final follow-up in the prompt-boundary chain (#264 → #271 → #272). Closes the gap #272 left open.

## The gap

#272 bounded agent observations with `WrapAuthored`, so nothing the model writes can end its own span. That protects **new** runs and does nothing for one already suspended.

A run can wait days on a human approval. Its stored window was written with `Wrap`, and the model had read the marker since step 1 — so that transcript may **already** carry prompt-voice text inside what looks like a span, and resuming replays it into every later step of the run.

## Why detection is not the answer

It cannot be told apart from a clean transcript after the fact:

- The goal prompt legitimately holds one span per grounding item, so "one balanced span per message" is not an invariant to check against.
- A `</m>…<m>` injection inside a `Wrap`ped observation reads as two well-formed, balanced, properly-ordered spans — indistinguishable from the legitimate multi-span case by structure alone.

What *is* decidable is which **rules** the text was written under. `Pending` now records that, and the resume path refuses anything older — the same answer, and the same `ErrConflict`, that a snapshot predating the per-run boundary already gets. Old stored rows unmarshal to version zero, which is exactly the refusal case; such a run is restarted rather than continued.

## Verification

Mutation-tested in **both** directions, because the gate can fail either way:

- Dropping the version check → the refusal test fails.
- `suspend` no longer stamping the version → the new round-trip test fails. Without that second test, a missed stamp would refuse every approval in flight and no test would say so.

`make check-backend` and `make test-integration` green, 0 skips, 25 packages.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refuse resuming runs suspended before observations were bounded to prevent replaying model-authored prompt text from older transcripts. Old snapshots are rejected with `ErrConflict` and must be restarted.

- **Bug Fixes**
  - Added `TranscriptVersion` to `Pending` and stamp it on suspend.
  - Resume rejects snapshots without a per-run fence or with an older transcript version, returning `ErrConflict` with a clear restart message.
  - Observations are considered safe only when bounded with `promptfence`’s authored wrapping.
  - Tests cover both refusal on stale snapshots and a successful suspend→resume round trip for current builds.

- **Migration**
  - If a resume returns `ErrConflict`, restart the run. No data migration required; older in-flight approvals will be refused and need a fresh run.

<sup>Written for commit 3d29cdf0c5d58e51c9882a0ad0cc248a99e0703f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

