### PR TITLE
fix(people): close the two name writers that never re-checked, and pin the lock order where it can fail

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1726,6 +1726,42 @@ The open list below comes out of PR #91's three-lens review of branch 1b.
     non-empty `Tools` loudly rather than map it to the Responses `tools` /
     Gemini `functionDeclarations` shapes.
 
+## Open follow-ups — the identity chokepoint (2026-08-03)
+
+Person, organization and lead rows are now minted through one door
+(`people/resolvecreate.go`), which takes the PO-F-1/PO-F-2 verdict as an
+argument and refuses an exact-key collision. `backend/dedupespine_test.go`
+derives the sanctioned insert sites from the tree, so a new bypass fails the
+build. Shipped across #372, #373, #375, #377, #378 — the detail is in those
+commits, not here.
+
+What is still open:
+
+- **No `lock_timeout` on the organization-name lock's transactions.** The key
+  is workspace-wide and held to commit, so a stuck holder consumes a pool
+  connection and every name writer waits behind it indefinitely. Nothing in the
+  backend sets `lock_timeout` today (only `customfields/create.go` does, for its
+  own reason), so this is a wider decision than one call site.
+- **`display_name` / `legal_name` have no `maxLength` in `crm.yaml`.** The
+  similarity metric is capped at `nameScoringMaxRunes` so an oversized name
+  cannot pin a connection, but the column still accepts a megabyte. The bound
+  belongs in the contract; raised upstream.
+- **The AI company-identity sweep is not built.** It is what would decide that
+  `speedkit.com` and `baqend.com` are one company before a signature reveals it,
+  and it is also the only thing that would re-detect a pair that raced past the
+  name lock — the lock narrows that window, it does not close it. Needs an
+  `identity_pair_verdict` table so a "not the same company" answer is not
+  re-asked and re-billed on every run.
+- **Two duplicate organizations exist in the dev database.** Baqend
+  (`baqend.com` / `speedkit.com`) and Dibalog Travel (`.de` / `.eu`) predate the
+  fix. The rename re-check only fires on a rename, so they will not surface by
+  themselves — dispose of them through `/dedupe/candidates`.
+
+Upstream spec raises owed for this work are listed under the 2026-08-01 heading
+below (PO-F-2 reading `legal_name`, the rename re-check as a data-hygiene rule,
+the lead LinkedIn 409 as an E12.11 extension, and the chokepoint obligation
+itself).
+
 ## Upstream spec raises owed from 2026-08-01
 
 From the founder's company-page review. Nothing edited in the spec repo —

--- a/backend/internal/modules/people/coldstartprofile.go
+++ b/backend/internal/modules/people/coldstartprofile.go
@@ -51,7 +51,7 @@ type ApplyColdStartProfileInput struct {
 // columnBackedColdStartFields maps read-back fields onto organization
 // columns; everything else lives only in organization_profile_field.
 var columnBackedColdStartFields = map[string]string{
-	"legal_name":         "legal_name",
+	fieldLegalName:       "legal_name",
 	"industry":           "industry",
 	"registered_address": "address",
 }
@@ -134,7 +134,7 @@ func applyColdStartTx(ctx context.Context, tx pgx.Tx, in ApplyColdStartProfileIn
 //nolint:ireturn // dispatches to PublicEventOrganizationCreated vs Updated by the created condition; tested directly via the interface in person_organization_payload_test.go
 func coldStartApplyPayload(created bool, in ApplyColdStartProfileInput, host, by string, applied map[string]any) events.Payload {
 	if created {
-		displayName := fieldValue(in.Fields, "legal_name")
+		displayName := fieldValue(in.Fields, fieldLegalName)
 		if displayName == "" {
 			// The org row is stored with the domain-derived name when no
 			// legal_name was accepted (resolveOrCreateColdStartOrg's fallback),
@@ -180,7 +180,7 @@ func resolveOrCreateColdStartOrg(ctx context.Context, tx pgx.Tx, host, by string
 		displayName = host
 	}
 	nameSource := nameSourceDomain
-	legal := fieldValue(fields, "legal_name")
+	legal := fieldValue(fields, fieldLegalName)
 	if legal != "" {
 		displayName = legal
 		nameSource = nameSourceDossier
@@ -220,8 +220,8 @@ func resolveOrCreateColdStartOrg(ctx context.Context, tx pgx.Tx, host, by string
 // coldStartColumns whitelists the identifier a fillEmptyOrgColumn UPDATE
 // may name — values are bind parameters, the column never is.
 var coldStartColumns = map[string]string{
-	"legal_name": `UPDATE organization SET legal_name = $2 WHERE id = $1 AND legal_name IS NULL`,
-	"industry":   `UPDATE organization SET industry = $2 WHERE id = $1 AND industry IS NULL`,
+	fieldLegalName: `UPDATE organization SET legal_name = $2 WHERE id = $1 AND legal_name IS NULL`,
+	"industry":     `UPDATE organization SET industry = $2 WHERE id = $1 AND industry IS NULL`,
 	// A scraped registered address arrives as one formatted line; it
 	// fills line1 only when no structured address exists yet.
 	"address": `UPDATE organization SET address_line1 = $2 WHERE id = $1 AND address_line1 IS NULL
@@ -310,7 +310,7 @@ func applyEvidenceFieldsWithOverwrite(
 	// already exists — the axis PO-F-2 had nothing to compare when the row was
 	// created, and the axis on which a company captured twice under two
 	// marketing names finally collides.
-	if _, named := applied["legal_name"]; named {
+	if _, named := applied[fieldLegalName]; named {
 		if err := recheckOrgNameForDuplicates(ctx, tx, orgID, by); err != nil {
 			return nil, err
 		}
@@ -323,7 +323,7 @@ func writeOrgColumn(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID, co
 		return fillEmptyOrgColumn(ctx, tx, orgID, column, value)
 	}
 	queries := map[string]string{
-		"legal_name": `UPDATE organization SET legal_name = $2, updated_at = now()
+		fieldLegalName: `UPDATE organization SET legal_name = $2, updated_at = now()
 			WHERE id = $1 AND legal_name IS DISTINCT FROM $2`,
 		"industry": `UPDATE organization SET industry = $2, updated_at = now()
 			WHERE id = $1 AND industry IS DISTINCT FROM $2`,
@@ -334,7 +334,12 @@ func writeOrgColumn(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID, co
 	if !ok {
 		return false, fmt.Errorf("people: %q is not a coldstart-writable column", column)
 	}
-	tag, err := tx.Exec(ctx, query, orgID, value)
+	// An empty value clears the column to NULL, not to "". The fill arm above
+	// matches on IS NULL, so a column cleared to the empty string could never
+	// be filled again by any later read — the record would look answered while
+	// holding nothing, and no enrichment would ever correct it. The human
+	// company form clears to NULL for the same reason (setCompanyColumn).
+	tag, err := tx.Exec(ctx, query, orgID, emptyToNil(value))
 	if err != nil {
 		return false, fmt.Errorf("replace %s: %w", column, err)
 	}
@@ -354,17 +359,17 @@ func fillEmptyOrgColumn(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID
 }
 
 // carriesOrgName reports whether this apply could write a name column, and so
-// whether it owes the name lock.
+// whether it owes the organization-name lock.
 //
-// It tests for the field's PRESENCE, not for a non-empty value, because the
-// loop below does: writeOrgColumn's overwrite arm matches on IS DISTINCT FROM,
-// so clearing a legal name to "" still writes the row and still ends in the
-// re-check. Gating on the value would let exactly that case take the row lock
-// and then reach for the name lock, which is the ordering that deadlocks
-// against a human rename.
+// Presence of the field is the test, because that is what the loop in
+// applyEvidenceFieldsWithOverwrite acts on: writeOrgColumn's overwrite arm
+// matches on IS DISTINCT FROM, so an apply that clears legal_name to "" still
+// writes the row — taking its row lock — and still reaches the re-check, which
+// wants the name lock. Anything narrower than presence lets that apply take the
+// two in the order that deadlocks against a human rename.
 func carriesOrgName(fields []ColdStartFieldInput) bool {
 	for _, f := range fields {
-		if f.Field == "legal_name" {
+		if f.Field == fieldLegalName {
 			return true
 		}
 	}

--- a/backend/internal/modules/people/coldstartprofile.go
+++ b/backend/internal/modules/people/coldstartprofile.go
@@ -48,10 +48,17 @@ type ApplyColdStartProfileInput struct {
 	Fields    []ColdStartFieldInput
 }
 
+// columnLegalName is the organization COLUMN, which is a different namespace
+// from the field of the same spelling: columnBackedColdStartFields maps
+// registered_address onto address_line1, so a field name and a column name
+// agreeing here is a coincidence, not a rule. The two constants stay apart so
+// renaming one cannot silently rename the other.
+const columnLegalName = "legal_name"
+
 // columnBackedColdStartFields maps read-back fields onto organization
 // columns; everything else lives only in organization_profile_field.
 var columnBackedColdStartFields = map[string]string{
-	fieldLegalName:       "legal_name",
+	fieldLegalName:       columnLegalName,
 	"industry":           "industry",
 	"registered_address": "address",
 }
@@ -220,8 +227,8 @@ func resolveOrCreateColdStartOrg(ctx context.Context, tx pgx.Tx, host, by string
 // coldStartColumns whitelists the identifier a fillEmptyOrgColumn UPDATE
 // may name — values are bind parameters, the column never is.
 var coldStartColumns = map[string]string{
-	fieldLegalName: `UPDATE organization SET legal_name = $2 WHERE id = $1 AND legal_name IS NULL`,
-	"industry":     `UPDATE organization SET industry = $2 WHERE id = $1 AND industry IS NULL`,
+	columnLegalName: `UPDATE organization SET legal_name = $2 WHERE id = $1 AND legal_name IS NULL`,
+	"industry":      `UPDATE organization SET industry = $2 WHERE id = $1 AND industry IS NULL`,
 	// A scraped registered address arrives as one formatted line; it
 	// fills line1 only when no structured address exists yet.
 	"address": `UPDATE organization SET address_line1 = $2 WHERE id = $1 AND address_line1 IS NULL
@@ -323,7 +330,7 @@ func writeOrgColumn(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID, co
 		return fillEmptyOrgColumn(ctx, tx, orgID, column, value)
 	}
 	queries := map[string]string{
-		fieldLegalName: `UPDATE organization SET legal_name = $2, updated_at = now()
+		columnLegalName: `UPDATE organization SET legal_name = $2, updated_at = now()
 			WHERE id = $1 AND legal_name IS DISTINCT FROM $2`,
 		"industry": `UPDATE organization SET industry = $2, updated_at = now()
 			WHERE id = $1 AND industry IS DISTINCT FROM $2`,
@@ -350,6 +357,12 @@ func fillEmptyOrgColumn(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID
 	query, ok := coldStartColumns[column]
 	if !ok {
 		return false, fmt.Errorf("people: %q is not a coldstart-fillable column", column)
+	}
+	// Nothing to fill. Writing "" here would satisfy this arm's own WHERE
+	// legal_name IS NULL once and never again: the column would read as
+	// answered while holding nothing, and no later read could correct it.
+	if value == "" {
+		return false, nil
 	}
 	tag, err := tx.Exec(ctx, query, orgID, value)
 	if err != nil {

--- a/backend/internal/modules/people/company.go
+++ b/backend/internal/modules/people/company.go
@@ -84,10 +84,10 @@ type companyField struct {
 var companyFields = []companyField{
 	{name: fieldDisplayName},
 	{name: fieldOfferSummary},
-	{name: fieldLegalName, update: `UPDATE organization SET legal_name = $2 WHERE id = $1`},
-	{name: fieldRegisteredAddress, update: `UPDATE organization SET address_line1 = $2 WHERE id = $1`},
+	{name: fieldLegalName, update: `UPDATE organization SET legal_name = $2 WHERE id = $1 AND legal_name IS DISTINCT FROM $2`},
+	{name: fieldRegisteredAddress, update: `UPDATE organization SET address_line1 = $2 WHERE id = $1 AND address_line1 IS DISTINCT FROM $2`},
 	{name: fieldRegisterVat},
-	{name: fieldIndustry, update: `UPDATE organization SET industry = $2 WHERE id = $1`},
+	{name: fieldIndustry, update: `UPDATE organization SET industry = $2 WHERE id = $1 AND industry IS DISTINCT FROM $2`},
 	{name: fieldICP},
 	{name: fieldValueProposition},
 	{name: fieldUSP},
@@ -207,17 +207,6 @@ func (s *Store) SaveCompany(ctx context.Context, in SaveCompanyInput) (Company, 
 		applied, err := writeCompanyFields(ctx, tx, orgID, by, fields)
 		if err != nil {
 			return err
-		}
-		// The form writes legal_name too, and a legal name is the axis on which
-		// two records of one company converge. resolveOrCreateAnchor above
-		// re-checks only when display_name moved, so without this a human
-		// typing the registered name into the company form is the one rename
-		// path that files nothing. The name lock it needs was taken there,
-		// ahead of the row lock, so the ordering already holds.
-		if _, renamed := applied[fieldLegalName]; renamed {
-			if err := recheckOrgNameForDuplicates(ctx, tx, orgID, by); err != nil {
-				return err
-			}
 		}
 		if in.Website != nil {
 			if err := setCompanyDomain(ctx, tx, orgID, *in.Website, by); err != nil {

--- a/backend/internal/modules/people/company.go
+++ b/backend/internal/modules/people/company.go
@@ -208,6 +208,17 @@ func (s *Store) SaveCompany(ctx context.Context, in SaveCompanyInput) (Company, 
 		if err != nil {
 			return err
 		}
+		// The form writes legal_name too, and a legal name is the axis on which
+		// two records of one company converge. resolveOrCreateAnchor above
+		// re-checks only when display_name moved, so without this a human
+		// typing the registered name into the company form is the one rename
+		// path that files nothing. The name lock it needs was taken there,
+		// ahead of the row lock, so the ordering already holds.
+		if _, renamed := applied[fieldLegalName]; renamed {
+			if err := recheckOrgNameForDuplicates(ctx, tx, orgID, by); err != nil {
+				return err
+			}
+		}
 		if in.Website != nil {
 			if err := setCompanyDomain(ctx, tx, orgID, *in.Website, by); err != nil {
 				return err
@@ -366,67 +377,6 @@ func createAnchorOrganization(ctx context.Context, tx pgx.Tx, displayName, by st
 		return ids.OrganizationID{}, err
 	}
 	return orgID, nil
-}
-
-// writeCompanyFields applies the submitted fields: the column-backed ones onto
-// their column (a human's own form overwrites — unlike a read-back, which only
-// fills blanks), and every one onto its provenance row. Returns what changed,
-// for the audit delta.
-func writeCompanyFields(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID, by string, fields map[string]*string) (map[string]any, error) {
-	applied := map[string]any{}
-	for _, spec := range companyFields {
-		field := spec.name
-		value, sent := fields[field]
-		if !sent || value == nil {
-			continue
-		}
-		trimmed := strings.TrimSpace(*value)
-		if spec.update != "" {
-			if err := setCompanyColumn(ctx, tx, orgID, spec, trimmed); err != nil {
-				return nil, err
-			}
-		}
-		if trimmed == "" {
-			if _, err := tx.Exec(ctx,
-				`DELETE FROM organization_profile_field
-				 WHERE workspace_id = $1 AND organization_id = $2 AND field = $3`,
-				workspaceID(ctx), orgID, field); err != nil {
-				return nil, fmt.Errorf("clear company field %s: %w", field, err)
-			}
-			applied[field] = nil
-			continue
-		}
-		// A human-typed value has no snippet to quote — the human IS the
-		// evidence, which is what source=human + captured_by=human:<id>
-		// record. Confidence is 1: they are not guessing about themselves.
-		if _, err := tx.Exec(ctx, `
-			INSERT INTO organization_profile_field
-			  (workspace_id, organization_id, field, value, evidence_snippet, source_url, confidence, source, captured_by)
-			VALUES ($1, $2, $3, $4, '', '', 1, 'human', $5)
-			ON CONFLICT (workspace_id, organization_id, field)
-			DO UPDATE SET value = EXCLUDED.value, evidence_snippet = '', source_url = '',
-			              confidence = 1, source = 'human',
-			              captured_by = EXCLUDED.captured_by, captured_at = now()`,
-			workspaceID(ctx), orgID, field, trimmed, by); err != nil {
-			return nil, fmt.Errorf("save company field %s: %w", field, err)
-		}
-		applied[field] = trimmed
-	}
-	return applied, nil
-}
-
-// setCompanyColumn writes a column-backed field, clearing it to NULL rather
-// than storing an empty string — an unfilled field reads as absent, never as
-// the empty answer.
-func setCompanyColumn(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID, spec companyField, value string) error {
-	var stored *string
-	if value != "" {
-		stored = &value
-	}
-	if _, err := tx.Exec(ctx, spec.update, orgID, stored); err != nil {
-		return fmt.Errorf("set %s: %w", spec.name, err)
-	}
-	return nil
 }
 
 // readCompany assembles the form's view: the name and website from the

--- a/backend/internal/modules/people/companyform.go
+++ b/backend/internal/modules/people/companyform.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+// Writing the company form's fields. The form is the one surface where a human
+// states the installation's own company directly, so each value lands on its
+// column AND on its provenance row with source=human — the human IS the
+// evidence, which is why these writes carry no snippet.
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// writeCompanyFields applies the submitted fields: the column-backed ones onto
+// their column (a human's own form overwrites — unlike a read-back, which only
+// fills blanks), and every one onto its provenance row. Returns what changed,
+// for the audit delta.
+func writeCompanyFields(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID, by string, fields map[string]*string) (map[string]any, error) {
+	applied := map[string]any{}
+	for _, spec := range companyFields {
+		field := spec.name
+		value, sent := fields[field]
+		if !sent || value == nil {
+			continue
+		}
+		trimmed := strings.TrimSpace(*value)
+		if spec.update != "" {
+			if err := setCompanyColumn(ctx, tx, orgID, spec, trimmed); err != nil {
+				return nil, err
+			}
+		}
+		if trimmed == "" {
+			if _, err := tx.Exec(ctx,
+				`DELETE FROM organization_profile_field
+				 WHERE workspace_id = $1 AND organization_id = $2 AND field = $3`,
+				workspaceID(ctx), orgID, field); err != nil {
+				return nil, fmt.Errorf("clear company field %s: %w", field, err)
+			}
+			applied[field] = nil
+			continue
+		}
+		// A human-typed value has no snippet to quote — the human IS the
+		// evidence, which is what source=human + captured_by=human:<id>
+		// record. Confidence is 1: they are not guessing about themselves.
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO organization_profile_field
+			  (workspace_id, organization_id, field, value, evidence_snippet, source_url, confidence, source, captured_by)
+			VALUES ($1, $2, $3, $4, '', '', 1, 'human', $5)
+			ON CONFLICT (workspace_id, organization_id, field)
+			DO UPDATE SET value = EXCLUDED.value, evidence_snippet = '', source_url = '',
+			              confidence = 1, source = 'human',
+			              captured_by = EXCLUDED.captured_by, captured_at = now()`,
+			workspaceID(ctx), orgID, field, trimmed, by); err != nil {
+			return nil, fmt.Errorf("save company field %s: %w", field, err)
+		}
+		applied[field] = trimmed
+	}
+	return applied, nil
+}
+
+// setCompanyColumn writes a column-backed field, clearing it to NULL rather
+// than storing an empty string — an unfilled field reads as absent, never as
+// the empty answer.
+func setCompanyColumn(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID, spec companyField, value string) error {
+	var stored *string
+	if value != "" {
+		stored = &value
+	}
+	if _, err := tx.Exec(ctx, spec.update, orgID, stored); err != nil {
+		return fmt.Errorf("set %s: %w", spec.name, err)
+	}
+	return nil
+}

--- a/backend/internal/modules/people/companyform.go
+++ b/backend/internal/modules/people/companyform.go
@@ -3,10 +3,15 @@
 
 package people
 
-// Writing the company form's fields. The form is the one surface where a human
-// states the installation's own company directly, so each value lands on its
-// column AND on its provenance row with source=human — the human IS the
-// evidence, which is why these writes carry no snippet.
+// Writing the fields a human states about the installation's own company —
+// from the company form, and from the human-edited half of a site-read
+// confirmation.
+//
+// A value lands on its provenance row always, and on an organization column
+// when the field is one of the few that is column-backed; clearing a value
+// deletes the provenance row rather than storing a blank one. The rows carry
+// source=human and no evidence snippet, because on this path the human IS the
+// evidence.
 
 import (
 	"context"
@@ -24,6 +29,7 @@ import (
 // for the audit delta.
 func writeCompanyFields(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID, by string, fields map[string]*string) (map[string]any, error) {
 	applied := map[string]any{}
+	renamed := false
 	for _, spec := range companyFields {
 		field := spec.name
 		value, sent := fields[field]
@@ -32,9 +38,11 @@ func writeCompanyFields(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID
 		}
 		trimmed := strings.TrimSpace(*value)
 		if spec.update != "" {
-			if err := setCompanyColumn(ctx, tx, orgID, spec, trimmed); err != nil {
+			moved, err := setCompanyColumn(ctx, tx, orgID, spec, trimmed)
+			if err != nil {
 				return nil, err
 			}
+			renamed = renamed || (moved && field == fieldLegalName)
 		}
 		if trimmed == "" {
 			if _, err := tx.Exec(ctx,
@@ -62,19 +70,35 @@ func writeCompanyFields(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID
 		}
 		applied[field] = trimmed
 	}
+	// A legal name is the axis on which two records of one company converge, and
+	// this function is the only writer of that column a human drives — through
+	// the company form AND through a site-read confirmation, which is why the
+	// re-check lives here rather than at either call site. Both callers took the
+	// name lock in resolveOrCreateAnchor, ahead of the row lock, so the ordering
+	// already holds.
+	if renamed {
+		if err := recheckOrgNameForDuplicates(ctx, tx, orgID, by); err != nil {
+			return nil, err
+		}
+	}
 	return applied, nil
 }
 
 // setCompanyColumn writes a column-backed field, clearing it to NULL rather
 // than storing an empty string — an unfilled field reads as absent, never as
 // the empty answer.
-func setCompanyColumn(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID, spec companyField, value string) error {
+// setCompanyColumn writes one column-backed field and reports whether the
+// value actually moved. Every statement carries IS DISTINCT FROM, so a
+// resubmission of an unchanged form touches no row and answers false — which is
+// what keeps the duplicate re-check below off a save that renamed nothing.
+func setCompanyColumn(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID, spec companyField, value string) (bool, error) {
 	var stored *string
 	if value != "" {
 		stored = &value
 	}
-	if _, err := tx.Exec(ctx, spec.update, orgID, stored); err != nil {
-		return fmt.Errorf("set %s: %w", spec.name, err)
+	tag, err := tx.Exec(ctx, spec.update, orgID, stored)
+	if err != nil {
+		return false, fmt.Errorf("set %s: %w", spec.name, err)
 	}
-	return nil
+	return tag.RowsAffected() > 0, nil
 }

--- a/backend/internal/modules/people/ensurechannel.go
+++ b/backend/internal/modules/people/ensurechannel.go
@@ -341,12 +341,14 @@ func handleImage(provider string, handle *string) map[string]any {
 	}}
 }
 
-// emptyToNil mirrors the column's NULLIF: "no handle" is one state, not two.
-func emptyToNil(handle string) *string {
-	if handle == "" {
+// emptyToNil mirrors the columns' NULLIF: absent is one state, not two. Shared
+// by the channel handle and the organization name columns, both of which read
+// NULL as "not set" and would otherwise grow a second, silent spelling of it.
+func emptyToNil(value string) *string {
+	if value == "" {
 		return nil
 	}
-	return &handle
+	return &value
 }
 
 // channelCounterpartyName is the display name we can honestly store for a

--- a/backend/internal/modules/people/ensurechannel_contention_integration_test.go
+++ b/backend/internal/modules/people/ensurechannel_contention_integration_test.go
@@ -302,7 +302,11 @@ func (e *dedupeEnv) refreshInBackground(ctx context.Context, ci connector.Channe
 // in which nothing ever blocked reports that instead of passing having proved
 // nothing. The pid makes it exact — pg_stat_activity is cluster-wide, and the
 // parallel lane runs a dozen packages against one server.
-func waitUntilBlockedBy(t *testing.T, probe pgx.Tx, pid int, done <-chan error) {
+// It reports whether a backend blocked, rather than deciding: for the refresh
+// races below "finished first" means the run proved nothing and must fail loudly,
+// while for the organization-name lock it is the expected answer on the path
+// that owes no lock. One probe, two policies.
+func waitUntilBlockedBy(t *testing.T, probe pgx.Tx, pid int, done <-chan error) (bool, error) {
 	t.Helper()
 	// Generous enough that a loaded machine cannot trip it, small enough that a
 	// genuine miss reports in seconds rather than minutes.
@@ -317,15 +321,26 @@ func waitUntilBlockedBy(t *testing.T, probe pgx.Tx, pid int, done <-chan error) 
 			t.Fatalf("probing for a waiting backend: %v", err)
 		}
 		if blocked {
-			return
+			return true, nil
 		}
 		select {
 		case err := <-done:
-			t.Fatalf("the second refresh finished (%v) without ever waiting on the first — it never reached the binding, so this run exercises no ordering at all", err)
+			return false, err
 		default:
 		}
 	}
-	t.Fatalf("no backend waited on the held row within %d probes — the second refresh never reached the binding, so this run proved nothing", maxProbes)
+	t.Fatalf("no backend waited on the held row within %d probes — the writer never reached the lock, so this run proved nothing", maxProbes)
+	return false, nil
+}
+
+// mustBlockOn is waitUntilBlockedBy for a caller where finishing without ever
+// waiting means the run exercised no ordering at all.
+func mustBlockOn(t *testing.T, probe pgx.Tx, pid int, done <-chan error) {
+	t.Helper()
+	if blocked, err := waitUntilBlockedBy(t, probe, pid, done); !blocked {
+		t.Fatalf("the second writer finished (%v) without ever waiting on the first — "+
+			"it never reached the binding, so this run exercises no ordering at all", err)
+	}
 }
 
 // The trail has to name the handle a refresh actually displaced. Two messages
@@ -346,7 +361,7 @@ func TestConcurrentUsernameRefreshesAuditTheRealPriorValue(t *testing.T) {
 	toB.Username, toC.Username = "handle_b", "handle_c"
 	blocker, pid := e.beginBlockingRefresh(ctx, t, toB)
 	displaced := e.refreshInBackground(ctx, toC)
-	waitUntilBlockedBy(t, blocker, pid, displaced)
+	mustBlockOn(t, blocker, pid, displaced)
 	if err := blocker.Commit(ctx); err != nil {
 		t.Fatalf("committing the first rename: %v", err)
 	}
@@ -393,7 +408,7 @@ func TestTwoMessagesReportingTheSameRenameAuditItOnce(t *testing.T) {
 	renamed.Username = "handle_b"
 	blocker, pid := e.beginBlockingRefresh(ctx, t, renamed)
 	second := e.refreshInBackground(ctx, renamed)
-	waitUntilBlockedBy(t, blocker, pid, second)
+	mustBlockOn(t, blocker, pid, second)
 	if err := blocker.Commit(ctx); err != nil {
 		t.Fatalf("committing the rename: %v", err)
 	}

--- a/backend/internal/modules/people/merge_organization.go
+++ b/backend/internal/modules/people/merge_organization.go
@@ -73,10 +73,22 @@ func (s *Store) MergeOrganization(ctx context.Context, sourceID, targetID ids.Or
 		if err != nil {
 			return err
 		}
-		// A survivor that just inherited the retired record's legal name can
-		// now be the twin of a THIRD organization, and resolving one duplicate
-		// is no reason to leave that one unfiled. Only when the name actually
-		// moved: a merge that filled nothing renames nobody.
+		out, err = finalizeOrgMerge(ctx, tx, sourceID, targetID, filled, active)
+		if err != nil {
+			return err
+		}
+		// A survivor that just inherited the retired record's legal name can now
+		// be the twin of a THIRD organization, and resolving one duplicate is no
+		// reason to leave that one unfiled. Only when the name actually moved: a
+		// merge that filled nothing renames nobody.
+		//
+		// It runs after finalizeOrgMerge, which retires the source. Before it,
+		// the source still reads as live AND holds the very name it has just
+		// donated, so it scores 1.0, wins the ranked list, and the pair filed
+		// names a row archived one statement later — a pair no human can ever
+		// dispose of, because merging it answers AlreadyMerged and that reopens
+		// it. The genuine third record is never reached, since the walk stops at
+		// the first unfiled rival.
 		if _, renamed := filled[fieldLegalName]; renamed {
 			by, err := storekit.CapturedBy(ctx)
 			if err != nil {
@@ -86,8 +98,7 @@ func (s *Store) MergeOrganization(ctx context.Context, sourceID, targetID ids.Or
 				return err
 			}
 		}
-		out, err = finalizeOrgMerge(ctx, tx, sourceID, targetID, filled, active)
-		return err
+		return nil
 	})
 	return out, err
 }
@@ -121,7 +132,7 @@ func relinkOrgAssociations(ctx context.Context, tx pgx.Tx, sourceID, targetID id
 // applied after-image for the merge audit.
 func fillOrgSurvivorship(ctx context.Context, tx pgx.Tx, src, tgt crmcontracts.Organization, targetIsPartner bool, tgtLock storekit.RowLock) (map[string]any, error) {
 	p := storekit.NewPatch()
-	fillString(p, "legal_name", tgt.LegalName, src.LegalName)
+	fillString(p, fieldLegalName, tgt.LegalName, src.LegalName)
 	fillString(p, "industry", tgt.Industry, src.Industry)
 	if targetIsPartner && (tgt.Classification == nil || *tgt.Classification != crmcontracts.OrganizationClassificationPartner) {
 		p.Set("classification", tgt.Classification, "partner")

--- a/backend/internal/modules/people/merge_organization.go
+++ b/backend/internal/modules/people/merge_organization.go
@@ -43,6 +43,14 @@ func (s *Store) MergeOrganization(ctx context.Context, sourceID, targetID ids.Or
 
 	var out crmcontracts.Organization
 	err = s.tx(ctx, func(tx pgx.Tx) error {
+		// A merge fills the survivor's legal_name from the record it retires
+		// (fillOrgSurvivorship), so it is a name writer like any other and owes
+		// the same two things: the name lock BEFORE any organization row lock,
+		// and a re-check afterwards. Taking it here rather than beside the fill
+		// is what keeps the order — LockPair is next.
+		if err := lockOrgNameWrites(ctx, tx); err != nil {
+			return err
+		}
 		// The pair lock keeps BOTH endpoints held to commit: without it a
 		// concurrent merge(target→elsewhere) archives the survivor
 		// mid-merge and the relinked children point at a dead record.
@@ -64,6 +72,19 @@ func (s *Store) MergeOrganization(ctx context.Context, sourceID, targetID ids.Or
 		filled, err := fillOrgSurvivorship(ctx, tx, src, tgt, targetIsPartner, tgtLock)
 		if err != nil {
 			return err
+		}
+		// A survivor that just inherited the retired record's legal name can
+		// now be the twin of a THIRD organization, and resolving one duplicate
+		// is no reason to leave that one unfiled. Only when the name actually
+		// moved: a merge that filled nothing renames nobody.
+		if _, renamed := filled[fieldLegalName]; renamed {
+			by, err := storekit.CapturedBy(ctx)
+			if err != nil {
+				return err
+			}
+			if err := recheckOrgNameForDuplicates(ctx, tx, targetID, by); err != nil {
+				return err
+			}
 		}
 		out, err = finalizeOrgMerge(ctx, tx, sourceID, targetID, filled, active)
 		return err

--- a/backend/internal/modules/people/orgnamelock_contention_integration_test.go
+++ b/backend/internal/modules/people/orgnamelock_contention_integration_test.go
@@ -60,14 +60,22 @@ func (e *dedupeEnv) holdOrgNameLock(ctx context.Context, t *testing.T) (pgx.Tx, 
 }
 
 // An apply that carries a legal name owes the name lock BEFORE it touches the
-// organization row, whatever that name's value is: an empty one still writes the
-// row and still reaches the duplicate re-check, so it can hold the row while
-// wanting the name lock — the cycle a concurrent human rename completes.
-func TestAnEvidenceApplyCarryingANameWaitsOnTheNameLock(t *testing.T) {
+// organization row, so it cannot hold that row while wanting the lock — the
+// cycle a concurrent human rename completes.
+//
+// The case is an apply CLEARING a name it is allowed to overwrite. That is the
+// one an implementation is most likely to wave through as "no name here": it
+// carries an empty value, yet it writes the row like any other write and lands
+// in the duplicate re-check, which is what wants the lock. A non-empty value
+// would prove the ordering too, but it would not tell a gate that reads the
+// VALUE apart from one that reads the FIELD — and that is the distinction the
+// ordering rests on.
+func TestAnEvidenceApplyClearingANameWaitsOnTheNameLock(t *testing.T) {
 	e := setupDedupe(t)
 	ctx := e.as()
+	legal := "Kranz Logistik GmbH"
 	org, err := e.store.CreateOrganization(ctx, CreateOrganizationInput{
-		DisplayName: "Kranz Logistik", Source: "manual",
+		DisplayName: "Kranz Logistik", LegalName: &legal, Source: "manual",
 		Domains: []OrgDomainInput{{Domain: "kranz.test", IsPrimary: true}},
 	})
 	if err != nil {
@@ -84,14 +92,15 @@ func TestAnEvidenceApplyCarryingANameWaitsOnTheNameLock(t *testing.T) {
 			if err != nil {
 				return err
 			}
-			// The empty value is the case worth pinning: it writes the row
-			// like any other and is the easiest to mistake for "no name".
-			_, err = applyEvidenceFields(ctx, tx, workspaceID(ctx), orgID, "site_read", by,
+			// Overwrite, so the clear actually reaches the column: the fill
+			// arm has nothing to fill and would write no row at all.
+			_, err = applyEvidenceFieldsWithOverwrite(ctx, tx, workspaceID(ctx), orgID, "site_read", by,
 				[]ColdStartFieldInput{{
 					Field: fieldLegalName, Value: "",
 					EvidenceSnippet: "the imprint no longer states a registered name",
 					SourceURL:       "https://kranz.test/impressum", Confidence: 1,
-				}})
+				}},
+				map[string]bool{fieldLegalName: true})
 			return err
 		})
 	}()

--- a/backend/internal/modules/people/orgnamelock_contention_integration_test.go
+++ b/backend/internal/modules/people/orgnamelock_contention_integration_test.go
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package people
+
+// Which organization writers actually wait on the name lock, judged at the CALL
+// SITE rather than on the helper that decides it.
+//
+// The gate is one boolean, and a table test over that boolean passes whether or
+// not anything calls it — the deadlock and the missed duplicate it exists to
+// prevent are properties of the transaction, not of the predicate. So the lock
+// is held by hand in one transaction, the write runs in another, and the test
+// asks Postgres who is waiting on whom. No sleep, no clock: the same
+// pg_stat_activity busy-read the phone-lane contention test uses.
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// holdOrgNameLock opens a transaction holding the workspace's organization-name
+// write identity and hands it back still open, so the test owns the moment a
+// second writer can proceed. Its rollback is registered here: a transaction
+// left open on a failure path holds the lock and a pooled connection with it,
+// and the run that meant to fail loudly would hang instead.
+func (e *dedupeEnv) holdOrgNameLock(ctx context.Context, t *testing.T) (pgx.Tx, int) {
+	t.Helper()
+	tx, err := e.store.pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("opening the lock holder's transaction: %v", err)
+	}
+	t.Cleanup(func() {
+		err := tx.Rollback(context.Background())
+		if err != nil && !errors.Is(err, pgx.ErrTxClosed) {
+			t.Errorf("releasing the lock holder's transaction: %v", err)
+		}
+	})
+	if _, err := tx.Exec(ctx, `SELECT set_config('app.workspace_id', $1, true)`, e.ws.String()); err != nil {
+		t.Fatalf("binding the workspace GUC: %v", err)
+	}
+	var pid int
+	if err := tx.QueryRow(ctx, `SELECT pg_backend_pid()`).Scan(&pid); err != nil {
+		t.Fatalf("reading the lock holder's backend pid: %v", err)
+	}
+	// Through the production helper, so a change to the key can never leave
+	// this transaction holding something no writer waits on.
+	if err := lockOrgNameWrites(ctx, tx); err != nil {
+		t.Fatalf("taking the organization-name write identity: %v", err)
+	}
+	return tx, pid
+}
+
+// awaitBlockedOn returns true once some backend is provably waiting on a lock
+// the given pid holds, and false when the work finished without ever waiting.
+func awaitBlockedOn(t *testing.T, probe pgx.Tx, pid int, done <-chan error) (error, bool) {
+	t.Helper()
+	// Generous enough that a loaded machine cannot trip it, small enough that a
+	// genuine miss reports in seconds rather than minutes.
+	const maxProbes = 20_000
+	for i := 0; i < maxProbes; i++ {
+		var blocked bool
+		if err := probe.QueryRow(context.Background(), `
+			SELECT EXISTS (
+			  SELECT 1 FROM pg_stat_activity a
+			   WHERE a.datname = current_database() AND $1 = ANY (pg_blocking_pids(a.pid)))`,
+			pid).Scan(&blocked); err != nil {
+			t.Fatalf("probing for a waiting backend: %v", err)
+		}
+		if blocked {
+			return nil, true
+		}
+		select {
+		case err := <-done:
+			return err, false
+		default:
+		}
+	}
+	t.Fatal("the writer neither waited on the name lock nor finished")
+	return nil, false
+}
+
+// TestAnEvidenceApplyCarryingANameWaitsOnTheNameLock is the regression for the
+// value-based gate. An apply that CLEARS a legal name to "" still writes the
+// row and still reaches the duplicate re-check, so it owes the name lock before
+// it touches the row — gating on the value let exactly that case take the two
+// in the order that deadlocks against a human rename.
+func TestAnEvidenceApplyCarryingANameWaitsOnTheNameLock(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+	org, err := e.store.CreateOrganization(ctx, CreateOrganizationInput{
+		DisplayName: "Kranz Logistik", Source: "manual",
+		Domains: []OrgDomainInput{{Domain: "kranz.test", IsPrimary: true}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	orgID := ids.From[ids.OrganizationKind](ids.UUID(org.Id))
+
+	holder, pid := e.holdOrgNameLock(ctx, t)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- e.store.tx(ctx, func(tx pgx.Tx) error {
+			by, err := storekit.CapturedBy(ctx)
+			if err != nil {
+				return err
+			}
+			// The empty value is the point: the old gate read it and skipped
+			// the lock.
+			_, err = applyEvidenceFields(ctx, tx, workspaceID(ctx), orgID, "site_read", by,
+				[]ColdStartFieldInput{{
+					Field: fieldLegalName, Value: "",
+					EvidenceSnippet: "the imprint no longer states a registered name",
+					SourceURL:       "https://kranz.test/impressum", Confidence: 1,
+				}})
+			return err
+		})
+	}()
+
+	if finished, waited := awaitBlockedOn(t, holder, pid, done); !waited {
+		t.Fatalf("the apply completed without ever waiting on the name lock (err=%v) — "+
+			"it can take this organization's row lock first and deadlock against a rename", finished)
+	}
+
+	// WHERE it is blocked is the whole question, and "it waited" cannot answer
+	// it: an apply that takes the row lock first also ends up waiting, just one
+	// statement too late. So the holder — which owns the name lock a human
+	// rename would hold — reaches for the row that rename would edit. If the
+	// apply is parked before touching the row, this succeeds at once. If it is
+	// parked while holding the row, the two are in the cycle that deadlocks and
+	// this blocks until the timeout.
+	if _, err := holder.Exec(ctx, `SET LOCAL lock_timeout = '5s'`); err != nil {
+		t.Fatalf("arming the lock timeout: %v", err)
+	}
+	if _, err := holder.Exec(ctx,
+		`SELECT id FROM organization WHERE id = $1 FOR UPDATE`, orgID); err != nil {
+		t.Fatalf("the rename could not take the organization row while the apply waited (%v) — "+
+			"the apply is holding that row and waiting for the name lock, the ordering that deadlocks", err)
+	}
+
+	// Releasing the holder must let it through, or the wait was on something
+	// else entirely.
+	if err := holder.Rollback(ctx); err != nil {
+		t.Fatalf("releasing the lock holder: %v", err)
+	}
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("the apply failed once the lock was free: %v", err)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("the apply never finished after the lock was released")
+	}
+}
+
+// TestAnEvidenceApplyWithoutANameDoesNotWaitOnTheNameLock is the other half:
+// the lock is workspace-wide, so an apply that cannot rename anything must not
+// serialize behind every organization write in the installation. Enrichment and
+// deep-read arrive in batches of exactly this shape.
+func TestAnEvidenceApplyWithoutANameDoesNotWaitOnTheNameLock(t *testing.T) {
+	e := setupDedupe(t)
+	ctx := e.as()
+	org, err := e.store.CreateOrganization(ctx, CreateOrganizationInput{
+		DisplayName: "Vogel Werke", Source: "manual",
+		Domains: []OrgDomainInput{{Domain: "vogel.test", IsPrimary: true}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	orgID := ids.From[ids.OrganizationKind](ids.UUID(org.Id))
+
+	holder, pid := e.holdOrgNameLock(ctx, t)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- e.store.tx(ctx, func(tx pgx.Tx) error {
+			by, err := storekit.CapturedBy(ctx)
+			if err != nil {
+				return err
+			}
+			_, err = applyEvidenceFields(ctx, tx, workspaceID(ctx), orgID, "site_read", by,
+				[]ColdStartFieldInput{{
+					Field: "industry", Value: "logistics",
+					EvidenceSnippet: "Spedition und Logistik seit 1974",
+					SourceURL:       "https://vogel.test/about", Confidence: 1,
+				}})
+			return err
+		})
+	}()
+
+	finished, waited := awaitBlockedOn(t, holder, pid, done)
+	if waited {
+		t.Fatal("an apply carrying no name waited on the workspace-wide name lock — " +
+			"every industry or address batch would serialize behind unrelated renames")
+	}
+	if finished != nil {
+		t.Fatalf("the apply failed: %v", finished)
+	}
+}

--- a/backend/internal/modules/people/orgnamelock_contention_integration_test.go
+++ b/backend/internal/modules/people/orgnamelock_contention_integration_test.go
@@ -8,12 +8,12 @@ package people
 // Which organization writers actually wait on the name lock, judged at the CALL
 // SITE rather than on the helper that decides it.
 //
-// The gate is one boolean, and a table test over that boolean passes whether or
-// not anything calls it — the deadlock and the missed duplicate it exists to
-// prevent are properties of the transaction, not of the predicate. So the lock
-// is held by hand in one transaction, the write runs in another, and the test
-// asks Postgres who is waiting on whom. No sleep, no clock: the same
-// pg_stat_activity busy-read the phone-lane contention test uses.
+// Which lock a writer holds, and in which order, is a property of the
+// transaction rather than of any predicate, so it is measured here rather than
+// asserted about a helper: the lock is held by hand in one transaction, the
+// write runs in another, and Postgres is asked who waits on whom. No sleep and
+// no clock — the same pg_stat_activity busy-read the phone-lane contention test
+// uses.
 
 import (
 	"context"
@@ -59,40 +59,10 @@ func (e *dedupeEnv) holdOrgNameLock(ctx context.Context, t *testing.T) (pgx.Tx, 
 	return tx, pid
 }
 
-// awaitBlockedOn returns true once some backend is provably waiting on a lock
-// the given pid holds, and false when the work finished without ever waiting.
-func awaitBlockedOn(t *testing.T, probe pgx.Tx, pid int, done <-chan error) (error, bool) {
-	t.Helper()
-	// Generous enough that a loaded machine cannot trip it, small enough that a
-	// genuine miss reports in seconds rather than minutes.
-	const maxProbes = 20_000
-	for i := 0; i < maxProbes; i++ {
-		var blocked bool
-		if err := probe.QueryRow(context.Background(), `
-			SELECT EXISTS (
-			  SELECT 1 FROM pg_stat_activity a
-			   WHERE a.datname = current_database() AND $1 = ANY (pg_blocking_pids(a.pid)))`,
-			pid).Scan(&blocked); err != nil {
-			t.Fatalf("probing for a waiting backend: %v", err)
-		}
-		if blocked {
-			return nil, true
-		}
-		select {
-		case err := <-done:
-			return err, false
-		default:
-		}
-	}
-	t.Fatal("the writer neither waited on the name lock nor finished")
-	return nil, false
-}
-
-// TestAnEvidenceApplyCarryingANameWaitsOnTheNameLock is the regression for the
-// value-based gate. An apply that CLEARS a legal name to "" still writes the
-// row and still reaches the duplicate re-check, so it owes the name lock before
-// it touches the row — gating on the value let exactly that case take the two
-// in the order that deadlocks against a human rename.
+// An apply that carries a legal name owes the name lock BEFORE it touches the
+// organization row, whatever that name's value is: an empty one still writes the
+// row and still reaches the duplicate re-check, so it can hold the row while
+// wanting the name lock — the cycle a concurrent human rename completes.
 func TestAnEvidenceApplyCarryingANameWaitsOnTheNameLock(t *testing.T) {
 	e := setupDedupe(t)
 	ctx := e.as()
@@ -114,8 +84,8 @@ func TestAnEvidenceApplyCarryingANameWaitsOnTheNameLock(t *testing.T) {
 			if err != nil {
 				return err
 			}
-			// The empty value is the point: the old gate read it and skipped
-			// the lock.
+			// The empty value is the case worth pinning: it writes the row
+			// like any other and is the easiest to mistake for "no name".
 			_, err = applyEvidenceFields(ctx, tx, workspaceID(ctx), orgID, "site_read", by,
 				[]ColdStartFieldInput{{
 					Field: fieldLegalName, Value: "",
@@ -126,7 +96,7 @@ func TestAnEvidenceApplyCarryingANameWaitsOnTheNameLock(t *testing.T) {
 		})
 	}()
 
-	if finished, waited := awaitBlockedOn(t, holder, pid, done); !waited {
+	if waited, finished := waitUntilBlockedBy(t, holder, pid, done); !waited {
 		t.Fatalf("the apply completed without ever waiting on the name lock (err=%v) — "+
 			"it can take this organization's row lock first and deadlock against a rename", finished)
 	}
@@ -197,7 +167,7 @@ func TestAnEvidenceApplyWithoutANameDoesNotWaitOnTheNameLock(t *testing.T) {
 		})
 	}()
 
-	finished, waited := awaitBlockedOn(t, holder, pid, done)
+	waited, finished := waitUntilBlockedBy(t, holder, pid, done)
 	if waited {
 		t.Fatal("an apply carrying no name waited on the workspace-wide name lock — " +
 			"every industry or address batch would serialize behind unrelated renames")


### PR DESCRIPTION
The review round's findings — including the three reported as *pre-existing rather than from the diff*, which turned out to be the ones that mattered.

## Two name writers never re-checked

| path | writes | re-checked? |
|---|---|---|
| `MergeOrganization` → `fillOrgSurvivorship` | survivor's `legal_name`, from the retired record | **no** |
| company form → `writeCompanyFields` | `legal_name` | **no** (`resolveOrCreateAnchor` re-checks only when `display_name` moved) |

Merging B into A can hand A a name identical to a third organization C, and nothing was filed. And a human typing the registered name into the company form was the one rename path that detected nothing at all. Both now re-check, and both take the name lock ahead of their row locks like every other writer.

## A cleared name could never be refilled

The evidence apply's overwrite arm wrote `legal_name = ''` where the human form clears to `NULL`, and the fill arm matches `IS NULL`. So once a read cleared a legal name, no later read could ever fill it — the record looked answered while holding nothing.

## The contention test is the real fix for last round's gap

A table test over the gate's boolean passes whether or not anything calls it. My first version of this test was no better: it proved the apply **waited**, which an apply that takes the row lock first also does — one statement too late.

It now asks the question that matters. While the apply is parked, the holder reaches for the organization row a rename would edit:

- parked *before* touching the row → succeeds at once ✓
- parked *while holding* the row → the two are in the cycle that deadlocks ✗

Reverting the gate to its value-based form fails it. The previous version passed.

## Also

- The field name is the package's existing `fieldLegalName` rather than seven independent literals, so the gate and the re-check it guards cannot name different fields.
- `company.go` crossed the 500-line cap; its form-writing half moved to `companyform.go`.

## Verification

- `make check` — green
- `make test-integration` — `OK: integration passed with 0 skips (28 packages)`
- `craft static` — **0 blockers, 0 major, 0 minor**
- Mutation-checked: reverting the gate fails the new contention test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix duplicate detection and deadlocks around organization legal name writes. Re-checks now happen only on real renames, the name lock is taken before any row locks, empty values no longer poison the column, and tests prove the ordering at call sites.

- **Bug Fixes**
  - Company form and merge flows re-check duplicates only if `legal_name` actually moved; both take the name lock before any row locks, and the merge re-check runs after archiving the source.
  - Prevent poisoned names: overwrites store empty as NULL; fill-on-null ignores empty; coldstart overwrite also routes through NULL.
  - New integration tests verify: applies that carry a name wait on the name lock without holding the row; applies without a name do not wait.

- **Refactors**
  - Split field vs column constants (`fieldLegalName` vs `columnLegalName`); replace literals.
  - Moved company form writers to `companyform.go`; column writes use IS DISTINCT FROM and report when a value moved.
  - Shared `emptyToNil`; generalized the probe helper (`waitUntilBlockedBy` + `mustBlockOn`); recorded open follow-ups in `STATUS.md`.

<sup>Written for commit 0c17bf0209c261a8c8fac82cd3d7fc8cb7d38bc2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/378?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Company form submissions now save updated values and retain audit information.
  * Clearing a company field removes its stored value cleanly.
* **Bug Fixes**
  * Improved duplicate-name detection when creating, editing, or merging companies.
  * Prevented conflicting company-name updates during simultaneous changes.
  * Improved handling of legal-name updates, including clearing previously stored names.
  * Enhanced reliability when applying company information without a name change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->