### PR TITLE
build(sbom): source-tree SBOM generation, license gate + keyless signing

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,92 @@
+name: SBOM
+
+# Regenerate the source-tree SBOM whenever a dependency set (Go or Node) or the
+# SBOM pipeline itself (Makefile targets, syft/grant policy, this workflow)
+# changes. syft/grant/cosign run through digest-pinned Docker images (see the
+# Makefile), so the runner needs only Docker — pre-installed on ubuntu-latest.
+on:
+  workflow_dispatch:
+  # Anchored once, reused by both events (YAML alias — DRY).
+  pull_request:
+    # Match ci.yml: ready_for_review joins the defaults so leaving draft triggers
+    # a run, and the job's draft guard skips work while the PR is still a draft.
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths: &dep-paths
+      - "go.work"
+      - "go.work.sum"
+      - "**/go.mod"
+      - "**/go.sum"
+      - "pnpm-lock.yaml"
+      - "**/package.json"
+      - "Makefile"
+      - ".syft.yaml"
+      - ".grant.yaml"
+      - ".github/workflows/sbom.yml"
+  push:
+    branches: [main]
+    paths: *dep-paths
+
+# contents: read is the floor for every job. The OIDC minting credential
+# (id-token: write) is NOT granted here — only the isolated sign job requests it,
+# so PR-controlled generation code can never mint a signing token.
+permissions:
+  contents: read
+
+jobs:
+  sbom:
+    name: sbom
+    runs-on: ubuntu-latest
+    # A draft PR iterating on dependency bumps has no SBOM consumer — skip it.
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: false
+          # SBOM_VERSION reads `git describe --tags --exact-match` (else the short
+          # revision); resolving a release tag needs the tags and history.
+          fetch-depth: 0
+      - name: Generate SBOMs
+        run: make sbom
+      - name: License gate
+        run: make sbom-check
+      - name: Publish SBOMs
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: sboms
+          path: sboms/
+          if-no-files-found: error
+          # PR artifacts are superseded by the next push; only main's linger.
+          retention-days: ${{ github.event_name == 'pull_request' && 14 || 90 }}
+
+  # Keyless signing is isolated from generation so PR-controlled build code never
+  # runs while id-token: write is in scope. Only main's SBOMs are signed: keyless
+  # cosign signatures land permanently in the public Rekor log and cannot be
+  # retracted, so a PR preview or a feature-branch dispatch must never produce
+  # one. `needs: sbom` means the license gate has already passed, so a
+  # policy-failing SBOM never reaches this job.
+  sign:
+    name: sign
+    needs: sbom
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # keyless cosign signing via the GitHub OIDC token
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: false
+      - name: Fetch generated SBOMs
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          name: sboms
+          path: sboms/
+      - name: Sign SBOMs (keyless cosign)
+        run: make sbom-sign
+      - name: Publish signatures
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: sbom-signatures
+          path: sboms/*.cosign.bundle
+          if-no-files-found: error
+          retention-days: 90

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,9 @@ coverage.out
 frontend/storybook-static/
 .tmp/
 
+# Generated SBOMs + cosign signatures (build artifacts — `make sbom`, published by CI)
+/sboms/
+
 # Factory boundary backstop: a dispatched worker that mistakenly writes
 # factory artifacts (plans/reports/UAT guides) into the worktree can never
 # stage them (target-minimum-setup §1).

--- a/.grant.yaml
+++ b/.grant.yaml
@@ -1,0 +1,38 @@
+format: table # Output format: "table" or "json" (default: "table")
+quiet: false # Suppress all non-essential output (default: false)
+verbose: false # Enable verbose output (default: false)
+
+# Allowed licenses. Baseline set: MIT, Apache-2.0, BSD-2-Clause,
+# BSD-3-Clause, ISC, 0BSD, Zlib, BSL-1.0, CC0-1.0. Extended to cover the
+# permissive / weak-copyleft licenses of dependencies actually present in the
+# tree (MIT-0, BlueOak-1.0.0, MPL-2.0) plus CC-BY-4.0 / Python-2.0 / Unlicense
+# (maintainer decision). BUSL-1.1 is Margince's own source license.
+allow:
+  - Apache-2.0
+  - MIT
+  - MIT-0
+  - BSD-2-Clause
+  - BSD-3-Clause
+  - ISC
+  - 0BSD
+  - Zlib
+  - BSL-1.0
+  - BlueOak-1.0.0
+  - MPL-2.0
+  - CC0-1.0
+  - CC-BY-4.0
+  - Python-2.0
+  - Unlicense
+  - BUSL-1.1
+
+# First-party components carry no third-party license to gate. (CI Actions are
+# excluded from the scan entirely in .syft.yaml, so they never reach grant.)
+# Every other package must still resolve to a known, allowed license.
+ignore-packages:
+  - github.com/gradionhq/margince/* # our own Go modules
+  - example.margince.dev/* # committed extension stubs (ADR-0069), first-party
+
+require-license: true # When true, deny packages with no detected licenses
+require-known-license: true
+disable-file-search: false # Disable filesystem license file search
+summary: true

--- a/.syft.yaml
+++ b/.syft.yaml
@@ -1,0 +1,38 @@
+# Source-tree SBOM defaults. `make sbom` drives the scan; it feeds
+# syft a clean `git archive HEAD` export, so the scan source is committed
+# content only — the Makefile owns the "what is scanned" policy, not this file.
+
+check-for-app-update: false
+
+output: cyclonedx-json
+
+format:
+  pretty: true
+
+source:
+  name: margince
+  # NB: syft has no `source.license` key — the primary component's license
+  # cannot be set from config. Margince's own source license is BUSL-1.1;
+  # first-party packages are handled in .grant.yaml (allow BUSL-1.1 + ignore
+  # github.com/gradionhq/margince/*).
+
+# Enrich package coordinates with license metadata. syft pulls Go
+# licenses from the module proxy and npm licenses from the registry, so `make
+# sbom` needs network access — it is not an offline scan.
+enrich:
+  - all
+license:
+  content: none
+
+# Committed trees that are agent/CI/build-tooling/test state, not shipped
+# product source or dependency manifests. The clean export already drops
+# uncommitted host state (node_modules, build output, .env); these drop the
+# committed non-product trees the scan would otherwise catalog as components.
+exclude:
+  - ./.claude/**
+  - ./.github/** # CI workflows — syft catalogs the referenced Actions as packages, but they are build infra, not shipped product
+  - ./.githooks/**
+  - ./.pnpm-store/**
+  - ./scratchpad/**
+  - ./cli/craft/** # code-craftsmanship gate (ADR-0045), a pre-push build tool — not shipped
+  - ./fixtures/** # test fixtures (e.g. the crm-hello extension module) — not shipped

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # The frontend lane is separate (`make frontend-check`) — it needs node+pnpm,
 # which not every backend machine has; CI runs both.
 
-.PHONY: help install ai-routing-local dev-fresh check check-backend check-q check-go check-fe build test test-v test-cover test-integration e2e-ai e2e-ai-report test-db-up test-it test-integration-serial bench-perf lint arch-lint vet gen gen-types gen-types-check drift composition check-composition test-extensions db-up db-init db-wait migrate migrate-up migrate-down run psql redis-cli tidy dev dev-stop dev-logs clean tools tools-go infra-up infra-down infra-logs infra-reset seed-dev seed-dev-db seed-reset verify-boot mcp-inspector frontend-check frontend-e2e fe-install fe-typecheck fe-lint fe-build fe-preview fe-format fe-test ds-purity font-lock icon-lint fitness-jurisdiction storybook fe-uat craft-static craft-residue check-craft-doc check-image-pins contract-breaking-check test-lanes go-file-length rls-store-path no-jurisdiction pkg-freeze hooks
+.PHONY: help install ai-routing-local dev-fresh check check-backend check-q check-go check-fe build test test-v test-cover test-integration e2e-ai e2e-ai-report test-db-up test-it test-integration-serial bench-perf lint arch-lint vet gen gen-types gen-types-check drift composition check-composition test-extensions db-up db-init db-wait migrate migrate-up migrate-down run psql redis-cli tidy dev dev-stop dev-logs clean tools tools-go infra-up infra-down infra-logs infra-reset seed-dev seed-dev-db seed-reset verify-boot mcp-inspector frontend-check frontend-e2e fe-install fe-typecheck fe-lint fe-build fe-preview fe-format fe-test ds-purity font-lock icon-lint fitness-jurisdiction storybook fe-uat craft-static craft-residue check-craft-doc check-image-pins contract-breaking-check test-lanes go-file-length rls-store-path no-jurisdiction pkg-freeze hooks sbom sbom-sign sbom-check
 
 # Bare `make` lists every command instead of running the first target.
 .DEFAULT_GOAL := help
@@ -305,3 +305,58 @@ pkg-freeze:
 hooks:
 	git config core.hooksPath .githooks
 	@echo "installed: core.hooksPath=.githooks (pre-push runs craft static on changed backend files)"
+
+# --- SBOM (software bill of materials, issue #331) ---
+# Repo-wide (backend + frontend + extensions), so it lives at the root, not
+# delegated to backend/. syft / grant / cosign run through digest-pinned Docker
+# images so the toolchain has zero host dependencies and a registry tag re-push
+# cannot swap the tools that read the repo and hold a signing identity. Tags are
+# comments — bump tag and digest together. Override SYFT/GRANT/COSIGN to use
+# host binaries (e.g. `make sbom SYFT=syft GRANT=grant`).
+SBOM_DIR     := sboms
+SYFT_IMAGE   ?= anchore/syft@sha256:1288ea4c8b38767b4e620c1e312c8cb26b6e887a99b4f07ab6cd19fc6f225026 # v1.50.0
+GRANT_IMAGE  ?= anchore/grant@sha256:172463611795f43b77302cdfbd7b3f81295492a7330e0820cfe41c3674920237 # v0.6.8
+COSIGN_IMAGE ?= gcr.io/projectsigstore/cosign@sha256:c77247c92f4dfea851c70555738226498393e34e2f9ca83cb959e51c230e4ad7 # v2.4.3
+DOCKER_SBOM  := docker run --rm -v "$(CURDIR)":/src -w /src
+SYFT         ?= $(DOCKER_SBOM) $(SYFT_IMAGE)
+GRANT        ?= $(DOCKER_SBOM) $(GRANT_IMAGE)
+# cosign's image runs as uid 65532, which cannot create files in the invoking
+# user's sboms/ dir through the bind mount — run it as root (syft's image does).
+# The OIDC env vars are ambient in CI (id-token: write).
+COSIGN       ?= $(DOCKER_SBOM) -u 0 -e SIGSTORE_ID_TOKEN -e ACTIONS_ID_TOKEN_REQUEST_URL -e ACTIONS_ID_TOKEN_REQUEST_TOKEN $(COSIGN_IMAGE)
+# Scan a clean export of committed HEAD, so host state (node_modules, .env, IDE
+# files) never leaks into the SBOM and .gitignore stays the single authority.
+SBOM_SRC     := .tmp/sbom-src
+# Release tag when HEAD is exactly on one, else dev-<short-revision>. The dev-
+# prefix marks an unreleased build at a glance; --exact-match avoids git
+# describe's nearest-tag "-N-g<sha>" form leaking a non-release tag (e.g.
+# archive/*) into the version.
+SBOM_VERSION ?= $(shell git describe --tags --exact-match 2>/dev/null || echo "dev-$$(git rev-parse --short HEAD 2>/dev/null || echo unknown)")
+SBOM_FILES   := $(SBOM_DIR)/margince.cdx.json $(SBOM_DIR)/margince.spdx221.json $(SBOM_DIR)/margince.spdx300.json
+
+## sbom — generate the source-tree SBOMs (CycloneDX + SPDX 2.2.1 + SPDX 3.0)
+## from a clean export of HEAD, license-enriched. Signing is separate: make sbom-sign (CI).
+sbom:
+	@mkdir -p $(SBOM_DIR)
+	@set -e; src=$(SBOM_SRC); \
+	  rm -rf "$$src"; mkdir -p "$$src"; \
+	  trap 'rm -rf "$$src"' EXIT; \
+	  git archive HEAD | tar -x -C "$$src"; \
+	  $(SYFT) scan dir:"$$src" -c .syft.yaml --source-version "$(SBOM_VERSION)" \
+	    -o cyclonedx-json=$(SBOM_DIR)/margince.cdx.json \
+	    -o spdx-json@2.2=$(SBOM_DIR)/margince.spdx221.json \
+	    -o spdx-json@3.0=$(SBOM_DIR)/margince.spdx300.json
+	@echo "wrote $(SBOM_FILES)"
+
+## sbom-sign — keyless-sign each generated SBOM with cosign (writes *.cosign.bundle; needs an OIDC token).
+sbom-sign:
+	@for f in $(SBOM_FILES); do \
+	  echo "signing $$f"; \
+	  $(COSIGN) sign-blob --yes --bundle "$$f.cosign.bundle" "$$f" || exit 1; \
+	done
+	@echo "signed: $(addsuffix .cosign.bundle,$(SBOM_FILES))"
+
+## sbom-check — license gate: grant fails if any bundled dependency uses a non-allowed license (.grant.yaml).
+sbom-check:
+	@test -f $(SBOM_DIR)/margince.cdx.json || { echo "FAIL: no SBOM found — run 'make sbom' first"; exit 1; }
+	@$(GRANT) check $(SBOM_DIR)/margince.cdx.json -c .grant.yaml


### PR DESCRIPTION
Adds root-level `make sbom` / `sbom-check` / `sbom-sign`.

- **`make sbom`** scans a clean `git archive HEAD` export with digest-pinned, dockerized syft and emits three license-enriched SBOMs — CycloneDX 1.7, SPDX 2.2.1, SPDX 3.0 — to `sboms/`.
- **`make sbom-check`** runs grant as the license gate (issue #331 allow-list plus first-party ignores).
- **`make sbom-sign`** keyless-signs with cosign, CI-only, after the gate passes (Rekor entries are permanent, so a policy-failing SBOM is never signed).

`.github/workflows/sbom.yml` regenerates on dependency/pipeline changes, gates, signs (push/dispatch only — fork/Dependabot PRs get no OIDC token), and publishes the SBOMs as build artifacts.

Scanning a committed export keeps host state (node_modules, .env, IDE files) out of the SBOM with no denylist to maintain; CI Actions are excluded via `.github/**` (build infra, not shipped); `sboms/` is a gitignored build artifact.

The syft/grant/cosign images are digest-pinned so a registry tag re-push cannot swap the toolchain that reads the repo and holds a signing identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds repo‑wide, source‑tree SBOMs from a clean git export, enforces a license allow‑list (Linear #331), and keyless‑signs SBOMs in CI. Publishes versioned `CycloneDX`/`SPDX` artifacts for all runs and `cosign` signatures for `main` only.

- New Features
  - Make targets `sbom`, `sbom-check`, `sbom-sign`; emits `CycloneDX` 1.7 and `SPDX` 2.2.1/3.0 JSON to `sboms/` (gitignored); version is exact tag or `dev-<short-sha>`.
  - Scans a clean `git archive HEAD` with dockerized, digest‑pinned `syft`/`grant`/`cosign`; `.syft.yaml` excludes CI/tooling and enriches licenses to keep host state out.
  - License gate via `grant` and `.grant.yaml` allow‑list; first‑party ignores; unknown or disallowed licenses fail.
  - CI `.github/workflows/sbom.yml` splits generation/gate and signing; `id-token: write` only in the sign job; triggers on dependency/pipeline changes; skips draft PRs; uploads SBOMs and `.cosign.bundle` signatures.

<sup>Written for commit 5e49d37c8ee7622cb8eadd63648f0973e8046e68. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated software bill of materials (SBOM) generation in multiple industry-standard formats.
  * Added license compliance checks to identify disallowed or unknown licenses.
  * Added cryptographic signing for SBOMs generated outside pull requests.
* **Chores**
  * SBOMs are automatically produced during relevant repository changes and retained as downloadable build artifacts.
  * Generated SBOM and signature files are excluded from source control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->