### PR TITLE
docs(status): record the four company-page limits answered on PR #356

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -56,10 +56,8 @@ may duplicate. Fix in `frontend/src/screens/companyactions.tsx` (`resolveTagId`)
 
 ## Open — the limits the company-page review named and PR #356 did not fix
 
-Each is real, each was raised by the review bots on that PR, and each is a
-change of a different size than the PR it was raised on. Every one of these
-was answered on the PR thread and the thread resolved, so the list here is the
-only remaining record.
+Each is real and each is a change of a different size than the PR it was
+raised on.
 
 1. **The owner picker sees one page of users.** `useRoster("user")` reads
    `GET /users?limit=200` and the edit form offers exactly those. In a
@@ -81,17 +79,14 @@ only remaining record.
    on phone layouts it can open behind the fixed bottom navigation. Both are
    one pass over the panel's width and stacking, in the design system rather
    than at any call site.
-4. **The new provenance branches in `trust.tsx` have no test.**
-   `trust.test.tsx` covers the self-render case; the branches added for a
-   missing `captured_by` and for a non-self human writer are unasserted.
-5. **A site read stores the seed it was asked for, not the one that
+4. **A site read stores the seed it was asked for, not the one that
    answered.** The crawl now carries the working spelling forward, so
    proposals, evidence and the logo all cite the site that served them — but
    the `site_read` row itself still records the original `https://<domain>`.
    Re-reading that company starts from the dead spelling again and pays the
    fallback ladder a second time. Persisting the answered URL is a migration
    plus a decision about whether the requested URL stays visible.
-6. **The brief's profile vocabulary is spelled out twice.**
+5. **The brief's profile vocabulary is spelled out twice.**
    `briefProfileFields` (orgbrief/input.go, which drives the fingerprint) and
    the keys of `profileLabels` (orgbrief/deterministic.go, which drives what
    renders) are two hand-kept lists of the same eight field names, and neither

--- a/STATUS.md
+++ b/STATUS.md
@@ -54,25 +54,44 @@ one.** The spec already says what to do with the overflow: surface it. When
 workspace's tag vocabulary is over its governed cap, not a silent create that
 may duplicate. Fix in `frontend/src/screens/companyactions.tsx` (`resolveTagId`).
 
-## Open — three limits the company-page review named and PR #356 did not fix
+## Open — the limits the company-page review named and PR #356 did not fix
 
 Each is real, each was raised by the review bots on that PR, and each is a
-change of a different size than the PR it was raised on.
+change of a different size than the PR it was raised on. Every one of these
+was answered on the PR thread and the thread resolved, so the list here is the
+only remaining record.
 
 1. **The owner picker sees one page of users.** `useRoster("user")` reads
    `GET /users?limit=200` and the edit form offers exactly those. In a
    workspace past 200 members an owner outside that page cannot be chosen, and
    the account's current owner shows as "Current owner (no longer in the user
    list)" when it is really just beyond the window. The fix is a searchable
-   picker backed by a server-side user search, not another page size.
-2. **A site read stores the seed it was asked for, not the one that
+   picker backed by a server-side user search, not another page size. The same
+   change should stop fetching the roster on every company open: today it is
+   read whether or not the reader touches the More-actions menu or the owner
+   field.
+2. **The chronology cannot reach older activities.** The Activities filter
+   reports `truncated` when `view.activities.page.has_more` is true, and the
+   "All" filter does the same when the activity feed is the side that still has
+   pages — but neither offers a control to load them. The rows exist and are
+   keyset-paged by time; what is missing is the "load older" affordance.
+3. **The overflow panel is not laid out for zoom or phones.** The panel in
+   `frontend/src/design-system/atoms.css` is a fixed 180px, so at 200% zoom on
+   a narrow viewport it can extend past the record column and be clipped, and
+   on phone layouts it can open behind the fixed bottom navigation. Both are
+   one pass over the panel's width and stacking, in the design system rather
+   than at any call site.
+4. **The new provenance branches in `trust.tsx` have no test.**
+   `trust.test.tsx` covers the self-render case; the branches added for a
+   missing `captured_by` and for a non-self human writer are unasserted.
+5. **A site read stores the seed it was asked for, not the one that
    answered.** The crawl now carries the working spelling forward, so
    proposals, evidence and the logo all cite the site that served them — but
    the `site_read` row itself still records the original `https://<domain>`.
    Re-reading that company starts from the dead spelling again and pays the
    fallback ladder a second time. Persisting the answered URL is a migration
    plus a decision about whether the requested URL stays visible.
-3. **The brief's profile vocabulary is spelled out twice.**
+6. **The brief's profile vocabulary is spelled out twice.**
    `briefProfileFields` (orgbrief/input.go, which drives the fingerprint) and
    the keys of `profileLabels` (orgbrief/deterministic.go, which drives what
    renders) are two hand-kept lists of the same eight field names, and neither


### PR DESCRIPTION
PR #356's review named seven limits the change did not fix. Three were already
in STATUS.md. Four were not, and I answered them on the review threads before
resolving them — which means without this commit there is no record they exist:

- the owner-roster page cap's second half: the roster is fetched on every
  company open, whether or not the reader touches the menu or the owner field
- the chronology reports `truncated` under both Activities and All but offers
  no control to load older pages
- the overflow panel is a fixed 180px, so it clips at 200% zoom on a narrow
  viewport and opens behind the fixed bottom nav on phones
- the provenance branches added to `trust.tsx` are not covered by
  `trust.test.tsx`

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update STATUS.md to document three open company‑page limits from PR #356, preserving the review’s answers as the record. Also removes an incorrect claim about missing tests in `trust.tsx`/`trust.test.tsx`.

Covers: roster fetched on every company open, missing “load older” control in chronology, and overflow panel layout issues at zoom and on phones.

<sup>Written for commit 1d5aa8f17ab497c4154a28e3c1568aa40fcd1e61. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/364?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the company-page follow-up checklist with additional tracked issues.
  * Added coverage for review-thread context, owner selection, activity pagination, responsive overflow panels, and data provenance.
  * Retained existing items related to site-read status and profile terminology, with updated numbering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->