### PR TITLE
ci: cut and publish the main patch on every mainline push

### DIFF
--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -1,0 +1,90 @@
+name: patch
+
+# Cut and publish the incremental patch for what lands on main. The patch is
+# produced by the release-management CLI (a closed-source tool built and
+# published from gradionhq/margince-constellation as a private container image),
+# run here against this repo's checkout: the product source that the patch
+# describes lives here, so the patch is cut here.
+#
+# The range is the push's before..after — exactly what the push added to the
+# mainline. On a branch creation or force-push there is no ancestor to diff from
+# (github.event.before is all-zeros), so the job no-ops. On a manual dispatch
+# there is no push range, so it falls back to the parent commit (HEAD~1..HEAD).
+#
+# The patch is a build artifact for the distribution pipeline to consume, not a
+# durable release, so it is kept for one day only.
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  # The release-management CLI image, published :latest from constellation's
+  # main (gradionhq/margince-constellation). It is private, so the pull
+  # authenticates with a PAT carrying read:packages (secret GHCR_PULL_TOKEN);
+  # the default GITHUB_TOKEN only reads this repository's own packages.
+  RELEASE_MANAGEMENT_IMAGE: ghcr.io/gradionhq/margince-constellation/release-management:latest
+
+jobs:
+  patch:
+    name: patch
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: false
+          # Full history so both ends of the range resolve; the shallow default
+          # would not carry the before commit.
+          fetch-depth: 0
+      - name: Log in to ghcr.io
+        env:
+          GHCR_TOKEN: ${{ secrets.GHCR_PULL_TOKEN }}
+          GHCR_USER: ${{ github.actor }}
+        run: echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
+      - name: Create the patch for what landed on main
+        id: patch
+        env:
+          BEFORE: ${{ github.event.before }}
+          AFTER: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          # A push carries its previous tip in BEFORE; a manual dispatch carries
+          # nothing, so fall back to the parent commit. An all-zeros BEFORE means
+          # no ancestor (branch creation / force-push): nothing to diff.
+          base="$BEFORE"
+          if [ -z "$base" ]; then
+            base="$(git rev-parse --verify HEAD~1 2>/dev/null || true)"
+          fi
+          if [ -z "$base" ] || printf '%s' "$base" | grep -qE '^0+$'; then
+            echo "No ancestor commit to diff from; no incremental patch to cut." >&2
+            echo "created=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # The image ENTRYPOINT is the CLI (WORKDIR /work); mount the checkout
+          # there and diff it with -repo. The container runs as root over a
+          # runner-owned mount, so inject safe.directory via git's env config
+          # (no writable config file needed) for the CLI's git subprocess.
+          docker run --rm \
+            -v "$PWD":/work \
+            -e GIT_CONFIG_COUNT=1 \
+            -e GIT_CONFIG_KEY_0=safe.directory \
+            -e GIT_CONFIG_VALUE_0='*' \
+            "$RELEASE_MANAGEMENT_IMAGE" \
+            create-patch -from "$base" -to "$AFTER" -repo . -out "main-$AFTER.patch"
+          echo "created=true" >> "$GITHUB_OUTPUT"
+      - name: Publish the patch with a short retention
+        if: steps.patch.outputs.created == 'true'
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: main-patch-${{ github.sha }}
+          path: main-${{ github.sha }}.patch
+          if-no-files-found: error
+          # A per-push build input for the dist pipeline, not a durable release.
+          retention-days: 1


### PR DESCRIPTION
## What

Adds `.github/workflows/patch.yml`. On a push to `main`, it runs the **release-management CLI** — the closed-source tool built and published as a private container image from `gradionhq/margince-constellation` — against this repo's checkout to create the incremental patch for the push, then publishes it as a build artifact.

- **Source**: this repo (the product code the patch describes).
- **Range**: `github.event.before` → `github.sha` — exactly what the push added to `main`. Manual dispatch falls back to `HEAD~1..HEAD`; a branch-creation/force-push (all-zeros `before`) no-ops.
- **Tool**: `ghcr.io/gradionhq/margince-constellation/release-management:latest`, run via `docker run` (image ENTRYPOINT is the CLI). `safe.directory` is injected through git's env config so the CLI's git subprocess trusts the runner-owned mount.
- **Publish**: `actions/upload-artifact` (pinned `v5.0.0`, matching `sbom.yml`).
- **Retention**: `retention-days: 1` — a per-push build input for the dist pipeline, not a durable release.

## Required before this works

The image is a **private** package under `margince-constellation`, so the pull can't use the default `GITHUB_TOKEN`. Add a repo/org secret **`GHCR_PULL_TOKEN`** — a PAT with `read:packages` for constellation's registry (or grant that package read access to this repo and switch the login to `GITHUB_TOKEN`).

## Note on validation

The `patch` job is guarded to `main` pushes, so it does not execute on this PR — only YAML/wiring is validated here. It first runs on the merge to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
On each push to `main`, this workflow runs the release-management CLI (`ghcr.io/gradionhq/margince-constellation/release-management:latest`) to create the incremental `before..after` patch and uploads it as a 1-day artifact. Branch creation/force-push no-ops; manual dispatch falls back to `HEAD~1..HEAD`.

- **Migration**
  - Add secret `GHCR_PULL_TOKEN` (PAT with `read:packages`) to pull the private image; or grant the package read access and use `GITHUB_TOKEN`.

<sup>Written for commit 12e3973c802617e078e1c66dc89f519024cda6e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated incremental patch release generation for changes merged into the main branch.
  * Patch packages can also be created on demand when needed.

* **Chores**
  * Improved release artifact handling, including secure publishing and temporary artifact storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->