### PR TITLE
fix(sbom): cover the whole committed tree, supplement licenses

### DIFF
--- a/.grant.yaml
+++ b/.grant.yaml
@@ -25,12 +25,19 @@ allow:
   - Unlicense
   - BUSL-1.1
 
-# First-party components carry no third-party license to gate. (CI Actions are
-# excluded from the scan entirely in .syft.yaml, so they never reach grant.)
-# Every other package must still resolve to a known, allowed license.
+# First-party components carry no third-party license to gate. The scan now
+# covers the whole committed tree (see .syft.yaml), so CI Actions reach grant as
+# packages; `make sbom-supplement` fills in their real (permissive) licenses,
+# except SonarSource's scanner action, which is LGPL-3.0-only. That action runs
+# only in CI — it is never linked into or shipped with the product, so its
+# copyleft never reaches Margince's BUSL-1.1 source — so it is ignored here rather
+# than admitted to `allow`, which stays the set of licenses accepted into the
+# shipped product. Every other package must still resolve to a known, allowed
+# license.
 ignore-packages:
   - github.com/gradionhq/margince/* # our own Go modules
   - example.margince.dev/* # committed extension stubs (ADR-0069), first-party
+  - SonarSource/sonarqube-scan-action # LGPL-3.0-only CI scanner action, runs in CI only, never shipped
 
 require-license: true # When true, deny packages with no detected licenses
 require-known-license: true

--- a/.syft.yaml
+++ b/.syft.yaml
@@ -28,11 +28,10 @@ license:
 # claims. syft's default selection ("owned-by-package") only hashes files
 # attributed to a discovered package, leaving first-party source
 # (backend/**, frontend/src/**, migrations, config templates) with no
-# checksum. "all" hashes the whole export — the same clean `git archive HEAD`
-# content, minus the exclude globs below — so the SBOM records a verifiable
-# digest for every shipped local file. SHA1 is kept because SPDX file entries
-# historically key on it; SHA256 and SHA512 are the modern integrity checks
-# consumers verify against.
+# checksum. "all" hashes the whole export — the entire clean `git archive HEAD`
+# content — so the SBOM records a verifiable digest for every committed file.
+# SHA1 is kept because SPDX file entries historically key on it; SHA256 and
+# SHA512 are the modern integrity checks consumers verify against.
 file:
   metadata:
     selection: all
@@ -41,16 +40,10 @@ file:
       - sha256
       - sha512
 
-# Committed trees that are agent/CI/build-tooling/test state, not shipped
-# product source or dependency manifests. The clean export already drops
-# uncommitted host state (node_modules, build output, .env); these drop the
-# committed non-product trees the scan would otherwise catalog as components.
-exclude:
-  - ./.claude/**
-  - ./.github/** # CI workflows — syft catalogs the referenced Actions as packages, but they are build infra, not shipped product
-  - ./.githooks/**
-  - ./.pnpm-store/**
-  - ./scratchpad/**
-  - ./cli/craft/** # code-craftsmanship gate (ADR-0045), a pre-push build tool — not shipped
-  - ./fixtures/** # test fixtures (e.g. the crm-hello extension module) — not shipped
-  - ./sbom-schemas/** # vendored upstream SPDX schemas for sbom-validate — build tooling, not shipped
+# No `exclude:` list on purpose. The constellation dist release gate rejects a
+# release unless the SBOM attests every file the release patch adds or modifies,
+# and the patch (create-patch) is a full committed-tree diff with no excludes. So
+# the SBOM file set must equal the whole committed tree: excluding any committed
+# tree here (CI workflows, cli/craft, fixtures, sbom-schemas, …) makes a commit
+# that touches it fail the gate. Uncommitted host state (node_modules, build
+# output, .env) is already absent — the scan runs on `git archive HEAD`.

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 # one target here that invokes the compiler directly instead of delegating.
 GO ?= go
 
-.PHONY: help install ai-routing-local dev-fresh check check-backend check-q check-go check-gates check-fe build test test-v test-cover test-integration e2e-ai e2e-ai-report ai-probe test-db-up test-it test-integration-serial bench-perf lint arch-lint vet gen gen-types gen-types-check drift composition check-composition test-extensions db-up db-init db-wait migrate migrate-up migrate-down run psql redis-cli tidy dev dev-stop dev-logs clean tools tools-go infra-up infra-down infra-logs infra-reset seed-dev seed-dev-db seed-reset verify-boot frontend-check frontend-e2e fe-install fe-typecheck fe-lint fe-build fe-preview fe-format fe-test ds-purity font-lock icon-lint fitness-jurisdiction storybook fe-uat craft-static craft-residue check-craft-doc check-image-pins contract-breaking-check test-lanes go-file-length rls-store-path no-jurisdiction pkg-freeze hooks sbom sbom-normalize sbom-parity sbom-validate sbom-sign sbom-check
+.PHONY: help install ai-routing-local dev-fresh check check-backend check-q check-go check-gates check-fe build test test-v test-cover test-integration e2e-ai e2e-ai-report ai-probe test-db-up test-it test-integration-serial bench-perf lint arch-lint vet gen gen-types gen-types-check drift composition check-composition test-extensions db-up db-init db-wait migrate migrate-up migrate-down run psql redis-cli tidy dev dev-stop dev-logs clean tools tools-go infra-up infra-down infra-logs infra-reset seed-dev seed-dev-db seed-reset verify-boot frontend-check frontend-e2e fe-install fe-typecheck fe-lint fe-build fe-preview fe-format fe-test ds-purity font-lock icon-lint fitness-jurisdiction storybook fe-uat craft-static craft-residue check-craft-doc check-image-pins contract-breaking-check test-lanes go-file-length rls-store-path no-jurisdiction pkg-freeze hooks sbom sbom-normalize sbom-supplement sbom-parity sbom-validate sbom-sign sbom-check
 
 # Bare `make` lists every command instead of running the first target.
 .DEFAULT_GOAL := help
@@ -387,9 +387,27 @@ sbom:
 	    -o spdx-json@2.2=$(SBOM_DIR)/margince.spdx221.json \
 	    -o spdx-json@3.0=$(SBOM_DIR)/margince.spdx300.json
 	@$(MAKE) sbom-normalize
+	@$(MAKE) sbom-supplement
 	@$(MAKE) sbom-parity
 	@$(MAKE) sbom-validate
 	@echo "wrote $(SBOM_FILES)"
+
+## sbom-supplement — fill in licenses syft cannot resolve. syft leaves GitHub
+## Actions unlicensed (anchore/syft#4209) and passes PyPI's ambiguous "BSD"
+## through for a couple of build-tooling deps, so the license gate would deny
+## them though their real licenses are permissive. This curated purl->SPDX map
+## (key = purl without version, so every pinned action version matches) sets the
+## license on the CycloneDX doc the gate reads and on the SPDX 2.2 doc, so both
+## license-bearing SBOMs agree; syft v1.50 emits no per-package license in SPDX
+## 3.0, so there is nothing to supplement there. SonarSource's action is left
+## unset on purpose — it is LGPL-3.0-only and ignored in .grant.yaml, not shipped.
+## Idempotent; keep the map in step with the workflows and the SPDX-tools deps.
+sbom-supplement:
+	@test -f $(SBOM_DIR)/margince.cdx.json || { echo "FAIL: no SBOM found — run 'make sbom' first"; exit 1; }
+	@set -e; cdx=$(SBOM_DIR)/margince.cdx.json; s22=$(SBOM_DIR)/margince.spdx221.json; \
+	  map='{"pkg:github/actions/checkout":"MIT","pkg:github/actions/cache":"MIT","pkg:github/actions/setup-go":"MIT","pkg:github/actions/setup-node":"MIT","pkg:github/actions/upload-artifact":"MIT","pkg:github/actions/download-artifact":"MIT","pkg:github/dorny/paths-filter":"MIT","pkg:github/pnpm/action-setup":"MIT","pkg:pypi/ply":"BSD-3-Clause","pkg:pypi/semantic-version":"BSD-2-Clause"}'; \
+	  jq --argjson m "$$map" '.components |= map(((.purl // "") | sub("@[^@]*$$"; "")) as $$k | if $$m[$$k] != null then .licenses = [{"license": {"id": $$m[$$k]}}] else . end)' "$$cdx" > "$$cdx.tmp" && mv "$$cdx.tmp" "$$cdx"; \
+	  jq --argjson m "$$map" '.packages |= map((([.externalRefs[]? | select(.referenceType == "purl") | .referenceLocator] | (.[0] // "")) | sub("@[^@]*$$"; "")) as $$k | if $$m[$$k] != null then (.licenseConcluded = $$m[$$k] | .licenseDeclared = $$m[$$k]) else . end)' "$$s22" > "$$s22.tmp" && mv "$$s22.tmp" "$$s22"
 
 ## sbom-normalize — reconcile syft's three writers so all three SBOMs describe one
 ## tree, the invariant the constellation dist gate enforces. syft scans the export

--- a/sbom-schemas/README.md
+++ b/sbom-schemas/README.md
@@ -42,5 +42,5 @@ replacing the file from its source and noting the change in the commit.
 | --- | --- |
 | `spdx-3.0.1.schema.json` | https://spdx.org/schema/3.0.1/spdx-json-schema.json |
 
-These are validation inputs, not shipped product, so `.syft.yaml` excludes this
-directory from the scan.
+These are validation inputs, not shipped product, but `.syft.yaml` includes this
+committed directory so the SBOM covers the complete committed tree.


### PR DESCRIPTION
## Problem

The constellation **dist release gate** (`ValidateReleaseArtifacts`) rejects a release unless every file the release **patch** adds or modifies is attested by all three SBOMs. `create-patch` cuts a **full committed-tree diff** with no exclude option, but `.syft.yaml` carried an `exclude:` list dropping committed tooling trees (`.github/**`, `sbom-schemas/**`, `cli/craft/**`, `fixtures/**`, `.claude/**`, `.githooks/**`). Any commit touching one of those failed the gate:

```
release artifacts do not agree:
  - cyclonedx-json: .github/workflows/sbom.yml: not found in SBOM
  - cyclonedx-json: sbom-schemas/README.md: not found in SBOM
  ...
```

## Change

1. **`.syft.yaml`** — remove the `exclude:` block. The SBOM now digests the whole committed tree (file count == `git ls-files` == 3243), so it matches the patch.
2. **`Makefile`** — new `sbom-supplement` step (jq, beside `sbom-normalize`). Removing the excludes re-catalogs the CI GitHub Actions and the SPDX-tools Python deps as packages; the license gate denies them. Instead of relaxing `grant`, supplement their real licenses from a curated purl→SPDX map on the CycloneDX and SPDX 2.2 docs:
   - GitHub Actions → `MIT`
   - `ply` → `BSD-3-Clause`, `semantic-version` → `BSD-2-Clause`
   - syft cannot resolve these itself (anchore/syft#4209); SPDX 3.0 carries no per-package license in syft v1.50, so nothing to supplement there.
3. **`.grant.yaml`** — ignore `SonarSource/sonarqube-scan-action` (LGPL-3.0-only). It runs in CI only and is never linked into or shipped with the product, so its copyleft never reaches the BUSL-1.1 source; `allow` stays the set of licenses accepted into the shipped product.

## Verification

- `make sbom` — 3243 files, three SBOMs agree (parity), all valid against their formats.
- Supplemented licenses correct in CycloneDX and SPDX 2.2; SonarSource left unset by design.
- `make sbom-check` — **no denied packages** (497 allowed, 3 ignored).

## Maintenance note

With whole-tree cataloging and a strict license gate, a **new action** added to any workflow needs a `sbom-supplement` map entry (its real SPDX license), or the license gate fails until it is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand SBOM coverage to the full committed tree and add a license-supplement step so the release patch gate and license gate both pass. Validation runs per format; signing waits for parity and validation.

- **New Features**
  - Removed `.syft.yaml` excludes; SBOM now matches the entire committed tree.
  - Added `sbom-supplement` (invoked by `make sbom`) to set real licenses: CI GitHub Actions → MIT; PyPI `ply` → BSD-3-Clause; `semantic-version` → BSD-2-Clause. Applied to CycloneDX and SPDX 2.2 (SPDX 3.0 in `syft` v1.50 lacks per-package licenses).
  - Validation: CycloneDX via `cyclonedx-cli`, SPDX 2.2 via `pyspdxtools`, SPDX 3.0 via vendored JSON Schema (`sbom-schemas/**`); `sbom-sign` depends on parity + validate.
  - Updated `.grant.yaml` to ignore `SonarSource/sonarqube-scan-action` (LGPL-3.0-only; CI-only, not shipped).

- **Migration**
  - When adding a GitHub Action, add its SPDX license to the `sbom-supplement` map or the license gate will fail.

<sup>Written for commit a7c4e45ac029d301394896761b2b7553b19efee4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/489?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SBOM generation now supplements license information and validates CycloneDX and SPDX outputs.
  * SBOM signing requires successful file-set parity and validation checks.
  * SBOM workflows also run when schema definitions change.

* **Documentation**
  * Added guidance for SBOM validation inputs, schema management, and reproducible validator setup.
  * Updated license-scanning and file-integrity documentation.

* **Chores**
  * Pinned SBOM tooling and validators for reproducible, read-only execution.
  * Expanded SBOM coverage to include all committed files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->