### PR TITLE
docs(company): stop the graph contract claiming a bound it does not have

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -27,12 +27,15 @@ The merge gate (`make check`), the real-Postgres integration lane
 ## Session pickup — 2026-07-30
 
 **The company-view rebuild is 6 of 7 PRs in.** #309 (composite read), #313
-(one-page view), #315 (evidence mark), #317 (account brief) and #319 (next-step
-suggestions + Ask Margince) are merged. **PR 6, the connections card, is on
-`feat/company-connections-graph`** — `GET /organizations/{id}/graph` in
+(one-page view), #315 (evidence mark), #317 (account brief), #319 (next-step
+suggestions + Ask Margince) and #322 (the connections card) are merged. **PR 7
+is the last one in the arc.**
+
+The connections card is `GET /organizations/{id}/graph` in
 `internal/compose/org360/graph*.go` plus `frontend/src/screens/connections.tsx`,
-wired into the company rail between the people and deals cards. `make check` and
-the graph's nine integration tests are green; `craft static` reports nothing.
+wired into the company rail between the people and deals cards. Its four review
+passes are worth reading before you extend it — the three decisions and three
+rules below all came out of them.
 
 **One class of bug the review round found, worth remembering.** The graph's
 person reads were gated by the ORDER its group list ran in: `readSeats` and
@@ -72,16 +75,19 @@ extending the card.
   an exact `dropped_count` needs a count over each group's whole membership, so
   the count is one index range scan per account. That trade is stated in the
   contract rather than assumed; if it ever needs to change, the response shape
-  changes with it (a floor plus a flag), not the count quietly.
+  changes with it (a floor plus a flag), not the count quietly. The contract said
+  the opposite for two commits — #326 fixes that — because the correction went
+  into a Go comment while the published description kept the promise. A gap
+  documented where the reader cannot see it is not documented.
 - **Every group total rides the same statement as its rows.** `WithWorkspaceTx`
   is Read Committed, so a total read in a second statement can be smaller than
   the rows the first one returned, and `dropped_count` then goes negative
   against the contract's own `minimum: 0`. If you add a capped group, count it
   with `count(*) OVER ()` or a CTE, never with a follow-up `SELECT count(*)`.
 
-**PR 7 is the last one, and graph level 2 is still deferred.** The card does not
-replace `RecordContextPanel` (that panel is on the deal, person and lead screens,
-never on the company view — the scope line assumed otherwise).
+**Graph level 2 is still deferred.** The card does not replace
+`RecordContextPanel` (that panel is on the deal, person and lead screens, never
+on the company view — PR 6's scope line assumed otherwise).
 
 **Two things worth knowing before touching the suggestion code.** The stall
 episode's monotonicity constraint is written at `stalledDeal.episode()` in

--- a/STATUS.md
+++ b/STATUS.md
@@ -67,6 +67,12 @@ extending the card.
   filled the budget and starved the others. The cap now lives in the query and
   picks distinct companies. Same trap waits for any group whose display unit is
   not its row unit.
+- **The graph read is proportional to the account, on purpose.** The caps bound
+  the rows returned and the per-contact §4 fold — the part that grows fast — but
+  an exact `dropped_count` needs a count over each group's whole membership, so
+  the count is one index range scan per account. That trade is stated in the
+  contract rather than assumed; if it ever needs to change, the response shape
+  changes with it (a floor plus a flag), not the count quietly.
 - **Every group total rides the same statement as its rows.** `WithWorkspaceTx`
   is Read Committed, so a total read in a second statement can be smaller than
   the rows the first one returned, and `dropped_count` then goes negative

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -931,17 +931,21 @@ paths:
         the deals already selected — so they are the one node kind that number does not
         speak for.
 
-        The reads themselves are bounded, so one request's cost follows the caps and not
-        the account. Deals are ordered and limited in the database, so their slice is
-        exactly the top N. Organizations are limited by COMPANY rather than by row, so a
-        company attached several ways — a parent that is also a reseller — cannot fill the
+        How each group picks its slice, because the three differ in ways a client can
+        see. Deals are ordered and limited in the database, so their slice is exactly the
+        top N. Organizations are limited by COMPANY rather than by row, so a company
+        attached several ways — a parent that is also a reseller — cannot fill the
         allowance and leave the others out; a relationship recorded twice is one edge, not
         two. Contacts are the one group ordered by something the database does not know
         yet (a relationship strength computed after the read), so an account with more
         than 500 contacts contributes the strongest of the first 500 by id rather than of
-        all of them. `dropped_count` is the true remainder in every case. No real account
-        is near that bound, and an installation that reaches it should read the contact
-        list from `GET /people` rather than from a card.
+        all of them — no real account is near that, and an installation that reaches it
+        should read the contact list from `GET /people` rather than from a card.
+
+        `dropped_count` is the true remainder in every case, including past that 500.
+        Keeping it true costs a count over each group's whole membership, so this read is
+        proportional to the account it describes and not to the caps; the caps bound the
+        rows returned and the per-contact work done on them, which is what grows fast.
 
         Native system-of-record only: a workspace reading from an incumbent mirror gets
         `422 unsupported_in_overlay_mode`, the same refusal the 360 gives, because the

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -503,17 +503,21 @@ export interface paths {
          *     the deals already selected — so they are the one node kind that number does not
          *     speak for.
          *
-         *     The reads themselves are bounded, so one request's cost follows the caps and not
-         *     the account. Deals are ordered and limited in the database, so their slice is
-         *     exactly the top N. Organizations are limited by COMPANY rather than by row, so a
-         *     company attached several ways — a parent that is also a reseller — cannot fill the
+         *     How each group picks its slice, because the three differ in ways a client can
+         *     see. Deals are ordered and limited in the database, so their slice is exactly the
+         *     top N. Organizations are limited by COMPANY rather than by row, so a company
+         *     attached several ways — a parent that is also a reseller — cannot fill the
          *     allowance and leave the others out; a relationship recorded twice is one edge, not
          *     two. Contacts are the one group ordered by something the database does not know
          *     yet (a relationship strength computed after the read), so an account with more
          *     than 500 contacts contributes the strongest of the first 500 by id rather than of
-         *     all of them. `dropped_count` is the true remainder in every case. No real account
-         *     is near that bound, and an installation that reaches it should read the contact
-         *     list from `GET /people` rather than from a card.
+         *     all of them — no real account is near that, and an installation that reaches it
+         *     should read the contact list from `GET /people` rather than from a card.
+         *
+         *     `dropped_count` is the true remainder in every case, including past that 500.
+         *     Keeping it true costs a count over each group's whole membership, so this read is
+         *     proportional to the account it describes and not to the caps; the caps bound the
+         *     rows returned and the per-contact work done on them, which is what grows fast.
          *
          *     Native system-of-record only: a workspace reading from an incumbent mirror gets
          *     `422 unsupported_in_overlay_mode`, the same refusal the 360 gives, because the


### PR DESCRIPTION
Follow-up to #322. One sentence in that PR's contract description is false, and it missed the squash by one push.

`GET /organizations/{id}/graph` claimed:

> The reads themselves are bounded, so one request's cost follows the caps and not the account.

It does not. An exact `dropped_count` needs a count over each group's whole membership, so the read **is** proportional to the account it describes. What the caps bound is the rows returned and the per-contact §4 fold done on them — the part that grows fast.

#322 corrected the Go comment on `graphScanCap` and left the published description promising the opposite, which is worse than either alone: the honest account ended up where no client reads it. This says both in the description, because the trade is a client's to know — if it ever has to change, the response shape changes with it (a floor plus a flag) rather than the count quietly becoming approximate.

The paragraph also loses its reassurance about request cost. A client cannot observe our index scans, and prose that exists only to reassure is the worst kind of line in a contract.

Docs and the regenerated types only — no behaviour change. `make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `GET /organizations/{id}/graph` docs by removing the false claim that reads are bounded by caps and clarifying that exact `dropped_count` needs whole-account counts, so cost scales with the account; caps only bound returned rows and per-contact work. Updates `backend/api/crm.yaml`, regenerated `frontend/src/api/schema.d.ts`, and `STATUS.md` (notes the connections card is merged and documents the proportional-read trade); docs only, no behavior change.

<sup>Written for commit 89a749befc7270fcc0e1f59f559433c569262a41. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/326?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

