### PR TITLE
fix(capture): a reply names the channel it arrived on

### DIFF
--- a/backend/api/public-events.yaml
+++ b/backend/api/public-events.yaml
@@ -1123,7 +1123,7 @@ components:
       description: >-
         Payload for engagement.reply — CAP-FORMULA-1: an inbound message
         in a thread we previously wrote outbound in is a reply, feeding
-        the engagement signal scoring (capture/sink.go's emitReply).
+        the engagement signal scoring (capture/sinkreply.go's emitReply).
       required:
         - matched_outbound_activity_id
         - channel
@@ -1136,7 +1136,11 @@ components:
           description: The prior outbound activity this inbound message replies to.
         channel:
           type: string
-          description: The channel the reply arrived on (today always email).
+          description: >-
+            The medium the reply arrived on and must be answered on:
+            `email` for the mail connectors (gmail, imap, graph all
+            reach one inbox), the channel provider itself for a
+            messaging connector (e.g. `telegram`).
         occurred_at:
           type: string
           format: date-time
@@ -1148,9 +1152,10 @@ components:
           type: string
           format: uuid
           description: >-
-            The already-known person behind the counterparty address
-            (absent when the counterparty resolves only in a follow-up
-            ensure).
+            The already-known person behind the counterparty — resolved
+            from the address on the mail path and from the channel
+            identity on a messaging one (absent when the counterparty
+            resolves only in a follow-up ensure).
       additionalProperties: false
 
     PublicEventConsentChanged:

--- a/backend/internal/compose/integration/telegram_roundtrip_integration_test.go
+++ b/backend/internal/compose/integration/telegram_roundtrip_integration_test.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 
@@ -35,6 +36,9 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/modules/privacy"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/connector"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
 )
 
 // sendRegistry is the WORKER role's connector registry, carrying the fake Bot
@@ -269,6 +273,98 @@ func TestAnArchivedOutboundIsNotAConversationToReplyInto(t *testing.T) {
 		`SELECT count(*) FROM event_outbox WHERE envelope->>'type' = 'engagement.reply'`); n != 0 {
 		t.Fatalf("%d engagement.reply events, want 0 — the only outbound in this thread was archived, "+
 			"so there is no live conversation the customer replied into", n)
+	}
+}
+
+// mailConnectorCtx is a MAIL connector principal in this workspace — the
+// channel suite's one non-channel actor, so a message can arrive by the other
+// medium without standing up a second harness.
+func (c *telegramEnv) mailConnectorCtx(t *testing.T) context.Context {
+	t.Helper()
+	ctx := principal.WithWorkspaceID(context.Background(), c.workspaceID(t))
+	ctx = principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalConnector, ID: "connector:gmail",
+		Permissions: principal.Permissions{
+			RoleKeys: []string{"connector"},
+			Objects:  map[string]principal.ObjectGrant{"activity": {Create: true}},
+			RowScope: principal.RowScopeAll,
+		},
+	})
+	return principal.WithCorrelationID(ctx, ids.NewV7())
+}
+
+// TestAForgedThreadKeyCannotReplyIntoAnotherMediumsConversation holds the
+// prior-outbound scan to one medium.
+//
+// thread_key is a single flat namespace carrying both a mail thread root and a
+// channel's provider:bot:chat key, and the mail half is attacker-supplied — it
+// is the message's own References root, copied verbatim. Both halves of a
+// Telegram key are discoverable (a bot id is public, and a private chat's id IS
+// the user's account id), so without a medium qualifier an outsider who can
+// send mail manufactures an engagement.reply against a Telegram conversation
+// they were never part of, and every consumer of that event — sequence
+// exit-on-reply, warm-room scoring, an answering automation — acts on it.
+func TestAForgedThreadKeyCannotReplyIntoAnotherMediumsConversation(t *testing.T) {
+	c := setupTelegramConnected(t)
+	opening := telegramUpdate{
+		updateID: 6301, messageID: 31, senderID: 771301,
+		username: "client", firstName: "Ora", text: "Can you quote the retrofit?",
+	}
+
+	runner, sub := newTelegramWorker(t, c, compose.JobRunnerConfig{SendRegistry: c.sendRegistry()})
+	startTelegramWorker(t, runner)
+
+	c.arrive(t, sub, opening)
+	awaitJobKind(t, sub, compose.TelegramIngestArgs{}.Kind())
+	activityID, personID := c.capturedMessage(t, opening)
+
+	// A real outbound goes into the Telegram conversation.
+	c.grantConsent(t, personID, "transactional")
+	if status := c.call(t, "POST", "/v1/activities/"+activityID+"/send-message", anyMap{
+		"body": "Sending it over today.", "consent_purpose": "transactional",
+	}, nil, nil); status != http.StatusAccepted {
+		t.Fatalf("the rep's reply → %d, want 202", status)
+	}
+	awaitJobKind(t, sub, compose.SendEmailArgs{}.Kind())
+
+	// The thread key that outbound is filed under is what an attacker would
+	// forge, so the test reads the real one rather than reconstructing it.
+	var forged string
+	if err := c.inWorkspace(t, c.slug, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT thread_key FROM activity WHERE id = $1`, activityID).Scan(&forged)
+	}); err != nil {
+		t.Fatalf("reading the conversation's thread key: %v", err)
+	}
+
+	// A stranger's MAIL lands carrying that key as its References root. It is a
+	// real inbound message that captures normally; only the thread it claims is
+	// a lie, so what the assertion below reads is the match, not a refusal.
+	mail := connector.NormalizedRecord{
+		EntityType: datasource.EntityActivity,
+		NaturalKey: connector.NaturalKey{SourceSystem: "gmail", SourceID: "forged-1@stranger.example"},
+		Fields: capture.ActivityFields{
+			Kind: "email", Subject: "Re: your conversation", Body: "let us talk",
+			Direction: connector.DirectionInbound, OccurredAt: time.Now().UTC(),
+		},
+		Source:     "gmail:forged-1@stranger.example",
+		CapturedBy: "connector:gmail",
+		Counterparty: connector.Counterparty{
+			Direction: connector.DirectionInbound,
+			Email:     "stranger@elsewhere.example", Domain: "elsewhere.example",
+			DisplayName: "A Stranger",
+		},
+		ThreadKey: forged,
+	}
+	if _, err := capture.NewSink(c.pool).Upsert(c.mailConnectorCtx(t), mail); err != nil {
+		t.Fatalf("capturing the stranger's mail: %v — it must land as an ordinary activity, "+
+			"or this test proves a refusal rather than the thread scan", err)
+	}
+
+	if n := c.count(t,
+		`SELECT count(*) FROM event_outbox WHERE envelope->>'type' = 'engagement.reply'`); n != 0 {
+		t.Fatalf("%d engagement.reply events, want 0 — a mail message claiming a Telegram "+
+			"conversation's thread key must not match the outbound in it", n)
 	}
 }
 

--- a/backend/internal/compose/integration/telegram_roundtrip_integration_test.go
+++ b/backend/internal/compose/integration/telegram_roundtrip_integration_test.go
@@ -187,6 +187,12 @@ func TestCustomerReplyNamesTheChannelItArrivedOn(t *testing.T) {
 	c.arrive(t, sub, answer)
 	awaitJobKind(t, sub, compose.TelegramIngestArgs{}.Kind())
 
+	// Counted before it is read: QueryRow over several rows scans the first and
+	// reports no error, so reading alone would green a path that double-fired.
+	if n := c.count(t,
+		`SELECT count(*) FROM event_outbox WHERE envelope->>'type' = 'engagement.reply'`); n != 1 {
+		t.Fatalf("%d engagement.reply events, want exactly 1 — the formula emits once per inbound message", n)
+	}
 	var channel, contactID string
 	if err := c.inWorkspace(t, c.slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(), `
@@ -195,7 +201,7 @@ func TestCustomerReplyNamesTheChannelItArrivedOn(t *testing.T) {
 			FROM event_outbox WHERE envelope->>'type' = 'engagement.reply'`,
 		).Scan(&channel, &contactID)
 	}); err != nil {
-		t.Fatalf("reading the reply fact: %v — want exactly one engagement.reply", err)
+		t.Fatalf("reading the reply fact: %v", err)
 	}
 	if channel != "telegram" {
 		t.Errorf("engagement.reply channel = %q, want %q — an automation answering this reply "+
@@ -204,6 +210,65 @@ func TestCustomerReplyNamesTheChannelItArrivedOn(t *testing.T) {
 	if contactID != personID {
 		t.Errorf("engagement.reply contact_id = %q, want the bound person %q — this sender resolves "+
 			"through person_channel_identity, so an address-only lookup names nobody", contactID, personID)
+	}
+}
+
+// TestAnArchivedOutboundIsNotAConversationToReplyInto holds the formula's
+// prior-outbound scan to `archived_at is null`.
+//
+// Archiving is how a human takes a message off the timeline. A scan that still
+// counted it would score engagement from a conversation the workspace has
+// withdrawn — and would do it invisibly, since the matched activity the event
+// names is one nobody can see any more. The assertion is a ZERO, so it is worth
+// saying what makes it meaningful: the same sequence WITHOUT the archive is
+// TestCustomerReplyNamesTheChannelItArrivedOn, which asserts exactly one event.
+// Only the archive differs between them.
+func TestAnArchivedOutboundIsNotAConversationToReplyInto(t *testing.T) {
+	c := setupTelegramConnected(t)
+	opening := telegramUpdate{
+		updateID: 6201, messageID: 21, senderID: 771201,
+		username: "browser", firstName: "Ida", text: "Are you at the fair next week?",
+	}
+	answer := telegramUpdate{
+		updateID: 6202, messageID: 22, senderID: 771201,
+		username: "browser", firstName: "Ida", text: "See you there.",
+	}
+
+	runner, sub := newTelegramWorker(t, c, compose.JobRunnerConfig{SendRegistry: c.sendRegistry()})
+	startTelegramWorker(t, runner)
+
+	c.arrive(t, sub, opening)
+	awaitJobKind(t, sub, compose.TelegramIngestArgs{}.Kind())
+	activityID, personID := c.capturedMessage(t, opening)
+
+	c.grantConsent(t, personID, "transactional")
+	var sent struct {
+		ID string `json:"id"`
+	}
+	if status := c.call(t, "POST", "/v1/activities/"+activityID+"/send-message", anyMap{
+		"body": "We are — hall 4.", "consent_purpose": "transactional",
+	}, nil, &sent); status != http.StatusAccepted {
+		t.Fatalf("the rep's reply → %d, want 202", status)
+	}
+	awaitJobKind(t, sub, compose.SendEmailArgs{}.Kind())
+
+	// The rep takes their message back off the timeline, leaving the thread with
+	// no LIVE outbound in it.
+	if err := c.inWorkspace(t, c.slug, func(tx pgx.Tx) error {
+		_, err := tx.Exec(context.Background(),
+			`UPDATE activity SET archived_at = now() WHERE id = $1`, sent.ID)
+		return err
+	}); err != nil {
+		t.Fatalf("archiving the outbound: %v", err)
+	}
+
+	c.arrive(t, sub, answer)
+	awaitJobKind(t, sub, compose.TelegramIngestArgs{}.Kind())
+
+	if n := c.count(t,
+		`SELECT count(*) FROM event_outbox WHERE envelope->>'type' = 'engagement.reply'`); n != 0 {
+		t.Fatalf("%d engagement.reply events, want 0 — the only outbound in this thread was archived, "+
+			"so there is no live conversation the customer replied into", n)
 	}
 }
 

--- a/backend/internal/compose/integration/telegram_roundtrip_integration_test.go
+++ b/backend/internal/compose/integration/telegram_roundtrip_integration_test.go
@@ -135,6 +135,78 @@ func TestInboundThenReplyRoundTrip(t *testing.T) {
 	c.assertSubjectAccessDescribesTheReply(t, personID, inbound, reply)
 }
 
+// TestCustomerReplyNamesTheChannelItArrivedOn continues the round trip one
+// message further, to the leg CAP-FORMULA-1 is actually about: the customer
+// answers the rep, and the reply fact that lands on the bus has to say it came
+// over Telegram.
+//
+// The formula keys on thread_key and direction only, so it fires here exactly
+// as it does for mail — activities/channelsend.go stamps the outbound bot
+// message with the conversation's thread_key precisely so it does. What it must
+// NOT do is describe the medium wrongly: `channel` is what an automation
+// answering an inbound reply routes on, so "email" on a Telegram reply sends
+// the answer to an address this subject does not have. The subject here has no
+// address at all, which is what makes contact_id load-bearing too — resolved
+// from the channel identity, it is nil for every mail-shaped lookup.
+func TestCustomerReplyNamesTheChannelItArrivedOn(t *testing.T) {
+	c := setupTelegramConnected(t)
+	opening := telegramUpdate{
+		updateID: 6101, messageID: 11, senderID: 771101,
+		username: "buyer", firstName: "Nils", text: "Do you ship to Hamburg?",
+	}
+	answer := telegramUpdate{
+		updateID: 6102, messageID: 12, senderID: 771101,
+		username: "buyer", firstName: "Nils", text: "Perfect, I'll take two.",
+	}
+	const repReply = "We do — two days by courier."
+
+	runner, sub := newTelegramWorker(t, c, compose.JobRunnerConfig{SendRegistry: c.sendRegistry()})
+	startTelegramWorker(t, runner)
+
+	// The opening message has no prior outbound above it, so it is not a reply.
+	c.arrive(t, sub, opening)
+	awaitJobKind(t, sub, compose.TelegramIngestArgs{}.Kind())
+	activityID, personID := c.capturedMessage(t, opening)
+	if n := c.count(t,
+		`SELECT count(*) FROM event_outbox WHERE envelope->>'type' = 'engagement.reply'`); n != 0 {
+		t.Fatalf("%d engagement.reply events after the opening message, want 0 — "+
+			"nothing outbound preceded it, so there is no thread to have replied into", n)
+	}
+
+	// The rep answers, which is what puts an outbound activity in this chat's
+	// thread for the customer's next message to match against.
+	c.grantConsent(t, personID, "transactional")
+	if status := c.call(t, "POST", "/v1/activities/"+activityID+"/send-message", anyMap{
+		"body": repReply, "consent_purpose": "transactional",
+	}, nil, nil); status != http.StatusAccepted {
+		t.Fatalf("the rep's reply → %d, want 202", status)
+	}
+	awaitJobKind(t, sub, compose.SendEmailArgs{}.Kind())
+
+	// And the customer writes back. THIS is the reply.
+	c.arrive(t, sub, answer)
+	awaitJobKind(t, sub, compose.TelegramIngestArgs{}.Kind())
+
+	var channel, contactID string
+	if err := c.inWorkspace(t, c.slug, func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(), `
+			SELECT envelope->'payload'->>'channel',
+			       coalesce(envelope->'payload'->>'contact_id', '')
+			FROM event_outbox WHERE envelope->>'type' = 'engagement.reply'`,
+		).Scan(&channel, &contactID)
+	}); err != nil {
+		t.Fatalf("reading the reply fact: %v — want exactly one engagement.reply", err)
+	}
+	if channel != "telegram" {
+		t.Errorf("engagement.reply channel = %q, want %q — an automation answering this reply "+
+			"routes on this value, and a Telegram customer has no address to answer at", channel, "telegram")
+	}
+	if contactID != personID {
+		t.Errorf("engagement.reply contact_id = %q, want the bound person %q — this sender resolves "+
+			"through person_channel_identity, so an address-only lookup names nobody", contactID, personID)
+	}
+}
+
 // assertSubjectAccessDescribesTheReply is Art. 15 over the message that just
 // left: the export must say WHICH account this installation messaged, not only
 // that some message existed.

--- a/backend/internal/contracts/publicevents_gen.go
+++ b/backend/internal/contracts/publicevents_gen.go
@@ -426,12 +426,12 @@ type PublicEventDealUpdated struct {
 	ChangedFields map[string]interface{} `json:"changed_fields"`
 }
 
-// PublicEventEngagementReply Payload for engagement.reply — CAP-FORMULA-1: an inbound message in a thread we previously wrote outbound in is a reply, feeding the engagement signal scoring (capture/sink.go's emitReply).
+// PublicEventEngagementReply Payload for engagement.reply — CAP-FORMULA-1: an inbound message in a thread we previously wrote outbound in is a reply, feeding the engagement signal scoring (capture/sinkreply.go's emitReply).
 type PublicEventEngagementReply struct {
-	// Channel The channel the reply arrived on (today always email).
+	// Channel The medium the reply arrived on and must be answered on: `email` for the mail connectors (gmail, imap, graph all reach one inbox), the channel provider itself for a messaging connector (e.g. `telegram`).
 	Channel string `json:"channel"`
 
-	// ContactId The already-known person behind the counterparty address (absent when the counterparty resolves only in a follow-up ensure).
+	// ContactId The already-known person behind the counterparty — resolved from the address on the mail path and from the channel identity on a messaging one (absent when the counterparty resolves only in a follow-up ensure).
 	ContactId *openapi_types.UUID `json:"contact_id,omitempty"`
 
 	// IdempotencyKey The capture natural key (source_system:source_id) this reply was detected from.

--- a/backend/internal/modules/capture/activity_payload_test.go
+++ b/backend/internal/modules/capture/activity_payload_test.go
@@ -66,7 +66,8 @@ func TestEngagementReplyPayload_WithContact(t *testing.T) {
 	occurredAt := time.Date(2026, 7, 22, 9, 30, 0, 0, time.UTC)
 	contact := ids.From[ids.PersonKind](ids.NewV7())
 
-	payload := engagementReplyPayload(matched, occurredAt, "gmail:msg-42", &contact)
+	payload := engagementReplyPayload(matched,
+		replyOrigin{channel: channelEmail, contactID: &contact}, occurredAt, "gmail:msg-42")
 
 	if !reflect.DeepEqual(payload.EventType(), "engagement.reply") {
 		t.Errorf("got %v, want %v", payload.EventType(), "engagement.reply")
@@ -112,7 +113,8 @@ func TestEngagementReplyPayload_NoContact(t *testing.T) {
 	matched := ids.NewV7()
 	occurredAt := time.Date(2026, 7, 22, 9, 30, 0, 0, time.UTC)
 
-	payload := engagementReplyPayload(matched, occurredAt, "gmail:msg-43", nil)
+	payload := engagementReplyPayload(matched,
+		replyOrigin{channel: channelEmail}, occurredAt, "gmail:msg-43")
 
 	if payload.ContactId != nil {
 		t.Errorf("expected nil, got %v", payload.ContactId)
@@ -123,5 +125,40 @@ func TestEngagementReplyPayload_NoContact(t *testing.T) {
 	}
 	if strings.Contains(string(raw), "contact_id") {
 		t.Errorf("%q should not contain %q", string(raw), "contact_id")
+	}
+}
+
+// TestEngagementReplyPayload_ChannelReply proves a reply that arrived over a
+// messaging channel names THAT channel, not mail. The field is what an
+// auto-reply automation routes on, so "email" on a Telegram reply would send
+// the answer somewhere the customer never wrote from.
+func TestEngagementReplyPayload_ChannelReply(t *testing.T) {
+	matched := ids.NewV7()
+	occurredAt := time.Date(2026, 7, 22, 9, 30, 0, 0, time.UTC)
+	contact := ids.From[ids.PersonKind](ids.NewV7())
+
+	payload := engagementReplyPayload(matched,
+		replyOrigin{channel: "telegram", contactID: &contact}, occurredAt, "telegram:7:42:9")
+
+	if !reflect.DeepEqual(payload.Channel, "telegram") {
+		t.Errorf("got %v, want %v", payload.Channel, "telegram")
+	}
+	if payload.ContactId == nil {
+		t.Fatalf("expected non-nil value")
+	}
+	if !reflect.DeepEqual(*payload.ContactId, openapi_types.UUID(contact.UUID)) {
+		t.Errorf("got %v, want %v", *payload.ContactId, openapi_types.UUID(contact.UUID))
+	}
+
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var decoded crmcontracts.PublicEventEngagementReply
+	if json.Unmarshal(raw, &decoded) != nil {
+		t.Fatalf("unexpected error: %v", json.Unmarshal(raw, &decoded))
+	}
+	if !reflect.DeepEqual(decoded, payload) {
+		t.Errorf("got %v, want %v", decoded, payload)
 	}
 }

--- a/backend/internal/modules/capture/sink.go
+++ b/backend/internal/modules/capture/sink.go
@@ -95,23 +95,8 @@ func (s *Sink) Upsert(ctx context.Context, rec connector.NormalizedRecord) (data
 		// cannot claim to be another one.
 		return datasource.EntityRef{}, fmt.Errorf("capture: captured_by %q does not match the acting connector %q", rec.CapturedBy, actor.ID)
 	}
-	switch shape := counterpartyShapeOf(rec.Counterparty); shape {
-	case shapeAmbiguous:
-		return datasource.EntityRef{}, ErrCounterpartyNamedTwice
-	case shapeHalfChannel:
-		return datasource.EntityRef{}, ErrChannelIdentityIncomplete
-	case shapeNone, shapeMail, shapeChannel:
-		// Well-formed; the channel arm is gated inside the transaction below.
-	default:
-		// A shape added to the enum without an arm here. Refusing it at THIS
-		// edge — before the transaction opens — is what keeps the refusal cheap:
-		// every downstream switch over the shape runs mid-transaction, after the
-		// activity, its audit row and its captured event are written, so a
-		// refusal there would fail the whole capture and hand the connector a
-		// deterministic error it retries forever (sinkensure.go states what that
-		// poison pill costs a mailbox). Admission is the one place a shape this
-		// module cannot classify can be turned away for nothing.
-		return datasource.EntityRef{}, fmt.Errorf("capture: unhandled counterparty shape %d", shape)
+	if err := admitCounterpartyShape(counterpartyShapeOf(rec.Counterparty)); err != nil {
+		return datasource.EntityRef{}, err
 	}
 
 	var ref datasource.EntityRef
@@ -194,6 +179,13 @@ func (s *Sink) Upsert(ctx context.Context, rec connector.NormalizedRecord) (data
 // captureActivity lands one activity: upsert on the natural key, links,
 // audit and event only when the row is new — a replay writes nothing.
 func (s *Sink) captureActivity(ctx context.Context, tx pgx.Tx, rec connector.NormalizedRecord, fields ActivityFields) (datasource.EntityRef, bool, counterpartyDecision, error) {
+	// One clock read for the whole capture. A provider payload carrying no
+	// timestamp falls back to now(), and THREE things downstream ask for that
+	// answer — the activity row, its audit image, and the reply fact — so asking
+	// separately files one message under three different times, and the reply
+	// event then claims to describe an activity it disagrees with. fields is a
+	// value copy, so settling it here settles it for every one of them.
+	fields.OccurredAt = defaultOccurredAt(fields.OccurredAt)
 	id, created, err := s.upsertActivity(ctx, tx, rec, fields)
 	if err != nil {
 		return datasource.EntityRef{}, false, counterpartyDecision{}, err
@@ -251,7 +243,7 @@ func (s *Sink) upsertActivity(ctx context.Context, tx pgx.Tx, rec connector.Norm
 	if err := auth.Require(ctx, "activity", principal.ActionCreate); err != nil {
 		return ids.ActivityID{}, false, err
 	}
-	occurredAt := defaultOccurredAt(fields.OccurredAt)
+	occurredAt := fields.OccurredAt
 	var id ids.ActivityID
 	err := tx.QueryRow(ctx, `
 		INSERT INTO activity (workspace_id, kind, subject, body, occurred_at, direction, source_system, source_id, source, captured_by, thread_key, counterparty_email, counterparty_outbound_attested, bulk_mail_attested)

--- a/backend/internal/modules/capture/sink.go
+++ b/backend/internal/modules/capture/sink.go
@@ -95,13 +95,23 @@ func (s *Sink) Upsert(ctx context.Context, rec connector.NormalizedRecord) (data
 		// cannot claim to be another one.
 		return datasource.EntityRef{}, fmt.Errorf("capture: captured_by %q does not match the acting connector %q", rec.CapturedBy, actor.ID)
 	}
-	switch counterpartyShapeOf(rec.Counterparty) {
+	switch shape := counterpartyShapeOf(rec.Counterparty); shape {
 	case shapeAmbiguous:
 		return datasource.EntityRef{}, ErrCounterpartyNamedTwice
 	case shapeHalfChannel:
 		return datasource.EntityRef{}, ErrChannelIdentityIncomplete
 	case shapeNone, shapeMail, shapeChannel:
 		// Well-formed; the channel arm is gated inside the transaction below.
+	default:
+		// A shape added to the enum without an arm here. Refusing it at THIS
+		// edge — before the transaction opens — is what keeps the refusal cheap:
+		// every downstream switch over the shape runs mid-transaction, after the
+		// activity, its audit row and its captured event are written, so a
+		// refusal there would fail the whole capture and hand the connector a
+		// deterministic error it retries forever (sinkensure.go states what that
+		// poison pill costs a mailbox). Admission is the one place a shape this
+		// module cannot classify can be turned away for nothing.
+		return datasource.EntityRef{}, fmt.Errorf("capture: unhandled counterparty shape %d", shape)
 	}
 
 	var ref datasource.EntityRef

--- a/backend/internal/modules/capture/sink.go
+++ b/backend/internal/modules/capture/sink.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
-	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
@@ -236,63 +235,6 @@ func (s *Sink) captureActivity(ctx context.Context, tx pgx.Tx, rec connector.Nor
 // (activities/activity.go) sets no fields but kind.
 func activityCaptureEventPayload(kind, sourceSystem string) crmcontracts.PublicEventActivityCaptured {
 	return crmcontracts.PublicEventActivityCaptured{Kind: kind, SourceSystem: &sourceSystem}
-}
-
-// emitReply is CAP-FORMULA-1: an INBOUND message in a thread we previously
-// wrote OUTBOUND in is a reply — the engagement signal scoring feeds on.
-// Emitted only when the activity row is new, so the at-least-once sync loop
-// cannot double-fire it; never a subject heuristic.
-func (s *Sink) emitReply(ctx context.Context, tx pgx.Tx, auditID ids.UUID, id ids.ActivityID, rec connector.NormalizedRecord, fields ActivityFields) error {
-	if fields.Direction != connector.DirectionInbound || rec.ThreadKey == "" {
-		return nil
-	}
-	var matched ids.UUID
-	err := tx.QueryRow(ctx, `
-		SELECT id FROM activity
-		WHERE thread_key = $1 AND direction = 'outbound' AND id <> $2
-		ORDER BY occurred_at DESC LIMIT 1`,
-		rec.ThreadKey, id).Scan(&matched)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("capture: reply detection: %w", err)
-	}
-	// contact_id resolves when the counterparty is already a person (the
-	// normal reply case — the outbound leg's ensure created them); a
-	// first-ever counterparty resolves in the follow-up ensure instead.
-	var contactID *ids.PersonID
-	if cp := strings.ToLower(strings.TrimSpace(rec.Counterparty.Email)); cp != "" {
-		var personID ids.PersonID
-		err := tx.QueryRow(ctx, `
-			SELECT person_id FROM person_email WHERE email = $1 AND archived_at IS NULL
-			ORDER BY is_primary DESC LIMIT 1`, cp).Scan(&personID)
-		if err == nil {
-			contactID = &personID
-		} else if !errors.Is(err, pgx.ErrNoRows) {
-			return fmt.Errorf("capture: reply contact lookup: %w", err)
-		}
-	}
-	idempotencyKey := rec.NaturalKey.SourceSystem + ":" + rec.NaturalKey.SourceID
-	payload := engagementReplyPayload(matched, defaultOccurredAt(fields.OccurredAt), idempotencyKey, contactID)
-	return storekit.EmitEvent(ctx, tx, auditID, id.UUID, payload)
-}
-
-// engagementReplyPayload builds the engagement.reply event — the reply's
-// contact_id is carried only when the counterparty already resolves to a
-// known person (absent, not null, otherwise).
-func engagementReplyPayload(matched ids.UUID, occurredAt time.Time, idempotencyKey string, contactID *ids.PersonID) crmcontracts.PublicEventEngagementReply {
-	payload := crmcontracts.PublicEventEngagementReply{
-		MatchedOutboundActivityId: openapi_types.UUID(matched),
-		Channel:                   "email",
-		OccurredAt:                occurredAt,
-		IdempotencyKey:            idempotencyKey,
-	}
-	if contactID != nil {
-		id := openapi_types.UUID(contactID.UUID)
-		payload.ContactId = &id
-	}
-	return payload
 }
 
 func (s *Sink) upsertActivity(ctx context.Context, tx pgx.Tx, rec connector.NormalizedRecord, fields ActivityFields) (ids.ActivityID, bool, error) {

--- a/backend/internal/modules/capture/sinkaudit.go
+++ b/backend/internal/modules/capture/sinkaudit.go
@@ -21,7 +21,7 @@ func capturedActivityAuditImage(rec connector.NormalizedRecord, fields ActivityF
 	return map[string]any{
 		"kind":            fields.Kind,
 		"direction":       fields.Direction,
-		"occurred_at":     defaultOccurredAt(fields.OccurredAt),
+		"occurred_at":     fields.OccurredAt,
 		fieldSourceSystem: rec.NaturalKey.SourceSystem,
 		fieldSourceID:     rec.NaturalKey.SourceID,
 	}

--- a/backend/internal/modules/capture/sinkchannel.go
+++ b/backend/internal/modules/capture/sinkchannel.go
@@ -70,6 +70,12 @@ const (
 	shapeChannel
 	shapeAmbiguous
 	shapeHalfChannel
+
+	// shapeCount bounds the enum so a walk over it derives rather than repeats
+	// the list. A shape appended above this line joins every such walk on its
+	// own, which is what keeps the switches that must all answer for it from
+	// drifting apart silently.
+	shapeCount
 )
 
 // A channel identity needs BOTH halves, and shapeChannel means both are present.

--- a/backend/internal/modules/capture/sinkchannel.go
+++ b/backend/internal/modules/capture/sinkchannel.go
@@ -101,6 +101,35 @@ func counterpartyShapeOf(cp connector.Counterparty) counterpartyShape {
 	}
 }
 
+// admitCounterpartyShape is the ONE gate on how a record names its human, and
+// it runs at the edge — before Upsert opens its transaction.
+//
+// Placement is the whole point. Every other switch over the shape runs
+// mid-transaction, after the activity, its audit row and its captured event are
+// written, so a refusal there fails the entire capture and hands the connector a
+// deterministic error it retries forever — the poison pill sinkensure.go's
+// savepoint exists to contain. Here a shape this module cannot classify is
+// turned away having cost nothing.
+//
+// It takes the shape rather than the Counterparty so the walk over the enum can
+// reach the arm no Counterparty can produce: a shape added to the const block
+// without an arm HERE is admitted silently and then met by an error downstream,
+// which is exactly the ordering this function exists to prevent.
+func admitCounterpartyShape(shape counterpartyShape) error {
+	switch shape {
+	case shapeNone, shapeMail, shapeChannel:
+		// Well-formed; the channel arm is gated again inside the transaction,
+		// under the account's own erasure lock.
+		return nil
+	case shapeAmbiguous:
+		return ErrCounterpartyNamedTwice
+	case shapeHalfChannel:
+		return ErrChannelIdentityIncomplete
+	default:
+		return fmt.Errorf("capture: unhandled counterparty shape %d", shape)
+	}
+}
+
 // ErrCounterpartyNamedTwice refuses a record naming its human both by an address
 // and by a channel identity. ErrChannelIdentityIncomplete refuses half a channel
 // identity. Both are sentinels rather than bare errors so the refusal can be

--- a/backend/internal/modules/capture/sinkreply.go
+++ b/backend/internal/modules/capture/sinkreply.go
@@ -108,7 +108,7 @@ func (s *Sink) emitReply(ctx context.Context, tx pgx.Tx, auditID ids.UUID, id id
 		return nil
 	}
 	idempotencyKey := rec.NaturalKey.SourceSystem + ":" + rec.NaturalKey.SourceID
-	payload := engagementReplyPayload(matched, origin, defaultOccurredAt(fields.OccurredAt), idempotencyKey)
+	payload := engagementReplyPayload(matched, origin, fields.OccurredAt, idempotencyKey)
 	return storekit.EmitEvent(ctx, tx, auditID, id.UUID, payload)
 }
 

--- a/backend/internal/modules/capture/sinkreply.go
+++ b/backend/internal/modules/capture/sinkreply.go
@@ -62,10 +62,16 @@ func (s *Sink) emitReply(ctx context.Context, tx pgx.Tx, auditID ids.UUID, id id
 		return nil
 	}
 	var matched ids.UUID
-	// archived_at IS NULL per the formula's own prior-outbound scan: an archived
-	// message is one a human took off the timeline, and treating it as evidence
-	// of correspondence would score engagement from a conversation the workspace
-	// has withdrawn.
+	// archived_at IS NULL is the formula's own prior-outbound scan. An archived
+	// message is off the timeline, so naming one as the matched outbound would
+	// point the reply fact at a row its consumers cannot read back.
+	//
+	// Archiving here is not only a human act: the retention evaluator
+	// (privacy/retention.go) and the noise sweep (activities/capturenoise.go)
+	// both archive activities by machine. So an installation running a retention
+	// policy stops reply-detecting threads whose outbound legs have aged out,
+	// even for a customer replying today. That follows the formula rather than
+	// this file's choosing, and it is the behaviour the spec pins.
 	err := tx.QueryRow(ctx, `
 		SELECT id FROM activity
 		WHERE thread_key = $1 AND direction = 'outbound' AND archived_at IS NULL AND id <> $2
@@ -82,9 +88,14 @@ func (s *Sink) emitReply(ctx context.Context, tx pgx.Tx, auditID ids.UUID, id id
 		return err
 	}
 	if !ok {
-		// A thread-matched inbound whose record names nobody. The match is real
-		// but the reply fact would carry neither a medium to answer on nor a
-		// human it came from, so there is nothing honest to publish.
+		// A thread-matched inbound whose record names no counterparty at all.
+		// The thread match is real and the medium is arguably still derivable
+		// from the record, so this is a DEVIATION from the formula, which emits
+		// on the match alone: what it refuses to do is publish a reply fact
+		// naming a medium nothing in the record actually attests to. Deviations
+		// belong upstream, not in a comment — .tmp/reply-origin/UPSTREAM.md
+		// raises it, and no live producer reaches this arm today (every mail
+		// connector drops a From-less message before capture).
 		return nil
 	}
 	idempotencyKey := rec.NaturalKey.SourceSystem + ":" + rec.NaturalKey.SourceID
@@ -101,7 +112,16 @@ func (s *Sink) emitReply(ctx context.Context, tx pgx.Tx, auditID ids.UUID, id id
 // means that guard has been bypassed — an invariant break the reply path must
 // state, not absorb into a silent no-event.
 func (s *Sink) replyOriginOf(ctx context.Context, tx pgx.Tx, cp connector.Counterparty) (replyOrigin, bool, error) {
-	switch shape := counterpartyShapeOf(cp); shape {
+	return s.replyOriginForShape(ctx, tx, cp, counterpartyShapeOf(cp))
+}
+
+// replyOriginForShape is replyOriginOf with the classification handed in, so the
+// arms can be walked across the whole enum rather than only the shapes a
+// Counterparty can be built to produce. Nothing but the seam above and that walk
+// calls it: a caller choosing its own shape would be re-deciding the one
+// question counterpartyShapeOf exists to answer.
+func (s *Sink) replyOriginForShape(ctx context.Context, tx pgx.Tx, cp connector.Counterparty, shape counterpartyShape) (replyOrigin, bool, error) {
+	switch shape {
 	case shapeMail:
 		contact, found, err := mailReplyContact(ctx, tx, cp.Email)
 		if err != nil {
@@ -166,6 +186,13 @@ func mailReplyContact(ctx context.Context, tx pgx.Tx, email string) (ids.PersonI
 // archived_at IS NULL), so this needs no ordering tiebreak the way the mail
 // lookup needs is_primary.
 func channelReplyContact(ctx context.Context, tx pgx.Tx, ci connector.ChannelIdentity) (ids.PersonID, bool, error) {
+	if ci.Provider == "" || ci.ChannelUserID == "" {
+		// shapeChannel already guarantees both halves, exactly as shapeMail
+		// guarantees a non-empty address for the sibling lookup. Both refuse an
+		// empty key anyway rather than probing on one: a half key matches by
+		// accident or matches nothing, and neither is an answer.
+		return ids.PersonID{}, false, nil
+	}
 	var personID ids.PersonID
 	err := tx.QueryRow(ctx, `
 		SELECT person_id FROM person_channel_identity

--- a/backend/internal/modules/capture/sinkreply.go
+++ b/backend/internal/modules/capture/sinkreply.go
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package capture
+
+// The reply half of the capture Sink (CAP-FORMULA-1): an INBOUND message in a
+// thread we previously wrote OUTBOUND in is a reply, and the engagement signal
+// scoring feeds on that fact.
+//
+// The formula keys on nothing but thread_key and direction, so it holds for any
+// threaded medium — mail and the channel connectors alike. What differs between
+// them is only how the record NAMES its human, and counterpartyShapeOf
+// (sinkchannel.go) is already the one place capture asks that question. This
+// file routes through it rather than assuming an answer.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/connector"
+)
+
+// channelEmail is the medium every mail connector reports. It is the MEDIUM and
+// not the source system on purpose: gmail, imap and graph are three ways of
+// reaching one inbox, and a consumer routing a reply back has the same job for
+// all three. A channel connector reports its provider instead, which is the
+// same rule — the provider IS the medium there.
+const channelEmail = "email"
+
+// replyOrigin is the single answer to "what medium did this reply arrive on,
+// and who is already on file for it". Both halves come out of ONE switch over
+// counterpartyShapeOf, so a new channel provider is one arm rather than a grep
+// across every site that had re-derived the answer for itself.
+type replyOrigin struct {
+	// channel is the medium a reply must be SENT BACK on, which is why it names
+	// the provider rather than a medium class: an automation answering an
+	// inbound reply routes on this value alone, and a class would make it
+	// re-derive the provider from the activity row anyway.
+	channel string
+	// contactID is the counterparty when they already resolve to a person.
+	// Nil is the ordinary first-contact case, not a fault: the ensure that
+	// creates them runs AFTER this transaction commits, so a first-ever sender
+	// has no person yet on either medium.
+	contactID *ids.PersonID
+}
+
+// emitReply is CAP-FORMULA-1: an INBOUND message in a thread we previously
+// wrote OUTBOUND in is a reply — the engagement signal scoring feeds on.
+// Emitted only when the activity row is new, so the at-least-once sync loop
+// cannot double-fire it; never a subject heuristic.
+func (s *Sink) emitReply(ctx context.Context, tx pgx.Tx, auditID ids.UUID, id ids.ActivityID, rec connector.NormalizedRecord, fields ActivityFields) error {
+	if fields.Direction != connector.DirectionInbound || rec.ThreadKey == "" {
+		return nil
+	}
+	var matched ids.UUID
+	// archived_at IS NULL per the formula's own prior-outbound scan: an archived
+	// message is one a human took off the timeline, and treating it as evidence
+	// of correspondence would score engagement from a conversation the workspace
+	// has withdrawn.
+	err := tx.QueryRow(ctx, `
+		SELECT id FROM activity
+		WHERE thread_key = $1 AND direction = 'outbound' AND archived_at IS NULL AND id <> $2
+		ORDER BY occurred_at DESC LIMIT 1`,
+		rec.ThreadKey, id).Scan(&matched)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("capture: reply detection: %w", err)
+	}
+	origin, ok, err := s.replyOriginOf(ctx, tx, rec.Counterparty)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		// A thread-matched inbound whose record names nobody. The match is real
+		// but the reply fact would carry neither a medium to answer on nor a
+		// human it came from, so there is nothing honest to publish.
+		return nil
+	}
+	idempotencyKey := rec.NaturalKey.SourceSystem + ":" + rec.NaturalKey.SourceID
+	payload := engagementReplyPayload(matched, origin, defaultOccurredAt(fields.OccurredAt), idempotencyKey)
+	return storekit.EmitEvent(ctx, tx, auditID, id.UUID, payload)
+}
+
+// replyOriginOf resolves the medium a reply arrived on and the person already
+// on file for it, in one switch over the shape the record names its human by.
+// It reports ok=false when there is no origin to publish at all.
+//
+// The two malformed shapes return their sentinel rather than a bare miss.
+// Upsert refuses both before any of this runs (sink.go), so reaching them here
+// means that guard has been bypassed — an invariant break the reply path must
+// state, not absorb into a silent no-event.
+func (s *Sink) replyOriginOf(ctx context.Context, tx pgx.Tx, cp connector.Counterparty) (replyOrigin, bool, error) {
+	switch shape := counterpartyShapeOf(cp); shape {
+	case shapeMail:
+		contact, found, err := mailReplyContact(ctx, tx, cp.Email)
+		if err != nil {
+			return replyOrigin{}, false, err
+		}
+		return withContact(replyOrigin{channel: channelEmail}, contact, found), true, nil
+	case shapeChannel:
+		contact, found, err := channelReplyContact(ctx, tx, cp.ChannelIdentity)
+		if err != nil {
+			return replyOrigin{}, false, err
+		}
+		return withContact(replyOrigin{channel: cp.ChannelIdentity.Provider}, contact, found), true, nil
+	case shapeNone:
+		return replyOrigin{}, false, nil
+	case shapeAmbiguous:
+		return replyOrigin{}, false, ErrCounterpartyNamedTwice
+	case shapeHalfChannel:
+		return replyOrigin{}, false, ErrChannelIdentityIncomplete
+	default:
+		// A shape added to the enum without an arm here. Naming it is the whole
+		// value of this arm: the alternative is a new medium silently publishing
+		// replies with an empty channel.
+		return replyOrigin{}, false, fmt.Errorf("capture: reply origin: unhandled counterparty shape %d", shape)
+	}
+}
+
+// withContact carries a resolved person onto the origin, and leaves it absent
+// when the lookup found none. It exists so both arms above spell "found or not"
+// the same way rather than each re-deriving a pointer from a flag.
+func withContact(origin replyOrigin, contact ids.PersonID, found bool) replyOrigin {
+	if found {
+		origin.contactID = &contact
+	}
+	return origin
+}
+
+// mailReplyContact resolves a mail counterparty to a person already on file.
+// A miss is not an error: the ensure that would create them runs after this
+// transaction commits, so the normal first-contact reply simply has no contact
+// to name yet.
+func mailReplyContact(ctx context.Context, tx pgx.Tx, email string) (ids.PersonID, bool, error) {
+	normalized := strings.ToLower(strings.TrimSpace(email))
+	if normalized == "" {
+		return ids.PersonID{}, false, nil
+	}
+	var personID ids.PersonID
+	err := tx.QueryRow(ctx, `
+		SELECT person_id FROM person_email WHERE email = $1 AND archived_at IS NULL
+		ORDER BY is_primary DESC LIMIT 1`, normalized).Scan(&personID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return ids.PersonID{}, false, nil
+	}
+	if err != nil {
+		return ids.PersonID{}, false, fmt.Errorf("capture: reply contact lookup: %w", err)
+	}
+	return personID, true, nil
+}
+
+// channelReplyContact is the same resolution on a channel identity — the key a
+// messaging connector names its human by, where mail names an address. The
+// binding is unique per live identity (uq_person_channel_identity is partial on
+// archived_at IS NULL), so this needs no ordering tiebreak the way the mail
+// lookup needs is_primary.
+func channelReplyContact(ctx context.Context, tx pgx.Tx, ci connector.ChannelIdentity) (ids.PersonID, bool, error) {
+	var personID ids.PersonID
+	err := tx.QueryRow(ctx, `
+		SELECT person_id FROM person_channel_identity
+		WHERE provider = $1 AND channel_user_id = $2 AND archived_at IS NULL`,
+		ci.Provider, ci.ChannelUserID).Scan(&personID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return ids.PersonID{}, false, nil
+	}
+	if err != nil {
+		return ids.PersonID{}, false, fmt.Errorf("capture: reply channel contact lookup: %w", err)
+	}
+	return personID, true, nil
+}
+
+// engagementReplyPayload builds the engagement.reply event from the origin the
+// switch above resolved — the reply's channel and, when the counterparty is
+// already a known person, their id (absent, not null, otherwise).
+func engagementReplyPayload(matched ids.UUID, origin replyOrigin, occurredAt time.Time, idempotencyKey string) crmcontracts.PublicEventEngagementReply {
+	payload := crmcontracts.PublicEventEngagementReply{
+		MatchedOutboundActivityId: openapi_types.UUID(matched),
+		Channel:                   origin.channel,
+		OccurredAt:                occurredAt,
+		IdempotencyKey:            idempotencyKey,
+	}
+	if origin.contactID != nil {
+		id := openapi_types.UUID(origin.contactID.UUID)
+		payload.ContactId = &id
+	}
+	return payload
+}

--- a/backend/internal/modules/capture/sinkreply.go
+++ b/backend/internal/modules/capture/sinkreply.go
@@ -72,11 +72,21 @@ func (s *Sink) emitReply(ctx context.Context, tx pgx.Tx, auditID ids.UUID, id id
 	// policy stops reply-detecting threads whose outbound legs have aged out,
 	// even for a customer replying today. That follows the formula rather than
 	// this file's choosing, and it is the behaviour the spec pins.
+	// Matched within ONE medium. thread_key is a single flat namespace holding
+	// both a mail thread root and a channel's `<provider>:<bot>:<chat>` key, and
+	// the mail half is attacker-supplied: it is the message's own References
+	// root, so a sender chooses it verbatim. Without this a forged References
+	// header naming a Telegram conversation — whose parts are both discoverable,
+	// a bot id being public and a private chat's id being the user's own —
+	// manufactures a reply fact against a conversation that sender was never in.
+	// A reply is answered on the medium it arrived on, so a cross-medium match
+	// could never have been actionable anyway.
 	err := tx.QueryRow(ctx, `
 		SELECT id FROM activity
-		WHERE thread_key = $1 AND direction = 'outbound' AND archived_at IS NULL AND id <> $2
+		WHERE thread_key = $1 AND direction = 'outbound' AND kind = $2
+		  AND archived_at IS NULL AND id <> $3
 		ORDER BY occurred_at DESC LIMIT 1`,
-		rec.ThreadKey, id).Scan(&matched)
+		rec.ThreadKey, fields.Kind, id).Scan(&matched)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil
 	}
@@ -89,13 +99,12 @@ func (s *Sink) emitReply(ctx context.Context, tx pgx.Tx, auditID ids.UUID, id id
 	}
 	if !ok {
 		// A thread-matched inbound whose record names no counterparty at all.
-		// The thread match is real and the medium is arguably still derivable
-		// from the record, so this is a DEVIATION from the formula, which emits
-		// on the match alone: what it refuses to do is publish a reply fact
-		// naming a medium nothing in the record actually attests to. Deviations
-		// belong upstream, not in a comment — .tmp/reply-origin/UPSTREAM.md
-		// raises it, and no live producer reaches this arm today (every mail
-		// connector drops a From-less message before capture).
+		// The thread match is real, so this is narrower than the formula, which
+		// emits on the match alone: what it refuses is a reply fact asserting a
+		// medium nothing in the record attests to. Which of the two CAP-FORMULA-1
+		// means is an open question against the spec, not a settled reading — no
+		// live producer reaches this arm either way, because every mail connector
+		// drops a From-less message before capture.
 		return nil
 	}
 	idempotencyKey := rec.NaturalKey.SourceSystem + ":" + rec.NaturalKey.SourceID
@@ -168,9 +177,17 @@ func mailReplyContact(ctx context.Context, tx pgx.Tx, email string) (ids.PersonI
 		return ids.PersonID{}, false, nil
 	}
 	var personID ids.PersonID
+	// The PERSON's own archived_at is checked, not only the binding's. Archiving
+	// a person does cascade to their satellites today, so this join changes no
+	// live answer — it stops the reply fact from depending on that cascade. A
+	// half-archived record (a retention pass, a merge, a repair) would otherwise
+	// name a person the consumer cannot read back, and the same reasoning holds
+	// for the channel twin below.
 	err := tx.QueryRow(ctx, `
-		SELECT person_id FROM person_email WHERE email = $1 AND archived_at IS NULL
-		ORDER BY is_primary DESC LIMIT 1`, normalized).Scan(&personID)
+		SELECT pe.person_id FROM person_email pe
+		JOIN person p ON p.id = pe.person_id AND p.archived_at IS NULL
+		WHERE pe.email = $1 AND pe.archived_at IS NULL
+		ORDER BY pe.is_primary DESC LIMIT 1`, normalized).Scan(&personID)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return ids.PersonID{}, false, nil
 	}
@@ -195,8 +212,9 @@ func channelReplyContact(ctx context.Context, tx pgx.Tx, ci connector.ChannelIde
 	}
 	var personID ids.PersonID
 	err := tx.QueryRow(ctx, `
-		SELECT person_id FROM person_channel_identity
-		WHERE provider = $1 AND channel_user_id = $2 AND archived_at IS NULL`,
+		SELECT pci.person_id FROM person_channel_identity pci
+		JOIN person p ON p.id = pci.person_id AND p.archived_at IS NULL
+		WHERE pci.provider = $1 AND pci.channel_user_id = $2 AND pci.archived_at IS NULL`,
 		ci.Provider, ci.ChannelUserID).Scan(&personID)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return ids.PersonID{}, false, nil

--- a/backend/internal/modules/capture/sinkreply_test.go
+++ b/backend/internal/modules/capture/sinkreply_test.go
@@ -21,26 +21,78 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/ports/connector"
 )
 
-// TestEveryCounterpartyShapeHasAReplyOriginArm walks the whole enum rather than
-// the shapes a Counterparty can be built to produce: the point is what happens
-// when someone ADDS a shape. Admission (Sink.Upsert) and this resolver each
-// switch over it, and the two drifting apart is the failure — a shape admitted
-// at the edge but unhandled here fails mid-transaction, after the activity and
-// its audit row are written, which is a capture the connector retries forever.
+// TestEveryCounterpartyShapeIsAnsweredByBothSwitches walks the whole enum rather
+// than the shapes a Counterparty can be built to produce, because the failure
+// this guards is what happens when someone ADDS a shape.
+//
+// Two switches read it and they must not drift: admission
+// (admitCounterpartyShape) decides whether the record is captured at all, and
+// the reply resolver decides what medium its reply fact names. A shape admitted
+// at the edge but unhandled in the resolver fails MID-TRANSACTION — after the
+// activity, its audit row and its captured event are written — which the
+// connector retries forever. Walking both in one test is what keeps the pair
+// honest; covering only the resolver would leave the edge free to admit
+// something nothing downstream can answer for.
 //
 // The bound is the enum's own shapeCount sentinel rather than a repeated list,
-// so a shape appended to the const block joins this walk on its own and turns
-// it red until the resolver names it. It asserts only that the resolver does
-// not fall through to its unhandled arm; what each shape SHOULD answer is the
-// sibling test's business.
-func TestEveryCounterpartyShapeHasAReplyOriginArm(t *testing.T) {
+// so a shape appended to the const block joins this walk on its own.
+func TestEveryCounterpartyShapeIsAnsweredByBothSwitches(t *testing.T) {
+	const unhandled = "unhandled counterparty shape"
 	sink := &Sink{}
 	for shape := shapeNone; shape < shapeCount; shape++ {
-		_, _, err := sink.replyOriginForShape(context.Background(), nil, connector.Counterparty{}, shape)
-		if err != nil && strings.Contains(err.Error(), "unhandled counterparty shape") {
-			t.Errorf("shape %d falls through to the unhandled arm — admission lets it in, "+
-				"so the reply path must answer for it rather than failing the capture", shape)
+		if err := admitCounterpartyShape(shape); err != nil && strings.Contains(err.Error(), unhandled) {
+			t.Errorf("admission has no arm for shape %d — every shape is either captured or "+
+				"refused by name, and neither can be decided by falling through", shape)
 		}
+		_, _, err := sink.replyOriginForShape(context.Background(), nil, connector.Counterparty{}, shape)
+		if err != nil && strings.Contains(err.Error(), unhandled) {
+			t.Errorf("the reply resolver has no arm for shape %d — admission lets it in, so the "+
+				"resolver must answer for it rather than failing a capture already written", shape)
+		}
+	}
+}
+
+// TestAdmissionRefusesTheTwoMalformedShapesByName pins WHICH refusal each
+// malformed shape earns. The walk above proves only that no shape falls
+// through; a caller telling a record that names its human twice from one that
+// names it by half a channel identity needs the sentinels to stay distinct.
+func TestAdmissionRefusesTheTwoMalformedShapesByName(t *testing.T) {
+	for _, tc := range []struct {
+		shape counterpartyShape
+		want  error
+	}{
+		{shapeNone, nil},
+		{shapeMail, nil},
+		{shapeChannel, nil},
+		{shapeAmbiguous, ErrCounterpartyNamedTwice},
+		{shapeHalfChannel, ErrChannelIdentityIncomplete},
+	} {
+		if err := admitCounterpartyShape(tc.shape); !errors.Is(err, tc.want) {
+			t.Errorf("admitCounterpartyShape(%d) = %v, want %v", tc.shape, err, tc.want)
+		}
+	}
+}
+
+// TestAShapeOutsideTheEnumIsRefusedRatherThanAdmitted drives the arm the walk
+// above cannot reach: a value no current constant names. Both switches must
+// REFUSE it rather than fall through to their well-formed branch, because
+// silently admitting a shape nothing can classify is how a capture reaches the
+// middle of its transaction with no answer for what it is holding.
+func TestAShapeOutsideTheEnumIsRefusedRatherThanAdmitted(t *testing.T) {
+	const unhandled = "unhandled counterparty shape"
+	unknown := shapeCount // past every named shape, by construction
+
+	err := admitCounterpartyShape(unknown)
+	if err == nil || !strings.Contains(err.Error(), unhandled) {
+		t.Errorf("admission of an unnamed shape = %v, want it refused by name", err)
+	}
+
+	origin, ok, err := (&Sink{}).replyOriginForShape(context.Background(), nil, connector.Counterparty{}, unknown)
+	if err == nil || !strings.Contains(err.Error(), unhandled) {
+		t.Errorf("the reply resolver on an unnamed shape = %v, want it refused by name", err)
+	}
+	if ok || origin.channel != "" {
+		t.Errorf("got origin %+v ok=%v, want neither — an unnamed shape names no medium", origin, ok)
 	}
 }
 

--- a/backend/internal/modules/capture/sinkreply_test.go
+++ b/backend/internal/modules/capture/sinkreply_test.go
@@ -15,10 +15,34 @@ package capture
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/gradionhq/margince/backend/internal/shared/ports/connector"
 )
+
+// TestEveryCounterpartyShapeHasAReplyOriginArm walks the whole enum rather than
+// the shapes a Counterparty can be built to produce: the point is what happens
+// when someone ADDS a shape. Admission (Sink.Upsert) and this resolver each
+// switch over it, and the two drifting apart is the failure — a shape admitted
+// at the edge but unhandled here fails mid-transaction, after the activity and
+// its audit row are written, which is a capture the connector retries forever.
+//
+// The bound is the enum's own shapeCount sentinel rather than a repeated list,
+// so a shape appended to the const block joins this walk on its own and turns
+// it red until the resolver names it. It asserts only that the resolver does
+// not fall through to its unhandled arm; what each shape SHOULD answer is the
+// sibling test's business.
+func TestEveryCounterpartyShapeHasAReplyOriginArm(t *testing.T) {
+	sink := &Sink{}
+	for shape := shapeNone; shape < shapeCount; shape++ {
+		_, _, err := sink.replyOriginForShape(context.Background(), nil, connector.Counterparty{}, shape)
+		if err != nil && strings.Contains(err.Error(), "unhandled counterparty shape") {
+			t.Errorf("shape %d falls through to the unhandled arm — admission lets it in, "+
+				"so the reply path must answer for it rather than failing the capture", shape)
+		}
+	}
+}
 
 func TestReplyOriginOf_RefusesMalformedAndUnnamedCounterparties(t *testing.T) {
 	sink := &Sink{}

--- a/backend/internal/modules/capture/sinkreply_test.go
+++ b/backend/internal/modules/capture/sinkreply_test.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package capture
+
+// The shapes replyOriginOf answers WITHOUT a database: a record naming nobody,
+// and the two malformed shapes Upsert already refuses. Each returns before the
+// contact lookup, which is what lets a nil tx stand here — and asserting that
+// is the point, because a shape that reached the lookup with a nil tx would
+// panic rather than refuse.
+//
+// The mail and channel arms both query, so they are proved in the integration
+// lane (compose/integration) against a real Postgres.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/ports/connector"
+)
+
+func TestReplyOriginOf_RefusesMalformedAndUnnamedCounterparties(t *testing.T) {
+	sink := &Sink{}
+	for _, tc := range []struct {
+		name    string
+		cp      connector.Counterparty
+		wantErr error
+	}{
+		{
+			// A calendar event or an import carrying no counterparty at all: no
+			// medium to answer on and nobody to answer, so no reply origin.
+			name: "no counterparty names no origin",
+			cp:   connector.Counterparty{},
+		},
+		{
+			name: "an address and a channel identity together are refused",
+			cp: connector.Counterparty{
+				Email:           "alice@example.com",
+				ChannelIdentity: connector.ChannelIdentity{Provider: "telegram", ChannelUserID: "77"},
+			},
+			wantErr: ErrCounterpartyNamedTwice,
+		},
+		{
+			name:    "half a channel identity is refused",
+			cp:      connector.Counterparty{ChannelIdentity: connector.ChannelIdentity{Provider: "telegram"}},
+			wantErr: ErrChannelIdentityIncomplete,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			origin, ok, err := sink.replyOriginOf(context.Background(), nil, tc.cp)
+
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("got error %v, want %v", err, tc.wantErr)
+			}
+			if ok {
+				t.Errorf("got ok=true, want false")
+			}
+			if origin.channel != "" {
+				t.Errorf("got channel %q, want empty", origin.channel)
+			}
+			if origin.contactID != nil {
+				t.Errorf("got contact %v, want nil", origin.contactID)
+			}
+		})
+	}
+}

--- a/frontend/src/api/public-events.ts
+++ b/frontend/src/api/public-events.ts
@@ -488,14 +488,14 @@ export interface components {
         PublicEventActivityUpdated: {
             changed_fields: components["schemas"]["PublicEventActivityChangedFields"];
         };
-        /** @description Payload for engagement.reply — CAP-FORMULA-1: an inbound message in a thread we previously wrote outbound in is a reply, feeding the engagement signal scoring (capture/sink.go's emitReply). */
+        /** @description Payload for engagement.reply — CAP-FORMULA-1: an inbound message in a thread we previously wrote outbound in is a reply, feeding the engagement signal scoring (capture/sinkreply.go's emitReply). */
         PublicEventEngagementReply: {
             /**
              * Format: uuid
              * @description The prior outbound activity this inbound message replies to.
              */
             matched_outbound_activity_id: string;
-            /** @description The channel the reply arrived on (today always email). */
+            /** @description The medium the reply arrived on and must be answered on: `email` for the mail connectors (gmail, imap, graph all reach one inbox), the channel provider itself for a messaging connector (e.g. `telegram`). */
             channel: string;
             /**
              * Format: date-time
@@ -506,7 +506,7 @@ export interface components {
             idempotency_key: string;
             /**
              * Format: uuid
-             * @description The already-known person behind the counterparty address (absent when the counterparty resolves only in a follow-up ensure).
+             * @description The already-known person behind the counterparty — resolved from the address on the mail path and from the channel identity on a messaging one (absent when the counterparty resolves only in a follow-up ensure).
              */
             contact_id?: string;
         };


### PR DESCRIPTION
## The defect

`emitReply` ran for every inbound activity carrying a thread key. Since the Telegram path landed, that includes channel records — `activities/channelsend.go:381` stamps the outbound bot message with the conversation's `thread_key` *precisely so* reply detection joins them. But the payload hardcoded its answer:

```go
Channel: "email",   // fired for Telegram replies too
```

and resolved `contact_id` through `person_email` alone, so a Telegram reply was published as mail from nobody.

Nothing reads `channel` today, so no consumer broke. It becomes load-bearing the moment an automation answers an inbound reply: `TriggerInboundReply` (`automation/catalog_triggers.go:71`) fires on this event, and the value is what tells it which medium to answer on. A Telegram customer has no address to answer at.

## The fix routes, it does not abstract

`counterpartyShapeOf` (`capture/sinkchannel.go:81`) already says of itself that it is *"the one place capture asks which it holds"*, and it is already total. `Upsert`, `refuseErasedChannelAccount` and `decideCounterparty` all route through it — `emitReply` was the only site that bypassed it and assumed an answer.

So `replyOriginOf` resolves the medium **and** the person in ONE switch over that shape:

| shape | channel | contact lookup |
|---|---|---|
| `shapeMail` | `"email"` | `person_email`, query unchanged |
| `shapeChannel` | `ChannelIdentity.Provider` → `"telegram"` | `person_channel_identity` |
| `shapeNone` | — | no origin, no event |
| `shapeAmbiguous` / `shapeHalfChannel` | — | their sentinel — `Upsert` refuses both first, so reaching here is a broken invariant, not a silent no-event |

A new channel provider is one arm rather than a grep across every site that had re-derived it. The channel value is the **provider name**, not a medium class, so an auto-reply automation routes on it directly instead of re-deriving the provider from `activity.kind`.

`emitReply` and `engagementReplyPayload` move to `sinkreply.go`, joining the `sinkchannel`/`sinklead`/`sinkensure` family.

## Also: `archived_at IS NULL` on the prior-outbound scan

CAP-FORMULA-1's `match_reply` requires it; the query omitted it. An archived message is one a human took off the timeline, and scoring engagement from a withdrawn conversation is not what the formula says.

**The matching index is deliberately NOT rebuilt here.** Migration `0139_drop_activity_bulk_mail_index` is a recorded incident about this precise operation on this precise table — a plain `CREATE INDEX` on `activity` holds a write-blocking lock for the whole build and pauses mail capture, `CONCURRENTLY` cannot run inside a transaction, and `dbmigrate.Up` wraps every migration in one. 0139 closes by saying an index here *"belongs behind a non-transactional migration path built for concurrent builds. That path does not exist yet, and inventing it inside a migration is how this happened."* The filter costs a few index-matched rows per thread; a thread holds a handful of messages.

## Upstream (contract-first, P3)

The spec catalog (`event-bus.md:533`) already types the field `channel: "email"|"deal_room"` — a multi-valued channel was always intended, it just has no case for a messaging provider. And `CAP-FORMULA-1`'s Inputs still read `kind=email` while its body keys on nothing but `thread_key` and `direction`.

A `margince-foundation` PR raising both accompanies this one and **merges when this merges**.

## Verification

- `make check-backend` — green
- `make test-integration` — `OK: integration passed with 0 skips (28 packages, parallel)`
- New `TestCustomerReplyNamesTheChannelItArrivedOn` was confirmed to **fail** against the pre-fix behaviour on both assertions (channel `"email"` ≠ `"telegram"`, empty `contact_id`), then pass with the fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes engagement.reply to report the actual medium (`email` or a provider like `telegram`) and resolve contacts across email and messaging so automations answer on the right channel. Also ensures replies match only live outbounds on the same medium and keeps timestamps consistent across activity, audit, and events.

- **Bug Fixes**
  - Resolve reply origin via `replyOriginOf` over `counterpartyShapeOf`; emit `channel` as `email` for mail or the provider for messaging; resolve `contact_id` via email/channel identities and join `person` to avoid archived people; update `public-events.yaml` and regenerate Go and frontend (`frontend/src/api/public-events.ts`) types.
  - Match prior outbound within one medium (`kind`) and only when `archived_at IS NULL`; add tests for Telegram replies, archived outbounds, and forged cross‑medium mail.
  - Set `occurred_at` once per capture and reuse for the activity row, audit image, and reply event for consistent timing.
  - Move reply logic to `sinkreply.go`; refuse unclassifiable counterparties at admission via `admitCounterpartyShape`; add `shapeCount` and tests ensuring every shape has a reply‑origin arm.

- **Migration**
  - No action required. Consumers routing on `channel` should expect provider names for messaging connectors.

<sup>Written for commit 4576b355360038ccd6ce2ec4d6daa5c7ee422121. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/389?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Reply events now accurately identify the channel where a customer response originated, including messaging channels.
  * Contact information is resolved across email and messaging identities when available.
  * Replies without a matching contact are still captured successfully.
  * Archived messages and mismatched conversation details no longer create incorrect reply events.
  * Duplicate reply events are prevented for more consistent activity tracking.

* **Documentation**
  * Updated engagement reply documentation with channel details and contact-resolution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->