### PR TITLE
feat(tenancy): every transaction can bind the installation, not just a request that carries it (ADR-0091 §9 step 3)

### DIFF
--- a/backend/internal/compose/installation.go
+++ b/backend/internal/compose/installation.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/modules/consent"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
 	"github.com/gradionhq/margince/backend/internal/modules/identity"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/platform/deployconfig"
 	"github.com/gradionhq/margince/backend/internal/platform/settings"
@@ -66,6 +67,13 @@ func EnsureInstallation(ctx context.Context, pool *pgxpool.Pool, log *slog.Logge
 	if err != nil {
 		return err
 	}
+	// Name the singleton every transaction in this process binds (ADR-0091 §9
+	// step 3). Until now a workspace reached the database only by riding a
+	// request context; a worker loop without one had to bind the GUC itself.
+	// Set here, at the one point that has resolved the installation and before
+	// any request or job is served.
+	database.BindInstallation(wsID.UUID)
+
 	if created {
 		log.Info("installation bootstrapped", "workspace_id", wsID.String(), "organization", cfg.Organization.Name)
 	} else {

--- a/backend/internal/platform/database/database.go
+++ b/backend/internal/platform/database/database.go
@@ -12,11 +12,13 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
@@ -83,9 +85,57 @@ func NewPool(ctx context.Context, dsn string) (*pgxpool.Pool, error) {
 	return pool, nil
 }
 
-// ErrNoWorkspace means a domain query was attempted outside a workspace
-// context — a programming error, surfaced before any SQL runs.
+// ErrNoWorkspace means a domain query was attempted with no workspace to bind
+// — before bootstrap has resolved the installation, or from a context that
+// carries none while none is bound process-wide. Surfaced before any SQL runs.
 var ErrNoWorkspace = errors.New("pg: no workspace bound to context")
+
+// installation holds the singleton organization this process serves, resolved
+// once at boot (ADR-0061 §3). It is the fallback WithWorkspaceTx binds when a
+// context carries no workspace of its own — the first step of ADR-0091 §9,
+// which retires the per-request tenant selector without touching the schema.
+//
+// Process-global because the thing it names is: one installation serves one
+// organization, and every transaction in this process binds the same id. It is
+// written once, by the boot path, and read by every transaction after.
+//
+// Nil until BindInstallation runs, so a query before bootstrap still fails
+// loudly rather than guessing. That is deliberate: pre-bootstrap there is no
+// installation to guess AT, and the worker polls this state until the API
+// creates one.
+var installation atomic.Pointer[ids.UUID]
+
+// resolveWorkspace decides which workspace a transaction binds: the context's
+// own if it carries one, otherwise the installation this process serves.
+//
+// Named and separated because it is the decision, not a detail of opening a
+// transaction — it is what ADR-0091 §9 step 3 changes, and it is provable
+// without a database precisely because it happens before any SQL.
+func resolveWorkspace(ctx context.Context) (ids.UUID, error) {
+	if wsID, ok := principal.WorkspaceID(ctx); ok {
+		return wsID, nil
+	}
+	bound := installation.Load()
+	if bound == nil {
+		return ids.UUID{}, ErrNoWorkspace
+	}
+	return *bound, nil
+}
+
+// BindInstallation names the singleton organization every transaction in this
+// process binds. Called once, by the boot path, after the installation is
+// resolved or created.
+//
+// What this changes, stated where a reader meets it: a context that carries no
+// workspace now reads the installation's data instead of failing with
+// ErrNoWorkspace. With one tenant there is nothing to leak ACROSS — the
+// fallback can only ever bind the id every request already binds — but the
+// loud failure that used to catch a path forgetting its workspace is gone.
+// ADR-0091 §4 accepts that trade for the schema phase; it arrives here because
+// the fallback is what lets the fleet loops and their rls-exempt hatches
+// collapse. RBAC is unaffected: auth.Require gates every store entry point
+// regardless of which workspace is bound.
+func BindInstallation(wsID ids.UUID) { installation.Store(&wsID) }
 
 // WithWorkspaceTx runs fn inside a transaction whose app.workspace_id GUC
 // is SET LOCAL to the context's workspace, which is what the RLS policies
@@ -94,9 +144,9 @@ var ErrNoWorkspace = errors.New("pg: no workspace bound to context")
 // checkout (the §1.3 pool-reuse rule). Every domain read and write goes
 // through here; there is no raw-pool path for tenant data.
 func WithWorkspaceTx(ctx context.Context, pool *pgxpool.Pool, fn func(pgx.Tx) error) error {
-	wsID, ok := principal.WorkspaceID(ctx)
-	if !ok {
-		return ErrNoWorkspace
+	wsID, err := resolveWorkspace(ctx)
+	if err != nil {
+		return err
 	}
 
 	tx, err := pool.Begin(ctx)

--- a/backend/internal/platform/database/installation_test.go
+++ b/backend/internal/platform/database/installation_test.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package database
+
+// The process-wide installation binding (ADR-0091 §9 step 3): which workspace
+// a transaction binds when the context carries none.
+//
+// Both directions matter and they pull against each other. Before boot has
+// resolved an installation there is nothing to guess at, so a query must fail
+// loudly — the worker polls exactly that state until the API bootstraps. After
+// boot, a context with no workspace binds the installation rather than failing,
+// which is what lets a worker loop stop carrying a workspace it could only ever
+// have set to the same value.
+//
+// No database is needed to prove either: the decision happens before any SQL
+// runs, which is the point of resolving it there.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// bindForTest sets the process-wide installation and restores whatever was
+// there afterwards, so these cases cannot leak into each other or into the
+// integration lane running in the same binary.
+func bindForTest(t *testing.T, wsID *ids.UUID) {
+	t.Helper()
+	previous := installation.Load()
+	installation.Store(wsID)
+	t.Cleanup(func() { installation.Store(previous) })
+}
+
+func TestATransactionWithNoWorkspaceFailsBeforeBootstrap(t *testing.T) {
+	bindForTest(t, nil)
+
+	_, err := resolveWorkspace(context.Background())
+	if !errors.Is(err, ErrNoWorkspace) {
+		t.Errorf("err = %v, want ErrNoWorkspace — a query before bootstrap must not guess an installation", err)
+	}
+}
+
+func TestAContextWithNoWorkspaceBindsTheInstallationAfterBoot(t *testing.T) {
+	bound := ids.NewV7()
+	bindForTest(t, &bound)
+
+	got, err := resolveWorkspace(context.Background())
+	if err != nil {
+		t.Fatalf("a context with no workspace failed after boot bound one: %v", err)
+	}
+	if got != bound {
+		t.Errorf("resolved %v, want the bound installation %v", got, bound)
+	}
+}
+
+func TestAContextsOwnWorkspaceWinsOverTheInstallation(t *testing.T) {
+	bound := ids.NewV7()
+	bindForTest(t, &bound)
+
+	// The fallback is a fallback. A context that names a workspace binds THAT
+	// one — the property every cross-tenant isolation test depends on, and the
+	// reason this step can land while RLS is still armed.
+	other := ids.NewV7()
+	got, err := resolveWorkspace(principal.WithWorkspaceID(context.Background(), other))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != other {
+		t.Errorf("resolved %v, want the context's own workspace %v — the fallback must not override it", got, other)
+	}
+}


### PR DESCRIPTION
First slice of **ADR-0091 phase 2** — the tenancy retirement ratified upstream as A136. Deliberately small: the *decision* about which workspace a transaction binds moves, and **not one of the 910 call sites changes**.

## What changes

Today a workspace reaches the database only by riding a request context. A worker loop without one has to bind the GUC itself — which is why the fleet scans exist and why 25 sites carry an `rls-exempt` comment.

`resolveWorkspace` now takes the context's workspace when there is one, and the installation this process serves otherwise. `BindInstallation` names that installation once, at the boot path that already resolved it.

## What it costs

Stated in `database.go` where a reader meets it: a context with no workspace now reads the installation's data instead of failing with `ErrNoWorkspace`. With one tenant there is nothing to leak *across* — the fallback can only bind the id every request already binds — but the loud failure that used to catch a path forgetting its workspace is gone.

ADR-0091 §4 accepts that trade for the schema phase; it arrives here because the fallback is what lets the fleet loops collapse. **RBAC is untouched**: `auth.Require` gates every store entry point regardless of which workspace is bound.

**Pre-bootstrap still fails loudly.** There is no installation to guess at before one exists, and the worker polls exactly that state until the API creates one — so the binding is nil until boot sets it, and a query in that window errors rather than inventing an answer.

## Why `resolveWorkspace` is its own function

Because it is the thing this step changes, and because it is provable without a database: the decision happens before any SQL, which is the whole reason it can be tested at all. Three cases, all of which matter — nothing bound, nothing on the context, and a context that names its own workspace, which **must still win** or every cross-tenant isolation test would stop meaning anything.

## Sequencing

RLS stays armed and the schema is untouched, which is what ADR-0091 §9 requires of this phase: the tenant-isolation suite staying green is the proof the change was faithful, and that suite only exists until the schema phase deletes it.

Sliced this way on purpose. #520 lived long enough for `main` to move under it five times, and four of those collisions were invisible to its own gates. This one is three files.

`make check-backend` and `make craft-static` green. Integration runs first in CI (no Docker locally).

Next slices, each its own PR: collapse the fleet loops and their `rls-exempt` hatches onto the binding; then `WithInfraTx` folds into one `Tx`. #521 — moving the eight readers off `workspace.base_currency`/`timezone` — is phase 4's first step and independent of these.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let transactions bind the boot-resolved installation when no workspace is on the context (ADR-0091 §9 step 3). Requests still bind their own workspace; pre-bootstrap still fails with `ErrNoWorkspace`.

- **Refactors**
  - Added `database.BindInstallation`, called once during boot from `compose.EnsureInstallation`.
  - Introduced `resolveWorkspace` and updated `WithWorkspaceTx` to use it.
  - Added tests for pre-bootstrap failure, installation fallback, and context override.

<sup>Written for commit 700ea1db3ec8178499de2f14436d337dafc2d605. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/557?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

