### PR TITLE
fix(jobs): one workspace arg, one spelling, so a null means what it says

### DIFF
--- a/backend/internal/compose/capturejobs.go
+++ b/backend/internal/compose/capturejobs.go
@@ -243,7 +243,7 @@ func (w *captureDigestWorkspaceWorker) Work(ctx context.Context, job *river.Job[
 // CaptureBackfillArgs pages ONE bounded backfill run (ADR-0063). Unique by
 // args while incomplete: start and any retry converge on one job.
 type CaptureBackfillArgs struct {
-	Workspace  ids.UUID `json:"workspace"`
+	Workspace  ids.UUID `json:"workspace_id"`
 	BackfillID string   `json:"backfill_id"`
 }
 

--- a/backend/internal/compose/commsjobs.go
+++ b/backend/internal/compose/commsjobs.go
@@ -36,7 +36,7 @@ import (
 // because comms_outbound is RLS-scoped and a job carries no session: the
 // worker binds this workspace before the dispatcher reads anything.
 type SendEmailArgs struct {
-	Workspace  ids.UUID `json:"workspace"`
+	Workspace  ids.UUID `json:"workspace_id"`
 	DeliveryID string   `json:"delivery_id"`
 }
 

--- a/backend/internal/compose/embedreindextransport.go
+++ b/backend/internal/compose/embedreindextransport.go
@@ -60,8 +60,13 @@ type embedReindexArgs struct {
 // Kind is the stable job identifier River persists in river_job.
 func (embedReindexArgs) Kind() string { return "embed_reindex" }
 
-// FleetWide marks this a dispatcher: it enumerates and enqueues,
-// and does no tenant work of its own (jobs.FleetWide).
+// FleetWide marks this fleet-wide and single-flight (jobs.FleetWide) — and
+// this kind is that marker's ONE named exception rather than a dispatcher: it
+// re-embeds every workspace's corpus inside a single row, binding each
+// workspace before it writes, so the writes are scoped even though there is no
+// row per workspace to fail as. Do not read it as precedent — a new fleet-wide
+// worker that writes is the shape jobs.FleetWide exists to name, and belongs
+// behind a per-workspace fan-out.
 func (embedReindexArgs) FleetWide() {}
 
 // errReindexAlreadyRunning signals the confirm callback's own unique-skip

--- a/backend/internal/compose/integration/jobwireformat_integration_test.go
+++ b/backend/internal/compose/integration/jobwireformat_integration_test.go
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// What River's encoder actually writes into river_job.args, read back off a
+// real Postgres.
+//
+// The struct-tag gate over the args types reads tag TEXT and stops there. It
+// cannot see a marshaled row, and the per-workspace reads of the job table
+// select `args->>'workspace_id'` rather than the Go field — so a tag the gate
+// approves and an encoder that ships some other key would both read green
+// while the query returned null for work a tenant really did.
+//
+// The claim is a biconditional: a non-null workspace_id means tenant work, a
+// null means a dispatcher. A dispatcher therefore rides in the same batch. A
+// test that only checked the key appears would pass on a system that shipped
+// it everywhere, which is the failure that lets a fleet fan-out be counted as
+// one workspace's pass.
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/platform/jobs"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// workspaceKeysOnTheWire reads each job enqueued above the given high-water
+// mark as kind → the workspace_id its args ship, nil when the key is absent.
+// The extraction is the production shape — the text operator the later
+// per-workspace queries use, not a decode back into the Go struct, which would
+// agree with itself whatever key the encoder chose. river_job is not
+// workspace-scoped, so it is read off the pool directly.
+func workspaceKeysOnTheWire(t *testing.T, e *Env, highWater int64) map[string]*string {
+	t.Helper()
+	rows, err := e.Pool.Query(context.Background(),
+		`SELECT kind, args->>'workspace_id' FROM river_job WHERE id > $1`, highWater)
+	if err != nil {
+		t.Fatalf("reading back the enqueued jobs: %v", err)
+	}
+	type wireRow struct {
+		Kind      string
+		Workspace *string
+	}
+	wire, err := pgx.CollectRows(rows, pgx.RowToStructByPos[wireRow])
+	if err != nil {
+		t.Fatalf("collecting the enqueued jobs: %v", err)
+	}
+	onWire := make(map[string]*string, len(wire))
+	for _, row := range wire {
+		if _, duplicate := onWire[row.Kind]; duplicate {
+			t.Fatalf("kind %s landed twice in one batch — one of the two would be hidden by the kind-keyed lookup", row.Kind)
+		}
+		onWire[row.Kind] = row.Workspace
+	}
+	return onWire
+}
+
+func TestRiverShipsTheWorkspaceUnderTheKeyThePerWorkspaceReadsSelect(t *testing.T) {
+	e := Setup(t)
+	ensureRiverSchema(t)
+	inserter, err := jobs.NewInserter(e.Pool, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err != nil {
+		t.Fatalf("jobs.NewInserter: %v", err)
+	}
+	ctx := context.Background()
+
+	// Every kind carries a DISTINCT workspace, so the assertion is that the
+	// value read back for a kind is the value that kind was enqueued with.
+	// Sharing one id across the batch would still hold if the encoder emitted
+	// a neighbouring row's workspace, and a non-null check alone would hold
+	// for the zero UUID — the two ways a workspace key can be present and
+	// still mean nothing.
+	tenantJobs := []jobs.WorkspaceScoped{
+		compose.SendEmailArgs{Workspace: ids.NewV7(), DeliveryID: ids.NewV7().String()},
+		compose.CaptureBackfillArgs{Workspace: ids.NewV7(), BackfillID: ids.NewV7().String()},
+		compose.TelegramIngestArgs{
+			Workspace: ids.NewV7(), ConnectionID: ids.NewV7().String(),
+			BotID: "bot", RawCaptureID: ids.NewV7().String(),
+		},
+		compose.TelegramPollArgs{Workspace: ids.NewV7(), ConnectionID: ids.NewV7().String()},
+		compose.VoiceBuildArgs{
+			Workspace: ids.NewV7(), ProfileID: ids.NewV7().String(),
+			BuildID: ids.NewV7().String(), RequestedBy: "human:" + e.Rep1.String(),
+		},
+		compose.CaptureSyncArgs{
+			Workspace: ids.NewV7(), ConnectionID: ids.NewV7().String(), Provider: "gmail",
+		},
+		compose.OverlayRefetchArgs{
+			Workspace: ids.NewV7(), IncumbentClass: "hubspot", ExternalID: ids.NewV7().String(),
+		},
+	}
+	dispatcher := jobs.FleetWide(compose.TelegramPollSweepArgs{})
+
+	// river_job is not workspace-scoped and River assigns its ids, so the batch
+	// is fenced by the table's high-water mark rather than by a workspace tx or
+	// a truncate: another suite's leftover rows in this process would otherwise
+	// answer a query keyed on kind alone.
+	var highWater int64
+	if err := e.Pool.QueryRow(ctx, `SELECT coalesce(max(id), 0) FROM river_job`).Scan(&highWater); err != nil {
+		t.Fatalf("reading the river_job high-water mark: %v", err)
+	}
+
+	for _, args := range tenantJobs {
+		if err := inserter.Enqueue(ctx, args, nil); err != nil {
+			t.Fatalf("enqueueing %s: %v", args.Kind(), err)
+		}
+	}
+	if err := inserter.Enqueue(ctx, dispatcher, nil); err != nil {
+		t.Fatalf("enqueueing %s: %v", dispatcher.Kind(), err)
+	}
+
+	onWire := workspaceKeysOnTheWire(t, e, highWater)
+	if len(onWire) != len(tenantJobs)+1 {
+		t.Fatalf("river_job holds %d of this batch's kinds, want %d — an insert that never landed would make every assertion below vacuous", len(onWire), len(tenantJobs)+1)
+	}
+
+	for _, args := range tenantJobs {
+		got, present := onWire[args.Kind()]
+		if !present {
+			t.Errorf("%s: no row landed for this kind", args.Kind())
+			continue
+		}
+		if got == nil {
+			t.Errorf("%s: args->>'workspace_id' is null — the tenant this job was enqueued for (%s) is invisible to every per-workspace read of river_job, which reads the null as a dispatcher rather than as work it cannot see", args.Kind(), args.WorkspaceID())
+			continue
+		}
+		if want := args.WorkspaceID().String(); *got != want {
+			t.Errorf("%s: args->>'workspace_id' = %q, want %q — the wire carries a different tenant than the args the job was enqueued with", args.Kind(), *got, want)
+		}
+	}
+
+	if got, present := onWire[dispatcher.Kind()]; !present {
+		t.Errorf("%s: no row landed for the dispatcher, so the null half of the invariant went unchecked", dispatcher.Kind())
+	} else if got != nil {
+		t.Errorf("%s: args->>'workspace_id' = %q, want null — a dispatcher enumerates the fleet and does no tenant work, so a workspace on its row is counted as a pass some tenant never got", dispatcher.Kind(), *got)
+	}
+}

--- a/backend/internal/compose/integration/jobwireformat_integration_test.go
+++ b/backend/internal/compose/integration/jobwireformat_integration_test.go
@@ -9,10 +9,11 @@ package integration
 // real Postgres.
 //
 // The struct-tag gate over the args types reads tag TEXT and stops there. It
-// cannot see a marshaled row, and the per-workspace reads of the job table
-// select `args->>'workspace_id'` rather than the Go field — so a tag the gate
-// approves and an encoder that ships some other key would both read green
-// while the query returned null for work a tenant really did.
+// cannot see a marshaled row, and the per-workspace reads of the job table are
+// built later in this phase and will select `args->>'workspace_id'` rather than
+// the Go field — so a tag the gate approves and an encoder that ships some
+// other key would both read green while that query returned null for work a
+// tenant really did.
 //
 // The claim is a biconditional: a non-null workspace_id means tenant work, a
 // null means a dispatcher. A dispatcher therefore rides in the same batch. A
@@ -39,9 +40,9 @@ import (
 // per-workspace queries use, not a decode back into the Go struct, which would
 // agree with itself whatever key the encoder chose. river_job is not
 // workspace-scoped, so it is read off the pool directly.
-func workspaceKeysOnTheWire(t *testing.T, e *Env, highWater int64) map[string]*string {
+func workspaceKeysOnTheWire(ctx context.Context, t *testing.T, e *Env, highWater int64) map[string]*string {
 	t.Helper()
-	rows, err := e.Pool.Query(context.Background(),
+	rows, err := e.Pool.Query(ctx,
 		`SELECT kind, args->>'workspace_id' FROM river_job WHERE id > $1`, highWater)
 	if err != nil {
 		t.Fatalf("reading back the enqueued jobs: %v", err)
@@ -66,7 +67,7 @@ func workspaceKeysOnTheWire(t *testing.T, e *Env, highWater int64) map[string]*s
 
 func TestRiverShipsTheWorkspaceUnderTheKeyThePerWorkspaceReadsSelect(t *testing.T) {
 	e := Setup(t)
-	ensureRiverSchema(t)
+	ApplyRiverSchema(t)
 	inserter, err := jobs.NewInserter(e.Pool, slog.New(slog.NewTextHandler(io.Discard, nil)))
 	if err != nil {
 		t.Fatalf("jobs.NewInserter: %v", err)
@@ -100,10 +101,12 @@ func TestRiverShipsTheWorkspaceUnderTheKeyThePerWorkspaceReadsSelect(t *testing.
 	}
 	dispatcher := jobs.FleetWide(compose.TelegramPollSweepArgs{})
 
-	// river_job is not workspace-scoped and River assigns its ids, so the batch
-	// is fenced by the table's high-water mark rather than by a workspace tx or
-	// a truncate: another suite's leftover rows in this process would otherwise
-	// answer a query keyed on kind alone.
+	// The high-water mark fences the read to rows THIS test inserted. river_job
+	// is not workspace-scoped, so there is no tenant predicate to narrow a
+	// kind-keyed query with, and the fence is what makes the assertions
+	// independent of whether the table arrived empty — an emptiness the reset
+	// grants only as a side effect of river_job being an ordinary public table
+	// on its list, not as anything the job substrate promises.
 	var highWater int64
 	if err := e.Pool.QueryRow(ctx, `SELECT coalesce(max(id), 0) FROM river_job`).Scan(&highWater); err != nil {
 		t.Fatalf("reading the river_job high-water mark: %v", err)
@@ -118,7 +121,7 @@ func TestRiverShipsTheWorkspaceUnderTheKeyThePerWorkspaceReadsSelect(t *testing.
 		t.Fatalf("enqueueing %s: %v", dispatcher.Kind(), err)
 	}
 
-	onWire := workspaceKeysOnTheWire(t, e, highWater)
+	onWire := workspaceKeysOnTheWire(ctx, t, e, highWater)
 	if len(onWire) != len(tenantJobs)+1 {
 		t.Fatalf("river_job holds %d of this batch's kinds, want %d — an insert that never landed would make every assertion below vacuous", len(onWire), len(tenantJobs)+1)
 	}

--- a/backend/internal/compose/integration/jobwireformat_integration_test.go
+++ b/backend/internal/compose/integration/jobwireformat_integration_test.go
@@ -8,12 +8,14 @@ package integration
 // What River's encoder actually writes into river_job.args, read back off a
 // real Postgres.
 //
-// The struct-tag gate over the args types reads tag TEXT and stops there. It
-// cannot see a marshaled row, and the per-workspace reads of the job table are
-// built later in this phase and will select `args->>'workspace_id'` rather than
-// the Go field — so a tag the gate approves and an encoder that ships some
-// other key would both read green while that query returned null for work a
-// tenant really did.
+// A per-workspace read of river_job selects `args->>'workspace_id'` — the
+// encoded row, not the decoded Go struct, which would agree with itself
+// whatever key the encoder chose. The struct-tag gate over the args types
+// reads tag TEXT and stops there, so a tag that gate approves and an encoder
+// that shipped some other key would BOTH read green while that query returned
+// null for work a tenant really did. No such read exists in the tree to catch
+// it, which is why the wire is asserted here directly rather than through a
+// consumer.
 //
 // The claim is a biconditional: a non-null workspace_id means tenant work, a
 // null means a dispatcher. A dispatcher therefore rides in the same batch. A
@@ -65,7 +67,7 @@ func workspaceKeysOnTheWire(ctx context.Context, t *testing.T, e *Env, highWater
 	return onWire
 }
 
-func TestRiverShipsTheWorkspaceUnderTheKeyThePerWorkspaceReadsSelect(t *testing.T) {
+func TestRiverEncodesTheWorkspaceArgAsWorkspaceIDAndOmitsItOnADispatcher(t *testing.T) {
 	e := Setup(t)
 	ApplyRiverSchema(t)
 	inserter, err := jobs.NewInserter(e.Pool, slog.New(slog.NewTextHandler(io.Discard, nil)))

--- a/backend/internal/compose/jobs_capture.go
+++ b/backend/internal/compose/jobs_capture.go
@@ -86,7 +86,7 @@ func (w *gmailSyncWorker) Work(ctx context.Context, _ *river.Job[GmailSyncArgs])
 // the dispatcher and the (future) push webhook can both enqueue without
 // double-running a mailbox.
 type CaptureSyncArgs struct {
-	Workspace    ids.UUID `json:"workspace"`
+	Workspace    ids.UUID `json:"workspace_id"`
 	ConnectionID string   `json:"connection_id"`
 	Provider     string   `json:"provider"`
 }

--- a/backend/internal/compose/jobs_overlay_refetch.go
+++ b/backend/internal/compose/jobs_overlay_refetch.go
@@ -34,7 +34,7 @@ import (
 // ONE re-fetch rather than N. IncumbentClass is the HubSpot object class
 // (contacts/companies/deals/leads); ExternalID is the mirror external id.
 type OverlayRefetchArgs struct {
-	Workspace      ids.UUID `json:"workspace"`
+	Workspace      ids.UUID `json:"workspace_id"`
 	IncumbentClass string   `json:"incumbent_class"`
 	ExternalID     string   `json:"external_id"`
 }

--- a/backend/internal/compose/telegramingest.go
+++ b/backend/internal/compose/telegramingest.go
@@ -55,7 +55,7 @@ import (
 // re-delivery of one update resolves to the same raw row and therefore the same
 // bot.
 type TelegramIngestArgs struct {
-	Workspace ids.UUID `json:"workspace"`
+	Workspace ids.UUID `json:"workspace_id"`
 	// ConnectionID names which connection read the update. The worker resolves
 	// nothing from it — that is the point of BotID — but it is the operational link
 	// between a queued job and the connection an operator is looking at, and the

--- a/backend/internal/compose/telegrampoll.go
+++ b/backend/internal/compose/telegrampoll.go
@@ -114,7 +114,7 @@ func (TelegramPollSweepArgs) FleetWide() {}
 // because a job queue is not a request and carries no tenant to inherit; the
 // cursor deliberately does not, because it moves (see LoadChannelPollTarget).
 type TelegramPollArgs struct {
-	Workspace    ids.UUID `json:"workspace"`
+	Workspace    ids.UUID `json:"workspace_id"`
 	ConnectionID string   `json:"connection_id"`
 }
 

--- a/backend/internal/compose/voicebuild.go
+++ b/backend/internal/compose/voicebuild.go
@@ -32,7 +32,7 @@ import (
 // incomplete: the api enqueue and the deferred-retry sweep converge on one
 // job per build row.
 type VoiceBuildArgs struct {
-	Workspace   ids.UUID `json:"workspace"`
+	Workspace   ids.UUID `json:"workspace_id"`
 	ProfileID   string   `json:"profile_id"`
 	BuildID     string   `json:"build_id"`
 	RequestedBy string   `json:"requested_by"`

--- a/backend/internal/platform/jobs/role.go
+++ b/backend/internal/platform/jobs/role.go
@@ -16,12 +16,17 @@ import (
 //
 // The accessor is WorkspaceID rather than a bare field because Go forbids a
 // method and a field of the same name, so implementations hold the value in a
-// `Workspace ids.UUID` field. The WIRE key is whatever that kind already
-// shipped with: a kind enqueued exactly once (a staged send, a backfill run, a
-// raw capture's ingest) has rows sitting in the queue across a deploy, and
-// renaming its key would decode them to a zero workspace that the binding then
-// refuses on every attempt — stranding the domain row those jobs exist to
-// advance. New kinds use `workspace_id`.
+// `Workspace ids.UUID` field, wired as `json:"workspace_id"` — one spelling on
+// every kind, held there by
+// TestEveryWorkspaceScopedArgsSpellsItsWorkspaceKeyTheSameWay. A kind that
+// spelled it differently would be invisible to `args->>'workspace_id'`, and a
+// per-workspace read of river_job would report it as no work at all rather
+// than as work the query cannot see.
+//
+// That read is not yet exact in the other direction: embed_reindex does tenant
+// work under the FleetWide marker (see below) and carries no workspace at all,
+// so a null in that column means "a dispatcher, OR embed_reindex" until it is
+// fanned out. One kind, named, not a class.
 type WorkspaceScoped interface {
 	river.JobArgs
 	WorkspaceID() ids.UUID

--- a/backend/jobwirekey_test.go
+++ b/backend/jobwirekey_test.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package backendarch
+
+// One workspace arg, one spelling, and only where it means something. A kind
+// that carries its tenant under a different wire key is invisible to
+// `args->>'workspace_id'`; a dispatcher that carries one is counted as a
+// tenant's pass it never made. Both directions have to hold, because the reads
+// built on this treat a non-null workspace_id as "this job did tenant work" and
+// a null as "a dispatcher" — and in each failure the wrong answer looks exactly
+// like the reassuring one, which is why this is a gate and not a convention.
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// workspaceArgFloor guards against a vacuous pass. This gate only reports on
+// the types it FINDS, so a walker that matched nothing would read green. The
+// tree holds 26 workspace-scoped kinds today; the floor only has to be low
+// enough never to false-alarm and high enough to catch a walker that broke.
+const workspaceArgFloor = 20
+
+// The ONE field name, type, and wire key every workspace-scoped args type
+// carries. The FIELD is `Workspace` because Go forbids a field and a method of
+// the same name and the accessor is WorkspaceID(); the KEY is `workspace_id`
+// because `args->>'workspace_id'` has to be total over tenant jobs.
+const (
+	workspaceArgField = "Workspace"
+	workspaceArgType  = "ids.UUID"
+	workspaceArgKey   = "workspace_id"
+)
+
+func TestEveryWorkspaceScopedArgsSpellsItsWorkspaceKeyTheSameWay(t *testing.T) {
+	dir := filepath.Join("internal", "compose")
+	byType := methodsByType(t, dir)
+	fset, files := parseGoFilesUnder(t, dir)
+
+	checked := 0
+	for _, file := range files {
+		for _, decl := range file.Decls {
+			gen, ok := decl.(*ast.GenDecl)
+			if !ok {
+				continue
+			}
+			for _, spec := range gen.Specs {
+				typeSpec, ok := spec.(*ast.TypeSpec)
+				if !ok {
+					continue
+				}
+				// Kind() is what makes a type River job args. Filtering on the
+				// role method alone would drag any unrelated compose type that
+				// happens to expose WorkspaceID() into the args shape and fail
+				// it for a rule it was never under.
+				methods := byType[typeSpec.Name.Name]
+				if !methods["Kind"] {
+					continue
+				}
+				scoped, fleet := methods["WorkspaceID"], methods["FleetWide"]
+				if !scoped && !fleet {
+					continue // jobrole_test.go owns "declares a role at all".
+				}
+				pos := fset.Position(typeSpec.Pos())
+				structType, ok := typeSpec.Type.(*ast.StructType)
+				if !ok {
+					t.Errorf("%s:%d: %s declares a job role but is not a struct — River marshals args to a JSON object, and a non-object carries no workspace_id at all.",
+						pos.Filename, pos.Line, typeSpec.Name.Name)
+					continue
+				}
+				if scoped {
+					checked++
+					assertWorkspaceArg(t, fset, typeSpec.Name.Name, structType)
+					continue
+				}
+				assertNoWorkspaceArg(t, fset, typeSpec.Name.Name, structType)
+			}
+		}
+	}
+	if checked < workspaceArgFloor {
+		t.Fatalf("inspected only %d workspace-scoped args types, expected at least %d — the walker matched nothing and this gate would pass vacuously", checked, workspaceArgFloor)
+	}
+}
+
+// assertWorkspaceArg checks one args struct carries its workspace under the
+// sanctioned name, type, and wire key.
+func assertWorkspaceArg(t *testing.T, fset *token.FileSet, typeName string, structType *ast.StructType) {
+	t.Helper()
+	for _, field := range structType.Fields.List {
+		for _, name := range field.Names {
+			if name.Name != workspaceArgField {
+				continue
+			}
+			pos := fset.Position(field.Pos())
+			if got := types.ExprString(field.Type); got != workspaceArgType {
+				t.Errorf("%s:%d: %s.%s is %s, want %s — workspaceJobCtx binds one type.",
+					pos.Filename, pos.Line, typeName, workspaceArgField, got, workspaceArgType)
+			}
+			if field.Tag == nil {
+				t.Errorf("%s:%d: %s.%s carries no struct tag, want `json:%q` — an untagged field ships as %q and args->>'workspace_id' misses it.",
+					pos.Filename, pos.Line, typeName, workspaceArgField, workspaceArgKey, workspaceArgField)
+				return
+			}
+			if got := jsonKey(field); got != workspaceArgKey {
+				t.Errorf("%s:%d: %s.%s ships as json:%q, want json:%q — a divergent key is invisible to args->>'workspace_id', and a null there reads as a dispatcher rather than as tenant work the query cannot see.",
+					pos.Filename, pos.Line, typeName, workspaceArgField, got, workspaceArgKey)
+			}
+			return
+		}
+	}
+	t.Errorf("%s declares WorkspaceID() but has no %s field — the accessor has to return something the wire carries.", typeName, workspaceArgField)
+}
+
+// assertNoWorkspaceArg holds the other half: a dispatcher does no tenant work,
+// so it must not ship the key that says it did.
+func assertNoWorkspaceArg(t *testing.T, fset *token.FileSet, typeName string, structType *ast.StructType) {
+	t.Helper()
+	for _, field := range structType.Fields.List {
+		if jsonKey(field) != workspaceArgKey {
+			continue
+		}
+		pos := fset.Position(field.Pos())
+		t.Errorf("%s:%d: %s is a dispatcher (it declares FleetWide()) but ships a json:%q key — a non-null workspace_id has to mean tenant work, or a per-workspace read of river_job counts a fan-out as a tenant's pass.",
+			pos.Filename, pos.Line, typeName, workspaceArgKey)
+	}
+}
+
+// jsonKey returns a field's wire name, dropping the `,omitempty`-style options
+// that would otherwise make an equality check miss.
+func jsonKey(field *ast.Field) string {
+	if field.Tag == nil {
+		return ""
+	}
+	tag := reflect.StructTag(strings.Trim(field.Tag.Value, "`")).Get("json")
+	name, _, _ := strings.Cut(tag, ",")
+	return name
+}

--- a/backend/jobwirekey_test.go
+++ b/backend/jobwirekey_test.go
@@ -17,15 +17,28 @@ import (
 	"go/types"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 )
 
-// workspaceArgFloor guards against a vacuous pass. This gate only reports on
-// the types it FINDS, so a walker that matched nothing would read green. The
-// tree holds 26 workspace-scoped kinds today; the floor only has to be low
-// enough never to false-alarm and high enough to catch a walker that broke.
+// workspaceArgFloor guards against a vacuous pass on the scoped side. This
+// gate only reports on the types it FINDS, so a walker that matched nothing
+// would read green. The tree holds 26 workspace-scoped kinds today; the floor
+// only has to be low enough never to false-alarm and high enough to catch a
+// walker that broke.
 const workspaceArgFloor = 20
+
+// dispatcherArgFloor is workspaceArgFloor's other half. assertNoWorkspaceArg
+// only runs on types the walker routes to it as FleetWide; if a future
+// receiver shape (an embedded marker, a generic receiver, a rename) stops
+// methodsByType from seeing FleetWide(), those types fall into "declares
+// neither role" and are skipped entirely — checked (the scoped count) stays
+// unaffected and reads plausible while the dispatcher half is inspected zero
+// times. The tree holds 20 FleetWide kinds today; same reasoning as
+// workspaceArgFloor: low enough never to false-alarm, high enough to catch a
+// broken walker.
+const dispatcherArgFloor = 15
 
 // The ONE field name, type, and wire key every workspace-scoped args type
 // carries. The FIELD is `Workspace` because Go forbids a field and a method of
@@ -42,7 +55,7 @@ func TestEveryWorkspaceScopedArgsSpellsItsWorkspaceKeyTheSameWay(t *testing.T) {
 	byType := methodsByType(t, dir)
 	fset, files := parseGoFilesUnder(t, dir)
 
-	checked := 0
+	checked, dispatcherChecked := 0, 0
 	for _, file := range files {
 		for _, decl := range file.Decls {
 			gen, ok := decl.(*ast.GenDecl)
@@ -78,12 +91,16 @@ func TestEveryWorkspaceScopedArgsSpellsItsWorkspaceKeyTheSameWay(t *testing.T) {
 					assertWorkspaceArg(t, fset, typeSpec.Name.Name, structType)
 					continue
 				}
+				dispatcherChecked++
 				assertNoWorkspaceArg(t, fset, typeSpec.Name.Name, structType)
 			}
 		}
 	}
 	if checked < workspaceArgFloor {
 		t.Fatalf("inspected only %d workspace-scoped args types, expected at least %d — the walker matched nothing and this gate would pass vacuously", checked, workspaceArgFloor)
+	}
+	if dispatcherChecked < dispatcherArgFloor {
+		t.Fatalf("inspected only %d dispatcher (FleetWide) args types, expected at least %d — the walker matched nothing on the dispatcher side and this gate would pass vacuously", dispatcherChecked, dispatcherArgFloor)
 	}
 }
 
@@ -106,7 +123,7 @@ func assertWorkspaceArg(t *testing.T, fset *token.FileSet, typeName string, stru
 					pos.Filename, pos.Line, typeName, workspaceArgField, workspaceArgKey, workspaceArgField)
 				return
 			}
-			if got := jsonKey(field); got != workspaceArgKey {
+			if got := jsonKey(t, fset, typeName, field); got != workspaceArgKey {
 				t.Errorf("%s:%d: %s.%s ships as json:%q, want json:%q — a divergent key is invisible to args->>'workspace_id', and a null there reads as a dispatcher rather than as tenant work the query cannot see.",
 					pos.Filename, pos.Line, typeName, workspaceArgField, got, workspaceArgKey)
 			}
@@ -121,7 +138,18 @@ func assertWorkspaceArg(t *testing.T, fset *token.FileSet, typeName string, stru
 func assertNoWorkspaceArg(t *testing.T, fset *token.FileSet, typeName string, structType *ast.StructType) {
 	t.Helper()
 	for _, field := range structType.Fields.List {
-		if jsonKey(field) != workspaceArgKey {
+		if len(field.Names) == 0 {
+			// encoding/json flattens an embedded field's own fields into the
+			// marshaled object, but this walker only reads declared fields —
+			// it cannot see into another package's type to know whether the
+			// embedded type carries a workspace_id. Require the field
+			// declared here instead of resolving through it.
+			pos := fset.Position(field.Pos())
+			t.Errorf("%s:%d: %s embeds %s — a dispatcher's args must declare their fields, not embed them, because this gate reads declared fields and cannot see through an embedded type to a workspace key it might carry.",
+				pos.Filename, pos.Line, typeName, types.ExprString(field.Type))
+			continue
+		}
+		if jsonKey(t, fset, typeName, field) != workspaceArgKey {
 			continue
 		}
 		pos := fset.Position(field.Pos())
@@ -131,12 +159,22 @@ func assertNoWorkspaceArg(t *testing.T, fset *token.FileSet, typeName string, st
 }
 
 // jsonKey returns a field's wire name, dropping the `,omitempty`-style options
-// that would otherwise make an equality check miss.
-func jsonKey(field *ast.Field) string {
+// that would otherwise make an equality check miss. strconv.Unquote handles
+// both a raw-string tag and a quoted-string tag — trimming backticks alone
+// would silently misparse the second spelling into an empty key, which on the
+// dispatcher side reads as "no workspace_id" for a field that ships one.
+func jsonKey(t *testing.T, fset *token.FileSet, typeName string, field *ast.Field) string {
+	t.Helper()
 	if field.Tag == nil {
 		return ""
 	}
-	tag := reflect.StructTag(strings.Trim(field.Tag.Value, "`")).Get("json")
+	raw, err := strconv.Unquote(field.Tag.Value)
+	if err != nil {
+		pos := fset.Position(field.Tag.Pos())
+		t.Fatalf("%s:%d: %s's struct tag %s will not unquote: %v — a tag this gate cannot parse is a tag it cannot verify.",
+			pos.Filename, pos.Line, typeName, field.Tag.Value, err)
+	}
+	tag := reflect.StructTag(raw).Get("json")
 	name, _, _ := strings.Cut(tag, ",")
 	return name
 }

--- a/backend/jobwirekey_test.go
+++ b/backend/jobwirekey_test.go
@@ -105,32 +105,58 @@ func TestEveryWorkspaceScopedArgsSpellsItsWorkspaceKeyTheSameWay(t *testing.T) {
 }
 
 // assertWorkspaceArg checks one args struct carries its workspace under the
-// sanctioned name, type, and wire key.
+// sanctioned name, type, and wire key — and carries it exactly ONCE. Stopping
+// at the first field that looks right would miss the second field claiming the
+// same key, which is the one way a type can satisfy every per-field rule here
+// and still ship no workspace at all.
 func assertWorkspaceArg(t *testing.T, fset *token.FileSet, typeName string, structType *ast.StructType) {
 	t.Helper()
+	carriers, declared := 0, false
 	for _, field := range structType.Fields.List {
-		for _, name := range field.Names {
-			if name.Name != workspaceArgField {
-				continue
-			}
-			pos := fset.Position(field.Pos())
-			if got := types.ExprString(field.Type); got != workspaceArgType {
-				t.Errorf("%s:%d: %s.%s is %s, want %s — workspaceJobCtx binds one type.",
-					pos.Filename, pos.Line, typeName, workspaceArgField, got, workspaceArgType)
-			}
-			if field.Tag == nil {
-				t.Errorf("%s:%d: %s.%s carries no struct tag, want `json:%q` — an untagged field ships as %q and args->>'workspace_id' misses it.",
-					pos.Filename, pos.Line, typeName, workspaceArgField, workspaceArgKey, workspaceArgField)
-				return
-			}
-			if got := jsonKey(t, fset, typeName, field); got != workspaceArgKey {
-				t.Errorf("%s:%d: %s.%s ships as json:%q, want json:%q — a divergent key is invisible to args->>'workspace_id', and a null there reads as a dispatcher rather than as tenant work the query cannot see.",
-					pos.Filename, pos.Line, typeName, workspaceArgField, got, workspaceArgKey)
-			}
-			return
+		if jsonKey(t, fset, typeName, field) == workspaceArgKey {
+			carriers++
+		}
+		if !declaresName(field, workspaceArgField) {
+			continue
+		}
+		declared = true
+		pos := fset.Position(field.Pos())
+		if got := types.ExprString(field.Type); got != workspaceArgType {
+			t.Errorf("%s:%d: %s.%s is %s, want %s — workspaceJobCtx binds one type.",
+				pos.Filename, pos.Line, typeName, workspaceArgField, got, workspaceArgType)
+		}
+		if field.Tag == nil {
+			t.Errorf("%s:%d: %s.%s carries no struct tag, want `json:%q` — an untagged field ships as %q and args->>'workspace_id' misses it.",
+				pos.Filename, pos.Line, typeName, workspaceArgField, workspaceArgKey, workspaceArgField)
+			continue
+		}
+		if got := jsonKey(t, fset, typeName, field); got != workspaceArgKey {
+			t.Errorf("%s:%d: %s.%s ships as json:%q, want json:%q — a divergent key is invisible to args->>'workspace_id', and a null there reads as a dispatcher rather than as tenant work the query cannot see.",
+				pos.Filename, pos.Line, typeName, workspaceArgField, got, workspaceArgKey)
 		}
 	}
-	t.Errorf("%s declares WorkspaceID() but has no %s field — the accessor has to return something the wire carries.", typeName, workspaceArgField)
+
+	pos := fset.Position(structType.Pos())
+	if !declared {
+		t.Errorf("%s:%d: %s declares WorkspaceID() but declares no %s field — an embedded type does not count, because this gate reads declared fields; want `%s %s` tagged json:%q, since the accessor has to return something the wire carries.",
+			pos.Filename, pos.Line, typeName, workspaceArgField, workspaceArgField, workspaceArgType, workspaceArgKey)
+	}
+	if carriers > 1 {
+		t.Errorf("%s:%d: %s declares %d fields under json:%q, want exactly one — encoding/json drops ALL of a set of conflicting fields at the same depth, so this type would carry no workspace on the wire at all and args->>'workspace_id' would read null for work a tenant really did.",
+			pos.Filename, pos.Line, typeName, carriers, workspaceArgKey)
+	}
+}
+
+// declaresName reports whether a struct field is declared under the given name.
+// An embedded field has no names and so is never one — deliberately: this gate
+// reads the fields declared here and cannot see into another package's type.
+func declaresName(field *ast.Field, want string) bool {
+	for _, name := range field.Names {
+		if name.Name == want {
+			return true
+		}
+	}
+	return false
 }
 
 // assertNoWorkspaceArg holds the other half: a dispatcher does no tenant work,
@@ -153,8 +179,8 @@ func assertNoWorkspaceArg(t *testing.T, fset *token.FileSet, typeName string, st
 			continue
 		}
 		pos := fset.Position(field.Pos())
-		t.Errorf("%s:%d: %s is a dispatcher (it declares FleetWide()) but ships a json:%q key — a non-null workspace_id has to mean tenant work, or a per-workspace read of river_job counts a fan-out as a tenant's pass.",
-			pos.Filename, pos.Line, typeName, workspaceArgKey)
+		t.Errorf("%s:%d: %s is a dispatcher (it declares FleetWide()) but ships a json:%q key — a non-null workspace_id has to mean tenant work, or a per-workspace read of river_job counts a fan-out as a tenant's pass. If this job does one workspace's work, declare WorkspaceID() %s instead of FleetWide(); if it dispatches, the workspace belongs on the child jobs it enqueues, not on its own args.",
+			pos.Filename, pos.Line, typeName, workspaceArgKey, workspaceArgType)
 	}
 }
 


### PR DESCRIPTION
Seven job kinds carried the workspace as `json:"workspace"` while the other nineteen used `json:"workspace_id"`. That made `args->>'workspace_id'` partial over tenant jobs, and a null in that column ambiguous between two opposite readings: a dispatcher, which legitimately does no tenant work, and a kind that spells its key differently. A per-workspace read of `river_job` resolves that ambiguity the reassuring way — it reports the divergent kind as no work at all.

This retags the seven, adds an AST gate that keeps every `WorkspaceID()`-declaring type on one spelling **in both directions**, and corrects the `WorkspaceScoped` contract doc, which previously instructed contributors to *preserve* divergent keys.

The divergence was deliberate: the doc preserved each kind's shipped key so rows queued across a deploy would not decode to a zero workspace and strand the domain row they exist to advance. That reasoning holds only under a live-upgrade constraint this project does not carry.

### What holds the invariant

The gate derives its subject from the tree, not from a maintained list: every type declaring `Kind()` plus a role method must carry `Workspace ids.UUID` tagged `json:"workspace_id"` if it is workspace-scoped, and must carry no such key if it declares `FleetWide()`. It was observed failing on all seven kinds before the fix, on a planted dispatcher violation for its other half, on a planted duplicate carrier, and its two vacuous-pass floors were each observed failing on a directory holding no job args.

The duplicate-carrier rule is not theoretical: the gate as first written **passed** on a type declaring two fields tagged `json:"workspace_id"`, where `encoding/json` drops both conflicting fields and the row ships no workspace at all — a null that reads as a dispatcher. That plant now fails.

The gate is syntactic, so it cannot see what River's encoder writes. An integration test closes that half against a real Postgres through the real River client: all seven retagged kinds plus a dispatcher as a negative control, each kind asserted against **its own distinct** workspace rather than merely non-null, since a non-null assertion passes against a hardcoded zero UUID.

## Proof of work — real stack

**Stack:** `97c141cd`, `make dev`, api started 11:47:46 vs the branch's last commit at 11:42:47. `bin/api` on disk is **byte-identical** (sha256 `b566f38d…bdf094`) to a fresh rebuild from a clean checkout of that commit. `bin/worker` — which wrote most of the rows below — carries **0** `json:"workspace"` strings and 4 `json:"workspace_id"`.

The head under review, `02888fc8`, adds only comment text, a test rename, and gate assertions on top of `97c141cd`; no production encoding changed between them.

### A real enqueue, driven through the running api

`POST /v1/voice-profiles/{id}/builds` → `202 Accepted`, producing `river_job` id 85:

```
 id | kind        | args
----+-------------+----------------------------------------------------------------
 85 | voice_build | {"build_id": "019fc5f3-…", "workspace_id": "019fc5f3-0922-708b-83c7-540f1236b914"}
```

That workspace is the one the login response returned. The other six of the seven need a real OAuth mail app, a Telegram bot token, or an IMAP/HubSpot connection, so they were not driven live and **nothing was hand-inserted to stand in for them** — they are covered by the integration test through River's own encoder.

### No row anywhere carries the old key

```
SELECT count(*) AS total_rows,
       count(*) FILTER (WHERE args ? 'workspace')                AS rows_with_old_key,
       count(*) FILTER (WHERE args->>'workspace_id' IS NOT NULL) AS rows_with_new_key
FROM river_job;

 total_rows | rows_with_old_key | rows_with_new_key
------------+-------------------+-------------------
         96 |                 0 |                14
```

### Every kind with a null workspace_id

```
SELECT DISTINCT kind FROM river_job WHERE args->>'workspace_id' IS NULL ORDER BY kind;

 capture_auto_enrich_sweep    graph_edge_reconcile     org_name_promotion
 capture_classify             idempotency_retention    overlay_reconcile
 capture_counterparty_verdict linkedin_rematch         participant_backfill
 capture_digest               close_date_sweep         telegram_poll_sweep
 capture_enrich               follow_up_reconcile      time_scan
 gmail_sync                   voice_build_retry
(17 rows)
```

All seventeen declare `FleetWide()`. The converse was checked too: no dispatcher appears in the non-null list.

**Independently verified by a second agent**, which re-derived every one of those seventeen kind→type→`FleetWide` `file:line` mappings against the commit's blob rather than taking the list on trust — zero drift — and confirmed the converse. It also found the first evidence pass had proved provenance only for `bin/api`, which wrote one of the rows, and had never run the query that directly excludes old-key rows; both gaps are closed above. One of its corrections is worth repeating: an earlier "every kind is all-or-nothing on the key" observation was an arithmetic artifact — 28 of 31 kinds had exactly one row — and is not offered as evidence.

**The invariant is not yet exact, and this PR does not claim it is.** `embed_reindex` does tenant work under the `FleetWide` marker and carries no workspace key at all, so a null still means "a dispatcher, **or** `embed_reindex`". A later PR converts it. The `WorkspaceScoped` doc names that exception rather than claiming it away, and this PR also corrects `embedreindextransport.go`, whose `FleetWide()` comment still described the kind as a dispatcher doing no tenant work — the one place that honesty did not reach.

## Carrying a dev database? Recreate it

`make infra-reset && make db-up && make migrate`.

Rows queued under the old key decode to a zero workspace, which the binding guard refuses on every attempt — the safe direction, and the wanted behaviour. But the domain row that job existed to advance is stranded, and four of the seven do not heal on their own:

- **`telegram_ingest` — permanent.** The poll acks Telegram and advances the channel offset in the **same transaction** as the ingest enqueue, and there is no history API and no re-drive. The module's own comment says River's retry is Telegram's only recovery path.
- **`comms_send_email`** — nothing re-enqueues a pending delivery, so an approved outbound row stays `pending` forever, looking deliverable.
- **`capture_backfill`**, **`voice_build`** — stranded; the voice retry worker re-drives only *deferred* builds, not queued ones.

Three do heal, because a dispatcher re-enqueues them: `capture_sync`, `telegram_poll`, `overlay_refetch`.

Separately, six of the seven are inserted with `river.UniqueOpts{ByArgs: true}`, and River hashes the **encoded** args — key names included — into `unique_key`, with none of the seven tagging its workspace `river:"unique"`. So an old row and a new one no longer coalesce: the stale row fails *and* a duplicate runs beside it.

A one-shot migration rewriting the key on existing rows was considered and deliberately not taken: local databases are disposable at this stage, this is not production, and a stranded job erroring out is the behaviour we want.

## Scope

No schema change, no production behaviour change beyond the wire key itself. This does not convert any sweep, does not touch `embed_reindex` beyond correcting its comment, deletes no `ratifiedFleetScans` waiver, and adds no metric — those are later PRs. A security redteam pass over the diff found no tenant-isolation, authz, injection, secret-handling, or error-leakage defect, and confirmed the zero-workspace refusal is total: all 26 workspace-scoped kinds reach the shared binding guard before any read or write, on every path including cancellation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes all job args to use `workspace_id` on the wire and hardens guards/tests so per-workspace reads of `river_job` are correct and a null truly means “dispatcher” (temporary exception: `embed_reindex`).

- **Bug Fixes**
  - Retagged seven args structs to `json:"workspace_id"` to remove mixed keys.
  - Strengthened the AST gate: require exactly one `Workspace ids.UUID` tagged `workspace_id` on all `WorkspaceScoped` types; forbid `workspace_id` on `FleetWide()`; reject embedded carriers; add scoped/dispatcher count floors to avoid vacuous passes; parse quoted tags via `strconv.Unquote`.
  - Added an integration test against Postgres that asserts the wire format: each tenant job writes its own `workspace_id`; a dispatcher omits it.
  - Clarified `embed_reindex` as the one fleet-wide writer and named exception until it’s fanned out.
  - No schema change; only the wire key name changed.

- **Migration**
  - If you have a local DB with queued jobs, reset it: `make infra-reset && make db-up && make migrate`.

<sup>Written for commit 5309a4be2c8fd0381e192572dcffbae51571d392. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/374?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized background job payloads to use the `workspace_id` field consistently.
  * Improved workspace-scoped job identification and filtering.
  * Clarified fleet-wide job handling to prevent workspace-scoping ambiguity.

* **Tests**
  * Added validation ensuring workspace-scoped jobs use the correct workspace field and fleet-wide jobs omit it.
  * Added integration coverage for serialized job payloads and workspace associations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->