### PR TITLE
docs(status): phase 1 A and B landed, and C is what is left

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -285,7 +285,7 @@ Vite/React web UI. What is deliberately still stubbed (answering explicit
 The merge gate (`make check`), the real-Postgres integration lane
 (`make test-integration`), and the live-boot job are all green.
 
-## Session pickup — 2026-08-03 (job observability, Phase 0 and Phase 1 PR 1, merged)
+## Session pickup — 2026-08-03 (job observability, Phase 0 + Phase 1 A/B, merged)
 
 **Every unit of tenant work now names one workspace, and spells it one way.**
 PR #367 bound each job to a single workspace; PR #374 made the wire agree with
@@ -325,24 +325,45 @@ are disposable at this stage and a stranded job failing loudly is the wanted
 behaviour, so recreate rather than debug: `make infra-reset && make db-up &&
 make migrate`.
 
-### Pick up here — Phase 1, PRs 2 through 8
+### Pick up here — Phase 1 C (PRs 7 and 8)
 
-Dependency-ordered; 2, 3 and 4 are independent of each other.
+**PRs 2 through 6 shipped as one change, #390.** All four remaining fleet passes
+are River dispatcher + workspace-worker pairs, so `args->>'workspace_id'` is
+non-null **iff** a job did tenant work — **with no exception**. The caveat that
+used to live in `jobs/role.go` and `embedreindextransport.go` is gone from both,
+and `backend/jobfleetwide_test.go` is what stops it coming back.
 
-2. **Retention conversion** — the highest-value single item: a nightly GDPR pass
-   currently logs a tenant's failure and returns `nil`.
-3. **Webhook retry conversion.**
-4. **Agent scheduler conversion** — currently aborts the whole fleet on one
-   workspace's error.
-5. **`embed_reindex` conversion** + the `FleetWide`-means-dispatcher gate. This
-   is what makes the caveat above deletable.
-6. **Waiver deletions** in `ratifiedFleetScans`, and the raised waiver bar.
 7. **Fleet metrics** — `job_queue_depth{queue}` (OPS-MET-2) plus the sweep
    counters. Foundation ADR-0080 / A125 admits a bounded `workspace_id` label on
    the job-runtime metrics — the id, never a name, and **not** on OPS-MET-1's
    latency histogram.
 8. **The per-workspace read endpoint** over `/v1` — the consumer all of the
-   above exists to make honest.
+   above exists to make honest. This is the contract change C was separated to
+   quarantine.
+
+**Two things #390 left honest rather than hidden**, and a reader of the job
+layer should know both. `populated_identity` on `embed_store_binding` means
+"last **released** under", not "last completed under": the design does not track
+whether every child succeeded, so a run whose children all failed still releases
+and stamps, and `/readyz` then reports `active`. And a forced reindex steal
+resets the pending set without cancelling the run it dispossesses, so both
+fleets run until the old children finish — bounded by `UpsertEmbedding`'s
+content-hash skip-compare, not by anything stopping them.
+
+**Owed by #390, and the reason a blocker survived five reviews:** no fitness
+test asserts that a workspace worker declares a `Timeout`. The GDPR retention
+worker shipped without one through five task reviews and was caught only by the
+whole-branch pass — under River's 1-minute default it would have been cancelled
+mid-pass nightly, burned its attempts, and left a permanently failing row for
+the one obligation whose whole point is auditability. Only
+`embedDriftWorkspaceWorker` is pinned today; `backend/` already has the scanner
+infrastructure to derive the rest.
+
+**Migration numbers race, and local gates cannot catch it.** #390's migration
+was renumbered twice — 0171 → 0172 → 0174 — and the second collision was found
+only by CI, because `TestEmbeddedMigrationNamespacesLoad` passes on each side
+independently and the duplicate exists only once the two trees are combined.
+Renumber as the **last** action before merge, not an early one.
 
 **Also still open, and deliberately not bundled:** eight workers call the
 binding guard as a validator and then re-bind in a per-kind helper. It touches


### PR DESCRIPTION
`STATUS.md`'s pickup section still listed PRs 2 through 6 as open work and still
named the `embed_reindex` caveat as live. #390 shipped all five and deleted that
caveat from both files that carried it, so the entry was describing a tree that
no longer exists.

Rewrites it to what is actually left — C, the fleet metrics and the per-workspace
`/v1` read endpoint — and records three things a reader of the job layer needs
that would otherwise only exist in #390's body:

- **What #390 left honest rather than hidden.** `populated_identity` means "last
  *released* under", not "last completed under", so a run whose children all
  failed still stamps and `/readyz` reports `active`; and a forced reindex steal
  does not cancel the run it dispossesses.
- **Why a blocker survived five task reviews.** No fitness test asserts that a
  workspace worker declares a `Timeout`. The GDPR retention worker shipped
  without one and was caught only by the whole-branch pass — under River's
  1-minute default it would have been cancelled mid-pass nightly and left a
  permanently failing row for the one obligation whose point is auditability.
- **That migration renumbering must be the last action before merge.** #390's
  migration moved twice, and the second collision was invisible to local gates:
  `TestEmbeddedMigrationNamespacesLoad` passes on each side independently and the
  duplicate exists only once the trees are combined.

Docs only — no code, no contract, no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `STATUS.md` to show Phase 1 A/B merged in #390 and set Phase 1 C as the remaining work: fleet metrics and the per‑workspace /v1 read endpoint. Also document two behavior clarifications from #390 (`populated_identity` stamps on release; reindex steals don’t cancel prior runs), flag the missing worker `Timeout` fitness test, and note migration renumbering must be done last to avoid CI‑only collisions.

<sup>Written for commit 3a873a6a1c482aa45a325db4e26504b4227e13f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

