### PR TITLE
fix(ai): ollama is told how big a window the request needs

### DIFF
--- a/backend/internal/modules/ai/ollama.go
+++ b/backend/internal/modules/ai/ollama.go
@@ -38,54 +38,77 @@ type ollamaWire struct {
 }
 
 type ollamaOptions struct {
-	// Omitted when unset: Ollama reads a literal `num_predict: 0` as "generate
-	// nothing", so a request that names no output budget must not send the
-	// field at all.
-	NumPredict int `json:"num_predict,omitempty"`
+	NumPredict int `json:"num_predict"`
 	NumCtx     int `json:"num_ctx"`
 }
 
-// ollamaDefaultContext is the window Ollama falls back to when a request names
-// none. Treated as a FLOOR rather than a value to compute against: a short
-// request must never end up with a smaller window than it would have had if
-// this adapter said nothing at all.
-const ollamaDefaultContext = 4096
+// ollamaMaxTokensDefault caps a request that didn't set MaxTokens, the same
+// answer anthropic and gemini give the same gap. The window below is sized from
+// this number, so leaving it unset would make the output allowance an accident
+// of the arithmetic rather than a stated budget.
+const ollamaMaxTokensDefault = 1024
 
-// ollamaTemplateHeadroom covers what the server adds around our text — the
-// chat template's role scaffolding, and the schema it compiles into a decoding
-// grammar. Approximate by nature, which is why it is generous.
-const ollamaTemplateHeadroom = 1024
+// ollamaContextFloor is Ollama's own default window. The adapter never asks for
+// less, so a short request cannot come out worse than saying nothing at all.
+const ollamaContextFloor = 4096
 
-// ollamaContextWindow sizes `num_ctx` to the request being made.
+// ollamaMaxContext caps the window the adapter will ask for.
+//
+// The prompt is not ours: the extraction lanes feed this provider the text of
+// crawled pages and captured messages, so its LENGTH is chosen by whoever
+// published the page or sent the mail. Ollama sizes the runner's KV cache from
+// num_ctx when it loads a model, so an uncapped window would let a remote party
+// pick that allocation — a megabyte of prose asks for a window in the hundreds
+// of thousands of tokens, gigabytes the host must find or fail trying, taking
+// every other AI lane in the installation with it.
+//
+// Clamping buys a better failure: past this point the prompt truncates, which
+// is confined to the page that caused it.
+const ollamaMaxContext = 32768
+
+// ollamaContextBucket quantizes the window. num_ctx is a RUNNER parameter —
+// Ollama reloads the model when a request's value differs from the loaded
+// one's — and a byte-derived window is a different number on nearly every call,
+// so a crawl fanning out over dozens of pages would pay a model load per page.
+// Rounding up keeps a whole workload on one loaded runner, and the remainder to
+// the boundary doubles as the headroom the chat template needs.
+const ollamaContextBucket = 4096
+
+// ollamaPerMessageOverhead is the role and delimiter scaffolding the template
+// wraps around each turn, which a byte count of the content alone cannot see.
+const ollamaPerMessageOverhead = 8
+
+// contextWindow sizes `num_ctx` for the assembled request.
 //
 // num_ctx bounds prompt AND completion together, while num_predict bounds only
-// the completion — so asking for more output tokens than the window can hold
-// past the prompt is a request that cannot be satisfied. Ollama does not refuse
-// it: it generates until the window is full and stops, reporting
-// `done_reason: "length"`.
+// the completion — so asking for more output than the window holds past the
+// prompt is a request Ollama cannot satisfy. It does not refuse: it generates
+// until the window is full and stops with `done_reason: "length"`.
 //
-// On a reasoning model that truncation lands INSIDE the thinking, which is not
-// the content field. The caller then gets a well-formed reply whose content is
-// the empty string, and a JSON-schema task fails as "unparseable reply" — a
-// wrong-looking model, not the resource limit it actually is. Measured on a
-// real crawled page: 1,085 prompt tokens and a 8,192-token budget against the
-// 4,096 default produced 3,011 generated tokens and zero content.
+// On a reasoning model that cut lands INSIDE the thinking, which is not the
+// content field, so the caller gets a well-formed reply whose content is the
+// empty string and a schema-carrying task fails as an unparseable one — a
+// wrong-looking model where the truth is a window too small for what was asked.
 //
-// The estimate is the module's ~4-bytes-per-token heuristic (embedTokenEstimate
-// meters the embed lane the same way). It only has to be close: the cost of
-// overshooting is memory Ollama would have reserved lazily anyway, and the cost
-// of undershooting is the silent truncation above.
-func ollamaContextWindow(req model.Request, wire ollamaWire) int {
-	prompt := len(req.System) + len(req.ResponseSchema)
-	for _, message := range wire.Messages {
-		prompt += len(message.Content)
+// Measured off the wire rather than the request: wire.Messages already carries
+// the system prompt as its leading turn, so counting req.System too would
+// double it. The ~4-bytes-per-token heuristic is the one the embed lane meters
+// with; it only has to be close, because the floor, the bucket and the cap
+// between them decide the value that actually ships.
+func (w ollamaWire) contextWindow(maxTokens int) int {
+	prompt := len(w.Format)
+	for _, message := range w.Messages {
+		prompt += len(message.Content) + len(message.Role) + ollamaPerMessageOverhead
 	}
-	for _, tool := range wire.Tools {
+	for _, tool := range w.Tools {
 		prompt += len(tool.Function.Name) + len(tool.Function.Description) + len(tool.Function.Parameters)
 	}
-	window := prompt/4 + req.MaxTokens + ollamaTemplateHeadroom
-	if window < ollamaDefaultContext {
-		return ollamaDefaultContext
+	window := ((prompt/4+maxTokens)/ollamaContextBucket + 1) * ollamaContextBucket
+	if window < ollamaContextFloor {
+		return ollamaContextFloor
+	}
+	if window > ollamaMaxContext {
+		return ollamaMaxContext
 	}
 	return window
 }
@@ -205,12 +228,13 @@ func (c *ollamaClient) sendChat(ctx context.Context, req model.Request, stream b
 		tw.Function.Parameters = tool.InputSchema
 		wire.Tools = append(wire.Tools, tw)
 	}
-	// Sized last: the window has to account for the messages and tools just
-	// assembled, so this cannot move above them.
-	wire.Options = &ollamaOptions{
-		NumPredict: req.MaxTokens,
-		NumCtx:     ollamaContextWindow(req, wire),
+	maxTokens := req.MaxTokens
+	if maxTokens <= 0 {
+		maxTokens = ollamaMaxTokensDefault
 	}
+	// Sized last: the window has to account for the messages, tools and schema
+	// just assembled, so this cannot move above them.
+	wire.Options = &ollamaOptions{NumPredict: maxTokens, NumCtx: wire.contextWindow(maxTokens)}
 	payload, _, err := sendablePayload(ctx, wire, req.SecretStripper)
 	if err != nil {
 		return nil, err

--- a/backend/internal/modules/ai/ollama.go
+++ b/backend/internal/modules/ai/ollama.go
@@ -38,7 +38,56 @@ type ollamaWire struct {
 }
 
 type ollamaOptions struct {
-	NumPredict int `json:"num_predict"`
+	// Omitted when unset: Ollama reads a literal `num_predict: 0` as "generate
+	// nothing", so a request that names no output budget must not send the
+	// field at all.
+	NumPredict int `json:"num_predict,omitempty"`
+	NumCtx     int `json:"num_ctx"`
+}
+
+// ollamaDefaultContext is the window Ollama falls back to when a request names
+// none. Treated as a FLOOR rather than a value to compute against: a short
+// request must never end up with a smaller window than it would have had if
+// this adapter said nothing at all.
+const ollamaDefaultContext = 4096
+
+// ollamaTemplateHeadroom covers what the server adds around our text — the
+// chat template's role scaffolding, and the schema it compiles into a decoding
+// grammar. Approximate by nature, which is why it is generous.
+const ollamaTemplateHeadroom = 1024
+
+// ollamaContextWindow sizes `num_ctx` to the request being made.
+//
+// num_ctx bounds prompt AND completion together, while num_predict bounds only
+// the completion — so asking for more output tokens than the window can hold
+// past the prompt is a request that cannot be satisfied. Ollama does not refuse
+// it: it generates until the window is full and stops, reporting
+// `done_reason: "length"`.
+//
+// On a reasoning model that truncation lands INSIDE the thinking, which is not
+// the content field. The caller then gets a well-formed reply whose content is
+// the empty string, and a JSON-schema task fails as "unparseable reply" — a
+// wrong-looking model, not the resource limit it actually is. Measured on a
+// real crawled page: 1,085 prompt tokens and a 8,192-token budget against the
+// 4,096 default produced 3,011 generated tokens and zero content.
+//
+// The estimate is the module's ~4-bytes-per-token heuristic (embedTokenEstimate
+// meters the embed lane the same way). It only has to be close: the cost of
+// overshooting is memory Ollama would have reserved lazily anyway, and the cost
+// of undershooting is the silent truncation above.
+func ollamaContextWindow(req model.Request, wire ollamaWire) int {
+	prompt := len(req.System) + len(req.ResponseSchema)
+	for _, message := range wire.Messages {
+		prompt += len(message.Content)
+	}
+	for _, tool := range wire.Tools {
+		prompt += len(tool.Function.Name) + len(tool.Function.Description) + len(tool.Function.Parameters)
+	}
+	window := prompt/4 + req.MaxTokens + ollamaTemplateHeadroom
+	if window < ollamaDefaultContext {
+		return ollamaDefaultContext
+	}
+	return window
 }
 
 type ollamaToolWire struct {
@@ -142,9 +191,6 @@ func (c *ollamaClient) sendChat(ctx context.Context, req model.Request, stream b
 	if wire.Model == "" {
 		wire.Model = c.defaultModel
 	}
-	if req.MaxTokens > 0 {
-		wire.Options = &ollamaOptions{NumPredict: req.MaxTokens}
-	}
 	if len(req.ResponseSchema) > 0 {
 		wire.Format = req.ResponseSchema
 	}
@@ -158,6 +204,12 @@ func (c *ollamaClient) sendChat(ctx context.Context, req model.Request, stream b
 		tw.Function.Description = tool.Description
 		tw.Function.Parameters = tool.InputSchema
 		wire.Tools = append(wire.Tools, tw)
+	}
+	// Sized last: the window has to account for the messages and tools just
+	// assembled, so this cannot move above them.
+	wire.Options = &ollamaOptions{
+		NumPredict: req.MaxTokens,
+		NumCtx:     ollamaContextWindow(req, wire),
 	}
 	payload, _, err := sendablePayload(ctx, wire, req.SecretStripper)
 	if err != nil {

--- a/backend/internal/modules/ai/ollama.go
+++ b/backend/internal/modules/ai/ollama.go
@@ -232,6 +232,14 @@ func (c *ollamaClient) sendChat(ctx context.Context, req model.Request, stream b
 	if maxTokens <= 0 {
 		maxTokens = ollamaMaxTokensDefault
 	}
+	// A budget past the largest window the adapter will ask for cannot be met
+	// whatever it says, and left unclamped it overflows the window arithmetic
+	// into a SMALL number — a request advertising an enormous num_predict
+	// against a tiny context, which Ollama then truncates at once. Clamped here
+	// rather than inside the window so the two fields cannot disagree.
+	if maxTokens > ollamaMaxContext {
+		maxTokens = ollamaMaxContext
+	}
 	// Sized last: the window has to account for the messages, tools and schema
 	// just assembled, so this cannot move above them.
 	wire.Options = &ollamaOptions{NumPredict: maxTokens, NumCtx: wire.contextWindow(maxTokens)}

--- a/backend/internal/modules/ai/ollama_test.go
+++ b/backend/internal/modules/ai/ollama_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -279,6 +280,24 @@ func TestOllamaSizesContextWindowToPromptPlusOutputBudget(t *testing.T) {
 	})
 	if grown.NumCtx <= base.NumCtx {
 		t.Fatalf("num_ctx did not grow with the prompt: %d then %d", base.NumCtx, grown.NumCtx)
+	}
+
+	// An absurd budget must clamp rather than wrap. Unclamped, `prompt/4 +
+	// maxTokens` overflows and the bucket arithmetic lands on a SMALL window —
+	// the model would be handed a huge num_predict against a tiny context and
+	// truncate immediately, which is the opposite of what the number says.
+	_, absurd, _ := sent(t, model.Request{
+		Messages:  []model.Message{{Role: "user", Content: "hi"}},
+		MaxTokens: math.MaxInt32,
+	})
+	if absurd.NumCtx != ollamaMaxContext {
+		t.Fatalf("num_ctx %d for an absurd budget, want the %d cap", absurd.NumCtx, ollamaMaxContext)
+	}
+	if absurd.NumPredict > absurd.NumCtx {
+		t.Fatalf(
+			"num_predict %d exceeds num_ctx %d — the budget promises more than the window can hold",
+			absurd.NumPredict, absurd.NumCtx,
+		)
 	}
 
 	// Prompt length is chosen by whoever published the page, so the window it

--- a/backend/internal/modules/ai/ollama_test.go
+++ b/backend/internal/modules/ai/ollama_test.go
@@ -169,14 +169,16 @@ func TestOllamaStreamReadsJSONLines(t *testing.T) {
 }
 
 // num_ctx bounds prompt AND completion together; num_predict bounds only the
-// completion. Left unsaid, Ollama uses a 4096 default, so a long page plus a
+// completion. Left unsaid, Ollama uses a 4096 default, so a long page and a
 // large output budget cannot both fit — and the model stops mid-generation
 // rather than refusing. On a reasoning model the cut lands inside the thinking,
-// so the reply arrives well-formed with an EMPTY content field and a
-// schema-carrying task fails as "unparseable reply". That reads as a bad model
-// and is really a window too small for what was asked.
+// so the reply arrives well-formed with an EMPTY content field.
+//
+// Ground truth here is the wire Ollama actually received, never the estimator's
+// own arithmetic: an assertion that recomputed the estimate would still hold if
+// the estimate itself regressed.
 func TestOllamaSizesContextWindowToPromptPlusOutputBudget(t *testing.T) {
-	options := func(t *testing.T, req model.Request) ollamaOptions {
+	sent := func(t *testing.T, req model.Request) (map[string]json.RawMessage, ollamaOptions, int) {
 		t.Helper()
 		var received []byte
 		client := newOllamaForTest(t, func(w http.ResponseWriter, r *http.Request) {
@@ -190,56 +192,103 @@ func TestOllamaSizesContextWindowToPromptPlusOutputBudget(t *testing.T) {
 		if _, err := client.Complete(context.Background(), req); err != nil {
 			t.Fatal(err)
 		}
-		var wire struct {
-			Options ollamaOptions `json:"options"`
+		var raw struct {
+			Options map[string]json.RawMessage `json:"options"`
 		}
-		if err := json.Unmarshal(received, &wire); err != nil {
+		if err := json.Unmarshal(received, &raw); err != nil {
 			t.Fatalf("wire not JSON: %v", err)
 		}
-		return wire.Options
+		var opts ollamaOptions
+		encoded, err := json.Marshal(raw.Options)
+		if err != nil {
+			t.Fatalf("re-encode options: %v", err)
+		}
+		if err := json.Unmarshal(encoded, &opts); err != nil {
+			t.Fatalf("options not decodable: %v", err)
+		}
+		return raw.Options, opts, len(received)
 	}
 
-	// The shape that produced the empty reply in the field: a crawled page as
-	// the prompt and a large output budget behind it.
 	page := strings.Repeat("Gradion Pte. Ltd. 77 High Street, Singapore. ", 400)
-	big := options(t, model.Request{
-		System:         "You extract company facts from ONE page.",
-		Messages:       []model.Message{{Role: "user", Content: page}},
-		MaxTokens:      8192,
-		ResponseSchema: []byte(`{"type":"object","properties":{"facts":{"type":"array"}}}`),
-	})
-	if big.NumPredict != 8192 {
-		t.Fatalf("num_predict not forwarded: %d", big.NumPredict)
-	}
-	// The invariant: the window holds the prompt AND everything we authorised
-	// the model to generate. Asserted as a relation over the request rather
-	// than a fixed number, so it keeps holding if the estimate is retuned.
-	promptTokens := (len(page) + len("You extract company facts from ONE page.")) / 4
-	if big.NumCtx < promptTokens+big.NumPredict {
-		t.Fatalf(
-			"num_ctx %d cannot hold prompt (~%d tok) plus num_predict %d — the model will stop mid-generation",
-			big.NumCtx, promptTokens, big.NumPredict,
-		)
-	}
-	// And it must beat the server default it is there to replace, or the field
-	// buys nothing.
-	if big.NumCtx <= ollamaDefaultContext {
-		t.Fatalf("num_ctx %d is no better than Ollama's %d default", big.NumCtx, ollamaDefaultContext)
+	schema := []byte(`{"type":"object","properties":{"facts":{"type":"array"}}}`)
+
+	for _, tc := range []struct {
+		name string
+		req  model.Request
+	}{
+		{"long page with a budget", model.Request{
+			System:         "You extract company facts from ONE page.",
+			Messages:       []model.Message{{Role: "user", Content: page}},
+			MaxTokens:      8192,
+			ResponseSchema: schema,
+		}},
+		{"long page with no budget named", model.Request{
+			Messages: []model.Message{{Role: "user", Content: page}},
+		}},
+		{"long page with tools", model.Request{
+			Messages: []model.Message{{Role: "user", Content: page}},
+			Tools: []model.ToolDef{{
+				Name: "lookup", Description: strings.Repeat("finds a record. ", 200),
+				InputSchema: schema,
+			}},
+			MaxTokens: 2048,
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			raw, opts, wireBytes := sent(t, tc.req)
+			// The window must hold everything actually sent plus everything the
+			// model was authorised to generate. wireBytes is the whole payload,
+			// so it over-counts the JSON scaffolding — which only makes this a
+			// stricter floor than the prompt alone.
+			if floor := wireBytes/4 + opts.NumPredict; opts.NumCtx < floor {
+				t.Fatalf(
+					"num_ctx %d cannot hold the %d-byte payload (~%d tok) plus num_predict %d — the model stops mid-generation",
+					opts.NumCtx, wireBytes, wireBytes/4, opts.NumPredict,
+				)
+			}
+			if opts.NumPredict <= 0 {
+				t.Fatalf("num_predict %d — a request with no stated budget must still get one", opts.NumPredict)
+			}
+			if _, present := raw["num_ctx"]; !present {
+				t.Fatalf("num_ctx absent from the wire: %v", raw)
+			}
+			if opts.NumCtx%ollamaContextBucket != 0 {
+				t.Fatalf("num_ctx %d is not a bucket multiple — a per-request value reloads the runner", opts.NumCtx)
+			}
+			if opts.NumCtx < ollamaContextFloor || opts.NumCtx > ollamaMaxContext {
+				t.Fatalf("num_ctx %d outside [%d,%d]", opts.NumCtx, ollamaContextFloor, ollamaMaxContext)
+			}
+		})
 	}
 
-	// A short request must not come out WORSE than saying nothing: the default
-	// is a floor, never a ceiling to compute down to.
-	small := options(t, model.Request{Messages: []model.Message{{Role: "user", Content: "hi"}}})
-	if small.NumCtx < ollamaDefaultContext {
-		t.Fatalf("num_ctx %d below Ollama's own %d default", small.NumCtx, ollamaDefaultContext)
+	// A short request must not come out worse than saying nothing at all.
+	_, small, _ := sent(t, model.Request{Messages: []model.Message{{Role: "user", Content: "hi"}}})
+	if small.NumCtx != ollamaContextFloor {
+		t.Fatalf("num_ctx %d for a two-byte prompt, want the %d floor", small.NumCtx, ollamaContextFloor)
 	}
-	// A request naming no output budget must not send `num_predict: 0`, which
-	// Ollama reads as "generate nothing".
-	encoded, err := json.Marshal(small)
-	if err != nil {
-		t.Fatalf("marshal options: %v", err)
+
+	// The window tracks the prompt rather than sitting at a constant: a bigger
+	// page must buy a bigger window, which a flat default would not.
+	_, grown, _ := sent(t, model.Request{
+		Messages:  []model.Message{{Role: "user", Content: strings.Repeat(page, 4)}},
+		MaxTokens: 2048,
+	})
+	_, base, _ := sent(t, model.Request{
+		Messages:  []model.Message{{Role: "user", Content: page}},
+		MaxTokens: 2048,
+	})
+	if grown.NumCtx <= base.NumCtx {
+		t.Fatalf("num_ctx did not grow with the prompt: %d then %d", base.NumCtx, grown.NumCtx)
 	}
-	if strings.Contains(string(encoded), `"num_predict":0`) {
-		t.Fatalf("num_predict: 0 sent for a request with no output budget: %s", encoded)
+
+	// Prompt length is chosen by whoever published the page, so the window it
+	// can ask for is capped: past the ceiling the prompt truncates, rather than
+	// a remote party sizing the host's KV-cache allocation.
+	_, hostile, _ := sent(t, model.Request{
+		Messages:  []model.Message{{Role: "user", Content: strings.Repeat("a", 4<<20)}},
+		MaxTokens: 8192,
+	})
+	if hostile.NumCtx != ollamaMaxContext {
+		t.Fatalf("num_ctx %d for a 4MiB prompt, want the %d cap", hostile.NumCtx, ollamaMaxContext)
 	}
 }

--- a/backend/internal/modules/ai/ollama_test.go
+++ b/backend/internal/modules/ai/ollama_test.go
@@ -167,3 +167,79 @@ func TestOllamaStreamReadsJSONLines(t *testing.T) {
 		t.Fatalf("stream mismatch: %q", got.String())
 	}
 }
+
+// num_ctx bounds prompt AND completion together; num_predict bounds only the
+// completion. Left unsaid, Ollama uses a 4096 default, so a long page plus a
+// large output budget cannot both fit — and the model stops mid-generation
+// rather than refusing. On a reasoning model the cut lands inside the thinking,
+// so the reply arrives well-formed with an EMPTY content field and a
+// schema-carrying task fails as "unparseable reply". That reads as a bad model
+// and is really a window too small for what was asked.
+func TestOllamaSizesContextWindowToPromptPlusOutputBudget(t *testing.T) {
+	options := func(t *testing.T, req model.Request) ollamaOptions {
+		t.Helper()
+		var received []byte
+		client := newOllamaForTest(t, func(w http.ResponseWriter, r *http.Request) {
+			received = readBody(t, r.Body)
+			if err := json.NewEncoder(w).Encode(map[string]any{
+				"message": map[string]string{"content": "{}"}, "done": true,
+			}); err != nil {
+				t.Errorf("encoding fixture response: %v", err)
+			}
+		})
+		if _, err := client.Complete(context.Background(), req); err != nil {
+			t.Fatal(err)
+		}
+		var wire struct {
+			Options ollamaOptions `json:"options"`
+		}
+		if err := json.Unmarshal(received, &wire); err != nil {
+			t.Fatalf("wire not JSON: %v", err)
+		}
+		return wire.Options
+	}
+
+	// The shape that produced the empty reply in the field: a crawled page as
+	// the prompt and a large output budget behind it.
+	page := strings.Repeat("Gradion Pte. Ltd. 77 High Street, Singapore. ", 400)
+	big := options(t, model.Request{
+		System:         "You extract company facts from ONE page.",
+		Messages:       []model.Message{{Role: "user", Content: page}},
+		MaxTokens:      8192,
+		ResponseSchema: []byte(`{"type":"object","properties":{"facts":{"type":"array"}}}`),
+	})
+	if big.NumPredict != 8192 {
+		t.Fatalf("num_predict not forwarded: %d", big.NumPredict)
+	}
+	// The invariant: the window holds the prompt AND everything we authorised
+	// the model to generate. Asserted as a relation over the request rather
+	// than a fixed number, so it keeps holding if the estimate is retuned.
+	promptTokens := (len(page) + len("You extract company facts from ONE page.")) / 4
+	if big.NumCtx < promptTokens+big.NumPredict {
+		t.Fatalf(
+			"num_ctx %d cannot hold prompt (~%d tok) plus num_predict %d — the model will stop mid-generation",
+			big.NumCtx, promptTokens, big.NumPredict,
+		)
+	}
+	// And it must beat the server default it is there to replace, or the field
+	// buys nothing.
+	if big.NumCtx <= ollamaDefaultContext {
+		t.Fatalf("num_ctx %d is no better than Ollama's %d default", big.NumCtx, ollamaDefaultContext)
+	}
+
+	// A short request must not come out WORSE than saying nothing: the default
+	// is a floor, never a ceiling to compute down to.
+	small := options(t, model.Request{Messages: []model.Message{{Role: "user", Content: "hi"}}})
+	if small.NumCtx < ollamaDefaultContext {
+		t.Fatalf("num_ctx %d below Ollama's own %d default", small.NumCtx, ollamaDefaultContext)
+	}
+	// A request naming no output budget must not send `num_predict: 0`, which
+	// Ollama reads as "generate nothing".
+	encoded, err := json.Marshal(small)
+	if err != nil {
+		t.Fatalf("marshal options: %v", err)
+	}
+	if strings.Contains(string(encoded), `"num_predict":0`) {
+		t.Fatalf("num_predict: 0 sent for a request with no output budget: %s", encoded)
+	}
+}


### PR DESCRIPTION
## What

The Ollama adapter sent `num_predict` and never `num_ctx`, so every local model call ran in whatever window Ollama defaults to — 4096 tokens.

`num_ctx` bounds prompt **and** completion together; `num_predict` bounds only the completion. So a request asking for more output than the window holds past its prompt is one Ollama cannot satisfy — and it does not refuse. It generates until the window is full and stops with `done_reason: "length"`.

On a reasoning model that cut lands **inside the thinking**, which is not the content field. The caller receives a well-formed reply whose content is the empty string, and any schema-carrying task fails as `unparseable_reply`. It reads as a bad model; the truth is a window too small for what was asked.

## How it was found

Onboarding's "read my site" failed on a real site. Traced through the worker log to the extraction lane, then reproduced against `qwen3.5:9b`:

```
prompt 1085 tok + generated 3011 tok = 4096   ← Ollama's default num_ctx, exactly
```

With `num_ctx` raised by hand the same call returned valid JSON with every fact extracted.

## The fix

The window is sized from the request the adapter is about to send: prompt estimate + authorised output + headroom for the chat template and the schema Ollama compiles into a decoding grammar. The estimate reuses the module's existing ~4-bytes-per-token heuristic (`embedTokenEstimate` meters the embed lane the same way).

Ollama's own default is treated as a **floor**, never a value to compute down to — a short request must not come out worse than saying nothing at all.

`num_predict` becomes `omitempty` in the same change: options now ride every request in order to carry the window, and a literal `num_predict: 0` reads to Ollama as "generate nothing", so a request naming no output budget must omit the field rather than send a zero.

## Verification

- `TestOllamaSizesContextWindowToPromptPlusOutputBudget` asserts the relation over the request rather than a fixed number, so it survives a retuned estimate. Confirmed to **fail against the previous behaviour**, with the arithmetic in the failure message: `num_ctx 0 cannot hold prompt (~4510 tok) plus num_predict 8192`.
- Live Ollama, same probe that produced the empty reply: `ollama ps` now reports `CONTEXT 10939` where it previously ran at the 4096 default.
- `make check-backend` green; `make craft-static` PASS (0 blocker, 0 major, 0 minor).

## What this does NOT fix

With the window corrected, `qwen3.5:9b` then spends its entire 8192-token budget reasoning and still returns no content on the page-extraction task. That is a model-and-task question, not an adapter one — a thinking model is a poor fit for a lane that crawls ~40 pages, and the measured 2m46s/page against 16s for a schema-native cloud model says the same thing.

What changes here is that the limit a local call runs into is the one that was actually asked for, rather than a silent default.

Two related findings, recorded but out of scope for this change:

- Passing `think: false` to Ollama makes this model stop honouring the JSON schema entirely — it answers in prose. Verified with a schema whose key names the prompt never mentions. So thinking cannot simply be disabled to buy back the budget.
- `provider: ollama` on any tier that processes real web pages will want the caller's `MaxTokens` to account for reasoning tokens, since Ollama counts them against `num_predict`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sizes the `ollama` context window per request so the prompt plus allowed output fit, with a 4k floor, 32k cap, and 4k buckets. Also clamps extreme `MaxTokens` to the cap to prevent overflow and mismatched options, and defaults `MaxTokens` to 1024 so `num_predict` stays positive.

- **Bug Fixes**
  - Compute `num_ctx` from the actual wire payload (messages/tools/schema), bucket to 4096, apply a 4096 floor and 32768 cap, and avoid double-counting the system prompt.
  - Always send options with computed `num_ctx`; default `MaxTokens` to 1024 and clamp it to `ollamaMaxContext` so `num_predict` cannot wrap small or exceed the window.
  - Tests assert window ≥ prompt+budget, is bucketed and within bounds, grows with prompt, and clamps for hostile-length inputs and absurd budgets.

<sup>Written for commit db7698d5c3c92c21f298f23d9043d1b38d49e7c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/506?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AI response handling for requests with large prompts or specified output limits.
  * Prevented unnecessary zero-value output limits from being sent when no limit is configured.
  * Preserved default context sizing for shorter requests.

* **Tests**
  * Added coverage for context-window sizing and output-limit behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->