### PR TITLE
A reused test template is brought to head, not trusted to be at it

### DIFF
--- a/scripts/lib-testdb.sh
+++ b/scripts/lib-testdb.sh
@@ -66,17 +66,41 @@ export TEMPLATE_NAME="${TEMPLATE_NAME:-margince_test}"
 owner_clone_dsn() { local db="$1"; echo "${O_PREFIX}/${db}${O_QUERY:+?$O_QUERY}"; }
 app_clone_dsn()   { local db="$1"; echo "${A_PREFIX}/${db}${A_QUERY:+?$A_QUERY}"; }
 
-# build_template — (re)create margince_test and migrate it to head with the same
-# embedded migration set the app uses (cmd/migrate → migrations.Core/Custom).
-# Fresh each call so the template can never carry a stale schema. Runs from the
-# repo root; the caller must have cd'd there (both scripts do).
-build_template() {
-  db_admin recreate-db --name "$TEMPLATE_NAME" >/dev/null
-  ( cd backend && go run ./cmd/migrate up --dsn "$(owner_clone_dsn "$TEMPLATE_NAME")" >/dev/null )
+# migrate_template — bring the template to head with the same embedded migration
+# set the app uses (cmd/migrate → migrations.Core/Custom, then River). Idempotent
+# by construction: the runner compares the tracking tables against the embedded
+# set, so at head it applies nothing. Prints what it applied — a heal is worth a
+# line, and a silent one reads exactly like a no-op.
+migrate_template() {
+  ( cd backend && go run ./cmd/migrate up --dsn "$(owner_clone_dsn "$TEMPLATE_NAME")" )
 }
 
-# ensure_template — build the template only if it is missing (fast reuse for the
-# single-package inner loop; the full lane rebuilds fresh via build_template).
+# build_template — (re)create margince_test and migrate it to head. Fresh each
+# call so the template can never carry a stale schema. Runs from the repo root;
+# the caller must have cd'd there (both scripts do).
+build_template() {
+  db_admin recreate-db --name "$TEMPLATE_NAME" >/dev/null
+  migrate_template >/dev/null
+}
+
+# ensure_template — the fast path for the single-package inner loop: reuse the
+# template rather than rebuilding it, but never reuse it blindly.
+#
+# PRESENT IS NOT CURRENT. This probed only for existence, and reused whatever it
+# found however old it was, so a template built before a migration landed handed
+# every clone a schema behind head. The failure that produces is thoroughly
+# misleading: tests fail inside the constraint or column the new migration adds,
+# naming code that is correct, in a package that has nothing to do with the
+# change you pulled. The full lane never shows it — that path calls
+# build_template — so it bites exactly when you are iterating on one package.
+#
+# Migrating rather than rebuilding is the cheap fix: at head the runner applies
+# nothing, and behind it applies only the delta. What this does NOT heal is a
+# template that has diverged rather than fallen behind — an edited migration, or
+# a checkout that no longer has one the template already applied. Migrations are
+# additive by repo rule, so falling behind is the case that happens; for the
+# other, `make test-db-up` rebuilds from scratch.
+#
 # db-exists separates "absent" (prints false) from "could not ask" (non-zero
 # exit) exactly so this caller can too: a failed probe propagates with its
 # stderr instead of reading as "missing" and force-rebuilding a healthy
@@ -87,7 +111,11 @@ ensure_template() {
     echo "FAIL: could not probe for template ${TEMPLATE_NAME} — fix the error above; a failed probe is not 'missing'" >&2
     return 1
   fi
-  [[ "$exists" = "true" ]] || build_template
+  if [[ "$exists" != "true" ]]; then
+    build_template
+    return
+  fi
+  migrate_template
 }
 
 # make_clone db — drop any stale clone, then copy the migrated template (a fast

--- a/scripts/lib-testdb.sh
+++ b/scripts/lib-testdb.sh
@@ -66,13 +66,32 @@ export TEMPLATE_NAME="${TEMPLATE_NAME:-margince_test}"
 owner_clone_dsn() { local db="$1"; echo "${O_PREFIX}/${db}${O_QUERY:+?$O_QUERY}"; }
 app_clone_dsn()   { local db="$1"; echo "${A_PREFIX}/${db}${A_QUERY:+?$A_QUERY}"; }
 
-# migrate_template — bring the template to head with the same embedded migration
-# set the app uses (cmd/migrate → migrations.Core/Custom, then River). Idempotent
-# by construction: the runner compares the tracking tables against the embedded
-# set, so at head it applies nothing. Prints what it applied — a heal is worth a
-# line, and a silent one reads exactly like a no-op.
+# migrate_template — apply any embedded migration the template has not recorded
+# (cmd/migrate → migrations.Core/Custom, then River). Idempotent: the runner
+# compares the tracking tables against the embedded set, so with nothing missing
+# it applies nothing.
+#
+# It reports a heal and stays SILENT otherwise, and the asymmetry is the point.
+# `migrate up` ends with "schema is at head", which is a stronger claim than it
+# can make: dbmigrate.Up appends versions absent from the tracking table and
+# skips every version already recorded, without checksumming what was applied.
+# A template carrying an EDITED migration, or one whose migration no longer
+# exists at this head, records the version either way — so that line would
+# announce currency over exactly the stale schema this function exists to catch.
+# Passing it through would re-create the silent-staleness bug one level up.
+# What is printed instead says only what actually happened.
 migrate_template() {
-  ( cd backend && go run ./cmd/migrate up --dsn "$(owner_clone_dsn "$TEMPLATE_NAME")" )
+  # rc, not `status`: zsh makes that name read-only, and these helpers are
+  # sourced from an interactive shell often enough to care.
+  local out rc=0
+  out="$( cd backend && go run ./cmd/migrate up --dsn "$(owner_clone_dsn "$TEMPLATE_NAME")" 2>&1 )" || rc=$?
+  if (( rc != 0 )); then
+    echo "$out" >&2
+    return "$rc"
+  fi
+  if [[ "$out" != "applied 0 core+custom + 0 river"* ]]; then
+    echo "test-db: template ${TEMPLATE_NAME} was behind — ${out%%; *}"
+  fi
 }
 
 # build_template — (re)create margince_test and migrate it to head. Fresh each
@@ -94,12 +113,15 @@ build_template() {
 # change you pulled. The full lane never shows it — that path calls
 # build_template — so it bites exactly when you are iterating on one package.
 #
-# Migrating rather than rebuilding is the cheap fix: at head the runner applies
-# nothing, and behind it applies only the delta. What this does NOT heal is a
-# template that has diverged rather than fallen behind — an edited migration, or
-# a checkout that no longer has one the template already applied. Migrations are
-# additive by repo rule, so falling behind is the case that happens; for the
-# other, `make test-db-up` rebuilds from scratch.
+# Migrating rather than rebuilding is the cheap fix: with nothing missing the
+# runner applies nothing, and behind it applies only the delta. What this does
+# NOT heal is a template that has DIVERGED rather than fallen behind — an edited
+# migration, or a checkout that no longer carries one the template already
+# applied. The tracking table records a version, not a checksum, so neither case
+# is even detectable here; migrate_template's silence means "nothing was
+# missing", never "the schema is correct". Migrations are additive by repo rule,
+# so falling behind is the case that happens; for the other, `make test-db-up`
+# rebuilds from scratch.
 #
 # db-exists separates "absent" (prints false) from "could not ask" (non-zero
 # exit) exactly so this caller can too: a failed probe propagates with its
@@ -119,11 +141,43 @@ ensure_template() {
 }
 
 # make_clone db — drop any stale clone, then copy the migrated template (a fast
-# file copy; no re-migration). CREATE ... TEMPLATE needs no session connected to
-# the template, which holds: nothing connects to margince_test after build.
+# file copy; no re-migration).
+#
+# CREATE ... TEMPLATE refuses while ANY session is connected to the source, and
+# one now can be: ensure_template migrates the template on every inner-loop run,
+# so a second `make test-it` started alongside the first can reach its clone
+# while that migration still holds the connection. Before, the inner loop only
+# probed for existence over the maintenance database and never touched the
+# template at all.
+#
+# Retried rather than locked, because the two callers want opposite things from
+# a lock: the parallel lane clones 25 times at once and must not serialize,
+# while the migration must exclude clones. A reader/writer lock in portable
+# shell buys a correctness problem of its own. The window here is one `migrate
+# up` against a template that is nearly always at head — sub-second, and hit
+# only by an overlapping start — so backing off and retrying closes it without
+# constraining the lane. The last failure propagates with its stderr: a clone
+# that cannot be made is fatal, never silently skipped.
+# The retry budget is read INSIDE the function, not from a script-level
+# variable: make_clone is `export -f`'d into xargs worker subshells, which
+# inherit exported variables only — TEMPLATE_NAME above is exported for exactly
+# that reason, and a bare one here would arrive empty in every lane worker.
 make_clone() {
-  local db="$1"
-  db_admin recreate-db --name "$db" --template "$TEMPLATE_NAME" >/dev/null
+  local db="$1" retries="${CLONE_RETRIES:-3}" attempt=1 out rc
+  while :; do
+    rc=0
+    out="$(db_admin recreate-db --name "$db" --template "$TEMPLATE_NAME" 2>&1)" || rc=$?
+    if (( rc == 0 )); then
+      return 0
+    fi
+    if (( attempt >= retries )); then
+      echo "$out" >&2
+      echo "FAIL: could not clone ${TEMPLATE_NAME} into ${db} after ${retries} attempts" >&2
+      return "$rc"
+    fi
+    sleep 1
+    attempt=$(( attempt + 1 ))
+  done
 }
 
 # drop_clone db — remove a throwaway clone. Failures propagate (stderr and

--- a/scripts/lib-testdb.sh
+++ b/scripts/lib-testdb.sh
@@ -84,13 +84,21 @@ migrate_template() {
   # rc, not `status`: zsh makes that name read-only, and these helpers are
   # sourced from an interactive shell often enough to care.
   local out rc=0
-  out="$( cd backend && go run ./cmd/migrate up --dsn "$(owner_clone_dsn "$TEMPLATE_NAME")" 2>&1 )" || rc=$?
+  # stderr is deliberately NOT captured. `go run` writes build and
+  # module-download diagnostics there, so a cold Go cache would put them in
+  # front of the summary this classifies on and report a template at head as
+  # behind. Left alone it goes to the terminal, which is where a real failure
+  # belongs anyway.
+  out="$( cd backend && go run ./cmd/migrate up --dsn "$(owner_clone_dsn "$TEMPLATE_NAME")" )" || rc=$?
   if (( rc != 0 )); then
-    echo "$out" >&2
     return "$rc"
   fi
-  if [[ "$out" != "applied 0 core+custom + 0 river"* ]]; then
-    echo "test-db: template ${TEMPLATE_NAME} was behind — ${out%%; *}"
+  # The summary is the LAST line, matched as its own string rather than as a
+  # prefix of the whole capture — same reason: anything printed ahead of it
+  # must not decide this.
+  local summary="${out##*$'\n'}"
+  if [[ "$summary" != "applied 0 core+custom + 0 river"* ]]; then
+    echo "test-db: template ${TEMPLATE_NAME} was behind — ${summary%%; *}"
   fi
 }
 
@@ -98,7 +106,11 @@ migrate_template() {
 # call so the template can never carry a stale schema. Runs from the repo root;
 # the caller must have cd'd there (both scripts do).
 build_template() {
-  db_admin recreate-db --name "$TEMPLATE_NAME" >/dev/null
+  # Stop here if the recreate failed. The PREVIOUS template survives such a
+  # failure, so migrating on regardless would bring the old one to head and
+  # return success — and `make test-db-up` would report a rebuild that never
+  # happened, over a template whose contents nobody chose.
+  db_admin recreate-db --name "$TEMPLATE_NAME" >/dev/null || return $?
   migrate_template >/dev/null
 }
 
@@ -164,6 +176,14 @@ ensure_template() {
 # that reason, and a bare one here would arrive empty in every lane worker.
 make_clone() {
   local db="$1" retries="${CLONE_RETRIES:-3}" attempt=1 out rc
+  # Validated, not coerced: shell arithmetic reads a non-numeric name as 0,
+  # which would turn the budget into "give up immediately", and an absurd one
+  # into a loop that sleeps its way past any timeout. Either way the operator
+  # asked for something this cannot honour, so say so.
+  if [[ ! "$retries" =~ ^[1-9][0-9]{0,2}$ ]]; then
+    echo "FAIL: CLONE_RETRIES must be a positive integer up to 999, got '${retries}'" >&2
+    return 1
+  fi
   while :; do
     rc=0
     out="$(db_admin recreate-db --name "$db" --template "$TEMPLATE_NAME" 2>&1)" || rc=$?


### PR DESCRIPTION
## The bug

`ensure_template` probed for the template's **existence** and reused whatever it found, however old:

```sh
[[ "$exists" = "true" ]] || build_template
```

A template built before a migration landed then handed every clone a schema behind head. What that produces is thoroughly misleading — tests fail inside the constraint or column the new migration adds, naming code that is correct, in a package unrelated to whatever you pulled.

Hit today: `audit_log_action_check` rejecting `password_link_issued`. Migration `0187` was on `main`; my template predated it; four password-link suites read as broken for it.

## Why it survived

Only the inner loop is exposed. `make test-integration` calls `build_template` and always starts fresh, so the full parallel lane is green while `make test-it` fails — the fast path you iterate on is the one that lies, and the slow path you'd check it against says everything is fine.

## The fix

Migrate the template it found, rather than rebuild it or trust it:

- **at head** → the runner compares the tracking tables against the embedded set and applies nothing
- **behind** → applies only the delta, no rebuild

Cost is a few hundred ms, inside the noise of the `go run` the existence probe already pays (probe alone: 641ms; probe + migrate: 574–854ms across runs).

## Verified

| Case | Result |
|---|---|
| Present but behind (staged as an existing-but-empty template) | `applied 198 core+custom + 7 river migration(s); schema is at head` → 137 tables |
| Present and at head | `applied 0 core+custom + 0 river` |
| Absent | builds, 137 tables |
| Real `make test-it` through the new path | passes, prints the at-head line |

## Limits, stated

This heals a template that has fallen **behind**. It does not heal one that has **diverged** — an edited migration, or a checkout that no longer carries one the template already applied. Migrations are additive by repo rule, so falling behind is the case that occurs; `make test-db-up` still rebuilds from scratch for the other.

The at-head line prints on every `make test-it`. That is deliberate: the thing that was silently wrong is exactly "is this template current", and one line answering it is worth the noise.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the reused test DB template current by migrating it to head instead of trusting it, and removes the misleading “at head” claim. Adds safe clone retries for `make test-it` and hardens output parsing and failure handling.

- **Bug Fixes**
  - `migrate_template`: runs embedded migrations (core/custom + River); reports only what it applied; stays silent when nothing changed; ignores `go run` stderr and classifies by the last line to avoid false “behind” reads.
  - `ensure_template`: migrates existing templates; only builds when missing.
  - `build_template`: stops on recreate failure (does not migrate the old template); then calls `migrate_template`; output suppressed on fresh builds.
  - `make_clone`: retries when the template is busy; reads `CLONE_RETRIES` inside the function for xargs workers; validates it as a positive integer; propagates the final error if exhausted.

<sup>Written for commit d7f16e17c47c71ebc6eaa36b9fb052850886aa58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/550?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database template maintenance by applying pending updates to existing templates.
  * Added clearer reporting when database updates are applied or fail.
  * Improved template cloning reliability by retrying failed attempts and reporting persistent errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->