### PR TITLE
fix(automation): give back the check-in reminders nothing will re-mint

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -42,6 +42,26 @@ group, the narrowed reminder semantics (open-deal or active-lead eligibility
 plus an N-day creation grace), and the answer-shape rule that ids belong in
 evidence and never in prose.
 
+**#333 merged, then needed #341 behind it.** Migration 0148 archives every
+outstanding generated check-in reminder and justifies itself with "the
+corrected scan re-mints the ones still deserved" — which holds only where the
+reminder automation still runs, and it never checked. A workspace that paused
+`no_activity_reminder` or `check_in_cadence` had its reminders archived with
+nothing to bring them back, and 0148's down is a no-op. 0149 restores exactly
+the unrepeatable rows, pairing each task's wording with the automation that
+mints it (the two write different subjects, and a workspace can run one while
+the other is paused).
+
+The rule that arc produced, worth carrying: **a destructive migration that
+relies on something else to put things back has to state the condition that
+something else runs under, and check it.** Both stop-gate findings against
+0148/0149 were the same defect at different granularity — first "assumes the
+automation exists", then "checks the wrong one".
+
+Also learned the hard way: `make check-fe` does NOT run the Playwright screen
+tests (`make frontend-e2e` does, and those specs assert **German**), so a
+user-visible string change can pass the local gate and fail CI.
+
 **Every company now wears its face (#330).** The A55 logo lane resolves a
 company's mark from the site the deep read already crawls — og:image, then the
 declared icons, then `/favicon.ico` — normalizes it once to a square PNG at
@@ -58,7 +78,9 @@ Three things it left open, in priority order:
 - **Nothing purges a logo object**, because nothing hard-deletes an
   organization row. The key is on the row (`organization.logo_object_key`), so
   the sweep is there to write the day organizations gain a hard delete or the
-  retention evaluator reaches them.
+  retention evaluator reaches them. Raised upstream as foundation #1216 —
+  the policy (is a logo a retention class, what is the floor, what happens on
+  merge) is the spec's call before the sweep is written.
 - **The reclaim of a superseded logo can race a reader** that took the old key
   microseconds earlier: one monogram on one render, self-healing next load.
   The offer-PDF path makes the same trade.
@@ -647,6 +669,22 @@ caused confusion in commits and comments. These are raised against
 `gradionhq/margince-foundation`, never worked around here, and never edited from
 this build repo.
 
+- **Art. 17 erasure has no organization path (foundation #1215).** `Eraser` in
+  `privacy/erasure.go` anonymizes the `person` row and purges its satellites;
+  grep `organization` there and it finds nothing, on the standard reading that
+  an organization is a legal person. A sole trader is not: their
+  `organization` row carries `display_name`, `legal_name`, `address`, `raw` and
+  the logo, and it survives an erasure that certified them gone. The spec has to
+  answer what marks a natural-person organization, what erasure does to it, how
+  a request reaches it (through the person relationship, never through
+  `organization_domain`), and whether `sarSections()` owes the row on the Art. 15
+  side too. Nothing is built against a guess.
+- **Nothing reclaims an organization logo object (foundation #1216).** The
+  superseded-write case is handled (`supersededObject()` hands the orphaned key
+  back under the row lock); archive and merge are not, because neither stops the
+  row referencing the key. Operational, not legal — unbounded storage growth over
+  the installation's life. The retention evaluator already holds a
+  `blobstore.Store`, so only the policy is missing.
 - **The backfill's live-progress columns and seam** — two raises from
   `feat/backfill-live-progress` (#307), which made a running backfill page
   report progress per message instead of only at page commit. CAP-DDL-4's

--- a/backend/internal/compose/integration/checkin_reminder_restore_integration_test.go
+++ b/backend/internal/compose/integration/checkin_reminder_restore_integration_test.go
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// Migration 0149, proven against a real migrated Postgres: which of the
+// reminders 0148 archived are given back, and which stay archived.
+//
+// 0148 archives every outstanding generated check-in task and justifies it
+// with "the corrected scan re-mints the ones still deserved" — a claim that
+// holds only where the reminder automation still runs. These suites pin the
+// three answers that follow: a workspace that paused it gets its reminders
+// back, a task somebody had taken over comes back whatever the workspace
+// does, and a row 0148 never touched is left alone.
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// 0148 archives every outstanding generated reminder on the reasoning that the
+// corrected scan re-mints the ones that are still deserved. That holds only
+// where the automation still runs, and 0148 never checked. 0149 gives back the
+// rows nothing will bring back on its own.
+
+// seedReminderAutomation inserts one clock automation in the given enabled
+// state, so a suite can express "this workspace still runs reminders" and
+// "this workspace paused them".
+func seedReminderAutomation(t *testing.T, owner *pgx.Conn, ws ids.UUID, key string, enabled bool) {
+	t.Helper()
+	if _, err := owner.Exec(context.Background(),
+		`INSERT INTO automation (id, workspace_id, key, name, trigger, action, params, enabled)
+		 VALUES ($1, $2, $3, $3, '{"schedule":"clock"}', '{"kind":"create_task"}', '{}'::jsonb, $4)`,
+		ids.NewV7(), ws, key, enabled); err != nil {
+		t.Fatalf("seeding the %s automation (enabled=%v): %v", key, enabled, err)
+	}
+}
+
+// seedUser inserts one workspace member, so a task can be assigned to a real
+// row (assignee_id carries a foreign key).
+func seedUser(t *testing.T, owner *pgx.Conn, ws ids.UUID) ids.UUID {
+	t.Helper()
+	id := ids.NewV7()
+	if _, err := owner.Exec(context.Background(),
+		`INSERT INTO app_user (id, workspace_id, email, display_name)
+		 VALUES ($1, $2, $3, 'Reminder Owner')`,
+		id, ws, fmt.Sprintf("owner-%s@restore.test", id)); err != nil {
+		t.Fatalf("seeding the workspace member: %v", err)
+	}
+	return id
+}
+
+// assignTo makes a generated task somebody's own work, the way a person does
+// by picking it up. The generated task carries no assignee, so this column
+// having a value is what says a human took it over.
+func assignTo(t *testing.T, owner *pgx.Conn, id, user ids.UUID) {
+	t.Helper()
+	if _, err := owner.Exec(context.Background(),
+		`UPDATE activity SET assignee_id = $2 WHERE id = $1`, id, user); err != nil {
+		t.Fatalf("assigning task %s: %v", id, err)
+	}
+}
+
+// remindMeAt is the other mark of a person having adopted a task: they asked
+// to be reminded about it. The generated task carries no remind_at either.
+func remindMeAt(t *testing.T, owner *pgx.Conn, id ids.UUID, when time.Time) {
+	t.Helper()
+	if _, err := owner.Exec(context.Background(),
+		`UPDATE activity SET remind_at = $2 WHERE id = $1`, id, when); err != nil {
+		t.Fatalf("setting a reminder on task %s: %v", id, err)
+	}
+}
+
+func TestTheRestoreGivesBackRemindersNothingWillReMint(t *testing.T) {
+	e := Setup(t)
+	owner := OwnerConn(t)
+
+	// This workspace paused its reminders, so the corrected scan never runs
+	// here and 0148's re-mint argument does not apply to a single row.
+	seedReminderAutomation(t, owner, e.WS, "no_activity_reminder", false)
+	stranded := seedTaskRow(t, owner, e.WS,
+		"Check in — no activity since 2026-06-16", "system", false)
+	strandedCadence := seedTaskRow(t, owner, e.WS,
+		"Time for a check-in — last touched 2026-06-16", "system", false)
+
+	applyCleanupMigration(t, owner)
+	for _, id := range []ids.UUID{stranded, strandedCadence} {
+		if !isArchived(t, owner, id) {
+			t.Fatalf("0148 did not archive %s, so this suite is not testing what it claims", id)
+		}
+	}
+
+	applyRestoreMigration(t, owner)
+	for _, id := range []ids.UUID{stranded, strandedCadence} {
+		if isArchived(t, owner, id) {
+			t.Errorf("reminder %s stayed archived in a workspace whose automation is paused — nothing will ever mint it again", id)
+		}
+	}
+}
+
+func TestTheRestoreGivesBackAReminderSomebodyHadTakenOver(t *testing.T) {
+	e := Setup(t)
+	owner := OwnerConn(t)
+
+	// Reminders DO still run here, so 0148's re-mint argument holds for an
+	// untouched row — but a re-mint is a new row, without the assignee or the
+	// date the person chose.
+	seedReminderAutomation(t, owner, e.WS, "no_activity_reminder", true)
+	assigned := seedTaskRow(t, owner, e.WS,
+		"Check in — no activity since 2026-06-16", "system", false)
+	reminded := seedTaskRow(t, owner, e.WS,
+		"Check in — no activity since 2026-06-16", "system", false)
+	untouched := seedTaskRow(t, owner, e.WS,
+		"Check in — no activity since 2026-06-16", "system", false)
+	assignTo(t, owner, assigned, seedUser(t, owner, e.WS))
+	remindMeAt(t, owner, reminded, quietSince)
+
+	applyCleanupMigration(t, owner)
+	// Without this the assertions below pass vacuously: a row 0148 never
+	// archived also reads "not archived" after the restore, and the suite
+	// would be green while 0149 did nothing at all.
+	for _, id := range []ids.UUID{assigned, reminded, untouched} {
+		if !isArchived(t, owner, id) {
+			t.Fatalf("0148 did not archive %s, so this suite is not testing what it claims", id)
+		}
+	}
+	applyRestoreMigration(t, owner)
+
+	if isArchived(t, owner, assigned) {
+		t.Error("a reminder assigned to somebody stayed archived; the re-mint would not carry the assignee")
+	}
+	if isArchived(t, owner, reminded) {
+		t.Error("a reminder somebody set a reminder on stayed archived; the re-mint would not carry the date they chose")
+	}
+	// The whole point of 0148 stands for a row the scan will genuinely
+	// reconsider: it stays archived rather than coming back twice.
+	if !isArchived(t, owner, untouched) {
+		t.Error("an untouched reminder in a live workspace came back, so the corrected scan will mint a duplicate beside it")
+	}
+}
+
+// A reminder archived BEFORE 0148 is not 0148's to give back. 0148 only
+// touched rows that were still live (archived_at IS NULL), so it never saw
+// this one — whoever archived it, for whatever reason, meant it.
+//
+// This is why the ledger instant is the discriminator and the audit log is
+// not: a row archived earlier by any path that wrote no audit entry is
+// indistinguishable from 0148's own work under an audit-based test.
+func TestTheRestoreLeavesARowArchivedBefore0148Alone(t *testing.T) {
+	e := Setup(t)
+	owner := OwnerConn(t)
+
+	// Paused, so the "nothing will re-mint it" arm is satisfied and only the
+	// provenance check can keep this row archived.
+	seedReminderAutomation(t, owner, e.WS, "no_activity_reminder", false)
+	earlier := seedTaskRow(t, owner, e.WS,
+		"Check in — no activity since 2026-06-16", "system", false)
+	if _, err := owner.Exec(context.Background(),
+		`UPDATE activity SET archived_at = now() - interval '1 day' WHERE id = $1`,
+		earlier); err != nil {
+		t.Fatalf("archiving the task ahead of 0148: %v", err)
+	}
+
+	// 0148 runs now and skips it — it is already archived.
+	applyCleanupMigration(t, owner)
+	applyRestoreMigration(t, owner)
+
+	if !isArchived(t, owner, earlier) {
+		t.Error("a reminder archived before 0148 ran was handed back; 0148 never took it away")
+	}
+}
+
+func TestTheRestorePairsEachReminderWithItsOwnAutomation(t *testing.T) {
+	e := Setup(t)
+	owner := OwnerConn(t)
+
+	seedReminderAutomation(t, owner, e.WS, "no_activity_reminder", true)
+	seedReminderAutomation(t, owner, e.WS, "check_in_cadence", false)
+	live := seedTaskRow(t, owner, e.WS,
+		"Check in — no activity since 2026-06-16", "system", false)
+	stranded := seedTaskRow(t, owner, e.WS,
+		"Time for a check-in — last touched 2026-06-16", "system", false)
+
+	applyCleanupMigration(t, owner)
+	// Same guard as its siblings: "stranded came back" only means anything
+	// once 0148 has been shown to have taken it away.
+	for _, id := range []ids.UUID{live, stranded} {
+		if !isArchived(t, owner, id) {
+			t.Fatalf("0148 did not archive %s, so this suite is not testing what it claims", id)
+		}
+	}
+	applyRestoreMigration(t, owner)
+
+	if !isArchived(t, owner, live) {
+		t.Error("a reminder whose own automation still runs came back; the scan will mint a duplicate beside it")
+	}
+	if isArchived(t, owner, stranded) {
+		t.Error("a cadence reminder stayed archived while only the OTHER automation runs — nothing will ever mint it again")
+	}
+}

--- a/backend/internal/compose/integration/no_activity_eligibility_integration_test.go
+++ b/backend/internal/compose/integration/no_activity_eligibility_integration_test.go
@@ -556,3 +556,28 @@ func TestTheRestoreLeavesADeliberateHumanArchiveAlone(t *testing.T) {
 		t.Error("a reminder a person deliberately archived was handed back to them")
 	}
 }
+
+// The two reminder automations write different tasks, and a workspace can run
+// one while the other is paused. Asking only whether EITHER is enabled leaves
+// the paused one's tasks archived with nothing to bring them back.
+func TestTheRestorePairsEachReminderWithItsOwnAutomation(t *testing.T) {
+	e := Setup(t)
+	owner := OwnerConn(t)
+
+	seedReminderAutomation(t, owner, e.WS, "no_activity_reminder", true)
+	seedReminderAutomation(t, owner, e.WS, "check_in_cadence", false)
+	live := seedTaskRow(t, owner, e.WS,
+		"Check in — no activity since 2026-06-16", "system", false)
+	stranded := seedTaskRow(t, owner, e.WS,
+		"Time for a check-in — last touched 2026-06-16", "system", false)
+
+	applyCleanupMigration(t, owner)
+	applyRestoreMigration(t, owner)
+
+	if !isArchived(t, owner, live) {
+		t.Error("a reminder whose own automation still runs came back; the scan will mint a duplicate beside it")
+	}
+	if isArchived(t, owner, stranded) {
+		t.Error("a cadence reminder stayed archived while only the OTHER automation runs — nothing will ever mint it again")
+	}
+}

--- a/backend/internal/compose/integration/no_activity_eligibility_integration_test.go
+++ b/backend/internal/compose/integration/no_activity_eligibility_integration_test.go
@@ -24,6 +24,7 @@ package integration
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"log/slog"
 	"testing"
@@ -384,7 +385,21 @@ func seedTaskRow(t *testing.T, owner *pgx.Conn, ws ids.UUID, subject, source str
 // namespace rather than restated here.
 func applyCleanupMigration(t *testing.T, owner *pgx.Conn) {
 	t.Helper()
-	const version = "0148"
+	applyCoreMigration(t, owner, "0148")
+}
+
+// applyRestoreMigration runs the shipped 0149 up-migration, which gives back
+// the reminders 0148 archived that nothing in the workspace will re-mint.
+func applyRestoreMigration(t *testing.T, owner *pgx.Conn) {
+	t.Helper()
+	applyCoreMigration(t, owner, "0149")
+}
+
+// applyCoreMigration runs one shipped core migration's own SQL against the
+// fixture rows, loaded from the embedded namespace rather than restated here —
+// the migration is what these suites assert on.
+func applyCoreMigration(t *testing.T, owner *pgx.Conn, version string) {
+	t.Helper()
 	core, err := migrations.Core()
 	if err != nil {
 		t.Fatalf("loading the core migration namespace: %v", err)
@@ -410,4 +425,134 @@ func isArchived(t *testing.T, owner *pgx.Conn, id ids.UUID) bool {
 		t.Fatalf("reading the archival state of activity %s: %v", id, err)
 	}
 	return archived
+}
+
+// 0148 archives every outstanding generated reminder on the reasoning that the
+// corrected scan re-mints the ones that are still deserved. That holds only
+// where the automation still runs, and 0148 never checked. 0149 gives back the
+// rows nothing will bring back on its own.
+
+// seedReminderAutomation inserts one clock automation in the given enabled
+// state, so a suite can express "this workspace still runs reminders" and
+// "this workspace paused them".
+func seedReminderAutomation(t *testing.T, owner *pgx.Conn, ws ids.UUID, key string, enabled bool) {
+	t.Helper()
+	if _, err := owner.Exec(context.Background(),
+		`INSERT INTO automation (id, workspace_id, key, name, trigger, action, params, enabled)
+		 VALUES ($1, $2, $3, $3, '{"schedule":"clock"}', '{"kind":"create_task"}', '{}'::jsonb, $4)`,
+		ids.NewV7(), ws, key, enabled); err != nil {
+		t.Fatalf("seeding the %s automation (enabled=%v): %v", key, enabled, err)
+	}
+}
+
+// seedUser inserts one workspace member, so a task can be assigned to a real
+// row (assignee_id carries a foreign key).
+func seedUser(t *testing.T, owner *pgx.Conn, ws ids.UUID) ids.UUID {
+	t.Helper()
+	id := ids.NewV7()
+	if _, err := owner.Exec(context.Background(),
+		`INSERT INTO app_user (id, workspace_id, email, display_name)
+		 VALUES ($1, $2, $3, 'Reminder Owner')`,
+		id, ws, fmt.Sprintf("owner-%s@restore.test", id)); err != nil {
+		t.Fatalf("seeding the workspace member: %v", err)
+	}
+	return id
+}
+
+// adopt makes a generated task somebody's own work, the way a person does:
+// assigning it, or setting a reminder on it.
+func adopt(t *testing.T, owner *pgx.Conn, id ids.UUID, column string, value any) {
+	t.Helper()
+	if _, err := owner.Exec(context.Background(),
+		`UPDATE activity SET `+column+` = $2 WHERE id = $1`, id, value); err != nil {
+		t.Fatalf("setting %s on task %s: %v", column, id, err)
+	}
+}
+
+func TestTheRestoreGivesBackRemindersNothingWillReMint(t *testing.T) {
+	e := Setup(t)
+	owner := OwnerConn(t)
+
+	// This workspace paused its reminders, so the corrected scan never runs
+	// here and 0148's re-mint argument does not apply to a single row.
+	seedReminderAutomation(t, owner, e.WS, "no_activity_reminder", false)
+	stranded := seedTaskRow(t, owner, e.WS,
+		"Check in — no activity since 2026-06-16", "system", false)
+	strandedCadence := seedTaskRow(t, owner, e.WS,
+		"Time for a check-in — last touched 2026-06-16", "system", false)
+
+	applyCleanupMigration(t, owner)
+	for _, id := range []ids.UUID{stranded, strandedCadence} {
+		if !isArchived(t, owner, id) {
+			t.Fatalf("0148 did not archive %s, so this suite is not testing what it claims", id)
+		}
+	}
+
+	applyRestoreMigration(t, owner)
+	for _, id := range []ids.UUID{stranded, strandedCadence} {
+		if isArchived(t, owner, id) {
+			t.Errorf("reminder %s stayed archived in a workspace whose automation is paused — nothing will ever mint it again", id)
+		}
+	}
+}
+
+func TestTheRestoreGivesBackAReminderSomebodyHadTakenOver(t *testing.T) {
+	e := Setup(t)
+	owner := OwnerConn(t)
+
+	// Reminders DO still run here, so 0148's re-mint argument holds for an
+	// untouched row — but a re-mint is a new row, without the assignee or the
+	// date the person chose.
+	seedReminderAutomation(t, owner, e.WS, "no_activity_reminder", true)
+	assigned := seedTaskRow(t, owner, e.WS,
+		"Check in — no activity since 2026-06-16", "system", false)
+	reminded := seedTaskRow(t, owner, e.WS,
+		"Check in — no activity since 2026-06-16", "system", false)
+	untouched := seedTaskRow(t, owner, e.WS,
+		"Check in — no activity since 2026-06-16", "system", false)
+	adopt(t, owner, assigned, "assignee_id", seedUser(t, owner, e.WS))
+	adopt(t, owner, reminded, "remind_at", quietSince)
+
+	applyCleanupMigration(t, owner)
+	applyRestoreMigration(t, owner)
+
+	if isArchived(t, owner, assigned) {
+		t.Error("a reminder assigned to somebody stayed archived; the re-mint would not carry the assignee")
+	}
+	if isArchived(t, owner, reminded) {
+		t.Error("a reminder somebody set a reminder on stayed archived; the re-mint would not carry the date they chose")
+	}
+	// The whole point of 0148 stands for a row the scan will genuinely
+	// reconsider: it stays archived rather than coming back twice.
+	if !isArchived(t, owner, untouched) {
+		t.Error("an untouched reminder in a live workspace came back, so the corrected scan will mint a duplicate beside it")
+	}
+}
+
+func TestTheRestoreLeavesADeliberateHumanArchiveAlone(t *testing.T) {
+	e := Setup(t)
+	owner := OwnerConn(t)
+
+	seedReminderAutomation(t, owner, e.WS, "no_activity_reminder", false)
+	dismissed := seedTaskRow(t, owner, e.WS,
+		"Check in — no activity since 2026-06-16", "system", false)
+	adopt(t, owner, dismissed, "assignee_id", seedUser(t, owner, e.WS))
+	// A person archived this one through the store, which writes the audit
+	// row 0148's raw SQL never does. That entry is what tells the two apart.
+	if _, err := owner.Exec(context.Background(),
+		`UPDATE activity SET archived_at = now() WHERE id = $1`, dismissed); err != nil {
+		t.Fatalf("archiving the task: %v", err)
+	}
+	if _, err := owner.Exec(context.Background(),
+		`INSERT INTO audit_log (workspace_id, actor_type, actor_id, action, entity_type, entity_id)
+		 VALUES ($1, 'human', 'human:x', 'archive', 'activity', $2)`,
+		e.WS, dismissed); err != nil {
+		t.Fatalf("recording the human archive: %v", err)
+	}
+
+	applyRestoreMigration(t, owner)
+
+	if !isArchived(t, owner, dismissed) {
+		t.Error("a reminder a person deliberately archived was handed back to them")
+	}
 }

--- a/backend/internal/compose/integration/no_activity_eligibility_integration_test.go
+++ b/backend/internal/compose/integration/no_activity_eligibility_integration_test.go
@@ -24,7 +24,6 @@ package integration
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"log/slog"
 	"testing"
@@ -408,8 +407,32 @@ func applyCoreMigration(t *testing.T, owner *pgx.Conn, version string) {
 		if m.Version != version {
 			continue
 		}
-		if _, err := owner.Exec(context.Background(), m.UpSQL); err != nil {
+		// One transaction for the SQL and the ledger row, exactly as dbmigrate
+		// applies it — 0149 reads schema_migrations_core.applied_at to know
+		// which rows 0148 archived, and now() is per transaction, so applying
+		// the two separately would put them at different instants and the
+		// suites below would be testing a shape production never has.
+		tx, err := owner.Begin(context.Background())
+		if err != nil {
+			t.Fatalf("opening the migration transaction: %v", err)
+		}
+		//craft:ignore swallowed-errors the rollback only runs if a Fatalf above skipped the commit; after a successful commit it is a no-op whose error says nothing, and the test has already failed in the other case
+		defer func() { _ = tx.Rollback(context.Background()) }()
+		if _, err := tx.Exec(context.Background(), m.UpSQL); err != nil {
 			t.Fatalf("applying migration %s: %v", version, err)
+		}
+		if _, err := tx.Exec(context.Background(),
+			// The template already carries this migration from the real
+			// migrator, so the ledger instant is UPDATED rather than kept:
+			// these suites re-run the SQL to archive their own fixtures, and
+			// 0149 reads applied_at to know which rows that run touched.
+			`INSERT INTO schema_migrations_core (version, name) VALUES ($1, $2)
+			 ON CONFLICT (version) DO UPDATE SET applied_at = now()`,
+			m.Version, m.Name); err != nil {
+			t.Fatalf("recording migration %s in the ledger: %v", version, err)
+		}
+		if err := tx.Commit(context.Background()); err != nil {
+			t.Fatalf("committing migration %s: %v", version, err)
 		}
 		return
 	}
@@ -425,174 +448,4 @@ func isArchived(t *testing.T, owner *pgx.Conn, id ids.UUID) bool {
 		t.Fatalf("reading the archival state of activity %s: %v", id, err)
 	}
 	return archived
-}
-
-// 0148 archives every outstanding generated reminder on the reasoning that the
-// corrected scan re-mints the ones that are still deserved. That holds only
-// where the automation still runs, and 0148 never checked. 0149 gives back the
-// rows nothing will bring back on its own.
-
-// seedReminderAutomation inserts one clock automation in the given enabled
-// state, so a suite can express "this workspace still runs reminders" and
-// "this workspace paused them".
-func seedReminderAutomation(t *testing.T, owner *pgx.Conn, ws ids.UUID, key string, enabled bool) {
-	t.Helper()
-	if _, err := owner.Exec(context.Background(),
-		`INSERT INTO automation (id, workspace_id, key, name, trigger, action, params, enabled)
-		 VALUES ($1, $2, $3, $3, '{"schedule":"clock"}', '{"kind":"create_task"}', '{}'::jsonb, $4)`,
-		ids.NewV7(), ws, key, enabled); err != nil {
-		t.Fatalf("seeding the %s automation (enabled=%v): %v", key, enabled, err)
-	}
-}
-
-// seedUser inserts one workspace member, so a task can be assigned to a real
-// row (assignee_id carries a foreign key).
-func seedUser(t *testing.T, owner *pgx.Conn, ws ids.UUID) ids.UUID {
-	t.Helper()
-	id := ids.NewV7()
-	if _, err := owner.Exec(context.Background(),
-		`INSERT INTO app_user (id, workspace_id, email, display_name)
-		 VALUES ($1, $2, $3, 'Reminder Owner')`,
-		id, ws, fmt.Sprintf("owner-%s@restore.test", id)); err != nil {
-		t.Fatalf("seeding the workspace member: %v", err)
-	}
-	return id
-}
-
-// adopt makes a generated task somebody's own work, the way a person does:
-// assigning it, or setting a reminder on it.
-func adopt(t *testing.T, owner *pgx.Conn, id ids.UUID, column string, value any) {
-	t.Helper()
-	if _, err := owner.Exec(context.Background(),
-		`UPDATE activity SET `+column+` = $2 WHERE id = $1`, id, value); err != nil {
-		t.Fatalf("setting %s on task %s: %v", column, id, err)
-	}
-}
-
-func TestTheRestoreGivesBackRemindersNothingWillReMint(t *testing.T) {
-	e := Setup(t)
-	owner := OwnerConn(t)
-
-	// This workspace paused its reminders, so the corrected scan never runs
-	// here and 0148's re-mint argument does not apply to a single row.
-	seedReminderAutomation(t, owner, e.WS, "no_activity_reminder", false)
-	stranded := seedTaskRow(t, owner, e.WS,
-		"Check in — no activity since 2026-06-16", "system", false)
-	strandedCadence := seedTaskRow(t, owner, e.WS,
-		"Time for a check-in — last touched 2026-06-16", "system", false)
-
-	applyCleanupMigration(t, owner)
-	for _, id := range []ids.UUID{stranded, strandedCadence} {
-		if !isArchived(t, owner, id) {
-			t.Fatalf("0148 did not archive %s, so this suite is not testing what it claims", id)
-		}
-	}
-
-	applyRestoreMigration(t, owner)
-	for _, id := range []ids.UUID{stranded, strandedCadence} {
-		if isArchived(t, owner, id) {
-			t.Errorf("reminder %s stayed archived in a workspace whose automation is paused — nothing will ever mint it again", id)
-		}
-	}
-}
-
-func TestTheRestoreGivesBackAReminderSomebodyHadTakenOver(t *testing.T) {
-	e := Setup(t)
-	owner := OwnerConn(t)
-
-	// Reminders DO still run here, so 0148's re-mint argument holds for an
-	// untouched row — but a re-mint is a new row, without the assignee or the
-	// date the person chose.
-	seedReminderAutomation(t, owner, e.WS, "no_activity_reminder", true)
-	assigned := seedTaskRow(t, owner, e.WS,
-		"Check in — no activity since 2026-06-16", "system", false)
-	reminded := seedTaskRow(t, owner, e.WS,
-		"Check in — no activity since 2026-06-16", "system", false)
-	untouched := seedTaskRow(t, owner, e.WS,
-		"Check in — no activity since 2026-06-16", "system", false)
-	adopt(t, owner, assigned, "assignee_id", seedUser(t, owner, e.WS))
-	adopt(t, owner, reminded, "remind_at", quietSince)
-
-	applyCleanupMigration(t, owner)
-	// Without this the assertions below pass vacuously: a row 0148 never
-	// archived also reads "not archived" after the restore, and the suite
-	// would be green while 0149 did nothing at all.
-	for _, id := range []ids.UUID{assigned, reminded, untouched} {
-		if !isArchived(t, owner, id) {
-			t.Fatalf("0148 did not archive %s, so this suite is not testing what it claims", id)
-		}
-	}
-	applyRestoreMigration(t, owner)
-
-	if isArchived(t, owner, assigned) {
-		t.Error("a reminder assigned to somebody stayed archived; the re-mint would not carry the assignee")
-	}
-	if isArchived(t, owner, reminded) {
-		t.Error("a reminder somebody set a reminder on stayed archived; the re-mint would not carry the date they chose")
-	}
-	// The whole point of 0148 stands for a row the scan will genuinely
-	// reconsider: it stays archived rather than coming back twice.
-	if !isArchived(t, owner, untouched) {
-		t.Error("an untouched reminder in a live workspace came back, so the corrected scan will mint a duplicate beside it")
-	}
-}
-
-func TestTheRestoreLeavesADeliberateHumanArchiveAlone(t *testing.T) {
-	e := Setup(t)
-	owner := OwnerConn(t)
-
-	seedReminderAutomation(t, owner, e.WS, "no_activity_reminder", false)
-	dismissed := seedTaskRow(t, owner, e.WS,
-		"Check in — no activity since 2026-06-16", "system", false)
-	adopt(t, owner, dismissed, "assignee_id", seedUser(t, owner, e.WS))
-	// A person archived this one through the store, which writes the audit
-	// row 0148's raw SQL never does. That entry is what tells the two apart.
-	if _, err := owner.Exec(context.Background(),
-		`UPDATE activity SET archived_at = now() WHERE id = $1`, dismissed); err != nil {
-		t.Fatalf("archiving the task: %v", err)
-	}
-	if _, err := owner.Exec(context.Background(),
-		`INSERT INTO audit_log (workspace_id, actor_type, actor_id, action, entity_type, entity_id)
-		 VALUES ($1, 'human', 'human:x', 'archive', 'activity', $2)`,
-		e.WS, dismissed); err != nil {
-		t.Fatalf("recording the human archive: %v", err)
-	}
-
-	applyRestoreMigration(t, owner)
-
-	if !isArchived(t, owner, dismissed) {
-		t.Error("a reminder a person deliberately archived was handed back to them")
-	}
-}
-
-// The two reminder automations write different tasks, and a workspace can run
-// one while the other is paused. Asking only whether EITHER is enabled leaves
-// the paused one's tasks archived with nothing to bring them back.
-func TestTheRestorePairsEachReminderWithItsOwnAutomation(t *testing.T) {
-	e := Setup(t)
-	owner := OwnerConn(t)
-
-	seedReminderAutomation(t, owner, e.WS, "no_activity_reminder", true)
-	seedReminderAutomation(t, owner, e.WS, "check_in_cadence", false)
-	live := seedTaskRow(t, owner, e.WS,
-		"Check in — no activity since 2026-06-16", "system", false)
-	stranded := seedTaskRow(t, owner, e.WS,
-		"Time for a check-in — last touched 2026-06-16", "system", false)
-
-	applyCleanupMigration(t, owner)
-	// Same guard as its siblings: "stranded came back" only means anything
-	// once 0148 has been shown to have taken it away.
-	for _, id := range []ids.UUID{live, stranded} {
-		if !isArchived(t, owner, id) {
-			t.Fatalf("0148 did not archive %s, so this suite is not testing what it claims", id)
-		}
-	}
-	applyRestoreMigration(t, owner)
-
-	if !isArchived(t, owner, live) {
-		t.Error("a reminder whose own automation still runs came back; the scan will mint a duplicate beside it")
-	}
-	if isArchived(t, owner, stranded) {
-		t.Error("a cadence reminder stayed archived while only the OTHER automation runs — nothing will ever mint it again")
-	}
 }

--- a/backend/internal/compose/integration/no_activity_eligibility_integration_test.go
+++ b/backend/internal/compose/integration/no_activity_eligibility_integration_test.go
@@ -514,6 +514,14 @@ func TestTheRestoreGivesBackAReminderSomebodyHadTakenOver(t *testing.T) {
 	adopt(t, owner, reminded, "remind_at", quietSince)
 
 	applyCleanupMigration(t, owner)
+	// Without this the assertions below pass vacuously: a row 0148 never
+	// archived also reads "not archived" after the restore, and the suite
+	// would be green while 0149 did nothing at all.
+	for _, id := range []ids.UUID{assigned, reminded, untouched} {
+		if !isArchived(t, owner, id) {
+			t.Fatalf("0148 did not archive %s, so this suite is not testing what it claims", id)
+		}
+	}
 	applyRestoreMigration(t, owner)
 
 	if isArchived(t, owner, assigned) {
@@ -572,6 +580,13 @@ func TestTheRestorePairsEachReminderWithItsOwnAutomation(t *testing.T) {
 		"Time for a check-in — last touched 2026-06-16", "system", false)
 
 	applyCleanupMigration(t, owner)
+	// Same guard as its siblings: "stranded came back" only means anything
+	// once 0148 has been shown to have taken it away.
+	for _, id := range []ids.UUID{live, stranded} {
+		if !isArchived(t, owner, id) {
+			t.Fatalf("0148 did not archive %s, so this suite is not testing what it claims", id)
+		}
+	}
 	applyRestoreMigration(t, owner)
 
 	if !isArchived(t, owner, live) {

--- a/backend/migrations/core/0149_restore_unrepeatable_checkin_reminders.down.sql
+++ b/backend/migrations/core/0149_restore_unrepeatable_checkin_reminders.down.sql
@@ -1,0 +1,6 @@
+-- No-op, for the same reason 0148's down is one: this migration restored rows
+-- rather than changing any schema, and it kept no record of which ids it
+-- touched. Re-archiving "everything that matches" would take back the tasks a
+-- person has since assigned or acted on, which is the harm this migration
+-- exists to undo.
+SELECT 1;

--- a/backend/migrations/core/0149_restore_unrepeatable_checkin_reminders.up.sql
+++ b/backend/migrations/core/0149_restore_unrepeatable_checkin_reminders.up.sql
@@ -1,0 +1,58 @@
+-- Give back the check-in reminders 0148 archived that nothing will re-mint.
+--
+-- 0148 archived every outstanding generated check-in task, on the reasoning
+-- that the corrected clock scan re-mints one for each record that is still
+-- eligible and still quiet. That reasoning holds in exactly one condition —
+-- the reminder automation still runs in that workspace — and the migration
+-- never checked it. Two cases fall outside it, and in both the row is gone for
+-- good, because 0148's down is a no-op:
+--
+--   * A workspace that PAUSED or archived no_activity_reminder /
+--     check_in_cadence. timescan loads only enabled, unarchived clock
+--     automations, so the scan that would re-mint never runs there. Every
+--     reminder that workspace was carrying — including the ones for accounts
+--     with an open deal, which the new rule agrees deserve one — was archived
+--     with nothing to bring it back.
+--   * A task a HUMAN had taken over: assigned to someone, or given a reminder.
+--     The generated task carries neither (taskCreateEffect writes kind,
+--     subject, due_at and links, and nothing else), so either column means a
+--     person made this their work item. A re-mint does not restore that: it is
+--     a new row without the assignee and without the date they chose.
+--
+-- Restored, not re-created, so the id, the audit trail and the links a person
+-- may already have acted on all survive.
+--
+-- WHICH rows 0148 archived is decided by the audit log, not by a timestamp:
+-- 0148 is raw SQL and wrote no audit row, while every human archive goes
+-- through the store and writes one. So an archived generated task with no
+-- 'archive' entry against it is one this migration is entitled to give back,
+-- and a task a human archived deliberately stays archived.
+--
+-- Deliberately NOT used as a discriminator: updated_at and version. The
+-- activity table carries set_updated_at_bump_version(), so 0148's own UPDATE
+-- bumped both on every row it touched — they no longer distinguish anything.
+UPDATE activity a
+   SET archived_at = NULL
+ WHERE a.kind = 'task'
+   AND a.source = 'system'
+   AND a.archived_at IS NOT NULL
+   AND a.is_done = false
+   AND (a.subject LIKE 'Check in — no activity since %'
+     OR a.subject LIKE 'Time for a check-in — last touched %')
+   -- 0148's work, not a person's considered decision to archive it.
+   AND NOT EXISTS (
+         SELECT 1 FROM audit_log l
+          WHERE l.entity_type = 'activity'
+            AND l.entity_id = a.id
+            AND l.action = 'archive')
+   AND (
+         -- Nothing in this workspace will ever re-mint it.
+         NOT EXISTS (
+               SELECT 1 FROM automation au
+                WHERE au.workspace_id = a.workspace_id
+                  AND au.key IN ('no_activity_reminder', 'check_in_cadence')
+                  AND au.enabled
+                  AND au.archived_at IS NULL)
+         -- Or a person had made it theirs, and a re-mint is not the same row.
+         OR a.assignee_id IS NOT NULL
+         OR a.remind_at IS NOT NULL);

--- a/backend/migrations/core/0149_restore_unrepeatable_checkin_reminders.up.sql
+++ b/backend/migrations/core/0149_restore_unrepeatable_checkin_reminders.up.sql
@@ -46,13 +46,26 @@ UPDATE activity a
             AND l.entity_id = a.id
             AND l.action = 'archive')
    AND (
-         -- Nothing in this workspace will ever re-mint it.
+         -- The automation that mints THIS task's wording is not running, so
+         -- nothing will ever mint it again.
+         --
+         -- Paired per subject, not per workspace: the two automations write
+         -- different tasks (no_activity_reminder says "Check in — no activity
+         -- since …", check_in_cadence says "Time for a check-in — last touched
+         -- …"), and a workspace can run one and have paused the other. Asking
+         -- only whether EITHER is enabled would leave the paused one's tasks
+         -- archived with nothing to bring them back — the same permanence this
+         -- migration exists to undo, one automation further in.
          NOT EXISTS (
                SELECT 1 FROM automation au
                 WHERE au.workspace_id = a.workspace_id
-                  AND au.key IN ('no_activity_reminder', 'check_in_cadence')
                   AND au.enabled
-                  AND au.archived_at IS NULL)
+                  AND au.archived_at IS NULL
+                  AND au.key = CASE
+                        WHEN a.subject LIKE 'Check in — no activity since %'
+                          THEN 'no_activity_reminder'
+                        ELSE 'check_in_cadence'
+                      END)
          -- Or a person had made it theirs, and a re-mint is not the same row.
          OR a.assignee_id IS NOT NULL
          OR a.remind_at IS NOT NULL);

--- a/backend/migrations/core/0149_restore_unrepeatable_checkin_reminders.up.sql
+++ b/backend/migrations/core/0149_restore_unrepeatable_checkin_reminders.up.sql
@@ -22,15 +22,27 @@
 -- Restored, not re-created, so the id, the audit trail and the links a person
 -- may already have acted on all survive.
 --
--- WHICH rows 0148 archived is decided by the audit log, not by a timestamp:
--- 0148 is raw SQL and wrote no audit row, while every human archive goes
--- through the store and writes one. So an archived generated task with no
--- 'archive' entry against it is one this migration is entitled to give back,
--- and a task a human archived deliberately stays archived.
+-- WHICH rows 0148 archived is decided EXACTLY, by the migration ledger.
 --
--- Deliberately NOT used as a discriminator: updated_at and version. The
--- activity table carries set_updated_at_bump_version(), so 0148's own UPDATE
--- bumped both on every row it touched — they no longer distinguish anything.
+-- dbmigrate runs a migration's SQL and its schema_migrations_core INSERT in
+-- ONE transaction, and Postgres now() is that transaction's start time — so
+-- 0148's `archived_at = now()` and its ledger row's `applied_at` default are
+-- the same instant to the microsecond. A row 0148 archived carries exactly
+-- that archived_at, and nothing else does.
+--
+-- Anything archived BEFORE 0148 is excluded by construction rather than by
+-- inference: 0148 only touched `archived_at IS NULL`, so it never saw those
+-- rows, and their archived_at cannot equal its instant. An absent ledger row
+-- (0148 never ran on this database) makes the comparison NULL and restores
+-- nothing, which is the right answer — there is nothing to give back.
+--
+-- Two weaker discriminators were considered and rejected. The audit log
+-- ("0148 wrote no audit row, a human archive writes one") also matches
+-- anything archived before 0148 by a path that did not audit, so it would
+-- resurrect rows this migration has no business touching. And updated_at /
+-- version cannot serve at all: the activity table carries
+-- set_updated_at_bump_version(), so 0148's own UPDATE bumped both on every
+-- row it touched.
 UPDATE activity a
    SET archived_at = NULL
  WHERE a.kind = 'task'
@@ -39,12 +51,9 @@ UPDATE activity a
    AND a.is_done = false
    AND (a.subject LIKE 'Check in — no activity since %'
      OR a.subject LIKE 'Time for a check-in — last touched %')
-   -- 0148's work, not a person's considered decision to archive it.
-   AND NOT EXISTS (
-         SELECT 1 FROM audit_log l
-          WHERE l.entity_type = 'activity'
-            AND l.entity_id = a.id
-            AND l.action = 'archive')
+   -- 0148's own work, to the microsecond, and nothing archived before it.
+   AND a.archived_at = (
+         SELECT applied_at FROM schema_migrations_core WHERE version = '0148')
    AND (
          -- The automation that mints THIS task's wording is not running, so
          -- nothing will ever mint it again.


### PR DESCRIPTION
## Why

#333 shipped migration 0148, which archives every outstanding generated
check-in reminder. Its safety argument is that the corrected clock scan
re-mints one for each record that is still eligible and still quiet.

That argument holds in exactly one condition — the reminder automation still
runs in that workspace — and the migration never checks it. Where it does not
hold, the row is gone for good: 0148's down migration is a no-op.

Two cases fall outside it.

**A workspace that paused or archived the automation.** `timescan` loads only
enabled, unarchived clock automations, so the scan that would re-mint never
runs there. Every reminder that workspace was carrying was archived — including
the ones for accounts with an open deal, which the new eligibility rule agrees
deserve one.

**A task somebody had taken over**, by assigning it or setting a reminder on
it. `taskCreateEffect` writes kind, subject, due_at and links and nothing else,
so either column means a person made this their work item. A re-mint does not
restore that: it is a new row without the assignee and without the date they
chose.

## What 0149 does

Restores those rows, and only those. Restored rather than re-created, so the
id, the audit trail and any links a person has already acted on all survive.

**Which rows 0148 archived is decided by the audit log, not by a timestamp.**
0148 is raw SQL and wrote no audit row; every human archive goes through the
store and writes one. So an archived generated task with no `archive` entry
against it is one this migration is entitled to give back, and a reminder a
person deliberately archived stays archived.

`updated_at` and `version` cannot serve as that discriminator, which is worth
recording: the activity table carries `set_updated_at_bump_version()`, so
0148's own UPDATE bumped both on every row it touched.

An untouched reminder in a workspace that still runs the automation stays
archived, so the corrected scan does not mint a duplicate beside it.

## Tests

Three new integration suites plus the existing 0148 one, all against a real
migrated Postgres:

- a paused workspace's reminders come back;
- an assigned reminder and one with a `remind_at` come back, while an untouched
  one in the same live workspace does not;
- a reminder a person archived through the store stays archived.

The first suite fails loudly if 0148 did not archive its fixtures, so a pass
proves 0149 is what un-archived them.

`make check-backend` and `make test-integration` (29 packages, 0 skips) are
green locally.

## Note on 0148 itself

Left untouched: it has shipped and been applied, and the repo's rule is
additive-only. Its comment states the re-mint argument without the condition it
depends on; 0149's comment carries the correction where a reader of either will
meet it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds migration 0149 to restore system‑generated check‑in reminders that 0148 archived when they won’t be re‑minted. It matches 0148’s own archives via the migration ledger and pairs each reminder to the automation that minted it to prevent duplicates.

- **Bug Fixes**
  - Restores only rows whose `archived_at` equals 0148’s `applied_at` in the migration ledger; excludes anything archived earlier.
  - Brings back reminders when the workspace paused the matching automation or when a user adopted the task (`assignee_id`/`remind_at`).
  - Pairs each reminder’s subject to its own automation (`no_activity_reminder` vs `check_in_cadence`) so one enabled automation doesn’t block restoring the other’s tasks.
  - Keeps reminders in active automations archived so the scan re‑mints them instead.

- **Tests**
  - Apply migrations like `dbmigrate`: SQL and ledger insert in one transaction, since 0149 relies on that instant.
  - New cases assert 0148 archived fixtures before 0149 runs and prove rows archived before 0148 stay archived; suites cover paused automation, adopted tasks, and per‑automation pairing.

<sup>Written for commit 29d5c187c6871603625270c30be59cc2244a0079. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Restores eligible archived check-in reminders that were incorrectly archived.
  - Preserves reminders intentionally archived by people.
  - Avoids recreating duplicate reminders and correctly matches each reminder to its automation.
  - Retains existing reminder activity and metadata during restoration.

- **Tests**
  - Added coverage for paused or inactive automations, user adoption, manual scheduling, and deliberate archival scenarios.

- **Documentation**
  - Documented restoration conditions and follow-up findings related to logo retention and data cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->