### PR TITLE
Record what profiling the integration lane found

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -35,6 +35,40 @@ fallback), **#495** (auth rate limits are process-local, so N replicas multiply
 every ceiling by N), **#496** (audit-verb down migrations cannot see the rows
 their refusal probe checks for, under production RLS).
 
+## Open — the integration lane's cost, profiled
+
+The lane is 1828 tests over 25 packages, ~493s summed (~300s wall, parallel).
+Profiled per test on 2026-08-06 because the suite *looked* inflated. It is not
+inflated by count: the slowest decile is 55% of the time and the fastest 1328
+tests together are 29%, so converting the small majority to unit tests would
+delete three-quarters of the suite to recover under a third of the runtime —
+and most of them assert database behaviour (RLS, CHECK→4xx, keyset pagination)
+that has no meaning without Postgres.
+
+Where the cost actually is, and what is worth doing about it:
+
+- **#524** — `internal/compose/integration` is half the lane (960 tests) and
+  runs 258–302s against a 300s per-package timeout, so it flakes on a loaded
+  machine. CI shards 12 ways and never sees it; the unsharded local lane and
+  `make test-it` do. The 300s default is documented against the sharded
+  assumption, and the script already bumps to 900s for the whole-package case
+  but gates that on `COVERDIR` rather than on `SHARD_TOTAL == 1`.
+- **#539** — that package's setup forks about five Postgres backends per test.
+  Sharing them measured ~18% (170.9s vs a 209.6s baseline) and is **blocked**:
+  the harness drops `cf_*` columns between tests, so a pooled connection
+  outliving that DDL serves a stale plan and fails with SQLSTATE 0A000 in a
+  suite unrelated to custom fields. The issue records the design that would
+  unblock it and the four cheaper approaches that were measured and do not pay.
+- **#535** — table-driven tests calling their harness inside `t.Run`, re-seeding
+  Postgres per case (~44s), which also hides that the property under test is pure.
+- **#536** — a few tests assert pure logic through a booted app; `check-test-lanes.sh`
+  forbids the mirror case (a unit test opening real infra) but cannot see this one.
+
+Two measurement notes for whoever picks this up. Run-to-run variance on the same
+commit is ~15%, so compare within one sitting on an idle machine. And both
+failures found while attempting #539 were order-dependent — they appeared only
+in a full-package or full-lane run, never in isolation.
+
 ## Open — contract drift: the reset's response gained five fields
 
 `backend/api/crm.yaml`'s `resetData` 200 body now declares `jobs_deleted`,


### PR DESCRIPTION
Session pickup record for the integration-lane investigation. Docs only — one new `## Open` section in STATUS.md, placed by the file's convention (newest near the top, after the first item).

## Why this is in STATUS.md and not just in the issues

The suite *looked* inflated, and the obvious remedy — move the many small tests to the unit lane — is wrong in a way that is not obvious without the numbers. Anyone who forms the same suspicion next month deserves the measurement rather than a second week of profiling.

1828 tests, ~493s summed. The slowest decile is 55% of the time; the fastest 1328 tests are 29% between them. So converting the small majority deletes three-quarters of the suite to recover under a third of the runtime — and most of those tests assert RLS, CHECK→4xx, or keyset pagination, which have no meaning without Postgres.

## What it points at

| | |
|---|---|
| **#524** | `compose/integration` is half the lane and runs 258–302s against a 300s per-package timeout. CI shards 12 ways and never sees it; the local lane does. |
| **#539** | ~18% available from sharing harness connections, blocked on pgx plan-cache invalidation (the harness drops `cf_*` columns between tests → SQLSTATE 0A000 in an unrelated suite). Records the unblocking design and four cheaper approaches that were measured and do not pay. |
| **#535** | Table-driven tests re-seeding Postgres per case (~44s). |
| **#536** | A few tests assert pure logic through a booted app; the lane gate cannot see them. |

## Two notes that will save the next person a day

Run-to-run variance on the same commit is ~15% — 209.6s and 242.9s were both clean baselines of the same package, which is enough to make a bad change look like a good one. And both failures found while attempting #539 were order-dependent: green in isolation, red in a full-package run. A single green run is not evidence here.

No code changes; no gates affected beyond the docs checks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a new section to `STATUS.md` documenting per-test profiling of the integration lane. It shows count isn’t the issue, flags `internal/compose/integration` flaking at the 300s per-package timeout on unsharded runs (CI shards 12), and an ~18% win blocked by `pgx` plan-cache invalidation, plus notes on variance and order-dependent failures, with pointers to #524, #539, #535, #536.

<sup>Written for commit 77f0707afd5adf8b4fad05ee0fd6565a79ce1205. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/549?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

