### PR TITLE
fix(sbom): sign as invoking user so signature bundles stay readable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -320,10 +320,14 @@ COSIGN_IMAGE ?= gcr.io/projectsigstore/cosign@sha256:c77247c92f4dfea851c70555738
 DOCKER_SBOM  := docker run --rm -v "$(CURDIR)":/src -w /src
 SYFT         ?= $(DOCKER_SBOM) $(SYFT_IMAGE)
 GRANT        ?= $(DOCKER_SBOM) $(GRANT_IMAGE)
-# cosign's image runs as uid 65532, which cannot create files in the invoking
-# user's sboms/ dir through the bind mount — run it as root (syft's image does).
+# cosign's image defaults to uid 65532, which owns neither the bind-mounted
+# sboms/ dir nor a writable HOME — run it as the invoking user so the *.cosign.bundle
+# files it writes (mode 0600) are owned by that user and stay readable to whatever
+# consumes them next (CI's upload-artifact runs as the same non-root runner). HOME
+# points at the gitignored .tmp so cosign's sigstore/TUF cache has somewhere to land.
 # The OIDC env vars are ambient in CI (id-token: write).
-COSIGN       ?= $(DOCKER_SBOM) -u 0 -e SIGSTORE_ID_TOKEN -e ACTIONS_ID_TOKEN_REQUEST_URL -e ACTIONS_ID_TOKEN_REQUEST_TOKEN $(COSIGN_IMAGE)
+COSIGN_HOME  := .tmp/cosign-home
+COSIGN       ?= $(DOCKER_SBOM) -u $(shell id -u):$(shell id -g) -e HOME=/src/$(COSIGN_HOME) -e SIGSTORE_ID_TOKEN -e ACTIONS_ID_TOKEN_REQUEST_URL -e ACTIONS_ID_TOKEN_REQUEST_TOKEN $(COSIGN_IMAGE)
 # Scan a clean export of committed HEAD, so host state (node_modules, .env, IDE
 # files) never leaks into the SBOM and .gitignore stays the single authority.
 SBOM_SRC     := .tmp/sbom-src
@@ -350,6 +354,7 @@ sbom:
 
 ## sbom-sign — keyless-sign each generated SBOM with cosign (writes *.cosign.bundle; needs an OIDC token).
 sbom-sign:
+	@mkdir -p $(COSIGN_HOME)
 	@for f in $(SBOM_FILES); do \
 	  echo "signing $$f"; \
 	  $(COSIGN) sign-blob --yes --bundle "$$f.cosign.bundle" "$$f" || exit 1; \


### PR DESCRIPTION
## Problem

The **SBOM** workflow's `sign` job fails at **Publish signatures** ([run 30583002645](https://github.com/gradionhq/margince-poc-v1/actions/runs/30583002645)):

```
Error: EACCES: permission denied, open '.../sboms/margince.cdx.json.cosign.bundle'
##[error]An error has occurred while creating the zip file for upload
```

Signing itself succeeds — only the upload fails. `cosign sign-blob --bundle` writes the `*.cosign.bundle` files mode `0600`. Because the cosign container ran as root (`-u 0`), the bundles were root-owned, so `upload-artifact` (running as the non-root runner) couldn't read them to zip. The SBOM JSONs upload fine because syft writes them `0644`.

## Fix

Run the cosign container as the invoking `uid:gid` instead of root. That user owns both the bind-mounted `sboms/` dir and the `0600` bundles it writes, so they stay readable to their owner — the same runner that uploads them. `HOME` points at the gitignored `.tmp/cosign-home` so cosign's sigstore/TUF cache has a writable location under an arbitrary uid. This also removes the root-owned build-output smell the previous comment acknowledged.

## Verification

- `./scripts/check-image-pins.sh` — still green (digest pin unchanged).
- Ran the cosign image locally as a non-root uid with the mounted `HOME`: `cosign version` works, and `sign-blob` reaches ephemeral-key generation and the Fulcio certificate request, failing only on a deliberately-invalid OIDC token — proving trust-root init and signing work as non-root. With CI's ambient OIDC token the bundle is produced owned by the runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run the `cosign` container as the invoking user and set a writable `HOME` so `*.cosign.bundle` files remain readable and the SBOM signing job can upload signatures. Fixes the CI “permission denied” error when zipping bundles.

- **Bug Fixes**
  - Run `cosign` with `-u $(id -u):$(id -g)` so 0600 bundles are owned by the runner.
  - Set `HOME` to `.tmp/cosign-home` for sigstore/TUF cache writes.
  - Create `COSIGN_HOME` before signing to avoid missing directory errors.

<sup>Written for commit 14e6ce34f673525a624a610146e89c37dcbad3e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SBOM signing reliability by running the signing process with the invoking user’s permissions.
  * Added a writable local cache location for signing credentials and preserved required OIDC authentication settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->