### PR TITLE
fix(jobs): the five follow-ups the job contract left open

### DIFF
--- a/backend/.golangci.strict.yml
+++ b/backend/.golangci.strict.yml
@@ -49,7 +49,14 @@ linters:
     - nilerr          # no return nil after a non-nil err
     - govet           # enable-all (the baseline runs the default vet suite)
     # --- anti-slop & taste-adjacent ---
-    - forbidigo       # project blocklist (see settings)
+    # forbidigo is deliberately ABSENT, and this is the only place that says
+    # so. It lives in .golangci.yml alone, repo-wide, because two passes
+    # enabling it with different `forbid:` sets made its in-source waiver
+    # unusable everywhere in the tree: a //nolint:forbidigo written against
+    # one set suppresses nothing under the other, and this config's nolintlint
+    # then fails the build for an unused directive — in a linter unrelated to
+    # the rule being waived, on a line that looks correct. One owner, one
+    # pattern set, and //nolint:forbidigo means what it says.
     - goconst         # repeated literals -> named const
     - unparam         # unused function parameters (speculative API)
     - unused          # dead/speculative code
@@ -110,14 +117,6 @@ linters:
           json: snake
           yaml: snake
         use-field-name: false
-    forbidigo:
-      analyze-types: true
-      forbid:
-        - pattern: '^fmt\.Print.*$'
-          msg: "use slog, not fmt.Print*"
-        - pattern: '^http\.Error$'
-          msg: "ship RFC 7807 JSON via platform/httperr, not http.Error"
-
   exclusions:
     generated: lax
     rules:

--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -1,5 +1,17 @@
 version: "2"
 
+run:
+  # The tagged lanes are linted here too. Without this the baseline compiles
+  # only untagged files, so the integration and livesmoke harnesses
+  # (internal/compose/integration, platform/testdb, budgettest, …) were the one
+  # part of the tree NO pass covered once forbidigo moved out of the strict
+  # config — and harness code is exactly where an http.Error or a stray
+  # fmt.Print slips in unnoticed. The tagged test files themselves are already
+  # exempted from the taste-adjacent rules below by path.
+  build-tags:
+    - integration
+    - livesmoke
+
 linters:
   default: standard
   enable:

--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -9,17 +9,29 @@ linters:
     - misspell
     - revive
   settings:
+    # forbidigo is enabled HERE AND NOWHERE ELSE, and that is the whole
+    # point rather than an accident of where the rules were written.
+    # .golangci.strict.yml used to enable it too, with a different `forbid:`
+    # set — and since that pass also runs nolintlint, a //nolint:forbidigo
+    # written against either set was reported as an UNUSED directive by the
+    # other, which failed `make check` in a linter unrelated to the rule
+    # being waived. The in-source waiver was therefore unusable tree-wide
+    # for this one linter, and the only remaining escape hatch was exempting
+    # a whole FILE by path, which is coarser than anything it stood in for.
+    # One owner means `//nolint:forbidigo // <reason>` works, and a waiver
+    # binds the line it sits on rather than the file it sits in.
+    #
+    # Two consequences of the move, both deliberate: the fmt.Print* and
+    # http.Error rules are now repo-wide rather than new-code-only, and the
+    # patterns below apply to the whole tree on every run.
     forbidigo:
       analyze-types: true
       forbid:
-        # The job-registration door, closed here rather than in
-        # .golangci.strict.yml: the strict pass is new-code-only
-        # (new-from-merge-base), and every registration site this binds is
-        # pre-existing. addDeclaredWorker's type parameter is what makes an
-        # undeclared kind unbuildable; any direct registration walks around
-        # that constraint, around jobs.Govern (so the worker answers River's
-        # option methods for itself again), and around the kind list
-        # jobs.MustBeTotal reads at boot.
+        # The job-registration door. addDeclaredWorker's type parameter is
+        # what makes an undeclared kind unbuildable; any direct registration
+        # walks around that constraint, around jobs.Govern (so the worker
+        # answers River's option methods for itself again), and around the
+        # kind list jobs.MustBeTotal reads at boot.
         #
         # ALL THREE of River's registration spellings, not just AddWorker:
         # AddWorkerArgs and AddWorkerSafely are equally unconstrained and
@@ -42,6 +54,17 @@ linters:
         - pattern: '^river\.PeriodicJobBundle\.'
           pkg: '^github\.com/riverqueue/river$'
           msg: "a periodic tick is api/jobs.yaml's to declare — give the kind a cadence: and let periodicFor build it; the bundle mutates the running schedule with an args type and an interval nothing in the contract has seen"
+        # Structured logging is the only logging: a fmt.Print* line carries
+        # no level, no correlation_id, and no fields, so it is invisible to
+        # every reader that joins a log line to an audit row and a bus event.
+        - pattern: '^fmt\.Print.*$'
+          msg: "use slog, not fmt.Print*"
+        # Every refusal this backend writes is an RFC 7807 problem document.
+        # http.Error writes text/plain, so a client that parses the contract's
+        # error shape meets an unparseable body on exactly the paths it needs
+        # most.
+        - pattern: '^http\.Error$'
+          msg: "ship RFC 7807 JSON via platform/httperr, not http.Error"
     depguard:
       rules:
         # Layer B of the boundary stack (ADR-0014 §3): the module DAG from
@@ -116,12 +139,11 @@ linters:
       # untestable from outside the contract.
       - path: '_test\.go$'
         linters: [forbidigo]
-      # jobregistry.go holds the ONE sanctioned river.AddWorker — the shared
-      # body addDeclaredWorker routes into. Excluded by path rather than by a
-      # //nolint, because the strict pass enables forbidigo with different
-      # patterns and its nolintlint would then read the directive as unused.
-      - path: 'internal/compose/jobregistry\.go$'
-        linters: [forbidigo]
+      # The ONE sanctioned river.AddWorker — the shared body addDeclaredWorker
+      # routes into — is waived IN SOURCE, on the line it applies to. There is
+      # deliberately no path exclusion for it: exempting the whole file would
+      # also exempt a second, unsanctioned registration added to it later,
+      # which is the gap the single-owner rule above exists to close.
 
 formatters:
   enable:

--- a/backend/cmd/worker/boothelpers_test.go
+++ b/backend/cmd/worker/boothelpers_test.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package main
+
+// The two boot phases run() delegates to. Both are one-liners around a
+// dependency, and both have exactly one failure the process must not survive:
+// a log level nobody meant, and an extension set that refused to register.
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestTheLoggerHonoursTheOperatorsLevelAndFormat — the level and the format
+// are the operator's, and a typo in either is a boot error rather than a
+// silent fallback to a level nobody asked for. A worker logging at the wrong
+// level looks healthy and says nothing.
+func TestTheLoggerHonoursTheOperatorsLevelAndFormat(t *testing.T) {
+	var out bytes.Buffer
+	log, err := newWorkerLogger(workerConfig{logLevel: "error", logFormat: "json"}, &out)
+	if err != nil {
+		t.Fatalf("newWorkerLogger: %v", err)
+	}
+
+	log.Info("this is below the configured level")
+	if out.Len() != 0 {
+		t.Errorf("an info line was written at level=error: %s", out.String())
+	}
+
+	log.Error("this one is not")
+	line := out.String()
+	if !strings.HasPrefix(strings.TrimSpace(line), "{") {
+		t.Errorf("format=json produced %q, which is not a JSON record", line)
+	}
+}
+
+func TestAnUnknownLogLevelOrFormatFailsTheBoot(t *testing.T) {
+	for _, tc := range []struct{ name, level, format string }{
+		{"level", "verbose", "text"},
+		{"format", "info", "logfmt"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var out bytes.Buffer
+			if _, err := newWorkerLogger(workerConfig{logLevel: tc.level, logFormat: tc.format}, &out); err == nil {
+				t.Errorf("an unknown %s was accepted; the operator would get a level or a format they did not ask for", tc.name)
+			}
+		})
+	}
+}
+
+// TestThisBuildsComposedExtensionSetRegisters — a failing registration aborts
+// the worker boot (ADR-0069 EXT-P4), so what this asserts is that the set THIS
+// build composes is one the boot survives. An extension whose declaration the
+// registry refuses fails here rather than at a customer's start-up.
+//
+// It does not compare the returned slice against composition.Extensions():
+// only a role's main may import the composition module, and TestCompositionWiredOnlyFromCmd
+// enforces that. The identity of the snapshot is a compile-time fact of run()
+// passing the returned value straight on to the boot inventory.
+func TestThisBuildsComposedExtensionSetRegisters(t *testing.T) {
+	if _, err := registerComposedExtensions(); err != nil {
+		t.Fatalf("this build's composed extension set refused to register, which aborts the worker boot: %v", err)
+	}
+}

--- a/backend/cmd/worker/boothelpers_test.go
+++ b/backend/cmd/worker/boothelpers_test.go
@@ -3,15 +3,85 @@
 
 package main
 
-// The two boot phases run() delegates to. Both are one-liners around a
-// dependency, and both have exactly one failure the process must not survive:
-// a log level nobody meant, and an extension set that refused to register.
+// The configuration phases run() delegates to before it opens anything. What
+// they share is the property the grouping exists for: none of them touches a
+// network, so every way a deployment can be misconfigured is refused while
+// there is nothing built to clean up.
 
 import (
 	"bytes"
+	"io"
+	"path/filepath"
 	"strings"
 	"testing"
 )
+
+// ONE test in this binary may drive configureWorker to completion.
+//
+// It registers the composed extension set into a PROCESS-GLOBAL registry, which
+// is a boot action and deliberately not idempotent: a second registration of
+// the same jurisdiction is refused, because in a running process that would
+// mean two packs claiming one jurisdiction. So the success path is exercised
+// once, below, and every other case here stops before that phase.
+
+// TestConfiguringTheWorkerFailsBeforeAnythingIsOpened is the property that
+// makes these phases one step: none of them opens a connection, so every way a
+// deployment can be misconfigured is refused while there is no pool, no bus
+// client and no listener to clean up. A phase that moved below the pool would
+// turn a typo into a half-built process.
+//
+// Both cases fail in the flag phase, ahead of the registration. The logger's
+// own refusal — the one phase after it — is driven directly by
+// TestAnUnknownLogLevelOrFormatFailsTheBoot instead.
+func TestConfiguringTheWorkerFailsBeforeAnythingIsOpened(t *testing.T) {
+	for _, tc := range []struct {
+		name, wantIn string
+		args         []string
+	}{
+		{"a missing dsn", "dsn", []string{}},
+		{"an interval no schedule can use", "runner-interval", []string{"--dsn", "postgres://localhost/x", "--runner-interval=0"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := configureWorker(tc.args, io.Discard)
+			if err == nil {
+				t.Fatalf("configureWorker(%v) succeeded; a misconfigured deployment must be refused here", tc.args)
+			}
+			if !strings.Contains(err.Error(), tc.wantIn) {
+				t.Errorf("the error does not name what was wrong (%q): %v", tc.wantIn, err)
+			}
+		})
+	}
+}
+
+// TestConfiguringTheWorkerCarriesTheDeploymentPostureOntoTheConfig is the
+// success path, and the only test here that reaches the extension registration.
+// A failing registration aborts the worker boot (ADR-0069 EXT-P4), so this also
+// asserts that the set THIS build composes is one the boot survives.
+//
+// The capture posture is resolved LAST, after the logger exists, because it
+// carries that logger into the Sink's post-commit steps where a fault is
+// reported rather than returned. Ordered the other way it would carry a nil.
+func TestConfiguringTheWorkerCarriesTheDeploymentPostureOntoTheConfig(t *testing.T) {
+	// A path with no file is a legitimate deployment: the docs say a missing
+	// config boots with defaults, so this exercises the whole chain rather
+	// than a fixture's contents.
+	boot, err := configureWorker([]string{
+		"--dsn", "postgres://localhost/x",
+		"--config", filepath.Join(t.TempDir(), "absent.yaml"),
+	}, io.Discard)
+	if err != nil {
+		t.Fatalf("configureWorker: %v — a composed extension set that refuses to register aborts the worker boot", err)
+	}
+	if boot.log == nil {
+		t.Error("no logger was built, so every phase after this one would report through nothing")
+	}
+	if boot.cfg.dsn != "postgres://localhost/x" {
+		t.Errorf("dsn = %q, want the one supplied", boot.cfg.dsn)
+	}
+	if boot.cfg.captureConfig.Logger == nil {
+		t.Error("the capture posture carries no logger; the Sink's post-commit steps report a fault through it, and a nil there is a panic on the one path that must not have one")
+	}
+}
 
 // TestTheLoggerHonoursTheOperatorsLevelAndFormat — the level and the format
 // are the operator's, and a typo in either is a boot error rather than a
@@ -47,20 +117,5 @@ func TestAnUnknownLogLevelOrFormatFailsTheBoot(t *testing.T) {
 				t.Errorf("an unknown %s was accepted; the operator would get a level or a format they did not ask for", tc.name)
 			}
 		})
-	}
-}
-
-// TestThisBuildsComposedExtensionSetRegisters — a failing registration aborts
-// the worker boot (ADR-0069 EXT-P4), so what this asserts is that the set THIS
-// build composes is one the boot survives. An extension whose declaration the
-// registry refuses fails here rather than at a customer's start-up.
-//
-// It does not compare the returned slice against composition.Extensions():
-// only a role's main may import the composition module, and TestCompositionWiredOnlyFromCmd
-// enforces that. The identity of the snapshot is a compile-time fact of run()
-// passing the returned value straight on to the boot inventory.
-func TestThisBuildsComposedExtensionSetRegisters(t *testing.T) {
-	if _, err := registerComposedExtensions(); err != nil {
-		t.Fatalf("this build's composed extension set refused to register, which aborts the worker boot: %v", err)
 	}
 }

--- a/backend/cmd/worker/boothelpers_test.go
+++ b/backend/cmd/worker/boothelpers_test.go
@@ -42,6 +42,10 @@ func TestConfiguringTheWorkerFailsBeforeAnythingIsOpened(t *testing.T) {
 		{"an interval no schedule can use", "runner-interval", []string{"--dsn", "postgres://localhost/x", "--runner-interval=0"}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			// --dsn backs its default with MARGINCE_DSN, so a CI that exports
+			// one would make the missing-dsn case boot successfully and this
+			// subtest fail for a reason that has nothing to do with the code.
+			t.Setenv("MARGINCE_DSN", "")
 			_, err := configureWorker(tc.args, io.Discard)
 			if err == nil {
 				t.Fatalf("configureWorker(%v) succeeded; a misconfigured deployment must be refused here", tc.args)

--- a/backend/cmd/worker/config.go
+++ b/backend/cmd/worker/config.go
@@ -109,9 +109,10 @@ func parseWorkerFlags(args []string) (workerConfig, error) {
 	// (compose.WebhookRetryConfig.Interval).
 	fs.DurationVar(&cfg.webhookRetryInterval, "webhook-retry-interval", 30*time.Second, "how often the outbound-webhook retry dispatcher fans one due-retry pass out per live workspace")
 	// Off by default, and off means no listener at all rather than one bound
-	// somewhere harmless: this surface carries workspace ids and has no
-	// authentication of its own, exactly like the api's, so exposing it is an
-	// operator's decision and so is the interface it binds.
+	// somewhere harmless. Unlike the api's /metrics it carries no workspace id
+	// and no tenant data — but it is unauthenticated and discloses dependency
+	// health and process capacity, so whether to expose it, and on which
+	// interface, is the operator's decision.
 	fs.StringVar(&cfg.observeAddr, "observe-addr", os.Getenv("MARGINCE_OBSERVE_ADDR"),
 		"address to serve this worker's /healthz, /readyz and /metrics on (e.g. 127.0.0.1:9101). Empty serves nothing. Process-local metrics only — the job-table and outbox gauges stay a single fleet-wide reading on the api.")
 	fs.StringVar(&cfg.logLevel, "log-level", envOr("MARGINCE_LOG_LEVEL", "info"), "log level: debug|info|warn|error")

--- a/backend/cmd/worker/config.go
+++ b/backend/cmd/worker/config.go
@@ -56,6 +56,7 @@ type workerConfig struct {
 	deepReadWall         time.Duration
 	logLevel             string
 	logFormat            string
+	observeAddr          string
 }
 
 // parseWorkerFlags parses and validates the boot flags; the DSN is the
@@ -92,21 +93,9 @@ func parseWorkerFlags(args []string) (workerConfig, error) {
 	fs.DurationVar(&cfg.gmailWatchRenew, "gmail-watch-renew-within", 48*time.Hour, "renew a Gmail watch this far ahead of its 7-day expiry")
 	fs.DurationVar(&cfg.overlayInterval, "overlay-reconcile-interval", 2*time.Minute, "overlay-mode incumbent mirror reconcile poll interval (design.md §4.4)")
 	fs.IntVar(&cfg.overlayBackfillLimit, "overlay-backfill-limit", 0, "cap the overlay initial mirror backfill at this many records per object class (dev/demo; 0 = uncapped)")
-	maxPagesDefault, err := envIntOr("MARGINCE_DEEPREAD_MAX_PAGES", 0)
-	if err != nil {
+	if err := registerDeepReadFlags(fs, &cfg); err != nil {
 		return workerConfig{}, err
 	}
-	maxBytesDefault, err := envIntOr("MARGINCE_DEEPREAD_MAX_BYTES", 0)
-	if err != nil {
-		return workerConfig{}, err
-	}
-	wallDefault, err := envDurationOr("MARGINCE_DEEPREAD_WALL", 0)
-	if err != nil {
-		return workerConfig{}, err
-	}
-	fs.IntVar(&cfg.deepReadMaxPages, "deepread-max-pages", maxPagesDefault, "deep-read crawl page cap; 0 takes the built-in default")
-	fs.IntVar(&cfg.deepReadMaxBytes, "deepread-max-bytes", maxBytesDefault, "deep-read crawl aggregate byte cap; 0 takes the built-in default")
-	fs.DurationVar(&cfg.deepReadWall, "deepread-wall", wallDefault, "deep-read crawl wall clock; 0 takes the built-in default")
 	// Outbound pacing. Zero on any of the three takes the compose default —
 	// a forgotten flag must degrade to the conservative rule, never to "no
 	// limit" or "defer forever".
@@ -119,6 +108,12 @@ func parseWorkerFlags(args []string) (workerConfig, error) {
 	// verbatim as the River schedule; compose clamps nothing
 	// (compose.WebhookRetryConfig.Interval).
 	fs.DurationVar(&cfg.webhookRetryInterval, "webhook-retry-interval", 30*time.Second, "how often the outbound-webhook retry dispatcher fans one due-retry pass out per live workspace")
+	// Off by default, and off means no listener at all rather than one bound
+	// somewhere harmless: this surface carries workspace ids and has no
+	// authentication of its own, exactly like the api's, so exposing it is an
+	// operator's decision and so is the interface it binds.
+	fs.StringVar(&cfg.observeAddr, "observe-addr", os.Getenv("MARGINCE_OBSERVE_ADDR"),
+		"address to serve this worker's /healthz, /readyz and /metrics on (e.g. 127.0.0.1:9101). Empty serves nothing. Process-local metrics only — the job-table and outbox gauges stay a single fleet-wide reading on the api.")
 	fs.StringVar(&cfg.logLevel, "log-level", envOr("MARGINCE_LOG_LEVEL", "info"), "log level: debug|info|warn|error")
 	fs.StringVar(&cfg.logFormat, "log-format", envOr("MARGINCE_LOG_FORMAT", "text"), "log format: text|json")
 	if err := fs.Parse(args); err != nil {
@@ -142,6 +137,31 @@ func parseWorkerFlags(args []string) (workerConfig, error) {
 		return workerConfig{}, err
 	}
 	return cfg, nil
+}
+
+// registerDeepReadFlags declares the three deep-read crawl caps. They are a
+// group of their own because each backs its flag default with an environment
+// variable that has to be READ before the flag is declared, and a set-but
+// unparseable value there is a boot error rather than a silent fallback to the
+// built-in — an operator who typed a cap and got the default instead would have
+// no way to tell.
+func registerDeepReadFlags(fs *flag.FlagSet, cfg *workerConfig) error {
+	maxPages, err := envIntOr("MARGINCE_DEEPREAD_MAX_PAGES", 0)
+	if err != nil {
+		return err
+	}
+	maxBytes, err := envIntOr("MARGINCE_DEEPREAD_MAX_BYTES", 0)
+	if err != nil {
+		return err
+	}
+	wall, err := envDurationOr("MARGINCE_DEEPREAD_WALL", 0)
+	if err != nil {
+		return err
+	}
+	fs.IntVar(&cfg.deepReadMaxPages, "deepread-max-pages", maxPages, "deep-read crawl page cap; 0 takes the built-in default")
+	fs.IntVar(&cfg.deepReadMaxBytes, "deepread-max-bytes", maxBytes, "deep-read crawl aggregate byte cap; 0 takes the built-in default")
+	fs.DurationVar(&cfg.deepReadWall, "deepread-wall", wall, "deep-read crawl wall clock; 0 takes the built-in default")
+	return nil
 }
 
 // validateSchedulerIntervals rejects a non-positive value for any duration

--- a/backend/cmd/worker/config_test.go
+++ b/backend/cmd/worker/config_test.go
@@ -65,6 +65,54 @@ func TestParseWorkerFlagsRejectsNonPositiveIntervals(t *testing.T) {
 	}
 }
 
+// TestADeepReadCapFromTheEnvironmentIsParsedOrRefused — each of the three
+// crawl caps backs its flag default with an environment variable, and a
+// set-but-unparseable value there is a boot error rather than a fallback to
+// the built-in. An operator who typed a cap and silently got the default
+// instead would have nothing to tell them the value never took.
+func TestADeepReadCapFromTheEnvironmentIsParsedOrRefused(t *testing.T) {
+	base := []string{"--dsn", "postgres://localhost/x"}
+	for _, tc := range []struct {
+		env, bad, good string
+		read           func(workerConfig) string
+	}{
+		{"MARGINCE_DEEPREAD_MAX_PAGES", "many", "7", func(c workerConfig) string { return itoa(c.deepReadMaxPages) }},
+		{"MARGINCE_DEEPREAD_MAX_BYTES", "8MiB", "4096", func(c workerConfig) string { return itoa(c.deepReadMaxBytes) }},
+		{"MARGINCE_DEEPREAD_WALL", "4 minutes", "1m30s", func(c workerConfig) string { return c.deepReadWall.String() }},
+	} {
+		t.Run(tc.env, func(t *testing.T) {
+			t.Setenv(tc.env, tc.bad)
+			if _, err := parseWorkerFlags(base); err == nil {
+				t.Errorf("%s=%q was accepted; an unparseable cap must fail the boot rather than fall back to the built-in default", tc.env, tc.bad)
+			} else if !strings.Contains(err.Error(), tc.env) {
+				t.Errorf("the error does not name the variable that failed: %v", err)
+			}
+
+			t.Setenv(tc.env, tc.good)
+			cfg, err := parseWorkerFlags(base)
+			if err != nil {
+				t.Fatalf("%s=%q: %v", tc.env, tc.good, err)
+			}
+			if got := tc.read(cfg); got != tc.good {
+				t.Errorf("%s=%q produced %q; the environment value must become the flag's default", tc.env, tc.good, got)
+			}
+		})
+	}
+}
+
+// itoa keeps the table above readable without a strconv import for one use.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var digits []byte
+	for n > 0 {
+		digits = append([]byte{byte('0' + n%10)}, digits...)
+		n /= 10
+	}
+	return string(digits)
+}
+
 // TestParseWorkerFlagsAcceptsPositiveIntervals proves the guard does not
 // reject the ordinary positive case (a smoke test so a stricter bound can
 // never silently reject a valid boot).

--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/compose"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/platform/deployconfig"
 	"github.com/gradionhq/margince/backend/internal/platform/events"
 	"github.com/gradionhq/margince/backend/internal/platform/httpserver"
 	kevents "github.com/gradionhq/margince/backend/internal/shared/kernel/events"
@@ -56,28 +57,11 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 		return err
 	}
 
-	cfg, err := parseWorkerFlags(args)
+	boot, err := configureWorker(args, stdout)
 	if err != nil {
 		return err
 	}
-
-	extensions, err := registerComposedExtensions()
-	if err != nil {
-		return err
-	}
-
-	deployCfg, err := loadDeployment(&cfg)
-	if err != nil {
-		return err
-	}
-
-	logger, err := newWorkerLogger(cfg, stdout)
-	if err != nil {
-		return err
-	}
-	// Set after the logger exists: the capture config carries it to the Sink's
-	// post-commit steps, where a fault is reported rather than returned.
-	cfg.captureConfig = compose.CaptureConfigFromDeploy(deployCfg.Capture, logger)
+	cfg, deployCfg, logger := boot.cfg, boot.deploy, boot.log
 
 	pool, err := database.NewPool(ctx, cfg.dsn)
 	if err != nil {
@@ -86,10 +70,10 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 	// Registered before the lanes' join below, so LIFO closes the pool after it.
 	defer pool.Close()
 
-	// Record the composed extension set when it changed since the last
-	// boot (ADR-0069 §5); pre-bootstrap it skips — the api records the
-	// first observation once it has bootstrapped the installation.
-	if err := compose.ObserveExtensionInventory(ctx, pool, logger, extensions); err != nil {
+	// Record the composed extension set when it changed since the last boot
+	// (ADR-0069 §5); pre-bootstrap it skips — the api records the first
+	// observation once it has bootstrapped the installation.
+	if err := compose.ObserveExtensionInventory(ctx, pool, logger, boot.extensions); err != nil {
 		return err
 	}
 
@@ -101,12 +85,15 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 	defer closeBus(rdb, logger)
 
 	// Before the lanes and the runner: a listener started after them reports
-	// nothing during exactly the window a slow boot needs explaining.
-	stopObserve, err := startObserveListener(ctx, cfg, pool, rdb, logger)
+	// nothing during exactly the window a slow boot needs explaining. /readyz
+	// answers "still starting" until started.complete below, so coming up
+	// early never makes this replica look ready before it can work.
+	started := &bootGate{}
+	observe, err := startObserveListener(ctx, cfg, pool, rdb, started, logger)
 	if err != nil {
 		return err
 	}
-	defer stopObserve()
+	defer observe.Stop()
 
 	//nolint:contextcheck // boot-time wiring: the model path outlives any request context (cmd/api resolves the same path under the same waiver)
 	modelPath, boundModels, err := selectModelPath(workerModelPathSpec(cfg, deployCfg), pool, logger)
@@ -129,6 +116,8 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 		return err
 	}
 	defer stopJobs()
+	// Every phase a replica needs to do work has returned; /readyz may say so.
+	started.complete()
 
 	relayUntilSignal(ctx, cfg, pool, rdb, logger, stdout)
 	return nil
@@ -147,6 +136,47 @@ func registerComposedExtensions() ([]extension.Extension, error) {
 		return nil, err
 	}
 	return extensions, nil
+}
+
+// workerBoot is everything decided before this process touches a network: the
+// parsed flags, the deployment file, the composed extension set, and the
+// logger the phases after it report through.
+type workerBoot struct {
+	cfg        workerConfig
+	deploy     deployconfig.Config
+	extensions []extension.Extension
+	log        *slog.Logger
+}
+
+// configureWorker runs the phases that can fail on configuration alone, in the
+// order they depend on each other: flags, then extensions (a failing
+// registration aborts the boot before anything is opened), then the deployment
+// file, then the logger — and the capture posture last, because it carries the
+// logger into the Sink's post-commit steps, where a fault is reported rather
+// than returned.
+//
+// Grouped because they share one property the phases after them do not: none
+// of them opens a connection, so a deployment misconfigured in any of these
+// ways fails before a pool, a bus client or a listener exists to clean up.
+func configureWorker(args []string, stdout io.Writer) (workerBoot, error) {
+	cfg, err := parseWorkerFlags(args)
+	if err != nil {
+		return workerBoot{}, err
+	}
+	extensions, err := registerComposedExtensions()
+	if err != nil {
+		return workerBoot{}, err
+	}
+	deployCfg, err := loadDeployment(&cfg)
+	if err != nil {
+		return workerBoot{}, err
+	}
+	log, err := newWorkerLogger(cfg, stdout)
+	if err != nil {
+		return workerBoot{}, err
+	}
+	cfg.captureConfig = compose.CaptureConfigFromDeploy(deployCfg.Capture, log)
+	return workerBoot{cfg: cfg, deploy: deployCfg, extensions: extensions, log: log}, nil
 }
 
 // newWorkerLogger builds this role's correlation-aware logger from the

--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -118,6 +118,11 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 	defer stopJobs()
 	// Every phase a replica needs to do work has returned; /readyz may say so.
 	started.complete()
+	// Deferred AFTER complete, so LIFO runs it FIRST: readiness goes false at
+	// the top of the shutdown, before the runner and the lanes are put down.
+	// The listener outlives both — it is stopped last — so a draining replica
+	// keeps answering, and what it answers is "stop sending me work".
+	defer started.draining()
 
 	relayUntilSignal(ctx, cfg, pool, rdb, logger, stdout)
 	return nil

--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/events"
 	"github.com/gradionhq/margince/backend/internal/platform/httpserver"
 	kevents "github.com/gradionhq/margince/backend/internal/shared/kernel/events"
+	"github.com/gradionhq/margince/backend/pkg/extension"
 )
 
 func main() {
@@ -60,12 +61,8 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 		return err
 	}
 
-	// Register the composed extension set before anything runs; a
-	// failing registration aborts the boot (ADR-0069 EXT-P4). ONE
-	// snapshot serves registration and the boot inventory below, so both
-	// observe the same declarations.
-	extensions := composition.Extensions()
-	if err := compose.RegisterExtensions(extensions); err != nil {
+	extensions, err := registerComposedExtensions()
+	if err != nil {
 		return err
 	}
 
@@ -74,11 +71,10 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 		return err
 	}
 
-	handler, err := httpserver.LogHandler(stdout, cfg.logLevel, cfg.logFormat)
+	logger, err := newWorkerLogger(cfg, stdout)
 	if err != nil {
 		return err
 	}
-	logger := slog.New(httpserver.WithCorrelation(handler))
 	// Set after the logger exists: the capture config carries it to the Sink's
 	// post-commit steps, where a fault is reported rather than returned.
 	cfg.captureConfig = compose.CaptureConfigFromDeploy(deployCfg.Capture, logger)
@@ -104,6 +100,14 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 	// Same ordering obligation as pool.Close above: the lanes read this client.
 	defer closeBus(rdb, logger)
 
+	// Before the lanes and the runner: a listener started after them reports
+	// nothing during exactly the window a slow boot needs explaining.
+	stopObserve, err := startObserveListener(ctx, cfg, pool, rdb, logger)
+	if err != nil {
+		return err
+	}
+	defer stopObserve()
+
 	//nolint:contextcheck // boot-time wiring: the model path outlives any request context (cmd/api resolves the same path under the same waiver)
 	modelPath, boundModels, err := selectModelPath(workerModelPathSpec(cfg, deployCfg), pool, logger)
 	if err != nil {
@@ -128,6 +132,33 @@ func run(ctx context.Context, args []string, stdout io.Writer) error {
 
 	relayUntilSignal(ctx, cfg, pool, rdb, logger, stdout)
 	return nil
+}
+
+// registerComposedExtensions registers the composed extension set before
+// anything else runs; a failing registration aborts the boot (ADR-0069 EXT-P4).
+//
+// It returns the SAME snapshot it registered, because run hands that value on
+// to the boot inventory: taking a second snapshot there would let the two
+// observe different declarations, and the inventory's whole job is to record
+// what this process is actually running.
+func registerComposedExtensions() ([]extension.Extension, error) {
+	extensions := composition.Extensions()
+	if err := compose.RegisterExtensions(extensions); err != nil {
+		return nil, err
+	}
+	return extensions, nil
+}
+
+// newWorkerLogger builds this role's correlation-aware logger from the
+// operator's --log-level and --log-format. Every process role shares the one
+// level/format vocabulary, and a typo in either is a boot error rather than a
+// silent fallback to a level nobody asked for.
+func newWorkerLogger(cfg workerConfig, stdout io.Writer) (*slog.Logger, error) {
+	handler, err := httpserver.LogHandler(stdout, cfg.logLevel, cfg.logFormat)
+	if err != nil {
+		return nil, err
+	}
+	return slog.New(httpserver.WithCorrelation(handler)), nil
 }
 
 // runResumeSubscriber consumes cg:overnight-agent: approval decisions

--- a/backend/cmd/worker/observe.go
+++ b/backend/cmd/worker/observe.go
@@ -114,8 +114,14 @@ func startObserveListener(ctx context.Context, cfg workerConfig, pool *pgxpool.P
 	mux.HandleFunc("/metrics", httpserver.Metrics(pool, nil, events.PublishedTotal, nil, nil, nil))
 
 	srv := &http.Server{
-		Addr:              cfg.observeAddr,
-		Handler:           httpserver.RecoverPanics(log, mux),
+		Addr: cfg.observeAddr,
+		// The same headers the api's chassis sets. This port serves no HTML
+		// and is not meant for a browser, which is exactly why nosniff and
+		// the rest are cheap here and worth having: an operator surface
+		// reachable from a browser tab should not depend on nobody opening
+		// one. RecoverPanics stays outermost so a panicking handler answers
+		// rather than killing the connection.
+		Handler:           httpserver.RecoverPanics(log, httpserver.SecureHeaders(mux)),
 		ReadHeaderTimeout: 5 * time.Second,
 		ReadTimeout:       observeReadTimeout,
 		WriteTimeout:      observeWriteTimeout,

--- a/backend/cmd/worker/observe.go
+++ b/backend/cmd/worker/observe.go
@@ -51,29 +51,40 @@ const (
 	observeShutdown     = 5 * time.Second
 )
 
-// bootGate reports whether this process has finished starting. /readyz is what
-// an orchestrator uses to decide a replica may be left in service, and the
-// listener comes up FIRST on purpose — answering a probe DURING boot is half
-// the reason to have one. Without this gate that ordering would make the
-// worker answer "ready" while the event lanes and the job runner were still
-// starting, so a rollout could retire the last working replica in favour of
-// one that had not yet picked up a job.
+// bootGate reports whether this replica is in a state to be left in service.
+// It answers no at BOTH ends of the process's life, and each end is a real
+// failure it exists to prevent:
 //
-// Atomic because the boot goroutine writes it while a scrape reads it.
-type bootGate struct{ done atomic.Bool }
+//   - Starting. The listener comes up FIRST on purpose — answering a probe
+//     during boot is half the reason to have one — so without this gate the
+//     worker would report ready while the event lanes and the job runner were
+//     still coming up, and a rollout could retire the last working replica in
+//     favour of one that had not yet picked up a job.
+//   - Draining. The probes keep serving through the whole shutdown, because
+//     the listener is stopped last so the drain itself stays observable. A
+//     terminating replica that still answered ready would keep being sent work
+//     it is in the middle of putting down.
+//
+// Atomic because the boot and signal paths write it while a scrape reads it.
+type bootGate struct{ ready atomic.Bool }
 
 // complete marks the boot finished. Called once, after the last phase that has
 // to be running before this replica can do any work.
-func (g *bootGate) complete() { g.done.Store(true) }
+func (g *bootGate) complete() { g.ready.Store(true) }
 
-// check is the ReadyCheck form. It reports what THIS process knows — whether
-// the phase that starts the runner returned — which is the honest substitute
-// for a River liveness accessor that does not exist.
+// draining marks the replica as leaving service. Called at the TOP of the
+// shutdown sequence, so readiness goes false before the job runner and the
+// lanes are put down rather than after.
+func (g *bootGate) draining() { g.ready.Store(false) }
+
+// check is the ReadyCheck form. It reports what THIS process knows about its
+// own lifecycle, which is the honest substitute for a River liveness accessor
+// that does not exist.
 func (g *bootGate) check(context.Context) error {
-	if g.done.Load() {
+	if g.ready.Load() {
 		return nil
 	}
-	return errors.New("the worker is still starting its event lanes and job runner")
+	return errors.New("the worker is not in service: it is still starting its event lanes and job runner, or already draining them")
 }
 
 // observeListener is a started operator surface: how to stop it, and the

--- a/backend/cmd/worker/observe.go
+++ b/backend/cmd/worker/observe.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// The worker role's operator surface: /healthz, /readyz and /metrics on a
+// listener of their own (OPS-MET-8's "every service").
+//
+// The worker is where the dispatchers actually run, and until this file it
+// published nothing at all. Every job-runtime gauge is served by cmd/api,
+// derived from river_job at request time, and that stays true — a job-table
+// projection is fleet-wide by construction and having two roles answer it
+// would mean two sources for one number. But it also means a single wedged
+// replica is indistinguishable from a healthy fleet: an operator could see
+// that work was not being done and not which process was failing to do it.
+//
+// So this listener carries only what is PROCESS-LOCAL and therefore differs
+// per target — the Go runtime, this process's own pool, this process's relay
+// counter. It re-serves no job-table gauge, and passes a nil outbox backlog
+// for the same reason: that read is the api's, and a second copy of a
+// fleet-wide number is a worse operator surface than one copy.
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/redis/go-redis/v9"
+
+	"github.com/gradionhq/margince/backend/internal/platform/events"
+	"github.com/gradionhq/margince/backend/internal/platform/httpserver"
+)
+
+// observeShutdown bounds the listener's own drain. A probe or a scrape is a
+// short request by construction — the metrics handler carries a 2s budget of
+// its own — so a window barely above that is enough to let one in flight
+// finish, and short enough that the observability surface never delays the
+// job drain behind it.
+const observeShutdown = 5 * time.Second
+
+// startObserveListener serves the worker's probes and metrics on cfg.observeAddr.
+//
+// An empty address is OFF, and off is the DEFAULT: this is an operator surface
+// with no authentication of its own — it carries workspace ids, exactly as the
+// api's does — so a deployment opts into exposing it and chooses the interface
+// it binds. Returning a no-op stop for that case keeps the caller's defer
+// unconditional; a boot that silently bound something the operator did not ask
+// for would be the worse failure.
+//
+// The listen is done HERE rather than inside the goroutine so a busy port or a
+// malformed address fails the boot with a message naming it, instead of being
+// logged into a process that carries on looking healthy.
+func startObserveListener(ctx context.Context, cfg workerConfig, pool *pgxpool.Pool, rdb *redis.Client, log *slog.Logger) (func(), error) {
+	if cfg.observeAddr == "" {
+		return func() {}, nil
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", httpserver.Healthz)
+	mux.HandleFunc("/readyz", httpserver.Readyz("", nil, workerReadyChecks(pool, rdb)...))
+	// nil backlog: the outbox backlog is a fleet-wide read the api already
+	// serves. nil jobStats and nil overlay for the same reason — both are
+	// projections of shared tables, not of this process.
+	mux.HandleFunc("/metrics", httpserver.Metrics(pool, nil, events.PublishedTotal, nil, nil, nil))
+
+	srv := &http.Server{
+		Addr:              cfg.observeAddr,
+		Handler:           httpserver.RecoverPanics(log, mux),
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	listener, err := (&net.ListenConfig{}).Listen(ctx, "tcp", cfg.observeAddr)
+	if err != nil {
+		return nil, fmt.Errorf("worker: --observe-addr %s: %w", cfg.observeAddr, err)
+	}
+	log.Info("worker observability listener", "addr", listener.Addr().String())
+
+	go func() {
+		if err := srv.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Error("worker observability listener stopped", "err", err)
+		}
+	}()
+
+	return func() {
+		// Its own window, detached from the run context: at shutdown that
+		// context is already cancelled, and passing it would turn every
+		// graceful drain into an immediate close.
+		stopCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), observeShutdown)
+		defer cancel()
+		if err := srv.Shutdown(stopCtx); err != nil {
+			log.Warn("stopping the worker observability listener", "err", err)
+		}
+	}, nil
+}
+
+// workerReadyChecks are the dependencies this role cannot work without: the
+// database it reads and writes every job through, and the bus its subscribers
+// consume from. Both are probed, because a worker that has one and not the
+// other is half a worker and reads as ready on a check of either alone.
+//
+// Deliberately NOT a check on the job runner: River's client has no exported
+// liveness accessor, so any answer here would be this file's guess about a
+// dependency's internals rather than a reading of it.
+func workerReadyChecks(pool *pgxpool.Pool, rdb *redis.Client) []httpserver.ReadyCheck {
+	return []httpserver.ReadyCheck{
+		{Name: "postgres", Check: pool.Ping},
+		{Name: "redis", Check: func(ctx context.Context) error { return rdb.Ping(ctx).Err() }},
+	}
+}

--- a/backend/cmd/worker/observe.go
+++ b/backend/cmd/worker/observe.go
@@ -16,7 +16,9 @@
 // per target — the Go runtime, this process's own pool, this process's relay
 // counter. It re-serves no job-table gauge, and passes a nil outbox backlog
 // for the same reason: that read is the api's, and a second copy of a
-// fleet-wide number is a worse operator surface than one copy.
+// fleet-wide number is a worse operator surface than one copy. It carries no
+// workspace id and no tenant data at all, which is what makes it a NARROWER
+// surface than the api's /metrics rather than a second copy of it.
 package main
 
 import (
@@ -26,6 +28,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"sync/atomic"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -35,33 +38,76 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/httpserver"
 )
 
-// observeShutdown bounds the listener's own drain. A probe or a scrape is a
-// short request by construction — the metrics handler carries a 2s budget of
-// its own — so a window barely above that is enough to let one in flight
-// finish, and short enough that the observability surface never delays the
-// job drain behind it.
-const observeShutdown = 5 * time.Second
+// The listener's own time bounds. Every request it serves is a probe or a
+// scrape — short by construction, and the metrics handler carries a 2s budget
+// of its own — so these are generous for the traffic and tight enough that an
+// unauthenticated client cannot hold a connection, and the goroutine behind
+// it, open indefinitely. observeShutdown is the drain window: barely above the
+// scrape budget, so this surface never delays the job drain behind it.
+const (
+	observeReadTimeout  = 10 * time.Second
+	observeWriteTimeout = 10 * time.Second
+	observeIdleTimeout  = 30 * time.Second
+	observeShutdown     = 5 * time.Second
+)
+
+// bootGate reports whether this process has finished starting. /readyz is what
+// an orchestrator uses to decide a replica may be left in service, and the
+// listener comes up FIRST on purpose — answering a probe DURING boot is half
+// the reason to have one. Without this gate that ordering would make the
+// worker answer "ready" while the event lanes and the job runner were still
+// starting, so a rollout could retire the last working replica in favour of
+// one that had not yet picked up a job.
+//
+// Atomic because the boot goroutine writes it while a scrape reads it.
+type bootGate struct{ done atomic.Bool }
+
+// complete marks the boot finished. Called once, after the last phase that has
+// to be running before this replica can do any work.
+func (g *bootGate) complete() { g.done.Store(true) }
+
+// check is the ReadyCheck form. It reports what THIS process knows — whether
+// the phase that starts the runner returned — which is the honest substitute
+// for a River liveness accessor that does not exist.
+func (g *bootGate) check(context.Context) error {
+	if g.done.Load() {
+		return nil
+	}
+	return errors.New("the worker is still starting its event lanes and job runner")
+}
+
+// observeListener is a started operator surface: how to stop it, and the
+// address it actually bound.
+//
+// Addr is the empty string when the surface is OFF and the resolved address
+// otherwise — a caller that asked for :0 gets the port the kernel chose. It is
+// returned rather than only logged so that "nothing was bound" is a value a
+// caller can check rather than an absence it has to infer.
+type observeListener struct {
+	Stop func()
+	Addr string
+}
 
 // startObserveListener serves the worker's probes and metrics on cfg.observeAddr.
 //
 // An empty address is OFF, and off is the DEFAULT: this is an operator surface
-// with no authentication of its own — it carries workspace ids, exactly as the
-// api's does — so a deployment opts into exposing it and chooses the interface
-// it binds. Returning a no-op stop for that case keeps the caller's defer
+// with no authentication of its own, so a deployment opts into exposing it and
+// chooses the interface it binds. Returning a no-op stop for that case keeps
+// the caller's defer
 // unconditional; a boot that silently bound something the operator did not ask
 // for would be the worse failure.
 //
 // The listen is done HERE rather than inside the goroutine so a busy port or a
 // malformed address fails the boot with a message naming it, instead of being
 // logged into a process that carries on looking healthy.
-func startObserveListener(ctx context.Context, cfg workerConfig, pool *pgxpool.Pool, rdb *redis.Client, log *slog.Logger) (func(), error) {
+func startObserveListener(ctx context.Context, cfg workerConfig, pool *pgxpool.Pool, rdb *redis.Client, boot *bootGate, log *slog.Logger) (observeListener, error) {
 	if cfg.observeAddr == "" {
-		return func() {}, nil
+		return observeListener{Stop: func() {}}, nil
 	}
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", httpserver.Healthz)
-	mux.HandleFunc("/readyz", httpserver.Readyz("", nil, workerReadyChecks(pool, rdb)...))
+	mux.HandleFunc("/readyz", httpserver.Readyz("", nil, workerReadyChecks(pool, rdb, boot)...))
 	// nil backlog: the outbox backlog is a fleet-wide read the api already
 	// serves. nil jobStats and nil overlay for the same reason — both are
 	// projections of shared tables, not of this process.
@@ -71,12 +117,16 @@ func startObserveListener(ctx context.Context, cfg workerConfig, pool *pgxpool.P
 		Addr:              cfg.observeAddr,
 		Handler:           httpserver.RecoverPanics(log, mux),
 		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       observeReadTimeout,
+		WriteTimeout:      observeWriteTimeout,
+		IdleTimeout:       observeIdleTimeout,
 	}
 	listener, err := (&net.ListenConfig{}).Listen(ctx, "tcp", cfg.observeAddr)
 	if err != nil {
-		return nil, fmt.Errorf("worker: --observe-addr %s: %w", cfg.observeAddr, err)
+		return observeListener{}, fmt.Errorf("worker: --observe-addr %s: %w", cfg.observeAddr, err)
 	}
-	log.Info("worker observability listener", "addr", listener.Addr().String())
+	bound := listener.Addr().String()
+	log.Info("worker observability listener", "addr", bound)
 
 	go func() {
 		if err := srv.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
@@ -84,7 +134,7 @@ func startObserveListener(ctx context.Context, cfg workerConfig, pool *pgxpool.P
 		}
 	}()
 
-	return func() {
+	return observeListener{Addr: bound, Stop: func() {
 		// Its own window, detached from the run context: at shutdown that
 		// context is already cancelled, and passing it would turn every
 		// graceful drain into an immediate close.
@@ -93,19 +143,22 @@ func startObserveListener(ctx context.Context, cfg workerConfig, pool *pgxpool.P
 		if err := srv.Shutdown(stopCtx); err != nil {
 			log.Warn("stopping the worker observability listener", "err", err)
 		}
-	}, nil
+	}}, nil
 }
 
-// workerReadyChecks are the dependencies this role cannot work without: the
-// database it reads and writes every job through, and the bus its subscribers
-// consume from. Both are probed, because a worker that has one and not the
-// other is half a worker and reads as ready on a check of either alone.
+// workerReadyChecks are what this replica needs before it can do any work: its
+// own boot having finished, the database every job is read and written
+// through, and the bus its subscribers consume from. All three are probed,
+// because a worker missing any one of them is not doing the work while
+// answering a check of the others perfectly.
 //
-// Deliberately NOT a check on the job runner: River's client has no exported
-// liveness accessor, so any answer here would be this file's guess about a
-// dependency's internals rather than a reading of it.
-func workerReadyChecks(pool *pgxpool.Pool, rdb *redis.Client) []httpserver.ReadyCheck {
+// Deliberately NOT a check on the River client itself: it exposes no liveness
+// accessor, so any answer here would be this file's guess about a dependency's
+// internals rather than a reading of it. The boot gate is what stands in its
+// place, and it reports only what this process actually knows.
+func workerReadyChecks(pool *pgxpool.Pool, rdb *redis.Client, boot *bootGate) []httpserver.ReadyCheck {
 	return []httpserver.ReadyCheck{
+		{Name: "boot", Check: boot.check},
 		{Name: "postgres", Check: pool.Ping},
 		{Name: "redis", Check: func(ctx context.Context) error { return rdb.Ping(ctx).Err() }},
 	}

--- a/backend/cmd/worker/observe_integration_test.go
+++ b/backend/cmd/worker/observe_integration_test.go
@@ -117,6 +117,29 @@ func TestEachDeclaredReadinessCheckCanActuallyFail(t *testing.T) {
 		}
 	})
 
+	t.Run("draining", func(t *testing.T) {
+		// The other end of the same gate. run() defers draining() AFTER
+		// complete(), so LIFO puts it ahead of the job-runner stop: a replica
+		// that has begun shutting down must stop being sent work while it is
+		// still putting down what it holds. The listener outlives the drain —
+		// it is stopped last — which is exactly why the answer has to change.
+		boot := bootedGate()
+		base := startProbeListener(t, workerTestPool(t), budgettest.Client(t), boot)
+		if status, _ := get(t, base+"/readyz"); status != http.StatusOK {
+			t.Fatalf("GET /readyz = %d before the drain, want 200", status)
+		}
+
+		boot.draining()
+
+		status, body := get(t, base+"/readyz")
+		if status != http.StatusServiceUnavailable {
+			t.Fatalf("GET /readyz = %d once shutdown began, want 503 — a draining replica must leave the pool", status)
+		}
+		if !strings.Contains(body, "boot") {
+			t.Errorf("the 503 body does not name the lifecycle check: %q", body)
+		}
+	})
+
 	t.Run("redis", func(t *testing.T) {
 		// Same shape for the bus, pointed at an address nothing listens on:
 		// that is what a bus outage looks like from inside this process, and

--- a/backend/cmd/worker/observe_integration_test.go
+++ b/backend/cmd/worker/observe_integration_test.go
@@ -64,6 +64,14 @@ func TestTheWorkerReadinessProbeAnswersFromItsRealDependencies(t *testing.T) {
 	if !strings.HasPrefix(body, "ready") {
 		t.Errorf("GET /readyz body = %q, want it to start with %q", body, "ready")
 	}
+	// The visibility lines the shared probe renders are reached only on the
+	// 200 path — a failing check returns before them — so this is the one
+	// place the omission can be asserted rather than passed over. The worker
+	// wires no AI lane, and an empty "ai: " reads as a state that could not be
+	// DETERMINED rather than as one that does not apply.
+	if strings.Contains(body, "ai:") {
+		t.Errorf("the worker reports an AI line it wires nothing for: %q", body)
+	}
 
 	_, metrics := get(t, base+"/metrics")
 	if !strings.Contains(metrics, "margince_pgxpool_conns") {

--- a/backend/cmd/worker/observe_integration_test.go
+++ b/backend/cmd/worker/observe_integration_test.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package main
+
+// The worker's readiness probe against its REAL dependencies. It is here
+// rather than in the unit lane because the probe's whole content is whether
+// those dependencies answer: a stubbed pool and bus would prove the stub, and
+// a readiness check that cannot fail is indistinguishable from one that always
+// passes.
+
+import (
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/platform/overlaybudget/budgettest"
+)
+
+// TestTheWorkerReadinessProbeAnswersFromItsRealDependencies — an orchestrator
+// reads /readyz to decide whether this replica should be left in service, and
+// the answer has to come from the database and the bus this process actually
+// holds. Both are named in the 200 body's checks by passing, and the pool
+// section of /metrics is asserted alongside because a pool wired here and not
+// there would mean the two surfaces disagree about the same process.
+func TestTheWorkerReadinessProbeAnswersFromItsRealDependencies(t *testing.T) {
+	pool := workerTestPool(t)
+	rdb := budgettest.Client(t)
+
+	probe, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserving a port: %v", err)
+	}
+	addr := probe.Addr().String()
+	if err := probe.Close(); err != nil {
+		t.Fatalf("releasing the reserved port: %v", err)
+	}
+
+	stop, err := startObserveListener(t.Context(), workerConfig{observeAddr: addr}, pool, rdb, quietLog())
+	if err != nil {
+		t.Fatalf("startObserveListener: %v", err)
+	}
+	t.Cleanup(stop)
+
+	status, body := get(t, "http://"+addr+"/readyz")
+	if status != http.StatusOK {
+		t.Fatalf("GET /readyz = %d (%s), want 200 with a live pool and bus", status, strings.TrimSpace(body))
+	}
+	if !strings.HasPrefix(body, "ready") {
+		t.Errorf("GET /readyz body = %q, want it to start with %q", body, "ready")
+	}
+
+	_, metrics := get(t, "http://"+addr+"/metrics")
+	if !strings.Contains(metrics, "margince_pgxpool_conns") {
+		t.Errorf("the worker published no pool gauges for a pool it holds; /readyz and /metrics "+
+			"would then disagree about the same process\ngot:\n%s", metrics)
+	}
+}
+
+// TestAnUnreachableDependencyMakesTheWorkerUnready is the other half, and the
+// one that makes the probe worth serving: a closed pool must produce a 503
+// naming the dependency, not a 200. A check that only ever passes tells an
+// orchestrator nothing it did not already assume.
+func TestAnUnreachableDependencyMakesTheWorkerUnready(t *testing.T) {
+	pool := workerTestPool(t)
+	rdb := budgettest.Client(t)
+
+	probe, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserving a port: %v", err)
+	}
+	addr := probe.Addr().String()
+	if err := probe.Close(); err != nil {
+		t.Fatalf("releasing the reserved port: %v", err)
+	}
+
+	stop, err := startObserveListener(t.Context(), workerConfig{observeAddr: addr}, pool, rdb, quietLog())
+	if err != nil {
+		t.Fatalf("startObserveListener: %v", err)
+	}
+	t.Cleanup(stop)
+
+	// Closing the pool is what a database outage looks like from inside this
+	// process: every acquire fails from here on. The pool is this test's own —
+	// workerTestPool opens one per test — so nothing else is reading it.
+	pool.Close()
+
+	status, body := get(t, "http://"+addr+"/readyz")
+	if status != http.StatusServiceUnavailable {
+		t.Fatalf("GET /readyz = %d, want 503 with the database gone", status)
+	}
+	if !strings.Contains(body, "postgres") {
+		t.Errorf("the 503 body does not name the failed dependency: %q", body)
+	}
+}

--- a/backend/cmd/worker/observe_integration_test.go
+++ b/backend/cmd/worker/observe_integration_test.go
@@ -10,89 +10,125 @@ package main
 // those dependencies answer: a stubbed pool and bus would prove the stub, and
 // a readiness check that cannot fail is indistinguishable from one that always
 // passes.
+//
+// So every check the probe declares is driven BOTH ways below — ready, and
+// then broken one dependency at a time. A check nobody can break is one that
+// could be deleted with every test still green, which is the same as not
+// having it.
 
 import (
-	"net"
 	"net/http"
 	"strings"
 	"testing"
 
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/redis/go-redis/v9"
+
 	"github.com/gradionhq/margince/backend/internal/platform/overlaybudget/budgettest"
 )
+
+// startProbeListener brings the surface up on a kernel-chosen port against the
+// dependencies given, and answers its base URL.
+func startProbeListener(t *testing.T, pool *pgxpool.Pool, rdb *redis.Client, boot *bootGate) string {
+	t.Helper()
+	observe, err := startObserveListener(t.Context(),
+		workerConfig{observeAddr: "127.0.0.1:0"}, pool, rdb, boot, quietLog())
+	if err != nil {
+		t.Fatalf("startObserveListener: %v", err)
+	}
+	t.Cleanup(observe.Stop)
+	return "http://" + observe.Addr
+}
+
+// bootedGate is a gate already marked complete — the state a replica is in
+// once run() has started its lanes and its job runner.
+func bootedGate() *bootGate {
+	var boot bootGate
+	boot.complete()
+	return &boot
+}
 
 // TestTheWorkerReadinessProbeAnswersFromItsRealDependencies — an orchestrator
 // reads /readyz to decide whether this replica should be left in service, and
 // the answer has to come from the database and the bus this process actually
-// holds. Both are named in the 200 body's checks by passing, and the pool
-// section of /metrics is asserted alongside because a pool wired here and not
-// there would mean the two surfaces disagree about the same process.
+// holds. The pool section of /metrics is asserted alongside, because a pool
+// wired into one surface and not the other would mean the two disagree about
+// the same process.
 func TestTheWorkerReadinessProbeAnswersFromItsRealDependencies(t *testing.T) {
-	pool := workerTestPool(t)
-	rdb := budgettest.Client(t)
+	base := startProbeListener(t, workerTestPool(t), budgettest.Client(t), bootedGate())
 
-	probe, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("reserving a port: %v", err)
-	}
-	addr := probe.Addr().String()
-	if err := probe.Close(); err != nil {
-		t.Fatalf("releasing the reserved port: %v", err)
-	}
-
-	stop, err := startObserveListener(t.Context(), workerConfig{observeAddr: addr}, pool, rdb, quietLog())
-	if err != nil {
-		t.Fatalf("startObserveListener: %v", err)
-	}
-	t.Cleanup(stop)
-
-	status, body := get(t, "http://"+addr+"/readyz")
+	status, body := get(t, base+"/readyz")
 	if status != http.StatusOK {
-		t.Fatalf("GET /readyz = %d (%s), want 200 with a live pool and bus", status, strings.TrimSpace(body))
+		t.Fatalf("GET /readyz = %d (%s), want 200 with a booted replica, a live pool and a live bus", status, strings.TrimSpace(body))
 	}
 	if !strings.HasPrefix(body, "ready") {
 		t.Errorf("GET /readyz body = %q, want it to start with %q", body, "ready")
 	}
 
-	_, metrics := get(t, "http://"+addr+"/metrics")
+	_, metrics := get(t, base+"/metrics")
 	if !strings.Contains(metrics, "margince_pgxpool_conns") {
 		t.Errorf("the worker published no pool gauges for a pool it holds; /readyz and /metrics "+
 			"would then disagree about the same process\ngot:\n%s", metrics)
 	}
 }
 
-// TestAnUnreachableDependencyMakesTheWorkerUnready is the other half, and the
-// one that makes the probe worth serving: a closed pool must produce a 503
-// naming the dependency, not a 200. A check that only ever passes tells an
-// orchestrator nothing it did not already assume.
-func TestAnUnreachableDependencyMakesTheWorkerUnready(t *testing.T) {
-	pool := workerTestPool(t)
-	rdb := budgettest.Client(t)
+// TestEachDeclaredReadinessCheckCanActuallyFail drives all three the other
+// way. Each arm breaks exactly ONE dependency and asserts the 503 names that
+// one: an arm that passed because a different check failed would prove nothing
+// about the check it is named for.
+func TestEachDeclaredReadinessCheckCanActuallyFail(t *testing.T) {
+	t.Run("boot", func(t *testing.T) {
+		// A gate never marked complete is the state during boot. The listener
+		// comes up before the lanes and the runner on purpose, so this is the
+		// window a rollout must not read as ready.
+		base := startProbeListener(t, workerTestPool(t), budgettest.Client(t), &bootGate{})
 
-	probe, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("reserving a port: %v", err)
-	}
-	addr := probe.Addr().String()
-	if err := probe.Close(); err != nil {
-		t.Fatalf("releasing the reserved port: %v", err)
-	}
+		status, body := get(t, base+"/readyz")
+		if status != http.StatusServiceUnavailable {
+			t.Fatalf("GET /readyz = %d, want 503 while the lanes and the job runner are still starting", status)
+		}
+		if !strings.Contains(body, "boot") {
+			t.Errorf("the 503 body does not name the boot check: %q", body)
+		}
+	})
 
-	stop, err := startObserveListener(t.Context(), workerConfig{observeAddr: addr}, pool, rdb, quietLog())
-	if err != nil {
-		t.Fatalf("startObserveListener: %v", err)
-	}
-	t.Cleanup(stop)
+	t.Run("postgres", func(t *testing.T) {
+		// Closing the pool is what a database outage looks like from inside
+		// this process: every acquire fails from here on. The pool is this
+		// subtest's own, so nothing else is reading it.
+		pool := workerTestPool(t)
+		base := startProbeListener(t, pool, budgettest.Client(t), bootedGate())
+		pool.Close()
 
-	// Closing the pool is what a database outage looks like from inside this
-	// process: every acquire fails from here on. The pool is this test's own —
-	// workerTestPool opens one per test — so nothing else is reading it.
-	pool.Close()
+		status, body := get(t, base+"/readyz")
+		if status != http.StatusServiceUnavailable {
+			t.Fatalf("GET /readyz = %d, want 503 with the database gone", status)
+		}
+		if !strings.Contains(body, "postgres") {
+			t.Errorf("the 503 body does not name the failed dependency: %q", body)
+		}
+	})
 
-	status, body := get(t, "http://"+addr+"/readyz")
-	if status != http.StatusServiceUnavailable {
-		t.Fatalf("GET /readyz = %d, want 503 with the database gone", status)
-	}
-	if !strings.Contains(body, "postgres") {
-		t.Errorf("the 503 body does not name the failed dependency: %q", body)
-	}
+	t.Run("redis", func(t *testing.T) {
+		// Same shape for the bus, pointed at an address nothing listens on:
+		// that is what a bus outage looks like from inside this process, and
+		// unlike closing the shared test client it leaves no other test's
+		// dependency broken. Without this arm the redis check could be deleted
+		// outright and every other test here would stay green.
+		unreachable := redis.NewClient(&redis.Options{Addr: "127.0.0.1:1"})
+		t.Cleanup(func() {
+			if err := unreachable.Close(); err != nil {
+				t.Errorf("closing the unreachable bus client: %v", err)
+			}
+		})
+		base := startProbeListener(t, workerTestPool(t), unreachable, bootedGate())
+
+		status, body := get(t, base+"/readyz")
+		if status != http.StatusServiceUnavailable {
+			t.Fatalf("GET /readyz = %d, want 503 with the bus gone", status)
+		}
+		if !strings.Contains(body, "redis") {
+			t.Errorf("the 503 body does not name the failed dependency: %q", body)
+		}
+	})
 }

--- a/backend/cmd/worker/observe_test.go
+++ b/backend/cmd/worker/observe_test.go
@@ -197,21 +197,6 @@ func TestTheWorkerSurfaceSetsTheSameBrowserFacingHeadersAsTheApi(t *testing.T) {
 	}
 }
 
-// TestTheWorkerReadinessBodyOmitsTheLineItWiresNothingFor — the shared probe
-// renders an AI visibility line for the roles that have one. The worker has
-// none, and an empty "ai: " reads as a role whose AI state could not be
-// determined rather than as one that has no AI at all: worse than silence,
-// because an operator has to learn to ignore it.
-func TestTheWorkerReadinessBodyOmitsTheLineItWiresNothingFor(t *testing.T) {
-	// A nil pool makes the postgres check fail, so this is the 503 body — the
-	// one an operator reads when something is wrong, and the one that must
-	// name the failed dependency and nothing it does not wire.
-	_, body := get(t, startForTest(t)+"/readyz")
-	if strings.Contains(body, "ai:") {
-		t.Errorf("the worker reports an AI line it wires nothing for: %q", body)
-	}
-}
-
 // TestTheWorkerMetricsOmitThePoolSectionRatherThanZeroingIt — a role wired
 // without a pool must publish no pool gauges at all. A zero-valued section
 // reads exactly like an idle pool, which is the reading an operator would act

--- a/backend/cmd/worker/observe_test.go
+++ b/backend/cmd/worker/observe_test.go
@@ -17,32 +17,29 @@ import (
 // under test is what it SERVES, not what it says about itself.
 func quietLog() *slog.Logger { return slog.New(slog.DiscardHandler) }
 
-// startForTest brings the listener up on a kernel-chosen port and answers its
-// base URL. A fixed port would make two packages' tests collide on a busy
-// machine, which reads as a flake in whichever ran second.
+// startForTest brings the listener up on a port the KERNEL chooses and answers
+// its base URL, read back from the listener itself. Asking for :0 and reading
+// Addr leaves no window: reserving a port, closing it and re-binding would let
+// another process take it in between, which reads as a flake rather than as
+// the race it is.
 func startForTest(t *testing.T) string {
 	t.Helper()
-
-	probe, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("reserving a port: %v", err)
-	}
-	addr := probe.Addr().String()
-	if err := probe.Close(); err != nil {
-		t.Fatalf("releasing the reserved port: %v", err)
-	}
 
 	// A nil pool and bus are enough for the two endpoints asserted below:
 	// /healthz reads nothing, and the metrics handler omits the pool section
 	// when it was handed none. /readyz is the one endpoint that would call
 	// into them, and it is the integration lane's to prove against real
 	// dependencies rather than against a stub that would only restate itself.
-	stop, err := startObserveListener(t.Context(), workerConfig{observeAddr: addr}, nil, nil, quietLog())
+	observe, err := startObserveListener(t.Context(), workerConfig{observeAddr: "127.0.0.1:0"},
+		nil, nil, &bootGate{}, quietLog())
 	if err != nil {
 		t.Fatalf("startObserveListener: %v", err)
 	}
-	t.Cleanup(stop)
-	return "http://" + addr
+	t.Cleanup(observe.Stop)
+	if observe.Addr == "" {
+		t.Fatal("a configured address bound nothing")
+	}
+	return "http://" + observe.Addr
 }
 
 // get fetches one path and answers its status and body.
@@ -68,20 +65,27 @@ func get(t *testing.T, url string) (int, string) {
 	return resp.StatusCode, string(body)
 }
 
-// TestAnUnconfiguredObserveAddressServesNothing — off is the default, and off
+// TestAnUnconfiguredObserveAddressBindsNothing — off is the default, and off
 // has to mean no listener rather than one bound somewhere the operator did not
-// choose. The stop function must still be callable, because the caller defers
-// it unconditionally and a nil there would panic every worker that never
-// enabled the surface.
-func TestAnUnconfiguredObserveAddressServesNothing(t *testing.T) {
-	stop, err := startObserveListener(t.Context(), workerConfig{}, nil, nil, quietLog())
+// choose. The bound address is what proves it: a listener opened anywhere would
+// report the address it took, so the empty string is the absence itself rather
+// than an absence inferred from a call that did not error.
+//
+// The stop function must still be callable, because the caller defers it
+// unconditionally and a nil there would panic every worker that never enabled
+// the surface.
+func TestAnUnconfiguredObserveAddressBindsNothing(t *testing.T) {
+	observe, err := startObserveListener(t.Context(), workerConfig{}, nil, nil, &bootGate{}, quietLog())
 	if err != nil {
 		t.Fatalf("an empty --observe-addr must be a legitimate configuration, got: %v", err)
 	}
-	if stop == nil {
+	if observe.Addr != "" {
+		t.Errorf("an empty --observe-addr bound %s; off must mean no listener at all", observe.Addr)
+	}
+	if observe.Stop == nil {
 		t.Fatal("no stop function returned; run() defers it unconditionally and would panic")
 	}
-	stop()
+	observe.Stop()
 }
 
 // TestAnUnusableObserveAddressFailsTheBoot — the listen happens during boot
@@ -99,10 +103,10 @@ func TestAnUnusableObserveAddressFailsTheBoot(t *testing.T) {
 		}
 	})
 
-	stop, err := startObserveListener(t.Context(),
-		workerConfig{observeAddr: held.Addr().String()}, nil, nil, quietLog())
+	observe, err := startObserveListener(t.Context(),
+		workerConfig{observeAddr: held.Addr().String()}, nil, nil, &bootGate{}, quietLog())
 	if err == nil {
-		stop()
+		observe.Stop()
 		t.Fatal("binding a port already in use succeeded; a worker that could not serve its probes must fail its boot")
 	}
 	if !strings.Contains(err.Error(), held.Addr().String()) {

--- a/backend/cmd/worker/observe_test.go
+++ b/backend/cmd/worker/observe_test.go
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package main
+
+import (
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+// quietLog keeps a listener's own log lines out of the test output; what is
+// under test is what it SERVES, not what it says about itself.
+func quietLog() *slog.Logger { return slog.New(slog.DiscardHandler) }
+
+// startForTest brings the listener up on a kernel-chosen port and answers its
+// base URL. A fixed port would make two packages' tests collide on a busy
+// machine, which reads as a flake in whichever ran second.
+func startForTest(t *testing.T) string {
+	t.Helper()
+
+	probe, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserving a port: %v", err)
+	}
+	addr := probe.Addr().String()
+	if err := probe.Close(); err != nil {
+		t.Fatalf("releasing the reserved port: %v", err)
+	}
+
+	// A nil pool and bus are enough for the two endpoints asserted below:
+	// /healthz reads nothing, and the metrics handler omits the pool section
+	// when it was handed none. /readyz is the one endpoint that would call
+	// into them, and it is the integration lane's to prove against real
+	// dependencies rather than against a stub that would only restate itself.
+	stop, err := startObserveListener(t.Context(), workerConfig{observeAddr: addr}, nil, nil, quietLog())
+	if err != nil {
+		t.Fatalf("startObserveListener: %v", err)
+	}
+	t.Cleanup(stop)
+	return "http://" + addr
+}
+
+// get fetches one path and answers its status and body.
+func get(t *testing.T, url string) (int, string) {
+	t.Helper()
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatalf("building a request for %s: %v", url, err)
+	}
+	resp, err := (&http.Client{Timeout: 5 * time.Second}).Do(req)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			t.Errorf("closing the response body: %v", err)
+		}
+	}()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("reading the response to %s: %v", url, err)
+	}
+	return resp.StatusCode, string(body)
+}
+
+// TestAnUnconfiguredObserveAddressServesNothing — off is the default, and off
+// has to mean no listener rather than one bound somewhere the operator did not
+// choose. The stop function must still be callable, because the caller defers
+// it unconditionally and a nil there would panic every worker that never
+// enabled the surface.
+func TestAnUnconfiguredObserveAddressServesNothing(t *testing.T) {
+	stop, err := startObserveListener(t.Context(), workerConfig{}, nil, nil, quietLog())
+	if err != nil {
+		t.Fatalf("an empty --observe-addr must be a legitimate configuration, got: %v", err)
+	}
+	if stop == nil {
+		t.Fatal("no stop function returned; run() defers it unconditionally and would panic")
+	}
+	stop()
+}
+
+// TestAnUnusableObserveAddressFailsTheBoot — the listen happens during boot
+// rather than inside the serving goroutine, so a busy port or a malformed
+// address stops the process with a message naming it. Logged instead, the
+// worker would carry on looking healthy while publishing nothing.
+func TestAnUnusableObserveAddressFailsTheBoot(t *testing.T) {
+	held, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("holding a port: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := held.Close(); err != nil {
+			t.Errorf("releasing the held port: %v", err)
+		}
+	})
+
+	stop, err := startObserveListener(t.Context(),
+		workerConfig{observeAddr: held.Addr().String()}, nil, nil, quietLog())
+	if err == nil {
+		stop()
+		t.Fatal("binding a port already in use succeeded; a worker that could not serve its probes must fail its boot")
+	}
+	if !strings.Contains(err.Error(), held.Addr().String()) {
+		t.Errorf("the error does not name the address that failed: %v", err)
+	}
+}
+
+// TestTheWorkerServesItsLivenessProbe — the point of the listener: an
+// orchestrator can ask this process whether it is alive at all.
+func TestTheWorkerServesItsLivenessProbe(t *testing.T) {
+	status, body := get(t, startForTest(t)+"/healthz")
+	if status != http.StatusOK {
+		t.Errorf("GET /healthz = %d, want 200", status)
+	}
+	if body != "ok" {
+		t.Errorf("GET /healthz body = %q, want %q", body, "ok")
+	}
+}
+
+// TestTheWorkerMetricsAreProcessLocalAndReServeNoFleetGauge is the boundary
+// the whole listener rests on. What this role adds is per-REPLICA visibility:
+// the fleet-wide readings stay a single copy on the api, because two roles
+// answering one number is a worse operator surface than one gap. A section
+// added here that reads a shared table would silently recreate that.
+func TestTheWorkerMetricsAreProcessLocalAndReServeNoFleetGauge(t *testing.T) {
+	status, body := get(t, startForTest(t)+"/metrics")
+	if status != http.StatusOK {
+		t.Fatalf("GET /metrics = %d, want 200", status)
+	}
+
+	for _, family := range []string{
+		"margince_process_goroutines",
+		"margince_process_heap_bytes",
+		"margince_process_heap_sys_bytes",
+		"margince_process_gc_cycles_total",
+		"margince_relay_published_total",
+	} {
+		if !strings.Contains(body, "# TYPE "+family+" ") {
+			t.Errorf("the worker publishes no %s; it is process-local and served nowhere else\ngot:\n%s", family, body)
+		}
+	}
+
+	// Each of these is a projection of a table every role shares, so the api's
+	// copy is the fleet's one reading of it.
+	for _, family := range []string{
+		"margince_job_queue_depth",
+		"margince_job_declared_info",
+		"margince_sweep_workspaces_total",
+		"margince_sweep_units_total",
+		"margince_outbox_unpublished",
+	} {
+		if strings.Contains(body, family) {
+			t.Errorf("the worker re-serves %s, which is a fleet-wide reading the api already answers; "+
+				"two sources for one number is worse than one\ngot:\n%s", family, body)
+		}
+	}
+}
+
+// TestTheWorkerMetricsOmitThePoolSectionRatherThanZeroingIt — a role wired
+// without a pool must publish no pool gauges at all. A zero-valued section
+// reads exactly like an idle pool, which is the reading an operator would act
+// on; the same "declared or absent" posture every other section takes.
+func TestTheWorkerMetricsOmitThePoolSectionRatherThanZeroingIt(t *testing.T) {
+	_, body := get(t, startForTest(t)+"/metrics")
+	if strings.Contains(body, "margince_pgxpool_conns") {
+		t.Errorf("a nil pool produced pool gauges, which read as an idle pool rather than as no pool\ngot:\n%s", body)
+	}
+}

--- a/backend/cmd/worker/observe_test.go
+++ b/backend/cmd/worker/observe_test.go
@@ -165,6 +165,53 @@ func TestTheWorkerMetricsAreProcessLocalAndReServeNoFleetGauge(t *testing.T) {
 	}
 }
 
+// TestTheWorkerSurfaceSetsTheSameBrowserFacingHeadersAsTheApi — this port
+// serves no HTML and is not meant for a browser, which is exactly why the
+// headers are worth setting rather than skipping: an operator surface reachable
+// from a browser tab must not depend on nobody opening one. The api's chassis
+// sets them on everything it answers; a second HTTP surface in the same product
+// answering without them is a difference nobody chose.
+func TestTheWorkerSurfaceSetsTheSameBrowserFacingHeadersAsTheApi(t *testing.T) {
+	base := startForTest(t)
+	for _, path := range []string{"/healthz", "/readyz", "/metrics"} {
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, base+path, nil)
+		if err != nil {
+			t.Fatalf("building a request for %s: %v", path, err)
+		}
+		resp, err := (&http.Client{Timeout: 5 * time.Second}).Do(req)
+		if err != nil {
+			t.Fatalf("GET %s: %v", path, err)
+		}
+		if err := resp.Body.Close(); err != nil {
+			t.Errorf("closing the response body: %v", err)
+		}
+		for header, want := range map[string]string{
+			"X-Content-Type-Options": "nosniff",
+			"X-Frame-Options":        "DENY",
+			"Referrer-Policy":        "no-referrer",
+		} {
+			if got := resp.Header.Get(header); got != want {
+				t.Errorf("GET %s: %s = %q, want %q", path, header, got, want)
+			}
+		}
+	}
+}
+
+// TestTheWorkerReadinessBodyOmitsTheLineItWiresNothingFor — the shared probe
+// renders an AI visibility line for the roles that have one. The worker has
+// none, and an empty "ai: " reads as a role whose AI state could not be
+// determined rather than as one that has no AI at all: worse than silence,
+// because an operator has to learn to ignore it.
+func TestTheWorkerReadinessBodyOmitsTheLineItWiresNothingFor(t *testing.T) {
+	// A nil pool makes the postgres check fail, so this is the 503 body — the
+	// one an operator reads when something is wrong, and the one that must
+	// name the failed dependency and nothing it does not wire.
+	_, body := get(t, startForTest(t)+"/readyz")
+	if strings.Contains(body, "ai:") {
+		t.Errorf("the worker reports an AI line it wires nothing for: %q", body)
+	}
+}
+
 // TestTheWorkerMetricsOmitThePoolSectionRatherThanZeroingIt — a role wired
 // without a pool must publish no pool gauges at all. A zero-valued section
 // reads exactly like an idle pool, which is the reading an operator would act

--- a/backend/internal/compose/agentsplit.go
+++ b/backend/internal/compose/agentsplit.go
@@ -163,7 +163,7 @@ func applyAutoExecuteAndStageResidue(w http.ResponseWriter, r *http.Request, nex
 			"fields %s were last edited by a human and were NOT applied; staged as approval %s — once a human approves it, repeat this request with ONLY those fields and the %s: %s header",
 			strings.Join(split.Conflicts, ", "), approvalID, approvalTokenHeader, approvalID),
 	}
-	buffered.flushJSON(w, record)
+	buffered.flushJSON(w, r, record)
 }
 
 // recordVersion pins the staged residue to the record version the auto-execute
@@ -221,13 +221,16 @@ func (b *bufferedResponse) flushTo(w http.ResponseWriter) {
 
 // flushJSON replays the buffered status and headers with a re-encoded
 // JSON body (the Content-Length of the original no longer applies).
-func (b *bufferedResponse) flushJSON(w http.ResponseWriter, payload map[string]any) {
+func (b *bufferedResponse) flushJSON(w http.ResponseWriter, r *http.Request, payload map[string]any) {
 	body, err := json.Marshal(payload)
 	if err != nil {
 		// Marshaling a map decoded from JSON cannot fail in practice; if
 		// it ever does, the staging already exists — report rather than
-		// send a truncated record.
-		http.Error(w, "re-encoding the split update response failed", http.StatusInternalServerError)
+		// send a truncated record. Through httperr like every other
+		// refusal on this surface: a client parsing RFC 7807 must not meet
+		// a text/plain body on one path out of a handler, and the marshal
+		// error itself stays server-side.
+		httperr.Write(w, r, fmt.Errorf("re-encoding the split update response failed: %w", err))
 		return
 	}
 	copyHeaders(w, b.header)

--- a/backend/internal/compose/agentsplit_test.go
+++ b/backend/internal/compose/agentsplit_test.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The buffered response the split gate replays through. What matters here is
+// the shape of what reaches the wire: a client of this surface parses RFC 7807
+// on every refusal, so one path out of the handler answering something else is
+// a client that cannot read its own error.
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// bufferedFor builds a buffered response already holding a status and headers,
+// as it would after the wrapped handler answered.
+func bufferedFor(status string) *bufferedResponse {
+	b := newBufferedResponse()
+	b.header.Set("Content-Type", "application/json")
+	b.header.Set("X-Recorded", status)
+	return b
+}
+
+func TestFlushJSONReplacesTheBodyAndItsContentLength(t *testing.T) {
+	b := bufferedFor("ok")
+	b.WriteHeader(http.StatusOK)
+	if _, err := b.Write([]byte(`{"id":"1"}`)); err != nil {
+		t.Fatalf("buffering the original body: %v", err)
+	}
+	rec := httptest.NewRecorder()
+
+	b.flushJSON(rec, httptest.NewRequest(http.MethodPatch, "/v1/deals/1", nil),
+		map[string]any{"id": "1", "staged_approval": map[string]any{"approval_id": "a1"}})
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want the buffered 200", rec.Code)
+	}
+	if got := rec.Header().Get("X-Recorded"); got != "ok" {
+		t.Errorf("the buffered headers were dropped: X-Recorded = %q", got)
+	}
+	body := rec.Body.String()
+	// The Content-Length of the ORIGINAL body no longer applies, and a stale
+	// one truncates the record for every client that honours it.
+	if got, want := rec.Header().Get("Content-Length"), len(body); got != "" && got != itoa(want) {
+		t.Errorf("Content-Length = %q, want %d — the length of what was actually written", got, want)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal([]byte(body), &decoded); err != nil {
+		t.Fatalf("the replayed body is not JSON: %v (%s)", err, body)
+	}
+	if _, staged := decoded["staged_approval"]; !staged {
+		t.Errorf("the staging note was not spliced into the replayed record: %s", body)
+	}
+}
+
+// unmarshalable is a payload value encoding/json refuses. A map decoded from
+// JSON cannot hold one in production — which is exactly why the branch needs a
+// test: it is unreachable by the handler and would otherwise never run.
+type unmarshalable struct{}
+
+func (unmarshalable) MarshalJSON() ([]byte, error) { return nil, errNotEncodable }
+
+var errNotEncodable = &json.UnsupportedValueError{Str: "deliberately unencodable"}
+
+// TestFlushJSONAnswersAMarshalFailureAsAProblemDocument — the staging already
+// exists at this point, so the client must be told the request failed rather
+// than handed a truncated record. Through httperr like every other refusal on
+// this surface: a text/plain body here is one a client parsing the contract's
+// error shape cannot read, on the path it needs most.
+func TestFlushJSONAnswersAMarshalFailureAsAProblemDocument(t *testing.T) {
+	b := bufferedFor("ok")
+	b.WriteHeader(http.StatusOK)
+	rec := httptest.NewRecorder()
+
+	b.flushJSON(rec, httptest.NewRequest(http.MethodPatch, "/v1/deals/1", nil),
+		map[string]any{"boom": unmarshalable{}})
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500 — the staging exists and the record could not be built", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.Contains(ct, "problem+json") {
+		t.Errorf("Content-Type = %q, want an RFC 7807 problem document", ct)
+	}
+	// The marshal error names Go internals; it belongs in the server log.
+	if strings.Contains(rec.Body.String(), "unencodable") {
+		t.Errorf("the marshal error leaked to the client: %s", rec.Body.String())
+	}
+}
+
+// itoa keeps the length comparison above readable without pulling strconv into
+// a file that needs it once.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var digits []byte
+	for n > 0 {
+		digits = append([]byte{byte('0' + n%10)}, digits...)
+		n /= 10
+	}
+	return string(digits)
+}

--- a/backend/internal/compose/capturejobs.go
+++ b/backend/internal/compose/capturejobs.go
@@ -323,14 +323,18 @@ func (w *captureBackfillWorker) Work(ctx context.Context, job *river.Job[Capture
 // against it would drop the freshly-imported history off the morning screen
 // until the nightly pass.
 //
-// The Safely variant is deliberate: a unit test may drive Work directly with
-// no River client in context, and the plain ClientFromContext PANICS there —
-// a best-effort enqueue must degrade to a no-op, never crash the pager. A
-// failed enqueue never fails the backfill either; the nightly pass still
-// covers the workspace.
+// The Safely variant is deliberate: the plain ClientFromContext PANICS when
+// there is no client, and a best-effort enqueue must degrade rather than crash
+// the pager. River puts the client in every Work context, so its absence means
+// this method was reached from somewhere that is not a running job — which is
+// worth a line, because silently returning is indistinguishable from having
+// enqueued. Neither branch fails the backfill: the nightly pass still covers
+// the workspace, and a completed import is not undone by a missing digest.
 func (w *captureBackfillWorker) enqueueDigest(ctx context.Context, args CaptureBackfillArgs) {
 	client, err := river.ClientFromContextSafely[pgx.Tx](ctx)
 	if err != nil {
+		w.log.WarnContext(ctx, "capture backfill: no River client in context, so the same-day digest was not enqueued",
+			"backfill", args.BackfillID, "err", err)
 		return
 	}
 	child := CaptureDigestWorkspaceArgs{Workspace: args.Workspace}

--- a/backend/internal/compose/capturejobs.go
+++ b/backend/internal/compose/capturejobs.go
@@ -290,12 +290,12 @@ func (w *captureBackfillWorker) Work(ctx context.Context, job *river.Job[Capture
 			return nil
 		}
 		if completed {
-			// The connect-time import just closed: build today's digest now so
-			// the morning screen reflects the freshly-imported history instead
-			// of waiting for the nightly pass. Best-effort — a failed enqueue
-			// never fails the backfill (the nightly run still covers it), and
-			// the digest job is unique-by-state so a duplicate offer is inert.
-			w.enqueueDigest(ctx, job.Args.BackfillID)
+			// The connect-time import just closed: build today's digest for
+			// THIS workspace now, so the morning screen reflects the
+			// freshly-imported history instead of waiting for the nightly
+			// pass. Best-effort — a failed enqueue never fails the backfill,
+			// which the nightly run still covers.
+			w.enqueueDigest(ctx, job.Args)
 		}
 		if done {
 			return nil
@@ -304,27 +304,39 @@ func (w *captureBackfillWorker) Work(ctx context.Context, job *river.Job[Capture
 	return river.JobSnooze(time.Second)
 }
 
-// enqueueDigest offers a same-day digest build through the ambient River
-// client; the digest worker rebuilds the day idempotently (as-of-now truths).
+// enqueueDigest offers a same-day digest build for THIS workspace through the
+// ambient River client; the digest worker rebuilds the day idempotently
+// (as-of-now truths).
+//
+// The child kind, never the dispatcher. The finishing tenant is known here, and
+// CaptureDigestArgs is a fleet fan-out: enqueueing it would run every workspace
+// in the installation because one of them imported its history, and N tenants
+// finishing together would run the fleet N times. The intent is local, so the
+// enqueue is too — which also leaves the fan-out path exclusively the
+// dispatcher's, so a digest pass in the sweep gauges is one a clock scheduled.
+//
+// oneOffChildOpts carries the queue and attempt cap the contract declares for
+// the kind, and states there why a one-off deliberately takes neither the sweep
+// tag nor the active-state uniqueness the fleet's children carry. The second of
+// those matters here in particular: a digest already RUNNING may have
+// snapshotted the workspace BEFORE this backfill's rows landed, and deduping
+// against it would drop the freshly-imported history off the morning screen
+// until the nightly pass.
+//
 // The Safely variant is deliberate: a unit test may drive Work directly with
 // no River client in context, and the plain ClientFromContext PANICS there —
-// a best-effort enqueue must degrade to a no-op, never crash the pager.
-//
-// No active-state uniqueness here (unlike the periodic sweep): a digest that
-// is already RUNNING may have snapshotted the workspace BEFORE this backfill's
-// rows landed, so deduping against it would drop the freshly-imported history
-// off the morning screen until the nightly pass. A completion must guarantee a
-// rebuild that sees its own data, so it always enqueues a fresh one — cheap
-// and idempotent (the build replaces the day). One completion fires once, so
-// this is not a fan-out.
-func (w *captureBackfillWorker) enqueueDigest(ctx context.Context, backfillID string) {
+// a best-effort enqueue must degrade to a no-op, never crash the pager. A
+// failed enqueue never fails the backfill either; the nightly pass still
+// covers the workspace.
+func (w *captureBackfillWorker) enqueueDigest(ctx context.Context, args CaptureBackfillArgs) {
 	client, err := river.ClientFromContextSafely[pgx.Tx](ctx)
 	if err != nil {
 		return
 	}
-	if _, err := client.Insert(ctx, CaptureDigestArgs{}, nil); err != nil {
+	child := CaptureDigestWorkspaceArgs{Workspace: args.Workspace}
+	if _, err := client.Insert(ctx, child, oneOffChildOpts(child.Kind())); err != nil {
 		w.log.WarnContext(ctx, "capture backfill: digest enqueue failed",
-			"backfill", backfillID, "err", err)
+			"backfill", args.BackfillID, "err", err)
 	}
 }
 

--- a/backend/internal/compose/capturejobs_integration_test.go
+++ b/backend/internal/compose/capturejobs_integration_test.go
@@ -15,12 +15,14 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"slices"
 	"testing"
 	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/riverqueue/river"
 
+	"github.com/gradionhq/margince/backend/internal/platform/jobs"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -72,6 +74,11 @@ func TestBackfillCompletionBuildsTheDigest(t *testing.T) {
 	// Drain the boot digest so the next one cannot be it — nor deduped by it.
 	awaitKindCompleted(waitCtx, t, sub, CaptureDigestWorkspaceArgs{}.Kind())
 
+	// The boot pass placed its own dispatcher row, so "no dispatcher exists" is
+	// not the claim to make — "the completion added none" is. Read the count
+	// before the backfill runs and hold it to that afterwards.
+	dispatchersBefore := countJobsOfKind(ctx, t, b, CaptureDigestArgs{}.Kind())
+
 	// Now schedule the backfill; the worker pages it to done and enqueues the
 	// same-day digest off the completion edge.
 	if err := runner.Enqueue(ctx, CaptureBackfillArgs{
@@ -82,6 +89,66 @@ func TestBackfillCompletionBuildsTheDigest(t *testing.T) {
 	awaitKindCompleted(waitCtx, t, sub, "capture_backfill")
 	// The digest that follows the completed backfill is the payoff wiring.
 	awaitKindCompleted(waitCtx, t, sub, CaptureDigestWorkspaceArgs{}.Kind())
+
+	// The waits above are satisfied by a digest of the right KIND, which the
+	// boot pass also produces — they prove the wiring fires, not WHAT it
+	// fires. What follows is the fix itself, and each half fails silently on a
+	// single-workspace fixture, where a fleet fan-out and a one-off enqueue
+	// produce the same visible outcome.
+
+	// A dispatcher row added here would be one workspace's backfill running
+	// the digest for every workspace in the installation.
+	if after := countJobsOfKind(ctx, t, b, CaptureDigestArgs{}.Kind()); after != dispatchersBefore {
+		t.Errorf("capture_digest rows went %d -> %d across the backfill; a completion must enqueue the "+
+			"CHILD kind for its own workspace, never the dispatcher that fans out over the whole fleet",
+			dispatchersBefore, after)
+	}
+
+	// An UNTAGGED child for this workspace is what a one-off enqueue looks
+	// like, and it is the row the boot fan-out cannot have written: every
+	// child of a fleet pass is tagged at the dispatch chokepoint. So finding
+	// one is proof the completion enqueued it, and proof it will not be
+	// counted as a fleet pass by the sweep gauges.
+	rows, err := b.env.Pool.Query(ctx,
+		`SELECT coalesce(args->>'workspace_id', ''), tags FROM river_job WHERE kind = $1 ORDER BY id`,
+		CaptureDigestWorkspaceArgs{}.Kind())
+	if err != nil {
+		t.Fatalf("reading digest rows: %v", err)
+	}
+	defer rows.Close()
+
+	var oneOffs int
+	for rows.Next() {
+		var workspace string
+		var tags []string
+		if err := rows.Scan(&workspace, &tags); err != nil {
+			t.Fatalf("scanning a digest row: %v", err)
+		}
+		if slices.Contains(tags, jobs.SweepTag) {
+			continue // the boot fan-out's own child
+		}
+		oneOffs++
+		if workspace != b.env.WS.String() {
+			t.Errorf("the one-off digest names workspace %q, want the finishing tenant's %q", workspace, b.env.WS)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("reading digest rows: %v", err)
+	}
+	if oneOffs != 1 {
+		t.Errorf("%d untagged capture_digest_workspace row(s), want exactly 1 — the completion's own digest, "+
+			"tagged as a fleet pass or never enqueued at all", oneOffs)
+	}
+}
+
+// countJobsOfKind answers how many river_job rows of a kind exist right now.
+func countJobsOfKind(ctx context.Context, t *testing.T, b *backfillWireEnv, kind string) int {
+	t.Helper()
+	var n int
+	if err := b.env.Pool.QueryRow(ctx, `SELECT count(*) FROM river_job WHERE kind = $1`, kind).Scan(&n); err != nil {
+		t.Fatalf("counting %s rows: %v", kind, err)
+	}
+	return n
 }
 
 func TestCaptureOvernightJobsRegisterAndRun(t *testing.T) {

--- a/backend/internal/compose/capturejobs_integration_test.go
+++ b/backend/internal/compose/capturejobs_integration_test.go
@@ -92,9 +92,9 @@ func TestBackfillCompletionBuildsTheDigest(t *testing.T) {
 
 	// The waits above are satisfied by a digest of the right KIND, which the
 	// boot pass also produces — they prove the wiring fires, not WHAT it
-	// fires. What follows is the fix itself, and each half fails silently on a
-	// single-workspace fixture, where a fleet fan-out and a one-off enqueue
-	// produce the same visible outcome.
+	// fires. The two assertions below tell a one-off workspace child from a
+	// fleet dispatcher, which on a single-workspace fixture produce the same
+	// visible outcome and are otherwise indistinguishable.
 
 	// A dispatcher row added here would be one workspace's backfill running
 	// the digest for every workspace in the installation.

--- a/backend/internal/compose/dispatch.go
+++ b/backend/internal/compose/dispatch.go
@@ -97,6 +97,35 @@ func workspaceSweepOpts(childKind string) *river.InsertOpts {
 	})
 }
 
+// oneOffChildOpts is workspaceSweepOpts' counterpart for the same child kind
+// enqueued for ONE already-known workspace by an event — a tenant's backfill
+// finishing, not a clock reaching a fleet. It reads the queue and the attempt
+// cap from the same declaration, so the two doors cannot route one workspace's
+// pass onto a queue the fleet's share of it never lands on.
+//
+// It deliberately omits BOTH of the things that make a fleet child a fleet
+// child, and each omission is the point rather than an oversight:
+//
+//   - No sweep tag. The tag is what lets a reader tell one workspace's share
+//     of a fleet pass from the same kind enqueued for its own reason, and the
+//     sweep gauges count tagged rows. A one-off tagged as a fleet pass would
+//     inflate the coverage reading of a pass that never ran.
+//   - No active-state uniqueness. The event's whole claim is that new rows
+//     landed, and a pass already RUNNING may have read the workspace before
+//     they did. Deduplicating against it would drop exactly the data the
+//     event fired about, and the caller would have no way to tell.
+//
+// Both are safe to omit only because a one-off enqueue is a single insert for
+// a single known workspace: it fires once per event, so nothing here bounds a
+// fan-out that could otherwise repeat per tick.
+func oneOffChildOpts(childKind string) *river.InsertOpts {
+	spec := fanOutChildSpec(childKind)
+	if spec.OptsOwner != jobs.OptsFanOut {
+		panic("compose: " + childKind + " declares an opts_owner other than fan_out, so its queue and attempt cap are not this helper's to set")
+	}
+	return &river.InsertOpts{Queue: spec.Queue, MaxAttempts: spec.MaxAttempts}
+}
+
 // fanOutChildren is every kind some dispatcher DECLARES it fans out to —
 // api/jobs.yaml's fans_out_to, read as the registry it is. Computed once
 // because a per-connection dispatcher consults it once per insert.

--- a/backend/internal/compose/dispatch.go
+++ b/backend/internal/compose/dispatch.go
@@ -73,8 +73,15 @@ const (
 
 // workspaceSweepOpts is the enqueue policy for one fanned-out child, read
 // from the child kind's own declaration. Taking the KIND rather than the
-// numbers is what makes the sweep tag unforgettable: a fan-out child's opts
+// numbers is what makes the sweep tag unforgettable: a FLEET PASS's child opts
 // are built here or in fanOutChildOpts and nowhere else, and both stamp it.
+//
+// oneOffChildOpts below builds the same kinds' opts WITHOUT the tag, and is
+// the only thing that does. That is not a hole in the argument, it is the
+// distinction the tag exists to draw: a job enqueued for one already-known
+// workspace by an event is not one workspace's share of a fleet pass, and the
+// helper takes no fleet as an argument, so it cannot be reached from a
+// dispatcher's loop by accident.
 //
 // The attempt cap is small on every fan-out kind because a fanned-out pass's
 // real retry cadence is the dispatcher's tick — a workspace that fails is
@@ -293,12 +300,14 @@ func fanOutChildOpts(childKind string, callerOpts *river.InsertOpts) *river.Inse
 // row. Tags are validated for format only and take no part in River's
 // unique key, so this changes no scheduling behaviour.
 //
-// Every production caller is in this file. A fan-out child's opts are built by
-// workspaceSweepOpts (a fleet insert) or fanOutChildOpts (a single one) and
+// Every production caller is in this file. A FLEET PASS's child opts are built
+// by workspaceSweepOpts (a fleet insert) or fanOutChildOpts (a single one) and
 // nowhere else, and both stamp the tag — so a dispatcher cannot forget it,
 // which is what an untagged child costs: silent absence from the sweep
 // gauges, while the gauge's own HELP text blames River's retention for the
-// gap. WHICH kinds may be fanned out to is the contract's to say and not this
+// gap. The third builder of the same kinds' opts, oneOffChildOpts, omits the
+// tag deliberately and states why; it is reachable only from a site that
+// already knows the one workspace it is enqueueing for. WHICH kinds may be fanned out to is the contract's to say and not this
 // comment's: fans_out_to in api/jobs.yaml is the registry, and both builders
 // refuse a kind no dispatcher declares there.
 //

--- a/backend/internal/compose/dispatch_test.go
+++ b/backend/internal/compose/dispatch_test.go
@@ -226,6 +226,47 @@ func TestFanOutChildOptsRefusesACallerOwnedKindWithNoOpts(t *testing.T) {
 	fanOutChildOpts(VoiceBuildArgs{}.Kind(), nil)
 }
 
+// A one-off child takes the same declared queue and attempt cap the fleet's
+// children take — routing one workspace's pass onto a different queue is drift
+// the contract exists to make impossible — and takes NEITHER of the two things
+// that would make it read as a fleet pass. Both omissions are asserted, because
+// a value that merely happened not to carry them is one field away from doing
+// so, and neither failure is visible at the call site.
+func TestOneOffChildOptsTakeTheDeclaredQueueButNotTheFleetPassMarkings(t *testing.T) {
+	kind := CaptureDigestWorkspaceArgs{}.Kind()
+	spec := specFor(t, kind)
+	opts := oneOffChildOpts(kind)
+
+	if opts.Queue != spec.Queue {
+		t.Errorf("Queue = %q, want the declared %q", opts.Queue, spec.Queue)
+	}
+	if opts.MaxAttempts != spec.MaxAttempts {
+		t.Errorf("MaxAttempts = %d, want the declared %d", opts.MaxAttempts, spec.MaxAttempts)
+	}
+	if slices.Contains(opts.Tags, jobs.SweepTag) {
+		t.Errorf("Tags = %v, want no %q — a job one tenant's backfill asked for is not one "+
+			"workspace's share of a fleet pass, and the sweep gauges count tagged rows",
+			opts.Tags, jobs.SweepTag)
+	}
+	if len(opts.UniqueOpts.ByState) != 0 {
+		t.Errorf("ByState = %v, want none — the event fired BECAUSE new rows landed, and an "+
+			"already-running pass may have read the workspace before they did",
+			opts.UniqueOpts.ByState)
+	}
+}
+
+// The same guard workspaceSweepOpts carries: a kind whose queue and attempt cap
+// are owned elsewhere must not have them supplied here either, or a one-off
+// would publish numbers the contract does not govern for that kind.
+func TestOneOffChildOptsRefusesAKindWhoseOptsItDoesNotOwn(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Error("a kind whose opts_owner is not fan_out must not silently get fan-out opts")
+		}
+	}()
+	oneOffChildOpts(TelegramPollArgs{}.Kind()) // opts_owner: args
+}
+
 func closeDateWorkspaceArgsFor(ws ids.UUID) river.JobArgs {
 	return CloseDateWorkspaceArgs{Workspace: ws}
 }
@@ -236,8 +277,8 @@ func closeDateWorkspaceArgsFor(ws ids.UUID) river.JobArgs {
 //
 // This covers the dispatchWith builder. The other one, fanOutChildOpts, is
 // covered by the posture tests above — between them every fan-out child's
-// opts are built here or there, and TestEveryFleetWideJobOnlyDispatches is
-// what proves no dispatcher reaches River by a third spelling.
+// opts are built here or there, and TestNoScheduledDispatcherIsEnqueuedByHand
+// is what proves no dispatcher is placed by a third spelling.
 func TestDispatchWithMarksEveryChildAsOneWorkspacesShareOfAFleetPass(t *testing.T) {
 	var got []river.InsertManyParams
 	insert := func(_ context.Context, params []river.InsertManyParams) error {

--- a/backend/internal/compose/jobcensus.go
+++ b/backend/internal/compose/jobcensus.go
@@ -78,6 +78,7 @@ func (c *JobCensus) Validate() error {
 		c.everyDerivedTimeoutStillEqualsItsConstant(),
 		c.exactlyTheOperatorKindsSupplyTheirTimeout(),
 		c.everyArgsFieldIsDeclaredAndBack(),
+		c.everyFanOutChildCarriesItsUnitKey(),
 		c.everyArgsOwnedKindInsertsOnItsDeclaredQueue(),
 		c.noArgsTypeAnswersToASecondKind(),
 		c.everyDeclaredQueueIsBuiltWithItsDeclaredBound(),

--- a/backend/internal/compose/jobcensusargs.go
+++ b/backend/internal/compose/jobcensusargs.go
@@ -208,7 +208,7 @@ func argsJSONKeys(args river.JobArgs) ([]string, error) {
 	}
 	var object map[string]json.RawMessage
 	if err := json.Unmarshal(encoded, &object); err != nil {
-		return nil, fmt.Errorf("its args encode to %s rather than to a JSON object, so river_job.args has no keys to group on", encoded)
+		return nil, fmt.Errorf("its args encode to %s rather than to a JSON object, so river_job.args has no keys to group on: %w", encoded, err)
 	}
 	return slices.Sorted(maps.Keys(object)), nil
 }

--- a/backend/internal/compose/jobcensusargs.go
+++ b/backend/internal/compose/jobcensusargs.go
@@ -143,6 +143,76 @@ func (c *JobCensus) everyArgsFieldIsDeclaredAndBack() []string {
 	return findings
 }
 
+// everyFanOutChildCarriesItsUnitKey holds the sweep-unit gauges to the rows
+// they read. The pair counts a fan-out pass per DECLARED unit by grouping on
+// one args key — jobs.FanOutUnit.ArgsKey — and a child whose struct does not
+// write that key contributes nothing to the group: the SQL's own filter drops
+// it, and the kind then reads as a pass with no units at all rather than as a
+// pass nobody can measure. An absent series and an idle one are the same
+// output, which is the failure mode the declared catalogue exists to end.
+//
+// It is checked against the ENCODER rather than against the field walk. What
+// the metric groups on is a key in river_job.args, and the key is what
+// encoding/json writes — a Go field named ConnectionID answers the walk while
+// the column holds connection_id, so a name-level check would pass on a type
+// whose rows the query cannot see.
+//
+// Every unit is held, workspace included, even though the workspace-unit kinds
+// are not published in this pair: their key is what the per-workspace pair and
+// the whole scoped read group on, so a child that stopped writing it would be
+// invisible to those too.
+func (c *JobCensus) everyFanOutChildCarriesItsUnitKey() []string {
+	var findings []string
+	units := jobs.FanOutUnits()
+	for _, kind := range slices.Sorted(maps.Keys(units)) {
+		wired, registered := c.wired[kind]
+		if !registered {
+			continue // already reported by the wired-and-back check.
+		}
+		key := units[kind].ArgsKey()
+		if key == "" {
+			findings = append(findings, fmt.Sprintf(
+				"%s is fanned out to but its dispatcher declares no fan_out_unit, so nothing says what one of its rows stands for", kind))
+			continue
+		}
+		written, err := argsJSONKeys(wired.args)
+		if err != nil {
+			findings = append(findings, fmt.Sprintf("%s: %v", kind, err))
+			continue
+		}
+		if !slices.Contains(written, key) {
+			findings = append(findings, fmt.Sprintf(
+				"%s is fanned out per %s but its rows carry no %q key (they carry %v) — the sweep gauges group on that key, so every child of this kind would be dropped from the count rather than reported as a failure",
+				kind, fanOutUnitName(units[kind]), key, written))
+		}
+	}
+	return findings
+}
+
+// argsJSONKeys is the top-level keys an args value actually lands in
+// river_job.args under, taken from encoding/json itself: River marshals the
+// value verbatim, so the encoder's answer is the column's content by
+// definition, and no re-derivation of it can be wrong in a different way.
+//
+// A zero value is enough because the question is about KEYS. Only a field
+// declared `omitempty` could vary with content, and one on a fan-out child's
+// unit id would be a defect of its own — an unset id that silently drops the
+// key rather than writing an empty one.
+func argsJSONKeys(args river.JobArgs) ([]string, error) {
+	if args == nil {
+		return nil, errors.New("the registration recorded no args value at all, so there is nothing to encode")
+	}
+	encoded, err := json.Marshal(args)
+	if err != nil {
+		return nil, fmt.Errorf("its args do not encode at all, so River could never enqueue one: %w", err)
+	}
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(encoded, &object); err != nil {
+		return nil, fmt.Errorf("its args encode to %s rather than to a JSON object, so river_job.args has no keys to group on", encoded)
+	}
+	return slices.Sorted(maps.Keys(object)), nil
+}
+
 // argsFieldNames is the fields an args type puts in river_job.args, under the
 // Go names the declaration spells them with and in the order the encoder writes
 // them — or the reason the type carries a payload this walk cannot see.

--- a/backend/internal/compose/jobdispatcherenqueue_test.go
+++ b/backend/internal/compose/jobdispatcherenqueue_test.go
@@ -15,13 +15,22 @@ import (
 // types exist today; the floor sits at eighteen so retiring a few passes does
 // not drag the gate along, while a walk that matched nothing — a rename of the
 // args types, a parse that silently found no files — still trips it.
+//
+// What this gate does NOT see, stated so nobody reads more into a green run
+// than it earns: it walks this package's own top-level product sources, so a
+// dispatcher value built in a subpackage, in a cmd, or through a helper that
+// returns river.JobArgs is outside it. Those are not idiom here — every
+// dispatcher in the tree is a bare args struct constructed in this package —
+// and the enqueue door itself is held separately, by the generated closed
+// union that refuses an undeclared args type and by forbidigo's ban on a
+// direct river.AddWorker.
 const dispatcherLiteralFloor = 18
 
 // periodicForArgs answers every composite literal this package's own sources
 // hand to periodicFor, keyed by node so the second walk can ask of a literal it
 // meets "is this the one periodicFor was given" rather than compare positions.
-func periodicForArgs(files []*ast.File) map[*ast.CompositeLit]struct{} {
-	scheduled := map[*ast.CompositeLit]struct{}{}
+func periodicForArgs(files []*ast.File) map[ast.Node]struct{} {
+	scheduled := map[ast.Node]struct{}{}
 	for _, file := range files {
 		ast.Inspect(file, func(n ast.Node) bool {
 			call, ok := n.(*ast.CallExpr)
@@ -33,14 +42,50 @@ func periodicForArgs(files []*ast.File) map[*ast.CompositeLit]struct{} {
 				return true
 			}
 			for _, arg := range call.Args {
-				if lit, ok := arg.(*ast.CompositeLit); ok {
-					scheduled[lit] = struct{}{}
-				}
+				scheduled[arg] = struct{}{}
 			}
 			return true
 		})
 	}
 	return scheduled
+}
+
+// dispatcherValueSites answers every place a node in this package's sources
+// produces a value of a named type, paired with that type's identifier.
+//
+// THREE spellings, not one. A composite literal is what the tree writes today,
+// but `var a CaptureDigestArgs` and `new(CaptureDigestArgs)` produce the same
+// value and reach the same Insert, so a gate that saw only the literal would be
+// green about the two ways around it. The node returned is the one a caller
+// compares against the periodicFor arguments — for the var form that is the
+// declaration itself, which periodicFor never receives, so a scheduled
+// dispatcher declared that way is always reported.
+func dispatcherValueSites(files []*ast.File) map[ast.Node]*ast.Ident {
+	sites := map[ast.Node]*ast.Ident{}
+	for _, file := range files {
+		ast.Inspect(file, func(n ast.Node) bool {
+			switch node := n.(type) {
+			case *ast.CompositeLit:
+				if name, ok := node.Type.(*ast.Ident); ok {
+					sites[node] = name
+				}
+			case *ast.ValueSpec:
+				if name, ok := node.Type.(*ast.Ident); ok {
+					sites[node] = name
+				}
+			case *ast.CallExpr:
+				fn, ok := node.Fun.(*ast.Ident)
+				if !ok || fn.Name != "new" || len(node.Args) != 1 {
+					return true
+				}
+				if name, ok := node.Args[0].(*ast.Ident); ok {
+					sites[node] = name
+				}
+			}
+			return true
+		})
+	}
+	return sites
 }
 
 // TestNoScheduledDispatcherIsEnqueuedByHand — a dispatcher's args type is the
@@ -60,46 +105,39 @@ func periodicForArgs(files []*ast.File) map[*ast.CompositeLit]struct{} {
 // What a caller wants instead is almost always the CHILD kind for the one
 // workspace it knows about, enqueued through oneOffChildOpts so it carries the
 // declared queue and attempt cap without being counted as a fleet pass.
+//
+// All three ways of producing the value are walked — a composite literal, a
+// var declaration, and new(T) — because they reach the same Insert and a gate
+// that saw only the first would be green about the other two.
 func TestNoScheduledDispatcherIsEnqueuedByHand(t *testing.T) {
 	byType := kindByGoType()
 	fset, files := parseComposeSources(t)
 	scheduled := periodicForArgs(files)
 
 	seen := 0
-	for _, file := range files {
-		ast.Inspect(file, func(n ast.Node) bool {
-			lit, ok := n.(*ast.CompositeLit)
-			if !ok {
-				return true
-			}
-			name, ok := lit.Type.(*ast.Ident)
-			if !ok {
-				return true
-			}
-			kind, declared := byType[name.Name]
-			if !declared {
-				return true
-			}
-			spec, ok := jobs.SpecFor(kind)
-			if !ok || spec.Role != jobs.Dispatcher {
-				return true
-			}
-			seen++
-			if _, viaSchedule := scheduled[lit]; viaSchedule {
-				return true
-			}
-			if spec.Cadence.OnDemand {
-				return true
-			}
-			t.Errorf("%s: %s (%s) is constructed outside periodicFor. It is a dispatcher with a "+
-				"declared cadence, so enqueueing it fans one job out per workspace across the whole "+
-				"installation — enqueue the child kind for the workspace this site actually knows about",
-				position(fset, lit.Pos()), name.Name, kind)
-			return true
-		})
+	for node, name := range dispatcherValueSites(files) {
+		kind, declared := byType[name.Name]
+		if !declared {
+			continue
+		}
+		spec, ok := jobs.SpecFor(kind)
+		if !ok || spec.Role != jobs.Dispatcher {
+			continue
+		}
+		seen++
+		if _, viaSchedule := scheduled[node]; viaSchedule {
+			continue
+		}
+		if spec.Cadence.OnDemand {
+			continue
+		}
+		t.Errorf("%s: %s (%s) is constructed outside periodicFor. It is a dispatcher with a "+
+			"declared cadence, so enqueueing it fans one job out per workspace across the whole "+
+			"installation — enqueue the child kind for the workspace this site actually knows about",
+			position(fset, node.Pos()), name.Name, kind)
 	}
 	if seen < dispatcherLiteralFloor {
-		t.Fatalf("only %d dispatcher args literals were found, under the floor of %d — this gate is no longer reading the package",
+		t.Fatalf("only %d dispatcher args value(s) were found, under the floor of %d — this gate is no longer reading the package",
 			seen, dispatcherLiteralFloor)
 	}
 }

--- a/backend/internal/compose/jobdispatcherenqueue_test.go
+++ b/backend/internal/compose/jobdispatcherenqueue_test.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+import (
+	"go/ast"
+	"go/token"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/platform/jobs"
+)
+
+// dispatcherLiteralFloor guards against a vacuous pass. Twenty-four dispatcher
+// types exist today; the floor sits at eighteen so retiring a few passes does
+// not drag the gate along, while a walk that matched nothing — a rename of the
+// args types, a parse that silently found no files — still trips it.
+const dispatcherLiteralFloor = 18
+
+// periodicForArgs answers every composite literal this package's own sources
+// hand to periodicFor, keyed by node so the second walk can ask of a literal it
+// meets "is this the one periodicFor was given" rather than compare positions.
+func periodicForArgs(files []*ast.File) map[*ast.CompositeLit]struct{} {
+	scheduled := map[*ast.CompositeLit]struct{}{}
+	for _, file := range files {
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			fn, ok := call.Fun.(*ast.Ident)
+			if !ok || fn.Name != "periodicFor" {
+				return true
+			}
+			for _, arg := range call.Args {
+				if lit, ok := arg.(*ast.CompositeLit); ok {
+					scheduled[lit] = struct{}{}
+				}
+			}
+			return true
+		})
+	}
+	return scheduled
+}
+
+// TestNoScheduledDispatcherIsEnqueuedByHand — a dispatcher's args type is the
+// whole fleet in one value. Constructing one anywhere but the schedule enqueues
+// a pass over EVERY workspace in the installation, so a caller that meant "run
+// this for the tenant in front of me" runs it for all of them, and N tenants
+// hitting the same trigger run the fleet N times. The intent reads local at the
+// call site and the effect is fleet-wide, which is why this is a gate rather
+// than a review note: nothing about the enqueue looks wrong.
+//
+// The one sanctioned exception is DERIVED, not listed: a dispatcher whose
+// declared cadence is on_demand has no clock, so a call site is the only thing
+// that can ever place it — embed_reindex, which a human's confirm enqueues.
+// Give a kind a cadence in api/jobs.yaml and its hand-enqueue sites fail here
+// on the next run.
+//
+// What a caller wants instead is almost always the CHILD kind for the one
+// workspace it knows about, enqueued through oneOffChildOpts so it carries the
+// declared queue and attempt cap without being counted as a fleet pass.
+func TestNoScheduledDispatcherIsEnqueuedByHand(t *testing.T) {
+	byType := kindByGoType()
+	fset, files := parseComposeSources(t)
+	scheduled := periodicForArgs(files)
+
+	seen := 0
+	for _, file := range files {
+		ast.Inspect(file, func(n ast.Node) bool {
+			lit, ok := n.(*ast.CompositeLit)
+			if !ok {
+				return true
+			}
+			name, ok := lit.Type.(*ast.Ident)
+			if !ok {
+				return true
+			}
+			kind, declared := byType[name.Name]
+			if !declared {
+				return true
+			}
+			spec, ok := jobs.SpecFor(kind)
+			if !ok || spec.Role != jobs.Dispatcher {
+				return true
+			}
+			seen++
+			if _, viaSchedule := scheduled[lit]; viaSchedule {
+				return true
+			}
+			if spec.Cadence.OnDemand {
+				return true
+			}
+			t.Errorf("%s: %s (%s) is constructed outside periodicFor. It is a dispatcher with a "+
+				"declared cadence, so enqueueing it fans one job out per workspace across the whole "+
+				"installation — enqueue the child kind for the workspace this site actually knows about",
+				position(fset, lit.Pos()), name.Name, kind)
+			return true
+		})
+	}
+	if seen < dispatcherLiteralFloor {
+		t.Fatalf("only %d dispatcher args literals were found, under the floor of %d — this gate is no longer reading the package",
+			seen, dispatcherLiteralFloor)
+	}
+}
+
+// position renders a node's file and line for a failure message.
+func position(fset *token.FileSet, pos token.Pos) string {
+	return fset.Position(pos).String()
+}

--- a/backend/internal/compose/jobmetrics.go
+++ b/backend/internal/compose/jobmetrics.go
@@ -4,12 +4,14 @@
 package compose
 
 // The job-runtime section of /metrics: OPS-MET-2's queue depth and the
-// gauges beside it, plus the sweep pair. Every number here is read from
-// river_job at scrape time rather than counted in process, because the
-// dispatchers run in cmd/worker and cmd/worker serves no exposition
-// endpoint at all — an in-process counter incremented there would be
-// invisible to every scrape while the api's own copy read a truthful
-// looking zero.
+// gauges beside it, plus the two sweep pairs. Every number here is read from
+// river_job at scrape time rather than counted in process, because the work
+// itself happens in cmd/worker: an in-process counter incremented there is
+// one replica's tally, so a fleet-wide number kept that way would report
+// whatever the scraped process happened to have done. cmd/worker does serve
+// its own /metrics (--observe-addr), and deliberately carries only what IS
+// process-local — its runtime, its pool, its relay counter — leaving every
+// reading of this shared table to the one reader here.
 //
 // The two families in jobdeclared.go beside it are the exception, and the
 // reason they exist: a table scan can only ever name a kind that HAS rows,

--- a/backend/internal/compose/jobmetrics.go
+++ b/backend/internal/compose/jobmetrics.go
@@ -212,6 +212,9 @@ func writeJobMetrics(w io.Writer, snap jobs.Snapshot) error {
 	if err := writeSweepGauges(w, snap.Sweeps); err != nil {
 		return err
 	}
+	if err := writeSweepUnitGauges(w, snap.Units); err != nil {
+		return err
+	}
 	if err := writeUnrecognisedStateGauge(w, unrecognised); err != nil {
 		return err
 	}
@@ -289,6 +292,46 @@ func writeSweepGauges(w io.Writer, sweeps []jobs.SweepPass) error {
 	for _, s := range ordered {
 		if _, err := fmt.Fprintf(w, "margince_sweep_workspaces_failed{sweep=%s} %d\n",
 			label(s.Kind), s.Failed); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// writeSweepUnitGauges renders the pair that answers the same question one
+// grain down, for the dispatchers that fan out per connection or per build.
+// The workspace pair above is the coarser reading of the same passes and can
+// mask a failed unit behind a healthy sibling in the same workspace; these two
+// cannot, because each unit is counted in its own right.
+//
+// Present ONLY for kinds whose declared unit is finer than a workspace. For
+// every other fan-out kind the unit IS the workspace, so this pair would repeat
+// the one above value for value, and two published series for one number is a
+// worse surface than one series and a documented pairing. The unit rides as a
+// label so an alert can see which grain it is reading without a lookup.
+func writeSweepUnitGauges(w io.Writer, units []jobs.SweepUnit) error {
+	ordered := slices.SortedFunc(slices.Values(units), func(a, b jobs.SweepUnit) int {
+		return cmp.Compare(a.Kind, b.Kind)
+	})
+
+	if err := writeFamilyHeader(w, "margince_sweep_units_total",
+		"Fan-out units with a surviving child of this fleet pass, for the dispatchers that fan out per connection or per build rather than per workspace. The unit label names the grain. Kinds that fan out per workspace are absent here and reported by margince_sweep_workspaces_total, which is the same measurement for them."); err != nil {
+		return err
+	}
+	for _, u := range ordered {
+		if _, err := fmt.Fprintf(w, "margince_sweep_units_total{sweep=%s,unit=%s} %d\n",
+			label(u.Kind), label(fanOutUnitName(u.Unit)), u.Units); err != nil {
+			return err
+		}
+	}
+
+	if err := writeFamilyHeader(w, "margince_sweep_units_failed",
+		"Fan-out units whose MOST RECENT child of this fleet pass ended discarded or cancelled. Unlike the per-workspace pair, a failed connection is counted even when a sibling connection in the same workspace succeeded afterwards -- which is the masking this pair exists to remove."); err != nil {
+		return err
+	}
+	for _, u := range ordered {
+		if _, err := fmt.Fprintf(w, "margince_sweep_units_failed{sweep=%s,unit=%s} %d\n",
+			label(u.Kind), label(fanOutUnitName(u.Unit)), u.Failed); err != nil {
 			return err
 		}
 	}

--- a/backend/internal/compose/jobmetrics_test.go
+++ b/backend/internal/compose/jobmetrics_test.go
@@ -137,6 +137,28 @@ func TestTheSweepPairIsRenderedPerFanOutKind(t *testing.T) {
 	}
 }
 
+// TestTheSweepUnitPairIsRenderedAtTheDeclaredGrain — the pair exists because
+// the per-workspace one cannot tell a workspace with one broken connection
+// from a healthy workspace. Both halves carry the same sweep label so an alert
+// can compare them, and the unit label says which grain is being read; without
+// it the two pairs are indistinguishable in a dashboard.
+func TestTheSweepUnitPairIsRenderedAtTheDeclaredGrain(t *testing.T) {
+	var buf bytes.Buffer
+	if err := writeJobMetrics(&buf, jobs.Snapshot{Units: []jobs.SweepUnit{
+		{Kind: "capture_sync", Unit: jobs.FanOutConnection, Units: 9, Failed: 2},
+	}}); err != nil {
+		t.Fatalf("writeJobMetrics: %v", err)
+	}
+	for _, line := range []string{
+		`margince_sweep_units_total{sweep="capture_sync",unit="connection"} 9`,
+		`margince_sweep_units_failed{sweep="capture_sync",unit="connection"} 2`,
+	} {
+		if !strings.Contains(buf.String(), line) {
+			t.Errorf("exposition missing %q\ngot:\n%s", line, buf.String())
+		}
+	}
+}
+
 // TestEverySeriesIsWrittenInAStableOrder — a scrape target's series order
 // should not flap between scrapes for no reason, and map iteration order is
 // not stable. sortedKeys next door exists for the same reason.

--- a/backend/internal/compose/jobmetrics_test.go
+++ b/backend/internal/compose/jobmetrics_test.go
@@ -212,6 +212,8 @@ func TestAnEmptySnapshotWritesEveryFamilyHeaderAndNoSeries(t *testing.T) {
 		"margince_job_oldest_queued_age_seconds",
 		"margince_sweep_workspaces_total",
 		"margince_sweep_workspaces_failed",
+		"margince_sweep_units_total",
+		"margince_sweep_units_failed",
 	} {
 		if !strings.Contains(buf.String(), "# TYPE "+family+" gauge") {
 			t.Errorf("family header for %s missing from an empty snapshot\ngot:\n%s", family, buf.String())
@@ -234,6 +236,7 @@ func TestARefusedWriteSurfacesRatherThanBeingRenderedPast(t *testing.T) {
 	snap := jobs.Snapshot{
 		Rows:   []jobs.StateRow{{Queue: "default", Kind: "k", Untenanted: true, State: "available", Count: 1}},
 		Sweeps: []jobs.SweepPass{{Kind: "s", Workspaces: 1}},
+		Units:  []jobs.SweepUnit{{Kind: "u", Unit: jobs.FanOutConnection, Units: 1}},
 	}
 
 	// Fail at each write in turn, so no single family's writes are the only

--- a/backend/internal/compose/jobregistry.go
+++ b/backend/internal/compose/jobregistry.go
@@ -170,5 +170,6 @@ func addGovernedWorker[T river.JobArgs](reg *jobRegistry, w jobs.WorkOnly[T], su
 	// and the boot it then refuses is what keeps the zero Spec's timeout —
 	// River's one-minute default — away from a running job.
 	spec, _ := jobs.SpecFor(kind)
+	//nolint:forbidigo // the ONE sanctioned registration: every kind reaches River through this line, already wrapped in jobs.Govern and already recorded for MustBeTotal
 	river.AddWorker(reg.workers, jobs.Govern[T](w, spec, supplied))
 }

--- a/backend/internal/compose/jobunitkey_test.go
+++ b/backend/internal/compose/jobunitkey_test.go
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package compose
+
+// The census arm that holds a fan-out child to carrying the args key its
+// dispatcher's declared unit names. The real wiring satisfies it, which is what
+// TestJobCensusMatchesTheContract asserts — these drive the FINDINGS, against
+// hand-built registrations, because an arm whose failure path never runs is
+// indistinguishable from one that cannot fail.
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/riverqueue/river"
+
+	"github.com/gradionhq/margince/backend/internal/platform/jobs"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// aFanOutChild answers one declared fan-out child kind whose unit is finer than
+// a workspace, so the fixtures below bind a kind the contract really fans out
+// per connection rather than one invented here.
+func aFanOutChild(t *testing.T) string {
+	t.Helper()
+	for kind, unit := range jobs.FanOutUnits() {
+		if unit == jobs.FanOutConnection {
+			return kind
+		}
+	}
+	t.Fatal("no kind is declared as fanned out per connection; this gate has nothing to check")
+	return ""
+}
+
+// keylessArgs is a child that names its unit in a Go field the JSON encoder
+// never writes under the key the metric groups on. It is the shape a
+// name-level check passes and the query does not: the column would hold
+// "connectionID", and args->>'connection_id' answers NULL for every row.
+type keylessArgs struct {
+	Workspace ids.UUID `json:"workspace_id"`
+	//nolint:tagliatelle // the wrong casing IS the fixture: this type exists to be a child whose column key is not the one the gauge groups on.
+	ConnectionID ids.UUID `json:"connectionID"`
+}
+
+func (keylessArgs) Kind() string { return "keyless_probe" }
+
+// selfEncodingArgs decides its own encoding, so its fields say nothing about
+// what lands in the column.
+type selfEncodingArgs struct {
+	ConnectionID ids.UUID
+}
+
+func (selfEncodingArgs) Kind() string { return "self_encoding_probe" }
+
+func (a selfEncodingArgs) MarshalJSON() ([]byte, error) {
+	return json.Marshal(a.ConnectionID.String())
+}
+
+// censusWith builds a census whose whole registry is one kind, so a finding can
+// only have come from that kind.
+func censusWith(kind string, args river.JobArgs) *JobCensus {
+	return &JobCensus{wired: map[string]wiredWorker{kind: {args: args}}}
+}
+
+func TestTheUnitKeyArmRefusesAChildThatDoesNotWriteTheKeyTheGaugeGroupsOn(t *testing.T) {
+	kind := aFanOutChild(t)
+	findings := censusWith(kind, keylessArgs{}).everyFanOutChildCarriesItsUnitKey()
+
+	if len(findings) != 1 {
+		t.Fatalf("got %d findings, want 1: %v", len(findings), findings)
+	}
+	if !strings.Contains(findings[0], "connection_id") {
+		t.Errorf("the finding does not name the missing key, so a reader cannot act on it: %s", findings[0])
+	}
+	if !strings.Contains(findings[0], kind) {
+		t.Errorf("the finding does not name the kind: %s", findings[0])
+	}
+}
+
+// A type that encodes ITSELF is refused rather than read past: its fields
+// govern nothing, so a walk that shrugged would report "no key missing" about
+// a column it never looked at.
+func TestTheUnitKeyArmRefusesAChildThatEncodesItself(t *testing.T) {
+	kind := aFanOutChild(t)
+	findings := censusWith(kind, selfEncodingArgs{}).everyFanOutChildCarriesItsUnitKey()
+
+	if len(findings) != 1 {
+		t.Fatalf("got %d findings, want 1: %v", len(findings), findings)
+	}
+	if !strings.Contains(findings[0], "JSON object") {
+		t.Errorf("the finding does not say what is wrong with the encoding: %s", findings[0])
+	}
+}
+
+// A kind the census never registered is the other arm's finding, not this
+// one's — reporting it twice sends a reader chasing two symptoms of one cause.
+func TestTheUnitKeyArmLeavesAnUnregisteredKindToTheWiringCheck(t *testing.T) {
+	if findings := (&JobCensus{wired: map[string]wiredWorker{}}).everyFanOutChildCarriesItsUnitKey(); len(findings) != 0 {
+		t.Errorf("an empty registry produced %d finding(s); every declared child is unwired there, which "+
+			"everyDeclaredKindIsWiredAndBack already reports: %v", len(findings), findings)
+	}
+}
+
+// argsJSONKeys is what the arm reads the column's shape from, and it answers
+// from the ENCODER rather than from field names. A registration that recorded
+// no args value at all has nothing to encode, and must say so rather than
+// answer an empty key set that reads as "carries nothing".
+func TestArgsJSONKeysRefusesARegistrationWithNoArgsValue(t *testing.T) {
+	keys, err := argsJSONKeys(nil)
+	if err == nil {
+		t.Fatalf("a nil args value answered %v rather than refusing; an empty key set reads as a type that carries nothing", keys)
+	}
+}
+
+func TestArgsJSONKeysAnswersTheEncodersOwnKeys(t *testing.T) {
+	keys, err := argsJSONKeys(keylessArgs{})
+	if err != nil {
+		t.Fatalf("argsJSONKeys: %v", err)
+	}
+	// The Go field is ConnectionID; the column key is what the tag says. The
+	// difference between the two is the whole reason this reads the encoder.
+	want := []string{"connectionID", "workspace_id"}
+	if len(keys) != len(want) || keys[0] != want[0] || keys[1] != want[1] {
+		t.Errorf("keys = %v, want %v — sorted, and taken from the tags rather than the field names", keys, want)
+	}
+}

--- a/backend/internal/compose/replayscope.go
+++ b/backend/internal/compose/replayscope.go
@@ -43,7 +43,7 @@ import (
 // every retry refused), and the HTTP method does not carry it either, since
 // `POST /v1/deals/{id}/advance`, `/merge` and `/offers/{id}/send` are updates.
 // Guessing it turns legitimate retries into 403s, which is a worse failure
-// than the gap. STATUS.md carries what closing it needs.
+// than the gap.
 type replayTarget struct {
 	object      string // RBAC object governing the body (recorded, not yet re-checked)
 	objectNote  string // …or why no object grant governs it

--- a/backend/internal/platform/httpserver/observe.go
+++ b/backend/internal/platform/httpserver/observe.go
@@ -14,6 +14,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"runtime"
 	"sort"
 	"strings"
 	"time"
@@ -251,12 +252,25 @@ func Metrics(pool *pgxpool.Pool, backlog func(context.Context) (int64, error), p
 		defer cancel()
 		w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
 
-		if n, err := backlog(ctx); err == nil {
-			_, _ = fmt.Fprintf(w, "# HELP margince_outbox_unpublished Committed outbox rows the relay has not shipped yet.\n")
-			_, _ = fmt.Fprintf(w, "# TYPE margince_outbox_unpublished gauge\n")
-			_, _ = fmt.Fprintf(w, "margince_outbox_unpublished %d\n", n)
-		} else {
-			slog.ErrorContext(r.Context(), "metrics: outbox backlog query failed", "err", err)
+		// Always first, and never injected: this section measures the
+		// PROCESS answering the scrape, so it is the one part of the
+		// exposition that means something different on every target and
+		// cannot be assembled anywhere but here.
+		writeRuntimeMetrics(w)
+
+		// The backlog is a fleet-wide reading of a shared table, so a role
+		// that would only duplicate another target's copy of it passes nil
+		// rather than querying — the same "declared or absent" posture the
+		// sections below take, and the reason a FAILED read writes nothing:
+		// a gauge reporting rows it did not count reads as a drained outbox.
+		if backlog != nil {
+			if n, err := backlog(ctx); err == nil {
+				_, _ = fmt.Fprintf(w, "# HELP margince_outbox_unpublished Committed outbox rows the relay has not shipped yet.\n")
+				_, _ = fmt.Fprintf(w, "# TYPE margince_outbox_unpublished gauge\n")
+				_, _ = fmt.Fprintf(w, "margince_outbox_unpublished %d\n", n)
+			} else {
+				slog.ErrorContext(r.Context(), "metrics: outbox backlog query failed", "err", err)
+			}
 		}
 
 		_, _ = fmt.Fprintf(w, "# HELP margince_relay_published_total Outbox rows shipped to the bus since process start.\n")
@@ -290,6 +304,44 @@ func Metrics(pool *pgxpool.Pool, backlog func(context.Context) (int64, error), p
 			writeOverlayMetrics(r.Context(), w, overlay)
 		}
 	}
+}
+
+// writeRuntimeMetrics renders what the SCRAPED PROCESS is doing, as opposed
+// to what the installation is doing. Every other section here is a reading of
+// shared state — the outbox table, the job table, the mirror — which any role
+// with a pool answers identically, so a wedged replica is arithmetically
+// invisible in them: the fleet-wide numbers are the same whichever process
+// served the scrape.
+//
+// These four are not. They are read out of THIS runtime, so they differ per
+// target and an operator can tell which process stopped working rather than
+// only that work stopped. That is the whole reason the worker role serves a
+// listener at all: it does the work and, until it did, published nothing about
+// itself.
+//
+// Named margince_process_* rather than Prometheus' conventional go_* because
+// this exposition is hand-rolled: if client_golang is ever adopted it brings
+// its own go_* collector, and two definitions of one series name is a worse
+// outcome than a prefix that says who wrote it.
+func writeRuntimeMetrics(w io.Writer) {
+	var mem runtime.MemStats
+	runtime.ReadMemStats(&mem)
+
+	_, _ = fmt.Fprintf(w, "# HELP margince_process_goroutines Goroutines running in the scraped process.\n")
+	_, _ = fmt.Fprintf(w, "# TYPE margince_process_goroutines gauge\n")
+	_, _ = fmt.Fprintf(w, "margince_process_goroutines %d\n", runtime.NumGoroutine())
+
+	_, _ = fmt.Fprintf(w, "# HELP margince_process_heap_bytes Heap bytes allocated and in use by the scraped process.\n")
+	_, _ = fmt.Fprintf(w, "# TYPE margince_process_heap_bytes gauge\n")
+	_, _ = fmt.Fprintf(w, "margince_process_heap_bytes %d\n", mem.HeapAlloc)
+
+	_, _ = fmt.Fprintf(w, "# HELP margince_process_heap_sys_bytes Heap bytes obtained from the OS by the scraped process -- with heap_bytes, whether memory is in use or merely held.\n")
+	_, _ = fmt.Fprintf(w, "# TYPE margince_process_heap_sys_bytes gauge\n")
+	_, _ = fmt.Fprintf(w, "margince_process_heap_sys_bytes %d\n", mem.HeapSys)
+
+	_, _ = fmt.Fprintf(w, "# HELP margince_process_gc_cycles_total Completed GC cycles since the scraped process started.\n")
+	_, _ = fmt.Fprintf(w, "# TYPE margince_process_gc_cycles_total counter\n")
+	_, _ = fmt.Fprintf(w, "margince_process_gc_cycles_total %d\n", mem.NumGC)
 }
 
 // writeOverlayMetrics renders the overlay sync-health section — split

--- a/backend/internal/platform/httpserver/observe.go
+++ b/backend/internal/platform/httpserver/observe.go
@@ -194,12 +194,24 @@ func Readyz(aiState string, embedState func(context.Context) string, checks ...R
 				return
 			}
 		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintln(w, "ready")
+		// Each visibility line is written only by a role that wires the thing
+		// it reports. The worker wires neither, and an empty "ai: " line is
+		// noise an operator has to learn to ignore — worse than silence,
+		// because it reads as a role whose AI state could not be determined.
+		if aiState != "" {
+			_, _ = fmt.Fprintf(w, "ai: %s\n", aiState)
+		}
+		// The embed line is written unconditionally, unlike the AI one: a nil
+		// embedState and a marker-read that already failed into "unknown" are
+		// deliberately indistinguishable here, so omitting it would turn one
+		// of those two into an absence and the other into a value.
 		embed := "unknown"
 		if embedState != nil {
 			embed = embedState(ctx)
 		}
-		w.WriteHeader(http.StatusOK)
-		_, _ = fmt.Fprintf(w, "ready\nai: %s\nembed: %s\n", aiState, embed)
+		_, _ = fmt.Fprintf(w, "embed: %s\n", embed)
 	}
 }
 

--- a/backend/internal/platform/jobs/fanoutunit_test.go
+++ b/backend/internal/platform/jobs/fanoutunit_test.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package jobs
+
+import (
+	"slices"
+	"testing"
+)
+
+// TestEveryFanOutUnitNamesAnArgsKey — ArgsKey is what the sweep-unit gauges
+// group on, and a unit answering the empty string silently drops every kind
+// declared with it out of the count. The set is closed and small enough to
+// state, which is the point: a fourth unit added to the enum without a key
+// fails here rather than at 3am on a dashboard reading zero.
+func TestEveryFanOutUnitNamesAnArgsKey(t *testing.T) {
+	keys := map[string]FanOutUnit{}
+	for _, unit := range []FanOutUnit{FanOutWorkspace, FanOutConnection, FanOutBuild} {
+		key := unit.ArgsKey()
+		if key == "" {
+			t.Errorf("fan-out unit %d names no args key, so a kind declared with it would be grouped on nothing", unit)
+			continue
+		}
+		if other, taken := keys[key]; taken {
+			t.Errorf("units %d and %d both name %q; two grains grouped on one key report one number for both", other, unit, key)
+		}
+		keys[key] = unit
+	}
+	// The zero unit is a kind that fans out to nothing, and it must answer no
+	// key at all rather than default to the workspace's — a default would make
+	// a missing declaration read as a declared one.
+	if key := FanOutUnit(0).ArgsKey(); key != "" {
+		t.Errorf("the zero fan-out unit answers %q; a kind that fans out to nothing has no unit to name", key)
+	}
+}
+
+// TestFanOutUnitsReadsTheEdgeBackwards — the unit is declared on the
+// DISPATCHER, so every consumer holding a child row needs the edge walked for
+// it. A map built the other way round (child → its own zero unit) would answer
+// plausibly and wrongly for every kind.
+func TestFanOutUnitsReadsTheEdgeBackwards(t *testing.T) {
+	units := FanOutUnits()
+	if len(units) == 0 {
+		t.Fatal("no fan-out edges at all — every check below would pass by iterating nothing")
+	}
+	for _, spec := range specs {
+		if spec.FanOutTo == "" {
+			if _, present := units[spec.Kind]; present && spec.Role == Dispatcher {
+				t.Errorf("%s fans out to nothing but is answered as a fan-out child", spec.Kind)
+			}
+			continue
+		}
+		got, present := units[spec.FanOutTo]
+		if !present {
+			t.Errorf("%s declares it fans out to %s, which is not answered as a fan-out child", spec.Kind, spec.FanOutTo)
+			continue
+		}
+		if got != spec.FanOutUnit {
+			t.Errorf("%s stands for unit %d, want %d — the dispatcher %s declares it",
+				spec.FanOutTo, got, spec.FanOutUnit, spec.Kind)
+		}
+	}
+}
+
+// TestSubWorkspaceFanOutsSelectsExactlyTheFinerGrains is the partition the two
+// sweep pairs rest on: a kind read by BOTH would publish one number twice, and
+// an operator summing the pairs would double-count a fleet. The selection is
+// what enforces it — a finer-unit child's rows carry workspace_id as well, so
+// nothing about the data would stop it appearing in both.
+func TestSubWorkspaceFanOutsSelectsExactlyTheFinerGrains(t *testing.T) {
+	kinds, argsKeys := subWorkspaceFanOuts()
+	if len(kinds) != len(argsKeys) {
+		t.Fatalf("%d kinds against %d args keys; the arrays are joined by index and would pair a kind with another's key",
+			len(kinds), len(argsKeys))
+	}
+	if !slices.IsSorted(kinds) {
+		t.Errorf("the kinds are unsorted (%v); a scrape target's series order must not flap between reads", kinds)
+	}
+
+	var workspaceGrain, finerGrain int
+	for kind, unit := range FanOutUnits() {
+		if unit == FanOutWorkspace {
+			workspaceGrain++
+			if slices.Contains(kinds, kind) {
+				t.Errorf("%s fans out per workspace but is read by the unit pair, where it would restate margince_sweep_workspaces_total exactly", kind)
+			}
+			continue
+		}
+		finerGrain++
+		i := slices.Index(kinds, kind)
+		if i < 0 {
+			t.Errorf("%s fans out per unit %d but the unit pair does not read it, so a failed unit stays masked by a healthy sibling", kind, unit)
+			continue
+		}
+		if argsKeys[i] != unit.ArgsKey() {
+			t.Errorf("%s is grouped on %q, want its declared unit's key %q", kind, argsKeys[i], unit.ArgsKey())
+		}
+	}
+	if workspaceGrain == 0 || finerGrain == 0 {
+		t.Fatalf("%d workspace-grain / %d finer-grain fan-outs declared; one side is unexercised and the partition is untested",
+			workspaceGrain, finerGrain)
+	}
+}

--- a/backend/internal/platform/jobs/fanoutunit_test.go
+++ b/backend/internal/platform/jobs/fanoutunit_test.go
@@ -8,17 +8,33 @@ import (
 	"testing"
 )
 
-// TestEveryFanOutUnitNamesAnArgsKey — ArgsKey is what the sweep-unit gauges
-// group on, and a unit answering the empty string silently drops every kind
-// declared with it out of the count. The set is closed and small enough to
-// state, which is the point: a fourth unit added to the enum without a key
-// fails here rather than at 3am on a dashboard reading zero.
-func TestEveryFanOutUnitNamesAnArgsKey(t *testing.T) {
+// TestEveryDeclaredFanOutUnitNamesAnArgsKey — ArgsKey is what the sweep-unit
+// gauges group on, and a unit answering the empty string is SKIPPED by
+// subWorkspaceFanOuts, so every kind declared with it drops silently out of the
+// count. Go's switch gives no exhaustiveness against that; this gate does.
+//
+// The units come from the COMPILED CONTRACT rather than from a list here.
+// Enumerating the enum by hand is the failure mode this replaces: a fourth
+// constant, or a fourth `fan_out_unit:` in api/jobs.yaml, would not enter a
+// hand-written loop, and the gate would stay green about exactly the change it
+// claims to catch. Reading what the file declares means the declaration itself
+// enrols the new unit.
+func TestEveryDeclaredFanOutUnitNamesAnArgsKey(t *testing.T) {
+	declaredUnits := map[FanOutUnit]string{}
+	for kind, spec := range specs {
+		if spec.FanOutTo != "" {
+			declaredUnits[spec.FanOutUnit] = kind
+		}
+	}
+	if len(declaredUnits) < 2 {
+		t.Fatalf("only %d distinct fan-out unit(s) are declared; this gate would pass on a single grain and prove nothing about a second", len(declaredUnits))
+	}
+
 	keys := map[string]FanOutUnit{}
-	for _, unit := range []FanOutUnit{FanOutWorkspace, FanOutConnection, FanOutBuild} {
+	for unit, declaringKind := range declaredUnits {
 		key := unit.ArgsKey()
 		if key == "" {
-			t.Errorf("fan-out unit %d names no args key, so a kind declared with it would be grouped on nothing", unit)
+			t.Errorf("%s declares fan-out unit %d, which names no args key — every child of it would be grouped on nothing and vanish from the unit gauges", declaringKind, unit)
 			continue
 		}
 		if other, taken := keys[key]; taken {
@@ -62,11 +78,16 @@ func TestFanOutUnitsReadsTheEdgeBackwards(t *testing.T) {
 	}
 }
 
-// TestSubWorkspaceFanOutsSelectsExactlyTheFinerGrains is the partition the two
-// sweep pairs rest on: a kind read by BOTH would publish one number twice, and
-// an operator summing the pairs would double-count a fleet. The selection is
-// what enforces it — a finer-unit child's rows carry workspace_id as well, so
-// nothing about the data would stop it appearing in both.
+// TestSubWorkspaceFanOutsSelectsExactlyTheFinerGrains — the unit pair reports a
+// kind only where its grain differs from the workspace pair's. A
+// workspace-grained kind read here would restate margince_sweep_workspaces_*
+// value for value, which is one number published twice; a finer-grained kind
+// NOT read here stays masked by a healthy sibling, which is the whole defect
+// the pair exists to remove.
+//
+// The two families still overlap — a per-connection kind's rows carry a
+// workspace id too, so it is reported by both, at two grains. That is
+// deliberate and is why the selection is asserted rather than assumed.
 func TestSubWorkspaceFanOutsSelectsExactlyTheFinerGrains(t *testing.T) {
 	kinds, argsKeys := subWorkspaceFanOuts()
 	if len(kinds) != len(argsKeys) {

--- a/backend/internal/platform/jobs/spec.go
+++ b/backend/internal/platform/jobs/spec.go
@@ -77,10 +77,15 @@ func (u FanOutUnit) ArgsKey() string {
 // done once over the compiled table rather than at every call site that needs
 // it. A child no dispatcher names is absent rather than defaulted: the fan-out
 // edges are the registry of what fans out at all.
+//
+// The walk is in KIND ORDER rather than map order. Two dispatchers naming one
+// child with different units is refused at generation, so the answer cannot
+// depend on iteration order — and iterating deterministically is what keeps
+// that true of this function rather than only of the file it reads.
 func FanOutUnits() map[string]FanOutUnit {
 	units := map[string]FanOutUnit{}
-	for _, spec := range specs {
-		if spec.FanOutTo != "" {
+	for _, kind := range slices.Sorted(maps.Keys(specs)) {
+		if spec := specs[kind]; spec.FanOutTo != "" {
 			units[spec.FanOutTo] = spec.FanOutUnit
 		}
 	}

--- a/backend/internal/platform/jobs/spec.go
+++ b/backend/internal/platform/jobs/spec.go
@@ -40,6 +40,47 @@ const (
 	FanOutBuild
 )
 
+// ArgsKey is the river_job.args key that identifies WHICH unit a child row
+// stands for — the workspace, the connection, or the build it was enqueued
+// against. It is what lets a reader count a fan-out pass at the grain the
+// dispatcher actually ran it at: two children of one workspace differ in this
+// key and in nothing else the job table carries.
+//
+// The mapping is a switch over the closed unit set rather than a table beside
+// it, so a fourth unit does not compile until it says which key names it, and
+// the census holds every declared child to actually carrying the key its
+// dispatcher's unit names. The zero FanOutUnit — a kind that fans out to
+// nothing — answers the empty string, which is not a key any row has.
+func (u FanOutUnit) ArgsKey() string {
+	switch u {
+	case FanOutWorkspace:
+		return "workspace_id"
+	case FanOutConnection:
+		return "connection_id"
+	case FanOutBuild:
+		return "build_id"
+	}
+	return ""
+}
+
+// FanOutUnits answers, per fan-out CHILD kind, what one row of it stands for.
+//
+// The unit is declared on the DISPATCHER, beside the edge it names, because
+// that is where the fan-out decision is made — so a reader holding a child row
+// has to walk the edge backwards to learn what it counts as. This is that walk,
+// done once over the compiled table rather than at every call site that needs
+// it. A child no dispatcher names is absent rather than defaulted: the fan-out
+// edges are the registry of what fans out at all.
+func FanOutUnits() map[string]FanOutUnit {
+	units := map[string]FanOutUnit{}
+	for _, spec := range specs {
+		if spec.FanOutTo != "" {
+			units[spec.FanOutTo] = spec.FanOutUnit
+		}
+	}
+	return units
+}
+
 // OptsOwner names who supplies a kind's River insert options, and therefore
 // how strongly the declaration binds them. The three levels genuinely differ
 // and the difference is stated rather than implied:

--- a/backend/internal/platform/jobs/spec.go
+++ b/backend/internal/platform/jobs/spec.go
@@ -46,11 +46,17 @@ const (
 // dispatcher actually ran it at: two children of one workspace differ in this
 // key and in nothing else the job table carries.
 //
-// The mapping is a switch over the closed unit set rather than a table beside
-// it, so a fourth unit does not compile until it says which key names it, and
-// the census holds every declared child to actually carrying the key its
-// dispatcher's unit names. The zero FanOutUnit — a kind that fans out to
-// nothing — answers the empty string, which is not a key any row has.
+// A unit with no key answers the empty string, and subWorkspaceFanOuts then
+// SKIPS it — so a fourth unit added without a key would quietly drop every
+// kind declared with it out of the unit gauges. Go's switch offers no
+// exhaustiveness for that, and this comment does not pretend otherwise: what
+// catches it is a gate, TestEveryDeclaredFanOutUnitNamesAnArgsKey, which reads
+// the units the CONTRACT actually declares rather than a list kept here. The
+// census then holds every declared child to writing the key its dispatcher's
+// unit names.
+//
+// The zero FanOutUnit — a kind that fans out to nothing — answers the empty
+// string on purpose: it has no unit, and no row of it has a key to group on.
 func (u FanOutUnit) ArgsKey() string {
 	switch u {
 	case FanOutWorkspace:

--- a/backend/internal/platform/jobs/stats.go
+++ b/backend/internal/platform/jobs/stats.go
@@ -299,6 +299,11 @@ func statsBySweep(ctx context.Context, pool *pgxpool.Pool) ([]SweepPass, error) 
 // declared sub-workspace kinds: a row of any other kind matches no pair and is
 // not read.
 //
+// The workspace predicate is carried over from statsBySweep unchanged, for the
+// reason it holds there: every kind read here is a tenant kind, so a row with a
+// unit key and no workspace is malformed, and counting it would credit a pass
+// with a unit belonging to no tenant.
+//
 // An empty pairing means the contract declares no such dispatcher, and the
 // query is skipped rather than run with two empty arrays — the answer is the
 // same, and the skip says why it is empty.
@@ -319,6 +324,7 @@ func statsBySweepUnit(ctx context.Context, pool *pgxpool.Pool) ([]SweepUnit, err
 		    JOIN unnest($1::text[], $2::text[]) AS u(kind, args_key) ON u.kind = j.kind
 		    WHERE '` + SweepTag + `' = ANY(j.tags)
 		      AND coalesce(j.args->>u.args_key, '') <> ''
+		      AND coalesce(j.args->>'workspace_id', '') <> ''
 		    ORDER BY j.kind, j.args->>u.args_key, j.created_at DESC, j.id DESC
 		) latest
 		GROUP BY kind`

--- a/backend/internal/platform/jobs/stats.go
+++ b/backend/internal/platform/jobs/stats.go
@@ -98,9 +98,15 @@ type SweepPass struct {
 // reports nothing. Counting at the declared unit is what makes that visible.
 //
 // Only the kinds whose unit is NOT the workspace are reported. For the other
-// twenty-one the two readings are the same measurement — the unit key IS
-// workspace_id — and publishing both would be two series for one number, which
-// is a worse operator surface than one series and a documented pairing.
+// twenty the unit key IS workspace_id, so this pair would restate
+// SweepPass value for value; publishing both would be one number twice.
+//
+// The two families therefore OVERLAP rather than partition: a per-connection
+// kind is reported by both, at two grains, because its rows carry a workspace
+// id as well as a connection id. That is the point — the coarse reading
+// answers fleet coverage and the fine one answers whether every unit ran —
+// but it means the two must never be summed, and an alert reads whichever
+// grain it means rather than adding them together.
 type SweepUnit struct {
 	Kind string
 	Unit FanOutUnit
@@ -123,12 +129,13 @@ type Snapshot struct {
 
 // Stats reads the live job table for the metric surface.
 //
-// TWO statements, not one. They read different populations — the runtime
+// THREE statements, not one. They read different populations — the runtime
 // gauges must exclude completed rows (a finished job is history, not depth)
-// while the sweep pair must include them (a pass whose workspaces all
-// succeeded is the healthy case, and it is completed rows that say so).
-// Folding them together needs a UNION with a discriminator and two nullable
-// halves; two legible grouped scans inside one budget is the better trade.
+// while both sweep reads must include them (a pass whose units all succeeded
+// is the healthy case, and it is completed rows that say so) — and the two
+// sweep reads group at different grains besides. Folding them together needs
+// a UNION with a discriminator and several nullable halves; three legible
+// grouped scans inside one budget is the better trade.
 //
 // A caller that could not complete the read gets the error, never a partial
 // or empty Snapshot: an unmeasured fleet renders identically to an idle one,

--- a/backend/internal/platform/jobs/stats.go
+++ b/backend/internal/platform/jobs/stats.go
@@ -11,6 +11,8 @@ package jobs
 import (
 	"context"
 	"fmt"
+	"maps"
+	"slices"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 )
@@ -84,10 +86,39 @@ type SweepPass struct {
 	Failed     int64
 }
 
+// SweepUnit is one fan-out kind read per FAN-OUT UNIT — the grain the
+// dispatcher actually ran the pass at — for the kinds whose unit is finer than
+// a workspace.
+//
+// It exists because SweepPass counts workspaces, and three dispatchers fan out
+// per CONNECTION and one per BUILD. A workspace holding two connections
+// produces two children per pass, and if one fails while the other succeeds
+// afterwards, the workspace's most recent child is the successful one: the
+// failure is real, the tenant is being half-served, and the workspace pair
+// reports nothing. Counting at the declared unit is what makes that visible.
+//
+// Only the kinds whose unit is NOT the workspace are reported. For the other
+// twenty-one the two readings are the same measurement — the unit key IS
+// workspace_id — and publishing both would be two series for one number, which
+// is a worse operator surface than one series and a documented pairing.
+type SweepUnit struct {
+	Kind string
+	Unit FanOutUnit
+	// Units is how many distinct units of this kind have a surviving child,
+	// and Failed how many of those most recently ended dead. The pair reads
+	// exactly as SweepPass's does, one grain down.
+	Units  int64
+	Failed int64
+}
+
 // Snapshot is one read of the job table, for a reader that renders it.
 type Snapshot struct {
 	Rows   []StateRow
 	Sweeps []SweepPass
+	// Units is empty when no declared kind fans out below the workspace,
+	// which is a legitimate fleet rather than a failed read — Stats returns
+	// the error for that.
+	Units []SweepUnit
 }
 
 // Stats reads the live job table for the metric surface.
@@ -111,7 +142,32 @@ func Stats(ctx context.Context, pool *pgxpool.Pool) (Snapshot, error) {
 	if err != nil {
 		return Snapshot{}, err
 	}
-	return Snapshot{Rows: rows, Sweeps: sweeps}, nil
+	units, err := statsBySweepUnit(ctx, pool)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	return Snapshot{Rows: rows, Sweeps: sweeps, Units: units}, nil
+}
+
+// subWorkspaceFanOuts answers the fan-out child kinds whose declared unit is
+// finer than a workspace, paired with the args key that identifies one — the
+// two arrays statsBySweepUnit joins the job table against.
+//
+// Derived from the contract on every call rather than kept as a list: a
+// dispatcher that changes its fan_out_unit, or a new one that fans out per
+// connection, is enrolled by the declaration that made it so. Both arrays are
+// built in one pass so they stay index-aligned by construction.
+func subWorkspaceFanOuts() (kinds, argsKeys []string) {
+	units := FanOutUnits()
+	for _, kind := range slices.Sorted(maps.Keys(units)) {
+		key := units[kind].ArgsKey()
+		if units[kind] == FanOutWorkspace || key == "" {
+			continue
+		}
+		kinds = append(kinds, kind)
+		argsKeys = append(argsKeys, key)
+	}
+	return kinds, argsKeys
 }
 
 func statsByState(ctx context.Context, pool *pgxpool.Pool) ([]StateRow, error) {
@@ -216,6 +272,68 @@ func statsBySweep(ctx context.Context, pool *pgxpool.Pool) ([]SweepPass, error) 
 	}
 	if err := cursor.Err(); err != nil {
 		return nil, fmt.Errorf("jobs: reading sweep passes: %w", err)
+	}
+	return out, nil
+}
+
+// statsBySweepUnit is statsBySweep one grain down, for the kinds whose
+// dispatcher fans out per connection or per build rather than per workspace.
+//
+// The reading rule is the SAME — latest outcome per unit, never a batch, for
+// the reason statsBySweep sets out in full — and only the key it is latest PER
+// changes: args->>'connection_id' instead of args->>'workspace_id'. That is
+// what removes the masking. A workspace with a healthy connection and a broken
+// one is one healthy unit and one failed unit here, where the workspace pair
+// sees only whichever child ran last.
+//
+// The kind→key pairing arrives as two aligned arrays and is JOINED against
+// rather than spliced into the SQL, so a kind name and an args key never reach
+// the statement as text. The unnest join is also what bounds the scan to the
+// declared sub-workspace kinds: a row of any other kind matches no pair and is
+// not read.
+//
+// An empty pairing means the contract declares no such dispatcher, and the
+// query is skipped rather than run with two empty arrays — the answer is the
+// same, and the skip says why it is empty.
+func statsBySweepUnit(ctx context.Context, pool *pgxpool.Pool) ([]SweepUnit, error) {
+	kinds, argsKeys := subWorkspaceFanOuts()
+	if len(kinds) == 0 {
+		return nil, nil
+	}
+
+	const q = `
+		SELECT kind,
+		       count(*)::bigint,
+		       count(*) FILTER (WHERE state IN ` + terminalBadStates + `)::bigint
+		FROM (
+		    SELECT DISTINCT ON (j.kind, j.args->>u.args_key)
+		           j.kind, j.state::text AS state
+		    FROM river_job j
+		    JOIN unnest($1::text[], $2::text[]) AS u(kind, args_key) ON u.kind = j.kind
+		    WHERE '` + SweepTag + `' = ANY(j.tags)
+		      AND coalesce(j.args->>u.args_key, '') <> ''
+		    ORDER BY j.kind, j.args->>u.args_key, j.created_at DESC, j.id DESC
+		) latest
+		GROUP BY kind`
+
+	cursor, err := pool.Query(ctx, q, kinds, argsKeys)
+	if err != nil {
+		return nil, fmt.Errorf("jobs: reading sweep units: %w", err)
+	}
+	defer cursor.Close()
+
+	units := FanOutUnits()
+	var out []SweepUnit
+	for cursor.Next() {
+		var s SweepUnit
+		if err := cursor.Scan(&s.Kind, &s.Units, &s.Failed); err != nil {
+			return nil, fmt.Errorf("jobs: scanning sweep units: %w", err)
+		}
+		s.Unit = units[s.Kind]
+		out = append(out, s)
+	}
+	if err := cursor.Err(); err != nil {
+		return nil, fmt.Errorf("jobs: reading sweep units: %w", err)
 	}
 	return out, nil
 }

--- a/backend/internal/platform/jobs/stats_integration_test.go
+++ b/backend/internal/platform/jobs/stats_integration_test.go
@@ -31,10 +31,14 @@ type seed struct {
 	Queue     string   // empty means "default"
 	State     string   // river_job_state
 	Workspace ids.UUID // the zero value writes NO workspace_id key at all — a dispatcher
-	Tags      []string
-	CreatedAt time.Time // the zero value means now
-	Scheduled time.Time // the zero value means CreatedAt
-	Attempt   int
+	// Connection is the fan-out unit of the three per-connection dispatchers.
+	// The zero value writes no connection_id key, which is what a
+	// workspace-grained child's args look like.
+	Connection ids.UUID
+	Tags       []string
+	CreatedAt  time.Time // the zero value means now
+	Scheduled  time.Time // the zero value means CreatedAt
+	Attempt    int
 }
 
 // finalizedStates are the states river_job's finalized_or_finalized_at_null
@@ -66,6 +70,9 @@ func seedJob(ctx context.Context, t *testing.T, pool *pgxpool.Pool, s seed) {
 	args := map[string]any{}
 	if s.Workspace != (ids.UUID{}) {
 		args["workspace_id"] = s.Workspace.String()
+	}
+	if s.Connection != (ids.UUID{}) {
+		args["connection_id"] = s.Connection.String()
 	}
 	encodedArgs, err := json.Marshal(args)
 	if err != nil {
@@ -118,6 +125,15 @@ func sweepFor(snap jobs.Snapshot, kind string) (jobs.SweepPass, bool) {
 		}
 	}
 	return jobs.SweepPass{}, false
+}
+
+func unitFor(snap jobs.Snapshot, kind string) (jobs.SweepUnit, bool) {
+	for _, u := range snap.Units {
+		if u.Kind == kind {
+			return u, true
+		}
+	}
+	return jobs.SweepUnit{}, false
 }
 
 // TestStatsCountsLiveWorkAndNamesTheWorkspaceThatOwnsIt proves the two
@@ -368,6 +384,105 @@ func TestSweepCountsEachWorkspacesLatestOutcomeAndSurvivesADeduplicatedRetry(t *
 		t.Errorf("Failed = %d, want 2: only B's LATEST outcome counts, and B succeeded "+
 			"before it died; D was cancelled, which is also work that did not happen",
 			pass.Failed)
+	}
+}
+
+// TestTheUnitPairSeesAFailedConnectionTheWorkspacePairMasks is the whole
+// reason the second pair exists, seeded as the exact shape that hides the
+// failure: ONE workspace, TWO connections, the broken one failing FIRST and
+// the healthy one completing after it.
+//
+// Read per workspace, that workspace's most recent child is the successful
+// one and the pass looks clean. Read per connection, one unit of two is dead.
+// Both readings are asserted here, not just the new one — the masking is a
+// documented property of the workspace pair, and a change that silently
+// "fixed" it there would break what that pair is for (a batch has no
+// identity in this table) while this test still passed on the new half alone.
+//
+// telegram_poll is used rather than a made-up kind because the unit read is
+// derived from the contract: only kinds a dispatcher declares it fans out to
+// per connection are read at all, so a fixture kind would prove a query that
+// never runs.
+func TestTheUnitPairSeesAFailedConnectionTheWorkspacePairMasks(t *testing.T) {
+	_, pool := migratedAppPool(t)
+	ctx := t.Context()
+	earlier, later := time.Now().Add(-2*time.Hour), time.Now().Add(-1*time.Hour)
+	ws := ids.NewV7()
+	broken, healthy := ids.NewV7(), ids.NewV7()
+
+	seedJob(ctx, t, pool, seed{
+		Kind: "telegram_poll", State: "discarded",
+		Workspace: ws, Connection: broken, Tags: []string{jobs.SweepTag}, CreatedAt: earlier,
+	})
+	seedJob(ctx, t, pool, seed{
+		Kind: "telegram_poll", State: "completed",
+		Workspace: ws, Connection: healthy, Tags: []string{jobs.SweepTag}, CreatedAt: later,
+	})
+
+	snap, err := jobs.Stats(ctx, pool)
+	if err != nil {
+		t.Fatalf("Stats: %v", err)
+	}
+
+	pass, ok := sweepFor(snap, "telegram_poll")
+	if !ok {
+		t.Fatal("no per-workspace sweep reported for a tagged kind")
+	}
+	if pass.Workspaces != 1 || pass.Failed != 0 {
+		t.Errorf("workspace pair = %d/%d covered/failed, want 1/0 — this pair counts one workspace "+
+			"once and reads its LATEST child, which is why the failure is invisible here",
+			pass.Workspaces, pass.Failed)
+	}
+
+	unit, ok := unitFor(snap, "telegram_poll")
+	if !ok {
+		t.Fatal("no per-unit sweep reported for a kind whose dispatcher fans out per connection")
+	}
+	if unit.Unit != jobs.FanOutConnection {
+		t.Errorf("Unit = %d, want FanOutConnection — the label an alert reads the grain off", unit.Unit)
+	}
+	if unit.Units != 2 {
+		t.Errorf("Units = %d, want 2: one workspace holding two connections is two units", unit.Units)
+	}
+	if unit.Failed != 1 {
+		t.Errorf("Failed = %d, want 1 — the broken connection, which the workspace pair reported as zero", unit.Failed)
+	}
+}
+
+// TestTheUnitPairIgnoresAnUntaggedRowAndAWorkspaceGrainedKind holds the two
+// boundaries of the new read. An untagged row of a per-connection kind is a
+// job someone triggered by hand, not one connection's share of a fleet pass;
+// and a kind whose declared unit IS the workspace must not appear here at all,
+// or its number would be published twice and an operator summing the pairs
+// would double-count the fleet.
+func TestTheUnitPairIgnoresAnUntaggedRowAndAWorkspaceGrainedKind(t *testing.T) {
+	_, pool := migratedAppPool(t)
+	ctx := t.Context()
+	ws := ids.NewV7()
+
+	seedJob(ctx, t, pool, seed{
+		Kind: "telegram_poll", State: "discarded",
+		Workspace: ws, Connection: ids.NewV7(),
+	})
+	seedJob(ctx, t, pool, seed{
+		Kind: "capture_digest_workspace", State: "discarded",
+		Workspace: ws, Tags: []string{jobs.SweepTag},
+	})
+
+	snap, err := jobs.Stats(ctx, pool)
+	if err != nil {
+		t.Fatalf("Stats: %v", err)
+	}
+	if unit, ok := unitFor(snap, "telegram_poll"); ok {
+		t.Errorf("an untagged row produced a unit series (%+v); a hand-triggered poll is not one "+
+			"connection's share of a fleet pass", unit)
+	}
+	if unit, ok := unitFor(snap, "capture_digest_workspace"); ok {
+		t.Errorf("a workspace-grained kind produced a unit series (%+v); it is already reported by "+
+			"the workspace pair, and two series for one number double-count", unit)
+	}
+	if pass, ok := sweepFor(snap, "capture_digest_workspace"); !ok || pass.Failed != 1 {
+		t.Errorf("the workspace-grained kind must still be reported by the workspace pair; got %+v (present=%t)", pass, ok)
 	}
 }
 

--- a/backend/jobregistrationban_test.go
+++ b/backend/jobregistrationban_test.go
@@ -258,19 +258,25 @@ func TestForbidigoIsEnabledInExactlyOneConfig(t *testing.T) {
 // files only would leave them covered by NOTHING, which is where an http.Error
 // or a stray fmt.Print goes unnoticed for longest.
 func TestTheOwningConfigLintsTheTaggedLanes(t *testing.T) {
-	tagged := map[string][]string{}
+	// The owner is DERIVED, not named: this holds whichever config enables
+	// forbidigo to the tags, so moving ownership moves the obligation with it
+	// rather than leaving this passing about a config that no longer runs the
+	// linter. TestForbidigoIsEnabledInExactlyOneConfig is what makes "the"
+	// owner well defined.
+	owner := ""
 	for _, name := range lintConfigs {
-		tagged[name] = readGolangciConfig(t, name).Run.BuildTags
-	}
-	for _, tag := range []string{"integration", "livesmoke"} {
-		var covered []string
-		for name, tags := range tagged {
-			if slices.Contains(tags, tag) {
-				covered = append(covered, name)
-			}
+		if slices.Contains(readGolangciConfig(t, name).Linters.Enable, "forbidigo") {
+			owner = name
+			break
 		}
-		if !slices.Contains(covered, ".golangci.yml") {
-			t.Errorf("no repo-wide pass declares the %q build tag, so the %s-only files are linted by nothing that runs tree-wide", tag, tag)
+	}
+	if owner == "" {
+		t.Fatal("no config enables forbidigo, so there is no owner to hold to anything")
+	}
+	tags := readGolangciConfig(t, owner).Run.BuildTags
+	for _, tag := range []string{"integration", "livesmoke"} {
+		if !slices.Contains(tags, tag) {
+			t.Errorf("%s owns forbidigo but does not declare the %q build tag, so the %s-only files are linted by nothing", owner, tag, tag)
 		}
 	}
 }

--- a/backend/jobregistrationban_test.go
+++ b/backend/jobregistrationban_test.go
@@ -185,6 +185,10 @@ type forbidRule struct {
 // golangciConfig is the sliver of .golangci.yml this gate reads. The keys are
 // golangci-lint's own, so they are spelled as it spells them.
 type golangciConfig struct {
+	Run struct {
+		//nolint:tagliatelle // golangci-lint's key, not ours to case.
+		BuildTags []string `yaml:"build-tags"`
+	} `yaml:"run"`
 	Linters struct {
 		Enable   []string `yaml:"enable"`
 		Settings struct {
@@ -219,8 +223,8 @@ var lintConfigs = []string{".golangci.yml", ".golangci.strict.yml"}
 // TestForbidigoIsEnabledInExactlyOneConfig keeps the in-source waiver usable.
 //
 // Both passes run over the same files, and the strict one also runs nolintlint.
-// With forbidigo enabled in both under different `forbid:` sets, a
-// //nolint:forbidigo written against one set suppresses nothing under the other,
+// With forbidigo enabled in both under different `forbid:` sets, an in-source
+// forbidigo waiver written against one set suppresses nothing under the other,
 // and nolintlint fails the build for an unused directive — reported by a linter
 // unrelated to the rule being waived, on a line that looks correct. The only
 // waiver left is then exempting a whole FILE by path, which is coarser than
@@ -242,8 +246,32 @@ func TestForbidigoIsEnabledInExactlyOneConfig(t *testing.T) {
 	case 0:
 		t.Error("no lint config enables forbidigo — the River registration and schedule bans are unenforced, and every check in this file passes by having nothing to check")
 	default:
-		t.Errorf("forbidigo is enabled in %s. Two passes with two pattern sets make //nolint:forbidigo unusable tree-wide: whichever set a directive was written for, the other reports it as an unused directive through nolintlint. Enable it in one config and let the other inherit nothing.",
+		t.Errorf("forbidigo is enabled in %s. Two passes with two pattern sets make an in-source forbidigo waiver unusable tree-wide: whichever set a directive was written for, the other reports it as an unused directive through nolintlint. Enable it in one config and let the other inherit nothing.",
 			strings.Join(enabling, " and "))
+	}
+}
+
+// TestTheOwningConfigLintsTheTaggedLanes — forbidigo now lives in one config,
+// and that config must see the same files the other one did. The strict pass
+// declares the integration and livesmoke tags, so before the move it was the
+// only thing linting the tagged harnesses; a baseline that compiled untagged
+// files only would leave them covered by NOTHING, which is where an http.Error
+// or a stray fmt.Print goes unnoticed for longest.
+func TestTheOwningConfigLintsTheTaggedLanes(t *testing.T) {
+	tagged := map[string][]string{}
+	for _, name := range lintConfigs {
+		tagged[name] = readGolangciConfig(t, name).Run.BuildTags
+	}
+	for _, tag := range []string{"integration", "livesmoke"} {
+		var covered []string
+		for name, tags := range tagged {
+			if slices.Contains(tags, tag) {
+				covered = append(covered, name)
+			}
+		}
+		if !slices.Contains(covered, ".golangci.yml") {
+			t.Errorf("no repo-wide pass declares the %q build tag, so the %s-only files are linted by nothing that runs tree-wide", tag, tag)
+		}
 	}
 }
 

--- a/backend/jobregistrationban_test.go
+++ b/backend/jobregistrationban_test.go
@@ -186,6 +186,7 @@ type forbidRule struct {
 // golangci-lint's own, so they are spelled as it spells them.
 type golangciConfig struct {
 	Linters struct {
+		Enable   []string `yaml:"enable"`
 		Settings struct {
 			Forbidigo struct {
 				//nolint:tagliatelle // golangci-lint's key, not ours to case.
@@ -196,12 +197,10 @@ type golangciConfig struct {
 	} `yaml:"linters"`
 }
 
-// riverForbidRules returns the blocklist entries that govern package river,
-// selected by their own pkg expression rather than by position, so reordering
-// or adding unrelated rules cannot silently change what is checked.
-func riverForbidRules(t *testing.T) []forbidRule {
+// readGolangciConfig parses one of the two lint configurations by file name.
+func readGolangciConfig(t *testing.T, name string) golangciConfig {
 	t.Helper()
-	path := filepath.Join(moduleDir(t, backendModulePath), ".golangci.yml")
+	path := filepath.Join(moduleDir(t, backendModulePath), name)
 	raw, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("reading %s: %v", path, err)
@@ -210,7 +209,51 @@ func riverForbidRules(t *testing.T) []forbidRule {
 	if err := yaml.Unmarshal(raw, &cfg); err != nil {
 		t.Fatalf("parsing %s: %v", path, err)
 	}
-	forbidigo := cfg.Linters.Settings.Forbidigo
+	return cfg
+}
+
+// lintConfigs is every golangci-lint configuration `make lint` runs — the
+// repo-wide baseline and the new-code-only strict pass.
+var lintConfigs = []string{".golangci.yml", ".golangci.strict.yml"}
+
+// TestForbidigoIsEnabledInExactlyOneConfig keeps the in-source waiver usable.
+//
+// Both passes run over the same files, and the strict one also runs nolintlint.
+// With forbidigo enabled in both under different `forbid:` sets, a
+// //nolint:forbidigo written against one set suppresses nothing under the other,
+// and nolintlint fails the build for an unused directive — reported by a linter
+// unrelated to the rule being waived, on a line that looks correct. The only
+// waiver left is then exempting a whole FILE by path, which is coarser than
+// anything it stands in for: a second, unsanctioned call added to that file
+// later goes unnoticed.
+//
+// So the rule is ownership, not pattern equality: exactly one config enables
+// forbidigo. Keeping the two sets identical by hand would restore the waiver
+// and reintroduce the duplicate nobody maintains.
+func TestForbidigoIsEnabledInExactlyOneConfig(t *testing.T) {
+	var enabling []string
+	for _, name := range lintConfigs {
+		if slices.Contains(readGolangciConfig(t, name).Linters.Enable, "forbidigo") {
+			enabling = append(enabling, name)
+		}
+	}
+	switch len(enabling) {
+	case 1:
+	case 0:
+		t.Error("no lint config enables forbidigo — the River registration and schedule bans are unenforced, and every check in this file passes by having nothing to check")
+	default:
+		t.Errorf("forbidigo is enabled in %s. Two passes with two pattern sets make //nolint:forbidigo unusable tree-wide: whichever set a directive was written for, the other reports it as an unused directive through nolintlint. Enable it in one config and let the other inherit nothing.",
+			strings.Join(enabling, " and "))
+	}
+}
+
+// riverForbidRules returns the blocklist entries that govern package river,
+// selected by their own pkg expression rather than by position, so reordering
+// or adding unrelated rules cannot silently change what is checked.
+func riverForbidRules(t *testing.T) []forbidRule {
+	t.Helper()
+	const path = ".golangci.yml"
+	forbidigo := readGolangciConfig(t, path).Linters.Settings.Forbidigo
 
 	// pkg is only consulted when forbidigo type-checks; without this the
 	// selection below would be reading a field the linter ignores.

--- a/backend/tools/gen-jobs/main_test.go
+++ b/backend/tools/gen-jobs/main_test.go
@@ -168,6 +168,73 @@ kinds:
 `, fanOutPairingRule)
 }
 
+// A child row carries no unit of its own: every consumer walks the fan-out edge
+// backwards to learn what one stands for. Two dispatchers naming one child with
+// DIFFERENT units make that answer depend on which edge the reader walked last,
+// which is iteration order — so the sweep-unit gauges would report a grain
+// nobody chose. Refused here, where a contract can still be edited.
+func TestParseRejectsTwoDispatchersFanningOutToOneChildWithDifferentUnits(t *testing.T) {
+	mustFail(t, validQueues+`
+kinds:
+  foo:
+    role: dispatcher
+    go_type: FooArgs
+    queue: default
+    timeout: 2m
+    opts_owner: caller
+    cadence: 24h
+    fans_out_to: shared_child
+    fan_out_unit: workspace
+  bar:
+    role: dispatcher
+    go_type: BarArgs
+    queue: default
+    timeout: 2m
+    opts_owner: caller
+    cadence: 24h
+    fans_out_to: shared_child
+    fan_out_unit: connection
+  shared_child:
+    role: workspace
+    go_type: SharedChildArgs
+    queue: default
+    timeout: 2m
+    opts_owner: caller
+`, "a child row stands for ONE unit")
+}
+
+// The same child claimed twice with the SAME unit is unambiguous, so it is not
+// this rule's business — the rule is about disagreement, not about sharing.
+func TestParseAcceptsTwoDispatchersFanningOutToOneChildWithOneUnit(t *testing.T) {
+	mustParse(t, validQueues+`
+kinds:
+  foo:
+    role: dispatcher
+    go_type: FooArgs
+    queue: default
+    timeout: 2m
+    opts_owner: caller
+    cadence: 24h
+    fans_out_to: shared_child
+    fan_out_unit: workspace
+  bar:
+    role: dispatcher
+    go_type: BarArgs
+    queue: default
+    timeout: 2m
+    opts_owner: caller
+    cadence: 24h
+    fans_out_to: shared_child
+    fan_out_unit: workspace
+  shared_child:
+    role: workspace
+    go_type: SharedChildArgs
+    queue: default
+    timeout: 2m
+    opts_owner: caller
+`)
+}
+
 func TestParseRejectsAnUnknownFanOutUnit(t *testing.T) {
 	mustFail(t, validQueues+`
 kinds:

--- a/backend/tools/gen-jobs/validate.go
+++ b/backend/tools/gen-jobs/validate.go
@@ -89,6 +89,13 @@ func (c contract) validate() error {
 		return fmt.Errorf("contract declares no kinds")
 	}
 	byGoType := make(map[string]string, len(c.Kinds))
+	// fannedOutBy records which dispatcher first claimed a child, so a second
+	// one naming it with a DIFFERENT unit is refused here rather than resolved
+	// by whichever the reader happened to walk last. A child row carries no
+	// unit of its own — every consumer walks the edge backwards to learn what
+	// one stands for — so two edges disagreeing about that make the answer a
+	// property of iteration order, and the unit gauges nondeterministic.
+	fannedOutBy := make(map[string]string, len(c.Kinds))
 	for _, name := range c.sortedKinds() {
 		def := c.Kinds[name]
 		if err := c.validateKind(name, def); err != nil {
@@ -99,6 +106,15 @@ func (c contract) validate() error {
 				name, def.GoType, other)
 		}
 		byGoType[def.GoType] = name
+		if def.FansOutTo == "" {
+			continue
+		}
+		if other, claimed := fannedOutBy[def.FansOutTo]; claimed &&
+			c.Kinds[other].FanOutUnit != def.FanOutUnit {
+			return fmt.Errorf("kind %q: fans out to %q per %s, but %q already fans out to it per %s — a child row stands for ONE unit, and two edges disagreeing about which makes the sweep-unit gauges depend on iteration order",
+				name, def.FansOutTo, def.FanOutUnit, other, c.Kinds[other].FanOutUnit)
+		}
+		fannedOutBy[def.FansOutTo] = name
 	}
 	return nil
 }

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -81,10 +81,11 @@ Operational endpoints (served next to `/v1`):
 
 Two readers over one table, `river_job`, answering two different questions.
 Both are served by `cmd/api`, and both are read at request time rather than
-counted in process — `cmd/worker`, where the dispatchers actually run,
-exposes no HTTP surface at all, so an in-process counter there would be
-invisible to every scrape while the api's own copy reported a truthful
-looking zero.
+counted in process: the job table is fleet-wide, so a counter kept inside
+`cmd/worker` would be invisible to every scrape of the api while the api's own
+copy reported a truthful-looking zero. That stays true — the worker never
+re-serves a job-table gauge, and `--observe-addr` below is about the process,
+not the fleet.
 
 **`/metrics` — is a queue growing?** Nine gauge families over the job table:
 
@@ -283,6 +284,44 @@ api's boot line says so; `cmd/worker` is load-bearing for E10 retry. See
 | `--deepread-max-pages` | `MARGINCE_DEEPREAD_MAX_PAGES` | `0` (= built-in 40) | deep-read crawl page cap |
 | `--deepread-max-bytes` | `MARGINCE_DEEPREAD_MAX_BYTES` | `0` (= built-in 32 MiB) | deep-read crawl aggregate byte cap |
 | `--deepread-wall` | `MARGINCE_DEEPREAD_WALL` | `0` (= built-in 4m) | deep-read crawl wall clock |
+| `--observe-addr` | `MARGINCE_OBSERVE_ADDR` | — (off) | address to serve this worker's `/healthz`, `/readyz` and `/metrics` on, e.g. `127.0.0.1:9101`. Empty serves nothing — see below |
+
+### The worker's own operator surface
+
+`--observe-addr` gives `cmd/worker` the three operational endpoints the api has
+always had. It answers a question the fleet-wide gauges structurally cannot:
+**which process** is not doing the work. Every job-table gauge is a projection
+of a shared table, so it reads the same whichever replica served the scrape —
+one wedged worker in a pool of three is arithmetically invisible in it.
+
+What this listener carries is therefore only what is **process-local**, and it
+re-serves no fleet-wide reading:
+
+| Family | Meaning |
+|---|---|
+| `margince_process_goroutines` | goroutines in the scraped process |
+| `margince_process_heap_bytes` / `margince_process_heap_sys_bytes` | heap in use, and heap held from the OS |
+| `margince_process_gc_cycles_total` | completed GC cycles since this process started |
+| `margince_pgxpool_conns` | this process's own connection pool, by class |
+| `margince_relay_published_total` | outbox rows *this* relay has shipped since start |
+
+The same `margince_process_*` section is served by `cmd/api` too — it describes
+whichever process answered, which is exactly what makes it worth having on both.
+`margince_outbox_unpublished`, the job-table gauges and the declared catalogue
+stay a **single** reading on the api: two roles answering one fleet number is a
+worse operator surface than one gap.
+
+`/readyz` probes the two dependencies this role cannot work without — Postgres
+and Redis — and answers `503` naming the one that failed. `/healthz` stays a
+dumb liveness answer, so a database outage stops traffic being routed here
+without restart-looping a process the outage did not break.
+
+**Off is the default, and it is not a convenience default.** This surface
+carries workspace ids and has no authentication of its own, exactly like the
+api's `/metrics`: exposing it is an operator decision, and so is the interface
+it binds. Bind it to a loopback or a private interface, never a public one. An
+address that cannot be bound is a **boot error** naming it — a worker that
+could not serve its probes must not carry on looking healthy.
 
 ### `worker siteread` — the deep-read debug loop (no DB)
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -237,7 +237,8 @@ Four things worth knowing before you build an alert on these:
   reports zero failures while a connection is dead. The unit pair counts each
   connection in its own right and reports the failure. Read the workspace pair
   for fleet coverage and the unit pair for whether every unit of a pass ran;
-  neither replaces the other, and no kind is in both.
+  neither replaces the other, and the four finer-grained kinds appear in both —
+  see the note above on never summing them.
 
 **`/metrics` is fleet-wide; the endpoint is not.** The exposition carries
 every workspace's id and every kind, because an operator scraping a service

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -342,7 +342,10 @@ that failed. `boot` is this replica having finished starting its event lanes and
 job runner: the listener comes up before those on purpose, so a probe answers
 during a slow boot, and without that check the ordering would let a rollout
 retire the last working replica in favour of one that had not yet picked up a
-job. The body carries no AI line — unlike the api this role wires none, and an
+job, and it goes false again the moment shutdown begins — the listener is
+stopped LAST so the drain stays observable, and a draining replica that still
+answered ready would keep being sent work it is putting down. The body carries
+no AI line — unlike the api this role wires none, and an
 empty field reads as a state that could not be determined rather than as one
 that does not apply. `/healthz` stays a dumb liveness answer, so a database
 outage stops traffic being routed here without restart-looping a process the

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -86,7 +86,7 @@ exposes no HTTP surface at all, so an in-process counter there would be
 invisible to every scrape while the api's own copy reported a truthful
 looking zero.
 
-**`/metrics` — is a queue growing?** Seven gauge families over the job table:
+**`/metrics` — is a queue growing?** Nine gauge families over the job table:
 
 | Family | Labels | Meaning |
 |---|---|---|
@@ -97,8 +97,18 @@ looking zero.
 | `margince_job_oldest_queued_age_seconds` | `queue`, `workspace_id` | how long the oldest runnable-and-unclaimed job has waited |
 | `margince_sweep_workspaces_total` | `sweep` | workspaces with a surviving child of that fleet pass |
 | `margince_sweep_workspaces_failed` | `sweep` | those whose MOST RECENT child is discarded or cancelled |
+| `margince_sweep_units_total` | `sweep`, `unit` | the same reading one grain down, for the dispatchers that fan out per **connection** or per **build**: units with a surviving child |
+| `margince_sweep_units_failed` | `sweep`, `unit` | those whose MOST RECENT child is discarded or cancelled |
 
-An eighth, `margince_job_unrecognised_state{state,queue,workspace_id}`,
+The last two exist because the workspace pair counts each workspace once, and
+four dispatchers fan out below that grain. They report **only** the kinds whose
+declared `fan_out_unit` is finer than a workspace — for the other twenty-one the
+unit *is* the workspace, so the two pairs would carry the same numbers. Together
+they partition the fan-out kinds: every kind appears in exactly one, so an alert
+covers the fleet with `margince_sweep_workspaces_failed > 0 or
+margince_sweep_units_failed > 0` and never double-counts.
+
+A tenth, `margince_job_unrecognised_state{state,queue,workspace_id}`,
 appears **only when it has something to report**: work sitting in a state
 this exposition does not classify. It is a signal to investigate, not a
 series to graph, which is why it is absent rather than zero the rest of the
@@ -193,14 +203,16 @@ Four things worth knowing before you build an alert on these:
   because the fleet shrank: the cleaner deletes finalized rows on its own
   schedule. An absent series is the honest answer — a fabricated zero would
   be indistinguishable from "the fleet is empty".
-
-One further limit, stated because nothing in the numbers reveals it: a
-dispatcher that fans out per **connection** rather than per workspace (Gmail
-sync, Gmail watch, Telegram poll) still counts each workspace once. If one
-workspace holds two connections and only one of them is failing, that
-workspace's most recent child may be the successful one, and the failure is
-not reflected in `margince_sweep_workspaces_failed`. Per-connection health is
-visible on the endpoint below, by kind.
+- **The per-workspace pair reads one grain too coarse for four dispatchers,**
+  and that is what `margince_sweep_units_*` is for. Gmail sync, Gmail watch and
+  the Telegram poll fan out per **connection**; the voice-build retry fans out
+  per **build**. A workspace holding two connections produces two children per
+  pass, and if the broken one failed before the healthy one succeeded, that
+  workspace's most recent child is the successful one — so the workspace pair
+  reports zero failures while a connection is dead. The unit pair counts each
+  connection in its own right and reports the failure. Read the workspace pair
+  for fleet coverage and the unit pair for whether every unit of a pass ran;
+  neither replaces the other, and no kind is in both.
 
 **`/metrics` is fleet-wide; the endpoint is not.** The exposition carries
 every workspace's id and every kind, because an operator scraping a service

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -103,11 +103,17 @@ not the fleet.
 
 The last two exist because the workspace pair counts each workspace once, and
 four dispatchers fan out below that grain. They report **only** the kinds whose
-declared `fan_out_unit` is finer than a workspace — for the other twenty-one the
-unit *is* the workspace, so the two pairs would carry the same numbers. Together
-they partition the fan-out kinds: every kind appears in exactly one, so an alert
-covers the fleet with `margince_sweep_workspaces_failed > 0 or
-margince_sweep_units_failed > 0` and never double-counts.
+declared `fan_out_unit` is finer than a workspace — for the other twenty the
+unit *is* the workspace, so the two pairs would carry the same numbers.
+
+The two families **overlap rather than partition**: a per-connection kind is
+reported by both, at two grains, because its rows carry a workspace id as well
+as a connection id. That is the point — the coarse reading answers *is every
+tenant covered*, the fine one answers *did every unit of the pass run* — but it
+means **never sum them**. `margince_sweep_units_failed{sweep="telegram_poll"}`
+and `margince_sweep_workspaces_failed{sweep="telegram_poll"}` can both be
+non-zero for one dead connection. Alert on whichever grain you mean; use
+`... > 0 or ... > 0` if you want either to page you, never `+`.
 
 A tenth, `margince_job_unrecognised_state{state,queue,workspace_id}`,
 appears **only when it has something to report**: work sitting in a state
@@ -204,6 +210,15 @@ Four things worth knowing before you build an alert on these:
   because the fleet shrank: the cleaner deletes finalized rows on its own
   schedule. An absent series is the honest answer — a fabricated zero would
   be indistinguishable from "the fleet is empty".
+- **Both `_failed` halves see only what River sees.** They count rows that ended
+  `discarded` or `cancelled`. A kind whose worker deliberately records its own
+  failure and returns `nil` — declared as `fault.nil_after_logging` in
+  `backend/api/jobs.yaml`, and true of `capture_sync` and `voice_build`, whose
+  retry cadence belongs to their own sidecar rather than to River — completes
+  green, so a handled failure of one of those does not reach either pair. For
+  those kinds a zero here means "River saw no dead rows", not "nothing failed";
+  their own domain state is the authority. This is a property of the sweep
+  reading as a whole, not of the per-unit half.
 - **The per-workspace pair reads one grain too coarse for four dispatchers,**
   and that is what `margince_sweep_units_*` is for. Gmail sync, Gmail watch and
   the Telegram poll fan out per **connection**; the voice-build retry fans out
@@ -316,12 +331,19 @@ and Redis — and answers `503` naming the one that failed. `/healthz` stays a
 dumb liveness answer, so a database outage stops traffic being routed here
 without restart-looping a process the outage did not break.
 
-**Off is the default, and it is not a convenience default.** This surface
-carries workspace ids and has no authentication of its own, exactly like the
-api's `/metrics`: exposing it is an operator decision, and so is the interface
-it binds. Bind it to a loopback or a private interface, never a public one. An
-address that cannot be bound is a **boot error** naming it — a worker that
-could not serve its probes must not carry on looking healthy.
+`/readyz` also reports **`boot`** — this replica has finished starting its
+event lanes and job runner. The listener comes up before those on purpose, so a
+probe answers during a slow boot; without the boot check that ordering would let
+a rollout retire the last working replica in favour of one that had not yet
+picked up a job.
+
+**Off is the default, and it is not a convenience default.** Unlike the api's
+`/metrics` this surface carries no workspace id and no tenant data at all — but
+it is still an unauthenticated operator surface that discloses dependency health
+and process capacity, so exposing it is an operator decision, and so is the
+interface it binds. Bind it to a loopback or a private interface, never a public
+one. An address that cannot be bound is a **boot error** naming it — a worker
+that could not serve its probes must not carry on looking healthy.
 
 ### `worker siteread` — the deep-read debug loop (no DB)
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -115,6 +115,15 @@ and `margince_sweep_workspaces_failed{sweep="telegram_poll"}` can both be
 non-zero for one dead connection. Alert on whichever grain you mean; use
 `... > 0 or ... > 0` if you want either to page you, never `+`.
 
+The `sweep` label on both pairs is the **child** kind, not the dispatcher's —
+`sweep="telegram_poll"`, not `telegram_poll_sweep` — because the child is what
+the rows hold, and mapping back to the dispatcher would be a hand-kept table.
+That matters for a dashboard: joining a sweep series to
+`margince_job_declared_info` on the kind lands on the CHILD's catalogue entry,
+which carries no `fan_out_unit` — that label is declared on the dispatcher. The
+unit pair carries its grain in its own `unit` label for exactly that reason, so
+no join is needed to read it.
+
 A tenth, `margince_job_unrecognised_state{state,queue,workspace_id}`,
 appears **only when it has something to report**: work sitting in a state
 this exposition does not classify. It is a signal to investigate, not a
@@ -326,16 +335,17 @@ whichever process answered, which is exactly what makes it worth having on both.
 stay a **single** reading on the api: two roles answering one fleet number is a
 worse operator surface than one gap.
 
-`/readyz` probes the two dependencies this role cannot work without — Postgres
-and Redis — and answers `503` naming the one that failed. `/healthz` stays a
-dumb liveness answer, so a database outage stops traffic being routed here
-without restart-looping a process the outage did not break.
-
-`/readyz` also reports **`boot`** — this replica has finished starting its
-event lanes and job runner. The listener comes up before those on purpose, so a
-probe answers during a slow boot; without the boot check that ordering would let
-a rollout retire the last working replica in favour of one that had not yet
-picked up a job.
+`/readyz` probes the three things this replica needs before it can do any work
+— **`boot`**, **`postgres`** and **`redis`** — and answers `503` naming the one
+that failed. `boot` is this replica having finished starting its event lanes and
+job runner: the listener comes up before those on purpose, so a probe answers
+during a slow boot, and without that check the ordering would let a rollout
+retire the last working replica in favour of one that had not yet picked up a
+job. The body carries no AI line — unlike the api this role wires none, and an
+empty field reads as a state that could not be determined rather than as one
+that does not apply. `/healthz` stays a dumb liveness answer, so a database
+outage stops traffic being routed here without restart-looping a process the
+outage did not break.
 
 **Off is the default, and it is not a convenience default.** Unlike the api's
 `/metrics` this surface carries no workspace id and no tenant data at all — but


### PR DESCRIPTION
Closes #428, #429, #430, #431, #432 — every follow-up filed from #446.

## What changes

**#432 — a dispatcher enqueued by hand runs the whole fleet.** One tenant finishing a capture backfill enqueued the `capture_digest` **dispatcher**, which fans one job out per workspace across the installation. The intent at that call site is local; the effect scaled with the number of tenants running backfills. It now enqueues the child kind for the one workspace it already knows, through `oneOffChildOpts` — declared queue and attempt cap, and deliberately *neither* the sweep tag (a job one tenant asked for is not one workspace's share of a fleet pass) nor the active-state uniqueness (the event fired *because* new rows landed; a pass already running may have read the workspace before they did).

Closed as a class, not at the call site: `TestNoScheduledDispatcherIsEnqueuedByHand` refuses a dispatcher args value constructed anywhere but `periodicFor`, in all three spellings (composite literal, `var`, `new(T)`). The one exception is **derived** from the contract rather than listed — a kind whose declared cadence is `on_demand` has no clock, so a call site is the only thing that can place it.

**#431 — a failed connection the workspace pair cannot see.** `margince_sweep_workspaces_*` counts distinct workspaces, and four dispatchers fan out below that grain. A workspace holding two connections produces two children per pass; if the broken one failed *before* the healthy one succeeded, the most recent child is the successful one and the pair reports zero failures.

Making the existing pair per-child would break what it is for — River resolves a uniqueness conflict by updating the existing row, so there is no "last pass" in `river_job` and any batch-keyed reading under-reports a dispatcher retried mid-fleet. So this is a **second** pair at the declared grain: `margince_sweep_units_total` / `_failed`, grouped on the args key the declared `fan_out_unit` names, with kind and key passed as two aligned arrays joined against `river_job` (neither reaches the statement as text).

The two families **overlap rather than partition** — a per-connection kind is reported by both, at two grains — which is stated in the docs together with *never sum them*.

Nothing here is hand-maintained: `FanOutUnits` walks the declared edges backwards, `ArgsKey` is a switch over the unit enum gated by a test that reads the units the **contract** declares, and a census arm holds every fan-out child to actually *writing* that key — checked against `encoding/json`, because a Go field named `ConnectionID` satisfies a name-level walk while the column holds `connection_id`.

**#430 — `cmd/worker` published nothing about itself.** `--observe-addr` (env `MARGINCE_OBSERVE_ADDR`, default **off**) serves `/healthz`, `/readyz` and `/metrics`. It carries only what is process-local — Go runtime, this process's pool, this process's relay counter — and re-serves no job-table gauge and no outbox backlog: those stay a single fleet-wide reading on the api, and a test asserts both directions by name. `/readyz` probes `boot`, `postgres` and `redis`; the boot gate exists because the listener comes up *before* the lanes and the runner on purpose, and without it a rollout could retire the last working replica for one that had not yet picked up a job.

**#428 — the waiver that could not be written.** `forbidigo` was enabled in both lint configs with different pattern sets, so an in-source waiver written for one was reported as *unused* by the other's `nolintlint`, failing the build in a linter unrelated to the rule being waived. It now lives in `.golangci.yml` alone, held there by a gate. Its two extra rules became repo-wide, which cost one real fix: the split-update handler answered a marshal failure with a `text/plain` `http.Error` on a surface where every other refusal is an RFC 7807 document.

**#429** — dropped the `STATUS.md` pointer from `replayscope.go`'s type comment.

## Gate evidence

Each gate was watched to fail before being trusted.

**The dispatcher gate, against the reverted fix:**
```
--- FAIL: TestNoScheduledDispatcherIsEnqueuedByHand
    capturejobs.go:336:34: CaptureDigestArgs (capture_digest) is constructed outside periodicFor.
    It is a dispatcher with a declared cadence, so enqueueing it fans one job out per workspace
    across the whole installation
```
And against a `var` declaration, which the first version of the walk could not see: `capturejobs.go:264:5: CaptureDigestArgs (capture_digest) is constructed outside periodicFor`.

**The unit-key census arm, with `ArgsKey` repointed at a key nothing writes:**
```
--- FAIL: TestJobCensusMatchesTheContract
    capture_sync is fanned out per connection but its rows carry no "conn_id" key
    (they carry [connection_id provider workspace_id]) — the sweep gauges group on that key,
    so every child of this kind would be dropped from the count rather than reported as a failure
```

**The #428 trap, reproduced and then removed.** With `forbidigo` re-added to the strict config under a different pattern set:
```
internal/compose/jobregistry.go:173:2: directive `//nolint:forbidigo // the ONE sanctioned
registration: …` is unused for linter "forbidigo" (nolintlint)
```
With the fix in place both passes report `0 issues.`

**The backfill-digest integration test, against the old behaviour:**
```
--- FAIL: TestBackfillCompletionBuildsTheDigest
    capture_digest rows went 1 -> 2 across the backfill; a completion must enqueue the CHILD kind
    0 untagged capture_digest_workspace row(s), want exactly 1
```

## UAT — live stack, two independent runs

Run against `make dev` (api :18080, worker observe surface :19101). Both agents reported PASS on every item.

**#430 — the worker surface.** `/healthz` → `200 ok`. `/readyz` → `200 ready`. `/metrics` serves exactly six families and no more:
```
margince_process_goroutines 83
margince_process_heap_bytes 26671128
margince_process_heap_sys_bytes 36339712
margince_process_gc_cycles_total 1
margince_relay_published_total 0
margince_pgxpool_conns{state="acquired"} 0
margince_pgxpool_conns{state="idle"} 7
margince_pgxpool_conns{state="total"} 7
margince_pgxpool_conns{state="max"} 16
```
`margince_job_queue_depth`, `margince_job_declared_info`, `margince_sweep_workspaces_total`, `margince_sweep_units_total` and `margince_outbox_unpublished` are absent as raw substrings — not even a HELP line mentions them. Every series has a `# HELP` and a `# TYPE`.

Proven process-local rather than the same reading twice, across three consecutive scrape rounds:
```
worker: goroutines 83→84  heap 28116632→28131456  pgxpool total 7
api   : goroutines  9→ 9  heap 23993016→24125080  pgxpool total 3
```
Two distinct PIDs behind the two ports. The live worker's command line carries **no** `--observe-addr` flag — the surface came on purely from the env var, so that path is proven end to end, and `--help` shows no default (Go prints one only for a non-zero value).

**#431 — the masking, reproduced in the live database.** One workspace, two connections, kind `telegram_poll`, both `sweep`-tagged; the broken one discarded 2h ago, the healthy one completed 1h ago.

Before:
```
# TYPE margince_sweep_units_total gauge      (header present, no series — idle fleet)
# TYPE margince_sweep_units_failed gauge
```
After the inserts — this is the issue, on the wire:
```
margince_sweep_workspaces_total{sweep="telegram_poll"} 1
margince_sweep_workspaces_failed{sweep="telegram_poll"} 0
margince_sweep_units_total{sweep="telegram_poll",unit="connection"} 2
margince_sweep_units_failed{sweep="telegram_poll",unit="connection"} 1
```
Then a tagged `capture_digest_workspace` row was added for the same workspace and appeared in `margince_sweep_workspaces_*` while `margince_sweep_units_*` still contained only the two `telegram_poll` lines — proving the exclusion is a grain **selection**, not an absence of data. Every seeded row was deleted and the series returned to their prior state.

## Review provenance

Two independent whole-branch reviews (Fable and Codex) before UAT. Between them they found the comment-asserts-a-false-invariant class **five** times — three introduced by this branch — plus three real gaps in the worker listener: `/readyz` answering ready before the lanes and runner started, no read/write/idle timeouts on an unauthenticated listener, and a reserve-close-rebind port race in the tests. All fixed; the listener now returns the address it bound, so `:0` works and "off bound nothing" is a value rather than an absence inferred from a call that did not error.

Two gates were **widened** rather than patched as a result: the dispatcher walk (three spellings, not one) and the baseline lint config, which now declares the `integration`/`livesmoke` tags — moving `forbidigo` out of the strict config had silently dropped the tagged harnesses out of every pass. Zero new findings from that widening, and a test holds it.

UAT then found three more the tests could not: an empty `ai:` line in the worker's readiness body, no browser-facing headers on the new surface, and a real dashboard hazard — the `sweep` label is the **child** kind, so a join to `margince_job_declared_info` lands on an entry carrying no `fan_out_unit`. All three fixed or documented.

**Bot round.** CodeRabbit and cubic then found 15 more between them. Ten were real and are fixed — including three genuine defects in this branch's own new code that neither earlier review nor UAT caught:

- `FanOutUnits` walked an **unordered map and overwrote on collision**. Nothing in the contract stopped two dispatchers naming one child with different units, and the winner would then be whichever the range reached last — a grain nobody chose, and one that could differ between processes. Closed at *generation* now, where a contract can still be edited; two edges sharing a child with the same unit stay legal, because the rule is about disagreement, not sharing.
- The unit read **dropped `statsBySweep`'s workspace predicate**, so a malformed row carrying a connection id and an empty `workspace_id` would credit a pass with coverage belonging to no tenant.
- `/readyz` **stayed green through the whole shutdown**. The listener is stopped last on purpose so the drain stays observable, which meant a terminating replica kept advertising itself while the runner and lanes were being put down. `bootGate` answers no at both ends of the process's life now, with `draining()` deferred after `complete()` so LIFO puts it ahead of the runner stop — 200 before, 503 after, proven in the integration lane.

Plus one unfalsifiable test of mine (the `ai:` omission asserted over a 503 body that never had the line), one env-dependent one (`--dsn` backs its default with `MARGINCE_DSN`), and four documentation and error-message corrections.

Four were declined with reasoning rather than silence, and two of those became follow-up issues: #460 (both sweep pairs carry a `_total` suffix on a gauge — a convention point that applies to all four families or to none, and a breaking dashboard change either way) and #461 (`/metrics` and `/readyz` discard response-write failures while the job section does not — pre-existing, and the split is principled but invisible). Every review thread is answered and resolved.

## What is deliberately NOT claimed

- **Both `_failed` halves see only what River sees.** A kind declaring `fault.nil_after_logging` — `capture_sync` and `voice_build`, whose retry cadence belongs to their own sidecar — records its own failure and completes green, so a handled failure does not reach either pair. This is a property of the sweep reading as a whole rather than of the new half, and it is now stated where an operator reads the number.
- **The dispatcher-enqueue gate walks this package's own top-level product sources.** A dispatcher value built in a subpackage, in a `cmd`, or returned from a helper is outside it. Stated in the test rather than left implied; the enqueue door itself is held separately by the generated closed union.
- **`unit="build"` is unexercised on the wire** — no live build data existed during UAT. The family and label rendering are unit-tested.

## Coverage

**84.1%** of this branch's new statements (246 statements, 207 covered), measured across the unit and integration lanes. Two files sit under the bar and neither is new ground: `cmd/worker/main.go` at 42.9% is `run()`, which needs a full boot to reach and was untested before this branch, and `internal/compose/agentsplit.go` at 66.7% is the split handler's staging path, which has no handler test at all — the lines this branch changed in it are covered.

## Gates run locally

`make check-backend`, `make check-fe`, `make craft-static`, `make test-integration` (`OK: integration passed with 0 skips`), and both `golangci-lint` passes (`0 issues.` each) — all after merging `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents accidental fleet-wide dispatches, adds per-unit sweep metrics, and gives `cmd/worker` its own health, readiness, and metrics surface. Also hardens readiness during shutdown, validates the job contract for unit consistency, and fixes docs and error shapes.

- **New Features**
  - Per-unit sweep metrics: `margince_sweep_units_total` and `_failed`, grouped by declared `unit` (e.g., `connection`, `build`). Docs note overlap with workspace pair.
  - `cmd/worker` observe surface: `--observe-addr` (env `MARGINCE_OBSERVE_ADDR`) serves `/healthz`, `/readyz` (boot/postgres/redis), and `/metrics` with process-local gauges only.

- **Bug Fixes**
  - Prevent fleet-wide dispatches: backfill completion enqueues the workspace child via `oneOffChildOpts` (no sweep tag or active-unique); gate rejects hand-enqueueing scheduled dispatchers outside `periodicFor` (except `on_demand`).
  - Metrics correctness and contract validation: enforce workspace scoping in unit reads; refuse two dispatchers fanning out to the same child with different units at generation time; deterministic unit mapping; tests added.
  - Hardened `cmd/worker` listener: proper readiness gating including flipping not-ready during shutdown, connection timeouts, safe `:0` binding, omits empty `ai:` line, and adds standard security headers.
  - Lint config: own `forbidigo` in `.golangci.yml` and lint `integration`/`livesmoke` tags; gate added to keep this ownership.
  - Split-update marshal failures now return RFC 7807 JSON; removed the stale `STATUS.md` reference and corrected docs.

<sup>Written for commit fe015faeccf2b3e8ffe1a1dc4420b59794d6d5e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/457?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional worker health, readiness, and metrics endpoints.
  * Added process-local runtime metrics and detailed per-unit job metrics.
  * Readiness checks now report boot, database, and cache status.

* **Bug Fixes**
  * Backfill completion now schedules workspace-scoped digest work.
  * Improved JSON error responses and response replay behavior.
  * Invalid worker settings are rejected earlier with clearer errors.

* **Documentation**
  * Documented observability endpoints, readiness behavior, and expanded metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
