### PR TITLE
fix(extensions): the extension tier catches up with the agent surface it composes into

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # Diff-scoped code-craftsmanship gate (ADR-0045, `craft static`).
 #
-# Runs the deterministic craftsmanship linter on the backend Go files that
-# THIS push changes vs origin/main — not the whole tree, so a push pays only
+# Runs the deterministic craftsmanship linter on the Go files that THIS push
+# changes vs origin/main — backend/, extensions/ and fixtures/ alike, since a
+# first-party unit ships the same product — not the whole tree, so a push pays only
 # for what it touches. BLOCKER and MAJOR findings both fail the push (--strict);
 # MINOR stays advisory. There is no pre-existing backlog to exempt: the tree was
 # cleared to zero before this bar was armed, and `make craft-static` is green.
@@ -21,11 +22,13 @@ if [ -z "$base" ]; then
 	exit 0
 fi
 
-# Changed-and-still-present backend Go files, excluding generated code.
-files="$(git diff --name-only --diff-filter=d "$base"...HEAD -- backend \
+# Changed-and-still-present Go files, excluding generated code. extensions/
+# and fixtures/ are each their own module and would otherwise escape the bar
+# entirely — a first-party unit ships the same product as backend/.
+files="$(git diff --name-only --diff-filter=d "$base"...HEAD -- backend extensions fixtures \
 	| grep -E '\.go$' | grep -v '_gen\.go$' || true)"
 if [ -z "$files" ]; then
-	echo "craft static: no changed backend Go files — ok"
+	echo "craft static: no changed Go files — ok"
 	exit 0
 fi
 
@@ -35,7 +38,7 @@ while IFS= read -r f; do
 	[ -n "$f" ] && args+=("$root/$f")
 done <<< "$files"
 
-echo "craft static: checking ${#args[@]} changed backend file(s)…"
+echo "craft static: checking ${#args[@]} changed Go file(s)…"
 if ! go run -C "$root/cli/craft" . static --strict "${args[@]}"; then
 	echo ""
 	echo "craft static BLOCKED the push. Fix the findings above, or waive a"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -343,14 +343,16 @@ legibility is the product, not polish.
 
 **The gate runs before every push (diff-scoped), and it is STRICT.**
 `.githooks/pre-push` runs the deterministic arm — `craft static --strict` (the repo's
-`cli/craft` tool, ADR-0045) — over the backend Go files **this push changes vs
-`origin/main`**. New/touched
+`cli/craft` tool, ADR-0045) — over the Go files **this push changes vs
+`origin/main`** in `backend/`, `extensions/` and `fixtures/` alike (a first-party
+extension unit ships the same product). New/touched
 code must be clean. There is no pre-existing backlog to exempt: the whole tree was
 cleared to zero findings before this bar was armed. So write it right the first time
 — a swallowed error, a sleep in a test, a bare `any` in a signature, or an 81-line
 function you add will block your push.
 - Install the hook once after cloning: **`make hooks`** (sets `core.hooksPath=.githooks`).
-- Full manual sweep of the whole backend: **`make craft-static`** — green, and the CI
+- Full manual sweep of every hand-written Go tree (`backend/`, `extensions/`,
+  `fixtures/`): **`make craft-static`** — green, and the CI
   `craftsmanship` job runs the same bar as a required check.
 - `BLOCKER` and `MAJOR` findings both block; `MINOR` is advisory. The size ceilings are
   80 body lines / 500 file lines for product code and 160 / 1000 for `*_test.go`.
@@ -372,7 +374,8 @@ Exempt: generated files (`*_gen.go`) and the drift-frozen
 `internal/contracts/` package — do NOT stamp those. The rule is enforced by
 `TestEveryHandWrittenGoFileCarriesTheLicenseHeader` in
 `backend/license_test.go` (part of `make check`), which derives the file
-list from the tree, so a new file that skips the header fails the gate.
+list from the tree — `backend/`, `extensions/` and `fixtures/`, since each
+unit is its own module — so a new file that skips the header fails the gate.
 Keep the copyright line as-is (`2026 Gradion`); it names the release year,
 not the current year. This is the license model's "honest labeling / don't
 strip notices" obligation (spec `business/12-license.md` §5, §8).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -284,9 +284,10 @@ The `backend/internal/{modules,platform,shared}` triad — the DAG is
 - `extensions/<name>/` — the stable extension tier (ADR-0069): each unit
   is its own Go module importing ONLY the marker-allowlisted
   `backend/pkg/**` surface; presence under `extensions/` is the
-  enablement. The vanilla tree ships `extensions/de` (the German
-  jurisdiction pack — GoBD calendar-year retention floors), first-party
-  and enabled by default. `make composition` (run by every build lane)
+  enablement. The vanilla tree ships two first-party units, enabled by
+  default: `extensions/de` (the German jurisdiction pack — GoBD
+  calendar-year retention floors) and `extensions/yogi` (one served
+  🟢/read agent tool — the worked example of the governed-tool kind). `make composition` (run by every build lane)
   generates the ignored `build/composition/` wiring; `composition/` at
   the root is the committed vanilla stub so bare go commands resolve.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -315,9 +315,10 @@ The `backend/internal/{modules,platform,shared}` triad — the DAG is
 - `extensions/<name>/` — the stable extension tier (ADR-0069): each unit
   is its own Go module importing ONLY the marker-allowlisted
   `backend/pkg/**` surface; presence under `extensions/` is the
-  enablement. The vanilla tree ships `extensions/de` (the German
-  jurisdiction pack — GoBD calendar-year retention floors), first-party
-  and enabled by default. `make composition` (run by every build lane)
+  enablement. The vanilla tree ships two first-party units, enabled by
+  default: `extensions/de` (the German jurisdiction pack — GoBD
+  calendar-year retention floors) and `extensions/yogi` (one served
+  🟢/read agent tool — the worked example of the governed-tool kind). `make composition` (run by every build lane)
   generates the ignored `build/composition/` wiring; `composition/` at
   the root is the committed vanilla stub so bare go commands resolve.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -374,14 +374,16 @@ legibility is the product, not polish.
 
 **The gate runs before every push (diff-scoped), and it is STRICT.**
 `.githooks/pre-push` runs the deterministic arm — `craft static --strict` (the repo's
-`cli/craft` tool, ADR-0045) — over the backend Go files **this push changes vs
-`origin/main`**. There is no pre-existing backlog to exempt: the whole tree was
+`cli/craft` tool, ADR-0045) — over the Go files **this push changes vs
+`origin/main`** in `backend/`, `extensions/` and `fixtures/` alike (a first-party
+extension unit ships the same product). There is no pre-existing backlog to exempt: the whole tree was
 cleared to zero findings before this bar was armed, so the rule is simply that
 touched code is clean. Write it right the first time — a swallowed error, a sleep
 in a test, a bare `any` in a signature, or an 81-line function you add will block
 your push.
 - Install the hook once after cloning: **`make hooks`** (sets `core.hooksPath=.githooks`).
-- Full manual sweep of the whole backend: **`make craft-static`** — green, and the
+- Full manual sweep of every hand-written Go tree (`backend/`, `extensions/`,
+  `fixtures/`): **`make craft-static`** — green, and the
   CI `craftsmanship` job runs the same bar as a required check.
 - `BLOCKER` and `MAJOR` findings both block; `MINOR` is advisory. The size ceilings
   are 80 body lines / 500 file lines for product code and 160 / 1000 for `*_test.go`
@@ -405,7 +407,8 @@ Exempt: generated files (`*_gen.go`) and the drift-frozen
 `internal/contracts/` package — do NOT stamp those. The rule is enforced by
 `TestEveryHandWrittenGoFileCarriesTheLicenseHeader` in
 `backend/license_test.go` (part of `make check`), which derives the file
-list from the tree, so a new file that skips the header fails the gate.
+list from the tree — `backend/`, `extensions/` and `fixtures/`, since each
+unit is its own module — so a new file that skips the header fails the gate.
 Keep the copyright line as-is (`2026 Gradion`); it names the release year,
 not the current year. This is the license model's "honest labeling / don't
 strip notices" obligation (spec `business/12-license.md` §5, §8).

--- a/Makefile
+++ b/Makefile
@@ -237,12 +237,17 @@ fe-uat:
 		pnpm exec playwright install chromium >/dev/null 2>&1 && \
 		node scripts/fe-uat.mjs $(ARGS)
 
-## craft-static — the deterministic code-craftsmanship gate (ADR-0045) over the
-## whole backend, strict: BLOCKER and MAJOR findings both fail it. The pre-push
-## hook (.githooks/pre-push) runs the same bar diff-scoped; this target is the
-## full manual sweep, and it is green — the backlog was cleared to arm it.
+## craft-static — the deterministic code-craftsmanship gate (ADR-0045) over
+## every hand-written Go tree, strict: BLOCKER and MAJOR findings both fail it.
+## The pre-push hook (.githooks/pre-push) runs the same bar diff-scoped; this
+## target is the full manual sweep, and it is green — the backlog was cleared
+## to arm it. extensions/ and fixtures/ are their own Go modules, so `./...`
+## never reaches them and the bar has to name them: a first-party unit ships
+## the same product, and the fixture is the worked example a unit author copies.
 craft-static:
 	go run -C cli/craft . static --strict --root ../../backend
+	go run -C cli/craft . static --strict --root ../../extensions
+	go run -C cli/craft . static --strict --root ../../fixtures
 
 ## craft-residue — fail if any unresolved CRAFT-FIX/CRAFT-DISPUTE marker was
 ## left in the backend tree (the review-loop residue check, ADR-0045). The CI

--- a/backend/internal/compose/extensiontools.go
+++ b/backend/internal/compose/extensiontools.go
@@ -97,6 +97,12 @@ func adaptExtensionTool(tool extension.Tool) (extensionTool, error) {
 	// outbound authority nothing declares, on a call nobody can be asked
 	// about. A handler-LESS outbound tool is fine — it is a manifest request,
 	// not a capability.
+	//
+	// This binds the DECLARATION. A handler is ordinary Go and could reach the
+	// network whatever cap it asks for — that is bounded by the composed set
+	// being the trust boundary (see buildExtensionTools), not by this check.
+	// What the check buys is that a unit cannot ASK for outbound authority and
+	// be granted it silently on the auto-execute tier.
 	if scope.Egresses() {
 		return extensionTool{}, fmt.Errorf(
 			"a served tool spending the outbound %q cap is not yet supported "+
@@ -122,12 +128,9 @@ func adaptExtensionTool(tool extension.Tool) (extensionTool, error) {
 			Tier:          tier,
 			InputSchema:   input,
 			OutputSchema:  tool.OutputSchema,
-			// Derived, never declared: whether a tool leaves the workspace is
-			// a property of the cap it spends, and the operator inventory and
-			// the openWorldHint both read this field. The refusal above means
-			// it resolves false for every tool this surface serves today;
-			// deriving it anyway keeps that an enforced consequence rather
-			// than a hand-set claim.
+			// Derived, never declared: egress is a property of the cap spent,
+			// not something a unit asserts. The refusal above means it is
+			// false for everything this surface serves today.
 			Egress: scope.Egresses(),
 		},
 		handle: tool.Handle,

--- a/backend/internal/compose/extensiontools.go
+++ b/backend/internal/compose/extensiontools.go
@@ -7,6 +7,7 @@ import (
 	"cmp"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -59,53 +60,78 @@ func buildExtensionTools(exts []extension.Extension) ([]mcp.Tool, error) {
 				return nil, fmt.Errorf("compose: extensions %q and %q both serve a tool named %q", owner, e.Name, tool.Name)
 			}
 			served[tool.Name] = e.Name
-			tier, err := mcpTier(tool.Tier)
+			adapted, err := adaptExtensionTool(tool)
 			if err != nil {
 				return nil, fmt.Errorf("compose: extension %q, tool %q: %w", e.Name, tool.Name, err)
 			}
-			// A served 🟡 tool would be refused on every call: the admission
-			// gate stages a confirm-first approval only for tools that
-			// implement the registry's staging seam, which this data-only
-			// adapter cannot. Serving one is a dead capability, so reject it
-			// until the staging seam is wired. A handler-LESS 🟡 tool is fine
-			// — it is a manifest request, not served.
-			if tier == mcp.TierConfirmationRequired {
-				return nil, fmt.Errorf("compose: extension %q, tool %q: a served confirmation-required tool is not yet supported (its approvals could never be staged)", e.Name, tool.Name)
-			}
-			scope, err := mcpScope(tool.RequestedScope)
-			if err != nil {
-				return nil, fmt.Errorf("compose: extension %q, tool %q: %w", e.Name, tool.Name, err)
-			}
-			input := tool.InputSchema
-			if input == nil {
-				// MCP requires every tool to advertise an object input schema;
-				// a tool that takes no arguments still needs one.
-				input = json.RawMessage(`{"type":"object"}`)
-			}
-			tools = append(tools, extensionTool{
-				spec: mcp.ToolSpec{
-					Name: tool.Name,
-					// A unit that declares a title gets it; one that does not
-					// is listed under its verb, which is what a client falls
-					// back to anyway. Optional rather than required on
-					// purpose: making a display string mandatory would refuse
-					// to boot an otherwise valid third-party unit over a label.
-					Title:         cmp.Or(tool.Title, tool.Name),
-					Version:       tool.Version,
-					RequiredScope: scope,
-					Tier:          tier,
-					InputSchema:   input,
-					OutputSchema:  tool.OutputSchema,
-					// A tool whose cap leaves the workspace — delivering under
-					// `send`, fetching under `enrich` — is surfaced as such in
-					// the operator inventory.
-					Egress: scope.Egresses(),
-				},
-				handle: tool.Handle,
-			})
+			tools = append(tools, adapted)
 		}
 	}
 	return tools, nil
+}
+
+// adaptExtensionTool maps ONE handler-bearing declaration onto the core
+// seam, refusing the two shapes this surface cannot honestly serve.
+func adaptExtensionTool(tool extension.Tool) (extensionTool, error) {
+	tier, err := mcpTier(tool.Tier)
+	if err != nil {
+		return extensionTool{}, err
+	}
+	// A served 🟡 tool would be refused on every call: the admission gate
+	// stages a confirm-first approval only for tools that implement the
+	// registry's staging seam, which this data-only adapter cannot. Serving
+	// one is a dead capability, so reject it until the staging seam is wired.
+	// A handler-LESS 🟡 tool is fine — it is a manifest request, not served.
+	if tier == mcp.TierConfirmationRequired {
+		return extensionTool{}, errors.New("a served confirmation-required tool is not yet supported (its approvals could never be staged)")
+	}
+	scope, err := mcpScope(tool.RequestedScope)
+	if err != nil {
+		return extensionTool{}, err
+	}
+	// Every core tool that leaves the workspace — send_email, send_message,
+	// book_meeting, the enrich pair — is 🟡, because the only control over a
+	// destination the product did not choose is a human deciding the call. A
+	// served extension tool cannot be 🟡 (see just above), so serving an
+	// outbound one would put this surface on the wrong side of that rule:
+	// outbound authority nothing declares, on a call nobody can be asked
+	// about. A handler-LESS outbound tool is fine — it is a manifest request,
+	// not a capability.
+	if scope.Egresses() {
+		return extensionTool{}, fmt.Errorf(
+			"a served tool spending the outbound %q cap is not yet supported "+
+				"(leaving the workspace requires the confirm-first tier, which this surface cannot stage)", scope)
+	}
+	input := tool.InputSchema
+	if input == nil {
+		// MCP requires every tool to advertise an object input schema; a tool
+		// that takes no arguments still needs one.
+		input = json.RawMessage(`{"type":"object"}`)
+	}
+	return extensionTool{
+		spec: mcp.ToolSpec{
+			Name: tool.Name,
+			// A unit that declares a title gets it; one that does not is
+			// listed under its verb, which is what a client falls back to
+			// anyway. Optional rather than required on purpose: making a
+			// display string mandatory would refuse to boot an otherwise valid
+			// third-party unit over a label.
+			Title:         cmp.Or(tool.Title, tool.Name),
+			Version:       tool.Version,
+			RequiredScope: scope,
+			Tier:          tier,
+			InputSchema:   input,
+			OutputSchema:  tool.OutputSchema,
+			// Derived, never declared: whether a tool leaves the workspace is
+			// a property of the cap it spends, and the operator inventory and
+			// the openWorldHint both read this field. The refusal above means
+			// it resolves false for every tool this surface serves today;
+			// deriving it anyway keeps that an enforced consequence rather
+			// than a hand-set claim.
+			Egress: scope.Egresses(),
+		},
+		handle: tool.Handle,
+	}, nil
 }
 
 // setComposedTools records the boot's tool set. Called once by

--- a/backend/internal/compose/extensiontools_test.go
+++ b/backend/internal/compose/extensiontools_test.go
@@ -113,12 +113,18 @@ func TestBuildExtensionToolsRejectsCrossUnitServedNameCollision(t *testing.T) {
 // declaring that this surface may reach outside at all. Both outbound caps,
 // because `send` delivering and `enrich` fetching leave by the same door.
 func TestBuildExtensionToolsRejectsAServedEgressTool(t *testing.T) {
+	// A verb per cap, so each subtest reads as the act it refuses rather than
+	// naming a delivery for the fetch case.
+	outboundVerbs := map[extension.Scope]string{
+		extension.ScopeSend:   "push_webhook",
+		extension.ScopeEnrich: "fetch_profile",
+	}
 	for _, scope := range []extension.Scope{extension.ScopeSend, extension.ScopeEnrich} {
 		t.Run(string(scope), func(t *testing.T) {
 			_, err := buildExtensionTools([]extension.Extension{{
 				Name: "demo", Version: "1.0.0",
 				Tools: []extension.Tool{{
-					Name: "push_webhook", Version: "1.0.0",
+					Name: outboundVerbs[scope], Version: "1.0.0",
 					Tier: extension.TierAutoExecute, RequestedScope: scope,
 					Handle: func(context.Context, json.RawMessage) (json.RawMessage, error) { return nil, nil },
 				}},

--- a/backend/internal/compose/extensiontools_test.go
+++ b/backend/internal/compose/extensiontools_test.go
@@ -107,27 +107,75 @@ func TestBuildExtensionToolsRejectsCrossUnitServedNameCollision(t *testing.T) {
 	}
 }
 
-// TestBuildExtensionToolsDerivesEgressAndDefaultsSchema: a send-scoped tool
-// is marked egress, and a tool that omits an input schema still advertises
-// an object one (MCP requires it).
-func TestBuildExtensionToolsDerivesEgressAndDefaultsSchema(t *testing.T) {
+// TestBuildExtensionToolsRejectsAServedEgressTool: every core tool that
+// leaves the workspace is 🟡, and a served extension tool cannot be — so an
+// outbound one would auto-execute with no human in the loop and no operation
+// declaring that this surface may reach outside at all. Both outbound caps,
+// because `send` delivering and `enrich` fetching leave by the same door.
+func TestBuildExtensionToolsRejectsAServedEgressTool(t *testing.T) {
+	for _, scope := range []extension.Scope{extension.ScopeSend, extension.ScopeEnrich} {
+		t.Run(string(scope), func(t *testing.T) {
+			_, err := buildExtensionTools([]extension.Extension{{
+				Name: "demo", Version: "1.0.0",
+				Tools: []extension.Tool{{
+					Name: "push_webhook", Version: "1.0.0",
+					Tier: extension.TierAutoExecute, RequestedScope: scope,
+					Handle: func(context.Context, json.RawMessage) (json.RawMessage, error) { return nil, nil },
+				}},
+			}})
+			if err == nil || !strings.Contains(err.Error(), "outbound") {
+				t.Fatalf("err = %v, want the served-egress rejection", err)
+			}
+		})
+	}
+}
+
+// TestBuildExtensionToolsDefaultsTheInputSchema: a tool that omits an input
+// schema still advertises an object one (MCP requires it of every tool).
+func TestBuildExtensionToolsDefaultsTheInputSchema(t *testing.T) {
 	tools, err := buildExtensionTools([]extension.Extension{{
 		Name: "demo", Version: "1.0.0",
 		Tools: []extension.Tool{{
-			Name: "push_webhook", Version: "1.0.0",
-			Tier: extension.TierAutoExecute, RequestedScope: extension.ScopeSend,
+			Name: "count_things", Version: "1.0.0",
+			Tier: extension.TierAutoExecute, RequestedScope: extension.ScopeRead,
 			Handle: func(context.Context, json.RawMessage) (json.RawMessage, error) { return nil, nil },
 		}},
 	}})
 	if err != nil {
 		t.Fatal(err)
 	}
-	spec := tools[0].Spec()
-	if !spec.Egress {
-		t.Error("a send-scoped tool must be marked egress")
+	if got := string(tools[0].Spec().InputSchema); got != `{"type":"object"}` {
+		t.Errorf("a tool without a declared input schema must advertise an object one, got %s", got)
 	}
-	if string(spec.InputSchema) != `{"type":"object"}` {
-		t.Errorf("a tool without a declared input schema must advertise an object one, got %s", spec.InputSchema)
+}
+
+// TestBuildExtensionToolsCarriesTheTitleAndFallsBackToTheVerb: a declared
+// title reaches tools/list, and a unit that declares none is listed under its
+// verb rather than registering a title-less spec (which the core registry
+// refuses outright).
+func TestBuildExtensionToolsCarriesTheTitleAndFallsBackToTheVerb(t *testing.T) {
+	handle := func(context.Context, json.RawMessage) (json.RawMessage, error) { return nil, nil }
+	tools, err := buildExtensionTools([]extension.Extension{{
+		Name: "demo", Version: "1.0.0",
+		Tools: []extension.Tool{
+			{
+				Name: "give_quote", Title: "Quote of the day", Version: "1.0.0",
+				Tier: extension.TierAutoExecute, RequestedScope: extension.ScopeRead, Handle: handle,
+			},
+			{
+				Name: "count_things", Version: "1.0.0",
+				Tier: extension.TierAutoExecute, RequestedScope: extension.ScopeRead, Handle: handle,
+			},
+		},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := tools[0].Spec().Title; got != "Quote of the day" {
+		t.Errorf("declared title = %q, want it carried to the served spec", got)
+	}
+	if got := tools[1].Spec().Title; got != "count_things" {
+		t.Errorf("title-less tool = %q, want the verb as its display name", got)
 	}
 }
 

--- a/backend/license_test.go
+++ b/backend/license_test.go
@@ -32,11 +32,14 @@ func isGenerated(path, text string) bool {
 	if strings.HasSuffix(path, "_gen.go") {
 		return true
 	}
-	// The whole contracts package is owned by the contract pipeline and
+	// The backend's contracts package is owned by the contract pipeline and
 	// frozen by the drift gate (`git diff --exit-code -- internal/contracts/`);
 	// even its hand-written doc.go/gen.go must stay byte-identical, so no
-	// notice is stamped there.
-	if strings.Contains(filepath.ToSlash(path), "internal/contracts/") {
+	// notice is stamped there. Anchored at the backend tree's own root, not
+	// matched anywhere in the path: the sweep also walks sibling modules, and
+	// a unit of its own naming a directory `internal/contracts/` would
+	// otherwise inherit an exemption that belongs to one frozen package.
+	if strings.HasPrefix(filepath.ToSlash(path), "internal/contracts/") {
 		return true
 	}
 	head := text
@@ -44,6 +47,20 @@ func isGenerated(path, text string) bool {
 		head = text[:i]
 	}
 	return generatedMarker.MatchString(head)
+}
+
+// TestTheContractsExemptionIsAnchoredToTheBackendTree: the exemption belongs
+// to ONE frozen package, so it must not travel to a sibling module that
+// happens to name a directory the same way — an inherited exemption is a file
+// shipping with no notice and a gate reporting it clean.
+func TestTheContractsExemptionIsAnchoredToTheBackendTree(t *testing.T) {
+	const unlicensed = "package contracts\n"
+	if !isGenerated("internal/contracts/doc.go", unlicensed) {
+		t.Error("the backend's frozen contracts package lost its exemption")
+	}
+	if isGenerated("../extensions/u/internal/contracts/tool.go", unlicensed) {
+		t.Error("a unit's own internal/contracts/ inherited the backend contract pipeline's exemption")
+	}
 }
 
 // licensedTree is one hand-written Go tree the notice rule covers, and

--- a/backend/license_test.go
+++ b/backend/license_test.go
@@ -46,30 +46,48 @@ func isGenerated(path, text string) bool {
 	return generatedMarker.MatchString(head)
 }
 
+// licensedTrees are the hand-written Go trees the notice rule covers. The
+// backend module is one of them, not all of them: extensions/ and fixtures/
+// are separate modules a `./...` from here never reaches, and a first-party
+// unit ships under the same license as the code it composes into.
+var licensedTrees = []string{".", "../extensions", "../fixtures"}
+
 func TestEveryHandWrittenGoFileCarriesTheLicenseHeader(t *testing.T) {
 	var missing []string
-	err := filepath.WalkDir(".", func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if d.IsDir() || !strings.HasSuffix(path, ".go") {
+	var checked int
+	walk := func(root string) error {
+		return filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() || !strings.HasSuffix(path, ".go") {
+				return nil
+			}
+			b, err := os.ReadFile(path) // #nosec G304 G122 -- path is a *.go file from walking the trusted source tree
+			if err != nil {
+				return err
+			}
+			text := string(b)
+			if isGenerated(path, text) {
+				return nil
+			}
+			checked++
+			if !strings.HasPrefix(text, spdxHeader) {
+				missing = append(missing, filepath.ToSlash(path))
+			}
 			return nil
+		})
+	}
+	for _, root := range licensedTrees {
+		if err := walk(root); err != nil {
+			t.Fatalf("walking %s: %v", root, err)
 		}
-		b, err := os.ReadFile(path) // #nosec G304 G122 -- path is a *.go file from walking the trusted source tree
-		if err != nil {
-			return err
-		}
-		text := string(b)
-		if isGenerated(path, text) {
-			return nil
-		}
-		if !strings.HasPrefix(text, spdxHeader) {
-			missing = append(missing, filepath.ToSlash(path))
-		}
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("walking tree: %v", err)
+	}
+	// A tree that yields no hand-written file passes silently, and silence
+	// here reads exactly like a clean tree — the failure mode a fitness
+	// function must never have.
+	if checked == 0 {
+		t.Fatal("no hand-written Go files found — the notice rule checked nothing")
 	}
 	if len(missing) > 0 {
 		t.Errorf("%d Go file(s) missing the BUSL-1.1 SPDX header (add it above the package clause, then a blank line):\n\t%s",

--- a/backend/license_test.go
+++ b/backend/license_test.go
@@ -46,17 +46,34 @@ func isGenerated(path, text string) bool {
 	return generatedMarker.MatchString(head)
 }
 
-// licensedTrees are the hand-written Go trees the notice rule covers. The
-// backend module is one of them, not all of them: extensions/ and fixtures/
-// are separate modules a `./...` from here never reaches, and a first-party
-// unit ships under the same license as the code it composes into.
-var licensedTrees = []string{".", "../extensions", "../fixtures"}
+// licensedTree is one hand-written Go tree the notice rule covers, and
+// whether that tree is guaranteed to contain a file. The backend module is one
+// tree, not all of them: extensions/ and fixtures/ are separate modules a
+// `./...` from here never reaches, and a first-party unit ships under the same
+// license as the code it composes into.
+//
+// mustHaveFiles is what stops a root from passing by scanning nothing — an
+// aggregate count cannot, because backend/ alone would carry it forever while
+// a unit tree silently escaped the rule. extensions/ is the one root that may
+// legitimately be empty: presence under it IS enablement, so the vanilla lane
+// composes an empty tree on purpose. A root that does not exist at all is
+// still caught, by the walk error below.
+type licensedTree struct {
+	root          string
+	mustHaveFiles bool
+}
+
+var licensedTrees = []licensedTree{
+	{root: ".", mustHaveFiles: true},
+	{root: "../extensions"},
+	{root: "../fixtures", mustHaveFiles: true},
+}
 
 func TestEveryHandWrittenGoFileCarriesTheLicenseHeader(t *testing.T) {
 	var missing []string
-	var checked int
-	walk := func(root string) error {
-		return filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+	walk := func(root string) (int, error) {
+		checked := 0
+		err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 			if err != nil {
 				return err
 			}
@@ -77,17 +94,16 @@ func TestEveryHandWrittenGoFileCarriesTheLicenseHeader(t *testing.T) {
 			}
 			return nil
 		})
+		return checked, err
 	}
-	for _, root := range licensedTrees {
-		if err := walk(root); err != nil {
-			t.Fatalf("walking %s: %v", root, err)
+	for _, tree := range licensedTrees {
+		checked, err := walk(tree.root)
+		if err != nil {
+			t.Fatalf("walking %s: %v", tree.root, err)
 		}
-	}
-	// A tree that yields no hand-written file passes silently, and silence
-	// here reads exactly like a clean tree — the failure mode a fitness
-	// function must never have.
-	if checked == 0 {
-		t.Fatal("no hand-written Go files found — the notice rule checked nothing")
+		if tree.mustHaveFiles && checked == 0 {
+			t.Fatalf("%s yielded no hand-written Go file — a root that scans nothing passes exactly like a clean one", tree.root)
+		}
 	}
 	if len(missing) > 0 {
 		t.Errorf("%d Go file(s) missing the BUSL-1.1 SPDX header (add it above the package clause, then a blank line):\n\t%s",

--- a/backend/pkg/extension/tool.go
+++ b/backend/pkg/extension/tool.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"strings"
 	"unicode"
+	"unicode/utf8"
 )
 
 // ToolHandler runs a governed tool after admission. It is the extension's
@@ -185,6 +186,13 @@ func validateTitle(title string) error {
 	// shorter. Both are the same instruction to the author.
 	if strings.TrimSpace(title) != title {
 		return fmt.Errorf("title %q is blank or carries surrounding whitespace — a client renders it verbatim in place of the verb; omit Title to fall back to the verb", title)
+	}
+	// Before the rune check, not after: ranging a Go string decodes an invalid
+	// byte to U+FFFD, which IS printable — so a malformed title would pass the
+	// loop below and then be rendered by a client as replacement characters
+	// the declaration never wrote.
+	if !utf8.ValidString(title) {
+		return fmt.Errorf("title %q is not valid UTF-8", title)
 	}
 	for _, r := range title {
 		if !unicode.IsPrint(r) {

--- a/backend/pkg/extension/tool.go
+++ b/backend/pkg/extension/tool.go
@@ -8,6 +8,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"strings"
+	"unicode"
 )
 
 // ToolHandler runs a governed tool after admission. It is the extension's
@@ -102,8 +104,9 @@ type Tool struct {
 	// Title is the human-readable label tools/list shows in place of Name
 	// (the protocol's display precedence is title > name). Optional: a unit
 	// that declares none is listed under its verb, which is what a client
-	// falls back to anyway. It carries no authority and the manifest
-	// generator does not read it — a display string is not a declaration.
+	// falls back to anyway. It carries no authority, so it is no part of the
+	// manifest's governance descriptor — but it is still validated, at gen
+	// time and at boot, because the core registry refuses a blank one.
 	Title string
 	// Version is the tool's own version, recorded for the registry; it
 	// carries no authority (decisions bind to digests, not versions).
@@ -146,6 +149,9 @@ func (t Tool) Validate() error {
 	if t.Version == "" {
 		return fmt.Errorf("tool %q declares no version", t.Name)
 	}
+	if err := validateTitle(t.Title); err != nil {
+		return fmt.Errorf("tool %q: %w", t.Name, err)
+	}
 	if err := t.Tier.Validate(); err != nil {
 		return fmt.Errorf("tool %q: %w", t.Name, err)
 	}
@@ -157,6 +163,33 @@ func (t Tool) Validate() error {
 	}
 	if err := validateSchemaObject("OutputSchema", t.OutputSchema); err != nil {
 		return fmt.Errorf("tool %q: %w", t.Name, err)
+	}
+	return nil
+}
+
+// validateTitle checks a declared display title. Absent is allowed — the
+// served spec falls back to the verb. Present-but-blank is not: the core
+// registry refuses a whitespace-only title (a client takes it over the name
+// and renders an empty heading), and that refusal is a boot PANIC, so a
+// title a unit author can see and fix has to fail here — at gen time, at the
+// declaration's own position — rather than crashing the process that
+// composes it. The framing and printability rules are Version's, for the
+// same reason: the string is rendered verbatim by a client that did not
+// write it.
+func validateTitle(title string) error {
+	if title == "" {
+		return nil
+	}
+	// One check for two faults, because TrimSpace collapses them: a
+	// whitespace-only title trims to empty, a framed one trims to something
+	// shorter. Both are the same instruction to the author.
+	if strings.TrimSpace(title) != title {
+		return fmt.Errorf("title %q is blank or carries surrounding whitespace — a client renders it verbatim in place of the verb; omit Title to fall back to the verb", title)
+	}
+	for _, r := range title {
+		if !unicode.IsPrint(r) {
+			return fmt.Errorf("title %q carries a non-printable character", title)
+		}
 	}
 	return nil
 }

--- a/backend/pkg/extension/tool_test.go
+++ b/backend/pkg/extension/tool_test.go
@@ -62,6 +62,7 @@ func TestToolValidate(t *testing.T) {
 		{"blank title", Tool{Name: "ping", Title: "   ", Version: "1.0.0", Tier: TierAutoExecute, RequestedScope: ScopeRead}},
 		{"framed title", Tool{Name: "ping", Title: " Ping it ", Version: "1.0.0", Tier: TierAutoExecute, RequestedScope: ScopeRead}},
 		{"non-printable title", Tool{Name: "ping", Title: "Ping\tit", Version: "1.0.0", Tier: TierAutoExecute, RequestedScope: ScopeRead}},
+		{"title that is not valid UTF-8", Tool{Name: "ping", Title: "Ping\xffit", Version: "1.0.0", Tier: TierAutoExecute, RequestedScope: ScopeRead}},
 		{"non-object input schema", Tool{Name: "ping", Version: "1.0.0", Tier: TierAutoExecute, RequestedScope: ScopeRead, InputSchema: json.RawMessage(`"scalar"`)}},
 		{"input schema not type object", Tool{Name: "ping", Version: "1.0.0", Tier: TierAutoExecute, RequestedScope: ScopeRead, InputSchema: json.RawMessage(`{"type":"array"}`)}},
 		{"malformed output schema", Tool{Name: "ping", Version: "1.0.0", Tier: TierAutoExecute, RequestedScope: ScopeRead, OutputSchema: json.RawMessage(`{bad`)}},

--- a/backend/pkg/extension/tool_test.go
+++ b/backend/pkg/extension/tool_test.go
@@ -41,6 +41,13 @@ func TestToolValidate(t *testing.T) {
 	if err := valid.Validate(); err != nil {
 		t.Fatalf("a well-formed tool must validate: %v", err)
 	}
+	// Title is optional, so the case above proves nothing about a declared
+	// one: a written label must pass on its own.
+	titled := valid
+	titled.Title = "Qualify a lead"
+	if err := titled.Validate(); err != nil {
+		t.Fatalf("a written title must validate: %v", err)
+	}
 
 	cases := []struct {
 		name string
@@ -52,6 +59,9 @@ func TestToolValidate(t *testing.T) {
 		{"tier not requestable", Tool{Name: "ping", Version: "1.0.0", Tier: "dynamic", RequestedScope: ScopeRead}},
 		{"scope outside vocabulary", Tool{Name: "ping", Version: "1.0.0", Tier: TierAutoExecute, RequestedScope: "admin"}},
 		{"missing scope", Tool{Name: "ping", Version: "1.0.0", Tier: TierAutoExecute}},
+		{"blank title", Tool{Name: "ping", Title: "   ", Version: "1.0.0", Tier: TierAutoExecute, RequestedScope: ScopeRead}},
+		{"framed title", Tool{Name: "ping", Title: " Ping it ", Version: "1.0.0", Tier: TierAutoExecute, RequestedScope: ScopeRead}},
+		{"non-printable title", Tool{Name: "ping", Title: "Ping\tit", Version: "1.0.0", Tier: TierAutoExecute, RequestedScope: ScopeRead}},
 		{"non-object input schema", Tool{Name: "ping", Version: "1.0.0", Tier: TierAutoExecute, RequestedScope: ScopeRead, InputSchema: json.RawMessage(`"scalar"`)}},
 		{"input schema not type object", Tool{Name: "ping", Version: "1.0.0", Tier: TierAutoExecute, RequestedScope: ScopeRead, InputSchema: json.RawMessage(`{"type":"array"}`)}},
 		{"malformed output schema", Tool{Name: "ping", Version: "1.0.0", Tier: TierAutoExecute, RequestedScope: ScopeRead, OutputSchema: json.RawMessage(`{bad`)}},

--- a/backend/tools/gen-composition/astreader.go
+++ b/backend/tools/gen-composition/astreader.go
@@ -189,7 +189,7 @@ func (r *unitReader) readTool(elt ast.Expr, ext string) (riskTierRequest, error)
 	if !ok || (lit.Type != nil && !isSelector(lit.Type, ext, "Tool")) {
 		return riskTierRequest{}, r.errAt(elt, "a Tools entry must be an extension.Tool literal")
 	}
-	var name, version, tier, scope string
+	var name, title, version, tier, scope string
 	for _, e := range lit.Elts {
 		kv, ok := e.(*ast.KeyValueExpr)
 		if !ok {
@@ -203,6 +203,12 @@ func (r *unitReader) readTool(elt ast.Expr, ext string) (riskTierRequest, error)
 		switch key.Name {
 		case "Name":
 			name, err = r.stringLit(kv.Value, "Tool.Name")
+		case "Title":
+			// Read to be VALIDATED, not to be recorded: a display string
+			// grants nothing, so it stays out of the descriptor and its
+			// digest — but the core registry refuses a blank one at boot, and
+			// this is where a unit author is told so at the declaration.
+			title, err = r.stringLit(kv.Value, "Tool.Title")
 		case "Version":
 			version, err = r.stringLit(kv.Value, "Tool.Version")
 		case "Tier":
@@ -220,25 +226,33 @@ func (r *unitReader) readTool(elt ast.Expr, ext string) (riskTierRequest, error)
 			return riskTierRequest{}, err
 		}
 	}
-	return r.toolRequest(lit, name, version, tier, scope)
+	return r.toolRequest(lit, declaredTool{name: name, title: title, version: version, tier: tier, scope: scope})
 }
+
+// declaredTool is one Tools entry as the source states it, before the
+// published grammar has passed judgement on it.
+type declaredTool struct{ name, title, version, tier, scope string }
 
 // toolRequest validates the declared tool through its published grammar
 // (the same Validate the boot preflight runs, raised here at the
 // declaration's position) and assembles its descriptor. A tool requires
 // one scope; the descriptor carries it as its (single-element) scope set,
-// the general shape shared across governed kinds. Version is not part
-// of the descriptor: resolutions bind to the digest, never a version.
-func (r *unitReader) toolRequest(at ast.Node, name, version, tier, scope string) (riskTierRequest, error) {
-	declared := extension.Tool{Name: name, Version: version, Tier: extension.Tier(tier), RequestedScope: extension.Scope(scope)}
+// the general shape shared across governed kinds. Version and Title are not
+// part of the descriptor: resolutions bind to the digest, never to a version
+// string, and never to a label.
+func (r *unitReader) toolRequest(at ast.Node, d declaredTool) (riskTierRequest, error) {
+	declared := extension.Tool{
+		Name: d.name, Title: d.title, Version: d.version,
+		Tier: extension.Tier(d.tier), RequestedScope: extension.Scope(d.scope),
+	}
 	if err := declared.Validate(); err != nil {
 		return riskTierRequest{}, r.errPos(at, "%v", err)
 	}
 	c := riskTierRequest{
-		ID:        "tool/" + name,
+		ID:        "tool/" + d.name,
 		Operation: opAgentToolInvoke,
-		Scopes:    []string{scope},
-		Tier:      tier,
+		Scopes:    []string{d.scope},
+		Tier:      d.tier,
 	}
 	digest, err := descriptorDigest(c)
 	if err != nil {

--- a/backend/tools/gen-composition/unitmanifest_test.go
+++ b/backend/tools/gen-composition/unitmanifest_test.go
@@ -287,6 +287,25 @@ func TestToolDerivesIntoRiskTier(t *testing.T) {
 	}
 }
 
+// TestADeclaredTitleDerivesButStaysOutOfTheDescriptor: a display string
+// grants nothing, so declaring one must neither fail the derivation (it did:
+// the field was unrecognized, which made a unit that named its tool
+// unbuildable) nor move the digest an operator decision binds to.
+func TestADeclaredTitleDerivesButStaysOutOfTheDescriptor(t *testing.T) {
+	fields := "\t\t\tName: \"sync_contacts\", Version: \"2.1.0\",\n\t\t\tTier: extension.TierAutoExecute,\n\t\t\tRequestedScope: extension.ScopeWrite,"
+	untitled, err := deriveSynthetic(t, "x", toolUnitSource(fields))
+	if err != nil {
+		t.Fatal(err)
+	}
+	titled, err := deriveSynthetic(t, "x", toolUnitSource("\t\t\tTitle: \"Sync contacts\",\n"+fields))
+	if err != nil {
+		t.Fatalf("a declared title must derive: %v", err)
+	}
+	if !bytes.Equal(untitled, titled) {
+		t.Fatalf("the title reached the governance descriptor:\n%s\nvs\n%s", untitled, titled)
+	}
+}
+
 // nonLiteralHeader opens every rejection case's synthetic unit.
 const nonLiteralHeader = `package x
 
@@ -363,6 +382,18 @@ var nonLiteralCases = []struct {
 		name:    "version with surrounding whitespace",
 		source:  nonLiteralNew("\t\tName: \"x\",\n\t\tVersion: \" 1.0.0\","),
 		wantErr: "surrounding whitespace",
+	},
+	{
+		// The core registry refuses a blank title with a boot panic, so the
+		// unit author has to hear it here, at the declaration, instead.
+		name:    "tool title that renders as nothing",
+		source:  toolUnitSource("\t\t\tName: \"t\", Title: \"   \", Version: \"1.0.0\", Tier: extension.TierAutoExecute, RequestedScope: extension.ScopeRead,"),
+		wantErr: "is blank or carries surrounding whitespace",
+	},
+	{
+		name:    "computed tool title",
+		source:  toolUnitSource("\t\t\tName: \"t\", Title: titleOf(), Version: \"1.0.0\", Tier: extension.TierAutoExecute, RequestedScope: extension.ScopeRead,") + "\nfunc titleOf() string { return \"T\" }\n",
+		wantErr: "Tool.Title must be a string literal",
 	},
 }
 

--- a/docs/explanation/extensibility.md
+++ b/docs/explanation/extensibility.md
@@ -213,10 +213,22 @@ the same `agents.Registry`, admission gate, and tool listing the core tools ride
 the reference unit that exercises that path end to end). Two limits hold there: a handler-less
 declaration stays a manifest request and serves nothing, and a *served* 🟡 confirm-first tool is
 refused at boot rather than registered, because this data-only adapter cannot implement the registry's
-staging seam — its approvals could never be staged, so the capability would be dead on every call. And
+staging seam — its approvals could never be staged, so the capability would be dead on every call. A
+served tool spending an outbound `send`/`enrich` cap is refused for the same reason read from the other
+end: it could only ever run 🟢, and every core verb that leaves the workspace is confirm-first, so
+serving one would be outbound authority with nobody to ask. That binds the DECLARATION — a handler is
+ordinary Go and could reach the network whatever cap it asks for; what the refusal buys is that a unit
+cannot ASK for outbound authority and be granted it silently. And
 until per-capability operator resolution lands, **the composed set is itself the trust boundary**: a
 handler-bearing tool is served at its declared tier because someone added the unit to the tree
-deliberately. The core stays country-neutral — a fitness gate
+deliberately.
+
+`Title` is the one field on the declaration that grants nothing: it is what `tools/list` DISPLAYS in
+place of the verb. Optional, and kept out of the manifest's governance descriptor and its digest — but
+validated at gen time all the same, because the core registry refuses a blank display name and would
+otherwise do it by panicking the boot that composed the unit.
+
+The core stays country-neutral — a fitness gate
 (`check-no-jurisdiction.sh`) scans hand-written core source for jurisdiction-specific identifiers and
 fails the build on a match. Germany does not live in the core; it lives in `extensions/de`, which
 declares the GoBD/AO statutory **retention floors** — commercial correspondence 6 years, and

--- a/docs/how-to/add-an-extension.md
+++ b/docs/how-to/add-an-extension.md
@@ -1,6 +1,6 @@
 # Add an extension (a stable-tier unit)
 
-For shipping a bounded add-on — today a **jurisdiction pack** — as a named, versioned unit under
+For shipping a bounded add-on — today a **jurisdiction pack** or a **governed agent tool** — as a named, versioned unit under
 `extensions/<name>/`, without editing any upstream-owned file. For *why* the seam is a compile-time
 declaration and what the surface guarantees, read
 [explanation/extensibility.md](../explanation/extensibility.md) first. For a country pack
@@ -8,8 +8,8 @@ specifically, the live capability is retention floors; the running example below
 
 An extension is its own Go module reaching the core through only the marker-allowlisted
 `backend/pkg/**` surface. **Presence under `extensions/` is the enablement** — there is no flag to
-flip. `extensions/de` (Germany) and `fixtures/extensions/crm-hello` (the walking-skeleton reference)
-are the two units to copy from.
+flip. `extensions/de` (Germany), `extensions/yogi` (one served agent tool) and
+`fixtures/extensions/crm-hello` (the walking-skeleton reference) are the units to copy from.
 
 ## Scaffold the unit
 
@@ -90,10 +90,49 @@ the values you declare must be ones a core engine already understands:
 
 Get the statutory content right — it's legal content, not a default. Pin it with a test (below).
 
+## Declare a governed agent tool (optional)
+
+A unit may also contribute **agent tools** — named verbs the MCP surface serves alongside the core
+ones. `extensions/yogi` is the first-party worked example; copy its shape:
+
+```go
+Tools: []extension.Tool{{
+	Name:           "yogi_quote",        // lower snake_case, unique across the composed set
+	Title:          "Yogi Berra quote",  // optional; what tools/list DISPLAYS, so write a label
+	Version:        "1.0.0",
+	Tier:           extension.TierAutoExecute,
+	RequestedScope: extension.ScopeRead,
+	InputSchema:    json.RawMessage(`{"type":"object"}`),
+	Handle:         quote,
+}}
+```
+
+What the surface will and will not serve:
+
+- **`Handle` decides whether the tool runs.** Omit it and the declaration is a manifest request and
+  nothing more — inert. Supply it and the tool is registered at boot into the same registry and
+  admission gate the core tools ride, so its tier and scope are enforced on every call.
+- **A served tool is 🟢 only.** `TierConfirmationRequired` is refused for a handler-bearing tool: this
+  surface cannot stage an approval, so a confirm-first extension tool would be refused on every call.
+- **A served tool may not leave the workspace.** `ScopeSend` and `ScopeEnrich` are refused for a
+  handler-bearing tool, because outbound work is confirm-first everywhere else in the product and a
+  🟢 outbound verb would reach a destination nobody approved.
+- **`Title` is optional but not free-form-blank.** A whitespace-only or space-framed title is refused
+  at generation; a unit that declares none is listed under its verb.
+- **`RequestedScope` is required** and comes from the closed passport vocabulary (`read`, `draft`,
+  `write`, `send`, `enrich`) — it is the cap a caller's passport must hold, so declare the one the
+  act actually spends.
+
+Your handler receives a `context.Context` and raw JSON, and nothing else — no pool, no provider, no
+record access. Validate arguments by decoding into a strict typed struct; `InputSchema` is
+client-facing documentation, not a validator.
+
 ## Write the unit's own test
 
 Each unit is its own Go module, so the backend's `./...` never reaches it — it carries its own tests,
-run by `make test-extensions` on the composed workspace. Pin the statutory content so a changed span
+run by `make test-extensions` on the composed workspace. Its Go files sit under the same
+craftsmanship and license-header gates as `backend/` — `make craft-static` sweeps `extensions/`, and
+the pre-push hook checks the extension files a push changes. Pin the statutory content so a changed span
 or class name is a deliberate, reviewed edit (copy the shape from `extensions/de/de_test.go`):
 
 ```go

--- a/docs/how-to/add-an-extension.md
+++ b/docs/how-to/add-an-extension.md
@@ -114,9 +114,12 @@ What the surface will and will not serve:
   admission gate the core tools ride, so its tier and scope are enforced on every call.
 - **A served tool is 🟢 only.** `TierConfirmationRequired` is refused for a handler-bearing tool: this
   surface cannot stage an approval, so a confirm-first extension tool would be refused on every call.
-- **A served tool may not leave the workspace.** `ScopeSend` and `ScopeEnrich` are refused for a
+- **A served tool may not DECLARE an outbound cap.** `ScopeSend` and `ScopeEnrich` are refused for a
   handler-bearing tool, because outbound work is confirm-first everywhere else in the product and a
-  🟢 outbound verb would reach a destination nobody approved.
+  🟢 outbound verb would reach a destination nobody approved. This binds the declaration, not the
+  handler: a handler is ordinary Go and could open a socket regardless, which is why the composed set
+  is itself the trust boundary (see
+  [explanation/extensibility.md](../explanation/extensibility.md)) and a unit is added deliberately.
 - **`Title` is optional but not free-form-blank.** A whitespace-only or space-framed title is refused
   at generation; a unit that declares none is listed under its verb.
 - **`RequestedScope` is required** and comes from the closed passport vocabulary (`read`, `draft`,

--- a/docs/how-to/add-an-extension.md
+++ b/docs/how-to/add-an-extension.md
@@ -122,9 +122,10 @@ What the surface will and will not serve:
   [explanation/extensibility.md](../explanation/extensibility.md)) and a unit is added deliberately.
 - **`Title` is optional but not free-form-blank.** A whitespace-only or space-framed title is refused
   at generation; a unit that declares none is listed under its verb.
-- **`RequestedScope` is required** and comes from the closed passport vocabulary (`read`, `draft`,
-  `write`, `send`, `enrich`) — it is the cap a caller's passport must hold, so declare the one the
-  act actually spends.
+- **`RequestedScope` is required.** The vocabulary is the closed passport set (`read`, `draft`,
+  `write`, `send`, `enrich`); a **served** tool may request only `read`, `draft` or `write`, since the
+  two outbound caps are refused above. It is the cap a caller's passport must hold, so declare the one
+  the act actually spends.
 
 Your handler receives a `context.Context` and raw JSON, and nothing else — no pool, no provider, no
 record access. Validate arguments by decoding into a strict typed struct; `InputSchema` is

--- a/docs/reference/agent-tools.md
+++ b/docs/reference/agent-tools.md
@@ -25,10 +25,13 @@ live surface differ from the table below:
   re-derived per call and can still refuse a tool the listing showed.
 - **Extensions register onto the same registry.** `registerComposedTools` runs
   last in `internal/compose/registry.go`, after the core registrars, so an
-  extension pack can add verbs (and a name that collides with a core verb fails
-  loudly at boot). The vanilla tree's one first-party pack, `extensions/de`,
-  registers no tools, so on a vanilla install the catalog below is the whole
-  surface.
+  extension unit can add verbs (and a name that collides with a core verb fails
+  loudly at boot). A served extension tool is 🟢 and inbound-only — the boot
+  refuses a handler-bearing confirm-first or `send`/`enrich` tool, because
+  neither could be staged for the human this surface has no way to ask. The
+  vanilla tree ships two first-party units: `extensions/de` registers no tools,
+  and `extensions/yogi` adds `yogi_quote` (🟢/read), so on a vanilla install the
+  catalog below plus that one verb is the whole surface.
 
 **Where it is served:** `cmd/api` mounts the tool surface at `/mcp` over
 Streamable HTTP, on the same origin as `/oauth/*` and the discovery documents.

--- a/docs/reference/agent-tools.md
+++ b/docs/reference/agent-tools.md
@@ -44,8 +44,11 @@ the credential: [how-to/mint-a-passport.md](../how-to/mint-a-passport.md).
 
 ## The catalog
 
-**26 tools**, listed in the order `Registry.Specs()` sorts them — which is the
-order `tools/list` returns.
+The **26 core tools**, listed in the order `Registry.Specs()` sorts them — which
+is the order `tools/list` returns. An enabled extension unit adds its own verbs
+to the same listing, so a vanilla install answers 27: these plus `yogi_quote`
+(🟢, `read`), which is not tabled here because the catalog tracks the core
+surface.
 
 Columns:
 
@@ -115,6 +118,9 @@ The passport vocabulary is closed: `read`, `draft`, `write`, `send`, `enrich`
 (`principal.Scope`). Effective authority is always the intersection of the
 passport's scopes and the granting human's live RBAC and seat — never the union,
 and never the passport alone.
+
+Counts are of the core catalog above; an enabled unit's verbs add to them
+(vanilla: `yogi_quote` makes `read` 13).
 
 | Scope | Tools it unlocks | What it means |
 |---|---|---|

--- a/docs/reference/agent-tools.md
+++ b/docs/reference/agent-tools.md
@@ -26,9 +26,11 @@ live surface differ from the table below:
 - **Extensions register onto the same registry.** `registerComposedTools` runs
   last in `internal/compose/registry.go`, after the core registrars, so an
   extension unit can add verbs (and a name that collides with a core verb fails
-  loudly at boot). A served extension tool is 🟢 and inbound-only — the boot
-  refuses a handler-bearing confirm-first or `send`/`enrich` tool, because
-  neither could be staged for the human this surface has no way to ask. The
+  loudly at boot). A served extension tool declares 🟢 and an inbound cap — the
+  boot refuses a handler-bearing confirm-first or `send`/`enrich` declaration,
+  because neither could be staged for the human this surface has no way to ask.
+  That governs what a unit may CLAIM; what its handler does is bounded by the
+  composed set being a trust boundary, not by the gate. The
   vanilla tree ships two first-party units: `extensions/de` registers no tools,
   and `extensions/yogi` adds `yogi_quote` (🟢/read), so on a vanilla install the
   catalog below plus that one verb is the whole surface.

--- a/docs/reference/make-targets.md
+++ b/docs/reference/make-targets.md
@@ -125,7 +125,7 @@ exception to it.
 
 | Target | What it does |
 |---|---|
-| `craft-static` | Full deterministic craftsmanship sweep of `backend/`, **strict**: BLOCKER and MAJOR findings both fail it, MINOR is advisory. Green — the backlog was cleared to arm this bar. The pre-push hook runs the same bar diff-scoped, and CI's `craftsmanship` job runs this target as a required check. Size ceilings: 80 body lines / 500 file lines for product code, 160 / 1000 for `*_test.go` |
+| `craft-static` | Full deterministic craftsmanship sweep of `backend/`, `extensions/` and `fixtures/` (each a separate Go module, so `./...` never reaches the latter two), **strict**: BLOCKER and MAJOR findings both fail it, MINOR is advisory. Green — the backlog was cleared to arm this bar. The pre-push hook runs the same bar diff-scoped, and CI's `craftsmanship` job runs this target as a required check. Size ceilings: 80 body lines / 500 file lines for product code, 160 / 1000 for `*_test.go` |
 | `craft-residue` | Fail if any unresolved `CRAFT-FIX`/`CRAFT-DISPUTE` review-loop marker is left in the backend tree. CI's `craft-residue` job runs it on **every** non-draft change, docs included |
 | `check-craft-doc` | Assert AGENTS.md still carries its `## Craftsmanship` section — a cheap doc floor so the gate's rules cannot be silently unpinned from the rulebook. A `check-backend` prerequisite |
 

--- a/extensions/yogi/yogi.go
+++ b/extensions/yogi/yogi.go
@@ -26,6 +26,7 @@ func New() extension.Extension {
 		Version: "1.0.0",
 		Tools: []extension.Tool{{
 			Name:           "yogi_quote",
+			Title:          "Yogi Berra quote",
 			Version:        "1.0.0",
 			Tier:           extension.TierAutoExecute,
 			RequestedScope: extension.ScopeRead,

--- a/extensions/yogi/yogi_test.go
+++ b/extensions/yogi/yogi_test.go
@@ -27,6 +27,12 @@ func TestNewDeclaresAServedTool(t *testing.T) {
 	if tool.Handle == nil {
 		t.Fatal("a served tool must carry a handler")
 	}
+	// A written title, not the verb un-snake-cased: tools/list shows title
+	// over name, and "yogi_quote" is the identifier the field exists to
+	// improve on.
+	if tool.Title == "" || tool.Title == tool.Name {
+		t.Fatalf("Title = %q, want a written display name", tool.Title)
+	}
 	if tool.Tier != extension.TierAutoExecute || tool.RequestedScope != extension.ScopeRead {
 		t.Fatalf("a read-only quote tool should request 🟢/read, got tier=%q scope=%q", tool.Tier, tool.RequestedScope)
 	}


### PR DESCRIPTION
Reviewing the extension tier against what has landed on `main` (#366's tool `Title`, #479's declared scope, #445's MAJOR-blocking craft bar) found three places it had fallen behind, and two docs that describe a surface we no longer have. Raised on #481 by @lstrojny ("don't forget the extension surface"; "the `Title` field does not have validation").

## A unit that declared `Title` could not be built

`gen-composition`'s tool reader had cases for `Name`, `Version`, `Tier`, `RequestedScope` — and nothing for `Title`, so a declaration carrying one failed generation outright:

```
extensions/u/u.go:12:23: Tool field Title is not derivable by this generator
```

The field `pkg/extension` advertises as optional therefore made a tool-bearing unit unbuildable. `extensions/de` is jurisdiction-only, which is why nothing caught it.

It reads the field now — to **validate** it, not to record it. A label grants nothing, so it stays out of the security descriptor and its digest (pinned by a test: titled and untitled derivations are byte-identical).

## `Title` had no validation, and a blank one panicked the boot

`Tool.Validate` ignored the field, and the adapter's `cmp.Or` only substitutes the *zero* string — so `Title: "   "` reached `Registry.Register`, which refuses a whitespace title by design, as a panic:

```
crmagents: ping_it has no Title — tools/list would render its identifier as its display name
```

A third-party unit's display string crashing the process is the wrong end of the pipeline. `Tool.Validate` now applies `Version`'s rules (present-but-blank, space-framed, non-printable), so the author hears it at the declaration's own position — at gen time, with a file and line.

`yogi_quote` finally has a title a client can show.

## A served extension tool could egress on auto-execute

Every core verb that leaves the workspace is 🟡 — `send_email`, `send_message`, `book_meeting`, the enrich pair — and two fitness tests hold that line. The extension tier inverted it: a handler-bearing 🟡 tool is refused (nothing can stage its approvals), so every served tool is 🟢, and nothing refused `TierAutoExecute` + `ScopeSend`. The old test asserted that combination *worked*.

The boot now refuses it, with the same fail-closed shape as the 🟡 refusal. A handler-less outbound tool stays legal — it is a manifest request, not a capability.

This binds the **declaration**, not the handler: a handler is ordinary Go in its own module and could dial out whatever cap it asks for. That is bounded by the composed set being the trust boundary, which is what the docs now say. What the check buys is that a unit cannot *ask* for outbound authority and be granted it silently on the auto-execute tier.

## The craft and license gates now reach `extensions/` and `fixtures/`

Each unit is its own module, so `./...` never reached them and neither did the bar armed in #445 — the pre-push hook was scoped `-- backend`, `make craft-static` swept `--root ../../backend`, and `license_test.go` walked only the backend tree. A first-party unit ships the same product. Both trees were already clean, so this arms the rule rather than clearing a backlog (verified: a swallowed error planted under `fixtures/` blocks the push).

The license sweep's anti-silence guard binds **per root**, not in aggregate — otherwise backend/'s thousands of files would satisfy it forever while a unit tree scanning zero files passed exactly like a clean one. `extensions/` is exempt because an empty enabled set is supported (the vanilla lane composes one on purpose); a missing directory is still caught by the walk error.

## Docs

- `explanation/extensibility.md` said a declared tool is "not yet served … currently inert". Handler-bearing tools have been served since the boot adapter landed, and `extensions/yogi` has been serving one.
- `reference/agent-tools.md` said the vanilla catalog is the whole surface. It is the catalog plus `yogi_quote`.
- `how-to/add-an-extension.md` gains the governed-tool section it never had.
- `make-targets.md`, `CLAUDE.md`, `AGENTS.md`: the new gate scope, and the two first-party units.

## Not in this PR

- **`sendOffer`** — the contract says sending "leaves the workspace"; the implementation only flips status and freezes FX. An upstream decision, tracked on #481.
- **The parity gate's blindness to extension tools** — `TestEveryRegisteredToolIsDeclaredOrAnIntent` lives on the unmerged `feat/agent-tools-match-the-contract` branch and would fail on a composed extension tool with advice that is wrong for one. It belongs to that branch and lands there.

## Verification

`make check-backend`, `make craft-static` (all three roots), `make test-extensions`, `make check-craft-doc` — green. Reviewed by the craftsmanship agent and by Codex; both passes are folded in (the per-root floor and the softened docs claim are theirs).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the extension tier with the core agent surface. Validates tool titles (UTF‑8 and printable), blocks unsafe served tools (confirm-first or outbound), and extends craft/license gates to `extensions/` and `fixtures/`. Docs now reflect served tools, scope limits, and core vs. vanilla catalog counts.

- **Bug Fixes**
  - Generator reads and validates `Tool.Title`; `Tool.Validate` rejects blank, space-framed, non-printable, or non‑UTF‑8 titles; served spec falls back to name when missing.
  - Served tools that declare `TierConfirmationRequired` or outbound caps (`send`/`enrich`) are refused; handler-less outbound tools remain manifest-only.
  - Default missing input schema to `{"type":"object"}`; tests cover title fallback and schema defaulting.

- **Craftsmanship and Docs**
  - Pre-push `craft static` checks changed Go files in `backend/`, `extensions/`, and `fixtures/`; `make craft-static` sweeps all three modules. License header gate runs per root with a per-root floor; `internal/contracts/` exemption is anchored to the backend tree; `extensions/` may be empty.
  - Docs: handler-bearing tools are served; outbound limits bind declarations; the composed set is the trust boundary; vanilla ships `extensions/de` and `extensions/yogi`. How-to notes served tools may request only `read`/`draft`/`write`. Agent-tools counts label core and call out `yogi_quote`.

<sup>Written for commit c7683616048f45e71f54d4d36ab37a4add10e33b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added display titles for extension tools, including the Yogi quote tool.
  * Extension tools now provide default input schemas when omitted.
  * Served tools enforce tier, scope, and capability restrictions.

* **Bug Fixes**
  * Invalid, blank, or non-printable tool titles are now rejected.
  * Tool titles are preserved for display while remaining excluded from governance digests.

* **Documentation**
  * Expanded extension and agent-tool guidance, including serving rules and validation requirements.

* **Chores**
  * Craftsmanship and license checks now cover backend, extensions, and fixtures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->