### PR TITLE
refactor(compose): break up the god-functions, split the two files that outgrew one concept

### DIFF
--- a/backend/internal/compose/aicert/scenariorender.go
+++ b/backend/internal/compose/aicert/scenariorender.go
@@ -90,6 +90,8 @@ func RenderScenario(sc Scenario) ([]byte, error) {
 // The default decoding would render a 19-digit id as 1.234567890123457e+18 and
 // an exact literal as its nearest double — silently changing the fixture on the
 // way to YAML, which is the one thing a round trip must not do.
+//
+//craft:ignore naked-any the return is a whole decoded JSON document — a fixture is free to be an object, an array or a bare scalar, so the shape is only known by inspecting it
 func decodePreservingNumbers(raw []byte) (any, error) {
 	dec := json.NewDecoder(bytes.NewReader(raw))
 	dec.UseNumber()
@@ -113,6 +115,8 @@ func decodePreservingNumbers(raw []byte) (any, error) {
 // types hold exactly; anything wider — a 20-digit id, a high-precision
 // decimal — would be silently approximated, which is the failure this whole
 // path exists to prevent.
+//
+//craft:ignore naked-any v is one node of a decoded JSON tree — mapping, sequence or scalar — and the type switch below IS what decides which; the rewritten node goes back into the same untyped slot it came from
 func exactNumbers(v any) any {
 	switch typed := v.(type) {
 	case map[string]any:
@@ -139,6 +143,8 @@ func exactNumbers(v any) any {
 // an !!int, and a decimal finer than float64 comes back rounded. Either way the
 // scenario that loads is not the scenario that was written — so RenderScenario
 // says so instead of emitting one that quietly differs.
+//
+//craft:ignore naked-any v walks the same decoded JSON tree exactNumbers produced, where every node is untyped until the switch reaches the numbers this check is about
 func representableNumbers(v any, path string) error {
 	switch typed := v.(type) {
 	case map[string]any:
@@ -200,6 +206,8 @@ type yamlNumber string
 // MarshalYAML tags the scalar so a reader parses it back as a number. The tag is
 // chosen from the lexeme rather than by converting: an integer literal too wide
 // for int64 is still an integer, and saying so costs nothing.
+//
+//craft:ignore naked-any the signature is fixed by yaml.v3's Marshaler interface; naming *yaml.Node here would stop implementing it
 func (n yamlNumber) MarshalYAML() (any, error) {
 	tag := "!!int"
 	if strings.ContainsAny(string(n), ".eE") {

--- a/backend/internal/compose/deepread.go
+++ b/backend/internal/compose/deepread.go
@@ -186,55 +186,13 @@ func (w *siteDeepReadWorker) run(ctx context.Context, args SiteDeepReadArgs) err
 		}
 		return fmt.Errorf("site deep read %s: begin: %w", args.SiteReadID, err)
 	}
-	// Before ANY spend: an operator who turned auto-enrich off gets no further
-	// crawling and no further model calls, including from work queued while it
-	// was on. Only the automatic lane is gated — a human who asked for a read
-	// is not governed by the automatic-enrichment setting.
-	// Everything past the claim runs as the requester the ROW names, so the
+	// Everything past the claim runs as the requester the ROW names — the
+	// dossier row is the authority on who asked, never the job payload — so the
 	// provenance on what this read writes is the row's answer too.
 	ctx = withClaimedRequester(ctx, claim.RequestedBy, args.SiteReadID)
 
-	// claim.RequestedBy, never args: the dossier row is the authority on who
-	// asked for this read, and the job payload is metadata that travelled
-	// beside it. Everything downstream that decides SPEND or AUTHORITY reads
-	// the row — a payload disagreeing with it must not buy a wider budget or
-	// skip a confirm-first proposal.
-	if isSystemRead(claim.RequestedBy) {
-		enabled, err := w.autoEnrichEnabled(ctx)
-		if err != nil {
-			// Recorded, not returned raw: the read is already claimed, so a
-			// bare error would leave it running until the reclaim window
-			// expires. Every other fault on this path records itself, and the
-			// sweep re-enqueues the org on its next pass.
-			return w.fail(ctx, args.SiteReadID,
-				fmt.Errorf("site deep read %s: reading the auto-enrich setting: %w", args.SiteReadID, err))
-		}
-		if !enabled {
-			// A triage read may not simply stop here. Its domain is a question
-			// somebody's mail already asked, and abandoning it would leave that
-			// question open forever — no organization for that domain, ever.
-			// Answering it from what the workspace already knows is the honest
-			// close, and it is what the operator's "don't crawl" actually means.
-			if isDomainTriageRequest(claim.RequestedBy) {
-				return w.triageWithoutLooking(ctx, args, claim)
-			}
-			return w.abandon(ctx, args.SiteReadID, "auto_enrich_disabled")
-		}
-	}
-	// The domain-triage lane runs before its subject exists: it decides whether
-	// an organization should be created at all, so it cannot share the path
-	// below, which assumes one to enrich. A role with no model path answers it
-	// the same way a disabled setting does, rather than failing a question the
-	// sweep would then re-ask forever.
-	if isDomainTriageRequest(claim.RequestedBy) {
-		if w.triageBrain == nil || w.extract.brain == nil {
-			return w.triageWithoutLooking(ctx, args, claim)
-		}
-		return w.runTriage(ctx, args, claim)
-	}
-	if w.extract.brain == nil {
-		return w.fail(ctx, args.SiteReadID,
-			errors.New("site deep read: worker has no model path — configure --ai-routing (or --ai-fake) on the worker role"))
+	if settled, err := w.routeClaimedRead(ctx, args, claim); settled || err != nil {
+		return err
 	}
 
 	if err := w.people.UpdateSiteReadProgress(ctx, args.SiteReadID, "crawling", nil); err != nil {
@@ -268,75 +226,62 @@ func (w *siteDeepReadWorker) run(ctx context.Context, args SiteDeepReadArgs) err
 	// dies outright.
 	w.resolveLogo(ctx, args, claim, crawl)
 
-	if deferred, deferErr := w.deferForBudget(ctx, args.SiteReadID, extraction.err); deferred {
-		return deferErr
-	}
-	mergedFields, legalConflict, legalDrops := applyLegalGate(extraction.fields, extraction.merged.entities, pageKindsOf(crawl.Pages), extraction.legalCensusIncomplete)
-	extraction.merged.entities = enrichLegalEntitiesFromProfile(extraction.merged.entities, mergedFields)
-	w.extract.reportDrops(ctx, laneLegal, legalDrops)
-	if legalConflict {
-		w.log.WarnContext(ctx, legalWarningMultipleEntities,
-			"read", args.SiteReadID.String(), "seed", claim.SeedURL)
-	}
-	factCount := len(mergedFields) + len(extraction.merged.facts)
-	if extraction.err != nil && factCount == 0 && len(extraction.merged.people) == 0 && len(extraction.merged.entities) == 0 {
-		// Every lane died before anything was evidenced: nothing honest
-		// to report but the failure itself.
-		return w.fail(ctx, args.SiteReadID, extraction.err)
-	}
+	return w.reportRead(ctx, args, claim, crawl, extraction)
+}
 
-	readPages := crawl.Pages
-	status := "done"
-	if crawl.Stopped != nil {
-		status = "partial"
-	}
-	if extraction.err != nil {
-		// Part of the fan-out died with evidence already in hand: what
-		// completed is the read, staged below like any other — a partial
-		// that keeps what was honestly read, never a failure that discards
-		// it. The terminal status makes returned-error retry churn
-		// pointless, so the cause is logged instead.
-		status = "partial"
-		w.log.ErrorContext(ctx, "site deep read degraded to partial: extraction failed in part",
-			"read", args.SiteReadID.String(), "err", extraction.err)
-	}
-
-	var proposalIDs []ids.UUID
-	if claim.OrganizationID != nil {
-		if isAutoEnrichRequest(claim.RequestedBy) {
-			// The auto-enrich lane applies the org's fields + facts directly
-			// (fill-empty, human-precedence) instead of staging a confirm-first
-			// proposal — the system chose to enrich this company, so there is no
-			// human to confirm. Site people still stage as leads (strangers stay
-			// staged, NEVER-8). Applied under the worker's PrincipalSystem ctx,
-			// which ApplyDeepReadTx's auth.Require accepts.
-			proposalIDs, err = w.autoApply(ctx, args, claim, mergedFields, extraction.merged.facts, extraction.merged.people)
-		} else {
-			proposalIDs, err = w.stageProposals(ctx, args.SiteReadID, claim, mergedFields, extraction.merged.facts, extraction.merged.people, len(readPages))
-		}
+// routeClaimedRead dispatches a claimed read to the lane that owns it, before
+// any spend: the disabled-auto-enrich close, the domain-triage lane (which
+// decides whether an organization should exist at all, so it cannot share the
+// enrichment path, which assumes one to enrich), or the honest failure of a
+// worker role with no model path. It reports whether it settled the read; not
+// settled is the ordinary enrichment read, which the caller crawls itself.
+func (w *siteDeepReadWorker) routeClaimedRead(ctx context.Context, args SiteDeepReadArgs, claim people.SiteReadClaim) (bool, error) {
+	// Before ANY spend: an operator who turned auto-enrich off gets no further
+	// crawling and no further model calls, including from work queued while it
+	// was on. Only the automatic lane is gated — a human who asked for a read
+	// is not governed by the automatic-enrichment setting.
+	//
+	// claim.RequestedBy, never args: the dossier row is the authority on who
+	// asked for this read, and the job payload is metadata that travelled
+	// beside it. Everything downstream that decides SPEND or AUTHORITY reads
+	// the row — a payload disagreeing with it must not buy a wider budget or
+	// skip a confirm-first proposal.
+	if isSystemRead(claim.RequestedBy) {
+		enabled, err := w.autoEnrichEnabled(ctx)
 		if err != nil {
-			return w.fail(ctx, args.SiteReadID, fmt.Errorf("site deep read %s: %w", args.SiteReadID, err))
+			// Recorded, not returned raw: the read is already claimed, so a
+			// bare error would leave it running until the reclaim window
+			// expires. Every other fault on this path records itself, and the
+			// sweep re-enqueues the org on its next pass.
+			return true, w.fail(ctx, args.SiteReadID,
+				fmt.Errorf("site deep read %s: reading the auto-enrich setting: %w", args.SiteReadID, err))
+		}
+		if !enabled {
+			// A triage read may not simply stop here. Its domain is a question
+			// somebody's mail already asked, and abandoning it would leave that
+			// question open forever — no organization for that domain, ever.
+			// Answering it from what the workspace already knows is the honest
+			// close, and it is what the operator's "don't crawl" actually means.
+			if isDomainTriageRequest(claim.RequestedBy) {
+				return true, w.triageWithoutLooking(ctx, args, claim)
+			}
+			return true, w.abandon(ctx, args.SiteReadID, "auto_enrich_disabled")
 		}
 	}
-	warnings := make([]string, 0, 2)
-	if legalConflict {
-		warnings = append(warnings, legalWarningMultipleEntities)
+	// A role with no model path answers a triage the same way a disabled
+	// setting does, rather than failing a question the sweep would then
+	// re-ask forever.
+	if isDomainTriageRequest(claim.RequestedBy) {
+		if w.triageBrain == nil || w.extract.brain == nil {
+			return true, w.triageWithoutLooking(ctx, args, claim)
+		}
+		return true, w.runTriage(ctx, args, claim)
 	}
-	if extraction.err != nil {
-		warnings = append(warnings, "Some pages could not be extracted; the grounded findings that completed are still available.")
+	if w.extract.brain == nil {
+		return true, w.fail(ctx, args.SiteReadID,
+			errors.New("site deep read: worker has no model path — configure --ai-routing (or --ai-fake) on the worker role"))
 	}
-	draftFields := deepReadFields(mergedFields)
-	draftPeople := siteReadPeople(extraction.merged.people)
-	draftEntities := siteReadLegalEntities(extraction.merged.entities)
-	proposalHash, err := siteReadProposalHash(draftFields, extraction.merged.facts, draftPeople, draftEntities)
-	if err != nil {
-		return w.fail(ctx, args.SiteReadID, fmt.Errorf("site deep read %s: hashing the draft: %w", args.SiteReadID, err))
-	}
-	// Zero surviving findings is an honest empty read — done, fact_count 0,
-	// no proposal — not an error: the site simply evidenced nothing.
-	return w.finish(ctx, args.SiteReadID, status, readPages, crawl, factCount, proposalIDs,
-		draftFields, extraction.merged.facts, draftPeople, draftEntities,
-		warnings, proposalHash)
+	return false, nil
 }
 
 func (w *siteDeepReadWorker) progressiveCallbacks(ctx context.Context, readID ids.UUID) (func(string, []crawlPage), func(pageFactsResult)) {

--- a/backend/internal/compose/deepreadreport.go
+++ b/backend/internal/compose/deepreadreport.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// What a finished deep read becomes: the legal-census gate over what the model
+// lanes evidenced, the findings that land (auto-enrich) or stage (confirm-first),
+// and the one terminal dossier write the SPA reads.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gradionhq/margince/backend/internal/modules/people"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// reportRead records the outcome of a crawl that succeeded. A read whose lanes
+// all died before evidencing anything has nothing honest to report but the
+// failure; everything else — down to zero surviving findings — is a read.
+func (w *siteDeepReadWorker) reportRead(ctx context.Context, args SiteDeepReadArgs, claim people.SiteReadClaim, crawl siteCrawl, extraction siteExtraction) error {
+	if deferred, deferErr := w.deferForBudget(ctx, args.SiteReadID, extraction.err); deferred {
+		return deferErr
+	}
+	mergedFields, legalConflict := w.gateLegalCensus(ctx, args, claim, crawl, &extraction)
+	factCount := len(mergedFields) + len(extraction.merged.facts)
+	if extraction.err != nil && factCount == 0 && len(extraction.merged.people) == 0 && len(extraction.merged.entities) == 0 {
+		// Every lane died before anything was evidenced: nothing honest
+		// to report but the failure itself.
+		return w.fail(ctx, args.SiteReadID, extraction.err)
+	}
+
+	readPages := crawl.Pages
+	status := w.dossierStatus(ctx, args.SiteReadID, crawl, extraction.err)
+
+	proposalIDs, err := w.landFindings(ctx, args, claim, mergedFields, extraction.merged, len(readPages))
+	if err != nil {
+		return w.fail(ctx, args.SiteReadID, fmt.Errorf("site deep read %s: %w", args.SiteReadID, err))
+	}
+	warnings := readWarnings(legalConflict, extraction.err)
+	draftFields := deepReadFields(mergedFields)
+	draftPeople := siteReadPeople(extraction.merged.people)
+	draftEntities := siteReadLegalEntities(extraction.merged.entities)
+	proposalHash, err := siteReadProposalHash(draftFields, extraction.merged.facts, draftPeople, draftEntities)
+	if err != nil {
+		return w.fail(ctx, args.SiteReadID, fmt.Errorf("site deep read %s: hashing the draft: %w", args.SiteReadID, err))
+	}
+	// Zero surviving findings is an honest empty read — done, fact_count 0,
+	// no proposal — not an error: the site simply evidenced nothing.
+	return w.finish(ctx, args.SiteReadID, status, readPages, crawl, factCount, proposalIDs,
+		draftFields, extraction.merged.facts, draftPeople, draftEntities,
+		warnings, proposalHash)
+}
+
+// gateLegalCensus runs the no-guess legal gate over the extraction: it answers
+// the profile fields that survived, folds those fields back into the census the
+// legal pages voted on, and reports what the gate dropped on the legal lane. A
+// multi-entity conflict is both logged and carried to the dossier as a warning,
+// because the read cannot decide which entity the company is.
+func (w *siteDeepReadWorker) gateLegalCensus(ctx context.Context, args SiteDeepReadArgs, claim people.SiteReadClaim, crawl siteCrawl, extraction *siteExtraction) ([]evidencedField, bool) {
+	mergedFields, legalConflict, legalDrops := applyLegalGate(extraction.fields, extraction.merged.entities, pageKindsOf(crawl.Pages), extraction.legalCensusIncomplete)
+	extraction.merged.entities = enrichLegalEntitiesFromProfile(extraction.merged.entities, mergedFields)
+	w.extract.reportDrops(ctx, laneLegal, legalDrops)
+	if legalConflict {
+		w.log.WarnContext(ctx, legalWarningMultipleEntities,
+			"read", args.SiteReadID.String(), "seed", claim.SeedURL)
+	}
+	return mergedFields, legalConflict
+}
+
+// dossierStatus is the terminal status of a read that evidenced something: a
+// crawl that stopped short of the site, or a fan-out that died in part, is
+// honestly partial rather than done.
+func (w *siteDeepReadWorker) dossierStatus(ctx context.Context, readID ids.UUID, crawl siteCrawl, extractErr error) string {
+	status := "done"
+	if crawl.Stopped != nil {
+		status = "partial"
+	}
+	if extractErr != nil {
+		// Part of the fan-out died with evidence already in hand: what
+		// completed is the read, staged like any other — a partial that keeps
+		// what was honestly read, never a failure that discards it. The
+		// terminal status makes returned-error retry churn pointless, so the
+		// cause is logged instead.
+		status = "partial"
+		w.log.ErrorContext(ctx, "site deep read degraded to partial: extraction failed in part",
+			"read", readID.String(), "err", extractErr)
+	}
+	return status
+}
+
+// landFindings puts the gated findings where the requesting lane says they
+// belong, and answers the proposal ids the dossier records. An onboarding draft
+// still unbound to an organization has nothing to land them against.
+func (w *siteDeepReadWorker) landFindings(ctx context.Context, args SiteDeepReadArgs, claim people.SiteReadClaim, mergedFields []evidencedField, merged pageFactsResult, pagesRead int) ([]ids.UUID, error) {
+	if claim.OrganizationID == nil {
+		return nil, nil
+	}
+	if isAutoEnrichRequest(claim.RequestedBy) {
+		// The auto-enrich lane applies the org's fields + facts directly
+		// (fill-empty, human-precedence) instead of staging a confirm-first
+		// proposal — the system chose to enrich this company, so there is no
+		// human to confirm. Site people still stage as leads (strangers stay
+		// staged, NEVER-8). Applied under the worker's PrincipalSystem ctx,
+		// which ApplyDeepReadTx's auth.Require accepts.
+		return w.autoApply(ctx, args, claim, mergedFields, merged.facts, merged.people)
+	}
+	return w.stageProposals(ctx, args.SiteReadID, claim, mergedFields, merged.facts, merged.people, pagesRead)
+}
+
+// readWarnings are the caveats the dossier shows a human: what this read could
+// not settle, so a confirmation is never made on an unstated assumption.
+func readWarnings(legalConflict bool, extractErr error) []string {
+	warnings := make([]string, 0, 2)
+	if legalConflict {
+		warnings = append(warnings, legalWarningMultipleEntities)
+	}
+	if extractErr != nil {
+		warnings = append(warnings, "Some pages could not be extracted; the grounded findings that completed are still available.")
+	}
+	return warnings
+}

--- a/backend/internal/compose/dispatch.go
+++ b/backend/internal/compose/dispatch.go
@@ -65,7 +65,7 @@ const (
 	aiCaptureQueue      = "ai_capture"
 	aiCaptureMaxWorkers = 2
 
-	// overlayReconcileQueue is serial. See the queue table in NewJobRunner
+	// overlayReconcileQueue is serial. See the queue table in jobRunnerQueues
 	// for why per-workspace parallelism is not what this phase is after.
 	overlayReconcileQueue = "overlay_reconcile"
 )

--- a/backend/internal/compose/flip.go
+++ b/backend/internal/compose/flip.go
@@ -243,29 +243,9 @@ func (f *flipRunner) Execute(ctx context.Context, req crmcontracts.OverlayFlipRe
 		return crmcontracts.OverlayFlipAccepted{}, err
 	}
 
-	operator, err := flipOperator(ctx)
+	rep, err := f.importMirrorEstate(ctx, run, mode, v.checks.Incumbent)
 	if err != nil {
 		return crmcontracts.OverlayFlipAccepted{}, err
-	}
-	source := mirrorFlipSource{ms: f.ms}
-	writers := newFlipWriters(f.pool, f.ms, v.checks.Incumbent).forRun(run.ID, operator)
-	assocs, err := source.Associations(ctx)
-	if err != nil {
-		return crmcontracts.OverlayFlipAccepted{}, err
-	}
-	writers.SetAssociations(assocs)
-
-	rep, err := migration.NewEngine(f.runs, writers).Run(ctx, run.ID, source)
-	if err != nil {
-		// The run record holds the failure + checkpoint: executing again
-		// resumes it. The mirror stays frozen — the estate must not
-		// drift between attempts. The cause is logged, not wrapped onto
-		// the wire: the engine's chain names internal call sites and can
-		// carry store sentinels that would remap the status.
-		f.log.Error("overlay flip: migration run failed", "run_id", run.ID.String(), "mode", string(mode), "err", err)
-		return crmcontracts.OverlayFlipAccepted{}, fmt.Errorf(
-			"the flip's migration run did not complete; it is resumable — re-run the flip to continue from its checkpoint (run %s): %w",
-			run.ID, apperrors.ErrConflict)
 	}
 
 	if err := f.svc.CompleteFlip(ctx, run.ID, string(mode)); err != nil {
@@ -283,6 +263,38 @@ func (f *flipRunner) Execute(ctx context.Context, req crmcontracts.OverlayFlipRe
 		out.EmergencyDisclosure = emergencyDisclosure(v.checks.LastSyncedAt)
 	}
 	return out, nil
+}
+
+// importMirrorEstate writes the sealed mirror into the native tables under
+// this run: the writers attribute every imported record to the run and to the
+// human who ordered the cutover, and the association map is loaded before the
+// first object so a record's links land with it rather than a pass later.
+func (f *flipRunner) importMirrorEstate(ctx context.Context, run migration.Run, mode crmcontracts.OverlayFlipRequestMode, incumbent string) (migration.Report, error) {
+	operator, err := flipOperator(ctx)
+	if err != nil {
+		return migration.Report{}, err
+	}
+	source := mirrorFlipSource{ms: f.ms}
+	writers := newFlipWriters(f.pool, f.ms, incumbent).forRun(run.ID, operator)
+	assocs, err := source.Associations(ctx)
+	if err != nil {
+		return migration.Report{}, err
+	}
+	writers.SetAssociations(assocs)
+
+	rep, err := migration.NewEngine(f.runs, writers).Run(ctx, run.ID, source)
+	if err != nil {
+		// The run record holds the failure + checkpoint: executing again
+		// resumes it. The mirror stays frozen — the estate must not
+		// drift between attempts. The cause is logged, not wrapped onto
+		// the wire: the engine's chain names internal call sites and can
+		// carry store sentinels that would remap the status.
+		f.log.Error("overlay flip: migration run failed", "run_id", run.ID.String(), "mode", string(mode), "err", err)
+		return migration.Report{}, fmt.Errorf(
+			"the flip's migration run did not complete; it is resumable — re-run the flip to continue from its checkpoint (run %s): %w",
+			run.ID, apperrors.ErrConflict)
+	}
+	return rep, nil
 }
 
 // parseFlipRequest is the confirm-first gate on the request itself: the

--- a/backend/internal/compose/idempotency.go
+++ b/backend/internal/compose/idempotency.go
@@ -18,6 +18,7 @@ package compose
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
@@ -161,87 +162,98 @@ func claimKey(r *http.Request, pool *pgxpool.Pool, principalID, key, endpoint, d
 	outcome := claimFresh
 	var stored storedResponse
 	err := database.WithWorkspaceTx(r.Context(), pool, func(tx pgx.Tx) error {
-		claim := func() (bool, error) {
-			tag, err := tx.Exec(r.Context(), `
-				INSERT INTO idempotency_key (workspace_id, principal_id, key, endpoint, request_digest)
-				VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3, $4)
-				ON CONFLICT (workspace_id, principal_id, key, endpoint) DO NOTHING`,
-				principalID, key, endpoint, digest)
-			if err != nil {
-				return false, err
-			}
-			return tag.RowsAffected() == 1, nil
-		}
-		claimed, err := claim()
+		claimed, err := insertClaim(r.Context(), tx, principalID, key, endpoint, digest)
 		if err != nil {
 			return err
 		}
 		if claimed {
 			return nil // fresh claim
 		}
-		var storedDigest, contentType string
-		var status *int
-		var respBody *string
-		var expired bool
-		err = tx.QueryRow(r.Context(), `
-			SELECT request_digest, response_status, response_body, response_content_type,
-			       created_at < now() - make_interval(secs => $4)
-			FROM idempotency_key
-			WHERE principal_id = $1 AND key = $2 AND endpoint = $3
-			FOR UPDATE`,
-			principalID, key, endpoint, replayWindow.Seconds()).Scan(&storedDigest, &status, &respBody, &contentType, &expired)
-		if errors.Is(err, pgx.ErrNoRows) {
-			// The retention sweep removed the row between the INSERT above and
-			// this read. It was past the replay window, so it was protecting
-			// nothing — but simply erroring here would degrade to executing
-			// with NO claim recorded, and two concurrent retries of one key
-			// would then both execute. Claim it again instead.
-			claimed, err = claim()
-			if err != nil {
-				return err
-			}
-			if claimed {
-				return nil
-			}
-			// Someone re-created it in the same instant; the honest answer is
-			// that this attempt is still in flight elsewhere.
-			outcome = claimInProgress
-			return nil
-		}
-		if err != nil {
-			return err
-		}
-		if expired {
-			// Past the retention window the key means nothing anymore:
-			// re-claim it in place for this attempt.
-			_, err := tx.Exec(r.Context(), `
-				UPDATE idempotency_key
-				SET request_digest = $4, response_status = NULL, response_body = NULL,
-				    response_content_type = DEFAULT, created_at = now()
-				WHERE principal_id = $1 AND key = $2 AND endpoint = $3`,
-				principalID, key, endpoint, digest)
-			return err
-		}
-		switch {
-		case storedDigest != digest:
-			outcome = claimMismatch
-		case status == nil:
-			outcome = claimInProgress
-		default:
-			outcome = claimReplay
-			stored.status = *status
-			stored.contentType = contentType
-			if respBody != nil {
-				stored.body = *respBody
-			}
-		}
-		return nil
+		outcome, stored, err = resolveExistingClaim(r.Context(), tx, principalID, key, endpoint, digest)
+		return err
 	})
 	if err != nil {
 		slog.ErrorContext(r.Context(), "idempotency claim failed; executing without replay protection", "err", err)
 		return claimFresh, storedResponse{}
 	}
 	return outcome, stored
+}
+
+// insertClaim writes the claim row insert-first and reports whether THIS
+// attempt is the one that claimed the key: false means a row for the same
+// (workspace, principal, key, endpoint) already exists.
+func insertClaim(ctx context.Context, tx pgx.Tx, principalID, key, endpoint, digest string) (bool, error) {
+	tag, err := tx.Exec(ctx, `
+		INSERT INTO idempotency_key (workspace_id, principal_id, key, endpoint, request_digest)
+		VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, $1, $2, $3, $4)
+		ON CONFLICT (workspace_id, principal_id, key, endpoint) DO NOTHING`,
+		principalID, key, endpoint, digest)
+	if err != nil {
+		return false, err
+	}
+	return tag.RowsAffected() == 1, nil
+}
+
+// resolveExistingClaim decides what an already-claimed key means for this
+// attempt: a replay of the recorded response, a first attempt still in flight,
+// the same key reused for a different body, or — past the replay window — a
+// re-claim in place. The row is read FOR UPDATE inside the caller's
+// transaction, so two concurrent attempts under one key cannot both execute.
+func resolveExistingClaim(ctx context.Context, tx pgx.Tx, principalID, key, endpoint, digest string) (claimOutcome, storedResponse, error) {
+	var storedDigest, contentType string
+	var status *int
+	var respBody *string
+	var expired bool
+	err := tx.QueryRow(ctx, `
+		SELECT request_digest, response_status, response_body, response_content_type,
+		       created_at < now() - make_interval(secs => $4)
+		FROM idempotency_key
+		WHERE principal_id = $1 AND key = $2 AND endpoint = $3
+		FOR UPDATE`,
+		principalID, key, endpoint, replayWindow.Seconds()).Scan(&storedDigest, &status, &respBody, &contentType, &expired)
+	if errors.Is(err, pgx.ErrNoRows) {
+		// The retention sweep removed the row between the INSERT above and
+		// this read. It was past the replay window, so it was protecting
+		// nothing — but simply erroring here would degrade to executing
+		// with NO claim recorded, and two concurrent retries of one key
+		// would then both execute. Claim it again instead.
+		claimed, err := insertClaim(ctx, tx, principalID, key, endpoint, digest)
+		if err != nil {
+			return claimFresh, storedResponse{}, err
+		}
+		if claimed {
+			return claimFresh, storedResponse{}, nil
+		}
+		// Someone re-created it in the same instant; the honest answer is
+		// that this attempt is still in flight elsewhere.
+		return claimInProgress, storedResponse{}, nil
+	}
+	if err != nil {
+		return claimFresh, storedResponse{}, err
+	}
+	if expired {
+		// Past the retention window the key means nothing anymore:
+		// re-claim it in place for this attempt.
+		_, err := tx.Exec(ctx, `
+			UPDATE idempotency_key
+			SET request_digest = $4, response_status = NULL, response_body = NULL,
+			    response_content_type = DEFAULT, created_at = now()
+			WHERE principal_id = $1 AND key = $2 AND endpoint = $3`,
+			principalID, key, endpoint, digest)
+		return claimFresh, storedResponse{}, err
+	}
+	switch {
+	case storedDigest != digest:
+		return claimMismatch, storedResponse{}, nil
+	case status == nil:
+		return claimInProgress, storedResponse{}, nil
+	default:
+		stored := storedResponse{status: *status, contentType: contentType}
+		if respBody != nil {
+			stored.body = *respBody
+		}
+		return claimReplay, stored, nil
+	}
 }
 
 // settleClaim records a 2xx outcome for replay and releases the claim on

--- a/backend/internal/compose/jobs.go
+++ b/backend/internal/compose/jobs.go
@@ -256,10 +256,12 @@ func NewJobRunner(pool *pgxpool.Pool, log *slog.Logger, cfg JobRunnerConfig) (*j
 	}, log)
 }
 
-// registerJobWorkers registers the workers this process role serves whatever
-// the deployment configured; the config-gated ones live in addConfiguredJobs
-// (jobs_configured.go). Registering a worker is not scheduling it — what gets
-// scheduled is unconditionalSweeps below.
+// registerJobWorkers registers the workers this process role can serve. Most
+// register whatever the deployment configured — a worker with no work simply
+// never runs — so only the send lane, which needs a registry to dispatch
+// through at all, is gated here; the lanes whose SCHEDULE is deployment-shaped
+// are addConfiguredJobs' (jobs_configured.go). Registering a worker is not
+// scheduling it: NewJobRunner assembles the periodic list.
 func registerJobWorkers(workers *river.Workers, pool *pgxpool.Pool, cfg JobRunnerConfig, log *slog.Logger) {
 	// The deep read is not periodic — the api enqueues one job per started
 	// dossier; the worker role only needs the worker registered.

--- a/backend/internal/compose/jobs.go
+++ b/backend/internal/compose/jobs.go
@@ -228,6 +228,39 @@ type JobRunnerConfig struct {
 // the Gmail poll.
 func NewJobRunner(pool *pgxpool.Pool, log *slog.Logger, cfg JobRunnerConfig) (*jobs.Runner, error) {
 	workers := river.NewWorkers()
+	registerJobWorkers(workers, pool, cfg, log)
+
+	periodic := unconditionalSweeps(cfg)
+	// The ADR-0078 relationship-graph passes register themselves, so this
+	// wiring stays one line as that surface grows (jobs_graph.go).
+	periodic = append(periodic, addGraphJobs(workers, pool, log)...)
+	// The ADR-0069 §3a embed drift sweep registers itself the same way
+	// (embeddriftsweep.go) — worker + tick only when an embed lane is bound.
+	periodic = append(periodic, addEmbedDriftSweepJob(workers, pool, cfg.Embedder, log)...)
+	// The GDPR retention pass registers itself the same way
+	// (jobs_privacyretention.go).
+	periodic = append(periodic, addPrivacyRetentionJobs(workers, pool, cfg, log)...)
+	// The outbound-webhook retry sweep likewise (jobs_webhookretry.go).
+	periodic = append(periodic, addWebhookRetryJobs(workers, pool, cfg)...)
+	// The Surface-B agent scheduler likewise (jobs_agentscheduler.go).
+	periodic = append(periodic, addAgentSchedulerJobs(workers, pool, cfg)...)
+	periodic = append(periodic, addSignalJobs(workers, pool, cfg, log)...)
+
+	// Everything that exists only because this deployment configured it.
+	periodic = append(periodic, addConfiguredJobs(workers, pool, cfg, log)...)
+
+	return jobs.New(pool, jobs.Config{
+		Queues:       jobRunnerQueues(),
+		Workers:      workers,
+		PeriodicJobs: periodic,
+	}, log)
+}
+
+// registerJobWorkers registers the workers this process role serves whatever
+// the deployment configured; the config-gated ones live in addConfiguredJobs
+// (jobs_configured.go). Registering a worker is not scheduling it — what gets
+// scheduled is unconditionalSweeps below.
+func registerJobWorkers(workers *river.Workers, pool *pgxpool.Pool, cfg JobRunnerConfig, log *slog.Logger) {
 	// The deep read is not periodic — the api enqueues one job per started
 	// dossier; the worker role only needs the worker registered.
 	river.AddWorker(workers, newSiteDeepReadWorker(pool, cfg.DeepReadBrain, cfg.DeepReadFactBrain, cfg.DeepReadTriageBrain, log, cfg.DeepReadCaps, cfg.Blobstore))
@@ -275,8 +308,14 @@ func NewJobRunner(pool *pgxpool.Pool, log *slog.Logger, cfg JobRunnerConfig) (*j
 	if cfg.SendRegistry != nil {
 		river.AddWorker(workers, newSendWorker(pool, cfg.SendRegistry, cfg.SendPacing))
 	}
+}
 
-	periodic := []*river.PeriodicJob{
+// unconditionalSweeps is every periodic pass an installation ticks whatever it
+// configured, as opposed to the ones an operator's own wiring switches on
+// (addConfiguredJobs). RunOnStart preserves the old ticker's boot-time first
+// pass.
+func unconditionalSweeps(cfg JobRunnerConfig) []*river.PeriodicJob {
+	return []*river.PeriodicJob{
 		river.NewPeriodicJob(
 			river.PeriodicInterval(cfg.CloseDateInterval),
 			func() (river.JobArgs, *river.InsertOpts) { return CloseDateSweepArgs{}, sweepInsertOpts() },
@@ -311,59 +350,43 @@ func NewJobRunner(pool *pgxpool.Pool, log *slog.Logger, cfg JobRunnerConfig) (*j
 			func() (river.JobArgs, *river.InsertOpts) { return IdempotencyRetentionArgs{}, sweepInsertOpts() },
 			&river.PeriodicJobOpts{RunOnStart: true}),
 	}
-	// The ADR-0078 relationship-graph passes register themselves, so this
-	// wiring stays one line as that surface grows (jobs_graph.go).
-	periodic = append(periodic, addGraphJobs(workers, pool, log)...)
-	// The ADR-0069 §3a embed drift sweep registers itself the same way
-	// (embeddriftsweep.go) — worker + tick only when an embed lane is bound.
-	periodic = append(periodic, addEmbedDriftSweepJob(workers, pool, cfg.Embedder, log)...)
-	// The GDPR retention pass registers itself the same way
-	// (jobs_privacyretention.go).
-	periodic = append(periodic, addPrivacyRetentionJobs(workers, pool, cfg, log)...)
-	// The outbound-webhook retry sweep likewise (jobs_webhookretry.go).
-	periodic = append(periodic, addWebhookRetryJobs(workers, pool, cfg)...)
-	// The Surface-B agent scheduler likewise (jobs_agentscheduler.go).
-	periodic = append(periodic, addAgentSchedulerJobs(workers, pool, cfg)...)
-	periodic = append(periodic, addSignalJobs(workers, pool, cfg, log)...)
+}
 
-	// Everything that exists only because this deployment configured it.
-	periodic = append(periodic, addConfiguredJobs(workers, pool, cfg, log)...)
-
-	return jobs.New(pool, jobs.Config{
-		Queues: map[string]river.QueueConfig{
-			river.QueueDefault: {MaxWorkers: 5},
-			// Deep reads run on their own bounded pool so long crawls cannot
-			// evict the short maintenance jobs from the default queue.
-			deepReadQueue: {MaxWorkers: deepReadMaxWorkers},
-			// Rate refreshes (FX fetch + pricing-page crawl+LLM extract) are
-			// likewise long; their own bounded pool keeps a multi-workspace
-			// burst from starving close-date, reconcile, and capture jobs.
-			rateRefreshQueue: {MaxWorkers: rateRefreshMaxWorkers},
-			// The AI-backed capture passes make serial model calls, so a
-			// fanned-out fleet of them would occupy every default worker and
-			// delay sends, Telegram polls, and capture syncs. Same species as
-			// deep reads — long and model-bound — so the same posture.
-			aiCaptureQueue: {MaxWorkers: aiCaptureMaxWorkers},
-			// Overlay reconcile is SERIAL by design. overlaybudget.ConsumeSearch
-			// counts but does not pace, and its keys are per workspace, so it
-			// cannot bound a provider-level burst: a concurrent fan-out could
-			// exceed the incumbent's per-second Search limit. Each workspace
-			// still gets its own job row, which is the observability this phase
-			// is after; per-workspace PARALLELISM is not.
-			overlayReconcileQueue: {MaxWorkers: 1},
-			// A full batch of sequential calls to endpoints this deployment
-			// does not control: long and outbound-bound, so the same posture
-			// deep reads take (webhookRetryQueue).
-			webhookRetryQueue: {MaxWorkers: webhookRetryMaxWorkers},
-			// A batch of agent runs, each entitled to the full RunWallClock —
-			// the longest pass in the tree (agentSchedulerQueue).
-			agentSchedulerQueue: {MaxWorkers: agentSchedulerMaxWorkers},
-			// A full batch per policy, each record its own multi-statement
-			// audited transaction — minutes of database-bound work per tenant
-			// (privacyRetentionQueue).
-			privacyRetentionQueue: {MaxWorkers: privacyRetentionMaxWorkers},
-		},
-		Workers:      workers,
-		PeriodicJobs: periodic,
-	}, log)
+// jobRunnerQueues is the runner's queue set: the default pool plus one bounded
+// pool per species of long job, so a burst of slow work never evicts the short
+// maintenance passes sharing the process.
+func jobRunnerQueues() map[string]river.QueueConfig {
+	return map[string]river.QueueConfig{
+		river.QueueDefault: {MaxWorkers: 5},
+		// Deep reads run on their own bounded pool so long crawls cannot
+		// evict the short maintenance jobs from the default queue.
+		deepReadQueue: {MaxWorkers: deepReadMaxWorkers},
+		// Rate refreshes (FX fetch + pricing-page crawl+LLM extract) are
+		// likewise long; their own bounded pool keeps a multi-workspace
+		// burst from starving close-date, reconcile, and capture jobs.
+		rateRefreshQueue: {MaxWorkers: rateRefreshMaxWorkers},
+		// The AI-backed capture passes make serial model calls, so a
+		// fanned-out fleet of them would occupy every default worker and
+		// delay sends, Telegram polls, and capture syncs. Same species as
+		// deep reads — long and model-bound — so the same posture.
+		aiCaptureQueue: {MaxWorkers: aiCaptureMaxWorkers},
+		// Overlay reconcile is SERIAL by design. overlaybudget.ConsumeSearch
+		// counts but does not pace, and its keys are per workspace, so it
+		// cannot bound a provider-level burst: a concurrent fan-out could
+		// exceed the incumbent's per-second Search limit. Each workspace
+		// still gets its own job row, which is the observability this phase
+		// is after; per-workspace PARALLELISM is not.
+		overlayReconcileQueue: {MaxWorkers: 1},
+		// A full batch of sequential calls to endpoints this deployment
+		// does not control: long and outbound-bound, so the same posture
+		// deep reads take (webhookRetryQueue).
+		webhookRetryQueue: {MaxWorkers: webhookRetryMaxWorkers},
+		// A batch of agent runs, each entitled to the full RunWallClock —
+		// the longest pass in the tree (agentSchedulerQueue).
+		agentSchedulerQueue: {MaxWorkers: agentSchedulerMaxWorkers},
+		// A full batch per policy, each record its own multi-statement
+		// audited transaction — minutes of database-bound work per tenant
+		// (privacyRetentionQueue).
+		privacyRetentionQueue: {MaxWorkers: privacyRetentionMaxWorkers},
+	}
 }

--- a/backend/internal/compose/jobs_overlay.go
+++ b/backend/internal/compose/jobs_overlay.go
@@ -294,15 +294,25 @@ func reconcileConnection(ctx context.Context, pool *pgxpool.Pool, vault keyvault
 	// and its callees treat that signal as a clean stop.
 	ms = ms.WithResolver(inc).WithFenceIdentity(d.ConnectedAt)
 
-	// Seed mirror_user_map from the incumbent's owners directory each
-	// sweep: match every incumbent owner's email to an existing workspace
-	// app_user and write the email-sourced mapping (design.md §4.6 — a
-	// MATCH, never an import). Running it per sweep (not only on connect)
-	// catches users who joined the workspace after connect and owners
-	// added incumbent-side since. Best-effort: a directory-fetch or
-	// per-owner match failure is logged and does not abort the record
-	// sweep below — an unseeded mapping is a fail-closed-eventually gap
-	// (the NEXT sweep retries), never a reason to stop syncing records.
+	if err := seedUserMapFromOwners(ctx, ms, inc, d, log); err != nil {
+		return err
+	}
+	if err := revalidateOwnerEmailMappings(ctx, ms, inc, d, log); err != nil {
+		return err
+	}
+	return sweepObjectClasses(ctx, sweepDeps{inc: inc, ms: ms, meter: meter, log: log}, d)
+}
+
+// seedUserMapFromOwners seeds mirror_user_map from the incumbent's owners
+// directory: it matches every incumbent owner's email to an existing workspace
+// app_user and writes the email-sourced mapping (design.md §4.6 — a MATCH,
+// never an import). Running it per sweep (not only on connect) catches users
+// who joined the workspace after connect and owners added incumbent-side
+// since. Best-effort: a directory-fetch or per-owner match failure is logged
+// and returns nil so the record sweep still runs — an unseeded mapping is a
+// fail-closed-eventually gap (the NEXT sweep retries), never a reason to stop
+// syncing records.
+func seedUserMapFromOwners(ctx context.Context, ms *overlay.MirrorStore, inc overlay.Incumbent, d overlay.DueOverlayConnection, log *slog.Logger) error {
 	if owners, err := inc.Owners(ctx); err != nil {
 		// The owners fetch is the sweep's first incumbent call. A
 		// connection-level failure here (auth revoked, rate-limited,
@@ -322,17 +332,20 @@ func reconcileConnection(ctx context.Context, pool *pgxpool.Pool, vault keyvault
 		log.WarnContext(ctx, "overlay reconcile: seeding mirror_user_map from the owners directory failed",
 			"workspace", d.Workspace.String(), "err", err)
 	}
+	return nil
+}
 
-	// Periodic realization of design.md §4.6 rule 5: an owner's email can
-	// change with NO record ever getting reassigned, so Ingest's own
-	// reassignment-triggered revalidateEmailMapping call (mirrorstore.go)
-	// never gets a chance to run for that owner. Once per sweep, per
-	// connection, re-check every email-sourced mapping this workspace has
-	// against inc's CURRENT owner emails — bounded to the distinct set of
-	// already-mapped owners, not a per-record scan. A failure here is
-	// logged and does not abort the object-class sweep below: a stale
-	// mapping is a fail-closed-eventually gap (the NEXT sweep tries
-	// again), not a reason to stop syncing records this tick.
+// revalidateOwnerEmailMappings is the periodic realization of design.md §4.6
+// rule 5: an owner's email can change with NO record ever getting reassigned,
+// so Ingest's own reassignment-triggered revalidateEmailMapping call
+// (mirrorstore.go) never gets a chance to run for that owner. Once per sweep,
+// per connection, it re-checks every email-sourced mapping this workspace has
+// against inc's CURRENT owner emails — bounded to the distinct set of
+// already-mapped owners, not a per-record scan. A per-mapping failure is
+// logged and returns nil so the object-class sweep still runs: a stale mapping
+// is a fail-closed-eventually gap (the NEXT sweep tries again), not a reason to
+// stop syncing records this tick.
+func revalidateOwnerEmailMappings(ctx context.Context, ms *overlay.MirrorStore, inc overlay.Incumbent, d overlay.DueOverlayConnection, log *slog.Logger) error {
 	if err := ms.RevalidateEmailMappings(ctx, inc); err != nil {
 		if errors.Is(err, overlay.ErrConnectionGone) {
 			return err
@@ -343,8 +356,14 @@ func reconcileConnection(ctx context.Context, pool *pgxpool.Pool, vault keyvault
 		log.WarnContext(ctx, "overlay reconcile: periodic email-mapping revalidation failed",
 			"workspace", d.Workspace.String(), "err", err)
 	}
+	return nil
+}
 
-	deps := sweepDeps{inc: inc, ms: ms, meter: meter, log: log}
+// sweepObjectClasses converges every overlayObjectClasses class for one
+// connection, in the catalog's order. It returns an error only for a failure
+// that must stop the whole connection's sweep, so the caller's backoff paces a
+// dead or throttled incumbent instead of the sweep re-running hot every tick.
+func sweepObjectClasses(ctx context.Context, deps sweepDeps, d overlay.DueOverlayConnection) error {
 	for _, objectClass := range overlayObjectClasses {
 		// A connection-level failure sweeping a SCOPE-BACKED class
 		// (contacts/companies/deals) aborts the whole sweep (the caller backs
@@ -362,7 +381,7 @@ func reconcileConnection(ctx context.Context, pool *pgxpool.Pool, vault keyvault
 			// absent object, or a portal-shaped validation error. Log the full
 			// err (the cause varies) and move on; it never breaks the
 			// scope-backed classes.
-			log.WarnContext(ctx, "overlay reconcile: best-effort object class sweep failed, skipping it",
+			deps.log.WarnContext(ctx, "overlay reconcile: best-effort object class sweep failed, skipping it",
 				"workspace", d.Workspace.String(), "object_class", objectClass, "err", err)
 		}
 	}

--- a/backend/internal/compose/onboardingsitereadtransport.go
+++ b/backend/internal/compose/onboardingsitereadtransport.go
@@ -246,38 +246,8 @@ func companySiteRead(read people.SiteRead, compared []people.SiteReadComparison,
 			EvidenceUrl: fact.SourceURL, Confidence: fact.Confidence,
 		})
 	}
-	entities := make([]crmcontracts.CompanySiteReadLegalEntity, 0, len(read.LegalEntities))
-	for _, entity := range read.LegalEntities {
-		wire := crmcontracts.CompanySiteReadLegalEntity{Name: entity.Name, SourceUrl: entity.SourceURL}
-		// The optional details stay ABSENT rather than empty: "the page did
-		// not state it" and "the page stated nothing" must not read alike.
-		if entity.RegisteredAddress != "" {
-			wire.RegisteredAddress = &entity.RegisteredAddress
-		}
-		if entity.RegisterNumber != "" {
-			wire.RegisterNumber = &entity.RegisterNumber
-		}
-		if entity.EvidenceSnippet != "" {
-			wire.EvidenceSnippet = &entity.EvidenceSnippet
-		}
-		entities = append(entities, wire)
-	}
-	found := make([]crmcontracts.CompanySiteReadPerson, 0, len(read.People))
-	for _, person := range read.People {
-		disposition := crmcontracts.CompanySiteReadPersonDisposition("separate_lead_proposal")
-		out := crmcontracts.CompanySiteReadPerson{
-			Name: person.Name, Role: person.Role, EvidenceSnippet: person.EvidenceSnippet,
-			EvidenceUrl: person.SourceURL, Disposition: &disposition,
-		}
-		if person.PublishedEmail != "" {
-			email := openapi_types.Email(person.PublishedEmail)
-			out.PublishedEmail = &email
-		}
-		if person.LinkedinURL != "" {
-			out.LinkedinUrl = &person.LinkedinURL
-		}
-		found = append(found, out)
-	}
+	entities := contractSiteReadLegalEntities(read.LegalEntities)
+	found := contractSiteReadPeople(read.People)
 	comparisons := contractSiteReadComparisons(compared)
 	// Every terminal status the store can hold maps to something. A status
 	// missing from this table renders as the empty string, which is not a
@@ -342,6 +312,46 @@ func contractRunSummary(summary ai.RunSummary) crmcontracts.AiRunSummary {
 		LatencyMs: summary.LatencyMS, EstimatedCostMicrousd: summary.EstimatedCostMicroUSD,
 		UnpricedCalls: summary.UnpricedCalls, Models: models,
 	}
+}
+
+func contractSiteReadLegalEntities(entities []people.SiteReadLegalEntity) []crmcontracts.CompanySiteReadLegalEntity {
+	out := make([]crmcontracts.CompanySiteReadLegalEntity, 0, len(entities))
+	for _, entity := range entities {
+		wire := crmcontracts.CompanySiteReadLegalEntity{Name: entity.Name, SourceUrl: entity.SourceURL}
+		// The optional details stay ABSENT rather than empty: "the page did
+		// not state it" and "the page stated nothing" must not read alike.
+		if entity.RegisteredAddress != "" {
+			wire.RegisteredAddress = &entity.RegisteredAddress
+		}
+		if entity.RegisterNumber != "" {
+			wire.RegisterNumber = &entity.RegisterNumber
+		}
+		if entity.EvidenceSnippet != "" {
+			wire.EvidenceSnippet = &entity.EvidenceSnippet
+		}
+		out = append(out, wire)
+	}
+	return out
+}
+
+func contractSiteReadPeople(found []people.SiteReadPerson) []crmcontracts.CompanySiteReadPerson {
+	out := make([]crmcontracts.CompanySiteReadPerson, 0, len(found))
+	for _, person := range found {
+		disposition := crmcontracts.CompanySiteReadPersonDisposition("separate_lead_proposal")
+		wire := crmcontracts.CompanySiteReadPerson{
+			Name: person.Name, Role: person.Role, EvidenceSnippet: person.EvidenceSnippet,
+			EvidenceUrl: person.SourceURL, Disposition: &disposition,
+		}
+		if person.PublishedEmail != "" {
+			email := openapi_types.Email(person.PublishedEmail)
+			wire.PublishedEmail = &email
+		}
+		if person.LinkedinURL != "" {
+			wire.LinkedinUrl = &person.LinkedinURL
+		}
+		out = append(out, wire)
+	}
+	return out
 }
 
 func contractSiteReadComparisons(compared []people.SiteReadComparison) []crmcontracts.CompanySiteReadComparison {

--- a/backend/internal/compose/overlaywebhook.go
+++ b/backend/internal/compose/overlaywebhook.go
@@ -158,86 +158,115 @@ func (h *hubspotWebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	// cross-tenant write; an unmapped subscription type is likewise dropped.
 	// A per-event enqueue failure answers 500 so HubSpot redelivers (the
 	// enqueue is unique-by-args, so a redelivery cannot double-run).
-	cache := map[string]portalResolution{}
-	haltByWS := map[string]bool{} // per-request halt cache (workspace → halted)
+	caches := newWebhookCaches()
 	for _, ev := range events {
-		wsID, ok, err := h.resolveWorkspace(r, cache, ev)
-		if err != nil {
-			// A transient binding failure (DB/transaction) is NOT an unbound
-			// portal: answer 500 so HubSpot redelivers rather than dropping the
-			// signal on the floor (the coalesced enqueue is unique-by-args, so a
-			// redelivery cannot double-run the re-fetch).
-			h.log.ErrorContext(r.Context(), "overlay webhook: resolving the portal binding",
-				"portal", ev.PortalIDString(), "err", err)
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-		if !ok {
-			continue
-		}
-		// Recognize what this lane handles BEFORE any ledger transaction: an
-		// unmapped object type or a deletion-family action is dropped here, so a
-		// dropped event never opens a halt/ledger transaction or risks a 500.
-		class, ok := hubspot.ObjectClassForSubscription(ev.SubscriptionType)
-		if !ok {
-			continue
-		}
-		// Every ledger read/write is workspace-scoped (RLS): bind the resolved
-		// tenant onto the context for the halt gate and the echo classification.
-		wsCtx := principal.WithWorkspaceID(r.Context(), wsID.UUID)
-		// Halt gate (OVA-AC-3 fail-safe): a mirror halted by a prior ledger
-		// collision refuses further signals. Cached per workspace per request so
-		// a batch reads the flag once; a mid-batch collision flips the cache
-		// immediately so the rest of the batch is skipped without re-querying.
-		if h.halted != nil {
-			halted, cached := haltByWS[wsID.String()]
-			if !cached {
-				halted, err = h.halted(wsCtx)
-				if err != nil {
-					h.log.ErrorContext(wsCtx, "overlay webhook: reading the mirror-halt flag", "err", err)
-					w.WriteHeader(http.StatusInternalServerError)
-					return
-				}
-				haltByWS[wsID.String()] = halted
-			}
-			if halted {
-				h.log.WarnContext(wsCtx, "overlay webhook: mirror is halted (ledger collision), ignoring the signal",
-					"workspace", wsID.String())
-				continue
-			}
-		}
-		// Echo suppression (OVA-DDL-6): a propertyChange carrying a property we
-		// just wrote (same value, inside the open window) is our own echo — drop
-		// it so the overlay does not re-fetch its own write. A collision halts
-		// the mirror (inside Classify) and is never silently suppressed.
-		if h.classify != nil && ev.PropertyName != "" {
-			switch verdict, err := h.classify(wsCtx, class, ev.ObjectIDString(), ev.PropertyName, ev.PropertyValue); {
-			case err != nil:
-				h.log.ErrorContext(wsCtx, "overlay webhook: classifying against the write ledger",
-					"workspace", wsID.String(), "id", ev.ObjectIDString(), "property", ev.PropertyName, "err", err)
-				w.WriteHeader(http.StatusInternalServerError)
-				return
-			case verdict == overlay.ClassEcho:
-				continue // our own write-back echoing — suppress, no re-fetch
-			case verdict == overlay.ClassCollision:
-				// The mirror was just halted inside Classify. Reflect it in the
-				// per-request cache so the rest of the batch is skipped, and do
-				// NOT re-fetch — the mirror stays halted (cleared by disconnect
-				// today) rather than risk mis-suppressing on state we distrust.
-				haltByWS[wsID.String()] = true
-				h.log.ErrorContext(wsCtx, "overlay webhook: write-ledger value-hash collision — mirror halted",
-					"workspace", wsID.String(), "id", ev.ObjectIDString(), "property", ev.PropertyName)
-				continue
-			}
-		}
-		if err := h.enqueueRefetch(r, wsID.UUID, class, ev.ObjectIDString()); err != nil {
-			h.log.ErrorContext(r.Context(), "overlay webhook: enqueueing re-fetch",
-				"workspace", wsID.String(), "class", class, "id", ev.ObjectIDString(), "err", err)
+		if err := h.ingestSignal(r, caches, ev); err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// webhookCaches are the lookup caches the events of ONE delivery share: portal
+// bindings resolved once per portal, and the mirror-halt flag read once per
+// workspace (a mid-batch collision flips it so the rest of the batch is skipped
+// without re-querying).
+type webhookCaches struct {
+	portals map[string]portalResolution
+	halted  map[string]bool
+}
+
+func newWebhookCaches() webhookCaches {
+	return webhookCaches{portals: map[string]portalResolution{}, halted: map[string]bool{}}
+}
+
+// ingestSignal turns one authenticated event into at most one coalesced
+// re-fetch. A nil error is a signal that was either ingested or deliberately
+// dropped (an unbound portal, an unmapped subscription, a halted mirror, our
+// own echo); a non-nil error is a transient failure — already logged here —
+// that the caller answers 500 for so HubSpot redelivers.
+func (h *hubspotWebhookHandler) ingestSignal(r *http.Request, caches webhookCaches, ev hubspot.WebhookEvent) error {
+	wsID, ok, err := h.resolveWorkspace(r, caches.portals, ev)
+	if err != nil {
+		// A transient binding failure (DB/transaction) is NOT an unbound
+		// portal: answer 500 so HubSpot redelivers rather than dropping the
+		// signal on the floor (the coalesced enqueue is unique-by-args, so a
+		// redelivery cannot double-run the re-fetch).
+		h.log.ErrorContext(r.Context(), "overlay webhook: resolving the portal binding",
+			"portal", ev.PortalIDString(), "err", err)
+		return err
+	}
+	if !ok {
+		return nil
+	}
+	// Recognize what this lane handles BEFORE any ledger transaction: an
+	// unmapped object type or a deletion-family action is dropped here, so a
+	// dropped event never opens a halt/ledger transaction or risks a 500.
+	class, ok := hubspot.ObjectClassForSubscription(ev.SubscriptionType)
+	if !ok {
+		return nil
+	}
+	// Every ledger read/write is workspace-scoped (RLS): bind the resolved
+	// tenant onto the context for the halt gate and the echo classification.
+	wsCtx := principal.WithWorkspaceID(r.Context(), wsID.UUID)
+	halted, err := h.mirrorHalted(wsCtx, caches, wsID)
+	if err != nil {
+		return err
+	}
+	if halted {
+		h.log.WarnContext(wsCtx, "overlay webhook: mirror is halted (ledger collision), ignoring the signal",
+			"workspace", wsID.String())
+		return nil
+	}
+	// Echo suppression (OVA-DDL-6): a propertyChange carrying a property we
+	// just wrote (same value, inside the open window) is our own echo — drop
+	// it so the overlay does not re-fetch its own write. A collision halts
+	// the mirror (inside Classify) and is never silently suppressed.
+	if h.classify != nil && ev.PropertyName != "" {
+		switch verdict, err := h.classify(wsCtx, class, ev.ObjectIDString(), ev.PropertyName, ev.PropertyValue); {
+		case err != nil:
+			h.log.ErrorContext(wsCtx, "overlay webhook: classifying against the write ledger",
+				"workspace", wsID.String(), "id", ev.ObjectIDString(), "property", ev.PropertyName, "err", err)
+			return err
+		case verdict == overlay.ClassEcho:
+			return nil // our own write-back echoing — suppress, no re-fetch
+		case verdict == overlay.ClassCollision:
+			// The mirror was just halted inside Classify. Reflect it in the
+			// per-request cache so the rest of the batch is skipped, and do
+			// NOT re-fetch — the mirror stays halted (cleared by disconnect
+			// today) rather than risk mis-suppressing on state we distrust.
+			caches.halted[wsID.String()] = true
+			h.log.ErrorContext(wsCtx, "overlay webhook: write-ledger value-hash collision — mirror halted",
+				"workspace", wsID.String(), "id", ev.ObjectIDString(), "property", ev.PropertyName)
+			return nil
+		}
+	}
+	if err := h.enqueueRefetch(r, wsID.UUID, class, ev.ObjectIDString()); err != nil {
+		h.log.ErrorContext(r.Context(), "overlay webhook: enqueueing re-fetch",
+			"workspace", wsID.String(), "class", class, "id", ev.ObjectIDString(), "err", err)
+		return err
+	}
+	return nil
+}
+
+// mirrorHalted answers the halt gate (OVA-AC-3 fail-safe): a mirror halted by a
+// prior ledger collision refuses further signals. A receiver with no ledger
+// wired cannot halt, and says so rather than consulting a flag nothing sets.
+func (h *hubspotWebhookHandler) mirrorHalted(ctx context.Context, caches webhookCaches, ws ids.WorkspaceID) (bool, error) {
+	if h.halted == nil {
+		return false, nil
+	}
+	if halted, cached := caches.halted[ws.String()]; cached {
+		return halted, nil
+	}
+	halted, err := h.halted(ctx)
+	if err != nil {
+		h.log.ErrorContext(ctx, "overlay webhook: reading the mirror-halt flag", "err", err)
+		return false, err
+	}
+	caches.halted[ws.String()] = halted
+	return halted, nil
 }
 
 // portalResolution is the per-request cache entry for one portal id: the

--- a/backend/internal/compose/report.go
+++ b/backend/internal/compose/report.go
@@ -16,24 +16,15 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
-	"sort"
-	"strings"
 	"time"
 
-	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
-	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
 )
-
-// reportRowLimit bounds any report; aggregates past this are a data
-// export, not a report.
-const reportRowLimit = 1000
 
 // Column references reused across the prebuilt report specs. One spelling
 // each so a dimension, measure, and filter that mean the same column cannot
@@ -328,128 +319,6 @@ func aggregateSelect(spec reportSpec, agg reportAggregate) (name, sel string, er
 		return "", "", &FieldNotAllowedError{Field: "fn=" + agg.Fn}
 	}
 }
-
-// fetchRows assembles the WHERE side (validated filters + the caller's
-// row-scope clause), runs the plan inside the workspace-bound
-// transaction, and shapes each row for the wire.
-func (e *reportEngine) fetchRows(ctx context.Context, report string, spec reportSpec, req reportRequest, groupBy, selects, columns []string) ([]map[string]any, error) {
-	var rows []map[string]any
-	err := database.WithWorkspaceTx(ctx, e.pool, func(tx pgx.Tx) error {
-		var args []any
-		arg := func(v any) int { args = append(args, v); return len(args) }
-		where, err := buildReportWhere(ctx, spec, req, arg)
-		if err != nil {
-			return err
-		}
-		pgRows, err := tx.Query(ctx, reportSQL(spec, selects, where, groupBy), args...)
-		if err != nil {
-			return fmt.Errorf("report %s: %w", report, err)
-		}
-		defer pgRows.Close()
-		rows, err = scanReportRows(pgRows, columns)
-		return err
-	})
-	if err != nil {
-		return nil, err
-	}
-	return rows, nil
-}
-
-// buildReportWhere assembles the WHERE side — the spec's base predicate,
-// the validated caller filters (sorted for a deterministic plan echo), and
-// the caller's row-scope clause — binding every value through arg.
-func buildReportWhere(ctx context.Context, spec reportSpec, req reportRequest, arg func(any) int) ([]string, error) {
-	where := []string{spec.baseWhere}
-	// Deterministic filter order — the plan echo and the SQL must not
-	// depend on map iteration.
-	filterKeys := make([]string, 0, len(req.Filters))
-	for key := range req.Filters {
-		filterKeys = append(filterKeys, key)
-	}
-	sort.Strings(filterKeys)
-	for _, key := range filterKeys {
-		expr, ok := spec.filters[key]
-		if !ok {
-			return nil, &FieldNotAllowedError{Field: key}
-		}
-		where = append(where, fmt.Sprintf("%s = $%d", expr, arg(req.Filters[key])))
-	}
-	var scope string
-	var err error
-	if spec.activityWalk {
-		scope, err = auth.ActivityScopeClause(ctx, "t", arg)
-	} else {
-		scope, err = auth.ScopeClauseFor(ctx, string(spec.entity), "t", arg)
-	}
-	if err != nil {
-		return nil, err
-	}
-	if scope != "" {
-		where = append(where, scope)
-	}
-	return where, nil
-}
-
-// reportSQL renders the aggregate query: the validated SELECT list over the
-// spec's FROM and WHERE, grouped and ordered by the dimension positions,
-// bounded by the report row limit.
-func reportSQL(spec reportSpec, selects, where, groupBy []string) string {
-	sql := fmt.Sprintf("SELECT %s FROM %s WHERE %s",
-		strings.Join(selects, ", "), spec.fromClause(), strings.Join(where, " AND "))
-	if len(groupBy) > 0 {
-		positions := make([]string, len(groupBy))
-		for i := range groupBy {
-			positions[i] = fmt.Sprint(i + 1)
-		}
-		sql += " GROUP BY " + strings.Join(positions, ", ") + " ORDER BY " + strings.Join(positions, ", ")
-	}
-	sql += fmt.Sprintf(" LIMIT %d", reportRowLimit)
-	return sql
-}
-
-// scanReportRows shapes each result row into a column→value map, rendering
-// values wire-friendly.
-func scanReportRows(pgRows pgx.Rows, columns []string) ([]map[string]any, error) {
-	// Empty, never nil. "No deals in that stage" is a real answer and arrives
-	// shaped like the array it is: nil marshals to `null`, which a model reads as
-	// "unknown". Normalized here so no transport can put null on the wire —
-	// reportOutcome.Rows is marshalled straight through on the tool surface.
-	rows := []map[string]any{}
-	for pgRows.Next() {
-		values, err := pgRows.Values()
-		if err != nil {
-			return nil, err
-		}
-		row := make(map[string]any, len(columns))
-		for i, col := range columns {
-			row[col] = wireValue(values[i])
-		}
-		rows = append(rows, row)
-	}
-	return rows, pgRows.Err()
-}
-
-// wireValue renders driver-native values JSON-friendly: uuids as their
-// canonical string, not a 16-byte array.
-//
-//craft:ignore naked-any report rows are schemaless by design — values arrive driver-native and leave JSON-wire-shaped
-func wireValue(v any) any {
-	if raw, ok := v.([16]byte); ok {
-		return ids.UUID(raw).String()
-	}
-	return v
-}
-
-// quoteIdent admits caller-chosen aggregate aliases into the SQL text
-// safely: strict identifier shape or the plan is rejected.
-func quoteIdent(name string) string {
-	if !identShape.MatchString(name) {
-		return "result"
-	}
-	return name
-}
-
-var identShape = regexp.MustCompile(`^[a-z][a-z0-9_]{0,62}$`)
 
 var errUnknownEntity = errors.New("compose: entity outside the schema descriptors")
 

--- a/backend/internal/compose/reportsql.go
+++ b/backend/internal/compose/reportsql.go
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The report query text: rendering a validated plan into SQL and shaping the
+// rows that come back. Every identifier here is a fixed expression the
+// report's spec supplied and every caller value travels as a bind parameter,
+// which is why this stays the ONE place report SQL is assembled — a second
+// builder is how a typed plan quietly becomes free SQL again.
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// reportRowLimit bounds any report; aggregates past this are a data
+// export, not a report.
+const reportRowLimit = 1000
+
+// fetchRows assembles the WHERE side (validated filters + the caller's
+// row-scope clause), runs the plan inside the workspace-bound
+// transaction, and shapes each row for the wire.
+func (e *reportEngine) fetchRows(ctx context.Context, report string, spec reportSpec, req reportRequest, groupBy, selects, columns []string) ([]map[string]any, error) {
+	var rows []map[string]any
+	err := database.WithWorkspaceTx(ctx, e.pool, func(tx pgx.Tx) error {
+		var args []any
+		arg := func(v any) int { args = append(args, v); return len(args) }
+		where, err := buildReportWhere(ctx, spec, req, arg)
+		if err != nil {
+			return err
+		}
+		pgRows, err := tx.Query(ctx, reportSQL(spec, selects, where, groupBy), args...)
+		if err != nil {
+			return fmt.Errorf("report %s: %w", report, err)
+		}
+		defer pgRows.Close()
+		rows, err = scanReportRows(pgRows, columns)
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+// buildReportWhere assembles the WHERE side — the spec's base predicate,
+// the validated caller filters (sorted for a deterministic plan echo), and
+// the caller's row-scope clause — binding every value through arg.
+func buildReportWhere(ctx context.Context, spec reportSpec, req reportRequest, arg func(any) int) ([]string, error) {
+	where := []string{spec.baseWhere}
+	// Deterministic filter order — the plan echo and the SQL must not
+	// depend on map iteration.
+	filterKeys := make([]string, 0, len(req.Filters))
+	for key := range req.Filters {
+		filterKeys = append(filterKeys, key)
+	}
+	sort.Strings(filterKeys)
+	for _, key := range filterKeys {
+		expr, ok := spec.filters[key]
+		if !ok {
+			return nil, &FieldNotAllowedError{Field: key}
+		}
+		where = append(where, fmt.Sprintf("%s = $%d", expr, arg(req.Filters[key])))
+	}
+	var scope string
+	var err error
+	if spec.activityWalk {
+		scope, err = auth.ActivityScopeClause(ctx, "t", arg)
+	} else {
+		scope, err = auth.ScopeClauseFor(ctx, string(spec.entity), "t", arg)
+	}
+	if err != nil {
+		return nil, err
+	}
+	if scope != "" {
+		where = append(where, scope)
+	}
+	return where, nil
+}
+
+// reportSQL renders the aggregate query: the validated SELECT list over the
+// spec's FROM and WHERE, grouped and ordered by the dimension positions,
+// bounded by the report row limit.
+func reportSQL(spec reportSpec, selects, where, groupBy []string) string {
+	sql := fmt.Sprintf("SELECT %s FROM %s WHERE %s",
+		strings.Join(selects, ", "), spec.fromClause(), strings.Join(where, " AND "))
+	if len(groupBy) > 0 {
+		positions := make([]string, len(groupBy))
+		for i := range groupBy {
+			positions[i] = fmt.Sprint(i + 1)
+		}
+		sql += " GROUP BY " + strings.Join(positions, ", ") + " ORDER BY " + strings.Join(positions, ", ")
+	}
+	sql += fmt.Sprintf(" LIMIT %d", reportRowLimit)
+	return sql
+}
+
+// scanReportRows shapes each result row into a column→value map, rendering
+// values wire-friendly.
+func scanReportRows(pgRows pgx.Rows, columns []string) ([]map[string]any, error) {
+	// Empty, never nil. "No deals in that stage" is a real answer and arrives
+	// shaped like the array it is: nil marshals to `null`, which a model reads as
+	// "unknown". Normalized here so no transport can put null on the wire —
+	// reportOutcome.Rows is marshalled straight through on the tool surface.
+	rows := []map[string]any{}
+	for pgRows.Next() {
+		values, err := pgRows.Values()
+		if err != nil {
+			return nil, err
+		}
+		row := make(map[string]any, len(columns))
+		for i, col := range columns {
+			row[col] = wireValue(values[i])
+		}
+		rows = append(rows, row)
+	}
+	return rows, pgRows.Err()
+}
+
+// wireValue renders driver-native values JSON-friendly: uuids as their
+// canonical string, not a 16-byte array.
+//
+//craft:ignore naked-any report rows are schemaless by design — values arrive driver-native and leave JSON-wire-shaped
+func wireValue(v any) any {
+	if raw, ok := v.([16]byte); ok {
+		return ids.UUID(raw).String()
+	}
+	return v
+}
+
+// quoteIdent admits caller-chosen aggregate aliases into the SQL text
+// safely: strict identifier shape or the plan is rejected.
+func quoteIdent(name string) string {
+	if !identShape.MatchString(name) {
+		return "result"
+	}
+	return name
+}
+
+var identShape = regexp.MustCompile(`^[a-z][a-z0-9_]{0,62}$`)

--- a/backend/internal/compose/routes.go
+++ b/backend/internal/compose/routes.go
@@ -156,14 +156,19 @@ func operationalMux(srv Server, pool *pgxpool.Pool, log *slog.Logger, identitySv
 		// the pointer alone.
 		mux.HandleFunc("/.well-known/oauth-protected-resource/mcp", authH.ProtectedResourceMetadata)
 	}
-	// Provider push webhooks: unauthenticated by nature (the provider is the
-	// caller), each verified by its own mechanism inside the handler; mounted
-	// only when configured — the route is absent otherwise.
+	mountProviderPushWebhooks(mux, srv, log)
+	return mux
+}
+
+// mountProviderPushWebhooks mounts the provider push receivers:
+// unauthenticated by nature (the provider is the caller), each verified by
+// its own mechanism inside the handler; mounted only when configured — the
+// route is absent otherwise.
+func mountProviderPushWebhooks(mux *http.ServeMux, srv Server, log *slog.Logger) {
 	if srv.gmailPush != nil {
 		mux.Handle("/webhooks/gmail", httpserver.Correlate(httpserver.AccessLog(log, srv.gmailPush)))
 	}
 	if srv.overlayWebhook != nil {
 		mux.Handle("/webhooks/hubspot", httpserver.Correlate(httpserver.AccessLog(log, srv.overlayWebhook)))
 	}
-	return mux
 }

--- a/backend/internal/compose/server.go
+++ b/backend/internal/compose/server.go
@@ -26,9 +26,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/activities"
 	"github.com/gradionhq/margince/backend/internal/modules/agents"
 	"github.com/gradionhq/margince/backend/internal/modules/ai"
-	"github.com/gradionhq/margince/backend/internal/modules/approvals"
 	"github.com/gradionhq/margince/backend/internal/modules/automation"
-	"github.com/gradionhq/margince/backend/internal/modules/capture"
 	"github.com/gradionhq/margince/backend/internal/modules/collections"
 	"github.com/gradionhq/margince/backend/internal/modules/consent"
 	"github.com/gradionhq/margince/backend/internal/modules/customfields"
@@ -255,9 +253,8 @@ var _ crmcontracts.ServerInterface = Server{}
 // New wires the modules and returns the ready http.Handler: contract
 // routes under /v1, health probe, session middleware, panic recovery.
 func New(pool *pgxpool.Pool, log *slog.Logger, opts ...Option) http.Handler {
-	// The fieldcatalog seam for deals (the peopleHandlers wiring in
-	// newServer carries the full note): active cf_* deal columns ride
-	// deal payloads on both surfaces.
+	// The fieldcatalog seam for deals (newPeopleHandlers carries the full
+	// note): active cf_* deal columns ride deal payloads on both surfaces.
 	dealsH := deals.NewHandlers(pool).WithFieldCatalog(customfields.NewService(pool, nil))
 	// Bootstrap happens at boot from deployment configuration
 	// (EnsureInstallation, A107/ADR-0061) — the HTTP surface only ever
@@ -280,33 +277,17 @@ func New(pool *pgxpool.Pool, log *slog.Logger, opts ...Option) http.Handler {
 	return httpserver.RecoverPanics(log, httpserver.LimitBodies(httpserver.SecureHeaders(mux)))
 }
 
-// newServer assembles the module handler sets. Every cross-module edge
-// is injected HERE, never as a sibling import (ADR-0054).
+// newServer assembles the module handler sets. Every cross-module edge is
+// injected here, or in the assembly step this calls for it
+// (serverassembly.go) — never as a sibling import (ADR-0054).
 func newServer(pool *pgxpool.Pool, log *slog.Logger, authH authHandlers, dealsH dealsHandlers) Server {
 	srv := Server{
-		authHandlers: authH,
-		// The fieldcatalog seam: customfields' catalog read makes the
-		// workspace's active cf_* columns ride person/organization
-		// payloads (values only — the schema-change engine stays behind
-		// WithSchemaPool; ActiveColumns needs none of it).
-		// The match stager is injected here because approvals is a sibling of
-		// people and a module never imports one: compose is where that edge is
-		// made, as it is for every other cross-module dependency.
-		peopleHandlers: people.NewHandlers(pool).
-			WithFieldCatalog(customfields.NewService(pool, nil)).
-			WithMatchStager(linkedInMatchStager(pool)),
-		dealsHandlers: dealsH,
-		activitiesHandlers: activities.NewHandlers(pool).
-			WithConsent(consent.NewGate(consent.NewStore(pool))).
-			// The public booking capture seams (feedback/14): people is the
-			// idempotent-on-email person path, consent records the
-			// passthrough — both injected here, never sibling imports.
-			WithPublicBooking(people.NewStore(pool), bookingConsentAdapter{store: consent.NewStore(pool)}).
-			// The RFC 8058 unsubscribe linker (B-E11.32): consent mints the
-			// preference token behind the List-Unsubscribe URL.
-			WithUnsubscribe(preferenceLinkAdapter{store: consent.NewStore(pool)}),
-		approvalsHandlers: approvalsHandlersWithEffects(pool),
-		searchHandlers:    search.NewHandlers(pool),
+		authHandlers:       authH,
+		peopleHandlers:     newPeopleHandlers(pool),
+		dealsHandlers:      dealsH,
+		activitiesHandlers: newActivitiesHandlers(pool),
+		approvalsHandlers:  approvalsHandlersWithEffects(pool),
+		searchHandlers:     search.NewHandlers(pool),
 		// Constructed, not merely embedded: the handler carries no nil-pool
 		// branch, so the zero value would panic on the first authenticated
 		// read rather than answer anything at all.
@@ -325,35 +306,10 @@ func newServer(pool *pgxpool.Pool, log *slog.Logger, authH authHandlers, dealsH 
 		reportHandlers:     reportHandlers{engine: newReportEngine(pool)},
 		// The Morning Brief always serves on the deterministic §10.1 floor;
 		// the L2 re-order is opt-in via WithBrief (the api role's model path).
-		Handlers: briefs.NewHandlers(briefs.NewBriefEngine(pool, people.NewStore(pool))),
-		Reads:    network.NewReads(pool),
-		// The workspace capture-settings surface (CAP-WIRE-7, ADR-0072):
-		// read the auto-enrich posture (all roles), toggle it (admin/ops).
-		captureSettingsHandlers: captureSettingsHandlers{store: capture.NewSettings(pool)},
-		// The workspace's own consumer-mail list (CAP-PARAM-5): the surviving
-		// domain control, and the only way an operator corrects a shipped
-		// baseline that is wrong about one of their customers.
-		consumerMailDomainHandlers: consumerMailDomainHandlers{store: capture.NewFreemailDomains(pool)},
-		// First-class filtered export (B-E15.13): the writer reuses the ONE
-		// predicate engine + the bundle writer's open-format rendering; the
-		// collections store resolves a saved view / dynamic list source
-		// behind its own visibility gate.
-		filteredExportHandlers: filteredExportHandlers{writer: NewFilteredExportWriter(pool), collections: collections.NewStore(pool)},
-		overlayExportHandlers:  newOverlayExportHandlers(pool, log),
-		orgRollupHandlers:      orgRollupHandlers{pool: pool, now: time.Now},
-		strengthHandlers:       strengthHandlers{people: people.NewStore(pool), now: time.Now},
-		// The installation's own company (the 0083 anchor). Its own store
-		// instance, like every other people-backed shadow here: the company
-		// form's write shape is people's, the transport is compose's.
-		companyHandlers:  companyHandlers{store: people.NewStore(pool), rollout: companyContextRolloutOnboarding},
-		siteReadHandlers: siteReadHandlers{companyContextRollout: companyContextRolloutOnboarding},
-		onboardingStateHandlers: onboardingStateHandlers{
-			state: identity.NewOnboardingStore(pool), company: people.NewStore(pool),
-			proposal: &onboardingProposalEngine{
-				state: identity.NewOnboardingStore(pool), people: people.NewStore(pool),
-				rollout: companyContextRolloutOnboarding,
-			},
-		},
+		Handlers:          briefs.NewHandlers(briefs.NewBriefEngine(pool, people.NewStore(pool))),
+		Reads:             network.NewReads(pool),
+		orgRollupHandlers: orgRollupHandlers{pool: pool, now: time.Now},
+		strengthHandlers:  strengthHandlers{people: people.NewStore(pool), now: time.Now},
 		// The schema-change pool is boot-optional; nil
 		// here means Create/SetOptions stay their generated 501 until the
 		// api role's WithSchemaPool rebuilds this over the real pool.
@@ -379,36 +335,10 @@ func newServer(pool *pgxpool.Pool, log *slog.Logger, authH authHandlers, dealsH 
 		// Redis client + config.
 		overlayMeter: failClosedOverlayMeter(),
 	}
-	// The overlay read dispatch is built with a nil live-incumbent resolver
-	// here (force-fresh degrades to the mirror). WithKeyvault injects the
-	// vault-backed resolver once the vault is known — the vault arrives via
-	// an option applied AFTER newServer returns, and the dispatch/provider/
-	// freshness reader are pointers shared across that return, so a
-	// boot-time SetOverlayIncumbentResolver reaches the same instance this
-	// field serves reads through.
-	srv.sorDispatch = NewDispatcher(NewProvider(pool), NewOverlayProvider(pool, srv.overlayMeter, nil), pool)
-	// The company view (org360) is assembled from THIS system of record;
-	// it asks the same dispatch every other overlay-aware read asks, so a
-	// workspace running on the incumbent mirror gets one honest refusal
-	// instead of a page that quietly omits most of itself. Wired after the
-	// literal because it needs srv.sorDispatch, which is built above.
-	// The people store carries the SAME fieldcatalog seam peopleHandlers
-	// gets: the 360 serves the organization object, and without it the
-	// company view would silently omit the cf_* columns GET
-	// /organizations/{id} returns for the same record.
-	// The brief reads THROUGH the 360 service, so it inherits every gate the
-	// page itself applies and can only describe what this caller may see.
-	// The model lane is nil here: WithAccountBrief binds the api role's
-	// summarize lane, and without it the brief serves its deterministic
-	// floor.
-	srv.peopleStore = people.NewStore(pool).WithFieldCatalog(customfields.NewService(pool, nil))
-	srv.org360Svc = org360.NewService(pool, srv.peopleStore, approvals.NewService(pool), time.Now)
-	srv.orgBriefSvc = orgbrief.NewService(pool, srv.org360Svc, srv.peopleStore, nil, "", time.Now)
-	srv.orgBriefHandlers = orgbrief.NewHandlers(srv.orgBriefSvc, srv.sorDispatch.isOverlay)
-	srv.org360Handlers = org360.NewHandlers(
-		srv.org360Svc,
-		srv.sorDispatch.isOverlay,
-	)
+	srv.wireCaptureSettingsSurface(pool)
+	srv.wireExportSurface(pool, log)
+	srv.wireOnboardingSurface(pool)
+	srv.wireSystemOfRecordReads(pool)
 	// toolRegistry backs ListAgentTools AND the MCP tool transport; it carries
 	// the vault-backed live-incumbent resolver that lets force-fresh reads and
 	// HUMAN write-back reach HubSpot (an AGENT write is refused before it gets
@@ -435,21 +365,6 @@ func (s *Server) rebuildToolRegistry(pool *pgxpool.Pool) {
 		s.replyDrafter, s.resolveOverlayIncumbent(pool), s.send)
 }
 
-// contractAPI mounts the generated contract router with the ADR-0055
-// admission layer, which rides INSIDE the router (it needs the matched
-// route pattern) and shares the MCP surface's tier table, approvals
-// staging, and live-authority gate — one gate, two transports.
-// readyzEmbedState builds /readyz's embed-status closure (Task 17) over
-// whatever embed lane this process role already wired via
-// WithEmbedReindex — the SAME store and embedder embedReindexHandlers'
-// status/preview/confirm read, so this reports through the one seam
-// rather than opening a second router/store pair. A role that never
-// wires an embed lane (no declared routing config, --ai-fake, or the
-// two self-gating nils WithEmbedReindex checks) leaves engine nil; that
-// is a legitimate "no embed lane to report on" shape, not a fault, so it
-// renders "unknown" exactly like a marker-read failure does — Readyz's
-// body never distinguishes the two, only ever "was this readable right
-// now or not."
 // signalStrength bridges people's §4 relationship-strength computation to
 // the slice the warm room consumes (signals.StrengthSource). It carries
 // only the score and its bucket across the seam — the full explainable

--- a/backend/internal/compose/serverassembly.go
+++ b/backend/internal/compose/serverassembly.go
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The assembly steps newServer runs. Each one binds ONE surface group
+// together with the cross-module edges it needs — a module never imports a
+// sibling (ADR-0054), so compose is where those edges are made. They live
+// beside the Server inventory rather than inside it so the literal in
+// server.go reads as what a process serves, not as how each set is built.
+// serveroptions.go is the other half of the wiring: what a process ROLE
+// layers on top of these defaults.
+
+import (
+	"log/slog"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/gradionhq/margince/backend/internal/compose/org360"
+	"github.com/gradionhq/margince/backend/internal/compose/orgbrief"
+	"github.com/gradionhq/margince/backend/internal/modules/activities"
+	"github.com/gradionhq/margince/backend/internal/modules/approvals"
+	"github.com/gradionhq/margince/backend/internal/modules/capture"
+	"github.com/gradionhq/margince/backend/internal/modules/collections"
+	"github.com/gradionhq/margince/backend/internal/modules/consent"
+	"github.com/gradionhq/margince/backend/internal/modules/customfields"
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
+	"github.com/gradionhq/margince/backend/internal/modules/people"
+)
+
+// newPeopleHandlers builds the person/organization/lead transport with the
+// seams compose owns for it.
+//
+// The fieldcatalog seam: customfields' catalog read makes the
+// workspace's active cf_* columns ride person/organization
+// payloads (values only — the schema-change engine stays behind
+// WithSchemaPool; ActiveColumns needs none of it).
+// The match stager is injected here because approvals is a sibling of
+// people and a module never imports one: compose is where that edge is
+// made, as it is for every other cross-module dependency.
+func newPeopleHandlers(pool *pgxpool.Pool) peopleHandlers {
+	return people.NewHandlers(pool).
+		WithFieldCatalog(customfields.NewService(pool, nil)).
+		WithMatchStager(linkedInMatchStager(pool))
+}
+
+// newActivitiesHandlers builds the timeline transport over the sibling
+// modules its inbound and outbound edges need.
+func newActivitiesHandlers(pool *pgxpool.Pool) activitiesHandlers {
+	return activities.NewHandlers(pool).
+		WithConsent(consent.NewGate(consent.NewStore(pool))).
+		// The public booking capture seams (feedback/14): people is the
+		// idempotent-on-email person path, consent records the
+		// passthrough — both injected here, never sibling imports.
+		WithPublicBooking(people.NewStore(pool), bookingConsentAdapter{store: consent.NewStore(pool)}).
+		// The RFC 8058 unsubscribe linker (B-E11.32): consent mints the
+		// preference token behind the List-Unsubscribe URL.
+		WithUnsubscribe(preferenceLinkAdapter{store: consent.NewStore(pool)})
+}
+
+// wireCaptureSettingsSurface binds the workspace's own capture posture
+// controls.
+func (s *Server) wireCaptureSettingsSurface(pool *pgxpool.Pool) {
+	// The workspace capture-settings surface (CAP-WIRE-7, ADR-0072):
+	// read the auto-enrich posture (all roles), toggle it (admin/ops).
+	s.captureSettingsHandlers = captureSettingsHandlers{store: capture.NewSettings(pool)}
+	// The workspace's own consumer-mail list (CAP-PARAM-5): the surviving
+	// domain control, and the only way an operator corrects a shipped
+	// baseline that is wrong about one of their customers.
+	s.consumerMailDomainHandlers = consumerMailDomainHandlers{store: capture.NewFreemailDomains(pool)}
+}
+
+// wireExportSurface binds the two export transports.
+func (s *Server) wireExportSurface(pool *pgxpool.Pool, log *slog.Logger) {
+	// First-class filtered export (B-E15.13): the writer reuses the ONE
+	// predicate engine + the bundle writer's open-format rendering; the
+	// collections store resolves a saved view / dynamic list source
+	// behind its own visibility gate.
+	s.filteredExportHandlers = filteredExportHandlers{writer: NewFilteredExportWriter(pool), collections: collections.NewStore(pool)}
+	s.overlayExportHandlers = newOverlayExportHandlers(pool, log)
+}
+
+// wireOnboardingSurface binds the first-run group: the installation's own
+// company, the site read that seeds it, and the onboarding state the two
+// report progress through — all three gated by the same rollout.
+func (s *Server) wireOnboardingSurface(pool *pgxpool.Pool) {
+	// The installation's own company (the 0083 anchor). Its own store
+	// instance, like every other people-backed shadow here: the company
+	// form's write shape is people's, the transport is compose's.
+	s.companyHandlers = companyHandlers{store: people.NewStore(pool), rollout: companyContextRolloutOnboarding}
+	s.siteReadHandlers = siteReadHandlers{companyContextRollout: companyContextRolloutOnboarding}
+	s.onboardingStateHandlers = onboardingStateHandlers{
+		state: identity.NewOnboardingStore(pool), company: people.NewStore(pool),
+		proposal: &onboardingProposalEngine{
+			state: identity.NewOnboardingStore(pool), people: people.NewStore(pool),
+			rollout: companyContextRolloutOnboarding,
+		},
+	}
+}
+
+// wireSystemOfRecordReads builds the per-workspace native/overlay dispatch
+// and the reads that ride it — the company view and its grounded prose.
+func (s *Server) wireSystemOfRecordReads(pool *pgxpool.Pool) {
+	// The overlay read dispatch is built with a nil live-incumbent resolver
+	// here (force-fresh degrades to the mirror). WithKeyvault injects the
+	// vault-backed resolver once the vault is known — the vault arrives via
+	// an option applied AFTER newServer returns, and the dispatch/provider/
+	// freshness reader are pointers shared across that return, so a
+	// boot-time SetOverlayIncumbentResolver reaches the same instance this
+	// field serves reads through.
+	s.sorDispatch = NewDispatcher(NewProvider(pool), NewOverlayProvider(pool, s.overlayMeter, nil), pool)
+	// The company view (org360) is assembled from THIS system of record;
+	// it asks the same dispatch every other overlay-aware read asks, so a
+	// workspace running on the incumbent mirror gets one honest refusal
+	// instead of a page that quietly omits most of itself. Wired after the
+	// dispatch because it needs it.
+	// The people store carries the SAME fieldcatalog seam peopleHandlers
+	// gets: the 360 serves the organization object, and without it the
+	// company view would silently omit the cf_* columns GET
+	// /organizations/{id} returns for the same record.
+	// The brief reads THROUGH the 360 service, so it inherits every gate the
+	// page itself applies and can only describe what this caller may see.
+	// The model lane is nil here: WithAccountBrief binds the api role's
+	// summarize lane, and without it the brief serves its deterministic
+	// floor.
+	s.peopleStore = people.NewStore(pool).WithFieldCatalog(customfields.NewService(pool, nil))
+	s.org360Svc = org360.NewService(pool, s.peopleStore, approvals.NewService(pool), time.Now)
+	s.orgBriefSvc = orgbrief.NewService(pool, s.org360Svc, s.peopleStore, nil, "", time.Now)
+	s.orgBriefHandlers = orgbrief.NewHandlers(s.orgBriefSvc, s.sorDispatch.isOverlay)
+	s.org360Handlers = org360.NewHandlers(
+		s.org360Svc,
+		s.sorDispatch.isOverlay,
+	)
+}

--- a/backend/internal/compose/signalextract.go
+++ b/backend/internal/compose/signalextract.go
@@ -172,83 +172,77 @@ func (x *SignalExtractor) readThread(
 	}
 	events, err := x.ask(ctx, thread)
 	if errors.Is(err, errRefusedReading) {
-		// The WATERMARK DOES NOT MOVE, and the refusal is COUNTED. A refusal
-		// says this reply was unusable, not that the conversation holds
-		// nothing, and the two are worlds apart for a reader: retiring the
-		// thread on the first one would drop whatever it actually says for
-		// good. Leaving it due forever is the other failure — dueThreads takes
-		// the newest extractThreadCap conversations, so a thread that never
-		// settles holds a slot in every pass and the backlog behind it is
-		// never reached. The count parks it after extractRefusalCap readings
-		// of the SAME text. Parking is a deferral, not a verdict: a new
-		// message unparks it, and so does time, because the model that could
-		// not read it is not the model that will be asked next week.
-		//
-		// It is not returned as an error either. Nothing here failed that a
-		// retry of the PASS would fix, and faulting the job would re-run every
-		// other thread to reach this one.
-		//
-		// clampToken for the same reason validateExtractPayload uses it on
-		// every echoed token: this error can carry model output, the model read
-		// untrusted mail, and an operator log is not the place for either a
-		// correspondent's chosen volume or their private text.
-		var refusals int
-		if markErr := database.WithWorkspaceTx(ctx, x.pool, func(tx pgx.Tx) error {
-			counted, countErr := recordThreadRefusal(ctx, tx, wsID, thread, now)
-			refusals = counted
-			return countErr
-		}); markErr != nil {
-			return 0, markErr
-		}
-		// Said differently once the attempts are gone, because it means
-		// something different: nobody will look at this conversation again for
-		// a week, and whatever it states is not on the account until then. A
-		// per-refusal line at the same level would bury that in the noise of
-		// the two that preceded it.
-		if refusals >= extractRefusalCap {
-			x.log.WarnContext(ctx, "signal extract: parking a conversation nothing could read",
-				"thread_key", thread.Key, "refusals", refusals,
-				"parked_for", extractParkFor.String(), "error", clampToken(err.Error()))
-			return 0, nil
-		}
-		x.log.InfoContext(ctx, "signal extract: refusing the model's reading, will try again",
-			"thread_key", thread.Key, "refusals", refusals,
-			"of", extractRefusalCap, "error", clampToken(err.Error()))
-		return 0, nil
+		return 0, x.deferRefusedReading(ctx, wsID, thread, now, err)
 	}
 	if err != nil {
 		// A provider or budget failure is not this thread's fault, so the
 		// watermark stays where it is and the conversation is read again.
 		return 0, err
 	}
+	return x.commitReading(ctx, wsID, thread, events, now)
+}
+
+// deferRefusedReading counts one refused reading of this conversation and
+// leaves it due for the next pass — or parks it, once the attempts are gone.
+//
+// The WATERMARK DOES NOT MOVE, and the refusal is COUNTED. A refusal says this
+// reply was unusable, not that the conversation holds nothing, and the two are
+// worlds apart for a reader: retiring the thread on the first one would drop
+// whatever it actually says for good. Leaving it due forever is the other
+// failure — dueThreads takes the newest extractThreadCap conversations, so a
+// thread that never settles holds a slot in every pass and the backlog behind
+// it is never reached. The count parks it after extractRefusalCap readings of
+// the SAME text. Parking is a deferral, not a verdict: a new message unparks
+// it, and so does time, because the model that could not read it is not the
+// model that will be asked next week.
+//
+// The refusal is not returned as an error either. Nothing here failed that a
+// retry of the PASS would fix, and faulting the job would re-run every other
+// thread to reach this one.
+func (x *SignalExtractor) deferRefusedReading(
+	ctx context.Context, wsID ids.WorkspaceID, thread settledThread, now time.Time, refusal error,
+) error {
+	var refusals int
+	if markErr := database.WithWorkspaceTx(ctx, x.pool, func(tx pgx.Tx) error {
+		counted, countErr := recordThreadRefusal(ctx, tx, wsID, thread, now)
+		refusals = counted
+		return countErr
+	}); markErr != nil {
+		return markErr
+	}
+	// clampToken for the same reason validateExtractPayload uses it on every
+	// echoed token: this error can carry model output, the model read untrusted
+	// mail, and an operator log is not the place for either a correspondent's
+	// chosen volume or their private text.
+	if refusals >= extractRefusalCap {
+		// Said differently once the attempts are gone, because it means
+		// something different: nobody will look at this conversation again for
+		// a week, and whatever it states is not on the account until then. A
+		// per-refusal line at the same level would bury that in the noise of
+		// the two that preceded it.
+		x.log.WarnContext(ctx, "signal extract: parking a conversation nothing could read",
+			"thread_key", thread.Key, "refusals", refusals,
+			"parked_for", extractParkFor.String(), "error", clampToken(refusal.Error()))
+		return nil
+	}
+	x.log.InfoContext(ctx, "signal extract: refusing the model's reading, will try again",
+		"thread_key", thread.Key, "refusals", refusals,
+		"of", extractRefusalCap, "error", clampToken(refusal.Error()))
+	return nil
+}
+
+// commitReading writes the signals this conversation stated and advances its
+// watermark in ONE transaction, and reports how many signals were raised.
+func (x *SignalExtractor) commitReading(
+	ctx context.Context, wsID ids.WorkspaceID, thread settledThread, events []extractedEvent, now time.Time,
+) (int, error) {
 	raised := 0
 	if err := database.WithWorkspaceTx(ctx, x.pool, func(tx pgx.Tx) error {
 		for _, event := range events {
 			if event.Confidence < extractConfidenceFloor {
 				continue
 			}
-			cited, err := ids.Parse(event.MessageID)
-			if err != nil {
-				// The validator has already checked every id against the ones
-				// supplied, so this cannot come from the model; it would mean
-				// the ids we sent are unparseable, which is our own bug.
-				return fmt.Errorf("cited message id: %w", err)
-			}
-			written, err := signals.RecordDerived(ctx, tx, wsID, signals.DerivedSignal{
-				Kind:           event.Kind,
-				OrganizationID: thread.OrganizationID,
-				Summary:        event.Summary,
-				Severity:       extractKinds[event.Kind],
-				Fingerprint:    signalFingerprint(event.Kind, thread.OrganizationID, cited),
-				Evidence: []signals.DerivedEvidence{
-					{Snippet: event.Summary, ActivityID: cited},
-				},
-				Audit: map[string]any{
-					paramKind:               event.Kind,
-					"thread_key":            thread.Key,
-					extractionConfidenceKey: float64(event.Confidence),
-				},
-			}, now)
+			written, err := recordExtractedEvent(ctx, tx, wsID, thread, event, now)
 			if err != nil {
 				return err
 			}
@@ -261,6 +255,36 @@ func (x *SignalExtractor) readThread(
 		return 0, err
 	}
 	return raised, nil
+}
+
+// recordExtractedEvent raises one event as a signal against the account,
+// citing the message it was stated in, and reports whether the card is new.
+func recordExtractedEvent(
+	ctx context.Context, tx pgx.Tx, wsID ids.WorkspaceID, thread settledThread,
+	event extractedEvent, now time.Time,
+) (bool, error) {
+	cited, err := ids.Parse(event.MessageID)
+	if err != nil {
+		// The validator has already checked every id against the ones
+		// supplied, so this cannot come from the model; it would mean
+		// the ids we sent are unparseable, which is our own bug.
+		return false, fmt.Errorf("cited message id: %w", err)
+	}
+	return signals.RecordDerived(ctx, tx, wsID, signals.DerivedSignal{
+		Kind:           event.Kind,
+		OrganizationID: thread.OrganizationID,
+		Summary:        event.Summary,
+		Severity:       extractKinds[event.Kind],
+		Fingerprint:    signalFingerprint(event.Kind, thread.OrganizationID, cited),
+		Evidence: []signals.DerivedEvidence{
+			{Snippet: event.Summary, ActivityID: cited},
+		},
+		Audit: map[string]any{
+			paramKind:               event.Kind,
+			"thread_key":            thread.Key,
+			extractionConfidenceKey: float64(event.Confidence),
+		},
+	}, now)
 }
 
 // errRefusedReading marks a reply this site will not act on. It is TERMINAL

--- a/backend/internal/compose/siteextract.go
+++ b/backend/internal/compose/siteextract.go
@@ -80,10 +80,7 @@ const (
 // live phase and the pages fetched so far.
 func crawlAndExtract(ctx context.Context, crawler *siteCrawler, x evidenceExtractor, seedURL string, onProgress func(phase string, pages []crawlPage), onDraft func(pageFactsResult)) (siteCrawl, siteExtraction, error) {
 	var out siteExtraction
-	var results []pageFactsResult
-	var published pageFactsResult
-	var failed []error
-	var mu sync.Mutex
+	collected := pageFactsCollector{onDraft: onDraft}
 	progress := func(phase string, pages []crawlPage) {
 		if onProgress != nil {
 			onProgress(phase, pages)
@@ -129,17 +126,7 @@ func crawlAndExtract(ctx context.Context, crawler *siteCrawler, x evidenceExtrac
 			defer wg.Done()
 			defer func() { <-sem }()
 			res, err := safeExtractPageFacts(ctx, x, page)
-			mu.Lock()
-			if err != nil {
-				failed = append(failed, fmt.Errorf("page %s: %w", page.URL, err))
-				if page.Kind == crmcontracts.SiteReadPageKindImpressum {
-					out.legalCensusIncomplete = true
-				}
-			} else {
-				results = append(results, res)
-				published = publishDraft(onDraft, results, published)
-			}
-			mu.Unlock()
+			collected.record(page, res, err)
 		}()
 	})
 	out.crawlMs = time.Since(crawlStart).Milliseconds()
@@ -161,11 +148,44 @@ func crawlAndExtract(ctx context.Context, crawler *siteCrawler, x evidenceExtrac
 	profileWg.Wait()
 
 	if profileErr != nil {
-		failed = append(failed, fmt.Errorf("profile lane: %w", profileErr))
+		collected.failed = append(collected.failed, fmt.Errorf("profile lane: %w", profileErr))
 	}
-	out.merged = mergeInCommitOrder(crawl, results)
-	out.err = errors.Join(failed...)
+	out.legalCensusIncomplete = collected.legalCensusIncomplete
+	out.merged = mergeInCommitOrder(crawl, collected.results)
+	out.err = errors.Join(collected.failed...)
 	return crawl, out, nil
+}
+
+// pageFactsCollector accumulates the streamed fact lane's outcomes. Pages
+// complete from up to pageExtractConcurrency goroutines at once, so every
+// fold goes through its lock; once every lane has been waited on the fields
+// are read directly.
+type pageFactsCollector struct {
+	onDraft func(pageFactsResult)
+
+	mu                    sync.Mutex
+	results               []pageFactsResult
+	published             pageFactsResult
+	failed                []error
+	legalCensusIncomplete bool
+}
+
+// record folds one page's outcome in: a failure joins the collected errors
+// and costs only that page's findings, a success republishes the read so
+// far. A failed LEGAL page also undercounts the entity census, which the
+// legal gate must not trust.
+func (c *pageFactsCollector) record(page crawlPage, res pageFactsResult, err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if err != nil {
+		c.failed = append(c.failed, fmt.Errorf("page %s: %w", page.URL, err))
+		if page.Kind == crmcontracts.SiteReadPageKindImpressum {
+			c.legalCensusIncomplete = true
+		}
+		return
+	}
+	c.results = append(c.results, res)
+	c.published = publishDraft(c.onDraft, c.results, c.published)
 }
 
 // publishDraft hands the caller the read SO FAR whenever it changed, so

--- a/backend/internal/compose/sitelogo.go
+++ b/backend/internal/compose/sitelogo.go
@@ -227,19 +227,7 @@ func (w *siteDeepReadWorker) resolveLogo(ctx context.Context, args SiteDeepReadA
 		return
 	}
 	orgID := ids.From[ids.OrganizationKind](*claim.OrganizationID)
-	// Ask before resolving anything: a field a person holds is not going to be
-	// written, so fetching and normalizing a mark for it is work nobody uses.
-	// The write applies the rule again under the row lock — this is the cheap
-	// path, never the authority.
-	held, err := w.people.LogoHeldByHuman(ctx, orgID)
-	if err != nil {
-		w.log.WarnContext(ctx, "reading the organization's logo provenance failed",
-			"read", args.SiteReadID.String(), "err", err)
-		return
-	}
-	if held {
-		w.log.InfoContext(ctx, "logo resolve skipped: a person's own logo holds the field",
-			"read", args.SiteReadID.String())
+	if !w.logoWorthResolving(ctx, args.SiteReadID, orgID) {
 		return
 	}
 
@@ -304,6 +292,26 @@ func (w *siteDeepReadWorker) resolveLogo(ctx context.Context, args SiteDeepReadA
 		"read", args.SiteReadID.String(), "source", logo.SourceURL,
 		"source_size", fmt.Sprintf("%dx%d", logo.SourceWidth, logo.SourceHeight),
 		"stored_bytes", len(logo.PNG), "candidates", logoAttemptSummary(attempts))
+}
+
+// logoWorthResolving asks before resolving anything: a field a person holds is
+// not going to be written, so fetching and normalizing a mark for it is work
+// nobody uses. The write applies the rule again under the row lock — this is
+// the cheap path, never the authority. A provenance read that fails leaves the
+// field's owner unknown, and the lane stands down rather than guess.
+func (w *siteDeepReadWorker) logoWorthResolving(ctx context.Context, readID ids.UUID, orgID ids.OrganizationID) bool {
+	held, err := w.people.LogoHeldByHuman(ctx, orgID)
+	if err != nil {
+		w.log.WarnContext(ctx, "reading the organization's logo provenance failed",
+			"read", readID.String(), "err", err)
+		return false
+	}
+	if held {
+		w.log.InfoContext(ctx, "logo resolve skipped: a person's own logo holds the field",
+			"read", readID.String())
+		return false
+	}
+	return true
 }
 
 // debugLogo projects a resolve onto the debug report's shape.

--- a/backend/internal/compose/sitereaddebug.go
+++ b/backend/internal/compose/sitereaddebug.go
@@ -119,17 +119,7 @@ func siteReadDebugRun(ctx context.Context, opts SiteReadDebugOptions, crawler *s
 	}
 	caps := opts.Caps.withDefaults()
 	log := &callLog{}
-	rec := &recordingBrain{inner: opts.Brain, log: log}
-	factInner := opts.FactBrain
-	if factInner == nil {
-		factInner = opts.Brain
-	}
-	recFacts := &recordingBrain{inner: factInner, log: log}
-	triageInner := opts.TriageBrain
-	if triageInner == nil {
-		triageInner = factInner
-	}
-	recTriage := &recordingBrain{inner: triageInner, log: log}
+	rec, recFacts, recTriage := recordingLanes(opts, log)
 	var dropped []DebugDrop
 	extract := evidenceExtractor{fetch: pageFetch, brain: rec, factBrain: recFacts, drops: func(sourceURL string, d droppedFinding) {
 		dropped = append(dropped, DebugDrop{
@@ -194,6 +184,26 @@ func siteReadDebugRun(ctx context.Context, opts SiteReadDebugOptions, crawler *s
 		report.Warnings = append(report.Warnings, warning)
 	}
 	return report, nil
+}
+
+// recordingLanes wraps each of the run's three model lanes in the report's
+// per-call telemetry, applying the fall-through SiteReadDebugOptions
+// documents: an unset fact lane borrows the profile brain, an unset triage
+// lane borrows the fact lane's. All three share one call log, so the report
+// lists the calls of the whole run in the order they returned.
+func recordingLanes(opts SiteReadDebugOptions, log *callLog) (profile, facts, triage *recordingBrain) {
+	profile = &recordingBrain{inner: opts.Brain, log: log}
+	factInner := opts.FactBrain
+	if factInner == nil {
+		factInner = opts.Brain
+	}
+	facts = &recordingBrain{inner: factInner, log: log}
+	triageInner := opts.TriageBrain
+	if triageInner == nil {
+		triageInner = factInner
+	}
+	triage = &recordingBrain{inner: triageInner, log: log}
+	return profile, facts, triage
 }
 
 // debugTriage runs the domain-triage classifier over the landing page the crawl


### PR DESCRIPTION
## What

Clears all 14 size findings (`long-func`, `large-file`) in `internal/compose`. Every change is a behavior-preserving extraction — no logic, error text, ordering, status code, log call, or transaction boundary is altered.

| function | body lines |
|---|---|
| `NewJobRunner` | 272 → 27 |
| `run` (deepread) | 162 → 49 |
| `newServer` | 138 → 70 |
| `reconcileConnection` | 129 → 63 |
| `ServeHTTP` (overlay webhook) | 127 → 55 |
| `readThread` (signalextract) | 94 → 14 |
| `crawlAndExtract` | 87 → 75 |
| `companySiteRead` | 86 → 56 |
| `siteReadDebugRun` | 85 → 75 |
| `Execute` (flip) | 85 → 65 |
| `claimKey` | 84 → 18 |
| `resolveLogo` | 83 → 71 |
| `operationalMux` | 81 → 74 |

Three new files: `serverassembly.go` (per-surface assembly steps, sibling to the existing per-role `serveroptions.go`), `deepreadreport.go` (everything after a successful crawl), `reportsql.go` (the single place report SQL text is assembled).

`report.go` 501 → 369. The **catalog stays put** on purpose: its wire names sit beside their SQL expressions, and that table is precisely why a caller-chosen identifier can never reach the query text. Moving it would also have inherited 11 `goconst` demands (the strict config uses `new-from-merge-base`, so moved lines count as new) that would have replaced readable wire names with constants — and one suggestion would have coupled the report and flip vocabularies.

Also folds in two findings that appeared on main while this branch was open: `signalextract.go`'s `readThread`, and the four `naked-any` signatures in `aicert/scenariorender.go` (waived with reasons — a corpus fixture is any JSON shape; `yaml.Marshaler` fixes the last).

## Safety

The risky paths were checked deliberately rather than assumed:

- **`overlaywebhook.go ServeHTTP`** — the whole security preamble (method check → `MaxBytesReader` 413/400 → timestamp replay guard → HMAC verification → unmarshal) is left **inline and untouched**. Only the per-event body moved. Nothing new is read before the signature check; no status code changed.
- **`flip.go Execute`** — cutover step order is unchanged: claim → verdict → admitMode → seal → resumeOrCreateRun → import → CompleteFlip → 202.
- **`idempotency.go claimKey`** — the `FOR UPDATE` read and re-claim still run inside the caller's single `WithWorkspaceTx`; conflict/replay verdicts unchanged.
- **Closure→parameter conversions** were audited for shared mutable state (the webhook's two caches and the crawl's fact collector are still shared by reference, so a mid-batch halt flip and the per-page accumulation stay observable).

A craft review of the full diff found **no behavior drift**. It did find a swallowed error the extraction introduced (a `settled`-only guard that dropped a non-nil error), now fixed in code rather than documented in a comment.

## Testing

- `make check-backend` green (incl. golangci strict, arch fitness, license headers).
- `make test-integration` → `OK: integration passed with 0 skips (28 packages, parallel)`.
- Sweep: 0 findings remaining in `internal/compose`.

Part of the craft strict-mode campaign (#401, #402, #404). Remaining: module long-funcs, cmd/tools, test outliers, then the `--strict` flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors `internal/compose` to break up long functions and keep behavior unchanged. Moves report SQL into `reportsql.go`, server assembly into `serverassembly.go`, and simplifies job runner wiring; clarifies `registerJobWorkers` docs around gating and periodic scheduling.

- **Refactors**
  - Split oversized flows into focused units: `serverassembly.go` (server wiring), `deepreadreport.go` (post-crawl reporting), `reportsql.go` (report SQL).
  - Extracted helpers to tighten paths without changing logic:
    - Jobs: `registerJobWorkers`, `unconditionalSweeps`, and add-* sweep registration. Updated comments to state worker gating and that periodic jobs are assembled from multiple helpers.
    - Webhooks: shared caches via `newWebhookCaches`; route mounts via `mountProviderPushWebhooks`.
    - Overlay reconcile: `seedUserMapFromOwners`, `revalidateOwnerEmailMappings`.
    - Idempotency: `insertClaim`, `fetchStoredResponse` inside the same tx.
    - Flip: import step moved to `importMirrorEstate` (order unchanged).
    - Site read: `pageFactsCollector`, `recordingLanes`, `logoWorthResolving`.
  - Preserved critical sequences and boundaries: webhook security preamble unchanged; flip cutover order intact; idempotency remains a single transaction.
  - Kept the report catalog in `report.go`; only SQL rendering moved to `reportsql.go`.

- **Bug Fixes**
  - Fixed a swallowed error in the deep-read success path introduced during extraction.

<sup>Written for commit 48a60b34e294fd62efb295a3e333cb2facf6ac1c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

