### PR TITLE
docs: pin the RBAC matrix session entry to its merged PR

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -316,7 +316,7 @@ Vite/React web UI. What is deliberately still stubbed (answering explicit
 The merge gate (`make check`), the real-Postgres integration lane
 (`make test-integration`), and the live-boot job are all green.
 
-## Session pickup — 2026-08-05 (the RBAC matrix doc and the migration replay gate, branch `feat/rbac-matrix-gate`)
+## Session pickup — 2026-08-05 (the RBAC matrix doc and the migration replay gate, PR #474, merged)
 
 **The migration gate now replays the upgrade instead of scanning the SQL.** The
 obligation is that an installation predating every backfill, upgraded to head,


### PR DESCRIPTION
`STATUS.md`'s 2026-08-05 entry named branch `feat/rbac-matrix-gate`, which was deleted when #474 squash-merged. STATUS.md is the session pickup record, so a reader following it should land on the merged PR rather than a dead ref — every other closed entry in the file names its PR that way.

Docs only; no code, no gates affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update STATUS.md to point the 2026-08-05 RBAC matrix session pickup entry to the merged PR #474 instead of the deleted branch, so readers land on a live record. Docs-only; no behavior or gates changed.

<sup>Written for commit e57c7609497c4aae9555c14fc5788888e3002f80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/475?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

