### PR TITLE
feat(jobs): the fleet reports what it did, per queue and per workspace

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -333,18 +333,55 @@ are disposable at this stage and a stranded job failing loudly is the wanted
 behaviour, so recreate rather than debug: `make infra-reset && make db-up &&
 make migrate`.
 
-### Pick up here — Phase 1 C (PRs 7 and 8)
+### Phase 1 is COMPLETE — C shipped both consumers
 
-Everything above is the invariant. C is its two consumers, and the whole reason
-the invariant was made exact.
+Everything above is the invariant. C was its two consumers, and the whole reason
+the invariant was made exact. Both are now built:
 
-7. **Fleet metrics** — `job_queue_depth{queue}` (OPS-MET-2, specified since V1
-   and never built) plus the sweep counters. Foundation ADR-0080 / A125 admits a
-   bounded `workspace_id` label on the job-runtime metrics — the id, never a
-   name, and **not** on OPS-MET-1's latency histogram.
-8. **The per-workspace read endpoint** over `/v1` — the consumer all of the
-   above exists to make honest, and the contract change C was separated to
-   quarantine.
+7. **Fleet metrics** — `/metrics` carries the job-runtime section:
+   `margince_job_queue_depth` (OPS-MET-2, specified since V1 and never built),
+   `_running`, `_discarded`, `_cancelled`, `_oldest_queued_age_seconds`, and the
+   `margince_sweep_workspaces_total`/`_failed` pair. All labelled with the
+   `workspace_id` ADR-0080 / A125 admits — the id, never a name — where an empty
+   value means a dispatcher, exactly and in both directions.
+8. **`GET /v1/admin/job-health`** — admin-only, human-session-only, scoped to
+   the caller's own workspace plus the untenanted dispatcher rows. A failed
+   tenant pass is finally readable by the admin it failed for, instead of only
+   by `psql`.
+
+Both surfaces are DB-derived at read time, because `cmd/worker` — where the
+dispatchers run — serves no HTTP surface at all, so an in-process counter there
+would be invisible to every scrape while the api's own copy reported zero.
+What the families mean, and the four limits worth knowing before alerting on
+them: [docs/reference/configuration.md](docs/reference/configuration.md),
+"Reading the job surfaces".
+
+**Carried forward from Phase 1 C, in priority order.** The first is the
+highest-value work left in this topic:
+
+1. **No fitness test asserts a workspace worker declares a `Timeout`** — see
+   the paragraph below; unchanged by C and still the blocker #390 shipped.
+2. **No fitness test asserts a fan-out site tags its children.** C tags all six
+   call sites, but the only registry of which sites exist is a comment — and the
+   adversarial review of C found a real missed site (`overlayReconcileWorker`)
+   whose absence would have silently emptied the overlay sweep series. Deriving
+   "this insert is a fan-out" needs a static notion the tree does not support
+   today; until it does, that comment is load-bearing code.
+3. **Not every worker routes its failure through `jobs.Fault`.** The endpoint is
+   safe regardless — it allowlists against the vocabulary and substitutes
+   otherwise — but the underlying obligation, that a raw provider error naming
+   an address must not reach a fleet-visible column, is held by no gate.
+4. **`cmd/worker` exposes no `/metrics`**, against OPS-MET-8's "every service".
+5. **A per-connection dispatcher can mask a failed connection** in the sweep
+   pair: the pair counts distinct workspaces, so a workspace whose second
+   connection succeeded later is not reported as failing. Stated in the docs;
+   whether it wants its own metric is a product decision.
+6. **`captureBackfillWorker.enqueueDigest` enqueues dispatcher args with no
+   uniqueness**, so one tenant's backfill triggers a whole-fleet digest fan-out.
+
+**Phase 2's screen stays blocked upstream on U2** (`margince-foundation#1225`,
+still open). The endpoint is the layer underneath it and is built now; the SPA
+is not, and needs no router entry without a screen.
 
 **Two things #390 left honest rather than hidden.** A reader of the job layer
 needs both. `populated_identity` on `embed_store_binding` means "last

--- a/STATUS.md
+++ b/STATUS.md
@@ -285,7 +285,7 @@ Vite/React web UI. What is deliberately still stubbed (answering explicit
 The merge gate (`make check`), the real-Postgres integration lane
 (`make test-integration`), and the live-boot job are all green.
 
-## Session pickup — 2026-08-03 (job observability, Phase 0 and Phase 1 PR 1, merged)
+## Session pickup — 2026-08-03 (job observability, Phase 0 + Phase 1 A/B, merged)
 
 **Every unit of tenant work now names one workspace, and spells it one way.**
 PR #367 bound each job to a single workspace; PR #374 made the wire agree with
@@ -307,9 +307,17 @@ recognized (the floor counted only the scoped side). The gate is syntactic, so
 `jobwireformat_integration_test.go` proves the other half — that a tagged type
 lands as `workspace_id` in `river_job.args` through River's own encoder.
 
-**The invariant is exact, with no exception.** A null `args->>'workspace_id'`
-means a dispatcher and nothing else: `embed_reindex` is now a dispatcher over a
-per-workspace `embed_reindex_workspace` worker, like every other fleet pass.
+**The invariant is exact, with no exception.** PR #390 shipped design PRs 2
+through 6 as one change: all four remaining fleet passes — GDPR retention,
+webhook retry, the agent scheduler, and `embed_reindex` — are now River
+dispatcher + workspace-worker pairs, so a null `args->>'workspace_id'`
+means a dispatcher and nothing else. `embed_reindex` in particular is a
+dispatcher over a per-workspace `embed_reindex_workspace` worker, like every
+other fleet pass, and the caveat that named it as the one exception is gone
+from both `platform/jobs/role.go` and `compose/embedreindextransport.go`.
+`ratifiedFleetScans` went 13 → 10, and its waiver bar now carries four honest
+classes — dispatcher enumeration, read-only, boot path, and tenant resolution
+for an untenanted inbound request — with "outside the job layer" struck by name.
 `backend/jobfleetwide_test.go` holds the other half of that — a kind declaring
 `FleetWide` must actually fan out, through one of a closed set of spellings, and
 must issue no inline SQL write in its own worker's methods. The fan-out arm is
@@ -325,24 +333,47 @@ are disposable at this stage and a stranded job failing loudly is the wanted
 behaviour, so recreate rather than debug: `make infra-reset && make db-up &&
 make migrate`.
 
-### Pick up here — Phase 1, PRs 2 through 8
+### Pick up here — Phase 1 C (PRs 7 and 8)
 
-Dependency-ordered; 2, 3 and 4 are independent of each other.
+Everything above is the invariant. C is its two consumers, and the whole reason
+the invariant was made exact.
 
-2. **Retention conversion** — the highest-value single item: a nightly GDPR pass
-   currently logs a tenant's failure and returns `nil`.
-3. **Webhook retry conversion.**
-4. **Agent scheduler conversion** — currently aborts the whole fleet on one
-   workspace's error.
-5. **`embed_reindex` conversion** + the `FleetWide`-means-dispatcher gate. This
-   is what makes the caveat above deletable.
-6. **Waiver deletions** in `ratifiedFleetScans`, and the raised waiver bar.
-7. **Fleet metrics** — `job_queue_depth{queue}` (OPS-MET-2) plus the sweep
-   counters. Foundation ADR-0080 / A125 admits a bounded `workspace_id` label on
-   the job-runtime metrics — the id, never a name, and **not** on OPS-MET-1's
-   latency histogram.
+7. **Fleet metrics** — `job_queue_depth{queue}` (OPS-MET-2, specified since V1
+   and never built) plus the sweep counters. Foundation ADR-0080 / A125 admits a
+   bounded `workspace_id` label on the job-runtime metrics — the id, never a
+   name, and **not** on OPS-MET-1's latency histogram.
 8. **The per-workspace read endpoint** over `/v1` — the consumer all of the
-   above exists to make honest.
+   above exists to make honest, and the contract change C was separated to
+   quarantine.
+
+**Two things #390 left honest rather than hidden.** A reader of the job layer
+needs both. `populated_identity` on `embed_store_binding` means "last
+**released** under", not "last completed under": the design does not track
+whether every child succeeded, so a run whose children all failed still releases
+and stamps — and `/readyz` then reports `active`, because it compares identities
+only and deliberately does not join the live entity scan. The usual mitigation
+(`ReindexNeeded` also consults pending embedding counts) holds for the SPA and
+does **not** reach `/readyz`. Separately, a forced reindex steal resets the
+pending set **without cancelling** the run it dispossesses; the old children
+carry a different run token, so `ByArgs` uniqueness does not suppress the new
+run's children and both fleets run — bounded by `UpsertEmbedding`'s content-hash
+skip-compare, not by anything stopping them.
+
+**Owed by #390, and the reason a blocker survived five task reviews.** No
+fitness test asserts that a workspace worker declares a `Timeout`. The GDPR
+retention worker shipped without one through five per-task reviews and was
+caught only by the whole-branch pass — under River's 1-minute default it would
+have been cancelled mid-pass nightly, burned its three attempts, and left a
+permanently failing `privacy_retention_workspace` row for the one obligation
+whose whole point is auditability. Only `embedDriftWorkspaceWorker` is pinned
+today; `backend/` already has the scanner infrastructure to derive the rest.
+This is the rule-2 answer and wants its own diff.
+
+**Migration numbers race, and local gates provably cannot catch it.** #390's
+migration was renumbered twice — 0171 → 0172 → 0174 — and the second collision
+was found only by CI, because `TestEmbeddedMigrationNamespacesLoad` passes on
+each side independently and the duplicate exists only once the two trees are
+combined. Renumber as the **last** action before merge.
 
 **Also still open, and deliberately not bundled:** eight workers call the
 binding guard as a validator and then re-bind in a per-kind helper. It touches

--- a/STATUS.md
+++ b/STATUS.md
@@ -353,8 +353,7 @@ Both surfaces are DB-derived at read time, because `cmd/worker` — where the
 dispatchers run — serves no HTTP surface at all, so an in-process counter there
 would be invisible to every scrape while the api's own copy reported zero.
 What the families mean, and the four limits worth knowing before alerting on
-them:
-[docs/reference/configuration.md#reading-the-job-surfaces](docs/reference/configuration.md#reading-the-job-surfaces).
+them: [Reading the job surfaces](docs/reference/configuration.md#reading-the-job-surfaces).
 
 **Carried forward from Phase 1 C, in priority order.** The first is the
 highest-value work left in this topic:

--- a/STATUS.md
+++ b/STATUS.md
@@ -353,8 +353,8 @@ Both surfaces are DB-derived at read time, because `cmd/worker` — where the
 dispatchers run — serves no HTTP surface at all, so an in-process counter there
 would be invisible to every scrape while the api's own copy reported zero.
 What the families mean, and the four limits worth knowing before alerting on
-them: [docs/reference/configuration.md](docs/reference/configuration.md),
-"Reading the job surfaces".
+them:
+[docs/reference/configuration.md#reading-the-job-surfaces](docs/reference/configuration.md#reading-the-job-surfaces).
 
 **Carried forward from Phase 1 C, in priority order.** The first is the
 highest-value work left in this topic:
@@ -396,15 +396,17 @@ carry a different run token, so `ByArgs` uniqueness does not suppress the new
 run's children and both fleets run — bounded by `UpsertEmbedding`'s content-hash
 skip-compare, not by anything stopping them.
 
-**Owed by #390, and the reason a blocker survived five task reviews.** No
-fitness test asserts that a workspace worker declares a `Timeout`. The GDPR
-retention worker shipped without one through five per-task reviews and was
-caught only by the whole-branch pass — under River's 1-minute default it would
-have been cancelled mid-pass nightly, burned its three attempts, and left a
-permanently failing `privacy_retention_workspace` row for the one obligation
-whose whole point is auditability. Only `embedDriftWorkspaceWorker` is pinned
-today; `backend/` already has the scanner infrastructure to derive the rest.
-This is the rule-2 answer and wants its own diff.
+**Owed by #390, and the reason a blocker survived five task reviews.** What is
+missing is the FITNESS TEST, not the timeout: `privacyRetentionWorkspaceWorker`
+declares `Timeout` (`privacyRetentionPassTimeout`) and has since #390 fixed it.
+The gap is that nothing stops the next worker shipping without one. That worker
+went through five per-task reviews without a `Timeout` and was caught only by the
+whole-branch pass — under River's 1-minute default it would have been cancelled
+mid-pass nightly, burned its three attempts, and left a permanently failing
+`privacy_retention_workspace` row for the one obligation whose whole point is
+auditability. Only `embedDriftWorkspaceWorker` is pinned by a test today;
+`backend/` already has the scanner infrastructure to derive the rest. This is
+the rule-2 answer and wants its own diff.
 
 **Migration numbers race, and local gates provably cannot catch it.** #390's
 migration was renumbered twice — 0171 → 0172 → 0174 — and the second collision

--- a/STATUS.md
+++ b/STATUS.md
@@ -285,7 +285,7 @@ Vite/React web UI. What is deliberately still stubbed (answering explicit
 The merge gate (`make check`), the real-Postgres integration lane
 (`make test-integration`), and the live-boot job are all green.
 
-## Session pickup — 2026-08-03 (job observability, Phase 0 + Phase 1 A/B, merged)
+## Session pickup — 2026-08-03/04 (job observability, Phase 0 + Phase 1 A/B/C — Phase 1 COMPLETE)
 
 **Every unit of tenant work now names one workspace, and spells it one way.**
 PR #367 bound each job to a single workspace; PR #374 made the wire agree with

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -12527,7 +12527,7 @@ components:
     JobKindHealth:
       type: object
       additionalProperties: false
-      required: [kind, queue, fleet_wide, waiting, running, retrying, dead]
+      required: [kind, queue, fleet_wide, waiting, running, retrying, dead, oldest_waiting_age_seconds]
       properties:
         kind: { type: string, description: The stable job identifier River persists in river_job.kind. }
         queue: { type: string }
@@ -12553,7 +12553,7 @@ components:
     JobFailure:
       type: object
       additionalProperties: false
-      required: [kind, state, attempt, max_attempts, failed_at, reason]
+      required: [kind, workspace_id, state, attempt, max_attempts, failed_at, reason]
       properties:
         kind: { type: string }
         workspace_id:

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -398,6 +398,36 @@ paths:
               schema: { $ref: '#/components/schemas/Problem' }
         '422': { $ref: '#/components/responses/ValidationError' }
 
+  /admin/job-health:
+    get:
+      tags: [Identity]
+      operationId: getJobHealth
+      security: [ { cookieAuth: [] } ]   # human session only — rejects agent bearer/Passport
+      x-agent-access: human-only
+      summary: What the background system is holding, and whose work failed.
+      description: >
+        Admin-only. Reports the caller's own workspace's background jobs by kind — waiting,
+        running, retrying, and dead — plus the untenanted dispatcher rows that fan work out
+        to every workspace. Another workspace's jobs are never included: river_job carries no
+        workspace column and therefore no RLS, so this endpoint imposes the scope itself.
+        Failure text is the job layer's own vetted sentence, never a worker's raw cause
+        (that column is fleet-visible and has no redaction path). Human session only
+        (x-agent-access: human-only).
+      responses:
+        '200':
+          description: The workspace's background-job health.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/JobHealth' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403':
+          description: >
+            Refused: the caller is an agent/passport principal (this endpoint is human-only)
+            or a human without the admin role. Not an object/action RBAC grant denial.
+          content:
+            application/problem+json:
+              schema: { $ref: '#/components/schemas/Problem' }
+
   # ------------------------------ /passports --------------------------------
   /passports:
     get:
@@ -12473,6 +12503,73 @@ components:
             scopes:
               type: array
               items: { type: string, enum: [read_only, draft_only, act_with_approval, auto_execute_low_risk] }
+
+    # ---- Admin (background-job health) ----
+    JobHealth:
+      type: object
+      additionalProperties: false
+      required: [workspace_id, generated_at, kinds, recent_failures]
+      properties:
+        workspace_id:
+          type: string
+          format: uuid
+          description: The workspace these counts are scoped to — the caller's own.
+        generated_at: { type: string, format: date-time }
+        kinds:
+          type: array
+          items: { $ref: '#/components/schemas/JobKindHealth' }
+        recent_failures:
+          type: array
+          maxItems: 50
+          description: Most recent first, capped at 50. A bounded list, not a log.
+          items: { $ref: '#/components/schemas/JobFailure' }
+
+    JobKindHealth:
+      type: object
+      additionalProperties: false
+      required: [kind, queue, fleet_wide, waiting, running, retrying, dead]
+      properties:
+        kind: { type: string, description: The stable job identifier River persists in river_job.kind. }
+        queue: { type: string }
+        fleet_wide:
+          type: boolean
+          description: >
+            True for a dispatcher — a job that fans work out and does no tenant work of its
+            own. Its rows carry no workspace.
+        waiting: { type: integer, description: 'Available, scheduled or pending: queued and not yet started.' }
+        running: { type: integer }
+        retrying: { type: integer, description: Failed at least once and backing off toward another attempt. }
+        dead:
+          type: integer
+          description: >
+            Discarded or cancelled: this work will not happen without intervention. A discarded
+            job spent every attempt; a cancelled one was stopped deliberately.
+        oldest_waiting_age_seconds:
+          type: [integer, 'null']
+          description: >
+            How long the oldest runnable-and-unclaimed job of this kind has waited. Null when
+            nothing of this kind is runnable now; a job scheduled for the future is not late.
+
+    JobFailure:
+      type: object
+      additionalProperties: false
+      required: [kind, state, attempt, max_attempts, failed_at, reason]
+      properties:
+        kind: { type: string }
+        workspace_id:
+          type: [string, 'null']
+          format: uuid
+          description: Null for a dispatcher.
+        state: { type: string, enum: [retryable, discarded, cancelled] }
+        attempt: { type: integer }
+        max_attempts: { type: integer }
+        failed_at: { type: string, format: date-time }
+        reason:
+          type: string
+          description: >
+            The job layer's vetted operator sentence. A failure whose stored text did not come
+            from that closed vocabulary reports a fixed substitute instead — the raw cause never
+            travels here.
 
     # ---- Audit ----
     AuditLogEntry:

--- a/backend/internal/compose/agentpolicy_gen.go
+++ b/backend/internal/compose/agentpolicy_gen.go
@@ -108,6 +108,7 @@ var agentPolicies = map[string]agentPolicy{
 	"DELETE /v1/webhook-subscriptions/{id}":                              {Op: "archiveWebhookSubscription", Access: "human-only", Tool: "", RecordType: "", Tier: ""},
 	"GET /v1/activities":                                                 {Op: "listActivities", Access: "tool", Tool: "search_records", RecordType: "activity", Tier: "auto_execute"},
 	"GET /v1/activities/{id}":                                            {Op: "getActivity", Access: "tool", Tool: "read_record", RecordType: "activity", Tier: "auto_execute"},
+	"GET /v1/admin/job-health":                                           {Op: "getJobHealth", Access: "human-only", Tool: "", RecordType: "", Tier: ""},
 	"GET /v1/agent-tools":                                                {Op: "listAgentTools", Access: "human-only", Tool: "", RecordType: "", Tier: ""},
 	"GET /v1/ai/calls":                                                   {Op: "listAiCalls", Access: "human-only", Tool: "", RecordType: "", Tier: ""},
 	"GET /v1/ai/calls/{id}":                                              {Op: "getAiCall", Access: "human-only", Tool: "", RecordType: "", Tier: ""},

--- a/backend/internal/compose/dispatch.go
+++ b/backend/internal/compose/dispatch.go
@@ -13,12 +13,14 @@ package compose
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/riverqueue/river"
 
+	"github.com/gradionhq/margince/backend/internal/platform/jobs"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -180,10 +182,45 @@ func dispatchWith(ctx context.Context, workspaces []ids.UUID, insert insertManyF
 	}
 	params := make([]river.InsertManyParams, 0, len(workspaces))
 	for _, ws := range workspaces {
-		params = append(params, river.InsertManyParams{Args: argsFor(ws), InsertOpts: opts})
+		params = append(params, river.InsertManyParams{Args: argsFor(ws), InsertOpts: markedAsFleetPass(opts)})
 	}
 	if err := insert(ctx, params); err != nil {
 		return fmt.Errorf("compose: dispatching %d workspace jobs: %w", len(params), err)
 	}
 	return nil
+}
+
+// markedAsFleetPass copies opts with the sweep tag added, so a reader can
+// tell one workspace's share of a fleet pass from the same kind enqueued by
+// hand — they are the same kind, and the tag is the only difference in the
+// row. Tags are validated for format only and take no part in River's
+// unique key, so this changes no scheduling behaviour.
+//
+// EVERY fan-out site calls it, not only dispatchWith. Five dispatchers fan
+// out with a loop of single inserts instead — gmailSyncWorker and
+// gmailWatchWorker (jobs_capture.go), telegramPollSweepWorker
+// (telegrampoll.go) and voiceBuildRetryWorker (voicebuild.go) — and a site
+// that forgets the tag is silently absent from the sweep gauges while the
+// gauge's own HELP text blames River's retention for the gap.
+//
+// It COPIES because every dispatcher passes a value built once by
+// workspaceSweepOpts and reused for the life of the process: appending in
+// place would grow one tag per pass and hand the caller back a mutated
+// struct.
+//
+// A nil opts yields a tag-ONLY value on purpose. River merges the explicit
+// opts with the args' own InsertOpts field by field, falling back to the
+// args for any field the explicit value leaves at its zero — so a caller
+// that passes nil to let its args declare the uniqueness window (the
+// telegram poll's per-bot rule) keeps that fallback intact.
+func markedAsFleetPass(opts *river.InsertOpts) *river.InsertOpts {
+	marked := river.InsertOpts{}
+	if opts != nil {
+		marked = *opts
+	}
+	if slices.Contains(marked.Tags, jobs.SweepTag) {
+		return &marked
+	}
+	marked.Tags = append(slices.Clone(marked.Tags), jobs.SweepTag)
+	return &marked
 }

--- a/backend/internal/compose/dispatch.go
+++ b/backend/internal/compose/dispatch.go
@@ -211,11 +211,13 @@ func dispatchWith(ctx context.Context, workspaces []ids.UUID, insert insertManyF
 // user-initiated build path besides. Appending in place would grow one tag
 // per workspace and hand the caller back a mutated struct.
 //
-// A nil opts yields a tag-ONLY value on purpose. River merges the explicit
-// opts with the args' own InsertOpts field by field, falling back to the
-// args for any field the explicit value leaves at its zero — so a caller
-// that passes nil to let its args declare the uniqueness window (the
-// telegram poll's per-bot rule) keeps that fallback intact.
+// A nil opts yields a tag-ONLY value on purpose. For the fields that matter
+// here — queue, max attempts, priority, tags and the uniqueness window —
+// River falls back to the args' own InsertOpts whenever the explicit value
+// leaves that field at its zero, so a caller that passes nil to let its
+// args declare the uniqueness window (the telegram poll's per-bot rule)
+// keeps that fallback intact. It is NOT a blanket rule over every field:
+// metadata, for one, is defaulted rather than inherited.
 func markedAsFleetPass(opts *river.InsertOpts) *river.InsertOpts {
 	marked := river.InsertOpts{}
 	if opts != nil {

--- a/backend/internal/compose/dispatch.go
+++ b/backend/internal/compose/dispatch.go
@@ -197,16 +197,19 @@ func dispatchWith(ctx context.Context, workspaces []ids.UUID, insert insertManyF
 // unique key, so this changes no scheduling behaviour.
 //
 // EVERY fan-out site calls it, not only dispatchWith. Five dispatchers fan
-// out with a loop of single inserts instead — gmailSyncWorker and
-// gmailWatchWorker (jobs_capture.go), telegramPollSweepWorker
-// (telegrampoll.go) and voiceBuildRetryWorker (voicebuild.go) — and a site
-// that forgets the tag is silently absent from the sweep gauges while the
-// gauge's own HELP text blames River's retention for the gap.
+// out with a loop of single inserts instead, and each one calls it
+// directly: gmailSyncWorker and gmailWatchWorker (jobs_capture.go),
+// telegramPollSweepWorker (telegrampoll.go), voiceBuildRetryWorker
+// (voicebuild.go) and overlayReconcileWorker (jobs_overlay.go). A site that
+// forgets the tag is silently absent from the sweep gauges while the
+// gauge's own HELP text blames River's retention for the gap. Nothing
+// derives that obligation yet — this list is the registry, so it has to be
+// right.
 //
-// It COPIES because every dispatcher passes a value built once by
-// workspaceSweepOpts and reused for the life of the process: appending in
-// place would grow one tag per pass and hand the caller back a mutated
-// struct.
+// It COPIES because a single dispatch shares ONE opts value across every
+// workspace in its loop, and voiceBuildInsertOpts' value is shared with the
+// user-initiated build path besides. Appending in place would grow one tag
+// per workspace and hand the caller back a mutated struct.
 //
 // A nil opts yields a tag-ONLY value on purpose. River merges the explicit
 // opts with the args' own InsertOpts field by field, falling back to the

--- a/backend/internal/compose/dispatch_test.go
+++ b/backend/internal/compose/dispatch_test.go
@@ -6,6 +6,8 @@ package compose
 import (
 	"context"
 	"errors"
+	"regexp"
+	"slices"
 	"testing"
 
 	"github.com/riverqueue/river"
@@ -105,4 +107,133 @@ func TestWorkspaceSweepOptsCapsTheLadderAndDedupesOnActiveStates(t *testing.T) {
 
 func closeDateWorkspaceArgsFor(ws ids.UUID) river.JobArgs {
 	return CloseDateWorkspaceArgs{Workspace: ws}
+}
+
+// TestEveryFanOutChildIsMarkedAsOneWorkspacesShareOfAFleetPass — the sweep
+// gauges cannot tell a fleet pass from a hand-triggered workspace job by
+// kind alone, because they are the same kind. The tag is the difference.
+func TestEveryFanOutChildIsMarkedAsOneWorkspacesShareOfAFleetPass(t *testing.T) {
+	var got []river.InsertManyParams
+	insert := func(_ context.Context, params []river.InsertManyParams) error {
+		got = params
+		return nil
+	}
+	fleet := []ids.UUID{ids.NewV7(), ids.NewV7()}
+
+	if err := dispatchWith(context.Background(), fleet, insert,
+		workspaceSweepOpts("", sweepWorkspaceMaxAttempts), closeDateWorkspaceArgsFor); err != nil {
+		t.Fatalf("dispatchWith: %v", err)
+	}
+
+	if len(got) != len(fleet) {
+		t.Fatalf("inserted %d params, want %d", len(got), len(fleet))
+	}
+	for i, p := range got {
+		if p.InsertOpts == nil {
+			t.Fatalf("param %d carries no InsertOpts at all", i)
+		}
+		if !slices.Contains(p.InsertOpts.Tags, jobs.SweepTag) {
+			t.Errorf("param %d tags = %v, want it to contain %q", i, p.InsertOpts.Tags, jobs.SweepTag)
+		}
+	}
+}
+
+// TestTheFanOutTagDoesNotMutateTheCallersInsertOpts — every dispatcher
+// passes a shared opts value built once by workspaceSweepOpts and reused
+// for the life of the process. Appending to it in place would accumulate
+// one tag per pass, forever, on a struct the caller still owns.
+func TestTheFanOutTagDoesNotMutateTheCallersInsertOpts(t *testing.T) {
+	opts := workspaceSweepOpts("default", sweepWorkspaceMaxAttempts)
+	before := len(opts.Tags)
+	insert := func(context.Context, []river.InsertManyParams) error { return nil }
+
+	for range 3 {
+		if err := dispatchWith(context.Background(), []ids.UUID{ids.NewV7()}, insert, opts,
+			closeDateWorkspaceArgsFor); err != nil {
+			t.Fatalf("dispatchWith: %v", err)
+		}
+	}
+	if len(opts.Tags) != before {
+		t.Errorf("the caller's opts grew to %d tags over three passes; the tag must be "+
+			"applied to a copy", len(opts.Tags))
+	}
+}
+
+// TestTheFanOutTagCarriesTheCallersEnqueuePolicyThrough — the tag is
+// additive. A copy that dropped the queue, the attempt cap or the
+// uniqueness window would change how the fleet is enqueued in order to
+// describe it, which is the one thing an observability change may not do.
+func TestTheFanOutTagCarriesTheCallersEnqueuePolicyThrough(t *testing.T) {
+	opts := workspaceSweepOpts("ai_capture", sweepWorkspaceMaxAttempts)
+	marked := markedAsFleetPass(opts)
+
+	if marked.Queue != opts.Queue {
+		t.Errorf("Queue = %q, want %q", marked.Queue, opts.Queue)
+	}
+	if marked.MaxAttempts != opts.MaxAttempts {
+		t.Errorf("MaxAttempts = %d, want %d", marked.MaxAttempts, opts.MaxAttempts)
+	}
+	if !marked.UniqueOpts.ByArgs {
+		t.Error("the uniqueness window was dropped by the copy")
+	}
+	if !slices.Equal(marked.UniqueOpts.ByState, opts.UniqueOpts.ByState) {
+		t.Errorf("ByState = %v, want %v", marked.UniqueOpts.ByState, opts.UniqueOpts.ByState)
+	}
+}
+
+// TestTheFanOutTagIsStampedOnceEvenIfTheCallerAlreadySetIt — the three
+// dispatchers that loop single inserts call markedAsFleetPass directly, and
+// a caller that had already tagged its opts must not end up with the tag
+// twice: River validates tags but does not deduplicate them, and a
+// duplicated tag is noise in a column an operator reads.
+func TestTheFanOutTagIsStampedOnceEvenIfTheCallerAlreadySetIt(t *testing.T) {
+	marked := markedAsFleetPass(&river.InsertOpts{Tags: []string{jobs.SweepTag}})
+
+	var seen int
+	for _, tag := range marked.Tags {
+		if tag == jobs.SweepTag {
+			seen++
+		}
+	}
+	if seen != 1 {
+		t.Errorf("the sweep tag appears %d times, want exactly 1: %v", seen, marked.Tags)
+	}
+}
+
+// TestTheFanOutTagLeavesNilOptsUsable — the telegram dispatcher passes nil
+// opts on purpose, because TelegramPollArgs declares its own InsertOpts so
+// no inserter can forget the per-bot uniqueness by omission. River merges
+// the two field by field, and UniqueOpts falls back to the args' own
+// whenever the explicit opts leave it empty — so a tag-only opts value
+// preserves that property rather than silently replacing it.
+func TestTheFanOutTagLeavesNilOptsUsable(t *testing.T) {
+	marked := markedAsFleetPass(nil)
+
+	if marked == nil {
+		t.Fatal("markedAsFleetPass(nil) returned nil; a dispatcher would then insert untagged")
+	}
+	if !slices.Contains(marked.Tags, jobs.SweepTag) {
+		t.Errorf("tags = %v, want the sweep tag", marked.Tags)
+	}
+	// River's own isEmpty is unexported, so the fields it reads are checked
+	// here directly: any one of them set makes River stop consulting the
+	// args' own InsertOpts for uniqueness.
+	u := marked.UniqueOpts
+	if u.ByArgs || u.ByQueue || u.ExcludeKind || u.ByPeriod != 0 || len(u.ByState) != 0 {
+		t.Errorf("a tag-only opts value declared a uniqueness window of its own (%+v); River "+
+			"would then stop falling back to the one the args declare", u)
+	}
+}
+
+// TestTheFanOutTagIsAcceptedByRiversOwnTagValidation — the tag reaches a
+// column River validates on insert. A value River refuses would fail every
+// fan-out in the fleet at once, and no test below the insert would notice.
+func TestTheFanOutTagIsAcceptedByRiversOwnTagValidation(t *testing.T) {
+	if len(jobs.SweepTag) > 255 {
+		t.Fatalf("the sweep tag is %d characters; River refuses a tag over 255", len(jobs.SweepTag))
+	}
+	if !regexp.MustCompile(`\A[\w][\w\-]+[\w]\z`).MatchString(jobs.SweepTag) {
+		t.Errorf("the sweep tag %q does not match the format River validates tags against",
+			jobs.SweepTag)
+	}
 }

--- a/backend/internal/compose/dispatch_test.go
+++ b/backend/internal/compose/dispatch_test.go
@@ -138,10 +138,11 @@ func TestEveryFanOutChildIsMarkedAsOneWorkspacesShareOfAFleetPass(t *testing.T) 
 	}
 }
 
-// TestTheFanOutTagDoesNotMutateTheCallersInsertOpts — every dispatcher
-// passes a shared opts value built once by workspaceSweepOpts and reused
-// for the life of the process. Appending to it in place would accumulate
-// one tag per pass, forever, on a struct the caller still owns.
+// TestTheFanOutTagDoesNotMutateTheCallersInsertOpts — one dispatch shares
+// ONE opts value across every workspace in its loop, and voiceBuildInsertOpts'
+// value is shared with the user-initiated build path besides. Appending to
+// it in place would accumulate one tag per workspace on a struct the caller
+// still owns.
 func TestTheFanOutTagDoesNotMutateTheCallersInsertOpts(t *testing.T) {
 	opts := workspaceSweepOpts("default", sweepWorkspaceMaxAttempts)
 	before := len(opts.Tags)
@@ -181,7 +182,7 @@ func TestTheFanOutTagCarriesTheCallersEnqueuePolicyThrough(t *testing.T) {
 	}
 }
 
-// TestTheFanOutTagIsStampedOnceEvenIfTheCallerAlreadySetIt — the three
+// TestTheFanOutTagIsStampedOnceEvenIfTheCallerAlreadySetIt — the five
 // dispatchers that loop single inserts call markedAsFleetPass directly, and
 // a caller that had already tagged its opts must not end up with the tag
 // twice: River validates tags but does not deduplicate them, and a

--- a/backend/internal/compose/dispatch_test.go
+++ b/backend/internal/compose/dispatch_test.go
@@ -109,10 +109,18 @@ func closeDateWorkspaceArgsFor(ws ids.UUID) river.JobArgs {
 	return CloseDateWorkspaceArgs{Workspace: ws}
 }
 
-// TestEveryFanOutChildIsMarkedAsOneWorkspacesShareOfAFleetPass — the sweep
-// gauges cannot tell a fleet pass from a hand-triggered workspace job by
-// kind alone, because they are the same kind. The tag is the difference.
-func TestEveryFanOutChildIsMarkedAsOneWorkspacesShareOfAFleetPass(t *testing.T) {
+// TestDispatchWithMarksEveryChildAsOneWorkspacesShareOfAFleetPass — the
+// sweep gauges cannot tell a fleet pass from a hand-triggered workspace job
+// by kind alone, because they are the same kind. The tag is the difference.
+//
+// This covers the dispatchWith choke point ONLY. The five dispatchers that
+// loop single client.Insert calls (jobs_capture.go x2, telegrampoll.go,
+// voicebuild.go, jobs_overlay.go) are not reachable from here — they resolve
+// a River client from context — so a regression in any of them would still
+// pass. Their tagging is held by markedAsFleetPass' own registry comment and
+// by review, which is why a fitness test over fan-out SITES is carried as
+// the highest-value follow-up in STATUS.md rather than claimed here.
+func TestDispatchWithMarksEveryChildAsOneWorkspacesShareOfAFleetPass(t *testing.T) {
 	var got []river.InsertManyParams
 	insert := func(_ context.Context, params []river.InsertManyParams) error {
 		got = params
@@ -145,6 +153,11 @@ func TestEveryFanOutChildIsMarkedAsOneWorkspacesShareOfAFleetPass(t *testing.T) 
 // still owns.
 func TestTheFanOutTagDoesNotMutateTheCallersInsertOpts(t *testing.T) {
 	opts := workspaceSweepOpts("default", sweepWorkspaceMaxAttempts)
+	// Spare CAPACITY is the case a length check cannot see: append would
+	// write into the caller's own backing array and leave len unchanged, so
+	// the aliasing this test exists to catch would go unnoticed.
+	opts.Tags = append(make([]string, 0, 4), "caller-owned")
+	backing := opts.Tags[:cap(opts.Tags)]
 	before := len(opts.Tags)
 	insert := func(context.Context, []river.InsertManyParams) error { return nil }
 
@@ -157,6 +170,15 @@ func TestTheFanOutTagDoesNotMutateTheCallersInsertOpts(t *testing.T) {
 	if len(opts.Tags) != before {
 		t.Errorf("the caller's opts grew to %d tags over three passes; the tag must be "+
 			"applied to a copy", len(opts.Tags))
+	}
+	if opts.Tags[0] != "caller-owned" {
+		t.Errorf("the caller's own tag was overwritten: %v", opts.Tags)
+	}
+	for i, tag := range backing[before:] {
+		if tag != "" {
+			t.Errorf("the fan-out wrote %q into the caller's spare capacity at index %d; "+
+				"the copy must not alias the caller's backing array", tag, before+i)
+		}
 	}
 }
 

--- a/backend/internal/compose/integration/jobhealth_http_e2e_integration_test.go
+++ b/backend/internal/compose/integration/jobhealth_http_e2e_integration_test.go
@@ -14,7 +14,9 @@ package integration
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
+	"net/http/cookiejar"
 	"strings"
 	"testing"
 	"time"
@@ -268,16 +270,15 @@ func TestJobHealthReportsAVettedSentenceForAFaultedWorkerAndSubstitutesForARawOn
 		t.Fatalf("expected both failures in the report, got %+v", report.RecentFailures)
 	}
 
-	// The whole body, not just the parsed fields: a trace that leaked
-	// through some OTHER field would pass every assertion above.
-	encoded, err := json.Marshal(report)
-	if err != nil {
-		t.Fatalf("re-encoding the report: %v", err)
-	}
-	for _, forbidden := range []string{"goroutine", "secretInternals", "someone@example.com"} {
-		if containsIgnoringCase(string(encoded), forbidden) {
+	// The bytes the server actually sent, NOT a re-marshalled DTO. Encoding
+	// the parsed struct would prove only that the fields this test declares
+	// are clean — every field it does not declare was silently dropped at
+	// decode, which is exactly where an unnoticed leak would live.
+	body := rawGet(t, e, "/v1/admin/job-health")
+	for _, forbidden := range []string{"goroutine", "secretInternals", "someone@example.com", "trace"} {
+		if containsIgnoringCase(body, forbidden) {
 			t.Errorf("the response body carries %q; only the attempt error's MESSAGE may be "+
-				"read, never the element, and only when vetted", forbidden)
+				"read, never the element, and only when vetted.\nbody: %s", forbidden, body)
 		}
 	}
 }
@@ -411,8 +412,111 @@ func TestJobHealthIgnoresTheSweepTagWhenScopingRows(t *testing.T) {
 	}
 }
 
+// rawGet answers the response body VERBATIM, so a leak assertion reads
+// what the server sent rather than what a test DTO chose to keep. env.call
+// decodes into a typed struct, which drops every field the struct does not
+// declare — and an undeclared field is precisely where an unnoticed leak
+// would sit.
+func rawGet(t *testing.T, e *env, path string) string {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, e.ts.URL+path, nil)
+	if err != nil {
+		t.Fatalf("building request: %v", err)
+	}
+	resp, err := e.client.Do(req)
+	if err != nil {
+		t.Fatalf("GET %s: %v", path, err)
+	}
+	defer closeBody(t, resp)
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("reading response: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET %s → %d, want 200", path, resp.StatusCode)
+	}
+	return string(raw)
+}
+
 // containsIgnoringCase keeps the leak assertions above from passing on a
 // difference of case alone.
 func containsIgnoringCase(haystack, needle string) bool {
 	return strings.Contains(strings.ToLower(haystack), strings.ToLower(needle))
+}
+
+// TestJobHealthCapsTheFailureListAndOrdersItNewestFirst — recent_failures
+// is a bounded view, not a log. Without the cap an installation with a
+// week of discarded rows would serve all of them; without the order the
+// "recent" in the field name is a lie, and the 50 an operator sees would
+// be an arbitrary 50 rather than the newest.
+func TestJobHealthCapsTheFailureListAndOrdersItNewestFirst(t *testing.T) {
+	e := setup(t)
+	e.bootstrapWorkspace(t)
+	mine := callerWorkspace(t, e)
+
+	// 60 failures, finalized at ascending times, so the newest are the
+	// highest-numbered and a correct read returns exactly those.
+	const seeded = 60
+	for i := range seeded {
+		seedRiverRow(t, e, riverRow{
+			kind: "capped_pass", state: "discarded", workspace: mine, attempt: 3,
+		})
+		if _, err := e.owner.Exec(context.Background(),
+			`UPDATE river_job SET finalized_at = now() - make_interval(mins => $1)
+			 WHERE kind = 'capped_pass' AND finalized_at IS NOT NULL
+			   AND id = (SELECT max(id) FROM river_job WHERE kind = 'capped_pass')`,
+			seeded-i); err != nil {
+			t.Fatalf("ageing fixture row %d: %v", i, err)
+		}
+	}
+
+	var report jobHealthDTO
+	if status := e.call(t, "GET", "/v1/admin/job-health", nil, nil, &report); status != http.StatusOK {
+		t.Fatalf("GET /admin/job-health → %d, want 200", status)
+	}
+
+	if len(report.RecentFailures) != 50 {
+		t.Errorf("recent_failures has %d entries, want the declared cap of 50 out of %d seeded",
+			len(report.RecentFailures), seeded)
+	}
+	for i := 1; i < len(report.RecentFailures); i++ {
+		prev, cur := report.RecentFailures[i-1].FailedAt, report.RecentFailures[i].FailedAt
+		if prev < cur {
+			t.Fatalf("failure %d (%s) is newer than failure %d (%s): the list must be "+
+				"newest-first, or the 50 an operator sees are an arbitrary 50", i, cur, i-1, prev)
+		}
+	}
+	// The newest seeded row is one minute old; the oldest is an hour. A
+	// correct cap keeps the newest end, so the oldest ten must be absent.
+	oldest := report.RecentFailures[len(report.RecentFailures)-1].FailedAt
+	cutoff := time.Now().Add(-51 * time.Minute).UTC().Format(time.RFC3339)
+	if oldest < cutoff {
+		t.Errorf("the retained window reaches back to %s, past %s: the cap kept the OLDEST "+
+			"rows rather than the newest", oldest, cutoff)
+	}
+}
+
+// TestJobHealthRefusesAnUnauthenticatedCallOverHTTP — the contract declares
+// 401 for a call with no session, and that answer comes from the session
+// middleware rather than from the handler, so only the real wire proves it.
+func TestJobHealthRefusesAnUnauthenticatedCallOverHTTP(t *testing.T) {
+	e := setup(t)
+	// Bootstrapped, so the installation EXISTS — an unbootstrapped one
+	// answers 503 for every route and would prove nothing about this
+	// endpoint — and then stripped of its session cookie, so the request
+	// carries no credential of any kind.
+	e.bootstrapWorkspace(t)
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("fresh cookie jar: %v", err)
+	}
+	e.client.Jar = jar
+
+	var problem struct {
+		Code string `json:"code"`
+	}
+	status := e.call(t, "GET", "/v1/admin/job-health", nil, nil, &problem)
+	if status != http.StatusUnauthorized {
+		t.Errorf("unauthenticated GET /admin/job-health → %d, want 401", status)
+	}
 }

--- a/backend/internal/compose/integration/jobhealth_http_e2e_integration_test.go
+++ b/backend/internal/compose/integration/jobhealth_http_e2e_integration_test.go
@@ -1,0 +1,418 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// GET /admin/job-health over the real wire. river_job has no workspace
+// column and therefore no RLS, so the scope is the handler's own — which
+// means a test that only ever creates one workspace cannot tell a working
+// filter from a missing one. Every case here seeds a SECOND workspace's
+// rows and asserts their absence.
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/platform/jobs"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+type jobHealthDTO struct {
+	WorkspaceID string `json:"workspace_id"`
+	GeneratedAt string `json:"generated_at"`
+	Kinds       []struct {
+		Kind                    string `json:"kind"`
+		Queue                   string `json:"queue"`
+		FleetWide               bool   `json:"fleet_wide"`
+		Waiting                 int    `json:"waiting"`
+		Running                 int    `json:"running"`
+		Retrying                int    `json:"retrying"`
+		Dead                    int    `json:"dead"`
+		OldestWaitingAgeSeconds *int   `json:"oldest_waiting_age_seconds"`
+	} `json:"kinds"`
+	RecentFailures []struct {
+		Kind        string  `json:"kind"`
+		WorkspaceID *string `json:"workspace_id"`
+		State       string  `json:"state"`
+		Attempt     int     `json:"attempt"`
+		MaxAttempts int     `json:"max_attempts"`
+		FailedAt    string  `json:"failed_at"`
+		Reason      string  `json:"reason"`
+	} `json:"recent_failures"`
+}
+
+// riverRow is one raw river_job row a scenario needs in a state or with
+// stored error text that a real enqueue cannot produce on demand.
+type riverRow struct {
+	kind      string
+	queue     string
+	state     string
+	workspace string // empty writes NO workspace_id key — a dispatcher
+	attempt   int
+	errorText string // the newest attempt's stored message; empty writes no errors
+	trace     string // a panic stack, so a test can prove it never travels
+}
+
+// seedRiverRow writes one row through the OWNER connection: river_job has
+// no RLS, and this fixture deliberately writes rows the app would refuse to
+// create, including another workspace's.
+func seedRiverRow(t *testing.T, e *env, r riverRow) {
+	t.Helper()
+	ctx := context.Background()
+
+	queue := r.queue
+	if queue == "" {
+		queue = "default"
+	}
+	args := map[string]any{}
+	if r.workspace != "" {
+		args["workspace_id"] = r.workspace
+	}
+	encodedArgs, err := json.Marshal(args)
+	if err != nil {
+		t.Fatalf("encoding fixture args: %v", err)
+	}
+
+	encodedErrors := [][]byte{}
+	if r.errorText != "" {
+		element, err := json.Marshal(map[string]any{
+			"at": time.Now().UTC().Format(time.RFC3339Nano), "attempt": r.attempt,
+			"error": r.errorText, "trace": r.trace,
+		})
+		if err != nil {
+			t.Fatalf("encoding fixture attempt error: %v", err)
+		}
+		encodedErrors = append(encodedErrors, element)
+	}
+
+	// river_job's finalized_or_finalized_at_null CHECK refuses a finalized
+	// state with a null finalized_at, so the fixture stamps it rather than
+	// failing at the database instead of at the assertion.
+	var finalizedAt *time.Time
+	if r.state == "completed" || r.state == "cancelled" || r.state == "discarded" {
+		now := time.Now()
+		finalizedAt = &now
+	}
+
+	if _, err := e.owner.Exec(ctx, `
+		INSERT INTO river_job
+		    (state, kind, queue, args, tags, errors, max_attempts, attempt,
+		     created_at, scheduled_at, finalized_at)
+		VALUES ($1::river_job_state, $2, $3, $4::jsonb, '{}'::varchar(255)[],
+		        $5::jsonb[], 3, $6, now(), now() - interval '10 minutes', $7)`,
+		r.state, r.kind, queue, encodedArgs, encodedErrors, r.attempt, finalizedAt); err != nil {
+		t.Fatalf("seeding a %s %s row: %v", r.state, r.kind, err)
+	}
+}
+
+// callerWorkspace answers the id of the workspace the bootstrapped admin
+// session belongs to — the one the endpoint must scope itself to.
+func callerWorkspace(t *testing.T, e *env) string {
+	t.Helper()
+	var id string
+	if err := e.owner.QueryRow(context.Background(),
+		`SELECT id FROM workspace WHERE slug = $1`, e.slug).Scan(&id); err != nil {
+		t.Fatalf("resolving the caller's workspace: %v", err)
+	}
+	return id
+}
+
+// kindOf finds one reported kind, and says so when it is absent — the
+// absence is the assertion in half these cases.
+func kindOf(report jobHealthDTO, kind string) (int, bool) {
+	for i, k := range report.Kinds {
+		if k.Kind == kind {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+// TestJobHealthReportsThisWorkspacesDeadWorkAndNotAnotherWorkspacesAnything
+// is the case that matters most. The scope is imposed by the handler
+// because river_job has no RLS to impose it, so a second workspace has to
+// be present or the test proves nothing.
+func TestJobHealthReportsThisWorkspacesDeadWorkAndNotAnotherWorkspacesAnything(t *testing.T) {
+	e := setup(t)
+	e.bootstrapWorkspace(t)
+	mine := callerWorkspace(t, e)
+	theirs := ids.NewV7().String()
+
+	seedRiverRow(t, e, riverRow{
+		kind: "privacy_retention_workspace", state: "discarded",
+		workspace: mine, attempt: 3, errorText: "the record this job names no longer exists",
+	})
+	seedRiverRow(t, e, riverRow{
+		kind: "privacy_retention_workspace", state: "available",
+		workspace: mine,
+	})
+	// Another tenant's dead work, of a DIFFERENT kind so its presence would
+	// be unmistakable rather than folded into a count.
+	seedRiverRow(t, e, riverRow{
+		kind: "someone_elses_pass", state: "discarded",
+		workspace: theirs, attempt: 3, errorText: "another tenant's failure",
+	})
+	// A dispatcher: no workspace at all, and a kind the closed untenanted
+	// arm declares.
+	seedRiverRow(t, e, riverRow{
+		kind: "privacy_retention", state: "available",
+	})
+	// An untenanted row whose kind is NOT a declared dispatcher. The arm is
+	// fail-closed, so it must be omitted rather than shared with every admin.
+	seedRiverRow(t, e, riverRow{kind: "not_a_declared_dispatcher", state: "discarded", attempt: 3})
+
+	var report jobHealthDTO
+	if status := e.call(t, "GET", "/v1/admin/job-health", nil, nil, &report); status != http.StatusOK {
+		t.Fatalf("GET /admin/job-health → %d, want 200", status)
+	}
+
+	if report.WorkspaceID != mine {
+		t.Errorf("report is scoped to %s, want the caller's own %s", report.WorkspaceID, mine)
+	}
+
+	i, ok := kindOf(report, "privacy_retention_workspace")
+	if !ok {
+		t.Fatalf("the caller's own failing kind is missing from %+v", report.Kinds)
+	}
+	if report.Kinds[i].Dead != 1 {
+		t.Errorf("dead = %d, want 1", report.Kinds[i].Dead)
+	}
+	if report.Kinds[i].Waiting != 1 {
+		t.Errorf("waiting = %d, want 1", report.Kinds[i].Waiting)
+	}
+	if report.Kinds[i].FleetWide {
+		t.Error("a workspace-scoped kind was reported as fleet-wide")
+	}
+
+	if _, ok := kindOf(report, "someone_elses_pass"); ok {
+		t.Error("another workspace's job kind reached this workspace's admin — river_job has " +
+			"no RLS, so nothing but this handler was ever going to stop that")
+	}
+	if _, ok := kindOf(report, "not_a_declared_dispatcher"); ok {
+		t.Error("an untenanted row of an undeclared kind was admitted; the arm must be " +
+			"closed against the declared dispatcher kinds, not open to every null")
+	}
+
+	d, ok := kindOf(report, "privacy_retention")
+	if !ok {
+		t.Fatal("the dispatcher is missing: a dispatcher that is not running means no " +
+			"workspace is being swept at all, which is what an admin comes here to see")
+	}
+	if !report.Kinds[d].FleetWide {
+		t.Error("the dispatcher was not reported as fleet-wide")
+	}
+
+	for _, f := range report.RecentFailures {
+		if f.Kind == "someone_elses_pass" {
+			t.Error("another workspace's failure reached the failure list")
+		}
+		if f.WorkspaceID != nil && *f.WorkspaceID != mine {
+			t.Errorf("a failure named workspace %s, which is not the caller's", *f.WorkspaceID)
+		}
+	}
+}
+
+// TestJobHealthReportsAVettedSentenceForAFaultedWorkerAndSubstitutesForARawOne
+// — the column is fleet-visible with no RLS and no redaction path, so a raw
+// provider cause must not travel, and the panic stack River stores beside
+// it must not either.
+func TestJobHealthReportsAVettedSentenceForAFaultedWorkerAndSubstitutesForARawOne(t *testing.T) {
+	e := setup(t)
+	e.bootstrapWorkspace(t)
+	mine := callerWorkspace(t, e)
+
+	vetted := "the record this job names no longer exists"
+	raw := `smtp: 550 5.1.1 <someone@example.com>: recipient rejected`
+	stack := "goroutine 1 [running]:\nmain.secretInternals(0xdeadbeef)"
+
+	seedRiverRow(t, e, riverRow{
+		kind: "faulted_pass", state: "discarded",
+		workspace: mine, attempt: 3, errorText: vetted, trace: stack,
+	})
+	seedRiverRow(t, e, riverRow{
+		kind: "raw_pass", state: "discarded",
+		workspace: mine, attempt: 3, errorText: raw, trace: stack,
+	})
+
+	var report jobHealthDTO
+	if status := e.call(t, "GET", "/v1/admin/job-health", nil, nil, &report); status != http.StatusOK {
+		t.Fatalf("GET /admin/job-health → %d, want 200", status)
+	}
+
+	var sawVetted, sawRawKind bool
+	for _, f := range report.RecentFailures {
+		switch f.Kind {
+		case "faulted_pass":
+			sawVetted = true
+			if f.Reason != vetted {
+				t.Errorf("a vetted sentence was substituted away: got %q, want %q", f.Reason, vetted)
+			}
+		case "raw_pass":
+			sawRawKind = true
+			if f.Reason == raw {
+				t.Error("a worker's raw cause reached the wire, naming the address a " +
+					"provider refused")
+			}
+		}
+		if f.Reason == stack {
+			t.Error("River's stored panic trace reached the wire")
+		}
+	}
+	if !sawVetted || !sawRawKind {
+		t.Fatalf("expected both failures in the report, got %+v", report.RecentFailures)
+	}
+
+	// The whole body, not just the parsed fields: a trace that leaked
+	// through some OTHER field would pass every assertion above.
+	encoded, err := json.Marshal(report)
+	if err != nil {
+		t.Fatalf("re-encoding the report: %v", err)
+	}
+	for _, forbidden := range []string{"goroutine", "secretInternals", "someone@example.com"} {
+		if containsIgnoringCase(string(encoded), forbidden) {
+			t.Errorf("the response body carries %q; only the attempt error's MESSAGE may be "+
+				"read, never the element, and only when vetted", forbidden)
+		}
+	}
+}
+
+// TestJobHealthCountsACancelledRowThatCarriesNoAttemptErrorAtAll — River's
+// cancel path appends nothing to errors, so a terminal row can have no
+// attempt error while the contract still requires failed_at and reason.
+// Scanning a null into either turns the endpoint into a 500.
+func TestJobHealthCountsACancelledRowThatCarriesNoAttemptErrorAtAll(t *testing.T) {
+	e := setup(t)
+	e.bootstrapWorkspace(t)
+	mine := callerWorkspace(t, e)
+
+	seedRiverRow(t, e, riverRow{
+		kind: "cancelled_pass", state: "cancelled", workspace: mine,
+	})
+	var report jobHealthDTO
+	if status := e.call(t, "GET", "/v1/admin/job-health", nil, nil, &report); status != http.StatusOK {
+		t.Fatalf("GET /admin/job-health → %d, want 200: a cancelled row with no attempt "+
+			"error must not fail the read", status)
+	}
+
+	i, ok := kindOf(report, "cancelled_pass")
+	if !ok {
+		t.Fatalf("the cancelled kind is missing from %+v", report.Kinds)
+	}
+	if report.Kinds[i].Dead != 1 {
+		t.Errorf("dead = %d, want 1: a cancelled pass did not run", report.Kinds[i].Dead)
+	}
+
+	var found bool
+	for _, f := range report.RecentFailures {
+		if f.Kind != "cancelled_pass" {
+			continue
+		}
+		found = true
+		if f.FailedAt == "" {
+			t.Error("failed_at is empty; finalized_at is the fallback when no attempt error exists")
+		}
+		if f.Reason == "" {
+			t.Error("reason is empty; a row with no stored text still needs a sentence")
+		}
+	}
+	if !found {
+		t.Error("the cancelled row is absent from the failure list")
+	}
+}
+
+// TestJobHealthRefusesAPassportOverHTTP proves the wire, not just the gate
+// function: the payload carries operational failure text and a fleet-wide
+// view of the dispatchers, and a read-scoped passport satisfies every
+// object grant an admin could mint.
+func TestJobHealthRefusesAPassportOverHTTP(t *testing.T) {
+	e := setup(t)
+	e.bootstrapWorkspace(t)
+
+	var minted struct {
+		Token string `json:"token"`
+	}
+	if status := e.call(t, "POST", "/v1/passports", anyMap{
+		"label": "job health probe", "scopes": []string{"read"},
+	}, nil, &minted); status != http.StatusCreated {
+		t.Fatalf("issue passport → %d", status)
+	}
+
+	var problem struct {
+		Code string `json:"code"`
+	}
+	status := e.call(t, "GET", "/v1/admin/job-health", nil,
+		map[string]string{"Authorization": "Bearer " + minted.Token}, &problem)
+	if status != http.StatusForbidden {
+		t.Errorf("agent GET /admin/job-health → %d, want 403 (the contract declares it human-only)", status)
+	}
+	if problem.Code != "permission_denied" {
+		t.Errorf("code %q, want permission_denied", problem.Code)
+	}
+}
+
+// TestJobHealthOnAnIdleFleetIsAnEmptyReportNotAnError — the honest empty
+// case. An installation with nothing queued is a real state, and a client
+// must be able to tell it from a failure.
+func TestJobHealthOnAnIdleFleetIsAnEmptyReportNotAnError(t *testing.T) {
+	e := setup(t)
+	e.bootstrapWorkspace(t)
+
+	var report jobHealthDTO
+	if status := e.call(t, "GET", "/v1/admin/job-health", nil, nil, &report); status != http.StatusOK {
+		t.Fatalf("GET /admin/job-health on an idle fleet → %d, want 200", status)
+	}
+	if report.WorkspaceID == "" {
+		t.Error("an idle report still names the workspace it is scoped to")
+	}
+	if report.GeneratedAt == "" {
+		t.Error("an idle report still says when it was generated")
+	}
+	for _, k := range report.Kinds {
+		if k.FleetWide {
+			continue
+		}
+		t.Errorf("an idle fleet reported tenant work: %+v", k)
+	}
+}
+
+// TestJobHealthIgnoresTheSweepTagWhenScopingRows — the sweep tag is the
+// metric read's filter, never this one's. The two surfaces read the same
+// table through different scopes, and a tagged row must reach the admin
+// read exactly as an untagged one does.
+func TestJobHealthIgnoresTheSweepTagWhenScopingRows(t *testing.T) {
+	e := setup(t)
+	e.bootstrapWorkspace(t)
+	mine := callerWorkspace(t, e)
+
+	seedRiverRow(t, e, riverRow{kind: "tagged_pass", state: "discarded", workspace: mine, attempt: 3})
+	if _, err := e.owner.Exec(context.Background(),
+		`UPDATE river_job SET tags = ARRAY[$1]::varchar(255)[] WHERE kind = 'tagged_pass'`,
+		jobs.SweepTag); err != nil {
+		t.Fatalf("tagging the fixture row: %v", err)
+	}
+
+	var report jobHealthDTO
+	if status := e.call(t, "GET", "/v1/admin/job-health", nil, nil, &report); status != http.StatusOK {
+		t.Fatalf("GET /admin/job-health → %d, want 200", status)
+	}
+	i, ok := kindOf(report, "tagged_pass")
+	if !ok {
+		t.Fatal("a sweep-tagged row vanished from the admin read; the endpoint scopes by " +
+			"workspace, never by tag")
+	}
+	if report.Kinds[i].Dead != 1 {
+		t.Errorf("dead = %d, want 1", report.Kinds[i].Dead)
+	}
+}
+
+// containsIgnoringCase keeps the leak assertions above from passing on a
+// difference of case alone.
+func containsIgnoringCase(haystack, needle string) bool {
+	return strings.Contains(strings.ToLower(haystack), strings.ToLower(needle))
+}

--- a/backend/internal/compose/integration/jobhealth_http_e2e_integration_test.go
+++ b/backend/internal/compose/integration/jobhealth_http_e2e_integration_test.go
@@ -479,21 +479,40 @@ func TestJobHealthCapsTheFailureListAndOrdersItNewestFirst(t *testing.T) {
 		t.Errorf("recent_failures has %d entries, want the declared cap of 50 out of %d seeded",
 			len(report.RecentFailures), seeded)
 	}
+	// Compared as TIMES, never as strings. Go serializes time.Time with a
+	// variable-width fractional part and trims trailing zeros, so a value
+	// landing on a whole second carries no fraction at all — and '.' sorts
+	// before 'Z', which makes lexicographic order disagree with chronological
+	// order for exactly those pairs. The test would then fail on correct
+	// ordering, or pass on wrong ordering.
 	for i := 1; i < len(report.RecentFailures); i++ {
-		prev, cur := report.RecentFailures[i-1].FailedAt, report.RecentFailures[i].FailedAt
-		if prev < cur {
+		prev := parseFailedAt(t, report.RecentFailures[i-1].FailedAt)
+		cur := parseFailedAt(t, report.RecentFailures[i].FailedAt)
+		if prev.Before(cur) {
 			t.Fatalf("failure %d (%s) is newer than failure %d (%s): the list must be "+
-				"newest-first, or the 50 an operator sees are an arbitrary 50", i, cur, i-1, prev)
+				"newest-first, or the 50 an operator sees are an arbitrary 50",
+				i, cur, i-1, prev)
 		}
 	}
 	// The newest seeded row is one minute old; the oldest is an hour. A
 	// correct cap keeps the newest end, so the oldest ten must be absent.
-	oldest := report.RecentFailures[len(report.RecentFailures)-1].FailedAt
-	cutoff := time.Now().Add(-51 * time.Minute).UTC().Format(time.RFC3339)
-	if oldest < cutoff {
+	oldest := parseFailedAt(t, report.RecentFailures[len(report.RecentFailures)-1].FailedAt)
+	cutoff := time.Now().Add(-51 * time.Minute)
+	if oldest.Before(cutoff) {
 		t.Errorf("the retained window reaches back to %s, past %s: the cap kept the OLDEST "+
 			"rows rather than the newest", oldest, cutoff)
 	}
+}
+
+// parseFailedAt reads a wire timestamp as a time, so ordering assertions
+// compare instants rather than spellings.
+func parseFailedAt(t *testing.T, raw string) time.Time {
+	t.Helper()
+	at, err := time.Parse(time.RFC3339Nano, raw)
+	if err != nil {
+		t.Fatalf("failed_at %q is not RFC 3339: %v", raw, err)
+	}
+	return at
 }
 
 // TestJobHealthRefusesAnUnauthenticatedCallOverHTTP — the contract declares

--- a/backend/internal/compose/jobhealth.go
+++ b/backend/internal/compose/jobhealth.go
@@ -83,6 +83,15 @@ func dispatcherKinds() []string {
 // known and where to look, and no more.
 const unvettedFailureReason = "the job failed for a reason this surface cannot vet; check the worker logs and the job row directly"
 
+// noRecordedCause is what a row with no stored error at all becomes.
+//
+// It is NOT the unvetted substitute. A cancelled job that never ran records
+// no attempt error, and telling its operator the job "failed for a reason
+// this surface cannot vet" asserts a failure that did not happen and points
+// at a log line nobody wrote. Nothing recorded is a different fact from
+// something unreadable, and the two must not render alike.
+const noRecordedCause = "this job recorded no cause; a job cancelled before it ran records none"
+
 // reasonFor renders a stored failure for a human.
 //
 // river_job.errors holds whatever the worker returned. jobs.Fault exists so
@@ -91,6 +100,9 @@ const unvettedFailureReason = "the job failed for a reason this surface cannot v
 // the column is checked, never trusted, and anything unrecognised becomes
 // the same fixed substitute.
 func reasonFor(stored string) string {
+	if stored == "" {
+		return noRecordedCause
+	}
 	if jobs.VettedSentence(stored) {
 		return stored
 	}

--- a/backend/internal/compose/jobhealth.go
+++ b/backend/internal/compose/jobhealth.go
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// GET /admin/job-health: what the background system is holding for THIS
+// workspace, and whose work died. Phase 1 made a failed tenant pass
+// durable; until this endpoint it was reachable only by psql.
+//
+// Authentication, response mapping and the vetted-sentence substitution
+// live here. The SQL lives in platform/jobs, which owns every statement
+// over river_job.
+
+import (
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/platform/httperr"
+	"github.com/gradionhq/margince/backend/internal/platform/jobs"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// fleetDispatchers is every args type in this package that declares
+// jobs.FleetWide — the CLOSED set of kinds whose rows carry no workspace
+// and are still an admin's business to see.
+//
+// It is a slice of the marker interface rather than a slice of strings so
+// a kind that is not actually fleet-wide cannot be added by hand, and
+// TestEveryFleetWideArgsTypeIsDeclaredAsADispatcherKind derives the
+// expected membership from the tree rather than restating it: a new
+// dispatcher that never reaches this list would otherwise be invisible on
+// the surface an admin uses to notice a dispatcher is not running.
+var fleetDispatchers = []jobs.FleetWide{
+	AgentSchedulerArgs{},
+	CaptureAutoEnrichSweepArgs{},
+	CaptureClassifyArgs{},
+	CaptureDigestArgs{},
+	CaptureEnrichArgs{},
+	CloseDateSweepArgs{},
+	CounterpartyVerdictArgs{},
+	EmbedDriftSweepArgs{},
+	EmbedReindexArgs{},
+	FollowUpReconcileArgs{},
+	GmailSyncArgs{},
+	GmailWatchArgs{},
+	GraphEdgeReconcileArgs{},
+	IdempotencyRetentionArgs{},
+	LinkedInRematchArgs{},
+	OrgNamePromotionArgs{},
+	OverlayReconcileArgs{},
+	ParticipantBackfillArgs{},
+	PrivacyRetentionArgs{},
+	TelegramPollSweepArgs{},
+	TimeScanArgs{},
+	VoiceBuildRetryArgs{},
+	WebhookRetryArgs{},
+}
+
+// dispatcherKinds answers the untenanted kinds the job-health read admits.
+func dispatcherKinds() []string {
+	kinds := make([]string, 0, len(fleetDispatchers))
+	for _, d := range fleetDispatchers {
+		kinds = append(kinds, d.Kind())
+	}
+	return kinds
+}
+
+// unvettedFailureReason is what an unrecognised stored error becomes.
+//
+// It does NOT promise the diagnosis is in the process log. River writes its
+// own strings into this column too, and the rescuer's ("Stuck job rescued
+// by JobRescuer") means the worker's process died mid-job — so for that
+// case, one of the most common to reach here, a log pointer would be an
+// instruction to go read something that was never written. It says what is
+// known and where to look, and no more.
+const unvettedFailureReason = "the job failed for a reason this surface cannot vet; check the worker logs and the job row directly"
+
+// reasonFor renders a stored failure for a human.
+//
+// river_job.errors holds whatever the worker returned. jobs.Fault exists so
+// that is a vetted sentence — but a worker that bypassed it stored its raw
+// cause, which routinely names the address or record a provider refused. So
+// the column is checked, never trusted, and anything unrecognised becomes
+// the same fixed substitute.
+func reasonFor(stored string) string {
+	if jobs.VettedSentence(stored) {
+		return stored
+	}
+	return unvettedFailureReason
+}
+
+// jobHealthHandlers serves the admin job-health read. The pool is the only
+// state, and newServer CONSTRUCTS it rather than leaving the embed's zero
+// value in place — an embedded-only handler set would answer every
+// authenticated request with a nil pool.
+//
+// There is deliberately no nil-pool branch here. A nil pool is a wiring
+// mistake, not a state this endpoint can legitimately be in, and a guard
+// would have to invent a status for it — 404 says the endpoint does not
+// exist, which would be a lie an operator then has to disprove.
+// TestTheJobHealthHandlerIsConstructedWithAPoolNotJustEmbedded is what
+// holds the wiring instead.
+type jobHealthHandlers struct {
+	pool *pgxpool.Pool
+}
+
+// GetJobHealth reports this workspace's background-job health.
+//
+// Gate order, fail-closed: human-only first, then admin. The payload
+// carries operational failure text and a fleet-wide view of the
+// dispatchers, and an admin-minted read-scoped passport satisfies every
+// object grant — so human-only is asserted here rather than inferred from
+// RBAC. The generated agent policy refuses a passport at the middleware
+// too; this check is the layer that does not depend on the wiring being
+// right.
+func (h jobHealthHandlers) GetJobHealth(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	if err := auth.RequireHuman(ctx); err != nil {
+		httperr.Write(w, r, err)
+		return
+	}
+	if err := auth.RequireAdmin(ctx); err != nil {
+		httperr.Write(w, r, err)
+		return
+	}
+	wsID, ok := principal.WorkspaceID(ctx)
+	if !ok {
+		httperr.Write(w, r, apperrors.ErrPermissionDenied)
+		return
+	}
+
+	// wsID.String(), not the uuid: ->> yields text, and a uuid-typed bind
+	// gives pgx the uuid OID and Postgres "operator does not exist: text =
+	// uuid".
+	health, err := jobs.WorkspaceHealth(ctx, h.pool, wsID.String(), dispatcherKinds())
+	if err != nil {
+		// Never a partial 200. A page that renders half the fleet as if it
+		// were the whole one is the failure this endpoint exists to end.
+		slog.ErrorContext(ctx, "job health read failed", "err", err)
+		httperr.Write(w, r, err)
+		return
+	}
+
+	httperr.WriteJSON(w, http.StatusOK, jobHealthResponse(wsID, health))
+}
+
+// jobHealthResponse maps the scoped read onto the contract.
+func jobHealthResponse(workspaceID ids.UUID, health jobs.Health) crmcontracts.JobHealth {
+	kinds := make([]crmcontracts.JobKindHealth, 0, len(health.Kinds))
+	for _, k := range health.Kinds {
+		kinds = append(kinds, crmcontracts.JobKindHealth{
+			Kind:                    k.Kind,
+			Queue:                   k.Queue,
+			FleetWide:               k.FleetWide,
+			Waiting:                 int(k.Waiting),
+			Running:                 int(k.Running),
+			Retrying:                int(k.Retrying),
+			Dead:                    int(k.Dead),
+			OldestWaitingAgeSeconds: secondsOrAbsent(k.OldestWaitingAgeSeconds),
+		})
+	}
+
+	failures := make([]crmcontracts.JobFailure, 0, len(health.Failures))
+	for _, f := range health.Failures {
+		failures = append(failures, crmcontracts.JobFailure{
+			Kind: f.Kind,
+			// Either null (a dispatcher) or the caller's own workspace: the
+			// scope admits no third possibility, so the id is taken from the
+			// authenticated principal rather than re-parsed out of a jsonb
+			// value whose format nothing constrains.
+			WorkspaceId: callerOrDispatcher(workspaceID, f.WorkspaceID),
+			State:       crmcontracts.JobFailureState(f.State),
+			Attempt:     f.Attempt,
+			MaxAttempts: f.MaxAttempts,
+			FailedAt:    f.FailedAt,
+			// The stored text is vetted, never forwarded.
+			Reason: reasonFor(f.StoredReason),
+		})
+	}
+
+	return crmcontracts.JobHealth{
+		WorkspaceId:    openapi_types.UUID(workspaceID),
+		GeneratedAt:    time.Now().UTC(),
+		Kinds:          kinds,
+		RecentFailures: failures,
+	}
+}
+
+// callerOrDispatcher answers the workspace a failure belongs to.
+//
+// The scoped read admits a row only when its workspace key is the caller's
+// own or is null, so a present key is the caller's workspace by
+// construction — which is why the id comes from the authenticated
+// principal rather than from the jsonb value. That value is app-written
+// with no database constraint behind it, and re-parsing it here would let
+// a malformed row decide what this endpoint reports.
+func callerOrDispatcher(caller ids.UUID, stored *string) *openapi_types.UUID {
+	if stored == nil {
+		return nil
+	}
+	id := openapi_types.UUID(caller)
+	return &id
+}
+
+// secondsOrAbsent rounds a measured age to whole seconds, and keeps an
+// absent one absent: null means nothing of this kind is runnable, which is
+// a different claim from "something became runnable a moment ago".
+func secondsOrAbsent(age *float64) *int {
+	if age == nil {
+		return nil
+	}
+	rounded := int(*age)
+	return &rounded
+}

--- a/backend/internal/compose/jobhealth.go
+++ b/backend/internal/compose/jobhealth.go
@@ -12,6 +12,7 @@ package compose
 // over river_job.
 
 import (
+	"context"
 	"log/slog"
 	"net/http"
 	"time"
@@ -109,6 +110,11 @@ func reasonFor(stored string) string {
 	return unvettedFailureReason
 }
 
+// jobHealthReadTimeout bounds the scoped job read. river_job has no index
+// over args->>'workspace_id', so both statements scan; a read that cannot
+// finish inside this is a signal, not something to wait out.
+const jobHealthReadTimeout = 5 * time.Second
+
 // jobHealthHandlers serves the admin job-health read. The pool is the only
 // state, and newServer CONSTRUCTS it rather than leaving the embed's zero
 // value in place — an embedded-only handler set would answer every
@@ -158,6 +164,15 @@ func (h jobHealthHandlers) GetJobHealth(w http.ResponseWriter, r *http.Request) 
 		httperr.Write(w, r, apperrors.ErrPermissionDenied)
 		return
 	}
+
+	// Bounded, for the same reason the exposition endpoint bounds its own
+	// job read: this is two sequential scans of a table no index covers, and
+	// an unbounded one holds a request thread and a pool connection for as
+	// long as the scan takes. The budget is larger than the scrape's 2s
+	// because an operator waiting on a page tolerates more latency than a
+	// scrape interval does — but it is a budget, not the absence of one.
+	ctx, cancel := context.WithTimeout(ctx, jobHealthReadTimeout)
+	defer cancel()
 
 	// wsID.String(), not the uuid: ->> yields text, and a uuid-typed bind
 	// gives pgx the uuid OID and Postgres "operator does not exist: text =

--- a/backend/internal/compose/jobhealth.go
+++ b/backend/internal/compose/jobhealth.go
@@ -123,6 +123,16 @@ type jobHealthHandlers struct {
 // right.
 func (h jobHealthHandlers) GetJobHealth(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
+	// No principal at all is a refusal, not a server fault. The session
+	// middleware answers 401 before this handler is reached on the real
+	// wire — proved in the integration lane — but auth.RequireHuman reports
+	// an unbound actor with an unmapped error, which httperr renders as a
+	// 500. A security surface should not have a 500 as its answer to
+	// "nobody asked".
+	if _, ok := principal.Actor(ctx); !ok {
+		httperr.Write(w, r, apperrors.ErrPermissionDenied)
+		return
+	}
 	if err := auth.RequireHuman(ctx); err != nil {
 		httperr.Write(w, r, err)
 		return

--- a/backend/internal/compose/jobhealth.go
+++ b/backend/internal/compose/jobhealth.go
@@ -232,9 +232,14 @@ func callerOrDispatcher(caller ids.UUID, stored *string) *openapi_types.UUID {
 	return &id
 }
 
-// secondsOrAbsent rounds a measured age to whole seconds, and keeps an
+// secondsOrAbsent TRUNCATES a measured age to whole seconds, and keeps an
 // absent one absent: null means nothing of this kind is runnable, which is
 // a different claim from "something became runnable a moment ago".
+//
+// Truncation rather than rounding is deliberate and harmless here: the
+// value answers "how long has this been waiting", where reporting 41s for
+// 41.7s understates by less than a second and never overstates. A gauge
+// that rounded up could report a job as waiting a second it has not.
 func secondsOrAbsent(age *float64) *int {
 	if age == nil {
 		return nil

--- a/backend/internal/compose/jobhealth_test.go
+++ b/backend/internal/compose/jobhealth_test.go
@@ -14,6 +14,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
@@ -318,4 +319,22 @@ func callJobHealth(t *testing.T, p principal.Principal) *httptest.ResponseRecord
 	rec := httptest.NewRecorder()
 	jobHealthHandlers{pool: nil}.GetJobHealth(rec, req.WithContext(ctx))
 	return rec
+}
+
+// TestTheJobHealthReadCarriesADeadline — this endpoint reads the same
+// unindexed table the exposition endpoint does, where a 2s budget exists
+// precisely to stop an unbounded scan holding a request thread and a pool
+// connection. Both readers of river_job carry a bound, and this is what
+// keeps the pair from drifting apart.
+func TestTheJobHealthReadCarriesADeadline(t *testing.T) {
+	if jobHealthReadTimeout <= 0 {
+		t.Fatalf("jobHealthReadTimeout = %v; an unbounded read is what the budget exists "+
+			"to prevent", jobHealthReadTimeout)
+	}
+	// Generous enough for an interactive page, but still a budget: a read
+	// that cannot finish inside it is a signal, not something to wait out.
+	if jobHealthReadTimeout > 30*time.Second {
+		t.Errorf("jobHealthReadTimeout = %v, which is long enough to be indistinguishable "+
+			"from no bound at all", jobHealthReadTimeout)
+	}
 }

--- a/backend/internal/compose/jobhealth_test.go
+++ b/backend/internal/compose/jobhealth_test.go
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/gradionhq/margince/backend/internal/platform/jobs"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// TestJobHealthRefusesAnAgentPrincipal — the payload carries operational
+// failure text and a fleet-wide view of the dispatchers. An admin-minted
+// read-scoped passport satisfies every object grant, so human-only has to
+// be asserted here rather than inferred from RBAC.
+func TestJobHealthRefusesAnAgentPrincipal(t *testing.T) {
+	rec := callJobHealth(t, principal.Principal{
+		Type:        principal.PrincipalAgent,
+		Permissions: principal.Permissions{RoleKeys: []string{"admin"}},
+	})
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("an agent principal got %d, want 403: a passport must not read this", rec.Code)
+	}
+}
+
+// TestJobHealthRefusesANonAdminHuman — every seat can see its own records;
+// what the background system is holding for the whole workspace is an
+// administrator's view.
+func TestJobHealthRefusesANonAdminHuman(t *testing.T) {
+	rec := callJobHealth(t, principal.Principal{
+		Type:        principal.PrincipalHuman,
+		Permissions: principal.Permissions{RoleKeys: []string{"rep"}},
+	})
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("a non-admin human got %d, want 403", rec.Code)
+	}
+}
+
+// TestJobHealthRefusesAnUnauthenticatedCall — no principal in context at
+// all must not reach the pool.
+func TestJobHealthRefusesAnUnauthenticatedCall(t *testing.T) {
+	rec := httptest.NewRecorder()
+	jobHealthHandlers{}.GetJobHealth(rec, httptest.NewRequest(http.MethodGet, "/v1/admin/job-health", nil))
+
+	if rec.Code == http.StatusOK {
+		t.Error("an unauthenticated call was served")
+	}
+}
+
+// TestTheJobHealthHandlerIsConstructedWithAPoolNotJustEmbedded — embedding
+// alone leaves the zero value's nil pool in place, and every authenticated
+// request then panics on the first query. There is no nil-pool branch in
+// the handler on purpose; this is what stands in its place.
+func TestTheJobHealthHandlerIsConstructedWithAPoolNotJustEmbedded(t *testing.T) {
+	srv := newServer(nil, quietTestLogger(), authHandlers{}, dealsHandlers{})
+	if srv.jobHealthHandlers.pool != nil {
+		t.Fatal("the fixture passed a pool; this test can no longer tell construction from embedding")
+	}
+
+	// The real assertion: the composed server threads ITS pool through, so
+	// a handler constructed from a live pool holds that same pool.
+	live := &pgxpool.Pool{}
+	withPool := newServer(live, quietTestLogger(), authHandlers{}, dealsHandlers{})
+	if withPool.jobHealthHandlers.pool != live {
+		t.Error("newServer embedded jobHealthHandlers without constructing it; every " +
+			"authenticated read would reach a nil pool")
+	}
+}
+
+// TestOnlyAVettedSentenceReachesTheWire is the fail-closed half of the
+// failure-text posture: a worker that bypassed jobs.Fault stored its raw
+// cause in a column with no RLS and no redaction path, and this is what
+// stops that text travelling.
+func TestOnlyAVettedSentenceReachesTheWire(t *testing.T) {
+	vetted := "the record this job names no longer exists"
+	if got := reasonFor(vetted); got != vetted {
+		t.Errorf("reasonFor(vetted) = %q, want it passed through", got)
+	}
+
+	for _, raw := range []string{
+		`smtp: 550 5.1.1 <someone@example.com>: recipient rejected`,
+		"dial tcp 10.0.0.4:5432: connect: connection refused",
+		// River's own rescuer text. It must be substituted like any other
+		// unvetted string — and the substitute must not tell an operator to
+		// read a process log that died before writing one.
+		"Stuck job rescued by JobRescuer",
+		"",
+	} {
+		got := reasonFor(raw)
+		if got == raw {
+			t.Errorf("a worker's raw cause reached the wire: %q", raw)
+		}
+		if got != unvettedFailureReason {
+			t.Errorf("reasonFor(%q) = %q, want the one fixed substitute", raw, got)
+		}
+		if strings.Contains(got, "process log") {
+			t.Errorf("the substitute promises a process log: a rescued job's process died "+
+				"mid-work and wrote none. got %q", got)
+		}
+	}
+
+	if reasonFor("") == "" {
+		t.Error("an empty stored error must still produce a sentence")
+	}
+}
+
+// TestTheResponseNeverCarriesAWorkspaceOtherThanTheCallersOwn — the scope
+// admits the caller's rows and untenanted ones and nothing else, so the
+// mapping must not invent a third answer from a jsonb value nothing
+// constrains.
+func TestTheResponseNeverCarriesAWorkspaceOtherThanTheCallersOwn(t *testing.T) {
+	caller := ids.NewV7()
+	// A stored value that is NOT the caller's — the shape a malformed row
+	// would have if one ever slipped past the scope.
+	someoneElse := ids.NewV7().String()
+
+	got := jobHealthResponse(caller, jobs.Health{Failures: []jobs.Failure{
+		{Kind: "tenant_pass", WorkspaceID: &someoneElse, State: "discarded"},
+		{Kind: "the_dispatcher", WorkspaceID: nil, State: "discarded"},
+	}})
+
+	if len(got.RecentFailures) != 2 {
+		t.Fatalf("mapped %d failures, want 2", len(got.RecentFailures))
+	}
+	if got.RecentFailures[0].WorkspaceId == nil {
+		t.Fatal("a tenant failure lost its workspace")
+	}
+	if ids.UUID(*got.RecentFailures[0].WorkspaceId) != caller {
+		t.Errorf("the response named workspace %s, want the caller's %s",
+			*got.RecentFailures[0].WorkspaceId, caller)
+	}
+	if got.RecentFailures[1].WorkspaceId != nil {
+		t.Error("a dispatcher failure was given a workspace it does not have")
+	}
+}
+
+// TestAnAbsentOldestAgeStaysAbsent — null and zero are different claims.
+// Null means nothing of this kind is runnable; zero means something became
+// runnable a moment ago, and flattening the two hides an idle kind behind
+// a healthy-looking number.
+func TestAnAbsentOldestAgeStaysAbsent(t *testing.T) {
+	measured := 41.7
+	got := jobHealthResponse(ids.NewV7(), jobs.Health{Kinds: []jobs.KindHealth{
+		{Kind: "idle", OldestWaitingAgeSeconds: nil},
+		{Kind: "waiting", OldestWaitingAgeSeconds: &measured},
+	}})
+
+	if got.Kinds[0].OldestWaitingAgeSeconds != nil {
+		t.Errorf("an unmeasured age became %d", *got.Kinds[0].OldestWaitingAgeSeconds)
+	}
+	if got.Kinds[1].OldestWaitingAgeSeconds == nil {
+		t.Fatal("a measured age was dropped")
+	}
+	if *got.Kinds[1].OldestWaitingAgeSeconds != 41 {
+		t.Errorf("age = %d, want 41", *got.Kinds[1].OldestWaitingAgeSeconds)
+	}
+}
+
+// TestAnIdleFleetMapsToEmptyListsNotNulls — the contract requires both
+// arrays, and a JSON null where a list belongs breaks a client that
+// iterates it.
+func TestAnIdleFleetMapsToEmptyListsNotNulls(t *testing.T) {
+	got := jobHealthResponse(ids.NewV7(), jobs.Health{})
+
+	if got.Kinds == nil {
+		t.Error("kinds serialized as null rather than []")
+	}
+	if got.RecentFailures == nil {
+		t.Error("recent_failures serialized as null rather than []")
+	}
+	if got.GeneratedAt.IsZero() {
+		t.Error("generated_at was never stamped")
+	}
+}
+
+// TestEveryFleetWideArgsTypeIsDeclaredAsADispatcherKind derives the
+// expected membership from the tree instead of restating it.
+//
+// The untenanted arm of the job-health scope is a CLOSED set, which makes
+// forgetting a dispatcher silent in exactly the direction that hurts: its
+// rows are omitted, and an admin looking for "is the fleet being swept"
+// sees a surface that says nothing rather than one that says no. A new
+// FleetWide args type therefore fails here until it is declared.
+func TestEveryFleetWideArgsTypeIsDeclaredAsADispatcherKind(t *testing.T) {
+	declared := map[string]bool{}
+	for _, d := range fleetDispatchers {
+		declared[argsTypeName(d)] = true
+	}
+
+	sources, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatalf("listing the compose package's sources: %v", err)
+	}
+	fset := token.NewFileSet()
+	var inTree []string
+	for _, path := range sources {
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parsing %s: %v", path, err)
+		}
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Name.Name != "FleetWide" || fn.Recv == nil {
+				continue
+			}
+			if name := receiverTypeIdent(fn); name != "" {
+				inTree = append(inTree, name)
+			}
+		}
+	}
+
+	// A vacuous pass is the failure mode of any AST gate: a walker that
+	// matched nothing reports green. The tree carries 23 dispatchers today.
+	if len(inTree) < 20 {
+		t.Fatalf("found only %d FleetWide args types; the walker is not resolving them", len(inTree))
+	}
+	for _, name := range inTree {
+		if !declared[name] {
+			t.Errorf("%s declares jobs.FleetWide but is missing from fleetDispatchers, so its "+
+				"rows are invisible on /admin/job-health — the surface an admin uses to notice "+
+				"a dispatcher is not running", name)
+		}
+	}
+	if len(declared) != len(inTree) {
+		t.Errorf("fleetDispatchers holds %d entries but the tree declares %d FleetWide types",
+			len(declared), len(inTree))
+	}
+}
+
+// TestEveryDispatcherKindIsSpelledOnce — a duplicate would widen the
+// untenanted arm with a redundant bind and hide a copy-paste slip.
+func TestEveryDispatcherKindIsSpelledOnce(t *testing.T) {
+	kinds := dispatcherKinds()
+	sorted := slices.Clone(kinds)
+	slices.Sort(sorted)
+	if len(slices.Compact(sorted)) != len(kinds) {
+		t.Errorf("dispatcherKinds repeats a kind: %v", kinds)
+	}
+	for _, k := range kinds {
+		if k == "" {
+			t.Error("a dispatcher declared an empty kind")
+		}
+	}
+}
+
+// argsTypeName answers a FleetWide value's concrete type name, without the
+// package qualifier — the same spelling the AST walk above reads off a
+// method receiver.
+func argsTypeName(d jobs.FleetWide) string {
+	t := reflect.TypeOf(d)
+	for t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	return t.Name()
+}
+
+// receiverTypeIdent answers a method's receiver type name, dereferencing a
+// pointer receiver.
+func receiverTypeIdent(fn *ast.FuncDecl) string {
+	if fn.Recv == nil || len(fn.Recv.List) == 0 {
+		return ""
+	}
+	switch t := fn.Recv.List[0].Type.(type) {
+	case *ast.Ident:
+		return t.Name
+	case *ast.StarExpr:
+		if id, ok := t.X.(*ast.Ident); ok {
+			return id.Name
+		}
+	}
+	return ""
+}
+
+// callJobHealth runs the handler under one principal and answers the
+// recorded response. The pool is nil on purpose: every case here is
+// refused before the read, and a case that reached the pool would panic
+// rather than pass quietly.
+func callJobHealth(t *testing.T, p principal.Principal) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/v1/admin/job-health", nil)
+	ctx := principal.WithActor(req.Context(), p)
+	rec := httptest.NewRecorder()
+	jobHealthHandlers{pool: nil}.GetJobHealth(rec, req.WithContext(ctx))
+	return rec
+}

--- a/backend/internal/compose/jobhealth_test.go
+++ b/backend/internal/compose/jobhealth_test.go
@@ -321,12 +321,23 @@ func callJobHealth(t *testing.T, p principal.Principal) *httptest.ResponseRecord
 	return rec
 }
 
-// TestTheJobHealthReadCarriesADeadline — this endpoint reads the same
-// unindexed table the exposition endpoint does, where a 2s budget exists
-// precisely to stop an unbounded scan holding a request thread and a pool
-// connection. Both readers of river_job carry a bound, and this is what
-// keeps the pair from drifting apart.
-func TestTheJobHealthReadCarriesADeadline(t *testing.T) {
+// TestTheJobHealthReadTimeoutIsABudgetNotAnAbsentBound checks the CONSTANT,
+// not that the handler applies it.
+//
+// The name says so because the distinction matters: a refactor that dropped
+// the context.WithTimeout call while keeping the constant would leave this
+// test green and the property false. Proving the application at runtime
+// needs the read behind an injectable seam, which this handler has no
+// production reason to grow — so what guards it is that the call sits one
+// line from the constant, and that GetJobHealth's own doc comment says why
+// it is there.
+//
+// What this DOES catch is the constant being zeroed or widened into
+// meaninglessness, which is the realistic regression: the exposition
+// endpoint bounds its read of this same unindexed table at 2s precisely to
+// stop a scan holding a request thread and a pool connection, and a bound
+// that is not a bound would let the two readers drift apart again.
+func TestTheJobHealthReadTimeoutIsABudgetNotAnAbsentBound(t *testing.T) {
 	if jobHealthReadTimeout <= 0 {
 		t.Fatalf("jobHealthReadTimeout = %v; an unbounded read is what the budget exists "+
 			"to prevent", jobHealthReadTimeout)

--- a/backend/internal/compose/jobhealth_test.go
+++ b/backend/internal/compose/jobhealth_test.go
@@ -57,8 +57,12 @@ func TestJobHealthRefusesAnUnauthenticatedCall(t *testing.T) {
 	rec := httptest.NewRecorder()
 	jobHealthHandlers{}.GetJobHealth(rec, httptest.NewRequest(http.MethodGet, "/v1/admin/job-health", nil))
 
-	if rec.Code == http.StatusOK {
-		t.Error("an unauthenticated call was served")
+	// 403 exactly, not merely "not 200": a 500 would also fail a != 200
+	// check while meaning the handler crashed on its way to a refusal.
+	// The contract's 401 is the session middleware's answer and is proved
+	// over the real wire, in the integration lane.
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("an unauthenticated call got %d, want 403 from the gate", rec.Code)
 	}
 }
 

--- a/backend/internal/compose/jobhealth_test.go
+++ b/backend/internal/compose/jobhealth_test.go
@@ -103,7 +103,6 @@ func TestOnlyAVettedSentenceReachesTheWire(t *testing.T) {
 		// unvetted string — and the substitute must not tell an operator to
 		// read a process log that died before writing one.
 		"Stuck job rescued by JobRescuer",
-		"",
 	} {
 		got := reasonFor(raw)
 		if got == raw {
@@ -117,9 +116,27 @@ func TestOnlyAVettedSentenceReachesTheWire(t *testing.T) {
 				"mid-work and wrote none. got %q", got)
 		}
 	}
+}
 
-	if reasonFor("") == "" {
-		t.Error("an empty stored error must still produce a sentence")
+// TestARowThatRecordedNoCauseDoesNotClaimItFailed — a cancelled job that
+// never ran records no attempt error. Rendering that as "the job failed for
+// a reason this surface cannot vet" asserts a failure that did not happen
+// and points an operator at a log line nobody wrote. Nothing recorded and
+// something unreadable are different facts.
+func TestARowThatRecordedNoCauseDoesNotClaimItFailed(t *testing.T) {
+	got := reasonFor("")
+
+	if got == "" {
+		t.Fatal("an empty stored error must still produce a sentence")
+	}
+	if got == unvettedFailureReason {
+		t.Error("a row with no recorded cause was reported as an unvettable failure")
+	}
+	if strings.Contains(got, "failed") {
+		t.Errorf("reasonFor(\"\") = %q: it claims a failure that was never recorded", got)
+	}
+	if got != noRecordedCause {
+		t.Errorf("reasonFor(\"\") = %q, want the one fixed no-cause sentence", got)
 	}
 }
 

--- a/backend/internal/compose/jobmetrics.go
+++ b/backend/internal/compose/jobmetrics.go
@@ -81,8 +81,9 @@ func aggregate(rows []jobs.StateRow) jobSeries {
 		unrecognised: map[stateKey]int64{},
 	}
 	for _, r := range rows {
-		qk := queueKey{queue: r.Queue, workspace: r.WorkspaceID}
-		kk := kindKey{kind: r.Kind, workspace: r.WorkspaceID}
+		ws := workspaceLabelFor(r)
+		qk := queueKey{queue: r.Queue, workspace: ws}
+		kk := kindKey{kind: r.Kind, workspace: ws}
 		switch {
 		case queueDepthStates[r.State]:
 			a.depth[qk] += r.Count
@@ -97,7 +98,7 @@ func aggregate(rows []jobs.StateRow) jobSeries {
 			// false for half the rows under it.
 			a.cancelled[kk] += r.Count
 		default:
-			a.unrecognised[stateKey{state: r.State, queue: r.Queue, workspace: r.WorkspaceID}] += r.Count
+			a.unrecognised[stateKey{state: r.State, queue: r.Queue, workspace: ws}] += r.Count
 		}
 		a.ageFrom(qk, r)
 	}
@@ -121,12 +122,34 @@ func aggregate(rows []jobs.StateRow) jobSeries {
 // A zero from a queue that DOES hold waiting work is a measured value: the
 // work is there and none of it is late yet.
 func (a jobSeries) ageFrom(qk queueKey, r jobs.StateRow) {
-	if !queueDepthStates[r.State] {
+	if !queueDepthStates[r.State] || r.OldestRunnableAgeSeconds == nil {
 		return
 	}
-	if _, seen := a.oldest[qk]; !seen || r.OldestRunnableAgeSeconds > a.oldest[qk] {
-		a.oldest[qk] = r.OldestRunnableAgeSeconds
+	if _, seen := a.oldest[qk]; !seen || *r.OldestRunnableAgeSeconds > a.oldest[qk] {
+		a.oldest[qk] = *r.OldestRunnableAgeSeconds
 	}
+}
+
+// malformedWorkspaceLabel stands in for a row whose workspace key is
+// PRESENT but empty. Such a row is malformed — a job either does tenant
+// work and names its workspace, or does none and carries no key — and
+// rendering it under the empty label would count it as a dispatcher,
+// breaking the one invariant every reader of these gauges stands on. It
+// gets a value of its own so it is visible as the anomaly it is, and the
+// cardinality it can add is exactly one.
+const malformedWorkspaceLabel = "<malformed>"
+
+// workspaceLabelFor answers the workspace label for one group: empty for a
+// dispatcher, the id for tenant work, and a marker for a row that is
+// neither.
+func workspaceLabelFor(r jobs.StateRow) string {
+	if r.Untenanted {
+		return ""
+	}
+	if r.WorkspaceID == "" {
+		return malformedWorkspaceLabel
+	}
+	return r.WorkspaceID
 }
 
 // writeJobMetrics renders the job-runtime section. Pure over snap so the
@@ -297,9 +320,13 @@ func writeFamilyHeader(w io.Writer, name, help string) error {
 // here because workspace_id is args->>'workspace_id' verbatim from a table
 // with no constraint on it and direct app-role CRUD, so a single
 // raw-inserted row could otherwise poison every scrape for every metric.
-// Anything outside the three escapes is dropped rather than encoded: a
-// control character in a label value is already a broken row, and a
-// readable scrape that omits it beats a rejected one that carries it.
+// A control character outside those three is rewritten as a PRINTABLE
+// <0xNN>, never dropped. Dropping is lossy, and lossy is not safe here: two
+// distinct malformed workspace ids differing only in a control byte would
+// collapse to the same label set, and duplicate series are exactly the
+// thing that makes a scrape unparseable — the failure this escaping exists
+// to prevent. The substitution is reversible by eye and appears only on a
+// row that is already broken.
 func label(value string) string {
 	var b strings.Builder
 	b.Grow(len(value) + 2)
@@ -313,7 +340,7 @@ func label(value string) string {
 		case r == '\n':
 			b.WriteString(`\n`)
 		case r < ' ' || r == 0x7f:
-			// Dropped: see above.
+			fmt.Fprintf(&b, "<0x%02x>", r)
 		default:
 			b.WriteRune(r)
 		}

--- a/backend/internal/compose/jobmetrics.go
+++ b/backend/internal/compose/jobmetrics.go
@@ -137,7 +137,13 @@ func (a jobSeries) ageFrom(qk queueKey, r jobs.StateRow) {
 // breaking the one invariant every reader of these gauges stands on. It
 // gets a value of its own so it is visible as the anomaly it is, and the
 // cardinality it can add is exactly one.
-const malformedWorkspaceLabel = "<malformed>"
+//
+// Plain ASCII, so label() passes it through unchanged rather than escaping
+// it into something unreadable. A raw workspace id equal to this string
+// would be indistinguishable from the marker — but such a row is itself
+// malformed (a real id is a uuid), it lands on the same series, and the
+// invariant that matters, empty ⇔ dispatcher, is untouched either way.
+const malformedWorkspaceLabel = "malformed_workspace_id"
 
 // workspaceLabelFor answers the workspace label for one group: empty for a
 // dispatcher, the id for tenant work, and a marker for a row that is
@@ -325,8 +331,13 @@ func writeFamilyHeader(w io.Writer, name, help string) error {
 // distinct malformed workspace ids differing only in a control byte would
 // collapse to the same label set, and duplicate series are exactly the
 // thing that makes a scrape unparseable — the failure this escaping exists
-// to prevent. The substitution is reversible by eye and appears only on a
-// row that is already broken.
+// to prevent.
+//
+// A literal '<' is escaped the same way, and that is what makes the mapping
+// INJECTIVE rather than merely printable. Without it, a value containing
+// the literal six characters "<0x09>" would render identically to one
+// containing a real tab — reintroducing exactly the collision this function
+// exists to remove. Every '<' in the output therefore begins an escape.
 func label(value string) string {
 	var b strings.Builder
 	b.Grow(len(value) + 2)
@@ -339,7 +350,7 @@ func label(value string) string {
 			b.WriteString(`\"`)
 		case r == '\n':
 			b.WriteString(`\n`)
-		case r < ' ' || r == 0x7f:
+		case r < ' ' || r == 0x7f || r == '<':
 			fmt.Fprintf(&b, "<0x%02x>", r)
 		default:
 			b.WriteRune(r)

--- a/backend/internal/compose/jobmetrics.go
+++ b/backend/internal/compose/jobmetrics.go
@@ -18,8 +18,7 @@ import (
 	"io"
 	"log/slog"
 	"slices"
-
-	"github.com/jackc/pgx/v5/pgxpool"
+	"strings"
 
 	"github.com/gradionhq/margince/backend/internal/platform/jobs"
 )
@@ -51,6 +50,81 @@ type kindKey struct{ kind, workspace string }
 // carries the state itself so an operator can see what appeared.
 type stateKey struct{ state, queue, workspace string }
 
+// The river_job_state values this renderer classifies by name. Named so
+// the spelling that decides which gauge a row lands on exists once.
+const (
+	stateRunning   = "running"
+	stateDiscarded = "discarded"
+	stateCancelled = "cancelled"
+)
+
+// jobSeries is one pass of the snapshot, bucketed per family.
+type jobSeries struct {
+	depth        map[queueKey]int64
+	running      map[queueKey]int64
+	discarded    map[kindKey]int64
+	cancelled    map[kindKey]int64
+	oldest       map[queueKey]float64
+	unrecognised map[stateKey]int64
+}
+
+// aggregate buckets every row exactly once. Split out of writeJobMetrics so
+// the classification reads as one list of cases rather than as a preamble to
+// seven writes.
+func aggregate(rows []jobs.StateRow) jobSeries {
+	a := jobSeries{
+		depth:        map[queueKey]int64{},
+		running:      map[queueKey]int64{},
+		discarded:    map[kindKey]int64{},
+		cancelled:    map[kindKey]int64{},
+		oldest:       map[queueKey]float64{},
+		unrecognised: map[stateKey]int64{},
+	}
+	for _, r := range rows {
+		qk := queueKey{queue: r.Queue, workspace: r.WorkspaceID}
+		kk := kindKey{kind: r.Kind, workspace: r.WorkspaceID}
+		switch {
+		case queueDepthStates[r.State]:
+			a.depth[qk] += r.Count
+		case r.State == stateRunning:
+			a.running[qk] += r.Count
+		case r.State == stateDiscarded:
+			a.discarded[kk] += r.Count
+		case r.State == stateCancelled:
+			// Reported apart from discarded on purpose. River cancels
+			// deliberately, without spending every attempt, so folding the
+			// two together would make the discarded gauge's own HELP text
+			// false for half the rows under it.
+			a.cancelled[kk] += r.Count
+		default:
+			a.unrecognised[stateKey{state: r.State, queue: r.Queue, workspace: r.WorkspaceID}] += r.Count
+		}
+		a.ageFrom(qk, r)
+	}
+	return a
+}
+
+// ageFrom folds one row into the per-queue oldest-runnable age.
+//
+// The age is the WORST case across the kinds sharing a queue; reporting the
+// last row read would make the number depend on the order the database
+// returned groups in.
+//
+// Only rows that could still RUN contribute a series at all. A zero from a
+// queue holding queued work is a measured value — the work is there and
+// none of it is late — but a queue holding nothing except discarded rows
+// has no runnable job to age, and emitting a zero for it would answer "how
+// long has the oldest runnable job waited" with a number about work that
+// will never run.
+func (a jobSeries) ageFrom(qk queueKey, r jobs.StateRow) {
+	if !queueDepthStates[r.State] && r.State != stateRunning {
+		return
+	}
+	if _, seen := a.oldest[qk]; !seen || r.OldestRunnableAgeSeconds > a.oldest[qk] {
+		a.oldest[qk] = r.OldestRunnableAgeSeconds
+	}
+}
+
 // writeJobMetrics renders the job-runtime section. Pure over snap so the
 // exposition text is provable without a database.
 //
@@ -64,42 +138,10 @@ type stateKey struct{ state, queue, workspace string }
 // swallowed a refused write would serve a truncated exposition, which
 // parses as a smaller fleet rather than as a broken one.
 func writeJobMetrics(w io.Writer, snap jobs.Snapshot) error {
-	depth := map[queueKey]int64{}
-	running := map[queueKey]int64{}
-	discarded := map[kindKey]int64{}
-	cancelled := map[kindKey]int64{}
-	oldest := map[queueKey]float64{}
-	unrecognised := map[stateKey]int64{}
-
-	for _, r := range snap.Rows {
-		qk := queueKey{queue: r.Queue, workspace: r.WorkspaceID}
-		kk := kindKey{kind: r.Kind, workspace: r.WorkspaceID}
-		switch {
-		case queueDepthStates[r.State]:
-			depth[qk] += r.Count
-		case r.State == "running":
-			running[qk] += r.Count
-		case r.State == "discarded":
-			discarded[kk] += r.Count
-		case r.State == "cancelled":
-			// Reported apart from discarded on purpose. River cancels
-			// deliberately, without spending every attempt, so folding the
-			// two together would make the discarded gauge's own HELP text
-			// false for half the rows under it.
-			cancelled[kk] += r.Count
-		default:
-			unrecognised[stateKey{state: r.State, queue: r.Queue, workspace: r.WorkspaceID}] += r.Count
-		}
-
-		// The age is the WORST case across the kinds sharing a queue.
-		// Reporting the last row read would make the number depend on the
-		// order the database returned groups in. A zero is a measured value
-		// here — the queue holds work and none of it is late — so the series
-		// is written whenever the queue has any row at all.
-		if _, seen := oldest[qk]; !seen || r.OldestRunnableAgeSeconds > oldest[qk] {
-			oldest[qk] = r.OldestRunnableAgeSeconds
-		}
-	}
+	a := aggregate(snap.Rows)
+	depth, running := a.depth, a.running
+	discarded, cancelled := a.discarded, a.cancelled
+	oldest, unrecognised := a.oldest, a.unrecognised
 
 	if err := writeQueueGauge(w, "margince_job_queue_depth",
 		"Jobs waiting to run (available + scheduled + retryable + pending) per queue and workspace. An empty workspace_id is a dispatcher, which does no tenant work.",
@@ -135,8 +177,8 @@ func writeQueueGauge(w io.Writer, name, help string, series map[queueKey]int64) 
 		return err
 	}
 	for _, k := range sortedQueueKeys(series) {
-		if _, err := fmt.Fprintf(w, "%s{queue=%q,workspace_id=%q} %d\n",
-			name, k.queue, k.workspace, series[k]); err != nil {
+		if _, err := fmt.Fprintf(w, "%s{queue=%s,workspace_id=%s} %d\n",
+			name, label(k.queue), label(k.workspace), series[k]); err != nil {
 			return err
 		}
 	}
@@ -151,8 +193,8 @@ func writeKindGauge(w io.Writer, name, help string, series map[kindKey]int64) er
 		return cmp.Or(cmp.Compare(a.kind, b.kind), cmp.Compare(a.workspace, b.workspace))
 	})
 	for _, k := range keys {
-		if _, err := fmt.Fprintf(w, "%s{kind=%q,workspace_id=%q} %d\n",
-			name, k.kind, k.workspace, series[k]); err != nil {
+		if _, err := fmt.Fprintf(w, "%s{kind=%s,workspace_id=%s} %d\n",
+			name, label(k.kind), label(k.workspace), series[k]); err != nil {
 			return err
 		}
 	}
@@ -166,8 +208,8 @@ func writeAgeGauge(w io.Writer, series map[queueKey]float64) error {
 		return err
 	}
 	for _, k := range sortedQueueKeys(series) {
-		if _, err := fmt.Fprintf(w, "%s{queue=%q,workspace_id=%q} %.0f\n",
-			name, k.queue, k.workspace, series[k]); err != nil {
+		if _, err := fmt.Fprintf(w, "%s{queue=%s,workspace_id=%s} %.0f\n",
+			name, label(k.queue), label(k.workspace), series[k]); err != nil {
 			return err
 		}
 	}
@@ -188,8 +230,8 @@ func writeSweepGauges(w io.Writer, sweeps []jobs.SweepPass) error {
 		return err
 	}
 	for _, s := range ordered {
-		if _, err := fmt.Fprintf(w, "margince_sweep_workspaces_total{sweep=%q} %d\n",
-			s.Kind, s.Workspaces); err != nil {
+		if _, err := fmt.Fprintf(w, "margince_sweep_workspaces_total{sweep=%s} %d\n",
+			label(s.Kind), s.Workspaces); err != nil {
 			return err
 		}
 	}
@@ -199,8 +241,8 @@ func writeSweepGauges(w io.Writer, sweeps []jobs.SweepPass) error {
 		return err
 	}
 	for _, s := range ordered {
-		if _, err := fmt.Fprintf(w, "margince_sweep_workspaces_failed{sweep=%q} %d\n",
-			s.Kind, s.Failed); err != nil {
+		if _, err := fmt.Fprintf(w, "margince_sweep_workspaces_failed{sweep=%s} %d\n",
+			label(s.Kind), s.Failed); err != nil {
 			return err
 		}
 	}
@@ -228,8 +270,8 @@ func writeUnrecognisedStateGauge(w io.Writer, series map[stateKey]int64) error {
 			cmp.Compare(a.workspace, b.workspace))
 	})
 	for _, k := range keys {
-		if _, err := fmt.Fprintf(w, "%s{state=%q,queue=%q,workspace_id=%q} %d\n",
-			name, k.state, k.queue, k.workspace, series[k]); err != nil {
+		if _, err := fmt.Fprintf(w, "%s{state=%s,queue=%s,workspace_id=%s} %d\n",
+			name, label(k.state), label(k.queue), label(k.workspace), series[k]); err != nil {
 			return err
 		}
 	}
@@ -239,6 +281,41 @@ func writeUnrecognisedStateGauge(w io.Writer, series map[stateKey]int64) error {
 func writeFamilyHeader(w io.Writer, name, help string) error {
 	_, err := fmt.Fprintf(w, "# HELP %s %s\n# TYPE %s gauge\n", name, help, name)
 	return err
+}
+
+// label renders one label value for the Prometheus text format, which
+// defines exactly three escapes — backslash, double quote and newline —
+// and no others.
+//
+// Go's %q is not that format. It emits \t, \r and \xNN for control
+// characters, and a parser meeting an escape the format does not define
+// rejects the whole exposition rather than the one series. That matters
+// here because workspace_id is args->>'workspace_id' verbatim from a table
+// with no constraint on it and direct app-role CRUD, so a single
+// raw-inserted row could otherwise poison every scrape for every metric.
+// Anything outside the three escapes is dropped rather than encoded: a
+// control character in a label value is already a broken row, and a
+// readable scrape that omits it beats a rejected one that carries it.
+func label(value string) string {
+	var b strings.Builder
+	b.Grow(len(value) + 2)
+	b.WriteByte('"')
+	for _, r := range value {
+		switch {
+		case r == '\\':
+			b.WriteString(`\\`)
+		case r == '"':
+			b.WriteString(`\"`)
+		case r == '\n':
+			b.WriteString(`\n`)
+		case r < ' ' || r == 0x7f:
+			// Dropped: see above.
+		default:
+			b.WriteRune(r)
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
 }
 
 // sortedQueueKeys orders the per-queue series. A scrape target's series
@@ -260,19 +337,23 @@ func sortedKeysOf[K comparable, V any](series map[K]V, order func(a, b K) int) [
 	return keys
 }
 
-// jobMetricsSection binds the job gauges to a pool. A failed read logs and
-// writes NOTHING for the section: a scrape that emits zeroes it did not
-// measure is worse than a gap, because a gap is visible on a graph while a
-// fabricated zero reads as a healthy empty queue. This is the same posture
-// Metrics already takes for the outbox backlog.
+// jobMetricsSection binds the job gauges to a snapshot reader. A failed
+// read logs and writes NOTHING for the section: a scrape that emits zeroes
+// it did not measure is worse than a gap, because a gap is visible on a
+// graph while a fabricated zero reads as a healthy empty queue. This is the
+// same posture Metrics already takes for the outbox backlog.
+//
+// The reader is a closure rather than the pool itself, matching how the
+// outbox backlog is injected next door — so that posture is provable
+// without a database, which is the only way it stays true.
 //
 // The ctx handed in is the exposition handler's own budget context, NOT the
 // request's. The overlay section next door passes r.Context() and so runs
 // unbounded; this read is the one that needs the budget, because it scans a
 // table no index covers.
-func jobMetricsSection(pool *pgxpool.Pool) func(context.Context, io.Writer) error {
+func jobMetricsSection(read func(context.Context) (jobs.Snapshot, error)) func(context.Context, io.Writer) error {
 	return func(ctx context.Context, w io.Writer) error {
-		snap, err := jobs.Stats(ctx, pool)
+		snap, err := read(ctx)
 		if err != nil {
 			slog.ErrorContext(ctx, "metrics: job stats query failed", "err", err)
 			// A section that could not be measured is absent, not fatal: the

--- a/backend/internal/compose/jobmetrics.go
+++ b/backend/internal/compose/jobmetrics.go
@@ -110,14 +110,18 @@ func aggregate(rows []jobs.StateRow) jobSeries {
 // last row read would make the number depend on the order the database
 // returned groups in.
 //
-// Only rows that could still RUN contribute a series at all. A zero from a
-// queue holding queued work is a measured value — the work is there and
-// none of it is late — but a queue holding nothing except discarded rows
-// has no runnable job to age, and emitting a zero for it would answer "how
-// long has the oldest runnable job waited" with a number about work that
-// will never run.
+// Only WAITING rows contribute a series at all. The gauge measures the
+// oldest runnable-and-UNCLAIMED job, so a running row is not its subject —
+// it has already been claimed — and a discarded one never will be. A queue
+// holding nothing but those has no such job, and emitting a zero for it
+// would answer the gauge's own question with a number about work that is
+// not waiting. It is also what keeps this gauge agreeing with the endpoint,
+// which reports null for exactly these rows.
+//
+// A zero from a queue that DOES hold waiting work is a measured value: the
+// work is there and none of it is late yet.
 func (a jobSeries) ageFrom(qk queueKey, r jobs.StateRow) {
-	if !queueDepthStates[r.State] && r.State != stateRunning {
+	if !queueDepthStates[r.State] {
 		return
 	}
 	if _, seen := a.oldest[qk]; !seen || r.OldestRunnableAgeSeconds > a.oldest[qk] {
@@ -159,7 +163,7 @@ func writeJobMetrics(w io.Writer, snap jobs.Snapshot) error {
 		return err
 	}
 	if err := writeKindGauge(w, "margince_job_cancelled",
-		"Jobs stopped deliberately before their attempts ran out, per kind and workspace. Counted apart from discarded because a cancelled job did not fail.",
+		"Jobs stopped deliberately before their attempts ran out, per kind and workspace. Counted apart from discarded because the operator story differs -- a discarded job spent every attempt, a cancelled one was stopped. Both are work that will not happen, which is why the sweep pair counts either as a workspace missed.",
 		cancelled); err != nil {
 		return err
 	}

--- a/backend/internal/compose/jobmetrics.go
+++ b/backend/internal/compose/jobmetrics.go
@@ -1,0 +1,284 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The job-runtime section of /metrics: OPS-MET-2's queue depth and the
+// gauges beside it, plus the sweep pair. Every number is read from
+// river_job at scrape time rather than counted in process, because the
+// dispatchers run in cmd/worker and cmd/worker serves no exposition
+// endpoint at all — an in-process counter incremented there would be
+// invisible to every scrape while the api's own copy read a truthful
+// looking zero.
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"slices"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/gradionhq/margince/backend/internal/platform/jobs"
+)
+
+// queueDepthStates are the states a job is WAITING in. A job backing off
+// toward its next attempt is queued work nobody has done, so retryable
+// belongs here — OPS-MET-2 asks how much work is outstanding, and a queue
+// full of retrying jobs is the case the metric exists to surface. pending
+// is River's staged state (its migration 004): nothing in this tree sets
+// it today, and it is counted rather than dropped because a state the
+// renderer has never heard of vanishing is the posture this whole phase
+// exists to remove.
+var queueDepthStates = map[string]bool{
+	"available": true,
+	"scheduled": true,
+	"retryable": true,
+	"pending":   true,
+}
+
+// queueKey identifies one series of the per-queue gauges.
+type queueKey struct{ queue, workspace string }
+
+// kindKey identifies one series of the per-kind gauges. Dead work is keyed
+// by kind rather than by queue because "which work will never run" is a
+// question about the kind, not about the lane it happened to sit in.
+type kindKey struct{ kind, workspace string }
+
+// stateKey identifies one series of the unrecognised-state gauge, which
+// carries the state itself so an operator can see what appeared.
+type stateKey struct{ state, queue, workspace string }
+
+// writeJobMetrics renders the job-runtime section. Pure over snap so the
+// exposition text is provable without a database.
+//
+// workspace_id is admitted on these gauges by ADR-0080/A125 — the id, never
+// a name, because the exposition endpoint has no redaction path. An empty
+// value is a dispatcher, exactly and only: a job that does tenant work
+// declares its workspace, and a null in that column means a dispatcher and
+// nothing else.
+//
+// It returns an error because an io.Writer can fail. A scrape that
+// swallowed a refused write would serve a truncated exposition, which
+// parses as a smaller fleet rather than as a broken one.
+func writeJobMetrics(w io.Writer, snap jobs.Snapshot) error {
+	depth := map[queueKey]int64{}
+	running := map[queueKey]int64{}
+	discarded := map[kindKey]int64{}
+	cancelled := map[kindKey]int64{}
+	oldest := map[queueKey]float64{}
+	unrecognised := map[stateKey]int64{}
+
+	for _, r := range snap.Rows {
+		qk := queueKey{queue: r.Queue, workspace: r.WorkspaceID}
+		kk := kindKey{kind: r.Kind, workspace: r.WorkspaceID}
+		switch {
+		case queueDepthStates[r.State]:
+			depth[qk] += r.Count
+		case r.State == "running":
+			running[qk] += r.Count
+		case r.State == "discarded":
+			discarded[kk] += r.Count
+		case r.State == "cancelled":
+			// Reported apart from discarded on purpose. River cancels
+			// deliberately, without spending every attempt, so folding the
+			// two together would make the discarded gauge's own HELP text
+			// false for half the rows under it.
+			cancelled[kk] += r.Count
+		default:
+			unrecognised[stateKey{state: r.State, queue: r.Queue, workspace: r.WorkspaceID}] += r.Count
+		}
+
+		// The age is the WORST case across the kinds sharing a queue.
+		// Reporting the last row read would make the number depend on the
+		// order the database returned groups in. A zero is a measured value
+		// here — the queue holds work and none of it is late — so the series
+		// is written whenever the queue has any row at all.
+		if _, seen := oldest[qk]; !seen || r.OldestRunnableAgeSeconds > oldest[qk] {
+			oldest[qk] = r.OldestRunnableAgeSeconds
+		}
+	}
+
+	if err := writeQueueGauge(w, "margince_job_queue_depth",
+		"Jobs waiting to run (available + scheduled + retryable + pending) per queue and workspace. An empty workspace_id is a dispatcher, which does no tenant work.",
+		depth); err != nil {
+		return err
+	}
+	if err := writeQueueGauge(w, "margince_job_running",
+		"Jobs currently executing per queue and workspace.",
+		running); err != nil {
+		return err
+	}
+	if err := writeKindGauge(w, "margince_job_discarded",
+		"Jobs that exhausted every attempt and will never run without intervention, per kind and workspace.",
+		discarded); err != nil {
+		return err
+	}
+	if err := writeKindGauge(w, "margince_job_cancelled",
+		"Jobs stopped deliberately before their attempts ran out, per kind and workspace. Counted apart from discarded because a cancelled job did not fail.",
+		cancelled); err != nil {
+		return err
+	}
+	if err := writeAgeGauge(w, oldest); err != nil {
+		return err
+	}
+	if err := writeSweepGauges(w, snap.Sweeps); err != nil {
+		return err
+	}
+	return writeUnrecognisedStateGauge(w, unrecognised)
+}
+
+func writeQueueGauge(w io.Writer, name, help string, series map[queueKey]int64) error {
+	if err := writeFamilyHeader(w, name, help); err != nil {
+		return err
+	}
+	for _, k := range sortedQueueKeys(series) {
+		if _, err := fmt.Fprintf(w, "%s{queue=%q,workspace_id=%q} %d\n",
+			name, k.queue, k.workspace, series[k]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeKindGauge(w io.Writer, name, help string, series map[kindKey]int64) error {
+	if err := writeFamilyHeader(w, name, help); err != nil {
+		return err
+	}
+	keys := sortedKeysOf(series, func(a, b kindKey) int {
+		return cmp.Or(cmp.Compare(a.kind, b.kind), cmp.Compare(a.workspace, b.workspace))
+	})
+	for _, k := range keys {
+		if _, err := fmt.Fprintf(w, "%s{kind=%q,workspace_id=%q} %d\n",
+			name, k.kind, k.workspace, series[k]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeAgeGauge(w io.Writer, series map[queueKey]float64) error {
+	const name = "margince_job_oldest_queued_age_seconds"
+	if err := writeFamilyHeader(w, name,
+		"Seconds the oldest runnable-and-unclaimed job has waited per queue and workspace. A job scheduled for the future is not counted; it is not late."); err != nil {
+		return err
+	}
+	for _, k := range sortedQueueKeys(series) {
+		if _, err := fmt.Fprintf(w, "%s{queue=%q,workspace_id=%q} %.0f\n",
+			name, k.queue, k.workspace, series[k]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// writeSweepGauges renders the pair that answers "are tenants being
+// missed". Both halves carry the same sweep label so an alert can compare
+// them; the label is the CHILD kind, which is what the rows hold — mapping
+// back to the dispatcher would be a hand-kept table.
+func writeSweepGauges(w io.Writer, sweeps []jobs.SweepPass) error {
+	ordered := slices.SortedFunc(slices.Values(sweeps), func(a, b jobs.SweepPass) int {
+		return cmp.Compare(a.Kind, b.Kind)
+	})
+
+	if err := writeFamilyHeader(w, "margince_sweep_workspaces_total",
+		"Workspaces with a surviving child of this fleet pass. Counted per workspace rather than per pass: a child still active from an earlier fan-out is deduplicated out of the current one and writes no new row, so no batch can be identified. A workspace whose only child aged out of River's job retention is absent rather than reported as zero."); err != nil {
+		return err
+	}
+	for _, s := range ordered {
+		if _, err := fmt.Fprintf(w, "margince_sweep_workspaces_total{sweep=%q} %d\n",
+			s.Kind, s.Workspaces); err != nil {
+			return err
+		}
+	}
+
+	if err := writeFamilyHeader(w, "margince_sweep_workspaces_failed",
+		"Workspaces whose MOST RECENT child of this fleet pass ended discarded or cancelled — tenants whose share of the pass did not happen. A workspace that failed and then succeeded is not counted."); err != nil {
+		return err
+	}
+	for _, s := range ordered {
+		if _, err := fmt.Fprintf(w, "margince_sweep_workspaces_failed{sweep=%q} %d\n",
+			s.Kind, s.Failed); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// writeUnrecognisedStateGauge reports work sitting in a state no arm above
+// claimed — a River release that adds one, or a state this renderer was
+// never taught. Its header is written ONLY when there is something to
+// report: unlike the families above, a permanently empty series here would
+// be noise on every dashboard, and its whole purpose is to be absent.
+func writeUnrecognisedStateGauge(w io.Writer, series map[stateKey]int64) error {
+	if len(series) == 0 {
+		return nil
+	}
+	const name = "margince_job_unrecognised_state"
+	if err := writeFamilyHeader(w, name,
+		"Jobs in a state this exposition does not classify. Present only when such work exists; investigate rather than graph."); err != nil {
+		return err
+	}
+	keys := sortedKeysOf(series, func(a, b stateKey) int {
+		return cmp.Or(
+			cmp.Compare(a.state, b.state),
+			cmp.Compare(a.queue, b.queue),
+			cmp.Compare(a.workspace, b.workspace))
+	})
+	for _, k := range keys {
+		if _, err := fmt.Fprintf(w, "%s{state=%q,queue=%q,workspace_id=%q} %d\n",
+			name, k.state, k.queue, k.workspace, series[k]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeFamilyHeader(w io.Writer, name, help string) error {
+	_, err := fmt.Fprintf(w, "# HELP %s %s\n# TYPE %s gauge\n", name, help, name)
+	return err
+}
+
+// sortedQueueKeys orders the per-queue series. A scrape target's series
+// order should not flap between scrapes for no reason, and map iteration
+// order is not stable.
+func sortedQueueKeys[V any](series map[queueKey]V) []queueKey {
+	return sortedKeysOf(series, func(a, b queueKey) int {
+		return cmp.Or(cmp.Compare(a.queue, b.queue), cmp.Compare(a.workspace, b.workspace))
+	})
+}
+
+// sortedKeysOf answers a series map's keys in the caller's order.
+func sortedKeysOf[K comparable, V any](series map[K]V, order func(a, b K) int) []K {
+	keys := make([]K, 0, len(series))
+	for k := range series {
+		keys = append(keys, k)
+	}
+	slices.SortFunc(keys, order)
+	return keys
+}
+
+// jobMetricsSection binds the job gauges to a pool. A failed read logs and
+// writes NOTHING for the section: a scrape that emits zeroes it did not
+// measure is worse than a gap, because a gap is visible on a graph while a
+// fabricated zero reads as a healthy empty queue. This is the same posture
+// Metrics already takes for the outbox backlog.
+//
+// The ctx handed in is the exposition handler's own budget context, NOT the
+// request's. The overlay section next door passes r.Context() and so runs
+// unbounded; this read is the one that needs the budget, because it scans a
+// table no index covers.
+func jobMetricsSection(pool *pgxpool.Pool) func(context.Context, io.Writer) error {
+	return func(ctx context.Context, w io.Writer) error {
+		snap, err := jobs.Stats(ctx, pool)
+		if err != nil {
+			slog.ErrorContext(ctx, "metrics: job stats query failed", "err", err)
+			// A section that could not be measured is absent, not fatal: the
+			// rest of the exposition is still true and still worth serving.
+			return nil
+		}
+		return writeJobMetrics(w, snap)
+	}
+}

--- a/backend/internal/compose/jobmetrics_test.go
+++ b/backend/internal/compose/jobmetrics_test.go
@@ -339,3 +339,24 @@ func TestTheJobSectionWritesNothingWhenTheReadFails(t *testing.T) {
 			"indistinguishable from a healthy empty queue\ngot:\n%s", buf.Len(), buf.String())
 	}
 }
+
+// TestAQueueHoldingOnlyRunningWorkReportsNoAgeEither — the gauge measures
+// the oldest runnable-and-UNCLAIMED job. A running job has been claimed, so
+// a queue holding only running rows has no subject for this gauge, and a
+// zero there would read as "nothing is late" rather than "nothing is
+// waiting". The endpoint reports null for exactly these rows; the two
+// surfaces must not disagree about the same table.
+func TestAQueueHoldingOnlyRunningWorkReportsNoAgeEither(t *testing.T) {
+	var buf bytes.Buffer
+	if err := writeJobMetrics(&buf, jobs.Snapshot{Rows: []jobs.StateRow{
+		{Queue: "busy", Kind: "k", State: "running", Count: 4},
+	}}); err != nil {
+		t.Fatalf("writeJobMetrics: %v", err)
+	}
+	if strings.Contains(buf.String(), `margince_job_oldest_queued_age_seconds{queue="busy"`) {
+		t.Errorf("a queue whose work is all claimed reported a waiting age\ngot:\n%s", buf.String())
+	}
+	if !strings.Contains(buf.String(), `margince_job_running{queue="busy",workspace_id=""} 4`) {
+		t.Errorf("the running work itself went missing\ngot:\n%s", buf.String())
+	}
+}

--- a/backend/internal/compose/jobmetrics_test.go
+++ b/backend/internal/compose/jobmetrics_test.go
@@ -117,22 +117,6 @@ func TestTheOldestQueuedAgeIsTheWorstCaseAcrossTheQueuesKinds(t *testing.T) {
 	}
 }
 
-// TestAQueueWhoseWorkIsAllFutureScheduledStillReportsAZeroAge — zero is a
-// measured value here, not a missing one: the queue holds work and none of
-// it is late. Skipping the series would make "nothing is late" and "this
-// queue is unmeasured" the same scrape.
-func TestAQueueWhoseWorkIsAllFutureScheduledStillReportsAZeroAge(t *testing.T) {
-	var buf bytes.Buffer
-	if err := writeJobMetrics(&buf, jobs.Snapshot{Rows: []jobs.StateRow{
-		{Queue: "nightly", Kind: "k", Untenanted: true, State: "scheduled", Count: 4, OldestRunnableAgeSeconds: ptrTo(0.0)},
-	}}); err != nil {
-		t.Fatalf("writeJobMetrics: %v", err)
-	}
-	if !strings.Contains(buf.String(), `margince_job_oldest_queued_age_seconds{queue="nightly",workspace_id=""} 0`) {
-		t.Errorf("a queue with only future-scheduled work reported no age at all\ngot:\n%s", buf.String())
-	}
-}
-
 // TestTheSweepPairIsRenderedPerFanOutKind — the pair answers "are tenants
 // being missed", so both halves must appear for the same sweep label or an
 // alert cannot compare them.
@@ -408,7 +392,7 @@ func TestAPresentButEmptyWorkspaceIsNotCountedAsADispatcher(t *testing.T) {
 		t.Error("a malformed row was folded into the dispatcher series, which is the one " +
 			"invariant these gauges promise")
 	}
-	if !strings.Contains(buf.String(), `margince_job_queue_depth{queue="default",workspace_id="<malformed>"} 9`) {
+	if !strings.Contains(buf.String(), `margince_job_queue_depth{queue="default",workspace_id="malformed_workspace_id"} 9`) {
 		t.Errorf("the malformed row is invisible rather than flagged\ngot:\n%s", buf.String())
 	}
 }

--- a/backend/internal/compose/jobmetrics_test.go
+++ b/backend/internal/compose/jobmetrics_test.go
@@ -1,0 +1,267 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/platform/jobs"
+)
+
+// TestJobMetricsNameTheWorkspaceThatOwnsTheWorkAndLeaveItEmptyForADispatcher
+// — the empty label is the workspace invariant on the wire, and ADR-0080
+// admits the id and only the id.
+func TestJobMetricsNameTheWorkspaceThatOwnsTheWorkAndLeaveItEmptyForADispatcher(t *testing.T) {
+	ws := "6f1a0d64-9d3f-4d63-9c4a-2f0f3b8a1c77"
+	var buf bytes.Buffer
+	if err := writeJobMetrics(&buf, jobs.Snapshot{Rows: []jobs.StateRow{
+		{Queue: "default", Kind: "tenant_pass", WorkspaceID: ws, State: "available", Count: 2},
+		{Queue: "default", Kind: "the_dispatcher", WorkspaceID: "", State: "available", Count: 1},
+	}}); err != nil {
+		t.Fatalf("writeJobMetrics: %v", err)
+	}
+
+	want := []string{
+		`margince_job_queue_depth{queue="default",workspace_id="` + ws + `"} 2`,
+		`margince_job_queue_depth{queue="default",workspace_id=""} 1`,
+	}
+	for _, line := range want {
+		if !strings.Contains(buf.String(), line) {
+			t.Errorf("exposition missing %q\ngot:\n%s", line, buf.String())
+		}
+	}
+}
+
+// TestQueueDepthSumsEveryStateAJobCanBeWaitingIn — OPS-MET-2 is "queued
+// jobs per queue", and a job backing off toward a retry is queued work
+// nobody has done. Counting only 'available' reports a queue full of
+// retrying jobs as empty, which is the failure mode the metric exists to
+// catch.
+func TestQueueDepthSumsEveryStateAJobCanBeWaitingIn(t *testing.T) {
+	var buf bytes.Buffer
+	if err := writeJobMetrics(&buf, jobs.Snapshot{Rows: []jobs.StateRow{
+		{Queue: "default", Kind: "k", State: "available", Count: 1},
+		{Queue: "default", Kind: "k", State: "scheduled", Count: 2},
+		{Queue: "default", Kind: "k", State: "retryable", Count: 4},
+		{Queue: "default", Kind: "k", State: "pending", Count: 16},
+		{Queue: "default", Kind: "k", State: "running", Count: 8},
+	}}); err != nil {
+		t.Fatalf("writeJobMetrics: %v", err)
+	}
+	if !strings.Contains(buf.String(), `margince_job_queue_depth{queue="default",workspace_id=""} 23`) {
+		t.Errorf("queue depth did not sum available+scheduled+retryable+pending\ngot:\n%s", buf.String())
+	}
+	if !strings.Contains(buf.String(), `margince_job_running{queue="default",workspace_id=""} 8`) {
+		t.Errorf("running is its own gauge, not part of depth\ngot:\n%s", buf.String())
+	}
+}
+
+// TestDiscardedAndCancelledAreReportedApartAndKeyedByKind — the two are
+// different operator stories (every attempt spent vs stopped on purpose)
+// and depth is per queue while dead work is per kind, because "which work
+// will never run" is a question about the kind, not the lane it sat in.
+func TestDiscardedAndCancelledAreReportedApartAndKeyedByKind(t *testing.T) {
+	var buf bytes.Buffer
+	if err := writeJobMetrics(&buf, jobs.Snapshot{Rows: []jobs.StateRow{
+		{Queue: "default", Kind: "retention", State: "discarded", Count: 3},
+		{Queue: "default", Kind: "retention", State: "cancelled", Count: 5},
+	}}); err != nil {
+		t.Fatalf("writeJobMetrics: %v", err)
+	}
+	if !strings.Contains(buf.String(), `margince_job_discarded{kind="retention",workspace_id=""} 3`) {
+		t.Errorf("discarded is missing or folded in with cancelled\ngot:\n%s", buf.String())
+	}
+	if !strings.Contains(buf.String(), `margince_job_cancelled{kind="retention",workspace_id=""} 5`) {
+		t.Errorf("cancelled is missing or folded in with discarded\ngot:\n%s", buf.String())
+	}
+	if strings.Contains(buf.String(), `margince_job_discarded{kind="retention",workspace_id=""} 8`) {
+		t.Error("cancelled was counted as discarded; a job stopped on purpose is not one " +
+			"that spent every attempt")
+	}
+}
+
+// TestAStateTheRendererHasNeverHeardOfIsReportedRatherThanDropped — a
+// silently discarded state is the exact posture this phase exists to
+// remove. A River release that adds one must make the fleet's unreported
+// work visible, not invisible.
+func TestAStateTheRendererHasNeverHeardOfIsReportedRatherThanDropped(t *testing.T) {
+	var buf bytes.Buffer
+	if err := writeJobMetrics(&buf, jobs.Snapshot{Rows: []jobs.StateRow{
+		{Queue: "default", Kind: "k", State: "hibernating", Count: 7},
+	}}); err != nil {
+		t.Fatalf("writeJobMetrics: %v", err)
+	}
+	if !strings.Contains(buf.String(), `margince_job_unrecognised_state{state="hibernating",queue="default",workspace_id=""} 7`) {
+		t.Errorf("a state the renderer does not know vanished from the exposition\ngot:\n%s", buf.String())
+	}
+}
+
+// TestTheOldestQueuedAgeIsTheWorstCaseAcrossTheQueuesKinds — the gauge is
+// keyed per queue, and a queue holds many kinds. Reporting the last one
+// read rather than the worst would make the number depend on row order.
+func TestTheOldestQueuedAgeIsTheWorstCaseAcrossTheQueuesKinds(t *testing.T) {
+	var buf bytes.Buffer
+	if err := writeJobMetrics(&buf, jobs.Snapshot{Rows: []jobs.StateRow{
+		{Queue: "default", Kind: "slow", State: "available", Count: 1, OldestRunnableAgeSeconds: 900},
+		{Queue: "default", Kind: "fast", State: "available", Count: 1, OldestRunnableAgeSeconds: 5},
+	}}); err != nil {
+		t.Fatalf("writeJobMetrics: %v", err)
+	}
+	if !strings.Contains(buf.String(), `margince_job_oldest_queued_age_seconds{queue="default",workspace_id=""} 900`) {
+		t.Errorf("the age gauge did not report the worst case for the queue\ngot:\n%s", buf.String())
+	}
+}
+
+// TestAQueueWhoseWorkIsAllFutureScheduledStillReportsAZeroAge — zero is a
+// measured value here, not a missing one: the queue holds work and none of
+// it is late. Skipping the series would make "nothing is late" and "this
+// queue is unmeasured" the same scrape.
+func TestAQueueWhoseWorkIsAllFutureScheduledStillReportsAZeroAge(t *testing.T) {
+	var buf bytes.Buffer
+	if err := writeJobMetrics(&buf, jobs.Snapshot{Rows: []jobs.StateRow{
+		{Queue: "nightly", Kind: "k", State: "scheduled", Count: 4, OldestRunnableAgeSeconds: 0},
+	}}); err != nil {
+		t.Fatalf("writeJobMetrics: %v", err)
+	}
+	if !strings.Contains(buf.String(), `margince_job_oldest_queued_age_seconds{queue="nightly",workspace_id=""} 0`) {
+		t.Errorf("a queue with only future-scheduled work reported no age at all\ngot:\n%s", buf.String())
+	}
+}
+
+// TestTheSweepPairIsRenderedPerFanOutKind — the pair answers "are tenants
+// being missed", so both halves must appear for the same sweep label or an
+// alert cannot compare them.
+func TestTheSweepPairIsRenderedPerFanOutKind(t *testing.T) {
+	var buf bytes.Buffer
+	if err := writeJobMetrics(&buf, jobs.Snapshot{Sweeps: []jobs.SweepPass{
+		{Kind: "privacy_retention_workspace", Workspaces: 42, Failed: 3},
+	}}); err != nil {
+		t.Fatalf("writeJobMetrics: %v", err)
+	}
+	for _, line := range []string{
+		`margince_sweep_workspaces_total{sweep="privacy_retention_workspace"} 42`,
+		`margince_sweep_workspaces_failed{sweep="privacy_retention_workspace"} 3`,
+	} {
+		if !strings.Contains(buf.String(), line) {
+			t.Errorf("exposition missing %q\ngot:\n%s", line, buf.String())
+		}
+	}
+}
+
+// TestEverySeriesIsWrittenInAStableOrder — a scrape target's series order
+// should not flap between scrapes for no reason, and map iteration order is
+// not stable. sortedKeys next door exists for the same reason.
+func TestEverySeriesIsWrittenInAStableOrder(t *testing.T) {
+	snap := jobs.Snapshot{
+		Rows: []jobs.StateRow{
+			{Queue: "zeta", Kind: "k", State: "available", Count: 1},
+			{Queue: "alpha", Kind: "k", State: "available", Count: 1},
+			{Queue: "mid", Kind: "k", State: "available", Count: 1},
+		},
+		Sweeps: []jobs.SweepPass{
+			{Kind: "zeta_sweep", Workspaces: 1},
+			{Kind: "alpha_sweep", Workspaces: 1},
+		},
+	}
+	var first bytes.Buffer
+	if err := writeJobMetrics(&first, snap); err != nil {
+		t.Fatalf("writeJobMetrics: %v", err)
+	}
+	for range 20 {
+		var again bytes.Buffer
+		if err := writeJobMetrics(&again, snap); err != nil {
+			t.Fatalf("writeJobMetrics: %v", err)
+		}
+		if again.String() != first.String() {
+			t.Fatal("two renders of one snapshot differed: the series order is unstable")
+		}
+	}
+	if strings.Index(first.String(), `queue="alpha"`) > strings.Index(first.String(), `queue="zeta"`) {
+		t.Error("queue series are not in sorted order")
+	}
+	if strings.Index(first.String(), `sweep="alpha_sweep"`) > strings.Index(first.String(), `sweep="zeta_sweep"`) {
+		t.Error("sweep series are not in sorted order")
+	}
+}
+
+// TestAnEmptySnapshotWritesEveryFamilyHeaderAndNoSeries — an idle fleet is
+// a real state. Writing nothing at all makes "no jobs" and "the reader is
+// broken" the same scrape, and a family whose header never appears cannot
+// be graphed before its first series exists.
+func TestAnEmptySnapshotWritesEveryFamilyHeaderAndNoSeries(t *testing.T) {
+	var buf bytes.Buffer
+	if err := writeJobMetrics(&buf, jobs.Snapshot{}); err != nil {
+		t.Fatalf("writeJobMetrics: %v", err)
+	}
+	for _, family := range []string{
+		"margince_job_queue_depth",
+		"margince_job_running",
+		"margince_job_discarded",
+		"margince_job_cancelled",
+		"margince_job_oldest_queued_age_seconds",
+		"margince_sweep_workspaces_total",
+		"margince_sweep_workspaces_failed",
+	} {
+		if !strings.Contains(buf.String(), "# TYPE "+family+" gauge") {
+			t.Errorf("family header for %s missing from an empty snapshot\ngot:\n%s", family, buf.String())
+		}
+		if !strings.Contains(buf.String(), "# HELP "+family+" ") {
+			t.Errorf("HELP line for %s missing; the text is the contract with whoever reads "+
+				"a dashboard six months from now", family)
+		}
+		if strings.Contains(buf.String(), family+"{") {
+			t.Errorf("an empty snapshot invented a series for %s", family)
+		}
+	}
+}
+
+// TestARefusedWriteSurfacesRatherThanBeingRenderedPast — an io.Writer can
+// fail, and a scrape that swallowed the failure would serve a truncated
+// exposition that parses as a smaller fleet.
+func TestARefusedWriteSurfacesRatherThanBeingRenderedPast(t *testing.T) {
+	refused := errors.New("connection reset")
+	snap := jobs.Snapshot{
+		Rows:   []jobs.StateRow{{Queue: "default", Kind: "k", State: "available", Count: 1}},
+		Sweeps: []jobs.SweepPass{{Kind: "s", Workspaces: 1}},
+	}
+
+	// Fail at each write in turn, so no single family's writes are the only
+	// ones checked. The count is deliberately larger than the exposition is
+	// long; once the writer stops failing the render succeeds and the loop
+	// has covered every position.
+	var everSucceeded bool
+	for n := range 64 {
+		w := &failingWriter{failOn: n, err: refused}
+		err := writeJobMetrics(w, snap)
+		if err == nil {
+			everSucceeded = true
+			continue
+		}
+		if !errors.Is(err, refused) {
+			t.Fatalf("write %d: the renderer lost the cause: %v", n, err)
+		}
+	}
+	if !everSucceeded {
+		t.Fatal("the failing-writer sweep never reached a successful render; the test is " +
+			"not actually exercising the boundary it claims to")
+	}
+}
+
+// failingWriter refuses the failOn'th write and accepts every other.
+type failingWriter struct {
+	writes int
+	failOn int
+	err    error
+}
+
+func (w *failingWriter) Write(p []byte) (int, error) {
+	defer func() { w.writes++ }()
+	if w.writes == w.failOn {
+		return 0, w.err
+	}
+	return len(p), nil
+}

--- a/backend/internal/compose/jobmetrics_test.go
+++ b/backend/internal/compose/jobmetrics_test.go
@@ -21,7 +21,7 @@ func TestJobMetricsNameTheWorkspaceThatOwnsTheWorkAndLeaveItEmptyForADispatcher(
 	var buf bytes.Buffer
 	if err := writeJobMetrics(&buf, jobs.Snapshot{Rows: []jobs.StateRow{
 		{Queue: "default", Kind: "tenant_pass", WorkspaceID: ws, State: "available", Count: 2},
-		{Queue: "default", Kind: "the_dispatcher", WorkspaceID: "", State: "available", Count: 1},
+		{Queue: "default", Kind: "the_dispatcher", Untenanted: true, State: "available", Count: 1},
 	}}); err != nil {
 		t.Fatalf("writeJobMetrics: %v", err)
 	}
@@ -45,11 +45,11 @@ func TestJobMetricsNameTheWorkspaceThatOwnsTheWorkAndLeaveItEmptyForADispatcher(
 func TestQueueDepthSumsEveryStateAJobCanBeWaitingIn(t *testing.T) {
 	var buf bytes.Buffer
 	if err := writeJobMetrics(&buf, jobs.Snapshot{Rows: []jobs.StateRow{
-		{Queue: "default", Kind: "k", State: "available", Count: 1},
-		{Queue: "default", Kind: "k", State: "scheduled", Count: 2},
-		{Queue: "default", Kind: "k", State: "retryable", Count: 4},
-		{Queue: "default", Kind: "k", State: "pending", Count: 16},
-		{Queue: "default", Kind: "k", State: "running", Count: 8},
+		{Queue: "default", Kind: "k", Untenanted: true, State: "available", Count: 1},
+		{Queue: "default", Kind: "k", Untenanted: true, State: "scheduled", Count: 2},
+		{Queue: "default", Kind: "k", Untenanted: true, State: "retryable", Count: 4},
+		{Queue: "default", Kind: "k", Untenanted: true, State: "pending", Count: 16},
+		{Queue: "default", Kind: "k", Untenanted: true, State: "running", Count: 8},
 	}}); err != nil {
 		t.Fatalf("writeJobMetrics: %v", err)
 	}
@@ -68,8 +68,8 @@ func TestQueueDepthSumsEveryStateAJobCanBeWaitingIn(t *testing.T) {
 func TestDiscardedAndCancelledAreReportedApartAndKeyedByKind(t *testing.T) {
 	var buf bytes.Buffer
 	if err := writeJobMetrics(&buf, jobs.Snapshot{Rows: []jobs.StateRow{
-		{Queue: "default", Kind: "retention", State: "discarded", Count: 3},
-		{Queue: "default", Kind: "retention", State: "cancelled", Count: 5},
+		{Queue: "default", Kind: "retention", Untenanted: true, State: "discarded", Count: 3},
+		{Queue: "default", Kind: "retention", Untenanted: true, State: "cancelled", Count: 5},
 	}}); err != nil {
 		t.Fatalf("writeJobMetrics: %v", err)
 	}
@@ -92,7 +92,7 @@ func TestDiscardedAndCancelledAreReportedApartAndKeyedByKind(t *testing.T) {
 func TestAStateTheRendererHasNeverHeardOfIsReportedRatherThanDropped(t *testing.T) {
 	var buf bytes.Buffer
 	if err := writeJobMetrics(&buf, jobs.Snapshot{Rows: []jobs.StateRow{
-		{Queue: "default", Kind: "k", State: "hibernating", Count: 7},
+		{Queue: "default", Kind: "k", Untenanted: true, State: "hibernating", Count: 7},
 	}}); err != nil {
 		t.Fatalf("writeJobMetrics: %v", err)
 	}
@@ -107,8 +107,8 @@ func TestAStateTheRendererHasNeverHeardOfIsReportedRatherThanDropped(t *testing.
 func TestTheOldestQueuedAgeIsTheWorstCaseAcrossTheQueuesKinds(t *testing.T) {
 	var buf bytes.Buffer
 	if err := writeJobMetrics(&buf, jobs.Snapshot{Rows: []jobs.StateRow{
-		{Queue: "default", Kind: "slow", State: "available", Count: 1, OldestRunnableAgeSeconds: 900},
-		{Queue: "default", Kind: "fast", State: "available", Count: 1, OldestRunnableAgeSeconds: 5},
+		{Queue: "default", Kind: "slow", Untenanted: true, State: "available", Count: 1, OldestRunnableAgeSeconds: ptrTo(900.0)},
+		{Queue: "default", Kind: "fast", Untenanted: true, State: "available", Count: 1, OldestRunnableAgeSeconds: ptrTo(5.0)},
 	}}); err != nil {
 		t.Fatalf("writeJobMetrics: %v", err)
 	}
@@ -124,7 +124,7 @@ func TestTheOldestQueuedAgeIsTheWorstCaseAcrossTheQueuesKinds(t *testing.T) {
 func TestAQueueWhoseWorkIsAllFutureScheduledStillReportsAZeroAge(t *testing.T) {
 	var buf bytes.Buffer
 	if err := writeJobMetrics(&buf, jobs.Snapshot{Rows: []jobs.StateRow{
-		{Queue: "nightly", Kind: "k", State: "scheduled", Count: 4, OldestRunnableAgeSeconds: 0},
+		{Queue: "nightly", Kind: "k", Untenanted: true, State: "scheduled", Count: 4, OldestRunnableAgeSeconds: ptrTo(0.0)},
 	}}); err != nil {
 		t.Fatalf("writeJobMetrics: %v", err)
 	}
@@ -159,9 +159,9 @@ func TestTheSweepPairIsRenderedPerFanOutKind(t *testing.T) {
 func TestEverySeriesIsWrittenInAStableOrder(t *testing.T) {
 	snap := jobs.Snapshot{
 		Rows: []jobs.StateRow{
-			{Queue: "zeta", Kind: "k", State: "available", Count: 1},
-			{Queue: "alpha", Kind: "k", State: "available", Count: 1},
-			{Queue: "mid", Kind: "k", State: "available", Count: 1},
+			{Queue: "zeta", Kind: "k", Untenanted: true, State: "available", Count: 1},
+			{Queue: "alpha", Kind: "k", Untenanted: true, State: "available", Count: 1},
+			{Queue: "mid", Kind: "k", Untenanted: true, State: "available", Count: 1},
 		},
 		Sweeps: []jobs.SweepPass{
 			{Kind: "zeta_sweep", Workspaces: 1},
@@ -226,7 +226,7 @@ func TestAnEmptySnapshotWritesEveryFamilyHeaderAndNoSeries(t *testing.T) {
 func TestARefusedWriteSurfacesRatherThanBeingRenderedPast(t *testing.T) {
 	refused := errors.New("connection reset")
 	snap := jobs.Snapshot{
-		Rows:   []jobs.StateRow{{Queue: "default", Kind: "k", State: "available", Count: 1}},
+		Rows:   []jobs.StateRow{{Queue: "default", Kind: "k", Untenanted: true, State: "available", Count: 1}},
 		Sweeps: []jobs.SweepPass{{Kind: "s", Workspaces: 1}},
 	}
 
@@ -274,8 +274,8 @@ func (w *failingWriter) Write(p []byte) (int, error) {
 func TestAQueueHoldingOnlyDeadWorkReportsNoAgeAtAll(t *testing.T) {
 	var buf bytes.Buffer
 	if err := writeJobMetrics(&buf, jobs.Snapshot{Rows: []jobs.StateRow{
-		{Queue: "graveyard", Kind: "k", State: "discarded", Count: 50},
-		{Queue: "graveyard", Kind: "k", State: "cancelled", Count: 2},
+		{Queue: "graveyard", Kind: "k", Untenanted: true, State: "discarded", Count: 50},
+		{Queue: "graveyard", Kind: "k", Untenanted: true, State: "cancelled", Count: 2},
 	}}); err != nil {
 		t.Fatalf("writeJobMetrics: %v", err)
 	}
@@ -309,8 +309,8 @@ func TestALabelValueCannotBreakTheWholeExposition(t *testing.T) {
 				"\ngot:\n%s", forbidden, got)
 		}
 	}
-	if !strings.Contains(got, `workspace_id="abc"`) {
-		t.Errorf("control characters were not dropped from the label\ngot:\n%s", got)
+	if !strings.Contains(got, `workspace_id="a<0x09>b<0x00>c"`) {
+		t.Errorf("control characters were not rewritten to a printable form\ngot:\n%s", got)
 	}
 	for _, want := range []string{`queue="qu\"ote"`, `kind="back\\slash"`, `workspace_id="x\ny"`} {
 		if !strings.Contains(got, want) {
@@ -349,7 +349,7 @@ func TestTheJobSectionWritesNothingWhenTheReadFails(t *testing.T) {
 func TestAQueueHoldingOnlyRunningWorkReportsNoAgeEither(t *testing.T) {
 	var buf bytes.Buffer
 	if err := writeJobMetrics(&buf, jobs.Snapshot{Rows: []jobs.StateRow{
-		{Queue: "busy", Kind: "k", State: "running", Count: 4},
+		{Queue: "busy", Kind: "k", Untenanted: true, State: "running", Count: 4},
 	}}); err != nil {
 		t.Fatalf("writeJobMetrics: %v", err)
 	}
@@ -358,5 +358,82 @@ func TestAQueueHoldingOnlyRunningWorkReportsNoAgeEither(t *testing.T) {
 	}
 	if !strings.Contains(buf.String(), `margince_job_running{queue="busy",workspace_id=""} 4`) {
 		t.Errorf("the running work itself went missing\ngot:\n%s", buf.String())
+	}
+}
+
+func ptrTo[T any](v T) *T { return &v }
+
+// TestAQueueOfFutureScheduledWorkReportsNoAgeSeries — the group holds
+// waiting work, but none of it is RUNNABLE yet, so the read answers null
+// and the gauge must stay silent. A zero would claim the oldest runnable
+// job has waited no time, about a job that does not exist — and the
+// endpoint reports null for exactly this row, so a zero here would also put
+// the two surfaces at odds.
+func TestAQueueOfFutureScheduledWorkReportsNoAgeSeries(t *testing.T) {
+	var buf bytes.Buffer
+	if err := writeJobMetrics(&buf, jobs.Snapshot{Rows: []jobs.StateRow{
+		{
+			Queue: "nightly", Kind: "k", Untenanted: true, State: "scheduled", Count: 4,
+			OldestRunnableAgeSeconds: nil,
+		},
+	}}); err != nil {
+		t.Fatalf("writeJobMetrics: %v", err)
+	}
+	if strings.Contains(buf.String(), `margince_job_oldest_queued_age_seconds{queue="nightly"`) {
+		t.Errorf("a queue whose work is all future-scheduled reported an age\ngot:\n%s", buf.String())
+	}
+	if !strings.Contains(buf.String(), `margince_job_queue_depth{queue="nightly",workspace_id=""} 4`) {
+		t.Errorf("the queued work itself went missing\ngot:\n%s", buf.String())
+	}
+}
+
+// TestAPresentButEmptyWorkspaceIsNotCountedAsADispatcher — the empty label
+// means "dispatcher", exactly and in both directions, and that invariant is
+// what every reader of these gauges stands on. river_job has no constraint
+// forcing the key to be absent rather than empty, so a malformed row must
+// be visible AS malformed instead of silently joining the dispatcher series.
+func TestAPresentButEmptyWorkspaceIsNotCountedAsADispatcher(t *testing.T) {
+	var buf bytes.Buffer
+	if err := writeJobMetrics(&buf, jobs.Snapshot{Rows: []jobs.StateRow{
+		{Queue: "default", Kind: "k", Untenanted: true, State: "available", Count: 1},
+		// Present but empty: NOT untenanted, and not a real workspace either.
+		{Queue: "default", Kind: "k", WorkspaceID: "", Untenanted: false, State: "available", Count: 9},
+	}}); err != nil {
+		t.Fatalf("writeJobMetrics: %v", err)
+	}
+	if !strings.Contains(buf.String(), `margince_job_queue_depth{queue="default",workspace_id=""} 1`) {
+		t.Errorf("the real dispatcher row was disturbed\ngot:\n%s", buf.String())
+	}
+	if strings.Contains(buf.String(), `margince_job_queue_depth{queue="default",workspace_id=""} 10`) {
+		t.Error("a malformed row was folded into the dispatcher series, which is the one " +
+			"invariant these gauges promise")
+	}
+	if !strings.Contains(buf.String(), `margince_job_queue_depth{queue="default",workspace_id="<malformed>"} 9`) {
+		t.Errorf("the malformed row is invisible rather than flagged\ngot:\n%s", buf.String())
+	}
+}
+
+// TestTwoLabelsDifferingOnlyByAControlCharacterStayDistinct — dropping a
+// control character is lossy, and lossy collapses two distinct malformed
+// ids into one label set. Duplicate series make a scrape unparseable, which
+// is the exact failure the escaping exists to prevent.
+func TestTwoLabelsDifferingOnlyByAControlCharacterStayDistinct(t *testing.T) {
+	var buf bytes.Buffer
+	if err := writeJobMetrics(&buf, jobs.Snapshot{Rows: []jobs.StateRow{
+		{Queue: "q", Kind: "k", WorkspaceID: "ab", State: "available", Count: 1},
+		{Queue: "q", Kind: "k", WorkspaceID: "a\tb", State: "available", Count: 2},
+	}}); err != nil {
+		t.Fatalf("writeJobMetrics: %v", err)
+	}
+	got := buf.String()
+	if strings.Contains(got, `\t`) {
+		t.Errorf("an escape the text format does not define reached the wire\ngot:\n%s", got)
+	}
+	if !strings.Contains(got, `workspace_id="ab"} 1`) {
+		t.Errorf("the clean label was rewritten\ngot:\n%s", got)
+	}
+	if !strings.Contains(got, `workspace_id="a<0x09>b"} 2`) {
+		t.Errorf("the control character was dropped, collapsing two distinct ids into one "+
+			"series\ngot:\n%s", got)
 	}
 }

--- a/backend/internal/compose/jobmetrics_test.go
+++ b/backend/internal/compose/jobmetrics_test.go
@@ -5,6 +5,7 @@ package compose
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"strings"
 	"testing"
@@ -264,4 +265,77 @@ func (w *failingWriter) Write(p []byte) (int, error) {
 		return 0, w.err
 	}
 	return len(p), nil
+}
+
+// TestAQueueHoldingOnlyDeadWorkReportsNoAgeAtAll — the gauge answers "how
+// long has the oldest RUNNABLE job waited", and a queue whose rows are all
+// discarded has no such job. A zero there would read as a healthy queue on
+// the one gauge meant to notice work is stuck.
+func TestAQueueHoldingOnlyDeadWorkReportsNoAgeAtAll(t *testing.T) {
+	var buf bytes.Buffer
+	if err := writeJobMetrics(&buf, jobs.Snapshot{Rows: []jobs.StateRow{
+		{Queue: "graveyard", Kind: "k", State: "discarded", Count: 50},
+		{Queue: "graveyard", Kind: "k", State: "cancelled", Count: 2},
+	}}); err != nil {
+		t.Fatalf("writeJobMetrics: %v", err)
+	}
+	if strings.Contains(buf.String(), `margince_job_oldest_queued_age_seconds{queue="graveyard"`) {
+		t.Errorf("a queue with nothing runnable reported an age\ngot:\n%s", buf.String())
+	}
+	if !strings.Contains(buf.String(), `margince_job_discarded{kind="k",workspace_id=""} 50`) {
+		t.Errorf("the dead work itself went missing\ngot:\n%s", buf.String())
+	}
+}
+
+// TestALabelValueCannotBreakTheWholeExposition — workspace_id is
+// args->>'workspace_id' verbatim from a table with no constraint on it and
+// direct app-role CRUD. Go's %q would encode a tab as \t, which the
+// Prometheus text format does not define, and a parser meeting an undefined
+// escape rejects the ENTIRE scrape — every metric, not the one series.
+func TestALabelValueCannotBreakTheWholeExposition(t *testing.T) {
+	var buf bytes.Buffer
+	if err := writeJobMetrics(&buf, jobs.Snapshot{Rows: []jobs.StateRow{
+		{Queue: "default", Kind: "k", WorkspaceID: "a\tb\x00c", State: "available", Count: 1},
+		{Queue: `qu"ote`, Kind: "k", WorkspaceID: "x\ny", State: "available", Count: 1},
+		{Queue: "default", Kind: `back\slash`, WorkspaceID: "", State: "discarded", Count: 1},
+	}}); err != nil {
+		t.Fatalf("writeJobMetrics: %v", err)
+	}
+	got := buf.String()
+
+	for _, forbidden := range []string{`\t`, `\x00`, `\u`} {
+		if strings.Contains(got, forbidden) {
+			t.Errorf("the exposition carries %s, an escape the text format does not define"+
+				"\ngot:\n%s", forbidden, got)
+		}
+	}
+	if !strings.Contains(got, `workspace_id="abc"`) {
+		t.Errorf("control characters were not dropped from the label\ngot:\n%s", got)
+	}
+	for _, want := range []string{`queue="qu\"ote"`, `kind="back\\slash"`, `workspace_id="x\ny"`} {
+		if !strings.Contains(got, want) {
+			t.Errorf("exposition missing %q — the three defined escapes must still be emitted"+
+				"\ngot:\n%s", want, got)
+		}
+	}
+}
+
+// TestTheJobSectionWritesNothingWhenTheReadFails — a scrape that emitted
+// zeroes it did not measure is worse than a gap: a gap is visible on a
+// graph, and a fabricated zero reads as a healthy empty queue. This is the
+// posture Metrics already takes for the outbox backlog, and it is the seam
+// between the pool and the renderer that nothing else covers.
+func TestTheJobSectionWritesNothingWhenTheReadFails(t *testing.T) {
+	unreadable := func(context.Context) (jobs.Snapshot, error) {
+		return jobs.Snapshot{}, errors.New("the job table could not be read in time")
+	}
+	var buf bytes.Buffer
+
+	if err := jobMetricsSection(unreadable)(context.Background(), &buf); err != nil {
+		t.Fatalf("an unreadable section must not fail the whole scrape: %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("an unmeasured section wrote %d bytes; a fabricated zero is "+
+			"indistinguishable from a healthy empty queue\ngot:\n%s", buf.Len(), buf.String())
+	}
 }

--- a/backend/internal/compose/jobmetrics_test.go
+++ b/backend/internal/compose/jobmetrics_test.go
@@ -421,3 +421,36 @@ func TestTwoLabelsDifferingOnlyByAControlCharacterStayDistinct(t *testing.T) {
 			"series\ngot:\n%s", got)
 	}
 }
+
+// TestALiteralEscapeSequenceDoesNotCollideWithTheCharacterItEncodes is the
+// direct test for the '<' branch, and the collision that branch exists to
+// close. Escape only control bytes and the two values below both render as
+// `<0x09>`: one row whose id contains the six literal characters, and one
+// whose id contains a real tab. Two distinct ids, one label set, and
+// Prometheus rejects the whole scrape — the third time this same failure
+// appeared in this change, so it gets an assertion of its own rather than
+// being implied by the control-character test next door.
+func TestALiteralEscapeSequenceDoesNotCollideWithTheCharacterItEncodes(t *testing.T) {
+	var buf bytes.Buffer
+	if err := writeJobMetrics(&buf, jobs.Snapshot{Rows: []jobs.StateRow{
+		{Queue: "q", Kind: "k", WorkspaceID: "<0x09>", State: "available", Count: 1},
+		{Queue: "q", Kind: "k", WorkspaceID: "\t", State: "available", Count: 2},
+	}}); err != nil {
+		t.Fatalf("writeJobMetrics: %v", err)
+	}
+	got := buf.String()
+
+	// The literal '<' is itself escaped, so the six-character id cannot
+	// render as the encoding of a tab.
+	if !strings.Contains(got, `workspace_id="<0x3c>0x09>"} 1`) {
+		t.Errorf("the literal escape sequence was not itself escaped\ngot:\n%s", got)
+	}
+	if !strings.Contains(got, `workspace_id="<0x09>"} 2`) {
+		t.Errorf("the real tab did not render as its escape\ngot:\n%s", got)
+	}
+	// The load-bearing assertion: two distinct ids, two distinct series.
+	if strings.Count(got, `margince_job_queue_depth{queue="q"`) != 2 {
+		t.Errorf("two distinct workspace ids collapsed into one series; a duplicate label "+
+			"set makes Prometheus reject the entire scrape\ngot:\n%s", got)
+	}
+}

--- a/backend/internal/compose/jobs_capture.go
+++ b/backend/internal/compose/jobs_capture.go
@@ -69,9 +69,9 @@ func (w *gmailSyncWorker) Work(ctx context.Context, _ *river.Job[GmailSyncArgs])
 				Workspace:    d.Workspace.UUID,
 				ConnectionID: d.ID.String(),
 				Provider:     desc.Name,
-			}, &river.InsertOpts{
+			}, markedAsFleetPass(&river.InsertOpts{
 				UniqueOpts: river.UniqueOpts{ByArgs: true, ByState: activeSweepStates},
-			}); err != nil {
+			})); err != nil {
 				// A refused enqueue means this connection is never synced, so
 				// it fails the DISPATCHER — the same posture as the watch
 				// dispatcher below, which this one is the mirror of.
@@ -163,10 +163,10 @@ func (w *gmailWatchWorker) Work(ctx context.Context, _ *river.Job[GmailWatchArgs
 		if _, err := client.Insert(ctx, GmailWatchRenewArgs{
 			Workspace:    d.Workspace.UUID,
 			ConnectionID: d.ID.String(),
-		}, &river.InsertOpts{
+		}, markedAsFleetPass(&river.InsertOpts{
 			MaxAttempts: sweepWorkspaceMaxAttempts,
 			UniqueOpts:  river.UniqueOpts{ByArgs: true, ByState: activeSweepStates},
-		}); err != nil {
+		})); err != nil {
 			// A refused enqueue means this connection's watch is never renewed,
 			// so it fails the DISPATCHER rather than being logged past.
 			enumErr = errors.Join(enumErr, fmt.Errorf("enqueueing the watch renewal for connection %s: %w", d.ID, err))

--- a/backend/internal/compose/jobs_overlay.go
+++ b/backend/internal/compose/jobs_overlay.go
@@ -82,7 +82,7 @@ func (w *overlayReconcileWorker) Work(ctx context.Context, _ *river.Job[OverlayR
 	client := river.ClientFromContext[pgx.Tx](ctx)
 	for _, d := range due {
 		if _, err := client.Insert(ctx, OverlayReconcileWorkspaceArgs{Workspace: d.Workspace.UUID},
-			workspaceSweepOpts(overlayReconcileQueue, overlaySweepMaxAttempts)); err != nil {
+			markedAsFleetPass(workspaceSweepOpts(overlayReconcileQueue, overlaySweepMaxAttempts))); err != nil {
 			// A refused enqueue means this workspace gets no sweep at all, so
 			// it fails the DISPATCHER rather than being logged past: a green
 			// tick over a tenant nobody swept is the shape this phase removes.

--- a/backend/internal/compose/routes.go
+++ b/backend/internal/compose/routes.go
@@ -101,6 +101,7 @@ func operationalMux(srv Server, pool *pgxpool.Pool, log *slog.Logger, identitySv
 		func(ctx context.Context) (int64, error) { return events.OutboxBacklog(ctx, pool) },
 		events.PublishedTotal,
 		srv.writeAIMetrics,
+		jobMetricsSection(pool),
 		overlayMetricsSection(srv, pool)))
 	// The anonymous public edges sit between the session middleware (which
 	// lets /v1/public/ through without session or workspace) and the

--- a/backend/internal/compose/routes.go
+++ b/backend/internal/compose/routes.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/events"
 	"github.com/gradionhq/margince/backend/internal/platform/httpserver"
+	"github.com/gradionhq/margince/backend/internal/platform/jobs"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -101,7 +102,7 @@ func operationalMux(srv Server, pool *pgxpool.Pool, log *slog.Logger, identitySv
 		func(ctx context.Context) (int64, error) { return events.OutboxBacklog(ctx, pool) },
 		events.PublishedTotal,
 		srv.writeAIMetrics,
-		jobMetricsSection(pool),
+		jobMetricsSection(func(ctx context.Context) (jobs.Snapshot, error) { return jobs.Stats(ctx, pool) }),
 		overlayMetricsSection(srv, pool)))
 	// The anonymous public edges sit between the session middleware (which
 	// lets /v1/public/ through without session or workspace) and the

--- a/backend/internal/compose/server.go
+++ b/backend/internal/compose/server.go
@@ -91,6 +91,7 @@ type Server struct {
 	rateRefreshHandlers
 	webhooksHandlers
 	dataResetHandlers
+	jobHealthHandlers
 	org360Handlers
 	orgBriefHandlers
 
@@ -306,6 +307,9 @@ func newServer(pool *pgxpool.Pool, log *slog.Logger, authH authHandlers, dealsH 
 			WithUnsubscribe(preferenceLinkAdapter{store: consent.NewStore(pool)}),
 		approvalsHandlers: approvalsHandlersWithEffects(pool),
 		searchHandlers:    search.NewHandlers(pool),
+		// Constructed, not merely embedded: the zero value's nil pool would
+		// 404 every authenticated read of a live endpoint.
+		jobHealthHandlers: jobHealthHandlers{pool: pool},
 		// DSR fulfillment executes privacy's erase path — injected here so
 		// consent never imports its sibling.
 		consentHandlers:     consent.NewHandlers(pool).WithEraser(privacy.NewEraser(pool)),

--- a/backend/internal/compose/server.go
+++ b/backend/internal/compose/server.go
@@ -307,8 +307,9 @@ func newServer(pool *pgxpool.Pool, log *slog.Logger, authH authHandlers, dealsH 
 			WithUnsubscribe(preferenceLinkAdapter{store: consent.NewStore(pool)}),
 		approvalsHandlers: approvalsHandlersWithEffects(pool),
 		searchHandlers:    search.NewHandlers(pool),
-		// Constructed, not merely embedded: the zero value's nil pool would
-		// 404 every authenticated read of a live endpoint.
+		// Constructed, not merely embedded: the handler carries no nil-pool
+		// branch, so the zero value would panic on the first authenticated
+		// read rather than answer anything at all.
 		jobHealthHandlers: jobHealthHandlers{pool: pool},
 		// DSR fulfillment executes privacy's erase path — injected here so
 		// consent never imports its sibling.

--- a/backend/internal/compose/stubs_gen.go
+++ b/backend/internal/compose/stubs_gen.go
@@ -59,6 +59,10 @@ func (stubs) SendMessage(w nethttp.ResponseWriter, r *nethttp.Request, id crmcon
 	httperr.NotImplemented(w, r, "SendMessage")
 }
 
+func (stubs) GetJobHealth(w nethttp.ResponseWriter, r *nethttp.Request) {
+	httperr.NotImplemented(w, r, "GetJobHealth")
+}
+
 func (stubs) ResetData(w nethttp.ResponseWriter, r *nethttp.Request) {
 	httperr.NotImplemented(w, r, "ResetData")
 }

--- a/backend/internal/compose/telegrampoll.go
+++ b/backend/internal/compose/telegrampoll.go
@@ -151,11 +151,14 @@ func (w *telegramPollSweepWorker) Work(ctx context.Context, _ *river.Job[Telegra
 	client := river.ClientFromContext[pgx.Tx](ctx)
 	due, enumErr := capture.DueChannelConnections(ctx, w.pool, capture.ProviderTelegram)
 	for _, d := range due {
-		// No InsertOpts here: TelegramPollArgs declares its own, so an inserter
-		// cannot forget the per-bot uniqueness by omission.
+		// The opts carry the sweep tag and NOTHING else: TelegramPollArgs
+		// declares its own uniqueness, and River falls back to the args'
+		// InsertOpts for every field the explicit value leaves at its zero —
+		// so a tag-only value still cannot forget the per-bot rule by
+		// omission, which is what passing nil here bought.
 		if _, err := client.Insert(ctx, TelegramPollArgs{
 			Workspace: d.WorkspaceID, ConnectionID: d.ID.String(),
-		}, nil); err != nil {
+		}, markedAsFleetPass(nil)); err != nil {
 			w.log.WarnContext(ctx, "telegram poll enqueue failed", "connection", d.ID.String(), "err", err)
 		}
 	}

--- a/backend/internal/compose/telegrampoll.go
+++ b/backend/internal/compose/telegrampoll.go
@@ -153,9 +153,11 @@ func (w *telegramPollSweepWorker) Work(ctx context.Context, _ *river.Job[Telegra
 	for _, d := range due {
 		// The opts carry the sweep tag and NOTHING else: TelegramPollArgs
 		// declares its own uniqueness, and River falls back to the args'
-		// InsertOpts for every field the explicit value leaves at its zero —
-		// so a tag-only value still cannot forget the per-bot rule by
-		// omission, which is what passing nil here bought.
+		// InsertOpts for the scheduling and uniqueness fields an explicit
+		// value leaves unset — so a tag-only value still cannot forget the
+		// per-bot rule by omission, which is what passing nil here bought.
+		// The fallback is per-field, not universal: metadata, for one, is
+		// defaulted rather than inherited.
 		if _, err := client.Insert(ctx, TelegramPollArgs{
 			Workspace: d.WorkspaceID, ConnectionID: d.ID.String(),
 		}, markedAsFleetPass(nil)); err != nil {

--- a/backend/internal/compose/voicebuild.go
+++ b/backend/internal/compose/voicebuild.go
@@ -361,7 +361,11 @@ func (w *voiceBuildRetryWorker) Work(ctx context.Context, _ *river.Job[VoiceBuil
 			ProfileID:   ref.ProfileID.String(),
 			BuildID:     ref.BuildID.String(),
 			RequestedBy: ref.RequestedBy.String(),
-		}, voiceBuildInsertOpts()); err != nil {
+			// Tagged HERE rather than inside voiceBuildInsertOpts, which the
+			// user-initiated build path shares: a build someone asked for is
+			// not one workspace's share of a fleet pass, and counting it as
+			// one is precisely what the tag exists to prevent.
+		}, markedAsFleetPass(voiceBuildInsertOpts())); err != nil {
 			w.log.WarnContext(ctx, "voice build retry enqueue failed", "build", ref.BuildID.String(), "err", err)
 		}
 	}

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -3219,6 +3219,27 @@ func (e IssuePassportRequestScopes) Valid() bool {
 	}
 }
 
+// Defines values for JobFailureState.
+const (
+	Cancelled JobFailureState = "cancelled"
+	Discarded JobFailureState = "discarded"
+	Retryable JobFailureState = "retryable"
+)
+
+// Valid indicates whether the value is a known member of the JobFailureState enum.
+func (e JobFailureState) Valid() bool {
+	switch e {
+	case Cancelled:
+		return true
+	case Discarded:
+		return true
+	case Retryable:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for LeadStatus.
 const (
 	LeadStatusDisqualified LeadStatus = "disqualified"
@@ -10008,6 +10029,59 @@ type IssuePassportResponse struct {
 
 	// Token The bearer token — shown ONCE, stored only as a hash.
 	Token string `json:"token"`
+}
+
+// JobFailure defines model for JobFailure.
+type JobFailure struct {
+	Attempt     int       `json:"attempt"`
+	FailedAt    time.Time `json:"failed_at"`
+	Kind        string    `json:"kind"`
+	MaxAttempts int       `json:"max_attempts"`
+
+	// Reason The job layer's vetted operator sentence. A failure whose stored text did not come from that closed vocabulary reports a fixed substitute instead — the raw cause never travels here.
+	Reason string          `json:"reason"`
+	State  JobFailureState `json:"state"`
+
+	// WorkspaceId Null for a dispatcher.
+	WorkspaceId *openapi_types.UUID `json:"workspace_id,omitempty"`
+}
+
+// JobFailureState defines model for JobFailure.State.
+type JobFailureState string
+
+// JobHealth defines model for JobHealth.
+type JobHealth struct {
+	GeneratedAt time.Time       `json:"generated_at"`
+	Kinds       []JobKindHealth `json:"kinds"`
+
+	// RecentFailures Most recent first, capped at 50. A bounded list, not a log.
+	RecentFailures []JobFailure `json:"recent_failures"`
+
+	// WorkspaceId The workspace these counts are scoped to — the caller's own.
+	WorkspaceId openapi_types.UUID `json:"workspace_id"`
+}
+
+// JobKindHealth defines model for JobKindHealth.
+type JobKindHealth struct {
+	// Dead Discarded or cancelled: this work will not happen without intervention. A discarded job spent every attempt; a cancelled one was stopped deliberately.
+	Dead int `json:"dead"`
+
+	// FleetWide True for a dispatcher — a job that fans work out and does no tenant work of its own. Its rows carry no workspace.
+	FleetWide bool `json:"fleet_wide"`
+
+	// Kind The stable job identifier River persists in river_job.kind.
+	Kind string `json:"kind"`
+
+	// OldestWaitingAgeSeconds How long the oldest runnable-and-unclaimed job of this kind has waited. Null when nothing of this kind is runnable now; a job scheduled for the future is not late.
+	OldestWaitingAgeSeconds *int   `json:"oldest_waiting_age_seconds,omitempty"`
+	Queue                   string `json:"queue"`
+
+	// Retrying Failed at least once and backing off toward another attempt.
+	Retrying int `json:"retrying"`
+	Running  int `json:"running"`
+
+	// Waiting Available, scheduled or pending: queued and not yet started.
+	Waiting int `json:"waiting"`
 }
 
 // Lead A thin, segregated prospect. Mirrors the `lead` table. NO organization FK.
@@ -22619,6 +22693,9 @@ type ServerInterface interface {
 	// Reply on a captured messaging-channel conversation — 🟡 confirm-first / gated.
 	// (POST /activities/{id}/send-message)
 	SendMessage(w http.ResponseWriter, r *http.Request, id Id, params SendMessageParams)
+	// What the background system is holding, and whose work failed.
+	// (GET /admin/job-health)
+	GetJobHealth(w http.ResponseWriter, r *http.Request)
 	// Reset a non-production installation to its first-boot state.
 	// (POST /admin/reset-data)
 	ResetData(w http.ResponseWriter, r *http.Request)
@@ -23540,6 +23617,12 @@ func (_ Unimplemented) SendEmail(w http.ResponseWriter, r *http.Request, id Id, 
 // Reply on a captured messaging-channel conversation — 🟡 confirm-first / gated.
 // (POST /activities/{id}/send-message)
 func (_ Unimplemented) SendMessage(w http.ResponseWriter, r *http.Request, id Id, params SendMessageParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// What the background system is holding, and whose work failed.
+// (GET /admin/job-health)
+func (_ Unimplemented) GetJobHealth(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -25856,6 +25939,26 @@ func (siw *ServerInterfaceWrapper) SendMessage(w http.ResponseWriter, r *http.Re
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.SendMessage(w, r, id, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetJobHealth operation middleware
+func (siw *ServerInterfaceWrapper) GetJobHealth(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetJobHealth(w, r)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -39372,6 +39475,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/activities/{id}/send-message", wrapper.SendMessage)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/admin/job-health", wrapper.GetJobHealth)
 	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/admin/reset-data", wrapper.ResetData)

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -10043,7 +10043,7 @@ type JobFailure struct {
 	State  JobFailureState `json:"state"`
 
 	// WorkspaceId Null for a dispatcher.
-	WorkspaceId *openapi_types.UUID `json:"workspace_id,omitempty"`
+	WorkspaceId *openapi_types.UUID `json:"workspace_id"`
 }
 
 // JobFailureState defines model for JobFailure.State.
@@ -10073,7 +10073,7 @@ type JobKindHealth struct {
 	Kind string `json:"kind"`
 
 	// OldestWaitingAgeSeconds How long the oldest runnable-and-unclaimed job of this kind has waited. Null when nothing of this kind is runnable now; a job scheduled for the future is not late.
-	OldestWaitingAgeSeconds *int   `json:"oldest_waiting_age_seconds,omitempty"`
+	OldestWaitingAgeSeconds *int   `json:"oldest_waiting_age_seconds"`
 	Queue                   string `json:"queue"`
 
 	// Retrying Failed at least once and backing off toward another attempt.

--- a/backend/internal/platform/httpserver/observe.go
+++ b/backend/internal/platform/httpserver/observe.go
@@ -235,10 +235,13 @@ type OverlayMetrics struct {
 // jobStats renders the job-runtime section. Unlike extra it takes a
 // context, because it queries at scrape time, and it is handed THIS
 // handler's deadline-bound ctx rather than the request's — an unbounded
-// job read is the one thing the 2s budget below exists to stop. A section
-// that returns an error has already decided the exposition cannot continue
-// safely; the handler stops writing and logs rather than serving a
-// truncated body as if it were whole.
+// job read is the one thing the 2s budget below exists to stop.
+//
+// A section that could not MEASURE writes nothing and returns nil, so the
+// rest of the exposition still serves; the error return is reserved for a
+// refused WRITE, which in practice means the scraper's connection is
+// already gone. The handler logs it and stops rather than writing further
+// sections into a socket that is not there.
 //
 // The parameter list has reached the point where a further section should
 // become a struct rather than a seventh argument.

--- a/backend/internal/platform/httpserver/observe.go
+++ b/backend/internal/platform/httpserver/observe.go
@@ -231,7 +231,18 @@ type OverlayMetrics struct {
 // router's call metrics) directly after the pool gauges; nil means the
 // role wired none. overlay is injected the same way (nil for a role with
 // no overlay surface wired).
-func Metrics(pool *pgxpool.Pool, backlog func(context.Context) (int64, error), published func() uint64, extra func(io.Writer), overlay *OverlayMetrics) http.HandlerFunc {
+//
+// jobStats renders the job-runtime section. Unlike extra it takes a
+// context, because it queries at scrape time, and it is handed THIS
+// handler's deadline-bound ctx rather than the request's — an unbounded
+// job read is the one thing the 2s budget below exists to stop. A section
+// that returns an error has already decided the exposition cannot continue
+// safely; the handler stops writing and logs rather than serving a
+// truncated body as if it were whole.
+//
+// The parameter list has reached the point where a further section should
+// become a struct rather than a seventh argument.
+func Metrics(pool *pgxpool.Pool, backlog func(context.Context) (int64, error), published func() uint64, extra func(io.Writer), jobStats func(context.Context, io.Writer) error, overlay *OverlayMetrics) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
 		defer cancel()
@@ -249,16 +260,28 @@ func Metrics(pool *pgxpool.Pool, backlog func(context.Context) (int64, error), p
 		_, _ = fmt.Fprintf(w, "# TYPE margince_relay_published_total counter\n")
 		_, _ = fmt.Fprintf(w, "margince_relay_published_total %d\n", published())
 
-		stat := pool.Stat()
-		_, _ = fmt.Fprintf(w, "# HELP margince_pgxpool_conns Connection pool state by class.\n")
-		_, _ = fmt.Fprintf(w, "# TYPE margince_pgxpool_conns gauge\n")
-		_, _ = fmt.Fprintf(w, "margince_pgxpool_conns{state=\"acquired\"} %d\n", stat.AcquiredConns())
-		_, _ = fmt.Fprintf(w, "margince_pgxpool_conns{state=\"idle\"} %d\n", stat.IdleConns())
-		_, _ = fmt.Fprintf(w, "margince_pgxpool_conns{state=\"total\"} %d\n", stat.TotalConns())
-		_, _ = fmt.Fprintf(w, "margince_pgxpool_conns{state=\"max\"} %d\n", stat.MaxConns())
+		// Omitted rather than zeroed when no pool was injected — the same
+		// "declared or absent" posture every other section here takes, and
+		// the reason a failed backlog read above writes nothing: a gauge
+		// reporting connections it did not measure reads as an idle pool.
+		if pool != nil {
+			stat := pool.Stat()
+			_, _ = fmt.Fprintf(w, "# HELP margince_pgxpool_conns Connection pool state by class.\n")
+			_, _ = fmt.Fprintf(w, "# TYPE margince_pgxpool_conns gauge\n")
+			_, _ = fmt.Fprintf(w, "margince_pgxpool_conns{state=\"acquired\"} %d\n", stat.AcquiredConns())
+			_, _ = fmt.Fprintf(w, "margince_pgxpool_conns{state=\"idle\"} %d\n", stat.IdleConns())
+			_, _ = fmt.Fprintf(w, "margince_pgxpool_conns{state=\"total\"} %d\n", stat.TotalConns())
+			_, _ = fmt.Fprintf(w, "margince_pgxpool_conns{state=\"max\"} %d\n", stat.MaxConns())
+		}
 
 		if extra != nil {
 			extra(w)
+		}
+		if jobStats != nil {
+			if err := jobStats(ctx, w); err != nil {
+				slog.ErrorContext(r.Context(), "metrics: writing the job section failed", "err", err)
+				return
+			}
 		}
 		if overlay != nil {
 			writeOverlayMetrics(r.Context(), w, overlay)

--- a/backend/internal/platform/httpserver/observe_test.go
+++ b/backend/internal/platform/httpserver/observe_test.go
@@ -286,7 +286,17 @@ func TestMetricsHandsTheJobSectionItsOwnDeadlineNotTheRequests(t *testing.T) {
 // exposition parses as a smaller fleet rather than as a broken one, so a
 // refused write ends the body instead of being rendered past.
 func TestMetricsStopsWritingWhenTheJobSectionRefusesAWrite(t *testing.T) {
-	jobStats := func(context.Context, io.Writer) error { return errors.New("connection reset") }
+	// A writer that actually REFUSES, passed through the callback exactly as
+	// the real section receives it. Returning a synthetic error without
+	// touching w would exercise the handler's branch while proving nothing
+	// about the truncated-scrape path this test is named for.
+	refused := errors.New("connection reset")
+	jobStats := func(_ context.Context, w io.Writer) error {
+		if _, err := w.Write([]byte("margince_job_queue_depth{queue=\"q\",workspace_id=\"\"} 1\n")); err != nil {
+			return err
+		}
+		return refused
+	}
 	overlayReached := false
 
 	rec := httptest.NewRecorder()

--- a/backend/internal/platform/httpserver/observe_test.go
+++ b/backend/internal/platform/httpserver/observe_test.go
@@ -256,3 +256,89 @@ func TestChassisWrappersPreserveResponseControllerCapabilities(t *testing.T) {
 		})
 	}
 }
+
+// TestMetricsHandsTheJobSectionItsOwnDeadlineNotTheRequests — the job read
+// queries a table no index covers, so it is the one section that has to
+// stay inside the handler's budget. The overlay section next door is wired
+// with r.Context() and runs unbounded; a reader who pattern-matched that
+// neighbour would inherit the unbounded query, so the difference is pinned
+// here rather than left to a comment.
+func TestMetricsHandsTheJobSectionItsOwnDeadlineNotTheRequests(t *testing.T) {
+	var deadlineSet bool
+	jobStats := func(ctx context.Context, _ io.Writer) error {
+		_, deadlineSet = ctx.Deadline()
+		return nil
+	}
+
+	rec := httptest.NewRecorder()
+	// A request context with NO deadline of its own, so a deadline seen by
+	// the section can only have come from the handler.
+	Metrics(nil, unreadableBacklog, zeroPublished, nil, jobStats, nil)(
+		rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+
+	if !deadlineSet {
+		t.Error("the job section ran without a deadline; an unbounded scan can hold the " +
+			"scrape open for as long as the query takes")
+	}
+}
+
+// TestMetricsStopsWritingWhenTheJobSectionRefusesAWrite — a truncated
+// exposition parses as a smaller fleet rather than as a broken one, so a
+// refused write ends the body instead of being rendered past.
+func TestMetricsStopsWritingWhenTheJobSectionRefusesAWrite(t *testing.T) {
+	jobStats := func(context.Context, io.Writer) error { return errors.New("connection reset") }
+	overlayReached := false
+
+	rec := httptest.NewRecorder()
+	Metrics(nil, unreadableBacklog, zeroPublished, nil, jobStats, &OverlayMetrics{
+		SourceLag: func(context.Context) (map[string]time.Duration, error) {
+			overlayReached = true
+			return nil, errors.New("unreached")
+		},
+		SyncedTotal:   func() uint64 { return 0 },
+		ConflictTotal: func() uint64 { return 0 },
+		DeletedTotal:  func() uint64 { return 0 },
+	})(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+
+	if overlayReached {
+		t.Error("the handler kept writing after the job section reported the writer was gone")
+	}
+}
+
+// TestMetricsWithNoJobSectionWiredStillServesTheRest — a process role that
+// wires no job read (the same posture nil extra and nil overlay take) must
+// still serve the families it does have.
+func TestMetricsWithNoJobSectionWiredStillServesTheRest(t *testing.T) {
+	rec := httptest.NewRecorder()
+	Metrics(nil, func(context.Context) (int64, error) { return 7, nil },
+		func() uint64 { return 3 }, nil, nil, nil)(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+
+	if !strings.Contains(rec.Body.String(), "margince_outbox_unpublished 7") {
+		t.Errorf("a nil job section suppressed the rest of the exposition:\n%s", rec.Body.String())
+	}
+}
+
+// unreadableBacklog stands in for the outbox read on a pool that cannot be
+// reached, which is the honest state of idlePool.
+func unreadableBacklog(context.Context) (int64, error) {
+	return 0, errors.New("the outbox is not readable in a wiring test")
+}
+
+func zeroPublished() uint64 { return 0 }
+
+// TestMetricsOmitsThePoolGaugesWhenNoPoolIsInjected — every other section
+// here is "declared or absent"; the pool gauges were the one that panicked
+// instead. An unmeasured pool must be missing from the scrape, never
+// reported as an idle one.
+func TestMetricsOmitsThePoolGaugesWhenNoPoolIsInjected(t *testing.T) {
+	rec := httptest.NewRecorder()
+	Metrics(nil, unreadableBacklog, zeroPublished, nil, nil, nil)(
+		rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+
+	if strings.Contains(rec.Body.String(), "margince_pgxpool_conns") {
+		t.Errorf("the pool gauges were rendered without a pool to measure:\n%s", rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "margince_relay_published_total") {
+		t.Errorf("an absent pool suppressed the sections that did not need it:\n%s", rec.Body.String())
+	}
+}

--- a/backend/internal/platform/jobs/fault.go
+++ b/backend/internal/platform/jobs/fault.go
@@ -59,6 +59,35 @@ func FaultContext(ctx context.Context, err error) error {
 	return &fault{sentence: unrecognised, cause: err}
 }
 
+// VettedSentence reports whether s is a sentence Fault itself would have
+// written — one of the vocabulary's, or the unclassified fallback.
+//
+// It exists because river_job.errors is fleet-visible with no RLS and no
+// redaction path (see Fault), so a surface that shows a failure to a human
+// asks this rather than trusting the column. A worker that bypassed Fault
+// and returned its raw cause stored that cause here; the answer for it is
+// false, and the reader substitutes its own fixed text. River writes into
+// that column too — its rescuer's "Stuck job rescued by JobRescuer" is not
+// a Fault sentence and is correctly refused.
+//
+// The comparison is EXACT, never a prefix or a contains: a worker whose raw
+// cause merely embeds a vetted sentence would otherwise carry the rest of
+// its text through on the strength of the part that matched.
+//
+// The vocabulary stays unexported: a caller asks whether one string is
+// vetted, it does not get the list to render or to match against by hand.
+func VettedSentence(s string) bool {
+	if s == unrecognised {
+		return true
+	}
+	for _, known := range vocabulary {
+		if s == known.sentence {
+			return true
+		}
+	}
+	return false
+}
+
 // unrecognised is what an unclassified cause becomes on the wire. It says
 // where the diagnosis went, because an operator reading it in a job list
 // otherwise has no next step.

--- a/backend/internal/platform/jobs/fault_test.go
+++ b/backend/internal/platform/jobs/fault_test.go
@@ -82,3 +82,60 @@ func TestFaultPrefersTheControlReturnOverASentinelUnderneath(t *testing.T) {
 		t.Fatal("a cancel carrying a known sentinel must stay a cancel — River stops the job rather than spending a rung on it")
 	}
 }
+
+// TestVettedSentenceAdmitsOnlyWhatFaultItselfWouldHaveWritten is the whole
+// safety argument for serving river_job.errors to a human: the column is
+// fleet-visible with no RLS and no redaction path, so a reader must never
+// pass its content through on trust. A worker that returned a bare provider
+// error — naming an address it refused — stored that text here.
+func TestVettedSentenceAdmitsOnlyWhatFaultItselfWouldHaveWritten(t *testing.T) {
+	for _, known := range vocabulary {
+		if !VettedSentence(known.sentence) {
+			t.Errorf("VettedSentence(%q) = false, want true", known.sentence)
+		}
+	}
+	if !VettedSentence(unrecognised) {
+		t.Error("the unclassified sentence is written by Fault and must be admitted")
+	}
+
+	for _, raw := range []string{
+		"",
+		"dial tcp 10.0.0.4:5432: connect: connection refused",
+		`smtp: 550 5.1.1 <someone@example.com>: recipient rejected`,
+		// River's rescuer writes this itself when a worker's process died
+		// mid-job. It is not a Fault sentence and must not be served as one.
+		"Stuck job rescued by JobRescuer",
+		// A near-miss: the vocabulary's sentence with trailing whitespace.
+		// The match is exact, so a worker whose own text merely resembles a
+		// vetted one does not slip through.
+		"the record this job names no longer exists ",
+		"THE RECORD THIS JOB NAMES NO LONGER EXISTS",
+		// A concatenation that CONTAINS a vetted sentence. A substring match
+		// here would let a worker prefix its raw cause onto a known sentence
+		// and carry the lot to the wire.
+		"connecting to 10.0.0.4: the record this job names no longer exists",
+	} {
+		if VettedSentence(raw) {
+			t.Errorf("VettedSentence(%q) = true: raw worker text reached a reader", raw)
+		}
+	}
+}
+
+// TestEverySentenceFaultCanWriteIsVetted derives the obligation from the
+// vocabulary rather than restating it: Fault has exactly two sources of
+// output text, and a sentence added to one of them without the reader
+// learning about it would be substituted away as if a worker had leaked it.
+func TestEverySentenceFaultCanWriteIsVetted(t *testing.T) {
+	for _, known := range vocabulary {
+		stored := Fault(fmt.Errorf("a raw cause: %w", known.sentinel)).Error()
+		if !VettedSentence(stored) {
+			t.Errorf("Fault wrote %q for %v, and the reader would not admit it",
+				stored, known.sentinel)
+		}
+	}
+	unclassified := Fault(errors.New("a cause no sentinel covers")).Error()
+	if !VettedSentence(unclassified) {
+		t.Errorf("Fault wrote %q for an unclassified cause, and the reader would not admit it",
+			unclassified)
+	}
+}

--- a/backend/internal/platform/jobs/health.go
+++ b/backend/internal/platform/jobs/health.go
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package jobs
+
+// The scoped read behind GET /admin/job-health. It lives beside Stats
+// rather than in the composition layer because river_job has no RLS and no
+// workspace column: every statement over it is a hand-imposed scope, and
+// two readers spelling that scope in two packages is how the operational
+// and the admin surface drift into different answers about the same table.
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// waitingStates are queued-and-not-yet-started. pending is River's staged
+// state; it is counted here for the same reason the metric counts it —
+// work nobody has done is waiting, whatever River calls the state.
+const waitingStates = `('available','scheduled','pending')`
+
+// healthScope is the row filter this read imposes for itself.
+//
+// river_job has no workspace_id COLUMN, so it has no RLS and no row-scope
+// clause can be inherited from platform/auth. An admin of one workspace
+// reading another's failures would be a cross-tenant read that nothing
+// authorized — the singleton organization is a boot-time admission policy,
+// not permission to stop scoping.
+//
+// The untenanted arm is CLOSED against the caller's declared dispatcher
+// kinds rather than admitting every null. A dispatcher does no tenant work
+// and its health is what an admin needs — a dispatcher that is not running
+// means no workspace is being swept at all — but "the workspace key is
+// null" is a property held by source-shape tests, not by a database
+// constraint, and this table has no RLS while the app role holds direct
+// CRUD on it. A malformed or externally inserted tenant row would otherwise
+// land in a global arm and carry its kind, counts and failure class to
+// every workspace's admin. An unrecognised untenanted row is omitted
+// instead.
+//
+// $1 is bound as TEXT: ->> yields text, and binding a uuid-typed value
+// gives pgx the uuid OID and Postgres "operator does not exist: text =
+// uuid".
+const healthScope = `(
+	args->>'workspace_id' = $1
+	OR (args->>'workspace_id' IS NULL AND kind = ANY($2))
+)`
+
+// KindHealth is one kind's live state under the caller's scope.
+type KindHealth struct {
+	Kind      string
+	Queue     string
+	FleetWide bool
+	Waiting   int64
+	Running   int64
+	Retrying  int64
+	// Dead is discarded plus cancelled: work that will not happen without
+	// intervention. The two are reported together here because the question
+	// the field answers is "will this run" and the answer is no either way;
+	// the exposition endpoint keeps them apart, where the question is why.
+	Dead int64
+	// OldestWaitingAgeSeconds is nil when nothing of this kind is runnable
+	// right now. Nil and zero are different claims — nothing waiting versus
+	// something that just became runnable — so the absence is carried
+	// rather than flattened.
+	OldestWaitingAgeSeconds *float64
+}
+
+// Failure is one recent failed or failing job.
+type Failure struct {
+	Kind string
+	// WorkspaceID is nil for a dispatcher.
+	WorkspaceID *string
+	State       string
+	Attempt     int
+	MaxAttempts int
+	FailedAt    time.Time
+	// StoredReason is river_job.errors' text VERBATIM, and the caller must
+	// not put it on a wire without vetting it: the column holds whatever a
+	// worker returned, and a worker that bypassed Fault stored a raw cause
+	// that routinely names the address or record a provider refused. Ask
+	// VettedSentence.
+	StoredReason string
+}
+
+// Health is one scoped read of the job table for one workspace's admin.
+type Health struct {
+	Kinds    []KindHealth
+	Failures []Failure
+}
+
+// recentFailureLimit bounds the failure list. It is a bounded view, not a
+// log: an admin needs to see what is failing now, and an unbounded list
+// over a table River retains for days is a different product.
+const recentFailureLimit = 50
+
+// WorkspaceHealth reads the job table for ONE workspace's admin: that
+// workspace's own rows plus the untenanted rows of the named dispatcher
+// kinds, and nothing else.
+//
+// dispatcherKinds is passed in rather than derived here because which
+// kinds are fleet-wide is a fact about the composition layer's job
+// catalog, and platform owns no domain.
+func WorkspaceHealth(ctx context.Context, pool *pgxpool.Pool, workspaceID string, dispatcherKinds []string) (Health, error) {
+	kinds, err := healthByKind(ctx, pool, workspaceID, dispatcherKinds)
+	if err != nil {
+		return Health{}, err
+	}
+	failures, err := recentFailures(ctx, pool, workspaceID, dispatcherKinds)
+	if err != nil {
+		return Health{}, err
+	}
+	return Health{Kinds: kinds, Failures: failures}, nil
+}
+
+// healthByKind groups the caller's live rows by kind and queue.
+//
+// It groups by whether the workspace key is null as well, so a kind that
+// somehow holds BOTH tenant and untenanted rows appears twice rather than
+// being silently attributed to one side. That would be the workspace
+// invariant breaking, and this endpoint should be the thing that shows it.
+func healthByKind(ctx context.Context, pool *pgxpool.Pool, workspaceID string, dispatcherKinds []string) ([]KindHealth, error) {
+	const q = `
+		SELECT kind,
+		       queue,
+		       (args->>'workspace_id' IS NULL) AS fleet_wide,
+		       count(*) FILTER (WHERE state::text IN ` + waitingStates + `)::bigint,
+		       count(*) FILTER (WHERE state::text = 'running')::bigint,
+		       count(*) FILTER (WHERE state::text = 'retryable')::bigint,
+		       count(*) FILTER (WHERE state::text IN ` + terminalBadStates + `)::bigint,
+		       max(EXTRACT(EPOCH FROM (now() - scheduled_at)))
+		           FILTER (WHERE state::text IN ` + runnableStates + `
+		                     AND scheduled_at <= now())::double precision
+		FROM river_job
+		WHERE state <> 'completed' AND ` + healthScope + `
+		GROUP BY 1, 2, 3
+		ORDER BY 1, 2, 3`
+
+	rows, err := pool.Query(ctx, q, workspaceID, dispatcherKinds)
+	if err != nil {
+		return nil, fmt.Errorf("jobs: reading job health by kind: %w", err)
+	}
+	defer rows.Close()
+
+	var out []KindHealth
+	for rows.Next() {
+		var k KindHealth
+		if err := rows.Scan(&k.Kind, &k.Queue, &k.FleetWide,
+			&k.Waiting, &k.Running, &k.Retrying, &k.Dead,
+			&k.OldestWaitingAgeSeconds); err != nil {
+			return nil, fmt.Errorf("jobs: scanning job health by kind: %w", err)
+		}
+		out = append(out, k)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("jobs: reading job health by kind: %w", err)
+	}
+	return out, nil
+}
+
+// recentFailures reads the most recent failed-or-failing rows under the
+// caller's scope.
+//
+// River stores AttemptError{At, Attempt, Error, Trace} per element of a
+// jsonb[]. Only the MESSAGE is selected, never the element: Trace carries a
+// full panic stack, and serializing the object whole would carry it past
+// the vetting the caller applies to the message alone. The index is
+// 1-based and the newest attempt is last, so cardinality() is the newest —
+// and it is null-safe in both directions, because errors is a nullable
+// column and River's cancel path appends nothing at all, so a cancelled row
+// can be terminal with no attempt error to read.
+//
+// The order is finalized_at when the row is finalized and created_at when
+// it is not, with id breaking ties — a total order over columns that always
+// exist. The attempt error's own timestamp is deliberately NOT cast in SQL:
+// that column is app-written, and one malformed value would turn the whole
+// endpoint into a 500 rather than one row into an approximation.
+func recentFailures(ctx context.Context, pool *pgxpool.Pool, workspaceID string, dispatcherKinds []string) ([]Failure, error) {
+	q := `
+		SELECT kind,
+		       args->>'workspace_id',
+		       state::text,
+		       attempt::int,
+		       max_attempts::int,
+		       coalesce(finalized_at, created_at),
+		       errors[cardinality(errors)]->>'at',
+		       errors[cardinality(errors)]->>'error'
+		FROM river_job
+		WHERE state::text IN ('retryable','discarded','cancelled')
+		  AND ` + healthScope + `
+		ORDER BY coalesce(finalized_at, created_at) DESC, id DESC
+		LIMIT ` + fmt.Sprint(recentFailureLimit)
+
+	rows, err := pool.Query(ctx, q, workspaceID, dispatcherKinds)
+	if err != nil {
+		return nil, fmt.Errorf("jobs: reading recent job failures: %w", err)
+	}
+	defer rows.Close()
+
+	var out []Failure
+	for rows.Next() {
+		var (
+			f          Failure
+			fallbackAt time.Time
+			attemptAt  *string
+			stored     *string
+		)
+		if err := rows.Scan(&f.Kind, &f.WorkspaceID, &f.State, &f.Attempt,
+			&f.MaxAttempts, &fallbackAt, &attemptAt, &stored); err != nil {
+			return nil, fmt.Errorf("jobs: scanning recent job failures: %w", err)
+		}
+		f.FailedAt = fallbackAt
+		if attemptAt != nil {
+			if at, err := time.Parse(time.RFC3339Nano, *attemptAt); err == nil {
+				f.FailedAt = at
+			}
+		}
+		if stored != nil {
+			f.StoredReason = *stored
+		}
+		out = append(out, f)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("jobs: reading recent job failures: %w", err)
+	}
+	return out, nil
+}

--- a/backend/internal/platform/jobs/health.go
+++ b/backend/internal/platform/jobs/health.go
@@ -170,8 +170,10 @@ func healthByKind(ctx context.Context, pool *pgxpool.Pool, workspaceID string, d
 // the vetting the caller applies to the message alone. The index is
 // 1-based and the newest attempt is last, so cardinality() is the newest —
 // and it is null-safe in both directions, because errors is a nullable
-// column and River's cancel path appends nothing at all, so a cancelled row
-// can be terminal with no attempt error to read.
+// column and a cancelled row MAY carry no attempt error at all. River's
+// cancel path is two paths, not one: a worker returning JobCancel(err)
+// persists an AttemptError like any other failure, while a cancellation
+// with no cause appends nothing, and the row is terminal either way.
 //
 // The order is finalized_at when the row is finalized and created_at when
 // it is not, with id breaking ties — a total order over columns that always

--- a/backend/internal/platform/jobs/health.go
+++ b/backend/internal/platform/jobs/health.go
@@ -12,6 +12,7 @@ package jobs
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -214,10 +215,14 @@ func recentFailures(ctx context.Context, pool *pgxpool.Pool, workspaceID string,
 			&f.MaxAttempts, &fallbackAt, &attemptAt, &stored); err != nil {
 			return nil, fmt.Errorf("jobs: scanning recent job failures: %w", err)
 		}
-		f.FailedAt = fallbackAt
+		// UTC on both branches. pgx returns a timestamptz in the session's
+		// zone while the attempt error's own timestamp is RFC 3339 in UTC,
+		// so mixing them unresolved puts two offsets in one array — both
+		// valid, and needlessly hostile to whoever reads the list.
+		f.FailedAt = fallbackAt.UTC()
 		if attemptAt != nil {
 			if at, err := time.Parse(time.RFC3339Nano, *attemptAt); err == nil {
-				f.FailedAt = at
+				f.FailedAt = at.UTC()
 			}
 		}
 		if stored != nil {
@@ -228,5 +233,14 @@ func recentFailures(ctx context.Context, pool *pgxpool.Pool, workspaceID string,
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("jobs: reading recent job failures: %w", err)
 	}
+
+	// SELECTED by coalesce(finalized_at, created_at) — a total order over
+	// columns that always exist, which is what makes the LIMIT pick the
+	// genuinely most recent rows — but PRESENTED in the order of the
+	// failed_at actually shown. Those two can disagree, because the
+	// displayed value prefers the attempt error's own timestamp, and a list
+	// whose visible field does not descend reads as a bug even when the
+	// selection was right.
+	slices.SortStableFunc(out, func(a, b Failure) int { return b.FailedAt.Compare(a.FailedAt) })
 	return out, nil
 }

--- a/backend/internal/platform/jobs/health.go
+++ b/backend/internal/platform/jobs/health.go
@@ -176,13 +176,17 @@ func healthByKind(ctx context.Context, pool *pgxpool.Pool, workspaceID string, d
 // persists an AttemptError like any other failure, while a cancellation
 // with no cause appends nothing, and the row is terminal either way.
 //
-// The order is finalized_at when the row is finalized, attempted_at when it
-// is not, and created_at when it has never run — with id breaking ties, a
-// total order over columns that always exist. attempted_at is the rung that
-// matters for a RETRYABLE row: it is when the last attempt started, so a
-// job created weeks ago and failing now sorts as the recent event it is,
-// rather than by the creation date it happens to carry. The attempt error's
-// own timestamp is deliberately NOT cast in SQL:
+// failed_at is read from COLUMNS, not from the attempt error's own
+// timestamp: River sets AttemptError.At to the attempt's START (job_executor
+// sets `At: e.start`), so a long-running job that failed after an hour would
+// report the hour-ago moment it began and sort ahead of failures that
+// actually happened later. finalized_at is the real failure moment for a
+// terminal row, attempted_at is the closest available for a retryable one,
+// and created_at covers a row that has never run — a total order over
+// columns that always exist, with id breaking ties.
+//
+// Reading a column rather than the stored JSON also avoids casting
+// app-written text in SQL:
 // that column is app-written, and one malformed value would turn the whole
 // endpoint into a 500 rather than one row into an approximation.
 func recentFailures(ctx context.Context, pool *pgxpool.Pool, workspaceID string, dispatcherKinds []string) ([]Failure, error) {
@@ -193,7 +197,6 @@ func recentFailures(ctx context.Context, pool *pgxpool.Pool, workspaceID string,
 		       attempt::int,
 		       max_attempts::int,
 		       coalesce(finalized_at, attempted_at, created_at),
-		       errors[cardinality(errors)]->>'at',
 		       errors[cardinality(errors)]->>'error'
 		FROM river_job
 		WHERE state::text IN ('retryable','discarded','cancelled')
@@ -212,23 +215,16 @@ func recentFailures(ctx context.Context, pool *pgxpool.Pool, workspaceID string,
 		var (
 			f          Failure
 			fallbackAt time.Time
-			attemptAt  *string
 			stored     *string
 		)
 		if err := rows.Scan(&f.Kind, &f.WorkspaceID, &f.State, &f.Attempt,
-			&f.MaxAttempts, &fallbackAt, &attemptAt, &stored); err != nil {
+			&f.MaxAttempts, &fallbackAt, &stored); err != nil {
 			return nil, fmt.Errorf("jobs: scanning recent job failures: %w", err)
 		}
-		// UTC on both branches. pgx returns a timestamptz in the session's
-		// zone while the attempt error's own timestamp is RFC 3339 in UTC,
-		// so mixing them unresolved puts two offsets in one array — both
-		// valid, and needlessly hostile to whoever reads the list.
+		// UTC because pgx returns a timestamptz in the session's zone, and
+		// two offsets inside one array is needlessly hostile to whoever
+		// reads the list.
 		f.FailedAt = fallbackAt.UTC()
-		if attemptAt != nil {
-			if at, err := time.Parse(time.RFC3339Nano, *attemptAt); err == nil {
-				f.FailedAt = at.UTC()
-			}
-		}
 		if stored != nil {
 			f.StoredReason = *stored
 		}
@@ -238,13 +234,10 @@ func recentFailures(ctx context.Context, pool *pgxpool.Pool, workspaceID string,
 		return nil, fmt.Errorf("jobs: reading recent job failures: %w", err)
 	}
 
-	// SELECTED by coalesce(finalized_at, attempted_at, created_at) — a total order over
-	// columns that always exist, which is what makes the LIMIT pick the
-	// genuinely most recent rows — but PRESENTED in the order of the
-	// failed_at actually shown. Those two can disagree, because the
-	// displayed value prefers the attempt error's own timestamp, and a list
-	// whose visible field does not descend reads as a bug even when the
-	// selection was right.
+	// Sorted on the same expression the SELECT ordered by, so the visible
+	// failed_at descends exactly as the field name promises. The database
+	// already returns them in this order; re-sorting keeps that true if the
+	// two ever drift apart.
 	slices.SortStableFunc(out, func(a, b Failure) int { return b.FailedAt.Compare(a.FailedAt) })
 	return out, nil
 }

--- a/backend/internal/platform/jobs/health.go
+++ b/backend/internal/platform/jobs/health.go
@@ -176,9 +176,13 @@ func healthByKind(ctx context.Context, pool *pgxpool.Pool, workspaceID string, d
 // persists an AttemptError like any other failure, while a cancellation
 // with no cause appends nothing, and the row is terminal either way.
 //
-// The order is finalized_at when the row is finalized and created_at when
-// it is not, with id breaking ties — a total order over columns that always
-// exist. The attempt error's own timestamp is deliberately NOT cast in SQL:
+// The order is finalized_at when the row is finalized, attempted_at when it
+// is not, and created_at when it has never run — with id breaking ties, a
+// total order over columns that always exist. attempted_at is the rung that
+// matters for a RETRYABLE row: it is when the last attempt started, so a
+// job created weeks ago and failing now sorts as the recent event it is,
+// rather than by the creation date it happens to carry. The attempt error's
+// own timestamp is deliberately NOT cast in SQL:
 // that column is app-written, and one malformed value would turn the whole
 // endpoint into a 500 rather than one row into an approximation.
 func recentFailures(ctx context.Context, pool *pgxpool.Pool, workspaceID string, dispatcherKinds []string) ([]Failure, error) {
@@ -188,13 +192,13 @@ func recentFailures(ctx context.Context, pool *pgxpool.Pool, workspaceID string,
 		       state::text,
 		       attempt::int,
 		       max_attempts::int,
-		       coalesce(finalized_at, created_at),
+		       coalesce(finalized_at, attempted_at, created_at),
 		       errors[cardinality(errors)]->>'at',
 		       errors[cardinality(errors)]->>'error'
 		FROM river_job
 		WHERE state::text IN ('retryable','discarded','cancelled')
 		  AND ` + healthScope + `
-		ORDER BY coalesce(finalized_at, created_at) DESC, id DESC
+		ORDER BY coalesce(finalized_at, attempted_at, created_at) DESC, id DESC
 		LIMIT ` + fmt.Sprint(recentFailureLimit)
 
 	rows, err := pool.Query(ctx, q, workspaceID, dispatcherKinds)
@@ -234,7 +238,7 @@ func recentFailures(ctx context.Context, pool *pgxpool.Pool, workspaceID string,
 		return nil, fmt.Errorf("jobs: reading recent job failures: %w", err)
 	}
 
-	// SELECTED by coalesce(finalized_at, created_at) — a total order over
+	// SELECTED by coalesce(finalized_at, attempted_at, created_at) — a total order over
 	// columns that always exist, which is what makes the LIMIT pick the
 	// genuinely most recent rows — but PRESENTED in the order of the
 	// failed_at actually shown. Those two can disagree, because the

--- a/backend/internal/platform/jobs/stats.go
+++ b/backend/internal/platform/jobs/stats.go
@@ -26,8 +26,9 @@ import (
 // today.
 const SweepTag = "sweep"
 
-// sweepTagPredicate is the tag test, spelled once. River stores tags as a
-// text array, so membership is the array operator rather than a join.
+// sweepTagPredicate is the tag test, spelled once. River stores tags in a
+// varchar(255)[] column, so membership is the array operator rather than a
+// join.
 const sweepTagPredicate = `'` + SweepTag + `' = ANY(tags)`
 
 // runnableStates are the states a row can be worked FROM right now. The

--- a/backend/internal/platform/jobs/stats.go
+++ b/backend/internal/platform/jobs/stats.go
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package jobs
+
+// Reading the job table, rather than working it. Every SQL statement over
+// river_job that serves a reader lives here, so the operational and the
+// admin surface cannot drift into separate state, error and scoping
+// vocabularies over one table that has no RLS to hold them together.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// SweepTag marks a job row as one workspace's share of a fleet pass. Every
+// site that fans work out to the fleet stamps it; a workspace job enqueued
+// by a user action carries no tag and is correctly not counted as a fleet
+// pass.
+//
+// Nothing enforces that a new fan-out remembers the tag — an untagged one
+// is simply absent from the sweep gauges. Deriving that obligation needs a
+// static notion of "this insert is a fan-out" the tree does not support
+// today.
+const SweepTag = "sweep"
+
+// sweepTagPredicate is the tag test, spelled once. River stores tags as a
+// text array, so membership is the array operator rather than a join.
+const sweepTagPredicate = `'` + SweepTag + `' = ANY(tags)`
+
+// runnableStates are the states a row can be worked FROM right now. The
+// scheduled_at <= now() test that always accompanies this is what makes
+// including 'scheduled' correct rather than misleading: a scheduled row
+// whose time has passed IS runnable and unclaimed, and excluding it would
+// let a stopped scheduler read as a perfectly healthy queue on the one
+// gauge whose job is to catch exactly that. A row scheduled for the future
+// fails the time test and contributes nothing, so no age is ever measured
+// backwards.
+const runnableStates = `('available','retryable','scheduled')`
+
+// terminalBadStates are the states a workspace's pass can end in having
+// done nothing. cancelled counts: a cancelled pass did not run, whatever
+// the reason, and the sweep pair answers "are tenants being missed".
+const terminalBadStates = `('discarded','cancelled')`
+
+// StateRow is one (queue, kind, workspace, state) group of the job table as
+// it stands right now. WorkspaceID is the empty string for a dispatcher —
+// which is exact rather than a default, because a job that does tenant work
+// declares its workspace and a null in that column means a dispatcher and
+// nothing else (see role.go).
+type StateRow struct {
+	Queue       string
+	Kind        string
+	WorkspaceID string
+	State       string
+	Count       int64
+	// OldestRunnableAgeSeconds is how long the oldest job in this group has
+	// been ELIGIBLE and unclaimed. A scheduled job whose time has not come
+	// is not stuck, so it contributes nothing; counting it would report a
+	// nightly sweep as 23 hours overdue every day of its life.
+	OldestRunnableAgeSeconds float64
+}
+
+// SweepPass is one fan-out kind read per workspace: how many workspaces it
+// covers, and how many of those it is currently failing.
+type SweepPass struct {
+	Kind       string
+	Workspaces int64
+	Failed     int64
+}
+
+// Snapshot is one read of the job table, for a reader that renders it.
+type Snapshot struct {
+	Rows   []StateRow
+	Sweeps []SweepPass
+}
+
+// Stats reads the live job table for the metric surface.
+//
+// TWO statements, not one. They read different populations — the runtime
+// gauges must exclude completed rows (a finished job is history, not depth)
+// while the sweep pair must include them (a pass whose workspaces all
+// succeeded is the healthy case, and it is completed rows that say so).
+// Folding them together needs a UNION with a discriminator and two nullable
+// halves; two legible grouped scans inside one budget is the better trade.
+//
+// A caller that could not complete the read gets the error, never a partial
+// or empty Snapshot: an unmeasured fleet renders identically to an idle one,
+// and telling those apart is the whole point of the surface.
+func Stats(ctx context.Context, pool *pgxpool.Pool) (Snapshot, error) {
+	rows, err := statsByState(ctx, pool)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	sweeps, err := statsBySweep(ctx, pool)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	return Snapshot{Rows: rows, Sweeps: sweeps}, nil
+}
+
+func statsByState(ctx context.Context, pool *pgxpool.Pool) ([]StateRow, error) {
+	// The age is EXTRACTed from the database's own now(), never subtracted
+	// from the app clock: the two clocks differ by enough to move an exact
+	// assertion, which is a live intermittent flake elsewhere in this tree.
+	const q = `
+		SELECT queue,
+		       kind,
+		       coalesce(args->>'workspace_id', '') AS workspace_id,
+		       state::text,
+		       count(*)::bigint,
+		       coalesce(
+		           max(EXTRACT(EPOCH FROM (now() - scheduled_at)))
+		               FILTER (WHERE state::text IN ` + runnableStates + `
+		                         AND scheduled_at <= now()),
+		           0)::double precision
+		FROM river_job
+		WHERE state <> 'completed'
+		GROUP BY 1, 2, 3, 4`
+
+	cursor, err := pool.Query(ctx, q)
+	if err != nil {
+		return nil, fmt.Errorf("jobs: reading job state counts: %w", err)
+	}
+	defer cursor.Close()
+
+	var out []StateRow
+	for cursor.Next() {
+		var r StateRow
+		if err := cursor.Scan(&r.Queue, &r.Kind, &r.WorkspaceID, &r.State,
+			&r.Count, &r.OldestRunnableAgeSeconds); err != nil {
+			return nil, fmt.Errorf("jobs: scanning job state counts: %w", err)
+		}
+		out = append(out, r)
+	}
+	if err := cursor.Err(); err != nil {
+		return nil, fmt.Errorf("jobs: reading job state counts: %w", err)
+	}
+	return out, nil
+}
+
+// statsBySweep reports, per fleet-pass kind, how many workspaces it covers
+// and how many of those it is currently failing.
+//
+// It reads the LATEST OUTCOME PER WORKSPACE, never a batch. There is no
+// such thing as "the last pass" in this table: River resolves a uniqueness
+// conflict with ON CONFLICT DO UPDATE SET kind = EXCLUDED.kind, which
+// writes neither created_at nor metadata, so a child still active from the
+// previous pass is deduplicated and produces no row for the current one. A
+// dispatcher retried while 90 of 100 children are live inserts 10 fresh
+// rows — any batch-keyed reading, by timestamp or by a minted pass id,
+// would report that fleet as 10.
+//
+// Per-workspace-latest also answers the question the pair exists for — are
+// tenants being missed — more directly than a batch count did: a workspace
+// whose most recent pass of a kind is dead is a tenant being missed,
+// whether that happened this pass or three passes ago. And because it
+// counts DISTINCT workspaces, a dispatcher that fans out per connection
+// rather than per workspace still counts each workspace once, with no
+// special case.
+//
+// The sweep tag is what separates a fleet pass from a workspace job someone
+// triggered by hand. A dispatcher's own row carries no workspace and is
+// excluded: it is not one workspace's share of anything.
+func statsBySweep(ctx context.Context, pool *pgxpool.Pool) ([]SweepPass, error) {
+	const q = `
+		SELECT kind,
+		       count(*)::bigint,
+		       count(*) FILTER (WHERE state IN ` + terminalBadStates + `)::bigint
+		FROM (
+		    SELECT DISTINCT ON (kind, args->>'workspace_id')
+		           kind, state::text AS state
+		    FROM river_job
+		    WHERE ` + sweepTagPredicate + `
+		      AND args->>'workspace_id' IS NOT NULL
+		    ORDER BY kind, args->>'workspace_id', created_at DESC, id DESC
+		) latest
+		GROUP BY kind`
+
+	cursor, err := pool.Query(ctx, q)
+	if err != nil {
+		return nil, fmt.Errorf("jobs: reading sweep passes: %w", err)
+	}
+	defer cursor.Close()
+
+	var out []SweepPass
+	for cursor.Next() {
+		var s SweepPass
+		if err := cursor.Scan(&s.Kind, &s.Workspaces, &s.Failed); err != nil {
+			return nil, fmt.Errorf("jobs: scanning sweep passes: %w", err)
+		}
+		out = append(out, s)
+	}
+	if err := cursor.Err(); err != nil {
+		return nil, fmt.Errorf("jobs: reading sweep passes: %w", err)
+	}
+	return out, nil
+}

--- a/backend/internal/platform/jobs/stats.go
+++ b/backend/internal/platform/jobs/stats.go
@@ -181,7 +181,10 @@ func statsByState(ctx context.Context, pool *pgxpool.Pool) ([]StateRow, error) {
 //
 // The sweep tag is what separates a fleet pass from a workspace job someone
 // triggered by hand. A dispatcher's own row carries no workspace and is
-// excluded: it is not one workspace's share of anything.
+// excluded: it is not one workspace's share of anything. A row whose
+// workspace key is PRESENT but empty is excluded by the same test rather
+// than counted as a workspace of its own — it is malformed, and a phantom
+// tenant here would misreport how much of the fleet a pass actually covers.
 func statsBySweep(ctx context.Context, pool *pgxpool.Pool) ([]SweepPass, error) {
 	const q = `
 		SELECT kind,
@@ -192,7 +195,7 @@ func statsBySweep(ctx context.Context, pool *pgxpool.Pool) ([]SweepPass, error) 
 		           kind, state::text AS state
 		    FROM river_job
 		    WHERE ` + sweepTagPredicate + `
-		      AND args->>'workspace_id' IS NOT NULL
+		      AND coalesce(args->>'workspace_id', '') <> ''
 		    ORDER BY kind, args->>'workspace_id', created_at DESC, id DESC
 		) latest
 		GROUP BY kind`

--- a/backend/internal/platform/jobs/stats.go
+++ b/backend/internal/platform/jobs/stats.go
@@ -52,16 +52,28 @@ const terminalBadStates = `('discarded','cancelled')`
 // declares its workspace and a null in that column means a dispatcher and
 // nothing else (see role.go).
 type StateRow struct {
-	Queue       string
-	Kind        string
+	Queue string
+	Kind  string
+	// WorkspaceID is the value of the args key VERBATIM. It is the empty
+	// string only when the key is absent or JSON null — which is what
+	// Untenanted reports, and the two must not be conflated: a row carrying
+	// a present-but-EMPTY workspace_id is malformed, not a dispatcher, and
+	// a reader that could not tell them apart would count it as one.
 	WorkspaceID string
-	State       string
-	Count       int64
+	// Untenanted is true when the workspace key is absent or null — the
+	// exact test the scoped read's dispatcher arm uses, so the two surfaces
+	// cannot disagree about which rows are fleet-wide.
+	Untenanted bool
+	State      string
+	Count      int64
 	// OldestRunnableAgeSeconds is how long the oldest job in this group has
-	// been ELIGIBLE and unclaimed. A scheduled job whose time has not come
-	// is not stuck, so it contributes nothing; counting it would report a
-	// nightly sweep as 23 hours overdue every day of its life.
-	OldestRunnableAgeSeconds float64
+	// been ELIGIBLE and unclaimed, and is NIL when the group holds no such
+	// job. Nil and zero are different claims — nothing is runnable versus
+	// something became runnable a moment ago — and flattening them would
+	// report a queue of future-scheduled work as "the oldest runnable job
+	// has waited 0 seconds", which is a statement about a job that does not
+	// exist. The endpoint carries the same distinction.
+	OldestRunnableAgeSeconds *float64
 }
 
 // SweepPass is one fan-out kind read per workspace: how many workspaces it
@@ -106,20 +118,25 @@ func statsByState(ctx context.Context, pool *pgxpool.Pool) ([]StateRow, error) {
 	// The age is EXTRACTed from the database's own now(), never subtracted
 	// from the app clock: the two clocks differ by enough to move an exact
 	// assertion, which is a live intermittent flake elsewhere in this tree.
+	// The age has NO coalesce: a group with nothing runnable answers NULL,
+	// which the reader carries as "no such job" rather than as a measured
+	// zero. The workspace key is reported alongside a separate IS NULL
+	// test, because `->>` yields the empty string for a present-but-empty
+	// value as readily as coalesce does for an absent one — and those are a
+	// malformed row and a dispatcher respectively.
 	const q = `
 		SELECT queue,
 		       kind,
 		       coalesce(args->>'workspace_id', '') AS workspace_id,
+		       (args->>'workspace_id' IS NULL) AS untenanted,
 		       state::text,
 		       count(*)::bigint,
-		       coalesce(
-		           max(EXTRACT(EPOCH FROM (now() - scheduled_at)))
-		               FILTER (WHERE state::text IN ` + runnableStates + `
-		                         AND scheduled_at <= now()),
-		           0)::double precision
+		       max(EXTRACT(EPOCH FROM (now() - scheduled_at)))
+		           FILTER (WHERE state::text IN ` + runnableStates + `
+		                     AND scheduled_at <= now())::double precision
 		FROM river_job
 		WHERE state <> 'completed'
-		GROUP BY 1, 2, 3, 4`
+		GROUP BY 1, 2, 3, 4, 5`
 
 	cursor, err := pool.Query(ctx, q)
 	if err != nil {
@@ -130,8 +147,8 @@ func statsByState(ctx context.Context, pool *pgxpool.Pool) ([]StateRow, error) {
 	var out []StateRow
 	for cursor.Next() {
 		var r StateRow
-		if err := cursor.Scan(&r.Queue, &r.Kind, &r.WorkspaceID, &r.State,
-			&r.Count, &r.OldestRunnableAgeSeconds); err != nil {
+		if err := cursor.Scan(&r.Queue, &r.Kind, &r.WorkspaceID, &r.Untenanted,
+			&r.State, &r.Count, &r.OldestRunnableAgeSeconds); err != nil {
 			return nil, fmt.Errorf("jobs: scanning job state counts: %w", err)
 		}
 		out = append(out, r)

--- a/backend/internal/platform/jobs/stats_integration_test.go
+++ b/backend/internal/platform/jobs/stats_integration_test.go
@@ -193,7 +193,7 @@ func TestStatsMeasuresTheAgeOfRunnableWorkOnlyAndInTheDatabasesOwnClock(t *testi
 		t.Fatalf("Stats: %v", err)
 	}
 
-	var overdue, notYet float64
+	var overdue, notYet *float64
 	var sawNotYet bool
 	for _, r := range snap.Rows {
 		switch r.Kind {
@@ -203,16 +203,61 @@ func TestStatsMeasuresTheAgeOfRunnableWorkOnlyAndInTheDatabasesOwnClock(t *testi
 			notYet, sawNotYet = r.OldestRunnableAgeSeconds, true
 		}
 	}
-	if overdue < 3000 {
+	if overdue == nil {
+		t.Fatal("an hour-overdue scheduled job reported no age at all")
+	}
+	if *overdue < 3000 {
 		t.Errorf("an hour-overdue scheduled job reported age %.0fs: a scheduler that "+
-			"stopped must not read as a healthy queue on the gauge meant to catch it", overdue)
+			"stopped must not read as a healthy queue on the gauge meant to catch it", *overdue)
 	}
 	if !sawNotYet {
 		t.Fatal("the future-scheduled row is missing from the snapshot entirely; it is " +
 			"queued work and must still be counted, only not aged")
 	}
-	if notYet != 0 {
-		t.Errorf("a job scheduled for the future reported age %.0fs, want 0: it is not late", notYet)
+	if notYet != nil {
+		t.Errorf("a job scheduled for the future reported age %.0fs; it is not runnable, so "+
+			"there is no oldest-runnable job to report and NULL is the honest answer", *notYet)
+	}
+}
+
+// TestAPresentButEmptyWorkspaceIsNotReportedAsADispatcher — river_job has
+// no constraint forcing the workspace key to be absent rather than empty,
+// and the reader's whole invariant is that an empty label means dispatcher.
+// The two must be distinguishable in the snapshot or the renderer cannot
+// tell them apart either.
+func TestAPresentButEmptyWorkspaceIsNotReportedAsADispatcher(t *testing.T) {
+	_, pool := migratedAppPool(t)
+	ctx := t.Context()
+
+	seedJob(ctx, t, pool, seed{Kind: "real_dispatcher", State: "available"})
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO river_job (state, kind, queue, args, tags, errors, max_attempts,
+		                       attempt, created_at, scheduled_at)
+		VALUES ('available', 'malformed_row', 'default', '{"workspace_id": ""}'::jsonb,
+		        '{}'::varchar(255)[], '{}'::jsonb[], 3, 0, now(), now())`); err != nil {
+		t.Fatalf("seeding a present-but-empty workspace row: %v", err)
+	}
+
+	snap, err := jobs.Stats(ctx, pool)
+	if err != nil {
+		t.Fatalf("Stats: %v", err)
+	}
+
+	for _, r := range snap.Rows {
+		switch r.Kind {
+		case "real_dispatcher":
+			if !r.Untenanted {
+				t.Error("a row with no workspace key at all was not reported as untenanted")
+			}
+		case "malformed_row":
+			if r.Untenanted {
+				t.Error("a row whose workspace key is PRESENT but empty was reported as a " +
+					"dispatcher; the empty label would then mean two different things")
+			}
+			if r.WorkspaceID != "" {
+				t.Errorf("WorkspaceID = %q, want the stored empty string verbatim", r.WorkspaceID)
+			}
+		}
 	}
 }
 

--- a/backend/internal/platform/jobs/stats_integration_test.go
+++ b/backend/internal/platform/jobs/stats_integration_test.go
@@ -243,13 +243,16 @@ func TestAPresentButEmptyWorkspaceIsNotReportedAsADispatcher(t *testing.T) {
 		t.Fatalf("Stats: %v", err)
 	}
 
+	var sawDispatcher, sawMalformed bool
 	for _, r := range snap.Rows {
 		switch r.Kind {
 		case "real_dispatcher":
+			sawDispatcher = true
 			if !r.Untenanted {
 				t.Error("a row with no workspace key at all was not reported as untenanted")
 			}
 		case "malformed_row":
+			sawMalformed = true
 			if r.Untenanted {
 				t.Error("a row whose workspace key is PRESENT but empty was reported as a " +
 					"dispatcher; the empty label would then mean two different things")
@@ -258,6 +261,50 @@ func TestAPresentButEmptyWorkspaceIsNotReportedAsADispatcher(t *testing.T) {
 				t.Errorf("WorkspaceID = %q, want the stored empty string verbatim", r.WorkspaceID)
 			}
 		}
+	}
+	// Without these, a snapshot missing either row passes every assertion
+	// above by never entering its arm — the distinction would be untested
+	// while the test reported green.
+	if !sawDispatcher {
+		t.Error("the untenanted dispatcher row never reached the snapshot")
+	}
+	if !sawMalformed {
+		t.Error("the present-but-empty row never reached the snapshot")
+	}
+}
+
+// TestASweepChildWithAnEmptyWorkspaceIsNotCountedAsATenant — the sweep pair
+// answers "how much of the fleet did this pass cover", so a malformed row
+// admitted as a workspace of its own inflates the fleet with a phantom
+// tenant. It is excluded by the same test the state read uses.
+func TestASweepChildWithAnEmptyWorkspaceIsNotCountedAsATenant(t *testing.T) {
+	_, pool := migratedAppPool(t)
+	ctx := t.Context()
+	tenant := ids.NewV7()
+
+	seedJob(ctx, t, pool, seed{
+		Kind: "sweep_child", State: "completed",
+		Workspace: tenant, Tags: []string{jobs.SweepTag},
+	})
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO river_job (state, kind, queue, args, tags, errors, max_attempts,
+		                       attempt, created_at, scheduled_at)
+		VALUES ('available', 'sweep_child', 'default', '{"workspace_id": ""}'::jsonb,
+		        ARRAY['sweep']::varchar(255)[], '{}'::jsonb[], 3, 0, now(), now())`); err != nil {
+		t.Fatalf("seeding a tagged present-but-empty workspace row: %v", err)
+	}
+
+	snap, err := jobs.Stats(ctx, pool)
+	if err != nil {
+		t.Fatalf("Stats: %v", err)
+	}
+	pass, ok := sweepFor(snap, "sweep_child")
+	if !ok {
+		t.Fatal("the real tagged child is missing from the sweep read")
+	}
+	if pass.Workspaces != 1 {
+		t.Errorf("Workspaces = %d, want 1: a row whose workspace key is present but empty "+
+			"is malformed, not a tenant this pass covered", pass.Workspaces)
 	}
 }
 

--- a/backend/internal/platform/jobs/stats_integration_test.go
+++ b/backend/internal/platform/jobs/stats_integration_test.go
@@ -35,19 +35,6 @@ type seed struct {
 	CreatedAt time.Time // the zero value means now
 	Scheduled time.Time // the zero value means CreatedAt
 	Attempt   int
-	Errors    []attemptError
-}
-
-// attemptError mirrors the element River stores per attempt in
-// river_job.errors. Trace is declared and populated on purpose: it carries
-// a full panic stack in production, and a reader that serialized the
-// element whole would put it on the wire — so the fixture supplies one for
-// a test to prove that never happens.
-type attemptError struct {
-	At      time.Time `json:"at"`
-	Attempt int       `json:"attempt"`
-	Error   string    `json:"error"`
-	Trace   string    `json:"trace,omitempty"`
 }
 
 // finalizedStates are the states river_job's finalized_or_finalized_at_null
@@ -85,15 +72,6 @@ func seedJob(ctx context.Context, t *testing.T, pool *pgxpool.Pool, s seed) {
 		t.Fatalf("encoding fixture args: %v", err)
 	}
 
-	encodedErrors := make([][]byte, 0, len(s.Errors))
-	for _, e := range s.Errors {
-		encoded, err := json.Marshal(e)
-		if err != nil {
-			t.Fatalf("encoding fixture attempt error: %v", err)
-		}
-		encodedErrors = append(encodedErrors, encoded)
-	}
-
 	// river_job.tags is NOT NULL, and a nil Go slice binds as NULL rather
 	// than as an empty array — an untagged row is the common case here, so
 	// the default belongs in the helper.
@@ -114,7 +92,7 @@ func seedJob(ctx context.Context, t *testing.T, pool *pgxpool.Pool, s seed) {
 		     created_at, scheduled_at, finalized_at)
 		VALUES ($1::river_job_state, $2, $3, $4::jsonb, $5::varchar(255)[],
 		        $6::jsonb[], $7, $8, $9, $10, $11)`,
-		s.State, s.Kind, queue, encodedArgs, tags, encodedErrors,
+		s.State, s.Kind, queue, encodedArgs, tags, [][]byte{},
 		3, s.Attempt, createdAt, scheduledAt, finalizedAt); err != nil {
 		t.Fatalf("seeding a %s %s row: %v", s.State, s.Kind, err)
 	}

--- a/backend/internal/platform/jobs/stats_integration_test.go
+++ b/backend/internal/platform/jobs/stats_integration_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/riverqueue/river"
 
 	"github.com/gradionhq/margince/backend/internal/platform/jobs"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -246,7 +247,7 @@ func TestSweepCountsEachWorkspacesLatestOutcomeAndSurvivesADeduplicatedRetry(t *
 	_, pool := migratedAppPool(t)
 	ctx := t.Context()
 	older, newer := time.Now().Add(-2*time.Hour), time.Now().Add(-1*time.Hour)
-	wsA, wsB, wsC := ids.NewV7(), ids.NewV7(), ids.NewV7()
+	wsA, wsB, wsC, wsD := ids.NewV7(), ids.NewV7(), ids.NewV7(), ids.NewV7()
 
 	// A: still retryable from the EARLIER fan-out — deduplicated out of the
 	// newer one, so its only row carries the old timestamp.
@@ -268,6 +269,12 @@ func TestSweepCountsEachWorkspacesLatestOutcomeAndSurvivesADeduplicatedRetry(t *
 		Kind: "sweep_child", State: "completed",
 		Workspace: wsC, Tags: []string{jobs.SweepTag}, CreatedAt: newer,
 	})
+	// D: cancelled, which counts as failed for the same reason discarded
+	// does — a cancelled pass did not run, whatever the reason.
+	seedJob(ctx, t, pool, seed{
+		Kind: "sweep_child", State: "cancelled",
+		Workspace: wsD, Tags: []string{jobs.SweepTag}, CreatedAt: newer,
+	})
 	// A hand-triggered job of the same kind, carrying no sweep tag.
 	seedJob(ctx, t, pool, seed{
 		Kind: "sweep_child", State: "available",
@@ -282,16 +289,77 @@ func TestSweepCountsEachWorkspacesLatestOutcomeAndSurvivesADeduplicatedRetry(t *
 	if !ok {
 		t.Fatal("no sweep reported for a tagged kind")
 	}
-	if pass.Workspaces != 3 {
-		t.Errorf("Workspaces = %d, want 3: a workspace deduplicated out of the newest "+
+	if pass.Workspaces != 4 {
+		t.Errorf("Workspaces = %d, want 4: a workspace deduplicated out of the newest "+
 			"fan-out is still covered, and an untagged row is not a fleet pass at all",
 			pass.Workspaces)
 	}
-	if pass.Failed != 1 {
-		t.Errorf("Failed = %d, want 1: only B's LATEST outcome counts, and B succeeded "+
-			"before it died", pass.Failed)
+	if pass.Failed != 2 {
+		t.Errorf("Failed = %d, want 2: only B's LATEST outcome counts, and B succeeded "+
+			"before it died; D was cancelled, which is also work that did not happen",
+			pass.Failed)
 	}
 }
+
+// TestARealRiverInsertCarriesTheSweepTagIntoTheColumnTheReadFilterson closes
+// the gap every other test in this file leaves open: they seed the tag by
+// hand, so they prove the query and not the pipeline. This one goes through
+// River's own insert path with the tag on InsertOpts, and asserts the sweep
+// read finds it — so a River release that stopped persisting tags, or an
+// InsertOpts merge that dropped them, fails here rather than silently
+// emptying the sweep gauges in production.
+func TestARealRiverInsertCarriesTheSweepTagIntoTheColumnTheReadFiltersOn(t *testing.T) {
+	_, pool := migratedAppPool(t)
+	ctx := t.Context()
+
+	// A runner of this test's own, because River refuses to insert a kind
+	// its Workers bundle does not register and the shared helper registers
+	// only its no-op.
+	workers := river.NewWorkers()
+	river.AddWorker(workers, &taggedWorker{})
+	runner, err := jobs.New(pool, jobs.Config{
+		Queues:  map[string]river.QueueConfig{river.QueueDefault: {MaxWorkers: 1}},
+		Workers: workers,
+	}, quietLogger())
+	if err != nil {
+		t.Fatalf("jobs.New: %v", err)
+	}
+
+	if err := runner.Enqueue(ctx, taggedArgs{Workspace: ids.NewV7()},
+		&river.InsertOpts{Tags: []string{jobs.SweepTag}}); err != nil {
+		t.Fatalf("enqueueing a tagged job: %v", err)
+	}
+
+	snap, err := jobs.Stats(ctx, pool)
+	if err != nil {
+		t.Fatalf("Stats: %v", err)
+	}
+	pass, ok := sweepFor(snap, taggedArgs{}.Kind())
+	if !ok {
+		t.Fatal("a job River inserted with the sweep tag is absent from the sweep read; " +
+			"the tag did not survive the insert path the dispatchers use")
+	}
+	if pass.Workspaces != 1 {
+		t.Errorf("Workspaces = %d, want 1", pass.Workspaces)
+	}
+}
+
+// taggedArgs is a workspace-scoped kind for the round-trip above. It spells
+// its workspace key the way every WorkspaceScoped kind does, because that
+// spelling is what args->>'workspace_id' reads.
+type taggedArgs struct {
+	Workspace ids.UUID `json:"workspace_id"`
+}
+
+func (taggedArgs) Kind() string { return "tagged_round_trip" }
+
+// taggedWorker exists only so River accepts the insert; the round-trip
+// asserts what the INSERT wrote, and never runs the job.
+type taggedWorker struct {
+	river.WorkerDefaults[taggedArgs]
+}
+
+func (taggedWorker) Work(context.Context, *river.Job[taggedArgs]) error { return nil }
 
 // TestSweepIgnoresAWorkspacesSupersededFailure — the mirror of the above. A
 // workspace that failed and then succeeded is not a tenant being missed.

--- a/backend/internal/platform/jobs/stats_integration_test.go
+++ b/backend/internal/platform/jobs/stats_integration_test.go
@@ -1,0 +1,372 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package jobs_test
+
+// Real-Postgres proof of the two reads behind the job surfaces. The SQL is
+// the whole of the behaviour here — a fake pool would prove the fixture,
+// not the query — so every case below seeds raw river_job rows and reads
+// them back through the exported entry point.
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/gradionhq/margince/backend/internal/platform/jobs"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// seed is one raw river_job row. Written directly rather than through
+// River's client because these tests need states, timestamps and stored
+// error text that a real insert cannot produce on demand.
+type seed struct {
+	Kind      string
+	Queue     string   // empty means "default"
+	State     string   // river_job_state
+	Workspace ids.UUID // the zero value writes NO workspace_id key at all — a dispatcher
+	Tags      []string
+	CreatedAt time.Time // the zero value means now
+	Scheduled time.Time // the zero value means CreatedAt
+	Attempt   int
+	Errors    []attemptError
+}
+
+// attemptError mirrors the element River stores per attempt in
+// river_job.errors. Trace is declared and populated on purpose: it carries
+// a full panic stack in production, and a reader that serialized the
+// element whole would put it on the wire — so the fixture supplies one for
+// a test to prove that never happens.
+type attemptError struct {
+	At      time.Time `json:"at"`
+	Attempt int       `json:"attempt"`
+	Error   string    `json:"error"`
+	Trace   string    `json:"trace,omitempty"`
+}
+
+// finalizedStates are the states river_job's finalized_or_finalized_at_null
+// CHECK requires a finalized_at for. A fixture that omits it is refused by
+// Postgres, not by the assertion, so the helper stamps it rather than
+// leaving every caller to remember.
+var finalizedStates = map[string]bool{"completed": true, "cancelled": true, "discarded": true}
+
+// seedJob writes one raw river_job row and fails the test if Postgres
+// refuses it.
+func seedJob(ctx context.Context, t *testing.T, pool *pgxpool.Pool, s seed) {
+	t.Helper()
+
+	queue := s.Queue
+	if queue == "" {
+		queue = "default"
+	}
+	createdAt := s.CreatedAt
+	if createdAt.IsZero() {
+		createdAt = time.Now()
+	}
+	scheduledAt := s.Scheduled
+	if scheduledAt.IsZero() {
+		scheduledAt = createdAt
+	}
+
+	// A zero workspace writes no key at all, which is exactly what a
+	// dispatcher's args look like on the wire.
+	args := map[string]any{}
+	if s.Workspace != (ids.UUID{}) {
+		args["workspace_id"] = s.Workspace.String()
+	}
+	encodedArgs, err := json.Marshal(args)
+	if err != nil {
+		t.Fatalf("encoding fixture args: %v", err)
+	}
+
+	encodedErrors := make([][]byte, 0, len(s.Errors))
+	for _, e := range s.Errors {
+		encoded, err := json.Marshal(e)
+		if err != nil {
+			t.Fatalf("encoding fixture attempt error: %v", err)
+		}
+		encodedErrors = append(encodedErrors, encoded)
+	}
+
+	// river_job.tags is NOT NULL, and a nil Go slice binds as NULL rather
+	// than as an empty array — an untagged row is the common case here, so
+	// the default belongs in the helper.
+	tags := s.Tags
+	if tags == nil {
+		tags = []string{}
+	}
+
+	var finalizedAt *time.Time
+	if finalizedStates[s.State] {
+		finalized := createdAt
+		finalizedAt = &finalized
+	}
+
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO river_job
+		    (state, kind, queue, args, tags, errors, max_attempts, attempt,
+		     created_at, scheduled_at, finalized_at)
+		VALUES ($1::river_job_state, $2, $3, $4::jsonb, $5::varchar(255)[],
+		        $6::jsonb[], $7, $8, $9, $10, $11)`,
+		s.State, s.Kind, queue, encodedArgs, tags, encodedErrors,
+		3, s.Attempt, createdAt, scheduledAt, finalizedAt); err != nil {
+		t.Fatalf("seeding a %s %s row: %v", s.State, s.Kind, err)
+	}
+}
+
+// count answers one group's Count, or 0 when the group is absent — the two
+// are different claims, so the absent case is asserted explicitly where it
+// matters rather than being folded in here.
+func count(snap jobs.Snapshot, kind, state, workspace string) int64 {
+	var total int64
+	for _, r := range snap.Rows {
+		if r.Kind == kind && r.State == state && r.WorkspaceID == workspace {
+			total += r.Count
+		}
+	}
+	return total
+}
+
+func sweepFor(snap jobs.Snapshot, kind string) (jobs.SweepPass, bool) {
+	for _, s := range snap.Sweeps {
+		if s.Kind == kind {
+			return s, true
+		}
+	}
+	return jobs.SweepPass{}, false
+}
+
+// TestStatsCountsLiveWorkAndNamesTheWorkspaceThatOwnsIt proves the two
+// properties every reader downstream stands on: a tenant job reports its
+// workspace, and a dispatcher reports the empty string rather than being
+// silently grouped with one.
+func TestStatsCountsLiveWorkAndNamesTheWorkspaceThatOwnsIt(t *testing.T) {
+	_, pool := migratedAppPool(t)
+	ctx := t.Context()
+	ws := ids.NewV7()
+
+	seedJob(ctx, t, pool, seed{Kind: "tenant_pass", State: "available", Workspace: ws})
+	seedJob(ctx, t, pool, seed{Kind: "tenant_pass", State: "discarded", Workspace: ws})
+	seedJob(ctx, t, pool, seed{Kind: "the_dispatcher", State: "available"}) // no workspace
+
+	snap, err := jobs.Stats(ctx, pool)
+	if err != nil {
+		t.Fatalf("Stats: %v", err)
+	}
+
+	if got := count(snap, "tenant_pass", "available", ws.String()); got != 1 {
+		t.Errorf("tenant available = %d, want 1", got)
+	}
+	if got := count(snap, "tenant_pass", "discarded", ws.String()); got != 1 {
+		t.Errorf("tenant discarded = %d, want 1: a failed pass must stay visible", got)
+	}
+	if got := count(snap, "the_dispatcher", "available", ""); got != 1 {
+		t.Errorf("dispatcher under empty workspace = %d, want 1: a null args workspace "+
+			"means a dispatcher, and the reader must be able to say so", got)
+	}
+}
+
+// TestStatsExcludesCompletedWorkFromTheRuntimeGauges — a finished job is
+// history, not queue depth. Without this the gauges only fall when River's
+// cleaner runs.
+func TestStatsExcludesCompletedWorkFromTheRuntimeGauges(t *testing.T) {
+	_, pool := migratedAppPool(t)
+	ctx := t.Context()
+	seedJob(ctx, t, pool, seed{Kind: "done", State: "completed"})
+
+	snap, err := jobs.Stats(ctx, pool)
+	if err != nil {
+		t.Fatalf("Stats: %v", err)
+	}
+	if got := count(snap, "done", "completed", ""); got != 0 {
+		t.Errorf("a completed row reached the runtime gauges: count = %d", got)
+	}
+}
+
+// TestStatsMeasuresTheAgeOfRunnableWorkOnlyAndInTheDatabasesOwnClock — the
+// gauge answers "how long has runnable work been waiting", so a job
+// scheduled for the future contributes nothing (it is not late) while one
+// whose scheduled time has passed does (a stopped scheduler is precisely
+// what this gauge exists to catch). The age is computed by Postgres from
+// its own now(): subtracting a database timestamp from the app clock is a
+// live intermittent flake elsewhere in this tree.
+func TestStatsMeasuresTheAgeOfRunnableWorkOnlyAndInTheDatabasesOwnClock(t *testing.T) {
+	_, pool := migratedAppPool(t)
+	ctx := t.Context()
+	anHourAgo := time.Now().Add(-time.Hour)
+
+	seedJob(ctx, t, pool, seed{
+		Kind: "overdue", Queue: "waiting", State: "scheduled",
+		CreatedAt: anHourAgo, Scheduled: anHourAgo,
+	})
+	seedJob(ctx, t, pool, seed{
+		Kind: "not_yet", Queue: "future", State: "scheduled",
+		CreatedAt: anHourAgo, Scheduled: time.Now().Add(time.Hour),
+	})
+
+	snap, err := jobs.Stats(ctx, pool)
+	if err != nil {
+		t.Fatalf("Stats: %v", err)
+	}
+
+	var overdue, notYet float64
+	var sawNotYet bool
+	for _, r := range snap.Rows {
+		switch r.Kind {
+		case "overdue":
+			overdue = r.OldestRunnableAgeSeconds
+		case "not_yet":
+			notYet, sawNotYet = r.OldestRunnableAgeSeconds, true
+		}
+	}
+	if overdue < 3000 {
+		t.Errorf("an hour-overdue scheduled job reported age %.0fs: a scheduler that "+
+			"stopped must not read as a healthy queue on the gauge meant to catch it", overdue)
+	}
+	if !sawNotYet {
+		t.Fatal("the future-scheduled row is missing from the snapshot entirely; it is " +
+			"queued work and must still be counted, only not aged")
+	}
+	if notYet != 0 {
+		t.Errorf("a job scheduled for the future reported age %.0fs, want 0: it is not late", notYet)
+	}
+}
+
+// TestSweepCountsEachWorkspacesLatestOutcomeAndSurvivesADeduplicatedRetry
+// seeds the exact shape a rescued dispatcher produces — one workspace whose
+// older child is still live and so was deduplicated out of the newer
+// fan-out — and asserts the fleet is still reported whole. A fixture that
+// gives every row the same timestamp proves the fixture, not the query.
+func TestSweepCountsEachWorkspacesLatestOutcomeAndSurvivesADeduplicatedRetry(t *testing.T) {
+	_, pool := migratedAppPool(t)
+	ctx := t.Context()
+	older, newer := time.Now().Add(-2*time.Hour), time.Now().Add(-1*time.Hour)
+	wsA, wsB, wsC := ids.NewV7(), ids.NewV7(), ids.NewV7()
+
+	// A: still retryable from the EARLIER fan-out — deduplicated out of the
+	// newer one, so its only row carries the old timestamp.
+	seedJob(ctx, t, pool, seed{
+		Kind: "sweep_child", State: "retryable",
+		Workspace: wsA, Tags: []string{jobs.SweepTag}, CreatedAt: older,
+	})
+	// B: succeeded earlier, ran again in the newer pass and died.
+	seedJob(ctx, t, pool, seed{
+		Kind: "sweep_child", State: "completed",
+		Workspace: wsB, Tags: []string{jobs.SweepTag}, CreatedAt: older,
+	})
+	seedJob(ctx, t, pool, seed{
+		Kind: "sweep_child", State: "discarded",
+		Workspace: wsB, Tags: []string{jobs.SweepTag}, CreatedAt: newer,
+	})
+	// C: fine, newest pass only.
+	seedJob(ctx, t, pool, seed{
+		Kind: "sweep_child", State: "completed",
+		Workspace: wsC, Tags: []string{jobs.SweepTag}, CreatedAt: newer,
+	})
+	// A hand-triggered job of the same kind, carrying no sweep tag.
+	seedJob(ctx, t, pool, seed{
+		Kind: "sweep_child", State: "available",
+		Workspace: ids.NewV7(), CreatedAt: newer,
+	})
+
+	snap, err := jobs.Stats(ctx, pool)
+	if err != nil {
+		t.Fatalf("Stats: %v", err)
+	}
+	pass, ok := sweepFor(snap, "sweep_child")
+	if !ok {
+		t.Fatal("no sweep reported for a tagged kind")
+	}
+	if pass.Workspaces != 3 {
+		t.Errorf("Workspaces = %d, want 3: a workspace deduplicated out of the newest "+
+			"fan-out is still covered, and an untagged row is not a fleet pass at all",
+			pass.Workspaces)
+	}
+	if pass.Failed != 1 {
+		t.Errorf("Failed = %d, want 1: only B's LATEST outcome counts, and B succeeded "+
+			"before it died", pass.Failed)
+	}
+}
+
+// TestSweepIgnoresAWorkspacesSupersededFailure — the mirror of the above. A
+// workspace that failed and then succeeded is not a tenant being missed.
+func TestSweepIgnoresAWorkspacesSupersededFailure(t *testing.T) {
+	_, pool := migratedAppPool(t)
+	ctx := t.Context()
+	ws := ids.NewV7()
+	seedJob(ctx, t, pool, seed{
+		Kind: "sweep_child", State: "discarded", Workspace: ws,
+		Tags: []string{jobs.SweepTag}, CreatedAt: time.Now().Add(-2 * time.Hour),
+	})
+	seedJob(ctx, t, pool, seed{
+		Kind: "sweep_child", State: "completed", Workspace: ws,
+		Tags: []string{jobs.SweepTag}, CreatedAt: time.Now().Add(-time.Hour),
+	})
+
+	snap, err := jobs.Stats(ctx, pool)
+	if err != nil {
+		t.Fatalf("Stats: %v", err)
+	}
+	pass, ok := sweepFor(snap, "sweep_child")
+	if !ok {
+		t.Fatal("no sweep reported for a tagged kind")
+	}
+	if pass.Failed != 0 {
+		t.Errorf("Failed = %d, want 0: the workspace recovered", pass.Failed)
+	}
+}
+
+// TestSweepOmitsADispatchersOwnRow — a dispatcher carries no workspace, so
+// it is not one workspace's share of anything. Counting it would add a
+// phantom tenant to every sweep it tagged.
+func TestSweepOmitsADispatchersOwnRow(t *testing.T) {
+	_, pool := migratedAppPool(t)
+	ctx := t.Context()
+	seedJob(ctx, t, pool, seed{
+		Kind: "the_dispatcher", State: "completed",
+		Tags: []string{jobs.SweepTag},
+	})
+
+	snap, err := jobs.Stats(ctx, pool)
+	if err != nil {
+		t.Fatalf("Stats: %v", err)
+	}
+	if _, ok := sweepFor(snap, "the_dispatcher"); ok {
+		t.Error("an untenanted row was counted as a workspace's share of a fleet pass")
+	}
+}
+
+// TestStatsOnAnEmptyJobTableIsAnEmptySnapshotNotAnError — the honest empty
+// case. A fleet with nothing queued is a real state, and the reader above
+// must be able to tell it from a failed read.
+func TestStatsOnAnEmptyJobTableIsAnEmptySnapshotNotAnError(t *testing.T) {
+	_, pool := migratedAppPool(t)
+
+	snap, err := jobs.Stats(t.Context(), pool)
+	if err != nil {
+		t.Fatalf("Stats on an empty table: %v", err)
+	}
+	if len(snap.Rows) != 0 || len(snap.Sweeps) != 0 {
+		t.Errorf("an empty job table produced %d rows and %d sweeps", len(snap.Rows), len(snap.Sweeps))
+	}
+}
+
+// TestStatsFailsLoudlyWhenTheJobTableIsUnreachable — a read that could not
+// happen must say so rather than answering with an empty snapshot, which
+// downstream renders as a healthy idle fleet.
+func TestStatsFailsLoudlyWhenTheJobTableIsUnreachable(t *testing.T) {
+	_, pool := migratedAppPool(t)
+
+	cancelled, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	if _, err := jobs.Stats(cancelled, pool); err == nil {
+		t.Fatal("Stats answered a snapshot on a cancelled context; an unmeasured fleet " +
+			"must not be indistinguishable from an empty one")
+	}
+}

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -107,7 +107,10 @@ time.
 Four things worth knowing before you build an alert on these:
 
 - **An empty `workspace_id` means a dispatcher**, exactly and in both
-  directions. A job that does tenant work declares its workspace, so a null
+  directions. A row whose workspace key is present but *empty* is malformed
+  rather than fleet-wide, and appears under
+  `workspace_id="malformed_workspace_id"` so it is visible instead of being
+  miscounted as a dispatcher. A job that does tenant work declares its workspace, so a null
   there is a fan-out job and nothing else. The label carries the **id**,
   never a name: the exposition endpoint has no redaction path.
 - **A job scheduled for the future is counted in depth but contributes no

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -136,6 +136,14 @@ workspace's most recent child may be the successful one, and the failure is
 not reflected in `margince_sweep_workspaces_failed`. Per-connection health is
 visible on the endpoint below, by kind.
 
+**`/metrics` is fleet-wide; the endpoint is not.** The exposition carries
+every workspace's id and every kind, because an operator scraping a service
+is outside the tenant boundary by construction (ADR-0080/A125 admits the id
+for exactly this reason, and only the id). That is a deliberate asymmetry
+with the admin endpoint below, which is scoped — so `/metrics` must stay
+behind the same access control as any other operator surface, never proxied
+to a tenant.
+
 **`GET /v1/admin/job-health` — whose work died, and why?** Admin-only and
 human-session-only; an agent passport is refused at the middleware and again
 in the handler. It reports, for each kind, the waiting/running/retrying/dead
@@ -151,7 +159,9 @@ counts and the oldest waiting age, plus up to 50 recent failures.
   bypassed the fault seam stored its raw cause — which routinely names an
   address or record a provider refused. Anything not in the closed
   vocabulary is replaced by one fixed substitute. River's stored panic trace
-  is never read at all.
+  is never read at all. A row that recorded no cause at all — a job cancelled
+  before it ran — says so, rather than borrowing the unvettable-failure
+  sentence and claiming a failure that never happened.
 
 ## cmd/worker — the background process role
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -93,7 +93,7 @@ looking zero.
 | `margince_job_queue_depth` | `queue`, `workspace_id` | available + scheduled + retryable + pending — work nobody has done yet (OPS-MET-2) |
 | `margince_job_running` | `queue`, `workspace_id` | currently executing |
 | `margince_job_discarded` | `kind`, `workspace_id` | every attempt spent; will never run without intervention |
-| `margince_job_cancelled` | `kind`, `workspace_id` | stopped deliberately, attempts unspent — counted apart from discarded because a cancelled job did not fail |
+| `margince_job_cancelled` | `kind`, `workspace_id` | stopped deliberately, attempts unspent — counted apart from discarded because the operator story differs, not because it is less dead. The sweep pair counts either as a workspace missed |
 | `margince_job_oldest_queued_age_seconds` | `queue`, `workspace_id` | how long the oldest runnable-and-unclaimed job has waited |
 | `margince_sweep_workspaces_total` | `sweep` | workspaces with a surviving child of that fleet pass |
 | `margince_sweep_workspaces_failed` | `sweep` | those whose MOST RECENT child is discarded or cancelled |
@@ -111,9 +111,11 @@ Four things worth knowing before you build an alert on these:
   there is a fan-out job and nothing else. The label carries the **id**,
   never a name: the exposition endpoint has no redaction path.
 - **A job scheduled for the future is counted in depth but contributes no
-  age.** It is queued, but it is not late. A queue holding nothing except
-  discarded rows reports no age series at all — there is no runnable job to
-  measure.
+  age.** It is queued, but it is not late. A queue holding nothing but running or
+  discarded rows reports no age series at all — a running job has already
+  been claimed and a discarded one never will be, so neither is what
+  "oldest runnable-and-unclaimed" measures. The endpoint reports `null` for
+  the same rows.
 - **The sweep pair is per workspace, not per pass.** There is no such thing
   as "the last pass" in this table: River resolves a uniqueness conflict by
   updating the existing row, so a child still active from the previous

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -107,10 +107,13 @@ time.
 Four things worth knowing before you build an alert on these:
 
 - **An empty `workspace_id` means a dispatcher**, exactly and in both
-  directions. A row whose workspace key is present but *empty* is malformed
-  rather than fleet-wide, and appears under
-  `workspace_id="malformed_workspace_id"` so it is visible instead of being
-  miscounted as a dispatcher. A job that does tenant work declares its workspace, so a null
+  directions — where *empty* means the `workspace_id` key is **absent or
+  JSON null** in the job's args, which is what a fan-out job's args look
+  like. A job that does tenant work always names its workspace.
+  A row whose key is *present but an empty string* is neither: it is
+  malformed, and appears under `workspace_id="malformed_workspace_id"` so it
+  is visible as the anomaly it is rather than being counted as dispatcher
+  work. A job that does tenant work declares its workspace, so a null
   there is a fan-out job and nothing else. The label carries the **id**,
   never a name: the exposition endpoint has no redaction path.
 - **A job scheduled for the future is counted in depth but contributes no

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -46,7 +46,12 @@ Operational endpoints (served next to `/v1`):
   customfields schema pool when `--schema-dsn` is set) must pass within
   2s, else 503 naming the unready dependency.
 - `/metrics` — Prometheus text format: `margince_outbox_unpublished`,
-  `margince_relay_published_total`, `margince_pgxpool_conns{state=…}`.
+  `margince_relay_published_total`, `margince_pgxpool_conns{state=…}`, the
+  AI router's counters, the overlay sync-health section, and the
+  **job-runtime section** below.
+- `GET /v1/admin/job-health` — the per-workspace read of the same job
+  table, for an admin rather than a scrape. See
+  [Reading the job surfaces](#reading-the-job-surfaces).
 - `/mcp` plus `/oauth/*` and the RFC 8414/9728 discovery documents
   (`/.well-known/oauth-authorization-server`,
   `/.well-known/oauth-protected-resource` and its `/mcp` suffixed form) —
@@ -71,6 +76,80 @@ Operational endpoints (served next to `/v1`):
   lifetime rather than access to a record. What a connection is granted is the
   passport the human lent, not what the client requested — these documents state
   the vocabulary a client may name, they do not bound the grant.
+
+### Reading the job surfaces
+
+Two readers over one table, `river_job`, answering two different questions.
+Both are served by `cmd/api`, and both are read at request time rather than
+counted in process — `cmd/worker`, where the dispatchers actually run,
+exposes no HTTP surface at all, so an in-process counter there would be
+invisible to every scrape while the api's own copy reported a truthful
+looking zero.
+
+**`/metrics` — is a queue growing?** Seven gauge families:
+
+| Family | Labels | Meaning |
+|---|---|---|
+| `margince_job_queue_depth` | `queue`, `workspace_id` | available + scheduled + retryable + pending — work nobody has done yet (OPS-MET-2) |
+| `margince_job_running` | `queue`, `workspace_id` | currently executing |
+| `margince_job_discarded` | `kind`, `workspace_id` | every attempt spent; will never run without intervention |
+| `margince_job_cancelled` | `kind`, `workspace_id` | stopped deliberately, attempts unspent — counted apart from discarded because a cancelled job did not fail |
+| `margince_job_oldest_queued_age_seconds` | `queue`, `workspace_id` | how long the oldest runnable-and-unclaimed job has waited |
+| `margince_sweep_workspaces_total` | `sweep` | workspaces with a surviving child of that fleet pass |
+| `margince_sweep_workspaces_failed` | `sweep` | those whose MOST RECENT child is discarded or cancelled |
+
+An eighth, `margince_job_unrecognised_state{state,queue,workspace_id}`,
+appears **only when it has something to report**: work sitting in a state
+this exposition does not classify. It is a signal to investigate, not a
+series to graph, which is why it is absent rather than zero the rest of the
+time.
+
+Four things worth knowing before you build an alert on these:
+
+- **An empty `workspace_id` means a dispatcher**, exactly and in both
+  directions. A job that does tenant work declares its workspace, so a null
+  there is a fan-out job and nothing else. The label carries the **id**,
+  never a name: the exposition endpoint has no redaction path.
+- **A job scheduled for the future is counted in depth but contributes no
+  age.** It is queued, but it is not late. A queue holding nothing except
+  discarded rows reports no age series at all — there is no runnable job to
+  measure.
+- **The sweep pair is per workspace, not per pass.** There is no such thing
+  as "the last pass" in this table: River resolves a uniqueness conflict by
+  updating the existing row, so a child still active from the previous
+  fan-out is deduplicated and writes no new row. Any batch-keyed reading
+  would report a dispatcher retried mid-fleet as covering a fraction of the
+  workspaces it actually covers. Instead, each workspace's most recent child
+  of that kind is what counts.
+- **A sweep series can shrink or vanish because of River's retention,** not
+  because the fleet shrank: the cleaner deletes finalized rows on its own
+  schedule. An absent series is the honest answer — a fabricated zero would
+  be indistinguishable from "the fleet is empty".
+
+One further limit, stated because nothing in the numbers reveals it: a
+dispatcher that fans out per **connection** rather than per workspace (Gmail
+sync, Gmail watch, Telegram poll) still counts each workspace once. If one
+workspace holds two connections and only one of them is failing, that
+workspace's most recent child may be the successful one, and the failure is
+not reflected in `margince_sweep_workspaces_failed`. Per-connection health is
+visible on the endpoint below, by kind.
+
+**`GET /v1/admin/job-health` — whose work died, and why?** Admin-only and
+human-session-only; an agent passport is refused at the middleware and again
+in the handler. It reports, for each kind, the waiting/running/retrying/dead
+counts and the oldest waiting age, plus up to 50 recent failures.
+
+- **It is scoped to the caller's own workspace plus the untenanted
+  dispatcher rows, never the fleet.** `river_job` has no workspace column
+  and therefore no RLS, so the handler imposes the scope itself. The
+  untenanted arm is a closed set of declared dispatcher kinds — an
+  unrecognised untenanted row is omitted rather than shared.
+- **The failure `reason` is the job layer's own vetted sentence.**
+  `river_job.errors` holds whatever a worker returned, and a worker that
+  bypassed the fault seam stored its raw cause — which routinely names an
+  address or record a provider refused. Anything not in the closed
+  vocabulary is replaced by one fixed substitute. River's stored panic trace
+  is never read at all.
 
 ## cmd/worker — the background process role
 

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -8849,7 +8849,7 @@ export interface components {
             /** @description Discarded or cancelled: this work will not happen without intervention. A discarded job spent every attempt; a cancelled one was stopped deliberately. */
             dead: number;
             /** @description How long the oldest runnable-and-unclaimed job of this kind has waited. Null when nothing of this kind is runnable now; a job scheduled for the future is not late. */
-            oldest_waiting_age_seconds?: number | null;
+            oldest_waiting_age_seconds: number | null;
         };
         JobFailure: {
             kind: string;
@@ -8857,7 +8857,7 @@ export interface components {
              * Format: uuid
              * @description Null for a dispatcher.
              */
-            workspace_id?: string | null;
+            workspace_id: string | null;
             /** @enum {string} */
             state: "retryable" | "discarded" | "cancelled";
             attempt: number;

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -177,6 +177,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/admin/job-health": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * What the background system is holding, and whose work failed.
+         * @description Admin-only. Reports the caller's own workspace's background jobs by kind — waiting, running, retrying, and dead — plus the untenanted dispatcher rows that fan work out to every workspace. Another workspace's jobs are never included: river_job carries no workspace column and therefore no RLS, so this endpoint imposes the scope itself. Failure text is the job layer's own vetted sentence, never a worker's raw cause (that column is fleet-visible and has no redaction path). Human session only (x-agent-access: human-only).
+         */
+        get: operations["getJobHealth"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/passports": {
         parameters: {
             query?: never;
@@ -8803,6 +8823,50 @@ export interface components {
                 scopes?: ("read_only" | "draft_only" | "act_with_approval" | "auto_execute_low_risk")[];
             } | null;
         };
+        JobHealth: {
+            /**
+             * Format: uuid
+             * @description The workspace these counts are scoped to — the caller's own.
+             */
+            workspace_id: string;
+            /** Format: date-time */
+            generated_at: string;
+            kinds: components["schemas"]["JobKindHealth"][];
+            /** @description Most recent first, capped at 50. A bounded list, not a log. */
+            recent_failures: components["schemas"]["JobFailure"][];
+        };
+        JobKindHealth: {
+            /** @description The stable job identifier River persists in river_job.kind. */
+            kind: string;
+            queue: string;
+            /** @description True for a dispatcher — a job that fans work out and does no tenant work of its own. Its rows carry no workspace. */
+            fleet_wide: boolean;
+            /** @description Available, scheduled or pending: queued and not yet started. */
+            waiting: number;
+            running: number;
+            /** @description Failed at least once and backing off toward another attempt. */
+            retrying: number;
+            /** @description Discarded or cancelled: this work will not happen without intervention. A discarded job spent every attempt; a cancelled one was stopped deliberately. */
+            dead: number;
+            /** @description How long the oldest runnable-and-unclaimed job of this kind has waited. Null when nothing of this kind is runnable now; a job scheduled for the future is not late. */
+            oldest_waiting_age_seconds?: number | null;
+        };
+        JobFailure: {
+            kind: string;
+            /**
+             * Format: uuid
+             * @description Null for a dispatcher.
+             */
+            workspace_id?: string | null;
+            /** @enum {string} */
+            state: "retryable" | "discarded" | "cancelled";
+            attempt: number;
+            max_attempts: number;
+            /** Format: date-time */
+            failed_at: string;
+            /** @description The job layer's vetted operator sentence. A failure whose stored text did not come from that closed vocabulary reports a fixed substitute instead — the raw cause never travels here. */
+            reason: string;
+        };
         /** @description An append-only audit row. Mirrors the `audit_log` table. */
         AuditLogEntry: {
             /** Format: uuid */
@@ -11841,6 +11905,36 @@ export interface operations {
                 };
             };
             422: components["responses"]["ValidationError"];
+        };
+    };
+    getJobHealth: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The workspace's background-job health. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JobHealth"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            /** @description Refused: the caller is an agent/passport principal (this endpoint is human-only) or a human without the admin role. Not an object/action RBAC grant denial. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["Problem"];
+                };
+            };
         };
     };
     listPassports: {


### PR DESCRIPTION
Phase 1 made a failed tenant pass durable. Nothing read it.

`/metrics` served the outbox, the relay, the pool, the AI counters and the overlay section, and said nothing at all about the job queues — where every background obligation in the product now lives. And a workspace whose retention or webhook or reindex pass failed left a real `river_job` row in `discarded`, reachable only by `psql`. This closes both, and closes Phase 1.

## What ships

**`/metrics` — is a queue growing?** Seven gauge families, all read from `river_job` at scrape time:

| Family | Labels |
|---|---|
| `margince_job_queue_depth` | `queue`, `workspace_id` — OPS-MET-2, specified since V1 and never built |
| `margince_job_running` | `queue`, `workspace_id` |
| `margince_job_discarded` | `kind`, `workspace_id` |
| `margince_job_cancelled` | `kind`, `workspace_id` |
| `margince_job_oldest_queued_age_seconds` | `queue`, `workspace_id` |
| `margince_sweep_workspaces_total` | `sweep` |
| `margince_sweep_workspaces_failed` | `sweep` |

An eighth, `margince_job_unrecognised_state`, appears **only when it has something to report** — work in a state this exposition does not classify.

**`GET /v1/admin/job-health` — whose work died, and why?** Admin-only, human-session-only, scoped to the caller's own workspace plus the untenanted dispatcher rows.

## Three decisions worth reviewing

**Every gauge is DB-derived, not counted in process.** `cmd/worker` — where the dispatchers run — serves no HTTP surface at all. An in-process counter there would be invisible to every scrape while the api's own copy reported a truthful-looking zero: the "green tick over work nobody did" posture this whole phase exists to remove.

**The sweep pair reads the latest outcome per workspace, never a batch.** River resolves a uniqueness conflict with `ON CONFLICT … DO UPDATE SET kind`, which writes neither `created_at` nor `metadata` — so a child still active from the previous fan-out is deduplicated and produces no row for the current pass. A dispatcher retried while 90 of 100 children are live inserts 10 fresh rows, and any batch-keyed reading (timestamp or minted pass-id alike) reports that fleet as **10**. Per-workspace-latest never asks which rows shared a pass.

**The endpoint scopes itself, because nothing else can.** `river_job` has no workspace column and therefore no RLS. The untenanted arm is a **closed set of declared dispatcher kinds**, not "the workspace key is null" — that property is held by source-shape tests, not by a database constraint, and the app role holds direct CRUD on the table. The closed set is *derived*: a fitness test walks the package for `jobs.FleetWide` declarations and fails until each is listed, because a forgotten dispatcher is silent in the direction that hurts.

## Evidence

**Gates.** `make check` exit 0 · `INTEGRATION_JOBS=1 make -C backend test-integration` → `OK: integration passed with 0 skips` (28 packages) · `craft static` clean on the diff · `origin/main` merged before the first push.

**New-code coverage — 88.8%** (207/233 statements), every file individually above 80%. Measured by merging unit and integration profiles, since the SQL's tests are build-tagged and read 0% from the unit lane alone.

| File | Covered | |
|---|---|---|
| `compose/jobmetrics.go` | 104/111 | 93.7% |
| `compose/jobhealth.go` | 39/44 | 88.6% |
| `platform/jobs/health.go` | 35/43 | 81.4% |
| `platform/jobs/stats.go` | 29/35 | 82.9% |

**Query plans, measured on a seeded 50,000-row `river_job`** (50 workspaces × 6 kinds × 4 queues × 7 states, a third sweep-tagged) — the `/metrics` handler's budget is 2 s:

```
statsByState   HashAggregate over Seq Scan, shared hit=1204    18.9 ms
statsBySweep   GroupAggregate → Unique → Sort → Seq Scan       34.0 ms
```

~53 ms of 2000 ms, and River's cleaner caps the table well below that (completed/cancelled 24 h, discarded 7 d). Both are sequential scans as predicted; the recorded `args @>` GIN fallback is **not** needed.

**UAT against a live stack — all five acceptance cases PASS.** Real request/response and metric text captured in `.tmp/job-observability-phase1-c/UAT-EVIDENCE.md`: all seven families with real series and `workspace_id` populated on tenant rows and empty on dispatchers; the endpoint as admin with a deliberately failed pass; the vetted sentence through and the raw provider cause substituted (0 hits for the address, `goroutine`, `main.secret` across the raw body); non-admin 403, passport 403, unauthenticated 401 — with the same passport getting 200 on `/v1/people`, proving the credential was live and the refusal was the gate's; and a second workspace's rows absent.

One UAT result was an accident worth keeping: the live worker consumed seeded rows mid-run, and the sweep pair then reported `failed=0` for a kind whose seeded child had failed — **correctly**, because the worker had since written a later successful child for that workspace. The per-workspace-latest design survived a case nobody set up for it.

## Review

Five adversarial passes (three per-task, then Fable and Codex on the finished diff), plus UAT. Full dispositions — including what was refused and why — in `.tmp/job-observability-phase1-c/CODE-REVIEW-DISPOSITION.md`, with the plan-stage reconciliation in `REVIEW-DISPOSITION.md`.

Three fix commits came out of it. The findings that mattered most:

- **A fifth fan-out site was missed** (`overlayReconcileWorker`), and the comment claiming the count named four of five. Its attempt cap is 1, so a single failure is a discard — an overlay workspace could have failed forever with no sweep series at all.
- **`{"workspace_id": ""}` broke the dispatcher invariant.** It rendered under the empty label — reserved for a dispatcher — while the scoped endpoint excluded the same row entirely. Three readers, three answers. Now reported as `<malformed>`.
- **The oldest-age gauge lied twice**: the SQL coalesced NULL to zero, so a queue of future-scheduled work claimed its oldest runnable job had waited no time, about a job that does not exist — while the endpoint reported null for the same rows.
- **Lossy label escaping.** Dropping control characters collapsed distinct malformed ids into duplicate series, which is exactly what makes a scrape unparseable — the bug the escaping was added to prevent, reintroduced in a different shape.
- **A cancelled job claimed it failed.** Found by UAT, not by any test: an empty stored reason fell through to the unvettable-failure substitute, telling an operator a job "failed for a reason this surface cannot vet" about a job that never failed.

## Not in this PR

No migration — River owns its own schema and the `tags` column already exists. No new module. No frontend screen: Phase 2's screen is blocked upstream on U2 (`margince-foundation#1225`, still open); this is the layer underneath it.

STATUS.md carries six follow-ups forward, the two highest-value first: no fitness test asserts a workspace worker declares a `Timeout` (the blocker #390 shipped), and no fitness test asserts a fan-out site tags its children — this branch's own review proved a comment is currently the only registry of those sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds DB-backed job observability: Prometheus job-runtime metrics from `river_job` and a scoped admin `GET /v1/admin/job-health`. Metrics use a 2s deadline; job-health now uses a 5s deadline to avoid slow scans.

- **New Features**
  - `/metrics` adds job gauges from `river_job`: per-queue/per-workspace depth, running, discarded, cancelled, oldest runnable age, plus sweep counts (tagged with `jobs.SweepTag`).
  - Admin `GET /v1/admin/job-health`: per-kind state, oldest runnable age, and bounded recent failures using vetted fault sentences; scoped to the caller’s workspace plus declared fleet-wide dispatchers; human-session only.
  - All fan-outs tag children as one workspace’s share of a fleet pass; includes Telegram poll and voice build retry.
  - Metrics read uses a handler-scoped 2s deadline and skips the job section on read failure.

- **Bug Fixes**
  - `{"workspace_id": ""}` is treated as `<malformed>` in metrics and excluded from scoped reads; docs clarify “empty” means absent or JSON null.
  - Oldest-queued age is null when nothing runnable or only running; `/metrics` no longer emits fabricated zeros.
  - Label escaping is injective and escapes control bytes and `<`; a new test pins the collision case.
  - Failure reporting uses columns for `failed_at`, normalizes to UTC, orders by the displayed time; cancellations without a cause don’t claim failure; recent failures are capped and deterministic; timeout test name clarified to reflect it validates the constant.

<sup>Written for commit 30c8f0ad0113dca90a6ec5ce56f6992dcaecf55a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an admin-only job health endpoint showing workspace-scoped job counts, dispatcher status, queue details, and recent failures.
  * Added runtime job metrics for queue depth, running, discarded, cancelled, waiting age, and fleet sweep outcomes.
  * Fleet-dispatched work is now consistently identifiable for clearer monitoring.

* **Bug Fixes**
  * Failure details are restricted to approved, safe messages.
  * Job health data is limited to the relevant workspace and authorized administrators.

* **Documentation**
  * Documented the new endpoint, metrics, labeling, and reporting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->