### PR TITLE
chore(sbom): pin the git revision in unreleased SBOM versions

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -42,8 +42,9 @@ jobs:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
-          # SBOM_VERSION reads `git describe --tags --exact-match` (else the short
-          # revision); resolving a release tag needs the tags and history.
+          # SBOM_VERSION is the release tag when HEAD is exactly on one (`git
+          # describe --tags --exact-match`), else the full git revision; resolving
+          # that tag needs the tags and history.
           fetch-depth: 0
       - name: Generate SBOMs
         run: make sbom

--- a/Makefile
+++ b/Makefile
@@ -324,11 +324,13 @@ COSIGN       ?= $(DOCKER_SBOM) -u $(shell id -u):$(shell id -g) -e HOME=/src/$(C
 # Scan a clean export of committed HEAD, so host state (node_modules, .env, IDE
 # files) never leaks into the SBOM and .gitignore stays the single authority.
 SBOM_SRC     := .tmp/sbom-src
-# Release tag when HEAD is exactly on one, else dev-<short-revision>. The dev-
-# prefix marks an unreleased build at a glance; --exact-match avoids git
-# describe's nearest-tag "-N-g<sha>" form leaking a non-release tag (e.g.
-# archive/*) into the version.
-SBOM_VERSION ?= $(shell git describe --tags --exact-match 2>/dev/null || echo "dev-$$(git rev-parse --short HEAD 2>/dev/null || echo unknown)")
+# A release build (HEAD exactly on a tag) reads as the tag alone — the tag maps
+# to one commit, so the revision is implicit. An unreleased build pins the full
+# git revision as dev-<revision> so a published pre-release SBOM is traceable to
+# its exact commit. --exact-match avoids git describe's nearest-tag "-N-g<sha>"
+# form leaking a non-release tag (e.g. archive/*) into a release version. The
+# revision travels inside each SBOM, so cosign's signature covers it.
+SBOM_VERSION ?= $(shell git describe --tags --exact-match 2>/dev/null || echo "dev-$$(git rev-parse HEAD 2>/dev/null || echo unknown)")
 SBOM_FILES   := $(SBOM_DIR)/margince.cdx.json $(SBOM_DIR)/margince.spdx221.json $(SBOM_DIR)/margince.spdx300.json
 
 ## sbom — generate the source-tree SBOMs (CycloneDX + SPDX 2.2.1 + SPDX 3.0)


### PR DESCRIPTION
## What

The SBOM `--source-version` (embedded in every generated and cosign-signed SBOM) now carries the **full git revision** for unreleased builds — `dev-<full-sha>` instead of the previous short sha — so a published pre-release SBOM is traceable to its exact commit.

Release builds (HEAD exactly on a tag) stay **tag-only**: the tag maps to a single commit, so the revision is implicit.

## Why

A published SBOM should pin the exact source it describes. For unreleased builds the short sha was ambiguous-adjacent; the full revision is the canonical identifier and travels inside the SBOM, so cosign's signature covers it.

## Changes

- `Makefile` — `SBOM_VERSION` uses `git rev-parse HEAD` (full) for the `dev-` fallback.
- `.github/workflows/sbom.yml` — comment updated to match; `fetch-depth: 0` unchanged (still needed for tag resolution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin SBOM `--source-version` to the full git revision for unreleased builds (`dev-<full-sha>`) so each pre-release SBOM is traceable to an exact commit. Release builds remain tag-only.

- **Refactors**
  - Makefile: `SBOM_VERSION` uses `git describe --tags --exact-match` or falls back to `dev-$(git rev-parse HEAD)`.
  - CI: updated SBOM workflow comment; keep `fetch-depth: 0` for tag resolution.

<sup>Written for commit 0e8c0874d1816a5c9802f8a1e16d67491645f599. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

