### PR TITLE
refactor(test): the account-360 suites become their own integration package

### DIFF
--- a/backend/dedupespine_test.go
+++ b/backend/dedupespine_test.go
@@ -60,7 +60,7 @@ var sanctionedMintSites = gatekit.Waive(map[string]string{
 	"internal/modules/people/lead.go": "the direct lead write shape",
 
 	// Test seeding, not a product path.
-	"internal/compose/integration/harness.go": "integration-harness row seeding",
+	"internal/compose/integration/seed.go": "integration-harness row seeding",
 })
 
 func TestEveryIdentityInsertGoesThroughTheChokepoint(t *testing.T) {

--- a/backend/internal/compose/integration/harness.go
+++ b/backend/internal/compose/integration/harness.go
@@ -153,22 +153,47 @@ func OwnerConn(t *testing.T) *pgx.Conn {
 	return conn
 }
 
+// Object names the permission fixtures and the link helpers both spell. Named
+// once so a fixture's grant vocabulary cannot drift from the entity type the
+// seeding helpers write.
+const (
+	objPerson   = "person"
+	objActivity = "activity"
+)
+
 // permissions fixtures mirror the RBAC matrix rows the suites
 // exercise; the seeded JSONB↔these shapes is identity's policy tests.
 var (
 	RepPerms = principal.Permissions{
 		RoleKeys: []string{"rep"},
 		Objects: map[string]principal.ObjectGrant{
-			"person":   {Create: true, Read: true, Update: true},
+			objPerson:  {Create: true, Read: true, Update: true},
 			"deal":     {Create: true, Read: true, Update: true},
 			"pipeline": {Read: true},
+		},
+		RowScope: principal.RowScopeTeam,
+	}
+	// AccountRepPerms is RepPerms widened to what the account sections read —
+	// the organization itself, its activities, and the tag/list chips. Row scope
+	// stays team on purpose: the interesting failures here are row-scope ones,
+	// and an unbounded admin short-circuits every scope clause.
+	AccountRepPerms = principal.Permissions{
+		RoleKeys: []string{"rep"},
+		Objects: map[string]principal.ObjectGrant{
+			"organization": {Read: true},
+			objPerson:      {Create: true, Read: true, Update: true},
+			"deal":         {Create: true, Read: true, Update: true},
+			objActivity:    {Create: true, Read: true, Update: true},
+			"pipeline":     {Read: true},
+			"tag":          {Read: true},
+			"list":         {Read: true},
 		},
 		RowScope: principal.RowScopeTeam,
 	}
 	ReadOnlyPerms = principal.Permissions{
 		RoleKeys: []string{"read_only"},
 		Objects: map[string]principal.ObjectGrant{
-			"person": {Read: true}, "deal": {Read: true}, "pipeline": {Read: true},
+			objPerson: {Read: true}, "deal": {Read: true}, "pipeline": {Read: true},
 		},
 		RowScope: principal.RowScopeAll,
 	}
@@ -181,11 +206,11 @@ var (
 	AdminPerms       = principal.Permissions{
 		RoleKeys: []string{"admin"},
 		Objects: map[string]principal.ObjectGrant{
-			"person":       {Create: true, Read: true, Update: true, Delete: true},
+			objPerson:      {Create: true, Read: true, Update: true, Delete: true},
 			"organization": {Create: true, Read: true, Update: true, Delete: true},
 			"deal":         {Create: true, Read: true, Update: true, Delete: true},
 			"lead":         {Create: true, Read: true, Update: true, Delete: true},
-			"activity":     {Create: true, Read: true, Update: true, Delete: true},
+			objActivity:    {Create: true, Read: true, Update: true, Delete: true},
 			"pipeline":     {Create: true, Read: true, Update: true, Delete: true},
 			// computed_field is read-only for every system role, admin
 			// included (RD-AC-7: no runtime formula-authoring surface
@@ -349,75 +374,20 @@ func (e *Env) WsCount(t *testing.T, sql string, args ...any) int {
 	return n
 }
 
-// DealFixture provisions the workspace with the seeded default pipeline
-// and returns the pipeline plus the open + won stage ids.
-func DealFixture(t *testing.T, e *Env) (pipeline ids.PipelineID, open, won ids.StageID) {
-	t.Helper()
-	admin := e.Admin()
-	if err := e.Deals.SeedDefaults(admin); err != nil {
-		t.Fatal(err)
-	}
-	p, err := e.Deals.DefaultPipeline(admin)
-	if err != nil {
-		t.Fatal(err)
-	}
-	for _, st := range *p.Stages {
-		switch st.Semantic {
-		case "open":
-			if open.IsZero() {
-				open = ids.From[ids.StageKind](ids.UUID(st.Id))
-			}
-		case "won":
-			won = ids.From[ids.StageKind](ids.UUID(st.Id))
-		}
-	}
-	return ids.From[ids.PipelineKind](ids.UUID(p.Id)), open, won
-}
-
-// SeedStakeholder creates a person, ties them to the deal as a
-// deal_stakeholder, and gives them one email in each named direction at
-// the fixed instant 2026-06-01T12:00Z — three days before the
-// 2026-06-04T12:00Z clock the consuming suites pin.
-func SeedStakeholder(t *testing.T, e *Env, owner *pgx.Conn, deal ids.UUID, directions ...string) ids.UUID {
-	t.Helper()
-	person := SeedRow(t, owner, `INSERT INTO person (id, workspace_id, full_name, source, captured_by)
-		VALUES ($1, $2, 'Stakeholder', 'manual', 'human:x')`, e.WS)
-	if _, err := owner.Exec(context.Background(),
-		`INSERT INTO relationship (workspace_id, kind, person_id, deal_id, source, captured_by)
-		 VALUES ($1, 'deal_stakeholder', $2, $3, 'manual', 'human:x')`, e.WS, person, deal); err != nil {
-		t.Fatal(err)
-	}
-	for _, direction := range directions {
-		touch := SeedRow(t, owner, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, direction, source, captured_by)
-			VALUES ($1, $2, 'email', 'touch', '2026-06-01T12:00:00Z', '`+direction+`', 'manual', 'human:x')`, e.WS)
-		LinkActivity(t, owner, e.WS, touch, "person", person)
-	}
-	return person
-}
-
-// LinkActivity attaches an activity to a person or deal through the
-// polymorphic link table.
-func LinkActivity(t *testing.T, owner *pgx.Conn, ws, activity ids.UUID, entityType string, entity ids.UUID) {
-	t.Helper()
-	column := "deal_id"
-	if entityType == "person" {
-		column = "person_id"
-	}
-	if _, err := owner.Exec(context.Background(),
-		`INSERT INTO activity_link (workspace_id, activity_id, entity_type, `+column+`) VALUES ($1, $2, $3, $4)`,
-		ws, activity, entityType, entity); err != nil {
-		t.Fatal(err)
-	}
-}
-
-// SeedRow inserts one row through the owner connection and returns its id.
-func SeedRow(t *testing.T, owner *pgx.Conn, sql string, ws ids.UUID) ids.UUID {
-	t.Helper()
-	id := ids.NewV7()
-	if _, err := owner.Exec(context.Background(), sql, id, ws); err != nil {
-		t.Fatalf("seeding: %v", err)
-	}
-	return id
+// AgentWithOrgRead binds an agent principal holding the same object grants
+// the rep does, unbounded, and CARRYING the granting human's user id — the
+// shape identity/passport.go actually mints, where OnBehalfOf becomes
+// UserID for row scope. An agent with no user id would be refused for the
+// wrong reason and would prove nothing about the human-only rule.
+func AgentWithOrgRead(e *Env) context.Context {
+	perms := AccountRepPerms
+	perms.RowScope = principal.RowScopeAll
+	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
+	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
+	return principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalAgent, ID: "agent:test", SeatType: principal.SeatFull,
+		UserID: e.Rep1, OnBehalfOf: e.Rep1, Permissions: perms,
+	})
 }
 
 // SchedulerPerms is RepPerms plus the activity grant the booking write
@@ -425,8 +395,8 @@ func SeedRow(t *testing.T, owner *pgx.Conn, sql string, ws ids.UUID) ids.UUID {
 var SchedulerPerms = principal.Permissions{
 	RoleKeys: []string{"rep"},
 	Objects: map[string]principal.ObjectGrant{
-		"person":   {Create: true, Read: true, Update: true},
-		"activity": {Create: true, Read: true, Update: true},
+		objPerson:   {Create: true, Read: true, Update: true},
+		objActivity: {Create: true, Read: true, Update: true},
 	},
 	RowScope: principal.RowScopeTeam,
 }

--- a/backend/internal/compose/integration/harness.go
+++ b/backend/internal/compose/integration/harness.go
@@ -9,6 +9,14 @@
 // non-test file so the white-box suites that must stay inside their
 // package (compose root, briefs) can import it; it deliberately imports
 // modules and platform only, never compose, so no import cycle can form.
+//
+// Suites also live in sibling packages that import this one (org360 is the
+// first). That is how the lane gets more than one scheduling slot: one package
+// is one slot, and this package is large enough to be the lane's long pole on
+// its own. Split a group out when it is a closed seam — it rides Env rather
+// than the booted-app fixture in e2e_integration_test.go, and it neither needs
+// nor owes an unexported helper across the boundary. A helper that two such
+// groups need is promoted here; one that only a group needs stays with it.
 package integration
 
 import (
@@ -153,9 +161,10 @@ func OwnerConn(t *testing.T) *pgx.Conn {
 	return conn
 }
 
-// Object names the permission fixtures and the link helpers both spell. Named
-// once so a fixture's grant vocabulary cannot drift from the entity type the
-// seeding helpers write.
+// The two RBAC object keys the permission fixtures below repeat often enough to
+// name. They are identity's policy vocabulary only — deliberately NOT reused for
+// the activity_link.entity_type values seed.go writes, which spell the same two
+// words today from a different namespace and are free to diverge.
 const (
 	objPerson   = "person"
 	objActivity = "activity"
@@ -173,10 +182,13 @@ var (
 		},
 		RowScope: principal.RowScopeTeam,
 	}
-	// AccountRepPerms is RepPerms widened to what the account sections read —
-	// the organization itself, its activities, and the tag/list chips. Row scope
-	// stays team on purpose: the interesting failures here are row-scope ones,
-	// and an unbounded admin short-circuits every scope clause.
+	// AccountRepPerms is the rep the account sections are read by: the
+	// organization itself, its people and deals, its activities, and the tag/list
+	// chips. It is a fixture in its own right rather than RepPerms plus a delta —
+	// RepPerms stays narrow because several suites read it as a rep who CANNOT
+	// see an organization, and widening it would make those pass while proving
+	// nothing. Row scope stays team for the same reason: the interesting failures
+	// here are row-scope ones, and an unbounded admin short-circuits every clause.
 	AccountRepPerms = principal.Permissions{
 		RoleKeys: []string{"rep"},
 		Objects: map[string]principal.ObjectGrant{
@@ -380,7 +392,15 @@ func (e *Env) WsCount(t *testing.T, sql string, args ...any) int {
 // UserID for row scope. An agent with no user id would be refused for the
 // wrong reason and would prove nothing about the human-only rule.
 func AgentWithOrgRead(e *Env) context.Context {
+	// Deep copy, not `perms := AccountRepPerms`: a plain struct copy shares the
+	// Objects map, and this fixture is now read from other packages. A later
+	// grant added here would widen it for every suite at once, which is exactly
+	// how a negative test starts passing without testing anything.
 	perms := AccountRepPerms
+	perms.Objects = make(map[string]principal.ObjectGrant, len(AccountRepPerms.Objects))
+	for object, grant := range AccountRepPerms.Objects {
+		perms.Objects[object] = grant
+	}
 	perms.RowScope = principal.RowScopeAll
 	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
 	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
@@ -390,8 +410,9 @@ func AgentWithOrgRead(e *Env) context.Context {
 	})
 }
 
-// SchedulerPerms is RepPerms plus the activity grant the booking write
-// needs; row scope stays team.
+// SchedulerPerms is the booking write's caller: the person grant it reads and
+// the activity grant it writes, and nothing else — not a superset of RepPerms,
+// which also holds deal and pipeline. Row scope stays team.
 var SchedulerPerms = principal.Permissions{
 	RoleKeys: []string{"rep"},
 	Objects: map[string]principal.ObjectGrant{

--- a/backend/internal/compose/integration/network_http_integration_test.go
+++ b/backend/internal/compose/integration/network_http_integration_test.go
@@ -193,7 +193,7 @@ func TestDealCoverageDoesNotCallARehiredStakeholderDeparted(t *testing.T) {
 	// live one decides: flagging this would announce a resignation every time
 	// somebody changed job title.
 	person := e.contactAt(t, org, "Promoted Person", "2026-01-31")
-	e.employ(t, person, org, "2026-02-01", "")
+	e.Employ(t, person, org, "2026-02-01", "")
 	e.stakeholder(t, deal, person, "champion")
 
 	risks := e.coverageRisks(t, deal)
@@ -319,11 +319,11 @@ func (e *env) contactAt(t *testing.T, org, name, endedAt string) string {
 		t.Fatalf("creating %s: %d", name, status)
 	}
 	id, _ := person["id"].(string)
-	e.employ(t, id, org, hiredOn, endedAt)
+	e.Employ(t, id, org, hiredOn, endedAt)
 	return id
 }
 
-func (e *env) employ(t *testing.T, person, org, startedAt, endedAt string) {
+func (e *env) Employ(t *testing.T, person, org, startedAt, endedAt string) {
 	t.Helper()
 	body := anyMap{
 		"kind": "employment", "person_id": person, "organization_id": org,

--- a/backend/internal/compose/integration/network_http_integration_test.go
+++ b/backend/internal/compose/integration/network_http_integration_test.go
@@ -193,7 +193,7 @@ func TestDealCoverageDoesNotCallARehiredStakeholderDeparted(t *testing.T) {
 	// live one decides: flagging this would announce a resignation every time
 	// somebody changed job title.
 	person := e.contactAt(t, org, "Promoted Person", "2026-01-31")
-	e.Employ(t, person, org, "2026-02-01", "")
+	e.employ(t, person, org, "2026-02-01", "")
 	e.stakeholder(t, deal, person, "champion")
 
 	risks := e.coverageRisks(t, deal)
@@ -319,11 +319,11 @@ func (e *env) contactAt(t *testing.T, org, name, endedAt string) string {
 		t.Fatalf("creating %s: %d", name, status)
 	}
 	id, _ := person["id"].(string)
-	e.Employ(t, id, org, hiredOn, endedAt)
+	e.employ(t, id, org, hiredOn, endedAt)
 	return id
 }
 
-func (e *env) Employ(t *testing.T, person, org, startedAt, endedAt string) {
+func (e *env) employ(t *testing.T, person, org, startedAt, endedAt string) {
 	t.Helper()
 	body := anyMap{
 		"kind": "employment", "person_id": person, "organization_id": org,

--- a/backend/internal/compose/integration/org360/org360_account_timeline_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_account_timeline_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package integration
+package org360
 
 // What "this activity belongs to this account" means, proved over a real
 // database and through every surface that asks the question.
@@ -25,6 +25,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/gradionhq/margince/backend/internal/compose/integration"
 	"github.com/gradionhq/margince/backend/internal/modules/activities"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
@@ -46,7 +47,7 @@ func accountMailAt(t *testing.T, owner *pgx.Conn, ws ids.UUID, subject string, a
 
 // employAt ties a person to an organization. endedOn nil is a live employment;
 // a date ends it.
-func employAt(t *testing.T, e *Env, person, org ids.UUID, endedOn *time.Time) {
+func employAt(t *testing.T, e *integration.Env, person, org ids.UUID, endedOn *time.Time) {
 	t.Helper()
 	e.WsExec(t, `INSERT INTO relationship
 		(workspace_id, kind, person_id, organization_id, started_at, ended_at, source, captured_by)
@@ -54,16 +55,8 @@ func employAt(t *testing.T, e *Env, person, org ids.UUID, endedOn *time.Time) {
 		e.WS, person, org, endedOn)
 }
 
-// linkToOrg attaches an activity directly to an account (the harness's
-// LinkActivity covers only the person and deal columns).
-func linkToOrg(t *testing.T, e *Env, activity, org ids.UUID) {
-	t.Helper()
-	e.WsExec(t, `INSERT INTO activity_link (workspace_id, activity_id, entity_type, organization_id)
-		VALUES ($1, $2, 'organization', $3)`, e.WS, activity, org)
-}
-
 // accountTimeline lists the account's timeline the way GET /activities does.
-func accountTimeline(ctx context.Context, t *testing.T, e *Env, org ids.UUID, limit int, cursor string) ([]ids.UUID, string) {
+func accountTimeline(ctx context.Context, t *testing.T, e *integration.Env, org ids.UUID, limit int, cursor string) ([]ids.UUID, string) {
 	t.Helper()
 	entityType := "organization"
 	in := activities.ListActivitiesInput{EntityType: &entityType, EntityID: &org, Limit: &limit}
@@ -95,14 +88,14 @@ func containsActivity(got []ids.UUID, want ids.UUID) bool {
 // timeline list and the company view's own section — which must agree,
 // because the section is that list.
 func TestAccountTimelineReachesMailThroughItsContactsAndDeals(t *testing.T) {
-	e := Setup(t)
-	owner := OwnerConn(t)
+	e := integration.Setup(t)
+	owner := integration.OwnerConn(t)
 	svc := org360Service(e)
-	pipeline, stage, _ := DealFixture(t, e)
+	pipeline, stage, _ := integration.DealFixture(t, e)
 
 	org := e.SeedOrg(t, "Acme", &e.Rep1)
 	other := e.SeedOrg(t, "Globex", &e.Rep1)
-	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, org360RepPerms)
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms)
 
 	employee := e.SeedPerson(t, "Dana Buyer", &e.Rep1)
 	employAt(t, e, employee, org, nil)
@@ -116,15 +109,15 @@ func TestAccountTimelineReachesMailThroughItsContactsAndDeals(t *testing.T) {
 	e.WsExec(t, `UPDATE deal SET organization_id = $2 WHERE id = $1`, deal, org)
 
 	direct := accountMailAt(t, owner, e.WS, "direct", org360Clock.Add(-1*time.Hour))
-	linkToOrg(t, e, direct, org)
+	integration.LinkToOrg(t, e, direct, org)
 	viaContact := accountMailAt(t, owner, e.WS, "via a current employee", org360Clock.Add(-2*time.Hour))
-	LinkActivity(t, owner, e.WS, viaContact, "person", employee)
+	integration.LinkActivity(t, owner, e.WS, viaContact, "person", employee)
 	viaDeal := accountMailAt(t, owner, e.WS, "via the deal", org360Clock.Add(-3*time.Hour))
-	LinkActivity(t, owner, e.WS, viaDeal, "deal", deal)
+	integration.LinkActivity(t, owner, e.WS, viaDeal, "deal", deal)
 	viaLeaver := accountMailAt(t, owner, e.WS, "via a former employee", org360Clock.Add(-4*time.Hour))
-	LinkActivity(t, owner, e.WS, viaLeaver, "person", leaver)
+	integration.LinkActivity(t, owner, e.WS, viaLeaver, "person", leaver)
 	viaStranger := accountMailAt(t, owner, e.WS, "via another account's contact", org360Clock.Add(-5*time.Hour))
-	LinkActivity(t, owner, e.WS, viaStranger, "person", stranger)
+	integration.LinkActivity(t, owner, e.WS, viaStranger, "person", stranger)
 
 	listed, _ := accountTimeline(rep, t, e, org, 25, "")
 	for _, want := range []struct {
@@ -176,11 +169,11 @@ func TestAccountTimelineReachesMailThroughItsContactsAndDeals(t *testing.T) {
 // read one is still the activity link-walk row scope, so reaching further must
 // not hand a bounded rep an item they could not open.
 func TestTheAccountWalkDoesNotWidenTheCallersRowScope(t *testing.T) {
-	e := Setup(t)
-	owner := OwnerConn(t)
+	e := integration.Setup(t)
+	owner := integration.OwnerConn(t)
 
 	org := e.SeedOrg(t, "Acme", &e.Rep1)
-	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, org360RepPerms)
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms)
 
 	// Both contacts work at the account; only one is inside Rep1's team scope.
 	mine := e.SeedPerson(t, "My Contact", &e.Rep1)
@@ -189,9 +182,9 @@ func TestTheAccountWalkDoesNotWidenTheCallersRowScope(t *testing.T) {
 	employAt(t, e, theirs, org, nil)
 
 	visible := accountMailAt(t, owner, e.WS, "terms", org360Clock.Add(-1*time.Hour))
-	LinkActivity(t, owner, e.WS, visible, "person", mine)
+	integration.LinkActivity(t, owner, e.WS, visible, "person", mine)
 	hidden := accountMailAt(t, owner, e.WS, "confidential terms", org360Clock.Add(-2*time.Hour))
-	LinkActivity(t, owner, e.WS, hidden, "person", theirs)
+	integration.LinkActivity(t, owner, e.WS, hidden, "person", theirs)
 
 	listed, _ := accountTimeline(rep, t, e, org, 25, "")
 	if containsActivity(listed, hidden) {
@@ -210,11 +203,11 @@ func TestTheAccountWalkDoesNotWidenTheCallersRowScope(t *testing.T) {
 // an activity reachable through TWO arms at once — the case a join would
 // duplicate and a duplicate is what shifts a keyset page boundary.
 func TestAccountTimelinePagesWithoutDuplicatesOrOmissions(t *testing.T) {
-	e := Setup(t)
-	owner := OwnerConn(t)
+	e := integration.Setup(t)
+	owner := integration.OwnerConn(t)
 
 	org := e.SeedOrg(t, "Acme", &e.Rep1)
-	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, org360RepPerms)
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms)
 	contact := e.SeedPerson(t, "Dana Buyer", &e.Rep1)
 	employAt(t, e, contact, org, nil)
 
@@ -224,10 +217,10 @@ func TestAccountTimelinePagesWithoutDuplicatesOrOmissions(t *testing.T) {
 	for i := range 5 {
 		mail := accountMailAt(t, owner, e.WS, "thread", org360Clock.Add(-time.Duration(i+1)*time.Hour))
 		if i%2 == 0 {
-			linkToOrg(t, e, mail, org)
+			integration.LinkToOrg(t, e, mail, org)
 		}
 		if i%2 == 1 || i == 2 {
-			LinkActivity(t, owner, e.WS, mail, "person", contact)
+			integration.LinkActivity(t, owner, e.WS, mail, "person", contact)
 		}
 		want = append(want, mail)
 	}
@@ -269,25 +262,25 @@ func TestAccountTimelinePagesWithoutDuplicatesOrOmissions(t *testing.T) {
 // only through a contact is on the page, so it is new here too — a rep told
 // "0 new" above three unread emails would stop trusting the marker.
 func TestSinceLastVisitCountsMailRolledUpThroughAContact(t *testing.T) {
-	e := Setup(t)
-	owner := OwnerConn(t)
+	e := integration.Setup(t)
+	owner := integration.OwnerConn(t)
 	svc := org360Service(e)
 
 	org := e.SeedOrg(t, "Acme", &e.Rep1)
 	orgID := ids.From[ids.OrganizationKind](org)
-	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, org360RepPerms)
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms)
 	contact := e.SeedPerson(t, "Dana Buyer", &e.Rep1)
 	employAt(t, e, contact, org, nil)
 
 	// Mail that arrived BEFORE the visit is not new; the ack pins the baseline
 	// at the read's own instant.
 	before := accountMailAt(t, owner, e.WS, "old thread", org360Clock.Add(-time.Hour))
-	LinkActivity(t, owner, e.WS, before, "person", contact)
+	integration.LinkActivity(t, owner, e.WS, before, "person", contact)
 	if _, err := svc.Acknowledge(rep, orgID); err != nil {
 		t.Fatalf("acknowledging the visit: %v", err)
 	}
 	after := accountMailAt(t, owner, e.WS, "new thread", org360Clock.Add(time.Hour))
-	LinkActivity(t, owner, e.WS, after, "person", contact)
+	integration.LinkActivity(t, owner, e.WS, after, "person", contact)
 
 	view, err := svc.Assemble(rep, orgID)
 	if err != nil {
@@ -306,43 +299,28 @@ func TestSinceLastVisitCountsMailRolledUpThroughAContact(t *testing.T) {
 	}
 }
 
-// accountMailDirectedAt seeds one message with an explicit direction, which is
-// the whole point of the pair below: the same last-touch date means opposite
-// things depending on who wrote it.
-func accountMailDirectedAt(t *testing.T, owner *pgx.Conn, ws ids.UUID, subject, direction string, at time.Time) ids.UUID {
-	t.Helper()
-	id := ids.NewV7()
-	if _, err := owner.Exec(context.Background(), `INSERT INTO activity
-		(id, workspace_id, kind, direction, subject, occurred_at, created_at, source, captured_by)
-		VALUES ($1, $2, 'email', $3, $4, $5, $5, 'manual', 'human:x')`,
-		id, ws, direction, subject, at); err != nil {
-		t.Fatalf("seeding %q: %v", subject, err)
-	}
-	return id
-}
-
 // TestLastTouchSeparatesWhoWroteLastAndWalksTheSameThreeLinks pins the pair
 // that replaced the header's 0-100 score (AC-company-2). One "last touch"
 // would collapse the only distinction that matters — an account we mailed a
 // fortnight ago with no reply reads identically to one that just wrote to us.
 func TestLastTouchSeparatesWhoWroteLastAndWalksTheSameThreeLinks(t *testing.T) {
-	e := Setup(t)
-	owner := OwnerConn(t)
+	e := integration.Setup(t)
+	owner := integration.OwnerConn(t)
 	svc := org360Service(e)
 
 	org := e.SeedOrg(t, "Scale Commerce", &e.Rep1)
-	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, org360RepPerms)
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms)
 	employee := e.SeedPerson(t, "Christian Contact", &e.Rep1)
 	employAt(t, e, employee, org, nil)
 
 	// The newest inbound reaches the account only through its contact, which
 	// is how capture files real mail — a direct-link-only reading would miss it.
-	oldInbound := accountMailDirectedAt(t, owner, e.WS, "old reply", "inbound", org360Clock.Add(-90*time.Hour))
-	linkToOrg(t, e, oldInbound, org)
-	newInbound := accountMailDirectedAt(t, owner, e.WS, "their reply", "inbound", org360Clock.Add(-30*time.Hour))
-	LinkActivity(t, owner, e.WS, newInbound, "person", employee)
-	outbound := accountMailDirectedAt(t, owner, e.WS, "our nudge", "outbound", org360Clock.Add(-2*time.Hour))
-	linkToOrg(t, e, outbound, org)
+	oldInbound := integration.AccountMailDirectedAt(t, owner, e.WS, "old reply", "inbound", org360Clock.Add(-90*time.Hour))
+	integration.LinkToOrg(t, e, oldInbound, org)
+	newInbound := integration.AccountMailDirectedAt(t, owner, e.WS, "their reply", "inbound", org360Clock.Add(-30*time.Hour))
+	integration.LinkActivity(t, owner, e.WS, newInbound, "person", employee)
+	outbound := integration.AccountMailDirectedAt(t, owner, e.WS, "our nudge", "outbound", org360Clock.Add(-2*time.Hour))
+	integration.LinkToOrg(t, e, outbound, org)
 
 	view, err := svc.Assemble(rep, ids.From[ids.OrganizationKind](org))
 	if err != nil {
@@ -360,14 +338,14 @@ func TestLastTouchSeparatesWhoWroteLastAndWalksTheSameThreeLinks(t *testing.T) {
 // heard from them" distinct from "we never looked". Null is the account's
 // answer; an absent section would be the caller's.
 func TestLastTouchIsNullRatherThanZeroWhenNothingWasCaptured(t *testing.T) {
-	e := Setup(t)
-	owner := OwnerConn(t)
+	e := integration.Setup(t)
+	owner := integration.OwnerConn(t)
 	svc := org360Service(e)
 
 	org := e.SeedOrg(t, "Silent Co", &e.Rep1)
-	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, org360RepPerms)
-	outbound := accountMailDirectedAt(t, owner, e.WS, "our first mail", "outbound", org360Clock.Add(-time.Hour))
-	linkToOrg(t, e, outbound, org)
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms)
+	outbound := integration.AccountMailDirectedAt(t, owner, e.WS, "our first mail", "outbound", org360Clock.Add(-time.Hour))
+	integration.LinkToOrg(t, e, outbound, org)
 
 	view, err := svc.Assemble(rep, ids.From[ids.OrganizationKind](org))
 	if err != nil {

--- a/backend/internal/compose/integration/org360/org360_account_timeline_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_account_timeline_integration_test.go
@@ -45,6 +45,14 @@ func accountMailAt(t *testing.T, owner *pgx.Conn, ws ids.UUID, subject string, a
 	return id
 }
 
+// employ ties a person to an organization as a current employee, in the role
+// the graph draws them in.
+func employ(t *testing.T, e *integration.Env, person, org ids.UUID, title string) {
+	t.Helper()
+	e.WsExec(t, `INSERT INTO relationship (workspace_id, kind, person_id, organization_id, role, source, captured_by)
+		VALUES ($1, 'employment', $2, $3, $4, 'manual', 'human:x')`, e.WS, person, org, title)
+}
+
 // employAt ties a person to an organization. endedOn nil is a live employment;
 // a date ends it.
 func employAt(t *testing.T, e *integration.Env, person, org ids.UUID, endedOn *time.Time) {

--- a/backend/internal/compose/integration/org360/org360_graph_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_graph_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package integration
+package org360
 
 // The connections card's SHAPE: what one hop from an account means, which way
 // each edge runs, and the transport that serves it. What the card may not show
@@ -26,6 +26,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/gradionhq/margince/backend/internal/compose/integration"
 	"github.com/gradionhq/margince/backend/internal/compose/org360"
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -49,11 +50,11 @@ func withSignalRead(base principal.Permissions) principal.Permissions {
 // graphRepPerms is the rep the 360 suite uses, plus the signal grant.
 // Team-scoped on purpose: an unbounded admin short-circuits every scope
 // clause, and the row-scope prune is the whole point of this suite.
-var graphRepPerms = withSignalRead(org360RepPerms)
+var graphRepPerms = withSignalRead(integration.AccountRepPerms)
 
 // graphAdminPerms is the unbounded admin plus the signal grant, for the
 // shape tests where row scope is not what is under examination.
-var graphAdminPerms = withSignalRead(AdminPerms)
+var graphAdminPerms = withSignalRead(integration.AdminPerms)
 
 // graphNodeKinds counts the nodes of each kind, which is how a test states
 // "the contacts are gone" without depending on their order.
@@ -112,13 +113,6 @@ func seedOrgSubjectSignal(t *testing.T, owner *pgx.Conn, ws, org ids.UUID) ids.U
 	return id
 }
 
-// employ ties a person to an organization as a current employee.
-func employ(t *testing.T, e *Env, person, org ids.UUID, title string) {
-	t.Helper()
-	e.WsExec(t, `INSERT INTO relationship (workspace_id, kind, person_id, organization_id, role, source, captured_by)
-		VALUES ($1, 'employment', $2, $3, $4, 'manual', 'human:x')`, e.WS, person, org, title)
-}
-
 // oneHopFixture is an account with one of every edge the card draws, plus two
 // records that sit exactly two hops out.
 type oneHopFixture struct {
@@ -131,9 +125,9 @@ type oneHopFixture struct {
 // seedOneHop builds that account. The two-hop records are seeded here too: a
 // suite that only ever seeds what should appear cannot tell a one-hop walk
 // from a walk with no limit at all.
-func seedOneHop(t *testing.T, e *Env) oneHopFixture {
+func seedOneHop(t *testing.T, e *integration.Env) oneHopFixture {
 	t.Helper()
-	pipeline, stage, _ := DealFixture(t, e)
+	pipeline, stage, _ := integration.DealFixture(t, e)
 	f := oneHopFixture{
 		parent:   e.SeedOrg(t, "Holding", &e.Rep1),
 		org:      e.SeedOrg(t, "Acme", &e.Rep1),
@@ -144,7 +138,7 @@ func seedOneHop(t *testing.T, e *Env) oneHopFixture {
 		VALUES ($1, 'partner_of', $2, $3, 'manual', 'human:x')`, e.WS, f.org, f.reseller)
 
 	f.employee = e.SeedPerson(t, "Dana Buyer", &e.Rep1)
-	employ(t, e, f.employee, f.org, "cto")
+	integration.Employ(t, e, f.employee, f.org, "cto")
 	f.deal = e.SeedDeal(t, "Renewal", pipeline, stage, &e.Rep1)
 	e.WsExec(t, `UPDATE deal SET organization_id = $2 WHERE id = $1`, f.deal, f.org)
 	f.stakeholder = e.SeedPerson(t, "Outside Counsel", &e.Rep1)
@@ -156,7 +150,7 @@ func seedOneHop(t *testing.T, e *Env) oneHopFixture {
 	f.grandparent = e.SeedOrg(t, "Grand Holding", &e.Rep1)
 	e.WsExec(t, `UPDATE organization SET parent_org_id = $2 WHERE id = $1`, f.parent, f.grandparent)
 	f.otherEmployer = e.SeedOrg(t, "Side Gig", &e.Rep1)
-	employ(t, e, f.employee, f.otherEmployer, "advisor")
+	integration.Employ(t, e, f.employee, f.otherEmployer, "advisor")
 	return f
 }
 
@@ -164,7 +158,7 @@ func seedOneHop(t *testing.T, e *Env) oneHopFixture {
 // the account is the root node, its employees, open deals, deal stakeholders,
 // parent and partner all arrive, and nothing two hops out does.
 func TestOrganizationGraphCentresOnTheAccountAndWalksOneHop(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	f := seedOneHop(t, e)
 
 	graph, err := org360Service(e).Graph(e.As(e.Rep1, nil, graphAdminPerms),
@@ -255,7 +249,7 @@ func assertNoDanglingEdge(t *testing.T, graph crmcontracts.OrganizationGraph) {
 // where the card allows ten, silently, because dropped_count comes off the whole
 // set either way.
 func TestOrganizationGraphRelatedCapCountsCompaniesNotEdges(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	svc := org360Service(e)
 	org := e.SeedOrg(t, "Acme", &e.Rep1)
 
@@ -315,7 +309,7 @@ func TestOrganizationGraphRelatedCapCountsCompaniesNotEdges(t *testing.T) {
 // against the real column, not against the placement helper: a child drawn as
 // its parent's parent would invert the whole card.
 func TestOrganizationGraphHierarchyEdgePointsParentToChild(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	svc := org360Service(e)
 
 	parent := e.SeedOrg(t, "Holding", &e.Rep1)
@@ -350,7 +344,7 @@ func TestOrganizationGraphHierarchyEdgePointsParentToChild(t *testing.T) {
 // let the service's gates decide, hand back the assembled body — and a native
 // workspace must reach it rather than meeting the overlay guard.
 func TestOrganizationGraphTransportServesANativeWorkspace(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	handlers := org360.NewHandlers(org360Service(e),
 		func(context.Context) (bool, error) { return false, nil })
 	org := ids.From[ids.OrganizationKind](e.SeedOrg(t, "Acme", &e.Rep1))
@@ -393,7 +387,7 @@ func TestOrganizationGraphTransportServesANativeWorkspace(t *testing.T) {
 // incumbent's records, not our relationship edges, so there is no honest graph
 // to draw from it — one refusal, not a card that quietly omits everything.
 func TestOrganizationGraphRefusesAnOverlayWorkspace(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	handlers := org360.NewHandlers(org360Service(e),
 		func(context.Context) (bool, error) { return true, nil })
 	org := ids.From[ids.OrganizationKind](e.SeedOrg(t, "Acme", &e.Rep1))

--- a/backend/internal/compose/integration/org360/org360_graph_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_graph_integration_test.go
@@ -12,7 +12,7 @@ package org360
 // assertions both use.
 //
 // The placement rules the graph applies to already-read rows (order, caps,
-// dropped_count) need no database and live in org360/graph_test.go.
+// dropped_count) need no database and live in compose/org360/graph_test.go.
 
 import (
 	"context"
@@ -27,7 +27,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/compose/integration"
-	"github.com/gradionhq/margince/backend/internal/compose/org360"
+	org360svc "github.com/gradionhq/margince/backend/internal/compose/org360"
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -138,7 +138,7 @@ func seedOneHop(t *testing.T, e *integration.Env) oneHopFixture {
 		VALUES ($1, 'partner_of', $2, $3, 'manual', 'human:x')`, e.WS, f.org, f.reseller)
 
 	f.employee = e.SeedPerson(t, "Dana Buyer", &e.Rep1)
-	integration.Employ(t, e, f.employee, f.org, "cto")
+	employ(t, e, f.employee, f.org, "cto")
 	f.deal = e.SeedDeal(t, "Renewal", pipeline, stage, &e.Rep1)
 	e.WsExec(t, `UPDATE deal SET organization_id = $2 WHERE id = $1`, f.deal, f.org)
 	f.stakeholder = e.SeedPerson(t, "Outside Counsel", &e.Rep1)
@@ -150,7 +150,7 @@ func seedOneHop(t *testing.T, e *integration.Env) oneHopFixture {
 	f.grandparent = e.SeedOrg(t, "Grand Holding", &e.Rep1)
 	e.WsExec(t, `UPDATE organization SET parent_org_id = $2 WHERE id = $1`, f.parent, f.grandparent)
 	f.otherEmployer = e.SeedOrg(t, "Side Gig", &e.Rep1)
-	integration.Employ(t, e, f.employee, f.otherEmployer, "advisor")
+	employ(t, e, f.employee, f.otherEmployer, "advisor")
 	return f
 }
 
@@ -345,7 +345,7 @@ func TestOrganizationGraphHierarchyEdgePointsParentToChild(t *testing.T) {
 // workspace must reach it rather than meeting the overlay guard.
 func TestOrganizationGraphTransportServesANativeWorkspace(t *testing.T) {
 	e := integration.Setup(t)
-	handlers := org360.NewHandlers(org360Service(e),
+	handlers := org360svc.NewHandlers(org360Service(e),
 		func(context.Context) (bool, error) { return false, nil })
 	org := ids.From[ids.OrganizationKind](e.SeedOrg(t, "Acme", &e.Rep1))
 	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, graphRepPerms)
@@ -388,7 +388,7 @@ func TestOrganizationGraphTransportServesANativeWorkspace(t *testing.T) {
 // to draw from it — one refusal, not a card that quietly omits everything.
 func TestOrganizationGraphRefusesAnOverlayWorkspace(t *testing.T) {
 	e := integration.Setup(t)
-	handlers := org360.NewHandlers(org360Service(e),
+	handlers := org360svc.NewHandlers(org360Service(e),
 		func(context.Context) (bool, error) { return true, nil })
 	org := ids.From[ids.OrganizationKind](e.SeedOrg(t, "Acme", &e.Rep1))
 

--- a/backend/internal/compose/integration/org360/org360_graphauthz_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_graphauthz_integration_test.go
@@ -47,7 +47,7 @@ func TestRouteInEdgesRefusesWithoutThePersonGrant(t *testing.T) {
 	e := integration.Setup(t)
 	org := ids.From[ids.OrganizationKind](e.SeedOrg(t, "Acme", &e.Rep1))
 	contact := e.SeedPerson(t, "Dana Buyer", &e.Rep1)
-	integration.Employ(t, e, contact, org.UUID, "cto")
+	employ(t, e, contact, org.UUID, "cto")
 
 	noPeople := e.As(e.Rep1, []ids.UUID{e.Team1}, principal.Permissions{
 		RoleKeys: []string{"rep"},
@@ -91,7 +91,7 @@ func TestOrganizationGraphOmitsAGroupTheCallerMayNotRead(t *testing.T) {
 
 	org := e.SeedOrg(t, "Acme", &e.Rep1)
 	employee := e.SeedPerson(t, "Dana Buyer", &e.Rep1)
-	integration.Employ(t, e, employee, org, "cto")
+	employ(t, e, employee, org, "cto")
 	deal := e.SeedDeal(t, "Renewal", pipeline, stage, &e.Rep1)
 	e.WsExec(t, `UPDATE deal SET organization_id = $2 WHERE id = $1`, deal, org)
 	e.WsExec(t, `INSERT INTO relationship (workspace_id, kind, person_id, deal_id, role, source, captured_by)
@@ -165,8 +165,8 @@ func TestOrganizationGraphPrunesNodesToTheCallersRowScope(t *testing.T) {
 	org := e.SeedOrg(t, "Acme", &e.Rep1)
 	mine := e.SeedPerson(t, "My Contact", &e.Rep1)
 	theirs := e.SeedPerson(t, "Their Contact", &e.Rep3)
-	integration.Employ(t, e, mine, org, "cto")
-	integration.Employ(t, e, theirs, org, "cfo")
+	employ(t, e, mine, org, "cto")
+	employ(t, e, theirs, org, "cfo")
 
 	myDeal := e.SeedDeal(t, "My Renewal", pipeline, stage, &e.Rep1)
 	theirDeal := e.SeedDeal(t, "Their Renewal", pipeline, stage, &e.Rep3)
@@ -250,8 +250,8 @@ func TestOrganizationGraphIntroPathNamesTheWarmRoomsContact(t *testing.T) {
 	org := e.SeedOrg(t, "Acme", &e.Rep1)
 	cold := e.SeedPerson(t, "Cold Contact", &e.Rep1)
 	warm := e.SeedPerson(t, "Warm Contact", &e.Rep1)
-	integration.Employ(t, e, cold, org, "cfo")
-	integration.Employ(t, e, warm, org, "cto")
+	employ(t, e, cold, org, "cfo")
+	employ(t, e, warm, org, "cto")
 	// Only the warm contact has qualifying interactions inside the §4 window,
 	// so the ranking has one honest answer rather than a tie.
 	for _, direction := range []string{"inbound", "outbound"} {
@@ -318,7 +318,7 @@ func TestOrganizationGraphCitesAnOrganizationSubjectSignal(t *testing.T) {
 
 	org := e.SeedOrg(t, "Acme", &e.Rep1)
 	contact := e.SeedPerson(t, "Warm Contact", &e.Rep1)
-	integration.Employ(t, e, contact, org, "cto")
+	employ(t, e, contact, org, "cto")
 	activity := integration.SeedRow(t, owner, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, direction, source, captured_by)
 		VALUES ($1, $2, 'email', 'terms', '2026-05-30T09:00:00Z', 'inbound', 'manual', 'human:x')`, e.WS)
 	integration.LinkActivity(t, owner, e.WS, activity, "person", contact)
@@ -348,7 +348,7 @@ func TestOrganizationGraphReportsNoIntroPathWithoutAnOpenSignal(t *testing.T) {
 
 	org := e.SeedOrg(t, "Acme", &e.Rep1)
 	contact := e.SeedPerson(t, "Warm Contact", &e.Rep1)
-	integration.Employ(t, e, contact, org, "cto")
+	employ(t, e, contact, org, "cto")
 	activity := integration.SeedRow(t, owner, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, direction, source, captured_by)
 		VALUES ($1, $2, 'email', 'terms', '2026-05-30T09:00:00Z', 'inbound', 'manual', 'human:x')`, e.WS)
 	integration.LinkActivity(t, owner, e.WS, activity, "person", contact)

--- a/backend/internal/compose/integration/org360/org360_graphauthz_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_graphauthz_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package integration
+package org360
 
 // What the connections card is NOT allowed to show. The graph's shape is
 // pinned in org360_graph_integration_test.go; this file is only about the
@@ -25,6 +25,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/gradionhq/margince/backend/internal/compose/integration"
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/modules/signals"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
@@ -43,10 +44,10 @@ import (
 // connections card are both callers today; when this read was gated only by
 // its callers, reordering the graph's group list turned it into an ungated one.
 func TestRouteInEdgesRefusesWithoutThePersonGrant(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	org := ids.From[ids.OrganizationKind](e.SeedOrg(t, "Acme", &e.Rep1))
 	contact := e.SeedPerson(t, "Dana Buyer", &e.Rep1)
-	employ(t, e, contact, org.UUID, "cto")
+	integration.Employ(t, e, contact, org.UUID, "cto")
 
 	noPeople := e.As(e.Rep1, []ids.UUID{e.Team1}, principal.Permissions{
 		RoleKeys: []string{"rep"},
@@ -84,13 +85,13 @@ func TestRouteInEdgesRefusesWithoutThePersonGrant(t *testing.T) {
 // whole card rests on: a company with contacts the caller cannot read must not
 // look like a company with no contacts.
 func TestOrganizationGraphOmitsAGroupTheCallerMayNotRead(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	svc := org360Service(e)
-	pipeline, stage, _ := DealFixture(t, e)
+	pipeline, stage, _ := integration.DealFixture(t, e)
 
 	org := e.SeedOrg(t, "Acme", &e.Rep1)
 	employee := e.SeedPerson(t, "Dana Buyer", &e.Rep1)
-	employ(t, e, employee, org, "cto")
+	integration.Employ(t, e, employee, org, "cto")
 	deal := e.SeedDeal(t, "Renewal", pipeline, stage, &e.Rep1)
 	e.WsExec(t, `UPDATE deal SET organization_id = $2 WHERE id = $1`, deal, org)
 	e.WsExec(t, `INSERT INTO relationship (workspace_id, kind, person_id, deal_id, role, source, captured_by)
@@ -157,15 +158,15 @@ func TestOrganizationGraphOmitsAGroupTheCallerMayNotRead(t *testing.T) {
 // KINDS a caller may see, the row scope says which ROWS. Every node kind is
 // checked, because one unscoped arm is a side channel for the whole class.
 func TestOrganizationGraphPrunesNodesToTheCallersRowScope(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	svc := org360Service(e)
-	pipeline, stage, _ := DealFixture(t, e)
+	pipeline, stage, _ := integration.DealFixture(t, e)
 
 	org := e.SeedOrg(t, "Acme", &e.Rep1)
 	mine := e.SeedPerson(t, "My Contact", &e.Rep1)
 	theirs := e.SeedPerson(t, "Their Contact", &e.Rep3)
-	employ(t, e, mine, org, "cto")
-	employ(t, e, theirs, org, "cfo")
+	integration.Employ(t, e, mine, org, "cto")
+	integration.Employ(t, e, theirs, org, "cfo")
 
 	myDeal := e.SeedDeal(t, "My Renewal", pipeline, stage, &e.Rep1)
 	theirDeal := e.SeedDeal(t, "Their Renewal", pipeline, stage, &e.Rep3)
@@ -224,7 +225,7 @@ func TestOrganizationGraphPrunesNodesToTheCallersRowScope(t *testing.T) {
 // is the whole graph's gate, and out-of-scope must be indistinguishable from
 // nonexistent.
 func TestOrganizationGraphHidesAnAccountOutsideTheCallersRowScope(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	svc := org360Service(e)
 	theirs := ids.From[ids.OrganizationKind](e.SeedOrg(t, "Other Team Account", &e.Rep3))
 
@@ -242,21 +243,21 @@ func TestOrganizationGraphHidesAnAccountOutsideTheCallersRowScope(t *testing.T) 
 // claim, taken against real rows: the card marks the same contact
 // GET /signals/{id}/intro-path would route through, and cites the signal.
 func TestOrganizationGraphIntroPathNamesTheWarmRoomsContact(t *testing.T) {
-	e := Setup(t)
-	owner := OwnerConn(t)
+	e := integration.Setup(t)
+	owner := integration.OwnerConn(t)
 	svc := org360Service(e)
 
 	org := e.SeedOrg(t, "Acme", &e.Rep1)
 	cold := e.SeedPerson(t, "Cold Contact", &e.Rep1)
 	warm := e.SeedPerson(t, "Warm Contact", &e.Rep1)
-	employ(t, e, cold, org, "cfo")
-	employ(t, e, warm, org, "cto")
+	integration.Employ(t, e, cold, org, "cfo")
+	integration.Employ(t, e, warm, org, "cto")
 	// Only the warm contact has qualifying interactions inside the §4 window,
 	// so the ranking has one honest answer rather than a tie.
 	for _, direction := range []string{"inbound", "outbound"} {
-		activity := SeedRow(t, owner, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, direction, source, captured_by)
+		activity := integration.SeedRow(t, owner, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, direction, source, captured_by)
 			VALUES ($1, $2, 'email', 'terms', '2026-05-30T09:00:00Z', '`+direction+`', 'manual', 'human:x')`, e.WS)
-		LinkActivity(t, owner, e.WS, activity, "person", warm)
+		integration.LinkActivity(t, owner, e.WS, activity, "person", warm)
 	}
 	signal := seedOpenSignal(t, owner, e.WS, org)
 
@@ -288,7 +289,7 @@ func TestOrganizationGraphIntroPathNamesTheWarmRoomsContact(t *testing.T) {
 
 	// A caller without the signal grant gets the same contacts and no path,
 	// named as withheld — advice absent is not advice that does not exist.
-	blind := e.As(e.Rep1, []ids.UUID{e.Team1}, org360RepPerms)
+	blind := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms)
 	graph, err = svc.Graph(blind, ids.From[ids.OrganizationKind](org))
 	if err != nil {
 		t.Fatalf("graph without the signal grant: %v", err)
@@ -311,16 +312,16 @@ func TestOrganizationGraphIntroPathNamesTheWarmRoomsContact(t *testing.T) {
 // is what keeps this card and GET /signals agreeing about what belongs to an
 // account.
 func TestOrganizationGraphCitesAnOrganizationSubjectSignal(t *testing.T) {
-	e := Setup(t)
-	owner := OwnerConn(t)
+	e := integration.Setup(t)
+	owner := integration.OwnerConn(t)
 	svc := org360Service(e)
 
 	org := e.SeedOrg(t, "Acme", &e.Rep1)
 	contact := e.SeedPerson(t, "Warm Contact", &e.Rep1)
-	employ(t, e, contact, org, "cto")
-	activity := SeedRow(t, owner, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, direction, source, captured_by)
+	integration.Employ(t, e, contact, org, "cto")
+	activity := integration.SeedRow(t, owner, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, direction, source, captured_by)
 		VALUES ($1, $2, 'email', 'terms', '2026-05-30T09:00:00Z', 'inbound', 'manual', 'human:x')`, e.WS)
-	LinkActivity(t, owner, e.WS, activity, "person", contact)
+	integration.LinkActivity(t, owner, e.WS, activity, "person", contact)
 	signal := seedOrgSubjectSignal(t, owner, e.WS, org)
 
 	graph, err := svc.Graph(e.As(e.Rep1, []ids.UUID{e.Team1}, graphRepPerms),
@@ -341,16 +342,16 @@ func TestOrganizationGraphCitesAnOrganizationSubjectSignal(t *testing.T) {
 // available whenever the account has contacts, so the absence has to come from
 // the signal, not from the contacts.
 func TestOrganizationGraphReportsNoIntroPathWithoutAnOpenSignal(t *testing.T) {
-	e := Setup(t)
-	owner := OwnerConn(t)
+	e := integration.Setup(t)
+	owner := integration.OwnerConn(t)
 	svc := org360Service(e)
 
 	org := e.SeedOrg(t, "Acme", &e.Rep1)
 	contact := e.SeedPerson(t, "Warm Contact", &e.Rep1)
-	employ(t, e, contact, org, "cto")
-	activity := SeedRow(t, owner, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, direction, source, captured_by)
+	integration.Employ(t, e, contact, org, "cto")
+	activity := integration.SeedRow(t, owner, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, direction, source, captured_by)
 		VALUES ($1, $2, 'email', 'terms', '2026-05-30T09:00:00Z', 'inbound', 'manual', 'human:x')`, e.WS)
-	LinkActivity(t, owner, e.WS, activity, "person", contact)
+	integration.LinkActivity(t, owner, e.WS, activity, "person", contact)
 
 	graph, err := svc.Graph(e.As(e.Rep1, []ids.UUID{e.Team1}, graphRepPerms), ids.From[ids.OrganizationKind](org))
 	if err != nil {

--- a/backend/internal/compose/integration/org360/org360_graphourside_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_graphourside_integration_test.go
@@ -18,7 +18,7 @@ package org360
 //
 // The placement rules over already-read rows — the owner who also wrote being
 // one node, the cap's drop count — need no database and live in
-// org360/graph_test.go.
+// compose/org360/graph_test.go.
 
 import (
 	"context"
@@ -142,7 +142,7 @@ func TestOrganizationGraphDrawsTheOwnerAndWhoHasBeenInContact(t *testing.T) {
 
 	org := e.SeedOrg(t, "Acme", &e.Rep1)
 	contact := e.SeedPerson(t, "Dana Buyer", &e.Rep1)
-	integration.Employ(t, e, contact, org, "cto")
+	employ(t, e, contact, org, "cto")
 	// Rep2 shares Team1 with Rep1 and wrote to the contact; Rep1 owns the
 	// account and has written nothing.
 	seedTouch(t, e, owner, "email", &e.Rep2, contact)
@@ -194,7 +194,7 @@ func TestOrganizationGraphDrawsNoContactEdgeForANonInteraction(t *testing.T) {
 
 	org := e.SeedOrg(t, "Acme", &e.Rep1)
 	contact := e.SeedPerson(t, "Dana Buyer", &e.Rep1)
-	integration.Employ(t, e, contact, org, "cto")
+	employ(t, e, contact, org, "cto")
 	seedTouch(t, e, owner, "email", nil, contact)
 	seedTouch(t, e, owner, "email", nil, contact)
 	seedTouch(t, e, owner, "task", &e.Rep2, contact)
@@ -241,7 +241,7 @@ func TestOrganizationGraphOmitsOurSideWithoutThePersonOrActivityGrant(t *testing
 
 	org := e.SeedOrg(t, "Acme", &e.Rep1)
 	contact := e.SeedPerson(t, "Dana Buyer", &e.Rep1)
-	integration.Employ(t, e, contact, org, "cto")
+	employ(t, e, contact, org, "cto")
 	seedTouch(t, e, owner, "email", &e.Rep2, contact)
 	orgID := ids.From[ids.OrganizationKind](org)
 
@@ -305,8 +305,8 @@ func TestOrganizationGraphDrawsNoContactEdgeForAnOutOfScopeContact(t *testing.T)
 	org := e.SeedOrg(t, "Acme", &e.Rep1)
 	mine := e.SeedPerson(t, "My Contact", &e.Rep1)
 	theirs := e.SeedPerson(t, "Their Contact", &e.Rep3)
-	integration.Employ(t, e, mine, org, "cto")
-	integration.Employ(t, e, theirs, org, "cfo")
+	employ(t, e, mine, org, "cto")
+	employ(t, e, theirs, org, "cfo")
 	writerToMine := seedMember(t, owner, e.WS, "Writes To Mine")
 	writerToTheirs := seedMember(t, owner, e.WS, "Writes To Theirs")
 	seedTouch(t, e, owner, "email", &writerToMine, mine)
@@ -359,7 +359,7 @@ func TestOrganizationGraphDrawsNoColleagueWhoNoLongerWorksHere(t *testing.T) {
 			// both would-be edges; Rep1, in the same team, is the caller.
 			org := e.SeedOrg(t, "Acme", &e.Rep2)
 			contact := e.SeedPerson(t, "Dana Buyer", &e.Rep1)
-			integration.Employ(t, e, contact, org, "cto")
+			employ(t, e, contact, org, "cto")
 			seedTouch(t, e, owner, "email", &e.Rep2, contact)
 			teammate := seedMember(t, owner, e.WS, "Live Teammate")
 			seedTouch(t, e, owner, "email", &teammate, contact)
@@ -430,7 +430,7 @@ func TestOrganizationGraphCapsColleaguesAgainstTheContactsItDraws(t *testing.T) 
 	outsiders := make([]ids.UUID, 0, undrawn)
 	for i := range undrawn {
 		contact := e.SeedPerson(t, fmt.Sprintf("Undrawn %02d", i), &e.Rep1)
-		integration.Employ(t, e, contact, org, "assistant")
+		employ(t, e, contact, org, "assistant")
 		colleague := seedMember(t, owner, e.WS, fmt.Sprintf("Outsider %02d", i))
 		outsiders = append(outsiders, colleague)
 		seedTouch(t, e, owner, "email", &colleague, contact)
@@ -444,7 +444,7 @@ func TestOrganizationGraphCapsColleaguesAgainstTheContactsItDraws(t *testing.T) 
 	var drawnContacts []ids.UUID
 	for i := range graphContactCapSeed {
 		contact := e.SeedPerson(t, fmt.Sprintf("Drawn %02d", i), &e.Rep1)
-		integration.Employ(t, e, contact, org, "cto")
+		employ(t, e, contact, org, "cto")
 		drawnContacts = append(drawnContacts, contact)
 		for range 3 {
 			seedTouch(t, e, owner, "email", &insiderA, contact)
@@ -515,7 +515,7 @@ func TestOrganizationGraphUserCapCountsUsersAndReportsTheRemainder(t *testing.T)
 	// An unassigned account, so the owner edge cannot pad the user count.
 	org := e.SeedOrg(t, "Acme", nil)
 	contact := e.SeedPerson(t, "Dana Buyer", &e.Rep1)
-	integration.Employ(t, e, contact, org, "cto")
+	employ(t, e, contact, org, "cto")
 	const writers = 13
 	for i := range writers {
 		member := seedMember(t, owner, e.WS, fmt.Sprintf("Colleague %02d", i))

--- a/backend/internal/compose/integration/org360/org360_graphourside_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_graphourside_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package integration
+package org360
 
 // Our side of the connections card: who in THIS workspace is connected to the
 // account. Before it existed the card answered "who works there" and left out
@@ -28,6 +28,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/gradionhq/margince/backend/internal/compose/integration"
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/modules/search"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
@@ -56,7 +57,7 @@ func seedMember(t *testing.T, owner *pgx.Conn, ws ids.UUID, name string) ids.UUI
 // and the cg:graph-edge consumer do between them in production. Seeding an
 // activity alone would leave the projection empty and every assertion below
 // would pass vacuously.
-func seedTouch(t *testing.T, e *Env, owner *pgx.Conn, kind string, colleague *ids.UUID, person ids.UUID) {
+func seedTouch(t *testing.T, e *integration.Env, owner *pgx.Conn, kind string, colleague *ids.UUID, person ids.UUID) {
 	t.Helper()
 	ctx := context.Background()
 	ws := e.WS
@@ -71,7 +72,7 @@ func seedTouch(t *testing.T, e *Env, owner *pgx.Conn, kind string, colleague *id
 		id, ws, kind, capturedBy); err != nil {
 		t.Fatalf("seeding a %s: %v", kind, err)
 	}
-	LinkActivity(t, owner, ws, id, "person", person)
+	integration.LinkActivity(t, owner, ws, id, "person", person)
 
 	// Only a real exchange has participants. A task is intent and a note is a
 	// record of thinking; neither means the two people spoke, which is why
@@ -95,7 +96,7 @@ func seedTouch(t *testing.T, e *Env, owner *pgx.Conn, kind string, colleague *id
 
 // foldEdges runs the recompute the cg:graph-edge consumer runs, so a test sees
 // the projection the worker would have built.
-func foldEdges(t *testing.T, e *Env, activityID ids.UUID) {
+func foldEdges(t *testing.T, e *integration.Env, activityID ids.UUID) {
 	t.Helper()
 	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
 	ctx = principal.WithActor(ctx, principal.Principal{
@@ -135,13 +136,13 @@ func graphEdgeTargets(graph crmcontracts.OrganizationGraph, kind crmcontracts.Or
 // The two connections, against real rows: the account's owner, and the
 // colleague who emailed one of its people.
 func TestOrganizationGraphDrawsTheOwnerAndWhoHasBeenInContact(t *testing.T) {
-	e := Setup(t)
-	owner := OwnerConn(t)
+	e := integration.Setup(t)
+	owner := integration.OwnerConn(t)
 	svc := org360Service(e)
 
 	org := e.SeedOrg(t, "Acme", &e.Rep1)
 	contact := e.SeedPerson(t, "Dana Buyer", &e.Rep1)
-	employ(t, e, contact, org, "cto")
+	integration.Employ(t, e, contact, org, "cto")
 	// Rep2 shares Team1 with Rep1 and wrote to the contact; Rep1 owns the
 	// account and has written nothing.
 	seedTouch(t, e, owner, "email", &e.Rep2, contact)
@@ -187,13 +188,13 @@ func TestOrganizationGraphDrawsTheOwnerAndWhoHasBeenInContact(t *testing.T) {
 // the first place — assigning work is intent, and writing something down is
 // not reaching out.
 func TestOrganizationGraphDrawsNoContactEdgeForANonInteraction(t *testing.T) {
-	e := Setup(t)
-	owner := OwnerConn(t)
+	e := integration.Setup(t)
+	owner := integration.OwnerConn(t)
 	svc := org360Service(e)
 
 	org := e.SeedOrg(t, "Acme", &e.Rep1)
 	contact := e.SeedPerson(t, "Dana Buyer", &e.Rep1)
-	employ(t, e, contact, org, "cto")
+	integration.Employ(t, e, contact, org, "cto")
 	seedTouch(t, e, owner, "email", nil, contact)
 	seedTouch(t, e, owner, "email", nil, contact)
 	seedTouch(t, e, owner, "task", &e.Rep2, contact)
@@ -234,13 +235,13 @@ func TestOrganizationGraphDrawsNoContactEdgeForANonInteraction(t *testing.T) {
 // grant gets the group named as withheld rather than an account that looks like
 // nobody here has ever spoken to it.
 func TestOrganizationGraphOmitsOurSideWithoutThePersonOrActivityGrant(t *testing.T) {
-	e := Setup(t)
-	owner := OwnerConn(t)
+	e := integration.Setup(t)
+	owner := integration.OwnerConn(t)
 	svc := org360Service(e)
 
 	org := e.SeedOrg(t, "Acme", &e.Rep1)
 	contact := e.SeedPerson(t, "Dana Buyer", &e.Rep1)
-	employ(t, e, contact, org, "cto")
+	integration.Employ(t, e, contact, org, "cto")
 	seedTouch(t, e, owner, "email", &e.Rep2, contact)
 	orgID := ids.From[ids.OrganizationKind](org)
 
@@ -297,15 +298,15 @@ func TestOrganizationGraphOmitsOurSideWithoutThePersonOrActivityGrant(t *testing
 // point at. Anything else would leak the fact of contact with a record whose
 // existence the card is hiding.
 func TestOrganizationGraphDrawsNoContactEdgeForAnOutOfScopeContact(t *testing.T) {
-	e := Setup(t)
-	owner := OwnerConn(t)
+	e := integration.Setup(t)
+	owner := integration.OwnerConn(t)
 	svc := org360Service(e)
 
 	org := e.SeedOrg(t, "Acme", &e.Rep1)
 	mine := e.SeedPerson(t, "My Contact", &e.Rep1)
 	theirs := e.SeedPerson(t, "Their Contact", &e.Rep3)
-	employ(t, e, mine, org, "cto")
-	employ(t, e, theirs, org, "cfo")
+	integration.Employ(t, e, mine, org, "cto")
+	integration.Employ(t, e, theirs, org, "cfo")
 	writerToMine := seedMember(t, owner, e.WS, "Writes To Mine")
 	writerToTheirs := seedMember(t, owner, e.WS, "Writes To Theirs")
 	seedTouch(t, e, owner, "email", &writerToMine, mine)
@@ -350,15 +351,15 @@ func setMemberStatus(t *testing.T, owner *pgx.Conn, user ids.UUID, status string
 func TestOrganizationGraphDrawsNoColleagueWhoNoLongerWorksHere(t *testing.T) {
 	for _, status := range []string{"deactivated", "suspended"} {
 		t.Run(status, func(t *testing.T) {
-			e := Setup(t)
-			owner := OwnerConn(t)
+			e := integration.Setup(t)
+			owner := integration.OwnerConn(t)
 			svc := org360Service(e)
 
 			// Rep2 owns the account AND wrote to its contact, so one person is
 			// both would-be edges; Rep1, in the same team, is the caller.
 			org := e.SeedOrg(t, "Acme", &e.Rep2)
 			contact := e.SeedPerson(t, "Dana Buyer", &e.Rep1)
-			employ(t, e, contact, org, "cto")
+			integration.Employ(t, e, contact, org, "cto")
 			seedTouch(t, e, owner, "email", &e.Rep2, contact)
 			teammate := seedMember(t, owner, e.WS, "Live Teammate")
 			seedTouch(t, e, owner, "email", &teammate, contact)
@@ -415,8 +416,8 @@ const graphContactCapSeed = 15
 // showing nobody on our side — while `our_side` and its dropped_count described
 // people the graph does not contain.
 func TestOrganizationGraphCapsColleaguesAgainstTheContactsItDraws(t *testing.T) {
-	e := Setup(t)
-	owner := OwnerConn(t)
+	e := integration.Setup(t)
+	owner := integration.OwnerConn(t)
 	svc := org360Service(e)
 
 	// An unassigned account, so no owner edge pads the user nodes.
@@ -429,7 +430,7 @@ func TestOrganizationGraphCapsColleaguesAgainstTheContactsItDraws(t *testing.T) 
 	outsiders := make([]ids.UUID, 0, undrawn)
 	for i := range undrawn {
 		contact := e.SeedPerson(t, fmt.Sprintf("Undrawn %02d", i), &e.Rep1)
-		employ(t, e, contact, org, "assistant")
+		integration.Employ(t, e, contact, org, "assistant")
 		colleague := seedMember(t, owner, e.WS, fmt.Sprintf("Outsider %02d", i))
 		outsiders = append(outsiders, colleague)
 		seedTouch(t, e, owner, "email", &colleague, contact)
@@ -443,7 +444,7 @@ func TestOrganizationGraphCapsColleaguesAgainstTheContactsItDraws(t *testing.T) 
 	var drawnContacts []ids.UUID
 	for i := range graphContactCapSeed {
 		contact := e.SeedPerson(t, fmt.Sprintf("Drawn %02d", i), &e.Rep1)
-		employ(t, e, contact, org, "cto")
+		integration.Employ(t, e, contact, org, "cto")
 		drawnContacts = append(drawnContacts, contact)
 		for range 3 {
 			seedTouch(t, e, owner, "email", &insiderA, contact)
@@ -507,14 +508,14 @@ func TestOrganizationGraphCapsColleaguesAgainstTheContactsItDraws(t *testing.T) 
 // the rows — a second count could see a newer snapshot and drive it NEGATIVE,
 // which the contract's own `minimum: 0` forbids.
 func TestOrganizationGraphUserCapCountsUsersAndReportsTheRemainder(t *testing.T) {
-	e := Setup(t)
-	owner := OwnerConn(t)
+	e := integration.Setup(t)
+	owner := integration.OwnerConn(t)
 	svc := org360Service(e)
 
 	// An unassigned account, so the owner edge cannot pad the user count.
 	org := e.SeedOrg(t, "Acme", nil)
 	contact := e.SeedPerson(t, "Dana Buyer", &e.Rep1)
-	employ(t, e, contact, org, "cto")
+	integration.Employ(t, e, contact, org, "cto")
 	const writers = 13
 	for i := range writers {
 		member := seedMember(t, owner, e.WS, fmt.Sprintf("Colleague %02d", i))

--- a/backend/internal/compose/integration/org360/org360_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_integration_test.go
@@ -29,7 +29,7 @@ import (
 	"time"
 
 	"github.com/gradionhq/margince/backend/internal/compose/integration"
-	"github.com/gradionhq/margince/backend/internal/compose/org360"
+	org360svc "github.com/gradionhq/margince/backend/internal/compose/org360"
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/modules/approvals"
 	"github.com/gradionhq/margince/backend/internal/modules/people"
@@ -46,16 +46,16 @@ var org360Clock = time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
 
 // org360Service builds the composite read over the harness pool with the
 // pinned clock.
-func org360Service(e *integration.Env) *org360.Service {
-	return org360.NewService(e.Pool, people.NewStore(e.Pool), approvals.NewService(e.Pool),
+func org360Service(e *integration.Env) *org360svc.Service {
+	return org360svc.NewService(e.Pool, people.NewStore(e.Pool), approvals.NewService(e.Pool),
 		func() time.Time { return org360Clock })
 }
 
 // org360SignalPerms is the same rep plus the signal read grant (the helper
 // the graph suite already keeps, org360_graph_integration_test.go). Separate
-// from integration.AccountRepPerms rather than folded into it because several tests read
-// that fixture as "a rep who cannot see signals" to prove a section is
-// withheld — granting it there made those pass without testing anything.
+// from integration.AccountRepPerms rather than folded into it because several
+// tests read that fixture as "a rep who cannot see signals" to prove a section
+// is withheld — granting it there made those pass without testing anything.
 var org360SignalPerms = withSignalRead(integration.AccountRepPerms)
 
 // org360NoDealPerms is the same rep with the deal grant taken away — the
@@ -257,7 +257,7 @@ func TestOrganization360ContactsHonorTheCallersRowScope(t *testing.T) {
 // only exists for mirror-backed ones.
 func TestOrganization360TransportServesANativeWorkspace(t *testing.T) {
 	e := integration.Setup(t)
-	handlers := org360.NewHandlers(org360Service(e),
+	handlers := org360svc.NewHandlers(org360Service(e),
 		func(context.Context) (bool, error) { return false, nil })
 	org := ids.From[ids.OrganizationKind](e.SeedOrg(t, "Acme", &e.Rep1))
 	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms)

--- a/backend/internal/compose/integration/org360/org360_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package integration
+package org360
 
 // The company view is one read that hands back nine sections at once, so
 // it is nine chances to out-see the dedicated endpoint each section
@@ -28,6 +28,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gradionhq/margince/backend/internal/compose/integration"
 	"github.com/gradionhq/margince/backend/internal/compose/org360"
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/modules/approvals"
@@ -45,34 +46,17 @@ var org360Clock = time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
 
 // org360Service builds the composite read over the harness pool with the
 // pinned clock.
-func org360Service(e *Env) *org360.Service {
+func org360Service(e *integration.Env) *org360.Service {
 	return org360.NewService(e.Pool, people.NewStore(e.Pool), approvals.NewService(e.Pool),
 		func() time.Time { return org360Clock })
 }
 
-// org360RepPerms is a team-scoped rep holding every grant the sections
-// ask for. The interesting failures are row-scope ones, and an unbounded
-// admin short-circuits every scope clause, so the fixture must be bounded.
-var org360RepPerms = principal.Permissions{
-	RoleKeys: []string{"rep"},
-	Objects: map[string]principal.ObjectGrant{
-		"organization": {Read: true},
-		"person":       {Create: true, Read: true, Update: true},
-		"deal":         {Create: true, Read: true, Update: true},
-		"activity":     {Create: true, Read: true, Update: true},
-		"pipeline":     {Read: true},
-		"tag":          {Read: true},
-		"list":         {Read: true},
-	},
-	RowScope: principal.RowScopeTeam,
-}
-
 // org360SignalPerms is the same rep plus the signal read grant (the helper
 // the graph suite already keeps, org360_graph_integration_test.go). Separate
-// from org360RepPerms rather than folded into it because several tests read
+// from integration.AccountRepPerms rather than folded into it because several tests read
 // that fixture as "a rep who cannot see signals" to prove a section is
 // withheld — granting it there made those pass without testing anything.
-var org360SignalPerms = withSignalRead(org360RepPerms)
+var org360SignalPerms = withSignalRead(integration.AccountRepPerms)
 
 // org360NoDealPerms is the same rep with the deal grant taken away — the
 // fixture that proves omission is distinguishable from emptiness.
@@ -87,12 +71,12 @@ var org360NoDealPerms = principal.Permissions{
 }
 
 func TestOrganization360OmitsSectionsTheCallerMayNotRead(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	svc := org360Service(e)
 	org := e.SeedOrg(t, "Acme", &e.Rep1)
 	orgID := ids.From[ids.OrganizationKind](org)
 
-	full, err := svc.Assemble(e.As(e.Rep1, []ids.UUID{e.Team1}, org360RepPerms), orgID)
+	full, err := svc.Assemble(e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms), orgID)
 	if err != nil {
 		t.Fatalf("assemble as a fully-granted rep: %v", err)
 	}
@@ -125,26 +109,26 @@ func TestOrganization360OmitsSectionsTheCallerMayNotRead(t *testing.T) {
 }
 
 func TestOrganization360HidesAnAccountOutsideTheCallersRowScope(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	svc := org360Service(e)
 	// Rep3 sits in the other team, so Rep1's team scope cannot reach it.
 	theirs := ids.From[ids.OrganizationKind](e.SeedOrg(t, "Other Team Account", &e.Rep3))
 
-	_, err := svc.Assemble(e.As(e.Rep1, []ids.UUID{e.Team1}, org360RepPerms), theirs)
+	_, err := svc.Assemble(e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms), theirs)
 	if !errors.Is(err, apperrors.ErrNotFound) {
 		t.Errorf("assemble out of row scope → %v, want ErrNotFound (existence-hiding)", err)
 	}
 	// The positive control: the same call on the caller's own account works,
 	// so the gate narrows scope rather than breaking the read.
 	mine := ids.From[ids.OrganizationKind](e.SeedOrg(t, "My Account", &e.Rep1))
-	if _, err := svc.Assemble(e.As(e.Rep1, []ids.UUID{e.Team1}, org360RepPerms), mine); err != nil {
+	if _, err := svc.Assemble(e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms), mine); err != nil {
 		t.Errorf("assemble on the caller's own account: %v", err)
 	}
 }
 
 func TestOrganization360ContactsCarryStrengthRolesAndConsent(t *testing.T) {
-	e := Setup(t)
-	owner := OwnerConn(t)
+	e := integration.Setup(t)
+	owner := integration.OwnerConn(t)
 	svc := org360Service(e)
 	admin := e.Admin()
 
@@ -158,12 +142,12 @@ func TestOrganization360ContactsCarryStrengthRolesAndConsent(t *testing.T) {
 	// Two qualifying interactions inside the §4 window, one each way, so
 	// the score is non-zero and reciprocity is balanced.
 	for _, direction := range []string{"inbound", "outbound"} {
-		activity := SeedRow(t, owner, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, direction, source, captured_by)
+		activity := integration.SeedRow(t, owner, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, direction, source, captured_by)
 			VALUES ($1, $2, 'email', 'terms', '2026-05-30T09:00:00Z', '`+direction+`', 'manual', 'human:x')`, e.WS)
-		LinkActivity(t, owner, e.WS, activity, "person", contact)
+		integration.LinkActivity(t, owner, e.WS, activity, "person", contact)
 	}
 
-	purpose := SeedRow(t, owner, `INSERT INTO consent_purpose (id, workspace_id, key, label)
+	purpose := integration.SeedRow(t, owner, `INSERT INTO consent_purpose (id, workspace_id, key, label)
 		VALUES ($1, $2, 'marketing_email', 'Marketing email')`, e.WS)
 	e.WsExec(t, `INSERT INTO person_consent (workspace_id, person_id, purpose_id, state)
 		VALUES ($1, $2, $3, 'granted')`, e.WS, contact, purpose)
@@ -210,15 +194,15 @@ func TestOrganization360ContactsCarryStrengthRolesAndConsent(t *testing.T) {
 // outbound is default-deny per purpose, and a missing key would let a
 // caller read absence as permission.
 func TestOrganization360ConsentReportsEveryPurposeEvenWithoutARow(t *testing.T) {
-	e := Setup(t)
-	owner := OwnerConn(t)
+	e := integration.Setup(t)
+	owner := integration.OwnerConn(t)
 	svc := org360Service(e)
 
 	org := e.SeedOrg(t, "Acme", &e.Rep1)
 	contact := e.SeedPerson(t, "Silent Contact", &e.Rep1)
 	e.WsExec(t, `INSERT INTO relationship (workspace_id, kind, person_id, organization_id, source, captured_by)
 		VALUES ($1, 'employment', $2, $3, 'manual', 'human:x')`, e.WS, contact, org)
-	SeedRow(t, owner, `INSERT INTO consent_purpose (id, workspace_id, key, label)
+	integration.SeedRow(t, owner, `INSERT INTO consent_purpose (id, workspace_id, key, label)
 		VALUES ($1, $2, 'product_updates', 'Product updates')`, e.WS)
 
 	view, err := svc.Assemble(e.Admin(), ids.From[ids.OrganizationKind](org))
@@ -240,7 +224,7 @@ func TestOrganization360ConsentReportsEveryPurposeEvenWithoutARow(t *testing.T) 
 // A contact the caller cannot read contributes nothing: not to the list,
 // not to the count, and not to the account's warmth.
 func TestOrganization360ContactsHonorTheCallersRowScope(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	svc := org360Service(e)
 
 	org := e.SeedOrg(t, "Acme", &e.Rep1)
@@ -251,7 +235,7 @@ func TestOrganization360ContactsHonorTheCallersRowScope(t *testing.T) {
 			VALUES ($1, 'employment', $2, $3, 'manual', 'human:x')`, e.WS, person, org)
 	}
 
-	view, err := svc.Assemble(e.As(e.Rep1, []ids.UUID{e.Team1}, org360RepPerms), ids.From[ids.OrganizationKind](org))
+	view, err := svc.Assemble(e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms), ids.From[ids.OrganizationKind](org))
 	if err != nil {
 		t.Fatalf("assemble: %v", err)
 	}
@@ -272,11 +256,11 @@ func TestOrganization360ContactsHonorTheCallersRowScope(t *testing.T) {
 // native workspace must reach it, not be refused by the overlay guard that
 // only exists for mirror-backed ones.
 func TestOrganization360TransportServesANativeWorkspace(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	handlers := org360.NewHandlers(org360Service(e),
 		func(context.Context) (bool, error) { return false, nil })
 	org := ids.From[ids.OrganizationKind](e.SeedOrg(t, "Acme", &e.Rep1))
-	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, org360RepPerms)
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/v1/organizations/"+org.String()+"/360", nil)
@@ -311,30 +295,14 @@ func TestOrganization360TransportServesANativeWorkspace(t *testing.T) {
 	}
 }
 
-// agentWithOrgRead binds an agent principal holding the same object grants
-// the rep does, unbounded, and CARRYING the granting human's user id — the
-// shape identity/passport.go actually mints, where OnBehalfOf becomes
-// UserID for row scope. An agent with no user id would be refused for the
-// wrong reason and would prove nothing about the human-only rule.
-func agentWithOrgRead(e *Env) context.Context {
-	perms := org360RepPerms
-	perms.RowScope = principal.RowScopeAll
-	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
-	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
-	return principal.WithActor(ctx, principal.Principal{
-		Type: principal.PrincipalAgent, ID: "agent:test", SeatType: principal.SeatFull,
-		UserID: e.Rep1, OnBehalfOf: e.Rep1, Permissions: perms,
-	})
-}
-
 // A task reaches this account through a contact the caller can read, while
 // also being linked to another team's deal. The task belongs on the page;
 // that deal's id does not.
 func TestOrganization360NextStepsHideALinkedDealOutOfRowScope(t *testing.T) {
-	e := Setup(t)
-	owner := OwnerConn(t)
+	e := integration.Setup(t)
+	owner := integration.OwnerConn(t)
 	svc := org360Service(e)
-	pipeline, stage, _ := DealFixture(t, e)
+	pipeline, stage, _ := integration.DealFixture(t, e)
 
 	org := e.SeedOrg(t, "Acme", &e.Rep1)
 	mine := e.SeedPerson(t, "My Contact", &e.Rep1)
@@ -343,12 +311,12 @@ func TestOrganization360NextStepsHideALinkedDealOutOfRowScope(t *testing.T) {
 	theirDeal := e.SeedDeal(t, "Other team deal", pipeline, stage, &e.Rep3)
 	e.WsExec(t, `UPDATE deal SET organization_id = $2 WHERE id = $1`, theirDeal, org)
 
-	task := SeedRow(t, owner, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, is_done, source, captured_by)
+	task := integration.SeedRow(t, owner, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, is_done, source, captured_by)
 		VALUES ($1, $2, 'task', 'Send the renewal paperwork', now(), false, 'manual', 'human:x')`, e.WS)
-	LinkActivity(t, owner, e.WS, task, "person", mine)
-	LinkActivity(t, owner, e.WS, task, "deal", theirDeal)
+	integration.LinkActivity(t, owner, e.WS, task, "person", mine)
+	integration.LinkActivity(t, owner, e.WS, task, "deal", theirDeal)
 
-	view, err := svc.Assemble(e.As(e.Rep1, []ids.UUID{e.Team1}, org360RepPerms), ids.From[ids.OrganizationKind](org))
+	view, err := svc.Assemble(e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms), ids.From[ids.OrganizationKind](org))
 	if err != nil {
 		t.Fatalf("assemble: %v", err)
 	}

--- a/backend/internal/compose/integration/org360/org360_querycount_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_querycount_integration_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/compose/integration"
-	"github.com/gradionhq/margince/backend/internal/compose/org360"
+	org360svc "github.com/gradionhq/margince/backend/internal/compose/org360"
 	"github.com/gradionhq/margince/backend/internal/modules/approvals"
 	"github.com/gradionhq/margince/backend/internal/modules/people"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
@@ -98,7 +98,7 @@ func TestOrganization360CostDoesNotGrowWithTheAccount(t *testing.T) {
 
 	tracer := &countingTracer{}
 	pool := tracedPool(t, tracer)
-	svc := org360.NewService(pool, people.NewStore(pool), approvals.NewService(pool),
+	svc := org360svc.NewService(pool, people.NewStore(pool), approvals.NewService(pool),
 		func() time.Time { return org360Clock })
 	ctx := e.Admin()
 

--- a/backend/internal/compose/integration/org360/org360_querycount_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_querycount_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package integration
+package org360
 
 // The 360 exists to replace a stack of round trips with one. That promise
 // is only true if the assembly's cost is flat in the size of the account:
@@ -26,6 +26,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/gradionhq/margince/backend/internal/compose/integration"
 	"github.com/gradionhq/margince/backend/internal/compose/org360"
 	"github.com/gradionhq/margince/backend/internal/modules/approvals"
 	"github.com/gradionhq/margince/backend/internal/modules/people"
@@ -86,12 +87,12 @@ func tracedPool(t *testing.T, tracer *countingTracer) *pgxpool.Pool {
 }
 
 func TestOrganization360CostDoesNotGrowWithTheAccount(t *testing.T) {
-	e := Setup(t)
-	owner := OwnerConn(t)
+	e := integration.Setup(t)
+	owner := integration.OwnerConn(t)
 
 	// One pipeline for both accounts: the fixture seeds the workspace
 	// default, and seeding it twice is a conflict, not a second pipeline.
-	pipeline, stage, _ := DealFixture(t, e)
+	pipeline, stage, _ := integration.DealFixture(t, e)
 	small := seedAccount(t, e, owner, "Small Account", 1, pipeline, stage)
 	large := seedAccount(t, e, owner, "Large Account", 12, pipeline, stage)
 
@@ -134,7 +135,7 @@ func TestOrganization360CostDoesNotGrowWithTheAccount(t *testing.T) {
 
 // seedAccount builds one organization with n employed contacts (each with
 // an interaction, so strength is real work) and n open deals.
-func seedAccount(t *testing.T, e *Env, owner *pgx.Conn, name string, n int,
+func seedAccount(t *testing.T, e *integration.Env, owner *pgx.Conn, name string, n int,
 	pipeline ids.PipelineID, stage ids.StageID,
 ) ids.OrganizationID {
 	t.Helper()
@@ -143,9 +144,9 @@ func seedAccount(t *testing.T, e *Env, owner *pgx.Conn, name string, n int,
 		contact := e.SeedPerson(t, name+" contact", &e.Rep1)
 		e.WsExec(t, `INSERT INTO relationship (workspace_id, kind, person_id, organization_id, source, captured_by)
 			VALUES ($1, 'employment', $2, $3, 'manual', 'human:x')`, e.WS, contact, org)
-		activity := SeedRow(t, owner, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, direction, source, captured_by)
+		activity := integration.SeedRow(t, owner, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, direction, source, captured_by)
 			VALUES ($1, $2, 'email', 'touch', '2026-05-28T09:00:00Z', 'inbound', 'manual', 'human:x')`, e.WS)
-		LinkActivity(t, owner, e.WS, activity, "person", contact)
+		integration.LinkActivity(t, owner, e.WS, activity, "person", contact)
 
 		deal := e.SeedDeal(t, name+" deal", pipeline, stage, &e.Rep1)
 		e.WsExec(t, `UPDATE deal SET organization_id = $2 WHERE id = $1`, deal, org)

--- a/backend/internal/compose/integration/org360/org360_signal_advice_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_signal_advice_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package integration
+package org360
 
 // Signal-derived advice end to end, over a real database: the conflict between
 // what the record says and what its own correspondence says, and the one signal
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gradionhq/margince/backend/internal/compose/integration"
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
@@ -29,7 +30,7 @@ import (
 // the reader — but it must state it FIRST, because acting on a stage that is
 // wrong is worse than not acting at all.
 func TestTheRecordAndItsOwnMailAreShownToDisagree(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	svc := org360Service(e)
 	org := ids.From[ids.OrganizationKind](e.SeedOrg(t, "Acme", &e.Rep1))
 	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, org360SignalPerms)
@@ -62,7 +63,7 @@ func TestTheRecordAndItsOwnMailAreShownToDisagree(t *testing.T) {
 // says so; it is that mail's conclusion. Firing there would hand every closed
 // account a permanent card nobody can clear.
 func TestAnEndedContractDoesNotContradictAnEndedRelationship(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	svc := org360Service(e)
 	org := ids.From[ids.OrganizationKind](e.SeedOrg(t, "Acme", &e.Rep1))
 	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, org360SignalPerms)
@@ -96,7 +97,7 @@ func kindsOf(found []crmcontracts.Organization360Suggestion) []string {
 // is nothing. The rule reads a record the reader has no right to, so it stays
 // silent rather than leaking its existence through advice.
 func TestTheConflictStaysSilentWithoutTheSignalGrant(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	svc := org360Service(e)
 	org := ids.From[ids.OrganizationKind](e.SeedOrg(t, "Acme", &e.Rep1))
 
@@ -104,8 +105,8 @@ func TestTheConflictStaysSilentWithoutTheSignalGrant(t *testing.T) {
 	seedSignal(t, e, org.UUID, "contract_ended", "warn",
 		"They wrote that the contract ends on 31 July.", "2026-05-20T09:00:00Z")
 
-	// org360RepPerms carries no signal grant, which is the point.
-	view, err := svc.Assemble(e.As(e.Rep1, []ids.UUID{e.Team1}, org360RepPerms), org)
+	// integration.AccountRepPerms carries no signal grant, which is the point.
+	view, err := svc.Assemble(e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms), org)
 	if err != nil {
 		t.Fatalf("assemble: %v", err)
 	}
@@ -117,9 +118,9 @@ func TestTheConflictStaysSilentWithoutTheSignalGrant(t *testing.T) {
 }
 
 // seedSignal writes one open derived signal at a severity and an instant.
-func seedSignal(t *testing.T, e *Env, org ids.UUID, kind, severity, summary, at string) {
+func seedSignal(t *testing.T, e *integration.Env, org ids.UUID, kind, severity, summary, at string) {
 	t.Helper()
-	SeedRow(t, OwnerConn(t), `INSERT INTO signal
+	integration.SeedRow(t, integration.OwnerConn(t), `INSERT INTO signal
 		(id, workspace_id, kind, source_channel, entity_type, entity_id, resolved_org_id,
 		 resolution_state, severity, summary, status, detected_at, source, captured_by)
 		VALUES ($1, $2, '`+kind+`', 'derived', 'organization', '`+org.String()+`',
@@ -131,7 +132,7 @@ func seedSignal(t *testing.T, e *Env, org ids.UUID, kind, severity, summary, at 
 // states the most serious, and among equals the newest — an old warning that
 // has been sitting there is less news than the one that just arrived.
 func TestTheStripStatesTheWorstOpenSignal(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	svc := org360Service(e)
 	org := ids.From[ids.OrganizationKind](e.SeedOrg(t, "Acme", &e.Rep1))
 	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, org360SignalPerms)
@@ -164,15 +165,15 @@ func TestTheStripStatesTheWorstOpenSignal(t *testing.T) {
 // there is nothing. The tile is absent, and the difference is what the signals
 // card is for.
 func TestTheStripStatesNoSignalWithoutTheGrant(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	svc := org360Service(e)
 	org := ids.From[ids.OrganizationKind](e.SeedOrg(t, "Acme", &e.Rep1))
 
 	seedSignal(t, e, org.UUID, "contract_ended", "warn",
 		"They wrote that the contract ends on 31 July.", "2026-05-21T09:00:00Z")
 
-	// org360RepPerms carries no signal grant, which is the point.
-	view, err := svc.Assemble(e.As(e.Rep1, []ids.UUID{e.Team1}, org360RepPerms), org)
+	// integration.AccountRepPerms carries no signal grant, which is the point.
+	view, err := svc.Assemble(e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms), org)
 	if err != nil {
 		t.Fatalf("assemble: %v", err)
 	}

--- a/backend/internal/compose/integration/org360/org360_suggestion_dismissal_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_suggestion_dismissal_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package integration
+package org360
 
 // Suggestion dismissals end to end, over a real database.
 //
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gradionhq/margince/backend/internal/compose/integration"
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
 	"github.com/gradionhq/margince/backend/internal/platform/httperr"
@@ -40,11 +41,11 @@ const wellFormedFingerprint = "0123456789abcdef0123456789abcdef0123456789abcdef0
 // five suggestions on a busy account ends up with an empty card and stalled
 // deals they were never shown.
 func TestDismissingASuggestionRevealsTheNextOne(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	svc := org360Service(e)
-	pipelineID, stage, _ := DealFixture(t, e)
+	pipelineID, stage, _ := integration.DealFixture(t, e)
 	org := ids.From[ids.OrganizationKind](e.SeedOrg(t, "Acme", &e.Rep1))
-	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, org360RepPerms)
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms)
 
 	// Seven stalled deals, more than the card lists.
 	for i := range 7 {
@@ -100,11 +101,11 @@ func stalledFingerprints(found []crmcontracts.Organization360Suggestion) []strin
 // ones and bring that advice back. A rep who works through a busy account has to
 // be able to reach the end of it.
 func TestNoDismissalIsEverResurrected(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	svc := org360Service(e)
-	pipelineID, stage, _ := DealFixture(t, e)
+	pipelineID, stage, _ := integration.DealFixture(t, e)
 	org := ids.From[ids.OrganizationKind](e.SeedOrg(t, "Acme", &e.Rep1))
-	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, org360RepPerms)
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms)
 
 	// More stalled deals than any retention bound would plausibly keep.
 	const stalled = 60
@@ -158,11 +159,11 @@ func TestNoDismissalIsEverResurrected(t *testing.T) {
 // The unit test pins the fingerprint; this pins that the read produces the
 // changed one, so the two halves cannot pass while disagreeing.
 func TestADismissedStallReturnsWhenTheDealStallsAgain(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	svc := org360Service(e)
-	pipelineID, stage, _ := DealFixture(t, e)
+	pipelineID, stage, _ := integration.DealFixture(t, e)
 	org := ids.From[ids.OrganizationKind](e.SeedOrg(t, "Acme", &e.Rep1))
-	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, org360RepPerms)
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms)
 	deal := e.SeedDeal(t, "Renewal", pipelineID, stage, &e.Rep1)
 	e.WsExec(t, `UPDATE deal SET organization_id = $2, created_at = $3, last_activity_at = $3
 		WHERE id = $1`, deal, org.UUID, org360Clock.AddDate(0, 0, -200))
@@ -211,11 +212,11 @@ func TestADismissedStallReturnsWhenTheDealStallsAgain(t *testing.T) {
 // they may have been shown again in between. The fingerprint carries only the idle
 // instant, which activities advance with greatest() and nothing lowers.
 func TestADeferralNeverResurrectsADismissal(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	svc := org360Service(e)
-	pipelineID, stage, _ := DealFixture(t, e)
+	pipelineID, stage, _ := integration.DealFixture(t, e)
 	org := ids.From[ids.OrganizationKind](e.SeedOrg(t, "Acme", &e.Rep1))
-	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, org360RepPerms)
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms)
 	deal := e.SeedDeal(t, "Renewal", pipelineID, stage, &e.Rep1)
 	e.WsExec(t, `UPDATE deal SET organization_id = $2, created_at = $3, last_activity_at = $3
 		WHERE id = $1`, deal, org.UUID, org360Clock.AddDate(0, 0, -200))
@@ -287,12 +288,12 @@ func TestADeferralNeverResurrectsADismissal(t *testing.T) {
 // It goes through deals.AdvanceDeal rather than an UPDATE, because what the episode
 // counts is the history row that path writes.
 func TestAdvancingADealReArmsDismissedStallAdvice(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	svc := org360Service(e)
-	pipelineID, stage, _ := DealFixture(t, e)
+	pipelineID, stage, _ := integration.DealFixture(t, e)
 	next := secondOpenStage(t, e, pipelineID, stage)
 	org := ids.From[ids.OrganizationKind](e.SeedOrg(t, "Acme", &e.Rep1))
-	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, org360RepPerms)
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms)
 	deal := e.SeedDeal(t, "Renewal", pipelineID, stage, &e.Rep1)
 	e.WsExec(t, `UPDATE deal SET organization_id = $2, created_at = $3, last_activity_at = $3
 		WHERE id = $1`, deal, org.UUID, org360Clock.AddDate(0, 0, -200))
@@ -317,7 +318,7 @@ func TestAdvancingADealReArmsDismissedStallAdvice(t *testing.T) {
 	// The deal moves to another OPEN stage, so it stays a candidate. Nothing logs
 	// an activity, so the stall rule's own inputs are unchanged and the deal is
 	// still stalled — but it has plainly been worked.
-	if _, err := e.Deals.AdvanceDeal(e.As(e.Rep1, nil, AdminPerms),
+	if _, err := e.Deals.AdvanceDeal(e.As(e.Rep1, nil, integration.AdminPerms),
 		ids.From[ids.DealKind](deal), deals.AdvanceDealInput{ToStageID: next}); err != nil {
 		t.Fatalf("advancing the deal: %v", err)
 	}
@@ -345,7 +346,7 @@ func TestAdvancingADealReArmsDismissedStallAdvice(t *testing.T) {
 	if err := svc.DismissSuggestion(rep, org, fresh[0]); err != nil {
 		t.Fatalf("dismiss the post-advance advice: %v", err)
 	}
-	if _, err := e.Deals.AdvanceDeal(e.As(e.Rep1, nil, AdminPerms),
+	if _, err := e.Deals.AdvanceDeal(e.As(e.Rep1, nil, integration.AdminPerms),
 		ids.From[ids.DealKind](deal), deals.AdvanceDealInput{ToStageID: next}); err != nil {
 		t.Fatalf("re-selecting the same stage: %v", err)
 	}
@@ -362,7 +363,7 @@ func TestAdvancingADealReArmsDismissedStallAdvice(t *testing.T) {
 
 // secondOpenStage finds another open stage in the pipeline, so a deal can be
 // advanced without leaving the open set the suggestion rules read.
-func secondOpenStage(t *testing.T, e *Env, pipelineID ids.PipelineID, notThisOne ids.StageID) ids.StageID {
+func secondOpenStage(t *testing.T, e *integration.Env, pipelineID ids.PipelineID, notThisOne ids.StageID) ids.StageID {
 	t.Helper()
 	p, err := e.Deals.GetPipeline(e.Admin(), pipelineID)
 	if err != nil {
@@ -389,11 +390,11 @@ func secondOpenStage(t *testing.T, e *Env, pipelineID ids.PipelineID, notThisOne
 // judged, so a dismissal has to re-arm. A fingerprint built from a fetched page
 // would stay in force over a pipeline the account no longer has.
 func TestNoNextStepFingerprintFollowsUnlistedDeals(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	svc := org360Service(e)
-	pipelineID, stage, _ := DealFixture(t, e)
+	pipelineID, stage, _ := integration.DealFixture(t, e)
 	org := ids.From[ids.OrganizationKind](e.SeedOrg(t, "Acme", &e.Rep1))
-	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, org360RepPerms)
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms)
 
 	// Two stalled deals — under the card's cap, so the no-next-step row is
 	// listed too — plus a healthy third the stalled listing never mentions.
@@ -447,13 +448,13 @@ func fingerprintOfKind(
 // A dismissal belongs to the rep who made it. One rep judging a suggestion
 // must not decide it for their colleague, who has never seen it.
 func TestSuggestionDismissalIsPerUser(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	svc := org360Service(e)
 	org := ids.From[ids.OrganizationKind](e.SeedOrg(t, "Acme", &e.Rep1))
 	seedUnansweredOutbound(t, e, org.UUID)
 
-	rep1 := e.As(e.Rep1, []ids.UUID{e.Team1}, org360RepPerms)
-	rep2 := e.As(e.Rep2, []ids.UUID{e.Team1}, org360RepPerms)
+	rep1 := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms)
+	rep2 := e.As(e.Rep2, []ids.UUID{e.Team1}, integration.AccountRepPerms)
 
 	view, err := svc.Assemble(rep1, org)
 	if err != nil {
@@ -503,11 +504,11 @@ func TestSuggestionDismissalIsPerUser(t *testing.T) {
 // situation holds and stops applying when the situation is genuinely a new
 // one. Without that, the surface would get quieter the longer it ran.
 func TestSuggestionDismissalReArmsWhenTheEvidenceChanges(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	svc := org360Service(e)
 	org := ids.From[ids.OrganizationKind](e.SeedOrg(t, "Acme", &e.Rep1))
 	seedUnansweredOutbound(t, e, org.UUID)
-	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, org360RepPerms)
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms)
 
 	first, err := svc.Assemble(rep, org)
 	if err != nil {
@@ -542,11 +543,11 @@ func TestSuggestionDismissalReArmsWhenTheEvidenceChanges(t *testing.T) {
 // A dismissal names a record, so it is a read: an account this caller cannot
 // see must refuse rather than confirm it exists.
 func TestSuggestionDismissalRefusesAnInvisibleAccount(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	svc := org360Service(e)
 	// Owned by Rep3, who sits in Team2 — outside Rep1's team-scoped row scope.
 	org := ids.From[ids.OrganizationKind](e.SeedOrg(t, "Someone else's account", &e.Rep3))
-	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, org360RepPerms)
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms)
 
 	// The record gate runs before anything else, so this is a 404 rather than the
 	// silent success an unmatched fingerprint gets on a visible account.
@@ -562,11 +563,11 @@ func TestSuggestionDismissalRefusesAnInvisibleAccount(t *testing.T) {
 // An agent has no opinion to record. Consuming a human's dismissal on their
 // behalf would silence advice that human never saw.
 func TestSuggestionDismissalRefusesAnAgent(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	svc := org360Service(e)
 	org := ids.From[ids.OrganizationKind](e.SeedOrg(t, "Acme", &e.Rep1))
 
-	err := svc.DismissSuggestion(agentWithOrgRead(e), org, wellFormedFingerprint)
+	err := svc.DismissSuggestion(integration.AgentWithOrgRead(e), org, wellFormedFingerprint)
 	if !errors.Is(err, apperrors.ErrPermissionDenied) {
 		t.Errorf("agent dismissal → %v, want ErrPermissionDenied", err)
 	}
@@ -580,10 +581,10 @@ func TestSuggestionDismissalRefusesAnAgent(t *testing.T) {
 // dismiss, and saying which reason would answer a question the caller has no
 // business asking.
 func TestSuggestionDismissalStoresNothingForASuggestionTheAccountDoesNotRaise(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	svc := org360Service(e)
 	org := ids.From[ids.OrganizationKind](e.SeedOrg(t, "Acme", &e.Rep1))
-	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, org360RepPerms)
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms)
 
 	// A quiet account raises nothing, so no fingerprint can match.
 	for _, forged := range []string{wellFormedFingerprint, strings.Repeat("a", 64)} {
@@ -618,10 +619,10 @@ func TestSuggestionDismissalStoresNothingForASuggestionTheAccountDoesNotRaise(t 
 // checked after the record gate, so the refusal cannot double as an existence
 // probe.
 func TestSuggestionDismissalRefusesAMalformedFingerprint(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	svc := org360Service(e)
 	org := ids.From[ids.OrganizationKind](e.SeedOrg(t, "Acme", &e.Rep1))
-	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, org360RepPerms)
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms)
 
 	for _, refused := range []string{"", "   ", "not-a-digest", strings.ToUpper(wellFormedFingerprint)} {
 		var detailed *httperr.DetailedError

--- a/backend/internal/compose/integration/org360/org360_suggestion_dismissal_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_suggestion_dismissal_integration_test.go
@@ -9,7 +9,7 @@ package org360
 //
 // A dismissal is per user and keyed on evidence, so silencing advice must
 // silence it for exactly one rep and stop silencing it when the situation
-// changes — the part the rules alone (org360/suggestions_test.go) cannot state.
+// changes — the part the rules alone (compose/org360/suggestions_test.go) cannot state.
 //
 // Every fixture sets its timestamps explicitly. The read's clock is pinned to
 // org360Clock while the database's now() is not, so a fixture on now() would

--- a/backend/internal/compose/integration/org360/org360_suggestions_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_suggestions_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package integration
+package org360
 
 // Suggestions end to end, over a real database.
 //
@@ -23,16 +23,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gradionhq/margince/backend/internal/compose/integration"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
 // seedUnansweredOutbound logs an outbound email old enough to be worth
 // chasing, linked to the account.
-func seedUnansweredOutbound(t *testing.T, e *Env, org ids.UUID) {
+func seedUnansweredOutbound(t *testing.T, e *integration.Env, org ids.UUID) {
 	t.Helper()
-	owner := OwnerConn(t)
-	sent := SeedRow(t, owner, `INSERT INTO activity
+	owner := integration.OwnerConn(t)
+	sent := integration.SeedRow(t, owner, `INSERT INTO activity
 		(id, workspace_id, kind, direction, subject, occurred_at, created_at, source, captured_by)
 		VALUES ($1, $2, 'email', 'outbound', 'Proposal — following up',
 		        '2026-05-10T09:00:00Z', '2026-05-10T09:00:00Z', 'manual', 'human:x')`, e.WS)
@@ -47,8 +48,8 @@ func seedUnansweredOutbound(t *testing.T, e *Env, org ids.UUID) {
 // newer notes, and a rep would read the silent card as "nothing to chase here" —
 // which is the one thing this surface must never say wrongly.
 func TestSuggestionsLookPastTheSectionPageCap(t *testing.T) {
-	e := Setup(t)
-	owner := OwnerConn(t)
+	e := integration.Setup(t)
+	owner := integration.OwnerConn(t)
 	svc := org360Service(e)
 	org := ids.From[ids.OrganizationKind](e.SeedOrg(t, "Acme", &e.Rep1))
 	seedUnansweredOutbound(t, e, org.UUID)
@@ -70,7 +71,7 @@ func TestSuggestionsLookPastTheSectionPageCap(t *testing.T) {
 			VALUES ($1, $2, 'organization', $3)`, e.WS, note, org.UUID)
 	}
 
-	view, err := svc.Assemble(e.As(e.Rep1, []ids.UUID{e.Team1}, org360RepPerms), org)
+	view, err := svc.Assemble(e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms), org)
 	if err != nil {
 		t.Fatalf("assemble: %v", err)
 	}
@@ -110,11 +111,11 @@ func TestSuggestionsLookPastTheSectionPageCap(t *testing.T) {
 // It needs an account that produces MORE than the card lists and at least one of
 // each kind, or the ordering never binds and the test passes on an accident.
 func TestTheMostUrgentAdviceLeadsAFullCard(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	svc := org360Service(e)
-	pipelineID, stage, _ := DealFixture(t, e)
+	pipelineID, stage, _ := integration.DealFixture(t, e)
 	org := ids.From[ids.OrganizationKind](e.SeedOrg(t, "Acme", &e.Rep1))
-	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, org360RepPerms)
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms)
 
 	seedUnansweredOutbound(t, e, org.UUID)
 	const stalled = maxListedSuggestions + 2
@@ -162,11 +163,11 @@ const maxListedSuggestions = 3
 // the listed part would leave a dismissal in force after a deal it never saw
 // changed.
 func TestSuggestionCountsAreTheAccountsNotTheReads(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	svc := org360Service(e)
-	pipelineID, stage, _ := DealFixture(t, e)
+	pipelineID, stage, _ := integration.DealFixture(t, e)
 	org := ids.From[ids.OrganizationKind](e.SeedOrg(t, "Acme", &e.Rep1))
-	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, org360RepPerms)
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms)
 
 	// Eight open deals, every one idle long enough to be stalled — more than the
 	// card lists, so the listing is bounded while the figures must not be.
@@ -217,12 +218,12 @@ func TestSuggestionCountsAreTheAccountsNotTheReads(t *testing.T) {
 // still see tasks here — so the test also pins the reachability the direct query
 // uses, by linking the only task through the DEAL rather than to the account.
 func TestNoNextStepSeesATaskThePageDoesNot(t *testing.T) {
-	e := Setup(t)
-	owner := OwnerConn(t)
+	e := integration.Setup(t)
+	owner := integration.OwnerConn(t)
 	svc := org360Service(e)
-	pipelineID, stage, _ := DealFixture(t, e)
+	pipelineID, stage, _ := integration.DealFixture(t, e)
 	org := ids.From[ids.OrganizationKind](e.SeedOrg(t, "Acme", &e.Rep1))
-	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, org360RepPerms)
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms)
 	deal := e.SeedDeal(t, "Renewal", pipelineID, stage, &e.Rep1)
 	e.WsExec(t, `UPDATE deal SET organization_id = $2 WHERE id = $1`, deal, org.UUID)
 
@@ -260,9 +261,9 @@ func TestNoNextStepSeesATaskThePageDoesNot(t *testing.T) {
 // deal reader can act on, and withholding it because they cannot read activities
 // would cost them advice they are entitled to.
 func TestSuggestionsSurviveWithoutTheActivityGrant(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	svc := org360Service(e)
-	pipelineID, stage, _ := DealFixture(t, e)
+	pipelineID, stage, _ := integration.DealFixture(t, e)
 	org := ids.From[ids.OrganizationKind](e.SeedOrg(t, "Acme", &e.Rep1))
 	deal := e.SeedDeal(t, "Fleet retrofit", pipelineID, stage, &e.Rep1)
 	e.WsExec(t, `UPDATE deal SET organization_id = $2, created_at = $3, last_activity_at = $3
@@ -299,7 +300,7 @@ func TestSuggestionsSurviveWithoutTheActivityGrant(t *testing.T) {
 // A caller shown neither the timeline nor the pipeline has nothing to be advised
 // from, so the section is omitted and named rather than answering empty.
 func TestSuggestionsAreOmittedWhenNeitherInputReachesTheCaller(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	svc := org360Service(e)
 	org := ids.From[ids.OrganizationKind](e.SeedOrg(t, "Acme", &e.Rep1))
 	seedUnansweredOutbound(t, e, org.UUID)

--- a/backend/internal/compose/integration/org360/org360_suggestions_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_suggestions_integration_test.go
@@ -7,7 +7,7 @@ package org360
 
 // Suggestions end to end, over a real database.
 //
-// The rules themselves are proved without one (org360/suggestions_test.go).
+// The rules themselves are proved without one (compose/org360/suggestions_test.go).
 // What needs the database is the part the rules cannot state: which advice a
 // real account actually raises, in what order the card offers it, and how much
 // of the account the rules still see once the read's own sections have applied
@@ -149,7 +149,7 @@ func TestTheMostUrgentAdviceLeadsAFullCard(t *testing.T) {
 	}
 }
 
-// maxListedSuggestions mirrors the card's own cap (org360.maxSuggestions). Spelled
+// maxListedSuggestions mirrors the card's own cap (org360svc.maxSuggestions). Spelled
 // here because the integration package cannot see the unexported constant, and a
 // test that derived it from the answer could not tell a cap from a coincidence.
 const maxListedSuggestions = 3

--- a/backend/internal/compose/integration/org360/org360_visit_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_visit_integration_test.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	"github.com/gradionhq/margince/backend/internal/compose/integration"
-	"github.com/gradionhq/margince/backend/internal/compose/org360"
+	org360svc "github.com/gradionhq/margince/backend/internal/compose/org360"
 	"github.com/gradionhq/margince/backend/internal/modules/approvals"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
 	"github.com/gradionhq/margince/backend/internal/modules/people"
@@ -46,7 +46,7 @@ func TestOrganizationViewAckIsMonotonicAndPerUser(t *testing.T) {
 
 	// A second tab whose clock lags must not rewind the mark: the upsert
 	// keeps the later of the two.
-	lagging := org360.NewService(e.Pool, people.NewStore(e.Pool), approvals.NewService(e.Pool),
+	lagging := org360svc.NewService(e.Pool, people.NewStore(e.Pool), approvals.NewService(e.Pool),
 		func() time.Time { return org360Clock.Add(-time.Hour) })
 	second, err := lagging.Acknowledge(rep1, org)
 	if err != nil {

--- a/backend/internal/compose/integration/org360/org360_visit_integration_test.go
+++ b/backend/internal/compose/integration/org360/org360_visit_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package integration
+package org360
 
 // The visit baseline and the three counts it answers.
 //
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gradionhq/margince/backend/internal/compose/integration"
 	"github.com/gradionhq/margince/backend/internal/compose/org360"
 	"github.com/gradionhq/margince/backend/internal/modules/approvals"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
@@ -30,10 +31,10 @@ import (
 )
 
 func TestOrganizationViewAckIsMonotonicAndPerUser(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	svc := org360Service(e)
 	org := ids.From[ids.OrganizationKind](e.SeedOrg(t, "Acme", &e.Rep1))
-	rep1 := e.As(e.Rep1, []ids.UUID{e.Team1}, org360RepPerms)
+	rep1 := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms)
 
 	first, err := svc.Acknowledge(rep1, org)
 	if err != nil {
@@ -58,7 +59,7 @@ func TestOrganizationViewAckIsMonotonicAndPerUser(t *testing.T) {
 
 	// Rep2 shares Rep1's team and can read the same account, but has never
 	// visited it: the baseline is per user, not per record.
-	rep2 := e.As(e.Rep2, []ids.UUID{e.Team1}, org360RepPerms)
+	rep2 := e.As(e.Rep2, []ids.UUID{e.Team1}, integration.AccountRepPerms)
 	view, err := svc.Assemble(rep2, org)
 	if err != nil {
 		t.Fatalf("assemble as the second rep: %v", err)
@@ -75,10 +76,10 @@ func TestOrganizationViewAckIsMonotonicAndPerUser(t *testing.T) {
 // The 360 is a read: it must never advance the mark it reports against,
 // or the "what changed" answer destroys itself on first sight.
 func TestOrganization360DoesNotAdvanceTheVisitBaseline(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	svc := org360Service(e)
 	org := ids.From[ids.OrganizationKind](e.SeedOrg(t, "Acme", &e.Rep1))
-	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, org360RepPerms)
+	rep := e.As(e.Rep1, []ids.UUID{e.Team1}, integration.AccountRepPerms)
 
 	if _, err := svc.Assemble(rep, org); err != nil {
 		t.Fatalf("assemble: %v", err)
@@ -97,14 +98,14 @@ func TestOrganization360DoesNotAdvanceTheVisitBaseline(t *testing.T) {
 // An agent acting through a passport is not a visitor: it must not consume
 // the human's unread marker, and it cannot triage approvals either.
 func TestOrganization360RefusesTheVisitBaselineToAnAgent(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	svc := org360Service(e)
 	org := ids.From[ids.OrganizationKind](e.SeedOrg(t, "Acme", &e.Rep1))
 
-	if _, err := svc.Acknowledge(agentWithOrgRead(e), org); !errors.Is(err, apperrors.ErrPermissionDenied) {
+	if _, err := svc.Acknowledge(integration.AgentWithOrgRead(e), org); !errors.Is(err, apperrors.ErrPermissionDenied) {
 		t.Errorf("agent acknowledgment → %v, want ErrPermissionDenied", err)
 	}
-	view, err := svc.Assemble(agentWithOrgRead(e), org)
+	view, err := svc.Assemble(integration.AgentWithOrgRead(e), org)
 	if err != nil {
 		t.Fatalf("assemble as an agent: %v", err)
 	}
@@ -120,14 +121,14 @@ func TestOrganization360RefusesTheVisitBaselineToAnAgent(t *testing.T) {
 // most easily-wrong query in the read — it has to count moves without
 // counting the deal's creation — so it is seeded both ways.
 func TestOrganization360CountsWhatChangedSinceTheAcknowledgedVisit(t *testing.T) {
-	e := Setup(t)
-	owner := OwnerConn(t)
+	e := integration.Setup(t)
+	owner := integration.OwnerConn(t)
 	svc := org360Service(e)
-	pipeline, stage, won := DealFixture(t, e)
+	pipeline, stage, won := integration.DealFixture(t, e)
 	// A REAL seeded user, not e.Admin()'s synthetic one: the baseline row
 	// carries a composite foreign key to app_user, so only a user that
 	// exists can acknowledge a visit.
-	admin := e.As(e.Rep1, nil, AdminPerms)
+	admin := e.As(e.Rep1, nil, integration.AdminPerms)
 	org := ids.From[ids.OrganizationKind](e.SeedOrg(t, "Acme", &e.Rep1))
 
 	// A deal created and an activity logged BEFORE the visit: neither is news.
@@ -137,7 +138,7 @@ func TestOrganization360CountsWhatChangedSinceTheAcknowledgedVisit(t *testing.T)
 	// accident rather than by design.
 	before := e.SeedDeal(t, "Old deal", pipeline, stage, &e.Rep1)
 	e.WsExec(t, `UPDATE deal SET organization_id = $2 WHERE id = $1`, before, org.UUID)
-	old := SeedRow(t, owner, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, created_at, source, captured_by)
+	old := integration.SeedRow(t, owner, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, created_at, source, captured_by)
 		VALUES ($1, $2, 'note', 'before the visit', '2026-05-01T09:00:00Z', '2026-05-01T09:00:00Z', 'manual', 'human:x')`, e.WS)
 	e.WsExec(t, `INSERT INTO activity_link (workspace_id, activity_id, entity_type, organization_id)
 		VALUES ($1, $2, 'organization', $3)`, e.WS, old, org.UUID)
@@ -148,7 +149,7 @@ func TestOrganization360CountsWhatChangedSinceTheAcknowledgedVisit(t *testing.T)
 
 	// Now: one new activity, one real stage move, and one NEW deal — whose
 	// creation writes a first-stage history row that must not count as a move.
-	fresh := SeedRow(t, owner, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, created_at, source, captured_by)
+	fresh := integration.SeedRow(t, owner, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, created_at, source, captured_by)
 		VALUES ($1, $2, 'note', 'after the visit', '2026-06-15T09:00:00Z', '2026-06-15T09:00:00Z', 'manual', 'human:x')`, e.WS)
 	e.WsExec(t, `INSERT INTO activity_link (workspace_id, activity_id, entity_type, organization_id)
 		VALUES ($1, $2, 'organization', $3)`, e.WS, fresh, org.UUID)
@@ -185,11 +186,11 @@ func TestOrganization360CountsWhatChangedSinceTheAcknowledgedVisit(t *testing.T)
 // The first visit is not "nothing happened": a caller who has never opened
 // the account gets the whole history counted, against a null baseline.
 func TestOrganization360CountsTheWholeHistoryOnAFirstVisit(t *testing.T) {
-	e := Setup(t)
-	owner := OwnerConn(t)
+	e := integration.Setup(t)
+	owner := integration.OwnerConn(t)
 	svc := org360Service(e)
 	org := ids.From[ids.OrganizationKind](e.SeedOrg(t, "Acme", &e.Rep1))
-	logged := SeedRow(t, owner, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, source, captured_by)
+	logged := integration.SeedRow(t, owner, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, source, captured_by)
 		VALUES ($1, $2, 'note', 'first contact', now(), 'manual', 'human:x')`, e.WS)
 	e.WsExec(t, `INSERT INTO activity_link (workspace_id, activity_id, entity_type, organization_id)
 		VALUES ($1, $2, 'organization', $3)`, e.WS, logged, org.UUID)

--- a/backend/internal/compose/integration/orgask_integration_test.go
+++ b/backend/internal/compose/integration/orgask_integration_test.go
@@ -143,7 +143,7 @@ func TestOrganizationAskRefusesAnAgent(t *testing.T) {
 	lane := &countingLane{reply: `{"sentences":[]}`}
 	svc := briefService(e, lane, "routing-1")
 
-	_, err := svc.Ask(agentWithOrgRead(e), org, crmcontracts.WhatsOpen)
+	_, err := svc.Ask(AgentWithOrgRead(e), org, crmcontracts.WhatsOpen)
 	if !errors.Is(err, apperrors.ErrPermissionDenied) {
 		t.Errorf("agent question → %v, want ErrPermissionDenied", err)
 	}

--- a/backend/internal/compose/integration/seed.go
+++ b/backend/internal/compose/integration/seed.go
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// The row-seeding helpers the Env-riding suites share: fixtures that put records
+// in front of a test. Kept apart from the harness boot so each file holds one
+// concept — and so growing the seeding vocabulary does not grow harness.go.
+
+// DealFixture provisions the workspace with the seeded default pipeline
+// and returns the pipeline plus the open + won stage ids.
+func DealFixture(t *testing.T, e *Env) (pipeline ids.PipelineID, open, won ids.StageID) {
+	t.Helper()
+	admin := e.Admin()
+	if err := e.Deals.SeedDefaults(admin); err != nil {
+		t.Fatal(err)
+	}
+	p, err := e.Deals.DefaultPipeline(admin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, st := range *p.Stages {
+		switch st.Semantic {
+		case "open":
+			if open.IsZero() {
+				open = ids.From[ids.StageKind](ids.UUID(st.Id))
+			}
+		case "won":
+			won = ids.From[ids.StageKind](ids.UUID(st.Id))
+		}
+	}
+	return ids.From[ids.PipelineKind](ids.UUID(p.Id)), open, won
+}
+
+// SeedStakeholder creates a person, ties them to the deal as a
+// deal_stakeholder, and gives them one email in each named direction at
+// the fixed instant 2026-06-01T12:00Z — three days before the
+// 2026-06-04T12:00Z clock the consuming suites pin.
+func SeedStakeholder(t *testing.T, e *Env, owner *pgx.Conn, deal ids.UUID, directions ...string) ids.UUID {
+	t.Helper()
+	person := SeedRow(t, owner, `INSERT INTO person (id, workspace_id, full_name, source, captured_by)
+		VALUES ($1, $2, 'Stakeholder', 'manual', 'human:x')`, e.WS)
+	if _, err := owner.Exec(context.Background(),
+		`INSERT INTO relationship (workspace_id, kind, person_id, deal_id, source, captured_by)
+		 VALUES ($1, 'deal_stakeholder', $2, $3, 'manual', 'human:x')`, e.WS, person, deal); err != nil {
+		t.Fatal(err)
+	}
+	for _, direction := range directions {
+		touch := SeedRow(t, owner, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, direction, source, captured_by)
+			VALUES ($1, $2, 'email', 'touch', '2026-06-01T12:00:00Z', '`+direction+`', 'manual', 'human:x')`, e.WS)
+		LinkActivity(t, owner, e.WS, touch, objPerson, person)
+	}
+	return person
+}
+
+// LinkActivity attaches an activity to a person or deal through the
+// polymorphic link table.
+func LinkActivity(t *testing.T, owner *pgx.Conn, ws, activity ids.UUID, entityType string, entity ids.UUID) {
+	t.Helper()
+	column := "deal_id"
+	if entityType == objPerson {
+		column = "person_id"
+	}
+	if _, err := owner.Exec(context.Background(),
+		`INSERT INTO activity_link (workspace_id, activity_id, entity_type, `+column+`) VALUES ($1, $2, $3, $4)`,
+		ws, activity, entityType, entity); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// SeedRow inserts one row through the owner connection and returns its id.
+func SeedRow(t *testing.T, owner *pgx.Conn, sql string, ws ids.UUID) ids.UUID {
+	t.Helper()
+	id := ids.NewV7()
+	if _, err := owner.Exec(context.Background(), sql, id, ws); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+	return id
+}
+
+// LinkToOrg attaches an activity directly to an account (LinkActivity above
+// covers only the person and deal columns).
+func LinkToOrg(t *testing.T, e *Env, activity, org ids.UUID) {
+	t.Helper()
+	e.WsExec(t, `INSERT INTO activity_link (workspace_id, activity_id, entity_type, organization_id)
+		VALUES ($1, $2, 'organization', $3)`, e.WS, activity, org)
+}
+
+// Employ ties a person to an organization as a current employee.
+func Employ(t *testing.T, e *Env, person, org ids.UUID, title string) {
+	t.Helper()
+	e.WsExec(t, `INSERT INTO relationship (workspace_id, kind, person_id, organization_id, role, source, captured_by)
+		VALUES ($1, 'employment', $2, $3, $4, 'manual', 'human:x')`, e.WS, person, org, title)
+}
+
+// AccountMailDirectedAt seeds one message with an explicit direction, which is
+// what a last-touch assertion turns on: the same date means opposite things
+// depending on who wrote it.
+func AccountMailDirectedAt(t *testing.T, owner *pgx.Conn, ws ids.UUID, subject, direction string, at time.Time) ids.UUID {
+	t.Helper()
+	id := ids.NewV7()
+	if _, err := owner.Exec(context.Background(), `INSERT INTO activity
+		(id, workspace_id, kind, direction, subject, occurred_at, created_at, source, captured_by)
+		VALUES ($1, $2, 'email', $3, $4, $5, $5, 'manual', 'human:x')`,
+		id, ws, direction, subject, at); err != nil {
+		t.Fatalf("seeding %q: %v", subject, err)
+	}
+	return id
+}

--- a/backend/internal/compose/integration/seed.go
+++ b/backend/internal/compose/integration/seed.go
@@ -49,10 +49,13 @@ func DealFixture(t *testing.T, e *Env) (pipeline ids.PipelineID, open, won ids.S
 	return ids.From[ids.PipelineKind](ids.UUID(p.Id)), open, won
 }
 
+// stakeholderTouchedAt is the instant SeedStakeholder's emails carry, three
+// days before the 2026-06-04T12:00Z clock the consuming suites pin.
+var stakeholderTouchedAt = time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+
 // SeedStakeholder creates a person, ties them to the deal as a
 // deal_stakeholder, and gives them one email in each named direction at
-// the fixed instant 2026-06-01T12:00Z — three days before the
-// 2026-06-04T12:00Z clock the consuming suites pin.
+// stakeholderTouchedAt.
 func SeedStakeholder(t *testing.T, e *Env, owner *pgx.Conn, deal ids.UUID, directions ...string) ids.UUID {
 	t.Helper()
 	person := SeedRow(t, owner, `INSERT INTO person (id, workspace_id, full_name, source, captured_by)
@@ -63,8 +66,18 @@ func SeedStakeholder(t *testing.T, e *Env, owner *pgx.Conn, deal ids.UUID, direc
 		t.Fatal(err)
 	}
 	for _, direction := range directions {
-		touch := SeedRow(t, owner, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, direction, source, captured_by)
-			VALUES ($1, $2, 'email', 'touch', '2026-06-01T12:00:00Z', '`+direction+`', 'manual', 'human:x')`, e.WS)
+		// created_at is pinned alongside occurred_at, not left to the column
+		// default: it is part of the activity shape a reader sees, and a
+		// wall-clock value there makes an assertion about this fixture depend on
+		// when the suite ran. direction is bound rather than interpolated, so a
+		// fixture input stays data even when a caller passes something unexpected.
+		touch := ids.NewV7()
+		if _, err := owner.Exec(context.Background(), `INSERT INTO activity
+			(id, workspace_id, kind, subject, occurred_at, created_at, direction, source, captured_by)
+			VALUES ($1, $2, 'email', 'touch', $3, $3, $4, 'manual', 'human:x')`,
+			touch, e.WS, stakeholderTouchedAt, direction); err != nil {
+			t.Fatalf("seeding %q touch: %v", direction, err)
+		}
 		LinkActivity(t, owner, e.WS, touch, "person", person)
 	}
 	return person

--- a/backend/internal/compose/integration/seed.go
+++ b/backend/internal/compose/integration/seed.go
@@ -15,9 +15,14 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
-// The row-seeding helpers the Env-riding suites share: fixtures that put records
-// in front of a test. Kept apart from the harness boot so each file holds one
-// concept — and so growing the seeding vocabulary does not grow harness.go.
+// The raw-SQL seeding helpers, as opposed to the store-mediated fixtures on Env
+// in harness.go: everything here writes rows with its own INSERT rather than
+// going through a module store, which is the line the two files are split on.
+//
+// That line is load-bearing, not tidiness. This file is the identity-mint site
+// backend/dedupespine_test.go sanctions BY PATH, so a direct
+// `INSERT INTO person|organization|lead` belongs here and nowhere else in the
+// package — put one in harness.go and the gate fails, which is the point.
 
 // DealFixture provisions the workspace with the seeded default pipeline
 // and returns the pipeline plus the open + won stage ids.
@@ -60,7 +65,7 @@ func SeedStakeholder(t *testing.T, e *Env, owner *pgx.Conn, deal ids.UUID, direc
 	for _, direction := range directions {
 		touch := SeedRow(t, owner, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, direction, source, captured_by)
 			VALUES ($1, $2, 'email', 'touch', '2026-06-01T12:00:00Z', '`+direction+`', 'manual', 'human:x')`, e.WS)
-		LinkActivity(t, owner, e.WS, touch, objPerson, person)
+		LinkActivity(t, owner, e.WS, touch, "person", person)
 	}
 	return person
 }
@@ -70,7 +75,7 @@ func SeedStakeholder(t *testing.T, e *Env, owner *pgx.Conn, deal ids.UUID, direc
 func LinkActivity(t *testing.T, owner *pgx.Conn, ws, activity ids.UUID, entityType string, entity ids.UUID) {
 	t.Helper()
 	column := "deal_id"
-	if entityType == objPerson {
+	if entityType == "person" {
 		column = "person_id"
 	}
 	if _, err := owner.Exec(context.Background(),
@@ -96,13 +101,6 @@ func LinkToOrg(t *testing.T, e *Env, activity, org ids.UUID) {
 	t.Helper()
 	e.WsExec(t, `INSERT INTO activity_link (workspace_id, activity_id, entity_type, organization_id)
 		VALUES ($1, $2, 'organization', $3)`, e.WS, activity, org)
-}
-
-// Employ ties a person to an organization as a current employee.
-func Employ(t *testing.T, e *Env, person, org ids.UUID, title string) {
-	t.Helper()
-	e.WsExec(t, `INSERT INTO relationship (workspace_id, kind, person_id, organization_id, role, source, captured_by)
-		VALUES ($1, 'employment', $2, $3, $4, 'manual', 'human:x')`, e.WS, person, org, title)
 }
 
 // AccountMailDirectedAt seeds one message with an explicit direction, which is

--- a/backend/internal/compose/integration/signalscan_integration_test.go
+++ b/backend/internal/compose/integration/signalscan_integration_test.go
@@ -75,9 +75,9 @@ func TestGhostedThreadIsRaisedOnceAndSurvivesARepeatPass(t *testing.T) {
 	// unanswered fortnight on an account nobody works is not an observation
 	// about a relationship.
 	e.WsExec(t, `UPDATE organization SET lifecycle = 'opportunity' WHERE id = $1`, org)
-	outbound := accountMailDirectedAt(t, owner, e.WS, "Update zu Margince", "outbound",
+	outbound := AccountMailDirectedAt(t, owner, e.WS, "Update zu Margince", "outbound",
 		now.AddDate(0, 0, -20))
-	linkToOrg(t, e, outbound, org)
+	LinkToOrg(t, e, outbound, org)
 
 	if written := ghostedScan(t, e, now); written != 1 {
 		t.Fatalf("first pass wrote %d signals, want 1", written)
@@ -102,8 +102,8 @@ func TestADismissedGhostedSignalDoesNotComeBack(t *testing.T) {
 
 	org := e.SeedOrg(t, "Dismissed Co", &e.Rep1)
 	e.WsExec(t, `UPDATE organization SET lifecycle = 'customer' WHERE id = $1`, org)
-	outbound := accountMailDirectedAt(t, owner, e.WS, "Following up", "outbound", now.AddDate(0, 0, -30))
-	linkToOrg(t, e, outbound, org)
+	outbound := AccountMailDirectedAt(t, owner, e.WS, "Following up", "outbound", now.AddDate(0, 0, -30))
+	LinkToOrg(t, e, outbound, org)
 	ghostedScan(t, e, now)
 
 	e.WsExec(t, `UPDATE signal SET status = 'dismissed' WHERE resolved_org_id = $1`, org)
@@ -124,16 +124,16 @@ func TestGhostedStaysQuietWhenTheyWroteLastOrNobodyIsWorkingTheAccount(t *testin
 	// They answered: the thread is not ghosted, it is ours to read.
 	answered := e.SeedOrg(t, "They Replied", &e.Rep1)
 	e.WsExec(t, `UPDATE organization SET lifecycle = 'opportunity' WHERE id = $1`, answered)
-	ours := accountMailDirectedAt(t, owner, e.WS, "Proposal", "outbound", now.AddDate(0, 0, -30))
-	linkToOrg(t, e, ours, answered)
-	theirs := accountMailDirectedAt(t, owner, e.WS, "Re: Proposal", "inbound", now.AddDate(0, 0, -20))
-	linkToOrg(t, e, theirs, answered)
+	ours := AccountMailDirectedAt(t, owner, e.WS, "Proposal", "outbound", now.AddDate(0, 0, -30))
+	LinkToOrg(t, e, ours, answered)
+	theirs := AccountMailDirectedAt(t, owner, e.WS, "Re: Proposal", "inbound", now.AddDate(0, 0, -20))
+	LinkToOrg(t, e, theirs, answered)
 
 	// Nobody is working this one: no open deal, and a lifecycle that is not live.
 	idle := e.SeedOrg(t, "Nobody's Account", &e.Rep1)
 	e.WsExec(t, `UPDATE organization SET lifecycle = 'disqualified' WHERE id = $1`, idle)
-	stale := accountMailDirectedAt(t, owner, e.WS, "Last try", "outbound", now.AddDate(0, 0, -60))
-	linkToOrg(t, e, stale, idle)
+	stale := AccountMailDirectedAt(t, owner, e.WS, "Last try", "outbound", now.AddDate(0, 0, -60))
+	LinkToOrg(t, e, stale, idle)
 
 	if written := ghostedScan(t, e, now); written != 0 {
 		t.Errorf("the rule fired %d times on accounts it should ignore", written)


### PR DESCRIPTION
First cut of #546. Ten files, 61 tests, out of the long pole and into their own package.

## Why a split and not a bigger budget

`internal/compose/integration` is 960 of the lane's 1828 tests and ~296s of its ~493s. The lane runs `JOBS = min(nproc, 8)` **whole packages** concurrently, so its wall clock is `max(longest package, summed/8)` = `max(296, 62)` = **296s**. The lane is bounded entirely by this one package while seven cores idle. #537's 600s budget bought headroom; it did not move that number, and nothing about a timeout can.

CI is unaffected either way — it slices by test across 12 shards, which is why CI never saw the problem and does not see this fix. This is a local inner-loop change.

## Why org360 first

Of 258 test files, this group was the only large one that is a genuinely closed seam:

| | org360 | capture | overlay | approval |
|---|---|---|---|---|
| files / tests | 10 / **61** | 20 / 57 | 12 / 35 | 9 / 21 |
| rides the booted-app fixture | **0** | 1 | 4 | 2 |
| external symbols needed | **0**\* | 7 | 9 | 8 |

\* after the four helpers below move. Every file rides the already-exported `Env` harness, so this cut needs no app-harness promotion at all — that larger refactor (462 field accesses + 158 call sites) is still ahead for the groups that do ride it, and this PR deliberately does not start it.

## What moved, and why there

Four helpers were declared inside the group but used from outside it, so they could not simply travel with it. They go to the harness, beside the seeding vocabulary they belong to: `LinkToOrg`, `Employ`, `AccountMailDirectedAt`, `AgentWithOrgRead`.

The rep fixture behind the last one lands as **`AccountRepPerms`**, not merged into the existing `RepPerms`. They are different grants — `RepPerms` is person/deal/pipeline; this one adds the organization, its activities, and the tag/list chips. Folding them together would have silently widened every suite that reads `RepPerms` as *a bounded rep*, which is exactly what several of them are asserting.

## Two gate-forced consequences, fixed not waived

- **`harness.go` crossed the 500-line cap.** The row-seeding helpers become `seed.go`. One concept per file, and the seeding vocabulary can now grow without growing the harness. Adding a length waiver for a file I had just grown would have been the wrong direction.
- **`TestEveryIdentityInsertGoesThroughTheChokepoint` enrolls sanctioned mint sites by path**, so the waiver follows the seeding code to its new file. Worth noting that the fitness test named the move within seconds — including that the old waiver now matched nothing. Working as designed.

Also constified `objPerson` / `objActivity`: strict lint applies the full ruleset to moved lines, and `goconst` fired once they were re-seen as new. Same shape as `platform/auth/linkscope.go`'s `tablePerson`.

## Verification

- `make check-backend` green; `make craft-static` 0 findings across backend/extensions/fixtures.
- `go vet -tags=integration ./internal/compose/integration/...` clean for both packages.
- `go list -tags=integration` confirms the lane now sees two packages where it saw one: `integration` (248 test files) and `integration/org360` (10) — a second scheduling slot, picked up by discovery with no script change.

**Not run:** the integration lane itself. It rebuilds the shared migrated template and a parallel session on this machine is working in the same tree; CI's shards are the check that matters for a move like this, since the transformation is name-qualification and file relocation with no logic change.

Next cuts, in the order their seams look cleanest: customfields (5 external symbols), oauth (8), then the app-harness promotion before overlay/telegram/approval can follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the Account 360 integration tests into their own package (`backend/internal/compose/integration/org360`) to add a second scheduling slot and speed up local runs. Moved shared seeders/helpers and tightened fixtures; also fixed a seeding helper for determinism and safety.

- **Refactors**
  - Created `backend/internal/compose/integration/org360` and moved 10 files (61 tests); suites now import `github.com/gradionhq/margince/backend/internal/compose/integration` and alias production `compose/org360` as `org360svc`.
  - Added `seed.go` for raw-SQL helpers (`DealFixture`, `SeedStakeholder`, `LinkActivity`, `LinkToOrg`, `AccountMailDirectedAt`, `SeedRow`); harness keeps store-mediated helpers.
  - Promoted `AgentWithOrgRead` and added `AccountRepPerms`; confined `objPerson`/`objActivity` to permission fixtures; `AgentWithOrgRead` now deep-copies its grant map.
  - Kept `employ` in the `org360` package; clarified when a suite group earns its own package.

- **Bug Fixes**
  - One timeout rule for whole-package runs via `resolve_it_timeout` (600s) used by both integration test lanes.
  - `SeedStakeholder` now pins `created_at` and binds `direction` to avoid clock flakiness and SQL injection; identity-mint waiver path updated to `internal/compose/integration/seed.go`.
  - Reverted an accidental `Employ` export; `orgask` tests now use `AgentWithOrgRead`.

<sup>Written for commit d94d71c0c9e594b9810069f47f9f5f5860c8b645. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/556?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Test Improvements**
  - Expanded integration-test coverage for account timelines, graphs, permissions, suggestions, visits, signals, and related scenarios.
  - Added shared test fixtures for deals, stakeholders, activities, employment, and directed account mail.

- **Reliability**
  - Increased the default integration-test timeout from 300 to 600 seconds.
  - Added configurable timeout validation through `INTEGRATION_TIMEOUT`.
  - Improved integration-test cost reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->