### PR TITLE
fix(contract): cc feeds the interaction edge, matching ADR-0078

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -11053,9 +11053,14 @@ components:
             `in_contact_with` — `from` is the workspace member who has been IN recorded
             interactions (email, call, meeting) with the contact at `to`. It is drawn from
             the recorded participants of those interactions, so it holds for
-            connector-captured mail as well as manually logged activity. Being copied on a
-            thread does not make one, and neither does a task assigned to a teammate: a cc
-            is exposure and an assignment is intent, while a logged exchange is contact.
+            connector-captured mail as well as manually logged activity. Every participant
+            role makes one, `cc` included: in an account team the person permanently in
+            copy is frequently the one who knows the customer, so excluding them removes
+            exactly the people this edge exists to find. The quality bar sits in the score
+            rather than a role filter — copy traffic is one-directional, so the reciprocity
+            term ranks a permanently-cc'd colleague below anyone in a two-way thread. A
+            task assigned to a teammate still makes none: an assignment is intent, while a
+            recorded interaction is contact.
         role:
           type: [string, 'null']
           description: |

--- a/backend/internal/compose/graphedge_integration_test.go
+++ b/backend/internal/compose/graphedge_integration_test.go
@@ -276,7 +276,8 @@ func TestTheNightlyRebuildAgreesWithTheIncrementalPath(t *testing.T) {
 	now := time.Now().UTC()
 
 	// A spread of traffic across two colleagues and two contacts, including a
-	// cc row that must not count and an archived one that must not either.
+	// cc row — which counts, one-directionally — and an archived one, which
+	// does not count at all. Both paths must fold them the same way.
 	c1 := v.person(t, "Contact One")
 	c2 := v.person(t, "Contact Two")
 	var all []ids.UUID

--- a/backend/internal/compose/org360/graphourside.go
+++ b/backend/internal/compose/org360/graphourside.go
@@ -125,9 +125,12 @@ func (g *graphAssembly) readAccountOwner() error {
 // opening a busy account saw "nobody here has been in touch", and there was no
 // error anywhere to suggest otherwise.
 //
-// Real contact still means a real exchange: the projection counts only direct
-// participant roles, so a cc never becomes a connection, and a task or a note
-// is not an interaction at all.
+// Real contact still means a recorded exchange rather than an intention: a
+// task or a note is not an interaction at all. Every participant role does
+// count, cc included (ADR-0078) — in an account team the colleague permanently
+// in copy is frequently the one who knows the customer. Copy-only traffic is
+// one-directional, so the reciprocity term ranks that colleague below anyone
+// in a two-way thread instead of a role filter removing them.
 //
 // On gating: the contacts passed in are the ones the card has already PLACED,
 // which means they have already passed the person row-scope gate — and capture

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -11149,9 +11149,14 @@ type OrganizationGraphEdge struct {
 	// `in_contact_with` — `from` is the workspace member who has been IN recorded
 	// interactions (email, call, meeting) with the contact at `to`. It is drawn from
 	// the recorded participants of those interactions, so it holds for
-	// connector-captured mail as well as manually logged activity. Being copied on a
-	// thread does not make one, and neither does a task assigned to a teammate: a cc
-	// is exposure and an assignment is intent, while a logged exchange is contact.
+	// connector-captured mail as well as manually logged activity. Every participant
+	// role makes one, `cc` included: in an account team the person permanently in
+	// copy is frequently the one who knows the customer, so excluding them removes
+	// exactly the people this edge exists to find. The quality bar sits in the score
+	// rather than a role filter — copy traffic is one-directional, so the reciprocity
+	// term ranks a permanently-cc'd colleague below anyone in a two-way thread. A
+	// task assigned to a teammate still makes none: an assignment is intent, while a
+	// recorded interaction is contact.
 	Kind OrganizationGraphEdgeKind `json:"kind"`
 
 	// Role The edge's role where it has one — an employment title, a stakeholder role
@@ -11196,9 +11201,14 @@ type OrganizationGraphEdge struct {
 // `in_contact_with` — `from` is the workspace member who has been IN recorded
 // interactions (email, call, meeting) with the contact at `to`. It is drawn from
 // the recorded participants of those interactions, so it holds for
-// connector-captured mail as well as manually logged activity. Being copied on a
-// thread does not make one, and neither does a task assigned to a teammate: a cc
-// is exposure and an assignment is intent, while a logged exchange is contact.
+// connector-captured mail as well as manually logged activity. Every participant
+// role makes one, `cc` included: in an account team the person permanently in
+// copy is frequently the one who knows the customer, so excluding them removes
+// exactly the people this edge exists to find. The quality bar sits in the score
+// rather than a role filter — copy traffic is one-directional, so the reciprocity
+// term ranks a permanently-cc'd colleague below anyone in a two-way thread. A
+// task assigned to a teammate still makes none: an assignment is intent, while a
+// recorded interaction is contact.
 type OrganizationGraphEdgeKind string
 
 // OrganizationGraphEdgeStrengthBucket The display band for `strength`, so a surface renders the same words everywhere.

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -7241,9 +7241,14 @@ export interface components {
              *     `in_contact_with` — `from` is the workspace member who has been IN recorded
              *     interactions (email, call, meeting) with the contact at `to`. It is drawn from
              *     the recorded participants of those interactions, so it holds for
-             *     connector-captured mail as well as manually logged activity. Being copied on a
-             *     thread does not make one, and neither does a task assigned to a teammate: a cc
-             *     is exposure and an assignment is intent, while a logged exchange is contact.
+             *     connector-captured mail as well as manually logged activity. Every participant
+             *     role makes one, `cc` included: in an account team the person permanently in
+             *     copy is frequently the one who knows the customer, so excluding them removes
+             *     exactly the people this edge exists to find. The quality bar sits in the score
+             *     rather than a role filter — copy traffic is one-directional, so the reciprocity
+             *     term ranks a permanently-cc'd colleague below anyone in a two-way thread. A
+             *     task assigned to a teammate still makes none: an assignment is intent, while a
+             *     recorded interaction is contact.
              * @enum {string}
              */
             kind: "employment" | "has_deal" | "deal_stakeholder" | "parent_of" | "partner_of" | "referred_by" | "co_sell_with" | "owns" | "in_contact_with";


### PR DESCRIPTION
## What

The `in_contact_with` description in `backend/api/crm.yaml` still said a cc creates no interaction edge. ADR-0078 reversed that on 2026-07-31 and the shipped code follows the ADR, so the normative contract contradicted the fold it describes.

## Why it mattered

`interactionRoles` in `internal/modules/search/graphedge.go` includes `'cc'`, and ADR-0078 carries "Every role feeds an edge, `cc` included (amended 2026-07-31, founder — reversing this ADR's first position)". The contract prose was a leftover copy of the pre-amendment position. Anyone reading the contract as the source of truth would have concluded the edge fold was wrong.

The reasoning the reversal recorded: in an account team the person permanently in copy is frequently the one who actually knows the customer, so filtering by role removes exactly the people the edge exists to find. The quality bar sits in the score instead — copy traffic is one-directional, so the reciprocity term ranks a permanently cc'd colleague below anyone in a two-way thread.

An assignment still makes no edge, and that sentence is kept.

## Scope

- `backend/api/crm.yaml` — the `in_contact_with` description only. No schema, path, or behaviour change.
- `backend/internal/contracts/api_gen.go` — regenerated via `make gen`.

Two matching stale copies in the spec repo (`specs/adr/DECISIONS.md` A123 and `specs/adr/README.md`) are being reconciled separately.

## Verification

`make check-backend` green, including the contract drift gate and `OK: composition reproducible`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the CRM API contract and internal comments with ADR-0078: `cc` participants create an `in_contact_with` edge; assignments still create none. Removes contract and comment drift; no behavior change.

- **Bug Fixes**
  - Updated `backend/api/crm.yaml` description for `in_contact_with` to include `cc` and note reciprocity scoring.
  - Regenerated `backend/internal/contracts/api_gen.go` and `frontend/src/api/schema.d.ts`.
  - Corrected comments in `backend/internal/compose/org360/graphourside.go` and `backend/internal/compose/graphedge_integration_test.go` to state that `cc` counts (ranked down by reciprocity).

<sup>Written for commit b159150b2fcd991362e845ca297739754db29cd8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified contact relationship documentation to include all interaction participants, including copied recipients.
  * Documented how one-way copied messages are evaluated through reciprocity scoring.
  * Confirmed that task assignments do not establish a contact relationship.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->