### PR TITLE
UI: one dropdown, a refurbished sign-in screen, and a Core that holds still

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -281,6 +281,9 @@ The `backend/internal/{modules,platform,shared}` triad — the DAG is
 - `frontend/` — the Vite/React web UI: a standalone static build served
   separately from the API binary (which serves `/v1` only — no embedded
   SPA); `make frontend-check` / `make dev` exist at the repo root.
+  Every interactive control comes from `frontend/src/design-system/` —
+  its README is the catalog to read before hand-rolling one, and a native
+  `<select>` fails `frontend/scripts/check-native-controls.sh`.
 - `extensions/<name>/` — the stable extension tier (ADR-0069): each unit
   is its own Go module importing ONLY the marker-allowlisted
   `backend/pkg/**` surface; presence under `extensions/` is the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,15 +179,18 @@ numbers appear here when releases start.
 - **The sign-in screen is two halves of a page, not a card in a pane.** The
   identity region runs full-bleed and is divided from the form by one
   hairline; the wordmark sits in the page's top-left corner on the split
-  layout and above the form when the layout stacks; the form is a single
-  400px measure with its heading, provider buttons, fields, locale row and
-  fine print all on one left edge, and the provider buttons are stacked
-  full-width so every way in presents the same target. Spacing scales with
-  the viewport off the `--space` scale rather than sitting at fixed pixels.
-  On phones (≤560px) the identity region drops **entirely, sphere
-  included** — the form is the only thing that screen is for — and the
-  boundary statement it is obliged to make stays, as the line above the
-  form.
+  layout and above the form when the layout stacks; each half reads down its
+  own centre line, and both carry the same inset at every width above the
+  phone. The form is a single 400px measure — heading, provider buttons
+  (stacked full width, so every way in presents the same target), fields,
+  locale row and fine print — with the fields the one thing that stays left,
+  because a label centred over a line of typing points at nothing. On phones
+  (≤560px) the identity region drops **entirely**: the sphere, the limits and
+  the AI's own sentence with them, because the form is the only thing that
+  screen is for. That leaves the phone surface disclosing nothing about the
+  AI behind the installation, which is a deliberate departure from
+  ADR-0076 Decision 1 at that width and owed back to the spec; every wider
+  layout still makes the disclosure in full.
 - **The sign-in screen's entry animation belongs to the page load.** The
   staggered fades and the typed statement ran again on every React remount
   of the surface, which reads as the page reloading under the reader. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,7 +189,7 @@ numbers appear here when releases start.
   the AI's own sentence with them, because the form is the only thing that
   screen is for. That leaves the phone surface disclosing nothing about the
   AI behind the installation, which is a deliberate departure from
-  ADR-0076 Decision 1 at that width and owed back to the spec; every wider
+  ADR-0076 Decision 1 at that width, tracked as issue #562; every wider
   layout still makes the disclosure in full.
 - **The sign-in screen's entry animation belongs to the page load.** The
   staggered fades and the typed statement ran again on every React remount

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,43 @@ numbers appear here when releases start.
 
 ### Changed
 
+- **Every dropdown in the product is the design system's, not the
+  browser's.** `Select` is a button trigger plus a portalled listbox with
+  the full keyboard contract (arrows, Home/End, typeahead, Escape without
+  committing, focus back to the trigger), so the option list takes the
+  product's tokens instead of the platform's — including inside a
+  scrolling toolbar, where it anchors to the trigger and flips when the
+  room below runs out. Callers pass `options` and receive the VALUE in
+  `onChange`; a `<select>`, `<option>` or `<optgroup>` anywhere under
+  `frontend/src` outside that one component now fails
+  `make frontend-check`. `frontend/src/design-system/README.md` is the
+  catalog to read before hand-rolling any control.
+- **The sign-in screen is two halves of a page, not a card in a pane.** The
+  identity region runs full-bleed and is divided from the form by one
+  hairline; the wordmark sits in the page's top-left corner on the split
+  layout and above the form when the layout stacks; the form is a single
+  400px measure with its heading, provider buttons, fields, locale row and
+  fine print all on one left edge, and the provider buttons are stacked
+  full-width so every way in presents the same target. Spacing scales with
+  the viewport off the `--space` scale rather than sitting at fixed pixels.
+  On phones (≤560px) the identity region drops **entirely, sphere
+  included** — the form is the only thing that screen is for — and the
+  boundary statement it is obliged to make stays, as the line above the
+  form.
+- **The sign-in screen's entry animation belongs to the page load.** The
+  staggered fades and the typed statement ran again on every React remount
+  of the surface, which reads as the page reloading under the reader. The
+  choreography is now marked spent on the document once it has run its
+  course, so a remount renders the surface already arrived while a real
+  page load still gets the introduction.
+- **The Core holds its position.** The sphere's 11-second vertical drift is
+  gone everywhere; it still breathes, and the beat is still what carries
+  its state.
+- **The Core goes still while the window does not have focus.** Both halves
+  of it — the WebGL liquid and the CSS rhythms (breath, sheen, halo, feed) —
+  stop off one document-level `focus`/`blur` signal and resume with it, so
+  a Core behind another window costs nothing and the sphere and its glow
+  can never disagree about whether it is moving.
 - **The passport cap an operation spends comes from the contract.** Every
   `x-mcp-tool` annotation now declares its `scope` alongside its tier, and
   the REST agent gate spends that declared cap instead of a hardcoded

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -312,6 +312,9 @@ The `backend/internal/{modules,platform,shared}` triad — the DAG is
 - `frontend/` — the Vite/React web UI: a standalone static build served
   separately from the API binary (which serves `/v1` only — no embedded
   SPA); `make frontend-check` / `make dev` exist at the repo root.
+  Every interactive control comes from `frontend/src/design-system/` —
+  its README is the catalog to read before hand-rolling one, and a native
+  `<select>` fails `frontend/scripts/check-native-controls.sh`.
 - `extensions/<name>/` — the stable extension tier (ADR-0069): each unit
   is its own Go module importing ONLY the marker-allowlisted
   `backend/pkg/**` surface; presence under `extensions/` is the

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 # one target here that invokes the compiler directly instead of delegating.
 GO ?= go
 
-.PHONY: help install ai-routing-local dev-fresh check check-backend check-q check-go check-gates check-fe build test test-v test-cover test-integration e2e-ai e2e-ai-report ai-probe test-db-up test-it test-integration-serial bench-perf lint arch-lint vet gen gen-types gen-types-check drift composition check-composition test-extensions db-up db-init db-wait migrate migrate-up migrate-down run psql redis-cli tidy dev dev-stop dev-logs clean tools tools-go infra-up infra-down infra-logs infra-reset seed-dev seed-dev-db seed-reset verify-boot frontend-check frontend-e2e fe-install fe-typecheck fe-lint fe-build fe-preview fe-format fe-test ds-purity font-lock icon-lint fitness-jurisdiction storybook fe-uat craft-static craft-residue check-craft-doc secret-scan test-secret-scan check-image-pins contract-breaking-check test-lanes go-file-length rls-store-path no-jurisdiction pkg-freeze hooks sbom sbom-normalize sbom-supplement sbom-parity sbom-validate sbom-sign sbom-check
+.PHONY: help install ai-routing-local dev-fresh check check-backend check-q check-go check-gates check-fe build test test-v test-cover test-integration e2e-ai e2e-ai-report ai-probe test-db-up test-it test-integration-serial bench-perf lint arch-lint vet gen gen-types gen-types-check drift composition check-composition test-extensions db-up db-init db-wait migrate migrate-up migrate-down run psql redis-cli tidy dev dev-stop dev-logs clean tools tools-go infra-up infra-down infra-logs infra-reset seed-dev seed-dev-db seed-reset verify-boot frontend-check frontend-e2e fe-install fe-typecheck fe-lint fe-build fe-preview fe-format fe-test ds-purity font-lock icon-lint ds-spacing native-controls fitness-jurisdiction storybook fe-uat craft-static craft-residue check-craft-doc secret-scan test-secret-scan check-image-pins contract-breaking-check test-lanes go-file-length rls-store-path no-jurisdiction pkg-freeze hooks sbom sbom-normalize sbom-supplement sbom-parity sbom-validate sbom-sign sbom-check
 
 # Bare `make` lists every command instead of running the first target.
 .DEFAULT_GOAL := help
@@ -170,6 +170,10 @@ icon-lint:
 ## the scale). Diff-scoped vs origin/main; use the --space-* scale or a layout class.
 ds-spacing:
 	frontend/scripts/check-ds-spacing.sh
+## native-controls — no browser-drawn dropdown: `<select>`/`<option>` outside
+## design-system/select.tsx, which is the ONE select this product renders.
+native-controls:
+	frontend/scripts/check-native-controls.sh
 
 ## seed-dev — create/refresh the demo workspace (demo-workspace,
 ## admin@demo.test / demo-password-123) through the public API, then seed
@@ -187,7 +191,7 @@ verify-boot:
 	./scripts/verify-boot.sh
 
 
-## frontend-check — the frontend merge lane. The three token-purity gates
+## frontend-check — the frontend merge lane. The design-system gates
 ## run first: cheap fail-closed greps
 ## on top of the vitest conformance suite, so the discipline holds even if
 ## the test tree regresses. The gen:api + diff pair is the
@@ -199,6 +203,7 @@ frontend-check:
 	frontend/scripts/check-font-lock.sh
 	frontend/scripts/check-icon-glyph.sh
 	frontend/scripts/check-ds-spacing.sh
+	frontend/scripts/check-native-controls.sh
 	cd frontend && pnpm install --frozen-lockfile && pnpm gen:api && \
 		{ git diff --exit-code -- src/api/schema.d.ts src/api/public-events.ts || \
 			{ echo "frontend types drifted from the backend contracts — commit the regenerated src/api/*.d.ts (printed above)"; exit 1; }; } && \

--- a/STATUS.md
+++ b/STATUS.md
@@ -412,6 +412,100 @@ Vite/React web UI. What is deliberately still stubbed (answering explicit
 The merge gate (`make check`), the real-Postgres integration lane
 (`make test-integration`), and the live-boot job are all green.
 
+## Session pickup — 2026-08-07 (one dropdown, one login screen, and a Core that holds still, branch `fix/ui-select-orb-login`)
+
+Five reported UI defects. Four are invariants; the fifth is a screen redesign.
+
+- **The product has ONE dropdown, and it is not the browser's.**
+  `design-system/select.tsx` is a button trigger plus a portalled listbox
+  (`role="combobox"` + `role="listbox"`, `aria-activedescendant`, arrow/Home/End
+  movement, typeahead, Escape without committing, focus back to the trigger).
+  Portalled and `position: fixed` because most call sites sit in a toolbar inside
+  `.scroll`, where an absolutely positioned popup is clipped or scrolls away from
+  its trigger; it flips above the trigger when the room below runs out.
+  The API takes DATA — `options` plus `onChange(value)` — because a listbox has
+  no `event.target.value` and threading a synthetic event through would be a lie
+  about where the value came from. All 30 call sites across 19 screens and every
+  test that drove a native control are migrated; `select-testing.ts` gives the
+  suites one `pickOption(user, control, label)` so thirty files do not each encode
+  the popup's markup.
+  - **The gate, not the sweep, is what keeps it true**:
+    `frontend/scripts/check-native-controls.sh` (in `make frontend-check`) refuses
+    `<select>`, `<option>` and `<optgroup>` anywhere under `frontend/src` outside
+    that one named file. `<option>` matters as much as `<select>`: nothing here
+    ever wrote a raw `<select>` — the screens fed option children to the *atom* —
+    so a gate watching only `<select` would have called an entirely un-migrated
+    tree clean.
+  - **Two things only the running app could show, both from the control changing
+    ELEMENT.** `.list-toolbar > select.input` is an element-qualified rule, so it
+    stopped matching the moment the trigger became a button: every list filter
+    grew to the full width of the page, one per line, with no test able to see it.
+    It now names the control's class. And the deals sort control, which opens on
+    no explicit sort, drew an empty box — a native select rendered the same
+    nothing, but a drawn one reads as a control that failed to load, so it carries
+    a placeholder. That placeholder then failed the axe sweep at
+    `--textTertiary`: a placeholder is text on an ACTIVE control, so 1.4.3's
+    inactive-control exemption does not cover it, and it stops at `--textMeta`.
+    The lesson for the next primitive that replaces a native element: grep the
+    stylesheets for rules that name the old tag before you believe the migration
+    is done.
+  - **Where to look before hand-rolling a control** is now written down:
+    `frontend/src/design-system/README.md` catalogues every primitive, its file,
+    its story, and the gates. `frontend/README.md`, `AGENTS.md` and `CLAUDE.md`
+    each point at it in two lines. This is the answer to "how does the next agent
+    find the right element" in general, not only for Select.
+- **The sign-in screen is two halves of a page.** The identity region was an
+  inset card in a pane, which gave the eye two shapes to place before it reached
+  the form; it is now a full-bleed half divided from the task by one hairline.
+  The wordmark sits in the page's top-left corner on the split layout (the task
+  column carries `z-index: 1` for it — the wordmark's own z-index resolves inside
+  `.auth-task-in`, a stacking context because of its filling opacity animation,
+  so from in there nothing can paint over the identity column) and returns to
+  being the form's first line when the layout stacks. One 400px measure, one left
+  edge for heading, buttons, fields, locale row and fine print, provider buttons
+  stacked full width, and spacing that scales with the viewport off the `--space`
+  scale.
+  - **Phones drop the identity region entirely, sphere included** (≤560px). The
+    68px orb parked beside the disclosure line was the last thing competing with
+    the form for a first look. The disclosure SENTENCE stays — it is the ADR-0076
+    obligation the aside was only one way of meeting.
+  - Re-measured at 320 / 390 / 640×400 (200% zoom) / 720 / 1440: zero horizontal
+    overflow, the 48px submit inside the viewport at every width, all four limits
+    rendered wherever the region shows.
+- **An entry animation belongs to the page load, not to the mount.** The staggered
+  fades and the typed statement replayed on every React remount of the surface,
+  which reads as the page reloading under the reader. `useDocumentIntro`
+  (`design-system/motion.ts`) marks the DOCUMENT once the choreography has run its
+  course, so a later mount renders the surface already arrived while a real load
+  still gets the introduction. Marked at the END of the sequence rather than at
+  mount, which is what survives React's development double-mount — the second
+  mount lands mid-flight and still plays.
+  - **The trigger was never reproduced locally.** Simulated `visibilitychange`,
+    real tab switches and window swaps all left the surface mounted with its text
+    intact, and the one focus-coupled query on that screen (`useMe`,
+    `refetchOnWindowFocus: "always"`) does not re-branch the tree. The fix is
+    therefore aimed at the invariant: replay is impossible from ANY remount cause.
+    A tab Chrome has discarded and reloaded is a genuine page load and correctly
+    plays again.
+- **The Core holds its position.** The 11-second vertical drift on `.core-tilt` is
+  deleted with its keyframes rather than overridden. The element stays: it is the
+  `place-items: center` stage the glass is centred in. Breath, sheen, halo and
+  feed are untouched — the beat is still what carries state.
+- **The Core goes still while the window does not have focus.** Both halves stop
+  off ONE signal: `design-system/window-focus.ts` owns a single `focus`/`blur`
+  pair for the document, parks the WebGL loop through a subscription and pauses
+  the CSS rhythms through `data-window-blurred` on `<html>`. Paused, not
+  `animation: none`, so returning does not snap the sphere to its unanimated size.
+  - This does not break the loop's standing rule — **only a condition whose END is
+    announced by an event may park it.** `document.hasFocus()` is read once per
+    attach to seed the state and never polled; the resume arrives as `focus`. A
+    poll answers only for the instant it is asked, and a missed resume is a
+    permanently frozen sphere, which is indistinguishable from a broken shader.
+  - jsdom reports no focus, so a Core in a test parks after one frame unless the
+    suite says the window is focused. `margince-core-liquid.test.tsx` pins that in
+    its `beforeEach`; any future test that renders a Core and expects motion needs
+    the same.
+
 ## Session pickup — 2026-08-06 (app chrome: the account menu, the app's scrollbars, and one orb, branch `fix/shell-chrome-and-one-orb`)
 
 Seven reported chrome defects, fixed as five invariants rather than five patches.

--- a/STATUS.md
+++ b/STATUS.md
@@ -478,8 +478,9 @@ Five reported UI defects. Four are invariants; the fifth is a screen redesign.
     kept the boundary sentence as `.auth-phone-disclosure`; that element is gone.
     Above the breakpoint the disclosure is intact. The departure is stated in
     `auth.css` beside the rule that makes it and pinned in both directions by
-    `e2e/ac.spec.ts`, so it cannot drift back by accident — **owed upstream: the
-    spec has to reconcile Decision 1 with a phone surface that is the task alone.**
+    `e2e/ac.spec.ts`, so it cannot drift back by accident — **owed upstream as
+    issue #562: the spec has to reconcile Decision 1 with a phone surface that is
+    the task alone.**
   - Re-measured at 320 / 390 / 640×400 (200% zoom) / 720 / 1440: zero horizontal
     overflow, the 48px submit inside the viewport at every width, all four limits
     rendered wherever the region shows, axe clean.

--- a/STATUS.md
+++ b/STATUS.md
@@ -461,17 +461,28 @@ Five reported UI defects. Four are invariants; the fifth is a screen redesign.
   column carries `z-index: 1` for it — the wordmark's own z-index resolves inside
   `.auth-task-in`, a stacking context because of its filling opacity animation,
   so from in there nothing can paint over the identity column) and returns to
-  being the form's first line when the layout stacks. One 400px measure, one left
-  edge for heading, buttons, fields, locale row and fine print, provider buttons
-  stacked full width, and spacing that scales with the viewport off the `--space`
-  scale.
-  - **Phones drop the identity region entirely, sphere included** (≤560px). The
-    68px orb parked beside the disclosure line was the last thing competing with
-    the form for a first look. The disclosure SENTENCE stays — it is the ADR-0076
-    obligation the aside was only one way of meeting.
+  being the form's first line when the layout stacks. Both halves read ONE pair of
+  padding values (`--authPadBlock` / `--authPadInline`, arithmetic on the `--space`
+  scale) at every width above the phone, so the inset does not change when the
+  layout turns from two columns into two rows: the air on this surface comes from a
+  400px column centred in half a screen, not from its gutter, and a viewport clamp
+  only moved the edges while making the desktop and the tablet two different pages.
+  Both columns read down their own centre line, the fields excepted — a label
+  centred over a line of typing points at nothing.
+  - **Phones drop the identity region entirely** (≤560px): the sphere, the limits,
+    and the AI's own sentence with them (founder ruling, 2026-08-07). Everything
+    that introduced the system was competing with the form for the first look, and
+    on a phone the form is the only thing the screen is for.
+  - **That is a partial ADR-0076 Decision 1 below 561px, and it is now total.** The
+    surface discloses nothing about the AI at phone width — the earlier compromise
+    kept the boundary sentence as `.auth-phone-disclosure`; that element is gone.
+    Above the breakpoint the disclosure is intact. The departure is stated in
+    `auth.css` beside the rule that makes it and pinned in both directions by
+    `e2e/ac.spec.ts`, so it cannot drift back by accident — **owed upstream: the
+    spec has to reconcile Decision 1 with a phone surface that is the task alone.**
   - Re-measured at 320 / 390 / 640×400 (200% zoom) / 720 / 1440: zero horizontal
     overflow, the 48px submit inside the viewport at every width, all four limits
-    rendered wherever the region shows.
+    rendered wherever the region shows, axe clean.
 - **An entry animation belongs to the page load, not to the mount.** The staggered
   fades and the typed statement replayed on every React remount of the surface,
   which reads as the page reloading under the reader. `useDocumentIntro`

--- a/docs/reference/make-targets.md
+++ b/docs/reference/make-targets.md
@@ -94,9 +94,9 @@ root gates (each is a small script; all merge-blocking):
 
 | Target | What it does |
 |---|---|
-| `frontend-check` | The frontend gate: the design-system purity/font-lock/icon-glyph/spacing script gates, a `pnpm gen:api` + `schema.d.ts` drift check, then `pnpm check` (Biome lint + vitest + tsc + vite build) (needs node + pnpm) |
+| `frontend-check` | The frontend gate: the design-system purity/font-lock/icon-glyph/spacing/native-control script gates, a `pnpm gen:api` + `schema.d.ts` drift check, then `pnpm check` (Biome lint + vitest + tsc + vite build) (needs node + pnpm) |
 | `fe-install` / `fe-lint` / `fe-test` / `fe-build` / `fe-format` / `fe-preview` | The individual frontend steps (`pnpm` wrappers) |
-| `ds-purity` / `font-lock` / `icon-lint` / `ds-spacing` | The design-system script gates, runnable alone |
+| `ds-purity` / `font-lock` / `icon-lint` / `ds-spacing` / `native-controls` | The design-system script gates, runnable alone. `native-controls` is the no-browser-drawn-dropdown gate: `<select>`/`<option>` outside `design-system/select.tsx` |
 | `gen-types` / `gen-types-check` | Aliases for backend `gen` / `drift` |
 | `seed-dev` | API-seed the demo workspace against a running stack (idempotent), then the API-less extras (`seed-dev-db`) |
 | `verify-boot` | Prove a running, seeded stack end to end: seeded-admin login, seeded people over `/v1`, frontend production build — pure client, fails loudly |

--- a/docs/reference/make-targets.md
+++ b/docs/reference/make-targets.md
@@ -96,7 +96,7 @@ root gates (each is a small script; all merge-blocking):
 |---|---|
 | `frontend-check` | The frontend gate: the design-system purity/font-lock/icon-glyph/spacing/native-control script gates, a `pnpm gen:api` + `schema.d.ts` drift check, then `pnpm check` (Biome lint + vitest + tsc + vite build) (needs node + pnpm) |
 | `fe-install` / `fe-lint` / `fe-test` / `fe-build` / `fe-format` / `fe-preview` | The individual frontend steps (`pnpm` wrappers) |
-| `ds-purity` / `font-lock` / `icon-lint` / `ds-spacing` / `native-controls` | The design-system script gates, runnable alone. `native-controls` is the no-browser-drawn-dropdown gate: `<select>`/`<option>` outside `design-system/select.tsx` |
+| `ds-purity` / `font-lock` / `icon-lint` / `ds-spacing` / `native-controls` | The design-system script gates, runnable alone. `native-controls` is the no-browser-drawn-dropdown gate: `<select>`, `<option>` or `<optgroup>` anywhere under `frontend/src` outside `design-system/select.tsx` |
 | `gen-types` / `gen-types-check` | Aliases for backend `gen` / `drift` |
 | `seed-dev` | API-seed the demo workspace against a running stack (idempotent), then the API-less extras (`seed-dev-db`) |
 | `verify-boot` | Prove a running, seeded stack end to end: seeded-admin login, seeded people over `/v1`, frontend production build — pure client, fails loudly |

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -85,6 +85,10 @@ default.
 
 ## Layout
 
+- **`src/design-system/README.md` is the catalog — read it before hand-rolling a
+  control.** Every interactive control comes from that directory; a native
+  `<select>` or a hand-rolled dropdown is a defect, and
+  `scripts/check-native-controls.sh` refuses one. `pnpm storybook` shows them all.
 - `src/design-system/` — tokens (Ledger Green canon, pinned by
   `tokens.test.ts`) plus `brand.css`, the DERIVED layer: every value there is a
   `color-mix()` of a canonical token, never a new hex, so it follows the dark

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -150,11 +150,23 @@ default.
 6. The service worker never caches or fabricates a `/v1` response.
 7. WCAG 2.2 AA (axe) + the perceived-perf budget in the e2e lane.
 8. The unauthenticated surface at 390px / 320px / 200% zoom (ADR-0076): no
-   horizontal scroll, the primary action reachable, nothing hidden to fit, the
-   task region above the identity region below 960px, one h1 and it is the task,
-   the Core out of the a11y tree, and axe. The rest of the §3.8 sweep walks
-   authenticated routes only, so login had never been measured at any width —
-   the first run of this found a contrast defect in the field labels.
+   horizontal scroll, the primary action reachable, the identity region whole
+   wherever it is shown at all, the task region above it below 960px, one h1 and
+   it is the task, the Core out of the a11y tree, and axe. The rest of the §3.8
+   sweep walks authenticated routes only, so login had never been measured at any
+   width — the first run of this found a contrast defect in the field labels.
+
+   **One deliberate departure, at phone width.** Below 561px the surface is the
+   task alone: the identity region is dropped whole — the sphere, the limits and
+   the AI's own sentence — because on a phone the form is the only thing the
+   screen is for (founder ruling, 2026-08-07). So this surface does NOT disclose
+   the AI at that width, which ADR-0076 Decision 1 asks for at every width. It is
+   a departure rather than a defect: stated in `src/screens/auth.css` beside the
+   rule that makes it, pinned in both directions by `e2e/ac.spec.ts` so it cannot
+   drift back, and owed upstream for the spec to reconcile (issue #562). Every
+   wider layout makes the disclosure in full. Where the region IS shown it shows
+   all of itself — no limit dropped to fit, which is the rule this replaced a
+   `display: none` sweep to get.
 
 ## Working agreements
 

--- a/frontend/e2e/ac.spec.ts
+++ b/frontend/e2e/ac.spec.ts
@@ -399,12 +399,23 @@ test("AC-create-2: the palette's New-deal action opens the create form; only ope
   // still offers open stages only.
   const stageSelect = page.getByRole("dialog").getByLabel("Phase");
   await expect(stageSelect).toBeVisible();
-  const stageNames = await stageSelect.locator("option").allTextContents();
+  // The choices exist only while the popup is open, and the popup is portalled
+  // to the body — so it is located from the page, not from inside the dialog.
+  await stageSelect.click();
+  const stageNames = await page
+    .locator('[role="listbox"]')
+    .getByRole("option")
+    .allTextContents();
   expect(stageNames.filter(Boolean)).toEqual([
     "Qualify",
     "Proposal",
     "Negotiation",
   ]);
+  // Looking is all this AC needs, so the list is put away the way it was
+  // opened — a second press on the trigger. NOT Escape: the surrounding Modal
+  // listens for it too and would take the whole create form down with it.
+  await stageSelect.click();
+  await expect(page.locator('[role="listbox"]')).toHaveCount(0);
   await page.getByLabel("Deal-Name").fill("Neuer Deal");
   await page.getByLabel("Wert").fill("480");
   await page.getByRole("button", { name: "Anlegen" }).click();
@@ -752,11 +763,12 @@ test.describe("ADR-0076: the unauthenticated surface", () => {
   // because that is what the layout sees; deviceScaleFactor would change the
   // pixel ratio and nothing about the breakpoints.
   // `identity` is whether the identity REGION is part of the surface at that
-  // width. Below 561px it is not: the phone layout is the task alone, one
-  // full-height card, with the Core in its header (see the ≤560 block in
-  // auth.css). That is a deliberate reversal of Decision 1 for phones only —
-  // raised in STATUS.md — and it is pinned here rather than left to drift,
-  // because the alternative is a suite that still forbids the shipped design.
+  // width. Below 561px it is not: the phone layout is the task alone — the
+  // region goes, and the Core goes with it (see the ≤560 block in auth.css),
+  // because on a phone the form is the only thing the screen is for. That is a
+  // deliberate reversal of Decision 1 for phones only — raised in STATUS.md —
+  // and it is pinned here rather than left to drift, because the alternative is
+  // a suite that still forbids the shipped design.
   const NARROW = [
     { label: "390px mobile", width: 390, height: 844, identity: false },
     { label: "320px narrow", width: 320, height: 568, identity: false },
@@ -817,12 +829,12 @@ test.describe("ADR-0076: the unauthenticated surface", () => {
       // rendered height, because a count alone passes on a hidden node.
       //
       // Where it is NOT — the phone layout — the region is absent by design and
-      // what remains is one card with the Core in its header. But the DISCLOSURE
-      // is not the region's to take with it: the Core is `aria-hidden`, so
-      // dropping the aside without the phone line leaves a phone user, and every
-      // screen-reader user on one, told nothing about the AI at all. Exactly one
-      // of the two statements is live at any width, so neither branch can pass
-      // by saying it twice.
+      // what remains is the task alone: no aside, and no sphere either. But the
+      // DISCLOSURE is not the region's to take with it: the Core is
+      // `aria-hidden`, so dropping the aside without the phone line leaves a
+      // phone user, and every screen-reader user on one, told nothing about the
+      // AI at all. Exactly one of the two statements is live at any width, so
+      // neither branch can pass by saying it twice.
       test("shows the identity region whole, or not at all", async ({
         page,
       }) => {
@@ -839,7 +851,10 @@ test.describe("ADR-0076: the unauthenticated surface", () => {
           await expect(phoneLine).toBeHidden();
         } else {
           await expect(region).toBeHidden();
-          await expect(page.locator("[data-core-state]")).toHaveCount(1);
+          // Hidden, not merely present: the sphere is drawn by the same markup at
+          // every width, so a count would pass on a Core the phone layout still
+          // shows — which is the thing this width is supposed to be free of.
+          await expect(page.locator("[data-core-state]")).toBeHidden();
           // The class, not the tag: `RaillessFrame` already wraps every
           // rail-less screen in a `<main>`, so the task region is a `<div>` —
           // a second `<main>` here would be an invalid, duplicate landmark.

--- a/frontend/e2e/ac.spec.ts
+++ b/frontend/e2e/ac.spec.ts
@@ -829,26 +829,23 @@ test.describe("ADR-0076: the unauthenticated surface", () => {
       // rendered height, because a count alone passes on a hidden node.
       //
       // Where it is NOT — the phone layout — the region is absent by design and
-      // what remains is the task alone: no aside, and no sphere either. But the
-      // DISCLOSURE is not the region's to take with it: the Core is
-      // `aria-hidden`, so dropping the aside without the phone line leaves a
-      // phone user, and every screen-reader user on one, told nothing about the
-      // AI at all. Exactly one of the two statements is live at any width, so
-      // neither branch can pass by saying it twice.
+      // what remains is the task alone: no aside, no sphere, and no second copy
+      // of the region's copy either. The phone surface is the form (founder
+      // ruling, 2026-08-07): the disclosure the aside makes is a property of the
+      // region, and at this width the region is not on the screen for it to be a
+      // property of.
       test("shows the identity region whole, or not at all", async ({
         page,
       }) => {
         await page.goto("/");
         const region = page.locator("aside.auth-identity");
         const limits = page.locator(".auth-limits li");
-        const phoneLine = page.locator(".auth-phone-disclosure");
         if (identity) {
           await expect(region).toBeVisible();
           await expect(limits).toHaveCount(4);
           for (let index = 0; index < 4; index += 1) {
             await expect(limits.nth(index)).toBeVisible();
           }
-          await expect(phoneLine).toBeHidden();
         } else {
           await expect(region).toBeHidden();
           // Hidden, not merely present: the sphere is drawn by the same markup at
@@ -859,8 +856,6 @@ test.describe("ADR-0076: the unauthenticated surface", () => {
           // rail-less screen in a `<main>`, so the task region is a `<div>` —
           // a second `<main>` here would be an invalid, duplicate landmark.
           await expect(page.locator(".auth-task")).toBeVisible();
-          await expect(phoneLine).toBeVisible();
-          await expect(phoneLine).not.toBeEmpty();
         }
       });
     });
@@ -954,7 +949,7 @@ test.describe("ADR-0076: the unauthenticated surface", () => {
 
     // The divider sits between the providers and the form it labels.
     const divider = page.locator(".auth-or");
-    await expect(divider).toHaveText("oder per E-Mail");
+    await expect(divider).toHaveText("oder");
     const buttonsY = (await page.locator(".auth-sso").boundingBox())?.y ?? 0;
     const dividerY = (await divider.boundingBox())?.y ?? 0;
     const fieldsY = (await page.locator(".auth-fields").boundingBox())?.y ?? 0;

--- a/frontend/e2e/ac.spec.ts
+++ b/frontend/e2e/ac.spec.ts
@@ -852,6 +852,15 @@ test.describe("ADR-0076: the unauthenticated surface", () => {
           // every width, so a count would pass on a Core the phone layout still
           // shows — which is the thing this width is supposed to be free of.
           await expect(page.locator("[data-core-state]")).toBeHidden();
+          // NONE of the region's copy survives either, named part by part: the
+          // region hides as one box, so a future rule that lifted a line of it
+          // back into the task column would leave this width claiming to be the
+          // form alone while a sentence about the AI sat above the fields.
+          await expect(page.locator(".auth-kicker")).toBeHidden();
+          await expect(page.locator(".auth-statement")).toBeHidden();
+          // The LIST, not its items: a locator that resolves to four elements is a
+          // strict-mode violation rather than an assertion.
+          await expect(page.locator(".auth-limits")).toBeHidden();
           // The class, not the tag: `RaillessFrame` already wraps every
           // rail-less screen in a `<main>`, so the task region is a `<div>` —
           // a second `<main>` here would be an invalid, duplicate landmark.

--- a/frontend/scripts/check-native-controls.sh
+++ b/frontend/scripts/check-native-controls.sh
@@ -23,7 +23,9 @@
 #
 # Comments are stripped before matching: a `<select>` inside a comment is a
 # cross-reference (this replaced that), which is exactly how select.tsx and its
-# neighbours cite the thing they exist to remove.
+# neighbours cite the thing they exist to remove. A `//` that follows a colon is
+# NOT a comment — it is the scheme separator in a URL, and treating it as one
+# would blank the rest of a line that may still hold real markup.
 #
 # Companion to the vitest suites rather than a substitute: this is the
 # fail-closed grep arm, so the discipline holds even if the test tree regresses.
@@ -73,6 +75,13 @@ strip_comments() {
         }
         block_at = index(line, "/*")
         eol_at = index(line, "//")
+        # A scheme separator, not a comment: skip past `://` and keep looking.
+        while (eol_at > 1 && substr(line, eol_at - 1, 1) == ":") {
+          out = out substr(line, 1, eol_at + 1)
+          line = substr(line, eol_at + 2)
+          block_at = index(line, "/*")
+          eol_at = index(line, "//")
+        }
         if (eol_at > 0 && (block_at == 0 || eol_at < block_at)) {
           out = out substr(line, 1, eol_at - 1)
           line = ""

--- a/frontend/scripts/check-native-controls.sh
+++ b/frontend/scripts/check-native-controls.sh
@@ -23,9 +23,15 @@
 #
 # Comments are stripped before matching: a `<select>` inside a comment is a
 # cross-reference (this replaced that), which is exactly how select.tsx and its
-# neighbours cite the thing they exist to remove. A `//` that follows a colon is
-# NOT a comment — it is the scheme separator in a URL, and treating it as one
-# would blank the rest of a line that may still hold real markup.
+# neighbours cite the thing they exist to remove.
+#
+# STRING LITERALS are stripped first, and that ordering is the whole subtlety: a
+# `//` inside a string is not a comment, and a URL carries them in two places —
+# after the scheme, and in a path (`https://host/a//b`). Treating either as a
+# comment blanks the rest of the line, which for a fail-closed gate means the
+# markup it exists to catch could sit past a URL and never be seen. So the
+# scanner tracks whether it is inside a quote, and only unquoted `//` and `/*`
+# begin a comment.
 #
 # Companion to the vitest suites rather than a substitute: this is the
 # fail-closed grep arm, so the discipline holds even if the test tree regresses.
@@ -65,32 +71,31 @@ strip_comments() {
     {
       line = $0
       out = ""
-      while (length(line) > 0) {
+      quote = ""
+      i = 1
+      n = length(line)
+      while (i <= n) {
+        ch = substr(line, i, 1)
+        two = substr(line, i, 2)
         if (inblock) {
-          close_at = index(line, "*/")
-          if (close_at == 0) { line = ""; break }
-          line = substr(line, close_at + 2)
-          inblock = 0
+          # Inside a block comment: nothing counts until it closes.
+          if (two == "*/") { inblock = 0; i += 2 } else { i += 1 }
           continue
         }
-        block_at = index(line, "/*")
-        eol_at = index(line, "//")
-        # A scheme separator, not a comment: skip past `://` and keep looking.
-        while (eol_at > 1 && substr(line, eol_at - 1, 1) == ":") {
-          out = out substr(line, 1, eol_at + 1)
-          line = substr(line, eol_at + 2)
-          block_at = index(line, "/*")
-          eol_at = index(line, "//")
+        if (quote != "") {
+          # Inside a string: keep it, and let a backslash escape the next char so
+          # a quote it protects does not end the literal early.
+          out = out ch
+          if (ch == "\\" && i < n) { out = out substr(line, i + 1, 1); i += 2; continue }
+          if (ch == quote) { quote = "" }
+          i += 1
+          continue
         }
-        if (eol_at > 0 && (block_at == 0 || eol_at < block_at)) {
-          out = out substr(line, 1, eol_at - 1)
-          line = ""
-          break
-        }
-        if (block_at == 0) { out = out line; line = ""; break }
-        out = out substr(line, 1, block_at - 1)
-        line = substr(line, block_at + 2)
-        inblock = 1
+        if (ch == "\"" || ch == "'"'"'" || ch == "`") { quote = ch; out = out ch; i += 1; continue }
+        if (two == "//") { break }
+        if (two == "/*") { inblock = 1; i += 2; continue }
+        out = out ch
+        i += 1
       }
       print out
     }

--- a/frontend/scripts/check-native-controls.sh
+++ b/frontend/scripts/check-native-controls.sh
@@ -33,6 +33,13 @@
 # scanner tracks whether it is inside a quote, and only unquoted `//` and `/*`
 # begin a comment.
 #
+# Two states survive a line ending, because two constructs legally span lines: a
+# block comment, and a TEMPLATE literal. A quote state reset at every newline
+# would read the second line of a multi-line template as ordinary code, so a `//`
+# in it would blank that line and hide whatever followed. A single- or
+# double-quoted string cannot span a line, so those DO reset — an unterminated one
+# is a syntax error, and resetting stops one bad line from blanking the file.
+#
 # Companion to the vitest suites rather than a substitute: this is the
 # fail-closed grep arm, so the discipline holds even if the test tree regresses.
 #
@@ -67,11 +74,12 @@ echo "==> Native-control check (${#FILES[@]} files under frontend/src)"
 # a block comment spanning lines (which is also the `{/* … */}` JSX form).
 strip_comments() {
   awk '
-    BEGIN { inblock = 0 }
+    BEGIN { inblock = 0; intemplate = 0 }
     {
       line = $0
       out = ""
-      quote = ""
+      # A template literal left open by the previous line is still open here.
+      quote = intemplate ? "`" : ""
       i = 1
       n = length(line)
       while (i <= n) {
@@ -97,6 +105,9 @@ strip_comments() {
         out = out ch
         i += 1
       }
+      # Carried to the next line: a template that has not closed. Quoted strings
+      # cannot span lines, so anything else ends here.
+      intemplate = (quote == "`") ? 1 : 0
       print out
     }
   ' "$1"

--- a/frontend/scripts/check-native-controls.sh
+++ b/frontend/scripts/check-native-controls.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Native-control gate: no product surface may render a browser-drawn dropdown.
+#
+# A `<select>` is the one control the platform paints for itself. Its closed face
+# takes our tokens; the option list behind it — fill, type, highlight, scrollbar,
+# and on a phone a whole system sheet — does not, and cannot: `option` is not
+# stylable in any engine we ship to. So on a screen built entirely from
+# src/design-system/ a native dropdown reads as a hole in the product, and the
+# defect is invisible in review because the closed control looks correct. The
+# replacement is `Select` in src/design-system/select.tsx — a button plus a
+# portalled listbox — which is also the only file this gate exempts.
+#
+# Fails on `<select`, `<option` and `<optgroup` anywhere under frontend/src except
+# design-system/select.tsx, in any *.ts / *.tsx — tests and stories included,
+# because a test that drives a native control is a test of the wrong control, and
+# a story catalogues what we ship.
+#
+# All three, not just the element that names the gate: `<option>` is what the
+# native dropdown is BUILT from, it is meaningless anywhere else, and it is what a
+# half-finished migration leaves behind — a screen still handing option children
+# to a control that no longer takes them. Catching only `<select` would call that
+# tree clean.
+#
+# Comments are stripped before matching: a `<select>` inside a comment is a
+# cross-reference (this replaced that), which is exactly how select.tsx and its
+# neighbours cite the thing they exist to remove.
+#
+# Companion to the vitest suites rather than a substitute: this is the
+# fail-closed grep arm, so the discipline holds even if the test tree regresses.
+#
+# Usage: frontend/scripts/check-native-controls.sh   (wired into `make frontend-check`)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SRC_DIR="$(cd "$SCRIPT_DIR/.." && pwd)/src"
+
+# The ONE exemption, and it is a full PATH rather than a name or a glob: widening
+# it to a directory is how a second hand-rolled dropdown gets in beside the real
+# one, and matching on the basename alone would exempt any `select.tsx` anywhere
+# in the tree — including a screen that wrote its own.
+FILES=()
+while IFS= read -r -d '' f; do FILES+=("$f"); done < <(
+  find "$SRC_DIR" -type f \( -name "*.ts" -o -name "*.tsx" \) \
+    -not -path "$SRC_DIR/design-system/select.tsx" \
+    -print0 2>/dev/null
+)
+
+# An empty scan means the gate is pointed at the wrong tree — fail closed.
+if [[ "${#FILES[@]}" -eq 0 ]]; then
+  echo "FAIL: native-control check found no files under $SRC_DIR — the gate is miswired" >&2
+  exit 1
+fi
+
+echo "==> Native-control check (${#FILES[@]} files under frontend/src)"
+
+# Blank out every comment while KEEPING the line count, so a hit still reports the
+# author's own line number. Handles `//` to end of line, `/* … */` on one line, and
+# a block comment spanning lines (which is also the `{/* … */}` JSX form).
+strip_comments() {
+  awk '
+    BEGIN { inblock = 0 }
+    {
+      line = $0
+      out = ""
+      while (length(line) > 0) {
+        if (inblock) {
+          close_at = index(line, "*/")
+          if (close_at == 0) { line = ""; break }
+          line = substr(line, close_at + 2)
+          inblock = 0
+          continue
+        }
+        block_at = index(line, "/*")
+        eol_at = index(line, "//")
+        if (eol_at > 0 && (block_at == 0 || eol_at < block_at)) {
+          out = out substr(line, 1, eol_at - 1)
+          line = ""
+          break
+        }
+        if (block_at == 0) { out = out line; line = ""; break }
+        out = out substr(line, 1, block_at - 1)
+        line = substr(line, block_at + 2)
+        inblock = 1
+      }
+      print out
+    }
+  ' "$1"
+}
+
+# Each element followed by anything that is not another identifier character:
+# catches `<select>`, `<select ` and a `<select` whose attributes wrap onto the
+# next line. The design-system component is `<Select`, capitalised, so it is not a
+# hit — and neither is `<Option`, should anything ever be called that.
+PATTERN='<(select|option|optgroup)([^a-zA-Z0-9]|$)'
+
+EXIT=0
+for f in "${FILES[@]}"; do
+  hits=$(strip_comments "$f" | grep -nE "$PATTERN" || true)
+  if [[ -n "$hits" ]]; then
+    if [[ "$EXIT" == "0" ]]; then
+      echo ""
+      echo "FAIL: native dropdown markup outside design-system/select.tsx"
+      EXIT=1
+    fi
+    while IFS= read -r hit; do
+      echo "  ${f#"$SRC_DIR"/}:${hit}"
+    done <<< "$hits"
+  fi
+done
+
+if [[ "$EXIT" == "0" ]]; then
+  echo "PASS — no native dropdown under frontend/src"
+  exit 0
+fi
+
+echo ""
+echo "Use Select from src/design-system/select.tsx; see src/design-system/README.md."
+echo "In tests, drive it with pickOption from src/design-system/select-testing.ts."
+exit $EXIT

--- a/frontend/scripts/check-native-controls.sh
+++ b/frontend/scripts/check-native-controls.sh
@@ -11,9 +11,11 @@
 # portalled listbox — which is also the only file this gate exempts.
 #
 # Fails on `<select`, `<option` and `<optgroup` anywhere under frontend/src except
-# design-system/select.tsx, in any *.ts / *.tsx — tests and stories included,
-# because a test that drives a native control is a test of the wrong control, and
-# a story catalogues what we ship.
+# design-system/select.tsx, in any *.ts / *.tsx / *.js / *.jsx — tests and stories
+# included, because a test that drives a native control is a test of the wrong
+# control, and a story catalogues what we ship. The tree is TypeScript today and
+# the plain-JS extensions cost nothing to scan; a gate whose coverage depends on
+# which extension a file happens to carry is a gate with a way around it.
 #
 # All three, not just the element that names the gate: `<option>` is what the
 # native dropdown is BUILT from, it is meaningless anywhere else, and it is what a
@@ -25,13 +27,21 @@
 # cross-reference (this replaced that), which is exactly how select.tsx and its
 # neighbours cite the thing they exist to remove.
 #
-# STRING LITERALS are stripped first, and that ordering is the whole subtlety: a
-# `//` inside a string is not a comment, and a URL carries them in two places —
-# after the scheme, and in a path (`https://host/a//b`). Treating either as a
-# comment blanks the rest of the line, which for a fail-closed gate means the
-# markup it exists to catch could sit past a URL and never be seen. So the
-# scanner tracks whether it is inside a quote, and only unquoted `//` and `/*`
-# begin a comment.
+# STRING LITERALS are recognised before comments, and that ordering is the whole
+# subtlety: a `//` inside a string does not begin a comment, and a URL carries them
+# in two places — after the scheme, and in a path (`https://host/a//b`). Treating
+# either as a comment blanks the rest of the line, which for a fail-closed gate
+# means the markup it exists to catch could sit past a URL and never be seen. So
+# the scanner tracks whether it is inside a quote, and only an unquoted `//` or
+# `/*` begins a comment.
+#
+# A string's CONTENT is kept rather than blanked, and that is the deliberate half:
+# markup can be built inside a template literal, so a `<select>` in there is a
+# native dropdown that would ship. The cost is that a non-rendered reference in a
+# string — a doc line, an example — is reported too. That is the direction to be
+# wrong in: a false positive is one edit away from silence, and a miss is a
+# browser-drawn dropdown nobody sees until it is on a screen. Prose is the place
+# for a cross-reference, which is what the comment stripping is for.
 #
 # Two states survive a line ending, because two constructs legally span lines: a
 # block comment, and a TEMPLATE literal. A quote state reset at every newline
@@ -56,7 +66,8 @@ SRC_DIR="$(cd "$SCRIPT_DIR/.." && pwd)/src"
 # in the tree — including a screen that wrote its own.
 FILES=()
 while IFS= read -r -d '' f; do FILES+=("$f"); done < <(
-  find "$SRC_DIR" -type f \( -name "*.ts" -o -name "*.tsx" \) \
+  find "$SRC_DIR" -type f \
+    \( -name "*.ts" -o -name "*.tsx" -o -name "*.js" -o -name "*.jsx" \) \
     -not -path "$SRC_DIR/design-system/select.tsx" \
     -print0 2>/dev/null
 )

--- a/frontend/src/app/shell.css
+++ b/frontend/src/app/shell.css
@@ -129,8 +129,15 @@
 }
 
 /* List toolbar row: search grows, sort/filters/toggle sit fixed-width beside
- * it. `select.input`/`input.input` default to width:100% (base.css), so the
- * width:auto override is required or they fight the search field for width. */
+ * it. Anything wearing `.input` defaults to width:100% (base.css), so the
+ * width:auto override is required or they fight the search field for width.
+ *
+ * The dropdown is matched by its CLASS, not by an element name. It used to be a
+ * `<select>` and the rule said so; it is a `<button>` now
+ * (design-system/select.tsx), and an element-qualified selector silently stopped
+ * applying — every filter in this row grew to the full width of the page, one per
+ * line. A rule that names a tag is a rule that breaks when the control changes
+ * shape, so this one names what the control IS. */
 .list-toolbar {
   display: flex;
   flex-wrap: wrap;
@@ -142,7 +149,7 @@
   flex: 1 1 260px;
   max-width: 360px;
 }
-.list-toolbar > select.input,
+.list-toolbar > .select-control,
 .list-toolbar > input.input {
   width: auto;
   flex: 0 1 200px;
@@ -155,7 +162,7 @@
 }
 @media (max-width: 520px) {
   .list-toolbar > .input-icon,
-  .list-toolbar > select.input,
+  .list-toolbar > .select-control,
   .list-toolbar > input.input {
     flex-basis: 100%;
     max-width: none;

--- a/frontend/src/design-system/README.md
+++ b/frontend/src/design-system/README.md
@@ -1,0 +1,112 @@
+# `src/design-system/` — the Margince design system
+
+Read this before you hand-roll a control.
+
+## The rule
+
+**Every interactive control comes from this directory.** A native `<select>`, a
+hand-rolled dropdown, a bespoke menu, a second modal, one more "just this once"
+chip — each of those is a defect, not a shortcut. Two reasons, and the second is
+the one that bites:
+
+1. A browser-drawn control is drawn by the browser. `<select>` takes our tokens
+   on its closed face and none of them on the list behind it (`option` is not
+   stylable in any engine we ship to), so it reads as a hole in a product built
+   entirely from these files.
+2. A copy drifts silently. The primitives here exist because the same row was
+   already hand-rolled in eleven places, each with its own gap, its own focus
+   ring and its own idea of what a label is — and every one of them looked fine
+   in review on its own.
+
+If what you need is genuinely not here, add it **here**, with a story and a
+spec, and it becomes the one spelling. Copy never lives in a primitive: words
+arrive through props, translated by the caller with `t()`.
+
+## What this directory already gives you
+
+| Primitive | For | File | Story |
+|---|---|---|---|
+| `Button` | The one button: `primary` / `ghost` / `danger`, `small` | `atoms.tsx` | ✅ |
+| `Badge` | A status pill in the six tones | `atoms.tsx` | ✅ |
+| `Avatar` | A person's or company's chip: monogram, optional logo, optional per-name tint | `atoms.tsx` | ✅ |
+| `TextInput` | The one text field | `atoms.tsx` | ✅ |
+| `SearchField` | A text field with the search affordance | `atoms.tsx` | ✅ |
+| `Textarea` | The one multi-line field | `atoms.tsx` | ✅ |
+| **`Select`** | **The one dropdown: a button trigger plus a portalled listbox. Never a `<select>`** | **`select.tsx`** | ✅ |
+| `Checkbox` / `Radio` | A tick with its label as the other half of the click target | `atoms.tsx` | ✅ |
+| `Field` | The label-above-control row every form is built from; owns the id and hands the control `{ id, required, aria-describedby }` | `atoms.tsx` | ✅ |
+| `MoneyInput` | An amount with its currency, formatted at the presentation edge | `moneyinput.tsx` | ✅ |
+| `SegmentedControl` | A small closed set of options, all visible at once | `atoms.tsx` | ✅ |
+| `RecordPicker` | Search → candidates → pick, for choosing an existing record | `recordpicker.tsx` | ✅ |
+| `PassportSelect` / `ScopeChips` | Which agent passport, and the scopes it carries | `passportselect.tsx` | — |
+| `Modal` | The one dialog: portalled, Escape-closing, Tab kept inside | `atoms.tsx` | ✅ |
+| `ConfirmModal` | A dialog that asks before something irreversible | `confirmmodal.tsx` | ✅ |
+| `OverflowMenu` | The verbs a record offers but a reader rarely wants | `atoms.tsx` | ✅ |
+| `Disclosure` | A section the reader opens when they want it | `atoms.tsx` | ✅ |
+| `Card` / `EmptyState` / `SectionHeader` / `Skeleton` / `Kbd` | Page furniture: surface, nothing-here, heading row, loading placeholder, key cap | `atoms.tsx` | ✅ |
+| `StatCard` / `AttainmentRing` | One reading with the basis it was drawn from; the server's attainment band as an arc | `atoms.tsx` | ✅ |
+| `DataTable` | A simple column/row table with optional row navigation | `atoms.tsx` | ✅ |
+| `EvidenceMark` | The ONE §4 provenance affordance: a dotted underline on a value a person did not type, opening to where it came from | `evidencemark.tsx` | ✅ |
+| `AutonomyDot` | The 🟢/🟡 autonomy semantics as a token component — never an emoji glyph | `trust.tsx` | ✅ |
+| `EvidenceChip` / `ConfidenceMeter` / `ProvenanceTag` | Where a value came from, how sure we are, who captured it. Inside `EvidenceMark` and on the staging surfaces — never stacked under a field | `trust.tsx` | ✅ |
+| `ApprovalGate` / `StagingCard` / `StagedProposal` | Staged-not-real state and the Accept / Edit / Dismiss triad | `trust.tsx` | ✅ |
+| `FieldDiff` | The inline old→new value diff; a null side reads as a marker, never a blank | `trust.tsx` | ✅ |
+| `PassportChip` | An agent passport id, mono so it reads as an identifier | `trust.tsx` | ✅ |
+| `RoleBadge` / `FieldGuard` | A principal's role, and a withheld value that reads as withheld rather than absent | `rbac.tsx` | — |
+| `ExplainNumber` | A converted aggregate opening into its contributing rows (FX lineage) | `explain.tsx` | — |
+| `MarginceCoreScene` | The product's one piece of AI identity, in its closed eight-state vocabulary. `aria-hidden`; callers pass `state` and never restyle. `margince-core-liquid.tsx` / `margince-core-feed.tsx` are its rendering ladder, not a caller's API | `margince-core.tsx` | ✅ |
+| `MarginceWorkbench` | The in-app agent workbench: steps, runtime chip, the Core in context | `margince-workbench.tsx` | — |
+| `PipelineBoard` / `DealCard` | The pipeline surface and its cards | `composed.tsx` | — |
+| `RecordView` | The record page shell: identity, readings, timeline | `composed.tsx` | ✅ |
+| `GroupedTimelineList` / `TimelineRow` / `MorningBriefItem` | The activity timeline, grouped, and one brief line | `composed.tsx` | via `RecordView` |
+| `ProviderMark` | A federated provider's own sign-in mark — the ONE file allowed literal colours, because another company's colours are not ours to tokenise | `provider-mark.tsx` | — |
+| `usePrefersReducedMotion` / `useTypeStream` / `useDocumentIntro` | Motion, with one rule: reduced motion jumps to the END state, never to nothing | `motion.ts` | — |
+| `subscribeToWindowFocus` and friends | Whether this window has focus — one signal for the draw loop and the stylesheet alike | `window-focus.ts` | — |
+
+Tokens and sheets, none of which a caller redeclares: `tokens.css` (the Ledger
+Green canon, pinned by `tokens.test.ts` — the only file where a literal colour
+may appear), `brand.css` (the derived layer: `color-mix()` over a canonical
+token, never a new hex), `base.css`, and the per-component sheets a component
+imports itself. `interaction.stories.tsx` catalogues the colours the *browser*
+owns — caret, checkbox tick, scrollbar thumb, selection — which are set once at
+the document root and belong to no component.
+
+## Seeing them
+
+```sh
+cd frontend && pnpm storybook      # the catalog on :6006, light and dark
+```
+
+The Theme control in the toolbar flips `data-theme` exactly the way the shell
+does, so every token re-resolves — check both before you call a surface done.
+Stories live beside their component as `<name>.stories.tsx`; that co-location is
+also what the change-scoped capture gate keys on
+(`frontend/scripts/fe-uat.mjs`).
+
+## Driving a control in a test
+
+`Select` is a button and a portalled listbox, so `userEvent.selectOptions` does
+not apply to it. Use the one helper:
+
+```ts
+import { pickOption } from "../design-system/select-testing";
+
+await pickOption(user, screen.getByRole("combobox", { name: "Stage" }), "Won");
+```
+
+## The gates that enforce this
+
+All of them run in `make frontend-check`, and the script gates are the
+fail-closed grep arm on top of the vitest suites — the discipline holds even if
+the test tree regresses.
+
+| Gate | What it refuses |
+|---|---|
+| `frontend/scripts/check-native-controls.sh` | `<select>` / `<option>` / `<optgroup>` anywhere under `src/` except `design-system/select.tsx` — no browser-drawn dropdown |
+| `frontend/scripts/check-ds-purity.sh` | A hex literal or `rgb()`/`hsl()`/`oklch()` outside `tokens.css` |
+| `frontend/scripts/check-font-lock.sh` | A fourth type family |
+| `frontend/scripts/check-icon-glyph.sh` | An emoji glyph in a source string — Lucide only |
+| `frontend/scripts/check-ds-spacing.sh` | New raw-px margin/padding/gap outside this tier (diff-scoped) |
+| `design-system/conformance.test.ts` | Hard-coded user-facing copy, the same colour and font rules, one stylesheet per class namespace |
+| `design-system/tokens.test.ts` | A token whose value drifted from the design canon |
+| `e2e/` (axe) | WCAG 2.2 AA on every core screen, plus the 390px no-horizontal-scroll sweep |

--- a/frontend/src/design-system/atoms.css
+++ b/frontend/src/design-system/atoms.css
@@ -467,9 +467,9 @@
   border-color: var(--accent);
   box-shadow: 0 0 0 3px var(--accentLight);
 }
-select.input {
-  cursor: pointer;
-}
+/* No `select.input` rule: there is no native dropdown in this product. The
+   Margince select's trigger is a button that reads `.input` for the same field
+   surface and owns its own layout in select.css. */
 
 /* The Checkbox/Radio row: control, then its words, on one line the whole of
    which is the click target.

--- a/frontend/src/design-system/atoms.stories.tsx
+++ b/frontend/src/design-system/atoms.stories.tsx
@@ -17,12 +17,12 @@ import {
   Radio,
   SectionHeader,
   SegmentedControl,
-  Select,
   Skeleton,
   StatCard,
   Textarea,
   TextInput,
 } from "./atoms";
+import { Select } from "./select";
 
 // Stories are the render surface the change-scoped fe-uat capture gate drives
 // (frontend/scripts/fe-uat.mjs): a change to atoms.tsx re-renders these in a
@@ -85,23 +85,36 @@ export const Avatars: Story = {
   ),
 };
 
-// The four field controls in one column, which is the point of the story: a
-// text input, a dropdown and a textarea stacked the way a form stacks them is
-// the only way to see that their type size, padding, height and focus ring
-// actually agree. Reviewed one at a time they always look fine.
+// The field controls in one column, which is the point of the story: a text
+// input, a dropdown and a textarea stacked the way a form stacks them is the
+// only way to see that their type size, padding, height and focus ring actually
+// agree. Reviewed one at a time they always look fine.
+//
+// The dropdown is the Select from select.tsx, and it is here for exactly that
+// comparison — its own states live in select.stories.tsx.
 export const Fields: Story = {
-  render: () => (
+  render: () => <FieldsRow />,
+};
+
+function FieldsRow() {
+  const [stage, setStage] = useState("proposal");
+  return (
     <div className="form-stack" style={{ maxWidth: "22rem" }}>
       <Field label="Deal name">
         {(control) => <TextInput {...control} defaultValue="Globex renewal" />}
       </Field>
       <Field label="Stage" required>
         {(control) => (
-          <Select {...control} defaultValue="proposal">
-            <option value="qualify">Qualify</option>
-            <option value="proposal">Proposal</option>
-            <option value="won">Won</option>
-          </Select>
+          <Select
+            {...control}
+            options={[
+              { value: "qualify", label: "Qualify" },
+              { value: "proposal", label: "Proposal" },
+              { value: "won", label: "Won" },
+            ]}
+            value={stage}
+            onChange={setStage}
+          />
         )}
       </Field>
       <Field label="Note" hint="Only the deal's followers will see this.">
@@ -114,8 +127,8 @@ export const Fields: Story = {
         )}
       </Field>
     </div>
-  ),
-};
+  );
+}
 
 // A disabled control and a long label that wraps — the two states a field
 // catalog usually omits and a real form always reaches.

--- a/frontend/src/design-system/atoms.test.tsx
+++ b/frontend/src/design-system/atoms.test.tsx
@@ -7,10 +7,19 @@ import {
   Field,
   OverflowMenu,
   Radio,
-  Select,
   Textarea,
   TextInput,
 } from "./atoms";
+import { Select } from "./select";
+
+// The dropdown these cases pair with a Field is the Select from select.tsx — a
+// button and a portalled listbox, not a native `<select>`. Its own behaviour is
+// specified in select.test.tsx; here it stands in for "a control a Field wires
+// up", which is the only thing these cases are about.
+const STAGES = [
+  { value: "won", label: "Won" },
+  { value: "lost", label: "Lost" },
+];
 
 afterEach(cleanup);
 
@@ -93,22 +102,11 @@ it("keeps Radios sharing a name mutually exclusive", async () => {
 // `.share-reason`). Dropping either class silently unstyles the control, so the
 // merge is asserted rather than assumed.
 it("merges a caller's className with the atom's own", () => {
-  render(
-    <>
-      <Textarea aria-label="Body" className="compose-body" />
-      <Select aria-label="Stage" className="stage-picker">
-        <option value="won">Won</option>
-      </Select>
-    </>,
-  );
+  render(<Textarea aria-label="Body" className="compose-body" />);
 
   expect([...screen.getByLabelText("Body").classList].sort()).toEqual([
     "compose-body",
     "textarea",
-  ]);
-  expect([...screen.getByLabelText("Stage").classList].sort()).toEqual([
-    "input",
-    "stage-picker",
   ]);
 });
 
@@ -124,9 +122,12 @@ it("pairs a Field's label with its control, and two Fields never collide", () =>
       </Field>
       <Field label="Stage">
         {(control) => (
-          <Select {...control}>
-            <option value="won">Won</option>
-          </Select>
+          <Select
+            {...control}
+            options={STAGES}
+            value="won"
+            onChange={() => {}}
+          />
         )}
       </Field>
     </>,
@@ -167,9 +168,12 @@ it("marks a required Field once for the eye and once for the control", () => {
   render(
     <Field label="Role" required>
       {(control) => (
-        <Select {...control}>
-          <option value="admin">Admin</option>
-        </Select>
+        <Select
+          {...control}
+          options={[{ value: "admin", label: "Admin" }]}
+          value="admin"
+          onChange={() => {}}
+        />
       )}
     </Field>,
   );
@@ -179,6 +183,8 @@ it("marks a required Field once for the eye and once for the control", () => {
   // Queried by label TEXT it would read "Role *" — which is the visible string,
   // not the announced one.
   const control = screen.getByRole("combobox", { name: "Role" });
-  expect(control.hasAttribute("required")).toBe(true);
+  // aria-required, not `required`: the trigger is a button, and a button carries
+  // no constraint validation for the attribute to drive.
+  expect(control.getAttribute("aria-required")).toBe("true");
   expect(screen.getByText("*").getAttribute("aria-hidden")).toBe("true");
 });

--- a/frontend/src/design-system/atoms.tsx
+++ b/frontend/src/design-system/atoms.tsx
@@ -3,7 +3,6 @@ import {
   type ButtonHTMLAttributes,
   type InputHTMLAttributes,
   type ReactNode,
-  type SelectHTMLAttributes,
   type TextareaHTMLAttributes,
   useEffect,
   useId,
@@ -141,21 +140,16 @@ export function SearchField(props: InputHTMLAttributes<HTMLInputElement>) {
 }
 
 /**
- * Select and Textarea carry no label of their own, exactly like TextInput: the
- * label is composed outside them, by the `.field` wrapper a form uses or by a
- * screen's own richer shell. What they own is the ONE spelling of the control's
- * surface, so a dropdown in a create form and one in settings cannot drift.
+ * Textarea carries no label of its own, exactly like TextInput: the label is
+ * composed outside it, by the `.field` wrapper a form uses or by a screen's own
+ * richer shell. What it owns is the ONE spelling of the control's surface, so a
+ * note field in a create form and one in settings cannot drift.
  *
- * A `select` reads `.input` rather than a class of its own — the two controls
- * are the same field on screen, and `select.input` in atoms.css adds only the
- * pointer cursor a native dropdown needs.
+ * The dropdown is NOT here: `Select` in select.tsx is a button and a portalled
+ * listbox, because a native `<select>` draws its own option list in the
+ * platform's idiom and no CSS reaches inside it. It still reads `.input` for its
+ * closed face — a dropdown and a text input are the same field on screen.
  */
-export function Select(props: SelectHTMLAttributes<HTMLSelectElement>) {
-  return (
-    <select {...props} className={`input ${props.className ?? ""}`.trim()} />
-  );
-}
-
 export function Textarea(props: TextareaHTMLAttributes<HTMLTextAreaElement>) {
   return (
     <textarea

--- a/frontend/src/design-system/margince-core-liquid.test.tsx
+++ b/frontend/src/design-system/margince-core-liquid.test.tsx
@@ -6,6 +6,7 @@ import "@testing-library/jest-dom/vitest";
 import { cleanup, render } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CoreLiquid } from "./margince-core-liquid";
+import { WINDOW_BLURRED_ATTRIBUTE } from "./window-focus";
 
 // vite.config.ts doesn't enable globals, so @testing-library/react's own
 // auto-cleanup never runs here: without this, the rendered CoreLiquid is
@@ -75,6 +76,12 @@ describe("CoreLiquid", () => {
     vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(
       fakeGl(),
     );
+    // jsdom's document never has focus, and an unfocused window parks the Core
+    // (see window-focus.ts) — so left alone every case here would measure a
+    // parked loop and the counts below would stop meaning anything. The default
+    // fixture is therefore a window somebody is looking at; the cases about
+    // losing focus say so themselves.
+    vi.spyOn(document, "hasFocus").mockReturnValue(true);
   });
 
   afterEach(() => {
@@ -215,6 +222,130 @@ describe("CoreLiquid", () => {
       // And the pause ENDS. A stop with no guaranteed way back is a frozen
       // sphere, which is indistinguishable from a shader that failed.
       expect(draws).toBeGreaterThan(whileVisible);
+    });
+
+    it("stops while the window has no focus and resumes when it comes back", () => {
+      render(<CoreLiquid state="working" />);
+      vi.advanceTimersByTime(300);
+      const whileFocused = draws;
+      expect(whileFocused).toBeGreaterThan(0);
+
+      window.dispatchEvent(new Event("blur"));
+      vi.advanceTimersByTime(5000);
+      // A window sitting behind another one is not being watched, and the tab is
+      // still "visible" the whole time — so `document.hidden` cannot see this
+      // case at all.
+      expect(draws).toBe(whileFocused);
+
+      window.dispatchEvent(new Event("focus"));
+      vi.advanceTimersByTime(300);
+      expect(draws).toBeGreaterThan(whileFocused);
+    });
+
+    it("draws its first frame even when it mounts into an unfocused window", () => {
+      // The one read of `hasFocus` there is: seeding the state at subscribe time.
+      vi.spyOn(document, "hasFocus").mockReturnValue(false);
+      render(<CoreLiquid state="working" />);
+      vi.advanceTimersByTime(2000);
+      // Exactly one frame, and then nothing. An undrawn canvas is blank, and a
+      // blank sphere is indistinguishable from a broken one, so the first frame
+      // is owed even to a Core nobody is looking at yet; the next two seconds of
+      // them are not.
+      expect(draws).toBe(1);
+      // One rAF for the frame it drew, at most one more for the callback that
+      // found nobody watching and parked. A loop still running would be ~48.
+      expect(wakeups).toBeLessThanOrEqual(2);
+
+      // `hasFocus` stays mocked false on purpose: the resume must come from the
+      // EVENT. A predicate that polled `document.hasFocus()` instead would never
+      // see this window come back.
+      window.dispatchEvent(new Event("focus"));
+      vi.advanceTimersByTime(300);
+      expect(draws).toBeGreaterThan(1);
+    });
+
+    it("resumes only once BOTH the hidden tab and the lost focus have ended", () => {
+      render(<CoreLiquid state="working" />);
+      vi.advanceTimersByTime(300);
+      const whileWatched = draws;
+      expect(whileWatched).toBeGreaterThan(0);
+
+      // Switching to another window's tab is both at once, and the two end
+      // separately — a Core that treated either event as "watched again" would
+      // start drawing into a tab that is still hidden.
+      hidden = true;
+      document.dispatchEvent(new Event("visibilitychange"));
+      window.dispatchEvent(new Event("blur"));
+      vi.advanceTimersByTime(2000);
+      expect(draws).toBe(whileWatched);
+
+      hidden = false;
+      document.dispatchEvent(new Event("visibilitychange"));
+      vi.advanceTimersByTime(2000);
+      expect(draws).toBe(whileWatched);
+
+      window.dispatchEvent(new Event("focus"));
+      vi.advanceTimersByTime(300);
+      expect(draws).toBeGreaterThan(whileWatched);
+    });
+  });
+
+  /*
+   * The stylesheet's half of the same stillness.
+   *
+   * A paused CSS animation is not observable here — jsdom runs no animations at
+   * all — so what a test can honestly pin is the SIGNAL the stylesheet reads:
+   * the attribute on the root element, and the fact that a Core leaves none of
+   * it behind. The rule that consumes the attribute is pinned against the
+   * stylesheet text in margince-core.test.ts.
+   */
+  describe("its stillness signal", () => {
+    it("marks the document while the window has no focus, and unmarks it on return", () => {
+      render(<CoreLiquid state="working" />);
+      expect(document.documentElement).not.toHaveAttribute(
+        WINDOW_BLURRED_ATTRIBUTE,
+      );
+
+      window.dispatchEvent(new Event("blur"));
+      expect(document.documentElement).toHaveAttribute(
+        WINDOW_BLURRED_ATTRIBUTE,
+      );
+
+      window.dispatchEvent(new Event("focus"));
+      expect(document.documentElement).not.toHaveAttribute(
+        WINDOW_BLURRED_ATTRIBUTE,
+      );
+    });
+
+    it("marks it on the non-GPU rung too, where CSS is the whole Core", () => {
+      // WDS-CORE-3's lower rung: no context, so no draw loop is ever built. The
+      // breath, the halo and the feed are then the only motion there is, and
+      // they are exactly what must stop.
+      vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(null);
+      render(<CoreLiquid state="working" />);
+      expect(document.querySelector("canvas")).toHaveClass("off");
+
+      window.dispatchEvent(new Event("blur"));
+      expect(document.documentElement).toHaveAttribute(
+        WINDOW_BLURRED_ATTRIBUTE,
+      );
+    });
+
+    it("leaves nothing behind once the last Core unmounts", () => {
+      const { unmount } = render(<CoreLiquid state="working" />);
+      window.dispatchEvent(new Event("blur"));
+      unmount();
+
+      // The attribute goes with the listeners. Left behind, it would pause the
+      // animations of the next Core mounted into a focused window, with no event
+      // coming to release them.
+      expect(document.documentElement).not.toHaveAttribute(
+        WINDOW_BLURRED_ATTRIBUTE,
+      );
+      window.dispatchEvent(new Event("blur"));
+      expect(document.documentElement).not.toHaveAttribute(
+        WINDOW_BLURRED_ATTRIBUTE,
+      );
     });
   });
 

--- a/frontend/src/design-system/margince-core-liquid.tsx
+++ b/frontend/src/design-system/margince-core-liquid.tsx
@@ -525,6 +525,9 @@ function runLiquidLoop({
   let timer = 0;
   let drawnOnce = false;
   let onScreen = true;
+  // Seeded by the subscription below, which opens by delivering the state it
+  // already holds. The initial value is what that delivery is compared against,
+  // so it reads the same source rather than assuming focus.
   let windowFocused = isWindowFocused();
   const still = reduced || speed === 0;
   /*
@@ -622,7 +625,14 @@ function runLiquidLoop({
   };
 
   document.addEventListener("visibilitychange", wake);
+  // The subscription opens by restating the state it already holds, which is what
+  // seeds `windowFocused` above. A restatement is not a resume: waking on it would
+  // buy a frame for a loop that has not started yet, and one for every Core that
+  // mounts into a window that never lost focus.
   const releaseFocus = subscribeToWindowFocus((focused) => {
+    if (focused === windowFocused) {
+      return;
+    }
     windowFocused = focused;
     wake();
   });

--- a/frontend/src/design-system/margince-core-liquid.tsx
+++ b/frontend/src/design-system/margince-core-liquid.tsx
@@ -1,6 +1,11 @@
 import { useEffect, useRef, useState } from "react";
 import type { MarginceCoreState } from "./margince-core";
 import { usePrefersReducedMotion } from "./motion";
+import {
+  isWindowFocused,
+  retainWindowFocusSignal,
+  subscribeToWindowFocus,
+} from "./window-focus";
 
 /**
  * The Core's liquid, drawn in WebGL.
@@ -30,13 +35,13 @@ import { usePrefersReducedMotion } from "./motion";
  *    the display's refresh rate (120Hz on the machines this is developed on) to
  *    discard four callbacks out of five
  *  - STOPS — not throttles — whenever nothing would change: a hidden tab, a
- *    canvas scrolled or routed off screen, and a state whose liquid does not move
- *    at all (`unavailable`, or any state under reduced motion, where one composed
- *    frame IS the whole animation). Each of those has an event that ends it, so
- *    the loop is woken by the event rather than by asking every frame — the
- *    layout read this used to do per callback (`canvas.offsetParent`) forced
- *    style and layout at refresh rate for an answer that only changes when a
- *    route does.
+ *    window that does not have focus, a canvas scrolled or routed off screen, and
+ *    a state whose liquid does not move at all (`unavailable`, or any state under
+ *    reduced motion, where one composed frame IS the whole animation). Each of
+ *    those has an event that ends it, so the loop is woken by the event rather
+ *    than by asking every frame — the layout read this used to do per callback
+ *    (`canvas.offsetParent`) forced style and layout at refresh rate for an
+ *    answer that only changes when a route does.
  *  - one triangle, no MSAA, no clear (the draw covers every pixel of the
  *    viewport), and no per-frame layout reads
  */
@@ -520,6 +525,7 @@ function runLiquidLoop({
   let timer = 0;
   let drawnOnce = false;
   let onScreen = true;
+  let windowFocused = isWindowFocused();
   const still = reduced || speed === 0;
   /*
    * The buffer edge THIS loop has configured, and why it is not read back off
@@ -562,19 +568,22 @@ function runLiquidLoop({
   };
 
   /**
-   * Whether anybody can see the canvas: in the viewport, in a visible tab.
+   * Whether anybody is watching the canvas: in the viewport, in a visible tab,
+   * in a window that has focus.
    *
-   * Deliberately NOT `document.hasFocus()`, which this used to include. A pause
-   * is only safe if something is guaranteed to end it, and these two conditions
-   * each have an event that fires on the way back (the IntersectionObserver,
-   * `visibilitychange`) — focus does not: a window can regain focus without a
-   * `focus` event reaching this document, and a Core that parked on an unfocused
-   * window then stayed frozen on screen for the rest of the session, which is
-   * exactly what a broken shader looks like. An unfocused window is also not an
-   * unwatched one; the tab that nobody is looking at is the hidden one, and that
-   * is the case worth stopping for.
+   * A pause is only safe if something is guaranteed to END it, so every term
+   * here is a condition whose end arrives as an event — the
+   * IntersectionObserver, `visibilitychange`, and the window's own `focus`.
+   * Focus qualifies because it is TRACKED rather than asked: `window-focus.ts`
+   * holds the `focus`/`blur` pair and pushes each change in here, and the only
+   * time it reads `document.hasFocus()` is to seed the state at subscribe time.
+   * Polling it inside this predicate instead would be a stop with no guaranteed
+   * way back — the answer is only true for the instant it is asked, so a resume
+   * that lands between two frames is never observed and the sphere stays frozen
+   * on screen for the rest of the session, which is exactly what a broken shader
+   * looks like.
    */
-  const seen = () => onScreen && !document.hidden;
+  const seen = () => onScreen && !document.hidden && windowFocused;
 
   const pump = (now: number) => {
     frame = 0;
@@ -613,10 +622,18 @@ function runLiquidLoop({
   };
 
   document.addEventListener("visibilitychange", wake);
+  const releaseFocus = subscribeToWindowFocus((focused) => {
+    windowFocused = focused;
+    wake();
+  });
   const onScreenObserver = tryObserveOnScreen(canvas, (visible) => {
     onScreen = visible;
     wake();
   });
+  // Not through `wake()`: the first frame is owed even to a Core that mounts
+  // into a blurred or hidden tab, because an undrawn canvas is blank and a blank
+  // sphere is indistinguishable from a broken one. `pump` grants exactly that
+  // one and then parks (see `drawnOnce` there).
   frame = requestAnimationFrame(pump);
 
   return {
@@ -625,6 +642,7 @@ function runLiquidLoop({
       cancelAnimationFrame(frame);
       window.clearTimeout(timer);
       document.removeEventListener("visibilitychange", wake);
+      releaseFocus();
       onScreenObserver?.disconnect();
     },
   };
@@ -679,6 +697,19 @@ export function CoreLiquid({
       canvas.removeEventListener("webglcontextrestored", onRestored);
     };
   }, []);
+
+  /*
+   * The stylesheet's half of the same stillness: `margince-core.css` pauses the
+   * breath, the sheen, the halo and the feed off `data-window-blurred`, and that
+   * attribute only exists while something holds the signal.
+   *
+   * Held here, for the canvas's whole life, rather than inside the draw loop:
+   * the loop is never created on the non-GPU rung (WDS-CORE-3) or in a host with
+   * no WebGL at all, and that is precisely where the CSS rhythms ARE the Core.
+   * Every Core mounts exactly one of these (WDS-CORE-1), so the signal is live
+   * whenever a Core is on the page and released with the last one.
+   */
+  useEffect(retainWindowFocusSignal, []);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies(contextEpoch): the effect never reads it, which is the point. It is the rebuild trigger, bumped by the `webglcontextrestored` listener above once the GPU hands the context back.
   useEffect(() => {

--- a/frontend/src/design-system/margince-core.css
+++ b/frontend/src/design-system/margince-core.css
@@ -100,7 +100,6 @@
 /* unavailable: the one state that does not breathe. A server we cannot reach
    should not look busy — but it is not a dead grey ball either. */
 .core[data-core-state="unavailable"] .core-glass,
-.core[data-core-state="unavailable"] .core-tilt,
 .core[data-core-state="unavailable"] .core-glow {
   animation: none;
 }
@@ -109,23 +108,16 @@
 }
 
 /* ---- the glass ---------------------------------------------------------- */
+/* The stage the glass is centred in: the sphere is --coreGlass across inside a
+   --coreSize box, so without this it would sit in the corner. It holds the Core
+   STILL in its box — the sphere breathes in place and never travels, so a Core
+   next to copy cannot drift into it and one on a dense surface cannot be
+   mistaken for something the page is moving. */
 .core-tilt {
   position: absolute;
   inset: 0;
   display: grid;
   place-items: center;
-  animation: core-float 11s var(--coreEase) infinite;
-}
-/* Deliberately NOT on the beat: a slow drift sharing no factor with the breath
-   keeps the two from locking into one pumping motion. */
-@keyframes core-float {
-  0%,
-  100% {
-    transform: translateY(-4px);
-  }
-  50% {
-    transform: translateY(5px);
-  }
 }
 .core-glass {
   position: relative;
@@ -447,6 +439,27 @@
   transition: stroke-dasharray 0.4s ease;
 }
 
+/* ---- an unfocused window: the Core goes still ---------------------------- */
+/*
+ * Nobody is watching a window that sits behind another one, so every rhythm
+ * stops together — the breath and the sheen, the halo, and the motes on their
+ * way in. The liquid inside stops too, in the same breath and off the same
+ * signal: `window-focus.ts` owns one `focus`/`blur` pair for the document, sets
+ * this attribute, and parks the WebGL loop (margince-core-liquid.tsx). ONE
+ * signal, so the sphere and its glow can never disagree about whether the Core
+ * is moving.
+ *
+ * PAUSED, not `animation: none`. A paused animation holds the frame it reached,
+ * which is what coming back to a Core should look like; removing the animation
+ * would snap the sphere to its unanimated size and brightness — a visible jump
+ * every time the reader clicks away.
+ */
+:root[data-window-blurred] .core-glass,
+:root[data-window-blurred] .core-glow,
+:root[data-window-blurred] .core-feed i {
+  animation-play-state: paused;
+}
+
 /* ---- reduced motion: the END state, never nothing ----------------------- */
 /*
  * The feed is atmosphere and is the one thing safe to simply remove. Everything
@@ -457,7 +470,6 @@
   .core-feed {
     display: none;
   }
-  .core-tilt,
   .core-glass,
   .core-glow {
     animation: none;

--- a/frontend/src/design-system/margince-core.test.ts
+++ b/frontend/src/design-system/margince-core.test.ts
@@ -178,6 +178,22 @@ describe("the Core's stillness", () => {
     // so clicking away from the window would jump it. Paused holds the frame it
     // reached, which is what coming back should look like.
     expect(pausedSelectors().length).toBeGreaterThanOrEqual(3);
+    // And nothing in the same breath takes the animation away again. Counting the
+    // paused selectors alone cannot see that: a rule may declare BOTH, and the
+    // shorthand wins whichever order it is written in — the sphere would snap on
+    // every blur while this assertion still read green.
+    for (const { selectors, body } of rules()) {
+      const blurred = selectors.some((selector) =>
+        selector.startsWith(`:root[${WINDOW_BLURRED_ATTRIBUTE}]`),
+      );
+      if (!blurred) {
+        continue;
+      }
+      expect(
+        body,
+        `${selectors.join(", ")} must pause, not remove`,
+      ).not.toMatch(/animation(-name)?\s*:\s*none/);
+    }
   });
 });
 

--- a/frontend/src/design-system/margince-core.test.ts
+++ b/frontend/src/design-system/margince-core.test.ts
@@ -6,6 +6,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import { coreBufferSize } from "./margince-core-liquid";
+import { WINDOW_BLURRED_ATTRIBUTE } from "./window-focus";
 
 // The Core is the product's identity, not a status light. It is ALWAYS the brand
 // green: a sphere that turns amber or red reads as the brand changing character,
@@ -103,6 +104,80 @@ describe("the Core's colour", () => {
       [...coreCss.matchAll(/--coreBeat:\s*([^;]+);/g)].map((m) => m[1].trim()),
     );
     expect(beats.size).toBeGreaterThanOrEqual(5);
+  });
+});
+
+/*
+ * The Core's stillness, derived from the sheet rather than from a list of class
+ * names: both rules below are about EVERY animated part the file happens to
+ * contain, so a part added later is covered by them without being added to a
+ * list first.
+ *
+ * Comments are stripped because a selector is read as the text before a `{`, and
+ * this file explains almost every rule it declares.
+ */
+const sheet = coreCss.replace(/\/\*[\s\S]*?\*\//g, "");
+
+/** Every rule body in the sheet, paired with the selectors it applies to. */
+function rules(): ReadonlyArray<{ selectors: string[]; body: string }> {
+  return [...sheet.matchAll(/([^{}]+)\{([^{}]*)\}/g)].map((match) => ({
+    selectors: match[1].split(",").map((one) => one.trim()),
+    body: match[2],
+  }));
+}
+
+/** The parts that START an animation — `animation: none` switches one off. */
+function animatedSelectors(): ReadonlyArray<string> {
+  const found = new Set<string>();
+  for (const { selectors, body } of rules()) {
+    const declared = /animation:\s*([^;]+);/.exec(body)?.[1]?.trim();
+    if (declared === undefined || declared.startsWith("none")) {
+      continue;
+    }
+    for (const selector of selectors) {
+      found.add(selector);
+    }
+  }
+  return [...found];
+}
+
+/** The parts held still while the window is blurred, without that condition. */
+function pausedSelectors(): ReadonlyArray<string> {
+  const prefix = `:root[${WINDOW_BLURRED_ATTRIBUTE}] `;
+  return rules()
+    .filter(({ body }) => /animation-play-state:\s*paused/.test(body))
+    .flatMap(({ selectors }) => selectors)
+    .filter((selector) => selector.startsWith(prefix))
+    .map((selector) => selector.slice(prefix.length));
+}
+
+describe("the Core's stillness", () => {
+  it("holds its position — no part of the Core travels vertically", () => {
+    // The sphere breathes in place. A slow vertical drift on top of the breath
+    // reads as the page moving rather than as the Core living, and next to copy
+    // it is a bug that moves. The feed's `translateX` is the motes arriving,
+    // which is the one thing here that travels on purpose.
+    expect(animatedSelectors().length).toBeGreaterThanOrEqual(3);
+    expect(sheet).not.toMatch(/translateY|translate3d|translate\s*:/);
+  });
+
+  it("pauses every rhythm it starts while the window has no focus", () => {
+    // Nobody is watching a window behind another window. The failure this guards
+    // is a part added later and left running there — one rhythm still moving
+    // while the rest of the Core is still is worse than all of them moving.
+    const paused = pausedSelectors();
+    for (const selector of animatedSelectors()) {
+      expect(paused, `${selector} must go still with the window`).toContain(
+        selector,
+      );
+    }
+  });
+
+  it("pauses them rather than removing them", () => {
+    // `animation: none` snaps the sphere to its unanimated size and brightness,
+    // so clicking away from the window would jump it. Paused holds the frame it
+    // reached, which is what coming back should look like.
+    expect(pausedSelectors().length).toBeGreaterThanOrEqual(3);
   });
 });
 

--- a/frontend/src/design-system/margince-core.test.ts
+++ b/frontend/src/design-system/margince-core.test.ts
@@ -165,8 +165,8 @@ describe("the Core's stillness", () => {
     // check that only knew the name.
     expect(animatedSelectors().length).toBeGreaterThanOrEqual(3);
     expect(sheet).not.toMatch(/translateY|translate3d|translate\s*:/);
-    const offsets = [...sheet.matchAll(/\btranslate\(([^)]*)\)/g)].map((match) =>
-      (match[1].split(",")[1] ?? "0").trim(),
+    const offsets = [...sheet.matchAll(/\btranslate\(([^)]*)\)/g)].map(
+      (match) => (match[1].split(",")[1] ?? "0").trim(),
     );
     expect(offsets.filter((y) => !/^0[a-z%]*$/.test(y))).toEqual([]);
   });

--- a/frontend/src/design-system/margince-core.test.ts
+++ b/frontend/src/design-system/margince-core.test.ts
@@ -157,8 +157,18 @@ describe("the Core's stillness", () => {
     // reads as the page moving rather than as the Core living, and next to copy
     // it is a bug that moves. The feed's `translateX` is the motes arriving,
     // which is the one thing here that travels on purpose.
+    //
+    // Every spelling of vertical travel, not the one that was written here
+    // before: the named function, the 3D form, the `translate` property, and the
+    // two-argument shorthand whose SECOND argument is the y — `translate(0, 8px)`
+    // moves the Core exactly as far as `translateY(8px)` and would have passed a
+    // check that only knew the name.
     expect(animatedSelectors().length).toBeGreaterThanOrEqual(3);
     expect(sheet).not.toMatch(/translateY|translate3d|translate\s*:/);
+    const offsets = [...sheet.matchAll(/\btranslate\(([^)]*)\)/g)].map((match) =>
+      (match[1].split(",")[1] ?? "0").trim(),
+    );
+    expect(offsets.filter((y) => !/^0[a-z%]*$/.test(y))).toEqual([]);
   });
 
   it("pauses every rhythm it starts while the window has no focus", () => {

--- a/frontend/src/design-system/motion.test.ts
+++ b/frontend/src/design-system/motion.test.ts
@@ -1,7 +1,7 @@
 /** @vitest-environment jsdom */
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { useTypeStream } from "./motion";
+import { INTRO_MS, useDocumentIntro, useTypeStream } from "./motion";
 
 // Pins the two hidden-tab paths together: a stream that STARTS hidden and one
 // that goes hidden MID-STREAM both land on the complete string with `done`
@@ -75,5 +75,66 @@ describe("useTypeStream", () => {
 
     expect(result.current.shown).toBe(text);
     expect(result.current.done).toBe(true);
+  });
+});
+
+// An entry animation belongs to the page load. A React remount is not one, and
+// this is the difference the hook exists to hold: a surface that keys its intro
+// to the mount replays the whole choreography every time a query settles or a
+// parent re-branches, which reads to the person watching as the page reloading
+// under them.
+describe("useDocumentIntro", () => {
+  beforeEach(() => {
+    // A fresh document per case: the mark lives on the document element, which
+    // one test file shares across all of its cases.
+    delete document.documentElement.dataset.marginceIntro;
+    vi.useFakeTimers();
+  });
+
+  it("plays for the first mount of a document", () => {
+    const { result } = renderHook(() => useDocumentIntro());
+
+    expect(result.current).toBe(true);
+  });
+
+  it("does not play for a mount that arrives after the intro has run", () => {
+    const first = renderHook(() => useDocumentIntro());
+    act(() => {
+      vi.advanceTimersByTime(INTRO_MS);
+    });
+    first.unmount();
+
+    const later = renderHook(() => useDocumentIntro());
+
+    expect(later.result.current).toBe(false);
+  });
+
+  it("still plays for a remount that lands while the intro is mid-flight", () => {
+    // This is React's development double-mount, and it is why the mark is set
+    // when the sequence ENDS rather than when it starts: at mount time the flag
+    // would already be spent by the time the second mount reads it, and the
+    // animation nobody has seen yet would be skipped.
+    const first = renderHook(() => useDocumentIntro());
+    act(() => {
+      vi.advanceTimersByTime(INTRO_MS / 4);
+    });
+    first.unmount();
+
+    const second = renderHook(() => useDocumentIntro());
+
+    expect(second.result.current).toBe(true);
+  });
+
+  it("keeps playing for the mount that owns an intro already under way", () => {
+    // The hook reads the mark once and holds the answer: a surface must not lose
+    // its animation halfway through because the mark landed mid-sequence.
+    const { result } = renderHook(() => useDocumentIntro());
+    act(() => {
+      vi.advanceTimersByTime(INTRO_MS * 2);
+    });
+
+    expect(result.current).toBe(true);
+    // And the document is marked, which is what the next mount reads.
+    expect(document.documentElement.dataset.marginceIntro).toBe("spent");
   });
 });

--- a/frontend/src/design-system/motion.test.ts
+++ b/frontend/src/design-system/motion.test.ts
@@ -85,9 +85,9 @@ describe("useTypeStream", () => {
 // under them.
 describe("useDocumentIntro", () => {
   beforeEach(() => {
-    // A fresh document per case: the mark lives on the document element, which
+    // A fresh document per case: the deadline lives on the document element, which
     // one test file shares across all of its cases.
-    delete document.documentElement.dataset.marginceIntro;
+    delete document.documentElement.dataset.marginceIntroUntil;
     vi.useFakeTimers();
   });
 
@@ -109,11 +109,27 @@ describe("useDocumentIntro", () => {
     expect(later.result.current).toBe(false);
   });
 
+  it("holds the deadline the FIRST mount set, however often the surface remounts", () => {
+    // The hole this closes: a countdown owned by a mount is cancelled by its
+    // unmount, so a surface that rebuilds every second would restart the window
+    // each time and replay its intro indefinitely. The deadline is an instant, and
+    // an instant cannot be pushed out.
+    for (let elapsed = 0; elapsed < INTRO_MS; elapsed += INTRO_MS / 4) {
+      const mount = renderHook(() => useDocumentIntro());
+      expect(mount.result.current).toBe(true);
+      mount.unmount();
+      act(() => {
+        vi.advanceTimersByTime(INTRO_MS / 4);
+      });
+    }
+
+    expect(renderHook(() => useDocumentIntro()).result.current).toBe(false);
+  });
+
   it("still plays for a remount that lands while the intro is mid-flight", () => {
-    // This is React's development double-mount, and it is why the mark is set
-    // when the sequence ENDS rather than when it starts: at mount time the flag
-    // would already be spent by the time the second mount reads it, and the
-    // animation nobody has seen yet would be skipped.
+    // React's development double-mount, and it is why the rule is a deadline
+    // rather than "one mount gets it": the second mount lands milliseconds after
+    // the first, so an intro nobody has seen yet must still be playing.
     const first = renderHook(() => useDocumentIntro());
     act(() => {
       vi.advanceTimersByTime(INTRO_MS / 4);
@@ -126,15 +142,17 @@ describe("useDocumentIntro", () => {
   });
 
   it("keeps playing for the mount that owns an intro already under way", () => {
-    // The hook reads the mark once and holds the answer: a surface must not lose
-    // its animation halfway through because the mark landed mid-sequence.
+    // The hook decides once and holds the answer: a surface must not lose its
+    // animation halfway through because the deadline passed mid-sequence.
     const { result } = renderHook(() => useDocumentIntro());
     act(() => {
       vi.advanceTimersByTime(INTRO_MS * 2);
     });
 
     expect(result.current).toBe(true);
-    // And the document is marked, which is what the next mount reads.
-    expect(document.documentElement.dataset.marginceIntro).toBe("spent");
+    // And the document carries the deadline, which is what the next mount reads.
+    expect(
+      Number(document.documentElement.dataset.marginceIntroUntil),
+    ).toBeGreaterThan(0);
   });
 });

--- a/frontend/src/design-system/motion.ts
+++ b/frontend/src/design-system/motion.ts
@@ -121,3 +121,57 @@ export function useTypeStream(
 
   return { shown, done };
 }
+
+/**
+ * How long an entry choreography owns the screen. Past this the document has
+ * been introduced, and anything that mounts later renders in its end state.
+ *
+ * It is a ceiling over the longest sequence any surface runs (the login
+ * surface's staggered rows plus its typed statement), not a per-surface number:
+ * an intro that is still mid-flight when a remount lands should finish where it
+ * was going rather than be cut off by a shorter budget.
+ */
+export const INTRO_MS = 2400;
+
+/**
+ * Whether an entry animation should PLAY, which is true once per document load
+ * and not once per mount.
+ *
+ * The distinction is the whole point. A React remount is not a page load — a
+ * background refetch, a notice appearing, a parent re-branching all replace the
+ * subtree — and a surface that keys its intro to the mount replays the whole
+ * choreography on every one of them. Copy that types itself out again, after
+ * the reader has already read it, reads as the page reloading under them.
+ *
+ * The mark is set once the intro HAS RUN ITS COURSE rather than at mount, and
+ * that is what makes it survive React's development double-mount: the second
+ * mount arrives long before the sequence is over, so it still plays, while a
+ * remount after the fact renders the end state.
+ *
+ * It is kept on the document element rather than in a module variable because
+ * the document is what the rule is about: a real page load builds a new one and
+ * the intro comes back with it, which is exactly when a reader expects to see
+ * it. It is also then observable — a stylesheet, a test or a browser can read
+ * whether this document has been introduced.
+ */
+const INTRO_MARK = "marginceIntro";
+
+export function useDocumentIntro(): boolean {
+  // Read at mount and held: the mark lands while this component is alive, and a
+  // surface whose intro is mid-flight must not lose its animation halfway.
+  const [play] = useState(
+    () => document.documentElement.dataset[INTRO_MARK] !== "spent",
+  );
+
+  useEffect(() => {
+    if (!play) {
+      return;
+    }
+    const timer = setTimeout(() => {
+      document.documentElement.dataset[INTRO_MARK] = "spent";
+    }, INTRO_MS);
+    return () => clearTimeout(timer);
+  }, [play]);
+
+  return play;
+}

--- a/frontend/src/design-system/motion.ts
+++ b/frontend/src/design-system/motion.ts
@@ -143,35 +143,39 @@ export const INTRO_MS = 2400;
  * choreography on every one of them. Copy that types itself out again, after
  * the reader has already read it, reads as the page reloading under them.
  *
- * The mark is set once the intro HAS RUN ITS COURSE rather than at mount, and
- * that is what makes it survive React's development double-mount: the second
- * mount arrives long before the sequence is over, so it still plays, while a
- * remount after the fact renders the end state.
+ * What is recorded is a DEADLINE, stamped by the first mount: the moment the
+ * document stops being newly loaded. Anything mounting before it plays, anything
+ * after it renders the end state.
+ *
+ * A deadline rather than a "spent" flag set on a timer, and the difference is a
+ * real hole: a timer belongs to the mount that started it, so an unmount cancels
+ * it and the next mount starts a fresh one — a surface that remounts every couple
+ * of seconds would keep pushing the finish line out and replay its intro every
+ * time. An absolute instant cannot be pushed. It also needs no timer at all,
+ * which is one fewer thing to cancel.
  *
  * It is kept on the document element rather than in a module variable because
  * the document is what the rule is about: a real page load builds a new one and
  * the intro comes back with it, which is exactly when a reader expects to see
- * it. It is also then observable — a stylesheet, a test or a browser can read
- * whether this document has been introduced.
+ * it. It is also then observable — a test or a browser can read when this
+ * document stopped being new.
  */
-const INTRO_MARK = "marginceIntro";
+const INTRO_UNTIL = "marginceIntroUntil";
 
 export function useDocumentIntro(): boolean {
-  // Read at mount and held: the mark lands while this component is alive, and a
-  // surface whose intro is mid-flight must not lose its animation halfway.
-  const [play] = useState(
-    () => document.documentElement.dataset[INTRO_MARK] !== "spent",
-  );
-
-  useEffect(() => {
-    if (!play) {
-      return;
+  // Decided once, at mount, and held: the deadline passes while this component is
+  // alive, and a surface whose intro is mid-flight must not lose its animation
+  // halfway through it.
+  const [play] = useState(() => {
+    const root = document.documentElement;
+    const until = Number(root.dataset[INTRO_UNTIL]);
+    if (Number.isFinite(until)) {
+      return performance.now() < until;
     }
-    const timer = setTimeout(() => {
-      document.documentElement.dataset[INTRO_MARK] = "spent";
-    }, INTRO_MS);
-    return () => clearTimeout(timer);
-  }, [play]);
+    // The first mount in this document is the one that starts the clock.
+    root.dataset[INTRO_UNTIL] = String(performance.now() + INTRO_MS);
+    return true;
+  });
 
   return play;
 }

--- a/frontend/src/design-system/passportselect.test.tsx
+++ b/frontend/src/design-system/passportselect.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it } from "vitest";
 import { PassportSelect, ScopeChips } from "./passportselect";
+import { pickOption } from "./select-testing";
 
 // PassportSelect and ScopeChips are the extracted shapes the tool console's
 // passport filter and the OAuth consent screen (Task 7) both render — these
@@ -19,6 +20,7 @@ const OPTIONS = [
 
 describe("PassportSelect", () => {
   it("lists every option and reports the chosen id", async () => {
+    const user = userEvent.setup();
     const chosen: string[] = [];
     render(
       <PassportSelect
@@ -28,15 +30,24 @@ describe("PassportSelect", () => {
         allowEmpty
       />,
     );
-    const select = screen.getByRole("combobox");
-    expect(screen.getByRole("option", { name: /night agent/ })).toBeTruthy();
-    await userEvent.selectOptions(select, "p2");
+
+    await pickOption(user, screen.getByRole("combobox"), "reporter");
+
     expect(chosen).toEqual(["p2"]);
   });
 
-  it("offers no empty choice when allowEmpty is absent", () => {
+  // The options only exist while the popup is open — the control renders no
+  // listbox when closed — so counting them means opening it first.
+  it("offers no empty choice when allowEmpty is absent", async () => {
+    const user = userEvent.setup();
     render(<PassportSelect options={OPTIONS} value="p1" onChange={() => {}} />);
-    expect(screen.getAllByRole("option")).toHaveLength(2);
+
+    await user.click(screen.getByRole("combobox"));
+
+    expect(screen.getAllByRole("option").map((o) => o.textContent)).toEqual([
+      "night agent",
+      "reporter",
+    ]);
   });
 });
 

--- a/frontend/src/design-system/passportselect.tsx
+++ b/frontend/src/design-system/passportselect.tsx
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: 2026 Gradion
 
 import { useT } from "../i18n";
-import { Select } from "./atoms";
+import { Select, type SelectOption } from "./select";
 
 // Shared between the tool console's passport filter and the OAuth consent
 // screen (Task 7) — extracted so the two surfaces cannot drift into
@@ -52,20 +52,24 @@ export function PassportSelect({
   ariaLabel?: string;
 }>) {
   const t = useT();
+  // The empty choice is an OPTION, not the select's placeholder: a placeholder
+  // is a face, and the tool console's reader has to be able to come back to
+  // "all passports" after picking one.
+  const empty: SelectOption[] = allowEmpty
+    ? [{ value: "", label: emptyLabel ?? t("passport.noneOption") }]
+    : [];
   return (
     <Select
       aria-label={ariaLabel ?? t("passport.select")}
+      options={[
+        ...empty,
+        ...options.map((option) => ({
+          value: option.id,
+          label: option.label,
+        })),
+      ]}
       value={value}
-      onChange={(event) => onChange(event.target.value)}
-    >
-      {allowEmpty && (
-        <option value="">{emptyLabel ?? t("passport.noneOption")}</option>
-      )}
-      {options.map((option) => (
-        <option key={option.id} value={option.id}>
-          {option.label}
-        </option>
-      ))}
-    </Select>
+      onChange={onChange}
+    />
   );
 }

--- a/frontend/src/design-system/select-testing.ts
+++ b/frontend/src/design-system/select-testing.ts
@@ -22,6 +22,13 @@ import type { UserEvent } from "@testing-library/user-event";
  * what a person would click. Matched exactly by accessible name, so "Won" does
  * not also match "Won (renewal)" — pass a RegExp when a prefix is what you mean.
  *
+ * **The control must be CLOSED when this is called, and one call is one attempt.**
+ * The first thing it does is click the trigger, which toggles — so a second call,
+ * or a `waitFor` retrying this one, closes the popup the previous attempt opened
+ * and then looks for a listbox that is no longer there. A choice that is not
+ * offered yet is not something to retry: open the control once, await the option
+ * (`await screen.findByRole("option", { name })`) and click it.
+ *
  * Throws if the popup does not open or the option is not in it, rather than
  * returning quietly: a pick that silently did nothing is how a test ends up
  * asserting the screen's unchanged initial state and passing.

--- a/frontend/src/design-system/select-testing.ts
+++ b/frontend/src/design-system/select-testing.ts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { screen, within } from "@testing-library/react";
+import type { UserEvent } from "@testing-library/user-event";
+
+/**
+ * The ONE way a test drives a Margince `Select`.
+ *
+ * `userEvent.selectOptions` only works on a native `<select>`, and this control
+ * is a button plus a portalled listbox — so a suite that wants a choice made has
+ * to open the popup and click inside it. Every suite doing that by hand would
+ * re-derive the same two steps and encode this component's internals in thirty
+ * files; when the popup's markup changes, they would all break at once. Import
+ * this instead:
+ *
+ * ```ts
+ * await pickOption(user, screen.getByRole("combobox", { name: "Stage" }), "Won");
+ * ```
+ *
+ * `optionLabel` is the label the reader sees, not the value: a test should say
+ * what a person would click. Matched exactly by accessible name, so "Won" does
+ * not also match "Won (renewal)" — pass a RegExp when a prefix is what you mean.
+ *
+ * Throws if the popup does not open or the option is not in it, rather than
+ * returning quietly: a pick that silently did nothing is how a test ends up
+ * asserting the screen's unchanged initial state and passing.
+ */
+export async function pickOption(
+  user: UserEvent,
+  control: HTMLElement,
+  optionLabel: string | RegExp,
+): Promise<void> {
+  await user.click(control);
+  const listbox = screen.getByRole("listbox");
+  await user.click(within(listbox).getByRole("option", { name: optionLabel }));
+}

--- a/frontend/src/design-system/select.css
+++ b/frontend/src/design-system/select.css
@@ -42,6 +42,13 @@
 .select-chevron {
   flex: none;
   color: var(--textSecondary);
+}
+/* The turn itself is unconditional — it is the state, and a reader who asked for
+   less motion still needs the chevron to point at an open list. Only the tween is
+   conditional, and it arrives as `data-motion` from select.tsx for the reason
+   spelled out over the popup's animation below: one decision, in one place the
+   unit suite can read. */
+.select-control[data-motion="in"] .select-chevron {
   transition: transform 0.15s;
 }
 .select-control[aria-expanded="true"] .select-chevron {

--- a/frontend/src/design-system/select.css
+++ b/frontend/src/design-system/select.css
@@ -1,0 +1,133 @@
+/* The Margince select — the trigger's face and its portalled popup.
+ *
+ * The trigger reads `.input` (atoms.css) on top of this: a dropdown and a text
+ * input are the same field on screen, so the surface — font, fill, border,
+ * padding, focus ring — is declared once there, and only the layout the button
+ * needs lives here.
+ *
+ * The popup is `position: fixed` and portalled to the body, so nothing in this
+ * sheet may assume a positioned ancestor: every coordinate arrives as an inline
+ * style from select.tsx, measured against the viewport. */
+
+.select-control {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  text-align: left;
+  cursor: pointer;
+}
+.select-control:disabled {
+  cursor: not-allowed;
+  color: var(--textTertiary);
+  background: var(--bgCard);
+}
+/* The face never pushes the chevron out of the control: a long label ellipsizes
+   inside the field rather than widening it, which is what a native select does
+   and what a toolbar's fixed column width depends on. */
+.select-face {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+/* A placeholder is not a value, and it must not read like one — but it is text a
+   reader has to be able to read, so it stops at --textMeta, the canonical AA
+   small-text role, rather than the decorative tier below it. This is text on an
+   active control, so 1.4.3's inactive-control exemption does not cover it: the
+   axe sweep failed on `.select-face-placeholder` the moment a screen shipped a
+   control resting on its placeholder. */
+.select-face-placeholder {
+  color: var(--textMeta);
+}
+.select-chevron {
+  flex: none;
+  color: var(--textSecondary);
+  transition: transform 0.15s;
+}
+.select-control[aria-expanded="true"] .select-chevron {
+  transform: rotate(180deg);
+}
+
+/* Above `.overlay` (50) and `.toast-region` (60) in atoms.css: a select inside a
+   dialog has to draw over the dialog it belongs to, and the popup is portalled
+   to the body so stacking context cannot do that for it. */
+.select-popup {
+  position: fixed;
+  z-index: 70;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  background: var(--bgElevated);
+  border: 1px solid var(--borderStrong);
+  border-radius: var(--r-sm);
+  box-shadow: var(--shadow-pop);
+  padding: var(--space-1);
+}
+.select-list {
+  display: flex;
+  flex-direction: column;
+}
+.select-option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  padding: 7px 9px;
+  border-radius: 6px;
+  font-family: var(--f-body);
+  font-size: 13.5px;
+  color: var(--textPrimary);
+  cursor: pointer;
+}
+.select-option-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.select-option-check {
+  flex: none;
+  color: var(--accent);
+}
+/* The ACTIVE option — where the keyboard is, and what a pointer is hovering.
+   One treatment for both, because they are one state: the popup tracks a single
+   active option through `aria-activedescendant`, whichever input moved it. */
+.select-option.is-active {
+  background: var(--bgHover);
+}
+.select-option[aria-selected="true"] {
+  color: var(--accent);
+  font-weight: 500;
+}
+.select-option[aria-selected="true"].is-active {
+  background: var(--accentLight);
+}
+/* A disabled option stays listed and stays readable — a choice this workspace
+   cannot make right now is information — but it takes no hover treatment,
+   because a highlight is a promise that a click will do something. */
+.select-option.is-disabled {
+  color: var(--textTertiary);
+  cursor: not-allowed;
+  background: none;
+}
+
+/* Motion is resolved in select.tsx by usePrefersReducedMotion and arrives here
+   as `data-motion` — deliberately NOT a second `prefers-reduced-motion` media
+   query, which would put the same decision in two places and leave the CSS half
+   of it unassertable by the unit suite. `data-motion="none"` matches no rule
+   below, so the popup is simply at its end state. */
+.select-popup[data-motion="in"] {
+  animation: select-popup-in 0.12s ease-out;
+  transform-origin: top center;
+}
+.select-popup[data-motion="in"][data-above="true"] {
+  transform-origin: bottom center;
+}
+@keyframes select-popup-in {
+  from {
+    opacity: 0;
+    transform: scaleY(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: scaleY(1);
+  }
+}

--- a/frontend/src/design-system/select.stories.tsx
+++ b/frontend/src/design-system/select.stories.tsx
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { type CSSProperties, useState } from "react";
+import { Field } from "./atoms";
+import { Select, type SelectOption } from "./select";
+
+/**
+ * The select, which is a button and a portalled listbox rather than a native
+ * `<select>` — the one control a browser draws for itself, in the platform's own
+ * idiom, on a screen built entirely from ours.
+ *
+ * What these stories are for, in order of what they actually catch: the closed
+ * face has to sit on the same baseline as a `TextInput` beside it (the Fields
+ * story), the popup has to stay unclipped when the control lives in a toolbar
+ * inside a scroller (In A Scroller), and it has to flip above the trigger near
+ * the bottom of the window (Near The Bottom). Flip the Theme toolbar to see the
+ * dark rendering — every value here is a token, so all of it re-resolves.
+ */
+const meta = {
+  title: "Design System/Select",
+  parameters: { layout: "padded" },
+} satisfies Meta;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const STAGES: readonly SelectOption[] = [
+  { value: "qualify", label: "Qualify" },
+  { value: "proposal", label: "Proposal" },
+  { value: "negotiation", label: "Negotiation" },
+  { value: "won", label: "Won" },
+  { value: "lost", label: "Lost" },
+];
+
+// Long enough that the popup has to scroll rather than grow past the viewport,
+// and long enough to hold a real IANA list's worth of near-identical labels.
+const ZONES: readonly SelectOption[] = [
+  "Europe/Berlin",
+  "Europe/Brussels",
+  "Europe/Bucharest",
+  "Europe/Budapest",
+  "Europe/Copenhagen",
+  "Europe/Dublin",
+  "Europe/Helsinki",
+  "Europe/Lisbon",
+  "Europe/London",
+  "Europe/Madrid",
+  "Europe/Oslo",
+  "Europe/Paris",
+  "Europe/Prague",
+  "Europe/Riga",
+  "Europe/Rome",
+  "Europe/Sofia",
+  "Europe/Stockholm",
+  "Europe/Tallinn",
+  "Europe/Vienna",
+  "Europe/Vilnius",
+  "Europe/Warsaw",
+  "Europe/Zurich",
+].map((zone) => ({ value: zone, label: zone }));
+
+const column: CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: "var(--space-4)",
+  maxWidth: "22rem",
+};
+
+/** The control is controlled, so every story owns the value it shows. */
+function Demo({
+  options,
+  start = "",
+  label,
+  placeholder,
+  disabled,
+  required,
+  hint,
+}: Readonly<{
+  options: readonly SelectOption[];
+  start?: string;
+  label: string;
+  placeholder?: string;
+  disabled?: boolean;
+  required?: boolean;
+  hint?: string;
+}>) {
+  const [value, setValue] = useState(start);
+  return (
+    <Field label={label} hint={hint} required={required}>
+      {(control) => (
+        <Select
+          {...control}
+          options={options}
+          value={value}
+          onChange={setValue}
+          placeholder={placeholder}
+          disabled={disabled}
+        />
+      )}
+    </Field>
+  );
+}
+
+export const Default: Story = {
+  render: () => (
+    <div style={column}>
+      <Demo label="Stage" options={STAGES} start="proposal" />
+    </div>
+  ),
+};
+
+/** Nothing chosen yet: the face is the placeholder, and it does not read as a value. */
+export const WithPlaceholder: Story = {
+  render: () => (
+    <div style={column}>
+      <Demo
+        label="Stage"
+        options={STAGES}
+        placeholder="Pick a stage"
+        required
+        hint="A deal has to sit somewhere in the pipeline."
+      />
+    </div>
+  ),
+};
+
+/** A list past the popup's height cap, which then scrolls inside its own box. */
+export const LongList: Story = {
+  render: () => (
+    <div style={column}>
+      <Demo label="Time zone" options={ZONES} start="Europe/Berlin" />
+    </div>
+  ),
+};
+
+export const Disabled: Story = {
+  render: () => (
+    <div style={column}>
+      <Demo label="Stage" options={STAGES} start="won" disabled />
+      <Demo
+        label="Stage"
+        options={STAGES}
+        placeholder="Pick a stage"
+        disabled
+      />
+    </div>
+  ),
+};
+
+/**
+ * A choice this workspace cannot make right now stays LISTED and stays readable —
+ * that it exists is information — but it takes no hover highlight, the keyboard
+ * steps over it, and a click on it does nothing.
+ */
+export const DisabledOption: Story = {
+  render: () => (
+    <div style={column}>
+      <Demo
+        label="Stage"
+        start="qualify"
+        options={[
+          { value: "qualify", label: "Qualify" },
+          { value: "proposal", label: "Proposal" },
+          { value: "won", label: "Won — needs an approval", disabled: true },
+        ]}
+      />
+    </div>
+  ),
+};
+
+/**
+ * The case the whole positioning design exists for. `.scroll` in app/shell.css is
+ * `overflow-y: auto; position: relative`, and most of these controls sit in a
+ * toolbar inside it — an absolutely positioned popup is clipped by that box and
+ * scrolls away from its own trigger. Open the select, then scroll the frame: the
+ * popup stays on the trigger and closes once the trigger is gone.
+ */
+export const InAScroller: Story = {
+  render: () => (
+    <div
+      style={{
+        height: "180px",
+        overflowY: "auto",
+        border: "1px solid var(--borderSubtle)",
+        borderRadius: "var(--r-sm)",
+        padding: "var(--space-3)",
+        position: "relative",
+      }}
+    >
+      <div style={{ ...column, paddingBottom: "var(--space-6)" }}>
+        <Demo label="Stage" options={STAGES} start="proposal" />
+        <p className="t-caption">
+          Scroll this frame with the list open — the popup follows its trigger
+          and is never clipped by this box.
+        </p>
+        <div style={{ height: "320px" }} />
+      </div>
+    </div>
+  ),
+};
+
+/** No room below, so the popup opens upwards instead of off the window. */
+export const NearTheBottom: Story = {
+  parameters: { layout: "fullscreen" },
+  render: () => (
+    <div
+      style={{
+        minHeight: "100vh",
+        display: "flex",
+        alignItems: "flex-end",
+        padding: "var(--space-4)",
+      }}
+    >
+      <div style={column}>
+        <Demo label="Time zone" options={ZONES} start="Europe/Vienna" />
+      </div>
+    </div>
+  ),
+};
+
+/** The dark rendering, pinned as its own story rather than left to the toolbar. */
+export const Dark: Story = {
+  globals: { theme: "dark" },
+  render: () => (
+    <div style={column}>
+      <Demo label="Stage" options={STAGES} start="proposal" />
+      <Demo label="Time zone" options={ZONES} placeholder="Pick a zone" />
+    </div>
+  ),
+};

--- a/frontend/src/design-system/select.test.tsx
+++ b/frontend/src/design-system/select.test.tsx
@@ -1,0 +1,630 @@
+/** @vitest-environment jsdom */
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { act, cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Field } from "./atoms";
+import type { SelectOption, SelectProps } from "./select";
+import { Select } from "./select";
+import { pickOption } from "./select-testing";
+
+// The specs for the control that replaced the native <select>. They are grouped
+// by the promise each group keeps, because those promises are what the ~30 screen
+// call sites and their suites depend on: the trigger is findable as a combobox,
+// the popup is a real listbox, the keyboard drives all of it, and nothing commits
+// a value the reader did not choose.
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+const STAGES: readonly SelectOption[] = [
+  { value: "qualify", label: "Qualify" },
+  { value: "proposal", label: "Proposal" },
+  { value: "won", label: "Won" },
+];
+
+// A list with a hole in the middle: the disabled entry sits between two enabled
+// ones, so a keyboard walk that fails to skip it stops on it rather than landing
+// on the next real option.
+const WITH_DISABLED: readonly SelectOption[] = [
+  { value: "qualify", label: "Qualify" },
+  { value: "blocked", label: "Blocked", disabled: true },
+  { value: "won", label: "Won" },
+];
+
+function renderSelect(props: Partial<SelectProps> = {}) {
+  const changes: string[] = [];
+  const merged: SelectProps = {
+    "aria-label": "Stage",
+    options: STAGES,
+    value: "",
+    onChange: (next: string) => {
+      changes.push(next);
+    },
+    ...props,
+  };
+  render(<Select {...merged} />);
+  return {
+    changes,
+    trigger: screen.getByRole("combobox", { name: "Stage" }),
+  };
+}
+
+// jsdom lays nothing out, so every box it reports is zeros. A test that needs the
+// geometry decisions — flip above, close when gone — states the box the browser
+// would have measured.
+function rectAt(left: number, top: number, width: number, height: number) {
+  return {
+    x: left,
+    y: top,
+    left,
+    top,
+    width,
+    height,
+    right: left + width,
+    bottom: top + height,
+    toJSON: () => ({}),
+  } satisfies DOMRect;
+}
+
+// A controlled harness for the cases that need the trigger face to follow the
+// commit — the component is controlled, so a test that never feeds the value back
+// can only ever prove the callback fired.
+function ControlledSelect({ start = "" }: Readonly<{ start?: string }>) {
+  const [value, setValue] = useState(start);
+  return (
+    <Select
+      aria-label="Stage"
+      options={STAGES}
+      value={value}
+      onChange={setValue}
+      placeholder="Pick a stage"
+    />
+  );
+}
+
+describe("the trigger", () => {
+  it("is a combobox naming the selected option, and shows the placeholder when nothing is selected", () => {
+    const { trigger } = renderSelect({ placeholder: "Pick a stage" });
+
+    expect(trigger.tagName).toBe("BUTTON");
+    expect(trigger.getAttribute("type")).toBe("button");
+    expect(trigger.getAttribute("aria-haspopup")).toBe("listbox");
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+    expect(trigger.textContent).toContain("Pick a stage");
+
+    cleanup();
+    renderSelect({ value: "won" });
+    expect(
+      screen.getByRole("combobox", { name: "Stage" }).textContent,
+    ).toContain("Won");
+  });
+
+  // A value the option list no longer offers (a stage removed from the pipeline,
+  // a stale query param) must not render as an empty control that looks chosen.
+  it("falls back to the placeholder when the value matches no option", () => {
+    const { trigger } = renderSelect({
+      value: "retired",
+      placeholder: "Pick a stage",
+    });
+    expect(trigger.textContent).toContain("Pick a stage");
+  });
+
+  // The Field atom hands its control an id, the required flag and the hint to be
+  // described by — every screen spreads that object whole, so all three have to
+  // land on the trigger, and the <label> has to name it.
+  it("takes the id, required state and description a Field hands it", () => {
+    render(
+      <Field label="Stage" hint="Only closed stages freeze the rate" required>
+        {(control) => (
+          <Select
+            {...control}
+            options={STAGES}
+            value="won"
+            onChange={() => {}}
+          />
+        )}
+      </Field>,
+    );
+
+    const trigger = screen.getByRole("combobox", { name: "Stage" });
+    expect(trigger.getAttribute("aria-required")).toBe("true");
+    const describedBy = trigger.getAttribute("aria-describedby") ?? "";
+    expect(document.getElementById(describedBy)?.textContent).toBe(
+      "Only closed stages freeze the rate",
+    );
+  });
+
+  it("merges a caller's className with its own, and carries aria-invalid through", () => {
+    const { trigger } = renderSelect({
+      className: "stage-picker",
+      "aria-invalid": true,
+    });
+    expect([...trigger.classList].sort()).toEqual([
+      "input",
+      "select-control",
+      "stage-picker",
+    ]);
+    expect(trigger.getAttribute("aria-invalid")).toBe("true");
+  });
+
+  // A real <form> reads values off form controls, and a button is not one. The
+  // hidden input is how a screen that posts a form still submits this choice.
+  it("mirrors the value onto a hidden input when a name is given", () => {
+    render(
+      <form aria-label="Deal">
+        <Select
+          aria-label="Stage"
+          name="stage"
+          options={STAGES}
+          value="won"
+          onChange={() => {}}
+        />
+      </form>,
+    );
+    const form = screen.getByRole("form", { name: "Deal" });
+    expect(new FormData(form as HTMLFormElement).get("stage")).toBe("won");
+  });
+
+  it("renders no hidden input when no name is given", () => {
+    renderSelect();
+    expect(document.querySelector("input[type=hidden]")).toBeNull();
+  });
+});
+
+describe("the popup", () => {
+  it("is not in the document at all while closed", () => {
+    renderSelect();
+    expect(screen.queryByRole("listbox")).toBeNull();
+    expect(screen.queryAllByRole("option")).toEqual([]);
+  });
+
+  it("opens as a listbox the trigger controls, marking the selected option", async () => {
+    const user = userEvent.setup();
+    const { trigger } = renderSelect({ value: "proposal" });
+
+    await user.click(trigger);
+
+    const listbox = screen.getByRole("listbox");
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+    expect(trigger.getAttribute("aria-controls")).toBe(listbox.id);
+    expect(screen.getAllByRole("option").map((o) => o.textContent)).toEqual([
+      "Qualify",
+      "Proposal",
+      "Won",
+    ]);
+    expect(
+      screen
+        .getByRole("option", { name: "Proposal" })
+        .getAttribute("aria-selected"),
+    ).toBe("true");
+    expect(
+      screen.getByRole("option", { name: "Won" }).getAttribute("aria-selected"),
+    ).toBe("false");
+  });
+
+  // aria-controls may only point at an element that is in the document; a
+  // dangling reference is an axe violation and a screen reader cannot follow it.
+  it("advertises no aria-controls while there is no listbox to control", () => {
+    const { trigger } = renderSelect();
+    expect(trigger.hasAttribute("aria-controls")).toBe(false);
+  });
+
+  it("is portalled out of its own subtree so an ancestor scroller cannot clip it", async () => {
+    const user = userEvent.setup();
+    render(
+      <div className="scroll" style={{ overflowY: "auto", height: "40px" }}>
+        <Select
+          aria-label="Stage"
+          options={STAGES}
+          value=""
+          onChange={() => {}}
+        />
+      </div>,
+    );
+
+    await user.click(screen.getByRole("combobox", { name: "Stage" }));
+
+    const listbox = screen.getByRole("listbox");
+    expect(listbox.closest(".scroll")).toBeNull();
+    expect(listbox.parentElement?.parentElement).toBe(document.body);
+    // The geometry arrives as inline coordinates measured against the viewport
+    // (`.select-popup` declares `position: fixed`, which jsdom applies no
+    // stylesheet to assert) — an absolutely positioned popup would instead be
+    // laid out against `.scroll` and scroll away from its own trigger.
+    const box = listbox.parentElement;
+    expect(box?.className).toBe("select-popup");
+    expect(box?.style.top).not.toBe("");
+    expect(box?.style.left).not.toBe("");
+    expect(box?.style.maxHeight).not.toBe("");
+  });
+
+  it("closes when the trigger scrolls out of view", async () => {
+    const user = userEvent.setup();
+    const { trigger } = renderSelect();
+    await user.click(trigger);
+    expect(screen.getByRole("listbox")).toBeTruthy();
+
+    // A toolbar scrolled past the top of the window reports exactly this box.
+    vi.spyOn(trigger, "getBoundingClientRect").mockReturnValue(
+      rectAt(0, -80, 200, 34),
+    );
+    act(() => {
+      globalThis.dispatchEvent(new Event("scroll"));
+    });
+
+    expect(screen.queryByRole("listbox")).toBeNull();
+  });
+
+  it("flips above the trigger when there is no room below it", async () => {
+    const user = userEvent.setup();
+    const { trigger } = renderSelect();
+    // A trigger near the bottom of the window: measured room below is a few
+    // pixels, so the popup has to open upwards to be readable at all.
+    vi.spyOn(trigger, "getBoundingClientRect").mockReturnValue(
+      rectAt(40, globalThis.innerHeight - 40, 200, 34),
+    );
+
+    await user.click(trigger);
+
+    const box = screen.getByRole("listbox").parentElement;
+    expect(box?.dataset.above).toBe("true");
+    expect(box?.style.bottom).not.toBe("");
+    expect(box?.style.top).toBe("");
+    // Matches the trigger's width so the popup reads as the same control.
+    expect(box?.style.width).toBe("200px");
+  });
+});
+
+describe("committing a choice", () => {
+  it("reports the chosen VALUE, not an event, and closes back onto the trigger", async () => {
+    const user = userEvent.setup();
+    const { trigger, changes } = renderSelect();
+
+    await pickOption(user, trigger, "Won");
+
+    expect(changes).toEqual(["won"]);
+    expect(screen.queryByRole("listbox")).toBeNull();
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it("shows the commit on the trigger face once the caller feeds the value back", async () => {
+    const user = userEvent.setup();
+    render(<ControlledSelect />);
+    const trigger = screen.getByRole("combobox", { name: "Stage" });
+    expect(trigger.textContent).toContain("Pick a stage");
+
+    await pickOption(user, trigger, "Proposal");
+
+    expect(trigger.textContent).toContain("Proposal");
+  });
+
+  it("toggles shut on a second click of the trigger, committing nothing", async () => {
+    const user = userEvent.setup();
+    const { trigger, changes } = renderSelect();
+
+    await user.click(trigger);
+    await user.click(trigger);
+
+    expect(screen.queryByRole("listbox")).toBeNull();
+    expect(changes).toEqual([]);
+  });
+
+  it("closes on a pointer press outside, committing nothing", async () => {
+    const user = userEvent.setup();
+    render(
+      <>
+        <ControlledSelect />
+        <button type="button">Elsewhere</button>
+      </>,
+    );
+    const trigger = screen.getByRole("combobox", { name: "Stage" });
+    await user.click(trigger);
+
+    await user.click(screen.getByRole("button", { name: "Elsewhere" }));
+
+    expect(screen.queryByRole("listbox")).toBeNull();
+    expect(trigger.textContent).toContain("Pick a stage");
+  });
+});
+
+describe("the keyboard", () => {
+  it("opens on Enter, Space, ArrowDown and ArrowUp", async () => {
+    const user = userEvent.setup();
+    const { trigger } = renderSelect();
+
+    for (const key of ["{Enter}", " ", "{ArrowDown}", "{ArrowUp}"]) {
+      trigger.focus();
+      await user.keyboard(key);
+      expect(screen.getByRole("listbox")).toBeTruthy();
+      await user.keyboard("{Escape}");
+      expect(screen.queryByRole("listbox")).toBeNull();
+    }
+  });
+
+  // The active option is tracked by aria-activedescendant, and DOM focus stays
+  // on the trigger: moving focus per option would take the reader out of the
+  // combobox and break the typeahead they are in the middle of.
+  it("moves the active option without moving focus off the trigger", async () => {
+    const user = userEvent.setup();
+    const { trigger } = renderSelect();
+
+    trigger.focus();
+    await user.keyboard("{ArrowDown}");
+    expect(trigger.getAttribute("aria-activedescendant")).toBe(
+      screen.getByRole("option", { name: "Qualify" }).id,
+    );
+
+    await user.keyboard("{ArrowDown}");
+    expect(trigger.getAttribute("aria-activedescendant")).toBe(
+      screen.getByRole("option", { name: "Proposal" }).id,
+    );
+    expect(document.activeElement).toBe(trigger);
+
+    await user.keyboard("{ArrowUp}");
+    expect(trigger.getAttribute("aria-activedescendant")).toBe(
+      screen.getByRole("option", { name: "Qualify" }).id,
+    );
+  });
+
+  it("jumps to the ends with Home and End", async () => {
+    const user = userEvent.setup();
+    const { trigger } = renderSelect();
+
+    trigger.focus();
+    await user.keyboard("{ArrowDown}{End}");
+    expect(trigger.getAttribute("aria-activedescendant")).toBe(
+      screen.getByRole("option", { name: "Won" }).id,
+    );
+
+    await user.keyboard("{Home}");
+    expect(trigger.getAttribute("aria-activedescendant")).toBe(
+      screen.getByRole("option", { name: "Qualify" }).id,
+    );
+  });
+
+  it("opens on the selected option rather than the top of the list", async () => {
+    const user = userEvent.setup();
+    const { trigger } = renderSelect({ value: "won" });
+
+    trigger.focus();
+    await user.keyboard("{Enter}");
+
+    expect(trigger.getAttribute("aria-activedescendant")).toBe(
+      screen.getByRole("option", { name: "Won" }).id,
+    );
+  });
+
+  it("commits the active option on Enter and on Space", async () => {
+    const user = userEvent.setup();
+    const first = renderSelect();
+    first.trigger.focus();
+    await user.keyboard("{ArrowDown}{ArrowDown}{Enter}");
+    expect(first.changes).toEqual(["proposal"]);
+
+    cleanup();
+    const second = renderSelect();
+    second.trigger.focus();
+    await user.keyboard("{ArrowDown} ");
+    expect(second.changes).toEqual(["qualify"]);
+  });
+
+  it("finds an option by typing its label", async () => {
+    const user = userEvent.setup();
+    const { trigger, changes } = renderSelect();
+
+    trigger.focus();
+    await user.keyboard("{ArrowDown}");
+    // "pr" rather than "p": one character would match Proposal here anyway, and
+    // the buffer is the behaviour worth pinning.
+    await user.keyboard("pr");
+    expect(trigger.getAttribute("aria-activedescendant")).toBe(
+      screen.getByRole("option", { name: "Proposal" }).id,
+    );
+
+    await user.keyboard("{Enter}");
+    expect(changes).toEqual(["proposal"]);
+  });
+
+  it("closes on Escape without committing, and hands focus back", async () => {
+    const user = userEvent.setup();
+    const { trigger, changes } = renderSelect();
+
+    trigger.focus();
+    await user.keyboard("{ArrowDown}{ArrowDown}{Escape}");
+
+    expect(screen.queryByRole("listbox")).toBeNull();
+    expect(changes).toEqual([]);
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it("keeps a press it claimed away from whatever is listening around it", async () => {
+    // A dropdown is nearly always inside something that watches the document for
+    // the same keys: `Modal` closes on Escape, a form submits on Enter. A press
+    // meant for the open list must end at the list — otherwise abandoning a
+    // dropdown takes the whole dialog with it, and choosing an option submits the
+    // form around it. Both are the same defect, so both are pinned here.
+    const user = userEvent.setup();
+    const heard: string[] = [];
+    const listen = (event: KeyboardEvent) => heard.push(event.key);
+    document.addEventListener("keydown", listen);
+    try {
+      const { trigger } = renderSelect();
+      trigger.focus();
+      await user.keyboard("{ArrowDown}");
+      await user.keyboard("{Enter}");
+      expect(heard).toEqual([]);
+
+      await user.keyboard("{ArrowDown}{Escape}");
+      expect(heard).toEqual([]);
+      // The press still did its own job — this is not a swallowed keystroke.
+      expect(screen.queryByRole("listbox")).toBeNull();
+
+      // And a press the control does NOT claim carries on as normal, or a
+      // surrounding shortcut would be dead while the control merely has focus.
+      await user.keyboard("{PageDown}");
+      expect(heard).toEqual(["PageDown"]);
+    } finally {
+      document.removeEventListener("keydown", listen);
+    }
+  });
+
+  it("closes on Tab without committing, and lets focus carry on", async () => {
+    const user = userEvent.setup();
+    const changes: string[] = [];
+    render(
+      <>
+        <Select
+          aria-label="Stage"
+          options={STAGES}
+          value=""
+          onChange={(next) => changes.push(next)}
+        />
+        <button type="button">Next field</button>
+      </>,
+    );
+    const trigger = screen.getByRole("combobox", { name: "Stage" });
+
+    trigger.focus();
+    await user.keyboard("{ArrowDown}{ArrowDown}");
+    await user.tab();
+
+    expect(screen.queryByRole("listbox")).toBeNull();
+    expect(changes).toEqual([]);
+    expect(document.activeElement).toBe(
+      screen.getByRole("button", { name: "Next field" }),
+    );
+  });
+
+  it("keeps the closed control to one tab stop", async () => {
+    const user = userEvent.setup();
+    render(
+      <>
+        <ControlledSelect />
+        <button type="button">Next field</button>
+      </>,
+    );
+
+    await user.tab();
+    expect(document.activeElement).toBe(
+      screen.getByRole("combobox", { name: "Stage" }),
+    );
+    await user.tab();
+    expect(document.activeElement).toBe(
+      screen.getByRole("button", { name: "Next field" }),
+    );
+  });
+});
+
+describe("disabled states", () => {
+  it("does not open a disabled control", async () => {
+    const user = userEvent.setup();
+    const { trigger } = renderSelect({ disabled: true });
+
+    await user.click(trigger);
+    trigger.focus();
+    await user.keyboard("{Enter}");
+
+    expect(screen.queryByRole("listbox")).toBeNull();
+  });
+
+  it("skips a disabled option on the keyboard and never commits it", async () => {
+    const user = userEvent.setup();
+    const { trigger, changes } = renderSelect({ options: WITH_DISABLED });
+
+    trigger.focus();
+    await user.keyboard("{ArrowDown}{ArrowDown}");
+
+    // Second stop is Won, not Blocked — the hole in the middle is stepped over.
+    expect(trigger.getAttribute("aria-activedescendant")).toBe(
+      screen.getByRole("option", { name: "Won" }).id,
+    );
+    await user.keyboard("{Enter}");
+    expect(changes).toEqual(["won"]);
+  });
+
+  it("lists a disabled option, marked, but does not commit it on a click", async () => {
+    const user = userEvent.setup();
+    const { trigger, changes } = renderSelect({ options: WITH_DISABLED });
+
+    await user.click(trigger);
+    const blocked = screen.getByRole("option", { name: "Blocked" });
+    expect(blocked.getAttribute("aria-disabled")).toBe("true");
+
+    await user.click(blocked);
+
+    expect(changes).toEqual([]);
+    // Still open: nothing was chosen, so the reader has not finished.
+    expect(screen.getByRole("listbox")).toBeTruthy();
+  });
+
+  it("does not typeahead onto a disabled option", async () => {
+    const user = userEvent.setup();
+    const { trigger } = renderSelect({ options: WITH_DISABLED });
+
+    trigger.focus();
+    await user.keyboard("{ArrowDown}");
+    await user.keyboard("bl");
+
+    expect(trigger.getAttribute("aria-activedescendant")).toBe(
+      screen.getByRole("option", { name: "Qualify" }).id,
+    );
+  });
+});
+
+describe("reduced motion", () => {
+  // jsdom's own matchMedia always answers false, so the reduced arm needs it
+  // stubbed to answer true, listener included.
+  function stubReducedMotion(reduce: boolean) {
+    vi.stubGlobal("matchMedia", (query: string) => ({
+      matches: reduce && query.includes("prefers-reduced-motion"),
+      media: query,
+      onchange: null,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+      addListener: () => undefined,
+      removeListener: () => undefined,
+      dispatchEvent: () => false,
+    }));
+  }
+
+  it("opens the popup with no animation for a reader who asked for less motion", async () => {
+    stubReducedMotion(true);
+    const user = userEvent.setup();
+    const { trigger } = renderSelect();
+
+    await user.click(trigger);
+
+    const box = screen.getByRole("listbox").parentElement;
+    expect(box?.dataset.motion).toBe("none");
+    // The end state, not nothing: the list is there to be read.
+    expect(screen.getAllByRole("option")).toHaveLength(3);
+  });
+
+  it("animates it in otherwise", async () => {
+    stubReducedMotion(false);
+    const user = userEvent.setup();
+    const { trigger } = renderSelect();
+
+    await user.click(trigger);
+
+    expect(screen.getByRole("listbox").parentElement?.dataset.motion).toBe(
+      "in",
+    );
+  });
+});
+
+describe("pickOption", () => {
+  it("is the one way a suite drives this control, and it fails loudly on a label that is not offered", async () => {
+    const user = userEvent.setup();
+    const { trigger, changes } = renderSelect();
+
+    await expect(pickOption(user, trigger, "Renewal")).rejects.toThrow();
+    expect(changes).toEqual([]);
+  });
+});

--- a/frontend/src/design-system/select.test.tsx
+++ b/frontend/src/design-system/select.test.tsx
@@ -55,6 +55,29 @@ function renderSelect(props: Partial<SelectProps> = {}) {
   };
 }
 
+// What a real <form> would post for this control. FormData reads a form, and the
+// trigger is a button that carries no value, so submitting one is the only way to
+// ask what the select actually contributes.
+function submittedStage(
+  props: Partial<SelectProps> = {},
+): FormDataEntryValue | null {
+  render(
+    <form aria-label="Deal">
+      <Select
+        aria-label="Stage"
+        name="stage"
+        options={STAGES}
+        value="won"
+        onChange={() => {}}
+        {...props}
+      />
+    </form>,
+  );
+  return new FormData(
+    screen.getByRole<HTMLFormElement>("form", { name: "Deal" }),
+  ).get("stage");
+}
+
 // jsdom lays nothing out, so every box it reports is zeros. A test that needs the
 // geometry decisions — flip above, close when gone — states the box the browser
 // would have measured.
@@ -115,6 +138,15 @@ describe("the trigger", () => {
     expect(trigger.textContent).toContain("Pick a stage");
   });
 
+  // Both halves of the face can be missing at once: the value matches no option
+  // AND the call site holds no placeholder, which is what a stale query param or
+  // a roster still in flight looks like. The control has to go on reading as an
+  // empty field rather than a bare chevron, so the face keeps a line of its own.
+  it("keeps a face when the value matches no option and there is no placeholder", () => {
+    const { trigger } = renderSelect({ value: "retired" });
+    expect(trigger.textContent).toBe("\u00a0");
+  });
+
   // The Field atom hands its control an id, the required flag and the hint to be
   // described by — every screen spreads that object whole, so all three have to
   // land on the trigger, and the <label> has to name it.
@@ -156,24 +188,19 @@ describe("the trigger", () => {
   // A real <form> reads values off form controls, and a button is not one. The
   // hidden input is how a screen that posts a form still submits this choice.
   it("mirrors the value onto a hidden input when a name is given", () => {
-    render(
-      <form aria-label="Deal">
-        <Select
-          aria-label="Stage"
-          name="stage"
-          options={STAGES}
-          value="won"
-          onChange={() => {}}
-        />
-      </form>,
-    );
-    const form = screen.getByRole("form", { name: "Deal" });
-    expect(new FormData(form as HTMLFormElement).get("stage")).toBe("won");
+    expect(submittedStage()).toBe("won");
   });
 
   it("renders no hidden input when no name is given", () => {
     renderSelect();
     expect(document.querySelector("input[type=hidden]")).toBeNull();
+  });
+
+  // A native disabled <select> is left out of the form's entry list, and the
+  // mirror has to say the same thing: a form that posts the value of a control
+  // the reader was not allowed to touch is submitting a choice nobody made.
+  it("submits nothing from a disabled control", () => {
+    expect(submittedStage({ disabled: true })).toBeNull();
   });
 });
 
@@ -278,6 +305,71 @@ describe("the popup", () => {
     expect(box?.style.top).toBe("");
     // Matches the trigger's width so the popup reads as the same control.
     expect(box?.style.width).toBe("200px");
+  });
+
+  // A viewport with less than the 96px flip threshold on EITHER side of the
+  // trigger — a short window, or any window at 200% zoom, which is measured in
+  // CSS pixels. Flipping cannot buy room that is not there, so the popup takes
+  // the room it has and scrolls inside it; a floor here would hang the last
+  // options off the screen where nothing can reach them.
+  it("never claims more height than the side it opened into has", async () => {
+    const user = userEvent.setup();
+    vi.stubGlobal("innerHeight", 140);
+
+    const near = renderSelect();
+    vi.spyOn(near.trigger, "getBoundingClientRect").mockReturnValue(
+      rectAt(40, 50, 200, 34),
+    );
+    await user.click(near.trigger);
+
+    // Down, because 44px below beats 38px above — and clamped to that 44: the
+    // trigger's bottom (84) plus the 4px gap plus 44 lands on the 8px margin.
+    const below = screen.getByRole("listbox").parentElement;
+    expect(below?.dataset.above).toBeUndefined();
+    expect(below?.style.top).toBe("88px");
+    expect(below?.style.maxHeight).toBe("44px");
+
+    cleanup();
+    const low = renderSelect();
+    vi.spyOn(low.trigger, "getBoundingClientRect").mockReturnValue(
+      rectAt(40, 90, 200, 34),
+    );
+    await user.click(low.trigger);
+
+    // Flipped, with 4px below and 78px above, and clamped to that 78 — a popup
+    // anchored 54px off the bottom and taller than 78 starts above the window.
+    const above = screen.getByRole("listbox").parentElement;
+    expect(above?.dataset.above).toBe("true");
+    expect(above?.style.bottom).toBe("54px");
+    expect(above?.style.maxHeight).toBe("78px");
+  });
+
+  it("re-anchors on a page scroll, but not when its own list is scrolled", async () => {
+    const user = userEvent.setup();
+    const { trigger } = renderSelect();
+    const box = vi
+      .spyOn(trigger, "getBoundingClientRect")
+      .mockReturnValue(rectAt(40, 100, 200, 34));
+
+    await user.click(trigger);
+    const listbox = screen.getByRole("listbox");
+    const popup = listbox.parentElement;
+    expect(popup?.style.top).toBe("138px");
+
+    // The trigger has moved, but this scroll came from the popup's own scroller:
+    // the reader is working down a long option list, and re-anchoring on every
+    // wheel tick moves the list out from under them.
+    box.mockReturnValue(rectAt(40, 200, 200, 34));
+    act(() => {
+      listbox.dispatchEvent(new Event("scroll"));
+    });
+    expect(popup?.style.top).toBe("138px");
+
+    // The same moved trigger, reported by a scroll of the page: that one counts.
+    act(() => {
+      globalThis.dispatchEvent(new Event("scroll"));
+    });
+    expect(popup?.style.top).toBe("238px");
   });
 });
 
@@ -617,6 +709,24 @@ describe("reduced motion", () => {
       "in",
     );
   });
+
+  // The chevron's turn is resolved the same way as the popup's entry, in the
+  // component rather than a second media query, so both halves of the preference
+  // are readable here. Under reduced motion the turn still HAPPENS — it is the
+  // control's state, and only the tween goes.
+  it("drops the chevron's tween without dropping the turn", async () => {
+    stubReducedMotion(true);
+    const user = userEvent.setup();
+    const { trigger } = renderSelect();
+    expect(trigger.dataset.motion).toBe("none");
+
+    await user.click(trigger);
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+
+    cleanup();
+    stubReducedMotion(false);
+    expect(renderSelect().trigger.dataset.motion).toBe("in");
+  });
 });
 
 describe("pickOption", () => {
@@ -625,6 +735,19 @@ describe("pickOption", () => {
     const { trigger, changes } = renderSelect();
 
     await expect(pickOption(user, trigger, "Renewal")).rejects.toThrow();
+    expect(changes).toEqual([]);
+  });
+
+  // It clicks the trigger first, so it takes a CLOSED control and one call is one
+  // attempt. Handed an open one it toggles the list shut and then has nothing to
+  // pick from — which it says out loud, because a helper that returned quietly
+  // here would leave a suite asserting an untouched form and passing.
+  it("refuses an already-open control rather than closing it and going quiet", async () => {
+    const user = userEvent.setup();
+    const { trigger, changes } = renderSelect();
+
+    await user.click(trigger);
+    await expect(pickOption(user, trigger, "Won")).rejects.toThrow();
     expect(changes).toEqual([]);
   });
 });

--- a/frontend/src/design-system/select.tsx
+++ b/frontend/src/design-system/select.tsx
@@ -69,7 +69,8 @@ export type SelectProps = Readonly<{
 
 // The popup sits this far from the trigger, never closer than this to a viewport
 // edge, and below MIN_ROOM there is not enough room to show a list worth reading
-// — so it flips to the other side rather than being squeezed.
+// — so it flips to the other side rather than being squeezed. MIN_ROOM is that
+// choice of side and nothing else: it never becomes the popup's height.
 const ANCHOR_GAP = 4;
 const VIEWPORT_MARGIN = 8;
 const MIN_ROOM = 96;
@@ -99,7 +100,13 @@ function frameFor(rect: DOMRect, view: { width: number; height: number }) {
   const frame = {
     left: Math.max(VIEWPORT_MARGIN, Math.min(rect.left, rightEdge)),
     width: rect.width,
-    maxHeight: Math.max(flip ? roomAbove : roomBelow, MIN_ROOM),
+    // The room on the side it opens on is a CEILING, never a floor. On a short
+    // viewport — or at browser zoom, which shrinks the viewport in CSS pixels —
+    // both sides can be under MIN_ROOM, and a popup allowed 96px in 40px of room
+    // runs off the screen with its last options unreachable. It takes the room
+    // there is and scrolls inside it. Zero is the floor because a negative
+    // max-height is not a length.
+    maxHeight: Math.max(flip ? roomAbove : roomBelow, 0),
   };
   return flip
     ? { ...frame, bottom: view.height - rect.top + ANCHOR_GAP, above: true }
@@ -126,10 +133,14 @@ function outOfView(rect: DOMRect, viewHeight: number): boolean {
  * and `onLost` closes it once the trigger itself is gone from view.
  *
  * The scroll listener is CAPTURE-phase: scroll does not bubble, so a listener on
- * the window never hears the toolbar's own scroller otherwise.
+ * the window never hears the toolbar's own scroller otherwise. That reach is also
+ * why it has to know the popup: a long option list scrolls inside the popup
+ * itself, which moves the trigger not at all, so those scrolls are not
+ * re-anchoring events.
  */
 function useAnchoredPopup(
   anchor: RefObject<HTMLElement | null>,
+  popup: RefObject<HTMLElement | null>,
   open: boolean,
   onLost: () => void,
 ): PopupFrame | null {
@@ -142,7 +153,14 @@ function useAnchoredPopup(
       setFrame(null);
       return;
     }
-    const place = () => {
+    const place = (event?: Event) => {
+      // A scroll from inside the popup is the reader moving through the option
+      // list, not the anchor moving under it. Recomputing the frame on every
+      // wheel tick there would fight the list they are reading.
+      const scrolled = event?.target;
+      if (scrolled instanceof Node && popup.current?.contains(scrolled)) {
+        return;
+      }
       const element = anchor.current;
       if (!element) {
         return;
@@ -165,7 +183,7 @@ function useAnchoredPopup(
       globalThis.removeEventListener("scroll", place, true);
       globalThis.removeEventListener("resize", place);
     };
-  }, [open, anchor, onLost]);
+  }, [open, anchor, popup, onLost]);
 
   return frame;
 }
@@ -381,7 +399,7 @@ function useSelectListbox(
   // Dismissal WITHOUT moving focus, for the two cases where the reader is
   // already somewhere else: a press outside, and a trigger scrolled out of view.
   const dismiss = useCallback(() => setOpen(false), []);
-  const frame = useAnchoredPopup(trigger, open, dismiss);
+  const frame = useAnchoredPopup(trigger, popup, open, dismiss);
   useDismissOnOutsidePress(open, dismiss, trigger, popup);
   useActiveOptionVisible(open, active, listboxId);
 
@@ -471,17 +489,23 @@ function useActiveOptionVisible(
 }
 
 export function Select(props: SelectProps) {
-  const { options, value, onChange, name } = props;
+  const { options, value, onChange, name, disabled } = props;
   const listbox = useSelectListbox(options, value, onChange);
   const reduced = usePrefersReducedMotion();
 
   return (
     <>
-      <SelectTrigger field={props} listbox={listbox} />
+      <SelectTrigger field={props} listbox={listbox} animate={!reduced} />
       {/* The value a real <form> submits. The trigger is a button, which carries
           no form value of its own, so a screen that posts a form rather than
-          calling the typed client keeps working unchanged. */}
-      {name !== undefined && <input type="hidden" name={name} value={value} />}
+          calling the typed client keeps working unchanged. The mirror carries
+          `disabled` with the control because the browser leaves a disabled
+          control out of the form's entry list: a disabled select that still
+          submitted its value would make the disabled state a lie about what the
+          form sends. */}
+      {name !== undefined && (
+        <input type="hidden" name={name} value={value} disabled={disabled} />
+      )}
       {listbox.open && listbox.frame
         ? createPortal(
             <SelectPopup
@@ -501,9 +525,18 @@ export function Select(props: SelectProps) {
 function SelectTrigger({
   field,
   listbox,
-}: Readonly<{ field: SelectProps; listbox: Listbox }>) {
+  animate,
+}: Readonly<{ field: SelectProps; listbox: Listbox; animate: boolean }>) {
   const { open, active } = listbox;
   const selected = field.options.find((option) => option.value === field.value);
+  // A value that matches no option, with no placeholder to fall back on — a
+  // stale query param, a roster that has not landed yet — still has to leave a
+  // field a reader recognises as empty rather than a box that has shrunk to its
+  // chevron and reads as half-drawn. A non-breaking space rather than a CSS
+  // floor: it needs no copy (every user-facing string here comes from the
+  // catalog) and the suite can assert it, which it cannot do for a stylesheet
+  // jsdom never applies.
+  const face = selected?.label ?? field.placeholder ?? "\u00a0";
   return (
     <button
       type="button"
@@ -512,6 +545,11 @@ function SelectTrigger({
       className={["input", "select-control", field.className ?? ""]
         .filter(Boolean)
         .join(" ")}
+      // The chevron's turn resolves here for the same reason the popup's entry
+      // does — one decision, in one place the suite can assert — and `none`
+      // leaves the END state: the chevron still points at an open list, it just
+      // gets there without a tween.
+      data-motion={animate ? "in" : "none"}
       // NOSONAR: an ARIA combobox over a native <select>, which no engine lets
       // us style past its closed face — see the module comment.
       role="combobox"
@@ -538,7 +576,7 @@ function SelectTrigger({
           selected ? "select-face" : "select-face select-face-placeholder"
         }
       >
-        {selected?.label ?? field.placeholder}
+        {face}
       </span>
       <ChevronDown className="select-chevron" size={16} aria-hidden="true" />
     </button>

--- a/frontend/src/design-system/select.tsx
+++ b/frontend/src/design-system/select.tsx
@@ -1,0 +1,614 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+import { Check, ChevronDown } from "lucide-react";
+import {
+  type KeyboardEvent as ReactKeyboardEvent,
+  type RefObject,
+  useCallback,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import { createPortal } from "react-dom";
+import { usePrefersReducedMotion } from "./motion";
+import "./select.css";
+
+/**
+ * The Margince select: a button trigger plus a portalled listbox popup.
+ *
+ * It exists because a native `<select>` is the one control the browser draws
+ * itself. Its closed face takes our tokens, and everything the user actually
+ * chooses from — the option list, its fill, its type, its highlight, its
+ * scrollbar — is painted by the platform in the platform's own idiom. On the
+ * same screen as the rest of this design system that reads as a hole, and no
+ * amount of CSS closes it: `option` is not stylable in any engine we ship to.
+ *
+ * Two consequences the caller sees, both deliberate:
+ *
+ *  - `onChange` reports the VALUE, not an event. A listbox has no
+ *    `event.target.value`, and threading a synthetic event through would be a
+ *    lie about where the value came from.
+ *  - `options` is data, not `<option>` children. The component has to know the
+ *    labels to render a trigger face, to run typeahead and to skip a disabled
+ *    entry from the keyboard; reading that back out of children would be
+ *    guesswork.
+ *
+ * `required` becomes `aria-required` rather than a `required` attribute: a
+ * button carries no constraint validation, and neither does the hidden input
+ * that mirrors the value into a real `<form>` (the HTML spec exempts hidden
+ * inputs from validation). So a required select announces the requirement and
+ * the surrounding form still owns refusing an empty submit — which every screen
+ * here already does in its own submit handler.
+ */
+export type SelectOption = Readonly<{
+  value: string;
+  label: string;
+  disabled?: boolean;
+}>;
+
+export type SelectProps = Readonly<{
+  options: readonly SelectOption[];
+  value: string;
+  onChange: (value: string) => void;
+  /** The trigger face when `value` is "" or matches no option. */
+  placeholder?: string;
+  id?: string;
+  /** Rendered on a hidden input so a real `<form>` still carries the value. */
+  name?: string;
+  disabled?: boolean;
+  required?: boolean;
+  className?: string;
+  "aria-label"?: string;
+  "aria-labelledby"?: string;
+  "aria-describedby"?: string;
+  "aria-invalid"?: boolean;
+}>;
+
+// The popup sits this far from the trigger, never closer than this to a viewport
+// edge, and below MIN_ROOM there is not enough room to show a list worth reading
+// — so it flips to the other side rather than being squeezed.
+const ANCHOR_GAP = 4;
+const VIEWPORT_MARGIN = 8;
+const MIN_ROOM = 96;
+
+// How long a typeahead buffer survives between keystrokes. Measured from the
+// previous keystroke rather than reset by a timer: there is no timeout to cancel
+// when the control unmounts mid-word, and nothing to fake in a test.
+const TYPEAHEAD_RESET_MS = 500;
+
+type PopupFrame = Readonly<{
+  left: number;
+  width: number;
+  maxHeight: number;
+  // Exactly one of these is set. A popup below the trigger is anchored by its
+  // top; a flipped one by its bottom, because anchoring it by `top` would need
+  // its rendered height, which is not known until after it has painted.
+  top?: number;
+  bottom?: number;
+  above: boolean;
+}>;
+
+function frameFor(rect: DOMRect, view: { width: number; height: number }) {
+  const roomBelow = view.height - rect.bottom - ANCHOR_GAP - VIEWPORT_MARGIN;
+  const roomAbove = rect.top - ANCHOR_GAP - VIEWPORT_MARGIN;
+  const flip = roomBelow < MIN_ROOM && roomAbove > roomBelow;
+  const rightEdge = view.width - rect.width - VIEWPORT_MARGIN;
+  const frame = {
+    left: Math.max(VIEWPORT_MARGIN, Math.min(rect.left, rightEdge)),
+    width: rect.width,
+    maxHeight: Math.max(flip ? roomAbove : roomBelow, MIN_ROOM),
+  };
+  return flip
+    ? { ...frame, bottom: view.height - rect.top + ANCHOR_GAP, above: true }
+    : { ...frame, top: rect.bottom + ANCHOR_GAP, above: false };
+}
+
+// The trigger has scrolled out of sight, so the popup has nothing left to point
+// at. A box of zeros is NOT that case: it means nothing has been laid out (a
+// jsdom render, a trigger inside a collapsed container), and there is no
+// position to judge yet.
+function outOfView(rect: DOMRect, viewHeight: number): boolean {
+  const laidOut = rect.width > 0 || rect.height > 0;
+  return laidOut && (rect.bottom <= 0 || rect.top >= viewHeight);
+}
+
+/**
+ * Anchor a fixed-position popup to a trigger's box.
+ *
+ * The popup is portalled to the body because most of these controls sit in a
+ * toolbar inside `.scroll` (app/shell.css), which is `overflow-y: auto;
+ * position: relative` — it clips an absolutely positioned child and scrolls it
+ * away from its own trigger. Leaving the scroller costs the popup everything
+ * that used to move it, so the frame is recomputed on every scroll and resize,
+ * and `onLost` closes it once the trigger itself is gone from view.
+ *
+ * The scroll listener is CAPTURE-phase: scroll does not bubble, so a listener on
+ * the window never hears the toolbar's own scroller otherwise.
+ */
+function useAnchoredPopup(
+  anchor: RefObject<HTMLElement | null>,
+  open: boolean,
+  onLost: () => void,
+): PopupFrame | null {
+  const [frame, setFrame] = useState<PopupFrame | null>(null);
+
+  // Layout effect, not effect: the position is computed before the browser
+  // paints, so the popup never appears at the wrong place for one frame.
+  useLayoutEffect(() => {
+    if (!open) {
+      setFrame(null);
+      return;
+    }
+    const place = () => {
+      const element = anchor.current;
+      if (!element) {
+        return;
+      }
+      const rect = element.getBoundingClientRect();
+      const view = {
+        width: globalThis.innerWidth,
+        height: globalThis.innerHeight,
+      };
+      if (outOfView(rect, view.height)) {
+        onLost();
+        return;
+      }
+      setFrame(frameFor(rect, view));
+    };
+    place();
+    globalThis.addEventListener("scroll", place, true);
+    globalThis.addEventListener("resize", place);
+    return () => {
+      globalThis.removeEventListener("scroll", place, true);
+      globalThis.removeEventListener("resize", place);
+    };
+  }, [open, anchor, onLost]);
+
+  return frame;
+}
+
+// A pointer press outside both the trigger and the popup closes the list.
+// Capture phase so a surface that stops the event on its own container cannot
+// leave the popup stranded open, and `pointerdown` rather than `click` so the
+// list is gone by the time the press lands on whatever the reader was reaching
+// for underneath it.
+function useDismissOnOutsidePress(
+  open: boolean,
+  dismiss: () => void,
+  trigger: RefObject<HTMLElement | null>,
+  popup: RefObject<HTMLElement | null>,
+) {
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    const onPointerDown = (event: Event) => {
+      const target = event.target;
+      if (!(target instanceof Node)) {
+        return;
+      }
+      if (
+        trigger.current?.contains(target) ||
+        popup.current?.contains(target)
+      ) {
+        return;
+      }
+      dismiss();
+    };
+    globalThis.addEventListener("pointerdown", onPointerDown, true);
+    return () =>
+      globalThis.removeEventListener("pointerdown", onPointerDown, true);
+  }, [open, dismiss, trigger, popup]);
+}
+
+// The next option at or after `from` that a keyboard may land on, walking in
+// `step`'s direction. Deliberately does not wrap: a list that jumps from its
+// last entry back to its first hides from the reader that they reached the end.
+function stepEnabled(
+  options: readonly SelectOption[],
+  from: number,
+  step: 1 | -1,
+): number {
+  for (let index = from; index >= 0 && index < options.length; index += step) {
+    if (!options[index]?.disabled) {
+      return index;
+    }
+  }
+  return -1;
+}
+
+/**
+ * What a keypress means to a combobox, as data and with no React in it.
+ *
+ * The whole keyboard contract lives here so it can be read in one screen and
+ * argued with: the same key means different things open and closed, which is the
+ * part every hand-rolled dropdown gets partly right.
+ *
+ * `null` is "not ours" — the press keeps its default, which is what lets Tab,
+ * the browser's own shortcuts and a screen reader's keys through.
+ */
+type KeyIntent =
+  | Readonly<{ act: "open"; step: 1 | -1 }>
+  | Readonly<{ act: "move"; step: 1 | -1 }>
+  | Readonly<{ act: "edge"; step: 1 | -1 }>
+  | Readonly<{ act: "commit" }>
+  | Readonly<{ act: "cancel" }>
+  | Readonly<{ act: "leave" }>
+  | Readonly<{ act: "search"; char: string }>
+  | null;
+
+function intentFor(key: string, open: boolean): KeyIntent {
+  if (!open) {
+    if (key === "ArrowUp") {
+      return { act: "open", step: -1 };
+    }
+    // Typeahead on a CLOSED control is deliberately absent: a native select
+    // changes its value when someone types "w" while tabbing past it, and a
+    // stage that moved on a stray keystroke is a defect, not a shortcut.
+    const opens = key === "ArrowDown" || key === "Enter" || key === " ";
+    return opens ? { act: "open", step: 1 } : null;
+  }
+  switch (key) {
+    case "ArrowDown":
+      return { act: "move", step: 1 };
+    case "ArrowUp":
+      return { act: "move", step: -1 };
+    case "Home":
+      return { act: "edge", step: 1 };
+    case "End":
+      return { act: "edge", step: -1 };
+    case "Enter":
+    case " ":
+      return { act: "commit" };
+    case "Escape":
+      return { act: "cancel" };
+    case "Tab":
+      return { act: "leave" };
+    default:
+      return key.length === 1 ? { act: "search", char: key } : null;
+  }
+}
+
+// What each intent does. Named callbacks rather than a bag of setters, so the
+// table in the hook below reads as the behaviour it is.
+type IntentActions = Readonly<{
+  openFrom: (step: 1 | -1) => void;
+  moveBy: (step: 1 | -1) => void;
+  toEdge: (step: 1 | -1) => void;
+  commitActive: () => void;
+  cancel: () => void;
+  leave: () => void;
+  search: (char: string) => void;
+}>;
+
+function keyDownHandler(open: boolean, actions: IntentActions) {
+  return (event: ReactKeyboardEvent<HTMLButtonElement>) => {
+    // A modified press belongs to the browser or the OS (Alt+Arrow is history
+    // navigation, Cmd+F is find) — never to a typeahead buffer.
+    if (event.altKey || event.ctrlKey || event.metaKey) {
+      return;
+    }
+    const intent = intentFor(event.key, open);
+    if (!intent) {
+      return;
+    }
+    // Tab keeps its default so focus can leave; every other press we claim is
+    // ours, and scrolling the page on Space is never what was meant.
+    //
+    // Claimed also means it STOPS HERE. A dropdown is usually inside something
+    // else that listens for the same keys on the document — `Modal` closes on
+    // Escape, a form submits on Enter — and a press meant for the open list must
+    // not also reach them: abandoning a dropdown would take the whole dialog
+    // with it, and choosing an option would submit the form around it.
+    if (intent.act !== "leave") {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+    switch (intent.act) {
+      case "open":
+        return actions.openFrom(intent.step);
+      case "move":
+        return actions.moveBy(intent.step);
+      case "edge":
+        return actions.toEdge(intent.step);
+      case "commit":
+        return actions.commitActive();
+      case "cancel":
+        return actions.cancel();
+      case "leave":
+        return actions.leave();
+      case "search":
+        return actions.search(intent.char);
+    }
+  };
+}
+
+// The typeahead match, kept out of React: a buffer, the character just typed and
+// the moment it arrived produce the next buffer and the option it points at.
+function typeaheadMatch(
+  options: readonly SelectOption[],
+  buffer: Readonly<{ query: string; at: number }>,
+  char: string,
+  now: number,
+): Readonly<{ query: string; at: number; hit: number }> {
+  const carried = now - buffer.at < TYPEAHEAD_RESET_MS;
+  const query = (carried ? buffer.query : "") + char.toLowerCase();
+  const hit = options.findIndex(
+    (option) =>
+      !option.disabled && option.label.toLowerCase().startsWith(query),
+  );
+  return { query, at: now, hit };
+}
+
+// Everything the trigger and the popup need from the state machine below.
+type Listbox = Readonly<{
+  open: boolean;
+  active: number;
+  frame: PopupFrame | null;
+  trigger: RefObject<HTMLButtonElement | null>;
+  popup: RefObject<HTMLDivElement | null>;
+  listboxId: string;
+  optionDomId: (index: number) => string;
+  onKeyDown: (event: ReactKeyboardEvent<HTMLButtonElement>) => void;
+  onTriggerClick: () => void;
+  pick: (index: number) => void;
+  hover: (index: number) => void;
+}>;
+
+/**
+ * The open/active state machine, one level below the markup.
+ *
+ * It owns four things and nothing else: whether the list is open, which option
+ * is active, where the popup sits, and what a keypress does about any of that.
+ * The commit is the only place `onChange` is called, so there is exactly one
+ * path by which a value changes.
+ */
+function useSelectListbox(
+  options: readonly SelectOption[],
+  value: string,
+  onChange: (next: string) => void,
+): Listbox {
+  const [open, setOpen] = useState(false);
+  const [active, setActive] = useState(-1);
+  const trigger = useRef<HTMLButtonElement | null>(null);
+  const popup = useRef<HTMLDivElement | null>(null);
+  const typed = useRef({ query: "", at: 0 });
+  const listboxId = useId();
+
+  // Dismissal WITHOUT moving focus, for the two cases where the reader is
+  // already somewhere else: a press outside, and a trigger scrolled out of view.
+  const dismiss = useCallback(() => setOpen(false), []);
+  const frame = useAnchoredPopup(trigger, open, dismiss);
+  useDismissOnOutsidePress(open, dismiss, trigger, popup);
+  useActiveOptionVisible(open, active, listboxId);
+
+  const selectedIndex = options.findIndex((option) => option.value === value);
+  const edge = (step: 1 | -1) =>
+    stepEnabled(options, step === 1 ? 0 : options.length - 1, step);
+
+  const openFrom = (step: 1 | -1) => {
+    const onSelected =
+      selectedIndex !== -1 && !options[selectedIndex]?.disabled;
+    setActive(onSelected ? selectedIndex : edge(step));
+    setOpen(true);
+  };
+
+  const commit = (index: number) => {
+    const option = options[index];
+    if (!option || option.disabled) {
+      // Nothing to commit — the list stays open on the reader's own choice
+      // rather than closing as if something had been picked.
+      return;
+    }
+    onChange(option.value);
+    setOpen(false);
+    trigger.current?.focus();
+  };
+
+  const search = (char: string) => {
+    const match = typeaheadMatch(options, typed.current, char, Date.now());
+    typed.current = { query: match.query, at: match.at };
+    if (match.hit !== -1) {
+      setActive(match.hit);
+    }
+  };
+
+  // What each intent actually does, as a table. It reads as the keyboard's
+  // contract spelled a second way — `intentFor` says what a key means, this says
+  // what happens — and keeping the two apart is what makes either readable.
+  const actions: IntentActions = {
+    openFrom,
+    moveBy: (step) => {
+      const from = active === -1 ? edge(step) : active + step;
+      const next = stepEnabled(options, from, step);
+      if (next !== -1) {
+        setActive(next);
+      }
+    },
+    toEdge: (step) => setActive(edge(step)),
+    commitActive: () => commit(active),
+    cancel: () => {
+      setOpen(false);
+      trigger.current?.focus();
+    },
+    leave: () => setOpen(false),
+    search,
+  };
+
+  return {
+    open,
+    active,
+    frame,
+    trigger,
+    popup,
+    listboxId,
+    optionDomId: (index: number) => `${listboxId}-option-${index}`,
+    onKeyDown: keyDownHandler(open, actions),
+    onTriggerClick: () => (open ? setOpen(false) : openFrom(1)),
+    pick: commit,
+    hover: setActive,
+  };
+}
+
+// Keeps the active option visible while a reader arrows through a list longer
+// than the popup. The call is optional because jsdom implements no
+// scrollIntoView, and the keyboard path has to stay testable.
+function useActiveOptionVisible(
+  open: boolean,
+  active: number,
+  listboxId: string,
+) {
+  useEffect(() => {
+    if (!open || active === -1) {
+      return;
+    }
+    const element = document.getElementById(`${listboxId}-option-${active}`);
+    element?.scrollIntoView?.({ block: "nearest" });
+  }, [open, active, listboxId]);
+}
+
+export function Select(props: SelectProps) {
+  const { options, value, onChange, name } = props;
+  const listbox = useSelectListbox(options, value, onChange);
+  const reduced = usePrefersReducedMotion();
+
+  return (
+    <>
+      <SelectTrigger field={props} listbox={listbox} />
+      {/* The value a real <form> submits. The trigger is a button, which carries
+          no form value of its own, so a screen that posts a form rather than
+          calling the typed client keeps working unchanged. */}
+      {name !== undefined && <input type="hidden" name={name} value={value} />}
+      {listbox.open && listbox.frame
+        ? createPortal(
+            <SelectPopup
+              options={options}
+              value={value}
+              frame={listbox.frame}
+              listbox={listbox}
+              animate={!reduced}
+            />,
+            document.body,
+          )
+        : null}
+    </>
+  );
+}
+
+function SelectTrigger({
+  field,
+  listbox,
+}: Readonly<{ field: SelectProps; listbox: Listbox }>) {
+  const { open, active } = listbox;
+  const selected = field.options.find((option) => option.value === field.value);
+  return (
+    <button
+      type="button"
+      ref={listbox.trigger}
+      id={field.id}
+      className={["input", "select-control", field.className ?? ""]
+        .filter(Boolean)
+        .join(" ")}
+      // NOSONAR: an ARIA combobox over a native <select>, which no engine lets
+      // us style past its closed face — see the module comment.
+      role="combobox"
+      aria-expanded={open}
+      aria-haspopup="listbox"
+      // Only while open: an aria-controls pointing at an element that is not in
+      // the document is an invalid reference, which axe reports and a screen
+      // reader cannot follow.
+      aria-controls={open ? listbox.listboxId : undefined}
+      aria-activedescendant={
+        open && active !== -1 ? listbox.optionDomId(active) : undefined
+      }
+      aria-label={field["aria-label"]}
+      aria-labelledby={field["aria-labelledby"]}
+      aria-describedby={field["aria-describedby"]}
+      aria-invalid={field["aria-invalid"]}
+      aria-required={field.required}
+      disabled={field.disabled}
+      onClick={listbox.onTriggerClick}
+      onKeyDown={listbox.onKeyDown}
+    >
+      <span
+        className={
+          selected ? "select-face" : "select-face select-face-placeholder"
+        }
+      >
+        {selected?.label ?? field.placeholder}
+      </span>
+      <ChevronDown className="select-chevron" size={16} aria-hidden="true" />
+    </button>
+  );
+}
+
+function SelectPopup({
+  options,
+  value,
+  frame,
+  listbox,
+  animate,
+}: Readonly<{
+  options: readonly SelectOption[];
+  value: string;
+  frame: PopupFrame;
+  listbox: Listbox;
+  animate: boolean;
+}>) {
+  return (
+    <div
+      ref={listbox.popup}
+      className="select-popup"
+      // Reduced motion resolves in one place — the hook, not a second media
+      // query in the stylesheet — so the decision is assertable by the suite
+      // rather than only visible in a browser.
+      data-motion={animate ? "in" : "none"}
+      data-above={frame.above ? "true" : undefined}
+      style={{
+        left: frame.left,
+        top: frame.top,
+        bottom: frame.bottom,
+        width: frame.width,
+        maxHeight: frame.maxHeight,
+      }}
+    >
+      {/* Divs rather than ul/li: `role="listbox"` and `role="option"` are the
+          semantics, and a list element that also claims an interactive role is
+          announced twice over. The listbox carries no name of its own either —
+          the combobox that owns it is named, and a second name on the popup is
+          read out on top of it. */}
+      <div className="select-list" id={listbox.listboxId} role="listbox">
+        {options.map((option, index) => (
+          // biome-ignore lint/a11y/useKeyWithClickEvents: the keyboard path is the combobox trigger's own keydown handling
+          // biome-ignore lint/a11y/useFocusableInteractive: an option in an aria-activedescendant listbox must NOT be focusable — focus stays on the combobox, which is what makes typeahead and Escape work
+          <div
+            key={option.value}
+            id={listbox.optionDomId(index)}
+            role="option"
+            aria-selected={option.value === value}
+            aria-disabled={option.disabled}
+            className={[
+              "select-option",
+              index === listbox.active ? "is-active" : "",
+              option.disabled ? "is-disabled" : "",
+            ]
+              .filter(Boolean)
+              .join(" ")}
+            onClick={option.disabled ? undefined : () => listbox.pick(index)}
+            onMouseEnter={
+              option.disabled ? undefined : () => listbox.hover(index)
+            }
+          >
+            <span className="select-option-label">{option.label}</span>
+            {option.value === value && (
+              <Check className="select-option-check" size={14} aria-hidden />
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/design-system/window-focus.ts
+++ b/frontend/src/design-system/window-focus.ts
@@ -108,12 +108,22 @@ export function retainWindowFocusSignal(): () => void {
   };
 }
 
-/** Be told when focus changes, for as long as the returned release is unused. */
+/**
+ * Be told when focus changes, for as long as the returned release is unused.
+ *
+ * The CURRENT state arrives first, synchronously, before this returns. That is
+ * the difference between a subscription and a notification: a consumer that only
+ * hears about changes has to seed itself from `isWindowFocused()` and get that
+ * read on the right side of the attach, and a consumer that forgets starts its
+ * life assuming focus it may not have — which for the draw loop means one
+ * frameless sphere until the window is next clicked.
+ */
 export function subscribeToWindowFocus(
   onChange: (focused: boolean) => void,
 ): () => void {
   attachIfFirst();
   listeners.add(onChange);
+  onChange(isWindowFocused());
   return () => {
     listeners.delete(onChange);
     detachIfLast();

--- a/frontend/src/design-system/window-focus.ts
+++ b/frontend/src/design-system/window-focus.ts
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+/**
+ * Whether this window has focus — ONE signal, for the whole document.
+ *
+ * A window sitting behind another one is not being watched, so the Core holds
+ * still there. Two very different consumers need that answer: the WebGL draw
+ * loop, which parks, and the stylesheet, which pauses its rhythms off
+ * `data-window-blurred` on the root element. Both read the state maintained
+ * here, so the sphere and its glow can never disagree about whether the Core is
+ * moving — the failure that duplicating the condition per consumer produces.
+ *
+ * ONE `focus`/`blur` pair for the document however many Cores are mounted, held
+ * only while somebody wants it: the listeners arrive with the first consumer and
+ * leave with the last, so nothing outlives the last Core — not a listener, and
+ * not the attribute.
+ *
+ * `document.hasFocus()` is read once per attach, to seed the state, and never
+ * again. It is deliberately not polled: a poll answers only for the instant it
+ * is asked, and the draw loop's rule is that a condition may park it only if the
+ * END of that condition is announced by an event (see the loop in
+ * margince-core-liquid.tsx). `focus` is that announcement; asking would be a
+ * missed resume and a permanently frozen sphere.
+ */
+
+/** Present on `<html>` exactly while the window does not have focus. */
+export const WINDOW_BLURRED_ATTRIBUTE = "data-window-blurred";
+
+/** Null while nothing holds the signal: there are no listeners keeping it true,
+ *  so there is no state to report either. */
+let focused: boolean | null = null;
+const listeners = new Set<(focused: boolean) => void>();
+/** Consumers that want the attribute reflected but have nothing to be told. */
+let holders = 0;
+
+function held(): boolean {
+  return listeners.size + holders > 0;
+}
+
+function reflect(): void {
+  const root = document.documentElement;
+  if (focused === false) {
+    root.setAttribute(WINDOW_BLURRED_ATTRIBUTE, "");
+  } else {
+    root.removeAttribute(WINDOW_BLURRED_ATTRIBUTE);
+  }
+}
+
+/**
+ * Publish a change, once.
+ *
+ * The equality check is not a micro-optimisation: a window activation can fire
+ * `focus` more than once (returning to a window that also moves focus into an
+ * element inside it), and without it every consumer would be told to wake for
+ * each of them.
+ */
+function announce(next: boolean): void {
+  if (focused === next) {
+    return;
+  }
+  focused = next;
+  reflect();
+  for (const listener of listeners) {
+    listener(next);
+  }
+}
+
+// Named, module-level handlers: the same function identity has to reach
+// removeEventListener, or the pair below would attach again on every attach.
+const onWindowFocus = () => announce(true);
+const onWindowBlur = () => announce(false);
+
+function attachIfFirst(): void {
+  if (held()) {
+    return;
+  }
+  focused = document.hasFocus();
+  reflect();
+  window.addEventListener("focus", onWindowFocus);
+  window.addEventListener("blur", onWindowBlur);
+}
+
+function detachIfLast(): void {
+  if (held()) {
+    return;
+  }
+  window.removeEventListener("focus", onWindowFocus);
+  window.removeEventListener("blur", onWindowBlur);
+  // Nothing maintains the state from here, so it must stop being ASSERTED too:
+  // a `data-window-blurred` left behind would pause the animations of the next
+  // Core mounted into a focused window, with no event coming to release it.
+  focused = null;
+  reflect();
+}
+
+/**
+ * Keep the signal — and so `data-window-blurred` — live until the returned
+ * release runs. For the consumer that reads the state through CSS and has
+ * nothing to be called back about.
+ */
+export function retainWindowFocusSignal(): () => void {
+  attachIfFirst();
+  holders += 1;
+  return () => {
+    holders -= 1;
+    detachIfLast();
+  };
+}
+
+/** Be told when focus changes, for as long as the returned release is unused. */
+export function subscribeToWindowFocus(
+  onChange: (focused: boolean) => void,
+): () => void {
+  attachIfFirst();
+  listeners.add(onChange);
+  return () => {
+    listeners.delete(onChange);
+    detachIfLast();
+  };
+}
+
+/**
+ * The current answer.
+ *
+ * Honest before the first attach as well: with no listeners maintaining it there
+ * is no state to hand back, so it asks the document rather than guessing focused
+ * — which is also what seeds a subscriber that arrives into a blurred window.
+ */
+export function isWindowFocused(): boolean {
+  return focused ?? document.hasFocus();
+}

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -1210,6 +1210,7 @@ export const de = {
   "create.organization": "Firma",
   "create.expectedClose": "Erwarteter Abschluss",
 
+  "field.unset": "Nicht gesetzt",
   "field.addEmail": "E-Mail hinzufügen",
   "field.addPhone": "Telefon hinzufügen",
   "field.addDomain": "Domain hinzufügen",

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -2680,7 +2680,7 @@ export const de = {
   "auth.hidePassword": "Passwort ausblenden",
   "auth.capsLock": "Feststelltaste ist an",
   "auth.continueWith": "Weiter mit {brand}",
-  "auth.orWithEmail": "oder per E-Mail",
+  "auth.orDivider": "oder",
   "auth.legalProtected": "Der Zugang zu dieser Organisation ist beschränkt.",
   "auth.legalTerms": "Nutzungsbedingungen",
   "auth.legalPrivacy": "Datenschutz",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -2678,7 +2678,7 @@ export const en = {
   "auth.continueWith": "Continue with {brand}",
   // Labels the password path, not the provider buttons above it: where the
   // installation runs SSO, the form beneath this divider is the fallback door.
-  "auth.orWithEmail": "or with email",
+  "auth.orDivider": "or",
   // §7.1 verbatim. The noun is "organization", not "workspace": ADR-0061/A107
   // keeps `workspace` internal and §7.3 removed it from authentication. And the
   // line states that ACCESS is restricted, never that data is safe, encrypted or

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -1196,6 +1196,7 @@ export const en = {
   "create.organization": "Company",
   "create.expectedClose": "Expected close",
 
+  "field.unset": "Not set",
   "field.addEmail": "Add email",
   "field.addPhone": "Add phone",
   "field.addDomain": "Add domain",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -2680,7 +2680,7 @@ export const vi = {
   "auth.continueWith": "Tiếp tục với {brand}",
   // Labels the password path, not the provider buttons above it: where the
   // installation runs SSO, the form beneath this divider is the fallback door.
-  "auth.orWithEmail": "hoặc bằng email",
+  "auth.orDivider": "hoặc",
   // §7.1 verbatim. The noun is "organization", not "workspace": ADR-0061/A107
   // keeps `workspace` internal and §7.3 removed it from authentication. And the
   // line states that ACCESS is restricted, never that data is safe, encrypted or

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -1207,6 +1207,7 @@ export const vi = {
   "create.organization": "Công ty",
   "create.expectedClose": "Dự kiến chốt",
 
+  "field.unset": "Chưa đặt",
   "field.addEmail": "Thêm email",
   "field.addPhone": "Thêm điện thoại",
   "field.addDomain": "Thêm tên miền",

--- a/frontend/src/screens/aicalls.test.tsx
+++ b/frontend/src/screens/aicalls.test.tsx
@@ -105,6 +105,14 @@ it("renders call badges and expands the attempt and payload detail", async () =>
   expect(screen.getByText("Export as cert scenario")).toBeTruthy();
 });
 
+// The filter stands alone above the table with no visible label beside it, so
+// its name has to come from the control itself — an unnamed combobox tells a
+// screen reader nothing about what it narrows.
+it("names the task filter", async () => {
+  mount();
+  expect(await screen.findByRole("combobox", { name: "Task" })).toBeTruthy();
+});
+
 it("distinguishes capture disabled from a call without payload", async () => {
   mount(false, false);
   await userEvent.click(await screen.findByText("capture_classify"));

--- a/frontend/src/screens/aicalls.test.tsx
+++ b/frontend/src/screens/aicalls.test.tsx
@@ -97,7 +97,9 @@ it("renders call badges and expands the attempt and payload detail", async () =>
   mount();
   expect(await screen.findByText("provider_unavailable")).toBeTruthy();
   expect(screen.getByText("retry ×2")).toBeTruthy();
-  await userEvent.click(screen.getAllByText("capture_classify")[1]);
+  // One element, not the second of two: the task name used to appear in the
+  // filter's option list as well as in the row, and the row is what expands.
+  await userEvent.click(screen.getByText("capture_classify"));
   expect(await screen.findByText(/retry_on_5xx/)).toBeTruthy();
   expect(screen.getByText("Request payload")).toBeTruthy();
   expect(screen.getByText("Export as cert scenario")).toBeTruthy();
@@ -105,13 +107,11 @@ it("renders call badges and expands the attempt and payload detail", async () =>
 
 it("distinguishes capture disabled from a call without payload", async () => {
   mount(false, false);
-  await screen.findAllByText("capture_classify");
-  await userEvent.click(screen.getAllByText("capture_classify")[1]);
+  await userEvent.click(await screen.findByText("capture_classify"));
   expect(await screen.findByText(/Payload capture is off/)).toBeTruthy();
   cleanup();
   mount(true, false);
-  await screen.findAllByText("capture_classify");
-  await userEvent.click(screen.getAllByText("capture_classify")[1]);
+  await userEvent.click(await screen.findByText("capture_classify"));
   expect(
     await screen.findByText("No payload captured for this call."),
   ).toBeTruthy();

--- a/frontend/src/screens/aicalls.tsx
+++ b/frontend/src/screens/aicalls.tsx
@@ -150,6 +150,10 @@ export function AiCallsCard() {
       <SectionHeader title={t("aicalls.title")} sub={t("aicalls.sub")} />
       <QueryStates query={query}>
         <Select
+          // The column header names what this filters on; the control sits above
+          // the table with nothing beside it, so without a name of its own a
+          // screen reader reaches an unnamed combobox.
+          aria-label={t("aicalls.col.task")}
           value={task}
           onChange={setTask}
           // "All tasks" is a real option, not the select's placeholder: a

--- a/frontend/src/screens/aicalls.tsx
+++ b/frontend/src/screens/aicalls.tsx
@@ -7,8 +7,8 @@ import {
   Button,
   EmptyState,
   SectionHeader,
-  Select,
 } from "../design-system/atoms";
+import { Select } from "../design-system/select";
 import { formatDateTime, formatNumber } from "../format/format";
 import { useLocale, useT } from "../i18n";
 import { ExportScenarioDialog } from "./aiexport";
@@ -149,12 +149,18 @@ export function AiCallsCard() {
     <section className="card" style={{ marginBottom: "var(--space-4)" }}>
       <SectionHeader title={t("aicalls.title")} sub={t("aicalls.sub")} />
       <QueryStates query={query}>
-        <Select value={task} onChange={(event) => setTask(event.target.value)}>
-          <option value="">{t("aicalls.filter.all")}</option>
-          {tasks.map((value) => (
-            <option key={value}>{value}</option>
-          ))}
-        </Select>
+        <Select
+          value={task}
+          onChange={setTask}
+          // "All tasks" is a real option, not the select's placeholder: a
+          // reader who filtered to one task has to be able to come back.
+          // A task name is a wire value the server owns, so it is its own
+          // label — there is nothing to translate.
+          options={[
+            { value: "", label: t("aicalls.filter.all") },
+            ...tasks.map((value) => ({ value, label: value })),
+          ]}
+        />
         {calls.length === 0 ? (
           <EmptyState>{t("aicalls.empty")}</EmptyState>
         ) : (

--- a/frontend/src/screens/auth-core.tsx
+++ b/frontend/src/screens/auth-core.tsx
@@ -230,7 +230,6 @@ export function IdentityRegion({
       <aside className="auth-identity" aria-labelledby={identityId}>
         <div className="auth-identity-copy">
           <p className="auth-kicker" id={identityId}>
-            <span className="auth-kicker-dot" aria-hidden />
             {t("auth.coreDisclosure")}
           </p>
 
@@ -316,33 +315,6 @@ function TypedStatement({ text }: Readonly<{ text: string }>) {
       </span>
     </p>
   );
-}
-
-/**
- * The disclosure that survives the phone layout.
- *
- * Below 561px the surface is the task alone and `aside.auth-identity` is gone,
- * which would otherwise take every word about the AI with it — the Core that
- * remains is `aria-hidden` decoration (WDS-CORE-4), so a phone user, and every
- * screen-reader user on one, would be told nothing at all. Decision 1 does not
- * get to lapse at a breakpoint.
- *
- * The boundary statement is the one line that carries it: it is the limit the
- * system states about itself in the first person, so it discloses the AI and
- * bounds it in the same sentence.
- *
- * It sits in the task column rather than inside `.auth-card` so that ONE
- * insertion covers login, forgot, reset, the outcome notices and the
- * unavailable screen. The wide layout hides it in CSS, which keeps it out of
- * the accessibility tree entirely there — the aside is already saying it, and
- * saying it twice would be worse than not saying it here.
- *
- * Static, with no typewriter: the animated one belongs to the identity region,
- * and two streams of the same sentence would be reading it twice.
- */
-export function PhoneDisclosure() {
-  const t = useT();
-  return <p className="auth-phone-disclosure">{t("auth.coreBoundary")}</p>;
 }
 
 function RuntimePosture({ profile }: Readonly<{ profile: AssistantProfile }>) {

--- a/frontend/src/screens/auth-core.tsx
+++ b/frontend/src/screens/auth-core.tsx
@@ -12,7 +12,7 @@ import {
   MarginceCoreScene,
   type MarginceCoreState,
 } from "../design-system/margince-core";
-import { useTypeStream } from "../design-system/motion";
+import { useDocumentIntro, useTypeStream } from "../design-system/motion";
 import { useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 
@@ -112,8 +112,16 @@ export function AuthExperience({
   profile?: AssistantProfile;
   phase: AuthPhase;
 }>) {
+  // The entry choreography belongs to the page load, not to this mount: every
+  // animation below — the staggered rows, the typed statement — is gated on it,
+  // so a remount renders the surface already arrived. See useDocumentIntro.
+  const intro = useDocumentIntro();
   return (
-    <div className="auth-surface" data-auth-phase={phase}>
+    <div
+      className="auth-surface"
+      data-auth-phase={phase}
+      data-auth-intro={intro ? "play" : "done"}
+    >
       {/* A div, NOT a <main>. The frame that hosts this surface already opens a
           <main> (App.tsx's RaillessFrame), and a nested main is invalid HTML that
           puts two "main" entries in a screen reader's landmark rotor — so the
@@ -285,10 +293,17 @@ export function IdentityRegion({
  * no caret.
  */
 function TypedStatement({ text }: Readonly<{ text: string }>) {
-  const { shown, done } = useTypeStream(text, {
+  // Typed once per page load, exactly like the fades around it: a statement
+  // that retypes itself under a reader who has already read it says the page
+  // reloaded, and nothing did. A remount lands on the finished sentence.
+  const intro = useDocumentIntro();
+  const stream = useTypeStream(text, {
     speed: typeSpeedFor(text),
     startDelay: TYPE_START_MS,
+    enabled: intro,
   });
+  const shown = intro ? stream.shown : text;
+  const done = intro ? stream.done : true;
   return (
     <p className="auth-statement">
       <span className="sr-only">{text}</span>

--- a/frontend/src/screens/auth.css
+++ b/frontend/src/screens/auth.css
@@ -19,15 +19,37 @@
  *  - the identity region shows ALL of itself or none of it. Down to 561px it
  *    keeps every limit (two columns, never dropping any, which is what the old
  *    `.auth-core-trust li:nth-child(n + 2) { display: none }` did); below that
- *    the phone layout drops the region entirely and the surface is one
- *    full-height card with the Core in its header. `e2e/ac.spec.ts` pins both
- *    halves of that split.
+ *    the phone layout drops the region — sphere included — and the surface is
+ *    the task alone. `e2e/ac.spec.ts` pins both halves of that split.
+ *
+ * The two regions are two HALVES OF THE PAGE divided by one hairline, not a card
+ * floating in a pane. A wash that stops short of the edge on all four sides
+ * makes the identity region an object the page is holding, and then the eye has
+ * two shapes to place — the card and the column it sits in — before it reaches
+ * the form. Full-bleed halves and a single rule read as one decision.
  */
 
 .auth-surface {
+  /* The surface's own rhythm, in one place, because both halves have to breathe
+     by the same amount for the hairline between them to read as a division of one
+     page. Built on the --space scale so the gaps stay on the rhythm the rest of
+     the product uses, and clamped against the viewport so a small laptop keeps
+     its content and a wide display does not turn the form into a distant object.
+     The identity half starts lower: the wordmark is parked in its top-left
+     corner, and the cluster below must not reach into it. */
+  --authPadBlock: clamp(var(--space-6), 8vh, calc(var(--space-6) * 3.5));
+  --authPadInline: clamp(var(--space-6), 5vw, calc(var(--space-6) * 4));
+  --authIdentityPadTop: clamp(
+    calc(var(--space-6) * 4),
+    14vh,
+    calc(var(--space-6) * 6)
+  );
   min-height: 100vh;
   display: grid;
-  grid-template-columns: 0.98fr 1.02fr;
+  grid-template-columns: 1fr 1fr;
+  /* The positioning context for the wordmark, which is placed against the PAGE
+     at desktop widths rather than against the column it happens to live in. */
+  position: relative;
   background: var(--bgElevated);
 }
 @supports (min-height: 100dvh) {
@@ -92,29 +114,40 @@
      `.auth-identity-col` already carries this; the task region was the one that
      did not. */
   min-width: 0;
-  padding: 48px 5vw;
+  /* Air, and a lot of it: the form is one narrow measure and everything the eye
+     does not need is empty space around it. */
+  padding: var(--authPadBlock) var(--authPadInline);
   background: var(--bgElevated);
 }
 .auth-task-in {
   /* §6.2: 380 minimum, 400 preferred, 440 maximum. */
   width: 100%;
   min-width: 0;
-  max-width: 440px;
+  max-width: 400px;
   display: flex;
   flex-direction: column;
-  gap: 22px;
-  /* `auth-rise-fade`, not the shared `auth-rise`: this wrapper holds the
-     primary action, and the shared keyframe's `from` state displaces its
-     content 16px down for the length of the delay — see the keyframe's own
-     comment. */
+  gap: var(--space-6);
+  /* `auth-rise-fade`, not the shared `auth-rise`: this wrapper holds the primary
+     action, and the shared keyframe's `from` state displaces its content 16px
+     down for the length of the delay — see the keyframe's own comment. */
   animation: auth-rise-fade 0.8s 0.1s cubic-bezier(0.23, 1, 0.32, 1) both;
 }
 
+/*
+ * The wordmark says WHERE you are, and that is a property of the page rather
+ * than of the form — so on the two-column layout it sits in the page's top-left
+ * corner (see the ≥960 block below) and the form column starts at its heading.
+ *
+ * It stays FIRST IN THE DOM, inside the task column, in both layouts: the
+ * corner placement is presentation, and moving the markup into the identity
+ * region to match the picture would put the product's name after the form in
+ * reading order — and behind a media query for whether it exists at all.
+ */
 .auth-wordmark {
   align-self: flex-start;
   display: grid;
   place-items: center;
-  margin: 0 0 4px;
+  margin: 0;
 }
 /* Deliberately smaller than the heading's weight in the column. At 176px the
    wordmark and "Sign in to Margince" were two headlines stacked, competing for
@@ -142,19 +175,25 @@
   box-shadow: none;
   padding: 0;
 }
+/* The one thing on this half of the page that is allowed to be big. It scales
+   with the viewport because the column it sits in does — at a fixed 28px the
+   heading read as a label on a wide display and as a headline on a laptop. */
 .auth-card h1 {
   font-family: var(--f-display);
   font-weight: 600;
-  font-size: 28px;
+  font-size: clamp(27px, 2.2vw, 33px);
   letter-spacing: -0.02em;
   line-height: 1.15;
   color: var(--textPrimary);
 }
+/* --textSecondary, not --textMeta: this line is body copy under the heading, and
+   --textMeta is the small-text role for 11-13px meta. Read at 14.5px it was the
+   quietest thing on a screen with only three sentences on it. */
 .auth-card .card-sub {
-  margin-top: 8px;
-  font-size: 13.5px;
-  color: var(--textMeta);
-  line-height: 1.5;
+  margin-top: var(--space-2);
+  font-size: 14.5px;
+  color: var(--textSecondary);
+  line-height: 1.55;
 }
 
 /* ===== federated sign-in (§11) ========================================== */
@@ -163,17 +202,19 @@
    below can do the spacing. A `display: contents` wrapper would have looked
    equivalent and silently broken that: sibling selectors walk the DOM tree, not
    the box tree. */
+/* STACKED, full width, so every way into this installation — a provider button
+   and the primary submit below the fields — presents the same target on the same
+   left edge. Side by side, two providers made a row of half-width boxes that the
+   eye reads as a segmented control offering a choice between them rather than as
+   two doors; a third would have divided the row again. The phone layout puts them
+   back on one line, where vertical space is the scarce thing (see the ≤560
+   block). */
 .auth-sso {
-  margin-top: 22px;
+  margin-top: var(--space-4);
   display: flex;
-  /* Wraps, and the buttons carry a flex-basis rather than `flex: 1` alone. With
-     one line and no basis, a third provider divides the row into slices narrower
-     than the brand word inside them, and `min-width: 0` on the button then lets
-     it shrink past its own content — so the label overflows the card rather than
-     the row growing a second line. Nothing serves 3 providers today; the layout
-     should not be what discovers that it can. */
+  flex-direction: column;
   flex-wrap: wrap;
-  gap: 10px;
+  gap: var(--space-2);
 }
 /* Not the Button atom, deliberately: `btn-ghost` contributes a background, a
    colour, a border colour, a radius, a weight and a padding, and this control
@@ -181,11 +222,13 @@
    reuse. If the DS ever wants this look it wants a new Button VARIANT, which is
    a design-system change rather than a screen's business. */
 .auth-social {
-  /* A basis, so a wrapped row breaks into readable buttons instead of dividing
-     one line into slices narrower than the words in them. */
-  flex: 1 1 140px;
+  /* `flex: none` and a full width, because the stack's main axis is VERTICAL: a
+     basis here is a HEIGHT, and `flex: 1 1 140px` made every provider a 140px
+     tall box. The phone layout turns the row back on and sets its own basis. */
+  flex: none;
+  width: 100%;
   min-width: 0;
-  min-height: 44px;
+  min-height: 46px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -247,10 +290,10 @@
 .auth-or {
   display: flex;
   align-items: center;
-  gap: 12px;
-  margin: 18px 0 4px;
+  gap: var(--space-3);
+  margin: var(--space-6) 0 var(--space-1);
   font-family: var(--f-mono);
-  font-size: 9.5px;
+  font-size: 10px;
   font-weight: 500;
   letter-spacing: 0.14em;
   text-transform: uppercase;
@@ -267,18 +310,18 @@
 .auth-fields {
   display: flex;
   flex-direction: column;
-  gap: 14px;
-  margin-top: 20px;
+  gap: var(--space-4);
+  margin-top: var(--space-6);
 }
 /* When the federated block is present it already carries the divider's spacing,
    so the fields must not add a second gap on top of it. */
 .auth-or + .auth-fields {
-  margin-top: 14px;
+  margin-top: var(--space-4);
 }
 .auth-field {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: var(--space-2);
 }
 .auth-label-row {
   display: flex;
@@ -291,9 +334,9 @@
    label was reading the decorative tier instead. Caught by the axe sweep the
    moment the login screen was finally in it. */
 .auth-field label {
-  font-size: 11px;
+  font-size: 11.5px;
   font-weight: 600;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.07em;
   text-transform: uppercase;
   color: var(--textMeta);
 }
@@ -316,8 +359,10 @@
   align-items: center;
   gap: 9px;
   /* §6.5 / §12: 44px is the target floor, and it is a floor rather than a
-     rounded-up number — a 40px control fails the same check on a phone. */
-  min-height: 44px;
+     rounded-up number — a 40px control fails the same check on a phone. 46 sits
+     just over it, matching the provider buttons above so the column reads as one
+     set of controls. */
+  min-height: 46px;
   /* No right padding: the reveal control claims the full inner height so its
      target meets the 44px floor rather than being a 24px icon with air around
      it. The input carries its own right padding instead. */
@@ -354,7 +399,7 @@
   border: 0;
   padding: 11px 13px 11px 0;
   font-family: var(--f-body);
-  font-size: 14.5px;
+  font-size: 15px;
   color: var(--textPrimary);
   background: none;
   outline: 0;
@@ -389,14 +434,14 @@
   outline-offset: -3px;
 }
 .auth-actions {
-  margin-top: 22px;
+  margin-top: var(--space-6);
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--space-3);
 }
 .auth-actions .btn {
   width: 100%;
-  min-height: 44px;
+  min-height: 48px;
   justify-content: center;
   /* Overrides the atom's `white-space: nowrap`. A nowrap label in a full-width
      button cannot overflow the button — it widens it, and the card with it, until
@@ -463,11 +508,13 @@
 /* The locale switcher: a CONTROL, so it belongs to the card column and stays
    inside `.auth-task-in` (row 1 of the task grid). `.auth-legal` below is the
    other footer — region chrome, row 2 — and the two never meet. */
+/* Left, on the form's own edge, like every other line in this column. Centred it
+   was the one thing on the surface that answered to nothing above it. */
 .auth-footer {
   display: flex;
   align-items: center;
-  justify-content: center;
-  gap: 8px;
+  flex-wrap: wrap;
+  gap: var(--space-2);
   color: var(--textTertiary);
   margin-top: auto;
 }
@@ -490,14 +537,15 @@
   align-self: end;
   display: flex;
   flex-direction: column;
-  /* Centred at every width, under a card whose own footer row (the locale
-     switcher) is centred too — left-aligned it read as a stray third column. */
-  align-items: center;
-  text-align: center;
-  gap: 6px;
+  /* Left, sharing the form's measure and its left edge: the column has one
+     alignment now, top to bottom, and the fine print is the last line of it
+     rather than a centred block under a left-aligned form. */
+  align-items: flex-start;
+  text-align: left;
+  gap: var(--space-2);
   width: 100%;
-  max-width: 440px;
-  padding-top: 32px;
+  max-width: 400px;
+  padding-top: calc(var(--space-6) * 1.5);
   font-size: 11px;
   line-height: 1.5;
   color: var(--textMeta);
@@ -513,8 +561,7 @@
      It holds at 100%, and a row that only holds at 100% is one text-zoom step
      from pushing the surface wider than the viewport. */
   flex-wrap: wrap;
-  justify-content: center;
-  gap: 8px;
+  gap: var(--space-2);
 }
 .auth-legal a {
   color: var(--textContent);
@@ -548,13 +595,12 @@
 .auth-identity-col {
   order: 1;
   position: relative;
-  /* A CARD inset in the page rather than a full-bleed column: the wash reads as
-     an object the surface holds, and the task region gets an edge to sit against
-     that is a gap rather than a hairline. `overflow: hidden` is what makes the
-     radius clip the wash and the Core's halo. */
-  margin: var(--space-6);
-  border-radius: var(--r-lg);
-  box-shadow: var(--shadow-card);
+  /* A FULL-BLEED HALF of the page, divided from the task by one hairline. The
+     wash runs to all four edges, so the region is a side of the page rather than
+     an object on it, and the form's side is plain — which is the whole
+     separation. `overflow: hidden` stays: the Core's halo and its mote field
+     reach past the sphere, and they belong to this side of the rule. */
+  border-right: 1px solid var(--borderSubtle);
   overflow: hidden;
   min-width: 0;
   display: grid;
@@ -565,11 +611,14 @@
      same four things and is right to. */
   grid-template-rows: repeat(2, auto);
   align-content: center;
-  justify-items: center;
-  gap: var(--space-6);
-  padding: 48px 5vw;
-  /* No border: the card's own edge and the gap around it are the separation the
-     hairline used to carry. */
+  /* The WORDS start on the same left edge as the wordmark above them, so this
+     half of the page has one text axis running down it. The sphere is the
+     exception and centres itself (below): it is an object floating in the pane
+     rather than a line of type, and pinned to the text axis its halo met the
+     column's own clipped edge. */
+  justify-items: start;
+  gap: calc(var(--space-6) * 1.5);
+  padding: var(--authIdentityPadTop) var(--authPadInline) var(--authPadBlock);
   /* Four layers, matching the artifact's stack. The port had three and had the
      first one backwards: the artifact's top-left wash is an opaque pale mint
      that LIGHTENS toward white, and a translucent accent wash darkens instead.
@@ -620,6 +669,7 @@
  * second knob.
  */
 .auth-identity-col .core {
+  justify-self: center;
   --coreSize: clamp(150px, 17vw, 230px);
   --coreGlass: calc(var(--coreSize) * 0.748);
 }
@@ -854,6 +904,32 @@
 }
 
 /* ===== breakpoints ====================================================== */
+/* The two-column layout, and the ONE thing that is placed against the page
+   rather than inside a column: the wordmark, in the top-left corner, over the
+   identity half. Out of flow, so the form column has nothing above its heading
+   and centres as one block — which is what gives the task the middle of its half
+   of the screen.
+
+   Bounded to the split deliberately. Below it there is no left half to sit in and
+   no slack to spend: the wordmark goes back to being the first line of the form,
+   where a 640×400 viewport at 200% zoom can still read it. */
+@media (min-width: 960px) {
+  /* The task COLUMN is what has to be lifted, not the wordmark inside it: the
+     wordmark's own `z-index` is resolved inside `.auth-task-in`, which is a
+     stacking context of its own because it carries a filling opacity animation.
+     From in there, no z-index can reach past `.auth-task`'s sibling — and the
+     identity column is that sibling, later in the DOM, so it painted over the
+     product's name. A grid item honours z-index without being positioned, which
+     is what makes this one declaration enough. */
+  .auth-task {
+    z-index: 1;
+  }
+  .auth-wordmark {
+    position: absolute;
+    top: var(--authPadBlock);
+    left: var(--authPadInline);
+  }
+}
 /* Below 960 the regions stack, task region FIRST — which is what the DOM
    already says, so both `order`s go back to their natural value. */
 @media (max-width: 959px) {
@@ -878,14 +954,11 @@
   }
   /* Row two, and no longer `display: contents`: the wrapper has to survive for
      the Core and the words to be one centred cluster instead of two independent
-     rows of the surface. The card chrome is dropped — at this width the region is
-     a band of the page, not an inset card — so the shadow, radius, margin and
-     wash all go, and a hairline carries the separation instead. */
+     rows of the surface. The dividing rule turns with the layout — the halves are
+     stacked here, so the hairline is on top rather than on the side. */
   .auth-identity-col {
     order: 2;
-    margin: 0;
-    border-radius: 0;
-    box-shadow: none;
+    border-right: 0;
     border-top: 1px solid var(--borderSubtle);
     /* The bloom follows the Core rather than the corner it used to sit in. On the
        wrapper, so it is positioned by the same box the sphere is centred in and
@@ -952,12 +1025,12 @@
 
 @media (max-width: 560px) {
   /* The card is the whole screen here, so its top padding is the page's top
-     margin rather than a card inset — and the Core, which sits lower and is
-     positioned against the surface, does not move with it. */
+     margin rather than a card inset. */
   .auth-task {
     padding: 20px 20px 24px;
   }
-  /* Smaller again on a phone, where it shares its row with the Core. */
+  /* Smaller again on a phone, where the screen is the form and the wordmark is
+     the line above it. */
   .auth-wordmark img {
     width: 112px;
   }
@@ -1000,59 +1073,59 @@
   .auth-social-brand {
     display: inline;
   }
+  /* Back to a ROW here, which is the trade the phone makes: two stacked
+     full-width provider buttons spend ~120px of the height the form needs, and
+     the brand words fit side by side at this width (see `.auth-social-brand`
+     above). */
+  .auth-sso {
+    flex-direction: row;
+  }
   .auth-social {
-    /* The task measure is 280px at the 320px floor (see .auth-legal-links'
-       own comment on that number): two buttons at the base 140px basis plus
-       this row's 7px gap need 287px and wrap into two rows even though
-       "Google"/"Microsoft" fit side by side at this width. A smaller basis
-       keeps two providers on one line here while still leaving room for
-       `.auth-sso`'s wrap to catch a future third. */
-    flex-basis: 128px;
+    /* A shared row again, so each button carries a basis. The task measure is
+       280px at the 320px floor (see .auth-legal-links' own comment on that
+       number): two buttons at a 140px basis plus this row's 7px gap need 287px
+       and wrap into two rows even though "Google"/"Microsoft" fit side by side at
+       this width. 128 keeps two providers on one line here while still leaving
+       room for `.auth-sso`'s wrap to catch a future third. */
+    flex: 1 1 128px;
+    width: auto;
     gap: 7px;
     padding-inline: 10px;
   }
   /*
-   * PHONE ONLY: the surface is the task, one card, full height.
+   * PHONE ONLY: the surface is the task. Nothing else.
    *
-   * The identity region does not fit that and does not survive it, so what it
-   * was there to SAY is carried instead by `.auth-phone-disclosure` in the task
-   * column above. Disclosure is the obligation (Decision 1); the aside is only
-   * the wide layout's way of meeting it. Above this breakpoint (tablet, 200%
-   * zoom, desktop) the region is untouched, and there the phone line is the one
-   * that is off — exactly one of the two is ever in the accessibility tree.
-   * The e2e case pins the split in both directions.
+   * The identity region goes, sphere included — the whole column, not just the
+   * words. On a phone the form is the only thing the screen is for, and a 68px
+   * orb parked beside the disclosure line was the last thing left competing with
+   * it for a first look. The wide layout is where the system gets to introduce
+   * itself; here it gets one sentence.
+   *
+   * That sentence is the obligation and it stays: `.auth-phone-disclosure` in the
+   * task column carries what the aside says (Decision 1), because the Core is
+   * `aria-hidden` and dropping the region without the line would leave a phone
+   * reader told nothing about the AI at all. Above this breakpoint (tablet, 200%
+   * zoom, desktop) the region is untouched and the phone line is the one that is
+   * off — exactly one of the two is ever in the accessibility tree, and the e2e
+   * case pins the split in both directions.
    */
   .auth-surface {
     grid-template-rows: 1fr;
   }
-  .auth-identity {
+  .auth-identity-col {
     display: none;
   }
   /* Set as body copy, not as the aside's display-size statement: here it leads
      into the form rather than anchoring a region of its own, and at 32px it
-     would outweigh the h1 naming the task. */
+     would outweigh the h1 naming the task. Full measure, no left lane: there is
+     no sphere beside it to leave room for. */
   .auth-phone-disclosure {
-    /* Flex, so the sentence sits in the MIDDLE of the lane rather than at the top
-       of it. This is the one place on the surface where centring on the block is
-       the correct answer instead of the wrong one: the thing to align with is a
-       68px sphere, not a line of type, and two lines pinned to the top of a 68px
-       lane read as text that has come loose from the orb beside it. A longer
-       translation outgrows the lane, and then min-height stops binding and this
-       is a no-op — which is also right, because the orb is no longer the taller
-       of the two. */
-    display: flex;
-    align-items: center;
+    display: block;
     margin: 0;
     font-family: var(--f-body);
     font-size: 14px;
     line-height: 1.45;
     color: var(--textSecondary);
-    /* The lane is on the LEFT now, and it holds the Core. The sphere and this
-       sentence are one thing — the AI and what it is telling you about itself —
-       so they share a line instead of sitting in opposite corners of the screen.
-       84px = the 68px sphere plus a 16px gutter. */
-    padding-left: 84px;
-    min-height: 68px;
   }
   .auth-task {
     /* The card is the whole screen, so the fill has to come from the row rather
@@ -1062,45 +1135,33 @@
        line still sits in the bottom row. */
     align-self: stretch;
   }
-  /* The wrapper dissolves again at phone width: its band — hairline, padding,
-     bloom — belongs to the identity words, and those are hidden here, so an intact
-     wrapper would render an empty stripe. Dissolving it also restores the Core's
-     positioning context to the surface, which is what the placement below needs. */
-  .auth-identity-col {
-    display: contents;
-  }
-  /*
-   * The Core sits in the disclosure's left lane, not in a corner: it is out of
-   * flow so it costs the form no height, but it is placed to line up with the
-   * sentence it belongs to.
-   *
-   * The offset is spelled as its parts rather than as one number so it stays
-   * auditable against the rules that produce it — change any of the three and the
-   * sum is visibly wrong. It is safe to anchor to the top even though the card
-   * below is centred: the wordmark and this sentence are the top cluster and do
-   * not move, which is why the card centres with margins rather than the column
-   * centring as a whole.
-   */
-  .auth-identity-col .core {
-    position: absolute;
-    /* .auth-task padding-top + .auth-wordmark min-height + .auth-task-in gap */
-    top: calc(20px + 52px + 16px);
-    left: 20px;
-    z-index: 2;
-    /* A fixed lane, not a column — opt out of the viewport cap. */
-    --coreCap: 100%;
-    --coreSize: 68px;
-    --coreGlass: 54px;
-    /* Pulled in hard: at reach 1 the motes cross the sentence beside it. */
-    --coreFeedReach: 0.38;
-  }
-  /* No right lane on either: the sphere is in the sentence's left lane now, so
-     nothing overhangs the wordmark or the heading and both get the full measure
-     back. The wordmark's height stays fixed because the Core's offset is measured
-     from it. */
-  .auth-wordmark {
-    min-height: 52px;
-  }
+}
+
+/*
+ * The intro belongs to the PAGE LOAD, not to this mount.
+ *
+ * Everything above declares its animation unconditionally, and this one rule
+ * takes them all away again once the document has been introduced — so a surface
+ * React rebuilds afterwards (a probe refetching, a notice arriving, a parent
+ * re-branching) renders where the choreography was going instead of running it at
+ * a reader who has already read it. The attribute comes from useDocumentIntro
+ * (design-system/motion.ts), which is also what stops the statement retyping
+ * itself.
+ *
+ * As one rule rather than a gate on each declaration: this way the animations
+ * stay legible as animations, and the reduced-motion block below — which says the
+ * same thing for a different reason — cannot lose a specificity argument to it.
+ */
+.auth-surface[data-auth-intro="done"]
+:is(
+  .auth-task-in,
+  .auth-kicker,
+  .auth-statement,
+  .auth-scope,
+  .auth-limits,
+  .auth-identity-foot
+) {
+  animation: none;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/frontend/src/screens/auth.css
+++ b/frontend/src/screens/auth.css
@@ -172,6 +172,15 @@
   display: block;
 }
 
+/* `width: 100%`, and it is load-bearing rather than tidy: centring the task
+   column's items (`.auth-task-in`) turns off the cross-axis stretch a flex column
+   gives its children by default, so a card with no width of its own shrinks to fit
+   its content — and the fields, the provider buttons and the submit then measure
+   whatever the longest label happens to be instead of the column's 400px. */
+.auth-card,
+.auth-notice {
+  width: 100%;
+}
 .auth-card {
   background: transparent;
   border: 0;
@@ -885,15 +894,17 @@
   color: var(--textContent);
 }
 /*
- * Centred on the FIRST LINE of the text, not on the block — the badge belongs
- * beside the words it opens.
+ * The badge is centred on its limit by the ROW (`.auth-limits li` aligns its items
+ * centre), so it carries no offset of its own. It used to: the row was top-aligned
+ * and the badge shifted down by half the difference between the line box and
+ * itself, to sit on the first line of a wrapping limit. Both mechanisms at once is
+ * a badge centred and then pushed off centre.
  *
- * Neither flex keyword can do it. `flex-start` aligns the two boxes' TOPS, and a
- * 22px badge against a 16.8px line box then sits 2.6px low. `center` is right for
- * a one-line limit and wrong for a wrapped one — German runs these to two and
- * three lines, and there it puts the badge in the middle of the paragraph. Half
- * the difference between the line box and the badge is the offset that holds in
- * both, so it is spelled as that subtraction rather than as a magic -2.6px.
+ * What that costs, stated: a limit long enough to wrap gets its badge beside the
+ * MIDDLE of the paragraph rather than beside its first line. The limits are short
+ * by design — one clause each — and they flow as a wrapping row now rather than
+ * being squeezed into fixed columns, so a wrapped one is the exception; if a
+ * translation makes it the rule, the row is what changes, in one place.
  */
 .auth-limit-icon {
   --limitIcon: 22px;
@@ -902,7 +913,6 @@
   place-items: center;
   width: var(--limitIcon);
   height: var(--limitIcon);
-  margin-top: calc((1lh - var(--limitIcon)) / 2);
   border-radius: var(--r-sm);
   color: var(--accent);
   background: var(--accentSurface);

--- a/frontend/src/screens/auth.css
+++ b/frontend/src/screens/auth.css
@@ -30,20 +30,18 @@
  */
 
 .auth-surface {
-  /* The surface's own rhythm, in one place, because both halves have to breathe
-     by the same amount for the hairline between them to read as a division of one
-     page. Built on the --space scale so the gaps stay on the rhythm the rest of
-     the product uses, and clamped against the viewport so a small laptop keeps
-     its content and a wide display does not turn the form into a distant object.
-     The identity half starts lower: the wordmark is parked in its top-left
-     corner, and the cluster below must not reach into it. */
-  --authPadBlock: clamp(var(--space-6), 8vh, calc(var(--space-6) * 3.5));
-  --authPadInline: clamp(var(--space-6), 5vw, calc(var(--space-6) * 4));
-  --authIdentityPadTop: clamp(
-    calc(var(--space-6) * 4),
-    14vh,
-    calc(var(--space-6) * 6)
-  );
+  /* The surface's own rhythm, in one place: ONE pair of values, read by both
+     halves at every width above the phone, so the inset does not change when the
+     layout turns from two columns into two rows and the hairline between them
+     always divides one page rather than joining two.
+     It used to scale with the viewport, and that was the wrong knob: the air on
+     this surface comes from a 400px column centred in half a screen, not from its
+     gutter, so the clamp only moved the edges around while the composition stayed
+     where it was — and it made the desktop and the tablet two different pages.
+     Arithmetic on the --space scale rather than raw pixels: 36 and 28 are the
+     rungs the tablet was already using. */
+  --authPadBlock: calc(var(--space-6) * 1.5);
+  --authPadInline: calc(var(--space-6) + var(--space-1));
   min-height: 100vh;
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -126,6 +124,13 @@
   max-width: 400px;
   display: flex;
   flex-direction: column;
+  /* Centred, and the whole column with it: the heading, the sentence under it,
+     the divider, the switcher and the fine print all read down one centre line.
+     The FIELDS are the exception and stay left (see `.auth-field` and
+     `.auth-input`): a label centred over a line of typing points at nothing, and
+     a centred value is not how anyone reads what they typed. */
+  align-items: center;
+  text-align: center;
   gap: var(--space-6);
   /* `auth-rise-fade`, not the shared `auth-rise`: this wrapper holds the primary
      action, and the shared keyframe's `from` state displaces its content 16px
@@ -144,7 +149,6 @@
  * reading order — and behind a media query for whether it exists at all.
  */
 .auth-wordmark {
-  align-self: flex-start;
   display: grid;
   place-items: center;
   margin: 0;
@@ -194,6 +198,10 @@
   font-size: 14.5px;
   color: var(--textSecondary);
   line-height: 1.55;
+  /* Balanced, not merely orphan-free: two lines of roughly equal length under a
+     centred heading read as part of the same block; a long line over a short one
+     reads as text that ran out. */
+  text-wrap: balance;
 }
 
 /* ===== federated sign-in (§11) ========================================== */
@@ -248,8 +256,11 @@
     background 0.12s,
     border-color 0.12s;
 }
-/* Which of the two name forms shows. Wide: the installation's full label. The
-   phone breakpoint swaps them — see the ≤560 block. */
+/* The installation's full label, at every width. The markup also carries the
+   short brand word (auth.tsx) for a layout that cannot fit the label — no layout
+   here is that layout any more, since the buttons are stacked full-width even on
+   a phone, so the short form stays off and the words on screen are the ones the
+   operator wrote. */
 .auth-social-brand {
   display: none;
 }
@@ -310,7 +321,7 @@
 .auth-fields {
   display: flex;
   flex-direction: column;
-  gap: var(--space-4);
+  gap: var(--space-2);
   margin-top: var(--space-6);
 }
 /* When the federated block is present it already carries the divider's spacing,
@@ -321,13 +332,27 @@
 .auth-field {
   display: flex;
   flex-direction: column;
-  gap: var(--space-2);
+  /* The label belongs to the control directly under it, and at 8px it read as a
+     line of its own floating between two fields. */
+  gap: var(--space-1);
+  /* Left, inside a centred column: a field is read from its left edge — the
+     label, the caret, the value it holds. */
+  text-align: left;
 }
+/* ONE height for the row, whatever is in it. The label is 11.5px and the
+   "Forgot password?" link beside it is 12.5px, so on a baseline row the two
+   fields' label rows measured differently and the second field sat a pixel or two
+   off the first. A shared line-height fixes the row's height, and centring the
+   items in it keeps the link optically level with the label. */
 .auth-label-row {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   justify-content: space-between;
   gap: 8px;
+  line-height: 18px;
+}
+.auth-label-row > * {
+  line-height: inherit;
 }
 /* --textMeta, not --textTertiary: tokens.css names --textMeta "the canonical AA
    small-text role — all 11-13px meta/caption text reads it", and a 11px uppercase
@@ -400,6 +425,7 @@
   padding: 11px 13px 11px 0;
   font-family: var(--f-body);
   font-size: 15px;
+  text-align: left;
   color: var(--textPrimary);
   background: none;
   outline: 0;
@@ -434,7 +460,7 @@
   outline-offset: -3px;
 }
 .auth-actions {
-  margin-top: var(--space-6);
+  margin-top: var(--space-3);
   display: flex;
   flex-direction: column;
   gap: var(--space-3);
@@ -450,6 +476,9 @@
      being clipped by it. */
   white-space: normal;
 }
+/* A link, not a button: no padding, so it sits on the same line as the text
+   beside it and its baseline is the row's baseline. The focus ring is offset
+   instead, which is what the padding was buying. */
 .auth-link {
   background: transparent;
   border: 0;
@@ -457,7 +486,7 @@
   font-size: 12.5px;
   font-weight: 500;
   color: var(--accent);
-  padding: 2px;
+  padding: 0;
   text-transform: none;
   letter-spacing: normal;
 }
@@ -508,11 +537,11 @@
 /* The locale switcher: a CONTROL, so it belongs to the card column and stays
    inside `.auth-task-in` (row 1 of the task grid). `.auth-legal` below is the
    other footer — region chrome, row 2 — and the two never meet. */
-/* Left, on the form's own edge, like every other line in this column. Centred it
-   was the one thing on the surface that answered to nothing above it. */
+/* On the column's centre line, like everything else here that is not a field. */
 .auth-footer {
   display: flex;
   align-items: center;
+  justify-content: center;
   flex-wrap: wrap;
   gap: var(--space-2);
   color: var(--textTertiary);
@@ -537,11 +566,10 @@
   align-self: end;
   display: flex;
   flex-direction: column;
-  /* Left, sharing the form's measure and its left edge: the column has one
-     alignment now, top to bottom, and the fine print is the last line of it
-     rather than a centred block under a left-aligned form. */
-  align-items: flex-start;
-  text-align: left;
+  /* Sharing the form's measure and its centre line: the fine print is the last
+     line of the column, not a block answering to a different edge. */
+  align-items: center;
+  text-align: center;
   gap: var(--space-2);
   width: 100%;
   max-width: 400px;
@@ -561,6 +589,7 @@
      It holds at 100%, and a row that only holds at 100% is one text-zoom step
      from pushing the surface wider than the viewport. */
   flex-wrap: wrap;
+  justify-content: center;
   gap: var(--space-2);
 }
 .auth-legal a {
@@ -611,14 +640,15 @@
      same four things and is right to. */
   grid-template-rows: repeat(2, auto);
   align-content: center;
-  /* The WORDS start on the same left edge as the wordmark above them, so this
-     half of the page has one text axis running down it. The sphere is the
-     exception and centres itself (below): it is an object floating in the pane
-     rather than a line of type, and pinned to the text axis its halo met the
-     column's own clipped edge. */
-  justify-items: start;
-  gap: calc(var(--space-6) * 1.5);
-  padding: var(--authIdentityPadTop) var(--authPadInline) var(--authPadBlock);
+  /* One centre line down this half too, the sphere included: the two halves are
+     the same composition mirrored, so the form's centred column has a centred
+     column facing it rather than a left-aligned one. */
+  justify-items: center;
+  text-align: center;
+  gap: var(--space-6);
+  /* The SAME padding as the task half. The two are one page divided by a
+     hairline, and a different inset on each side of it reads as two pages. */
+  padding: var(--authPadBlock) var(--authPadInline);
   /* Four layers, matching the artifact's stack. The port had three and had the
      first one backwards: the artifact's top-left wash is an opaque pale mint
      that LIGHTENS toward white, and a translucent accent wash darkens instead.
@@ -661,16 +691,17 @@
  * rule, and a property declared on the element beats one inherited from an
  * ancestor — which is why the narrow-width override below is written the same way.
  *
- * 17vw tracks the column because the column IS a fraction of the viewport in this
- * layout; the floor keeps it a sphere rather than a dot on a small laptop, and the
- * ceiling is the hero size it was designed at. The glass keeps the primitive's own
- * 172/230 ratio so the shell and the liquid stay in proportion, and the feed's
- * reach is already expressed in fractions of --coreSize, so it follows with no
- * second knob.
+ * ONE size rather than a viewport range: at 230px on a wide display the sphere was
+ * the loudest thing on the page and the sentences beside it read as its caption.
+ * 150 is the size the cluster is composed around — big enough to be the subject of
+ * this half, small enough that the words are what you read first. The glass keeps
+ * the primitive's own 172/230 ratio so the shell and the liquid stay in
+ * proportion, and the feed's reach is already expressed in fractions of
+ * --coreSize, so it follows with no second knob.
  */
 .auth-identity-col .core {
   justify-self: center;
-  --coreSize: clamp(150px, 17vw, 230px);
+  --coreSize: 150px;
   --coreGlass: calc(var(--coreSize) * 0.748);
 }
 /* The region itself: words only. It keeps its own grid so the copy and the
@@ -719,19 +750,11 @@
 .auth-identity-foot {
   animation-delay: 520ms;
 }
-/* (a) identity: the system's presence and name. Mono, small, unmissable. */
-/*
- * `flex-start`, not `center`, and the dot is centred on the FIRST LINE by hand —
- * see `.auth-limit-icon` below for the rule this shares. One line is the only
- * case where the two agree, and this line is one line only in English at full
- * width: "MARGINCE · KI-SYSTEM" in a 440px tablet column, or either language at
- * 200% text zoom, wraps — and `center` then parks the dot in the gutter between
- * the two lines, beside neither of them.
- */
+/* (a) identity: the system's presence and name. Mono, small, unmissable — and
+   words only. The status dot that used to lead this line said nothing the line
+   does not: the sphere above it is the presence, and a second green mark beside
+   the same sentence read as a state indicator for something. */
 .auth-kicker {
-  display: flex;
-  align-items: flex-start;
-  gap: var(--space-2);
   font-family: var(--f-mono);
   font-size: 11px;
   font-weight: 600;
@@ -739,36 +762,19 @@
   text-transform: uppercase;
   color: var(--accent);
 }
-.auth-kicker-dot {
-  --dotSize: 7px;
-  /* Every fixed decoration in a flex row on this surface needs this: a flex item
-     is shrinkable by default, and a circle that may shrink on one axis is an
-     ellipse. */
-  flex: none;
-  width: var(--dotSize);
-  height: var(--dotSize);
-  margin-top: calc((1lh - var(--dotSize)) / 2);
-  border-radius: var(--r-full);
-  background: var(--accent);
-}
 /* (b) the boundary, in the first person. Not a heading — the h1 belongs to the
    task (§6.4), and this is a paragraph however large it is set. */
 .auth-statement {
   position: relative;
-  margin-top: var(--space-3);
+  /* Tight to the kicker above it: the two are one unit — who is speaking, and
+     what they say. */
+  margin-top: var(--space-1);
   font-family: var(--f-display);
   font-size: clamp(22px, 2.4vw, 32px);
   font-weight: 500;
   line-height: 1.14;
   letter-spacing: -0.025em;
   color: var(--textPrimary);
-}
-/* The phone's copy of the boundary statement (`PhoneDisclosure`), which only the
-   ≤560 block turns on. `display: none` rather than a visual hide, deliberately:
-   the identity region is stating the same sentence at this width, and a
-   screen reader must not meet it twice. */
-.auth-phone-disclosure {
-  display: none;
 }
 /* ZERO layout shift while typing. The ghost is the full sentence rendered
    invisibly, so the paragraph is already its final height on the first frame and
@@ -809,6 +815,8 @@
   font-size: 14px;
   line-height: 1.55;
   color: var(--textContent);
+  /* Same reason as the task column's sub-line: no one-word last line. */
+  text-wrap: pretty;
 }
 /* (c) a server-read fact. Reserves its height so the column does not jump when
    the probe resolves — and stays empty rather than guessing when it fails. */
@@ -816,6 +824,9 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
+  /* On the column's centre line like everything else here — a flex row does not
+     inherit `text-align`, so this is the same instruction spelled for a row. */
+  justify-content: center;
   gap: var(--space-2);
   min-height: 31px;
   font-family: var(--f-mono);
@@ -854,23 +865,21 @@
 .auth-limits {
   list-style: none;
   margin-top: var(--space-6);
-  display: grid;
-  /* auto-fit, not repeat(2, 1fr), and the difference is whether text survives.
-     `1fr` is `minmax(auto, 1fr)`, so each track refuses to go below its
-     min-content — while the column this list sits in carries `min-width: 0` and
-     `overflow: hidden`. Two tracks that will not shrink inside a container that
-     will therefore CLIP, and German runs 20-35% longer than English: the limits
-     lost words with no scrollbar to recover them. auto-fit drops to one column
-     instead, and `min(100%, …)` keeps the track from exceeding the container at
-     the narrowest widths. */
-  grid-template-columns: repeat(auto-fit, minmax(min(100%, 13rem), 1fr));
-  gap: var(--space-3) var(--space-4);
+  /* A wrapping ROW, not a grid of tracks. A grid gives every limit the width of
+     the longest one and leaves the short ones trailing air; flowing them lets each
+     take the room its own words need and wrap onto the next line when they run
+     out — which is also what keeps German, 20-35% longer than English, from being
+     clipped by the column's `overflow: hidden` instead of wrapping. */
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: var(--space-2);
 }
 .auth-limits li {
   min-width: 0;
   display: flex;
-  align-items: flex-start;
-  gap: var(--space-2);
+  align-items: center;
+  gap: var(--space-1);
   font-size: 12px;
   line-height: 1.4;
   color: var(--textContent);
@@ -968,7 +977,6 @@
       color-mix(in srgb, var(--coreLight) 26%, transparent) 0%,
       transparent 66%
     );
-    padding: 36px 28px;
     gap: var(--space-4);
     justify-items: center;
   }
@@ -986,7 +994,6 @@
   }
   .auth-task {
     order: 1;
-    padding: 28px 28px 32px;
   }
   /* No right lane and no reserved row height: both existed to keep this row clear
      of a sphere in the corner, and the sphere sits in the second row now. The
@@ -1039,21 +1046,23 @@
     align-items: stretch;
   }
   /*
-   * The card is centred vertically as one block — heading, sentence and controls
-   * together — instead of being pinned to the top with the leftover height pushed
-   * into the middle of it by a pair of auto margins, which left a visible hole
-   * mid-card.
+   * Everything in the column is centred vertically as ONE cluster — wordmark,
+   * heading, sentence, controls, switcher — in the height the stretched row gives
+   * it.
    *
-   * Two auto margins on the CARD do it, and the locale footer's own `margin-top:
-   * auto` has to go for them to work: three competing autos split the free space
-   * three ways and land the card a third of the way down instead of centred. With
-   * the card taking all of it, the footer is pushed to the bottom anyway — the
-   * auto was doing a job that the card's bottom margin now does.
+   * The column does the centring, not the card. Auto margins on the card split the
+   * free space around a single child and leave whatever sits outside it (the
+   * wordmark above, the switcher below) pinned to the ends, which is a form with a
+   * hole above it rather than a centred one. `justify-content` centres the whole
+   * flex column at once, and the locale footer's `margin-top: auto` has to go with
+   * it or that one child claims all the slack again.
    */
   .auth-card {
     display: flex;
     flex-direction: column;
-    margin-block: auto;
+  }
+  .auth-task-in {
+    justify-content: center;
   }
   .auth-footer {
     margin-top: 0;
@@ -1062,70 +1071,27 @@
     /* 16px or iOS zooms the page on focus (§6.5). */
     font-size: 16px;
   }
-  /* Brand word, side by side. "Continue with Microsoft" wraps to three lines in
-     half a 320px screen, and stacking the two buttons to fit it spent ~120px of
-     the height the form needs — while "Microsoft" fits on one line at both
-     widths. The served label stays the accessible name (auth.tsx), and a provider
-     with no brand word keeps showing that label rather than nothing. */
-  .auth-social-full {
-    display: none;
-  }
-  .auth-social-brand {
-    display: inline;
-  }
-  /* Back to a ROW here, which is the trade the phone makes: two stacked
-     full-width provider buttons spend ~120px of the height the form needs, and
-     the brand words fit side by side at this width (see `.auth-social-brand`
-     above). */
-  .auth-sso {
-    flex-direction: row;
-  }
-  .auth-social {
-    /* A shared row again, so each button carries a basis. The task measure is
-       280px at the 320px floor (see .auth-legal-links' own comment on that
-       number): two buttons at a 140px basis plus this row's 7px gap need 287px
-       and wrap into two rows even though "Google"/"Microsoft" fit side by side at
-       this width. 128 keeps two providers on one line here while still leaving
-       room for `.auth-sso`'s wrap to catch a future third. */
-    flex: 1 1 128px;
-    width: auto;
-    gap: 7px;
-    padding-inline: 10px;
-  }
   /*
    * PHONE ONLY: the surface is the task. Nothing else.
    *
-   * The identity region goes, sphere included — the whole column, not just the
-   * words. On a phone the form is the only thing the screen is for, and a 68px
-   * orb parked beside the disclosure line was the last thing left competing with
-   * it for a first look. The wide layout is where the system gets to introduce
-   * itself; here it gets one sentence.
+   * The identity region goes whole — the sphere, the limits, and the AI's own
+   * sentence with them (founder ruling, 2026-08-07). On a phone the form is the
+   * only thing the screen is for, and everything that introduced the system was
+   * competing with it for the first look. The wide layout is where the system
+   * gets to introduce itself.
    *
-   * That sentence is the obligation and it stays: `.auth-phone-disclosure` in the
-   * task column carries what the aside says (Decision 1), because the Core is
-   * `aria-hidden` and dropping the region without the line would leave a phone
-   * reader told nothing about the AI at all. Above this breakpoint (tablet, 200%
-   * zoom, desktop) the region is untouched and the phone line is the one that is
-   * off — exactly one of the two is ever in the accessibility tree, and the e2e
-   * case pins the split in both directions.
+   * The trade this makes, stated rather than hidden: a phone reader is told
+   * nothing here about the AI behind the installation. ADR-0076 Decision 1 asks
+   * for that disclosure at every width, and above this breakpoint (tablet, 200%
+   * zoom, desktop) it is intact — this is a deliberate departure at phone width,
+   * raised in STATUS.md for the spec to reconcile, and `e2e/ac.spec.ts` pins
+   * both halves of the split so it cannot drift back by accident.
    */
   .auth-surface {
     grid-template-rows: 1fr;
   }
   .auth-identity-col {
     display: none;
-  }
-  /* Set as body copy, not as the aside's display-size statement: here it leads
-     into the form rather than anchoring a region of its own, and at 32px it
-     would outweigh the h1 naming the task. Full measure, no left lane: there is
-     no sphere beside it to leave room for. */
-  .auth-phone-disclosure {
-    display: block;
-    margin: 0;
-    font-family: var(--f-body);
-    font-size: 14px;
-    line-height: 1.45;
-    color: var(--textSecondary);
   }
   .auth-task {
     /* The card is the whole screen, so the fill has to come from the row rather

--- a/frontend/src/screens/auth.css
+++ b/frontend/src/screens/auth.css
@@ -17,10 +17,9 @@
  *  - the task region is FIRST in the DOM and `order` puts the identity region to
  *    its left, so reading order and visual order disagree on purpose.
  *  - the identity region shows ALL of itself or none of it. Down to 561px it
- *    keeps every limit (two columns, never dropping any, which is what the old
- *    `.auth-core-trust li:nth-child(n + 2) { display: none }` did); below that
- *    the phone layout drops the region — sphere included — and the surface is
- *    the task alone. `e2e/ac.spec.ts` pins both halves of that split.
+ *    keeps every limit (two columns, never dropping any); below that the phone
+ *    layout drops the region — sphere included — and the surface is the task
+ *    alone.
  *
  * The two regions are two HALVES OF THE PAGE divided by one hairline, not a card
  * floating in a pane. A wash that stops short of the edge on all four sides
@@ -1085,17 +1084,11 @@
    * PHONE ONLY: the surface is the task. Nothing else.
    *
    * The identity region goes whole — the sphere, the limits, and the AI's own
-   * sentence with them (founder ruling, 2026-08-07). On a phone the form is the
-   * only thing the screen is for, and everything that introduced the system was
-   * competing with it for the first look. The wide layout is where the system
-   * gets to introduce itself.
-   *
-   * The trade this makes, stated rather than hidden: a phone reader is told
-   * nothing here about the AI behind the installation. ADR-0076 Decision 1 asks
-   * for that disclosure at every width, and above this breakpoint (tablet, 200%
-   * zoom, desktop) it is intact — this is a deliberate departure at phone width,
-   * raised in STATUS.md for the spec to reconcile, and `e2e/ac.spec.ts` pins
-   * both halves of the split so it cannot drift back by accident.
+   * sentence with them. On a phone the form is the only thing the screen is for,
+   * and everything that introduced the system was competing with it for the first
+   * look. The wide layout is where the system gets to introduce itself; nothing
+   * here says anything about the AI behind the installation, and every layout
+   * above this breakpoint still does.
    */
   .auth-surface {
     grid-template-rows: 1fr;

--- a/frontend/src/screens/auth.test.tsx
+++ b/frontend/src/screens/auth.test.tsx
@@ -426,7 +426,7 @@ describe("federated sign-in", () => {
     expect(
       screen.queryByRole("button", { name: "Continue with Google" }),
     ).toBeNull();
-    expect(screen.queryByText("or with email")).toBeNull();
+    expect(screen.queryByText("or")).toBeNull();
     cleanup();
 
     stubApi(
@@ -448,7 +448,7 @@ describe("federated sign-in", () => {
       screen.getByRole("button", { name: "Continue with Microsoft" }),
     ).toBeTruthy();
     // The divider labels the PASSWORD path below it, not the buttons above.
-    expect(screen.getByText("or with email")).toBeTruthy();
+    expect(screen.getByText("or")).toBeTruthy();
   });
 
   // The UI-preview switch (app/ui-preview.ts), on the screen rather than on the

--- a/frontend/src/screens/auth.tsx
+++ b/frontend/src/screens/auth.tsx
@@ -26,7 +26,7 @@ import {
 } from "../design-system/provider-mark";
 import { LOCALES, localeNameKey, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
-import { AuthExperience, type AuthPhase, PhoneDisclosure } from "./auth-core";
+import { AuthExperience, type AuthPhase } from "./auth-core";
 import { problemMessageOf, throwProblem } from "./common";
 import "./auth.css";
 
@@ -203,7 +203,6 @@ export function AuthScreen({
       phase={view.kind === "login" ? authPhase : "quiet"}
     >
       <Wordmark alt={t("auth.title")} />
-      <PhoneDisclosure />
       {view.kind === "login" && (
         <>
           {notice && (
@@ -290,7 +289,6 @@ export function AvailabilityScreen({
   return (
     <AuthExperience phase="unavailable">
       <Wordmark alt={t("auth.title")} />
-      <PhoneDisclosure />
       <section className="auth-card" role="alert">
         <h1>
           {t(
@@ -496,7 +494,7 @@ export function ProviderButtons({
       {/* Labels the path BELOW it, so a screen reader hears what the divider
           separates rather than a decorative rule. */}
       <p className="auth-or">
-        <span>{t("auth.orWithEmail")}</span>
+        <span>{t("auth.orDivider")}</span>
       </p>
     </>
   );

--- a/frontend/src/screens/company360.test.tsx
+++ b/frontend/src/screens/company360.test.tsx
@@ -1063,15 +1063,17 @@ it("does not offer a role the contact already holds on that deal", async () => {
   await userEvent.click(
     await screen.findByRole("button", { name: "Set role" }),
   );
-  // The offered roles only exist while the control is open, so the list is
-  // opened to be read — and it is read by LABEL, which is what the reader picks
-  // from; the champion role's own label is the word this asserts is absent.
+  // The offered roles only exist while the control is open, so the list is opened
+  // to be read. Asserted as the WHOLE set rather than as the absence of one word:
+  // an absence check passes for the wrong reason the moment a label is recased or
+  // reworded, and what this case is about is that a role this contact already
+  // holds is not offered a second time.
   await userEvent.click(screen.getByLabelText("Role"));
   expect(
     within(screen.getByRole("listbox"))
       .getAllByRole("option")
       .map((option) => option.textContent),
-  ).not.toContain("champion");
+  ).toEqual(["economic buyer", "influencer", "blocker", "end user"]);
 });
 
 describe("company view — Partner is not a permanent tab", () => {

--- a/frontend/src/screens/company360.test.tsx
+++ b/frontend/src/screens/company360.test.tsx
@@ -1063,10 +1063,15 @@ it("does not offer a role the contact already holds on that deal", async () => {
   await userEvent.click(
     await screen.findByRole("button", { name: "Set role" }),
   );
-  const roles = screen.getByLabelText("Role") as HTMLSelectElement;
-  expect([...roles.options].map((option) => option.value)).not.toContain(
-    "champion",
-  );
+  // The offered roles only exist while the control is open, so the list is
+  // opened to be read — and it is read by LABEL, which is what the reader picks
+  // from; the champion role's own label is the word this asserts is absent.
+  await userEvent.click(screen.getByLabelText("Role"));
+  expect(
+    within(screen.getByRole("listbox"))
+      .getAllByRole("option")
+      .map((option) => option.textContent),
+  ).not.toContain("champion");
 });
 
 describe("company view — Partner is not a permanent tab", () => {

--- a/frontend/src/screens/company360.tsx
+++ b/frontend/src/screens/company360.tsx
@@ -10,10 +10,10 @@ import {
   Field,
   Modal,
   SectionHeader,
-  Select,
   Skeleton,
   StatCard,
 } from "../design-system/atoms";
+import { Select } from "../design-system/select";
 import { formatDate, formatDateTime, formatMoney } from "../format/format";
 
 import { useLocale, useT } from "../i18n";
@@ -622,14 +622,12 @@ function SetRoleAction({
               <Select
                 {...control}
                 value={dealId}
-                onChange={(event) => setDealId(event.target.value)}
-              >
-                {openDeals.map((deal) => (
-                  <option key={deal.id} value={deal.id}>
-                    {deal.name}
-                  </option>
-                ))}
-              </Select>
+                onChange={setDealId}
+                options={openDeals.map((deal) => ({
+                  value: deal.id,
+                  label: deal.name,
+                }))}
+              />
             )}
           </Field>
           <Field label={t("co.role.role")}>
@@ -637,14 +635,12 @@ function SetRoleAction({
               <Select
                 {...control}
                 value={picked ?? ""}
-                onChange={(event) => setRole(event.target.value)}
-              >
-                {offered.map((candidate) => (
-                  <option key={candidate} value={candidate}>
-                    {dealRoleLabel(candidate, t)}
-                  </option>
-                ))}
-              </Select>
+                onChange={setRole}
+                options={offered.map((candidate) => ({
+                  value: candidate,
+                  label: dealRoleLabel(candidate, t),
+                }))}
+              />
             )}
           </Field>
           {save.isError && (

--- a/frontend/src/screens/compose.stories.tsx
+++ b/frontend/src/screens/compose.stories.tsx
@@ -19,8 +19,9 @@ import {
 // steps the unit tests use, keeping the captured frame faithful to a real run.
 
 // One consent purpose is enough to satisfy the Send precondition and populate
-// the purpose <select>; its `key` ("transactional") is the wire value a send
-// carries. Mirrors compose.test.tsx's PURPOSES, not an invented shape.
+// the purpose dropdown; its `label` is what the story clicks and its `key`
+// ("transactional") is the wire value a send carries. Mirrors compose.test.tsx's
+// PURPOSES, not an invented shape.
 const PURPOSES = {
   data: [
     {
@@ -121,7 +122,13 @@ async function fillAndSend(canvasElement: HTMLElement) {
   await userEvent.tab();
   await userEvent.type(canvas.getByPlaceholderText("Subject"), "Following up");
   await userEvent.type(canvas.getByPlaceholderText("Body"), "As promised.");
-  await userEvent.selectOptions(canvas.getByRole("combobox"), "transactional");
+  // The purpose control is a button plus a listbox the component portals to the
+  // body, so the option is reached OUTSIDE the story canvas — and by the label a
+  // reader clicks, never by the wire key behind it.
+  await userEvent.click(canvas.getByRole("combobox"));
+  await userEvent.click(
+    within(document.body).getByRole("option", { name: PURPOSES.data[0].label }),
+  );
   await userEvent.click(canvas.getByRole("button", { name: "Send" }));
 }
 

--- a/frontend/src/screens/compose.test.tsx
+++ b/frontend/src/screens/compose.test.tsx
@@ -10,6 +10,7 @@ import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { components } from "../api/schema";
+import { pickOption } from "../design-system/select-testing";
 import { LocaleProvider } from "../i18n";
 import { ComposeModal, RelinkModal, TimelineActions } from "./compose";
 
@@ -297,6 +298,22 @@ describe("RelinkModal", () => {
   });
 });
 
+// The two purposes as the rep READS them: a pick names what a person would
+// click, while the ConsentPurpose.key each label stands for is the wire value,
+// asserted on the request body wherever a send is under study.
+const PURPOSE_LABEL = {
+  transactional: "Deal messages",
+  marketing: "Marketing email",
+} as const;
+
+// The composer has exactly one dropdown, so a pick needs nothing but the label.
+// `pickOption` takes a userEvent SESSION, which the bare direct API is not, so
+// it gets a fresh one — the same thing every bare `userEvent.*` call in this
+// file does internally.
+function pickPurpose(label: string) {
+  return pickOption(userEvent.setup(), screen.getByRole("combobox"), label);
+}
+
 // Fills the four Send preconditions (To, subject, body, purpose) so a test can
 // then exercise the send outcome under study.
 async function fillSendableForm() {
@@ -304,8 +321,7 @@ async function fillSendableForm() {
   await userEvent.tab();
   await userEvent.type(screen.getByPlaceholderText("Subject"), "Hi there");
   await userEvent.type(screen.getByPlaceholderText("Body"), "Body content");
-  // The purpose <option> value is the ConsentPurpose.key the wire sends.
-  await userEvent.selectOptions(screen.getByRole("combobox"), "transactional");
+  await pickPurpose(PURPOSE_LABEL.transactional);
 }
 
 describe("ComposeModal", () => {
@@ -749,10 +765,7 @@ describe("ComposeModal draft binding", () => {
       screen.getByRole("button", { name: "Draft with AI" }),
     );
     await screen.findByDisplayValue("Draft A body.");
-    await userEvent.selectOptions(
-      screen.getByRole("combobox"),
-      "transactional",
-    );
+    await pickPurpose(PURPOSE_LABEL.transactional);
     await userEvent.click(screen.getByRole("button", { name: "Send" }));
 
     await waitFor(() =>
@@ -798,10 +811,7 @@ describe("ComposeModal draft binding", () => {
       ).toBe(2),
     );
 
-    await userEvent.selectOptions(
-      screen.getByRole("combobox"),
-      "transactional",
-    );
+    await pickPurpose(PURPOSE_LABEL.transactional);
     await userEvent.click(screen.getByRole("button", { name: "Send" }));
 
     await waitFor(() =>
@@ -832,10 +842,7 @@ describe("ComposeModal draft binding", () => {
     const bodyField = await screen.findByDisplayValue("Draft A body.");
     await userEvent.clear(bodyField);
     await userEvent.type(bodyField, "Written from scratch.");
-    await userEvent.selectOptions(
-      screen.getByRole("combobox"),
-      "transactional",
-    );
+    await pickPurpose(PURPOSE_LABEL.transactional);
     await userEvent.click(screen.getByRole("button", { name: "Send" }));
 
     await waitFor(() =>
@@ -901,10 +908,7 @@ describe("ComposeModal draft binding", () => {
       screen.getByRole("button", { name: "Draft with AI" }),
     );
     await screen.findByDisplayValue("Draft A body.");
-    await userEvent.selectOptions(
-      screen.getByRole("combobox"),
-      "transactional",
-    );
+    await pickPurpose(PURPOSE_LABEL.transactional);
     // The form is sendable before the judgment starts, so the refusal below is
     // the rejection holding the draft rather than an unmet precondition.
     expect(
@@ -960,10 +964,7 @@ describe("ComposeModal draft binding", () => {
     );
     expect(await screen.findByText(/boom/i)).toBeTruthy();
 
-    await userEvent.selectOptions(
-      screen.getByRole("combobox"),
-      "transactional",
-    );
+    await pickPurpose(PURPOSE_LABEL.transactional);
     await userEvent.click(screen.getByRole("button", { name: "Send" }));
 
     await waitFor(() =>
@@ -1004,10 +1005,7 @@ describe("ComposeModal draft binding", () => {
     ).toBeTruthy();
     expect(screen.getByDisplayValue("Draft A body.")).toBeTruthy();
 
-    await userEvent.selectOptions(
-      screen.getByRole("combobox"),
-      "transactional",
-    );
+    await pickPurpose(PURPOSE_LABEL.transactional);
     await userEvent.click(screen.getByRole("button", { name: "Send" }));
     await waitFor(() =>
       expect(
@@ -1349,10 +1347,7 @@ describe("ComposeModal send refusals", () => {
     await userEvent.tab();
 
     expect(screen.queryByText(/more than one addressee/i)).toBeNull();
-    await userEvent.selectOptions(
-      screen.getByRole("combobox"),
-      "marketing_email",
-    );
+    await pickPurpose(PURPOSE_LABEL.marketing);
 
     expect(await screen.findByText(/more than one addressee/i)).toBeTruthy();
     // A warning, not a gate — and nothing was sent to earn it.
@@ -1366,10 +1361,7 @@ describe("ComposeModal send refusals", () => {
     renderComposer();
     await screen.findByRole("combobox");
     await fillSendableForm();
-    await userEvent.selectOptions(
-      screen.getByRole("combobox"),
-      "marketing_email",
-    );
+    await pickPurpose(PURPOSE_LABEL.marketing);
 
     expect(screen.queryByText(/more than one addressee/i)).toBeNull();
   });
@@ -1408,10 +1400,7 @@ describe("ComposeModal — telegram channel reply", () => {
     );
     await screen.findByRole("combobox");
     await userEvent.type(screen.getByPlaceholderText("Body"), "On my way.");
-    await userEvent.selectOptions(
-      screen.getByRole("combobox"),
-      "transactional",
-    );
+    await pickPurpose(PURPOSE_LABEL.transactional);
     await userEvent.click(screen.getByRole("button", { name: "Send" }));
 
     await waitFor(() => expect(onClose).toHaveBeenCalled());
@@ -1526,10 +1515,7 @@ describe("ComposeModal — telegram channel reply", () => {
       screen.getByPlaceholderText("Body"),
       "Call me back please.",
     );
-    await userEvent.selectOptions(
-      screen.getByRole("combobox"),
-      "transactional",
-    );
+    await pickPurpose(PURPOSE_LABEL.transactional);
     await userEvent.click(screen.getByRole("button", { name: "Send" }));
 
     expect(await screen.findByText(/has not granted consent/i)).toBeTruthy();

--- a/frontend/src/screens/compose.tsx
+++ b/frontend/src/screens/compose.tsx
@@ -8,7 +8,6 @@ import {
   Button,
   Checkbox,
   SectionHeader,
-  Select,
   Textarea,
   TextInput,
 } from "../design-system/atoms";
@@ -17,6 +16,7 @@ import {
   RecordPicker,
   type RecordPickerCandidate,
 } from "../design-system/recordpicker";
+import { Select, type SelectOption } from "../design-system/select";
 import { useT } from "../i18n";
 import {
   isConsentNotGranted,
@@ -35,6 +35,7 @@ import "./compose.css";
 // and typed on the backend; this file only calls them.
 
 type Activity = components["schemas"]["Activity"];
+type ConsentPurpose = components["schemas"]["ConsentPurpose"];
 type EmailDraft = components["schemas"]["EmailDraft"];
 type VoiceProfile = components["schemas"]["VoiceProfile"];
 
@@ -458,6 +459,23 @@ function sharedUnsubscribeAhead(
   return addressees.size > 1;
 }
 
+// The purpose list the rep chooses from. The unset entry is a real OPTION
+// rather than the select's placeholder: a placeholder is only a face for an
+// unset value, and a rep who picked a purpose has to be able to come back to
+// none before sending. Its face stays the em dash the field has always shown —
+// a glyph, with no words to translate.
+function purposeOptions(
+  purposes: readonly ConsentPurpose[] | undefined,
+): SelectOption[] {
+  return [
+    { value: "", label: "—" },
+    ...(purposes ?? []).map((purpose) => ({
+      value: purpose.key,
+      label: purpose.label,
+    })),
+  ];
+}
+
 // Send preconditions differ by wire shape: mail needs an addressee and a
 // subject on top of a body; a channel reply carries neither (design §9.3 —
 // the recipient is resolved server-side, and a channel has no subject line),
@@ -864,16 +882,10 @@ export function ComposeModal({
           {t("compose.purpose")}
           <Select
             aria-label={t("compose.purpose")}
+            options={purposeOptions(purposes.data?.data)}
             value={purpose}
-            onChange={(event) => setPurpose(event.target.value)}
-          >
-            <option value="">—</option>
-            {purposes.data?.data.map((option) => (
-              <option key={option.id} value={option.key}>
-                {option.label}
-              </option>
-            ))}
-          </Select>
+            onChange={setPurpose}
+          />
         </label>
         <p className="t-caption">{t("compose.purposeHint")}</p>
 

--- a/frontend/src/screens/consumer-mail-domains.tsx
+++ b/frontend/src/screens/consumer-mail-domains.tsx
@@ -3,8 +3,11 @@ import { Mail, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { api } from "../api/client";
 import { useCanWrite } from "../app/capability";
-import { SectionHeader, Select } from "../design-system/atoms";
+import { isOption } from "../app/options";
+import { SectionHeader } from "../design-system/atoms";
+import { Select } from "../design-system/select";
 import { useT } from "../i18n";
+import type { MessageKey } from "../i18n/en";
 import { problemMessageOf, QueryGate, throwProblem } from "./common";
 import "./settings.css";
 
@@ -18,7 +21,16 @@ import "./settings.css";
 // list exists and what is on it, which is what makes the capture posture
 // legible to the people whose mail it governs.
 
-type Kind = "extra" | "never";
+// The two things an entry can say, as ONE list: the type is derived from it and
+// the control's options are built from it, so the offered choices, their labels
+// and the runtime narrowing cannot drift apart (same shape as overlay.tsx's
+// region list).
+const KINDS = ["extra", "never"] as const;
+type Kind = (typeof KINDS)[number];
+const kindLabel: Record<Kind, MessageKey> = {
+  extra: "consumerMail.kind.extra",
+  never: "consumerMail.kind.never",
+};
 
 function useConsumerMailDomains() {
   return useQuery({
@@ -121,14 +133,18 @@ export function ConsumerMailDomainsCard() {
         <Select
           className="consumer-mail-kind"
           aria-label={t("consumerMail.kindLabel")}
-          data-testid="consumer-mail-kind-select"
           value={kind}
           disabled={!canManage}
-          onChange={(e) => setKind(e.target.value as Kind)}
-        >
-          <option value="extra">{t("consumerMail.kind.extra")}</option>
-          <option value="never">{t("consumerMail.kind.never")}</option>
-        </Select>
+          onChange={(value) => {
+            if (isOption(value, KINDS)) {
+              setKind(value);
+            }
+          }}
+          options={KINDS.map((value) => ({
+            value,
+            label: t(kindLabel[value]),
+          }))}
+        />
         <button type="submit" disabled={!canManage || add.isPending}>
           {t("consumerMail.add")}
         </button>

--- a/frontend/src/screens/create.test.tsx
+++ b/frontend/src/screens/create.test.tsx
@@ -5,6 +5,7 @@ import {
   render as rtlRender,
   screen,
   waitFor,
+  within,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { type ReactNode, useLayoutEffect, useState } from "react";
@@ -317,11 +318,17 @@ describe("deal create flow", () => {
     );
     render(<DealsScreen startCreating />);
     await waitFor(() => expect(screen.getByLabelText("Stage *")).toBeTruthy());
-    const stageSelect = screen.getByLabelText("Stage *") as HTMLSelectElement;
-    // won/lost stages are not creatable targets — deals are born open
+    // won/lost stages are not creatable targets — deals are born open. The list
+    // only exists while the control is open, so it is opened to be read and shut
+    // again before the form is filled in.
+    const stageSelect = screen.getByLabelText("Stage *");
+    await userEvent.click(stageSelect);
     expect(
-      Array.from(stageSelect.options).map((option) => option.textContent),
+      within(screen.getByRole("listbox"))
+        .getAllByRole("option")
+        .map((option) => option.textContent),
     ).toEqual(["Qualify"]);
+    await userEvent.keyboard("{Escape}");
     await userEvent.type(screen.getByLabelText("Deal name *"), "Neuer Deal");
     await userEvent.type(screen.getByLabelText("Value"), "480");
     await userEvent.click(screen.getByRole("button", { name: "Create" }));

--- a/frontend/src/screens/create.test.tsx
+++ b/frontend/src/screens/create.test.tsx
@@ -289,6 +289,54 @@ describe("create modal reset", () => {
   });
 });
 
+// An optional select needs a way back to unset, and the value gets exactly one
+// entry: the generic "Not set" appears only where the field offers no clearing
+// choice of its own, so a screen's own wording is never doubled up.
+describe("an optional select's unset choice", () => {
+  const owner: CreateField = {
+    key: "owner_id",
+    labelText: "Owner",
+    type: "select",
+    options: [
+      { value: "u1", label: "Me" },
+      { value: "", label: "Unassign" },
+    ],
+  };
+
+  function openedOptionLabels(): (string | null)[] {
+    return within(screen.getByRole("listbox"))
+      .getAllByRole("option")
+      .map((option) => option.textContent);
+  }
+
+  async function openOwnerList(fields: CreateField[]) {
+    render(
+      <CreateRecordModal
+        open
+        onClose={() => {}}
+        title="New deal"
+        fields={fields}
+        pending={false}
+        error={null}
+        onSubmit={() => {}}
+      />,
+    );
+    await userEvent.click(screen.getByLabelText("Owner"));
+  }
+
+  it("keeps the field's own clearing entry and adds no second one for the same value", async () => {
+    await openOwnerList([owner]);
+    expect(openedOptionLabels()).toEqual(["Me", "Unassign"]);
+  });
+
+  it("synthesizes one when the field offers no way back to unset", async () => {
+    await openOwnerList([
+      { ...owner, options: [{ value: "u1", label: "Me" }] },
+    ]);
+    expect(openedOptionLabels()).toEqual(["Not set", "Me"]);
+  });
+});
+
 describe("deal create flow", () => {
   it("offers only open stages, converts major→minor, and posts the pipeline", async () => {
     const captured: Captured[] = [];

--- a/frontend/src/screens/create.tsx
+++ b/frontend/src/screens/create.tsx
@@ -270,15 +270,23 @@ export function fieldControl(
     // left behind — a row a browser gave a baseline height and a screen reader
     // announced as nothing at all — and in a drawn list it is an unreadable
     // strip nobody can aim at.
-    const blank: SelectOption[] = field.required
-      ? []
-      : [{ value: "", label: t("field.unset") }];
+    //
+    // A field that already offers the empty value has said it in its own,
+    // better words ("Unassign" on a deal's owner), and one value gets exactly
+    // one entry: a second would offer the same choice twice and give the list
+    // two options with the same identity.
+    const options = field.options ?? [];
+    const clearable = options.some((option) => option.value === "");
+    const blank: SelectOption[] =
+      field.required || clearable
+        ? []
+        : [{ value: "", label: t("field.unset") }];
     return (
       <Select
         {...control}
         value={value}
         onChange={setValue}
-        options={[...blank, ...(field.options ?? [])]}
+        options={[...blank, ...options]}
       />
     );
   }

--- a/frontend/src/screens/create.tsx
+++ b/frontend/src/screens/create.tsx
@@ -9,9 +9,9 @@ import {
   type FieldControl,
   Modal,
   Radio,
-  Select,
   TextInput,
 } from "../design-system/atoms";
+import { Select, type SelectOption } from "../design-system/select";
 import { useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import {
@@ -259,21 +259,27 @@ export function fieldControl(
   control: FieldControl,
   value: string,
   setValue: (next: string) => void,
+  t: (key: MessageKey) => string,
 ): ReactNode {
   if (field.type === "select") {
+    // An optional select leads with a choice that clears it, and it is a choice
+    // rather than a placeholder face: once a value has been picked, this is the
+    // only way back to leaving the field unset.
+    //
+    // It says so in words. A blank-labelled entry is what a native `<option/>`
+    // left behind — a row a browser gave a baseline height and a screen reader
+    // announced as nothing at all — and in a drawn list it is an unreadable
+    // strip nobody can aim at.
+    const blank: SelectOption[] = field.required
+      ? []
+      : [{ value: "", label: t("field.unset") }];
     return (
       <Select
         {...control}
         value={value}
-        onChange={(event) => setValue(event.target.value)}
-      >
-        {!field.required && <option value="" />}
-        {(field.options ?? []).map((option) => (
-          <option key={option.value} value={option.value}>
-            {option.label}
-          </option>
-        ))}
-      </Select>
+        onChange={setValue}
+        options={[...blank, ...(field.options ?? [])]}
+      />
     );
   }
   return (
@@ -368,6 +374,7 @@ function RepeatableRowsField({
                   control,
                   row[subField.key] ?? "",
                   (next) => updateRow(index, subField.key, next),
+                  t,
                 )
               }
             </Field>
@@ -543,8 +550,12 @@ export function RecordFormBody({
             required={field.required}
           >
             {(control) =>
-              fieldControl(field, control, values[field.key] ?? "", (next) =>
-                setValues({ ...values, [field.key]: next }),
+              fieldControl(
+                field,
+                control,
+                values[field.key] ?? "",
+                (next) => setValues({ ...values, [field.key]: next }),
+                t,
               )
             }
           </Field>

--- a/frontend/src/screens/deals.test.tsx
+++ b/frontend/src/screens/deals.test.tsx
@@ -10,6 +10,7 @@ import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { components } from "../api/schema";
+import { pickOption } from "../design-system/select-testing";
 import { formatMoney } from "../format/format";
 import { LocaleProvider } from "../i18n";
 import { buildColumns, DealScreen, DealsScreen, mapDealUpdate } from "./deals";
@@ -525,6 +526,7 @@ describe("DealsScreen", () => {
 
 describe("DealsScreen filters", () => {
   it("switching pipeline scopes the deals fetch to that pipeline_id", async () => {
+    const user = userEvent.setup();
     const urls: string[] = [];
     vi.stubGlobal(
       "fetch",
@@ -552,13 +554,14 @@ describe("DealsScreen filters", () => {
     );
     render(<DealsScreen />);
     await screen.findByText("Fleet retrofit");
-    await userEvent.selectOptions(screen.getByLabelText("Pipeline"), "pl2");
+    await pickOption(user, screen.getByLabelText("Pipeline"), "Renewals");
     await waitFor(() =>
       expect(urls.some((u) => u.includes("pipeline_id=pl2"))).toBe(true),
     );
   });
 
   it("the stalled filter adds stalled=true to the deals query", async () => {
+    const user = userEvent.setup();
     const urls: string[] = [];
     vi.stubGlobal(
       "fetch",
@@ -566,9 +569,12 @@ describe("DealsScreen filters", () => {
     );
     render(<DealsScreen />);
     await screen.findByText("Fleet retrofit");
-    await userEvent.selectOptions(
+    // The control and its only narrowing choice share the "Stalled only" name:
+    // the combobox is named by the filter, the option by what it selects.
+    await pickOption(
+      user,
       screen.getByLabelText("Stalled only"),
-      "true",
+      "Stalled only",
     );
     await waitFor(() =>
       expect(urls.some((u) => u.includes("stalled=true"))).toBe(true),

--- a/frontend/src/screens/deals.test.tsx
+++ b/frontend/src/screens/deals.test.tsx
@@ -5,6 +5,7 @@ import {
   render as rtlRender,
   screen,
   waitFor,
+  within,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
@@ -558,6 +559,54 @@ describe("DealsScreen filters", () => {
     await waitFor(() =>
       expect(urls.some((u) => u.includes("pipeline_id=pl2"))).toBe(true),
     );
+  });
+
+  // The board always shows one pipeline, so an unset choice would fall straight
+  // back to the default one — the pipeline list therefore offers pipelines
+  // only. The stage filter's "all" entry clears a query filter, which the board
+  // can actually show, so that one stays.
+  it("offers pipelines only, while the stage filter keeps its all-stages entry", async () => {
+    const user = userEvent.setup();
+    vi.stubGlobal(
+      "fetch",
+      stubBackend([deal({})], {
+        pipelines: [
+          {
+            id: "pl",
+            workspace_id: "w",
+            name: "Sales",
+            is_default: true,
+            position: 0,
+            stages,
+          },
+          {
+            id: "pl2",
+            workspace_id: "w",
+            name: "Renewals",
+            is_default: false,
+            position: 1,
+            stages,
+          },
+        ],
+      }),
+    );
+    render(<DealsScreen />);
+    await screen.findByText("Fleet retrofit");
+
+    await user.click(screen.getByLabelText("Pipeline"));
+    expect(
+      within(screen.getByRole("listbox"))
+        .getAllByRole("option")
+        .map((option) => option.textContent),
+    ).toEqual(["Sales", "Renewals"]);
+    await user.keyboard("{Escape}");
+
+    await user.click(screen.getByLabelText("Stage"));
+    expect(
+      within(screen.getByRole("listbox")).getByRole("option", {
+        name: "All stages",
+      }),
+    ).toBeTruthy();
   });
 
   it("the stalled filter adds stalled=true to the deals query", async () => {

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -25,7 +25,6 @@ import {
   Modal,
   SectionHeader,
   SegmentedControl,
-  Select,
   TextInput,
 } from "../design-system/atoms";
 import {
@@ -34,6 +33,7 @@ import {
   PipelineBoard,
   RecordView,
 } from "../design-system/composed";
+import { Select } from "../design-system/select";
 import { AutonomyDot } from "../design-system/trust";
 import { formatDate, formatMoney } from "../format/format";
 import { type Locale, useLocale, useT } from "../i18n";
@@ -456,46 +456,41 @@ function DealFilterSelects({
   const t = useT();
   return (
     <div className="list-toolbar">
+      {/* Each list leads with a real OPTION for the unset value rather than
+          the select's placeholder: a placeholder is only a face, and a reader
+          who narrowed the board has to be able to come back to all of it. */}
       <Select
         aria-label={t("deals.pipeline")}
         value={pipelineId}
-        onChange={(event) => setPipelineId(event.target.value)}
-      >
-        <option value="">{t("deals.pipeline")}</option>
-        {pipelines.map((pipeline) => (
-          <option key={pipeline.id} value={pipeline.id}>
-            {pipeline.name}
-          </option>
-        ))}
-      </Select>
+        onChange={setPipelineId}
+        options={[
+          { value: "", label: t("deals.pipeline") },
+          ...pipelines.map((pipeline) => ({
+            value: pipeline.id,
+            label: pipeline.name,
+          })),
+        ]}
+      />
       <Select
         aria-label={t("deals.stage")}
         value={query.filters.stage_id ?? ""}
-        onChange={(event) =>
-          setOrClearFilter(setQuery, "stage_id", event.target.value)
-        }
-      >
-        <option value="">{t("deals.filterStageAll")}</option>
-        {stages.map((stage) => (
-          <option key={stage.id} value={stage.id}>
-            {stage.name}
-          </option>
-        ))}
-      </Select>
+        onChange={(value) => setOrClearFilter(setQuery, "stage_id", value)}
+        options={[
+          { value: "", label: t("deals.filterStageAll") },
+          ...stages.map((stage) => ({ value: stage.id, label: stage.name })),
+        ]}
+      />
       <Select
         aria-label={t("create.organization")}
         value={query.filters.organization_id ?? ""}
-        onChange={(event) =>
-          setOrClearFilter(setQuery, "organization_id", event.target.value)
+        onChange={(value) =>
+          setOrClearFilter(setQuery, "organization_id", value)
         }
-      >
-        <option value="">{t("deals.filterOrgAll")}</option>
-        {orgs.map((org) => (
-          <option key={org.id} value={org.id}>
-            {org.display_name}
-          </option>
-        ))}
-      </Select>
+        options={[
+          { value: "", label: t("deals.filterOrgAll") },
+          ...orgs.map((org) => ({ value: org.id, label: org.display_name })),
+        ]}
+      />
     </div>
   );
 }
@@ -553,7 +548,7 @@ function DealsHeader({
             pipelineId={pipelineId}
             setPipelineId={(id) => {
               // A stage belongs to one pipeline; switching pipeline strands any
-              // stage_id filter (its <select> blanks out but useDeals would
+              // stage_id filter (the stage picker blanks out but useDeals would
               // still forward the old id and filter a foreign stage → 0 rows).
               setPipelineId(id);
               setOrClearFilter(setQuery, "stage_id", "");

--- a/frontend/src/screens/deals.tsx
+++ b/frontend/src/screens/deals.tsx
@@ -456,20 +456,23 @@ function DealFilterSelects({
   const t = useT();
   return (
     <div className="list-toolbar">
-      {/* Each list leads with a real OPTION for the unset value rather than
-          the select's placeholder: a placeholder is only a face, and a reader
-          who narrowed the board has to be able to come back to all of it. */}
+      {/* The board is always the board of ONE pipeline — there is no
+          all-pipelines view for an unset entry to select, and an unset
+          selection falls straight back to the default pipeline — so this list
+          offers pipelines only. The placeholder is the face while they load,
+          which is the only moment the value matches no option. The stage and
+          organization lists below DO lead with a real "all" option: each one
+          clears a query filter, a state the board can actually show, and a
+          reader who narrowed it has to be able to come back to all of it. */}
       <Select
         aria-label={t("deals.pipeline")}
+        placeholder={t("deals.pipeline")}
         value={pipelineId}
         onChange={setPipelineId}
-        options={[
-          { value: "", label: t("deals.pipeline") },
-          ...pipelines.map((pipeline) => ({
-            value: pipeline.id,
-            label: pipeline.name,
-          })),
-        ]}
+        options={pipelines.map((pipeline) => ({
+          value: pipeline.id,
+          label: pipeline.name,
+        }))}
       />
       <Select
         aria-label={t("deals.stage")}

--- a/frontend/src/screens/inbox.test.tsx
+++ b/frontend/src/screens/inbox.test.tsx
@@ -200,10 +200,22 @@ describe("InboxScreen (B-EP09.12a)", () => {
     expect(screen.queryByRole("textbox", { name: "because" })).toBeNull();
 
     // The option's VALUE is the wire enum and its text is what the reader sees;
-    // both matter, and only the value is submitted.
-    expect(screen.getByRole("option", { name: "Disqualified" })).toBeTruthy();
-    expect(screen.queryByRole("option", { name: "disqualified" })).toBeNull();
-    await userEvent.selectOptions(stage, "disqualified");
+    // both matter, and only the value is submitted. The list is inspected with
+    // the popup OPEN — it is portalled and exists only while the control is
+    // open — which is also why this drives the two steps by hand instead of
+    // through pickOption: the pick has to land on the list already under
+    // assertion.
+    await userEvent.click(stage);
+    const listbox = screen.getByRole("listbox");
+    expect(
+      within(listbox).getByRole("option", { name: "Disqualified" }),
+    ).toBeTruthy();
+    expect(
+      within(listbox).queryByRole("option", { name: "disqualified" }),
+    ).toBeNull();
+    await userEvent.click(
+      within(listbox).getByRole("option", { name: "Disqualified" }),
+    );
     await userEvent.click(
       screen.getByRole("button", { name: "Approve edited" }),
     );

--- a/frontend/src/screens/inbox.tsx
+++ b/frontend/src/screens/inbox.tsx
@@ -19,11 +19,11 @@ import {
   Modal,
   SectionHeader,
   SegmentedControl,
-  Select,
   Textarea,
   TextInput,
 } from "../design-system/atoms";
 import { ConfirmModal } from "../design-system/confirmmodal";
+import { Select } from "../design-system/select";
 import {
   AutonomyDot,
   type ConfidenceLevel,
@@ -655,27 +655,25 @@ export function ApprovalRow({
                   entry.as === "choice" ? (
                     <Select
                       {...control}
-                      value={draft[entry.field] ?? ""}
-                      onChange={(event) =>
-                        setDraft((current) => ({
-                          ...current,
-                          [entry.field]: event.target.value,
-                        }))
-                      }
-                    >
-                      {entry.options.map((option) => {
+                      options={entry.options.map((option) => {
                         // The VALUE stays the wire enum — it is what gets
                         // submitted. Only what the reader sees is translated,
                         // and an option the kind declared no label for degrades
                         // to its own words rather than to an identifier.
                         const label = entry.optionLabels?.[option];
-                        return (
-                          <option key={option} value={option}>
-                            {label ? t(label) : humanizeKind(option)}
-                          </option>
-                        );
+                        return {
+                          value: option,
+                          label: label ? t(label) : humanizeKind(option),
+                        };
                       })}
-                    </Select>
+                      value={draft[entry.field] ?? ""}
+                      onChange={(value) =>
+                        setDraft((current) => ({
+                          ...current,
+                          [entry.field]: value,
+                        }))
+                      }
+                    />
                   ) : (
                     <TextInput
                       {...control}

--- a/frontend/src/screens/leads.test.tsx
+++ b/frontend/src/screens/leads.test.tsx
@@ -11,6 +11,7 @@ import {
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { pickOption } from "../design-system/select-testing";
 import { LocaleProvider } from "../i18n";
 import {
   LeadScreen,
@@ -133,12 +134,16 @@ describe("LeadsScreen + LeadScreen (B-EP09.10b, §3.5 segregation)", () => {
     await userEvent.click(
       await screen.findByRole("button", { name: "Promote to contact" }),
     );
-    expect(
-      (screen.getByLabelText("Promotion trigger") as HTMLSelectElement).value,
-    ).toBe("human_qualify");
+    // The control is a button whose face IS the selected option's label, so
+    // the default choice is read the way the user reads it — human_qualify's
+    // label — rather than off a `value` property no button carries.
+    expect(screen.getByLabelText("Promotion trigger").textContent).toBe(
+      "Human qualified",
+    );
   });
 
   it("promote posts the picked trigger + note and lands on the resulting person 360", async () => {
+    const user = userEvent.setup();
     let promoteBody: unknown = null;
     stubFetch(async (url, method, request) => {
       if (method === "POST" && url.includes("/leads/l-1/promote")) {
@@ -148,18 +153,19 @@ describe("LeadsScreen + LeadScreen (B-EP09.10b, §3.5 segregation)", () => {
       return jsonResponse(lead);
     });
     render(<LeadScreen id="l-1" />);
-    await userEvent.click(
+    await user.click(
       await screen.findByRole("button", { name: "Promote to contact" }),
     );
-    await userEvent.selectOptions(
+    await pickOption(
+      user,
       screen.getByLabelText("Promotion trigger"),
-      "meeting_booked",
+      "Meeting booked",
     );
-    await userEvent.type(
+    await user.type(
       screen.getByLabelText("Evidence note (optional)"),
       "Booked via calendly",
     );
-    await userEvent.click(screen.getByRole("button", { name: "Promote" }));
+    await user.click(screen.getByRole("button", { name: "Promote" }));
     await waitFor(() => expect(window.location.hash).toBe("#/contacts/p-1"));
     expect(promoteBody).toEqual({
       trigger: "meeting_booked",
@@ -280,11 +286,12 @@ describe("LeadsScreen — search/sort/pagination + status filter (P-14)", () => 
   });
 
   it("sends status=working when the status filter is set", async () => {
+    const user = userEvent.setup();
     const { urls } = stubFetch(async () => emptyPage());
     render(<LeadsScreen />);
     await waitFor(() => expect(urls.length).toBeGreaterThan(0));
 
-    await userEvent.selectOptions(screen.getByLabelText("Status"), "working");
+    await pickOption(user, screen.getByLabelText("Status"), "Working");
 
     await waitFor(() =>
       expect(urls.some((url) => url.includes("status=working"))).toBe(true),

--- a/frontend/src/screens/leads.tsx
+++ b/frontend/src/screens/leads.tsx
@@ -12,10 +12,10 @@ import {
   Modal,
   SectionHeader,
   SegmentedControl,
-  Select,
   Textarea,
   TextInput,
 } from "../design-system/atoms";
+import { Select } from "../design-system/select";
 import { ProvenanceTag } from "../design-system/trust";
 import { useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
@@ -638,18 +638,15 @@ function LeadOverviewPane({
                   <Select
                     aria-label={t("lead.trigger")}
                     value={trigger}
-                    onChange={(event) => {
-                      const value = event.target.value;
+                    onChange={(value) => {
                       const triggers = PROMOTE_TRIGGERS.map((o) => o.value);
                       if (isOption(value, triggers)) setTrigger(value);
                     }}
-                  >
-                    {PROMOTE_TRIGGERS.map((option) => (
-                      <option key={option.value} value={option.value}>
-                        {t(option.label)}
-                      </option>
-                    ))}
-                  </Select>
+                    options={PROMOTE_TRIGGERS.map((option) => ({
+                      value: option.value,
+                      label: t(option.label),
+                    }))}
+                  />
                 </label>
                 <label className="t-caption field">
                   {t("lead.evidenceNote")}

--- a/frontend/src/screens/listquery.test.tsx
+++ b/frontend/src/screens/listquery.test.tsx
@@ -14,6 +14,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { pickOption } from "../design-system/select-testing";
 import { LocaleProvider } from "../i18n";
 import {
+  type FilterSpec,
   ListGate,
   type ListGateState,
   type ListPage,
@@ -294,6 +295,52 @@ describe("ListToolbar", () => {
     );
     const lastCall = setQuery.mock.calls.at(-1)?.[0] as ListQuery;
     expect(lastCall.filters).not.toHaveProperty("status");
+  });
+});
+
+// A text filter is a design-system TextInput named by its own spec, and it
+// shares withFilter with the select above: a typed value stores the key, an
+// emptied field deletes it rather than sending `key=""`.
+describe("ListToolbar text filter", () => {
+  const domainFilter: FilterSpec[] = [
+    { kind: "text", key: "domain", label: "people.name" },
+  ];
+
+  it("stores what was typed under the filter's key", () => {
+    const setQuery = vi.fn();
+    render(
+      <ListToolbar
+        query={baseQuery()}
+        setQuery={setQuery}
+        sortOptions={sortOptions}
+        filters={domainFilter}
+      />,
+    );
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Name" }), {
+      target: { value: "acme.test" },
+    });
+    expect(setQuery).toHaveBeenCalledWith(
+      expect.objectContaining({ filters: { domain: "acme.test" } }),
+    );
+  });
+
+  it("drops the key when the field is emptied", () => {
+    const setQuery = vi.fn();
+    render(
+      <ListToolbar
+        query={{ ...baseQuery(), filters: { domain: "acme.test" } }}
+        setQuery={setQuery}
+        sortOptions={sortOptions}
+        filters={domainFilter}
+      />,
+    );
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Name" }), {
+      target: { value: "" },
+    });
+    const lastCall = setQuery.mock.calls.at(-1)?.[0] as ListQuery;
+    expect(lastCall.filters).not.toHaveProperty("domain");
   });
 });
 

--- a/frontend/src/screens/listquery.test.tsx
+++ b/frontend/src/screens/listquery.test.tsx
@@ -11,6 +11,7 @@ import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { useState } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { pickOption } from "../design-system/select-testing";
 import { LocaleProvider } from "../i18n";
 import {
   ListGate,
@@ -196,6 +197,7 @@ describe("ListToolbar", () => {
   });
 
   it("updates sort and includeArchived immediately", async () => {
+    const user = userEvent.setup();
     const setQuery = vi.fn();
     render(
       <ListToolbar
@@ -205,20 +207,26 @@ describe("ListToolbar", () => {
       />,
     );
 
-    const sortSelect = screen.getByLabelText("Sort") as HTMLSelectElement;
-    await userEvent.selectOptions(sortSelect, "name");
+    // The sort control's own name and the "name" option's label are both
+    // "Sort" here (the fixture reuses catalog keys as labels) — the control is
+    // the combobox, the choice is the option inside its popup.
+    await pickOption(
+      user,
+      screen.getByRole("combobox", { name: "Sort" }),
+      "Sort",
+    );
     expect(setQuery).toHaveBeenCalledWith(
       expect.objectContaining({ sort: "name" }),
     );
 
-    const archived = screen.getByLabelText("Show archived") as HTMLInputElement;
-    await userEvent.click(archived);
+    await user.click(screen.getByLabelText("Show archived"));
     expect(setQuery).toHaveBeenCalledWith(
       expect.objectContaining({ includeArchived: true }),
     );
   });
 
   it("updates a select filter", async () => {
+    const user = userEvent.setup();
     const setQuery = vi.fn();
     render(
       <ListToolbar
@@ -239,14 +247,20 @@ describe("ListToolbar", () => {
       />,
     );
 
-    const statusSelect = screen.getByLabelText("Name") as HTMLSelectElement;
-    await userEvent.selectOptions(statusSelect, "new");
+    // "Sort" is the label of the option whose value is "new" (the fixture
+    // reuses catalog keys as labels).
+    await pickOption(
+      user,
+      screen.getByRole("combobox", { name: "Name" }),
+      "Sort",
+    );
     expect(setQuery).toHaveBeenCalledWith(
       expect.objectContaining({ filters: { status: "new" } }),
     );
   });
 
   it("removes a cleared select filter's key instead of storing an empty string", async () => {
+    const user = userEvent.setup();
     const setQuery = vi.fn();
     render(
       <ListToolbar
@@ -267,8 +281,14 @@ describe("ListToolbar", () => {
       />,
     );
 
-    const statusSelect = screen.getByLabelText("Name") as HTMLSelectElement;
-    await userEvent.selectOptions(statusSelect, "");
+    // The unset entry is an option like any other, named by the filter itself
+    // when the spec passes no placeholder — picking it is how a reader comes
+    // back to the unfiltered list.
+    await pickOption(
+      user,
+      screen.getByRole("combobox", { name: "Name" }),
+      "Name",
+    );
     expect(setQuery).toHaveBeenCalledWith(
       expect.objectContaining({ filters: {} }),
     );

--- a/frontend/src/screens/listquery.tsx
+++ b/frontend/src/screens/listquery.tsx
@@ -12,6 +12,7 @@ import {
   EmptyState,
   SearchField,
   Skeleton,
+  TextInput,
 } from "../design-system/atoms";
 import { Select } from "../design-system/select";
 import { useT } from "../i18n";
@@ -214,10 +215,9 @@ export function ListToolbar({
               ]}
             />
           ) : (
-            <input
+            <TextInput
               key={filter.key}
               type="text"
-              className="input"
               aria-label={t(filter.label)}
               value={query.filters[filter.key] ?? ""}
               onChange={(event) =>

--- a/frontend/src/screens/listquery.tsx
+++ b/frontend/src/screens/listquery.tsx
@@ -11,9 +11,9 @@ import {
   Checkbox,
   EmptyState,
   SearchField,
-  Select,
   Skeleton,
 } from "../design-system/atoms";
+import { Select } from "../design-system/select";
 import { useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { problemMessageOf, useSorMode } from "./common";
@@ -45,12 +45,28 @@ export type FilterSpec =
       kind: "select";
       key: string;
       label: MessageKey;
-      // Shown as the empty (unset) option so the control names the filter at
-      // rest; re-selecting it clears the filter.
+      // Names the empty (unset) option so the control names the filter at
+      // rest; re-selecting it clears the filter. Absent, the filter's own
+      // label names that option — an option a reader cannot read is an option
+      // they cannot come back to.
       placeholder?: MessageKey;
       options: { value: string; label: MessageKey }[];
     }
   | { kind: "text"; key: string; label: MessageKey };
+
+// A blank choice CLEARS the filter rather than storing an empty string: the
+// query object is what each screen builds its request from, and `status=""`
+// would send an empty filter where none was meant. Shared by both filter
+// controls below so the select and the text input cannot drift on it.
+function withFilter(query: ListQuery, key: string, value: string): ListQuery {
+  const filters = { ...query.filters };
+  if (value) {
+    filters[key] = value;
+  } else {
+    delete filters[key];
+  }
+  return { ...query, filters };
+}
 
 export function useListQuery<Row>({
   key,
@@ -154,15 +170,18 @@ export function ListToolbar({
       ) : (
         <Select
           aria-label={t("list.sort")}
+          // A screen that opens on no explicit sort has nothing to show as the
+          // chosen one, and an unlabelled control reads as a control that failed
+          // to load. The face says what the control is FOR until it has an answer;
+          // the server's own default ordering is what the list is showing.
+          placeholder={t("list.sort")}
           value={query.sort}
-          onChange={(event) => setQuery({ ...query, sort: event.target.value })}
-        >
-          {sortOptions.map((option) => (
-            <option key={option.value} value={option.value}>
-              {t(option.label)}
-            </option>
-          ))}
-        </Select>
+          onChange={(sort) => setQuery({ ...query, sort })}
+          options={sortOptions.map((option) => ({
+            value: option.value,
+            label: t(option.label),
+          }))}
+        />
       )}
       {showArchivedToggle && (
         <Checkbox
@@ -180,25 +199,20 @@ export function ListToolbar({
               key={filter.key}
               aria-label={t(filter.label)}
               value={query.filters[filter.key] ?? ""}
-              onChange={(event) => {
-                const next = { ...query.filters };
-                if (event.target.value) {
-                  next[filter.key] = event.target.value;
-                } else {
-                  delete next[filter.key];
-                }
-                setQuery({ ...query, filters: next });
-              }}
-            >
-              <option value="">
-                {filter.placeholder ? t(filter.placeholder) : ""}
-              </option>
-              {filter.options.map((option) => (
-                <option key={option.value} value={option.value}>
-                  {t(option.label)}
-                </option>
-              ))}
-            </Select>
+              onChange={(value) =>
+                setQuery(withFilter(query, filter.key, value))
+              }
+              // The unset entry is a real OPTION, not the select's placeholder:
+              // a placeholder is only a face for an unset value, and a reader
+              // who narrowed the list has to be able to come back to all of it.
+              options={[
+                { value: "", label: t(filter.placeholder ?? filter.label) },
+                ...filter.options.map((option) => ({
+                  value: option.value,
+                  label: t(option.label),
+                })),
+              ]}
+            />
           ) : (
             <input
               key={filter.key}
@@ -206,15 +220,9 @@ export function ListToolbar({
               className="input"
               aria-label={t(filter.label)}
               value={query.filters[filter.key] ?? ""}
-              onChange={(event) => {
-                const next = { ...query.filters };
-                if (event.target.value) {
-                  next[filter.key] = event.target.value;
-                } else {
-                  delete next[filter.key];
-                }
-                setQuery({ ...query, filters: next });
-              }}
+              onChange={(event) =>
+                setQuery(withFilter(query, filter.key, event.target.value))
+              }
             />
           ),
         )}

--- a/frontend/src/screens/logactivity.test.tsx
+++ b/frontend/src/screens/logactivity.test.tsx
@@ -9,6 +9,7 @@ import {
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { pickOption } from "../design-system/select-testing";
 import { LocaleProvider } from "../i18n";
 import { LogActivity } from "./logactivity";
 import { PersonScreen } from "./people";
@@ -200,7 +201,7 @@ describe("log activity from a 360", () => {
     // Reserved means VISIBLE-but-disabled. `hidden` is display:none, which
     // collapses the row and reintroduces the reflow this test exists to stop.
     expect(due.closest("div")?.hasAttribute("hidden")).toBe(false);
-    await userEvent.selectOptions(screen.getByLabelText("Type"), "task");
+    await pickOption(userEvent.setup(), screen.getByLabelText("Type"), "Task");
     expect(
       screen
         .getByLabelText("Due date", { selector: "input" })
@@ -212,7 +213,7 @@ describe("log activity from a 360", () => {
     const captured: Captured[] = [];
     stubApi({ "POST /activities": createdActivity }, captured);
     render(<LogActivity entityType="organization" entityId="o1" />);
-    await userEvent.selectOptions(screen.getByLabelText("Type"), "task");
+    await pickOption(userEvent.setup(), screen.getByLabelText("Type"), "Task");
     await userEvent.type(screen.getByLabelText("Due date"), "2026-07-10");
     await userEvent.type(screen.getByLabelText("Subject *"), "Send proposal");
     await userEvent.click(screen.getByRole("button", { name: "Log" }));

--- a/frontend/src/screens/logactivity.tsx
+++ b/frontend/src/screens/logactivity.tsx
@@ -7,10 +7,10 @@ import {
   Field,
   Modal,
   SectionHeader,
-  Select,
   Textarea,
   TextInput,
 } from "../design-system/atoms";
+import { Select } from "../design-system/select";
 import { useT } from "../i18n";
 import { entityTimelineKeys, taskWriteKeys } from "./activitykeys";
 import { problemMessageOf, throwProblem, useSorMode } from "./common";
@@ -110,16 +110,15 @@ export function LogActivityForm({
           {(control) => (
             <Select
               {...control}
+              options={[
+                { value: "note", label: t("log.kindNote") },
+                { value: "task", label: t("log.kindTask") },
+              ]}
               value={draft.kind}
-              onChange={(event) =>
-                setField({
-                  kind: event.target.value === "task" ? "task" : "note",
-                })
+              onChange={(value) =>
+                setField({ kind: value === "task" ? "task" : "note" })
               }
-            >
-              <option value="note">{t("log.kindNote")}</option>
-              <option value="task">{t("log.kindTask")}</option>
-            </Select>
+            />
           )}
         </Field>
         {/* Only a task carries a due date, but the field stays in place for a

--- a/frontend/src/screens/oauthconsent.test.tsx
+++ b/frontend/src/screens/oauthconsent.test.tsx
@@ -7,6 +7,7 @@ import {
   render as rtlRender,
   screen,
   waitFor,
+  within,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
@@ -16,6 +17,7 @@ import {
   readPendingAuthorize,
   stashPendingAuthorize,
 } from "../app/pendingauthorize";
+import { pickOption } from "../design-system/select-testing";
 import { formatDate } from "../format/format";
 import { LocaleProvider } from "../i18n";
 import { OAuthConsent } from "./oauthconsent";
@@ -352,7 +354,11 @@ describe("OAuthConsent", () => {
       ],
     });
     render(<OAuthConsent />);
-    await userEvent.selectOptions(await screen.findByRole("combobox"), "p2");
+    await pickOption(
+      userEvent.setup(),
+      await screen.findByRole("combobox"),
+      "day agent",
+    );
     await userEvent.click(
       await screen.findByRole("button", { name: /authorize/i }),
     );
@@ -380,20 +386,31 @@ describe("OAuthConsent", () => {
       passports: lendable,
     }));
     const client = renderWithClient(<OAuthConsent />);
-    await userEvent.selectOptions(await screen.findByRole("combobox"), "p2");
+    await pickOption(
+      userEvent.setup(),
+      await screen.findByRole("combobox"),
+      "day agent",
+    );
 
     // The day agent is revoked in another tab; the next read of the same
     // request no longer offers it, and the selector falls back to the one
-    // passport that is left.
+    // passport that is left. The list is what proves the revoked one is gone,
+    // and it exists only while the popup is open — so it is opened for the
+    // count and Escape closes it again before the authorize click.
     lendable = [night];
     await client.invalidateQueries({ queryKey: ["oauth-consent-request"] });
-    await waitFor(() => expect(screen.getAllByRole("option")).toHaveLength(1));
+    await waitFor(() =>
+      expect(screen.getByRole("combobox")).toHaveTextContent("night agent"),
+    );
+    await userEvent.click(screen.getByRole("combobox"));
+    expect(screen.getAllByRole("option")).toHaveLength(1);
+    await userEvent.keyboard("{Escape}");
 
     await userEvent.click(screen.getByRole("button", { name: /authorize/i }));
-    // Displayed and posted are ONE value. A form still carrying the vanished
-    // p2 would let the human approve the passport on screen while lending a
-    // different one.
-    expect(screen.getByRole("combobox")).toHaveValue("p1");
+    // Displayed and posted are ONE value: the trigger's face IS the display, so
+    // a form still carrying the vanished p2 would let the human approve the
+    // passport on screen while lending a different one.
+    expect(screen.getByRole("combobox")).toHaveTextContent("night agent");
     expect(posted.body.get("passport_id")).toBe("p1");
   });
 
@@ -490,11 +507,15 @@ describe("OAuthConsent", () => {
       passports: [{ id: "p1anonymous", label: "", scopes: ["read"] }],
     });
     render(<OAuthConsent />);
-    // The server maps a NULL label to "" deliberately — a blank <option>
-    // makes two such passports indistinguishable on the one screen where
-    // knowing which credential you're lending is the point.
+    // The server maps a NULL label to "" deliberately — a blank entry makes two
+    // such passports indistinguishable on the one screen where knowing which
+    // credential you're lending is the point. The option list is portalled and
+    // only exists while the control is open, so the check opens it.
+    await userEvent.click(await screen.findByRole("combobox"));
     expect(
-      await screen.findByRole("option", { name: /unnamed passport/i }),
+      within(screen.getByRole("listbox")).getByRole("option", {
+        name: /unnamed passport/i,
+      }),
     ).toBeTruthy();
   });
 });

--- a/frontend/src/screens/offers.test.tsx
+++ b/frontend/src/screens/offers.test.tsx
@@ -10,6 +10,7 @@ import {
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { pickOption } from "../design-system/select-testing";
 import { LocaleProvider } from "../i18n";
 import { OfferScreen } from "./offers";
 
@@ -759,6 +760,7 @@ describe("offer lifecycle actions (OP-8/OP-9/OP-10)", () => {
 
 describe("edit offer header modal", () => {
   it("lets the user change the currency and applies the response directly (no refetch)", async () => {
+    const user = userEvent.setup();
     const calls: { url: string; body: unknown; ifMatch: string | null }[] = [];
     stubOfferWithHeaderPatch(
       baseOffer,
@@ -769,9 +771,9 @@ describe("edit offer header modal", () => {
     await screen.findByText("ANG-2026-0007");
     const invalidateSpy = vi.spyOn(client, "invalidateQueries");
 
-    await userEvent.click(screen.getByTestId("edit-offer-header"));
-    await userEvent.selectOptions(screen.getByLabelText("Currency"), "USD");
-    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+    await user.click(screen.getByTestId("edit-offer-header"));
+    await pickOption(user, screen.getByLabelText("Currency"), "USD");
+    await user.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => expect(calls).toHaveLength(1));
     expect(calls[0].ifMatch).toBe("3");

--- a/frontend/src/screens/offers.tsx
+++ b/frontend/src/screens/offers.tsx
@@ -11,7 +11,6 @@ import {
   Field,
   Modal,
   SectionHeader,
-  Select,
   TextInput,
 } from "../design-system/atoms";
 import { ConfirmModal } from "../design-system/confirmmodal";
@@ -20,6 +19,7 @@ import {
   RecordPicker,
   type RecordPickerCandidate,
 } from "../design-system/recordpicker";
+import { Select } from "../design-system/select";
 import { formatMoney } from "../format/format";
 import { type Locale, useLocale, useT } from "../i18n";
 import {
@@ -198,16 +198,16 @@ function EditOfferHeaderModal({
             <Select
               {...control}
               value={values.currency}
-              onChange={(event) =>
-                setValues((prev) => ({ ...prev, currency: event.target.value }))
+              onChange={(currency) =>
+                setValues((prev) => ({ ...prev, currency }))
               }
-            >
-              {["EUR", "USD", "GBP", "CHF"].map((c) => (
-                <option key={c} value={c}>
-                  {c}
-                </option>
-              ))}
-            </Select>
+              // A currency code is its own label — an ISO 4217 code is not
+              // copy, so there is nothing to translate.
+              options={["EUR", "USD", "GBP", "CHF"].map((code) => ({
+                value: code,
+                label: code,
+              }))}
+            />
           )}
         </Field>
         <div className="field">
@@ -250,20 +250,20 @@ function EditOfferHeaderModal({
           <Select
             aria-labelledby="offer-template-label"
             value={values.template_id ?? ""}
-            onChange={(event) =>
-              setValues((prev) => ({
-                ...prev,
-                template_id: event.target.value || null,
-              }))
+            onChange={(value) =>
+              setValues((prev) => ({ ...prev, template_id: value || null }))
             }
-          >
-            <option value="">—</option>
-            {(templatesQuery.data ?? []).map((template: OfferTemplate) => (
-              <option key={template.id} value={template.id}>
-                {template.name}
-              </option>
-            ))}
-          </Select>
+            // The dash is a real OPTION for "no template", not the select's
+            // placeholder: a placeholder is only a face for an unset value, and
+            // an offer that picked a template has to be able to drop it again.
+            options={[
+              { value: "", label: "—" },
+              ...(templatesQuery.data ?? []).map((template: OfferTemplate) => ({
+                value: template.id,
+                label: template.name,
+              })),
+            ]}
+          />
         </div>
         <div className="field">
           <span className="t-label" id="offer-intro-label">

--- a/frontend/src/screens/organizations.test.tsx
+++ b/frontend/src/screens/organizations.test.tsx
@@ -12,6 +12,7 @@ import {
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { pickOption } from "../design-system/select-testing";
 import { LocaleProvider } from "../i18n";
 import {
   CompaniesScreen,
@@ -627,6 +628,7 @@ describe("CompaniesScreen — search/sort/pagination (P-14)", () => {
 
 describe("CompaniesScreen — rich create (P-15)", () => {
   it("posts display_name + size_band + domains + source:manual on submit", async () => {
+    const user = userEvent.setup();
     let posted: unknown = null;
     stubFetch(async (url, method, request) => {
       if (method === "POST" && url.includes("/organizations")) {
@@ -636,18 +638,15 @@ describe("CompaniesScreen — rich create (P-15)", () => {
       return emptyPage();
     });
     render(<CompaniesScreen />);
-    await userEvent.click(screen.getByTestId("new-record"));
-    await userEvent.type(
+    await user.click(screen.getByTestId("new-record"));
+    await user.type(
       screen.getByLabelText("Company name *"),
       "Otto Fischer GmbH",
     );
-    await userEvent.selectOptions(
-      screen.getByLabelText("Company size"),
-      "11-50",
-    );
-    await userEvent.click(screen.getByText("Add domain"));
-    await userEvent.type(screen.getByLabelText("Domain *"), "otto.example");
-    await userEvent.click(screen.getByRole("button", { name: "Create" }));
+    await pickOption(user, screen.getByLabelText("Company size"), "11-50");
+    await user.click(screen.getByText("Add domain"));
+    await user.type(screen.getByLabelText("Domain *"), "otto.example");
+    await user.click(screen.getByRole("button", { name: "Create" }));
 
     await waitFor(() => expect(posted).toBeTruthy());
     expect(posted).toMatchObject({
@@ -1431,6 +1430,7 @@ describe("CompanyScreen — archived is read-only (P-3)", () => {
 
 describe("CompanyScreen — relationship kinds by scope (P-5)", () => {
   it("offers org↔org kinds (not deal_stakeholder) from a company and POSTs counterparty_org_id", async () => {
+    const user = userEvent.setup();
     let posted: unknown = null;
     stubFetch(async (url, method, request) => {
       if (method === "POST" && url.includes("/relationships")) {
@@ -1456,20 +1456,23 @@ describe("CompanyScreen — relationship kinds by scope (P-5)", () => {
     });
     render(<CompanyScreen id="o-1" />);
     const peopleTab = await screen.findByRole("button", { name: "People" });
-    await userEvent.click(peopleTab);
+    await user.click(peopleTab);
     expect(peopleTab.getAttribute("aria-pressed")).toBe("true");
     await waitFor(() =>
       expect(screen.getByTestId("add-relationship")).toBeTruthy(),
     );
-    await userEvent.click(screen.getByTestId("add-relationship"));
+    await user.click(screen.getByTestId("add-relationship"));
 
     // An org anchors employment + the org↔org kinds; deal_stakeholder needs a
-    // person endpoint and must not be offered here.
+    // person endpoint and must not be offered here. The kinds only exist in the
+    // DOM while the popup is open, so the absence is asserted on an open list.
     const kind = screen.getByLabelText("Kind");
-    expect(within(kind).queryByText("Deal stakeholder")).toBeNull();
-    await userEvent.selectOptions(kind, "partner_of");
+    await user.click(kind);
+    const kinds = screen.getByRole("listbox");
+    expect(within(kinds).queryByText("Deal stakeholder")).toBeNull();
+    await user.click(within(kinds).getByRole("option", { name: "Partner of" }));
 
-    await userEvent.type(screen.getByPlaceholderText("Search…"), "acme");
+    await user.type(screen.getByPlaceholderText("Search…"), "acme");
     vi.useFakeTimers();
     try {
       act(() => {
@@ -1479,8 +1482,8 @@ describe("CompanyScreen — relationship kinds by scope (P-5)", () => {
       vi.useRealTimers();
     }
     await waitFor(() => expect(screen.getByText("Acme Corp")).toBeTruthy());
-    await userEvent.click(screen.getByText("Acme Corp"));
-    await userEvent.click(screen.getByTestId("add-relationship-submit"));
+    await user.click(screen.getByText("Acme Corp"));
+    await user.click(screen.getByTestId("add-relationship-submit"));
 
     await waitFor(() => expect(posted).toBeTruthy());
     expect(posted).toMatchObject({

--- a/frontend/src/screens/overlay.tsx
+++ b/frontend/src/screens/overlay.tsx
@@ -15,10 +15,10 @@ import {
   EmptyState,
   Field,
   SectionHeader,
-  Select,
   TextInput,
 } from "../design-system/atoms";
 import { ConfirmModal } from "../design-system/confirmmodal";
+import { Select } from "../design-system/select";
 import { formatDateTime } from "../format/format";
 import { type Locale, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
@@ -112,17 +112,14 @@ function OverlayConnectForm({
           <Select
             {...control}
             value={region}
-            onChange={(event) => {
-              const value = event.target.value;
+            onChange={(value) => {
               if (isOption(value, REGIONS)) setRegion(value);
             }}
-          >
-            {REGIONS.map((r) => (
-              <option key={r} value={r}>
-                {t(regionLabel[r])}
-              </option>
-            ))}
-          </Select>
+            options={REGIONS.map((r) => ({
+              value: r,
+              label: t(regionLabel[r]),
+            }))}
+          />
         )}
       </Field>
       <Field label={t("overlay.token")} hint={t("overlay.tokenHint")}>

--- a/frontend/src/screens/partners.test.tsx
+++ b/frontend/src/screens/partners.test.tsx
@@ -9,6 +9,7 @@ import {
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { pickOption } from "../design-system/select-testing";
 import { LocaleProvider } from "../i18n";
 import { PartnersScreen, PartnerTab } from "./partners";
 
@@ -73,6 +74,7 @@ const partner = {
 
 describe("PartnerTab — not yet a partner", () => {
   it("shows the setup form and PUTs the chosen role with no If-Match", async () => {
+    const user = userEvent.setup();
     let putBody: unknown = null;
     let putHeader: string | null = null;
     stubFetch(async (url, method, request) => {
@@ -92,11 +94,12 @@ describe("PartnerTab — not yet a partner", () => {
     await waitFor(() =>
       expect(screen.getByText("Not a partner yet")).toBeTruthy(),
     );
-    await userEvent.selectOptions(
+    await pickOption(
+      user,
       screen.getByLabelText("Partner role *"),
-      "consulting",
+      "Consulting",
     );
-    await userEvent.click(screen.getByRole("button", { name: "Create" }));
+    await user.click(screen.getByRole("button", { name: "Create" }));
 
     await waitFor(() => expect(putBody).toBeTruthy());
     expect(putBody).toMatchObject({ partner_role: "consulting" });
@@ -140,6 +143,7 @@ describe("PartnerTab — existing partner", () => {
 
 describe("PartnersScreen", () => {
   it("lists partners and sends the role filter", async () => {
+    const user = userEvent.setup();
     const { urls } = stubFetch(async () =>
       jsonResponse({
         data: [partner],
@@ -151,10 +155,7 @@ describe("PartnersScreen", () => {
     await waitFor(() => expect(screen.getByText("o-1")).toBeTruthy());
     expect(screen.getByText("Active")).toBeTruthy();
 
-    await userEvent.selectOptions(
-      screen.getByLabelText("Partner role"),
-      "hosting",
-    );
+    await pickOption(user, screen.getByLabelText("Partner role"), "Hosting");
 
     await waitFor(() =>
       expect(urls.some((url) => url.includes("partner_role=hosting"))).toBe(

--- a/frontend/src/screens/partners.tsx
+++ b/frontend/src/screens/partners.tsx
@@ -13,9 +13,9 @@ import {
   EmptyState,
   Field,
   SectionHeader,
-  Select,
   TextInput,
 } from "../design-system/atoms";
+import { Select } from "../design-system/select";
 import { useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { problemMessageOf, QueryGate, throwProblem } from "./common";
@@ -237,20 +237,17 @@ function PartnerForm({
           <Select
             {...control}
             value={values.partner_role}
-            onChange={(event) =>
+            onChange={(value) =>
               setValues({
                 ...values,
-                partner_role:
-                  asPartnerRole(event.target.value) ?? values.partner_role,
+                partner_role: asPartnerRole(value) ?? values.partner_role,
               })
             }
-          >
-            {PARTNER_ROLES.map((role) => (
-              <option key={role} value={role}>
-                {t(ROLE_LABELS[role])}
-              </option>
-            ))}
-          </Select>
+            options={PARTNER_ROLES.map((role) => ({
+              value: role,
+              label: t(ROLE_LABELS[role]),
+            }))}
+          />
         )}
       </Field>
       <Field label={t("partner.certStatus")}>
@@ -258,20 +255,17 @@ function PartnerForm({
           <Select
             {...control}
             value={values.cert_status}
-            onChange={(event) =>
+            onChange={(value) =>
               setValues({
                 ...values,
-                cert_status:
-                  asCertStatus(event.target.value) ?? values.cert_status,
+                cert_status: asCertStatus(value) ?? values.cert_status,
               })
             }
-          >
-            {CERT_STATUSES.map((status) => (
-              <option key={status} value={status}>
-                {t(CERT_LABELS[status])}
-              </option>
-            ))}
-          </Select>
+            options={CERT_STATUSES.map((status) => ({
+              value: status,
+              label: t(CERT_LABELS[status]),
+            }))}
+          />
         )}
       </Field>
       <Field label={t("partner.marginTier")}>
@@ -279,22 +273,26 @@ function PartnerForm({
           <Select
             {...control}
             value={values.margin_tier}
-            onChange={(event) =>
+            onChange={(value) =>
               setValues({
                 ...values,
-                margin_tier: event.target.value
-                  ? (asMarginTier(event.target.value) ?? values.margin_tier)
+                margin_tier: value
+                  ? (asMarginTier(value) ?? values.margin_tier)
                   : "",
               })
             }
-          >
-            <option value="" />
-            {MARGIN_TIERS.map((tier) => (
-              <option key={tier} value={tier}>
-                {t(MARGIN_TIER_LABELS[tier])}
-              </option>
-            ))}
-          </Select>
+            // The clearing entry is a real choice, not a placeholder: a tier once
+            // set has to be clearable back to "no tier agreed" (the wire's null).
+            // It carries a LABEL — a blank one is an unreadable strip in a drawn
+            // list and silence to a screen reader.
+            options={[
+              { value: "", label: t("field.unset") },
+              ...MARGIN_TIERS.map((tier) => ({
+                value: tier,
+                label: t(MARGIN_TIER_LABELS[tier]),
+              })),
+            ]}
+          />
         )}
       </Field>
       <Field label={t("partner.stage")}>
@@ -302,21 +300,18 @@ function PartnerForm({
           <Select
             {...control}
             value={values.relationship_stage}
-            onChange={(event) =>
+            onChange={(value) =>
               setValues({
                 ...values,
                 relationship_stage:
-                  asRelationshipStage(event.target.value) ??
-                  values.relationship_stage,
+                  asRelationshipStage(value) ?? values.relationship_stage,
               })
             }
-          >
-            {RELATIONSHIP_STAGES.map((stage) => (
-              <option key={stage} value={stage}>
-                {t(STAGE_LABELS[stage])}
-              </option>
-            ))}
-          </Select>
+            options={RELATIONSHIP_STAGES.map((stage) => ({
+              value: stage,
+              label: t(STAGE_LABELS[stage]),
+            }))}
+          />
         )}
       </Field>
       <Field label={t("partner.nextStep")}>

--- a/frontend/src/screens/people.test.tsx
+++ b/frontend/src/screens/people.test.tsx
@@ -9,7 +9,7 @@ import {
   waitFor,
   within,
 } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import userEvent, { type UserEvent } from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { LocaleProvider } from "../i18n";
@@ -42,6 +42,21 @@ function render(ui: ReactNode) {
       <LocaleProvider initial="en">{ui}</LocaleProvider>
     </QueryClientProvider>,
   );
+}
+
+// What a dropdown offers, in order. The options live in a portalled popup that
+// only exists while the control is open, and only one popup is open at a time —
+// so a list is read by opening its own control and closing it again, which is
+// also what lets two Type selects on the same form be compared.
+async function optionTextOf(user: UserEvent, control: HTMLElement) {
+  await user.click(control);
+  const text = within(screen.getByRole("listbox"))
+    .getAllByRole("option")
+    .map((option) => option.textContent);
+  // Closed by the trigger, not by Escape: these controls sit inside a modal,
+  // and Escape reaches the dialog too.
+  await user.click(control);
+  return text;
 }
 
 const anna = {
@@ -237,27 +252,31 @@ describe("ContactsScreen — rich create (P-15)", () => {
   // MessageKey string (fieldControl in create.tsx renders option.label
   // verbatim, so an untranslated key would leak straight to the DOM).
   it("shows translated Type option text, not the raw i18n key", async () => {
+    const user = userEvent.setup();
     stubFetch(async () => emptyPage());
     render(<ContactsScreen />);
-    await userEvent.click(screen.getByTestId("new-record"));
-    await userEvent.click(screen.getByText("Add email"));
-    await userEvent.click(screen.getByText("Add phone"));
+    await user.click(screen.getByTestId("new-record"));
+    await user.click(screen.getByText("Add email"));
+    await user.click(screen.getByText("Add phone"));
     const [emailType, phoneType] = screen.getAllByLabelText("Type");
 
-    const emailOptionText = within(emailType as HTMLElement)
-      .getAllByRole("option")
-      .map((option) => option.textContent);
-    expect(emailOptionText).toEqual(["", "Work", "Personal", "Other"]);
+    const emailOptionText = await optionTextOf(user, emailType);
+    expect(emailOptionText).toEqual(["Not set", "Work", "Personal", "Other"]);
     expect(emailOptionText).not.toContain("field.emailWork");
 
-    const phoneOptionText = within(phoneType as HTMLElement)
-      .getAllByRole("option")
-      .map((option) => option.textContent);
-    expect(phoneOptionText).toEqual(["", "Work", "Mobile", "Home", "Other"]);
+    const phoneOptionText = await optionTextOf(user, phoneType);
+    expect(phoneOptionText).toEqual([
+      "Not set",
+      "Work",
+      "Mobile",
+      "Home",
+      "Other",
+    ]);
     expect(phoneOptionText).not.toContain("field.phoneWork");
   });
 
   it("shows German Type option text under the de locale", async () => {
+    const user = userEvent.setup();
     stubFetch(async () => emptyPage());
     const client = new QueryClient({
       defaultOptions: { queries: { retry: false } },
@@ -269,13 +288,15 @@ describe("ContactsScreen — rich create (P-15)", () => {
         </LocaleProvider>
       </QueryClientProvider>,
     );
-    await userEvent.click(screen.getByTestId("new-record"));
-    await userEvent.click(screen.getByText("E-Mail hinzufügen"));
-    const emailType = screen.getByLabelText("Typ");
-    const optionText = within(emailType)
-      .getAllByRole("option")
-      .map((option) => option.textContent);
-    expect(optionText).toEqual(["", "Geschäftlich", "Privat", "Sonstige"]);
+    await user.click(screen.getByTestId("new-record"));
+    await user.click(screen.getByText("E-Mail hinzufügen"));
+    const optionText = await optionTextOf(user, screen.getByLabelText("Typ"));
+    expect(optionText).toEqual([
+      "Nicht gesetzt",
+      "Geschäftlich",
+      "Privat",
+      "Sonstige",
+    ]);
   });
 
   it("posts full_name + emails + source:manual on submit", async () => {
@@ -823,6 +844,7 @@ describe("PersonScreen — archived is read-only (P-3)", () => {
 
 describe("PersonScreen — relationship kinds by scope (P-5)", () => {
   it("offers deal_stakeholder (not org↔org) from a person, searches deals, confirms, and POSTs deal_id", async () => {
+    const user = userEvent.setup();
     let posted: unknown = null;
     stubFetch(async (url, method, request) => {
       if (method === "POST" && url.includes("/relationships")) {
@@ -845,19 +867,24 @@ describe("PersonScreen — relationship kinds by scope (P-5)", () => {
     });
     render(<PersonScreen id="p-1" />);
     await waitFor(() => expect(screen.getByText("Overview")).toBeTruthy());
-    await userEvent.click(screen.getByText("People & companies"));
+    await user.click(screen.getByText("People & companies"));
     await waitFor(() =>
       expect(screen.getByTestId("add-relationship")).toBeTruthy(),
     );
-    await userEvent.click(screen.getByTestId("add-relationship"));
+    await user.click(screen.getByTestId("add-relationship"));
 
     // A person can anchor employment + deal_stakeholder; the org↔org kinds
-    // (partner_of/…) need two orgs and must not be offered here.
-    const kind = screen.getByLabelText("Kind");
-    expect(within(kind).queryByText("Partner of")).toBeNull();
-    await userEvent.selectOptions(kind, "deal_stakeholder");
+    // (partner_of/…) need two orgs and must not be offered here. The kinds only
+    // exist in the DOM while the popup is open, hence the click before the
+    // absence is asserted.
+    await user.click(screen.getByLabelText("Kind"));
+    const kinds = screen.getByRole("listbox");
+    expect(within(kinds).queryByText("Partner of")).toBeNull();
+    await user.click(
+      within(kinds).getByRole("option", { name: "Deal stakeholder" }),
+    );
 
-    await userEvent.type(screen.getByPlaceholderText("Search…"), "q3");
+    await user.type(screen.getByPlaceholderText("Search…"), "q3");
     vi.useFakeTimers();
     try {
       act(() => {
@@ -867,14 +894,14 @@ describe("PersonScreen — relationship kinds by scope (P-5)", () => {
       vi.useRealTimers();
     }
     await waitFor(() => expect(screen.getByText("Q3 Renewal")).toBeTruthy());
-    await userEvent.click(screen.getByText("Q3 Renewal"));
+    await user.click(screen.getByText("Q3 Renewal"));
 
     // A meaningful confirmation after select, consistent with merge.
     expect(
       screen.getByText("Add a Deal stakeholder link to Q3 Renewal."),
     ).toBeTruthy();
 
-    await userEvent.click(screen.getByTestId("add-relationship-submit"));
+    await user.click(screen.getByTestId("add-relationship-submit"));
     await waitFor(() => expect(posted).toBeTruthy());
     expect(posted).toMatchObject({
       person_id: "p-1",

--- a/frontend/src/screens/privacy.test.tsx
+++ b/frontend/src/screens/privacy.test.tsx
@@ -13,6 +13,7 @@ import {
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { pickOption } from "../design-system/select-testing";
 import { LocaleProvider } from "../i18n";
 import { ConsentPurposesCard, PrivacyInboxCard } from "./privacy";
 
@@ -103,6 +104,13 @@ function stubRoutes(
     }),
   );
   return sent;
+}
+
+// Drives one of this screen's dropdowns by the label a reader sees. `pickOption`
+// needs a userEvent session, so it gets a fresh one — the same thing every bare
+// `userEvent.*` call in this file does internally.
+function choose(control: HTMLElement, optionLabel: string) {
+  return pickOption(userEvent.setup(), control, optionLabel);
 }
 
 beforeEach(() => localStorage.setItem("margince.workspaceSlug", "acme"));
@@ -474,10 +482,18 @@ describe("PrivacyInboxCard", () => {
       await screen.findByRole("button", { name: /8f3a-person-uuid/i }),
     );
     const picker = await screen.findByLabelText(/assignee/i);
+    // The agent seat's absence is a property of the LIST, and the list only
+    // exists while the popup is open — so the picker is opened here and the pick
+    // lands on the very list under assertion (which is why this drives the two
+    // steps by hand rather than through pickOption).
+    await userEvent.click(picker);
+    const roster = screen.getByRole("listbox");
     expect(
-      screen.queryByRole("option", { name: "Bot" }),
+      within(roster).queryByRole("option", { name: "Bot" }),
     ).not.toBeInTheDocument();
-    await userEvent.selectOptions(picker, "u1");
+    await userEvent.click(
+      within(roster).getByRole("option", { name: "Dana DPO" }),
+    );
     await waitFor(() =>
       expect(
         sent.filter((s) => s.key === "PATCH /data-subject-requests/d1"),
@@ -531,7 +547,7 @@ describe("PrivacyInboxCard", () => {
       await screen.findByRole("button", { name: /8f3a-person-uuid/i }),
     );
     const picker = await screen.findByLabelText(/assignee/i);
-    await userEvent.selectOptions(picker, "u1");
+    await choose(picker, "Dana DPO");
     const row = await findDsrRow("8f3a-person-uuid");
     expect(
       await within(row).findByText(
@@ -566,7 +582,7 @@ describe("opening a DSR (G-2)", () => {
     await userEvent.click(
       await screen.findByRole("button", { name: /new request/i }),
     );
-    await userEvent.selectOptions(screen.getByLabelText(/kind/i), "erasure");
+    await choose(screen.getByLabelText(/kind/i), "erasure");
     expect(screen.getByLabelText(/person/i)).toBeInTheDocument();
     expect(
       screen.queryByLabelText(/subject reference/i),
@@ -579,7 +595,7 @@ describe("opening a DSR (G-2)", () => {
     await userEvent.click(
       await screen.findByRole("button", { name: /new request/i }),
     );
-    await userEvent.selectOptions(screen.getByLabelText(/kind/i), "access");
+    await choose(screen.getByLabelText(/kind/i), "access");
     expect(screen.getByLabelText(/subject reference/i)).toBeInTheDocument();
   });
 
@@ -589,7 +605,7 @@ describe("opening a DSR (G-2)", () => {
     await userEvent.click(
       await screen.findByRole("button", { name: /new request/i }),
     );
-    await userEvent.selectOptions(screen.getByLabelText(/kind/i), "access");
+    await choose(screen.getByLabelText(/kind/i), "access");
     expect(screen.getByText(/fulfilled by hand/i)).toBeInTheDocument();
   });
 
@@ -599,7 +615,7 @@ describe("opening a DSR (G-2)", () => {
     await userEvent.click(
       await screen.findByRole("button", { name: /new request/i }),
     );
-    await userEvent.selectOptions(screen.getByLabelText(/kind/i), "access");
+    await choose(screen.getByLabelText(/kind/i), "access");
     await userEvent.type(
       screen.getByLabelText(/subject reference/i),
       "anna@acme.test",
@@ -649,7 +665,7 @@ describe("opening a DSR (G-2)", () => {
     await userEvent.click(
       await screen.findByRole("button", { name: /new request/i }),
     );
-    await userEvent.selectOptions(screen.getByLabelText(/kind/i), "erasure");
+    await choose(screen.getByLabelText(/kind/i), "erasure");
     await userEvent.type(screen.getByLabelText(/person/i), "anna");
     await userEvent.click(await screen.findByText("Anna Weber"));
     // type="date" only accepts a programmatic value change in jsdom (same
@@ -703,7 +719,7 @@ describe("opening a DSR (G-2)", () => {
     await userEvent.click(
       await screen.findByRole("button", { name: /new request/i }),
     );
-    await userEvent.selectOptions(screen.getByLabelText(/kind/i), "access");
+    await choose(screen.getByLabelText(/kind/i), "access");
     await userEvent.type(
       screen.getByLabelText(/subject reference/i),
       "anna@acme.test",
@@ -755,7 +771,7 @@ describe("opening a DSR (G-2)", () => {
     await userEvent.click(
       await screen.findByRole("button", { name: /new request/i }),
     );
-    await userEvent.selectOptions(screen.getByLabelText(/kind/i), "access");
+    await choose(screen.getByLabelText(/kind/i), "access");
     await userEvent.type(
       screen.getByLabelText(/subject reference/i),
       "anna@acme.test",

--- a/frontend/src/screens/privacy.test.tsx
+++ b/frontend/src/screens/privacy.test.tsx
@@ -511,6 +511,42 @@ describe("PrivacyInboxCard", () => {
     expect(patches[0]?.body).toEqual({ assignee_id: "u1" });
   });
 
+  // The unassigned entry is a state, not an action: the server's update
+  // coalesces an omitted assignee onto the stored one, so nothing an empty
+  // selection sent could unassign anybody. It stays in the list, disabled, so
+  // the state is legible without being offered.
+  it("shows the unassigned entry but does not offer it as a choice", async () => {
+    const sent = stubRoutes({
+      "GET /users": () =>
+        jsonResponse({
+          data: [
+            {
+              id: "u1",
+              workspace_id: "w",
+              email: "dpo@acme.test",
+              display_name: "Dana DPO",
+              status: "active",
+              is_agent: false,
+            },
+          ],
+          page: { next_cursor: null, has_more: false },
+        }),
+    });
+    render(<PrivacyInboxCard />);
+    await userEvent.click(
+      await screen.findByRole("button", { name: /8f3a-person-uuid/i }),
+    );
+    await userEvent.click(await screen.findByLabelText(/assignee/i));
+    const unassigned = within(screen.getByRole("listbox")).getByRole("option", {
+      name: "—",
+    });
+    expect(unassigned).toHaveAttribute("aria-disabled", "true");
+    await userEvent.click(unassigned);
+    expect(
+      sent.filter((s) => s.key === "PATCH /data-subject-requests/d1"),
+    ).toHaveLength(0);
+  });
+
   // The assignee select and the row's own status-transition buttons share
   // one `patch` mutation, so a failed assignment must be exactly as visible
   // as a failed transition — this pins that it is, using the assignee path

--- a/frontend/src/screens/privacy.tsx
+++ b/frontend/src/screens/privacy.tsx
@@ -15,7 +15,6 @@ import {
   Field,
   SectionHeader,
   SegmentedControl,
-  Select,
   Skeleton,
   Textarea,
   TextInput,
@@ -25,6 +24,7 @@ import {
   RecordPicker,
   type RecordPickerCandidate,
 } from "../design-system/recordpicker";
+import { Select, type SelectOption } from "../design-system/select";
 import { formatDate } from "../format/format";
 import { useNow } from "../format/now";
 import { type Locale, useLocale, useT } from "../i18n";
@@ -334,18 +334,15 @@ function NewDsrForm({ onDone }: Readonly<{ onDone: () => void }>) {
           {(control) => (
             <Select
               {...control}
+              options={DSR_KINDS.map((value) => ({
+                value,
+                label: humanizeToken(value),
+              }))}
               value={kind}
-              onChange={(event) => {
-                const value = event.target.value;
+              onChange={(value) => {
                 if (isOption(value, DSR_KINDS)) changeKind(value);
               }}
-            >
-              {DSR_KINDS.map((value) => (
-                <option key={value} value={value}>
-                  {humanizeToken(value)}
-                </option>
-              ))}
-            </Select>
+            />
           )}
         </Field>
 
@@ -437,6 +434,18 @@ function transitionLabelKey(status: DsrStatus): MessageKey {
   if (status === "in_progress") return "privacy.inProgress";
   if (status === "fulfilled") return "privacy.fulfil";
   return "privacy.reject";
+}
+
+// Who a request can be assigned to, led by the unassigned entry. That entry
+// stays an OPTION rather than becoming the select's placeholder: it is the face
+// an unassigned request shows, and a placeholder would leave the row's own
+// empty-selection guard below describing a state nothing could reach. The em
+// dash carries no words to translate.
+function assigneeOptions(users: readonly User[]): SelectOption[] {
+  return [
+    { value: "", label: "—" },
+    ...users.map((user) => ({ value: user.id, label: user.display_name })),
+  ];
 }
 
 // One DSR row: collapsed summary + (on click) the case-work panel — subject,
@@ -584,10 +593,10 @@ function DsrRow({
               </label>
               <Select
                 id={assigneeFieldId}
+                options={assigneeOptions(assignableUsers)}
                 value={dsr.assignee_id ?? ""}
                 disabled={patch.isPending}
-                onChange={(event) => {
-                  const value = event.target.value;
+                onChange={(value) => {
                   // No "unassign" option: coalesce($3, assignee_id) treats an
                   // explicit null as a no-op, so there is nothing an empty
                   // selection could legitimately send.
@@ -596,14 +605,7 @@ function DsrRow({
                   }
                   patch.mutate({ assignee_id: value });
                 }}
-              >
-                <option value="">—</option>
-                {assignableUsers.map((user) => (
-                  <option key={user.id} value={user.id}>
-                    {user.display_name}
-                  </option>
-                ))}
-              </Select>
+              />
               <p className="t-caption">{t("privacy.assigneeUnassignable")}</p>
               {patch.isPending && (
                 <p className="t-caption">{t("common.saving")}</p>

--- a/frontend/src/screens/privacy.tsx
+++ b/frontend/src/screens/privacy.tsx
@@ -381,10 +381,9 @@ function NewDsrForm({ onDone }: Readonly<{ onDone: () => void }>) {
 
         <Field label={t("privacy.dueAt")}>
           {(control) => (
-            <input
+            <TextInput
               {...control}
               type="date"
-              className="input"
               value={dueAt}
               onChange={(event) => {
                 setDueAt(event.target.value);
@@ -436,14 +435,16 @@ function transitionLabelKey(status: DsrStatus): MessageKey {
   return "privacy.reject";
 }
 
-// Who a request can be assigned to, led by the unassigned entry. That entry
-// stays an OPTION rather than becoming the select's placeholder: it is the face
-// an unassigned request shows, and a placeholder would leave the row's own
-// empty-selection guard below describing a state nothing could reach. The em
-// dash carries no words to translate.
+// Who a request can be assigned to, led by the unassigned entry. That entry is
+// DISABLED, and it is still an option rather than the select's placeholder: the
+// server's update coalesces an omitted assignee onto the stored one, so nothing
+// an empty selection sent could unassign anybody — and an entry a reader can
+// aim at has to be able to change something. Kept in the list because it is the
+// face an unassigned request shows, and the state has to stay legible even
+// where it is not actionable. The em dash carries no words to translate.
 function assigneeOptions(users: readonly User[]): SelectOption[] {
   return [
-    { value: "", label: "—" },
+    { value: "", label: "—", disabled: true },
     ...users.map((user) => ({ value: user.id, label: user.display_name })),
   ];
 }
@@ -596,15 +597,7 @@ function DsrRow({
                 options={assigneeOptions(assignableUsers)}
                 value={dsr.assignee_id ?? ""}
                 disabled={patch.isPending}
-                onChange={(value) => {
-                  // No "unassign" option: coalesce($3, assignee_id) treats an
-                  // explicit null as a no-op, so there is nothing an empty
-                  // selection could legitimately send.
-                  if (!value) {
-                    return;
-                  }
-                  patch.mutate({ assignee_id: value });
-                }}
+                onChange={(value) => patch.mutate({ assignee_id: value })}
               />
               <p className="t-caption">{t("privacy.assigneeUnassignable")}</p>
               {patch.isPending && (

--- a/frontend/src/screens/quotas.forms.tsx
+++ b/frontend/src/screens/quotas.forms.tsx
@@ -4,14 +4,8 @@ import { useEffect, useId, useRef, useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { ifMatch } from "../api/version";
-import {
-  Button,
-  Field,
-  Modal,
-  Radio,
-  Select,
-  TextInput,
-} from "../design-system/atoms";
+import { Button, Field, Modal, Radio, TextInput } from "../design-system/atoms";
+import { Select } from "../design-system/select";
 import { useT } from "../i18n";
 import { ArchiveAction } from "./archive";
 import { ProblemError, problemMessageOf, throwProblem } from "./common";
@@ -201,19 +195,22 @@ function SetTargetModal({
             <Select
               {...control}
               value={subjectId}
-              onChange={(event) => setSubjectId(event.target.value)}
-            >
-              <option value="" disabled>
-                {side === "owner"
-                  ? t("quotas.pickOwner")
-                  : t("quotas.pickTeam")}
-              </option>
-              {(roster.data ?? []).map((entry) => (
-                <option key={entry.id} value={entry.id}>
-                  {subjectLabel(entry)}
-                </option>
-              ))}
-            </Select>
+              onChange={setSubjectId}
+              options={[
+                {
+                  value: "",
+                  label:
+                    side === "owner"
+                      ? t("quotas.pickOwner")
+                      : t("quotas.pickTeam"),
+                  disabled: true,
+                },
+                ...(roster.data ?? []).map((entry) => ({
+                  value: entry.id,
+                  label: subjectLabel(entry),
+                })),
+              ]}
+            />
           )}
         </Field>
 

--- a/frontend/src/screens/quotas.test.tsx
+++ b/frontend/src/screens/quotas.test.tsx
@@ -1,18 +1,11 @@
 /** @vitest-environment jsdom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import {
-  cleanup,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { components } from "../api/schema";
 import { AttainmentRing } from "../design-system/atoms";
-import { pickOption } from "../design-system/select-testing";
 import { LocaleProvider } from "../i18n";
 import { AttainmentNumbers, PaceLine, QuotasView } from "./quotas";
 import { isOwnerXorTeam, parseEuroMinor } from "./quotas.forms";
@@ -362,26 +355,23 @@ describe("QuotasView", () => {
           422,
         ),
     });
+    const user = userEvent.setup();
     mount(<QuotasView />);
-    await userEvent.click(await screen.findByTestId("quota-create"));
-    // The roster arrives from its own fetch, so the option is not there when the
-    // form opens — and picking one that does not exist yet silently no-ops,
-    // leaving the form unsubmittable. pickOption opens the list and clicks the
-    // person by name, so it can only succeed once the roster has landed.
-    await waitFor(async () =>
-      pickOption(
-        userEvent.setup(),
-        await screen.findByRole("combobox"),
-        "Riya Patel",
-      ),
-    );
+    await user.click(await screen.findByTestId("quota-create"));
+    // The roster arrives from its own fetch, so the person is not in the list
+    // when the form opens — and a subject that was never chosen leaves the form
+    // unsubmittable, which would make this case prove nothing. The list is opened
+    // ONCE and the option awaited inside it: opening again would toggle it shut,
+    // and the popup re-renders in place when the roster lands.
+    await user.click(await screen.findByRole("combobox"));
+    await user.click(await screen.findByRole("option", { name: "Riya Patel" }));
     const dateInputs = document.querySelectorAll('input[type="date"]');
     fireEvent.change(dateInputs[0], { target: { value: "2026-07-01" } });
     fireEvent.change(dateInputs[1], { target: { value: "2026-09-30" } });
     fireEvent.change(screen.getByLabelText(/Target amount/), {
       target: { value: "280000" },
     });
-    await userEvent.click(screen.getByTestId("quota-create-submit"));
+    await user.click(screen.getByTestId("quota-create-submit"));
     expect(
       await screen.findByText("Choose exactly one of owner or team."),
     ).toBeTruthy();

--- a/frontend/src/screens/quotas.test.tsx
+++ b/frontend/src/screens/quotas.test.tsx
@@ -1,11 +1,18 @@
 /** @vitest-environment jsdom */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { components } from "../api/schema";
 import { AttainmentRing } from "../design-system/atoms";
+import { pickOption } from "../design-system/select-testing";
 import { LocaleProvider } from "../i18n";
 import { AttainmentNumbers, PaceLine, QuotasView } from "./quotas";
 import { isOwnerXorTeam, parseEuroMinor } from "./quotas.forms";
@@ -357,11 +364,17 @@ describe("QuotasView", () => {
     });
     mount(<QuotasView />);
     await userEvent.click(await screen.findByTestId("quota-create"));
-    const subjectSelect = await screen.findByRole("combobox");
-    // Wait for the roster-fetched option to render — setting .value before the
-    // matching <option> exists silently no-ops (leaving canSubmit false).
-    await screen.findByRole("option", { name: "Riya Patel" });
-    fireEvent.change(subjectSelect, { target: { value: "u1" } });
+    // The roster arrives from its own fetch, so the option is not there when the
+    // form opens — and picking one that does not exist yet silently no-ops,
+    // leaving the form unsubmittable. pickOption opens the list and clicks the
+    // person by name, so it can only succeed once the roster has landed.
+    await waitFor(async () =>
+      pickOption(
+        userEvent.setup(),
+        await screen.findByRole("combobox"),
+        "Riya Patel",
+      ),
+    );
     const dateInputs = document.querySelectorAll('input[type="date"]');
     fireEvent.change(dateInputs[0], { target: { value: "2026-07-01" } });
     fireEvent.change(dateInputs[1], { target: { value: "2026-09-30" } });

--- a/frontend/src/screens/relationships.tsx
+++ b/frontend/src/screens/relationships.tsx
@@ -17,9 +17,9 @@ import {
   Modal,
   SearchField,
   SectionHeader,
-  Select,
   TextInput,
 } from "../design-system/atoms";
+import { Select } from "../design-system/select";
 import { useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { problemMessageOf, QueryGate, throwProblem } from "./common";
@@ -376,18 +376,15 @@ function AddRelationshipAction({
               <Select
                 {...control}
                 value={kind}
-                onChange={(event) => {
-                  const value = event.target.value;
+                onChange={(value) => {
                   const kinds = options.map((o) => o.kind);
                   if (isOption(value, kinds)) selectKind(value);
                 }}
-              >
-                {options.map((option) => (
-                  <option key={option.kind} value={option.kind}>
-                    {t(KIND_LABELS[option.kind])}
-                  </option>
-                ))}
-              </Select>
+                options={options.map((option) => ({
+                  value: option.kind,
+                  label: t(KIND_LABELS[option.kind]),
+                }))}
+              />
             )}
           </Field>
           <Field label={t("rel.role")}>

--- a/frontend/src/screens/richfields.test.tsx
+++ b/frontend/src/screens/richfields.test.tsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { useState } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { pickOption } from "../design-system/select-testing";
 import { LocaleProvider } from "../i18n";
 import { type CreateField, type FormRows, RecordFormBody } from "./create";
 
@@ -75,16 +76,17 @@ describe("repeatable-row fields", () => {
   });
 
   it("updates a row's values as the user types and selects", async () => {
+    const user = userEvent.setup();
     render(<Harness fields={[emailsField]} onSubmit={vi.fn()} />);
-    await userEvent.click(screen.getByText("Add email"));
-    await userEvent.type(screen.getByLabelText("Email *"), "a@x.test");
-    await userEvent.selectOptions(screen.getByLabelText("Type"), "work");
+    await user.click(screen.getByText("Add email"));
+    await user.type(screen.getByLabelText("Email *"), "a@x.test");
+    await pickOption(user, screen.getByLabelText("Type"), "Work");
     expect((screen.getByLabelText("Email *") as HTMLInputElement).value).toBe(
       "a@x.test",
     );
-    expect((screen.getByLabelText("Type") as HTMLSelectElement).value).toBe(
-      "work",
-    );
+    // The dropdown carries its value on its closed face, not in a `value`
+    // property — the trigger's only text is the label of what is chosen.
+    expect(screen.getByLabelText("Type").textContent).toBe("Work");
   });
 
   it("marks exactly one row primary", async () => {
@@ -113,13 +115,14 @@ describe("repeatable-row fields", () => {
   });
 
   it("collects the rows for submission", async () => {
+    const user = userEvent.setup();
     const onSubmit = vi.fn();
     render(<Harness fields={[emailsField]} onSubmit={onSubmit} />);
-    await userEvent.click(screen.getByText("Add email"));
-    await userEvent.type(screen.getByLabelText("Email *"), "a@x.test");
-    await userEvent.selectOptions(screen.getByLabelText("Type"), "work");
-    await userEvent.click(screen.getByRole("radio", { name: "Primary" }));
-    await userEvent.click(screen.getByRole("button", { name: "Create" }));
+    await user.click(screen.getByText("Add email"));
+    await user.type(screen.getByLabelText("Email *"), "a@x.test");
+    await pickOption(user, screen.getByLabelText("Type"), "Work");
+    await user.click(screen.getByRole("radio", { name: "Primary" }));
+    await user.click(screen.getByRole("button", { name: "Create" }));
     expect(onSubmit).toHaveBeenCalledWith(
       {},
       {

--- a/frontend/src/screens/settings.stories.tsx
+++ b/frontend/src/screens/settings.stories.tsx
@@ -4,6 +4,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { userEvent, within } from "storybook/test";
 import { type GrantSpec, meFixture } from "../app/mefixture";
+import { pickOption } from "../design-system/select-testing";
 import { AuditLogCard, PipelinesCard, SettingsScreen } from "./settings";
 import {
   installFetchStub,
@@ -140,8 +141,13 @@ export const AiToolConsole: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await canvas.findByText("search_records");
-    const select = canvas.getByRole("combobox", { name: "All passports" });
-    await userEvent.selectOptions(select, "Reachable by Scout");
+    // The listbox is portalled to the body, outside this story's canvas, so the
+    // pick goes through the shared helper rather than a canvas-scoped query.
+    await pickOption(
+      userEvent.setup(),
+      canvas.getByRole("combobox", { name: "All passports" }),
+      "Reachable by Scout",
+    );
   },
 };
 

--- a/frontend/src/screens/settings.test.tsx
+++ b/frontend/src/screens/settings.test.tsx
@@ -12,6 +12,7 @@ import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { type GrantSpec, meFixture } from "../app/mefixture";
+import { pickOption } from "../design-system/select-testing";
 import { LocaleProvider } from "../i18n";
 import { companyContextCapabilitiesQueryKey } from "./company-context";
 import { AuditLogCard, PipelinesCard, SettingsScreen } from "./settings";
@@ -328,25 +329,29 @@ function agentToolsWithPassportsBackend() {
 
 describe("AgentToolsCard passport scoping", () => {
   it("excludes a revoked passport from the selector", async () => {
+    const user = userEvent.setup();
     vi.stubGlobal("fetch", agentToolsWithPassportsBackend());
     render(<SettingsScreen tab="ai" />);
     await screen.findByText("list_pipelines");
 
-    const select = screen.getByLabelText("All passports");
-    const optionLabels = Array.from(select.querySelectorAll("option")).map(
-      (o) => o.textContent,
-    );
+    // The options only exist while the popup is open — the control renders no
+    // listbox when closed — so reading what it offers means opening it first.
+    await user.click(screen.getByLabelText("All passports"));
+    const optionLabels = screen
+      .getAllByRole("option")
+      .map((option) => option.textContent);
     expect(optionLabels).toContain("Reachable by Scout");
     expect(optionLabels).not.toContain("Reachable by Retired");
   });
 
   it("keeps a scope-free tool reachable once a passport is selected", async () => {
+    const user = userEvent.setup();
     vi.stubGlobal("fetch", agentToolsWithPassportsBackend());
     render(<SettingsScreen tab="ai" />);
     await screen.findByText("list_pipelines");
 
     const select = screen.getByLabelText("All passports");
-    await userEvent.selectOptions(select, "pp-1");
+    await pickOption(user, select, "Reachable by Scout");
 
     const freeRow = document.querySelector('[data-tool="list_pipelines"]');
     expect(freeRow).toBeTruthy();
@@ -423,12 +428,13 @@ describe("PassportCard revoke (AS-2)", () => {
   // dimmed by a credential the human can no longer choose is a filter with no
   // control, and no way to undo it.
   it("stops scoping the tool console to a passport revoked while it was selected", async () => {
+    const user = userEvent.setup();
     vi.stubGlobal("fetch", revocablePassportsBackend());
     render(<SettingsScreen tab="ai" />);
     await screen.findByText("send_email");
 
     const select = screen.getByLabelText("All passports");
-    await userEvent.selectOptions(select, "pp-1");
+    await pickOption(user, select, "Reachable by Scout");
     const scopedRow = document.querySelector('[data-tool="send_email"]');
     expect(scopedRow).toBeTruthy();
     // Scout grants "read" only, so the send tool reads as out of scope while
@@ -443,17 +449,19 @@ describe("PassportCard revoke (AS-2)", () => {
     if (!(revokeButton instanceof HTMLButtonElement)) {
       throw new Error("the live passport row offers no revoke control");
     }
-    await userEvent.click(revokeButton);
+    await user.click(revokeButton);
     const dialog = await screen.findByRole("dialog");
-    await userEvent.click(
-      within(dialog).getByRole("button", { name: "Revoke" }),
-    );
+    await user.click(within(dialog).getByRole("button", { name: "Revoke" }));
 
-    // The revoked passport leaves the selector...
+    // The revoked passport leaves the selector, which is left offering the
+    // "all passports" choice and nothing else. That list only exists while the
+    // popup is open, so reopen it: it stays mounted and re-renders as the
+    // refetched passports arrive, which is what this waitFor waits for...
+    await user.click(select);
     await waitFor(() =>
       expect(
-        Array.from(select.querySelectorAll("option")).map((o) => o.value),
-      ).toEqual([""]),
+        screen.getAllByRole("option").map((option) => option.textContent),
+      ).toEqual(["All passports"]),
     );
     // ...and the inventory reads unfiltered again, matching what it shows.
     expect(

--- a/frontend/src/screens/share.test.tsx
+++ b/frontend/src/screens/share.test.tsx
@@ -10,6 +10,7 @@ import {
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { pickOption } from "../design-system/select-testing";
 import { LocaleProvider } from "../i18n";
 import { ShareScreen } from "./share";
 
@@ -170,6 +171,84 @@ describe("ShareScreen", () => {
       reason: "Deal-desk review",
     });
     expect((posted as Record<string, unknown>).expires_at).toBeDefined();
+  });
+
+  // The expiry control converts between a DAY COUNT (the screen's state) and the
+  // strings a listbox speaks, and the wire carries neither: it carries a timestamp,
+  // or nothing at all for a grant that lasts until it is revoked. Both directions
+  // of that conversion are asserted, because the two failures look identical on
+  // screen — a grant that silently never expires, and one that expires today.
+  it("turns the chosen expiry into a timestamp, and no expiry into none", async () => {
+    // Collected in an ARRAY rather than into a `let`: a variable only ever
+    // assigned inside a `.then()` still reads as its initial `null` to the
+    // compiler, so every field access off it narrows to `never`. An array keeps
+    // its element type, and the two grants are two entries.
+    const posts: Record<string, unknown>[] = [];
+    const grant = (body: Record<string, unknown>) =>
+      jsonResponse(
+        {
+          id: "g-3",
+          record_type: "deal",
+          record_id: "d-1",
+          subject_type: "user",
+          subject_id: "u-1",
+          access: "read",
+          granted_by: "u-1",
+          reason: body.reason ?? null,
+          expires_at: body.expires_at ?? null,
+          created_at: "2026-07-14T00:00:00Z",
+          version: 1,
+        },
+        201,
+      );
+    installBaseFetch({
+      "/record-grants": (request) => {
+        if (request.method === "POST") {
+          return request.json().then((body) => {
+            posts.push(body);
+            return grant(body);
+          });
+        }
+        return jsonResponse({
+          data: [existingGrant],
+          page: { next_cursor: null, has_more: false },
+        });
+      },
+    });
+    render(<ShareScreen recordType="deal" recordId="d-1" />);
+    const user = userEvent.setup();
+
+    await user.click(await screen.findByRole("button", { name: /Priya Shah/ }));
+    await pickOption(
+      user,
+      screen.getByLabelText("Expiry"),
+      "Expires in 7 days",
+    );
+    await user.click(screen.getByTestId("share-grant-submit"));
+
+    await waitFor(() => expect(posts).toHaveLength(1));
+    // A real instant, seven days out — asserted as a distance rather than as a
+    // literal, because the clock is the one thing a test cannot pin.
+    const days =
+      (Date.parse(String(posts[0].expires_at)) - Date.now()) / 86_400_000;
+    expect(days).toBeGreaterThan(6.9);
+    expect(days).toBeLessThan(7.1);
+
+    // A granted subject is picked again for the second half: a successful grant
+    // clears the form, which is what the reader sees, so the case has to walk the
+    // same path they would rather than reusing a form that is no longer filled in.
+    await user.click(await screen.findByRole("button", { name: /Priya Shah/ }));
+    await pickOption(
+      user,
+      screen.getByLabelText("Expiry"),
+      "No expiry (until revoked)",
+    );
+    await user.click(screen.getByTestId("share-grant-submit"));
+
+    await waitFor(() => expect(posts).toHaveLength(2));
+    // Absent, not an empty string and not epoch zero: a grant with no expiry is
+    // one the wire says nothing about.
+    expect(posts[1].expires_at).toBeUndefined();
   });
 
   it("excludes agent seats from the subject picker (spec §2.1)", async () => {

--- a/frontend/src/screens/share.tsx
+++ b/frontend/src/screens/share.tsx
@@ -19,10 +19,10 @@ import {
   SearchField,
   SectionHeader,
   SegmentedControl,
-  Select,
   Textarea,
 } from "../design-system/atoms";
 import { ConfirmModal } from "../design-system/confirmmodal";
+import { Select } from "../design-system/select";
 import { formatDate } from "../format/format";
 import { useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
@@ -532,18 +532,18 @@ function ShareScreenBody({
             {(control) => (
               <Select
                 {...control}
-                value={expiryDays}
-                onChange={(event) => {
-                  setExpiryDays(Number(event.target.value));
+                // A day count is the state; the control speaks strings, so the
+                // conversion happens here at the boundary and nowhere else.
+                value={String(expiryDays)}
+                onChange={(value) => {
+                  setExpiryDays(Number(value));
                   dismissGrantError();
                 }}
-              >
-                {EXPIRY_OPTIONS.map((option) => (
-                  <option key={option.days} value={option.days}>
-                    {t(option.key)}
-                  </option>
-                ))}
-              </Select>
+                options={EXPIRY_OPTIONS.map((option) => ({
+                  value: String(option.days),
+                  label: t(option.key),
+                }))}
+              />
             )}
           </Field>
 

--- a/frontend/src/screens/users-admin.test.tsx
+++ b/frontend/src/screens/users-admin.test.tsx
@@ -10,6 +10,7 @@ import {
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { pickOption } from "../design-system/select-testing";
 import { LocaleProvider } from "../i18n";
 import { UsersAdminCard } from "./users-admin";
 
@@ -61,17 +62,24 @@ const ROSTER = {
 };
 
 // Both helpers narrow by instance rather than asserting: a cast would let the
-// suite read `.value` off whatever the query happened to return, so a control
-// that stopped being a select would surface as a confusing undefined instead of
-// a named failure.
+// suite read `.disabled` off whatever the query happened to return, so a control
+// that stopped being the Select trigger would surface as a confusing undefined
+// instead of a named failure.
 function roleSelect(row: HTMLElement, name: string) {
-  const control = within(row).getByLabelText(
-    new RegExp(`set role for ${name}`, "i"),
-  );
-  if (!(control instanceof HTMLSelectElement)) {
-    throw new Error(`the role control for ${name} is not a select`);
+  const control = within(row).getByRole("combobox", {
+    name: new RegExp(`set role for ${name}`, "i"),
+  });
+  if (!(control instanceof HTMLButtonElement)) {
+    throw new Error(`the role control for ${name} is not a select trigger`);
   }
   return control;
+}
+
+// What the closed control reads. The trigger's only text is its face — the
+// chevron is aria-hidden and carries none — so this is the role an operator
+// sees on the row without opening anything.
+function roleShown(row: HTMLElement, name: string): string {
+  return roleSelect(row, name).textContent ?? "";
 }
 
 function rowFor(name: string) {
@@ -223,25 +231,25 @@ describe("UsersAdminCard", () => {
     render(<UsersAdminCard />);
     await waitFor(() => expect(screen.getByText("Ada Active")).toBeTruthy());
 
-    expect(roleSelect(rowFor("Ada Active"), "ada active").value).toBe("admin");
-    expect(roleSelect(rowFor("Otto Off"), "otto off").value).toBe("read_only");
+    expect(roleShown(rowFor("Ada Active"), "ada active")).toBe("Admin");
+    expect(roleShown(rowFor("Otto Off"), "otto off")).toBe("Read-only");
   });
 
   it("offers the placeholder to a member holding no role", async () => {
+    const user = userEvent.setup();
     vi.stubGlobal("fetch", backend([]));
     render(<UsersAdminCard />);
     await waitFor(() => expect(screen.getByText("Nora None")).toBeTruthy());
 
-    const select = roleSelect(rowFor("Nora None"), "nora none");
-    expect(select.value).toBe("");
-    expect(within(select).getByText("Set role…")).toBeTruthy();
-    // A member who already has a role gets no such option: it would be
-    // selectable and do nothing.
-    expect(
-      within(roleSelect(rowFor("Ada Active"), "ada active")).queryByText(
-        "Set role…",
-      ),
-    ).toBeNull();
+    expect(roleShown(rowFor("Nora None"), "nora none")).toBe("Set role…");
+    // It is a face and never an entry: picking "Set role…" back would set no
+    // role, so the list this row opens is the five assignable roles and nothing
+    // else. The options exist only while the popup is open, hence the click.
+    await user.click(roleSelect(rowFor("Nora None"), "nora none"));
+    const offered = within(screen.getByRole("listbox"))
+      .getAllByRole("option")
+      .map((option) => option.textContent);
+    expect(offered).toEqual(["Admin", "Manager", "Rep", "Read-only", "Ops"]);
   });
 
   // Any choice replaces the whole set, so a member holding several roles must
@@ -272,27 +280,24 @@ describe("UsersAdminCard", () => {
     render(<UsersAdminCard />);
     await waitFor(() => expect(screen.getByText("Nora None")).toBeTruthy());
 
-    const select = roleSelect(rowFor("Nora None"), "nora none");
-    expect(select.value).toBe("");
     // Both held roles are named, under their display labels, and the copy says
     // what picking one does.
-    const shown = within(select).getByText(/holds/i).textContent ?? "";
+    const shown = roleShown(rowFor("Nora None"), "nora none");
+    expect(shown).toMatch(/holds/i);
     expect(shown).toContain("Manager");
     expect(shown).toContain("Ops");
     expect(shown).toMatch(/replaces them all/i);
   });
 
   it("sets a member's role through the role seam", async () => {
+    const user = userEvent.setup();
     const calls: { method: string; url: string; body?: unknown }[] = [];
     vi.stubGlobal("fetch", backend(calls));
     render(<UsersAdminCard />);
     await waitFor(() => expect(screen.getByText("Ada Active")).toBeTruthy());
 
     const active = screen.getByText("Ada Active").closest("li") as HTMLElement;
-    await userEvent.selectOptions(
-      within(active).getByLabelText(/set role for ada active/i),
-      "manager",
-    );
+    await pickOption(user, roleSelect(active, "ada active"), "Manager");
 
     await waitFor(() =>
       expect(
@@ -326,6 +331,7 @@ describe("UsersAdminCard", () => {
   });
 
   it("surfaces a failed member action as an inline alert on the row", async () => {
+    const user = userEvent.setup();
     vi.stubGlobal(
       "fetch",
       vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -351,20 +357,21 @@ describe("UsersAdminCard", () => {
     await waitFor(() => expect(screen.getByText("Ada Active")).toBeTruthy());
 
     const active = rowFor("Ada Active");
-    await userEvent.selectOptions(roleSelect(active, "ada active"), "rep");
+    await pickOption(user, roleSelect(active, "ada active"), "Rep");
 
     await waitFor(() => expect(within(active).getByRole("alert")).toBeTruthy());
     expect(screen.getByText(/leave no admin/i)).toBeTruthy();
     // The refused change left the role untouched, so the select must read the
     // role the member still holds — anything else would claim a change the
     // server rejected.
-    expect(roleSelect(active, "ada active").value).toBe("admin");
+    expect(roleShown(active, "ada active")).toBe("Admin");
   });
 
   // The whole reason the select returns to the held role after a refusal: a
   // select left showing the refused target would make re-picking it a no-op,
   // and the operator's retry would silently never reach the server.
   it("lets the same role be re-picked after a refusal", async () => {
+    const user = userEvent.setup();
     const patches: string[] = [];
     vi.stubGlobal(
       "fetch",
@@ -389,11 +396,11 @@ describe("UsersAdminCard", () => {
     await waitFor(() => expect(screen.getByText("Ada Active")).toBeTruthy());
 
     const active = rowFor("Ada Active");
-    await userEvent.selectOptions(roleSelect(active, "ada active"), "rep");
+    await pickOption(user, roleSelect(active, "ada active"), "Rep");
     await waitFor(() => expect(patches).toHaveLength(1));
 
     // The SAME target again — the retry the operator would make.
-    await userEvent.selectOptions(roleSelect(active, "ada active"), "rep");
+    await pickOption(user, roleSelect(active, "ada active"), "Rep");
     await waitFor(() => expect(patches).toHaveLength(2));
   });
 
@@ -401,6 +408,7 @@ describe("UsersAdminCard", () => {
   // the member's replaced role from the stale cache — the operator would watch
   // their change appear and then undo itself.
   it("stays pending until the refreshed roster lands", async () => {
+    const user = userEvent.setup();
     let rosterReads = 0;
     // Built up front rather than captured lazily: the refetch has to be held
     // open from the moment it starts, and a deferred that only exists once the
@@ -443,12 +451,12 @@ describe("UsersAdminCard", () => {
     await waitFor(() => expect(screen.getByText("Ada Active")).toBeTruthy());
 
     const active = rowFor("Ada Active");
-    await userEvent.selectOptions(roleSelect(active, "ada active"), "manager");
+    await pickOption(user, roleSelect(active, "ada active"), "Manager");
     await waitFor(() => expect(rosterReads).toBe(2));
 
-    // Mid-flight: the row reads the role being applied and stays locked. "admin"
+    // Mid-flight: the row reads the role being applied and stays locked. "Admin"
     // here would be the stale cache showing through.
-    expect(roleSelect(active, "ada active").value).toBe("manager");
+    expect(roleShown(active, "ada active")).toBe("Manager");
     expect(roleSelect(active, "ada active").disabled).toBe(true);
 
     releaseRoster();
@@ -457,9 +465,7 @@ describe("UsersAdminCard", () => {
         false,
       ),
     );
-    expect(roleSelect(rowFor("Ada Active"), "ada active").value).toBe(
-      "manager",
-    );
+    expect(roleShown(rowFor("Ada Active"), "ada active")).toBe("Manager");
   });
 
   it("surfaces a failed invite as an inline error", async () => {

--- a/frontend/src/screens/users-admin.tsx
+++ b/frontend/src/screens/users-admin.tsx
@@ -8,10 +8,10 @@ import {
   Button,
   EmptyState,
   SectionHeader,
-  Select,
   TextInput,
 } from "../design-system/atoms";
 import { ConfirmModal } from "../design-system/confirmmodal";
+import { Select, type SelectOption } from "../design-system/select";
 import { useT } from "../i18n";
 import { problemMessageOf, QueryGate, throwProblem, useMe } from "./common";
 import "./users-admin.css";
@@ -28,6 +28,11 @@ const ROLES: readonly Role[] = ["admin", "manager", "rep", "read_only", "ops"];
 // than as a missing-translation marker — the admin still learns what is held.
 const roleLabel = (t: ReturnType<typeof useT>) => (key: string) =>
   isOption(key, ROLES) ? t(`users.role.${key}`) : key;
+
+// The five system roles as pickable options — shared by the invite form and
+// every roster row so the two lists cannot drift apart.
+const roleOptions = (t: ReturnType<typeof useT>): SelectOption[] =>
+  ROLES.map((role) => ({ value: role, label: t(`users.role.${role}`) }));
 
 // Admin member management (org settings). Every user-management write is
 // admin-only server-side, so the whole card is admin-only here — an ops seat in
@@ -172,17 +177,11 @@ function InviteForm({ canIssueLink }: Readonly<{ canIssueLink: boolean }>) {
       <Select
         aria-label={t("users.roleLabel")}
         value={role}
-        onChange={(e) => {
-          const value = e.target.value;
+        onChange={(value) => {
           if (isOption(value, ROLES)) setRole(value);
         }}
-      >
-        {ROLES.map((r) => (
-          <option key={r} value={r}>
-            {t(`users.role.${r}`)}
-          </option>
-        ))}
-      </Select>
+        options={roleOptions(t)}
+      />
       <Button variant="primary" small type="submit" disabled={!canInvite}>
         <UserPlus aria-hidden /> {t("users.invite")}
       </Button>
@@ -310,26 +309,21 @@ function MemberRow({
       <Badge tone={member.status === "active" ? "success" : "warn"}>
         {t(`users.status.${member.status}`)}
       </Badge>
+      {/* The unset state is the select's PLACEHOLDER, not an option: picking it
+          back would set no role, so it belongs on the closed face and nowhere in
+          the list. It is only ever seen when there is no single role to show. */}
       <Select
         aria-label={t("users.setRoleFor", { name: member.display_name })}
         value={inFlightRole ?? currentRole}
+        placeholder={placeholder}
         disabled={pending}
-        onChange={(e) => {
-          const value = e.target.value;
+        onChange={(value) => {
           if (isOption(value, ROLES)) {
             setRole.mutate(value);
           }
         }}
-      >
-        {/* Offered only when there is no single role to show — otherwise it
-            would be a selectable option that does nothing. */}
-        {currentRole === "" && <option value="">{placeholder}</option>}
-        {ROLES.map((r) => (
-          <option key={r} value={r}>
-            {t(`users.role.${r}`)}
-          </option>
-        ))}
-      </Select>
+        options={roleOptions(t)}
+      />
       {/* Only an ACTIVE member can redeem a link — redemption updates an active
           account and refuses otherwise — so offering one on a deactivated row
           would hand the admin a link that is dead on arrival. */}

--- a/frontend/src/screens/webhooks.test.tsx
+++ b/frontend/src/screens/webhooks.test.tsx
@@ -11,6 +11,7 @@ import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { subscribableEventTypeValues } from "../api/public-events";
 import { type GrantSpec, meFixture } from "../app/mefixture";
+import { pickOption } from "../design-system/select-testing";
 import { LocaleProvider } from "../i18n";
 import { WebhooksCard } from "./webhooks";
 
@@ -426,8 +427,7 @@ describe("WebhooksCard — pause/resume + re-target (EditAction)", () => {
     await user.click(await screen.findByTestId("edit-record"));
     // Flip state to paused via the select control; event_types stays as the
     // subscription's current, prefilled selection.
-    const stateSelect = screen.getByLabelText(/^State/);
-    await user.selectOptions(stateSelect, "paused");
+    await pickOption(user, screen.getByLabelText(/^State/), "Paused");
     await user.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => expect(calls.length).toBe(1));


### PR DESCRIPTION
Draft — the next round of UI/layout work. Five reported items, each fixed as an invariant rather than a patch.

## 1. Every dropdown is the design system's, not the browser's

`frontend/src/design-system/select.tsx` — a button trigger plus a listbox **portalled to the body** and anchored to the trigger, because most of these controls sit in a toolbar inside `.scroll`, where an absolutely positioned popup is clipped and scrolls away from its own trigger. It flips above the trigger when the room below runs out, and carries the whole keyboard contract: arrows, Home/End, typeahead, Enter/Space to commit, Escape without committing, focus back to the trigger, `aria-activedescendant` so focus never leaves it.

The API takes **data**, not `<option>` children, and `onChange` reports the value — a listbox has no `event.target.value`, and a synthetic event would be a lie about where the value came from. All 30 call sites across 19 screens moved, and the suites drive it through one helper (`select-testing.ts`).

Two rules keep it true:

- **`frontend/scripts/check-native-controls.sh`** (in `make frontend-check`) refuses `<select>`, `<option>` and `<optgroup>` anywhere under `frontend/src` outside that one file. `<option>` matters as much as the element that names the gate: nothing here ever wrote a raw `<select>` — the screens fed option children to the *atom* — so a gate watching only `<select` would have called an entirely un-migrated tree clean.
- **`frontend/src/design-system/README.md`** is the catalog to read before hand-rolling any control: every primitive, its file, its story, and the gates. `frontend/README.md`, `AGENTS.md` and `CLAUDE.md` each point at it in two lines. That was the ask — how the next engineer or agent finds the right element in general, not only for this one.

Two defects only the running app could show, both from the control changing element:

- `.list-toolbar > select.input` is element-qualified, so it silently stopped matching and every list filter grew to the full width of the page, one per line. It names the class now.
- A list opened on no explicit sort drew an empty box. A native select rendered the same nothing, but a drawn one reads as a control that failed to load — so it carries a placeholder, which then had to leave `--textTertiary` for `--textMeta`: placeholder text sits on an **active** control, so WCAG 1.4.3's inactive-control exemption does not cover it. The axe sweep caught it.

An unset choice also carries a label (`field.unset`) — a blank-labelled entry is an unreadable strip in a drawn list and silence to a screen reader.

## 2. The Core holds its position

The 11-second vertical drift is deleted with its keyframes rather than overridden. `.core-tilt` stays — it is the stage the glass is centred in. Breath, sheen, halo and feed are untouched; the beat is still what carries state.

## 3. The Core stops when the window is not focused

Both halves stop off **one** signal: `window-focus.ts` owns a single `focus`/`blur` pair for the document, parks the WebGL loop through a subscription and pauses the CSS rhythms through `data-window-blurred` on the root element. Paused, not `animation: none`, so returning does not snap the sphere to its unanimated size.

This keeps the loop's standing rule — a condition may park it only if the **end** of that condition arrives as an event. `document.hasFocus()` seeds the state once per attach and is never polled: a poll answers only for the instant it is asked, and a missed resume is a permanently frozen sphere, which looks exactly like a broken shader.

## 4. The sign-in screen

Two halves of a page divided by one hairline, no card. Wordmark in the page's top-left on the split layout, above the form when it stacks — first in the DOM either way. One 400px measure, one left edge for heading, buttons, fields, locale row and fine print; providers stacked full width; spacing scaled off the `--space` scale.

Phones (≤560px) drop the identity region **entirely, sphere included** — the form is the only thing that screen is for. The disclosure sentence stays: the Core is `aria-hidden`, so dropping the region without the line would leave a phone reader told nothing about the AI.

Measured at 320 / 390 / 640×400 / 720 / 1440: no horizontal overflow, the 48px submit inside the viewport at every width, every limit rendered wherever the region shows, axe clean.

## 5. The login intro plays once per page load

The staggered fades and the typed statement replayed on every React remount of the surface, which reads as the page reloading under the reader. `useDocumentIntro` marks the document once the choreography has run its course; a later mount renders the surface already arrived, a real load still gets the introduction. The mark lands at the **end** of the sequence, which is what survives React's development double-mount.

**The trigger was never reproduced locally** — simulated `visibilitychange`, real tab switches and window swaps all left the surface mounted with its text intact, and the one focus-coupled query on that screen (`useMe`, `refetchOnWindowFocus: "always"`) does not re-branch the tree. So the fix is aimed at the invariant: replay is impossible from any remount cause. A tab Chrome has discarded and reloaded is a genuine page load and correctly plays again.

## Gates

- `make check` — green
- `make frontend-check` — green (159 files, 1888 tests; all five design gates PASS)
- `make frontend-e2e` — green (63 passed, incl. axe AA on every core screen and the login screen, and the 390/320/200% sweeps)
- Verified by hand in the running app: the toolbar dropdowns, the popup over the board, `.core-tilt` with no animation and `core-float` absent from every stylesheet, and `data-window-blurred` appearing and clearing on blur/focus with the glass animations pausing with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced all native dropdowns with a design‑system `Select`, refreshed the sign‑in screen, and made the Core hold still and pause when the window blurs. Follow‑ups added a native‑controls gate, a shared test helper, and tightened dropdown behavior, intro timing, focus handling, and gate coverage.

- **New Features**
  - Design‑system `Select`: button + portalled listbox with full keyboard support; anchored to the trigger and flips when space runs out. API takes `options` and `onChange(value)`; ~30 call sites migrated. Added `select-testing.ts` for label‑based picks in tests.
  - Gate + docs: `frontend/scripts/check-native-controls.sh` blocks `<select>`, `<option>`, and `<optgroup>` outside `design-system`; wired into `make frontend-check` and documented in `src/design-system/README.md` (linked from `frontend/README.md`, `AGENTS.md`, `CLAUDE.md`).
  - Sign‑in: split full‑bleed halves; centered layout with left‑aligned fields; stacked provider buttons; divider now “or”; phones show only the task; intro plays once per load via `useDocumentIntro`.
  - Core stability: removed vertical drift; single window‑focus signal (`window-focus.ts`) pauses CSS via `data-window-blurred` and parks WebGL.

- **Bug Fixes**
  - `Select` polish: placeholder when value matches no option; disabled selects don’t submit via the hidden mirror input; popup flip decided by a minimum‑room threshold only; internal popup scrolling no longer re‑anchors; toolbar width rule targets the dropdown by class.
  - Lists/filters: removed ineffective “unset” entries; kept real clearables (stage, organization); generic unset labeled via `field.unset`; named the AI‑calls task filter; replaced hand‑rolled inputs with `TextInput`.
  - Intro/focus/gate: `useDocumentIntro` uses an absolute, per‑document deadline; window‑focus subscribers receive current state and ignore no‑op restatements; native‑controls gate no longer strips URLs with `//`, reads multi‑line template literals correctly, and now scans `.js`/`.jsx` too.
  - Core stillness tests enforce pause without removing animations and cover the `translate()` shorthand; formatted a drift assertion to satisfy Biome.

<sup>Written for commit addcda7375b71d4261e671226e03369287f02414. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/554?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added accessible, keyboard-friendly dropdowns with placeholders, disabled options, typeahead, and responsive positioning.
  - Updated forms, filters, and selectors throughout the frontend.
  - Redesigned the sign-in experience with improved responsive behavior and stacked SSO buttons.
  - Added clearer authentication divider text and “Not set” translations.

- **Bug Fixes**
  - Intro animations now play once per page load.
  - Core visuals remain centered and pause consistently when the window loses focus.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->