### PR TITLE
build(sbom): digest every local file, not just package-owned ones

### DIFF
--- a/.syft.yaml
+++ b/.syft.yaml
@@ -24,6 +24,23 @@ enrich:
 license:
   content: none
 
+# Digest every file in the scanned tree, not just files a package cataloger
+# claims. syft's default selection ("owned-by-package") only hashes files
+# attributed to a discovered package, leaving first-party source
+# (backend/**, frontend/src/**, migrations, config templates) with no
+# checksum. "all" hashes the whole export — the same clean `git archive HEAD`
+# content, minus the exclude globs below — so the SBOM records a verifiable
+# digest for every shipped local file. SHA1 is kept because SPDX file entries
+# historically key on it; SHA256 and SHA512 are the modern integrity checks
+# consumers verify against.
+file:
+  metadata:
+    selection: all
+    digests:
+      - sha1
+      - sha256
+      - sha512
+
 # Committed trees that are agent/CI/build-tooling/test state, not shipped
 # product source or dependency manifests. The clean export already drops
 # uncommitted host state (node_modules, build output, .env); these drop the


### PR DESCRIPTION
## What

Extend the source-tree SBOMs to record a hash digest for **every** local file, not only files a package cataloger claims.

syft's default file-metadata selection (`owned-by-package`) hashes only files it can attribute to a discovered dependency, so all first-party source — `backend/**`, `frontend/src/**`, migrations, config templates — landed in the SBOM with no checksum. This sets `file.metadata.selection: all` in `.syft.yaml` so syft digests every file in the scanned tree (the same clean `git archive HEAD` export, minus the existing `exclude` globs).

Digests recorded: **sha1, sha256, sha512** — sha1 because SPDX file entries historically key on it, sha256/sha512 as the modern integrity checks consumers verify against.

## Verification

Ran `make sbom` locally against the pinned syft image:

- CycloneDX: **2456** file components, each carrying SHA-1 + SHA-256 + SHA-512
- SPDX 2.2.1 / 3.0: all file entries checksummed
- **0** files leaked from the excluded trees (`cli/craft`, `fixtures`, `.github`, `.claude`) — the `exclude` globs still apply to file cataloging
- `make sbom-check` (grant license gate) still green — it reads package licenses, not file entries

Config-only change (`.syft.yaml`); `sboms/` remains a gitignored build artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Configure `syft` via `.syft.yaml` to hash every file in the source tree so SBOMs include checksums for all first‑party files. Adds SHA‑1, SHA‑256, and SHA‑512 digests to each file entry; existing exclude globs still apply.

<sup>Written for commit 6162105f5b542939fb113d66f9d43a7daa62e876. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated software inventory scanning to generate SHA-1, SHA-256, and SHA-512 hashes for every file in the scanned directory.
  * Improved completeness of file integrity and inventory results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->