### PR TITLE
feat(company): the company page tells the truth about an account (P0)

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -13086,6 +13086,17 @@ components:
         evidence_snippet: { type: [string, 'null'] }
         source_url: { type: [string, 'null'], format: uri }
         confidence: { type: [number, 'null'], minimum: 0, maximum: 1 }
+        suspect_reason:
+          type: [string, 'null']
+          enum: [null, phone_shaped_location, not_a_phone, not_a_year, not_an_email, not_a_size]
+          readOnly: true
+          description: >-
+            Why this fact's VALUE contradicts its FIELD, or null when it does not. The extractor
+            picks the field from a closed per-page menu and the category follows the field, so a
+            phone number on a contact page can land as `location` and a register number as
+            `employee_range` — the row is well-formed and still wrong. Computed at read from the
+            value's shape; it never gates the fact, because a heuristic that hid data would be
+            worse than one that flags it.
         updated_at: { type: string, format: date-time }
 
     OrganizationFactListResponse:

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -10733,12 +10733,28 @@ components:
           format: date-time
           description: The instant the assembling transaction read. Sections are consistent to this moment under Read Committed.
         organization: { $ref: '#/components/schemas/Organization' }
+        last_inbound_at:
+          type: [string, 'null']
+          format: date-time
+          description: >-
+            When they last wrote to us, over the same three-link walk the timeline uses (the
+            activity's own link, its deal's organization, the employer of the contact it is filed
+            against). Null means nothing inbound was ever captured — which is a fact about the
+            account, not a missing field. Absent entirely when the caller has no activity grant,
+            named in `sections_omitted` as `last_touch`.
+        last_outbound_at:
+          type: [string, 'null']
+          format: date-time
+          description: >-
+            When we last wrote to them, same walk. Shown BESIDE last_inbound_at rather than folded
+            into one "last touch": which direction went last is the whole question — an account we
+            mailed a fortnight ago with no reply is not the same as one that just wrote to us.
         sections_omitted:
           type: array
           description: The sections withheld for lack of a grant — so a client can say "you can't see this" instead of "there is none".
           items:
             type: string
-            enum: [people, deals, strength, activities, tags, list_memberships, pending_approvals, next_steps, since_last_visit, suggestions]
+            enum: [people, deals, strength, activities, tags, list_memberships, pending_approvals, next_steps, since_last_visit, suggestions, last_touch]
         people:
           type: object
           required: [data, page]

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -721,6 +721,16 @@ paths:
           in: query
           schema: { type: string }
           description: Lookup by normalized domain (the employer-inference index).
+        - name: lifecycle
+          in: query
+          schema: { type: string, enum: [unknown, target, prospect, opportunity, customer, former_customer, disqualified] }
+          description: Where the account stands with us (DM-VOCAB-2, ADR-0079/A124).
+        - name: relationship_type
+          in: query
+          schema: { type: string, enum: [customer, partner, supplier, investor, portfolio_company, competitor, other] }
+          description: >-
+            Accounts carrying this relationship type. Multi-valued per account, so this selects
+            accounts that are AT LEAST this — a partner that is also a customer matches both.
         - name: q
           in: query
           schema: { type: string }
@@ -10322,7 +10332,30 @@ components:
         domains:
           type: array
           items: { $ref: '#/components/schemas/OrganizationDomain' }
-        classification: { type: [string, 'null'], enum: [null, prospect, customer, agency, reseller, tech_vendor, platform, partner, competitor, other], description: "An org IS a partner iff classification='partner' AND it has a `partner` row (A41/ADR-0032). Values match the data-model §4.1 CHECK." }
+        lifecycle:
+          type: string
+          enum: [unknown, target, prospect, opportunity, customer, former_customer, disqualified]
+          description: >-
+            WHERE THE ACCOUNT STANDS with us (PO-DDL-4, ADR-0079/A124). Single-valued: an account is at
+            one point in a sales motion at a time. `unknown` is the default and means it — the retired
+            `classification` defaulted to `prospect` and, having no writer, rendered that default on
+            every unassessed account as though someone had judged it.
+        relationship_types:
+          type: array
+          items: { type: string, enum: [customer, partner, supplier, investor, portfolio_company, competitor, other] }
+          description: >-
+            WHAT THE COMPANY IS to us (PO-DDL-4b, ADR-0079/A124). Multi-valued, because a company is
+            legitimately several things at once — the partner program is built on companies that are
+            simultaneously partners and customers. An org IS a partner iff it carries `partner` here AND
+            has a `partner` row; removing the type while that row lives is refused (422).
+        classification:
+          type: [string, 'null']
+          enum: [null, prospect, customer, agency, reseller, tech_vendor, platform, partner, competitor, other]
+          deprecated: true
+          description: >-
+            RETIRED (ADR-0079/A124) — superseded by `lifecycle` + `relationship_types`, which split the
+            two questions this one value tried to answer at once. Carried one release, written by
+            nothing; read it for migration comparison only.
         logo_url:
           type: [string, 'null']
           readOnly: true
@@ -10396,6 +10429,18 @@ components:
           type: array
           description: Replace-set of the org's live domains (add new, archive removed, flip is_primary). Absent = untouched; an empty array clears all domains.
           items: { $ref: '#/components/schemas/OrganizationDomainInput' }
+        lifecycle:
+          type: string
+          enum: [unknown, target, prospect, opportunity, customer, former_customer, disqualified]
+          description: Where the account stands with us (ADR-0079/A124). Absent = untouched.
+        relationship_types:
+          type: array
+          description: >-
+            Replace-set of what the company is to us (add new, archive removed), the same shape as
+            `domains`. Absent = untouched; an empty array clears every type. Removing `partner` while
+            the org still has a `partner` extension row is refused with 422 — the invariant binds both
+            ways, and an invariant nothing enforces is a comment.
+          items: { type: string, enum: [customer, partner, supplier, investor, portfolio_company, competitor, other] }
       additionalProperties: true
       x-extension: true
 

--- a/backend/internal/compose/integration/fieldhistory_integration_test.go
+++ b/backend/internal/compose/integration/fieldhistory_integration_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/modules/activities"
+	"github.com/gradionhq/margince/backend/internal/modules/people"
 	"github.com/gradionhq/margince/backend/internal/modules/privacy"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
@@ -497,5 +498,59 @@ func TestFieldHistoryHonestEmptyForVisibleRecordWithNoMatches(t *testing.T) {
 	}
 	if page.Entries == nil || len(page.Entries) != 0 || page.HasMore {
 		t.Fatalf("want honest empty page (non-nil, zero entries): %+v", page)
+	}
+}
+
+// TestEnrichmentWritesProjectAsRealColumnDiffs is the honesty check on what
+// the company page's Changes filter shows a reader.
+//
+// A cold-start apply used to audit with before=nil and after={source,
+// source_url, fields:[…]} — a bag whose keys are not columns. Field history
+// projects per FIELD from before/after images, so it rendered pseudo-fields
+// called "source" and "fields": changes that never happened on the record,
+// while the actual legal_name it had just written appeared nowhere. The
+// operation's metadata now rides audit_log.evidence, which is the column for
+// it, and before/after carry the record's own images.
+func TestEnrichmentWritesProjectAsRealColumnDiffs(t *testing.T) {
+	e := Setup(t)
+
+	// The apply resolves its target by the source URL's host, so it names the
+	// organization it touched rather than one seeded beside it.
+	org, err := e.People.ApplyColdStartProfile(e.Admin(), people.ApplyColdStartProfileInput{
+		SourceURL: "https://scale.example/impressum",
+		Fields: []people.ColdStartFieldInput{
+			{Field: "legal_name", Value: "Scale Commerce GmbH", EvidenceSnippet: "Scale Commerce GmbH, Berlin", SourceURL: "https://scale.example/impressum", Confidence: 0.9},
+			// Not column-backed: it lands as evidence only, so it must NOT
+			// appear as a field change on the organization row.
+			{Field: "offer_summary", Value: "Managed hosting", EvidenceSnippet: "Managed hosting for e-commerce", SourceURL: "https://scale.example", Confidence: 0.8},
+		},
+	})
+	if err != nil {
+		t.Fatalf("apply cold-start profile: %v", err)
+	}
+
+	page, err := privacy.ListFieldHistory(e.Admin(), e.Pool, privacy.FieldHistoryFilter{
+		EntityType: "organization", EntityID: org.UUID,
+	})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	seen := map[string]bool{}
+	for _, entry := range page.Entries {
+		seen[entry.Field] = true
+	}
+	for _, pseudo := range []string{"source", "source_url", "fields", "facts"} {
+		if seen[pseudo] {
+			t.Errorf("field history shows %q as a changed field — that is operation metadata, not a column on the record", pseudo)
+		}
+	}
+	if seen["offer_summary"] {
+		t.Error("a profile-field-only value appeared as an organization column change")
+	}
+	// And the positive half: the column the apply actually filled is the one a
+	// reader now sees. Asserting only the absence of the pseudo-fields would
+	// pass just as well if the write had stopped auditing altogether.
+	if !seen["legal_name"] {
+		t.Errorf("legal_name is missing from field history: %v — the apply wrote it, so the record's own change must be what shows", seen)
 	}
 }

--- a/backend/internal/compose/integration/merge_integration_test.go
+++ b/backend/internal/compose/integration/merge_integration_test.go
@@ -14,6 +14,7 @@ package integration
 import (
 	"context"
 	"errors"
+	"slices"
 	"testing"
 
 	"github.com/jackc/pgx/v5"
@@ -179,14 +180,16 @@ func TestMergeOrganization_partnerExtensionMovesIntoVacancy(t *testing.T) {
 	srcID, tgtID := orgIDOf(ids.UUID(source.Id)), orgIDOf(ids.UUID(target.Id))
 	// The source carries the partner program; the target has none.
 	e.WsExec(t, `INSERT INTO partner (workspace_id, organization_id, source, captured_by) VALUES ($1, $2, 'manual', 'human:test')`, e.WS, srcID)
-	e.WsExec(t, `UPDATE organization SET classification = 'partner' WHERE id = $1`, srcID)
+	e.WsExec(t, `INSERT INTO organization_relationship_type (workspace_id, organization_id, relationship_type, source, captured_by)
+		VALUES ($1, $2, 'partner', 'manual', 'human:test')`, e.WS, srcID)
 
 	if _, err := e.People.MergeOrganization(admin, srcID, tgtID); err != nil {
 		t.Fatalf("merge: %v", err)
 	}
 
-	// The 1:1 extension moved into the vacancy, and the survivor flips to
-	// classification=partner (the A41 invariant).
+	// The 1:1 extension moved into the vacancy, and the survivor carries the
+	// partner relationship type — the invariant ADR-0079 moved off
+	// classification and now enforces in both directions.
 	if n := e.WsCount(t, `SELECT count(*) FROM partner WHERE organization_id = $1`, tgtID); n != 1 {
 		t.Errorf("survivor has %d partner rows, want the moved 1", n)
 	}
@@ -197,8 +200,14 @@ func TestMergeOrganization_partnerExtensionMovesIntoVacancy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read survivor: %v", err)
 	}
-	if got.Classification == nil || string(*got.Classification) != "partner" {
-		t.Errorf("survivor classification = %v, want partner", got.Classification)
+	types := []string{}
+	if got.RelationshipTypes != nil {
+		for _, relType := range *got.RelationshipTypes {
+			types = append(types, string(relType))
+		}
+	}
+	if !slices.Contains(types, "partner") {
+		t.Errorf("survivor carries %v, want partner among them", types)
 	}
 }
 

--- a/backend/internal/compose/integration/org360_account_timeline_integration_test.go
+++ b/backend/internal/compose/integration/org360_account_timeline_integration_test.go
@@ -305,3 +305,78 @@ func TestSinceLastVisitCountsMailRolledUpThroughAContact(t *testing.T) {
 			view.SinceLastVisit.BaselineAt, org360Clock)
 	}
 }
+
+// accountMailDirectedAt seeds one message with an explicit direction, which is
+// the whole point of the pair below: the same last-touch date means opposite
+// things depending on who wrote it.
+func accountMailDirectedAt(t *testing.T, owner *pgx.Conn, ws ids.UUID, subject, direction string, at time.Time) ids.UUID {
+	t.Helper()
+	id := ids.NewV7()
+	if _, err := owner.Exec(context.Background(), `INSERT INTO activity
+		(id, workspace_id, kind, direction, subject, occurred_at, created_at, source, captured_by)
+		VALUES ($1, $2, 'email', $3, $4, $5, $5, 'manual', 'human:x')`,
+		id, ws, direction, subject, at); err != nil {
+		t.Fatalf("seeding %q: %v", subject, err)
+	}
+	return id
+}
+
+// TestLastTouchSeparatesWhoWroteLastAndWalksTheSameThreeLinks pins the pair
+// that replaced the header's 0-100 score (AC-company-2). One "last touch"
+// would collapse the only distinction that matters — an account we mailed a
+// fortnight ago with no reply reads identically to one that just wrote to us.
+func TestLastTouchSeparatesWhoWroteLastAndWalksTheSameThreeLinks(t *testing.T) {
+	e := Setup(t)
+	owner := OwnerConn(t)
+	svc := org360Service(e)
+
+	org := e.SeedOrg(t, "Scale Commerce", &e.Rep1)
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, org360RepPerms)
+	employee := e.SeedPerson(t, "Christian Contact", &e.Rep1)
+	employAt(t, e, employee, org, nil)
+
+	// The newest inbound reaches the account only through its contact, which
+	// is how capture files real mail — a direct-link-only reading would miss it.
+	oldInbound := accountMailDirectedAt(t, owner, e.WS, "old reply", "inbound", org360Clock.Add(-90*time.Hour))
+	linkToOrg(t, e, oldInbound, org)
+	newInbound := accountMailDirectedAt(t, owner, e.WS, "their reply", "inbound", org360Clock.Add(-30*time.Hour))
+	LinkActivity(t, owner, e.WS, newInbound, "person", employee)
+	outbound := accountMailDirectedAt(t, owner, e.WS, "our nudge", "outbound", org360Clock.Add(-2*time.Hour))
+	linkToOrg(t, e, outbound, org)
+
+	view, err := svc.Assemble(rep, ids.From[ids.OrganizationKind](org))
+	if err != nil {
+		t.Fatalf("assemble: %v", err)
+	}
+	if view.LastInboundAt == nil || !view.LastInboundAt.Equal(org360Clock.Add(-30*time.Hour)) {
+		t.Errorf("last inbound = %v, want the contact-linked reply at -30h", view.LastInboundAt)
+	}
+	if view.LastOutboundAt == nil || !view.LastOutboundAt.Equal(org360Clock.Add(-2*time.Hour)) {
+		t.Errorf("last outbound = %v, want our nudge at -2h", view.LastOutboundAt)
+	}
+}
+
+// TestLastTouchIsNullRatherThanZeroWhenNothingWasCaptured keeps "we have never
+// heard from them" distinct from "we never looked". Null is the account's
+// answer; an absent section would be the caller's.
+func TestLastTouchIsNullRatherThanZeroWhenNothingWasCaptured(t *testing.T) {
+	e := Setup(t)
+	owner := OwnerConn(t)
+	svc := org360Service(e)
+
+	org := e.SeedOrg(t, "Silent Co", &e.Rep1)
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, org360RepPerms)
+	outbound := accountMailDirectedAt(t, owner, e.WS, "our first mail", "outbound", org360Clock.Add(-time.Hour))
+	linkToOrg(t, e, outbound, org)
+
+	view, err := svc.Assemble(rep, ids.From[ids.OrganizationKind](org))
+	if err != nil {
+		t.Fatalf("assemble: %v", err)
+	}
+	if view.LastInboundAt != nil {
+		t.Errorf("last inbound = %v, want null — they have never written", view.LastInboundAt)
+	}
+	if view.LastOutboundAt == nil {
+		t.Error("last outbound is null, but we mailed them an hour ago")
+	}
+}

--- a/backend/internal/compose/integration/org360_querycount_integration_test.go
+++ b/backend/internal/compose/integration/org360_querycount_integration_test.go
@@ -118,10 +118,15 @@ func TestOrganization360CostDoesNotGrowWithTheAccount(t *testing.T) {
 			"the composite read must be flat in the size of the account, or it is the round-trip stack it replaced",
 			largeCost, smallCost)
 	}
-	// A ceiling as well as a shape: nine sections, a handful of queries
-	// each at most. If this ever needs raising, the reason belongs in the
-	// commit that raises it.
-	const budget = 25
+	// A ceiling as well as a shape: ten sections, a handful of queries each
+	// at most. If this ever needs raising, the reason belongs in the commit
+	// that raises it.
+	//
+	// Raised 25 → 27 for the last_touch section (ADR-0079 arc): it is a new
+	// section, and it costs its own grant check and its own read. Two rather
+	// than one because the read is gated like every other section — a caller
+	// without the activity grant gets silence, not a timestamp.
+	const budget = 27
 	if smallCost > budget {
 		t.Errorf("one 360 issued %d queries, budget is %d", smallCost, budget)
 	}

--- a/backend/internal/compose/integration/orgrollup_integration_test.go
+++ b/backend/internal/compose/integration/orgrollup_integration_test.go
@@ -96,6 +96,47 @@ func seedRollupOrgActivity(t *testing.T, e *Env, org ids.UUID, occurredAt time.T
 		e.WS, activityID, org)
 }
 
+// seedRollupDealLinkedActivity files one activity against a DEAL of the
+// given organization and never against the organization itself — the
+// second of the three arms an account's timeline walks.
+func seedRollupDealLinkedActivity(t *testing.T, e *Env, st rollupStages, org ids.UUID, occurredAt time.Time) {
+	t.Helper()
+	dealID := ids.NewV7()
+	e.WsExec(t, `INSERT INTO deal (id, workspace_id, name, pipeline_id, stage_id, organization_id, status, source, captured_by)
+		VALUES ($1, $2, 'Deal With Mail', $3, $4, $5, 'open', 'manual', 'human:test')`,
+		dealID, e.WS, st.pipeline, st.open, org)
+	activityID := ids.NewV7()
+	e.WsExec(t, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, source, captured_by)
+		VALUES ($1, $2, 'email', 'deal thread', $3, 'manual', 'human:test')`,
+		activityID, e.WS, occurredAt)
+	e.WsExec(t, `INSERT INTO activity_link (workspace_id, activity_id, entity_type, deal_id)
+		VALUES ($1, $2, 'deal', $3)`,
+		e.WS, activityID, dealID)
+}
+
+// seedRollupPersonLinkedActivity files one activity against a PERSON
+// currently employed by the given organization and never against the
+// organization itself — the third arm, and the one that carries most of a
+// real account's mail, because capture files a message against the person
+// it was with.
+func seedRollupPersonLinkedActivity(t *testing.T, e *Env, org ids.UUID, occurredAt time.Time) {
+	t.Helper()
+	personID := ids.NewV7()
+	e.WsExec(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by)
+		VALUES ($1, $2, 'Rollup Contact', 'manual', 'human:test')`,
+		personID, e.WS)
+	e.WsExec(t, `INSERT INTO relationship (id, workspace_id, kind, person_id, organization_id, source, captured_by)
+		VALUES ($1, $2, 'employment', $3, $4, 'manual', 'human:test')`,
+		ids.NewV7(), e.WS, personID, org)
+	activityID := ids.NewV7()
+	e.WsExec(t, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, source, captured_by)
+		VALUES ($1, $2, 'email', 'contact thread', $3, 'connector:gmail', 'connector:gmail')`,
+		activityID, e.WS, occurredAt)
+	e.WsExec(t, `INSERT INTO activity_link (workspace_id, activity_id, entity_type, person_id)
+		VALUES ($1, $2, 'person', $3)`,
+		e.WS, activityID, personID)
+}
+
 // rollupOrgReadPerms is the minimal caller the rollup admits: read on
 // organization, deal, AND activity at the given row-scope tier — the
 // rollup surfaces deal money and activity counts, so it demands the same
@@ -420,5 +461,65 @@ func TestOrgRollupSelfScopeSkipsPruning(t *testing.T) {
 	}
 	if len(res.RestrictedExcluded) != 0 {
 		t.Errorf("self restricted = %+v, want empty — self scope never prunes", res.RestrictedExcluded)
+	}
+}
+
+// TestOrgRollupCounts30dActivityThroughEveryLinkTheTimelineWalks pins the
+// count to the same reachability the timeline uses. The number sits above
+// a list the reader can scroll: when it counted only activities carrying a
+// direct organization link, an account whose mail is filed against its
+// people — which is what capture does — reported a fraction of what the
+// page below it displayed, and the busier the account the wider the gap.
+func TestOrgRollupCounts30dActivityThroughEveryLinkTheTimelineWalks(t *testing.T) {
+	e := Setup(t)
+	st := seedRollupStages(t, e)
+	org := seedRollupOrg(t, e, "Reachable Co", nil, nil)
+	now := time.Now().UTC()
+
+	seedRollupOrgActivity(t, e, org, now.Add(-24*time.Hour))
+	seedRollupDealLinkedActivity(t, e, st, org, now.Add(-48*time.Hour))
+	seedRollupPersonLinkedActivity(t, e, org, now.Add(-72*time.Hour))
+	// Out of window through the same two indirect arms: reachability
+	// widening must not smuggle past the 30-day bound.
+	seedRollupDealLinkedActivity(t, e, st, org, now.AddDate(0, 0, -40))
+	seedRollupPersonLinkedActivity(t, e, org, now.Add(24*time.Hour))
+
+	res, err := compose.OrgHierarchyRollup(e.Admin(), e.Pool, org, "self", fixedClock(now))
+	if err != nil {
+		t.Fatalf("self rollup: %v", err)
+	}
+	if res.ActivityCount30d != 3 {
+		t.Errorf("activity count = %d, want 3 (own link + its deal's + its contact's, in window)", res.ActivityCount30d)
+	}
+}
+
+// TestOrgRollupCountsAnActivityReachingTheTreeTwiceOnlyOnce guards the
+// EXISTS: one message linked to both the account and its deal is one
+// message, and a join would have counted it per link.
+func TestOrgRollupCountsAnActivityReachingTheTreeTwiceOnlyOnce(t *testing.T) {
+	e := Setup(t)
+	st := seedRollupStages(t, e)
+	org := seedRollupOrg(t, e, "Double Linked Co", nil, nil)
+	now := time.Now().UTC()
+
+	dealID := ids.NewV7()
+	e.WsExec(t, `INSERT INTO deal (id, workspace_id, name, pipeline_id, stage_id, organization_id, status, source, captured_by)
+		VALUES ($1, $2, 'Both Links', $3, $4, $5, 'open', 'manual', 'human:test')`,
+		dealID, e.WS, st.pipeline, st.open, org)
+	activityID := ids.NewV7()
+	e.WsExec(t, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, source, captured_by)
+		VALUES ($1, $2, 'email', 'filed twice', $3, 'manual', 'human:test')`,
+		activityID, e.WS, now.Add(-24*time.Hour))
+	e.WsExec(t, `INSERT INTO activity_link (workspace_id, activity_id, entity_type, organization_id)
+		VALUES ($1, $2, 'organization', $3)`, e.WS, activityID, org)
+	e.WsExec(t, `INSERT INTO activity_link (workspace_id, activity_id, entity_type, deal_id)
+		VALUES ($1, $2, 'deal', $3)`, e.WS, activityID, dealID)
+
+	res, err := compose.OrgHierarchyRollup(e.Admin(), e.Pool, org, "self", fixedClock(now))
+	if err != nil {
+		t.Fatalf("self rollup: %v", err)
+	}
+	if res.ActivityCount30d != 1 {
+		t.Errorf("activity count = %d, want 1 (two links, one message)", res.ActivityCount30d)
 	}
 }

--- a/backend/internal/compose/integration/relationship_integration_test.go
+++ b/backend/internal/compose/integration/relationship_integration_test.go
@@ -12,6 +12,7 @@ package integration
 
 import (
 	"net/http"
+	"slices"
 	"testing"
 )
 
@@ -131,12 +132,16 @@ func TestPartnerPromotionLifecycle(t *testing.T) {
 	}, nil, &partner); status != http.StatusOK || partner.CertStatus != "certified" {
 		t.Fatalf("upsert partner → %d %+v", status, partner)
 	}
-	// Promotion flips the org's classification.
+	// Promotion writes the partner relationship type — the half of the
+	// invariant that lives on the organization (ADR-0079 amending ADR-0032).
 	var org struct {
-		Classification string `json:"classification"`
+		RelationshipTypes []string `json:"relationship_types"`
 	}
-	if status := e.call(t, "GET", "/v1/organizations/"+e.orgID, nil, nil, &org); status != http.StatusOK || org.Classification != "partner" {
-		t.Fatalf("org after promotion → %d classification=%q", status, org.Classification)
+	if status := e.call(t, "GET", "/v1/organizations/"+e.orgID, nil, nil, &org); status != http.StatusOK {
+		t.Fatalf("org after promotion → %d", status)
+	}
+	if !slices.Contains(org.RelationshipTypes, "partner") {
+		t.Fatalf("org after promotion carries %v, want partner among them", org.RelationshipTypes)
 	}
 	var partners struct {
 		Data []struct {

--- a/backend/internal/compose/org360/assemble.go
+++ b/backend/internal/compose/org360/assemble.go
@@ -267,16 +267,39 @@ func (a *assembly) readLastTouch() error {
 	if scope != "" {
 		where += " AND " + scope
 	}
-	var inbound, outbound *time.Time
-	if err := a.tx.QueryRow(a.ctx, `
-		SELECT max(a.occurred_at) FILTER (WHERE a.direction = 'inbound'),
-		       max(a.occurred_at) FILTER (WHERE a.direction = 'outbound')
-		FROM activity a WHERE `+where, args...).Scan(&inbound, &outbound); err != nil {
+	// Two ordered LIMIT-1 arms in ONE round trip, rather than two FILTERed
+	// max() aggregates. An aggregate has to see every qualifying row before it
+	// can answer; each arm here stops at the first, so the cost is bounded by
+	// how far back the newest message of that direction is rather than by the
+	// account's whole history.
+	rows, err := a.tx.Query(a.ctx, `
+		(SELECT 'inbound' AS direction, a.occurred_at FROM activity a
+		  WHERE `+where+` AND a.direction = 'inbound'
+		  ORDER BY a.occurred_at DESC LIMIT 1)
+		UNION ALL
+		(SELECT 'outbound', a.occurred_at FROM activity a
+		  WHERE `+where+` AND a.direction = 'outbound'
+		  ORDER BY a.occurred_at DESC LIMIT 1)`, args...)
+	if err != nil {
 		return err
 	}
-	a.out.LastInboundAt = inbound
-	a.out.LastOutboundAt = outbound
-	return nil
+	defer rows.Close()
+	for rows.Next() {
+		var direction string
+		var at time.Time
+		if err := rows.Scan(&direction, &at); err != nil {
+			return err
+		}
+		// A direction with no message returns no row at all, which is how the
+		// null reaches the wire: nothing of that direction was ever captured.
+		when := at
+		if direction == "inbound" {
+			a.out.LastInboundAt = &when
+			continue
+		}
+		a.out.LastOutboundAt = &when
+	}
+	return rows.Err()
 }
 
 func (a *assembly) readNextSteps() error {

--- a/backend/internal/compose/org360/assemble.go
+++ b/backend/internal/compose/org360/assemble.go
@@ -32,6 +32,7 @@ const (
 	sectionDeals           = crmcontracts.Organization360SectionsOmitted("deals")
 	sectionStrength        = crmcontracts.Organization360SectionsOmitted("strength")
 	sectionActivities      = crmcontracts.Organization360SectionsOmitted("activities")
+	sectionLastTouch       = crmcontracts.Organization360SectionsOmitted("last_touch")
 	sectionTags            = crmcontracts.Organization360SectionsOmitted("tags")
 	sectionListMemberships = crmcontracts.Organization360SectionsOmitted("list_memberships")
 	sectionApprovals       = crmcontracts.Organization360SectionsOmitted("pending_approvals")
@@ -93,6 +94,7 @@ func (s *Service) sections(ctx context.Context, tx pgx.Tx, orgID ids.Organizatio
 		{sectionStrength, a.readStrength},
 		{sectionDeals, a.readDeals},
 		{sectionActivities, a.readTimeline},
+		{sectionLastTouch, a.readLastTouch},
 		{sectionNextSteps, a.readNextSteps},
 		{sectionTags, a.readTags},
 		{sectionListMemberships, a.readListMemberships},
@@ -236,6 +238,44 @@ func (a *assembly) readTimeline() error {
 		return err
 	}
 	a.out.Activities = &crmcontracts.ActivityListResponse{Data: data, Page: pageInfo(page)}
+	return nil
+}
+
+// readLastTouch answers which direction went last, and when — the pair that
+// replaced the header's 0-100 score (AC-company-2, ADR-0079 arc).
+//
+// Two timestamps rather than one "last touch", because which side wrote last
+// IS the question: an account we mailed a fortnight ago with no reply and one
+// that wrote to us this morning have the same last-touch date and opposite
+// meanings.
+//
+// It walks the same three links the timeline does (activities.OrgLinkedActivityExists),
+// so the header can never disagree with the list under it, and
+// it carries the caller's activity row scope, so a rep sees the last message
+// THEY may read rather than the account's true last message.
+func (a *assembly) readLastTouch() error {
+	if err := auth.Require(a.ctx, "activity", principal.ActionRead); err != nil {
+		return err
+	}
+	args := []any{a.orgID.UUID}
+	arg := func(v any) int { args = append(args, v); return len(args) }
+	scope, err := auth.ActivityScopeClause(a.ctx, "a", arg)
+	if err != nil {
+		return err
+	}
+	where := "a.archived_at IS NULL AND " + activities.OrgLinkedActivityExists(1)
+	if scope != "" {
+		where += " AND " + scope
+	}
+	var inbound, outbound *time.Time
+	if err := a.tx.QueryRow(a.ctx, `
+		SELECT max(a.occurred_at) FILTER (WHERE a.direction = 'inbound'),
+		       max(a.occurred_at) FILTER (WHERE a.direction = 'outbound')
+		FROM activity a WHERE `+where, args...).Scan(&inbound, &outbound); err != nil {
+		return err
+	}
+	a.out.LastInboundAt = inbound
+	a.out.LastOutboundAt = outbound
 	return nil
 }
 

--- a/backend/internal/compose/orgrollupread.go
+++ b/backend/internal/compose/orgrollupread.go
@@ -22,6 +22,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/gradionhq/margince/backend/internal/modules/activities"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
@@ -389,19 +390,26 @@ func closedWonMinorThisQuarter(ctx context.Context, tx pgx.Tx, included []ids.UU
 	return total, err
 }
 
-// orgActivityCount30d counts distinct live activities linked to any
-// included organization in the half-open window [asOf−30d, asOf).
-// DISTINCT because one activity may link several orgs of the same tree
-// and must count once; the upper bound keeps a future-dated activity (a
-// scheduled call, a clock-skewed import) out of a count that claims to
-// describe the PAST 30 days.
+// orgActivityCount30d counts live activities that reach any included
+// organization in the half-open window [asOf−30d, asOf). The upper bound
+// keeps a future-dated activity (a scheduled call, a clock-skewed import)
+// out of a count that claims to describe the PAST 30 days.
+//
+// "Reaches" is activities.OrgLinkedActivityExistsAny — the same three-arm
+// walk (own link, its deal's org, the contact's employer) the timeline
+// list and the company view's sections use. A count that answered a
+// narrower question than the timeline it is displayed above was a number
+// the reader could disprove by scrolling.
+//
+// EXISTS rather than a join, so an activity reachable through several
+// links of the same tree is one row and COUNT(*) needs no DISTINCT.
 func orgActivityCount30d(ctx context.Context, tx pgx.Tx, included []ids.UUID, asOf time.Time) (int, error) {
 	var count int
 	err := tx.QueryRow(ctx, `
-		SELECT COUNT(DISTINCT a.id)
+		SELECT COUNT(*)
 		FROM activity a
-		JOIN activity_link l ON l.activity_id = a.id AND l.entity_type = 'organization'
-		WHERE l.organization_id = ANY($1) AND a.archived_at IS NULL
+		WHERE `+activities.OrgLinkedActivityExistsAny(1)+`
+		  AND a.archived_at IS NULL
 		  AND a.occurred_at >= $2 AND a.occurred_at < $3`,
 		included, asOf.AddDate(0, 0, -30), asOf).Scan(&count)
 	return count, err

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -3799,6 +3799,7 @@ func (e OrganizationSizeBand) Valid() bool {
 const (
 	Organization360SectionsOmittedActivities       Organization360SectionsOmitted = "activities"
 	Organization360SectionsOmittedDeals            Organization360SectionsOmitted = "deals"
+	Organization360SectionsOmittedLastTouch        Organization360SectionsOmitted = "last_touch"
 	Organization360SectionsOmittedListMemberships  Organization360SectionsOmitted = "list_memberships"
 	Organization360SectionsOmittedNextSteps        Organization360SectionsOmitted = "next_steps"
 	Organization360SectionsOmittedPendingApprovals Organization360SectionsOmitted = "pending_approvals"
@@ -3815,6 +3816,8 @@ func (e Organization360SectionsOmitted) Valid() bool {
 	case Organization360SectionsOmittedActivities:
 		return true
 	case Organization360SectionsOmittedDeals:
+		return true
+	case Organization360SectionsOmittedLastTouch:
 		return true
 	case Organization360SectionsOmittedListMemberships:
 		return true
@@ -10996,8 +10999,14 @@ type Organization360 struct {
 	AsOf time.Time `json:"as_of"`
 
 	// Deals The account's open deals plus the two lifetime figures the header needs.
-	Deals           *Organization360Deals `json:"deals,omitempty"`
-	ListMemberships *[]List               `json:"list_memberships,omitempty"`
+	Deals *Organization360Deals `json:"deals,omitempty"`
+
+	// LastInboundAt When they last wrote to us, over the same three-link walk the timeline uses (the activity's own link, its deal's organization, the employer of the contact it is filed against). Null means nothing inbound was ever captured — which is a fact about the account, not a missing field. Absent entirely when the caller has no activity grant, named in `sections_omitted` as `last_touch`.
+	LastInboundAt *time.Time `json:"last_inbound_at,omitempty"`
+
+	// LastOutboundAt When we last wrote to them, same walk. Shown BESIDE last_inbound_at rather than folded into one "last touch": which direction went last is the whole question — an account we mailed a fortnight ago with no reply is not the same as one that just wrote to us.
+	LastOutboundAt  *time.Time `json:"last_outbound_at,omitempty"`
+	ListMemberships *[]List    `json:"list_memberships,omitempty"`
 	NextSteps       *struct {
 		Data []Organization360NextStep `json:"data"`
 		Page PageInfo                  `json:"page"`

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -3693,6 +3693,72 @@ func (e OrganizationClassification) Valid() bool {
 	}
 }
 
+// Defines values for OrganizationLifecycle.
+const (
+	OrganizationLifecycleCustomer       OrganizationLifecycle = "customer"
+	OrganizationLifecycleDisqualified   OrganizationLifecycle = "disqualified"
+	OrganizationLifecycleFormerCustomer OrganizationLifecycle = "former_customer"
+	OrganizationLifecycleOpportunity    OrganizationLifecycle = "opportunity"
+	OrganizationLifecycleProspect       OrganizationLifecycle = "prospect"
+	OrganizationLifecycleTarget         OrganizationLifecycle = "target"
+	OrganizationLifecycleUnknown        OrganizationLifecycle = "unknown"
+)
+
+// Valid indicates whether the value is a known member of the OrganizationLifecycle enum.
+func (e OrganizationLifecycle) Valid() bool {
+	switch e {
+	case OrganizationLifecycleCustomer:
+		return true
+	case OrganizationLifecycleDisqualified:
+		return true
+	case OrganizationLifecycleFormerCustomer:
+		return true
+	case OrganizationLifecycleOpportunity:
+		return true
+	case OrganizationLifecycleProspect:
+		return true
+	case OrganizationLifecycleTarget:
+		return true
+	case OrganizationLifecycleUnknown:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for OrganizationRelationshipTypes.
+const (
+	OrganizationRelationshipTypesCompetitor       OrganizationRelationshipTypes = "competitor"
+	OrganizationRelationshipTypesCustomer         OrganizationRelationshipTypes = "customer"
+	OrganizationRelationshipTypesInvestor         OrganizationRelationshipTypes = "investor"
+	OrganizationRelationshipTypesOther            OrganizationRelationshipTypes = "other"
+	OrganizationRelationshipTypesPartner          OrganizationRelationshipTypes = "partner"
+	OrganizationRelationshipTypesPortfolioCompany OrganizationRelationshipTypes = "portfolio_company"
+	OrganizationRelationshipTypesSupplier         OrganizationRelationshipTypes = "supplier"
+)
+
+// Valid indicates whether the value is a known member of the OrganizationRelationshipTypes enum.
+func (e OrganizationRelationshipTypes) Valid() bool {
+	switch e {
+	case OrganizationRelationshipTypesCompetitor:
+		return true
+	case OrganizationRelationshipTypesCustomer:
+		return true
+	case OrganizationRelationshipTypesInvestor:
+		return true
+	case OrganizationRelationshipTypesOther:
+		return true
+	case OrganizationRelationshipTypesPartner:
+		return true
+	case OrganizationRelationshipTypesPortfolioCompany:
+		return true
+	case OrganizationRelationshipTypesSupplier:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for OrganizationSizeBand.
 const (
 	OrganizationSizeBandLessThannil OrganizationSizeBand = "<nil>"
@@ -5709,6 +5775,72 @@ func (e UpdateLeadRequestStatus) Valid() bool {
 	}
 }
 
+// Defines values for UpdateOrganizationRequestLifecycle.
+const (
+	UpdateOrganizationRequestLifecycleCustomer       UpdateOrganizationRequestLifecycle = "customer"
+	UpdateOrganizationRequestLifecycleDisqualified   UpdateOrganizationRequestLifecycle = "disqualified"
+	UpdateOrganizationRequestLifecycleFormerCustomer UpdateOrganizationRequestLifecycle = "former_customer"
+	UpdateOrganizationRequestLifecycleOpportunity    UpdateOrganizationRequestLifecycle = "opportunity"
+	UpdateOrganizationRequestLifecycleProspect       UpdateOrganizationRequestLifecycle = "prospect"
+	UpdateOrganizationRequestLifecycleTarget         UpdateOrganizationRequestLifecycle = "target"
+	UpdateOrganizationRequestLifecycleUnknown        UpdateOrganizationRequestLifecycle = "unknown"
+)
+
+// Valid indicates whether the value is a known member of the UpdateOrganizationRequestLifecycle enum.
+func (e UpdateOrganizationRequestLifecycle) Valid() bool {
+	switch e {
+	case UpdateOrganizationRequestLifecycleCustomer:
+		return true
+	case UpdateOrganizationRequestLifecycleDisqualified:
+		return true
+	case UpdateOrganizationRequestLifecycleFormerCustomer:
+		return true
+	case UpdateOrganizationRequestLifecycleOpportunity:
+		return true
+	case UpdateOrganizationRequestLifecycleProspect:
+		return true
+	case UpdateOrganizationRequestLifecycleTarget:
+		return true
+	case UpdateOrganizationRequestLifecycleUnknown:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for UpdateOrganizationRequestRelationshipTypes.
+const (
+	UpdateOrganizationRequestRelationshipTypesCompetitor       UpdateOrganizationRequestRelationshipTypes = "competitor"
+	UpdateOrganizationRequestRelationshipTypesCustomer         UpdateOrganizationRequestRelationshipTypes = "customer"
+	UpdateOrganizationRequestRelationshipTypesInvestor         UpdateOrganizationRequestRelationshipTypes = "investor"
+	UpdateOrganizationRequestRelationshipTypesOther            UpdateOrganizationRequestRelationshipTypes = "other"
+	UpdateOrganizationRequestRelationshipTypesPartner          UpdateOrganizationRequestRelationshipTypes = "partner"
+	UpdateOrganizationRequestRelationshipTypesPortfolioCompany UpdateOrganizationRequestRelationshipTypes = "portfolio_company"
+	UpdateOrganizationRequestRelationshipTypesSupplier         UpdateOrganizationRequestRelationshipTypes = "supplier"
+)
+
+// Valid indicates whether the value is a known member of the UpdateOrganizationRequestRelationshipTypes enum.
+func (e UpdateOrganizationRequestRelationshipTypes) Valid() bool {
+	switch e {
+	case UpdateOrganizationRequestRelationshipTypesCompetitor:
+		return true
+	case UpdateOrganizationRequestRelationshipTypesCustomer:
+		return true
+	case UpdateOrganizationRequestRelationshipTypesInvestor:
+		return true
+	case UpdateOrganizationRequestRelationshipTypesOther:
+		return true
+	case UpdateOrganizationRequestRelationshipTypesPartner:
+		return true
+	case UpdateOrganizationRequestRelationshipTypesPortfolioCompany:
+		return true
+	case UpdateOrganizationRequestRelationshipTypesSupplier:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for UpdateOrganizationRequestSizeBand.
 const (
 	UpdateOrganizationRequestSizeBandLessThannil UpdateOrganizationRequestSizeBand = "<nil>"
@@ -7113,6 +7245,72 @@ func (e ListOrganizationsParamsCapturedByKind) Valid() bool {
 	case ListOrganizationsParamsCapturedByKindHuman:
 		return true
 	case ListOrganizationsParamsCapturedByKindSystem:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for ListOrganizationsParamsLifecycle.
+const (
+	ListOrganizationsParamsLifecycleCustomer       ListOrganizationsParamsLifecycle = "customer"
+	ListOrganizationsParamsLifecycleDisqualified   ListOrganizationsParamsLifecycle = "disqualified"
+	ListOrganizationsParamsLifecycleFormerCustomer ListOrganizationsParamsLifecycle = "former_customer"
+	ListOrganizationsParamsLifecycleOpportunity    ListOrganizationsParamsLifecycle = "opportunity"
+	ListOrganizationsParamsLifecycleProspect       ListOrganizationsParamsLifecycle = "prospect"
+	ListOrganizationsParamsLifecycleTarget         ListOrganizationsParamsLifecycle = "target"
+	ListOrganizationsParamsLifecycleUnknown        ListOrganizationsParamsLifecycle = "unknown"
+)
+
+// Valid indicates whether the value is a known member of the ListOrganizationsParamsLifecycle enum.
+func (e ListOrganizationsParamsLifecycle) Valid() bool {
+	switch e {
+	case ListOrganizationsParamsLifecycleCustomer:
+		return true
+	case ListOrganizationsParamsLifecycleDisqualified:
+		return true
+	case ListOrganizationsParamsLifecycleFormerCustomer:
+		return true
+	case ListOrganizationsParamsLifecycleOpportunity:
+		return true
+	case ListOrganizationsParamsLifecycleProspect:
+		return true
+	case ListOrganizationsParamsLifecycleTarget:
+		return true
+	case ListOrganizationsParamsLifecycleUnknown:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for ListOrganizationsParamsRelationshipType.
+const (
+	ListOrganizationsParamsRelationshipTypeCompetitor       ListOrganizationsParamsRelationshipType = "competitor"
+	ListOrganizationsParamsRelationshipTypeCustomer         ListOrganizationsParamsRelationshipType = "customer"
+	ListOrganizationsParamsRelationshipTypeInvestor         ListOrganizationsParamsRelationshipType = "investor"
+	ListOrganizationsParamsRelationshipTypeOther            ListOrganizationsParamsRelationshipType = "other"
+	ListOrganizationsParamsRelationshipTypePartner          ListOrganizationsParamsRelationshipType = "partner"
+	ListOrganizationsParamsRelationshipTypePortfolioCompany ListOrganizationsParamsRelationshipType = "portfolio_company"
+	ListOrganizationsParamsRelationshipTypeSupplier         ListOrganizationsParamsRelationshipType = "supplier"
+)
+
+// Valid indicates whether the value is a known member of the ListOrganizationsParamsRelationshipType enum.
+func (e ListOrganizationsParamsRelationshipType) Valid() bool {
+	switch e {
+	case ListOrganizationsParamsRelationshipTypeCompetitor:
+		return true
+	case ListOrganizationsParamsRelationshipTypeCustomer:
+		return true
+	case ListOrganizationsParamsRelationshipTypeInvestor:
+		return true
+	case ListOrganizationsParamsRelationshipTypeOther:
+		return true
+	case ListOrganizationsParamsRelationshipTypePartner:
+		return true
+	case ListOrganizationsParamsRelationshipTypePortfolioCompany:
+		return true
+	case ListOrganizationsParamsRelationshipTypeSupplier:
 		return true
 	default:
 		return false
@@ -10718,7 +10916,8 @@ type Organization struct {
 	// CapturedBy Server-stamped from the authenticated principal (human:<uuid> | agent:<id> | connector:<name>); never client-supplied.
 	CapturedBy *string `json:"captured_by,omitempty"`
 
-	// Classification An org IS a partner iff classification='partner' AND it has a `partner` row (A41/ADR-0032). Values match the data-model §4.1 CHECK.
+	// Classification RETIRED (ADR-0079/A124) — superseded by `lifecycle` + `relationship_types`, which split the two questions this one value tried to answer at once. Carried one release, written by nothing; read it for migration comparison only.
+	// Deprecated: this property has been marked as deprecated upstream, but no `x-deprecated-reason` was set
 	Classification *OrganizationClassification `json:"classification,omitempty"`
 
 	// ComputedFields S-E15.8c formula-field display rows (RD-AC-6/RD-AC-7/RD-AC-N-1). Populated on
@@ -10731,6 +10930,9 @@ type Organization struct {
 	Id             openapi_types.UUID    `json:"id"`
 	Industry       *string               `json:"industry,omitempty"`
 	LegalName      *string               `json:"legal_name,omitempty"`
+
+	// Lifecycle WHERE THE ACCOUNT STANDS with us (PO-DDL-4, ADR-0079/A124). Single-valued: an account is at one point in a sales motion at a time. `unknown` is the default and means it — the retired `classification` defaulted to `prospect` and, having no writer, rendered that default on every unassessed account as though someone had judged it.
+	Lifecycle *OrganizationLifecycle `json:"lifecycle,omitempty"`
 
 	// LogoUrl Where to fetch the company's resolved logo image (A55) — the `getOrganizationLogo`
 	// path for this record, cookie-authenticated and same-origin. The key is ABSENT
@@ -10751,10 +10953,13 @@ type Organization struct {
 	// A68/ADR-0053 adds the relationship-in-flight layer: lifecycle stage, relationship health,
 	// partner fit, next step, and served segments. Behavior is Fast-follow, but the V1 schema is
 	// forward-compatible.
-	Partner  *Partner                `json:"partner,omitempty"`
-	Raw      *map[string]interface{} `json:"raw,omitempty"`
-	SizeBand *OrganizationSizeBand   `json:"size_band,omitempty"`
-	Source   string                  `json:"source"`
+	Partner *Partner                `json:"partner,omitempty"`
+	Raw     *map[string]interface{} `json:"raw,omitempty"`
+
+	// RelationshipTypes WHAT THE COMPANY IS to us (PO-DDL-4b, ADR-0079/A124). Multi-valued, because a company is legitimately several things at once — the partner program is built on companies that are simultaneously partners and customers. An org IS a partner iff it carries `partner` here AND has a `partner` row; removing the type while that row lives is refused (422).
+	RelationshipTypes *[]OrganizationRelationshipTypes `json:"relationship_types,omitempty"`
+	SizeBand          *OrganizationSizeBand            `json:"size_band,omitempty"`
+	Source            string                           `json:"source"`
 
 	// Strength Deterministic org-level relationship-strength roll-up (features/07 §4). Read-only derived view; NULL until capture has interactions.
 	Strength  *RelationshipStrength `json:"strength,omitempty"`
@@ -10770,8 +10975,14 @@ type Organization struct {
 	AdditionalProperties map[string]interface{} `json:"-"`
 }
 
-// OrganizationClassification An org IS a partner iff classification='partner' AND it has a `partner` row (A41/ADR-0032). Values match the data-model §4.1 CHECK.
+// OrganizationClassification RETIRED (ADR-0079/A124) — superseded by `lifecycle` + `relationship_types`, which split the two questions this one value tried to answer at once. Carried one release, written by nothing; read it for migration comparison only.
 type OrganizationClassification string
+
+// OrganizationLifecycle WHERE THE ACCOUNT STANDS with us (PO-DDL-4, ADR-0079/A124). Single-valued: an account is at one point in a sales motion at a time. `unknown` is the default and means it — the retired `classification` defaulted to `prospect` and, having no writer, rendered that default on every unassessed account as though someone had judged it.
+type OrganizationLifecycle string
+
+// OrganizationRelationshipTypes defines model for Organization.RelationshipTypes.
+type OrganizationRelationshipTypes string
 
 // OrganizationSizeBand defines model for Organization.SizeBand.
 type OrganizationSizeBand string
@@ -13012,14 +13223,26 @@ type UpdateOrganizationRequest struct {
 	DisplayName *string  `json:"display_name,omitempty"`
 
 	// Domains Replace-set of the org's live domains (add new, archive removed, flip is_primary). Absent = untouched; an empty array clears all domains.
-	Domains              *[]OrganizationDomainInput         `json:"domains,omitempty"`
-	Industry             *string                            `json:"industry,omitempty"`
-	LegalName            *string                            `json:"legal_name,omitempty"`
-	OwnerId              *openapi_types.UUID                `json:"owner_id,omitempty"`
-	ParentOrgId          *openapi_types.UUID                `json:"parent_org_id,omitempty"`
-	SizeBand             *UpdateOrganizationRequestSizeBand `json:"size_band,omitempty"`
-	AdditionalProperties map[string]interface{}             `json:"-"`
+	Domains   *[]OrganizationDomainInput `json:"domains,omitempty"`
+	Industry  *string                    `json:"industry,omitempty"`
+	LegalName *string                    `json:"legal_name,omitempty"`
+
+	// Lifecycle Where the account stands with us (ADR-0079/A124). Absent = untouched.
+	Lifecycle   *UpdateOrganizationRequestLifecycle `json:"lifecycle,omitempty"`
+	OwnerId     *openapi_types.UUID                 `json:"owner_id,omitempty"`
+	ParentOrgId *openapi_types.UUID                 `json:"parent_org_id,omitempty"`
+
+	// RelationshipTypes Replace-set of what the company is to us (add new, archive removed), the same shape as `domains`. Absent = untouched; an empty array clears every type. Removing `partner` while the org still has a `partner` extension row is refused with 422 — the invariant binds both ways, and an invariant nothing enforces is a comment.
+	RelationshipTypes    *[]UpdateOrganizationRequestRelationshipTypes `json:"relationship_types,omitempty"`
+	SizeBand             *UpdateOrganizationRequestSizeBand            `json:"size_band,omitempty"`
+	AdditionalProperties map[string]interface{}                        `json:"-"`
 }
+
+// UpdateOrganizationRequestLifecycle Where the account stands with us (ADR-0079/A124). Absent = untouched.
+type UpdateOrganizationRequestLifecycle string
+
+// UpdateOrganizationRequestRelationshipTypes defines model for UpdateOrganizationRequest.RelationshipTypes.
+type UpdateOrganizationRequestRelationshipTypes string
 
 // UpdateOrganizationRequestSizeBand defines model for UpdateOrganizationRequest.SizeBand.
 type UpdateOrganizationRequestSizeBand string
@@ -15054,11 +15277,23 @@ type ListOrganizationsParams struct {
 
 	// Domain Lookup by normalized domain (the employer-inference index).
 	Domain *string `form:"domain,omitempty" json:"domain,omitempty"`
-	Q      *string `form:"q,omitempty" json:"q,omitempty"`
+
+	// Lifecycle Where the account stands with us (DM-VOCAB-2, ADR-0079/A124).
+	Lifecycle *ListOrganizationsParamsLifecycle `form:"lifecycle,omitempty" json:"lifecycle,omitempty"`
+
+	// RelationshipType Accounts carrying this relationship type. Multi-valued per account, so this selects accounts that are AT LEAST this — a partner that is also a customer matches both.
+	RelationshipType *ListOrganizationsParamsRelationshipType `form:"relationship_type,omitempty" json:"relationship_type,omitempty"`
+	Q                *string                                  `form:"q,omitempty" json:"q,omitempty"`
 }
 
 // ListOrganizationsParamsCapturedByKind defines parameters for ListOrganizations.
 type ListOrganizationsParamsCapturedByKind string
+
+// ListOrganizationsParamsLifecycle defines parameters for ListOrganizations.
+type ListOrganizationsParamsLifecycle string
+
+// ListOrganizationsParamsRelationshipType defines parameters for ListOrganizations.
+type ListOrganizationsParamsRelationshipType string
 
 // CreateOrganizationParams defines parameters for CreateOrganization.
 type CreateOrganizationParams struct {
@@ -19842,6 +20077,14 @@ func (a *Organization) UnmarshalJSON(b []byte) error {
 		delete(object, "legal_name")
 	}
 
+	if raw, found := object["lifecycle"]; found {
+		err = json.Unmarshal(raw, &a.Lifecycle)
+		if err != nil {
+			return fmt.Errorf("error reading 'lifecycle': %w", err)
+		}
+		delete(object, "lifecycle")
+	}
+
 	if raw, found := object["logo_url"]; found {
 		err = json.Unmarshal(raw, &a.LogoUrl)
 		if err != nil {
@@ -19888,6 +20131,14 @@ func (a *Organization) UnmarshalJSON(b []byte) error {
 			return fmt.Errorf("error reading 'raw': %w", err)
 		}
 		delete(object, "raw")
+	}
+
+	if raw, found := object["relationship_types"]; found {
+		err = json.Unmarshal(raw, &a.RelationshipTypes)
+		if err != nil {
+			return fmt.Errorf("error reading 'relationship_types': %w", err)
+		}
+		delete(object, "relationship_types")
 	}
 
 	if raw, found := object["size_band"]; found {
@@ -20026,6 +20277,13 @@ func (a Organization) MarshalJSON() ([]byte, error) {
 		}
 	}
 
+	if a.Lifecycle != nil {
+		object["lifecycle"], err = json.Marshal(a.Lifecycle)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'lifecycle': %w", err)
+		}
+	}
+
 	if a.LogoUrl != nil {
 		object["logo_url"], err = json.Marshal(a.LogoUrl)
 		if err != nil {
@@ -20065,6 +20323,13 @@ func (a Organization) MarshalJSON() ([]byte, error) {
 		object["raw"], err = json.Marshal(a.Raw)
 		if err != nil {
 			return nil, fmt.Errorf("error marshaling 'raw': %w", err)
+		}
+	}
+
+	if a.RelationshipTypes != nil {
+		object["relationship_types"], err = json.Marshal(a.RelationshipTypes)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'relationship_types': %w", err)
 		}
 	}
 
@@ -21775,6 +22040,14 @@ func (a *UpdateOrganizationRequest) UnmarshalJSON(b []byte) error {
 		delete(object, "legal_name")
 	}
 
+	if raw, found := object["lifecycle"]; found {
+		err = json.Unmarshal(raw, &a.Lifecycle)
+		if err != nil {
+			return fmt.Errorf("error reading 'lifecycle': %w", err)
+		}
+		delete(object, "lifecycle")
+	}
+
 	if raw, found := object["owner_id"]; found {
 		err = json.Unmarshal(raw, &a.OwnerId)
 		if err != nil {
@@ -21789,6 +22062,14 @@ func (a *UpdateOrganizationRequest) UnmarshalJSON(b []byte) error {
 			return fmt.Errorf("error reading 'parent_org_id': %w", err)
 		}
 		delete(object, "parent_org_id")
+	}
+
+	if raw, found := object["relationship_types"]; found {
+		err = json.Unmarshal(raw, &a.RelationshipTypes)
+		if err != nil {
+			return fmt.Errorf("error reading 'relationship_types': %w", err)
+		}
+		delete(object, "relationship_types")
 	}
 
 	if raw, found := object["size_band"]; found {
@@ -21853,6 +22134,13 @@ func (a UpdateOrganizationRequest) MarshalJSON() ([]byte, error) {
 		}
 	}
 
+	if a.Lifecycle != nil {
+		object["lifecycle"], err = json.Marshal(a.Lifecycle)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'lifecycle': %w", err)
+		}
+	}
+
 	if a.OwnerId != nil {
 		object["owner_id"], err = json.Marshal(a.OwnerId)
 		if err != nil {
@@ -21864,6 +22152,13 @@ func (a UpdateOrganizationRequest) MarshalJSON() ([]byte, error) {
 		object["parent_org_id"], err = json.Marshal(a.ParentOrgId)
 		if err != nil {
 			return nil, fmt.Errorf("error marshaling 'parent_org_id': %w", err)
+		}
+	}
+
+	if a.RelationshipTypes != nil {
+		object["relationship_types"], err = json.Marshal(a.RelationshipTypes)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'relationship_types': %w", err)
 		}
 	}
 
@@ -31951,6 +32246,32 @@ func (siw *ServerInterfaceWrapper) ListOrganizations(w http.ResponseWriter, r *h
 			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "domain"})
 		} else {
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "domain", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "lifecycle" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "lifecycle", r.URL.Query(), &params.Lifecycle, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "lifecycle"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "lifecycle", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "relationship_type" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "relationship_type", r.URL.Query(), &params.RelationshipType, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "relationship_type"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "relationship_type", Err: err})
 		}
 		return
 	}

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -4062,6 +4062,36 @@ func (e OrganizationFactSource) Valid() bool {
 	}
 }
 
+// Defines values for OrganizationFactSuspectReason.
+const (
+	OrganizationFactSuspectReasonLessThannil         OrganizationFactSuspectReason = "<nil>"
+	OrganizationFactSuspectReasonNotAPhone           OrganizationFactSuspectReason = "not_a_phone"
+	OrganizationFactSuspectReasonNotASize            OrganizationFactSuspectReason = "not_a_size"
+	OrganizationFactSuspectReasonNotAYear            OrganizationFactSuspectReason = "not_a_year"
+	OrganizationFactSuspectReasonNotAnEmail          OrganizationFactSuspectReason = "not_an_email"
+	OrganizationFactSuspectReasonPhoneShapedLocation OrganizationFactSuspectReason = "phone_shaped_location"
+)
+
+// Valid indicates whether the value is a known member of the OrganizationFactSuspectReason enum.
+func (e OrganizationFactSuspectReason) Valid() bool {
+	switch e {
+	case OrganizationFactSuspectReasonLessThannil:
+		return true
+	case OrganizationFactSuspectReasonNotAPhone:
+		return true
+	case OrganizationFactSuspectReasonNotASize:
+		return true
+	case OrganizationFactSuspectReasonNotAYear:
+		return true
+	case OrganizationFactSuspectReasonNotAnEmail:
+		return true
+	case OrganizationFactSuspectReasonPhoneShapedLocation:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for OrganizationGraphGroupsOmitted.
 const (
 	OrganizationGraphGroupsOmittedContacts  OrganizationGraphGroupsOmitted = "contacts"
@@ -6563,22 +6593,22 @@ func (e VoiceProfileEvaluationRepeatsPerPrompt) Valid() bool {
 
 // Defines values for VoiceProfileVersionReason.
 const (
-	Automatic  VoiceProfileVersionReason = "automatic"
-	Manual     VoiceProfileVersionReason = "manual"
-	Onboarding VoiceProfileVersionReason = "onboarding"
-	Rollback   VoiceProfileVersionReason = "rollback"
+	VoiceProfileVersionReasonAutomatic  VoiceProfileVersionReason = "automatic"
+	VoiceProfileVersionReasonManual     VoiceProfileVersionReason = "manual"
+	VoiceProfileVersionReasonOnboarding VoiceProfileVersionReason = "onboarding"
+	VoiceProfileVersionReasonRollback   VoiceProfileVersionReason = "rollback"
 )
 
 // Valid indicates whether the value is a known member of the VoiceProfileVersionReason enum.
 func (e VoiceProfileVersionReason) Valid() bool {
 	switch e {
-	case Automatic:
+	case VoiceProfileVersionReasonAutomatic:
 		return true
-	case Manual:
+	case VoiceProfileVersionReasonManual:
 		return true
-	case Onboarding:
+	case VoiceProfileVersionReasonOnboarding:
 		return true
-	case Rollback:
+	case VoiceProfileVersionReasonRollback:
 		return true
 	default:
 		return false
@@ -11286,9 +11316,12 @@ type OrganizationFact struct {
 	Field           OrganizationFactField    `json:"field"`
 	Source          OrganizationFactSource   `json:"source"`
 	SourceUrl       *string                  `json:"source_url,omitempty"`
-	UpdatedAt       time.Time                `json:"updated_at"`
-	Value           string                   `json:"value"`
-	ValueKey        string                   `json:"value_key"`
+
+	// SuspectReason Why this fact's VALUE contradicts its FIELD, or null when it does not. The extractor picks the field from a closed per-page menu and the category follows the field, so a phone number on a contact page can land as `location` and a register number as `employee_range` — the row is well-formed and still wrong. Computed at read from the value's shape; it never gates the fact, because a heuristic that hid data would be worse than one that flags it.
+	SuspectReason *OrganizationFactSuspectReason `json:"suspect_reason,omitempty"`
+	UpdatedAt     time.Time                      `json:"updated_at"`
+	Value         string                         `json:"value"`
+	ValueKey      string                         `json:"value_key"`
 }
 
 // OrganizationFactCategory defines model for OrganizationFact.Category.
@@ -11299,6 +11332,9 @@ type OrganizationFactField string
 
 // OrganizationFactSource defines model for OrganizationFact.Source.
 type OrganizationFactSource string
+
+// OrganizationFactSuspectReason Why this fact's VALUE contradicts its FIELD, or null when it does not. The extractor picks the field from a closed per-page menu and the category follows the field, so a phone number on a contact page can land as `location` and a register number as `employee_range` — the row is well-formed and still wrong. Computed at read from the value's shape; it never gates the fact, because a heuristic that hid data would be worse than one that flags it.
+type OrganizationFactSuspectReason string
 
 // OrganizationFactListResponse defines model for OrganizationFactListResponse.
 type OrganizationFactListResponse struct {

--- a/backend/internal/modules/activities/orgscope.go
+++ b/backend/internal/modules/activities/orgscope.go
@@ -36,14 +36,36 @@ import (
 // orgPos is the bind position carrying the organization id; the caller registers
 // it once and every arm reads the same one.
 func OrgLinkedActivityExists(orgPos int) string {
+	return activityReachesOrg(sprintf("$%d", orgPos))
+}
+
+// OrgLinkedActivityExistsAny is the same walk over a SET of organizations, for
+// a caller that binds an id array rather than one id.
+//
+// The hierarchy roll-up needs it. Its 30-day count used to match
+// activity_link.organization_id alone, which asked a narrower question than the
+// timeline the number is displayed above: capture files mail against the PERSON
+// it was with, so an account's busiest correspondence carries no organization
+// link at all and went uncounted. One walk, two bind shapes — a fourth link
+// added to the model still reaches both.
+//
+// orgsPos is the bind position carrying the organization id array.
+func OrgLinkedActivityExistsAny(orgsPos int) string {
+	return activityReachesOrg(sprintf("ANY($%d)", orgsPos))
+}
+
+// activityReachesOrg is the walk itself. operand is what each arm compares its
+// organization id against — a single bind, or ANY(array) — so the three links
+// are written once and neither caller can drift from the other.
+func activityReachesOrg(operand string) string {
 	return sprintf(`EXISTS (
 		    SELECT 1 FROM activity_link l
 		    LEFT JOIN deal d ON d.id = l.deal_id
 		    LEFT JOIN relationship r ON r.person_id = l.person_id AND r.kind = 'employment'
 		      AND r.ended_at IS NULL AND r.archived_at IS NULL
 		    WHERE l.activity_id = a.id
-		      AND (l.organization_id = $%[1]d OR d.organization_id = $%[1]d OR r.organization_id = $%[1]d))`,
-		orgPos)
+		      AND (l.organization_id = %[1]s OR d.organization_id = %[1]s OR r.organization_id = %[1]s))`,
+		operand)
 }
 
 // listActivitiesFilter builds the timeline query's join, WHERE terms and

--- a/backend/internal/modules/collections/vocab.go
+++ b/backend/internal/modules/collections/vocab.go
@@ -43,9 +43,15 @@ var segmentEngines = map[string]storekit.Query{
 		Table:     "organization",
 		BaseWhere: whereArchivedNull,
 		Fields: map[string]storekit.Field{
-			"owner_id":       {Expr: colOwnerID, Type: storekit.FieldID},
-			"industry":       {Expr: "t.industry", Type: storekit.FieldText},
-			"size_band":      {Expr: "t.size_band", Type: storekit.FieldPicklist},
+			"owner_id":  {Expr: colOwnerID, Type: storekit.FieldID},
+			"industry":  {Expr: "t.industry", Type: storekit.FieldText},
+			"size_band": {Expr: "t.size_band", Type: storekit.FieldPicklist},
+			"lifecycle": {Expr: "t.lifecycle", Type: storekit.FieldPicklist},
+			// RETIRED with the column (ADR-0079/A124), and kept here for the one
+			// release it survives: a saved segment written against it must keep
+			// evaluating until its author has moved it to lifecycle. Dropping the
+			// field would turn every such list into an error at read time, which
+			// is a worse answer than a stale one.
 			"classification": {Expr: "t.classification", Type: storekit.FieldPicklist},
 		},
 	},

--- a/backend/internal/modules/people/coldstartprofile.go
+++ b/backend/internal/modules/people/coldstartprofile.go
@@ -52,6 +52,49 @@ var columnBackedColdStartFields = map[string]string{
 	"registered_address": "address",
 }
 
+// readColdStartColumnImages reads the columns an apply may touch, so the audit
+// can record what each one WAS. Without this the write recorded only what it
+// set, and field history had no diff to project — the reason it rendered
+// pseudo-fields instead of "legal_name: X → Y".
+func readColdStartColumnImages(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID) (map[string]any, error) {
+	var legalName, industry, addressLine1 *string
+	if err := tx.QueryRow(ctx,
+		`SELECT legal_name, industry, address_line1 FROM organization WHERE id = $1`,
+		orgID).Scan(&legalName, &industry, &addressLine1); err != nil {
+		return nil, fmt.Errorf("read organization column images: %w", err)
+	}
+	out := map[string]any{}
+	for column, value := range map[string]*string{
+		"legal_name": legalName, "industry": industry, "address_line1": addressLine1,
+	} {
+		if value == nil {
+			// An empty column reads as an explicit null in the image, never as
+			// an absent key: "it had nothing" and "nobody looked" are different
+			// answers, and field history renders them differently.
+			out[column] = nil
+			continue
+		}
+		out[column] = *value
+	}
+	return out, nil
+}
+
+// changedColumnsOnly narrows the two images to the columns that actually moved.
+// A field-history projection reads every key in the pair, so carrying an
+// untouched column through would publish "industry: Automotive → Automotive"
+// as a change on a run that only filled the legal name.
+func changedColumnsOnly(before, after map[string]any) (map[string]any, map[string]any) {
+	b, a := map[string]any{}, map[string]any{}
+	for column, afterValue := range after {
+		if before[column] == afterValue {
+			continue
+		}
+		b[column] = before[column]
+		a[column] = afterValue
+	}
+	return b, a
+}
+
 // ApplyColdStartProfile executes an ACCEPTED coldstart proposal. A
 // column a human (or any earlier capture) already filled is left
 // untouched — acceptance covers the staged diff, not an overwrite of
@@ -96,16 +139,34 @@ func applyColdStartTx(ctx context.Context, tx pgx.Tx, in ApplyColdStartProfileIn
 	if err != nil {
 		return ids.OrganizationID{}, err
 	}
+	// The columns as they stand BEFORE the apply. Read first, because the
+	// write only reports whether it changed something, not what it replaced —
+	// and an audit row with no before image gives field history nothing to
+	// diff, which is why it used to render pseudo-fields.
+	before, err := readColdStartColumnImages(ctx, tx, orgID)
+	if err != nil {
+		return ids.OrganizationID{}, err
+	}
 	applied, err := applyEvidenceFields(ctx, tx, wsID, orgID, companySourceSiteRead, by, in.Fields)
 	if err != nil {
 		return ids.OrganizationID{}, err
 	}
+	after, err := readColdStartColumnImages(ctx, tx, orgID)
+	if err != nil {
+		return ids.OrganizationID{}, err
+	}
+	before, after = changedColumnsOnly(before, after)
 
 	action := "update"
 	if created {
 		action = "create"
 	}
-	auditID, err := storekit.Audit(ctx, tx, action, "organization", orgID.UUID, nil, map[string]any{
+	// before/after carry the RECORD's own column images and nothing else; the
+	// operation's metadata rides audit_log.evidence, which is what that column
+	// is for. Folding source/source_url/fields into the after image made field
+	// history project them as changes to fields named "source" and "facts" —
+	// changes that never happened on the record (storekit.AuditWithEvidence).
+	auditID, err := storekit.AuditWithEvidence(ctx, tx, action, "organization", orgID.UUID, before, after, map[string]any{
 		auditKeySource: companySourceSiteRead, auditKeySourceURL: in.SourceURL, auditKeyFields: applied,
 	})
 	if err != nil {

--- a/backend/internal/modules/people/coldstartprofile.go
+++ b/backend/internal/modules/people/coldstartprofile.go
@@ -53,17 +53,19 @@ var columnBackedColdStartFields = map[string]string{
 }
 
 // readColdStartColumnImages reads the columns an apply may touch, so the audit
-// can record what each one WAS. Without this the write recorded only what it
-// set, and field history had no diff to project — the reason it rendered
-// pseudo-fields instead of "legal_name: X → Y".
+// row can carry what each one WAS. The column writes report only whether they
+// changed something, never what they replaced, so the before image has to be
+// read: field history projects per field from before/after, and an image-less
+// audit row gives it nothing to diff.
 func readColdStartColumnImages(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID) (map[string]any, error) {
+	var displayName string
 	var legalName, industry, addressLine1 *string
 	if err := tx.QueryRow(ctx,
-		`SELECT legal_name, industry, address_line1 FROM organization WHERE id = $1`,
-		orgID).Scan(&legalName, &industry, &addressLine1); err != nil {
+		`SELECT display_name, legal_name, industry, address_line1 FROM organization WHERE id = $1`,
+		orgID).Scan(&displayName, &legalName, &industry, &addressLine1); err != nil {
 		return nil, fmt.Errorf("read organization column images: %w", err)
 	}
-	out := map[string]any{}
+	out := map[string]any{fieldDisplayName: displayName}
 	for column, value := range map[string]*string{
 		"legal_name": legalName, "industry": industry, "address_line1": addressLine1,
 	} {
@@ -139,10 +141,9 @@ func applyColdStartTx(ctx context.Context, tx pgx.Tx, in ApplyColdStartProfileIn
 	if err != nil {
 		return ids.OrganizationID{}, err
 	}
-	// The columns as they stand BEFORE the apply. Read first, because the
-	// write only reports whether it changed something, not what it replaced —
-	// and an audit row with no before image gives field history nothing to
-	// diff, which is why it used to render pseudo-fields.
+	// The columns as they stand before the apply, including display_name: a
+	// created organization gets its name here, and that is a column change a
+	// reader is entitled to see.
 	before, err := readColdStartColumnImages(ctx, tx, orgID)
 	if err != nil {
 		return ids.OrganizationID{}, err
@@ -161,11 +162,10 @@ func applyColdStartTx(ctx context.Context, tx pgx.Tx, in ApplyColdStartProfileIn
 	if created {
 		action = "create"
 	}
-	// before/after carry the RECORD's own column images and nothing else; the
-	// operation's metadata rides audit_log.evidence, which is what that column
-	// is for. Folding source/source_url/fields into the after image made field
-	// history project them as changes to fields named "source" and "facts" —
-	// changes that never happened on the record (storekit.AuditWithEvidence).
+	// before/after carry the RECORD's own column images and nothing else. The
+	// operation's metadata rides audit_log.evidence, which is the column for
+	// it: anything placed in the images is projected by field history as a
+	// change to a field of that name (storekit.AuditWithEvidence).
 	auditID, err := storekit.AuditWithEvidence(ctx, tx, action, "organization", orgID.UUID, before, after, map[string]any{
 		auditKeySource: companySourceSiteRead, auditKeySourceURL: in.SourceURL, auditKeyFields: applied,
 	})

--- a/backend/internal/modules/people/handlers_organization.go
+++ b/backend/internal/modules/people/handlers_organization.go
@@ -35,14 +35,16 @@ func (h Handlers) MergeOrganization(w http.ResponseWriter, r *http.Request, id c
 
 func (h Handlers) ListOrganizations(w http.ResponseWriter, r *http.Request, params crmcontracts.ListOrganizationsParams) {
 	in := ListOrganizationsInput{
-		Cursor:          params.Cursor,
-		Limit:           params.Limit,
-		Query:           params.Q,
-		IncludeArchived: params.IncludeArchived != nil && *params.IncludeArchived,
-		CapturedByKind:  capturedByKindArg(params.CapturedByKind),
-		AiWritten:       params.AiWritten,
-		Sort:            params.Sort,
-		CustomFilters:   httperr.CustomFieldFilters(r),
+		Cursor:           params.Cursor,
+		Limit:            params.Limit,
+		Query:            params.Q,
+		IncludeArchived:  params.IncludeArchived != nil && *params.IncludeArchived,
+		CapturedByKind:   capturedByKindArg(params.CapturedByKind),
+		AiWritten:        params.AiWritten,
+		Sort:             params.Sort,
+		CustomFilters:    httperr.CustomFieldFilters(r),
+		Lifecycle:        enumArg(params.Lifecycle),
+		RelationshipType: enumArg(params.RelationshipType),
 	}
 	in.OwnerID = idArg[ids.UserKind](params.OwnerId)
 
@@ -182,4 +184,15 @@ func (h Handlers) ArchiveOrganization(w http.ResponseWriter, r *http.Request, id
 		return
 	}
 	httperr.WriteJSON(w, http.StatusOK, org)
+}
+
+// enumArg reads an optional generated enum query parameter as the plain string
+// the store filters on. A nil parameter stays nil: an omitted filter is not a
+// filter, never an empty-string match.
+func enumArg[T ~string](v *T) *string {
+	if v == nil {
+		return nil
+	}
+	s := string(*v)
+	return &s
 }

--- a/backend/internal/modules/people/mapping.go
+++ b/backend/internal/modules/people/mapping.go
@@ -181,6 +181,17 @@ func organizationUpdateInput(req crmcontracts.UpdateOrganizationRequest, ifVersi
 		}
 		in.Domains = &desired
 	}
+	if req.Lifecycle != nil {
+		lifecycle := string(*req.Lifecycle)
+		in.Lifecycle = &lifecycle
+	}
+	if req.RelationshipTypes != nil {
+		desired := make([]string, 0, len(*req.RelationshipTypes))
+		for _, t := range *req.RelationshipTypes {
+			desired = append(desired, string(t))
+		}
+		in.RelationshipTypes = &desired
+	}
 	return in
 }
 

--- a/backend/internal/modules/people/merge_organization.go
+++ b/backend/internal/modules/people/merge_organization.go
@@ -90,20 +90,33 @@ func relinkOrgAssociations(ctx context.Context, tx pgx.Tx, sourceID, targetID id
 	if _, err := relinkLinkRows(ctx, tx, "organization", sourceID.UUID, targetID.UUID); err != nil {
 		return false, fmt.Errorf("relink activity/list/tag rows: %w", err)
 	}
+	// The survivor ends up with the UNION of both companies' relationship
+	// types. These are child ROWS, so survivorship on the organization row
+	// cannot move them — they have to be re-homed here, beside the domains.
+	if err := moveOrgRelationshipTypes(ctx, tx, sourceID, targetID); err != nil {
+		return false, err
+	}
 	return absorbOrgReferences(ctx, tx, sourceID, targetID)
 }
 
 // fillOrgSurvivorship folds the merged-away org's fields into the survivor
-// where the survivor is blank and, when the survivor gained the 1:1 partner
-// extension, flips its classification to 'partner' (the A41 invariant:
-// classification='partner' iff a partner row exists). It returns the
+// where the survivor is blank, and — when the survivor gained the 1:1 partner
+// extension — asserts the 'partner' relationship type that is the other half
+// of the invariant (ADR-0079 amending ADR-0032 §Decision 2). It returns the
 // applied after-image for the merge audit.
+//
+// A merged-away partner would otherwise leave the survivor holding the
+// extension row with nothing saying it is a partner, which is exactly the
+// half-state the enforced invariant exists to make impossible.
 func fillOrgSurvivorship(ctx context.Context, tx pgx.Tx, src, tgt crmcontracts.Organization, targetIsPartner bool, tgtLock storekit.RowLock) (map[string]any, error) {
 	p := storekit.NewPatch()
 	fillString(p, "legal_name", tgt.LegalName, src.LegalName)
 	fillString(p, "industry", tgt.Industry, src.Industry)
-	if targetIsPartner && (tgt.Classification == nil || *tgt.Classification != crmcontracts.OrganizationClassificationPartner) {
-		p.Set("classification", tgt.Classification, "partner")
+	if targetIsPartner {
+		if err := ensureOrgRelationshipType(ctx, tx, workspaceID(ctx), ids.OrganizationID{UUID: ids.UUID(tgt.Id)},
+			relationshipTypePartner, "system", "system:merge"); err != nil {
+			return nil, err
+		}
 	}
 	if !p.Empty() {
 		if err := p.ApplyLocked(ctx, tx, tgtLock); err != nil {

--- a/backend/internal/modules/people/organization.go
+++ b/backend/internal/modules/people/organization.go
@@ -188,6 +188,14 @@ type UpdateOrganizationInput struct {
 	// add missing, archive removed, flip is_primary). nil leaves domains
 	// untouched; an empty slice clears them.
 	Domains *[]OrgDomainInput
+	// Lifecycle, when non-nil, moves where the account stands with us
+	// (ADR-0079/A124). nil leaves it untouched.
+	Lifecycle *string
+	// RelationshipTypes, when non-nil, is the desired live type set — the same
+	// replace-set shape as Domains. nil leaves them untouched; an empty slice
+	// clears them, except that 'partner' cannot be dropped while the partner
+	// extension row lives.
+	RelationshipTypes *[]string
 	// CustomFields carries the request body's extra top-level keys
 	// (additionalProperties); only active cf_* catalog columns land,
 	// drop-on-mismatch (customfields.go).
@@ -222,6 +230,20 @@ func (s *Store) UpdateOrganization(ctx context.Context, id ids.OrganizationID, i
 		// bump (updated_at below), so If-Match still guards it and the audit
 		// row records the transition — the same shape as UpdatePerson/social.
 		var by string
+		if in.RelationshipTypes != nil {
+			if by, err = storekit.CapturedBy(ctx); err != nil {
+				return err
+			}
+			deduped, err := dedupeRelationshipTypes(*in.RelationshipTypes)
+			if err != nil {
+				return err
+			}
+			*in.RelationshipTypes = deduped
+			// The reconcile rides the org row's version bump, exactly as the
+			// domain replace-set does, so If-Match still guards it and the
+			// audit row records the transition.
+			p.Set("updated_at", current.UpdatedAt, time.Now().UTC())
+		}
 		if in.Domains != nil {
 			if by, err = storekit.CapturedBy(ctx); err != nil {
 				return err
@@ -263,6 +285,14 @@ func (s *Store) UpdateOrganization(ctx context.Context, id ids.OrganizationID, i
 			before["domains"] = domainsBefore
 			after["domains"] = domainSummaries(*in.Domains)
 		}
+		if in.RelationshipTypes != nil {
+			typesBefore, err := reconcileOrgRelationshipTypes(ctx, tx, workspaceID(ctx), id, "manual", by, *in.RelationshipTypes)
+			if err != nil {
+				return err
+			}
+			before["relationship_types"] = typesBefore
+			after["relationship_types"] = *in.RelationshipTypes
+		}
 
 		auditID, err := storekit.Audit(ctx, tx, "update", "organization", id.UUID, before, after)
 		if err != nil {
@@ -298,6 +328,9 @@ func buildOrganizationPatch(ctx context.Context, tx pgx.Tx, current crmcontracts
 	}
 	if in.OwnerID != nil {
 		p.Set(ownerIDColumn, current.OwnerId, *in.OwnerID)
+	}
+	if in.Lifecycle != nil {
+		p.Set("lifecycle", lifecycleValue(current.Lifecycle), *in.Lifecycle)
 	}
 	if in.ParentOrgID != nil {
 		if err := auth.EnsureLinkTarget(ctx, tx, "organization", in.ParentOrgID.UUID); err != nil {
@@ -338,6 +371,10 @@ func (s *Store) ArchiveOrganization(ctx context.Context, id ids.OrganizationID) 
 		for _, stmt := range []string{
 			`UPDATE organization SET archived_at = $2 WHERE id = $1 AND archived_at IS NULL`,
 			`UPDATE organization_domain SET archived_at = $2 WHERE organization_id = $1 AND archived_at IS NULL`,
+			// An archived account that still carried a live 'partner' type row
+			// would keep answering the partner list (ADR-0079's invariant runs
+			// over LIVE rows), so the types retire with their parent.
+			`UPDATE organization_relationship_type SET archived_at = $2 WHERE organization_id = $1 AND archived_at IS NULL`,
 			`UPDATE relationship SET archived_at = $2 WHERE (organization_id = $1 OR counterparty_org_id = $1) AND archived_at IS NULL`,
 		} {
 			if _, err := tx.Exec(ctx, stmt, id, now); err != nil {
@@ -368,7 +405,7 @@ func (s *Store) ArchiveOrganization(ctx context.Context, id ids.OrganizationID) 
 
 const orgColumns = `id, workspace_id, display_name, legal_name, industry, size_band, owner_id,
 	address_line1, address_line2, address_city, address_region, address_postal_code, address_country,
-	classification, relevance, parent_org_id, merged_into_id, logo_object_key, source, captured_by,
+	classification, lifecycle, relevance, parent_org_id, merged_into_id, logo_object_key, source, captured_by,
 	version, created_at, updated_at, archived_at`
 
 // readOrganization resolves one organization row; active names the
@@ -390,6 +427,9 @@ func readOrganization(ctx context.Context, tx pgx.Tx, id ids.OrganizationID, arc
 	if err := attachOrgDomains(ctx, tx, orgs); err != nil {
 		return crmcontracts.Organization{}, err
 	}
+	if err := attachOrgRelationshipTypes(ctx, tx, orgs); err != nil {
+		return crmcontracts.Organization{}, err
+	}
 	return orgs[0], nil
 }
 
@@ -400,7 +440,7 @@ func scanOrganization(row pgx.Row, active []fieldcatalog.Column, extra ...any) (
 	var o crmcontracts.Organization
 	var id, wsID ids.UUID
 	var ownerID, parentID, mergedInto *ids.UUID
-	var classification string
+	var classification, lifecycle string
 	var relevance *int16
 	var addr crmcontracts.Address
 	var logoObjectKey *string
@@ -409,7 +449,7 @@ func scanOrganization(row pgx.Row, active []fieldcatalog.Column, extra ...any) (
 	dests := []any{
 		&id, &wsID, &o.DisplayName, &o.LegalName, &o.Industry, &o.SizeBand, &ownerID,
 		&addr.Line1, &addr.Line2, &addr.City, &addr.Region, &addr.PostalCode, &addr.Country,
-		&classification, &relevance, &parentID, &mergedInto, &logoObjectKey, &o.Source, &o.CapturedBy,
+		&classification, &lifecycle, &relevance, &parentID, &mergedInto, &logoObjectKey, &o.Source, &o.CapturedBy,
 		&version, &o.CreatedAt, &o.UpdatedAt, &o.ArchivedAt,
 	}
 	cf := storekit.ScanDests(active)
@@ -427,6 +467,8 @@ func scanOrganization(row pgx.Row, active []fieldcatalog.Column, extra ...any) (
 	o.MergedIntoId = uuidPtr(mergedInto)
 	cls := crmcontracts.OrganizationClassification(classification)
 	o.Classification = &cls
+	lc := crmcontracts.OrganizationLifecycle(lifecycle)
+	o.Lifecycle = &lc
 	o.LogoUrl = LogoURL(id, logoObjectKey)
 	if a := addressOrNil(addr); a != nil {
 		o.Address = a

--- a/backend/internal/modules/people/organization.go
+++ b/backend/internal/modules/people/organization.go
@@ -330,6 +330,9 @@ func buildOrganizationPatch(ctx context.Context, tx pgx.Tx, current crmcontracts
 		p.Set(ownerIDColumn, current.OwnerId, *in.OwnerID)
 	}
 	if in.Lifecycle != nil {
+		if err := checkLifecycle(*in.Lifecycle); err != nil {
+			return nil, err
+		}
 		p.Set("lifecycle", lifecycleValue(current.Lifecycle), *in.Lifecycle)
 	}
 	if in.ParentOrgID != nil {

--- a/backend/internal/modules/people/organization_fact_quality.go
+++ b/backend/internal/modules/people/organization_fact_quality.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+// Which stored facts contradict themselves.
+//
+// The site extractor picks a fact's FIELD from a closed per-page menu, and the
+// CATEGORY is derived from the field — so an out-of-menu field cannot be
+// generated at all. What it cannot prevent is the right field carrying the
+// wrong KIND of value: a phone number on a contact page lands as `location`
+// because a contact page's menu offers both, and a commercial-register number
+// lands as `employee_range` because both are digits. The row passes every gate
+// and is still wrong, and it is wrong in a way a human spots instantly.
+//
+// So this names the contradiction rather than trying to prevent it. It reads
+// the value's SHAPE and reports why it disagrees with its field. It is
+// deliberately narrow: each rule fires only on a shape that is unambiguous,
+// because a false flag on a real fact teaches the reader to ignore the flag.
+//
+// It never hides or rewrites a fact. A heuristic that suppressed data would be
+// worse than the miscategorization it is chasing — the evidence is still
+// there, still cited, and a human decides.
+
+import (
+	"regexp"
+	"strings"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+)
+
+var (
+	// Enough digits to be a phone number, and the punctuation phone numbers
+	// actually use. Deliberately requires 7+ digits: a street number and a
+	// postcode together do not reach it.
+	phoneShaped = regexp.MustCompile(`^[+()\d][\d\s()./+-]{5,}$`)
+	// A four-digit year in the range a company can plausibly have been founded.
+	yearShaped = regexp.MustCompile(`^(1[5-9]\d{2}|20\d{2})$`)
+	// A range, a bare count, or a count with a qualifier — "11-50", "200",
+	// "500+", "ca. 40". What it rejects is a value with no digits at all, or
+	// one long enough to be a sentence.
+	sizeShaped = regexp.MustCompile(`\d`)
+)
+
+// factSuspectReason reports why a fact's value contradicts its field, or an
+// empty string when it does not. Pure, so the rules are testable without a
+// database and readable as a list.
+func factSuspectReason(field crmcontracts.OrganizationFactField, value string) string {
+	v := strings.TrimSpace(value)
+	if v == "" {
+		return ""
+	}
+	switch field {
+	case crmcontracts.OrganizationFactFieldLocation:
+		// The one seen in the wild: a contact page's phone number filed as a
+		// location, because that page's menu offers both fields.
+		if phoneShaped.MatchString(v) {
+			return string(crmcontracts.OrganizationFactSuspectReasonPhoneShapedLocation)
+		}
+	case crmcontracts.OrganizationFactFieldPhone:
+		if !phoneShaped.MatchString(v) {
+			return string(crmcontracts.OrganizationFactSuspectReasonNotAPhone)
+		}
+	case crmcontracts.OrganizationFactFieldFoundedYear:
+		if !yearShaped.MatchString(v) {
+			return string(crmcontracts.OrganizationFactSuspectReasonNotAYear)
+		}
+	case crmcontracts.OrganizationFactFieldContactEmail:
+		// Shape only, not deliverability: an address with no @ and no dot is
+		// not an address by any reading, and anything stricter would start
+		// rejecting real ones.
+		if !strings.Contains(v, "@") || !strings.Contains(v, ".") {
+			return string(crmcontracts.OrganizationFactSuspectReasonNotAnEmail)
+		}
+	case crmcontracts.OrganizationFactFieldEmployeeRange:
+		// A register number IS digits, so digits alone cannot separate them.
+		// Length can: "11-50" and "HRB 123456 B" are different sizes of thing.
+		if !sizeShaped.MatchString(v) || len(v) > 24 {
+			return string(crmcontracts.OrganizationFactSuspectReasonNotASize)
+		}
+	}
+	return ""
+}

--- a/backend/internal/modules/people/organization_fact_quality.go
+++ b/backend/internal/modules/people/organization_fact_quality.go
@@ -30,10 +30,11 @@ import (
 )
 
 var (
-	// Enough digits to be a phone number, and the punctuation phone numbers
-	// actually use. Deliberately requires 7+ digits: a street number and a
-	// postcode together do not reach it.
-	phoneShaped = regexp.MustCompile(`^[+()\d][\d\s()./+-]{5,}$`)
+	// The punctuation phone numbers actually use, and nothing else. Shape
+	// alone is not enough — "(....)" matches it — so the digit COUNT is
+	// checked separately below.
+	phoneCharsOnly = regexp.MustCompile(`^[+()\d][\d\s()./+-]{5,}$`)
+	digit          = regexp.MustCompile(`\d`)
 	// A four-digit year in the range a company can plausibly have been founded.
 	yearShaped = regexp.MustCompile(`^(1[5-9]\d{2}|20\d{2})$`)
 	// A range, a bare count, or a count with a qualifier — "11-50", "200",
@@ -41,6 +42,14 @@ var (
 	// one long enough to be a sentence.
 	sizeShaped = regexp.MustCompile(`\d`)
 )
+
+// phoneShaped is a value made only of phone punctuation AND carrying enough
+// digits to be a number. Seven is the floor because a house number and a
+// postcode together must not reach it, or every German street address would
+// be flagged as a phone number.
+func phoneShaped(v string) bool {
+	return phoneCharsOnly.MatchString(v) && len(digit.FindAllString(v, -1)) >= 7
+}
 
 // factSuspectReason reports why a fact's value contradicts its field, or an
 // empty string when it does not. Pure, so the rules are testable without a
@@ -54,11 +63,11 @@ func factSuspectReason(field crmcontracts.OrganizationFactField, value string) s
 	case crmcontracts.OrganizationFactFieldLocation:
 		// The one seen in the wild: a contact page's phone number filed as a
 		// location, because that page's menu offers both fields.
-		if phoneShaped.MatchString(v) {
+		if phoneShaped(v) {
 			return string(crmcontracts.OrganizationFactSuspectReasonPhoneShapedLocation)
 		}
 	case crmcontracts.OrganizationFactFieldPhone:
-		if !phoneShaped.MatchString(v) {
+		if !phoneShaped(v) {
 			return string(crmcontracts.OrganizationFactSuspectReasonNotAPhone)
 		}
 	case crmcontracts.OrganizationFactFieldFoundedYear:

--- a/backend/internal/modules/people/organization_fact_quality_test.go
+++ b/backend/internal/modules/people/organization_fact_quality_test.go
@@ -48,6 +48,10 @@ func TestFactSuspectReasonNamesTheContradictionAndStaysQuietOtherwise(t *testing
 
 		// Fields with no rule stay silent rather than guessing.
 		{"a service, which has no shape to check", crmcontracts.OrganizationFactFieldService, "Managed hosting", ""},
+		// Phone punctuation with no digits behind it is not a phone number,
+		// and must not drag a location into the flag.
+		{"punctuation that is not a number", crmcontracts.OrganizationFactFieldLocation, "(.....)", ""},
+		{"a short internal extension is not enough", crmcontracts.OrganizationFactFieldLocation, "12-345", ""},
 		{"an empty value is nothing to judge", crmcontracts.OrganizationFactFieldPhone, "   ", ""},
 	}
 	for _, tc := range cases {

--- a/backend/internal/modules/people/organization_fact_quality_test.go
+++ b/backend/internal/modules/people/organization_fact_quality_test.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+import (
+	"testing"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+)
+
+// The rules exist because the extractor can pick the right FIELD and still
+// carry the wrong KIND of value, and both halves matter: a rule that misses
+// the real miscategorisation is useless, and one that fires on a good fact
+// teaches the reader to ignore the flag.
+func TestFactSuspectReasonNamesTheContradictionAndStaysQuietOtherwise(t *testing.T) {
+	cases := []struct {
+		name  string
+		field crmcontracts.OrganizationFactField
+		value string
+		want  string
+	}{
+		// The one seen in the wild: a contact page offers both fields, so its
+		// phone number can land as the company's location.
+		{"a phone number filed as a location", crmcontracts.OrganizationFactFieldLocation, "+49 30 1234567", "phone_shaped_location"},
+		{"a real street address", crmcontracts.OrganizationFactFieldLocation, "Ritterstraße 12, 10969 Berlin", ""},
+		{"a bare country", crmcontracts.OrganizationFactFieldLocation, "Germany", ""},
+		// A house number and a postcode together must not reach the digit
+		// threshold, or every German address would be flagged.
+		{"an address that is mostly digits", crmcontracts.OrganizationFactFieldLocation, "Hauptstr. 5, 80331", ""},
+
+		{"a phone that is prose", crmcontracts.OrganizationFactFieldPhone, "call us anytime", "not_a_phone"},
+		{"a phone in national format", crmcontracts.OrganizationFactFieldPhone, "030 / 1234-567", ""},
+
+		{"a founding year that is a register number", crmcontracts.OrganizationFactFieldFoundedYear, "HRB 123456", "not_a_year"},
+		{"a plausible founding year", crmcontracts.OrganizationFactFieldFoundedYear, "1998", ""},
+		{"a year outside any company's life", crmcontracts.OrganizationFactFieldFoundedYear, "3025", "not_a_year"},
+
+		{"an email with no at sign", crmcontracts.OrganizationFactFieldContactEmail, "info at scale.example", "not_an_email"},
+		{"an ordinary address", crmcontracts.OrganizationFactFieldContactEmail, "info@scale.example", ""},
+
+		// A register number IS digits, so only its length separates it from a
+		// headcount.
+		{"a register number filed as a headcount", crmcontracts.OrganizationFactFieldEmployeeRange, "HRB 123456 B, Amtsgericht Berlin", "not_a_size"},
+		{"a band", crmcontracts.OrganizationFactFieldEmployeeRange, "11-50", ""},
+		{"an open-ended count", crmcontracts.OrganizationFactFieldEmployeeRange, "500+", ""},
+		{"a headcount with no digits at all", crmcontracts.OrganizationFactFieldEmployeeRange, "several dozen", "not_a_size"},
+
+		// Fields with no rule stay silent rather than guessing.
+		{"a service, which has no shape to check", crmcontracts.OrganizationFactFieldService, "Managed hosting", ""},
+		{"an empty value is nothing to judge", crmcontracts.OrganizationFactFieldPhone, "   ", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := factSuspectReason(tc.field, tc.value); got != tc.want {
+				t.Errorf("factSuspectReason(%s, %q) = %q, want %q", tc.field, tc.value, got, tc.want)
+			}
+		})
+	}
+}

--- a/backend/internal/modules/people/organization_fact_read.go
+++ b/backend/internal/modules/people/organization_fact_read.go
@@ -78,6 +78,14 @@ func (s *Store) ListOrganizationFacts(ctx context.Context, id ids.OrganizationID
 			fact.Category = crmcontracts.OrganizationFactCategory(category)
 			fact.Field = crmcontracts.OrganizationFactField(field)
 			fact.Source = crmcontracts.OrganizationFactSource(source)
+			// Computed at read rather than stored: the rules are a judgment
+			// about shape and will be tuned, and a stored verdict would keep
+			// answering with the version of the rule that happened to run on
+			// the day the row landed.
+			if reason := factSuspectReason(fact.Field, fact.Value); reason != "" {
+				suspect := crmcontracts.OrganizationFactSuspectReason(reason)
+				fact.SuspectReason = &suspect
+			}
 			out = append(out, fact)
 		}
 		if err := rows.Err(); err != nil {

--- a/backend/internal/modules/people/organization_list.go
+++ b/backend/internal/modules/people/organization_list.go
@@ -30,12 +30,16 @@ const orgNameColumn = "display_name"
 // ListOrganizationsInput carries the organization list's contract
 // parameters.
 type ListOrganizationsInput struct {
-	Cursor          *string
-	Limit           *int
-	Query           *string
-	OwnerID         *ids.UserID
-	Classification  *string
-	IncludeArchived bool
+	Cursor  *string
+	Limit   *int
+	Query   *string
+	OwnerID *ids.UserID
+	// Classification is RETIRED with the column (ADR-0079/A124) and reaches no
+	// wire parameter; Lifecycle and RelationshipType replace it.
+	Classification   *string
+	Lifecycle        *string
+	RelationshipType *string
+	IncludeArchived  bool
 	// CapturedByKind filters on the captured_by prefix (ADR-0075/A121 §3a).
 	CapturedByKind *string
 	// AiWritten filters on whether an AI wrote into the record (§3a).
@@ -85,10 +89,28 @@ func (s *Store) ListOrganizations(ctx context.Context, in ListOrganizationsInput
 			if in.Classification != nil {
 				where = append(where, storekit.SQLf("classification = $%d", arg(*in.Classification)))
 			}
+			if in.Lifecycle != nil {
+				where = append(where, storekit.SQLf("lifecycle = $%d", arg(*in.Lifecycle)))
+			}
+			if in.RelationshipType != nil {
+				// EXISTS, not a join: an account carries several types and a
+				// join would return it once per matching row, which the keyset
+				// cursor would then page over as if they were distinct records.
+				where = append(where, storekit.SQLf(`EXISTS (
+					SELECT 1 FROM organization_relationship_type rt
+					WHERE rt.organization_id = organization.id
+					  AND rt.relationship_type = $%d AND rt.archived_at IS NULL)`,
+					arg(*in.RelationshipType)))
+			}
 			return where, nil
 		},
-		scan:   scanOrganizationPage,
-		attach: attachOrgDomains,
+		scan: scanOrganizationPage,
+		attach: func(ctx context.Context, tx pgx.Tx, orgs []crmcontracts.Organization) error {
+			if err := attachOrgDomains(ctx, tx, orgs); err != nil {
+				return err
+			}
+			return attachOrgRelationshipTypes(ctx, tx, orgs)
+		},
 		cursorKey: func(last crmcontracts.Organization) (time.Time, ids.UUID) {
 			return last.CreatedAt, ids.UUID(last.Id)
 		},

--- a/backend/internal/modules/people/organization_relationship_types.go
+++ b/backend/internal/modules/people/organization_relationship_types.go
@@ -162,15 +162,21 @@ func reconcileOrgRelationshipTypes(
 	for _, t := range desired {
 		desiredSet[t] = true
 	}
-	if !desiredSet[relationshipTypePartner] {
-		isPartner, err := hasPartnerRow(ctx, tx, orgID)
-		if err != nil {
-			return nil, err
-		}
-		if isPartner {
-			return nil, httperr.Validation("relationship_types", "partner_row_exists",
-				"this company has a partner programme, so it stays a partner — remove the programme first")
-		}
+	// The invariant binds BOTH ways, so it is checked both ways. Guarding only
+	// the removal left the other half open: a patch could name this company a
+	// partner with no programme behind it, and every partner API — which reads
+	// the extension table — would go on saying it is not one.
+	isPartner, err := hasPartnerRow(ctx, tx, orgID)
+	if err != nil {
+		return nil, err
+	}
+	switch {
+	case isPartner && !desiredSet[relationshipTypePartner]:
+		return nil, httperr.Validation("relationship_types", "partner_row_exists",
+			"this company has a partner programme, so it stays a partner — remove the programme first")
+	case !isPartner && desiredSet[relationshipTypePartner]:
+		return nil, httperr.Validation("relationship_types", "partner_row_missing",
+			"a partner is a company with a partner programme — set one up first")
 	}
 
 	liveSet := make(map[string]bool, len(live))
@@ -255,4 +261,25 @@ func lifecycleValue(l *crmcontracts.OrganizationLifecycle) string {
 		return string(crmcontracts.OrganizationLifecycleUnknown)
 	}
 	return string(*l)
+}
+
+// validLifecycles is the closed vocabulary, checked before the database sees
+// it so a bad value is a 422 naming the field rather than a CHECK violation.
+var validLifecycles = map[string]bool{
+	string(crmcontracts.OrganizationLifecycleUnknown):        true,
+	string(crmcontracts.OrganizationLifecycleTarget):         true,
+	string(crmcontracts.OrganizationLifecycleProspect):       true,
+	string(crmcontracts.OrganizationLifecycleOpportunity):    true,
+	string(crmcontracts.OrganizationLifecycleCustomer):       true,
+	string(crmcontracts.OrganizationLifecycleFormerCustomer): true,
+	string(crmcontracts.OrganizationLifecycleDisqualified):   true,
+}
+
+// checkLifecycle refuses a value outside the vocabulary.
+func checkLifecycle(value string) error {
+	if validLifecycles[value] {
+		return nil
+	}
+	return httperr.Validation("lifecycle", "invalid_enum",
+		fmt.Sprintf("%q is not a lifecycle", value))
 }

--- a/backend/internal/modules/people/organization_relationship_types.go
+++ b/backend/internal/modules/people/organization_relationship_types.go
@@ -1,0 +1,258 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+// What a company IS to us (PO-DDL-4b, ADR-0079/A124) — the multi-valued half
+// of the split that retired organization.classification.
+//
+// It is multi-valued because a company is legitimately several things at once:
+// the partner program (A38/ADR-0030) is built on companies that are
+// simultaneously partners and customers, and an agency is often a reseller and
+// a client. The single enum could hold one of those and silently erased the
+// rest.
+//
+// The rows are an owned child of the organization, written only through the
+// organization's own gated paths — the patch below and the partner upsert —
+// which is the visibility decision the schema fitness gate records.
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/jackc/pgx/v5"
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/platform/httperr"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// relationshipTypePartner is the one type bound to another row's existence.
+const relationshipTypePartner = string(crmcontracts.OrganizationRelationshipTypesPartner)
+
+// validRelationshipTypes is the closed vocabulary, checked before the database
+// sees it so a bad value is a 422 naming the field rather than a CHECK
+// violation surfacing as a 500.
+var validRelationshipTypes = map[string]bool{
+	string(crmcontracts.OrganizationRelationshipTypesCustomer):         true,
+	string(crmcontracts.OrganizationRelationshipTypesPartner):          true,
+	string(crmcontracts.OrganizationRelationshipTypesSupplier):         true,
+	string(crmcontracts.OrganizationRelationshipTypesInvestor):         true,
+	string(crmcontracts.OrganizationRelationshipTypesPortfolioCompany): true,
+	string(crmcontracts.OrganizationRelationshipTypesCompetitor):       true,
+	string(crmcontracts.OrganizationRelationshipTypesOther):            true,
+}
+
+// dedupeRelationshipTypes collapses repeats and rejects anything outside the
+// vocabulary, so the reconcile and the audit-after both see one row per type.
+// The order is normalized too: a caller sending the same set in a different
+// order must produce the same audit image, or every re-save reads as a change.
+func dedupeRelationshipTypes(desired []string) ([]string, error) {
+	seen := make(map[string]bool, len(desired))
+	out := make([]string, 0, len(desired))
+	for _, t := range desired {
+		if !validRelationshipTypes[t] {
+			return nil, httperr.Validation("relationship_types", "invalid_enum",
+				fmt.Sprintf("%q is not a relationship type", t))
+		}
+		if seen[t] {
+			continue
+		}
+		seen[t] = true
+		out = append(out, t)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// attachOrgRelationshipTypes fills the wire field for a page of organizations
+// in one query, the same batch shape attachOrgDomains uses.
+//
+// An organization with no types gets an EMPTY slice rather than a nil one: the
+// reader asked what this company is to us and the answer is "nothing recorded",
+// which is a fact, not a missing field.
+func attachOrgRelationshipTypes(ctx context.Context, tx pgx.Tx, orgs []crmcontracts.Organization) error {
+	if len(orgs) == 0 {
+		return nil
+	}
+	idx := make(map[openapi_types.UUID]*crmcontracts.Organization, len(orgs))
+	orgIDs := make([]ids.UUID, len(orgs))
+	for i := range orgs {
+		idx[orgs[i].Id] = &orgs[i]
+		orgIDs[i] = ids.UUID(orgs[i].Id)
+		empty := []crmcontracts.OrganizationRelationshipTypes{}
+		orgs[i].RelationshipTypes = &empty
+	}
+
+	rows, err := tx.Query(ctx,
+		`SELECT organization_id, relationship_type
+		 FROM organization_relationship_type
+		 WHERE organization_id = ANY($1) AND archived_at IS NULL
+		 ORDER BY relationship_type`, orgIDs)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var orgID ids.UUID
+		var relType string
+		if err := rows.Scan(&orgID, &relType); err != nil {
+			return err
+		}
+		o, ok := idx[openapi_types.UUID(orgID)]
+		if !ok {
+			continue
+		}
+		*o.RelationshipTypes = append(*o.RelationshipTypes, crmcontracts.OrganizationRelationshipTypes(relType))
+	}
+	return rows.Err()
+}
+
+// readLiveRelationshipTypes is the current set, for the reconcile's before
+// image and for the partner-invariant guard.
+func readLiveRelationshipTypes(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID) ([]string, error) {
+	rows, err := tx.Query(ctx,
+		`SELECT relationship_type FROM organization_relationship_type
+		 WHERE organization_id = $1 AND archived_at IS NULL
+		 ORDER BY relationship_type`, orgID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var live []string
+	for rows.Next() {
+		var t string
+		if err := rows.Scan(&t); err != nil {
+			return nil, err
+		}
+		live = append(live, t)
+	}
+	return live, rows.Err()
+}
+
+// hasPartnerRow reports whether the organization carries the partner program
+// extension — the other half of the invariant this file guards.
+func hasPartnerRow(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID) (bool, error) {
+	var exists bool
+	err := tx.QueryRow(ctx,
+		`SELECT EXISTS (SELECT 1 FROM partner WHERE organization_id = $1)`, orgID).Scan(&exists)
+	return exists, err
+}
+
+// reconcileOrgRelationshipTypes applies the replace-set: insert what is new,
+// archive what is gone, leave the rest alone so an untouched type keeps its
+// original provenance and created_at. Returns the before image for the audit.
+//
+// It refuses to drop `partner` while the partner extension row lives. ADR-0032
+// bound partnerhood to a classification value and nothing enforced it; ADR-0079
+// moves the invariant here and this is where it is kept. Refusing is the honest
+// answer: the caller is asking for a state the partner APIs would contradict,
+// and silently keeping the row would make the request a lie in the other
+// direction.
+func reconcileOrgRelationshipTypes(
+	ctx context.Context, tx pgx.Tx, wsID ids.WorkspaceID, orgID ids.OrganizationID, source, by string, desired []string,
+) ([]string, error) {
+	live, err := readLiveRelationshipTypes(ctx, tx, orgID)
+	if err != nil {
+		return nil, err
+	}
+	desiredSet := make(map[string]bool, len(desired))
+	for _, t := range desired {
+		desiredSet[t] = true
+	}
+	if !desiredSet[relationshipTypePartner] {
+		isPartner, err := hasPartnerRow(ctx, tx, orgID)
+		if err != nil {
+			return nil, err
+		}
+		if isPartner {
+			return nil, httperr.Validation("relationship_types", "partner_row_exists",
+				"this company has a partner programme, so it stays a partner — remove the programme first")
+		}
+	}
+
+	liveSet := make(map[string]bool, len(live))
+	for _, t := range live {
+		liveSet[t] = true
+	}
+	for _, t := range desired {
+		if liveSet[t] {
+			continue
+		}
+		if _, err := tx.Exec(ctx,
+			`INSERT INTO organization_relationship_type
+			   (workspace_id, organization_id, relationship_type, source, captured_by)
+			 VALUES ($1, $2, $3, $4, $5)`,
+			wsID, orgID, t, source, by); err != nil {
+			return nil, fmt.Errorf("insert relationship type %q: %w", t, err)
+		}
+	}
+	for _, t := range live {
+		if desiredSet[t] {
+			continue
+		}
+		if _, err := tx.Exec(ctx,
+			`UPDATE organization_relationship_type SET archived_at = now()
+			 WHERE organization_id = $1 AND relationship_type = $2 AND archived_at IS NULL`,
+			orgID, t); err != nil {
+			return nil, fmt.Errorf("archive relationship type %q: %w", t, err)
+		}
+	}
+	return live, nil
+}
+
+// ensureOrgRelationshipType asserts one type without disturbing the others.
+// The partner upsert calls it to keep its half of the invariant, inside the
+// same transaction that writes the partner row — the classification flip it
+// replaces did exactly this, for exactly this reason.
+func ensureOrgRelationshipType(
+	ctx context.Context, tx pgx.Tx, wsID ids.WorkspaceID, orgID ids.OrganizationID, relType, source, by string,
+) error {
+	_, err := tx.Exec(ctx,
+		`INSERT INTO organization_relationship_type
+		   (workspace_id, organization_id, relationship_type, source, captured_by)
+		 SELECT $1, $2, $3, $4, $5
+		 WHERE NOT EXISTS (
+		   SELECT 1 FROM organization_relationship_type
+		   WHERE organization_id = $2 AND relationship_type = $3 AND archived_at IS NULL)`,
+		wsID, orgID, relType, source, by)
+	if err != nil {
+		return fmt.Errorf("ensure relationship type %q: %w", relType, err)
+	}
+	return nil
+}
+
+// moveOrgRelationshipTypes re-homes the loser's types onto the survivor in a
+// merge, so the survivor ends up with the UNION of both. Types the survivor
+// already carries are archived on the loser rather than moved, because the
+// unique index admits one live row per (organization, type) and the survivor's
+// own row is the one with the older provenance worth keeping.
+func moveOrgRelationshipTypes(ctx context.Context, tx pgx.Tx, from, to ids.OrganizationID) error {
+	if _, err := tx.Exec(ctx,
+		`UPDATE organization_relationship_type l SET archived_at = now()
+		 WHERE l.organization_id = $1 AND l.archived_at IS NULL
+		   AND EXISTS (SELECT 1 FROM organization_relationship_type s
+		               WHERE s.organization_id = $2 AND s.relationship_type = l.relationship_type
+		                 AND s.archived_at IS NULL)`, from, to); err != nil {
+		return fmt.Errorf("archive duplicate relationship types on merge: %w", err)
+	}
+	if _, err := tx.Exec(ctx,
+		`UPDATE organization_relationship_type SET organization_id = $2
+		 WHERE organization_id = $1 AND archived_at IS NULL`, from, to); err != nil {
+		return fmt.Errorf("re-home relationship types on merge: %w", err)
+	}
+	return nil
+}
+
+// lifecycleValue reads the wire's optional lifecycle as the string the patch
+// compares against. The column is NOT NULL, so a read always carries one; the
+// pointer is the contract's shape, not a real absence, and an empty before
+// image would make every first edit look like a change from nothing.
+func lifecycleValue(l *crmcontracts.OrganizationLifecycle) string {
+	if l == nil {
+		return string(crmcontracts.OrganizationLifecycleUnknown)
+	}
+	return string(*l)
+}

--- a/backend/internal/modules/people/organization_relationship_types_integration_test.go
+++ b/backend/internal/modules/people/organization_relationship_types_integration_test.go
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package people
+
+// Lifecycle and relationship types (ADR-0079/A124): the replace-set rides the
+// organization's own write shape exactly as the domain set does, and the
+// partner invariant — an org IS a partner iff it has the extension row AND a
+// live 'partner' type — is enforced in both directions rather than described.
+//
+// ADR-0032 bound partnerhood to a classification value and nothing enforced
+// it, so a plain patch could take the label off a company the partner APIs
+// still returned. That is the hole these tests close.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// asAdmin widens the shared dedupe principal to the two verbs this file needs
+// beyond the base rep: promoting a partner and archiving an account. The
+// harness's default grant set is deliberately narrow, so a test that needs
+// more asks for it rather than the harness handing every test everything.
+func asAdmin(e *dedupeEnv) context.Context {
+	ctx := principal.WithWorkspaceID(context.Background(), e.ws)
+	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
+	return principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:" + e.rep.String(), UserID: e.rep,
+		Permissions: principal.Permissions{
+			RoleKeys: []string{"admin"},
+			Objects: map[string]principal.ObjectGrant{
+				"person":       {Create: true, Read: true, Update: true, Delete: true},
+				"organization": {Create: true, Read: true, Update: true, Delete: true},
+				"relationship": {Create: true, Read: true},
+				"partner":      {Create: true, Read: true, Update: true},
+			},
+			RowScope: principal.RowScopeAll,
+		},
+	})
+}
+
+func liveTypesOf(ctx context.Context, t *testing.T, e *dedupeEnv, orgID ids.OrganizationID) map[string]bool {
+	t.Helper()
+	out := map[string]bool{}
+	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		types, err := readLiveRelationshipTypes(ctx, tx, orgID)
+		if err != nil {
+			return err
+		}
+		for _, ty := range types {
+			out[ty] = true
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+func TestOrganizationStartsAtUnknownRatherThanClaimingToBeAProspect(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+	org, err := e.store.CreateOrganization(ctx, CreateOrganizationInput{
+		DisplayName: "Unassessed GmbH", Source: "manual",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The retired classification defaulted to 'prospect' and had no writer, so
+	// every untouched account rendered that default as though someone had
+	// judged it. 'unknown' is the honest answer to a question nobody asked.
+	if org.Lifecycle == nil || *org.Lifecycle != crmcontracts.OrganizationLifecycleUnknown {
+		t.Errorf("lifecycle at birth = %v, want unknown", org.Lifecycle)
+	}
+	if org.RelationshipTypes == nil || len(*org.RelationshipTypes) != 0 {
+		t.Errorf("relationship types at birth = %v, want an empty set", org.RelationshipTypes)
+	}
+}
+
+func TestUpdateOrganizationRelationshipTypesReplaceSet(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+	org, err := e.store.CreateOrganization(ctx, CreateOrganizationInput{
+		DisplayName: "Scale Commerce GmbH", Source: "manual",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	orgID := ids.From[ids.OrganizationKind](ids.UUID(org.Id))
+
+	lifecycle := string(crmcontracts.OrganizationLifecycleFormerCustomer)
+	types := []string{"customer", "supplier"}
+	updated, err := e.store.UpdateOrganization(ctx, orgID, UpdateOrganizationInput{
+		Lifecycle:         &lifecycle,
+		RelationshipTypes: &types,
+	})
+	if err != nil {
+		t.Fatalf("first replace-set: %v", err)
+	}
+	// The account the whole arc is named for: its contract ended AND it is
+	// still several things to us. The retired enum could hold one of these.
+	if updated.Lifecycle == nil || *updated.Lifecycle != crmcontracts.OrganizationLifecycleFormerCustomer {
+		t.Errorf("lifecycle = %v, want former_customer", updated.Lifecycle)
+	}
+	if live := liveTypesOf(ctx, t, e, orgID); !live["customer"] || !live["supplier"] || len(live) != 2 {
+		t.Fatalf("types after first set = %+v, want {customer, supplier}", live)
+	}
+
+	// Replace-set: supplier goes, competitor arrives, customer is untouched.
+	next := []string{"customer", "competitor"}
+	if _, err := e.store.UpdateOrganization(ctx, orgID, UpdateOrganizationInput{RelationshipTypes: &next}); err != nil {
+		t.Fatalf("second replace-set: %v", err)
+	}
+	live := liveTypesOf(ctx, t, e, orgID)
+	if !live["customer"] || !live["competitor"] || live["supplier"] || len(live) != 2 {
+		t.Fatalf("types after second set = %+v, want {customer, competitor}", live)
+	}
+
+	// An empty set clears them; nothing here is a partner, so nothing refuses.
+	empty := []string{}
+	if _, err := e.store.UpdateOrganization(ctx, orgID, UpdateOrganizationInput{RelationshipTypes: &empty}); err != nil {
+		t.Fatalf("clearing set: %v", err)
+	}
+	if live := liveTypesOf(ctx, t, e, orgID); len(live) != 0 {
+		t.Fatalf("types after clear = %+v, want none", live)
+	}
+}
+
+func TestRelationshipTypesRefuseAValueOutsideTheVocabulary(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+	org, err := e.store.CreateOrganization(ctx, CreateOrganizationInput{
+		DisplayName: "Vocabulary GmbH", Source: "manual",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	orgID := ids.From[ids.OrganizationKind](ids.UUID(org.Id))
+
+	bad := []string{"customer", "frenemy"}
+	// Refused in Go, so the caller gets a 422 naming the field rather than a
+	// CHECK violation surfacing as a 500.
+	if _, err := e.store.UpdateOrganization(ctx, orgID, UpdateOrganizationInput{RelationshipTypes: &bad}); err == nil {
+		t.Fatal("a value outside the vocabulary was accepted")
+	}
+	if live := liveTypesOf(ctx, t, e, orgID); len(live) != 0 {
+		t.Fatalf("a refused set still wrote %+v — the whole set must land or none of it", live)
+	}
+}
+
+func TestPartnerPromotionWritesTheTypeAndThePatchCannotTakeItAway(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := asAdmin(e)
+	org, err := e.store.CreateOrganization(ctx, CreateOrganizationInput{
+		DisplayName: "Channel Partner GmbH", Source: "manual",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	orgID := ids.From[ids.OrganizationKind](ids.UUID(org.Id))
+
+	if _, err := e.store.UpsertPartner(ctx, UpsertPartnerInput{
+		OrganizationID: orgID, PartnerRole: "hosting",
+	}); err != nil {
+		t.Fatalf("promote to partner: %v", err)
+	}
+	// Half the invariant: the extension row implies the type, written in the
+	// same transaction so the two can never disagree.
+	if live := liveTypesOf(ctx, t, e, orgID); !live["partner"] {
+		t.Fatalf("types after promotion = %+v, want partner among them", live)
+	}
+
+	// The other half: the patch cannot strip the type while the programme
+	// exists. Under ADR-0032 this was a comment, and a plain patch could take
+	// the label off a company listPartners still returned.
+	without := []string{"customer"}
+	if _, err := e.store.UpdateOrganization(ctx, orgID, UpdateOrganizationInput{RelationshipTypes: &without}); err == nil {
+		t.Fatal("dropping the partner type while the partner row lives was accepted")
+	}
+	if live := liveTypesOf(ctx, t, e, orgID); !live["partner"] {
+		t.Fatalf("types after the refused patch = %+v — the refusal must change nothing", live)
+	}
+}
+
+func TestArchivingAnAccountRetiresItsRelationshipTypes(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := asAdmin(e)
+	org, err := e.store.CreateOrganization(ctx, CreateOrganizationInput{
+		DisplayName: "Gone Away GmbH", Source: "manual",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	orgID := ids.From[ids.OrganizationKind](ids.UUID(org.Id))
+	types := []string{"customer"}
+	if _, err := e.store.UpdateOrganization(ctx, orgID, UpdateOrganizationInput{RelationshipTypes: &types}); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := e.store.ArchiveOrganization(ctx, orgID); err != nil {
+		t.Fatalf("archive: %v", err)
+	}
+	// An archived account holding a live type row would keep answering the
+	// filters, which read live rows only.
+	if live := liveTypesOf(ctx, t, e, orgID); len(live) != 0 {
+		t.Fatalf("types after archive = %+v, want none — they retire with their parent", live)
+	}
+}

--- a/backend/internal/modules/people/organization_relationship_types_integration_test.go
+++ b/backend/internal/modules/people/organization_relationship_types_integration_test.go
@@ -190,6 +190,29 @@ func TestPartnerPromotionWritesTheTypeAndThePatchCannotTakeItAway(t *testing.T) 
 	}
 }
 
+func TestNamingAnAccountAPartnerWithoutAProgrammeIsRefused(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+	org, err := e.store.CreateOrganization(ctx, CreateOrganizationInput{
+		DisplayName: "Aspiring Partner GmbH", Source: "manual",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	orgID := ids.From[ids.OrganizationKind](ids.UUID(org.Id))
+
+	// The invariant binds both ways. Guarding only the removal left this half
+	// open: the account would carry the label while every partner API — which
+	// reads the extension table — went on saying it is not one.
+	claim := []string{"partner"}
+	if _, err := e.store.UpdateOrganization(ctx, orgID, UpdateOrganizationInput{RelationshipTypes: &claim}); err == nil {
+		t.Fatal("an account with no partner programme was named a partner")
+	}
+	if live := liveTypesOf(ctx, t, e, orgID); len(live) != 0 {
+		t.Fatalf("the refused patch still wrote %+v", live)
+	}
+}
+
 func TestArchivingAnAccountRetiresItsRelationshipTypes(t *testing.T) {
 	e := setupDedupe(t)
 	ctx := asAdmin(e)

--- a/backend/internal/modules/people/organizationfact.go
+++ b/backend/internal/modules/people/organizationfact.go
@@ -227,6 +227,13 @@ func (s *Store) ApplyDeepReadTx(ctx context.Context, tx pgx.Tx, in DeepReadPropo
 	if err := auth.EnsureVisible(ctx, tx, "organization", in.OrganizationID.UUID); err != nil {
 		return err
 	}
+	// The columns as they stand before the apply — see applyColdStartTx: the
+	// write reports only that it changed something, so the before image has to
+	// be read, or field history has no diff to project.
+	before, err := readColdStartColumnImages(ctx, tx, in.OrganizationID)
+	if err != nil {
+		return err
+	}
 	appliedFields, err := applyEvidenceFields(ctx, tx, wsID, in.OrganizationID, companySourceSiteRead, by, fields)
 	if err != nil {
 		return err
@@ -235,7 +242,16 @@ func (s *Store) ApplyDeepReadTx(ctx context.Context, tx pgx.Tx, in DeepReadPropo
 	if err != nil {
 		return err
 	}
-	auditID, err := storekit.Audit(ctx, tx, "update", "organization", in.OrganizationID.UUID, nil, map[string]any{
+	after, err := readColdStartColumnImages(ctx, tx, in.OrganizationID)
+	if err != nil {
+		return err
+	}
+	before, after = changedColumnsOnly(before, after)
+	// The facts and the profile-field evidence are NOT column images — they
+	// live in their own sidecar tables — so they ride the evidence column with
+	// the rest of the operation's metadata. Only what changed on the
+	// organization row itself belongs in before/after.
+	auditID, err := storekit.AuditWithEvidence(ctx, tx, "update", "organization", in.OrganizationID.UUID, before, after, map[string]any{
 		auditKeySource: companySourceSiteRead, auditKeySourceURL: in.SourceURL,
 		auditKeyFields: appliedFields, auditKeyFacts: appliedFacts,
 	})

--- a/backend/internal/modules/people/partner.go
+++ b/backend/internal/modules/people/partner.go
@@ -182,10 +182,14 @@ func (s *Store) UpsertPartner(ctx context.Context, in UpsertPartnerInput) (partn
 		if out, err = upsertPartnerRow(ctx, tx, in, fit, capturedBy); err != nil {
 			return err
 		}
-		// Promotion is an org fact: classification flips with the row.
-		if _, err := tx.Exec(ctx,
-			`UPDATE organization SET classification = 'partner' WHERE id = $1 AND classification <> 'partner'`,
-			in.OrganizationID); err != nil {
+		// Promotion is an org fact, and it is the invariant's other half: an org
+		// IS a partner iff it has this row AND a live 'partner' relationship
+		// type (ADR-0079 amending ADR-0032 §Decision 2). Both are written in
+		// this one transaction, so the two can never disagree — the
+		// classification flip this replaces did the same job for the same
+		// reason, against a column that could hold only one answer.
+		if err := ensureOrgRelationshipType(ctx, tx, workspaceID(ctx), in.OrganizationID,
+			relationshipTypePartner, "system", capturedBy); err != nil {
 			return err
 		}
 		// Per-field keys, matching the upsert request's field names: the

--- a/backend/migrations/core/0169_organization_lifecycle_and_relationship_types.down.sql
+++ b/backend/migrations/core/0169_organization_lifecycle_and_relationship_types.down.sql
@@ -1,0 +1,12 @@
+-- Reverse of 0169. classification was never dropped and never stopped being
+-- written by the migration's own backfill, so the down path only has to remove
+-- what 0169 added: the type rows go with their table, and lifecycle goes with
+-- its column. Nothing needs to be reconstructed.
+
+DROP TABLE IF EXISTS organization_relationship_type;
+
+DROP INDEX IF EXISTS idx_org_lifecycle;
+
+ALTER TABLE organization DROP COLUMN IF EXISTS lifecycle;
+
+COMMENT ON COLUMN organization.classification IS NULL;

--- a/backend/migrations/core/0169_organization_lifecycle_and_relationship_types.up.sql
+++ b/backend/migrations/core/0169_organization_lifecycle_and_relationship_types.up.sql
@@ -75,30 +75,36 @@ GRANT SELECT, INSERT, UPDATE, DELETE ON organization_relationship_type TO margin
 -- the same unearned claim the old default made, and waste the split.
 UPDATE organization SET lifecycle = 'customer' WHERE classification = 'customer';
 
--- The type rows the old enum can be read as. agency/reseller are partner
--- motions; tech_vendor/platform are things we buy from. 'prospect' and 'other'
--- name no relationship and produce no row.
+-- The type rows the old enum can be read as. tech_vendor/platform are things
+-- we buy from. 'prospect' and 'other' name no relationship and produce no row.
+--
+-- 'partner' is NOT assigned here, and that is the whole subtlety: an org IS a
+-- partner iff it carries this type AND a `partner` extension row, and the
+-- store now refuses a patch that breaks either direction. Handing the type to
+-- every old `agency` and `reseller` — which have no extension row, because
+-- nothing ever created one for them — would land those rows in a state the
+-- running system rejects, on the first edit anyone made. They map to no type
+-- and a human retags them, which is the honest outcome for a column that
+-- never had a writer.
 INSERT INTO organization_relationship_type (workspace_id, organization_id, relationship_type, source, captured_by)
 SELECT o.workspace_id, o.id,
        CASE o.classification
          WHEN 'customer'    THEN 'customer'
-         WHEN 'partner'     THEN 'partner'
          WHEN 'competitor'  THEN 'competitor'
-         WHEN 'agency'      THEN 'partner'
-         WHEN 'reseller'    THEN 'partner'
          WHEN 'tech_vendor' THEN 'supplier'
          WHEN 'platform'    THEN 'supplier'
        END,
        'migration', 'migration'
 FROM organization o
-WHERE o.classification IN ('customer','partner','competitor','agency','reseller','tech_vendor','platform')
+WHERE o.classification IN ('customer','competitor','tech_vendor','platform')
   AND o.archived_at IS NULL
 ON CONFLICT DO NOTHING;
 
--- The moved invariant, asserted from the first migrated read: an org is a
--- partner iff it has a partner extension row AND a live partner type row
--- (ADR-0079 amending ADR-0032 §Decision 2). An org carrying the extension but
--- some other classification would otherwise start life violating it.
+-- The partner type comes from the EXTENSION ROW and only from it, which is
+-- what makes the moved invariant true of every migrated row (ADR-0079 amending
+-- ADR-0032 §Decision 2). A classification of 'partner' without an extension
+-- row was already a broken state under ADR-0032; carrying it forward would
+-- import that breakage into the vocabulary that now enforces it.
 INSERT INTO organization_relationship_type (workspace_id, organization_id, relationship_type, source, captured_by)
 SELECT p.workspace_id, p.organization_id, 'partner', 'migration', 'migration'
 FROM partner p

--- a/backend/migrations/core/0169_organization_lifecycle_and_relationship_types.up.sql
+++ b/backend/migrations/core/0169_organization_lifecycle_and_relationship_types.up.sql
@@ -1,0 +1,114 @@
+-- 0169: where an account STANDS and what it IS to us become two fields
+-- (PO-DDL-4 / PO-DDL-4b, ADR-0079 / A124).
+--
+-- organization.classification held one value and answered two questions. Two
+-- of its nine values are stages of a sales motion, six are kinds of company,
+-- one is a shrug — so setting 'partner' erased whether they buy from us, and a
+-- company that is an agency AND a client AND a co-sell partner got one slot.
+-- There was no churn state at all: an account that ended its contract could
+-- only be relabelled by overwriting 'customer', destroying the fact it ever
+-- was one.
+--
+-- The column also never had a writer. ADR-0032 said enrichment would set it;
+-- that writer was never built, so the only writers are partner promotion and
+-- merge survivorship and every other row sits on DEFAULT 'prospect' forever.
+-- The label a reader saw was the default rendered as a finding. That is why
+-- the backfill below can be this simple — there is almost no stored meaning to
+-- carry across.
+
+-- WHERE THE ACCOUNT STANDS. Single-valued: an account is at one point in a
+-- sales motion at a time. It is a COLUMN and not a child row because a staged
+-- approval re-validates its target's version at execute time (ADR-0036 §2) and
+-- a version-less target is undecidable and fails closed — the 🟡 "their
+-- contract ended, so this is a former customer" proposal needs a versioned row
+-- to bind to.
+ALTER TABLE organization
+  ADD COLUMN lifecycle text NOT NULL DEFAULT 'unknown'
+    CHECK (lifecycle IN ('unknown','target','prospect','opportunity','customer','former_customer','disqualified'));
+
+CREATE INDEX idx_org_lifecycle ON organization (workspace_id, lifecycle) WHERE archived_at IS NULL;
+
+-- WHAT THE COMPANY IS TO US. Multi-valued, because a company is legitimately
+-- several things at once — the partner program is built on companies that are
+-- simultaneously partners and customers, and an agency is often a reseller and
+-- a client. A table rather than an array so each row carries its own
+-- provenance: "they are a competitor" can be a human judgment or an inference,
+-- and the two must stay distinguishable.
+CREATE TABLE organization_relationship_type (
+  id                uuid PRIMARY KEY DEFAULT uuidv7(),
+  workspace_id      uuid NOT NULL REFERENCES workspace(id) ON DELETE RESTRICT,
+  organization_id   uuid NOT NULL,
+  relationship_type text NOT NULL
+                      CHECK (relationship_type IN ('customer','partner','supplier','investor','portfolio_company','competitor','other')),
+  source            text NOT NULL,
+  captured_by       text NOT NULL,
+  version           bigint NOT NULL DEFAULT 1,
+  created_at        timestamptz NOT NULL DEFAULT now(),
+  updated_at        timestamptz NOT NULL DEFAULT now(),
+  archived_at       timestamptz NULL,
+  -- Composite, so the database itself rejects a type row pointed at an
+  -- organization in another workspace — RLS keeps a query inside one tenant,
+  -- but only the FK keeps a WRITE from naming a row outside it.
+  FOREIGN KEY (workspace_id, organization_id) REFERENCES organization (workspace_id, id) ON DELETE CASCADE
+);
+
+-- One live row per type per account; archiving frees the slot so a type can be
+-- asserted again later without colliding with the record of the last time.
+CREATE UNIQUE INDEX uq_org_rel_type ON organization_relationship_type (organization_id, relationship_type)
+  WHERE archived_at IS NULL;
+CREATE INDEX idx_org_rel_type_org ON organization_relationship_type (workspace_id, organization_id)
+  WHERE archived_at IS NULL;
+
+CREATE TRIGGER trg_organization_relationship_type_updated BEFORE UPDATE ON organization_relationship_type
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at_bump_version();
+
+ALTER TABLE organization_relationship_type ENABLE ROW LEVEL SECURITY;
+ALTER TABLE organization_relationship_type FORCE ROW LEVEL SECURITY;
+CREATE POLICY organization_relationship_type_tenant_isolation ON organization_relationship_type
+  USING (workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid)
+  WITH CHECK (workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid);
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON organization_relationship_type TO margince_app;
+
+-- BACKFILL. lifecycle takes 'unknown' for everything that was not explicitly a
+-- customer: carrying 'prospect' forward would re-assert in the new vocabulary
+-- the same unearned claim the old default made, and waste the split.
+UPDATE organization SET lifecycle = 'customer' WHERE classification = 'customer';
+
+-- The type rows the old enum can be read as. agency/reseller are partner
+-- motions; tech_vendor/platform are things we buy from. 'prospect' and 'other'
+-- name no relationship and produce no row.
+INSERT INTO organization_relationship_type (workspace_id, organization_id, relationship_type, source, captured_by)
+SELECT o.workspace_id, o.id,
+       CASE o.classification
+         WHEN 'customer'    THEN 'customer'
+         WHEN 'partner'     THEN 'partner'
+         WHEN 'competitor'  THEN 'competitor'
+         WHEN 'agency'      THEN 'partner'
+         WHEN 'reseller'    THEN 'partner'
+         WHEN 'tech_vendor' THEN 'supplier'
+         WHEN 'platform'    THEN 'supplier'
+       END,
+       'migration', 'migration'
+FROM organization o
+WHERE o.classification IN ('customer','partner','competitor','agency','reseller','tech_vendor','platform')
+  AND o.archived_at IS NULL
+ON CONFLICT DO NOTHING;
+
+-- The moved invariant, asserted from the first migrated read: an org is a
+-- partner iff it has a partner extension row AND a live partner type row
+-- (ADR-0079 amending ADR-0032 §Decision 2). An org carrying the extension but
+-- some other classification would otherwise start life violating it.
+INSERT INTO organization_relationship_type (workspace_id, organization_id, relationship_type, source, captured_by)
+SELECT p.workspace_id, p.organization_id, 'partner', 'migration', 'migration'
+FROM partner p
+JOIN organization o ON o.id = p.organization_id
+WHERE o.archived_at IS NULL
+ON CONFLICT DO NOTHING;
+
+-- classification is RETIRED, not dropped: kept one release, written by
+-- nothing, `deprecated: true` on the wire, so the migration stays reversible
+-- and the two vocabularies can be compared in production. A follow-up
+-- migration drops it once no reader remains.
+COMMENT ON COLUMN organization.classification IS
+  'RETIRED (ADR-0079/A124) — superseded by organization.lifecycle + organization_relationship_type. Written by nothing; dropped in a follow-up migration.';

--- a/backend/migrations/schema_fitness_integration_test.go
+++ b/backend/migrations/schema_fitness_integration_test.go
@@ -276,9 +276,10 @@ var rowScopedFKDecisions = map[string]string{
 	// activity write, not inside comms. Both send transports stage through
 	// that one path and pass the activity id they just created, never an
 	// externally-supplied reference.
-	"comms_outbound.activity_id":          "child row: written only inside the caller's own transaction, alongside the activity write it reports on",
-	"consent_event.person_id":             "child row: written through the person's own gated paths",
-	"organization_domain.organization_id": "child row: written through the organization's own gated paths",
+	"comms_outbound.activity_id":                     "child row: written only inside the caller's own transaction, alongside the activity write it reports on",
+	"consent_event.person_id":                        "child row: written through the person's own gated paths",
+	"organization_domain.organization_id":            "child row: written through the organization's own gated paths",
+	"organization_relationship_type.organization_id": "child row: written through the organization's own gated paths (the patch that sets relationship types, and the partner upsert)",
 	// The disposition NAMES the organization its own verdict created, in the
 	// same transaction that created it. There is no client-supplied reference
 	// to gate: nothing outside the triage resolve ever writes this column, and

--- a/backend/tableownership_test.go
+++ b/backend/tableownership_test.go
@@ -65,14 +65,15 @@ var tableOwners = map[string]string{
 	// The channel identity is a resolution key on the person, not connection
 	// state: it answers "which Person is this Telegram user", so it lives with
 	// the one dedupe implementation that resolves them.
-	"person_channel_identity":    "internal/modules/people",
-	"organization":               "internal/modules/people",
-	"organization_domain":        "internal/modules/people",
-	"relationship":               "internal/modules/people",
-	"partner":                    "internal/modules/people",
-	"lead":                       "internal/modules/people",
-	"organization_profile_field": "internal/modules/people",
-	"person_profile_field":       "internal/modules/people",
+	"person_channel_identity":        "internal/modules/people",
+	"organization":                   "internal/modules/people",
+	"organization_domain":            "internal/modules/people",
+	"organization_relationship_type": "internal/modules/people",
+	"relationship":                   "internal/modules/people",
+	"partner":                        "internal/modules/people",
+	"lead":                           "internal/modules/people",
+	"organization_profile_field":     "internal/modules/people",
+	"person_profile_field":           "internal/modules/people",
 	// The signature pass's per-person read cursor (PO-F-2a): which mail was
 	// already shown to the model, so the same empty signature is not re-read
 	// every night.

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -9408,6 +9408,11 @@ export interface components {
             /** Format: uri */
             source_url?: string | null;
             confidence?: number | null;
+            /**
+             * @description Why this fact's VALUE contradicts its FIELD, or null when it does not. The extractor picks the field from a closed per-page menu and the category follows the field, so a phone number on a contact page can land as `location` and a register number as `employee_range` — the row is well-formed and still wrong. Computed at read from the value's shape; it never gates the fact, because a heuristic that hid data would be worse than one that flags it.
+             * @enum {string|null}
+             */
+            readonly suspect_reason?: null | "phone_shaped_location" | "not_a_phone" | "not_a_year" | "not_an_email" | "not_a_size";
             /** Format: date-time */
             updated_at: string;
         };

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -6949,8 +6949,18 @@ export interface components {
              */
             as_of: string;
             organization: components["schemas"]["Organization"];
+            /**
+             * Format: date-time
+             * @description When they last wrote to us, over the same three-link walk the timeline uses (the activity's own link, its deal's organization, the employer of the contact it is filed against). Null means nothing inbound was ever captured — which is a fact about the account, not a missing field. Absent entirely when the caller has no activity grant, named in `sections_omitted` as `last_touch`.
+             */
+            last_inbound_at?: string | null;
+            /**
+             * Format: date-time
+             * @description When we last wrote to them, same walk. Shown BESIDE last_inbound_at rather than folded into one "last touch": which direction went last is the whole question — an account we mailed a fortnight ago with no reply is not the same as one that just wrote to us.
+             */
+            last_outbound_at?: string | null;
             /** @description The sections withheld for lack of a grant — so a client can say "you can't see this" instead of "there is none". */
-            sections_omitted: ("people" | "deals" | "strength" | "activities" | "tags" | "list_memberships" | "pending_approvals" | "next_steps" | "since_last_visit" | "suggestions")[];
+            sections_omitted: ("people" | "deals" | "strength" | "activities" | "tags" | "list_memberships" | "pending_approvals" | "next_steps" | "since_last_visit" | "suggestions" | "last_touch")[];
             people?: {
                 data: components["schemas"]["Organization360Contact"][];
                 page: components["schemas"]["PageInfo"];

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -6605,7 +6605,15 @@ export interface components {
             readonly computed_fields?: components["schemas"]["ComputedField"][];
             domains?: components["schemas"]["OrganizationDomain"][];
             /**
-             * @description An org IS a partner iff classification='partner' AND it has a `partner` row (A41/ADR-0032). Values match the data-model §4.1 CHECK.
+             * @description WHERE THE ACCOUNT STANDS with us (PO-DDL-4, ADR-0079/A124). Single-valued: an account is at one point in a sales motion at a time. `unknown` is the default and means it — the retired `classification` defaulted to `prospect` and, having no writer, rendered that default on every unassessed account as though someone had judged it.
+             * @enum {string}
+             */
+            lifecycle?: "unknown" | "target" | "prospect" | "opportunity" | "customer" | "former_customer" | "disqualified";
+            /** @description WHAT THE COMPANY IS to us (PO-DDL-4b, ADR-0079/A124). Multi-valued, because a company is legitimately several things at once — the partner program is built on companies that are simultaneously partners and customers. An org IS a partner iff it carries `partner` here AND has a `partner` row; removing the type while that row lives is refused (422). */
+            relationship_types?: ("customer" | "partner" | "supplier" | "investor" | "portfolio_company" | "competitor" | "other")[];
+            /**
+             * @deprecated
+             * @description RETIRED (ADR-0079/A124) — superseded by `lifecycle` + `relationship_types`, which split the two questions this one value tried to answer at once. Carried one release, written by nothing; read it for migration comparison only.
              * @enum {string|null}
              */
             classification?: null | "prospect" | "customer" | "agency" | "reseller" | "tech_vendor" | "platform" | "partner" | "competitor" | "other";
@@ -6673,6 +6681,13 @@ export interface components {
             parent_org_id?: string | null;
             /** @description Replace-set of the org's live domains (add new, archive removed, flip is_primary). Absent = untouched; an empty array clears all domains. */
             domains?: components["schemas"]["OrganizationDomainInput"][];
+            /**
+             * @description Where the account stands with us (ADR-0079/A124). Absent = untouched.
+             * @enum {string}
+             */
+            lifecycle?: "unknown" | "target" | "prospect" | "opportunity" | "customer" | "former_customer" | "disqualified";
+            /** @description Replace-set of what the company is to us (add new, archive removed), the same shape as `domains`. Absent = untouched; an empty array clears every type. Removing `partner` while the org still has a `partner` extension row is refused with 422 — the invariant binds both ways, and an invariant nothing enforces is a comment. */
+            relationship_types?: ("customer" | "partner" | "supplier" | "investor" | "portfolio_company" | "competitor" | "other")[];
         } & {
             [key: string]: unknown;
         };
@@ -12266,6 +12281,10 @@ export interface operations {
                 owner_id?: string;
                 /** @description Lookup by normalized domain (the employer-inference index). */
                 domain?: string;
+                /** @description Where the account stands with us (DM-VOCAB-2, ADR-0079/A124). */
+                lifecycle?: "unknown" | "target" | "prospect" | "opportunity" | "customer" | "former_customer" | "disqualified";
+                /** @description Accounts carrying this relationship type. Multi-valued per account, so this selects accounts that are AT LEAST this — a partner that is also a customer matches both. */
+                relationship_type?: "customer" | "partner" | "supplier" | "investor" | "portfolio_company" | "competitor" | "other";
                 q?: string;
             };
             header?: never;

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -226,7 +226,7 @@ export const de = {
   "merge.submit": "Zusammenführen",
 
   "tab.overview": "Übersicht",
-  "tab.relationships": "Beziehungen",
+  "tab.relationships": "Personen & Firmen",
   "tab.partner": "Partner",
   "tab.rollup": "Roll-up",
   "tab.history": "Verlauf",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -498,6 +498,13 @@ export const de = {
   "org.relType.portfolio_company": "Portfoliounternehmen",
   "org.relType.competitor": "Wettbewerber",
   "org.relType.other": "Sonstige",
+  // Warum ein Fakt seinem eigenen Feld widerspricht. Der Fakt bleibt mit
+  // seinem Beleg sichtbar — ein Mensch erkennt es, Ausblenden wäre schlechter.
+  "co.factSuspect.phoneShapedLocation": "Sieht nach einer Telefonnummer aus",
+  "co.factSuspect.notAPhone": "Sieht nicht nach einer Telefonnummer aus",
+  "co.factSuspect.notAYear": "Sieht nicht nach einer Jahreszahl aus",
+  "co.factSuspect.notAnEmail": "Sieht nicht nach einer E-Mail-Adresse aus",
+  "co.factSuspect.notASize": "Sieht nicht nach einer Mitarbeiterzahl aus",
   "org.partnerSetUp": "Partnerprogramm einrichten",
   // Die Einstufung, wie ein Leser sie sieht. Die Spalte speichert das Enum;
   // das Enum selbst anzuzeigen ("prospect") sagte einem deutschen Leser nichts.

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -480,6 +480,24 @@ export const de = {
   "org.classification": "Typ",
   // Nur dort angeboten, wo es noch kein Partnerprogramm gibt: der Tab mit dem
   // Formular erscheint erst, wenn eines besteht — so entsteht das erste.
+  // Wo der Account bei uns steht, und was er für uns ist — die zwei Fragen,
+  // die die abgelöste Einstufung mit einem Wert beantworten wollte.
+  "org.lifecycle": "Phase",
+  "org.relationshipTypes": "Beziehung zu uns",
+  "org.lifecycle.unknown": "Nicht eingeschätzt",
+  "org.lifecycle.target": "Zielkunde",
+  "org.lifecycle.prospect": "Interessent",
+  "org.lifecycle.opportunity": "Chance",
+  "org.lifecycle.customer": "Kunde",
+  "org.lifecycle.former_customer": "Ehemaliger Kunde",
+  "org.lifecycle.disqualified": "Disqualifiziert",
+  "org.relType.customer": "Kunde",
+  "org.relType.partner": "Partner",
+  "org.relType.supplier": "Lieferant",
+  "org.relType.investor": "Investor",
+  "org.relType.portfolio_company": "Portfoliounternehmen",
+  "org.relType.competitor": "Wettbewerber",
+  "org.relType.other": "Sonstige",
   "org.partnerSetUp": "Partnerprogramm einrichten",
   // Die Einstufung, wie ein Leser sie sieht. Die Spalte speichert das Enum;
   // das Enum selbst anzuzeigen ("prospect") sagte einem deutschen Leser nichts.

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -478,6 +478,9 @@ export const de = {
   "org.industry": "Branche",
   "org.size": "Größe",
   "org.classification": "Typ",
+  // Nur dort angeboten, wo es noch kein Partnerprogramm gibt: der Tab mit dem
+  // Formular erscheint erst, wenn eines besteht — so entsteht das erste.
+  "org.partnerSetUp": "Partnerprogramm einrichten",
   // Die Einstufung, wie ein Leser sie sieht. Die Spalte speichert das Enum;
   // das Enum selbst anzuzeigen ("prospect") sagte einem deutschen Leser nichts.
   "org.class.prospect": "Interessent",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -502,15 +502,16 @@ export const de = {
   "signal.kind.other": "Sonstiges",
   "record.profile": "Profil",
   "record.business": "Geschäft",
-  "co.pulse.strongestLead": "St\u00e4rkster Kontakt",
-  "co.pulse.strengthTail.one":
-    "\u2014 der einzige hier (Beziehung {score}/100)",
-  "co.pulse.strengthTail.other":
-    "\u2014 von {count} Personen hier (Beziehung {score}/100)",
-  "co.pulse.strengthExplain":
-    "Beziehungsst\u00e4rke, 0\u2013100: wie viel Austausch es mit diesem Account gab \u2014 gemessen an dem Kontakt, mit dem es den meisten gab.",
+  "co.pulse.strongestLead": "Zugang \u00fcber",
+  "co.pulse.strengthTail.one": "\u2014 der einzige Kontakt hier",
+  "co.pulse.strengthTail.other": "\u2014 von {count} Kontakten hier",
   "co.pulse.noStrength": "Noch keine Interaktionen erfasst",
-  "co.pulse.lastTouch": "Letzter Kontakt {when}",
+  // Zwei Zeitpunkte, nie zu einem "letzter Kontakt" verschmolzen: wer zuletzt
+  // geschrieben hat, ist die eigentliche Frage.
+  "co.pulse.lastInbound": "Sie schrieben {when}",
+  "co.pulse.lastOutbound": "Wir schrieben {when}",
+  "co.pulse.noInbound": "Sie haben nie geschrieben",
+  "co.pulse.noOutbound": "Wir haben nie geschrieben",
   "co.pulse.neverTouched": "Noch nie kontaktiert",
   "co.pulse.owner": "Betreut von",
   "co.owner.notInRoster": "Aktuell zugeordnet (nicht mehr in der Nutzerliste)",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -492,15 +492,17 @@ export const en = {
   "signal.kind.other": "Other",
   "record.profile": "Profile",
   "record.business": "Business",
-  "co.pulse.strongestLead": "Strongest contact",
-  "co.pulse.strengthTail.one":
-    "\u2014 the only one here (relationship {score}/100)",
-  "co.pulse.strengthTail.other":
-    "\u2014 of {count} people here (relationship {score}/100)",
-  "co.pulse.strengthExplain":
-    "Relationship strength, 0\u2013100: how much back-and-forth there has been with this account, taken from the contact with the most.",
+  "co.pulse.strongestLead": "Way in",
+  "co.pulse.strengthTail.one": "\u2014 the only contact here",
+  "co.pulse.strengthTail.other": "\u2014 of {count} contacts here",
   "co.pulse.noStrength": "No interactions logged yet",
-  "co.pulse.lastTouch": "Last touch {when}",
+  // Two timestamps, never folded into one "last touch": which side wrote
+  // last is the question. Mailed a fortnight ago with no reply, and wrote
+  // to us this morning, are the same date and opposite situations.
+  "co.pulse.lastInbound": "They wrote {when}",
+  "co.pulse.lastOutbound": "We wrote {when}",
+  "co.pulse.noInbound": "They have never written",
+  "co.pulse.noOutbound": "We have never written",
   "co.pulse.neverTouched": "Never contacted",
   "co.pulse.owner": "Owner",
   "co.owner.notInRoster": "Current owner (no longer in the user list)",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -221,7 +221,7 @@ export const en = {
   "merge.submit": "Merge",
 
   "tab.overview": "Overview",
-  "tab.relationships": "Relationships",
+  "tab.relationships": "People & companies",
   "tab.partner": "Partner",
   "tab.rollup": "Roll-up",
   "tab.history": "History",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -469,6 +469,24 @@ export const en = {
   "org.classification": "Type",
   // Offered only where there is no partner programme yet: the tab that holds
   // the form appears once one exists, so this is how the first one is made.
+  // Where the account stands with us, and what it is to us — the two
+  // questions the retired classification answered with one value.
+  "org.lifecycle": "Stage",
+  "org.relationshipTypes": "Relationship to us",
+  "org.lifecycle.unknown": "Not assessed",
+  "org.lifecycle.target": "Target",
+  "org.lifecycle.prospect": "Prospect",
+  "org.lifecycle.opportunity": "Opportunity",
+  "org.lifecycle.customer": "Customer",
+  "org.lifecycle.former_customer": "Former customer",
+  "org.lifecycle.disqualified": "Disqualified",
+  "org.relType.customer": "Customer",
+  "org.relType.partner": "Partner",
+  "org.relType.supplier": "Supplier",
+  "org.relType.investor": "Investor",
+  "org.relType.portfolio_company": "Portfolio company",
+  "org.relType.competitor": "Competitor",
+  "org.relType.other": "Other",
   "org.partnerSetUp": "Set up partner programme",
   // The classification values a reader sees. The column stores the enum;
   // rendering the enum itself ("prospect") told a German reader nothing and

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -487,6 +487,13 @@ export const en = {
   "org.relType.portfolio_company": "Portfolio company",
   "org.relType.competitor": "Competitor",
   "org.relType.other": "Other",
+  // Why a stored fact contradicts its own field. The fact is still shown
+  // with its evidence — a reader can tell, and hiding it would be worse.
+  "co.factSuspect.phoneShapedLocation": "Looks like a phone number",
+  "co.factSuspect.notAPhone": "Does not look like a phone number",
+  "co.factSuspect.notAYear": "Does not look like a year",
+  "co.factSuspect.notAnEmail": "Does not look like an email address",
+  "co.factSuspect.notASize": "Does not look like a headcount",
   "org.partnerSetUp": "Set up partner programme",
   // The classification values a reader sees. The column stores the enum;
   // rendering the enum itself ("prospect") told a German reader nothing and

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -467,6 +467,9 @@ export const en = {
   "org.industry": "Industry",
   "org.size": "Size",
   "org.classification": "Type",
+  // Offered only where there is no partner programme yet: the tab that holds
+  // the form appears once one exists, so this is how the first one is made.
+  "org.partnerSetUp": "Set up partner programme",
   // The classification values a reader sees. The column stores the enum;
   // rendering the enum itself ("prospect") told a German reader nothing and
   // an English one only slightly more.

--- a/frontend/src/screens/company360.css
+++ b/frontend/src/screens/company360.css
@@ -282,3 +282,10 @@
 .co-prep-foot:empty {
   display: none;
 }
+
+/* A fact whose value contradicts its field. It sits beside the value rather
+   than replacing it: the reader needs to see what was extracted to judge it. */
+.co-fact-suspect {
+  display: inline-block;
+  margin-inline-start: 0.4rem;
+}

--- a/frontend/src/screens/company360.test.tsx
+++ b/frontend/src/screens/company360.test.tsx
@@ -94,7 +94,25 @@ const EMPTY_BRIEF = {
 // otherwise still being served to the next one.
 let briefBody: unknown = EMPTY_BRIEF;
 
-function stub(three60: unknown, status = 200) {
+// partnerOrg is the account that HAS a partner programme, and so carries the
+// second tab. The bare fixture deliberately does not: a Partner tab on an
+// account with no programme is the thing the tab gate removed.
+const partnerOrg = {
+  ...org,
+  partner: {
+    id: "pt-1",
+    workspace_id: "w",
+    organization_id: "o-1",
+    relationship_stage: "active",
+    source: "manual",
+    captured_by: "human:u1",
+    version: 1,
+    created_at: "2026-06-01T08:00:00Z",
+    updated_at: "2026-06-01T08:00:00Z",
+  },
+};
+
+function stub(three60: unknown, status = 200, account: unknown = org) {
   // The paths actually requested. A test proves the page did NOT refetch by
   // counting these rather than by trusting that it did not.
   const fetched: string[] = [];
@@ -113,7 +131,7 @@ function stub(three60: unknown, status = 200) {
         return jsonResponse(briefBody);
       }
       if (pathname.endsWith("/organizations/o-1")) {
-        return jsonResponse(org);
+        return jsonResponse(account);
       }
       if (pathname.endsWith("/pipelines")) {
         // One default pipeline with one OPEN stage — enough for a deal
@@ -370,7 +388,7 @@ describe("company view — consent is per purpose", () => {
 
 describe("company view — the rails belong to the account, not to a tab", () => {
   it("keeps both side columns mounted when the reader switches tab", async () => {
-    stub(view());
+    stub(view(), 200, partnerOrg);
     renderCompany();
 
     await screen.findByRole("complementary", { name: "Business" });
@@ -388,7 +406,7 @@ describe("company view — the rails belong to the account, not to a tab", () =>
   });
 
   it("does not refetch the account when the reader switches tab and back", async () => {
-    const fetched = stub(view());
+    const fetched = stub(view(), 200, partnerOrg);
     renderCompany();
     await screen.findByRole("complementary", { name: "Business" });
     const before = fetched.filter((path) => path.endsWith("/360")).length;
@@ -400,7 +418,7 @@ describe("company view — the rails belong to the account, not to a tab", () =>
   });
 
   it("leaves the timeline to the overview rather than repeating it under a form", async () => {
-    stub(view());
+    stub(view(), 200, partnerOrg);
     renderCompany();
     await screen.findByRole("region", { name: "Timeline" });
 
@@ -1036,4 +1054,79 @@ it("does not offer a role the contact already holds on that deal", async () => {
   expect([...roles.options].map((option) => option.value)).not.toContain(
     "champion",
   );
+});
+
+describe("company view — Partner is not a permanent tab", () => {
+  it("shows no tab strip at all on an account with no partner programme", async () => {
+    stub(view());
+    renderCompany();
+    await screen.findByRole("complementary", { name: "Business" });
+
+    // One tab is not a choice: the strip goes entirely rather than offering
+    // the reader the page they are already on.
+    expect(screen.queryByRole("button", { name: "Partner" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Overview" })).toBeNull();
+  });
+
+  it("shows both tabs once the account has a programme", async () => {
+    stub(view(), 200, partnerOrg);
+    renderCompany();
+    await screen.findByRole("complementary", { name: "Business" });
+
+    expect(screen.getByRole("button", { name: "Partner" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Overview" })).toBeTruthy();
+  });
+
+  it("keeps the setup form reachable, so a first partner row can still be made", async () => {
+    stub(view());
+    renderCompany();
+    await screen.findByRole("complementary", { name: "Business" });
+
+    await userEvent.click(screen.getByRole("button", { name: "More actions" }));
+    await userEvent.click(
+      screen.getByRole("button", { name: "Set up partner programme" }),
+    );
+
+    // Asking for the form is what puts the tab on screen — without this the
+    // hidden tab would have made the first partner row unreachable.
+    expect(screen.getByRole("button", { name: "Partner" })).toBeTruthy();
+  });
+});
+
+describe("company view — the visit baseline", () => {
+  it("acknowledges the visit after the reader has stayed", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      const fetched = stub(view());
+      renderCompany();
+      await screen.findByRole("complementary", { name: "Business" });
+      expect(fetched.some((path) => path.endsWith("/view-ack"))).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      await waitFor(() =>
+        expect(fetched.some((path) => path.endsWith("/view-ack"))).toBe(true),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not acknowledge a visit the reader bounced straight out of", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      const fetched = stub(view());
+      const { unmount } = render(<CompanyScreen id="o-1" />);
+      await screen.findByRole("complementary", { name: "Business" });
+      unmount();
+
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      // Marking unread activity as seen because a record flashed past is the
+      // one failure this baseline must never have.
+      expect(fetched.some((path) => path.endsWith("/view-ack"))).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/frontend/src/screens/company360.test.tsx
+++ b/frontend/src/screens/company360.test.tsx
@@ -1130,3 +1130,32 @@ describe("company view — the visit baseline", () => {
     }
   });
 });
+
+describe("company view — where the account stands, and what it is to us", () => {
+  it("shows the lifecycle and every relationship type as separate badges", async () => {
+    stub(view(), 200, {
+      ...org,
+      lifecycle: "former_customer",
+      relationship_types: ["partner", "supplier"],
+    });
+    renderCompany();
+    await screen.findByRole("complementary", { name: "Business" });
+
+    // The retired classification held ONE value, which is how an account whose
+    // contract had ended still read as "Prospect" while it was also a partner.
+    expect(screen.getByText("Former customer")).toBeTruthy();
+    expect(screen.getByText("Partner")).toBeTruthy();
+    expect(screen.getByText("Supplier")).toBeTruthy();
+  });
+
+  it("draws no badge for an account nobody has assessed", async () => {
+    stub(view(), 200, { ...org, lifecycle: "unknown", relationship_types: [] });
+    renderCompany();
+    await screen.findByRole("complementary", { name: "Business" });
+
+    // 'unknown' is the honest default, and a badge announcing it on every new
+    // record is noise — the old column defaulted to 'prospect' and rendered
+    // that default as though someone had judged it.
+    expect(screen.queryByText("Not assessed")).toBeNull();
+  });
+});

--- a/frontend/src/screens/company360.test.tsx
+++ b/frontend/src/screens/company360.test.tsx
@@ -95,22 +95,12 @@ const EMPTY_BRIEF = {
 let briefBody: unknown = EMPTY_BRIEF;
 
 // partnerOrg is the account that HAS a partner programme, and so carries the
-// second tab. The bare fixture deliberately does not: a Partner tab on an
-// account with no programme is the thing the tab gate removed.
-const partnerOrg = {
-  ...org,
-  partner: {
-    id: "pt-1",
-    workspace_id: "w",
-    organization_id: "o-1",
-    relationship_stage: "active",
-    source: "manual",
-    captured_by: "human:u1",
-    version: 1,
-    created_at: "2026-06-01T08:00:00Z",
-    updated_at: "2026-06-01T08:00:00Z",
-  },
-};
+// second tab. Partnerhood is read off the relationship type rather than the
+// extension row, because the Organization read never selects that row — the
+// two are equivalent, since the store enforces the invariant both ways.
+// The bare fixture deliberately carries neither: a Partner tab on an account
+// with no programme is the thing the tab gate removed.
+const partnerOrg = { ...org, relationship_types: ["partner"] };
 
 function stub(three60: unknown, status = 200, account: unknown = org) {
   // The paths actually requested. A test proves the page did NOT refetch by
@@ -1133,10 +1123,12 @@ describe("company view — the visit baseline", () => {
 
 describe("company view — where the account stands, and what it is to us", () => {
   it("shows the lifecycle and every relationship type as separate badges", async () => {
+    // Not "partner": that type also raises the Partner tab, and the badge and
+    // the tab would then share a label, which tells the test nothing.
     stub(view(), 200, {
       ...org,
       lifecycle: "former_customer",
-      relationship_types: ["partner", "supplier"],
+      relationship_types: ["customer", "supplier"],
     });
     renderCompany();
     await screen.findByRole("complementary", { name: "Business" });
@@ -1144,7 +1136,7 @@ describe("company view — where the account stands, and what it is to us", () =
     // The retired classification held ONE value, which is how an account whose
     // contract had ended still read as "Prospect" while it was also a partner.
     expect(screen.getByText("Former customer")).toBeTruthy();
-    expect(screen.getByText("Partner")).toBeTruthy();
+    expect(screen.getByText("Customer")).toBeTruthy();
     expect(screen.getByText("Supplier")).toBeTruthy();
   });
 

--- a/frontend/src/screens/company360.tsx
+++ b/frontend/src/screens/company360.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { type ReactNode, useId, useState } from "react";
+import { type ReactNode, useEffect, useId, useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { navigate } from "../app/router";
@@ -107,6 +107,51 @@ export function useOrganization360(id: string) {
       return { state: "ready", view: data };
     },
   });
+}
+
+// VIEW_ACK_DWELL_MS is how long the account must stay open before the visit
+// counts. Opening a record and bouncing straight back out is not reading it,
+// and an ack from that would mark unread activity as seen.
+const VIEW_ACK_DWELL_MS = 5_000;
+
+/**
+ * useAcknowledgeOrganizationView advances THIS reader's "last seen" baseline
+ * for the account — the thing that makes "N new since your last visit" mean
+ * anything on the next visit. Without it the server keeps answering with no
+ * baseline at all, so every visit reads as the first one.
+ *
+ * The 360 deliberately does not advance the baseline itself (a prefetch must
+ * not be indistinguishable from a visit), so this is the only caller. Leaving
+ * before the dwell elapses cancels the timer: the baseline moves only for a
+ * visit that actually happened, and when in doubt it stays where it is —
+ * showing an item twice is a smaller wrong than hiding one.
+ *
+ * Success does NOT invalidate the 360. The "new since your last visit" line
+ * describes the visit in progress; refetching it out from under the reader
+ * would erase the very thing they opened the page to see.
+ */
+export function useAcknowledgeOrganizationView(id: string, visited: boolean) {
+  const ack = useMutation({
+    mutationFn: async (organizationId: string) => {
+      const { error } = await api.POST("/organizations/{id}/view-ack", {
+        params: { path: { id: organizationId } },
+      });
+      if (error) {
+        throw new Error(problemMessage(error));
+      }
+    },
+  });
+  // The mutation's own error state holds a failure; nothing renders it. A
+  // baseline that did not move costs the reader one repeated line next time,
+  // which is not worth an error banner over the account they came to read.
+  const fire = ack.mutate;
+  useEffect(() => {
+    if (!visited) {
+      return;
+    }
+    const timer = window.setTimeout(() => fire(id), VIEW_ACK_DWELL_MS);
+    return () => window.clearTimeout(timer);
+  }, [id, visited, fire]);
 }
 
 // isOverlayRefusal distinguishes "this workspace reads elsewhere" from every

--- a/frontend/src/screens/organizations.test.tsx
+++ b/frontend/src/screens/organizations.test.tsx
@@ -1151,8 +1151,8 @@ describe("CompanyScreen — Relationships tab (P-5)", () => {
     });
     render(<CompanyScreen id="o-1" />);
 
-    await screen.findByText("Relationships");
-    await userEvent.click(screen.getByText("Relationships"));
+    await screen.findByText("People & companies");
+    await userEvent.click(screen.getByText("People & companies"));
 
     await waitFor(() => expect(screen.getByText("Employment")).toBeTruthy());
     expect(screen.getByText("cto")).toBeTruthy();
@@ -1184,8 +1184,8 @@ describe("CompanyScreen — Relationships tab (P-5)", () => {
       return jsonResponse(org);
     });
     render(<CompanyScreen id="o-1" />);
-    await screen.findByText("Relationships");
-    await userEvent.click(screen.getByText("Relationships"));
+    await screen.findByText("People & companies");
+    await userEvent.click(screen.getByText("People & companies"));
     await waitFor(() =>
       expect(screen.getByTestId("add-relationship")).toBeTruthy(),
     );
@@ -1405,8 +1405,8 @@ describe("CompanyScreen — relationship kinds by scope (P-5)", () => {
       return jsonResponse(org);
     });
     render(<CompanyScreen id="o-1" />);
-    await screen.findByText("Relationships");
-    await userEvent.click(screen.getByText("Relationships"));
+    await screen.findByText("People & companies");
+    await userEvent.click(screen.getByText("People & companies"));
     await waitFor(() =>
       expect(screen.getByTestId("add-relationship")).toBeTruthy(),
     );

--- a/frontend/src/screens/organizations.test.tsx
+++ b/frontend/src/screens/organizations.test.tsx
@@ -1151,7 +1151,7 @@ describe("CompanyScreen — Relationships tab (P-5)", () => {
     });
     render(<CompanyScreen id="o-1" />);
 
-    await waitFor(() => expect(screen.getByText("Overview")).toBeTruthy());
+    await screen.findByText("Relationships");
     await userEvent.click(screen.getByText("Relationships"));
 
     await waitFor(() => expect(screen.getByText("Employment")).toBeTruthy());
@@ -1184,7 +1184,7 @@ describe("CompanyScreen — Relationships tab (P-5)", () => {
       return jsonResponse(org);
     });
     render(<CompanyScreen id="o-1" />);
-    await waitFor(() => expect(screen.getByText("Overview")).toBeTruthy());
+    await screen.findByText("Relationships");
     await userEvent.click(screen.getByText("Relationships"));
     await waitFor(() =>
       expect(screen.getByTestId("add-relationship")).toBeTruthy(),
@@ -1238,8 +1238,6 @@ describe("CompanyScreen — hierarchy roll-up in the rail (P-7)", () => {
     );
     render(<CompanyScreen id="o-1" />);
 
-    await waitFor(() => expect(screen.getByText("Overview")).toBeTruthy());
-
     await waitFor(() => expect(screen.getByText("€48,000.00")).toBeTruthy());
     expect(screen.getByText("€12,000.00")).toBeTruthy();
     expect(screen.getByText("12")).toBeTruthy();
@@ -1262,8 +1260,6 @@ describe("CompanyScreen — hierarchy roll-up in the rail (P-7)", () => {
       },
     );
     render(<CompanyScreen id="o-1" />);
-
-    await waitFor(() => expect(screen.getByText("Overview")).toBeTruthy());
 
     await waitFor(() =>
       expect(
@@ -1293,8 +1289,6 @@ describe("CompanyScreen — hierarchy roll-up in the rail (P-7)", () => {
       },
     );
     render(<CompanyScreen id="o-1" />);
-
-    await waitFor(() => expect(screen.getByText("Overview")).toBeTruthy());
 
     await waitFor(() =>
       expect(
@@ -1411,7 +1405,7 @@ describe("CompanyScreen — relationship kinds by scope (P-5)", () => {
       return jsonResponse(org);
     });
     render(<CompanyScreen id="o-1" />);
-    await waitFor(() => expect(screen.getByText("Overview")).toBeTruthy());
+    await screen.findByText("Relationships");
     await userEvent.click(screen.getByText("Relationships"));
     await waitFor(() =>
       expect(screen.getByTestId("add-relationship")).toBeTruthy(),

--- a/frontend/src/screens/organizations.test.tsx
+++ b/frontend/src/screens/organizations.test.tsx
@@ -1299,7 +1299,7 @@ describe("CompanyScreen — hierarchy roll-up in the rail (P-7)", () => {
 });
 
 describe("CompanyScreen — the account pulse line (P-4)", () => {
-  it("leads with the score, who carries it, and how many contacts it beat", async () => {
+  it("names the way in and both directions, and shows no composite score", async () => {
     stubFetch(
       async (url) => {
         if (url.includes("/activities")) {
@@ -1326,21 +1326,22 @@ describe("CompanyScreen — the account pulse line (P-4)", () => {
             },
             last_interaction: "2026-06-20T12:00:00Z",
           },
+          last_inbound_at: "2026-06-20T12:00:00Z",
+          last_outbound_at: "2026-06-28T09:00:00Z",
         },
       },
     );
     render(<CompanyScreen id="o-1" />);
 
-    // The contact, the count and the score all read off the one composite
-    // response — no second round trip for the header. The line leads with the
-    // person because that is what a rep acts on; the score follows, labelled,
-    // because a bare number scales to nothing.
-    await waitFor(() =>
-      expect(screen.getByText(/Strongest contact/)).toBeTruthy(),
-    );
-    expect(screen.getByText(/of 3 people here/)).toBeTruthy();
-    expect(screen.getByText(/relationship 41\/100/)).toBeTruthy();
-    expect(screen.getByText(/Last touch/)).toBeTruthy();
+    // The way in first, because that is what a rep acts on, then who wrote
+    // last in each direction.
+    await waitFor(() => expect(screen.getByText(/Way in/)).toBeTruthy());
+    expect(screen.getByText(/of 3 contacts here/)).toBeTruthy();
+    expect(screen.getByText(/They wrote/)).toBeTruthy();
+    expect(screen.getByText(/We wrote/)).toBeTruthy();
+    // The composite is gone: it was PO-F-3's MAX over contacts, so one
+    // talkative contact spoke for the account and "41/100" read as a verdict.
+    expect(screen.queryByText(/41\/100/)).toBeNull();
   });
 
   it("says there is no relationship rather than showing a zero", async () => {

--- a/frontend/src/screens/organizations.tsx
+++ b/frontend/src/screens/organizations.tsx
@@ -1181,6 +1181,19 @@ const FACT_CATEGORY_LABELS: Record<OrganizationFact["category"], MessageKey> = {
 
 // One fact row: the value carries its own evidence mark, the same
 // affordance every derived value on this page uses.
+// Why a fact looks wrong, in the words a reader can act on. Typed against the
+// schema union, so a rule added upstream fails the build here rather than
+// rendering a raw reason code.
+type FactSuspectReason = NonNullable<OrganizationFact["suspect_reason"]>;
+
+const FACT_SUSPECT_LABELS: Record<FactSuspectReason, MessageKey> = {
+  phone_shaped_location: "co.factSuspect.phoneShapedLocation",
+  not_a_phone: "co.factSuspect.notAPhone",
+  not_a_year: "co.factSuspect.notAYear",
+  not_an_email: "co.factSuspect.notAnEmail",
+  not_a_size: "co.factSuspect.notASize",
+};
+
 function FactRow({
   fact,
   onOpenHistory,
@@ -1196,6 +1209,17 @@ function FactRow({
           source={derivedSource(fact, locale)}
           onOpenHistory={onOpenHistory}
         />
+        {/* The value contradicts its own field — a phone number filed as a
+            location, a register number filed as a headcount. The fact is still
+            shown with its evidence: hiding it would be a worse answer than
+            flagging it, and the reader is the one who can tell. */}
+        {fact.suspect_reason && (
+          <span className="co-fact-suspect">
+            <Badge tone="warn">
+              {t(FACT_SUSPECT_LABELS[fact.suspect_reason])}
+            </Badge>
+          </span>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/screens/organizations.tsx
+++ b/frontend/src/screens/organizations.tsx
@@ -56,6 +56,7 @@ import {
   RECORD_ZONE,
   SignalsCard,
   TagsCard,
+  useAcknowledgeOrganizationView,
   useOrganization360,
 } from "./company360";
 import { ListAction, NewDealAction, TagAction } from "./companyactions";
@@ -1209,6 +1210,24 @@ function FactsCard({
 const COMPANY_TABS = ["overview", "partner"] as const;
 type CompanyTab = (typeof COMPANY_TABS)[number];
 
+// Partner is not a permanent tab. It renders the partner programme —
+// certification, role, margin tier — which is a form about a commercial
+// arrangement the overwhelming majority of accounts do not have. A tab that
+// is empty on nearly every record teaches the reader to skip the tab strip.
+//
+// It shows for an account that HAS a partner programme, and for the reader
+// who just asked to set one up (the overflow menu switches the tab, which is
+// what `tab` already carries) — so the only path to a first partner row is
+// still open, and the form stops greeting everyone else.
+function companyTabsFor(
+  org: Organization,
+  tab: CompanyTab,
+): readonly CompanyTab[] {
+  return org.partner || tab === "partner"
+    ? COMPANY_TABS
+    : (["overview"] as const);
+}
+
 // Which slice of the account's chronology is on screen. Activities is what
 // happened WITH them, changes is what happened TO the record; a reader who
 // wants them in one order picks "all".
@@ -1300,7 +1319,12 @@ function CompanyEditAction({
 function CompanyActionBadges({
   org,
   onOpenHistory,
-}: Readonly<{ org: Organization; onOpenHistory: () => void }>) {
+  onSetUpPartner,
+}: Readonly<{
+  org: Organization;
+  onOpenHistory: () => void;
+  onSetUpPartner: () => void;
+}>) {
   const t = useT();
   const overlay = useSorMode() === "overlay";
   // An archived record is read-only: the backend rejects edit/merge/archive
@@ -1383,6 +1407,15 @@ function CompanyActionBadges({
           {writable && !overlay && (
             <ShareAction recordType="organization" recordId={org.id} />
           )}
+          {/* The way in to the partner programme for an account that has none.
+            The tab only shows once there IS one, so without this the first
+            partner row would be unreachable — this is the same form, asked
+            for rather than offered. */}
+          {writable && !overlay && !org.partner && (
+            <Button small onClick={onSetUpPartner}>
+              {t("org.partnerSetUp")}
+            </Button>
+          )}
           {/* The audit spine: who changed this record and when. It reads as an
             inspection of the record rather than part of its story, so it sits
             with the other rare verbs instead of beside the account's own
@@ -1406,6 +1439,10 @@ export function CompanyScreen({ id }: Readonly<{ id: string }>) {
   const t = useT();
   const [tab, setTab] = useState<CompanyTab>("overview");
   const view = useOrganization360(id);
+  // Only an assembled 360 counts as a visit: in overlay mode there is no
+  // baseline to advance, and a page that never rendered the account is not
+  // one the reader saw.
+  useAcknowledgeOrganizationView(id, view.data?.state === "ready");
   // The account itself still comes from its own read: the 360 refuses
   // entirely in overlay mode, and the header must render either way.
   const orgQuery = useQuery({
@@ -1456,19 +1493,24 @@ function CompanyRecord({
   // workspace that flipped mode after this page cached its read would
   // otherwise keep serving a native-looking company view.
   const overlay = view.data?.state === "overlay" || sorMode === "overlay";
-  const tabs = (
-    <div className="co-tabs">
-      <SegmentedControl
-        options={COMPANY_TABS}
-        value={tab}
-        onChange={onTab}
-        labels={{
-          overview: t("tab.overview"),
-          partner: t("tab.partner"),
-        }}
-      />
-    </div>
-  );
+  const visibleTabs = companyTabsFor(org, tab);
+  // One tab is not a choice. A segmented control with a single option is a
+  // button that does nothing, so the strip disappears entirely rather than
+  // asking the reader to pick the page they are already on.
+  const tabs =
+    visibleTabs.length > 1 ? (
+      <div className="co-tabs">
+        <SegmentedControl
+          options={visibleTabs}
+          value={tab}
+          onChange={onTab}
+          labels={{
+            overview: t("tab.overview"),
+            partner: t("tab.partner"),
+          }}
+        />
+      </div>
+    ) : null;
 
   // Both tabs render inside ONE page. Partner used to be a different
   // component tree with no rails, so switching tab unmounted both side
@@ -1912,6 +1954,7 @@ function CompanyPage({
         <CompanyActionBadges
           org={org}
           onOpenHistory={() => setAuditOpen(true)}
+          onSetUpPartner={() => onTab("partner")}
         />
       }
       pulse={

--- a/frontend/src/screens/organizations.tsx
+++ b/frontend/src/screens/organizations.tsx
@@ -62,7 +62,12 @@ import {
 import { ListAction, NewDealAction, TagAction } from "./companyactions";
 import { CompanyApprovalsPanel, DecisionsChip } from "./companyapprovals";
 import { TimelineActions } from "./compose";
-import { CreateAction, type CreateField, type FormRows } from "./create";
+import {
+  CreateAction,
+  type CreateField,
+  type FormRows,
+  splitMultiselectValue,
+} from "./create";
 import { CustomFieldsCard } from "./customfields.card";
 import { useObjectCustomFields } from "./customfields.form";
 import { EditAction } from "./edit";
@@ -114,6 +119,32 @@ const CLASSIFICATION_LABELS: Record<Classification, MessageKey> = {
   partner: "org.class.partner",
   competitor: "org.class.competitor",
   other: "org.class.other",
+};
+
+// Where the account stands with us, and what it is to us (ADR-0079/A124).
+// Typed against the schema unions, so a value added upstream fails the build
+// here rather than reaching a reader as a raw enum.
+type Lifecycle = NonNullable<Organization["lifecycle"]>;
+type RelationshipType = NonNullable<Organization["relationship_types"]>[number];
+
+const LIFECYCLE_LABELS: Record<Lifecycle, MessageKey> = {
+  unknown: "org.lifecycle.unknown",
+  target: "org.lifecycle.target",
+  prospect: "org.lifecycle.prospect",
+  opportunity: "org.lifecycle.opportunity",
+  customer: "org.lifecycle.customer",
+  former_customer: "org.lifecycle.former_customer",
+  disqualified: "org.lifecycle.disqualified",
+};
+
+const RELATIONSHIP_TYPE_LABELS: Record<RelationshipType, MessageKey> = {
+  customer: "org.relType.customer",
+  partner: "org.relType.partner",
+  supplier: "org.relType.supplier",
+  investor: "org.relType.investor",
+  portfolio_company: "org.relType.portfolio_company",
+  competitor: "org.relType.competitor",
+  other: "org.relType.other",
 };
 type CreateOrganizationRequest =
   components["schemas"]["CreateOrganizationRequest"];
@@ -269,6 +300,21 @@ export function mapOrgUpdate(
   if (!sameDomainSet(desired, current)) {
     body.domains = desired;
   }
+  const lifecycle = stringField(values.lifecycle).trim();
+  if (lifecycle) {
+    body.lifecycle = lifecycle as NonNullable<
+      UpdateOrganizationRequest["lifecycle"]
+    >;
+  }
+  // Always sent when the field was rendered, even empty: this is a replace-set,
+  // and "the user cleared every type" is an edit, not an absence. The form
+  // channel joins a multiselect into one comma string, so an empty string is
+  // the honest empty set.
+  if (values.relationship_types !== undefined) {
+    body.relationship_types = splitMultiselectValue(
+      stringField(values.relationship_types),
+    ) as NonNullable<UpdateOrganizationRequest["relationship_types"]>;
+  }
   return body;
 }
 
@@ -300,6 +346,29 @@ const companyCreateFields: CreateField[] = [
 // proposals — so a select for it would collect an answer and drop it. The
 // badge names the value; changing it needs a contract that does not exist
 // yet (raised in STATUS.md).
+// The two vocabularies that replaced classification (ADR-0079/A124): where the
+// account stands with us, and what it is to us. Kept in wire order so the
+// select reads as a progression rather than an alphabet.
+export const LIFECYCLE_OPTIONS = [
+  "unknown",
+  "target",
+  "prospect",
+  "opportunity",
+  "customer",
+  "former_customer",
+  "disqualified",
+] as const;
+
+export const RELATIONSHIP_TYPE_OPTIONS = [
+  "customer",
+  "partner",
+  "supplier",
+  "investor",
+  "portfolio_company",
+  "competitor",
+  "other",
+] as const;
+
 export function companyEditFields(
   owners: readonly { id: string; display_name: string }[],
   hasOwner: boolean,
@@ -332,6 +401,27 @@ export function companyEditFields(
       options: owners.map((user) => ({
         value: user.id,
         label: user.display_name,
+      })),
+    },
+    // Where the account stands, and what it is to us — the two questions the
+    // retired classification tried to answer with one value, and the reason
+    // neither was editable from this page at all.
+    {
+      key: "lifecycle",
+      label: "org.lifecycle",
+      type: "select",
+      options: LIFECYCLE_OPTIONS.map((value) => ({
+        value,
+        label: LIFECYCLE_LABELS[value],
+      })),
+    },
+    {
+      key: "relationship_types",
+      label: "org.relationshipTypes",
+      type: "multiselect",
+      options: RELATIONSHIP_TYPE_OPTIONS.map((value) => ({
+        value,
+        label: RELATIONSHIP_TYPE_LABELS[value],
       })),
     },
     {
@@ -1333,11 +1423,19 @@ function CompanyActionBadges({
   const writable = !org.archived_at;
   return (
     <>
-      {org.classification && (
-        <span title={t("org.class.explain")}>
-          <Badge>{t(CLASSIFICATION_LABELS[org.classification])}</Badge>
-        </span>
+      {/* Where the account stands, then what it is to us. Two badges, because
+          they answer two questions — the retired classification held one value
+          and so could answer only one, which is how an account whose contract
+          had ended still read as "Prospect". `unknown` is not drawn: a badge
+          saying nobody has assessed this yet is noise on every new record. */}
+      {org.lifecycle && org.lifecycle !== "unknown" && (
+        <Badge>{t(LIFECYCLE_LABELS[org.lifecycle])}</Badge>
       )}
+      {(org.relationship_types ?? []).map((relType) => (
+        <Badge key={relType} tone="accent">
+          {t(RELATIONSHIP_TYPE_LABELS[relType])}
+        </Badge>
+      ))}
       {org.archived_at && <Badge tone="warn">{t("record.archived")}</Badge>}
       {/* An archived record read from a mirror offers nothing at all: every
           write is refused and the history is a native read the mirror has no

--- a/frontend/src/screens/organizations.tsx
+++ b/frontend/src/screens/organizations.tsx
@@ -1564,28 +1564,38 @@ function CompanyPulse({
   const { locale } = useLocale();
   const viewerId = useViewerId();
   const strength = view?.strength;
-  // The strength section is what carries BOTH the score and the last touch.
-  // Withheld or absent, the line says nothing about either: "never
-  // contacted" read off missing data is a business conclusion the page has
-  // no basis for, and it is the one a rep would act on.
-  const strengthKnown = Boolean(
-    view && !view.sections_omitted?.includes("strength"),
+  // Withheld or absent, the line says nothing at all: "never contacted" read
+  // off missing data is a business conclusion the page has no basis for, and
+  // it is the one a rep would act on.
+  const touchKnown = Boolean(
+    view && !view.sections_omitted?.includes("last_touch"),
   );
+  const inbound = view?.last_inbound_at;
+  const outbound = view?.last_outbound_at;
+  const when = (at: string) => formatDateTime(at, locale, RECORD_ZONE);
   return (
     <>
       {strength && <StrengthPulse strength={strength} />}
-      {strengthKnown && (
-        <span>
-          {strength?.last_interaction
-            ? t("co.pulse.lastTouch", {
-                when: formatDateTime(
-                  strength.last_interaction,
-                  locale,
-                  RECORD_ZONE,
-                ),
-              })
-            : t("co.pulse.neverTouched")}
-        </span>
+      {/* Both directions, side by side. Folding them into one "last touch"
+          hides the only distinction a reader acts on: an account we mailed a
+          fortnight ago with no reply and one that wrote to us this morning
+          have the same last-touch date and opposite meanings. */}
+      {touchKnown && !inbound && !outbound && (
+        <span>{t("co.pulse.neverTouched")}</span>
+      )}
+      {touchKnown && (inbound || outbound) && (
+        <>
+          <span>
+            {inbound
+              ? t("co.pulse.lastInbound", { when: when(inbound) })
+              : t("co.pulse.noInbound")}
+          </span>
+          <span>
+            {outbound
+              ? t("co.pulse.lastOutbound", { when: when(outbound) })
+              : t("co.pulse.noOutbound")}
+          </span>
+        </>
       )}
       {/* The owner, named as the owner. Unlabelled it read as one more
           person in a row of people, and the reader had no way to tell the
@@ -1615,11 +1625,20 @@ function CompanyPulse({
   );
 }
 
-// StrengthPulse renders the score and, when there is one, the contact who
-// carries it. The contributor's NAME is a live lookup, so the sentence is
-// assembled from two translated halves around it rather than interpolating
-// an empty placeholder and appending the name after the full stop — which
-// broke word order in English and worse in German.
+// StrengthPulse names the contact who carries the relationship — the way in —
+// and no longer renders a 0-100 score (AC-company-2, ADR-0079 arc).
+//
+// The number was PO-F-3's MAX over the account's contacts, and PO-F-3 is a
+// decayed count of recent two-way messages. So one talkative contact spoke for
+// the whole account, a long low-volume relationship scored near zero, and the
+// header showed "Relationship 2/100" as though it were a verdict. The factors
+// are still computed and still shown in the relationship detail, where each is
+// traceable to the messages behind it; only the single number is withheld.
+//
+// The contributor's NAME is a live lookup, so the sentence is assembled from
+// two translated halves around it rather than interpolating an empty
+// placeholder and appending the name after the full stop — which broke word
+// order in English and worse in German.
 function StrengthPulse({
   strength,
 }: Readonly<{ strength: NonNullable<Organization360View["strength"]> }>) {
@@ -1629,18 +1648,15 @@ function StrengthPulse({
     // relationship to attribute and no number worth leading with.
     return <span>{t("co.pulse.noStrength")}</span>;
   }
-  // The person, then the number — and the number says what it measures.
-  // "2 · via Christian Hagemeyer of 3 contacts" led with a bare score nobody
-  // could scale and buried the one fact a rep acts on: who the way in is.
   return (
-    <span title={t("co.pulse.strengthExplain")}>
+    <span>
       {t("co.pulse.strongestLead")}{" "}
       <EntityRef kind="person" id={strength.contributor_person_id} />{" "}
       {t(
         strength.contact_count === 1
           ? "co.pulse.strengthTail.one"
           : "co.pulse.strengthTail.other",
-        { count: strength.contact_count, score: strength.score },
+        { count: strength.contact_count },
       )}
     </span>
   );

--- a/frontend/src/screens/organizations.tsx
+++ b/frontend/src/screens/organizations.tsx
@@ -62,7 +62,6 @@ import {
 import { ListAction, NewDealAction, TagAction } from "./companyactions";
 import { CompanyApprovalsPanel, DecisionsChip } from "./companyapprovals";
 import { TimelineActions } from "./compose";
-import { ConnectionsCard } from "./connections";
 import { CreateAction, type CreateField, type FormRows } from "./create";
 import { CustomFieldsCard } from "./customfields.card";
 import { useObjectCustomFields } from "./customfields.form";
@@ -2153,9 +2152,13 @@ function businessRail({
           }
         />
         <SignalsCard orgId={org.id} />
-        <Disclosure summary={t("co.connections.title")}>
-          <ConnectionsCard orgId={org.id} />
-        </Disclosure>
+        {/* Connections is deliberately not here. It listed the account owner
+            and the same employees the People card already names, against two
+            different strength scales and a bare "2" nobody could read — the
+            page's own answer to a question no reader had asked. The graph read
+            stays (connections.tsx, GET /organizations/{id}/graph): it returns
+            as a per-contact "find a route in", which is the question that IS
+            worth asking, and only where a route actually exists. */}
         <Disclosure summary={t("co.tags.title")}>
           <TagsCard
             view={view}
@@ -2192,9 +2195,6 @@ function businessRail({
   return (
     <>
       <PeopleCard />
-      {/* The connections card reads its own endpoint, so a failed 360 tells it
-          nothing — it still tries, and says so itself if its own read fails. */}
-      <ConnectionsCard orgId={org.id} />
       <DealsCard />
       <SignalsCard orgId={org.id} />
       <TagsCard />

--- a/frontend/src/screens/organizations.tsx
+++ b/frontend/src/screens/organizations.tsx
@@ -103,23 +103,6 @@ import {
 // firmographics card, and timeline stay exactly as they were.
 
 type Organization = components["schemas"]["Organization"];
-type Classification = NonNullable<Organization["classification"]>;
-
-// How the classification column reads to a person. The column stores the
-// enum; printing the enum itself put "prospect" in front of a German reader
-// and told an English one only slightly more. Typed against the schema union,
-// so a value added upstream fails the build here rather than leaking raw.
-const CLASSIFICATION_LABELS: Record<Classification, MessageKey> = {
-  prospect: "org.class.prospect",
-  customer: "org.class.customer",
-  agency: "org.class.agency",
-  reseller: "org.class.reseller",
-  tech_vendor: "org.class.tech_vendor",
-  platform: "org.class.platform",
-  partner: "org.class.partner",
-  competitor: "org.class.competitor",
-  other: "org.class.other",
-};
 
 // Where the account stands with us, and what it is to us (ADR-0079/A124).
 // Typed against the schema unions, so a value added upstream fails the build
@@ -341,11 +324,9 @@ const companyCreateFields: CreateField[] = [
 // The edit form, built per-render because the owner options are the live user
 // roster.
 //
-// Classification is NOT here. `UpdateOrganizationRequest` carries no such
-// field — the value is set by the partner extension and by confirmed
-// proposals — so a select for it would collect an answer and drop it. The
-// badge names the value; changing it needs a contract that does not exist
-// yet (raised in STATUS.md).
+// Stage and relationship types ARE here now: the retired classification could
+// not be edited from anywhere, because the update contract carried no such
+// field.
 // The two vocabularies that replaced classification (ADR-0079/A124): where the
 // account stands with us, and what it is to us. Kept in wire order so the
 // select reads as a progression rather than an alphabet.
@@ -518,12 +499,13 @@ export function CompaniesScreen() {
               },
               {
                 key: "class",
-                header: t("org.classification"),
+                header: t("org.lifecycle"),
+                // classification is retired and no longer written by anything,
+                // so a column reading it would show whatever it happened to
+                // hold when the split shipped, forever.
                 render: (org: Organization) =>
-                  org.classification ? (
-                    <Badge>
-                      {t(CLASSIFICATION_LABELS[org.classification])}
-                    </Badge>
+                  org.lifecycle && org.lifecycle !== "unknown" ? (
+                    <Badge>{t(LIFECYCLE_LABELS[org.lifecycle])}</Badge>
                   ) : null,
               },
               {
@@ -1336,7 +1318,13 @@ function companyTabsFor(
   org: Organization,
   tab: CompanyTab,
 ): readonly CompanyTab[] {
-  return org.partner || tab === "partner"
+  // Gated on the relationship type, not on `org.partner`: the Organization
+  // read does not select the extension row, so that field is always absent
+  // and every partner would lose the tab. The type is equivalent and IS
+  // returned — an org carries it exactly when it has a programme, which the
+  // store enforces in both directions (ADR-0079/A124).
+  const isPartner = (org.relationship_types ?? []).includes("partner");
+  return isPartner || tab === "partner"
     ? COMPANY_TABS
     : (["overview"] as const);
 }
@@ -1532,11 +1520,13 @@ function CompanyActionBadges({
             The tab only shows once there IS one, so without this the first
             partner row would be unreachable — this is the same form, asked
             for rather than offered. */}
-          {writable && !overlay && !org.partner && (
-            <Button small onClick={onSetUpPartner}>
-              {t("org.partnerSetUp")}
-            </Button>
-          )}
+          {writable &&
+            !overlay &&
+            !(org.relationship_types ?? []).includes("partner") && (
+              <Button small onClick={onSetUpPartner}>
+                {t("org.partnerSetUp")}
+              </Button>
+            )}
           {/* The audit spine: who changed this record and when. It reads as an
             inspection of the record rather than part of its story, so it sits
             with the other rare verbs instead of beside the account's own

--- a/frontend/src/screens/people.test.tsx
+++ b/frontend/src/screens/people.test.tsx
@@ -638,7 +638,7 @@ describe("PersonScreen — Relationships tab (P-5)", () => {
     render(<PersonScreen id="p-1" />);
 
     await waitFor(() => expect(screen.getByText("Overview")).toBeTruthy());
-    await userEvent.click(screen.getByText("Relationships"));
+    await userEvent.click(screen.getByText("People & companies"));
 
     await waitFor(() => expect(screen.getByText("Employment")).toBeTruthy());
     expect(screen.getByText("cto")).toBeTruthy();
@@ -668,7 +668,7 @@ describe("PersonScreen — Relationships tab (P-5)", () => {
     });
     render(<PersonScreen id="p-1" />);
     await waitFor(() => expect(screen.getByText("Overview")).toBeTruthy());
-    await userEvent.click(screen.getByText("Relationships"));
+    await userEvent.click(screen.getByText("People & companies"));
     await waitFor(() =>
       expect(screen.getByTestId("add-relationship")).toBeTruthy(),
     );
@@ -721,7 +721,7 @@ describe("PersonScreen — Relationships tab (P-5)", () => {
     });
     render(<PersonScreen id="p-1" />);
     await waitFor(() => expect(screen.getByText("Overview")).toBeTruthy());
-    await userEvent.click(screen.getByText("Relationships"));
+    await userEvent.click(screen.getByText("People & companies"));
     await waitFor(() =>
       expect(screen.getByTestId("remove-relationship")).toBeTruthy(),
     );
@@ -834,7 +834,7 @@ describe("PersonScreen — relationship kinds by scope (P-5)", () => {
     });
     render(<PersonScreen id="p-1" />);
     await waitFor(() => expect(screen.getByText("Overview")).toBeTruthy());
-    await userEvent.click(screen.getByText("Relationships"));
+    await userEvent.click(screen.getByText("People & companies"));
     await waitFor(() =>
       expect(screen.getByTestId("add-relationship")).toBeTruthy(),
     );


### PR DESCRIPTION
Phase 0 of the company-page overhaul: make the page trustworthy before rebuilding it. Spec side is merged — [ADR-0079](https://github.com/gradionhq/margince-foundation/pull/1226) and the [score amendment](https://github.com/gradionhq/margince-foundation/pull/1228).

## The audit that started it

The ScaleCommerce record holds an inbound email ending the contract on 31 July 2026 and a live opportunity with two of its people. The page said **Prospect**, showed **Relationship 2/100**, and claimed **Activity (30d): 0** above a timeline with three messages in it. Every one of those was a different bug.

## What changed

**`classification` is split in two.** It held one value and answered two questions — two of its nine values are stages of a sales motion, six are kinds of company. So `partner` erased whether they buy from us, and there was no churn state at all: an account that ended its contract could only be relabelled by overwriting `customer`. Now `organization.lifecycle` says where the account stands and `organization_relationship_type` says what the company is to us, multi-valued.

The sharpest finding: `classification` was `NOT NULL DEFAULT 'prospect'` and **never had a writer**. ADR-0032 said enrichment would set it; that was never built. So "Prospect" was the column's default rendered as a finding — which is also why this migration carries almost no stored meaning across.

**The partner invariant is enforced instead of described.** ADR-0032 said an org is a partner iff `classification='partner'` and a partner row exists; nothing checked either direction. Both are checked now, in one locked transaction.

**"Activity (30d)" counts what the timeline shows.** It matched only direct organization links while the timeline walks three; since capture files mail against the *person*, a busy account's correspondence never reached the count.

**The header says who wrote last.** `last_inbound_at` and `last_outbound_at`, kept apart — an account we mailed a fortnight ago with no reply and one that wrote this morning share a date and mean opposite things. The 0–100 score is gone: it was PO-F-3's MAX over contacts, so one talkative contact spoke for the whole account. The factors stay computed and shown.

**Enrichment writes show as the columns they changed.** Cold-start and deep-read audited with a metadata bag, so field history rendered pseudo-fields called "source" and "facts" — changes that never happened — while the `legal_name` just written appeared nowhere.

**Smaller ones:** the visit baseline is recorded (nothing ever called `view-ack`, so "first time opening" showed on every visit); Partner is no longer a permanent tab; Connections is gone from the rail; facts whose value contradicts their field say so.

## Review

Codex reviewed the phase before this went up and found two blockers, both since fixed: the invariant only bound one way, and the migration's own backfill created violating rows for old `agency`/`reseller` orgs. The full integration lane caught three more that per-package runs had missed.

## Open decision

`agency`/`reseller`/`tech_vendor`/`platform` map to no relationship type; a human retags them. Mapping them automatically was the original plan and is what created the violating rows, since none of them have a partner programme.

## Gates

`make check` green. `make test-integration` green — 28 packages, 0 skips.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the company page honest. Split “classification” into clear fields, fix activity and header readings, and gate Partner and visit baselines so what you see matches reality.

- New Features
  - New fields: `organization.lifecycle` (single) and `organization_relationship_type` (multi), with migration 0169. Editable on the company form and shown as badges. API/list filters support `lifecycle` and `relationship_type`; `classification` stays one release for compatibility.
  - Header shows last_inbound_at and last_outbound_at instead of a 0–100 score; omitted when the caller lacks activity access.
  - Records a visit baseline after a 5s dwell to power “since your last visit”.
  - Facts that contradict their field show a small suspect badge.
  - UI: Partner tab only when the account is a partner; “Relationships” → “People & companies”; Connections card removed.

- Bug Fixes
  - “Activity (30d)” matches the timeline by walking activity, deal’s org, and contact’s employer; query budget 25 → 27 for the new last-touch section.
  - Field history for enrichment/deep reads shows real column diffs, not pseudo-fields.
  - Partner invariant enforced both ways: a partner must have the programme row and the `partner` relationship type; migration stops auto-tagging `agency`/`reseller` as partners.
  - Merge carries the union of relationship types to the survivor; archive retires them with the org.

<sup>Written for commit 4424424b9787ab1e1c52cf8f27cb998fce92a943. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/371?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Filter organizations by lifecycle and relationship type.
  * Manage lifecycle values and multiple relationship types, including partner status.
  * View inbound and outbound contact timestamps in company summaries.
  * See warnings for potentially contradictory organization facts.
  * Partner tools and tabs now appear only for applicable organizations.
  * Company views are acknowledged automatically after remaining open briefly.

* **Improvements**
  * Activity rollups now include relevant organization, deal, and contact connections without double-counting.
  * Organization merges and updates preserve relationship information more reliably.
  * Company pulse summaries now emphasize strongest contributors and contact counts instead of relationship scores.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->