### PR TITLE
fix(auth): the reset token stops leaving the browser, and one spelling for the emailed link

### DIFF
--- a/backend/internal/modules/identity/handlers_users.go
+++ b/backend/internal/modules/identity/handlers_users.go
@@ -138,7 +138,7 @@ func (h Handlers) sendInvite(r *http.Request, email, rawToken string) {
 	if h.resetMailer == nil || rawToken == "" {
 		return
 	}
-	link := h.resetBaseURL + "/reset-password?token=" + rawToken
+	link := passwordLink(h.resetBaseURL, rawToken)
 	body := "You've been invited to Margince.\n\n" +
 		"Set your password within seven days to sign in:\n\n  " + link + "\n\n" +
 		"If you weren't expecting this, you can ignore this email."

--- a/backend/internal/modules/identity/passwordlink.go
+++ b/backend/internal/modules/identity/passwordlink.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package identity
+
+// passwordLink is the ONE spelling of an emailed set-password deep link, and the
+// reason it is a function rather than a string per caller is that the token's
+// PLACEMENT in the URL is a security property — not a decision each caller gets
+// to make. Both mails that use it carry a live single-use credential: the reset
+// link for one hour, the invite link for seven days.
+//
+// The token rides in the FRAGMENT, which a BROWSER never puts on the wire. That
+// closes the three legs a query string loses on: the credential cannot reach an
+// access log, cannot be sent as a Referer on the SPA's same-origin /v1 calls, and
+// cannot become a Cache Storage key — a service worker caching a navigation keys
+// it on the full URL, query included.
+//
+// It is not an absolute guarantee, and the difference matters when reading the
+// TTLs above. A click-tracking mail gateway (Safe Links, Proofpoint, Mimecast)
+// re-serializes the whole URL — fragment and all — into its OWN query string, so
+// the token lands in a third party's request line whichever form we choose. The
+// fragment is the right default; the containment is single use plus the TTL.
+//
+// The shape is the app's own hash route rather than a bare `#token=` because
+// `parseHash` (frontend app/router.tsx) reads the first hash segment as the screen
+// name and strips a hash-local query: `#/reset-password?token=…` parses, while
+// `#token=…` would make the token itself the screen name.
+//
+// `baseURL` arrives with any trailing slash already trimmed (see
+// `Handlers.WithPasswordReset`), so this concatenation cannot produce `//#/`.
+func passwordLink(baseURL, rawToken string) string {
+	return baseURL + "/#/reset-password?token=" + rawToken
+}

--- a/backend/internal/modules/identity/passwordlink_test.go
+++ b/backend/internal/modules/identity/passwordlink_test.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package identity
+
+// Where an emailed credential sits in a URL is a security property, so it is
+// gated rather than reviewed. Two mails carry a live single-use token — the
+// password reset (one hour) and the member invite (seven days) — and both are
+// only as safe as the URL they are pasted into: a token in the server-visible
+// part reaches nginx access logs, is sent as a Referer on the SPA's same-origin
+// /v1 calls, and becomes a Cache Storage key when a service worker caches the
+// navigation.
+//
+// A test of `passwordLink` alone would keep passing while a caller hand-rolled a
+// second link beside it, so the guard below derives the obligation from the
+// package's own source instead.
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestPasswordLinkKeepsTheTokenOutOfTheServerVisibleURL(t *testing.T) {
+	link := passwordLink("https://crm.example.test", "raw-token-value")
+
+	// Everything before the '#' is what a server, a proxy and an access log get
+	// to see. The token must not be in it.
+	serverVisible, fragment, found := strings.Cut(link, "#")
+	if !found {
+		t.Fatalf("link carries no fragment, so the token is server-visible: %q", link)
+	}
+	if strings.Contains(serverVisible, "raw-token-value") {
+		t.Errorf(
+			"token appears in the server-visible part of the link: %q (full: %q)",
+			serverVisible, link,
+		)
+	}
+	if !strings.Contains(fragment, "raw-token-value") {
+		t.Errorf("token is not in the fragment, so the link cannot work: %q", link)
+	}
+}
+
+// readsBaseURL matches a READ of the field, so the assignment in
+// `WithPasswordReset` is not mistaken for a link being built.
+var readsBaseURL = regexp.MustCompile(`h\.resetBaseURL\s*[^=\s]|h\.resetBaseURL\s*$`)
+
+func TestEveryEmailedLinkIsBuiltByPasswordLink(t *testing.T) {
+	// Keyed on the BASE URL rather than on a path string, and that choice is the
+	// whole strength of this test: any hand-rolled builder must read
+	// `h.resetBaseURL` to have something to build from, whatever it does with the
+	// path afterwards. Matching a literal like "/reset-password?token=" instead
+	// would pass for an fmt.Sprintf, for a split constant, or for any other
+	// spelling of the same defect — a point fix dressed as a fitness function.
+	//
+	// One directory, non-recursively, is the CORRECT scope and not a shortcut:
+	// `resetBaseURL` is an unexported field, so no other package — including
+	// `identity/internal/...` — can read it. The field's visibility is what bounds
+	// the search. Widen this to the tree and it stops being a closed argument.
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read package dir: %v", err)
+	}
+
+	scanned, checked := 0, 0
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") {
+			continue
+		}
+		// Test files may read the field in order to assert against it.
+		if strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		source, err := os.ReadFile(filepath.Clean(name))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		scanned++
+		for number, line := range strings.Split(string(source), "\n") {
+			if !readsBaseURL.MatchString(line) {
+				continue
+			}
+			checked++
+			if !strings.Contains(line, "passwordLink(") {
+				t.Errorf(
+					"%s:%d reads resetBaseURL outside passwordLink — build the link "+
+						"with passwordLink so the token stays in the fragment:\n\t%s",
+					name, number+1, strings.TrimSpace(line),
+				)
+			}
+		}
+	}
+
+	// A scan that matched nothing would pass while proving nothing, so both the
+	// file walk and the field reads have to have found something.
+	if scanned == 0 {
+		t.Fatal("scanned no package source files — the guard is vacuous")
+	}
+	if checked == 0 {
+		t.Fatal("found no read of resetBaseURL — the guard no longer matches the field")
+	}
+}

--- a/backend/internal/modules/identity/reset.go
+++ b/backend/internal/modules/identity/reset.go
@@ -87,6 +87,18 @@ func (h Handlers) RequestPasswordReset(w http.ResponseWriter, r *http.Request) {
 		if done != nil {
 			defer done()
 		}
+		// This goroutine OUTLIVES the request, so the chassis's recovery
+		// middleware — which wraps the handler — cannot see a panic in here, and an
+		// unrecovered panic in any goroutine takes the whole process down. The
+		// endpoint is unauthenticated, which is what makes that unacceptable rather
+		// than merely untidy: it would be a one-request denial of service for
+		// anybody who could reach a panicking path. Nothing below panics today; the
+		// point is that a future edit here must not be able to.
+		defer func() {
+			if panicked := recover(); panicked != nil {
+				slog.Error("password-reset send panicked", "panic", panicked)
+			}
+		}()
 		rawToken, err := h.svc.CreatePasswordReset(workCtx, email.String())
 		if err != nil {
 			slog.Error("password-reset token mint failed", "err", err)
@@ -95,19 +107,7 @@ func (h Handlers) RequestPasswordReset(w http.ResponseWriter, r *http.Request) {
 		if rawToken == "" {
 			return
 		}
-		// The token rides in the FRAGMENT, never in the server-visible query, and
-		// that is a security property rather than a style choice. A fragment is
-		// never sent to a server, so the live single-use credential cannot reach
-		// an access log, cannot be sent as a Referer on the same-origin /v1 calls
-		// the SPA makes before it has scrubbed the URL, and cannot become a Cache
-		// Storage key (which includes the query). All three defeated the
-		// front-end's own scrub, which ran too late to help.
-		//
-		// The shape is the app's own hash route rather than a bare `#token=`:
-		// `parseHash` (app/router.tsx) reads the first hash segment as the screen
-		// name and strips a hash-local query, so `#/reset-password?token=…` parses
-		// correctly while `#token=…` would make the token itself the screen name.
-		link := h.resetBaseURL + "/#/reset-password?token=" + rawToken
+		link := passwordLink(h.resetBaseURL, rawToken)
 		body := "Someone requested a password reset for your Margince account.\n\n" +
 			"Reset your password within one hour:\n\n  " + link + "\n\n" +
 			"If this wasn't you, ignore this email — your password is unchanged."

--- a/backend/internal/modules/identity/reset.go
+++ b/backend/internal/modules/identity/reset.go
@@ -95,7 +95,19 @@ func (h Handlers) RequestPasswordReset(w http.ResponseWriter, r *http.Request) {
 		if rawToken == "" {
 			return
 		}
-		link := h.resetBaseURL + "/reset-password?token=" + rawToken
+		// The token rides in the FRAGMENT, never in the server-visible query, and
+		// that is a security property rather than a style choice. A fragment is
+		// never sent to a server, so the live single-use credential cannot reach
+		// an access log, cannot be sent as a Referer on the same-origin /v1 calls
+		// the SPA makes before it has scrubbed the URL, and cannot become a Cache
+		// Storage key (which includes the query). All three defeated the
+		// front-end's own scrub, which ran too late to help.
+		//
+		// The shape is the app's own hash route rather than a bare `#token=`:
+		// `parseHash` (app/router.tsx) reads the first hash segment as the screen
+		// name and strips a hash-local query, so `#/reset-password?token=…` parses
+		// correctly while `#token=…` would make the token itself the screen name.
+		link := h.resetBaseURL + "/#/reset-password?token=" + rawToken
 		body := "Someone requested a password reset for your Margince account.\n\n" +
 			"Reset your password within one hour:\n\n  " + link + "\n\n" +
 			"If this wasn't you, ignore this email — your password is unchanged."

--- a/backend/internal/modules/identity/reset_integration_test.go
+++ b/backend/internal/modules/identity/reset_integration_test.go
@@ -70,14 +70,19 @@ func TestPasswordResetFlowEndToEnd(t *testing.T) {
 	if mail.sent != 1 || mail.to != e.member.Email {
 		t.Fatalf("mail = %+v, want one message to the member", mail)
 	}
-	// The token must be in the FRAGMENT. A query string would hand this live
-	// single-use credential to every access log, Referer header and Cache Storage
-	// key on the way in, so the shape is a security assertion, not a formatting one.
-	if strings.Contains(mail.body, "/reset-password?token=") {
-		t.Fatalf("reset link puts the token in the server-visible query: %q", mail.body)
-	}
 	if !strings.Contains(mail.body, "https://crm.example.test/#/reset-password?token=") {
 		t.Fatalf("mail body carries no reset link: %q", mail.body)
+	}
+	// The token must be in the FRAGMENT, because a query string hands this live
+	// single-use credential to every access log, Referer header and Cache Storage
+	// key on the way in — the shape is a security assertion, not a formatting one.
+	//
+	// Split on '#' rather than searching the whole body: the correct link contains
+	// "/reset-password?token=" too, immediately AFTER the fragment marker, so a
+	// naive substring check fires on the good link and proves nothing.
+	serverVisible, _, _ := strings.Cut(mail.body, "#")
+	if strings.Contains(serverVisible, "token=") {
+		t.Fatalf("reset link puts the token in the server-visible query: %q", mail.body)
 	}
 	match := resetLinkToken.FindStringSubmatch(mail.body)
 	if match == nil {

--- a/backend/internal/modules/identity/reset_integration_test.go
+++ b/backend/internal/modules/identity/reset_integration_test.go
@@ -70,7 +70,13 @@ func TestPasswordResetFlowEndToEnd(t *testing.T) {
 	if mail.sent != 1 || mail.to != e.member.Email {
 		t.Fatalf("mail = %+v, want one message to the member", mail)
 	}
-	if !strings.Contains(mail.body, "https://crm.example.test/reset-password?token=") {
+	// The token must be in the FRAGMENT. A query string would hand this live
+	// single-use credential to every access log, Referer header and Cache Storage
+	// key on the way in, so the shape is a security assertion, not a formatting one.
+	if strings.Contains(mail.body, "/reset-password?token=") {
+		t.Fatalf("reset link puts the token in the server-visible query: %q", mail.body)
+	}
+	if !strings.Contains(mail.body, "https://crm.example.test/#/reset-password?token=") {
 		t.Fatalf("mail body carries no reset link: %q", mail.body)
 	}
 	match := resetLinkToken.FindStringSubmatch(mail.body)

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -12,6 +12,21 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # No referrers leave this origin, ever. The default
+    # (strict-origin-when-cross-origin) sends the FULL url on same-origin
+    # requests, and the SPA's api calls are same-origin by construction
+    # (api/client.ts pins the base to location.origin + /v1) — so any secret a
+    # url ever carries would be handed to the api in a header. `always` is
+    # required: without it nginx omits the header on error responses, which are
+    # exactly the pages a mistyped or expired link lands on.
+    #
+    # REPEATED in every location that sets an add_header of its own. nginx's
+    # add_header does not merge with an inherited one — a location with any
+    # add_header REPLACES the whole inherited set — so a policy declared only
+    # here would be silently dropped on exactly the asset and shell responses
+    # below. This is the one directive where DRY loses to correctness.
+    add_header Referrer-Policy "no-referrer" always;
+
     gzip on;
     gzip_types text/css application/javascript application/json image/svg+xml;
     gzip_min_length 1024;
@@ -23,12 +38,14 @@ server {
         try_files $uri =404;
         expires 1y;
         add_header Cache-Control "public, immutable";
+        add_header Referrer-Policy "no-referrer" always;
     }
 
     # The app shell must revalidate — otherwise a shared cache can keep serving a
     # stale index.html that points at build assets a new deploy has replaced.
     location = /index.html {
         add_header Cache-Control "no-cache";
+        add_header Referrer-Policy "no-referrer" always;
     }
 
     # Client-side routing: every unknown path falls back to the app shell.

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -37,6 +37,20 @@ globalThis.addEventListener("fetch", (event) => {
   if (url.origin !== globalThis.location.origin) {
     return;
   }
+  // NEVER cache a URL that carries a query. A Cache Storage key is the full
+  // request URL, query included, so caching one writes whatever the query holds
+  // to disk — where it survives until the cache name is bumped, and is then
+  // served cache-first. That is a credential store, not a shell cache: the
+  // password-reset link used to arrive as `?token=…`, and caching its navigation
+  // silently undid the front-end's own effort to scrub the token from history.
+  //
+  // The reset link is a hash route now and a fragment never reaches a service
+  // worker at all, so this is defence in depth rather than the only guard — but
+  // the rule is worth keeping absolute: nothing here needs a query cached, and
+  // the next query-bearing URL will not come with a security review attached.
+  if (url.search !== "") {
+    return;
+  }
 
   event.respondWith(
     caches.match(request).then(

--- a/frontend/src/app/shell.tsx
+++ b/frontend/src/app/shell.tsx
@@ -36,6 +36,7 @@ import {
 import { paletteHotkeyLabel } from "./palette";
 import { type Route, routeHash, useRoute } from "./router";
 import { SorModeChip } from "./sormodechip";
+import { applyTheme, persistTheme, resolveTheme, type Theme } from "./theme";
 import "./shell.css";
 
 type CompanyProfile = components["schemas"]["CompanyProfile"];
@@ -50,7 +51,6 @@ export type ShellCounts = Partial<Record<string, number>>;
 const COLLAPSE_KEY = "margince.sidebarCollapsed";
 // Comfortably past --shellAnim (0.36s) in shell.css: the two must not disagree.
 const SETTLE_MS = 420;
-const THEME_KEY = "margince.theme";
 
 // Storage is unavailable in some embedded contexts; a missing preference is a
 // default, never an error.
@@ -390,26 +390,21 @@ function resolveTitle(
   return offRailKey ? t(offRailKey) : screen;
 }
 
-function useTheme(): readonly ["light" | "dark", () => void] {
-  const [theme, setTheme] = useState<"light" | "dark">(() => {
-    const stored = readStored(THEME_KEY);
-    if (stored === "light" || stored === "dark") {
-      return stored;
-    }
-    const prefersDark =
-      typeof window.matchMedia === "function" &&
-      window.matchMedia("(prefers-color-scheme: dark)").matches;
-    return prefersDark ? "dark" : "light";
-  });
+// Owns CHANGING the theme. Deciding and applying it live in app/theme.ts,
+// because the boot path needs both before this component exists — every
+// unauthenticated surface renders without a TopBar, and used to render without a
+// theme.
+function useTheme(): readonly [Theme, () => void] {
+  const [theme, setTheme] = useState<Theme>(resolveTheme);
 
   useEffect(() => {
-    document.documentElement.dataset.theme = theme;
+    applyTheme(theme);
   }, [theme]);
 
   const toggle = useCallback(() => {
     setTheme((current) => {
       const next = current === "light" ? "dark" : "light";
-      writeStored(THEME_KEY, next);
+      persistTheme(next);
       return next;
     });
   }, []);

--- a/frontend/src/app/theme.ts
+++ b/frontend/src/app/theme.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+/**
+ * The document's theme: resolved in ONE place, applied before React mounts.
+ *
+ * This exists because the theme used to be owned entirely by `useTheme` inside
+ * `TopBar` — the AUTHENTICATED chrome. Every unauthenticated surface therefore
+ * rendered with no `data-theme` at all: a reader whose OS is set to dark got the
+ * light sign-in page, however carefully the dark tokens were authored. Worse, the
+ * effect that set the attribute had no cleanup, so after signing out of a dark
+ * session the stale `dark` persisted and the SAME screen rendered dark. One
+ * screen, two appearances, neither of them chosen.
+ *
+ * Applying it at boot fixes both at once, and keeping the resolution here rather
+ * than duplicating it means the boot path and the toggle cannot drift on what
+ * "dark" means. The toggle still owns CHANGING the theme (see `useTheme`); this
+ * module owns deciding and applying it.
+ */
+
+export type Theme = "light" | "dark";
+
+export const THEME_KEY = "margince.theme";
+
+/** Storage is unavailable in some embedded contexts; a missing preference is a
+ *  default, never an error. */
+function readStoredTheme(): string | null {
+  try {
+    return window.localStorage.getItem(THEME_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function persistTheme(theme: Theme): void {
+  try {
+    window.localStorage.setItem(THEME_KEY, theme);
+  } catch {
+    // A browser refusing storage must not break the toggle.
+  }
+}
+
+/**
+ * An explicit choice wins; otherwise follow the operating system.
+ *
+ * The OS fallback is what makes the unauthenticated surface correct for a reader
+ * who has never signed in and so has never had a chance to choose.
+ */
+export function resolveTheme(): Theme {
+  const stored = readStoredTheme();
+  if (stored === "light" || stored === "dark") {
+    return stored;
+  }
+  const prefersDark =
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(prefers-color-scheme: dark)").matches;
+  return prefersDark ? "dark" : "light";
+}
+
+export function applyTheme(theme: Theme): void {
+  document.documentElement.dataset.theme = theme;
+}

--- a/frontend/src/design-system/tokens.css
+++ b/frontend/src/design-system/tokens.css
@@ -28,6 +28,16 @@
 
   --borderSubtle: #e5e9e7;
   --borderStrong: #d2d8d4;
+  /* The boundary of an INTERACTIVE control — a text input, a button that carries
+     no fill — and it is a separate token from --borderStrong because it answers
+     to a different rule. --borderStrong divides content, where any visible
+     hairline does the job; this one is often the ONLY thing telling a user that
+     a rectangle accepts typing, and WCAG 1.4.11 therefore asks it for 3:1
+     against its background. --borderStrong measures 1.45:1 on white and cannot
+     be raised to 3:1 without turning every content divider into a hard rule.
+     Chosen to clear 3:1 against BOTH --bgElevated and --bgPage (3.33 / 3.24),
+     since controls sit on both. */
+  --borderControl: #868f89;
 
   --online: #22c55e;
   --teal: #0e7490;
@@ -142,6 +152,14 @@
   --bgHover: #1f332c;
 
   --accent: #16a34a;
+  /* DARK ink on the accent, not white — and the accent itself is untouched
+     because #16a34a is the ADR-0040 mandate. The dark palette lightens the
+     accent, which flips which ink can sit on it: white measured 3.30:1 against
+     it at 13.5px/600, under the 4.5:1 AA needs (600 weight is not bold, and
+     13.5px is not large text), and that text is the primary action on every
+     surface — "Sign in", "Send reset link", "Set new password". This ink gives
+     5.04:1. Light theme keeps white at 5.35:1. */
+  --textOnAccent: #04240f;
   --accentLight: rgba(22, 163, 74, 0.14);
   --accentMed: rgba(22, 163, 74, 0.26);
   /* Dark: the fills lift and the text tones brighten, so a monogram keeps the
@@ -167,6 +185,18 @@
 
   --borderSubtle: #22352e;
   --borderStrong: #31463d;
+  /* 3.45:1 on --bgElevated, 3.79:1 on --bgPage — the dark counterpart of the
+     control boundary, held to the same 1.4.11 floor. */
+  --borderControl: #5f7a6e;
+
+  /* Themed, because the light values are a 4-5% WARM BLACK — invisible on
+     #0e1b16. Any card whose separation depends on its shadow simply lost its
+     edge in dark, and the login surface's brand pane is exactly that case: its
+     fill sits within a couple of ΔE of the pane behind it, so with no shadow the
+     two-pane split had no visible boundary at all. Pure black at a much higher
+     alpha is what reads on a dark surface. */
+  --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.4), 0 4px 16px rgba(0, 0, 0, 0.36);
+  --shadow-pop: 0 8px 30px rgba(0, 0, 0, 0.55);
 
   /* higher alpha so the teal read-pill fill stays legible on the darker card
    * surface (same light→dark bump --accentLight makes). --teal is unthemed. */

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2283,7 +2283,14 @@ export const de = {
   "auth.resetSub": "Dein Link ist gültig. Wähle ein neues Passwort.",
   "auth.newPassword": "Neues Passwort",
   "auth.setNewPassword": "Neues Passwort speichern",
-  "auth.resetFailed": "Dieser Link ist ungültig, verbraucht oder abgelaufen.",
+  // "bereits verwendet", nicht "verbraucht": ein Link wird verwendet, nicht
+  // verbraucht wie Kraftstoff.
+  "auth.resetFailed":
+    "Dieser Link ist ungültig, bereits verwendet oder abgelaufen.",
+  "auth.resetRejectedPassword":
+    "Dieses Passwort wurde abgelehnt. Wähle ein anderes und versuche es erneut.",
+  "auth.resetServerFailed":
+    "Wir konnten dein Passwort gerade nicht setzen. Dein Link ist weiterhin gültig — versuche es in einem Moment erneut.",
   "auth.requestNewLink": "Neuen Link anfordern",
   "auth.resetDoneTitle": "Passwort aktualisiert",
   "auth.resetDoneBody":

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2279,6 +2279,14 @@ export const en = {
   "auth.newPassword": "New password",
   "auth.setNewPassword": "Set new password",
   "auth.resetFailed": "That reset link is invalid, used, or expired.",
+  // The password was refused, not the link — so the link is still good and the
+  // user must not be sent to replace it.
+  "auth.resetRejectedPassword":
+    "That password was refused. Choose a different one and try again.",
+  // Neither the link's fault nor the user's: the token is untouched, so retrying
+  // the same one is the right advice.
+  "auth.resetServerFailed":
+    "We couldn't set your password just now. Your link is still valid — try again in a moment.",
   "auth.requestNewLink": "Request a new link",
   "auth.resetDoneTitle": "Password updated",
   "auth.resetDoneBody":

--- a/frontend/src/i18n/index.tsx
+++ b/frontend/src/i18n/index.tsx
@@ -2,6 +2,7 @@ import {
   createContext,
   type ReactNode,
   useContext,
+  useEffect,
   useMemo,
   useState,
 } from "react";
@@ -72,6 +73,20 @@ export function LocaleProvider({
   // An explicit initial (a server-provided locale, once /v1/me carries one)
   // is authoritative; otherwise fall to the browser's own preference.
   const [locale, setLocale] = useState<Locale>(() => initial ?? detectLocale());
+  /*
+   * The document's own language follows the catalog. index.html can only ship a
+   * static `lang`, so without this every German reader gets German text inside a
+   * document declared English — a screen reader then applies English phonemes to
+   * German words, which is the difference between a page that can be listened to
+   * and one that cannot. WCAG 3.1.1.
+   *
+   * It fails on FIRST LOAD, not only after the switcher is used, because
+   * `detectLocale` reads the browser's own preference — so the reader most likely
+   * to need it is the one who never touches the switch.
+   */
+  useEffect(() => {
+    document.documentElement.lang = locale;
+  }, [locale]);
   const value = useMemo(() => ({ locale, setLocale }), [locale]);
   return (
     <LocaleContext.Provider value={value}>{children}</LocaleContext.Provider>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,6 +3,7 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./App";
 import { api } from "./api/client";
+import { applyTheme, resolveTheme } from "./app/theme";
 import { LocaleProvider } from "./i18n";
 import "./app.css";
 
@@ -11,6 +12,14 @@ const queryClient = new QueryClient({
     queries: { retry: 1, refetchOnWindowFocus: false },
   },
 });
+
+// BEFORE the first render, and before any authentication is known. The theme
+// used to be applied by an effect inside the signed-in chrome, so every
+// unauthenticated surface — sign-in, password reset, the availability screens —
+// ignored a dark-mode reader entirely, and inherited a stale attribute after a
+// sign-out. Setting it here also avoids a light-to-dark flash on reload for a
+// reader who has chosen dark.
+applyTheme(resolveTheme());
 
 // A 403 is the server disagreeing with the capability snapshot the UI is
 // rendering from — either the grants changed under a live session (a role

--- a/frontend/src/screens/auth-core.tsx
+++ b/frontend/src/screens/auth-core.tsx
@@ -113,10 +113,16 @@ export function AuthExperience({
 }>) {
   return (
     <div className="auth-surface" data-auth-phase={phase}>
-      <main className="auth-task">
+      {/* A div, NOT a <main>. The frame that hosts this surface already opens a
+          <main> (App.tsx's RaillessFrame), and a nested main is invalid HTML that
+          puts two "main" entries in a screen reader's landmark rotor — so the
+          user is asked to choose between two things claiming to be the one main
+          region. The task region's own identity comes from being the first thing
+          in the DOM (see the order note above), not from the tag. */}
+      <div className="auth-task">
         <div className="auth-task-in">{children}</div>
         <LegalFooter />
-      </main>
+      </div>
       <IdentityRegion profile={profile} phase={phase} />
     </div>
   );

--- a/frontend/src/screens/auth.css
+++ b/frontend/src/screens/auth.css
@@ -154,7 +154,9 @@
   justify-content: center;
   gap: 9px;
   padding: 11px 12px;
-  border: 1px solid var(--borderStrong);
+  /* Same rule as the input shell: an unfilled button on a same-coloured pane is
+     defined entirely by its border, so the border owes 1.4.11 its 3:1. */
+  border: 1px solid var(--borderControl);
   border-radius: var(--r-md);
   background: var(--bgElevated);
   cursor: pointer;
@@ -283,7 +285,12 @@
      target meets the 44px floor rather than being a 24px icon with air around
      it. The input carries its own right padding instead. */
   padding: 0 0 0 13px;
-  border: 1px solid var(--borderStrong);
+  /* --borderControl, not --borderStrong. The shell's fill equals the pane's fill
+     (--bgElevated both), so this border is the ONLY thing that says "you can type
+     here" — and at --borderStrong it measured 1.45:1, well under the 3:1 WCAG
+     1.4.11 asks of a control boundary. A field a low-vision user cannot find is
+     not a styling nit. */
+  border: 1px solid var(--borderControl);
   border-radius: var(--r-md);
   background: var(--bgElevated);
   transition:

--- a/frontend/src/screens/auth.test.tsx
+++ b/frontend/src/screens/auth.test.tsx
@@ -562,8 +562,8 @@ describe("AuthScreen reset deep link", () => {
     );
     vi.stubGlobal("location", {
       ...window.location,
-      pathname: "/reset-password",
-      search: "?token=raw-reset-token",
+      pathname: "/",
+      hash: "#/reset-password?token=raw-reset-token",
       origin: "http://localhost",
     });
     render(<AuthScreen onAuthed={vi.fn()} />);
@@ -585,8 +585,8 @@ describe("AuthScreen reset deep link", () => {
     );
     vi.stubGlobal("location", {
       ...window.location,
-      pathname: "/reset-password",
-      search: "?token=spent-token",
+      pathname: "/",
+      hash: "#/reset-password?token=spent-token",
       origin: "http://localhost",
     });
     render(<AuthScreen onAuthed={vi.fn()} />);
@@ -600,6 +600,108 @@ describe("AuthScreen reset deep link", () => {
       await screen.findByText("That reset link is invalid, used, or expired."),
     ).toBeTruthy();
     expect(screen.getByText("Request a new link")).toBeTruthy();
+  });
+
+  // These three cases exist because one string used to serve every failure, and
+  // the remedy it offered — "Request a new link" — SUPERSEDES the token the user
+  // is still holding. So for anything that is not a token verdict, the old copy
+  // was both wrong and destructive. What each failure must not do is as important
+  // as what it says, hence the absence assertions.
+  it("blames the password, not the link, when the server refuses the password", async () => {
+    stubApi({ password: true, password_reset: true }, () =>
+      ok(422, { title: "validation_error", detail: "password too weak" }),
+    );
+    vi.stubGlobal("location", {
+      ...window.location,
+      pathname: "/",
+      hash: "#/reset-password?token=good-token",
+      origin: "http://localhost",
+    });
+    render(<AuthScreen onAuthed={vi.fn()} />);
+
+    await userEvent.type(
+      await screen.findByLabelText("New password"),
+      "an entirely new password{enter}",
+    );
+
+    expect(
+      await screen.findByText(
+        "That password was refused. Choose a different one and try again.",
+      ),
+    ).toBeTruthy();
+    // The link is still good, so replacing it must not be offered.
+    expect(screen.queryByText("Request a new link")).toBeNull();
+  });
+
+  it("keeps a good link alive when the request never reaches the server", async () => {
+    stubApi({ password: true, password_reset: true }, () => {
+      throw new TypeError("Failed to fetch");
+    });
+    vi.stubGlobal("location", {
+      ...window.location,
+      pathname: "/",
+      hash: "#/reset-password?token=good-token",
+      origin: "http://localhost",
+    });
+    render(<AuthScreen onAuthed={vi.fn()} />);
+
+    await userEvent.type(
+      await screen.findByLabelText("New password"),
+      "an entirely new password{enter}",
+    );
+
+    expect(
+      await screen.findByText(
+        "We couldn't set your password just now. Your link is still valid — try again in a moment.",
+      ),
+    ).toBeTruthy();
+    expect(screen.queryByText("Request a new link")).toBeNull();
+  });
+
+  it("announces a reset failure to assistive tech", async () => {
+    // The reset error was the one error region on this surface with no role, so a
+    // screen-reader user submitted an expired token and was told nothing.
+    stubApi({ password: true, password_reset: true }, () =>
+      ok(401, { title: "unauthorized", detail: "invalid, used, or expired" }),
+    );
+    vi.stubGlobal("location", {
+      ...window.location,
+      pathname: "/",
+      hash: "#/reset-password?token=spent-token",
+      origin: "http://localhost",
+    });
+    render(<AuthScreen onAuthed={vi.fn()} />);
+
+    await userEvent.type(
+      await screen.findByLabelText("New password"),
+      "an entirely new password{enter}",
+    );
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain(
+      "That reset link is invalid, used, or expired.",
+    );
+  });
+
+  it("ignores a token in the server-visible query string", async () => {
+    // The security property, asserted directly rather than implied by the happy
+    // path: a query string is sent to servers, lands in access logs, is attached
+    // as a Referer on same-origin api calls, and becomes a Cache Storage key. So
+    // the reset view must open ONLY for a fragment token. If someone reverts the
+    // parser to location.search to "be more forgiving", this fails.
+    stubApi({ password: true, password_reset: true }, () => ok(204));
+    vi.stubGlobal("location", {
+      ...window.location,
+      pathname: "/reset-password",
+      search: "?token=raw-reset-token",
+      hash: "",
+      origin: "http://localhost",
+    });
+    render(<AuthScreen onAuthed={vi.fn()} />);
+
+    // The sign-in form, not the reset form.
+    expect(await screen.findByLabelText("Email")).toBeTruthy();
+    expect(screen.queryByLabelText("New password")).toBeNull();
   });
 });
 

--- a/frontend/src/screens/auth.tsx
+++ b/frontend/src/screens/auth.tsx
@@ -61,22 +61,48 @@ type View =
   | { kind: "reset"; token: string }
   | { kind: "reset-done" };
 
+/** The hash route the emailed reset link lands on. Minted by identity/reset.go. */
+const RESET_ROUTE = "reset-password";
+
 // resetTokenFromLocation reads the emailed deep link
-// (/reset-password?token=…): the SPA serves every path, and the
-// unauthenticated gate renders this screen wherever the link lands. The
-// token is a live single-use credential, so it is scrubbed from the
-// address bar (and browser history) the moment it is read — it lives on
-// only in component state.
+// (/#/reset-password?token=…): the unauthenticated gate renders this screen
+// wherever the link lands, so no route table entry is needed. The token is a
+// live single-use credential, so it is scrubbed from the address bar (and
+// browser history) the moment it is read — it lives on only in component state.
 function resetTokenFromLocation(): string | null {
   if (typeof globalThis.location === "undefined") {
     return null;
   }
-  if (!globalThis.location.pathname.endsWith("/reset-password")) {
+  // The FRAGMENT, not the query string, and the whole point is that a fragment
+  // never leaves the browser: it is not sent to a server, so it cannot land in
+  // an access log or in a Referer header, and it is not part of a Cache Storage
+  // key, so the service worker cannot persist it to disk. The scrub below is
+  // still worth doing — it keeps the token out of the session's history entry —
+  // but it used to be the ONLY defence, and it ran after the first same-origin
+  // API call had already carried the token off the page.
+  //
+  // Parsed as the app's own hash route (`#/reset-password?token=…`) so the
+  // emailed link is a normal client route: `parseHash` strips a hash-local query
+  // before deriving the screen name, and any static host serves index.html for
+  // `/` without an SPA fallback.
+  const hash = globalThis.location.hash.replace(/^#\/?/, "");
+  const [route, query] = [
+    hash.split("?")[0],
+    hash.slice(hash.indexOf("?") + 1),
+  ];
+  if (route !== RESET_ROUTE || !hash.includes("?")) {
     return null;
   }
-  const token = new URLSearchParams(globalThis.location.search).get("token");
+  const token = new URLSearchParams(query).get("token");
   if (token) {
-    globalThis.history?.replaceState?.(null, "", globalThis.location.pathname);
+    // replaceState, not a hash assignment: assigning to location.hash fires
+    // hashchange and pushes an entry, which would put the token back in history
+    // — the exact thing this line exists to prevent.
+    globalThis.history?.replaceState?.(
+      null,
+      "",
+      `${globalThis.location.pathname}#/${RESET_ROUTE}`,
+    );
   }
   return token;
 }
@@ -587,7 +613,19 @@ function LoginForm({
             className="auth-input"
             type="email"
             required
+            /* A stable `name`, because `id` here cannot be one: useId() derives
+               its value from the component's position in the tree, and this
+               tree changes with the notice and the provider block. Chrome
+               autofills from the autocomplete token alone, but Firefox and
+               several password managers fall back to name/id to match a SAVED
+               credential to a rendered field — with neither stable, they have
+               nothing to match on. */
+            name="email"
             autoComplete="username"
+            inputMode="email"
+            autoCapitalize="none"
+            autoCorrect="off"
+            spellCheck={false}
             placeholder={t("auth.emailPlaceholder")}
             value={email}
             onChange={(event) => setEmail(event.target.value)}
@@ -627,7 +665,10 @@ function LoginForm({
             className="auth-input"
             type={showPassword ? "text" : "password"}
             required
+            name="password"
             autoComplete="current-password"
+            autoCapitalize="none"
+            spellCheck={false}
             placeholder={t("auth.passwordPlaceholder")}
             value={password}
             onChange={(event) => setPassword(event.target.value)}
@@ -695,7 +736,16 @@ function ForgotForm({
             id={emailId}
             className="auth-input"
             type="email"
-            autoComplete="username"
+            required
+            name="email"
+            /* "email", not "username": this form never accepts a password, and
+               labelling it username invites a manager to treat it as a sign-in
+               field and offer to fill a credential that has nowhere to go. */
+            autoComplete="email"
+            inputMode="email"
+            autoCapitalize="none"
+            autoCorrect="off"
+            spellCheck={false}
             placeholder={t("auth.emailPlaceholder")}
             value={email}
             onChange={(event) => setEmail(event.target.value)}
@@ -727,6 +777,48 @@ function ForgotForm({
 
 const MIN_PASSWORD = 12;
 
+/*
+ * Why a reset failure has to be classified at all.
+ *
+ * Every failure used to render one string: "That reset link is invalid, used, or
+ * expired", above a "Request a new link" button. For a spent token that is
+ * exactly right. For anything else it is false, and the offered remedy is
+ * actively harmful — minting a new link SUPERSEDES the outstanding token
+ * (identity/reset.go), so a user whose request merely hit a network blip is told
+ * their good link is dead and then invited to destroy it.
+ *
+ * `token` is the only failure where a new link is the answer. A refused password
+ * belongs to the field, a budget refusal is a wait, and a server or transport
+ * fault is neither the link's fault nor the user's.
+ */
+type ResetFailure = "token" | "password" | "rate-limited" | "server";
+
+class ResetError extends Error {
+  readonly failure: ResetFailure;
+  constructor(failure: ResetFailure) {
+    super(failure);
+    this.name = "ResetError";
+    this.failure = failure;
+  }
+}
+
+function resetFailureOf(status: number | undefined): ResetFailure {
+  // 401 is the ONLY token verdict, and it is deliberately one verdict: the
+  // server refuses to distinguish unknown from used from expired so a token
+  // cannot be probed. That is why the copy names all three.
+  if (status === 401) return "token";
+  if (status === 422) return "password";
+  if (status === 429) return "rate-limited";
+  return "server";
+}
+
+function resetErrorKey(failure: ResetFailure): MessageKey {
+  if (failure === "token") return "auth.resetFailed";
+  if (failure === "password") return "auth.resetRejectedPassword";
+  if (failure === "rate-limited") return "auth.errRateLimited";
+  return "auth.resetServerFailed";
+}
+
 function ResetForm({
   token,
   onDone,
@@ -738,15 +830,26 @@ function ResetForm({
 
   const reset = useMutation({
     mutationFn: async () => {
-      const { error } = await api.POST("/auth/reset-password", {
-        body: { token, new_password: password },
-      });
-      if (error) {
-        throw new Error(problemMessage(error));
+      // `.catch(() => null)` for the same reason LoginForm does it: a rejected
+      // fetch (offline, DNS, CORS) is not an HTTP error and arrives as a thrown
+      // TypeError. Without this, a transport fault was indistinguishable from a
+      // dead token — and the remedy offered for a dead token destroys a live one.
+      const result = await api
+        .POST("/auth/reset-password", {
+          body: { token, new_password: password },
+        })
+        .catch(() => null);
+      if (!result) {
+        throw new ResetError("server");
+      }
+      if (result.error) {
+        throw new ResetError(resetFailureOf(result.response?.status));
       }
     },
     onSuccess: onDone,
   });
+  const failure =
+    reset.error instanceof ResetError ? reset.error.failure : "server";
 
   const ready = password.length >= MIN_PASSWORD;
   const submit = (event: FormEvent) => {
@@ -771,18 +874,29 @@ function ResetForm({
             id={passwordId}
             className="auth-input"
             type="password"
+            required
+            minLength={MIN_PASSWORD}
+            name="new-password"
             autoComplete="new-password"
+            autoCapitalize="none"
+            spellCheck={false}
             value={password}
             onChange={(event) => setPassword(event.target.value)}
           />
         </Field>
       </div>
       {reset.isError && (
-        <div className="auth-error">
-          <p className="ae-t">{t("auth.resetFailed")}</p>
-          <button type="button" className="auth-link" onClick={onRestart}>
-            {t("auth.requestNewLink")}
-          </button>
+        <div className="auth-error" role="alert">
+          <p className="ae-t">{t(resetErrorKey(failure))}</p>
+          {/* The new-link offer appears ONLY for a token verdict. Everywhere else
+              it is the one action that makes things worse: it invalidates the
+              token the user is still holding, which for a network blip or a
+              refused password is a working link thrown away. */}
+          {failure === "token" && (
+            <button type="button" className="auth-link" onClick={onRestart}>
+              {t("auth.requestNewLink")}
+            </button>
+          )}
         </div>
       )}
       <div className="auth-actions">


### PR DESCRIPTION
Lifts two of @luitpold's commits out of #339 so the onboarding PR carries no backend changes. Both are cherry-picked whole — frontend and backend together — because they are one fix each and splitting them would break the flow.

Commits are unchanged and authorship is preserved. The only edit is a conflict resolution in `frontend/src/main.tsx`, where main's 403 handler and this branch's early `applyTheme` both wanted the same spot; both are kept.

## What these fix

**The password-reset token was travelling in the query string**, and three paths leaked it before `auth.tsx` could scrub it:
- the service worker cached it to disk (a Cache Storage key includes the query, and it was then served cache-first),
- the browser sent the full URL in the `Referer` on same-origin API calls, since no `Referrer-Policy` was set,
- nginx logged the query by default.

The emailed link now carries the token in the fragment, which never reaches a server, never appears in a `Referer`, and is not part of a cache key. `Referrer-Policy: no-referrer` and a service worker that refuses to cache any query-bearing URL are added as depth. No compatibility shim: `password_reset` is false on every installation without a mailer, so no link of the old shape exists in the wild, and a test asserts the query form is ignored.

**The set-password link had two spellings**, one per call site. Now built in one place, gated.

## Verification

- `make check-fe`: 125 files, 1324 tests, lint, tsc and build green.
- `go build ./...` clean; `go test ./internal/modules/identity/...` green across identity, password and policy.

## Sequencing

Once this merges, merging `main` into `feat/onboarding-surface-redesign` drops these files from #339's diff — no history rewriting on the shared branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep password reset and invite tokens in the URL fragment so they never leave the browser, and unify deep-link building. Also fixes unauthenticated screens with correct theming, clearer error messages, and better accessibility.

- **Bug Fixes**
  - Security: tokens now use `#/reset-password?token=…`; all emails go through `passwordLink`; query-string tokens are ignored; `Referrer-Policy: no-referrer` added; the service worker stops caching any URL with a query; reset mail goroutine is panic-safe; tests enforce fragment-only.
  - Reset UX: classify errors (token/password/rate-limited/server); show “Request a new link” only for token errors; error region gets `role="alert"`; improved EN/DE copy.

- **Refactors**
  - Theming and a11y: theme is resolved/applied at boot (`app/theme.ts`) to avoid flashes and cover unauthenticated pages; stronger non-text contrast via `--borderControl` and dark `--textOnAccent`, with themed shadows; remove nested `<main>`; set `document.documentElement.lang` from i18n; add stable input `name`s and mobile/email hints; tests updated.

<sup>Written for commit 258e3be6d61453400927d333cc0b84a6640f9e07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/464?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

