### PR TITLE
feat(identity): the admin roster says what role each member holds

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -6330,7 +6330,8 @@ paths:
       description: |
         The workspace member roster: id + display name + email + seat/status. Any authenticated member
         may read it (needed to pick a record-share subject and to resolve subject/granter names). Excludes
-        archived users. Row-scoped by workspace RLS.
+        archived users. Row-scoped by workspace RLS. `User.roles` rides the row only for an admin caller,
+        who is the only one who can act on it.
       x-mcp-tool: { verb: search_records, record_type: app_user, tier: auto_execute, scope: read }
       parameters:
         - $ref: '#/components/parameters/Cursor'
@@ -13312,6 +13313,15 @@ components:
         timezone: { type: string, default: UTC, description: IANA name. }
         status: { type: string, enum: [active, suspended, deactivated], default: active }
         is_agent: { type: boolean, default: false, description: First-party Agent Runner identity vs a human seat. }
+        roles:
+          type: array
+          items: { type: string }
+          description: >
+            This member's assigned system role keys. Present ONLY for an admin caller — the roster
+            is readable by every authenticated member (it feeds the share/assignee pickers), and a
+            rep has no business enumerating who holds `admin`. Normally exactly one key:
+            `inviteUser` assigns one and `changeUserRole` replaces the whole set with one. Clients
+            that render a single current role must still handle the empty and multi-key cases.
         created_at: { type: string, format: date-time }
         updated_at: { type: string, format: date-time }
         archived_at: { type: [string, 'null'], format: date-time }

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -13322,6 +13322,8 @@ components:
             rep has no business enumerating who holds `admin`. Normally exactly one key:
             `inviteUser` assigns one and `changeUserRole` replaces the whole set with one. Clients
             that render a single current role must still handle the empty and multi-key cases.
+            Deliberately absent on `MeResponse.user`, whose sibling `MeResponse.roles` is the one
+            authority for the caller's own roles — the same fact spelled twice could disagree.
         created_at: { type: string, format: date-time }
         updated_at: { type: string, format: date-time }
         archived_at: { type: [string, 'null'], format: date-time }
@@ -13500,7 +13502,9 @@ components:
         roles:
           type: array
           items: { type: string }
-          description: Effective role keys for this principal.
+          description: >
+            Effective role keys for this principal, and the one authority for them —
+            `user.roles` is deliberately left unset here rather than repeating the same fact.
         teams:
           type: array
           items: { type: string, format: uuid }

--- a/backend/internal/compose/integration/roster_integration_test.go
+++ b/backend/internal/compose/integration/roster_integration_test.go
@@ -27,6 +27,9 @@ type rosterUser struct {
 	DisplayName string `json:"display_name"`
 	Status      string `json:"status"`
 	IsAgent     bool   `json:"is_agent"`
+	// A pointer so "the field was withheld" stays distinguishable from "this
+	// member holds no role" — the whole point of the admin-only disclosure.
+	Roles *[]string `json:"roles"`
 }
 
 type rosterTeam struct {
@@ -175,6 +178,82 @@ func TestRosterReadsUsersAndTeams(t *testing.T) {
 	}
 	if desk.WorkspaceID != wsA.String() {
 		t.Errorf("Deal Desk workspace_id = %q, want %q", desk.WorkspaceID, wsA)
+	}
+}
+
+// The roster answers every authenticated member, so the role keys it now
+// carries need their DENY arm proved where the gate actually lives — at the
+// handler, off the request principal. The unit test downstairs proves only that
+// the two mappings differ; a regression that inlined the admin mapping into the
+// response loop would pass it and leak here.
+func TestRosterWithholdsRoleKeysFromANonAdmin(t *testing.T) {
+	e := setup(t)
+	e.bootstrapWorkspace(t) // admin ada@example.com, session in the jar
+
+	wsA := wsID(t, e, e.slug)
+	rep := ids.NewV7()
+	seedInWorkspace(
+		t, e, wsA,
+		stmt(`INSERT INTO app_user (id, workspace_id, email, display_name) VALUES ($1, $2, 'rep@example.com', 'Rep One')`, rep, wsA),
+		// Borrow the bootstrap admin's hash so the rep can actually sign in:
+		// the gate under test reads the request principal, so the assertion is
+		// only worth anything from a real non-admin session.
+		stmt(`UPDATE app_user SET password_hash = (SELECT password_hash FROM app_user WHERE email = 'ada@example.com') WHERE id = $1`, rep),
+		stmt(`INSERT INTO role_assignment (workspace_id, role_id, user_id)
+		      SELECT $2, r.id, $1 FROM role r WHERE r.key = 'rep'`, rep, wsA),
+	)
+
+	// The admin arm first, from the session the bootstrap left: every row
+	// carries its keys, and the seeded rep's read back as exactly [rep].
+	var asAdmin struct {
+		Data []rosterUser `json:"data"`
+	}
+	if status := e.call(t, "GET", "/v1/users", nil, nil, &asAdmin); status != http.StatusOK {
+		t.Fatalf("admin list users → %d, want 200", status)
+	}
+	for _, u := range asAdmin.Data {
+		if u.Roles == nil {
+			t.Fatalf("admin roster: %q carries no roles field", u.Email)
+		}
+		if u.Email == "rep@example.com" && (len(*u.Roles) != 1 || (*u.Roles)[0] != "rep") {
+			t.Errorf("admin roster: rep roles = %v, want [rep]", *u.Roles)
+		}
+	}
+
+	// Now the deny arm, from the rep's own session.
+	if status := e.call(t, "POST", "/v1/auth/login", anyMap{
+		"email": "rep@example.com", "password": "correct-horse-battery",
+	}, nil, nil); status != http.StatusOK {
+		t.Fatalf("rep login → %d, want 200", status)
+	}
+	var asRep struct {
+		Data []rosterUser `json:"data"`
+	}
+	if status := e.call(t, "GET", "/v1/users", nil, nil, &asRep); status != http.StatusOK {
+		t.Fatalf("rep list users → %d, want 200", status)
+	}
+	if len(asRep.Data) == 0 {
+		t.Fatal("rep roster is empty; the deny arm would pass vacuously")
+	}
+	for _, u := range asRep.Data {
+		if u.Roles != nil {
+			t.Errorf("rep sees %q roles = %v; a non-admin must not learn who holds a role", u.Email, *u.Roles)
+		}
+	}
+
+	// The same principal check gates the widened view — a rep asking for it is
+	// answered with the active-only roster, not refused, so this is the only
+	// place that failure would show.
+	var repWidened struct {
+		Data []rosterUser `json:"data"`
+	}
+	if status := e.call(t, "GET", "/v1/users?include_inactive=true", nil, nil, &repWidened); status != http.StatusOK {
+		t.Fatalf("rep list users (include_inactive) → %d, want 200", status)
+	}
+	for _, u := range repWidened.Data {
+		if u.Roles != nil {
+			t.Errorf("rep sees %q roles = %v via include_inactive", u.Email, *u.Roles)
+		}
 	}
 }
 

--- a/backend/internal/compose/integration/roster_integration_test.go
+++ b/backend/internal/compose/integration/roster_integration_test.go
@@ -107,9 +107,18 @@ func TestRosterReadsUsersAndTeams(t *testing.T) {
 		t.Fatalf("seeding workspace B: %v", err)
 	}
 	wsB := wsID(t, e, "fable-other")
+	// B's member holds a role whose key exists in NO other workspace, so if the
+	// role aggregate ever escaped its tenant the string would be unmistakable in
+	// A's response. role/role_assignment are FORCE-RLS deny-on-unset, and every
+	// roster read runs inside WithWorkspaceTx — this is what proves it rather
+	// than asserting it.
+	eve := ids.NewV7()
 	seedInWorkspace(
 		t, e, wsB,
-		stmt(`INSERT INTO app_user (id, workspace_id, email, display_name) VALUES ($1, $2, 'eve@other.example', 'Eve Other')`, ids.NewV7(), wsB),
+		stmt(`INSERT INTO app_user (id, workspace_id, email, display_name) VALUES ($1, $2, 'eve@other.example', 'Eve Other')`, eve, wsB),
+		stmt(`INSERT INTO role (workspace_id, key, name) VALUES ($1, 'other-tenant-only', 'Other Tenant Only')`, wsB),
+		stmt(`INSERT INTO role_assignment (workspace_id, role_id, user_id)
+		      SELECT $1, r.id, $2 FROM role r WHERE r.key = 'other-tenant-only'`, wsB, eve),
 	)
 
 	// (e) No session → 401, before we lean on the authenticated reads.
@@ -143,6 +152,18 @@ func TestRosterReadsUsersAndTeams(t *testing.T) {
 	for _, u := range users.Data {
 		if u.WorkspaceID != wsA.String() {
 			t.Errorf("user %q workspace_id = %q, want %q", u.Email, u.WorkspaceID, wsA)
+		}
+	}
+	// The role aggregate is tenant-scoped too, not just the member rows: B's
+	// uniquely-keyed role must appear nowhere in A's page.
+	for _, u := range users.Data {
+		if u.Roles == nil {
+			continue
+		}
+		for _, key := range *u.Roles {
+			if key == "other-tenant-only" {
+				t.Errorf("cross-tenant leak: %q carries workspace B's role key", u.Email)
+			}
 		}
 	}
 

--- a/backend/internal/compose/integration/users_admin_http_integration_test.go
+++ b/backend/internal/compose/integration/users_admin_http_integration_test.go
@@ -20,6 +20,10 @@ type userWire struct {
 	Email       string `json:"email"`
 	DisplayName string `json:"display_name"`
 	Status      string `json:"status"`
+	// A pointer so an absent field stays distinguishable from an empty one:
+	// absent means the caller was not admitted to the role keys, empty means
+	// the member holds none.
+	Roles *[]string `json:"roles"`
 }
 
 type userListWire struct {
@@ -40,6 +44,7 @@ func TestAdminUserManagementOverHTTP(t *testing.T) {
 	if invited.ID == "" || invited.Email != "newbie@acme.test" || invited.Status != "active" {
 		t.Fatalf("invited member = %+v, want active, lowercased email", invited)
 	}
+	assertRoles(t, "invite", invited, "rep")
 	base := "/v1/users/" + invited.ID
 
 	// A duplicate email refuses.
@@ -74,12 +79,20 @@ func TestAdminUserManagementOverHTTP(t *testing.T) {
 	if !containsUser(roster.Data, invited.ID) {
 		t.Fatalf("active roster missing the invited member %s", invited.ID)
 	}
+	// An admin's roster carries every member's role keys — the admin card reads
+	// the current role off them.
+	for _, u := range roster.Data {
+		if u.Roles == nil {
+			t.Errorf("roster member %q has no roles field; an admin caller must see it", u.Email)
+		}
+	}
 
-	// Change role.
+	// Change role. The response reports the role now held, not the one replaced.
 	var afterRole userWire
 	if status := e.call(t, "PATCH", base+"/role", map[string]any{"role": "manager"}, nil, &afterRole); status != http.StatusOK {
 		t.Fatalf("change role -> %d, want 200", status)
 	}
+	assertRoles(t, "change role", afterRole, "manager")
 
 	// Deactivate: the member drops from the active roster but is visible with include_inactive.
 	var afterOff userWire
@@ -124,6 +137,24 @@ func TestAdminUserManagementOverHTTP(t *testing.T) {
 	}
 	if status := e.call(t, "PATCH", "/v1/users/"+me.User.ID+"/role", map[string]any{"role": "rep"}, nil, nil); status != http.StatusConflict {
 		t.Fatalf("demoting the last admin -> %d, want 409", status)
+	}
+}
+
+// assertRoles checks the member response reports exactly the role keys the
+// admin surface renders a current role from.
+func assertRoles(t *testing.T, what string, got userWire, want ...string) {
+	t.Helper()
+	if got.Roles == nil {
+		t.Fatalf("%s: roles absent from an admin's response; want %v", what, want)
+	}
+	if len(*got.Roles) != len(want) {
+		t.Fatalf("%s: roles = %v, want %v", what, *got.Roles, want)
+	}
+	for i, key := range want {
+		if (*got.Roles)[i] != key {
+			t.Errorf("%s: roles = %v, want %v", what, *got.Roles, want)
+			return
+		}
 	}
 }
 

--- a/backend/internal/compose/integration/users_admin_http_integration_test.go
+++ b/backend/internal/compose/integration/users_admin_http_integration_test.go
@@ -47,12 +47,14 @@ func TestAdminUserManagementOverHTTP(t *testing.T) {
 	assertRoles(t, "invite", invited, "rep")
 	base := "/v1/users/" + invited.ID
 
-	// A duplicate email refuses.
+	// A duplicate email refuses, and says so in words.
+	var dupe refusalWire
 	if status := e.call(t, "POST", "/v1/users", map[string]any{
 		"email": "newbie@acme.test", "display_name": "Dupe", "role": "rep",
-	}, nil, nil); status != http.StatusConflict {
+	}, nil, &dupe); status != http.StatusConflict {
 		t.Fatalf("duplicate invite -> %d, want 409", status)
 	}
+	assertActionableRefusal(t, "duplicate invite", dupe)
 
 	// Malformed input is refused before any member is created.
 	if status := e.call(t, "POST", "/v1/users", map[string]any{
@@ -94,6 +96,13 @@ func TestAdminUserManagementOverHTTP(t *testing.T) {
 	}
 	assertRoles(t, "change role", afterRole, "manager")
 
+	// A role nobody defines is still a 404: the refusal wording this endpoint
+	// adds is for ONE cause, and every other error must pass through with the
+	// status it already had.
+	if status := e.call(t, "PATCH", base+"/role", map[string]any{"role": "no-such-role"}, nil, nil); status != http.StatusNotFound {
+		t.Fatalf("change role to an undefined role -> %d, want 404", status)
+	}
+
 	// Deactivate: the member drops from the active roster but is visible with include_inactive.
 	var afterOff userWire
 	if status := e.call(t, "POST", base+"/deactivate", nil, nil, &afterOff); status != http.StatusOK {
@@ -122,6 +131,17 @@ func TestAdminUserManagementOverHTTP(t *testing.T) {
 		t.Fatalf("reactivated member status = %q, want active", afterOn.Status)
 	}
 
+	// A SUSPENDED member is not merely deactivated — the hold was placed for a
+	// different reason (e.g. lockout), so reactivating would quietly clear it.
+	// The refusal has to explain that, or an admin reads it as a broken button.
+	seedInWorkspace(t, e, wsID(t, e, e.slug),
+		stmt(`UPDATE app_user SET status = 'suspended' WHERE id = $1::uuid`, invited.ID))
+	var suspended refusalWire
+	if status := e.call(t, "POST", base+"/reactivate", nil, nil, &suspended); status != http.StatusConflict {
+		t.Fatalf("reactivating a suspended member -> %d, want 409", status)
+	}
+	assertActionableRefusal(t, "reactivating a suspended member", suspended)
+
 	// The bootstrap admin is the only admin (the invited member is a rep):
 	// neither deactivating nor demoting them is allowed — it would lock the org.
 	var me struct {
@@ -132,11 +152,38 @@ func TestAdminUserManagementOverHTTP(t *testing.T) {
 	if status := e.call(t, "GET", "/v1/me", nil, nil, &me); status != http.StatusOK {
 		t.Fatalf("GET /me -> %d, want 200", status)
 	}
-	if status := e.call(t, "POST", "/v1/users/"+me.User.ID+"/deactivate", nil, nil, nil); status != http.StatusConflict {
+	var offLast, demoteLast refusalWire
+	if status := e.call(t, "POST", "/v1/users/"+me.User.ID+"/deactivate", nil, nil, &offLast); status != http.StatusConflict {
 		t.Fatalf("deactivating the last admin -> %d, want 409", status)
 	}
-	if status := e.call(t, "PATCH", "/v1/users/"+me.User.ID+"/role", map[string]any{"role": "rep"}, nil, nil); status != http.StatusConflict {
+	assertActionableRefusal(t, "deactivating the last admin", offLast)
+	if status := e.call(t, "PATCH", "/v1/users/"+me.User.ID+"/role", map[string]any{"role": "rep"}, nil, &demoteLast); status != http.StatusConflict {
 		t.Fatalf("demoting the last admin -> %d, want 409", status)
+	}
+	assertActionableRefusal(t, "demoting the last admin", demoteLast)
+}
+
+type refusalWire struct {
+	Code   string `json:"code"`
+	Detail string `json:"detail"`
+}
+
+// assertActionableRefusal holds this surface's 409s to the bar the repo sets for
+// every error: say what went wrong AND what to do. The refusals here reached the
+// operator as the bare word "conflict" — a status slug rendered as if it were a
+// message — so the check is that a detail exists, reads as a sentence, and is
+// not just the code again.
+func assertActionableRefusal(t *testing.T, what string, got refusalWire) {
+	t.Helper()
+	if got.Detail == "" {
+		t.Errorf("%s: refusal carries no detail; the operator is shown only %q", what, got.Code)
+		return
+	}
+	if strings.EqualFold(strings.TrimSpace(got.Detail), got.Code) {
+		t.Errorf("%s: detail = %q, which is just the code — it names neither the cause nor the fix", what, got.Detail)
+	}
+	if len(strings.Fields(got.Detail)) < 5 {
+		t.Errorf("%s: detail = %q is too terse to tell an admin what to do next", what, got.Detail)
 	}
 }
 

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -11270,7 +11270,7 @@ type MeResponse struct {
 		Scopes     *[]MeResponsePassportScopes `json:"scopes,omitempty"`
 	} `json:"passport,omitempty"`
 
-	// Roles Effective role keys for this principal.
+	// Roles Effective role keys for this principal, and the one authority for them — `user.roles` is deliberately left unset here rather than repeating the same fact.
 	Roles []string `json:"roles"`
 
 	// SystemOfRecord The workspace's active system-of-record mode (workspace.x_sor_mode). `native` is the
@@ -14874,7 +14874,7 @@ type User struct {
 	// IsAgent First-party Agent Runner identity vs a human seat.
 	IsAgent bool `json:"is_agent"`
 
-	// Roles This member's assigned system role keys. Present ONLY for an admin caller — the roster is readable by every authenticated member (it feeds the share/assignee pickers), and a rep has no business enumerating who holds `admin`. Normally exactly one key: `inviteUser` assigns one and `changeUserRole` replaces the whole set with one. Clients that render a single current role must still handle the empty and multi-key cases.
+	// Roles This member's assigned system role keys. Present ONLY for an admin caller — the roster is readable by every authenticated member (it feeds the share/assignee pickers), and a rep has no business enumerating who holds `admin`. Normally exactly one key: `inviteUser` assigns one and `changeUserRole` replaces the whole set with one. Clients that render a single current role must still handle the empty and multi-key cases. Deliberately absent on `MeResponse.user`, whose sibling `MeResponse.roles` is the one authority for the caller's own roles — the same fact spelled twice could disagree.
 	Roles  *[]string  `json:"roles,omitempty"`
 	Status UserStatus `json:"status"`
 

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -14872,8 +14872,11 @@ type User struct {
 	Id          openapi_types.UUID  `json:"id"`
 
 	// IsAgent First-party Agent Runner identity vs a human seat.
-	IsAgent bool       `json:"is_agent"`
-	Status  UserStatus `json:"status"`
+	IsAgent bool `json:"is_agent"`
+
+	// Roles This member's assigned system role keys. Present ONLY for an admin caller — the roster is readable by every authenticated member (it feeds the share/assignee pickers), and a rep has no business enumerating who holds `admin`. Normally exactly one key: `inviteUser` assigns one and `changeUserRole` replaces the whole set with one. Clients that render a single current role must still handle the empty and multi-key cases.
+	Roles  *[]string  `json:"roles,omitempty"`
+	Status UserStatus `json:"status"`
 
 	// Timezone IANA name.
 	Timezone    *string            `json:"timezone,omitempty"`

--- a/backend/internal/modules/identity/handlers_roster.go
+++ b/backend/internal/modules/identity/handlers_roster.go
@@ -15,14 +15,11 @@ import (
 
 // ListUsers serves one keyset page of the workspace member roster.
 func (h Handlers) ListUsers(w http.ResponseWriter, r *http.Request, params crmcontracts.ListUsersParams) {
+	actor, hasActor := identityFrom(r.Context())
+	isAdmin := hasActor && actor.hasRole(roleAdmin)
 	// The widened admin management view is honored only for an admin caller;
 	// everyone else gets the active-only roster the share/assignee pickers use.
-	includeInactive := false
-	if params.IncludeInactive != nil && *params.IncludeInactive {
-		if actor, ok := identityFrom(r.Context()); ok && actor.hasRole("admin") {
-			includeInactive = true
-		}
-	}
+	includeInactive := isAdmin && params.IncludeInactive != nil && *params.IncludeInactive
 	rows, page, err := h.svc.ListUsers(r.Context(), ListUsersInput{
 		Q:               params.Q,
 		Cursor:          params.Cursor,
@@ -33,9 +30,16 @@ func (h Handlers) ListUsers(w http.ResponseWriter, r *http.Request, params crmco
 		httperr.Write(w, r, err)
 		return
 	}
+	// Role keys ride the admin's roster only — an admin is the only caller who
+	// can change a role, and the pickers every other member reads this for have
+	// no use for who holds `admin`.
+	wire := wireUser
+	if isAdmin {
+		wire = wireUserWithRoles
+	}
 	data := make([]crmcontracts.User, 0, len(rows))
 	for _, u := range rows {
-		data = append(data, wireUser(u))
+		data = append(data, wire(u))
 	}
 	httperr.WriteJSON(w, http.StatusOK, crmcontracts.UserListResponse{Data: data, Page: pageInfo(page)})
 }
@@ -72,7 +76,9 @@ func pageInfo(p storekit.Page) crmcontracts.PageInfo {
 
 // wireUser maps a roster row to the contract User. workspace_id is
 // required on User; no credential column ever leaves the store — userRow
-// carries none, so none can leak here.
+// carries none, so none can leak here. Role keys are deliberately absent:
+// the roster answers every authenticated member, and only wireUserWithRoles
+// adds them.
 func wireUser(u userRow) crmcontracts.User {
 	created := u.CreatedAt
 	return crmcontracts.User{
@@ -84,6 +90,17 @@ func wireUser(u userRow) crmcontracts.User {
 		IsAgent:     u.IsAgent,
 		CreatedAt:   &created,
 	}
+}
+
+// wireUserWithRoles is the admin view of a member: wireUser plus the role
+// keys the admin card renders and acts on. Splitting it from wireUser makes
+// the disclosure gate structural — a caller that has not been checked for
+// admin cannot reach the roles by forgetting a flag.
+func wireUserWithRoles(u userRow) crmcontracts.User {
+	wire := wireUser(u)
+	roles := u.Roles
+	wire.Roles = &roles
+	return wire
 }
 
 // wireTeam maps a roster row to the contract Team, setting the optional

--- a/backend/internal/modules/identity/handlers_roster.go
+++ b/backend/internal/modules/identity/handlers_roster.go
@@ -25,6 +25,7 @@ func (h Handlers) ListUsers(w http.ResponseWriter, r *http.Request, params crmco
 		Cursor:          params.Cursor,
 		Limit:           params.Limit,
 		IncludeInactive: includeInactive,
+		WithRoles:       isAdmin,
 	})
 	if err != nil {
 		httperr.Write(w, r, err)

--- a/backend/internal/modules/identity/handlers_roster.go
+++ b/backend/internal/modules/identity/handlers_roster.go
@@ -30,6 +30,10 @@ func (h Handlers) ListUsers(w http.ResponseWriter, r *http.Request, params crmco
 		httperr.Write(w, r, err)
 		return
 	}
+	// Same URL, different body per caller: an admin's page carries role keys and
+	// the widened status view, a rep's carries neither. A shared cache keyed on
+	// the URL alone would serve one of them the other's answer.
+	w.Header().Set("Cache-Control", "private, no-store")
 	wire := rosterUserMapping(isAdmin)
 	data := make([]crmcontracts.User, 0, len(rows))
 	for _, u := range rows {

--- a/backend/internal/modules/identity/handlers_roster.go
+++ b/backend/internal/modules/identity/handlers_roster.go
@@ -30,13 +30,7 @@ func (h Handlers) ListUsers(w http.ResponseWriter, r *http.Request, params crmco
 		httperr.Write(w, r, err)
 		return
 	}
-	// Role keys ride the admin's roster only — an admin is the only caller who
-	// can change a role, and the pickers every other member reads this for have
-	// no use for who holds `admin`.
-	wire := wireUser
-	if isAdmin {
-		wire = wireUserWithRoles
-	}
+	wire := rosterUserMapping(isAdmin)
 	data := make([]crmcontracts.User, 0, len(rows))
 	for _, u := range rows {
 		data = append(data, wire(u))
@@ -90,6 +84,18 @@ func wireUser(u userRow) crmcontracts.User {
 		IsAgent:     u.IsAgent,
 		CreatedAt:   &created,
 	}
+}
+
+// rosterUserMapping picks the User mapping this caller may see. Role keys ride
+// the admin's roster only — an admin is the only caller who can act on a role,
+// and the share/assignee pickers every other member reads this roster for have
+// no use for who holds `admin`. Named rather than inlined so the disclosure
+// decision is one testable thing instead of a branch inside a loop.
+func rosterUserMapping(isAdmin bool) func(userRow) crmcontracts.User {
+	if isAdmin {
+		return wireUserWithRoles
+	}
+	return wireUser
 }
 
 // wireUserWithRoles is the admin view of a member: wireUser plus the role

--- a/backend/internal/modules/identity/handlers_users.go
+++ b/backend/internal/modules/identity/handlers_users.go
@@ -239,8 +239,9 @@ func (h Handlers) actor(w http.ResponseWriter, r *http.Request) (Identity, bool)
 // writeUserByID reads the member back (any status) and writes it — the shared
 // tail of every admin write, so the client always sees the resulting row. Every
 // caller is admin-only (the service methods re-check it), so the row carries
-// its role keys: a role change that answered without them would leave the
-// client rendering the role it just replaced.
+// its role keys: an admin write answers the same shape the admin roster does,
+// and a member row that dropped them here would mean the field's presence
+// tracked the endpoint rather than the caller.
 func (h Handlers) writeUserByID(w http.ResponseWriter, r *http.Request, userID ids.UserID, status int) {
 	row, err := h.svc.GetUser(r.Context(), userID)
 	if err != nil {

--- a/backend/internal/modules/identity/handlers_users.go
+++ b/backend/internal/modules/identity/handlers_users.go
@@ -66,7 +66,9 @@ func (h Handlers) InviteUser(w http.ResponseWriter, r *http.Request) {
 		Role:        string(req.Role),
 	})
 	if err != nil {
-		httperr.Write(w, r, err)
+		httperr.Write(w, r, conflictIf(err, errEmailTaken,
+			"a member with this email already exists in this organization; if they were "+
+				"deactivated, reactivate them from the roster instead of inviting again"))
 		return
 	}
 	h.sendInvite(r, email.String(), rawToken)
@@ -84,7 +86,9 @@ func (h Handlers) ChangeUserRole(w http.ResponseWriter, r *http.Request, id crmc
 		return
 	}
 	if err := h.svc.ChangeUserRole(r.Context(), actor, ids.UserID{UUID: ids.UUID(id)}, string(req.Role)); err != nil {
-		httperr.Write(w, r, err)
+		httperr.Write(w, r, conflictIf(err, errLastActiveAdmin,
+			"this member is the organization's only active administrator; give another "+
+				"member the admin role first, then change this one's"))
 		return
 	}
 	h.writeUserByID(w, r, ids.UserID{UUID: ids.UUID(id)}, http.StatusOK)
@@ -109,7 +113,9 @@ func (h Handlers) DeactivateUser(w http.ResponseWriter, r *http.Request, id crmc
 		UserID: ids.UserID{UUID: ids.UUID(id)},
 		Reason: req.Reason,
 	}); err != nil {
-		httperr.Write(w, r, err)
+		httperr.Write(w, r, conflictIf(err, errLastActiveAdmin,
+			"this member is the organization's only active administrator; deactivating them "+
+				"would leave nobody able to manage users — give another member the admin role first"))
 		return
 	}
 	h.writeUserByID(w, r, ids.UserID{UUID: ids.UUID(id)}, http.StatusOK)
@@ -122,7 +128,9 @@ func (h Handlers) ReactivateUser(w http.ResponseWriter, r *http.Request, id crmc
 		return
 	}
 	if err := h.svc.ReactivateUser(r.Context(), actor, ids.UserID{UUID: ids.UUID(id)}); err != nil {
-		httperr.Write(w, r, err)
+		httperr.Write(w, r, conflictIf(err, errNotDeactivated,
+			"this member is suspended, not deactivated; a suspension is cleared by resolving "+
+				"what caused it, and reactivating would hide that"))
 		return
 	}
 	h.writeUserByID(w, r, ids.UserID{UUID: ids.UUID(id)}, http.StatusOK)
@@ -194,6 +202,19 @@ func (h Handlers) IssueUserPasswordLink(w http.ResponseWriter, r *http.Request, 
 		SetPasswordUrl: passwordLink(h.passwordLinkBaseURL, rawToken),
 		ExpiresAt:      expiresAt,
 	})
+}
+
+// conflictIf renders cause as a 409 the operator can act on when err is that
+// cause, and returns err untouched otherwise. The service says WHICH refusal
+// happened; the handler knows which verb was attempted, so the next step is
+// worded here. Without this the whole surface answers the bare word "conflict",
+// which tells an admin neither what went wrong nor what to do — the sentinel's
+// own text is a log line, not advice.
+func conflictIf(err, cause error, detail string) error {
+	if !errors.Is(err, cause) {
+		return err
+	}
+	return &httperr.DetailedError{Status: http.StatusConflict, Code: "conflict", Detail: detail}
 }
 
 // tooManyPasswordLinksBy renders an issuance-ceiling refusal. The generic

--- a/backend/internal/modules/identity/handlers_users.go
+++ b/backend/internal/modules/identity/handlers_users.go
@@ -237,14 +237,17 @@ func (h Handlers) actor(w http.ResponseWriter, r *http.Request) (Identity, bool)
 }
 
 // writeUserByID reads the member back (any status) and writes it — the shared
-// tail of every admin write, so the client always sees the resulting row.
+// tail of every admin write, so the client always sees the resulting row. Every
+// caller is admin-only (the service methods re-check it), so the row carries
+// its role keys: a role change that answered without them would leave the
+// client rendering the role it just replaced.
 func (h Handlers) writeUserByID(w http.ResponseWriter, r *http.Request, userID ids.UserID, status int) {
 	row, err := h.svc.GetUser(r.Context(), userID)
 	if err != nil {
 		httperr.Write(w, r, err)
 		return
 	}
-	httperr.WriteJSON(w, status, wireUser(row))
+	httperr.WriteJSON(w, status, wireUserWithRoles(row))
 }
 
 // sendInvite mails the single-use set-password link when a mailer is wired.

--- a/backend/internal/modules/identity/roster.go
+++ b/backend/internal/modules/identity/roster.go
@@ -14,6 +14,7 @@ package identity
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -35,6 +36,12 @@ type ListUsersInput struct {
 	// the admin management view; the default active-only roster serves the
 	// share/assignee pickers. The server gates the widened view to admins.
 	IncludeInactive bool
+	// WithRoles reads each member's role keys. Admin-only, and the reason the
+	// read is optional at all: the pickers every other member uses this roster
+	// for never render a role, so they should not pay per row to fetch one.
+	// The wire mapping withholds the keys independently — this makes the
+	// non-admin page not even carry them out of the database.
+	WithRoles bool
 }
 
 type userRow struct {
@@ -44,9 +51,11 @@ type userRow struct {
 	DisplayName string
 	Status      string
 	IsAgent     bool
-	// Roles are the member's assigned system role keys. Read on every roster
-	// row, but only an admin's response carries them — the wire mapping is
-	// where that gate lives (see wireUserWithRoles).
+	// Roles are the member's assigned system role keys, read only when the
+	// caller asked for them (ListUsersInput.WithRoles) — otherwise empty,
+	// because the row never fetched them. The wire mapping withholds them
+	// again on its own (see wireUserWithRoles): the read decides what is paid
+	// for, the mapping decides what is disclosed.
 	Roles     []string
 	CreatedAt time.Time
 }
@@ -61,10 +70,27 @@ const roleKeys = `(SELECT COALESCE(array_agg(r.key ORDER BY r.key), '{}')
 	  FROM role_assignment ra JOIN role r ON r.id = ra.role_id
 	  WHERE ra.user_id = app_user.id)`
 
-const userColumns = `id, workspace_id, email, display_name, status, is_agent, ` + roleKeys + `, created_at`
+// noRoleKeys stands in for the aggregate on the reads that would only discard
+// it, so the scan target keeps its shape and the column list its length.
+const noRoleKeys = `'{}'::text[]`
+
+// userColumns is the roster SELECT list. wantRoles decides whether each row
+// pays for the per-row role lookup: only an admin's response carries the keys,
+// and the picker reads every other member makes would throw them away. The
+// choice is a bool decided by the handler, never request text — the WHERE
+// clauses below stay fixed and bind-parameterized, which is the invariant that
+// keeps this file free of built SQL.
+func userColumns(wantRoles bool) string {
+	if wantRoles {
+		return fmt.Sprintf(userColumnsTemplate, roleKeys)
+	}
+	return fmt.Sprintf(userColumnsTemplate, noRoleKeys)
+}
+
+const userColumnsTemplate = `id, workspace_id, email, display_name, status, is_agent, %s, created_at`
 
 const listUsersQuery = `
-	SELECT ` + userColumns + `
+	SELECT %s
 	FROM app_user
 	WHERE archived_at IS NULL AND status = 'active'
 	  AND ($1::timestamptz IS NULL OR (created_at, id) > ($1, $2))
@@ -72,7 +98,7 @@ const listUsersQuery = `
 	LIMIT $3`
 
 const listUsersFilteredQuery = `
-	SELECT ` + userColumns + `
+	SELECT %s
 	FROM app_user
 	WHERE archived_at IS NULL AND status = 'active'
 	  AND (display_name ILIKE $1 OR email ILIKE $1)
@@ -83,7 +109,7 @@ const listUsersFilteredQuery = `
 // The admin management roster: every non-archived member regardless of status,
 // so a deactivated member is visible to reactivate.
 const listUsersAllQuery = `
-	SELECT ` + userColumns + `
+	SELECT %s
 	FROM app_user
 	WHERE archived_at IS NULL
 	  AND ($1::timestamptz IS NULL OR (created_at, id) > ($1, $2))
@@ -91,7 +117,7 @@ const listUsersAllQuery = `
 	LIMIT $3`
 
 const listUsersAllFilteredQuery = `
-	SELECT ` + userColumns + `
+	SELECT %s
 	FROM app_user
 	WHERE archived_at IS NULL
 	  AND (display_name ILIKE $1 OR email ILIKE $1)
@@ -105,12 +131,14 @@ func scanUser(r pgx.Row) (userRow, error) {
 	return u, err
 }
 
-const getUserQuery = `SELECT ` + userColumns + ` FROM app_user WHERE id = $1 AND archived_at IS NULL`
+const getUserQueryTemplate = `SELECT %s FROM app_user WHERE id = $1 AND archived_at IS NULL`
 
 // GetUser reads one member by id regardless of status (RLS-scoped to the
 // caller's workspace) — the read the admin write handlers return after a
-// mutation. ErrNotFound when absent or archived.
+// mutation, every one of them admin-only, so it always carries the role keys.
+// ErrNotFound when absent or archived.
 func (s *Service) GetUser(ctx context.Context, userID ids.UserID) (userRow, error) {
+	getUserQuery := fmt.Sprintf(getUserQueryTemplate, userColumns(true))
 	var u userRow
 	err := database.WithWorkspaceTx(ctx, s.pool, func(tx pgx.Tx) error {
 		row, scanErr := scanUser(tx.QueryRow(ctx, getUserQuery, userID))
@@ -133,9 +161,10 @@ func (s *Service) ListUsers(ctx context.Context, in ListUsersInput) ([]userRow, 
 	if in.IncludeInactive {
 		plain, filtered = listUsersAllQuery, listUsersAllFilteredQuery
 	}
+	columns := userColumns(in.WithRoles)
 	return listRosterPage(ctx, s.pool, in.Q, in.Cursor, in.Limit, rosterQuery[userRow]{
-		plain:     plain,
-		filtered:  filtered,
+		plain:     fmt.Sprintf(plain, columns),
+		filtered:  fmt.Sprintf(filtered, columns),
 		scan:      scanUser,
 		cursorKey: func(u userRow) (time.Time, ids.UUID) { return u.CreatedAt, u.ID },
 	})

--- a/backend/internal/modules/identity/roster.go
+++ b/backend/internal/modules/identity/roster.go
@@ -54,7 +54,9 @@ type userRow struct {
 // roleKeys aggregates the member's assigned role keys, sorted so a member
 // holding more than one reads the same way on every request. A member with no
 // assignment yields an empty array rather than NULL, so the scan target never
-// has to distinguish "none" from "unknown".
+// has to distinguish "none" from "unknown". It correlates to the UNALIASED
+// app_user of the enclosing SELECT — every userColumns query spells it that
+// way; an alias there would silently break the correlation.
 const roleKeys = `(SELECT COALESCE(array_agg(r.key ORDER BY r.key), '{}')
 	  FROM role_assignment ra JOIN role r ON r.id = ra.role_id
 	  WHERE ra.user_id = app_user.id)`

--- a/backend/internal/modules/identity/roster.go
+++ b/backend/internal/modules/identity/roster.go
@@ -44,10 +44,22 @@ type userRow struct {
 	DisplayName string
 	Status      string
 	IsAgent     bool
-	CreatedAt   time.Time
+	// Roles are the member's assigned system role keys. Read on every roster
+	// row, but only an admin's response carries them — the wire mapping is
+	// where that gate lives (see wireUserWithRoles).
+	Roles     []string
+	CreatedAt time.Time
 }
 
-const userColumns = `id, workspace_id, email, display_name, status, is_agent, created_at`
+// roleKeys aggregates the member's assigned role keys, sorted so a member
+// holding more than one reads the same way on every request. A member with no
+// assignment yields an empty array rather than NULL, so the scan target never
+// has to distinguish "none" from "unknown".
+const roleKeys = `(SELECT COALESCE(array_agg(r.key ORDER BY r.key), '{}')
+	  FROM role_assignment ra JOIN role r ON r.id = ra.role_id
+	  WHERE ra.user_id = app_user.id)`
+
+const userColumns = `id, workspace_id, email, display_name, status, is_agent, ` + roleKeys + `, created_at`
 
 const listUsersQuery = `
 	SELECT ` + userColumns + `
@@ -87,7 +99,7 @@ const listUsersAllFilteredQuery = `
 
 func scanUser(r pgx.Row) (userRow, error) {
 	var u userRow
-	err := r.Scan(&u.ID, &u.WorkspaceID, &u.Email, &u.DisplayName, &u.Status, &u.IsAgent, &u.CreatedAt)
+	err := r.Scan(&u.ID, &u.WorkspaceID, &u.Email, &u.DisplayName, &u.Status, &u.IsAgent, &u.Roles, &u.CreatedAt)
 	return u, err
 }
 

--- a/backend/internal/modules/identity/roster_test.go
+++ b/backend/internal/modules/identity/roster_test.go
@@ -124,6 +124,27 @@ func TestWireUserWithRolesKeepsAnUnassignedSeatDistinctFromAWithheldOne(t *testi
 	}
 }
 
+// The roster serves both callers off the same rows, so which mapping the
+// caller gets IS the disclosure gate.
+func TestRosterUserMappingDisclosesRoleKeysOnlyToAnAdmin(t *testing.T) {
+	row := userRow{
+		ID:          ids.NewV7(),
+		WorkspaceID: ids.NewV7(),
+		Email:       "ada@example.com",
+		DisplayName: "Ada Admin",
+		Status:      "active",
+		Roles:       []string{"admin"},
+		CreatedAt:   time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC),
+	}
+
+	if got := rosterUserMapping(false)(row); got.Roles != nil {
+		t.Errorf("non-admin roster Roles = %v, want nil", *got.Roles)
+	}
+	if got := rosterUserMapping(true)(row); got.Roles == nil {
+		t.Error("admin roster Roles = nil, want the member's role keys")
+	}
+}
+
 func TestWireTeam(t *testing.T) {
 	id := ids.NewV7()
 	ws := ids.NewV7()

--- a/backend/internal/modules/identity/roster_test.go
+++ b/backend/internal/modules/identity/roster_test.go
@@ -59,6 +59,71 @@ func TestWireUser(t *testing.T) {
 	}
 }
 
+// The roster answers every authenticated member, so the shared mapping must
+// withhold the role keys even when the row it is given carries them — that
+// omission is the whole disclosure gate, and a row read for an admin is the
+// same row read for a rep.
+func TestWireUserWithholdsRoleKeys(t *testing.T) {
+	got := wireUser(userRow{
+		ID:          ids.NewV7(),
+		WorkspaceID: ids.NewV7(),
+		Email:       "ada@example.com",
+		DisplayName: "Ada Admin",
+		Status:      "active",
+		Roles:       []string{"admin"},
+		CreatedAt:   time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC),
+	})
+
+	if got.Roles != nil {
+		t.Errorf("Roles = %v, want nil — a non-admin roster must not disclose who holds a role", *got.Roles)
+	}
+}
+
+func TestWireUserWithRolesCarriesTheRoleKeys(t *testing.T) {
+	row := userRow{
+		ID:          ids.NewV7(),
+		WorkspaceID: ids.NewV7(),
+		Email:       "ada@example.com",
+		DisplayName: "Ada Admin",
+		Status:      "active",
+		Roles:       []string{"admin"},
+		CreatedAt:   time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC),
+	}
+	got := wireUserWithRoles(row)
+
+	if got.Roles == nil {
+		t.Fatal("Roles = nil, want the member's role keys — the admin card renders the current role from them")
+	}
+	if len(*got.Roles) != 1 || (*got.Roles)[0] != "admin" {
+		t.Errorf("Roles = %v, want [admin]", *got.Roles)
+	}
+	// Everything else is the shared mapping; only the role keys are added.
+	if got.DisplayName != row.DisplayName || string(got.Status) != row.Status {
+		t.Errorf("got %q/%q, want %q/%q", got.DisplayName, got.Status, row.DisplayName, row.Status)
+	}
+}
+
+// An unassigned seat has no role, and the admin card distinguishes that from
+// "not disclosed" — so it must arrive as an empty list, never as an absent one.
+func TestWireUserWithRolesKeepsAnUnassignedSeatDistinctFromAWithheldOne(t *testing.T) {
+	got := wireUserWithRoles(userRow{
+		ID:          ids.NewV7(),
+		WorkspaceID: ids.NewV7(),
+		Email:       "nora@example.com",
+		DisplayName: "Nora None",
+		Status:      "active",
+		Roles:       []string{},
+		CreatedAt:   time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC),
+	})
+
+	if got.Roles == nil {
+		t.Fatal("Roles = nil, want an empty list — absent means withheld, not unassigned")
+	}
+	if len(*got.Roles) != 0 {
+		t.Errorf("Roles = %v, want empty", *got.Roles)
+	}
+}
+
 func TestWireTeam(t *testing.T) {
 	id := ids.NewV7()
 	ws := ids.NewV7()

--- a/backend/internal/modules/identity/users.go
+++ b/backend/internal/modules/identity/users.go
@@ -13,6 +13,7 @@ package identity
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
@@ -33,6 +34,19 @@ const (
 	userStatusDeactivated = "deactivated"
 	userAuditKeyStatus    = "status"
 	roleAdmin             = "admin"
+)
+
+// The three distinct refusals this surface can answer with. Each WRAPS
+// apperrors.ErrConflict, so every caller that only asks "was this a conflict?"
+// is unaffected, while a handler can tell them apart and say which one it was:
+// the bare sentinel reaches the operator as the single word "conflict", which
+// names neither what happened nor what to do about it. The advice differs per
+// verb (deactivating vs demoting the last admin), so the handler supplies the
+// wording and these carry only the cause.
+var (
+	errEmailTaken      = fmt.Errorf("%w: a member with this email already exists", apperrors.ErrConflict)
+	errNotDeactivated  = fmt.Errorf("%w: the member is not deactivated", apperrors.ErrConflict)
+	errLastActiveAdmin = fmt.Errorf("%w: the member is the only active administrator", apperrors.ErrConflict)
 )
 
 // InviteUserInput carries the admin-supplied details for a new member. No
@@ -77,7 +91,7 @@ func (s *Service) InviteUser(ctx context.Context, actor Identity, in InviteUserI
 			wsID, in.Email, in.DisplayName).Scan(&newUserID)
 		var pgErr *pgconn.PgError
 		if errors.As(insErr, &pgErr) && pgErr.Code == "23505" {
-			return apperrors.ErrConflict
+			return errEmailTaken
 		}
 		if insErr != nil {
 			return insErr
@@ -142,7 +156,7 @@ func (s *Service) ReactivateUser(ctx context.Context, actor Identity, userID ids
 		// is held for a different reason (e.g. lockout) and must not be silently
 		// cleared by this path.
 		if status != userStatusDeactivated {
-			return apperrors.ErrConflict
+			return errNotDeactivated
 		}
 		if _, err := tx.Exec(ctx,
 			`UPDATE app_user SET status = 'active' WHERE id = $1`, userID); err != nil {
@@ -269,7 +283,7 @@ func (s *Service) DeactivateUser(ctx context.Context, actor Identity, in Deactiv
 			return err
 		}
 		if lastAdmin {
-			return apperrors.ErrConflict
+			return errLastActiveAdmin
 		}
 		if _, err := tx.Exec(ctx,
 			`UPDATE app_user SET status = 'deactivated' WHERE id = $1`, in.UserID); err != nil {
@@ -408,7 +422,7 @@ func (s *Service) ChangeUserRole(ctx context.Context, actor Identity, userID ids
 				return err
 			}
 			if lastAdmin {
-				return apperrors.ErrConflict
+				return errLastActiveAdmin
 			}
 		}
 

--- a/backend/internal/modules/identity/users_admin_integration_test.go
+++ b/backend/internal/modules/identity/users_admin_integration_test.go
@@ -44,6 +44,12 @@ func TestInviteUserCreatesActiveMemberWithRoleTokenAndEvent(t *testing.T) {
 	if member.Status != "active" || member.Email != "newbie@acme.test" {
 		t.Fatalf("invited member = %+v; want active + lowercased email", member)
 	}
+	// The member read carries the assigned role keys — the admin card renders
+	// the current role from them, so the aggregate must survive the round trip
+	// and not merely be correct in the assignment table.
+	if len(member.Roles) != 1 || member.Roles[0] != "rep" {
+		t.Errorf("invited member Roles = %v, want [rep]", member.Roles)
+	}
 
 	var role string
 	if err := e.owner.QueryRow(context.Background(),

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -3893,7 +3893,8 @@ export interface paths {
          * List workspace members (roster) — cursor-paginated. Read-only.
          * @description The workspace member roster: id + display name + email + seat/status. Any authenticated member
          *     may read it (needed to pick a record-share subject and to resolve subject/granter names). Excludes
-         *     archived users. Row-scoped by workspace RLS.
+         *     archived users. Row-scoped by workspace RLS. `User.roles` rides the row only for an admin caller,
+         *     who is the only one who can act on it.
          */
         get: operations["listUsers"];
         put?: never;
@@ -9409,6 +9410,8 @@ export interface components {
              * @default false
              */
             is_agent: boolean;
+            /** @description This member's assigned system role keys. Present ONLY for an admin caller — the roster is readable by every authenticated member (it feeds the share/assignee pickers), and a rep has no business enumerating who holds `admin`. Normally exactly one key: `inviteUser` assigns one and `changeUserRole` replaces the whole set with one. Clients that render a single current role must still handle the empty and multi-key cases. */
+            roles?: string[];
             /** Format: date-time */
             created_at?: string;
             /** Format: date-time */

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -9410,7 +9410,7 @@ export interface components {
              * @default false
              */
             is_agent: boolean;
-            /** @description This member's assigned system role keys. Present ONLY for an admin caller — the roster is readable by every authenticated member (it feeds the share/assignee pickers), and a rep has no business enumerating who holds `admin`. Normally exactly one key: `inviteUser` assigns one and `changeUserRole` replaces the whole set with one. Clients that render a single current role must still handle the empty and multi-key cases. */
+            /** @description This member's assigned system role keys. Present ONLY for an admin caller — the roster is readable by every authenticated member (it feeds the share/assignee pickers), and a rep has no business enumerating who holds `admin`. Normally exactly one key: `inviteUser` assigns one and `changeUserRole` replaces the whole set with one. Clients that render a single current role must still handle the empty and multi-key cases. Deliberately absent on `MeResponse.user`, whose sibling `MeResponse.roles` is the one authority for the caller's own roles — the same fact spelled twice could disagree. */
             roles?: string[];
             /** Format: date-time */
             created_at?: string;
@@ -9547,7 +9547,7 @@ export interface components {
             non_production: boolean;
             /** @description Whether THIS CALLER may issue member set-password links (`issueUserPasswordLink`) — true only when the caller holds `admin` AND the installation has no outbound-email channel AND a public base URL is configured. Deliberately a caller capability rather than a deployment-posture flag: `/me` answers every authenticated member, and a bare posture boolean would tell every rep whether the installation has email configured. Clients render the action on this, so an admin never sees a control that can only fail (ADR-0061 Amendment 1). */
             admin_password_link: boolean;
-            /** @description Effective role keys for this principal. */
+            /** @description Effective role keys for this principal, and the one authority for them — `user.roles` is deliberately left unset here rather than repeating the same fact. */
             roles: string[];
             teams: string[];
             /**

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -3112,6 +3112,7 @@ export const de = {
   "users.invite": "Einladen",
   "users.setRole": "Rolle setzen…",
   "users.setRoleFor": "Rolle für {name} setzen",
+  "users.rolesHeld": "Hat {roles} — eine auszuwählen ersetzt alle",
   "users.deactivate": "Deaktivieren",
   "users.reactivate": "Reaktivieren",
   "users.status.active": "Aktiv",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -3112,7 +3112,7 @@ export const de = {
   "users.invite": "Einladen",
   "users.setRole": "Rolle setzen…",
   "users.setRoleFor": "Rolle für {name} setzen",
-  "users.rolesHeld": "Hat {roles} — eine auszuwählen ersetzt alle",
+  "users.rolesHeld": "Hat {roles}. Eine auszuwählen ersetzt alle",
   "users.deactivate": "Deaktivieren",
   "users.reactivate": "Reaktivieren",
   "users.status.active": "Aktiv",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -3075,6 +3075,7 @@ export const en = {
   "users.invite": "Invite",
   "users.setRole": "Set role…",
   "users.setRoleFor": "Set role for {name}",
+  "users.rolesHeld": "Holds {roles} — choosing one replaces them all",
   "users.deactivate": "Deactivate",
   "users.reactivate": "Reactivate",
   "users.status.active": "Active",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -3075,7 +3075,7 @@ export const en = {
   "users.invite": "Invite",
   "users.setRole": "Set role…",
   "users.setRoleFor": "Set role for {name}",
-  "users.rolesHeld": "Holds {roles} — choosing one replaces them all",
+  "users.rolesHeld": "Holds {roles}. Choosing one replaces them all",
   "users.deactivate": "Deactivate",
   "users.reactivate": "Reactivate",
   "users.status.active": "Active",

--- a/frontend/src/screens/users-admin.test.tsx
+++ b/frontend/src/screens/users-admin.test.tsx
@@ -304,18 +304,116 @@ describe("UsersAdminCard", () => {
     render(<UsersAdminCard />);
     await waitFor(() => expect(screen.getByText("Ada Active")).toBeTruthy());
 
-    const active = screen.getByText("Ada Active").closest("li") as HTMLElement;
-    await userEvent.selectOptions(
-      within(active).getByLabelText(/set role for ada active/i),
-      "rep",
-    );
+    const active = rowFor("Ada Active");
+    await userEvent.selectOptions(roleSelect(active, "ada active"), "rep");
 
     await waitFor(() => expect(within(active).getByRole("alert")).toBeTruthy());
     expect(screen.getByText(/leave no admin/i)).toBeTruthy();
     // The refused change left the role untouched, so the select must read the
     // role the member still holds — anything else would claim a change the
-    // server rejected, and would make re-picking "rep" a silent no-op.
+    // server rejected.
     expect(roleSelect(active, "ada active").value).toBe("admin");
+  });
+
+  // The whole reason the select returns to the held role after a refusal: a
+  // select left showing the refused target would make re-picking it a no-op,
+  // and the operator's retry would silently never reach the server.
+  it("lets the same role be re-picked after a refusal", async () => {
+    const patches: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const req =
+          input instanceof Request ? input : new Request(String(input), init);
+        if (req.url.endsWith("/v1/me")) {
+          return jsonResponse({
+            user: { email: "admin@acme.test" },
+            roles: ["admin"],
+            teams: [],
+          });
+        }
+        if (req.url.includes("/users") && req.method === "GET") {
+          return jsonResponse(ROSTER);
+        }
+        patches.push(req.url);
+        return jsonResponse({ title: "Conflict", detail: "Try again." }, 409);
+      }),
+    );
+    render(<UsersAdminCard />);
+    await waitFor(() => expect(screen.getByText("Ada Active")).toBeTruthy());
+
+    const active = rowFor("Ada Active");
+    await userEvent.selectOptions(roleSelect(active, "ada active"), "rep");
+    await waitFor(() => expect(patches).toHaveLength(1));
+
+    // The SAME target again — the retry the operator would make.
+    await userEvent.selectOptions(roleSelect(active, "ada active"), "rep");
+    await waitFor(() => expect(patches).toHaveLength(2));
+  });
+
+  // A settled mutation whose roster refetch is still outstanding would render
+  // the member's replaced role from the stale cache — the operator would watch
+  // their change appear and then undo itself.
+  it("stays pending until the refreshed roster lands", async () => {
+    let rosterReads = 0;
+    // Built up front rather than captured lazily: the refetch has to be held
+    // open from the moment it starts, and a deferred that only exists once the
+    // request arrives would race the assertions below.
+    let releaseRoster = () => {};
+    const rosterHeld = new Promise<void>((resolve) => {
+      releaseRoster = resolve;
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const req =
+          input instanceof Request ? input : new Request(String(input), init);
+        if (req.url.endsWith("/v1/me")) {
+          return jsonResponse({
+            user: { email: "admin@acme.test" },
+            roles: ["admin"],
+            teams: [],
+          });
+        }
+        if (req.url.includes("/users") && req.method === "GET") {
+          rosterReads += 1;
+          if (rosterReads === 1) {
+            return jsonResponse(ROSTER);
+          }
+          // Hold the refetch open so the window between "mutation done" and
+          // "new roster in hand" is observable rather than a race.
+          await rosterHeld;
+          return jsonResponse({
+            ...ROSTER,
+            data: ROSTER.data.map((u) =>
+              u.id === "u-active" ? { ...u, roles: ["manager"] } : u,
+            ),
+          });
+        }
+        return jsonResponse({}, 200);
+      }),
+    );
+    render(<UsersAdminCard />);
+    await waitFor(() => expect(screen.getByText("Ada Active")).toBeTruthy());
+
+    const active = rowFor("Ada Active");
+    await userEvent.selectOptions(roleSelect(active, "ada active"), "manager");
+    await waitFor(() => expect(rosterReads).toBe(2));
+
+    // Mid-flight: the row reads the role being applied and stays locked. "admin"
+    // here would be the stale cache showing through.
+    expect(roleSelect(active, "ada active").value).toBe("manager");
+    expect(roleSelect(active, "ada active").disabled).toBe(true);
+
+    releaseRoster();
+    await waitFor(() =>
+      expect(roleSelect(rowFor("Ada Active"), "ada active").disabled).toBe(
+        false,
+      ),
+    );
+    expect(roleSelect(rowFor("Ada Active"), "ada active").value).toBe(
+      "manager",
+    );
   });
 
   it("surfaces a failed invite as an inline error", async () => {

--- a/frontend/src/screens/users-admin.test.tsx
+++ b/frontend/src/screens/users-admin.test.tsx
@@ -60,18 +60,26 @@ const ROSTER = {
   page: { next_cursor: null, has_more: false },
 };
 
+// Both helpers narrow by instance rather than asserting: a cast would let the
+// suite read `.value` off whatever the query happened to return, so a control
+// that stopped being a select would surface as a confusing undefined instead of
+// a named failure.
 function roleSelect(row: HTMLElement, name: string) {
-  return within(row).getByLabelText(
+  const control = within(row).getByLabelText(
     new RegExp(`set role for ${name}`, "i"),
-  ) as HTMLSelectElement;
+  );
+  if (!(control instanceof HTMLSelectElement)) {
+    throw new Error(`the role control for ${name} is not a select`);
+  }
+  return control;
 }
 
 function rowFor(name: string) {
   const row = screen.getByText(name).closest("li");
-  if (!row) {
+  if (!(row instanceof HTMLElement)) {
     throw new Error(`no member row rendered for ${name}`);
   }
-  return row as HTMLElement;
+  return row;
 }
 
 function backend(calls: { method: string; url: string; body?: unknown }[]) {
@@ -234,6 +242,44 @@ describe("UsersAdminCard", () => {
         "Set role…",
       ),
     ).toBeNull();
+  });
+
+  // Any choice replaces the whole set, so a member holding several roles must
+  // not read as a blank "Set role…" — that would let an admin strip privileges
+  // they were never shown.
+  it("names the roles a multi-role member holds", async () => {
+    const twoRoles = {
+      ...ROSTER,
+      data: ROSTER.data.map((u) =>
+        u.id === "u-none" ? { ...u, roles: ["manager", "ops"] } : u,
+      ),
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const req =
+          input instanceof Request ? input : new Request(String(input), init);
+        if (req.url.endsWith("/v1/me")) {
+          return jsonResponse({
+            user: { email: "admin@acme.test" },
+            roles: ["admin"],
+            teams: [],
+          });
+        }
+        return jsonResponse(twoRoles);
+      }),
+    );
+    render(<UsersAdminCard />);
+    await waitFor(() => expect(screen.getByText("Nora None")).toBeTruthy());
+
+    const select = roleSelect(rowFor("Nora None"), "nora none");
+    expect(select.value).toBe("");
+    // Both held roles are named, under their display labels, and the copy says
+    // what picking one does.
+    const shown = within(select).getByText(/holds/i).textContent ?? "";
+    expect(shown).toContain("Manager");
+    expect(shown).toContain("Ops");
+    expect(shown).toMatch(/replaces them all/i);
   });
 
   it("sets a member's role through the role seam", async () => {

--- a/frontend/src/screens/users-admin.test.tsx
+++ b/frontend/src/screens/users-admin.test.tsx
@@ -24,6 +24,9 @@ function jsonResponse(body: unknown, status = 200) {
   });
 }
 
+// `roles` rides the roster only for an admin caller, which this card always is.
+// Nora holds none — an unassigned seat is reachable and has no current role to
+// show.
 const ROSTER = {
   data: [
     {
@@ -33,6 +36,7 @@ const ROSTER = {
       display_name: "Ada Active",
       status: "active",
       is_agent: false,
+      roles: ["admin"],
     },
     {
       id: "u-off",
@@ -41,10 +45,34 @@ const ROSTER = {
       display_name: "Otto Off",
       status: "deactivated",
       is_agent: false,
+      roles: ["read_only"],
+    },
+    {
+      id: "u-none",
+      workspace_id: "ws-1",
+      email: "nora@acme.test",
+      display_name: "Nora None",
+      status: "active",
+      is_agent: false,
+      roles: [],
     },
   ],
   page: { next_cursor: null, has_more: false },
 };
+
+function roleSelect(row: HTMLElement, name: string) {
+  return within(row).getByLabelText(
+    new RegExp(`set role for ${name}`, "i"),
+  ) as HTMLSelectElement;
+}
+
+function rowFor(name: string) {
+  const row = screen.getByText(name).closest("li");
+  if (!row) {
+    throw new Error(`no member row rendered for ${name}`);
+  }
+  return row as HTMLElement;
+}
 
 function backend(calls: { method: string; url: string; body?: unknown }[]) {
   // openapi-fetch calls fetch(request) with a Request object, so read the
@@ -182,6 +210,32 @@ describe("UsersAdminCard", () => {
     );
   });
 
+  it("reads back each member's current role", async () => {
+    vi.stubGlobal("fetch", backend([]));
+    render(<UsersAdminCard />);
+    await waitFor(() => expect(screen.getByText("Ada Active")).toBeTruthy());
+
+    expect(roleSelect(rowFor("Ada Active"), "ada active").value).toBe("admin");
+    expect(roleSelect(rowFor("Otto Off"), "otto off").value).toBe("read_only");
+  });
+
+  it("offers the placeholder to a member holding no role", async () => {
+    vi.stubGlobal("fetch", backend([]));
+    render(<UsersAdminCard />);
+    await waitFor(() => expect(screen.getByText("Nora None")).toBeTruthy());
+
+    const select = roleSelect(rowFor("Nora None"), "nora none");
+    expect(select.value).toBe("");
+    expect(within(select).getByText("Set role…")).toBeTruthy();
+    // A member who already has a role gets no such option: it would be
+    // selectable and do nothing.
+    expect(
+      within(roleSelect(rowFor("Ada Active"), "ada active")).queryByText(
+        "Set role…",
+      ),
+    ).toBeNull();
+  });
+
   it("sets a member's role through the role seam", async () => {
     const calls: { method: string; url: string; body?: unknown }[] = [];
     vi.stubGlobal("fetch", backend(calls));
@@ -258,6 +312,10 @@ describe("UsersAdminCard", () => {
 
     await waitFor(() => expect(within(active).getByRole("alert")).toBeTruthy());
     expect(screen.getByText(/leave no admin/i)).toBeTruthy();
+    // The refused change left the role untouched, so the select must read the
+    // role the member still holds — anything else would claim a change the
+    // server rejected, and would make re-picking "rep" a silent no-op.
+    expect(roleSelect(active, "ada active").value).toBe("admin");
   });
 
   it("surfaces a failed invite as an inline error", async () => {

--- a/frontend/src/screens/users-admin.tsx
+++ b/frontend/src/screens/users-admin.tsx
@@ -269,6 +269,21 @@ function MemberRow({
   const pending =
     setRole.isPending || deactivate.isPending || reactivate.isPending;
 
+  // The role the select reads back. `roles` arrives only for an admin caller —
+  // which this card always is — and normally holds exactly one key. No key (an
+  // unassigned seat) and several keys both leave the select on its placeholder:
+  // neither has a single current role to show, and picking one collapses the
+  // set to that one either way.
+  const currentRole =
+    member.roles?.length === 1 && isOption(member.roles[0], ROLES)
+      ? member.roles[0]
+      : "";
+  // While a change is in flight the select shows the role being applied, so the
+  // row never snaps back to the old one under the operator. A FAILED change
+  // leaves it on the current role, which is what keeps a retry live: re-picking
+  // the same target still fires onChange.
+  const inFlightRole = setRole.isPending ? setRole.variables : undefined;
+
   return (
     <li className="users-row">
       <span className="users-who">
@@ -278,11 +293,9 @@ function MemberRow({
       <Badge tone={member.status === "active" ? "success" : "warn"}>
         {t(`users.status.${member.status}`)}
       </Badge>
-      {/* Controlled at "" so the label always resets — re-selecting the same
-          role after a failed change still fires onChange. */}
       <Select
         aria-label={t("users.setRoleFor", { name: member.display_name })}
-        value=""
+        value={inFlightRole ?? currentRole}
         disabled={pending}
         onChange={(e) => {
           const value = e.target.value;
@@ -291,7 +304,9 @@ function MemberRow({
           }
         }}
       >
-        <option value="">{t("users.setRole")}</option>
+        {/* Offered only when there is no single role to show — otherwise it
+            would be a selectable option that does nothing. */}
+        {currentRole === "" && <option value="">{t("users.setRole")}</option>}
         {ROLES.map((r) => (
           <option key={r} value={r}>
             {t(`users.role.${r}`)}

--- a/frontend/src/screens/users-admin.tsx
+++ b/frontend/src/screens/users-admin.tsx
@@ -217,9 +217,14 @@ function MemberRow({
     setLinkOpen(true);
     void passwordLink.mint(member.id);
   };
+  // Returns the refetch so each onSuccess can hand it back to react-query,
+  // which then keeps the mutation pending until the new roster lands. Without
+  // that the mutation settles first and the row renders the pre-change roster
+  // it still has cached — the member's OLD role, briefly, right after a
+  // successful change.
   const refresh = () => {
     setError(null);
-    qc.invalidateQueries({ queryKey: ["users-admin"] });
+    return qc.invalidateQueries({ queryKey: ["users-admin"] });
   };
   const onError = (e: Error) => setError(e.message);
 
@@ -248,7 +253,7 @@ function MemberRow({
     },
     onSuccess: () => {
       setConfirmOff(false);
-      refresh();
+      return refresh();
     },
     onError,
   });
@@ -278,10 +283,11 @@ function MemberRow({
     member.roles?.length === 1 && isOption(member.roles[0], ROLES)
       ? member.roles[0]
       : "";
-  // While a change is in flight the select shows the role being applied, so the
-  // row never snaps back to the old one under the operator. A FAILED change
-  // leaves it on the current role, which is what keeps a retry live: re-picking
-  // the same target still fires onChange.
+  // While a change is in flight the select shows the role being applied — and
+  // it stays in flight until the refreshed roster lands (see refresh), so the
+  // row never renders the replaced role. A FAILED change leaves the select on
+  // the role still held, which is what keeps a retry live: re-picking the same
+  // target still fires onChange.
   const inFlightRole = setRole.isPending ? setRole.variables : undefined;
 
   return (

--- a/frontend/src/screens/users-admin.tsx
+++ b/frontend/src/screens/users-admin.tsx
@@ -23,6 +23,12 @@ type Role = components["schemas"]["ChangeUserRoleRequest"]["role"];
 
 const ROLES: readonly Role[] = ["admin", "manager", "rep", "read_only", "ops"];
 
+// roleLabel names a held role key. The catalog covers the five system roles;
+// a workspace-defined key has no translation, so it reads as itself rather
+// than as a missing-translation marker — the admin still learns what is held.
+const roleLabel = (t: ReturnType<typeof useT>) => (key: string) =>
+  isOption(key, ROLES) ? t(`users.role.${key}`) : key;
+
 // Admin member management (org settings). Every user-management write is
 // admin-only server-side, so the whole card is admin-only here — an ops seat in
 // the Organization group would otherwise see controls that only 403. The roster
@@ -276,13 +282,18 @@ function MemberRow({
 
   // The role the select reads back. `roles` arrives only for an admin caller —
   // which this card always is — and normally holds exactly one key. No key (an
-  // unassigned seat) and several keys both leave the select on its placeholder:
-  // neither has a single current role to show, and picking one collapses the
-  // set to that one either way.
+  // unassigned seat) and several keys both leave the select on its placeholder,
+  // because neither has one current role to show.
+  const heldRoles = member.roles ?? [];
   const currentRole =
-    member.roles?.length === 1 && isOption(member.roles[0], ROLES)
-      ? member.roles[0]
-      : "";
+    heldRoles.length === 1 && isOption(heldRoles[0], ROLES) ? heldRoles[0] : "";
+  // A member holding SEVERAL roles is the case worth naming: any choice here
+  // replaces the whole set, so a neutral "Set role…" would let an admin strip
+  // privileges they never saw. The placeholder says what is held instead.
+  const placeholder =
+    heldRoles.length > 1
+      ? t("users.rolesHeld", { roles: heldRoles.map(roleLabel(t)).join(", ") })
+      : t("users.setRole");
   // While a change is in flight the select shows the role being applied — and
   // it stays in flight until the refreshed roster lands (see refresh), so the
   // row never renders the replaced role. A FAILED change leaves the select on
@@ -312,7 +323,7 @@ function MemberRow({
       >
         {/* Offered only when there is no single role to show — otherwise it
             would be a selectable option that does nothing. */}
-        {currentRole === "" && <option value="">{t("users.setRole")}</option>}
+        {currentRole === "" && <option value="">{placeholder}</option>}
         {ROLES.map((r) => (
           <option key={r} value={r}>
             {t(`users.role.${r}`)}


### PR DESCRIPTION
## Why

The **Users & roles** settings card could set a member's role but never show one. Every row's dropdown read `Set role…`, so an admin acted on state the UI refused to display — and after a change, the row went straight back to the placeholder, giving no confirmation that anything had happened.

That was not a frontend gap: `GET /users` returned a `User` with no role on it at all, in this repo's `crm.yaml` and in the spec's. `/me` carried `roles`, but only for yourself.

## What changed

**Contract.** `User` gains an optional `roles` array, populated **only for an admin caller**. The roster is readable by every authenticated member — it feeds the share and assignee pickers — so a rep enumerating who holds `admin` would have been a new disclosure, not a rendering detail. `MeResponse.roles` is declared the one authority for the caller's own roles, so the same fact is never spelled twice.

**Backend.** The roster read aggregates each member's role keys. The disclosure gate is structural rather than a flag: `wireUser` withholds the keys, `wireUserWithRoles` adds them, and `rosterUserMapping(isAdmin)` picks between them — a path that has not been checked for admin has nothing to leak. The response is now `Cache-Control: private, no-store`, because one URL answers admin and rep with different bodies.

**Frontend.** The row's `Select` is controlled on the member's current role. A member holding no role, or more than one, keeps the placeholder — neither has a single current role to show.

**Two bugs found during review and fixed here:**

1. `refresh` fired the roster refetch without returning the promise, so the mutation settled first and the row briefly re-rendered the member's **old** role right after a successful change. Returning the invalidation keeps the mutation pending across the refetch.
2. Every refusal on this surface reached the operator as the single word **`conflict`** — the status slug rendered as if it were a message. UAT confirmed it verbatim. Four refusals now say what happened and what to do next: duplicate-email invite, last-admin deactivation, last-admin demotion, and reactivating a suspended member.

## Verification

**Local gates, all green on the final tree:** `make check`, `make craft-static` (0 blocker / 0 major / 0 minor across `backend/`, `extensions/`, `fixtures/`), `make test-integration` (1784 tests, **0 skips**).

**New-code coverage — 95%** on Go (38/40 new executable lines), measured from the merged integration+unit profile the way CI feeds SonarCloud; **94.8%** statements on `users-admin.tsx`. The 2 uncovered Go lines are `conflictIf`'s pass-through, itself asserted by the new "an undefined role is still a 404" case.

**Both behavioural fixes are mutation-tested** — the code each test defends was deliberately broken and the test was watched to fail:

| Mutation | Test that caught it |
|---|---|
| drop the `return` in `refresh` | `stays pending until the refreshed roster lands` |
| force `rosterUserMapping(true)` | `TestRosterWithholdsRoleKeysFromANonAdmin` — `rep sees "ada@example.com" roles = [admin]` |

**Adversarial security review** found no exploitable defect. It verified that a passport/agent principal never binds an `Identity` (so `isAdmin` is false and the keys are withheld), that all four `writeUserByID` callers genuinely re-check admin, and that the correlated subselect is RLS-scoped and disturbs neither the bind numbering nor the keyset cursor. Its one hardening note — the missing cache directive — is applied above.

### UAT (run against the live stack)

| # | Scenario | Result |
|---|---|---|
| 1 | Each row's dropdown reads back the member's actual current role | **PASS** |
| 2 | Rep → Manager round-trips, no flicker, survives reload | **PASS** |
| 3 | Demoting the only admin is refused; dropdown snaps back to Admin; a second attempt genuinely re-fires (409 captured on a cleared network log, so it is provably the retry) | **PASS** |
| 4 | All roles restored; roster left exactly as found | **PASS** |

## Known issues, not fixed here

- **The refusal is styled as ordinary body text** — small grey copy, no error colour or icon, sitting below the row's buttons rather than beside the control that failed. Easy to miss.
- **A refusal is sticky across re-navigation** — it clears only on a genuine remount, so a stale error can hang under a row that is now in a valid state.
- **A retry gives no in-flight feedback** — the error text is already present and simply stays, so a real retry and a no-op look identical from the user's seat.
- **`TestPersonStrengthHTTPReconciles` / `TestAC_TG_4_RedeliveryYieldsExactlyOneActivity`** each stalled once right after `POST /v1/auth/login` and took the whole `compose/integration` package past its 5m ceiling; green on re-run. Unrelated to this diff (the first occurrence predates every test added here).
- Three frontend tests in files this PR does not touch (`company-context`, `onboarding`, `company-act`) each failed once across earlier runs and passed in isolation; the branch has since gone green on two consecutive full `make check` runs and three `make check-fe` runs. Flagged rather than dismissed — I could not reproduce them on demand.

## Spec

The matching `User.roles` change is applied to `margince-foundation`'s `specs/contract/crm.yaml` but is **uncommitted** — that repo sits on an unrelated branch, so landing it is a separate call.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show each member’s current role in the admin Users & roles roster, with role visibility gated to admins. Also adds clear, actionable error messages, fixes a brief post-change flicker, and names multi‑role holdings in the UI, while avoiding unnecessary role lookups for non-admin reads.

- **New Features**
  - Contract: `User.roles` (array) is returned only for admin callers; `MeResponse.roles` remains the source of truth for your own roles.
  - Backend: Optional role aggregation via `WithRoles`; admin-only disclosure through a named `rosterUserMapping`; admin-only widened view; admin write responses read back the member with roles; `/v1/users` now sets `Cache-Control: private, no-store`.
  - Frontend: Role select shows the current role; shows a placeholder when no or multiple roles; multi‑role placeholder lists held roles and notes that choosing one replaces all; shows the in‑flight role and disables the select until the refreshed roster arrives; unknown role keys display as their raw key.
  - Tests: Prove the role aggregate is tenant‑scoped and that non‑admins never see role keys; HTTP tests assert roles appear on admin responses and stay hidden for reps.

- **Bug Fixes**
  - Resolved mutation/refetch timing so the UI doesn’t flicker back to the old role; mutations stay pending until the roster refetch completes.
  - Replaced bare “conflict” with actionable refusals for duplicate invite, last‑admin deactivation, last‑admin demotion, and reactivating a suspended member.

<sup>Written for commit 1a03b5c019f097fd002902409ce75ca2601a9b02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/517?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

