### PR TITLE
perf(web): cache the pnpm store and tsc build info across image builds

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,8 +1,17 @@
+# syntax=docker/dockerfile:1
+
 # The Vite/React SPA — a static build served by nginx. The app talks only to the
 # /v1 contract surface, same-origin (frontend/src/api/client.ts derives its base
 # from location.origin + "/v1"), so there are NO build-time API-base env vars:
 # the D13 ingress routes /v1 (+ /healthz /readyz /metrics) to the api service and
 # / to this one, both under the same host.
+
+# The BuildKit cache mounts below only pay off on a builder whose daemon outlives
+# the build — the D13 Jenkins agent, which is what the deploy pipeline uses. On an
+# ephemeral runner (this repo's own `docker image (web)` CI job, a fresh
+# ubuntu-latest per run) they start empty every time and cost nothing; making
+# those builds faster would need an exported cache (cache-to/cache-from type=gha)
+# or a persistent builder, which is a separate change to the workflow.
 
 # ── Stage 1: build ───────────────────────────────────────────────────────────
 FROM node:22-alpine AS builder
@@ -15,7 +24,14 @@ RUN corepack enable
 WORKDIR /app
 COPY frontend/package.json frontend/pnpm-lock.yaml frontend/pnpm-workspace.yaml ./frontend/
 WORKDIR /app/frontend
-RUN pnpm install --frozen-lockfile --ignore-scripts
+# The pnpm store and corepack's pnpm download live on BuildKit cache mounts. The
+# store is otherwise empty on every build ("reused 0, downloaded 326"), so a CI
+# run re-fetches the whole dependency set from the registry. The store is
+# content-addressed and the install stays --frozen-lockfile, so what gets
+# installed is unchanged — only where the tarballs come from.
+RUN --mount=type=cache,id=margince-pnpm-store,target=/pnpm-store \
+    --mount=type=cache,id=margince-corepack,target=/root/.cache/node/corepack \
+    pnpm install --frozen-lockfile --ignore-scripts --store-dir /pnpm-store
 
 # The OpenAPI contract the TS types are generated from (pnpm gen:api reads
 # ../backend/api/*.yaml), then the app source.
@@ -27,7 +43,15 @@ COPY frontend/ ./frontend/
 # the image's types pinned to the contract it was built against rather than
 # trusting the committed schema.d.ts.
 WORKDIR /app/frontend
-RUN pnpm gen:api && pnpm build
+# `tsc -b` dominates this step (~40s of ~51s locally; vite itself is ~6s). Both
+# composite projects write their .tsbuildinfo into node_modules/.tmp, which is
+# discarded with the builder stage, so every build type-checks the whole tree from
+# scratch. Persisting just that directory makes tsc incremental across builds;
+# it keys off recorded file content hashes, so changed files are still re-checked
+# and the type gate over the freshly generated schema.d.ts is unchanged.
+RUN --mount=type=cache,id=margince-tsbuildinfo,target=/app/frontend/node_modules/.tmp \
+    --mount=type=cache,id=margince-corepack,target=/root/.cache/node/corepack \
+    pnpm gen:api && pnpm build
 
 # ── Stage 2: serve ───────────────────────────────────────────────────────────
 # nginx-unprivileged runs as a non-root user (uid 101) and listens on 8080.


### PR DESCRIPTION
## Why

A staging deploy's Build stage took **7m54s**. Five `RUN` steps accounted for 429s of it (90%), and every one was doing work a warm cache would skip. The Go side is being fixed in the deploy repo (`margince-d13-deploy`); this PR is the web image's share.

Two things made the web image rebuild from cold every run:

- **The pnpm store starts empty.** CI logs show `reused 0, downloaded 326` — all 326 packages re-fetched from the registry, plus corepack re-downloading pnpm itself (`! Corepack is about to download …pnpm-11.20.0.tgz`).
- **`tsc -b` has no incremental state.** Both composite projects write `.tsbuildinfo` into `node_modules/.tmp`, which is discarded with the builder stage, so the whole tree is type-checked from scratch. `tsc` was ~40s of the ~51s build step; `vite build` is only ~6s of it.

## What changed

`Dockerfile.web` only. Three BuildKit cache mounts, plus `# syntax=docker/dockerfile:1` to guarantee the mount syntax regardless of the daemon's built-in frontend:

| Mount | Purpose |
|---|---|
| `/pnpm-store` | pnpm's content-addressable store (via `--store-dir`) |
| `/root/.cache/node/corepack` | corepack's pnpm download |
| `/app/frontend/node_modules/.tmp` | the two projects' `.tsbuildinfo` |

No build semantics change: the install stays `--frozen-lockfile --ignore-scripts`, `gen:api` still regenerates `schema.d.ts` from `crm.yaml`, and `tsc -b` still type-checks against the regenerated types.

## Measured

Local, `linux/arm64`, source at `d8432e28` with one `src` file changed to simulate a source bump:

| Step | Before | After |
|---|---|---|
| `pnpm install` | 11.5s | **7.9s** (`reused 326, downloaded 0`) |
| `pnpm gen:api && pnpm build` | 50.9s | **13.3s** (`tsc` ~40s → ~7s) |

The residual ~7s of `pnpm install` is the supply-chain policy verification (`Lockfile passes supply-chain policies (405 entries in 6.4s)`) — intentional, not cache-addressable.

**Which builder this helps.** These mounts only pay off where the daemon outlives the build — the **D13 Jenkins agent**, which is what the deploy pipeline uses and where the 7m54s was measured. That agent is roughly 1.5x slower than this machine (the same cold work took 50.9s here vs 78.1s there), so expect the web image to go from ~93s to ~30s in the deploy pipeline.

On this repo's own `docker image (web)` CI job the mounts are a **no-op** — `ci.yml` runs a plain `docker build` on a fresh `ubuntu-latest` per run, so they start empty every time. They cost nothing there. Speeding that job up would need an exported cache (`cache-to`/`cache-from: type=gha`) or a persistent builder, which is a separate change to the workflow and not attempted here. A comment in `Dockerfile.web` now records this.

## Verification

- **Output is byte-identical.** Built the same tree with the unmodified `Dockerfile.web` and with this one; sha256 over every file served from `/usr/share/nginx/html` matches (`8fca062c…`).
- **The type gate still fires.** Appended a deliberate `const x: number = "string"` to `src/main.tsx` and rebuilt with a warm `tsbuildinfo` cache: build fails, `src/main.tsx(68,7): error TS2322`. Incremental `tsc` keys off recorded file content hashes, so changed files are re-checked.
- Full image builds green; nginx stage unaffected.

## Follow-up, not in this PR

The type error above printed **twice**, once per composite project — `tsconfig.node.json` includes `"src"` alongside `vite.config.ts`, so all 408 files / ~152k LOC get type-checked under both `tsconfig.app.json` and `tsconfig.node.json`. Deduplicating that would roughly halve the remaining `tsc` time.

It needs care rather than a one-line `include` edit: `tsconfig.app.json` *excludes* `src/**/*.test.ts(x)`, so the node project appears to be the only thing currently type-checking the tests — and `vitest.setup.ts`, `playwright.config.ts` and `e2e/` are in neither project today. A separate `tsconfig.test.json` referenced from the root config is probably the right shape. Happy to open that separately if you agree with the direction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved application build efficiency through persistent caching during dependency installation, API generation, and frontend builds.
  * Updated container build configuration to provide more consistent build performance.
  * Preserved existing dependency-locking, installation, type-checking, API generation, and frontend build behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->