### PR TITLE
docs(status): move the company-page and lead-quality arc to the archive

### DIFF
--- a/STATUS-ARCHIVE.md
+++ b/STATUS-ARCHIVE.md
@@ -31,10 +31,10 @@ the effect runs, the approval was left approved-but-unredeemed with no lead
 created. The pin is now opt-in per approval kind — a lead read off a company's
 website is FILED under that company rather than being an operation on it, so
 its effect reads no organization row and has no version to guard. A fitness
-test holds the opt-out list against the kinds whose effects actually read their
+test holds that list against the kinds whose effects actually read their
 target.
 
-#342 rebuilt the company detail page around a meeting brief that states what
+PR `#342` rebuilt the company detail page around a meeting brief that states what
 the account means rather than listing what it holds, made email bodies
 readable, grouped and deduplicated the facts wall, collapsed three overlapping
 people sections into one, and kept the rails mounted across tab switches. It

--- a/STATUS-ARCHIVE.md
+++ b/STATUS-ARCHIVE.md
@@ -38,14 +38,19 @@ target.
 the account means rather than listing what it holds, made email bodies
 readable, grouped and deduplicated the facts wall, collapsed three overlapping
 people sections into one, and kept the rails mounted across tab switches. It
-also closed three defects in the site read's published-person lane: customer
-testimonials were becoming leads at the company whose site they appeared on
-(fixed by requiring an email address the page actually printed), people already
-on file were re-proposed (fixed by a probe that runs under the REQUESTING
-HUMAN's grants, because answering it workspace-wide made the approval inbox an
-existence oracle for records the reader's row scope hides), and re-reads stacked
-duplicate questions (fixed by keying the approval's logical identity on the
-lead's natural key). `approvals.StageInTx` now refuses an input carrying
+also worked three defects in the site read's published-person lane. Two are
+closed: people already on file were re-proposed (fixed by a probe that runs
+under the REQUESTING HUMAN's grants, because answering it workspace-wide made
+the approval inbox an existence oracle for records the reader's row scope
+hides), and re-reads stacked duplicate questions (fixed by keying the
+approval's logical identity on the lead's natural key).
+
+The third is only narrowed, not closed. A published person must now carry an
+email address the page actually printed, which removed every testimonial lead
+observed in practice — none of them published an address. But the floor proves
+CONTACTABILITY, not affiliation: a testimonial that does print the quoted
+person's own address still becomes a lead filed under the wrong company. See
+STATUS.md for the open call. `approvals.StageInTx` now refuses an input carrying
 `Identity` or `JoinPending` instead of ignoring both silently.
 
 **The company-view rebuild, finished — six feature PRs (#309, #313, #315, #317,

--- a/STATUS-ARCHIVE.md
+++ b/STATUS-ARCHIVE.md
@@ -23,6 +23,31 @@
 
 ## Landed arcs
 
+**The company page rework and the leads behind it — PRs #349 and #342
+(2026-07-31).** #349 fixed a defect that silently destroyed leads: accepting a
+staged `site_lead` failed with `version_skew` whenever anything had written to
+the pinned organization after staging, and because the decision commits before
+the effect runs, the approval was left approved-but-unredeemed with no lead
+created. The pin is now opt-in per approval kind — a lead read off a company's
+website is FILED under that company rather than being an operation on it, so
+its effect reads no organization row and has no version to guard. A fitness
+test holds the opt-out list against the kinds whose effects actually read their
+target.
+
+#342 rebuilt the company detail page around a meeting brief that states what
+the account means rather than listing what it holds, made email bodies
+readable, grouped and deduplicated the facts wall, collapsed three overlapping
+people sections into one, and kept the rails mounted across tab switches. It
+also closed three defects in the site read's published-person lane: customer
+testimonials were becoming leads at the company whose site they appeared on
+(fixed by requiring an email address the page actually printed), people already
+on file were re-proposed (fixed by a probe that runs under the REQUESTING
+HUMAN's grants, because answering it workspace-wide made the approval inbox an
+existence oracle for records the reader's row scope hides), and re-reads stacked
+duplicate questions (fixed by keying the approval's logical identity on the
+lead's natural key). `approvals.StageInTx` now refuses an input carrying
+`Identity` or `JoinPending` instead of ignoring both silently.
+
 **The company-view rebuild, finished — six feature PRs (#309, #313, #315, #317,
 #319, #322) plus one follow-up (#326).** They turned the organization record page
 into one composite read with a one-page view over it: the 360 itself, the evidence

--- a/STATUS.md
+++ b/STATUS.md
@@ -12,25 +12,14 @@
 > session narrative). When an item here closes, move its narrative to the
 > archive rather than growing this file.
 
-## Fixed — staged leads could not be accepted (merged 2026-07-31)
+## Open defect — capture_counterparty repeats the version-pin failure
 
-Accepting a staged `site_lead` failed with `version_skew` whenever anything had
-written to the pinned organization after staging, and the lead was then
-unrecoverable: the decision commits before the effect runs, so a failed accept
-left the approval `approved` but unredeemed. Auto-enrich and accepting the
-deep-read bundle both wrote the org's profile fields, which made every sibling
-lead from that read un-acceptable.
-
-Fixed in PR #349: the pin is now opt-in per approval kind. A `site_lead` is
-FILED under a company rather than being an operation on it, so its effect never
-reads the organization row and has no version to guard —
-`approvals.TargetIsContextOnly` names the kinds that opt out, and a fitness
-test holds the list against the kinds whose effects actually read their target.
-
-The same class still applies to `capture_counterparty`, whose pinned `activity`
-version is bumped by the classify pass
-(`activities/capturelabel.go:77-81`) — that one has a different cause and is
-still open.
+`capture_counterparty` stages with a pinned `activity` version, and the classify
+pass bumps that version (`activities/capturelabel.go:77-81`), so the accept can
+fail the same way `site_lead` used to. The `site_lead` fix (PR #349, opt-in pins
+via `approvals.TargetIsContextOnly`) does not cover it: a counterparty decision
+IS about the activity it names, so the pin is arguably correct and the classify
+write is what needs to move. Decide which before changing either.
 
 ## Open decision — the organization brief endpoint has no client
 
@@ -148,7 +137,7 @@ The merge gate (`make check`), the real-Postgres integration lane
 ## Session pickup — 2026-07-31
 
 **The site read stopped proposing leads nobody asked for.** Three defects in
-the published-person lane closed on `feat/company-page-wow-slice`:
+the published-person lane closed in PR #342 (merged):
 
 - **Testimonials became leads.** A home or about page's "what our clients say"
   wall names people who work elsewhere, and they were filed as contacts at the

--- a/STATUS.md
+++ b/STATUS.md
@@ -21,6 +21,21 @@ via `approvals.TargetIsContextOnly`) does not cover it: a counterparty decision
 IS about the activity it names, so the pin is arguably correct and the classify
 write is what needs to move. Decide which before changing either.
 
+## Open decision — a testimonial with an email files under the wrong company
+
+The site read only proposes a published person who carries a name, a role, and
+an email address the page actually PRINTED. That floor removed every
+testimonial lead seen in practice, because none of them published an address.
+
+It proves contactability, not affiliation. A "what our clients say" wall that
+does print the quoted person's own address — `jane@client.example` on our
+site — still yields a lead filed as a contact AT our company, which their own
+quoted job title disproves on the same line.
+
+Requiring the address to sit on the crawled site's own domain would close it,
+and would also drop staff who publish a personal address. That trade is a
+product call, not a bug fix, so it is raised rather than taken.
+
 ## Open decision — the organization brief endpoint has no client
 
 `GET /organizations/{id}/brief` is no longer read by the web UI. Its card was
@@ -160,11 +175,7 @@ the published-person lane closed in PR #342 (merged):
   ignoring both, and `StageOrJoinPendingInTx` is the door that honors them.
 
 **Still open in this area:** the email floor proves contactability, not
-affiliation. A testimonial that prints the quoted person's own address
-(`jane@client.example` on our site) still becomes a lead filed under the wrong
-company. Requiring the address to sit on the crawled site's own domain would
-close it, at the cost of dropping staff who publish a personal address —
-a product call, not a bug fix. Raised here rather than decided.
+affiliation — see the open decision above.
 
 **A second model vendor is now certifiable.** `config/ai-routing.openrouter.example.yaml`
 binds OpenRouter through the generic `openai_compatible` adapter, with three


### PR DESCRIPTION
STATUS.md carries open work only, per its own header. PRs #349 and #342 are
merged, so their narrative moves to STATUS-ARCHIVE.md.

What stays in STATUS is the part that is genuinely still open:
`capture_counterparty` repeats the version-pin failure, and the `site_lead`
fix deliberately does not cover it — a counterparty decision IS about the
activity it names, so the pin is arguably right there and the classify-pass
write is what needs to move. That call is not made yet.

Also drops a reference to `feat/company-page-wow-slice`, a branch that no
longer exists.

Docs only. No code, no gates affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved merged arcs (company page rework and lead fixes from PRs #349 and #342) from STATUS.md to STATUS-ARCHIVE.md so STATUS shows only open work. Clarified the testimonial misfiling is still an open decision, kept the `capture_counterparty` version-pin defect, standardized the pin-selection term (opt-in per approval kind) across STATUS and the archive, replaced the obsolete branch reference with PR #342, and fixed a stray heading; docs-only.

<sup>Written for commit e7194e63fb38c40adc8fbe9c238aedcbc321c14c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/350?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added archived release notes covering fixes for version-skew handling, opt-out pinning, company details, lead filtering, deduplication, and approval validation.
  * Updated current status documentation with a known approval version-pin defect and clarified the session pickup resolution.
  * Documented additional validation and identity-handling improvements for greater operational visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->