### PR TITLE
fix(test-lane): one budget rule, reachable from both integration lanes

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -47,12 +47,15 @@ that has no meaning without Postgres.
 
 Where the cost actually is, and what is worth doing about it:
 
-- **#524** — `internal/compose/integration` is half the lane (960 tests) and
-  runs 258–302s against a 300s per-package timeout, so it flakes on a loaded
-  machine. CI shards 12 ways and never sees it; the unsharded local lane and
-  `make test-it` do. The 300s default is documented against the sharded
-  assumption, and the script already bumps to 900s for the whole-package case
-  but gates that on `COVERDIR` rather than on `SHARD_TOTAL == 1`.
+- **#524** — **closed.** `internal/compose/integration` is half the lane (960
+  tests) and ran 258–302s against a 300s per-package timeout, so it flaked on a
+  loaded machine. CI shards 12 ways and never saw it; the unsharded local lane
+  and `make test-it` did. #537 raised the budget to 600s and made the cost report
+  print each package's share of it, so a margin shrinking to nothing is visible
+  before it crosses. The one-package lane kept a hardcoded `-timeout=300s` that
+  no variable could reach, which left `make test-it` on this package failing at
+  a bound the lane itself had already moved; both lanes now resolve the budget
+  through one `resolve_it_timeout` in `scripts/lib-testdb.sh`.
 - **#539** — that package's setup forks about five Postgres backends per test.
   Sharing them measured ~18% (170.9s vs a 209.6s baseline) and is **blocked**:
   the harness drops `cf_*` columns between tests, so a pooled connection

--- a/scripts/lib-testdb.sh
+++ b/scripts/lib-testdb.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Shared helpers for the parallel integration lanes (test-integration-parallel.sh
 # and test-integration-one.sh): parse this repo's owner + app DSNs, clone/drop a
-# throwaway per-package database, and derive a per-slot MinIO bucket. Source
-# this; don't execute it.
+# throwaway per-package database, derive a per-slot MinIO bucket, and resolve the
+# per-package test timeout both lanes answer to. Source this; don't execute it.
 #
 # This repo's clone-per-package test-DB shape:
 #   - TWO roles, not one — MARGINCE_TEST_DSN (owner: migrates + seeds) and
@@ -210,3 +210,37 @@ drop_clone() { local db="$1"; db_admin drop-db --name "$db" >/dev/null; }
 # bucket_for SLOT [BASE] — DNS-compliant private MinIO bucket per slot (the store
 # auto-creates it). Hyphen, never underscore.
 bucket_for() { echo "${2:-${MARGINCE_TEST_BLOBSTORE_BUCKET:-margince-test}}-p${1}"; }
+
+# resolve_it_timeout — set IT_TIMEOUT, the per-package `go test -timeout`, from
+# INTEGRATION_TIMEOUT or the lane default. Both entry points run whole packages
+# against the same suites, so they answer to one budget and one spelling of the
+# rule; a second copy is how the two drift into disagreeing about what a package
+# is allowed to cost. Exits rather than returning on a bad value: a lane that ran
+# on a budget nobody asked for is worse than one that refuses to start.
+#
+# The budget is sized for the slowest package, not the median: compose/integration
+# alone runs within a few seconds of 300s and tips over it under the concurrency
+# the parallel lane itself creates, which reads as a regression in whatever branch
+# happens to be running. 600s is headroom while that package is split.
+#
+# `go test -timeout` also accepts 10m or 1h30s. The parallel lane's budget column
+# reads this as a seconds count, so anything else would price every package
+# against a nonsense denominator and print a percentage nobody can act on.
+# Rejecting the spelling is better than reporting confidently wrong numbers.
+#
+# Zero is rejected separately and matters more: `go test -timeout 0` DISABLES the
+# timeout, so a run that meant to loosen the budget would instead remove the guard
+# entirely and let a hung package sit until the CI job's own limit — the one
+# failure this bound exists to turn into a legible message.
+resolve_it_timeout() {
+  IT_TIMEOUT="${INTEGRATION_TIMEOUT:-600s}"
+  if [[ ! "$IT_TIMEOUT" =~ ^[0-9]+s$ ]]; then
+    echo "FAIL: INTEGRATION_TIMEOUT must be <seconds>s (e.g. 600s), got '${IT_TIMEOUT}'"
+    exit 1
+  fi
+  if (( ${IT_TIMEOUT%s} == 0 )); then
+    echo "FAIL: INTEGRATION_TIMEOUT must be greater than 0s — go test reads 0 as NO timeout, which "\
+"removes the per-package guard rather than widening it"
+    exit 1
+  fi
+}

--- a/scripts/test-integration-one.sh
+++ b/scripts/test-integration-one.sh
@@ -7,12 +7,18 @@
 #   scripts/test-integration-one.sh DIR [RUN]
 #     DIR  repo-root package dir, e.g. backend/internal/compose/integration
 #     RUN  optional -run regex, e.g. TestVoiceProfileMutationsRejectAgents
+#
+# Env:
+#   INTEGRATION_TIMEOUT  go-test timeout, as <seconds>s — the same budget and the
+#                        same rule as the parallel lane, since this runs a whole
+#                        package too
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 # shellcheck source=scripts/lib-testdb.sh
 source "$ROOT/scripts/lib-testdb.sh"
+resolve_it_timeout
 
 DIR="${1:-}"
 RUN="${2:-}"
@@ -49,4 +55,4 @@ echo "test-integration-one: backend $rel ${RUN:+(-run $RUN) }(db=$db)"
        MARGINCE_TEST_APP_DSN="$(app_clone_dsn "$db")" \
        MARGINCE_TEST_BLOBSTORE_BUCKET="$(bucket_for one)" \
        MARGINCE_TEST_REDIS_DB="${MARGINCE_TEST_REDIS_DB:-15}" \
-    go test -p 1 -tags=integration -v -count=1 -timeout=300s "${run_flag[@]+"${run_flag[@]}"}" "$rel" )
+    go test -p 1 -tags=integration -v -count=1 -timeout="$IT_TIMEOUT" "${run_flag[@]+"${run_flag[@]}"}" "$rel" )

--- a/scripts/test-integration-parallel.sh
+++ b/scripts/test-integration-parallel.sh
@@ -50,8 +50,9 @@
 #                           (discovery/assigned/ran/meta) and per-package binary
 #                           covdata pods for the CI fan-in to reconcile + merge;
 #                           coverage instrumentation is on iff this is set
-#   INTEGRATION_TIMEOUT     per-package go-test timeout, as <seconds>s
-#                           (default 600s; the budget column parses this)
+#   INTEGRATION_TIMEOUT     per-package go-test timeout, as <seconds>s (default
+#                           600s; the budget column parses this). Resolved in
+#                           scripts/lib-testdb.sh, shared with the one-package lane
 #   MARGINCE_TEST_DSN / MARGINCE_TEST_APP_DSN   owner + app DSNs (Makefile defaults)
 set -euo pipefail
 
@@ -91,31 +92,11 @@ if [[ -n "$SHARD_OUT" ]]; then
   export COVERDIR
 fi
 
-# Per-package go-test timeout. The budget is sized for the slowest package, not
-# the median: `compose/integration` alone runs within a few seconds of 300s and
-# tips over it under the concurrency this lane itself creates, which reads as a
-# regression in whatever branch happens to be running. 600s is headroom while
-# that package is split and per-package timings are reported (issue #538).
-# Overridable via INTEGRATION_TIMEOUT.
-IT_TIMEOUT="${INTEGRATION_TIMEOUT:-600s}"
-# `go test -timeout` also accepts 10m or 1h30s. The budget column below reads
-# this as a seconds count, so anything else would price every package against a
-# nonsense denominator and print a percentage nobody can act on. Rejecting the
-# spelling is better than reporting confidently wrong numbers.
-#
-# Zero is rejected separately and matters more: `go test -timeout 0` DISABLES the
-# timeout, so a run that meant to loosen the budget would instead remove the
-# guard entirely and let a hung package sit until the CI job's own limit — the
-# one failure this bound exists to turn into a legible message.
-if [[ ! "$IT_TIMEOUT" =~ ^[0-9]+s$ ]]; then
-  echo "FAIL: INTEGRATION_TIMEOUT must be <seconds>s (e.g. 600s), got '${IT_TIMEOUT}'"
-  exit 1
-fi
-if (( ${IT_TIMEOUT%s} == 0 )); then
-  echo "FAIL: INTEGRATION_TIMEOUT must be greater than 0s — go test reads 0 as NO timeout, which "\
-"removes the per-package guard rather than widening it"
-  exit 1
-fi
+# Per-package go-test timeout and its budget rule — shared with the one-package
+# lane (scripts/lib-testdb.sh resolve_it_timeout), so both cost a package the same.
+resolve_it_timeout
+# A single-shard coverage run is the one case that executes whole packages WITH
+# instrumentation on top, so it alone earns more than the shared budget.
 if [[ -n "${COVERDIR:-}" && -z "${INTEGRATION_TIMEOUT:-}" ]] && (( SHARD_TOTAL == 1 )); then
   IT_TIMEOUT=900s
 fi


### PR DESCRIPTION
## What

`resolve_it_timeout` in `scripts/lib-testdb.sh` — the per-package `go test -timeout` and its validation, in one place, called by both integration lanes.

## Why

#537 moved the parallel lane's budget to 600s and added the `% of budget` column. `scripts/test-integration-one.sh` did not come along:

```sh
go test -p 1 -tags=integration -v -count=1 -timeout=300s …
```

Inline, no variable, no env override. So `make test-it DIR=backend/internal/compose/integration` — the inner-loop command for the one package this whole thread is about — still failed at a bound the lane it belongs to had already moved, and could not be nursed past it even deliberately. That is precisely when someone iterating on that package needs to.

Two entry points ran whole packages against the same suites while disagreeing about what a package is allowed to cost. Rather than copy the new default across, the budget rule moves to the lib both scripts already source. The `SHARD_TOTAL == 1` coverage bump stays in the parallel lane, where the condition it reads lives.

This is the remainder of #524. The budget half landed in #537; this is the sibling call site that got missed — the shape CLAUDE.md's rule 1 is about ("fixed the case under review, missed the sibling copy").

## Verification

13 assertions against the real `resolve_it_timeout`, sourced the way each lane sources it:

```
  ok   default                            0|600s
  ok   explicit 900s                      0|900s
  ok   10m rejected                       1|FAIL: INTEGRATION_TIMEOUT must be <seconds>s
  ok   1h30s rejected                     1|FAIL: INTEGRATION_TIMEOUT must be <seconds>s
  ok   bare number reject                 1|FAIL: INTEGRATION_TIMEOUT must be <seconds>s
  ok   0s rejected                        1|FAIL: INTEGRATION_TIMEOUT must be greater tha
  ok   test-integration-parallel.sh       calls resolve_it_timeout / uses $IT_TIMEOUT
  ok   test-integration-one.sh            calls resolve_it_timeout / uses $IT_TIMEOUT
  ok   no hardcoded -timeout= left in scripts/
```

`bash -n` clean on all three scripts; `make check-backend` green. Behaviour for the parallel lane is unchanged by construction — the same default, the same two guards, the same messages, relocated.

**Not run:** the integration lane itself. It rebuilds the shared migrated template, and a parallel session on this machine is working on that template's staleness logic. No Go changed.

## Note on the comment move

The relocated comment drops its `(issue #538)` reference — history belongs to git, and the invariant reads the same without it.

Closes #524. The package-size half is #546.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
