### PR TITLE
chore(renovate): automerge every green update, not just Go non-majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,6 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
-permissions:
-  contents: read
-
 # One live run per ref: a new push to the same branch/PR cancels the stale
 # run instead of queueing behind it. Runs on main are never cancelled — a
 # merge must not kill the in-flight check of the previous merge.
@@ -51,6 +48,8 @@ jobs:
     name: changes
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       backend: ${{ steps.filter.outputs.backend }}
       frontend: ${{ steps.filter.outputs.frontend }}
@@ -100,6 +99,8 @@ jobs:
     name: dco
     if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
@@ -122,6 +123,8 @@ jobs:
     needs: [changes]
     if: needs.changes.outputs.backend == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
@@ -210,6 +213,8 @@ jobs:
     needs: [changes]
     if: needs.changes.outputs.backend == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
@@ -265,6 +270,8 @@ jobs:
     needs: [deterministic-gates, changes]
     if: needs.changes.outputs.backend == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
@@ -284,6 +291,8 @@ jobs:
     # CRAFT-FIX/CRAFT-DISPUTE marker in any file fails the merge.
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
@@ -315,6 +324,8 @@ jobs:
     needs: [changes]
     if: needs.changes.outputs.backend == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       # A red shard must not cancel its siblings: one CI run should report
       # every failing test, not the first shard to trip.
@@ -368,6 +379,8 @@ jobs:
     needs: [changes]
     if: needs.changes.outputs.backend == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
@@ -405,6 +418,8 @@ jobs:
       && needs.changes.outputs.backend == 'true'
       && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
@@ -449,6 +464,8 @@ jobs:
     needs: [changes]
     if: needs.changes.outputs.docker == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       # A broken web image must not hide whether api/worker still build.
       fail-fast: false
@@ -480,6 +497,8 @@ jobs:
       && needs.changes.outputs.docker == 'true'
       && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: .
@@ -495,6 +514,8 @@ jobs:
     needs: [changes]
     if: needs.changes.outputs.backend == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
@@ -548,6 +569,8 @@ jobs:
       && (needs.extension-reference.result == 'success' || needs.extension-reference.result == 'skipped')
       && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: .
@@ -600,6 +623,8 @@ jobs:
     needs: [changes]
     if: needs.changes.outputs.e2e == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: .
@@ -677,6 +702,8 @@ jobs:
     needs: [changes]
     if: needs.changes.outputs.frontend == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: .
@@ -726,6 +753,8 @@ jobs:
     needs: [changes, frontend]
     if: needs.changes.outputs.frontend == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -445,7 +445,7 @@ jobs:
   # required check; a build the deploy pipeline would reject fails the merge
   # here instead.
   docker-image:
-    name: docker image (${{ matrix.image }})
+    name: docker image (${{ matrix.role }})
     needs: [changes]
     if: needs.changes.outputs.docker == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
@@ -453,7 +453,9 @@ jobs:
       # A broken web image must not hide whether api/worker still build.
       fail-fast: false
       matrix:
-        image: [api, web, worker]
+        # `role`, not `image`: the check-image-pins gate key-anchors every
+        # `image:` in a workflow as a container reference to digest-check.
+        role: [api, web, worker]
     defaults:
       run:
         working-directory: .
@@ -462,7 +464,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Build the image
-        run: docker build -f Dockerfile.${{ matrix.image }} .
+        run: docker build -f Dockerfile.${{ matrix.role }} .
 
   vuln:
     name: govulncheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -441,9 +441,9 @@ jobs:
   # deploy tooling — no other job builds them, so without this gate a FROM
   # bump (Renovate's dockerfile manager auto-merges when green) or a stage
   # restructure would ship untested: the change matches no other classifier
-  # scope, every meaningful job skips, and the PR looks green. Each leg is a
-  # required check; a build the deploy pipeline would reject fails the merge
-  # here instead.
+  # scope, every meaningful job skips, and the PR looks green. The
+  # `docker-images` fan-in below is the required check; a build the deploy
+  # pipeline would reject fails the merge here instead.
   docker-image:
     name: docker image (${{ matrix.role }})
     needs: [changes]
@@ -465,6 +465,30 @@ jobs:
           persist-credentials: false
       - name: Build the image
         run: docker build -f Dockerfile.${{ matrix.role }} .
+
+  # The fan-in — the single required "docker images" context. Static-named
+  # because a path-skipped matrix job reports ONE check run under its
+  # unexpanded name ("docker image (${{ matrix.role }})"), so the expanded
+  # leg names can never be required contexts. Same shape as the integration
+  # fan-in: it must RUN and FAIL when a leg fails — `needs` alone would leave
+  # it skipped, and a skipped required check counts as passing.
+  docker-images:
+    name: docker images (api + web + worker)
+    needs: [changes, docker-image]
+    if: >-
+      !cancelled()
+      && needs.changes.outputs.docker == 'true'
+      && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: .
+    steps:
+      - name: Every image built
+        env:
+          BUILD_RESULT: ${{ needs.docker-image.result }}
+        run: |
+          [ "$BUILD_RESULT" = "success" ] || { echo "docker image builds: $BUILD_RESULT"; exit 1; }
 
   vuln:
     name: govulncheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
   #   frontend = frontend/ + backend/api (the contract drives FE types) —
   #              gates the frontend lane + UAT
   #   e2e      = backend/ + frontend/ + infra — gates the full-stack live-boot
+  #   docker   = the root Dockerfile.* + .dockerignore — gates the image builds
   changes:
     name: changes
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
@@ -54,6 +55,7 @@ jobs:
       backend: ${{ steps.filter.outputs.backend }}
       frontend: ${{ steps.filter.outputs.frontend }}
       e2e: ${{ steps.filter.outputs.e2e }}
+      docker: ${{ steps.filter.outputs.docker }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
@@ -87,6 +89,9 @@ jobs:
               - 'extensions/**'
               - 'fixtures/**'
               - 'composition/**'
+            docker:
+              - 'Dockerfile.*'
+              - '.dockerignore'
 
   # Every commit in a PR carries a Developer Certificate of Origin sign-off.
   # PR-only: the direct-to-main workflow signs off at push time, and history
@@ -431,6 +436,33 @@ jobs:
           path: backend/coverage.out
           if-no-files-found: ignore
           retention-days: 1
+
+  # The root Dockerfiles (api, web, worker) are consumed only by downstream
+  # deploy tooling — no other job builds them, so without this gate a FROM
+  # bump (Renovate's dockerfile manager auto-merges when green) or a stage
+  # restructure would ship untested: the change matches no other classifier
+  # scope, every meaningful job skips, and the PR looks green. Each leg is a
+  # required check; a build the deploy pipeline would reject fails the merge
+  # here instead.
+  docker-image:
+    name: docker image (${{ matrix.image }})
+    needs: [changes]
+    if: needs.changes.outputs.docker == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+    runs-on: ubuntu-latest
+    strategy:
+      # A broken web image must not hide whether api/worker still build.
+      fail-fast: false
+      matrix:
+        image: [api, web, worker]
+    defaults:
+      run:
+        working-directory: .
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+      - name: Build the image
+        run: docker build -f Dockerfile.${{ matrix.image }} .
 
   vuln:
     name: govulncheck

--- a/infra/ci-pipeline.md
+++ b/infra/ci-pipeline.md
@@ -26,7 +26,7 @@ previous merge.
 ## Run only the checks a change can affect
 
 The first job, **`changes`**, classifies the diff (dorny/paths-filter,
-SHA-pinned) into three scopes; every downstream job gates on the relevant
+SHA-pinned) into four scopes; every downstream job gates on the relevant
 output. A required job skipped this way still counts as passing.
 
 | Scope | Paths | Gates |
@@ -56,7 +56,7 @@ changes ──┬─> deterministic-gates ──> craftsmanship
           ├─> vuln                                                     │
           ├─> frontend ──> uat                                         │
           ├─> live-boot                                                │
-          ├─> docker-image (×3: api, web, worker)                      │
+          ├─> docker-image (×3: api, web, worker) ─> docker-images     │
           v                                                            v
         deterministic-gates + integration + frontend ──────> sonarcloud
   dco  (PR-only, independent)
@@ -91,6 +91,7 @@ one required check.
 | `uat` | `make frontend-e2e`: the AC-`<screen>`-N screen-acceptance criteria as named Playwright tests + axe WCAG 2.2 AA + the 390px no-horizontal-scroll sweep + the PERF-1 record-open budget. Mocks the API at the network edge, so it is self-contained |
 | `live-boot` | The README quickstart run literally: compose up → migrate → api → `seed-dev` → `verify-boot`. Keeps the API-driven seed and the boot proof honest — the integration shards never boot the api or run the seed script, so those would rot invisibly without this job |
 | `docker image (api\|web\|worker)` | `docker build` of the root Dockerfiles, which only downstream deploy tooling otherwise consumes. Without it a `FROM` bump or stage restructure matches no other classifier scope — every meaningful job skips and the PR looks green — which matters doubly now that Renovate auto-merges green dependency PRs, `dockerfile` manager included |
+| `docker images (api + web + worker)` | The fan-in — and the required check. A path-skipped matrix job reports one check run under its **unexpanded** name, so the leg names can't be required contexts; this static-named job asserts every build leg succeeded (same shape as the `integration` fan-in: it must run and fail, not skip, when a leg fails) |
 | `sonarcloud` | The CI-based scan (below) |
 
 ## Coverage → SonarCloud

--- a/infra/ci-pipeline.md
+++ b/infra/ci-pipeline.md
@@ -34,6 +34,7 @@ output. A required job skipped this way still counts as passing.
 | `backend` | `backend/**`, `infra/**`, `go.work[.sum]`, `Makefile`, `scripts/**`, `.github/workflows/**`, `AGENTS.md`, `sonar-project.properties` | Go build/gate, craftsmanship, integration, vuln |
 | `frontend` | `frontend/**`, `backend/api/**` (the contract drives FE types) | frontend lane, UAT |
 | `e2e` | `backend/**`, `frontend/**`, `infra/**` | full-stack live-boot |
+| `docker` | root `Dockerfile.*`, `.dockerignore` | the three image builds |
 
 Consequences:
 
@@ -55,6 +56,7 @@ changes ──┬─> deterministic-gates ──> craftsmanship
           ├─> vuln                                                     │
           ├─> frontend ──> uat                                         │
           ├─> live-boot                                                │
+          ├─> docker-image (×3: api, web, worker)                      │
           v                                                            v
         deterministic-gates + integration + frontend ──────> sonarcloud
   dco  (PR-only, independent)
@@ -88,6 +90,7 @@ one required check.
 | `frontend` | `make frontend-check` (biome + vitest + tsc + Vite build) + a Storybook catalog build (stories must compile & register). Emits `fe-coverage` (lcov) |
 | `uat` | `make frontend-e2e`: the AC-`<screen>`-N screen-acceptance criteria as named Playwright tests + axe WCAG 2.2 AA + the 390px no-horizontal-scroll sweep + the PERF-1 record-open budget. Mocks the API at the network edge, so it is self-contained |
 | `live-boot` | The README quickstart run literally: compose up → migrate → api → `seed-dev` → `verify-boot`. Keeps the API-driven seed and the boot proof honest — the integration shards never boot the api or run the seed script, so those would rot invisibly without this job |
+| `docker image (api\|web\|worker)` | `docker build` of the root Dockerfiles, which only downstream deploy tooling otherwise consumes. Without it a `FROM` bump or stage restructure matches no other classifier scope — every meaningful job skips and the PR looks green — which matters doubly now that Renovate auto-merges green dependency PRs, `dockerfile` manager included |
 | `sonarcloud` | The CI-based scan (below) |
 
 ## Coverage → SonarCloud
@@ -122,7 +125,7 @@ Wiring details:
   pushes).
 - `persist-credentials: false` on the checkouts of the jobs that execute
   PR-authored code (the `integration` shards, unit-coverage pass and fan-in,
-  `live-boot`, `frontend`, `uat`) — so a
+  `live-boot`, `frontend`, `uat`, the `docker image` builds) — so a
   malicious PR running `make test-integration` / `make frontend-e2e` can't read
   the persisted `GITHUB_TOKEN`. The diff-scoped gate jobs
   (`deterministic-gates`, `craftsmanship`, `craft-residue`) keep the token on

--- a/renovate.json
+++ b/renovate.json
@@ -21,11 +21,6 @@
       "matchManagers": ["gomod"],
       "matchDepTypes": ["golang"],
       "enabled": false
-    },
-    {
-      "description": "No CI job builds the root Dockerfiles, so a FROM bump skips every meaningful gate (gradionhq/margince-poc-v1#400) — keep these human-merged until an image-build gate exists",
-      "matchManagers": ["dockerfile"],
-      "automerge": false
     }
   ],
   "vulnerabilityAlerts": {

--- a/renovate.json
+++ b/renovate.json
@@ -8,14 +8,14 @@
   "postUpdateOptions": ["gomodTidy"],
   "prConcurrentLimit": 5,
   "platformAutomerge": true,
+  "automerge": true,
   "minimumReleaseAge": "7 days",
   "internalChecksFilter": "strict",
   "packageRules": [
     {
       "matchManagers": ["gomod"],
       "matchUpdateTypes": ["patch", "minor"],
-      "groupName": "go dependencies (non-major)",
-      "automerge": true
+      "groupName": "go dependencies (non-major)"
     },
     {
       "matchManagers": ["gomod"],

--- a/renovate.json
+++ b/renovate.json
@@ -21,6 +21,11 @@
       "matchManagers": ["gomod"],
       "matchDepTypes": ["golang"],
       "enabled": false
+    },
+    {
+      "description": "No CI job builds the root Dockerfiles, so a FROM bump skips every meaningful gate (gradionhq/margince-poc-v1#400) — keep these human-merged until an image-build gate exists",
+      "matchManagers": ["dockerfile"],
+      "automerge": false
     }
   ],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
## What

1. Enables Renovate automerge for all package managers and update types by moving `automerge: true` to the top level of `renovate.json`. Previously only the gomod patch/minor group auto-merged; npm, GitHub Actions, and Docker updates sat waiting for a manual merge even when fully green.
2. Adds the CI gate that makes that safe for Docker updates: a `docker image (api|web|worker)` matrix job that `docker build`s the root Dockerfiles whenever `Dockerfile.*` / `.dockerignore` change (new `docker` classifier scope). Until now no job built these images, so a `FROM` bump matched no classifier scope and would have auto-merged with every meaningful gate skipped (caught by cubic review on this PR). All three images verified building locally.

Closes #400

## Why it's safe

Automerge only fires through GitHub auto-merge (`platformAutomerge`), which still requires every required check on `main` to pass plus resolved conversations. The 7-day `minimumReleaseAge` and `internalChecksFilter: strict` stability window are unchanged, so nothing merges before it has aged and gone green.

Follow-up after merge: add the three `docker image (…)` contexts to branch protection's required checks (required is what makes the gate binding for auto-merge; it must land on `main` first so open PRs aren't blocked on a check their heads can't produce).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI now detects Docker-related changes and independently builds the API, web, and worker images.
  * Docker image build failures are reported separately for clearer troubleshooting.
  * Dependency update automation can now merge eligible updates automatically.

* **Documentation**
  * Updated CI documentation to describe Docker change detection, image builds, and related security practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->