### PR TITLE
docs(status): the deferral bounds and the auto-enrich default are ratified

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1294,9 +1294,20 @@ Open work, roughly in priority order:
   would resolve nothing. The sender is not shut out: the live-unique index
   covers only `pending` and `unsure`, so their next message opens a fresh row
   and gets a fresh verdict.
-  **Still open in this arc:** the upstream ADR raises listed throughout this
-  entry — `PendingDeferralCap`/`PendingDeferralDomainCap`/`UnsureReviewWindow`
-  all want CAP-PARAM entries, and none of the three values is founder-confirmed.
+  **Ratified upstream (foundation #1198, 2026-07-28).** The three bounds are no
+  longer build-side constants nobody signed off:
+  `PendingDeferralCap` = 500, `PendingDeferralDomainCap` = 50 and
+  `UnsureReviewWindow` = 30 days are pinned as **CAP-PARAM-8** in
+  `specs/subsystems/capture.md` and in ADR-0072 §5, with DECISIONS A118 carrying
+  an *Amended 2026-07-28* block. They stay SOURCE CONSTANTS rather than runtime
+  config, by the same reasoning that pins the dedupe thresholds (PO-PARAM-1): a
+  workspace tuning its own ceiling makes "an outsider cannot set our AI spend"
+  unauditable across installations.
+  The same amendment settles `capture_auto_enrich`: **default ON is the shipping
+  default**, not the testing posture, and the ADR's "GA default is its own later
+  decision" caveat is withdrawn.
+  **Still open in this arc:** the other upstream raises listed throughout this
+  entry (the §1 ladder wording), and the synchronous enrich-on-capture trigger.
 
 - **Site-read legal census — three known gaps (#162).** `FinishSiteRead`'s CAS
   guards only on `status = 'running'`, so a reclaimed-then-returning worker can


### PR DESCRIPTION
foundation #1198 landed the upstream half of last night's capture arc.

- `PendingDeferralCap` = 500, `PendingDeferralDomainCap` = 50 and `UnsureReviewWindow` = 30 days are pinned as **CAP-PARAM-8** (ADR-0072 §5 + the capture chapter's parameter table), with DECISIONS A118 carrying an *Amended 2026-07-28* block.
- `capture_auto_enrich` **default ON is the shipping default**, not a testing posture; the ADR's "GA default is its own later decision" caveat is withdrawn.

They stay source constants rather than runtime config, on the PO-PARAM-1 precedent: a workspace tuning its own ceiling makes "an outsider cannot set our AI spend" unauditable across installations.

STATUS said all four were unconfirmed. They are not, and a pickup record that understates what is decided sends the next session to re-litigate it. Docs only — no code change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update STATUS.md to mark the deferral bounds as ratified and set `capture_auto_enrich` default to ON. Replaces the “still open” note with CAP-PARAM-8 values (`PendingDeferralCap`=500, `PendingDeferralDomainCap`=50, `UnsureReviewWindow`=30 days) and clarifies these remain source constants.

<sup>Written for commit b293ad1ea903e77b38a2b388b40170046ec0f188. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project status to reflect ratified capture deferral and audit-bound parameters.
  * Clarified that automatic capture enrichment is enabled by default.
  * Documented remaining open upstream decisions and the synchronous enrichment trigger.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->