### PR TITLE
fix(people): the organization name lock has to be as coarse as the tier it guards

### DIFF
--- a/backend/internal/modules/people/renamerecheck.go
+++ b/backend/internal/modules/people/renamerecheck.go
@@ -34,6 +34,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/jackc/pgx/v5"
 
@@ -69,17 +70,12 @@ func recheckOrgNameForDuplicates(ctx context.Context, tx pgx.Tx, orgID ids.Organ
 		return fmt.Errorf("people: reading the renamed organization: %w", err)
 	}
 
-	// Two organizations converging on ONE name concurrently would, at READ
-	// COMMITTED, each read before the other committed, each find nothing, and
-	// both land with no pair filed — the duplicate this whole path exists to
-	// catch, missed by a race. Taking the normalized names as write identities
-	// serializes them, so the second sees the first.
-	//
-	// BOTH axes are locked, because either can be the one that collides: two
-	// records converging on a shared registered name while their display names
-	// stay different is the same race, and locking only the display name would
-	// leave it open. The keys are taken in a fixed order so two renames naming
-	// the same pair in opposite orders cannot deadlock.
+	// Two organizations converging on names that score against each other would,
+	// at READ COMMITTED, each read before the other committed, each find
+	// nothing, and both land with no pair filed — the duplicate this whole path
+	// exists to catch, missed by a race. Both axes are locked, because either
+	// can be the colliding one: two records converging on a shared registered
+	// name while their display names stay different is the same race.
 	if err := lockOrgNameIdentities(ctx, tx, display, legal); err != nil {
 		return err
 	}
@@ -117,12 +113,28 @@ func recheckOrgNameForDuplicates(ctx context.Context, tx pgx.Tx, orgID ids.Organ
 	return nil
 }
 
-// lockOrgNameIdentities takes each distinct normalized name as a write
-// identity, sorted so the order is the same for every caller.
+// lockOrgNameIdentities serializes the writers whose names could score against
+// each other, sorted so the order is the same for every caller and two writers
+// naming the same pair cannot deadlock.
+//
+// The key is the FIRST token of the normalized name, not the whole name. The
+// tier this guards matches on similarity, not equality: "Baqend" and "Baqend
+// Solutions" normalize to different strings yet score well above the threshold,
+// so keying on the whole name would serialize only the exact-equal case and let
+// every other near-match race — which is the shape the guard exists for. Jaro-
+// Winkler weights a shared prefix heavily, so a leading token is the cheap
+// approximation of "could these two score against each other".
+//
+// What it does NOT cover, stated rather than implied: two names that score
+// above the threshold WITHOUT sharing a leading token ("Acme Ltd" against
+// "ACME-Group Ltd" once normalization splits them differently) can still race
+// and both land unfiled. Closing that needs a range lock over a similarity
+// neighbourhood, which an advisory key cannot express — the honest remedy is
+// the nightly sweep, which re-scores everything regardless of how it arrived.
 func lockOrgNameIdentities(ctx context.Context, tx pgx.Tx, names ...string) error {
 	keys := make([]string, 0, len(names))
 	for _, name := range names {
-		if key := NormalizeOrgName(name); key != "" {
+		if key := orgNameLockKey(name); key != "" {
 			keys = append(keys, key)
 		}
 	}
@@ -133,6 +145,21 @@ func lockOrgNameIdentities(ctx context.Context, tx pgx.Tx, names ...string) erro
 		}
 	}
 	return nil
+}
+
+// orgNameLockKey is the leading normalized token of an organization name, or
+// "" when the name carries none.
+//
+// Sharing a first word is not a false grouping: "Acme Logistics" and "Acme
+// Bakery" score 0.76 against each other, above the review threshold, so the
+// tier would file them as a pair anyway. The key groups exactly the records
+// that already have something to say to each other.
+func orgNameLockKey(name string) string {
+	normalized := NormalizeOrgName(name)
+	if normalized == "" {
+		return ""
+	}
+	return strings.Fields(normalized)[0]
 }
 
 // orgPairAlreadyFiled reports whether the queue already holds this pair, in

--- a/backend/internal/modules/people/renamerecheck_test.go
+++ b/backend/internal/modules/people/renamerecheck_test.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+import "testing"
+
+// The lock key has to be coarse enough that two names which SCORE against each
+// other take the same key — otherwise the guard serializes only exact-equal
+// names while the tier it protects matches on similarity, and every near-match
+// still races. Each case below pairs a lock-key expectation with the score the
+// fuzzy tier would give, so the two cannot drift apart silently.
+func TestOrganizationNameLockKeyCoversWhatTheFuzzyTierMatches(t *testing.T) {
+	cases := []struct {
+		name         string
+		left, right  string
+		sameKey      bool
+		wouldCollide bool
+	}{
+		{"legal suffix stripped", "Baqend", "Baqend GmbH", true, true},
+		{"trailing qualifier", "Baqend", "Baqend Solutions", true, true},
+		// Two genuinely different companies, yet the tier scores them 0.76 —
+		// above the threshold. They are a review pair in their own right, so
+		// sharing a lock key costs nothing they were not already going to file.
+		{"different companies sharing a first word", "Acme Logistics", "Acme Bakery", true, true},
+		{"unrelated names", "Baqend", "Zorbatron Heavy Industry", false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			leftKey, rightKey := orgNameLockKey(tc.left), orgNameLockKey(tc.right)
+			if got := leftKey == rightKey; got != tc.sameKey {
+				t.Errorf("same lock key = %v (%q vs %q), want %v", got, leftKey, rightKey, tc.sameKey)
+			}
+			score := nameSimilarity(NormalizeOrgName(tc.left), NormalizeOrgName(tc.right))
+			collides := score >= dedupeReviewThreshold
+			if collides != tc.wouldCollide {
+				t.Errorf("fuzzy score %.4f collides = %v, want %v", score, collides, tc.wouldCollide)
+			}
+			// The invariant the guard rests on: anything the tier would file
+			// must have been serialized first.
+			if collides && leftKey != rightKey {
+				t.Errorf("%q and %q score %.4f (>= %.2f) but take different lock keys %q/%q — "+
+					"the pair can race and both land unfiled",
+					tc.left, tc.right, score, dedupeReviewThreshold, leftKey, rightKey)
+			}
+		})
+	}
+}
+
+// A name that normalizes to nothing takes no lock rather than an empty one:
+// every such create would otherwise serialize on one shared key. A name that
+// is ONLY a legal form keeps it — NormalizeOrgName strips a trailing suffix
+// only when something else remains, so "GmbH" is a name like any other.
+func TestOrganizationNameLockKeyIsEmptyWhenThereIsNoName(t *testing.T) {
+	for _, name := range []string{"", "   "} {
+		if key := orgNameLockKey(name); key != "" {
+			t.Errorf("orgNameLockKey(%q) = %q, want empty", name, key)
+		}
+	}
+}


### PR DESCRIPTION
Follow-up to #372, which merged while this fix was still in progress.

## The defect

#372 added an advisory lock so two creates converging on one company name serialize, and the second sees the first's committed row instead of both scoring `no_match` and landing unfiled.

It keyed on the **whole normalized name**. That serializes only names that normalize *equal* — but the tier it guards matches on **similarity**:

| pair | normalized | same lock key? | fuzzy score |
|---|---|---|---|
| Baqend / Baqend GmbH | `baqend` / `baqend` | yes | 1.00 |
| Baqend / Baqend Solutions | `baqend` / `baqend solutions` | **no** | **0.90** |

So the second pair could still race and both land with no pair on the queue — the exact failure the lock was added to close.

## The fix

The key is now the **leading normalized token**. Jaro-Winkler weights a shared prefix heavily, so a first word is the cheap approximation of "could these two score against each other".

Sharing a first word is not a false grouping: "Acme Logistics" and "Acme Bakery" score **0.76**, above the threshold, so the tier would file them as a pair anyway. The key groups exactly the records that already have something to say to each other.

## What it still does not cover

Stated in the code rather than implied: two names scoring above the threshold *without* sharing a leading token can race and both land unfiled. An advisory key cannot express a range lock over a similarity neighbourhood. The remedy is the nightly sweep (the planned follow-up), which re-scores everything regardless of how it arrived.

## Test

`renamerecheck_test.go` pins the invariant rather than the implementation: for each pair it asserts both the lock key and the fuzzy score, and fails when a pair scoring above the threshold takes different keys. Writing it caught two wrong assumptions of mine — that "Acme Logistics"/"Acme Bakery" score below the threshold (they don't), and that a name which is only a legal form normalizes away (`NormalizeOrgName` strips a trailing suffix only when something else remains, so "GmbH" is a name like any other).

## Verification

- `make check` — green
- `make test-integration` — `OK: integration passed with 0 skips (28 packages)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make org-name locking match the similarity-based dedupe tier to prevent races. We now lock by the first normalized token so near-matches serialize and don’t land unfiled.

- **Bug Fixes**
  - Use the leading normalized token as the advisory lock key for display and legal names, ordered to avoid deadlocks.
  - Add tests in `renamerecheck_test.go` that pin the lock-key invariant against fuzzy scores and cover empty/whitespace names.

<sup>Written for commit 36ffa5e8705ca4b8b5e16aeaf00c9caf11fc7a13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

