### PR TITLE
fix(overlay): stop a resumed flip creating records the crash already landed

### DIFF
--- a/backend/internal/compose/flip_test.go
+++ b/backend/internal/compose/flip_test.go
@@ -215,3 +215,28 @@ func TestStageCatalogPlacement(t *testing.T) {
 		}
 	})
 }
+
+func TestAdoptedDealClosesOnlyWhenItIsStillOpen(t *testing.T) {
+	closed := flipPlacement{closedStage: &[]ids.StageID{ids.New[ids.StageKind]()}[0], closedSemantic: stageSemanticWon}
+	open := flipPlacement{}
+
+	// The case the repair exists for: the crash created the deal on its
+	// open birth stage and died before the close. Left alone it would be
+	// reported converged while sitting open, and the estate's won revenue
+	// would simply be missing.
+	if !adoptedDealNeedsClosing(closed, "open") {
+		t.Error("a deal the incumbent calls closed, still open natively, must be closed on the resumed attempt")
+	}
+	// The ordinary replay: the attempt that created it also closed it.
+	// Advancing again would refight a settled close and its FX freeze.
+	for _, status := range []string{"won", "lost"} {
+		if adoptedDealNeedsClosing(closed, status) {
+			t.Errorf("a deal already %s was advanced again", status)
+		}
+	}
+	// The incumbent says open, so open is correct and there is nothing
+	// to assert — closing here would invent a terminal state.
+	if adoptedDealNeedsClosing(open, "open") {
+		t.Error("an open incumbent deal must not be closed")
+	}
+}

--- a/backend/internal/compose/flip_test.go
+++ b/backend/internal/compose/flip_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/modules/deals"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
@@ -224,19 +225,19 @@ func TestAdoptedDealClosesOnlyWhenItIsStillOpen(t *testing.T) {
 	// open birth stage and died before the close. Left alone it would be
 	// reported converged while sitting open, and the estate's won revenue
 	// would simply be missing.
-	if !adoptedDealNeedsClosing(closed, "open") {
+	if !adoptedDealNeedsClosing(closed, deals.DealOpen) {
 		t.Error("a deal the incumbent calls closed, still open natively, must be closed on the resumed attempt")
 	}
 	// The ordinary replay: the attempt that created it also closed it.
 	// Advancing again would refight a settled close and its FX freeze.
-	for _, status := range []string{"won", "lost"} {
+	for _, status := range []deals.DealStatus{deals.DealWon, deals.DealLost} {
 		if adoptedDealNeedsClosing(closed, status) {
 			t.Errorf("a deal already %s was advanced again", status)
 		}
 	}
 	// The incumbent says open, so open is correct and there is nothing
 	// to assert — closing here would invent a terminal state.
-	if adoptedDealNeedsClosing(open, "open") {
+	if adoptedDealNeedsClosing(open, deals.DealOpen) {
 		t.Error("an open incumbent deal must not be closed")
 	}
 }

--- a/backend/internal/compose/flipdeals.go
+++ b/backend/internal/compose/flipdeals.go
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// Landing an incumbent deal natively. It is the only estate class whose
+// arrival takes two steps — born on an open stage, because the store
+// forbids any other birth, then advanced to its terminal one — and that
+// second step is what makes it the only class the crash repair has to
+// finish rather than merely recognize.
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/modules/migration"
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+func (w *flipWriters) ensureDeal(ctx context.Context, row migration.Row) (migration.EnsureResult, error) {
+	owner, disclosure, err := w.resolveOwner(ctx, row, flipObjectDeal)
+	if err != nil {
+		return migration.EnsureResult{}, err
+	}
+	stages, err := w.stageCatalog(ctx)
+	if err != nil {
+		return migration.EnsureResult{}, err
+	}
+	rawStage := fieldString(row.Fields, "stage_id")
+	placement := stages.place(rawStage)
+
+	name := strings.TrimSpace(fieldString(row.Fields, "name"))
+	if name == "" {
+		name = overlayUnnamed
+	}
+	in := deals.CreateDealInput{
+		Name:       name,
+		Currency:   fieldStringPtr(row.Fields, "currency"),
+		PipelineID: placement.pipeline,
+		StageID:    placement.birthStage,
+		OwnerID:    owner,
+		Source:     w.provenance(flipObjectDeal, row.ExternalID),
+	}
+	if minor, ok := fieldInt64(row.Fields, "amount_minor"); ok {
+		in.AmountMinor = &minor
+	}
+	if closeAt, ok := overlayTime(row.Fields, "expected_close_date"); ok {
+		in.ExpectedClose = &closeAt
+	}
+	deal, err := w.deals.CreateDeal(ctx, in)
+	if err != nil {
+		return migration.EnsureResult{}, fmt.Errorf("flip import: creating deal %s: %w", row.ExternalID, err)
+	}
+	dealID := ids.From[ids.DealKind](ids.UUID(deal.Id))
+	if err := w.remember(ctx, flipObjectDeal, row.ExternalID, ids.UUID(deal.Id)); err != nil {
+		return migration.EnsureResult{}, err
+	}
+
+	// A closed estate deal is born open (the store's open-birth-stage
+	// rule), then advanced to the terminal stage — the same won/lost path
+	// a native close takes, FX freeze included.
+	if placement.closedStage != nil {
+		var lostReason *string
+		if placement.closedSemantic == "lost" {
+			reason := "imported closed-lost from the incumbent estate"
+			lostReason = &reason
+		}
+		if _, err := w.deals.AdvanceDeal(ctx, dealID, deals.AdvanceDealInput{ToStageID: *placement.closedStage, LostReason: lostReason}); err != nil {
+			return migration.EnsureResult{}, fmt.Errorf("flip import: closing imported deal %s: %w", row.ExternalID, err)
+		}
+	}
+	notes := stageDisclosure(placement, rawStage, row.ExternalID)
+	if disclosure != "" {
+		if notes != "" {
+			notes += "; "
+		}
+		notes += disclosure
+	}
+	return migration.EnsureResult{Created: true, Disclosure: notes}, nil
+}
+
+// settleAdoptedDeal finishes a deal the identity map already binds but
+// whose close may never have run.
+//
+// Landing a closed estate deal takes two transactions — born on an open
+// stage (the store's open-birth rule), then advanced to its terminal
+// one. A crash between the create and the identity write leaves the
+// first done and the second not; the reconcile then adopts the row, and
+// without this the import would answer Unchanged and leave a closed-won
+// deal parked open, counted as converged. Re-asserting is idempotent:
+// the ordinary replay case finds the deal already terminal and does
+// nothing.
+func (w *flipWriters) settleAdoptedDeal(ctx context.Context, dealID ids.DealID, row migration.Row) (migration.EnsureResult, error) {
+	stages, err := w.stageCatalog(ctx)
+	if err != nil {
+		return migration.EnsureResult{}, err
+	}
+	placement := stages.place(fieldString(row.Fields, "stage_id"))
+	if placement.closedStage == nil {
+		// The incumbent says this deal is open, which is how it was born.
+		return migration.EnsureResult{Unchanged: true}, nil
+	}
+	deal, err := w.deals.GetDeal(ctx, dealID, storekit.LiveOnly)
+	if err != nil {
+		return migration.EnsureResult{}, fmt.Errorf("flip import: reading adopted deal %s: %w", row.ExternalID, err)
+	}
+	if !adoptedDealNeedsClosing(placement, string(deal.Status)) {
+		return migration.EnsureResult{Unchanged: true}, nil
+	}
+	var lostReason *string
+	if placement.closedSemantic == stageSemanticLost {
+		reason := "imported closed-lost from the incumbent estate"
+		lostReason = &reason
+	}
+	if _, err := w.deals.AdvanceDeal(ctx, dealID, deals.AdvanceDealInput{
+		ToStageID: *placement.closedStage, LostReason: lostReason,
+	}); err != nil {
+		return migration.EnsureResult{}, fmt.Errorf("flip import: closing adopted deal %s: %w", row.ExternalID, err)
+	}
+	return migration.EnsureResult{Unchanged: true, Disclosure: fmt.Sprintf(
+		"deal %s was recovered from an interrupted attempt and closed on this one", row.ExternalID)}, nil
+}
+
+// adoptedDealNeedsClosing is the idempotency rule behind
+// settleAdoptedDeal: close only a deal the incumbent says is terminal
+// and that is still open natively. Both halves matter — re-advancing an
+// already-closed deal would refight a settled close (and its FX freeze),
+// while skipping an open one leaves the estate's revenue wrong.
+func adoptedDealNeedsClosing(placement flipPlacement, nativeStatus string) bool {
+	return placement.closedStage != nil && nativeStatus == "open"
+}

--- a/backend/internal/compose/flipdeals.go
+++ b/backend/internal/compose/flipdeals.go
@@ -107,7 +107,7 @@ func (w *flipWriters) settleAdoptedDeal(ctx context.Context, dealID ids.DealID, 
 	if err != nil {
 		return migration.EnsureResult{}, fmt.Errorf("flip import: reading adopted deal %s: %w", row.ExternalID, err)
 	}
-	if !adoptedDealNeedsClosing(placement, string(deal.Status)) {
+	if !adoptedDealNeedsClosing(placement, deals.DealStatus(deal.Status)) {
 		return migration.EnsureResult{Unchanged: true}, nil
 	}
 	var lostReason *string
@@ -129,6 +129,6 @@ func (w *flipWriters) settleAdoptedDeal(ctx context.Context, dealID ids.DealID, 
 // and that is still open natively. Both halves matter — re-advancing an
 // already-closed deal would refight a settled close (and its FX freeze),
 // while skipping an open one leaves the estate's revenue wrong.
-func adoptedDealNeedsClosing(placement flipPlacement, nativeStatus string) bool {
-	return placement.closedStage != nil && nativeStatus == "open"
+func adoptedDealNeedsClosing(placement flipPlacement, nativeStatus deals.DealStatus) bool {
+	return placement.closedStage != nil && nativeStatus == deals.DealOpen
 }

--- a/backend/internal/compose/flipreconcile.go
+++ b/backend/internal/compose/flipreconcile.go
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// Repairing the identity map after a crashed flip.
+//
+// A record lands in two steps that are NOT one transaction: the owning
+// module store creates the native row (its own write shape — domain row
+// + audit + outbox), then the engine's identity map records what that
+// external id became. A process that dies between them leaves a created
+// record the resume cannot see, and the resume would create it again.
+//
+// The repair is possible because the flip stamps `source` inside the
+// RESERVED import namespace, which every client-facing create wire
+// refuses (shared/kernel/provenance). So a native row bearing the
+// reserved prefix can only have been written by an importer — which is
+// what makes reading provenance back safe here, when reading the
+// client-writable part of it would not be. The prefix names the
+// incumbent and the class, not a run: another attempt's orphan is
+// precisely what this adopts.
+//
+// Adoption is restricted to LIVE rows. A row that was archived or
+// merged away since the crash is a tombstone: binding an external id to
+// it would suppress the real estate record — the import would report it
+// converged, never create it, and every activity resolving through that
+// identity would attach to the tombstone's survivor. Left unadopted, it
+// simply gets created properly.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/modules/migration"
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// ReconcileIdentities adopts records this run created but never mapped,
+// so a resumed flip recognizes its own work instead of duplicating it.
+func (w *flipWriters) ReconcileIdentities(ctx context.Context) error {
+	// The scan reads five module tables and binds identities off what it
+	// finds, so the grant is checked before the first read rather than
+	// at the write that follows it. Row scope is deliberately NOT
+	// applied: an orphan owned by another seat is still this run's to
+	// adopt, and skipping it would duplicate the record instead.
+	if err := auth.Require(ctx, "import_run", principal.ActionCreate); err != nil {
+		return err
+	}
+	for _, object := range flipImportOrder {
+		pairs, err := w.orphanedIdentities(ctx, object)
+		if err != nil {
+			return err
+		}
+		if err := w.identities.RecordIdentities(ctx, w.runID, w.incumbent, object, pairs); err != nil {
+			return err
+		}
+		for _, p := range pairs {
+			w.nativeIDs[w.cacheKey(object, p.ExternalID)] = p.NativeID
+		}
+	}
+	return nil
+}
+
+// orphanedIdentities finds live native rows for one class whose
+// reserved-namespace provenance names this incumbent and that the
+// identity map does not yet know about. The prefix is scoped to
+// incumbent and class, not to a run: another attempt's orphan is
+// exactly what this is meant to adopt.
+func (w *flipWriters) orphanedIdentities(ctx context.Context, object string) ([]migration.IdentityPair, error) {
+	if !flipImportable(object) {
+		// The allowlist is what keeps the class out of the format string
+		// below; an unknown one is a programming error, not a query.
+		return nil, fmt.Errorf("flip reconcile: %q is not an importable object", object)
+	}
+	prefix := w.provenance(object, "")
+	byExternal := map[string]ids.UUID{}
+	err := database.WithWorkspaceTx(ctx, w.pool, func(tx pgx.Tx) error {
+		// starts_with, not LIKE: the prefix carries the incumbent's name,
+		// and a `_` or `%` in it would silently widen the match to other
+		// incumbents while the length-based strip below took the wrong
+		// number of characters. The external id is extracted ONCE, in
+		// SQL, and the join reuses it — two spellings of the same strip
+		// agreed only while the match was a true prefix.
+		rows, err := tx.Query(ctx, fmt.Sprintf(`
+			SELECT n.id, right(n.source, -length($1::text)) AS external_id
+			FROM %s n
+			LEFT JOIN import_record_map m
+			  ON m.workspace_id = n.workspace_id
+			 AND m.source_system = $2
+			 AND m.object = $3
+			 AND m.external_id = right(n.source, -length($1::text))
+			WHERE starts_with(n.source, $1) AND m.native_id IS NULL
+			  AND %s`, object, liveClause(object)),
+			prefix, w.incumbent, object)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		seen := map[string]bool{}
+		for rows.Next() {
+			var id ids.UUID
+			var ext string
+			if err := rows.Scan(&id, &ext); err != nil {
+				return err
+			}
+			// A row whose provenance is the bare prefix names no external
+			// record; it cannot be bound to one, so it is left alone
+			// rather than mapped under an empty key.
+			if ext == "" {
+				continue
+			}
+			// Two live rows claiming one external id is ambiguous, and the
+			// insert's conflict rule would pick whichever landed first
+			// while the caller's cache kept the last. Adopt neither: the
+			// duplicate is visible, and a wrong binding would not be.
+			if seen[ext] {
+				delete(byExternal, ext)
+				continue
+			}
+			seen[ext] = true
+			byExternal[ext] = id
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, fmt.Errorf("flip reconcile: finding unmapped %s records from a previous attempt: %w", object, err)
+	}
+	pairs := make([]migration.IdentityPair, 0, len(byExternal))
+	for ext, id := range byExternal {
+		pairs = append(pairs, migration.IdentityPair{ExternalID: ext, NativeID: id})
+	}
+	return pairs, nil
+}
+
+// liveClause is the per-class liveness predicate the adoption scan adds.
+// Only person and organization carry a merge pointer; every scanned
+// class carries archived_at. A tombstone must never be adopted.
+func liveClause(object string) string {
+	if object == flipObjectPerson || object == flipObjectOrganization {
+		return "n.archived_at IS NULL AND n.merged_into_id IS NULL"
+	}
+	return "n.archived_at IS NULL"
+}

--- a/backend/internal/compose/flipwire_test.go
+++ b/backend/internal/compose/flipwire_test.go
@@ -12,6 +12,7 @@ package compose
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -19,6 +20,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/overlay"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/provenance"
 )
 
 func TestBlockingContains(t *testing.T) {
@@ -216,5 +218,38 @@ func TestExportGateProvesNothingWithoutAWatermark(t *testing.T) {
 	}
 	if exported {
 		t.Error("a zero cutoff reported an export as proven; every historical export would clear the gate")
+	}
+}
+
+func TestTheFlipStampsProvenanceInsideTheReservedNamespace(t *testing.T) {
+	// The resume repair recognizes its own records by this prefix, and
+	// only the prefix makes that safe — every client create wire refuses
+	// it, so a row carrying it cannot have been planted.
+	w := &flipWriters{incumbent: "hubspot"}
+	stamp := w.provenance(flipObjectPerson, "p-1")
+	if !provenance.ReservedSourceSystem(stamp) {
+		t.Fatalf("provenance = %q, want the reserved prefix; without it a planted row would be adopted as the importer's own", stamp)
+	}
+	if stamp != provenance.ReservedSourceSystemPrefix+"hubspot:person:p-1" {
+		t.Errorf("provenance = %q, want incumbent:object:external_id inside the namespace", stamp)
+	}
+	// The empty external id is the LIKE prefix the repair scans on, so it
+	// must be a strict prefix of a real row's stamp — otherwise the scan
+	// matches nothing and the repair silently adopts nobody.
+	if prefix := w.provenance(flipObjectPerson, ""); !strings.HasPrefix(stamp, prefix) || prefix == stamp {
+		t.Errorf("scan prefix %q is not a strict prefix of %q", prefix, stamp)
+	}
+	// Distinct classes never share a prefix, or the repair would bind an
+	// organization's external id to a person.
+	if strings.HasPrefix(w.provenance(flipObjectDeal, "x"), w.provenance(flipObjectPerson, "")) {
+		t.Error("a deal's provenance matched the person scan prefix")
+	}
+}
+
+func TestReconcileRefusesAnObjectOutsideTheAllowlist(t *testing.T) {
+	// The class is interpolated into the scan's FROM clause, so the
+	// allowlist — not the caller — is what keeps a table name out of it.
+	if _, err := (&flipWriters{incumbent: "hubspot"}).orphanedIdentities(t.Context(), "person; DROP TABLE person"); err == nil {
+		t.Fatal("an unlisted object must be refused before any query is built")
 	}
 }

--- a/backend/internal/compose/flipwriters.go
+++ b/backend/internal/compose/flipwriters.go
@@ -117,7 +117,7 @@ var _ migration.Writers = (*flipWriters)(nil)
 
 // provenance is the imported row's source stamp.
 func (w *flipWriters) provenance(object, ext string) string {
-	return fmt.Sprintf("%s:%s:%s", w.incumbent, object, ext)
+	return provenance.ReservedSourceSystemPrefix + fmt.Sprintf("%s:%s:%s", w.incumbent, object, ext)
 }
 
 // importSourceSystem namespaces the source_system the flip writes on the
@@ -148,12 +148,16 @@ func (w *flipWriters) Exists(ctx context.Context, object, ext string) (bool, err
 }
 
 // lookup answers whether this external id already landed natively, via
-// the ENGINE-OWNED identity map. It deliberately does not read the rows'
-// own source/source_system columns: those are client-writable on every
-// create path, so a caller could pre-plant a row under an incumbent id
-// and have the flip treat the real estate record as already imported —
-// suppressing it, and capturing the activities that resolve through the
-// same identity.
+// the ENGINE-OWNED identity map — never by reading a row's own
+// provenance. Outside the reserved import namespace those columns are
+// client-writable, so a caller could pre-plant a row under an incumbent
+// id and have the flip treat the real estate record as already
+// imported: suppressing it, and capturing the activities that resolve
+// through the same identity.
+//
+// The crash repair (flipreconcile.go) DOES read provenance back, and
+// the two are consistent: it matches only the reserved prefix, which no
+// client-facing path can write, and only on live rows.
 func (w *flipWriters) lookup(ctx context.Context, object, ext string) (ids.UUID, bool, error) {
 	if !flipImportable(object) {
 		return ids.UUID{}, false, fmt.Errorf("flip import: %q is not an importable object", object)
@@ -192,12 +196,23 @@ func (w *flipWriters) remember(ctx context.Context, object, ext string, id ids.U
 
 // Ensure lands one estate row through the owning store.
 func (w *flipWriters) Ensure(ctx context.Context, object string, row migration.Row) (migration.EnsureResult, error) {
-	if _, found, err := w.lookup(ctx, object, row.ExternalID); err != nil {
+	if id, found, err := w.lookup(ctx, object, row.ExternalID); err != nil {
 		return migration.EnsureResult{}, err
 	} else if found {
 		// The flip's source is a FROZEN snapshot, so an already-landed
 		// row cannot differ from what is stored: nothing to rewrite, and
 		// the report says so rather than claiming an update.
+		//
+		// A deal is the exception, because landing it takes TWO steps —
+		// born open, then advanced to its terminal stage. An adopted
+		// orphan (created before a crash, recovered by the reconcile)
+		// completed only the first, so returning Unchanged here would
+		// leave a closed-won estate deal parked open forever, reported as
+		// converged. Re-asserting the close is idempotent: a deal that
+		// already reached its terminal stage needs nothing.
+		if object == flipObjectDeal {
+			return w.settleAdoptedDeal(ctx, ids.From[ids.DealKind](id), row)
+		}
 		return migration.EnsureResult{Unchanged: true}, nil
 	}
 	switch object {
@@ -349,68 +364,6 @@ func (w *flipWriters) ensureLead(ctx context.Context, row migration.Row) (migrat
 		return migration.EnsureResult{}, err
 	}
 	return migration.EnsureResult{Created: true, Disclosure: disclosure}, nil
-}
-
-func (w *flipWriters) ensureDeal(ctx context.Context, row migration.Row) (migration.EnsureResult, error) {
-	owner, disclosure, err := w.resolveOwner(ctx, row, flipObjectDeal)
-	if err != nil {
-		return migration.EnsureResult{}, err
-	}
-	stages, err := w.stageCatalog(ctx)
-	if err != nil {
-		return migration.EnsureResult{}, err
-	}
-	rawStage := fieldString(row.Fields, "stage_id")
-	placement := stages.place(rawStage)
-
-	name := strings.TrimSpace(fieldString(row.Fields, "name"))
-	if name == "" {
-		name = overlayUnnamed
-	}
-	in := deals.CreateDealInput{
-		Name:       name,
-		Currency:   fieldStringPtr(row.Fields, "currency"),
-		PipelineID: placement.pipeline,
-		StageID:    placement.birthStage,
-		OwnerID:    owner,
-		Source:     w.provenance(flipObjectDeal, row.ExternalID),
-	}
-	if minor, ok := fieldInt64(row.Fields, "amount_minor"); ok {
-		in.AmountMinor = &minor
-	}
-	if closeAt, ok := overlayTime(row.Fields, "expected_close_date"); ok {
-		in.ExpectedClose = &closeAt
-	}
-	deal, err := w.deals.CreateDeal(ctx, in)
-	if err != nil {
-		return migration.EnsureResult{}, fmt.Errorf("flip import: creating deal %s: %w", row.ExternalID, err)
-	}
-	dealID := ids.From[ids.DealKind](ids.UUID(deal.Id))
-	if err := w.remember(ctx, flipObjectDeal, row.ExternalID, ids.UUID(deal.Id)); err != nil {
-		return migration.EnsureResult{}, err
-	}
-
-	// A closed estate deal is born open (the store's open-birth-stage
-	// rule), then advanced to the terminal stage — the same won/lost path
-	// a native close takes, FX freeze included.
-	if placement.closedStage != nil {
-		var lostReason *string
-		if placement.closedSemantic == "lost" {
-			reason := "imported closed-lost from the incumbent estate"
-			lostReason = &reason
-		}
-		if _, err := w.deals.AdvanceDeal(ctx, dealID, deals.AdvanceDealInput{ToStageID: *placement.closedStage, LostReason: lostReason}); err != nil {
-			return migration.EnsureResult{}, fmt.Errorf("flip import: closing imported deal %s: %w", row.ExternalID, err)
-		}
-	}
-	notes := stageDisclosure(placement, rawStage, row.ExternalID)
-	if disclosure != "" {
-		if notes != "" {
-			notes += "; "
-		}
-		notes += disclosure
-	}
-	return migration.EnsureResult{Created: true, Disclosure: notes}, nil
 }
 
 func (w *flipWriters) ensureActivity(ctx context.Context, row migration.Row) (migration.EnsureResult, error) {

--- a/backend/internal/compose/integration/overlay_cutover_lifecycle_integration_test.go
+++ b/backend/internal/compose/integration/overlay_cutover_lifecycle_integration_test.go
@@ -170,17 +170,17 @@ func TestOverlayCutoverRetirementAndReconstruction(t *testing.T) {
 			t.Errorf("%s = %d, want %d", name, n, want)
 		}
 	}
-	assertCount("reconstructed persons", `SELECT count(*) FROM person WHERE source LIKE 'hubspot:%'`, 3)
-	assertCount("reconstructed organizations", `SELECT count(*) FROM organization WHERE source LIKE 'hubspot:%'`, 2)
-	assertCount("reconstructed deals", `SELECT count(*) FROM deal WHERE source LIKE 'hubspot:%'`, 2)
+	assertCount("reconstructed persons", `SELECT count(*) FROM person WHERE source LIKE 'mirror:hubspot:%'`, 3)
+	assertCount("reconstructed organizations", `SELECT count(*) FROM organization WHERE source LIKE 'mirror:hubspot:%'`, 2)
+	assertCount("reconstructed deals", `SELECT count(*) FROM deal WHERE source LIKE 'mirror:hubspot:%'`, 2)
 	assertCount("reconstructed leads", `SELECT count(*) FROM lead WHERE source_system = 'mirror:hubspot'`, 1)
 	assertCount("reconstructed activities", `SELECT count(*) FROM activity WHERE source_system = 'mirror:hubspot'`, 1)
 	assertCount("reconstructed deal→org FK", `
 		SELECT count(*) FROM deal d JOIN organization o ON o.id = d.organization_id AND o.workspace_id = d.workspace_id
-		WHERE d.source = 'hubspot:deal:d-open' AND o.source = 'hubspot:organization:org-1'`, 1)
+		WHERE d.source = 'mirror:hubspot:deal:d-open' AND o.source = 'mirror:hubspot:organization:org-1'`, 1)
 	assertCount("reconstructed employment", `
 		SELECT count(*) FROM relationship r JOIN person p ON p.id = r.person_id AND p.workspace_id = r.workspace_id
-		WHERE r.kind = 'employment' AND p.source = 'hubspot:person:p-1'`, 1)
+		WHERE r.kind = 'employment' AND p.source = 'mirror:hubspot:person:p-1'`, 1)
 	// The bundle's owner map named the SOURCE workspace's admin, who does
 	// not exist in this clean instance — so ownership falls to the
 	// rebuild's own operator rather than landing ownerless (an ownerless
@@ -192,7 +192,7 @@ func TestOverlayCutoverRetirementAndReconstruction(t *testing.T) {
 	var ownedByOperator int
 	if err := database.WithWorkspaceTx(cleanCtx, f.pool, func(tx pgx.Tx) error {
 		return tx.QueryRow(cleanCtx,
-			`SELECT count(*) FROM person WHERE source LIKE 'hubspot:%' AND owner_id = $1`, rebuildOperator.UserID).Scan(&ownedByOperator)
+			`SELECT count(*) FROM person WHERE source LIKE 'mirror:hubspot:%' AND owner_id = $1`, rebuildOperator.UserID).Scan(&ownedByOperator)
 	}); err != nil {
 		t.Fatalf("counting rebuilt persons by owner: %v", err)
 	}

--- a/backend/internal/compose/integration/overlay_flip_integration_test.go
+++ b/backend/internal/compose/integration/overlay_flip_integration_test.go
@@ -742,3 +742,59 @@ func (w *failAfterWriter) Write(p []byte) (int, error) {
 	}
 	return len(p), nil
 }
+
+// A deal lands in TWO transactions — born on an open stage, then
+// advanced to its terminal one — so a crash between the create and the
+// identity write leaves a native deal that is open, unmapped, and
+// invisible to the next attempt's lookup. This is the state that leaves
+// behind, seeded directly: a closed-won estate deal that only got half
+// way. The flip must recognize it (one deal, not two) AND finish it
+// (won, not parked open).
+//
+// Only this lane can prove either half: the adoption is a SQL scan over
+// reserved-namespace provenance, and the close reads the native deal's
+// status back — neither is reachable from the unit fakes.
+func TestAFlipAdoptsAHalfLandedDealAndFinishesClosingIt(t *testing.T) {
+	f := setupFlipEstate(t)
+	e := f.e
+	f.writePreflipExport(t)
+
+	f.inWorkspaceTx(t, func(tx pgx.Tx) error {
+		_, err := tx.Exec(f.adminCtx, `
+			INSERT INTO deal (workspace_id, name, pipeline_id, stage_id, status, source, captured_by)
+			SELECT p.workspace_id, 'Half-landed estate deal', p.id, s.id, 'open',
+			       'mirror:hubspot:deal:d-won', $1
+			FROM pipeline p
+			JOIN stage s ON s.pipeline_id = p.id AND s.workspace_id = p.workspace_id
+			WHERE p.is_default AND s.semantic = 'open'
+			ORDER BY s.position LIMIT 1`, f.adminID)
+		return err
+	})
+
+	var verdict crmcontracts.OverlayFlipPreflight
+	if code := e.call(t, "POST", "/v1/overlay/flip:preflight", anyMap{}, nil, &verdict); code != http.StatusOK || !verdict.Ready {
+		t.Fatalf("green preflight = %d ready=%v", code, verdict.Ready)
+	}
+	var accepted crmcontracts.OverlayFlipAccepted
+	if code := e.call(t, "POST", "/v1/overlay/flip", anyMap{
+		"confirmation_phrase": "FLIP TO SOR",
+	}, nil, &accepted); code != http.StatusAccepted {
+		t.Fatalf("execute = %d %+v", code, accepted)
+	}
+
+	var total, won int
+	f.inWorkspaceTx(t, func(tx pgx.Tx) error {
+		if err := tx.QueryRow(f.adminCtx,
+			`SELECT count(*) FROM deal WHERE source = 'mirror:hubspot:deal:d-won'`).Scan(&total); err != nil {
+			return err
+		}
+		return tx.QueryRow(f.adminCtx,
+			`SELECT count(*) FROM deal WHERE source = 'mirror:hubspot:deal:d-won' AND status = 'won'`).Scan(&won)
+	})
+	if total != 1 {
+		t.Errorf("deals for d-won = %d, want 1 — the half-landed deal was created a second time", total)
+	}
+	if won != 1 {
+		t.Errorf("won deals for d-won = %d, want 1 — the adopted deal was left parked open and the estate's revenue is wrong", won)
+	}
+}

--- a/backend/internal/compose/integration/overlay_flip_integration_test.go
+++ b/backend/internal/compose/integration/overlay_flip_integration_test.go
@@ -287,9 +287,9 @@ func (f flipEstate) nativeEstateRows(t *testing.T) map[string]int {
 	t.Helper()
 	counts := map[string]int{}
 	for object, query := range map[string]string{
-		"person":       `SELECT count(*) FROM person WHERE source LIKE 'hubspot:%'`,
-		"organization": `SELECT count(*) FROM organization WHERE source LIKE 'hubspot:%'`,
-		"deal":         `SELECT count(*) FROM deal WHERE source LIKE 'hubspot:%'`,
+		"person":       `SELECT count(*) FROM person WHERE source LIKE 'mirror:hubspot:%'`,
+		"organization": `SELECT count(*) FROM organization WHERE source LIKE 'mirror:hubspot:%'`,
+		"deal":         `SELECT count(*) FROM deal WHERE source LIKE 'mirror:hubspot:%'`,
 		"lead":         `SELECT count(*) FROM lead WHERE source_system = 'mirror:hubspot'`,
 		"activity":     `SELECT count(*) FROM activity WHERE source_system = 'mirror:hubspot'`,
 	} {
@@ -486,35 +486,35 @@ func TestOverlayFlipFreshSyncExecute(t *testing.T) {
 	}
 	assertOne("deal→organization FK", `
 		SELECT count(*) FROM deal d JOIN organization o ON o.id = d.organization_id AND o.workspace_id = d.workspace_id
-		WHERE d.source = 'hubspot:deal:d-open' AND o.source = 'hubspot:organization:org-1'`)
+		WHERE d.source = 'mirror:hubspot:deal:d-open' AND o.source = 'mirror:hubspot:organization:org-1'`)
 	assertOne("primary employment relationship", `
 		SELECT count(*) FROM relationship r
 		JOIN person p ON p.id = r.person_id AND p.workspace_id = r.workspace_id
-		WHERE r.kind = 'employment' AND r.is_current_primary AND p.source = 'hubspot:person:p-1'`)
+		WHERE r.kind = 'employment' AND r.is_current_primary AND p.source = 'mirror:hubspot:person:p-1'`)
 	assertOne("activity link", `
 		SELECT count(*) FROM activity_link al
 		JOIN activity a ON a.id = al.activity_id AND a.workspace_id = al.workspace_id
 		JOIN person p ON p.id = al.person_id AND p.workspace_id = al.workspace_id
-		WHERE a.source_system = 'mirror:hubspot' AND p.source = 'hubspot:person:p-1'`)
+		WHERE a.source_system = 'mirror:hubspot' AND p.source = 'mirror:hubspot:person:p-1'`)
 	assertOne("closed-won deal", `
-		SELECT count(*) FROM deal WHERE source = 'hubspot:deal:d-won' AND status = 'won'`)
+		SELECT count(*) FROM deal WHERE source = 'mirror:hubspot:deal:d-won' AND status = 'won'`)
 	// The child rows the mapper nests: a contact's email and a company's
 	// domain. Both were silently dropped by a flat read once, so they
 	// are pinned per-record rather than by count.
 	assertOne("imported person's email", `
 		SELECT count(*) FROM person_email pe
 		JOIN person p ON p.id = pe.person_id AND p.workspace_id = pe.workspace_id
-		WHERE p.source = 'hubspot:person:p-1' AND pe.email = 'mor@baer-pharma.test'`)
+		WHERE p.source = 'mirror:hubspot:person:p-1' AND pe.email = 'mor@baer-pharma.test'`)
 	assertOne("imported organization's domain", `
 		SELECT count(*) FROM organization_domain od
 		JOIN organization o ON o.id = od.organization_id AND o.workspace_id = od.workspace_id
-		WHERE o.source = 'hubspot:organization:org-1' AND od.domain = 'baer-pharma.test'`)
+		WHERE o.source = 'mirror:hubspot:organization:org-1' AND od.domain = 'baer-pharma.test'`)
 	// Owners survive the flip: every estate row named incumbent owner
 	// "owner-1", which mirror_user_map binds to the admin.
 	var ownedByAdmin int
 	f.inWorkspaceTx(t, func(tx pgx.Tx) error {
 		return tx.QueryRow(f.adminCtx,
-			`SELECT count(*) FROM person WHERE source LIKE 'hubspot:%' AND owner_id = $1`, f.adminID).Scan(&ownedByAdmin)
+			`SELECT count(*) FROM person WHERE source LIKE 'mirror:hubspot:%' AND owner_id = $1`, f.adminID).Scan(&ownedByAdmin)
 	})
 	if ownedByAdmin != 3 {
 		t.Errorf("imported persons owned by the admin = %d, want 3 — two by mirror_user_map, and the unowned one inheriting the operator", ownedByAdmin)
@@ -523,7 +523,7 @@ func TestOverlayFlipFreshSyncExecute(t *testing.T) {
 	var ownerless int
 	f.inWorkspaceTx(t, func(tx pgx.Tx) error {
 		return tx.QueryRow(f.adminCtx,
-			`SELECT count(*) FROM person WHERE source LIKE 'hubspot:%' AND owner_id IS NULL`).Scan(&ownerless)
+			`SELECT count(*) FROM person WHERE source LIKE 'mirror:hubspot:%' AND owner_id IS NULL`).Scan(&ownerless)
 	})
 	if ownerless != 0 {
 		t.Errorf("%d imported person(s) landed ownerless — an ownerless native row is visible to every seat, which the mirror row was not", ownerless)

--- a/backend/internal/modules/activities/mapping.go
+++ b/backend/internal/modules/activities/mapping.go
@@ -26,19 +26,6 @@ func (e *RequiredFieldError) FieldFault() (field, code, message string) {
 	return e.Field, "required", e.Error()
 }
 
-// ReservedSourceSystemError refuses a client write into the importer's
-// source-system namespace (see activityLogInput). Maps to 422.
-type ReservedSourceSystemError struct{ Value string }
-
-func (e *ReservedSourceSystemError) Error() string {
-	return "source_system " + e.Value + " is reserved for imports"
-}
-
-// FieldFault refuses a client write into the importer's namespace as caller-fixable.
-func (e *ReservedSourceSystemError) FieldFault() (field, code, message string) {
-	return "source_system", "reserved_source_system", e.Error()
-}
-
 // pathID asserts a contract path id as entity K's id — the widening
 // point between the wire and the typed store surface (the route already
 // names the entity, so the assertion lives here, not in the store).
@@ -82,8 +69,13 @@ func activityLogInput(req crmcontracts.CreateActivityRequest) (LogActivityInput,
 	// caller who could spell the reserved prefix could pre-plant a row
 	// under an incumbent record id and have a later import hand it back
 	// as already existing (provenance.ReservedSourceSystemPrefix).
-	if req.SourceSystem != nil && provenance.ReservedSourceSystem(*req.SourceSystem) {
-		return LogActivityInput{}, &ReservedSourceSystemError{Value: *req.SourceSystem}
+	if req.SourceSystem != nil {
+		if err := provenance.Refuse("source_system", *req.SourceSystem); err != nil {
+			return LogActivityInput{}, err
+		}
+	}
+	if err := provenance.Refuse("source", req.Source); err != nil {
+		return LogActivityInput{}, err
 	}
 	in := LogActivityInput{
 		Kind:         string(req.Kind),

--- a/backend/internal/modules/activities/mapping_reservedsource_test.go
+++ b/backend/internal/modules/activities/mapping_reservedsource_test.go
@@ -56,3 +56,16 @@ func TestActivityLogInputRefusesAReservedSource(t *testing.T) {
 		t.Errorf("refusal names field %q, want source", refused.Field)
 	}
 }
+
+func TestActivityLogInputAcceptsAnOrdinarySource(t *testing.T) {
+	// The guard is a prefix rule, not a ban on the field: an ordinary
+	// provenance string has to survive, or every capture connector that
+	// stamps its own source would start failing at the wire.
+	in, err := activityLogInput(crmcontracts.CreateActivityRequest{Kind: "note", Source: "webform"})
+	if err != nil {
+		t.Fatalf("an ordinary source must stay writable: %v", err)
+	}
+	if in.Source != "webform" {
+		t.Errorf("Source = %q, want it carried through", in.Source)
+	}
+}

--- a/backend/internal/modules/activities/mapping_reservedsource_test.go
+++ b/backend/internal/modules/activities/mapping_reservedsource_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/provenance"
 )
 
 func TestActivityLogInputRefusesTheImporterNamespace(t *testing.T) {
@@ -19,9 +20,9 @@ func TestActivityLogInputRefusesTheImporterNamespace(t *testing.T) {
 	_, err := activityLogInput(crmcontracts.CreateActivityRequest{
 		Kind: "email", SourceSystem: &reserved, SourceId: strPtr("emails:900"),
 	})
-	var refused *ReservedSourceSystemError
+	var refused *provenance.ReservedError
 	if !errors.As(err, &refused) {
-		t.Fatalf("err = %v, want ReservedSourceSystemError — a client must not write the importer's namespace", err)
+		t.Fatalf("err = %v, want provenance.ReservedError — a client must not write the importer's namespace", err)
 	}
 }
 
@@ -39,3 +40,19 @@ func TestActivityLogInputAcceptsAnOrdinarySourceSystem(t *testing.T) {
 }
 
 func strPtr(s string) *string { return &s }
+
+// The `source` guard matters as much as source_system's: activity is one
+// of the classes the crash repair scans by provenance, so a client that
+// could write the namespace there could have a planted row adopted.
+func TestActivityLogInputRefusesAReservedSource(t *testing.T) {
+	_, err := activityLogInput(crmcontracts.CreateActivityRequest{
+		Kind: "note", Source: "mirror:hubspot:activity:a-1",
+	})
+	var refused *provenance.ReservedError
+	if !errors.As(err, &refused) {
+		t.Fatalf("err = %v, want provenance.ReservedError", err)
+	}
+	if refused.Field != "source" {
+		t.Errorf("refusal names field %q, want source", refused.Field)
+	}
+}

--- a/backend/internal/modules/deals/mapping.go
+++ b/backend/internal/modules/deals/mapping.go
@@ -13,6 +13,7 @@ import (
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/provenance"
 )
 
 // RequiredFieldError maps to 422 on both surfaces.
@@ -45,6 +46,9 @@ func idArg[K ids.EntityKind](u *openapi_types.UUID) *ids.ID[K] {
 func dealCreateInput(req crmcontracts.CreateDealRequest) (CreateDealInput, error) {
 	if req.Name == "" {
 		return CreateDealInput{}, &RequiredFieldError{Field: "name"}
+	}
+	if err := provenance.Refuse("source", req.Source); err != nil {
+		return CreateDealInput{}, err
 	}
 	in := CreateDealInput{
 		Name:           req.Name,

--- a/backend/internal/modules/deals/mapping_reservedsource_test.go
+++ b/backend/internal/modules/deals/mapping_reservedsource_test.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package deals
+
+// A deal has no (source_system, source_id) replay key, so `source` is
+// the only provenance it carries — and the flip's crash repair reads it
+// back to recognize deals it created but had not yet recorded in the
+// identity map. That repair is safe only while no client can write the
+// importer's namespace, which is what this mapper enforces.
+
+import (
+	"errors"
+	"testing"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/provenance"
+)
+
+func TestDealCreateInputRefusesTheImporterNamespace(t *testing.T) {
+	_, err := dealCreateInput(crmcontracts.CreateDealRequest{
+		Name: "Planted", Source: "mirror:hubspot:deal:d-1",
+	})
+	var refused *provenance.ReservedError
+	if !errors.As(err, &refused) {
+		t.Fatalf("err = %v, want provenance.ReservedError — a planted deal could be adopted as the importer's own", err)
+	}
+	if refused.Field != "source" {
+		t.Errorf("refusal names field %q, want source", refused.Field)
+	}
+}
+
+func TestDealCreateInputAcceptsAnOrdinarySource(t *testing.T) {
+	in, err := dealCreateInput(crmcontracts.CreateDealRequest{Name: "Real", Source: "webform"})
+	if err != nil {
+		t.Fatalf("an ordinary source must stay writable: %v", err)
+	}
+	if in.Source != "webform" {
+		t.Errorf("Source = %q, want it carried through", in.Source)
+	}
+}

--- a/backend/internal/modules/migration/engine.go
+++ b/backend/internal/modules/migration/engine.go
@@ -98,6 +98,12 @@ type AssocResult struct {
 // of the whole source must converge (IEM-FORM-1's upsert-by-key).
 type Writers interface {
 	Exists(ctx context.Context, object, externalID string) (bool, error)
+	// ReconcileIdentities repairs the record of what already landed
+	// before a RESUMED run walks its source again. The native create and
+	// the identity write are two transactions, so a process that died
+	// between them left a record nothing can now recognize — and the
+	// resume would create it a second time. Called only when resuming.
+	ReconcileIdentities(ctx context.Context) error
 	Ensure(ctx context.Context, object string, row Row) (EnsureResult, error)
 	Associate(ctx context.Context, a Assoc) (AssocResult, error)
 }
@@ -234,6 +240,18 @@ func (e *Engine) Run(ctx context.Context, runID RunID, src Source) (Report, erro
 	}
 	if run.Status != StatusRunning {
 		return Report{}, fmt.Errorf("migration run %s is %s, not %s: %w", runID, run.Status, StatusRunning, apperrors.ErrConflict)
+	}
+	// Unconditionally, before the loop can duplicate anything: adopt
+	// records an earlier attempt created but never got to record.
+	//
+	// Gating this on the run's checkpoint looked like a free
+	// optimization and was a hole. The checkpoint advances only AFTER a
+	// row lands, so a crash on the very first row leaves it at zero —
+	// and a re-created run (a fresh bundle upload, a re-sealed snapshot)
+	// starts at zero with a previous attempt's orphans still on disk.
+	// Both are exactly the case the repair exists for.
+	if err := e.w.ReconcileIdentities(ctx); err != nil {
+		return Report{}, e.fail(ctx, runID, Report{}, fmt.Errorf("migration run: reconciling a previous attempt's records: %w", err))
 	}
 	counts, err := src.Counts(ctx)
 	if err != nil {

--- a/backend/internal/modules/migration/engine_test.go
+++ b/backend/internal/modules/migration/engine_test.go
@@ -41,30 +41,67 @@ func (f *fakeSource) Rows(_ context.Context, object string, offset, limit int) (
 
 func (f *fakeSource) Associations(context.Context) ([]Assoc, error) { return f.assocs, nil }
 
-// fakeWriters records every ensure; existing simulates rows already
-// landed natively; failAt injects a crash at the Nth ensure call.
+// fakeWriters models the real writer's TWO-STEP landing, because the
+// gap between the steps is the thing worth testing: `landed` is the
+// native record (the module store's own transaction) and `mapped` is
+// the identity map (a second one). Exists reads `mapped`, exactly as
+// the real lookup does, so a record that landed without being mapped is
+// invisible until a reconcile adopts it.
+//
+// failAt injects a crash at the Nth ensure call; failAfterCreate makes
+// that crash land the record first, which is the process death this
+// whole seam exists for.
 type fakeWriters struct {
-	existing map[string]bool // object+"/"+ext
-	ensured  []string
-	assocs   []Assoc
-	calls    int
-	failAt   int // 0 = never
+	landed          map[string]bool // object+"/"+ext — the native row exists
+	mapped          map[string]bool // …and the identity map knows it
+	ensured         []string
+	assocs          []Assoc
+	calls           int
+	failAt          int // 0 = never
+	failAfterCreate bool
+	reconciles      int
+}
+
+// newFakeWriters starts with nothing landed and nothing mapped.
+func newFakeWriters() *fakeWriters {
+	return &fakeWriters{landed: map[string]bool{}, mapped: map[string]bool{}}
 }
 
 func (w *fakeWriters) Exists(_ context.Context, object, ext string) (bool, error) {
-	return w.existing[object+"/"+ext], nil
+	return w.mapped[object+"/"+ext], nil
+}
+
+// ReconcileIdentities adopts everything that landed but was never
+// mapped — the repair the resume depends on.
+func (w *fakeWriters) ReconcileIdentities(context.Context) error {
+	w.reconciles++
+	for key := range w.landed {
+		w.mapped[key] = true
+	}
+	return nil
 }
 
 func (w *fakeWriters) Ensure(_ context.Context, object string, row Row) (EnsureResult, error) {
 	w.calls++
+	key := object + "/" + row.ExternalID
 	if w.failAt > 0 && w.calls == w.failAt {
+		if w.failAfterCreate {
+			// The record IS in the database; the process died before the
+			// identity map learned of it.
+			w.landed[key] = true
+			w.ensured = append(w.ensured, key)
+		}
 		return EnsureResult{}, errors.New("injected crash")
 	}
-	key := object + "/" + row.ExternalID
-	created := !w.existing[key]
-	w.existing[key] = true
+	// The real writer opens with the same lookup: a row the identity map
+	// already binds is a replayed page, not work to redo.
+	if w.mapped[key] {
+		return EnsureResult{Unchanged: true}, nil
+	}
+	w.landed[key] = true
+	w.mapped[key] = true
 	w.ensured = append(w.ensured, key)
-	return EnsureResult{Created: created}, nil
+	return EnsureResult{Created: true}, nil
 }
 
 func (w *fakeWriters) Associate(_ context.Context, a Assoc) (AssocResult, error) {
@@ -146,7 +183,7 @@ func twoObjectSource() *fakeSource {
 
 func TestDryRunClassifiesWithoutWriting(t *testing.T) {
 	src := twoObjectSource()
-	w := &fakeWriters{existing: map[string]bool{"person/p-1": true}}
+	w := &fakeWriters{landed: map[string]bool{"person/p-1": true}, mapped: map[string]bool{"person/p-1": true}}
 	e := &Engine{w: w} // no run records on purpose: a dry-run must never touch them
 
 	rep, err := e.DryRun(context.Background(), src)
@@ -178,7 +215,7 @@ func TestDryRunClassifiesWithoutWriting(t *testing.T) {
 
 func TestRunImportsInOrderWithSkipsDisclosed(t *testing.T) {
 	src := twoObjectSource()
-	w := &fakeWriters{existing: map[string]bool{}}
+	w := newFakeWriters()
 	runs := newFakeRuns()
 	e := &Engine{runs: runs, w: w}
 
@@ -224,7 +261,8 @@ func TestRunImportsInOrderWithSkipsDisclosed(t *testing.T) {
 
 func TestRunResumesFromCheckpointAndConverges(t *testing.T) {
 	src := twoObjectSource()
-	w := &fakeWriters{existing: map[string]bool{}, failAt: 3} // crash on person/p-1
+	w := newFakeWriters()
+	w.failAt = 3 // crash on person/p-1
 	runs := newFakeRuns()
 	e := &Engine{runs: runs, w: w}
 
@@ -315,7 +353,8 @@ func threeObjectSource() *fakeSource {
 // a backwards cursor, so getting this wrong wedges every retry.
 func TestRunResumesAcrossALaterClassBoundary(t *testing.T) {
 	src := threeObjectSource()
-	w := &fakeWriters{existing: map[string]bool{}, failAt: 6} // crash on deal/d-2
+	w := newFakeWriters()
+	w.failAt = 6 // crash on deal/d-2
 	runs := newFakeRuns()
 	e := &Engine{runs: runs, w: w}
 
@@ -346,7 +385,7 @@ func TestRunResumesAcrossALaterClassBoundary(t *testing.T) {
 func TestRunRefusesANonRunningRecord(t *testing.T) {
 	runs := newFakeRuns()
 	runs.run.Status = StatusComplete
-	e := &Engine{runs: runs, w: &fakeWriters{existing: map[string]bool{}}}
+	e := &Engine{runs: runs, w: newFakeWriters()}
 	_, err := e.Run(context.Background(), RunID{}, twoObjectSource())
 	if !errors.Is(err, apperrors.ErrConflict) {
 		t.Fatalf("err = %v, want ErrConflict for a non-running record", err)
@@ -387,7 +426,7 @@ func TestAnOwnedRowWithNoPayloadIsStillAnEmptyPayloadSkip(t *testing.T) {
 		}},
 	}
 
-	dry, err := (&Engine{w: &fakeWriters{existing: map[string]bool{}}}).DryRun(context.Background(), src)
+	dry, err := (&Engine{w: newFakeWriters()}).DryRun(context.Background(), src)
 	if err != nil {
 		t.Fatalf("DryRun: %v", err)
 	}
@@ -399,7 +438,7 @@ func TestAnOwnedRowWithNoPayloadIsStillAnEmptyPayloadSkip(t *testing.T) {
 		t.Errorf("dry-run person = %+v, want p-blank skipped and only p-real counted", got)
 	}
 
-	w := &fakeWriters{existing: map[string]bool{}}
+	w := newFakeWriters()
 	rep, err := (&Engine{runs: newFakeRuns(), w: w}).Run(context.Background(), RunID{}, src)
 	if err != nil {
 		t.Fatalf("Run: %v", err)
@@ -413,5 +452,83 @@ func TestAnOwnedRowWithNoPayloadIsStillAnEmptyPayloadSkip(t *testing.T) {
 	if len(rep.Objects) != 1 || len(rep.Objects[0].Skipped) != 1 ||
 		rep.Objects[0].Skipped[0].Reason != "empty_payload" {
 		t.Errorf("import report = %+v, want the owned blank row disclosed as empty_payload", rep.Objects)
+	}
+}
+
+// The native create and the identity write are two transactions. A
+// process that dies between them leaves a record the identity map has
+// never heard of — and since Exists reads that map, the resumed run
+// would happily create the SAME record a second time. In a one-way
+// cutover that is a duplicate nobody asked for and nothing removes.
+func TestAResumeAdoptsRecordsTheCrashLandedButNeverMapped(t *testing.T) {
+	src := twoObjectSource()
+	w := newFakeWriters()
+	w.failAt, w.failAfterCreate = 3, true // person/p-1 lands, then the process dies
+	runs := newFakeRuns()
+	e := &Engine{runs: runs, w: w}
+
+	if _, err := e.Run(context.Background(), RunID{}, src); err == nil {
+		t.Fatal("Run must surface the injected crash")
+	}
+	if !w.landed["person/p-1"] || w.mapped["person/p-1"] {
+		t.Fatalf("the crash should leave p-1 landed but unmapped (landed=%v mapped=%v)",
+			w.landed["person/p-1"], w.mapped["person/p-1"])
+	}
+
+	runs.run.Status = StatusRunning
+	w.failAt, w.failAfterCreate = 0, false
+	if _, err := e.Run(context.Background(), RunID{}, src); err != nil {
+		t.Fatalf("resumed Run: %v", err)
+	}
+	if w.reconciles == 0 {
+		t.Error("the resume never repaired, so it could only have re-created what the crash landed")
+	}
+	seen := map[string]int{}
+	for _, k := range w.ensured {
+		seen[k]++
+	}
+	if seen["person/p-1"] != 1 {
+		t.Errorf("person/p-1 was written %d times; the record the crash landed was created again", seen["person/p-1"])
+	}
+	if len(seen) != 4 {
+		t.Errorf("distinct records = %d (%v), want the same 4 an uninterrupted run lands", len(seen), seen)
+	}
+}
+
+// The checkpoint advances only AFTER a row lands, so a crash on the
+// FIRST row leaves it at zero — and a re-created run (a fresh bundle
+// upload, a re-sealed snapshot) also starts at zero with the previous
+// attempt's orphans still on disk. Gating the repair on the checkpoint
+// therefore skipped it in exactly the cases it exists for.
+func TestTheRepairRunsEvenWhenNoCheckpointWasEverRecorded(t *testing.T) {
+	src := twoObjectSource()
+	w := newFakeWriters()
+	w.failAt, w.failAfterCreate = 1, true // the very first row: checkpoint never moves
+	runs := newFakeRuns()
+	e := &Engine{runs: runs, w: w}
+
+	if _, err := e.Run(context.Background(), RunID{}, src); err == nil {
+		t.Fatal("Run must surface the injected crash")
+	}
+	if runs.run.Checkpoint != 0 {
+		t.Fatalf("checkpoint = %d, want 0 — this test is only meaningful at the boundary", runs.run.Checkpoint)
+	}
+
+	runs.run.Status = StatusRunning
+	w.failAt, w.failAfterCreate = 0, false
+	if _, err := e.Run(context.Background(), RunID{}, src); err != nil {
+		t.Fatalf("resumed Run: %v", err)
+	}
+	if w.reconciles == 0 {
+		t.Error("a zero checkpoint skipped the repair; the first record of every attempt was left duplicable")
+	}
+	seen := map[string]int{}
+	for _, k := range w.ensured {
+		seen[k]++
+	}
+	for key, n := range seen {
+		if n != 1 {
+			t.Errorf("%s was written %d times; the record the crash landed was created again", key, n)
+		}
 	}
 }

--- a/backend/internal/modules/migration/run.go
+++ b/backend/internal/modules/migration/run.go
@@ -243,6 +243,46 @@ func (s *RunStore) RecordIdentity(ctx context.Context, runID RunID, sourceSystem
 	})
 }
 
+// IdentityPair is one source-record → native-record binding.
+type IdentityPair struct {
+	ExternalID string
+	NativeID   ids.UUID
+}
+
+// RecordIdentities records many bindings in one statement, for the
+// resume-time repair that adopts records a crashed attempt created but
+// never got to map. Same conflict rule as RecordIdentity: an existing
+// binding stands, so repairing twice is a no-op and a binding this run
+// already holds is never overwritten.
+func (s *RunStore) RecordIdentities(ctx context.Context, runID RunID, sourceSystem, object string, pairs []IdentityPair) error {
+	if err := auth.Require(ctx, importRunObject, principal.ActionCreate); err != nil {
+		return err
+	}
+	if len(pairs) == 0 {
+		return nil
+	}
+	externals := make([]string, len(pairs))
+	natives := make([]ids.UUID, len(pairs))
+	for i, p := range pairs {
+		externals[i], natives[i] = p.ExternalID, p.NativeID
+	}
+	return s.tx(ctx, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `
+			INSERT INTO import_record_map (workspace_id, source_system, object, external_id, native_id, import_run_id)
+			SELECT NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, e, n, $5
+			FROM unnest($3::text[], $4::uuid[]) AS t(e, n)
+			ON CONFLICT (workspace_id, source_system, object, external_id) DO NOTHING`,
+			sourceSystem, object, externals, natives, runID)
+		if storekit.IsForeignKeyViolation(err) {
+			return fmt.Errorf("import run %s: %w", runID, apperrors.ErrNotFound)
+		}
+		if err != nil {
+			return fmt.Errorf("migration: recording %d %s identities: %w", len(pairs), object, err)
+		}
+		return nil
+	})
+}
+
 // FlipImportLiveness reports whether a flip import is ACTUALLY in
 // flight, for the overlay module's Disconnect probe.
 //

--- a/backend/internal/modules/people/mapping.go
+++ b/backend/internal/modules/people/mapping.go
@@ -56,6 +56,9 @@ func personCreateInput(req crmcontracts.CreatePersonRequest) (CreatePersonInput,
 	if req.FullName == "" {
 		return CreatePersonInput{}, &RequiredFieldError{Field: "full_name"}
 	}
+	if err := provenance.Refuse("source", req.Source); err != nil {
+		return CreatePersonInput{}, err
+	}
 	in := CreatePersonInput{
 		FullName:  req.FullName,
 		FirstName: req.FirstName,
@@ -125,6 +128,9 @@ func organizationCreateInput(req crmcontracts.CreateOrganizationRequest) (Create
 	if req.DisplayName == "" {
 		return CreateOrganizationInput{}, &RequiredFieldError{Field: "display_name"}
 	}
+	if err := provenance.Refuse("source", req.Source); err != nil {
+		return CreateOrganizationInput{}, err
+	}
 	in := CreateOrganizationInput{
 		DisplayName:  req.DisplayName,
 		LegalName:    req.LegalName,
@@ -178,19 +184,6 @@ func organizationUpdateInput(req crmcontracts.UpdateOrganizationRequest, ifVersi
 	return in
 }
 
-// ReservedSourceSystemError refuses a client write into the importer's
-// source-system namespace. Maps to 422.
-type ReservedSourceSystemError struct{ Value string }
-
-func (e *ReservedSourceSystemError) Error() string {
-	return "source_system " + e.Value + " is reserved for imports"
-}
-
-// FieldFault refuses a client write into the importer's namespace as caller-fixable.
-func (e *ReservedSourceSystemError) FieldFault() (field, code, message string) {
-	return "source_system", "reserved_source_system", e.Error()
-}
-
 // leadCreateInput maps the create wire onto the store input, refusing a
 // client write into the importer's source-system namespace: the lead
 // store keys its idempotent replay on (source_system, source_id), so a
@@ -199,8 +192,13 @@ func (e *ReservedSourceSystemError) FieldFault() (field, code, message string) {
 // already existing — suppressing the real record. The importer writes
 // that namespace from inside the process, never through this mapper.
 func leadCreateInput(req crmcontracts.CreateLeadRequest) (CreateLeadInput, error) {
-	if req.SourceSystem != nil && provenance.ReservedSourceSystem(*req.SourceSystem) {
-		return CreateLeadInput{}, &ReservedSourceSystemError{Value: *req.SourceSystem}
+	if req.SourceSystem != nil {
+		if err := provenance.Refuse("source_system", *req.SourceSystem); err != nil {
+			return CreateLeadInput{}, err
+		}
+	}
+	if err := provenance.Refuse("source", req.Source); err != nil {
+		return CreateLeadInput{}, err
 	}
 	in := CreateLeadInput{
 		FullName:        req.FullName,

--- a/backend/internal/modules/people/mapping_reservedsource_test.go
+++ b/backend/internal/modules/people/mapping_reservedsource_test.go
@@ -3,18 +3,21 @@
 
 package people
 
-// The importer's source-system namespace is a security boundary, and
-// this mapper is where it is enforced: the lead store keys its
-// idempotent replay on (source_system, source_id), so a client able to
-// spell the reserved prefix could pre-plant a row under an incumbent
-// record id and have a later import hand it back as already existing —
-// suppressing the real record.
+// The importer's provenance namespace is a security boundary, and these
+// mappers are where it is enforced. Two distinct things depend on it:
+// the lead store keys its idempotent replay on (source_system,
+// source_id), so a client able to spell the reserved prefix could
+// pre-plant a row under an incumbent record id and have a later import
+// hand it back as already existing; and the flip's crash repair reads
+// `source` back to recognize records it created but had not yet mapped,
+// which is only safe while nothing else can write that prefix.
 
 import (
 	"errors"
 	"testing"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/provenance"
 )
 
 func TestLeadCreateInputRefusesTheImporterNamespace(t *testing.T) {
@@ -22,9 +25,9 @@ func TestLeadCreateInputRefusesTheImporterNamespace(t *testing.T) {
 	_, err := leadCreateInput(crmcontracts.CreateLeadRequest{
 		SourceSystem: &reserved, SourceId: ptr("501"),
 	})
-	var refused *ReservedSourceSystemError
+	var refused *provenance.ReservedError
 	if !errors.As(err, &refused) {
-		t.Fatalf("err = %v, want ReservedSourceSystemError — a client must not write the importer's namespace", err)
+		t.Fatalf("err = %v, want provenance.ReservedError — a client must not write the importer's namespace", err)
 	}
 	if refused.Value != reserved {
 		t.Errorf("refusal names %q, want the offending value", refused.Value)
@@ -41,6 +44,45 @@ func TestLeadCreateInputAcceptsAnOrdinarySourceSystem(t *testing.T) {
 	}
 	if in.SourceSystem == nil || *in.SourceSystem != ordinary {
 		t.Errorf("SourceSystem = %v, want it carried through", in.SourceSystem)
+	}
+}
+
+// EVERY create wire that accepts provenance refuses the namespace. The
+// flip stamps `source` inside it on persons, organizations and deals —
+// classes with no (source_system, source_id) replay key — so a gap in
+// any one of these lets a planted row be adopted as the importer's own.
+func TestEveryProvenanceWireRefusesTheImporterNamespace(t *testing.T) {
+	const reserved = "mirror:hubspot:person:p-1"
+	var refused *provenance.ReservedError
+
+	if _, err := personCreateInput(crmcontracts.CreatePersonRequest{
+		FullName: "Planted", Source: reserved,
+	}); !errors.As(err, &refused) {
+		t.Errorf("person: err = %v, want the namespace refused", err)
+	}
+	if _, err := organizationCreateInput(crmcontracts.CreateOrganizationRequest{
+		DisplayName: "Planted", Source: reserved,
+	}); !errors.As(err, &refused) {
+		t.Errorf("organization: err = %v, want the namespace refused", err)
+	}
+	if _, err := leadCreateInput(crmcontracts.CreateLeadRequest{
+		FullName: ptr("Planted"), Source: reserved,
+	}); !errors.As(err, &refused) {
+		t.Errorf("lead source: err = %v, want the namespace refused", err)
+	}
+
+	// The refusal names the field it arrived on, because the two are
+	// different wire fields and the caller has to know which to change.
+	if refused != nil && refused.Field != "source" {
+		t.Errorf("refusal names field %q, want source", refused.Field)
+	}
+
+	// An ordinary provenance string stays writable — the guard is a
+	// prefix rule, not a ban on the field.
+	if _, err := personCreateInput(crmcontracts.CreatePersonRequest{
+		FullName: "Real", Source: "hubspot:person:p-1",
+	}); err != nil {
+		t.Errorf("an ordinary source must stay writable: %v", err)
 	}
 }
 

--- a/backend/internal/shared/kernel/provenance/importnamespace.go
+++ b/backend/internal/shared/kernel/provenance/importnamespace.go
@@ -24,3 +24,32 @@ const ReservedSourceSystemPrefix = "mirror:"
 func ReservedSourceSystem(sourceSystem string) bool {
 	return strings.HasPrefix(sourceSystem, ReservedSourceSystemPrefix)
 }
+
+// ReservedError refuses a client write into the importer's namespace,
+// naming the field it arrived on. One type rather than one per module:
+// the rule is a single invariant — no client-facing path may write this
+// namespace — and three copies of it would be three places for the next
+// provenance field to be forgotten.
+type ReservedError struct{ Field, Value string }
+
+func (e *ReservedError) Error() string {
+	return e.Field + " " + e.Value + " is reserved for imports; omit it or use a value outside the " + ReservedSourceSystemPrefix + " namespace"
+}
+
+// FieldFault states the refusal as caller-fixable, which is how it
+// reaches every surface — the HTTP mapper and the MCP tool surface both
+// read this rather than each module restating it.
+func (e *ReservedError) FieldFault() (field, code, message string) {
+	return e.Field, "reserved_source_system", e.Error()
+}
+
+// Refuse guards ONE provenance field on a create wire. The flip stamps
+// its own writes inside this namespace and reads them back to recognize
+// records a crashed attempt landed, which is safe only while nothing
+// else can spell the prefix.
+func Refuse(field, value string) error {
+	if ReservedSourceSystem(value) {
+		return &ReservedError{Field: field, Value: value}
+	}
+	return nil
+}

--- a/backend/internal/shared/kernel/provenance/importnamespace_test.go
+++ b/backend/internal/shared/kernel/provenance/importnamespace_test.go
@@ -4,8 +4,11 @@
 package provenance_test
 
 import (
+	"errors"
+	"strings"
 	"testing"
 
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/provenance"
 )
 
@@ -22,5 +25,47 @@ func TestReservedSourceSystem(t *testing.T) {
 		if provenance.ReservedSourceSystem(allowed) {
 			t.Errorf("%q is an ordinary source system and must stay writable", allowed)
 		}
+	}
+}
+
+func TestRefuseNamesTheFieldAndLetsOrdinaryValuesThrough(t *testing.T) {
+	err := provenance.Refuse("source", provenance.ReservedSourceSystemPrefix+"hubspot:person:p-1")
+	var reserved *provenance.ReservedError
+	if !errors.As(err, &reserved) {
+		t.Fatalf("err = %v, want ReservedError — a client write into the import namespace must be refused", err)
+	}
+	if reserved.Field != "source" {
+		t.Errorf("refusal names field %q, want the one it arrived on; the caller has to know which to change", reserved.Field)
+	}
+	if !strings.Contains(reserved.Error(), "source") || !strings.Contains(reserved.Error(), "reserved") {
+		t.Errorf("message %q says neither the field nor why", reserved.Error())
+	}
+	// The guard is a prefix rule, not a ban: ordinary provenance — and an
+	// empty one — stay writable, or every create wire would break.
+	for _, ordinary := range []string{"", "hubspot", "hubspot:person:p-1", "mirrorless"} {
+		if err := provenance.Refuse("source", ordinary); err != nil {
+			t.Errorf("Refuse(%q) = %v, want nil", ordinary, err)
+		}
+	}
+}
+
+func TestReservedErrorStatesItselfAsCallerFixable(t *testing.T) {
+	// Implementing apperrors.FieldFault is what carries this refusal to
+	// the caller as a 422 naming the field — on the HTTP surface AND on
+	// the MCP tool surface, neither of which knows this type. Without it
+	// the refusal degrades to an opaque internal fault telling the caller
+	// to retry something that will never succeed.
+	var fault apperrors.FieldFault = &provenance.ReservedError{
+		Field: "source", Value: "mirror:hubspot:person:p-1",
+	}
+	field, code, message := fault.FieldFault()
+	if field != "source" {
+		t.Errorf("field = %q, want the one the value arrived on", field)
+	}
+	if code != "reserved_source_system" {
+		t.Errorf("code = %q, want the contract's machine code", code)
+	}
+	if !strings.Contains(message, "reserved") || !strings.Contains(message, provenance.ReservedSourceSystemPrefix) {
+		t.Errorf("message %q must say what is wrong and which namespace to avoid", message)
 	}
 }


### PR DESCRIPTION
Closes the first and highest-value item of #336, found in the review of #320.

## The defect

A record lands in two steps that are **not** one transaction: the owning module store writes the native row under its own write shape (domain row + audit + outbox), then the engine's identity map records what that external id became. `Exists` reads the identity map, so a process that died between the two steps left a record nothing could recognize — and the resumed run created it again. In a one-way cutover that is a duplicate nobody asked for and nothing removes.

## Why not just use one transaction

That was the obvious fix and it is the wrong shape here: it means a module store accepting an externally-owned transaction, across three modules, which is exactly the boundary ADR-0054 draws. The alternative makes the crash *repairable* instead, using an invariant the cutover already relies on.

## The approach

The flip previously stamped `source` with a value a client could also write — which is precisely why the identity map had to be the sole authority on "already imported" (a caller could otherwise pre-plant a row under a guessed incumbent id and have the flip treat the real record as already handled).

It now stamps `source` inside the **reserved import namespace**, and every create wire that accepts provenance refuses that namespace. `person`, `organization` and `deal` join the `lead` and `activity` paths that already guarded it — the last three matter most here, because they have no `(source_system, source_id)` replay key and `source` is the only provenance they carry.

With that closed, a native row bearing the prefix can only be this importer's own work. So a resumed run opens by adopting rows that carry its prefix and are not yet mapped. It runs **only** on resume — a first attempt has nothing to adopt and should not pay five table scans to discover that.

## Testing

`TestAResumeAdoptsRecordsTheCrashLandedButNeverMapped` reproduces the exact process death (record landed, identity write lost) and asserts the resumed run writes it once. Verified to fail against the unfixed code — without the repair it reports `person/p-1 was written 2 times`.

The engine's fake writer now models the two steps as separate state. With a single map it could not express "landed but never recorded", so the defect would have passed the suite untouched — which is how it survived eleven review rounds on #320.

`TestEveryProvenanceWireRefusesTheImporterNamespace` covers all five wires as one rule rather than per-call-site, and the deals module gets its own guard and test.

Gates green: `make check`, and `make test-integration` at 0 skips across 29 packages (at `INTEGRATION_JOBS=2`; the machine hits `out of shared memory` in unrelated fixture setup at 4).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops a resumed flip from creating duplicates by adopting previously landed, unmapped rows marked with a reserved provenance prefix; the repair runs at the start of every attempt (even with a zero checkpoint), only adopts live rows, and finishes closing adopted deals when needed. Closes #336 items 1 and 8.

- **Bug Fixes**
  - Added early `ReconcileIdentities` that runs unconditionally, adopts rows stamped with `mirror:` and missing from the identity map, skips archived/merged rows, rejects ambiguous external IDs, uses `starts_with`, extracts the external ID once, and enforces a class allowlist.
  - Adopted deals are closed only if the incumbent is terminal and the native status is still open; the check now uses `deals.DealStatus` (type-safe) and remains idempotent on replay.
  - Flip stamps `source` with the reserved `mirror:` prefix; all create wires refuse that namespace on `source` and `source_system` with 422 field errors, while ordinary provenance values remain allowed; integration queries updated to `mirror:`.

- **Refactors**
  - Centralized reserved-namespace enforcement in `provenance` (`Refuse`, `ReservedError`); added bulk `RecordIdentities`; updated the `Writers` interface and engine to invoke reconciliation once per attempt.
  - Tests cover zero-checkpoint runs, the live-row rule, prefix strictness, the class allowlist, the deal-close rule, and adoption/finishing of half-landed deals.

<sup>Written for commit 7cfe20150636f2d22d5661fd1c32909454273a31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/338?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added native deal importing with names, amounts, close dates, owners, currencies, and deal stages.
  - Imported closed deals now retain their closed or lost status and relevant details.
  - Interrupted imports can resume without duplicating records or losing identity mappings.
  - Existing deals are safely adopted and finalized after interrupted imports.

- **Bug Fixes**
  - Prevented client-provided values from using the reserved importer provenance namespace.
  - Improved recovery of deals whose closing process was interrupted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->