### PR TITLE
fix(test-lane): a leading-zero timeout is a number, not an octal literal

### DIFF
--- a/STATUS-ARCHIVE.md
+++ b/STATUS-ARCHIVE.md
@@ -21,6 +21,40 @@
 > [CHANGELOG.md](CHANGELOG.md) and [README.md → *What works
 > today*](README.md#what-works-today).
 
+## 2026-08-07 — the integration lane's per-package timeout, and the lane it did not reach
+
+Closes #524 (#538 was the same report, closed as a duplicate of it).
+
+`internal/compose/integration` is half the lane (960 tests) and ran 258–302s
+against a 300s per-package `go test -timeout`, so it crossed the line on a
+loaded machine and under the concurrency the lane itself creates. The failure
+read as a runtime hang — a panic naming whichever test had just started at `0s`
+— rather than a package running two seconds long, and everything queued behind
+it never ran. The lane's discovery cross-check caught the thinner run, so it
+could never read as green; the cost was that a branch went red for a reason
+unrelated to its diff.
+
+CI never saw it: the matrix shards by test, twelve ways, so no shard approaches
+the bound. The exposure was the unsharded path — `make test-integration`
+locally, and `make test-it` on this one package. That is the inner loop, so the
+flake landed on whoever was iterating.
+
+#537 raised the budget to 600s and taught the cost report to print each
+package's share of it, so a margin shrinking toward nothing is visible before
+it crosses rather than after. What that left behind was the sibling call site:
+`scripts/test-integration-one.sh` spelled `-timeout=300s` inline, with no
+variable and no env override, so `make test-it` on this package still failed at
+a bound the lane it belongs to had already moved — and could not be nursed past
+it even deliberately, which is exactly when someone iterating on that package
+needs to. Both lanes now resolve the budget through one `resolve_it_timeout` in
+`scripts/lib-testdb.sh`, the file they already share.
+
+The remaining half of the problem is that a bigger budget does not stop one
+package from being the lane's long pole: the lane runs whole packages
+concurrently, so its wall clock bottoms out at the largest one no matter how
+many cores are free. That is #546, and the first cut of it (the account-360
+suites, 61 tests into their own package) shipped the same day.
+
 ## 2026-08-01 — the company page: what it says, and the logo that was never fetched
 
 Shipped on PR #356 (`feat/company-page-clarity`). The open items this work

--- a/STATUS-ARCHIVE.md
+++ b/STATUS-ARCHIVE.md
@@ -39,7 +39,7 @@ the bound. The exposure was the unsharded path — `make test-integration`
 locally, and `make test-it` on this one package. That is the inner loop, so the
 flake landed on whoever was iterating.
 
-#537 raised the budget to 600s and taught the cost report to print each
+PR #537 raised the budget to 600s and taught the cost report to print each
 package's share of it, so a margin shrinking toward nothing is visible before
 it crosses rather than after. What that left behind was the sibling call site:
 `scripts/test-integration-one.sh` spelled `-timeout=300s` inline, with no

--- a/STATUS.md
+++ b/STATUS.md
@@ -47,15 +47,9 @@ that has no meaning without Postgres.
 
 Where the cost actually is, and what is worth doing about it:
 
-- **#524** — **closed.** `internal/compose/integration` is half the lane (960
-  tests) and ran 258–302s against a 300s per-package timeout, so it flaked on a
-  loaded machine. CI shards 12 ways and never saw it; the unsharded local lane
-  and `make test-it` did. #537 raised the budget to 600s and made the cost report
-  print each package's share of it, so a margin shrinking to nothing is visible
-  before it crosses. The one-package lane kept a hardcoded `-timeout=300s` that
-  no variable could reach, which left `make test-it` on this package failing at
-  a bound the lane itself had already moved; both lanes now resolve the budget
-  through one `resolve_it_timeout` in `scripts/lib-testdb.sh`.
+- **#524** — closed; the per-package budget is 600s, both lanes resolve it
+  through one `resolve_it_timeout`, and the cost report prints each package's
+  share of it. Narrative in [STATUS-ARCHIVE.md](STATUS-ARCHIVE.md).
 - **#539** — that package's setup forks about five Postgres backends per test.
   Sharing them measured ~18% (170.9s vs a 209.6s baseline) and is **blocked**:
   the harness drops `cf_*` columns between tests, so a pooled connection

--- a/scripts/lib-testdb.sh
+++ b/scripts/lib-testdb.sh
@@ -238,7 +238,11 @@ resolve_it_timeout() {
     echo "FAIL: INTEGRATION_TIMEOUT must be <seconds>s (e.g. 600s), got '${IT_TIMEOUT}'"
     exit 1
   fi
-  if (( ${IT_TIMEOUT%s} == 0 )); then
+  # Matched, not evaluated: `(( 08 == 0 ))` reads a leading zero as octal and
+  # fails with "value too great for base", which leaves 08s and 09s accepted
+  # behind a bash error nobody asked about. A zero budget is a string question,
+  # so ask it as one.
+  if [[ "${IT_TIMEOUT%s}" =~ ^0+$ ]]; then
     echo "FAIL: INTEGRATION_TIMEOUT must be greater than 0s — go test reads 0 as NO timeout, which "\
 "removes the per-package guard rather than widening it"
     exit 1


### PR DESCRIPTION
Two review findings raised on #556 that actually belong to `main` — #556's branch still carried the #524 commit as an ancestor (main took it as a squash), so the bots reviewed those files there. #556 has been rebased and no longer touches them; this PR carries the fixes.

## The bug

```
$ INTEGRATION_TIMEOUT=08s make test-it DIR=…
lib-testdb.sh: line 241: 08 == 0 : 08: value too great for base (error token is "08")
```

`08s` passes the `^[0-9]+s$` format check, then reaches `(( ${IT_TIMEOUT%s} == 0 ))`, where bash reads the leading zero as an octal literal. The arithmetic fails, which makes the `if` false, so **the value is accepted anyway** — the lane runs on exactly the budget the caller asked for, behind an error message about nothing they did wrong. `08s` and `09s` are the two that trip it; `007s` is octal-legal and passes silently.

Whether the budget is zero is a question about the string, so it is now asked as one. `0s` and `000s` still refuse, for the reason the surrounding comment already gives: `go test -timeout 0` disables the timeout rather than widening it.

Verified with the resolver suite extended to cover the cases it previously did not:

```
  ok   08s accepted                       0|08s
  ok   09s accepted                       0|09s
  ok   060s accepted                      0|060s
  ok   000s rejected                      1|FAIL: INTEGRATION_TIMEOUT must be greater tha
```

17 assertions, all passing; the 13 pre-existing ones are unchanged.

## The STATUS.md move

STATUS.md's header says it carries open work only, and that a closed item's narrative moves to STATUS-ARCHIVE.md rather than growing in place. I marked #524 closed and then grew its entry, which is the opposite. The narrative moves to the archive (append-at-top, as that file prescribes) and the open lane keeps a three-line pointer.

Credit: both findings were raised by CodeRabbit and cubic on #556.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mis-parsing of leading-zero `INTEGRATION_TIMEOUT` in the test lane; moves the closed #524 narrative to `STATUS-ARCHIVE.md` and fixes a markdownlint warning.

- **Bug Fixes**
  - In `scripts/lib-testdb.sh` (`resolve_it_timeout`), replace the numeric zero check with a string match to avoid octal parsing. `08s`/`09s` now accepted; `0s`/`000s` still rejected to avoid disabling `go test -timeout`.

- **Refactors**
  - Moved the #524 write-up from `STATUS.md` to `STATUS-ARCHIVE.md` and left a short pointer; fixed markdownlint MD018 in the archive.

<sup>Written for commit b3ecba97dc47ff89f8846c7ae8c15ab9c0f9beae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved integration-test timeout handling for values such as `08s` and `09s`.
  * Continued rejecting zero-second timeout values.
  * Standardized package-level timeout resolution across test lanes.

* **Documentation**
  * Updated testing status information and archived details about a previous integration-test timeout incident.
  * Documented package budget allocation and ongoing long-running test considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->