### PR TITLE
approvals: take the identity lock before reading the prior offers

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1245,12 +1245,21 @@ Open work, roughly in priority order:
   takes — a separate check followed by a stage leaves a window where a decision
   lands in between, the check reads "not declined", the staging finds no pending
   row to join, and the refused offer is recreated anyway. Ordered instead of
-  interleaved, whoever gets there first wins cleanly. Note what the tests do and
-  do not cover: they pin that a declined rename is never re-offered across later
-  passes, which is the user-visible obligation; the ordering itself rests on the
-  row lock and the single transaction, not on a test that stages an interleaving
-  (one written for it proved the same thing the durability test already did, and
-  claiming otherwise in its name would have been the noise T11 forbids).
+  interleaved, whoever gets there first wins cleanly.
+  **And the row lock alone was not enough (#288).** `FOR UPDATE` locks the rows
+  it finds and locks NOTHING when it finds none, so an empty result is not the
+  same as "no offer can appear": a second pass reading before the first has
+  committed sees no prior offers at all, and by the time it writes, the first
+  pass's offer may exist AND have been rejected — it then finds no PENDING row to
+  join and recreates exactly what the human refused. The per-identity advisory
+  lock (already used inside `stageOrJoinPendingInTx`, now hoisted into
+  `lockProposalIdentity` and taken FIRST) is what makes the read late enough to
+  see it. Proven rather than argued, in
+  `TestStageUnlessDeclinedWaitsForACompetingPassBeforeReading`:
+  it holds that lock in one transaction, watches `pg_locks` until
+  the staging is provably blocked on it (busy-read, no clock), commits a rejected
+  offer, and asserts nothing was staged — it fails on exactly that assertion when
+  the hoisted lock is removed.
   The §2.9 amendment landed with it: `SignatureCandidates` no longer retires a
   person the moment ANY profile-field row exists (one accepted title used to
   silence the company name their signature also states) — the predicate is now

--- a/backend/internal/modules/approvals/stageunlessdeclined_integration_test.go
+++ b/backend/internal/modules/approvals/stageunlessdeclined_integration_test.go
@@ -194,3 +194,106 @@ func waitForLockWaiter(t *testing.T, e *stagingEnv) {
 	}
 	t.Fatal("no backend ever waited on the advisory lock — the staging did not reach it, so this run proved nothing")
 }
+
+// The refusal is narrow: only a REJECTED prior offer stops a staging. Everything
+// else about the same proposal behaves exactly as Stage does, which is what makes
+// StageUnlessDeclined safe to use in place of it.
+func TestStageUnlessDeclinedStagesWhenNothingWasRefused(t *testing.T) {
+	e := setupStaging(t)
+	target := ids.NewV7()
+	if _, err := e.owner.Exec(context.Background(), `
+		INSERT INTO organization (id, workspace_id, display_name, source, captured_by)
+		VALUES ($1, $2, 'Gitex', 'gmail:seed', 'connector:gmail')`, target, e.ws); err != nil {
+		t.Fatal(err)
+	}
+	in := StageInput{
+		Kind:           "org_name_promotion",
+		ProposedChange: []byte(`{"proposed_name":"Gitex Global"}`),
+		DiffHash:       "hash-nothing-refused",
+		TargetType:     "organization",
+		TargetID:       target,
+		Summary:        "Rename Gitex to Gitex Global?",
+		JoinPending:    true,
+	}
+
+	first, staged, err := e.svc.StageUnlessDeclined(e.as(), in)
+	if err != nil {
+		t.Fatalf("StageUnlessDeclined: %v", err)
+	}
+	if !staged || first.IsZero() {
+		t.Fatal("a proposal nobody has refused must stage")
+	}
+
+	t.Run("a second pass joins the standing offer instead of adding one", func(t *testing.T) {
+		again, staged, err := e.svc.StageUnlessDeclined(e.as(), in)
+		if err != nil {
+			t.Fatalf("StageUnlessDeclined: %v", err)
+		}
+		if !staged || again != first {
+			t.Fatalf("second pass returned %v (staged=%v), want the standing offer %v", again, staged, first)
+		}
+		var offers int
+		if err := e.owner.QueryRow(context.Background(),
+			`SELECT count(*) FROM approval WHERE workspace_id = $1 AND target_entity_id = $2`,
+			e.ws, target).Scan(&offers); err != nil {
+			t.Fatal(err)
+		}
+		if offers != 1 {
+			t.Fatalf("%d offers, want the one that was already standing", offers)
+		}
+	})
+
+	t.Run("an approved offer does not block a later one", func(t *testing.T) {
+		// Only a refusal is an answer of "no". An offer the human ACCEPTED says
+		// nothing about whether the same proposal may be made again — and for a
+		// nightly stager it usually means the work simply came round again.
+		if _, err := e.owner.Exec(context.Background(),
+			`UPDATE approval SET status = 'approved', decided_by = $2, decided_at = now()
+			  WHERE workspace_id = $1 AND target_entity_id = $3`, e.ws, e.rep, target); err != nil {
+			t.Fatal(err)
+		}
+		_, staged, err := e.svc.StageUnlessDeclined(e.as(), in)
+		if err != nil {
+			t.Fatalf("StageUnlessDeclined: %v", err)
+		}
+		if !staged {
+			t.Fatal("an approved offer must not be read as a refusal")
+		}
+	})
+}
+
+// The non-joining form takes the same refusal check: a caller that does not want
+// its proposal joined to a standing one still must not re-offer a refused one.
+func TestStageUnlessDeclinedRefusesWithoutJoinPending(t *testing.T) {
+	e := setupStaging(t)
+	target := ids.NewV7()
+	if _, err := e.owner.Exec(context.Background(), `
+		INSERT INTO organization (id, workspace_id, display_name, source, captured_by)
+		VALUES ($1, $2, 'Gitex', 'gmail:seed', 'connector:gmail')`, target, e.ws); err != nil {
+		t.Fatal(err)
+	}
+	in := StageInput{
+		Kind:           "org_name_promotion",
+		ProposedChange: []byte(`{"proposed_name":"Gitex Global"}`),
+		DiffHash:       "hash-no-join",
+		TargetType:     "organization",
+		TargetID:       target,
+		Summary:        "Rename Gitex to Gitex Global?",
+	}
+
+	if _, staged, err := e.svc.StageUnlessDeclined(e.as(), in); err != nil || !staged {
+		t.Fatalf("first staging: staged=%v err=%v", staged, err)
+	}
+	if _, err := e.owner.Exec(context.Background(),
+		`UPDATE approval SET status = 'rejected', decided_by = $2, decided_at = now()
+		  WHERE workspace_id = $1 AND target_entity_id = $3`, e.ws, e.rep, target); err != nil {
+		t.Fatal(err)
+	}
+	_, staged, err := e.svc.StageUnlessDeclined(e.as(), in)
+	if err != nil {
+		t.Fatalf("StageUnlessDeclined: %v", err)
+	}
+	if staged {
+		t.Fatal("re-offered a refused proposal on the non-joining path")
+	}
+}

--- a/backend/internal/modules/approvals/stageunlessdeclined_integration_test.go
+++ b/backend/internal/modules/approvals/stageunlessdeclined_integration_test.go
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package approvals
+
+// StageUnlessDeclined's ordering, over a real Postgres — the one property that
+// cannot be shown without two live transactions.
+//
+// The refusal itself is arithmetic: read the prior offers, skip if any is
+// rejected. What needs proving is that the read happens LATE ENOUGH to see an
+// offer a competing pass is still writing. `FOR UPDATE` cannot give that on its
+// own: it locks the rows it finds, and it finds nothing when the competing pass
+// has not committed yet — so the identity lock has to be taken first.
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+type stagingEnv struct {
+	svc   *Service
+	pool  *pgxpool.Pool
+	owner *pgx.Conn
+	ws    ids.UUID
+	rep   ids.UUID
+}
+
+func setupStaging(t *testing.T) *stagingEnv {
+	t.Helper()
+	ownerDSN := os.Getenv("MARGINCE_TEST_DSN")
+	appDSN := os.Getenv("MARGINCE_TEST_APP_DSN")
+	if ownerDSN == "" || appDSN == "" {
+		t.Fatal("MARGINCE_TEST_DSN / MARGINCE_TEST_APP_DSN not set — run `make db-up` (integration tests fail loudly, they never skip)")
+	}
+	ctx := context.Background()
+	owner, err := pgx.Connect(ctx, ownerDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := owner.Close(context.Background()); err != nil {
+			t.Errorf("closing owner connection: %v", err)
+		}
+	})
+
+	e := &stagingEnv{owner: owner, ws: ids.NewV7(), rep: ids.NewV7()}
+	if _, err := owner.Exec(ctx,
+		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Staging', $2, 'EUR')`,
+		e.ws, "st-"+e.ws.String()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := owner.Exec(ctx,
+		`INSERT INTO app_user (id, workspace_id, email, display_name) VALUES ($1, $2, $3, 'Rep')`,
+		e.rep, e.ws, "rep-"+e.rep.String()+"@st.test"); err != nil {
+		t.Fatal(err)
+	}
+	pool, err := database.NewPool(ctx, appDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+	e.pool, e.svc = pool, NewService(pool)
+	return e
+}
+
+func (e *stagingEnv) as() context.Context {
+	ctx := principal.WithWorkspaceID(context.Background(), e.ws)
+	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
+	return principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:" + e.rep.String(), UserID: e.rep,
+		Permissions: principal.Permissions{RoleKeys: []string{"admin"}},
+	})
+}
+
+// A staging that starts while a competing pass is mid-write must not read the
+// world as it was before that write. If it did, it would see no prior offers,
+// find no PENDING row to join once the other pass committed, and recreate an
+// offer a human had already refused.
+//
+// The competing pass is played by a held transaction: it takes the identity lock
+// this staging must also take, writes the rejected offer, and commits. The
+// staging is therefore blocked at the lock — by Postgres, not by a timer — until
+// that write is visible, and must then refuse.
+//
+// Without the identity lock taken FIRST, this staging reads past the block: its
+// `FOR UPDATE` finds no rows to lock, and it stages. That is the defect.
+func TestStageUnlessDeclinedWaitsForACompetingPassBeforeReading(t *testing.T) {
+	e := setupStaging(t)
+	ctx := e.as()
+	// A real organization: the staging path resolves its target's version, so a
+	// target that does not exist would fail the run for a reason that has nothing
+	// to do with the ordering under test.
+	target := ids.NewV7()
+	if _, err := e.owner.Exec(context.Background(), `
+		INSERT INTO organization (id, workspace_id, display_name, source, captured_by)
+		VALUES ($1, $2, 'Gitex', 'gmail:seed', 'connector:gmail')`, target, e.ws); err != nil {
+		t.Fatal(err)
+	}
+	in := StageInput{
+		Kind:           "org_name_promotion",
+		ProposedChange: []byte(`{"proposed_name":"Gitex Global"}`),
+		DiffHash:       "deterministic-hash-for-this-proposal",
+		TargetType:     "organization",
+		TargetID:       target,
+		Summary:        "Rename Gitex to Gitex Global?",
+		JoinPending:    true,
+	}
+
+	// The competing pass: hold the identity lock, so the staging below cannot
+	// read until this commits.
+	blocker, err := e.pool.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := blocker.Exec(ctx, `SELECT set_config('app.workspace_id', $1, true)`, e.ws.String()); err != nil {
+		t.Fatal(err)
+	}
+	if err := lockProposalIdentity(ctx, blocker, e.ws, in); err != nil {
+		t.Fatalf("taking the identity lock: %v", err)
+	}
+
+	staged := make(chan bool, 1)
+	errs := make(chan error, 1)
+	go func() {
+		_, ok, err := e.svc.StageUnlessDeclined(e.as(), in)
+		errs <- err
+		staged <- ok
+	}()
+
+	// Wait for the staging to be BLOCKED on that lock rather than merely slow.
+	// Busy-read of pg_locks: no clock, no sleep — the loop either observes the
+	// waiter or fails loudly, so a green run means the ordering really was
+	// exercised.
+	waitForLockWaiter(t, e)
+
+	// Now the competing pass finishes: the offer exists and has been refused.
+	if _, err := blocker.Exec(ctx, `
+		INSERT INTO approval (workspace_id, kind, status, proposed_change, diff_hash,
+		                      target_entity_type, target_entity_id, summary, proposed_by,
+		                      decided_by, decided_at, expires_at)
+		VALUES ($1, $2, 'rejected', $3, $4, $5, $6, $7, $8, $9, now(), now() + interval '1 day')`,
+		e.ws, in.Kind, in.ProposedChange, in.DiffHash, in.TargetType, in.TargetID,
+		in.Summary, "human:"+e.rep.String(), e.rep); err != nil {
+		t.Fatalf("writing the refused offer: %v", err)
+	}
+	if err := blocker.Commit(ctx); err != nil {
+		t.Fatalf("committing the competing pass: %v", err)
+	}
+
+	if err := <-errs; err != nil {
+		t.Fatalf("StageUnlessDeclined: %v", err)
+	}
+	if <-staged {
+		t.Fatal("staged an offer a human had already refused — the read ran before the competing write was visible")
+	}
+	var offers int
+	if err := e.owner.QueryRow(context.Background(),
+		`SELECT count(*) FROM approval WHERE workspace_id = $1 AND target_entity_id = $2`,
+		e.ws, target).Scan(&offers); err != nil {
+		t.Fatal(err)
+	}
+	if offers != 1 {
+		t.Fatalf("%d offers, want only the refused one", offers)
+	}
+}
+
+// waitForLockWaiter blocks until some backend is WAITING on an advisory lock,
+// which is what proves the staging goroutine reached the lock and stopped there.
+// Bounded and loud: a run that never observes the waiter fails rather than
+// quietly testing a weaker ordering than the one it claims.
+func waitForLockWaiter(t *testing.T, e *stagingEnv) {
+	t.Helper()
+	const maxProbes = 200_000
+	for probe := 0; probe < maxProbes; probe++ {
+		var waiting bool
+		if err := e.owner.QueryRow(context.Background(),
+			`SELECT EXISTS (SELECT 1 FROM pg_locks
+			   WHERE locktype = 'advisory' AND NOT granted)`).Scan(&waiting); err != nil {
+			t.Fatal(err)
+		}
+		if waiting {
+			return
+		}
+	}
+	t.Fatal("no backend ever waited on the advisory lock — the staging did not reach it, so this run proved nothing")
+}

--- a/backend/internal/modules/approvals/staging.go
+++ b/backend/internal/modules/approvals/staging.go
@@ -158,27 +158,14 @@ func decodeJSONObject(raw json.RawMessage) (map[string]any, error) {
 	return m, nil
 }
 
-// stageOrJoinPendingInTx serializes one proposal identity and returns its live
-// pending approval when another worker already staged it. The transaction
-// lock covers the empty-set case that a row lock cannot protect, so replicas
-// cannot both observe no pending row and create duplicates.
 func (s *Service) stageOrJoinPendingInTx(ctx context.Context, tx pgx.Tx, in StageInput) (ids.ApprovalID, error) {
 	var id ids.ApprovalID
 	wsID, ok := principal.WorkspaceID(ctx)
 	if !ok {
 		return ids.ApprovalID{}, errors.New("crmapprovals: no workspace bound to context")
 	}
-	// The lock serializes one proposal identity: the diff hash by default, the
-	// logical Identity when set — two workers proposing DIFFERENT diffs for one
-	// identity must not interleave between the join-check and the supersede.
-	discriminator := in.DiffHash
-	if len(in.Identity) > 0 {
-		discriminator = string(in.Identity)
-	}
-	if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock(hashtextextended(
-			'approval_pending:' || $1::text || ':' || $2 || ':' || $3::text || ':' || $4, 0))`,
-		wsID, in.Kind, in.TargetID, discriminator); err != nil {
-		return ids.ApprovalID{}, fmt.Errorf("lock pending approval identity: %w", err)
+	if err := lockProposalIdentity(ctx, tx, wsID, in); err != nil {
+		return ids.ApprovalID{}, err
 	}
 	err := tx.QueryRow(ctx, `SELECT id FROM approval
 			WHERE workspace_id = $1 AND kind = $2 AND target_entity_id = $3 AND diff_hash = $4
@@ -353,146 +340,4 @@ func optionalTargetID(id ids.UUID) *openapi_types.UUID {
 	}
 	v := openapi_types.UUID(id)
 	return &v
-}
-
-// HasPendingFor reports whether a live pending staging of this kind,
-// target and exact proposed change already sits in the inbox. Stagers
-// fed by at-least-once triggers (connector syncs re-hitting the same
-// collision) consult it so a recurring trigger cannot multiply
-// identical proposals.
-func (s *Service) HasPendingFor(ctx context.Context, kind string, targetID ids.UUID, diffHash string) (bool, error) {
-	var exists bool
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
-		return tx.QueryRow(ctx, `
-			SELECT EXISTS (SELECT 1 FROM approval
-			  WHERE kind = $1 AND target_entity_id = $2 AND diff_hash = $3
-			    AND status = 'pending' AND expires_at > now())`,
-			kind, targetID, diffHash).Scan(&exists)
-	})
-	return exists, err
-}
-
-// HasPendingKind reports whether a live pending staging of this kind
-// sits against the target at all, whatever its proposed change. Nightly
-// sweeps whose proposal moves with "today" consult it — a diff-hash
-// identity check (HasPendingFor) would let every pass stack a fresh
-// staging on one still awaiting decision.
-func (s *Service) HasPendingKind(ctx context.Context, kind string, targetID ids.UUID) (bool, error) {
-	var exists bool
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
-		return tx.QueryRow(ctx, `
-			SELECT EXISTS (SELECT 1 FROM approval
-			  WHERE kind = $1 AND target_entity_id = $2
-			    AND status = 'pending' AND expires_at > now())`,
-			kind, targetID).Scan(&exists)
-	})
-	return exists, err
-}
-
-// WithdrawInTx takes one live proposal off the inbox on the caller's
-// transaction: forced expiry, audited with the reason, deliberately event-free.
-//
-// The mechanism is supersession's — backdate expires_at a full day, so the row
-// reads expired under both the database clock and the service clock that
-// effectiveStatus judges with. Withdrawal is not a new status: the CHECK and the
-// public ApprovalStatus enum stay closed, and expiry is already invisible on the
-// bus (no subscriber can observe a TTL lapse either), so nothing a consumer
-// relies on changes.
-//
-// It exists so an owner of the underlying question can retract it when the
-// question stops being one — the capture ledger ageing out an unanswered review
-// is the first caller. It reports whether the offer was still live to take:
-// withdrawing an already-decided approval does nothing and says so, because what
-// a human answered is not the caller's to take back, and a caller that acts on
-// the retraction needs to know the retraction happened.
-func (s *Service) WithdrawInTx(ctx context.Context, tx pgx.Tx, id ids.ApprovalID, reason string) (bool, error) {
-	p, ok := principal.Actor(ctx)
-	if !ok {
-		return false, errors.New("crmapprovals: no actor bound to context")
-	}
-	// The same row lock decideInTx takes, for the same reason: a decision landing
-	// concurrently has to be ordered against this write rather than interleaved
-	// with it. A human who wins the lock leaves the row decided and this reports
-	// false; one who loses re-reads an expired row and is refused.
-	var locked ids.ApprovalID
-	if err := tx.QueryRow(ctx, `SELECT id FROM approval WHERE id = $1 FOR UPDATE`, id).Scan(&locked); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return false, nil
-		}
-		return false, fmt.Errorf("lock approval to withdraw: %w", err)
-	}
-	tag, err := tx.Exec(ctx, `
-		UPDATE approval SET expires_at = now() - interval '1 day'
-		 WHERE id = $1 AND status = 'pending'`, id)
-	if err != nil {
-		return false, fmt.Errorf("withdraw approval: %w", err)
-	}
-	if tag.RowsAffected() == 0 {
-		return false, nil
-	}
-	if _, err := s.audit(ctx, tx, p, "update", id.UUID, map[string]any{
-		"withdrawn": true, "reason": reason,
-	}); err != nil {
-		return false, fmt.Errorf("audit withdrawn approval: %w", err)
-	}
-	return true, nil
-}
-
-// StageUnlessDeclined stages in — unless a human has already REJECTED this exact
-// proposal (same kind, same target, same proposed change). It reports whether
-// anything was staged.
-//
-// It exists because a nightly stager re-derives the same proposal every pass, and
-// JoinPending joins only a PENDING row: the moment a human says no, the next pass
-// finds nothing to join and stages a fresh copy of what was just refused. Their
-// "no" would mean nothing.
-//
-// Checking first and staging afterwards is not enough, and the gap is small but
-// real: a decision landing between the two leaves the check reading "not
-// declined" and the staging finding no pending row to join, so the refused offer
-// is recreated anyway. The row lock closes it — the same
-// `SELECT ... FOR UPDATE` decideInTx takes, so the two are ordered rather than
-// interleaved. Whoever gets there first wins cleanly: the decision blocks until
-// this commits and then decides the offer this joined, or this reads the row as
-// already rejected and stages nothing.
-func (s *Service) StageUnlessDeclined(ctx context.Context, in StageInput) (ids.ApprovalID, bool, error) {
-	var id ids.ApprovalID
-	staged := false
-	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
-		wsID, ok := principal.WorkspaceID(ctx)
-		if !ok {
-			return errors.New("crmapprovals: no workspace bound to context")
-		}
-		// Locks every row this exact proposal has ever produced, decided or not.
-		// A first-ever staging locks nothing, which is correct: there is no
-		// decision to be ordered against something that does not exist yet.
-		rows, err := tx.Query(ctx, `
-			SELECT status FROM approval
-			 WHERE workspace_id = $1 AND kind = $2 AND target_entity_id = $3 AND diff_hash = $4
-			 ORDER BY created_at
-			 FOR UPDATE`, wsID, in.Kind, in.TargetID, in.DiffHash)
-		if err != nil {
-			return fmt.Errorf("lock the prior offers for this proposal: %w", err)
-		}
-		statuses, err := pgx.CollectRows(rows, pgx.RowTo[string])
-		if err != nil {
-			return fmt.Errorf("read the prior offers for this proposal: %w", err)
-		}
-		for _, status := range statuses {
-			if status == approvalStatusRejected {
-				return nil
-			}
-		}
-		if in.JoinPending {
-			id, err = s.stageOrJoinPendingInTx(ctx, tx, in)
-		} else {
-			id, err = s.StageInTx(ctx, tx, in)
-		}
-		if err != nil {
-			return err
-		}
-		staged = true
-		return nil
-	})
-	return id, staged, err
 }

--- a/backend/internal/modules/approvals/stagingidentity.go
+++ b/backend/internal/modules/approvals/stagingidentity.go
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package approvals
+
+// One proposal identity: whether the thing about to be staged is already on the
+// table, and who owns that identity while it is decided.
+//
+// A stager fed by an at-least-once trigger — a connector sync re-hitting the same
+// collision, a nightly sweep re-deriving the same diff — asks the same question
+// every pass. Answering it is not a lookup but an ORDERING problem, which is why
+// these live together: the probes below are only sound while the identity lock is
+// held, and a caller that reads before taking it reads a world that is about to
+// change underneath it.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// stageOrJoinPendingInTx serializes one proposal identity and returns its live
+// pending approval when another worker already staged it. The transaction
+// lock covers the empty-set case that a row lock cannot protect, so replicas
+// cannot both observe no pending row and create duplicates.
+// lockProposalIdentity serializes one proposal identity for the rest of the
+// transaction: the diff hash by default, the logical Identity when set. Two
+// workers proposing DIFFERENT diffs for one identity must not interleave between
+// the join-check and the supersede — and, for StageUnlessDeclined, a second
+// worker must not read the prior offers before the first has finished writing
+// one.
+//
+// Re-entrant within a transaction, so a caller that takes it before its own
+// reads and then calls through to staging pays for it once.
+func lockProposalIdentity(ctx context.Context, tx pgx.Tx, wsID ids.UUID, in StageInput) error {
+	discriminator := in.DiffHash
+	if len(in.Identity) > 0 {
+		discriminator = string(in.Identity)
+	}
+	if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock(hashtextextended(
+			'approval_pending:' || $1::text || ':' || $2 || ':' || $3::text || ':' || $4, 0))`,
+		wsID, in.Kind, in.TargetID, discriminator); err != nil {
+		return fmt.Errorf("lock pending approval identity: %w", err)
+	}
+	return nil
+}
+
+// HasPendingFor reports whether a live pending staging of this kind,
+// target and exact proposed change already sits in the inbox. Stagers
+// fed by at-least-once triggers (connector syncs re-hitting the same
+// collision) consult it so a recurring trigger cannot multiply
+// identical proposals.
+func (s *Service) HasPendingFor(ctx context.Context, kind string, targetID ids.UUID, diffHash string) (bool, error) {
+	var exists bool
+	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `
+			SELECT EXISTS (SELECT 1 FROM approval
+			  WHERE kind = $1 AND target_entity_id = $2 AND diff_hash = $3
+			    AND status = 'pending' AND expires_at > now())`,
+			kind, targetID, diffHash).Scan(&exists)
+	})
+	return exists, err
+}
+
+// HasPendingKind reports whether a live pending staging of this kind
+// sits against the target at all, whatever its proposed change. Nightly
+// sweeps whose proposal moves with "today" consult it — a diff-hash
+// identity check (HasPendingFor) would let every pass stack a fresh
+// staging on one still awaiting decision.
+func (s *Service) HasPendingKind(ctx context.Context, kind string, targetID ids.UUID) (bool, error) {
+	var exists bool
+	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `
+			SELECT EXISTS (SELECT 1 FROM approval
+			  WHERE kind = $1 AND target_entity_id = $2
+			    AND status = 'pending' AND expires_at > now())`,
+			kind, targetID).Scan(&exists)
+	})
+	return exists, err
+}
+
+// WithdrawInTx takes one live proposal off the inbox on the caller's
+// transaction: forced expiry, audited with the reason, deliberately event-free.
+//
+// The mechanism is supersession's — backdate expires_at a full day, so the row
+// reads expired under both the database clock and the service clock that
+// effectiveStatus judges with. Withdrawal is not a new status: the CHECK and the
+// public ApprovalStatus enum stay closed, and expiry is already invisible on the
+// bus (no subscriber can observe a TTL lapse either), so nothing a consumer
+// relies on changes.
+//
+// It exists so an owner of the underlying question can retract it when the
+// question stops being one — the capture ledger ageing out an unanswered review
+// is the first caller. It reports whether the offer was still live to take:
+// withdrawing an already-decided approval does nothing and says so, because what
+// a human answered is not the caller's to take back, and a caller that acts on
+// the retraction needs to know the retraction happened.
+func (s *Service) WithdrawInTx(ctx context.Context, tx pgx.Tx, id ids.ApprovalID, reason string) (bool, error) {
+	p, ok := principal.Actor(ctx)
+	if !ok {
+		return false, errors.New("crmapprovals: no actor bound to context")
+	}
+	// The same row lock decideInTx takes, for the same reason: a decision landing
+	// concurrently has to be ordered against this write rather than interleaved
+	// with it. A human who wins the lock leaves the row decided and this reports
+	// false; one who loses re-reads an expired row and is refused.
+	var locked ids.ApprovalID
+	if err := tx.QueryRow(ctx, `SELECT id FROM approval WHERE id = $1 FOR UPDATE`, id).Scan(&locked); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return false, nil
+		}
+		return false, fmt.Errorf("lock approval to withdraw: %w", err)
+	}
+	tag, err := tx.Exec(ctx, `
+		UPDATE approval SET expires_at = now() - interval '1 day'
+		 WHERE id = $1 AND status = 'pending'`, id)
+	if err != nil {
+		return false, fmt.Errorf("withdraw approval: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return false, nil
+	}
+	if _, err := s.audit(ctx, tx, p, "update", id.UUID, map[string]any{
+		"withdrawn": true, "reason": reason,
+	}); err != nil {
+		return false, fmt.Errorf("audit withdrawn approval: %w", err)
+	}
+	return true, nil
+}
+
+// StageUnlessDeclined stages in — unless a human has already REJECTED this exact
+// proposal (same kind, same target, same proposed change). It reports whether
+// anything was staged.
+//
+// It exists because a nightly stager re-derives the same proposal every pass, and
+// JoinPending joins only a PENDING row: the moment a human says no, the next pass
+// finds nothing to join and stages a fresh copy of what was just refused. Their
+// "no" would mean nothing.
+//
+// Checking first and staging afterwards is not enough, and the gap is small but
+// real: a decision landing between the two leaves the check reading "not
+// declined" and the staging finding no pending row to join, so the refused offer
+// is recreated anyway. The row lock closes it — the same
+// `SELECT ... FOR UPDATE` decideInTx takes, so the two are ordered rather than
+// interleaved. Whoever gets there first wins cleanly: the decision blocks until
+// this commits and then decides the offer this joined, or this reads the row as
+// already rejected and stages nothing.
+func (s *Service) StageUnlessDeclined(ctx context.Context, in StageInput) (ids.ApprovalID, bool, error) {
+	var id ids.ApprovalID
+	staged := false
+	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
+		wsID, ok := principal.WorkspaceID(ctx)
+		if !ok {
+			return errors.New("crmapprovals: no workspace bound to context")
+		}
+		// The identity lock FIRST, before the read below — this is the ordering
+		// that a row lock alone cannot give.
+		//
+		// `FOR UPDATE` locks the rows it finds, so it orders this against a
+		// decision on an offer that already exists. It locks NOTHING when the
+		// query finds nothing, and an empty result is not the same as "no offer
+		// can appear": a second pass reading before the first has committed sees
+		// no prior offers at all, and by the time it writes, the first pass's
+		// offer may exist AND have been rejected. It would then find no PENDING
+		// row to join and recreate exactly what the human refused. Serializing on
+		// the identity means the second pass reads after the first has finished,
+		// so the offer it must not recreate is there to be seen.
+		if err := lockProposalIdentity(ctx, tx, wsID, in); err != nil {
+			return err
+		}
+		// Locks every row this exact proposal has ever produced, decided or not,
+		// so a decision landing on one of them is ordered against this staging
+		// rather than interleaved with it.
+		rows, err := tx.Query(ctx, `
+			SELECT status FROM approval
+			 WHERE workspace_id = $1 AND kind = $2 AND target_entity_id = $3 AND diff_hash = $4
+			 ORDER BY created_at
+			 FOR UPDATE`, wsID, in.Kind, in.TargetID, in.DiffHash)
+		if err != nil {
+			return fmt.Errorf("lock the prior offers for this proposal: %w", err)
+		}
+		statuses, err := pgx.CollectRows(rows, pgx.RowTo[string])
+		if err != nil {
+			return fmt.Errorf("read the prior offers for this proposal: %w", err)
+		}
+		for _, status := range statuses {
+			if status == approvalStatusRejected {
+				return nil
+			}
+		}
+		if in.JoinPending {
+			id, err = s.stageOrJoinPendingInTx(ctx, tx, in)
+		} else {
+			id, err = s.StageInTx(ctx, tx, in)
+		}
+		if err != nil {
+			return err
+		}
+		staged = true
+		return nil
+	})
+	return id, staged, err
+}


### PR DESCRIPTION
`FOR UPDATE` locks the rows it finds, and locks **nothing** when it finds none.

I wrote that case off in #287 — *"a first-ever staging locks nothing, which is
correct: there is no decision to be ordered against something that does not exist
yet"* — and stop-time review was right that it is wrong. An empty result is not
the same as "no offer can appear".

## The window that was left open

```
pass B: read prior offers   -> none        (nothing to lock; no ordering gained)
pass A:                      stages offer O1, commits
        human:               rejects O1, commits
pass B: stage                -> no PENDING row to join -> creates a fresh offer
```

B recreates exactly what the human refused. The row lock cannot help here,
because at B's read time there was no row to lock.

## The fix

The per-identity advisory lock already existed and was already the right key — it
was just taken **too late**, inside `stageOrJoinPendingInTx`, after the declined
check. It is now `lockProposalIdentity`, taken **first**, so the read happens
after any competing pass has finished writing. Advisory locks are re-entrant
within a transaction, so the inner call through to staging costs nothing.

## Proven, not argued

The previous round could only state the ordering and admit no test covered it.
This one is testable because the lock is now the first thing that happens:

`TestStageUnlessDeclinedWaitsForACompetingPassBeforeReading` holds the identity
lock in one transaction, watches `pg_locks` until the staging is provably blocked
on it — a bounded busy-read, no clock and no sleep, and it fails loudly if the
waiter never appears rather than proving a weaker ordering than it claims — then
commits a rejected offer and asserts nothing was staged.

I checked it in both directions before trusting it: with the hoisted lock removed
it fails on exactly that assertion (`staged an offer a human had already
refused`), and the target organization is seeded precisely so the broken path
reaches the staging rather than dying earlier on an unrelated error.

## Also

The identity concerns moved to `stagingidentity.go` (the 500-line file gate):
`lockProposalIdentity`, `stageOrJoinPendingInTx`'s join/supersede pair, the
`HasPendingFor`/`HasPendingKind` probes, `WithdrawInTx` and `StageUnlessDeclined`.
They belong together — those probes are only sound while that lock is held.

## Verification

`make check` green; the full zero-skip `make test-integration` green (26 packages
— approvals joins the lane with its first integration test). No contract change,
no migration, no frontend change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race in approvals staging by taking the per-identity advisory lock before reading prior offers. Prevents recreating offers that a human already rejected and makes concurrent passes read after competing writes.

- **Bug Fixes**
  - Take `lockProposalIdentity` at the start of `StageUnlessDeclined`, before the `FOR UPDATE` read.
  - Ensures empty reads don’t slip past a concurrent write; rejected offers aren’t recreated.
  - Added integration test `TestStageUnlessDeclinedWaitsForACompetingPassBeforeReading` that proves the lock-based ordering via `pg_locks`.
  - Added integration tests that pin `StageUnlessDeclined` behavior: stages when nothing was refused, joins a standing offer, approved prior offers don’t block, and the non-joining path applies the same refusal check.

- **Refactors**
  - Moved proposal-identity logic to `stagingidentity.go` (`lockProposalIdentity`, `HasPendingFor`, `HasPendingKind`, `WithdrawInTx`, `StageUnlessDeclined`), trimming `staging.go`.

<sup>Written for commit 3265e273063bd92c54407942767c857066e303bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

