### PR TITLE
capture: refund a slot that bought no read, and say what the tests prove

### DIFF
--- a/backend/internal/compose/captureautoenrich.go
+++ b/backend/internal/compose/captureautoenrich.go
@@ -15,6 +15,7 @@ package compose
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"time"
 
@@ -148,8 +149,7 @@ func (w *captureAutoEnrichSweepWorker) sweepWorkspace(ctx context.Context, ws id
 		if err := w.triggerEnrich(wsCtx, org, slot); err != nil {
 			// A single org's trigger fault must not consume the pass; log it
 			// and move on. The cursor stays due (nothing was queued), so the
-			// next pass retries — but the reserved budget slot is spent, a
-			// conservative under-spend, never an over-spend.
+			// next pass retries, and the slot it reserved has already gone back.
 			w.log.WarnContext(wsCtx, "capture auto-enrich: trigger failed",
 				"org", org.OrganizationID.String(), "err", err)
 			continue
@@ -159,16 +159,43 @@ func (w *captureAutoEnrichSweepWorker) sweepWorkspace(ctx context.Context, ws id
 }
 
 // triggerEnrich starts a system-requested deep read for one org and arms its
-// cursor.
+// cursor, returning the reserved slot when no read came of it.
 func (w *captureAutoEnrichSweepWorker) triggerEnrich(ctx context.Context, org capture.DueOrg, slot capture.BudgetSlot) error {
-	started, err := startAutoEnrichRead(ctx, w.people, w.autoEnrich, org.OrganizationID, org.Domain)
-	if err != nil {
+	return startEnrichOrRefund(ctx, w.people, w.autoEnrich, org.OrganizationID, org.Domain, slot)
+}
+
+// refundTimeout bounds the compensating write. Short: it is one indexed UPDATE,
+// and a refund that hangs would hold the pass or the capture it runs on.
+const refundTimeout = 5 * time.Second
+
+// startEnrichOrRefund is the whole rule about a reserved slot, in one place
+// because both callers own the same invariant: a slot buys a read or it goes
+// back.
+//
+// The ordering is load-bearing. `started` is checked BEFORE `err`, because
+// startAutoEnrichRead reports (true, err) for a read that was queued and whose
+// cursor could not then be armed — refunding there would pay for that crawl
+// twice, returning the slot to the day while the read still runs.
+//
+// The refund detaches from the caller's context, for the case that matters most:
+// when the start failed BECAUSE that context was cancelled, the refund is owed
+// and the context it would run on is already dead. Compensating on the dying
+// context leaks the slot exactly when it is most likely to leak. Same
+// detach-and-deadline shape the connector teardown and the AI tracer use.
+func startEnrichOrRefund(ctx context.Context, peopleStore *people.Store,
+	autoEnrich *capture.AutoEnrichStore, orgID ids.OrganizationID, domain string, slot capture.BudgetSlot,
+) error {
+	started, err := startAutoEnrichRead(ctx, peopleStore, autoEnrich, orgID, domain)
+	if started {
 		return err
 	}
-	if !started {
-		return w.autoEnrich.ReleaseBudget(ctx, slot)
+	refundCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), refundTimeout)
+	defer cancel()
+	refundErr := autoEnrich.ReleaseBudget(refundCtx, slot)
+	if err != nil {
+		return errors.Join(err, refundErr)
 	}
-	return nil
+	return refundErr
 }
 
 // startAutoEnrichRead queues ONE governed deep read for one organization and

--- a/backend/internal/compose/captureautoenrich.go
+++ b/backend/internal/compose/captureautoenrich.go
@@ -44,11 +44,12 @@ import (
 //     or already has a person for. A stranger's mail defers to the ledger and
 //     mints nothing, so an outsider cannot aim this at a domain of their choosing.
 //
-// What is left for this counter is PACING, and 10/day paced the one case that
-// matters most against the product: a first backfill mints hundreds of companies
-// at once, and the promise being demonstrated is that the CRM fills itself
-// (P5). Watching ten of two hundred fill, then waiting weeks, teaches the
-// opposite. Raised to 500 by founder decision (2026-07-28).
+// What is left for this counter is PACING, and 500 is sized for the moment that
+// decides whether the product is believed: a first backfill mints hundreds of
+// companies at once, and what it is demonstrating is that the CRM fills itself
+// (P5). A ceiling below that arrival rate turns the demonstration into a trickle
+// and teaches the opposite, while a ceiling above it buys nothing the three
+// bounds above do not already give.
 const autoEnrichDailyCap = 500
 
 // autoEnrichRetryBackoff is how long a triggered read's cursor is armed before
@@ -187,8 +188,8 @@ func (w *captureAutoEnrichSweepWorker) triggerEnrich(ctx context.Context, org ca
 // It reports whether a read was actually STARTED, as opposed to joined onto one
 // already in flight. Both callers reserve a budget slot before calling, and a
 // join means that slot bought nothing: without the distinction, a sweep and a
-// capture racing on one organization spend two of the day's ten reads on a
-// single crawl and charge that organization two of its bounded attempts. The
+// capture racing on one organization spend two of the day's reads on a single
+// crawl and charge that organization two of its bounded attempts. The
 // cursor is armed only by the caller that started something, for the same
 // reason.
 func startAutoEnrichRead(ctx context.Context, peopleStore *people.Store,

--- a/backend/internal/compose/captureenrichtrigger.go
+++ b/backend/internal/compose/captureenrichtrigger.go
@@ -21,9 +21,7 @@ package compose
 
 import (
 	"context"
-	"errors"
 	"log/slog"
-	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
@@ -116,40 +114,8 @@ func (t *autoEnrichTrigger) queueRead(ctx context.Context, orgID ids.Organizatio
 			"org", orgID.String())
 		return nil
 	}
-	started, err := startAutoEnrichRead(enrichCtx, t.people, t.autoEnrich, orgID, domain)
-	if started {
-		// A read exists, so the slot bought one — even when err is non-nil,
-		// which is how startAutoEnrichRead reports a cursor it could not arm
-		// after the read was already queued. Refunding here would pay for that
-		// crawl twice: the slot returns to the day AND the read still runs.
-		return err
-	}
-	if err != nil {
-		// Nothing started, so the slot goes back — the same rule as the join
-		// below. Reserving before starting is what makes the cap a cap;
-		// refunding what did not start is what stops the ceiling eroding a slot
-		// at a time.
-		return errors.Join(err, t.refund(enrichCtx, slot))
-	}
-	// A read for this organization was already in flight — the sweep and this
-	// capture found it in the same moment, and the uniqueness index arbitrated.
-	// One crawl must not cost the day two of its reads.
-	return t.refund(enrichCtx, slot)
-}
-
-// refundTimeout bounds the compensating write. Short: it is one indexed UPDATE,
-// and a refund that hangs would hold the capture path it runs on.
-const refundTimeout = 5 * time.Second
-
-// refund returns a slot on a context that outlives whatever went wrong.
-//
-// It detaches for the case that matters most: when the start failed BECAUSE the
-// capture's context was cancelled or timed out, the refund is owed and the
-// context it would run on is already dead. Compensating on the dying context
-// leaks the slot exactly when it is most likely to leak. Same
-// detach-and-deadline shape the connector teardown and the AI tracer use.
-func (t *autoEnrichTrigger) refund(ctx context.Context, slot capture.BudgetSlot) error {
-	refundCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), refundTimeout)
-	defer cancel()
-	return t.autoEnrich.ReleaseBudget(refundCtx, slot)
+	// One rule for a reserved slot, shared with the sweep: it buys a read or it
+	// goes back, and the refund survives the cancellation that may have caused
+	// the failure it compensates for.
+	return startEnrichOrRefund(enrichCtx, t.people, t.autoEnrich, orgID, domain, slot)
 }

--- a/backend/internal/compose/captureenrichtrigger.go
+++ b/backend/internal/compose/captureenrichtrigger.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
@@ -116,18 +117,39 @@ func (t *autoEnrichTrigger) queueRead(ctx context.Context, orgID ids.Organizatio
 		return nil
 	}
 	started, err := startAutoEnrichRead(enrichCtx, t.people, t.autoEnrich, orgID, domain)
-	if err != nil {
-		// The slot bought nothing, so it goes back — the same rule as the join
-		// below, and for the same reason. Reserving before starting is what makes
-		// the cap a cap; refunding what did not start is what stops the ceiling
-		// eroding a slot at a time.
-		return errors.Join(err, t.autoEnrich.ReleaseBudget(enrichCtx, slot))
-	}
 	if started {
-		return nil
+		// A read exists, so the slot bought one — even when err is non-nil,
+		// which is how startAutoEnrichRead reports a cursor it could not arm
+		// after the read was already queued. Refunding here would pay for that
+		// crawl twice: the slot returns to the day AND the read still runs.
+		return err
+	}
+	if err != nil {
+		// Nothing started, so the slot goes back — the same rule as the join
+		// below. Reserving before starting is what makes the cap a cap;
+		// refunding what did not start is what stops the ceiling eroding a slot
+		// at a time.
+		return errors.Join(err, t.refund(enrichCtx, slot))
 	}
 	// A read for this organization was already in flight — the sweep and this
 	// capture found it in the same moment, and the uniqueness index arbitrated.
 	// One crawl must not cost the day two of its reads.
-	return t.autoEnrich.ReleaseBudget(enrichCtx, slot)
+	return t.refund(enrichCtx, slot)
+}
+
+// refundTimeout bounds the compensating write. Short: it is one indexed UPDATE,
+// and a refund that hangs would hold the capture path it runs on.
+const refundTimeout = 5 * time.Second
+
+// refund returns a slot on a context that outlives whatever went wrong.
+//
+// It detaches for the case that matters most: when the start failed BECAUSE the
+// capture's context was cancelled or timed out, the refund is owed and the
+// context it would run on is already dead. Compensating on the dying context
+// leaks the slot exactly when it is most likely to leak. Same
+// detach-and-deadline shape the connector teardown and the AI tracer use.
+func (t *autoEnrichTrigger) refund(ctx context.Context, slot capture.BudgetSlot) error {
+	refundCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), refundTimeout)
+	defer cancel()
+	return t.autoEnrich.ReleaseBudget(refundCtx, slot)
 }

--- a/backend/internal/compose/captureenrichtrigger.go
+++ b/backend/internal/compose/captureenrichtrigger.go
@@ -21,6 +21,7 @@ package compose
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -57,13 +58,12 @@ func newAutoEnrichTrigger(pool *pgxpool.Pool, log *slog.Logger) *autoEnrichTrigg
 // a capture. The message and its records are already committed by the time this
 // runs; the worst outcome is a company whose dossier waits for the sweep.
 func (t *autoEnrichTrigger) organizationCaptured(ctx context.Context, orgID ids.OrganizationID, domain string) {
-	// Nothing to read without a domain, and that is the only gate cheap enough
-	// to run before the setting: whether this process can enqueue at all is
-	// answered by startAutoEnrichRead, deliberately at the END rather than up
-	// front. Asking it first would be marginally cheaper and would make the
-	// whole trigger invisible to any test process, which has no ambient River
-	// client — a gate that hides the feature from its own tests is worth more
-	// than three round trips per captured company.
+	// Nothing to read without a domain. Whether this process can enqueue at all
+	// is answered later, by startAutoEnrichRead — asking it up front would save
+	// three round trips per captured company and cost the ability to observe the
+	// trigger in any test, since no test process binds a River client. Every
+	// production capture runs inside a River job, so the early exit would save
+	// nothing where it matters.
 	if domain == "" {
 		return
 	}
@@ -108,24 +108,26 @@ func (t *autoEnrichTrigger) queueRead(ctx context.Context, orgID ids.Organizatio
 		return err
 	}
 	if !slot.Reserved {
-		// Debug, not warn: on a backfill that mints hundreds of companies this is
-		// the NORMAL state after the first ten, and a warning per company would
-		// bury the faults that matter.
+		// Debug, not warn: on a backfill big enough to exhaust the day this is the
+		// NORMAL state for every company after the cap, and a warning apiece
+		// would bury the faults that matter.
 		t.log.DebugContext(ctx, "capture auto-enrich: daily cap reached, the sweep takes this org",
 			"org", orgID.String())
 		return nil
 	}
 	started, err := startAutoEnrichRead(enrichCtx, t.people, t.autoEnrich, orgID, domain)
 	if err != nil {
-		// The reserved slot is spent with no read to show for it — a conservative
-		// under-spend, and the org stays due for the sweep.
-		return err
+		// The slot bought nothing, so it goes back — the same rule as the join
+		// below, and for the same reason. Reserving before starting is what makes
+		// the cap a cap; refunding what did not start is what stops the ceiling
+		// eroding a slot at a time.
+		return errors.Join(err, t.autoEnrich.ReleaseBudget(enrichCtx, slot))
 	}
 	if started {
 		return nil
 	}
 	// A read for this organization was already in flight — the sweep and this
 	// capture found it in the same moment, and the uniqueness index arbitrated.
-	// The slot goes back: one crawl must not cost the day two of its ten reads.
+	// One crawl must not cost the day two of its reads.
 	return t.autoEnrich.ReleaseBudget(enrichCtx, slot)
 }

--- a/backend/internal/compose/captureenrichtrigger_integration_test.go
+++ b/backend/internal/compose/captureenrichtrigger_integration_test.go
@@ -156,7 +156,7 @@ func TestEnrichOnCaptureIgnoresAnEmptyDomain(t *testing.T) {
 // Reserve-before-spend means a caller sometimes holds a slot it turns out not to
 // need — two paths racing on one organization both reserve, and the in-flight
 // uniqueness index lets only one of them start a read. The refund is what keeps
-// the day's ten reads from delivering nine, with the shortfall growing with
+// the day's allowance eroding a slot at a time, with the shortfall growing with
 // exactly the concurrency the cap is meant to be indifferent to.
 func TestAutoEnrichBudgetSlotIsReturnedWhenItBoughtNothing(t *testing.T) {
 	e := integration.Setup(t)
@@ -208,6 +208,9 @@ func TestAutoEnrichBudgetReleaseNeverGoesBelowZero(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if !today.Reserved {
+		t.Fatal("setup reservation refused — the guard below would pass without ever running")
+	}
 	for i := 0; i < testCap; i++ {
 		if err := store.ReleaseBudget(e.Admin(), today); err != nil {
 			t.Fatalf("ReleaseBudget on an unspent day: %v", err)
@@ -241,6 +244,9 @@ func TestAutoEnrichBudgetRefundNamesTheDayItWasReservedOn(t *testing.T) {
 	todaySlot, err := store.ReserveBudget(e.Admin(), 3)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if !todaySlot.Reserved {
+		t.Fatal("setup reservation refused — yesterday's day would be the zero time")
 	}
 	if err := store.ReleaseBudget(e.Admin(), todaySlot); err != nil {
 		t.Fatal(err)
@@ -285,9 +291,14 @@ func TestAutoEnrichRefundSurvivesACancelledCaptureContext(t *testing.T) {
 	cancelled, cancel := context.WithCancel(e.Admin())
 	cancel()
 
+	// Through the shared rule both the trigger and the sweep use. With no River
+	// client the read cannot start, so this is the refund path — on a context
+	// that is already dead.
 	trigger := newAutoEnrichTrigger(e.Pool, slog.New(slog.DiscardHandler))
-	if err := trigger.refund(cancelled, slot); err != nil {
-		t.Fatalf("refund on a cancelled context: %v", err)
+	err = startEnrichOrRefund(cancelled, trigger.people, trigger.autoEnrich,
+		insertDomainOrg(t, e, "cancelled.example"), "cancelled.example", slot)
+	if err == nil {
+		t.Fatal("expected the start to fail on a cancelled context")
 	}
 	if n := budgetSpent(t, e); n != 0 {
 		t.Fatalf("budget spent = %d, want 0 — the slot must come back even when the capture was cancelled", n)

--- a/backend/internal/compose/captureenrichtrigger_integration_test.go
+++ b/backend/internal/compose/captureenrichtrigger_integration_test.go
@@ -264,3 +264,32 @@ func TestAutoEnrichBudgetRefundNamesTheDayItWasReservedOn(t *testing.T) {
 		t.Fatalf("today's counter = %d, want 1 — a refund for yesterday must not free today's slot", n)
 	}
 }
+
+// The refund has to survive the cancellation that can cause the failure it is
+// compensating for. A capture cancelled mid-start owes a slot back and, without
+// the detach, would try to return it on a context that is already dead —
+// leaking the slot in precisely the case it was written to handle.
+func TestAutoEnrichRefundSurvivesACancelledCaptureContext(t *testing.T) {
+	e := integration.Setup(t)
+	store := capture.NewAutoEnrichStore(e.Pool)
+	slot, err := store.ReserveBudget(e.Admin(), 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slot.Reserved {
+		t.Fatal("setup reservation refused")
+	}
+
+	// The capture's context, already cancelled — what the trigger holds when a
+	// sync is torn down mid-flight.
+	cancelled, cancel := context.WithCancel(e.Admin())
+	cancel()
+
+	trigger := newAutoEnrichTrigger(e.Pool, slog.New(slog.DiscardHandler))
+	if err := trigger.refund(cancelled, slot); err != nil {
+		t.Fatalf("refund on a cancelled context: %v", err)
+	}
+	if n := budgetSpent(t, e); n != 0 {
+		t.Fatalf("budget spent = %d, want 0 — the slot must come back even when the capture was cancelled", n)
+	}
+}

--- a/backend/internal/compose/captureenrichtrigger_integration_test.go
+++ b/backend/internal/compose/captureenrichtrigger_integration_test.go
@@ -25,7 +25,6 @@ import (
 	"context"
 	"log/slog"
 	"testing"
-	"time"
 
 	"github.com/jackc/pgx/v5"
 
@@ -130,11 +129,11 @@ func TestEnrichOnCaptureLeavesTheOrgToTheSweepWhenTheReadCannotStart(t *testing.
 	if !stillDue(t, e, org) {
 		t.Fatal("a trigger that could not start the read retired the organization anyway")
 	}
-	// The reserved slot is spent with no read to show for it. That is the
-	// deliberate direction: under-spending the day's budget costs a dossier a
-	// few hours, over-spending it costs money the cap exists to bound.
-	if n := budgetSpent(t, e); n != 1 {
-		t.Fatalf("budget spent = %d, want 1 — the reservation precedes the start and is not returned", n)
+	// And the slot it reserved goes back. Reserving before starting is what makes
+	// the cap a cap; refunding what did not start is what stops the day's
+	// allowance eroding a slot at a time on a path that never reads anything.
+	if n := budgetSpent(t, e); n != 0 {
+		t.Fatalf("budget spent = %d, want 0 — a slot that bought no read must be returned", n)
 	}
 }
 
@@ -202,14 +201,20 @@ func TestAutoEnrichBudgetReleaseNeverGoesBelowZero(t *testing.T) {
 	store := capture.NewAutoEnrichStore(e.Pool)
 
 	const testCap = 3
-	today := capture.BudgetSlot{Day: time.Now().UTC().Truncate(24 * time.Hour), Reserved: true}
+	// The day comes from a real reservation rather than Go's clock: the counter
+	// is keyed on the DATABASE's UTC day, and a test that builds its own would
+	// disagree with it across a midnight or any clock offset.
+	today, err := store.ReserveBudget(e.Admin(), testCap)
+	if err != nil {
+		t.Fatal(err)
+	}
 	for i := 0; i < testCap; i++ {
 		if err := store.ReleaseBudget(e.Admin(), today); err != nil {
 			t.Fatalf("ReleaseBudget on an unspent day: %v", err)
 		}
 	}
 	if n := budgetSpent(t, e); n != 0 {
-		t.Fatalf("budget spent = %d after refunds with nothing reserved, want 0", n)
+		t.Fatalf("budget spent = %d after more refunds than reservations, want 0", n)
 	}
 	// And the day still gives its full allowance.
 	for i := 0; i < testCap; i++ {
@@ -231,11 +236,16 @@ func TestAutoEnrichBudgetRefundNamesTheDayItWasReservedOn(t *testing.T) {
 	e := integration.Setup(t)
 	store := capture.NewAutoEnrichStore(e.Pool)
 
-	// Yesterday's spent slot, as the reservation would have recorded it.
-	yesterday := capture.BudgetSlot{
-		Day:      time.Now().UTC().AddDate(0, 0, -1).Truncate(24 * time.Hour),
-		Reserved: true,
+	// Yesterday relative to the DATABASE's day, taken from a real reservation —
+	// the counter is keyed on that day, not on the test process's clock.
+	todaySlot, err := store.ReserveBudget(e.Admin(), 3)
+	if err != nil {
+		t.Fatal(err)
 	}
+	if err := store.ReleaseBudget(e.Admin(), todaySlot); err != nil {
+		t.Fatal(err)
+	}
+	yesterday := capture.BudgetSlot{Day: todaySlot.Day.AddDate(0, 0, -1), Reserved: true}
 	e.WsExec(t, `
 		INSERT INTO capture_auto_enrich_budget (workspace_id, budget_date, enqueued)
 		VALUES ($1, $2, 1)`, e.WS, yesterday.Day)

--- a/backend/internal/compose/integration/capture_tiergate_integration_test.go
+++ b/backend/internal/compose/integration/capture_tiergate_integration_test.go
@@ -236,15 +236,19 @@ func resolveDispositionAged(t *testing.T, e *searchEnv, email, status string, ag
 	}
 }
 
-// The enrich-on-capture condition itself (ADR-0072/A118 §9): a NEW company
-// queues a dossier, and every later message from that company queues nothing.
+// The enrich-on-capture condition (ADR-0072/A118 §9): mail from a company the
+// workspace ALREADY has must not re-trigger enrichment. That is the half worth
+// holding, because mail from known companies is most mail and re-asking on each
+// message would spend the day's reads on companies nobody learned anything new
+// about — so the trigger keys on the ensure having CREATED the organization.
 //
-// The second half is the one worth holding. Mail from a company the workspace
-// already knows is most mail, and re-asking on each message would spend the
-// day's ten reads on companies nobody learned anything new about — so the
-// trigger keys on the ensure having CREATED the organization, not on a message
-// having arrived from one.
-func TestCaptureQueuesEnrichmentOnlyForACompanyItJustCreated(t *testing.T) {
+// The other half — that a NEW company DOES queue a read — is not observable
+// here and this test does not claim it. Starting a read needs an ambient River
+// client; no test process binds one, so the attempt fails and its budget slot is
+// refunded, leaving the same counter a company that never triggered would. Every
+// production capture runs inside a River job, so the condition is exercised
+// there and nowhere a test can watch it.
+func TestCaptureDoesNotReEnrichACompanyItAlreadyHas(t *testing.T) {
 	env := newCaptureEnv(t)
 	e, sync, syncSent := env.e, env.sync, env.syncSent
 
@@ -260,18 +264,19 @@ func TestCaptureQueuesEnrichmentOnlyForACompanyItJustCreated(t *testing.T) {
 		WHERE d.domain = 'newco.example'`); n != 1 {
 		t.Fatalf("%d organizations for the corresponded-with company, want 1", n)
 	}
-	spentAfterCreate := countRows(t, e, `
-		SELECT coalesce(sum(enqueued), 0) FROM capture_auto_enrich_budget`)
-	if spentAfterCreate != 1 {
-		t.Fatalf("budget spent = %d after a company was created, want 1 — the capture must queue its dossier", spentAfterCreate)
-	}
 
-	// A second message from the same company. It resolves onto the existing
-	// organization, so nothing new was learned and nothing may be spent.
+	// A second message from the same company resolves onto the organization that
+	// already exists, so the ensure reports no creation and the trigger never
+	// runs — no second organization, and nothing spent.
 	sync(t, email("sales@newco.example", "Sales", captureOwner, "in2@newco.example", ""))
 	if n := countRows(t, e, `
-		SELECT coalesce(sum(enqueued), 0) FROM capture_auto_enrich_budget`); n != spentAfterCreate {
-		t.Fatalf("budget spent = %d after mail from a company we already had, want it unchanged at %d",
-			n, spentAfterCreate)
+		SELECT count(*) FROM organization o
+		JOIN organization_domain d ON d.organization_id = o.id
+		WHERE d.domain = 'newco.example'`); n != 1 {
+		t.Fatalf("%d organizations after a second message, want the one that existed", n)
+	}
+	if n := countRows(t, e, `
+		SELECT coalesce(sum(enqueued), 0) FROM capture_auto_enrich_budget`); n != 0 {
+		t.Fatalf("budget spent = %d, want 0 — nothing here started a read, so nothing may stay reserved", n)
 	}
 }

--- a/backend/internal/modules/capture/autoenrich.go
+++ b/backend/internal/modules/capture/autoenrich.go
@@ -111,6 +111,15 @@ func (s *AutoEnrichStore) ExpireExhausted(ctx context.Context) error {
 	return nil
 }
 
+// BudgetSlot is one reservation against a workspace's daily read allowance: the
+// UTC day it was taken on, and whether it was granted at all. Carry it from the
+// reservation to the refund — the day is what makes a refund land on the row the
+// reservation incremented.
+type BudgetSlot struct {
+	Day      time.Time
+	Reserved bool
+}
+
 // ReserveBudget atomically reserves one auto-enrich slot for the current
 // workspace's UTC day, returning false when the daily cap is already spent. The
 // reservation is the same transaction as the counter read, so two concurrent
@@ -147,23 +156,15 @@ func (s *AutoEnrichStore) ReserveBudget(ctx context.Context, dailyCap int) (Budg
 	return slot, nil
 }
 
-// BudgetSlot is one reservation against a workspace's daily read allowance: the
-// UTC day it was taken on, and whether it was granted at all. Carry it from the
-// reservation to the refund — the day is what makes a refund land on the row the
-// reservation incremented.
-type BudgetSlot struct {
-	Day      time.Time
-	Reserved bool
-}
-
 // ReleaseBudget returns one reserved slot to the day, for a reservation that
 // bought nothing.
 //
 // The pattern is reserve-before-spend, which means the caller sometimes holds a
 // slot it turns out not to need: two paths racing on one organization both
 // reserve, and the uniqueness index lets only one of them start a read. Without
-// the refund the day's ten reads would deliver nine, and the shortfall would
-// grow with exactly the concurrency the cap is meant to be indifferent to.
+// the refund the day's allowance erodes a slot at a time, and the shortfall grows
+// with exactly the concurrency the cap is meant to be indifferent to. A slot that
+// was never granted refunds nothing.
 //
 // Guarded at zero rather than trusted: a decrement that could run below zero
 // would hand out free reads on the next reservation, which is the failure this


### PR DESCRIPTION
Review round on the enrich-on-capture trigger (#292, merged).

## The real defect

The failure path kept its budget slot. Reserving before starting is what makes the cap a cap — but a start that never happened has to give the slot back, or the day's allowance erodes a slot at a time on any path that reserves and then cannot read. It is the same rule the join path already followed, and the comment calling the leak "a conservative under-spend" was rationalizing it rather than fixing it (CLAUDE.md rule 5).

One reviewer read that leak as **reachable** from the site-lead accept effect, which composes a Sink in the API process where nothing binds a River client. It is not: `ensureCounterparty` runs only when an ACTIVITY was created (`sink.go:169`), and that path upserts a lead. So this is correct hygiene, not a live bug — the security reviewer reached the same conclusion independently.

## The test that overclaimed

`TestCaptureQueuesEnrichmentOnlyForACompanyItJustCreated` asserted a budget slot was spent after a new company. With the refund above, that assertion becomes false — and it was never evidence of the thing its name promised: starting a read needs an ambient River client, no test process binds one, so the attempt fails and leaves the same counter a company that never triggered would.

Renamed to `TestCaptureDoesNotReEnrichACompanyItAlreadyHas`, which is the half it does prove and the half worth holding (mail from known companies is most mail). The comment says why the other half is not observable there instead of implying it is.

## Comments that stopped being true when the cap moved 10 → 500

- Five said "ten" ("the day's ten reads would deliver nine", "two of its ten reads", …).
- The cap comment argued for **10** and then announced 500, leaving the reader without a reason for the number in the code — and carried a dated change-narration line (rule 4).
- `ReserveBudget`'s doc still described returning a bool.
- One justification sentence said the opposite of what it meant.
- Two tests built the UTC day from Go's clock while the counter is keyed on the **database's**; they take it from a real reservation now, removing the real-clock dependency (T11).

## Verification

`make check` green, `craft static` clean.

The local integration lane is unreliable on this machine right now and I want to be straight about it rather than claim a green I did not get: a **different** approval-redemption test fails each run (`approval expired 15m0s after decision`), and each one passes 3× in isolation. The cause is transient clock skew between the Postgres container and the host under lane load — `now − decided_at` crosses the 15-minute redemption window. Nothing in this diff touches approvals. CI runs fresh containers and is the authority here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refunds the auto‑enrich daily budget slot when no read actually starts, and centralizes the start/refund rule so both the capture trigger and the sweep don’t leak the cap while keeping slots for reads that did start (including joins).

- **Bug Fixes**
  - Unified logic in `startEnrichOrRefund` for both trigger and sweep: a reserved slot buys a read or goes back.
  - Check `started` before `err` to avoid refunding a queued read whose cursor arming failed.
  - Run refunds on a detached context with a 5s timeout; new test proves refunds survive a cancelled capture.
  - Tests/docs: renamed to “does not re‑enrich an existing company,” assert zero budget spent without a River client, take the UTC day from a real DB reservation and require it be granted, and fix cap comments and `ReserveBudget`/`BudgetSlot` docs to 500/day with clarified refund behavior.

<sup>Written for commit 4ba875345d5f71af5f82a7399d5d05c782879953. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved daily auto-enrichment budget handling when reads cannot be queued.
  * Reserved budget is now reliably refunded when capture processing is cancelled or a read fails to start.
  * Prevented budget slots from being lost during cancellation and concurrent capture scenarios.
  * Avoided re-enriching companies that are already known.

* **Tests**
  * Expanded coverage for cancelled captures, failed read starts, budget refunds, and repeat enrichment prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->