### PR TITLE
The workspace row's settings return to first boot too

### DIFF
--- a/backend/internal/compose/datareset.go
+++ b/backend/internal/compose/datareset.go
@@ -16,6 +16,7 @@ import (
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
+	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/modules/overlay"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/blobstore"
@@ -240,6 +241,24 @@ func (h dataResetHandlers) sweepAndReseed(ctx context.Context, wsID ids.UUID, co
 			return err
 		}
 		counts.SorModeReverted = reverted
+
+		// And every OTHER setting on that same row, back to the default a fresh
+		// bootstrap leaves. The overlay flip above is not the general case, it
+		// is the reported one: the sweep is derived from the tables carrying a
+		// workspace_id column and workspace keys on id, so NO workspace-level
+		// setting is in its target set — capture_auto_enrich (CAP-PARAM-7)
+		// outlived every reset before this call, and so would the next setting
+		// added to the row.
+		//
+		// identity owns that row and derives its own column list the same way,
+		// so nothing here has to be kept in step with the schema. It runs AFTER
+		// the flip, and restores those two columns again as part of its sweep,
+		// because whether the installation WAS in overlay mode is only knowable
+		// before something writes the column — a blanket restore cannot report
+		// what it changed, and that fact belongs in the audit row.
+		if err := identity.ResetWorkspaceConfig(ctx, tx); err != nil {
+			return err
+		}
 
 		// Re-seed under a system principal + a fresh correlation id, exactly as
 		// bootstrap does (identity/installation.go), so the seeders' own

--- a/backend/internal/compose/datareset_integration_test.go
+++ b/backend/internal/compose/datareset_integration_test.go
@@ -376,6 +376,41 @@ func TestResetReturnsAnOverlayWorkspaceToNativeMode(t *testing.T) {
 	}
 }
 
+// TestResetRestoresWorkspaceLevelSettings is the general case behind the
+// overlay one above: the mode columns are not the only configuration living on
+// the workspace row, and the sweep reaches none of it. The sweep's target list
+// is derived from the tables carrying a workspace_id column; workspace keys on
+// id, so it is not excluded from that list, it is not a candidate for it.
+//
+// capture_auto_enrich (CAP-PARAM-7) is the second setting on the row today and
+// stands in for every one added after it: an operator who wiped the
+// installation would otherwise find yesterday's settings still applied to a
+// database with nothing in it.
+func TestResetRestoresWorkspaceLevelSettings(t *testing.T) {
+	e := integration.Setup(t)
+	ctx := e.Admin()
+	e.WsExec(t, `UPDATE workspace SET capture_auto_enrich = false WHERE id = $1`, e.WS)
+
+	h := dataResetHandlers{
+		pool:  e.Pool,
+		seeds: deployconfig.Seeds{},
+		env:   runtimeenv.Development,
+		log:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	if _, err := h.run(ctx, "Authz"); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	var autoEnrich bool
+	if err := e.Pool.QueryRow(ctx,
+		`SELECT capture_auto_enrich FROM workspace WHERE id = $1`, e.WS).Scan(&autoEnrich); err != nil {
+		t.Fatalf("reading the setting back: %v", err)
+	}
+	if !autoEnrich {
+		t.Error("capture_auto_enrich = false after a reset, want true (its declared default) — a workspace-level setting outlived the wipe")
+	}
+}
+
 // TestResetLeavesANativeWorkspaceAlone: the flip is conditional, so a native
 // installation's reset claims no mode change in its evidence.
 func TestResetLeavesANativeWorkspaceAlone(t *testing.T) {

--- a/backend/internal/modules/identity/workspaceconfig.go
+++ b/backend/internal/modules/identity/workspaceconfig.go
@@ -13,6 +13,7 @@ package identity
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -87,14 +88,20 @@ func workspaceConfigColumns(ctx context.Context, tx pgx.Tx) ([]string, error) {
 // exactly as RevertToNative sits behind Disconnect's.
 //
 // The GUC is read WITHOUT missing_ok, for the reason RevertToNative gives:
-// unset, it would resolve to NULL, match no row, and report success having
-// restored nothing.
+// with it, an unset app.workspace_id would resolve to NULL, match no row, and
+// let this report success having restored nothing. Zero rows updated is
+// refused for the other half of that: unlike RevertToNative, this statement
+// has no predicate beyond the id, so there is no reading under which it
+// legitimately matches nothing.
 func ResetWorkspaceConfig(ctx context.Context, tx pgx.Tx) error {
 	cols, err := workspaceConfigColumns(ctx, tx)
 	if err != nil {
 		return err
 	}
 	if len(cols) == 0 {
+		// A workspace row that is identity and nothing else has nothing to
+		// restore. That is not a state this schema is in, which is asserted
+		// rather than assumed — see the fitness rail's vacuity check.
 		return nil
 	}
 	assignments := make([]string, 0, len(cols))
@@ -104,9 +111,14 @@ func ResetWorkspaceConfig(ctx context.Context, tx pgx.Tx) error {
 	// One statement, never one per column: the row carries CHECK constraints
 	// spanning two columns at once (overlay's x_overlay_iff_incumbent), and a
 	// column-at-a-time restore would have to pass through the state they forbid.
-	if _, err := tx.Exec(ctx, `UPDATE workspace SET `+strings.Join(assignments, ", ")+
-		` WHERE id = current_setting('app.workspace_id')::uuid`); err != nil {
+	tag, err := tx.Exec(ctx, `UPDATE workspace SET `+strings.Join(assignments, ", ")+
+		` WHERE id = current_setting('app.workspace_id')::uuid`)
+	if err != nil {
 		return fmt.Errorf("identity: restoring the workspace's configuration columns: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return errors.New("identity: restoring the workspace's configuration columns: " +
+			"the bound app.workspace_id names no workspace row, so nothing was restored")
 	}
 	return nil
 }

--- a/backend/internal/modules/identity/workspaceconfig.go
+++ b/backend/internal/modules/identity/workspaceconfig.go
@@ -20,11 +20,19 @@ import (
 	"github.com/jackc/pgx/v5"
 )
 
-// preservedWorkspaceColumns are the workspace columns a config reset leaves
-// alone: the primary key, the four values bootstrap takes from the deployment
+// preservedWorkspaceColumns are the workspace columns the restore does not
+// assign: the primary key, the four values bootstrap takes from the deployment
 // configuration, and the row's own lifecycle timestamps. A reset wipes an
 // installation's DATA — it does not re-create the installation, so its name,
 // currency, zone and age outlive it.
+//
+// updated_at is listed for a different reason than the rest. The reset really
+// does write this row, so trg_workspace_updated moves that column, and it
+// should: it records when the row was last written, which is now. It is here
+// because assigning it would take it from the trigger, not because the write
+// is meant to be invisible — a reset that left it untouched would report the
+// row as unwritten since before the reset, which is precisely the reading that
+// exposed this bug in the first place.
 //
 // Everything NOT listed here is configuration and is restored. That direction
 // is deliberate: a column added later is restored by default rather than

--- a/backend/internal/modules/identity/workspaceconfig.go
+++ b/backend/internal/modules/identity/workspaceconfig.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package identity
+
+// The workspace row has two halves. Bootstrap writes the installation's
+// IDENTITY from the deployment configuration file — name, slug, base
+// currency, timezone (installation.go) — and every other column on the row is
+// CONFIGURATION: it arrives at the default its migration declared and is
+// changed later through a settings surface. ResetWorkspaceConfig below
+// restores the second half to those defaults. The first half is what a data
+// reset must not touch, because the installation itself survives the reset.
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// preservedWorkspaceColumns are the workspace columns a config reset leaves
+// alone: the primary key, the four values bootstrap takes from the deployment
+// configuration, and the row's own lifecycle timestamps. A reset wipes an
+// installation's DATA — it does not re-create the installation, so its name,
+// currency, zone and age outlive it.
+//
+// Everything NOT listed here is configuration and is restored. That direction
+// is deliberate: a column added later is restored by default rather than
+// silently escaping the reset, and a column that genuinely belongs to the
+// installation's identity has to be declared here to be spared.
+var preservedWorkspaceColumns = map[string]bool{
+	"id": true, "name": true, "slug": true, "base_currency": true,
+	"timezone": true, "created_at": true, "updated_at": true, "archived_at": true,
+}
+
+// workspaceConfigColumns lists the workspace columns a reset restores — every
+// column of the table that is not preserved, derived from the catalog for the
+// same reason the data reset derives its table sweep from one: a setting added
+// later (capture_auto_enrich, x_sor_mode, …) is restored automatically instead
+// of escaping a hand-kept list.
+func workspaceConfigColumns(ctx context.Context, tx pgx.Tx) ([]string, error) {
+	rows, err := tx.Query(ctx, `
+		SELECT a.attname
+		FROM pg_attribute a
+		JOIN pg_class c ON c.oid = a.attrelid
+		JOIN pg_namespace n ON n.oid = c.relnamespace
+		WHERE n.nspname = 'public'
+		  AND c.relname = 'workspace'
+		  AND c.relkind = 'r'
+		  AND a.attnum > 0 AND NOT a.attisdropped
+		ORDER BY a.attname`)
+	if err != nil {
+		return nil, fmt.Errorf("identity: listing the workspace's configuration columns: %w", err)
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		if !preservedWorkspaceColumns[name] {
+			out = append(out, name)
+		}
+	}
+	return out, rows.Err()
+}
+
+// ResetWorkspaceConfig returns the bound workspace's configuration columns to
+// their declared defaults inside the caller's transaction — the workspace-row
+// half of the non-production data reset.
+//
+// It exists because that reset's table sweep structurally cannot reach this
+// row: the sweep targets tables carrying a workspace_id column, and workspace
+// keys on id, so no workspace-level setting is in its candidate set at all.
+// Without this every such setting survived a reset that reported the
+// installation returned to first-boot state.
+//
+// `= DEFAULT` rather than values spelled here: the default belongs to the
+// migration that declared the column, and a copy in Go is a second place for
+// it to be wrong. What keeps that safe as columns are added is a fitness
+// rail, not review — see workspaceconfig_integration_test.go.
+//
+// The caller gates: this is the reset orchestration's step, already behind
+// that endpoint's non-production + human + admin + typed-confirmation chain,
+// exactly as RevertToNative sits behind Disconnect's.
+//
+// The GUC is read WITHOUT missing_ok, for the reason RevertToNative gives:
+// unset, it would resolve to NULL, match no row, and report success having
+// restored nothing.
+func ResetWorkspaceConfig(ctx context.Context, tx pgx.Tx) error {
+	cols, err := workspaceConfigColumns(ctx, tx)
+	if err != nil {
+		return err
+	}
+	if len(cols) == 0 {
+		return nil
+	}
+	assignments := make([]string, 0, len(cols))
+	for _, col := range cols {
+		assignments = append(assignments, pgx.Identifier{col}.Sanitize()+" = DEFAULT")
+	}
+	// One statement, never one per column: the row carries CHECK constraints
+	// spanning two columns at once (overlay's x_overlay_iff_incumbent), and a
+	// column-at-a-time restore would have to pass through the state they forbid.
+	if _, err := tx.Exec(ctx, `UPDATE workspace SET `+strings.Join(assignments, ", ")+
+		` WHERE id = current_setting('app.workspace_id')::uuid`); err != nil {
+		return fmt.Errorf("identity: restoring the workspace's configuration columns: %w", err)
+	}
+	return nil
+}

--- a/backend/internal/modules/identity/workspaceconfig_integration_test.go
+++ b/backend/internal/modules/identity/workspaceconfig_integration_test.go
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package identity
+
+// The rails under ResetWorkspaceConfig. Its column list is derived from the
+// live catalog, so the two ways it can go wrong are both schema drift the Go
+// code cannot see: a preserved name that no longer matches a column (the
+// installation's identity silently starts being restored), and a config column
+// `= DEFAULT` cannot legally write (the whole reset aborts at runtime). Both
+// are asserted here, against the schema as migrated.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// seedConfigWorkspace inserts one workspace to exercise the restore against
+// and returns its id. The database persists across binary runs, so the slug
+// carries the id's random tail — the leading bytes are a millisecond timestamp
+// and two runs in the same minute would collide on workspace_slug_unique.
+func seedConfigWorkspace(t *testing.T, owner *pgx.Conn) ids.UUID {
+	t.Helper()
+	slug := "wsconfig-" + ids.NewV7().String()[24:]
+	var ws ids.UUID
+	if err := owner.QueryRow(context.Background(),
+		`INSERT INTO workspace (name, slug, base_currency, timezone)
+		 VALUES ($1, $2, 'EUR', 'Europe/Berlin') RETURNING id`, slug, slug).Scan(&ws); err != nil {
+		t.Fatalf("seeding the workspace: %v", err)
+	}
+	return ws
+}
+
+// TestResetWorkspaceConfigRestoresSettingsAndKeepsIdentity is the behavioural
+// proof, over the two settings the row carries today: an installation with
+// auto-enrich switched off and flipped into overlay mode comes back to exactly
+// what a fresh bootstrap leaves, while the name, currency and zone bootstrap
+// took from the deployment file are untouched.
+func TestResetWorkspaceConfigRestoresSettingsAndKeepsIdentity(t *testing.T) {
+	owner, pool := setupIdentityDB(t)
+	ctx := context.Background()
+	ws := seedConfigWorkspace(t, owner)
+
+	// Move every setting off its default. The two overlay columns move
+	// together because x_overlay_iff_incumbent admits no other state.
+	if _, err := owner.Exec(ctx, `
+		UPDATE workspace
+		   SET capture_auto_enrich = false, x_sor_mode = 'overlay', x_incumbent = 'hubspot'
+		 WHERE id = $1`, ws); err != nil {
+		t.Fatalf("configuring the workspace away from its defaults: %v", err)
+	}
+
+	wsCtx := principal.WithWorkspaceID(ctx, ws)
+	if err := database.WithWorkspaceTx(wsCtx, pool, func(tx pgx.Tx) error {
+		return ResetWorkspaceConfig(wsCtx, tx)
+	}); err != nil {
+		t.Fatalf("ResetWorkspaceConfig: %v", err)
+	}
+
+	var autoEnrich bool
+	var mode, name, currency, timezone string
+	var incumbent *string
+	if err := owner.QueryRow(ctx, `
+		SELECT capture_auto_enrich, x_sor_mode, x_incumbent, name, base_currency, timezone
+		  FROM workspace WHERE id = $1`, ws).
+		Scan(&autoEnrich, &mode, &incumbent, &name, &currency, &timezone); err != nil {
+		t.Fatalf("reading the workspace back: %v", err)
+	}
+	if !autoEnrich {
+		t.Error("capture_auto_enrich = false, want true — the setting outlived the reset that claimed to restore first-boot state")
+	}
+	if mode != "native" {
+		t.Errorf("x_sor_mode = %q, want native", mode)
+	}
+	if incumbent != nil {
+		t.Errorf("x_incumbent = %q, want NULL", *incumbent)
+	}
+	if currency != "EUR" || timezone != "Europe/Berlin" || name == "" {
+		t.Errorf("identity was rewritten: name=%q base_currency=%q timezone=%q — a reset wipes the data, not the installation",
+			name, currency, timezone)
+	}
+}
+
+// TestResetWorkspaceConfigLeavesOtherWorkspacesAlone: workspace is the one
+// table outside RLS (data-model §1.2), so nothing under this statement stops
+// it from restoring every row in the table. The bound GUC is the whole
+// isolation, which makes a co-tenant's settings surviving the property worth
+// asserting rather than assuming.
+func TestResetWorkspaceConfigLeavesOtherWorkspacesAlone(t *testing.T) {
+	owner, pool := setupIdentityDB(t)
+	ctx := context.Background()
+	mine := seedConfigWorkspace(t, owner)
+	theirs := seedConfigWorkspace(t, owner)
+
+	if _, err := owner.Exec(ctx,
+		`UPDATE workspace SET capture_auto_enrich = false WHERE id = $1`, theirs); err != nil {
+		t.Fatalf("configuring the co-tenant: %v", err)
+	}
+
+	wsCtx := principal.WithWorkspaceID(ctx, mine)
+	if err := database.WithWorkspaceTx(wsCtx, pool, func(tx pgx.Tx) error {
+		return ResetWorkspaceConfig(wsCtx, tx)
+	}); err != nil {
+		t.Fatalf("ResetWorkspaceConfig: %v", err)
+	}
+
+	var autoEnrich bool
+	if err := owner.QueryRow(ctx,
+		`SELECT capture_auto_enrich FROM workspace WHERE id = $1`, theirs).Scan(&autoEnrich); err != nil {
+		t.Fatalf("reading the co-tenant back: %v", err)
+	}
+	if autoEnrich {
+		t.Error("the co-tenant's capture_auto_enrich was restored too — one installation's reset reconfigured another's")
+	}
+}
+
+// TestPreservedWorkspaceColumnsAreRealAndExcluded is the stale-name rail: each
+// preserved name must still be a column of the workspace table. A rename or a
+// drop that left the set behind would not fail anything — the name simply
+// stops matching, and the column it was protecting quietly joins the restore
+// set on the next reset.
+func TestPreservedWorkspaceColumnsAreRealAndExcluded(t *testing.T) {
+	_, pool := setupIdentityDB(t)
+	ctx := context.Background()
+
+	if err := database.WithInfraTx(ctx, pool, func(tx pgx.Tx) error {
+		// information_schema, not the pg_catalog query under test, so this
+		// genuinely fails on drift rather than agreeing with itself.
+		rows, err := tx.Query(ctx, `
+			SELECT column_name FROM information_schema.columns
+			WHERE table_schema = 'public' AND table_name = 'workspace'`)
+		if err != nil {
+			return err
+		}
+		existing := map[string]bool{}
+		for rows.Next() {
+			var name string
+			if err := rows.Scan(&name); err != nil {
+				rows.Close()
+				return err
+			}
+			existing[name] = true
+		}
+		rows.Close()
+		if err := rows.Err(); err != nil {
+			return err
+		}
+		for name := range preservedWorkspaceColumns {
+			if !existing[name] {
+				t.Errorf("preserved column %q is not a current workspace column (renamed/dropped?) — a reset would start restoring what it names", name)
+			}
+		}
+		cols, err := workspaceConfigColumns(ctx, tx)
+		if err != nil {
+			return err
+		}
+		for _, col := range cols {
+			if preservedWorkspaceColumns[col] {
+				t.Errorf("preserved column %q appears in the restore set", col)
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("column introspection: %v", err)
+	}
+}
+
+// TestEveryWorkspaceConfigColumnCanTakeItsDeclaredDefault is the forward rail
+// the preserved-set check cannot give: the restore writes `= DEFAULT`, which
+// on a column declaring no default writes NULL. For a NOT NULL column that
+// aborts the whole reset transaction — the sweep, the re-seed and the audit
+// row with it — at runtime, on an installation an operator is already wiping.
+// A column added as NOT NULL DEFAULT … passes; one added NOT NULL and
+// backfilled without keeping a default fails here, where the fix is cheap.
+func TestEveryWorkspaceConfigColumnCanTakeItsDeclaredDefault(t *testing.T) {
+	_, pool := setupIdentityDB(t)
+	ctx := context.Background()
+
+	if err := database.WithInfraTx(ctx, pool, func(tx pgx.Tx) error {
+		cols, err := workspaceConfigColumns(ctx, tx)
+		if err != nil {
+			return err
+		}
+		if len(cols) == 0 {
+			t.Fatal("the workspace row carries no configuration column at all — every assertion here would hold vacuously")
+		}
+		for _, col := range cols {
+			var notNull, hasDefault bool
+			if err := tx.QueryRow(ctx, `
+				SELECT a.attnotnull, a.atthasdef
+				FROM pg_attribute a
+				JOIN pg_class c ON c.oid = a.attrelid
+				JOIN pg_namespace n ON n.oid = c.relnamespace
+				WHERE n.nspname = 'public' AND c.relname = 'workspace' AND a.attname = $1`,
+				col).Scan(&notNull, &hasDefault); err != nil {
+				return err
+			}
+			if notNull && !hasDefault {
+				t.Errorf("config column %q is NOT NULL with no declared default — `SET %s = DEFAULT` writes NULL and aborts the reset; give the column a default or declare it preserved",
+					col, col)
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("column introspection: %v", err)
+	}
+}

--- a/backend/internal/modules/identity/workspaceconfig_integration_test.go
+++ b/backend/internal/modules/identity/workspaceconfig_integration_test.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -74,11 +75,13 @@ func TestResetWorkspaceConfigRestoresSettingsAndKeepsIdentity(t *testing.T) {
 	ws := seedConfigWorkspace(t, pool, "settings")
 
 	// Move every setting off its default. The two overlay columns move
-	// together because x_overlay_iff_incumbent admits no other state.
-	if _, err := owner.Exec(ctx, `
+	// together because x_overlay_iff_incumbent admits no other state. The
+	// stamp this leaves is what the restore's own write has to move past.
+	var before time.Time
+	if err := owner.QueryRow(ctx, `
 		UPDATE workspace
 		   SET capture_auto_enrich = false, x_sor_mode = 'overlay', x_incumbent = 'hubspot'
-		 WHERE id = $1`, ws); err != nil {
+		 WHERE id = $1 RETURNING updated_at`, ws).Scan(&before); err != nil {
 		t.Fatalf("configuring the workspace away from its defaults: %v", err)
 	}
 
@@ -92,10 +95,11 @@ func TestResetWorkspaceConfigRestoresSettingsAndKeepsIdentity(t *testing.T) {
 	var autoEnrich bool
 	var mode, name, currency, timezone string
 	var incumbent *string
+	var after time.Time
 	if err := owner.QueryRow(ctx, `
-		SELECT capture_auto_enrich, x_sor_mode, x_incumbent, name, base_currency, timezone
+		SELECT capture_auto_enrich, x_sor_mode, x_incumbent, name, base_currency, timezone, updated_at
 		  FROM workspace WHERE id = $1`, ws).
-		Scan(&autoEnrich, &mode, &incumbent, &name, &currency, &timezone); err != nil {
+		Scan(&autoEnrich, &mode, &incumbent, &name, &currency, &timezone, &after); err != nil {
 		t.Fatalf("reading the workspace back: %v", err)
 	}
 	if !autoEnrich {
@@ -110,6 +114,17 @@ func TestResetWorkspaceConfigRestoresSettingsAndKeepsIdentity(t *testing.T) {
 	if currency != configBootstrap.BaseCurrency || timezone != configBootstrap.Timezone || name == "" {
 		t.Errorf("identity was rewritten: name=%q base_currency=%q timezone=%q — a reset wipes the data, not the installation",
 			name, currency, timezone)
+	}
+
+	// created_at is preserved and updated_at is not, and the difference is the
+	// point: the restore assigns neither, but it does WRITE the row, so the
+	// trigger moves the modification stamp. Pinned because the alternative
+	// reads like a tidier invariant ("a reset touches no timestamp") and is
+	// the exact appearance the unfixed bug had — a workspace row whose
+	// updated_at predates the reset is a row the reset never wrote.
+	if !after.After(before) {
+		t.Errorf("updated_at is %s after a reset of a row last written %s — the row was written, and the stamp that records that must move",
+			after, before)
 	}
 }
 

--- a/backend/internal/modules/identity/workspaceconfig_integration_test.go
+++ b/backend/internal/modules/identity/workspaceconfig_integration_test.go
@@ -5,38 +5,62 @@
 
 package identity
 
-// The rails under ResetWorkspaceConfig. Its column list is derived from the
-// live catalog, so the two ways it can go wrong are both schema drift the Go
-// code cannot see: a preserved name that no longer matches a column (the
-// installation's identity silently starts being restored), and a config column
-// `= DEFAULT` cannot legally write (the whole reset aborts at runtime). Both
-// are asserted here, against the schema as migrated.
+// The rails under ResetWorkspaceConfig, against the schema as migrated. The
+// column list is derived from the live catalog, so every way this goes wrong
+// is drift the Go code cannot see, in one of two directions: a setting that
+// escapes the restore, or — the destructive one — a value the deployment
+// configured being restored away. The last test here is the rail for that
+// second direction, and it is the reason the fixtures below bootstrap through
+// the real installation path rather than inserting a row by hand.
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
-// seedConfigWorkspace inserts one workspace to exercise the restore against
-// and returns its id. The database persists across binary runs, so the slug
-// carries the id's random tail — the leading bytes are a millisecond timestamp
-// and two runs in the same minute would collide on workspace_slug_unique.
-func seedConfigWorkspace(t *testing.T, owner *pgx.Conn) ids.UUID {
+// configBootstrap is the deployment configuration every fixture here is
+// bootstrapped from. Each value that lands on the workspace row differs from
+// that column's declared default — a timezone that is not UTC, a currency that
+// is not the fallback — so a restore that reached one of them CHANGES the row
+// instead of coincidentally rewriting it with what was already there.
+var configBootstrap = InstallationBootstrap{
+	BaseCurrency: "CHF", Timezone: "Europe/Berlin",
+	AdminName: "Admin", AdminPassword: "a bootstrap password!",
+}
+
+// seedConfigWorkspace bootstraps one installation through createInstallation —
+// the path a first boot actually takes, so "what a fresh bootstrap leaves" is
+// the real thing rather than this file's idea of it — and returns its id.
+//
+// The database persists across binary runs, so the name (and the slug and
+// admin email derived from it) carries the id's random tail: the leading bytes
+// are a millisecond timestamp, and two runs inside the same minute would
+// collide on workspace_slug_unique.
+func seedConfigWorkspace(t *testing.T, pool *pgxpool.Pool, label string) ids.UUID {
 	t.Helper()
-	slug := "wsconfig-" + ids.NewV7().String()[24:]
-	var ws ids.UUID
-	if err := owner.QueryRow(context.Background(),
-		`INSERT INTO workspace (name, slug, base_currency, timezone)
-		 VALUES ($1, $2, 'EUR', 'Europe/Berlin') RETURNING id`, slug, slug).Scan(&ws); err != nil {
-		t.Fatalf("seeding the workspace: %v", err)
+	ctx := context.Background()
+	name := "wsconfig-" + label + "-" + ids.NewV7().String()[24:]
+	boot := configBootstrap
+	boot.OrganizationName = name
+	boot.AdminEmail = "admin@" + name + ".test"
+
+	var ws ids.WorkspaceID
+	if err := database.WithInfraTx(ctx, pool, func(tx pgx.Tx) error {
+		var err error
+		ws, err = createInstallation(ctx, tx, boot, nil)
+		return err
+	}); err != nil {
+		t.Fatalf("bootstrapping the %s installation: %v", label, err)
 	}
-	return ws
+	return ws.UUID
 }
 
 // TestResetWorkspaceConfigRestoresSettingsAndKeepsIdentity is the behavioural
@@ -47,7 +71,7 @@ func seedConfigWorkspace(t *testing.T, owner *pgx.Conn) ids.UUID {
 func TestResetWorkspaceConfigRestoresSettingsAndKeepsIdentity(t *testing.T) {
 	owner, pool := setupIdentityDB(t)
 	ctx := context.Background()
-	ws := seedConfigWorkspace(t, owner)
+	ws := seedConfigWorkspace(t, pool, "settings")
 
 	// Move every setting off its default. The two overlay columns move
 	// together because x_overlay_iff_incumbent admits no other state.
@@ -83,7 +107,7 @@ func TestResetWorkspaceConfigRestoresSettingsAndKeepsIdentity(t *testing.T) {
 	if incumbent != nil {
 		t.Errorf("x_incumbent = %q, want NULL", *incumbent)
 	}
-	if currency != "EUR" || timezone != "Europe/Berlin" || name == "" {
+	if currency != configBootstrap.BaseCurrency || timezone != configBootstrap.Timezone || name == "" {
 		t.Errorf("identity was rewritten: name=%q base_currency=%q timezone=%q — a reset wipes the data, not the installation",
 			name, currency, timezone)
 	}
@@ -97,8 +121,8 @@ func TestResetWorkspaceConfigRestoresSettingsAndKeepsIdentity(t *testing.T) {
 func TestResetWorkspaceConfigLeavesOtherWorkspacesAlone(t *testing.T) {
 	owner, pool := setupIdentityDB(t)
 	ctx := context.Background()
-	mine := seedConfigWorkspace(t, owner)
-	theirs := seedConfigWorkspace(t, owner)
+	mine := seedConfigWorkspace(t, pool, "mine")
+	theirs := seedConfigWorkspace(t, pool, "theirs")
 
 	if _, err := owner.Exec(ctx,
 		`UPDATE workspace SET capture_auto_enrich = false WHERE id = $1`, theirs); err != nil {
@@ -173,13 +197,16 @@ func TestPreservedWorkspaceColumnsAreRealAndExcluded(t *testing.T) {
 	}
 }
 
-// TestEveryWorkspaceConfigColumnCanTakeItsDeclaredDefault is the forward rail
-// the preserved-set check cannot give: the restore writes `= DEFAULT`, which
-// on a column declaring no default writes NULL. For a NOT NULL column that
-// aborts the whole reset transaction — the sweep, the re-seed and the audit
-// row with it — at runtime, on an installation an operator is already wiping.
-// A column added as NOT NULL DEFAULT … passes; one added NOT NULL and
-// backfilled without keeping a default fails here, where the fix is cheap.
+// TestEveryWorkspaceConfigColumnCanTakeItsDeclaredDefault: the restore writes
+// `= DEFAULT`, which on a column declaring no default writes NULL. For a NOT
+// NULL column that aborts the whole reset transaction — the sweep, the re-seed
+// and the audit row with it — at runtime, on an installation an operator is
+// already wiping.
+//
+// The behavioural tests above would fail on such a column too, since they run
+// the real statement. What this adds is the diagnosis: it names the column and
+// says what to do about it, instead of leaving a reader to read 23502 off a
+// statement that lists every column on the row.
 func TestEveryWorkspaceConfigColumnCanTakeItsDeclaredDefault(t *testing.T) {
 	_, pool := setupIdentityDB(t)
 	ctx := context.Background()
@@ -212,4 +239,84 @@ func TestEveryWorkspaceConfigColumnCanTakeItsDeclaredDefault(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("column introspection: %v", err)
 	}
+}
+
+// perInstallationWorkspaceColumns are the columns two installations differ in
+// by construction — the key, the name and slug each was created under, and the
+// timestamps of its own creation. Everything else on the row is either the
+// deployment configuration both were bootstrapped from or a setting at its
+// declared default, so the comparison below can hold them equal.
+var perInstallationWorkspaceColumns = map[string]bool{
+	"id": true, "name": true, "slug": true, "created_at": true, "updated_at": true,
+}
+
+// TestAResetWorkspaceMatchesAFreshlyBootstrappedOne is the rail for the
+// direction that loses data rather than leaking it.
+//
+// Restoring is the DEFAULT here: a column not named in preservedWorkspaceColumns
+// is restored, which is what keeps a new setting from escaping the reset. The
+// cost of that default is the mirror-image mistake — someone adds a column
+// bootstrap writes from margince.yaml and does not declare it preserved, and
+// the reset then quietly discards what the deployment configured. No rail over
+// the restore set can see that, because nothing distinguishes such a column
+// from a setting by shape.
+//
+// Comparing against a SECOND installation bootstrapped from the same
+// configuration can: the fresh one still carries the configured value, the
+// reset one has been returned to the column's default, and the two rows
+// disagree on a key. That is why both fixtures run through createInstallation,
+// and why configBootstrap's values are all off-default — a column bootstrap
+// writes with exactly its own default is invisible here, and to every other
+// test, because there is nothing to observe.
+func TestAResetWorkspaceMatchesAFreshlyBootstrappedOne(t *testing.T) {
+	owner, pool := setupIdentityDB(t)
+	ctx := context.Background()
+
+	// A bootstrap field added later reaches the workspace row only if
+	// createInstallation writes it there, and this test can only see it if
+	// configBootstrap sets it off-default. Neither is checkable from here, so
+	// the field count is the tripwire that sends the next author to look.
+	if got := reflect.TypeOf(InstallationBootstrap{}).NumField(); got != 6 {
+		t.Errorf("InstallationBootstrap has %d fields, this test was written against 6 — if the new one lands on the workspace row, declare its column in preservedWorkspaceColumns and give it an off-default value in configBootstrap, then update this count", got)
+	}
+
+	ws := seedConfigWorkspace(t, pool, "reset")
+	fresh := seedConfigWorkspace(t, pool, "fresh")
+	if _, err := owner.Exec(ctx, `
+		UPDATE workspace
+		   SET capture_auto_enrich = false, x_sor_mode = 'overlay', x_incumbent = 'hubspot'
+		 WHERE id = $1`, ws); err != nil {
+		t.Fatalf("configuring the workspace away from its defaults: %v", err)
+	}
+
+	wsCtx := principal.WithWorkspaceID(ctx, ws)
+	if err := database.WithWorkspaceTx(wsCtx, pool, func(tx pgx.Tx) error {
+		return ResetWorkspaceConfig(wsCtx, tx)
+	}); err != nil {
+		t.Fatalf("ResetWorkspaceConfig: %v", err)
+	}
+
+	after, freshRow := readWorkspaceRow(t, owner, ws), readWorkspaceRow(t, owner, fresh)
+	for col, want := range freshRow {
+		if perInstallationWorkspaceColumns[col] {
+			continue
+		}
+		if got := after[col]; !reflect.DeepEqual(got, want) {
+			t.Errorf("column %q is %v after a reset, but a freshly bootstrapped installation carries %v — if this column holds deployment configuration, declare it in preservedWorkspaceColumns; if it is a setting, its default and its bootstrap value disagree",
+				col, got, want)
+		}
+	}
+}
+
+// readWorkspaceRow returns one workspace row as column → value. The whole row,
+// not a named list: a column added later has to reach the comparison above
+// without anyone remembering to add it here.
+func readWorkspaceRow(t *testing.T, owner *pgx.Conn, ws ids.UUID) map[string]any {
+	t.Helper()
+	var row map[string]any
+	if err := owner.QueryRow(context.Background(),
+		`SELECT to_jsonb(w) FROM workspace w WHERE id = $1`, ws).Scan(&row); err != nil {
+		t.Fatalf("reading the workspace row: %v", err)
+	}
+	return row
 }

--- a/backend/internal/modules/overlay/teardown.go
+++ b/backend/internal/modules/overlay/teardown.go
@@ -123,10 +123,16 @@ func (s *Service) Disconnect(ctx context.Context) error {
 
 // RevertToNative returns the bound workspace to native mode inside the
 // caller's transaction, reporting whether it had to. It is the ONE spelling of
-// that flip: Disconnect's teardown takes it, and so does the non-production
-// data reset, which sweeps every table overlay mode depends on and would
-// otherwise leave the workspace claiming to read from an incumbent it no
-// longer has a connection to.
+// that flip as an intentional act: Disconnect's teardown takes it, and so does
+// the non-production data reset, which sweeps every table overlay mode depends
+// on and would otherwise leave the workspace claiming to read from an
+// incumbent it no longer has a connection to.
+//
+// The reset then runs identity.ResetWorkspaceConfig, which restores EVERY
+// setting on the workspace row to its declared default and so lands on these
+// two columns again. That ordering is required, not incidental: whether the
+// installation was in overlay mode is only knowable before something writes
+// the column, and only this call reports it.
 //
 // Both columns move in one statement because the schema admits no intermediate
 // state (the x_overlay_iff_incumbent CHECK: a mode of 'overlay' and a non-NULL

--- a/backend/internal/modules/overlay/teardown.go
+++ b/backend/internal/modules/overlay/teardown.go
@@ -128,9 +128,10 @@ func (s *Service) Disconnect(ctx context.Context) error {
 // on and would otherwise leave the workspace claiming to read from an
 // incumbent it no longer has a connection to.
 //
-// The reset then runs identity.ResetWorkspaceConfig, which restores EVERY
-// setting on the workspace row to its declared default and so lands on these
-// two columns again. That ordering is required, not incidental: whether the
+// The reset then runs identity.ResetWorkspaceConfig, which restores every
+// non-preserved column on the workspace row to its declared default — these
+// two among them, so they are written again. That ordering is required, not
+// incidental: whether the
 // installation was in overlay mode is only knowable before something writes
 // the column, and only this call reports it.
 //

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -526,10 +526,20 @@ On success it wipes workspace domain + seeded-config data back to the
 first-boot bootstrapped state and re-runs the module seeders (pipeline/stages,
 consent purposes + retention, AI defaults, starter automations, the booking
 page) — the same seed path `identity`'s installation bootstrap uses. It
-**preserves** the identity/auth layer (`workspace`, every `app_user`, roles,
-role assignments, teams, team memberships, sessions, passports, tokens — so
-login keeps working) and the append-only ledgers `audit_log` / `system_log`.
+**preserves** the identity/auth layer (every `app_user`, roles, role
+assignments, teams, team memberships, sessions, passports, tokens — so login
+keeps working) and the append-only ledgers `audit_log` / `system_log`.
 The reset itself is recorded as an `audit_log` row (action `reset_data`).
+
+The `workspace` row survives too — it carries the organization — but only its
+**installation identity** is preserved: the primary key, the name, slug, base
+currency and timezone bootstrap took from `margince.yaml`, and the row's
+timestamps. Every other column on it is a workspace-level **setting**, and each
+one goes back to the default its migration declared (`capture_auto_enrich`, the
+overlay mode columns, and whatever is added next). Nothing here is a kept list:
+the columns are derived from the catalog, so a setting added later is restored
+the day its column exists, and a column that genuinely belongs to the
+installation's identity has to be declared preserved to be spared.
 
 The sweep runs as the app role — no superuser, no disabled triggers — so it
 discovers a safe delete order at runtime (a savepoint per table per pass,
@@ -572,10 +582,13 @@ against records that no longer exist. The endpoint therefore also:
    before the rows naming them go. Which tables hold one is derived from the
    catalog on the `credential_ref` column, so a connection table added later is
    covered the day its column exists.
-6. **Returns an overlay-mode installation to native.** The `workspace` row is
-   preserved because it carries the organization, but everything overlay mode
-   depends on is swept — the incumbent connection, the mirror, the budget
-   counters — so a workspace left in overlay would claim to read from an
+6. **Restores every workspace-level setting**, including returning an
+   overlay-mode installation to native. The table sweep reaches none of them:
+   its target list is derived from the tables carrying a `workspace_id` column,
+   and `workspace` keys on `id`, so that row is not a candidate for it at all.
+   The overlay columns are the consequential case — everything overlay mode
+   depends on IS swept (the incumbent connection, the mirror, the budget
+   counters), so a workspace left in overlay would claim to read from an
    incumbent it no longer has a connection to, dispatching every read at an
    empty mirror. `x_sor_mode` and `x_incumbent` flip together, as the schema
    requires. This is not the governed `Disconnect` teardown: those rows are

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -533,8 +533,9 @@ The reset itself is recorded as an `audit_log` row (action `reset_data`).
 
 The `workspace` row survives too — it carries the organization — but only its
 **installation identity** is preserved: the primary key, the name, slug, base
-currency and timezone bootstrap took from `margince.yaml`, and the row's
-timestamps. Every other column on it is a workspace-level **setting**, and each
+currency and timezone bootstrap took from `margince.yaml`, and `created_at`.
+(`updated_at` moves, as it does for any write — the reset did write the row.)
+Every other column on it is a workspace-level **setting**, and each
 one goes back to the default its migration declared (`capture_auto_enrich`, the
 overlay mode columns, and whatever is added next). Nothing here is a kept list:
 the columns are derived from the catalog, so a setting added later is restored


### PR DESCRIPTION
Closes #519.

## What was wrong

`POST /v1/admin/reset-data` reports it has returned the installation to first-boot state. Its table sweep is derived from the tables carrying a `workspace_id` column, and `workspace` keys on `id` — so the row holding every workspace-level **setting** is not excluded from that sweep, it was never a candidate for it.

#513 handled the consequential special case (an overlay workspace stranded with an emptied mirror and no API path back to native). The general hole stayed open: `capture_auto_enrich` (CAP-PARAM-7) still outlived the wipe, and so would the next setting added to the row.

## The fix

`identity` owns the `workspace` table, so the restore lives there. `ResetWorkspaceConfig` derives its column list from the catalog exactly as the sweep derives its tables, and writes `= DEFAULT` so each value stays where its migration declared it.

A setting added later is restored with no list to keep in step. A column that genuinely belongs to the installation's identity — the four values bootstrap takes from the deployment file, the key, the lifecycle timestamps — has to be declared preserved to be spared.

The overlay flip stays where #513 put it and runs first: whether the installation **was** in overlay mode is only knowable before something writes the column, and that fact belongs in the audit row.

## Rails

Three, one per way this drifts. Each was mutation-tested against the defect it guards:

| Rail | Catches | Proven by |
|---|---|---|
| `TestPreservedWorkspaceColumnsAreRealAndExcluded` | a preserved name that no longer matches a column, which would quietly start restoring the installation's own identity | renamed `timezone` → fails |
| `TestEveryWorkspaceConfigColumnCanTakeItsDeclaredDefault` | a config column that is `NOT NULL` with no default — `= DEFAULT` writes NULL there and aborts the whole reset transaction at runtime, on an install an operator is already wiping | planted such a column → SQLSTATE 23502, and the rail names it |
| `TestAResetWorkspaceMatchesAFreshlyBootstrappedOne` | the destructive direction: a column bootstrap writes from `margince.yaml`, added without being declared preserved, silently discarded by the next reset | undeclared `timezone` → fails naming the column |

The third compares the reset row against a second installation bootstrapped from the same configuration, so it needs no list of settings at all. Both fixtures bootstrap through `createInstallation` — "what a fresh bootstrap leaves" is the real path, not this file's idea of it — and the configuration they use is off-default in every column it reaches, since a column bootstrapped with exactly its own default has nothing to observe.

## Also

- `docs/reference/configuration.md` said the `workspace` row is preserved. It was the only written record of the preserved/restored split, so it was describing exactly the thing this fix corrects, backwards.
- `ResetWorkspaceConfig` refuses zero rows updated. Its doc argued the GUC must not be able to match no row while the body accepted that in silence; unlike `RevertToNative`, this statement has no predicate beyond the id, so nothing matched is unambiguously wrong.
- `RevertToNative`'s doc called itself the one spelling of the mode flip. It is the one *intentional* one, and now says so.

## Verification

`make check-backend`, `make craft-static`, and `make test-integration` are green. One note for the reviewer: `internal/compose/integration` runs at 258–300s against a 300s per-package timeout and timed out once on a loaded machine, then passed twice on the same code — a pre-existing margin, unrelated to this diff.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `POST /v1/admin/reset-data` also restore workspace-level settings to their declared defaults, after reverting overlay mode, so resets truly return to first boot while keeping the organization’s identity.

- **Bug Fixes**
  - Added `identity.ResetWorkspaceConfig` to set non-preserved `workspace` columns to `DEFAULT`, derived from the catalog; runs after `overlay.RevertToNative` and rejects zero-row updates.
  - Preserves identity fields: id, name, slug, base_currency, timezone, created_at; `updated_at` moves because the row is written.
  - New tests/rails: preserved-name drift, NOT NULL-without-default, and parity with a freshly bootstrapped workspace; added compose test confirming `capture_auto_enrich` restores.
  - Docs clarify the preserved/restored split, why `updated_at` moves, that resets target non-preserved columns, and that `RevertToNative` is the intentional flip before the blanket restore.

<sup>Written for commit 97adae99c4f4dcb6516b752dee7a709c17d3a475. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/523?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

