### PR TITLE
perf(testdb): reset integration data with DELETE, not a blanket TRUNCATE

### DIFF
--- a/backend/integrationmigrateonce_test.go
+++ b/backend/integrationmigrateonce_test.go
@@ -6,7 +6,7 @@ package backendarch
 // Migrate-once discipline for the compose/integration suites as a fitness
 // function. The package migrates the schema exactly once per test process
 // (internal/platform/testdb.EnsureSchema) and resets between tests with a fast
-// TRUNCATE (testdb.Truncate); a suite that instead runs its own DROP SCHEMA +
+// data-only reset (testdb.Reset); a suite that instead runs its own DROP SCHEMA +
 // dbmigrate.Up on every setup silently reintroduces the ~0.8s-per-test migrate
 // that once dominated the lane. The obligation is derived from the tree — any
 // new *_test.go in the package that calls dbmigrate.Up is caught here — so the
@@ -14,7 +14,7 @@ package backendarch
 //
 // perfbench is the one sanctioned exception: it seeds a large volume and asserts
 // query-latency SLOs, so it wants pristine physical tables (no bloat or stale
-// planner stats from prior TRUNCATE cycles) and pays a genuine fresh migrate. It
+// planner stats from prior reset cycles) and pays a genuine fresh migrate. It
 // runs once, so the cost it opts back into is negligible.
 
 import (
@@ -55,7 +55,7 @@ func TestComposeIntegrationSuitesMigrateOncePerProcess(t *testing.T) {
 	}
 	if len(offenders) > 0 {
 		t.Errorf("%d compose/integration suite(s) migrate inline instead of riding testdb.EnsureSchema — "+
-			"replace the DROP SCHEMA + dbmigrate.Up block with testdb.EnsureSchema + testdb.Truncate (see harness.go):\n\t%s",
+			"replace the DROP SCHEMA + dbmigrate.Up block with testdb.EnsureSchema + testdb.Reset (see harness.go):\n\t%s",
 			len(offenders), strings.Join(offenders, "\n\t"))
 	}
 

--- a/backend/internal/compose/integration/ai_meter_integration_test.go
+++ b/backend/internal/compose/integration/ai_meter_integration_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 // meterFreshDatabase resets the data to a clean slate and ensures the schema is
-// migrated (once per process, then a fast TRUNCATE — see package testdb),
+// migrated (once per process, then a fast data-only reset — see package testdb),
 // returning the owner connection and the RLS-bound app DSN.
 func meterFreshDatabase(t *testing.T, ctx context.Context) (*pgx.Conn, string) {
 	t.Helper()
@@ -47,7 +47,7 @@ func meterFreshDatabase(t *testing.T, ctx context.Context) (*pgx.Conn, string) {
 	if err := testdb.EnsureSchema(ctx, owner); err != nil {
 		t.Fatalf("migrating schema: %v", err)
 	}
-	if err := testdb.Truncate(ctx, owner); err != nil {
+	if err := testdb.Reset(ctx, owner); err != nil {
 		t.Fatalf("resetting database: %v", err)
 	}
 	return owner, appDSN

--- a/backend/internal/compose/integration/e2e_integration_test.go
+++ b/backend/internal/compose/integration/e2e_integration_test.go
@@ -76,7 +76,7 @@ func setupWithOptions(t *testing.T, opts ...compose.Option) *env {
 	if err := testdb.EnsureSchema(ctx, owner); err != nil {
 		t.Fatalf("migrating schema: %v", err)
 	}
-	if err := testdb.Truncate(ctx, owner); err != nil {
+	if err := testdb.Reset(ctx, owner); err != nil {
 		t.Fatalf("resetting database: %v", err)
 	}
 

--- a/backend/internal/compose/integration/harness.go
+++ b/backend/internal/compose/integration/harness.go
@@ -44,10 +44,10 @@ type Env struct {
 
 // Setup gives each test a clean, migrated database and seeds the
 // workspace/user/team fixture, returning the ready Env. The schema is migrated
-// once per test process (testdb.EnsureSchema); every later test resets via a
-// fast TRUNCATE (testdb.Truncate) instead of remigrating — see package testdb
-// for why that dominated the lane. Integration tests fail loudly without a
-// database — they never skip.
+// once per test process (testdb.EnsureSchema); every later test resets the data
+// only (testdb.Reset) — nothing here remigrates, and nothing truncates the whole
+// schema; see package testdb for what each of those costs.
+// Integration tests fail loudly without a database — they never skip.
 func Setup(t *testing.T) *Env {
 	t.Helper()
 	ownerDSN := os.Getenv("MARGINCE_TEST_DSN")
@@ -69,7 +69,7 @@ func Setup(t *testing.T) *Env {
 	if err := testdb.EnsureSchema(ctx, owner); err != nil {
 		t.Fatal(err)
 	}
-	if err := testdb.Truncate(ctx, owner); err != nil {
+	if err := testdb.Reset(ctx, owner); err != nil {
 		t.Fatal(err)
 	}
 

--- a/backend/internal/compose/integration/passports_integration_test.go
+++ b/backend/internal/compose/integration/passports_integration_test.go
@@ -54,7 +54,7 @@ func setupPassports(t *testing.T) *passportsEnv {
 	if err := testdb.EnsureSchema(ctx, owner); err != nil {
 		t.Fatal(err)
 	}
-	if err := testdb.Truncate(ctx, owner); err != nil {
+	if err := testdb.Reset(ctx, owner); err != nil {
 		t.Fatal(err)
 	}
 

--- a/backend/internal/compose/integration/perfbench_integration_test.go
+++ b/backend/internal/compose/integration/perfbench_integration_test.go
@@ -57,8 +57,9 @@ var benchTiers = map[search.BenchTier]benchTierSpec{
 }
 
 // benchDatabase connects as owner, resets the schema, and migrates. This is
-// the ONE compose/integration suite that migrates inline instead of riding the
-// shared migrate-once harness (testdb.EnsureSchema + Reset) — it seeds a
+// the ONE compose/integration suite that migrates inline rather than riding the
+// migrate-once harness every other suite uses (testdb.EnsureSchema + Reset) —
+// it seeds a
 // large volume and asserts query-latency SLOs, so it wants pristine physical
 // tables (fresh relfilenodes, no bloat or stale planner stats a prior reset
 // cycle would leave) and pays a genuine fresh migrate. It runs once per tier, so

--- a/backend/internal/compose/integration/perfbench_integration_test.go
+++ b/backend/internal/compose/integration/perfbench_integration_test.go
@@ -58,9 +58,9 @@ var benchTiers = map[search.BenchTier]benchTierSpec{
 
 // benchDatabase connects as owner, resets the schema, and migrates. This is
 // the ONE compose/integration suite that migrates inline instead of riding the
-// shared migrate-once harness (testdb.EnsureSchema + Truncate) — it seeds a
+// shared migrate-once harness (testdb.EnsureSchema + Reset) — it seeds a
 // large volume and asserts query-latency SLOs, so it wants pristine physical
-// tables (fresh relfilenodes, no bloat or stale planner stats a prior TRUNCATE
+// tables (fresh relfilenodes, no bloat or stale planner stats a prior reset
 // cycle would leave) and pays a genuine fresh migrate. It runs once per tier, so
 // the cost is negligible. The migrate-once guard
 // (TestComposeIntegrationSuitesMigrateOncePerProcess) allowlists this file for

--- a/backend/internal/compose/integration/rls_coverage_integration_test.go
+++ b/backend/internal/compose/integration/rls_coverage_integration_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 // freshlyMigratedOwner connects as owner and returns a clean, migrated schema
-// (migrated once per process, then reset with a fast TRUNCATE — see package
+// (migrated once per process, then a fast data-only reset — see package
 // testdb) — the schema-derivation arrange step, needing only the owner DSN (no
 // app pool is involved in a coverage sweep).
 func freshlyMigratedOwner(t *testing.T) *pgx.Conn {
@@ -45,7 +45,7 @@ func freshlyMigratedOwner(t *testing.T) *pgx.Conn {
 	if err := testdb.EnsureSchema(ctx, owner); err != nil {
 		t.Fatalf("migrating schema: %v", err)
 	}
-	if err := testdb.Truncate(ctx, owner); err != nil {
+	if err := testdb.Reset(ctx, owner); err != nil {
 		t.Fatalf("resetting database: %v", err)
 	}
 	return owner

--- a/backend/internal/compose/integration/search_integration_test.go
+++ b/backend/internal/compose/integration/search_integration_test.go
@@ -60,7 +60,7 @@ func setupSearch(t *testing.T) *searchEnv {
 	if err := testdb.EnsureSchema(ctx, owner); err != nil {
 		t.Fatal(err)
 	}
-	if err := testdb.Truncate(ctx, owner); err != nil {
+	if err := testdb.Reset(ctx, owner); err != nil {
 		t.Fatal(err)
 	}
 

--- a/backend/internal/compose/jobs_integration_test.go
+++ b/backend/internal/compose/jobs_integration_test.go
@@ -84,7 +84,7 @@ func TestNewJobRunnerWiresTheOverlayPollerWhenAVaultIsConfigured(t *testing.T) {
 
 // riverSchemaOnce guards the River migration per test-binary process, the
 // same contract as testdb.EnsureSchema: the schema survives the per-test
-// Truncate, but the truncate DOES empty river_migration's applied-version
+// reset, but the reset DOES empty river_migration's applied-version
 // ledger — so a second in-process migrate would re-run River's first
 // migration against tables that still exist and fail on CREATE TABLE.
 // jobs.Migrate is not idempotent (a second call fails "river_migration

--- a/backend/internal/platform/testdb/reset.go
+++ b/backend/internal/platform/testdb/reset.go
@@ -7,33 +7,35 @@
 // integration suites need a clean database per test, and the obvious way to get
 // one — DROP SCHEMA + re-run every embedded migration on each Setup — dominated
 // the lane: the heaviest package alone remigrated ~180 times (~0.8s each). This
-// package splits the cost. EnsureSchema migrates ONCE per test-binary process;
-// every later test in that process rides the already-migrated schema and only
-// Truncates the data. Migration cost drops from once-per-test to once-per-
-// package, and a TRUNCATE is milliseconds. Correctness holds because no
-// migration seeds reference data a test depends on — the only data-touching
-// migration (person_social backfill) is a no-op on an empty database.
+// package splits the cost. EnsureSchema migrates ONCE per test-binary process
+// and records the empty schema's physical size; every later test in that process
+// rides the already-migrated schema and only resets the data. Correctness holds
+// because no migration seeds reference data a test depends on — the only
+// data-touching migration (person_social backfill) is a no-op on an empty
+// database.
 //
-// TRUNCATE empties rows but does not revert schema changes, and the
-// customfields engine is the one place in the system allowed to run a runtime
-// ALTER TABLE (it adds cf_<slug> columns to record tables). A cf_ column added
-// by one test would otherwise survive into the next, which reads it as a
-// column that is already "taken platform-wide". So the reset also drops every
-// leaked cf_ column — see dropCustomFieldColumns.
+// Emptying rows does not revert schema changes, so the reset also drops the
+// runtime cf_ columns the customfields engine adds — see dropCustomFieldColumns.
 //
 // The reset stays safe under the lane's -p 1: within a package process tests
-// run serially, so nothing races the shared connection between Truncate and the
-// next test. Across packages, each go-test binary is its own process (and, under
+// run serially, so nothing races the shared connection between Reset and the
+// next test. That covers tests, not goroutines a test leaves running — the
+// DELETE batch takes row locks rather than TRUNCATE's whole-table ones, so a
+// straggling writer is no longer locked out, and a suite that leaks one must
+// stop it in cleanup. Across packages, each go-test binary is its own process (and, under
 // the parallel runner, its own throwaway database), so migrateOnce is genuinely
 // per-database.
 package testdb
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 
 	"github.com/gradionhq/margince/backend/internal/platform/dbmigrate"
 	"github.com/gradionhq/margince/backend/migrations"
@@ -42,11 +44,46 @@ import (
 var (
 	migrateOnce sync.Once
 	migrateErr  error
+
+	// emptySizes is the physical size of every table on the freshly migrated,
+	// still-empty schema, keyed by qualified name. reclaimBloat measures growth
+	// against it — see there for why an absolute size threshold cannot work.
+	// Atomic because EnsureSchema writes it, every later Reset reads it, and
+	// baselineNewTables replaces it mid-run — Reset never calls EnsureSchema, so
+	// there is no happens-before edge a plain map could rely on.
+	emptySizes atomic.Pointer[map[string]int64]
 )
+
+// publicTables is the ONE spelling of which relations a reset acts on: ordinary
+// tables in public, minus the schema_migrations_* ledger. That ledger is
+// preserved so EnsureSchema's once-per-process contract holds — re-running
+// dbmigrate.Up in a later process (parallel runner, fresh clone) must still see
+// an unmigrated database, while a reset leaves the applied-version rows intact
+// for the current one. Every caller selects a qualified identifier from it, so
+// the emitted statements never depend on search_path resolution.
+const publicTables = `
+	FROM pg_class c
+	JOIN pg_namespace n ON n.oid = c.relnamespace
+	WHERE n.nspname = 'public'
+	  AND c.relkind = 'r'
+	  AND c.relname NOT LIKE 'schema_migrations_%'`
+
+// reclaimSlack is how much a table may grow past its empty size before a reset
+// TRUNCATEs it instead of DELETEing it. Growth, not absolute size, is the
+// signal: see reclaimBloat.
+const reclaimSlack = 256 << 10
+
+// execQuerier is the pgx subset each reset step needs, so every step can run
+// inside Reset's single transaction rather than racing it on the bare
+// connection.
+type execQuerier interface {
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+	Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error)
+}
 
 // EnsureSchema migrates the test database exactly once per process. The first
 // integration test to run pays the DROP SCHEMA + full embedded migration; every
-// later test in the same process is a no-op here and resets via Truncate. Any
+// later test in the same process is a no-op here and resets via Reset. Any
 // caller may pass any owner connection to the same database — the migration runs
 // on whichever connection wins the race to the sync.Once, and the result is the
 // same schema for all of them.
@@ -71,89 +108,314 @@ func EnsureSchema(ctx context.Context, owner *pgx.Conn) error {
 			migrateErr = err
 			return
 		}
+		// The schema is migrated and provably empty exactly here, which is the
+		// only moment a per-table "this is what zero rows costs" baseline can be
+		// taken.
+		sizes, err := tableSizes(ctx, owner)
+		if err != nil {
+			migrateErr = fmt.Errorf("recording empty-schema sizes: %w", err)
+			return
+		}
+		emptySizes.Store(&sizes)
 	})
 	return migrateErr
 }
 
-// Truncate empties every data table (RESTART IDENTITY, CASCADE) so the next test
-// sees a clean database without re-running migrations. The schema_migrations_*
-// bookkeeping tables are preserved so EnsureSchema's once-per-process contract
-// holds: re-running dbmigrate.Up on a later process (parallel runner, fresh
-// clone) still sees an unmigrated database, while a truncate here leaves the
-// applied-version ledger intact for the current process.
-func Truncate(ctx context.Context, owner *pgx.Conn) error {
-	rows, err := owner.Query(ctx, `
-		SELECT quote_ident(tablename)
-		FROM pg_tables
-		WHERE schemaname = 'public'
-		  AND tablename NOT LIKE 'schema_migrations_%'`)
+// Reset empties every data table so the next test sees a clean database without
+// re-running migrations.
+//
+// The reset is DELETE, not TRUNCATE, because TRUNCATE's cost is per-table, not
+// per-row: it takes an ACCESS EXCLUSIVE lock and swaps a relfilenode for every
+// table it touches, and CASCADE drags the whole FK graph in behind whichever
+// table is named. Blindly truncating this schema costs ~500ms
+// even when every table is already empty, which — at one reset per test — was
+// most of the heaviest package's runtime. The DELETE batch measures ~15ms.
+//
+// Everything runs in ONE transaction, so the database is either fully reset or
+// visibly failed. That matters more than it looks: the batch runs with FK
+// enforcement off, so a half-applied reset would leave dangling references that
+// Postgres will never complain about, and a later suite would read them as real
+// data.
+func Reset(ctx context.Context, owner *pgx.Conn) error {
+	tx, err := owner.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("beginning reset: %w", err)
+	}
+	if err := resetWithin(ctx, tx); err != nil {
+		if rbErr := tx.Rollback(ctx); rbErr != nil {
+			return fmt.Errorf("%w (rollback: %v)", err, rbErr)
+		}
+		return err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("committing reset: %w", err)
+	}
+	return nil
+}
+
+// resetWithin performs every step of the reset on one transaction.
+func resetWithin(ctx context.Context, tx execQuerier) error {
+	// Two transaction-local settings, both load-bearing, both reverted by the
+	// commit or rollback that ends this transaction:
+	//
+	// session_replication_role = replica suppresses every non-ALWAYS trigger.
+	// That covers the FK triggers, which is what lets one unordered DELETE batch
+	// stand in for TRUNCATE ... CASCADE, AND the
+	// append-only guards on audit_log and system_log, whose BEFORE DELETE
+	// triggers RAISE unconditionally. TRUNCATE never fired row triggers, so
+	// those guards are a dependency the DELETE introduces: every test writes an
+	// audit row, so without replica mode the very first reset aborts. Do not
+	// replace this with topologically ordered DELETEs.
+	//
+	// row_security = off closes the second exposure. TRUNCATE is not subject to
+	// RLS; DELETE is, and every workspace_id table carries FORCE ROW LEVEL
+	// SECURITY with deny-on-unset policies (gated by
+	// migrations/schema_fitness_integration_test.go) while this transaction sets
+	// no app.workspace_id GUC — so a role without BYPASSRLS would delete zero
+	// rows and report a clean database. Setting session_replication_role is
+	// itself SUSET, so it is the first statement such a role fails on and the
+	// primary guard; this makes the RLS half fail loudly too rather than
+	// filtering silently.
+	if _, err := tx.Exec(ctx, `
+		SELECT set_config('session_replication_role', 'replica', true),
+		       set_config('row_security', 'off', true)`); err != nil {
+		return fmt.Errorf("arming reset session: %w", err)
+	}
+
+	tables, err := queryIdents(ctx, tx,
+		`SELECT quote_ident(n.nspname) || '.' || quote_ident(c.relname) `+publicTables+` ORDER BY c.relname`)
+	if err != nil {
+		return fmt.Errorf("listing data tables: %w", err)
+	}
+	// A migrated database always has tables, so an empty list means the schema is
+	// gone, not that there is nothing to do. Reporting a clean reset for that is
+	// the same silent-success shape the settings above exist to eliminate.
+	if len(tables) == 0 {
+		return fmt.Errorf("no data tables in public — call EnsureSchema before Reset; the schema is missing or was dropped")
+	}
+	unbaselined, err := reclaimBloat(ctx, tx)
 	if err != nil {
 		return err
 	}
-	var tables []string
-	for rows.Next() {
-		var t string
-		if err := rows.Scan(&t); err != nil {
-			rows.Close()
-			return err
-		}
-		tables = append(tables, t)
+	// Identifiers cannot be bound parameters, so the batch is built by
+	// concatenation — but every name comes from quote_ident() over pg_class,
+	// never from caller input, and is schema-qualified, so it is injection-safe
+	// and search_path-independent.
+	if _, err := tx.Exec(ctx, `DELETE FROM `+strings.Join(tables, `; DELETE FROM `)+`;`); err != nil {
+		return fmt.Errorf("emptying data tables: %w", err)
 	}
-	rows.Close()
-	if err := rows.Err(); err != nil {
+	if err := restartSequences(ctx, tx); err != nil {
 		return err
 	}
-	if len(tables) == 0 {
+	if err := dropCustomFieldColumns(ctx, tx); err != nil {
+		return err
+	}
+	// Every table is empty now, which is the only moment a table that did not
+	// exist when EnsureSchema ran can be given a real baseline.
+	return baselineNewTables(ctx, tx, unbaselined)
+}
+
+// baselineNewTables records the empty size of tables that appeared after
+// EnsureSchema took its baseline — River migrates its own river_* schema the
+// first time a suite boots a job client, partway through a package run. It runs
+// at the end of a reset, where the tables are empty by construction, so the size
+// it records is genuinely an empty size.
+//
+// Without this such a table would be measured against zero for the rest of the
+// process, and the reclaim would TRUNCATE it on every single reset from the
+// moment its own empty footprint exceeded the slack — the per-table cost this
+// path exists to avoid, reintroduced for one table and invisible in a green lane.
+func baselineNewTables(ctx context.Context, q execQuerier, unbaselined []string) error {
+	if len(unbaselined) == 0 {
 		return nil
 	}
-	// The table list is built by concatenation because identifiers cannot be
-	// bound parameters — but every name comes from quote_ident() over the
-	// pg_tables system catalog, never from caller input, so it is injection-safe.
-	// One statement: CASCADE resolves FK order, RESTART IDENTITY resets the few
-	// serial sequences (most ids are client-side UUIDv7, so this is belt-and-braces).
-	if _, err := owner.Exec(ctx, `TRUNCATE `+strings.Join(tables, ", ")+` RESTART IDENTITY CASCADE`); err != nil {
-		return err
+	sizes, err := tableSizes(ctx, q)
+	if err != nil {
+		return fmt.Errorf("baselining new tables: %w", err)
 	}
-	return dropCustomFieldColumns(ctx, owner)
+	merged := make(map[string]int64, len(sizes))
+	if recorded := emptySizes.Load(); recorded != nil {
+		for name, size := range *recorded {
+			merged[name] = size
+		}
+	}
+	for _, name := range unbaselined {
+		if size, ok := sizes[name]; ok {
+			merged[name] = size
+		}
+	}
+	emptySizes.Store(&merged)
+	return nil
+}
+
+// reclaimBloat TRUNCATEs the tables that have grown well past their empty size.
+// DELETE leaves dead tuples behind — in the indexes as well as the heap — so
+// without this the volume the perf suite seeds (tens of thousands of rows) would
+// keep costing every later test's scans until autovacuum caught up, and the
+// customfields suites' ALTER TABLE would keep rewriting the dead weight with it.
+//
+// The trigger is GROWTH against the recorded empty baseline, not an absolute
+// size, because on this schema an empty table is not small — index storage
+// dominates a table that holds no rows. Any absolute threshold low enough to
+// catch real bloat therefore sits close to the empty footprint, and the first
+// migration to push a hot table over it would make every reset TRUNCATE that
+// table forever, silently restoring the per-table cost this whole path exists to
+// avoid. Measuring growth is immune to that: adding indexes raises the baseline
+// with it.
+//
+// A table with no baseline yet is measured against zero for this one reset, and
+// reports itself so the caller can baseline it once it is empty. Nothing here
+// depends on how large an unbaselined table happens to be.
+func reclaimBloat(ctx context.Context, tx execQuerier) ([]string, error) {
+	sizes, err := tableSizes(ctx, tx)
+	if err != nil {
+		return nil, fmt.Errorf("measuring table sizes: %w", err)
+	}
+	var baseline map[string]int64
+	if recorded := emptySizes.Load(); recorded != nil {
+		baseline = *recorded
+	}
+	var bloated, unbaselined []string
+	for name, size := range sizes {
+		known, ok := baseline[name]
+		if !ok {
+			unbaselined = append(unbaselined, name)
+		}
+		if size > known+reclaimSlack {
+			bloated = append(bloated, name)
+		}
+	}
+	if len(bloated) == 0 {
+		return unbaselined, nil
+	}
+	// CASCADE because TRUNCATE still refuses a table whose referencing tables
+	// are not named, structurally, whatever the triggers are doing. Everything
+	// it reaches is being emptied in this transaction anyway.
+	if _, err := tx.Exec(ctx, `TRUNCATE `+strings.Join(bloated, ", ")+` CASCADE`); err != nil {
+		return nil, fmt.Errorf("reclaiming bloated tables: %w", err)
+	}
+	return unbaselined, nil
+}
+
+// tableSizes returns each reset-eligible table's total physical size — heap,
+// indexes and TOAST — keyed by the same qualified identifier the reset emits.
+// Size comes from pg_class.oid rather than a name cast to regclass: a
+// name::regclass resolves through search_path, and the planner may evaluate that
+// call before the schema filter, which makes it fail on the first
+// information_schema row it sees.
+func tableSizes(ctx context.Context, q execQuerier) (map[string]int64, error) {
+	rows, err := q.Query(ctx,
+		`SELECT quote_ident(n.nspname) || '.' || quote_ident(c.relname), pg_total_relation_size(c.oid) `+publicTables)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	sizes := make(map[string]int64)
+	for rows.Next() {
+		var name string
+		var size int64
+		if err := rows.Scan(&name, &size); err != nil {
+			return nil, err
+		}
+		sizes[name] = size
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return sizes, nil
+}
+
+// restartSequences rewinds the counters the DELETE batch cannot: emptying rows
+// leaves a sequence where it stood, and a test that asserts on a generated number
+// must not see the previous test's value. Nearly every id in the schema is a
+// client-side UUIDv7, so only a handful of sequences exist.
+//
+// Scoped to sequences OWNED BY a table the reset empties, which is what
+// TRUNCATE ... RESTART IDENTITY covered. A sequence attached to anything the
+// reset preserves, or attached to no table at all, is out of scope.
+func restartSequences(ctx context.Context, tx execQuerier) error {
+	seqs, err := queryIdents(ctx, tx, `
+		SELECT quote_ident(n.nspname) || '.' || quote_ident(s.relname)
+		FROM pg_class s
+		JOIN pg_namespace n ON n.oid = s.relnamespace
+		JOIN pg_depend d ON d.objid = s.oid AND d.classid = 'pg_class'::regclass
+		                AND d.refclassid = 'pg_class'::regclass AND d.deptype IN ('a', 'i')
+		WHERE s.relkind = 'S'
+		  AND d.refobjid IN (SELECT c.oid `+publicTables+`)`)
+	if err != nil {
+		return fmt.Errorf("listing sequences: %w", err)
+	}
+	if len(seqs) == 0 {
+		return nil
+	}
+	if _, err := tx.Exec(ctx, `ALTER SEQUENCE `+strings.Join(seqs, ` RESTART; ALTER SEQUENCE `)+` RESTART;`); err != nil {
+		return fmt.Errorf("restarting sequences: %w", err)
+	}
+	return nil
 }
 
 // dropCustomFieldColumns reverts the runtime DDL the customfields engine adds —
 // the cf_<slug> columns it appends to record tables (people, deals, …) as the
-// system's single sanctioned ALTER-TABLE chokepoint. TRUNCATE clears the rows
-// but leaves the columns, so without this a cf_ column created by one test
-// leaks into the next and is rejected as "taken platform-wide". No migrated
-// baseline table carries a cf_-prefixed column, so every match here is a
-// leaked custom field and safe to drop; DROP COLUMN cascades its generated
-// cf_<slug>_check constraint with it.
-func dropCustomFieldColumns(ctx context.Context, owner *pgx.Conn) error {
-	rows, err := owner.Query(ctx, `
-		SELECT quote_ident(table_name), quote_ident(column_name)
+// system's single sanctioned ALTER-TABLE chokepoint. Emptying rows leaves the
+// columns, so without this a cf_ column created by one test leaks into the next
+// and is rejected as "taken platform-wide". No migrated baseline table carries a
+// cf_-prefixed column, so every match here is a leaked custom field and safe to
+// drop; DROP COLUMN cascades its generated cf_<slug>_check constraint with it.
+func dropCustomFieldColumns(ctx context.Context, tx execQuerier) error {
+	// Constrained to the tables the reset owns: information_schema.columns also
+	// lists view columns, and a view over a record table exposes its cf_ columns.
+	// ALTER TABLE cannot drop a view's column, and since the reset is one
+	// transaction that failure would roll back the whole reset, not just itself.
+	rows, err := tx.Query(ctx, `
+		SELECT quote_ident(table_schema) || '.' || quote_ident(table_name), quote_ident(column_name)
 		FROM information_schema.columns
 		WHERE table_schema = 'public'
-		  AND column_name LIKE 'cf\_%'`)
+		  AND column_name LIKE 'cf\_%'
+		  AND table_name IN (SELECT c.relname `+publicTables+`)`)
 	if err != nil {
-		return err
+		return fmt.Errorf("listing leaked custom-field columns: %w", err)
 	}
 	var stmts []string
 	for rows.Next() {
 		var table, column string
 		if err := rows.Scan(&table, &column); err != nil {
 			rows.Close()
-			return err
+			return fmt.Errorf("scanning leaked custom-field columns: %w", err)
 		}
-		// Identifiers cannot be bound parameters, but both names come from
-		// quote_ident() over information_schema, never from caller input, so
-		// the concatenation is injection-safe (same posture as Truncate).
+		// Same posture as the DELETE batch: quote_ident over a system catalog,
+		// schema-qualified, never caller input.
 		stmts = append(stmts, `ALTER TABLE `+table+` DROP COLUMN `+column+` CASCADE`)
 	}
 	rows.Close()
 	if err := rows.Err(); err != nil {
-		return err
+		return fmt.Errorf("listing leaked custom-field columns: %w", err)
 	}
 	for _, stmt := range stmts {
-		if _, err := owner.Exec(ctx, stmt); err != nil {
-			return err
+		if _, err := tx.Exec(ctx, stmt); err != nil {
+			return fmt.Errorf("dropping leaked custom-field column: %w", err)
 		}
 	}
 	return nil
+}
+
+// queryIdents runs a query whose single column is an already-quoted identifier
+// and collects the results — the shape three of the reset's steps need.
+func queryIdents(ctx context.Context, q execQuerier, sql string) ([]string, error) {
+	rows, err := q.Query(ctx, sql)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var idents []string
+	for rows.Next() {
+		var ident string
+		if err := rows.Scan(&ident); err != nil {
+			return nil, err
+		}
+		idents = append(idents, ident)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return idents, nil
 }

--- a/backend/internal/platform/testdb/reset.go
+++ b/backend/internal/platform/testdb/reset.go
@@ -288,6 +288,9 @@ func reclaimBloat(ctx context.Context, tx execQuerier) ([]string, error) {
 	if len(bloated) == 0 {
 		return unbaselined, nil
 	}
+	// Same injection posture as the DELETE batch: every name is quote_ident()
+	// over pg_class and schema-qualified, never caller input.
+	//
 	// CASCADE because TRUNCATE still refuses a table whose referencing tables
 	// are not named, structurally, whatever the triggers are doing. Everything
 	// it reaches is being emptied in this transaction anyway.

--- a/backend/internal/platform/testdb/reset_test.go
+++ b/backend/internal/platform/testdb/reset_test.go
@@ -1,0 +1,400 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package testdb
+
+import (
+	"context"
+	"os"
+	"sort"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// The reset is what every integration suite relies on for isolation, and every way
+// it can fail is quiet: a table it stops emptying, an RLS-filtered DELETE that
+// affects nothing, a cf_ column left behind. None of those announce themselves —
+// they surface later as a flake in some unrelated suite that reads like a
+// product bug. So the obligations are asserted here, derived from the catalog
+// rather than from a list somebody has to remember to update.
+
+func ownerConn(t *testing.T) *pgx.Conn {
+	t.Helper()
+	dsn := os.Getenv("MARGINCE_TEST_DSN")
+	if dsn == "" {
+		t.Fatal("MARGINCE_TEST_DSN not set — run `make db-up` (integration tests fail loudly, they never skip)")
+	}
+	conn, err := pgx.Connect(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("connecting as owner: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := conn.Close(context.Background()); err != nil {
+			t.Errorf("closing owner connection: %v", err)
+		}
+	})
+	if err := EnsureSchema(context.Background(), conn); err != nil {
+		t.Fatalf("migrating: %v", err)
+	}
+	return conn
+}
+
+// nonEmptyTables names every relation that could hold a test's rows and still
+// does. It deliberately does NOT reuse publicTables — deriving the check from the
+// same fragment the reset emits from would only confirm that the reset emptied
+// what it chose to look at — but note what this can and cannot see: it only
+// disagrees with the reset about a table that HOLDS ROWS, and a test can only
+// seed a handful. Scope itself is asserted directly, over the whole catalog, by
+// TestResetScopeCoversEveryDataRelation.
+func nonEmptyTables(ctx context.Context, t *testing.T, owner *pgx.Conn) []string {
+	t.Helper()
+	tables, err := queryIdents(ctx, owner, `
+		SELECT quote_ident(n.nspname) || '.' || quote_ident(c.relname)
+		FROM pg_class c
+		JOIN pg_namespace n ON n.oid = c.relnamespace
+		WHERE n.nspname NOT LIKE 'pg\_%'
+		  AND n.nspname <> 'information_schema'
+		  AND c.relkind IN ('r', 'p', 'f')
+		  AND c.relname NOT LIKE 'schema_migrations_%'
+		ORDER BY n.nspname, c.relname`)
+	if err != nil {
+		t.Fatalf("listing tables: %v", err)
+	}
+	var dirty []string
+	for _, table := range tables {
+		var n int
+		if err := owner.QueryRow(ctx, `SELECT count(*) FROM `+table).Scan(&n); err != nil {
+			t.Fatalf("counting %s: %v", table, err)
+		}
+		if n > 0 {
+			dirty = append(dirty, table)
+		}
+	}
+	return dirty
+}
+
+// Every other test here proves the reset does the right thing to the tables it
+// looks at. This one proves it looks at all of them, which no row-seeding test
+// can: narrowing publicTables — one stray predicate, or the relkind filter
+// missing a class the schema later gains — makes the reset silently stop
+// emptying whole table families, and a test only notices for a table it happens
+// to have seeded. Comparing the reset's own scope against the catalog closes
+// that whole axis in one assertion rather than one seed per table.
+func TestResetScopeCoversEveryDataRelation(t *testing.T) {
+	ctx := context.Background()
+	owner := ownerConn(t)
+
+	inScope, err := queryIdents(ctx, owner,
+		`SELECT quote_ident(n.nspname) || '.' || quote_ident(c.relname) `+publicTables+` ORDER BY c.relname`)
+	if err != nil {
+		t.Fatalf("listing the reset's scope: %v", err)
+	}
+	// Derived independently and deliberately wider: any relation in public that
+	// stores rows, whatever its relkind, minus the ledger the reset preserves on
+	// purpose. Partitioned parents ('p') count — their leaves are emptied, but a
+	// parent outside the reset's scope also hides from reclaimBloat and
+	// restartSequences.
+	expected, err := queryIdents(ctx, owner, `
+		SELECT quote_ident(n.nspname) || '.' || quote_ident(c.relname)
+		FROM pg_class c
+		JOIN pg_namespace n ON n.oid = c.relnamespace
+		WHERE n.nspname = 'public'
+		  AND c.relkind IN ('r', 'p')
+		  AND c.relname NOT LIKE 'schema_migrations_%'
+		ORDER BY c.relname`)
+	if err != nil {
+		t.Fatalf("listing every data relation: %v", err)
+	}
+	if len(expected) == 0 {
+		t.Fatal("found no data relations — this test would pass vacuously")
+	}
+
+	scoped := make(map[string]bool, len(inScope))
+	for _, name := range inScope {
+		scoped[name] = true
+	}
+	var missed []string
+	for _, name := range expected {
+		if !scoped[name] {
+			missed = append(missed, name)
+		}
+	}
+	if len(missed) > 0 {
+		t.Errorf("the reset does not cover %d data relation(s): %v — rows written there survive every reset "+
+			"and leak into the next test, which no row-count assertion here would notice", len(missed), missed)
+	}
+}
+
+func TestResetEmptiesEveryDataTableIncludingTheAppendOnlyOnes(t *testing.T) {
+	ctx := context.Background()
+	owner := ownerConn(t)
+	if err := Reset(ctx, owner); err != nil {
+		t.Fatalf("reset to a known-clean start: %v", err)
+	}
+
+	ws := "00000000-0000-7000-8000-0000000000aa"
+	if _, err := owner.Exec(ctx, `
+		INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'reset', 'reset-probe', 'EUR')`, ws); err != nil {
+		t.Fatalf("seeding workspace: %v", err)
+	}
+	// audit_log carries a BEFORE DELETE trigger that raises unconditionally, so
+	// this row is the one that proves the reset suppresses the append-only guards
+	// and not merely the FK triggers.
+	if _, err := owner.Exec(ctx, `
+		INSERT INTO audit_log (workspace_id, actor_type, actor_id, action, entity_type, entity_id)
+		VALUES ($1, 'human', 'human:probe', 'create', 'workspace', $1)`, ws); err != nil {
+		t.Fatalf("seeding audit_log: %v", err)
+	}
+	// TWO rows, so the sequence lands on a value the restart must visibly move.
+	// One row would leave last_value = 1, which is also where RESTART leaves it,
+	// and the assertion below could then never fail.
+	if _, err := owner.Exec(ctx, `
+		INSERT INTO event_outbox (stream, envelope)
+		VALUES ('probe', '{}'::jsonb), ('probe', '{}'::jsonb)`); err != nil {
+		t.Fatalf("seeding event_outbox: %v", err)
+	}
+
+	if dirty := nonEmptyTables(ctx, t, owner); len(dirty) == 0 {
+		t.Fatal("seeding wrote nothing — this test would pass vacuously")
+	}
+
+	if err := Reset(ctx, owner); err != nil {
+		t.Fatalf("Reset: %v", err)
+	}
+
+	if dirty := nonEmptyTables(ctx, t, owner); len(dirty) > 0 {
+		t.Errorf("Reset left rows in %v — every reset-eligible table must be empty", dirty)
+	}
+
+	// last_value alone is ambiguous — it reads 1 both for "one row consumed" and
+	// for "restarted" — so is_called is what actually distinguishes a rewound
+	// sequence from a used one.
+	var seqLast int64
+	var seqCalled bool
+	if err := owner.QueryRow(ctx,
+		`SELECT last_value, is_called FROM event_outbox_seq_seq`).Scan(&seqLast, &seqCalled); err != nil {
+		t.Fatalf("reading sequence: %v", err)
+	}
+	if seqLast != 1 || seqCalled {
+		t.Errorf("event_outbox_seq_seq is at (last_value=%d, is_called=%t), want (1, false) — "+
+			"Reset must rewind sequences, since emptying rows does not", seqLast, seqCalled)
+	}
+}
+
+func TestResetPreservesTheMigrationLedger(t *testing.T) {
+	ctx := context.Background()
+	owner := ownerConn(t)
+
+	var before int
+	if err := owner.QueryRow(ctx, `SELECT count(*) FROM schema_migrations_core`).Scan(&before); err != nil {
+		t.Fatalf("counting the core ledger: %v", err)
+	}
+	if before == 0 {
+		t.Fatal("the core migration ledger is empty — EnsureSchema did not record anything to preserve")
+	}
+	if err := Reset(ctx, owner); err != nil {
+		t.Fatalf("Reset: %v", err)
+	}
+	var after int
+	if err := owner.QueryRow(ctx, `SELECT count(*) FROM schema_migrations_core`).Scan(&after); err != nil {
+		t.Fatalf("counting the core ledger: %v", err)
+	}
+	if after != before {
+		t.Errorf("Reset changed schema_migrations_core from %d to %d rows — a later process must still see a migrated database", before, after)
+	}
+}
+
+func TestResetDropsLeakedCustomFieldColumns(t *testing.T) {
+	ctx := context.Background()
+	owner := ownerConn(t)
+	if _, err := owner.Exec(ctx, `ALTER TABLE person ADD COLUMN cf_reset_probe text`); err != nil {
+		t.Fatalf("adding a cf_ column: %v", err)
+	}
+	if err := Reset(ctx, owner); err != nil {
+		t.Fatalf("Reset: %v", err)
+	}
+	var leaked int
+	if err := owner.QueryRow(ctx, `
+		SELECT count(*) FROM information_schema.columns
+		WHERE table_schema = 'public' AND column_name LIKE 'cf\_%'`).Scan(&leaked); err != nil {
+		t.Fatalf("counting cf_ columns: %v", err)
+	}
+	if leaked != 0 {
+		t.Errorf("%d cf_ column(s) survived Reset — the next test would read them as taken platform-wide", leaked)
+	}
+}
+
+// DELETE alone would leave a bulk-seeded table's dead tuples in place, and the
+// whole lane pays for that afterwards: the perf suite seeds tens of thousands of
+// rows, and every later test's scans and ALTER TABLEs would drag the corpse
+// along until autovacuum caught up. Reset is supposed to hand the storage back.
+// Without the reclaim path this fails — the rows go, the pages do not.
+func TestResetReclaimsStorageFromABulkSeededTable(t *testing.T) {
+	ctx := context.Background()
+	owner := ownerConn(t)
+	if err := Reset(ctx, owner); err != nil {
+		t.Fatalf("reset to a known-clean start: %v", err)
+	}
+	if _, err := owner.Exec(ctx, `
+		INSERT INTO workspace (id, name, slug, base_currency)
+		SELECT uuidv7(), 'bulk' || g, 'bulk-' || g, 'EUR' FROM generate_series(1, 20000) g`); err != nil {
+		t.Fatalf("bulk-seeding workspace: %v", err)
+	}
+
+	const table = `public.workspace`
+	baseline := *emptySizes.Load()
+	grown, err := tableSizes(ctx, owner)
+	if err != nil {
+		t.Fatalf("measuring table sizes: %v", err)
+	}
+	if grown[table] <= baseline[table]+reclaimSlack {
+		t.Fatalf("workspace only reached %d bytes against a %d-byte baseline (slack %d) — "+
+			"the seed is too small to exercise the reclaim path, so this test would pass vacuously",
+			grown[table], baseline[table], reclaimSlack)
+	}
+
+	var ledger int
+	if err := owner.QueryRow(ctx, `SELECT count(*) FROM schema_migrations_core`).Scan(&ledger); err != nil {
+		t.Fatalf("counting the core ledger: %v", err)
+	}
+
+	if err := Reset(ctx, owner); err != nil {
+		t.Fatalf("Reset: %v", err)
+	}
+
+	after, err := tableSizes(ctx, owner)
+	if err != nil {
+		t.Fatalf("measuring table sizes: %v", err)
+	}
+	if after[table] > baseline[table]+reclaimSlack {
+		t.Errorf("workspace still holds %d bytes after Reset (baseline %d, slack %d) — "+
+			"the storage was not reclaimed, so every later test pays for this bloat",
+			after[table], baseline[table], reclaimSlack)
+	}
+	// The reclaim path TRUNCATEs ... CASCADE, which is the one statement in the
+	// reset that could reach the preserved ledger through a foreign key.
+	var ledgerAfter int
+	if err := owner.QueryRow(ctx, `SELECT count(*) FROM schema_migrations_core`).Scan(&ledgerAfter); err != nil {
+		t.Fatalf("counting the core ledger: %v", err)
+	}
+	if ledgerAfter != ledger {
+		t.Errorf("the reclaim path changed schema_migrations_core from %d to %d rows — "+
+			"TRUNCATE ... CASCADE must not reach the preserved ledger", ledger, ledgerAfter)
+	}
+}
+
+// A reset that pays TRUNCATE's per-table price costs ~500ms per test even when
+// every table is already empty, which is enough to put the heaviest package over
+// the lane's per-package cap. The sharded CI lane cannot see that — each shard
+// runs a fraction of every package, so no shard approaches the cap — so the
+// property is asserted here instead.
+//
+// Rewriting a relation is what makes TRUNCATE expensive and exactly what DELETE
+// does not do, so relfilenode identity separates the two with no timing
+// assertion and no flakiness: on an ALREADY-EMPTY schema a reset must move no
+// storage at all. A blanket TRUNCATE fails this immediately, and so does a
+// reclaim predicate that has drifted into firing on empty tables — one
+// TRUNCATE ... CASCADE drags in ~110 tables behind whichever one it names.
+func TestResetOnAnEmptySchemaRewritesNoStorage(t *testing.T) {
+	ctx := context.Background()
+	owner := ownerConn(t)
+	if err := Reset(ctx, owner); err != nil {
+		t.Fatalf("reset to a known-empty schema: %v", err)
+	}
+
+	before, err := relfilenodes(ctx, owner)
+	if err != nil {
+		t.Fatalf("reading relfilenodes: %v", err)
+	}
+	if len(before) == 0 {
+		t.Fatal("read no relfilenodes — this test would pass vacuously")
+	}
+
+	if err := Reset(ctx, owner); err != nil {
+		t.Fatalf("Reset: %v", err)
+	}
+
+	after, err := relfilenodes(ctx, owner)
+	if err != nil {
+		t.Fatalf("reading relfilenodes: %v", err)
+	}
+	var rewritten, vanished []string
+	for name, node := range before {
+		switch after[name] {
+		case node:
+		case 0:
+			vanished = append(vanished, name)
+		default:
+			rewritten = append(rewritten, name)
+		}
+	}
+	if len(vanished) > 0 {
+		sort.Strings(vanished)
+		t.Errorf("relation(s) %v disappeared across the reset — a reset must not drop tables", vanished)
+	}
+	if len(rewritten) > 0 {
+		sort.Strings(rewritten)
+		shown := rewritten
+		suffix := ""
+		if len(shown) > 3 {
+			shown, suffix = shown[:3], ", …"
+		}
+		t.Errorf("Reset rewrote %d of %d relations on an already-empty schema (%v%s) — "+
+			"the reset must not pay TRUNCATE's per-table cost when there is nothing to reclaim",
+			len(rewritten), len(before), shown, suffix)
+	}
+}
+
+// relfilenodes maps each reset-eligible table to its on-disk relation. TRUNCATE
+// swaps it; DELETE leaves it alone.
+func relfilenodes(ctx context.Context, owner *pgx.Conn) (map[string]uint32, error) {
+	rows, err := owner.Query(ctx,
+		`SELECT quote_ident(n.nspname) || '.' || quote_ident(c.relname), c.relfilenode `+publicTables)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	nodes := make(map[string]uint32)
+	for rows.Next() {
+		var name string
+		var node uint32
+		if err := rows.Scan(&name, &node); err != nil {
+			return nil, err
+		}
+		nodes[name] = node
+	}
+	return nodes, rows.Err()
+}
+
+// Whether the baseline was taken on an empty schema is a property of where
+// EnsureSchema records it, not of its values, so this cannot assert it directly.
+// What it can assert is that a baseline exists at all and that every entry is
+// sane — present, non-zero, and below the slack, which is what keeps the
+// reclaim from firing on a table that merely holds no rows.
+func TestEnsureSchemaRecordsASaneBaseline(t *testing.T) {
+	ownerConn(t) // runs EnsureSchema; the baseline is its side effect
+
+	recorded := emptySizes.Load()
+	if recorded == nil || len(*recorded) == 0 {
+		t.Fatal("EnsureSchema recorded no empty-schema baseline — reclaimBloat would silently fall back to an absolute size threshold")
+	}
+	for name, size := range *recorded {
+		if size <= 0 {
+			t.Errorf("baseline for %s is %d bytes — a migrated table always occupies storage, so the baseline was not taken on the migrated schema", name, size)
+		}
+		// reclaimBloat's fallback for a missing baseline is to measure against
+		// zero, which is only safe while no empty table reaches the slack on its
+		// own. That is true today with room to spare, and it is the kind of margin
+		// a few added indexes erode silently: once an empty table crosses the
+		// slack, the fallback TRUNCATEs it on every reset and the per-test cost
+		// this whole path avoids comes straight back.
+		if size >= reclaimSlack {
+			t.Errorf("%s occupies %d bytes empty, at or past the %d-byte slack — reclaimBloat's "+
+				"missing-baseline fallback would now TRUNCATE it on every reset; raise reclaimSlack",
+				name, size, reclaimSlack)
+		}
+	}
+}

--- a/backend/internal/platform/testdb/reset_test.go
+++ b/backend/internal/platform/testdb/reset_test.go
@@ -375,25 +375,42 @@ func relfilenodes(ctx context.Context, owner *pgx.Conn) (map[string]uint32, erro
 // sane — present, non-zero, and below the slack, which is what keeps the
 // reclaim from firing on a table that merely holds no rows.
 func TestEnsureSchemaRecordsASaneBaseline(t *testing.T) {
-	ownerConn(t) // runs EnsureSchema; the baseline is its side effect
+	ctx := context.Background()
+	owner := ownerConn(t) // runs EnsureSchema; the baseline is its side effect
 
-	recorded := emptySizes.Load()
-	if recorded == nil || len(*recorded) == 0 {
+	if recorded := emptySizes.Load(); recorded == nil || len(*recorded) == 0 {
 		t.Fatal("EnsureSchema recorded no empty-schema baseline — reclaimBloat would silently fall back to an absolute size threshold")
 	}
-	for name, size := range *recorded {
+
+	// The slack half is checked against a freshly measured empty schema rather
+	// than against the stored baseline. Both would read the same numbers today,
+	// but the stored map is process-global and baselineNewTables may replace an
+	// entry mid-run, which would make a failure here point at EnsureSchema for
+	// something it did not do. Measuring live keeps the message true, and covers
+	// tables that appeared after EnsureSchema as well as the ones it recorded.
+	if err := Reset(ctx, owner); err != nil {
+		t.Fatalf("reset to an empty schema: %v", err)
+	}
+	sizes, err := tableSizes(ctx, owner)
+	if err != nil {
+		t.Fatalf("measuring table sizes: %v", err)
+	}
+	if len(sizes) == 0 {
+		t.Fatal("measured no tables — this test would pass vacuously")
+	}
+	for name, size := range sizes {
 		if size <= 0 {
-			t.Errorf("baseline for %s is %d bytes — a migrated table always occupies storage, so the baseline was not taken on the migrated schema", name, size)
+			t.Errorf("%s occupies %d bytes — a migrated table always holds storage, so this measurement is not of the migrated schema", name, size)
 		}
-		// reclaimBloat's fallback for a missing baseline is to measure against
-		// zero, which is only safe while no empty table reaches the slack on its
-		// own. That is true today with room to spare, and it is the kind of margin
-		// a few added indexes erode silently: once an empty table crosses the
-		// slack, the fallback TRUNCATEs it on every reset and the per-test cost
-		// this whole path avoids comes straight back.
+		// reclaimBloat measures a table with no baseline against zero, which is
+		// only safe while no empty table reaches the slack on its own. That holds
+		// today with room to spare, and it is the kind of margin a few added
+		// indexes erode silently: once an empty table crosses the slack, the
+		// fallback TRUNCATEs it on every reset and the per-test cost this whole
+		// path avoids comes straight back.
 		if size >= reclaimSlack {
-			t.Errorf("%s occupies %d bytes empty, at or past the %d-byte slack — reclaimBloat's "+
-				"missing-baseline fallback would now TRUNCATE it on every reset; raise reclaimSlack",
+			t.Errorf("%s occupies %d bytes empty, at or past the %d-byte slack — a table with no "+
+				"baseline would now be TRUNCATEd on every reset; raise reclaimSlack",
 				name, size, reclaimSlack)
 		}
 	}

--- a/docs/reference/platform-toolkit.md
+++ b/docs/reference/platform-toolkit.md
@@ -114,8 +114,8 @@ robots-aware, paced, byte/time-bounded. No extraction, no discovery policy — t
 - **Reach for it when:** fetching a tenant-supplied URL — never hand-roll an `http.Client` for one.
 
 ### `platform/testdb` — test database harness
-Migrate-once schema setup + fast `TRUNCATE` reset for the integration lanes (`EnsureSchema`,
-`Truncate`); the `integrationmigrateonce_test.go` gate enforces its use.
+Migrate-once schema setup + fast data-only reset for the integration lanes (`EnsureSchema`,
+`Reset`); the `integrationmigrateonce_test.go` gate enforces its use.
 - **Reach for it when:** writing a real-Postgres test setup.
 
 ---

--- a/scripts/test-integration-parallel.sh
+++ b/scripts/test-integration-parallel.sh
@@ -10,7 +10,7 @@
 # This runner removes the shared-state constraint instead of the serialization.
 # Each package gets private throwaway state, so concurrent packages share nothing:
 #   Postgres — its own empty clone db (the Go harness migrates it once, then
-#              TRUNCATEs between tests — see internal/platform/testdb).
+#              resets the data between tests — see internal/platform/testdb).
 #   MinIO    — a private bucket (MARGINCE_TEST_BLOBSTORE_BUCKET=<base>-p<idx>),
 #              auto-created by the blobstore store.
 #   Redis    — the one shared instance, but each package gets its own logical


### PR DESCRIPTION
## The problem

The integration lane's per-test reset (`testdb.Truncate`) truncated all 116 public tables with `CASCADE` on every test. TRUNCATE prices **per table, not per row** — an ACCESS EXCLUSIVE lock and a fresh relfilenode each, with `CASCADE` dragging the whole FK graph in behind whichever table is named. Measured on the migrated schema: **~500ms per reset even when every table is already empty**. One `TRUNCATE workspace CASCADE` reaches ~110 tables.

At one reset per test that was most of the heaviest package's runtime:

| | before |
|---|---|
| `compose/integration`, standalone | **395.9s** / 583 tests |
| per-test minimum | 0.40s |
| per-test median | 0.53s |

The lane's per-package cap is 300s, so **`make test-integration` could not pass on `main`** — reproduced across several runs including at the merge base. There is no slow test: 245 of the first 344 came in under 0.6s, i.e. almost entirely fixed reset overhead. Actual assertion work was only ~60s of the 396s.

CI stayed green because it shards that package 12 ways by test, so no shard ever approaches the cap. That divergence is why this could land unnoticed.

## The change

The reset runs in **one transaction**: arm the session, reclaim any table grown past its empty-schema baseline, empty the rest with a single `DELETE` batch, rewind the sequences those tables own, drop leaked `cf_` columns. `Truncate` is renamed `Reset`, since it no longer truncates.

| | before | after |
|---|---|---|
| `compose/integration`, standalone | 395.9s | **123.1s** |
| per-test median | 0.53s | 0.10s |
| under the parallel lane | >300s (timeout) | ~150s |

583 tests, 0 failures. Full lane green (26 packages, 0 skips) across repeated runs.

### Two settings carry the batch, both load-bearing

**`session_replication_role = replica`** suppresses every non-ALWAYS trigger. That covers the FK triggers — which is what lets one unordered DELETE stand in for `CASCADE` — **and** the append-only guards on `audit_log`/`system_log`, whose `BEFORE DELETE` triggers raise unconditionally. TRUNCATE never fired row triggers, so those guards are a dependency DELETE *introduces*: every test writes an audit row, so without replica mode the first reset aborts. Verified:

```
DELETE FROM audit_log;                             -> ERROR: audit_log is append-only
SET LOCAL session_replication_role = replica; ...  -> DELETE 1
```

**`row_security = off`** makes the other new exposure loud. DELETE is subject to RLS where TRUNCATE was not, 104 tables carry `FORCE ROW LEVEL SECURITY` with deny-on-unset policies, and the reset binds no workspace GUC. On a role without BYPASSRLS the DELETEs match zero rows and the reset **reports success on a dirty database** — a weakened isolation gate that looks exactly like a passing one. With `row_security` off, Postgres raises instead of filtering. `SET LOCAL` reverts on both commit and rollback, so nothing leaks into the reused connection.

### Reclaiming on growth, not absolute size

DELETE leaves dead tuples, so tables that grew real storage are still TRUNCATEd. The trigger is **growth against a per-process empty-schema baseline**, not an absolute threshold, because an empty table here is not small — index storage dominates one holding no rows. Any absolute threshold low enough to catch real bloat sits close to the empty footprint, and the first migration past it would truncate that table on every reset forever, silently restoring the cost this path exists to avoid. Tables that appear after the baseline (River migrates its own `river_*` schema mid-run) are baselined at the end of the first reset that sees them, when they are empty by construction.

## Tests

The package had **none**; it now has seven, covering obligations that previously failed silently — and each verified to actually fail when the thing it guards is broken:

- scope asserted against the catalog, independently derived and deliberately wider than the reset's own query, so a narrowed scope cannot hide (a stray `AND relname NOT LIKE 'consent%'` is caught: *"the reset does not cover 3 data relation(s)"*)
- the append-only tables, the preserved migration ledger, sequence rewind (`is_called`, not just `last_value` — those are ambiguous), `cf_` column cleanup, storage reclaim
- a **relfilenode** check: rewriting a relation is what makes TRUNCATE expensive and exactly what DELETE does not do, so on an already-empty schema the reset must move no storage. Deterministic, no timing assertion. Reverting to a blanket TRUNCATE fails it immediately: *"Reset rewrote 111 of 111 relations on an already-empty schema"*.

**CI sharding verified**: all 7 land on 7 different shards, each exactly once (complete + disjoint under the runner's own round-robin), and each passes standalone in its own process and clone DB — which is what a shard actually runs.

## Not addressed

The local/CI divergence itself. Nothing in CI runs the unsharded package, so a package can still grow past the cap with every check green. Worth a separate ticket — a CI job running the bare developer command was prototyped and deliberately left out of this PR to keep it to one concern.

## Gates

`make check-backend` ✅ · `craft static` 0 blockers ✅ · `make test-integration` 26 packages / 0 skips / 0 failures ✅

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces blanket TRUNCATEs with a fast, single-transaction, DELETE-based data reset that keeps the schema intact. Drops `compose/integration` from 395.9s to ~123.1s and renames `testdb.Truncate` to `testdb.Reset`.

- **Refactors**
  - New reset flow: set `session_replication_role=replica` and `row_security=off`, reclaim tables grown past an empty-schema baseline, DELETE remaining tables, restart owned sequences, and drop leaked `cf_*` columns.
  - Baselines and safety: record table sizes during `EnsureSchema`, baseline new tables post-reset, and build concatenated identifiers from `quote_ident` over catalogs; tests now measure the slack invariant live.
  - Tests and harness: add guard tests (scope, append-only tables, migration ledger, sequence rewind, `cf_*` cleanup, storage reclaim, relfilenode no-rewrite); switch integration harness/docs/scripts to `Reset`; clarify perfbench comment.

- **Migration**
  - Replace `testdb.Truncate(ctx, conn)` with `testdb.Reset(ctx, conn)` in integration setups.

<sup>Written for commit 25ea779e94c5ab1a3e3d4be71072e0798c74064e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved integration test database resets with faster data-only cleanup while preserving migration state.
  * Automatically reclaims storage when needed to reduce database bloat and stale statistics.

* **Reliability**
  * Reset operations now clear test data, sequences, and leaked custom fields while preserving required migration records.
  * Added comprehensive validation for reset coverage, isolation, storage reclamation, and empty-schema behavior.

* **Documentation**
  * Updated integration testing guidance to describe the new reset workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->