### PR TITLE
the channel reply is a governed, stageable tool

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -228,6 +228,29 @@ Vite/React web UI. What is deliberately still stubbed (answering explicit
 The merge gate (`make check`), the real-Postgres integration lane
 (`make test-integration`), and the live-boot job are all green.
 
+## Session pickup — 2026-08-01 (channel reply governance, branch `feat/channel-send-tool`)
+
+**The channel reply is now a governed, stageable tool.** `POST
+/v1/activities/{id}/send-message` is admitted under the `send` scope, at
+`TierConfirmationRequired`, through a registered `send_message` tool whose
+`StageInfo` pins the conversation's row version — the same posture
+`send_offer` and outbound mail already carry, closing the gap where the
+channel-reply route resolved by synthesis at `write`.
+
+A ratchet test (`agentpolicysynthesis_test.go`) now pins every verb that
+still resolves by synthesis into one of two maps: verbs where `write` is
+the right cap, and known outbound holes. Not fixed here, deliberately:
+
+- **Five outbound verbs are still admitted under `write` by synthesis** —
+  `send_offer`, `enrich`, `reconcile_overlay`, `connect_incumbent`,
+  `disconnect_incumbent`. Closing each means registering a tool and scope
+  for it; `connect_incumbent`/`disconnect_incumbent` additionally need the
+  tier and scope decided together, which nothing has done yet.
+- **`send_email` and `book_meeting` are both 🟡 tools with no `StageInfo`.**
+  An MCP call to either refuses outright rather than ever staging an
+  approval — there is no path to a "yes" for an agent caller today, only
+  the REST route's own confirm-first gate.
+
 ## Session pickup — 2026-07-31 (relationship graph, branch `feat/network-graph`)
 
 **"Who on our team knows this contact" is now a stored fact, and the company

--- a/STATUS.md
+++ b/STATUS.md
@@ -262,6 +262,28 @@ the right cap, and known outbound holes. Not fixed here, deliberately:
   — and on `dispatch.explain`'s reading of all four post-staging — remains
   open.
 
+**Security finding, recorded not fixed: an approved channel send binds the
+message text but not the recipient.** `relink_activity` is `auto_execute`
+(`compose/agentpolicy_gen.go`); it rewrites `activity_link` rows to point a
+conversation at a different person without ever updating the `activity` row
+itself, so the pinned row version a staged `send_message` approval carries
+does not move when the conversation's counterparty changes
+(`activities/lifecycle.go`, the relink insert). `activities.Store.SendMessage`
+resolves the recipient fresh at execution time from those links
+(`reachableOnConversation`), not from anything captured when the approval was
+staged. So an agent can stage "send message M on conversation A", have a
+human approve it, auto-execute a relink that repoints A's person link, then
+redeem the byte-identical approved call — and M delivers to someone the human
+never approved sending to. This is pre-existing (a `write`-scoped passport
+could already do the same over REST before this branch) and affects both the
+REST and MCP transports; this branch neither introduces nor fixes it. The
+missing invariant: a staged send's authority is bound to the message content
+and a version pin on the wrong row. A real fix needs the recipient itself
+resolved at staging time and its identity (not just the conversation's row
+version) bound into the staged authority and rechecked at redemption, and a
+person-link change on an activity to bump that activity's own version so an
+intervening relink invalidates a pin that predates it.
+
 ## Session pickup — 2026-07-31 (relationship graph, branch `feat/network-graph`)
 
 **"Who on our team knows this contact" is now a stored fact, and the company

--- a/STATUS.md
+++ b/STATUS.md
@@ -250,6 +250,17 @@ the right cap, and known outbound holes. Not fixed here, deliberately:
   An MCP call to either refuses outright rather than ever staging an
   approval — there is no path to a "yes" for an agent caller today, only
   the REST route's own confirm-first gate.
+- **The four channel-send refusals wrap no `apperrors` sentinel.**
+  `errEmptyMessageBody`, `NotAChannelConversationError`,
+  `ChannelNotSendCapableError`, and `ChannelRecipientError` (all in
+  `activities/channelsend.go`) carry none of the fixed sentinels, so on
+  MCP, `dispatch.explain`'s default branch tells an agent "failed for an
+  internal reason... Retry" even for the permanent ones among them, while
+  REST maps the same four to actionable 422s. `StageInfo` now refuses the
+  two an agent trips at staging time (empty body, non-channel anchor)
+  before an approval is ever minted, but the taxonomy gap on the other two
+  — and on `dispatch.explain`'s reading of all four post-staging — remains
+  open.
 
 ## Session pickup — 2026-07-31 (relationship graph, branch `feat/network-graph`)
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -238,14 +238,23 @@ The merge gate (`make check`), the real-Postgres integration lane
 channel-reply route resolved by synthesis at `write`.
 
 A ratchet test (`agentpolicysynthesis_test.go`) now pins every verb that
-still resolves by synthesis into one of two maps: verbs where `write` is
-the right cap, and known outbound holes. Not fixed here, deliberately:
+still resolves by synthesis into one of three maps: verbs where `write` is
+the right cap (`synthesizedVerbs`), known outbound holes (`outboundHoles`),
+and verbs an agent can never actually execute even once approved
+(`deadEndVerbs`). Not fixed here, deliberately:
 
-- **Five outbound verbs are still admitted under `write` by synthesis** —
-  `send_offer`, `enrich`, `reconcile_overlay`, `connect_incumbent`,
-  `disconnect_incumbent`. Closing each means registering a tool and scope
-  for it; `connect_incumbent`/`disconnect_incumbent` additionally need the
-  tier and scope decided together, which nothing has done yet.
+- **Four outbound verbs are still admitted under `write` by synthesis** —
+  `send_offer`, `enrich`, `connect_incumbent`, `reconcile_overlay`. Closing
+  each means registering a tool and scope for it; `connect_incumbent`
+  additionally needs the tier and scope decided together, which nothing has
+  done yet.
+- **`share_record` is a dead end, not an outbound hole.** Its handlers
+  (`identity/grants.go`) reject any principal that is not
+  `PrincipalHuman`, and redemption never changes the redeeming actor's
+  type — so an agent-staged, human-approved `share_record` call is refused
+  at redemption every time. It is pinned in `deadEndVerbs` rather than
+  `outboundHoles` because there is no scope decision that would ever make
+  it succeed.
 - **`send_email` and `book_meeting` are both 🟡 tools with no `StageInfo`.**
   An MCP call to either refuses outright rather than ever staging an
   approval — there is no path to a "yes" for an agent caller today, only

--- a/backend/internal/compose/agentgate_scope_test.go
+++ b/backend/internal/compose/agentgate_scope_test.go
@@ -22,32 +22,47 @@ import (
 func TestOutboundVerbsRequireTheSendScope(t *testing.T) {
 	registry := NewRegistry(nil, SendPath{})
 
-	outbound := map[string]string{
-		"send_email":   "POST /v1/activities/{id}/send-email",
-		"send_message": "POST /v1/activities/{id}/send-message",
+	// The outbound universe: every verb still pinned as a hole, plus every
+	// registered tool that declares egress. Deriving it is what makes closing a
+	// hole at the wrong scope fail here rather than pass quietly.
+	outbound := map[string]bool{}
+	for verb := range outboundHoles {
+		outbound[verb] = true
+	}
+	for _, spec := range NewRegistry(nil, SendPath{}).Specs() {
+		if spec.Egress {
+			outbound[spec.Name] = true
+		}
 	}
 
-	for verb, route := range outbound {
-		pol, known := agentPolicies[route]
-		if !known {
-			t.Fatalf("%s: route %q is absent from the generated policy table", verb, route)
+	for route, pol := range agentPolicies {
+		if pol.Access != accessTool || !outbound[pol.Tool] {
+			continue
 		}
-		if pol.Tool != verb {
-			t.Fatalf("%s: route %q declares tool %q", verb, route, pol.Tool)
+		if _, registered := registry.Spec(pol.Tool); !registered {
+			// A pinned hole is known-wrong — outboundHoles names the debt,
+			// not a passing grade — so it must not be asserted against
+			// ScopeSend here. TestThePinsDescribeVerbsThatStillExist covers
+			// the other half: it fails the moment the verb gains a tool,
+			// which is when this branch starts asserting on it instead.
+			if _, pinned := outboundHoles[pol.Tool]; !pinned {
+				t.Errorf("%s (%s) is derived as outbound but is neither registered nor a pinned hole", pol.Tool, route)
+			}
+			continue
 		}
 		spec, ok := operationSpec(pol, registry)
 		if !ok {
-			t.Fatalf("%s: the gate cannot resolve a spec for it", verb)
+			t.Fatalf("%s: the gate cannot resolve a spec for it", pol.Tool)
 		}
 		if spec.RequiredScope != principal.ScopeSend {
 			t.Errorf("%s admits under scope %q, want %q — a write-only passport can send with it",
-				verb, spec.RequiredScope, principal.ScopeSend)
+				pol.Tool, spec.RequiredScope, principal.ScopeSend)
 		}
 		if spec.Tier != mcp.TierConfirmationRequired {
-			t.Errorf("%s admits at tier %v, want TierConfirmationRequired", verb, spec.Tier)
+			t.Errorf("%s admits at tier %v, want TierConfirmationRequired", pol.Tool, spec.Tier)
 		}
 		if !spec.Egress {
-			t.Errorf("%s does not declare egress; it leaves the workspace", verb)
+			t.Errorf("%s does not declare egress; it leaves the workspace", pol.Tool)
 		}
 	}
 }

--- a/backend/internal/compose/agentgate_scope_test.go
+++ b/backend/internal/compose/agentgate_scope_test.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The scope an outbound verb is admitted under is the cap the granting human
+// set, not a property of the transport. A passport that may not send mail may
+// not send a channel message either — one act, two wires.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/mcp"
+)
+
+func TestOutboundVerbsRequireTheSendScope(t *testing.T) {
+	registry := NewRegistry(nil, SendPath{})
+
+	outbound := map[string]string{
+		"send_email":   "POST /v1/activities/{id}/send-email",
+		"send_message": "POST /v1/activities/{id}/send-message",
+	}
+
+	for verb, route := range outbound {
+		pol, known := agentPolicies[route]
+		if !known {
+			t.Fatalf("%s: route %q is absent from the generated policy table", verb, route)
+		}
+		if pol.Tool != verb {
+			t.Fatalf("%s: route %q declares tool %q", verb, route, pol.Tool)
+		}
+		spec, ok := operationSpec(pol, registry)
+		if !ok {
+			t.Fatalf("%s: the gate cannot resolve a spec for it", verb)
+		}
+		if spec.RequiredScope != principal.ScopeSend {
+			t.Errorf("%s admits under scope %q, want %q — a write-only passport can send with it",
+				verb, spec.RequiredScope, principal.ScopeSend)
+		}
+		if spec.Tier != mcp.TierConfirmationRequired {
+			t.Errorf("%s admits at tier %v, want TierConfirmationRequired", verb, spec.Tier)
+		}
+		if !spec.Egress {
+			t.Errorf("%s does not declare egress; it leaves the workspace", verb)
+		}
+	}
+}
+
+// Resolving a spec is not admitting a call: refusal happens in Admit
+// (agentgate.go:129). This is the other half of the invariant.
+func TestAWriteOnlyPassportIsRefusedTheChannelReply(t *testing.T) {
+	pol := agentPolicies["POST /v1/activities/{id}/send-message"]
+	spec, ok := operationSpec(pol, NewRegistry(nil, SendPath{}))
+	if !ok {
+		t.Fatal("the gate cannot resolve a spec for the channel reply")
+	}
+
+	ctx := principal.WithWorkspaceID(context.Background(), ids.NewV7())
+	ctx = principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalAgent, ID: "agent:t", OnBehalfOf: ids.NewV7(),
+		PassportID: ids.NewV7(),
+		Scopes:     principal.NewScopeSet(principal.ScopeRead, principal.ScopeWrite),
+	})
+
+	// fullSeat (extensiontools_test.go) is a permissive gate authority — a
+	// full seat and empty RBAC — so admission here turns purely on the
+	// spec's required scope against the passport's granted scopes, the
+	// thing under test. The workspace binding is what lets Admit reach that
+	// scope decision instead of failing closed on a missing tenant first.
+	if _, err := auth.NewGate(fullSeat{}).Admit(ctx, spec, nil); !errors.Is(err, apperrors.ErrScopeExceeded) {
+		t.Errorf("a write-only passport was admitted to the channel reply: err = %v, want ErrScopeExceeded", err)
+	}
+}

--- a/backend/internal/compose/agentgate_scope_test.go
+++ b/backend/internal/compose/agentgate_scope_test.go
@@ -67,8 +67,9 @@ func TestOutboundVerbsRequireTheSendScope(t *testing.T) {
 	}
 }
 
-// Resolving a spec is not admitting a call: refusal happens in Admit
-// (agentgate.go:129). This is the other half of the invariant.
+// Resolving a spec is not admitting a call: refusal happens inside
+// auth.Gate.Admit, not in the spec resolution above. This is the other half
+// of the invariant.
 func TestAWriteOnlyPassportIsRefusedTheChannelReply(t *testing.T) {
 	pol := agentPolicies["POST /v1/activities/{id}/send-message"]
 	spec, ok := operationSpec(pol, NewRegistry(nil, SendPath{}))
@@ -86,8 +87,10 @@ func TestAWriteOnlyPassportIsRefusedTheChannelReply(t *testing.T) {
 	// fullSeat (extensiontools_test.go) is a permissive gate authority — a
 	// full seat and empty RBAC — so admission here turns purely on the
 	// spec's required scope against the passport's granted scopes, the
-	// thing under test. The workspace binding is what lets Admit reach that
-	// scope decision instead of failing closed on a missing tenant first.
+	// thing under test. auth.Gate.Admit checks that scope before it ever
+	// reads the workspace, so the binding below is not load-bearing for this
+	// assertion — it is here only to make the context a realistic agent
+	// context.
 	if _, err := auth.NewGate(fullSeat{}).Admit(ctx, spec, nil); !errors.Is(err, apperrors.ErrScopeExceeded) {
 		t.Errorf("a write-only passport was admitted to the channel reply: err = %v, want ErrScopeExceeded", err)
 	}

--- a/backend/internal/compose/agentpolicysynthesis_test.go
+++ b/backend/internal/compose/agentpolicysynthesis_test.go
@@ -26,8 +26,8 @@ var synthesizedVerbs = map[string]string{
 	"draft_offer":           "regenerates a draft in place — no message is transmitted to a counterparty; the AI lane may send the deal's context to the configured model provider, but that is governed by model routing and budget, not the send scope",
 	"relink_activity":       "moves an activity between records; internal and reversible",
 	"render_offer":          "renders a document for the caller; no transmission",
-	"share_record":          "grants and revokes access inside the workspace",
 	"disqualify_lead":       "internal lifecycle change; the row survives disqualification",
+	"disconnect_incumbent":  "revokes the connection row, purges the mirror, and flips the workspace to native mode, all local; the sealed vault credential it deletes afterward is our own Postgres-backed store, not the incumbent — nothing here calls out. Contrast connect_incumbent (outboundHoles), which calls the incumbent's API and writes that credential in the first place",
 }
 
 // outboundHoles are synthesized verbs that DO leave the workspace and are
@@ -36,15 +36,35 @@ var synthesizedVerbs = map[string]string{
 // as the debt it is rather than as approval. Closing one means registering a
 // tool for it (as send_message was) and deleting its line.
 var outboundHoles = map[string]string{
-	"send_offer":           "send",
-	"enrich":               "enrich",
-	"connect_incumbent":    "write is likely right for authenticating a connection, but the tier and scope were never decided together",
-	"disconnect_incumbent": "as connect_incumbent",
-	"reconcile_overlay":    "enrich — the sweep it queues calls overlay.Reconcile's inc.Modified fetch against the incumbent's API and spends its budget",
+	// send_offer only flips the offer's status to sent, freezes fx_rate_to_base
+	// and the buyer/issuer snapshots, and emits offer.sent
+	// (deals/offer_lifecycle.go:39-96) — no delivery, no counterparty
+	// transport. The contract's summary at api/crm.yaml (sendOffer) promises
+	// sending "leaves the workspace"; the implementation does not perform
+	// that leaving. It stays here because a delivery mechanism is the
+	// intended shape (ADR context: an outbound send), not because today's
+	// code egresses — this is a contract/implementation discrepancy to
+	// reconcile upstream, not merely scope-registration debt.
+	"send_offer":        "send — pinned for what the contract promises, though the current implementation performs no delivery (see comment above)",
+	"enrich":            "enrich",
+	"connect_incumbent": "write is likely right for authenticating a connection, but the tier and scope were never decided together",
+	"reconcile_overlay": "enrich — the sweep it queues calls overlay.Reconcile's inc.Modified fetch against the incumbent's API and spends its budget",
+}
+
+// deadEndVerbs are synthesized verbs whose approved-and-redeemed agent call
+// can never execute: the handler behind them requires a human principal, so
+// staging one, having a human approve it, and redeeming it as the agent that
+// staged it always ends in refusal at the store. They are pinned here —
+// distinct from synthesizedVerbs (an internal `write` is the correct cap)
+// and outboundHoles (egress admitted under the wrong scope) — because
+// neither of those labels is true of them: the verb is reachable, resolves
+// at `write` by synthesis, and yet no agent call through it can ever land.
+var deadEndVerbs = map[string]string{
+	"share_record": "createRecordGrant/revokeRecordGrant (identity/grants.go:141,189) reject any principal.Actor whose Type is not PrincipalHuman. Redemption (agents.RedeemAndMark, compose/agentgate.go) marks the context as released but never changes the actor's type — the redeeming caller is still the staging agent — so an agent-staged, human-approved share_record is refused at redemption every time. It is not outbound (the grant never leaves the workspace) and not a legitimate write cap (no agent call through it can succeed), so it belongs in neither other map.",
 }
 
 func TestEverySynthesizedVerbIsPinned(t *testing.T) {
-	for _, pins := range []map[string]string{synthesizedVerbs, outboundHoles} {
+	for _, pins := range []map[string]string{synthesizedVerbs, outboundHoles, deadEndVerbs} {
 		for verb, reason := range pins {
 			if strings.TrimSpace(reason) == "" {
 				t.Errorf("the pin for %s has no reason — a pin must say why the verb may resolve by synthesis", verb)
@@ -68,6 +88,9 @@ func TestEverySynthesizedVerbIsPinned(t *testing.T) {
 			continue
 		}
 		if _, known := outboundHoles[pol.Tool]; known {
+			continue
+		}
+		if _, deadEnd := deadEndVerbs[pol.Tool]; deadEnd {
 			continue
 		}
 		unexplained = append(unexplained, pol.Tool+" ("+route+")")
@@ -97,7 +120,7 @@ func TestThePinsDescribeVerbsThatStillExist(t *testing.T) {
 		}
 	}
 
-	for _, pins := range []map[string]string{synthesizedVerbs, outboundHoles} {
+	for _, pins := range []map[string]string{synthesizedVerbs, outboundHoles, deadEndVerbs} {
 		for verb := range pins {
 			if !inTable[verb] {
 				t.Errorf("%s is pinned but no longer appears in the policy table; delete the pin", verb)

--- a/backend/internal/compose/agentpolicysynthesis_test.go
+++ b/backend/internal/compose/agentpolicysynthesis_test.go
@@ -14,6 +14,7 @@ package compose
 
 import (
 	"sort"
+	"strings"
 	"testing"
 )
 
@@ -22,7 +23,7 @@ import (
 // cap for it.
 var synthesizedVerbs = map[string]string{
 	"advance_project_phase": "internal state change on a project; reversible by advancing again",
-	"draft_offer":           "regenerates a draft in place; nothing leaves the workspace",
+	"draft_offer":           "regenerates a draft in place — no message is transmitted to a counterparty; the AI lane may send the deal's context to the configured model provider, but that is governed by model routing and budget, not the send scope",
 	"relink_activity":       "moves an activity between records; internal and reversible",
 	"render_offer":          "renders a document for the caller; no transmission",
 	"share_record":          "grants and revokes access inside the workspace",
@@ -30,20 +31,30 @@ var synthesizedVerbs = map[string]string{
 }
 
 // outboundHoles are synthesized verbs that DO leave the workspace and are
-// admitted under `write` today. The value names the scope each should carry, so
-// the pin reads as the debt it is rather than as approval. Closing one means
-// registering a tool for it (as send_message was) and deleting its line.
+// admitted under `write` today. The value names the scope each should carry
+// — or, where that has not been decided, says so and why — so the pin reads
+// as the debt it is rather than as approval. Closing one means registering a
+// tool for it (as send_message was) and deleting its line.
 var outboundHoles = map[string]string{
 	"send_offer":           "send",
 	"enrich":               "enrich",
-	"connect_incumbent":    "write is likely right for authenticating a connection, but the tier and scope were never decided together — see DESIGN §3.5",
+	"connect_incumbent":    "write is likely right for authenticating a connection, but the tier and scope were never decided together",
 	"disconnect_incumbent": "as connect_incumbent",
-	"reconcile_overlay":    "enrich — the sweep it queues calls the incumbent's API and spends its budget (overlay/reconcile.go:106)",
+	"reconcile_overlay":    "enrich — the sweep it queues calls overlay.Reconcile's inc.Modified fetch against the incumbent's API and spends its budget",
 }
 
 func TestEverySynthesizedVerbIsPinned(t *testing.T) {
+	for _, pins := range []map[string]string{synthesizedVerbs, outboundHoles} {
+		for verb, reason := range pins {
+			if strings.TrimSpace(reason) == "" {
+				t.Errorf("the pin for %s has no reason — a pin must say why the verb may resolve by synthesis", verb)
+			}
+		}
+	}
+
 	registry := NewRegistry(nil, SendPath{})
 
+	checked := 0
 	unexplained := []string{}
 	for route, pol := range agentPolicies {
 		if pol.Access != accessTool {
@@ -52,6 +63,7 @@ func TestEverySynthesizedVerbIsPinned(t *testing.T) {
 		if _, registered := registry.Spec(pol.Tool); registered {
 			continue
 		}
+		checked++
 		if _, pinned := synthesizedVerbs[pol.Tool]; pinned {
 			continue
 		}
@@ -59,6 +71,9 @@ func TestEverySynthesizedVerbIsPinned(t *testing.T) {
 			continue
 		}
 		unexplained = append(unexplained, pol.Tool+" ("+route+")")
+	}
+	if checked == 0 {
+		t.Fatal("no synthesized tool routes in the generated policy — the pin no longer covers anything")
 	}
 
 	sort.Strings(unexplained)

--- a/backend/internal/compose/agentpolicysynthesis_test.go
+++ b/backend/internal/compose/agentpolicysynthesis_test.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// A verb in the generated policy table with no registered tool is not refused:
+// operationSpec synthesizes a spec for it at the write scope. That is right for
+// an internal, reversible operation and wrong for anything leaving the
+// workspace — an outbound verb admitted under `write` ignores the cap the
+// granting human set on the passport.
+//
+// The maps below are a pin, not a description: a new synthesized verb fails
+// this test until someone writes down why it may be one.
+
+import (
+	"sort"
+	"testing"
+)
+
+// synthesizedVerbs maps each verb that legitimately resolves without a
+// registered tool to the reason it may. An entry claims `write` is the right
+// cap for it.
+var synthesizedVerbs = map[string]string{
+	"advance_project_phase": "internal state change on a project; reversible by advancing again",
+	"draft_offer":           "regenerates a draft in place; nothing leaves the workspace",
+	"relink_activity":       "moves an activity between records; internal and reversible",
+	"render_offer":          "renders a document for the caller; no transmission",
+	"share_record":          "grants and revokes access inside the workspace",
+	"disqualify_lead":       "internal lifecycle change; the row survives disqualification",
+}
+
+// outboundHoles are synthesized verbs that DO leave the workspace and are
+// admitted under `write` today. The value names the scope each should carry, so
+// the pin reads as the debt it is rather than as approval. Closing one means
+// registering a tool for it (as send_message was) and deleting its line.
+var outboundHoles = map[string]string{
+	"send_offer":           "send",
+	"enrich":               "enrich",
+	"connect_incumbent":    "write is likely right for authenticating a connection, but the tier and scope were never decided together — see DESIGN §3.5",
+	"disconnect_incumbent": "as connect_incumbent",
+	"reconcile_overlay":    "enrich — the sweep it queues calls the incumbent's API and spends its budget (overlay/reconcile.go:106)",
+}
+
+func TestEverySynthesizedVerbIsPinned(t *testing.T) {
+	registry := NewRegistry(nil, SendPath{})
+
+	unexplained := []string{}
+	for route, pol := range agentPolicies {
+		if pol.Access != accessTool {
+			continue
+		}
+		if _, registered := registry.Spec(pol.Tool); registered {
+			continue
+		}
+		if _, pinned := synthesizedVerbs[pol.Tool]; pinned {
+			continue
+		}
+		if _, known := outboundHoles[pol.Tool]; known {
+			continue
+		}
+		unexplained = append(unexplained, pol.Tool+" ("+route+")")
+	}
+
+	sort.Strings(unexplained)
+	for _, verb := range unexplained {
+		t.Errorf("%s has no registered tool and no pin: it is admitted at the write scope by "+
+			"synthesis. Register a tool for it, or add it to synthesizedVerbs with the reason "+
+			"`write` is the right cap.", verb)
+	}
+}
+
+// The pins must not outlive what they describe. A verb that gains a tool, or
+// leaves the contract, loses its line — otherwise the pin becomes a list of
+// things that used to be true.
+func TestThePinsDescribeVerbsThatStillExist(t *testing.T) {
+	registry := NewRegistry(nil, SendPath{})
+
+	inTable := map[string]bool{}
+	for _, pol := range agentPolicies {
+		if pol.Access == accessTool {
+			inTable[pol.Tool] = true
+		}
+	}
+
+	for _, pins := range []map[string]string{synthesizedVerbs, outboundHoles} {
+		for verb := range pins {
+			if !inTable[verb] {
+				t.Errorf("%s is pinned but no longer appears in the policy table; delete the pin", verb)
+			}
+			if _, registered := registry.Spec(verb); registered {
+				t.Errorf("%s is pinned as synthesized but now has a registered tool; delete the pin", verb)
+			}
+		}
+	}
+}

--- a/backend/internal/compose/approval_kinds_test.go
+++ b/backend/internal/compose/approval_kinds_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gradionhq/margince/backend/internal/modules/activities"
 	"github.com/gradionhq/margince/backend/internal/modules/agents"
 	"github.com/gradionhq/margince/backend/internal/modules/approvals"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -63,6 +64,8 @@ func (stubComms) SendEmail(context.Context, ids.UUID, agents.SendEmailArgs) (jso
 func (stubComms) SendMessage(context.Context, ids.UUID, agents.SendMessageArgs) (json.RawMessage, error) {
 	return nil, nil
 }
+
+func (stubComms) IsChannelKind(kind string) bool { return activities.IsChannelKind(kind) }
 
 func (stubComms) Availability(context.Context, *ids.UUID, time.Time, time.Time, int) (json.RawMessage, error) {
 	return nil, nil

--- a/backend/internal/compose/approval_kinds_test.go
+++ b/backend/internal/compose/approval_kinds_test.go
@@ -33,6 +33,7 @@ type stubApprovals struct{}
 func (stubApprovals) Stage(_ context.Context, _ agents.StageRequest) (ids.ApprovalID, error) {
 	return ids.ApprovalID{}, nil
 }
+
 func (stubApprovals) Redeem(_ context.Context, _ ids.ApprovalID, _, _ string) (int64, bool, error) {
 	return 0, false, nil
 }
@@ -44,6 +45,7 @@ type stubRetriever struct{}
 func (stubRetriever) Search(context.Context, retrieval.Query) ([]retrieval.Hit, error) {
 	return nil, nil
 }
+
 func (stubRetriever) AssembleContext(context.Context, datasource.EntityRef, retrieval.AssembleOptions) (retrieval.Context, error) {
 	return retrieval.Context{}, nil
 }
@@ -53,12 +55,19 @@ type stubComms struct{}
 func (stubComms) DraftEmail(context.Context, ids.UUID, string) (string, string, error) {
 	return "", "", nil
 }
+
 func (stubComms) SendEmail(context.Context, ids.UUID, agents.SendEmailArgs) (json.RawMessage, error) {
 	return nil, nil
 }
+
+func (stubComms) SendMessage(context.Context, ids.UUID, agents.SendMessageArgs) (json.RawMessage, error) {
+	return nil, nil
+}
+
 func (stubComms) Availability(context.Context, *ids.UUID, time.Time, time.Time, int) (json.RawMessage, error) {
 	return nil, nil
 }
+
 func (stubComms) BookMeeting(context.Context, agents.BookMeetingArgs) (json.RawMessage, error) {
 	return nil, nil
 }
@@ -67,7 +76,7 @@ func TestEveryConfirmationRequiredToolHasADecisionGrantMapping(t *testing.T) {
 	registry := agents.NewRegistry(stubApprovals{}, nil)
 	agents.RegisterCoreTools(registry, nil, nil, nil, nil)
 	agents.RegisterIntentTools(registry, stubRetriever{})
-	agents.RegisterCommsTools(registry, stubComms{})
+	agents.RegisterCommsTools(registry, stubComms{}, nil)
 
 	for _, spec := range registry.Specs() {
 		if spec.Tier == mcp.TierAutoExecute {

--- a/backend/internal/compose/comms.go
+++ b/backend/internal/compose/comms.go
@@ -29,6 +29,11 @@ type commsAdapter struct {
 	// the HTTP transport passes, so the tool surface cannot accept a message
 	// nothing will carry.
 	stager activities.DeliveryStager
+	// channelStager is the same machinery in its channel shape. Two fields
+	// rather than one because the delivery store keeps two staging shapes: one
+	// struct carrying both an RFC822 subject and a channel recipient could
+	// describe a message that is half of each.
+	channelStager activities.ChannelDeliveryStager
 }
 
 var _ agents.Comms = commsAdapter{}
@@ -68,6 +73,21 @@ func (c commsAdapter) SendEmail(ctx context.Context, anchor ids.UUID, in agents.
 		Body:           in.Body,
 		ConsentPurpose: in.ConsentPurpose,
 	}, c.gate, c.stager)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(map[string]any{"activity_id": sent.Id, "status": "accepted"})
+}
+
+// SendMessage replies on a captured channel conversation through the SAME
+// store method the HTTP transport calls, so the consent gate, the recipient
+// resolution and the RBAC check cannot differ by transport. The recipient is
+// absent from the arguments by design: the store resolves it from the anchor.
+func (c commsAdapter) SendMessage(ctx context.Context, anchor ids.UUID, in agents.SendMessageArgs) (json.RawMessage, error) {
+	sent, err := c.store.SendMessage(ctx, ids.From[ids.ActivityKind](anchor), activities.SendMessageInput{
+		Body:           in.Body,
+		ConsentPurpose: in.ConsentPurpose,
+	}, c.gate, c.channelStager)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/compose/comms.go
+++ b/backend/internal/compose/comms.go
@@ -94,6 +94,11 @@ func (c commsAdapter) SendMessage(ctx context.Context, anchor ids.UUID, in agent
 	return json.Marshal(map[string]any{"activity_id": sent.Id, "status": "accepted"})
 }
 
+// IsChannelKind delegates to activities.IsChannelKind — the same test the
+// store's own SendMessage refuses on — so StageInfo's pre-check and Handle's
+// eventual refusal can never drift onto two different answers for the same kind.
+func (c commsAdapter) IsChannelKind(kind string) bool { return activities.IsChannelKind(kind) }
+
 func (c commsAdapter) Availability(ctx context.Context, host *ids.UUID, from, to time.Time, durationMinutes int) (json.RawMessage, error) {
 	hostID, err := defaultHost(ctx, host)
 	if err != nil {

--- a/backend/internal/compose/integration/channelsend_integration_test.go
+++ b/backend/internal/compose/integration/channelsend_integration_test.go
@@ -205,6 +205,18 @@ func (c *channelSendEnv) sendReply(t *testing.T, purpose string, headers map[str
 	return status, answer.Code, answer.Detail
 }
 
+// mintPassport issues an agent passport under the given scopes and returns its bearer token.
+func (c *channelSendEnv) mintPassport(t *testing.T, scopes []string) string {
+	t.Helper()
+	var minted struct {
+		Token string `json:"token"`
+	}
+	if status := c.call(t, "POST", "/v1/passports", anyMap{"label": "reply agent", "scopes": scopes}, nil, &minted); status != http.StatusCreated {
+		t.Fatalf("issue passport → %d", status)
+	}
+	return minted.Token
+}
+
 // stagedChannelDeliveries counts channel-shaped comms_outbound rows — the fact a
 // refusal must not leave behind, and the fact an acceptance must.
 func (c *channelSendEnv) stagedChannelDeliveries(t *testing.T) int {
@@ -233,22 +245,34 @@ func (c *channelSendEnv) outboundActivities(t *testing.T) int {
 	return n
 }
 
-// An agent caller meets the 🟡 gate: outbound and irreversible, so it may propose
-// the send and may not perform it. The refusal has to happen before the message
-// is staged — an agent that could stage one has already sent it as far as the
-// customer is concerned.
+// A write-only passport may not reach an outbound verb at all: the scope cap
+// the granting human set is checked before the tier question is asked.
+func TestSendMessageRefusesAWriteOnlyPassport(t *testing.T) {
+	c := setupChannelSend(t)
+	token := c.mintPassport(t, []string{"read", "write"})
+
+	status, code, _ := c.sendReply(t, "transactional", map[string]string{"Authorization": "Bearer " + token})
+
+	if status != http.StatusForbidden || code != "scope_exceeds_grantor" {
+		t.Fatalf("write-only passport reply → %d %q, want 403 scope_exceeds_grantor", status, code)
+	}
+	if n := c.stagedChannelDeliveries(t); n != 0 {
+		t.Fatalf("%d deliveries staged behind a scope-refused send, want 0", n)
+	}
+	if n := c.outboundActivities(t); n != 0 {
+		t.Fatalf("%d outbound activities logged behind a scope-refused send, want 0", n)
+	}
+}
+
+// A send-scoped agent caller meets the 🟡 gate: it may propose the send and may
+// not perform it. The refusal has to happen before the message is staged — an
+// agent that could stage one has already sent it as far as the customer is
+// concerned.
 func TestSendMessageRequiresAnApprovalTokenForAnAgentCaller(t *testing.T) {
 	c := setupChannelSend(t)
-	var minted struct {
-		Token string `json:"token"`
-	}
-	if status := c.call(t, "POST", "/v1/passports", anyMap{
-		"label": "reply agent", "scopes": []string{"read", "write"},
-	}, nil, &minted); status != http.StatusCreated {
-		t.Fatalf("issue passport → %d", status)
-	}
+	token := c.mintPassport(t, []string{"read", "send"})
 
-	status, code, detail := c.sendReply(t, "transactional", map[string]string{"Authorization": "Bearer " + minted.Token})
+	status, code, detail := c.sendReply(t, "transactional", map[string]string{"Authorization": "Bearer " + token})
 
 	if status != http.StatusForbidden || code != "approval_required" {
 		t.Fatalf("agent reply with no approval token → %d %q, want 403 approval_required", status, code)

--- a/backend/internal/compose/integration/channelsend_integration_test.go
+++ b/backend/internal/compose/integration/channelsend_integration_test.go
@@ -22,6 +22,7 @@ package integration
 import (
 	"context"
 	"crypto/rand"
+	"fmt"
 	"net/http"
 	"strings"
 	"testing"
@@ -181,10 +182,10 @@ func (c *channelSendEnv) connectBot(t *testing.T) {
 	}
 }
 
-// sendReply posts the reply and returns the status plus the problem's first
-// validation code — the words the rep is shown, which is where the "what do I do
-// about it" has to live.
-func (c *channelSendEnv) sendReply(t *testing.T, purpose string, headers map[string]string) (status int, code, message string) {
+// sendReply posts a reply with the given body and returns the status plus the
+// problem's first validation code — the words the rep is shown, which is
+// where the "what do I do about it" has to live.
+func (c *channelSendEnv) sendReply(t *testing.T, purpose, body string, headers map[string]string) (status int, code, message string) {
 	t.Helper()
 	var answer struct {
 		Code    string `json:"code"`
@@ -197,7 +198,7 @@ func (c *channelSendEnv) sendReply(t *testing.T, purpose string, headers map[str
 		} `json:"details"`
 	}
 	status = c.call(t, "POST", "/v1/activities/"+c.activityID+"/send-message", anyMap{
-		"body": "Yes — shipping Monday.", "consent_purpose": purpose,
+		"body": body, "consent_purpose": purpose,
 	}, headers, &answer)
 	if errs := answer.Details.Errors; len(errs) > 0 {
 		return status, errs[0].Code, errs[0].Message
@@ -215,6 +216,14 @@ func (c *channelSendEnv) mintPassport(t *testing.T, scopes []string) string {
 		t.Fatalf("issue passport → %d", status)
 	}
 	return minted.Token
+}
+
+// sendReplyAs mints a passport under the given scopes and sends the reply as
+// that agent — the two-step pattern both scope tests below share.
+func (c *channelSendEnv) sendReplyAs(t *testing.T, scopes []string, purpose string) (status int, code, message string) {
+	t.Helper()
+	token := c.mintPassport(t, scopes)
+	return c.sendReply(t, purpose, "Yes — shipping Monday.", map[string]string{"Authorization": "Bearer " + token})
 }
 
 // stagedChannelDeliveries counts channel-shaped comms_outbound rows — the fact a
@@ -245,23 +254,30 @@ func (c *channelSendEnv) outboundActivities(t *testing.T) int {
 	return n
 }
 
+// assertNoOutboundEffect fails if a refusal left behind a staged delivery or a
+// logged outbound activity — the two facts every refusal path in this suite
+// must NOT produce, named by the caller's description of the refusal.
+func (c *channelSendEnv) assertNoOutboundEffect(t *testing.T, refusal string) {
+	t.Helper()
+	if n := c.stagedChannelDeliveries(t); n != 0 {
+		t.Fatalf("%d deliveries staged behind %s, want 0", n, refusal)
+	}
+	if n := c.outboundActivities(t); n != 0 {
+		t.Fatalf("%d outbound activities logged behind %s, want 0", n, refusal)
+	}
+}
+
 // A write-only passport may not reach an outbound verb at all: the scope cap
 // the granting human set is checked before the tier question is asked.
 func TestSendMessageRefusesAWriteOnlyPassport(t *testing.T) {
 	c := setupChannelSend(t)
-	token := c.mintPassport(t, []string{"read", "write"})
 
-	status, code, _ := c.sendReply(t, "transactional", map[string]string{"Authorization": "Bearer " + token})
+	status, code, _ := c.sendReplyAs(t, []string{"read", "write"}, "transactional")
 
 	if status != http.StatusForbidden || code != "scope_exceeds_grantor" {
 		t.Fatalf("write-only passport reply → %d %q, want 403 scope_exceeds_grantor", status, code)
 	}
-	if n := c.stagedChannelDeliveries(t); n != 0 {
-		t.Fatalf("%d deliveries staged behind a scope-refused send, want 0", n)
-	}
-	if n := c.outboundActivities(t); n != 0 {
-		t.Fatalf("%d outbound activities logged behind a scope-refused send, want 0", n)
-	}
+	c.assertNoOutboundEffect(t, "a scope-refused send")
 }
 
 // A send-scoped agent caller meets the 🟡 gate: it may propose the send and may
@@ -270,9 +286,8 @@ func TestSendMessageRefusesAWriteOnlyPassport(t *testing.T) {
 // concerned.
 func TestSendMessageRequiresAnApprovalTokenForAnAgentCaller(t *testing.T) {
 	c := setupChannelSend(t)
-	token := c.mintPassport(t, []string{"read", "send"})
 
-	status, code, detail := c.sendReply(t, "transactional", map[string]string{"Authorization": "Bearer " + token})
+	status, code, detail := c.sendReplyAs(t, []string{"read", "send"}, "transactional")
 
 	if status != http.StatusForbidden || code != "approval_required" {
 		t.Fatalf("agent reply with no approval token → %d %q, want 403 approval_required", status, code)
@@ -282,12 +297,7 @@ func TestSendMessageRequiresAnApprovalTokenForAnAgentCaller(t *testing.T) {
 	if !strings.Contains(detail, "X-Approval-Token") {
 		t.Fatalf("refusal detail %q does not tell the agent how to redeem an approval", detail)
 	}
-	if n := c.stagedChannelDeliveries(t); n != 0 {
-		t.Fatalf("%d deliveries staged behind a refused agent send, want 0", n)
-	}
-	if n := c.outboundActivities(t); n != 0 {
-		t.Fatalf("%d outbound activities logged behind a refused agent send, want 0", n)
-	}
+	c.assertNoOutboundEffect(t, "a refused agent send")
 }
 
 // The human's own action IS the approval (ADR-0055), so their reply carries no
@@ -297,7 +307,7 @@ func TestSendMessageRequiresAnApprovalTokenForAnAgentCaller(t *testing.T) {
 func TestSendMessageAcceptsAHumanCallerWithoutAToken(t *testing.T) {
 	c := setupChannelSend(t)
 
-	status, code, detail := c.sendReply(t, "transactional", nil)
+	status, code, detail := c.sendReply(t, "transactional", "Yes — shipping Monday.", nil)
 
 	if status != http.StatusAccepted {
 		t.Fatalf("human reply → %d %q (%s), want 202", status, code, detail)
@@ -342,7 +352,7 @@ func TestSendMessageRefusesWhenNoBotIsBoundForTheChannel(t *testing.T) {
 		t.Fatalf("disconnecting the bot: %v", err)
 	}
 
-	status, code, detail := c.sendReply(t, "transactional", nil)
+	status, code, detail := c.sendReply(t, "transactional", "Yes — shipping Monday.", nil)
 
 	if status != http.StatusUnprocessableEntity || code != "channel_not_send_capable" {
 		t.Fatalf("reply with no bot bound → %d %q, want 422 channel_not_send_capable", status, code)
@@ -365,33 +375,18 @@ func TestSendMessageRefusesAnEmptyBody(t *testing.T) {
 	c := setupChannelSend(t)
 
 	for _, body := range []string{"", "   \n\t "} {
-		var answer struct {
-			Details struct {
-				Errors []struct {
-					Code    string `json:"code"`
-					Message string `json:"message"`
-				} `json:"errors"`
-			} `json:"details"`
-		}
-		status := c.call(t, "POST", "/v1/activities/"+c.activityID+"/send-message", anyMap{
-			"body": body, "consent_purpose": "transactional",
-		}, nil, &answer)
+		status, code, message := c.sendReply(t, "transactional", body, nil)
 
 		if status != http.StatusUnprocessableEntity {
 			t.Fatalf("reply with body %q → %d, want 422", body, status)
 		}
-		if len(answer.Details.Errors) == 0 || answer.Details.Errors[0].Code != "empty_message_body" {
-			t.Fatalf("reply with body %q answered %+v, want an empty_message_body validation error", body, answer.Details.Errors)
+		if code != "empty_message_body" {
+			t.Fatalf("reply with body %q answered code %q, want an empty_message_body validation error", body, code)
 		}
-		if detail := answer.Details.Errors[0].Message; !strings.Contains(detail, "type") {
-			t.Fatalf("refusal detail %q does not tell the rep what to do", detail)
+		if !strings.Contains(message, "type") {
+			t.Fatalf("refusal detail %q does not tell the rep what to do", message)
 		}
-		if n := c.stagedChannelDeliveries(t); n != 0 {
-			t.Fatalf("%d deliveries staged behind an empty body %q, want 0", n, body)
-		}
-		if n := c.outboundActivities(t); n != 0 {
-			t.Fatalf("%d outbound activities logged behind an empty body %q, want 0", n, body)
-		}
+		c.assertNoOutboundEffect(t, fmt.Sprintf("an empty body %q", body))
 	}
 }
 
@@ -402,17 +397,12 @@ func TestSendMessageRefusesAnEmptyBody(t *testing.T) {
 func TestSendMessageRefusesWithoutConsentForThePurpose(t *testing.T) {
 	c := setupChannelSend(t)
 
-	status, code, _ := c.sendReply(t, "marketing_email", nil)
+	status, code, _ := c.sendReply(t, "marketing_email", "Yes — shipping Monday.", nil)
 
 	if status != http.StatusConflict || code != "consent_not_granted" {
 		t.Fatalf("reply under an ungranted purpose → %d %q, want 409 consent_not_granted", status, code)
 	}
-	if n := c.stagedChannelDeliveries(t); n != 0 {
-		t.Fatalf("%d deliveries staged behind a suppressed reply, want 0", n)
-	}
-	if n := c.outboundActivities(t); n != 0 {
-		t.Fatalf("%d outbound activities logged behind a suppressed reply, want 0", n)
-	}
+	c.assertNoOutboundEffect(t, "a suppressed reply")
 }
 
 // A person who blocked the bot cannot be reached, and blocking does NOT archive
@@ -428,7 +418,7 @@ func TestSendMessageRefusesAnUnreachablePerson(t *testing.T) {
 		t.Fatalf("blocking the identity: %v", err)
 	}
 
-	status, code, detail := c.sendReply(t, "transactional", nil)
+	status, code, detail := c.sendReply(t, "transactional", "Yes — shipping Monday.", nil)
 
 	if status != http.StatusUnprocessableEntity || code != "person_unreachable" {
 		t.Fatalf("reply to a blocked person → %d %q, want 422 person_unreachable", status, code)
@@ -436,12 +426,7 @@ func TestSendMessageRefusesAnUnreachablePerson(t *testing.T) {
 	if !strings.Contains(detail, "blocked") {
 		t.Fatalf("refusal detail %q does not say why the person cannot be reached", detail)
 	}
-	if n := c.stagedChannelDeliveries(t); n != 0 {
-		t.Fatalf("%d deliveries staged behind an unreachable recipient, want 0", n)
-	}
-	if n := c.outboundActivities(t); n != 0 {
-		t.Fatalf("%d outbound activities logged behind an unreachable recipient, want 0", n)
-	}
+	c.assertNoOutboundEffect(t, "an unreachable recipient")
 }
 
 // Without the outbound activity the UI's optimistic append vanishes the moment

--- a/backend/internal/compose/integration/channelsend_mcp_integration_test.go
+++ b/backend/internal/compose/integration/channelsend_mcp_integration_test.go
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The send_message tool's own loop, end to end over the real database: an
+// MCP tools/call → the 🟡 refusal STAGES an approval instead of dead-ending
+// (agents.Registry.Invoke's staging branch, registry.go:126-150) → a human
+// approves it → the retry carrying approval_id is the ONLY call that reaches
+// Handle and performs the send.
+//
+// channelsend_integration_test.go proves the REST twin of this refusal, but
+// that is a DIFFERENT code path (compose/agentgate.go's stageRefusal via
+// canonicalRESTCall) that predates this branch and exercises neither
+// sendMessageTool.StageInfo nor Invoke's staging branch. This file is the
+// one proof of the MCP loop.
+//
+// It drives Registry.Invoke directly rather than the wire transport: the
+// JSON-RPC framing, discovery and admission machinery is already proven end
+// to end by mcp_transport_integration_test.go against a different tool, and
+// Invoke is the one call every transport — stdio, hosted MCP, Surface B —
+// dispatches through (registry.go's package comment). What was missing is
+// the send_message-specific stage → approve → redeem loop against real
+// Postgres, which is what this test drives.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
+	"github.com/gradionhq/margince/backend/internal/platform/jobs"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/workflow"
+)
+
+// sendMessageInvoker builds the SAME governed registry the api role
+// composes — including a REAL delivery machinery, so a redeemed send lands
+// in comms_outbound instead of refusing on a nil stager — and returns an
+// Invoke closure that re-authenticates the passport per call, exactly as
+// every transport does (registry.go's Invoke doc: "There is no other path
+// to a Handle in this package").
+func (c *channelSendEnv) sendMessageInvoker(t *testing.T, agentToken string) func(args string) (string, error) {
+	t.Helper()
+	ensureRiverSchema(t)
+	inserter, err := jobs.NewInserter(c.pool, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err != nil {
+		t.Fatalf("jobs.NewInserter: %v", err)
+	}
+	registry := compose.NewRegistry(c.pool, compose.SendPath{
+		Delivery: compose.NewDeliveryStager(c.pool, inserter),
+	})
+	authSvc := identity.NewService(c.pool)
+	return func(args string) (string, error) {
+		wsID, err := authSvc.InstallationWorkspace(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		ctx := principal.WithWorkspaceID(context.Background(), wsID.UUID)
+		agent, err := authSvc.AuthenticateAgent(ctx, agentToken)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ctx = principal.WithCorrelationID(principal.WithActor(ctx, agent.Principal()), ids.NewV7())
+		out, invokeErr := registry.Invoke(ctx, "send_message", json.RawMessage(args))
+		return string(out), invokeErr
+	}
+}
+
+// TestSendMessageMCPLoopStagesApprovesAndRedeemsAgainstRealPostgres proves
+// the loop finding 2 found unproven: a send-scoped agent's tools/call
+// refusal stages a REAL approval row and sends nothing; a human's approval
+// makes it decidable; the retry carrying approval_id is the only call that
+// reaches Handle and produces the outbound activity plus its staged
+// delivery; and the redemption is single-use.
+func TestSendMessageMCPLoopStagesApprovesAndRedeemsAgainstRealPostgres(t *testing.T) {
+	c := setupChannelSend(t)
+	token := c.mintPassport(t, []string{"read", "send"})
+	invoke := c.sendMessageInvoker(t, token)
+
+	args := fmt.Sprintf(`{"activity_id":%q,"body":"Yes — shipping Monday.","consent_purpose":"transactional"}`, c.activityID)
+
+	_, err := invoke(args)
+	var staged *workflow.StagedApprovalError
+	if !errors.As(err, &staged) {
+		t.Fatalf("first send_message call → %v, want a StagedApprovalError", err)
+	}
+	if staged.ApprovalID.IsZero() {
+		t.Fatal("StagedApprovalError carries a zero approval id")
+	}
+	c.assertNoOutboundEffect(t, "a staged-but-not-yet-approved send_message call")
+
+	if status := c.call(t, "POST", "/v1/approvals/"+staged.ApprovalID.String()+"/approve", anyMap{}, nil, nil); status != http.StatusOK {
+		t.Fatalf("human approve → %d", status)
+	}
+
+	retryArgs := fmt.Sprintf(
+		`{"activity_id":%q,"body":"Yes — shipping Monday.","consent_purpose":"transactional","approval_id":%q}`,
+		c.activityID, staged.ApprovalID.String())
+	out, retryErr := invoke(retryArgs)
+	if retryErr != nil {
+		t.Fatalf("approved retry → %v, want it to reach Handle and send", retryErr)
+	}
+	var sent struct {
+		ActivityID string `json:"activity_id"`
+		Status     string `json:"status"`
+	}
+	if err := json.Unmarshal([]byte(out), &sent); err != nil {
+		t.Fatalf("send_message result does not decode: %v (%s)", err, out)
+	}
+	if sent.Status != "accepted" {
+		t.Fatalf("send_message result = %+v, want status accepted", sent)
+	}
+
+	if n := c.stagedChannelDeliveries(t); n != 1 {
+		t.Fatalf("%d channel deliveries staged after the approved retry, want 1", n)
+	}
+	if n := c.outboundActivities(t); n != 1 {
+		t.Fatalf("%d outbound activities logged after the approved retry, want 1", n)
+	}
+
+	// Exactly-once: the approval was consumed by the retry above, so
+	// replaying the identical call must not send a second time.
+	if _, replayErr := invoke(retryArgs); replayErr == nil {
+		t.Fatal("replaying a consumed approval succeeded; redemption must be single-use")
+	}
+	if n := c.stagedChannelDeliveries(t); n != 1 {
+		t.Fatalf("%d channel deliveries staged after replaying a consumed approval, want still 1", n)
+	}
+}

--- a/backend/internal/compose/integration/channelsend_mcp_integration_test.go
+++ b/backend/internal/compose/integration/channelsend_mcp_integration_test.go
@@ -35,6 +35,8 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/jackc/pgx/v5"
+
 	"github.com/gradionhq/margince/backend/internal/compose"
 	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/platform/jobs"
@@ -121,6 +123,21 @@ func TestSendMessageMCPLoopStagesApprovesAndRedeemsAgainstRealPostgres(t *testin
 		t.Fatalf("send_message result = %+v, want status accepted", sent)
 	}
 
+	// The delivery names THIS activity (channelsend.go's outboundChannelMessage
+	// doc), so the id the tool call handed back must be the same id the staged
+	// delivery anchors on — otherwise the response could name any activity while
+	// the delivery transmits a different one.
+	var deliveryActivity string
+	if err := c.inWorkspace(t, c.slug, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT activity_id::text FROM comms_outbound WHERE channel_user_id IS NOT NULL`).Scan(&deliveryActivity)
+	}); err != nil {
+		t.Fatalf("reading the staged delivery's activity: %v", err)
+	}
+	if deliveryActivity != sent.ActivityID {
+		t.Fatalf("the staged delivery anchors activity %s, want the one the response named (%s)", deliveryActivity, sent.ActivityID)
+	}
+
 	if n := c.stagedChannelDeliveries(t); n != 1 {
 		t.Fatalf("%d channel deliveries staged after the approved retry, want 1", n)
 	}
@@ -135,5 +152,8 @@ func TestSendMessageMCPLoopStagesApprovesAndRedeemsAgainstRealPostgres(t *testin
 	}
 	if n := c.stagedChannelDeliveries(t); n != 1 {
 		t.Fatalf("%d channel deliveries staged after replaying a consumed approval, want still 1", n)
+	}
+	if n := c.outboundActivities(t); n != 1 {
+		t.Fatalf("%d outbound activities logged after replaying a consumed approval, want still 1", n)
 	}
 }

--- a/backend/internal/compose/integration/channelsend_no_gmail_integration_test.go
+++ b/backend/internal/compose/integration/channelsend_no_gmail_integration_test.go
@@ -84,7 +84,7 @@ func TestSendMessageRefusesWithNoGoogleAppConfiguredAndNoBotBound(t *testing.T) 
 	c := setupChannelSendNoGmail(t)
 	// No connectBot call: this workspace has bound no bot for telegram.
 
-	status, code, detail := c.sendReply(t, "transactional", nil)
+	status, code, detail := c.sendReply(t, "transactional", "Yes — shipping Monday.", nil)
 
 	if status != http.StatusUnprocessableEntity || code != "channel_not_send_capable" {
 		t.Fatalf("reply with no Google app configured and no bot bound → %d %q, want 422 channel_not_send_capable", status, code)
@@ -105,7 +105,7 @@ func TestSendMessageAcceptsWithNoGoogleAppConfiguredButABotBound(t *testing.T) {
 	c := setupChannelSendNoGmail(t)
 	c.connectBot(t)
 
-	status, code, detail := c.sendReply(t, "transactional", nil)
+	status, code, detail := c.sendReply(t, "transactional", "Yes — shipping Monday.", nil)
 
 	if status != http.StatusAccepted {
 		t.Fatalf("reply with a bot bound and no Google app configured → %d %q (%s), want 202", status, code, detail)

--- a/backend/internal/compose/registry.go
+++ b/backend/internal/compose/registry.go
@@ -83,7 +83,7 @@ func registryWithGate(pool *pgxpool.Pool, gate *auth.Gate, drafter activities.Em
 	// and how a deal is covered. Both 🟢 — they name people, they change
 	// nothing.
 	agents.RegisterNetworkTools(registry, whoKnowsLister(pool), coverageReader(pool))
-	agents.RegisterCommsTools(registry, newCommsAdapter(pool, drafter, send))
+	agents.RegisterCommsTools(registry, newCommsAdapter(pool, drafter, send), provider)
 	// The composed extension set's governed tools ride the same registry
 	// and admission gate as the core tools, registered last so a name that
 	// collides with a core verb fails loudly (RegisterExtensions stashed

--- a/backend/internal/compose/sendpath.go
+++ b/backend/internal/compose/sendpath.go
@@ -136,9 +136,10 @@ func sendStore(pool *pgxpool.Pool, send SendPath) *activities.Store {
 // that surface has no send to configure.
 func newCommsAdapter(pool *pgxpool.Pool, drafter activities.EmailDrafter, send SendPath) commsAdapter {
 	return commsAdapter{
-		store:  sendStore(pool, send),
-		gate:   consent.NewGate(consent.NewStore(pool)),
-		draft:  drafter,
-		stager: send.Delivery,
+		store:         sendStore(pool, send),
+		gate:          consent.NewGate(consent.NewStore(pool)),
+		draft:         drafter,
+		stager:        send.Delivery,
+		channelStager: send.Delivery,
 	}
 }

--- a/backend/internal/modules/agents/stagingfitness_test.go
+++ b/backend/internal/modules/agents/stagingfitness_test.go
@@ -15,9 +15,10 @@ package agents
 //   - update_record stages through stageConflicts, not StageInfo, so it is
 //     invisible here; TestUpdateRecordRefusesStagingForATargetHeldElsewhere is
 //     its pin, and that test fails if its guard is removed.
-//   - the walk builds only RegisterCoreTools. Every stageable tool lives there
-//     today; one registered by another family would escape, which is what the
-//     count assertion below is for — it changes the moment the core set does.
+//   - the walk builds only RegisterCoreTools and RegisterCommsTools. Every
+//     stageable tool lives in one of the two today; one registered by a third
+//     family would escape, which is what the count assertion below is for — it
+//     changes the moment either set does.
 
 import (
 	"context"
@@ -42,13 +43,14 @@ func (elsewhereProvider) Read(_ context.Context, ref datasource.EntityRef) (data
 }
 
 func TestEveryStageableToolRefusesATargetHeldElsewhere(t *testing.T) {
-	person, lead, deal, stage := ids.NewV7(), ids.NewV7(), ids.NewV7(), ids.NewV7()
+	person, lead, deal, stage, activity := ids.NewV7(), ids.NewV7(), ids.NewV7(), ids.NewV7(), ids.NewV7()
 	args := map[string]string{
 		"archive_record": fmt.Sprintf(`{"record_type":"person","id":%q}`, person),
 		"promote_lead":   fmt.Sprintf(`{"lead_id":%q,"trigger":"meeting_booked"}`, lead),
 		"merge_records":  fmt.Sprintf(`{"record_type":"person","source_id":%q,"target_id":%q}`, ids.NewV7(), person),
 		"advance_deal":   fmt.Sprintf(`{"deal_id":%q,"to_stage_id":%q}`, deal, stage),
 		"progress_deal":  fmt.Sprintf(`{"deal_id":%q,"to_stage_id":%q,"note":"n"}`, deal, stage),
+		"send_message":   fmt.Sprintf(`{"activity_id":%q,"body":"b","consent_purpose":"support"}`, activity),
 	}
 
 	registry := NewRegistry(&recordingApprovals{}, nil)
@@ -56,6 +58,7 @@ func TestEveryStageableToolRefusesATargetHeldElsewhere(t *testing.T) {
 	// before advance_deal/progress_deal reach StageSemantic, so its answer is
 	// never read on this path.
 	RegisterCoreTools(registry, elsewhereProvider{}, fixedStages{semantic: "won"}, nil, noConflicts{})
+	RegisterCommsTools(registry, &recordingComms{}, elsewhereProvider{})
 
 	// registry.tools IS the universe — walking Specs() and looking the name back
 	// up adds a miss branch that could silently hide a tool from this pin.

--- a/backend/internal/modules/agents/tools_comms.go
+++ b/backend/internal/modules/agents/tools_comms.go
@@ -5,7 +5,7 @@ package agents
 
 // The communication verbs on the MCP surface (crm.yaml x-mcp-tool):
 // draft_email / check_availability are 🟢 (propose, never commit);
-// send_email / book_meeting are 🟡 — the registry's admission gate
+// send_email / send_message / book_meeting are 🟡 — the registry's admission gate
 // stages them for approval exactly like every other confirmation_required tool. The
 // module never touches activities' internals: compose injects the
 // Comms seam, which delegates to the SAME store methods the HTTP
@@ -14,10 +14,12 @@ package agents
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/mcp"
 )
 
@@ -26,6 +28,10 @@ import (
 type Comms interface {
 	DraftEmail(ctx context.Context, anchor ids.UUID, intent string) (subject, body string, err error)
 	SendEmail(ctx context.Context, anchor ids.UUID, in SendEmailArgs) (json.RawMessage, error)
+	// SendMessage replies on a captured channel conversation. It takes no
+	// addressee: the recipient is the person the anchor conversation is with,
+	// resolved server-side, so a reply can only reach the human who opened it.
+	SendMessage(ctx context.Context, anchor ids.UUID, in SendMessageArgs) (json.RawMessage, error)
 	Availability(ctx context.Context, host *ids.UUID, from, to time.Time, durationMinutes int) (json.RawMessage, error)
 	BookMeeting(ctx context.Context, in BookMeetingArgs) (json.RawMessage, error)
 }
@@ -36,6 +42,14 @@ type SendEmailArgs struct {
 	Subject        string   `json:"subject"`
 	Body           string   `json:"body"`
 	ConsentPurpose string   `json:"consent_purpose"`
+}
+
+// SendMessageArgs is one channel reply. It carries no subject and no
+// addressee, and that absence is the transport's shape rather than an
+// omission: a messaging channel has neither.
+type SendMessageArgs struct {
+	Body           string `json:"body"`
+	ConsentPurpose string `json:"consent_purpose"`
 }
 
 type BookMeetingArgs struct {
@@ -49,13 +63,16 @@ type BookMeetingArgs struct {
 	} `json:"links"`
 }
 
-// RegisterCommsTools wires the four verbs over the injected seam.
-func RegisterCommsTools(r *Registry, comms Comms) {
+// RegisterCommsTools wires the five verbs over the injected seam. The provider
+// is the record reader send_message stages against; the other four verbs do not
+// stage and never read it.
+func RegisterCommsTools(r *Registry, comms Comms, p datasource.SystemOfRecordProvider) {
 	if comms == nil {
 		return
 	}
 	r.Register(draftEmailTool{comms: comms})
 	r.Register(sendEmailTool{comms: comms})
+	r.Register(sendMessageTool{comms: comms, p: p})
 	r.Register(checkAvailability{comms: comms})
 	r.Register(bookMeetingTool{comms: comms})
 }
@@ -124,6 +141,65 @@ func (t sendEmailTool) Handle(ctx context.Context, in json.RawMessage) (json.Raw
 		return nil, err
 	}
 	return t.comms.SendEmail(ctx, args.ActivityID, args.SendEmailArgs)
+}
+
+// --- send_message (🟡: outbound + irreversible, the channel twin of send_email) ---
+
+// sendMessageTool carries a record reader its mail twin does not: a 🟡 tool
+// stages through StageInfo, and staging has to know the version of the row the
+// effect targets and refuse one whose authority lives in another system.
+type sendMessageTool struct {
+	comms Comms
+	p     datasource.SystemOfRecordProvider
+}
+
+func (t sendMessageTool) Spec() mcp.ToolSpec {
+	return mcp.ToolSpec{
+		Name: "send_message", Version: toolVersionV1,
+		RequiredScope: principal.ScopeSend, Tier: mcp.TierConfirmationRequired, Egress: true,
+		OpenAPIOp: "sendMessage",
+		InputSchema: schema(`{"type":"object","required":["activity_id","body","consent_purpose"],"properties":{
+			"activity_id":{"type":"string","format":"uuid","description":"The captured conversation being replied to"},
+			"body":{"type":"string","minLength":1},
+			"consent_purpose":{"type":"string","description":"Purpose key the recipient must have granted"},
+			"approval_id":{"type":"string","format":"uuid","description":"Set on retry after a human approved the staged call"}},
+			"additionalProperties":false}`),
+		OutputSchema: schema(`{"type":"object"}`),
+	}
+}
+
+type sendMessageToolArgs struct {
+	ActivityID ids.UUID `json:"activity_id"`
+	SendMessageArgs
+}
+
+func (t sendMessageTool) StageInfo(ctx context.Context, in json.RawMessage) (StageInfo, error) {
+	var args sendMessageToolArgs
+	if err := decodeArgs(in, &args); err != nil {
+		return StageInfo{}, err
+	}
+	rec, err := t.p.Read(ctx, datasource.EntityRef{Type: datasource.EntityActivity, ID: args.ActivityID})
+	if err != nil {
+		return StageInfo{}, err
+	}
+	if err := refuseStagingElsewhere(rec); err != nil {
+		return StageInfo{}, err
+	}
+	return StageInfo{
+		TargetType: string(datasource.EntityActivity), TargetID: args.ActivityID, TargetVersion: &rec.Version,
+		// The inbox shows the human what they are releasing. The message text
+		// is the thing being approved, so it belongs in the summary; the
+		// recipient does not, because nobody named one — the conversation did.
+		Summary: fmt.Sprintf("Reply on a captured conversation: %q", args.Body),
+	}, nil
+}
+
+func (t sendMessageTool) Handle(ctx context.Context, in json.RawMessage) (json.RawMessage, error) {
+	var args sendMessageToolArgs
+	if err := decodeArgs(in, &args); err != nil {
+		return nil, err
+	}
+	return t.comms.SendMessage(ctx, args.ActivityID, args.SendMessageArgs)
 }
 
 // --- check_availability (🟢 read) ---

--- a/backend/internal/modules/agents/tools_comms.go
+++ b/backend/internal/modules/agents/tools_comms.go
@@ -197,6 +197,18 @@ func (t sendMessageTool) StageInfo(ctx context.Context, in json.RawMessage) (Sta
 	// mints an approval a human can approve, the approved retry consumes that
 	// one-shot approval on redemption, and only then does the store refuse
 	// permanently — a "yes" with no path to actually happening.
+	//
+	// SendMessage has two more permanent refusals this does not guard:
+	// ChannelRecipientError (the conversation reaches nobody, or more than
+	// one person) and ChannelNotSendCapableError (the workspace has no bot
+	// bound for the provider). Both are the same "yes with no path to
+	// actually happening" shape as the two guarded above, but closing them
+	// needs a reachability read this call does not have: the record read
+	// above returns the anchor's fields, not who the conversation resolves
+	// to or whether a bot is bound, and answering either question here would
+	// mean a new datasource seam method plus a database read at staging
+	// time — staging today only reads the anchor already fetched for
+	// version-pinning.
 	if strings.TrimSpace(args.Body) == "" {
 		return StageInfo{}, &BadArgsError{Cause: fmt.Errorf("body is empty or whitespace-only; a channel provider rejects a text-less message")}
 	}

--- a/backend/internal/modules/agents/tools_comms.go
+++ b/backend/internal/modules/agents/tools_comms.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -32,6 +33,12 @@ type Comms interface {
 	// addressee: the recipient is the person the anchor conversation is with,
 	// resolved server-side, so a reply can only reach the human who opened it.
 	SendMessage(ctx context.Context, anchor ids.UUID, in SendMessageArgs) (json.RawMessage, error)
+	// IsChannelKind reports whether an activity kind is a messaging-channel
+	// conversation send_message may reply on. StageInfo needs the exact
+	// answer activities.IsChannelKind gives — the same test the store's own
+	// SendMessage refuses on — but this module may not import activities
+	// directly (modules never import a sibling), so the seam carries it.
+	IsChannelKind(kind string) bool
 	Availability(ctx context.Context, host *ids.UUID, from, to time.Time, durationMinutes int) (json.RawMessage, error)
 	BookMeeting(ctx context.Context, in BookMeetingArgs) (json.RawMessage, error)
 }
@@ -184,6 +191,24 @@ func (t sendMessageTool) StageInfo(ctx context.Context, in json.RawMessage) (Sta
 	}
 	if err := refuseStagingElsewhere(rec); err != nil {
 		return StageInfo{}, err
+	}
+	// Refuse here what Handle's eventual SendMessage call would refuse anyway
+	// (errEmptyMessageBody, NotAChannelConversationError): otherwise staging
+	// mints an approval a human can approve, the approved retry consumes that
+	// one-shot approval on redemption, and only then does the store refuse
+	// permanently — a "yes" with no path to actually happening.
+	if strings.TrimSpace(args.Body) == "" {
+		return StageInfo{}, &BadArgsError{Cause: fmt.Errorf("body is empty or whitespace-only; a channel provider rejects a text-less message")}
+	}
+	var anchor struct {
+		Kind string `json:"kind"`
+	}
+	if err := json.Unmarshal(rec.Fields, &anchor); err != nil {
+		return StageInfo{}, fmt.Errorf("crmagents: activity %s read back with unreadable fields: %w", args.ActivityID, err)
+	}
+	if !t.comms.IsChannelKind(anchor.Kind) {
+		return StageInfo{}, &BadArgsError{Cause: fmt.Errorf(
+			"activity %s is a %q activity, not a messaging-channel conversation; reply on the channel the conversation was held on", args.ActivityID, anchor.Kind)}
 	}
 	return StageInfo{
 		TargetType: string(datasource.EntityActivity), TargetID: args.ActivityID, TargetVersion: &rec.Version,

--- a/backend/internal/modules/agents/tools_comms_test.go
+++ b/backend/internal/modules/agents/tools_comms_test.go
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/mcp"
+)
+
+// recordingComms captures what the tool handed the seam.
+type recordingComms struct {
+	anchor ids.UUID
+	args   SendMessageArgs
+}
+
+func (c *recordingComms) DraftEmail(context.Context, ids.UUID, string) (string, string, error) {
+	return "", "", nil
+}
+func (c *recordingComms) SendEmail(context.Context, ids.UUID, SendEmailArgs) (json.RawMessage, error) {
+	return nil, nil
+}
+func (c *recordingComms) Availability(context.Context, *ids.UUID, time.Time, time.Time, int) (json.RawMessage, error) {
+	return nil, nil
+}
+func (c *recordingComms) BookMeeting(context.Context, BookMeetingArgs) (json.RawMessage, error) {
+	return nil, nil
+}
+func (c *recordingComms) SendMessage(_ context.Context, anchor ids.UUID, in SendMessageArgs) (json.RawMessage, error) {
+	c.anchor, c.args = anchor, in
+	return json.RawMessage(`{"status":"accepted"}`), nil
+}
+
+// nativeActivityProvider serves the anchor as a row this database owns —
+// Freshness.Authoritative true, the only case an approval can be released for.
+type nativeActivityProvider struct {
+	datasource.SystemOfRecordProvider
+	version int64
+}
+
+func (p nativeActivityProvider) Read(_ context.Context, ref datasource.EntityRef) (datasource.Record, error) {
+	return datasource.Record{
+		Ref: ref, Version: p.version,
+		Freshness: datasource.FreshnessInfo{Authoritative: true},
+		Fields:    json.RawMessage(`{"kind":"telegram"}`),
+	}, nil
+}
+
+// mirroredActivityProvider serves it as a record held elsewhere — the shape
+// overlay.Provider returns, and the one refuseStagingElsewhere exists for.
+type mirroredActivityProvider struct {
+	datasource.SystemOfRecordProvider
+}
+
+func (mirroredActivityProvider) Read(_ context.Context, ref datasource.EntityRef) (datasource.Record, error) {
+	return datasource.Record{Ref: ref, Fields: json.RawMessage(`{"kind":"telegram"}`)}, nil
+}
+
+// The channel reply governs exactly as the mail send does: same scope, same
+// tier, same egress declaration. A transport difference is not a governance
+// difference.
+func TestSendMessageToolGovernsAsSendEmailDoes(t *testing.T) {
+	spec := sendMessageTool{}.Spec()
+
+	if spec.RequiredScope != principal.ScopeSend {
+		t.Errorf("RequiredScope = %q, want %q", spec.RequiredScope, principal.ScopeSend)
+	}
+	if spec.Tier != mcp.TierConfirmationRequired {
+		t.Errorf("Tier = %v, want TierConfirmationRequired", spec.Tier)
+	}
+	if !spec.Egress {
+		t.Error("Egress = false; the reply leaves the workspace")
+	}
+	if spec.OpenAPIOp != "sendMessage" {
+		t.Errorf("OpenAPIOp = %q, want %q", spec.OpenAPIOp, "sendMessage")
+	}
+}
+
+// The recipient is never an argument: it is resolved from the conversation.
+func TestSendMessageToolNamesNoRecipient(t *testing.T) {
+	var decoded struct {
+		Properties           map[string]json.RawMessage `json:"properties"`
+		AdditionalProperties bool                       `json:"additionalProperties"`
+	}
+	if err := json.Unmarshal(sendMessageTool{}.Spec().InputSchema, &decoded); err != nil {
+		t.Fatalf("input schema is not JSON: %v", err)
+	}
+	if len(decoded.Properties) == 0 {
+		t.Fatal("input schema declares no properties")
+	}
+	for _, forbidden := range []string{"to", "cc", "chat_id", "recipient", "subject"} {
+		if _, present := decoded.Properties[forbidden]; present {
+			t.Errorf("input schema accepts %q; the recipient is resolved from the conversation", forbidden)
+		}
+	}
+	if decoded.AdditionalProperties {
+		t.Error("input schema does not close additionalProperties")
+	}
+}
+
+// A 🟡 tool that cannot describe its own staging is advertised and unusable:
+// Invoke drops a non-stageable tool with the bare refusal and creates no
+// approval (registry.go:127).
+func TestSendMessageToolStagesAgainstTheConversation(t *testing.T) {
+	anchor := ids.NewV7()
+	tool := sendMessageTool{comms: &recordingComms{}, p: nativeActivityProvider{version: 7}}
+
+	info, err := tool.StageInfo(context.Background(),
+		json.RawMessage(`{"activity_id":"`+anchor.String()+`","body":"b","consent_purpose":"support"}`))
+	if err != nil {
+		t.Fatalf("StageInfo: %v", err)
+	}
+	if info.TargetType != string(datasource.EntityActivity) || info.TargetID != anchor {
+		t.Errorf("staged against %s/%v, want activity/%v", info.TargetType, info.TargetID, anchor)
+	}
+	if info.TargetVersion == nil || *info.TargetVersion != 7 {
+		t.Errorf("TargetVersion = %v, want the anchor's row version so redemption re-checks it", info.TargetVersion)
+	}
+	if info.Summary == "" {
+		t.Error("Summary is empty; the inbox would show an unlabelled approval")
+	}
+}
+
+// An approval for a record held in an external system of record could never be
+// released, so staging refuses rather than creating one.
+func TestSendMessageToolRefusesToStageAMirroredConversation(t *testing.T) {
+	tool := sendMessageTool{comms: &recordingComms{}, p: mirroredActivityProvider{}}
+
+	_, err := tool.StageInfo(context.Background(),
+		json.RawMessage(`{"activity_id":"`+ids.NewV7().String()+`","body":"b","consent_purpose":"support"}`))
+	if !errors.Is(err, apperrors.ErrUnsupportedBySoR) {
+		t.Errorf("StageInfo err = %v, want ErrUnsupportedBySoR for a mirror-backed conversation", err)
+	}
+}
+
+func TestSendMessageToolPassesTheAnchorAndArgsToTheSeam(t *testing.T) {
+	comms := &recordingComms{}
+	anchor := ids.NewV7()
+
+	out, err := sendMessageTool{comms: comms, p: nativeActivityProvider{}}.Handle(context.Background(),
+		json.RawMessage(`{"activity_id":"`+anchor.String()+`","body":"on my way","consent_purpose":"support"}`))
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if comms.anchor != anchor {
+		t.Errorf("anchor = %v, want %v", comms.anchor, anchor)
+	}
+	if comms.args.Body != "on my way" || comms.args.ConsentPurpose != "support" {
+		t.Errorf("args = %+v, want body %q purpose %q", comms.args, "on my way", "support")
+	}
+	if string(out) != `{"status":"accepted"}` {
+		t.Errorf("out = %s, want the seam's own answer", out)
+	}
+}
+
+// decodeArgs rejects unknown fields but does not require non-zero ones
+// (tools.go:74). An unknown field must still be refused here, so a client
+// typo is never silently dropped into a customer-visible send.
+func TestSendMessageToolRefusesUnknownArguments(t *testing.T) {
+	_, err := sendMessageTool{comms: &recordingComms{}, p: nativeActivityProvider{}}.Handle(
+		context.Background(),
+		json.RawMessage(`{"activity_id":"`+ids.NewV7().String()+`","body":"b","consent_purpose":"support","to":"@someone"}`))
+	if err == nil {
+		t.Error("an unknown `to` argument was accepted; the recipient is not the caller's to name")
+	}
+}
+
+func TestRegisterCommsToolsRegistersTheChannelReply(t *testing.T) {
+	r := NewRegistry(nil, nil)
+	RegisterCommsTools(r, &recordingComms{}, nativeActivityProvider{})
+
+	if _, ok := r.Spec("send_message"); !ok {
+		t.Error("send_message is not registered; the MCP surface cannot reach the channel reply")
+	}
+}

--- a/backend/internal/modules/agents/tools_comms_test.go
+++ b/backend/internal/modules/agents/tools_comms_test.go
@@ -44,18 +44,35 @@ func (c *recordingComms) SendMessage(_ context.Context, anchor ids.UUID, in Send
 	return json.RawMessage(`{"status":"accepted"}`), nil
 }
 
+// IsChannelKind mirrors activities.IsChannelKind's answer for this
+// installation's one wired channel provider, without importing that module
+// (agents may not import a sibling): "telegram" is the only kind
+// send_message can ever reply on, so it is the only one this double admits.
+func (c *recordingComms) IsChannelKind(kind string) bool { return kind == "telegram" }
+
 // nativeActivityProvider serves the anchor as a row this database owns —
 // Freshness.Authoritative true, the only case an approval can be released for.
 type nativeActivityProvider struct {
 	datasource.SystemOfRecordProvider
 	version int64
+	// kind is the anchor activity's kind; empty defaults to "telegram" so
+	// existing call sites that don't care about the kind stay a channel.
+	kind string
 }
 
 func (p nativeActivityProvider) Read(_ context.Context, ref datasource.EntityRef) (datasource.Record, error) {
+	kind := p.kind
+	if kind == "" {
+		kind = "telegram"
+	}
+	fields, err := json.Marshal(map[string]string{"kind": kind})
+	if err != nil {
+		return datasource.Record{}, err
+	}
 	return datasource.Record{
 		Ref: ref, Version: p.version,
 		Freshness: datasource.FreshnessInfo{Authoritative: true},
-		Fields:    json.RawMessage(`{"kind":"telegram"}`),
+		Fields:    fields,
 	}, nil
 }
 
@@ -147,6 +164,40 @@ func TestSendMessageToolRefusesToStageAMirroredConversation(t *testing.T) {
 		json.RawMessage(`{"activity_id":"`+ids.NewV7().String()+`","body":"b","consent_purpose":"support"}`))
 	if !errors.Is(err, apperrors.ErrUnsupportedBySoR) {
 		t.Errorf("StageInfo err = %v, want ErrUnsupportedBySoR for a mirror-backed conversation", err)
+	}
+}
+
+// An empty (or whitespace-only) body must never mint an approval: Handle's
+// eventual SendMessage call refuses it with errEmptyMessageBody, so a human
+// who approved it would have released a "yes" that can only fail on
+// redemption — the shape StageInfo exists to close off.
+func TestSendMessageToolRefusesToStageAnEmptyBody(t *testing.T) {
+	for name, body := range map[string]string{"empty": "", "whitespace-only": "   "} {
+		t.Run(name, func(t *testing.T) {
+			tool := sendMessageTool{comms: &recordingComms{}, p: nativeActivityProvider{}}
+
+			_, err := tool.StageInfo(context.Background(),
+				json.RawMessage(`{"activity_id":"`+ids.NewV7().String()+`","body":"`+body+`","consent_purpose":"support"}`))
+			var bad *BadArgsError
+			if !errors.As(err, &bad) {
+				t.Errorf("StageInfo err = %v, want *BadArgsError for a %s body", err, name)
+			}
+		})
+	}
+}
+
+// An anchor that is not a messaging-channel conversation (a note, a mail
+// thread, ...) must never mint an approval either: Handle's eventual
+// SendMessage call refuses it with NotAChannelConversationError, the same
+// "yes with no path to happening" shape the empty-body guard closes.
+func TestSendMessageToolRefusesToStageANonChannelAnchor(t *testing.T) {
+	tool := sendMessageTool{comms: &recordingComms{}, p: nativeActivityProvider{kind: "note"}}
+
+	_, err := tool.StageInfo(context.Background(),
+		json.RawMessage(`{"activity_id":"`+ids.NewV7().String()+`","body":"b","consent_purpose":"support"}`))
+	var bad *BadArgsError
+	if !errors.As(err, &bad) {
+		t.Errorf("StageInfo err = %v, want *BadArgsError for a non-channel anchor kind", err)
 	}
 }
 

--- a/backend/internal/modules/agents/tools_comms_test.go
+++ b/backend/internal/modules/agents/tools_comms_test.go
@@ -127,7 +127,11 @@ func TestSendMessageToolStagesAgainstTheConversation(t *testing.T) {
 		t.Errorf("staged against %s/%v, want activity/%v", info.TargetType, info.TargetID, anchor)
 	}
 	if info.TargetVersion == nil || *info.TargetVersion != 7 {
-		t.Errorf("TargetVersion = %v, want the anchor's row version so redemption re-checks it", info.TargetVersion)
+		// This is the tool's own contribution to staging, not the pin of
+		// record: the approvals engine resolves its own version server-side
+		// inside the staging transaction and the adapter that forwards this
+		// StageRequest drops TargetVersion rather than passing it through.
+		t.Errorf("TargetVersion = %v, want the anchor's row version", info.TargetVersion)
 	}
 	if info.Summary == "" {
 		t.Error("Summary is empty; the inbox would show an unlabelled approval")

--- a/backend/internal/modules/agents/tools_comms_test.go
+++ b/backend/internal/modules/agents/tools_comms_test.go
@@ -26,15 +26,19 @@ type recordingComms struct {
 func (c *recordingComms) DraftEmail(context.Context, ids.UUID, string) (string, string, error) {
 	return "", "", nil
 }
+
 func (c *recordingComms) SendEmail(context.Context, ids.UUID, SendEmailArgs) (json.RawMessage, error) {
 	return nil, nil
 }
+
 func (c *recordingComms) Availability(context.Context, *ids.UUID, time.Time, time.Time, int) (json.RawMessage, error) {
 	return nil, nil
 }
+
 func (c *recordingComms) BookMeeting(context.Context, BookMeetingArgs) (json.RawMessage, error) {
 	return nil, nil
 }
+
 func (c *recordingComms) SendMessage(_ context.Context, anchor ids.UUID, in SendMessageArgs) (json.RawMessage, error) {
 	c.anchor, c.args = anchor, in
 	return json.RawMessage(`{"status":"accepted"}`), nil
@@ -89,7 +93,7 @@ func TestSendMessageToolGovernsAsSendEmailDoes(t *testing.T) {
 func TestSendMessageToolNamesNoRecipient(t *testing.T) {
 	var decoded struct {
 		Properties           map[string]json.RawMessage `json:"properties"`
-		AdditionalProperties bool                       `json:"additionalProperties"`
+		AdditionalProperties bool                       `json:"additionalProperties"` //nolint:tagliatelle // JSON Schema spec keyword, must be camelCase
 	}
 	if err := json.Unmarshal(sendMessageTool{}.Spec().InputSchema, &decoded); err != nil {
 		t.Fatalf("input schema is not JSON: %v", err)


### PR DESCRIPTION
# The channel reply is a governed, stageable tool

A passport holding `write` but not `send` could stage a customer-facing Telegram message. The same passport could not stage an email.

`POST /v1/activities/{id}/send-message` has been declared a 🟡 MCP verb since the channel shipped (`x-mcp-tool: { verb: send_message, record_type: activity, tier: confirmation_required }`), but no tool named `send_message` was ever registered. So the admission gate took its synthesis branch:

```go
// compose/agentgate.go, operationSpec
tier := mcp.TierAutoExecute
if pol.Tier == tierConfirmationRequired { tier = mcp.TierConfirmationRequired }
return mcp.ToolSpec{Name: pol.Tool, RequiredScope: principal.ScopeWrite, Tier: tier}, true
```

The tier survived — the call was 🟡 and refused without an approval token. **The scope did not.** `auth.Gate.Admit` enforces `RequiredScope` (`admit.go:62`), so the channel reply was admitted under `write` while `send_email` demanded `send`. Nothing sent unattended; what was lost is the cap the granting human set on the passport, which is the bound ADR-0055 says a passport carries.

## What this changes

`send_message` becomes a real tool — `ScopeSend`, 🟡 `TierConfirmationRequired`, `Egress: true` — reaching activities through the existing `agents.Comms` seam and the same `activities.Store.SendMessage` the HTTP transport calls. A registered spec beats synthesis, so one registration closes the scope hole, corrects the egress declaration, and puts the verb on `tools/list` together.

**It does not mirror `send_email` in one respect, deliberately.** `Registry.Invoke` stages a refused 🟡 call only if the tool implements `stageableTool`; otherwise it returns the bare refusal and **creates no approval** (`agents/registry.go:127`). `send_email` and `book_meeting` are both shaped that way today, so an MCP `tools/call` on either refuses with a path to no yes. Copying that would have shipped AC7.3's agent path in name only. `send_message` therefore implements `StageInfo`, reading the anchor through the datasource provider and applying `refuseStagingElsewhere` — `datasource.EntityActivity` **is** served by the overlay mirror (`overlay/provider.go:256`), so a mirror-backed anchor is real and an approval for one could never be released.

`send_email` and `book_meeting` keep that gap. It is named in `STATUS.md` rather than fixed here.

## The class, not the instance

`agentpolicysynthesis_test.go` pins every verb that still resolves by synthesis — 12 before this change, 11 after — in three maps: legitimately internal, outbound holes, and dead ends.

| verb | classification |
|---|---|
| `enrich` | outbound hole — should carry `enrich` (`principal.ScopeEnrich` exists; `interfaces.md` §2.1 declares it) |
| `reconcile_overlay` | outbound hole — `auto_execute`, and the sweep it queues calls the incumbent's API and spends its budget, with no human in the loop |
| `connect_incumbent` | outbound hole — calls the incumbent and writes a vault credential |
| `send_offer` | outbound hole, **but its reason is not what its name says**: `deals/offer_lifecycle.go` only flips status, freezes FX and emits `offer.sent`. It transmits nothing, while the contract promises delivery — a contract/implementation discrepancy, not merely scope debt |
| `share_record` | **dead end** — an agent can stage it and a human can approve it, but redemption consumes the one-shot authority and then `identity/grants.go` rejects the non-human principal. The approval can never succeed |
| `disconnect_incumbent` | internal after all — teardown is local (revoke, purge, credential delete); it never calls the incumbent |

They are pinned as **named debt carrying the classification they deserve**, not blessed. A new synthesized verb fails the test until someone writes down why it may be one, and `TestThePinsDescribeVerbsThatStillExist` deletes a pin the moment it goes stale. The ratchet was watched failing before it was trusted: deleting the `render_offer` pin fails naming that verb and its route.

Worth stating plainly: **five of these classifications were wrong when first written** and were corrected only because reviewers walked the call paths (`reconcile_overlay`, `draft_offer`, `send_offer`, `share_record`, `disconnect_incumbent`). A pin map is only worth the verification behind it.

## One thing this PR does not fix, and a reader should know about

**An approved channel send binds the message text, not the recipient.** `relink_activity` is `auto_execute`; relinking rewrites `activity_link` rows without touching the `activity` row, so the pinned row version does not move; and `SendMessage` resolves the recipient fresh at execution from those links. So an agent can stage "message M on conversation A", have a human approve it, auto-execute a relink that swaps the person link, then redeem the byte-identical call — delivering M to someone the human never approved.

This is **pre-existing** (before this branch a `write`-scoped passport could do the same on REST) and affects both transports. This PR neither introduces nor fixes it; it narrows who can reach it. A real fix needs a server-resolved recipient fingerprint bound into the staged authority and rechecked at redemption, plus person-link changes bumping the activity version — spanning activities, approvals and both transports, and resting on a product decision about what an approval binds. Recorded in `STATUS.md`.

**The durable fix is upstream.** `interfaces.md` §2.1 already declares each tool's scope; `x-mcp-tool` in `crm.yaml` does not carry it, so the generator emits none and the gate guesses `write`. That ask, with these four outbound holes behind it, goes to the spec rather than being patched here.

## Verification

| lane | result |
|---|---|
| `make check` / `make check-backend` | green |
| `make test-integration-serial` | `OK: integration passed with 0 skips` |
| UAT over live HTTP, 5 cases | 5 PASS — evidence in the first comment |
| MCP stage → approve → redeem → single-use | proved against real Postgres (`channelsend_mcp_integration_test.go`) |

The parallel integration lane fails on this machine with 684 `tls error: EOF` **at connect**: the default fan-out exhausts Postgres `max_connections=100` alongside a second local stack. Not a code failure — the serial lane (`-p 1`, the Makefile's own escape hatch) is fully green, and the two new channel-send cases pass in every run, parallel or serial.

UAT was run at `0d6033f6`. Commits after it changed test files, comments and `STATUS.md`, plus one production change adding the staging-time body/anchor-kind guards — which only refuse earlier what the store already refused, so nothing the UAT exercised changed behaviour.

## Two things a reader should know

**The first review of this defect was wrong, in the comfortable direction.** It reported that an agent "cannot reach" the channel reply because no tool was registered. Reading `operationSpec` showed the opposite: the call is admitted, just under the wrong scope. The bug was worse than the report, not better.

**`GET /v1/agent-tools` does not filter by passport.** UAT case 4 was proved against the real MCP `POST /mcp` `tools/list`, which does. The `/v1/agent-tools` surface is an unfiltered registry dump for a human session; that is pre-existing and untouched here, but it is not the scope-filtering surface it looks like.

**The UAT's original case-3 narrative was wrong and is corrected in the evidence file.** It claimed the staged approval "could not exist before `StageInfo` shipped". It could: `stageRefusal` staged this verb at the merge base via a REST-only path. What the branch changes on REST is the scope; the MCP staging loop is new, and is proved by the integration test above rather than by the UAT.

## Deliberately not in this PR

The four outbound holes and the one dead end above; `send_email`/`book_meeting` staging; the `x-mcp-tool` `scope:` field (a spec change); and the sovereignty disclosure at Telegram enablement, which is a separate finding from the same review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
