### PR TITLE
refactor: name the boolean pairs, and make the forget-cached test able to fail

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -212,7 +212,7 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 	// neither switch (and, with it, their own Router, cache and budget).
 	//nolint:contextcheck // boot-time wiring: the model path outlives any request context
 	modelPath, aiState, assistantProfile, routingVersion, err := resolveModelPath(
-		cfg.routingPath, cfg.fakeBrain, pool, deployCfg.AI.CapturePayloads, logger)
+		modelPathSpecFrom(cfg, deployCfg), pool, logger)
 	if err != nil {
 		return err
 	}

--- a/backend/cmd/api/modelwiring.go
+++ b/backend/cmd/api/modelwiring.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/compose"
 	"github.com/gradionhq/margince/backend/internal/modules/ai"
 	"github.com/gradionhq/margince/backend/internal/modules/search"
+	"github.com/gradionhq/margince/backend/internal/platform/deployconfig"
 	"github.com/gradionhq/margince/backend/internal/platform/jobs"
 )
 
@@ -37,10 +38,29 @@ import (
 // callers that cache model-written content keyed on it.
 func routingVersionOf(cfg ai.RoutingConfig) string { return cfg.RoutingVersion() }
 
-func resolveModelPath(routingPath string, fakeBrain bool, pool *pgxpool.Pool, capturePayloads bool, log *slog.Logger) (*compose.ModelPath, string, ai.PublicProfile, string, error) {
+// modelPathSpec names the boot knobs resolveModelPath switches on, so a call
+// site labels each flag instead of passing anonymous booleans.
+type modelPathSpec struct {
+	routingPath     string
+	fakeBrain       bool
+	capturePayloads bool
+}
+
+// modelPathSpecFrom gathers the model-path knobs from where each is declared:
+// the routing choice from the process flags, the capture posture from the
+// deployment config.
+func modelPathSpecFrom(cfg apiConfig, deployCfg deployconfig.Config) modelPathSpec {
+	return modelPathSpec{
+		routingPath:     cfg.routingPath,
+		fakeBrain:       cfg.fakeBrain,
+		capturePayloads: deployCfg.AI.CapturePayloads,
+	}
+}
+
+func resolveModelPath(spec modelPathSpec, pool *pgxpool.Pool, log *slog.Logger) (*compose.ModelPath, string, ai.PublicProfile, string, error) {
 	switch {
-	case routingPath != "":
-		cfg, err := ai.LoadRoutingFile(routingPath)
+	case spec.routingPath != "":
+		cfg, err := ai.LoadRoutingFile(spec.routingPath)
 		if err != nil {
 			return nil, "", ai.PublicProfile{}, "", err
 		}
@@ -51,15 +71,15 @@ func resolveModelPath(routingPath string, fakeBrain bool, pool *pgxpool.Pool, ca
 		for _, w := range cfg.UnboundLadderWarnings() {
 			log.Warn(w)
 		}
-		modelPath, err := compose.NewModelPath(cfg, pool, capturePayloads, log)
+		modelPath, err := compose.NewModelPath(cfg, pool, spec.capturePayloads, log)
 		if err != nil {
 			return nil, "", ai.PublicProfile{}, "", err
 		}
 		return &modelPath, compose.AIStateConfigured,
 			ai.NewPublicProfile(compose.AIStateConfigured, cfg), routingVersionOf(cfg), nil
-	case fakeBrain:
+	case spec.fakeBrain:
 		cfg := ai.FakeRoutingConfig()
-		modelPath, err := compose.NewModelPath(cfg, pool, capturePayloads, log)
+		modelPath, err := compose.NewModelPath(cfg, pool, spec.capturePayloads, log)
 		if err != nil {
 			return nil, "", ai.PublicProfile{}, "", err
 		}

--- a/backend/cmd/api/modelwiring_test.go
+++ b/backend/cmd/api/modelwiring_test.go
@@ -32,7 +32,7 @@ func discardLogger() *slog.Logger {
 // case: no declared routing file and no --ai-fake resolves to a nil
 // path and the unconfigured state, never a silent default provider.
 func TestResolveModelPathNeitherFlagIsUnconfigured(t *testing.T) {
-	modelPath, state, profile, _, err := resolveModelPath("", false, nil, false, discardLogger())
+	modelPath, state, profile, _, err := resolveModelPath(modelPathSpec{}, nil, discardLogger())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -53,7 +53,7 @@ func TestResolveModelPathNeitherFlagIsUnconfigured(t *testing.T) {
 // uses) rather than bypassing the Router — every lane must be non-nil,
 // or a consumer wired against it would nil-panic on first use.
 func TestResolveModelPathFakeArmBindsEveryLane(t *testing.T) {
-	modelPath, state, profile, _, err := resolveModelPath("", true, nil, false, discardLogger())
+	modelPath, state, profile, _, err := resolveModelPath(modelPathSpec{fakeBrain: true}, nil, discardLogger())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -95,7 +95,7 @@ func TestResolveModelPathFakeArmBindsEveryLane(t *testing.T) {
 // test needs no external credential or network access.
 func TestResolveModelPathRoutingFileArmBindsEveryLane(t *testing.T) {
 	path := writeFakeRoutingFile(t)
-	modelPath, state, profile, _, err := resolveModelPath(path, false, nil, false, discardLogger())
+	modelPath, state, profile, _, err := resolveModelPath(modelPathSpec{routingPath: path}, nil, discardLogger())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -117,7 +117,7 @@ func TestResolveModelPathRoutingFileArmBindsEveryLane(t *testing.T) {
 // --ai-routing path fails the boot rather than silently falling back to
 // unconfigured or fake.
 func TestResolveModelPathRoutingFileArmSurfacesLoadError(t *testing.T) {
-	_, _, _, _, err := resolveModelPath(filepath.Join(t.TempDir(), "does-not-exist.yaml"), false, nil, false, discardLogger())
+	_, _, _, _, err := resolveModelPath(modelPathSpec{routingPath: filepath.Join(t.TempDir(), "does-not-exist.yaml")}, nil, discardLogger())
 	if err == nil {
 		t.Fatal("expected an error for a missing routing file, got nil")
 	}
@@ -130,7 +130,7 @@ func TestColdStartOptionsRespectsResolvedPath(t *testing.T) {
 	if got := coldStartOptions(nil, ""); got != nil {
 		t.Fatalf("coldStartOptions(nil) = %d options, want 0", len(got))
 	}
-	modelPath, _, _, _, err := resolveModelPath("", true, nil, false, discardLogger())
+	modelPath, _, _, _, err := resolveModelPath(modelPathSpec{fakeBrain: true}, nil, discardLogger())
 	if err != nil {
 		t.Fatalf("resolveModelPath: %v", err)
 	}
@@ -147,7 +147,7 @@ func TestOfferDraftOptionsRespectsResolvedPath(t *testing.T) {
 	if got := offerDraftOptions(nil, nil); got != nil {
 		t.Fatalf("offerDraftOptions(nil) = %d options, want 0", len(got))
 	}
-	modelPath, _, _, _, err := resolveModelPath("", true, nil, false, discardLogger())
+	modelPath, _, _, _, err := resolveModelPath(modelPathSpec{fakeBrain: true}, nil, discardLogger())
 	if err != nil {
 		t.Fatalf("resolveModelPath: %v", err)
 	}

--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -33,7 +33,6 @@ import (
 	"github.com/redis/go-redis/v9"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
-	"github.com/gradionhq/margince/backend/internal/modules/ai"
 	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/modules/people"
 	"github.com/gradionhq/margince/backend/internal/modules/search"
@@ -417,58 +416,6 @@ func startJobRunner(ctx context.Context, pool *pgxpool.Pool, rdb *redis.Client, 
 			logger.Warn("stopping job runner", "err", err)
 		}
 	}, nil
-}
-
-// modelPathSpec names the boot knobs selectModelPath switches on, so a call
-// site labels each flag instead of passing anonymous booleans.
-type modelPathSpec struct {
-	routingPath     string
-	fake            bool
-	capturePayloads bool
-}
-
-// selectModelPath resolves the model path: a routing config for real
-// deployments, the offline fake behind an explicit dev flag, or the
-// zero path — the runner and the embed lane simply don't start without
-// a declared model; nothing is picked silently.
-func selectModelPath(spec modelPathSpec, pool *pgxpool.Pool, log *slog.Logger) (compose.ModelPath, map[string]map[string]bool, error) {
-	switch {
-	case spec.routingPath != "":
-		cfg, err := ai.LoadRoutingFile(spec.routingPath)
-		if err != nil {
-			return compose.ModelPath{}, nil, err
-		}
-		// A task whose whole fallback ladder has no bound tier is not a
-		// boot error (a deployment may legitimately not run every
-		// workload), but it must be loud: log it now, not discover it
-		// from a refused call.
-		for _, w := range cfg.UnboundLadderWarnings() {
-			log.Warn(w)
-		}
-		// The bound model ids travel with the path because they describe the
-		// SAME binding: the cost refresh narrows a provider catalog to the
-		// models this deployment actually calls.
-		return modelPathWithBoundModels(cfg, pool, spec.capturePayloads, log)
-	case spec.fake:
-		// A real ModelPath over ai.FakeRoutingConfig() rather than
-		// FakeModelPath's direct client wiring: the worker always has a
-		// pool, so --ai-fake safely rides the real Router (tiering, the
-		// budget guardrail, metering, call tracing) with only the
-		// provider swapped for the deterministic fake. capturePayloads
-		// still names the deployment's own posture — cmd/api's
-		// resolveModelPath honors it on this same arm, and two process
-		// roles must never disagree on whether content capture is on.
-		return modelPathWithBoundModels(ai.FakeRoutingConfig(), pool, spec.capturePayloads, log)
-	default:
-		return compose.ModelPath{}, nil, nil
-	}
-}
-
-// modelPathWithBoundModels assembles the path and reports which models the SAME
-// binding names, so the two can never describe different routing configs.
-func modelPathWithBoundModels(cfg ai.RoutingConfig, pool *pgxpool.Pool, capturePayloads bool, log *slog.Logger) (compose.ModelPath, map[string]map[string]bool, error) {
-	path, err := compose.NewModelPath(cfg, pool, capturePayloads, log)
-	return path, cfg.BoundModelIDsByProvider(), err
 }
 
 // runResumeSubscriber consumes cg:overnight-agent: approval decisions

--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -131,7 +131,11 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 	}()
 
 	//nolint:contextcheck // boot-time wiring: the model path outlives any request context (cmd/api resolves the same path under the same waiver)
-	modelPath, boundModels, err := selectModelPath(cfg.routingPath, cfg.fakeBrain, deployCfg.AI.CapturePayloads, pool, logger)
+	modelPath, boundModels, err := selectModelPath(modelPathSpec{
+		routingPath:     cfg.routingPath,
+		fake:            cfg.fakeBrain,
+		capturePayloads: deployCfg.AI.CapturePayloads,
+	}, pool, logger)
 	if err != nil {
 		return err
 	}
@@ -415,14 +419,22 @@ func startJobRunner(ctx context.Context, pool *pgxpool.Pool, rdb *redis.Client, 
 	}, nil
 }
 
+// modelPathSpec names the boot knobs selectModelPath switches on, so a call
+// site labels each flag instead of passing anonymous booleans.
+type modelPathSpec struct {
+	routingPath     string
+	fake            bool
+	capturePayloads bool
+}
+
 // selectModelPath resolves the model path: a routing config for real
 // deployments, the offline fake behind an explicit dev flag, or the
 // zero path — the runner and the embed lane simply don't start without
 // a declared model; nothing is picked silently.
-func selectModelPath(routingPath string, fake, capturePayloads bool, pool *pgxpool.Pool, log *slog.Logger) (compose.ModelPath, map[string]map[string]bool, error) {
+func selectModelPath(spec modelPathSpec, pool *pgxpool.Pool, log *slog.Logger) (compose.ModelPath, map[string]map[string]bool, error) {
 	switch {
-	case routingPath != "":
-		cfg, err := ai.LoadRoutingFile(routingPath)
+	case spec.routingPath != "":
+		cfg, err := ai.LoadRoutingFile(spec.routingPath)
 		if err != nil {
 			return compose.ModelPath{}, nil, err
 		}
@@ -436,8 +448,8 @@ func selectModelPath(routingPath string, fake, capturePayloads bool, pool *pgxpo
 		// The bound model ids travel with the path because they describe the
 		// SAME binding: the cost refresh narrows a provider catalog to the
 		// models this deployment actually calls.
-		return modelPathWithBoundModels(cfg, pool, capturePayloads, log)
-	case fake:
+		return modelPathWithBoundModels(cfg, pool, spec.capturePayloads, log)
+	case spec.fake:
 		// A real ModelPath over ai.FakeRoutingConfig() rather than
 		// FakeModelPath's direct client wiring: the worker always has a
 		// pool, so --ai-fake safely rides the real Router (tiering, the
@@ -446,7 +458,7 @@ func selectModelPath(routingPath string, fake, capturePayloads bool, pool *pgxpo
 		// still names the deployment's own posture — cmd/api's
 		// resolveModelPath honors it on this same arm, and two process
 		// roles must never disagree on whether content capture is on.
-		return modelPathWithBoundModels(ai.FakeRoutingConfig(), pool, capturePayloads, log)
+		return modelPathWithBoundModels(ai.FakeRoutingConfig(), pool, spec.capturePayloads, log)
 	default:
 		return compose.ModelPath{}, nil, nil
 	}

--- a/backend/cmd/worker/modelwiring.go
+++ b/backend/cmd/worker/modelwiring.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package main
+
+import (
+	"log/slog"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/modules/ai"
+)
+
+// modelPathSpec names the boot knobs selectModelPath switches on, so a call
+// site labels each flag instead of passing anonymous booleans.
+type modelPathSpec struct {
+	routingPath     string
+	fake            bool
+	capturePayloads bool
+}
+
+// selectModelPath resolves the model path: a routing config for real
+// deployments, the offline fake behind an explicit dev flag, or the
+// zero path — the runner and the embed lane simply don't start without
+// a declared model; nothing is picked silently.
+func selectModelPath(spec modelPathSpec, pool *pgxpool.Pool, log *slog.Logger) (compose.ModelPath, map[string]map[string]bool, error) {
+	switch {
+	case spec.routingPath != "":
+		cfg, err := ai.LoadRoutingFile(spec.routingPath)
+		if err != nil {
+			return compose.ModelPath{}, nil, err
+		}
+		// A task whose whole fallback ladder has no bound tier is not a
+		// boot error (a deployment may legitimately not run every
+		// workload), but it must be loud: log it now, not discover it
+		// from a refused call.
+		for _, w := range cfg.UnboundLadderWarnings() {
+			log.Warn(w)
+		}
+		// The bound model ids travel with the path because they describe the
+		// SAME binding: the cost refresh narrows a provider catalog to the
+		// models this deployment actually calls.
+		return modelPathWithBoundModels(cfg, pool, spec.capturePayloads, log)
+	case spec.fake:
+		// A real ModelPath over ai.FakeRoutingConfig() rather than
+		// FakeModelPath's direct client wiring: the worker always has a
+		// pool, so --ai-fake safely rides the real Router (tiering, the
+		// budget guardrail, metering, call tracing) with only the
+		// provider swapped for the deterministic fake. capturePayloads
+		// still names the deployment's own posture — cmd/api's
+		// resolveModelPath honors it on this same arm, and two process
+		// roles must never disagree on whether content capture is on.
+		return modelPathWithBoundModels(ai.FakeRoutingConfig(), pool, spec.capturePayloads, log)
+	default:
+		return compose.ModelPath{}, nil, nil
+	}
+}
+
+// modelPathWithBoundModels assembles the path and reports which models the SAME
+// binding names, so the two can never describe different routing configs.
+func modelPathWithBoundModels(cfg ai.RoutingConfig, pool *pgxpool.Pool, capturePayloads bool, log *slog.Logger) (compose.ModelPath, map[string]map[string]bool, error) {
+	path, err := compose.NewModelPath(cfg, pool, capturePayloads, log)
+	return path, cfg.BoundModelIDsByProvider(), err
+}

--- a/backend/internal/compose/dispatcherwritemode_test.go
+++ b/backend/internal/compose/dispatcherwritemode_test.go
@@ -14,25 +14,36 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
 )
 
-// cachedModeDispatcher builds a Dispatcher whose cache already answers
-// `cached` for wsID while the workspace ROW (what queryMode reads) answers
-// `stored`. Passing cached=false with stored=true reproduces the second api
-// replica in the connect race: the process that committed the flip
-// invalidated only its OWN cache, so this one still holds the pre-flip mode.
+// sorMode names the workspace's system-of-record answer at one layer of the
+// dispatcher — the cache entry or the workspace row: modeOverlay routes to
+// the mirror, modeNative to the native modules.
+type sorMode bool
+
+const (
+	modeNative  sorMode = false
+	modeOverlay sorMode = true
+)
+
+// cachedModeDispatcher builds a Dispatcher whose cache answers `cached` for
+// wsID while the workspace ROW (what queryMode reads) says overlay — the
+// post-flip truth every case here starts from. Passing cached=modeNative
+// reproduces the second api replica in the connect race: the process that
+// committed the flip invalidated only its OWN cache, so this one still holds
+// the pre-flip mode.
 //
 // queryMode counts its calls, so a test can assert not just where a verb
 // routed but whether the mode was actually re-read or served from the entry
 // seeded below. The native provider is left nil: a verb that wrongly routes
 // native panics rather than quietly passing.
-func cachedModeDispatcher(wsID ids.UUID, cached, stored bool) (*Dispatcher, *int) {
+func cachedModeDispatcher(wsID ids.UUID, cached sorMode) (*Dispatcher, *int) {
 	calls := 0
 	now := dispatcherFixedNow
 	d := newDispatcherWithClock(nil, overlay.NewProvider(nil, nil), nil, func() time.Time { return now })
 	d.queryMode = func(context.Context, ids.UUID) (bool, error) {
 		calls++
-		return stored, nil
+		return bool(modeOverlay), nil
 	}
-	d.cache[wsID] = sorModeCacheEntry{overlay: cached, expiresAt: now.Add(time.Hour)}
+	d.cache[wsID] = sorModeCacheEntry{overlay: bool(cached), expiresAt: now.Add(time.Hour)}
 	return d, &calls
 }
 
@@ -52,7 +63,7 @@ func cachedModeDispatcher(wsID ids.UUID, cached, stored bool) (*Dispatcher, *int
 // panic rather than quietly pass — the assertion is that none of them do.
 func TestDispatcherWriteVerbsIgnoreAStaleCachedMode(t *testing.T) {
 	wsID := ids.NewV7()
-	d, calls := cachedModeDispatcher(wsID, false /* cached: native */, true /* stored: overlay */)
+	d, calls := cachedModeDispatcher(wsID, modeNative)
 	ctx := principal.WithWorkspaceID(context.Background(), wsID)
 	ref := datasource.EntityRef{Type: datasource.EntityPerson, ID: ids.NewV7()}
 
@@ -104,7 +115,7 @@ func TestDispatcherWriteVerbsIgnoreAStaleCachedMode(t *testing.T) {
 // write, and it makes the doc above false.
 func TestOverlayWriteShadowResolvesTheModeOnce(t *testing.T) {
 	wsID := ids.NewV7()
-	d, calls := cachedModeDispatcher(wsID, false /* cached: native */, true /* stored: overlay */)
+	d, calls := cachedModeDispatcher(wsID, modeNative)
 	ctx := principal.WithWorkspaceID(context.Background(), wsID)
 	ref := datasource.EntityRef{Type: datasource.EntityPerson, ID: ids.NewV7()}
 
@@ -135,7 +146,7 @@ func TestOverlayWriteShadowResolvesTheModeOnce(t *testing.T) {
 // not a divergent write.
 func TestDispatcherReadVerbsStillUseTheCachedMode(t *testing.T) {
 	wsID := ids.NewV7()
-	d, calls := cachedModeDispatcher(wsID, true /* cached: overlay */, true /* stored: overlay */)
+	d, calls := cachedModeDispatcher(wsID, modeOverlay)
 	ctx := principal.WithWorkspaceID(context.Background(), wsID)
 
 	if _, err := d.Read(ctx, datasource.EntityRef{Type: datasource.EntityPerson, ID: ids.NewV7()}); err == nil {

--- a/backend/internal/compose/embedreindextransport.go
+++ b/backend/internal/compose/embedreindextransport.go
@@ -235,13 +235,9 @@ func embedReindexDriftError(previewedIdentity *string, configured string) error 
 	}
 }
 
-// embedReindexNotNeededError answers the 409 that stops a no-op confirm: no
-// pending work, no reindex already in flight, and the caller didn't pass
-// force.
-func embedReindexNotNeededError(needed bool, jobStatus string, force bool) error {
-	if needed || jobStatus == reembeddingStatus || force {
-		return nil
-	}
+// errEmbedReindexNotNeeded is the 409 that stops a no-op confirm — the store
+// is current, nothing is in flight, and the caller didn't pass force.
+func errEmbedReindexNotNeeded() error {
 	return &httperr.DetailedError{
 		Status: http.StatusConflict,
 		Code:   "reindex_not_needed",
@@ -286,8 +282,10 @@ func (e *embedReindexEngine) confirm(w http.ResponseWriter, r *http.Request) {
 		httperr.Write(w, r, err)
 		return
 	}
-	if notNeededErr := embedReindexNotNeededError(needed, jobStatus, force); notNeededErr != nil {
-		httperr.Write(w, r, notNeededErr)
+	// No pending work, no reindex already in flight, and no force: the
+	// confirm is a no-op and refuses rather than rebuilding a current store.
+	if !needed && jobStatus != reembeddingStatus && !force {
+		httperr.Write(w, r, errEmbedReindexNotNeeded())
 		return
 	}
 

--- a/backend/internal/compose/nativeonlytools_test.go
+++ b/backend/internal/compose/nativeonlytools_test.go
@@ -256,7 +256,7 @@ func TestSlippingListerServesNativeMode(t *testing.T) {
 // not — which drives the real SQL.
 func TestSlippingGuardRefusesOnAStaleNativeCache(t *testing.T) {
 	wsID := ids.NewV7()
-	d, calls := cachedModeDispatcher(wsID, false /* cached: native */, true /* stored: overlay */)
+	d, calls := cachedModeDispatcher(wsID, modeNative)
 	ctx := principal.WithWorkspaceID(context.Background(), wsID)
 
 	ranNative := false

--- a/backend/internal/modules/ai/structured_forget_test.go
+++ b/backend/internal/modules/ai/structured_forget_test.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/model"
 )
 
@@ -51,10 +52,32 @@ func TestSecondAttemptFailureAlsoEvictsItsCachedAnswer(t *testing.T) {
 	}
 }
 
+// Outside a workspace the helper must return without evicting anything: a key
+// it cannot scope belongs to no tenant, and guessing one would drop another
+// workspace's valid answer.
 func TestForgetCachedToleratesAMissingWorkspace(t *testing.T) {
 	r := testRouter(map[Tier]model.Client{TierCheapCloud: NewFakeClient().Script("x")},
 		&memMeter{}, DefaultMonthlyTokens, ProfileEUHosted)
-	// Outside a workspace there is no cache row to evict; the helper must
-	// simply return rather than derive a key it cannot scope.
-	r.forgetCached(context.Background(), TaskColdStart, structuredReq())
+	// Two entries stand in for what an unscoped eviction could reach: a real
+	// tenant's answer, and the one at the key a workspace-less call would
+	// derive if it computed a key at all.
+	for _, seeded := range []struct {
+		name string
+		wsID ids.WorkspaceID
+	}{
+		{"a real tenant's entry", ids.From[ids.WorkspaceKind](ids.NewV7())},
+		{"the entry at the unscoped key", ids.WorkspaceID{}},
+	} {
+		key, err := cacheKey(seeded.wsID, TaskColdStart, structuredReq())
+		if err != nil {
+			t.Fatalf("deriving the cache key for %s: %v", seeded.name, err)
+		}
+		r.cache.put(key, seeded.wsID, model.Response{Text: `{"ok":true}`}, TierCheapCloud)
+
+		r.forgetCached(context.Background(), TaskColdStart, structuredReq())
+
+		if _, _, ok := r.cache.get(key, seeded.wsID); !ok {
+			t.Errorf("a workspace-less eviction dropped %s; it must derive no key at all", seeded.name)
+		}
+	}
 }

--- a/backend/internal/modules/identity/onboarding.go
+++ b/backend/internal/modules/identity/onboarding.go
@@ -406,28 +406,20 @@ func auditOnboardingState(
 	if err != nil {
 		return err
 	}
-	return storekit.EmitEvent(ctx, tx, auditID, after.ID, onboardingStateChangedPayload(
-		userID, after.Path, after.Step, after.Version,
-		after.VoiceSkipped, after.ConnectSkipped, after.CompletedAt != nil,
-	))
+	return storekit.EmitEvent(ctx, tx, auditID, after.ID, onboardingStateChangedPayload(userID, after))
 }
 
 // onboardingStateChangedPayload builds onboarding.state_changed's typed
-// payload.
-func onboardingStateChangedPayload(
-	userID ids.UUID,
-	path, step string,
-	version int64,
-	voiceSkipped, connectSkipped, completed bool,
-) crmcontracts.PublicEventOnboardingStateChanged {
+// payload from the state row the transaction just wrote.
+func onboardingStateChangedPayload(userID ids.UUID, state OnboardingState) crmcontracts.PublicEventOnboardingStateChanged {
 	return crmcontracts.PublicEventOnboardingStateChanged{
 		UserId:         openapi_types.UUID(userID),
-		Path:           path,
-		Step:           step,
-		Version:        version,
-		VoiceSkipped:   voiceSkipped,
-		ConnectSkipped: connectSkipped,
-		Completed:      completed,
+		Path:           state.Path,
+		Step:           state.Step,
+		Version:        state.Version,
+		VoiceSkipped:   state.VoiceSkipped,
+		ConnectSkipped: state.ConnectSkipped,
+		Completed:      state.CompletedAt != nil,
 	}
 }
 

--- a/backend/internal/modules/identity/payload_test.go
+++ b/backend/internal/modules/identity/payload_test.go
@@ -230,7 +230,9 @@ func TestPassportRevokedPayload(t *testing.T) {
 }
 
 func TestOnboardingStateChangedPayload(t *testing.T) {
-	payload := onboardingStateChangedPayload(payloadTestUserID.UUID, "website", "connect", 3, true, false, false)
+	payload := onboardingStateChangedPayload(payloadTestUserID.UUID, OnboardingState{
+		Path: "website", Step: "connect", Version: 3, VoiceSkipped: true,
+	})
 
 	if !reflect.DeepEqual(payload.EventType(), "onboarding.state_changed") {
 		t.Errorf("got %v, want %v", payload.EventType(), "onboarding.state_changed")


### PR DESCRIPTION
## What

Closes the last 6 non-size MAJOR findings from `craft static`: the 5 `boolean-trap` signatures and the 1 `assertion-free-test`.

**Boolean traps** — each signature now takes what it actually models:
- `cmd/api` + `cmd/worker`: a `modelPathSpec` struct; the api's is built by `modelPathSpecFrom(cfg, deployCfg)` in the wiring file, so each knob is named where it's declared.
- `compose` dispatcher-mode test helper: a named `sorMode` type (`modeNative`/`modeOverlay`) — and the `stored` parameter is gone, since every case starts from the same post-flip row (unparam agreed).
- `identity`: `onboardingStateChangedPayload` takes the `OnboardingState` row instead of six unpacked fields.
- `compose` reindex guard: `embedReindexNotNeededError(needed, jobStatus, force)` becomes `errEmbedReindexNotNeeded()` with the condition inline at its one call site, which reads better than a three-bool predicate.

**Assertion-free test** — `TestForgetCachedToleratesAMissingWorkspace` called `forgetCached` and asserted nothing; it could only fail by panicking. It now seeds the result cache both at a real tenant's key and at the key a workspace-less call would derive, and proves both survive.

## Testing

- Mutation-checked the rewritten test: removing the `if !ok { return }` guard in `forgetCached` makes it fail ("a workspace-less eviction dropped the entry at the unscoped key"); restoring it passes. That's the property the old test claimed.
- `make check-backend` green (incl. golangci strict: the worker's `selectModelPath` carries the same documented `contextcheck` waiver the api role already had — `NewModelPath` takes no context, so there is none to propagate).
- Sweep: 0 boolean-trap, 0 assertion-free-test. Also kept `cmd/api/main.go` under the 500-line ceiling that my first call-site draft had tipped over.

Part of the craft strict-mode campaign (#401, #402). Remaining: prod long-func refactors, test outliers, then the `--strict` flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced anonymous booleans with named specs to eliminate boolean traps, and made the cache-eviction test actually fail on regressions. Also aligned worker boot wiring with `cmd/api` for clarity.

- **Refactors**
  - `cmd/api` and `cmd/worker`: added `modelPathSpec`; `resolveModelPath`/`selectModelPath` now take the spec; moved worker model wiring to `modelwiring.go`.
  - `compose` dispatcher tests: introduced `sorMode` (`modeNative`/`modeOverlay`); removed the extra `stored` parameter and start from the post-flip state.
  - `identity`: `onboardingStateChangedPayload` now takes an `OnboardingState` instead of unpacked fields.
  - `compose` reindex guard: replaced `embedReindexNotNeededError(needed, jobStatus, force)` with an inline condition and `errEmbedReindexNotNeeded()`.

- **Bug Fixes**
  - `ai` cache eviction test: `TestForgetCachedToleratesAMissingWorkspace` now seeds cache entries (tenant and unscoped) and asserts neither is evicted, so it fails if the guard is removed.

<sup>Written for commit 08920789a41d212cadeb8dbe25e8d819e742501f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

