### PR TITLE
feat(mcp): three verbs the contract declares that the surface could not reach

### DIFF
--- a/backend/internal/compose/agentgate.go
+++ b/backend/internal/compose/agentgate.go
@@ -355,12 +355,27 @@ func advanceDealTierInput(ctx context.Context, deps tierDeps, _ agentPolicy, _ *
 	var args struct {
 		ToStageID ids.UUID `json:"to_stage_id"`
 	}
-	// Two different faults, so two different answers. An unreadable body is not
-	// an omitted key, and telling the caller "to_stage_id is required" when the
-	// JSON never parsed points them at a field that may well be there.
+	// THREE faults, three answers, and the order matters because each later check
+	// presumes the earlier one passed.
+	//
+	// json.Unmarshal alone cannot tell them apart: it fails identically for a body
+	// that is not JSON and for a body that is perfectly good JSON carrying a
+	// to_stage_id the UUID decoder refuses. Answering "not readable JSON" to the
+	// second sends the caller hunting a syntax error that is not there, while the
+	// real fault — a value they can see and fix — goes unnamed.
+	if !json.Valid(body) {
+		// malformed_json, the code httperr.Decode answers on the session half of
+		// this same route — one mistake must not carry two machine codes keyed on
+		// which credential the caller presented.
+		return mcp.TierResolverInput{}, httperr.Validation("body", "malformed_json",
+			"the request body is not readable JSON")
+	}
 	if err := json.Unmarshal(body, &args); err != nil {
+		// Valid JSON the shape refuses: a non-object, or a to_stage_id that is not
+		// a UUID string. Naming the field is right for both — the fix is to send an
+		// object carrying a canonical UUID there.
 		return mcp.TierResolverInput{}, httperr.Validation("to_stage_id", "invalid",
-			"the request body is not readable JSON, so the target stage cannot be resolved")
+			"to_stage_id must be a canonical UUID string on a JSON object body")
 	}
 	// The omission goes through the one implementation, so a passport reaching
 	// this gate and a session reaching advanceDealInput read the SAME sentence.

--- a/backend/internal/compose/agentgate.go
+++ b/backend/internal/compose/agentgate.go
@@ -355,8 +355,19 @@ func advanceDealTierInput(ctx context.Context, deps tierDeps, _ agentPolicy, _ *
 	var args struct {
 		ToStageID ids.UUID `json:"to_stage_id"`
 	}
-	if err := json.Unmarshal(body, &args); err != nil || args.ToStageID.IsZero() {
-		return mcp.TierResolverInput{}, httperr.Validation("to_stage_id", "required", "to_stage_id must be a stage UUID")
+	// Two different faults, so two different answers. An unreadable body is not
+	// an omitted key, and telling the caller "to_stage_id is required" when the
+	// JSON never parsed points them at a field that may well be there.
+	if err := json.Unmarshal(body, &args); err != nil {
+		return mcp.TierResolverInput{}, httperr.Validation("to_stage_id", "invalid",
+			"the request body is not readable JSON, so the target stage cannot be resolved")
+	}
+	// The omission goes through the one implementation, so a passport reaching
+	// this gate and a session reaching advanceDealInput read the SAME sentence.
+	// The gate resolves the tier before the handler runs, so without this the
+	// rule had two spellings on the one field U3 unified.
+	if err := httperr.RequireBodyID("to_stage_id", args.ToStageID); err != nil {
+		return mcp.TierResolverInput{}, err
 	}
 	semantic, pipelineID, err := deps.stages.StageSemantic(ctx, args.ToStageID)
 	if err != nil {

--- a/backend/internal/compose/agentgate_pin_test.go
+++ b/backend/internal/compose/agentgate_pin_test.go
@@ -182,3 +182,74 @@ func TestRedemptionWithoutAPinLeavesIfMatchAlone(t *testing.T) {
 		t.Errorf("forwarded If-Match = %q, want it unset for an unpinned approval", forwarded)
 	}
 }
+
+// undecidableConfirmFirstTypes are the confirm-first target types the approvals
+// inbox has no visibility rule for, each with what it costs.
+//
+// The cost is the same for every entry and it is severe: `decidable` backs the
+// inbox list, the single Get and the Decide, so a row it rejects is invisible AND
+// undecidable — an authority object a human can neither release nor reject. The
+// approval.requested fan-out is dropped for the same reason
+// (webhooks.approvalTargetVisible has the matching arms), so nobody is even told.
+// The row then sits pending until the staging TTL clears it, and an agent
+// retrying a legitimate refusal accumulates more of them.
+//
+// This is a backlog, not a design: every entry is a confirm-first verb the tool
+// surface or a passport's REST call can stage today. It is written down so the
+// class is enumerated rather than invisible, and so it can only shrink — a NEW
+// confirm-first record type joins it deliberately or fails the gate below.
+var undecidableConfirmFirstTypes = map[string]string{
+	"list":                 "approvals.targetVisible has no `list` arm — a staged list change is invisible in the inbox and cannot be decided",
+	"tag":                  "no `tag` arm; same effect",
+	"project":              "no `project` arm, though the row is owner-scoped exactly like a deal — this one is a straightforward auth.VisibleTo addition",
+	"record_grant":         "no `record_grant` arm; share_record is also a dead end at redemption (see synthesizedVerbs' deadEndVerbs)",
+	"saved_view":           "no `saved_view` arm",
+	"offer_template":       "no `offer_template` arm",
+	"overlay_connection":   "no `overlay_connection` arm",
+	"webhook_subscription": "no `webhook_subscription` arm",
+}
+
+// Every confirm-first operation that names a concrete record type must stage a
+// row a human can actually SEE and DECIDE.
+//
+// The read-side twin of the pin gate above, and it closes the same shape of hole
+// one level further on: a pinned target nobody can see is still a zombie. The
+// invariant is derived from the generated policy table rather than from a list of
+// the types someone remembered, so a verb that becomes confirm-first upstream
+// fails here until its target type gains a visibility rule or a ratified reason.
+func TestEveryConfirmFirstTargetTypeIsDecidable(t *testing.T) {
+	for recordType, cost := range undecidableConfirmFirstTypes {
+		if strings.TrimSpace(cost) == "" {
+			t.Errorf("undecidableConfirmFirstTypes[%s] has no reason — a waiver must say what it costs", recordType)
+		}
+	}
+
+	used := map[string]bool{}
+	checked := 0
+	for route, pol := range agentPolicies {
+		if pol.Access != accessTool || pol.Tier == tierAutoExecute || pol.RecordType == "" {
+			continue
+		}
+		checked++
+		if approvals.TargetTypeDecidable(string(pol.RecordType)) {
+			continue
+		}
+		if _, ratified := undecidableConfirmFirstTypes[string(pol.RecordType)]; ratified {
+			used[string(pol.RecordType)] = true
+			continue
+		}
+		t.Errorf("%s (%s) stages against %q, which approvals.targetVisible has no rule for — the staged "+
+			"row would be invisible in the inbox and undecidable at the decision, so no human could ever "+
+			"release or reject it. Give the type a visibility arm, or ratify the residue in "+
+			"undecidableConfirmFirstTypes with what it costs.", route, pol.Op, pol.RecordType)
+	}
+	if checked == 0 {
+		t.Fatal("no confirm-first record-typed routes in the generated policy — the gate no longer covers anything")
+	}
+	for recordType := range undecidableConfirmFirstTypes {
+		if !used[recordType] {
+			t.Errorf("undecidableConfirmFirstTypes[%s] matches no confirm-first route, or the type gained a "+
+				"visibility rule — stale waiver, remove it", recordType)
+		}
+	}
+}

--- a/backend/internal/compose/agentgate_pin_test.go
+++ b/backend/internal/compose/agentgate_pin_test.go
@@ -199,14 +199,24 @@ func TestRedemptionWithoutAPinLeavesIfMatchAlone(t *testing.T) {
 // class is enumerated rather than invisible, and so it can only shrink — a NEW
 // confirm-first record type joins it deliberately or fails the gate below.
 var undecidableConfirmFirstTypes = map[string]string{
-	"list":                 "approvals.targetVisible has no `list` arm — a staged list change is invisible in the inbox and cannot be decided",
-	"tag":                  "no `tag` arm; same effect",
-	"project":              "no `project` arm, though the row is owner-scoped exactly like a deal — this one is a straightforward auth.VisibleTo addition",
-	"record_grant":         "no `record_grant` arm; share_record is also a dead end at redemption (see synthesizedVerbs' deadEndVerbs)",
-	"saved_view":           "no `saved_view` arm",
-	"offer_template":       "no `offer_template` arm",
-	"overlay_connection":   "no `overlay_connection` arm",
-	"webhook_subscription": "no `webhook_subscription` arm",
+	"list": "archiveList stages against a list; a curator cannot release or reject the deletion of " +
+		"their own segment. The row is owner-scoped, so this is an auth.VisibleTo arm.",
+	"tag": "archiveTag — same shape and the same one-line fix as `list`.",
+	"record_grant": "createRecordGrant/revokeRecordGrant. Left waived rather than fixed because " +
+		"visibility is not the only gap: share_record ALSO dead-ends at redemption (deadEndVerbs in " +
+		"agentpolicysynthesis_test.go — the grant verbs reject any non-human principal, so an " +
+		"agent-staged, human-approved grant is refused as the redeeming agent every time). An arm here " +
+		"would make the row decidable and the operation would still never land, which is worse than an " +
+		"honest dead end. Answer the redemption question first.",
+	"saved_view": "archiveSavedView; the owner cannot release the deletion of their own view. " +
+		"Owner-scoped, so an auth.VisibleTo arm.",
+	"offer_template": "archiveOfferTemplate; workspace-shared config with no row scope, so it wants " +
+		"the targetExists floor `product` and `custom_field` already use, not a scope probe.",
+	"overlay_connection": "disconnectIncumbent stages against the connection row, so nobody can " +
+		"approve cutting the workspace back to native mode — the one transition an operator most needs " +
+		"to confirm deliberately.",
+	"webhook_subscription": "archiveWebhookSubscription; the subscription owner cannot release the " +
+		"deletion of their own endpoint. Owner-scoped.",
 }
 
 // Every confirm-first operation that names a concrete record type must stage a

--- a/backend/internal/compose/integration/customfields_http_assertions_test.go
+++ b/backend/internal/compose/integration/customfields_http_assertions_test.go
@@ -391,12 +391,16 @@ func assertListFiltering(t *testing.T, e *env) {
 		t.Fatalf("status=retired must include only the retired field: %+v", retiredOnly.Data)
 	}
 
+	// A DIFFERENT valid target object, not just any string: the object parameter
+	// is membership-checked against customfields.FieldObjects, so a non-target
+	// (`activity`, `relationship`) answers 422 and would prove nothing about
+	// filtering.
 	var otherObject customFieldListWire
-	if s := e.call(t, "GET", "/v1/custom-fields?object=activity", nil, nil, &otherObject); s != http.StatusOK {
+	if s := e.call(t, "GET", "/v1/custom-fields?object=organization", nil, nil, &otherObject); s != http.StatusOK {
 		t.Fatalf("list other-object status = %d, want 200: %+v", s, otherObject)
 	}
 	if containsID(otherObject.Data, active.ID) || containsID(otherObject.Data, retiring.ID) {
-		t.Fatalf("object filter leaked a lead field into the activity list: %+v", otherObject.Data)
+		t.Fatalf("object filter leaked a lead field into the organization list: %+v", otherObject.Data)
 	}
 }
 

--- a/backend/internal/compose/integration/overlay_dispatch_integration_test.go
+++ b/backend/internal/compose/integration/overlay_dispatch_integration_test.go
@@ -161,11 +161,20 @@ var overlayReaderPerms = principal.Permissions{
 }
 
 func overlayActorCtx(ws, user ids.UUID) context.Context {
+	return overlayActorCtxWith(ws, user, overlayReaderPerms)
+}
+
+// overlayActorCtxWith is overlayActorCtx for a caller that needs a WIDER grant
+// than the least-privilege reader. It exists so a mode-guard assertion can hand
+// the actor every object grant the guarded read would need — otherwise an
+// unwired guard fails the assertion with "permission denied", which passes for
+// the wrong reason and leaves object RBAC looking like the backstop it is not.
+func overlayActorCtxWith(ws, user ids.UUID, perms principal.Permissions) context.Context {
 	ctx := principal.WithWorkspaceID(context.Background(), ws)
 	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
 	return principal.WithActor(ctx, principal.Principal{
 		Type: principal.PrincipalHuman, ID: "human:" + user.String(), UserID: user,
-		Permissions: overlayReaderPerms,
+		Permissions: perms,
 	})
 }
 

--- a/backend/internal/compose/integration/overlay_toolsurface_integration_test.go
+++ b/backend/internal/compose/integration/overlay_toolsurface_integration_test.go
@@ -40,11 +40,20 @@ import (
 )
 
 // nativeOnlyAgentTools are the tools whose only implementation reads the
-// native domain tables: the compiled report engine, the two retrieval-
-// grounded context intents, and the pipeline-risk scan. None has a mirror
-// projection to serve, so each owes an honest refusal in overlay mode. The
-// args only have to be well-formed — the refusal must land before any record
-// lookup, so a not-found in place of the sentinel means the guard runs late.
+// native domain tables: the compiled report engine, the two retrieval-grounded
+// context intents, the pipeline-risk scan and its draft sibling, the two
+// relationship-graph reads, and the pipeline configuration read. None has a
+// mirror projection to serve, so each owes an honest refusal in overlay mode.
+// The args only have to be well-formed — the refusal must land before any
+// record lookup, so a not-found in place of the sentinel means the guard runs
+// late.
+//
+// This map is HAND-KEPT, and that is its weakness: "which tools read native
+// tables" is not visible from a tool spec, so a newly guarded tool joins this
+// pin only because someone remembered. It has been wrong that way before —
+// intro_path_to and at_risk_relationships carried nativeOnly guards that this
+// gate had never examined. Whoever adds a nativeOnly… wrapper in
+// compose/nativeonlytools.go adds its tool here in the same change.
 func nativeOnlyAgentTools(anchor ids.UUID) map[string]string {
 	return map[string]string{
 		"run_report":               `{"report":"deals-by-stage"}`,
@@ -52,14 +61,37 @@ func nativeOnlyAgentTools(anchor ids.UUID) map[string]string {
 		"prep_for_meeting":         fmt.Sprintf(`{"record_type":"person","record_id":%q}`, anchor),
 		"whats_slipping_this_week": `{}`,
 		"draft_follow_ups_for":     `{"segment":"slipping"}`,
+		"intro_path_to":            fmt.Sprintf(`{"organization_id":%q}`, anchor),
+		"at_risk_relationships":    `{}`,
+		"list_pipelines":           `{}`,
 	}
+}
+
+// nativeToolReaderPerms is overlayReaderPerms plus the `pipeline` object.
+// list_pipelines rides the deals module's own config read, which is RBAC-gated
+// on `pipeline` — so a reader without that grant is refused for a reason that
+// has nothing to do with system-of-record mode, and the native half of this
+// suite would be asserting the wrong thing.
+func nativeToolReaderPerms() principal.Permissions {
+	perms := overlayReaderPerms
+	objects := make(map[string]principal.ObjectGrant, len(perms.Objects)+1)
+	for object, grant := range perms.Objects {
+		objects[object] = grant
+	}
+	objects["pipeline"] = principal.ObjectGrant{Read: true}
+	perms.Objects = objects
+	return perms
 }
 
 func TestOverlayAgentToolsRefuseRatherThanAnswerFromNativeTables(t *testing.T) {
 	e := Setup(t)
 	ws, user := seedOverlayModeWorkspace(t)
 	registry := compose.NewRegistry(e.Pool, compose.SendPath{})
-	ctx := overlayActorCtx(ws, user)
+	// Every object grant a guarded read could need, so an unwired guard fails
+	// with the native-table answer this suite exists to forbid rather than with
+	// "permission denied" — which would pass the assertion for a reason that has
+	// nothing to do with system-of-record mode.
+	ctx := overlayActorCtxWith(ws, user, nativeToolReaderPerms())
 
 	for name, args := range nativeOnlyAgentTools(ids.NewV7()) {
 		t.Run(name, func(t *testing.T) {
@@ -305,13 +337,15 @@ func seedNativeModeWorkspaceForFlip(t *testing.T) (ws, user ids.UUID) {
 func TestNativeAgentToolsAreNotRefusedByTheSoRModeGuard(t *testing.T) {
 	e := Setup(t)
 	registry := compose.NewRegistry(e.Pool, compose.SendPath{})
-	ctx := e.As(e.Rep1, nil, overlayReaderPerms)
+	ctx := e.As(e.Rep1, nil, nativeToolReaderPerms())
 
-	// The two anchored intents may honestly answer not-found (their anchor id
-	// is minted, not seeded); the two that take no record must SUCCEED, so a
+	// The anchored intents may honestly answer not-found (their anchor id is
+	// minted, not seeded); the ones that take no record must SUCCEED, so a
 	// native report path that broke outright cannot hide behind "well, it
 	// didn't say unsupported_by_sor".
-	anchored := map[string]bool{"catch_me_up_on": true, "prep_for_meeting": true}
+	anchored := map[string]bool{
+		"catch_me_up_on": true, "prep_for_meeting": true, "intro_path_to": true,
+	}
 
 	for name, args := range nativeOnlyAgentTools(ids.NewV7()) {
 		t.Run(name, func(t *testing.T) {

--- a/backend/internal/compose/integration/overlay_toolsurface_integration_test.go
+++ b/backend/internal/compose/integration/overlay_toolsurface_integration_test.go
@@ -48,12 +48,12 @@ import (
 // record lookup, so a not-found in place of the sentinel means the guard runs
 // late.
 //
-// This map is HAND-KEPT, and that is its weakness: "which tools read native
-// tables" is not visible from a tool spec, so a newly guarded tool joins this
-// pin only because someone remembered. It has been wrong that way before —
-// intro_path_to and at_risk_relationships carried nativeOnly guards that this
-// gate had never examined. Whoever adds a nativeOnly… wrapper in
-// compose/nativeonlytools.go adds its tool here in the same change.
+// Every `nativeOnly…` guard in compose/nativeonlytools.go must name its tool
+// here, and every tool here must be named by exactly one guard —
+// TestEveryNativeOnlyGuardNamesAToolThePinCovers holds the two in step. So a
+// newly guarded tool is enrolled by the gate rather than by being remembered,
+// which is what "which tools read native tables is not visible from a tool spec"
+// otherwise costs.
 func nativeOnlyAgentTools(anchor ids.UUID) map[string]string {
 	return map[string]string{
 		"run_report":               `{"report":"deals-by-stage"}`,

--- a/backend/internal/compose/integration/pipelinediscovery_integration_test.go
+++ b/backend/internal/compose/integration/pipelinediscovery_integration_test.go
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The dead end, closed end to end: a caller that knows nothing but the tool
+// list must be able to create a deal.
+//
+// This is U2's acceptance criterion, and it is here rather than in a manual
+// script because a manual run proves it once. `create_record` for a deal
+// REQUIRES pipeline_id and stage_id; before list_pipelines nothing on the
+// surface yielded either, so the only two ways to obtain them were to read the
+// database or to be told. Both are things an agent cannot do.
+//
+// It drives compose.NewRegistry — the same constructor the api role uses — so a
+// future edit that unregisters the tool, drops a field from its answer, or
+// stops the deal mapping from accepting those ids turns this red.
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// toolPipeline is what a caller can see of the answer: only the fields the tool
+// advertises are decoded, so a field renamed on the wire fails here rather than
+// being read off the Go struct that produced it.
+type toolPipeline struct {
+	ID        ids.UUID `json:"id"`
+	Name      string   `json:"name"`
+	IsDefault bool     `json:"is_default"`
+	Stages    []struct {
+		ID             ids.UUID `json:"id"`
+		Name           string   `json:"name"`
+		Semantic       string   `json:"semantic"`
+		WinProbability int      `json:"win_probability"`
+		Position       int      `json:"position"`
+	} `json:"stages"`
+}
+
+func TestADealCanBeCreatedFromNothingButTheToolSurface(t *testing.T) {
+	e := Setup(t)
+	DealFixture(t, e) // the workspace's seeded default pipeline
+	registry := compose.NewRegistry(e.Pool, compose.SendPath{})
+	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, AdminPerms)
+
+	out, err := registry.Invoke(ctx, "list_pipelines", json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("list_pipelines: %v", err)
+	}
+	var answer struct {
+		Pipelines []toolPipeline `json:"pipelines"`
+	}
+	if err := json.Unmarshal(out, &answer); err != nil {
+		t.Fatalf("unreadable list_pipelines answer %s: %v", out, err)
+	}
+	if len(answer.Pipelines) == 0 {
+		t.Fatalf("list_pipelines answered %s — the seeded default pipeline is missing", out)
+	}
+
+	// The caller picks the way an agent would: the default pipeline, and the
+	// first stage whose semantic says a deal belongs there. Not "the first
+	// stage", and not a stage matched by name — semantic is the field that
+	// carries the meaning, which is why the tool returns it.
+	pipeline := answer.Pipelines[0]
+	for _, p := range answer.Pipelines {
+		if p.IsDefault {
+			pipeline = p
+			break
+		}
+	}
+	var open ids.UUID
+	for _, stage := range pipeline.Stages {
+		if stage.Semantic == "open" {
+			open = stage.ID
+			break
+		}
+	}
+	if open.IsZero() {
+		t.Fatalf("no stage in %q reports semantic=open; stages were %+v — a deal cannot be born",
+			pipeline.Name, pipeline.Stages)
+	}
+
+	created, err := registry.Invoke(ctx, "create_record", json.RawMessage(
+		`{"record_type":"deal","fields":{"name":"Pipeline discovery","pipeline_id":"`+
+			pipeline.ID.String()+`","stage_id":"`+open.String()+`","currency":"EUR","amount_minor":250000}}`))
+	if err != nil {
+		t.Fatalf("create_record deal with ids obtained from list_pipelines: %v", err)
+	}
+
+	// The read-back proves the write landed rather than that the call returned:
+	// create_record answers with the record it created, so a deal id and the
+	// stage it was filed into are both in the payload.
+	var record struct {
+		RecordType string          `json:"record_type"`
+		ID         ids.UUID        `json:"id"`
+		Fields     json.RawMessage `json:"fields"`
+	}
+	if err := json.Unmarshal(created, &record); err != nil {
+		t.Fatalf("unreadable create_record answer %s: %v", created, err)
+	}
+	if record.RecordType != "deal" || record.ID.IsZero() {
+		t.Fatalf("create_record answered %s, want a deal carrying an id", created)
+	}
+	var fields struct {
+		StageID    ids.UUID `json:"stage_id"`
+		PipelineID ids.UUID `json:"pipeline_id"`
+	}
+	if err := json.Unmarshal(record.Fields, &fields); err != nil {
+		t.Fatalf("unreadable deal fields %s: %v", record.Fields, err)
+	}
+	if fields.StageID != open || fields.PipelineID != pipeline.ID {
+		t.Errorf("the deal was filed into pipeline %s stage %s, want the pair list_pipelines named (%s / %s)",
+			fields.PipelineID, fields.StageID, pipeline.ID, open)
+	}
+}
+
+// The move, from the same starting point: advance_deal's to_stage_id has the
+// same problem create_record's stage_id had, and the same answer.
+func TestADealCanBeAdvancedToAStageObtainedFromTheToolSurface(t *testing.T) {
+	e := Setup(t)
+	pipeline, open, _ := DealFixture(t, e)
+	dealID := e.SeedDeal(t, "Advance discovery", pipeline, open, &e.Rep1)
+	registry := compose.NewRegistry(e.Pool, compose.SendPath{})
+	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, AdminPerms)
+
+	out, err := registry.Invoke(ctx, "list_pipelines", json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("list_pipelines: %v", err)
+	}
+	var answer struct {
+		Pipelines []toolPipeline `json:"pipelines"`
+	}
+	if err := json.Unmarshal(out, &answer); err != nil {
+		t.Fatalf("unreadable list_pipelines answer %s: %v", out, err)
+	}
+
+	// A LATER open stage: advancing onto a won or lost one is 🟡 and would be
+	// staged rather than executed, which is a different assertion.
+	var target ids.UUID
+	for _, p := range answer.Pipelines {
+		if pipeline.UUID != p.ID {
+			continue
+		}
+		for _, stage := range p.Stages {
+			if stage.Semantic == "open" && stage.ID != open.UUID {
+				target = stage.ID
+				break
+			}
+		}
+	}
+	if target.IsZero() {
+		t.Fatalf("the seeded pipeline offers no second open stage in %s", out)
+	}
+
+	advanced, err := registry.Invoke(ctx, "advance_deal", json.RawMessage(
+		`{"deal_id":"`+dealID.String()+`","to_stage_id":"`+target.String()+`"}`))
+	if err != nil {
+		t.Fatalf("advance_deal onto an open stage from list_pipelines: %v", err)
+	}
+	var record struct {
+		Fields struct {
+			StageID ids.UUID `json:"stage_id"`
+		} `json:"fields"`
+	}
+	if err := json.Unmarshal(advanced, &record); err != nil {
+		t.Fatalf("unreadable advance_deal answer %s: %v", advanced, err)
+	}
+	if record.Fields.StageID != target {
+		t.Errorf("the deal sits in stage %s, want the one list_pipelines named (%s)",
+			record.Fields.StageID, target)
+	}
+}

--- a/backend/internal/compose/integration/relationship_integration_test.go
+++ b/backend/internal/compose/integration/relationship_integration_test.go
@@ -277,3 +277,60 @@ func assertDecidableInTheInbox(t *testing.T, e *env, approvalID, wantTargetType 
 	}
 	t.Fatalf("the staged approval is not in the pending inbox (%d rows) — nobody can act on it", len(inbox.Data))
 }
+
+// An approval stays decidable after its target edge is archived out from under it.
+//
+// EnsureRelationshipVisible deliberately does NOT filter archived rows, unlike
+// Store.GetRelationship, which does. That asymmetry is the whole reason a human can
+// still REJECT a staged archive of an edge somebody removed in the meantime — and
+// nothing gated it, so the next author adding `AND r.archived_at IS NULL` for
+// symmetry with the read verb would take the guarantee away with every test green.
+//
+// This is the case that makes the deviation load-bearing rather than a comment.
+func TestAnApprovalStaysDecidableAfterItsEdgeIsArchived(t *testing.T) {
+	e := setupRelationships(t)
+
+	var edge struct {
+		ID string `json:"id"`
+	}
+	if status := e.call(t, "POST", "/v1/relationships", anyMap{
+		"kind": "employment", "person_id": e.personID, "organization_id": e.orgID,
+		"role": "cfo", "source": "ui",
+	}, nil, &edge); status != http.StatusCreated {
+		t.Fatalf("create employment → %d", status)
+	}
+
+	var minted struct {
+		Token string `json:"token"`
+	}
+	if status := e.call(t, "POST", "/v1/passports", anyMap{
+		"label": "archived edge agent", "scopes": []string{"read", "write"},
+	}, nil, &minted); status != http.StatusCreated {
+		t.Fatalf("issue passport → %d", status)
+	}
+
+	var problem struct {
+		Detail string `json:"detail"`
+	}
+	if status := e.call(t, "DELETE", "/v1/relationships/"+edge.ID, nil,
+		map[string]string{"Authorization": "Bearer " + minted.Token}, &problem); status != http.StatusForbidden {
+		t.Fatalf("agent archive → %d, want 403 approval_required", status)
+	}
+	approvalID := extractStagedApprovalID(t, problem.Detail)
+
+	// The human archives the edge themselves, which is exactly the race the
+	// approval was staged into: the target is gone before anyone decided.
+	if status := e.call(t, "DELETE", "/v1/relationships/"+edge.ID, nil, nil, nil); status != http.StatusOK {
+		t.Fatalf("human archive → %d", status)
+	}
+
+	// The staged row must STILL be visible and rejectable. If it were not, the
+	// approval would sit pending until its TTL with no way to clear it.
+	assertDecidableInTheInbox(t, e.env, approvalID, "relationship")
+	if got := e.call(t, "POST", "/v1/approvals/"+approvalID+"/reject", anyMap{
+		"reason": "already archived",
+	}, nil, nil); got != http.StatusOK {
+		t.Errorf("rejecting an approval whose edge was archived → %d, want 200 — a human must be able to "+
+			"clear authority whose target is gone", got)
+	}
+}

--- a/backend/internal/compose/integration/relationship_integration_test.go
+++ b/backend/internal/compose/integration/relationship_integration_test.go
@@ -116,6 +116,91 @@ func TestRelationshipLifecycle(t *testing.T) {
 	}
 }
 
+// Ending an employment is a 🟡 act for an AGENT: it changes what the record says
+// about a person's job, and it is hard to undo for whoever needed the edge. The
+// human path above deletes it outright, because the confirm-first tier governs
+// agent principals, not people in their own seat (ADR-0055 makes a passport's
+// REST call governed exactly like its MCP twin).
+//
+// The pin is the second assertion, and it is the one worth spelling out: this
+// REST path stages through the approvals engine, which resolves target_version
+// itself inside the staging transaction for every target type its versionTables
+// set knows — `relationship` is in that set, so the pin lands without the
+// caller offering one. A type absent from it stages a NULL pin, and redemption's
+// skew check short-circuits on NULL, so the approval would authorize the archive
+// against whatever the edge had drifted to inside the TTL.
+//
+// (The MCP twin reaches staging differently — archive_record's StageInfo READS
+// the target to summarize it — which is why the seam owes a relationship Read.
+// That read is exercised by create_record's read-back in
+// relationship_seam_integration_test.go.)
+func TestArchivingAnEdgeStagesForAnAgentAndPinsItsVersion(t *testing.T) {
+	e := setupRelationships(t)
+
+	var edge struct {
+		ID      string `json:"id"`
+		Version int64  `json:"version"`
+	}
+	if status := e.call(t, "POST", "/v1/relationships", anyMap{
+		"kind": "employment", "person_id": e.personID, "organization_id": e.orgID,
+		"role": "cto", "source": "ui",
+	}, nil, &edge); status != http.StatusCreated {
+		t.Fatalf("create employment → %d", status)
+	}
+
+	var minted struct {
+		Token string `json:"token"`
+	}
+	if status := e.call(t, "POST", "/v1/passports", anyMap{
+		"label": "edge agent", "scopes": []string{"read", "write"},
+	}, nil, &minted); status != http.StatusCreated {
+		t.Fatalf("issue passport → %d", status)
+	}
+	bearer := map[string]string{"Authorization": "Bearer " + minted.Token}
+
+	var problem struct {
+		Code   string `json:"code"`
+		Detail string `json:"detail"`
+	}
+	status := e.call(t, "DELETE", "/v1/relationships/"+edge.ID, nil, bearer, &problem)
+	if status != http.StatusForbidden || problem.Code != "approval_required" {
+		t.Fatalf("agent archive → %d %q, want 403 approval_required", status, problem.Code)
+	}
+	approvalID := extractStagedApprovalID(t, problem.Detail)
+
+	// The pin the STAGING read produced. Without it the approval would authorize
+	// the archive against whatever the edge had drifted to inside the TTL — and a
+	// nil pin is exactly what a target type the seam cannot read produces.
+	var pin *int64
+	if err := e.owner.QueryRow(t.Context(),
+		`SELECT target_version FROM approval WHERE id = $1`, approvalID).Scan(&pin); err != nil {
+		t.Fatal(err)
+	}
+	if pin == nil {
+		t.Fatal("the staged archive carries no target_version — redemption's skew check short-circuits " +
+			"on NULL, so the approval would authorize the archive whatever the edge became")
+	}
+	if *pin != edge.Version {
+		t.Errorf("target_version = %d, want the edge's own %d", *pin, edge.Version)
+	}
+
+	// The edge is untouched while the approval is pending.
+	var listed struct {
+		Data []struct {
+			ID         string  `json:"id"`
+			ArchivedAt *string `json:"archived_at"`
+		} `json:"data"`
+	}
+	if got := e.call(t, "GET", "/v1/relationships?person_id="+e.personID+"&kind=employment", nil, nil, &listed); got != http.StatusOK {
+		t.Fatalf("list while parked → %d", got)
+	}
+	for _, rel := range listed.Data {
+		if rel.ID == edge.ID && rel.ArchivedAt != nil {
+			t.Errorf("the edge was archived while its approval was still pending")
+		}
+	}
+}
+
 func TestPartnerPromotionLifecycle(t *testing.T) {
 	e := setupRelationships(t)
 

--- a/backend/internal/compose/integration/relationship_integration_test.go
+++ b/backend/internal/compose/integration/relationship_integration_test.go
@@ -184,20 +184,31 @@ func TestArchivingAnEdgeStagesForAnAgentAndPinsItsVersion(t *testing.T) {
 		t.Errorf("target_version = %d, want the edge's own %d", *pin, edge.Version)
 	}
 
+	assertDecidableInTheInbox(t, e.env, approvalID, "relationship")
+
 	// The edge is untouched while the approval is pending.
-	var listed struct {
+	var parked struct {
 		Data []struct {
 			ID         string  `json:"id"`
 			ArchivedAt *string `json:"archived_at"`
 		} `json:"data"`
 	}
-	if got := e.call(t, "GET", "/v1/relationships?person_id="+e.personID+"&kind=employment", nil, nil, &listed); got != http.StatusOK {
+	if got := e.call(t, "GET", "/v1/relationships?person_id="+e.personID+"&kind=employment", nil, nil, &parked); got != http.StatusOK {
 		t.Fatalf("list while parked → %d", got)
 	}
-	for _, rel := range listed.Data {
+	for _, rel := range parked.Data {
 		if rel.ID == edge.ID && rel.ArchivedAt != nil {
 			t.Errorf("the edge was archived while its approval was still pending")
 		}
+	}
+
+	// And it can be REJECTED, which is the half a caller cannot fake: a decision
+	// runs the same visibility predicate as the list.
+	if got := e.call(t, "POST", "/v1/approvals/"+approvalID+"/reject", anyMap{
+		"reason": "probe",
+	}, nil, nil); got != http.StatusOK {
+		t.Fatalf("deciding the staged archive → %d, want 200 — a row the inbox lists and cannot decide is "+
+			"the same dead end one step later", got)
 	}
 }
 
@@ -234,4 +245,35 @@ func TestPartnerPromotionLifecycle(t *testing.T) {
 	if status := e.call(t, "GET", "/v1/partners?cert_status=suspended", nil, nil, &partners); status != http.StatusOK {
 		t.Fatalf("filtered list → %d", status)
 	}
+}
+
+// assertDecidableInTheInbox is the assertion that makes a 403 approval_required
+// mean something: a staged row a human cannot SEE is one they can never release
+// or reject, and `decidable` backs the list, the single read and the decision
+// alike — so an approval whose target type the inbox has no visibility rule for
+// is a zombie, and the fan-out that would have told anyone is dropped too.
+func assertDecidableInTheInbox(t *testing.T, e *env, approvalID, wantTargetType string) {
+	t.Helper()
+	var inbox struct {
+		Data []struct {
+			ID         string `json:"id"`
+			TargetType string `json:"target_entity_type"`
+		} `json:"data"`
+	}
+	if got := e.call(t, "GET", "/v1/approvals?status=pending", nil, nil, &inbox); got != http.StatusOK {
+		t.Fatalf("list approvals → %d", got)
+	}
+	for _, a := range inbox.Data {
+		if a.ID != approvalID {
+			continue
+		}
+		if a.TargetType != wantTargetType {
+			t.Errorf("the staged row's target_entity_type is %q, want %q", a.TargetType, wantTargetType)
+		}
+		if got := e.call(t, "GET", "/v1/approvals/"+approvalID, nil, nil, nil); got != http.StatusOK {
+			t.Fatalf("GET the staged approval → %d, want 200", got)
+		}
+		return
+	}
+	t.Fatalf("the staged approval is not in the pending inbox (%d rows) — nobody can act on it", len(inbox.Data))
 }

--- a/backend/internal/compose/integration/relationship_seam_integration_test.go
+++ b/backend/internal/compose/integration/relationship_seam_integration_test.go
@@ -276,9 +276,10 @@ func TestAnEdgeCannotBeCreatedOverAnEndpointTheCallerCannotSee(t *testing.T) {
 	}
 }
 
-// The refusals a caller can act on. #370 gave the shape and date rules their own
-// fault verdicts; this is the check that they reach the TOOL surface, which
-// never runs the HTTP mapper those verdicts used to live in.
+// The refusals a caller can act on. The shape and date rules carry their own
+// fault verdicts, and this is the check that those verdicts reach the TOOL
+// surface — which never runs the HTTP mapper, so a verdict that lived only in a
+// transport branch would arrive as an internal fault with advice to retry.
 func TestAMisshapenEdgeIsRefusedWithSomethingTheCallerCanAct(t *testing.T) {
 	e := Setup(t)
 	registry := compose.NewRegistry(e.Pool, compose.SendPath{})

--- a/backend/internal/compose/integration/relationship_seam_integration_test.go
+++ b/backend/internal/compose/integration/relationship_seam_integration_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/compose"
 	"github.com/gradionhq/margince/backend/internal/modules/agents"
 	"github.com/gradionhq/margince/backend/internal/modules/people"
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/platform/httperr"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -405,3 +406,76 @@ func TestAProjectStakeholderEdgeKeepsTheProjectItNames(t *testing.T) {
 			fields.ProjectID, projectID)
 	}
 }
+
+// ONE hidden endpoint is enough, which is the rule the conjunction exists for and
+// the case the both-hidden test above cannot reach.
+//
+// This file's premise is that an edge readable by someone who cannot read its
+// ORGANIZATION discloses that organization's existence and its link to a person
+// they can read. With both ends hidden, an edge would also be refused by a
+// provider that only ever checked the person — so the both-hidden case passes
+// against a weaker rule than the one claimed. Only this case separates a
+// CONJUNCTION from a check of whichever endpoint happens to be looked at first.
+func TestOneHiddenEndpointIsEnoughToHideTheEdge(t *testing.T) {
+	e := Setup(t)
+	registry := compose.NewRegistry(e.Pool, compose.SendPath{})
+	admin := e.As(e.Rep1, nil, AdminPerms)
+	stranger := e.As(e.Rep3, []ids.UUID{e.Team2}, relationshipReaderPerms())
+
+	// The person is the STRANGER's own, so their row scope admits it. The
+	// organization belongs to Rep2, so it does not.
+	mine, err := e.People.CreatePerson(stranger, people.CreatePersonInput{FullName: "Rep3 Visible", Source: "manual"})
+	if err != nil {
+		t.Fatalf("Rep3 creating their own person: %v", err)
+	}
+	owner := ids.From[ids.UserKind](e.Rep2)
+	hidden, err := e.People.CreateOrganization(admin, people.CreateOrganizationInput{
+		DisplayName: "Rep2 Only", OwnerID: &owner, Source: "manual",
+	})
+	if err != nil {
+		t.Fatalf("seeding the hidden organization: %v", err)
+	}
+
+	// Created by the admin, so the edge's existence owes nothing to the stranger.
+	created, err := registry.Invoke(admin, "create_record", json.RawMessage(fmt.Sprintf(
+		`{"record_type":"relationship","fields":{"kind":"employment","person_id":%q,"organization_id":%q,"source":"ui"}}`,
+		mine.Id, hidden.Id)))
+	if err != nil {
+		t.Fatalf("create_record as admin over a mixed pair: %v", err)
+	}
+	edgeID, _ := wireEdge(t, created)
+
+	// The stranger can read the person. They must still not reach the edge — and
+	// the answer must be NOT FOUND, because a permission-denied would confirm it.
+	if _, err := e.People.GetPerson(stranger, ids.From[ids.PersonKind](ids.UUID(mine.Id)), storekit.LiveOnly); err != nil {
+		t.Fatalf("the stranger cannot read their OWN person, so this case proves nothing: %v", err)
+	}
+	for _, call := range []struct{ tool, args string }{
+		{"update_record", fmt.Sprintf(`{"record_type":"relationship","id":%q,"fields":{"started_at":"2026-05-01"}}`, edgeID)},
+		{"archive_record", fmt.Sprintf(`{"record_type":"relationship","id":%q}`, edgeID)},
+	} {
+		_, err := registry.Invoke(stranger, call.tool, json.RawMessage(call.args))
+		if !errors.Is(err, apperrors.ErrNotFound) {
+			t.Errorf("%s on an edge with ONE hidden endpoint = %v, want ErrNotFound — the visible person "+
+				"is not enough, or the rule is a check of one end rather than a conjunction of all of them",
+				call.tool, err)
+		}
+	}
+
+	// And the edge is absent from the person-filtered LIST, which is how a list
+	// hides: by omission, not by refusing.
+	edges, _, err := e.People.ListRelationships(stranger, people.ListRelationshipsInput{
+		PersonID: idPtr(ids.From[ids.PersonKind](ids.UUID(mine.Id))),
+	})
+	if err != nil {
+		t.Fatalf("listing the stranger's own person's edges: %v", err)
+	}
+	if len(edges) != 0 {
+		t.Errorf("the list returned %d edge(s) for a person whose only edge points at an organization the "+
+			"caller cannot read — the organization's existence and its link to this person both leak",
+			len(edges))
+	}
+}
+
+// idPtr takes the address of a typed id for the optional filter fields.
+func idPtr[K ids.EntityKind](id ids.ID[K]) *ids.ID[K] { return &id }

--- a/backend/internal/compose/integration/relationship_seam_integration_test.go
+++ b/backend/internal/compose/integration/relationship_seam_integration_test.go
@@ -1,0 +1,406 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// A relationship edge as a first-class resource on the tool surface: created,
+// read, patched and archived through compose.NewRegistry, the same constructor
+// the api role uses.
+//
+// A new entity reaching records through the datasource seam is where visibility
+// goes wrong, so that is what most of this file is about. An edge's visibility
+// derives from its ENDPOINTS — every non-null one must be visible to the caller
+// — and the failure mode is specific: an edge that answered would name two
+// records, so an edge readable by someone who cannot read its organization
+// leaks that organization's existence and its link to a person. Unit tests
+// cannot reach that rule; it is rendered as SQL against the caller's row scope.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/modules/agents"
+	"github.com/gradionhq/margince/backend/internal/modules/people"
+	"github.com/gradionhq/margince/backend/internal/platform/httperr"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/workflow"
+)
+
+// edgeFields is the read-back shape a caller sees. Only what the contract
+// declares is decoded, so a field the wire mapping drops fails here — which is
+// the whole point for project_id, which it used to drop.
+type edgeFields struct {
+	Kind             string    `json:"kind"`
+	PersonID         *ids.UUID `json:"person_id"`
+	OrganizationID   *ids.UUID `json:"organization_id"`
+	DealID           *ids.UUID `json:"deal_id"`
+	ProjectID        *ids.UUID `json:"project_id"`
+	Role             *string   `json:"role"`
+	IsCurrentPrimary *bool     `json:"is_current_primary"`
+	StartedAt        *string   `json:"started_at"`
+}
+
+// wireEdge decodes a create/update/read answer into the record envelope plus
+// the edge's own fields.
+func wireEdge(t *testing.T, raw json.RawMessage) (ids.UUID, edgeFields) {
+	t.Helper()
+	var record struct {
+		RecordType string          `json:"record_type"`
+		ID         ids.UUID        `json:"id"`
+		Fields     json.RawMessage `json:"fields"`
+	}
+	if err := json.Unmarshal(raw, &record); err != nil {
+		t.Fatalf("unreadable answer %s: %v", raw, err)
+	}
+	if record.RecordType != "relationship" {
+		t.Fatalf("record_type = %q, want relationship (answer %s)", record.RecordType, raw)
+	}
+	var fields edgeFields
+	if err := json.Unmarshal(record.Fields, &fields); err != nil {
+		t.Fatalf("unreadable edge fields %s: %v", record.Fields, err)
+	}
+	return record.ID, fields
+}
+
+// relationshipReaderPerms is a row-scoped caller: they may read and write edges
+// and their endpoints, but only over rows they own. RowScopeOwn is what makes
+// the endpoint-conjunction clause render at all — an unbounded caller carries no
+// clause, so a suite that only used AdminPerms would assert nothing about it.
+func relationshipReaderPerms() principal.Permissions {
+	return principal.Permissions{
+		RoleKeys: []string{"rep"},
+		Objects: map[string]principal.ObjectGrant{
+			"person":       {Create: true, Read: true, Update: true, Delete: true},
+			"organization": {Create: true, Read: true, Update: true, Delete: true},
+			"relationship": {Create: true, Read: true, Update: true, Delete: true},
+		},
+		RowScope: principal.RowScopeOwn,
+	}
+}
+
+// seedEndpointPair creates a person and an organization under the caller's own
+// context, so both are visible to it whatever row scope it carries.
+func seedEndpointPair(ctx context.Context, t *testing.T, e *Env, who, where string) (person, org ids.UUID) {
+	t.Helper()
+	p, err := e.People.CreatePerson(ctx, people.CreatePersonInput{FullName: who, Source: "manual"})
+	if err != nil {
+		t.Fatalf("seeding the person %q: %v", who, err)
+	}
+	o, err := e.People.CreateOrganization(ctx, people.CreateOrganizationInput{DisplayName: where, Source: "manual"})
+	if err != nil {
+		t.Fatalf("seeding the organization %q: %v", where, err)
+	}
+	return ids.UUID(p.Id), ids.UUID(o.Id)
+}
+
+// createEmployment writes one employment edge through create_record and returns
+// the edge as the caller reads it back.
+func createEmployment(ctx context.Context, t *testing.T, r *agents.Registry, person, org ids.UUID, extra string) (ids.UUID, edgeFields) {
+	t.Helper()
+	created, err := r.Invoke(ctx, "create_record", json.RawMessage(fmt.Sprintf(
+		`{"record_type":"relationship","fields":{"kind":"employment","person_id":%q,"organization_id":%q,"source":"ui"%s}}`,
+		person, org, extra)))
+	if err != nil {
+		t.Fatalf("create_record relationship: %v", err)
+	}
+	return wireEdge(t, created)
+}
+
+func TestAnEmploymentEdgeLivesItsWholeLifeThroughTheToolSurface(t *testing.T) {
+	e := Setup(t)
+	registry := compose.NewRegistry(e.Pool, compose.SendPath{})
+	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, AdminPerms)
+	person, org := seedEndpointPair(ctx, t, e, "Ada Employed", "Employer GmbH")
+
+	// CREATE. The read-back is what proves the write landed: create_record
+	// answers with the record it made, and for an edge that means the seam had
+	// to serve a relationship Read too — without it the row would commit and the
+	// tool would report a read-back failure.
+	edgeID, fields := createEmployment(ctx, t, registry, person, org, `,"role":"cto","is_current_primary":true`)
+	if fields.Kind != "employment" || fields.PersonID == nil || *fields.PersonID != person ||
+		fields.OrganizationID == nil || *fields.OrganizationID != org {
+		t.Fatalf("the edge read back as %+v, want an employment between the seeded pair", fields)
+	}
+	if fields.Role == nil || *fields.Role != "cto" {
+		t.Errorf("role = %v, want cto", fields.Role)
+	}
+
+	// UPDATE. A patch reaches the dates and role, never the endpoints. Filling
+	// a field the edge does not hold yet stays auto-execute — there is no human
+	// value to undo — which is what makes this the case that proves the patch
+	// path serves an edge at all.
+	updated, err := registry.Invoke(ctx, "update_record", json.RawMessage(fmt.Sprintf(
+		`{"record_type":"relationship","id":%q,"fields":{"started_at":"2026-02-01"}}`, edgeID)))
+	if err != nil {
+		t.Fatalf("update_record relationship: %v", err)
+	}
+	_, patched := wireEdge(t, updated)
+	if patched.StartedAt == nil || *patched.StartedAt != "2026-02-01" {
+		t.Errorf("started_at after patch = %v, want 2026-02-01", patched.StartedAt)
+	}
+	// The endpoints survived the patch: coalesce-style updates that lost a
+	// nullable column would silently detach the edge from one of its ends.
+	if patched.PersonID == nil || patched.OrganizationID == nil {
+		t.Errorf("the patch dropped an endpoint: %+v", patched)
+	}
+	if patched.Role == nil || *patched.Role != "cto" {
+		t.Errorf("role = %v after an unrelated patch, want the human's own cto", patched.Role)
+	}
+
+	// And per-field human-edit precedence reaches the new entity too: `role` was
+	// written by a human, so overwriting it is STAGED rather than applied. This
+	// is the rule that stops a tool call quietly undoing someone's edit, and a
+	// new record type inherits it or it does not hold.
+	_, err = registry.Invoke(ctx, "update_record", json.RawMessage(fmt.Sprintf(
+		`{"record_type":"relationship","id":%q,"fields":{"role":"vp_sales"}}`, edgeID)))
+	var overwrite *workflow.StagedApprovalError
+	if !errors.As(err, &overwrite) {
+		t.Errorf("overwriting a human-written role answered %v, want a staged approval", err)
+	}
+
+	// ARCHIVE. The caller here is a HUMAN in their own seat, so the 🟡 tier does
+	// not stage — that gate is for agent principals, and the agent half is
+	// proven over REST with a real passport
+	// (TestArchivingAnEdgeStagesForAnAgentAndPinsItsVersion).
+	if _, err := registry.Invoke(ctx, "archive_record", json.RawMessage(fmt.Sprintf(
+		`{"record_type":"relationship","id":%q}`, edgeID))); err != nil {
+		t.Fatalf("archive_record relationship: %v", err)
+	}
+	// And it is GONE from the read, like every other archived record: a Read
+	// that went on serving it would report an employment that had been ended.
+	if _, err := e.People.GetRelationship(ctx, edgeID); !errors.Is(err, apperrors.ErrNotFound) {
+		t.Errorf("reading the archived edge = %v, want ErrNotFound", err)
+	}
+	if _, err := registry.Invoke(ctx, "update_record", json.RawMessage(fmt.Sprintf(
+		`{"record_type":"relationship","id":%q,"fields":{"started_at":"2026-04-01"}}`, edgeID))); !errors.Is(err, apperrors.ErrNotFound) {
+		t.Errorf("patching the archived edge = %v, want ErrNotFound", err)
+	}
+}
+
+func TestAnEdgeIsInvisibleWhenEitherEndpointIsOutOfTheCallersRowScope(t *testing.T) {
+	e := Setup(t)
+	registry := compose.NewRegistry(e.Pool, compose.SendPath{})
+	admin := e.As(e.Rep1, nil, AdminPerms)
+
+	// Both endpoints owned by Rep2. The edge is created by the admin, so its
+	// existence owes nothing to Rep1.
+	owner := ids.From[ids.UserKind](e.Rep2)
+	person, err := e.People.CreatePerson(admin, people.CreatePersonInput{
+		FullName: "Rep2 Contact", OwnerID: &owner, Source: "manual",
+	})
+	if err != nil {
+		t.Fatalf("seeding the person: %v", err)
+	}
+	org, err := e.People.CreateOrganization(admin, people.CreateOrganizationInput{
+		DisplayName: "Rep2 Account", OwnerID: &owner, Source: "manual",
+	})
+	if err != nil {
+		t.Fatalf("seeding the organization: %v", err)
+	}
+	created, err := registry.Invoke(admin, "create_record", json.RawMessage(fmt.Sprintf(
+		`{"record_type":"relationship","fields":{"kind":"employment","person_id":%q,"organization_id":%q,"source":"ui"}}`,
+		person.Id, org.Id)))
+	if err != nil {
+		t.Fatalf("create_record relationship as admin: %v", err)
+	}
+	edgeID, _ := wireEdge(t, created)
+
+	// Rep3 owns neither endpoint and sits in the other team. Every verb that
+	// returns or touches the row must answer NOT FOUND — not permission-denied,
+	// which would confirm the edge exists.
+	stranger := e.As(e.Rep3, []ids.UUID{e.Team2}, relationshipReaderPerms())
+	for _, call := range []struct{ tool, args string }{
+		{"update_record", fmt.Sprintf(`{"record_type":"relationship","id":%q,"fields":{"role":"cto"}}`, edgeID)},
+		{"archive_record", fmt.Sprintf(`{"record_type":"relationship","id":%q}`, edgeID)},
+	} {
+		_, err := registry.Invoke(stranger, call.tool, json.RawMessage(call.args))
+		if !errors.Is(err, apperrors.ErrNotFound) {
+			t.Errorf("%s on an out-of-scope edge = %v, want ErrNotFound — an edge whose endpoints the "+
+				"caller cannot read must not answer that it exists", call.tool, err)
+		}
+		if errors.Is(err, apperrors.ErrPermissionDenied) {
+			t.Errorf("%s answered permission-denied, which confirms the edge exists", call.tool)
+		}
+	}
+
+	// And the same caller CAN reach an edge over endpoints they do own, so the
+	// refusals above are the scope rule and not a blanket denial. Without this
+	// control the whole test would pass against a provider that refused every
+	// relationship.
+	ownPerson, ownOrg := seedEndpointPair(stranger, t, e, "Rep3 Own", "Rep3 Account")
+	ownEdge, _ := createEmployment(stranger, t, registry, ownPerson, ownOrg, "")
+	// started_at, not role: role carries a human's audited write from the create,
+	// so patching it would stage for precedence and say nothing about row scope.
+	if _, err := registry.Invoke(stranger, "update_record", json.RawMessage(fmt.Sprintf(
+		`{"record_type":"relationship","id":%q,"fields":{"started_at":"2026-03-01"}}`, ownEdge))); err != nil {
+		t.Errorf("Rep3 patching their own edge: %v — the refusals above are a blanket denial, not row scope", err)
+	}
+}
+
+// An edge may not be created OVER an endpoint the caller cannot see either: a
+// write that succeeded would tell the caller the record on the other end exists,
+// and would attach one of their own records to it.
+func TestAnEdgeCannotBeCreatedOverAnEndpointTheCallerCannotSee(t *testing.T) {
+	e := Setup(t)
+	registry := compose.NewRegistry(e.Pool, compose.SendPath{})
+	admin := e.As(e.Rep1, nil, AdminPerms)
+
+	owner := ids.From[ids.UserKind](e.Rep2)
+	hidden, err := e.People.CreateOrganization(admin, people.CreateOrganizationInput{
+		DisplayName: "Not Yours", OwnerID: &owner, Source: "manual",
+	})
+	if err != nil {
+		t.Fatalf("seeding the hidden organization: %v", err)
+	}
+	stranger := e.As(e.Rep3, []ids.UUID{e.Team2}, relationshipReaderPerms())
+	mine, err := e.People.CreatePerson(stranger, people.CreatePersonInput{FullName: "Rep3 Contact", Source: "manual"})
+	if err != nil {
+		t.Fatalf("Rep3 creating their own person: %v", err)
+	}
+
+	_, err = registry.Invoke(stranger, "create_record", json.RawMessage(fmt.Sprintf(
+		`{"record_type":"relationship","fields":{"kind":"employment","person_id":%q,"organization_id":%q,"source":"ui"}}`,
+		mine.Id, hidden.Id)))
+
+	if !errors.Is(err, apperrors.ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound — an edge onto an invisible organization would disclose it", err)
+	}
+}
+
+// The refusals a caller can act on. #370 gave the shape and date rules their own
+// fault verdicts; this is the check that they reach the TOOL surface, which
+// never runs the HTTP mapper those verdicts used to live in.
+func TestAMisshapenEdgeIsRefusedWithSomethingTheCallerCanAct(t *testing.T) {
+	e := Setup(t)
+	registry := compose.NewRegistry(e.Pool, compose.SendPath{})
+	ctx := e.As(e.Rep1, nil, AdminPerms)
+
+	person, err := e.People.CreatePerson(ctx, people.CreatePersonInput{FullName: "Shape Probe", Source: "manual"})
+	if err != nil {
+		t.Fatalf("seeding the person: %v", err)
+	}
+	org, err := e.People.CreateOrganization(ctx, people.CreateOrganizationInput{DisplayName: "Shape Org", Source: "manual"})
+	if err != nil {
+		t.Fatalf("seeding the organization: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name, args, wants string
+	}{
+		{
+			// The kind/endpoint mismatch: employment wants person + organization,
+			// so a counterparty org is the wrong pair. The refusal is a
+			// MessageFault, because the fault is in the PAIR — no single
+			// argument is wrong on its own.
+			name: "wrong endpoint pair for the kind",
+			args: fmt.Sprintf(`{"record_type":"relationship","fields":{"kind":"employment","person_id":%q,`+
+				`"counterparty_org_id":%q,"source":"ui"}}`, person.Id, org.Id),
+			wants: "employment",
+		},
+		{
+			name: "a kind the vocabulary does not have",
+			args: fmt.Sprintf(`{"record_type":"relationship","fields":{"kind":"drinking_buddy","person_id":%q,`+
+				`"organization_id":%q,"source":"ui"}}`, person.Id, org.Id),
+			wants: "kind",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := registry.Invoke(ctx, "create_record", json.RawMessage(tc.args))
+			if err == nil {
+				t.Fatal("the write was accepted")
+			}
+			// Classified, which is what decides whether the agent reads a
+			// sentence it can act on or "the tool failed for an internal reason".
+			fault, ok := httperr.Classify(err)
+			if !ok {
+				t.Fatalf("err = %v is outside the taxonomy, so the tool surface reports it as an "+
+					"internal fault with advice to retry a call the server has already settled", err)
+			}
+			if fault.Status < 400 || fault.Status >= 500 {
+				t.Errorf("status = %d, want a 4xx — this is the caller's mistake", fault.Status)
+			}
+			if !strings.Contains(strings.ToLower(err.Error()), tc.wants) {
+				t.Errorf("refusal %q names nothing the caller can change; expected it to mention %q",
+					err.Error(), tc.wants)
+			}
+		})
+	}
+}
+
+// A date range that runs backwards names the field at fault, on this surface as
+// on the other one.
+func TestAnEdgeEndingBeforeItBeganNamesTheDateField(t *testing.T) {
+	e := Setup(t)
+	registry := compose.NewRegistry(e.Pool, compose.SendPath{})
+	ctx := e.As(e.Rep1, nil, AdminPerms)
+
+	person, err := e.People.CreatePerson(ctx, people.CreatePersonInput{FullName: "Date Probe", Source: "manual"})
+	if err != nil {
+		t.Fatalf("seeding the person: %v", err)
+	}
+	org, err := e.People.CreateOrganization(ctx, people.CreateOrganizationInput{DisplayName: "Date Org", Source: "manual"})
+	if err != nil {
+		t.Fatalf("seeding the organization: %v", err)
+	}
+
+	_, err = registry.Invoke(ctx, "create_record", json.RawMessage(fmt.Sprintf(
+		`{"record_type":"relationship","fields":{"kind":"employment","person_id":%q,"organization_id":%q,`+
+			`"started_at":"2026-06-01","ended_at":"2026-01-01","source":"ui"}}`, person.Id, org.Id)))
+	if err == nil {
+		t.Fatal("an edge that ended before it began was accepted")
+	}
+	fault, ok := httperr.Classify(err)
+	if !ok {
+		t.Fatalf("err = %v is outside the taxonomy", err)
+	}
+	named := false
+	for _, field := range fault.Fields {
+		if field.Field == "ended_at" {
+			named = true
+		}
+	}
+	if !named {
+		t.Errorf("the refusal's fields are %+v, want one naming ended_at — the field a caller changes",
+			fault.Fields)
+	}
+}
+
+// project_id, which the create mapping used to drop and the wire mapping never
+// rendered. A project_stakeholder edge is the kind that cannot exist without it:
+// unguarded, its project endpoint vanished on the way in and the database
+// refused the edge for a pair the caller HAD supplied.
+func TestAProjectStakeholderEdgeKeepsTheProjectItNames(t *testing.T) {
+	e := Setup(t)
+	registry := compose.NewRegistry(e.Pool, compose.SendPath{})
+	ctx := e.As(e.Rep1, []ids.UUID{e.Team1}, AdminPerms)
+
+	person, err := e.People.CreatePerson(ctx, people.CreatePersonInput{FullName: "Stakeholder", Source: "manual"})
+	if err != nil {
+		t.Fatalf("seeding the person: %v", err)
+	}
+	org := e.SeedOrg(t, "Project Owner GmbH", nil)
+	project := seedProject(ctx, t, e, "Edge project", nil, org, nil)
+	projectID := project.ID.UUID
+
+	created, err := registry.Invoke(ctx, "create_record", json.RawMessage(fmt.Sprintf(
+		`{"record_type":"relationship","fields":{"kind":"project_stakeholder","project_id":%q,"person_id":%q,`+
+			`"role":"sponsor","source":"ui"}}`, projectID, person.Id)))
+	if err != nil {
+		t.Fatalf("create_record project_stakeholder: %v — this is the shape that fails when project_id "+
+			"is dropped between the body and the store", err)
+	}
+	_, fields := wireEdge(t, created)
+	if fields.ProjectID == nil || *fields.ProjectID != projectID {
+		t.Errorf("project_id read back as %v, want %s — the endpoint that defines this kind",
+			fields.ProjectID, projectID)
+	}
+}

--- a/backend/internal/compose/integration/relationshipscope_integration_test.go
+++ b/backend/internal/compose/integration/relationshipscope_integration_test.go
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// An endpoint the visibility conjunction forgets is an endpoint that leaks.
+//
+// A relationship owns no owner_id: it is visible when EVERY non-null endpoint is
+// visible, which auth.RelationshipEndpointScope renders as one EXISTS per endpoint
+// column. That clause is the only thing standing between an edge and the records it
+// names — an edge answered to someone who cannot read one of its ends discloses
+// that record's existence AND its link to the other.
+//
+// The clause enumerates its columns, and it has to: each needs the table it points
+// at, which no schema introspection supplies. So the hazard is a migration adding a
+// sixth endpoint column that the clause never learns about — the edge would then be
+// scoped by four of its five ends, and rows reachable through the new one would be
+// visible to anyone. Nothing in the unit-test lane can see that, because the column
+// list and the clause are the same source.
+//
+// This gate reads the DATABASE instead: every foreign key on `relationship` that
+// points at a row-scoped record table must appear in the clause. It fails on the
+// migration, not on the leak.
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// scopedEndpointTables are the record tables whose rows carry row scope, so a
+// relationship column pointing at one of them MUST be in the conjunction. A
+// foreign key to anything else (a workspace, a user, a catalog row) is not an
+// endpoint whose visibility an edge inherits.
+var scopedEndpointTables = map[string]bool{
+	"person": true, "organization": true, "deal": true, "project": true, "lead": true,
+}
+
+// tenantColumn rides in every foreign key on a tenant table: the FKs here are
+// composite, `(workspace_id, <endpoint>) REFERENCES <table>(workspace_id, id)`, so
+// that a row can never point across tenants. It is not an endpoint — RLS owns it,
+// and the conjunction would gain nothing by re-checking the workspace the GUC
+// already binds — so it is excluded by name rather than by being forgotten.
+const tenantColumn = "workspace_id"
+
+func TestEveryScopedEndpointColumnIsInTheVisibilityConjunction(t *testing.T) {
+	e := Setup(t)
+
+	// Read the real foreign keys off the live schema. pg_constraint is the
+	// authority — a column added by a migration appears here the moment it exists,
+	// which is the whole point of asking the database rather than the Go list.
+	type fk struct{ column, target string }
+	var keys []fk
+	ctx := e.Admin()
+	if err := database.WithWorkspaceTx(ctx, e.Pool, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `
+			SELECT att.attname, cl.relname
+			  FROM pg_constraint con
+			  JOIN pg_class src ON src.oid = con.conrelid
+			  JOIN pg_class cl ON cl.oid = con.confrelid
+			  JOIN unnest(con.conkey) AS k(attnum) ON true
+			  JOIN pg_attribute att ON att.attrelid = con.conrelid AND att.attnum = k.attnum
+			 WHERE con.contype = 'f' AND src.relname = 'relationship'`)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var got fk
+			if err := rows.Scan(&got.column, &got.target); err != nil {
+				return err
+			}
+			keys = append(keys, got)
+		}
+		return rows.Err()
+	}); err != nil {
+		t.Fatalf("reading relationship's foreign keys: %v", err)
+	}
+	if len(keys) == 0 {
+		t.Fatal("relationship declares no foreign keys — the introspection is reading the wrong table")
+	}
+
+	// The clause, rendered for a row-scoped caller so it is not the empty string
+	// an unbounded principal gets.
+	scoped := e.As(e.Rep1, []ids.UUID{e.Team1}, relationshipReaderPerms())
+	var args []any
+	clause, err := auth.RelationshipEndpointScope(scoped, "r", func(v any) int {
+		args = append(args, v)
+		return len(args)
+	})
+	if err != nil {
+		t.Fatalf("rendering the endpoint scope: %v", err)
+	}
+	if clause == "" {
+		t.Fatal("a row-scoped caller rendered an EMPTY clause — every edge would be visible to them")
+	}
+
+	missing := []string{}
+	endpoints := 0
+	for _, key := range keys {
+		if !scopedEndpointTables[key.target] || key.column == tenantColumn {
+			continue
+		}
+		endpoints++
+		// The column has to be constrained BY NAME in the clause. Substring is
+		// enough and deliberately crude: the clause is generated SQL, and what
+		// this asserts is that the column was not forgotten, not how it is spelled.
+		if !strings.Contains(clause, "r."+key.column) {
+			missing = append(missing, key.column+" → "+key.target)
+		}
+	}
+	// The walk must have SEEN the endpoints, or a rename that emptied it would read
+	// as a clean pass. Five columns point at four record tables today; the floor is
+	// that there is more than one, since a conjunction of one is not a conjunction.
+	if endpoints < 2 {
+		t.Fatalf("only %d scoped endpoint column(s) found on relationship — the introspection is not "+
+			"reading the foreign keys this gate is about", endpoints)
+	}
+	sort.Strings(missing)
+	for _, gap := range missing {
+		t.Errorf("relationship.%s is a foreign key to a row-scoped table and does NOT appear in "+
+			"auth.RelationshipEndpointScope's clause. An edge carrying it would be scoped by its other "+
+			"endpoints only, so a caller who cannot read that row could still read the edge naming it — "+
+			"and learn the row exists. Add the column to relationshipEndpointColumns.", gap)
+	}
+}

--- a/backend/internal/compose/integration/requiredbodyids_http_integration_test.go
+++ b/backend/internal/compose/integration/requiredbodyids_http_integration_test.go
@@ -328,13 +328,43 @@ func TestAPassportReadsTheSameRefusalAsASessionForAnOmittedStage(t *testing.T) {
 	// And an unreadable body is a DIFFERENT fault: answering "to_stage_id is
 	// required" for JSON that never parsed points the caller at a field that may
 	// well be there.
-	malformed := postRawBody(t, e, "/v1/deals/"+deal+"/advance", "{not json", bearer)
-	if malformed.status != http.StatusUnprocessableEntity {
-		t.Fatalf("a malformed body → %d, want 422", malformed.status)
-	}
-	if malformed.problem.Detail == asPassport.Detail {
-		t.Errorf("an unreadable body and an omitted key answer the same sentence %q — two faults, one message",
-			malformed.problem.Detail)
+	// Three faults, three answers — and the middle one is the trap. A body that is
+	// perfectly readable JSON carrying a to_stage_id the UUID decoder refuses fails
+	// the SAME json.Unmarshal as a body that is not JSON at all, so one branch for
+	// both tells a caller to hunt a syntax error that is not there while the value
+	// they can actually see and fix goes unnamed.
+	for name, tc := range map[string]struct {
+		body      string
+		wantField string
+		// distinctFrom is the omitted-key sentence: every one of these must differ
+		// from it, or the fault they name is one the caller cannot tell apart.
+		distinctFrom string
+	}{
+		"not JSON at all":        {"{not json", "body", asPassport.Detail},
+		"empty body":             {"", "body", asPassport.Detail},
+		"valid JSON, not a UUID": {`{"to_stage_id":"banana"}`, "to_stage_id", asPassport.Detail},
+		"valid JSON, a number":   {`{"to_stage_id":12345}`, "to_stage_id", asPassport.Detail},
+		"valid JSON, an array":   {`[]`, "to_stage_id", asPassport.Detail},
+	} {
+		t.Run(name, func(t *testing.T) {
+			answer := postRawBody(t, e, "/v1/deals/"+deal+"/advance", tc.body, bearer)
+			if answer.status != http.StatusUnprocessableEntity {
+				t.Fatalf("→ %d, want 422: %+v", answer.status, answer.problem)
+			}
+			if !namesField(answer.problem, tc.wantField) {
+				t.Errorf("names %+v, want the field %q", answer.problem.Details.Errors, tc.wantField)
+			}
+			if answer.problem.Detail == tc.distinctFrom {
+				t.Errorf("answers the omitted-key sentence %q for a different fault — the caller cannot "+
+					"tell which mistake they made", answer.problem.Detail)
+			}
+			// The specific lie this closes: claiming the body was unreadable when it
+			// parsed fine.
+			if tc.wantField == "to_stage_id" && strings.Contains(answer.problem.Detail, "not readable JSON") {
+				t.Errorf("body %q is valid JSON and the refusal says %q — the caller is sent hunting a "+
+					"syntax error that does not exist", tc.body, answer.problem.Detail)
+			}
+		})
 	}
 }
 

--- a/backend/internal/compose/integration/requiredbodyids_http_integration_test.go
+++ b/backend/internal/compose/integration/requiredbodyids_http_integration_test.go
@@ -1,0 +1,284 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// Making a refusal clearer must not turn it into a probe for whether a record
+// exists.
+//
+// Every body in this suite now names an omitted required id instead of answering
+// a bare not-found. That fix has one way to go wrong, and it is the dangerous
+// one: if the SUPPLIED-but-invisible case starts answering 422 as well, the
+// surface has become an existence oracle — a caller could enumerate ids and read
+// the status code to learn which rows are there.
+//
+// So each body is driven twice over real HTTP, and the pair is the assertion:
+//
+//	omitted                     → 422 naming the wire field
+//	supplied, names nothing      → 404, saying nothing
+//
+// The unit probes in each module prove the guard is called; only this lane can
+// prove the second half, because existence-hiding is rendered by a row-scoped
+// query against real rows.
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// problemBody is the RFC 7807 shape both cases answer with. Fields is decoded
+// because "422" alone is not the claim — the caller has to be told WHICH field.
+type problemBody struct {
+	Code    string `json:"code"`
+	Detail  string `json:"detail"`
+	Details struct {
+		Errors []struct {
+			Field string `json:"field"`
+			Code  string `json:"code"`
+		} `json:"errors"`
+	} `json:"details"`
+}
+
+// namesField reports whether a 422 body's per-field breakdown names field.
+func namesField(problem problemBody, field string) bool {
+	for _, refusal := range problem.Details.Errors {
+		if refusal.Field == field {
+			return true
+		}
+	}
+	return false
+}
+
+// requiredIDFixtures are the records the twelve rows below need in order to
+// reach their guard at all: a container in the path, or a subject the body can
+// legitimately name. A missing PATH id would 404 for its own reasons and prove
+// nothing about the body.
+type requiredIDFixtures struct {
+	person, organization, activity string
+	list, tag, project             string
+	deal, subjectUser              string
+}
+
+func seedRequiredIDFixtures(t *testing.T, e *env) requiredIDFixtures {
+	t.Helper()
+	var out requiredIDFixtures
+	out.person = createAndID(t, e, "/v1/people", anyMap{"full_name": "Merge Source"})
+	out.organization = createAndID(t, e, "/v1/organizations", anyMap{"display_name": "Merge Org"})
+	out.activity = createAndID(t, e, "/v1/activities", anyMap{
+		"kind": "note", "body": "relink probe",
+		"links": []anyMap{{"entity_type": "person", "entity_id": out.person}},
+	})
+	out.list = createAndID(t, e, "/v1/lists", anyMap{
+		"name": "Required IDs", "entity_type": "person", "list_type": "static",
+	})
+	out.tag = createAndID(t, e, "/v1/tags", anyMap{"name": "required-ids"})
+	out.project = createAndID(t, e, "/v1/projects", anyMap{
+		"name": "Stakeholder probe", "organization_id": out.organization, "source": "manual",
+	})
+	out.deal = seedDealForRequiredIDs(t, e)
+
+	// A REAL user for the grant's subject, so the subject_id row isolates
+	// subject_id and the record_id row isolates record_id.
+	var users struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if status := e.call(t, "GET", "/v1/users", nil, nil, &users); status != http.StatusOK || len(users.Data) == 0 {
+		t.Fatalf("list users → %d (%d users)", status, len(users.Data))
+	}
+	out.subjectUser = users.Data[0].ID
+	return out
+}
+
+// createAndID posts one fixture and returns its id, failing loudly if the create
+// itself was refused — a fixture that silently did not exist would turn every row
+// below into a 404 about the path.
+func createAndID(t *testing.T, e *env, path string, body anyMap) string {
+	t.Helper()
+	var created struct {
+		ID string `json:"id"`
+	}
+	if status := e.call(t, "POST", path, body, nil, &created); status != http.StatusCreated {
+		t.Fatalf("POST %s → %d, want 201", path, status)
+	}
+	if created.ID == "" {
+		t.Fatalf("POST %s returned no id", path)
+	}
+	return created.ID
+}
+
+// requiredIDCase is one body, driven twice. omitted and supplied differ ONLY in
+// the id under test, so the status difference cannot come from anything else.
+type requiredIDCase struct {
+	method, path      string
+	omitted, supplied anyMap
+	field             string
+}
+
+// requiredIDCases is every body this suite drives, keyed by the field under
+// test. Data, kept out of the test so the assertions stay readable — and one
+// entry per required id rather than per body, because CreateRecordGrantRequest
+// carries two and a guard that named only the first would leave the second
+// answering not-found for a subject nobody sent.
+func requiredIDCases(f requiredIDFixtures, absent string) map[string]requiredIDCase {
+	return map[string]requiredIDCase{
+		// The asymmetry PR #370 created: the MCP twin was guarded at
+		// Registry.Invoke while REST answered a bare 404 for the same mistake.
+		"AdvanceDealRequest.to_stage_id": {
+			method: "POST", path: "/v1/deals/" + f.deal + "/advance",
+			omitted: anyMap{}, supplied: anyMap{"to_stage_id": absent}, field: "to_stage_id",
+		},
+		"CreateStageRequest.pipeline_id": {
+			method: "POST", path: "/v1/stages",
+			omitted:  anyMap{"name": "Orphan stage", "position": 9},
+			supplied: anyMap{"name": "Orphan stage", "position": 9, "pipeline_id": absent},
+			field:    "pipeline_id",
+		},
+		"MergePersonJSONBody.target_id": {
+			method: "POST", path: "/v1/people/" + f.person + "/merge",
+			omitted: anyMap{}, supplied: anyMap{"target_id": absent}, field: "target_id",
+		},
+		"MergeOrganizationJSONBody.target_id": {
+			method: "POST", path: "/v1/organizations/" + f.organization + "/merge",
+			omitted: anyMap{}, supplied: anyMap{"target_id": absent}, field: "target_id",
+		},
+		"RelinkActivityJSONBody.entity_id": {
+			method: "POST", path: "/v1/activities/" + f.activity + "/relink",
+			omitted:  anyMap{"entity_type": "person"},
+			supplied: anyMap{"entity_type": "person", "entity_id": absent},
+			field:    "entity_id",
+		},
+		"RecordConsentRequest.purpose_id": {
+			method: "POST", path: "/v1/people/" + f.person + "/consent",
+			omitted:  anyMap{"new_state": "granted"},
+			supplied: anyMap{"new_state": "granted", "purpose_id": absent},
+			field:    "purpose_id",
+		},
+		"IssueDoubleOptInJSONBody.purpose_id": {
+			method: "POST", path: "/v1/people/" + f.person + "/consent/double-opt-in",
+			omitted: anyMap{}, supplied: anyMap{"purpose_id": absent}, field: "purpose_id",
+		},
+		"AddListMemberRequest.entity_id": {
+			method: "POST", path: "/v1/lists/" + f.list + "/members",
+			omitted:  anyMap{"entity_type": "person"},
+			supplied: anyMap{"entity_type": "person", "entity_id": absent},
+			field:    "entity_id",
+		},
+		"ApplyTagRequest.entity_id": {
+			method: "POST", path: "/v1/tags/" + f.tag + "/apply",
+			omitted:  anyMap{"entity_type": "person"},
+			supplied: anyMap{"entity_type": "person", "entity_id": absent},
+			field:    "entity_id",
+		},
+		"SetProjectStakeholderRequest.person_id": {
+			method: "PUT", path: "/v1/projects/" + f.project + "/stakeholders",
+			omitted:  anyMap{"role": "sponsor"},
+			supplied: anyMap{"role": "sponsor", "person_id": absent},
+			field:    "person_id",
+		},
+		// Two required ids, so two rows: a guard that named only the first would
+		// leave the second answering not-found for a subject nobody sent.
+		"CreateRecordGrantRequest.record_id": {
+			method: "POST", path: "/v1/record-grants",
+			omitted: anyMap{
+				"access": "read", "record_type": "person", "subject_type": "user", "subject_id": f.subjectUser,
+			},
+			supplied: anyMap{
+				"access": "read", "record_type": "person", "subject_type": "user",
+				"subject_id": f.subjectUser, "record_id": absent,
+			},
+			field: "record_id",
+		},
+		"CreateRecordGrantRequest.subject_id": {
+			method: "POST", path: "/v1/record-grants",
+			omitted: anyMap{
+				"access": "read", "record_type": "person", "subject_type": "user", "record_id": f.person,
+			},
+			supplied: anyMap{
+				"access": "read", "record_type": "person", "subject_type": "user",
+				"record_id": f.person, "subject_id": absent,
+			},
+			field: "subject_id",
+		},
+	}
+}
+
+func TestAnOmittedRequiredIDIsNamedAndASuppliedOneStaysHidden(t *testing.T) {
+	e := setup(t)
+	e.slug = "required-ids"
+	bootstrapWorkspaceSession(t, e, "Required IDs", "ids@fable.test", "Admin")
+
+	for name, tc := range requiredIDCases(seedRequiredIDFixtures(t, e), ids.NewV7().String()) {
+		t.Run(name+"/omitted names the field", func(t *testing.T) {
+			var problem problemBody
+			status := e.call(t, tc.method, tc.path, tc.omitted, nil, &problem)
+			if status != http.StatusUnprocessableEntity {
+				t.Fatalf("→ %d, want 422 (a bare 404 is the defect this closes): %+v", status, problem)
+			}
+			if !namesField(problem, tc.field) {
+				t.Errorf("the 422 names %+v, want the wire field %q — a status alone leaves the caller "+
+					"guessing which key they forgot", problem.Details.Errors, tc.field)
+			}
+		})
+		t.Run(name+"/supplied but invisible stays a 404", func(t *testing.T) {
+			var problem problemBody
+			status := e.call(t, tc.method, tc.path, tc.supplied, nil, &problem)
+			if status != http.StatusNotFound {
+				t.Fatalf("→ %d, want 404: a well-formed id that names nothing must not be distinguishable "+
+					"from one the caller may not see, or the status code enumerates rows: %+v", status, problem)
+			}
+			// And it must not name the field either: a 404 that said "purpose_id"
+			// would confirm the caller's id was structurally accepted and only
+			// the row was missing.
+			if namesField(problem, tc.field) {
+				t.Errorf("the 404 names %q, which tells the caller their id was accepted and the row is "+
+					"simply absent", tc.field)
+			}
+		})
+	}
+}
+
+// seedDealForRequiredIDs opens one deal in the workspace's seeded default
+// pipeline and returns its id — the advance route needs a real deal in the path,
+// or its 404 would be about the deal rather than about the stage.
+func seedDealForRequiredIDs(t *testing.T, e *env) string {
+	t.Helper()
+	var pipelines struct {
+		Data []struct {
+			ID     string `json:"id"`
+			Stages []struct {
+				ID       string `json:"id"`
+				Semantic string `json:"semantic"`
+			} `json:"stages"`
+		} `json:"data"`
+	}
+	if status := e.call(t, "GET", "/v1/pipelines", nil, nil, &pipelines); status != http.StatusOK || len(pipelines.Data) == 0 {
+		t.Fatalf("list pipelines → %d (%d pipelines)", status, len(pipelines.Data))
+	}
+	pipeline := pipelines.Data[0]
+	open := ""
+	for _, stage := range pipeline.Stages {
+		if stage.Semantic == "open" {
+			open = stage.ID
+			break
+		}
+	}
+	if open == "" {
+		t.Fatalf("the seeded pipeline has no open stage: %+v", pipeline.Stages)
+	}
+	var deal struct {
+		ID string `json:"id"`
+	}
+	if status := e.call(t, "POST", "/v1/deals", anyMap{
+		"name": "Advance probe", "pipeline_id": pipeline.ID, "stage_id": open,
+		"currency": "EUR", "amount_minor": 1000, "source": "ui",
+	}, nil, &deal); status != http.StatusCreated {
+		t.Fatalf("create deal → %d", status)
+	}
+	return deal.ID
+}

--- a/backend/internal/compose/integration/requiredbodyids_http_integration_test.go
+++ b/backend/internal/compose/integration/requiredbodyids_http_integration_test.go
@@ -24,7 +24,10 @@ package integration
 // query against real rows.
 
 import (
+	"encoding/json"
+	"io"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -127,8 +130,8 @@ type requiredIDCase struct {
 // answering not-found for a subject nobody sent.
 func requiredIDCases(f requiredIDFixtures, absent string) map[string]requiredIDCase {
 	return map[string]requiredIDCase{
-		// The asymmetry PR #370 created: the MCP twin was guarded at
-		// Registry.Invoke while REST answered a bare 404 for the same mistake.
+		// The MCP twin is guarded at Registry.Invoke, so this route is the half
+		// that has to keep up: one rule, one answer, whichever surface asks.
 		"AdvanceDealRequest.to_stage_id": {
 			method: "POST", path: "/v1/deals/" + f.deal + "/advance",
 			omitted: anyMap{}, supplied: anyMap{"to_stage_id": absent}, field: "to_stage_id",
@@ -281,4 +284,93 @@ func seedDealForRequiredIDs(t *testing.T, e *env) string {
 		t.Fatalf("create deal → %d", status)
 	}
 	return deal.ID
+}
+
+// The same rule, reached through the AGENT gate instead of the handler.
+//
+// A passport's REST call to a dynamic-tier tool resolves its tier BEFORE the
+// handler runs (compose/agentgate.go), so `advance_deal` has a second entry point
+// for the very field U3 unified — and the session-driven pair above cannot see
+// it. One rule must read the same on both, or the asymmetry has simply moved from
+// one transport to one credential type.
+func TestAPassportReadsTheSameRefusalAsASessionForAnOmittedStage(t *testing.T) {
+	e := setup(t)
+	e.slug = "required-ids-agent"
+	bootstrapWorkspaceSession(t, e, "Required IDs Agent", "agent-ids@fable.test", "Admin")
+	deal := seedDealForRequiredIDs(t, e)
+
+	var minted struct {
+		Token string `json:"token"`
+	}
+	if status := e.call(t, "POST", "/v1/passports", anyMap{
+		"label": "stage agent", "scopes": []string{"read", "write"},
+	}, nil, &minted); status != http.StatusCreated {
+		t.Fatalf("issue passport → %d", status)
+	}
+	bearer := map[string]string{"Authorization": "Bearer " + minted.Token}
+
+	var asSession, asPassport problemBody
+	sessionStatus := e.call(t, "POST", "/v1/deals/"+deal+"/advance", anyMap{}, nil, &asSession)
+	passportStatus := e.call(t, "POST", "/v1/deals/"+deal+"/advance", anyMap{}, bearer, &asPassport)
+
+	if sessionStatus != http.StatusUnprocessableEntity || passportStatus != http.StatusUnprocessableEntity {
+		t.Fatalf("session → %d, passport → %d; want 422 from both", sessionStatus, passportStatus)
+	}
+	if asSession.Detail != asPassport.Detail {
+		t.Errorf("one rule, two sentences:\n  session:  %q\n  passport: %q", asSession.Detail, asPassport.Detail)
+	}
+	for _, answer := range []problemBody{asSession, asPassport} {
+		if !namesField(answer, "to_stage_id") {
+			t.Errorf("the refusal names %+v, want the wire field to_stage_id", answer.Details.Errors)
+		}
+	}
+
+	// And an unreadable body is a DIFFERENT fault: answering "to_stage_id is
+	// required" for JSON that never parsed points the caller at a field that may
+	// well be there.
+	malformed := postRawBody(t, e, "/v1/deals/"+deal+"/advance", "{not json", bearer)
+	if malformed.status != http.StatusUnprocessableEntity {
+		t.Fatalf("a malformed body → %d, want 422", malformed.status)
+	}
+	if malformed.problem.Detail == asPassport.Detail {
+		t.Errorf("an unreadable body and an omitted key answer the same sentence %q — two faults, one message",
+			malformed.problem.Detail)
+	}
+}
+
+// rawAnswer is a response to a body the harness cannot marshal for us, because
+// the point is that it is not valid JSON.
+type rawAnswer struct {
+	status  int
+	problem problemBody
+}
+
+// postRawBody sends bytes verbatim. env.call marshals its body, so it can never
+// produce the malformed-JSON case the gate has to tell apart from an omitted key.
+func postRawBody(t *testing.T, e *env, path, body string, headers map[string]string) rawAnswer {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, e.ts.URL+path, strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("building request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	resp, err := e.client.Do(req)
+	if err != nil {
+		t.Fatalf("POST %s: %v", path, err)
+	}
+	defer closeBody(t, resp)
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("reading response: %v", err)
+	}
+	out := rawAnswer{status: resp.StatusCode}
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &out.problem); err != nil {
+			t.Fatalf("POST %s: decoding %q: %v", path, raw, err)
+		}
+	}
+	return out
 }

--- a/backend/internal/compose/nativeonlytools.go
+++ b/backend/internal/compose/nativeonlytools.go
@@ -136,11 +136,10 @@ func (r nativeOnlyRetriever) AssembleContext(ctx context.Context, anchor datasou
 	return r.inner.AssembleContext(ctx, anchor, opts)
 }
 
-// nativeOnlyIntroPath and nativeOnlyAtRisk guard the two relationship-graph
-// tools. Both ground on the interaction projection and the native employment
-// and deal tables, none of which the incumbent mirror holds — so in overlay
-// mode they would answer "nobody can get you in" and "nothing is at risk",
-// which are believable answers rather than visible failures.
+// nativeOnlyIntroPath guards intro_path_to. It grounds on the interaction
+// projection and the native employment table, neither of which the incumbent
+// mirror holds — so in overlay mode it would answer "nobody here can get you in",
+// which is a believable answer rather than a visible failure.
 func nativeOnlyIntroPath(mode overlayModeChecker, list agents.IntroPathLister) agents.IntroPathLister {
 	return func(ctx context.Context, orgID ids.UUID) ([]agents.IntroRoute, bool, error) {
 		overlay, err := mode.isOverlayUncached(ctx)
@@ -154,6 +153,9 @@ func nativeOnlyIntroPath(mode overlayModeChecker, list agents.IntroPathLister) a
 	}
 }
 
+// nativeOnlyAtRisk guards at_risk_relationships, over the caller's own native
+// deal rows and the same interaction projection. Unguarded it would answer
+// "nothing is at risk" for a workspace whose deals it cannot see.
 func nativeOnlyAtRisk(mode overlayModeChecker, list agents.AtRiskLister) agents.AtRiskLister {
 	return func(ctx context.Context) (agents.AtRiskReport, error) {
 		overlay, err := mode.isOverlayUncached(ctx)

--- a/backend/internal/compose/nativeonlytools.go
+++ b/backend/internal/compose/nativeonlytools.go
@@ -188,9 +188,11 @@ func nativeOnlyPipelines(mode overlayModeChecker, list agents.PipelineLister) ag
 	}
 }
 
-// nativeOnlySlippingLister guards whats_slipping_this_week, whose candidate
-// set is the native deals store. The mirror serves no stage or pipeline
-// dial, so there is no overlay query to fall back to.
+// nativeOnlySlippingLister guards whats_slipping_this_week AND
+// draft_follow_ups_for — both, because RegisterSlippingTools hands this one
+// lister to each of them, so the drafter's candidate set is the same guarded
+// read. The candidates come from the native deals store, and the mirror serves no
+// stage or pipeline dial, so there is no overlay query to fall back to.
 func nativeOnlySlippingLister(mode overlayModeChecker, list agents.SlippingLister) agents.SlippingLister {
 	return func(ctx context.Context) ([]agents.SlippingDeal, error) {
 		overlay, err := mode.isOverlayUncached(ctx)

--- a/backend/internal/compose/nativeonlytools.go
+++ b/backend/internal/compose/nativeonlytools.go
@@ -167,6 +167,25 @@ func nativeOnlyAtRisk(mode overlayModeChecker, list agents.AtRiskLister) agents.
 	}
 }
 
+// nativeOnlyPipelines guards list_pipelines. The mirror holds no pipeline
+// projection — an incumbent's pipelines and stages are never mirrored — so the
+// native tables hold none of an overlay workspace's configuration and the
+// unguarded answer would be "this workspace has no pipelines". A caller
+// believing that concludes the deal verbs are unusable, when what is true is
+// that this capability is not served in overlay mode.
+func nativeOnlyPipelines(mode overlayModeChecker, list agents.PipelineLister) agents.PipelineLister {
+	return func(ctx context.Context) ([]agents.Pipeline, error) {
+		overlay, err := mode.isOverlayUncached(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if overlay {
+			return nil, apperrors.ErrUnsupportedBySoR
+		}
+		return list(ctx)
+	}
+}
+
 // nativeOnlySlippingLister guards whats_slipping_this_week, whose candidate
 // set is the native deals store. The mirror serves no stage or pipeline
 // dial, so there is no overlay query to fall back to.

--- a/backend/internal/compose/nativeonlytools_test.go
+++ b/backend/internal/compose/nativeonlytools_test.go
@@ -156,6 +156,54 @@ func TestRetrieverServesNativeMode(t *testing.T) {
 	}
 }
 
+// --- list_pipelines ---
+
+func TestPipelineListerRefusesInOverlayMode(t *testing.T) {
+	called := false
+	inner := func(context.Context) ([]agents.Pipeline, error) {
+		called = true
+		return nil, nil
+	}
+
+	_, err := nativeOnlyPipelines(overlayMode(), inner)(context.Background())
+
+	if !errors.Is(err, apperrors.ErrUnsupportedBySoR) {
+		t.Fatalf("err = %v, want ErrUnsupportedBySoR", err)
+	}
+	if called {
+		t.Error("the native pipeline read ran for an overlay workspace — the native tables hold none " +
+			"of its configuration, so the answer would be 'this workspace has no pipelines'")
+	}
+}
+
+func TestPipelineListerServesNativeMode(t *testing.T) {
+	called := false
+	inner := func(context.Context) ([]agents.Pipeline, error) {
+		called = true
+		return nil, nil
+	}
+
+	if _, err := nativeOnlyPipelines(nativeMode(), inner)(context.Background()); err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if !called {
+		t.Error("native mode did not reach the pipeline read")
+	}
+}
+
+func TestPipelineListerRefusesWhenModeCannotBeResolved(t *testing.T) {
+	// An unresolved mode refuses rather than defaulting to native: guessing
+	// wrong in that direction is the silent break the guard exists to stop.
+	inner := func(context.Context) ([]agents.Pipeline, error) {
+		t.Error("the native pipeline read ran without a resolved system-of-record mode")
+		return nil, nil
+	}
+
+	if _, err := nativeOnlyPipelines(unresolvableMode(), inner)(context.Background()); err == nil {
+		t.Fatal("err = nil, want the mode-resolution failure")
+	}
+}
+
 // --- whats_slipping_this_week ---
 
 func TestSlippingListerRefusesInOverlayMode(t *testing.T) {

--- a/backend/internal/compose/nativeonlytools_test.go
+++ b/backend/internal/compose/nativeonlytools_test.go
@@ -278,21 +278,27 @@ func TestSlippingGuardRefusesOnAStaleNativeCache(t *testing.T) {
 	}
 }
 
-// Every nativeOnly… guard in this file must be pinned by the wiring suite.
+// Every nativeOnly… guard in this file must name the tool(s) it guards, and the
+// wiring pin must cover exactly those tools.
 //
 // The unit specs above prove what a guard DOES given a mode; only
 // integration/overlay_toolsurface_integration_test.go proves a guard is actually
-// wired, and its map is written by hand. That map has been wrong exactly this way
-// before — intro_path_to and at_risk_relationships carried guards it had never
-// examined — so the obligation is derived here instead of being remembered:
+// wired, and its map is written by hand. So the obligation is derived here:
 // declaring a guard enrols its tool.
 //
-// The guard→tool link cannot be read off a type (a decorator is invisible from the
-// tool spec), so it is read off the DECLARATION: the doc comment of every
-// nativeOnly… function must name the tool or tools it guards, and each of those
-// names must appear in the pin. That makes the comment load-bearing rather than
-// decorative, which is the point — a guard whose comment does not say what it
-// guards cannot be checked by anything.
+// The guard→tool link cannot be read off a type — a decorator is invisible from
+// the tool spec — so it is read off the DECLARATION's doc comment. That makes the
+// comment load-bearing, which is the point, but a comment is prose and prose can
+// be wrong in two ways this gate has to close:
+//
+//   - a guard that is a TYPE rather than a func (nativeOnlyRetriever is one, and it
+//     guards two of the eight pinned tools), which a FuncDecl-only walk never sees;
+//   - a doc that names SOME pinned tool rather than its own, which a
+//     does-it-mention-any check passes.
+//
+// Hence a bijection: every pinned tool is named by exactly one guard, and every
+// guard names at least one pinned tool. That also forces a guard handed to two
+// tools to name both — nativeOnlySlippingLister is one.
 func TestEveryNativeOnlyGuardNamesAToolThePinCovers(t *testing.T) {
 	const guardFile = "nativeonlytools.go"
 	fset := token.NewFileSet()
@@ -302,31 +308,71 @@ func TestEveryNativeOnlyGuardNamesAToolThePinCovers(t *testing.T) {
 	}
 	pinned := pinnedNativeOnlyTools(t)
 
-	guards := 0
+	// guard name → the doc comment that must name its tools. Both declaration
+	// shapes, because a guard may be a decorator func OR a decorator type.
+	docs := map[string]string{}
 	for _, decl := range file.Decls {
-		fn, ok := decl.(*ast.FuncDecl)
-		if !ok || !strings.HasPrefix(fn.Name.Name, "nativeOnly") {
-			continue
-		}
-		guards++
-		doc := fn.Doc.Text()
-		named := []string{}
-		for tool := range pinned {
-			if strings.Contains(doc, tool) {
-				named = append(named, tool)
+		switch d := decl.(type) {
+		case *ast.FuncDecl:
+			if strings.HasPrefix(d.Name.Name, nativeOnlyPrefix) {
+				docs[d.Name.Name] = d.Doc.Text()
+			}
+		case *ast.GenDecl:
+			for _, spec := range d.Specs {
+				ts, ok := spec.(*ast.TypeSpec)
+				if !ok || !strings.HasPrefix(ts.Name.Name, nativeOnlyPrefix) {
+					continue
+				}
+				// A single-spec GenDecl carries the doc; a grouped one leaves it
+				// on the spec.
+				doc := ts.Doc.Text()
+				if doc == "" {
+					doc = d.Doc.Text()
+				}
+				docs[ts.Name.Name] = doc
 			}
 		}
-		if len(named) == 0 {
-			t.Errorf("%s guards something the wiring pin does not cover. Its doc comment must name the "+
-				"tool(s) it guards, and each must appear in nativeOnlyAgentTools "+
+	}
+	if len(docs) == 0 {
+		t.Fatalf("no %s… declaration found in %s — the walk is reading the wrong file", nativeOnlyPrefix, guardFile)
+	}
+
+	namedBy := map[string][]string{}
+	for guard, doc := range docs {
+		named := 0
+		for tool := range pinned {
+			if strings.Contains(doc, tool) {
+				namedBy[tool] = append(namedBy[tool], guard)
+				named++
+			}
+		}
+		if named == 0 {
+			t.Errorf("%s names no tool the wiring pin covers. Its doc comment must name the tool(s) it "+
+				"guards, and each must appear in nativeOnlyAgentTools "+
 				"(compose/integration/overlay_toolsurface_integration_test.go) — a guard nothing drives "+
-				"against a real overlay workspace is a guard nobody has tested.\ndoc: %q", fn.Name.Name, doc)
+				"against a real overlay workspace is a guard nobody has tested.\ndoc: %q", guard, doc)
 		}
 	}
-	if guards == 0 {
-		t.Fatalf("no nativeOnly… declaration found in %s — the walk is reading the wrong file", guardFile)
+
+	// The other direction, which is what catches a doc naming the wrong tool: a
+	// pinned tool no guard claims is either unguarded or guarded by a decorator
+	// whose comment points somewhere else.
+	for tool := range pinned {
+		switch len(namedBy[tool]) {
+		case 1:
+		case 0:
+			t.Errorf("the wiring pin covers %q and no nativeOnly… guard's doc names it — either the tool "+
+				"has no mode guard at all, or the guard that decorates it describes a different tool", tool)
+		default:
+			t.Errorf("%q is named by %v — two guards claiming one tool means at least one comment is "+
+				"describing something it does not decorate", tool, namedBy[tool])
+		}
 	}
 }
+
+// nativeOnlyPrefix is the naming convention the walk above depends on: a mode
+// guard in this file is named for what it guards against, not for what it wraps.
+const nativeOnlyPrefix = "nativeOnly"
 
 // pinnedNativeOnlyTools reads the tool names out of the integration suite's pin.
 // Parsed rather than duplicated: a copy here would be a third hand-kept list, and

--- a/backend/internal/compose/nativeonlytools_test.go
+++ b/backend/internal/compose/nativeonlytools_test.go
@@ -15,8 +15,12 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -272,4 +276,93 @@ func TestSlippingGuardRefusesOnAStaleNativeCache(t *testing.T) {
 	if *calls == 0 {
 		t.Error("the guard never re-read workspace.x_sor_mode")
 	}
+}
+
+// Every nativeOnly… guard in this file must be pinned by the wiring suite.
+//
+// The unit specs above prove what a guard DOES given a mode; only
+// integration/overlay_toolsurface_integration_test.go proves a guard is actually
+// wired, and its map is written by hand. That map has been wrong exactly this way
+// before — intro_path_to and at_risk_relationships carried guards it had never
+// examined — so the obligation is derived here instead of being remembered:
+// declaring a guard enrols its tool.
+//
+// The guard→tool link cannot be read off a type (a decorator is invisible from the
+// tool spec), so it is read off the DECLARATION: the doc comment of every
+// nativeOnly… function must name the tool or tools it guards, and each of those
+// names must appear in the pin. That makes the comment load-bearing rather than
+// decorative, which is the point — a guard whose comment does not say what it
+// guards cannot be checked by anything.
+func TestEveryNativeOnlyGuardNamesAToolThePinCovers(t *testing.T) {
+	const guardFile = "nativeonlytools.go"
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, guardFile, nil, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", guardFile, err)
+	}
+	pinned := pinnedNativeOnlyTools(t)
+
+	guards := 0
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || !strings.HasPrefix(fn.Name.Name, "nativeOnly") {
+			continue
+		}
+		guards++
+		doc := fn.Doc.Text()
+		named := []string{}
+		for tool := range pinned {
+			if strings.Contains(doc, tool) {
+				named = append(named, tool)
+			}
+		}
+		if len(named) == 0 {
+			t.Errorf("%s guards something the wiring pin does not cover. Its doc comment must name the "+
+				"tool(s) it guards, and each must appear in nativeOnlyAgentTools "+
+				"(compose/integration/overlay_toolsurface_integration_test.go) — a guard nothing drives "+
+				"against a real overlay workspace is a guard nobody has tested.\ndoc: %q", fn.Name.Name, doc)
+		}
+	}
+	if guards == 0 {
+		t.Fatalf("no nativeOnly… declaration found in %s — the walk is reading the wrong file", guardFile)
+	}
+}
+
+// pinnedNativeOnlyTools reads the tool names out of the integration suite's pin.
+// Parsed rather than duplicated: a copy here would be a third hand-kept list, and
+// the whole point is that there be one.
+func pinnedNativeOnlyTools(t *testing.T) map[string]bool {
+	t.Helper()
+	const pinFile = "integration/overlay_toolsurface_integration_test.go"
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, pinFile, nil, 0)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", pinFile, err)
+	}
+	out := map[string]bool{}
+	ast.Inspect(file, func(n ast.Node) bool {
+		fn, ok := n.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != "nativeOnlyAgentTools" {
+			return true
+		}
+		ast.Inspect(fn.Body, func(inner ast.Node) bool {
+			kv, ok := inner.(*ast.KeyValueExpr)
+			if !ok {
+				return true
+			}
+			if key, ok := kv.Key.(*ast.BasicLit); ok && key.Kind == token.STRING {
+				name, err := strconv.Unquote(key.Value)
+				if err != nil {
+					t.Fatalf("unquoting a pinned tool name: %v", err)
+				}
+				out[name] = true
+			}
+			return true
+		})
+		return false
+	})
+	if len(out) == 0 {
+		t.Fatalf("no tool names found in %s's nativeOnlyAgentTools — the pin moved or was renamed", pinFile)
+	}
+	return out
 }

--- a/backend/internal/compose/networkseams.go
+++ b/backend/internal/compose/networkseams.go
@@ -111,7 +111,18 @@ func coverageReader(pool *pgxpool.Pool) agents.CoverageReader {
 }
 
 func toAgentCoverage(c network.DealCoverage, names map[ids.UUID]string) agents.DealCoverageAnswer {
-	out := agents.DealCoverageAnswer{DealID: c.DealID}
+	// Both collections start EMPTY, never nil: a deal with no stakeholder seat
+	// and nobody on our side is the answer that says the deal is uncovered, and
+	// it is the answer a rep most needs. Marshalled from a nil slice it reaches a
+	// model as `null`, which reads as "unknown" — so the tool would hedge about
+	// coverage exactly where it has something definite to say. The same rule the
+	// sibling reads uphold (whoKnowsTool, introPathTool, list_pipelines), applied
+	// where the answer is BUILT rather than at the one tool that returns it.
+	out := agents.DealCoverageAnswer{
+		DealID:       c.DealID,
+		Stakeholders: make([]agents.CoverageSeat, 0, len(c.Stakeholders)),
+		OurSide:      make([]agents.KnownColleague, 0, len(c.OurSide)),
+	}
 	for _, s := range c.Stakeholders {
 		out.Stakeholders = append(out.Stakeholders, agents.CoverageSeat{
 			PersonID: s.PersonID, Role: s.Role, Engaged: s.Engaged,

--- a/backend/internal/compose/networkseams_test.go
+++ b/backend/internal/compose/networkseams_test.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The relationship-graph seam mappings, where a shape decision is made that a
+// model reads.
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose/network"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// An uncovered deal answers empty ARRAYS, not nulls.
+//
+// "No stakeholder seats and nobody from our side" is the most useful answer this
+// tool gives — it is the one that says the deal rests on nothing — and a model
+// handed `null` reads it as "unknown" and hedges. Every sibling read on this
+// surface normalizes; found by UAT on the one that did not.
+func TestAnUncoveredDealAnswersEmptyArraysNotNulls(t *testing.T) {
+	answer := toAgentCoverage(network.DealCoverage{DealID: ids.NewV7()}, nil)
+
+	raw, err := json.Marshal(answer)
+	if err != nil {
+		t.Fatalf("marshalling the coverage answer: %v", err)
+	}
+	for _, member := range []string{`"stakeholders":[]`, `"our_side":[]`, `"risks":[]`} {
+		if !json.Valid(raw) {
+			t.Fatalf("unreadable payload %s", raw)
+		}
+		if !strings.Contains(string(raw), member) {
+			t.Errorf("payload = %s, want %s — a null reads to a model as \"unknown\", which is a "+
+				"different claim from \"nobody\"", raw, member)
+		}
+	}
+}

--- a/backend/internal/compose/networkseams_test.go
+++ b/backend/internal/compose/networkseams_test.go
@@ -29,9 +29,6 @@ func TestAnUncoveredDealAnswersEmptyArraysNotNulls(t *testing.T) {
 		t.Fatalf("marshalling the coverage answer: %v", err)
 	}
 	for _, member := range []string{`"stakeholders":[]`, `"our_side":[]`, `"risks":[]`} {
-		if !json.Valid(raw) {
-			t.Fatalf("unreadable payload %s", raw)
-		}
 		if !strings.Contains(string(raw), member) {
 			t.Errorf("payload = %s, want %s — a null reads to a model as \"unknown\", which is a "+
 				"different claim from \"nobody\"", raw, member)

--- a/backend/internal/compose/pipelineseams.go
+++ b/backend/internal/compose/pipelineseams.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The seam behind list_pipelines: pipeline configuration for the tool surface,
+// read through the deals module's OWN entry point.
+//
+// Store.ListPipelines already carries auth.Require("pipeline", read) and
+// already nests each pipeline's live stages, ordered by position, inside one
+// WithWorkspaceTx. So this adapter is a mapping and nothing more — no SQL of
+// its own, which is what makes the `pipeline` RBAC object apply to the tool for
+// free rather than by a second enforcement that could drift from the first.
+//
+// Pipelines are CONFIG, not records: they deliberately do not travel the
+// datasource record seam, which would put them in the EntityType vocabulary and
+// therefore into every polymorphic reference that vocabulary governs.
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/modules/agents"
+	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// pipelineLister answers list_pipelines from the workspace's live pipeline
+// configuration.
+func pipelineLister(pool *pgxpool.Pool) agents.PipelineLister {
+	store := deals.NewStore(pool)
+	return func(ctx context.Context) ([]agents.Pipeline, error) {
+		rows, err := store.ListPipelines(ctx)
+		if err != nil {
+			return nil, err
+		}
+		out := make([]agents.Pipeline, 0, len(rows))
+		for _, p := range rows {
+			out = append(out, toAgentPipeline(p))
+		}
+		return out, nil
+	}
+}
+
+// toAgentPipeline maps one contract pipeline onto the tool shape.
+func toAgentPipeline(p crmcontracts.Pipeline) agents.Pipeline {
+	out := agents.Pipeline{
+		ID:        ids.UUID(p.Id),
+		Name:      p.Name,
+		IsDefault: p.IsDefault,
+		Position:  p.Position,
+		Stages:    []agents.Stage{},
+	}
+	// Stages is an optional member on the contract shape; readPipeline always
+	// sets it, so a nil here would mean the read changed underneath us. Either
+	// way the tool answers an empty list rather than a null.
+	if p.Stages == nil {
+		return out
+	}
+	for _, st := range *p.Stages {
+		out.Stages = append(out.Stages, agents.Stage{
+			ID:             ids.UUID(st.Id),
+			Name:           st.Name,
+			Semantic:       string(st.Semantic),
+			WinProbability: st.WinProbability,
+			Position:       st.Position,
+		})
+	}
+	return out
+}

--- a/backend/internal/compose/provider.go
+++ b/backend/internal/compose/provider.go
@@ -54,7 +54,8 @@ var searchable = []datasource.EntityType{datasource.EntityPerson, datasource.Ent
 
 func (p *Provider) Read(ctx context.Context, ref datasource.EntityRef) (datasource.Record, error) {
 	switch ref.Type {
-	case datasource.EntityPerson, datasource.EntityOrganization, datasource.EntityLead:
+	case datasource.EntityPerson, datasource.EntityOrganization, datasource.EntityLead,
+		datasource.EntityRelationship:
 		return p.people.Read(ctx, ref)
 	case datasource.EntityDeal, datasource.EntityProject:
 		return p.deals.Read(ctx, ref)
@@ -118,7 +119,8 @@ func (p *Provider) Search(ctx context.Context, q datasource.SearchQuery) (dataso
 
 func (p *Provider) Create(ctx context.Context, in datasource.CreateInput) (datasource.EntityRef, error) {
 	switch in.EntityType {
-	case datasource.EntityPerson, datasource.EntityOrganization, datasource.EntityLead:
+	case datasource.EntityPerson, datasource.EntityOrganization, datasource.EntityLead,
+		datasource.EntityRelationship:
 		return p.people.Create(ctx, in)
 	case datasource.EntityDeal, datasource.EntityProject:
 		return p.deals.Create(ctx, in)
@@ -131,7 +133,8 @@ func (p *Provider) Create(ctx context.Context, in datasource.CreateInput) (datas
 
 func (p *Provider) Update(ctx context.Context, in datasource.UpdateInput) (datasource.EntityRef, error) {
 	switch in.Ref.Type {
-	case datasource.EntityPerson, datasource.EntityOrganization, datasource.EntityLead:
+	case datasource.EntityPerson, datasource.EntityOrganization, datasource.EntityLead,
+		datasource.EntityRelationship:
 		return p.people.Update(ctx, in)
 	case datasource.EntityDeal, datasource.EntityProject:
 		return p.deals.Update(ctx, in)
@@ -144,7 +147,7 @@ func (p *Provider) Update(ctx context.Context, in datasource.UpdateInput) (datas
 
 func (p *Provider) Archive(ctx context.Context, r datasource.EntityRef) (datasource.EntityRef, error) {
 	switch r.Type {
-	case datasource.EntityPerson, datasource.EntityOrganization:
+	case datasource.EntityPerson, datasource.EntityOrganization, datasource.EntityRelationship:
 		return p.people.Archive(ctx, r)
 	case datasource.EntityDeal, datasource.EntityProject:
 		return p.deals.Archive(ctx, r)

--- a/backend/internal/compose/registry.go
+++ b/backend/internal/compose/registry.go
@@ -70,6 +70,12 @@ func registryWithGate(pool *pgxpool.Pool, gate *auth.Gate, drafter activities.Em
 	// cached mode. See overlayModeChecker for why that distinction is typed.
 	sorMode := overlayModeChecker(provider)
 	agents.RegisterCoreTools(registry, provider, provider, provider, fieldOwnership{pool: pool})
+	// Pipeline config, and it registers next to the core CRUD set because it is
+	// what makes two of those verbs reachable: create_record for a deal and
+	// advance_deal both name ids no other tool yields. Config is not a record,
+	// so it rides its own seam rather than the datasource one — and that seam
+	// needs the overlay guard the record verbs get from the Dispatcher for free.
+	agents.RegisterPipelineTool(registry, nativeOnlyPipelines(sorMode, pipelineLister(pool)))
 	agents.RegisterReportTool(registry, nativeOnlyReportRunner(sorMode, reportToolRunner(newReportEngine(pool))))
 	// The intent tools ground on the graph walk (no embed lane needed);
 	// the comms tools ride the same store paths as the HTTP transport.

--- a/backend/internal/modules/activities/lifecycle.go
+++ b/backend/internal/modules/activities/lifecycle.go
@@ -21,6 +21,7 @@ import (
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/platform/httperr"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -141,6 +142,13 @@ type RelinkActivityInput struct {
 }
 
 func (s *Store) RelinkActivity(ctx context.Context, id ids.ActivityID, in RelinkActivityInput) (crmcontracts.Activity, error) {
+	// Relinking moves an activity ONTO a record; without an entity_id there is
+	// nowhere to move it. Required by the contract, and true only here: the zero
+	// UUID reaches the link-target gate and answers not-found for a record the
+	// caller never named.
+	if err := httperr.RequireBodyID("entity_id", in.EntityID); err != nil {
+		return crmcontracts.Activity{}, err
+	}
 	if err := auth.Require(ctx, "activity", principal.ActionUpdate); err != nil {
 		return crmcontracts.Activity{}, err
 	}

--- a/backend/internal/modules/activities/requiredids_test.go
+++ b/backend/internal/modules/activities/requiredids_test.go
@@ -4,54 +4,25 @@
 package activities
 
 // A required body id the caller omitted must be named as a missing argument, not
-// discovered as a missing row.
+// discovered as a missing row: an absent key decodes to the zero UUID with no
+// error, so unguarded it reaches a lookup, matches nothing, and answers a bare
+// not-found for a record the caller never mentioned.
 //
-// oapi-codegen renders a REQUIRED body id as a non-pointer UUID and
-// encoding/json leaves an absent key at the zero value with no error, so the
-// zero UUID used to travel to a lookup, match nothing, and answer a bare
-// not-found — telling the caller a record they never mentioned does not exist.
+// The guard is at the store entry point — the door every transport comes through —
+// and it runs BEFORE any authority check or query, which is why these probes need
+// no database and no actor: a store over a nil pool never reaches one.
 //
-// The guard sits at the store entry point, which is the door every transport
-// comes through, and it runs BEFORE any authority check or query — which is why
-// these probes need no database and no actor: a store over a nil pool never
-// reaches one.
-//
-// The refusal's SHAPE (422, the field named, the stable `required` code, and that
-// it classifies on both surfaces) is proven once in
-// platform/httperr/requirebodyid_test.go. What is left here is the only question
-// this package can answer: is the guard actually called for my body.
+// The refusal's SHAPE is proven once in platform/httperr/requirebodyid_test.go and
+// asserted here through faulttest. What is left is the only question this package
+// can answer: is the guard actually called for my body.
 
 import (
 	"context"
-	"net/http"
 	"testing"
 
-	"github.com/gradionhq/margince/backend/internal/platform/httperr"
+	"github.com/gradionhq/margince/backend/internal/platform/httperr/faulttest"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
-
-// assertNamesTheOmittedID asserts the observable property: the caller's mistake,
-// with the wire field they omitted named.
-func assertNamesTheOmittedID(t *testing.T, err error, field string) {
-	t.Helper()
-	if err == nil {
-		t.Fatalf("an absent %s was accepted, so the caller is sent looking for a record it never named", field)
-	}
-	fault, ok := httperr.Classify(err)
-	if !ok {
-		t.Fatalf("an absent %s answered %v, which is outside the taxonomy — a surface would report the "+
-			"caller's own omission as an internal server fault", field, err)
-	}
-	if fault.Status != http.StatusUnprocessableEntity {
-		t.Errorf("an absent %s answered status %d, want 422 (404 is the defect this closes)", field, fault.Status)
-	}
-	for _, refusal := range fault.Fields {
-		if refusal.Field == field {
-			return
-		}
-	}
-	t.Errorf("the refusal for an absent %s names %+v, want the wire field %q", field, fault.Fields, field)
-}
 
 func TestAnOmittedRelinkTargetIsNamed(t *testing.T) {
 	// RelinkActivityJSONBody.entity_id. Relinking moves an activity ONTO a
@@ -60,5 +31,5 @@ func TestAnOmittedRelinkTargetIsNamed(t *testing.T) {
 	_, err := NewStore(nil).RelinkActivity(context.Background(), ids.New[ids.ActivityKind](), RelinkActivityInput{
 		EntityType: "person",
 	})
-	assertNamesTheOmittedID(t, err, "entity_id")
+	faulttest.AssertNamesOmittedID(t, err, "entity_id")
 }

--- a/backend/internal/modules/activities/requiredids_test.go
+++ b/backend/internal/modules/activities/requiredids_test.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package activities
+
+// A required body id the caller omitted must be named as a missing argument, not
+// discovered as a missing row.
+//
+// oapi-codegen renders a REQUIRED body id as a non-pointer UUID and
+// encoding/json leaves an absent key at the zero value with no error, so the
+// zero UUID used to travel to a lookup, match nothing, and answer a bare
+// not-found — telling the caller a record they never mentioned does not exist.
+//
+// The guard sits at the store entry point, which is the door every transport
+// comes through, and it runs BEFORE any authority check or query — which is why
+// these probes need no database and no actor: a store over a nil pool never
+// reaches one.
+//
+// The refusal's SHAPE (422, the field named, the stable `required` code, and that
+// it classifies on both surfaces) is proven once in
+// platform/httperr/requirebodyid_test.go. What is left here is the only question
+// this package can answer: is the guard actually called for my body.
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/platform/httperr"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// assertNamesTheOmittedID asserts the observable property: the caller's mistake,
+// with the wire field they omitted named.
+func assertNamesTheOmittedID(t *testing.T, err error, field string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("an absent %s was accepted, so the caller is sent looking for a record it never named", field)
+	}
+	fault, ok := httperr.Classify(err)
+	if !ok {
+		t.Fatalf("an absent %s answered %v, which is outside the taxonomy — a surface would report the "+
+			"caller's own omission as an internal server fault", field, err)
+	}
+	if fault.Status != http.StatusUnprocessableEntity {
+		t.Errorf("an absent %s answered status %d, want 422 (404 is the defect this closes)", field, fault.Status)
+	}
+	for _, refusal := range fault.Fields {
+		if refusal.Field == field {
+			return
+		}
+	}
+	t.Errorf("the refusal for an absent %s names %+v, want the wire field %q", field, fault.Fields, field)
+}
+
+func TestAnOmittedRelinkTargetIsNamed(t *testing.T) {
+	// RelinkActivityJSONBody.entity_id. Relinking moves an activity ONTO a
+	// record; with no entity_id there is nowhere to move it, and the zero UUID
+	// reached the link-target gate instead.
+	_, err := NewStore(nil).RelinkActivity(context.Background(), ids.New[ids.ActivityKind](), RelinkActivityInput{
+		EntityType: "person",
+	})
+	assertNamesTheOmittedID(t, err, "entity_id")
+}

--- a/backend/internal/modules/agents/conformance_test.go
+++ b/backend/internal/modules/agents/conformance_test.go
@@ -122,6 +122,7 @@ func fullRegistry(t *testing.T) *Registry {
 	t.Helper()
 	r := NewRegistry(nil, auth.NewGate(fullSeatAuthority{}))
 	RegisterCoreTools(r, nil, nil, nil, nil)
+	RegisterPipelineTool(r, func(context.Context) ([]Pipeline, error) { return nil, nil })
 	RegisterReportTool(r, nil)
 	RegisterIntentTools(r, inertRetriever{})
 	RegisterSlippingTools(r,

--- a/backend/internal/modules/agents/conformance_test.go
+++ b/backend/internal/modules/agents/conformance_test.go
@@ -108,10 +108,10 @@ func (inertRetriever) AssembleContext(context.Context, datasource.EntityRef, ret
 	return retrieval.Context{}, nil
 }
 
-// fullRegistry builds EVERY tool the product ships, through all six
+// fullRegistry builds EVERY tool the product ships, through all seven
 // registrars.
 //
-// Building only some of them is how a walk lies: three of the six families
+// Building only some of them is how a walk lies: three of the seven families
 // (network, slipping, intents) carry their own hand-written JSON schema
 // literals, and a walk that skips them certifies eight tools it never looked
 // at — which is exactly the failure TestTheWholeToolListEncodes exists to

--- a/backend/internal/modules/agents/idargs_test.go
+++ b/backend/internal/modules/agents/idargs_test.go
@@ -140,6 +140,7 @@ func idProbeDispatcher(t *testing.T) *Dispatcher {
 	t.Helper()
 	r := NewRegistry(nil, auth.NewGate(fullSeatAuthority{}))
 	RegisterCoreTools(r, seamProbeProvider{}, seamProbeProvider{}, nil, noConflicts{})
+	RegisterPipelineTool(r, func(context.Context) ([]Pipeline, error) { return nil, errSeamReached })
 	RegisterReportTool(r, func(context.Context, string, json.RawMessage) (json.RawMessage, error) {
 		return nil, errSeamReached
 	})

--- a/backend/internal/modules/agents/recordfields.go
+++ b/backend/internal/modules/agents/recordfields.go
@@ -45,9 +45,13 @@ var (
 		datasource.EntityLead:         reflect.TypeFor[crmcontracts.CreateLeadRequest](),
 		datasource.EntityActivity:     reflect.TypeFor[crmcontracts.CreateActivityRequest](),
 		datasource.EntityProject:      reflect.TypeFor[crmcontracts.CreateProjectRequest](),
+		datasource.EntityRelationship: reflect.TypeFor[crmcontracts.CreateRelationshipRequest](),
 	}
 	// An activity patch cannot reach its LINKS: UpdateActivityRequest declares
-	// no link field, so this list has none to describe.
+	// no link field, so this list has none to describe. A relationship patch
+	// cannot reach its ENDPOINTS for the same structural reason and a stronger
+	// domain one — an edge's ends are what it IS, so moving one is an archive
+	// plus a new edge, never an update.
 	updateShapes = map[datasource.EntityType]reflect.Type{
 		datasource.EntityPerson:       reflect.TypeFor[crmcontracts.UpdatePersonRequest](),
 		datasource.EntityOrganization: reflect.TypeFor[crmcontracts.UpdateOrganizationRequest](),
@@ -55,6 +59,7 @@ var (
 		datasource.EntityLead:         reflect.TypeFor[crmcontracts.UpdateLeadRequest](),
 		datasource.EntityActivity:     reflect.TypeFor[crmcontracts.UpdateActivityRequest](),
 		datasource.EntityProject:      reflect.TypeFor[crmcontracts.UpdateProjectRequest](),
+		datasource.EntityRelationship: reflect.TypeFor[crmcontracts.UpdateRelationshipRequest](),
 	}
 )
 
@@ -130,10 +135,29 @@ func describeRecordFields(shapes map[datasource.EntityType]reflect.Type) string 
 		b.WriteString("A deal's `pipeline_id` and `stage_id` come from list_pipelines — nothing else ")
 		b.WriteString("on this surface yields them, and neither is defaultable. ")
 	}
-	// The two traps a caller cannot see from the field list alone, and the
-	// second one is why a write can look like it worked and not have.
-	b.WriteString("A person's employer is NOT a field here: employment is a relationship record, ")
-	b.WriteString("which this tool cannot create. ")
+	// The trap a caller cannot see from the field list alone. A relationship's
+	// field list shows `kind`, `person_id`, `organization_id`, `deal_id` and
+	// `project_id` all as equal optional siblings — and they are not: which PAIR
+	// is required is decided by the kind, enforced by a database CHECK, and
+	// invisible from a flat list of names. A caller working from names alone
+	// sends a plausible pair and gets a shape refusal it cannot predict.
+	//
+	// Keyed on the shape actually being described, so the create tool carries
+	// this and the patch tool does not: a patch cannot reach an endpoint at all.
+	if _, creatable := shapes[datasource.EntityRelationship]; creatable {
+		b.WriteString("A person's employer is a relationship, not a field on the person: ")
+		b.WriteString("record_type=relationship with kind=employment, person_id and organization_id. ")
+		b.WriteString("Each kind requires its OWN endpoint pair and rejects any other — ")
+		b.WriteString("employment: person + organization; deal_stakeholder: deal + person; ")
+		b.WriteString("project_stakeholder: project + person; partner_of, referred_by and ")
+		b.WriteString("co_sell_with: organization + counterparty_org_id. ")
+	} else {
+		// The patch tool still owes the reader the pointer, because a person's
+		// employer is the field they will look for first and not find.
+		b.WriteString("A person's employer is NOT a field here: employment is a relationship, ")
+		b.WriteString("created and archived as record_type=relationship — its endpoints are what it ")
+		b.WriteString("IS, so they cannot be patched. ")
+	}
 	// The other field a caller reasonably expects and will not find. An
 	// activity DOES carry links — log_activity takes them — so being told the
 	// field is unknown, with no pointer, reads as "this is impossible" rather

--- a/backend/internal/modules/agents/recordfields.go
+++ b/backend/internal/modules/agents/recordfields.go
@@ -117,7 +117,18 @@ func describeRecordFields(shapes map[datasource.EntityType]reflect.Type) string 
 		b.WriteString(": ")
 		b.WriteString(strings.Join(contractFieldNames(shape), ", "))
 	}
-	b.WriteString(". A task is record_type=activity with kind=task. ")
+	b.WriteString(". ")
+	writeFieldAdvisories(&b, shapes)
+	return b.String()
+}
+
+// writeFieldAdvisories appends the things a caller CANNOT see from a field list:
+// which fields lie, which are not fields at all, and which key shape reaches a
+// custom field. Each is keyed on a field the shapes actually declare, so an
+// advisory appears on the tool it is true of — the create tool and the patch tool
+// disagree about several of them, and the wrong advice is worse than none.
+func writeFieldAdvisories(b *strings.Builder, shapes map[datasource.EntityType]reflect.Type) {
+	b.WriteString("A task is record_type=activity with kind=task. ")
 	// Only where the shapes actually carry `source`. On create it is accepted
 	// and then overwritten, so believing it took effect would be wrong; on
 	// update no request type has it at all, so it is REFUSED as an unknown key
@@ -142,15 +153,22 @@ func describeRecordFields(shapes map[datasource.EntityType]reflect.Type) string 
 	// invisible from a flat list of names. A caller working from names alone
 	// sends a plausible pair and gets a shape refusal it cannot predict.
 	//
-	// Keyed on the shape actually being described, so the create tool carries
-	// this and the patch tool does not: a patch cannot reach an endpoint at all.
-	if _, creatable := shapes[datasource.EntityRelationship]; creatable {
+	// Keyed on an ENDPOINT FIELD, not on the record type, because both maps carry
+	// relationship — the patch tool serves it too. Only the create shape declares
+	// `counterparty_org_id`, so this is the honest test for "can the caller name
+	// an endpoint at all", which is what the pairing rule is about.
+	if describesField(shapes, "counterparty_org_id") {
 		b.WriteString("A person's employer is a relationship, not a field on the person: ")
 		b.WriteString("record_type=relationship with kind=employment, person_id and organization_id. ")
 		b.WriteString("Each kind requires its OWN endpoint pair and rejects any other — ")
 		b.WriteString("employment: person + organization; deal_stakeholder: deal + person; ")
 		b.WriteString("project_stakeholder: project + person; partner_of, referred_by and ")
 		b.WriteString("co_sell_with: organization + counterparty_org_id. ")
+		// An edge is returned only by the call that WRITES it: read_record and
+		// search_records do not serve `relationship` (the contract has no
+		// single-relationship GET), so an id thrown away is an id nothing on this
+		// surface will hand back.
+		b.WriteString("Keep the id a relationship write returns — no read tool serves an edge. ")
 	} else {
 		// The patch tool still owes the reader the pointer, because a person's
 		// employer is the field they will look for first and not find.
@@ -175,7 +193,6 @@ func describeRecordFields(shapes map[datasource.EntityType]reflect.Type) string 
 	b.WriteString("Extra keys are read as custom-field values and must be named cf_<slug> for a ")
 	b.WriteString("custom field ACTIVE in this workspace; any other key is silently discarded, ")
 	b.WriteString("so re-read the record if you are unsure a value landed.")
-	return b.String()
 }
 
 // customFieldPrefix is the only shape an extra key may take: the

--- a/backend/internal/modules/agents/recordfields.go
+++ b/backend/internal/modules/agents/recordfields.go
@@ -157,40 +157,18 @@ func writeFieldAdvisories(b *strings.Builder, shapes map[datasource.EntityType]r
 	// relationship — the patch tool serves it too. Only the create shape declares
 	// `counterparty_org_id`, so this is the honest test for "can the caller name
 	// an endpoint at all", which is what the pairing rule is about.
-	if describesField(shapes, "counterparty_org_id") {
-		b.WriteString("A person's employer is a relationship, not a field on the person: ")
-		b.WriteString("record_type=relationship with kind=employment, person_id and organization_id. ")
-		// REQUIRES, not "and rejects any other". The schema's shape CHECKs pin the
-		// pair each kind must have and forbid the endpoints that would contradict
-		// it, but they do not forbid every irrelevant one — an employment edge will
-		// accept a stray counterparty_org_id. Promising more than the constraints
-		// deliver would be a description a caller could disprove.
-		b.WriteString("Each kind REQUIRES its own endpoint pair, and a wrong pair is refused by name — ")
-		b.WriteString("employment: person + organization; deal_stakeholder: deal + person; ")
-		b.WriteString("project_stakeholder: project + person; partner_of, referred_by and ")
-		b.WriteString("co_sell_with: organization + counterparty_org_id. ")
-		// An edge is not searchable: search_records' record_type enum has no
-		// relationship, and there is no list-relationships tool. So the id a write
-		// returns is the only handle on the edge this surface will give out.
-		//
-		// It deliberately does NOT say "no read tool serves an edge" — read_record
-		// answers a relationship by id even though its enum does not advertise one
-		// (the contract has no single-relationship GET), and a description a caller
-		// can disprove in one call costs more than the silence it replaced.
-		b.WriteString("An edge is not searchable, so keep the id a relationship write returns. ")
-	} else {
-		// The patch tool still owes the reader the pointer, because a person's
-		// employer is the field they will look for first and not find.
-		b.WriteString("A person's employer is NOT a field here: employment is a relationship, ")
-		b.WriteString("created and archived as record_type=relationship — its endpoints are what it ")
-		b.WriteString("IS, so they cannot be patched. ")
-	}
+	writeRelationshipAdvisory(b, shapes)
 	// The other field a caller reasonably expects and will not find. An
-	// activity DOES carry links — log_activity takes them — so being told the
-	// field is unknown, with no pointer, reads as "this is impossible" rather
-	// than "this is a different verb". Only said where an activity is actually
-	// in scope, so the create tool does not carry advice about a patch.
-	if _, updatable := shapes[datasource.EntityActivity]; updatable {
+	// activity DOES carry links — log_activity and create_record both take them —
+	// so being told the field is unknown, with no pointer, reads as "this is
+	// impossible" rather than "this is a different verb".
+	//
+	// Keyed on the ABSENCE of the links field, not on the record type: both shape
+	// maps carry activity, so a record-type test put this patch-only advice on the
+	// create tool too, which DOES accept links. Same mistake as the endpoint
+	// advisory above, in its sibling.
+	_, hasActivity := shapes[datasource.EntityActivity]
+	if hasActivity && !describesField(shapes, "links") {
 		// Says what is true and stops. Naming the relink action would be
 		// directing the reader at something this surface does not serve: it is
 		// a REST operation with no tool behind it, so an agent told to use it
@@ -202,6 +180,42 @@ func writeFieldAdvisories(b *strings.Builder, shapes map[datasource.EntityType]r
 	b.WriteString("Extra keys are read as custom-field values and must be named cf_<slug> for a ")
 	b.WriteString("custom field ACTIVE in this workspace; any other key is silently discarded, ")
 	b.WriteString("so re-read the record if you are unsure a value landed.")
+	// …but not for every record type, and the exception is this surface's own
+	// decision: a type takes custom fields only if its contract shape carries the
+	// additionalProperties bag a cf_ value travels in, and activity and
+	// relationship carry none. Promising carriage there would send an agent to
+	// write a key the strict decoder refuses.
+	//
+	// DERIVED from the shapes, not listed: the exclusion is a property of the
+	// generated contract, and agents may not import customfields to ask it
+	// (a module never imports a sibling). So the same question its FieldObjects
+	// gate asks — is there a catch-all — is asked here, of the shapes in hand.
+	if without := typesWithoutCustomFieldCarriage(shapes); without != "" {
+		b.WriteString(" No custom fields on " + without + ": those types carry no cf_ values at all, ")
+		b.WriteString("so a cf_ key there is refused rather than stored.")
+	}
+}
+
+// typesWithoutCustomFieldCarriage names the record types in shapes whose contract
+// body has no additionalProperties catch-all, in EntityTypes() order so the text
+// is byte-stable. Empty when every type in shapes carries one.
+//
+// The catch-all is a `json:"-"` MAP field — oapi-codegen's rendering of
+// additionalProperties — and its presence is exactly "can this shape hold a key
+// the schema does not name", which is what a cf_ value needs.
+func typesWithoutCustomFieldCarriage(shapes map[datasource.EntityType]reflect.Type) string {
+	var without []string
+	for _, recordType := range datasource.EntityTypes() {
+		shape, ok := shapes[recordType]
+		if !ok {
+			continue
+		}
+		if field, found := shape.FieldByName("AdditionalProperties"); found && field.Type.Kind() == reflect.Map {
+			continue
+		}
+		without = append(without, string(recordType))
+	}
+	return strings.Join(without, " or ")
 }
 
 // customFieldPrefix is the only shape an extra key may take: the
@@ -307,4 +321,41 @@ const stageIDNote = `,"description":"The target stage. Obtain it from list_pipel
 // forbids those rather than leaving the difference to chance.
 func jsonString(s string) string {
 	return strconv.Quote(s)
+}
+
+// writeRelationshipAdvisory says what a relationship needs, because an edge's
+// requirements are per-KIND and invisible from a flat field list: `kind`,
+// `person_id`, `organization_id`, `deal_id` and `project_id` all read as equal
+// optional siblings, and they are not. Which pair is required is decided by the
+// kind and enforced by a database CHECK, so a caller working from names alone
+// sends a plausible pair and gets a shape refusal it could not have predicted.
+func writeRelationshipAdvisory(b *strings.Builder, shapes map[datasource.EntityType]reflect.Type) {
+	if describesField(shapes, "counterparty_org_id") {
+		b.WriteString("A person's employer is a relationship, not a field on the person: ")
+		b.WriteString("record_type=relationship with kind=employment, person_id and organization_id. ")
+		// REQUIRES, not "and rejects any other". The schema's shape CHECKs pin the
+		// pair each kind must have and forbid the endpoints that would contradict
+		// it, but they do not forbid every irrelevant one — an employment edge will
+		// accept a stray counterparty_org_id. Promising more than the constraints
+		// deliver would be a description a caller could disprove.
+		b.WriteString("Each kind REQUIRES its own endpoint pair, and a wrong pair is refused by name — ")
+		b.WriteString("employment: person + organization; deal_stakeholder: deal + person; ")
+		b.WriteString("project_stakeholder: project + person; partner_of, referred_by and ")
+		b.WriteString("co_sell_with: organization + counterparty_org_id. ")
+		// An edge is not searchable: search_records' record_type enum has no
+		// relationship, and there is no list-relationships tool. So the id a write
+		// returns is the only handle on the edge this surface will give out.
+		//
+		// It deliberately does NOT say "no read tool serves an edge" — read_record
+		// answers a relationship by id even though its enum does not advertise one
+		// (the contract has no single-relationship GET), and a description a caller
+		// can disprove in one call costs more than the silence it replaced.
+		b.WriteString("An edge is not searchable, so keep the id a relationship write returns. ")
+	} else {
+		// The patch tool still owes the reader the pointer, because a person's
+		// employer is the field they will look for first and not find.
+		b.WriteString("A person's employer is NOT a field here: employment is a relationship, ")
+		b.WriteString("created and archived as record_type=relationship — its endpoints are what it ")
+		b.WriteString("IS, so they cannot be patched. ")
+	}
 }

--- a/backend/internal/modules/agents/recordfields.go
+++ b/backend/internal/modules/agents/recordfields.go
@@ -121,6 +121,15 @@ func describeRecordFields(shapes map[datasource.EntityType]reflect.Type) string 
 	if describesField(shapes, "source") {
 		b.WriteString("`source` is accepted but overwritten — this surface stamps its own provenance. ")
 	}
+	// Where the two ids a deal cannot be born without come from. Naming them as
+	// required (which the mapping does) without saying that is what made
+	// create_record/deal unusable: a caller was told exactly what it needed and
+	// had nowhere to get it. Keyed on the field, so this sentence appears on the
+	// tool whose shapes actually declare it and not on the patch tool.
+	if describesField(shapes, "pipeline_id") {
+		b.WriteString("A deal's `pipeline_id` and `stage_id` come from list_pipelines — nothing else ")
+		b.WriteString("on this surface yields them, and neither is defaultable. ")
+	}
 	// The two traps a caller cannot see from the field list alone, and the
 	// second one is why a write can look like it worked and not have.
 	b.WriteString("A person's employer is NOT a field here: employment is a relationship record, ")
@@ -226,6 +235,16 @@ func rejectUnknownFields(shapes map[datasource.EntityType]reflect.Type, recordTy
 // spent on exactly that before the reason was visible, so the requirement is
 // stated where it is read rather than left implied by a keyword.
 const timestampNote = `,"description":"RFC 3339 with a zone offset — 2026-07-31T16:35:00+07:00 or 2026-07-31T09:35:00Z. A bare local time without an offset is refused."`
+
+// stageIDNote is appended to every stage-id argument the tool surface takes.
+// Two tools declared it as a bare format:uuid, which named the requirement
+// without making it obtainable: the id lives in pipeline configuration, and
+// until list_pipelines existed nothing on this surface yielded one. Saying where
+// it comes from is the difference between a correct refusal and a dead end. The
+// semantic half is here because it is what decides the tier — a caller that
+// picks a stage without reading it cannot tell an immediate move from one that
+// will wait on a human.
+const stageIDNote = `,"description":"The target stage. Obtain it from list_pipelines — no other tool yields a stage id. That stage's semantic decides what happens next: open executes immediately, won or lost is staged for a human's approval."`
 
 // jsonString renders s as a JSON string literal so a description built at init
 // time can be spliced into a hand-written schema literal safely.

--- a/backend/internal/modules/agents/recordfields.go
+++ b/backend/internal/modules/agents/recordfields.go
@@ -160,15 +160,24 @@ func writeFieldAdvisories(b *strings.Builder, shapes map[datasource.EntityType]r
 	if describesField(shapes, "counterparty_org_id") {
 		b.WriteString("A person's employer is a relationship, not a field on the person: ")
 		b.WriteString("record_type=relationship with kind=employment, person_id and organization_id. ")
-		b.WriteString("Each kind requires its OWN endpoint pair and rejects any other — ")
+		// REQUIRES, not "and rejects any other". The schema's shape CHECKs pin the
+		// pair each kind must have and forbid the endpoints that would contradict
+		// it, but they do not forbid every irrelevant one — an employment edge will
+		// accept a stray counterparty_org_id. Promising more than the constraints
+		// deliver would be a description a caller could disprove.
+		b.WriteString("Each kind REQUIRES its own endpoint pair, and a wrong pair is refused by name — ")
 		b.WriteString("employment: person + organization; deal_stakeholder: deal + person; ")
 		b.WriteString("project_stakeholder: project + person; partner_of, referred_by and ")
 		b.WriteString("co_sell_with: organization + counterparty_org_id. ")
-		// An edge is returned only by the call that WRITES it: read_record and
-		// search_records do not serve `relationship` (the contract has no
-		// single-relationship GET), so an id thrown away is an id nothing on this
-		// surface will hand back.
-		b.WriteString("Keep the id a relationship write returns — no read tool serves an edge. ")
+		// An edge is not searchable: search_records' record_type enum has no
+		// relationship, and there is no list-relationships tool. So the id a write
+		// returns is the only handle on the edge this surface will give out.
+		//
+		// It deliberately does NOT say "no read tool serves an edge" — read_record
+		// answers a relationship by id even though its enum does not advertise one
+		// (the contract has no single-relationship GET), and a description a caller
+		// can disprove in one call costs more than the silence it replaced.
+		b.WriteString("An edge is not searchable, so keep the id a relationship write returns. ")
 	} else {
 		// The patch tool still owes the reader the pointer, because a person's
 		// employer is the field they will look for first and not find.

--- a/backend/internal/modules/agents/recordfields_test.go
+++ b/backend/internal/modules/agents/recordfields_test.go
@@ -362,8 +362,9 @@ func TestTheCreateAndPatchDescriptionsDisagreeAboutEndpoints(t *testing.T) {
 	patch := describeRecordFields(updateShapes)
 
 	// The pairing rule is create-only: naming a pair is a thing only a create can
-	// do.
-	const pairingRule = "Each kind requires its OWN endpoint pair"
+	// do. Keyed on the stable CLAIM, not on the sentence — a reworded advisory is
+	// not a regression, a missing one is.
+	const pairingRule = "endpoint pair"
 	if !strings.Contains(create, pairingRule) {
 		t.Errorf("create_record's description does not state the per-kind endpoint pairing rule, which "+
 			"is invisible from a flat field list: %q", create)

--- a/backend/internal/modules/agents/recordfields_test.go
+++ b/backend/internal/modules/agents/recordfields_test.go
@@ -349,3 +349,33 @@ func recordTypeEnum(t *testing.T, tool string, raw json.RawMessage) []string {
 	}
 	return parsed.Properties.RecordType.Enum
 }
+
+// The create and patch descriptions must not converge.
+//
+// They differ on one thing that matters: an edge's endpoints can be NAMED on
+// create and cannot be patched at all, because an edge's ends are what it is. The
+// branch that says so was keyed on `shapes[EntityRelationship]` at first, and both
+// maps carry that key — so the patch tool shipped the create tool's pairing rule
+// and the sentence written for the patch tool was unreachable.
+func TestTheCreateAndPatchDescriptionsDisagreeAboutEndpoints(t *testing.T) {
+	create := describeRecordFields(createShapes)
+	patch := describeRecordFields(updateShapes)
+
+	// The pairing rule is create-only: naming a pair is a thing only a create can
+	// do.
+	const pairingRule = "Each kind requires its OWN endpoint pair"
+	if !strings.Contains(create, pairingRule) {
+		t.Errorf("create_record's description does not state the per-kind endpoint pairing rule, which "+
+			"is invisible from a flat field list: %q", create)
+	}
+	if strings.Contains(patch, pairingRule) {
+		t.Error("update_record's description states the endpoint pairing rule, and a patch cannot reach " +
+			"an endpoint — so it is advice the caller cannot act on")
+	}
+
+	// And the patch tool says what IS true for it, rather than saying nothing.
+	if !strings.Contains(patch, "cannot be patched") {
+		t.Errorf("update_record's description never says an edge's endpoints are unpatchable, which is "+
+			"the first thing a caller looks for and does not find: %q", patch)
+	}
+}

--- a/backend/internal/modules/agents/recordfields_test.go
+++ b/backend/internal/modules/agents/recordfields_test.go
@@ -379,4 +379,54 @@ func TestTheCreateAndPatchDescriptionsDisagreeAboutEndpoints(t *testing.T) {
 		t.Errorf("update_record's description never says an edge's endpoints are unpatchable, which is "+
 			"the first thing a caller looks for and does not find: %q", patch)
 	}
+
+	// The same mistake in its sibling: an activity's links ARE settable on create
+	// and not patchable, and both shape maps carry activity — so a record-type key
+	// put the patch-only advice on the create tool too.
+	const linksAdvisory = "links are NOT patchable"
+	if !strings.Contains(patch, linksAdvisory) {
+		t.Errorf("update_record's description does not say an activity's links are unpatchable: %q", patch)
+	}
+	if strings.Contains(create, linksAdvisory) {
+		t.Error("create_record's description says an activity's links are NOT patchable — create_record " +
+			"and log_activity both ACCEPT links, so it is advice against a field the tool takes")
+	}
+}
+
+// The closing custom-field sentence must not promise carriage the surface
+// withholds.
+//
+// Every record type's description ends by telling callers that extra cf_<slug>
+// keys are read as custom-field values. That is false for activity and
+// relationship: neither contract shape carries the additionalProperties bag a cf_
+// value travels in, and customfields.FieldObjects deliberately excludes both — so
+// an agent following the description writes a key the strict decoder refuses.
+func TestTheCustomFieldSentenceNamesTheTypesThatTakeNone(t *testing.T) {
+	for name, description := range map[string]string{
+		"create": describeRecordFields(createShapes),
+		"update": describeRecordFields(updateShapes),
+	} {
+		if !strings.Contains(description, "cf_<slug>") {
+			t.Fatalf("%s: the description no longer mentions the custom-field key shape at all: %q",
+				name, description)
+		}
+		// The exclusion clause, isolated with Cut so the assertion reads the
+		// SENTENCE rather than the whole description — "activity" appears earlier
+		// in the field lists, so a substring test over the full text would pass
+		// without any exclusion being stated at all.
+		_, exclusion, found := strings.Cut(description, "No custom fields on")
+		if !found {
+			t.Errorf("%s: the description promises cf_ carriage and excludes nothing, though activity and "+
+				"relationship carry no additionalProperties bag — a cf_ key on either is refused, not "+
+				"stored: %q", name, description)
+			continue
+		}
+		// Both, and by name: an agent reads prose, so "some types are excluded"
+		// would leave it guessing which.
+		for _, excluded := range []string{"activity", "relationship"} {
+			if !strings.Contains(exclusion, excluded) {
+				t.Errorf("%s: the cf_ exclusion clause %q does not name %q", name, exclusion, excluded)
+			}
+		}
+	}
 }

--- a/backend/internal/modules/agents/tools.go
+++ b/backend/internal/modules/agents/tools.go
@@ -296,9 +296,9 @@ func (t createRecord) Spec() mcp.ToolSpec {
 	return mcp.ToolSpec{
 		Name: "create_record", Title: "Create a record", Version: toolVersionV1,
 		RequiredScope: principal.ScopeWrite, Tier: mcp.TierAutoExecute,
-		OpenAPIOp: "createPerson/createOrganization/createDeal/createLead/createProject",
+		OpenAPIOp: "createPerson/createOrganization/createDeal/createLead/createProject/createRelationship",
 		InputSchema: schema(`{"type":"object","required":["record_type","fields"],"properties":{
-			"record_type":{"type":"string","enum":["person","organization","deal","lead","activity","project"]},
+			"record_type":{"type":"string","enum":["person","organization","deal","lead","activity","project","relationship"]},
 			"fields":{"type":"object","description":` + jsonString(describeRecordFields(createShapes)) + `}},
 			"additionalProperties":false}`),
 		OutputSchema: schema(`{"type":"object"}`),

--- a/backend/internal/modules/agents/tools.go
+++ b/backend/internal/modules/agents/tools.go
@@ -390,7 +390,7 @@ func (t advanceDeal) Spec() mcp.ToolSpec {
 		OpenAPIOp:     "advanceDeal",
 		InputSchema: schema(`{"type":"object","required":["deal_id","to_stage_id"],"properties":{
 			"deal_id":{"type":"string","format":"uuid"},
-			"to_stage_id":{"type":"string","format":"uuid"},
+			"to_stage_id":{"type":"string","format":"uuid"` + stageIDNote + `},
 			"lost_reason":{"type":"string","description":"Required when the target stage closes the deal as lost"},
 			"if_version":{"type":"integer"},
 			"approval_id":{"type":"string","format":"uuid","description":"Set on retry after a human approved a won/lost move"}},

--- a/backend/internal/modules/agents/tools_confirm.go
+++ b/backend/internal/modules/agents/tools_confirm.go
@@ -272,17 +272,22 @@ func recordLabel(rec datasource.Record) string {
 		DisplayName string `json:"display_name"`
 		Name        string `json:"name"`
 		Email       string `json:"email"`
-		// Kind is last because it is the weakest label — it names a CLASS, not
-		// an instance. It is here for the one record type that has no name of
-		// any sort: a relationship is an edge, and its identity is its kind plus
-		// two endpoints. Without it a human is asked to approve
-		// "Archive relationship 0195c3…", which tells them nothing about what
-		// disappears; with it they at least read "employment".
-		Kind string `json:"kind"`
+		Kind        string `json:"kind"`
 	}
 	//craft:ignore swallowed-errors label extraction is best-effort by design — unparseable fields fall through to the id below
 	_ = json.Unmarshal(rec.Fields, &f)
-	for _, s := range []string{f.FullName, f.DisplayName, f.Name, f.Email, f.Kind} {
+	// An edge has no name of any sort: its identity is its kind plus two
+	// endpoints, so "Archive relationship 0195c3…" tells the approving human
+	// nothing about what disappears, while "employment" at least names the class.
+	//
+	// Scoped to that ONE type rather than added to the ladder below. `kind` is a
+	// field an activity also carries, and there the id is the better answer: a
+	// staged overwrite reading `Update activity "note"` would name a class where a
+	// human needs to know WHICH note, and would suppress the id that told them.
+	if rec.Ref.Type == datasource.EntityRelationship && f.Kind != "" {
+		return fmt.Sprintf("%q", f.Kind)
+	}
+	for _, s := range []string{f.FullName, f.DisplayName, f.Name, f.Email} {
 		if s != "" {
 			return fmt.Sprintf("%q", s)
 		}

--- a/backend/internal/modules/agents/tools_confirm.go
+++ b/backend/internal/modules/agents/tools_confirm.go
@@ -37,9 +37,9 @@ func (t archiveRecord) Spec() mcp.ToolSpec {
 	return mcp.ToolSpec{
 		Name: "archive_record", Title: "Archive a record", Version: toolVersionV1,
 		RequiredScope: principal.ScopeWrite, Tier: mcp.TierConfirmationRequired,
-		OpenAPIOp: "archivePerson/archiveOrganization/archiveDeal/archiveProject",
+		OpenAPIOp: "archivePerson/archiveOrganization/archiveDeal/archiveProject/archiveRelationship",
 		InputSchema: schema(`{"type":"object","required":["record_type","id"],"properties":{
-			"record_type":{"type":"string","enum":["person","organization","deal","project"]},
+			"record_type":{"type":"string","enum":["person","organization","deal","project","relationship"]},
 			"id":{"type":"string","format":"uuid"},
 			"approval_id":{"type":"string","format":"uuid","description":"Set on retry after a human approved the staged call"}},
 			"additionalProperties":false}`),
@@ -272,10 +272,17 @@ func recordLabel(rec datasource.Record) string {
 		DisplayName string `json:"display_name"`
 		Name        string `json:"name"`
 		Email       string `json:"email"`
+		// Kind is last because it is the weakest label — it names a CLASS, not
+		// an instance. It is here for the one record type that has no name of
+		// any sort: a relationship is an edge, and its identity is its kind plus
+		// two endpoints. Without it a human is asked to approve
+		// "Archive relationship 0195c3…", which tells them nothing about what
+		// disappears; with it they at least read "employment".
+		Kind string `json:"kind"`
 	}
 	//craft:ignore swallowed-errors label extraction is best-effort by design — unparseable fields fall through to the id below
 	_ = json.Unmarshal(rec.Fields, &f)
-	for _, s := range []string{f.FullName, f.DisplayName, f.Name, f.Email} {
+	for _, s := range []string{f.FullName, f.DisplayName, f.Name, f.Email, f.Kind} {
 		if s != "" {
 			return fmt.Sprintf("%q", s)
 		}

--- a/backend/internal/modules/agents/tools_confirm_test.go
+++ b/backend/internal/modules/agents/tools_confirm_test.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// What a human reads when asked to approve a 🟡 call.
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+)
+
+// The label a staged call shows the approver, per record type.
+//
+// `kind` is a weak label — it names a CLASS, not an instance — and it is only ever
+// the best answer for an edge, which has no name at all. An activity carries a
+// `kind` too, and there the id is what a human needs: "Update activity" plus a
+// class name says nothing about WHICH note is being overwritten.
+func TestRecordLabelUsesKindOnlyForAnEdge(t *testing.T) {
+	edgeID, activityID := ids.NewV7(), ids.NewV7()
+	for name, tc := range map[string]struct {
+		entity datasource.EntityType
+		id     ids.UUID
+		fields string
+		want   string
+	}{
+		"an edge has no name, so its kind is the label": {
+			datasource.EntityRelationship, edgeID, `{"kind":"employment"}`, `"employment"`,
+		},
+		"an activity's kind is NOT its label — the id identifies the row": {
+			datasource.EntityActivity, activityID, `{"kind":"note","body":"..."}`, activityID.String(),
+		},
+		"a named record still wins over everything": {
+			datasource.EntityDeal, ids.NewV7(), `{"name":"Acme renewal","kind":"whatever"}`, `"Acme renewal"`,
+		},
+		"nothing to read falls back to the id": {
+			datasource.EntityPerson, edgeID, `{}`, edgeID.String(),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := recordLabel(datasource.Record{
+				Ref: datasource.EntityRef{Type: tc.entity, ID: tc.id}, Fields: json.RawMessage(tc.fields),
+			})
+			if got != tc.want {
+				t.Errorf("recordLabel = %s, want %s", got, tc.want)
+			}
+		})
+	}
+}

--- a/backend/internal/modules/agents/tools_network.go
+++ b/backend/internal/modules/agents/tools_network.go
@@ -206,6 +206,20 @@ func (t accountCoverageTool) Handle(ctx context.Context, in json.RawMessage) (js
 	if err != nil {
 		return nil, err
 	}
+	// At the BOUNDARY, not only in whichever implementation built the answer.
+	// CoverageReader is a func seam: a second implementation satisfies it without
+	// passing through compose's builder, and "no seats, nobody on our side" is the
+	// most useful thing this tool says — a model handed null reads it as "unknown"
+	// and hedges about coverage the server was certain of.
+	if answer.Stakeholders == nil {
+		answer.Stakeholders = []CoverageSeat{}
+	}
+	if answer.OurSide == nil {
+		answer.OurSide = []KnownColleague{}
+	}
+	if answer.Risks == nil {
+		answer.Risks = []CoverageRisk{}
+	}
 	return json.Marshal(answer)
 }
 

--- a/backend/internal/modules/agents/tools_pipelines.go
+++ b/backend/internal/modules/agents/tools_pipelines.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// Pipeline and stage discovery: the read that makes the deal-shaped write
+// verbs usable at all.
+//
+// `create_record` for a deal REQUIRES pipeline_id and stage_id, and
+// `advance_deal` requires to_stage_id — and until this tool existed no verb on
+// the surface yielded one. A correct refusal into a dead end is still a dead
+// end: an agent was told exactly which two ids it needed and had no way to
+// obtain either.
+//
+// ONE tool, stages nested, not a list-pipelines plus a list-stages: a stage is
+// meaningless without the pipeline that owns it, and two tools would force a
+// join an agent has no reason to perform. 🟢 — it reads configuration and
+// changes nothing.
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/mcp"
+)
+
+// Pipeline is one pipeline with its live stages, in the shape a model
+// consumes: the ids it needs to write, plus enough configuration to choose
+// between them.
+type Pipeline struct {
+	ID   ids.UUID `json:"id"`
+	Name string   `json:"name"`
+	// IsDefault marks the workspace's default pipeline — the one to pick when
+	// the caller has no reason to prefer another.
+	IsDefault bool    `json:"is_default"`
+	Position  int     `json:"position"`
+	Stages    []Stage `json:"stages"`
+}
+
+// Stage is one stage of a pipeline. Semantic is the load-bearing field: it is
+// what tells a caller which stage a deal is born into (open) and which two
+// close it (won/lost), and it is what advance_deal's tier resolver keys off —
+// so a name-based guess at "the first stage" is not a substitute for reading it.
+type Stage struct {
+	ID             ids.UUID `json:"id"`
+	Name           string   `json:"name"`
+	Semantic       string   `json:"semantic"`
+	WinProbability int      `json:"win_probability"`
+	Position       int      `json:"position"`
+}
+
+// PipelineLister answers "what pipelines and stages does this workspace have".
+// Compose implements it over the deals module's own row-scoped config reads, so
+// the `pipeline` RBAC object gates this tool exactly as it gates the HTTP
+// surface.
+type PipelineLister func(ctx context.Context) ([]Pipeline, error)
+
+// RegisterPipelineTool wires the config read behind the deal write verbs. A nil
+// seam registers nothing: a surface that cannot ground its answer does not
+// pretend to.
+func RegisterPipelineTool(r *Registry, list PipelineLister) {
+	if list == nil {
+		return
+	}
+	r.Register(listPipelinesTool{list: list})
+}
+
+// --- list_pipelines (🟢 read) ---
+
+type listPipelinesTool struct{ list PipelineLister }
+
+func (t listPipelinesTool) Spec() mcp.ToolSpec {
+	return mcp.ToolSpec{
+		Name: "list_pipelines", Title: "List pipelines and their stages", Version: toolVersionV1,
+		RequiredScope: principal.ScopeRead, Tier: mcp.TierAutoExecute,
+		OpenAPIOp: "listPipelines/listStages",
+		// No arguments. The whole config is small, bounded by how many pipelines
+		// a workspace configures, and a filter would only let a caller ask for
+		// the one it cannot name yet.
+		InputSchema: schema(`{"type":"object","properties":{},"description":` +
+			jsonString("Every pipeline with its live stages. Call this FIRST to obtain the "+
+				"`pipeline_id` and `stage_id` that create_record for a deal requires, and the "+
+				"`to_stage_id` that advance_deal requires — no other tool yields them. Read each "+
+				"stage's `semantic`: `open` stages are where a deal is born and moves; `won` and "+
+				"`lost` close it, and advancing onto one needs a human's approval. Do not infer a "+
+				"stage's meaning from its name.") + `,"additionalProperties":false}`),
+		OutputSchema: schema(`{"type":"object"}`),
+	}
+}
+
+func (t listPipelinesTool) Handle(ctx context.Context, in json.RawMessage) (json.RawMessage, error) {
+	var args struct{}
+	if err := decodeArgs(in, &args); err != nil {
+		return nil, err
+	}
+	pipelines, err := t.list(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if pipelines == nil {
+		// An empty LIST, not a null. A workspace with no pipeline configured is
+		// a real state — it means the deal verbs cannot be used yet — and a model
+		// handed null reads it as "unknown" and hedges instead of saying so.
+		pipelines = []Pipeline{}
+	}
+	// Every pipeline's stages normalize too: a pipeline with no live stage is
+	// the case a caller most needs to see as "none", because it is the one that
+	// makes create_record for a deal impossible.
+	for i := range pipelines {
+		if pipelines[i].Stages == nil {
+			pipelines[i].Stages = []Stage{}
+		}
+	}
+	return json.Marshal(map[string]any{"pipelines": pipelines})
+}

--- a/backend/internal/modules/agents/tools_pipelines.go
+++ b/backend/internal/modules/agents/tools_pipelines.go
@@ -51,6 +51,13 @@ type Stage struct {
 	Position       int      `json:"position"`
 }
 
+// listPipelinesAnswer is the tool's wire shape. Named rather than assembled as a
+// map[string]any: the payload is fully typed already, so the map would be an
+// untyped hop that also leaves the response shape undocumented.
+type listPipelinesAnswer struct {
+	Pipelines []Pipeline `json:"pipelines"`
+}
+
 // PipelineLister answers "what pipelines and stages does this workspace have".
 // Compose implements it over the deals module's own row-scoped config reads, so
 // the `pipeline` RBAC object gates this tool exactly as it gates the HTTP
@@ -113,5 +120,5 @@ func (t listPipelinesTool) Handle(ctx context.Context, in json.RawMessage) (json
 			pipelines[i].Stages = []Stage{}
 		}
 	}
-	return json.Marshal(map[string]any{"pipelines": pipelines})
+	return json.Marshal(listPipelinesAnswer{Pipelines: pipelines})
 }

--- a/backend/internal/modules/agents/tools_pipelines_test.go
+++ b/backend/internal/modules/agents/tools_pipelines_test.go
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// list_pipelines is thin over its seam, so what is worth pinning is the
+// decisions around it: the tier and scope (it reads configuration), what an
+// empty workspace answers, and that the answer never carries a JSON null where
+// a caller was promised a list.
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/mcp"
+)
+
+func TestListPipelinesIsReadTierAndNeedsOnlyReadScope(t *testing.T) {
+	spec := listPipelinesTool{}.Spec()
+	if spec.Tier != mcp.TierAutoExecute {
+		t.Errorf("tier = %v, want auto-execute — it reads configuration and changes nothing", spec.Tier)
+	}
+	if spec.RequiredScope != principal.ScopeRead {
+		t.Errorf("RequiredScope = %v, want read", spec.RequiredScope)
+	}
+	// The description is the whole reason the tool is discoverable: it is what
+	// tells an agent that the two ids create_record refuses without are HERE.
+	// A tool that answered correctly and did not say what it is for would leave
+	// the dead end exactly where it was.
+	for _, want := range []string{"pipeline_id", "stage_id", "to_stage_id", "semantic"} {
+		if !strings.Contains(string(spec.InputSchema), want) {
+			t.Errorf("the description names no %s — an agent reading tools/list cannot tell "+
+				"this is the tool that unblocks the deal verbs", want)
+		}
+	}
+}
+
+func TestAnAbsentPipelineSeamRegistersNoTool(t *testing.T) {
+	// A role wired without the seam must not advertise a tool that always errors.
+	r := NewRegistry(nil, nil)
+	RegisterPipelineTool(r, nil)
+	if _, found := r.Spec("list_pipelines"); found {
+		t.Error("list_pipelines registered with no seam behind it")
+	}
+}
+
+func TestAWorkspaceWithNoPipelinesAnswersAnEmptyListNotNull(t *testing.T) {
+	// "This workspace has no pipelines configured" is a true and useful answer —
+	// it is the answer that says the deal verbs cannot be used yet. A JSON null
+	// reads to a model as "unknown", which is a different claim.
+	tool := listPipelinesTool{list: func(context.Context) ([]Pipeline, error) { return nil, nil }}
+	out, err := tool.Handle(context.Background(), json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("an unconfigured workspace answered an error: %v", err)
+	}
+	if !strings.Contains(string(out), `"pipelines":[]`) {
+		t.Errorf("payload = %s, want an empty pipelines array", out)
+	}
+}
+
+func TestAPipelineWithNoLiveStagesAnswersAnEmptyStageListNotNull(t *testing.T) {
+	// The case a caller most needs to see as "none": a pipeline whose stages are
+	// all archived cannot host a deal, and `"stages":null` would leave a model
+	// unsure whether it simply had not been told.
+	tool := listPipelinesTool{list: func(context.Context) ([]Pipeline, error) {
+		return []Pipeline{{ID: ids.NewV7(), Name: "Sales", IsDefault: true}}, nil
+	}}
+	out, err := tool.Handle(context.Background(), json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if !strings.Contains(string(out), `"stages":[]`) {
+		t.Errorf("payload = %s, want an empty stages array on the stageless pipeline", out)
+	}
+}
+
+func TestListPipelinesRefusesAnUnknownArgument(t *testing.T) {
+	// The seam is never reached with arguments the tool does not take: a filter
+	// silently ignored would let a caller believe it had narrowed the answer.
+	reached := false
+	tool := listPipelinesTool{list: func(context.Context) ([]Pipeline, error) {
+		reached = true
+		return nil, nil
+	}}
+	if _, err := tool.Handle(context.Background(), json.RawMessage(`{"pipeline_id":"x"}`)); err == nil {
+		t.Error("an unknown argument was accepted")
+	}
+	if reached {
+		t.Error("the seam was reached despite an unknown argument")
+	}
+}
+
+// A tool that REQUIRES a pipeline or stage id must say where one comes from.
+//
+// This is the defect U2 closes, stated as an invariant rather than as three
+// fixes: create_record for a deal and both stage-move tools named the ids they
+// needed and nothing on the surface yielded one, so a correct refusal was a dead
+// end. Derived from the registry, so a tool added later that takes a stage id
+// inherits the obligation instead of quietly reopening the dead end.
+func TestEveryToolNeedingAPipelineOrStageIDPointsAtListPipelines(t *testing.T) {
+	const source = "list_pipelines"
+	checked := 0
+	for _, spec := range fullRegistry(t).Specs() {
+		// The source itself owes no pointer to itself.
+		if spec.Name == source {
+			continue
+		}
+		schemaText := string(spec.InputSchema)
+		if !strings.Contains(schemaText, "stage_id") && !strings.Contains(schemaText, "pipeline_id") {
+			continue
+		}
+		checked++
+		if !strings.Contains(schemaText, source) {
+			t.Errorf("%s takes a pipeline or stage id and never names %s — a caller is told what it "+
+				"needs with nowhere to get it, which is the dead end this tool exists to close", spec.Name, source)
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no tool declares a pipeline or stage id — this walk passed vacuously, so either the " +
+			"argument was renamed or the registry it reads is not the product's")
+	}
+}
+
+func TestListPipelinesCarriesEveryStageFieldACallerNeeds(t *testing.T) {
+	// The four fields the tool exists to deliver. `semantic` is the load-bearing
+	// one — it is what says which stage a deal is born into and which two close
+	// it — and `win_probability` and `position` are what let a caller choose
+	// between open stages without reading their names.
+	stage := Stage{ID: ids.NewV7(), Name: "Discovery", Semantic: "open", WinProbability: 25, Position: 2}
+	tool := listPipelinesTool{list: func(context.Context) ([]Pipeline, error) {
+		return []Pipeline{{ID: ids.NewV7(), Name: "Sales", Position: 0, Stages: []Stage{stage}}}, nil
+	}}
+	out, err := tool.Handle(context.Background(), json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	var payload struct {
+		Pipelines []struct {
+			ID     ids.UUID `json:"id"`
+			Stages []Stage  `json:"stages"`
+		} `json:"pipelines"`
+	}
+	if err := json.Unmarshal(out, &payload); err != nil {
+		t.Fatalf("unreadable payload: %v", err)
+	}
+	if len(payload.Pipelines) != 1 || len(payload.Pipelines[0].Stages) != 1 {
+		t.Fatalf("payload = %s, want one pipeline carrying one stage", out)
+	}
+	if got := payload.Pipelines[0].Stages[0]; got != stage {
+		t.Errorf("stage round-tripped as %+v, want %+v", got, stage)
+	}
+}

--- a/backend/internal/modules/agents/tools_progress.go
+++ b/backend/internal/modules/agents/tools_progress.go
@@ -45,7 +45,7 @@ func (t progressDeal) Spec() mcp.ToolSpec {
 		OpenAPIOp:    "advanceDeal + logActivity",
 		InputSchema: schema(`{"type":"object","required":["deal_id","to_stage_id"],"properties":{
 			"deal_id":{"type":"string","format":"uuid"},
-			"to_stage_id":{"type":"string","format":"uuid"},
+			"to_stage_id":{"type":"string","format":"uuid"` + stageIDNote + `},
 			"lost_reason":{"type":"string","description":"Required when the target stage closes the deal as lost"},
 			"note":{"type":"string","description":"Logged as a note on the deal's timeline after the move"},
 			"if_version":{"type":"integer"},

--- a/backend/internal/modules/agents/tools_update.go
+++ b/backend/internal/modules/agents/tools_update.go
@@ -47,9 +47,9 @@ func (t updateRecord) Spec() mcp.ToolSpec {
 		Name: "update_record", Title: "Update a record", Version: toolVersionV1,
 		RequiredScope: principal.ScopeWrite,
 		Tier:          mcp.TierAutoExecute,
-		OpenAPIOp:     "updatePerson/updateOrganization/updateDeal/updateLead/updateActivity/updateProject",
+		OpenAPIOp:     "updatePerson/updateOrganization/updateDeal/updateLead/updateActivity/updateProject/updateRelationship",
 		InputSchema: schema(`{"type":"object","required":["record_type","id","fields"],"properties":{
-			"record_type":{"type":"string","enum":["person","organization","deal","lead","activity","project"]},
+			"record_type":{"type":"string","enum":["person","organization","deal","lead","activity","project","relationship"]},
 			"id":{"type":"string","format":"uuid"},
 			"fields":{"type":"object","description":` + jsonString("Only sent fields change. Fields a human last edited are not applied: they are staged for approval and named in the result's staged_approval. "+describeRecordFields(updateShapes)) + `},
 			"if_version":{"type":"integer","description":"Optimistic-concurrency guard: the last-seen record version"},

--- a/backend/internal/modules/approvals/authority.go
+++ b/backend/internal/modules/approvals/authority.go
@@ -121,8 +121,9 @@ var kindDecidedEvents = map[string]decidedEcho{
 // both the decision-grant map and the visibility probe — one spelling, so a
 // typo in either cannot silently make a kind undecidable.
 const (
-	targetOffer   = "offer"
-	targetProduct = "product"
+	targetOffer        = "offer"
+	targetProduct      = "product"
+	targetRelationship = "relationship"
 )
 
 // selfOnlyKinds are the staging kinds whose proposal is nobody's business but
@@ -142,6 +143,61 @@ const (
 // webhooks module's selfOnlyEvents, which keeps the same three LinkedIn facts
 // off the workspace fan-out for the same reason.
 var selfOnlyKinds = map[string]bool{"linkedin_match": true}
+
+// targetProbe names HOW a target type's visibility is decided. It exists so the
+// answer "is this target type decidable at all" has ONE source: targetVisible
+// switches on it, and TargetTypeDecidable reports on it.
+//
+// That mattered the moment the tool surface started minting staged rows for types
+// nobody had checked. A type with no rule is not decidable, which means its
+// staged row is invisible in the inbox AND undecidable at the decision — an
+// authority object a human can neither release nor reject, and the fan-out that
+// would have told them about it is dropped for the same reason. The composition
+// layer derives the obligation over the generated policy table
+// (TestEveryConfirmFirstTargetTypeIsDecidable), so a confirm-first verb whose
+// target type has no rule here fails a gate instead of shipping a zombie.
+type targetProbe int
+
+const (
+	// probeNoRule is the zero value on purpose: an unrecognized type falls here
+	// and fails closed.
+	probeNoRule targetProbe = iota
+	// probeOwnScope — the row carries owner_id, so its own row scope answers.
+	probeOwnScope
+	// probeInheritedScope — the row owns no owner_id and inherits from what it
+	// points at: an offer from its deal, a signal from its subject, an activity
+	// from any linked record, an edge from ALL of its endpoints.
+	probeInheritedScope
+	// probeExistence — workspace-shared admin config with no row scope; the
+	// decision-grant check is the authority and existence is the floor.
+	probeExistence
+	// probeActingWorkspace — the target IS a workspace (an effective-dated price
+	// sheet with no row of its own yet), so the floor is that it is THIS one.
+	probeActingWorkspace
+)
+
+func probeFor(targetType string) targetProbe {
+	switch targetType {
+	case "person", "organization", "deal", "lead":
+		return probeOwnScope
+	case targetOffer, "signal", objectActivity, targetRelationship:
+		return probeInheritedScope
+	case targetProduct, "custom_field":
+		return probeExistence
+	case "fx_rate", "ai_model_rate":
+		return probeActingWorkspace
+	default:
+		return probeNoRule
+	}
+}
+
+// TargetTypeDecidable reports whether a staged row against this target type can
+// be seen and decided at all. Exported for the composition layer's gate: a
+// confirm-first verb whose target type answers false stages authority objects
+// that no human can ever release or reject.
+func TargetTypeDecidable(targetType string) bool {
+	return probeFor(targetType) != probeNoRule
+}
 
 // decidable is the ONE visibility-and-authority predicate for the inbox
 // and the decision: true when p holds every grant approving a would
@@ -192,14 +248,14 @@ func targetVisible(ctx context.Context, tx pgx.Tx, targetType *string, targetID 
 	if targetType == nil || targetID == nil {
 		return false, nil
 	}
-	switch *targetType {
-	case "person", "organization", "deal", "lead":
+	switch probeFor(*targetType) {
+	case probeOwnScope:
 		return auth.VisibleTo(ctx, tx, *targetType, *targetID)
-	case targetOffer, "signal", "activity":
+	case probeInheritedScope:
 		return targetVisibleThroughParent(ctx, tx, *targetType, *targetID)
-	case targetProduct, "custom_field":
+	case probeExistence:
 		return targetExists(ctx, tx, *targetType, *targetID)
-	case "fx_rate", "ai_model_rate":
+	case probeActingWorkspace:
 		// Effective-dated price sheets are workspace-shared admin config
 		// with no row scope. A refresh proposal targets the workspace (a
 		// brand-new currency/model has no row yet), so existence is not the
@@ -211,7 +267,7 @@ func targetVisible(ctx context.Context, tx pgx.Tx, targetType *string, targetID 
 		wsID, ok := principal.WorkspaceID(ctx)
 		return ok && *targetID == wsID, nil
 	default:
-		return false, nil // unknown target type: fail closed
+		return false, nil // no rule for this target type: fail closed
 	}
 }
 
@@ -232,8 +288,14 @@ func targetVisibleThroughParent(ctx context.Context, tx pgx.Tx, targetType strin
 		return auth.VisibleTo(ctx, tx, "deal", dealID)
 	}
 	ensure := auth.EnsureSignalVisible
-	if targetType == "activity" {
+	switch targetType {
+	case objectActivity:
 		ensure = auth.EnsureActivityVisible
+	case targetRelationship:
+		// An edge inherits the CONJUNCTION of its endpoints' scope, which is one
+		// spelling in platform/auth because people's own reads and this probe are
+		// two readers of the same rule.
+		ensure = auth.EnsureRelationshipVisible
 	}
 	switch err := ensure(ctx, tx, targetID); {
 	case err == nil:

--- a/backend/internal/modules/approvals/authority.go
+++ b/backend/internal/modules/approvals/authority.go
@@ -38,7 +38,7 @@ var decisionGrants = map[string][]struct {
 	// progress_deal is advance_deal plus a timeline note; the gated effect
 	// is the deal move, so deciding it needs the same grant.
 	"progress_deal":  {{tableDeal, principal.ActionUpdate}},
-	"promote_lead":   {{"lead", principal.ActionUpdate}, {"person", principal.ActionCreate}},
+	"promote_lead":   {{tableLead, principal.ActionUpdate}, {tablePerson, principal.ActionCreate}},
 	"archive_record": {}, // resolved from the target's entity type below
 	"merge_records":  {}, // resolved from the target's entity type below
 	"share_record":   {}, // resolved from the target's entity type below
@@ -59,8 +59,8 @@ var decisionGrants = map[string][]struct {
 	// Accepting a cold-start read-back writes enrichment fields onto an
 	// organization; "enrich" is the same effect staged through the
 	// transport gate by an agent caller.
-	"coldstart": {{"organization", principal.ActionUpdate}},
-	"enrich":    {{"organization", principal.ActionUpdate}},
+	"coldstart": {{tableOrganization, principal.ActionUpdate}},
+	"enrich":    {{tableOrganization, principal.ActionUpdate}},
 	// A rate refresh proposes an effective-dated row on a workspace-shared
 	// price sheet; deciding it needs the same admin/ops Create grant the
 	// editor's write path requires.
@@ -68,24 +68,24 @@ var decisionGrants = map[string][]struct {
 	"ai_model_rate_proposal": {{"ai_model_rate", principal.ActionCreate}},
 	// Accepting a deep site read writes profile fields and category facts
 	// onto the target organization — the same update authority enrich needs.
-	"deepread": {{"organization", principal.ActionUpdate}},
+	"deepread": {{tableOrganization, principal.ActionUpdate}},
 	// Accepting a site_lead proposal (a published person from a deep read's
 	// team page) captures them as a LEAD through the capture sink — the
 	// effect is a lead create, so deciding it needs that grant.
-	"site_lead": {{"lead", principal.ActionCreate}},
+	"site_lead": {{tableLead, principal.ActionCreate}},
 	// Approving a LinkedIn match links an imported connection to a contact and
 	// writes that contact's LinkedIn address — a person write, so deciding it
 	// needs the grant the write itself takes.
-	"linkedin_match": {{"person", principal.ActionUpdate}},
+	"linkedin_match": {{tablePerson, principal.ActionUpdate}},
 	// Accepting a capture_counterparty proposal (ADR-0072/A118: a first-time
 	// sender the verdict engine could not judge) creates the person and, unless
 	// the domain is free-mail, the organization behind them — so deciding it
 	// needs both create grants, exactly as if the approver had typed them in.
-	"capture_counterparty": {{"person", principal.ActionCreate}, {"organization", principal.ActionCreate}},
+	"capture_counterparty": {{tablePerson, principal.ActionCreate}, {tableOrganization, principal.ActionCreate}},
 	// Accepting an org_name_promotion proposal (PO-F-2a: one employee's
 	// signature naming their company, with nothing corroborating it) renames
 	// the organization — the same update authority the name editor needs.
-	"org_name_promotion": {{"organization", principal.ActionUpdate}},
+	"org_name_promotion": {{tableOrganization, principal.ActionUpdate}},
 	// Confirming a nightly close-date correction (formulas §11 🟡 tier)
 	// releases an expected_close_date write onto the deal.
 	"close_date_correction": {{tableDeal, principal.ActionUpdate}},

--- a/backend/internal/modules/approvals/authority.go
+++ b/backend/internal/modules/approvals/authority.go
@@ -34,10 +34,10 @@ var decisionGrants = map[string][]struct {
 	Object string
 	Action principal.Action
 }{
-	"advance_deal": {{"deal", principal.ActionUpdate}},
+	"advance_deal": {{tableDeal, principal.ActionUpdate}},
 	// progress_deal is advance_deal plus a timeline note; the gated effect
 	// is the deal move, so deciding it needs the same grant.
-	"progress_deal":  {{"deal", principal.ActionUpdate}},
+	"progress_deal":  {{tableDeal, principal.ActionUpdate}},
 	"promote_lead":   {{"lead", principal.ActionUpdate}, {"person", principal.ActionCreate}},
 	"archive_record": {}, // resolved from the target's entity type below
 	"merge_records":  {}, // resolved from the target's entity type below
@@ -88,7 +88,7 @@ var decisionGrants = map[string][]struct {
 	"org_name_promotion": {{"organization", principal.ActionUpdate}},
 	// Confirming a nightly close-date correction (formulas §11 🟡 tier)
 	// releases an expected_close_date write onto the deal.
-	"close_date_correction": {{"deal", principal.ActionUpdate}},
+	"close_date_correction": {{tableDeal, principal.ActionUpdate}},
 	// Confirming an overnight follow-up proposal (features/07 §8a) creates
 	// the drafted task activity; the target deal's visibility gates who
 	// may see and decide it (targetVisible), the create grant gates the
@@ -117,13 +117,24 @@ var kindDecidedEvents = map[string]decidedEcho{
 }
 
 // The target types this package names in more than one place. They are the
-// `target_entity_type` vocabulary the staged rows carry, and each is spoken by
-// both the decision-grant map and the visibility probe — one spelling, so a
-// typo in either cannot silently make a kind undecidable.
+// `target_entity_type` vocabulary the staged rows carry, and this package spells
+// each in several places — the visibility probe's classification, the
+// decision-grant map, and the version-table whitelist. One spelling, because a
+// typo makes a target undecidable in the first and unpinnable in the last, and
+// neither failure announces itself.
 const (
 	targetOffer        = "offer"
 	targetProduct      = "product"
 	targetRelationship = "relationship"
+	// The row-scoped record tables. Named as a SET rather than one at a time: this
+	// package spells them in the probe classification, the decision-grant map and
+	// the version-table whitelist, and a typo makes a target undecidable in the
+	// first and unpinnable in the last without announcing either.
+	tablePerson       = "person"
+	tableOrganization = "organization"
+	tableDeal         = "deal"
+	tableLead         = "lead"
+	tableProject      = "project"
 )
 
 // selfOnlyKinds are the staging kinds whose proposal is nobody's business but
@@ -178,7 +189,7 @@ const (
 
 func probeFor(targetType string) targetProbe {
 	switch targetType {
-	case "person", "organization", "deal", "lead":
+	case tablePerson, tableOrganization, tableDeal, tableLead, tableProject:
 		return probeOwnScope
 	case targetOffer, "signal", objectActivity, targetRelationship:
 		return probeInheritedScope
@@ -285,10 +296,12 @@ func targetVisibleThroughParent(ctx context.Context, tx pgx.Tx, targetType strin
 		if err != nil {
 			return false, err
 		}
-		return auth.VisibleTo(ctx, tx, "deal", dealID)
+		return auth.VisibleTo(ctx, tx, tableDeal, dealID)
 	}
-	ensure := auth.EnsureSignalVisible
+	var ensure func(context.Context, pgx.Tx, ids.UUID) error
 	switch targetType {
+	case "signal":
+		ensure = auth.EnsureSignalVisible
 	case objectActivity:
 		ensure = auth.EnsureActivityVisible
 	case targetRelationship:
@@ -296,6 +309,15 @@ func targetVisibleThroughParent(ctx context.Context, tx pgx.Tx, targetType strin
 		// spelling in platform/auth because people's own reads and this probe are
 		// two readers of the same rule.
 		ensure = auth.EnsureRelationshipVisible
+	default:
+		// TOTAL on purpose. A signal default read as "whatever is left", so a type
+		// added to probeFor's inherited-scope arm — which looks like the whole act
+		// of enrolling one — would have been probed against the SIGNAL table: a
+		// wrong-scope answer rather than a closed one, from the branch that exists
+		// to be closed. probeFor is the one source only if this cannot silently
+		// disagree with it.
+		return false, fmt.Errorf(
+			"crmapprovals: %q is classified as inherited-scope with no parent probe", targetType)
 	}
 	switch err := ensure(ctx, tx, targetID); {
 	case err == nil:

--- a/backend/internal/modules/approvals/redeem.go
+++ b/backend/internal/modules/approvals/redeem.go
@@ -138,9 +138,9 @@ func validateRedemptionTarget(ctx context.Context, tx pgx.Tx, a row) error {
 // must leave TargetVersion nil for it rather than mint a pin redemption
 // could never verify.
 var versionTables = map[string]bool{
-	"person": true, "organization": true, "deal": true, "lead": true, "activity": true,
-	targetOffer: true, targetProduct: true, "list": true, "tag": true, "relationship": true,
-	"project": true,
+	tablePerson: true, tableOrganization: true, tableDeal: true, tableLead: true, objectActivity: true,
+	targetOffer: true, targetProduct: true, "list": true, "tag": true, targetRelationship: true,
+	tableProject: true,
 }
 
 // contextTargetKinds are the staging kinds whose target_entity names what the

--- a/backend/internal/modules/collections/lists.go
+++ b/backend/internal/modules/collections/lists.go
@@ -49,6 +49,12 @@ var memberEntityTables = func() map[string]bool {
 // points at.
 const entityTypeField = "entity_type"
 
+// entityIDField names its sibling — the polymorphic TARGET a member or a tag
+// application points at. Named beside entity_type because the two travel
+// together in every body on this surface, and a refusal has to name the wire
+// path, never prose.
+const entityIDField = "entity_id"
+
 // memberEntityVocabulary renders the accepted set for the refusal message.
 // Derived from the same map the check uses, because a message that restates
 // the vocabulary drifts from it silently — the caller is then told a record

--- a/backend/internal/modules/collections/members.go
+++ b/backend/internal/modules/collections/members.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/platform/httperr"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -125,6 +126,14 @@ func (s *Store) listStaticMembers(ctx context.Context, tx pgx.Tx, listID ids.Lis
 }
 
 func (s *Store) AddMember(ctx context.Context, listID ids.ListID, entityType string, entityID ids.UUID) (memberRow, error) {
+	// The contract declares entity_id required, which is a claim only a check
+	// makes true: an absent key decodes to the zero UUID with no error, reaches
+	// the link-target gate below, matches nothing, and answers not-found for a
+	// record the caller never named. The guard is at the STORE entry, not in the
+	// handler, because this is the door every transport comes through.
+	if err := httperr.RequireBodyID(entityIDField, entityID); err != nil {
+		return memberRow{}, err
+	}
 	if err := auth.Require(ctx, "list", principal.ActionUpdate); err != nil {
 		return memberRow{}, err
 	}

--- a/backend/internal/modules/collections/requiredids_test.go
+++ b/backend/internal/modules/collections/requiredids_test.go
@@ -4,54 +4,25 @@
 package collections
 
 // A required body id the caller omitted must be named as a missing argument, not
-// discovered as a missing row.
+// discovered as a missing row: an absent key decodes to the zero UUID with no
+// error, so unguarded it reaches a lookup, matches nothing, and answers a bare
+// not-found for a record the caller never mentioned.
 //
-// oapi-codegen renders a REQUIRED body id as a non-pointer UUID and
-// encoding/json leaves an absent key at the zero value with no error, so the
-// zero UUID used to travel to a lookup, match nothing, and answer a bare
-// not-found — telling the caller a record they never mentioned does not exist.
+// The guard is at the store entry point — the door every transport comes through —
+// and it runs BEFORE any authority check or query, which is why these probes need
+// no database and no actor: a store over a nil pool never reaches one.
 //
-// The guard sits at the store entry point, which is the door every transport
-// comes through, and it runs BEFORE any authority check or query — which is why
-// these probes need no database and no actor: a store over a nil pool never
-// reaches one.
-//
-// The refusal's SHAPE (422, the field named, the stable `required` code, and that
-// it classifies on both surfaces) is proven once in
-// platform/httperr/requirebodyid_test.go. What is left here is the only question
-// this package can answer: is the guard actually called for my body.
+// The refusal's SHAPE is proven once in platform/httperr/requirebodyid_test.go and
+// asserted here through faulttest. What is left is the only question this package
+// can answer: is the guard actually called for my body.
 
 import (
 	"context"
-	"net/http"
 	"testing"
 
-	"github.com/gradionhq/margince/backend/internal/platform/httperr"
+	"github.com/gradionhq/margince/backend/internal/platform/httperr/faulttest"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
-
-// assertNamesTheOmittedID asserts the observable property: the caller's mistake,
-// with the wire field they omitted named.
-func assertNamesTheOmittedID(t *testing.T, err error, field string) {
-	t.Helper()
-	if err == nil {
-		t.Fatalf("an absent %s was accepted, so the caller is sent looking for a record it never named", field)
-	}
-	fault, ok := httperr.Classify(err)
-	if !ok {
-		t.Fatalf("an absent %s answered %v, which is outside the taxonomy — a surface would report the "+
-			"caller's own omission as an internal server fault", field, err)
-	}
-	if fault.Status != http.StatusUnprocessableEntity {
-		t.Errorf("an absent %s answered status %d, want 422 (404 is the defect this closes)", field, fault.Status)
-	}
-	for _, refusal := range fault.Fields {
-		if refusal.Field == field {
-			return
-		}
-	}
-	t.Errorf("the refusal for an absent %s names %+v, want the wire field %q", field, fault.Fields, field)
-}
 
 func TestAnOmittedMemberOrTagTargetIsNamed(t *testing.T) {
 	// AddListMemberRequest.entity_id and ApplyTagRequest.entity_id. Both reach
@@ -61,8 +32,8 @@ func TestAnOmittedMemberOrTagTargetIsNamed(t *testing.T) {
 	ctx := context.Background()
 
 	_, err := store.AddMember(ctx, ids.New[ids.ListKind](), "person", ids.UUID{})
-	assertNamesTheOmittedID(t, err, "entity_id")
+	faulttest.AssertNamesOmittedID(t, err, "entity_id")
 
 	_, err = store.ApplyTag(ctx, ids.New[ids.TagKind](), "person", ids.UUID{})
-	assertNamesTheOmittedID(t, err, "entity_id")
+	faulttest.AssertNamesOmittedID(t, err, "entity_id")
 }

--- a/backend/internal/modules/collections/requiredids_test.go
+++ b/backend/internal/modules/collections/requiredids_test.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package collections
+
+// A required body id the caller omitted must be named as a missing argument, not
+// discovered as a missing row.
+//
+// oapi-codegen renders a REQUIRED body id as a non-pointer UUID and
+// encoding/json leaves an absent key at the zero value with no error, so the
+// zero UUID used to travel to a lookup, match nothing, and answer a bare
+// not-found — telling the caller a record they never mentioned does not exist.
+//
+// The guard sits at the store entry point, which is the door every transport
+// comes through, and it runs BEFORE any authority check or query — which is why
+// these probes need no database and no actor: a store over a nil pool never
+// reaches one.
+//
+// The refusal's SHAPE (422, the field named, the stable `required` code, and that
+// it classifies on both surfaces) is proven once in
+// platform/httperr/requirebodyid_test.go. What is left here is the only question
+// this package can answer: is the guard actually called for my body.
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/platform/httperr"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// assertNamesTheOmittedID asserts the observable property: the caller's mistake,
+// with the wire field they omitted named.
+func assertNamesTheOmittedID(t *testing.T, err error, field string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("an absent %s was accepted, so the caller is sent looking for a record it never named", field)
+	}
+	fault, ok := httperr.Classify(err)
+	if !ok {
+		t.Fatalf("an absent %s answered %v, which is outside the taxonomy — a surface would report the "+
+			"caller's own omission as an internal server fault", field, err)
+	}
+	if fault.Status != http.StatusUnprocessableEntity {
+		t.Errorf("an absent %s answered status %d, want 422 (404 is the defect this closes)", field, fault.Status)
+	}
+	for _, refusal := range fault.Fields {
+		if refusal.Field == field {
+			return
+		}
+	}
+	t.Errorf("the refusal for an absent %s names %+v, want the wire field %q", field, fault.Fields, field)
+}
+
+func TestAnOmittedMemberOrTagTargetIsNamed(t *testing.T) {
+	// AddListMemberRequest.entity_id and ApplyTagRequest.entity_id. Both reach
+	// auth.EnsureLinkTarget unguarded, whose miss is indistinguishable from a
+	// record the caller cannot see.
+	store := NewStore(nil)
+	ctx := context.Background()
+
+	_, err := store.AddMember(ctx, ids.New[ids.ListKind](), "person", ids.UUID{})
+	assertNamesTheOmittedID(t, err, "entity_id")
+
+	_, err = store.ApplyTag(ctx, ids.New[ids.TagKind](), "person", ids.UUID{})
+	assertNamesTheOmittedID(t, err, "entity_id")
+}

--- a/backend/internal/modules/collections/tags.go
+++ b/backend/internal/modules/collections/tags.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/platform/httperr"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -138,6 +139,11 @@ type taggableRow struct {
 }
 
 func (s *Store) ApplyTag(ctx context.Context, tagID ids.TagID, entityType string, entityID ids.UUID) (taggableRow, error) {
+	// Required by the contract, true only if checked: the zero UUID would reach
+	// the row-scope link gate and answer not-found for a record nobody named.
+	if err := httperr.RequireBodyID(entityIDField, entityID); err != nil {
+		return taggableRow{}, err
+	}
 	if err := auth.Require(ctx, "tag", principal.ActionUpdate); err != nil {
 		return taggableRow{}, err
 	}

--- a/backend/internal/modules/consent/doi.go
+++ b/backend/internal/modules/consent/doi.go
@@ -35,6 +35,11 @@ type IssuedDOI struct {
 	ExpiresAt time.Time
 }
 
+// purposeIDField names the wire path every purpose refusal on this surface
+// points at. Named once because three refusals use it, and a field slot holds a
+// wire field path, never prose.
+const purposeIDField = "purpose_id"
+
 // IssueDoubleOptIn mints the single-use confirmation token a DOI grant
 // must later present. Only the sha256 lands in the database — the
 // session/passport secret discipline — so a stolen table cannot confirm
@@ -45,11 +50,6 @@ type IssuedDOI struct {
 // stance); the deliver flag is recorded on the audit row so the
 // issuance intent stays attributable, and the plaintext never lands in
 // audit or outbox payloads.
-// purposeIDField names the wire path every purpose refusal on this surface
-// points at. Named once because three refusals use it, and a field slot holds a
-// wire field path, never prose.
-const purposeIDField = "purpose_id"
-
 func (s *Store) IssueDoubleOptIn(ctx context.Context, personID ids.PersonID, purposeID ids.PurposeID, deliver bool) (IssuedDOI, error) {
 	// A token confirms consent FOR a purpose; without one there is nothing to
 	// confirm. Unguarded, the zero UUID reaches the purpose read and answers

--- a/backend/internal/modules/consent/doi.go
+++ b/backend/internal/modules/consent/doi.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/platform/httperr"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -44,7 +45,18 @@ type IssuedDOI struct {
 // stance); the deliver flag is recorded on the audit row so the
 // issuance intent stays attributable, and the plaintext never lands in
 // audit or outbox payloads.
+// purposeIDField names the wire path every purpose refusal on this surface
+// points at. Named once because three refusals use it, and a field slot holds a
+// wire field path, never prose.
+const purposeIDField = "purpose_id"
+
 func (s *Store) IssueDoubleOptIn(ctx context.Context, personID ids.PersonID, purposeID ids.PurposeID, deliver bool) (IssuedDOI, error) {
+	// A token confirms consent FOR a purpose; without one there is nothing to
+	// confirm. Unguarded, the zero UUID reaches the purpose read and answers
+	// not-found for a purpose nobody named.
+	if err := httperr.RequireBodyID(purposeIDField, purposeID.UUID); err != nil {
+		return IssuedDOI{}, err
+	}
 	if err := auth.Require(ctx, "person", principal.ActionUpdate); err != nil {
 		return IssuedDOI{}, err
 	}
@@ -68,7 +80,7 @@ func (s *Store) IssueDoubleOptIn(ctx context.Context, personID ids.PersonID, pur
 			return err
 		}
 		if !requiresDOI {
-			return &ValidationError{Field: "purpose_id", Reason: "purpose does not require a double opt-in"}
+			return &ValidationError{Field: purposeIDField, Reason: "purpose does not require a double opt-in"}
 		}
 		issued := s.now().UTC()
 		if _, err := tx.Exec(ctx, `

--- a/backend/internal/modules/consent/requiredids_test.go
+++ b/backend/internal/modules/consent/requiredids_test.go
@@ -4,54 +4,25 @@
 package consent
 
 // A required body id the caller omitted must be named as a missing argument, not
-// discovered as a missing row.
+// discovered as a missing row: an absent key decodes to the zero UUID with no
+// error, so unguarded it reaches a lookup, matches nothing, and answers a bare
+// not-found for a record the caller never mentioned.
 //
-// oapi-codegen renders a REQUIRED body id as a non-pointer UUID and
-// encoding/json leaves an absent key at the zero value with no error, so the
-// zero UUID used to travel to a lookup, match nothing, and answer a bare
-// not-found — telling the caller a record they never mentioned does not exist.
+// The guard is at the store entry point — the door every transport comes through —
+// and it runs BEFORE any authority check or query, which is why these probes need
+// no database and no actor: a store over a nil pool never reaches one.
 //
-// The guard sits at the store entry point, which is the door every transport
-// comes through, and it runs BEFORE any authority check or query — which is why
-// these probes need no database and no actor: a store over a nil pool never
-// reaches one.
-//
-// The refusal's SHAPE (422, the field named, the stable `required` code, and that
-// it classifies on both surfaces) is proven once in
-// platform/httperr/requirebodyid_test.go. What is left here is the only question
-// this package can answer: is the guard actually called for my body.
+// The refusal's SHAPE is proven once in platform/httperr/requirebodyid_test.go and
+// asserted here through faulttest. What is left is the only question this package
+// can answer: is the guard actually called for my body.
 
 import (
 	"context"
-	"net/http"
 	"testing"
 
-	"github.com/gradionhq/margince/backend/internal/platform/httperr"
+	"github.com/gradionhq/margince/backend/internal/platform/httperr/faulttest"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
-
-// assertNamesTheOmittedID asserts the observable property: the caller's mistake,
-// with the wire field they omitted named.
-func assertNamesTheOmittedID(t *testing.T, err error, field string) {
-	t.Helper()
-	if err == nil {
-		t.Fatalf("an absent %s was accepted, so the caller is sent looking for a record it never named", field)
-	}
-	fault, ok := httperr.Classify(err)
-	if !ok {
-		t.Fatalf("an absent %s answered %v, which is outside the taxonomy — a surface would report the "+
-			"caller's own omission as an internal server fault", field, err)
-	}
-	if fault.Status != http.StatusUnprocessableEntity {
-		t.Errorf("an absent %s answered status %d, want 422 (404 is the defect this closes)", field, fault.Status)
-	}
-	for _, refusal := range fault.Fields {
-		if refusal.Field == field {
-			return
-		}
-	}
-	t.Errorf("the refusal for an absent %s names %+v, want the wire field %q", field, fault.Fields, field)
-}
 
 func TestAnOmittedPurposeIsNamed(t *testing.T) {
 	// RecordConsentRequest.purpose_id and IssueDoubleOptInJSONBody.purpose_id. A
@@ -63,8 +34,8 @@ func TestAnOmittedPurposeIsNamed(t *testing.T) {
 	_, err := store.Record(ctx, RecordInput{
 		PersonID: ids.New[ids.PersonKind](), NewState: "granted",
 	})
-	assertNamesTheOmittedID(t, err, "purpose_id")
+	faulttest.AssertNamesOmittedID(t, err, "purpose_id")
 
 	_, err = store.IssueDoubleOptIn(ctx, ids.New[ids.PersonKind](), ids.PurposeID{}, true)
-	assertNamesTheOmittedID(t, err, "purpose_id")
+	faulttest.AssertNamesOmittedID(t, err, "purpose_id")
 }

--- a/backend/internal/modules/consent/requiredids_test.go
+++ b/backend/internal/modules/consent/requiredids_test.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package consent
+
+// A required body id the caller omitted must be named as a missing argument, not
+// discovered as a missing row.
+//
+// oapi-codegen renders a REQUIRED body id as a non-pointer UUID and
+// encoding/json leaves an absent key at the zero value with no error, so the
+// zero UUID used to travel to a lookup, match nothing, and answer a bare
+// not-found — telling the caller a record they never mentioned does not exist.
+//
+// The guard sits at the store entry point, which is the door every transport
+// comes through, and it runs BEFORE any authority check or query — which is why
+// these probes need no database and no actor: a store over a nil pool never
+// reaches one.
+//
+// The refusal's SHAPE (422, the field named, the stable `required` code, and that
+// it classifies on both surfaces) is proven once in
+// platform/httperr/requirebodyid_test.go. What is left here is the only question
+// this package can answer: is the guard actually called for my body.
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/platform/httperr"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// assertNamesTheOmittedID asserts the observable property: the caller's mistake,
+// with the wire field they omitted named.
+func assertNamesTheOmittedID(t *testing.T, err error, field string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("an absent %s was accepted, so the caller is sent looking for a record it never named", field)
+	}
+	fault, ok := httperr.Classify(err)
+	if !ok {
+		t.Fatalf("an absent %s answered %v, which is outside the taxonomy — a surface would report the "+
+			"caller's own omission as an internal server fault", field, err)
+	}
+	if fault.Status != http.StatusUnprocessableEntity {
+		t.Errorf("an absent %s answered status %d, want 422 (404 is the defect this closes)", field, fault.Status)
+	}
+	for _, refusal := range fault.Fields {
+		if refusal.Field == field {
+			return
+		}
+	}
+	t.Errorf("the refusal for an absent %s names %+v, want the wire field %q", field, fault.Fields, field)
+}
+
+func TestAnOmittedPurposeIsNamed(t *testing.T) {
+	// RecordConsentRequest.purpose_id and IssueDoubleOptInJSONBody.purpose_id. A
+	// consent record without a purpose is not a consent record, and a double
+	// opt-in token confirms consent FOR one.
+	store := NewStore(nil)
+	ctx := context.Background()
+
+	_, err := store.Record(ctx, RecordInput{
+		PersonID: ids.New[ids.PersonKind](), NewState: "granted",
+	})
+	assertNamesTheOmittedID(t, err, "purpose_id")
+
+	_, err = store.IssueDoubleOptIn(ctx, ids.New[ids.PersonKind](), ids.PurposeID{}, true)
+	assertNamesTheOmittedID(t, err, "purpose_id")
+}

--- a/backend/internal/modules/consent/store.go
+++ b/backend/internal/modules/consent/store.go
@@ -239,11 +239,6 @@ func consentSubject(in RecordInput) (subject, error) {
 	return subject{}, &ValidationError{Field: "subject", Reason: "consent needs a subject — a person or a lead"}
 }
 
-// Record sets one subject×purpose state and appends the proof row —
-// audited (consent_grant/consent_withdraw) and emitted (consent.changed)
-// in the same transaction as every other mutation. The subject is a
-// person or, before promotion, a lead (E12.20). Re-asserting the
-// current state is idempotent: no second proof row, no second event.
 // admitRecord settles everything decidable before the transaction opens: which
 // subject the request is about, that it names a purpose at all, that the caller
 // may write consent for that subject, and that the state is one a caller may

--- a/backend/internal/modules/consent/store.go
+++ b/backend/internal/modules/consent/store.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/platform/httperr"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -243,15 +244,51 @@ func consentSubject(in RecordInput) (subject, error) {
 // in the same transaction as every other mutation. The subject is a
 // person or, before promotion, a lead (E12.20). Re-asserting the
 // current state is idempotent: no second proof row, no second event.
-func (s *Store) Record(ctx context.Context, in RecordInput) (State, error) {
+// admitRecord settles everything decidable before the transaction opens: which
+// subject the request is about, that it names a purpose at all, that the caller
+// may write consent for that subject, and that the state is one a caller may
+// record. Extracted so Record itself is about the write.
+//
+// The ORDER is the interesting part, and it is deliberate in two places.
+//
+// The subject comes first because a body naming both a person and a lead is not a
+// well-formed consent request at all, so "which subject" outranks "which
+// purpose" — and the authority check cannot even run before it, since which
+// object grant applies depends on the answer.
+//
+// The purpose guard comes before that authority check, which puts every
+// input-shape refusal together at the front, the order CreateRelationship
+// already uses for an unknown kind. A required field's NAME is published
+// contract, so answering it ahead of authority discloses nothing.
+func admitRecord(ctx context.Context, in RecordInput) (subject, error) {
 	sub, err := consentSubject(in)
 	if err != nil {
-		return State{}, err
+		return subject{}, err
+	}
+	// purpose_id is required by the contract, which is a claim only a check makes
+	// true: an absent key decodes to the zero UUID with no error, and the purpose
+	// read inside the transaction would answer not-found for a purpose the caller
+	// never named.
+	if err := httperr.RequireBodyID(purposeIDField, in.PurposeID.UUID); err != nil {
+		return subject{}, err
 	}
 	if err := auth.Require(ctx, sub.entityType, principal.ActionUpdate); err != nil {
-		return State{}, err
+		return subject{}, err
 	}
 	if _, err := ParseRecordableState(in.NewState); err != nil {
+		return subject{}, err
+	}
+	return sub, nil
+}
+
+// Record sets one subject×purpose state and appends the proof row —
+// audited (consent_grant/consent_withdraw) and emitted (consent.changed)
+// in the same transaction as every other mutation. The subject is a
+// person or, before promotion, a lead (E12.20). Re-asserting the
+// current state is idempotent: no second proof row, no second event.
+func (s *Store) Record(ctx context.Context, in RecordInput) (State, error) {
+	sub, err := admitRecord(ctx, in)
+	if err != nil {
 		return State{}, err
 	}
 	actor, _ := principal.Actor(ctx)
@@ -355,7 +392,7 @@ func (s *Store) resolveDOIConfirmation(ctx context.Context, tx pgx.Tx, in Record
 		return nil, nil
 	}
 	if sub.entityType != "person" {
-		return nil, &ValidationError{Field: "purpose_id", Reason: "a double opt-in purpose needs a person subject; promote the lead before granting it"}
+		return nil, &ValidationError{Field: purposeIDField, Reason: "a double opt-in purpose needs a person subject; promote the lead before granting it"}
 	}
 	if in.DoubleOptInToken == nil || *in.DoubleOptInToken == "" {
 		return nil, &ValidationError{Field: "double_opt_in_token", Reason: "purpose requires a confirmed double opt-in"}

--- a/backend/internal/modules/consent/store.go
+++ b/backend/internal/modules/consent/store.go
@@ -387,7 +387,13 @@ func (s *Store) resolveDOIConfirmation(ctx context.Context, tx pgx.Tx, in Record
 		return nil, nil
 	}
 	if sub.entityType != "person" {
-		return nil, &ValidationError{Field: purposeIDField, Reason: "a double opt-in purpose needs a person subject; promote the lead before granting it"}
+		return nil, &ValidationError{
+			// The subject, not the purpose: the purpose is fine and the caller
+			// cannot fix it. What they must change is which subject they named,
+			// which is the field consentSubject's own refusals already use.
+			Field:  "subject",
+			Reason: "a double opt-in purpose needs a person subject; promote the lead before granting it",
+		}
 	}
 	if in.DoubleOptInToken == nil || *in.DoubleOptInToken == "" {
 		return nil, &ValidationError{Field: "double_opt_in_token", Reason: "purpose requires a confirmed double opt-in"}

--- a/backend/internal/modules/customfields/engine.go
+++ b/backend/internal/modules/customfields/engine.go
@@ -55,8 +55,9 @@ var FieldTypes = []string{TypeText, TypeNumber, TypeDate, TypeCurrency, TypePick
 // column exists, and every read drops the value. The two exclusions are named
 // rather than left to be inferred from an absence:
 //
-//   - activity — no store wiring, no wire carriage. The already-shipped defect
-//     above; naming it here is what closes it.
+//   - activity — no store wiring, no wire carriage, so a custom field on an
+//     activity can be created and never read back. That has been true since it
+//     shipped, hidden only by the SPA's picker; naming it here is what closes it.
 //   - relationship — same two gaps. Custom fields on edges is deliberately its
 //     own future change, because it opens a question no gate here can answer: a
 //     `relationship` row is EXCLUDED from piiTables today, judged against a

--- a/backend/internal/modules/customfields/engine.go
+++ b/backend/internal/modules/customfields/engine.go
@@ -42,19 +42,46 @@ const (
 // the way the custom_field.type CHECK constraint spells them.
 var FieldTypes = []string{TypeText, TypeNumber, TypeDate, TypeCurrency, TypePicklist, TypeBoolean}
 
-// FieldObjects is the closed, ordered set of core objects a custom field
-// can attach to. It is derived from the canonical entity vocabulary rather
-// than restated, so the catalog CHECK, this package and the vocabulary
-// cannot drift apart (the drift is what TestEveryDomainEnumMatchesItsSchemaCheck
-// pins).
-var FieldObjects = func() []string {
-	all := datasource.EntityTypes()
-	out := make([]string, 0, len(all))
-	for _, e := range all {
-		out = append(out, string(e))
-	}
-	return out
-}()
+// FieldObjects is the closed, ordered set of core objects a custom field can
+// attach to: those whose store READS the cf_* columns through the fieldcatalog
+// seam and whose contract shapes CARRY the values on the wire.
+//
+// It used to be datasource.EntityTypes() — the whole entity vocabulary — and
+// that derivation over-promised, because neither of those two properties is
+// something the vocabulary says anything about. `object=activity` is the proof:
+// it has been accepted by this engine and served by nobody since the day it
+// shipped. The activity store has no fieldcatalog wiring and the Activity
+// contract schema has no additionalProperties, so a custom field on an activity
+// can be created and never read back. Only the SPA's picker hides it, which is
+// a screen, not a gate.
+//
+// So the set is spelled out, and the two exclusions are named rather than left
+// to be inferred from an absence:
+//
+//   - activity — no store wiring, no wire carriage. The already-shipped defect
+//     above; naming it here is what closes it.
+//   - relationship — same two gaps. Custom fields on edges is deliberately its
+//     own future change, because it opens a question no gate here can answer: a
+//     `relationship` row is EXCLUDED from piiTables today, judged against a
+//     closed set of business facts, and an open-ended cf_* column on a person's
+//     employment edge would change that premise while Art. 17 erasure and
+//     Art. 15 SAR both stay blind to it.
+//
+// The catalog CHECK stays WIDER than this list (migrations/core/0171), which is
+// safe because this engine is the only writer of that table, and is the same
+// posture the other three EntityType-bound CHECKs already have.
+//
+// TestEveryFieldObjectCarriesItsValuesOnTheWire is what stops the list from
+// quietly over-promising again: it asserts every member's contract create and
+// read shapes actually declare the additionalProperties bag a cf_* value
+// travels in.
+var FieldObjects = []string{
+	string(datasource.EntityPerson),
+	string(datasource.EntityOrganization),
+	string(datasource.EntityDeal),
+	string(datasource.EntityLead),
+	string(datasource.EntityProject),
+}
 
 var allowedObjects = func() map[string]bool {
 	m := make(map[string]bool, len(FieldObjects))

--- a/backend/internal/modules/customfields/engine.go
+++ b/backend/internal/modules/customfields/engine.go
@@ -43,20 +43,17 @@ const (
 var FieldTypes = []string{TypeText, TypeNumber, TypeDate, TypeCurrency, TypePicklist, TypeBoolean}
 
 // FieldObjects is the closed, ordered set of core objects a custom field can
-// attach to: those whose store READS the cf_* columns through the fieldcatalog
-// seam and whose contract shapes CARRY the values on the wire.
+// attach to. A member must satisfy BOTH properties, and neither is something the
+// entity vocabulary says anything about — which is why this is spelled out rather
+// than derived from it:
 //
-// It used to be datasource.EntityTypes() — the whole entity vocabulary — and
-// that derivation over-promised, because neither of those two properties is
-// something the vocabulary says anything about. `object=activity` is the proof:
-// it has been accepted by this engine and served by nobody since the day it
-// shipped. The activity store has no fieldcatalog wiring and the Activity
-// contract schema has no additionalProperties, so a custom field on an activity
-// can be created and never read back. Only the SPA's picker hides it, which is
-// a screen, not a gate.
+//   - its store reads and writes the cf_* columns through the fieldcatalog seam
+//   - its contract create and read shapes declare the additionalProperties bag a
+//     cf_* value travels in
 //
-// So the set is spelled out, and the two exclusions are named rather than left
-// to be inferred from an absence:
+// Fail either and the field is creatable and never served: the ALTER runs, the
+// column exists, and every read drops the value. The two exclusions are named
+// rather than left to be inferred from an absence:
 //
 //   - activity — no store wiring, no wire carriage. The already-shipped defect
 //     above; naming it here is what closes it.

--- a/backend/internal/modules/customfields/engine_test.go
+++ b/backend/internal/modules/customfields/engine_test.go
@@ -318,10 +318,15 @@ func TestFieldTypes_MatchesMigrationCheckSpelling(t *testing.T) {
 	}
 }
 
-func TestFieldObjects_MatchesMigrationCheckSpelling(t *testing.T) {
-	want := []string{"person", "organization", "deal", "lead", "activity", "project"}
+// The ordered set, pinned so a member cannot be added or dropped without the
+// change being stated. What each member has to be TRUE of — a store that reads
+// its cf_* columns and a contract shape that carries them — is derived in
+// fieldobjects_test.go rather than restated here.
+func TestFieldObjects_IsTheExplicitTargetSet(t *testing.T) {
+	want := []string{"person", "organization", "deal", "lead", "project"}
 	if len(FieldObjects) != len(want) {
-		t.Fatalf("FieldObjects = %v, want %v", FieldObjects, want)
+		t.Fatalf("FieldObjects = %v, want %v — activity and relationship are excluded for want of "+
+			"wire carriage and store wiring; see the engine's own comment", FieldObjects, want)
 	}
 	for i, w := range want {
 		if FieldObjects[i] != w {

--- a/backend/internal/modules/customfields/fieldobjects_test.go
+++ b/backend/internal/modules/customfields/fieldobjects_test.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package customfields
+
+// A custom field this engine accepts must be one the wire can actually carry.
+//
+// FieldObjects used to be datasource.EntityTypes(), and that derivation was
+// wrong in a way no test noticed: `object=activity` has been accepted since it
+// shipped and served by nobody, because a cf_* value travels in the contract
+// schema's additionalProperties bag and Activity has none. The field could be
+// created, the ALTER ran, the column existed — and every read dropped it. Only
+// the SPA's picker hid it, which is a screen, not a gate.
+//
+// So the list is explicit now, and this is what stops it over-promising again.
+// The PROPERTY is derived (reflection over the generated contract structs); only
+// the object → shape pairing is written down, and a member missing from that
+// pairing fails rather than being skipped.
+
+import (
+	"reflect"
+	"testing"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+)
+
+// carriageShapes binds each object to the contract types a cf_* value has to
+// survive: the body it is WRITTEN in and the schema it is READ back from. Both,
+// because carriage on only one half is the shape of the activity defect —
+// accepted on the way in, gone on the way out.
+var carriageShapes = map[string]struct{ create, read reflect.Type }{
+	string(datasource.EntityPerson): {
+		reflect.TypeFor[crmcontracts.CreatePersonRequest](), reflect.TypeFor[crmcontracts.Person](),
+	},
+	string(datasource.EntityOrganization): {
+		reflect.TypeFor[crmcontracts.CreateOrganizationRequest](), reflect.TypeFor[crmcontracts.Organization](),
+	},
+	string(datasource.EntityDeal): {
+		reflect.TypeFor[crmcontracts.CreateDealRequest](), reflect.TypeFor[crmcontracts.Deal](),
+	},
+	string(datasource.EntityLead): {
+		reflect.TypeFor[crmcontracts.CreateLeadRequest](), reflect.TypeFor[crmcontracts.Lead](),
+	},
+	string(datasource.EntityProject): {
+		reflect.TypeFor[crmcontracts.CreateProjectRequest](), reflect.TypeFor[crmcontracts.Project](),
+	},
+	// The two exclusions, carried here so the assertion below can state WHY
+	// each is excluded rather than assert an absence from FieldObjects.
+	string(datasource.EntityActivity): {
+		reflect.TypeFor[crmcontracts.CreateActivityRequest](), reflect.TypeFor[crmcontracts.Activity](),
+	},
+	string(datasource.EntityRelationship): {
+		reflect.TypeFor[crmcontracts.CreateRelationshipRequest](), reflect.TypeFor[crmcontracts.Relationship](),
+	},
+}
+
+// carriesCustomFieldValues reports whether a generated contract struct declares
+// the additionalProperties catch-all a cf_* key travels in. oapi-codegen renders
+// it as a map field tagged `json:"-"`, populated by the type's own
+// marshal/unmarshal — so its presence is exactly the question "can this shape
+// hold a key the schema does not name".
+func carriesCustomFieldValues(t reflect.Type) bool {
+	field, ok := t.FieldByName("AdditionalProperties")
+	return ok && field.Type.Kind() == reflect.Map
+}
+
+func TestEveryFieldObjectCarriesItsValuesOnTheWire(t *testing.T) {
+	for _, object := range FieldObjects {
+		shapes, paired := carriageShapes[object]
+		if !paired {
+			t.Errorf("FieldObjects names %q and carriageShapes has no entry for it, so this gate "+
+				"skipped the one member it could not check. Add the pair.", object)
+			continue
+		}
+		for label, shape := range map[string]reflect.Type{"create": shapes.create, "read": shapes.read} {
+			if !carriesCustomFieldValues(shape) {
+				t.Errorf("object %q is a custom-field target but its %s shape %s declares no "+
+					"additionalProperties — a value written there cannot be carried, so the field "+
+					"would be creatable and never served", object, label, shape.Name())
+			}
+		}
+	}
+}
+
+// The exclusions are excluded for a REASON, and the reason is checkable. When
+// upstream gives one of these shapes carriage, this goes red and says so —
+// which is the moment to revisit the exclusion rather than to discover months
+// later that the gap closed and nobody noticed.
+func TestTheExcludedObjectsStillLackTheCarriageThatWouldAdmitThem(t *testing.T) {
+	admitted := map[string]bool{}
+	for _, object := range FieldObjects {
+		admitted[object] = true
+	}
+	for _, object := range []string{string(datasource.EntityActivity), string(datasource.EntityRelationship)} {
+		if admitted[object] {
+			continue // it is a target now; the gate above governs it
+		}
+		shapes := carriageShapes[object]
+		if carriesCustomFieldValues(shapes.create) && carriesCustomFieldValues(shapes.read) {
+			t.Errorf("%q is excluded from FieldObjects for want of wire carriage, and both its "+
+				"contract shapes now declare additionalProperties. The reason for the exclusion has "+
+				"expired: either wire the store's cf_* columns and admit it, or restate why it stays "+
+				"out. For relationship, the privacy question comes first — an edge is excluded from "+
+				"piiTables on the premise that its columns are a closed set of business facts.", object)
+		}
+	}
+}
+
+// FieldObjects is no longer the CHECK's set, and that is deliberate: the catalog
+// CHECK (migrations/core/0171) is WIDER. This pins the direction of that
+// difference, because the safe asymmetry is only one way round — this engine is
+// the table's sole writer, so an allowlist narrower than the CHECK refuses
+// cleanly, while one wider than the CHECK would fail at INSERT with a
+// constraint violation no caller can act on.
+func TestEveryFieldObjectIsSpelledTheWayTheCatalogCheckSpellsIt(t *testing.T) {
+	// The CHECK's vocabulary is the entity vocabulary; membership in it is what
+	// makes a spelling insertable at all.
+	vocabulary := map[string]bool{}
+	for _, entity := range datasource.EntityTypes() {
+		vocabulary[string(entity)] = true
+	}
+	for _, object := range FieldObjects {
+		if !vocabulary[object] {
+			t.Errorf("FieldObjects names %q, which is not in the entity vocabulary the "+
+				"custom_field.object CHECK mirrors — a field for it would be refused by the "+
+				"database at INSERT, after the ALTER had already run", object)
+		}
+	}
+}

--- a/backend/internal/modules/deals/handlers_deal.go
+++ b/backend/internal/modules/deals/handlers_deal.go
@@ -101,11 +101,12 @@ func (h Handlers) AdvanceDeal(w http.ResponseWriter, r *http.Request, id crmcont
 		return
 	}
 
-	deal, err := h.store.AdvanceDeal(r.Context(), pathID[ids.DealKind](id), AdvanceDealInput{
-		ToStageID:  pathID[ids.StageKind](req.ToStageId),
-		LostReason: req.LostReason,
-		IfVersion:  ifVersion,
-	})
+	in, err := advanceDealInput(req, ifVersion)
+	if err != nil {
+		writeStoreErr(w, r, err)
+		return
+	}
+	deal, err := h.store.AdvanceDeal(r.Context(), pathID[ids.DealKind](id), in)
 	if err != nil {
 		writeStoreErr(w, r, err)
 		return

--- a/backend/internal/modules/deals/handlers_stages.go
+++ b/backend/internal/modules/deals/handlers_stages.go
@@ -53,14 +53,10 @@ func (h Handlers) CreateStage(w http.ResponseWriter, r *http.Request, _ crmcontr
 	if !httperr.Decode(w, r, &req) {
 		return
 	}
-	in := CreateStageInput{
-		PipelineID:     pathID[ids.PipelineKind](req.PipelineId),
-		Name:           req.Name,
-		Position:       req.Position,
-		WinProbability: req.WinProbability,
-	}
-	if req.Semantic != nil {
-		in.Semantic = string(*req.Semantic)
+	in, err := stageCreateInput(req)
+	if err != nil {
+		writeStoreErr(w, r, err)
+		return
 	}
 	stage, err := h.store.CreateStage(r.Context(), in)
 	if err != nil {

--- a/backend/internal/modules/deals/mapping.go
+++ b/backend/internal/modules/deals/mapping.go
@@ -12,6 +12,7 @@ import (
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/platform/httperr"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/provenance"
 )
@@ -45,17 +46,57 @@ func idArg[K ids.EntityKind](u *openapi_types.UUID) *ids.ID[K] {
 
 // requireBodyID refuses a required non-pointer id the body simply omitted.
 //
-// A required id is generated as a NON-POINTER openapi_types.UUID, so an absent
-// key decodes to the zero UUID with no error — "required" in the contract is a
-// claim only this check makes true. What made that worth a named helper is
-// where the zero value lands: it reaches a lookup that matches nothing and
-// comes back as a bare not-found, which names no argument on either surface. A
-// caller is then told the record it never mentioned does not exist.
+// The rule, the message and the wire shape live in ONE place for the whole tree
+// (httperr.RequireBodyID) — eight modules need it, and eleven copies of the same
+// three lines is eleven places for one refusal to be spelled differently. This
+// stays as the module's local name for it because it is what converts the
+// generated contract type: httperr deliberately does not import the contracts.
+//
+// RequiredFieldError is still the module's own error for a required non-id FIELD
+// (a deal without a name, a line item without a description) — a different claim
+// with a different reader.
 func requireBodyID(field string, id openapi_types.UUID) error {
-	if ids.UUID(id).IsZero() {
-		return &RequiredFieldError{Field: field}
+	return httperr.RequireBodyID(field, ids.UUID(id))
+}
+
+// advanceDealInput maps the advance body onto the store input.
+//
+// It exists so the guard sits in a mapping both transports could share rather
+// than inside the HTTP handler: the MCP twin (advance_deal) is guarded at
+// Registry.Invoke, so REST answered a bare 404 for the identical mistake — the
+// "one rule, two answers" shape PR #370 removed from UpdateRelationship and then
+// created here.
+func advanceDealInput(req crmcontracts.AdvanceDealRequest, ifVersion *int64) (AdvanceDealInput, error) {
+	// Unchecked, the zero UUID travels to the stage lookup, whose composite
+	// WHERE matches nothing and answers a bare not-found — for a deal that is in
+	// the URL and exists, sending the caller hunting for a stage it never named.
+	if err := requireBodyID("to_stage_id", req.ToStageId); err != nil {
+		return AdvanceDealInput{}, err
 	}
-	return nil
+	return AdvanceDealInput{
+		ToStageID:  pathID[ids.StageKind](req.ToStageId),
+		LostReason: req.LostReason,
+		IfVersion:  ifVersion,
+	}, nil
+}
+
+// stageCreateInput maps the create-stage body onto the store input. A stage
+// without a pipeline has nowhere to be: unguarded, the zero UUID reaches the
+// pipeline probe and answers not-found for a pipeline the caller never named.
+func stageCreateInput(req crmcontracts.CreateStageRequest) (CreateStageInput, error) {
+	if err := requireBodyID("pipeline_id", req.PipelineId); err != nil {
+		return CreateStageInput{}, err
+	}
+	in := CreateStageInput{
+		PipelineID:     pathID[ids.PipelineKind](req.PipelineId),
+		Name:           req.Name,
+		Position:       req.Position,
+		WinProbability: req.WinProbability,
+	}
+	if req.Semantic != nil {
+		in.Semantic = string(*req.Semantic)
+	}
+	return in, nil
 }
 
 func dealCreateInput(req crmcontracts.CreateDealRequest) (CreateDealInput, error) {

--- a/backend/internal/modules/deals/mapping.go
+++ b/backend/internal/modules/deals/mapping.go
@@ -62,10 +62,10 @@ func requireBodyID(field string, id openapi_types.UUID) error {
 // advanceDealInput maps the advance body onto the store input.
 //
 // It exists so the guard sits in a mapping both transports could share rather
-// than inside the HTTP handler: the MCP twin (advance_deal) is guarded at
-// Registry.Invoke, so REST answered a bare 404 for the identical mistake — the
-// "one rule, two answers" shape PR #370 removed from UpdateRelationship and then
-// created here.
+// than inside the HTTP handler. The MCP twin (advance_deal) is guarded at
+// Registry.Invoke and the agent gate resolves this tool's tier before the handler
+// runs, so `to_stage_id` has three readers — and one rule with three spellings is
+// three chances for a caller to be told something different for one mistake.
 func advanceDealInput(req crmcontracts.AdvanceDealRequest, ifVersion *int64) (AdvanceDealInput, error) {
 	// Unchecked, the zero UUID travels to the stage lookup, whose composite
 	// WHERE matches nothing and answers a bare not-found — for a deal that is in

--- a/backend/internal/modules/deals/requiredids_test.go
+++ b/backend/internal/modules/deals/requiredids_test.go
@@ -31,7 +31,7 @@ package deals
 
 import (
 	"encoding/json"
-	"errors"
+	"net/http"
 	"reflect"
 	"strings"
 	"testing"
@@ -39,6 +39,7 @@ import (
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/platform/httperr"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -81,6 +82,8 @@ func completeBody(t *testing.T, shape reflect.Type, omit string) map[string]any 
 			body[name] = ids.NewV7().String()
 		case reflect.TypeFor[string]():
 			body[name] = "probe"
+		case reflect.TypeFor[int]():
+			body[name] = 1
 		default:
 			t.Fatalf("%s.%s is a required %s this probe cannot populate — extend completeBody",
 				shape.Name(), field.Name, field.Type)
@@ -124,6 +127,35 @@ func TestEveryRequiredBodyIDIsNamedWhenAbsent(t *testing.T) {
 				return err
 			},
 		},
+		{
+			// The asymmetry PR #370 created: advance_deal is guarded on the MCP
+			// side at Registry.Invoke, so REST answered a bare 404 for the
+			// identical mistake — one rule, two answers.
+			name:  "AdvanceDealRequest",
+			shape: reflect.TypeFor[crmcontracts.AdvanceDealRequest](),
+			call: func(t *testing.T, body []byte) error {
+				t.Helper()
+				var req crmcontracts.AdvanceDealRequest
+				if err := json.Unmarshal(body, &req); err != nil {
+					t.Fatalf("probe body does not decode: %v", err)
+				}
+				_, err := advanceDealInput(req, nil)
+				return err
+			},
+		},
+		{
+			name:  "CreateStageRequest",
+			shape: reflect.TypeFor[crmcontracts.CreateStageRequest](),
+			call: func(t *testing.T, body []byte) error {
+				t.Helper()
+				var req crmcontracts.CreateStageRequest
+				if err := json.Unmarshal(body, &req); err != nil {
+					t.Fatalf("probe body does not decode: %v", err)
+				}
+				_, err := stageCreateInput(req)
+				return err
+			},
+		},
 	} {
 		fields := requiredIDFields(tc.shape)
 		if len(fields) == 0 {
@@ -136,18 +168,38 @@ func TestEveryRequiredBodyIDIsNamedWhenAbsent(t *testing.T) {
 				if err != nil {
 					t.Fatalf("marshal probe body: %v", err)
 				}
-				var missing *RequiredFieldError
-				err = tc.call(t, body)
-				if !errors.As(err, &missing) {
-					t.Fatalf("an absent %s was answered with %T (%v); want *RequiredFieldError, or the "+
-						"caller is sent looking for a record it never named. Validate it in the mapping, "+
-						"which both transports share.", field, err, err)
-				}
-				if missing.Field != field {
-					t.Errorf("the refusal names %q, want the wire field %q — the name is what a caller "+
-						"branches on and what a model reads back", missing.Field, field)
-				}
+				assertNamesTheOmittedID(t, tc.call(t, body), field)
 			})
 		}
 	}
+}
+
+// assertNamesTheOmittedID is the one assertion every probe makes: the refusal
+// classifies as the caller's mistake and names the wire field they omitted.
+//
+// It asserts the OBSERVABLE property rather than a concrete error type, because
+// there are two legitimate carriers — this module's RequiredFieldError for a
+// required non-id field, and httperr.RequireBodyID for the ids — and a caller
+// cannot tell them apart, which is the point.
+func assertNamesTheOmittedID(t *testing.T, err error, field string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("an absent %s was accepted, so the caller is sent looking for a record it never "+
+			"named", field)
+	}
+	fault, ok := httperr.Classify(err)
+	if !ok {
+		t.Fatalf("an absent %s was answered with %v, which is outside the taxonomy — a surface would "+
+			"report the caller's own omission as an internal server fault", field, err)
+	}
+	if fault.Status != http.StatusUnprocessableEntity {
+		t.Errorf("an absent %s answered status %d, want 422 (404 is the defect this closes)", field, fault.Status)
+	}
+	for _, refusal := range fault.Fields {
+		if refusal.Field == field {
+			return
+		}
+	}
+	t.Errorf("the refusal for an absent %s names %+v, want the wire field %q — the name is what a "+
+		"caller branches on and what a model reads back", field, fault.Fields, field)
 }

--- a/backend/internal/modules/deals/requiredids_test.go
+++ b/backend/internal/modules/deals/requiredids_test.go
@@ -31,7 +31,6 @@ package deals
 
 import (
 	"encoding/json"
-	"net/http"
 	"reflect"
 	"strings"
 	"testing"
@@ -39,7 +38,7 @@ import (
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
-	"github.com/gradionhq/margince/backend/internal/platform/httperr"
+	"github.com/gradionhq/margince/backend/internal/platform/httperr/faulttest"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -128,9 +127,9 @@ func TestEveryRequiredBodyIDIsNamedWhenAbsent(t *testing.T) {
 			},
 		},
 		{
-			// The asymmetry PR #370 created: advance_deal is guarded on the MCP
-			// side at Registry.Invoke, so REST answered a bare 404 for the
-			// identical mistake — one rule, two answers.
+			// advance_deal is guarded on the MCP side at Registry.Invoke, so this
+			// mapping is what keeps REST from answering a bare 404 for the
+			// identical mistake.
 			name:  "AdvanceDealRequest",
 			shape: reflect.TypeFor[crmcontracts.AdvanceDealRequest](),
 			call: func(t *testing.T, body []byte) error {
@@ -168,38 +167,8 @@ func TestEveryRequiredBodyIDIsNamedWhenAbsent(t *testing.T) {
 				if err != nil {
 					t.Fatalf("marshal probe body: %v", err)
 				}
-				assertNamesTheOmittedID(t, tc.call(t, body), field)
+				faulttest.AssertNamesOmittedID(t, tc.call(t, body), field)
 			})
 		}
 	}
-}
-
-// assertNamesTheOmittedID is the one assertion every probe makes: the refusal
-// classifies as the caller's mistake and names the wire field they omitted.
-//
-// It asserts the OBSERVABLE property rather than a concrete error type, because
-// there are two legitimate carriers — this module's RequiredFieldError for a
-// required non-id field, and httperr.RequireBodyID for the ids — and a caller
-// cannot tell them apart, which is the point.
-func assertNamesTheOmittedID(t *testing.T, err error, field string) {
-	t.Helper()
-	if err == nil {
-		t.Fatalf("an absent %s was accepted, so the caller is sent looking for a record it never "+
-			"named", field)
-	}
-	fault, ok := httperr.Classify(err)
-	if !ok {
-		t.Fatalf("an absent %s was answered with %v, which is outside the taxonomy — a surface would "+
-			"report the caller's own omission as an internal server fault", field, err)
-	}
-	if fault.Status != http.StatusUnprocessableEntity {
-		t.Errorf("an absent %s answered status %d, want 422 (404 is the defect this closes)", field, fault.Status)
-	}
-	for _, refusal := range fault.Fields {
-		if refusal.Field == field {
-			return
-		}
-	}
-	t.Errorf("the refusal for an absent %s names %+v, want the wire field %q — the name is what a "+
-		"caller branches on and what a model reads back", field, fault.Fields, field)
 }

--- a/backend/internal/modules/identity/grants.go
+++ b/backend/internal/modules/identity/grants.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/platform/httperr"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -128,6 +129,18 @@ type CreateGrantInput struct {
 }
 
 func (s *Service) CreateRecordGrant(ctx context.Context, in CreateGrantInput) (grantRow, error) {
+	// Both ids, and both before anything else: a grant is a triple of record,
+	// subject and access, and each id is required by the contract — a claim only
+	// this check makes true. Unguarded, a zero record_id reaches the row-scope
+	// probe and a zero subject_id reaches the subject lookup, and each answers
+	// not-found for something the caller never named. The record refusal comes
+	// first because it is what the grant is ABOUT.
+	if err := httperr.RequireBodyID("record_id", in.RecordID); err != nil {
+		return grantRow{}, err
+	}
+	if err := httperr.RequireBodyID("subject_id", in.SubjectID); err != nil {
+		return grantRow{}, err
+	}
 	if !shareableRecordTypes[in.RecordType] {
 		return grantRow{}, &InvalidScopeError{Scope: "record_type " + in.RecordType}
 	}

--- a/backend/internal/modules/identity/requiredids_test.go
+++ b/backend/internal/modules/identity/requiredids_test.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package identity
+
+// A required body id the caller omitted must be named as a missing argument, not
+// discovered as a missing row.
+//
+// oapi-codegen renders a REQUIRED body id as a non-pointer UUID and
+// encoding/json leaves an absent key at the zero value with no error, so the
+// zero UUID used to travel to a lookup, match nothing, and answer a bare
+// not-found — telling the caller a record they never mentioned does not exist.
+//
+// The guard sits at the store entry point, which is the door every transport
+// comes through, and it runs BEFORE any authority check or query — which is why
+// these probes need no database and no actor: a store over a nil pool never
+// reaches one.
+//
+// The refusal's SHAPE (422, the field named, the stable `required` code, and that
+// it classifies on both surfaces) is proven once in
+// platform/httperr/requirebodyid_test.go. What is left here is the only question
+// this package can answer: is the guard actually called for my body.
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/platform/httperr"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// assertNamesTheOmittedID asserts the observable property: the caller's mistake,
+// with the wire field they omitted named.
+func assertNamesTheOmittedID(t *testing.T, err error, field string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("an absent %s was accepted, so the caller is sent looking for a record it never named", field)
+	}
+	fault, ok := httperr.Classify(err)
+	if !ok {
+		t.Fatalf("an absent %s answered %v, which is outside the taxonomy — a surface would report the "+
+			"caller's own omission as an internal server fault", field, err)
+	}
+	if fault.Status != http.StatusUnprocessableEntity {
+		t.Errorf("an absent %s answered status %d, want 422 (404 is the defect this closes)", field, fault.Status)
+	}
+	for _, refusal := range fault.Fields {
+		if refusal.Field == field {
+			return
+		}
+	}
+	t.Errorf("the refusal for an absent %s names %+v, want the wire field %q", field, fault.Fields, field)
+}
+
+func TestBothOmittedGrantIDsAreNamed(t *testing.T) {
+	// CreateRecordGrantRequest carries TWO required ids, and each is its own
+	// assertion: a grant is a triple of record, subject and access, so a guard
+	// that named only the first would leave the second answering not-found for a
+	// subject the caller never sent.
+	svc := NewService(nil)
+	ctx := context.Background()
+
+	_, err := svc.CreateRecordGrant(ctx, CreateGrantInput{
+		RecordType: "person", SubjectType: "user", Access: "read",
+		SubjectID: ids.NewV7(),
+	})
+	assertNamesTheOmittedID(t, err, "record_id")
+
+	_, err = svc.CreateRecordGrant(ctx, CreateGrantInput{
+		RecordType: "person", SubjectType: "user", Access: "read",
+		RecordID: ids.NewV7(),
+	})
+	assertNamesTheOmittedID(t, err, "subject_id")
+}

--- a/backend/internal/modules/identity/requiredids_test.go
+++ b/backend/internal/modules/identity/requiredids_test.go
@@ -4,54 +4,25 @@
 package identity
 
 // A required body id the caller omitted must be named as a missing argument, not
-// discovered as a missing row.
+// discovered as a missing row: an absent key decodes to the zero UUID with no
+// error, so unguarded it reaches a lookup, matches nothing, and answers a bare
+// not-found for a record the caller never mentioned.
 //
-// oapi-codegen renders a REQUIRED body id as a non-pointer UUID and
-// encoding/json leaves an absent key at the zero value with no error, so the
-// zero UUID used to travel to a lookup, match nothing, and answer a bare
-// not-found — telling the caller a record they never mentioned does not exist.
+// The guard is at the store entry point — the door every transport comes through —
+// and it runs BEFORE any authority check or query, which is why these probes need
+// no database and no actor: a store over a nil pool never reaches one.
 //
-// The guard sits at the store entry point, which is the door every transport
-// comes through, and it runs BEFORE any authority check or query — which is why
-// these probes need no database and no actor: a store over a nil pool never
-// reaches one.
-//
-// The refusal's SHAPE (422, the field named, the stable `required` code, and that
-// it classifies on both surfaces) is proven once in
-// platform/httperr/requirebodyid_test.go. What is left here is the only question
-// this package can answer: is the guard actually called for my body.
+// The refusal's SHAPE is proven once in platform/httperr/requirebodyid_test.go and
+// asserted here through faulttest. What is left is the only question this package
+// can answer: is the guard actually called for my body.
 
 import (
 	"context"
-	"net/http"
 	"testing"
 
-	"github.com/gradionhq/margince/backend/internal/platform/httperr"
+	"github.com/gradionhq/margince/backend/internal/platform/httperr/faulttest"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
-
-// assertNamesTheOmittedID asserts the observable property: the caller's mistake,
-// with the wire field they omitted named.
-func assertNamesTheOmittedID(t *testing.T, err error, field string) {
-	t.Helper()
-	if err == nil {
-		t.Fatalf("an absent %s was accepted, so the caller is sent looking for a record it never named", field)
-	}
-	fault, ok := httperr.Classify(err)
-	if !ok {
-		t.Fatalf("an absent %s answered %v, which is outside the taxonomy — a surface would report the "+
-			"caller's own omission as an internal server fault", field, err)
-	}
-	if fault.Status != http.StatusUnprocessableEntity {
-		t.Errorf("an absent %s answered status %d, want 422 (404 is the defect this closes)", field, fault.Status)
-	}
-	for _, refusal := range fault.Fields {
-		if refusal.Field == field {
-			return
-		}
-	}
-	t.Errorf("the refusal for an absent %s names %+v, want the wire field %q", field, fault.Fields, field)
-}
 
 func TestBothOmittedGrantIDsAreNamed(t *testing.T) {
 	// CreateRecordGrantRequest carries TWO required ids, and each is its own
@@ -65,11 +36,11 @@ func TestBothOmittedGrantIDsAreNamed(t *testing.T) {
 		RecordType: "person", SubjectType: "user", Access: "read",
 		SubjectID: ids.NewV7(),
 	})
-	assertNamesTheOmittedID(t, err, "record_id")
+	faulttest.AssertNamesOmittedID(t, err, "record_id")
 
 	_, err = svc.CreateRecordGrant(ctx, CreateGrantInput{
 		RecordType: "person", SubjectType: "user", Access: "read",
 		RecordID: ids.NewV7(),
 	})
-	assertNamesTheOmittedID(t, err, "subject_id")
+	faulttest.AssertNamesOmittedID(t, err, "subject_id")
 }

--- a/backend/internal/modules/overlay/provider.go
+++ b/backend/internal/modules/overlay/provider.go
@@ -246,8 +246,12 @@ func mirrorRowMatchesText(row Row, lowerText string) bool {
 	return false
 }
 
-// knownEntityTypes is the fixed set of entity types the overlay mirror
-// can ever hold (datasource.go's frozen EntityType constants).
+// knownEntityTypes is the set of entity types the overlay mirror can hold — a
+// SUBSET of the seam's vocabulary, not a copy of it. `project` and
+// `relationship` are full members of datasource.EntityTypes() and have no
+// mirror projection, which is why a write naming one answers the declared
+// unsupported-by-SoR sentinel (requireSupportedWrite) rather than
+// UnsupportedEntityError.
 var knownEntityTypes = []datasource.EntityType{
 	datasource.EntityPerson,
 	datasource.EntityOrganization,

--- a/backend/internal/modules/overlay/provider_writes.go
+++ b/backend/internal/modules/overlay/provider_writes.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"log/slog"
 	"reflect"
+	"slices"
 	"sort"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
@@ -357,12 +358,30 @@ func requireSupportedWrite(verb WriteVerb, et datasource.EntityType) error {
 	if SupportsWrite(verb, et) {
 		return nil
 	}
-	if _, err := writeContractTarget(et, verb == WriteUpdate); err != nil {
-		// An entity the mirror does not carry at all — the honest answer is
-		// "no such entity here", not "this verb is unsupported".
+	if !isSeamEntityType(et) {
+		// Not in the seam's vocabulary at all — "no such entity here", which is
+		// a different answer from "this capability is not served here", and the
+		// caller acts on it differently: one is a misspelling to fix, the other
+		// a mode to stop asking in.
 		return &datasource.UnsupportedEntityError{Type: string(et)}
 	}
+	// A RECOGNIZED type the mirror does not carry. It gets the declared
+	// unsupported-by-SoR answer (AC-OV-2), not the unknown-entity one.
+	//
+	// The discriminator used to be writeContractTarget, which conflated "has a
+	// contract write shape in this file's switch" with "is a known entity" — so
+	// `project` and `relationship`, both full members of the vocabulary, were
+	// refused with a message that named the vocabulary they belong to and told
+	// the caller their entity_type was not served ANYWHERE. Deriving membership
+	// from EntityTypes() fixes both at once, and enrols the next type added
+	// there without an edit here.
 	return apperrors.ErrUnsupportedBySoR
+}
+
+// isSeamEntityType reports whether et is a member of the datasource seam's
+// entity vocabulary, derived from EntityTypes() rather than from any local list.
+func isSeamEntityType(et datasource.EntityType) bool {
+	return slices.Contains(datasource.EntityTypes(), et)
 }
 
 // SupportsWrite reports whether the overlay provider can serve verb for et.

--- a/backend/internal/modules/overlay/provider_writes_test.go
+++ b/backend/internal/modules/overlay/provider_writes_test.go
@@ -154,6 +154,55 @@ func TestSupportsWriteMatchesTheProviderVerbs(t *testing.T) {
 	}
 }
 
+// A vocabulary member the mirror does not carry gets the DECLARED capability
+// refusal; a string that is not a vocabulary member at all gets the
+// unknown-entity one. The two answers mean different things and a caller acts on
+// them differently — "stop asking for this in overlay mode" versus "you
+// misspelled the type" — so conflating them is the defect, whichever way round.
+//
+// Derived from EntityTypes() minus knownEntityTypes rather than naming project
+// and relationship: the next vocabulary member added without a mirror
+// projection is covered without an edit here.
+func TestARecognizedTypeTheMirrorDoesNotCarryIsDeclaredUnsupportedNotUnknown(t *testing.T) {
+	mirrored := map[datasource.EntityType]bool{}
+	for _, et := range knownEntityTypes {
+		mirrored[et] = true
+	}
+	unmirrored := []datasource.EntityType{}
+	for _, et := range datasource.EntityTypes() {
+		if !mirrored[et] {
+			unmirrored = append(unmirrored, et)
+		}
+	}
+	if len(unmirrored) == 0 {
+		t.Fatal("every vocabulary member is mirrored — this walk passed vacuously")
+	}
+
+	for _, et := range unmirrored {
+		for _, verb := range AllWriteVerbs() {
+			err := requireSupportedWrite(verb, et)
+			if !errors.Is(err, apperrors.ErrUnsupportedBySoR) {
+				t.Errorf("requireSupportedWrite(%s, %s) = %v, want ErrUnsupportedBySoR — %s is in the "+
+					"seam vocabulary, so refusing it as an unknown entity_type tells the caller their "+
+					"type does not exist anywhere", verb, et, err, et)
+			}
+			var unknown *datasource.UnsupportedEntityError
+			if errors.As(err, &unknown) {
+				t.Errorf("requireSupportedWrite(%s, %s) answered UnsupportedEntityError, whose message "+
+					"names the vocabulary %s belongs to", verb, et, et)
+			}
+		}
+	}
+
+	// The other half of the discrimination: a non-member is still unknown.
+	for _, verb := range AllWriteVerbs() {
+		var unknown *datasource.UnsupportedEntityError
+		if err := requireSupportedWrite(verb, datasource.EntityType("widget")); !errors.As(err, &unknown) {
+			t.Errorf("requireSupportedWrite(%s, widget) = %v, want UnsupportedEntityError", verb, err)
+		}
+	}
+}
+
 func TestCompleteWritePatchActivityCarriesKindForward(t *testing.T) {
 	p := NewProvider(nil, nil)
 	fields := map[string]any{"subject": "Follow up"}

--- a/backend/internal/modules/people/handlers_relationship.go
+++ b/backend/internal/modules/people/handlers_relationship.go
@@ -72,23 +72,7 @@ func (h Handlers) CreateRelationship(w http.ResponseWriter, r *http.Request) {
 	if !httperr.Decode(w, r, &req) {
 		return
 	}
-	in := CreateRelationshipInput{
-		Kind:              string(req.Kind),
-		Role:              req.Role,
-		Source:            req.Source,
-		IsCurrentPrimary:  req.IsCurrentPrimary != nil && *req.IsCurrentPrimary,
-		PersonID:          idArg[ids.PersonKind](req.PersonId),
-		OrganizationID:    idArg[ids.OrganizationKind](req.OrganizationId),
-		CounterpartyOrgID: idArg[ids.OrganizationKind](req.CounterpartyOrgId),
-		DealID:            idArg[ids.DealKind](req.DealId),
-	}
-	if req.StartedAt != nil {
-		in.StartedAt = &req.StartedAt.Time
-	}
-	if req.EndedAt != nil {
-		in.EndedAt = &req.EndedAt.Time
-	}
-	rel, err := h.store.CreateRelationship(r.Context(), in)
+	rel, err := h.store.CreateRelationship(r.Context(), relationshipCreateInput(req))
 	if err != nil {
 		writeStoreErr(w, r, err)
 		return
@@ -105,18 +89,7 @@ func (h Handlers) UpdateRelationship(w http.ResponseWriter, r *http.Request, id 
 	if !httperr.Decode(w, r, &req) {
 		return
 	}
-	in := UpdateRelationshipInput{
-		Role:             req.Role,
-		IsCurrentPrimary: req.IsCurrentPrimary,
-		IfVersion:        ifVersion,
-	}
-	if req.StartedAt != nil {
-		in.StartedAt = &req.StartedAt.Time
-	}
-	if req.EndedAt != nil {
-		in.EndedAt = &req.EndedAt.Time
-	}
-	rel, err := h.store.UpdateRelationship(r.Context(), ids.UUID(id), in)
+	rel, err := h.store.UpdateRelationship(r.Context(), ids.UUID(id), relationshipUpdateInput(req, ifVersion))
 	if err != nil {
 		writeStoreErr(w, r, err)
 		return

--- a/backend/internal/modules/people/merge.go
+++ b/backend/internal/modules/people/merge.go
@@ -92,12 +92,12 @@ type relinkCounts struct {
 	ActivityLinks int64 `json:"activity_links"`
 }
 
-// MergePerson merges person source→target and returns the survivor.
 // targetIDField names the wire path the merge bodies use for the SURVIVOR. Named
 // once because both merge verbs refuse on it, and a field slot holds a wire
 // field path, never prose.
 const targetIDField = "target_id"
 
+// MergePerson merges person source→target and returns the survivor.
 func (s *Store) MergePerson(ctx context.Context, sourceID, targetID ids.PersonID) (crmcontracts.Person, error) {
 	// target_id is required by the contract, which is true only if checked. An
 	// absent key decodes to the zero UUID, and the self-merge guard below does

--- a/backend/internal/modules/people/merge.go
+++ b/backend/internal/modules/people/merge.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/platform/httperr"
 
 	"github.com/jackc/pgx/v5"
 	openapi_types "github.com/oapi-codegen/runtime/types"
@@ -92,7 +93,19 @@ type relinkCounts struct {
 }
 
 // MergePerson merges person source→target and returns the survivor.
+// targetIDField names the wire path the merge bodies use for the SURVIVOR. Named
+// once because both merge verbs refuse on it, and a field slot holds a wire
+// field path, never prose.
+const targetIDField = "target_id"
+
 func (s *Store) MergePerson(ctx context.Context, sourceID, targetID ids.PersonID) (crmcontracts.Person, error) {
+	// target_id is required by the contract, which is true only if checked. An
+	// absent key decodes to the zero UUID, and the self-merge guard below does
+	// not catch it (a real source id never equals the zero one), so it reaches
+	// the pair lock and answers not-found for a survivor nobody named.
+	if err := httperr.RequireBodyID(targetIDField, targetID.UUID); err != nil {
+		return crmcontracts.Person{}, err
+	}
 	// authz.go maps the merge verb to update: rewriting where records
 	// point is curation of both rows, not deletion of one.
 	if err := auth.Require(ctx, "person", principal.ActionUpdate); err != nil {

--- a/backend/internal/modules/people/merge_organization.go
+++ b/backend/internal/modules/people/merge_organization.go
@@ -20,6 +20,7 @@ import (
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/platform/httperr"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -30,6 +31,12 @@ import (
 // survivor. The org half additionally re-homes the hierarchy (A's
 // children become B's) and the deal/partner attributions.
 func (s *Store) MergeOrganization(ctx context.Context, sourceID, targetID ids.OrganizationID) (crmcontracts.Organization, error) {
+	// Same rule, same reason as MergePerson: an omitted target_id is not caught
+	// by the self-merge check and would answer not-found for a survivor the
+	// caller never named.
+	if err := httperr.RequireBodyID(targetIDField, targetID.UUID); err != nil {
+		return crmcontracts.Organization{}, err
+	}
 	if err := auth.Require(ctx, "organization", principal.ActionUpdate); err != nil {
 		return crmcontracts.Organization{}, err
 	}

--- a/backend/internal/modules/people/projectstakeholder.go
+++ b/backend/internal/modules/people/projectstakeholder.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/platform/httperr"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -46,6 +47,12 @@ type SetProjectStakeholderInput struct {
 // raw uniqueness error instead would make an idempotent PUT fail purely on
 // timing.
 func (s *Store) SetProjectStakeholder(ctx context.Context, in SetProjectStakeholderInput) (relationshipRow, error) {
+	// A stakeholder seat names a PERSON; without one there is no seat. Required
+	// by the contract, and true only here: the zero UUID would reach the edge
+	// lookup and answer not-found for a person the caller never named.
+	if err := httperr.RequireBodyID("person_id", in.PersonID.UUID); err != nil {
+		return relationshipRow{}, err
+	}
 	if err := auth.Require(ctx, "relationship", principal.ActionCreate); err != nil {
 		return relationshipRow{}, err
 	}

--- a/backend/internal/modules/people/projectstakeholder.go
+++ b/backend/internal/modules/people/projectstakeholder.go
@@ -148,7 +148,7 @@ func (s *Store) RemoveProjectStakeholder(ctx context.Context, projectID ids.Proj
 		var args []any
 		arg := func(v any) int { args = append(args, v); return len(args) }
 		kindPos, projectPos, personPos := arg(projectStakeholderKind), arg(projectID), arg(personID)
-		scope, err := relationshipEndpointScope(ctx, "r", arg)
+		scope, err := auth.RelationshipEndpointScope(ctx, "r", arg)
 		if err != nil {
 			return err
 		}

--- a/backend/internal/modules/people/provider.go
+++ b/backend/internal/modules/people/provider.go
@@ -64,6 +64,12 @@ func (p *Provider) Read(ctx context.Context, r datasource.EntityRef) (datasource
 			return datasource.Record{}, err
 		}
 		return datasource.NewRecord(r, v, v.Version)
+	case datasource.EntityRelationship:
+		row, err := p.store.GetRelationship(ctx, r.ID)
+		if err != nil {
+			return datasource.Record{}, err
+		}
+		return datasource.NewRecord(r, wireRelationship(row), &row.Version)
 	default:
 		return datasource.Record{}, &datasource.UnsupportedEntityError{Type: string(r.Type)}
 	}
@@ -167,6 +173,16 @@ func (p *Provider) Create(ctx context.Context, in datasource.CreateInput) (datas
 		}
 		v, _, err := p.store.CreateLead(ctx, mapped)
 		return ref(datasource.EntityLead, v.Id), err
+	case datasource.EntityRelationship:
+		var req crmcontracts.CreateRelationshipRequest
+		if err := datasource.StrictDecode(raw, &req); err != nil {
+			return datasource.EntityRef{}, err
+		}
+		req.Source = in.Source
+		row, err := p.store.CreateRelationship(ctx, relationshipCreateInput(req))
+		// The edge's own id, not an endpoint's: the caller asked for a
+		// relationship and the read-back has to reach the row it created.
+		return datasource.EntityRef{Type: datasource.EntityRelationship, ID: row.ID}, err
 	default:
 		return datasource.EntityRef{}, &datasource.UnsupportedEntityError{Type: string(in.EntityType)}
 	}
@@ -199,6 +215,13 @@ func (p *Provider) Update(ctx context.Context, in datasource.UpdateInput) (datas
 		}
 		v, err := p.store.UpdateLead(ctx, ids.From[ids.LeadKind](in.Ref.ID), leadUpdateInput(req, in.IfVersion))
 		return ref(datasource.EntityLead, v.Id), err
+	case datasource.EntityRelationship:
+		var req crmcontracts.UpdateRelationshipRequest
+		if err := datasource.StrictDecode(raw, &req); err != nil {
+			return datasource.EntityRef{}, err
+		}
+		row, err := p.store.UpdateRelationship(ctx, in.Ref.ID, relationshipUpdateInput(req, in.IfVersion))
+		return datasource.EntityRef{Type: datasource.EntityRelationship, ID: row.ID}, err
 	default:
 		return datasource.EntityRef{}, &datasource.UnsupportedEntityError{Type: string(in.Ref.Type)}
 	}
@@ -212,6 +235,9 @@ func (p *Provider) Archive(ctx context.Context, r datasource.EntityRef) (datasou
 	case datasource.EntityOrganization:
 		v, err := p.store.ArchiveOrganization(ctx, ids.From[ids.OrganizationKind](r.ID))
 		return ref(datasource.EntityOrganization, v.Id), err
+	case datasource.EntityRelationship:
+		row, err := p.store.ArchiveRelationship(ctx, r.ID)
+		return datasource.EntityRef{Type: datasource.EntityRelationship, ID: row.ID}, err
 	default:
 		return datasource.EntityRef{}, &datasource.UnsupportedEntityError{Type: string(r.Type)}
 	}

--- a/backend/internal/modules/people/provider.go
+++ b/backend/internal/modules/people/provider.go
@@ -44,6 +44,13 @@ func ref(t datasource.EntityType, id openapi_types.UUID) datasource.EntityRef {
 	return datasource.EntityRef{Type: t, ID: ids.UUID(id)}
 }
 
+// edgeRef is ref for a relationship: the row carries the kernel id directly
+// rather than the contract's, because an edge has no contract shape the store
+// returns — it returns its own row.
+func edgeRef(id ids.UUID) datasource.EntityRef {
+	return datasource.EntityRef{Type: datasource.EntityRelationship, ID: id}
+}
+
 func (p *Provider) Read(ctx context.Context, r datasource.EntityRef) (datasource.Record, error) {
 	switch r.Type {
 	case datasource.EntityPerson:
@@ -182,7 +189,7 @@ func (p *Provider) Create(ctx context.Context, in datasource.CreateInput) (datas
 		row, err := p.store.CreateRelationship(ctx, relationshipCreateInput(req))
 		// The edge's own id, not an endpoint's: the caller asked for a
 		// relationship and the read-back has to reach the row it created.
-		return datasource.EntityRef{Type: datasource.EntityRelationship, ID: row.ID}, err
+		return edgeRef(row.ID), err
 	default:
 		return datasource.EntityRef{}, &datasource.UnsupportedEntityError{Type: string(in.EntityType)}
 	}
@@ -221,7 +228,7 @@ func (p *Provider) Update(ctx context.Context, in datasource.UpdateInput) (datas
 			return datasource.EntityRef{}, err
 		}
 		row, err := p.store.UpdateRelationship(ctx, in.Ref.ID, relationshipUpdateInput(req, in.IfVersion))
-		return datasource.EntityRef{Type: datasource.EntityRelationship, ID: row.ID}, err
+		return edgeRef(row.ID), err
 	default:
 		return datasource.EntityRef{}, &datasource.UnsupportedEntityError{Type: string(in.Ref.Type)}
 	}
@@ -237,7 +244,7 @@ func (p *Provider) Archive(ctx context.Context, r datasource.EntityRef) (datasou
 		return ref(datasource.EntityOrganization, v.Id), err
 	case datasource.EntityRelationship:
 		row, err := p.store.ArchiveRelationship(ctx, r.ID)
-		return datasource.EntityRef{Type: datasource.EntityRelationship, ID: row.ID}, err
+		return edgeRef(row.ID), err
 	default:
 		return datasource.EntityRef{}, &datasource.UnsupportedEntityError{Type: string(r.Type)}
 	}

--- a/backend/internal/modules/people/relationship.go
+++ b/backend/internal/modules/people/relationship.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
@@ -29,46 +28,6 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
-
-// RelationshipConflictError names the uniqueness rule that refused an edge.
-//
-// It carries the constraint so a caller racing ITSELF — an idempotent attach
-// whose insert lost to a concurrent one — can tell which rule fired and
-// recover by adopting the winner. Wrapping the driver error would say the same
-// thing and cost too much: a *pgconn.PgError anywhere in the chain makes
-// httperr treat the refusal as an infrastructure fault (blanking the client's
-// detail and logging at ERROR), and the agent runner echoes err.Error() into
-// its transcript, which would put SQLSTATE text in a model prompt.
-type RelationshipConflictError struct{ Constraint string }
-
-// relationshipConflictDetails says what each rule actually refused, in the
-// caller's terms. One shared sentence cannot serve all three: the primary-
-// employer index is keyed on the PERSON alone, so its conflict is with a
-// different company entirely — telling that caller "this already exists
-// between these records" would name the wrong pair and send them looking for
-// a row that is not there.
-var relationshipConflictDetails = map[string]string{
-	"uq_rel_current_primary_employer": "this person already has a current primary employer — end that employment, or add this one without the primary flag",
-	"uq_rel_deal_person_role":         "this person already holds that role on the deal",
-	projectStakeholderUnique:          "this person is already a stakeholder on the project",
-}
-
-// Error says what the caller can act on. The constraint name stays OFF the
-// wire: httperr sends a sentinel's own text as the 409 detail, and an index
-// name is a database internal — it tells a client nothing it can use and
-// describes our schema to anyone probing it.
-func (e *RelationshipConflictError) Error() string {
-	if detail, ok := relationshipConflictDetails[e.Constraint]; ok {
-		return detail
-	}
-	// A rule added to the switch above but not described here: still a
-	// truthful refusal, just a less specific one.
-	return "a live relationship already conflicts with this one"
-}
-
-// Is reports this as the conflict sentinel, so every transport that maps
-// ErrConflict to 409 keeps doing so without knowing this type exists.
-func (e *RelationshipConflictError) Is(target error) bool { return target == apperrors.ErrConflict }
 
 // relationshipAnchor names the endpoint whose lifecycle a kind
 // annotates — the entity whose .updated event a mutation emits and
@@ -248,29 +207,6 @@ func untypedPtr[K ids.EntityKind](id *ids.ID[K]) *ids.UUID {
 		return nil
 	}
 	return &id.UUID
-}
-
-// mapRelationshipConstraint turns the insert's constraint failures into
-// typed input errors: the rel_* CHECKs are the kind→endpoint shape rules
-// (migration 0007) — bad input, not a fault — and the partial unique
-// indexes are the edge dedupe rules (a second identical edge conflicts
-// with the existing one). Anything else surfaces unchanged.
-func mapRelationshipConstraint(err error, kind string) error {
-	if constraint, ok := storekit.CheckViolation(err); ok {
-		switch constraint {
-		case "rel_employment_shape", "rel_stakeholder_shape", "rel_partner_shape", "rel_project_stakeholder_shape":
-			return &RelationshipShapeError{Kind: kind}
-		case "rel_dates":
-			return &RelationshipDatesError{}
-		}
-	}
-	if constraint, ok := storekit.UniqueViolation(err); ok {
-		switch constraint {
-		case "uq_rel_current_primary_employer", "uq_rel_deal_person_role", projectStakeholderUnique:
-			return &RelationshipConflictError{Constraint: constraint}
-		}
-	}
-	return err
 }
 
 type UpdateRelationshipInput struct {
@@ -456,32 +392,43 @@ func aliased(columns, alias string) string {
 	return strings.Join(parts, ", ")
 }
 
-func wireRelationship(rel relationshipRow) crmcontracts.Relationship {
-	out := crmcontracts.Relationship{
-		Id:          openapi_types.UUID(rel.ID),
-		WorkspaceId: openapi_types.UUID(rel.WorkspaceID.UUID),
-		Kind:        crmcontracts.RelationshipKind(rel.Kind),
-		Source:      rel.Source,
-		CapturedBy:  &rel.CapturedBy,
-		CreatedAt:   rel.CreatedAt,
-		UpdatedAt:   rel.UpdatedAt,
-		ArchivedAt:  rel.ArchivedAt,
-		Role:        rel.Role,
+// GetRelationship reads one edge under the endpoint-visibility rule, in its own
+// transaction — the entry point the datasource seam needs, since every other
+// caller of visibleRelationship already holds a transaction of its own.
+//
+// The seam needs it for three verbs and not only for a read tool: create_record
+// reads the edge back after writing it, and archive_record reads the target
+// BEFORE staging, to summarize for the human who will approve. Without this the
+// edge would commit and the tool would report a read-back failure — a false
+// failure with a real side effect — and the 🟡 archive could not even stage.
+//
+// The RBAC gate is the read one, not the anchor's update one that the mutating
+// verbs also demand: reading an edge discloses its endpoints, which is what
+// `relationship` read governs. Absence and out-of-scope answer identically.
+func (s *Store) GetRelationship(ctx context.Context, id ids.UUID) (relationshipRow, error) {
+	if err := auth.Require(ctx, "relationship", principal.ActionRead); err != nil {
+		return relationshipRow{}, err
 	}
-	version := crmcontracts.RowVersion(rel.Version)
-	out.Version = &version
-	out.IsCurrentPrimary = &rel.IsCurrentPrimary
-	out.PersonId = uuidPtr(untypedPtr(rel.PersonID))
-	out.OrganizationId = uuidPtr(untypedPtr(rel.OrganizationID))
-	out.CounterpartyOrgId = uuidPtr(untypedPtr(rel.CounterpartyOrgID))
-	out.DealId = uuidPtr(untypedPtr(rel.DealID))
-	if rel.StartedAt != nil {
-		out.StartedAt = &openapi_types.Date{Time: *rel.StartedAt}
-	}
-	if rel.EndedAt != nil {
-		out.EndedAt = &openapi_types.Date{Time: *rel.EndedAt}
-	}
-	return out
+	var out relationshipRow
+	err := s.tx(ctx, func(tx pgx.Tx) error {
+		row, err := s.visibleRelationship(ctx, tx, id)
+		if err != nil {
+			return err
+		}
+		// Live only, matching every other record type's Read (which passes
+		// storekit.LiveOnly). visibleRelationship deliberately does NOT filter —
+		// Update locks live-only itself and Archive's own WHERE clause does the
+		// work — so the filter belongs here, or an archived edge would go on
+		// being served by the one verb whose whole job is to say what the record
+		// currently is. Post-filtering is safe: the row already passed this
+		// caller's endpoint scope, so nothing about it is disclosed by the check.
+		if row.ArchivedAt != nil {
+			return apperrors.ErrNotFound
+		}
+		out = row
+		return nil
+	})
+	return out, err
 }
 
 // EnsureProjectVisible probes a project id under the caller's row scope —

--- a/backend/internal/modules/people/relationship.go
+++ b/backend/internal/modules/people/relationship.go
@@ -96,8 +96,16 @@ type CreateRelationshipInput struct {
 }
 
 func (s *Store) CreateRelationship(ctx context.Context, in CreateRelationshipInput) (relationshipRow, error) {
+	// A SUPPLIED kind outside the vocabulary is a different fault from an omitted
+	// one, and they used to answer the same sentence: a caller who sent
+	// kind="EMPLOYMENT" was told `kind` is required, which is factually wrong about
+	// a field they can see in their own request. The case-sensitivity trap makes
+	// that land in practice, so the refusal names the allowed set.
+	if in.Kind == "" {
+		return relationshipRow{}, &RequiredFieldError{Field: relationshipKindField}
+	}
 	if !relationshipKinds[in.Kind] {
-		return relationshipRow{}, &RequiredFieldError{Field: "kind"}
+		return relationshipRow{}, &RelationshipKindError{Kind: in.Kind}
 	}
 	anchorObject, _ := relationshipAnchor(in.Kind)
 	if err := auth.Require(ctx, "relationship", principal.ActionCreate); err != nil {

--- a/backend/internal/modules/people/relationship.go
+++ b/backend/internal/modules/people/relationship.go
@@ -14,7 +14,6 @@ package people
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strings"
 	"time"
 
@@ -80,37 +79,6 @@ func scanRelationship(r pgx.Row) (relationshipRow, error) {
 		&out.DealID, &out.ProjectID, &out.Role, &out.IsCurrentPrimary, &out.StartedAt, &out.EndedAt,
 		&out.Source, &out.CapturedBy, &out.Version, &out.CreatedAt, &out.UpdatedAt, &out.ArchivedAt)
 	return out, err
-}
-
-// relationshipEndpointScope renders "every non-null endpoint is
-// visible": one EXISTS per endpoint table under the caller's own/team
-// predicate. Only a caller unbounded over EVERY endpoint table carries no
-// clause — person and organization hold capture privacy, so that is the
-// system principal alone.
-func relationshipEndpointScope(ctx context.Context, alias string, arg func(any) int) (string, error) {
-	actor, ok := principal.Actor(ctx)
-	if !ok {
-		return "", errors.New("crmpeople: no actor bound to context")
-	}
-	if auth.UnboundedFor(actor, "person", "organization", "deal", projectObjectName) {
-		return "", nil
-	}
-	var clauses []string
-	for _, endpoint := range []struct{ column, table string }{
-		{"person_id", "person"},
-		{"organization_id", "organization"},
-		{"counterparty_org_id", "organization"},
-		{"deal_id", "deal"},
-		{"project_id", projectObjectName},
-	} {
-		predicate := auth.VisiblePredicate(actor, endpoint.table, arg)
-		clauses = append(clauses, fmt.Sprintf(
-			`(%[1]s.%[2]s IS NULL OR EXISTS (
-			   SELECT 1 FROM %[3]s ep WHERE ep.id = %[1]s.%[2]s AND ep.archived_at IS NULL AND %[4]s))`,
-			alias, endpoint.column, endpoint.table, predicate("ep"),
-		))
-	}
-	return "(" + strings.Join(clauses, " AND ") + ")", nil
 }
 
 type CreateRelationshipInput struct {
@@ -304,7 +272,7 @@ func (s *Store) visibleRelationship(ctx context.Context, tx pgx.Tx, id ids.UUID)
 	var args []any
 	arg := func(v any) int { args = append(args, v); return len(args) }
 	idPos := arg(id)
-	scope, err := relationshipEndpointScope(ctx, "r", arg)
+	scope, err := auth.RelationshipEndpointScope(ctx, "r", arg)
 	if err != nil {
 		return relationshipRow{}, err
 	}

--- a/backend/internal/modules/people/relationship_list.go
+++ b/backend/internal/modules/people/relationship_list.go
@@ -90,7 +90,7 @@ func relationshipListWhere(ctx context.Context, in ListRelationshipsInput, arg f
 		}
 		where = append(where, storekit.SQLf("r.id > $%d", arg(after)))
 	}
-	scope, err := relationshipEndpointScope(ctx, "r", arg)
+	scope, err := auth.RelationshipEndpointScope(ctx, "r", arg)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/modules/people/relationship_mapping.go
+++ b/backend/internal/modules/people/relationship_mapping.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+// Contract request → store input, and store row → contract response, for
+// relationship edges — in ONE place, because two surfaces now decode these
+// shapes: the HTTP handlers and the SoR provider the MCP tool surface comes
+// through. While the mapping was inline in the handler there was only one
+// caller and one place to be wrong; there are two now, and a defaulting rule in
+// only one of them makes the surfaces silently disagree.
+//
+// Extracting it found a defect that had been live on the REST path the whole
+// time: the create handler never read `project_id`, and the response never
+// rendered it. So `POST /v1/relationships` with kind=project_stakeholder — a
+// member of the contract's own kind enum — lost its project endpoint on the way
+// in and died on rel_project_stakeholder_shape, blaming a pair the caller had
+// supplied. Copying that into the provider would have shipped it twice.
+
+import (
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// relationshipCreateInput maps the contract create body onto the store input.
+// Every endpoint the body declares travels, including project_id: which pair a
+// kind needs is the rel_*_shape CHECKs' rule, and dropping a field here turns
+// their refusal into a lie about what the caller sent.
+func relationshipCreateInput(req crmcontracts.CreateRelationshipRequest) CreateRelationshipInput {
+	in := CreateRelationshipInput{
+		Kind:              string(req.Kind),
+		Role:              req.Role,
+		Source:            req.Source,
+		IsCurrentPrimary:  req.IsCurrentPrimary != nil && *req.IsCurrentPrimary,
+		PersonID:          idArg[ids.PersonKind](req.PersonId),
+		OrganizationID:    idArg[ids.OrganizationKind](req.OrganizationId),
+		CounterpartyOrgID: idArg[ids.OrganizationKind](req.CounterpartyOrgId),
+		DealID:            idArg[ids.DealKind](req.DealId),
+		ProjectID:         idArg[ids.ProjectKind](req.ProjectId),
+	}
+	// The two dates are wire DATES and store timestamps, so each needs its
+	// Time lifted out; a nil date stays nil, which the store reads as "not
+	// stated" rather than as the zero instant.
+	if req.StartedAt != nil {
+		in.StartedAt = &req.StartedAt.Time
+	}
+	if req.EndedAt != nil {
+		in.EndedAt = &req.EndedAt.Time
+	}
+	return in
+}
+
+// relationshipUpdateInput maps the contract patch onto the store input. The
+// patch carries no endpoints at all — an edge's ends are what it IS, so moving
+// one is a new edge and an archive, never an update — which is why this takes
+// the version pin the create mapper has no use for.
+func relationshipUpdateInput(req crmcontracts.UpdateRelationshipRequest, ifVersion *int64) UpdateRelationshipInput {
+	in := UpdateRelationshipInput{
+		Role:             req.Role,
+		IsCurrentPrimary: req.IsCurrentPrimary,
+		IfVersion:        ifVersion,
+	}
+	if req.StartedAt != nil {
+		in.StartedAt = &req.StartedAt.Time
+	}
+	if req.EndedAt != nil {
+		in.EndedAt = &req.EndedAt.Time
+	}
+	return in
+}
+
+// wireRelationship renders one edge for the wire. Every endpoint column the row
+// holds is rendered, project_id included: an edge that read back without the
+// endpoint that defines it left both surfaces describing a
+// project_stakeholder seat that named no project.
+func wireRelationship(rel relationshipRow) crmcontracts.Relationship {
+	out := crmcontracts.Relationship{
+		Id:          openapi_types.UUID(rel.ID),
+		WorkspaceId: openapi_types.UUID(rel.WorkspaceID.UUID),
+		Kind:        crmcontracts.RelationshipKind(rel.Kind),
+		Source:      rel.Source,
+		CapturedBy:  &rel.CapturedBy,
+		CreatedAt:   rel.CreatedAt,
+		UpdatedAt:   rel.UpdatedAt,
+		ArchivedAt:  rel.ArchivedAt,
+		Role:        rel.Role,
+	}
+	version := crmcontracts.RowVersion(rel.Version)
+	out.Version = &version
+	out.IsCurrentPrimary = &rel.IsCurrentPrimary
+	out.PersonId = uuidPtr(untypedPtr(rel.PersonID))
+	out.OrganizationId = uuidPtr(untypedPtr(rel.OrganizationID))
+	out.CounterpartyOrgId = uuidPtr(untypedPtr(rel.CounterpartyOrgID))
+	out.DealId = uuidPtr(untypedPtr(rel.DealID))
+	out.ProjectId = uuidPtr(untypedPtr(rel.ProjectID))
+	if rel.StartedAt != nil {
+		out.StartedAt = &openapi_types.Date{Time: *rel.StartedAt}
+	}
+	if rel.EndedAt != nil {
+		out.EndedAt = &openapi_types.Date{Time: *rel.EndedAt}
+	}
+	return out
+}

--- a/backend/internal/modules/people/relationshiperrors.go
+++ b/backend/internal/modules/people/relationshiperrors.go
@@ -4,6 +4,10 @@
 package people
 
 import (
+	"sort"
+	"strconv"
+	"strings"
+
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 )
@@ -25,7 +29,10 @@ import (
 type RelationshipShapeError struct{ Kind string }
 
 func (e *RelationshipShapeError) Error() string {
-	return "a " + e.Kind + " relationship does not take this combination of endpoints"
+	// No indefinite article: "a employment relationship" is wrong for the two
+	// kinds that begin with a vowel, and picking one per kind is a rule about
+	// English that the refusal does not need.
+	return "kind " + strconv.Quote(e.Kind) + " does not take this combination of endpoints"
 }
 
 // MessageFault names the condition and what to check, with no field: the
@@ -35,6 +42,40 @@ func (e *RelationshipShapeError) MessageFault() (code, message string) {
 	return "relationship_shape_invalid",
 		e.Error() + " — check which person/organization/deal/project fields this kind requires"
 }
+
+// relationshipKindField is the wire path both kind refusals name: the omitted-kind
+// RequiredFieldError and the invalid-kind one below.
+const relationshipKindField = "kind"
+
+// RelationshipKindError refuses a kind outside the closed vocabulary.
+//
+// FieldFault on `kind`: unlike the shape error next door, this one HAS a single
+// offending argument, and the fix is to change that one value — so the message
+// names the set to choose from rather than leaving the caller to guess which
+// spelling the server wanted.
+type RelationshipKindError struct{ Kind string }
+
+func (e *RelationshipKindError) Error() string {
+	return "`" + relationshipKindField + "` " + strconv.Quote(e.Kind) + " is not a relationship kind; use one of " + relationshipKindList
+}
+
+// FieldFault names kind and the contract's code for a value outside an enum.
+func (e *RelationshipKindError) FieldFault() (field, code, message string) {
+	return relationshipKindField, "invalid_value", e.Error()
+}
+
+// relationshipKindList renders the vocabulary from relationshipKinds rather than
+// restating it, so a kind added to the map cannot be missing from the refusal
+// that teaches it. Sorted, because a map's order would make the message differ
+// between processes for one rule.
+var relationshipKindList = func() string {
+	kinds := make([]string, 0, len(relationshipKinds))
+	for kind := range relationshipKinds {
+		kinds = append(kinds, kind)
+	}
+	sort.Strings(kinds)
+	return strings.Join(kinds, ", ")
+}()
 
 // RelationshipDatesError refuses an edge that ended before it started.
 type RelationshipDatesError struct{}

--- a/backend/internal/modules/people/relationshiperrors.go
+++ b/backend/internal/modules/people/relationshiperrors.go
@@ -3,8 +3,14 @@
 
 package people
 
-// What a relationship edge may not be. relationship.go owns the writes; these
-// are the input refusals its constraint mapping answers with.
+import (
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+)
+
+// What a relationship edge may not be, and the ONE mapping that turns the
+// database's refusal of each rule into a typed one. relationship.go owns the
+// writes; every refusal they can produce lives here.
 //
 // Each carries its verdict on itself, so one mapping serves every surface, and
 // each carries the RIGHT verdict: a FieldFault names an argument the caller can
@@ -40,4 +46,67 @@ func (e *RelationshipDatesError) Error() string {
 // FieldFault names ended_at: it is a real argument, and moving it is the fix.
 func (e *RelationshipDatesError) FieldFault() (field, code, message string) {
 	return "ended_at", "invalid_date_range", e.Error()
+}
+
+// RelationshipConflictError names the uniqueness rule that refused an edge.
+//
+// It carries the constraint so a caller racing ITSELF — an idempotent attach
+// whose insert lost to a concurrent one — can tell which rule fired and
+// recover by adopting the winner. Wrapping the driver error would say the same
+// thing and cost too much: a *pgconn.PgError anywhere in the chain makes
+// httperr treat the refusal as an infrastructure fault (blanking the client's
+// detail and logging at ERROR), and the agent runner echoes err.Error() into
+// its transcript, which would put SQLSTATE text in a model prompt.
+type RelationshipConflictError struct{ Constraint string }
+
+// relationshipConflictDetails says what each rule actually refused, in the
+// caller's terms. One shared sentence cannot serve all three: the primary-
+// employer index is keyed on the PERSON alone, so its conflict is with a
+// different company entirely — telling that caller "this already exists
+// between these records" would name the wrong pair and send them looking for
+// a row that is not there.
+var relationshipConflictDetails = map[string]string{
+	"uq_rel_current_primary_employer": "this person already has a current primary employer — end that employment, or add this one without the primary flag",
+	"uq_rel_deal_person_role":         "this person already holds that role on the deal",
+	projectStakeholderUnique:          "this person is already a stakeholder on the project",
+}
+
+// Error says what the caller can act on. The constraint name stays OFF the
+// wire: httperr sends a sentinel's own text as the 409 detail, and an index
+// name is a database internal — it tells a client nothing it can use and
+// describes our schema to anyone probing it.
+func (e *RelationshipConflictError) Error() string {
+	if detail, ok := relationshipConflictDetails[e.Constraint]; ok {
+		return detail
+	}
+	// A rule added to the switch above but not described here: still a
+	// truthful refusal, just a less specific one.
+	return "a live relationship already conflicts with this one"
+}
+
+// Is reports this as the conflict sentinel, so every transport that maps
+// ErrConflict to 409 keeps doing so without knowing this type exists.
+func (e *RelationshipConflictError) Is(target error) bool { return target == apperrors.ErrConflict }
+
+// mapRelationshipConstraint turns the insert's constraint failures into
+// typed input errors: the rel_* CHECKs are the kind→endpoint shape rules
+// (migration 0007) — bad input, not a fault — and the partial unique
+// indexes are the edge dedupe rules (a second identical edge conflicts
+// with the existing one). Anything else surfaces unchanged.
+func mapRelationshipConstraint(err error, kind string) error {
+	if constraint, ok := storekit.CheckViolation(err); ok {
+		switch constraint {
+		case "rel_employment_shape", "rel_stakeholder_shape", "rel_partner_shape", "rel_project_stakeholder_shape":
+			return &RelationshipShapeError{Kind: kind}
+		case "rel_dates":
+			return &RelationshipDatesError{}
+		}
+	}
+	if constraint, ok := storekit.UniqueViolation(err); ok {
+		switch constraint {
+		case "uq_rel_current_primary_employer", "uq_rel_deal_person_role", projectStakeholderUnique:
+			return &RelationshipConflictError{Constraint: constraint}
+		}
+	}
+	return err
 }

--- a/backend/internal/modules/people/requiredids_test.go
+++ b/backend/internal/modules/people/requiredids_test.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+// A required body id the caller omitted must be named as a missing argument, not
+// discovered as a missing row.
+//
+// oapi-codegen renders a REQUIRED body id as a non-pointer UUID and
+// encoding/json leaves an absent key at the zero value with no error, so the
+// zero UUID used to travel to a lookup, match nothing, and answer a bare
+// not-found — telling the caller a record they never mentioned does not exist.
+//
+// The guard sits at the store entry point, which is the door every transport
+// comes through, and it runs BEFORE any authority check or query — which is why
+// these probes need no database and no actor: a store over a nil pool never
+// reaches one.
+//
+// The refusal's SHAPE (422, the field named, the stable `required` code, and that
+// it classifies on both surfaces) is proven once in
+// platform/httperr/requirebodyid_test.go. What is left here is the only question
+// this package can answer: is the guard actually called for my body.
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/platform/httperr"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// assertNamesTheOmittedID asserts the observable property: the caller's mistake,
+// with the wire field they omitted named.
+func assertNamesTheOmittedID(t *testing.T, err error, field string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("an absent %s was accepted, so the caller is sent looking for a record it never named", field)
+	}
+	fault, ok := httperr.Classify(err)
+	if !ok {
+		t.Fatalf("an absent %s answered %v, which is outside the taxonomy — a surface would report the "+
+			"caller's own omission as an internal server fault", field, err)
+	}
+	if fault.Status != http.StatusUnprocessableEntity {
+		t.Errorf("an absent %s answered status %d, want 422 (404 is the defect this closes)", field, fault.Status)
+	}
+	for _, refusal := range fault.Fields {
+		if refusal.Field == field {
+			return
+		}
+	}
+	t.Errorf("the refusal for an absent %s names %+v, want the wire field %q", field, fault.Fields, field)
+}
+
+func TestAnOmittedMergeTargetOrStakeholderIsNamed(t *testing.T) {
+	// MergePersonJSONBody.target_id, MergeOrganizationJSONBody.target_id and
+	// SetProjectStakeholderRequest.person_id.
+	//
+	// The merge pair is the sharp case: the self-merge guard next to it does NOT
+	// catch an omitted target, because a real source id never equals the zero
+	// one — so the zero id reached the pair lock and answered not-found for a
+	// survivor nobody named.
+	store := NewStore(nil)
+	ctx := context.Background()
+
+	_, err := store.MergePerson(ctx, ids.New[ids.PersonKind](), ids.PersonID{})
+	assertNamesTheOmittedID(t, err, "target_id")
+
+	_, err = store.MergeOrganization(ctx, ids.New[ids.OrganizationKind](), ids.OrganizationID{})
+	assertNamesTheOmittedID(t, err, "target_id")
+
+	_, err = store.SetProjectStakeholder(ctx, SetProjectStakeholderInput{
+		ProjectID: ids.New[ids.ProjectKind](), Role: "sponsor",
+	})
+	assertNamesTheOmittedID(t, err, "person_id")
+}

--- a/backend/internal/modules/people/requiredids_test.go
+++ b/backend/internal/modules/people/requiredids_test.go
@@ -4,54 +4,25 @@
 package people
 
 // A required body id the caller omitted must be named as a missing argument, not
-// discovered as a missing row.
+// discovered as a missing row: an absent key decodes to the zero UUID with no
+// error, so unguarded it reaches a lookup, matches nothing, and answers a bare
+// not-found for a record the caller never mentioned.
 //
-// oapi-codegen renders a REQUIRED body id as a non-pointer UUID and
-// encoding/json leaves an absent key at the zero value with no error, so the
-// zero UUID used to travel to a lookup, match nothing, and answer a bare
-// not-found — telling the caller a record they never mentioned does not exist.
+// The guard is at the store entry point — the door every transport comes through —
+// and it runs BEFORE any authority check or query, which is why these probes need
+// no database and no actor: a store over a nil pool never reaches one.
 //
-// The guard sits at the store entry point, which is the door every transport
-// comes through, and it runs BEFORE any authority check or query — which is why
-// these probes need no database and no actor: a store over a nil pool never
-// reaches one.
-//
-// The refusal's SHAPE (422, the field named, the stable `required` code, and that
-// it classifies on both surfaces) is proven once in
-// platform/httperr/requirebodyid_test.go. What is left here is the only question
-// this package can answer: is the guard actually called for my body.
+// The refusal's SHAPE is proven once in platform/httperr/requirebodyid_test.go and
+// asserted here through faulttest. What is left is the only question this package
+// can answer: is the guard actually called for my body.
 
 import (
 	"context"
-	"net/http"
 	"testing"
 
-	"github.com/gradionhq/margince/backend/internal/platform/httperr"
+	"github.com/gradionhq/margince/backend/internal/platform/httperr/faulttest"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
-
-// assertNamesTheOmittedID asserts the observable property: the caller's mistake,
-// with the wire field they omitted named.
-func assertNamesTheOmittedID(t *testing.T, err error, field string) {
-	t.Helper()
-	if err == nil {
-		t.Fatalf("an absent %s was accepted, so the caller is sent looking for a record it never named", field)
-	}
-	fault, ok := httperr.Classify(err)
-	if !ok {
-		t.Fatalf("an absent %s answered %v, which is outside the taxonomy — a surface would report the "+
-			"caller's own omission as an internal server fault", field, err)
-	}
-	if fault.Status != http.StatusUnprocessableEntity {
-		t.Errorf("an absent %s answered status %d, want 422 (404 is the defect this closes)", field, fault.Status)
-	}
-	for _, refusal := range fault.Fields {
-		if refusal.Field == field {
-			return
-		}
-	}
-	t.Errorf("the refusal for an absent %s names %+v, want the wire field %q", field, fault.Fields, field)
-}
 
 func TestAnOmittedMergeTargetOrStakeholderIsNamed(t *testing.T) {
 	// MergePersonJSONBody.target_id, MergeOrganizationJSONBody.target_id and
@@ -65,13 +36,13 @@ func TestAnOmittedMergeTargetOrStakeholderIsNamed(t *testing.T) {
 	ctx := context.Background()
 
 	_, err := store.MergePerson(ctx, ids.New[ids.PersonKind](), ids.PersonID{})
-	assertNamesTheOmittedID(t, err, "target_id")
+	faulttest.AssertNamesOmittedID(t, err, "target_id")
 
 	_, err = store.MergeOrganization(ctx, ids.New[ids.OrganizationKind](), ids.OrganizationID{})
-	assertNamesTheOmittedID(t, err, "target_id")
+	faulttest.AssertNamesOmittedID(t, err, "target_id")
 
 	_, err = store.SetProjectStakeholder(ctx, SetProjectStakeholderInput{
 		ProjectID: ids.New[ids.ProjectKind](), Role: "sponsor",
 	})
-	assertNamesTheOmittedID(t, err, "person_id")
+	faulttest.AssertNamesOmittedID(t, err, "person_id")
 }

--- a/backend/internal/modules/webhooks/deliveryvisibility.go
+++ b/backend/internal/modules/webhooks/deliveryvisibility.go
@@ -345,6 +345,13 @@ func (s *Store) approvalTargetVisible(ctx context.Context, targetType string, ta
 		return s.rowScopedVisible(ctx, "activity", func(c context.Context, tx pgx.Tx) error {
 			return auth.EnsureActivityVisible(c, tx, targetID)
 		})
+	case "relationship":
+		// An edge inherits the CONJUNCTION of its endpoints' scope. The object-read
+		// floor is `relationship`, matching every other row-scoped arm here — the
+		// endpoint reads are the clause's own business.
+		return s.rowScopedVisible(ctx, "relationship", func(c context.Context, tx pgx.Tx) error {
+			return auth.EnsureRelationshipVisible(c, tx, targetID)
+		})
 	case "product":
 		// Rate-card products are workspace-shared config with no row scope —
 		// existence is the floor (approvals.targetVisible); an archived product

--- a/backend/internal/platform/auth/inheritedscope.go
+++ b/backend/internal/platform/auth/inheritedscope.go
@@ -13,6 +13,7 @@ package auth
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/jackc/pgx/v5"
 
@@ -174,6 +175,104 @@ func EnsureActivityVisibleLive(ctx context.Context, tx pgx.Tx, id ids.UUID) erro
 func probeExistsLive(ctx context.Context, tx pgx.Tx, from, alias string, idPos int, clause string, args []any) error {
 	q := fmt.Sprintf(`SELECT EXISTS (SELECT 1 FROM %s WHERE %s.id = $%d AND %s.archived_at IS NULL`,
 		from, alias, idPos, alias)
+	if clause != "" {
+		q += " AND " + clause
+	}
+	q += ")"
+
+	var visible bool
+	if err := tx.QueryRow(ctx, q, args...).Scan(&visible); err != nil {
+		return err
+	}
+	if !visible {
+		return apperrors.ErrNotFound
+	}
+	return nil
+}
+
+// RelationshipEndpointScope is the edge analogue: a relationship owns no
+// owner_id, and its sensitivity is the CONJUNCTION of its endpoints' — an edge
+// names two records, so one readable by someone who cannot read either end would
+// disclose that record's existence and its link to the other.
+//
+// Every non-null endpoint must be visible under the caller's row scope, on read
+// exactly as on write. Only a caller unbounded over EVERY endpoint table carries
+// no clause; person and organization hold capture privacy, so that is the system
+// principal alone.
+//
+// It lives here rather than in people for the reason the two rules above do:
+// scope policy has exactly one spelling (ADR-0054 §8), and this rule now has two
+// readers in different modules — people's own list and read SQL, and the
+// approvals inbox, which must decide whether a staged archive of an edge is
+// visible to the human being asked to approve it. A second copy of a conjunction
+// is a second place for one of its five arms to be forgotten.
+//
+// alias names the relationship table in the outer query.
+func RelationshipEndpointScope(ctx context.Context, alias string, arg func(any) int) (string, error) {
+	p, err := rbacActor(ctx)
+	if err != nil {
+		return "", err
+	}
+	if UnboundedFor(p, relationshipEndpoints()...) {
+		return "", nil
+	}
+	clauses := make([]string, 0, len(relationshipEndpointColumns))
+	for _, endpoint := range relationshipEndpointColumns {
+		predicate := VisiblePredicate(p, endpoint.table, arg)
+		clauses = append(clauses, fmt.Sprintf(
+			`(%[1]s.%[2]s IS NULL OR EXISTS (
+			   SELECT 1 FROM %[3]s ep WHERE ep.id = %[1]s.%[2]s AND ep.archived_at IS NULL AND %[4]s))`,
+			alias, endpoint.column, endpoint.table, predicate("ep"),
+		))
+	}
+	return "(" + strings.Join(clauses, " AND ") + ")", nil
+}
+
+// relationshipEndpointColumns is every endpoint an edge can carry, paired with
+// the table it points at. Two columns point at `organization`, which is why this
+// is a slice and not a map.
+var relationshipEndpointColumns = []struct{ column, table string }{
+	{"person_id", tablePerson},
+	{"organization_id", tableOrganization},
+	{"counterparty_org_id", tableOrganization},
+	{"deal_id", tableDeal},
+	{"project_id", tableProject},
+}
+
+// relationshipEndpoints is the distinct endpoint TABLES, for the unbounded
+// short-circuit. Derived from the column list so the two cannot disagree about
+// which tables an edge can reach.
+func relationshipEndpoints() []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(relationshipEndpointColumns))
+	for _, endpoint := range relationshipEndpointColumns {
+		if seen[endpoint.table] {
+			continue
+		}
+		seen[endpoint.table] = true
+		out = append(out, endpoint.table)
+	}
+	return out
+}
+
+// EnsureRelationshipVisible probes one edge under the endpoint-conjunction rule.
+// Absence and out-of-scope answer identically (existence-hiding), which is what
+// lets the approvals inbox ask "may this human see the edge this archive targets"
+// without disclosing that the edge exists.
+//
+// Archived edges still answer visible, matching the clause the owning store uses:
+// an approval staged against an edge that was archived in the meantime stays
+// DECIDABLE, so a human can reject it rather than find an undecidable row.
+func EnsureRelationshipVisible(ctx context.Context, tx pgx.Tx, id ids.UUID) error {
+	var args []any
+	arg := func(v any) int { args = append(args, v); return len(args) }
+	idPos := arg(id)
+
+	clause, err := RelationshipEndpointScope(ctx, "r", arg)
+	if err != nil {
+		return err
+	}
+	q := fmt.Sprintf(`SELECT EXISTS (SELECT 1 FROM relationship r WHERE r.id = $%d`, idPos)
 	if clause != "" {
 		q += " AND " + clause
 	}

--- a/backend/internal/platform/httperr/faulttest/faulttest.go
+++ b/backend/internal/platform/httperr/faulttest/faulttest.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// Package faulttest is the shared assertion for a refusal that must name the
+// input at fault.
+//
+// It lives in the platform tier beside the taxonomy it reads, because the
+// question it answers belongs to that taxonomy and not to any module: does this
+// error classify, does it classify as the CALLER's mistake, and does it name the
+// wire field they must change. Eight modules make refusals of that shape and each
+// had its own copy of the check — so the rule was spelled once in production code
+// and eight times in tests, which is one place to fix a defect and eight to
+// forget.
+package faulttest
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/platform/httperr"
+)
+
+// AssertNamesField asserts that err is a 4xx the caller can act on, whose
+// per-field breakdown names field.
+//
+// The OBSERVABLE property, not a concrete error type, and deliberately: there are
+// several legitimate carriers — a module's own FieldFault error, httperr's
+// Validation, httperr.RequireBodyID — and a caller cannot tell them apart, which
+// is the whole point of the taxonomy. A test pinned to one carrier fails when a
+// refusal is correctly re-homed.
+func AssertNamesField(t *testing.T, err error, field string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("a request missing %s was accepted", field)
+	}
+	fault, ok := httperr.Classify(err)
+	if !ok {
+		t.Fatalf("the refusal for %s is %v, which is outside the taxonomy — every surface would report "+
+			"the caller's own mistake as an internal server fault, with advice to retry a call the "+
+			"server has already settled", field, err)
+	}
+	if fault.Status < 400 || fault.Status >= 500 {
+		t.Errorf("the refusal for %s answers status %d, want a 4xx — this is the caller's mistake",
+			field, fault.Status)
+	}
+	for _, refusal := range fault.Fields {
+		if refusal.Field == field {
+			return
+		}
+	}
+	t.Errorf("the refusal for %s names %+v, want the wire field %q — the name is what a caller branches "+
+		"on and what a model reads back", field, fault.Fields, field)
+}
+
+// AssertNamesOmittedID is AssertNamesField for the specific case of a required
+// body id the caller left out. It adds the one thing that case owes on top: the
+// status must be 422 and not the 404 it used to be, because a not-found sends the
+// caller looking for a record they never named.
+func AssertNamesOmittedID(t *testing.T, err error, field string) {
+	t.Helper()
+	AssertNamesField(t, err, field)
+	if err == nil {
+		return
+	}
+	if fault, ok := httperr.Classify(err); ok && fault.Status == http.StatusNotFound {
+		t.Errorf("an omitted %s answered 404 — that is the defect this guard closes, not the fix", field)
+	}
+}

--- a/backend/internal/platform/httperr/faulttest/faulttest.go
+++ b/backend/internal/platform/httperr/faulttest/faulttest.go
@@ -52,17 +52,23 @@ func AssertNamesField(t *testing.T, err error, field string) {
 		"on and what a model reads back", field, fault.Fields, field)
 }
 
-// AssertNamesOmittedID is AssertNamesField for the specific case of a required
-// body id the caller left out. It adds the one thing that case owes on top: the
-// status must be 422 and not the 404 it used to be, because a not-found sends the
-// caller looking for a record they never named.
+// AssertNamesOmittedID is AssertNamesField for a required body id the caller left
+// out, and it pins the status EXACTLY rather than to the 4xx band.
+//
+// 422 is the claim: the body was well-formed and one required value was absent. A
+// 404 is the specific answer this guard class exists to stop — it sends the caller
+// looking for a record they never named — but a 400 or a 409 would be wrong too,
+// and the local copies this replaced all asserted the exact code. A consolidation
+// that widened the assertion would have quietly weakened six suites.
 func AssertNamesOmittedID(t *testing.T, err error, field string) {
 	t.Helper()
 	AssertNamesField(t, err, field)
-	if err == nil {
-		return
+	fault, ok := httperr.Classify(err)
+	if !ok {
+		return // AssertNamesField has already failed the test on this
 	}
-	if fault, ok := httperr.Classify(err); ok && fault.Status == http.StatusNotFound {
-		t.Errorf("an omitted %s answered 404 — that is the defect this guard closes, not the fix", field)
+	if fault.Status != http.StatusUnprocessableEntity {
+		t.Errorf("an omitted %s answered status %d, want exactly 422 — the body is well-formed and one "+
+			"required value is missing", field, fault.Status)
 	}
 }

--- a/backend/internal/platform/httperr/httperr.go
+++ b/backend/internal/platform/httperr/httperr.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/values"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
 )
@@ -406,6 +407,33 @@ func Validation(field, code, message string) *DetailedError {
 		Detail: message,
 		Fields: []FieldError{{Field: field, Code: code, Message: message}},
 	}
+}
+
+// RequireBodyID refuses a required body id the caller simply omitted, naming the
+// wire field. Nil when the id is present.
+//
+// The defect it closes is the generator's: oapi-codegen renders a REQUIRED body
+// id as a non-pointer UUID, and encoding/json leaves an absent key at the zero
+// value with no error. So "required" in the contract is a claim only this check
+// makes true — and what made it worth a named helper is where the zero value
+// LANDS. It reaches a lookup or a link-target probe, matches no row, and comes
+// back as a bare not-found: the caller is told a record it never mentioned does
+// not exist, on a request whose real fault was an absent key.
+//
+// It lives here rather than per-module because Classify matches *DetailedError
+// before anything else, so one call answers a 422 naming the field on REST AND
+// the same field-named sentence on the MCP tool surface — which never runs a
+// module's HTTP mapper. A module error type per caller would be a second
+// spelling of a rule whose wire output is byte-identical.
+//
+// The id arrives as ids.UUID: this package deliberately does not import the
+// generated contracts, so the openapi_types.UUID conversion happens at the call
+// site, where the contract type legally lives.
+func RequireBodyID(field string, id ids.UUID) error {
+	if id.IsZero() {
+		return Validation(field, "required", field+" is required")
+	}
+	return nil
 }
 
 // fieldDetails renders the per-field breakdown into the contract's

--- a/backend/internal/platform/httperr/requirebodyid_test.go
+++ b/backend/internal/platform/httperr/requirebodyid_test.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package httperr
+
+// The SHAPE of a missing-required-id refusal, proven once.
+//
+// This is the half that used to be re-proven in every module: that the refusal
+// is a 422, that it names the wire field, that its code is stable, and that it
+// classifies — which is what decides whether the MCP tool surface reads a
+// sentence an agent can act on or "the tool failed for an internal reason".
+// There is one implementation now, so there is one place to assert it, and each
+// module's own probe is left with the question only it can answer: is the guard
+// actually called for my body.
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+func TestRequireBodyIDNamesTheFieldAndClassifiesAsTheCallersMistake(t *testing.T) {
+	err := RequireBodyID("to_stage_id", ids.UUID{})
+	if err == nil {
+		t.Fatal("a zero id was accepted — an absent required key decodes to exactly this value")
+	}
+
+	fault, ok := Classify(err)
+	if !ok {
+		t.Fatalf("err = %v is outside the taxonomy, so a surface reporting it would call the caller's "+
+			"own omission an internal server fault", err)
+	}
+	if fault.Status != http.StatusUnprocessableEntity {
+		t.Errorf("status = %d, want 422 — the body is well-formed and one required value is missing",
+			fault.Status)
+	}
+	if len(fault.Fields) != 1 {
+		t.Fatalf("fields = %+v, want exactly one naming the omitted id", fault.Fields)
+	}
+	if got := fault.Fields[0].Field; got != "to_stage_id" {
+		t.Errorf("field = %q, want the wire path to_stage_id — a caller branches on this", got)
+	}
+	if got := fault.Fields[0].Code; got != "required" {
+		t.Errorf("code = %q, want the stable machine code `required`", got)
+	}
+}
+
+// The refusal must not be a not-found, because that is the answer it exists to
+// replace: a caller told "not found" for an id they never sent goes looking for a
+// record instead of at their own request.
+func TestRequireBodyIDIsNotANotFound(t *testing.T) {
+	fault, _ := Classify(RequireBodyID("purpose_id", ids.UUID{}))
+	if fault.Status == http.StatusNotFound {
+		t.Error("an omitted required id answered 404 — the defect, not the fix")
+	}
+}
+
+func TestRequireBodyIDPassesAnIDThatIsPresent(t *testing.T) {
+	// The control. A guard that refused everything would satisfy the assertions
+	// above and break every write on the surface.
+	if err := RequireBodyID("record_id", ids.NewV7()); err != nil {
+		t.Errorf("a supplied id was refused: %v", err)
+	}
+}
+
+// Existence-hiding is the thing this class of fix must not break: making a
+// refusal clearer must not turn it into a probe for whether a record exists. A
+// SUPPLIED id that names nothing visible still has to reach the lookup and come
+// back as a 404, so the guard must be silent about any id it is given.
+func TestRequireBodyIDSaysNothingAboutWhetherAnIDExists(t *testing.T) {
+	for _, id := range []ids.UUID{ids.NewV7(), ids.NewV7()} {
+		if err := RequireBodyID("record_id", id); err != nil {
+			t.Fatalf("the guard refused a well-formed id %s (%v) — it would then be answering a "+
+				"question about existence, which belongs to the row-scoped lookup", id, err)
+		}
+	}
+}
+
+// The sentence a caller reads, and it has to name the field: both surfaces
+// render Detail, and the MCP one renders ONLY that — a structured fields array
+// an agent never sees is not an explanation.
+func TestRequireBodyIDSaysWhichFieldInTheDetailBothSurfacesRender(t *testing.T) {
+	fault, ok := Classify(RequireBodyID("subject_id", ids.UUID{}))
+	if !ok {
+		t.Fatal("the refusal does not classify")
+	}
+	if want := "subject_id is required"; fault.Detail != want {
+		t.Errorf("detail = %q, want %q", fault.Detail, want)
+	}
+	// And the verdict survives WRAPPING, because a module that adds context with
+	// %w must not have to know which concrete type carries it.
+	wrapped := fmt.Errorf("mapping the advance body: %w", RequireBodyID("to_stage_id", ids.UUID{}))
+	var detailed *DetailedError
+	if !errors.As(wrapped, &detailed) {
+		t.Fatal("the refusal does not survive wrapping, so a module that adds context loses the verdict")
+	}
+	if wrappedFault, ok := Classify(wrapped); !ok || len(wrappedFault.Fields) != 1 {
+		t.Errorf("a wrapped refusal classified as (%+v, %v), want the field list intact", wrappedFault, ok)
+	}
+}

--- a/backend/internal/shared/ports/datasource/datasource.go
+++ b/backend/internal/shared/ports/datasource/datasource.go
@@ -27,14 +27,40 @@ const (
 	EntityLead         EntityType = "lead"
 	EntityActivity     EntityType = "activity"
 	EntityProject      EntityType = "project"
+	// EntityRelationship is an EDGE between two records — employment, a deal
+	// or project stakeholder seat, an org↔org partner tie. It belongs in THIS
+	// vocabulary and deliberately not in RecordType below: the seam's record
+	// verbs serve it, but nothing points AT an edge. You cannot tag one, add
+	// one to a list, link an activity to it, or grant access to it — so adding
+	// a RecordRelationship would widen five polymorphic columns to hold a
+	// target that has no meaning.
+	//
+	// Declaring this constant is what obliges all four EntityType-bound
+	// schema CHECKs (attachment, embedding, field_provenance, custom_field) to
+	// carry 'relationship' too: TestEveryDomainEnumMatchesItsSchemaCheck
+	// derives the Go set from every constant of this type declared in the
+	// package, so there is no way to add one and widen only some of them.
+	// migrations/core/0171 is that reconciliation, and says what each widening
+	// does and does not open.
+	EntityRelationship EntityType = "relationship"
 )
 
 // EntityTypes returns the vocabulary in a stable order, for the callers
-// that enumerate it — the custom-field target set, the embedding lanes,
-// the provenance surfaces — rather than branch on a single value. It hands
-// back a fresh slice so no caller can widen the vocabulary for the others.
+// that enumerate it — the embedding lanes, the provenance surfaces, the
+// description order the tool schemas render in — rather than branch on a
+// single value. It hands back a fresh slice so no caller can widen the
+// vocabulary for the others.
+//
+// It is NOT the custom-field target set any more. That set is now spelled
+// explicitly in customfields.FieldObjects, because a type belongs there only
+// if its store reads cf_* columns AND its contract shapes carry them — two
+// properties this vocabulary says nothing about. Deriving acceptance from it
+// is how `object=activity` came to be creatable and never served.
 func EntityTypes() []EntityType {
-	return []EntityType{EntityPerson, EntityOrganization, EntityDeal, EntityLead, EntityActivity, EntityProject}
+	return []EntityType{
+		EntityPerson, EntityOrganization, EntityDeal, EntityLead,
+		EntityActivity, EntityProject, EntityRelationship,
+	}
 }
 
 // RecordType names the entity types that are records — EntityType minus
@@ -101,9 +127,11 @@ type SystemOfRecordProvider interface {
 	Create(ctx context.Context, in CreateInput) (EntityRef, error)
 	Update(ctx context.Context, in UpdateInput) (EntityRef, error)
 	AdvanceDeal(ctx context.Context, in AdvanceDealInput) (EntityRef, error)
-	// Archive soft-deletes one person/organization/deal (🟡 on the tool
-	// surface: a visibility change is hard to undo for whoever needed the
-	// row). Leads leave through their own lifecycle verbs.
+	// Archive soft-deletes one person/organization/deal/project, or one
+	// relationship edge (🟡 on the tool surface: a visibility change is hard to
+	// undo for whoever needed the row). Leads leave through their own lifecycle
+	// verbs. Archiving an edge is how a person's employment ENDS on this seam —
+	// an edge's endpoints are what it is, so they are never patched.
 	Archive(ctx context.Context, ref EntityRef) (EntityRef, error)
 	// Merge folds source into target (person/organization only), non-lossy,
 	// and returns the survivor's ref (features/01 §1.3). 🟡 on the tool

--- a/backend/internal/shared/ports/datasource/datasource.go
+++ b/backend/internal/shared/ports/datasource/datasource.go
@@ -64,11 +64,12 @@ func EntityTypes() []EntityType {
 }
 
 // RecordType names the entity types that are records — EntityType minus
-// activity, which is a timeline event and so is never itself a grouping
-// target. It is the one vocabulary behind every polymorphic reference TO a
-// record: activity links, list membership, tags, saved views and record
-// grants all spell their target with this set, and each of those columns'
-// CHECK constraints is pinned to it by TestEveryDomainEnumMatchesItsSchemaCheck.
+// activity (a timeline event) and relationship (an edge: nothing points AT one),
+// neither of which is ever itself a grouping target. It is the one vocabulary
+// behind every polymorphic reference TO a record: activity links, list
+// membership, tags, saved views and record grants all spell their target with
+// this set, and each of those columns' CHECK constraints is pinned to it by
+// TestEveryDomainEnumMatchesItsSchemaCheck.
 type RecordType string
 
 // The record vocabulary. Each value is mirrored by a schema CHECK, pinned

--- a/backend/internal/shared/ports/datasource/util.go
+++ b/backend/internal/shared/ports/datasource/util.go
@@ -26,14 +26,12 @@ import (
 // than as the set being denied.
 type UnsupportedEntityError struct{ Type string }
 
-// Error says which of the two claims it is making. "known types are …" said
-// only one of them, and the vocabulary it renders now contains a member no
-// provider serves every verb for: `relationship` has record verbs and no
-// search, no schema descriptor, no attachment writer. So that phrasing produced
-// a sentence refusing relationship WHILE listing relationship as available —
-// each hand-listed default branch would have emitted it. Naming the vocabulary
-// as a vocabulary keeps the hint (a caller learns the spelling) without the
-// implied promise that every member reaches every verb.
+// Error makes two claims and keeps them apart, because the vocabulary contains a
+// member no provider serves every verb for: `relationship` has record verbs and
+// no search, no schema descriptor, no attachment writer. So the hint names the
+// vocabulary AS a vocabulary — a caller learns the spelling — without the implied
+// promise that every member reaches every verb. Phrased as "the types served
+// here", the sentence would refuse relationship while listing it as available.
 func (e *UnsupportedEntityError) Error() string {
 	return "entity_type " + e.Type + " is not served here; the vocabulary is " + entityVocabulary +
 		", and a valid type can name a verb or provider that does not serve it"

--- a/backend/internal/shared/ports/datasource/util.go
+++ b/backend/internal/shared/ports/datasource/util.go
@@ -26,8 +26,17 @@ import (
 // than as the set being denied.
 type UnsupportedEntityError struct{ Type string }
 
+// Error says which of the two claims it is making. "known types are …" said
+// only one of them, and the vocabulary it renders now contains a member no
+// provider serves every verb for: `relationship` has record verbs and no
+// search, no schema descriptor, no attachment writer. So that phrasing produced
+// a sentence refusing relationship WHILE listing relationship as available —
+// each hand-listed default branch would have emitted it. Naming the vocabulary
+// as a vocabulary keeps the hint (a caller learns the spelling) without the
+// implied promise that every member reaches every verb.
 func (e *UnsupportedEntityError) Error() string {
-	return "entity_type " + e.Type + " is not served here; known types are " + entityVocabulary
+	return "entity_type " + e.Type + " is not served here; the vocabulary is " + entityVocabulary +
+		", and a valid type can name a verb or provider that does not serve it"
 }
 
 // entityVocabulary renders the known set from EntityTypes rather than

--- a/backend/migrations/core/0171_relationship_entity_type.down.sql
+++ b/backend/migrations/core/0171_relationship_entity_type.down.sql
@@ -1,0 +1,32 @@
+-- Reverses 0171. The relationship-typed ROWS go first, then the vocabularies
+-- narrow back.
+--
+-- That order is forced: ADD CONSTRAINT ... CHECK validates the rows already in
+-- the table, so narrowing a vocabulary while a 'relationship' row still holds it
+-- aborts the whole rollback. On a fresh schema there is nothing to find and
+-- either order appears to work, which is exactly why it is stated here rather
+-- than discovered on the one database that has data.
+--
+-- Deleting them is the honest reverse: without the vocabulary these rows cannot
+-- be written, and none of them is the edge itself — each is something hung OFF
+-- an edge, so the relationship table is untouched.
+DELETE FROM custom_field     WHERE object      = 'relationship';
+DELETE FROM field_provenance WHERE object_type = 'relationship';
+DELETE FROM embedding        WHERE entity_type = 'relationship';
+DELETE FROM attachment       WHERE entity_type = 'relationship';
+
+ALTER TABLE custom_field DROP CONSTRAINT custom_field_object_check;
+ALTER TABLE custom_field ADD CONSTRAINT custom_field_object_check
+  CHECK (object IN ('person','organization','deal','lead','activity','project'));
+
+ALTER TABLE field_provenance DROP CONSTRAINT field_provenance_object_type_check;
+ALTER TABLE field_provenance ADD CONSTRAINT field_provenance_object_type_check
+  CHECK (object_type IN ('person','organization','deal','lead','activity','project'));
+
+ALTER TABLE embedding DROP CONSTRAINT embedding_entity_type_check;
+ALTER TABLE embedding ADD CONSTRAINT embedding_entity_type_check
+  CHECK (entity_type IN ('person','organization','deal','lead','activity','project'));
+
+ALTER TABLE attachment DROP CONSTRAINT attachment_entity_type_check;
+ALTER TABLE attachment ADD CONSTRAINT attachment_entity_type_check
+  CHECK (entity_type IN ('person','organization','deal','lead','activity','project'));

--- a/backend/migrations/core/0171_relationship_entity_type.up.sql
+++ b/backend/migrations/core/0171_relationship_entity_type.up.sql
@@ -1,0 +1,52 @@
+-- Relationship joins the EntityType vocabulary.
+--
+-- An edge becomes a first-class resource on the record verbs (create, read,
+-- update, archive through the datasource seam), which means the Go constant
+-- datasource.EntityRelationship now exists — and
+-- TestEveryDomainEnumMatchesItsSchemaCheck derives the EntityType set from
+-- every constant of that type DECLARED in the package, not from EntityTypes().
+-- So all four EntityType-bound CHECKs widen together or none of them may: there
+-- is no additive option that widens three.
+--
+-- What widening each CHECK actually opens is a separate question, answered one
+-- level up at each facility's own acceptance gate, and for three of the four the
+-- answer is "nothing":
+--
+--   attachment.entity_type      the contract's own enum Valid() stays closed, so
+--                               an upload for an edge still 422s honestly
+--   embedding.entity_type       the embed lanes (searchBranches/embedText) stay
+--                               closed, and edges emit no relationship.* events,
+--                               so no writer can exist
+--   field_provenance.object_type  the writers pass hardcoded literals; the
+--                               relationship row's own source/captured_by
+--                               already carry its provenance
+--   custom_field.object         customfields.FieldObjects is the gate, and it is
+--                               now an EXPLICIT list that excludes relationship
+--                               (and activity) for want of contract carriage and
+--                               store wiring — see the engine's own comment
+--
+-- The CHECK therefore ends up WIDER than the custom-field engine's allowlist,
+-- which is the same posture the other three already have and is safe because the
+-- engine is that table's only writer. Custom fields on edges is deliberately its
+-- own future change, and it starts with a privacy question (does a cf_* column
+-- on an edge make `relationship` a piiTables member?), not with an ALTER.
+--
+-- Additive only (ADR-0017): drop and re-add each CHECK wider, exactly as
+-- 0131_project did for the same four columns. RecordType is untouched —
+-- an edge is not a record you can tag, list, or link an activity to.
+
+ALTER TABLE attachment DROP CONSTRAINT attachment_entity_type_check;
+ALTER TABLE attachment ADD CONSTRAINT attachment_entity_type_check
+  CHECK (entity_type IN ('person','organization','deal','lead','activity','project','relationship'));
+
+ALTER TABLE embedding DROP CONSTRAINT embedding_entity_type_check;
+ALTER TABLE embedding ADD CONSTRAINT embedding_entity_type_check
+  CHECK (entity_type IN ('person','organization','deal','lead','activity','project','relationship'));
+
+ALTER TABLE field_provenance DROP CONSTRAINT field_provenance_object_type_check;
+ALTER TABLE field_provenance ADD CONSTRAINT field_provenance_object_type_check
+  CHECK (object_type IN ('person','organization','deal','lead','activity','project','relationship'));
+
+ALTER TABLE custom_field DROP CONSTRAINT custom_field_object_check;
+ALTER TABLE custom_field ADD CONSTRAINT custom_field_object_check
+  CHECK (object IN ('person','organization','deal','lead','activity','project','relationship'));

--- a/backend/requiredbodyids_test.go
+++ b/backend/requiredbodyids_test.go
@@ -20,10 +20,11 @@ package backendarch
 // fails here until someone decides which it is, and a waiver that stops being
 // true fails too — so the list of unguarded bodies can only shrink.
 //
-// Why a waiver list at all: the guarded pair sits in the deals mapping that both
-// transports share, and the rest each need their own REST mapping touched. Naming
-// them is what keeps the invariant from being quietly half-stated while the tool
-// surface alone is fixed.
+// Where the guard goes: httperr.RequireBodyID is the one implementation, called
+// from the point where the decoded body becomes store input — a mapping where the
+// module has one (deals), the store entry point where it does not, because that is
+// the door every transport comes through. Never in the HTTP handler alone, which
+// is what left the MCP twin and the REST route answering differently.
 
 import (
 	"go/ast"
@@ -40,31 +41,42 @@ const generatedContract = "internal/contracts/api_gen.go"
 // name today, proved by TestEveryRequiredBodyIDIsNamedWhenAbsent in the module
 // that owns the mapping.
 var probedRequiredIDBodies = map[string]bool{
-	"CreateDealRequest":    true,
-	"CreateProjectRequest": true,
+	"CreateDealRequest":            true,
+	"CreateProjectRequest":         true,
+	"AdvanceDealRequest":           true,
+	"CreateStageRequest":           true,
+	"AddListMemberRequest":         true,
+	"ApplyTagRequest":              true,
+	"RecordConsentRequest":         true,
+	"IssueDoubleOptInJSONBody":     true,
+	"SetProjectStakeholderRequest": true,
+	"CreateRecordGrantRequest":     true,
+	"MergePersonJSONBody":          true,
+	"MergeOrganizationJSONBody":    true,
+	"RelinkActivityJSONBody":       true,
 }
 
-// unguardedRequiredIDBodies names each body that still answers a bare not-found
-// for an id the caller never sent, with where the fix belongs. Removing an entry
-// means guarding the mapping and adding a probe beside the two above.
+// unguardedRequiredIDBodies is what is left, and both entries are WAIVERS rather
+// than gaps: neither can produce the defect. Every body that could has a guard
+// and a probe.
+//
+// The list is kept — rather than deleted along with the last real gap — because
+// the walk fails on a body it can neither find probed nor find waived. A required
+// id added upstream therefore lands here as a failure until someone decides which
+// it is, which is the difference between having fixed eleven things and having
+// closed the class.
 var unguardedRequiredIDBodies = map[string]string{
-	"AdvanceDealRequest":            "to_stage_id — deals/handlers_deal.go passes it raw. The MCP twin IS guarded at Registry.Invoke, so REST currently answers worse for the same mistake; the sharpest one to fix next",
-	"CreateStageRequest":            "pipeline_id — deals/handlers_stages.go",
-	"AddListMemberRequest":          "entity_id — collections/handlers.go, reaches auth.EnsureLinkTarget",
-	"ApplyTagRequest":               "entity_id — collections/handlers.go, reaches auth.EnsureLinkTarget",
-	"RecordConsentRequest":          "purpose_id — consent/handlers.go",
-	"IssueDoubleOptInJSONBody":      "purpose_id — consent/handlers.go",
-	"SetProjectStakeholderRequest":  "person_id — people/handlers_projectstakeholder.go",
-	"CreateRecordGrantRequest":      "record_id and subject_id — identity grants",
-	"MergePersonJSONBody":           "target_id — people/handlers_person.go; MergePerson checks source!=target and then locks the pair",
-	"MergeOrganizationJSONBody":     "target_id — people/handlers_organization.go, same shape",
-	"RelinkActivityJSONBody":        "entity_id — activities/handlers_lifecycle.go",
-	"UploadAttachmentMultipartBody": "entity_id — attachments",
 	// Not a request body at all: the GDPR data-subject-request ENTITY, whose `id`
 	// is its own primary key rather than a caller-supplied reference. Waived
 	// because the name heuristic above cannot tell the two apart, and narrowing
 	// the heuristic to exclude it would risk excluding a real body.
 	"DataSubjectRequest": "not a request body — the DSR entity; `id` is its own key, not a caller-supplied reference",
+	// Multipart never decodes into this generated type. The handler
+	// (activities/handlers_attachment.go) calls ParseMultipartForm and
+	// FormValue("entity_id"), so an absent part yields "" and ids.Parse already
+	// refuses it as a 422 naming the field. It cannot become a zero UUID reaching
+	// a lookup, which is the only hazard this gate is about.
+	"UploadAttachmentMultipartBody": "multipart; FormValue + ids.Parse already refuses an absent part as a 422",
 }
 
 func TestEveryContractBodyWithARequiredIDIsAccountedFor(t *testing.T) {

--- a/frontend/src/screens/customfields.logic.ts
+++ b/frontend/src/screens/customfields.logic.ts
@@ -12,9 +12,14 @@ export type CfType =
   | "boolean";
 
 // Chip order is normative (AC-custom-fields-2): Deal, Company, Contact, Lead.
-// PARAM-2 also pins `activity` as a target object; the screen AC enumerates
-// only these four, so we follow the screen AC and omit activity here — flagged
-// for the docs chain-rule rather than silently added.
+//
+// `activity` is not here and no longer needs a flag: the engine itself stopped
+// accepting it. Its target set (customfields.FieldObjects) is now the objects
+// whose stores read cf_* columns AND whose contract schemas carry them, and an
+// activity has neither — so a field on one was creatable and never served, and
+// this screen was the only thing hiding it. `project` DOES qualify server-side
+// and is absent here, which is a screen gap rather than a mismatch: the screen
+// AC enumerates these four.
 export const CF_OBJECTS: readonly CfObject[] = [
   "deal",
   "organization",


### PR DESCRIPTION
Three verbs the contract declares that the surface could not reach
(`.tmp/NEXT-MCP-MISSING.md` O4, O5, O14). One commit per unit, in the order that
made each testable.

## U2 — the deal verbs' ids were unobtainable (`97c802d3`)

`create_record` for a deal REQUIRES `pipeline_id` and `stage_id`, `advance_deal`
requires `to_stage_id`, and **no tool on the surface yielded one** — so PR #370's
UAT could not create a deal through `/mcp` at all. A correct refusal into a dead
end is still a dead end.

`list_pipelines` (🟢 read) answers each pipeline with its live stages nested,
carrying the `semantic` that says which stage a deal is born into and which two
close it. One tool, not two: a stage is meaningless without its pipeline.

The seam rides `deals.Store.ListPipelines`, which already carries
`auth.Require("pipeline", read)` and already nests stages inside one
`WithWorkspaceTx` — so the RBAC object applies to the tool with no second
enforcement to drift from the first. Pipelines stay **off** the datasource record
seam: config is not a record, and joining `EntityType` would enrol them in every
polymorphic reference that vocabulary governs.

Every tool that takes a pipeline or stage id now names where one comes from,
asserted by walking the registry rather than by three fixes.

## U1 — a relationship is a resource the record verbs serve (`54c1469c`)

The contract declares `create_record`, `update_record` and `archive_record` for
`relationship` at `auto_execute`. The enum omitted it and the seam had no such
entity, so `create_record` for a person could not express who they work for.
Drift, not a missing feature.

**Read is not optional and not for a read tool.** `create_record` reads the record
back, so without it the edge COMMITS and the tool reports a read-back failure — a
false failure with a real side effect. Probed by removing the case; the failure
reproduces verbatim.

**Two pre-existing defects fixed rather than copied**, both surfaced by moving the
mapping out of the handler: the create handler never read `project_id`, so REST
`POST /v1/relationships` with `kind=project_stakeholder` lost its project endpoint
and died on `rel_project_stakeholder_shape` **blaming a pair the caller had
supplied**; and `wireRelationship` never rendered it, so the edge read back without
the endpoint that defines it.

### The decision inside this unit

Declaring `EntityRelationship` obliges all four `EntityType`-bound CHECKs to widen
— `TestEveryDomainEnumMatchesItsSchemaCheck` derives the Go set from the
constant's **existence**, so there is no option that widens three. Probed:
widening three fails, naming the fourth.

Three of the four are inert (their acceptance gates stay closed). The fourth,
`custom_field.object`, had its gate derived from `EntityTypes()` and would have
opened automatically — so **`customfields.FieldObjects` is now the explicit set of
objects whose stores read `cf_*` columns AND whose contract schemas carry them.**

That also fixes a defect already on main: **`object=activity` has been accepted by
the engine and served by nobody since it shipped**, hidden only by the SPA's
picker. A new gate asserts every member's create and read shapes declare the
`additionalProperties` bag a `cf_*` value travels in, and a member with no shape
pair fails rather than being skipped — probed both ways.

⚠️ **Behaviour change:** `object=activity` now answers 422 on the custom-fields
surface (create and the list filter). That IS the fix. The SPA's `CfObject` already
excluded activity.

Custom fields on edges is deliberately deferred, because it starts with a privacy
question that **no gate goes red for**: a `relationship` row is excluded from
`piiTables` on the premise that its columns are a closed set of business facts,
and Art. 17 erasure and Art. 15 SAR are both blind to `cf_*` on an edge. Filed as
its own ticket with the analysis.

### Two smaller honesty fixes it forced

- Overlay now declares the **capability** unsupported rather than the entity
  unknown. The discriminator was `writeContractTarget`, which conflated "has a
  write shape in this switch" with "is a known entity" — so `project` and
  `relationship`, both vocabulary members, were refused with a message naming the
  vocabulary they belong to. Membership derives from `EntityTypes()` now, which
  fixes both and enrols the next one.
- `UnsupportedEntityError` stops claiming the vocabulary is the served set. With a
  member that has record verbs and no search, no schema descriptor and no
  attachment writer, `known types are …relationship…` was a sentence refusing
  relationship while listing it as available.

## U3 — eleven bodies answered a bare 404 for an id nobody sent (`9c28cb1d`)

A required body id is generated as a NON-POINTER UUID and `encoding/json` leaves an
absent key at the zero value with no error. So "required" was a claim nothing made
true: `POST /v1/deals/{id}/advance` with `{}` answered **404 for a deal that is in
the URL and exists**.

**One implementation.** `httperr.RequireBodyID` lives in the taxonomy package
because `Classify` matches `*DetailedError` first — so one call answers a 422
naming the field on REST and the same field-named sentence on MCP, which never
runs a module's HTTP mapper. Consent and identity needed no new error type for it;
`deals.requireBodyID` delegates, so the class has one implementation rather than
one plus eleven.

`unguardedRequiredIDBodies` is down to its **two waivers** — `DataSubjectRequest`
(not a body; the DSR entity, whose `id` is its own key) and
`UploadAttachmentMultipartBody` (`FormValue` + `ids.Parse` already 422s an absent
part). The list is kept, not deleted: the walk fails on a body it can neither find
probed nor find waived, so a required id added upstream lands there until someone
decides which it is.

**Existence-hiding is the thing this must not break**, and it has one way to go
wrong: if the SUPPLIED-but-invisible case also answered 422, the surface would be
an oracle for enumerating rows. So every one of the eleven is driven twice over
real HTTP — omitted → 422 naming the field, supplied and matching nothing → 404
that names nothing.

## The fourth commit: what adversarial review found

Both subagents ran against the assembled diff before push. The security half
found one real defect, and it was one this PR made reachable.

**A staged relationship archive was an authority object nobody could act on.**
`approvals.targetVisible` had no `relationship` arm, and `decidable` backs the
inbox list, the single read AND the decision — so the row was invisible and
undecidable at once, while `webhooks.approvalTargetVisible`'s matching gap
dropped the `approval.requested` fan-out that would have told anyone. An agent
retrying a legitimate refusal accumulated pending rows only the TTL cleared.

The endpoint-conjunction rule moved to `platform/auth`, where scope policy has
exactly one spelling (ADR-0054 §8) — it now has two readers in different
modules. And the class is **enumerated** rather than closed one member at a
time: a gate derives the obligation over the generated policy table, and the
**eight** confirm-first types broken the same way today (`list`, `tag`,
`project`, `record_grant`, `saved_view`, `offer_template`,
`overlay_connection`, `webhook_subscription`) are ratified waivers stating what
each costs, so the list can only shrink.

**Three craft defects, each a place where this PR's own change made a sibling
wrong:**

- The **agent gate** validated `to_stage_id` itself, so a PASSPORT read
  `"must be a stage UUID"` where a session read `"is required"` — one rule, two
  sentences, on the very field U3 unified. The session-driven suite could not
  see it because it never sent a bearer. It does now, and asserts the two are
  equal.
- `describeRecordFields` keyed the endpoint-pairing advisory on the record
  type, and **both** shape maps carry relationship — so `update_record` shipped
  the create tool's pairing rule for endpoints a patch cannot reach, and the
  branch written for the patch tool was dead.
- `recordLabel`'s `kind` fallback was added for edges and degraded every
  **activity** approval summary to a class name, suppressing the id a human
  needs to know which note is being overwritten.

Also: the nativeOnly wiring pin named its own weakness in a comment and asked
the next author to remember — it derives now, and two guards had comments that
named no tool. Plus rule 4 housekeeping: ticket numbers and fix narration out
of comments, two constants that had orphaned their function's doc,
`RecordType`'s own comment which this PR made false, and five copies of one
test assertion collapsed onto `platform/httperr/faulttest`.

**The security review also verified clean, so a re-review need not re-litigate
these:** the twelve guards fire on the zero UUID alone (no status-code oracle in
either direction), all four of migration 0171's widenings are inert with the
mechanism named for each, RLS holds, a staged archive cannot be redeemed against
a different edge, and `list_pipelines` adds no reachability a passport did not
already have over REST.

## What was verified, and how

| | |
|---|---|
| `make check-backend` | green (build, vet, lint incl. the strict new-code set, arch-lint, unit, contract drift, 500-LOC cap with **0 waivers**) |
| `make test-integration` | green — `OK: integration passed with 0 skips (28 packages, parallel)` |
| `craft static`, whole branch diff | **0 blockers, 0 majors, 0 minors** |
| `make gen` diff | none. `crm.yaml` is untouched, which was the plan's own prediction |
| Registered tools | 26 (was 25) |
| `x-mcp-tool` annotations | 114, unchanged |

**Every new or changed gate was probed by breaking what it watches**, because in
#370 three gates certified things they had never examined:

- unwire `nativeOnlyPipelines` → the overlay pin reports `{"pipelines":[]}`
  presented as an answer
- strip the stage-id pointer → the registry walk names `advance_deal`; rename the
  argument → it fails as vacuous
- admit `activity` to `FieldObjects` → the carriage gate names both its shapes; add
  a member with no shape pair → it says the gate skipped it
- widen three of four CHECKs → the enum gate names the fourth column
- remove the relationship seam Read → `write landed but read-back failed`
- remove any one of the twelve required-id guards → all twelve redden their owning
  probe

**Coverage the diff also closed, unasked:** the overlay wiring pin
(`nativeOnlyAgentTools`) had never examined `intro_path_to` or
`at_risk_relationships` despite both carrying guards, and its actor lacked the
grants a guarded read needs — so an unwired guard would have failed on RBAC rather
than on the mode.

## Known and deliberate

- **`read_record` does not advertise `relationship`** (there is no
  `GET /v1/relationships/{id}` contract op). It nonetheless WORKS, because
  `Registry.Invoke` validates uuid presence and not schema enums — the surface
  understating itself, which is the safe direction. Raised upstream as part of O13
  along with the `x-mcp-tool` annotation for the pipeline reads.
- **`list_pipelines` is a build-side verb**: `listPipelines`/`listStages` carry no
  `x-mcp-tool`. Same shape as `send_message`/`who_knows` (TG-CR-5); the annotation
  is requested upstream in the same breath.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unblocks deal and relationship flows in MCP by adding pipeline discovery, making `relationship` a first‑class record on the seam, and standardizing required‑ID validation. Also normalizes coverage responses and tightens tool docs and error handling.

- **New Features**
  - Added `list_pipelines` (read) tool returning pipelines with nested stages; enables `create_record` (deal) and `advance_deal`. Guarded to SoR only.
  - Served `relationship` via record verbs (`create_record`, `update_record`, `archive_record`) through `datasource`; read‑back implemented; mapping shared between REST and MCP.
  - Registered pipeline seam and tool; record field descriptions updated to reflect edge endpoints (create‑only).

- **Bug Fixes**
  - Coverage: `account_coverage` returns empty arrays (not nulls) for `stakeholders`, `our_side`, and `risks`; enforced at the seam boundary.
  - Required IDs and errors: unified missing‑ID checks via `httperr.RequireBodyID`; `advance_deal` now distinguishes malformed JSON, invalid UUID, and missing `to_stage_id` with consistent messages across session and passport.
  - Approvals and visibility: staged `relationship` archives are now visible/decidable; inbox/webhook visibility updated; added a DB‑level guard to include all relationship endpoint FKs in the row‑scope conjunction.
  - Custom fields: explicit target set excludes `activity`; `object=activity` now 422; UI copy aligned.
  - Tool specs and labels: corrected create/patch advisories (edge endpoints are create‑only; `activity`/`relationship` don’t carry `cf_*`), noted `read_record` can fetch a `relationship` by id (not searchable); pipeline tool uses a typed payload; activity approval labels now show the id. 
  - Overlay writes: distinguish unsupported‑by‑SoR from unknown entity; `project`/`relationship` now get the correct capability refusal.
  - Approvals map: switched decision‑grant entries to table constants to prevent drift/typos that could make staged rows undecidable.

<sup>Written for commit a9fbeecb098c2c2b6537daf0e1427ed2e7bdb948. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added relationship support for creating, updating, viewing, and archiving relationship records.
  * Added pipeline and stage discovery, including identifiers, stages, semantics, probabilities, and default status.
  * Added relationship visibility controls that respect endpoint permissions and row-level access.
  * Expanded agent tools and guidance for relationship records and deal-stage operations.

* **Bug Fixes**
  * Required identifiers now produce clear 422 validation errors naming the missing field.
  * Improved handling of malformed JSON and unsupported overlay-mode tools.
  * Clarified supported custom-field object types and overlay write errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->