### PR TITLE
feat(craft): give test files their own size ceilings (160 func / 1000 file)

### DIFF
--- a/cli/craft/static/checks.go
+++ b/cli/craft/static/checks.go
@@ -189,18 +189,28 @@ func todoWithoutRef(fc *fileContext, _ Config) []Finding {
 	return out
 }
 
-// largeFile flags a file past the architecture/11 §3 size smell threshold.
+// largeFile flags a file past the architecture/11 §3 size smell threshold;
+// test files use the relaxed Config.MaxTestFileLines ceiling.
 func largeFile(fc *fileContext, cfg Config) []Finding {
-	if fc.lineN <= cfg.MaxFileLines {
+	max := cfg.MaxFileLines
+	if fc.isTest {
+		max = cfg.MaxTestFileLines
+	}
+	if fc.lineN <= max {
 		return nil
 	}
 	return []Finding{newFinding("large-file", Major, fc.path, 1,
-		"file is %d lines (> %d) — split it by concept", fc.lineN, cfg.MaxFileLines)}
+		"file is %d lines (> %d) — split it by concept", fc.lineN, max)}
 }
 
 // longFunc flags a function whose body exceeds the line ceiling — the
-// god-function / arrow-code smell.
+// god-function / arrow-code smell. Test files use the relaxed
+// Config.MaxTestFuncLines ceiling.
 func longFunc(fc *fileContext, cfg Config) []Finding {
+	max := cfg.MaxFuncLines
+	if fc.isTest {
+		max = cfg.MaxTestFuncLines
+	}
 	var out []Finding
 	for _, d := range fc.file.Decls {
 		fn, ok := d.(*ast.FuncDecl)
@@ -208,9 +218,9 @@ func longFunc(fc *fileContext, cfg Config) []Finding {
 			continue
 		}
 		span := fc.line(fn.Body.Rbrace) - fc.line(fn.Body.Lbrace) - 1
-		if span > cfg.MaxFuncLines {
+		if span > max {
 			out = append(out, newFinding("long-func", Major, fc.path, fc.line(fn.Pos()),
-				"%s is %d body lines (> %d) — extract helpers", fn.Name.Name, span, cfg.MaxFuncLines))
+				"%s is %d body lines (> %d) — extract helpers", fn.Name.Name, span, max))
 		}
 	}
 	return out

--- a/cli/craft/static/runner.go
+++ b/cli/craft/static/runner.go
@@ -18,10 +18,16 @@ import (
 // filled with the defaults in withDefaults, so callers can set only what they
 // care about.
 type Config struct {
-	MaxFileLines int    // largeFile threshold (0 → default 500)
-	MaxFuncLines int    // longFunc threshold (0 → default 80)
-	DomainMarker string // path substring marking a domain module (default "internal/modules/")
-	Strict       bool   // when true, MAJOR findings also block the merge
+	MaxFileLines int // largeFile threshold (0 → default 500)
+	MaxFuncLines int // longFunc threshold (0 → default 80)
+	// Test files get their own, higher size ceilings: a long scenario test
+	// that sets up, acts, and asserts in one honest sequence is not the
+	// god-function smell the prod thresholds hunt — but a cap remains so a
+	// suite still splits once it stops being navigable.
+	MaxTestFileLines int    // largeFile threshold for *_test.go (0 → default 1000)
+	MaxTestFuncLines int    // longFunc threshold for *_test.go (0 → default 160)
+	DomainMarker     string // path substring marking a domain module (default "internal/modules/")
+	Strict           bool   // when true, MAJOR findings also block the merge
 }
 
 func (c Config) withDefaults() Config {
@@ -30,6 +36,12 @@ func (c Config) withDefaults() Config {
 	}
 	if c.MaxFuncLines == 0 {
 		c.MaxFuncLines = 80
+	}
+	if c.MaxTestFileLines == 0 {
+		c.MaxTestFileLines = 1000
+	}
+	if c.MaxTestFuncLines == 0 {
+		c.MaxTestFuncLines = 160
 	}
 	if c.DomainMarker == "" {
 		c.DomainMarker = "internal/modules/"

--- a/cli/craft/static/static_test.go
+++ b/cli/craft/static/static_test.go
@@ -3,7 +3,10 @@
 
 package static
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // lintSource parses one in-memory file under the given name and returns its
 // findings — the name drives the _test.go / domain-path flags, so a case can
@@ -146,6 +149,44 @@ func TestVerdict_onlyBlockerBlocks(t *testing.T) {
 	}
 	if v := verdict(f, true); v != "BLOCK" {
 		t.Fatalf("verdict -strict with MAJOR = %q, want BLOCK", v)
+	}
+}
+
+// sizeSrc returns a package with one function whose body is n lines.
+func sizeSrc(n int) string {
+	var b strings.Builder
+	b.WriteString("package p\n\nvar x int\n\nfunc run() {\n")
+	for i := 0; i < n; i++ {
+		b.WriteString("\tx++\n")
+	}
+	b.WriteString("}\n")
+	return b.String()
+}
+
+func TestLongFunc_testFilesGetTheRelaxedCeiling(t *testing.T) {
+	src := sizeSrc(120) // over the 80 prod ceiling, under the 160 test one
+	if got := counts(lintSource(t, "p.go", src), "long-func"); got != 1 {
+		t.Fatalf("prod file at 120 body lines: long-func = %d, want 1", got)
+	}
+	if got := counts(lintSource(t, "p_test.go", src), "long-func"); got != 0 {
+		t.Fatalf("test file at 120 body lines: long-func = %d, want 0", got)
+	}
+	if got := counts(lintSource(t, "p_test.go", sizeSrc(170)), "long-func"); got != 1 {
+		t.Fatalf("test file at 170 body lines: long-func = %d, want 1", got)
+	}
+}
+
+func TestLargeFile_testFilesGetTheRelaxedCeiling(t *testing.T) {
+	src := "package p\n" + strings.Repeat("// filler\n", 600)
+	if got := counts(lintSource(t, "p.go", src), "large-file"); got != 1 {
+		t.Fatalf("prod file at 600 lines: large-file = %d, want 1", got)
+	}
+	if got := counts(lintSource(t, "p_test.go", src), "large-file"); got != 0 {
+		t.Fatalf("test file at 600 lines: large-file = %d, want 0", got)
+	}
+	src = "package p\n" + strings.Repeat("// filler\n", 1100)
+	if got := counts(lintSource(t, "p_test.go", src), "large-file"); got != 1 {
+		t.Fatalf("test file at 1100 lines: large-file = %d, want 1", got)
 	}
 }
 

--- a/cli/craft/version/gate-version.json
+++ b/cli/craft/version/gate-version.json
@@ -1,6 +1,6 @@
 {
   "_comment": "The pinned gate identity. prompt_version, code_version and model_id are pinned here; rubric_version comes from cli/craft/rubric/rubric.json and exemplar_set_version from cli/craft/version/exemplars.json. Every verdict stamps the composed gate_version, so any commit's review is reproducible and auditable (architecture/17 \u00a71). code_version pins the gate's own source (bumped on every cli/craft code change, so a verdict names the exact gate revision that produced it). Bumping any field is an explicit, version-controlled promotion (B-EP11.8b), never a live edit of a running gate.",
   "prompt_version": "1",
-  "code_version": "3",
+  "code_version": "4",
   "model_id": "claude-opus-4-8"
 }


### PR DESCRIPTION
## What

The static craftsmanship gate's size checks (`long-func`, `large-file`) now apply relaxed ceilings to `*_test.go` files: **160 body lines / 1000 file lines** (prod stays 80/500). New `Config.MaxTestFuncLines` / `Config.MaxTestFileLines` fields with defaults; `code_version` bumped 3→4 per the gate-identity contract.

## Why

Groundwork for flipping `craft static --strict` on (MAJOR findings hard-block). Of the 170-finding MAJOR backlog, 105 are size findings in test files — long-but-honest scenario suites, median 98 body lines. A strict gate must only report findings a human would act on, so tests get an explicit, still-capped ceiling: the pathological tail (a 277-line test func, 3 files >1000 lines) stays flagged and will be refactored in a follow-up PR series (naked-any, boolean-trap, prod long-funcs, test outliers), after which strict mode lands.

## Testing

- New `TestLongFunc_testFilesGetTheRelaxedCeiling` / `TestLargeFile_testFilesGetTheRelaxedCeiling` (fail-first TDD).
- `go test ./...` in cli/craft green; `make check-backend` green.
- Full-backend sweep: 170 → 72 findings, all remaining ones actionable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Relaxed size ceilings for Go test files in the static craftsmanship gate: 160 lines per function and 1000 lines per file (prod stays 80/500). This cuts noisy MAJOR findings (170 → 72) to prep for `craft static --strict`.

- **New Features**
  - Added `Config.MaxTestFuncLines` (160) and `Config.MaxTestFileLines` (1000) with defaults; checks pick test vs prod thresholds automatically.
  - Bumped gate `code_version` to 4 and added unit tests covering the relaxed ceilings.

<sup>Written for commit a4c9723814ce94c7855bcdf4fba47173e3ee110e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

