### PR TITLE
fix(overlay): stop the agent surface answering for a system of record it cannot reach

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -30,6 +30,35 @@ Open work, roughly in priority order.
 
 ### Correctness and security
 
+- **Overlay: 45 of 49 pre-open-source review findings are still open.** The two
+  Critical ones are fixed (the agent surface answering from native tables for an
+  overlay workspace, and ungoverned agent write-back into the incumbent). What
+  remains, in the order worth taking: `docs/explanation/overlay-augmentation.md`
+  carries nine verifiably false claims and is the first thing an OSS reader meets
+  (cheapest, highest exposure); a single unmappable incumbent record freezes its
+  object class forever, because a mapping failure aborts the whole page and the
+  cursor is never saved; `Reconcile` discards the partial watermark it returns on
+  error, so a portal past HubSpot's 10k search window livelocks; backfill is
+  entirely unmetered and nothing paces the 4 req/s bound `meter.go`'s own doc
+  claims it enforces; every closed deal in a custom pipeline reads
+  `status: "open"` because only the default pipeline's stage keys are recognised;
+  ADR-0044's 2×SLO fail-closed visibility floor is unimplemented (`snapshot_at`
+  is written and never read); and Art. 17 erasure never reaches the mirror while
+  the explanation doc says it does. The last two are compliance-shaped.
+
+- **Overlay: agent write-back is a declared refusal, not confirm-first.** A
+  mirrored target has no authority object a human can see and release — the
+  approvals decidability probe and the redemption version pin both read our own
+  tables, which the record has no row in — so staging one would name a release
+  path that dead-ends. `egressbackstop.go` therefore answers
+  `unsupported_by_sor`, which is stricter than AC-OV-5's confirm-first intent.
+  Reconciled against ADR-0075 §3 in PR #304: §3's posture (direct apply,
+  attributed, reversible, findable) governs writes to OUR records, and two of its
+  three legs are weakened by construction across a boundary we do not own. The
+  released-approval check in that file is the seam a real confirm-first
+  implementation plugs into once approvals can describe a non-authoritative
+  target.
+
 - **Recorded idempotency bodies survive Art. 17 erasure.**
   `idempotency_key.response_body` (migration 0033) holds full 2xx `Person`/
   `Lead`/`Activity` bodies for 24h, and `privacy/erasure.go` does not touch that
@@ -375,6 +404,22 @@ this build repo.
   0141), and `interfaces.md` §1 gains an optional `BackfillProgress` seam
   beside `Backfiller`/`Watcher`/`Sender`. Both are additive; neither changes
   what a committed run reports.
+
+- **`/me`'s `system_of_record` description promises a code this build never
+  emits at top level.** It tells clients that unservable reads answer 422
+  `unsupported_in_overlay_mode`, but that spelling only ever appears nested in
+  `details.errors[].code` under a top-level `validation_error`; the overlay read
+  shadows and the report shadows answer top-level `unsupported_by_sor`. Either
+  the description or the split needs to move, and the choice is the contract's.
+
+- **Overlay lifecycle ops are agent-reachable.** `connectOverlay`,
+  `disconnectOverlay` and `executeOverlayFlip` carry `x-agent-access: tool`
+  rather than `human-only`, so an agent acting for an admin can command a
+  system-of-record posture change (connect, or revoke-and-purge). That reads like
+  ADR-0055's human-only governance class, alongside approval decisions and
+  pipeline config. Raised from the overlay review; the annotation source is the
+  contract.
+
 - **ADR-0072 §1 ladder wording** — the ladder reads T1 → "ensure person+org
   NOW", which taken literally would mint a "Gmail" organization for a free-mail
   address the owner has corresponded with, exactly the junk the ADR exists to

--- a/STATUS.md
+++ b/STATUS.md
@@ -46,6 +46,25 @@ Open work, roughly in priority order.
   is written and never read); and Art. 17 erasure never reaches the mirror while
   the explanation doc says it does. The last two are compliance-shaped.
 
+- **The released-approval marker is context-wide, and one transport forwards
+  its pin while the other does not.** `agents.RedeemAndMark` returns a context
+  marked as released, and `egressbackstop.go` acts on that marker — but it
+  authorizes every external write inside that request or `Handle`, not the one
+  `(tool, diff_hash)` the human released, and a workspace flipped to overlay
+  inside the redemption TTL turns a change approved as local into third-party
+  egress. Separately, the REST gate forwards the redeemed version pin as its own
+  `If-Match` (closing the redeem-tx→write-tx window) while the MCP registry
+  discards it, so that window is shut on one transport and open on the other.
+  Both are pre-existing and bounded; binding the marker to the redeemed call
+  rather than to the context would remove the class.
+
+- **The REST merge twin stages a mirrored target without the authority guard.**
+  `POST /v1/{people,organizations}/{id}/merge` reaches `stageRefusal`, which
+  never calls `refuseStagingElsewhere` for either record — the MCP twin does. It
+  fails closed today only as a side effect: resolving the version pin reads the
+  native row, which a mirrored record does not have. That is the pin's doing, not
+  a guard, so a target type with no version column would open it. Worth the pin.
+
 - **Overlay: agent write-back is a declared refusal, not confirm-first.** A
   mirrored target has no authority object a human can see and release — the
   approvals decidability probe and the redemption version pin both read our own

--- a/backend/internal/compose/agentgate.go
+++ b/backend/internal/compose/agentgate.go
@@ -231,7 +231,12 @@ func redeemIfPresented(w http.ResponseWriter, r *http.Request, next http.Handler
 	if pinned {
 		r.Header.Set("If-Match", strconv.FormatInt(pin, 10))
 	}
-	next.ServeHTTP(w, r)
+	// Mark the released call, exactly as the MCP registry does after its own
+	// Redeem. Without this the seam's external-egress backstop would refuse
+	// the approved write it just let a human authorize — the approval would be
+	// granted for a call that can never run. WithContext shares the header map
+	// set just above, so the pin travels with the marked request.
+	next.ServeHTTP(w, r.WithContext(agents.WithApprovalRedeemed(r.Context())))
 	return true
 }
 

--- a/backend/internal/compose/agentgate.go
+++ b/backend/internal/compose/agentgate.go
@@ -214,7 +214,10 @@ func redeemIfPresented(w http.ResponseWriter, r *http.Request, next http.Handler
 			approvalTokenHeader, apperrors.ErrApprovalTokenInvalid))
 		return true
 	}
-	pin, pinned, rErr := staging.Redeem(r.Context(), approvalID, pol.Tool, diffHash)
+	// Redeeming and marking are one step (agents.RedeemAndMark), so this
+	// transport cannot forward an approved call without the released marker the
+	// seam's egress backstop reads — nor obtain that marker without redeeming.
+	released, pin, pinned, rErr := agents.RedeemAndMark(r.Context(), staging, approvalID, pol.Tool, diffHash)
 	if rErr != nil {
 		httperr.Write(w, r, rErr)
 		return true
@@ -231,12 +234,9 @@ func redeemIfPresented(w http.ResponseWriter, r *http.Request, next http.Handler
 	if pinned {
 		r.Header.Set("If-Match", strconv.FormatInt(pin, 10))
 	}
-	// Mark the released call, exactly as the MCP registry does after its own
-	// Redeem. Without this the seam's external-egress backstop would refuse
-	// the approved write it just let a human authorize — the approval would be
-	// granted for a call that can never run. WithContext shares the header map
-	// set just above, so the pin travels with the marked request.
-	next.ServeHTTP(w, r.WithContext(agents.WithApprovalRedeemed(r.Context())))
+	// WithContext shares the header map set just above, so the pin travels with
+	// the released request.
+	next.ServeHTTP(w, r.WithContext(released))
 	return true
 }
 

--- a/backend/internal/compose/dispatcher.go
+++ b/backend/internal/compose/dispatcher.go
@@ -115,13 +115,22 @@ func (d *Dispatcher) isOverlay(ctx context.Context) (bool, error) {
 	return d.overlayModeFor(ctx, wsID)
 }
 
-// isOverlayForWrite answers the same question as isOverlay, but never from
+// isOverlayUncached answers the same question as isOverlay, but never from
 // the cache: it reads workspace.x_sor_mode fresh and refreshes the cached
 // entry with what it found.
 //
-// A cached answer is fine for a read — serving one request's list from the
-// pre-flip system of record for a moment costs a stale screen, and the next
-// request corrects it. A WRITE has no such second chance. The cache is
+// The name says what it does, not who calls it, because two different classes
+// of caller cannot afford a stale answer:
+//
+//   - Every MUTATION boundary. A cached answer is fine for an ordinary read —
+//     serving one request's list from the pre-flip system of record for a
+//     moment costs a stale screen, and the next request corrects it. A WRITE
+//     has no such second chance.
+//   - The native-only capability guards (nativeonlytools.go). For them a stale
+//     'native' is not a stale screen either: it serves a well-formed empty
+//     native result as an ANSWER, which is the defect those guards exist to
+//     remove. The cache is
+//
 // per-process and Invalidate only reaches the process that committed the
 // flip, so a second api replica (or a worker) can still hold 'native' for
 // the rest of the TTL after a workspace connects. A mutation dispatched on
@@ -134,7 +143,7 @@ func (d *Dispatcher) isOverlay(ctx context.Context) (bool, error) {
 // the overlay side the canonical write commits at the incumbent, outside
 // any database of ours). What closes the remainder is the disconnect fence
 // on the overlay side and this check on the native side.
-func (d *Dispatcher) isOverlayForWrite(ctx context.Context) (bool, error) {
+func (d *Dispatcher) isOverlayUncached(ctx context.Context) (bool, error) {
 	wsID, ok := principal.WorkspaceID(ctx)
 	if !ok {
 		return false, nil
@@ -278,13 +287,13 @@ func (d *Dispatcher) StageSemantic(ctx context.Context, stageID ids.UUID) (strin
 }
 
 // Create dispatches to the overlay mirror or the native SoR modules per
-// ctx's workspace.x_sor_mode. The mutating verbs here — and only these —
-// resolve the mode UNCACHED (isOverlayForWrite); see its doc for why a write
-// cannot take the cached answer a read happily takes. Overlay serves update
+// ctx's workspace.x_sor_mode. The mutating verbs here resolve the mode
+// UNCACHED (isOverlayUncached); see its doc for why a write cannot take the
+// cached answer an ordinary read happily takes. Overlay serves update
 // and archive; every other write verb it declares unsupported and refuses at
 // the provider (overlay.SupportsWrite).
 func (d *Dispatcher) Create(ctx context.Context, in datasource.CreateInput) (datasource.EntityRef, error) {
-	ov, err := d.isOverlayForWrite(ctx)
+	ov, err := d.isOverlayUncached(ctx)
 	if err != nil {
 		return datasource.EntityRef{}, err
 	}
@@ -297,7 +306,7 @@ func (d *Dispatcher) Create(ctx context.Context, in datasource.CreateInput) (dat
 // Update dispatches to the overlay mirror or the native SoR modules per
 // ctx's workspace.x_sor_mode; see Create's doc on the uncached mode read.
 func (d *Dispatcher) Update(ctx context.Context, in datasource.UpdateInput) (datasource.EntityRef, error) {
-	ov, err := d.isOverlayForWrite(ctx)
+	ov, err := d.isOverlayUncached(ctx)
 	if err != nil {
 		return datasource.EntityRef{}, err
 	}
@@ -305,14 +314,14 @@ func (d *Dispatcher) Update(ctx context.Context, in datasource.UpdateInput) (dat
 }
 
 // updateInMode is Update for a caller that has ALREADY paid the fresh
-// isOverlayForWrite read for this request — the REST write shadow, which must
+// isOverlayUncached read for this request — the REST write shadow, which must
 // resolve the mode itself to choose between the native module handler and the
 // overlay path before it can dispatch at all.
 //
 // Without it that shadow would read workspace.x_sor_mode twice per mutation:
 // once to route, once inside this dispatch. Both reads are fresh, so the
 // second is not a correctness gain, only a second round trip — and
-// isOverlayForWrite's own contract is that a mutation boundary pays ONE.
+// isOverlayUncached's own contract is that a mutation boundary pays ONE.
 func (d *Dispatcher) updateInMode(ctx context.Context, ov bool, in datasource.UpdateInput) (datasource.EntityRef, error) {
 	if ov {
 		if err := refuseUngovernedAgentEgress(ctx, overlay.WriteUpdate, in.Ref.Type); err != nil {
@@ -327,7 +336,7 @@ func (d *Dispatcher) updateInMode(ctx context.Context, ov bool, in datasource.Up
 // modules per ctx's workspace.x_sor_mode; see Create's doc on the uncached
 // mode read.
 func (d *Dispatcher) AdvanceDeal(ctx context.Context, in datasource.AdvanceDealInput) (datasource.EntityRef, error) {
-	ov, err := d.isOverlayForWrite(ctx)
+	ov, err := d.isOverlayUncached(ctx)
 	if err != nil {
 		return datasource.EntityRef{}, err
 	}
@@ -341,7 +350,7 @@ func (d *Dispatcher) AdvanceDeal(ctx context.Context, in datasource.AdvanceDealI
 // per ctx's workspace.x_sor_mode; see Create's doc on overlay's write
 // gap.
 func (d *Dispatcher) Archive(ctx context.Context, ref datasource.EntityRef) (datasource.EntityRef, error) {
-	ov, err := d.isOverlayForWrite(ctx)
+	ov, err := d.isOverlayUncached(ctx)
 	if err != nil {
 		return datasource.EntityRef{}, err
 	}
@@ -363,7 +372,7 @@ func (d *Dispatcher) archiveInMode(ctx context.Context, ov bool, ref datasource.
 // Merge dispatches to the overlay mirror or the native SoR modules per
 // ctx's workspace.x_sor_mode; see Create's doc on the uncached mode read.
 func (d *Dispatcher) Merge(ctx context.Context, in datasource.MergeInput) (datasource.EntityRef, error) {
-	ov, err := d.isOverlayForWrite(ctx)
+	ov, err := d.isOverlayUncached(ctx)
 	if err != nil {
 		return datasource.EntityRef{}, err
 	}
@@ -377,7 +386,7 @@ func (d *Dispatcher) Merge(ctx context.Context, in datasource.MergeInput) (datas
 // modules per ctx's workspace.x_sor_mode; see Create's doc on the uncached
 // mode read.
 func (d *Dispatcher) PromoteLead(ctx context.Context, id ids.UUID, trigger string, evidenceNote *string) (datasource.EntityRef, bool, error) {
-	ov, err := d.isOverlayForWrite(ctx)
+	ov, err := d.isOverlayUncached(ctx)
 	if err != nil {
 		return datasource.EntityRef{}, false, err
 	}

--- a/backend/internal/compose/dispatcher.go
+++ b/backend/internal/compose/dispatcher.go
@@ -315,6 +315,9 @@ func (d *Dispatcher) Update(ctx context.Context, in datasource.UpdateInput) (dat
 // isOverlayForWrite's own contract is that a mutation boundary pays ONE.
 func (d *Dispatcher) updateInMode(ctx context.Context, ov bool, in datasource.UpdateInput) (datasource.EntityRef, error) {
 	if ov {
+		if err := refuseUngovernedAgentEgress(ctx, overlay.WriteUpdate, in.Ref.Type); err != nil {
+			return datasource.EntityRef{}, err
+		}
 		return d.overlay.Update(ctx, in)
 	}
 	return d.native.Update(ctx, in)
@@ -349,6 +352,9 @@ func (d *Dispatcher) Archive(ctx context.Context, ref datasource.EntityRef) (dat
 // request — see updateInMode.
 func (d *Dispatcher) archiveInMode(ctx context.Context, ov bool, ref datasource.EntityRef) (datasource.EntityRef, error) {
 	if ov {
+		if err := refuseUngovernedAgentEgress(ctx, overlay.WriteArchive, ref.Type); err != nil {
+			return datasource.EntityRef{}, err
+		}
 		return d.overlay.Archive(ctx, ref)
 	}
 	return d.native.Archive(ctx, ref)

--- a/backend/internal/compose/dispatcher_test.go
+++ b/backend/internal/compose/dispatcher_test.go
@@ -68,7 +68,7 @@ func TestDispatcherRoutesEveryReadVerbToTheOverlayProviderWhenCached(t *testing.
 		t.Error("StageSemantic: want ErrUnsupportedBySoR, got nil")
 	}
 	// The WRITE verbs are deliberately absent here: they never consult this
-	// cache (isOverlayForWrite), so seeding it would prove nothing about where
+	// cache (isOverlayUncached), so seeding it would prove nothing about where
 	// they route. TestDispatcherWriteVerbsIgnoreAStaleCachedMode covers them.
 	if _, err := d.Freshness(ctx, ref); err == nil {
 		t.Error("Freshness: want the overlay provider's nil-mirror-store error, got nil")

--- a/backend/internal/compose/dispatcherwritemode_test.go
+++ b/backend/internal/compose/dispatcherwritemode_test.go
@@ -94,7 +94,7 @@ func TestDispatcherWriteVerbsIgnoreAStaleCachedMode(t *testing.T) {
 	}
 }
 
-// TestOverlayWriteShadowResolvesTheModeOnce pins isOverlayForWrite's own
+// TestOverlayWriteShadowResolvesTheModeOnce pins isOverlayUncached's own
 // contract — a mutation boundary pays ONE workspace-row read.
 //
 // The REST write shadow has to resolve the mode itself to choose between the
@@ -109,7 +109,7 @@ func TestOverlayWriteShadowResolvesTheModeOnce(t *testing.T) {
 	ref := datasource.EntityRef{Type: datasource.EntityPerson, ID: ids.NewV7()}
 
 	// What the shadow does: resolve once, then dispatch with that answer.
-	ov, err := d.isOverlayForWrite(ctx)
+	ov, err := d.isOverlayUncached(ctx)
 	if err != nil {
 		t.Fatalf("resolving the write mode: %v", err)
 	}

--- a/backend/internal/compose/egressbackstop.go
+++ b/backend/internal/compose/egressbackstop.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The egress backstop: the one gate under every write that leaves our boundary
+// and lands in a third party's CRM. It lives beside the dispatch it guards
+// (Dispatcher.updateInMode / archiveInMode call it) rather than inside
+// dispatcher.go, so the routing concern and the authorization concern read as
+// the separate things they are.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gradionhq/margince/backend/internal/modules/agents"
+	"github.com/gradionhq/margince/backend/internal/modules/overlay"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+)
+
+// refuseUngovernedAgentEgress is the backstop under EVERY write that lands in
+// an external system of record. Such a write leaves our boundary and appears
+// in a third party's CRM, and mirrored content is T2 — attacker-influenceable
+// by design — so a manipulated agent must not place content there on its own
+// authority (AC-OV-5).
+//
+// It answers the DECLARED unsupported-by-SoR result rather than "needs
+// approval", because in this build there is no approval an agent could
+// actually get for it: staging one requires an authority object a human can
+// both see and release, and for a mirrored target neither holds — the
+// decidability probe reads our own tables, and the redemption version pin
+// re-reads a row that does not exist. Answering "needs human release" would
+// name a path that dead-ends, which is exactly what the unsupported sentinel
+// exists to avoid. Confirm-first agent write-back is therefore blocked on the
+// approvals layer being able to describe a non-authoritative target at all —
+// both its decidability probe and its redemption pin read our own tables. The
+// released-approval check below is the seam such a change would plug into,
+// which is why it stays even though nothing can set the marker on this path
+// today: a future released approval must not be refused by the gate it was
+// granted for.
+//
+// It gates only verbs the overlay adapter actually serves, so an agent asking
+// for a permanently unsupported one still gets that answer from the provider
+// (with its own object-RBAC and row-scope checks) rather than this one, and
+// so "every write" stays true by construction as SupportsWrite changes.
+//
+// It sits on updateInMode/archiveInMode rather than Update/Archive so the
+// REST write shadow, which dispatches through those directly, cannot slip
+// underneath it. A human in their own seat is not gated here: that is object
+// RBAC's question, per ADR-0055's split between seat authority and agent
+// autonomy.
+//
+// Running ahead of the provider's own auth.Require means an agent with no
+// grant learns the workspace runs on an incumbent before it learns it lacks
+// permission. That discloses nothing: /me reports system_of_record.mode to
+// every authenticated principal by contract, so the mode is not a secret this
+// ordering could leak — and the answer is identical for a record that exists
+// and one that does not, so it is no existence oracle either.
+func refuseUngovernedAgentEgress(ctx context.Context, verb overlay.WriteVerb, et datasource.EntityType) error {
+	if !overlay.SupportsWrite(verb, et) {
+		return nil
+	}
+	if !isAgentPrincipal(ctx) {
+		return nil
+	}
+	if agents.ApprovalRedeemed(ctx) {
+		return nil
+	}
+	return fmt.Errorf(
+		"an agent cannot write %s into this workspace's external system of record: %w",
+		et, apperrors.ErrUnsupportedBySoR)
+}
+
+// isAgentPrincipal reports whether ctx acts under a passport rather than a
+// human seat or a system role. AgentIdentity.Principal is the only production
+// constructor of that type, so every agent surface — REST bearer, stdio and
+// hosted MCP, the Surface-B runner — answers true here.
+func isAgentPrincipal(ctx context.Context) bool {
+	actor, ok := principal.Actor(ctx)
+	return ok && actor.Type == principal.PrincipalAgent
+}

--- a/backend/internal/compose/egressbackstop_test.go
+++ b/backend/internal/compose/egressbackstop_test.go
@@ -107,9 +107,7 @@ func TestRESTGateDoesNotMarkAnUnredeemedCall(t *testing.T) {
 // branches that close it. The marker is set only by a dispatch layer straight
 // after its own Redeem, so it stands for "a human released exactly this call".
 func TestEgressBackstopAllowsAReleasedAgentWrite(t *testing.T) {
-	// Obtained the only way it can be: by actually redeeming. That the marker
-	// cannot be minted any other way is the point — a doc comment asking callers
-	// not to forge it was not enforcement.
+	// Obtained by redeeming, the only way it can be.
 	ctx, _, _, err := agents.RedeemAndMark(egressAgentCtx(), stubApprovals{},
 		ids.New[ids.ApprovalKind](), "update_record", "hash")
 	if err != nil {

--- a/backend/internal/compose/egressbackstop_test.go
+++ b/backend/internal/compose/egressbackstop_test.go
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// Specs for the egress backstop under every write into an external system of
+// record. It lives at the seam because the tool is not the only route: the
+// REST twin of update_record and qualify_lead both reach the incumbent
+// through the same dispatch, so a per-tool gate could never be the control.
+// A human in their own seat is object RBAC's question, not this gate's
+// (ADR-0055's split).
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/modules/agents"
+	"github.com/gradionhq/margince/backend/internal/modules/overlay"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+)
+
+// egressAgentCtx is a passport-shaped principal: the type every agent
+// surface authenticates as, and the only one this gate governs.
+func egressAgentCtx() context.Context {
+	return principal.WithActor(context.Background(), principal.Principal{
+		Type: principal.PrincipalAgent, ID: "agent:t", OnBehalfOf: ids.NewV7(),
+		PassportID: ids.NewV7(),
+		Scopes:     principal.NewScopeSet(principal.ScopeWrite),
+	})
+}
+
+// The refusal is the DECLARED unsupported-by-SoR answer, not "needs
+// approval": there is no approval an agent could get for this in this build,
+// and naming a path that dead-ends is what the sentinel exists to avoid.
+func TestEgressBackstopRefusesAnUnreleasedAgentWrite(t *testing.T) {
+	err := refuseUngovernedAgentEgress(egressAgentCtx(), overlay.WriteUpdate, datasource.EntityPerson)
+
+	if !errors.Is(err, apperrors.ErrUnsupportedBySoR) {
+		t.Fatalf("err = %v, want ErrUnsupportedBySoR", err)
+	}
+}
+
+// A verb the overlay adapter never serves is the provider's answer to give,
+// with its own object-RBAC and row-scope checks — not this gate's. Otherwise
+// an agent is told to seek approval for something permanently unsupported.
+func TestEgressBackstopLeavesUnsupportedVerbsToTheProvider(t *testing.T) {
+	if err := refuseUngovernedAgentEgress(egressAgentCtx(), overlay.WriteCreate, datasource.EntityPerson); err != nil {
+		t.Errorf("Create err = %v, want nil (the provider declares it unsupported)", err)
+	}
+	if err := refuseUngovernedAgentEgress(egressAgentCtx(), overlay.WriteArchive, datasource.EntityLead); err != nil {
+		t.Errorf("Archive of a non-archivable type err = %v, want nil", err)
+	}
+}
+
+// The REST agent gate is the second dispatch layer, and it must mark what it
+// redeems: the seam backstop reads that marker, so a gate that redeems an
+// approval without setting it would refuse the very write the human just
+// authorized — the approval would be granted for a call that can never run.
+// The MCP registry's own marking is covered by its redemption tests; this
+// pins the REST half, which had no such coverage.
+func TestRESTRedemptionMarksTheCallReleasedForTheSeam(t *testing.T) {
+	var seen bool
+	next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		seen = agents.ApprovalRedeemed(r.Context())
+	})
+
+	approvalID := ids.New[ids.ApprovalKind]()
+	req := httptest.NewRequest(http.MethodPatch, "/v1/people/"+ids.NewV7().String(), http.NoBody)
+	req.Header.Set(approvalTokenHeader, approvalID.String())
+
+	handled := redeemIfPresented(httptest.NewRecorder(), req, next, stubApprovals{},
+		agentPolicy{Op: "updatePerson", Access: "tool", Tool: "update_record", RecordType: "person"}, []byte(`{}`))
+
+	if !handled {
+		t.Fatal("a presented approval token was not consumed by the REST gate")
+	}
+	if !seen {
+		t.Error("the redeemed call reached the handler unmarked — the seam backstop would refuse an approved write")
+	}
+}
+
+// The mirror image: a request with no token must NOT look released, or the
+// backstop would wave every unapproved agent write through.
+func TestRESTGateDoesNotMarkAnUnredeemedCall(t *testing.T) {
+	var seen bool
+	next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		seen = agents.ApprovalRedeemed(r.Context())
+	})
+	req := httptest.NewRequest(http.MethodPatch, "/v1/people/"+ids.NewV7().String(), http.NoBody)
+
+	if redeemIfPresented(httptest.NewRecorder(), req, next, stubApprovals{}, agentPolicy{Tool: "update_record"}, []byte(`{}`)) {
+		t.Fatal("a request with no approval token was treated as a redemption")
+	}
+	if seen {
+		t.Error("an unredeemed call was marked released")
+	}
+}
+
+// The one branch that OPENS the gate. Its failure mode is an ungoverned write
+// landing in a third party's CRM, so it is pinned rather than left to the
+// branches that close it. The marker is set only by a dispatch layer straight
+// after its own Redeem, so it stands for "a human released exactly this call".
+func TestEgressBackstopAllowsAReleasedAgentWrite(t *testing.T) {
+	ctx := agents.WithApprovalRedeemed(egressAgentCtx())
+
+	if err := refuseUngovernedAgentEgress(ctx, overlay.WriteUpdate, datasource.EntityPerson); err != nil {
+		t.Fatalf("err = %v, want nil for a released call", err)
+	}
+}
+
+// A person acting in their own seat is governed by object RBAC; gating them
+// here would break the human write path the SPA and REST both offer.
+func TestEgressBackstopDoesNotGateAHumanSeat(t *testing.T) {
+	if err := refuseUngovernedAgentEgress(humanCtx(), overlay.WriteUpdate, datasource.EntityPerson); err != nil {
+		t.Fatalf("err = %v, want nil for a human seat", err)
+	}
+}
+
+// A system principal is not an agent acting on a prompt: background sweeps
+// carry it, and so does automation's action executor, whose overlay write-back
+// compose/workflows.go documents as intended. The allowance is deliberate —
+// standing automation is authored by a human and governed at author time.
+func TestEgressBackstopDoesNotGateASystemOrUnboundContext(t *testing.T) {
+	system := principal.WithActor(context.Background(), principal.Principal{
+		Type: principal.PrincipalSystem, ID: "system:reconcile",
+	})
+	if err := refuseUngovernedAgentEgress(system, overlay.WriteUpdate, datasource.EntityPerson); err != nil {
+		t.Errorf("system principal err = %v, want nil", err)
+	}
+	if err := refuseUngovernedAgentEgress(context.Background(), overlay.WriteUpdate, datasource.EntityPerson); err != nil {
+		t.Errorf("unbound context err = %v, want nil", err)
+	}
+}
+
+// Rule 2 — derive the obligation, don't maintain it as a list. The entity axis
+// is already by construction (the gate calls the same SupportsWrite the
+// provider does), but the VERB axis is not: if SupportsWrite ever answers true
+// for a verb whose Dispatcher method has no backstop, an agent write reaches
+// the incumbent ungoverned. This fails the day that happens rather than
+// leaving it to a reviewer to notice.
+func TestEveryOverlayServedWriteVerbIsBackstopped(t *testing.T) {
+	// The verbs the gate is wired under, by the Dispatcher method that calls it.
+	backstopped := map[overlay.WriteVerb]bool{
+		overlay.WriteUpdate:  true,
+		overlay.WriteArchive: true,
+	}
+	// Both axes derived: the verbs from the overlay module, the mirrored types
+	// from the same map the REST write guard keys on. A newly mirrored type or a
+	// fourth verb is then covered by this claim without anyone remembering to
+	// extend a list here.
+	for _, verb := range overlay.AllWriteVerbs() {
+		for recordType := range overlayMirroredTypes {
+			et := datasource.EntityType(recordType)
+			if !overlay.SupportsWrite(verb, et) || backstopped[verb] {
+				continue
+			}
+			t.Errorf("overlay serves %v on %s but Dispatcher has no egress backstop for that verb — "+
+				"an agent write would reach the incumbent ungoverned", verb, et)
+		}
+	}
+}

--- a/backend/internal/compose/egressbackstop_test.go
+++ b/backend/internal/compose/egressbackstop_test.go
@@ -107,7 +107,14 @@ func TestRESTGateDoesNotMarkAnUnredeemedCall(t *testing.T) {
 // branches that close it. The marker is set only by a dispatch layer straight
 // after its own Redeem, so it stands for "a human released exactly this call".
 func TestEgressBackstopAllowsAReleasedAgentWrite(t *testing.T) {
-	ctx := agents.WithApprovalRedeemed(egressAgentCtx())
+	// Obtained the only way it can be: by actually redeeming. That the marker
+	// cannot be minted any other way is the point — a doc comment asking callers
+	// not to forge it was not enforcement.
+	ctx, _, _, err := agents.RedeemAndMark(egressAgentCtx(), stubApprovals{},
+		ids.New[ids.ApprovalKind](), "update_record", "hash")
+	if err != nil {
+		t.Fatalf("redeeming: %v", err)
+	}
 
 	if err := refuseUngovernedAgentEgress(ctx, overlay.WriteUpdate, datasource.EntityPerson); err != nil {
 		t.Fatalf("err = %v, want nil for a released call", err)

--- a/backend/internal/compose/integration/overlay_e2e_test.go
+++ b/backend/internal/compose/integration/overlay_e2e_test.go
@@ -308,6 +308,7 @@ func TestOverlayReadAndSyncEndToEnd(t *testing.T) {
 			t.Errorf("overlay-mode %s = %d, want 422 — a provenance filter the mirror cannot answer must be refused, never ignored", path, code)
 		}
 	}
+	assertReportOpsRefusedInOverlay(t, e)
 
 	// --- bullet 3: an UNMAPPED user sees ZERO rows (fail-closed
 	// visibility — MirrorStore.List answers apperrors.ErrNotFound for a
@@ -361,6 +362,30 @@ func TestOverlayReadAndSyncEndToEnd(t *testing.T) {
 			if key != "incumbent" && key != "region" && key != "status" {
 				t.Errorf("connection audit snapshot carries an unexpected field %q — PII/credential leak: %v", key, snapshot)
 			}
+		}
+	}
+}
+
+// assertReportOpsRefusedInOverlay pins both report operations to the declared
+// sentinel over HTTP. It asserts the CODE, not just the status: /derivation
+// answers 422 for a malformed query too, so a status-only check stays green
+// with the guard removed and would prove nothing. Only an HTTP call can catch
+// a shadow being unwired — the unit specs cover the guard itself — and the SPA
+// hiding these screens is exactly why the callers left (an agent, a direct API
+// client) have nothing else protecting them.
+func assertReportOpsRefusedInOverlay(t *testing.T, e *env) {
+	t.Helper()
+	for _, op := range []struct{ method, path string }{
+		{"POST", "/v1/reports/deals-by-stage"},
+		{"GET", "/v1/reports/deals-by-stage/derivation?by=stage"},
+	} {
+		var problem struct {
+			Code string `json:"code"`
+		}
+		code := e.call(t, op.method, op.path, nil, nil, &problem)
+		if code != http.StatusUnprocessableEntity || problem.Code != "unsupported_by_sor" {
+			t.Fatalf("overlay-mode %s %s = %d %q, want 422 unsupported_by_sor",
+				op.method, op.path, code, problem.Code)
 		}
 	}
 }

--- a/backend/internal/compose/integration/overlay_toolsurface_integration_test.go
+++ b/backend/internal/compose/integration/overlay_toolsurface_integration_test.go
@@ -1,0 +1,330 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// Bounded equivalence on the AGENT surface (AC-OV-2 / ADR-0018): every tool
+// the production registry advertises must, for an overlay-mode workspace,
+// either behave as it does natively or answer the DECLARED
+// unsupported-by-SoR sentinel. What it must never do is query the native
+// tables — which hold none of that workspace's records — and present the
+// resulting empty answer as a successful result. "No deals are slipping" and
+// "this report returned zero rows" are the exact failure this criterion
+// exists to forbid, because neither is distinguishable from a true answer.
+//
+// The unit specs for the guards themselves live in
+// compose/nativeonlytools_test.go. This suite asserts the guards are
+// actually WIRED, by driving compose.NewRegistry — the same constructor
+// cmd/mcp and the api role use — against a real overlay-mode workspace. A
+// future edit that unwires a guard keeps those unit specs green and turns
+// this one red.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/modules/overlay"
+	"github.com/gradionhq/margince/backend/internal/platform/overlaybudget"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+)
+
+// nativeOnlyAgentTools are the tools whose only implementation reads the
+// native domain tables: the compiled report engine, the two retrieval-
+// grounded context intents, and the pipeline-risk scan. None has a mirror
+// projection to serve, so each owes an honest refusal in overlay mode. The
+// args only have to be well-formed — the refusal must land before any record
+// lookup, so a not-found in place of the sentinel means the guard runs late.
+func nativeOnlyAgentTools(anchor ids.UUID) map[string]string {
+	return map[string]string{
+		"run_report":               `{"report":"deals-by-stage"}`,
+		"catch_me_up_on":           fmt.Sprintf(`{"record_type":"person","record_id":%q}`, anchor),
+		"prep_for_meeting":         fmt.Sprintf(`{"record_type":"person","record_id":%q}`, anchor),
+		"whats_slipping_this_week": `{}`,
+		"draft_follow_ups_for":     `{"segment":"slipping"}`,
+	}
+}
+
+func TestOverlayAgentToolsRefuseRatherThanAnswerFromNativeTables(t *testing.T) {
+	e := Setup(t)
+	ws, user := seedOverlayModeWorkspace(t)
+	registry := compose.NewRegistry(e.Pool, compose.SendPath{})
+	ctx := overlayActorCtx(ws, user)
+
+	for name, args := range nativeOnlyAgentTools(ids.NewV7()) {
+		t.Run(name, func(t *testing.T) {
+			if _, ok := registry.Spec(name); !ok {
+				t.Fatalf("%s is not registered — this pin no longer covers it", name)
+			}
+			out, err := registry.Invoke(ctx, name, json.RawMessage(args))
+			if err == nil {
+				t.Fatalf("%s answered %s for an overlay workspace — a native-table result presented as an answer", name, out)
+			}
+			if !errors.Is(err, apperrors.ErrUnsupportedBySoR) {
+				t.Fatalf("%s err = %v, want ErrUnsupportedBySoR (a declared refusal, not an incidental failure)", name, err)
+			}
+		})
+	}
+}
+
+// A write into the incumbent is outbound egress (AC-OV-5), so an agent must
+// not be able to place content in the customer's CRM on its own authority.
+// Per-field human-edit precedence cannot govern it — a mirrored record has
+// no human audit history, so nothing ever reads as human-owned and every
+// patch would pass through. The assertion that matters most is the negative
+// one: the mirror row is untouched, so nothing was pushed.
+func TestOverlayUpdateRecordRefusesAnAgentRatherThanWritingBack(t *testing.T) {
+	e := Setup(t)
+	overlayWS, actorID := seedOverlayModeWorkspace(t)
+	ctx := overlayActorCtx(overlayWS, actorID)
+
+	mirror := overlay.NewMirrorStore(e.Pool, stubOwnerEmails{})
+	if err := mirror.UpsertUserMap(ctx, ids.From[ids.UserKind](actorID), "hubspot", "owner-1", "manual"); err != nil {
+		t.Fatalf("mapping the acting user to owner-1: %v", err)
+	}
+	if err := mirror.Ingest(ctx, overlay.Record{
+		ObjectClass:     "person",
+		ExternalID:      "100214862042",
+		Fields:          map[string]any{"firstname": "Ada", "lastname": "Overlay", "jobtitle": "Analyst"},
+		ModifiedAt:      time.Now().UTC(),
+		OwnerExternalID: "owner-1",
+	}); err != nil {
+		t.Fatalf("ingesting the overlay fixture record: %v", err)
+	}
+
+	// The tool addresses the record by the id its own reads hand out, so
+	// resolve it the way an agent would rather than minting one.
+	d := compose.NewDispatcher(compose.NewProvider(e.Pool), compose.NewOverlayProvider(e.Pool, overlaybudget.New(nil, nil), nil), e.Pool)
+	found, err := d.Search(ctx, datasource.SearchQuery{
+		EntityTypes: []datasource.EntityType{datasource.EntityPerson},
+		Limit:       10,
+	})
+	if err != nil || len(found.Records) != 1 {
+		t.Fatalf("resolving the mirrored person: err=%v records=%d", err, len(found.Records))
+	}
+	target := found.Records[0].Ref.ID
+
+	registry := compose.NewRegistry(e.Pool, compose.SendPath{})
+	args := fmt.Sprintf(`{"record_type":"person","id":%q,"fields":{"job_title":"Principal Analyst"}}`, target)
+
+	_, err = registry.Invoke(agentActorCtx(overlayWS, actorID), "update_record", json.RawMessage(args))
+
+	if !errors.Is(err, apperrors.ErrUnsupportedBySoR) {
+		t.Fatalf("update_record err = %v, want ErrUnsupportedBySoR — an ungoverned agent write reached the incumbent", err)
+	}
+	// No approval row is minted: staging one would name a release path that
+	// dead-ends, since the decidability probe and the redemption version pin
+	// both read tables a mirrored record has no row in.
+	var staged int
+	if err := OwnerConn(t).QueryRow(ctx,
+		`SELECT count(*) FROM approval WHERE workspace_id = $1`, overlayWS).Scan(&staged); err != nil {
+		t.Fatalf("counting staged approvals: %v", err)
+	}
+	if staged != 0 {
+		t.Errorf("staged approvals = %d, want 0 — an unreleasable authority object was created", staged)
+	}
+
+	// And the mirror still holds the incumbent's own value: nothing was
+	// pushed outward.
+	unchanged, err := d.Read(ctx, found.Records[0].Ref)
+	if err != nil {
+		t.Fatalf("re-reading the mirrored person: %v", err)
+	}
+	if !bytes.Contains(unchanged.Fields, []byte("Analyst")) || bytes.Contains(unchanged.Fields, []byte("Principal Analyst")) {
+		t.Errorf("mirror fields = %s — the unapproved patch was applied", unchanged.Fields)
+	}
+}
+
+// The seam backstop, proven where it actually sits. update_record is not the
+// only way an agent reaches a write: the REST twin (PATCH /v1/people/{id}
+// under an agent passport) runs the same per-field split, which finds nothing
+// human-owned on a mirrored record, and qualify_lead writes through the
+// provider with no gate of its own. Both — and any write tool added later —
+// funnel through Dispatcher's update/archive dispatch, so that is where the
+// refusal has to live. Testing it here covers every one of those routes at
+// once rather than one route and a hope.
+func TestOverlayWritesRefuseAnUnreleasedAgentAtTheSeam(t *testing.T) {
+	e := Setup(t)
+	ws, actorID := seedOverlayModeWorkspace(t)
+	ctx := overlayActorCtx(ws, actorID)
+
+	mirror := overlay.NewMirrorStore(e.Pool, stubOwnerEmails{})
+	if err := mirror.UpsertUserMap(ctx, ids.From[ids.UserKind](actorID), "hubspot", "owner-1", "manual"); err != nil {
+		t.Fatalf("mapping the acting user to owner-1: %v", err)
+	}
+	if err := mirror.Ingest(ctx, overlay.Record{
+		ObjectClass: "person", ExternalID: "100214862044",
+		Fields:     map[string]any{"firstname": "Seam", "lastname": "Backstop"},
+		ModifiedAt: time.Now().UTC(), OwnerExternalID: "owner-1",
+	}); err != nil {
+		t.Fatalf("ingesting the overlay fixture record: %v", err)
+	}
+
+	d := compose.NewDispatcher(compose.NewProvider(e.Pool), compose.NewOverlayProvider(e.Pool, overlaybudget.New(nil, nil), nil), e.Pool)
+	found, err := d.Search(ctx, datasource.SearchQuery{
+		EntityTypes: []datasource.EntityType{datasource.EntityPerson}, Limit: 10,
+	})
+	if err != nil || len(found.Records) != 1 {
+		t.Fatalf("resolving the mirrored person: err=%v records=%d", err, len(found.Records))
+	}
+	ref := found.Records[0].Ref
+	patch := datasource.UpdateInput{Ref: ref, Patch: json.RawMessage(`{"job_title":"Principal"}`), Source: "tool"}
+
+	// An agent with no released approval is refused before the incumbent is
+	// touched, whatever route brought it here.
+	if _, err := d.Update(agentActorCtx(ws, actorID), patch); !errors.Is(err, apperrors.ErrUnsupportedBySoR) {
+		t.Errorf("agent Update err = %v, want ErrUnsupportedBySoR", err)
+	}
+	if _, err := d.Archive(agentActorCtx(ws, actorID), ref); !errors.Is(err, apperrors.ErrUnsupportedBySoR) {
+		t.Errorf("agent Archive err = %v, want ErrUnsupportedBySoR", err)
+	}
+
+	// A human in their own seat is object RBAC's question, not this gate's:
+	// the write proceeds past the backstop (and then fails for its own
+	// reasons in this fixture, which has no incumbent write resolver).
+	if _, err := d.Update(ctx, patch); errors.Is(err, apperrors.ErrUnsupportedBySoR) {
+		t.Errorf("human Update was gated by the agent egress backstop: %v", err)
+	}
+}
+
+// agentActorCtx is overlayActorCtx as a PASSPORT principal — the type every
+// agent surface authenticates as, and the only one the egress backstop gates.
+func agentActorCtx(ws, user ids.UUID) context.Context {
+	perms := overlayReaderPerms
+	perms.Objects = map[string]principal.ObjectGrant{
+		"person": {Read: true, Update: true, Delete: true},
+	}
+	ctx := principal.WithWorkspaceID(context.Background(), ws)
+	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
+	return principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalAgent, ID: "agent:" + user.String(),
+		OnBehalfOf: user, UserID: user, PassportID: ids.NewV7(),
+		Scopes:      principal.NewScopeSet(principal.ScopeWrite),
+		Permissions: perms,
+	})
+}
+
+// The egress gate is a mutation boundary, so it must resolve the mode
+// UNCACHED. A workspace that connects an overlay invalidates only the
+// process that committed the flip, so another api replica — or the same one
+// inside the cache TTL — can still hold 'native'. If the gate trusted that,
+// it would auto-execute while Dispatcher.Update (which does read fresh)
+// routed the very same patch to the incumbent: the write reaches a third
+// party's CRM with the confirm-first gate believing it never left our
+// boundary. This drives that exact skew: warm the cache as native, flip
+// x_sor_mode underneath with no invalidation, and assert the gate still
+// holds.
+func TestOverlayUpdateRecordEgressGateIgnoresAStaleNativeModeCache(t *testing.T) {
+	e := Setup(t)
+	ws, actorID := seedNativeModeWorkspaceForFlip(t)
+	ctx := overlayActorCtx(ws, actorID)
+	registry := compose.NewRegistry(e.Pool, compose.SendPath{})
+
+	// Warm this process's mode cache while the workspace is still native, by
+	// making the same read an ordinary request would.
+	if _, err := registry.Invoke(ctx, "search_records",
+		json.RawMessage(`{"q":"anything","record_type":"person"}`)); err != nil {
+		t.Fatalf("warming the mode cache with a native-mode read: %v", err)
+	}
+
+	// Flip to overlay the way a connect does, but WITHOUT Invalidate — the
+	// state a second replica is in for the rest of the TTL.
+	if _, err := OwnerConn(t).Exec(ctx,
+		`UPDATE workspace SET x_sor_mode = 'overlay', x_incumbent = 'hubspot' WHERE id = $1`, ws); err != nil {
+		t.Fatalf("flipping the workspace to overlay mode: %v", err)
+	}
+
+	mirror := overlay.NewMirrorStore(e.Pool, stubOwnerEmails{})
+	if err := mirror.UpsertUserMap(ctx, ids.From[ids.UserKind](actorID), "hubspot", "owner-1", "manual"); err != nil {
+		t.Fatalf("mapping the acting user to owner-1: %v", err)
+	}
+	if err := mirror.Ingest(ctx, overlay.Record{
+		ObjectClass:     "person",
+		ExternalID:      "100214862043",
+		Fields:          map[string]any{"firstname": "Grace", "lastname": "Stale", "jobtitle": "Analyst"},
+		ModifiedAt:      time.Now().UTC(),
+		OwnerExternalID: "owner-1",
+	}); err != nil {
+		t.Fatalf("ingesting the overlay fixture record: %v", err)
+	}
+
+	d := compose.NewDispatcher(compose.NewProvider(e.Pool), compose.NewOverlayProvider(e.Pool, overlaybudget.New(nil, nil), nil), e.Pool)
+	found, err := d.Search(ctx, datasource.SearchQuery{
+		EntityTypes: []datasource.EntityType{datasource.EntityPerson},
+		Limit:       10,
+	})
+	if err != nil || len(found.Records) != 1 {
+		t.Fatalf("resolving the mirrored person: err=%v records=%d", err, len(found.Records))
+	}
+
+	args := fmt.Sprintf(`{"record_type":"person","id":%q,"fields":{"job_title":"Principal Analyst"}}`, found.Records[0].Ref.ID)
+	_, err = registry.Invoke(agentActorCtx(ws, actorID), "update_record", json.RawMessage(args))
+
+	if !errors.Is(err, apperrors.ErrUnsupportedBySoR) {
+		t.Fatalf("update_record err = %v, want ErrUnsupportedBySoR — the egress gate trusted a stale native mode cache", err)
+	}
+}
+
+// seedNativeModeWorkspaceForFlip mints a workspace that starts NATIVE (so a
+// read can warm the mode cache with that answer) plus one human user. Its
+// overlay sibling, seedOverlayModeWorkspace, cannot serve here: the
+// x_overlay_iff_incumbent CHECK makes it overlay from creation, leaving no
+// native window to cache.
+func seedNativeModeWorkspaceForFlip(t *testing.T) (ws, user ids.UUID) {
+	t.Helper()
+	owner := OwnerConn(t)
+	ws = ids.NewV7()
+	if _, err := owner.Exec(context.Background(),
+		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Pre-flip', $2, 'EUR')`,
+		ws, "preflip-"+ws.String()); err != nil {
+		t.Fatalf("seeding the native-mode workspace: %v", err)
+	}
+	user = ids.NewV7()
+	if _, err := owner.Exec(context.Background(),
+		`INSERT INTO app_user (id, workspace_id, email, display_name) VALUES ($1, $2, $3, 'Pre-flip User')`,
+		user, ws, "preflip-"+user.String()+"@overlay.test"); err != nil {
+		t.Fatalf("seeding the native-mode workspace's user: %v", err)
+	}
+	return ws, user
+}
+
+// The guard is a mode gate, not a kill switch: the same registry must still
+// serve a native workspace. Such a call may fail on its own terms (bad
+// arguments, a missing anchor record) but never with the unsupported-by-SoR
+// sentinel, which means "this system of record cannot do this at all".
+func TestNativeAgentToolsAreNotRefusedByTheSoRModeGuard(t *testing.T) {
+	e := Setup(t)
+	registry := compose.NewRegistry(e.Pool, compose.SendPath{})
+	ctx := e.As(e.Rep1, nil, overlayReaderPerms)
+
+	// The two anchored intents may honestly answer not-found (their anchor id
+	// is minted, not seeded); the two that take no record must SUCCEED, so a
+	// native report path that broke outright cannot hide behind "well, it
+	// didn't say unsupported_by_sor".
+	anchored := map[string]bool{"catch_me_up_on": true, "prep_for_meeting": true}
+
+	for name, args := range nativeOnlyAgentTools(ids.NewV7()) {
+		t.Run(name, func(t *testing.T) {
+			_, err := registry.Invoke(ctx, name, json.RawMessage(args))
+			if errors.Is(err, apperrors.ErrUnsupportedBySoR) {
+				t.Fatalf("%s refused a NATIVE workspace with unsupported_by_sor — the mode guard is inverted", name)
+			}
+			switch {
+			case anchored[name] && err != nil && !errors.Is(err, apperrors.ErrNotFound):
+				t.Fatalf("%s err = %v, want nil or ErrNotFound", name, err)
+			case !anchored[name] && err != nil:
+				t.Fatalf("%s err = %v, want nil — a native workspace must actually be served", name, err)
+			}
+		})
+	}
+}

--- a/backend/internal/compose/nativeonlytools.go
+++ b/backend/internal/compose/nativeonlytools.go
@@ -41,11 +41,16 @@ import (
 
 // sorModeProbe reports whether the acting workspace's system of record is the
 // incumbent rather than our own tables. The guards below take the UNCACHED
-// spelling (Dispatcher.isOverlayForWrite): a stale 'native' answer here does not
+// spelling (Dispatcher.isOverlayUncached): a stale 'native' answer here does not
 // cost a retry, it serves a well-formed empty native result as an answer, which
 // is the defect they exist to remove. A mode read that fails propagates, so an
 // unresolved mode refuses the call rather than defaulting to native.
 type sorModeProbe func(ctx context.Context) (bool, error)
+
+// nativeOnlyModeProbe is the probe every native-only guard takes. Named so the
+// choice of the UNCACHED read is a thing a test can hold, not a comment: for
+// these guards a stale 'native' answer is a wrong ANSWER, not a stale screen.
+func nativeOnlyModeProbe(d *Dispatcher) sorModeProbe { return d.isOverlayUncached }
 
 // nativeOnlyReportRunner guards run_report. The spec names this capability
 // as one an incumbent has no analogue for, so the refusal is the declared
@@ -91,7 +96,7 @@ func refuseReportInOverlayMode(w http.ResponseWriter, r *http.Request, mode sorM
 // RunReport shadows the embedded reportHandlers so the mode guard runs
 // before the native engine ever sees the request.
 func (s Server) RunReport(w http.ResponseWriter, r *http.Request, report string) {
-	if refuseReportInOverlayMode(w, r, s.sorDispatch.isOverlayForWrite) {
+	if refuseReportInOverlayMode(w, r, nativeOnlyModeProbe(s.sorDispatch)) {
 		return
 	}
 	s.reportHandlers.RunReport(w, r, report)
@@ -103,7 +108,7 @@ func (s Server) RunReport(w http.ResponseWriter, r *http.Request, report string)
 // answer one route over — and the whole argument above is that a hidden
 // screen is not a server-side gate.
 func (s Server) ExplainReport(w http.ResponseWriter, r *http.Request, report string, params crmcontracts.ExplainReportParams) {
-	if refuseReportInOverlayMode(w, r, s.sorDispatch.isOverlayForWrite) {
+	if refuseReportInOverlayMode(w, r, nativeOnlyModeProbe(s.sorDispatch)) {
 		return
 	}
 	s.reportHandlers.ExplainReport(w, r, report, params)

--- a/backend/internal/compose/nativeonlytools.go
+++ b/backend/internal/compose/nativeonlytools.go
@@ -40,10 +40,11 @@ import (
 )
 
 // sorModeProbe reports whether the acting workspace's system of record is the
-// incumbent rather than our own tables. The guards below are reads, so they
-// take Dispatcher.isOverlay (cached); a mode read that fails propagates, so an
-// unresolved mode refuses the call instead of defaulting to native and
-// answering wrongly.
+// incumbent rather than our own tables. The guards below take the UNCACHED
+// spelling (Dispatcher.isOverlayForWrite): a stale 'native' answer here does not
+// cost a retry, it serves a well-formed empty native result as an answer, which
+// is the defect they exist to remove. A mode read that fails propagates, so an
+// unresolved mode refuses the call rather than defaulting to native.
 type sorModeProbe func(ctx context.Context) (bool, error)
 
 // nativeOnlyReportRunner guards run_report. The spec names this capability
@@ -90,7 +91,7 @@ func refuseReportInOverlayMode(w http.ResponseWriter, r *http.Request, mode sorM
 // RunReport shadows the embedded reportHandlers so the mode guard runs
 // before the native engine ever sees the request.
 func (s Server) RunReport(w http.ResponseWriter, r *http.Request, report string) {
-	if refuseReportInOverlayMode(w, r, s.sorDispatch.isOverlay) {
+	if refuseReportInOverlayMode(w, r, s.sorDispatch.isOverlayForWrite) {
 		return
 	}
 	s.reportHandlers.RunReport(w, r, report)
@@ -102,7 +103,7 @@ func (s Server) RunReport(w http.ResponseWriter, r *http.Request, report string)
 // answer one route over — and the whole argument above is that a hidden
 // screen is not a server-side gate.
 func (s Server) ExplainReport(w http.ResponseWriter, r *http.Request, report string, params crmcontracts.ExplainReportParams) {
-	if refuseReportInOverlayMode(w, r, s.sorDispatch.isOverlay) {
+	if refuseReportInOverlayMode(w, r, s.sorDispatch.isOverlayForWrite) {
 		return
 	}
 	s.reportHandlers.ExplainReport(w, r, report, params)

--- a/backend/internal/compose/nativeonlytools.go
+++ b/backend/internal/compose/nativeonlytools.go
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// Native-only tool dependencies, guarded by the workspace's system-of-record
+// mode.
+//
+// Most of the agent surface rides the datasource seam, so the Dispatcher
+// already routes it per workspace. Three dependencies cannot: the compiled
+// report engine, the retrieval seam behind the context intents, and the
+// pipeline-risk lister all query the native domain tables directly.
+//
+// Reports have a seam verb, but not this one: RunReport carries an ad-hoc
+// ReportPlan, while the tool names a prebuilt report key and answers with
+// plan and derivation metadata that has no seam shape. The context intents
+// and the pipeline scan have no verb at all, and the mirror holds no
+// context-graph or pipeline projection for them to read.
+//
+// Handed an overlay workspace, those engines would run against native tables
+// holding none of its records and return a well-formed empty answer — a
+// silent break, which ADR-0018's bounded-capability guarantee forbids
+// outright: a tool either behaves identically across modes or returns a
+// DECLARED unsupported-by-SoR result (AC-OV-2). "No deals are slipping" is a
+// worse failure than "this is not available here", because only one of them
+// is visibly wrong. So the composition layer wraps each dependency here,
+// where cross-module edges belong, and the tools stay mode-unaware.
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/modules/agents"
+	"github.com/gradionhq/margince/backend/internal/platform/httperr"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/retrieval"
+)
+
+// sorModeProbe reports whether the acting workspace's system of record is the
+// incumbent rather than our own tables. The guards below are reads, so they
+// take Dispatcher.isOverlay (cached); a mode read that fails propagates, so an
+// unresolved mode refuses the call instead of defaulting to native and
+// answering wrongly.
+type sorModeProbe func(ctx context.Context) (bool, error)
+
+// nativeOnlyReportRunner guards run_report. The spec names this capability
+// as one an incumbent has no analogue for, so the refusal is the declared
+// answer, not a degradation.
+func nativeOnlyReportRunner(mode sorModeProbe, run agents.ReportRunner) agents.ReportRunner {
+	return func(ctx context.Context, report string, planArgs json.RawMessage) (json.RawMessage, error) {
+		overlay, err := mode(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if overlay {
+			return nil, apperrors.ErrUnsupportedBySoR
+		}
+		return run(ctx, report, planArgs)
+	}
+}
+
+// refuseReportInOverlayMode is the REST half, shared by both report
+// operations. It reports whether it answered the request, so a caller runs
+// the native engine only when the workspace actually has one.
+//
+// The answer is the ErrUnsupportedBySoR sentinel, not a validation error:
+// run_report is an L1 MCP tool, and the contract binds every one of them to
+// pass identically or return a declared `unsupported_by_sor` (422). A
+// validation error would tell the caller their input was wrong when the
+// request was fine and the capability simply is not there — and it would
+// answer a different machine code than the same verb's tool half. The
+// `unsupported_in_overlay_mode` spelling next door is for refused query
+// DIALS, which genuinely are input.
+func refuseReportInOverlayMode(w http.ResponseWriter, r *http.Request, mode sorModeProbe) bool {
+	overlay, err := mode(r.Context())
+	if err != nil {
+		httperr.Write(w, r, err)
+		return true
+	}
+	if !overlay {
+		return false
+	}
+	httperr.Write(w, r, apperrors.ErrUnsupportedBySoR)
+	return true
+}
+
+// RunReport shadows the embedded reportHandlers so the mode guard runs
+// before the native engine ever sees the request.
+func (s Server) RunReport(w http.ResponseWriter, r *http.Request, report string) {
+	if refuseReportInOverlayMode(w, r, s.sorDispatch.isOverlay) {
+		return
+	}
+	s.reportHandlers.RunReport(w, r, report)
+}
+
+// ExplainReport shadows the drill-through sibling. It runs the same native
+// engine and returns the SOURCE ROWS behind one aggregate, so leaving it
+// unguarded would hand an overlay workspace the identical well-formed empty
+// answer one route over — and the whole argument above is that a hidden
+// screen is not a server-side gate.
+func (s Server) ExplainReport(w http.ResponseWriter, r *http.Request, report string, params crmcontracts.ExplainReportParams) {
+	if refuseReportInOverlayMode(w, r, s.sorDispatch.isOverlay) {
+		return
+	}
+	s.reportHandlers.ExplainReport(w, r, report, params)
+}
+
+// nativeOnlyRetriever guards catch_me_up_on and prep_for_meeting, whose
+// grounding is the full-text index and context graph — neither of which
+// holds mirrored content.
+type nativeOnlyRetriever struct {
+	mode  sorModeProbe
+	inner retrieval.Retriever
+}
+
+func (r nativeOnlyRetriever) Search(ctx context.Context, q retrieval.Query) ([]retrieval.Hit, error) {
+	overlay, err := r.mode(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if overlay {
+		return nil, apperrors.ErrUnsupportedBySoR
+	}
+	return r.inner.Search(ctx, q)
+}
+
+func (r nativeOnlyRetriever) AssembleContext(ctx context.Context, anchor datasource.EntityRef, opts retrieval.AssembleOptions) (retrieval.Context, error) {
+	overlay, err := r.mode(ctx)
+	if err != nil {
+		return retrieval.Context{}, err
+	}
+	if overlay {
+		return retrieval.Context{}, apperrors.ErrUnsupportedBySoR
+	}
+	return r.inner.AssembleContext(ctx, anchor, opts)
+}
+
+// nativeOnlySlippingLister guards whats_slipping_this_week, whose candidate
+// set is the native deals store. The mirror serves no stage or pipeline
+// dial, so there is no overlay query to fall back to.
+func nativeOnlySlippingLister(mode sorModeProbe, list agents.SlippingLister) agents.SlippingLister {
+	return func(ctx context.Context) ([]agents.SlippingDeal, error) {
+		overlay, err := mode(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if overlay {
+			return nil, apperrors.ErrUnsupportedBySoR
+		}
+		return list(ctx)
+	}
+}

--- a/backend/internal/compose/nativeonlytools_test.go
+++ b/backend/internal/compose/nativeonlytools_test.go
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// Specs for the native-only tool guard: a tool whose only implementation
+// reads the native domain tables holds no answer for an overlay workspace,
+// whose records live in the incumbent and whose mirror carries no report,
+// context-graph, or pipeline-risk projection. Such a tool must answer the
+// declared unsupported-by-SoR sentinel (AC-OV-2 / ADR-0018) — querying the
+// empty native tables and presenting the result would be a silent break,
+// the one failure mode bounded equivalence exists to forbid.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/modules/agents"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/retrieval"
+)
+
+func overlayMode() sorModeProbe { return func(context.Context) (bool, error) { return true, nil } }
+func nativeMode() sorModeProbe  { return func(context.Context) (bool, error) { return false, nil } }
+func unresolvableMode() sorModeProbe {
+	return func(context.Context) (bool, error) { return false, errors.New("mode read failed") }
+}
+
+// --- run_report ---
+
+func TestReportRunnerRefusesInOverlayMode(t *testing.T) {
+	called := false
+	inner := func(context.Context, string, json.RawMessage) (json.RawMessage, error) {
+		called = true
+		return json.RawMessage(`{"rows":[],"total_rows":0}`), nil
+	}
+
+	_, err := nativeOnlyReportRunner(overlayMode(), inner)(context.Background(), "deals-by-stage", nil)
+
+	if !errors.Is(err, apperrors.ErrUnsupportedBySoR) {
+		t.Fatalf("err = %v, want ErrUnsupportedBySoR", err)
+	}
+	if called {
+		t.Error("the native report engine ran for an overlay workspace — an empty native result would be presented as an answer")
+	}
+}
+
+func TestReportRunnerServesNativeMode(t *testing.T) {
+	inner := func(context.Context, string, json.RawMessage) (json.RawMessage, error) {
+		return json.RawMessage(`{"total_rows":7}`), nil
+	}
+
+	out, err := nativeOnlyReportRunner(nativeMode(), inner)(context.Background(), "deals-by-stage", nil)
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if string(out) != `{"total_rows":7}` {
+		t.Errorf("out = %s, want the engine's own result", out)
+	}
+}
+
+func TestReportRunnerRefusesWhenModeCannotBeResolved(t *testing.T) {
+	inner := func(context.Context, string, json.RawMessage) (json.RawMessage, error) {
+		t.Error("the native report engine ran without a resolved system-of-record mode")
+		return nil, nil
+	}
+
+	if _, err := nativeOnlyReportRunner(unresolvableMode(), inner)(context.Background(), "deals-by-stage", nil); err == nil {
+		t.Fatal("err = nil, want the mode-resolution failure")
+	}
+}
+
+// The REST twin of run_report carries the same refusal: an agent or a
+// direct API caller must not receive an empty native report as an answer
+// just because the SPA happens to hide the screen in overlay mode.
+func TestRunReportOverRESTRefusesInOverlayMode(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/reports/deals-by-stage", nil)
+
+	refuseReportInOverlayMode(rec, req, overlayMode())
+
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422", rec.Code)
+	}
+	// The same machine code the tool half answers — a caller must not have to
+	// know which transport it used to recognise a declared capability gap.
+	if !strings.Contains(rec.Body.String(), "unsupported_by_sor") {
+		t.Errorf("body = %s, want the unsupported_by_sor sentinel", rec.Body.String())
+	}
+}
+
+func TestRunReportOverRESTServesNativeMode(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/reports/deals-by-stage", nil)
+
+	if refused := refuseReportInOverlayMode(rec, req, nativeMode()); refused {
+		t.Fatal("a native workspace was refused its own report")
+	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("body = %s — the guard wrote a response for a native workspace", rec.Body.String())
+	}
+}
+
+// --- catch_me_up_on / prep_for_meeting (the retrieval seam) ---
+
+type recordingRetriever struct {
+	searched  bool
+	assembled bool
+}
+
+func (r *recordingRetriever) Search(context.Context, retrieval.Query) ([]retrieval.Hit, error) {
+	r.searched = true
+	return nil, nil
+}
+
+func (r *recordingRetriever) AssembleContext(context.Context, datasource.EntityRef, retrieval.AssembleOptions) (retrieval.Context, error) {
+	r.assembled = true
+	return retrieval.Context{}, nil
+}
+
+func TestRetrieverRefusesBothVerbsInOverlayMode(t *testing.T) {
+	inner := &recordingRetriever{}
+	guarded := nativeOnlyRetriever{mode: overlayMode(), inner: inner}
+	anchor := datasource.EntityRef{Type: datasource.EntityPerson, ID: ids.NewV7()}
+
+	if _, err := guarded.Search(context.Background(), retrieval.Query{Text: "acme"}); !errors.Is(err, apperrors.ErrUnsupportedBySoR) {
+		t.Errorf("Search err = %v, want ErrUnsupportedBySoR", err)
+	}
+	if _, err := guarded.AssembleContext(context.Background(), anchor, retrieval.AssembleOptions{}); !errors.Is(err, apperrors.ErrUnsupportedBySoR) {
+		t.Errorf("AssembleContext err = %v, want ErrUnsupportedBySoR", err)
+	}
+	if inner.searched || inner.assembled {
+		t.Errorf("the native retriever ran for an overlay workspace (searched=%v assembled=%v)", inner.searched, inner.assembled)
+	}
+}
+
+func TestRetrieverServesNativeMode(t *testing.T) {
+	inner := &recordingRetriever{}
+	guarded := nativeOnlyRetriever{mode: nativeMode(), inner: inner}
+
+	if _, err := guarded.Search(context.Background(), retrieval.Query{Text: "acme"}); err != nil {
+		t.Fatalf("Search err = %v, want nil", err)
+	}
+	if !inner.searched {
+		t.Error("native mode did not reach the retriever")
+	}
+}
+
+// --- whats_slipping_this_week ---
+
+func TestSlippingListerRefusesInOverlayMode(t *testing.T) {
+	called := false
+	inner := func(context.Context) ([]agents.SlippingDeal, error) {
+		called = true
+		return nil, nil
+	}
+
+	_, err := nativeOnlySlippingLister(overlayMode(), inner)(context.Background())
+
+	if !errors.Is(err, apperrors.ErrUnsupportedBySoR) {
+		t.Fatalf("err = %v, want ErrUnsupportedBySoR", err)
+	}
+	if called {
+		t.Error("the native deals lister ran for an overlay workspace — an empty pipeline would read as nothing slipping")
+	}
+}
+
+func TestSlippingListerServesNativeMode(t *testing.T) {
+	called := false
+	inner := func(context.Context) ([]agents.SlippingDeal, error) {
+		called = true
+		return nil, nil
+	}
+
+	if _, err := nativeOnlySlippingLister(nativeMode(), inner)(context.Background()); err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if !called {
+		t.Error("native mode did not reach the deals lister")
+	}
+}

--- a/backend/internal/compose/overlaywrite.go
+++ b/backend/internal/compose/overlaywrite.go
@@ -132,7 +132,12 @@ func overlayWriteGuard(mode overlayModeChecker) func(http.Handler) http.Handler 
 				return
 			}
 			verb, isSeamVerb := overlayWriteVerbs[pol.Tool]
-			if isSeamVerb && overlay.SupportsWrite(verb, datasource.EntityType(pol.RecordType)) {
+			servedBySeam := isSeamVerb && overlay.SupportsWrite(verb, datasource.EntityType(pol.RecordType))
+			// A seam-served verb by a HUMAN cannot be refused here, so it needs
+			// no mode read at this layer — the dispatch resolves the mode fresh
+			// anyway, and paying for it twice per mutation buys nothing. Reading
+			// the principal is free; reading the workspace row is not.
+			if servedBySeam && !isAgentPrincipal(r.Context()) {
 				next.ServeHTTP(w, r)
 				return
 			}
@@ -142,6 +147,23 @@ func overlayWriteGuard(mode overlayModeChecker) func(http.Handler) http.Handler 
 				return
 			}
 			if inOverlay {
+				// A verb the seam cannot serve is refused, as before. An AGENT
+				// principal is refused even for a verb it CAN serve, and refused
+				// HERE — outside the agent gate — for two reasons that outlive
+				// the mechanism downstream.
+				//
+				// It answers the DECLARED sentinel. Left to the agent gate, a 🟡
+				// twin would try to stage, and staging a mirrored target fails
+				// while resolving the version pin (no native row), so the agent
+				// would learn "not found" about a record it can read rather than
+				// "this system of record cannot do this". And the refusal lands
+				// before the idempotency layer can record it under a key, so the
+				// approved retry is not answered from a cached refusal.
+				//
+				// The seam gate (egressbackstop.go) is the backstop for every
+				// route including this one; this keeps REST's ANSWER agreeing
+				// with it rather than leaving the transport to say something
+				// else on the way there.
 				httperr.Write(w, r, apperrors.ErrUnsupportedBySoR)
 				return
 			}

--- a/backend/internal/compose/overlaywrite.go
+++ b/backend/internal/compose/overlaywrite.go
@@ -82,12 +82,12 @@ var overlayRecordWriteTools = map[string]bool{
 // interface so the guard is unit-testable without the full dispatch.
 //
 // It is deliberately the UNCACHED resolver (dispatcher.go's
-// isOverlayForWrite), not the read path's cached one: this guard runs only on
+// isOverlayUncached), not the read path's cached one: this guard runs only on
 // mutating requests, and a mutation routed on a stale mode is the silent
-// divergence the guard exists to prevent — see isOverlayForWrite's own doc
+// divergence the guard exists to prevent — see isOverlayUncached's own doc
 // for what that costs and what it still cannot promise.
 type overlayModeChecker interface {
-	isOverlayForWrite(ctx context.Context) (bool, error)
+	isOverlayUncached(ctx context.Context) (bool, error)
 }
 
 // overlayWriteGuard refuses a mutating REST request whose native module
@@ -141,7 +141,7 @@ func overlayWriteGuard(mode overlayModeChecker) func(http.Handler) http.Handler 
 				next.ServeHTTP(w, r)
 				return
 			}
-			inOverlay, err := mode.isOverlayForWrite(r.Context())
+			inOverlay, err := mode.isOverlayUncached(r.Context())
 			if err != nil {
 				httperr.Write(w, r, err)
 				return

--- a/backend/internal/compose/overlaywrite_test.go
+++ b/backend/internal/compose/overlaywrite_test.go
@@ -32,7 +32,7 @@ type fakeMode struct {
 	reads   int
 }
 
-func (f *fakeMode) isOverlayForWrite(context.Context) (bool, error) {
+func (f *fakeMode) isOverlayUncached(context.Context) (bool, error) {
 	f.reads++
 	return f.overlay, f.err
 }

--- a/backend/internal/compose/overlaywrite_test.go
+++ b/backend/internal/compose/overlaywrite_test.go
@@ -5,6 +5,7 @@ package compose
 
 import (
 	"context"
+	"errors"
 	"go/ast"
 	"go/parser"
 	"go/token"
@@ -17,16 +18,24 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	"github.com/gradionhq/margince/backend/internal/modules/overlay"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
 )
 
-// fakeMode is an overlayModeChecker stub returning a fixed answer.
+// fakeMode is an overlayModeChecker stub returning a fixed answer. It counts
+// reads so a test can assert the workspace row was NOT consulted, which is the
+// only way to state that claim rather than infer it from an outcome.
 type fakeMode struct {
 	overlay bool
 	err     error
+	reads   int
 }
 
-func (f fakeMode) isOverlayForWrite(context.Context) (bool, error) { return f.overlay, f.err }
+func (f *fakeMode) isOverlayForWrite(context.Context) (bool, error) {
+	f.reads++
+	return f.overlay, f.err
+}
 
 // guardRequest builds a request carrying the chi route pattern the guard
 // keys on — the same shape the contract router populates before running
@@ -82,7 +91,7 @@ func TestOverlayWriteGuard(t *testing.T) {
 				nextCalled = true
 				w.WriteHeader(http.StatusOK)
 			})
-			h := overlayWriteGuard(fakeMode{overlay: tc.overlay})(next)
+			h := overlayWriteGuard(&fakeMode{overlay: tc.overlay})(next)
 			rec := httptest.NewRecorder()
 			h.ServeHTTP(rec, guardRequest(tc.method, tc.pattern))
 
@@ -105,7 +114,7 @@ func runOverlayWriteGuard(method, pattern string) (nextCalled bool, status int) 
 		nextCalled = true
 		w.WriteHeader(http.StatusOK)
 	})
-	h := overlayWriteGuard(fakeMode{overlay: true})(next)
+	h := overlayWriteGuard(&fakeMode{overlay: true})(next)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, guardRequest(method, pattern))
 	return nextCalled, rec.Code
@@ -255,6 +264,7 @@ var overlayEntityTitles = map[string]string{
 func TestOverlayWriteShadowsCoverEverySupportedWrite(t *testing.T) {
 	declared := serverDeclaredMethods(t)
 	verbPrefixes := map[overlay.WriteVerb]string{
+		overlay.WriteCreate:  "Create",
 		overlay.WriteUpdate:  "Update",
 		overlay.WriteArchive: "Archive",
 	}
@@ -276,3 +286,104 @@ func TestOverlayWriteShadowsCoverEverySupportedWrite(t *testing.T) {
 		}
 	}
 }
+
+// guardRequestAs is guardRequest with a principal bound — the state the
+// identity middleware leaves before the router runs. It is needed because
+// isAgentPrincipal is the ONLY discriminator for a verb the seam can serve: a
+// principal-less request takes the human path, so the agent branch has to be
+// driven explicitly or it is untested. What that branch closes is a live
+// chain — staged from a nil version pin, redeemed with nothing re-checked,
+// archived in the customer's CRM.
+func guardRequestAs(method, pattern string, p principal.Principal) *http.Request {
+	r := guardRequest(method, pattern)
+	return r.WithContext(principal.WithActor(r.Context(), p))
+}
+
+func guardAgent() principal.Principal {
+	return principal.Principal{
+		Type: principal.PrincipalAgent, ID: "agent:t", OnBehalfOf: ids.NewV7(),
+		PassportID: ids.NewV7(), Scopes: principal.NewScopeSet(principal.ScopeWrite),
+	}
+}
+
+func guardHuman() principal.Principal {
+	return principal.Principal{Type: principal.PrincipalHuman, ID: "human:t", UserID: ids.NewV7()}
+}
+
+func TestOverlayWriteGuardRefusesAnAgentEvenForASeamServedVerb(t *testing.T) {
+	// Both are verbs the seam DOES serve, so only the principal decides.
+	for _, tc := range []struct{ method, pattern string }{
+		{"PATCH", "/v1/people/{id}"},
+		{"DELETE", "/v1/people/{id}"},
+	} {
+		t.Run(tc.method, func(t *testing.T) {
+			nexted := false
+			next := http.HandlerFunc(func(http.ResponseWriter, *http.Request) { nexted = true })
+			rec := httptest.NewRecorder()
+
+			overlayWriteGuard(&fakeMode{overlay: true})(next).
+				ServeHTTP(rec, guardRequestAs(tc.method, tc.pattern, guardAgent()))
+
+			if nexted {
+				t.Error("an agent write reached the handler — it would be staged, then released past the seam backstop")
+			}
+			if rec.Code != http.StatusUnprocessableEntity {
+				t.Errorf("status = %d, want 422", rec.Code)
+			}
+		})
+	}
+}
+
+// The other direction of the same clause: a human keeps the write it always
+// had, and takes the fast path without a mode read.
+func TestOverlayWriteGuardPassesAHumanSeamServedWrite(t *testing.T) {
+	for _, tc := range []struct{ method, pattern string }{
+		{"PATCH", "/v1/people/{id}"},
+		{"DELETE", "/v1/people/{id}"},
+	} {
+		t.Run(tc.method, func(t *testing.T) {
+			nexted := false
+			next := http.HandlerFunc(func(http.ResponseWriter, *http.Request) { nexted = true })
+			rec := httptest.NewRecorder()
+
+			mode := &fakeMode{overlay: true}
+			overlayWriteGuard(mode)(next).
+				ServeHTTP(rec, guardRequestAs(tc.method, tc.pattern, guardHuman()))
+
+			if !nexted {
+				t.Errorf("a human seam-served write was blocked (status %d)", rec.Code)
+			}
+			// The fast path exists to spare a second workspace-row read per
+			// mutation; the dispatch resolves the mode fresh either way.
+			if mode.reads != 0 {
+				t.Errorf("the guard read the mode %d time(s) on a human seam-served write, want 0", mode.reads)
+			}
+		})
+	}
+}
+
+// The guard's fail-closed branch: it cannot tell whether this workspace reads
+// from the incumbent, so it must refuse rather than let a write through on a
+// guess. Nothing else asserts this, and it is the one path where guessing
+// wrong sends a mutation to the wrong system of record.
+func TestOverlayWriteGuardRefusesWhenTheModeCannotBeResolved(t *testing.T) {
+	nexted := false
+	next := http.HandlerFunc(func(http.ResponseWriter, *http.Request) { nexted = true })
+	rec := httptest.NewRecorder()
+
+	// A verb the seam does NOT serve, so the guard reaches the mode read.
+	mode := &fakeMode{err: errModeUnresolvable}
+	overlayWriteGuard(mode)(next).ServeHTTP(rec, guardRequest("POST", "/v1/people"))
+
+	if nexted {
+		t.Error("the guard admitted a write without resolving the system-of-record mode")
+	}
+	if rec.Code == http.StatusOK {
+		t.Errorf("status = %d, want a refusal", rec.Code)
+	}
+	if mode.reads != 1 {
+		t.Errorf("mode reads = %d, want 1", mode.reads)
+	}
+}
+
+var errModeUnresolvable = errors.New("the workspace row could not be read")

--- a/backend/internal/compose/overlaywriteshadow.go
+++ b/backend/internal/compose/overlaywriteshadow.go
@@ -32,7 +32,7 @@ import (
 )
 
 // overlayWriteMode answers whether this MUTATING request dispatches to the
-// mirror, resolved uncached (dispatcher.go's isOverlayForWrite) rather than
+// mirror, resolved uncached (dispatcher.go's isOverlayUncached) rather than
 // through the read path's TTL cache. A write shadow that took the cached
 // answer could hand a mutation to the native module handler for the rest of
 // the TTL after another process flipped the workspace into overlay — a
@@ -40,7 +40,7 @@ import (
 // the incumbent. A mode-resolution failure is written to w (ok=false), the
 // same fail-closed posture overlayReadMode takes.
 func (s Server) overlayWriteMode(w http.ResponseWriter, r *http.Request) (overlayMode, ok bool) {
-	ov, err := s.sorDispatch.isOverlayForWrite(r.Context())
+	ov, err := s.sorDispatch.isOverlayUncached(r.Context())
 	if err != nil {
 		httperr.Write(w, r, err)
 		return false, false

--- a/backend/internal/compose/registry.go
+++ b/backend/internal/compose/registry.go
@@ -61,20 +61,15 @@ func registryWithGate(pool *pgxpool.Pool, gate *auth.Gate, drafter activities.Em
 	// like the REST surface's, sharing the same per-workspace windows.
 	provider := NewDispatcher(NewProvider(pool), NewOverlayProvider(pool, failClosedOverlayMeter(), resolveIncumbent), pool)
 	registry := agents.NewRegistry(approvalsAdapter{svc: approvals.NewService(pool)}, gate)
-	// The three native-only dependencies below are READS, so they take the
-	// cached mode answer. Both directions of staleness are bounded and
-	// accepted, the same trade overlayread.go's read shadows make: a stale
-	// 'overlay' costs one retry, and a stale 'native' can serve one empty
-	// native answer — the very defect this file guards — for at most
-	// sorModeCacheTTL on a replica that saw no Invalidate. Naming that
-	// honestly rather than only the benign half: it is a five-second window
-	// after a connect, not a standing hole.
-	//
-	// The write side does not take this trade at all; it is governed at the seam
-	// (egressbackstop.go's refuseUngovernedAgentEgress, called from
-	// dispatcher.go's updateInMode/archiveInMode), which resolves the mode fresh
-	// like every other mutation boundary.
-	sorMode := sorModeProbe(provider.isOverlay)
+	// The native-only guards below take the UNCACHED mode read, like the write
+	// boundaries do. The cached answer is fine when staleness costs a retry, but
+	// here the stale direction that matters is 'native': for up to the cache TTL
+	// on a replica that saw no Invalidate, a just-connected overlay workspace
+	// would get a well-formed empty native report presented as an answer — the
+	// exact defect these guards exist to remove, not a lesser one. Each of these
+	// three paths is a report or a graph walk, so one indexed workspace-row read
+	// is noise against what it guards.
+	sorMode := sorModeProbe(provider.isOverlayForWrite)
 	agents.RegisterCoreTools(registry, provider, provider, provider, fieldOwnership{pool: pool})
 	agents.RegisterReportTool(registry, nativeOnlyReportRunner(sorMode, reportToolRunner(newReportEngine(pool))))
 	// The intent tools ground on the graph walk (no embed lane needed);

--- a/backend/internal/compose/registry.go
+++ b/backend/internal/compose/registry.go
@@ -61,15 +61,9 @@ func registryWithGate(pool *pgxpool.Pool, gate *auth.Gate, drafter activities.Em
 	// like the REST surface's, sharing the same per-workspace windows.
 	provider := NewDispatcher(NewProvider(pool), NewOverlayProvider(pool, failClosedOverlayMeter(), resolveIncumbent), pool)
 	registry := agents.NewRegistry(approvalsAdapter{svc: approvals.NewService(pool)}, gate)
-	// The native-only guards below take the UNCACHED mode read, like the write
-	// boundaries do. The cached answer is fine when staleness costs a retry, but
-	// here the stale direction that matters is 'native': for up to the cache TTL
-	// on a replica that saw no Invalidate, a just-connected overlay workspace
-	// would get a well-formed empty native report presented as an answer — the
-	// exact defect these guards exist to remove, not a lesser one. Each of these
-	// three paths is a report or a graph walk, so one indexed workspace-row read
-	// is noise against what it guards.
-	sorMode := sorModeProbe(provider.isOverlayForWrite)
+	// The guards take the uncached read — see sorModeProbe for why a stale
+	// 'native' here is a wrong answer rather than a stale screen.
+	sorMode := nativeOnlyModeProbe(provider)
 	agents.RegisterCoreTools(registry, provider, provider, provider, fieldOwnership{pool: pool})
 	agents.RegisterReportTool(registry, nativeOnlyReportRunner(sorMode, reportToolRunner(newReportEngine(pool))))
 	// The intent tools ground on the graph walk (no embed lane needed);

--- a/backend/internal/compose/registry.go
+++ b/backend/internal/compose/registry.go
@@ -61,19 +61,43 @@ func registryWithGate(pool *pgxpool.Pool, gate *auth.Gate, drafter activities.Em
 	// like the REST surface's, sharing the same per-workspace windows.
 	provider := NewDispatcher(NewProvider(pool), NewOverlayProvider(pool, failClosedOverlayMeter(), resolveIncumbent), pool)
 	registry := agents.NewRegistry(approvalsAdapter{svc: approvals.NewService(pool)}, gate)
+	// The three native-only dependencies below are READS, so they take the
+	// cached mode answer. Both directions of staleness are bounded and
+	// accepted, the same trade overlayread.go's read shadows make: a stale
+	// 'overlay' costs one retry, and a stale 'native' can serve one empty
+	// native answer — the very defect this file guards — for at most
+	// sorModeCacheTTL on a replica that saw no Invalidate. Naming that
+	// honestly rather than only the benign half: it is a five-second window
+	// after a connect, not a standing hole.
+	//
+	// The write side does not take this trade at all; it is governed at the seam
+	// (egressbackstop.go's refuseUngovernedAgentEgress, called from
+	// dispatcher.go's updateInMode/archiveInMode), which resolves the mode fresh
+	// like every other mutation boundary.
+	sorMode := sorModeProbe(provider.isOverlay)
 	agents.RegisterCoreTools(registry, provider, provider, provider, fieldOwnership{pool: pool})
-	agents.RegisterReportTool(registry, reportToolRunner(newReportEngine(pool)))
+	agents.RegisterReportTool(registry, nativeOnlyReportRunner(sorMode, reportToolRunner(newReportEngine(pool))))
 	// The intent tools ground on the graph walk (no embed lane needed);
 	// the comms tools ride the same store paths as the HTTP transport.
-	agents.RegisterIntentTools(registry, search.NewRetriever(search.NewStore(pool), nil))
+	agents.RegisterIntentTools(registry, nativeOnlyRetriever{
+		mode:  sorMode,
+		inner: search.NewRetriever(search.NewStore(pool), nil),
+	})
 	// The pipeline-risk intents: the candidate set rides the deals
 	// module's row-scoped list, the drafts land through the provider.
-	agents.RegisterSlippingTools(registry, slippingLister(pool), followUpDrafter(provider))
+	agents.RegisterSlippingTools(registry, nativeOnlySlippingLister(sorMode, slippingLister(pool)), followUpDrafter(provider))
 	agents.RegisterCommsTools(registry, newCommsAdapter(pool, drafter, send))
 	// The composed extension set's governed tools ride the same registry
 	// and admission gate as the core tools, registered last so a name that
 	// collides with a core verb fails loudly (RegisterExtensions stashed
 	// them at boot, before this ran).
+	//
+	// They need no native-only guard: extension.ToolHandler is handed a context
+	// and raw JSON and nothing else — no provider, no pool, no store — and the
+	// boot adapter injects none, so an extension tool cannot read a domain table
+	// to answer wrongly for an overlay workspace. If that surface ever grants
+	// record access, it has to arrive mode-routed through the datasource seam,
+	// or gain the guard the three dependencies above take.
 	registerComposedTools(registry)
 	return registry
 }

--- a/backend/internal/compose/reporthandlers.go
+++ b/backend/internal/compose/reporthandlers.go
@@ -13,7 +13,10 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/httperr"
 )
 
-// reportHandlers shadows the generated RunReport stub over the engine.
+// reportHandlers shadows the generated RunReport/ExplainReport stubs over the
+// engine. Both are themselves shadowed again on Server, by the overlay-mode
+// guards in nativeonlytools.go: the engine reads native domain tables, which
+// hold none of an overlay workspace's records, so neither verb may run for one.
 type reportHandlers struct {
 	engine *reportEngine
 }

--- a/backend/internal/compose/server.go
+++ b/backend/internal/compose/server.go
@@ -324,8 +324,9 @@ func newServer(pool *pgxpool.Pool, log *slog.Logger, authH authHandlers, dealsH 
 	// field serves reads through.
 	srv.sorDispatch = NewDispatcher(NewProvider(pool), NewOverlayProvider(pool, srv.overlayMeter, nil), pool)
 	// toolRegistry backs ListAgentTools AND the MCP tool transport; it carries
-	// the vault-backed live-incumbent resolver so overlay write-back
-	// (Create/Update/Archive) actually reaches HubSpot from the agent surface.
+	// the vault-backed live-incumbent resolver that lets force-fresh reads and
+	// HUMAN write-back reach HubSpot (an AGENT write is refused before it gets
+	// there — egressbackstop.go).
 	// The closure captures srv and reads srv.vault LAZILY at request time, so
 	// building it here (before WithKeyvault installs the vault) is fine.
 	srv.rebuildToolRegistry(pool)

--- a/backend/internal/modules/agents/approvals.go
+++ b/backend/internal/modules/agents/approvals.go
@@ -71,17 +71,34 @@ type stageableTool interface {
 // question (the diff_hash binding guarantees the call IS that effect).
 type approvalRedeemedKey struct{}
 
-// WithApprovalRedeemed marks ctx as carrying a released approval.
-//
-// Callable ONLY by a dispatch layer, and ONLY on the statement after its own
-// Redeem returned nil: everything downstream — including the seam's
-// external-egress backstop — treats the marker as proof that a human
-// released exactly this call, so setting it anywhere else forges that proof.
-// It is exported because there are two dispatch layers, the MCP registry and
-// the REST agent gate, and both must mark what they redeem or an approved
-// write is refused by the very gate the approval was granted for.
-func WithApprovalRedeemed(ctx context.Context) context.Context {
+// withApprovalRedeemed marks ctx as carrying a released approval. It stays
+// unexported on purpose: everything downstream — including the seam's
+// external-egress backstop — treats the marker as proof that a human released
+// exactly this call, so an exported setter would let any caller forge that
+// proof, and a doc comment asking them not to is not enforcement. The only way
+// to obtain a marked context is RedeemAndMark, which cannot mark without
+// redeeming first.
+func withApprovalRedeemed(ctx context.Context) context.Context {
 	return context.WithValue(ctx, approvalRedeemedKey{}, true)
+}
+
+// RedeemAndMark consumes an approval and returns a context marked as released,
+// binding the two together so neither can happen without the other. The
+// version pin travels back for a transport that must forward it as its own
+// precondition; pinned is false when the approval carried none.
+//
+// This is the ONLY way to obtain a released context. There are two dispatch
+// layers — the MCP registry and the REST agent gate — and both must mark what
+// they redeem, or the gate refuses the very write the approval was granted for;
+// making the marking a consequence of redeeming is what keeps that true without
+// trusting either caller to remember.
+func RedeemAndMark(ctx context.Context, approvals Approvals, approvalID ids.ApprovalID, tool, diffHash string,
+) (marked context.Context, version int64, pinned bool, err error) {
+	version, pinned, err = approvals.Redeem(ctx, approvalID, tool, diffHash)
+	if err != nil {
+		return ctx, 0, false, err
+	}
+	return withApprovalRedeemed(ctx), version, pinned, nil
 }
 
 // ApprovalRedeemed reports whether this call already consumed a redeemed

--- a/backend/internal/modules/agents/approvals.go
+++ b/backend/internal/modules/agents/approvals.go
@@ -15,9 +15,12 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/diffhash"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
 )
 
 var errInvalidApprovalID = errors.New("approval_id must be a UUID string")
@@ -68,13 +71,52 @@ type stageableTool interface {
 // question (the diff_hash binding guarantees the call IS that effect).
 type approvalRedeemedKey struct{}
 
-func withApprovalRedeemed(ctx context.Context) context.Context {
+// WithApprovalRedeemed marks ctx as carrying a released approval.
+//
+// Callable ONLY by a dispatch layer, and ONLY on the statement after its own
+// Redeem returned nil: everything downstream — including the seam's
+// external-egress backstop — treats the marker as proof that a human
+// released exactly this call, so setting it anywhere else forges that proof.
+// It is exported because there are two dispatch layers, the MCP registry and
+// the REST agent gate, and both must mark what they redeem or an approved
+// write is refused by the very gate the approval was granted for.
+func WithApprovalRedeemed(ctx context.Context) context.Context {
 	return context.WithValue(ctx, approvalRedeemedKey{}, true)
 }
 
-func approvalRedeemed(ctx context.Context) bool {
+// ApprovalRedeemed reports whether this call already consumed a redeemed
+// approval. Exported because the composition layer needs the same answer at
+// the datasource seam, where a write into an external system of record is
+// refused unless a human released this exact call. Read-only by design: the
+// marker is settable only here, immediately after a successful Redeem.
+func ApprovalRedeemed(ctx context.Context) bool {
 	redeemed, ok := ctx.Value(approvalRedeemedKey{}).(bool)
 	return ok && redeemed
+}
+
+// refuseStagingElsewhere refuses to stage a change whose target's authority
+// lives in another system of record.
+//
+// A staged approval is an authority object a human must be able to both SEE
+// and RELEASE, and for such a target neither holds: the decidability probe and
+// the redemption version pin both read our own tables, which the record has no
+// row in. Staging anyway puts a decision in an inbox that can never take
+// effect and cannot be withdrawn — the zombie authority object the REST gate's
+// own decision-grant check refuses to mint. Answering the declared
+// unsupported-by-SoR sentinel instead makes the 🟡 tools agree with the
+// datasource seam, which refuses the same write for the same reason. That
+// agreement is only true while EVERY stageable tool calls this, so the set is
+// derived rather than trusted: stagingfitness_test.go walks the registry and
+// fails on a stageable tool that does not refuse.
+//
+// rec must be the record the change targets, read through the seam.
+func refuseStagingElsewhere(rec datasource.Record) error {
+	if rec.Freshness.Authoritative {
+		return nil
+	}
+	return fmt.Errorf(
+		"this %s is held in an external system of record, so an approval for it could never be released: %w",
+		rec.Ref.Type, apperrors.ErrUnsupportedBySoR)
 }
 
 // splitApproval pops the approval_id argument and canonicalizes what

--- a/backend/internal/modules/agents/approvals.go
+++ b/backend/internal/modules/agents/approvals.go
@@ -71,13 +71,8 @@ type stageableTool interface {
 // question (the diff_hash binding guarantees the call IS that effect).
 type approvalRedeemedKey struct{}
 
-// withApprovalRedeemed marks ctx as carrying a released approval. It stays
-// unexported on purpose: everything downstream — including the seam's
-// external-egress backstop — treats the marker as proof that a human released
-// exactly this call, so an exported setter would let any caller forge that
-// proof, and a doc comment asking them not to is not enforcement. The only way
-// to obtain a marked context is RedeemAndMark, which cannot mark without
-// redeeming first.
+// withApprovalRedeemed marks ctx as carrying a released approval. Set only by
+// RedeemAndMark, which cannot mark without a successful Redeem.
 func withApprovalRedeemed(ctx context.Context) context.Context {
 	return context.WithValue(ctx, approvalRedeemedKey{}, true)
 }
@@ -87,8 +82,9 @@ func withApprovalRedeemed(ctx context.Context) context.Context {
 // version pin travels back for a transport that must forward it as its own
 // precondition; pinned is false when the approval carried none.
 //
-// This is the ONLY way to obtain a released context. There are two dispatch
-// layers — the MCP registry and the REST agent gate — and both must mark what
+// Outside this package this is the ONLY way to obtain a released context: the
+// marker is proof that a human released exactly THIS call, so only the
+// redemption path may set it. There are two dispatch layers — the MCP registry and the REST agent gate — and both must mark what
 // they redeem, or the gate refuses the very write the approval was granted for;
 // making the marking a consequence of redeeming is what keeps that true without
 // trusting either caller to remember.
@@ -105,7 +101,7 @@ func RedeemAndMark(ctx context.Context, approvals Approvals, approvalID ids.Appr
 // approval. Exported because the composition layer needs the same answer at
 // the datasource seam, where a write into an external system of record is
 // refused unless a human released this exact call. Read-only by design: the
-// marker is settable only here, immediately after a successful Redeem.
+// marker is set only by RedeemAndMark.
 func ApprovalRedeemed(ctx context.Context) bool {
 	redeemed, ok := ctx.Value(approvalRedeemedKey{}).(bool)
 	return ok && redeemed

--- a/backend/internal/modules/agents/approvals_marker_test.go
+++ b/backend/internal/modules/agents/approvals_marker_test.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// The released marker is proof a human released THIS call, and the seam's
+// external-egress backstop acts on it. RedeemAndMark exists so the proof cannot
+// be minted without the redemption; this pins the half that matters — a
+// redemption that fails marks nothing, so a caller that ignored the error still
+// carries an unreleased context.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// refusingApprovals redeems nothing: the case a caller must not be able to
+// turn into a released context by ignoring the error.
+type refusingApprovals struct{}
+
+var errRedeemRefused = errors.New("approval already consumed")
+
+func (refusingApprovals) Stage(context.Context, StageRequest) (ids.ApprovalID, error) {
+	return ids.ApprovalID{}, errRedeemRefused
+}
+
+func (refusingApprovals) Redeem(context.Context, ids.ApprovalID, string, string) (int64, bool, error) {
+	return 0, false, errRedeemRefused
+}
+
+func TestRedeemAndMarkLeavesTheContextUnreleasedWhenRedemptionFails(t *testing.T) {
+	ctx, version, pinned, err := RedeemAndMark(context.Background(), refusingApprovals{},
+		ids.New[ids.ApprovalKind](), "update_record", "hash")
+
+	if !errors.Is(err, errRedeemRefused) {
+		t.Fatalf("err = %v, want the redemption failure", err)
+	}
+	if ApprovalRedeemed(ctx) {
+		t.Error("a failed redemption returned a released context — the marker would authorize an unapproved write")
+	}
+	if version != 0 || pinned {
+		t.Errorf("version=%d pinned=%v, want the zero pin on failure", version, pinned)
+	}
+}
+
+func TestRedeemAndMarkReleasesOnlyAfterASuccessfulRedeem(t *testing.T) {
+	ctx, _, _, err := RedeemAndMark(context.Background(), &recordingApprovals{},
+		ids.New[ids.ApprovalKind](), "update_record", "hash")
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if !ApprovalRedeemed(ctx) {
+		t.Error("a successful redemption did not release the context — an approved write would be refused")
+	}
+}

--- a/backend/internal/modules/agents/precedence_test.go
+++ b/backend/internal/modules/agents/precedence_test.go
@@ -116,6 +116,17 @@ func (r *recordingApprovals) Redeem(_ context.Context, id ids.ApprovalID, tool, 
 	return 0, false, nil
 }
 
+// nativeRecord stamps the authority a LOCAL system of record always carries;
+// datasource.NewRecord does it for the real provider, so a native fixture that
+// omits it is unfaithful. It is load-bearing here: refuseStagingElsewhere
+// reads exactly this flag, so an unstamped fixture would be refused rather
+// than staged, and these specs would test the external-target path under the
+// name of the native one.
+func nativeRecord(rec datasource.Record) datasource.Record {
+	rec.Freshness.Authoritative = true
+	return rec
+}
+
 // fixedProvider serves one record and captures updates; only the calls
 // the update tool makes are implemented — anything else is out of the
 // test's contract.
@@ -160,7 +171,11 @@ func agentCtx() context.Context {
 // is human-owned, an approvals recorder, and an auto-execute admission gate.
 func splitRegistry(conflicts []string, approvals *recordingApprovals, provider *fixedProvider) *Registry {
 	r := NewRegistry(approvals, auth.NewGate(fullSeatAuthority{}))
-	r.Register(updateRecord{p: provider, ownership: fixedOwnership{conflicts: conflicts}, staging: r.approvals})
+	r.Register(updateRecord{
+		p:         provider,
+		ownership: fixedOwnership{conflicts: conflicts},
+		staging:   r.approvals,
+	})
 	return r
 }
 
@@ -195,11 +210,11 @@ func assertRedeemedHash(t *testing.T, approvals *recordingApprovals, diffHash st
 
 func TestUpdateRecordMixedPatchSplitsAndBindsTheSubPatch(t *testing.T) {
 	target := ids.NewV7()
-	provider := &fixedProvider{record: datasource.Record{
+	provider := &fixedProvider{record: nativeRecord(datasource.Record{
 		Ref:     datasource.EntityRef{Type: datasource.EntityPerson, ID: target},
 		Fields:  json.RawMessage(`{"full_name":"Greta Human","title":"CTO"}`),
 		Version: 7,
-	}}
+	})}
 	approvals := &recordingApprovals{}
 	r := splitRegistry([]string{"full_name"}, approvals, provider)
 
@@ -272,11 +287,11 @@ func TestUpdateRecordMixedPatchSplitsAndBindsTheSubPatch(t *testing.T) {
 
 func TestUpdateRecordAllHumanOwnedStagesTheWholeCall(t *testing.T) {
 	target := ids.NewV7()
-	provider := &fixedProvider{record: datasource.Record{
+	provider := &fixedProvider{record: nativeRecord(datasource.Record{
 		Ref:     datasource.EntityRef{Type: datasource.EntityPerson, ID: target},
 		Fields:  json.RawMessage(`{"full_name":"Greta Human"}`),
 		Version: 3,
-	}}
+	})}
 	approvals := &recordingApprovals{}
 	r := splitRegistry([]string{"full_name"}, approvals, provider)
 
@@ -306,9 +321,9 @@ func TestUpdateRecordAllHumanOwnedStagesTheWholeCall(t *testing.T) {
 
 func TestAutoExecuteCallWithApprovalIDValidatesInsteadOfIgnoring(t *testing.T) {
 	target := ids.NewV7()
-	provider := &fixedProvider{record: datasource.Record{
+	provider := &fixedProvider{record: nativeRecord(datasource.Record{
 		Ref: datasource.EntityRef{Type: datasource.EntityPerson, ID: target},
-	}}
+	})}
 	approvals := &recordingApprovals{redeemErr: fmt.Errorf("already redeemed: %w", apperrors.ErrApprovalTokenInvalid)}
 	r := splitRegistry(nil, approvals, provider)
 

--- a/backend/internal/modules/agents/registry.go
+++ b/backend/internal/modules/agents/registry.go
@@ -111,7 +111,7 @@ func (r *Registry) Invoke(ctx context.Context, name string, in json.RawMessage) 
 			if _, _, err := r.approvals.Redeem(ctx, approvalID, spec.Name, diffHash); err != nil {
 				return nil, err
 			}
-			ctx = withApprovalRedeemed(ctx)
+			ctx = WithApprovalRedeemed(ctx)
 		}
 		return t.Handle(ctx, args)
 	case !errors.Is(err, apperrors.ErrRequiresApproval) || r.approvals == nil:
@@ -120,7 +120,11 @@ func (r *Registry) Invoke(ctx context.Context, name string, in json.RawMessage) 
 		if _, _, err := r.approvals.Redeem(ctx, approvalID, spec.Name, diffHash); err != nil {
 			return nil, err
 		}
-		return t.Handle(ctx, args)
+		// Mark it, exactly as the auto-execute branch above does: everything
+		// downstream — including the seam's external-egress backstop — reads
+		// this marker to know a human released the call. Redeeming without it
+		// refuses the write the approval was granted for.
+		return t.Handle(WithApprovalRedeemed(ctx), args)
 	default:
 		stageable, ok := t.(stageableTool)
 		if !ok {

--- a/backend/internal/modules/agents/registry.go
+++ b/backend/internal/modules/agents/registry.go
@@ -108,9 +108,9 @@ func (r *Registry) Invoke(ctx context.Context, name string, in json.RawMessage) 
 			if r.approvals == nil {
 				return nil, fmt.Errorf("crmagents: approval_id presented but this surface has no approvals engine: %w", apperrors.ErrApprovalTokenInvalid)
 			}
-			marked, _, _, err := RedeemAndMark(ctx, r.approvals, approvalID, spec.Name, diffHash)
-			if err != nil {
-				return nil, err
+			marked, _, _, rErr := RedeemAndMark(ctx, r.approvals, approvalID, spec.Name, diffHash)
+			if rErr != nil {
+				return nil, rErr
 			}
 			ctx = marked
 		}

--- a/backend/internal/modules/agents/registry.go
+++ b/backend/internal/modules/agents/registry.go
@@ -108,23 +108,21 @@ func (r *Registry) Invoke(ctx context.Context, name string, in json.RawMessage) 
 			if r.approvals == nil {
 				return nil, fmt.Errorf("crmagents: approval_id presented but this surface has no approvals engine: %w", apperrors.ErrApprovalTokenInvalid)
 			}
-			if _, _, err := r.approvals.Redeem(ctx, approvalID, spec.Name, diffHash); err != nil {
+			marked, _, _, err := RedeemAndMark(ctx, r.approvals, approvalID, spec.Name, diffHash)
+			if err != nil {
 				return nil, err
 			}
-			ctx = WithApprovalRedeemed(ctx)
+			ctx = marked
 		}
 		return t.Handle(ctx, args)
 	case !errors.Is(err, apperrors.ErrRequiresApproval) || r.approvals == nil:
 		return nil, err
 	case !approvalID.IsZero():
-		if _, _, err := r.approvals.Redeem(ctx, approvalID, spec.Name, diffHash); err != nil {
-			return nil, err
+		marked, _, _, rErr := RedeemAndMark(ctx, r.approvals, approvalID, spec.Name, diffHash)
+		if rErr != nil {
+			return nil, rErr
 		}
-		// Mark it, exactly as the auto-execute branch above does: everything
-		// downstream — including the seam's external-egress backstop — reads
-		// this marker to know a human released the call. Redeeming without it
-		// refuses the write the approval was granted for.
-		return t.Handle(WithApprovalRedeemed(ctx), args)
+		return t.Handle(marked, args)
 	default:
 		stageable, ok := t.(stageableTool)
 		if !ok {

--- a/backend/internal/modules/agents/runner/runner.go
+++ b/backend/internal/modules/agents/runner/runner.go
@@ -250,17 +250,14 @@ func observeRefusal(win *window, step modelStep, err error, meta Meta, resp mode
 		directive = "this workspace's system of record cannot serve this tool at all; do not call it again in this run"
 	}
 	win.observeThen(step.Tool, observation, directive)
-	// Bound the COMBINED record while reserving room for the directive. Two
-	// constraints meet here: provider text whose LENGTH is influenceable by
-	// mirrored content must not crowd "this was terminal" out of the trace, and
-	// it must not grow the entry past the cap either. Reserving the directive's
-	// own room satisfies both, where truncating after joining loses the finding
-	// and truncating only the payload overruns the bound.
-	recorded := truncate(observation)
+	// Reserve the directive's room inside the cap: provider text whose LENGTH is
+	// influenceable by mirrored content must neither crowd "this was terminal"
+	// out of the trace nor grow the entry past the bound.
+	suffix := ""
 	if directive != "" {
-		suffix := " — " + directive
-		recorded = truncateTo(observation, traceObservationLimit-len(suffix)) + suffix
+		suffix = " — " + directive
 	}
+	recorded := truncateTo(observation, traceObservationLimit-len(suffix)) + suffix
 	return Step{
 		Tool: step.Tool, Args: step.Args, Observation: recorded,
 		ModelID: meta.ModelID, Tier: meta.Tier, TokensIn: resp.InputTokens, TokensOut: resp.OutputTokens,
@@ -433,26 +430,32 @@ func withApprovalID(args json.RawMessage, id ids.ApprovalID) (json.RawMessage, e
 	return json.Marshal(m)
 }
 
-// truncate bounds trace observations: the trace is a record of what
-// happened, not a second copy of every payload.
+// traceObservationLimit bounds trace observations: the trace is a record of
+// what happened, not a second copy of every payload.
 const traceObservationLimit = 2000
 
 // truncationMarker names the elision, and its own length counts against the
 // cap — a caller reserving room for a suffix has to reserve for this too.
 const truncationMarker = "…[truncated]"
 
+// truncate bounds one trace observation at the default limit.
 func truncate(s string) string { return truncateTo(s, traceObservationLimit) }
 
-// truncateTo bounds s so the RESULT is at most limit bytes, marker included, so
-// a caller that must also fit a suffix inside the same cap can reserve its room
-// rather than overrun it.
+// truncateTo bounds s so the RESULT is at most limit bytes, marker included —
+// which is what lets a caller reserve room for a suffix inside the same cap
+// rather than overrun it. The bound holds for every limit, including one too
+// small to carry the marker: a function that exists to enforce a cap must not
+// exceed it while saying it does.
 func truncateTo(s string, limit int) string {
+	if limit < 0 {
+		limit = 0
+	}
 	if len(s) <= limit {
 		return s
 	}
-	keep := limit - len(truncationMarker)
-	if keep < 0 {
-		keep = 0
+	if limit <= len(truncationMarker) {
+		// No room to say "elided" without breaking the bound; the bound wins.
+		return s[:limit]
 	}
-	return s[:keep] + truncationMarker
+	return s[:limit-len(truncationMarker)] + truncationMarker
 }

--- a/backend/internal/modules/agents/runner/runner.go
+++ b/backend/internal/modules/agents/runner/runner.go
@@ -250,13 +250,16 @@ func observeRefusal(win *window, step modelStep, err error, meta Meta, resp mode
 		directive = "this workspace's system of record cannot serve this tool at all; do not call it again in this run"
 	}
 	win.observeThen(step.Tool, observation, directive)
-	// Truncate the observation BEFORE joining, so a long refusal cannot crowd
-	// the directive out of the trace. err.Error() carries provider text whose
-	// LENGTH is influenceable by mirrored content, and "this was terminal" is
-	// the half a later reader needs most — bound the payload, keep the finding.
+	// Bound the COMBINED record while reserving room for the directive. Two
+	// constraints meet here: provider text whose LENGTH is influenceable by
+	// mirrored content must not crowd "this was terminal" out of the trace, and
+	// it must not grow the entry past the cap either. Reserving the directive's
+	// own room satisfies both, where truncating after joining loses the finding
+	// and truncating only the payload overruns the bound.
 	recorded := truncate(observation)
 	if directive != "" {
-		recorded += " — " + directive
+		suffix := " — " + directive
+		recorded = truncateTo(observation, traceObservationLimit-len(suffix)) + suffix
 	}
 	return Step{
 		Tool: step.Tool, Args: step.Args, Observation: recorded,
@@ -434,9 +437,22 @@ func withApprovalID(args json.RawMessage, id ids.ApprovalID) (json.RawMessage, e
 // happened, not a second copy of every payload.
 const traceObservationLimit = 2000
 
-func truncate(s string) string {
-	if len(s) <= traceObservationLimit {
+// truncationMarker names the elision, and its own length counts against the
+// cap — a caller reserving room for a suffix has to reserve for this too.
+const truncationMarker = "…[truncated]"
+
+func truncate(s string) string { return truncateTo(s, traceObservationLimit) }
+
+// truncateTo bounds s so the RESULT is at most limit bytes, marker included, so
+// a caller that must also fit a suffix inside the same cap can reserve its room
+// rather than overrun it.
+func truncateTo(s string, limit int) string {
+	if len(s) <= limit {
 		return s
 	}
-	return s[:traceObservationLimit] + "…[truncated]"
+	keep := limit - len(truncationMarker)
+	if keep < 0 {
+		keep = 0
+	}
+	return s[:keep] + truncationMarker
 }

--- a/backend/internal/modules/agents/runner/runner.go
+++ b/backend/internal/modules/agents/runner/runner.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/promptfence"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/mcp"
@@ -232,6 +233,38 @@ func (r *Runner) Resume(ctx context.Context, job Job, dec Decision) (Result, err
 	return r.loop(ctx, job, win, carried)
 }
 
+// observeRefusal feeds a refusal back as an observation and returns the
+// trace step for it. A DECLARED capability gap is called out as terminal,
+// because it is not a fault the model can route around by trying again — and
+// this is the loop with a step budget, so a re-plan that re-calls the same
+// tool spends the run on a permanent no.
+func observeRefusal(win *window, step modelStep, err error, meta Meta, resp model.Response) Step {
+	observation := "tool call refused: " + err.Error()
+	// Telling the model not to retry is an ORDER, so it rides the directive
+	// argument: inside the fence it would be text the prompt has already
+	// declared to be data the model must disregard (observeThen's own doc). The
+	// trace keeps both halves joined — a trace is a record of what happened,
+	// not a prompt.
+	directive := ""
+	if errors.Is(err, apperrors.ErrUnsupportedBySoR) {
+		directive = "this workspace's system of record cannot serve this tool at all; do not call it again in this run"
+	}
+	win.observeThen(step.Tool, observation, directive)
+	// Truncate the observation BEFORE joining, so a long refusal cannot crowd
+	// the directive out of the trace. err.Error() carries provider text whose
+	// LENGTH is influenceable by mirrored content, and "this was terminal" is
+	// the half a later reader needs most — bound the payload, keep the finding.
+	recorded := truncate(observation)
+	if directive != "" {
+		recorded += " — " + directive
+	}
+	return Step{
+		Tool: step.Tool, Args: step.Args, Observation: recorded,
+		ModelID: meta.ModelID, Tier: meta.Tier, TokensIn: resp.InputTokens, TokensOut: resp.OutputTokens,
+		Admission: "refused",
+	}
+}
+
 // consecutiveInvalidLimit ends a run whose model cannot produce a valid
 // step: retry-with-error-feedback twice, then degrade honestly
 // (ai-operational-spec §5.2 — never a partial fabrication).
@@ -293,13 +326,7 @@ func (r *Runner) loop(ctx context.Context, job Job, win *window, acc Result) (Re
 			// back as observations — the model learns it cannot do that
 			// and re-plans; agent ≤ human holds without the loop knowing
 			// the policy.
-			observation := "tool call refused: " + err.Error()
-			win.observe(step.Tool, observation)
-			acc.Steps = append(acc.Steps, Step{
-				Tool: step.Tool, Args: step.Args, Observation: truncate(observation),
-				ModelID: meta.ModelID, Tier: meta.Tier, TokensIn: resp.InputTokens, TokensOut: resp.OutputTokens,
-				Admission: "refused",
-			})
+			acc.Steps = append(acc.Steps, observeRefusal(win, step, err, meta, resp))
 		default:
 			win.observe(step.Tool, string(out))
 			acc.Steps = append(acc.Steps, Step{

--- a/backend/internal/modules/agents/runner/runner_test.go
+++ b/backend/internal/modules/agents/runner/runner_test.go
@@ -163,6 +163,67 @@ func TestRefusalFedBackAsObservation(t *testing.T) {
 	}
 }
 
+// A DECLARED capability gap is terminal, and the observation must say so: this
+// is the loop with a step budget, so a model that re-plans into the same tool
+// spends the run on a permanent no. Contrast the refusal above, which the
+// model legitimately may route around.
+func TestUnsupportedBySoRIsObservedAsTerminal(t *testing.T) {
+	surface := &fakeSurface{errs: map[string]error{
+		"run_report": fmt.Errorf("reports: %w", apperrors.ErrUnsupportedBySoR),
+	}}
+	brain := &scriptedBrain{texts: []string{
+		`{"tool":"run_report","args":{}}`,
+		`{"final":{"summary":"answered without the report"}}`,
+	}}
+
+	res, err := New(surface, brain).Run(context.Background(), Job{Goal: "g"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Outcome != OutcomeCompleted {
+		t.Fatalf("a declared refusal must not end the run: %+v", res)
+	}
+	last := brain.requests[len(brain.requests)-1]
+	joined := ""
+	for _, m := range last.Messages {
+		joined += m.Content
+	}
+	if !strings.Contains(joined, "do not call it again") {
+		t.Errorf("the model was not told the refusal is terminal: %q", joined)
+	}
+}
+
+// Presence is not enough: the directive must sit OUTSIDE the span the prompt
+// declares to be never-instructions, or the model has been told to disregard
+// the one sentence that saves the run's budget. This is a unit test rather than
+// an end-to-end one because the marker carries a per-call nonce — reading it
+// from any other window yields a name that matches nothing, which is exactly
+// how an end-to-end placement check passes while the directive sits fenced.
+func TestTerminalDirectiveStaysOutsideTheObservationSpan(t *testing.T) {
+	win := newWindow(Job{Goal: "g"}, nil)
+	marker, ok := promptfence.MarkerIn(win.system)
+	if !ok {
+		t.Fatal("the run's system prompt declares no data boundary")
+	}
+
+	observeRefusal(win, modelStep{Tool: "run_report"},
+		fmt.Errorf("reports: %w", apperrors.ErrUnsupportedBySoR), Meta{}, model.Response{})
+
+	msgs := win.snapshot()
+	last := msgs[len(msgs)-1].Content
+	at := strings.Index(last, "do not call it again")
+	if at < 0 {
+		t.Fatalf("the terminal directive is missing: %q", last)
+	}
+	closed := strings.Index(last, "</"+marker+">")
+	if closed < 0 {
+		t.Fatalf("the observation carries no data span to be outside of: %q", last)
+	}
+	if at < closed {
+		t.Errorf("the terminal directive sits inside the data span, so the model is told to ignore it: %q", last)
+	}
+}
+
 func TestConfirmationRequiredStagingSuspendsRun(t *testing.T) {
 	approvalID := ids.New[ids.ApprovalKind]()
 	surface := &fakeSurface{errs: map[string]error{
@@ -650,5 +711,25 @@ func TestARunSuspendedByThisBuildResumes(t *testing.T) {
 	}
 	if res.Outcome != OutcomeCompleted {
 		t.Fatalf("resume did not complete: %+v", res)
+	}
+}
+
+// The trace must keep the terminal finding even when the refusal text is huge.
+// err.Error() carries provider text whose LENGTH is influenceable by mirrored
+// content, so joining first and truncating after would let a long payload push
+// "this was terminal" out of the persisted record — the half a later reader
+// needs most.
+func TestALongRefusalDoesNotCrowdTheTerminalFindingOutOfTheTrace(t *testing.T) {
+	win := newWindow(Job{Goal: "g"}, nil)
+	huge := strings.Repeat("x", traceObservationLimit*2)
+
+	step := observeRefusal(win, modelStep{Tool: "run_report"},
+		fmt.Errorf("%s: %w", huge, apperrors.ErrUnsupportedBySoR), Meta{}, model.Response{})
+
+	if !strings.Contains(step.Observation, "do not call it again") {
+		t.Errorf("the terminal finding was truncated out of the trace: %q", step.Observation)
+	}
+	if !strings.Contains(step.Observation, "truncated") {
+		t.Error("the oversized payload was not bounded")
 	}
 }

--- a/backend/internal/modules/agents/runner/runner_test.go
+++ b/backend/internal/modules/agents/runner/runner_test.go
@@ -732,4 +732,11 @@ func TestALongRefusalDoesNotCrowdTheTerminalFindingOutOfTheTrace(t *testing.T) {
 	if !strings.Contains(step.Observation, "truncated") {
 		t.Error("the oversized payload was not bounded")
 	}
+	// And the combined entry respects the cap: reserving the directive's room is
+	// what lets both hold at once. Appending after truncating the payload alone
+	// would keep the finding but overrun the bound.
+	if len(step.Observation) > traceObservationLimit {
+		t.Errorf("trace entry is %d bytes, over the %d cap — provider-controlled text grew the record",
+			len(step.Observation), traceObservationLimit)
+	}
 }

--- a/backend/internal/modules/agents/runner/runner_test.go
+++ b/backend/internal/modules/agents/runner/runner_test.go
@@ -740,3 +740,18 @@ func TestALongRefusalDoesNotCrowdTheTerminalFindingOutOfTheTrace(t *testing.T) {
 			len(step.Observation), traceObservationLimit)
 	}
 }
+
+// truncateTo enforces a cap, so it must not exceed the cap it enforces — not
+// even for a limit too small to carry the elision marker, where the marker
+// would otherwise be the overrun.
+func TestTruncateToNeverExceedsItsLimit(t *testing.T) {
+	long := strings.Repeat("x", 500)
+	for _, limit := range []int{-5, 0, 1, len(truncationMarker) - 1, len(truncationMarker), len(truncationMarker) + 1, 100} {
+		if got := len(truncateTo(long, limit)); limit >= 0 && got > limit {
+			t.Errorf("truncateTo(limit=%d) returned %d bytes", limit, got)
+		}
+	}
+	if got := truncateTo("short", 100); got != "short" {
+		t.Errorf("an in-bounds string was altered: %q", got)
+	}
+}

--- a/backend/internal/modules/agents/stagingfitness_test.go
+++ b/backend/internal/modules/agents/stagingfitness_test.go
@@ -82,3 +82,25 @@ func TestEveryStageableToolRefusesATargetHeldElsewhere(t *testing.T) {
 			"may now be unexercised", walked, len(args))
 	}
 }
+
+// A merge touches TWO records, so validating only the pinned survivor leaves
+// the other half unguarded: the merge archives and relinks the source, and an
+// externally-held source under a locally-authoritative survivor is still a
+// change no approval could release.
+func TestMergeRefusesAnExternallyHeldSourceUnderALocalSurvivor(t *testing.T) {
+	survivor, src := ids.NewV7(), ids.NewV7()
+	survivorRef := datasource.EntityRef{Type: datasource.EntityPerson, ID: survivor}
+	sourceRef := datasource.EntityRef{Type: datasource.EntityPerson, ID: src}
+	p := &fakeSoR{records: map[datasource.EntityRef]datasource.Record{
+		survivorRef: nativeRecord(datasource.Record{Ref: survivorRef, Fields: json.RawMessage(`{}`), Version: 4}),
+		// Deliberately unstamped: this record's authority lives elsewhere.
+		sourceRef: {Ref: sourceRef, Fields: json.RawMessage(`{}`)},
+	}}
+
+	_, err := mergeRecords{p: p}.StageInfo(context.Background(),
+		json.RawMessage(fmt.Sprintf(`{"record_type":"person","source_id":%q,"target_id":%q}`, src, survivor)))
+
+	if !errors.Is(err, apperrors.ErrUnsupportedBySoR) {
+		t.Fatalf("StageInfo err = %v, want ErrUnsupportedBySoR — the merge source was not validated", err)
+	}
+}

--- a/backend/internal/modules/agents/stagingfitness_test.go
+++ b/backend/internal/modules/agents/stagingfitness_test.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// Derived coverage for the staging refusal (review-loop rule 2). Pinning the
+// predicate alone cannot hold the invariant: refuseStagingElsewhere has to be
+// CALLED by every tool that stages, and a per-site spec only ever covers the
+// sites someone remembered. So this enumerates the core registry's
+// StageInfo-shaped tools and requires each to refuse a target whose authority
+// lives elsewhere — one with no args entry fails here, and one that forgets the
+// guard fails here too.
+//
+// Two boundaries this walk does NOT cover, stated so neither reads as covered:
+//   - update_record stages through stageConflicts, not StageInfo, so it is
+//     invisible here; TestUpdateRecordRefusesStagingForATargetHeldElsewhere is
+//     its pin, and that test fails if its guard is removed.
+//   - the walk builds only RegisterCoreTools. Every stageable tool lives there
+//     today; one registered by another family would escape, which is what the
+//     count assertion below is for — it changes the moment the core set does.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+)
+
+// elsewhereProvider serves every read as a record whose system of record is
+// external — the shape overlay.Provider returns (Authoritative false).
+type elsewhereProvider struct {
+	datasource.SystemOfRecordProvider
+}
+
+func (elsewhereProvider) Read(_ context.Context, ref datasource.EntityRef) (datasource.Record, error) {
+	return datasource.Record{Ref: ref, Fields: json.RawMessage(`{"full_name":"Mirrored"}`)}, nil
+}
+
+func TestEveryStageableToolRefusesATargetHeldElsewhere(t *testing.T) {
+	person, lead, deal, stage := ids.NewV7(), ids.NewV7(), ids.NewV7(), ids.NewV7()
+	args := map[string]string{
+		"archive_record": fmt.Sprintf(`{"record_type":"person","id":%q}`, person),
+		"promote_lead":   fmt.Sprintf(`{"lead_id":%q,"trigger":"meeting_booked"}`, lead),
+		"merge_records":  fmt.Sprintf(`{"record_type":"person","source_id":%q,"target_id":%q}`, ids.NewV7(), person),
+		"advance_deal":   fmt.Sprintf(`{"deal_id":%q,"to_stage_id":%q}`, deal, stage),
+		"progress_deal":  fmt.Sprintf(`{"deal_id":%q,"to_stage_id":%q,"note":"n"}`, deal, stage),
+	}
+
+	registry := NewRegistry(&recordingApprovals{}, nil)
+	// fixedStages only satisfies the constructor: refuseStagingElsewhere returns
+	// before advance_deal/progress_deal reach StageSemantic, so its answer is
+	// never read on this path.
+	RegisterCoreTools(registry, elsewhereProvider{}, fixedStages{semantic: "won"}, nil, noConflicts{})
+
+	// registry.tools IS the universe — walking Specs() and looking the name back
+	// up adds a miss branch that could silently hide a tool from this pin.
+	walked := 0
+	for name, tool := range registry.tools {
+		stageable, isStageable := tool.(stageableTool)
+		if !isStageable {
+			continue
+		}
+		walked++
+		in, known := args[name]
+		if !known {
+			t.Errorf("%s can stage an approval but this pin carries no arguments for it — "+
+				"add them, so its refusal of an externally-held target is actually exercised", name)
+			continue
+		}
+		if _, err := stageable.StageInfo(context.Background(), json.RawMessage(in)); !errors.Is(err, apperrors.ErrUnsupportedBySoR) {
+			t.Errorf("%s.StageInfo err = %v, want ErrUnsupportedBySoR — it would mint an approval "+
+				"no human can release, because redemption re-reads a row this record does not have", name, err)
+		}
+	}
+	if walked != len(args) {
+		t.Errorf("walked %d stageable core tools, pinned %d — the core set changed, so a staging site "+
+			"may now be unexercised", walked, len(args))
+	}
+}

--- a/backend/internal/modules/agents/stdio.go
+++ b/backend/internal/modules/agents/stdio.go
@@ -223,6 +223,15 @@ func (s *StdioServer) explain(tool string, err error) string {
 	case errors.Is(err, apperrors.ErrApprovalTokenInvalid):
 		return "The approval token was not accepted — it may be consumed, expired, or for a different call. " +
 			"Ask for a fresh approval and retry. (" + err.Error() + ")"
+	case errors.Is(err, apperrors.ErrUnsupportedBySoR):
+		// A DECLARED capability gap (AC-OV-2), not a fault: this workspace's
+		// records live in a system that cannot answer this tool. Saying so —
+		// and saying do-not-retry — is the whole point of declaring it;
+		// falling through to the generic branch would tell the agent to retry
+		// a permanent refusal and burn a scheduled run's whole step budget on
+		// it.
+		return "This workspace's system of record cannot serve this tool, and no retry will change that. " +
+			"Do not retry it; use another tool, or tell the user this capability is unavailable here. (" + err.Error() + ")"
 	default:
 		s.log.Error("mcp: tool call failed", "tool", tool, "err", err)
 		return "The tool failed for an internal reason; nothing may have changed. " +

--- a/backend/internal/modules/agents/stdio_test.go
+++ b/backend/internal/modules/agents/stdio_test.go
@@ -52,6 +52,10 @@ func TestExplainKeepsSentinelGuidance(t *testing.T) {
 		{fmt.Errorf("row: %w", apperrors.ErrNotFound), "No such record"},
 		{fmt.Errorf("cas: %w", apperrors.ErrVersionSkew), "changed since it was read"},
 		{fmt.Errorf("token: %w", apperrors.ErrApprovalTokenInvalid), "approval token"},
+		// A declared capability gap must say do-not-retry: the generic branch
+		// tells the agent to retry, which for a permanent refusal spends a
+		// scheduled run's whole step budget re-calling the same tool.
+		{fmt.Errorf("mode: %w", apperrors.ErrUnsupportedBySoR), "Do not retry"},
 	}
 	for _, tc := range cases {
 		if got := srv.explain("t", tc.err); !strings.Contains(got, tc.want) {

--- a/backend/internal/modules/agents/tools.go
+++ b/backend/internal/modules/agents/tools.go
@@ -377,6 +377,9 @@ func (t advanceDeal) StageInfo(ctx context.Context, in json.RawMessage) (StageIn
 	if err != nil {
 		return StageInfo{}, err
 	}
+	if err := refuseStagingElsewhere(rec); err != nil {
+		return StageInfo{}, err
+	}
 	semantic, _, err := t.stages.StageSemantic(ctx, args.ToStageID)
 	if err != nil {
 		return StageInfo{}, err

--- a/backend/internal/modules/agents/tools_confirm.go
+++ b/backend/internal/modules/agents/tools_confirm.go
@@ -54,6 +54,9 @@ func (t archiveRecord) StageInfo(ctx context.Context, in json.RawMessage) (Stage
 	if err != nil {
 		return StageInfo{}, err
 	}
+	if err := refuseStagingElsewhere(rec); err != nil {
+		return StageInfo{}, err
+	}
 	return StageInfo{
 		TargetType: args.RecordType, TargetID: args.ID, TargetVersion: &rec.Version,
 		Summary: fmt.Sprintf("Archive %s %s", args.RecordType, recordLabel(rec)),
@@ -119,6 +122,9 @@ func (t promoteLead) StageInfo(ctx context.Context, in json.RawMessage) (StageIn
 	if err != nil {
 		return StageInfo{}, err
 	}
+	if err := refuseStagingElsewhere(rec); err != nil {
+		return StageInfo{}, err
+	}
 	return StageInfo{
 		TargetType: "lead", TargetID: args.LeadID, TargetVersion: &rec.Version,
 		Summary: fmt.Sprintf("Promote lead %s to a contact (%s)", recordLabel(rec), args.Trigger),
@@ -149,7 +155,7 @@ func (t promoteLead) Handle(ctx context.Context, in json.RawMessage) (json.RawMe
 	}
 	return json.Marshal(map[string]any{
 		"merged": merged,
-		"person": wireRecord{RecordType: string(rec.Ref.Type), ID: rec.Ref.ID, Fields: rec.Fields, Version: rec.Version},
+		"person": newWireRecord(rec),
 	})
 }
 
@@ -201,6 +207,9 @@ func (t mergeRecords) StageInfo(ctx context.Context, in json.RawMessage) (StageI
 	// too, only to label the inbox entry.
 	survivor, err := t.p.Read(ctx, datasource.EntityRef{Type: datasource.EntityType(args.RecordType), ID: args.TargetID})
 	if err != nil {
+		return StageInfo{}, err
+	}
+	if err := refuseStagingElsewhere(survivor); err != nil {
 		return StageInfo{}, err
 	}
 	source, err := t.p.Read(ctx, datasource.EntityRef{Type: datasource.EntityType(args.RecordType), ID: args.SourceID})

--- a/backend/internal/modules/agents/tools_confirm.go
+++ b/backend/internal/modules/agents/tools_confirm.go
@@ -209,12 +209,17 @@ func (t mergeRecords) StageInfo(ctx context.Context, in json.RawMessage) (StageI
 	if err != nil {
 		return StageInfo{}, err
 	}
-	if err := refuseStagingElsewhere(survivor); err != nil {
-		return StageInfo{}, err
-	}
 	source, err := t.p.Read(ctx, datasource.EntityRef{Type: datasource.EntityType(args.RecordType), ID: args.SourceID})
 	if err != nil {
 		return StageInfo{}, err
+	}
+	// BOTH records, not just the pinned survivor: a merge archives and relinks
+	// the source too, so an externally-held source under a local survivor is
+	// still a change to a record whose approval could never be released.
+	for _, rec := range []datasource.Record{survivor, source} {
+		if err := refuseStagingElsewhere(rec); err != nil {
+			return StageInfo{}, err
+		}
 	}
 	return StageInfo{
 		TargetType: args.RecordType, TargetID: args.TargetID, TargetVersion: &survivor.Version,

--- a/backend/internal/modules/agents/tools_confirm.go
+++ b/backend/internal/modules/agents/tools_confirm.go
@@ -203,8 +203,10 @@ func (t mergeRecords) StageInfo(ctx context.Context, in json.RawMessage) (StageI
 	}
 	// Pin the SURVIVOR's version: the human's yes is a judgment about
 	// merging into B as it is now, so if B changes before redemption the
-	// approval no longer covers it (version skew, re-stage). Read the source
-	// too, only to label the inbox entry.
+	// approval no longer covers it (version skew, re-stage). The source is read
+	// because it is the other half of the change — the merge archives and
+	// relinks it — so its authority is checked too and its label goes in the
+	// summary.
 	survivor, err := t.p.Read(ctx, datasource.EntityRef{Type: datasource.EntityType(args.RecordType), ID: args.TargetID})
 	if err != nil {
 		return StageInfo{}, err
@@ -213,13 +215,13 @@ func (t mergeRecords) StageInfo(ctx context.Context, in json.RawMessage) (StageI
 	if err != nil {
 		return StageInfo{}, err
 	}
-	// BOTH records, not just the pinned survivor: a merge archives and relinks
-	// the source too, so an externally-held source under a local survivor is
-	// still a change to a record whose approval could never be released.
-	for _, rec := range []datasource.Record{survivor, source} {
-		if err := refuseStagingElsewhere(rec); err != nil {
-			return StageInfo{}, err
-		}
+	// Every record this change touches, not just the pinned one, and named so a
+	// human reading the refusal knows which half of the merge blocked it.
+	if err := refuseStagingElsewhere(survivor); err != nil {
+		return StageInfo{}, fmt.Errorf("the record being merged INTO: %w", err)
+	}
+	if err := refuseStagingElsewhere(source); err != nil {
+		return StageInfo{}, fmt.Errorf("the record being merged FROM: %w", err)
 	}
 	return StageInfo{
 		TargetType: args.RecordType, TargetID: args.TargetID, TargetVersion: &survivor.Version,

--- a/backend/internal/modules/agents/tools_progress.go
+++ b/backend/internal/modules/agents/tools_progress.go
@@ -80,6 +80,9 @@ func (t progressDeal) StageInfo(ctx context.Context, in json.RawMessage) (StageI
 	if err != nil {
 		return StageInfo{}, err
 	}
+	if err := refuseStagingElsewhere(rec); err != nil {
+		return StageInfo{}, err
+	}
 	semantic, _, err := t.stages.StageSemantic(ctx, args.ToStageID)
 	if err != nil {
 		return StageInfo{}, err

--- a/backend/internal/modules/agents/tools_progress_test.go
+++ b/backend/internal/modules/agents/tools_progress_test.go
@@ -62,7 +62,9 @@ func progressFixture(dealID, noteID ids.UUID) *fakeSoR {
 	dealRef := datasource.EntityRef{Type: datasource.EntityDeal, ID: dealID}
 	return &fakeSoR{
 		records: map[datasource.EntityRef]datasource.Record{
-			dealRef: {Ref: dealRef, Fields: json.RawMessage(`{"name":"Acme renewal"}`), Version: 5},
+			dealRef: nativeRecord(datasource.Record{
+				Ref: dealRef, Fields: json.RawMessage(`{"name":"Acme renewal"}`), Version: 5,
+			}),
 		},
 		createRef: datasource.EntityRef{Type: datasource.EntityActivity, ID: noteID},
 	}

--- a/backend/internal/modules/agents/tools_qualify_test.go
+++ b/backend/internal/modules/agents/tools_qualify_test.go
@@ -56,7 +56,7 @@ func leadFixture(t *testing.T, id ids.UUID, fields string, version int64) *fakeS
 	t.Helper()
 	ref := datasource.EntityRef{Type: datasource.EntityLead, ID: id}
 	return &fakeSoR{records: map[datasource.EntityRef]datasource.Record{
-		ref: {Ref: ref, Fields: json.RawMessage(fields), Version: version},
+		ref: nativeRecord(datasource.Record{Ref: ref, Fields: json.RawMessage(fields), Version: version}),
 	}}
 }
 

--- a/backend/internal/modules/agents/tools_update.go
+++ b/backend/internal/modules/agents/tools_update.go
@@ -79,7 +79,7 @@ func (t updateRecord) Handle(ctx context.Context, in json.RawMessage) (json.RawM
 	if err := decodeArgs(in, &args); err != nil {
 		return nil, err
 	}
-	if approvalRedeemed(ctx) {
+	if ApprovalRedeemed(ctx) {
 		// The dispatch layer consumed an approval bound to exactly this
 		// call — the human already released the overwrite it performs.
 		return t.apply(ctx, args, args.Fields)
@@ -108,11 +108,15 @@ func (t updateRecord) Handle(ctx context.Context, in json.RawMessage) (json.RawM
 		}
 		return nil, &workflow.StagedApprovalError{ApprovalID: id}
 	}
+	return t.applySplit(ctx, args, split)
+}
 
-	// Mixed patch: the auto-execute remainder lands first, then the residue is
-	// staged against the post-write version — the version the approving
-	// human actually sees, so the pin (ADR-0036 §2) covers this call's
-	// own auto-execute half instead of being invalidated by it.
+// applySplit handles the mixed patch: the auto-execute remainder lands
+// first, then the residue is staged against the post-write version — the
+// version the approving human actually sees, so the pin (ADR-0036 §2)
+// covers this call's own auto-execute half instead of being invalidated by
+// it.
+func (t updateRecord) applySplit(ctx context.Context, args updateRecordArgs, split PatchSplit) (json.RawMessage, error) {
 	applied, err := t.applyRecord(ctx, args, split.AutoExecute)
 	if err != nil {
 		return nil, err
@@ -160,6 +164,9 @@ func (t updateRecord) stageConflicts(ctx context.Context, args updateRecordArgs,
 	if err != nil {
 		return ids.ApprovalID{}, err
 	}
+	if err := refuseStagingElsewhere(rec); err != nil {
+		return ids.ApprovalID{}, err
+	}
 	return t.staging.Stage(ctx, StageRequest{
 		Tool:           "update_record",
 		ProposedChange: canonical,
@@ -198,7 +205,5 @@ func (t updateRecord) applyRecord(ctx context.Context, args updateRecordArgs, pa
 	if err != nil {
 		return wireRecord{}, fmt.Errorf("crmagents: write landed but read-back failed: %w", err)
 	}
-	return wireRecord{
-		RecordType: string(rec.Ref.Type), ID: rec.Ref.ID, Fields: rec.Fields, Version: rec.Version,
-	}, nil
+	return newWireRecord(rec), nil
 }

--- a/backend/internal/modules/agents/tools_update_test.go
+++ b/backend/internal/modules/agents/tools_update_test.go
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// update_record's own specs. The egress governance that used to live here
+// moved to the datasource seam (compose/dispatcher.go): the tool is not the
+// only route to an incumbent write, so a per-tool gate could not be the
+// control. What remains here is the tool's own contract.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+)
+
+// noConflicts is the ownership answer a record with no human audit history
+// produces: nothing is human-owned, so nothing is withheld.
+type noConflicts struct{}
+
+func (noConflicts) HumanOwnedConflicts(context.Context, string, ids.UUID, json.RawMessage) ([]string, error) {
+	return nil, nil
+}
+
+func personFixture(t *testing.T, id ids.UUID) *fakeSoR {
+	t.Helper()
+	ref := datasource.EntityRef{Type: datasource.EntityPerson, ID: id}
+	return &fakeSoR{records: map[datasource.EntityRef]datasource.Record{
+		ref: nativeRecord(datasource.Record{
+			Ref: ref, Fields: json.RawMessage(`{"full_name":"Ada Lovelace"}`), Version: 3,
+		}),
+	}}
+}
+
+func updateArgs(t *testing.T, id ids.UUID) json.RawMessage {
+	t.Helper()
+	in, err := json.Marshal(map[string]any{
+		"record_type": "person",
+		"id":          id,
+		"fields":      map[string]any{"job_title": "Analyst"},
+	})
+	if err != nil {
+		t.Fatalf("marshaling args: %v", err)
+	}
+	return in
+}
+
+// A patch no human has touched applies in the same call — the per-field
+// split's whole point is that a machine's own fields are not held hostage.
+func TestUpdateRecordAppliesAPatchWithNoHumanOwnedField(t *testing.T) {
+	id := ids.NewV7()
+	p := personFixture(t, id)
+	approvals := &recordingApprovals{}
+	tool := updateRecord{p: p, ownership: noConflicts{}, staging: approvals}
+
+	if _, err := tool.Handle(context.Background(), updateArgs(t, id)); err != nil {
+		t.Fatalf("Handle err = %v, want nil", err)
+	}
+	if len(p.updates) != 1 {
+		t.Errorf("provider.Update called %d time(s), want 1", len(p.updates))
+	}
+	if len(approvals.staged) != 0 {
+		t.Errorf("staged %d approval(s) for a conflict-free patch, want 0", len(approvals.staged))
+	}
+}
+
+// A released call performs exactly the effect the human approved, without
+// re-asking the precedence question.
+func TestUpdateRecordAppliesAReleasedCall(t *testing.T) {
+	id := ids.NewV7()
+	p := personFixture(t, id)
+	tool := updateRecord{p: p, ownership: noConflicts{}, staging: &recordingApprovals{}}
+
+	ctx := WithApprovalRedeemed(context.Background())
+	if _, err := tool.Handle(ctx, updateArgs(t, id)); err != nil {
+		t.Fatalf("Handle err = %v, want nil", err)
+	}
+	if len(p.updates) != 1 {
+		t.Errorf("provider.Update called %d time(s) after release, want 1", len(p.updates))
+	}
+}
+
+// A composition with no approvals engine cannot stage a human-owned
+// overwrite, so it refuses rather than applying one.
+func TestUpdateRecordRefusesAConflictItCannotStage(t *testing.T) {
+	id := ids.NewV7()
+	p := personFixture(t, id)
+	tool := updateRecord{p: p, ownership: fixedOwnership{conflicts: []string{"job_title"}}, staging: nil}
+
+	_, err := tool.Handle(context.Background(), updateArgs(t, id))
+
+	if !errors.Is(err, apperrors.ErrRequiresApproval) {
+		t.Fatalf("Handle err = %v, want ErrRequiresApproval", err)
+	}
+	if len(p.updates) != 0 {
+		t.Errorf("provider.Update called %d time(s), want 0", len(p.updates))
+	}
+}
+
+// A 🟡 tool must not mint an approval for a record whose authority lives
+// elsewhere: the human would be asked to release a change that redemption can
+// never verify, because the pin and the decidability probe both read our own
+// tables. Refusing keeps every staging tool agreeing with the datasource seam,
+// which refuses the same write for the same reason.
+func TestStagingIsRefusedForANonAuthoritativeTarget(t *testing.T) {
+	ref := datasource.EntityRef{Type: datasource.EntityPerson, ID: ids.NewV7()}
+	mirrored := datasource.Record{Ref: ref, Fields: json.RawMessage(`{}`)}
+
+	err := refuseStagingElsewhere(mirrored)
+
+	if !errors.Is(err, apperrors.ErrUnsupportedBySoR) {
+		t.Fatalf("err = %v, want ErrUnsupportedBySoR", err)
+	}
+	if err := refuseStagingElsewhere(nativeRecord(mirrored)); err != nil {
+		t.Errorf("a locally-authoritative record must stage: %v", err)
+	}
+}
+
+// update_record stages through stageConflicts, not StageInfo, so the derived
+// walk in stagingfitness_test.go cannot see it. This is that site's pin: a
+// patch WITH a human-owned conflict is what reaches stageConflicts, and for a
+// target held elsewhere it must refuse rather than mint an approval no human
+// can release.
+func TestUpdateRecordRefusesStagingForATargetHeldElsewhere(t *testing.T) {
+	id := ids.NewV7()
+	ref := datasource.EntityRef{Type: datasource.EntityPerson, ID: id}
+	// Deliberately NOT nativeRecord: this record's authority lives elsewhere.
+	p := &fakeSoR{records: map[datasource.EntityRef]datasource.Record{
+		ref: {Ref: ref, Fields: json.RawMessage(`{"job_title":"Analyst"}`), Version: 3},
+	}}
+	approvals := &recordingApprovals{}
+	tool := updateRecord{
+		p:         p,
+		ownership: fixedOwnership{conflicts: []string{"job_title"}},
+		staging:   approvals,
+	}
+
+	_, err := tool.Handle(context.Background(), updateArgs(t, id))
+
+	if !errors.Is(err, apperrors.ErrUnsupportedBySoR) {
+		t.Fatalf("Handle err = %v, want ErrUnsupportedBySoR", err)
+	}
+	if len(approvals.staged) != 0 {
+		t.Errorf("staged %d approval(s) against an externally-held record, want 0", len(approvals.staged))
+	}
+	if len(p.updates) != 0 {
+		t.Errorf("provider.Update called %d time(s), want 0", len(p.updates))
+	}
+}

--- a/backend/internal/modules/agents/tools_update_test.go
+++ b/backend/internal/modules/agents/tools_update_test.go
@@ -76,7 +76,7 @@ func TestUpdateRecordAppliesAReleasedCall(t *testing.T) {
 	p := personFixture(t, id)
 	tool := updateRecord{p: p, ownership: noConflicts{}, staging: &recordingApprovals{}}
 
-	ctx := WithApprovalRedeemed(context.Background())
+	ctx := withApprovalRedeemed(context.Background())
 	if _, err := tool.Handle(ctx, updateArgs(t, id)); err != nil {
 		t.Fatalf("Handle err = %v, want nil", err)
 	}

--- a/backend/internal/modules/overlay/provider_writes.go
+++ b/backend/internal/modules/overlay/provider_writes.go
@@ -331,6 +331,18 @@ const (
 	WriteArchive WriteVerb = "archive"
 )
 
+// AllWriteVerbs returns every value above. Exported so a caller that must
+// reason over the whole set — the composition layer's fitness test that every
+// verb SupportsWrite can answer true for is egress-gated — derives it from here
+// instead of restating the list, which a fourth verb would silently outgrow.
+//
+// A function rather than a package-level slice: a caller that truncated a
+// shared slice would silently narrow whatever that fitness test covers, which
+// is the opposite of what deriving the set is for.
+func AllWriteVerbs() []WriteVerb {
+	return []WriteVerb{WriteCreate, WriteUpdate, WriteArchive}
+}
+
 // requireSupportedWrite refuses a verb SupportsWrite does not declare for
 // et — the ONE enforcement point for that declaration, applied inside each
 // write verb rather than at any one transport.

--- a/frontend/src/screens/reports.tsx
+++ b/frontend/src/screens/reports.tsx
@@ -112,8 +112,9 @@ export function ReportsScreen() {
   // report/pipeline queries are disabled, so this fallback key is inert.
   const report: ReportKey = segment === "quotas" ? "deals-by-stage" : segment;
   // Deal reports aggregate over the pipeline/stage structure the overlay mirror
-  // does not hold (the report endpoints 404 in overlay), so the report segments
-  // show the honest unavailable state; the native quotas tab still works.
+  // does not hold (the report endpoints answer 422 unsupported_by_sor in
+  // overlay), so the report segments show the honest unavailable state; the
+  // native quotas tab still works.
   const overlay = useSorMode() === "overlay";
   const reportActive = segment !== "quotas" && !overlay;
 


### PR DESCRIPTION
Closes the two Critical findings from a pre-open-source review of the overlay
feature, plus nine defects found while fixing them. Reviewed over six
craft/security rounds; the last round was the first to find no blocker.

## C1 — five agent tools answered for a system of record they cannot reach

`run_report`, `catch_me_up_on`, `prep_for_meeting`, `whats_slipping_this_week`
and `draft_follow_ups_for` are wired to engines that read the native domain
tables directly. Reports have a seam verb but it carries only ad-hoc plans, and
the mirror holds no context-graph or pipeline projection at all, so none of them
could ride the Dispatcher. Handed an overlay workspace they queried tables
holding none of its records and returned a well-formed empty result as a
**successful** answer — "nothing is slipping" from a portal with a live
pipeline. `overlay.Provider.RunReport` already declared the correct refusal; no
production caller reached it.

The composition layer now guards each dependency (`nativeonlytools.go`), so the
tools stay mode-unaware. Both REST report operations are shadowed — `RunReport`
and the `ExplainReport` drill-through that returns source rows — and both answer
the declared `unsupported_by_sor` sentinel, the same machine code the tool half
gives. The SPA hiding Reports in overlay is exactly why this must exist
server-side: the callers it does not cover are an agent and a direct API client.

## C2 — agent write-back reached the customer's CRM ungoverned

`update_record` auto-executed into HubSpot. Its only brake was per-field
human-edit precedence, which reads the audit trail — and a mirrored record has
no human audit history, so the conflict set was always empty and every patch
went outward. A closed loop with T2 mirror content, which is
attacker-influenceable by design.

The refusal is at the **seam**, not in the tool, because the tool was never the
only route: the REST twin under an agent passport runs the same toothless split,
and `qualify_lead` writes through the provider with no gate of its own.
Dispatcher's update/archive dispatch is what every write caller funnels through
— including the REST write shadow, which is why the gate sits on
`updateInMode`/`archiveInMode` rather than `Update`/`Archive`. It gates only
verbs the adapter actually serves, so "every write" holds by construction as
`SupportsWrite` changes.

### ⚠️ Scope decision to confirm before merge

It answers **`unsupported_by_sor`, not "needs approval"** — i.e. agent
write-back to the incumbent is a *declared refusal*, which is **stricter than
AC-OV-5's confirm-first intent**.

The reason: no approval an agent could get exists here. Staging one needs an
authority object a human can both see and release, and for a mirrored target
neither holds — `approvals/authority.go`'s decidability probe and
`approvals/redeem.go`'s version pin both read *our own* tables, which the record
has no row in. Naming a path that dead-ends is what the declared sentinel exists
to avoid. Confirm-first agent write-back is therefore blocked on the approvals
layer being able to describe a non-authoritative target; the released-approval
check is the seam that change plugs into. **Human seats are unaffected** — that
stays object RBAC's question, per ADR-0055's split.

If reviewers prefer confirm-first now, that is a governance-module change and
should be its own PR rather than smuggled into a security fix.

## Nine further defects, each fixed at the invariant

- The egress probe first read the **cached** mode on a mutation boundary; a
  stale `native` answer would open the gate while the dispatch, resolving fresh,
  still routed the patch to the incumbent.
- The MCP confirm-first redemption branch redeemed an approval without marking
  the call released — asymmetric with the auto-execute branch three lines above.
- Six staging sites minted approvals no human could release (the version pin
  re-reads a row a mirrored record does not have). All six now refuse.
- REST could **release** an agent overlay write with nothing re-verified: a 🟡
  twin stages from `If-Match` alone, which a mirror row has no version for, so
  the pin was nil and redemption checked nothing.
- `ExplainReport` — the unguarded sibling of the endpoint C1 guarded.
- REST reports answered `validation_error`, telling callers their input was
  wrong when the request was fine.
- A declared refusal reached agents as a retryable internal fault, in stdio's
  explanation **and** in the Surface-B runner's observation — the loop with a
  step budget to spend on a permanent no.
- T2 taint dropped on `update_record`'s read-back (finding J12).
- `frontend`: the Reports comment claimed these endpoints 404 in overlay; they
  now answer 422.

## Tests

Unit specs for every guard, the backstop's principal and capability handling,
and both directions of the human/agent discriminator. Two derived fitness
functions rather than hand lists: every verb `SupportsWrite` can answer true for
must be egress-gated, and every stageable tool must refuse an externally-held
target (a new one with no args entry fails). An integration suite drives
`compose.NewRegistry` — the constructor `cmd/mcp` and the api role use — against
a real overlay workspace, including the seam itself so the REST and
`qualify_lead` routes are covered rather than assumed.

**Every regression test here was confirmed to fail against the unfixed code**,
not merely to pass against the fixed one. Three tests passed for the wrong
reason during development and were caught that way — one asserted only an HTTP
status where the route returns the same status for a malformed query, so it
stayed green with the guard removed. Re-verified after the rebase: both Critical
controls still fail on mutation.

## Gates

`make check` ✅ · `make test-integration` ✅ (0 skips, 25 packages) ·
`craft static` ✅ 0 blocker. The 6 remaining craft advisories are all
pre-existing and in scope only because this touches their files (`newServer` is
one line *shorter* than on main; the three `naked-any` in `provider_writes.go`
predate this). Refactoring code this PR didn't write inside a security fix would
widen the blast radius.

## Three items for upstream, not this PR

1. The `/me` contract description tells clients unservable reads answer
   `unsupported_in_overlay_mode` — a code that only ever appears nested under
   `validation_error` in this build. Needs spec reconciliation (P3), not a local
   edit.
2. `connectOverlay` / `disconnectOverlay` / `executeOverlayFlip` are annotated
   `Access: "tool"` rather than `human-only`, so an agent can reach
   system-of-record posture changes. Reads like ADR-0055's human-only
   governance class.
3. The remaining 45 review findings are unaddressed here, incl. the mirror's
   fail-closed 2×SLO visibility floor, GDPR erasure not reaching the mirror
   while the docs claim it does, custom-pipeline deals reading `status: "open"`,
   and the explanation doc's nine false claims.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops agents from answering or writing to a system of record they can’t reach in overlay mode. Adds a seam egress backstop and uncached mode-aware guards so tools return `unsupported_by_sor`, and agent runs don’t retry.

- **Bug Fixes**
  - Guard native-only tools (`run_report`, `catch_me_up_on`, `prep_for_meeting`, `whats_slipping_this_week`, `draft_follow_ups_for`); both tool and REST report ops (`RunReport`/`ExplainReport`) return 422 `unsupported_by_sor` in overlay; guards use the uncached SoR probe.
  - Add seam egress backstop `refuseUngovernedAgentEgress` in `Dispatcher.updateInMode`/`archiveInMode`; gate only verbs `overlay.SupportsWrite` serves; refuse agent writes unless a released approval is present; human seats unaffected.
  - REST write guard refuses agents in overlay even for seam‑served verbs; fast path for human seam‑served writes; resolve SoR mode fresh for writes and ignore stale caches.
  - Mark released calls via `agents.RedeemAndMark`; cannot mark if redeem fails; reads use `agents.ApprovalRedeemed`; setter kept unexported to prevent forging.
  - Refuse staging for mirrored targets with `refuseStagingElsewhere` (applies to `archive_record`, `promote_lead`, `merge_records`, `advance_deal`, `progress_deal`, and `update_record` staging); validate both merge survivor and source.
  - Normalize errors and agent UX: HTTP 422 `unsupported_by_sor`; stdio says “do not retry”; the runner adds a terminal directive outside the data fence and never exceeds the cap (space reserved for the directive).
  - Integration and fitness tests cover native-only guards, stale‑mode cases, seam backstop, human/agent discrimination, no‑marking‑on‑failed‑redeem, and that every served write verb is backstopped.

- **Refactors**
  - Wrap native‑only dependencies with uncached, mode‑aware adapters in `nativeonlytools.go` and wire via `registry.go` using a named `nativeOnlyModeProbe`; rename write resolver to `isOverlayUncached` and clarify docs.
  - Expose `overlay.AllWriteVerbs()` and add tests so every served write verb is covered by the backstop.
  - Record overlay review follow‑ups and two upstream contract items in `STATUS.md` (remaining findings, `/me` code spelling, overlay lifecycle ops access).

<sup>Written for commit 2028bf7be96450829c96a112beaac82dab19519d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an egress backstop that blocks agent writes to external system-of-record boundaries in overlay mode until approval is redeemed.
  * Added native-only guards for selected tools/endpoints in overlay workspaces (returns `422 unsupported_by_sor`).
* **Bug Fixes**
  * Overlay agent seam-served writes are now refused.
  * REST report endpoints now return `422 unsupported_by_sor` in overlay mode.
* **Tests**
  * Expanded unit and end-to-end coverage for approval redemption, overlay/tool refusals, and staging “elsewhere” protections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Relationship to ADR-0075 §3 (write posture)

ADR-0075 §3 landed after this branch was cut and points the other way on write
posture: staging every model-derived write **was proposed and rejected**
(founder, 2026-07-28), and what is pinned instead is *direct apply, attributed,
reversible, findable*. This PR refuses an agent write outright, which is further
than the staging that was rejected — so the distinction is recorded here rather
than left implied.

**This PR does not touch the lane §3 governs.** The auto-enrich and capture
writes run as `PrincipalSystem` (`compose/captureautoenrich.go`), and this gate
fires only on `PrincipalAgent`. The self-filling CRM is unaffected.

**Why egress is a different risk class.** §3's safety argument rests on three
legs and states that "weakening any one of them puts staging back on the table."
For a write into the customer's HubSpot, two are weakened by construction:

- **Reversible** — a human edit cannot flip a HubSpot field's provenance to
  `human:*`, and our fill-only-empty / human-precedence rule does not govern
  another vendor's store. The correction that "settles it for good" natively has
  no equivalent there.
- **Attributed** — HubSpot carries no `captured_by`. The attribution exists only
  in our audit log, not where the data now lives and not where the customer's
  other integrations read it.

§3 itself distinguishes by risk class (citing ADR-0072 §3, where the
irreversible half does require corroboration), and AC-OV-5 independently
classifies incumbent write-back as *egress*, confirm-first "like any external
send." That is the doctrine this PR implements.

**What would change it.** Confirm-first — the AC-OV-5 intent — needs the
approvals layer to describe a non-authoritative target: today its decidability
probe and its redemption version pin both read our own tables, which a mirrored
record has no row in. When that lands, the released-approval check already in
`egressbackstop.go` is the seam it plugs into.
