### PR TITLE
docs: explain the GOWORK binding, and reconcile the extension tier with what ships

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -89,7 +89,7 @@ maps the codebase and links everything below.
 **Modes and extension**
 
 - [overlay-augmentation.md](explanation/overlay-augmentation.md) — the two SoR modes, the frozen seam + inner incumbent seam, the mirror-as-cache, fail-closed visibility, and teardown for the HubSpot overlay (branch 1: read + continuous sync).
-- [extensibility.md](explanation/extensibility.md) — the stable extension tier: the inert compile-time declaration, the marker-allowlisted surface, the composition build, boot reconciliation, and the fitness functions that hold the boundary.
+- [extensibility.md](explanation/extensibility.md) — the stable extension tier: the inert compile-time declaration, the marker-allowlisted surface, the composition build, the `GOWORK` binding that decides which composition module the compiler links, boot reconciliation, and the fitness functions that hold the boundary.
 ### Operate — run it in production
 - [deployment.md](deployment.md) — self-hosting: the container materials, the two-role non-superuser database model FORCE RLS requires, env-only configuration, one-host routing for `/v1` + `/mcp` + the OAuth flow, health checks, and order of operations.
 

--- a/docs/explanation/extensibility.md
+++ b/docs/explanation/extensibility.md
@@ -3,7 +3,8 @@
 How a bounded add-on lands in this product **without editing a single upstream-owned file**. This is
 the *extension tier*: one named, versioned unit under `extensions/<name>/`, its own Go module,
 reaching the core through one narrow published surface and composed in at build time. The vanilla tree
-already ships one — `extensions/de`, the German jurisdiction pack.
+already ships two — `extensions/de`, the German jurisdiction pack, and `extensions/yogi`, the reference
+unit that serves one governed agent tool.
 
 This page is for a contributor who wants the whole idea first, then the detail. Start here; to
 actually *build* a unit, jump to [how-to/add-an-extension.md](../how-to/add-an-extension.md).
@@ -18,6 +19,9 @@ make composition ─▶ build/composition/     generated wiring (ignored); an em
    │                                        tree reproduces the committed stub byte-for-byte
    │  Extensions() []extension.Extension
    ▼
+GOWORK=build/composition/go.work   ONE import path, two implementations on disk; the
+   │                                workspace decides which one the compiler links
+   ▼
 cmd/{api,worker} main ─▶ compose.RegisterExtensions(set)
    │                              │
    │                   ① validate the WHOLE set   ─▶  ② apply → core registries
@@ -27,8 +31,8 @@ core consumes the capability        e.g. the retention engine reads a jurisdicti
 ```
 
 Read top to bottom, that is the entire lifecycle: a unit *declares* a value, the generator *composes*
-the enabled set, each role binary *reconciles* it into the core at boot, and the core *consumes* it.
-Everything below is detail on one of those four steps.
+the enabled set, the build *binds* one composition module, each role binary *reconciles* it into the
+core at boot, and the core *consumes* it. Everything below is detail on one of those five steps.
 
 ## Purpose — why a whole tier for this
 
@@ -69,7 +73,7 @@ Four rules hold the whole tier together:
 
 ## The parts
 
-Four moving pieces, matching the four steps in the picture.
+Five moving pieces, matching the five steps in the picture.
 
 ### 1. The declaration — what a unit exports
 
@@ -89,8 +93,9 @@ That value is the entire contract. `Name` is the canonical unit name (it must eq
 name, obeys `^[a-z0-9]+(-[a-z0-9]+)*$`, ≤32 chars) and keys the unit's namespace everywhere it will
 touch — `x_<name>_<table>` tables, `/x/<name>/` paths, the `x_<name>` database role. `Version` is
 recorded in the boot inventory and carries no authority. **Capabilities are the remaining fields** —
-`Jurisdictions` (passive policy) and `Tools` (the first *governed* kind, deriving risk-tier
-requests into the manifest; not yet served — see §3).
+`Jurisdictions` (passive policy) and `Tools` (the first *governed* kind: a risk-tier request in the
+manifest, and — when the declaration carries a handler — a tool the agent surface actually serves,
+see §5).
 
 ### 2. The published surface — and the marker that gates it
 
@@ -127,8 +132,8 @@ from the declaration's AST, so review tooling and the coming approval flow learn
 without compiling or executing its code. The first governed kind is the **agent tool**
 (`extension.Tool`: a verb, a requested tier, one requested scope); a tool declaration derives into one
 risk-tier request carrying the §5 security descriptor (id, operation, scopes, tier) and its
-digest. Declaring a tool records the request in the manifest — *serving* it, registration behind the
-operator-approval gate, arrives in a later slice; until then a declared tool is inert. Passive policy
+digest. Declaring a tool records the request in the manifest; whether it is also *served* depends on
+the declaration carrying a handler (§5). Passive policy
 that an extension merely supplies requests no risk tier and does not appear: a jurisdiction pack exposes no
 governed operation (the core consults its policy at boot — it is never an agent that acts) and asks
 for no tier, so a jurisdiction-only unit (like `de`) carries an empty risk-tiers list — there is
@@ -137,7 +142,50 @@ nothing to approve. The returned `extension.Extension` literal and the fields th
 position rather than producing a manifest that silently omits a request. The manifest is committed
 with the unit and drift-gated like the contract; its digest rides in `composition.json` per unit.
 
-### 4. The boot reconciliation — validate the set, then apply
+### 4. The build-time binding — which `composition` module the compiler links
+
+The generator writes the composed wiring, but nothing yet says the *binary* should use it. That is a
+separate step, and it is worth understanding on its own: the composition module exists **twice on
+disk under one import path**.
+
+| | Module path | `Extensions()` returns |
+|---|---|---|
+| `composition/` — committed vanilla stub | `github.com/gradionhq/margince/composition` | `nil` |
+| `build/composition/backend/` — generated, git-ignored | `github.com/gradionhq/margince/composition` | the enabled set |
+
+Core code carries one unconditional `composition.Extensions()` call — no build tags, no `if enabled`.
+**Which function body that call links to is decided by the active Go workspace**, through two
+resolution mechanisms whose precedence is the whole trick:
+
+- **`replace` in `backend/go.mod`** points the import path at `../composition`, the stub. It is
+  committed, so it is what a bare `go build` — or `gopls` in an editor — resolves. That is deliberate:
+  tooling always sees vanilla.
+- **`use` in the generated `build/composition/go.work`** lists the generated module's directory. A
+  `use` entry does not substitute one path for another; it declares that directory as the local source
+  for whatever module path its own `go.mod` names. **A workspace member outranks a member module's
+  `replace`**, so inside this workspace the generated module wins and the `replace` is never reached.
+
+Hence the switch in `backend/Makefile`, which every build, test, and run lane carries:
+
+```make
+COMPOSITION_DIR := $(abspath ../build/composition)
+GOWORK_COMPOSED := GOWORK=$(COMPOSITION_DIR)/go.work
+```
+
+Two consequences worth internalizing. First, `gen-composition` itself runs under the **root**
+`go.work` instead: it lives in the separate `backend/tools` module and must resolve *before* the
+composition exists, so it cannot depend on a workspace that its own output creates. Second, a lane
+that forgets to export `GOWORK` does not fail — it silently produces a **vanilla** binary that boots
+fine and looks identical. The byte-identity gate is what makes that safe rather than alarming for the
+empty set, but for a non-empty `extensions/` tree it is a real failure mode: check `GOWORK` before
+concluding an extension "did not load".
+
+The confusing part when reading the tree is that the generated module sits in a directory named
+`backend/` while declaring the `composition` module path. Go only ever reads the `module` line; the
+directory name is a sibling-of-outputs convention (`build/composition/` also holds `api/` and
+`frontend/`), never a Go-meaningful name.
+
+### 5. The boot reconciliation — validate the set, then apply
 
 Each role binary wires the composed set at exactly one place — its `main.go`:
 
@@ -158,9 +206,17 @@ Validate-then-apply makes "partially registered extension" a state the system ca
 
 **Today: two capability kinds.** A **jurisdiction pack** supplies *country-specific policy the core
 consults; it is never an actor* — it exposes no governed operation, so it never appears in the unit
-manifest. An **agent tool** (`extension.Tool`) is the first *governed* kind: it derives an risk-tier
-request into `manifest.generated.json` for operator resolution (§7), but is **not yet served** —
-registration behind the approval gate arrives in a later slice, so a declared tool is currently inert. The core stays country-neutral — a fitness gate
+manifest. An **agent tool** (`extension.Tool`) is the first *governed* kind: it derives a risk-tier
+request into `manifest.generated.json` for operator resolution (§7), and a tool declaring a `Handle`
+**is served** — `buildExtensionTools` adapts it to the core `mcp.Tool` seam and boot registers it into
+the same `agents.Registry`, admission gate, and tool listing the core tools ride (`extensions/yogi` is
+the reference unit that exercises that path end to end). Two limits hold there: a handler-less
+declaration stays a manifest request and serves nothing, and a *served* 🟡 confirm-first tool is
+refused at boot rather than registered, because this data-only adapter cannot implement the registry's
+staging seam — its approvals could never be staged, so the capability would be dead on every call. And
+until per-capability operator resolution lands, **the composed set is itself the trust boundary**: a
+handler-bearing tool is served at its declared tier because someone added the unit to the tree
+deliberately. The core stays country-neutral — a fitness gate
 (`check-no-jurisdiction.sh`) scans hand-written core source for jurisdiction-specific identifiers and
 fails the build on a match. Germany does not live in the core; it lives in `extensions/de`, which
 declares the GoBD/AO statutory **retention floors** — commercial correspondence 6 years, and
@@ -173,11 +229,26 @@ only the correspondence floor actually binds a record; the accounting-vouchers c
 aliases, so the core retention engine consults the *same* constants an extension declares.
 
 **How new capabilities arrive.** A new capability kind is a new *field* on `extension.Extension` and a
-new marked `pkg/**` package holding its contract — existing units keep compiling. Two capabilities are
+new marked `pkg/**` package holding its contract — existing units keep compiling. Capabilities are
 reserved in the naming scheme but **not yet landed**: a unit owning its own `x_<name>_*` tables (the
 extension-migration namespace — which is why `cmd/migrate` is permitted but not *required* to wire the
 composition today) and its own `/x/<name>/` HTTP surface. The unit name is already validated to the
 full identifier budget so a name chosen today stays valid when those arrive.
+
+**The composition is Go-only today, and it says so out loud.** `build/composition/` already emits
+`api/crm.yaml` and `frontend/extensions.gen.ts` alongside the Go wiring, but both are **placeholders**:
+the contract is copied byte-identically from `backend/api/crm.yaml`, and the frontend file is a
+constant `export const extensions = [] as const;` that no `frontend/src` module imports. Correspondingly
+the generator **refuses** a unit that ships an `api/`, `frontend/`, or `migrations/` directory — it
+fails with *"composition is not built yet — the walking skeleton composes Go registrations only"*
+rather than ignoring the directory. So the honest summary of the tier as it stands: the
+selection-and-binding machinery is complete and gated, the capability surface it carries is two kinds
+deep and backend-only, and the other three slices are scaffolded as fail-loud stubs.
+
+One ordering constraint falls out of that, worth knowing before designing the frontend slice: the SPA
+gates affordances with `useCan(object, action)` over an `RbacObject` **generated from `crm.yaml`'s
+enums**, so a page gated on an extension-owned RBAC object needs the contract overlay first. The API
+slice precedes the frontend slice, or an extension page gates only on core objects.
 
 ## The guardrails — held from the tree
 
@@ -208,10 +279,13 @@ the whole path).
 | The jurisdiction-pack contract | `backend/pkg/extension/jurisdiction/jurisdiction.go` |
 | The core-internal jurisdiction registry (aliases the published types) | `backend/internal/shared/ports/jurisdiction/jurisdiction.go` |
 | Boot reconciliation (validate-then-apply) | `backend/internal/compose/extensions.go` |
+| Served-tool adaptation into the core MCP seam | `backend/internal/compose/extensiontools.go` |
 | Role-main wiring | `backend/cmd/{api,worker}/main.go` |
 | The composition generator | `backend/tools/gen-composition/` |
-| The committed vanilla stub | `composition/extensions_gen.go` |
+| The committed vanilla stub (and its `replace` in `backend/go.mod`) | `composition/extensions_gen.go` |
+| The `GOWORK` switch every build lane carries | `backend/Makefile` (`GOWORK_COMPOSED`) |
 | The first-party German pack | `extensions/de/de.go` |
+| The reference served-tool unit | `extensions/yogi/yogi.go` |
 | The reference fixture | `fixtures/extensions/crm-hello/crmhello.go` |
 | The extension-tier fitness tests | `backend/extensions_arch_test.go` |
 
@@ -220,4 +294,6 @@ the whole path).
 - [how-to/add-an-extension.md](../how-to/add-an-extension.md) — build and ship a unit, step by step.
 - [privacy-and-consent.md](privacy-and-consent.md) — the retention engine that consumes a pack.
 - [composition-layer.md](composition-layer.md) — how `compose` boots and wires the composed set.
+- [agent-surface.md](agent-surface.md) — the registry and admission gate a served extension tool joins.
+- [frontend-architecture.md](frontend-architecture.md) — the SPA an extension frontend slice would extend.
 - [reference/make-targets.md](../reference/make-targets.md) — `composition`, `check-composition`, `test-extensions`.


### PR DESCRIPTION
## What

`docs/explanation/extensibility.md` walked a unit from declaration to boot in four steps. The **binding** was missing — and it is the step that reading the tree makes look like a bug: the composition module exists twice on disk under one import path (`composition/` committed stub, `build/composition/backend/` generated), so two `go.mod` files carry an identical `module github.com/gradionhq/margince/composition` line.

Which body `composition.Extensions()` links to is decided by the active Go workspace, not by anything in the source. That was documented nowhere in `docs/` beyond one passing `GOWORK` mention in the `make-targets.md` table.

## Added — part 4, the build-time binding

- The two-module table, and why the directory named `backend/` declares the `composition` path (Go reads the `module` line; the name is a sibling-of-outputs convention).
- `replace` in `backend/go.mod` vs `use` in the generated `go.work`, and the precedence that makes it work: **a workspace member outranks a member module's `replace`**, so the `replace` is never reached inside the composed workspace. Bare `go build` and `gopls` therefore always see vanilla — deliberately.
- The `GOWORK_COMPOSED` switch every build/test/run lane carries.
- Why `gen-composition` runs under the **root** workspace instead: it lives in the separate `backend/tools` module and must resolve before its own output exists.
- The failure mode a forgotten `GOWORK` produces — a vanilla binary that boots fine and looks identical. Check `GOWORK` before concluding an extension "did not load".

Threaded into the existing picture (four steps → five) and the `docs/README.md` index line.

## Reconciled — two stale claims

1. **"already ships one"** → two. `extensions/yogi` is committed.
2. **"a declared tool is not yet served / currently inert"** → no longer true. `buildExtensionTools` adapts a handler-bearing tool to the `mcp.Tool` seam and `registerComposedTools` registers it into `agents.Registry` (`internal/compose/registry.go:116`). Replaced with the limits that actually hold — a handler-less declaration stays a manifest request, a *served* 🟡 tool is refused at boot because the data-only adapter cannot implement the staging seam — and the composed set named as the trust boundary until per-capability operator resolution lands (per the TRUST MODEL comment in `extensiontools.go`).

## Also recorded — the composition is Go-only today

`api/crm.yaml` is a byte-identical copy; `frontend/extensions.gen.ts` is a constant `[]` that no `frontend/src` module imports; and `scan.go` **refuses** a unit shipping `api/`, `frontend/`, or `migrations/` rather than ignoring it. Plus the ordering constraint that follows: `useCan` takes an `RbacObject` generated from `crm.yaml`, so the API slice precedes any frontend slice.

## Verification

Docs-only diff (2 files). All four cross-doc links resolve; both code citations checked against the files. The pre-push hook took the docs-only path (`craft static: no changed backend Go files — ok`), and no backend or frontend source is touched.

## Known gap, not fixed here

`docs/reference/make-targets.md:58` still says a default checkout composes `{de}` — stale for the same reason as claim 1. Left out to keep this diff to the one page; happy to fold it in or file it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies how the active `GOWORK` selects the `composition` module at build time (`composition/` stub vs `build/composition/backend/` generated), how `go.work use` outranks `go.mod replace`, and where `GOWORK_COMPOSED` is used.
Updates the extension-tier docs to match what ships: two committed units, served handler-backed tools (with limits), a Go-only composition, and the failure mode when `GOWORK` is unset.

<sup>Written for commit e524c4c627f420eebbcb489076563edc8fb06577. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

