### PR TITLE
fix(people): the name lock is owed on a name FIELD, not on a name VALUE

### DIFF
--- a/backend/internal/modules/people/coldstartprofile.go
+++ b/backend/internal/modules/people/coldstartprofile.go
@@ -259,7 +259,7 @@ func applyEvidenceFieldsWithOverwrite(
 	// lock, and a path holding both in the other order deadlocks against a
 	// human rename. Whether a name is coming is knowable here, which is what
 	// makes the early take possible.
-	if fieldValue(fields, "legal_name") != "" {
+	if carriesOrgName(fields) {
 		if err := lockOrgNameWrites(ctx, tx); err != nil {
 			return nil, err
 		}
@@ -351,6 +351,24 @@ func fillEmptyOrgColumn(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID
 		return false, fmt.Errorf("fill %s: %w", column, err)
 	}
 	return tag.RowsAffected() == 1, nil
+}
+
+// carriesOrgName reports whether this apply could write a name column, and so
+// whether it owes the name lock.
+//
+// It tests for the field's PRESENCE, not for a non-empty value, because the
+// loop below does: writeOrgColumn's overwrite arm matches on IS DISTINCT FROM,
+// so clearing a legal name to "" still writes the row and still ends in the
+// re-check. Gating on the value would let exactly that case take the row lock
+// and then reach for the name lock, which is the ordering that deadlocks
+// against a human rename.
+func carriesOrgName(fields []ColdStartFieldInput) bool {
+	for _, f := range fields {
+		if f.Field == "legal_name" {
+			return true
+		}
+	}
+	return false
 }
 
 func fieldValue(fields []ColdStartFieldInput, name string) string {

--- a/backend/internal/modules/people/renamerecheck_test.go
+++ b/backend/internal/modules/people/renamerecheck_test.go
@@ -98,3 +98,34 @@ func TestAPlausibleNameIsFarInsideTheScoringBound(t *testing.T) {
 		t.Errorf("normalized %q lost its tail", normalized)
 	}
 }
+
+// The name lock is owed whenever an evidence apply COULD write a name, and the
+// loop that writes it keys off the field being present, not off its value
+// carrying one. Clearing a legal name to "" still writes the row and still ends
+// in the re-check, so gating the lock on the value would let that case take the
+// row lock first and reach for the name lock second — the ordering that
+// deadlocks against a human rename.
+func TestAnEvidenceApplyOwesTheNameLockWheneverItCarriesANameField(t *testing.T) {
+	cases := []struct {
+		name   string
+		fields []ColdStartFieldInput
+		owes   bool
+	}{
+		{"a stated legal name", []ColdStartFieldInput{{Field: "legal_name", Value: "Baqend GmbH"}}, true},
+		{"a CLEARED legal name", []ColdStartFieldInput{{Field: "legal_name", Value: ""}}, true},
+		{"legal name among others", []ColdStartFieldInput{
+			{Field: "industry", Value: "software"}, {Field: "legal_name", Value: "Acme AG"},
+		}, true},
+		{"no name field at all", []ColdStartFieldInput{
+			{Field: "industry", Value: "software"}, {Field: "registered_address", Value: "Hamburg"},
+		}, false},
+		{"nothing applied", nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := carriesOrgName(tc.fields); got != tc.owes {
+				t.Errorf("carriesOrgName = %v, want %v", got, tc.owes)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Follow-up to #375, which merged while this fix was still local. The regression is on `main`.

## The defect

#375 narrowed the organization-name lock so only an apply carrying a name pays for it. The gate tested the field's **value**:

```go
if fieldValue(fields, "legal_name") != "" {
```

The loop it guards keys off the field being **present**. `writeOrgColumn`'s overwrite arm matches on `IS DISTINCT FROM`, so clearing a legal name to `""` still writes the row, still sets `applied["legal_name"]`, and still ends in the re-check.

So an apply that *cleared* a legal name took the organization's row lock and then reached for the name lock — precisely the ordering #375 existed to remove, reintroduced by the gate meant to narrow it. A human rename holding the name lock and waiting on that row deadlocks against it.

## The fix

`carriesOrgName` tests presence, which is what the loop tests. A table test pins the cleared-value case alongside the ordinary ones, because that is the case the value-based gate got wrong and the one a future narrowing would get wrong again.

## How it was found

The background security scan of the previous commit, not the gates. No test covered an empty-valued name field, and the deadlock needs two concurrent transactions to show itself — which is also why the still-open follow-up for a real contention test (in the shape of `creatededupe_contention_integration_test.go`) matters.

## Verification

- `make check` — green
- `make test-integration` — `OK: integration passed with 0 skips (28 packages)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a deadlock by taking the organization-name lock based on the presence of the `legal_name` field, not whether its value is non-empty. Clearing a legal name now correctly takes the name lock, preventing the row-lock → name-lock ordering that could deadlock with a human rename.

- **Bug Fixes**
  - Replaced `fieldValue(fields, "legal_name") != ""` with `carriesOrgName(fields)` to gate the lock on field presence.
  - Added a table-driven test covering stated, cleared, mixed, and absent `legal_name` cases.

<sup>Written for commit e6e5efbc58f730cb7e0d3a63d534e2950eca2e71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/377?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

