### PR TITLE
chore(gates): a waiver is a type, and three obligations derive from the right authority

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,11 @@
 # The frontend lane is separate (`make frontend-check`) — it needs node+pnpm,
 # which not every backend machine has; CI runs both.
 
-.PHONY: help install ai-routing-local dev-fresh check check-backend check-q check-go check-fe build test test-v test-cover test-integration e2e-ai e2e-ai-report ai-probe test-db-up test-it test-integration-serial bench-perf lint arch-lint vet gen gen-types gen-types-check drift composition check-composition test-extensions db-up db-init db-wait migrate migrate-up migrate-down run psql redis-cli tidy dev dev-stop dev-logs clean tools tools-go infra-up infra-down infra-logs infra-reset seed-dev seed-dev-db seed-reset verify-boot frontend-check frontend-e2e fe-install fe-typecheck fe-lint fe-build fe-preview fe-format fe-test ds-purity font-lock icon-lint fitness-jurisdiction storybook fe-uat craft-static craft-residue check-craft-doc check-image-pins contract-breaking-check test-lanes go-file-length rls-store-path no-jurisdiction pkg-freeze hooks sbom sbom-sign sbom-check
+# Overridable exactly as in backend/Makefile, so a pinned toolchain reaches the
+# one target here that invokes the compiler directly instead of delegating.
+GO ?= go
+
+.PHONY: help install ai-routing-local dev-fresh check check-backend check-q check-go check-gates check-fe build test test-v test-cover test-integration e2e-ai e2e-ai-report ai-probe test-db-up test-it test-integration-serial bench-perf lint arch-lint vet gen gen-types gen-types-check drift composition check-composition test-extensions db-up db-init db-wait migrate migrate-up migrate-down run psql redis-cli tidy dev dev-stop dev-logs clean tools tools-go infra-up infra-down infra-logs infra-reset seed-dev seed-dev-db seed-reset verify-boot frontend-check frontend-e2e fe-install fe-typecheck fe-lint fe-build fe-preview fe-format fe-test ds-purity font-lock icon-lint fitness-jurisdiction storybook fe-uat craft-static craft-residue check-craft-doc check-image-pins contract-breaking-check test-lanes go-file-length rls-store-path no-jurisdiction pkg-freeze hooks sbom sbom-sign sbom-check
 
 # Bare `make` lists every command instead of running the first target.
 .DEFAULT_GOAL := help
@@ -62,6 +66,15 @@ check-q:
 ## work; the full `make check` adds the deterministic script gates.
 check-go:
 	$(MAKE) -C backend check
+
+## check-gates — the meta-gate lane: the waiver census, the obligations derived
+## from the migrations and the contract, and the walk-scope proofs. A dev-loop
+## convenience for iterating on those gates, and NEVER a prerequisite of
+## check-backend: every test named below lives in `package backendarch`, which
+## `make -C backend check` already runs uncached, so `make check` covers them
+## and a prerequisite here would only run them twice.
+check-gates:
+	@cd backend && $(GO) test -count=1 -run 'TestEveryPackageLevelReasonMapIsAWaiverOrADeclaredFixture|TestEveryWaiversDeclarationIsSweptForStalenessExactlyOnce|TestGatekitServesTestsOnly|TestEveryVersionPinnedTableBumpsItsVersion|TestEveryToolRegistrarIsInvokedByEveryFullRegistry|TestAPublishedFieldNameIsAFieldNameNotProse|TestEveryValidationFieldLiteralNamesAContractField|TestSeamReachableModulesCarryTheirOwnFieldVerdict|TestEveryStoreEntryPointIsAuthGated' .
 
 ## infra-up / infra-down — aliases for the dev stack (some deploy tooling and
 ## UAT guides call the infra lane by these names). infra-up

--- a/backend/aitaskwiring_test.go
+++ b/backend/aitaskwiring_test.go
@@ -42,6 +42,7 @@ import (
 	"testing"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/shared/gatekit"
 )
 
 // composeImportPath is the package whose ModelPath the roles hand around.
@@ -57,11 +58,12 @@ const composeImportPath = modulePath + "/internal/compose"
 // renamed upstream therefore stops matching its exemption — and lands on the
 // "owns no lane" error asking for one, which is the direction a stale
 // exemption should fail in.
-var laneWiringExemptions = map[string]string{
+var laneWiringExemptions = gatekit.Waive(map[string]string{
 	"cert_judge": "the rubric judge is built by the certification runner on its own pinned binding (aicert/runner.go), never by a process role — a judge on the candidate's lane would let a model grade itself",
-}
+})
 
 func TestEveryCensusedSiteRidesALaneAProcessRoleWires(t *testing.T) {
+	defer laneWiringExemptions.AssertAllMatched(t)
 	census, err := compose.NewTaskCensus()
 	if err != nil {
 		t.Fatalf("building the task census: %v", err)
@@ -74,10 +76,7 @@ func TestEveryCensusedSiteRidesALaneAProcessRoleWires(t *testing.T) {
 	for _, site := range census.All() {
 		task := string(site.Task)
 		lane, hasLane := laneNameFor(task)
-		if reason, exempt := laneWiringExemptions[task]; exempt {
-			if strings.TrimSpace(reason) == "" {
-				t.Errorf("site %s/%s is exempted from the wiring rule with no reason — state why no process role runs it, or drop the exemption", site.Task, site.Variant)
-			}
+		if laneWiringExemptions.Waived(t, task) {
 			if hasLane {
 				t.Errorf("site %s/%s is exempted as laneless, but ModelPath.%s exists — drop the exemption and let the rule hold it", site.Task, site.Variant, lane)
 			}

--- a/backend/auditcoherence_test.go
+++ b/backend/auditcoherence_test.go
@@ -30,24 +30,27 @@ import (
 	"sort"
 	"strings"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/gatekit"
 )
 
 // auditActionDBOnly: verbs the audit_log_action_check CHECK allows that the
 // contract does not (yet) define. Each carries a one-line reason.
-var auditActionDBOnly = map[string]string{
+var auditActionDBOnly = gatekit.Waive(map[string]string{
 	// live in signal_resolution writes (migration 0047); flagged upstream
 	// for spec adoption (see migration 0053's note).
 	"resolve": "signal_resolution writes (0047); flagged upstream for spec adoption",
-}
+})
 
 func TestAuditLogEnumCoherence(t *testing.T) {
+	defer auditActionDBOnly.AssertAllMatched(t)
 	contractAction, contractActorType := auditLogContractEnums(t)
 	ddl := tableCheckSets(t) // reused from enumsync_test.go (last-wins over migrations)
 
 	cases := []struct {
 		column   string
 		contract []string
-		dbOnly   map[string]string
+		dbOnly   *gatekit.Waivers[string]
 	}{
 		{"audit_log.action", contractAction, auditActionDBOnly},
 		{"audit_log.actor_type", contractActorType, nil},
@@ -75,13 +78,13 @@ func TestAuditLogEnumCoherence(t *testing.T) {
 			if _, ok := conSet[v]; ok {
 				continue
 			}
-			if _, waived := c.dbOnly[v]; waived {
+			if c.dbOnly.Waived(t, v) {
 				continue
 			}
 			t.Errorf("%s: DDL CHECK allows %q but the contract does not define it — add it to crm.yaml (P3), or record it in auditActionDBOnly with a reason", c.column, v)
 		}
 		// The waiver is a ratchet: a waived verb must genuinely be DB-only.
-		for v := range c.dbOnly {
+		for _, v := range c.dbOnly.Subjects() {
 			if _, ok := ddlSet[v]; !ok {
 				t.Errorf("%s: stale waiver %q — no DDL CHECK allows it; remove it from auditActionDBOnly", c.column, v)
 			}

--- a/backend/consentproof_test.go
+++ b/backend/consentproof_test.go
@@ -26,6 +26,8 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/gatekit"
 )
 
 // consentStateWrite matches an INSERT into person_consent (every insert
@@ -38,15 +40,10 @@ var consentProofInsert = regexp.MustCompile(`(?is)INSERT\s+INTO\s+consent_event\
 
 // unprovenConsentWrites are the ratified proof-free state writes, keyed
 // by "package-dir:FuncName" with the rationale inline.
-var unprovenConsentWrites = map[string]string{}
+var unprovenConsentWrites = gatekit.Waive(map[string]string{})
 
 func TestEveryConsentStateWriteAppendsProof(t *testing.T) {
-	for fn, rationale := range unprovenConsentWrites {
-		if strings.TrimSpace(rationale) == "" {
-			t.Errorf("unprovenConsentWrites[%s] has no rationale — a waiver must say why the proof row is missing", fn)
-		}
-	}
-	used := map[string]bool{}
+	defer unprovenConsentWrites.AssertAllMatched(t)
 	fset := token.NewFileSet()
 	for _, root := range []string{"internal/modules", "internal/compose"} {
 		err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
@@ -84,8 +81,7 @@ func TestEveryConsentStateWriteAppendsProof(t *testing.T) {
 				})
 				if writesState && !appendsProof {
 					key := filepath.ToSlash(filepath.Dir(path)) + ":" + fn.Name.Name
-					if _, ratified := unprovenConsentWrites[key]; ratified {
-						used[key] = true
+					if unprovenConsentWrites.Waived(t, key) {
 						continue
 					}
 					t.Errorf("%s: %s writes a person_consent state without appending a consent_event — every state change carries its Art. 7(1) proof (data-model §3.4), or the exception is ratified in unprovenConsentWrites",
@@ -96,11 +92,6 @@ func TestEveryConsentStateWriteAppendsProof(t *testing.T) {
 		})
 		if err != nil {
 			t.Fatal(err)
-		}
-	}
-	for key := range unprovenConsentWrites {
-		if !used[key] {
-			t.Errorf("unprovenConsentWrites[%s] matches no proof-free consent state write — stale waiver, remove it", key)
 		}
 	}
 }

--- a/backend/dedupespine_test.go
+++ b/backend/dedupespine_test.go
@@ -26,6 +26,8 @@ import (
 	"sort"
 	"strings"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/gatekit"
 )
 
 // mintSite matches an INSERT into one of the three identity tables. The
@@ -38,7 +40,7 @@ var mintSite = regexp.MustCompile(`(?is)INSERT\s+INTO\s+(person|organization|lea
 // row, each with the reason it is on it. Adding an entry is a deliberate
 // decision about where duplicates can enter the system, which is why it is
 // spelled out rather than pattern-matched.
-var sanctionedMintSites = map[string]string{
+var sanctionedMintSites = gatekit.Waive(map[string]string{
 	// The chokepoint. createPerson/createOrganization take the PO-F ladder's
 	// verdict as an argument, so a create that never consulted it cannot be
 	// written, and they refuse outright when the verdict is an exact-key
@@ -59,10 +61,10 @@ var sanctionedMintSites = map[string]string{
 
 	// Test seeding, not a product path.
 	"internal/compose/integration/harness.go": "integration-harness row seeding",
-}
+})
 
 func TestEveryIdentityInsertGoesThroughTheChokepoint(t *testing.T) {
-	found := map[string]bool{}
+	defer sanctionedMintSites.AssertAllMatched(t)
 	for _, path := range goSourceFiles(t, ".") {
 		if strings.HasSuffix(path, "_test.go") {
 			continue
@@ -76,24 +78,13 @@ func TestEveryIdentityInsertGoesThroughTheChokepoint(t *testing.T) {
 			continue
 		}
 		rel := filepath.ToSlash(path)
-		if _, ok := sanctionedMintSites[rel]; !ok {
+		if !sanctionedMintSites.Waived(t, rel) {
 			t.Errorf("%s mints a person, organization or lead row directly.\n"+
 				"Identity rows are minted only through the chokepoint in "+
 				"internal/modules/people/resolvecreate.go, which requires the PO-F-1/PO-F-2 "+
 				"verdict and refuses an exact-key collision. Route the insert through it — "+
 				"or, if this really is a new write shape, enroll it in sanctionedMintSites "+
 				"with the reason it cannot.", rel)
-			continue
-		}
-		found[rel] = true
-	}
-
-	// The list stays honest in the other direction too: an entry whose file no
-	// longer mints anything is stale, and a stale allowlist quietly re-opens
-	// the door the next time that file grows an INSERT.
-	for rel, reason := range sanctionedMintSites {
-		if !found[rel] {
-			t.Errorf("sanctionedMintSites still lists %s (%s) but it no longer mints an identity row — drop the entry", rel, reason)
 		}
 	}
 }
@@ -144,10 +135,10 @@ var mergedIntoWrite = regexp.MustCompile(`(?is)(UPDATE\s+(person|organization)\s
 
 // sanctionedMergeWriters own the redirect pointer that retires one record into
 // another.
-var sanctionedMergeWriters = map[string]string{
+var sanctionedMergeWriters = gatekit.Waive(map[string]string{
 	"internal/modules/people/merge.go":              "the person merge path",
 	"internal/modules/people/merge_organization.go": "the organization merge path",
-}
+})
 
 // TestOnlyTheMergePathRetiresARecord is the structural half of the
 // no-silent-auto-merge guarantee (data-hygiene: fuzzy candidates never
@@ -155,7 +146,7 @@ var sanctionedMergeWriters = map[string]string{
 // else; only a human's disposition, executed by the merge path, may point one
 // record at another.
 func TestOnlyTheMergePathRetiresARecord(t *testing.T) {
-	found := map[string]bool{}
+	defer sanctionedMergeWriters.AssertAllMatched(t)
 	for _, path := range goSourceFiles(t, ".") {
 		if strings.HasSuffix(path, "_test.go") {
 			continue
@@ -168,23 +159,16 @@ func TestOnlyTheMergePathRetiresARecord(t *testing.T) {
 		if isGenerated(path, string(body)) {
 			continue
 		}
-		if _, ok := sanctionedMergeWriters[rel]; ok {
-			found[rel] = mergedIntoWrite.MatchString(string(body))
+		if !mergedIntoWrite.MatchString(string(body)) {
 			continue
 		}
-		if mergedIntoWrite.MatchString(string(body)) {
-			t.Errorf("%s writes merged_into_id.\n"+
-				"Retiring one record into another is the merge path's alone "+
-				"(internal/modules/people/merge.go, merge_organization.go), reached only by a "+
-				"human's disposition on the dedupe queue — DEDUPE_FUZZY_AUTOMERGE is pinned never.", rel)
+		if sanctionedMergeWriters.Waived(t, rel) {
+			continue
 		}
-	}
-	// Same staleness rule as the mint-site list: an entry whose file no longer
-	// writes the pointer is a guard that has quietly stopped guarding anything.
-	for rel, reason := range sanctionedMergeWriters {
-		if !found[rel] {
-			t.Errorf("sanctionedMergeWriters still lists %s (%s) but it no longer writes merged_into_id — drop the entry", rel, reason)
-		}
+		t.Errorf("%s writes merged_into_id.\n"+
+			"Retiring one record into another is the merge path's alone "+
+			"(internal/modules/people/merge.go, merge_organization.go), reached only by a "+
+			"human's disposition on the dedupe queue — DEDUPE_FUZZY_AUTOMERGE is pinned never.", rel)
 	}
 }
 

--- a/backend/errmatch_test.go
+++ b/backend/errmatch_test.go
@@ -21,14 +21,16 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/gatekit"
 )
 
 // errTextMatchWaivers are the ratified error-text matches. The only
 // admissible ground is a protocol whose machine-readable error code IS
 // the message prefix, with no typed accessor in the client library.
-var errTextMatchWaivers = map[string]string{
+var errTextMatchWaivers = gatekit.Waive(map[string]string{
 	"internal/platform/events/subscriber.go:isBusyGroup": "RESP wire errors carry their machine code as the message's first token (BUSYGROUP); go-redis exposes no typed accessor, so the prefix match IS the code match",
-}
+})
 
 // errorTextCall reports whether expr is a niladic `<recv>.Error()` call —
 // the error-message extraction every string match here keys on.
@@ -74,12 +76,7 @@ func matchesErrorText(n ast.Node) (verb string, found bool) {
 }
 
 func TestNoErrorMessageStringMatching(t *testing.T) {
-	for key, rationale := range errTextMatchWaivers {
-		if strings.TrimSpace(rationale) == "" {
-			t.Errorf("errTextMatchWaivers[%s] has no rationale — a waiver must say why text is the only handle", key)
-		}
-	}
-	used := map[string]bool{}
+	defer errTextMatchWaivers.AssertAllMatched(t)
 	fset := token.NewFileSet()
 	err := filepath.WalkDir("internal", func(path string, d fs.DirEntry, err error) error {
 		if err != nil || d.IsDir() {
@@ -107,8 +104,7 @@ func TestNoErrorMessageStringMatching(t *testing.T) {
 				if !found {
 					return true
 				}
-				if _, waived := errTextMatchWaivers[key]; waived {
-					used[key] = true
+				if errTextMatchWaivers.Waived(t, key) {
 					return true
 				}
 				t.Errorf("%s: %s over err.Error() — Postgres failures are classified by SQLSTATE/constraint name (storekit helpers), never by message text",
@@ -120,10 +116,5 @@ func TestNoErrorMessageStringMatching(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatal(err)
-	}
-	for key := range errTextMatchWaivers {
-		if !used[key] {
-			t.Errorf("errTextMatchWaivers[%s] matches no error-text comparison — stale waiver, remove it", key)
-		}
 	}
 }

--- a/backend/fieldnames_test.go
+++ b/backend/fieldnames_test.go
@@ -42,11 +42,14 @@ import (
 	"go/token"
 	"io/fs"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/gatekit"
 )
 
 // wireFieldName is what a contract field path may look like: a lowercase segment,
@@ -306,4 +309,191 @@ func stringLiteralPrefix(expr ast.Expr) (string, bool) {
 		return strings.TrimSuffix(left, "."), true
 	}
 	return "", false
+}
+
+// httpErrPackage and validationHelper name the transport helper whose first argument
+// lands in the wire field slot; customFieldPrefix is the one field-name family the
+// contract cannot enumerate, a governed column added at runtime and named per workspace.
+const (
+	httpErrPackage    = "httperr"
+	validationHelper  = "Validation"
+	customFieldPrefix = "cf_"
+
+	// minContractFieldNames is the vacuity floor on the vocabulary: the contract declares
+	// hundreds of properties, so a smaller set means the extraction read a fraction of the
+	// file, and every correct literal then fails at once — a verdict on the code under test
+	// when the broken thing is the yardstick. The floor guards the low side only; a
+	// vocabulary admitting everything certifies prose in silence and no count bounds that,
+	// since the honest count rises with every property added. Shape bounds it, below.
+	minContractFieldNames = 100
+)
+
+// validationFieldsOutsideTheContract holds the field names correct but undeclared.
+var validationFieldsOutsideTheContract = gatekit.Waive(map[string]string{
+	"arguments": "compose/registry.go's MCP tools/call handler names params.arguments, which is " +
+		"the JSON-RPC request shape rather than a REST contract property — correct for that " +
+		"wire, and absent from api_gen.go's tags because no REST body carries it",
+})
+
+// A field name published through the transport helper has to BE a field name.
+//
+// The FieldFault walk above polices the field slot on typed refusals. The same slot is
+// reachable a second way — `httperr.Validation`'s first argument, which REST renders as
+// `details.errors[].field` — where prose is the same unactionable answer, one indirection
+// outside the walk that watches for it. httperr's own unqualified calls count too.
+//
+// The vocabulary is the contract's own field names — every distinct `json:"…"` name the
+// generated types declare — rather than a naming shape: camelCase properties
+// (`privateAppToken`) and header parameters (`If-Match`) sit beside snake_case body ones, so
+// the shape rule serving the walk above would refuse fields the contract has.
+//
+// Coverage rests on a convention: 109 of the 142 calls lead with a string literal, spelling
+// 62 distinct paths, and a concatenation counts as literal-leading — its literal prefix is
+// judged, its computed tail is not. The other 33 pass a computed value (`bad.field`,
+// `pred.Field`, `param`) no static reading resolves; several are package-level constants,
+// which a reading that resolved identifiers within a package could judge too.
+func TestEveryValidationFieldLiteralNamesAContractField(t *testing.T) {
+	vocabulary := contractFieldNames(t)
+	checked := 0
+	for _, pf := range parseInternalTree(t) {
+		ast.Inspect(pf.file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok || len(call.Args) == 0 ||
+				!callsValidationHelper(call.Fun, pf.file.Name.Name == httpErrPackage) {
+				return true
+			}
+			text, isLiteral := leadingStringLiteral(call.Args[0])
+			if !isLiteral {
+				return true
+			}
+			checked++
+			reportIfNotAContractField(t, pf.path, text, vocabulary)
+			return true
+		})
+	}
+	if checked == 0 {
+		t.Fatalf("no %s.%s call names a field literally — the helper was renamed and this gate "+
+			"watches nothing", httpErrPackage, validationHelper)
+	}
+	validationFieldsOutsideTheContract.AssertAllMatched(t)
+}
+
+// contractFieldNames is the set of field names the contract declares: the `json:"…"` name
+// of every member of every generated type, options stripped — the tag rather than the YAML
+// schema name because the tag is what the wire carries.
+func contractFieldNames(t *testing.T) map[string]bool {
+	t.Helper()
+	path := filepath.Join(internalTree, "contracts", "api_gen.go")
+	file, err := parser.ParseFile(token.NewFileSet(), path, nil, 0)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", path, err)
+	}
+	out := map[string]bool{}
+	ast.Inspect(file, func(n ast.Node) bool {
+		structType, ok := n.(*ast.StructType)
+		if !ok {
+			return true
+		}
+		for _, member := range structType.Fields.List {
+			if member.Tag == nil {
+				continue
+			}
+			tag, unquoteErr := strconv.Unquote(member.Tag.Value)
+			if unquoteErr != nil {
+				t.Fatalf("%s: reading struct tag %s: %v", path, member.Tag.Value, unquoteErr)
+			}
+			name, _, _ := strings.Cut(reflect.StructTag(tag).Get("json"), ",")
+			if name == "" || name == "-" {
+				continue
+			}
+			if strings.ContainsAny(name, " \t\n") {
+				t.Errorf("%s: %q reached the field-name vocabulary — no declared property name carries "+
+					"whitespace, so the extraction is reading text that is not a json tag and a "+
+					"vocabulary built from it admits prose as a field", path, name)
+				continue
+			}
+			out[name] = true
+		}
+		return true
+	})
+	if len(out) < minContractFieldNames {
+		t.Fatalf("%s yielded %d field names, below the floor of %d — the extraction is broken, so "+
+			"every literal judged against it is judged against nothing", path, len(out), minContractFieldNames)
+	}
+	return out
+}
+
+// callsValidationHelper reports whether fun names the transport helper; the
+// unqualified form counts only inside httperr, whose own calls carry no qualifier.
+func callsValidationHelper(fun ast.Expr, insideHTTPErr bool) bool {
+	if sel, ok := fun.(*ast.SelectorExpr); ok {
+		pkg, qualified := sel.X.(*ast.Ident)
+		return qualified && pkg.Name == httpErrPackage && sel.Sel.Name == validationHelper
+	}
+	bare, unqualified := fun.(*ast.Ident)
+	return unqualified && insideHTTPErr && bare.Name == validationHelper
+}
+
+// leadingStringLiteral returns a string argument's literal text, or the ACCUMULATED literal
+// prefix of a concatenation — every literal operand from the left, joined, up to the first
+// computed one, since `"company_draft." + field` is a legal dotted path at runtime.
+// Accumulating rather than reading the leftmost operand holds against prose split across
+// operands: `"name" + ": missing" + x` has a field-shaped leftmost operand, and the joined
+// prefix `name: missing` does not. Unlike stringLiteralPrefix the trailing dot stays —
+// whether a path ending at a separator names anything is the segment walk's question.
+func leadingStringLiteral(expr ast.Expr) (string, bool) {
+	switch e := expr.(type) {
+	case *ast.BasicLit:
+		if e.Kind != token.STRING {
+			return "", false
+		}
+		text, err := strconv.Unquote(e.Value)
+		if err != nil {
+			return "", false
+		}
+		return text, true
+	case *ast.BinaryExpr:
+		if e.Op != token.ADD {
+			return "", false
+		}
+		left, ok := leadingStringLiteral(e.X)
+		if !ok {
+			return "", false
+		}
+		if right, literal := leadingStringLiteral(e.Y); literal {
+			left += right
+		}
+		return left, true
+	}
+	return "", false
+}
+
+// reportIfNotAContractField judges a dotted path one segment at a time, because a nested
+// path is legal while no whole path is a declared name. An index is dropped (`edits[0]`
+// addresses `edits`), and so is the empty segment a runtime-continued path leaves at its end.
+func reportIfNotAContractField(t *testing.T, path, text string, vocabulary map[string]bool) {
+	t.Helper()
+	named := 0
+	for _, segment := range strings.Split(text, ".") {
+		if index := strings.IndexByte(segment, '['); index >= 0 {
+			segment = segment[:index]
+		}
+		if segment == "" {
+			continue
+		}
+		named++
+		if vocabulary[segment] || strings.HasPrefix(segment, customFieldPrefix) ||
+			validationFieldsOutsideTheContract.Waived(t, segment) {
+			continue
+		}
+		t.Errorf("%s: %s.%s publishes field %q, whose segment %q is not a field the contract declares. "+
+			"REST renders that slot as details.errors[].field, so use the contract's own name (or a %s "+
+			"custom field) and put the explanation in the message argument — or refuse with a "+
+			"MessageFault, which publishes no field, when no single argument is the wrong one.",
+			path, httpErrPackage, validationHelper, text, segment, customFieldPrefix)
+	}
+	if named == 0 {
+		t.Errorf("%s: %s.%s publishes field %q, which addresses no field at all — name the field, or "+
+			"refuse with a MessageFault.", path, httpErrPackage, validationHelper, text)
+	}
 }

--- a/backend/fieldnames_test.go
+++ b/backend/fieldnames_test.go
@@ -347,11 +347,14 @@ var validationFieldsOutsideTheContract = gatekit.Waive(map[string]string{
 // (`privateAppToken`) and header parameters (`If-Match`) sit beside snake_case body ones, so
 // the shape rule serving the walk above would refuse fields the contract has.
 //
-// Coverage rests on a convention: 109 of the 142 calls lead with a string literal, spelling
-// 62 distinct paths, and a concatenation counts as literal-leading — its literal prefix is
-// judged, its computed tail is not. The other 33 pass a computed value (`bad.field`,
-// `pred.Field`, `param`) no static reading resolves; several are package-level constants,
-// which a reading that resolved identifiers within a package could judge too.
+// Coverage rests on a convention: the calls judged are the ones leading with a string
+// literal, and a concatenation counts as literal-leading — its literal prefix is judged, its
+// computed tail is not. The residue is real rather than implied away: a call whose field
+// argument is a computed value (`bad.field`, `pred.Field`, `param`) is past what a static
+// reading resolves, and several of those values are package-level constants, which a reading
+// that resolved identifiers within a package could judge too. What keeps the convention from
+// certifying nothing is asserted rather than counted — a walk that judged no literal at all
+// fails below, as does a vocabulary too small to be the contract's.
 func TestEveryValidationFieldLiteralNamesAContractField(t *testing.T) {
 	vocabulary := contractFieldNames(t)
 	checked := 0

--- a/backend/fieldnames_test.go
+++ b/backend/fieldnames_test.go
@@ -269,46 +269,65 @@ func returnedFieldNames(body *ast.BlockStmt) []string {
 	return out
 }
 
-// stringLiteralPrefix returns the literal text of a string expression, or the
-// ACCUMULATED literal prefix of a concatenation — every literal operand from the
-// left, joined, up to the first computed one.
+// stringLiteralPrefix is the FieldFault walk's view of a field expression: the
+// literal prefix, with the trailing dot dropped where a computed tail continues
+// the path, so a legitimate nested one (`"edits." + key`) is not read as
+// malformed. A literal that simply ends at a separator names nothing and keeps
+// it, for wireFieldName to refuse.
 //
-// Accumulating rather than taking the leftmost operand is what makes the gate
-// hold against the obvious evasion. `"kind: " + kind` fails on its space either
-// way, but splitting it as `"kind" + ": " + kind` parses as
+// Accumulating the prefix rather than taking the leftmost operand is what makes
+// the gate hold against the obvious evasion. `"kind: " + kind` fails on its space
+// either way, but splitting it as `"kind" + ": " + kind` parses as
 // `(("kind" + ": ") + kind)`, whose leftmost operand is the perfectly
 // field-shaped `"kind"` — so a leftmost-only reading certifies the exact prose it
 // exists to refuse. Joined, the prefix is `kind: ` and the space fails it again.
+func stringLiteralPrefix(expr ast.Expr) (text string, isLiteral bool) {
+	prefix, literal, dynamicTail := literalPrefix(expr)
+	if !literal {
+		return "", false
+	}
+	if dynamicTail {
+		return strings.TrimSuffix(prefix, "."), true
+	}
+	return prefix, true
+}
+
+// literalPrefix is the one reading of a string expression's literal prefix, which
+// both field-name walks rest on: the text, whether there was one at all, and
+// whether a computed operand continues it.
 //
-// A trailing dot is dropped so a legitimate nested path (`"edits." + key`) is not
-// read as malformed.
-func stringLiteralPrefix(expr ast.Expr) (string, bool) {
+// It stops at the first computed operand. Literals that a computed operand
+// separates are not adjacent, so `"a" + dynamic + "b"` reads as the prefix `a`
+// with a tail — joining it to `ab` would judge a value no run ever produces.
+func literalPrefix(expr ast.Expr) (text string, isLiteral, dynamicTail bool) {
 	switch e := expr.(type) {
 	case *ast.BasicLit:
 		if e.Kind != token.STRING {
-			return "", false
+			return "", false, false
 		}
 		text, err := strconv.Unquote(e.Value)
 		if err != nil {
-			return "", false
+			return "", false, false
 		}
-		return text, true
+		return text, true, false
 	case *ast.BinaryExpr:
 		if e.Op != token.ADD {
-			return "", false
+			return "", false, false
 		}
-		left, ok := stringLiteralPrefix(e.X)
+		left, ok, leftTail := literalPrefix(e.X)
 		if !ok {
-			return "", false
+			return "", false, false
 		}
-		// The right operand joins the prefix only when it too is literal; a
-		// computed one ends the prefix and leaves what precedes it to be judged.
-		if right, literal := stringLiteralPrefix(e.Y); literal {
-			left += right
+		if leftTail {
+			return left, true, true
 		}
-		return strings.TrimSuffix(left, "."), true
+		right, literal, rightTail := literalPrefix(e.Y)
+		if !literal {
+			return left, true, true
+		}
+		return left + right, true, rightTail
 	}
-	return "", false
+	return "", false, false
 }
 
 // httpErrPackage and validationHelper name the transport helper whose first argument
@@ -365,12 +384,12 @@ func TestEveryValidationFieldLiteralNamesAContractField(t *testing.T) {
 				!callsValidationHelper(call.Fun, pf.file.Name.Name == httpErrPackage) {
 				return true
 			}
-			text, isLiteral := leadingStringLiteral(call.Args[0])
+			text, isLiteral, dynamicTail := literalPrefix(call.Args[0])
 			if !isLiteral {
 				return true
 			}
 			checked++
-			reportIfNotAContractField(t, pf.path, text, vocabulary)
+			reportIfNotAContractField(t, pf.path, text, vocabulary, dynamicTail)
 			return true
 		})
 	}
@@ -437,51 +456,27 @@ func callsValidationHelper(fun ast.Expr, insideHTTPErr bool) bool {
 	return unqualified && insideHTTPErr && bare.Name == validationHelper
 }
 
-// leadingStringLiteral returns a string argument's literal text, or the ACCUMULATED literal
-// prefix of a concatenation — every literal operand from the left, joined, up to the first
-// computed one, since `"company_draft." + field` is a legal dotted path at runtime.
-// Accumulating rather than reading the leftmost operand holds against prose split across
-// operands: `"name" + ": missing" + x` has a field-shaped leftmost operand, and the joined
-// prefix `name: missing` does not. Unlike stringLiteralPrefix the trailing dot stays —
-// whether a path ending at a separator names anything is the segment walk's question.
-func leadingStringLiteral(expr ast.Expr) (string, bool) {
-	switch e := expr.(type) {
-	case *ast.BasicLit:
-		if e.Kind != token.STRING {
-			return "", false
-		}
-		text, err := strconv.Unquote(e.Value)
-		if err != nil {
-			return "", false
-		}
-		return text, true
-	case *ast.BinaryExpr:
-		if e.Op != token.ADD {
-			return "", false
-		}
-		left, ok := leadingStringLiteral(e.X)
-		if !ok {
-			return "", false
-		}
-		if right, literal := leadingStringLiteral(e.Y); literal {
-			left += right
-		}
-		return left, true
-	}
-	return "", false
-}
-
 // reportIfNotAContractField judges a dotted path one segment at a time, because a nested
 // path is legal while no whole path is a declared name. An index is dropped (`edits[0]`
-// addresses `edits`), and so is the empty segment a runtime-continued path leaves at its end.
-func reportIfNotAContractField(t *testing.T, path, text string, vocabulary map[string]bool) {
+// addresses `edits`). An empty segment addresses nothing, so a leading or interior one is
+// malformed; a trailing one is the separator a computed tail continues from
+// (`"company_draft." + field`), and is only legal when there is such a tail.
+func reportIfNotAContractField(t *testing.T, path, text string, vocabulary map[string]bool, dynamicTail bool) {
 	t.Helper()
 	named := 0
-	for _, segment := range strings.Split(text, ".") {
+	segments := strings.Split(text, ".")
+	for i, segment := range segments {
 		if index := strings.IndexByte(segment, '['); index >= 0 {
 			segment = segment[:index]
 		}
 		if segment == "" {
+			if i == len(segments)-1 && dynamicTail {
+				continue
+			}
+			t.Errorf("%s: %s.%s publishes field %q, which has an empty segment: a dotted path names a "+
+				"segment on each side of every separator, and it may end at one only when a computed "+
+				"tail continues it. Name the segment, or refuse with a MessageFault, which publishes "+
+				"no field.", path, httpErrPackage, validationHelper, text)
 			continue
 		}
 		named++

--- a/backend/gatecensus_test.go
+++ b/backend/gatecensus_test.go
@@ -53,14 +53,15 @@ const (
 	wantFixtureAnnotations = 9
 )
 
-// reasonMap is one package-level declaration mapping subjects to strings — the
-// population rules 1 and 2 are derived over.
-type reasonMap struct {
+// censusDecl is one package-level declaration this census governs — a map from
+// subjects to reason strings, or a gatekit waiver set: the population rules 1
+// and 2 are derived over.
+type censusDecl struct {
 	path   string
 	pkg    string
 	line   int
 	name   string
-	waived bool // constructed through gatekit.Waive
+	waived bool // a gatekit waiver set, so already held to gatekit's standard
 }
 
 // A package-level map from subject to reason is a waiver or a declared fixture.
@@ -77,7 +78,7 @@ func TestEveryPackageLevelReasonMapIsAWaiverOrADeclaredFixture(t *testing.T) {
 	for _, pf := range files {
 		markers, commented := fixtureMarkers(pf, fset)
 		written += len(markers)
-		for _, decl := range reasonMaps(t, pf, fset) {
+		for _, decl := range censusDecls(t, pf, fset) {
 			declared++
 			reason, marked := fixtureReason(markers, commented, decl.line)
 			switch {
@@ -126,6 +127,10 @@ func TestEveryPackageLevelReasonMapIsAWaiverOrADeclaredFixture(t *testing.T) {
 // better than zero — matched accumulates across every test in the package, so
 // whichever runs first sees the other's subjects unreached and reports staleness
 // that is not there.
+//
+// The population is every declaration that IS a waiver set, however it was
+// constructed: a set a helper assembles grants exactly what an inline literal
+// grants, so reading the entries would decide the obligation on a spelling.
 func TestEveryWaiversDeclarationIsSweptForStalenessExactlyOnce(t *testing.T) {
 	files, fset := censusFiles(t, "Go source", func(string) bool { return true })
 
@@ -133,7 +138,7 @@ func TestEveryWaiversDeclarationIsSweptForStalenessExactlyOnce(t *testing.T) {
 	// package that declares it can name it in a sweep.
 	type pkgKey struct{ dir, pkg string }
 	sweeps := map[pkgKey]map[string]int{}
-	var declared []reasonMap
+	var declared []censusDecl
 	for _, pf := range files {
 		key := pkgKey{dir: path.Dir(pf.path), pkg: pf.file.Name.Name}
 		if sweeps[key] == nil {
@@ -142,7 +147,7 @@ func TestEveryWaiversDeclarationIsSweptForStalenessExactlyOnce(t *testing.T) {
 		for receiver, count := range assertAllMatchedSites(pf) {
 			sweeps[key][receiver] += count
 		}
-		for _, decl := range reasonMaps(t, pf, fset) {
+		for _, decl := range censusDecls(t, pf, fset) {
 			if decl.waived {
 				declared = append(declared, decl)
 			}
@@ -236,8 +241,8 @@ func censusFiles(t *testing.T, what string, keep func(path string) bool) ([]pars
 // waiver machinery belongs to.
 func isTestSource(path string) bool { return strings.HasSuffix(path, "_test.go") }
 
-// reasonMaps returns every package-level declaration in the file whose value
-// type is string, keyed by any type at all.
+// censusDecls returns every package-level declaration in the file that is a map
+// with string values, keyed by any type at all, or a gatekit waiver set.
 //
 // The walk is over the file's declarations, not over its text: a declaration
 // inside a `var ( … )` group is invisible to a pattern anchored on `var`. The
@@ -245,10 +250,10 @@ func isTestSource(path string) bool { return strings.HasSuffix(path, "_test.go")
 // gate draws subjects from, a record type or a table name as readily as a
 // string, and a rule that only saw map[string]string would sail past the typed
 // ones while typed keys are the direction gatekit pushes.
-func reasonMaps(t *testing.T, pf parsedFile, fset *token.FileSet) []reasonMap {
+func censusDecls(t *testing.T, pf parsedFile, fset *token.FileSet) []censusDecl {
 	t.Helper()
-	waive := gatekitName(t, pf)
-	var out []reasonMap
+	gatekitLocal := gatekitName(t, pf)
+	var out []censusDecl
 	for _, decl := range pf.file.Decls {
 		gen, isGen := decl.(*ast.GenDecl)
 		if !isGen || gen.Tok != token.VAR {
@@ -259,12 +264,12 @@ func reasonMaps(t *testing.T, pf parsedFile, fset *token.FileSet) []reasonMap {
 			if !isValue {
 				continue
 			}
-			mapped, waived := stringValuedMap(value, waive)
-			if !mapped {
+			mapped, waived := reasonMapOrWaiverSet(value, gatekitLocal)
+			if !mapped && !waived {
 				continue
 			}
 			for _, name := range value.Names {
-				out = append(out, reasonMap{
+				out = append(out, censusDecl{
 					path:   pf.path,
 					pkg:    pf.file.Name.Name,
 					line:   fset.Position(value.Pos()).Line,
@@ -277,30 +282,34 @@ func reasonMaps(t *testing.T, pf parsedFile, fset *token.FileSet) []reasonMap {
 	return out
 }
 
-// stringValuedMap reports whether the spec declares a map with string values,
-// and whether gatekit.Waive constructs it. The three shapes such a declaration
-// takes are the bare literal, the type with no value, and the literal handed to
-// Waive.
-func stringValuedMap(spec *ast.ValueSpec, waive string) (mapped, waived bool) {
+// reasonMapOrWaiverSet reports what the spec is to this census: mapped when it
+// declares a map with string values — the shape rule 1 requires classified — and
+// waived when it declares a waiver set, which rule 1 has nothing left to ask of
+// and rule 2 requires one sweep of.
+//
+// A reason map takes two shapes, the bare literal and the type with no value —
+// the second being a map the test's own walk fills. A waiver set takes two as
+// well, and neither reads the entries: gatekit.Waive is the signal wherever its
+// argument came from, because a set a helper assembles is ratified exactly as
+// much as one written inline; and the *gatekit.Waivers[…] type names a waiver set
+// however the value reaches the name.
+func reasonMapOrWaiverSet(spec *ast.ValueSpec, gatekitLocal string) (mapped, waived bool) {
+	if isWaiversType(spec.Type, gatekitLocal) {
+		return false, true
+	}
+	for _, value := range spec.Values {
+		call, isCall := value.(*ast.CallExpr)
+		if isCall && namesGatekitMember(call.Fun, gatekitLocal, "Waive") {
+			return false, true
+		}
+	}
 	if isStringValuedMapType(spec.Type) {
 		return true, false
 	}
 	for _, value := range spec.Values {
-		switch expr := value.(type) {
-		case *ast.CompositeLit:
-			if isStringValuedMapType(expr.Type) {
-				return true, false
-			}
-		case *ast.CallExpr:
-			if !isWaiveCall(expr.Fun, waive) {
-				continue
-			}
-			for _, arg := range expr.Args {
-				literal, isLiteral := arg.(*ast.CompositeLit)
-				if isLiteral && isStringValuedMapType(literal.Type) {
-					return true, true
-				}
-			}
+		literal, isLiteral := value.(*ast.CompositeLit)
+		if isLiteral && isStringValuedMapType(literal.Type) {
+			return true, false
 		}
 	}
 	return false, false
@@ -317,26 +326,38 @@ func isStringValuedMapType(expr ast.Expr) bool {
 	return isIdent && value.Name == "string"
 }
 
-// isWaiveCall reports whether the callee is gatekit.Waive, named through the
-// local name the file imports gatekit under, or unqualified inside gatekit's own
-// package.
-func isWaiveCall(callee ast.Expr, waive string) bool {
-	if waive == "" {
+// isWaiversType reports whether the expression names gatekit's waiver-set type,
+// instantiated as a generic type must be: `*gatekit.Waivers[string]`, or
+// `Waivers[K]` inside gatekit itself. A pointer is stripped first — what the
+// declaration holds is a waiver set either way.
+func isWaiversType(expr ast.Expr, gatekitLocal string) bool {
+	if pointer, isPointer := expr.(*ast.StarExpr); isPointer {
+		expr = pointer.X
+	}
+	instantiated, isInstantiated := expr.(*ast.IndexExpr)
+	return isInstantiated && namesGatekitMember(instantiated.X, gatekitLocal, "Waivers")
+}
+
+// namesGatekitMember reports whether the expression names the given gatekit
+// identifier, through the local name the file imports gatekit under, or
+// unqualified inside gatekit's own package.
+func namesGatekitMember(expr ast.Expr, gatekitLocal, member string) bool {
+	if gatekitLocal == "" {
 		return false
 	}
-	if bare, isIdent := callee.(*ast.Ident); isIdent {
-		return waive == "." && bare.Name == "Waive"
+	if bare, isIdent := expr.(*ast.Ident); isIdent {
+		return gatekitLocal == "." && bare.Name == member
 	}
-	selector, isSelector := callee.(*ast.SelectorExpr)
-	if !isSelector || selector.Sel.Name != "Waive" {
+	selector, isSelector := expr.(*ast.SelectorExpr)
+	if !isSelector || selector.Sel.Name != member {
 		return false
 	}
 	qualifier, isIdent := selector.X.(*ast.Ident)
-	return isIdent && qualifier.Name == waive
+	return isIdent && qualifier.Name == gatekitLocal
 }
 
 // gatekitName is the local name the file imports gatekit under, "." inside
-// gatekit's own package, and "" when the file cannot name Waive at all.
+// gatekit's own package, and "" when the file cannot name gatekit at all.
 // Resolving the name keeps an aliased import inside the rule instead of
 // silently reclassifying its waivers as bare maps.
 func gatekitName(t *testing.T, pf parsedFile) string {

--- a/backend/gatecensus_test.go
+++ b/backend/gatecensus_test.go
@@ -1,0 +1,430 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package backendarch
+
+// The census over this repo's own gate machinery: a gate's exceptions are held
+// to the standard the gate holds its subjects to.
+//
+// gatekit gives a waiver two obligations — state what it costs, and describe
+// code that still exists — and enforces both. A map declared beside a gate
+// instead of inside gatekit has neither: it reads as a ratified exception while
+// certifying nothing, and it is one `var` away from every gate in the tree. The
+// three rules here derive the population from the tree rather than tracking it
+// as a list, so the next declaration inherits the obligation:
+//
+//   - a package-level map from subject to reason, in a test file, is either a
+//     gatekit.Waivers set or a declared fixture;
+//   - every waiver set is swept for staleness from exactly one place;
+//   - nothing but a test reaches the waiver machinery at all.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+const (
+	// backendTree is the census universe: every Go file this module and the tool
+	// module under it declare, whichever tier they sit in.
+	backendTree = "."
+
+	// gatekitImportPath is the waiver machinery every rule here is about.
+	gatekitImportPath = "github.com/gradionhq/margince/backend/internal/shared/gatekit"
+
+	// fixtureMarker declares that a package-level reason map is deliberately NOT
+	// a waiver, and the text after it says what the map is instead — expected
+	// data a test compares against, or state the test's own walk writes. The
+	// marker classifies; it never excuses, which is why the text is required: a
+	// bare marker would be the reasonless waiver this census exists to refuse.
+	fixtureMarker = "gatekit:fixture"
+
+	// wantFixtureAnnotations pins how many declarations carry the marker.
+	// Permitting the marker without counting it would let it spread quietly and
+	// reopen the class these rules close; pinned, every new one moves a number a
+	// reviewer sees.
+	wantFixtureAnnotations = 9
+)
+
+// reasonMap is one package-level declaration mapping subjects to strings — the
+// population rules 1 and 2 are derived over.
+type reasonMap struct {
+	path   string
+	pkg    string
+	line   int
+	name   string
+	waived bool // constructed through gatekit.Waive
+}
+
+// A package-level map from subject to reason is a waiver or a declared fixture.
+//
+// Both halves of a waiver's contract live in gatekit: a reason too short to
+// state a cost fails where the entry is relied on, and an entry no subject
+// reached is reported stale. A bare map beside a gate has neither, so it keeps
+// reading as ratification long after the code it named is gone. The alternative
+// is not "no map" — some of these maps ARE the assertion — but saying which,
+// once, at the declaration.
+func TestEveryPackageLevelReasonMapIsAWaiverOrADeclaredFixture(t *testing.T) {
+	files, fset := censusFiles(t, "test source", isTestSource)
+	declared, annotated, written := 0, 0, 0
+	for _, pf := range files {
+		markers, commented := fixtureMarkers(pf, fset)
+		written += len(markers)
+		for _, decl := range reasonMaps(t, pf, fset) {
+			declared++
+			reason, marked := fixtureReason(markers, commented, decl.line)
+			switch {
+			case decl.waived && marked:
+				t.Errorf("%s:%d: %s is a waiver set and also carries a %s marker: the marker says a map "+
+					"is not a waiver, so on a waiver it contradicts the declaration — drop it",
+					decl.path, decl.line, decl.name, fixtureMarker)
+			case decl.waived:
+			case !marked:
+				t.Errorf("%s:%d: %s maps subjects to reason strings but is neither a waiver nor a declared "+
+					"fixture: wrap it in gatekit.Waive so its reasons are held to a standard and its stale "+
+					"entries reported, or, if the values are expected data rather than costs, say so with a "+
+					"`// %s <what it is>` line on the declaration",
+					decl.path, decl.line, decl.name, fixtureMarker)
+			case reason == "":
+				annotated++
+				t.Errorf("%s:%d: %s carries a bare %s marker: the marker only says the map is not a waiver, "+
+					"so without the text saying what it IS, it is the reasonless exception this census refuses",
+					decl.path, decl.line, decl.name, fixtureMarker)
+			default:
+				annotated++
+			}
+		}
+	}
+	if declared == 0 {
+		t.Fatalf("no package-level map-to-string declaration found in %d test sources — the walk enumerates "+
+			"nothing, and a census that matches nothing certifies the whole tree", len(files))
+	}
+	if annotated != wantFixtureAnnotations {
+		t.Errorf("%d declarations are marked %s, pinned at %d: a fixture is a classification made once, so "+
+			"move the pin in the same change that adds or removes one",
+			annotated, fixtureMarker, wantFixtureAnnotations)
+	}
+	if written != annotated {
+		t.Errorf("%d %s markers are written but %d sit on a declaration this census enumerates: a marker "+
+			"anywhere else classifies nothing — put it on the declaration's own comment block, with no blank "+
+			"line between", written, fixtureMarker, annotated)
+	}
+}
+
+// Every waiver set is swept for staleness from exactly one place.
+//
+// AssertAllMatched is what turns a waiver from a permanent grant into one that
+// has to keep describing live code, and gatekit cannot call it for you: zero
+// call sites makes that sweep opt-in, which is the same as absent. Two are no
+// better than zero — matched accumulates across every test in the package, so
+// whichever runs first sees the other's subjects unreached and reports staleness
+// that is not there.
+func TestEveryWaiversDeclarationIsSweptForStalenessExactlyOnce(t *testing.T) {
+	files, fset := censusFiles(t, "Go source", func(string) bool { return true })
+
+	// A package, not a directory: a waiver set is unexported, so only the
+	// package that declares it can name it in a sweep.
+	type pkgKey struct{ dir, pkg string }
+	sweeps := map[pkgKey]map[string]int{}
+	var declared []reasonMap
+	for _, pf := range files {
+		key := pkgKey{dir: path.Dir(pf.path), pkg: pf.file.Name.Name}
+		if sweeps[key] == nil {
+			sweeps[key] = map[string]int{}
+		}
+		for receiver, count := range assertAllMatchedSites(pf) {
+			sweeps[key][receiver] += count
+		}
+		for _, decl := range reasonMaps(t, pf, fset) {
+			if decl.waived {
+				declared = append(declared, decl)
+			}
+		}
+	}
+	if len(declared) == 0 {
+		t.Fatalf("no gatekit.Waive declaration found in %d Go sources — the walk enumerates nothing, and a "+
+			"census that matches nothing certifies the whole tree", len(files))
+	}
+	for _, decl := range declared {
+		switch sweeps[pkgKey{path.Dir(decl.path), decl.pkg}][decl.name] {
+		case 1:
+		case 0:
+			t.Errorf("%s:%d: nothing calls %s.AssertAllMatched: an entry that matched no subject then reads "+
+				"as ratification of code that is gone — call it once, from the test that walks the full "+
+				"subject set", decl.path, decl.line, decl.name)
+		default:
+			t.Errorf("%s:%d: %s.AssertAllMatched is called from more than one place in package %s: matches "+
+				"accumulate across the package's tests, so whichever asserts first reports staleness that is "+
+				"not there — leave the call to the test that walks the full subject set",
+				decl.path, decl.line, decl.name, decl.pkg)
+		}
+	}
+}
+
+// gatekit serves tests only.
+//
+// gatekit is test infrastructure living in internal/shared, a tier that
+// otherwise holds the product's Tier-0 domain leaves. That placement is safe
+// only while product code cannot reach it: a waiver mechanism callable from a
+// store would be a way to mark shipped behaviour "ratified", which is the one
+// thing a waiver must not be able to do.
+//
+// The walk covers every non-test Go file in the backend tree — internal/, cmd/,
+// pkg/, migrations/ and the tools module — which is the whole population able to
+// reach gatekit at all. The workspace's other modules (composition, cli/craft,
+// extensions/*) sit outside the github.com/gradionhq/margince/backend/ prefix,
+// so the toolchain's internal-package rule refuses them the import before this
+// walk would have to.
+func TestGatekitServesTestsOnly(t *testing.T) {
+	files, _ := censusFiles(t, "product source", func(p string) bool { return !isTestSource(p) })
+	for _, pf := range files {
+		for _, imported := range pf.file.Imports {
+			if importPath(t, pf.path, imported) != gatekitImportPath {
+				continue
+			}
+			t.Errorf("%s imports gatekit from product code: a gate's exceptions must not be reachable from "+
+				"the code they would exempt, or a shipped path could ratify itself", pf.path)
+		}
+	}
+}
+
+// censusFiles parses every Go file under the backend tree that keep admits,
+// comments included, and fails when it admits none: each rule proves its own
+// walk finds something, because a walk that matches nothing reports green over
+// whatever it was pointed away from.
+//
+// Files are parsed one at a time rather than loaded as packages so that a build
+// constraint cannot hide one — the integration-tagged suites hold waivers too,
+// and they are exactly the ones an untagged build never compiles.
+func censusFiles(t *testing.T, what string, keep func(path string) bool) ([]parsedFile, *token.FileSet) {
+	t.Helper()
+	fset := token.NewFileSet()
+	var out []parsedFile
+	err := filepath.WalkDir(backendTree, func(walked string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil || entry.IsDir() {
+			return walkErr
+		}
+		rel := filepath.ToSlash(walked)
+		if !strings.HasSuffix(rel, ".go") || !keep(rel) {
+			return nil
+		}
+		file, parseErr := parser.ParseFile(fset, walked, nil, parser.ParseComments)
+		if parseErr != nil {
+			return parseErr
+		}
+		out = append(out, parsedFile{path: rel, file: file})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking %s for every %s: %v", backendTree, what, err)
+	}
+	if len(out) == 0 {
+		t.Fatalf("no %s found under %s — the census is reading the wrong tree", what, backendTree)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].path < out[j].path })
+	return out, fset
+}
+
+// isTestSource reports whether the path is a Go test file — the only tier the
+// waiver machinery belongs to.
+func isTestSource(path string) bool { return strings.HasSuffix(path, "_test.go") }
+
+// reasonMaps returns every package-level declaration in the file whose value
+// type is string, keyed by any type at all.
+//
+// The walk is over the file's declarations, not over its text: a declaration
+// inside a `var ( … )` group is invisible to a pattern anchored on `var`. The
+// key is deliberately unconstrained — a waiver is keyed by the vocabulary its
+// gate draws subjects from, a record type or a table name as readily as a
+// string, and a rule that only saw map[string]string would sail past the typed
+// ones while typed keys are the direction gatekit pushes.
+func reasonMaps(t *testing.T, pf parsedFile, fset *token.FileSet) []reasonMap {
+	t.Helper()
+	waive := gatekitName(t, pf)
+	var out []reasonMap
+	for _, decl := range pf.file.Decls {
+		gen, isGen := decl.(*ast.GenDecl)
+		if !isGen || gen.Tok != token.VAR {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			value, isValue := spec.(*ast.ValueSpec)
+			if !isValue {
+				continue
+			}
+			mapped, waived := stringValuedMap(value, waive)
+			if !mapped {
+				continue
+			}
+			for _, name := range value.Names {
+				out = append(out, reasonMap{
+					path:   pf.path,
+					pkg:    pf.file.Name.Name,
+					line:   fset.Position(value.Pos()).Line,
+					name:   name.Name,
+					waived: waived,
+				})
+			}
+		}
+	}
+	return out
+}
+
+// stringValuedMap reports whether the spec declares a map with string values,
+// and whether gatekit.Waive constructs it. The three shapes such a declaration
+// takes are the bare literal, the type with no value, and the literal handed to
+// Waive.
+func stringValuedMap(spec *ast.ValueSpec, waive string) (mapped, waived bool) {
+	if isStringValuedMapType(spec.Type) {
+		return true, false
+	}
+	for _, value := range spec.Values {
+		switch expr := value.(type) {
+		case *ast.CompositeLit:
+			if isStringValuedMapType(expr.Type) {
+				return true, false
+			}
+		case *ast.CallExpr:
+			if !isWaiveCall(expr.Fun, waive) {
+				continue
+			}
+			for _, arg := range expr.Args {
+				literal, isLiteral := arg.(*ast.CompositeLit)
+				if isLiteral && isStringValuedMapType(literal.Type) {
+					return true, true
+				}
+			}
+		}
+	}
+	return false, false
+}
+
+// isStringValuedMapType reports whether the expression is a map type whose
+// values are strings — the reason side of a subject-to-reason map.
+func isStringValuedMapType(expr ast.Expr) bool {
+	mapType, isMap := expr.(*ast.MapType)
+	if !isMap {
+		return false
+	}
+	value, isIdent := mapType.Value.(*ast.Ident)
+	return isIdent && value.Name == "string"
+}
+
+// isWaiveCall reports whether the callee is gatekit.Waive, named through the
+// local name the file imports gatekit under, or unqualified inside gatekit's own
+// package.
+func isWaiveCall(callee ast.Expr, waive string) bool {
+	if waive == "" {
+		return false
+	}
+	if bare, isIdent := callee.(*ast.Ident); isIdent {
+		return waive == "." && bare.Name == "Waive"
+	}
+	selector, isSelector := callee.(*ast.SelectorExpr)
+	if !isSelector || selector.Sel.Name != "Waive" {
+		return false
+	}
+	qualifier, isIdent := selector.X.(*ast.Ident)
+	return isIdent && qualifier.Name == waive
+}
+
+// gatekitName is the local name the file imports gatekit under, "." inside
+// gatekit's own package, and "" when the file cannot name Waive at all.
+// Resolving the name keeps an aliased import inside the rule instead of
+// silently reclassifying its waivers as bare maps.
+func gatekitName(t *testing.T, pf parsedFile) string {
+	t.Helper()
+	if pf.file.Name.Name == "gatekit" {
+		return "."
+	}
+	for _, imported := range pf.file.Imports {
+		if importPath(t, pf.path, imported) != gatekitImportPath {
+			continue
+		}
+		if imported.Name != nil {
+			return imported.Name.Name
+		}
+		return "gatekit"
+	}
+	return ""
+}
+
+// importPath is the unquoted path of an import spec.
+func importPath(t *testing.T, file string, imported *ast.ImportSpec) string {
+	t.Helper()
+	unquoted, err := strconv.Unquote(imported.Path.Value)
+	if err != nil {
+		t.Fatalf("%s: import path %s does not unquote: %v", file, imported.Path.Value, err)
+	}
+	return unquoted
+}
+
+// fixtureMarkers indexes every fixture marker in the file by the line it sits
+// on, mapped to the text after it, alongside the line of every comment so a
+// marker can be tied to the declaration below it.
+//
+// Text is read raw off each comment, as cli/craft reads its own //craft:ignore
+// directives. Go treats any comment matching //<word>:<word> as a directive and
+// CommentGroup.Text() drops directives, so a marker read through Text() is
+// invisible to the census that requires it — the space after the slashes keeps
+// the marker readable to a person, not findable to this walk.
+func fixtureMarkers(pf parsedFile, fset *token.FileSet) (markers map[int]string, commented map[int]bool) {
+	markers = map[int]string{}
+	commented = map[int]bool{}
+	for _, group := range pf.file.Comments {
+		for _, comment := range group.List {
+			line := fset.Position(comment.Slash).Line
+			commented[line] = true
+			text := strings.TrimSpace(strings.TrimPrefix(strings.TrimPrefix(comment.Text, "//"), "/*"))
+			if !strings.HasPrefix(text, fixtureMarker) {
+				continue
+			}
+			reason := strings.TrimSuffix(strings.TrimSpace(text[len(fixtureMarker):]), "*/")
+			markers[line] = strings.TrimSpace(reason)
+		}
+	}
+	return markers, commented
+}
+
+// fixtureReason returns the reason from the marker in the comment block directly
+// above line, and whether that block carries one at all. Adjacency is what binds
+// a marker to a declaration: a marker one blank line away annotates nothing, and
+// a marker further up the file annotates whatever it does sit above.
+func fixtureReason(markers map[int]string, commented map[int]bool, line int) (string, bool) {
+	for above := line - 1; commented[above]; above-- {
+		if reason, marked := markers[above]; marked {
+			return reason, true
+		}
+	}
+	return "", false
+}
+
+// assertAllMatchedSites counts, per receiver name, the AssertAllMatched calls in
+// the file.
+func assertAllMatchedSites(pf parsedFile) map[string]int {
+	sites := map[string]int{}
+	ast.Inspect(pf.file, func(node ast.Node) bool {
+		call, isCall := node.(*ast.CallExpr)
+		if !isCall {
+			return true
+		}
+		selector, isSelector := call.Fun.(*ast.SelectorExpr)
+		if !isSelector || selector.Sel.Name != "AssertAllMatched" {
+			return true
+		}
+		receiver, isIdent := selector.X.(*ast.Ident)
+		if !isIdent {
+			return true
+		}
+		sites[receiver.Name]++
+		return true
+	})
+	return sites
+}

--- a/backend/gatecensus_test.go
+++ b/backend/gatecensus_test.go
@@ -50,7 +50,7 @@ const (
 	// Permitting the marker without counting it would let it spread quietly and
 	// reopen the class these rules close; pinned, every new one moves a number a
 	// reviewer sees.
-	wantFixtureAnnotations = 9
+	wantFixtureAnnotations = 11
 )
 
 // censusDecl is one package-level declaration this census governs — a map from

--- a/backend/gatecensus_test.go
+++ b/backend/gatecensus_test.go
@@ -315,6 +315,94 @@ func reasonMapOrWaiverSet(spec *ast.ValueSpec, gatekitLocal string) (mapped, wai
 	return false, false
 }
 
+// Every spelling the classifier admits is pinned here, because rules 1 and 2
+// derive their whole population from it: a shape it stops recognising drops those
+// declarations out of the census silently, and the census then reads green over
+// the maps it was written to govern. The typed spelling is the one that needs
+// this most — nothing in the tree declares a waiver that way today, so only a
+// probe can prove the arm still classifies it.
+func TestTheCensusClassifiesEveryWaiverAndReasonMapSpelling(t *testing.T) {
+	for _, probe := range []struct {
+		name        string
+		declaration string
+		mapped      bool
+		waived      bool
+	}{
+		{
+			name:        "a waiver built from an inline literal is a waiver",
+			declaration: `var x = gatekit.Waive(map[string]string{"a": "why a is ratified"})`,
+			waived:      true,
+		},
+		{
+			name:        "a waiver a helper assembles is ratified exactly as much",
+			declaration: `var x = gatekit.Waive(buildWaivers())`,
+			waived:      true,
+		},
+		{
+			name:        "the typed declaration names a waiver however the value reaches it",
+			declaration: `var x *gatekit.Waivers[string] = build()`,
+			waived:      true,
+		},
+		{
+			name:        "a bare reason map is the shape rule 1 requires classified",
+			declaration: `var x = map[string]string{"a": "the reason a is listed"}`,
+			mapped:      true,
+		},
+		{
+			name:        "a reason map keyed by a domain type is one too",
+			declaration: `var x = map[datasource.RecordType]string{}`,
+			mapped:      true,
+		},
+		{
+			name:        "a reason map the test's own walk fills declares only its type",
+			declaration: `var x map[string]string`,
+			mapped:      true,
+		},
+		{
+			name:        "a map that holds no reasons is neither",
+			declaration: `var x = map[string]bool{"a": true}`,
+		},
+	} {
+		t.Run(probe.name, func(t *testing.T) {
+			spec, gatekitLocal := probeDeclaration(t, probe.declaration)
+			mapped, waived := reasonMapOrWaiverSet(spec, gatekitLocal)
+			if mapped != probe.mapped || waived != probe.waived {
+				t.Errorf("reasonMapOrWaiverSet(%s) = mapped %t, waived %t; want mapped %t, waived %t",
+					probe.declaration, mapped, waived, probe.mapped, probe.waived)
+			}
+		})
+	}
+}
+
+// probeDeclaration parses one package-level var declaration and returns its spec
+// alongside the local name gatekit is imported under, so a probe exercises the
+// same name resolution a file in the tree does.
+//
+// The source is a string rather than a file: a probe package on disk would be
+// walked by this census and by every other gate that reads the tree, and the
+// declarations here are deliberately the shapes those gates report on.
+func probeDeclaration(t *testing.T, declaration string) (*ast.ValueSpec, string) {
+	t.Helper()
+	source := "package probe\n\nimport \"" + gatekitImportPath + "\"\n\n" + declaration + "\n"
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "probe.go", source, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("parsing the probe declaration %q: %v", declaration, err)
+	}
+	pf := parsedFile{path: "probe.go", file: file}
+	for _, decl := range file.Decls {
+		gen, isGen := decl.(*ast.GenDecl)
+		if !isGen || gen.Tok != token.VAR {
+			continue
+		}
+		if spec, isValue := gen.Specs[0].(*ast.ValueSpec); isValue {
+			return spec, gatekitName(t, pf)
+		}
+	}
+	t.Fatalf("the probe declaration %q holds no package-level var for the census to classify", declaration)
+	return nil, ""
+}
+
 // isStringValuedMapType reports whether the expression is a map type whose
 // values are strings — the reason side of a subject-to-reason map.
 func isStringValuedMapType(expr ast.Expr) bool {

--- a/backend/idempotencymap_test.go
+++ b/backend/idempotencymap_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/gradionhq/margince/backend/internal/shared/gatekit"
 )
 
 const idempotencyMapSource = "internal/compose/replayscope.go"
@@ -34,14 +36,14 @@ const idempotencyMapSource = "internal/compose/replayscope.go"
 // be honored yet. An exemption never outlives its cause: an entry the
 // contract stops declaring, or one that shows up in the runtime map
 // anyway, fails the gate.
-var idempotencyExemptions = map[string]string{
+var idempotencyExemptions = gatekit.Waive(map[string]string{
 	"POST /v1/public/booking/{host_slug}": "anonymous edge: every visitor shares the" +
 		" system:public_booking principal, so the middleware's per-principal claim scope" +
 		" cannot tell callers apart — one visitor's key + body would replay another's" +
 		" recorded confirmation; the anonymous surface needs its own dedupe scope" +
 		" (workspace + request digest) before the promise can be honored, and the slot's" +
 		" natural key refuses duplicate bookings meanwhile",
-}
+})
 
 // contractOperation is the slice of one crm.yaml operation this gate
 // reads: the parameter list, each entry either a $ref or an inline
@@ -144,6 +146,7 @@ func mappedIdempotentOperations(t *testing.T) map[string]bool {
 }
 
 func TestIdempotentOperationsMirrorTheContract(t *testing.T) {
+	defer idempotencyExemptions.AssertAllMatched(t)
 	declared := idempotencyKeyDeclarations(t)
 	mapped := mappedIdempotentOperations(t)
 	// Vacuous-pass guards: both sides carry dozens of operations; finding
@@ -156,7 +159,7 @@ func TestIdempotentOperationsMirrorTheContract(t *testing.T) {
 		t.Fatalf("found only %d entries in replayableOperations — the source extractor no longer sees the map", len(mapped))
 	}
 
-	for op := range idempotencyExemptions {
+	for _, op := range idempotencyExemptions.Subjects() {
 		if !declared[op] {
 			t.Errorf("idempotencyExemptions names %s but the contract no longer declares IdempotencyKey on it — delete the stale exemption", op)
 		}
@@ -165,7 +168,7 @@ func TestIdempotentOperationsMirrorTheContract(t *testing.T) {
 		}
 	}
 	for op := range declared {
-		if !mapped[op] && idempotencyExemptions[op] == "" {
+		if !mapped[op] && !idempotencyExemptions.Waived(t, op) {
 			t.Errorf("%s declares the IdempotencyKey parameter but is missing from replayableOperations — a retried request re-executes instead of replaying", op)
 		}
 	}

--- a/backend/idempotencymap_test.go
+++ b/backend/idempotencymap_test.go
@@ -146,7 +146,6 @@ func mappedIdempotentOperations(t *testing.T) map[string]bool {
 }
 
 func TestIdempotentOperationsMirrorTheContract(t *testing.T) {
-	defer idempotencyExemptions.AssertAllMatched(t)
 	declared := idempotencyKeyDeclarations(t)
 	mapped := mappedIdempotentOperations(t)
 	// Vacuous-pass guards: both sides carry dozens of operations; finding
@@ -158,6 +157,9 @@ func TestIdempotentOperationsMirrorTheContract(t *testing.T) {
 	if len(mapped) < 20 {
 		t.Fatalf("found only %d entries in replayableOperations — the source extractor no longer sees the map", len(mapped))
 	}
+	// Registered only past the vacuity guards: on either Fatal every entry would
+	// report as unmatched, burying the one failure that explains all of them.
+	defer idempotencyExemptions.AssertAllMatched(t)
 
 	for _, op := range idempotencyExemptions.Subjects() {
 		if !declared[op] {

--- a/backend/internal/compose/agentgate_pin_test.go
+++ b/backend/internal/compose/agentgate_pin_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/approvals"
 	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/modules/webhooks"
+	"github.com/gradionhq/margince/backend/internal/shared/gatekit"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -82,7 +83,7 @@ func TestStageRefusalNamesTheTargetAndSuppliesNoClientPin(t *testing.T) {
 // nobody has. The gate can only see membership in approvals.versionTables, so
 // whether a column is live is a claim these rationales make and a reader must be
 // able to check.
-var unpinnableConfirmFirstTypes = map[string]string{
+var unpinnableConfirmFirstTypes = gatekit.Waive(map[agentRecordType]string{
 	"custom_field": "custom_field HAS a version column (migrations/core/0063) but nothing maintains it: " +
 		"the catalog's own writers (customfields' rename, options and retire paths) issue bare UPDATEs " +
 		"rather than storekit's guarded patch, so the column never leaves 1 and never takes an If-Match. " +
@@ -98,7 +99,7 @@ var unpinnableConfirmFirstTypes = map[string]string{
 		"`incumbent_connection` (migrations/custom/20260716120000_overlay), under a different name and " +
 		"with no version column, so approvals.targetVersion cannot even resolve a table for this target " +
 		"type. connect/disconnect are whole-row transitions the diff_hash binds.",
-}
+})
 
 // Every confirm-first operation that names a concrete record type must have
 // a type the approvals engine can PIN — or sit in the ratified list above
@@ -108,13 +109,8 @@ var unpinnableConfirmFirstTypes = map[string]string{
 // confirm-first routes carried a pin the agent could simply decline to
 // supply, and nothing said so.
 func TestConfirmFirstTargetsArePinnable(t *testing.T) {
-	for recordType, rationale := range unpinnableConfirmFirstTypes {
-		if strings.TrimSpace(rationale) == "" {
-			t.Errorf("unpinnableConfirmFirstTypes[%s] has no rationale — a waiver must say why no pin is possible", recordType)
-		}
-	}
+	defer unpinnableConfirmFirstTypes.AssertAllMatched(t)
 
-	used := map[string]bool{}
 	checked := 0
 	for route, pol := range agentPolicies {
 		if pol.Access != accessTool || pol.Tier == tierAutoExecute || pol.RecordType == "" {
@@ -124,8 +120,7 @@ func TestConfirmFirstTargetsArePinnable(t *testing.T) {
 		if approvals.TargetVersionCheckable(string(pol.RecordType)) {
 			continue
 		}
-		if _, ratified := unpinnableConfirmFirstTypes[string(pol.RecordType)]; ratified {
-			used[string(pol.RecordType)] = true
+		if unpinnableConfirmFirstTypes.Waived(t, pol.RecordType) {
 			continue
 		}
 		t.Errorf("%s (%s) stages against %q, which carries no version pin — either give the table a version column "+
@@ -133,11 +128,6 @@ func TestConfirmFirstTargetsArePinnable(t *testing.T) {
 	}
 	if checked == 0 {
 		t.Fatal("no confirm-first record-typed routes in the generated policy — the pin no longer covers anything")
-	}
-	for recordType := range unpinnableConfirmFirstTypes {
-		if !used[recordType] {
-			t.Errorf("unpinnableConfirmFirstTypes[%s] matches no confirm-first route — stale waiver, remove it", recordType)
-		}
 	}
 }
 
@@ -216,7 +206,7 @@ func TestRedemptionWithoutAPinLeavesIfMatchAlone(t *testing.T) {
 // surface or a passport's REST call can stage today. It is written down so the
 // class is enumerated rather than invisible, and so it can only shrink — a NEW
 // confirm-first record type joins it deliberately or fails the gate below.
-var undecidableConfirmFirstTypes = map[string]string{
+var undecidableConfirmFirstTypes = gatekit.Waive(map[agentRecordType]string{
 	"record_grant": "createRecordGrant/revokeRecordGrant, undecidable on BOTH halves of the " +
 		"claim, and neither is fixable here. AUTHORITY: share_record resolves its decision grant " +
 		"from the target's entity type, so deciding one demands `record_grant.update` — and " +
@@ -229,7 +219,7 @@ var undecidableConfirmFirstTypes = map[string]string{
 		"minting `record_grant` as one, is a product decision about whether an agent may propose " +
 		"sharing at all; making the row merely decidable would leave an operation that still never " +
 		"lands, which is worse than an honest dead end.",
-}
+})
 
 // stagedRowDecidable answers the gate's WHOLE claim about one route's staged
 // row: that a human can see it, and that the grants deciding it derives are ones
@@ -280,13 +270,8 @@ func stagedRowDecidable(pol agentPolicy, hasTargetID bool) (bool, string) {
 // its type with a NULL id — a different decidability question from the same
 // type's, and one a type-only walk answers green over.
 func TestEveryConfirmFirstTargetTypeIsDecidable(t *testing.T) {
-	for recordType, cost := range undecidableConfirmFirstTypes {
-		if strings.TrimSpace(cost) == "" {
-			t.Errorf("undecidableConfirmFirstTypes[%s] has no reason — a waiver must say what it costs", recordType)
-		}
-	}
+	defer undecidableConfirmFirstTypes.AssertAllMatched(t)
 
-	used := map[string]bool{}
 	checked := 0
 	for route, pol := range agentPolicies {
 		if pol.Access != accessTool || pol.Tier == tierAutoExecute || pol.RecordType == "" {
@@ -306,8 +291,7 @@ func TestEveryConfirmFirstTargetTypeIsDecidable(t *testing.T) {
 		if decidable {
 			continue
 		}
-		if _, ratified := undecidableConfirmFirstTypes[string(pol.RecordType)]; ratified {
-			used[string(pol.RecordType)] = true
+		if undecidableConfirmFirstTypes.Waived(t, pol.RecordType) {
 			continue
 		}
 		t.Errorf("%s (%s) stages against %q, which %s. No human could ever release or reject that row. "+
@@ -316,12 +300,6 @@ func TestEveryConfirmFirstTargetTypeIsDecidable(t *testing.T) {
 	}
 	if checked == 0 {
 		t.Fatal("no confirm-first record-typed routes in the generated policy — the gate no longer covers anything")
-	}
-	for recordType := range undecidableConfirmFirstTypes {
-		if !used[recordType] {
-			t.Errorf("undecidableConfirmFirstTypes[%s] matches no confirm-first route, or the type gained a "+
-				"visibility rule — stale waiver, remove it", recordType)
-		}
 	}
 }
 

--- a/backend/internal/compose/agentgate_scope_test.go
+++ b/backend/internal/compose/agentgate_scope_test.go
@@ -26,7 +26,7 @@ func TestOutboundVerbsRequireTheSendScope(t *testing.T) {
 	// registered tool that declares egress. Deriving it is what makes closing a
 	// hole at the wrong scope fail here rather than pass quietly.
 	outbound := map[string]bool{}
-	for verb := range outboundHoles {
+	for _, verb := range outboundHoles.Subjects() {
 		outbound[verb] = true
 	}
 	for _, spec := range NewRegistry(nil, SendPath{}).Specs() {
@@ -45,7 +45,7 @@ func TestOutboundVerbsRequireTheSendScope(t *testing.T) {
 			// ScopeSend here. TestThePinsDescribeVerbsThatStillExist covers
 			// the other half: it fails the moment the verb gains a tool,
 			// which is when this branch starts asserting on it instead.
-			if _, pinned := outboundHoles[pol.Tool]; !pinned {
+			if !outboundHoles.Waived(t, pol.Tool) {
 				t.Errorf("%s (%s) is derived as outbound but is neither registered nor a pinned hole", pol.Tool, route)
 			}
 			continue

--- a/backend/internal/compose/agentpolicysynthesis_test.go
+++ b/backend/internal/compose/agentpolicysynthesis_test.go
@@ -14,28 +14,29 @@ package compose
 
 import (
 	"sort"
-	"strings"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/gatekit"
 )
 
 // synthesizedVerbs maps each verb that legitimately resolves without a
 // registered tool to the reason it may. An entry claims `write` is the right
 // cap for it.
-var synthesizedVerbs = map[string]string{
+var synthesizedVerbs = gatekit.Waive(map[string]string{
 	"advance_project_phase": "internal state change on a project; reversible by advancing again",
 	"draft_offer":           "regenerates a draft in place — no message is transmitted to a counterparty; the AI lane may send the deal's context to the configured model provider, but that is governed by model routing and budget, not the send scope",
 	"relink_activity":       "moves an activity between records; internal and reversible",
 	"render_offer":          "renders a document for the caller; no transmission",
 	"disqualify_lead":       "internal lifecycle change; the row survives disqualification",
 	"disconnect_incumbent":  "revokes the connection row, purges the mirror, and flips the workspace to native mode, all local; the sealed vault credential it deletes afterward is our own Postgres-backed store, not the incumbent — nothing here calls out. Contrast connect_incumbent (outboundHoles), which calls the incumbent's API and writes that credential in the first place",
-}
+})
 
 // outboundHoles are synthesized verbs that DO leave the workspace and are
 // admitted under `write` today. The value names the scope each should carry
 // — or, where that has not been decided, says so and why — so the pin reads
 // as the debt it is rather than as approval. Closing one means registering a
 // tool for it (as send_message was) and deleting its line.
-var outboundHoles = map[string]string{
+var outboundHoles = gatekit.Waive(map[string]string{
 	// send_offer only flips the offer's status to sent, freezes fx_rate_to_base
 	// and the buyer/issuer snapshots, and emits offer.sent
 	// (deals/offer_lifecycle.go:39-96) — no delivery, no counterparty
@@ -49,7 +50,7 @@ var outboundHoles = map[string]string{
 	"enrich":            "enrich",
 	"connect_incumbent": "write is likely right for authenticating a connection, but the tier and scope were never decided together",
 	"reconcile_overlay": "enrich — the sweep it queues calls overlay.Reconcile's inc.Modified fetch against the incumbent's API and spends its budget",
-}
+})
 
 // deadEndVerbs are synthesized verbs whose approved-and-redeemed agent call
 // can never execute: the handler behind them requires a human principal, so
@@ -59,18 +60,14 @@ var outboundHoles = map[string]string{
 // and outboundHoles (egress admitted under the wrong scope) — because
 // neither of those labels is true of them: the verb is reachable, resolves
 // at `write` by synthesis, and yet no agent call through it can ever land.
-var deadEndVerbs = map[string]string{
+var deadEndVerbs = gatekit.Waive(map[string]string{
 	"share_record": "createRecordGrant/revokeRecordGrant (identity/grants.go:141,189) reject any principal.Actor whose Type is not PrincipalHuman. Redemption (agents.RedeemAndMark, compose/agentgate.go) marks the context as released but never changes the actor's type — the redeeming caller is still the staging agent — so an agent-staged, human-approved share_record is refused at redemption every time. It is not outbound (the grant never leaves the workspace) and not a legitimate write cap (no agent call through it can succeed), so it belongs in neither other map.",
-}
+})
 
 func TestEverySynthesizedVerbIsPinned(t *testing.T) {
-	for _, pins := range []map[string]string{synthesizedVerbs, outboundHoles, deadEndVerbs} {
-		for verb, reason := range pins {
-			if strings.TrimSpace(reason) == "" {
-				t.Errorf("the pin for %s has no reason — a pin must say why the verb may resolve by synthesis", verb)
-			}
-		}
-	}
+	defer synthesizedVerbs.AssertAllMatched(t)
+	defer outboundHoles.AssertAllMatched(t)
+	defer deadEndVerbs.AssertAllMatched(t)
 
 	registry := NewRegistry(nil, SendPath{})
 
@@ -84,13 +81,13 @@ func TestEverySynthesizedVerbIsPinned(t *testing.T) {
 			continue
 		}
 		checked++
-		if _, pinned := synthesizedVerbs[pol.Tool]; pinned {
+		if synthesizedVerbs.Waived(t, pol.Tool) {
 			continue
 		}
-		if _, known := outboundHoles[pol.Tool]; known {
+		if outboundHoles.Waived(t, pol.Tool) {
 			continue
 		}
-		if _, deadEnd := deadEndVerbs[pol.Tool]; deadEnd {
+		if deadEndVerbs.Waived(t, pol.Tool) {
 			continue
 		}
 		unexplained = append(unexplained, pol.Tool+" ("+route+")")
@@ -120,8 +117,8 @@ func TestThePinsDescribeVerbsThatStillExist(t *testing.T) {
 		}
 	}
 
-	for _, pins := range []map[string]string{synthesizedVerbs, outboundHoles, deadEndVerbs} {
-		for verb := range pins {
+	for _, pins := range []*gatekit.Waivers[string]{synthesizedVerbs, outboundHoles, deadEndVerbs} {
+		for _, verb := range pins.Subjects() {
 			if !inTable[verb] {
 				t.Errorf("%s is pinned but no longer appears in the policy table; delete the pin", verb)
 			}

--- a/backend/internal/compose/agentpolicysynthesis_test.go
+++ b/backend/internal/compose/agentpolicysynthesis_test.go
@@ -70,10 +70,11 @@ var deadEndVerbs = gatekit.Waive(map[string]string{
 
 func TestEverySynthesizedVerbIsPinned(t *testing.T) {
 	// This sweep visits every synthesized verb in the policy table, so it is the
-	// one place all three maps' staleness is owned. That is only sound because
-	// TestThePinsDescribeVerbsThatStillExist independently holds the other half:
-	// a pinned verb that left the table, or that gained a registered tool, is
-	// skipped by the loop below and would never be reported here.
+	// one place all three maps' staleness is owned. A pinned verb that left the
+	// table, or that gained a registered tool, is skipped by the loop below and
+	// so goes unmatched — this sweep reports it stale on its own.
+	// TestThePinsDescribeVerbsThatStillExist names WHICH of the two happened,
+	// sharpening the diagnosis rather than carrying the detection.
 	defer synthesizedVerbs.AssertAllMatched(t)
 	defer outboundHoles.AssertAllMatched(t)
 	defer deadEndVerbs.AssertAllMatched(t)

--- a/backend/internal/compose/agentpolicysynthesis_test.go
+++ b/backend/internal/compose/agentpolicysynthesis_test.go
@@ -46,8 +46,12 @@ var outboundHoles = gatekit.Waive(map[string]string{
 	// intended shape (ADR context: an outbound send), not because today's
 	// code egresses — this is a contract/implementation discrepancy to
 	// reconcile upstream, not merely scope-registration debt.
-	"send_offer":        "send — pinned for what the contract promises, though the current implementation performs no delivery (see comment above)",
-	"enrich":            "enrich",
+	"send_offer": "send — pinned for what the contract promises, though the current implementation performs no delivery (see comment above)",
+	"enrich": "enrich — scrapeCompany and deepReadCompany fetch " +
+		"the target's own website through the web-read seam, and both " +
+		"coldstart operations do the same before any record exists, so " +
+		"the call egresses; nothing is transmitted to a counterparty, " +
+		"which is why it still reads as an internal write today",
 	"connect_incumbent": "write is likely right for authenticating a connection, but the tier and scope were never decided together",
 	"reconcile_overlay": "enrich — the sweep it queues calls overlay.Reconcile's inc.Modified fetch against the incumbent's API and spends its budget",
 })
@@ -65,6 +69,11 @@ var deadEndVerbs = gatekit.Waive(map[string]string{
 })
 
 func TestEverySynthesizedVerbIsPinned(t *testing.T) {
+	// This sweep visits every synthesized verb in the policy table, so it is the
+	// one place all three maps' staleness is owned. That is only sound because
+	// TestThePinsDescribeVerbsThatStillExist independently holds the other half:
+	// a pinned verb that left the table, or that gained a registered tool, is
+	// skipped by the loop below and would never be reported here.
 	defer synthesizedVerbs.AssertAllMatched(t)
 	defer outboundHoles.AssertAllMatched(t)
 	defer deadEndVerbs.AssertAllMatched(t)

--- a/backend/internal/compose/aitaskregistry_test.go
+++ b/backend/internal/compose/aitaskregistry_test.go
@@ -22,6 +22,8 @@ import (
 // and agree with whatever this build declares, including a narrowing added to
 // hide a case that quietly stopped driving its path, and including one dropped
 // from a case that still needs it.
+// gatekit:fixture the scope each narrowed site's reading is compared against —
+// expected data, not an exception granted to the site.
 var narrowedSites = map[string]string{
 	// One call labels a batch; every below-floor message is re-asked solo.
 	"capture_classify/classify": aitasks.ScopeSingleCall,

--- a/backend/internal/compose/certcase_fieldextract_test.go
+++ b/backend/internal/compose/certcase_fieldextract_test.go
@@ -95,6 +95,8 @@ func runFieldExtractCase(t *testing.T, want map[string]string, reply string) (ai
 	return prepared.Evaluate(trace), trace
 }
 
+// gatekit:fixture the field value this case's reply is graded against —
+// expected data the case owns, not a waived exception.
 var fieldExtractWantLegalName = map[string]string{
 	string(crmcontracts.ColdStartFieldFieldLegalName): "Acme Robotics GmbH",
 }

--- a/backend/internal/compose/certcase_signatureenrich_test.go
+++ b/backend/internal/compose/certcase_signatureenrich_test.go
@@ -107,6 +107,8 @@ func runSignatureEnrichCase(
 	return prepared.Evaluate(trace), trace
 }
 
+// gatekit:fixture the title this case's reply is graded against — expected data
+// the case owns, not a waived exception.
 var signatureEnrichWantTitle = map[string]string{"title": "CTO"}
 
 func TestSignatureEnrichCaseSeparatesTheFourThingsAReplyCanBe(t *testing.T) {

--- a/backend/internal/compose/certcase_sitepagefacts_test.go
+++ b/backend/internal/compose/certcase_sitepagefacts_test.go
@@ -116,6 +116,8 @@ func runSitePageFactsCase(t *testing.T, fixture json.RawMessage, want map[string
 	return prepared.Evaluate(trace), trace
 }
 
+// gatekit:fixture the fact value this case's reply is graded against — expected
+// data the case owns, not a waived exception.
 var sitePageFactsWantAudit = map[string]string{people.FactService: "Cloud Cost Audit"}
 
 // sitePageFactsReplyCase is one reply and the outcome this site owes it. Each

--- a/backend/internal/compose/certcase_siteprofile_test.go
+++ b/backend/internal/compose/certcase_siteprofile_test.go
@@ -121,6 +121,8 @@ func runSiteProfileCase(t *testing.T, want map[string]string, reply string) (ait
 	return prepared.Evaluate(trace), trace
 }
 
+// gatekit:fixture the legal name this case's reply is graded against — expected
+// data the case owns, not a waived exception.
 var siteProfileWantLegalName = map[string]string{
 	string(crmcontracts.ColdStartFieldFieldLegalName): "Acme Robotics GmbH",
 }

--- a/backend/internal/compose/modellanes_test.go
+++ b/backend/internal/compose/modellanes_test.go
@@ -22,14 +22,15 @@ import (
 	"testing"
 
 	"github.com/gradionhq/margince/backend/internal/modules/ai"
+	"github.com/gradionhq/margince/backend/internal/shared/gatekit"
 )
 
 // laneExemptions are the ModelPath fields that are NOT task lanes, each with
 // the reason it is not. An exemption without a reason is itself a finding: the
 // point of the list is that adding to it costs an explanation.
-var laneExemptions = map[string]string{
+var laneExemptions = gatekit.Waive(map[string]string{
 	"Embedder": "the retrieval embed lane — the router itself under no task label, typed search.Embedder",
-}
+})
 
 // taskConstantName renders a contract task name the way tools/gen-aitasks
 // renders the ai.Task… constant suffix (cert_judge -> CertJudge), so the
@@ -59,6 +60,8 @@ func exportedLanes(t reflect.Type) []reflect.StructField {
 }
 
 func TestEveryModelLaneIsNamedForAShippedTask(t *testing.T) {
+	defer laneExemptions.AssertAllMatched(t)
+
 	shipped := map[string]bool{}
 	for _, task := range ai.AllTasks() {
 		if ai.Status(task) == ai.StatusShipped {
@@ -70,10 +73,7 @@ func TestEveryModelLaneIsNamedForAShippedTask(t *testing.T) {
 	}
 
 	for _, field := range exportedLanes(reflect.TypeOf(ModelPath{})) {
-		if reason, exempt := laneExemptions[field.Name]; exempt {
-			if strings.TrimSpace(reason) == "" {
-				t.Errorf("ModelPath.%s is exempted from the lane-naming rule with no reason — state why it is not a task lane, or drop the exemption", field.Name)
-			}
+		if laneExemptions.Waived(t, field.Name) {
 			continue
 		}
 		if !shipped[field.Name] {
@@ -98,7 +98,7 @@ func TestEveryModelLaneIsWiredToTheTaskItIsNamedFor(t *testing.T) {
 			t.Errorf("ModelPath.%s is declared but the model path constructor leaves it nil — bind it in modelPathForRouter so it rides the same router as every other lane", field.Name)
 			continue
 		}
-		if _, exempt := laneExemptions[field.Name]; exempt {
+		if laneExemptions.Waived(t, field.Name) {
 			continue
 		}
 		var task ai.Task

--- a/backend/internal/compose/overlaywrite_test.go
+++ b/backend/internal/compose/overlaywrite_test.go
@@ -245,6 +245,8 @@ func serverDeclaredMethods(t *testing.T) map[string]bool {
 // overlayEntityTitles is the Go-identifier title-case for each mirrored
 // entity type, spelling the Update<Title>/Archive<Title> shadow method
 // names the same way the contract's own generated operation names do.
+// gatekit:fixture the expected spelling each shadow method name is built from —
+// naming-convention data, not a cost.
 var overlayEntityTitles = map[string]string{
 	string(datasource.EntityPerson):       "Person",
 	string(datasource.EntityOrganization): "Organization",

--- a/backend/internal/compose/schemadescriptors_test.go
+++ b/backend/internal/compose/schemadescriptors_test.go
@@ -5,10 +5,10 @@ package compose
 
 import (
 	"context"
-	"strings"
 	"testing"
 
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/shared/gatekit"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
@@ -28,9 +28,11 @@ import (
 // recordTypesWithoutDescriptor names the record types that legitimately have
 // no descriptor, each with the reason it cannot be served yet. Empty is the
 // correct state: an entry is a promise to come back, not a place to park one.
-var recordTypesWithoutDescriptor = map[datasource.RecordType]string{}
+var recordTypesWithoutDescriptor = gatekit.Waive(map[datasource.RecordType]string{})
 
 func TestEveryRecordTypeHasASchemaDescriptor(t *testing.T) {
+	defer recordTypesWithoutDescriptor.AssertAllMatched(t)
+
 	records := datasource.RecordTypes()
 	if len(records) == 0 {
 		t.Fatal("the record vocabulary is empty — this gate walked nothing, so it proves nothing")
@@ -40,11 +42,7 @@ func TestEveryRecordTypeHasASchemaDescriptor(t *testing.T) {
 		described[obj.Type] = obj.Fields
 	}
 	for _, record := range records {
-		if why, excluded := recordTypesWithoutDescriptor[record]; excluded {
-			if len(strings.TrimSpace(why)) < 40 {
-				t.Errorf("recordTypesWithoutDescriptor[%s] has no real rationale — a record type "+
-					"the schema surface refuses must say what is missing before it can be served", record)
-			}
+		if recordTypesWithoutDescriptor.Waived(t, record) {
 			continue
 		}
 		fields, ok := described[datasource.EntityType(record)]
@@ -59,7 +57,7 @@ func TestEveryRecordTypeHasASchemaDescriptor(t *testing.T) {
 				"introspection and compiles no report plan", record)
 		}
 	}
-	for record := range recordTypesWithoutDescriptor {
+	for _, record := range recordTypesWithoutDescriptor.Subjects() {
 		if _, ok := described[datasource.EntityType(record)]; ok {
 			t.Errorf("recordTypesWithoutDescriptor[%s] names a type that HAS a descriptor — stale "+
 				"waiver, remove it", record)

--- a/backend/internal/modules/automation/seed_test.go
+++ b/backend/internal/modules/automation/seed_test.go
@@ -16,6 +16,8 @@ import (
 // pinnedSeededNames is UAT.md:72's six, name-for-name — this test fails
 // the moment a seeded entry's Name drifts from the pinned copy, same as
 // a key drift.
+// gatekit:fixture the pinned name each seeded entry is compared against —
+// expected data, not an exception granted to a template.
 var pinnedSeededNames = map[string]string{
 	noActivityReminderName: "No-activity reminder",
 	renewalReminderName:    "Renewal reminder",

--- a/backend/internal/platform/auth/auditgrant_test.go
+++ b/backend/internal/platform/auth/auditgrant_test.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gradionhq/margince/backend/internal/shared/gatekit"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
@@ -45,7 +46,7 @@ var auditActionCheckLiteral = regexp.MustCompile(`'([a-z_]+)'`)
 // auditVerbNoGrant: verbs the audit_log_action_check CHECK admits that no
 // human- or agent-authored storekit.Audit call writes, so no CRUD grant
 // attributes them. Each carries the reason it needs none.
-var auditVerbNoGrant = map[string]string{
+var auditVerbNoGrant = gatekit.Waive(map[string]string{
 	"approve": "approvals writes its own decision row (approvals/service.go) without the authorization_rule column",
 	// Rule() renders the AUDITED entity, and this verb's only storekit writer
 	// audits voice_profile_version — not an RBAC policy object, so any rule it
@@ -60,9 +61,11 @@ var auditVerbNoGrant = map[string]string{
 	"disqualify":  "admitted by the contract vocabulary; no Go writer emits it yet",
 	"send_email":  "the agent tool of that name stages an approval; the send itself audits the activity as create",
 	"reset_data":  "audited on workspace, which is not an RBAC policy object; the governing check is auth.RequireAdmin (a role gate, not an object CRUD grant)",
-}
+})
 
 func TestEveryAuditVerbRendersItsAuthorizationRule(t *testing.T) {
+	defer auditVerbNoGrant.AssertAllMatched(t)
+
 	verbs := auditActionVocabulary(t)
 
 	// A HUMAN principal: AuthzRule short-circuits to "system" for the system
@@ -73,16 +76,11 @@ func TestEveryAuditVerbRendersItsAuthorizationRule(t *testing.T) {
 		Permissions: principal.Permissions{RoleKeys: []string{"rep"}, RowScope: principal.RowScopeTeam},
 	}
 
-	admitted := make(map[string]struct{}, len(verbs))
 	for _, verb := range verbs {
-		admitted[verb] = struct{}{}
-		reason, waived := auditVerbNoGrant[verb]
+		waived := auditVerbNoGrant.Waived(t, verb)
 		rule := AuthzRule(human, "project", verb)
 
 		if waived {
-			if reason == "" {
-				t.Errorf("audit verb %q: reasonless waiver in auditVerbNoGrant", verb)
-			}
 			if rule != "" {
 				t.Errorf("audit verb %q: stale waiver — it now renders %q; remove it from auditVerbNoGrant", verb, rule)
 			}
@@ -90,14 +88,6 @@ func TestEveryAuditVerbRendersItsAuthorizationRule(t *testing.T) {
 		}
 		if rule == "" {
 			t.Errorf("audit verb %q: AuthzRule renders a BLANK authorization_rule — every write of this verb would record no governing grant. Add it to auditActionGrant naming the grant its write path actually requires, or record it in auditVerbNoGrant with a reason", verb)
-		}
-	}
-
-	// The ratchet in the other direction: a waived verb the vocabulary no
-	// longer admits is dead weight that hides the next drift.
-	for verb := range auditVerbNoGrant {
-		if _, ok := admitted[verb]; !ok {
-			t.Errorf("audit verb %q: stale waiver — no audit_log_action_check admits it; remove it from auditVerbNoGrant", verb)
 		}
 	}
 }

--- a/backend/internal/shared/gatekit/gatekit_test.go
+++ b/backend/internal/shared/gatekit/gatekit_test.go
@@ -5,6 +5,9 @@ package gatekit
 
 import (
 	"fmt"
+	"go/ast"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -128,5 +131,155 @@ func TestWaiveCopiesItsInputSoALaterMutationCannotWidenTheSet(t *testing.T) {
 	rec := &recorder{TB: t}
 	if w.Waived(rec, "b") {
 		t.Error("a post-construction mutation widened the waiver set")
+	}
+}
+
+// The probe trees below are written into t.TempDir() rather than testdata/,
+// because several of this repo's gates walk the whole tree for every *.go file
+// without excluding testdata — a probe package committed there would be
+// license-checked, purity-checked and import-parsed as though it were product.
+//
+// obligated marks a file the probe Scope must judge; plain marks one it must
+// not. The marker is a declaration rather than an import so the probe tree
+// needs no resolvable module.
+const (
+	obligatedSource = "package %s\n\nfunc ObligatedSite() {}\n"
+	plainSource     = "package %s\n\nfunc somethingElse() {}\n"
+)
+
+// writeProbeTree materializes rel-path → contents under a fresh temp dir and
+// returns it, for use as a Scope's Tree.
+func writeProbeTree(t *testing.T, files map[string]string) string {
+	t.Helper()
+	tree := t.TempDir()
+	for rel, contents := range files {
+		path := filepath.Join(tree, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+			t.Fatalf("creating %s: %v", filepath.Dir(rel), err)
+		}
+		if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+			t.Fatalf("writing %s: %v", rel, err)
+		}
+	}
+	return tree
+}
+
+// declaresObligatedSite is the probe subject predicate.
+func declaresObligatedSite(_ string, file *ast.File) bool {
+	for _, decl := range file.Decls {
+		if fn, ok := decl.(*ast.FuncDecl); ok && fn.Name.Name == "ObligatedSite" {
+			return true
+		}
+	}
+	return false
+}
+
+// paths flattens a sweep result for comparison.
+func paths(files []ParsedFile) string {
+	out := make([]string, 0, len(files))
+	for _, f := range files {
+		out = append(out, f.Path)
+	}
+	return strings.Join(out, ",")
+}
+
+func TestFilesReturnsTheObligatedFilesUnderEveryRoot(t *testing.T) {
+	tree := writeProbeTree(t, map[string]string{
+		"inside/obligated.go":         fmt.Sprintf(obligatedSource, "inside"),
+		"inside/plain.go":             fmt.Sprintf(plainSource, "inside"),
+		"inside/obligated_test.go":    fmt.Sprintf(obligatedSource, "inside"),
+		"inside/obligated_gen.go":     fmt.Sprintf(obligatedSource, "inside"),
+		"inside/nested/obligated.go":  fmt.Sprintf(obligatedSource, "nested"),
+		"alsoinside/obligated.go":     fmt.Sprintf(obligatedSource, "alsoinside"),
+		"elsewhere/notevengo.txt":     "func ObligatedSite() {}\n",
+		"elsewhere/alsoobligated.txt": "ignored",
+	})
+	scope := Scope{
+		Tree:    tree,
+		Roots:   []string{"inside", "alsoinside"},
+		Subject: declaresObligatedSite,
+	}
+	rec := &recorder{TB: t}
+	swept := scope.Files(rec)
+	want := "alsoinside/obligated.go,inside/nested/obligated.go,inside/obligated.go"
+	if got := paths(swept); got != want {
+		t.Errorf("Files() = %q, want %q — a test, a generated or a non-Go file is not a subject", got, want)
+	}
+	for _, f := range swept {
+		if f.File == nil {
+			t.Errorf("%s came back without its syntax: a caller has nothing left to judge", f.Path)
+		}
+	}
+	if len(rec.errs) != 0 {
+		t.Errorf("a scope whose roots hold every subject reported: %s", rec.joined())
+	}
+}
+
+// The vacuity floor: a root that yields nothing certifies nothing, and reads
+// exactly like a root that yields no violation.
+func TestFilesFailsWhenARootHoldsNoSubjectAtAll(t *testing.T) {
+	tree := writeProbeTree(t, map[string]string{
+		"inside/obligated.go": fmt.Sprintf(obligatedSource, "inside"),
+		"barren/plain.go":     fmt.Sprintf(plainSource, "barren"),
+	})
+	scope := Scope{
+		Tree:    tree,
+		Roots:   []string{"inside", "barren"},
+		Subject: declaresObligatedSite,
+	}
+	rec := &recorder{TB: t}
+	scope.Files(rec)
+	if len(rec.errs) != 1 {
+		t.Fatalf("want exactly one vacuity report, got %d: %s", len(rec.errs), rec.joined())
+	}
+	if !strings.Contains(rec.errs[0], "barren") {
+		t.Errorf("the vacuity report names the wrong root: %s", rec.errs[0])
+	}
+}
+
+func TestFilesFailsWhenASubjectLivesOutsideEveryRoot(t *testing.T) {
+	tree := writeProbeTree(t, map[string]string{
+		"inside/obligated.go":  fmt.Sprintf(obligatedSource, "inside"),
+		"outside/obligated.go": fmt.Sprintf(obligatedSource, "outside"),
+	})
+	scope := Scope{
+		Tree:    tree,
+		Roots:   []string{"inside"},
+		Subject: declaresObligatedSite,
+	}
+	rec := &recorder{TB: t}
+	if got := paths(scope.Files(rec)); got != "inside/obligated.go" {
+		t.Errorf("Files() = %q, want only the in-root subject", got)
+	}
+	if len(rec.errs) != 1 {
+		t.Fatalf("want exactly one out-of-root report, got %d: %s", len(rec.errs), rec.joined())
+	}
+	if !strings.Contains(rec.errs[0], "outside/obligated.go") {
+		t.Errorf("the report names the wrong file: %s", rec.errs[0])
+	}
+}
+
+func TestAnExemptedOutsideSubjectIsAcceptedAndCountsAsMatched(t *testing.T) {
+	tree := writeProbeTree(t, map[string]string{
+		"inside/obligated.go":  fmt.Sprintf(obligatedSource, "inside"),
+		"outside/obligated.go": fmt.Sprintf(obligatedSource, "outside"),
+	})
+	exempt := Waive(map[string]string{
+		"outside/obligated.go": "holds the marker but answers to another gate, so this one must not judge it",
+	})
+	scope := Scope{
+		Tree:    tree,
+		Roots:   []string{"inside"},
+		Subject: declaresObligatedSite,
+		Exempt:  exempt,
+	}
+	rec := &recorder{TB: t}
+	scope.Files(rec)
+	if len(rec.errs) != 0 {
+		t.Errorf("a ratified out-of-root subject was reported anyway: %s", rec.joined())
+	}
+	exempt.AssertAllMatched(rec)
+	if len(rec.errs) != 0 {
+		t.Errorf("the sweep did not mark the exemption it relied on: %s", rec.joined())
 	}
 }

--- a/backend/internal/shared/gatekit/gatekit_test.go
+++ b/backend/internal/shared/gatekit/gatekit_test.go
@@ -88,20 +88,6 @@ func TestSubjectsEnumeratesInADeterministicOrder(t *testing.T) {
 	}
 }
 
-// Reading a reason is relying on the waiver, so it counts as a match — a gate
-// that reports its waivers must not then be told they are all stale.
-func TestReasonMarksTheSubjectMatched(t *testing.T) {
-	w := Waive(map[string]string{"a": "ratified for the reason stated right here in full"})
-	rec := &recorder{TB: t}
-	if _, ok := w.Reason(rec, "a"); !ok {
-		t.Fatal("Reason did not find a ratified subject")
-	}
-	w.AssertAllMatched(rec)
-	if len(rec.errs) != 0 {
-		t.Errorf("reading a reason left the subject unmatched: %s", rec.joined())
-	}
-}
-
 // A nil set behaves as an empty one. Gates hold these in case tables where a
 // nil map means "no exceptions", and Go lets them read a nil map freely — the
 // type has to preserve that, or converting such a gate replaces a passing test
@@ -111,9 +97,6 @@ func TestANilWaiversBehavesAsAnEmptySet(t *testing.T) {
 	rec := &recorder{TB: t}
 	if w.Waived(rec, "anything") {
 		t.Error("a nil waiver set ratified a subject")
-	}
-	if _, ok := w.Reason(rec, "anything"); ok {
-		t.Error("a nil waiver set produced a reason")
 	}
 	if got := w.Subjects(); len(got) != 0 {
 		t.Errorf("Subjects() on a nil set = %v, want empty", got)

--- a/backend/internal/shared/gatekit/gatekit_test.go
+++ b/backend/internal/shared/gatekit/gatekit_test.go
@@ -401,6 +401,57 @@ func TestARootNamedTwiceIsReportedOnce(t *testing.T) {
 	}
 }
 
+// A fixture under testdata is input to a test, not code that ships, so it is
+// neither swept for subjects nor owed an exemption — inside a root or outside
+// every one of them.
+func TestFilesSweepsNothingUnderTestdata(t *testing.T) {
+	tree := writeProbeTree(t, map[string]string{
+		"inside/obligated.go":                   fmt.Sprintf(obligatedSource, "inside"),
+		"inside/testdata/obligated.go":          fmt.Sprintf(obligatedSource, "fixture"),
+		"inside/testdata/nested/obligated.go":   fmt.Sprintf(obligatedSource, "fixture"),
+		"outside/testdata/obligated.go":         fmt.Sprintf(obligatedSource, "fixture"),
+		"outside/testdatafiles/notafixture.txt": "ignored",
+	})
+	scope := Scope{
+		Tree:    tree,
+		Roots:   []string{"inside"},
+		Subject: declaresObligatedSite,
+	}
+	rec := &recorder{TB: t}
+	if got := paths(scope.Files(rec)); got != "inside/obligated.go" {
+		t.Errorf("Files() = %q, want only the product source — a testdata fixture is not swept", got)
+	}
+	if len(rec.errs) != 0 {
+		t.Errorf("a testdata fixture was reported as an unratified subject: %s", rec.joined())
+	}
+}
+
+// A source the sweep cannot parse is a hole in the tree the roots are proven
+// against, so it fails and names the file. Skipping it would return the sweep's
+// verdict over a smaller tree than it claims — the vacuity this package exists
+// to refuse.
+func TestFilesFailsWhenASweptSourceCannotBeParsed(t *testing.T) {
+	tree := writeProbeTree(t, map[string]string{
+		"inside/obligated.go": fmt.Sprintf(obligatedSource, "inside"),
+		"inside/broken.go":    "package inside\n\nfunc (\n",
+	})
+	scope := Scope{
+		Tree:    tree,
+		Roots:   []string{"inside"},
+		Subject: declaresObligatedSite,
+	}
+	rec := &recorder{TB: t}
+	if got := scope.Files(rec); got != nil {
+		t.Errorf("Files() = %v, want no verdict from a tree the sweep could not read whole", paths(got))
+	}
+	if len(rec.errs) != 1 {
+		t.Fatalf("want exactly one unreadable-source report, got %d: %s", len(rec.errs), rec.joined())
+	}
+	if !strings.Contains(rec.errs[0], "inside/broken.go") || !strings.Contains(rec.errs[0], "could not read") {
+		t.Errorf("the report does not name the file it could not read: %s", rec.errs[0])
+	}
+}
+
 func TestAnExemptedOutsideSubjectIsAcceptedAndCountsAsMatched(t *testing.T) {
 	tree := writeProbeTree(t, map[string]string{
 		"inside/obligated.go":  fmt.Sprintf(obligatedSource, "inside"),

--- a/backend/internal/shared/gatekit/gatekit_test.go
+++ b/backend/internal/shared/gatekit/gatekit_test.go
@@ -55,6 +55,56 @@ func TestAReasonlessWaiverFailsWhereItIsReliedOn(t *testing.T) {
 	}
 }
 
+// The floor measures the text a reason states, not the bytes it occupies: space
+// is not an argument, and a subject long enough to clear the byte count is still
+// only the subject.
+func TestAReasonThatStatesNoCostIsRefusedHoweverLongItIs(t *testing.T) {
+	const subject = "internal/modules/people/store.go"
+	for _, probe := range []struct{ name, reason string }{
+		{"blank padding", strings.Repeat(" ", 25)},
+		{"mixed whitespace padding", "  \t\n   \n\t     \n            "},
+		{"the subject restated", subject},
+		{"the subject in another case", strings.ToUpper(subject)},
+		{"the subject quoted", `"` + subject + `"`},
+		{"the subject with a trailing period", subject + "."},
+		{"the subject in parentheses", "(" + subject + ")"},
+		{"the subject with padding around it", "  " + subject + " \n"},
+	} {
+		t.Run(probe.name, func(t *testing.T) {
+			w := Waive(map[string]string{subject: probe.reason})
+			rec := &recorder{TB: t}
+			if !w.Waived(rec, subject) {
+				t.Error("the subject stays waived — the reason is the defect, not the ratification")
+			}
+			if len(rec.errs) != 1 || !strings.Contains(rec.joined(), "what it costs") {
+				t.Errorf("a reason stating no cost was accepted: %s", rec.joined())
+			}
+		})
+	}
+}
+
+// A reason may open with its subject and then explain it — the shape several
+// live gates write — because naming the subject first and stating the cost after
+// is a reason, and refusing it would push those gates to bury the subject.
+func TestAReasonOpeningWithItsSubjectAndThenExplainingIsAccepted(t *testing.T) {
+	for _, probe := range []struct{ subject, reason string }{
+		{"enrich", "enrich — scrapeCompany fetches the target's own website through the web-read seam"},
+		{"send_offer", "send — pinned for what the contract promises, though today's code performs no delivery"},
+		{"arguments", "arguments names the JSON-RPC request shape rather than a REST contract property"},
+	} {
+		t.Run(probe.subject, func(t *testing.T) {
+			w := Waive(map[string]string{probe.subject: probe.reason})
+			rec := &recorder{TB: t}
+			if !w.Waived(rec, probe.subject) {
+				t.Fatal("a ratified subject was not waived")
+			}
+			if len(rec.errs) != 0 {
+				t.Errorf("a reason that states a cost was refused: %s", rec.joined())
+			}
+		})
+	}
+}
+
 func TestAWaiverMatchingNothingIsReportedAsStale(t *testing.T) {
 	w := Waive(map[string]string{
 		"live":  "reached by the lookup below, so it must not be reported",
@@ -84,6 +134,24 @@ func TestSubjectsEnumeratesInADeterministicOrder(t *testing.T) {
 	for range 8 {
 		if got := w.Subjects(); strings.Join(got, ",") != "a,b,c" {
 			t.Fatalf("Subjects() = %v, want a,b,c in every call", got)
+		}
+	}
+}
+
+// A gate keys its waivers by its own vocabulary's type, and two of them key by a
+// named string type. The order is total over any such type, because a string
+// subject has exactly one rendering and no two distinct subjects share it.
+func TestSubjectsOfAWaiverSetKeyedByANamedStringTypeAreOrderedToo(t *testing.T) {
+	type recordType string
+	w := Waive(map[recordType]string{
+		"organization": "the third subject, ratified for the reason stated right here",
+		"deal":         "the first subject, ratified for the reason stated right here",
+		"person":       "the second subject, ratified for the reason stated right here",
+	})
+	for range 8 {
+		got := w.Subjects()
+		if len(got) != 3 || got[0] != "deal" || got[1] != "organization" || got[2] != "person" {
+			t.Fatalf("Subjects() = %v, want deal,organization,person in every call", got)
 		}
 	}
 }

--- a/backend/internal/shared/gatekit/gatekit_test.go
+++ b/backend/internal/shared/gatekit/gatekit_test.go
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package gatekit
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// recorder captures what a gate would have reported, so a test can assert on
+// the report instead of failing with it. testing.TB is embedded for its
+// unexported methods; every method this package calls is overridden.
+type recorder struct {
+	testing.TB
+	errs []string
+}
+
+func (r *recorder) Errorf(format string, args ...any) {
+	r.errs = append(r.errs, fmt.Sprintf(format, args...))
+}
+
+func (r *recorder) Helper() {}
+
+func (r *recorder) joined() string { return strings.Join(r.errs, "\n") }
+
+func TestWaivedRatifiesAKnownSubjectAndRefusesAnUnknownOne(t *testing.T) {
+	w := Waive(map[string]string{
+		"record_grant": "no RBAC object may name it, so the row is refused for everyone forever",
+	})
+	rec := &recorder{TB: t}
+	if !w.Waived(rec, "record_grant") {
+		t.Error("a ratified subject was not waived")
+	}
+	if w.Waived(rec, "person") {
+		t.Error("an unratified subject was waived")
+	}
+	if len(rec.errs) != 0 {
+		t.Errorf("a well-formed waiver reported: %s", rec.joined())
+	}
+}
+
+func TestAReasonlessWaiverFailsWhereItIsReliedOn(t *testing.T) {
+	w := Waive(map[string]string{"enrich": "enrich"})
+	rec := &recorder{TB: t}
+	if !w.Waived(rec, "enrich") {
+		t.Error("the subject stays waived — the reason is the defect, not the ratification")
+	}
+	if len(rec.errs) != 1 || !strings.Contains(rec.joined(), "what it costs") {
+		t.Errorf("a reason that only repeats its key was accepted: %s", rec.joined())
+	}
+}
+
+func TestAWaiverMatchingNothingIsReportedAsStale(t *testing.T) {
+	w := Waive(map[string]string{
+		"live":  "reached by the lookup below, so it must not be reported",
+		"stale": "describes a subject that no longer exists anywhere in the tree",
+	})
+	rec := &recorder{TB: t}
+	if !w.Waived(rec, "live") {
+		t.Fatal("setup: the live subject was not waived")
+	}
+	w.AssertAllMatched(rec)
+	if len(rec.errs) != 1 {
+		t.Fatalf("want exactly one stale report, got %d: %s", len(rec.errs), rec.joined())
+	}
+	if !strings.Contains(rec.errs[0], "stale") {
+		t.Errorf("the report names the wrong entry: %s", rec.errs[0])
+	}
+}
+
+// Enumeration is deterministic because a gate that walks its waivers reports
+// findings in that order, and an unstable order makes a failure unreadable.
+func TestSubjectsEnumeratesInADeterministicOrder(t *testing.T) {
+	w := Waive(map[string]string{
+		"c": "the third subject, ratified for the reason stated right here",
+		"a": "the first subject, ratified for the reason stated right here",
+		"b": "the second subject, ratified for the reason stated here",
+	})
+	for range 8 {
+		if got := w.Subjects(); strings.Join(got, ",") != "a,b,c" {
+			t.Fatalf("Subjects() = %v, want a,b,c in every call", got)
+		}
+	}
+}
+
+// Reading a reason is relying on the waiver, so it counts as a match — a gate
+// that reports its waivers must not then be told they are all stale.
+func TestReasonMarksTheSubjectMatched(t *testing.T) {
+	w := Waive(map[string]string{"a": "ratified for the reason stated right here in full"})
+	rec := &recorder{TB: t}
+	if _, ok := w.Reason(rec, "a"); !ok {
+		t.Fatal("Reason did not find a ratified subject")
+	}
+	w.AssertAllMatched(rec)
+	if len(rec.errs) != 0 {
+		t.Errorf("reading a reason left the subject unmatched: %s", rec.joined())
+	}
+}
+
+// A nil set behaves as an empty one. Gates hold these in case tables where a
+// nil map means "no exceptions", and Go lets them read a nil map freely — the
+// type has to preserve that, or converting such a gate replaces a passing test
+// with a panic that takes its whole binary down.
+func TestANilWaiversBehavesAsAnEmptySet(t *testing.T) {
+	var w *Waivers[string]
+	rec := &recorder{TB: t}
+	if w.Waived(rec, "anything") {
+		t.Error("a nil waiver set ratified a subject")
+	}
+	if _, ok := w.Reason(rec, "anything"); ok {
+		t.Error("a nil waiver set produced a reason")
+	}
+	if got := w.Subjects(); len(got) != 0 {
+		t.Errorf("Subjects() on a nil set = %v, want empty", got)
+	}
+	w.AssertAllMatched(rec)
+	if len(rec.errs) != 0 {
+		t.Errorf("a nil waiver set reported: %s", rec.joined())
+	}
+}
+
+func TestWaiveCopiesItsInputSoALaterMutationCannotWidenTheSet(t *testing.T) {
+	entries := map[string]string{"a": "ratified for the reason stated right here in full"}
+	w := Waive(entries)
+	entries["b"] = "smuggled in after ratification, which must not be honoured"
+	rec := &recorder{TB: t}
+	if w.Waived(rec, "b") {
+		t.Error("a post-construction mutation widened the waiver set")
+	}
+}

--- a/backend/internal/shared/gatekit/gatekit_test.go
+++ b/backend/internal/shared/gatekit/gatekit_test.go
@@ -242,6 +242,97 @@ func TestFilesFailsWhenASubjectLivesOutsideEveryRoot(t *testing.T) {
 	}
 }
 
+// A Scope missing either half of its claim sweeps for nothing, and says which
+// half is missing — neither guard needs a tree, because there is no question yet
+// to ask of one.
+func TestFilesRefusesAScopeThatClaimsNothing(t *testing.T) {
+	for _, probe := range []struct {
+		name  string
+		scope Scope
+		says  string
+	}{
+		{
+			name:  "no subject predicate",
+			scope: Scope{Roots: []string{"inside"}},
+			says:  "sweeps for nothing",
+		},
+		{
+			name:  "no roots",
+			scope: Scope{Subject: declaresObligatedSite},
+			says:  "claims no coverage",
+		},
+	} {
+		t.Run(probe.name, func(t *testing.T) {
+			rec := &recorder{TB: t}
+			if got := probe.scope.Files(rec); got != nil {
+				t.Errorf("Files() = %v, want no subjects from a scope that claims nothing", paths(got))
+			}
+			if len(rec.errs) != 1 {
+				t.Fatalf("want exactly one report, got %d: %s", len(rec.errs), rec.joined())
+			}
+			if !strings.Contains(rec.errs[0], probe.says) {
+				t.Errorf("the report does not say %q: %s", probe.says, rec.errs[0])
+			}
+		})
+	}
+}
+
+// A root that is not a subtree is refused at the root, not diagnosed as a
+// missing obligation: swept, "." would report every subject out-of-root and the
+// root itself vacuous, which reads as a tree-wide gap when the tree is fine.
+func TestFilesRefusesARootThatNamesNoSubtree(t *testing.T) {
+	for _, probe := range []struct {
+		name string
+		root string
+		says string
+	}{
+		{name: "the sweep universe itself", root: ".", says: "covers the whole sweep universe"},
+		{name: "an empty root", root: "", says: "covers the whole sweep universe"},
+		{name: "an absolute root", root: "/", says: "is an absolute path"},
+	} {
+		t.Run(probe.name, func(t *testing.T) {
+			tree := writeProbeTree(t, map[string]string{
+				"inside/obligated.go": fmt.Sprintf(obligatedSource, "inside"),
+			})
+			scope := Scope{Tree: tree, Roots: []string{probe.root}, Subject: declaresObligatedSite}
+			rec := &recorder{TB: t}
+			if got := scope.Files(rec); got != nil {
+				t.Errorf("Files() = %v, want no subjects from a refused root", paths(got))
+			}
+			if len(rec.errs) != 1 {
+				t.Fatalf("want exactly one report naming the root, got %d: %s", len(rec.errs), rec.joined())
+			}
+			if !strings.Contains(rec.errs[0], probe.says) {
+				t.Errorf("the report does not say %q: %s", probe.says, rec.errs[0])
+			}
+		})
+	}
+}
+
+// A root named twice is one root: it is reported once, and the sweep it proves
+// is the same sweep either way.
+func TestARootNamedTwiceIsReportedOnce(t *testing.T) {
+	tree := writeProbeTree(t, map[string]string{
+		"inside/obligated.go":  fmt.Sprintf(obligatedSource, "inside"),
+		"outside/obligated.go": fmt.Sprintf(obligatedSource, "outside"),
+	})
+	scope := Scope{
+		Tree:    tree,
+		Roots:   []string{"inside", "inside"},
+		Subject: declaresObligatedSite,
+	}
+	rec := &recorder{TB: t}
+	if got := paths(scope.Files(rec)); got != "inside/obligated.go" {
+		t.Errorf("Files() = %q, want only the in-root subject", got)
+	}
+	if len(rec.errs) != 1 {
+		t.Fatalf("want exactly one out-of-root report, got %d: %s", len(rec.errs), rec.joined())
+	}
+	if !strings.Contains(rec.errs[0], "(inside)") {
+		t.Errorf("the report lists the root more than once: %s", rec.errs[0])
+	}
+}
+
 func TestAnExemptedOutsideSubjectIsAcceptedAndCountsAsMatched(t *testing.T) {
 	tree := writeProbeTree(t, map[string]string{
 		"inside/obligated.go":  fmt.Sprintf(obligatedSource, "inside"),

--- a/backend/internal/shared/gatekit/gatekit_test.go
+++ b/backend/internal/shared/gatekit/gatekit_test.go
@@ -83,6 +83,32 @@ func TestAReasonThatStatesNoCostIsRefusedHoweverLongItIs(t *testing.T) {
 	}
 }
 
+// The floor counts characters, not bytes. A handful of wide runes occupies
+// twenty bytes while saying about as much as a handful of ASCII ones, so a
+// byte-counted floor would ratify it; the same count of runes states a cost in
+// any script, so a reason written in one is held to the same length as an
+// English one and no stricter.
+func TestTheReasonFloorCountsCharactersRatherThanBytes(t *testing.T) {
+	const wide = "貸方の理由"                          // five runes, fifteen bytes
+	const enough = "この免除が何を犠牲にしているかを説明する理由がここにある" // twenty-eight runes
+
+	rec := &recorder{TB: t}
+	if !Waive(map[string]string{"a": wide}).Waived(rec, "a") {
+		t.Fatal("setup: the subject was not waived")
+	}
+	if len(rec.errs) != 1 || !strings.Contains(rec.joined(), "what it costs") {
+		t.Errorf("a five-character reason was accepted because its bytes reached the floor: %s", rec.joined())
+	}
+
+	rec = &recorder{TB: t}
+	if !Waive(map[string]string{"a": enough}).Waived(rec, "a") {
+		t.Fatal("setup: the subject was not waived")
+	}
+	if len(rec.errs) != 0 {
+		t.Errorf("a reason well past the floor in characters was refused: %s", rec.joined())
+	}
+}
+
 // A reason may open with its subject and then explain it — the shape several
 // live gates write — because naming the subject first and stating the cost after
 // is a reason, and refusing it would push those gates to bury the subject.

--- a/backend/internal/shared/gatekit/scope.go
+++ b/backend/internal/shared/gatekit/scope.go
@@ -76,11 +76,39 @@ func (s Scope) Files(t testing.TB) []ParsedFile {
 		return nil
 	}
 
-	var inside []ParsedFile
-	var outside []string
-	subjectsPerRoot := make([]int, len(roots))
+	inside, outside, subjectsPerRoot, err := s.sweep(tree, roots)
+	if err != nil {
+		t.Errorf("sweeping %s: %v", tree, err)
+		return nil
+	}
+
+	for i, root := range roots {
+		if subjectsPerRoot[i] == 0 {
+			t.Errorf("%s holds no site this gate judges — a root that finds nothing certifies nothing, so "+
+				"either the root is stale or the obligation has moved; correct it rather than leaving the "+
+				"gate reading green over an empty tree", root)
+		}
+	}
+	sort.Strings(outside)
+	for _, path := range outside {
+		if s.Exempt.Waived(t, path) {
+			continue
+		}
+		t.Errorf("%s holds a site this gate must judge but lies outside every root (%s), so the gate never "+
+			"sees it: widen the roots if this tier is in scope, or ratify the file in the scope's Exempt set "+
+			"with the reason it is not this gate's business", path, strings.Join(roots, ", "))
+	}
+	return inside
+}
+
+// sweep parses the swept sources under tree once and partitions the subjects it
+// finds into those a root covers and those no root does, alongside the number of
+// subjects each root holds. A subject under several roots counts for each of
+// them, because every root owes its own evidence of not being vacuous.
+func (s Scope) sweep(tree string, roots []string) (inside []ParsedFile, outside []string, perRoot []int, err error) {
+	perRoot = make([]int, len(roots))
 	fset := token.NewFileSet()
-	err := filepath.WalkDir(tree, func(path string, entry fs.DirEntry, walkErr error) error {
+	err = filepath.WalkDir(tree, func(path string, entry fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
 		}
@@ -105,7 +133,7 @@ func (s Scope) Files(t testing.TB) []ParsedFile {
 		covered := false
 		for i, root := range roots {
 			if under(rel, root) {
-				subjectsPerRoot[i]++
+				perRoot[i]++
 				covered = true
 			}
 		}
@@ -116,28 +144,7 @@ func (s Scope) Files(t testing.TB) []ParsedFile {
 		inside = append(inside, ParsedFile{Path: rel, File: file})
 		return nil
 	})
-	if err != nil {
-		t.Errorf("sweeping %s: %v", tree, err)
-		return nil
-	}
-
-	for i, root := range roots {
-		if subjectsPerRoot[i] == 0 {
-			t.Errorf("%s holds no site this gate judges — a root that finds nothing certifies nothing, so "+
-				"either the root is stale or the obligation has moved; correct it rather than leaving the "+
-				"gate reading green over an empty tree", root)
-		}
-	}
-	sort.Strings(outside)
-	for _, path := range outside {
-		if s.Exempt.Waived(t, path) {
-			continue
-		}
-		t.Errorf("%s holds a site this gate must judge but lies outside every root (%s), so the gate never "+
-			"sees it: widen the roots if this tier is in scope, or ratify the file in the scope's Exempt set "+
-			"with the reason it is not this gate's business", path, strings.Join(roots, ", "))
-	}
-	return inside
+	return inside, outside, perRoot, err
 }
 
 // universe resolves the tree the roots are proven against.

--- a/backend/internal/shared/gatekit/scope.go
+++ b/backend/internal/shared/gatekit/scope.go
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package gatekit
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// ParsedFile is one swept source file: its slash-normalised path relative to
+// the sweep universe, and its syntax. The path is what a gate reports and what
+// an Exempt entry is keyed by, so it reads the same on every machine.
+type ParsedFile struct {
+	Path string
+	File *ast.File
+}
+
+// Scope turns a path-scoped gate's walk root from an assertion into a proof.
+//
+// A gate that walks a subtree and judges what it finds says two things: what is
+// wrong inside the subtree, and — silently — that the subtree is where the
+// obligated code lives. Only the first is checked. A root that names the wrong
+// tree, or that a later split left behind, finds nothing objectionable and
+// reads green, which is indistinguishable from a clean tree.
+//
+// Scope checks the second claim by sweeping the negative space: it looks at the
+// code the gate does NOT look at, and reports any subject it finds there. A
+// subject outside every root, unratified, means the roots are wrong.
+type Scope struct {
+	// Roots are the subtrees the gate claims cover its obligation, relative to
+	// Tree.
+	Roots []string
+	// Subject reports whether a parsed file holds a site this gate must judge.
+	// It is the same predicate inside the roots and outside them — the sweep is
+	// only meaningful because both sides are asked the same question.
+	Subject func(path string, file *ast.File) bool
+	// Exempt ratifies files that hold a Subject OUTSIDE every Root and are
+	// nonetheless not this gate's business, keyed by path. Each entry carries
+	// the reason it is not, and AssertAllMatched reports one that has gone
+	// stale.
+	Exempt *Waivers[string]
+	// Tree bounds the sweep: the universe the Roots are proven against. Empty
+	// means the module root, found by walking up for go.mod — every gate in the
+	// module then proves its roots against the same tree, whichever package it
+	// runs from.
+	Tree string
+}
+
+// Files parses the sweep universe once and returns the subjects under Roots,
+// having first proven that those roots are where the subjects are: every root
+// must hold at least one, and no unratified subject may lie outside all of
+// them. Files are returned in the walk's lexical order.
+//
+// Sources are parsed with comments, so a Subject may read a doc comment.
+func (s Scope) Files(t testing.TB) []ParsedFile {
+	t.Helper()
+	if s.Subject == nil {
+		t.Errorf("a Scope with no Subject predicate sweeps for nothing: name the site this gate must judge")
+		return nil
+	}
+	roots := s.normalizedRoots()
+	if len(roots) == 0 {
+		t.Errorf("a Scope with no Roots claims no coverage: name the subtrees this gate's obligation lives in")
+		return nil
+	}
+	tree := s.universe(t)
+	if tree == "" {
+		return nil
+	}
+
+	var inside []ParsedFile
+	var outside []string
+	subjectsPerRoot := make([]int, len(roots))
+	fset := token.NewFileSet()
+	err := filepath.WalkDir(tree, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		rel, relErr := filepath.Rel(tree, path)
+		if relErr != nil {
+			return relErr
+		}
+		rel = filepath.ToSlash(rel)
+		if !isSweptSource(rel) {
+			return nil
+		}
+		file, parseErr := parser.ParseFile(fset, path, nil, parser.ParseComments)
+		if parseErr != nil {
+			return parseErr
+		}
+		if !s.Subject(rel, file) {
+			return nil
+		}
+		covered := false
+		for i, root := range roots {
+			if under(rel, root) {
+				subjectsPerRoot[i]++
+				covered = true
+			}
+		}
+		if !covered {
+			outside = append(outside, rel)
+			return nil
+		}
+		inside = append(inside, ParsedFile{Path: rel, File: file})
+		return nil
+	})
+	if err != nil {
+		t.Errorf("sweeping %s: %v", tree, err)
+		return nil
+	}
+
+	for i, root := range roots {
+		if subjectsPerRoot[i] == 0 {
+			t.Errorf("%s holds no site this gate judges — a root that finds nothing certifies nothing, so "+
+				"either the root is stale or the obligation has moved; correct it rather than leaving the "+
+				"gate reading green over an empty tree", root)
+		}
+	}
+	sort.Strings(outside)
+	for _, path := range outside {
+		if s.Exempt.Waived(t, path) {
+			continue
+		}
+		t.Errorf("%s holds a site this gate must judge but lies outside every root (%s), so the gate never "+
+			"sees it: widen the roots if this tier is in scope, or ratify the file in the scope's Exempt set "+
+			"with the reason it is not this gate's business", path, strings.Join(roots, ", "))
+	}
+	return inside
+}
+
+// universe resolves the tree the roots are proven against.
+func (s Scope) universe(t testing.TB) string {
+	t.Helper()
+	if s.Tree != "" {
+		return s.Tree
+	}
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("resolving the working directory to find the module root: %v", err)
+		return ""
+	}
+	for {
+		// A stat that does not succeed is the answer "no go.mod here", which the
+		// loop handles by moving up; reaching the filesystem root is the failure.
+		if info, statErr := os.Stat(filepath.Join(dir, "go.mod")); statErr == nil && !info.IsDir() {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Errorf("no go.mod above the working directory: a Scope with no Tree is bounded by the module "+
+				"root, and there is none (searched up from %s)", dir)
+			return ""
+		}
+		dir = parent
+	}
+}
+
+// normalizedRoots returns the roots in the one spelling paths are compared in,
+// deduplicated so a root named twice cannot mask an empty one.
+func (s Scope) normalizedRoots() []string {
+	seen := make(map[string]bool, len(s.Roots))
+	roots := make([]string, 0, len(s.Roots))
+	for _, root := range s.Roots {
+		root = strings.TrimSuffix(filepath.ToSlash(filepath.Clean(root)), "/")
+		if root == "" || seen[root] {
+			continue
+		}
+		seen[root] = true
+		roots = append(roots, root)
+	}
+	return roots
+}
+
+// under reports whether path lies in root, matching whole segments so that
+// "internal/modules" does not swallow "internal/modulesomething".
+func under(path, root string) bool {
+	return path == root || strings.HasPrefix(path, root+"/")
+}
+
+// isSweptSource reports whether the file is hand-written product source. Tests
+// are excluded because a gate judges what ships; generated files because a
+// finding there is fixed in the generator, and this repo spells generated
+// output "_gen.go" everywhere.
+func isSweptSource(path string) bool {
+	return strings.HasSuffix(path, ".go") &&
+		!strings.HasSuffix(path, "_test.go") &&
+		!strings.HasSuffix(path, "_gen.go")
+}

--- a/backend/internal/shared/gatekit/scope.go
+++ b/backend/internal/shared/gatekit/scope.go
@@ -115,39 +115,55 @@ func (s Scope) sweep(tree string, roots []string) (inside []ParsedFile, outside 
 		if walkErr != nil {
 			return walkErr
 		}
-		if entry.IsDir() {
-			return nil
+		subject, isSubject, subjectErr := s.subjectAt(fset, tree, path, entry)
+		if subjectErr != nil {
+			return subjectErr
 		}
-		rel, relErr := filepath.Rel(tree, path)
-		if relErr != nil {
-			return relErr
-		}
-		rel = filepath.ToSlash(rel)
-		if !isSweptSource(rel) {
-			return nil
-		}
-		file, parseErr := parser.ParseFile(fset, path, nil, parser.ParseComments)
-		if parseErr != nil {
-			return parseErr
-		}
-		if !s.Subject(rel, file) {
+		if !isSubject {
 			return nil
 		}
 		covered := false
 		for i, root := range roots {
-			if under(rel, root) {
+			if under(subject.Path, root) {
 				perRoot[i]++
 				covered = true
 			}
 		}
 		if !covered {
-			outside = append(outside, rel)
+			outside = append(outside, subject.Path)
 			return nil
 		}
-		inside = append(inside, ParsedFile{Path: rel, File: file})
+		inside = append(inside, subject)
 		return nil
 	})
 	return inside, outside, perRoot, err
+}
+
+// subjectAt resolves one walk entry to the parsed subject it holds, reporting
+// false when the entry is not a subject at all — a directory, a source the sweep
+// does not judge, or a file the predicate declines. A file the sweep judges but
+// cannot read is an error, never a silent skip: the roots would then be proven
+// against a tree with a hole in it.
+func (s Scope) subjectAt(fset *token.FileSet, tree, path string, entry fs.DirEntry) (ParsedFile, bool, error) {
+	if entry.IsDir() {
+		return ParsedFile{}, false, nil
+	}
+	rel, err := filepath.Rel(tree, path)
+	if err != nil {
+		return ParsedFile{}, false, err
+	}
+	rel = filepath.ToSlash(rel)
+	if !isSweptSource(rel) {
+		return ParsedFile{}, false, nil
+	}
+	file, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
+	if err != nil {
+		return ParsedFile{}, false, err
+	}
+	if !s.Subject(rel, file) {
+		return ParsedFile{}, false, nil
+	}
+	return ParsedFile{Path: rel, File: file}, true, nil
 }
 
 // universe resolves the tree the roots are proven against.

--- a/backend/internal/shared/gatekit/scope.go
+++ b/backend/internal/shared/gatekit/scope.go
@@ -4,13 +4,14 @@
 package gatekit
 
 import (
+	"fmt"
 	"go/ast"
 	"go/parser"
 	"go/token"
 	"io/fs"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -92,7 +93,7 @@ func (s Scope) Files(t testing.TB) []ParsedFile {
 				"gate reading green over an empty tree", root)
 		}
 	}
-	sort.Strings(outside)
+	slices.Sort(outside)
 	for _, path := range outside {
 		if s.Exempt.Waived(t, path) {
 			continue
@@ -158,7 +159,7 @@ func (s Scope) subjectAt(fset *token.FileSet, tree, path string, entry fs.DirEnt
 	}
 	file, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
 	if err != nil {
-		return ParsedFile{}, false, err
+		return ParsedFile{}, false, fmt.Errorf("could not read %s, and a source the sweep cannot read may hold a subject the roots are then never proven against: %w", rel, err)
 	}
 	if !s.Subject(rel, file) {
 		return ParsedFile{}, false, nil
@@ -233,9 +234,14 @@ func under(path, root string) bool {
 // isSweptSource reports whether the file is hand-written product source. Tests
 // are excluded because a gate judges what ships; generated files because a
 // finding there is fixed in the generator, and this repo spells generated
-// output "_gen.go" everywhere.
+// output "_gen.go" everywhere; and anything under a testdata directory because
+// the Go toolchain builds nothing there — a file in testdata is a fixture a test
+// reads, so it ships no behaviour for a gate to judge.
 func isSweptSource(path string) bool {
-	return strings.HasSuffix(path, ".go") &&
-		!strings.HasSuffix(path, "_test.go") &&
-		!strings.HasSuffix(path, "_gen.go")
+	if !strings.HasSuffix(path, ".go") ||
+		strings.HasSuffix(path, "_test.go") ||
+		strings.HasSuffix(path, "_gen.go") {
+		return false
+	}
+	return !slices.Contains(strings.Split(path, "/"), "testdata")
 }

--- a/backend/internal/shared/gatekit/scope.go
+++ b/backend/internal/shared/gatekit/scope.go
@@ -66,7 +66,10 @@ func (s Scope) Files(t testing.TB) []ParsedFile {
 		t.Errorf("a Scope with no Subject predicate sweeps for nothing: name the site this gate must judge")
 		return nil
 	}
-	roots := s.normalizedRoots()
+	roots, usable := s.normalizedRoots(t)
+	if !usable {
+		return nil
+	}
 	if len(roots) == 0 {
 		t.Errorf("a Scope with no Roots claims no coverage: name the subtrees this gate's obligation lives in")
 		return nil
@@ -175,19 +178,34 @@ func (s Scope) universe(t testing.TB) string {
 }
 
 // normalizedRoots returns the roots in the one spelling paths are compared in,
-// deduplicated so a root named twice cannot mask an empty one.
-func (s Scope) normalizedRoots() []string {
+// deduplicated so a root named twice is reported once, and reports whether every
+// declared root names a subtree at all. A root that does not is refused here
+// rather than swept, because sweeping it produces a confident finding about the
+// obligation when the defect is in the root's spelling.
+func (s Scope) normalizedRoots(t testing.TB) (roots []string, usable bool) {
+	t.Helper()
 	seen := make(map[string]bool, len(s.Roots))
-	roots := make([]string, 0, len(s.Roots))
-	for _, root := range s.Roots {
-		root = strings.TrimSuffix(filepath.ToSlash(filepath.Clean(root)), "/")
-		if root == "" || seen[root] {
+	roots = make([]string, 0, len(s.Roots))
+	for _, declared := range s.Roots {
+		root := strings.TrimSuffix(filepath.ToSlash(filepath.Clean(declared)), "/")
+		switch {
+		case root == ".":
+			t.Errorf("a Scope root of %q covers the whole sweep universe, so no code lies outside the roots "+
+				"and the sweep has nothing left to judge: name the subtrees this gate's obligation lives in",
+				declared)
+			return nil, false
+		case root == "":
+			t.Errorf("a Scope root of %q is an absolute path, and a root is relative to the sweep universe, so "+
+				"it matches no file at all: name the subtrees this gate's obligation lives in, relative to Tree",
+				declared)
+			return nil, false
+		case seen[root]:
 			continue
 		}
 		seen[root] = true
 		roots = append(roots, root)
 	}
-	return roots
+	return roots, true
 }
 
 // under reports whether path lies in root, matching whole segments so that

--- a/backend/internal/shared/gatekit/waivers.go
+++ b/backend/internal/shared/gatekit/waivers.go
@@ -14,17 +14,26 @@
 package gatekit
 
 import (
-	"fmt"
-	"sort"
+	"slices"
+	"strings"
 	"sync"
 	"testing"
 )
 
-// minReason is the shortest text that can state a cost. A reason that only
-// names its own subject, or repeats its key, identifies the exception without
-// saying what it buys or gives up — which is the half a later reader needs in
-// order to judge whether the trade still holds.
+// minReason is the shortest text that can state a cost, measured on the text a
+// reason states rather than the bytes it occupies: whitespace is normalised
+// first, so padding is not length.
+//
+// Length is only half the floor. A reason that restates its own subject
+// identifies the exception at any length without saying what it buys or gives
+// up — which is the half a later reader needs in order to judge whether the
+// trade still holds — so a restatement is refused however long the subject is.
 const minReason = 20
+
+// reasonEdgePunctuation is the quoting and terminal punctuation a restatement
+// may wear without becoming a reason: `"enrich"`, `(enrich)` and `enrich.` all
+// say exactly what `enrich` says.
+const reasonEdgePunctuation = " \t\"'`“”‘’.,:;!?()[]{}<>"
 
 // Waivers is a set of ratified exceptions to one gate's rule, each bound to the
 // reason it costs.
@@ -32,8 +41,10 @@ const minReason = 20
 // K is the vocabulary the gate's subjects are drawn from — a record type, a
 // table name, an operationId. Keying by the caller's own named type keeps the
 // type instead of casting it away at the lookup, so a record-type waiver cannot
-// be keyed by a tool name.
-type Waivers[K comparable] struct {
+// be keyed by a tool name. It is a string type, which is what makes the report
+// order below total: every subject has one rendering, and no two distinct
+// subjects share it.
+type Waivers[K ~string] struct {
 	// mu guards matched. A package-level Waivers is shared by every test in its
 	// package, so concurrent access is possible the moment any of them calls
 	// t.Parallel(); an unguarded map would surface as a stale-waiver report at
@@ -46,7 +57,7 @@ type Waivers[K comparable] struct {
 // Waive ratifies entries, each mapping a subject to what waiving it costs. The
 // input is copied: a caller that mutates its literal afterwards must not widen
 // what was ratified.
-func Waive[K comparable](entries map[K]string) *Waivers[K] {
+func Waive[K ~string](entries map[K]string) *Waivers[K] {
 	reasons := make(map[K]string, len(entries))
 	for subject, reason := range entries {
 		reasons[subject] = reason
@@ -75,11 +86,31 @@ func (w *Waivers[K]) Waived(t testing.TB, subject K) bool {
 		return false
 	}
 	w.matched[subject] = true
-	if len(reason) < minReason {
-		t.Errorf("waiver %v carries no usable reason (%q): state what it costs, so the next "+
+	stated := statedText(reason)
+	switch {
+	case restatesSubject(stated, string(subject)):
+		t.Errorf("waiver %s answers with its own subject (%q): state what it costs, so the next "+
+			"reader can judge whether the cost is still worth paying", subject, reason)
+	case len(stated) < minReason:
+		t.Errorf("waiver %s carries no usable reason (%q): state what it costs, so the next "+
 			"reader can judge whether the cost is still worth paying", subject, reason)
 	}
 	return true
+}
+
+// statedText reduces a reason to the text it states: no surrounding space, and
+// every internal run of whitespace read as the one space it stands for.
+func statedText(reason string) string {
+	return strings.Join(strings.Fields(reason), " ")
+}
+
+// restatesSubject reports whether a reason says its subject over again and
+// nothing more. The whole text is compared, never a prefix: a reason that opens
+// with its subject and then explains it — `enrich — the call fetches the
+// target's own website` — is the shape several gates write, and it does state a
+// cost.
+func restatesSubject(stated, subject string) bool {
+	return strings.EqualFold(strings.Trim(stated, reasonEdgePunctuation), strings.TrimSpace(subject))
 }
 
 // Subjects returns every ratified subject in a deterministic order, for the
@@ -95,9 +126,7 @@ func (w *Waivers[K]) Subjects() []K {
 	for subject := range w.reasons {
 		subjects = append(subjects, subject)
 	}
-	sort.Slice(subjects, func(i, j int) bool {
-		return fmt.Sprintf("%v", subjects[i]) < fmt.Sprintf("%v", subjects[j])
-	})
+	slices.Sort(subjects)
 	return subjects
 }
 
@@ -119,10 +148,10 @@ func (w *Waivers[K]) AssertAllMatched(t testing.TB) {
 	stale := make([]string, 0, len(w.reasons))
 	for subject := range w.reasons {
 		if !w.matched[subject] {
-			stale = append(stale, fmt.Sprintf("%v", subject))
+			stale = append(stale, string(subject))
 		}
 	}
-	sort.Strings(stale)
+	slices.Sort(stale)
 	for _, subject := range stale {
 		t.Errorf("waiver %s matched no subject: delete it, or correct the key if the subject "+
 			"was renamed", subject)

--- a/backend/internal/shared/gatekit/waivers.go
+++ b/backend/internal/shared/gatekit/waivers.go
@@ -134,6 +134,10 @@ func (w *Waivers[K]) AssertAllMatched(t testing.TB) {
 
 // waivedLocked is the shared body of Waived and Reason. mu is held.
 func (w *Waivers[K]) waivedLocked(t testing.TB, subject K) bool {
+	// Helper marking is per-function, and the reason-floor Errorf lives here:
+	// without this the failure is reported at gatekit's own line rather than at
+	// the gate that relied on the waiver.
+	t.Helper()
 	reason, ratified := w.reasons[subject]
 	if !ratified {
 		return false

--- a/backend/internal/shared/gatekit/waivers.go
+++ b/backend/internal/shared/gatekit/waivers.go
@@ -61,28 +61,25 @@ func Waive[K comparable](entries map[K]string) *Waivers[K] {
 // separate validation step is one more call a new gate can omit, and a waiver
 // whose reason nothing checks is exactly the gap this package closes.
 func (w *Waivers[K]) Waived(t testing.TB, subject K) bool {
+	// The reason floor below reports through t, and Helper marking is
+	// per-function: without this the failure is attributed to gatekit's own line
+	// rather than to the gate that relied on the waiver.
 	t.Helper()
 	if w == nil {
 		return false
 	}
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	return w.waivedLocked(t, subject)
-}
-
-// Reason returns the ratified reason, for a gate that reports its own waivers.
-// Reading a reason is relying on the waiver, so it counts as a match.
-func (w *Waivers[K]) Reason(t testing.TB, subject K) (string, bool) {
-	t.Helper()
-	if w == nil {
-		return "", false
+	reason, ratified := w.reasons[subject]
+	if !ratified {
+		return false
 	}
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	if !w.waivedLocked(t, subject) {
-		return "", false
+	w.matched[subject] = true
+	if len(reason) < minReason {
+		t.Errorf("waiver %v carries no usable reason (%q): state what it costs, so the next "+
+			"reader can judge whether the cost is still worth paying", subject, reason)
 	}
-	return w.reasons[subject], true
+	return true
 }
 
 // Subjects returns every ratified subject in a deterministic order, for the
@@ -130,22 +127,4 @@ func (w *Waivers[K]) AssertAllMatched(t testing.TB) {
 		t.Errorf("waiver %s matched no subject: delete it, or correct the key if the subject "+
 			"was renamed", subject)
 	}
-}
-
-// waivedLocked is the shared body of Waived and Reason. mu is held.
-func (w *Waivers[K]) waivedLocked(t testing.TB, subject K) bool {
-	// Helper marking is per-function, and the reason-floor Errorf lives here:
-	// without this the failure is reported at gatekit's own line rather than at
-	// the gate that relied on the waiver.
-	t.Helper()
-	reason, ratified := w.reasons[subject]
-	if !ratified {
-		return false
-	}
-	w.matched[subject] = true
-	if len(reason) < minReason {
-		t.Errorf("waiver %v carries no usable reason (%q): state what it costs, so the next "+
-			"reader can judge whether the cost is still worth paying", subject, reason)
-	}
-	return true
 }

--- a/backend/internal/shared/gatekit/waivers.go
+++ b/backend/internal/shared/gatekit/waivers.go
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// Package gatekit is where this repo's fitness gates hold their waivers and
+// their walk scopes.
+//
+// A waiver carries two obligations: it states what it costs, and it describes
+// code that still exists. Both are enforced here rather than per gate, so a
+// gate cannot hold its exceptions to a weaker standard than its neighbours.
+//
+// gatekit is imported only from _test.go files. A waiver mechanism reachable
+// from product code would be a way to mark shipped behaviour "ratified", which
+// is not what a waiver is for; the census holds that line.
+package gatekit
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+	"testing"
+)
+
+// minReason is the shortest text that can state a cost. A reason that only
+// names its own subject, or repeats its key, identifies the exception without
+// saying what it buys or gives up — which is the half a later reader needs in
+// order to judge whether the trade still holds.
+const minReason = 20
+
+// Waivers is a set of ratified exceptions to one gate's rule, each bound to the
+// reason it costs.
+//
+// K is the vocabulary the gate's subjects are drawn from — a record type, a
+// table name, an operationId. Keying by the caller's own named type keeps the
+// type instead of casting it away at the lookup, so a record-type waiver cannot
+// be keyed by a tool name.
+type Waivers[K comparable] struct {
+	// mu guards matched. A package-level Waivers is shared by every test in its
+	// package, so concurrent access is possible the moment any of them calls
+	// t.Parallel(); an unguarded map would surface as a stale-waiver report at
+	// random.
+	mu      sync.Mutex
+	reasons map[K]string
+	matched map[K]bool
+}
+
+// Waive ratifies entries, each mapping a subject to what waiving it costs. The
+// input is copied: a caller that mutates its literal afterwards must not widen
+// what was ratified.
+func Waive[K comparable](entries map[K]string) *Waivers[K] {
+	reasons := make(map[K]string, len(entries))
+	for subject, reason := range entries {
+		reasons[subject] = reason
+	}
+	return &Waivers[K]{reasons: reasons, matched: make(map[K]bool, len(entries))}
+}
+
+// Waived reports whether subject is ratified, recording the match so
+// AssertAllMatched can tell a live waiver from one describing code that is gone.
+//
+// It takes t because a reasonless entry must fail where it is RELIED ON: a
+// separate validation step is one more call a new gate can omit, and a waiver
+// whose reason nothing checks is exactly the gap this package closes.
+func (w *Waivers[K]) Waived(t testing.TB, subject K) bool {
+	t.Helper()
+	if w == nil {
+		return false
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.waivedLocked(t, subject)
+}
+
+// Reason returns the ratified reason, for a gate that reports its own waivers.
+// Reading a reason is relying on the waiver, so it counts as a match.
+func (w *Waivers[K]) Reason(t testing.TB, subject K) (string, bool) {
+	t.Helper()
+	if w == nil {
+		return "", false
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if !w.waivedLocked(t, subject) {
+		return "", false
+	}
+	return w.reasons[subject], true
+}
+
+// Subjects returns every ratified subject in a deterministic order, for the
+// gates that walk their waivers rather than querying them. It does NOT mark
+// anything matched: enumerating the set is not yet relying on any entry.
+func (w *Waivers[K]) Subjects() []K {
+	if w == nil {
+		return nil
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	subjects := make([]K, 0, len(w.reasons))
+	for subject := range w.reasons {
+		subjects = append(subjects, subject)
+	}
+	sort.Slice(subjects, func(i, j int) bool {
+		return fmt.Sprintf("%v", subjects[i]) < fmt.Sprintf("%v", subjects[j])
+	})
+	return subjects
+}
+
+// AssertAllMatched reports every entry no subject reached. Such an entry
+// certifies nothing while reading as though it does, which is worse than no
+// waiver at all.
+//
+// Call it from exactly ONE place per declaration: matched accumulates across
+// every test in the package, so two tests each sweeping half the subjects would
+// make whichever asserted first report false staleness. The owner is the test
+// that enumerates the full subject set.
+func (w *Waivers[K]) AssertAllMatched(t testing.TB) {
+	t.Helper()
+	if w == nil {
+		return
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	stale := make([]string, 0, len(w.reasons))
+	for subject := range w.reasons {
+		if !w.matched[subject] {
+			stale = append(stale, fmt.Sprintf("%v", subject))
+		}
+	}
+	sort.Strings(stale)
+	for _, subject := range stale {
+		t.Errorf("waiver %s matched no subject: delete it, or correct the key if the subject "+
+			"was renamed", subject)
+	}
+}
+
+// waivedLocked is the shared body of Waived and Reason. mu is held.
+func (w *Waivers[K]) waivedLocked(t testing.TB, subject K) bool {
+	reason, ratified := w.reasons[subject]
+	if !ratified {
+		return false
+	}
+	w.matched[subject] = true
+	if len(reason) < minReason {
+		t.Errorf("waiver %v carries no usable reason (%q): state what it costs, so the next "+
+			"reader can judge whether the cost is still worth paying", subject, reason)
+	}
+	return true
+}

--- a/backend/internal/shared/gatekit/waivers.go
+++ b/backend/internal/shared/gatekit/waivers.go
@@ -18,11 +18,13 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"unicode/utf8"
 )
 
-// minReason is the shortest text that can state a cost, measured on the text a
-// reason states rather than the bytes it occupies: whitespace is normalised
-// first, so padding is not length.
+// minReason is the shortest text that can state a cost, counted in characters
+// rather than bytes: whitespace is normalised first so padding is not length,
+// and a reason written in a script whose runes are several bytes wide states no
+// more than the same count of them in ASCII.
 //
 // Length is only half the floor. A reason that restates its own subject
 // identifies the exception at any length without saying what it buys or gives
@@ -91,7 +93,7 @@ func (w *Waivers[K]) Waived(t testing.TB, subject K) bool {
 	case restatesSubject(stated, string(subject)):
 		t.Errorf("waiver %s answers with its own subject (%q): state what it costs, so the next "+
 			"reader can judge whether the cost is still worth paying", subject, reason)
-	case len(stated) < minReason:
+	case utf8.RuneCountInString(stated) < minReason:
 		t.Errorf("waiver %s carries no usable reason (%q): state what it costs, so the next "+
 			"reader can judge whether the cost is still worth paying", subject, reason)
 	}

--- a/backend/jobargscontent_test.go
+++ b/backend/jobargscontent_test.go
@@ -22,6 +22,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/gatekit"
 )
 
 // contentWords name a payload rather than a pointer to one. Matched as a
@@ -37,13 +39,13 @@ var contentWords = []string{
 // real exception should be rare enough to argue about. The validation below
 // exists so that when one does appear it cannot arrive without a rationale, or
 // outlive the field it was written for.
-var contentFieldWaivers = map[string]string{}
+var contentFieldWaivers = gatekit.Waive(map[string]string{})
 
 func TestJobArgsCarryReferencesNotContent(t *testing.T) {
+	defer contentFieldWaivers.AssertAllMatched(t)
 	dir := filepath.Join("internal", "compose")
 	byType := methodsByType(t, dir)
 	fields := structFields(t, dir)
-	used := map[string]bool{}
 	checked := 0
 
 	for typeName, methods := range byType {
@@ -58,8 +60,7 @@ func TestJobArgsCarryReferencesNotContent(t *testing.T) {
 				if !strings.Contains(lower, word) {
 					continue
 				}
-				if _, waived := contentFieldWaivers[key]; waived {
-					used[key] = true
+				if contentFieldWaivers.Waived(t, key) {
 					break
 				}
 				t.Errorf("%s looks like content, not a reference (matched %q). A job names a row; the worker reads it. If this really is a reference, waive it in contentFieldWaivers with a rationale.", key, word)
@@ -69,14 +70,6 @@ func TestJobArgsCarryReferencesNotContent(t *testing.T) {
 	}
 	if checked < jobArgsFloor {
 		t.Fatalf("found only %d job args types, expected at least %d — the walker matched nothing", checked, jobArgsFloor)
-	}
-	for key, reason := range contentFieldWaivers {
-		if reason == "" {
-			t.Errorf("%s: waiver without a rationale", key)
-		}
-		if !used[key] {
-			t.Errorf("%s: stale waiver — no such field trips the gate any more; delete it", key)
-		}
 	}
 }
 

--- a/backend/jobargscontent_test.go
+++ b/backend/jobargscontent_test.go
@@ -36,13 +36,12 @@ var contentWords = []string{
 
 // contentFieldWaivers are ratified exceptions, keyed "Type.Field". EMPTY is
 // the expected steady state — a job names a row and the worker reads it, so a
-// real exception should be rare enough to argue about. The validation below
-// exists so that when one does appear it cannot arrive without a rationale, or
-// outlive the field it was written for.
+// real exception should be rare enough to argue about. The waiver type holds
+// each entry to a stated rationale and reports one that outlives the field it
+// was written for, so when an exception does appear it cannot arrive bare.
 var contentFieldWaivers = gatekit.Waive(map[string]string{})
 
 func TestJobArgsCarryReferencesNotContent(t *testing.T) {
-	defer contentFieldWaivers.AssertAllMatched(t)
 	dir := filepath.Join("internal", "compose")
 	byType := methodsByType(t, dir)
 	fields := structFields(t, dir)
@@ -71,6 +70,10 @@ func TestJobArgsCarryReferencesNotContent(t *testing.T) {
 	if checked < jobArgsFloor {
 		t.Fatalf("found only %d job args types, expected at least %d — the walker matched nothing", checked, jobArgsFloor)
 	}
+	// Staleness is only meaningful once the sweep above actually ran: on the
+	// vacuity Fatal every entry would report as unmatched, burying the one
+	// failure that explains all of them.
+	contentFieldWaivers.AssertAllMatched(t)
 }
 
 // structFields returns the declared field names of every struct type in dir.

--- a/backend/jobfault_test.go
+++ b/backend/jobfault_test.go
@@ -36,7 +36,6 @@ var nilAfterLogging = gatekit.Waive(map[string]string{
 })
 
 func TestEveryWorkerReturnsThroughJobsFault(t *testing.T) {
-	defer nilAfterLogging.AssertAllMatched(t)
 	fset, files := parseGoFilesUnder(t, filepath.Join("internal", "compose"))
 	workers := 0
 	for _, file := range files {
@@ -87,6 +86,10 @@ func TestEveryWorkerReturnsThroughJobsFault(t *testing.T) {
 	if workers < workerFloor {
 		t.Fatalf("found only %d Work methods, expected at least %d — the walker matched nothing", workers, workerFloor)
 	}
+	// Staleness is only meaningful once the sweep above actually ran: on the
+	// vacuity Fatal every entry would report as unmatched, burying the one
+	// failure that explains all of them.
+	nilAfterLogging.AssertAllMatched(t)
 }
 
 // errorLogsAndReturnsNil reports whether fn both logs a failure and returns

--- a/backend/jobfault_test.go
+++ b/backend/jobfault_test.go
@@ -17,6 +17,8 @@ import (
 	"go/ast"
 	"path/filepath"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/gatekit"
 )
 
 // workerFloor guards against a vacuous pass, as in the role gate.
@@ -26,17 +28,17 @@ const workerFloor = 20
 // That shape is EXACTLY the defect this phase removes — a tenant failure
 // becoming a green River row — so each entry states the durable retry policy
 // that makes it honest here. A worker not listed must return its failure.
-var nilAfterLogging = map[string]string{
+var nilAfterLogging = gatekit.Waive(map[string]string{
 	"captureSyncWorker":               "the connector sidecar owns the retry: a failed sync leaves next_sync_at unadvanced, so the dispatcher re-enqueues it on the next scan — the job row's success means 'this attempt is concluded', not 'the sync succeeded'",
 	"captureBackfillWorker":           "the backfill ROW owns the outcome: RunBackfillStep ends the run and records the fault class on the row against its own give-up cap, on a context detached from the job because the job context dying mid-page is the commonest fault. A River retry would re-page a run the engine already ended",
 	"overlayReconcileWorkspaceWorker": "two nil paths, neither a swallowed sweep failure. The disconnect fence: every fenced write aborted with ErrConnectionGone, so there is nothing to retry and nothing to back off. And a failed RecordSweepSuccess, which leaves the previous backoff in place — the next due-scan is simply later than it needed to be, never earlier. A genuine sweep failure IS returned; the row fails and stays failed, because this kind takes a single attempt and its retry is the backoff the worker just recorded",
 	"voiceBuildWorker":                "the build ROW owns its state: every model failure lands on the row as deferred or failed, never as a River retry loop, and the deferred-retry sweep re-enqueues what is due",
-}
+})
 
 func TestEveryWorkerReturnsThroughJobsFault(t *testing.T) {
+	defer nilAfterLogging.AssertAllMatched(t)
 	fset, files := parseGoFilesUnder(t, filepath.Join("internal", "compose"))
 	workers := 0
-	usedNilWaiver := map[string]bool{}
 	for _, file := range files {
 		for _, decl := range file.Decls {
 			fn, ok := decl.(*ast.FuncDecl)
@@ -74,9 +76,7 @@ func TestEveryWorkerReturnsThroughJobsFault(t *testing.T) {
 			// durable retry policy elsewhere makes the success honest.
 			recv := receiverTypeName(fn)
 			if errorLogsAndReturnsNil(fn) {
-				if _, waived := nilAfterLogging[recv]; waived {
-					usedNilWaiver[recv] = true
-				} else {
+				if !nilAfterLogging.Waived(t, recv) {
 					pos := fset.Position(fn.Pos())
 					t.Errorf("%s:%d: %s logs an error and returns nil — River will record this job as completed while the work failed. Return the failure, or ratify it in nilAfterLogging naming the retry policy that makes success honest.",
 						pos.Filename, pos.Line, recv)
@@ -86,14 +86,6 @@ func TestEveryWorkerReturnsThroughJobsFault(t *testing.T) {
 	}
 	if workers < workerFloor {
 		t.Fatalf("found only %d Work methods, expected at least %d — the walker matched nothing", workers, workerFloor)
-	}
-	for recv, reason := range nilAfterLogging {
-		if reason == "" {
-			t.Errorf("%s: nil-after-logging waiver without a rationale", recv)
-		}
-		if !usedNilWaiver[recv] {
-			t.Errorf("%s: stale waiver — it no longer logs-and-returns-nil; delete it", recv)
-		}
 	}
 }
 

--- a/backend/mcpfaultcoverage_test.go
+++ b/backend/mcpfaultcoverage_test.go
@@ -33,10 +33,11 @@ package backendarch
 // into the tool registry. Any tier the tool surface can reach owes the same
 // obligation, so the scope is "reachable", not "is a module".
 //
-// That makes the path list a load-bearing claim rather than configuration: it
-// asserts where obligated code lives, and it needs re-checking whenever a new
-// tier starts serving the surface. A gate reading the wrong tree reads green for
-// a reason nobody is looking at.
+// That path list is a load-bearing claim rather than configuration: it asserts
+// where obligated code lives. So it is not asserted here — it is PROVEN, by
+// gatekit.Scope sweeping the whole module for files that import the seam and
+// reporting any that lie outside both roots. A new tier that starts serving the
+// surface fails this gate instead of quietly falling out of its reach.
 
 import (
 	"go/ast"
@@ -47,6 +48,8 @@ import (
 	"sort"
 	"strings"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/gatekit"
 )
 
 const modulesDir = "internal/modules"
@@ -60,6 +63,35 @@ const composeDir = "internal/compose"
 
 // seamReachableRoots are the trees an MCP tool call can reach code in.
 var seamReachableRoots = []string{modulesDir, composeDir}
+
+// seamScope proves seamReachableRoots: every file in the module that imports the
+// datasource seam either lives under one of those roots, or is ratified below as
+// not this gate's business.
+var seamScope = gatekit.Scope{
+	Roots:   seamReachableRoots,
+	Subject: importsDatasourceSeam,
+	Exempt:  seamOutsideRoots,
+}
+
+// seamOutsideRoots ratifies the files that import the seam yet owe no unit
+// verdict. They are all one of two things: a shared PORT, which borrows
+// datasource's entity vocabulary to type its own interfaces, or the platform
+// CLASSIFIER, which names datasource's typed errors to give them one wire shape.
+// Neither owns a store, a transport branch, or an error of its own, so there is
+// nothing here for a FieldFault to carry.
+//
+// Narrowing the subject to "is a capability tier" would have silenced these
+// instead, and it is the wrong instrument: a subject predicate that consults the
+// roots can never contradict them, and the sweep would collapse back into the
+// assertion it replaces.
+var seamOutsideRoots = gatekit.Waive(map[string]string{
+	"internal/platform/httperr/httperr.go":         "httperr IS the one classifier both surfaces run: it names datasource's own FieldDecodeError and UnsupportedEntityError so each gets a single wire verdict. It declares no domain error and maps none of its own to a 422 — obligating the classifier would invert the rule this gate enforces",
+	"internal/platform/httperr/wire.go":            "the same classifier's decode helper, calling datasource.RejectNonCanonicalKeys so every surface refuses an unknown key identically; a platform package owns no domain, so it has no error type of its own to carry a verdict",
+	"internal/platform/httperr/decoderefusal.go":   "the classifier's decode-refusal half, naming datasource.UnknownFieldError and FieldDecodeError to render one refusal shape for both surfaces; it maps no error IT declares to a 422",
+	"internal/shared/ports/connector/connector.go": "a seam DEFINITION rather than a capability: it borrows datasource's EntityType and EntityRef to type the connector port's signatures. A Tier-0 shared port has no store, no transport and no error of its own",
+	"internal/shared/ports/retrieval/retrieval.go": "the same posture: the retrieval port's signatures are typed in datasource's EntityRef vocabulary, and a frozen interface declaration has no transport branch to remove",
+	"internal/shared/ports/workflow/workflow.go":   "the same posture: the workflow port types its trigger and action shapes with datasource.EntityRef; it declares interfaces and value shapes only, never an error it maps to a 422",
+})
 
 // seamImportPath is the datasource seam — the MCP surface's door into a
 // module's stores. Importing it is the marker, deliberately BROADER than
@@ -79,6 +111,22 @@ type moduleSource struct {
 	files map[string]*ast.File
 }
 
+// unitOf names the unit a path under one of the roots belongs to. Under
+// modules, the first path segment is the isolation boundary and so the unit;
+// compose is one unit whatever its subpackages.
+func unitOf(path string) (name, dir string) {
+	rest, isModule := strings.CutPrefix(path, modulesDir+"/")
+	if !isModule {
+		return "compose", composeDir
+	}
+	name, _, _ = strings.Cut(rest, "/")
+	return name, modulesDir + "/" + name
+}
+
+// parseModules groups every non-test, non-generated file under the roots into
+// its unit. A unit is judged as a whole because the type that carries a verdict
+// and the transport branch that maps it to a 422 routinely sit in different
+// files of the same package.
 func parseModules(t *testing.T) []moduleSource {
 	t.Helper()
 	byUnit := map[string]*moduleSource{}
@@ -94,15 +142,7 @@ func parseModules(t *testing.T) []moduleSource {
 				strings.HasSuffix(path, "_gen.go") {
 				return nil
 			}
-			// Under modules, the first path segment is the isolation boundary
-			// and so the unit. compose is one unit whatever its subpackages.
-			name := "compose"
-			dir := composeDir
-			if root == modulesDir {
-				rest := strings.TrimPrefix(path, modulesDir+"/")
-				name, _, _ = strings.Cut(rest, "/")
-				dir = modulesDir + "/" + name
-			}
+			name, dir := unitOf(path)
 			file, parseErr := parser.ParseFile(fset, path, nil, parser.ParseComments)
 			if parseErr != nil {
 				return parseErr
@@ -117,20 +157,6 @@ func parseModules(t *testing.T) []moduleSource {
 			t.Fatalf("walking %s: %v", root, err)
 		}
 	}
-	// Both roots must have produced something: a rename that emptied either one
-	// would otherwise shrink this gate's reach in silence.
-	for _, root := range seamReachableRoots {
-		found := false
-		for _, unit := range byUnit {
-			if strings.HasPrefix(unit.dir, root) {
-				found = true
-				break
-			}
-		}
-		if !found {
-			t.Fatalf("no source found under %s — the gate is reading the wrong tree", root)
-		}
-	}
 	out := make([]moduleSource, 0, len(byUnit))
 	for _, unit := range byUnit {
 		out = append(out, *unit)
@@ -139,17 +165,26 @@ func parseModules(t *testing.T) []moduleSource {
 	return out
 }
 
-// touchesDatasourceSeam reports whether the module imports the seam, i.e.
-// whether an MCP tool call can reach its code at all.
-func (m moduleSource) touchesDatasourceSeam() bool {
-	for _, file := range m.files {
-		for _, imp := range file.Imports {
-			if imp.Path != nil && strings.Trim(imp.Path.Value, `"`) == seamImportPath {
-				return true
-			}
+// importsDatasourceSeam reports whether the file imports the seam, i.e. whether
+// an MCP tool call can reach the code around it at all.
+func importsDatasourceSeam(_ string, file *ast.File) bool {
+	for _, imp := range file.Imports {
+		if imp.Path != nil && strings.Trim(imp.Path.Value, `"`) == seamImportPath {
+			return true
 		}
 	}
 	return false
+}
+
+// seamReachableUnits are the units the sweep found seam-importing code in.
+func seamReachableUnits(t *testing.T) map[string]bool {
+	t.Helper()
+	units := map[string]bool{}
+	for _, src := range seamScope.Files(t) {
+		name, _ := unitOf(src.Path)
+		units[name] = true
+	}
+	return units
 }
 
 // faultMethods are the three shapes a module error may use to carry its own
@@ -392,12 +427,13 @@ func isUnprocessableEntity(expr ast.Expr) bool {
 }
 
 func TestSeamReachableModulesCarryTheirOwnFieldVerdict(t *testing.T) {
-	obligated := 0
+	defer seamOutsideRoots.AssertAllMatched(t)
+
+	reachable := seamReachableUnits(t)
 	for _, module := range parseModules(t) {
-		if !module.touchesDatasourceSeam() {
+		if !reachable[module.name] {
 			continue
 		}
-		obligated++
 		carries := module.implementsFieldFault()
 		mapped := module.validationMappedTypes(module.helpersReturning422())
 
@@ -416,8 +452,5 @@ func TestSeamReachableModulesCarryTheirOwnFieldVerdict(t *testing.T) {
 				"agent to retry it. Add FieldFault() to the type and delete the transport branch.",
 				module.dir, module.name, name)
 		}
-	}
-	if obligated == 0 {
-		t.Fatalf("no module imports %s — the marker is stale and this gate is asserting nothing", seamImportPath)
 	}
 }

--- a/backend/migrations/schema_fitness_integration_test.go
+++ b/backend/migrations/schema_fitness_integration_test.go
@@ -16,6 +16,8 @@ import (
 	"context"
 	"strings"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/gatekit"
 )
 
 // TestRLS_coversEveryTenantTable is the fitness function for the "RLS on
@@ -28,12 +30,14 @@ import (
 // rlsExemptTables are the ratified non-RLS workspace_id tables. Every
 // entry carries its rationale inline — an entry without one is a
 // finding, and a stale entry (table gone or since enrolled) fails too.
-var rlsExemptTables = map[string]string{
+var rlsExemptTables = gatekit.Waive(map[string]string{
 	"booking_page":     "the slug→tenant RESOLVER (0036): it is read to discover which workspace to bind BEFORE any GUC exists, exactly like the workspace table itself (data-model §1.2); it carries no CRM record data — slug, workspace, host, revocation only",
 	"preference_token": "the token→tenant RESOLVER (0048): the no-login preference center / RFC 8058 unsubscribe reads it to discover which workspace to bind BEFORE any GUC exists, exactly like booking_page; it carries no CRM record data beyond the person link + revocation",
-}
+})
 
 func TestRLS_coversEveryTenantTable(t *testing.T) {
+	defer rlsExemptTables.AssertAllMatched(t)
+
 	ownerDSN, _ := dsns(t)
 	owner := connect(t, ownerDSN)
 	resetSchema(t, owner)
@@ -58,7 +62,6 @@ func TestRLS_coversEveryTenantTable(t *testing.T) {
 	defer rows.Close()
 
 	tenantTables := 0
-	exemptSeen := map[string]bool{}
 	for rows.Next() {
 		var name string
 		var enabled, forced, hasPolicy bool
@@ -66,11 +69,7 @@ func TestRLS_coversEveryTenantTable(t *testing.T) {
 			t.Fatal(err)
 		}
 		tenantTables++
-		if rationale, exempt := rlsExemptTables[name]; exempt {
-			exemptSeen[name] = true
-			if strings.TrimSpace(rationale) == "" {
-				t.Errorf("rlsExemptTables[%s] has no rationale — an exemption must say why RLS cannot apply", name)
-			}
+		if rlsExemptTables.Waived(t, name) {
 			if enabled || forced {
 				t.Errorf("table %s is RLS-exempt by rationale but HAS row security — retire the stale exemption", name)
 			}
@@ -81,11 +80,6 @@ func TestRLS_coversEveryTenantTable(t *testing.T) {
 		}
 		if !hasPolicy {
 			t.Errorf("table %s has RLS flags but NO policy — it would deny everything, or worse, a later DISABLE would open it", name)
-		}
-	}
-	for name := range rlsExemptTables {
-		if !exemptSeen[name] {
-			t.Errorf("rlsExemptTables names %s but the schema has no such workspace_id table — retire the stale exemption", name)
 		}
 	}
 	if err := rows.Err(); err != nil {
@@ -248,7 +242,7 @@ func TestSchema_organizationOpenPipelineRollupIsSecurityInvoker(t *testing.T) {
 // rowScopedFKDecisions is the classification: one entry per FK column
 // naming a row-scoped business record. Values are prose for the reader;
 // the map's completeness is the invariant.
-var rowScopedFKDecisions = map[string]string{
+var rowScopedFKDecisions = gatekit.Waive(map[string]string{
 	// Client-supplied references — visibility-gated at the store:
 	"site_read.organization_id":            "gated: auth.EnsureVisible in StartSiteRead (the one human entry point); Begin/Finish only re-address a row Start created, and GetSiteRead re-checks EnsureVisible on every read",
 	"deal.organization_id":                 "gated: auth.EnsureLinkTarget in CreateDeal/UpdateDeal (H1)",
@@ -361,7 +355,7 @@ var rowScopedFKDecisions = map[string]string{
 	// addresses the ghost row rather than naming a person.
 	"linkedin_connection.matched_person_id": "server-derived: resolved by the ghost matcher's own row-scoped lookup, never from a request body",
 	"linkedin_connection.matched_org_id":    "server-derived: resolved by the ghost matcher's own row-scoped lookup, never from a request body",
-}
+})
 
 // TestFK_rowScopedTargetsHaveVisibilityDecision derives the H1 obligation
 // from the schema: an FK argument that names a row-scoped business record
@@ -373,6 +367,8 @@ var rowScopedFKDecisions = map[string]string{
 // table that nobody classified fails here, so the decision cannot be
 // skipped silently.
 func TestFK_rowScopedTargetsHaveVisibilityDecision(t *testing.T) {
+	defer rowScopedFKDecisions.AssertAllMatched(t)
+
 	ownerDSN, _ := dsns(t)
 	owner := connect(t, ownerDSN)
 	resetSchema(t, owner)
@@ -394,26 +390,17 @@ func TestFK_rowScopedTargetsHaveVisibilityDecision(t *testing.T) {
 	}
 	defer rows.Close()
 
-	seen := map[string]bool{}
 	for rows.Next() {
 		var srcTable, srcCol, target string
 		if err := rows.Scan(&srcTable, &srcCol, &target); err != nil {
 			t.Fatal(err)
 		}
 		key := srcTable + "." + srcCol
-		seen[key] = true
-		if _, decided := rowScopedFKDecisions[key]; !decided {
+		if !rowScopedFKDecisions.Waived(t, key) {
 			t.Errorf("FK %s -> %s has no visibility decision: a reference to a row-scoped record is a read of it — gate it (auth.EnsureLinkTarget) or classify it here", key, target)
 		}
 	}
 	if err := rows.Err(); err != nil {
 		t.Fatal(err)
-	}
-	// The map must not carry dead entries either — a renamed column would
-	// otherwise keep a stale decision alive forever.
-	for key := range rowScopedFKDecisions {
-		if !seen[key] {
-			t.Errorf("decision map entry %s matches no FK in the live schema — remove or fix it", key)
-		}
 	}
 }

--- a/backend/promptfence_test.go
+++ b/backend/promptfence_test.go
@@ -131,6 +131,7 @@ func TestNoPromptDeclaresAFixedDataBoundary(t *testing.T) {
 // every instance found so far has taken.
 func TestAFileThatPromisesADataBoundaryBuildsOne(t *testing.T) {
 	var offenders []string
+	claimants := 0
 	goFilesUnderTree(t, func(path, body string) {
 		if strings.HasPrefix(path, promptfencePackage) {
 			return
@@ -138,6 +139,7 @@ func TestAFileThatPromisesADataBoundaryBuildsOne(t *testing.T) {
 		if !boundaryClaim.MatchString(body) {
 			return
 		}
+		claimants++
 		if buildsAFence.MatchString(body) {
 			return
 		}
@@ -146,6 +148,11 @@ func TestAFileThatPromisesADataBoundaryBuildsOne(t *testing.T) {
 		}
 		offenders = append(offenders, path)
 	})
+	if claimants == 0 {
+		t.Fatal("boundaryClaim matched no file outside promptfence, so this rule judged nothing: the pattern " +
+			"derives the subjects, and a derivation that finds none reads green over every prompt in the tree " +
+			"— widen boundaryClaim to the sentences the prompts now use")
+	}
 	if len(offenders) > 0 {
 		t.Errorf("these files tell a model that some region of a prompt is data rather than instructions, without minting the boundary that makes it true — fence the region with promptfence and let Fence.Rule write the sentence:\n  %s",
 			strings.Join(offenders, "\n  "))
@@ -153,9 +160,9 @@ func TestAFileThatPromisesADataBoundaryBuildsOne(t *testing.T) {
 }
 
 // An entry naming a file that no longer claims a data boundary reads stale
-// here: this is the sweep that reaches every file in the tree unconditionally,
-// so it is the one that owns AssertAllMatched. It holds that each entry still
-// names a claim, not that the claim still needs waiving — a file that now
+// here: this is the sweep that reaches every non-test Go file with no further
+// filter, so it is the one that owns AssertAllMatched. It holds that each entry
+// still names a claim, not that the claim still needs waiving — a file that now
 // mints its fence as well still matches, and stays matched.
 func TestEveryBoundaryClaimWaiverIsStillReachable(t *testing.T) {
 	defer claimWithoutFence.AssertAllMatched(t)

--- a/backend/promptfence_test.go
+++ b/backend/promptfence_test.go
@@ -152,9 +152,11 @@ func TestAFileThatPromisesADataBoundaryBuildsOne(t *testing.T) {
 	}
 }
 
-// The waiver list is only honest if every entry still exists and still needs
-// it: this is the sweep that reaches every file in the tree unconditionally,
-// so it is the one that owns AssertAllMatched.
+// An entry naming a file that no longer claims a data boundary reads stale
+// here: this is the sweep that reaches every file in the tree unconditionally,
+// so it is the one that owns AssertAllMatched. It holds that each entry still
+// names a claim, not that the claim still needs waiving — a file that now
+// mints its fence as well still matches, and stays matched.
 func TestEveryBoundaryClaimWaiverIsStillReachable(t *testing.T) {
 	defer claimWithoutFence.AssertAllMatched(t)
 	goFilesUnderTree(t, func(path, body string) {

--- a/backend/promptfence_test.go
+++ b/backend/promptfence_test.go
@@ -30,6 +30,8 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/gatekit"
 )
 
 // The fixed marker no prompt may build a boundary from again.
@@ -54,7 +56,7 @@ var buildsAFence = regexp.MustCompile(`promptfence\.(New|FromMarker)\(`)
 // claimWithoutFence names the files allowed to promise a boundary without
 // minting one, with the reason. Keep this at zero if you can; every entry is a
 // prompt whose safety rests on something other than a nonce.
-var claimWithoutFence = map[string]string{}
+var claimWithoutFence = gatekit.Waive(map[string]string{})
 
 // sourceWithoutComments renders one file's CODE, comments discarded.
 //
@@ -130,15 +132,19 @@ func TestNoPromptDeclaresAFixedDataBoundary(t *testing.T) {
 func TestAFileThatPromisesADataBoundaryBuildsOne(t *testing.T) {
 	var offenders []string
 	goFilesUnderTree(t, func(path, body string) {
-		if strings.HasPrefix(path, promptfencePackage) || claimWithoutFence[path] != "" {
+		if strings.HasPrefix(path, promptfencePackage) {
 			return
 		}
 		if !boundaryClaim.MatchString(body) {
 			return
 		}
-		if !buildsAFence.MatchString(body) {
-			offenders = append(offenders, path)
+		if buildsAFence.MatchString(body) {
+			return
 		}
+		if claimWithoutFence.Waived(t, path) {
+			return
+		}
+		offenders = append(offenders, path)
 	})
 	if len(offenders) > 0 {
 		t.Errorf("these files tell a model that some region of a prompt is data rather than instructions, without minting the boundary that makes it true — fence the region with promptfence and let Fence.Rule write the sentence:\n  %s",
@@ -146,17 +152,14 @@ func TestAFileThatPromisesADataBoundaryBuildsOne(t *testing.T) {
 	}
 }
 
-// The waiver list is only honest if every entry still exists and still needs it.
+// The waiver list is only honest if every entry still exists and still needs
+// it: this is the sweep that reaches every file in the tree unconditionally,
+// so it is the one that owns AssertAllMatched.
 func TestEveryBoundaryClaimWaiverIsStillReachable(t *testing.T) {
-	seen := map[string]bool{}
+	defer claimWithoutFence.AssertAllMatched(t)
 	goFilesUnderTree(t, func(path, body string) {
-		if claimWithoutFence[path] != "" && boundaryClaim.MatchString(body) {
-			seen[path] = true
+		if boundaryClaim.MatchString(body) {
+			claimWithoutFence.Waived(t, path)
 		}
 	})
-	for path := range claimWithoutFence {
-		if !seen[path] {
-			t.Errorf("%s is waived from the data-boundary rule but no longer makes the claim — delete the waiver", path)
-		}
-	}
 }

--- a/backend/publicevents_test.go
+++ b/backend/publicevents_test.go
@@ -49,6 +49,7 @@ import (
 	"testing"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/shared/gatekit"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/events"
 )
 
@@ -222,12 +223,13 @@ func TestSubscribableEventTypeEnumMatchesPayloadCatalog(t *testing.T) {
 // probe-reachable. An entry that names a non-dynamic or non-subscribable
 // event is stale and fails below; a dynamic event in neither set is a silent
 // default and also fails.
-var dynamicProbeResolved = map[string]string{
+var dynamicProbeResolved = gatekit.Waive(map[string]string{
 	"consent.changed":   "subject is person XOR lead (consent/store.go stamps sub.entityType) — both hit the row-scope probe branch",
 	"retention.applied": "subject is person/lead/deal/activity for policy-driven sweeps (all row-scope probed); its ownerless ai_call/ai_call_payload/voice_learning_signal telemetry subjects are the deferredDeliveryEntities half",
-}
+})
 
 func TestEverySubscribableEventIsDeliveryResolvable(t *testing.T) {
+	defer dynamicProbeResolved.AssertAllMatched(t)
 	entityByEvent := parseContractEntityTypes(t)
 	c := parseDeliveryClassification(t)
 
@@ -252,7 +254,7 @@ func TestEverySubscribableEventIsDeliveryResolvable(t *testing.T) {
 		}
 		if entity == "dynamic" {
 			_, deferred := c.deferredEvents[ev]
-			_, probed := dynamicProbeResolved[ev]
+			probed := dynamicProbeResolved.Waived(t, ev)
 			switch {
 			case deferred && probed:
 				t.Errorf("dynamic event %q is BOTH event-deferred and probe-resolved — ambiguous classification", ev)
@@ -266,27 +268,12 @@ func TestEverySubscribableEventIsDeliveryResolvable(t *testing.T) {
 		}
 	}
 
-	// No stale dynamicProbeResolved entry: each must name a real dynamic
-	// subscribable event.
+	// No stale deferredDeliveryEvents entry: every deferred event must be a
+	// real dynamic subscribable event (else the waiver is dead).
 	subscribable := map[string]bool{}
 	for _, ev := range subscribableTypes() {
 		subscribable[ev] = true
 	}
-	for ev, rationale := range dynamicProbeResolved {
-		if strings.TrimSpace(rationale) == "" {
-			t.Errorf("dynamicProbeResolved[%q] has no rationale — a ratified classification must say why it is probe-reachable", ev)
-		}
-		if !subscribable[ev] {
-			t.Errorf("dynamicProbeResolved[%q] is not a subscribable event — stale entry, remove it", ev)
-			continue
-		}
-		if entityByEvent[ev] != "dynamic" {
-			t.Errorf("dynamicProbeResolved[%q] is x-entity-type %q, not dynamic — stale entry, remove it", ev, entityByEvent[ev])
-		}
-	}
-
-	// No stale deferredDeliveryEvents entry either: every deferred event must
-	// be a real dynamic subscribable event (else the waiver is dead).
 	for ev := range c.deferredEvents {
 		if !subscribable[ev] {
 			t.Errorf("deferredDeliveryEvents has %q, which is not a subscribable event — stale waiver, remove it from deliveryvisibility.go", ev)

--- a/backend/rbaccoverage_test.go
+++ b/backend/rbaccoverage_test.go
@@ -68,6 +68,8 @@ var frozenLegacyObjects = []string{
 // migration that grants it to existing installations. TestEveryNamedBackfill
 // below proves each named migration exists AND writes that object's JSON path;
 // the parity test in backend/migrations executes the five newest end to end.
+// gatekit:fixture the migration each object's grant is looked up in — the value
+// is the identifier the assertion resolves, not the cost of an exception
 var objectBackfills = map[string]string{
 	"ai_model_rate":        "0117",
 	"automation":           "0035",
@@ -95,6 +97,8 @@ var objectBackfills = map[string]string{
 // customNamespaceBackfills are objects whose backfill lives in the fork-owned
 // custom/ namespace rather than core/ (ADR-0017). Same obligation, different
 // directory.
+// gatekit:fixture the custom-namespace migration each object's grant is looked
+// up in — the value is the identifier the assertion resolves, not a cost
 var customNamespaceBackfills = map[string]string{
 	"import_run":         "20260730130000",
 	"overlay_connection": "20260716130000",

--- a/backend/rbacgate_test.go
+++ b/backend/rbacgate_test.go
@@ -20,6 +20,12 @@ package backendarch
 //
 // Exceptions are explicit, keyed by "package-dir:FuncName", each with
 // the rationale that ratified it; a reasonless or stale waiver fails.
+//
+// The tree the gate reads is itself proven rather than assumed:
+// storeEntryPointScope sweeps the whole module for the same entry-point
+// shape and reports any that lies outside internal/modules, so a store
+// that grows in another tier fails this gate instead of falling out of
+// its reach unnoticed.
 
 import (
 	"go/ast"
@@ -213,6 +219,62 @@ var ungatedEntryPoints = gatekit.Waive(map[string]string{ // #nosec G101 -- waiv
 	"internal/modules/comms:ClearInFlight":   "the retraction half of MarkInFlight, same posture: it nulls that timestamp once the provider gave a definite answer. Both are timestamps about this system's own transport attempt, not tenant data",
 })
 
+// storeEntryPointScope proves the gate's single root: every file in the module
+// that declares an entry point of this shape lives under internal/modules, or is
+// ratified below.
+var storeEntryPointScope = gatekit.Scope{
+	Roots:   []string{modulesDir},
+	Subject: declaresStoreEntryPoint,
+	Exempt:  entryPointsOutsideModules,
+}
+
+// entryPointsOutsideModules ratifies the files that hold this entry-point shape
+// outside internal/modules. Each says what the methods are; none says they are
+// correctly gated, because this gate has not judged them — bringing a tier under
+// it is its own decision, taken with its own evidence, and ratifying the sweep is
+// not that decision. The entries are the ratchet: a file that stops holding the
+// shape is reported stale here, so the question cannot be forgotten.
+var entryPointsOutsideModules = gatekit.Waive(map[string]string{
+	"internal/compose/org360/assemble.go":     "org360.Service.Assemble — a compose read service assembling the record-360 view across domain tables; this package does reference the platform auth gate (auth.Require, EnsureVisible, the scope clauses), but whether the gate's transitive resolution proves that for each entry point is a judgement this change has not made",
+	"internal/compose/org360/graph.go":        "org360.Service.Graph — the same read service's relationship graph, in a package that reaches auth through its section helpers; enrolling compose in this gate is a separate decision from proving where the entry points are",
+	"internal/compose/org360/dismissal.go":    "org360.Service.DismissSuggestion — the suggestion-dismissal write; it opens with auth.RequireHuman and auth.Require, so it is not a suspected gap, but this gate has not been the thing that checked it",
+	"internal/compose/org360/viewbaseline.go": "org360.Service.Acknowledge — the record-view acknowledgement write, likewise opening with auth.RequireHuman and auth.Require; ratified here only as a subject the roots do not cover",
+	"internal/compose/orgbrief/service.go":    "orgbrief.Service.Get and .Ask — the organization brief read and its question surface, both opening with auth.RequireHuman; whether RequireHuman alone is the right admission for them is a question for the tier's own review, not for this sweep",
+	"internal/compose/runnerservice.go":       "RunnerService.TickWorkspace and .HandleEvent — the agent runner's worker-loop and event-bus seams, which carry no human principal at all; that posture is what the module-side waivers spell out for their sweep entry points, and applying the same reasoning to compose needs the tier brought under the gate first",
+	"internal/platform/blobstore/memory.go":   "memoryStore's Put/Get/Delete/Health — a blobstore.Store driver, matched only because the receiver type name ends in \"Store\". It moves opaque bytes under a caller-supplied key and holds no record and no workspace column, so there is no RBAC object for this gate's rule to name",
+	"internal/platform/blobstore/s3.go":       "s3Store's Put/Get/Delete/Health — the same driver interface over S3, matched by the same receiver-name suffix; the admission that matters for a blob is taken by the module surface that mints its key, not by an object-storage client",
+})
+
+// declaresStoreEntryPoint reports whether the file holds an entry point of the
+// shape this gate judges. Integration-tagged files are excluded for the same
+// reason the walk excludes them: the obligation binds production stores, and a
+// tagged file can never reach a shipped binary.
+func declaresStoreEntryPoint(path string, file *ast.File) bool {
+	if isIntegrationTagged(path) {
+		return false
+	}
+	for _, decl := range file.Decls {
+		if fn, ok := decl.(*ast.FuncDecl); ok && isStoreEntryPoint(fn) {
+			return true
+		}
+	}
+	return false
+}
+
+// isStoreEntryPoint is the three-part shape: exported, a pointer receiver on a
+// *Store or *Service type, and a context.Context parameter.
+func isStoreEntryPoint(fn *ast.FuncDecl) bool {
+	if fn.Recv == nil || len(fn.Recv.List) == 0 || !fn.Name.IsExported() {
+		return false
+	}
+	star, ok := fn.Recv.List[0].Type.(*ast.StarExpr)
+	if !ok {
+		return false
+	}
+	receiver, ok := star.X.(*ast.Ident)
+	return ok && storeReceiver(receiver.Name) && takesContext(fn)
+}
+
 // gateFnInfo is what the gate needs to know about one function name in a
 // package: whether any body under that name references auth, and every
 // name it mentions (the transitive-resolution edges).
@@ -225,67 +287,79 @@ type gateFnInfo struct {
 // the gate must prove reaches auth.
 type gateEntry struct{ dir, name string }
 
-// collectStoreEntryPoints parses every non-test, non-integration module
-// source file and returns, per package dir, the function index (a name
-// shared across receivers merges optimistically — see the package
+// collectStoreEntryPoints returns, per package dir, the function index (a
+// name shared across receivers merges optimistically — see the package
 // comment) plus the list of exported *Store/*Service methods to check.
 func collectStoreEntryPoints(t *testing.T) (map[string]map[string]*gateFnInfo, []gateEntry) {
 	t.Helper()
-	pkgs := map[string]map[string]*gateFnInfo{}
 	var entries []gateEntry
-
-	fset := token.NewFileSet()
-	err := filepath.WalkDir("internal/modules", func(path string, d fs.DirEntry, err error) error {
-		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") ||
-			isIntegrationTagged(path) {
-			return err
-		}
-		path = filepath.ToSlash(path)
-		dir := filepath.ToSlash(filepath.Dir(path))
-		file, err := parser.ParseFile(fset, path, nil, 0)
-		if err != nil {
-			return err
-		}
-		if pkgs[dir] == nil {
-			pkgs[dir] = map[string]*gateFnInfo{}
-		}
-		for _, decl := range file.Decls {
+	for _, src := range storeEntryPointScope.Files(t) {
+		dir := filepath.ToSlash(filepath.Dir(src.Path))
+		for _, decl := range src.File.Decls {
 			fn, ok := decl.(*ast.FuncDecl)
-			if !ok || fn.Body == nil {
+			if !ok || !isStoreEntryPoint(fn) {
 				continue
 			}
-			info := pkgs[dir][fn.Name.Name]
-			if info == nil {
-				info = &gateFnInfo{calls: map[string]bool{}}
-				pkgs[dir][fn.Name.Name] = info
-			}
-			ast.Inspect(fn.Body, func(n ast.Node) bool {
-				if sel, ok := n.(*ast.SelectorExpr); ok {
-					if pkg, ok := sel.X.(*ast.Ident); ok && pkg.Name == "auth" {
-						info.auth = true
-					}
-					info.calls[sel.Sel.Name] = true
-				}
-				if id, ok := n.(*ast.Ident); ok {
-					info.calls[id.Name] = true
-				}
-				return true
-			})
-			if fn.Recv == nil || !fn.Name.IsExported() {
-				continue
-			}
-			if se, ok := fn.Recv.List[0].Type.(*ast.StarExpr); ok {
-				if id, ok := se.X.(*ast.Ident); ok && storeReceiver(id.Name) && takesContext(fn) {
-					entries = append(entries, gateEntry{dir, fn.Name.Name})
-				}
-			}
+			entries = append(entries, gateEntry{dir, fn.Name.Name})
 		}
-		return nil
-	})
-	if err != nil {
-		t.Fatal(err)
 	}
-	return pkgs, entries
+	return packageFunctionIndex(t), entries
+}
+
+// packageFunctionIndex indexes every function in every package under the
+// scope's roots. It reads WHOLE packages, not only the files that hold an
+// entry point, because the auth call that gates a method routinely sits in
+// a same-package helper in another file — indexing only the entry-point
+// files would report those methods ungated.
+func packageFunctionIndex(t *testing.T) map[string]map[string]*gateFnInfo {
+	t.Helper()
+	pkgs := map[string]map[string]*gateFnInfo{}
+	fset := token.NewFileSet()
+	for _, root := range storeEntryPointScope.Roots {
+		err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+			if err != nil || d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") ||
+				isIntegrationTagged(path) {
+				return err
+			}
+			path = filepath.ToSlash(path)
+			dir := filepath.ToSlash(filepath.Dir(path))
+			file, parseErr := parser.ParseFile(fset, path, nil, 0)
+			if parseErr != nil {
+				return parseErr
+			}
+			if pkgs[dir] == nil {
+				pkgs[dir] = map[string]*gateFnInfo{}
+			}
+			for _, decl := range file.Decls {
+				fn, ok := decl.(*ast.FuncDecl)
+				if !ok || fn.Body == nil {
+					continue
+				}
+				info := pkgs[dir][fn.Name.Name]
+				if info == nil {
+					info = &gateFnInfo{calls: map[string]bool{}}
+					pkgs[dir][fn.Name.Name] = info
+				}
+				ast.Inspect(fn.Body, func(n ast.Node) bool {
+					if sel, ok := n.(*ast.SelectorExpr); ok {
+						if pkg, ok := sel.X.(*ast.Ident); ok && pkg.Name == "auth" {
+							info.auth = true
+						}
+						info.calls[sel.Sel.Name] = true
+					}
+					if id, ok := n.(*ast.Ident); ok {
+						info.calls[id.Name] = true
+					}
+					return true
+				})
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	return pkgs
 }
 
 // reachesAuthGate resolves gatedness transitively over same-package
@@ -312,6 +386,7 @@ func reachesAuthGate(fns map[string]*gateFnInfo, name string, seen map[string]bo
 
 func TestEveryStoreEntryPointIsAuthGated(t *testing.T) {
 	defer ungatedEntryPoints.AssertAllMatched(t)
+	defer entryPointsOutsideModules.AssertAllMatched(t)
 
 	pkgs, entries := collectStoreEntryPoints(t)
 

--- a/backend/rbacgate_test.go
+++ b/backend/rbacgate_test.go
@@ -29,10 +29,12 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/gatekit"
 )
 
 // ungatedEntryPoints are the ratified auth-free store/service methods.
-var ungatedEntryPoints = map[string]string{ // #nosec G101 -- waiver rationales for the fitness gate, not credentials
+var ungatedEntryPoints = gatekit.Waive(map[string]string{ // #nosec G101 -- waiver rationales for the fitness gate, not credentials
 	// Reached only from worker sweeps, approvals effect executors, or a
 	// service that owns the gate above them. Each entry states which.
 	"internal/modules/ai:CostReport":                         "aggregates the workspace's OWN ai_call rows under RLS and returns totals, never a record; the cost surface above it takes the grant",
@@ -209,7 +211,7 @@ var ungatedEntryPoints = map[string]string{ // #nosec G101 -- waiver rationales 
 	"internal/modules/comms:RecordDeferral":  "worker-loop pacing transition, system principal, same posture as Load: it notes which rule is holding a delivery back and gives back the attempt that dispatch counted, because a deferral reached no provider. It discloses nothing and can only ever leave a pending delivery pending",
 	"internal/modules/comms:MarkInFlight":    "worker-loop at-most-once transition, system principal, same posture as Load: it stamps one timestamp on a pending delivery before the provider call so a crashed attempt is visible to the next one. It reads nothing back and discloses nothing",
 	"internal/modules/comms:ClearInFlight":   "the retraction half of MarkInFlight, same posture: it nulls that timestamp once the provider gave a definite answer. Both are timestamps about this system's own transport attempt, not tenant data",
-}
+})
 
 // gateFnInfo is what the gate needs to know about one function name in a
 // package: whether any body under that name references auth, and every
@@ -309,30 +311,19 @@ func reachesAuthGate(fns map[string]*gateFnInfo, name string, seen map[string]bo
 }
 
 func TestEveryStoreEntryPointIsAuthGated(t *testing.T) {
-	for fn, rationale := range ungatedEntryPoints {
-		if strings.TrimSpace(rationale) == "" {
-			t.Errorf("ungatedEntryPoints[%s] has no rationale — a waiver must say why no gate is needed", fn)
-		}
-	}
+	defer ungatedEntryPoints.AssertAllMatched(t)
 
 	pkgs, entries := collectStoreEntryPoints(t)
 
-	used := map[string]bool{}
 	for _, e := range entries {
 		if reachesAuthGate(pkgs[e.dir], e.name, map[string]bool{}) {
 			continue
 		}
 		key := e.dir + ":" + e.name
-		if _, ratified := ungatedEntryPoints[key]; ratified {
-			used[key] = true
+		if ungatedEntryPoints.Waived(t, key) {
 			continue
 		}
 		t.Errorf("%s: exported %s reaches no auth gate (directly or via same-package helpers) — every store entry point is RBAC-gated, or the exception is ratified in ungatedEntryPoints", e.dir, e.name)
-	}
-	for key := range ungatedEntryPoints {
-		if !used[key] {
-			t.Errorf("ungatedEntryPoints[%s] matches no ungated entry point — stale waiver, remove it", key)
-		}
 	}
 }
 

--- a/backend/registrarparity_test.go
+++ b/backend/registrarparity_test.go
@@ -51,12 +51,18 @@ const (
 // fullToolRegistries are the builders that each wire the whole tool surface,
 // named by the function that does the wiring, with what its completeness buys.
 var fullToolRegistries = []struct{ path, builder, claim string }{
-	{"internal/compose/registry.go", "registryWithGate",
-		"the surface a client is served: an unregistered tool does not exist"},
-	{agentsDir + "/conformance_test.go", "fullRegistry",
-		"the encoding walk: an unregistered tool's schema is never checked"},
-	{agentsDir + "/idargs_test.go", "idProbeDispatcher",
-		"the seam walk: an unregistered tool's arguments are never dispatched"},
+	{
+		"internal/compose/registry.go", "registryWithGate",
+		"the surface a client is served: an unregistered tool does not exist",
+	},
+	{
+		agentsDir + "/conformance_test.go", "fullRegistry",
+		"the encoding walk: an unregistered tool's schema is never checked",
+	},
+	{
+		agentsDir + "/idargs_test.go", "idProbeDispatcher",
+		"the seam walk: an unregistered tool's arguments are never dispatched",
+	},
 }
 
 // toolRegistrar is one discovered registrar and where it is declared.

--- a/backend/registrarparity_test.go
+++ b/backend/registrarparity_test.go
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package backendarch
+
+// A registry that claims to be complete must be.
+//
+// The governed tool surface is wired by a family of package-level registrars,
+// and three builders each claim to invoke EVERY one of them: production's, and
+// two test registries that exist only to walk the whole surface — one proving
+// each tool reaches its seam, one proving the whole tool list encodes. A
+// registrar missing from one of them shrinks that walk in silence: the walk
+// still passes, over a smaller set than it names.
+//
+// The three are deliberately not collapsed into one builder. The tests are
+// package agents and production is package compose, and their seams differ on
+// purpose — one wires seams that return a sentinel, to prove the seam was
+// reached; one wires inert seams, to prove encoding; production wires the real
+// ones. So the registrar list is DERIVED from the package and the parity
+// asserted, rather than hand-kept in three places and hoped equal.
+//
+// The derivation keys on the parameter's TYPE, not on the function's name
+// shape: a registrar may wire one tool or a family, and the parameter it takes
+// may be called anything.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"sort"
+	"strings"
+	"testing"
+)
+
+const (
+	agentsDir        = "internal/modules/agents"
+	agentsImportPath = "github.com/gradionhq/margince/backend/" + agentsDir
+
+	// registryType is the type a tool registrar takes: taking it is what makes
+	// a function a registrar.
+	registryType = "Registry"
+
+	// registrarPrefix narrows the candidates the parameter type then decides.
+	registrarPrefix = "Register"
+
+	// toolRegistrarFloor is the vacuity floor: a derivation that discovered
+	// nothing would certify all three builders at once.
+	toolRegistrarFloor = 7
+)
+
+// fullToolRegistries are the builders that each wire the whole tool surface,
+// named by the function that does the wiring, with what its completeness buys.
+var fullToolRegistries = []struct{ path, builder, claim string }{
+	{"internal/compose/registry.go", "registryWithGate",
+		"the surface a client is served: an unregistered tool does not exist"},
+	{agentsDir + "/conformance_test.go", "fullRegistry",
+		"the encoding walk: an unregistered tool's schema is never checked"},
+	{agentsDir + "/idargs_test.go", "idProbeDispatcher",
+		"the seam walk: an unregistered tool's arguments are never dispatched"},
+}
+
+// toolRegistrar is one discovered registrar and where it is declared.
+type toolRegistrar struct{ name, at string }
+
+func TestEveryToolRegistrarIsInvokedByEveryFullRegistry(t *testing.T) {
+	registrars, methods := toolRegistrars(t)
+	if len(registrars) < toolRegistrarFloor {
+		t.Fatalf("discovered only %d tool registrars in %s, expected at least %d: the AST derivation broke, not the subject — a registrar is a package-level func taking *%s, and this gate is currently certifying every builder against an empty list",
+			len(registrars), agentsDir, toolRegistrarFloor, registryType)
+	}
+
+	// The door every tool comes through is a METHOD on the registry, not a
+	// registrar of tools. Counting it would inflate the discovered list by one
+	// name no builder ever calls, and the parity assertion would fail for a
+	// reason that has nothing to do with any tool.
+	if len(methods) == 0 {
+		t.Fatalf("no %s* method on *%s found in %s: the receiver-based exclusion below has nothing to exclude, so it no longer proves anything",
+			registrarPrefix, registryType, agentsDir)
+	}
+	for _, method := range methods {
+		for _, r := range registrars {
+			if r.name == method {
+				t.Errorf("%s is a method on *%s and was discovered as a registrar (%s): a receiver makes it the registry's own door, not a tool family, and no builder calls it",
+					method, registryType, r.at)
+			}
+		}
+	}
+
+	for _, registry := range fullToolRegistries {
+		called := registrarCalls(t, registry.path, registry.builder)
+		for _, r := range registrars {
+			if called[r.name] {
+				continue
+			}
+			t.Errorf("%s (%s) does not invoke %s, declared at %s — %s. Wire it there, or move it off *%s if it is not a tool registrar",
+				registry.builder, registry.path, r.name, r.at, registry.claim, registryType)
+		}
+	}
+}
+
+// toolRegistrars discovers the package-level tool registrars of the agents
+// package, and separately the Register* methods on the registry type — the
+// receiver is what tells the two apart.
+func toolRegistrars(t *testing.T) (registrars []toolRegistrar, methods []string) {
+	t.Helper()
+	fset := token.NewFileSet()
+	files := parsePackageDir(t, fset, agentsDir) // reused from versionguard_test.go
+	for _, file := range files {
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || !strings.HasPrefix(fn.Name.Name, registrarPrefix) {
+				continue
+			}
+			if fn.Recv != nil {
+				if len(fn.Recv.List) == 1 && pointsAtRegistry(fn.Recv.List[0].Type) {
+					methods = append(methods, fn.Name.Name)
+				}
+				continue
+			}
+			params := fn.Type.Params
+			if params == nil || len(params.List) == 0 || !pointsAtRegistry(params.List[0].Type) {
+				continue
+			}
+			registrars = append(registrars, toolRegistrar{fn.Name.Name, fset.Position(fn.Pos()).String()})
+		}
+	}
+	sort.Slice(registrars, func(i, j int) bool { return registrars[i].name < registrars[j].name })
+	sort.Strings(methods)
+	return registrars, methods
+}
+
+// pointsAtRegistry reports whether an expression spells the type *Registry.
+func pointsAtRegistry(expr ast.Expr) bool {
+	star, ok := expr.(*ast.StarExpr)
+	if !ok {
+		return false
+	}
+	name, ok := star.X.(*ast.Ident)
+	return ok && name.Name == registryType
+}
+
+// registrarCalls returns the function names one builder calls, whether as a
+// bare identifier (the builders inside package agents) or through the agents
+// import (the production builder in package compose).
+func registrarCalls(t *testing.T, path, builder string) map[string]bool {
+	t.Helper()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, nil, 0)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", path, err)
+	}
+	local := localImportName(file, agentsImportPath)
+
+	var body *ast.BlockStmt
+	for _, decl := range file.Decls {
+		if fn, ok := decl.(*ast.FuncDecl); ok && fn.Recv == nil && fn.Name.Name == builder {
+			body = fn.Body
+		}
+	}
+	if body == nil {
+		t.Fatalf("%s: builder %s not found — the parity derivation lost one of the registries it compares, so it can no longer hold that registry to the list", path, builder)
+	}
+
+	called := map[string]bool{}
+	ast.Inspect(body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		switch fun := call.Fun.(type) {
+		case *ast.Ident:
+			called[fun.Name] = true
+		case *ast.SelectorExpr:
+			if pkg, ok := fun.X.(*ast.Ident); ok && local != "" && pkg.Name == local {
+				called[fun.Sel.Name] = true
+			}
+		}
+		return true
+	})
+	return called
+}
+
+// localImportName gives the name an import path is spelled as in one file —
+// its alias when it carries one, otherwise the path's last segment. Empty when
+// the file does not import it at all, which is the case for the two builders
+// that live in the package itself.
+func localImportName(file *ast.File, path string) string {
+	for _, spec := range file.Imports {
+		if spec.Path.Value != `"`+path+`"` {
+			continue
+		}
+		if spec.Name != nil {
+			return spec.Name.Name
+		}
+		return path[strings.LastIndex(path, "/")+1:]
+	}
+	return ""
+}

--- a/backend/registrarparity_test.go
+++ b/backend/registrarparity_test.go
@@ -21,7 +21,10 @@ package backendarch
 //
 // The derivation keys on the parameter's TYPE, not on the function's name
 // shape: a registrar may wire one tool or a family, and the parameter it takes
-// may be called anything.
+// may be called anything and sit at any position in the signature — a registrar
+// that takes its configuration first is still a registrar, and one the
+// derivation misses can be absent from every builder while this gate reads
+// green.
 
 import (
 	"go/ast"
@@ -123,8 +126,7 @@ func toolRegistrars(t *testing.T) (registrars []toolRegistrar, methods []string)
 				}
 				continue
 			}
-			params := fn.Type.Params
-			if params == nil || len(params.List) == 0 || !pointsAtRegistry(params.List[0].Type) {
+			if !takesRegistry(fn.Type.Params) {
 				continue
 			}
 			registrars = append(registrars, toolRegistrar{fn.Name.Name, fset.Position(fn.Pos()).String()})
@@ -133,6 +135,22 @@ func toolRegistrars(t *testing.T) (registrars []toolRegistrar, methods []string)
 	sort.Slice(registrars, func(i, j int) bool { return registrars[i].name < registrars[j].name })
 	sort.Strings(methods)
 	return registrars, methods
+}
+
+// takesRegistry reports whether any parameter of a signature is a *Registry.
+// Every parameter is asked, not just the first: a registrar that leads with its
+// own configuration takes the registry second, and a derivation reading only
+// position 0 never discovers it.
+func takesRegistry(params *ast.FieldList) bool {
+	if params == nil {
+		return false
+	}
+	for _, param := range params.List {
+		if pointsAtRegistry(param.Type) {
+			return true
+		}
+	}
+	return false
 }
 
 // pointsAtRegistry reports whether an expression spells the type *Registry.

--- a/backend/replayscope_test.go
+++ b/backend/replayscope_test.go
@@ -251,6 +251,8 @@ func mappedReplayScope(t *testing.T) map[string]expectedTarget {
 
 // replayScopeConsts holds the file's string consts, so a reason written once
 // and referenced by name reads the same to this gate as an inline literal.
+// gatekit:fixture state this file's own walk writes as it parses, read back to
+// resolve a name — a cache, so nothing here is ratified or goes stale.
 var replayScopeConsts = map[string]string{}
 
 // stringLiteral flattens a string literal, a concatenation of them (the

--- a/backend/requiredbodyids_test.go
+++ b/backend/requiredbodyids_test.go
@@ -33,6 +33,8 @@ import (
 	"sort"
 	"strings"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/gatekit"
 )
 
 const generatedContract = "internal/contracts/api_gen.go"
@@ -65,7 +67,7 @@ var probedRequiredIDBodies = map[string]bool{
 // id added upstream therefore lands here as a failure until someone decides which
 // it is, which is the difference between having fixed eleven things and having
 // closed the class.
-var unguardedRequiredIDBodies = map[string]string{
+var unguardedRequiredIDBodies = gatekit.Waive(map[string]string{
 	// Not a request body at all: the GDPR data-subject-request ENTITY, whose `id`
 	// is its own primary key rather than a caller-supplied reference. Waived
 	// because the name heuristic above cannot tell the two apart, and narrowing
@@ -77,9 +79,10 @@ var unguardedRequiredIDBodies = map[string]string{
 	// refuses it as a 422 naming the field. It cannot become a zero UUID reaching
 	// a lookup, which is the only hazard this gate is about.
 	"UploadAttachmentMultipartBody": "multipart; FormValue + ids.Parse already refuses an absent part as a 422",
-}
+})
 
 func TestEveryContractBodyWithARequiredIDIsAccountedFor(t *testing.T) {
+	defer unguardedRequiredIDBodies.AssertAllMatched(t)
 	bodies := contractBodiesWithARequiredID(t)
 	if len(bodies) == 0 {
 		t.Fatalf("no request body in %s declares a required non-pointer UUID — the walk is reading "+
@@ -92,7 +95,7 @@ func TestEveryContractBodyWithARequiredIDIsAccountedFor(t *testing.T) {
 	}
 	sort.Strings(names)
 	for _, name := range names {
-		if probedRequiredIDBodies[name] || unguardedRequiredIDBodies[name] != "" {
+		if probedRequiredIDBodies[name] || unguardedRequiredIDBodies.Waived(t, name) {
 			continue
 		}
 		t.Errorf("%s declares required id(s) %v and is neither probed nor waived. An absent key "+
@@ -101,14 +104,8 @@ func TestEveryContractBodyWithARequiredIDIsAccountedFor(t *testing.T) {
 			"transports share and probe it, or add it to unguardedRequiredIDBodies with a reason.",
 			name, bodies[name])
 	}
-	// A stale entry on either list is a failure: it would outlive the thing it
-	// describes and make the gap look different from what it is.
-	for name := range unguardedRequiredIDBodies {
-		if _, still := bodies[name]; !still {
-			t.Errorf("unguardedRequiredIDBodies names %s, which no longer declares a required "+
-				"non-pointer UUID — drop the entry", name)
-		}
-	}
+	// A stale entry is a failure: it would outlive the thing it describes and
+	// make the gap look different from what it is.
 	for name := range probedRequiredIDBodies {
 		if _, still := bodies[name]; !still {
 			t.Errorf("probedRequiredIDBodies names %s, which no longer declares a required "+

--- a/backend/requiredbodyids_test.go
+++ b/backend/requiredbodyids_test.go
@@ -82,12 +82,14 @@ var unguardedRequiredIDBodies = gatekit.Waive(map[string]string{
 })
 
 func TestEveryContractBodyWithARequiredIDIsAccountedFor(t *testing.T) {
-	defer unguardedRequiredIDBodies.AssertAllMatched(t)
 	bodies := contractBodiesWithARequiredID(t)
 	if len(bodies) == 0 {
 		t.Fatalf("no request body in %s declares a required non-pointer UUID — the walk is reading "+
 			"the wrong shape", generatedContract)
 	}
+	// Registered only past the vacuity guard: on that Fatal every entry would
+	// report as unmatched, burying the one failure that explains all of them.
+	defer unguardedRequiredIDBodies.AssertAllMatched(t)
 
 	names := make([]string, 0, len(bodies))
 	for name := range bodies {

--- a/backend/tableownership_test.go
+++ b/backend/tableownership_test.go
@@ -25,10 +25,11 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"sort"
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/gatekit"
 )
 
 // storekitOwned marks the tables written ONLY through
@@ -238,7 +239,7 @@ var tableOwners = map[string]string{
 // crossStoreWrites are the ratified writes outside the writer's own tables,
 // keyed "module-dir:table". Every entry carries its rationale inline so the
 // gate is self-contained on a clean checkout.
-var crossStoreWrites = map[string]string{
+var crossStoreWrites = gatekit.Waive(map[string]string{
 	// people's merge/promotion relink rows across aggregates inside their
 	// single transaction — the primary aggregate owns the single-tx
 	// cross-aggregate write, because a merge that could half-commit its
@@ -344,7 +345,7 @@ var crossStoreWrites = map[string]string{
 	// call, the same single-transaction rationale privacy's erasure
 	// entries above document.
 	"internal/modules/overlay:workspace": "flips its own fork-owned x_sor_mode/x_incumbent columns atomically with the connection row write, inside the same transaction (the x_overlay_iff_incumbent CHECK demands both change together)",
-}
+})
 
 // sqlWriteTargets extracts write-statement table names from one SQL (or
 // SQL-carrying format) string. UPDATE requires a SET clause so prose and
@@ -478,15 +479,10 @@ func collectTableWrites(t *testing.T) map[string][]tableWrite {
 }
 
 func TestEveryPackageOnlyWritesTablesItOwns(t *testing.T) {
-	for key, rationale := range crossStoreWrites {
-		if strings.TrimSpace(rationale) == "" {
-			t.Errorf("crossStoreWrites[%s] has no rationale — a cross-store write must say why it cannot go through the owning module", key)
-		}
-	}
+	defer crossStoreWrites.AssertAllMatched(t)
 
 	writes := collectTableWrites(t)
 
-	usedWaivers := map[string]bool{}
 	for owner, ws := range writes {
 		for _, w := range ws {
 			declared, known := tableOwners[w.table]
@@ -499,23 +495,11 @@ func TestEveryPackageOnlyWritesTablesItOwns(t *testing.T) {
 				continue
 			}
 			key := owner + ":" + w.table
-			if _, ratified := crossStoreWrites[key]; ratified {
-				usedWaivers[key] = true
+			if crossStoreWrites.Waived(t, key) {
 				continue
 			}
 			t.Errorf("%s: %s writes table %q owned by %s — move the write into the owning module, or ratify it in crossStoreWrites[%q] with a self-contained rationale",
 				w.pos, owner, w.table, declared, key)
 		}
-	}
-
-	var stale []string
-	for key := range crossStoreWrites {
-		if !usedWaivers[key] {
-			stale = append(stale, key)
-		}
-	}
-	sort.Strings(stale)
-	for _, key := range stale {
-		t.Errorf("crossStoreWrites[%s] matches no remaining write — stale waiver, remove it", key)
 	}
 }

--- a/backend/tableownership_test.go
+++ b/backend/tableownership_test.go
@@ -41,6 +41,8 @@ const storekitOwned = "internal/platform/database/storekit"
 // owns its writes (module doc.go "Tables owned" declarations, kept in sync).
 // This map is the hand-maintained artifact: a new table gets an owner here
 // before its first write lands.
+// gatekit:fixture the owning module path each table's writes are compared
+// against — expected data, not a cost anyone is paying.
 var tableOwners = map[string]string{
 	// identity
 	"workspace":                "internal/modules/identity",

--- a/backend/updateguard_test.go
+++ b/backend/updateguard_test.go
@@ -28,6 +28,8 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/gatekit"
 )
 
 // byIDUpdate matches a single-row-by-primary-key UPDATE inside one SQL
@@ -90,7 +92,7 @@ func versionedTables(t *testing.T) map[string]bool {
 // by "package-dir:FuncName". Every entry carries its rationale inline;
 // an entry without one is a finding, and one matching no function is
 // stale and fails.
-var unguardedByIDUpdates = map[string]string{
+var unguardedByIDUpdates = gatekit.Waive(map[string]string{
 	// Archive is an absolute idempotent transition: the write sets
 	// archived_at unconditionally (no state derived from a pre-read),
 	// so concurrent archives converge on the same terminal row and the
@@ -135,7 +137,7 @@ var unguardedByIDUpdates = map[string]string{
 	"internal/modules/privacy:apply":                      "terminal absolute writes: the retention sweep archives/anonymizes regardless of concurrent state, by design",
 	"internal/modules/privacy:eraseActivityContent":       "terminal absolute write: the sweep's activity/erase action empties the body and stamps the tombstone subject regardless of concurrent state, by design",
 	"internal/modules/privacy:anonymizePersonRecord":      "terminal absolute write: the sweep's person/anonymize action overwrites the PII columns regardless of concurrent state, by design",
-}
+})
 
 // guardMarkers are the identifiers whose presence in the same function
 // witnesses a concurrency guard: the storekit guarded-apply family, the
@@ -150,13 +152,8 @@ var guardMarkers = map[string]bool{
 }
 
 func TestEveryByIDUpdateCarriesAConcurrencyGuard(t *testing.T) {
-	for fn, rationale := range unguardedByIDUpdates {
-		if strings.TrimSpace(rationale) == "" {
-			t.Errorf("unguardedByIDUpdates[%s] has no rationale — a waiver must say why no guard is needed", fn)
-		}
-	}
+	defer unguardedByIDUpdates.AssertAllMatched(t)
 	versioned := versionedTables(t)
-	used := map[string]bool{}
 	fset := token.NewFileSet()
 	for _, root := range []string{"internal/modules", "internal/compose", "internal/platform"} {
 		err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
@@ -200,8 +197,7 @@ func TestEveryByIDUpdateCarriesAConcurrencyGuard(t *testing.T) {
 				})
 				if updatesByID && !guarded {
 					key := filepath.ToSlash(filepath.Dir(path)) + ":" + fn.Name.Name
-					if _, ratified := unguardedByIDUpdates[key]; ratified {
-						used[key] = true
+					if unguardedByIDUpdates.Waived(t, key) {
 						continue
 					}
 					t.Errorf("%s: %s runs a by-id UPDATE with no concurrency guard — use storekit.ApplyGuarded/ApplyWithVersion, lock the row first (LockRow/LockPair/FOR UPDATE/advisory lock), or check RowsAffected as a CAS; a real exception is ratified in unguardedByIDUpdates",
@@ -212,11 +208,6 @@ func TestEveryByIDUpdateCarriesAConcurrencyGuard(t *testing.T) {
 		})
 		if err != nil {
 			t.Fatal(err)
-		}
-	}
-	for key := range unguardedByIDUpdates {
-		if !used[key] {
-			t.Errorf("unguardedByIDUpdates[%s] matches no unguarded by-id update — stale waiver, remove it", key)
 		}
 	}
 }

--- a/backend/versionguard_test.go
+++ b/backend/versionguard_test.go
@@ -81,8 +81,8 @@ func TestEveryVersionPinnedTableBumpsItsVersion(t *testing.T) {
 
 	for _, table := range sortedNames(pinned) {
 		if at, ok := dropped[table]; ok {
-			t.Errorf("approvals.versionTables pins %s, and %s drops a trigger on it: this derivation reads the migrations as a set and cannot tell whether the %s attachment survived the drop, so the pin can no longer be shown to bind anything",
-				table, at, bumpFunction)
+			t.Errorf("approvals.versionTables pins %s, and %s drops a trigger on it: this derivation reads the migrations as a set and cannot tell whether the %s attachment survived the drop, so the pin can no longer be shown to bind anything. Re-attach %s BEFORE UPDATE on %s in a later migration, so one CREATE TRIGGER statement carries the attachment on its own, or drop %s from versionTables in %s/redeem.go and leave TargetVersion nil for that type",
+				table, at, bumpFunction, bumpFunction, table, table, approvalsDir)
 			continue
 		}
 		if _, ok := bumped[table]; ok {
@@ -104,7 +104,7 @@ func versionPinnedTables(t *testing.T) map[string]bool {
 	t.Helper()
 	fset := token.NewFileSet()
 	files := parsePackageDir(t, fset, approvalsDir)
-	consts := stringConsts(files)
+	consts := stringConsts(t, fset, files)
 
 	lit := packageVarCompositeLit(t, files, "versionTables")
 	tables := map[string]bool{}
@@ -155,8 +155,14 @@ func versionBumpAttachments(t *testing.T) (bumped, dropped map[string]string) {
 			text := sqlLineComment.ReplaceAllString(string(raw), "")
 			line := 1
 			for _, stmt := range strings.Split(text, ";") {
+				// Splitting on ";" leaves the newlines that FOLLOW the previous
+				// statement at the head of this one. They belong to the gap, so
+				// they are counted before the position is taken — counting them
+				// afterwards reports every statement at the preceding ";".
+				body := strings.TrimLeft(stmt, " \t\r\n")
+				line += strings.Count(stmt[:len(stmt)-len(body)], "\n")
 				at := path + ":" + strconv.Itoa(line)
-				line += strings.Count(stmt, "\n")
+				line += strings.Count(body, "\n")
 				if m := triggerDrop.FindStringSubmatch(stmt); m != nil {
 					dropped[m[1]] = at
 					continue
@@ -201,8 +207,13 @@ func parsePackageDir(t *testing.T, fset *token.FileSet, dir string) []*ast.File 
 	return files
 }
 
-// stringConsts indexes every package-level string constant by name.
-func stringConsts(files []*ast.File) map[string]string {
+// stringConsts indexes every package-level string constant by name. A literal
+// the parser accepted as token.STRING but that does not unquote is reported
+// rather than skipped: the constant would silently drop out of the index, and
+// every versionTables key spelled with it would then look unresolvable for a
+// reason that has nothing to do with the pin.
+func stringConsts(t *testing.T, fset *token.FileSet, files []*ast.File) map[string]string {
+	t.Helper()
 	consts := map[string]string{}
 	for _, file := range files {
 		for _, decl := range file.Decls {
@@ -222,6 +233,8 @@ func stringConsts(files []*ast.File) map[string]string {
 					}
 					value, err := strconv.Unquote(lit.Value)
 					if err != nil {
+						t.Errorf("%s: const %s holds a string literal that does not unquote (%s): %v — it cannot enter the constant index, so any versionTables key spelled with it resolves to nothing",
+							fset.Position(lit.Pos()), name.Name, lit.Value, err)
 						continue
 					}
 					consts[name.Name] = value

--- a/backend/versionguard_test.go
+++ b/backend/versionguard_test.go
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package backendarch
+
+// A version pin is only real if the pinned table's version actually moves.
+//
+// Membership in approvals.versionTables is what makes the binding real:
+// resolveTargetVersion reads the row's version into the staged approval,
+// validateRedemptionTarget re-checks it at redemption, and the agent gate
+// forwards it as the released call's If-Match. A table whose version never
+// changes gives a pin that re-checks a constant — three steps that all appear
+// to work while binding the human's approval to nothing.
+//
+// The version moves by DATABASE TRIGGER: set_updated_at_bump_version(), the one
+// house function that assigns version = OLD.version + 1, attached BEFORE UPDATE
+// per table. So the obligation is derived from the migrations, which are the
+// authority on what the database does, and not from any module's write shape —
+// a table whose writers issue bare UPDATEs still bumps, because the trigger
+// fires anyway.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// bumpFunction is the sole mechanism that moves a version column: the only
+// inline `version + 1` in the whole migration tree is this function's body.
+const bumpFunction = "set_updated_at_bump_version"
+
+// approvalsDir holds both halves of the derivation's Go side — the map and the
+// constants its keys are spelled as.
+const approvalsDir = "internal/modules/approvals"
+
+// versionPinnedTableFloor is the vacuity floor on the Go side: the map's keys
+// are constant identifiers declared in a different file of the same package, so
+// a resolution that silently yields fewer subjects would certify the rest.
+const versionPinnedTableFloor = 14
+
+var (
+	// triggerAttachment captures the table a CREATE TRIGGER fires on. Applied
+	// per STATEMENT, never per line: the CREATE TRIGGER clause, the FOR EACH
+	// ROW / WHEN clauses and the EXECUTE FUNCTION clause sit on different
+	// lines, so a line-scoped match would find no attachment at all — a gate
+	// reading green off zero subjects.
+	triggerAttachment = regexp.MustCompile(`(?is)\bCREATE\s+TRIGGER\b.*?\bBEFORE\s+UPDATE\s+ON\s+([a-z_]+)`)
+
+	// triggerDrop captures the table a DROP TRIGGER statement detaches from. It
+	// does not name the function it dropped, which is exactly why it matters
+	// here: this scan reads the migrations as a SET, so a drop it cannot order
+	// against the attachment invalidates the conclusion for that table.
+	triggerDrop = regexp.MustCompile(`(?is)\bDROP\s+TRIGGER\b[^;]*?\bON\s+([a-z_]+)`)
+
+	// sqlLineComment strips `-- …` so prose naming the bump function is never
+	// read as an attachment of it.
+	sqlLineComment = regexp.MustCompile(`--[^\n]*`)
+)
+
+func TestEveryVersionPinnedTableBumpsItsVersion(t *testing.T) {
+	pinned := versionPinnedTables(t)
+	if len(pinned) < versionPinnedTableFloor {
+		t.Fatalf("resolved only %d keys of approvals.versionTables, expected at least %d: the AST derivation broke, not the subject — every key is a constant identifier declared elsewhere in package %s, so this gate is currently certifying nothing",
+			len(pinned), versionPinnedTableFloor, approvalsDir)
+	}
+
+	bumped, dropped := versionBumpAttachments(t)
+	if len(bumped) == 0 {
+		t.Fatalf("no %s attachment found in the migrations: the SQL derivation broke, not the subject — the scan must be statement-scoped, since the CREATE TRIGGER and EXECUTE FUNCTION clauses sit on different lines",
+			bumpFunction)
+	}
+	versioned := versionedTables(t) // reused from updateguard_test.go
+
+	for _, table := range sortedNames(pinned) {
+		if at, ok := dropped[table]; ok {
+			t.Errorf("approvals.versionTables pins %s, and %s drops a trigger on it: this derivation reads the migrations as a set and cannot tell whether the %s attachment survived the drop, so the pin can no longer be shown to bind anything",
+				table, at, bumpFunction)
+			continue
+		}
+		if _, ok := bumped[table]; ok {
+			continue
+		}
+		column := "the table has no version column at all"
+		if versioned[table] {
+			column = "the table carries a version column that nothing moves"
+		}
+		t.Errorf("approvals.versionTables pins %s but no migration attaches %s BEFORE UPDATE on it — %s, so the staged pin, the redemption re-check and the released call's If-Match all compare a constant. Attach the trigger in a new migration under migrations/core, or drop %s from versionTables in %s/redeem.go and leave TargetVersion nil for that type",
+			table, bumpFunction, column, table, approvalsDir)
+	}
+}
+
+// versionPinnedTables resolves the table names in approvals.versionTables. The
+// keys are constant identifiers, so the whole package is parsed — redeem.go
+// alone resolves not a single one.
+func versionPinnedTables(t *testing.T) map[string]bool {
+	t.Helper()
+	fset := token.NewFileSet()
+	files := parsePackageDir(t, fset, approvalsDir)
+	consts := stringConsts(files)
+
+	lit := packageVarCompositeLit(t, files, "versionTables")
+	tables := map[string]bool{}
+	for _, elt := range lit.Elts {
+		kv, ok := elt.(*ast.KeyValueExpr)
+		if !ok {
+			t.Errorf("approvals.versionTables at %s: element is not a key/value pair, so its table cannot be read", fset.Position(elt.Pos()))
+			continue
+		}
+		switch key := kv.Key.(type) {
+		case *ast.Ident:
+			table, ok := consts[key.Name]
+			if !ok {
+				t.Errorf("approvals.versionTables at %s: key %s is not a string constant of package approvals, so its table cannot be read", fset.Position(key.Pos()), key.Name)
+				continue
+			}
+			tables[table] = true
+		case *ast.BasicLit:
+			table, err := strconv.Unquote(key.Value)
+			if err != nil {
+				t.Errorf("approvals.versionTables at %s: key %s is not a quoted string", fset.Position(key.Pos()), key.Value)
+				continue
+			}
+			tables[table] = true
+		default:
+			t.Errorf("approvals.versionTables at %s: key is neither an identifier nor a string literal, so its table cannot be read", fset.Position(kv.Key.Pos()))
+		}
+	}
+	return tables
+}
+
+// versionBumpAttachments derives, per table, where the migrations attach the
+// bump trigger and where they drop a trigger from it. Statement-scoped over
+// both migration namespaces (ADR-0017), because the fork seam may attach its
+// own.
+func versionBumpAttachments(t *testing.T) (bumped, dropped map[string]string) {
+	t.Helper()
+	bumped, dropped = map[string]string{}, map[string]string{}
+	for _, root := range []string{"migrations/core", "migrations/custom"} {
+		err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+			if err != nil || d.IsDir() || !strings.HasSuffix(path, ".up.sql") {
+				return err
+			}
+			raw, err := os.ReadFile(path) // #nosec G304 G122 -- path is a *.up.sql file from walking the trusted migrations tree
+			if err != nil {
+				return err
+			}
+			text := sqlLineComment.ReplaceAllString(string(raw), "")
+			line := 1
+			for _, stmt := range strings.Split(text, ";") {
+				at := path + ":" + strconv.Itoa(line)
+				line += strings.Count(stmt, "\n")
+				if m := triggerDrop.FindStringSubmatch(stmt); m != nil {
+					dropped[m[1]] = at
+					continue
+				}
+				if !strings.Contains(stmt, bumpFunction) {
+					continue
+				}
+				if m := triggerAttachment.FindStringSubmatch(stmt); m != nil {
+					bumped[m[1]] = at
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walking %s: %v", root, err)
+		}
+	}
+	return bumped, dropped
+}
+
+// parsePackageDir parses the hand-written Go files of ONE package directory,
+// non-recursively: a subpackage's identifiers are a different scope and must
+// not resolve here.
+func parsePackageDir(t *testing.T, fset *token.FileSet, dir string) []*ast.File {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("reading %s: %v", dir, err)
+	}
+	var files []*ast.File
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") || strings.HasSuffix(e.Name(), "_test.go") {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parsing %s: %v", path, err)
+		}
+		files = append(files, file)
+	}
+	return files
+}
+
+// stringConsts indexes every package-level string constant by name.
+func stringConsts(files []*ast.File) map[string]string {
+	consts := map[string]string{}
+	for _, file := range files {
+		for _, decl := range file.Decls {
+			gd, ok := decl.(*ast.GenDecl)
+			if !ok || gd.Tok != token.CONST {
+				continue
+			}
+			for _, spec := range gd.Specs {
+				vs, ok := spec.(*ast.ValueSpec)
+				if !ok || len(vs.Names) != len(vs.Values) {
+					continue
+				}
+				for i, name := range vs.Names {
+					lit, ok := vs.Values[i].(*ast.BasicLit)
+					if !ok || lit.Kind != token.STRING {
+						continue
+					}
+					value, err := strconv.Unquote(lit.Value)
+					if err != nil {
+						continue
+					}
+					consts[name.Name] = value
+				}
+			}
+		}
+	}
+	return consts
+}
+
+// packageVarCompositeLit returns the composite literal a named package-level
+// var is initialised with.
+func packageVarCompositeLit(t *testing.T, files []*ast.File, name string) *ast.CompositeLit {
+	t.Helper()
+	for _, file := range files {
+		for _, decl := range file.Decls {
+			gd, ok := decl.(*ast.GenDecl)
+			if !ok || gd.Tok != token.VAR {
+				continue
+			}
+			for _, spec := range gd.Specs {
+				vs, ok := spec.(*ast.ValueSpec)
+				if !ok || len(vs.Names) != 1 || vs.Names[0].Name != name || len(vs.Values) != 1 {
+					continue
+				}
+				lit, ok := vs.Values[0].(*ast.CompositeLit)
+				if !ok {
+					t.Fatalf("%s is not initialised with a composite literal, so its subjects cannot be derived", name)
+				}
+				return lit
+			}
+		}
+	}
+	t.Fatalf("var %s not found in the parsed package: the derivation lost its subject list", name)
+	return nil
+}
+
+// sortedNames gives a set's members a stable report order.
+func sortedNames(set map[string]bool) []string {
+	names := make([]string, 0, len(set))
+	for name := range set {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/backend/versionguard_test.go
+++ b/backend/versionguard_test.go
@@ -18,6 +18,14 @@ package backendarch
 // authority on what the database does, and not from any module's write shape —
 // a table whose writers issue bare UPDATEs still bumps, because the trigger
 // fires anyway.
+//
+// What the database ends up with is the FINAL state of the migrations, so that
+// is what is derived: they are read in apply order — core then custom, each
+// namespace by ascending version, which is how dbmigrate applies them — and
+// each statement is applied to a per-trigger state. A CREATE TRIGGER records
+// the function that trigger executes; a DROP TRIGGER removes that record. A
+// table qualifies when a trigger still attached after the last migration fires
+// before an UPDATE and executes the bump function.
 
 import (
 	"go/ast"
@@ -47,23 +55,45 @@ const approvalsDir = "internal/modules/approvals"
 const versionPinnedTableFloor = 14
 
 var (
-	// triggerAttachment captures the table a CREATE TRIGGER fires on. Applied
-	// per STATEMENT, never per line: the CREATE TRIGGER clause, the FOR EACH
-	// ROW / WHEN clauses and the EXECUTE FUNCTION clause sit on different
-	// lines, so a line-scoped match would find no attachment at all — a gate
-	// reading green off zero subjects.
-	triggerAttachment = regexp.MustCompile(`(?is)\bCREATE\s+TRIGGER\b.*?\bBEFORE\s+UPDATE\s+ON\s+([a-z_]+)`)
+	// triggerAttachment captures a CREATE TRIGGER's name, its event list and the
+	// table it fires on. Applied per STATEMENT, never per line: the name, the
+	// event list, the FOR EACH ROW / WHEN clauses and the EXECUTE clause sit on
+	// different lines, so a line-scoped match would find no attachment at all —
+	// a gate reading green off zero subjects.
+	triggerAttachment = regexp.MustCompile(`(?is)\bCREATE\s+(?:OR\s+REPLACE\s+)?(?:CONSTRAINT\s+)?TRIGGER\s+([a-z_][a-z0-9_]*)\s+(BEFORE|AFTER|INSTEAD\s+OF)\s+(.*?)\bON\s+([a-z_][a-z0-9_]*)`)
 
-	// triggerDrop captures the table a DROP TRIGGER statement detaches from. It
-	// does not name the function it dropped, which is exactly why it matters
-	// here: this scan reads the migrations as a SET, so a drop it cannot order
-	// against the attachment invalidates the conclusion for that table.
-	triggerDrop = regexp.MustCompile(`(?is)\bDROP\s+TRIGGER\b[^;]*?\bON\s+([a-z_]+)`)
+	// triggerExecutes captures the function named in the EXECUTE clause — the
+	// only part of a CREATE TRIGGER that says what the trigger runs. A statement
+	// that merely mentions a function elsewhere, in its own trigger name or
+	// beside a different EXECUTE clause, executes something else.
+	triggerExecutes = regexp.MustCompile(`(?is)\bEXECUTE\s+(?:FUNCTION|PROCEDURE)\s+([a-z_][a-z0-9_]*)\s*\(`)
 
-	// sqlLineComment strips `-- …` so prose naming the bump function is never
-	// read as an attachment of it.
+	// triggerDrop captures the trigger name and table a DROP TRIGGER detaches:
+	// PostgreSQL scopes a trigger name to its table, so the pair is what the
+	// statement removes, and a drop of one trigger says nothing about the others
+	// on the same table.
+	triggerDrop = regexp.MustCompile(`(?is)\bDROP\s+TRIGGER\s+(?:IF\s+EXISTS\s+)?([a-z_][a-z0-9_]*)\s+ON\s+([a-z_][a-z0-9_]*)`)
+
+	// updateEvent finds the UPDATE event in a trigger's event list. A trigger
+	// declared for several events fires on each of them, so an event list
+	// naming UPDATE alongside others fires before an update too.
+	updateEvent = regexp.MustCompile(`(?i)\bUPDATE\b`)
+
+	// sqlLineComment strips `-- …` so prose in a comment is never read as a
+	// statement the database runs.
 	sqlLineComment = regexp.MustCompile(`--[^\n]*`)
 )
+
+// attachedTrigger identifies one trigger by the pair PostgreSQL identifies it
+// by: its name, scoped to the table it is attached to.
+type attachedTrigger struct{ name, table string }
+
+// triggerBody is what a CREATE TRIGGER declared — the function the trigger
+// executes, and whether it fires before an UPDATE.
+type triggerBody struct {
+	function     string
+	beforeUpdate bool
+}
 
 func TestEveryVersionPinnedTableBumpsItsVersion(t *testing.T) {
 	pinned := versionPinnedTables(t)
@@ -72,27 +102,22 @@ func TestEveryVersionPinnedTableBumpsItsVersion(t *testing.T) {
 			len(pinned), versionPinnedTableFloor, approvalsDir)
 	}
 
-	bumped, dropped := versionBumpAttachments(t)
+	bumped := versionBumpingTables(t)
 	if len(bumped) == 0 {
-		t.Fatalf("no %s attachment found in the migrations: the SQL derivation broke, not the subject — the scan must be statement-scoped, since the CREATE TRIGGER and EXECUTE FUNCTION clauses sit on different lines",
+		t.Fatalf("no table is left with a BEFORE UPDATE trigger executing %s: the SQL derivation broke, not the subject — the scan must be statement-scoped and take the function from the EXECUTE clause, since a trigger's name, its event list and that clause sit on different lines",
 			bumpFunction)
 	}
 	versioned := versionedTables(t) // reused from updateguard_test.go
 
 	for _, table := range sortedNames(pinned) {
-		if at, ok := dropped[table]; ok {
-			t.Errorf("approvals.versionTables pins %s, and %s drops a trigger on it: this derivation reads the migrations as a set and cannot tell whether the %s attachment survived the drop, so the pin can no longer be shown to bind anything. Re-attach %s BEFORE UPDATE on %s in a later migration, so one CREATE TRIGGER statement carries the attachment on its own, or drop %s from versionTables in %s/redeem.go and leave TargetVersion nil for that type",
-				table, at, bumpFunction, bumpFunction, table, table, approvalsDir)
-			continue
-		}
-		if _, ok := bumped[table]; ok {
+		if bumped[table] {
 			continue
 		}
 		column := "the table has no version column at all"
 		if versioned[table] {
 			column = "the table carries a version column that nothing moves"
 		}
-		t.Errorf("approvals.versionTables pins %s but no migration attaches %s BEFORE UPDATE on it — %s, so the staged pin, the redemption re-check and the released call's If-Match all compare a constant. Attach the trigger in a new migration under migrations/core, or drop %s from versionTables in %s/redeem.go and leave TargetVersion nil for that type",
+		t.Errorf("approvals.versionTables pins %s but the migrations leave no BEFORE UPDATE trigger on it executing %s — %s, so the staged pin, the redemption re-check and the released call's If-Match all compare a constant. Attach the trigger in a new migration under migrations/core, or drop %s from versionTables in %s/redeem.go and leave TargetVersion nil for that type",
 			table, bumpFunction, column, table, approvalsDir)
 	}
 }
@@ -136,13 +161,15 @@ func versionPinnedTables(t *testing.T) map[string]bool {
 	return tables
 }
 
-// versionBumpAttachments derives, per table, where the migrations attach the
-// bump trigger and where they drop a trigger from it. Statement-scoped over
-// both migration namespaces (ADR-0017), because the fork seam may attach its
-// own.
-func versionBumpAttachments(t *testing.T) (bumped, dropped map[string]string) {
+// versionBumpingTables derives the tables the migrations leave with a live
+// BEFORE UPDATE attachment of the bump function. Statement-scoped over both
+// migration namespaces (ADR-0017), because the fork seam may attach its own.
+func versionBumpingTables(t *testing.T) map[string]bool {
 	t.Helper()
-	bumped, dropped = map[string]string{}, map[string]string{}
+	live := map[attachedTrigger]triggerBody{}
+	// Namespace order and, inside each, the walk's lexical order are the order
+	// dbmigrate applies the files in: every version is a fixed-width sequence
+	// number or a timestamp, so ascending version and ascending name agree.
 	for _, root := range []string{"migrations/core", "migrations/custom"} {
 		err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 			if err != nil || d.IsDir() || !strings.HasSuffix(path, ".up.sql") {
@@ -152,35 +179,47 @@ func versionBumpAttachments(t *testing.T) (bumped, dropped map[string]string) {
 			if err != nil {
 				return err
 			}
-			text := sqlLineComment.ReplaceAllString(string(raw), "")
-			line := 1
-			for _, stmt := range strings.Split(text, ";") {
-				// Splitting on ";" leaves the newlines that FOLLOW the previous
-				// statement at the head of this one. They belong to the gap, so
-				// they are counted before the position is taken — counting them
-				// afterwards reports every statement at the preceding ";".
-				body := strings.TrimLeft(stmt, " \t\r\n")
-				line += strings.Count(stmt[:len(stmt)-len(body)], "\n")
-				at := path + ":" + strconv.Itoa(line)
-				line += strings.Count(body, "\n")
-				if m := triggerDrop.FindStringSubmatch(stmt); m != nil {
-					dropped[m[1]] = at
-					continue
-				}
-				if !strings.Contains(stmt, bumpFunction) {
-					continue
-				}
-				if m := triggerAttachment.FindStringSubmatch(stmt); m != nil {
-					bumped[m[1]] = at
-				}
-			}
+			applyTriggerStatements(sqlLineComment.ReplaceAllString(string(raw), ""), live)
 			return nil
 		})
 		if err != nil {
 			t.Fatalf("walking %s: %v", root, err)
 		}
 	}
-	return bumped, dropped
+
+	bumped := map[string]bool{}
+	for trigger, body := range live {
+		if body.beforeUpdate && body.function == bumpFunction {
+			bumped[trigger.table] = true
+		}
+	}
+	return bumped
+}
+
+// applyTriggerStatements folds one migration's trigger statements into the live
+// attachment state: a CREATE TRIGGER records what that trigger executes, a DROP
+// TRIGGER removes the record. A re-attachment therefore heals a drop, and a drop
+// of one trigger leaves every other trigger on the same table standing.
+func applyTriggerStatements(text string, live map[attachedTrigger]triggerBody) {
+	for _, stmt := range strings.Split(text, ";") {
+		if m := triggerDrop.FindStringSubmatch(stmt); m != nil {
+			delete(live, attachedTrigger{name: m[1], table: m[2]})
+			continue
+		}
+		m := triggerAttachment.FindStringSubmatch(stmt)
+		if m == nil {
+			continue
+		}
+		// An attachment whose EXECUTE clause the scan cannot read runs a function
+		// this derivation cannot name, so it is recorded as executing nothing —
+		// it replaces whatever the same trigger executed before, rather than
+		// leaving that reading in place.
+		body := triggerBody{beforeUpdate: strings.EqualFold(m[2], "BEFORE") && updateEvent.MatchString(m[3])}
+		if executes := triggerExecutes.FindStringSubmatch(stmt); executes != nil {
+			body.function = executes[1]
+		}
+		live[attachedTrigger{name: m[1], table: m[4]}] = body
+	}
 }
 
 // parsePackageDir parses the hand-written Go files of ONE package directory,

--- a/backend/writeshape_test.go
+++ b/backend/writeshape_test.go
@@ -23,6 +23,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/gatekit"
 )
 
 // auditOnlyWrites are the ratified audit-without-event functions, keyed
@@ -31,7 +33,7 @@ import (
 // entry without a rationale is a finding, not a pass. When the spec's
 // events.md gains the missing event types, wiring storekit.Emit into
 // these mutations removes the entries.
-var auditOnlyWrites = map[string]string{
+var auditOnlyWrites = gatekit.Waive(map[string]string{
 	"internal/modules/activities:RedactCapturedNoiseTx":  "the ADR-0072 noise redaction nulls content on a row that is ALREADY archived, and the one consumer that would not have reacted to the archive — the embedding lane — is handled directly: the redaction deletes the vectors itself, so no subscriber is left holding derived content. The closed catalog (events.md \u00a75) defines no activity.redacted type, and re-announcing an invisible row's content change would tell the rest nothing they can act on",
 	"internal/modules/activities:auditIdentityReKey":     "the outbound-send reconcile moves a sent message onto the transport identity its provider actually stamped. activity.updated is the only candidate event and its changed_fields is a REQUIRED, typed, BOUNDED delta over the fields a human patches (subject, body, occurred_at, due_at, remind_at, assignee_id, is_done, a relinked target) — the natural key is not among them and cannot be expressed as one, so emitting it would publish an empty required delta: an event that says a change happened and cannot say what. The closed catalog (events.md §5, shared/kernel/events/catalog.go) defines no transport-identity verb either, and the closed-verb law forbids inventing one build-side. Recorded upstream (P3): the fix is a contract change — a typed identity delta or a discrete reconciliation event — not a build-side substitute",
 	"internal/modules/collections:CreateSavedView":       "saved views are per-user view state, not record facts — events.md §5.3c ratifies this config family as audit-only and defines no saved_view.* type",
@@ -114,15 +116,10 @@ var auditOnlyWrites = map[string]string{
 	// WriteFiltered no longer belongs here: the bulk export is a non-entity
 	// operational event, so it moved from storekit.Audit to storekit.LogSystem
 	// (system_log, 0074) \u2014 it writes no audit_log row at all now.
-}
+})
 
 func TestEveryAuditedMutationEmitsAnEvent(t *testing.T) {
-	for fn, rationale := range auditOnlyWrites {
-		if strings.TrimSpace(rationale) == "" {
-			t.Errorf("auditOnlyWrites[%s] has no rationale — a waiver must say why the event is missing", fn)
-		}
-	}
-	used := map[string]bool{}
+	defer auditOnlyWrites.AssertAllMatched(t)
 	emissionPathsByDir := map[string]map[string]bool{}
 	fset := token.NewFileSet()
 	for _, root := range []string{"internal/modules", "internal/compose"} {
@@ -171,8 +168,7 @@ func TestEveryAuditedMutationEmitsAnEvent(t *testing.T) {
 				})
 				if audits && !emits {
 					key := filepath.ToSlash(filepath.Dir(path)) + ":" + fn.Name.Name
-					if _, ratified := auditOnlyWrites[key]; ratified {
-						used[key] = true
+					if auditOnlyWrites.Waived(t, key) {
 						continue
 					}
 					t.Errorf("%s: %s calls storekit.Audit without storekit.Emit — every audited mutation ships its event, or the exception is ratified in auditOnlyWrites",
@@ -183,11 +179,6 @@ func TestEveryAuditedMutationEmitsAnEvent(t *testing.T) {
 		})
 		if err != nil {
 			t.Fatal(err)
-		}
-	}
-	for key := range auditOnlyWrites {
-		if !used[key] {
-			t.Errorf("auditOnlyWrites[%s] matches no audit-only function — stale waiver, remove it", key)
 		}
 	}
 }


### PR DESCRIPTION
# chore(gates): a waiver is a type, and three obligations derive from the right authority

## What this changes, and why

This repo's fitness gates each carry a list of ratified exceptions. Until now every one of those
lists was a bare `map[K]string` in a test file — a subject mapped to the sentence waiving it — and
every obligation a waiver owes was hand-rolled per gate by whoever wrote it.

A waiver owes two things. It must **state what it costs**, so a later reader can judge whether the
trade still holds. And it must **describe code that still exists**, because an entry that matches
nothing certifies nothing while reading exactly like ratification. In the merge-base tree the first
obligation existed as twelve copies of `if strings.TrimSpace(reason) == "" { … }` — a blank-text
check, which a one-word reason passes. The second existed as per-gate sweep loops emitting twenty
distinct "stale waiver, remove it" messages, each with its own wording, its own accumulator and its
own idea of when to run. Several waiver texts had drifted into being factually false, because nothing
held them to anything.

The load-bearing change is one sentence: **a waiver is a type.** `gatekit.Waivers[K]` holds both
obligations once (`backend/internal/shared/gatekit/waivers.go`), so a gate cannot hold its exceptions
to a weaker standard than its neighbours. The reason floor fires at the point of *reliance*
(`waivers.go:78`), not in a separate validation step a new gate can forget to call; staleness is
reported by `AssertAllMatched` (`waivers.go:112`); and `K` stays the caller's own type, so a
record-type waiver cannot be keyed by a tool name.

26 existing maps were converted and 3 new waiver sets introduced, for 29 `gatekit.Waive` declarations
across 23 files. A census (`backend/gatecensus_test.go`) closes the loop: no package-level reason map
in any test file escapes the type without saying, at its declaration, that it is deliberately
something else. Nine carry a `// gatekit:fixture <what it is>` marker and the count is pinned
(`gatecensus_test.go:53`), so a tenth is a conscious act a reviewer sees.

Two further defects in the same family are fixed:

- **A path-scoped gate's walk root was an assertion, never a proof.** A gate that walks
  `internal/modules` and finds nothing wrong has also, silently, claimed that `internal/modules` is
  where the obligation lives. `gatekit.Scope` (`scope.go:37`) checks the second claim by sweeping the
  negative space — the code the gate does *not* look at — and reporting any subject found there, plus
  refusing a root that holds no subject at all. Two gates adopt it: `mcpfaultcoverage_test.go` (roots
  `internal/modules` + `internal/compose`) and `rbacgate_test.go` (root `internal/modules`).
- **Three obligations were asserted where they could be derived.** A version pin now requires a table
  whose version actually moves, derived from the `set_updated_at_bump_version` trigger attachments in
  the migrations (`versionguard_test.go`). Three hand-kept tool registries must each invoke all seven
  registrars, derived by AST from the declarations themselves (`registrarparity_test.go`). A field
  name published through `httperr.Validation` must be a name the contract declares, derived from
  `api_gen.go`'s `json:"…"` tags (`fieldnames_test.go:358`).

## What it does not change

**Zero product diff.** Against the merge base (`ff0424a7`), the branch touches 39 files. 38 are
`*_test.go`. The only non-test files are:

| File | What changed |
|---|---|
| `Makefile` | one new `check-gates` target + `GO ?= go` + a `.PHONY` entry |
| `backend/internal/shared/gatekit/waivers.go` | new, 130 lines |
| `backend/internal/shared/gatekit/scope.go` | new, 241 lines |

No handler, migration, contract, config or frontend file. `gatekit` is imported only from `_test.go`
files, and `TestGatekitServesTestsOnly` (`gatecensus_test.go:190`) holds that line — a waiver
mechanism reachable from product code would be a way to mark shipped behaviour "ratified".

**No CI change and no new required check.** `check-gates` is a dev-loop convenience and is
deliberately *not* a prerequisite of `check-backend`: every test it names lives in `package
backendarch`, which `make -C backend check` already runs via `go test -count=1 .`. The gates ride the
existing merge gate; a prerequisite would only run them twice.

## Proof of work: UAT

This PR changes no product behaviour, so UAT means proving the **gates bite**. 27 probes ran across
the four gates, each in an isolated `git archive` copy under `/private/tmp/` (no `.git`, so no
`git checkout` escape hatch), each restored and the restoration verified by `diff` against a fresh
extraction. Selected verbatim output below; not all 27 blocks are reproduced.

### Gate 1 — waiver integrity and the census (9 probes)

| Probe | Expected | Actual | Verdict |
|---|---|---|---|
| Shorten a real reason to one word (`crossStoreWrites`) | fails at the reliance point, names the subject | `waiver internal/modules/activities:deal carries no usable reason ("denormalized"): state what it costs…` | bit |
| Add a fabricated entry matching nothing | `AssertAllMatched` reports it, and *only* it | `waiver zzz_not_a_real_subject matched no subject: delete it…` | bit |
| Revert a string-keyed waiver to a bare map (`auditOnlyWrites`) | census rule 1 names the map | **Go build failure** — the map's own call sites live in the census's package | did not bite as worded; see below |
| Same, with call sites patched to compile | census rule 1 names the map | names `writeshape_test.go:34` and teaches the fix | bit |
| Revert the **typed-key** waiver (`recordTypesWithoutDescriptor`) | census rule 1 names it, proving no `map[string]string` special case | names `internal/compose/schemadescriptors_test.go:31` | bit, cleanly |
| Strip the text after `// gatekit:fixture` | census refuses the bare marker | `tableOwners carries a bare gatekit:fixture marker…` | bit |
| Change the marker to `//gatekit:fixture` (no space) | census must **still** see it and PASS | PASS | bit (correctly silent) |
| Delete an `AssertAllMatched` call | census rule 2: nothing sweeps the declaration | `nothing calls crossStoreWrites.AssertAllMatched…` | bit |
| Add a second `AssertAllMatched` call | census rule 2: more than one sweeper | `…is called from more than one place in package backendarch…` | bit |

The typed-key probe is the one that carries the argument, because an earlier design of the census
keyed only on `map[string]string` and would have passed it while being wrong:

```
=== RUN   TestEveryPackageLevelReasonMapIsAWaiverOrADeclaredFixture
    gatecensus_test.go:90: internal/compose/schemadescriptors_test.go:31: recordTypesWithoutDescriptor maps subjects to reason strings but is neither a waiver nor a declared fixture: wrap it in gatekit.Waive so its reasons are held to a standard and its stale entries reported, or, if the values are expected data rather than costs, say so with a `// gatekit:fixture <what it is>` line on the declaration
--- FAIL: TestEveryPackageLevelReasonMapIsAWaiverOrADeclaredFixture (0.67s)
```

**The one probe that did not bite as worded, and why the outcome is stronger.** Reverting
`auditOnlyWrites` to a bare map produced a Go build failure, not the census message, because that
map's `.Waived` / `.AssertAllMatched` call sites live in the same package as the census — compilation
stops before any test logic runs. Patching the call sites to compile confirmed the census does flag
it by name. So the real behaviour is: a half-converted map in the census's own package cannot even
build, and one elsewhere is caught by the census.

### Gate 2 — `gatekit.Scope`'s root proof (5 probes)

| Probe | Expected | Actual | Verdict |
|---|---|---|---|
| Remove one `seamOutsideRoots` entry | fails naming the un-ratified file and both roots | names `internal/shared/ports/workflow/workflow.go` | bit |
| Remove one `entryPointsOutsideModules` entry | same, single root | names `internal/platform/blobstore/memory.go` | bit |
| Point a root at a real but subject-free directory | vacuity message naming the root | `internal/shared/apperrors holds no site this gate judges…` | bit |
| **Create a NEW out-of-root subject** (`strayseam.go`) | fails naming a file no `Exempt` entry has ever seen | named exactly | bit |
| Add an `Exempt` entry for a nonexistent file | `AssertAllMatched` reports it stale | `waiver internal/compose/nosuchfile.go matched no subject…` | bit |

The fourth probe is worth more than removing an existing exemption, because it demonstrates the
sweep *catching* something rather than un-ratifying something. A new hand-written package
`internal/platform/strayseam/strayseam.go` importing the datasource seam — a tier no `Exempt` set had
ever seen:

```
=== RUN   TestSeamReachableModulesCarryTheirOwnFieldVerdict
    mcpfaultcoverage_test.go:432: internal/platform/strayseam/strayseam.go holds a site this gate must judge but lies outside every root (internal/modules, internal/compose), so the gate never sees it: widen the roots if this tier is in scope, or ratify the file in the scope's Exempt set with the reason it is not this gate's business
--- FAIL: TestSeamReachableModulesCarryTheirOwnFieldVerdict (0.56s)
```

### Gate 3 — the version pin derives from the trigger (5 probes)

| Probe | Expected | Actual | Verdict |
|---|---|---|---|
| Pin `record_grant` (version column, no trigger) | fails naming the table and the mechanism | exact message | bit |
| Pin `automation` (independently verified untriggered) | same | exact message | bit |
| Go-side vacuity: shrink `versionTables` below 14 | "the AST derivation broke" | exact message | bit |
| SQL-side vacuity: split on `\n` instead of `;` | "the SQL derivation broke" | exact message | bit |
| Append a `DROP TRIGGER` on a pinned table | fails naming table + drop location | exact message | bit |

The first probe shows the obligation being derived from the migrations rather than from a call
pattern in Go — the pin binds only if a trigger moves the column:

```
=== RUN   TestEveryVersionPinnedTableBumpsItsVersion
    versionguard_test.go:95: approvals.versionTables pins record_grant but no migration attaches set_updated_at_bump_version BEFORE UPDATE on it — the table carries a version column that nothing moves, so the staged pin, the redemption re-check and the released call's If-Match all compare a constant. Attach the trigger in a new migration under migrations/core, or drop record_grant from versionTables in internal/modules/approvals/redeem.go and leave TargetVersion nil for that type
```

The line-split probe is the one that proves the statement-scoping is load-bearing rather than
defensive: `CREATE TRIGGER … BEFORE UPDATE ON <table>` and `EXECUTE FUNCTION
set_updated_at_bump_version()` sit on different lines in every real attachment, so a line-oriented
read finds **zero** and the vacuity floor catches it instead of reading green over an empty set:

```
    versionguard_test.go:77: no set_updated_at_bump_version attachment found in the migrations: the SQL derivation broke, not the subject — the scan must be statement-scoped, since the CREATE TRIGGER and EXECUTE FUNCTION clauses sit on different lines
```

One documented deviation: the Go-side vacuity probe was *instructed* as "rename `authority.go`", which
breaks the real package build (its fourteen constants are production identifiers, not gate fodder).
The build-safe equivalent — shrinking `versionTables` below the floor — hit the exact intended
message.

### Gate 4 — registrar parity and the published field name (8 probes)

| Probe | Expected | Actual | Verdict |
|---|---|---|---|
| A1 — new `RegisterProbeTools`, no call site | fails, all 3 registries named | all 3 named | bit |
| A2 — **singular** `RegisterProbeTool` | caught despite the `Register*Tools` name pattern missing it | all 3 named | bit |
| A3 — **renamed parameter** `(reg *Registry)` | caught despite a literal-text shape missing it | all 3 named | bit |
| A4 — drop `RegisterPipelineTool` from ONE registry | fails naming only that registry | only `idProbeDispatcher` named | bit |
| B1 — prose in the field slot | fails, quoting the prose | `"must be after started_at"` quoted | bit |
| B2 — plausible typo `"startd_at"` | fails, proving vocabulary not shape | named | bit |
| B3 — correct camelCase `"privateAppToken"` | **PASS** | PASS | bit (correctly silent) |
| B4 — remove the `"arguments"` waiver | fails naming the MCP `tools/call` handler | `internal/compose/registry.go` named | bit |

A2 and A3 together defeat both naive derivations. Two real registrars are singular
(`RegisterPipelineTool`, `RegisterReportTool`), so a name-shape rule would have missed them; every
real registrar happens to name its parameter `r`, so a literal-text rule would have passed by
coincidence. The gate keys on the first parameter's **type**:

```
=== RUN   TestEveryToolRegistrarIsInvokedByEveryFullRegistry
    registrarparity_test.go:101: registryWithGate (internal/compose/registry.go) does not invoke RegisterProbeTool, declared at internal/modules/agents/tools.go:386:1 — the surface a client is served: an unregistered tool does not exist. Wire it there, or move it off *Registry if it is not a tool registrar
```

A4 is the realistic regression shape — wired into two of three lists, not the third — and the message
names which one, with its own reason for why that list matters:

```
    registrarparity_test.go:101: idProbeDispatcher (internal/modules/agents/idargs_test.go) does not invoke RegisterPipelineTool, declared at internal/modules/agents/tools_pipelines.go:70:1 — the seam walk: an unregistered tool's arguments are never dispatched. Wire it there, or move it off *Registry if it is not a tool registrar
```

B2 and B3 are the pair that matters for the field-slot gate. `"startd_at"` is shape-legal — lowercase,
underscored, no spaces — and is rejected:

```
    fieldnames_test.go:370: internal/compose/company.go: httperr.Validation publishes field "startd_at", whose segment "startd_at" is not a field the contract declares. REST renders that slot as details.errors[].field, so use the contract's own name (or a cf_ custom field) and put the explanation in the message argument — or refuse with a MessageFault, which publishes no field, when no single argument is the wrong one.
```

…while `"privateAppToken"`, a genuinely declared camelCase contract property
(`internal/contracts/api_gen.go`, `json:"privateAppToken"`), is **accepted**. The PASS is the
evidence:

```
=== RUN   TestEveryValidationFieldLiteralNamesAContractField
--- PASS: TestEveryValidationFieldLiteralNamesAContractField (0.27s)
PASS
ok  	github.com/gradionhq/margince/backend	1.187s
```

A gate that failed on a correct contract field would be worse than no gate. Together the two probes
show it checks the contract's vocabulary, not a naming shape.

## What UAT could not verify

- **That the gates hold under `t.Parallel()`.** `AssertAllMatched`'s `matched` map accumulates across
  a package's tests, and the single-owner invariant assumes sequential execution. There are currently
  **zero** `t.Parallel()` calls anywhere in `backend/**/*_test.go`, verified independently, so the
  assumption holds today and nothing here introduces one — but no gate enforces that it stays true.
  (`Waivers.matched` is mutex-guarded regardless, so the failure mode would be a false staleness
  report, not a data race.)
- **Any product behaviour.** There is none. No endpoint, migration, contract or handler changed, so
  there is no UI path, no API response and no database effect to exercise. The `make dev` stack was
  never started and did not need to be.
- **CI-environment behaviour.** Everything was proven on one macOS host. These gates walk the tree
  with `go/parser` and read `migrations/*.sql` and `internal/contracts/api_gen.go` from disk, so they
  are path-sensitive; CI is the first place that combination runs on Linux from a clean checkout.
- **The deferred findings' actual correctness.** The 16 ratified out-of-root store entry points are
  ratified, not resolved. UAT proved the sweep reports them; it did not prove their RBAC posture is
  right.

## The reviews

Two independent reviewers, with deliberately different mandates.

**Codex — unstated premises and second-order effects — verdict BLOCK**, two blockers. Its sandbox was
read-only, including the temp directories `go test` needs, so it could not run probes and marked every
claim as established-by-reading. Both blockers were assessed against source rather than taken at face
value:

1. **CONFIRMED and fixed — the census could not see a non-literal `gatekit.Waive(...)` declaration.**
   The old classifier returned `waived` only when `Waive`'s argument was an `*ast.CompositeLit` of a
   string-valued map type, so `var w = gatekit.Waive(buildWaivers())` fell out of the population of
   **both** rules — nothing would demand an `AssertAllMatched` for it, and a stale entry in it would
   read green forever. No such declaration exists today, but the census's whole purpose is to make an
   ungoverned waiver impossible. Fixed by splitting the classifier into two signals that never read
   the entries: a `Waive` call is ratification whatever its argument is, and the
   `*gatekit.Waivers[…]` type counts too, initializer or not. A probe declaration passed the old
   census and fails the new one:

   ```
   --- FAIL: TestEveryWaiversDeclarationIsSweptForStalenessExactlyOnce (0.68s)
       gatecensus_test.go:164: probewaiver_test.go:12: nothing calls probeWaived.AssertAllMatched: an entry that matched no subject then reads as ratification of code that is gone — call it once, from the test that walks the full subject set
   ```

   No new `gatekit` API; the fix is entirely in `gatecensus_test.go`.
2. **Verified as a mischaracterisation — "staleness is attached to a test run, so `-run` subsets go
   green."** Its example was `laneExemptions`, matched in both tests of `modellanes_test.go` with
   `AssertAllMatched` only in the first. Both were read: each sweeps the same complete set
   (`exportedLanes(ModelPath{})`), and the *owner's* sweep is complete, which is the property that
   matters. Running only the non-owner skips an assertion — but that is inherent to `-run` subsetting
   in any suite, and CI runs the full package. There is no full-run configuration in which staleness
   goes unchecked. Recorded as a documented design property, not fixed.

**Fable — internal coherence — verdict APPROVE WITH FINDINGS.** It independently found the same
census hole, **by execution** rather than by reading, which is the stronger of the two pieces of
evidence for the same defect. Its execution also forced two comment corrections, both cases of a doc
comment claiming more than its sweep proves:

- `internal/compose/agentpolicysynthesis_test.go:71` claimed the owner's sweep was "only sound
  because" a sibling test held the other half. It is sound on its own — a pinned verb that left the
  table is skipped by the loop and so goes unmatched, and the owner reports it. The sibling *names
  which* of two things happened; it sharpens the diagnosis, it does not carry the detection.
- `promptfence_test.go:155` claimed the sweep holds that "every entry still exists **and still needs
  it**". It holds only the first: a file that now mints its fence as well still matches, and stays
  matched. The comment now says so.

## The defect this PR found in itself

`fieldnames_test.go`'s doc comment pinned counts:

> Coverage rests on a convention: 109 of the 142 calls lead with a string literal, spelling 62
> distinct paths… the other 33 pass a computed value

Measured independently on the rebased tree, two ways that agree — a standalone AST script replaying
the gate's own walk, and a temporary `t.Logf` inside the real test — the tree holds **148**
`httperr.Validation` call sites, **115** literal-leading, **33** computed, **65** distinct literal
paths. Three of the four numbers are false. They were true when written and the rebase onto a moved
`main` falsified them **within a day**, because main's ten commits added `Validation` call sites and
contract properties.

That is precisely the defect class this PR exists to eliminate — a prose claim that rots — sitting in
the file whose own argument is that a vocabulary must be *derived* rather than asserted.

The fix is structural, not arithmetic. The counts are gone; the convention stays (which calls are
judged, and that a concatenation counts as literal-leading with its computed tail unjudged); the
residue keeps its shape and its three honest examples. What replaces the counts is code: the walk
going blind is caught by `if checked == 0 { t.Fatalf(…) }` in the test itself, and the vocabulary
going blind by `minContractFieldNames = 100` (`fieldnames_test.go:328`). A new floor on
literal-leading calls would be a second yardstick for a claim the first already covers, and — being
a number that rises with the tree — would rot on the next merge in exactly the way this fix removes.

Then CLAUDE.md rule 1 was applied — fix the invariant, not the call site — and every comment in all
38 changed Go files was swept for the same class. **This is the only site.** Everything else numeric
is an HTTP status code, a line citation, or a stable structural fact, and the derived gates' comments
use qualitative language ("three builders", "the one house function") instead of counts. The three
hard pins that do exist are sound by construction: `versionPinnedTableFloor = 14`
(`versionguard_test.go:47`) and `toolRegistrarFloor = 7` (`registrarparity_test.go:48`) are
**floors**, which a growing tree cannot falsify, and `wantFixtureAnnotations = 9`
(`gatecensus_test.go:53`) is a deliberate equality whose whole point is that adding an annotation
must be a conscious act.

## Findings recorded and deliberately deferred

**Security-relevant, and the reason `Scope`'s second adopter was chosen.** `rbacgate_test.go` walks
only `internal/modules`, while the comparable `writeshape_test.go` walks `internal/modules` *and*
`internal/compose`. The sweep answered which is right: applying `rbacgate_test.go`'s own three-part
predicate to the whole tree finds **8 exported `*Store`/`*Service` methods under `internal/compose`**
outside the gate's reach — four on `org360.Service`, two on `orgbrief.Service`, two on
`RunnerService` — plus **8 on `blobstore`'s `memoryStore`/`s3Store`**, matched only because a receiver
type name ends in `Store`.

All 16 are ratified through `Scope.Exempt` (`rbacgate_test.go:237`, 8 file-keyed entries) with reasons
that state the deferral rather than claim the code is fine. **None** was added to
`ungatedEntryPoints`, because that map means "this entry point is ungated and that is accepted", and
asserting it here would be an RBAC judgement this PR has not made. Most of the compose methods open
with `auth.RequireHuman` / `auth.Require` in their own bodies; the two on `RunnerService` are
worker/event-driven and carry no human principal, and are ratified neither way.

Also recorded and not acted on:

- **`custom_field`'s waiver text is provably FALSE** — the table *does* carry the version trigger
  (`migrations/core/0063_custom_field_catalog.up.sql:51`) — while `record_grant`'s is **SOUND**:
  version column, no trigger, no update path.
- **`internal/modules/approvals/redeem.go:136`'s comment still names the wrong bump mechanism** (it
  credits storekit's guarded patch; the trigger is what moves the column). A *product* file, so
  fixing it here would break the zero-product-diff property.
- **The 14 package-level `map[K]bool` exemption sets**, which carry no reason at all, and the **109
  function-local `:= map[K]string` declarations** — both out of the census's population by design.
  Codex framed the consequence precisely: this is an incentive gradient, since making a set
  `map[K]bool` or moving it inside a function makes it invisible.
- **`Scope` makes exemption cheaper than widening the roots** — the seam gate hardcodes its model of
  scope in three places, so teaching it a new tier costs more than adding one `Exempt` line.

These are tracked in the repo's own tracker (`.tmp/NEXT-MCP-MISSING.md`) rather than as GitHub issues:
a deliberate departure from CLAUDE.md's finding-to-issue rule, taken by the repo owner for this
record-and-defer PR, and stated here rather than left implicit.

## Local gate results

| Gate | Result |
|---|---|
| `make check` (the merge gate, both halves) | **PASS**, exit 0 — FE: 123 test files, 1292 tests |
| `make test-integration` | **PASS** — `OK: integration passed with 0 skips (28 packages, parallel)` |
| `craft static`, diff-scoped over all 38 changed backend Go files | **PASS — 0 blocker, 0 major, 0 minor** |
| `craft residue` | clean, no CRAFT markers |
| `go test -count=1 .` / `./internal/...` / `go vet ./...` / `gofmt -l .` | all clean |
| New-code coverage | **85.0%** merged; **81.1%** from `gatekit`'s own package tests alone |

Only `waivers.go` and `scope.go` bear coverage — SonarCloud's `sonar.test.inclusions` marks
`**/*_test.go` as test code, exempt from coverage metrics — so the 38 test files do not dilute or
inflate the number. Per-function, everything in `waivers.go` is 87.5–100%; the weakest point is
`scope.go`'s `universe` at 53.3%, whose error branches (no `go.mod` above the working directory, an
unreadable one) are untested because both adopters and every unit test take the success path.
Recorded rather than papered over.

**The integration lane needs `INTEGRATION_TIMEOUT=900s` locally.** The default per-package budget is
300s (`scripts/test-integration-parallel.sh:96`), which is on the edge for
`internal/compose/integration` — it runs for roughly that long, so on a loaded machine the package
alarm fires mid-test. CI is unaffected either way: its integration job shards, and per-shard slices
stay well under the default, while the unsharded coverage run self-raises to 900s
(`test-integration-parallel.sh:97-99`, which triggers only when `COVERDIR` is set — so a plain local
run does not get the raise). The failure mode was `panic: test timed out after 5m0s`, never a failed
assertion, and the lane passes with the budget raised.

## Review guide — hardest first

1. **The `AssertAllMatched` single-owner invariant** (`waivers.go:112-130`). `matched` accumulates
   across every test in a package, so **zero** calls makes staleness opt-in and **two** make whichever
   asserts first emit staleness that is not there. The tree is 29 `gatekit.Waive` declarations and 29
   `AssertAllMatched` call sites, 1:1, and `TestEveryWaiversDeclarationIsSweptForStalenessExactlyOnce`
   (`gatecensus_test.go:134`) is what keeps it that way. The judgement worth checking is *which* test
   owns each sweep: it must be the one that enumerates the **full** subject set, which is why every
   enumeration site uses keys-only `Subjects()` — enumerating a set is not yet relying on any entry,
   so `Subjects` deliberately does not mark, and only `Waived` does.
2. **The three derived gates' vacuity floors.** A derivation that breaks must fail loudly, not
   certify an empty set. `versionPinnedTableFloor = 14` (`versionguard_test.go:47`) and the SQL-side
   `len(bumped) == 0` guard (`:76`); `toolRegistrarFloor = 7` (`registrarparity_test.go:48`) plus the
   `len(methods) == 0` check (`:82`); `minContractFieldNames = 100` (`fieldnames_test.go:328`) and
   `checked == 0` (`:377`). Each has a UAT probe above; the question for review is whether the floor
   is on the right quantity.
3. **The out-of-root exemptions' reasons** — 8 file-keyed entries covering the 16 store methods
   (`rbacgate_test.go:237`) and 6 seam files (`mcpfaultcoverage_test.go:87`). These are the judgement
   calls, not the mechanism. Read them for whether each states a *cost* — "this tier is not this
   gate's business, because …" — rather than merely asserting the code is fine.
4. **`Scope`'s two proofs** (`scope.go:85-100`): every root holds at least one subject, and no
   unratified subject lies outside all of them. `Tree` is left empty by both adopters, so the sweep
   universe is the whole module — measured as strictly stronger than narrowing to `internal`, with
   zero noise from `cmd/`, `pkg/` or `tools/`.
5. **The census's classifier** (`gatecensus_test.go:75`, `:134`) never reads a map's entries: a
   declaration is a reason map by *type*, a waiver set by the `Waive` call or the `Waivers` type, and a
   fixture by an explicit marker. Reading the entries would decide the obligation on a spelling.

## End-of-work review round: craftsmanship and security

Two further reviewers ran over the diff after the ones above — one on craftsmanship, one adversarial on
security. Six findings were confirmed and fixed; three were assessed as pre-existing and recorded.

**Fixed:**

- **`Waivers.Reason` had no caller and is deleted.** It was added on the premise that gates report their
  own waivers, but every one of the five sites that walk a waiver set uses keys-only `Subjects()` —
  deliberately, since `Reason` marked a subject matched and would have made `AssertAllMatched` decorative.
  An unused exported method in a new package is the speculative code this repo's rules forbid, and it is
  worse here than elsewhere: this package's whole argument is that unexercised claims rot. `waivedLocked`
  was inlined into `Waived`, its sole remaining caller.
- **`normalizedRoots` gave a confidently wrong diagnosis for a mis-spelled root.** `Roots: {"."}` reported
  "`.` holds no site this gate judges … either the root is stale or the obligation has moved" *plus* every
  subject as out-of-root — a wrong story about a root-spelling mistake. Both `"."` and the absolute
  spelling are now refused by name. (The finding claimed the `root == ""` arm was dead; it is reachable
  via `Roots: {"/"}`, so it was kept and given its own message rather than deleted.)
- **SonarCloud `go:S3776` on `sweep`** — cognitive complexity 19 against 15. Resolved by extracting
  `subjectAt` (resolve a walk entry to a parsed subject, or say it is not one), leaving the callback as the
  partition step: `sweep` 19 → 13, `subjectAt` 5, everything else under 11. Measured with `gocognit`,
  which reproduces Sonar's 19 exactly on the pre-fix file.
- **gatekit's own guard arms were unexercised** — the nil-`Subject` arm, the empty-`Roots` arm and the
  root-dedup arm had zero coverage, in the package whose thesis is that a check nothing exercises certifies
  nothing. Each now has a test asserting its reported message.
- **The census's typed-declaration arm is now gated by a table test** over parsed source snippets. The arm
  exists so `var x *gatekit.Waivers[string] = build()` cannot evade the census; nothing in CI executed it,
  so a wrong AST shape would have gone unnoticed. Six spellings are now pinned.
- **`promptfence_test.go`**: the owner comment said "every file in the tree unconditionally" when
  `goFilesUnderTree` skips `_test.go`; and its sibling `TestAFileThatPromisesADataBoundaryBuildsOne` judged
  exactly **one** file in the whole tree, so rewording that single prompt would have taken the gate green
  over zero subjects — the precise vacuity `Scope` proves against, two files away. It now has the floor its
  sibling sweep already had.

**Security verdict: no exploitable defect introduced.** The reviewer re-implemented both the old and new
RBAC-gate predicates and enumerated them: **453 subjects on each side, byte-identical keys.** Waiver key
sets across all 11 converted gates are identical (`ungatedEntryPoints` 146/146, `crossStoreWrites`
173/173, and so on); the only additions anywhere are the 8 new `Exempt` keys, which are a new set rather
than a widening of an existing one. Every deleted loop is subsumed, and the reason floor moved from
"non-empty" to ≥20 characters, which is strictly stronger. It also verified the 16 ratified subjects are
genuinely gated: `org360`'s reads take mandatory admission through `people.Store.GetOrganizationTx`, which
carries both `auth.Require` and `auth.EnsureVisible`; `orgbrief` opens with `RequireHuman` and its cache
read happens *after* the gated assemble, so no replay path returns a record ungated; and
`RunnerService`'s two methods have one non-HTTP caller each.

**Recorded, not fixed** — one is worth a reviewer's attention:

- **`Scope.Exempt` is keyed by file, not by method**, so a ratified file can grow a new ungated entry point
  silently. Demonstrated: appending a method to `internal/compose/org360/assemble.go` leaves the gate
  green, while the same method in a new file under that directory turns it red. Not a regression — the old
  gate never looked at `internal/compose` at all — but the residual gap is real, and it is entangled with
  the deferred decision about those methods' RBAC posture, so it belongs with that decision rather than
  here.
- A future exception list spelled `map[string]bool` escapes the census, which covers string-valued maps.
  The known boundary, already tracked.
- `requiredbodyids_test.go`'s `probedRequiredIDBodies[name] || …Waived(t, name)` short-circuits, so a name
  on both lists never marks the waiver matched. Fails red (false staleness), never green.

## The gates absorbing a sibling PR, unchanged

While this branch was open, #408 ("a refusal names the field, and the tool says what that field takes")
merged to `main`. It landed squarely inside three of these gates' subject areas: it rewrote
`internal/compose/registry.go`, added `reportcatalog.go`, reworked `reporterrors.go`, and edited **both**
test registries that `TestEveryToolRegistrarIsInvokedByEveryFullRegistry` holds to parity
(`conformance_test.go` and `idargs_test.go`).

After rebasing onto it, **every gate passed with no change to any gate**:

- The registrar-parity gate re-derived its seven registrars and re-found all three registries' call
  sites, despite both test registries having been edited.
- The field-slot gate went from judging 148 `httperr.Validation` call sites to **151**, and from 115
  literal-leading arguments to **118** — it absorbed #408's three new refusal sites and held each to the
  contract's own vocabulary automatically.
- The census's `wantFixtureAnnotations = 9` still held, so #408 introduced no package-level reason map.
- The seam sweep still found exactly its six ratified out-of-root files.

That is the argument for deriving an obligation instead of pinning a list, demonstrated rather than
asserted. It is also the third time in one day that the counts removed from `fieldnames_test.go`'s doc
comment would have been wrong had they stayed.

## The census caught a sibling PR's ungoverned maps, in CI, before either could merge

The best evidence for this change arrived by accident. While the PR sat green, #433 ("backfill six RBAC
objects that never reached existing installations") merged to `main`, adding `backend/rbaccoverage_test.go`
with two new package-level reason-shaped maps — `objectBackfills` and `customNamespaceBackfills`.

Nothing on this branch or that one was wrong. But GitHub tests the *merge* commit, so CI ran the census
over the combined tree and failed:

```
gatecensus_test.go:91: rbaccoverage_test.go:71: objectBackfills maps subjects to reason strings but is
neither a waiver nor a declared fixture: wrap it in gatekit.Waive so its reasons are held to a standard
and its stale entries reported, or, if the values are expected data rather than costs, say so with a
`// gatekit:fixture <what it is>` line on the declaration
```

That is the census doing precisely the job it was written for: two new maps of the exact shape this PR
governs appeared, and the gate demanded they be classified before the tree could hold both changes. It
also demonstrates the failure message teaching the fix rather than merely refusing — the classification
followed straight from it.

Both are **fixtures**: the value is the migration identifier the assertion resolves (`"automation": "0035"`),
not the cost of an exception — the same shape as `tableOwners`. Both now carry a `gatekit:fixture` marker
and the pin moved from 9 to **11**, which is what the pin is for: a new classification is a number a
reviewer sees move.

Worth noting what this says about the local-versus-CI boundary. Every local gate was green, because the
sibling file did not exist in the working tree yet. Only the merge commit could surface it. That is an
argument for the obligation living in a gate rather than in a reviewer's attention.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added architecture and coverage checks for validation fields, registrar parity, version triggers, RBAC boundaries, and backend gate coverage.
  * Added a shared framework for managing and validating documented test exceptions.
  * Added a command to run the backend architecture checks without cached results.

* **Bug Fixes**
  * Improved detection of stale, unused, malformed, or incomplete test exceptions.
  * Strengthened validation of field paths, migration triggers, and reachable backend components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->