### PR TITLE
refactor(test): the search fixture becomes importable, like Env before it

### DIFF
--- a/backend/integrationmigrateonce_test.go
+++ b/backend/integrationmigrateonce_test.go
@@ -50,6 +50,13 @@ import (
 // than this gate owns today.
 const migrationsPackage = "migrations"
 
+// testdbPackage implements the migrate-once mechanism every suite is required to
+// ride, so it is where dbmigrate.Up is SUPPOSED to be called. Excluded by rule
+// rather than waived, for the same reason migrationsPackage is: a waiver would
+// read as "this one is allowed to misbehave" when in fact it is the definition of
+// behaving. Only reachable now that this gate walks non-test files too.
+const testdbPackage = "internal/platform/testdb"
+
 // inlineMigrators are the suites outside migrationsPackage ratified to migrate
 // on their own, each bound to what the exception costs.
 var inlineMigrators = gatekit.Waive(map[string]string{
@@ -63,8 +70,17 @@ func TestIntegrationSuitesMigrateOncePerProcess(t *testing.T) {
 	var offenders, inMigrations []string
 	fset := token.NewFileSet()
 	err := filepath.WalkDir(".", func(path string, d fs.DirEntry, err error) error {
-		if err != nil || d.IsDir() || !strings.HasSuffix(path, "_test.go") {
+		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".go") {
 			return err
+		}
+		// Every file the lane compiles, not only the _test.go ones. A shared
+		// fixture that moves into a non-test file so sibling packages can import
+		// it would otherwise walk straight out of this gate's reach while still
+		// being the thing that migrates — and the gate would keep passing,
+		// covering less, saying nothing. Membership is the build tag, which is
+		// what actually decides whether the lane runs the file.
+		if !strings.HasSuffix(path, "_test.go") && !isIntegrationTagged(path) {
+			return nil
 		}
 		path = filepath.ToSlash(path)
 		file, err := parser.ParseFile(fset, path, nil, 0)
@@ -76,6 +92,9 @@ func TestIntegrationSuitesMigrateOncePerProcess(t *testing.T) {
 		}
 		if strings.HasPrefix(path, migrationsPackage+"/") {
 			inMigrations = append(inMigrations, path)
+			return nil
+		}
+		if strings.HasPrefix(path, testdbPackage+"/") {
 			return nil
 		}
 		if !inlineMigrators.Waived(t, path) {

--- a/backend/integrationmigrateonce_test.go
+++ b/backend/integrationmigrateonce_test.go
@@ -3,7 +3,7 @@
 
 package backendarch
 
-// Migrate-once discipline for every integration suite in the module, as a
+// Migrate-once discipline for everything the integration lane compiles, as a
 // fitness function. A suite migrates the schema once per test process
 // (internal/platform/testdb.EnsureSchema) and resets between tests with a fast
 // data-only reset (testdb.Reset); one that instead runs its own DROP SCHEMA +
@@ -13,7 +13,14 @@ package backendarch
 // subtree is where the obligated code lives, and that second claim is the one
 // nothing checks.
 //
-// Any test file that REFERENCES the migrate entry point is caught, not only one
+// Every file the lane COMPILES is judged, not only the _test.go ones: a shared
+// fixture that moves into a build-tagged non-test file so sibling packages can
+// import it is still the thing that migrates, and keying on the filename suffix
+// would let it walk out of reach here while the gate kept passing. Membership is
+// therefore the build tag, which is what actually decides whether the lane
+// compiles a file.
+//
+// Any such file that REFERENCES the migrate entry point is caught, not only one
 // that applies it: `up := dm.Up; up(...)` migrates just as much as `dm.Up(...)`,
 // and a file has no reason to hold the migrator except to run it. That closes the
 // function-value route without type-aware analysis, and the qualifier is resolved
@@ -103,12 +110,13 @@ func TestIntegrationSuitesMigrateOncePerProcess(t *testing.T) {
 		return nil
 	})
 	if err != nil {
-		t.Fatalf("walking the module for test files: %v", err)
+		t.Fatalf("walking the module for integration-lane files: %v", err)
 	}
 
 	if len(offenders) > 0 {
-		t.Errorf("%d integration suite(s) migrate inline instead of riding testdb.EnsureSchema — "+
-			"replace the DROP SCHEMA + dbmigrate.Up block with testdb.EnsureSchema + testdb.Reset "+
+		t.Errorf("%d integration-lane file(s) migrate inline instead of riding testdb.EnsureSchema — "+
+			"a suite or a shared fixture in a build-tagged non-test file counts alike. Replace the "+
+			"DROP SCHEMA + dbmigrate.Up block with testdb.EnsureSchema + testdb.Reset "+
 			"(see internal/compose/integration/harness.go):\n\t%s",
 			len(offenders), strings.Join(offenders, "\n\t"))
 	}

--- a/backend/internal/compose/integration/binding_integration_test.go
+++ b/backend/internal/compose/integration/binding_integration_test.go
@@ -23,15 +23,15 @@ import (
 )
 
 func TestSeedBindingOnEmptyStoreHasNoFirstBootWart(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	ctx := context.Background()
 	const identity = "fake/seed@1024"
 
-	if err := e.store.SeedBinding(ctx, identity); err != nil {
+	if err := e.Store.SeedBinding(ctx, identity); err != nil {
 		t.Fatalf("SeedBinding: %v", err)
 	}
 
-	populated, status, _, err := e.store.PopulatedIdentity(ctx)
+	populated, status, _, err := e.Store.PopulatedIdentity(ctx)
 	if err != nil {
 		t.Fatalf("PopulatedIdentity: %v", err)
 	}
@@ -42,7 +42,7 @@ func TestSeedBindingOnEmptyStoreHasNoFirstBootWart(t *testing.T) {
 		t.Fatalf("status = %q, want idle", status)
 	}
 
-	needed, err := e.store.ReindexNeeded(ctx, identity)
+	needed, err := e.Store.ReindexNeeded(ctx, identity)
 	if err != nil {
 		t.Fatalf("ReindexNeeded: %v", err)
 	}
@@ -52,11 +52,11 @@ func TestSeedBindingOnEmptyStoreHasNoFirstBootWart(t *testing.T) {
 }
 
 func TestReindexNeededAfterStaleIdentityRow(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	ctx := context.Background()
 	const identity = "fake/current@1024"
 
-	if err := e.store.SeedBinding(ctx, identity); err != nil {
+	if err := e.Store.SeedBinding(ctx, identity); err != nil {
 		t.Fatalf("SeedBinding: %v", err)
 	}
 
@@ -64,14 +64,14 @@ func TestReindexNeededAfterStaleIdentityRow(t *testing.T) {
 	// A row stamped under a DIFFERENT identity than currentIdentity — the
 	// entity has an embedding row, just not a current one, so it must
 	// still count as pending (the swap case, distinct from "no row at all").
-	if _, err := e.owner.Exec(ctx, `
+	if _, err := e.Owner.Exec(ctx, `
 		INSERT INTO embedding (workspace_id, entity_type, entity_id, chunk_ix, chunk_hash, model, embedding)
 		VALUES ($1, 'person', $2, 0, 'stale-hash', 'fake/old@1024', '[1,2,3]'::vector)`,
 		e.WS, personID); err != nil {
 		t.Fatalf("seeding the stale-identity row: %v", err)
 	}
 
-	pending, err := e.store.EntitiesPending(ctx, identity)
+	pending, err := e.Store.EntitiesPending(ctx, identity)
 	if err != nil {
 		t.Fatalf("EntitiesPending: %v", err)
 	}
@@ -79,7 +79,7 @@ func TestReindexNeededAfterStaleIdentityRow(t *testing.T) {
 		t.Fatalf("EntitiesPending = %d, want 1 (the stale-identity row must count as pending)", pending)
 	}
 
-	needed, err := e.store.ReindexNeeded(ctx, identity)
+	needed, err := e.Store.ReindexNeeded(ctx, identity)
 	if err != nil {
 		t.Fatalf("ReindexNeeded: %v", err)
 	}
@@ -89,18 +89,18 @@ func TestReindexNeededAfterStaleIdentityRow(t *testing.T) {
 }
 
 func TestSeedBindingIsIdempotentAndConcurrentSafe(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	ctx := context.Background()
 	const first = "fake/first@1024"
 	const second = "fake/second@1024"
 
-	if err := e.store.SeedBinding(ctx, first); err != nil {
+	if err := e.Store.SeedBinding(ctx, first); err != nil {
 		t.Fatalf("first SeedBinding: %v", err)
 	}
-	if err := e.store.SeedBinding(ctx, second); err != nil {
+	if err := e.Store.SeedBinding(ctx, second); err != nil {
 		t.Fatalf("second SeedBinding must no-op, not error: %v", err)
 	}
-	populated, _, _, err := e.store.PopulatedIdentity(ctx)
+	populated, _, _, err := e.Store.PopulatedIdentity(ctx)
 	if err != nil {
 		t.Fatalf("PopulatedIdentity: %v", err)
 	}
@@ -110,14 +110,14 @@ func TestSeedBindingIsIdempotentAndConcurrentSafe(t *testing.T) {
 
 	// Two concurrent seeds against a fresh (unseeded) store both succeed —
 	// ON CONFLICT DO NOTHING arbitrates the race inside Postgres, not here.
-	e2 := setupSearch(t)
+	e2 := SetupSearch(t)
 	var wg sync.WaitGroup
 	errs := make([]error, 2)
 	for i := range errs {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			errs[i] = e2.store.SeedBinding(context.Background(), "fake/concurrent@1024")
+			errs[i] = e2.Store.SeedBinding(context.Background(), "fake/concurrent@1024")
 		}(i)
 	}
 	wg.Wait()
@@ -135,15 +135,15 @@ func TestSeedBindingIsIdempotentAndConcurrentSafe(t *testing.T) {
 // second claim, and it is refused by name (ErrReembeddingInFlight) rather than
 // by a bare zero row count that could equally mean an unseeded marker.
 func TestClaimAndEnqueueReembeddingIsSingleFlightOnTheRun(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	ctx := context.Background()
 	const identity = "fake/claim@1024"
-	if err := e.store.SeedBinding(ctx, identity); err != nil {
+	if err := e.Store.SeedBinding(ctx, identity); err != nil {
 		t.Fatalf("SeedBinding: %v", err)
 	}
 
 	var ran bool
-	err := e.store.ClaimAndEnqueueReembedding(ctx, claimOf(identity), func(tx pgx.Tx) error {
+	err := e.Store.ClaimAndEnqueueReembedding(ctx, claimOf(identity), func(tx pgx.Tx) error {
 		ran = true
 		return nil
 	})
@@ -153,7 +153,7 @@ func TestClaimAndEnqueueReembeddingIsSingleFlightOnTheRun(t *testing.T) {
 	if !ran {
 		t.Fatal("the enqueue callback must run inside the claim transaction")
 	}
-	_, status, _, err := e.store.PopulatedIdentity(ctx)
+	_, status, _, err := e.Store.PopulatedIdentity(ctx)
 	if err != nil {
 		t.Fatalf("PopulatedIdentity: %v", err)
 	}
@@ -162,7 +162,7 @@ func TestClaimAndEnqueueReembeddingIsSingleFlightOnTheRun(t *testing.T) {
 	}
 
 	ran = false
-	err = e.store.ClaimAndEnqueueReembedding(ctx, claimOf(identity), func(tx pgx.Tx) error {
+	err = e.Store.ClaimAndEnqueueReembedding(ctx, claimOf(identity), func(tx pgx.Tx) error {
 		ran = true
 		return nil
 	})
@@ -179,13 +179,13 @@ func TestClaimAndEnqueueReembeddingIsSingleFlightOnTheRun(t *testing.T) {
 // holding the marker, and the two answer different status codes — so they must
 // not collapse into one error.
 //
-// Its own test because setupSearch RESETS the database. Asserting this inside
+// Its own test because SetupSearch RESETS the database. Asserting this inside
 // the single-flight test would mean tearing down the very claim that test is
 // about, and would hold only for as long as it stayed the last assertion in the
 // function.
 func TestClaimAndEnqueueReembeddingNamesAnUnseededMarker(t *testing.T) {
-	e := setupSearch(t)
-	err := e.store.ClaimAndEnqueueReembedding(context.Background(),
+	e := SetupSearch(t)
+	err := e.Store.ClaimAndEnqueueReembedding(context.Background(),
 		claimOf("fake/unseeded@1024"), func(pgx.Tx) error { return nil })
 	if !errors.Is(err, search.ErrBindingNotSeeded) {
 		t.Fatalf("claim against an unseeded marker = %v, want ErrBindingNotSeeded", err)
@@ -193,15 +193,15 @@ func TestClaimAndEnqueueReembeddingNamesAnUnseededMarker(t *testing.T) {
 }
 
 func TestClaimAndEnqueueReembeddingRollsBackCASOnEnqueueError(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	ctx := context.Background()
 	const identity = "fake/rollback@1024"
-	if err := e.store.SeedBinding(ctx, identity); err != nil {
+	if err := e.Store.SeedBinding(ctx, identity); err != nil {
 		t.Fatalf("SeedBinding: %v", err)
 	}
 
 	enqueueErr := errors.New("enqueue exploded")
-	err := e.store.ClaimAndEnqueueReembedding(ctx, claimOf(identity), func(tx pgx.Tx) error {
+	err := e.Store.ClaimAndEnqueueReembedding(ctx, claimOf(identity), func(tx pgx.Tx) error {
 		return enqueueErr
 	})
 	if !errors.Is(err, enqueueErr) {
@@ -210,7 +210,7 @@ func TestClaimAndEnqueueReembeddingRollsBackCASOnEnqueueError(t *testing.T) {
 
 	// The CAS must have rolled back with the failed callback — status
 	// stays idle, never left stranded in reembedding with no live job.
-	_, status, _, err := e.store.PopulatedIdentity(ctx)
+	_, status, _, err := e.Store.PopulatedIdentity(ctx)
 	if err != nil {
 		t.Fatalf("PopulatedIdentity: %v", err)
 	}
@@ -231,20 +231,20 @@ func TestClaimAndEnqueueReembeddingRollsBackCASOnEnqueueError(t *testing.T) {
 // so populated_identity means "last released under" (search's
 // releaseReembeddingTx).
 func TestReleaseReembeddingOnlyEverActsOnItsOwnRun(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	ctx := context.Background()
 	const original = "fake/orig@1024"
 	const claimed = "fake/claimed@1024"
-	if err := e.store.SeedBinding(ctx, original); err != nil {
+	if err := e.Store.SeedBinding(ctx, original); err != nil {
 		t.Fatalf("SeedBinding: %v", err)
 	}
 
 	// Releasing while no run holds the marker must be a no-op: nothing was
 	// claimed, so nothing should read populated under a never-run job's identity.
-	if err := e.store.ReleaseReembedding(ctx, ids.NewV7()); err != nil {
+	if err := e.Store.ReleaseReembedding(ctx, ids.NewV7()); err != nil {
 		t.Fatalf("ReleaseReembedding with no run in flight: %v", err)
 	}
-	populated, status, _, err := e.store.PopulatedIdentity(ctx)
+	populated, status, _, err := e.Store.PopulatedIdentity(ctx)
 	if err != nil {
 		t.Fatalf("PopulatedIdentity: %v", err)
 	}
@@ -253,13 +253,13 @@ func TestReleaseReembeddingOnlyEverActsOnItsOwnRun(t *testing.T) {
 	}
 
 	run := ids.NewV7()
-	if err := e.store.ClaimAndEnqueueReembedding(ctx, search.ReembedClaim{Run: run, TargetIdentity: claimed}, func(tx pgx.Tx) error { return nil }); err != nil {
+	if err := e.Store.ClaimAndEnqueueReembedding(ctx, search.ReembedClaim{Run: run, TargetIdentity: claimed}, func(tx pgx.Tx) error { return nil }); err != nil {
 		t.Fatalf("ClaimAndEnqueueReembedding: %v", err)
 	}
-	if err := e.store.ReleaseReembedding(ctx, ids.NewV7()); err != nil {
+	if err := e.Store.ReleaseReembedding(ctx, ids.NewV7()); err != nil {
 		t.Fatalf("ReleaseReembedding under a run that does not hold the marker: %v", err)
 	}
-	populated, status, _, err = e.store.PopulatedIdentity(ctx)
+	populated, status, _, err = e.Store.PopulatedIdentity(ctx)
 	if err != nil {
 		t.Fatalf("PopulatedIdentity: %v", err)
 	}
@@ -267,10 +267,10 @@ func TestReleaseReembeddingOnlyEverActsOnItsOwnRun(t *testing.T) {
 		t.Fatalf("a run that does not hold the marker released it: populated=%q status=%q", populated, status)
 	}
 
-	if err := e.store.ReleaseReembedding(ctx, run); err != nil {
+	if err := e.Store.ReleaseReembedding(ctx, run); err != nil {
 		t.Fatalf("ReleaseReembedding from the claiming run: %v", err)
 	}
-	populated, status, _, err = e.store.PopulatedIdentity(ctx)
+	populated, status, _, err = e.Store.PopulatedIdentity(ctx)
 	if err != nil {
 		t.Fatalf("PopulatedIdentity: %v", err)
 	}
@@ -283,17 +283,17 @@ func TestReleaseReembeddingOnlyEverActsOnItsOwnRun(t *testing.T) {
 }
 
 func TestReindexNeededOnDimsOnlyDifference(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	ctx := context.Background()
 	// Same provider/model, different width — a real operator scenario
 	// (widening the embed dimension), not a different model at all.
 	const populated = "gemini/embed-001@1024"
 	const configured = "gemini/embed-001@768"
 
-	if err := e.store.SeedBinding(ctx, populated); err != nil {
+	if err := e.Store.SeedBinding(ctx, populated); err != nil {
 		t.Fatalf("SeedBinding: %v", err)
 	}
-	needed, err := e.store.ReindexNeeded(ctx, configured)
+	needed, err := e.Store.ReindexNeeded(ctx, configured)
 	if err != nil {
 		t.Fatalf("ReindexNeeded: %v", err)
 	}
@@ -303,17 +303,17 @@ func TestReindexNeededOnDimsOnlyDifference(t *testing.T) {
 }
 
 func TestPendingAndTokenSumAggregateAcrossWorkspaces(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	ctx := context.Background()
 	const identity = "fake/agg@1024"
-	if err := e.store.SeedBinding(ctx, identity); err != nil {
+	if err := e.Store.SeedBinding(ctx, identity); err != nil {
 		t.Fatalf("SeedBinding: %v", err)
 	}
 
 	// A sibling workspace search's own setup does not create — proves the
 	// fleet enumeration (not just the harness's one workspace) is real.
 	ws2 := ids.NewV7()
-	if _, err := e.owner.Exec(ctx, `INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Search Two', 'search-two', 'EUR')`, ws2); err != nil {
+	if _, err := e.Owner.Exec(ctx, `INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Search Two', 'search-two', 'EUR')`, ws2); err != nil {
 		t.Fatalf("seeding the sibling workspace: %v", err)
 	}
 
@@ -328,7 +328,7 @@ func TestPendingAndTokenSumAggregateAcrossWorkspaces(t *testing.T) {
 	e.seed(t, `INSERT INTO lead (id, workspace_id, source, captured_by) VALUES ($1, $2, 'manual', 'human:x')`)
 	// Already covered at the current identity: must not count as pending.
 	coveredID := e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Already Covered', 'manual', 'human:x')`)
-	if _, err := e.owner.Exec(ctx, `
+	if _, err := e.Owner.Exec(ctx, `
 		INSERT INTO embedding (workspace_id, entity_type, entity_id, chunk_ix, chunk_hash, model, embedding)
 		VALUES ($1, 'person', $2, 0, 'covered-hash', $3, '[1,2,3]'::vector)`,
 		e.WS, coveredID, identity); err != nil {
@@ -336,20 +336,20 @@ func TestPendingAndTokenSumAggregateAcrossWorkspaces(t *testing.T) {
 	}
 
 	ws2PersonID := ids.NewV7()
-	if _, err := e.owner.Exec(ctx, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, $3, 'manual', 'human:x')`,
+	if _, err := e.Owner.Exec(ctx, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, $3, 'manual', 'human:x')`,
 		ws2PersonID, ws2, nameTwo); err != nil {
 		t.Fatalf("seeding the sibling workspace's person: %v", err)
 	}
 
-	counts, err := e.store.PendingByWorkspace(ctx, identity)
+	counts, err := e.Store.PendingByWorkspace(ctx, identity)
 	if err != nil {
 		t.Fatalf("PendingByWorkspace: %v", err)
 	}
-	tokens, err := e.store.TokenSumByWorkspace(ctx, identity)
+	tokens, err := e.Store.TokenSumByWorkspace(ctx, identity)
 	if err != nil {
 		t.Fatalf("TokenSumByWorkspace: %v", err)
 	}
-	total, err := e.store.EntitiesPending(ctx, identity)
+	total, err := e.Store.EntitiesPending(ctx, identity)
 	if err != nil {
 		t.Fatalf("EntitiesPending: %v", err)
 	}

--- a/backend/internal/compose/integration/binding_integration_test.go
+++ b/backend/internal/compose/integration/binding_integration_test.go
@@ -60,7 +60,7 @@ func TestReindexNeededAfterStaleIdentityRow(t *testing.T) {
 		t.Fatalf("SeedBinding: %v", err)
 	}
 
-	personID := e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Stale Row Person', 'manual', 'human:x')`)
+	personID := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Stale Row Person', 'manual', 'human:x')`)
 	// A row stamped under a DIFFERENT identity than currentIdentity — the
 	// entity has an embedding row, just not a current one, so it must
 	// still count as pending (the swap case, distinct from "no row at all").
@@ -321,13 +321,13 @@ func TestPendingAndTokenSumAggregateAcrossWorkspaces(t *testing.T) {
 	const nameOrg = "Pending Org"
 	const nameTwo = "Pending Two"
 
-	e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, '`+nameOne+`', 'manual', 'human:x')`)
-	e.seed(t, `INSERT INTO organization (id, workspace_id, display_name, source, captured_by) VALUES ($1, $2, '`+nameOrg+`', 'manual', 'human:x')`)
+	e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, '`+nameOne+`', 'manual', 'human:x')`)
+	e.Seed(t, `INSERT INTO organization (id, workspace_id, display_name, source, captured_by) VALUES ($1, $2, '`+nameOrg+`', 'manual', 'human:x')`)
 	// A lead with every text-bearing column NULL: concat_ws collapses to
 	// '', so it must NOT count as pending — the non-empty qualifier.
-	e.seed(t, `INSERT INTO lead (id, workspace_id, source, captured_by) VALUES ($1, $2, 'manual', 'human:x')`)
+	e.Seed(t, `INSERT INTO lead (id, workspace_id, source, captured_by) VALUES ($1, $2, 'manual', 'human:x')`)
 	// Already covered at the current identity: must not count as pending.
-	coveredID := e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Already Covered', 'manual', 'human:x')`)
+	coveredID := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Already Covered', 'manual', 'human:x')`)
 	if _, err := e.Owner.Exec(ctx, `
 		INSERT INTO embedding (workspace_id, entity_type, entity_id, chunk_ix, chunk_hash, model, embedding)
 		VALUES ($1, 'person', $2, 0, 'covered-hash', $3, '[1,2,3]'::vector)`,

--- a/backend/internal/compose/integration/capture_account_rebind_integration_test.go
+++ b/backend/internal/compose/integration/capture_account_rebind_integration_test.go
@@ -54,7 +54,7 @@ func (c *accountBoundConnector) BackfillPage(ctx context.Context, auth connector
 // reconnectAs while the page is out at the provider, and returns the run's row
 // afterwards. It is the whole race in one helper: the only difference between a
 // reauth and a rebind is whether the second grant names the same mailbox.
-func startImportReconnectingMidPage(t *testing.T, e *searchEnv, account, reconnectAs string) (status string, scanned int, cursor []byte) {
+func startImportReconnectingMidPage(t *testing.T, e *SearchEnv, account, reconnectAs string) (status string, scanned int, cursor []byte) {
 	t.Helper()
 	seedCaptureRole(t, e)
 	registry := newTestCaptureRegistry(e, newTestKeyvault(t, e))
@@ -85,7 +85,7 @@ func startImportReconnectingMidPage(t *testing.T, e *searchEnv, account, reconne
 // to the same account and the same import it always did — fencing it off would
 // report the import the human was told to repair as "cancelled".
 func TestAReauthOfTheSameAccountLetsAnInFlightPageCommit(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	status, scanned, cursor := startImportReconnectingMidPage(t, e, "same@example.com", "same@example.com")
 	if status != "running" {
 		t.Fatalf("status = %s, want running — a routine reauth must not end the import it was meant to keep alive", status)
@@ -99,7 +99,7 @@ func TestAReauthOfTheSameAccountLetsAnInFlightPageCommit(t *testing.T) {
 // a mailbox this connection no longer points at, so its counters and its cursor
 // are not history the new account gets to inherit.
 func TestRebindingToAnotherAccountFencesAnInFlightPage(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	status, scanned, cursor := startImportReconnectingMidPage(t, e, "first@example.com", "second@example.com")
 	if scanned != 0 || len(cursor) != 0 {
 		t.Fatalf("the second mailbox was credited with the first one's page: scanned=%d cursor=%q", scanned, cursor)
@@ -111,7 +111,7 @@ func TestRebindingToAnotherAccountFencesAnInFlightPage(t *testing.T) {
 
 // readConnectionAccount reads what a connection is currently bound to and where
 // it is up to.
-func readConnectionAccount(t *testing.T, e *searchEnv, connID ids.UUID) (label *string, cursor []byte) {
+func readConnectionAccount(t *testing.T, e *SearchEnv, connID ids.UUID) (label *string, cursor []byte) {
 	t.Helper()
 	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		return tx.QueryRow(e.Admin(), `
@@ -126,7 +126,7 @@ func readConnectionAccount(t *testing.T, e *searchEnv, connID ids.UUID) (label *
 
 // connectAndSync grants the provider under the given account and pulls once, so
 // the connection carries a real watermark before anything reconnects.
-func connectAndSync(t *testing.T, registry *capture.Registry, e *searchEnv, account string) ids.UUID {
+func connectAndSync(t *testing.T, registry *capture.Registry, e *SearchEnv, account string) ids.UUID {
 	t.Helper()
 	grantCtx := e.humanWithScopes(e.Rep1, []principal.Scope{principal.ScopeRead})
 	connID, err := registry.Connect(grantCtx, "gmail", connector.Auth(account))
@@ -143,7 +143,7 @@ func connectAndSync(t *testing.T, registry *capture.Registry, e *searchEnv, acco
 }
 
 func TestReconnectingADifferentAccountDropsTheFirstAccountsWatermark(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	seedCaptureRole(t, e)
 	registry := newTestCaptureRegistry(e, newTestKeyvault(t, e))
 	registry.Register(&accountBoundConnector{pagedConnector: &pagedConnector{messages: 5, pageSize: 10}})
@@ -165,7 +165,7 @@ func TestReconnectingADifferentAccountDropsTheFirstAccountsWatermark(t *testing.
 }
 
 func TestReconnectingTheSameAccountKeepsItsWatermark(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	seedCaptureRole(t, e)
 	registry := newTestCaptureRegistry(e, newTestKeyvault(t, e))
 	registry.Register(&accountBoundConnector{pagedConnector: &pagedConnector{messages: 5, pageSize: 10}})
@@ -183,7 +183,7 @@ func TestReconnectingTheSameAccountKeepsItsWatermark(t *testing.T) {
 }
 
 func TestANewAccountMayImportANarrowerWindowThanTheOldOne(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	seedCaptureRole(t, e)
 	registry := newTestCaptureRegistry(e, newTestKeyvault(t, e))
 	registry.Register(&accountBoundConnector{pagedConnector: &pagedConnector{messages: 5, pageSize: 10}})

--- a/backend/internal/compose/integration/capture_authority_integration_test.go
+++ b/backend/internal/compose/integration/capture_authority_integration_test.go
@@ -27,14 +27,14 @@ import (
 )
 
 func TestConnectRefusesAGrantFromADeactivatedHuman(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	// The production resolver, not the always-live harness fake: liveness is
 	// exactly what is under test.
 	registry := capture.NewRegistry(e.Pool, capture.NewSink(e.Pool), identity.NewService(e.Pool), newTestKeyvault(t, e))
 	registry.Register(&scopeFake{})
 	grantCtx := e.humanWithScopes(e.Rep1, []principal.Scope{principal.ScopeRead})
 
-	if _, err := e.owner.Exec(context.Background(),
+	if _, err := e.Owner.Exec(context.Background(),
 		`UPDATE app_user SET status = 'deactivated' WHERE id = $1`, e.Rep1); err != nil {
 		t.Fatal(err)
 	}
@@ -46,7 +46,7 @@ func TestConnectRefusesAGrantFromADeactivatedHuman(t *testing.T) {
 		t.Errorf("the refused grant persisted %d connections, want 0", n)
 	}
 	var sealed int
-	if err := e.owner.QueryRow(context.Background(), `SELECT count(*) FROM vault_secret`).Scan(&sealed); err != nil {
+	if err := e.Owner.QueryRow(context.Background(), `SELECT count(*) FROM vault_secret`).Scan(&sealed); err != nil {
 		t.Fatal(err)
 	}
 	if sealed != 0 {
@@ -55,7 +55,7 @@ func TestConnectRefusesAGrantFromADeactivatedHuman(t *testing.T) {
 
 	// The control: the same call from a live human still connects, so the
 	// refusal above is about liveness and not about the wiring.
-	if _, err := e.owner.Exec(context.Background(),
+	if _, err := e.Owner.Exec(context.Background(),
 		`UPDATE app_user SET status = 'active' WHERE id = $1`, e.Rep1); err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/compose/integration/capture_backfill_integration_test.go
+++ b/backend/internal/compose/integration/capture_backfill_integration_test.go
@@ -87,7 +87,7 @@ func (p *pagedConnector) BackfillPage(_ context.Context, _ connector.Auth, _ tim
 // their run by hand. Run and job still commit together — there is just no job.
 func enqueueNothing(context.Context, pgx.Tx, ids.UUID) error { return nil }
 
-func readBackfillRow(t *testing.T, e *searchEnv, id ids.UUID) (status string, scanned, captured int, cursor []byte) {
+func readBackfillRow(t *testing.T, e *SearchEnv, id ids.UUID) (status string, scanned, captured int, cursor []byte) {
 	t.Helper()
 	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(), `
@@ -101,7 +101,7 @@ func readBackfillRow(t *testing.T, e *searchEnv, id ids.UUID) (status string, sc
 }
 
 func TestBackfillLifecycle(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	prov := &pagedConnector{messages: 25, pageSize: 10}
 	registry := newTestCaptureRegistry(e, newTestKeyvault(t, e))
 	registry.Register(prov)
@@ -224,7 +224,7 @@ func TestBackfillLifecycle(t *testing.T) {
 // the two pre-commit failure edges: an unreadable committed cursor (parse
 // error) and a readable cursor the provider then rejects (page error).
 func TestBackfillStepFaultsAreTerminal(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	registry := newTestCaptureRegistry(e, newTestKeyvault(t, e))
 	registry.Register(&pagedConnector{messages: 25, pageSize: 10})
 	grantCtx := e.humanWithScopes(e.Rep1, []principal.Scope{principal.ScopeRead})
@@ -285,7 +285,7 @@ func TestBackfillStepFaultsAreTerminal(t *testing.T) {
 // out, and until the user finds that, every retry answers 409 backfill_running.
 // So the run and the job that claims it commit together or not at all.
 func TestStartBackfillRollsBackWhenTheJobCannotBeScheduled(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	registry := newTestCaptureRegistry(e, newTestKeyvault(t, e))
 	registry.Register(&pagedConnector{messages: 25, pageSize: 10})
 	grantCtx := e.humanWithScopes(e.Rep1, []principal.Scope{principal.ScopeRead})

--- a/backend/internal/compose/integration/capture_backfill_progress_integration_test.go
+++ b/backend/internal/compose/integration/capture_backfill_progress_integration_test.go
@@ -57,7 +57,7 @@ func (c *reportingConnector) BackfillPage(ctx context.Context, _ connector.Auth,
 
 // readInflight reads the transient columns directly — the test's proof that
 // they are cleared, which the summed status read alone cannot show.
-func readInflight(t *testing.T, e *searchEnv, id ids.UUID) (scanned, captured int) {
+func readInflight(t *testing.T, e *SearchEnv, id ids.UUID) (scanned, captured int) {
 	t.Helper()
 	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		return tx.QueryRow(e.Admin(), `
@@ -74,7 +74,7 @@ func readInflight(t *testing.T, e *searchEnv, id ids.UUID) (scanned, captured in
 // opens a run against it. pacing is the live-tally write pacing: 0 writes every
 // report, which is what a test walking a page in microseconds needs to observe
 // the tally at all.
-func startReportingBackfill(t *testing.T, e *searchEnv, prov *reportingConnector, pacing time.Duration) (*capture.Registry, context.Context, ids.UUID) {
+func startReportingBackfill(t *testing.T, e *SearchEnv, prov *reportingConnector, pacing time.Duration) (*capture.Registry, context.Context, ids.UUID) {
 	t.Helper()
 	registry := newTestCaptureRegistry(e, newTestKeyvault(t, e)).WithProgressPacing(pacing)
 	registry.Register(prov)
@@ -90,7 +90,7 @@ func startReportingBackfill(t *testing.T, e *searchEnv, prov *reportingConnector
 }
 
 func TestBackfillProgressIsVisibleWhileThePageRuns(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	prov := &reportingConnector{pagedConnector: &pagedConnector{messages: 20, pageSize: 10}}
 	registry, grantCtx, runID := startReportingBackfill(t, e, prov, 0)
 	rep := ids.From[ids.UserKind](e.Rep1)
@@ -152,7 +152,7 @@ func TestBackfillProgressIsPacedRatherThanWrittenPerMessage(t *testing.T) {
 	// update per message purely so a number can move faster than anyone reads
 	// it. Under a pacing longer than the page takes, only the first report is
 	// written — and the page's commit still reports every message.
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	prov := &reportingConnector{pagedConnector: &pagedConnector{messages: 20, pageSize: 10}}
 	registry, grantCtx, runID := startReportingBackfill(t, e, prov, time.Hour)
 	rep := ids.From[ids.UserKind](e.Rep1)
@@ -184,7 +184,7 @@ func TestBackfillProgressDiesWithTheFailedPage(t *testing.T) {
 	// A page that fails transiently is retried from the committed cursor, so
 	// its partial tally must not survive — kept, it would be added to the same
 	// messages when the retry counts them for real.
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	prov := &reportingConnector{pagedConnector: &pagedConnector{messages: 20, pageSize: 10}, failAfter: 4}
 	registry, grantCtx, runID := startReportingBackfill(t, e, prov, 0)
 	wsCtx := principal.WithWorkspaceID(context.Background(), e.WS)
@@ -213,7 +213,7 @@ func TestBackfillProgressIsFencedByTheConnectionGeneration(t *testing.T) {
 	// fenced off, and the live tally must be fenced the same way — otherwise
 	// the screen keeps counting up mail from an account this run no longer has,
 	// right until the commit cancels it.
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	seedCaptureRole(t, e)
 	prov := &reportingConnector{pagedConnector: &pagedConnector{messages: 20, pageSize: 10}}
 	registry, grantCtx, runID := startReportingBackfill(t, e, prov, 0)
@@ -255,7 +255,7 @@ func TestCancelClearsTheLiveTallyAndTheRunningPageCannotWriteItBack(t *testing.T
 	// terminal and its counts are what they keep, so the page's live tally must
 	// go with it — and the messages the page keeps walking afterwards must not
 	// write it back.
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	prov := &reportingConnector{pagedConnector: &pagedConnector{messages: 20, pageSize: 10}}
 	registry, grantCtx, runID := startReportingBackfill(t, e, prov, 0)
 	rep := ids.From[ids.UserKind](e.Rep1)

--- a/backend/internal/compose/integration/capture_backfill_retry_integration_test.go
+++ b/backend/internal/compose/integration/capture_backfill_retry_integration_test.go
@@ -46,7 +46,7 @@ func (f *flakyConnector) BackfillPage(ctx context.Context, auth connector.Auth, 
 
 // readBackfillRetryState reads the scheduling half of a run: what the pager
 // must not lose across a transient fault.
-func readBackfillRetryState(t *testing.T, e *searchEnv, id ids.UUID) (status string, failures int, errClass *string, cursor []byte) {
+func readBackfillRetryState(t *testing.T, e *SearchEnv, id ids.UUID) (status string, failures int, errClass *string, cursor []byte) {
 	t.Helper()
 	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		return tx.QueryRow(e.Admin(), `
@@ -62,7 +62,7 @@ func readBackfillRetryState(t *testing.T, e *searchEnv, id ids.UUID) (status str
 
 // startFlakyBackfill connects gmail for Rep1 over a connector with the given
 // page faults and opens a run against it.
-func startFlakyBackfill(t *testing.T, e *searchEnv, faults []error) (*capture.Registry, ids.UUID) {
+func startFlakyBackfill(t *testing.T, e *SearchEnv, faults []error) (*capture.Registry, ids.UUID) {
 	t.Helper()
 	registry := newTestCaptureRegistry(e, newTestKeyvault(t, e))
 	registry.Register(&flakyConnector{pagedConnector: &pagedConnector{messages: 25, pageSize: 10}, faults: faults})
@@ -78,7 +78,7 @@ func startFlakyBackfill(t *testing.T, e *searchEnv, faults []error) (*capture.Re
 }
 
 func TestBackfillSurvivesATransientProviderFault(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	registry, runID := startFlakyBackfill(t, e, []error{&connector.RateLimitedError{}})
 	wsCtx := principal.WithWorkspaceID(context.Background(), e.WS)
 
@@ -141,7 +141,7 @@ func (c *dyingJobConnector) BackfillPage(context.Context, connector.Auth, time.T
 // the run row is the only thing that can bring the import back, and every write
 // that decides its fate has to outlive the context that killed the page.
 func TestABackfillPageWhoseJobContextDiedNeverWedgesTheRun(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	registry := newTestCaptureRegistry(e, newTestKeyvault(t, e))
 	fake := &dyingJobConnector{pagedConnector: &pagedConnector{messages: 25, pageSize: 10}}
 	registry.Register(fake)
@@ -209,7 +209,7 @@ func TestABackfillPageWhoseJobContextDiedNeverWedgesTheRun(t *testing.T) {
 }
 
 func TestBackfillEndsOnAFaultNoRetryCanFix(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	registry, runID := startFlakyBackfill(t, e, []error{connector.ErrAuthRejected})
 	wsCtx := principal.WithWorkspaceID(context.Background(), e.WS)
 

--- a/backend/internal/compose/integration/capture_backfill_yield_integration_test.go
+++ b/backend/internal/compose/integration/capture_backfill_yield_integration_test.go
@@ -102,7 +102,7 @@ func (m *mailPageConnector) BackfillPage(ctx context.Context, _ connector.Auth, 
 }
 
 func TestBackfillCountsOnlyTheCounterpartiesItsOwnPagesCreated(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	seedCaptureRole(t, e)
 	// The production wiring, because the counters under test are filled by the
 	// real auto-create resolver: a bare Sink creates nothing to count.
@@ -168,7 +168,7 @@ func TestBackfillYieldsAreVisibleWhileThePageRuns(t *testing.T) {
 	// organization as it creates one, so the two numbers beside "emails
 	// captured" have to move during the page as well — a screen where only the
 	// mail count advances tells the user the import found nobody.
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	seedCaptureRole(t, e)
 	prov := &mailPageConnector{
 		raws: [][]byte{
@@ -230,7 +230,7 @@ func TestBackfillYieldsAreVisibleWhileThePageRuns(t *testing.T) {
 // count would wrongly credit to the run under test: three counterparties
 // indistinguishable from a second gmail connection's captures, and one person a
 // human typed in.
-func seedForeignCounterparties(t *testing.T, e *searchEnv) {
+func seedForeignCounterparties(t *testing.T, e *SearchEnv) {
 	t.Helper()
 	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		for _, q := range []string{
@@ -254,7 +254,7 @@ func seedForeignCounterparties(t *testing.T, e *searchEnv) {
 	}
 }
 
-func readBackfillYieldColumns(t *testing.T, e *searchEnv, id ids.UUID) (people, organizations int) {
+func readBackfillYieldColumns(t *testing.T, e *SearchEnv, id ids.UUID) (people, organizations int) {
 	t.Helper()
 	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		return tx.QueryRow(e.Admin(), `
@@ -274,7 +274,7 @@ func TestBackfillYieldsSurviveATransientFault(t *testing.T) {
 	// people and companies the failed attempt minted are counted by that
 	// attempt or by nobody — dropping them with the rest of its tally
 	// undercounts the run for good.
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	seedCaptureRole(t, e)
 	prov := &mailPageConnector{
 		raws: [][]byte{
@@ -343,7 +343,7 @@ func TestBackfillYieldsSurviveACancelUnderTheRunningPage(t *testing.T) {
 	// that carries the run's STATE is fenced on the live statuses, so after the
 	// cancel none of them match — and the page's counterparties, which exist
 	// and which no replay will offer again, were credited by nobody.
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	seedCaptureRole(t, e)
 	prov := &mailPageConnector{raws: yieldFixture(), sent: map[string]bool{"y3@myco.example": true}}
 	registry := compose.NewCaptureRegistry(e.Pool, newTestKeyvault(t, e), compose.CaptureConfig{}).
@@ -389,7 +389,7 @@ func TestBackfillYieldsAreCreditedOnceAtTheRetryCeiling(t *testing.T) {
 	// A page that fails transiently AT the ceiling runs two writes: the
 	// failure ladder and the terminal one. When both credited the yields, the
 	// run reported twice the people it actually created.
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	seedCaptureRole(t, e)
 	prov := &mailPageConnector{
 		raws: yieldFixture(),
@@ -431,7 +431,7 @@ func TestBackfillYieldsAreCreditedOnceAtTheRetryCeiling(t *testing.T) {
 }
 
 // readRunAndYields reads the run's state and its committed yield columns.
-func readRunAndYields(t *testing.T, e *searchEnv, id ids.UUID) (status string, people, organizations int) {
+func readRunAndYields(t *testing.T, e *SearchEnv, id ids.UUID) (status string, people, organizations int) {
 	t.Helper()
 	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		return tx.QueryRow(e.Admin(), `
@@ -447,7 +447,7 @@ func readRunAndYields(t *testing.T, e *searchEnv, id ids.UUID) (status string, p
 // seedBackfillFailuresAtCeiling puts the run one fault below
 // backfillMaxConsecutiveFailures (10), so the next fault is the one that both
 // climbs the ladder and ends the run — the interleaving that double-credited.
-func seedBackfillFailuresAtCeiling(t *testing.T, e *searchEnv, id ids.UUID) {
+func seedBackfillFailuresAtCeiling(t *testing.T, e *SearchEnv, id ids.UUID) {
 	t.Helper()
 	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		_, execErr := tx.Exec(e.Admin(), `

--- a/backend/internal/compose/integration/capture_env_test.go
+++ b/backend/internal/compose/integration/capture_env_test.go
@@ -119,7 +119,7 @@ func emailWithListUnsub(from, fromName, to, msgID string) []byte {
 	return []byte(strings.Join(lines, "\r\n"))
 }
 
-func countRows(t *testing.T, e *searchEnv, query string) int {
+func countRows(t *testing.T, e *SearchEnv, query string) int {
 	t.Helper()
 	var n int
 	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
@@ -135,7 +135,7 @@ func countRows(t *testing.T, e *searchEnv, query string) int {
 // derives. The production authority resolves the granting human's LIVE role, so
 // without it the ensure path is denied and every counterparty assertion reads as
 // a resolver bug.
-func seedCaptureRole(t *testing.T, e *searchEnv) {
+func seedCaptureRole(t *testing.T, e *SearchEnv) {
 	t.Helper()
 	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		var roleID string
@@ -161,14 +161,14 @@ func seedCaptureRole(t *testing.T, e *searchEnv) {
 // tier gate are what these tests prove), a connected gmail connection, and the
 // two pull shapes. Built per test so each starts from a clean mailbox.
 type captureEnv struct {
-	e        *searchEnv
+	e        *SearchEnv
 	sync     func(t *testing.T, raws ...[]byte)
 	syncSent func(t *testing.T, sent map[string]bool, raws ...[]byte)
 }
 
 func newCaptureEnv(t *testing.T) captureEnv {
 	t.Helper()
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	conn := &mailBatchConnector{}
 	registry := compose.NewCaptureRegistry(e.Pool, newTestKeyvault(t, e), compose.CaptureConfig{})
 	registry.Register(conn)

--- a/backend/internal/compose/integration/capture_fence_integration_test.go
+++ b/backend/internal/compose/integration/capture_fence_integration_test.go
@@ -59,7 +59,7 @@ func (c *interruptedConnector) BackfillPage(ctx context.Context, auth connector.
 
 // readConnectionSyncState reads the two facts a superseded cycle must not
 // touch: the connection's watermark and the sidecar's health verdict.
-func readConnectionSyncState(t *testing.T, e *searchEnv, connID ids.UUID) (status string, cursor []byte, lastSynced *time.Time) {
+func readConnectionSyncState(t *testing.T, e *SearchEnv, connID ids.UUID) (status string, cursor []byte, lastSynced *time.Time) {
 	t.Helper()
 	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		return tx.QueryRow(e.Admin(), `
@@ -75,7 +75,7 @@ func readConnectionSyncState(t *testing.T, e *searchEnv, connID ids.UUID) (statu
 }
 
 func TestASyncDisconnectedMidFlightCommitsNothing(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	seedCaptureRole(t, e)
 	registry := newTestCaptureRegistry(e, newTestKeyvault(t, e))
 	fake := &interruptedConnector{pagedConnector: &pagedConnector{messages: 25, pageSize: 10}}
@@ -112,7 +112,7 @@ func TestASyncDisconnectedMidFlightCommitsNothing(t *testing.T) {
 }
 
 func TestABackfillPageDisconnectedMidFlightCommitsNothing(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	seedCaptureRole(t, e)
 	registry := newTestCaptureRegistry(e, newTestKeyvault(t, e))
 	fake := &interruptedConnector{pagedConnector: &pagedConnector{messages: 25, pageSize: 10}}

--- a/backend/internal/compose/integration/capture_integration_test.go
+++ b/backend/internal/compose/integration/capture_integration_test.go
@@ -105,7 +105,7 @@ func (m *mailFake) HealthCheck(context.Context, connector.Auth) error { return n
 // one workspace-bound transaction.
 type captureCounts struct{ activities, leads, raws, audits int }
 
-func readCaptureCounts(t *testing.T, e *searchEnv) captureCounts {
+func readCaptureCounts(t *testing.T, e *SearchEnv) captureCounts {
 	t.Helper()
 	var got captureCounts
 	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
@@ -127,7 +127,7 @@ func readCaptureCounts(t *testing.T, e *searchEnv) captureCounts {
 }
 
 func TestCaptureSyncIsIdempotentAndProvenanced(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	personID := e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Inbox Sender', 'manual', 'human:x')`)
 
 	registry := newTestCaptureRegistry(e, newTestKeyvault(t, e))
@@ -154,7 +154,7 @@ func TestCaptureSyncIsIdempotentAndProvenanced(t *testing.T) {
 	// Raw capture is evidence: the replay carried DIFFERENT bytes, and
 	// the stored original must not have moved.
 	var payload string
-	if err := e.owner.QueryRow(context.Background(),
+	if err := e.Owner.QueryRow(context.Background(),
 		`SELECT payload->>'sync' FROM raw_capture WHERE source_id = 'msg-1'`).Scan(&payload); err != nil {
 		t.Fatal(err)
 	}
@@ -166,7 +166,7 @@ func TestCaptureSyncIsIdempotentAndProvenanced(t *testing.T) {
 	}
 	// The captured event went through the outbox exactly once.
 	var captured int
-	if err := e.owner.QueryRow(context.Background(),
+	if err := e.Owner.QueryRow(context.Background(),
 		`SELECT count(*) FROM event_outbox WHERE envelope->>'type' = 'activity.captured'`).Scan(&captured); err != nil {
 		t.Fatal(err)
 	}
@@ -203,7 +203,7 @@ func TestCaptureSyncIsIdempotentAndProvenanced(t *testing.T) {
 }
 
 func TestCaptureScopeIntersectionRefusesOverScopedConnector(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	registry := newTestCaptureRegistry(e, newTestKeyvault(t, e))
 	registry.Register(&mailFake{scopes: []principal.Scope{principal.ScopeRead, principal.ScopeSend}})
 
@@ -222,7 +222,7 @@ func TestCaptureScopeIntersectionRefusesOverScopedConnector(t *testing.T) {
 }
 
 func TestReconnectUnarchivesTheConnection(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	registry := newTestCaptureRegistry(e, newTestKeyvault(t, e))
 	registry.Register(&mailFake{})
 
@@ -263,7 +263,7 @@ func TestReconnectUnarchivesTheConnection(t *testing.T) {
 }
 
 func TestCaptureLinkTargetOutsideScopeRefused(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	// A person owned by team2 — invisible to the team1 granting human.
 	foreignPerson := e.seed(t, `INSERT INTO person (id, workspace_id, full_name, owner_id, source, captured_by) VALUES ($1, $2, 'Foreign Target', $3, 'manual', 'human:x')`, e.Rep3)
 
@@ -290,10 +290,10 @@ func TestCaptureLinkTargetOutsideScopeRefused(t *testing.T) {
 	}
 }
 
-// humanWithScopes builds a human principal in the searchEnv workspace
+// humanWithScopes builds a human principal in the SearchEnv workspace
 // carrying rep-grade RBAC (team scope) plus explicit verb scopes for
 // the connector grant check.
-func (e *searchEnv) humanWithScopes(user ids.UUID, scopes []principal.Scope) context.Context {
+func (e *SearchEnv) humanWithScopes(user ids.UUID, scopes []principal.Scope) context.Context {
 	scopeSet := principal.NewScopeSet()
 	for _, s := range scopes {
 		scopeSet[s] = struct{}{}
@@ -335,6 +335,6 @@ func (fakeAuthority) SeatType(context.Context, ids.UUID, ids.UUID) (principal.Se
 	return principal.SeatFull, nil
 }
 
-func newTestCaptureRegistry(e *searchEnv, vault keyvault.Vault) *capture.Registry {
+func newTestCaptureRegistry(e *SearchEnv, vault keyvault.Vault) *capture.Registry {
 	return capture.NewRegistry(e.Pool, capture.NewSink(e.Pool), fakeAuthority{}, vault)
 }

--- a/backend/internal/compose/integration/capture_integration_test.go
+++ b/backend/internal/compose/integration/capture_integration_test.go
@@ -128,7 +128,7 @@ func readCaptureCounts(t *testing.T, e *SearchEnv) captureCounts {
 
 func TestCaptureSyncIsIdempotentAndProvenanced(t *testing.T) {
 	e := SetupSearch(t)
-	personID := e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Inbox Sender', 'manual', 'human:x')`)
+	personID := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Inbox Sender', 'manual', 'human:x')`)
 
 	registry := newTestCaptureRegistry(e, newTestKeyvault(t, e))
 	fake := &mailFake{linkTo: personID}
@@ -265,7 +265,7 @@ func TestReconnectUnarchivesTheConnection(t *testing.T) {
 func TestCaptureLinkTargetOutsideScopeRefused(t *testing.T) {
 	e := SetupSearch(t)
 	// A person owned by team2 — invisible to the team1 granting human.
-	foreignPerson := e.seed(t, `INSERT INTO person (id, workspace_id, full_name, owner_id, source, captured_by) VALUES ($1, $2, 'Foreign Target', $3, 'manual', 'human:x')`, e.Rep3)
+	foreignPerson := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, owner_id, source, captured_by) VALUES ($1, $2, 'Foreign Target', $3, 'manual', 'human:x')`, e.Rep3)
 
 	registry := newTestCaptureRegistry(e, newTestKeyvault(t, e))
 	fake := &mailFake{linkTo: foreignPerson}

--- a/backend/internal/compose/integration/capture_ledger_integration_test.go
+++ b/backend/internal/compose/integration/capture_ledger_integration_test.go
@@ -131,7 +131,7 @@ func TestCaptureLedgerRefusesAVerdictFromAnExpiredClaim(t *testing.T) {
 
 // resolveWith runs one Resolve on its own transaction, as the verdict engine
 // does, and reports whether this caller was the one that closed the row.
-func resolveWith(t *testing.T, e *searchEnv, store *capture.PendingStore, p capture.PendingCounterparty, status string) bool {
+func resolveWith(t *testing.T, e *SearchEnv, store *capture.PendingStore, p capture.PendingCounterparty, status string) bool {
 	t.Helper()
 	var resolved bool
 	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
@@ -147,7 +147,7 @@ func resolveWith(t *testing.T, e *searchEnv, store *capture.PendingStore, p capt
 
 // expireClaimLease backdates a row's lease so it is claimable again — the state
 // a crashed or stalled worker leaves behind.
-func expireClaimLease(t *testing.T, e *searchEnv, id ids.UUID) {
+func expireClaimLease(t *testing.T, e *SearchEnv, id ids.UUID) {
 	t.Helper()
 	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(), `
@@ -164,7 +164,7 @@ func expireClaimLease(t *testing.T, e *searchEnv, id ids.UUID) {
 // fillLedgerToCeiling tops the workspace up to exactly its open-disposition
 // ceiling, leaving the queue full but not over — so the next capture is the
 // first one the cap refuses.
-func fillLedgerToCeiling(t *testing.T, e *searchEnv, activityID, ownerID ids.UUID) {
+func fillLedgerToCeiling(t *testing.T, e *SearchEnv, activityID, ownerID ids.UUID) {
 	t.Helper()
 	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		var live int
@@ -234,7 +234,7 @@ func TestCaptureLedgerStopsDeferringOneFloodingDomain(t *testing.T) {
 // fillDomainToShare tops one domain up to exactly its share of the ceiling,
 // leaving it full but not over — so the next message from it is the first the
 // per-domain cap refuses.
-func fillDomainToShare(t *testing.T, e *searchEnv, domain string, activityID, ownerID ids.UUID) {
+func fillDomainToShare(t *testing.T, e *SearchEnv, domain string, activityID, ownerID ids.UUID) {
 	t.Helper()
 	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		var live int

--- a/backend/internal/compose/integration/capture_lifecycle_audit_integration_test.go
+++ b/backend/internal/compose/integration/capture_lifecycle_audit_integration_test.go
@@ -42,7 +42,7 @@ func (v *hangUpVault) Delete(ctx context.Context, ws ids.WorkspaceID, ref keyvau
 }
 
 // connectionCredentialRef reads the ref a connection row currently names.
-func connectionCredentialRef(t *testing.T, e *searchEnv, connID ids.UUID) string {
+func connectionCredentialRef(t *testing.T, e *SearchEnv, connID ids.UUID) string {
 	t.Helper()
 	var ref *string
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
@@ -58,7 +58,7 @@ func connectionCredentialRef(t *testing.T, e *searchEnv, connID ids.UUID) string
 }
 
 func TestReconnectDeletesSupersededCredentialWhenTheCallerHangsUp(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	vault := newTestKeyvault(t, e)
 	hangUp := &hangUpVault{Vault: vault}
 	registry := newTestCaptureRegistry(e, hangUp)
@@ -85,7 +85,7 @@ func TestReconnectDeletesSupersededCredentialWhenTheCallerHangsUp(t *testing.T) 
 }
 
 func TestDisconnectDeletesTheCredentialWhenTheCallerHangsUp(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	vault := newTestKeyvault(t, e)
 	hangUp := &hangUpVault{Vault: vault}
 	registry := newTestCaptureRegistry(e, hangUp)
@@ -130,7 +130,7 @@ type lifecycleAudit struct {
 
 // connectionAudits reads every audit_log row naming a capture_connection, in
 // occurrence order.
-func connectionAudits(t *testing.T, e *searchEnv) []lifecycleAudit {
+func connectionAudits(t *testing.T, e *SearchEnv) []lifecycleAudit {
 	t.Helper()
 	var out []lifecycleAudit
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
@@ -157,7 +157,7 @@ func connectionAudits(t *testing.T, e *searchEnv) []lifecycleAudit {
 }
 
 func TestConnectAndDisconnectLeaveAnAttributableAuditRow(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	registry := newTestCaptureRegistry(e, newTestKeyvault(t, e))
 	registry.Register(&authAssertingFake{})
 
@@ -213,7 +213,7 @@ func TestConnectAndDisconnectLeaveAnAttributableAuditRow(t *testing.T) {
 
 // connectionGeneration reads the lifecycle fence a deferred sync or backfill
 // page commits its work against.
-func connectionGeneration(t *testing.T, e *searchEnv, connID ids.UUID) int {
+func connectionGeneration(t *testing.T, e *SearchEnv, connID ids.UUID) int {
 	t.Helper()
 	var generation int
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
@@ -231,7 +231,7 @@ func connectionGeneration(t *testing.T, e *searchEnv, connID ids.UUID) int {
 // not a second withdrawal: the human withdrew once, so the trail must say so
 // once, and there is no new cycle out at the provider left to fence.
 func TestARetriedDisconnectDoesNotReAuditTheWithdrawal(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	registry := newTestCaptureRegistry(e, newTestKeyvault(t, e))
 	registry.Register(&authAssertingFake{})
 
@@ -270,10 +270,10 @@ func TestARetriedDisconnectDoesNotReAuditTheWithdrawal(t *testing.T) {
 // UPDATE on capture_sync_state raise — the cheapest way to fail Connect AFTER
 // its audit row is written. It is statement-level on purpose: a fresh
 // connection has no sidecar row yet, so a row-level trigger would never fire.
-func refuseSyncStateUpdates(t *testing.T, e *searchEnv) {
+func refuseSyncStateUpdates(t *testing.T, e *SearchEnv) {
 	t.Helper()
 	ctx := context.Background()
-	if _, err := e.owner.Exec(ctx, `
+	if _, err := e.Owner.Exec(ctx, `
 		CREATE FUNCTION refuse_sync_state_update() RETURNS trigger LANGUAGE plpgsql AS $$
 		BEGIN RAISE EXCEPTION 'sync state refused by test'; END $$;
 		CREATE TRIGGER refuse_sync_state BEFORE UPDATE ON capture_sync_state
@@ -281,7 +281,7 @@ func refuseSyncStateUpdates(t *testing.T, e *searchEnv) {
 		t.Fatalf("installing the sync-state failure trigger: %v", err)
 	}
 	t.Cleanup(func() {
-		if _, err := e.owner.Exec(context.Background(), `
+		if _, err := e.Owner.Exec(context.Background(), `
 			DROP TRIGGER refuse_sync_state ON capture_sync_state;
 			DROP FUNCTION refuse_sync_state_update();`); err != nil {
 			t.Errorf("removing the sync-state failure trigger: %v", err)
@@ -293,7 +293,7 @@ func refuseSyncStateUpdates(t *testing.T, e *searchEnv) {
 // to follow it: a connect that fails anywhere in its transaction must leave no
 // trace of a connection that never existed.
 func TestAConnectThatFailsLeavesNoAuditRow(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	registry := newTestCaptureRegistry(e, newTestKeyvault(t, e))
 	registry.Register(&authAssertingFake{})
 	refuseSyncStateUpdates(t, e)

--- a/backend/internal/compose/integration/capture_provider_scopes_integration_test.go
+++ b/backend/internal/compose/integration/capture_provider_scopes_integration_test.go
@@ -34,7 +34,7 @@ type grantingFake struct {
 func (f *grantingFake) GrantedScopes(connector.Auth) ([]string, error) { return f.granted, nil }
 
 func TestConnectPersistsTheProviderGrantedScopes(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	granted := []string{"offline_access", "User.Read", "Mail.Read"}
 	registry := capture.NewRegistry(e.Pool, capture.NewSink(e.Pool), fakeAuthority{}, newTestKeyvault(t, e))
 	registry.Register(&grantingFake{granted: granted})
@@ -74,7 +74,7 @@ func TestConnectPersistsTheProviderGrantedScopes(t *testing.T) {
 }
 
 func TestAConnectorThatCannotReportItsGrantRecordsNoClaim(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	registry := capture.NewRegistry(e.Pool, capture.NewSink(e.Pool), fakeAuthority{}, newTestKeyvault(t, e))
 	registry.Register(&mailFake{})
 

--- a/backend/internal/compose/integration/capture_scope_integration_test.go
+++ b/backend/internal/compose/integration/capture_scope_integration_test.go
@@ -69,7 +69,7 @@ func (s *recordingStager) StageMerge(_ context.Context, in capture.MergeProposal
 // newScopeCaptureRegistry wires the registry over a Sink with a recording
 // merge stager — the default test registry has none, and "no proposal was
 // staged" is only an assertion when staging is wired.
-func newScopeCaptureRegistry(t *testing.T, e *searchEnv, fake *scopeFake) (*capture.Registry, *recordingStager) {
+func newScopeCaptureRegistry(t *testing.T, e *SearchEnv, fake *scopeFake) (*capture.Registry, *recordingStager) {
 	t.Helper()
 	stager := &recordingStager{}
 	sink := capture.NewSink(e.Pool).WithStager(stager)
@@ -79,7 +79,7 @@ func newScopeCaptureRegistry(t *testing.T, e *searchEnv, fake *scopeFake) (*capt
 }
 
 func TestCaptureSkipsALeadCollidingWithAnInvisibleIncumbent(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	// A lead owned by team2's rep — outside the team1 granting human's scope.
 	e.seed(t, `INSERT INTO lead (id, workspace_id, full_name, email, owner_id, source, captured_by)
 		VALUES ($1, $2, 'Hidden Prospect', 'collide@scope.test', $3, 'manual', 'human:x')`, e.Rep3)
@@ -118,7 +118,7 @@ func TestCaptureSkipsALeadCollidingWithAnInvisibleIncumbent(t *testing.T) {
 }
 
 func TestCaptureSkipsAnActivityReplayWhoseIncumbentLeftTheGrantingHumansScope(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	foreign := e.seed(t, `INSERT INTO person (id, workspace_id, full_name, owner_id, source, captured_by)
 		VALUES ($1, $2, 'Foreign Counterparty', $3, 'manual', 'human:x')`, e.Rep3)
 
@@ -141,11 +141,11 @@ func TestCaptureSkipsAnActivityReplayWhoseIncumbentLeftTheGrantingHumansScope(t 
 	// The activity is later linked to a record the granting human cannot see,
 	// which takes the activity itself out of their scope (the link walk).
 	var activityID ids.UUID
-	if err := e.owner.QueryRow(context.Background(),
+	if err := e.Owner.QueryRow(context.Background(),
 		`SELECT id FROM activity WHERE source_system = 'graph' AND source_id = 'msg-9'`).Scan(&activityID); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := e.owner.Exec(context.Background(), `
+	if _, err := e.Owner.Exec(context.Background(), `
 		INSERT INTO activity_link (workspace_id, activity_id, entity_type, person_id)
 		VALUES ($1, $2, 'person', $3)`, e.WS, activityID, foreign); err != nil {
 		t.Fatal(err)

--- a/backend/internal/compose/integration/capture_scope_integration_test.go
+++ b/backend/internal/compose/integration/capture_scope_integration_test.go
@@ -81,7 +81,7 @@ func newScopeCaptureRegistry(t *testing.T, e *SearchEnv, fake *scopeFake) (*capt
 func TestCaptureSkipsALeadCollidingWithAnInvisibleIncumbent(t *testing.T) {
 	e := SetupSearch(t)
 	// A lead owned by team2's rep — outside the team1 granting human's scope.
-	e.seed(t, `INSERT INTO lead (id, workspace_id, full_name, email, owner_id, source, captured_by)
+	e.Seed(t, `INSERT INTO lead (id, workspace_id, full_name, email, owner_id, source, captured_by)
 		VALUES ($1, $2, 'Hidden Prospect', 'collide@scope.test', $3, 'manual', 'human:x')`, e.Rep3)
 
 	fake := &scopeFake{records: []connector.NormalizedRecord{{
@@ -119,7 +119,7 @@ func TestCaptureSkipsALeadCollidingWithAnInvisibleIncumbent(t *testing.T) {
 
 func TestCaptureSkipsAnActivityReplayWhoseIncumbentLeftTheGrantingHumansScope(t *testing.T) {
 	e := SetupSearch(t)
-	foreign := e.seed(t, `INSERT INTO person (id, workspace_id, full_name, owner_id, source, captured_by)
+	foreign := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, owner_id, source, captured_by)
 		VALUES ($1, $2, 'Foreign Counterparty', $3, 'manual', 'human:x')`, e.Rep3)
 
 	fake := &scopeFake{records: []connector.NormalizedRecord{{

--- a/backend/internal/compose/integration/capture_settings_integration_test.go
+++ b/backend/internal/compose/integration/capture_settings_integration_test.go
@@ -27,7 +27,7 @@ import (
 
 // captureSettingsCtx builds a human principal in the env workspace with a
 // specific capture_settings grant.
-func (e *searchEnv) captureSettingsCtx(grant principal.ObjectGrant) context.Context {
+func (e *SearchEnv) captureSettingsCtx(grant principal.ObjectGrant) context.Context {
 	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
 	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
 	return principal.WithActor(ctx, principal.Principal{
@@ -40,7 +40,7 @@ func (e *searchEnv) captureSettingsCtx(grant principal.ObjectGrant) context.Cont
 }
 
 func TestCaptureSettingsStore(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	store := capture.NewSettings(compose.NewSettingsStore(e.Pool))
 
 	admin := e.captureSettingsCtx(principal.ObjectGrant{Read: true, Update: true})

--- a/backend/internal/compose/integration/capture_syncstate_integration_test.go
+++ b/backend/internal/compose/integration/capture_syncstate_integration_test.go
@@ -64,7 +64,7 @@ type syncStateRow struct {
 	class    *string
 }
 
-func readSyncState(t *testing.T, e *searchEnv, connID ids.UUID) (string, syncStateRow) {
+func readSyncState(t *testing.T, e *SearchEnv, connID ids.UUID) (string, syncStateRow) {
 	t.Helper()
 	var status string
 	var row syncStateRow
@@ -85,7 +85,7 @@ func readSyncState(t *testing.T, e *searchEnv, connID ids.UUID) (string, syncSta
 }
 
 func TestSyncFailureNeverKillsAConnection(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	moody := &moodyConnector{name: "gmail"}
 	registry := newTestCaptureRegistry(e, newTestKeyvault(t, e))
 	registry.Register(moody)
@@ -222,7 +222,7 @@ func TestSyncFailureNeverKillsAConnection(t *testing.T) {
 }
 
 // forceDue moves the connection's pacing clock into the past.
-func forceDue(t *testing.T, e *searchEnv, connID ids.UUID) {
+func forceDue(t *testing.T, e *SearchEnv, connID ids.UUID) {
 	t.Helper()
 	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(),

--- a/backend/internal/compose/integration/capture_tiergate_integration_test.go
+++ b/backend/internal/compose/integration/capture_tiergate_integration_test.go
@@ -224,7 +224,7 @@ func TestCaptureTierGateReopensASenderWhoseNoiseVerdictHasAged(t *testing.T) {
 
 // resolveDispositionAged puts an address's disposition into a terminal state
 // resolved the given duration ago.
-func resolveDispositionAged(t *testing.T, e *searchEnv, email, status string, ago time.Duration) {
+func resolveDispositionAged(t *testing.T, e *SearchEnv, email, status string, ago time.Duration) {
 	t.Helper()
 	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(), `

--- a/backend/internal/compose/integration/embedding_integration_test.go
+++ b/backend/internal/compose/integration/embedding_integration_test.go
@@ -92,7 +92,7 @@ func TestEmbeddingUpsertReusesUnchangedText(t *testing.T) {
 	e := SetupSearch(t)
 	fake := ai.NewFakeClient()
 	embedder := fakeEmbedder(t, fake)
-	personID := e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Vector Person', 'manual', 'human:x')`)
+	personID := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Vector Person', 'manual', 'human:x')`)
 
 	fresh, err := e.Store.UpsertEmbedding(e.Admin(), "person", personID, "Vector Person", embedder)
 	if err != nil || !fresh {
@@ -116,8 +116,8 @@ func TestSimilarityRankingAndRowScope(t *testing.T) {
 	fake := ai.NewFakeClient()
 	embedder := fakeEmbedder(t, fake)
 
-	shared := e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Anke Schulz', 'manual', 'human:x')`)
-	foreign := e.seed(t, `INSERT INTO person (id, workspace_id, full_name, owner_id, source, captured_by) VALUES ($1, $2, 'Bernd Kruse', $3, 'manual', 'human:x')`, e.Rep3)
+	shared := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Anke Schulz', 'manual', 'human:x')`)
+	foreign := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, owner_id, source, captured_by) VALUES ($1, $2, 'Bernd Kruse', $3, 'manual', 'human:x')`, e.Rep3)
 	for id, text := range map[ids.UUID]string{shared: "Anke Schulz", foreign: "Bernd Kruse"} {
 		if _, err := e.Store.UpsertEmbedding(e.Admin(), "person", id, text, embedder); err != nil {
 			t.Fatal(err)
@@ -143,7 +143,7 @@ func TestSimilarityRankingAndRowScope(t *testing.T) {
 	}
 
 	// rep1 (team1) cannot see rep3's row through the vector lane either.
-	hits, err = e.Store.SimilarEntities(e.asTeamRep(e.Rep1, e.Team1), queryVec.Vectors[0], identity, 10)
+	hits, err = e.Store.SimilarEntities(e.AsTeamRep(e.Rep1, e.Team1), queryVec.Vectors[0], identity, 10)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -159,9 +159,9 @@ func TestHybridRRFAgreementWins(t *testing.T) {
 	fake := ai.NewFakeClient()
 	embedder := fakeEmbedder(t, fake)
 
-	agree := e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Solar Grid', 'manual', 'human:x')`)
-	lexOnly := e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Solar Panels', 'manual', 'human:x')`)
-	vecOnly := e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Photovoltaik Cluster', 'manual', 'human:x')`)
+	agree := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Solar Grid', 'manual', 'human:x')`)
+	lexOnly := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Solar Panels', 'manual', 'human:x')`)
+	vecOnly := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Photovoltaik Cluster', 'manual', 'human:x')`)
 
 	// Embeddings: the agreeing row and the vector-only row both embed
 	// the QUERY text (identical vector); the lexical-only row embeds
@@ -200,7 +200,7 @@ func TestEmbedGenMaintainsRowsFromEvents(t *testing.T) {
 	fake := ai.NewFakeClient()
 	gen := search.NewEmbedGen(e.Store, fakeEmbedder(t, fake))
 
-	personID := e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Event Driven', 'manual', 'human:x')`)
+	personID := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Event Driven', 'manual', 'human:x')`)
 	env := kevents.Envelope{
 		EventID:     ids.NewV7(),
 		Type:        "person.created",
@@ -258,7 +258,7 @@ func TestUpsertReembedsOnIdentityChange(t *testing.T) {
 	fake := ai.NewFakeClient()
 	embedderA := fakeEmbedderNamed(t, fake, "model-a")
 	embedderB := fakeEmbedderNamed(t, fake, "model-b")
-	personID := e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Identity Person', 'manual', 'human:x')`)
+	personID := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Identity Person', 'manual', 'human:x')`)
 
 	fresh, err := e.Store.UpsertEmbedding(e.Admin(), "person", personID, "Same Text", embedderA)
 	if err != nil || !fresh {
@@ -290,7 +290,7 @@ func TestUpsertSkipsUnchangedUnderSameIdentity(t *testing.T) {
 	e := SetupSearch(t)
 	fake := ai.NewFakeClient()
 	embedder := fakeEmbedderNamed(t, fake, "model-c")
-	personID := e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Stable Person', 'manual', 'human:x')`)
+	personID := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Stable Person', 'manual', 'human:x')`)
 
 	fresh, err := e.Store.UpsertEmbedding(e.Admin(), "person", personID, "Stable Text", embedder)
 	if err != nil || !fresh {
@@ -311,7 +311,7 @@ func TestUpsertSkipsUnchangedUnderSameIdentity(t *testing.T) {
 // vector into a column other rows expect at a fixed width.
 func TestUpsertRejectsWidthMismatch(t *testing.T) {
 	e := SetupSearch(t)
-	personID := e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Width Mismatch', 'manual', 'human:x')`)
+	personID := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Width Mismatch', 'manual', 'human:x')`)
 	// dims (999) deliberately differs from resDims (1024): the declared
 	// identity and the actual response disagree, which the width guard
 	// must catch by comparing against the IDENTITY's width, not a fixed
@@ -336,7 +336,7 @@ func TestUpsertRejectsWidthMismatch(t *testing.T) {
 // it ever reaches storage.
 func TestUpsertRejectsZeroVector(t *testing.T) {
 	e := SetupSearch(t)
-	personID := e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Zero Vector', 'manual', 'human:x')`)
+	personID := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Zero Vector', 'manual', 'human:x')`)
 	// Width matches (1024/1024) so only the zero-vector guard can be what
 	// rejects this — a decoy width mismatch would leave the test proving
 	// the wrong guard fired.
@@ -367,8 +367,8 @@ func TestSimilarEntitiesFiltersIdentityAndDoesNotCrossDimCrash(t *testing.T) {
 	e := SetupSearch(t)
 	ctx := context.Background()
 
-	threeDim := e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Three Dim Person', 'manual', 'human:x')`)
-	twoDim := e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Two Dim Person', 'manual', 'human:x')`)
+	threeDim := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Three Dim Person', 'manual', 'human:x')`)
+	twoDim := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Two Dim Person', 'manual', 'human:x')`)
 
 	// Seed the unbounded embedding column directly at two different
 	// widths under two different identities — the mixed-width store
@@ -447,7 +447,7 @@ func (embedIdentityNeverCalled) EmbedIdentity() (string, int) { return "", 0 }
 // acking (platform/events' at-least-once bus then redelivers forever).
 func TestUpsertEmbeddingNoOpsAndWritesNoRowOnUnboundLane(t *testing.T) {
 	e := SetupSearch(t)
-	personID := e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Unbound Person', 'manual', 'human:x')`)
+	personID := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Unbound Person', 'manual', 'human:x')`)
 
 	fresh, err := e.Store.UpsertEmbedding(e.Admin(), "person", personID, "Unbound Person", embedIdentityNeverCalled{})
 	if err != nil {
@@ -475,7 +475,7 @@ func TestUpsertEmbeddingNoOpsAndWritesNoRowOnUnboundLane(t *testing.T) {
 // no live width or model.
 func TestHybridSearchDegradesToLexicalOnUnboundLane(t *testing.T) {
 	e := SetupSearch(t)
-	personID := e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Lexical Only Grid', 'manual', 'human:x')`)
+	personID := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Lexical Only Grid', 'manual', 'human:x')`)
 
 	hits, err := e.Store.HybridSearch(e.Admin(), "Lexical Only Grid", embedIdentityNeverCalled{}, 10)
 	if err != nil {

--- a/backend/internal/compose/integration/embedding_integration_test.go
+++ b/backend/internal/compose/integration/embedding_integration_test.go
@@ -89,37 +89,37 @@ func (s stubEmbedder) Embed(context.Context, model.EmbedRequest) (model.Embeddin
 func (s stubEmbedder) EmbedIdentity() (string, int) { return s.identity, s.dims }
 
 func TestEmbeddingUpsertReusesUnchangedText(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	fake := ai.NewFakeClient()
 	embedder := fakeEmbedder(t, fake)
 	personID := e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Vector Person', 'manual', 'human:x')`)
 
-	fresh, err := e.store.UpsertEmbedding(e.Admin(), "person", personID, "Vector Person", embedder)
+	fresh, err := e.Store.UpsertEmbedding(e.Admin(), "person", personID, "Vector Person", embedder)
 	if err != nil || !fresh {
 		t.Fatalf("first upsert fresh=%v err=%v", fresh, err)
 	}
-	fresh, err = e.store.UpsertEmbedding(e.Admin(), "person", personID, "Vector Person", embedder)
+	fresh, err = e.Store.UpsertEmbedding(e.Admin(), "person", personID, "Vector Person", embedder)
 	if err != nil || fresh {
 		t.Fatalf("unchanged text recomputed: fresh=%v err=%v", fresh, err)
 	}
 	if calls := len(fake.Calls()); calls != 1 {
 		t.Fatalf("embedder called %d times for unchanged text, want 1", calls)
 	}
-	fresh, err = e.store.UpsertEmbedding(e.Admin(), "person", personID, "Vector Person renamed", embedder)
+	fresh, err = e.Store.UpsertEmbedding(e.Admin(), "person", personID, "Vector Person renamed", embedder)
 	if err != nil || !fresh {
 		t.Fatalf("changed text not re-embedded: fresh=%v err=%v", fresh, err)
 	}
 }
 
 func TestSimilarityRankingAndRowScope(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	fake := ai.NewFakeClient()
 	embedder := fakeEmbedder(t, fake)
 
 	shared := e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Anke Schulz', 'manual', 'human:x')`)
 	foreign := e.seed(t, `INSERT INTO person (id, workspace_id, full_name, owner_id, source, captured_by) VALUES ($1, $2, 'Bernd Kruse', $3, 'manual', 'human:x')`, e.Rep3)
 	for id, text := range map[ids.UUID]string{shared: "Anke Schulz", foreign: "Bernd Kruse"} {
-		if _, err := e.store.UpsertEmbedding(e.Admin(), "person", id, text, embedder); err != nil {
+		if _, err := e.Store.UpsertEmbedding(e.Admin(), "person", id, text, embedder); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -134,7 +134,7 @@ func TestSimilarityRankingAndRowScope(t *testing.T) {
 		t.Fatal(err)
 	}
 	identity, _ := embedder.EmbedIdentity()
-	hits, err := e.store.SimilarEntities(e.Admin(), queryVec.Vectors[0], identity, 10)
+	hits, err := e.Store.SimilarEntities(e.Admin(), queryVec.Vectors[0], identity, 10)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -143,7 +143,7 @@ func TestSimilarityRankingAndRowScope(t *testing.T) {
 	}
 
 	// rep1 (team1) cannot see rep3's row through the vector lane either.
-	hits, err = e.store.SimilarEntities(e.asTeamRep(e.Rep1, e.Team1), queryVec.Vectors[0], identity, 10)
+	hits, err = e.Store.SimilarEntities(e.asTeamRep(e.Rep1, e.Team1), queryVec.Vectors[0], identity, 10)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -155,7 +155,7 @@ func TestSimilarityRankingAndRowScope(t *testing.T) {
 }
 
 func TestHybridRRFAgreementWins(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	fake := ai.NewFakeClient()
 	embedder := fakeEmbedder(t, fake)
 
@@ -171,12 +171,12 @@ func TestHybridRRFAgreementWins(t *testing.T) {
 		vecOnly: "solar grid",
 		lexOnly: "completely different topic",
 	} {
-		if _, err := e.store.UpsertEmbedding(e.Admin(), "person", id, text, embedder); err != nil {
+		if _, err := e.Store.UpsertEmbedding(e.Admin(), "person", id, text, embedder); err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	hits, err := e.store.HybridSearch(e.Admin(), "solar grid", embedder, 10)
+	hits, err := e.Store.HybridSearch(e.Admin(), "solar grid", embedder, 10)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -196,9 +196,9 @@ func TestHybridRRFAgreementWins(t *testing.T) {
 }
 
 func TestEmbedGenMaintainsRowsFromEvents(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	fake := ai.NewFakeClient()
-	gen := search.NewEmbedGen(e.store, fakeEmbedder(t, fake))
+	gen := search.NewEmbedGen(e.Store, fakeEmbedder(t, fake))
 
 	personID := e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Event Driven', 'manual', 'human:x')`)
 	env := kevents.Envelope{
@@ -236,10 +236,10 @@ func TestEmbedGenMaintainsRowsFromEvents(t *testing.T) {
 // assertion surface for "which binding actually produced this row" the
 // tests below need. Every current caller checks a person row; narrow to
 // that instead of carrying an entityType parameter no test varies.
-func (e *searchEnv) storedEmbeddingModel(t *testing.T, entityID ids.UUID) string {
+func (e *SearchEnv) storedEmbeddingModel(t *testing.T, entityID ids.UUID) string {
 	t.Helper()
 	var model string
-	err := e.owner.QueryRow(context.Background(),
+	err := e.Owner.QueryRow(context.Background(),
 		`SELECT model FROM embedding WHERE workspace_id = $1 AND entity_type = 'person' AND entity_id = $2 AND chunk_ix = 0`,
 		e.WS, entityID).Scan(&model)
 	if err != nil {
@@ -254,13 +254,13 @@ func (e *searchEnv) storedEmbeddingModel(t *testing.T, entityID ids.UUID) string
 // on hash-only would leave every existing row stamped with a model that
 // no longer serves the workspace, indistinguishable from a live one.
 func TestUpsertReembedsOnIdentityChange(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	fake := ai.NewFakeClient()
 	embedderA := fakeEmbedderNamed(t, fake, "model-a")
 	embedderB := fakeEmbedderNamed(t, fake, "model-b")
 	personID := e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Identity Person', 'manual', 'human:x')`)
 
-	fresh, err := e.store.UpsertEmbedding(e.Admin(), "person", personID, "Same Text", embedderA)
+	fresh, err := e.Store.UpsertEmbedding(e.Admin(), "person", personID, "Same Text", embedderA)
 	if err != nil || !fresh {
 		t.Fatalf("first upsert fresh=%v err=%v", fresh, err)
 	}
@@ -269,7 +269,7 @@ func TestUpsertReembedsOnIdentityChange(t *testing.T) {
 		t.Fatalf("stored model = %q, want %q", gotModel, wantIdentityA)
 	}
 
-	fresh, err = e.store.UpsertEmbedding(e.Admin(), "person", personID, "Same Text", embedderB)
+	fresh, err = e.Store.UpsertEmbedding(e.Admin(), "person", personID, "Same Text", embedderB)
 	if err != nil || !fresh {
 		t.Fatalf("identity change did not re-embed unchanged text: fresh=%v err=%v", fresh, err)
 	}
@@ -287,16 +287,16 @@ func TestUpsertReembedsOnIdentityChange(t *testing.T) {
 // counterpart to the re-embed test above, so a same-binding no-op stays
 // free even after this task adds the identity comparison.
 func TestUpsertSkipsUnchangedUnderSameIdentity(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	fake := ai.NewFakeClient()
 	embedder := fakeEmbedderNamed(t, fake, "model-c")
 	personID := e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Stable Person', 'manual', 'human:x')`)
 
-	fresh, err := e.store.UpsertEmbedding(e.Admin(), "person", personID, "Stable Text", embedder)
+	fresh, err := e.Store.UpsertEmbedding(e.Admin(), "person", personID, "Stable Text", embedder)
 	if err != nil || !fresh {
 		t.Fatalf("first upsert fresh=%v err=%v", fresh, err)
 	}
-	fresh, err = e.store.UpsertEmbedding(e.Admin(), "person", personID, "Stable Text", embedder)
+	fresh, err = e.Store.UpsertEmbedding(e.Admin(), "person", personID, "Stable Text", embedder)
 	if err != nil || fresh {
 		t.Fatalf("unchanged text+identity recomputed: fresh=%v err=%v", fresh, err)
 	}
@@ -310,7 +310,7 @@ func TestUpsertSkipsUnchangedUnderSameIdentity(t *testing.T) {
 // EmbedIdentity dims — fails loudly instead of writing an unrankable
 // vector into a column other rows expect at a fixed width.
 func TestUpsertRejectsWidthMismatch(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	personID := e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Width Mismatch', 'manual', 'human:x')`)
 	// dims (999) deliberately differs from resDims (1024): the declared
 	// identity and the actual response disagree, which the width guard
@@ -321,7 +321,7 @@ func TestUpsertRejectsWidthMismatch(t *testing.T) {
 		vectors: [][]float32{make([]float32, 1024)}, resDims: 1024,
 	}
 
-	fresh, err := e.store.UpsertEmbedding(e.Admin(), "person", personID, "Width Mismatch Text", stub)
+	fresh, err := e.Store.UpsertEmbedding(e.Admin(), "person", personID, "Width Mismatch Text", stub)
 	if err == nil {
 		t.Fatal("width mismatch must be a hard error")
 	}
@@ -335,7 +335,7 @@ func TestUpsertRejectsWidthMismatch(t *testing.T) {
 // sorts FIRST, silently outranking every real match — is rejected before
 // it ever reaches storage.
 func TestUpsertRejectsZeroVector(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	personID := e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Zero Vector', 'manual', 'human:x')`)
 	// Width matches (1024/1024) so only the zero-vector guard can be what
 	// rejects this — a decoy width mismatch would leave the test proving
@@ -345,7 +345,7 @@ func TestUpsertRejectsZeroVector(t *testing.T) {
 		vectors: [][]float32{make([]float32, 1024)}, resDims: 1024,
 	}
 
-	fresh, err := e.store.UpsertEmbedding(e.Admin(), "person", personID, "Zero Vector Text", stub)
+	fresh, err := e.Store.UpsertEmbedding(e.Admin(), "person", personID, "Zero Vector Text", stub)
 	if err == nil {
 		t.Fatal("an all-zero vector must be a hard error")
 	}
@@ -364,7 +364,7 @@ func TestUpsertRejectsZeroVector(t *testing.T) {
 // the predicate were ever removed — must itself error with a dimension
 // mismatch, proving the filter is load-bearing, not decoration.
 func TestSimilarEntitiesFiltersIdentityAndDoesNotCrossDimCrash(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	ctx := context.Background()
 
 	threeDim := e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Three Dim Person', 'manual', 'human:x')`)
@@ -374,13 +374,13 @@ func TestSimilarEntitiesFiltersIdentityAndDoesNotCrossDimCrash(t *testing.T) {
 	// widths under two different identities — the mixed-width store
 	// Task 6's migration made possible, and Task 7's read-side filter
 	// must survive.
-	if _, err := e.owner.Exec(ctx, `
+	if _, err := e.Owner.Exec(ctx, `
 		INSERT INTO embedding (workspace_id, entity_type, entity_id, chunk_ix, chunk_hash, model, embedding)
 		VALUES ($1, 'person', $2, 0, 'hash-three', 'm@3', '[1,2,3]'::vector)`,
 		e.WS, threeDim); err != nil {
 		t.Fatalf("seeding the 3-dim row: %v", err)
 	}
-	if _, err := e.owner.Exec(ctx, `
+	if _, err := e.Owner.Exec(ctx, `
 		INSERT INTO embedding (workspace_id, entity_type, entity_id, chunk_ix, chunk_hash, model, embedding)
 		VALUES ($1, 'person', $2, 0, 'hash-two', 'm@2', '[1,2]'::vector)`,
 		e.WS, twoDim); err != nil {
@@ -389,7 +389,7 @@ func TestSimilarEntitiesFiltersIdentityAndDoesNotCrossDimCrash(t *testing.T) {
 
 	// (a) Filtered to "m@3": returns only the m@3 hit and does not crash
 	// against the differently-sized m@2 sibling sharing the same column.
-	hits, err := e.store.SimilarEntities(e.Admin(), []float32{1, 2, 3}, "m@3", 10)
+	hits, err := e.Store.SimilarEntities(e.Admin(), []float32{1, 2, 3}, "m@3", 10)
 	if err != nil {
 		t.Fatalf("SimilarEntities must not cross-dim crash when identity-filtered: %v", err)
 	}
@@ -446,10 +446,10 @@ func (embedIdentityNeverCalled) EmbedIdentity() (string, int) { return "", 0 }
 // EVERY embedding write and keep search.EmbedGen.HandleEvent from ever
 // acking (platform/events' at-least-once bus then redelivers forever).
 func TestUpsertEmbeddingNoOpsAndWritesNoRowOnUnboundLane(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	personID := e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Unbound Person', 'manual', 'human:x')`)
 
-	fresh, err := e.store.UpsertEmbedding(e.Admin(), "person", personID, "Unbound Person", embedIdentityNeverCalled{})
+	fresh, err := e.Store.UpsertEmbedding(e.Admin(), "person", personID, "Unbound Person", embedIdentityNeverCalled{})
 	if err != nil {
 		t.Fatalf("unbound lane must not error, got %v", err)
 	}
@@ -458,7 +458,7 @@ func TestUpsertEmbeddingNoOpsAndWritesNoRowOnUnboundLane(t *testing.T) {
 	}
 
 	var count int
-	if err := e.owner.QueryRow(context.Background(),
+	if err := e.Owner.QueryRow(context.Background(),
 		`SELECT count(*) FROM embedding WHERE workspace_id = $1 AND entity_type = 'person' AND entity_id = $2`,
 		e.WS, personID).Scan(&count); err != nil {
 		t.Fatalf("counting embedding rows: %v", err)
@@ -474,10 +474,10 @@ func TestUpsertEmbeddingNoOpsAndWritesNoRowOnUnboundLane(t *testing.T) {
 // gets — rather than calling Embed/SimilarEntities against a lane with
 // no live width or model.
 func TestHybridSearchDegradesToLexicalOnUnboundLane(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	personID := e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Lexical Only Grid', 'manual', 'human:x')`)
 
-	hits, err := e.store.HybridSearch(e.Admin(), "Lexical Only Grid", embedIdentityNeverCalled{}, 10)
+	hits, err := e.Store.HybridSearch(e.Admin(), "Lexical Only Grid", embedIdentityNeverCalled{}, 10)
 	if err != nil {
 		t.Fatalf("unbound lane must not error, got %v", err)
 	}

--- a/backend/internal/compose/integration/embeddriftsweep_integration_test.go
+++ b/backend/internal/compose/integration/embeddriftsweep_integration_test.go
@@ -40,11 +40,11 @@ func TestSweepWorkspaceEmbeddingDriftHealsIdentityMatchedGaps(t *testing.T) {
 		t.Fatalf("SeedBinding: %v", err)
 	}
 
-	embeddedID := e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Embedded Person', 'manual', 'human:x')`)
+	embeddedID := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Embedded Person', 'manual', 'human:x')`)
 	if _, err := e.Store.UpsertEmbedding(e.Admin(), "person", embeddedID, "Embedded Person", embedder); err != nil {
 		t.Fatalf("seeding the already-embedded baseline: %v", err)
 	}
-	lostID := e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Lost Event Person', 'manual', 'human:x')`)
+	lostID := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Lost Event Person', 'manual', 'human:x')`)
 	baselineCalls := len(fake.Calls())
 
 	healed, err := e.Store.SweepWorkspaceEmbeddingDrift(ctx, ids.From[ids.WorkspaceKind](e.WS), embedder)
@@ -102,7 +102,7 @@ func TestSweepWorkspaceEmbeddingDriftRefusesTheBindingChangeCase(t *testing.T) {
 	if err := e.Store.SeedBinding(ctx, "provider/model-old@1024"); err != nil {
 		t.Fatalf("SeedBinding: %v", err)
 	}
-	e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Unswept Person', 'manual', 'human:x')`)
+	e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Unswept Person', 'manual', 'human:x')`)
 
 	// The refusal only proves anything if there was real pending work to
 	// refuse — healed==0 over an empty pending set is vacuous.
@@ -144,7 +144,7 @@ func TestSweepWorkspaceEmbeddingDriftWaitsOutARunningReindex(t *testing.T) {
 	if err := e.Store.ClaimAndEnqueueReembedding(ctx, search.ReembedClaim{Run: ids.NewV7(), TargetIdentity: identity}, func(pgx.Tx) error { return nil }); err != nil {
 		t.Fatalf("ClaimAndEnqueueReembedding: %v", err)
 	}
-	e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Mid Reindex Person', 'manual', 'human:x')`)
+	e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Mid Reindex Person', 'manual', 'human:x')`)
 
 	// The wait-out only proves anything if the sweep had real pending work
 	// it chose not to touch — healed==0 over an empty set is vacuous.

--- a/backend/internal/compose/integration/embeddriftsweep_integration_test.go
+++ b/backend/internal/compose/integration/embeddriftsweep_integration_test.go
@@ -30,24 +30,24 @@ import (
 // one: one model call, pending drops to 0, and the binding marker is not
 // touched (the sweep is not a reindex and must never stamp the marker).
 func TestSweepWorkspaceEmbeddingDriftHealsIdentityMatchedGaps(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	ctx := context.Background()
 	fake := ai.NewFakeClient()
 	embedder := fakeEmbedderNamed(t, fake, "model-current")
 	identity, _ := embedder.EmbedIdentity()
 
-	if err := e.store.SeedBinding(ctx, identity); err != nil {
+	if err := e.Store.SeedBinding(ctx, identity); err != nil {
 		t.Fatalf("SeedBinding: %v", err)
 	}
 
 	embeddedID := e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Embedded Person', 'manual', 'human:x')`)
-	if _, err := e.store.UpsertEmbedding(e.Admin(), "person", embeddedID, "Embedded Person", embedder); err != nil {
+	if _, err := e.Store.UpsertEmbedding(e.Admin(), "person", embeddedID, "Embedded Person", embedder); err != nil {
 		t.Fatalf("seeding the already-embedded baseline: %v", err)
 	}
 	lostID := e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Lost Event Person', 'manual', 'human:x')`)
 	baselineCalls := len(fake.Calls())
 
-	healed, err := e.store.SweepWorkspaceEmbeddingDrift(ctx, ids.From[ids.WorkspaceKind](e.WS), embedder)
+	healed, err := e.Store.SweepWorkspaceEmbeddingDrift(ctx, ids.From[ids.WorkspaceKind](e.WS), embedder)
 	if err != nil {
 		t.Fatalf("SweepWorkspaceEmbeddingDrift: %v", err)
 	}
@@ -61,7 +61,7 @@ func TestSweepWorkspaceEmbeddingDriftHealsIdentityMatchedGaps(t *testing.T) {
 		t.Fatalf("lost entity's embedding model = %q, want %q", got, identity)
 	}
 
-	pending, err := e.store.EntitiesPending(ctx, identity)
+	pending, err := e.Store.EntitiesPending(ctx, identity)
 	if err != nil {
 		t.Fatalf("EntitiesPending: %v", err)
 	}
@@ -69,7 +69,7 @@ func TestSweepWorkspaceEmbeddingDriftHealsIdentityMatchedGaps(t *testing.T) {
 		t.Fatalf("EntitiesPending = %d, want 0 after the sweep", pending)
 	}
 
-	populated, status, _, err := e.store.PopulatedIdentity(ctx)
+	populated, status, _, err := e.Store.PopulatedIdentity(ctx)
 	if err != nil {
 		t.Fatalf("PopulatedIdentity: %v", err)
 	}
@@ -79,7 +79,7 @@ func TestSweepWorkspaceEmbeddingDriftHealsIdentityMatchedGaps(t *testing.T) {
 
 	// A second pass over a healed store is a no-op — the sweep is safe to
 	// tick forever.
-	healed, err = e.store.SweepWorkspaceEmbeddingDrift(ctx, ids.From[ids.WorkspaceKind](e.WS), embedder)
+	healed, err = e.Store.SweepWorkspaceEmbeddingDrift(ctx, ids.From[ids.WorkspaceKind](e.WS), embedder)
 	if err != nil {
 		t.Fatalf("second SweepWorkspaceEmbeddingDrift: %v", err)
 	}
@@ -94,12 +94,12 @@ func TestSweepWorkspaceEmbeddingDriftHealsIdentityMatchedGaps(t *testing.T) {
 // that state is the operator's preview→confirm rebuild to trigger, never
 // the sweep's (ADR-0069 §3a keeps the consent gate exactly there).
 func TestSweepWorkspaceEmbeddingDriftRefusesTheBindingChangeCase(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	ctx := context.Background()
 	fake := ai.NewFakeClient()
 	embedder := fakeEmbedderNamed(t, fake, "model-new")
 
-	if err := e.store.SeedBinding(ctx, "provider/model-old@1024"); err != nil {
+	if err := e.Store.SeedBinding(ctx, "provider/model-old@1024"); err != nil {
 		t.Fatalf("SeedBinding: %v", err)
 	}
 	e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Unswept Person', 'manual', 'human:x')`)
@@ -107,7 +107,7 @@ func TestSweepWorkspaceEmbeddingDriftRefusesTheBindingChangeCase(t *testing.T) {
 	// The refusal only proves anything if there was real pending work to
 	// refuse — healed==0 over an empty pending set is vacuous.
 	identity, _ := embedder.EmbedIdentity()
-	pending, err := e.store.EntitiesPending(ctx, identity)
+	pending, err := e.Store.EntitiesPending(ctx, identity)
 	if err != nil {
 		t.Fatalf("EntitiesPending: %v", err)
 	}
@@ -115,7 +115,7 @@ func TestSweepWorkspaceEmbeddingDriftRefusesTheBindingChangeCase(t *testing.T) {
 		t.Fatalf("test setup: EntitiesPending = %d, want 1", pending)
 	}
 
-	healed, err := e.store.SweepWorkspaceEmbeddingDrift(ctx, ids.From[ids.WorkspaceKind](e.WS), embedder)
+	healed, err := e.Store.SweepWorkspaceEmbeddingDrift(ctx, ids.From[ids.WorkspaceKind](e.WS), embedder)
 	if err != nil {
 		t.Fatalf("SweepWorkspaceEmbeddingDrift: %v", err)
 	}
@@ -132,23 +132,23 @@ func TestSweepWorkspaceEmbeddingDriftRefusesTheBindingChangeCase(t *testing.T) {
 // the store for that window, and the sweep re-running underneath it would
 // double-walk the same pending set for nothing.
 func TestSweepWorkspaceEmbeddingDriftWaitsOutARunningReindex(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	ctx := context.Background()
 	fake := ai.NewFakeClient()
 	embedder := fakeEmbedderNamed(t, fake, "model-current")
 	identity, _ := embedder.EmbedIdentity()
 
-	if err := e.store.SeedBinding(ctx, identity); err != nil {
+	if err := e.Store.SeedBinding(ctx, identity); err != nil {
 		t.Fatalf("SeedBinding: %v", err)
 	}
-	if err := e.store.ClaimAndEnqueueReembedding(ctx, search.ReembedClaim{Run: ids.NewV7(), TargetIdentity: identity}, func(pgx.Tx) error { return nil }); err != nil {
+	if err := e.Store.ClaimAndEnqueueReembedding(ctx, search.ReembedClaim{Run: ids.NewV7(), TargetIdentity: identity}, func(pgx.Tx) error { return nil }); err != nil {
 		t.Fatalf("ClaimAndEnqueueReembedding: %v", err)
 	}
 	e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Mid Reindex Person', 'manual', 'human:x')`)
 
 	// The wait-out only proves anything if the sweep had real pending work
 	// it chose not to touch — healed==0 over an empty set is vacuous.
-	pending, err := e.store.EntitiesPending(ctx, identity)
+	pending, err := e.Store.EntitiesPending(ctx, identity)
 	if err != nil {
 		t.Fatalf("EntitiesPending: %v", err)
 	}
@@ -156,7 +156,7 @@ func TestSweepWorkspaceEmbeddingDriftWaitsOutARunningReindex(t *testing.T) {
 		t.Fatalf("test setup: EntitiesPending = %d, want 1", pending)
 	}
 
-	healed, err := e.store.SweepWorkspaceEmbeddingDrift(ctx, ids.From[ids.WorkspaceKind](e.WS), embedder)
+	healed, err := e.Store.SweepWorkspaceEmbeddingDrift(ctx, ids.From[ids.WorkspaceKind](e.WS), embedder)
 	if err != nil {
 		t.Fatalf("SweepWorkspaceEmbeddingDrift: %v", err)
 	}

--- a/backend/internal/compose/integration/embedreindex_fanout_integration_test.go
+++ b/backend/internal/compose/integration/embedreindex_fanout_integration_test.go
@@ -27,7 +27,7 @@ import (
 
 // reembedFleetEnv is one search harness plus a claimed run over a named fleet.
 type reembedFleetEnv struct {
-	*searchEnv
+	*SearchEnv
 	embedder search.Embedder
 	identity string
 	run      ids.UUID
@@ -39,20 +39,20 @@ type reembedFleetEnv struct {
 // exercise is the RUN, and the confirm has its own suite.
 func setupReembedFleet(t *testing.T) *reembedFleetEnv {
 	t.Helper()
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	ctx := context.Background()
 	ApplyRiverSchema(t)
 	embedder := fakeEmbedderNamed(t, ai.NewFakeClient(), "model-fanout")
 	identity, _ := embedder.EmbedIdentity()
-	if err := e.store.SeedBinding(ctx, identity); err != nil {
+	if err := e.Store.SeedBinding(ctx, identity); err != nil {
 		t.Fatalf("SeedBinding: %v", err)
 	}
 	run := ids.NewV7()
-	if err := e.store.ClaimAndEnqueueReembedding(ctx,
+	if err := e.Store.ClaimAndEnqueueReembedding(ctx,
 		search.ReembedClaim{Run: run, TargetIdentity: identity}, func(pgx.Tx) error { return nil }); err != nil {
 		t.Fatalf("claiming the run: %v", err)
 	}
-	return &reembedFleetEnv{searchEnv: e, embedder: embedder, identity: identity, run: run}
+	return &reembedFleetEnv{SearchEnv: e, embedder: embedder, identity: identity, run: run}
 }
 
 // TestEmbedReindexFansOutOneJobPerLiveWorkspaceAndFailsOnlyTheFailedTenant is
@@ -64,21 +64,21 @@ func setupReembedFleet(t *testing.T) *reembedFleetEnv {
 // reached every workspace it is ever going to.
 func TestEmbedReindexFansOutOneJobPerLiveWorkspaceAndFailsOnlyTheFailedTenant(t *testing.T) {
 	re := setupReembedFleet(t)
-	healthy := seedExtraWorkspace(t, re.owner, "reindex-healthy", false)
-	archived := seedExtraWorkspace(t, re.owner, "reindex-archived", true)
+	healthy := seedExtraWorkspace(t, re.Owner, "reindex-healthy", false)
+	archived := seedExtraWorkspace(t, re.Owner, "reindex-archived", true)
 
 	// Both live tenants get an entity to embed, so each child has real work and
 	// the victim's write actually reaches the fault.
 	re.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Faulted Fanout Person', 'manual', 'human:x')`)
 	healthyPersonID := ids.NewV7()
-	if _, err := re.owner.Exec(context.Background(),
+	if _, err := re.Owner.Exec(context.Background(),
 		`INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Healthy Fanout Person', 'manual', 'human:x')`,
 		healthyPersonID, healthy); err != nil {
 		t.Fatalf("seeding the healthy tenant's person: %v", err)
 	}
 	// Permanent, not transient: a fault that healed would let the tenant
 	// complete on a later attempt and read as green — the outcome this denies.
-	failEmbeddingWritesFor(t, re.owner, re.WS)
+	failEmbeddingWritesFor(t, re.Owner, re.WS)
 
 	runner, completed, failed := startTestJobRunner(t, re.Pool, compose.JobRunnerConfig{
 		CloseDateInterval: time.Hour,
@@ -106,7 +106,7 @@ func TestEmbedReindexFansOutOneJobPerLiveWorkspaceAndFailsOnlyTheFailedTenant(t 
 	}
 	// The pass is only worth a row if it did the work.
 	var model string
-	if err := re.owner.QueryRow(context.Background(),
+	if err := re.Owner.QueryRow(context.Background(),
 		`SELECT model FROM embedding WHERE workspace_id = $1 AND entity_type = 'person' AND entity_id = $2 AND chunk_ix = 0`,
 		healthy, healthyPersonID).Scan(&model); err != nil {
 		t.Fatalf("reading the healthy tenant's embedding: %v", err)
@@ -179,7 +179,7 @@ func TestEmbedReindexForceTakesTheMarkerBackFromAWedgedRun(t *testing.T) {
 // with no job anywhere to explain why.
 func TestEmbedReindexDispatcherWithAnEmptyFleetHandsTheMarkerBack(t *testing.T) {
 	re := setupReembedFleet(t)
-	if _, err := re.owner.Exec(context.Background(),
+	if _, err := re.Owner.Exec(context.Background(),
 		`UPDATE workspace SET archived_at = now() WHERE id = $1`, re.WS); err != nil {
 		t.Fatalf("archiving the only workspace: %v", err)
 	}
@@ -197,7 +197,7 @@ func TestEmbedReindexDispatcherWithAnEmptyFleetHandsTheMarkerBack(t *testing.T) 
 	defer cancel()
 	awaitKindsCompleted(waitCtx, t, completed, compose.EmbedReindexArgs{}.Kind())
 
-	populated, status, _, err := re.store.PopulatedIdentity(context.Background())
+	populated, status, _, err := re.Store.PopulatedIdentity(context.Background())
 	if err != nil {
 		t.Fatalf("PopulatedIdentity: %v", err)
 	}

--- a/backend/internal/compose/integration/embedreindex_fanout_integration_test.go
+++ b/backend/internal/compose/integration/embedreindex_fanout_integration_test.go
@@ -69,7 +69,7 @@ func TestEmbedReindexFansOutOneJobPerLiveWorkspaceAndFailsOnlyTheFailedTenant(t 
 
 	// Both live tenants get an entity to embed, so each child has real work and
 	// the victim's write actually reaches the fault.
-	re.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Faulted Fanout Person', 'manual', 'human:x')`)
+	re.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Faulted Fanout Person', 'manual', 'human:x')`)
 	healthyPersonID := ids.NewV7()
 	if _, err := re.Owner.Exec(context.Background(),
 		`INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Healthy Fanout Person', 'manual', 'human:x')`,

--- a/backend/internal/compose/integration/export_integration_test.go
+++ b/backend/internal/compose/integration/export_integration_test.go
@@ -69,56 +69,56 @@ type exportFixture struct {
 
 func (e *SearchEnv) seedExportFixture(t *testing.T) exportFixture {
 	t.Helper()
-	pipelineID := e.seed(t, `INSERT INTO pipeline (id, workspace_id, name, is_default, position) VALUES ($1, $2, 'Sales', true, 0)`)
-	stageID := e.seed(t, `INSERT INTO stage (id, workspace_id, pipeline_id, name, position, semantic, win_probability) VALUES ($1, $2, $3, 'Qualify', 0, 'open', 10)`, pipelineID)
+	pipelineID := e.Seed(t, `INSERT INTO pipeline (id, workspace_id, name, is_default, position) VALUES ($1, $2, 'Sales', true, 0)`)
+	stageID := e.Seed(t, `INSERT INTO stage (id, workspace_id, pipeline_id, name, position, semantic, win_probability) VALUES ($1, $2, $3, 'Qualify', 0, 'open', 10)`, pipelineID)
 
 	var f exportFixture
 	// rep1 (team1) carries a social row to prove the child relation
 	// travels with its parent.
-	f.rep1Person = e.seed(t, `INSERT INTO person (id, workspace_id, owner_id, full_name, source, captured_by)
+	f.rep1Person = e.Seed(t, `INSERT INTO person (id, workspace_id, owner_id, full_name, source, captured_by)
 		VALUES ($1, $2, $3, 'Rep1 Person', 'manual', 'human:x')`, e.Rep1)
-	e.seed(t, `INSERT INTO person_social (id, workspace_id, person_id, platform, handle)
+	e.Seed(t, `INSERT INTO person_social (id, workspace_id, person_id, platform, handle)
 		VALUES ($1, $2, $3, 'linkedin', 'in/rep1')`, f.rep1Person)
-	f.rep3Person = e.seed(t, `INSERT INTO person (id, workspace_id, owner_id, full_name, source, captured_by)
+	f.rep3Person = e.Seed(t, `INSERT INTO person (id, workspace_id, owner_id, full_name, source, captured_by)
 		VALUES ($1, $2, $3, 'Rep3 Person', 'manual', 'human:x')`, e.Rep3)
-	f.rep1Org = e.seed(t, `INSERT INTO organization (id, workspace_id, owner_id, display_name, source, captured_by)
+	f.rep1Org = e.Seed(t, `INSERT INTO organization (id, workspace_id, owner_id, display_name, source, captured_by)
 		VALUES ($1, $2, $3, 'Rep1 Org', 'manual', 'human:x')`, e.Rep1)
-	f.rep3Org = e.seed(t, `INSERT INTO organization (id, workspace_id, owner_id, display_name, source, captured_by)
+	f.rep3Org = e.Seed(t, `INSERT INTO organization (id, workspace_id, owner_id, display_name, source, captured_by)
 		VALUES ($1, $2, $3, 'Rep3 Org', 'manual', 'human:x')`, e.Rep3)
-	f.rep1Deal = e.seed(t, `INSERT INTO deal (id, workspace_id, owner_id, name, pipeline_id, stage_id, organization_id, amount_minor, currency, source, captured_by)
+	f.rep1Deal = e.Seed(t, `INSERT INTO deal (id, workspace_id, owner_id, name, pipeline_id, stage_id, organization_id, amount_minor, currency, source, captured_by)
 		VALUES ($1, $2, $3, 'Rep1 Deal', $4, $5, $6, 100000, 'EUR', 'manual', 'human:x')`, e.Rep1, pipelineID, stageID, f.rep1Org)
-	f.rep3Deal = e.seed(t, `INSERT INTO deal (id, workspace_id, owner_id, name, pipeline_id, stage_id, organization_id, amount_minor, currency, source, captured_by)
+	f.rep3Deal = e.Seed(t, `INSERT INTO deal (id, workspace_id, owner_id, name, pipeline_id, stage_id, organization_id, amount_minor, currency, source, captured_by)
 		VALUES ($1, $2, $3, 'Rep3 Deal', $4, $5, $6, 200000, 'EUR', 'manual', 'human:x')`, e.Rep3, pipelineID, stageID, f.rep3Org)
-	f.rep1Lead = e.seed(t, `INSERT INTO lead (id, workspace_id, owner_id, full_name, source, captured_by)
+	f.rep1Lead = e.Seed(t, `INSERT INTO lead (id, workspace_id, owner_id, full_name, source, captured_by)
 		VALUES ($1, $2, $3, 'Rep1 Lead', 'manual', 'human:x')`, e.Rep1)
-	f.rep3Lead = e.seed(t, `INSERT INTO lead (id, workspace_id, owner_id, full_name, source, captured_by)
+	f.rep3Lead = e.Seed(t, `INSERT INTO lead (id, workspace_id, owner_id, full_name, source, captured_by)
 		VALUES ($1, $2, $3, 'Rep3 Lead', 'manual', 'human:x')`, e.Rep3)
 
 	// Employment edges: each connects a rep's person to that rep's org, so
 	// the whole edge is visible only to that rep (both endpoints owned).
-	e.seed(t, `INSERT INTO relationship (id, workspace_id, kind, person_id, organization_id, source, captured_by)
+	e.Seed(t, `INSERT INTO relationship (id, workspace_id, kind, person_id, organization_id, source, captured_by)
 		VALUES ($1, $2, 'employment', $3, $4, 'manual', 'human:x')`, f.rep1Person, f.rep1Org)
-	e.seed(t, `INSERT INTO relationship (id, workspace_id, kind, person_id, organization_id, source, captured_by)
+	e.Seed(t, `INSERT INTO relationship (id, workspace_id, kind, person_id, organization_id, source, captured_by)
 		VALUES ($1, $2, 'employment', $3, $4, 'manual', 'human:x')`, f.rep3Person, f.rep3Org)
 
 	// Activities scope through their links.
-	f.rep1Activity = e.seed(t, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, source, captured_by)
+	f.rep1Activity = e.Seed(t, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, source, captured_by)
 		VALUES ($1, $2, 'note', 'Rep1 note', now(), 'manual', 'human:x')`)
-	e.seed(t, `INSERT INTO activity_link (id, workspace_id, activity_id, entity_type, person_id) VALUES ($1, $2, $3, 'person', $4)`, f.rep1Activity, f.rep1Person)
-	f.rep3Activity = e.seed(t, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, source, captured_by)
+	e.Seed(t, `INSERT INTO activity_link (id, workspace_id, activity_id, entity_type, person_id) VALUES ($1, $2, $3, 'person', $4)`, f.rep1Activity, f.rep1Person)
+	f.rep3Activity = e.Seed(t, `INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, source, captured_by)
 		VALUES ($1, $2, 'note', 'Rep3 note', now(), 'manual', 'human:x')`)
-	e.seed(t, `INSERT INTO activity_link (id, workspace_id, activity_id, entity_type, person_id) VALUES ($1, $2, $3, 'person', $4)`, f.rep3Activity, f.rep3Person)
+	e.Seed(t, `INSERT INTO activity_link (id, workspace_id, activity_id, entity_type, person_id) VALUES ($1, $2, $3, 'person', $4)`, f.rep3Activity, f.rep3Person)
 
 	// Attachments on each rep's person — the files manifest source.
-	e.seed(t, `INSERT INTO attachment (id, workspace_id, entity_type, entity_id, filename, storage_key, source, captured_by)
+	e.Seed(t, `INSERT INTO attachment (id, workspace_id, entity_type, entity_id, filename, storage_key, source, captured_by)
 		VALUES ($1, $2, 'person', $3, 'rep1.pdf', 'blob/rep1', 'manual', 'human:x')`, f.rep1Person)
-	e.seed(t, `INSERT INTO attachment (id, workspace_id, entity_type, entity_id, filename, storage_key, source, captured_by)
+	e.Seed(t, `INSERT INTO attachment (id, workspace_id, entity_type, entity_id, filename, storage_key, source, captured_by)
 		VALUES ($1, $2, 'person', $3, 'rep3.pdf', 'blob/rep3', 'manual', 'human:x')`, f.rep3Person)
 
 	// Audit rows targeting each rep's person (audit_log is record-mutations-only).
-	e.seed(t, `INSERT INTO audit_log (id, workspace_id, actor_type, actor_id, action, entity_type, entity_id)
+	e.Seed(t, `INSERT INTO audit_log (id, workspace_id, actor_type, actor_id, action, entity_type, entity_id)
 		VALUES ($1, $2, 'human', $3, 'create', 'person', $4)`, "human:"+e.Rep1.String(), f.rep1Person)
-	e.seed(t, `INSERT INTO audit_log (id, workspace_id, actor_type, actor_id, action, entity_type, entity_id)
+	e.Seed(t, `INSERT INTO audit_log (id, workspace_id, actor_type, actor_id, action, entity_type, entity_id)
 		VALUES ($1, $2, 'human', $3, 'create', 'person', $4)`, "human:"+e.Rep3.String(), f.rep3Person)
 	return f
 }

--- a/backend/internal/compose/integration/export_integration_test.go
+++ b/backend/internal/compose/integration/export_integration_test.go
@@ -38,7 +38,7 @@ func exportReadGrants() map[string]principal.ObjectGrant {
 	return grants
 }
 
-func (e *searchEnv) exportAdmin() context.Context {
+func (e *SearchEnv) exportAdmin() context.Context {
 	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
 	return principal.WithActor(ctx, principal.Principal{
 		Type: principal.PrincipalHuman, ID: "human:" + ids.NewV7().String(), UserID: ids.NewV7(),
@@ -46,7 +46,7 @@ func (e *searchEnv) exportAdmin() context.Context {
 	})
 }
 
-func (e *searchEnv) exportRep(user, team ids.UUID) context.Context {
+func (e *SearchEnv) exportRep(user, team ids.UUID) context.Context {
 	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
 	return principal.WithActor(ctx, principal.Principal{
 		Type: principal.PrincipalHuman, ID: "human:" + user.String(), UserID: user,
@@ -67,7 +67,7 @@ type exportFixture struct {
 	rep3Activity           ids.UUID
 }
 
-func (e *searchEnv) seedExportFixture(t *testing.T) exportFixture {
+func (e *SearchEnv) seedExportFixture(t *testing.T) exportFixture {
 	t.Helper()
 	pipelineID := e.seed(t, `INSERT INTO pipeline (id, workspace_id, name, is_default, position) VALUES ($1, $2, 'Sales', true, 0)`)
 	stageID := e.seed(t, `INSERT INTO stage (id, workspace_id, pipeline_id, name, position, semantic, win_probability) VALUES ($1, $2, $3, 'Qualify', 0, 'open', 10)`, pipelineID)
@@ -177,7 +177,7 @@ func csvColumn(t *testing.T, raw []byte, column string) []string {
 }
 
 func TestExportBundleCompleteAndValidOpenFormat(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	f := e.seedExportFixture(t)
 
 	var buf bytes.Buffer
@@ -246,7 +246,7 @@ func TestExportBundleCompleteAndValidOpenFormat(t *testing.T) {
 // exactly its own records and none of the other team's — across every
 // scoped member (records, edges, activities, files, audit).
 func TestExportRowScopeExcludesInvisibleRecords(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	f := e.seedExportFixture(t)
 
 	var buf bytes.Buffer
@@ -301,7 +301,7 @@ func TestExportRowScopeExcludesInvisibleRecords(t *testing.T) {
 // RBAC bounds what the export contains: an object with no read grant is
 // omitted from the bundle entirely, not silently dumped.
 func TestExportOmitsObjectsWithoutReadGrant(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	e.seedExportFixture(t)
 
 	ctx := principal.WithWorkspaceID(context.Background(), e.WS)

--- a/backend/internal/compose/integration/fieldprovenance_integration_test.go
+++ b/backend/internal/compose/integration/fieldprovenance_integration_test.go
@@ -27,7 +27,7 @@ import (
 
 func TestFieldProvenanceCoversCaptureAcrossObjectTypes(t *testing.T) {
 	e := SetupSearch(t)
-	personID := e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Inbox Sender', 'manual', 'human:x')`)
+	personID := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Inbox Sender', 'manual', 'human:x')`)
 
 	registry := newTestCaptureRegistry(e, newTestKeyvault(t, e))
 	fake := &mailFake{linkTo: personID}

--- a/backend/internal/compose/integration/fieldprovenance_integration_test.go
+++ b/backend/internal/compose/integration/fieldprovenance_integration_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestFieldProvenanceCoversCaptureAcrossObjectTypes(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	personID := e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Inbox Sender', 'manual', 'human:x')`)
 
 	registry := newTestCaptureRegistry(e, newTestKeyvault(t, e))
@@ -82,7 +82,7 @@ func TestFieldProvenanceCoversCaptureAcrossObjectTypes(t *testing.T) {
 // assertCaptureStampedBothObjectTypes checks the capture stamped
 // field-level provenance for BOTH object types it created (activity +
 // lead), under the connector's identity.
-func assertCaptureStampedBothObjectTypes(t *testing.T, e *searchEnv) {
+func assertCaptureStampedBothObjectTypes(t *testing.T, e *SearchEnv) {
 	t.Helper()
 	type stampRow struct {
 		objectType, field, source, capturedBy string
@@ -123,9 +123,9 @@ func assertCaptureStampedBothObjectTypes(t *testing.T, e *searchEnv) {
 // JSONB provenance column (gate Q1) — derived from the live schema so a
 // future object cannot quietly reintroduce the rejected shape.
 func TestNoPerObjectJSONBProvenanceBacking(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	var offenders int
-	err := e.owner.QueryRow(context.Background(), `
+	err := e.Owner.QueryRow(context.Background(), `
 		SELECT count(*) FROM information_schema.columns
 		WHERE table_schema = 'public'
 		  AND data_type = 'jsonb'

--- a/backend/internal/compose/integration/filteredexport_integration_test.go
+++ b/backend/internal/compose/integration/filteredexport_integration_test.go
@@ -39,7 +39,7 @@ type filteredDealFixture struct {
 	matchOther ids.UUID // rep3, forecast 'commit' — matches but invisible to rep1
 }
 
-func (e *searchEnv) seedFilteredDeals(t *testing.T) filteredDealFixture {
+func (e *SearchEnv) seedFilteredDeals(t *testing.T) filteredDealFixture {
 	t.Helper()
 	pipelineID := e.seed(t, `INSERT INTO pipeline (id, workspace_id, name, is_default, position) VALUES ($1, $2, 'Sales', true, 0)`)
 	stageID := e.seed(t, `INSERT INTO stage (id, workspace_id, pipeline_id, name, position, semantic, win_probability) VALUES ($1, $2, $3, 'Qualify', 0, 'open', 10)`, pipelineID)
@@ -65,7 +65,7 @@ func commitDeals() storekit.Predicate {
 // both visible to them and match the predicate — excluding invisible rows
 // AND non-matching rows.
 func TestFilteredExportIsScopedAndFiltered(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	f := e.seedFilteredDeals(t)
 
 	result, err := compose.NewFilteredExportWriter(e.Pool).WriteFiltered(
@@ -98,7 +98,7 @@ func TestFilteredExportIsScopedAndFiltered(t *testing.T) {
 // and carry the same slice, and that the export operation writes one
 // audit_log row describing what slice was exported.
 func TestFilteredExportOpenFormatsAndAudit(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	e.seedFilteredDeals(t)
 	writer := compose.NewFilteredExportWriter(e.Pool)
 
@@ -155,7 +155,7 @@ func TestFilteredExportOpenFormatsAndAudit(t *testing.T) {
 // TestFilteredExportEmptyResultIsHonest: a predicate that matches nothing
 // yields a valid CSV with only the header row, not an error.
 func TestFilteredExportEmptyResultIsHonest(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	e.seedFilteredDeals(t)
 
 	result, err := compose.NewFilteredExportWriter(e.Pool).WriteFiltered(
@@ -181,7 +181,7 @@ func TestFilteredExportEmptyResultIsHonest(t *testing.T) {
 // resource's §13.5 allow-list is a PredicateError the transport maps to
 // 422 — the filter can never reach an arbitrary column.
 func TestFilteredExportRejectsOutOfVocabularyPredicate(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	e.seedFilteredDeals(t)
 
 	_, err := compose.NewFilteredExportWriter(e.Pool).WriteFiltered(
@@ -200,10 +200,10 @@ func TestFilteredExportRejectsOutOfVocabularyPredicate(t *testing.T) {
 // lastSystemLog reads the most recent system_log row for an action inside
 // the workspace-bound GUC (FORCE RLS applies even to the table owner), so the
 // suite can assert the export was recorded.
-func lastSystemLog(t *testing.T, e *searchEnv, action string) (gotAction string, detail map[string]any) {
+func lastSystemLog(t *testing.T, e *SearchEnv, action string) (gotAction string, detail map[string]any) {
 	t.Helper()
 	ctx := context.Background()
-	tx, err := e.owner.Begin(ctx)
+	tx, err := e.Owner.Begin(ctx)
 	if err != nil {
 		t.Fatalf("begin: %v", err)
 	}

--- a/backend/internal/compose/integration/filteredexport_integration_test.go
+++ b/backend/internal/compose/integration/filteredexport_integration_test.go
@@ -41,11 +41,11 @@ type filteredDealFixture struct {
 
 func (e *SearchEnv) seedFilteredDeals(t *testing.T) filteredDealFixture {
 	t.Helper()
-	pipelineID := e.seed(t, `INSERT INTO pipeline (id, workspace_id, name, is_default, position) VALUES ($1, $2, 'Sales', true, 0)`)
-	stageID := e.seed(t, `INSERT INTO stage (id, workspace_id, pipeline_id, name, position, semantic, win_probability) VALUES ($1, $2, $3, 'Qualify', 0, 'open', 10)`, pipelineID)
+	pipelineID := e.Seed(t, `INSERT INTO pipeline (id, workspace_id, name, is_default, position) VALUES ($1, $2, 'Sales', true, 0)`)
+	stageID := e.Seed(t, `INSERT INTO stage (id, workspace_id, pipeline_id, name, position, semantic, win_probability) VALUES ($1, $2, $3, 'Qualify', 0, 'open', 10)`, pipelineID)
 
 	deal := func(owner ids.UUID, name, forecast string) ids.UUID {
-		return e.seed(t, `INSERT INTO deal (id, workspace_id, owner_id, name, pipeline_id, stage_id, forecast_category, source, captured_by)
+		return e.Seed(t, `INSERT INTO deal (id, workspace_id, owner_id, name, pipeline_id, stage_id, forecast_category, source, captured_by)
 			VALUES ($1, $2, $3, $4, $5, $6, $7, 'manual', 'human:x')`, owner, name, pipelineID, stageID, forecast)
 	}
 	return filteredDealFixture{

--- a/backend/internal/compose/integration/gcal_connector_integration_test.go
+++ b/backend/internal/compose/integration/gcal_connector_integration_test.go
@@ -75,7 +75,7 @@ func gcalStub(t *testing.T, owner string) *httptest.Server {
 }
 
 func TestGcalConnectorSyncsExternalMeetingAndSkipsInternal(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	const owner = "rep@ws.example"
 	stub := gcalStub(t, owner)
 
@@ -153,7 +153,7 @@ func TestGcalConnectorSyncsExternalMeetingAndSkipsInternal(t *testing.T) {
 // listConnectors / the fleet due-poll / disconnectConnector for the one gcal
 // connection: it lists connected, is paced out right after a sync, becomes due
 // again once the pacing clock passes, and after disconnect the poller skips it.
-func assertGcalConnectionSurface(grantCtx context.Context, e *searchEnv, t *testing.T, registry *capture.Registry, connID ids.UUID) {
+func assertGcalConnectionSurface(grantCtx context.Context, e *SearchEnv, t *testing.T, registry *capture.Registry, connID ids.UUID) {
 	t.Helper()
 	views, err := registry.Connections(grantCtx)
 	if err != nil {

--- a/backend/internal/compose/integration/gmail_connector_integration_test.go
+++ b/backend/internal/compose/integration/gmail_connector_integration_test.go
@@ -80,7 +80,7 @@ func writeJSON(w http.ResponseWriter, v any) {
 }
 
 func TestGmailConnectorSyncsAnActivity(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	const owner = "rep@ws.example"
 	stub := gmailStub(t, owner)
 

--- a/backend/internal/compose/integration/gmail_push_integration_test.go
+++ b/backend/internal/compose/integration/gmail_push_integration_test.go
@@ -48,7 +48,7 @@ func pushBody(t *testing.T, email string) []byte {
 }
 
 func TestGmailPushWebhookRoutesToTheConnection(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	const mailbox = "push-owner@ws.example"
 
 	registry := newTestCaptureRegistry(e, newTestKeyvault(t, e))

--- a/backend/internal/compose/integration/gmail_watch_integration_test.go
+++ b/backend/internal/compose/integration/gmail_watch_integration_test.go
@@ -34,7 +34,7 @@ import (
 const gmailPushTopic = "projects/margince/topics/gmail-push"
 
 func TestGmailWatchRegistersRenewsAndLeavesCursor(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	const owner = "rep@ws.example"
 	stub := gmailStub(t, owner)
 
@@ -121,7 +121,7 @@ func TestGmailWatchRegistersRenewsAndLeavesCursor(t *testing.T) {
 // the watch on RunOnStart and writes watch_expires_at — the scheduled path,
 // not a direct RenewWatch call.
 func TestGmailWatchJobRenewsOnSchedule(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	ApplyRiverSchema(t)
 	const owner = "rep@ws.example"
 	stub := gmailStub(t, owner)
@@ -199,7 +199,7 @@ func awaitWatchKindCompleted(ctx context.Context, t *testing.T, sub <-chan *rive
 	}
 }
 
-func readCursor(t *testing.T, e *searchEnv, connID ids.UUID) []byte {
+func readCursor(t *testing.T, e *SearchEnv, connID ids.UUID) []byte {
 	t.Helper()
 	var cursor []byte
 	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
@@ -212,7 +212,7 @@ func readCursor(t *testing.T, e *searchEnv, connID ids.UUID) []byte {
 	return cursor
 }
 
-func readWatchExpiry(t *testing.T, e *searchEnv, connID ids.UUID) *time.Time {
+func readWatchExpiry(t *testing.T, e *SearchEnv, connID ids.UUID) *time.Time {
 	t.Helper()
 	var exp *time.Time
 	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {

--- a/backend/internal/compose/integration/grants_integration_test.go
+++ b/backend/internal/compose/integration/grants_integration_test.go
@@ -27,9 +27,9 @@ import (
 // the store layer where scoped principals are cheap to mint.
 func TestRecordGrantWidensRowScopeAndRevokes(t *testing.T) {
 	e := SetupSearch(t)
-	foreign := e.seed(t, `INSERT INTO person (id, workspace_id, full_name, owner_id, source, captured_by) VALUES ($1, $2, 'Shared Secret', $3, 'manual', 'human:x')`, e.Rep3)
+	foreign := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, owner_id, source, captured_by) VALUES ($1, $2, 'Shared Secret', $3, 'manual', 'human:x')`, e.Rep3)
 
-	repCtx := e.asTeamRep(e.Rep1, e.Team1)
+	repCtx := e.AsTeamRep(e.Rep1, e.Team1)
 	peopleStore := people.NewStore(e.Pool)
 
 	// Before the grant: team scope hides rep3's record from rep1.
@@ -42,7 +42,7 @@ func TestRecordGrantWidensRowScopeAndRevokes(t *testing.T) {
 		t.Fatalf("pre-grant search: %v %+v", err, page.Hits)
 	}
 
-	grantID := e.seed(t, `INSERT INTO record_grant (id, workspace_id, record_type, record_id, subject_type, subject_id, access, granted_by)
+	grantID := e.Seed(t, `INSERT INTO record_grant (id, workspace_id, record_type, record_id, subject_type, subject_id, access, granted_by)
 		VALUES ($1, $2, 'person', $3, 'user', $4, 'read', $5)`, foreign, e.Rep1, e.Rep3)
 
 	// After: the direct read, the search branch, and the link probe all

--- a/backend/internal/compose/integration/grants_integration_test.go
+++ b/backend/internal/compose/integration/grants_integration_test.go
@@ -26,7 +26,7 @@ import (
 // The widening itself is a platform/auth property, so it is asserted at
 // the store layer where scoped principals are cheap to mint.
 func TestRecordGrantWidensRowScopeAndRevokes(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	foreign := e.seed(t, `INSERT INTO person (id, workspace_id, full_name, owner_id, source, captured_by) VALUES ($1, $2, 'Shared Secret', $3, 'manual', 'human:x')`, e.Rep3)
 
 	repCtx := e.asTeamRep(e.Rep1, e.Team1)
@@ -37,7 +37,7 @@ func TestRecordGrantWidensRowScopeAndRevokes(t *testing.T) {
 		t.Fatal("foreign person visible before any grant")
 	}
 	// A search misses it too.
-	page, err := e.store.Search(repCtx, search.Input{Query: "Shared Secret"})
+	page, err := e.Store.Search(repCtx, search.Input{Query: "Shared Secret"})
 	if err != nil || len(page.Hits) != 0 {
 		t.Fatalf("pre-grant search: %v %+v", err, page.Hits)
 	}
@@ -50,7 +50,7 @@ func TestRecordGrantWidensRowScopeAndRevokes(t *testing.T) {
 	if _, err := peopleStore.GetPerson(repCtx, personIDOf(foreign), storekit.LiveOnly); err != nil {
 		t.Fatalf("granted person still hidden: %v", err)
 	}
-	page, err = e.store.Search(repCtx, search.Input{Query: "Shared Secret"})
+	page, err = e.Store.Search(repCtx, search.Input{Query: "Shared Secret"})
 	if err != nil || len(page.Hits) != 1 {
 		t.Fatalf("post-grant search: %v %+v", err, page.Hits)
 	}

--- a/backend/internal/compose/integration/harness.go
+++ b/backend/internal/compose/integration/harness.go
@@ -5,18 +5,25 @@
 
 // Package integration holds the cross-module integration suites — the
 // compose charter exercised end to end over a real migrated Postgres —
-// and the one shared harness they ride. The harness lives in this
-// non-test file so the white-box suites that must stay inside their
-// package (compose root, briefs) can import it; it deliberately imports
-// modules and platform only, never compose, so no import cycle can form.
+// and the shared harnesses they ride: Env here, and SearchEnv in
+// searchenv.go. Both live in non-test files so the white-box suites that
+// must stay inside their package (compose root, briefs) can import them;
+// both deliberately import modules and platform only, never compose, so no
+// import cycle can form.
 //
 // Suites also live in sibling packages that import this one (org360 is the
 // first). That is how the lane gets more than one scheduling slot: one package
 // is one slot, and this package is large enough to be the lane's long pole on
-// its own. Split a group out when it is a closed seam — it rides Env rather
-// than the booted-app fixture in e2e_integration_test.go, and it neither needs
-// nor owes an unexported helper across the boundary. A helper that two such
-// groups need is promoted here; one that only a group needs stays with it.
+// its own. Split a group out when it is a closed seam — it rides an EXPORTED
+// fixture (Env or SearchEnv) rather than the booted-app fixture in
+// e2e_integration_test.go, and it neither needs nor owes an unexported helper
+// across the boundary. A helper that two such groups need is promoted here; one
+// that only a group needs stays with it.
+//
+// A fixture is only importable if its METHODS are in a non-test file too: a
+// method declared in a _test.go file is not part of the package a sibling
+// imports, so a group could hold the fixture and still be unable to build a
+// principal context or seed a row. Promote the methods with the type.
 package integration
 
 import (
@@ -161,13 +168,15 @@ func OwnerConn(t *testing.T) *pgx.Conn {
 	return conn
 }
 
-// The two RBAC object keys the permission fixtures below repeat often enough to
+// The RBAC object keys the permission fixtures below repeat often enough to
 // name. They are identity's policy vocabulary only — deliberately NOT reused for
-// the activity_link.entity_type values seed.go writes, which spell the same two
-// words today from a different namespace and are free to diverge.
+// the activity_link.entity_type values seed.go writes, which spell some of the
+// same words today from a different namespace and are free to diverge.
 const (
 	objPerson   = "person"
 	objActivity = "activity"
+	objDeal     = "deal"
+	objOrg      = "organization"
 )
 
 // permissions fixtures mirror the RBAC matrix rows the suites
@@ -177,7 +186,7 @@ var (
 		RoleKeys: []string{"rep"},
 		Objects: map[string]principal.ObjectGrant{
 			objPerson:  {Create: true, Read: true, Update: true},
-			"deal":     {Create: true, Read: true, Update: true},
+			objDeal:    {Create: true, Read: true, Update: true},
 			"pipeline": {Read: true},
 		},
 		RowScope: principal.RowScopeTeam,
@@ -192,20 +201,20 @@ var (
 	AccountRepPerms = principal.Permissions{
 		RoleKeys: []string{"rep"},
 		Objects: map[string]principal.ObjectGrant{
-			"organization": {Read: true},
-			objPerson:      {Create: true, Read: true, Update: true},
-			"deal":         {Create: true, Read: true, Update: true},
-			objActivity:    {Create: true, Read: true, Update: true},
-			"pipeline":     {Read: true},
-			"tag":          {Read: true},
-			"list":         {Read: true},
+			objOrg:      {Read: true},
+			objPerson:   {Create: true, Read: true, Update: true},
+			objDeal:     {Create: true, Read: true, Update: true},
+			objActivity: {Create: true, Read: true, Update: true},
+			"pipeline":  {Read: true},
+			"tag":       {Read: true},
+			"list":      {Read: true},
 		},
 		RowScope: principal.RowScopeTeam,
 	}
 	ReadOnlyPerms = principal.Permissions{
 		RoleKeys: []string{"read_only"},
 		Objects: map[string]principal.ObjectGrant{
-			objPerson: {Read: true}, "deal": {Read: true}, "pipeline": {Read: true},
+			objPerson: {Read: true}, objDeal: {Read: true}, "pipeline": {Read: true},
 		},
 		RowScope: principal.RowScopeAll,
 	}
@@ -218,12 +227,12 @@ var (
 	AdminPerms       = principal.Permissions{
 		RoleKeys: []string{"admin"},
 		Objects: map[string]principal.ObjectGrant{
-			objPerson:      {Create: true, Read: true, Update: true, Delete: true},
-			"organization": {Create: true, Read: true, Update: true, Delete: true},
-			"deal":         {Create: true, Read: true, Update: true, Delete: true},
-			"lead":         {Create: true, Read: true, Update: true, Delete: true},
-			objActivity:    {Create: true, Read: true, Update: true, Delete: true},
-			"pipeline":     {Create: true, Read: true, Update: true, Delete: true},
+			objPerson:   {Create: true, Read: true, Update: true, Delete: true},
+			objOrg:      {Create: true, Read: true, Update: true, Delete: true},
+			objDeal:     {Create: true, Read: true, Update: true, Delete: true},
+			"lead":      {Create: true, Read: true, Update: true, Delete: true},
+			objActivity: {Create: true, Read: true, Update: true, Delete: true},
+			"pipeline":  {Create: true, Read: true, Update: true, Delete: true},
 			// computed_field is read-only for every system role, admin
 			// included (RD-AC-7: no runtime formula-authoring surface
 			// exists) — identity/internal/policy.go's real seed, mirrored

--- a/backend/internal/compose/integration/installation_settings_integration_test.go
+++ b/backend/internal/compose/integration/installation_settings_integration_test.go
@@ -189,9 +189,9 @@ func TestBaseCurrencyFreezesOnceADealHasConvertedAgainstIt(t *testing.T) {
 	// INSERT..SELECT that matches nothing SUCCEEDS, so a missing fixture would
 	// leave this test asserting a freeze that never had a deal to fire on —
 	// passing or failing for the wrong reason either way.
-	pipeline := e.seed(t, `
+	pipeline := e.Seed(t, `
 		INSERT INTO pipeline (id, workspace_id, name, is_default) VALUES ($1, $2, 'Freeze fixture', false)`)
-	stage := e.seed(t, `
+	stage := e.Seed(t, `
 		INSERT INTO stage (id, workspace_id, pipeline_id, name, position, semantic, win_probability)
 		VALUES ($1, $2, $3, 'Won', 1, 'won', 100)`, pipeline)
 	// Every CHECK on `deal` has to be satisfied for the row to land, and the
@@ -202,7 +202,7 @@ func TestBaseCurrencyFreezesOnceADealHasConvertedAgainstIt(t *testing.T) {
 	//   deal_lost_reason          — not reached; 'won', not 'lost'
 	// The frozen rate is the one this test actually needs; the rest are the
 	// price of a valid closed deal.
-	e.seed(t, `
+	e.Seed(t, `
 		INSERT INTO deal (id, workspace_id, name, pipeline_id, stage_id, source, captured_by,
 		                  amount_minor, currency, fx_rate_to_base, status, closed_at)
 		VALUES ($1, $2, 'Converted deal', $3, $4, 'seed', 'system:test',

--- a/backend/internal/compose/integration/installation_settings_integration_test.go
+++ b/backend/internal/compose/integration/installation_settings_integration_test.go
@@ -40,7 +40,7 @@ import (
 
 // installationSettingsCtx builds a human principal in the env workspace with a
 // specific installation_settings grant.
-func (e *searchEnv) installationSettingsCtx(grant principal.ObjectGrant) context.Context {
+func (e *SearchEnv) installationSettingsCtx(grant principal.ObjectGrant) context.Context {
 	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
 	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
 	return principal.WithActor(ctx, principal.Principal{
@@ -52,7 +52,7 @@ func (e *searchEnv) installationSettingsCtx(grant principal.ObjectGrant) context
 	})
 }
 
-func installationAuditCount(t *testing.T, e *searchEnv) int {
+func installationAuditCount(t *testing.T, e *SearchEnv) int {
 	t.Helper()
 	var n int
 	if err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
@@ -65,7 +65,7 @@ func installationAuditCount(t *testing.T, e *searchEnv) int {
 }
 
 func TestInstallationSettingsReadWriteAndGate(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	store := identity.NewInstallationSettings(e.Pool, compose.NewSettingsStore(e.Pool))
 
 	admin := e.installationSettingsCtx(principal.ObjectGrant{Read: true, Update: true})
@@ -134,7 +134,7 @@ func TestInstallationSettingsReadWriteAndGate(t *testing.T) {
 }
 
 func TestInstallationSettingsRefuseValuesTheOwningModuleRejects(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	store := identity.NewInstallationSettings(e.Pool, compose.NewSettingsStore(e.Pool))
 	admin := e.installationSettingsCtx(principal.ObjectGrant{Read: true, Update: true})
 
@@ -173,7 +173,7 @@ func TestInstallationSettingsRefuseValuesTheOwningModuleRejects(t *testing.T) {
 // a test that creates a deal carrying a frozen conversion rate can tell a
 // working guard from an absent one.
 func TestBaseCurrencyFreezesOnceADealHasConvertedAgainstIt(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	store := identity.NewInstallationSettings(e.Pool, compose.NewSettingsStore(e.Pool))
 	admin := e.installationSettingsCtx(principal.ObjectGrant{Read: true, Update: true})
 

--- a/backend/internal/compose/integration/keyvault_capture_integration_test.go
+++ b/backend/internal/compose/integration/keyvault_capture_integration_test.go
@@ -195,7 +195,7 @@ func TestBackfillMigratesLegacyAuthRowOntoTheVault(t *testing.T) {
 
 	// A legacy row: a connected connection whose credential still lives in the
 	// auth bytea column, no vault ref yet.
-	connID := e.seed(t, `
+	connID := e.Seed(t, `
 		INSERT INTO capture_connection (id, workspace_id, provider, user_id, scopes, status, auth)
 		VALUES ($1, $2, 'graph', $3, $4, 'connected', $5)`,
 		e.Rep1, []string{string(principal.ScopeRead)}, []byte("granted-token"))

--- a/backend/internal/compose/integration/keyvault_capture_integration_test.go
+++ b/backend/internal/compose/integration/keyvault_capture_integration_test.go
@@ -32,8 +32,8 @@ import (
 
 // newTestKeyvault builds the local (config-backed) provider over the test
 // pool with a fresh random root key. The vault_secret table exists because
-// setupSearch migrated the schema.
-func newTestKeyvault(t *testing.T, e *searchEnv) keyvault.Vault {
+// SetupSearch migrated the schema.
+func newTestKeyvault(t *testing.T, e *SearchEnv) keyvault.Vault {
 	t.Helper()
 	key := make([]byte, 32)
 	if _, err := rand.Read(key); err != nil {
@@ -78,7 +78,7 @@ func (f *authAssertingFake) Normalize(context.Context, connector.RawRecord) ([]c
 func (f *authAssertingFake) HealthCheck(context.Context, connector.Auth) error { return nil }
 
 func TestConnectSealsCredentialInVaultNotOnTheRow(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	vault := newTestKeyvault(t, e)
 	registry := newTestCaptureRegistry(e, vault)
 	registry.Register(&authAssertingFake{})
@@ -116,7 +116,7 @@ func TestConnectSealsCredentialInVaultNotOnTheRow(t *testing.T) {
 }
 
 func TestSyncResolvesCredentialFromVault(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	vault := newTestKeyvault(t, e)
 	registry := newTestCaptureRegistry(e, vault)
 	fake := &authAssertingFake{}
@@ -139,7 +139,7 @@ func TestSyncResolvesCredentialFromVault(t *testing.T) {
 // memory fake does, plus surface a wrong-root-key decrypt as an error (not
 // absence) without leaking the plaintext.
 func TestLocalVaultIsolationAndWrongKeyOnRealPostgres(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	vault := newTestKeyvault(t, e)
 	ctx := context.Background()
 	wsA := ids.From[ids.WorkspaceKind](e.WS)
@@ -187,7 +187,7 @@ func TestLocalVaultIsolationAndWrongKeyOnRealPostgres(t *testing.T) {
 }
 
 func TestBackfillMigratesLegacyAuthRowOntoTheVault(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	vault := newTestKeyvault(t, e)
 	registry := newTestCaptureRegistry(e, vault)
 	fake := &authAssertingFake{}

--- a/backend/internal/compose/integration/leadrouting_integration_test.go
+++ b/backend/internal/compose/integration/leadrouting_integration_test.go
@@ -27,24 +27,24 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
-// routingEnv is a searchEnv plus a third active rep, so the rotation
+// routingEnv is a SearchEnv plus a third active rep, so the rotation
 // has a shape (two owners cannot distinguish round-robin from ping-pong).
 type routingEnv struct {
-	*searchEnv
+	*SearchEnv
 	Rep2   ids.UUID
 	engine *automation.WorkflowEngine
 }
 
 func setupRouting(t *testing.T) *routingEnv {
 	t.Helper()
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	rep2 := ids.NewV7()
-	if _, err := e.owner.Exec(context.Background(),
+	if _, err := e.Owner.Exec(context.Background(),
 		`INSERT INTO app_user (id, workspace_id, email, display_name) VALUES ($1, $2, 'rep2@search.test', 'Rep Two')`,
 		rep2, e.WS); err != nil {
 		t.Fatal(err)
 	}
-	return &routingEnv{searchEnv: e, Rep2: rep2, engine: compose.NewWorkflowEngine(e.Pool)}
+	return &routingEnv{SearchEnv: e, Rep2: rep2, engine: compose.NewWorkflowEngine(e.Pool)}
 }
 
 // routeNewLead seeds one unowned lead and dispatches its lead.created
@@ -67,7 +67,7 @@ func (e *routingEnv) routeNewLead(t *testing.T, source string) (ids.UUID, *ids.U
 func (e *routingEnv) leadOwner(t *testing.T, leadID ids.UUID) *ids.UUID {
 	t.Helper()
 	var owner *ids.UUID
-	if err := e.owner.QueryRow(context.Background(),
+	if err := e.Owner.QueryRow(context.Background(),
 		`SELECT owner_id FROM lead WHERE id = $1`, leadID).Scan(&owner); err != nil {
 		t.Fatal(err)
 	}
@@ -77,7 +77,7 @@ func (e *routingEnv) leadOwner(t *testing.T, leadID ids.UUID) *ids.UUID {
 func TestLeadRoutingRoundRobinIsFairAndCapsAreNeverExceeded(t *testing.T) {
 	e := setupRouting(t)
 	pool := []ids.UUID{e.Rep1, e.Rep2, e.Rep3}
-	enableLeadRouting(t, e.searchEnv, map[string]any{
+	enableLeadRouting(t, e.SearchEnv, map[string]any{
 		"owners":        []string{e.Rep1.String(), e.Rep2.String(), e.Rep3.String()},
 		"cap_per_owner": 2,
 	})
@@ -99,7 +99,7 @@ func TestLeadRoutingRoundRobinIsFairAndCapsAreNeverExceeded(t *testing.T) {
 		t.Fatalf("all-capped pool still assigned %v — the cap was exceeded", owner)
 	}
 	var after []byte
-	if err := e.owner.QueryRow(context.Background(),
+	if err := e.Owner.QueryRow(context.Background(),
 		`SELECT after FROM audit_log WHERE entity_type = 'lead' AND entity_id = $1 AND action = 'assign'`,
 		leadID).Scan(&after); err != nil {
 		t.Fatalf("the no-capacity decision left no audit row: %v", err)
@@ -118,7 +118,7 @@ func TestLeadRoutingRoundRobinIsFairAndCapsAreNeverExceeded(t *testing.T) {
 	// Promoting one of rep1's leads frees capacity; the next lead goes
 	// to rep1 — the cap counts OPEN leads, so closed work hands the
 	// rotation back.
-	if _, err := e.owner.Exec(context.Background(),
+	if _, err := e.Owner.Exec(context.Background(),
 		`UPDATE lead SET status = 'promoted', promoted_at = now()
 		 WHERE id IN (SELECT id FROM lead WHERE owner_id = $1 LIMIT 1)`, e.Rep1); err != nil {
 		t.Fatal(err)
@@ -130,7 +130,7 @@ func TestLeadRoutingRoundRobinIsFairAndCapsAreNeverExceeded(t *testing.T) {
 
 func TestLeadRoutingRuleOutranksRotationButNeverTheCap(t *testing.T) {
 	e := setupRouting(t)
-	enableLeadRouting(t, e.searchEnv, map[string]any{
+	enableLeadRouting(t, e.SearchEnv, map[string]any{
 		"owners":        []string{e.Rep1.String(), e.Rep2.String()},
 		"cap_per_owner": 1,
 		"rules": []map[string]any{
@@ -157,7 +157,7 @@ func TestLeadRoutingRuleOutranksRotationButNeverTheCap(t *testing.T) {
 
 func TestLeadRoutingLeavesHumanAssignmentsAlone(t *testing.T) {
 	e := setupRouting(t)
-	enableLeadRouting(t, e.searchEnv, map[string]any{
+	enableLeadRouting(t, e.SearchEnv, map[string]any{
 		"owners": []string{e.Rep1.String()},
 	})
 

--- a/backend/internal/compose/integration/leadrouting_integration_test.go
+++ b/backend/internal/compose/integration/leadrouting_integration_test.go
@@ -51,7 +51,7 @@ func setupRouting(t *testing.T) *routingEnv {
 // through the engine, returning the resulting owner (nil = unassigned).
 func (e *routingEnv) routeNewLead(t *testing.T, source string) (ids.UUID, *ids.UUID) {
 	t.Helper()
-	leadID := e.seed(t,
+	leadID := e.Seed(t,
 		`INSERT INTO lead (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Routed Lead', $3, 'human:x')`,
 		source)
 	if err := e.engine.HandleEvent(context.Background(), kevents.Envelope{
@@ -161,7 +161,7 @@ func TestLeadRoutingLeavesHumanAssignmentsAlone(t *testing.T) {
 		"owners": []string{e.Rep1.String()},
 	})
 
-	leadID := e.seed(t,
+	leadID := e.Seed(t,
 		`INSERT INTO lead (id, workspace_id, full_name, source, owner_id, captured_by) VALUES ($1, $2, 'Claimed Lead', 'manual', $3, 'human:x')`,
 		e.Rep3)
 	if err := e.engine.HandleEvent(context.Background(), kevents.Envelope{

--- a/backend/internal/compose/integration/leadscore_integration_test.go
+++ b/backend/internal/compose/integration/leadscore_integration_test.go
@@ -49,7 +49,7 @@ func TestLeadScoreRecomputesFromLinkedActivities(t *testing.T) {
 	// A working lead with a decision-maker title from a high-intent
 	// source: fit = 15 + 8 = 23 (§3.1). Inserted with score 0 so the
 	// recompute demonstrably rebuilds fit AND behavior.
-	leadID := e.seed(t, `INSERT INTO lead (id, workspace_id, full_name, title, status, source, score, captured_by)
+	leadID := e.Seed(t, `INSERT INTO lead (id, workspace_id, full_name, title, status, source, score, captured_by)
 	                     VALUES ($1, $2, 'Vera VP', 'VP Sales', 'working', 'inbound', 0, 'human:x')`)
 
 	// An inbound email linked to the lead = one fresh reply (+25).

--- a/backend/internal/compose/integration/leadscore_integration_test.go
+++ b/backend/internal/compose/integration/leadscore_integration_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 // asFullUser binds a principal that may log activities and work leads.
-func (e *searchEnv) asFullUser() context.Context {
+func (e *SearchEnv) asFullUser() context.Context {
 	grants := map[string]principal.ObjectGrant{}
 	for _, object := range []string{"person", "organization", "deal", "lead", "activity"} {
 		grants[object] = principal.ObjectGrant{Create: true, Read: true, Update: true}
@@ -42,7 +42,7 @@ func (e *searchEnv) asFullUser() context.Context {
 }
 
 func TestLeadScoreRecomputesFromLinkedActivities(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	engine := compose.NewWorkflowEngine(e.Pool)
 	ctx := e.asFullUser()
 
@@ -89,7 +89,7 @@ func TestLeadScoreRecomputesFromLinkedActivities(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := e.owner.Exec(context.Background(),
+	if _, err := e.Owner.Exec(context.Background(),
 		`UPDATE activity SET meeting_status = 'held' WHERE id = $1`, ids.UUID(meeting.Id)); err != nil {
 		t.Fatal(err)
 	}
@@ -113,7 +113,7 @@ func TestLeadScoreRecomputesFromLinkedActivities(t *testing.T) {
 
 	// The recompute emitted the catalog's lead.updated with the score delta.
 	var events int
-	if err := e.owner.QueryRow(context.Background(),
+	if err := e.Owner.QueryRow(context.Background(),
 		`SELECT count(*) FROM event_outbox WHERE envelope->>'type' = 'lead.updated'
 		   AND envelope->'payload'->'changed_fields'->'delta' ? 'score'`).Scan(&events); err != nil {
 		t.Fatal(err)
@@ -137,10 +137,10 @@ func dispatchActivityCaptured(t *testing.T, engine *automation.WorkflowEngine, w
 }
 
 // currentLeadScore reads the lead's score through the owner connection.
-func currentLeadScore(t *testing.T, e *searchEnv, leadID ids.UUID) int {
+func currentLeadScore(t *testing.T, e *SearchEnv, leadID ids.UUID) int {
 	t.Helper()
 	var score int
-	if err := e.owner.QueryRow(context.Background(),
+	if err := e.Owner.QueryRow(context.Background(),
 		`SELECT score FROM lead WHERE id = $1`, leadID).Scan(&score); err != nil {
 		t.Fatal(err)
 	}
@@ -150,7 +150,7 @@ func currentLeadScore(t *testing.T, e *searchEnv, leadID ids.UUID) int {
 // assertRecomputeRanExactlyOnce checks a redelivered event applied
 // nothing twice: one workflow run row and exactly one audited lead
 // score update.
-func assertRecomputeRanExactlyOnce(t *testing.T, e *searchEnv) {
+func assertRecomputeRanExactlyOnce(t *testing.T, e *SearchEnv) {
 	t.Helper()
 	var runs, audits int
 	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {

--- a/backend/internal/compose/integration/leadscore_override_integration_test.go
+++ b/backend/internal/compose/integration/leadscore_override_integration_test.go
@@ -66,7 +66,7 @@ func TestLeadScoreOverrideIsSticky(t *testing.T) {
 	// A working lead: decision-maker title (+15) from a high-intent source
 	// (+8) → machine fit is 23. Seeded at score 0 so a resumed recompute
 	// demonstrably rebuilds it.
-	leadID := e.seed(t, `INSERT INTO lead (id, workspace_id, full_name, title, status, source, score, captured_by)
+	leadID := e.Seed(t, `INSERT INTO lead (id, workspace_id, full_name, title, status, source, score, captured_by)
 	                     VALUES ($1, $2, 'Vera VP', 'VP Sales', 'working', 'inbound', 0, 'human:x')`)
 
 	// (1) A human score with no reason is rejected (AC-S1).

--- a/backend/internal/compose/integration/leadscore_override_integration_test.go
+++ b/backend/internal/compose/integration/leadscore_override_integration_test.go
@@ -33,11 +33,11 @@ func intp(i int) *int       { return &i }
 // override columns exist and lead still carries FORCE row-level security
 // (ADD COLUMN never relaxes it).
 func TestLeadScoreOverrideColumnsAndRLS(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	ctx := context.Background()
 
 	var forced bool
-	if err := e.owner.QueryRow(ctx,
+	if err := e.Owner.QueryRow(ctx,
 		`SELECT relforcerowsecurity FROM pg_class WHERE relname = 'lead'`).Scan(&forced); err != nil {
 		t.Fatal(err)
 	}
@@ -46,7 +46,7 @@ func TestLeadScoreOverrideColumnsAndRLS(t *testing.T) {
 	}
 
 	var cols int
-	if err := e.owner.QueryRow(ctx,
+	if err := e.Owner.QueryRow(ctx,
 		`SELECT count(*) FROM information_schema.columns
 		   WHERE table_name = 'lead' AND column_name IN ('score_override_reason', 'score_computed')`).Scan(&cols); err != nil {
 		t.Fatal(err)
@@ -57,7 +57,7 @@ func TestLeadScoreOverrideColumnsAndRLS(t *testing.T) {
 }
 
 func TestLeadScoreOverrideIsSticky(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	engine := compose.NewWorkflowEngine(e.Pool)
 	ctx := e.asFullUser()
 	store := people.NewStore(e.Pool)

--- a/backend/internal/compose/integration/reembed_integration_test.go
+++ b/backend/internal/compose/integration/reembed_integration_test.go
@@ -52,7 +52,7 @@ func TestReembedWorkspaceReembedsAllLiveEntitiesAndIsResumable(t *testing.T) {
 	names := []string{"Reembed One", "Reembed Two", "Reembed Three"}
 	personIDs := make([]ids.UUID, len(names))
 	for i, name := range names {
-		id := e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, $3, 'manual', 'human:x')`, name)
+		id := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, $3, 'manual', 'human:x')`, name)
 		if _, err := e.Store.UpsertEmbedding(e.Admin(), "person", id, name, staleEmbedder); err != nil {
 			t.Fatalf("seeding the stale-identity baseline for %s: %v", name, err)
 		}
@@ -155,7 +155,7 @@ func TestReembedWorkspaceCostsOnlyTheWorkspaceThatCannotWrite(t *testing.T) {
 	}
 
 	healthy := seedExtraWorkspace(t, e.Owner, "reembed-healthy", false)
-	e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Faulted Tenant Person', 'manual', 'human:x')`)
+	e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Faulted Tenant Person', 'manual', 'human:x')`)
 	healthyPersonID := ids.NewV7()
 	if _, err := e.Owner.Exec(ctx, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Healthy Tenant Person', 'manual', 'human:x')`,
 		healthyPersonID, healthy); err != nil {
@@ -203,7 +203,7 @@ func TestReembedWorkspaceIdentityDriftCancelsWithoutTouchingRows(t *testing.T) {
 	if err := e.Store.SeedBinding(ctx, markerIdentity); err != nil {
 		t.Fatalf("SeedBinding: %v", err)
 	}
-	personID := e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Drift Person', 'manual', 'human:x')`)
+	personID := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Drift Person', 'manual', 'human:x')`)
 	if _, err := e.Owner.Exec(ctx, `
 		INSERT INTO embedding (workspace_id, entity_type, entity_id, chunk_ix, chunk_hash, model, embedding)
 		VALUES ($1, 'person', $2, 0, 'stale-hash', $3, '[1,2,3]'::vector)`,

--- a/backend/internal/compose/integration/reembed_integration_test.go
+++ b/backend/internal/compose/integration/reembed_integration_test.go
@@ -34,7 +34,7 @@ import (
 // the same identity must cost zero additional embed calls — the
 // resumability property Task 6's skip-compare exists to provide.
 func TestReembedWorkspaceReembedsAllLiveEntitiesAndIsResumable(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	ctx := context.Background()
 	fake := ai.NewFakeClient()
 	staleEmbedder := fakeEmbedderNamed(t, fake, "model-stale")
@@ -45,7 +45,7 @@ func TestReembedWorkspaceReembedsAllLiveEntitiesAndIsResumable(t *testing.T) {
 		t.Fatalf("test setup produced identical identities %q — no swap exercised", staleIdentity)
 	}
 
-	if err := e.store.SeedBinding(ctx, staleIdentity); err != nil {
+	if err := e.Store.SeedBinding(ctx, staleIdentity); err != nil {
 		t.Fatalf("SeedBinding: %v", err)
 	}
 
@@ -53,7 +53,7 @@ func TestReembedWorkspaceReembedsAllLiveEntitiesAndIsResumable(t *testing.T) {
 	personIDs := make([]ids.UUID, len(names))
 	for i, name := range names {
 		id := e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, $3, 'manual', 'human:x')`, name)
-		if _, err := e.store.UpsertEmbedding(e.Admin(), "person", id, name, staleEmbedder); err != nil {
+		if _, err := e.Store.UpsertEmbedding(e.Admin(), "person", id, name, staleEmbedder); err != nil {
 			t.Fatalf("seeding the stale-identity baseline for %s: %v", name, err)
 		}
 		personIDs[i] = id
@@ -62,7 +62,7 @@ func TestReembedWorkspaceReembedsAllLiveEntitiesAndIsResumable(t *testing.T) {
 
 	wsID := ids.From[ids.WorkspaceKind](e.WS)
 	run := ids.NewV7()
-	if err := e.store.ReembedWorkspace(ctx, search.ReembedPass{Run: run, Identity: newIdentity}, wsID, newEmbedder); err != nil {
+	if err := e.Store.ReembedWorkspace(ctx, search.ReembedPass{Run: run, Identity: newIdentity}, wsID, newEmbedder); err != nil {
 		t.Fatalf("ReembedWorkspace: %v", err)
 	}
 
@@ -77,7 +77,7 @@ func TestReembedWorkspaceReembedsAllLiveEntitiesAndIsResumable(t *testing.T) {
 		t.Fatalf("first ReembedWorkspace made %d embed calls, want %d (one per live entity)", firstPassCalls, len(names))
 	}
 
-	pending, err := e.store.EntitiesPending(ctx, newIdentity)
+	pending, err := e.Store.EntitiesPending(ctx, newIdentity)
 	if err != nil {
 		t.Fatalf("EntitiesPending: %v", err)
 	}
@@ -88,7 +88,7 @@ func TestReembedWorkspaceReembedsAllLiveEntitiesAndIsResumable(t *testing.T) {
 	// Resumability: nothing changed since the first pass, so every row is
 	// already current under newIdentity — the skip-compare inside
 	// UpsertEmbedding must short-circuit before ever calling the embedder.
-	if err := e.store.ReembedWorkspace(ctx, search.ReembedPass{Run: run, Identity: newIdentity}, wsID, newEmbedder); err != nil {
+	if err := e.Store.ReembedWorkspace(ctx, search.ReembedPass{Run: run, Identity: newIdentity}, wsID, newEmbedder); err != nil {
 		t.Fatalf("second ReembedWorkspace: %v", err)
 	}
 	secondPassCalls := len(fake.Calls()) - baselineCalls - firstPassCalls
@@ -145,37 +145,37 @@ func failEmbeddingWritesFor(t *testing.T, owner *pgx.Conn, ws ids.UUID) {
 // tenant's transient write fault left every workspace behind it in the fleet
 // order un-re-embedded — silently, with no row anywhere saying so.
 func TestReembedWorkspaceCostsOnlyTheWorkspaceThatCannotWrite(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	ctx := context.Background()
 	fake := ai.NewFakeClient()
 	embedder := fakeEmbedderNamed(t, fake, "model-isolation")
 	identity, _ := embedder.EmbedIdentity()
-	if err := e.store.SeedBinding(ctx, identity); err != nil {
+	if err := e.Store.SeedBinding(ctx, identity); err != nil {
 		t.Fatalf("SeedBinding: %v", err)
 	}
 
-	healthy := seedExtraWorkspace(t, e.owner, "reembed-healthy", false)
+	healthy := seedExtraWorkspace(t, e.Owner, "reembed-healthy", false)
 	e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Faulted Tenant Person', 'manual', 'human:x')`)
 	healthyPersonID := ids.NewV7()
-	if _, err := e.owner.Exec(ctx, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Healthy Tenant Person', 'manual', 'human:x')`,
+	if _, err := e.Owner.Exec(ctx, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Healthy Tenant Person', 'manual', 'human:x')`,
 		healthyPersonID, healthy); err != nil {
 		t.Fatalf("seeding the healthy tenant's person: %v", err)
 	}
-	failEmbeddingWritesFor(t, e.owner, e.WS)
+	failEmbeddingWritesFor(t, e.Owner, e.WS)
 
-	if err := e.store.ReembedWorkspace(ctx, search.ReembedPass{Run: ids.NewV7(), Identity: identity}, ids.From[ids.WorkspaceKind](e.WS), embedder); err == nil {
+	if err := e.Store.ReembedWorkspace(ctx, search.ReembedPass{Run: ids.NewV7(), Identity: identity}, ids.From[ids.WorkspaceKind](e.WS), embedder); err == nil {
 		t.Fatal("a workspace whose embedding writes could not land reported success — nothing records that its corpus was never rebuilt")
 	}
 
 	// The fault is one tenant's, and the pass now takes the tenant it is given.
-	if err := e.store.ReembedWorkspace(ctx, search.ReembedPass{Run: ids.NewV7(), Identity: identity}, ids.From[ids.WorkspaceKind](healthy), embedder); err != nil {
+	if err := e.Store.ReembedWorkspace(ctx, search.ReembedPass{Run: ids.NewV7(), Identity: identity}, ids.From[ids.WorkspaceKind](healthy), embedder); err != nil {
 		t.Fatalf("the healthy tenant's pass, while the victim's is faulted: %v", err)
 	}
-	// Read outside e.WS: searchEnv.storedEmbeddingModel is pinned to the
+	// Read outside e.WS: SearchEnv.storedEmbeddingModel is pinned to the
 	// harness's own workspace, and a cross-tenant claim has to read the tenant
 	// it is making the claim about.
 	var model string
-	if err := e.owner.QueryRow(ctx,
+	if err := e.Owner.QueryRow(ctx,
 		`SELECT model FROM embedding WHERE workspace_id = $1 AND entity_type = 'person' AND entity_id = $2 AND chunk_ix = 0`,
 		healthy, healthyPersonID).Scan(&model); err != nil {
 		t.Fatalf("reading the healthy tenant's embedding: %v", err)
@@ -193,18 +193,18 @@ func TestReembedWorkspaceCostsOnlyTheWorkspaceThatCannotWrite(t *testing.T) {
 // job cancels cleanly instead of burning its ladder against an identity
 // nothing serves anymore.
 func TestReembedWorkspaceIdentityDriftCancelsWithoutTouchingRows(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	ctx := context.Background()
 	fake := ai.NewFakeClient()
 	embedder := fakeEmbedderNamed(t, fake, "model-current")
 
 	const markerIdentity = "stale-marker-identity"
 	const staleRowIdentity = "stale-marker-identity"
-	if err := e.store.SeedBinding(ctx, markerIdentity); err != nil {
+	if err := e.Store.SeedBinding(ctx, markerIdentity); err != nil {
 		t.Fatalf("SeedBinding: %v", err)
 	}
 	personID := e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Drift Person', 'manual', 'human:x')`)
-	if _, err := e.owner.Exec(ctx, `
+	if _, err := e.Owner.Exec(ctx, `
 		INSERT INTO embedding (workspace_id, entity_type, entity_id, chunk_ix, chunk_hash, model, embedding)
 		VALUES ($1, 'person', $2, 0, 'stale-hash', $3, '[1,2,3]'::vector)`,
 		e.WS, personID, staleRowIdentity); err != nil {
@@ -213,7 +213,7 @@ func TestReembedWorkspaceIdentityDriftCancelsWithoutTouchingRows(t *testing.T) {
 
 	// The job's own args identity does NOT match what embedder actually
 	// reports — the drift the guard exists to catch.
-	err := e.store.ReembedWorkspace(ctx, search.ReembedPass{Run: ids.NewV7(), Identity: "some-other-target-identity"}, ids.From[ids.WorkspaceKind](e.WS), embedder)
+	err := e.Store.ReembedWorkspace(ctx, search.ReembedPass{Run: ids.NewV7(), Identity: "some-other-target-identity"}, ids.From[ids.WorkspaceKind](e.WS), embedder)
 	if !errors.Is(err, search.ErrIdentityDrift) {
 		t.Fatalf("ReembedWorkspace with a mismatched argsIdentity = %v, want ErrIdentityDrift", err)
 	}
@@ -224,7 +224,7 @@ func TestReembedWorkspaceIdentityDriftCancelsWithoutTouchingRows(t *testing.T) {
 	if got := e.storedEmbeddingModel(t, personID); got != staleRowIdentity {
 		t.Fatalf("drift guard must not touch existing rows, model = %q, want unchanged %q", got, staleRowIdentity)
 	}
-	_, status, _, err := e.store.PopulatedIdentity(ctx)
+	_, status, _, err := e.Store.PopulatedIdentity(ctx)
 	if err != nil {
 		t.Fatalf("PopulatedIdentity: %v", err)
 	}
@@ -240,28 +240,28 @@ func TestReembedWorkspaceIdentityDriftCancelsWithoutTouchingRows(t *testing.T) {
 // removal is also idempotent, which is what makes a retried job harmless
 // under at-least-once delivery.
 func TestReembedRunMarkerIsReleasedByTheLastWorkspaceOutAndNotBefore(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	ctx := context.Background()
 	const populated = "fake/populated@1024"
 	const target = "fake/target@1024"
-	if err := e.store.SeedBinding(ctx, populated); err != nil {
+	if err := e.Store.SeedBinding(ctx, populated); err != nil {
 		t.Fatalf("SeedBinding: %v", err)
 	}
-	second := seedExtraWorkspace(t, e.owner, "reembed-marker", false)
+	second := seedExtraWorkspace(t, e.Owner, "reembed-marker", false)
 
 	run := claimOf(target)
-	if err := e.store.ClaimAndEnqueueReembedding(ctx, run, func(pgx.Tx) error { return nil }); err != nil {
+	if err := e.Store.ClaimAndEnqueueReembedding(ctx, run, func(pgx.Tx) error { return nil }); err != nil {
 		t.Fatalf("ClaimAndEnqueueReembedding: %v", err)
 	}
 	fleet := []ids.WorkspaceID{ids.From[ids.WorkspaceKind](e.WS), ids.From[ids.WorkspaceKind](second)}
-	if err := e.store.SeedReembeddingFleet(ctx, run.Run, fleet, func(pgx.Tx) error { return nil }); err != nil {
+	if err := e.Store.SeedReembeddingFleet(ctx, run.Run, fleet, func(pgx.Tx) error { return nil }); err != nil {
 		t.Fatalf("SeedReembeddingFleet: %v", err)
 	}
 
-	if err := e.store.FinishWorkspaceReembedding(ctx, run.Run, fleet[0]); err != nil {
+	if err := e.Store.FinishWorkspaceReembedding(ctx, run.Run, fleet[0]); err != nil {
 		t.Fatalf("finishing the first workspace: %v", err)
 	}
-	got, status, _, err := e.store.PopulatedIdentity(ctx)
+	got, status, _, err := e.Store.PopulatedIdentity(ctx)
 	if err != nil {
 		t.Fatalf("PopulatedIdentity: %v", err)
 	}
@@ -271,10 +271,10 @@ func TestReembedRunMarkerIsReleasedByTheLastWorkspaceOutAndNotBefore(t *testing.
 
 	// Idempotent: the same workspace reporting twice (a retried job) must not
 	// count as the second workspace and release early.
-	if err := e.store.FinishWorkspaceReembedding(ctx, run.Run, fleet[0]); err != nil {
+	if err := e.Store.FinishWorkspaceReembedding(ctx, run.Run, fleet[0]); err != nil {
 		t.Fatalf("re-finishing the first workspace: %v", err)
 	}
-	_, status, _, err = e.store.PopulatedIdentity(ctx)
+	_, status, _, err = e.Store.PopulatedIdentity(ctx)
 	if err != nil {
 		t.Fatalf("PopulatedIdentity: %v", err)
 	}
@@ -282,10 +282,10 @@ func TestReembedRunMarkerIsReleasedByTheLastWorkspaceOutAndNotBefore(t *testing.
 		t.Fatalf("marker = %q after ONE workspace reported twice, want reembedding", status)
 	}
 
-	if err := e.store.FinishWorkspaceReembedding(ctx, run.Run, fleet[1]); err != nil {
+	if err := e.Store.FinishWorkspaceReembedding(ctx, run.Run, fleet[1]); err != nil {
 		t.Fatalf("finishing the last workspace: %v", err)
 	}
-	got, status, _, err = e.store.PopulatedIdentity(ctx)
+	got, status, _, err = e.Store.PopulatedIdentity(ctx)
 	if err != nil {
 		t.Fatalf("PopulatedIdentity: %v", err)
 	}
@@ -295,10 +295,10 @@ func TestReembedRunMarkerIsReleasedByTheLastWorkspaceOutAndNotBefore(t *testing.
 
 	// A straggler from the released run must find nothing to act on rather
 	// than re-releasing a marker a later run may hold by then.
-	if err := e.store.FinishWorkspaceReembedding(ctx, run.Run, fleet[0]); err != nil {
+	if err := e.Store.FinishWorkspaceReembedding(ctx, run.Run, fleet[0]); err != nil {
 		t.Fatalf("a straggler of a released run must be a no-op, got: %v", err)
 	}
-	if err := e.store.ClaimAndEnqueueReembedding(ctx, claimOf(target), func(pgx.Tx) error { return nil }); err != nil {
+	if err := e.Store.ClaimAndEnqueueReembedding(ctx, claimOf(target), func(pgx.Tx) error { return nil }); err != nil {
 		t.Fatalf("the released marker must be claimable again: %v", err)
 	}
 }

--- a/backend/internal/compose/integration/reembedrun_integration_test.go
+++ b/backend/internal/compose/integration/reembedrun_integration_test.go
@@ -203,7 +203,7 @@ func TestAHealthyRunIsNotStealableHoweverLongItTakes(t *testing.T) {
 	}
 
 	for i := range 4 {
-		e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, $3, 'manual', 'human:x')`,
+		e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, $3, 'manual', 'human:x')`,
 			fmt.Sprintf("Slow Corpus Person %d", i))
 	}
 
@@ -281,7 +281,7 @@ func TestReembedReportsProgressBeforeItsScanAndItsFirstEmbed(t *testing.T) {
 		t.Fatalf("seeding the run: %v", err)
 	}
 	for i := range 2 {
-		e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, $3, 'manual', 'human:x')`,
+		e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, $3, 'manual', 'human:x')`,
 			fmt.Sprintf("Slow First Entity Person %d", i))
 	}
 	ageMarkerPastTheStealWindow(t, e)

--- a/backend/internal/compose/integration/reembedrun_integration_test.go
+++ b/backend/internal/compose/integration/reembedrun_integration_test.go
@@ -41,40 +41,40 @@ func claimOf(identity string) search.ReembedClaim {
 // emptied it, release a marker whose own children are still working. That is the
 // fleet reporting itself re-embedded while it is not.
 func TestAStragglerOfAFinishedRunCannotActOnTheRunThatReplacedIt(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	ctx := context.Background()
 	const identity = "fake/same-identity@1024"
-	if err := e.store.SeedBinding(ctx, identity); err != nil {
+	if err := e.Store.SeedBinding(ctx, identity); err != nil {
 		t.Fatalf("SeedBinding: %v", err)
 	}
 	ws := ids.From[ids.WorkspaceKind](e.WS)
 
 	finished := claimOf(identity)
-	if err := e.store.ClaimAndEnqueueReembedding(ctx, finished, func(pgx.Tx) error { return nil }); err != nil {
+	if err := e.Store.ClaimAndEnqueueReembedding(ctx, finished, func(pgx.Tx) error { return nil }); err != nil {
 		t.Fatalf("claiming the first run: %v", err)
 	}
-	if err := e.store.SeedReembeddingFleet(ctx, finished.Run, []ids.WorkspaceID{ws}, func(pgx.Tx) error { return nil }); err != nil {
+	if err := e.Store.SeedReembeddingFleet(ctx, finished.Run, []ids.WorkspaceID{ws}, func(pgx.Tx) error { return nil }); err != nil {
 		t.Fatalf("seeding the first run: %v", err)
 	}
-	if err := e.store.FinishWorkspaceReembedding(ctx, finished.Run, ws); err != nil {
+	if err := e.Store.FinishWorkspaceReembedding(ctx, finished.Run, ws); err != nil {
 		t.Fatalf("finishing the first run's only workspace: %v", err)
 	}
 
 	// The replacement run: same identity, as `force` produces.
 	current := claimOf(identity)
-	if err := e.store.ClaimAndEnqueueReembedding(ctx, current, func(pgx.Tx) error { return nil }); err != nil {
+	if err := e.Store.ClaimAndEnqueueReembedding(ctx, current, func(pgx.Tx) error { return nil }); err != nil {
 		t.Fatalf("claiming the replacement run: %v", err)
 	}
-	if err := e.store.SeedReembeddingFleet(ctx, current.Run, []ids.WorkspaceID{ws}, func(pgx.Tx) error { return nil }); err != nil {
+	if err := e.Store.SeedReembeddingFleet(ctx, current.Run, []ids.WorkspaceID{ws}, func(pgx.Tx) error { return nil }); err != nil {
 		t.Fatalf("seeding the replacement run: %v", err)
 	}
 
 	// The first run's straggler finally returns.
-	if err := e.store.FinishWorkspaceReembedding(ctx, finished.Run, ws); err != nil {
+	if err := e.Store.FinishWorkspaceReembedding(ctx, finished.Run, ws); err != nil {
 		t.Fatalf("the straggler must be a no-op, got: %v", err)
 	}
 
-	_, status, _, err := e.store.PopulatedIdentity(ctx)
+	_, status, _, err := e.Store.PopulatedIdentity(ctx)
 	if err != nil {
 		t.Fatalf("PopulatedIdentity: %v", err)
 	}
@@ -85,7 +85,7 @@ func TestAStragglerOfAFinishedRunCannotActOnTheRunThatReplacedIt(t *testing.T) {
 	// releasing would leave the replacement run holding a marker its own child
 	// can no longer account for, which the status alone does not show.
 	var pending int
-	if err := e.owner.QueryRow(ctx,
+	if err := e.Owner.QueryRow(ctx,
 		`SELECT cardinality(reembedding_pending) FROM embed_store_binding WHERE singleton`).Scan(&pending); err != nil {
 		t.Fatalf("reading the replacement run's pending set: %v", err)
 	}
@@ -93,10 +93,10 @@ func TestAStragglerOfAFinishedRunCannotActOnTheRunThatReplacedIt(t *testing.T) {
 		t.Fatalf("the replacement run has %d workspaces outstanding, want 1 — a straggler of the previous run took one out of a set that was never its own", pending)
 	}
 	// And the replacement's own child still empties its set when it reports.
-	if err := e.store.FinishWorkspaceReembedding(ctx, current.Run, ws); err != nil {
+	if err := e.Store.FinishWorkspaceReembedding(ctx, current.Run, ws); err != nil {
 		t.Fatalf("finishing the replacement run's workspace: %v", err)
 	}
-	if _, status, _, err = e.store.PopulatedIdentity(ctx); err != nil {
+	if _, status, _, err = e.Store.PopulatedIdentity(ctx); err != nil {
 		t.Fatalf("PopulatedIdentity: %v", err)
 	}
 	if status != "idle" {
@@ -111,23 +111,23 @@ func TestAStragglerOfAFinishedRunCannotActOnTheRunThatReplacedIt(t *testing.T) {
 // still running — leaving those workspaces in the set with nothing left to take
 // them out.
 func TestASecondFanOutOfTheSameRunIsRefused(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	ctx := context.Background()
 	const identity = "fake/seed-once@1024"
-	if err := e.store.SeedBinding(ctx, identity); err != nil {
+	if err := e.Store.SeedBinding(ctx, identity); err != nil {
 		t.Fatalf("SeedBinding: %v", err)
 	}
 	claim := claimOf(identity)
-	if err := e.store.ClaimAndEnqueueReembedding(ctx, claim, func(pgx.Tx) error { return nil }); err != nil {
+	if err := e.Store.ClaimAndEnqueueReembedding(ctx, claim, func(pgx.Tx) error { return nil }); err != nil {
 		t.Fatalf("claiming: %v", err)
 	}
 	fleet := []ids.WorkspaceID{ids.From[ids.WorkspaceKind](e.WS)}
-	if err := e.store.SeedReembeddingFleet(ctx, claim.Run, fleet, func(pgx.Tx) error { return nil }); err != nil {
+	if err := e.Store.SeedReembeddingFleet(ctx, claim.Run, fleet, func(pgx.Tx) error { return nil }); err != nil {
 		t.Fatalf("first seed: %v", err)
 	}
 
 	var reFannedOut bool
-	err := e.store.SeedReembeddingFleet(ctx, claim.Run, fleet, func(pgx.Tx) error {
+	err := e.Store.SeedReembeddingFleet(ctx, claim.Run, fleet, func(pgx.Tx) error {
 		reFannedOut = true
 		return nil
 	})
@@ -153,10 +153,10 @@ func steppingClock(step time.Duration) func() time.Time {
 
 // markerAge is how long ago the binding marker last moved, measured by the
 // database's own clock — the same comparison the steal predicate makes.
-func markerAge(t *testing.T, e *searchEnv) time.Duration {
+func markerAge(t *testing.T, e *SearchEnv) time.Duration {
 	t.Helper()
 	var seconds float64
-	if err := e.owner.QueryRow(context.Background(),
+	if err := e.Owner.QueryRow(context.Background(),
 		`SELECT extract(epoch FROM now() - updated_at)::float8 FROM embed_store_binding WHERE singleton`).Scan(&seconds); err != nil {
 		t.Fatalf("reading the marker's age: %v", err)
 	}
@@ -166,9 +166,9 @@ func markerAge(t *testing.T, e *searchEnv) time.Duration {
 // ageMarkerPastTheStealWindow puts the marker's last movement two hours back,
 // which is what a run that stopped reporting leaves behind. Aged rather than
 // waited out: a suite that waits an hour is a suite nobody runs.
-func ageMarkerPastTheStealWindow(t *testing.T, e *searchEnv) {
+func ageMarkerPastTheStealWindow(t *testing.T, e *SearchEnv) {
 	t.Helper()
-	if _, err := e.owner.Exec(context.Background(),
+	if _, err := e.Owner.Exec(context.Background(),
 		`UPDATE embed_store_binding SET updated_at = now() - interval '2 hours' WHERE singleton`); err != nil {
 		t.Fatalf("ageing the marker past the steal window: %v", err)
 	}
@@ -184,21 +184,21 @@ func ageMarkerPastTheStealWindow(t *testing.T, e *searchEnv) {
 // two children re-embedding the same corpus at once, doubling model spend on the
 // largest tenant in the fleet.
 func TestAHealthyRunIsNotStealableHoweverLongItTakes(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	ctx := context.Background()
 	fake := ai.NewFakeClient()
 	embedder := fakeEmbedderNamed(t, fake, "model-slow-but-healthy")
 	identity, _ := embedder.EmbedIdentity()
-	if err := e.store.SeedBinding(ctx, identity); err != nil {
+	if err := e.Store.SeedBinding(ctx, identity); err != nil {
 		t.Fatalf("SeedBinding: %v", err)
 	}
 	ws := ids.From[ids.WorkspaceKind](e.WS)
 
 	working := claimOf(identity)
-	if err := e.store.ClaimAndEnqueueReembedding(ctx, working, func(pgx.Tx) error { return nil }); err != nil {
+	if err := e.Store.ClaimAndEnqueueReembedding(ctx, working, func(pgx.Tx) error { return nil }); err != nil {
 		t.Fatalf("claiming the run: %v", err)
 	}
-	if err := e.store.SeedReembeddingFleet(ctx, working.Run, []ids.WorkspaceID{ws}, func(pgx.Tx) error { return nil }); err != nil {
+	if err := e.Store.SeedReembeddingFleet(ctx, working.Run, []ids.WorkspaceID{ws}, func(pgx.Tx) error { return nil }); err != nil {
 		t.Fatalf("seeding the run: %v", err)
 	}
 
@@ -217,11 +217,11 @@ func TestAHealthyRunIsNotStealableHoweverLongItTakes(t *testing.T) {
 	// nothing here finishes the workspace.
 	slow := steppingClock(search.ReembedProgressStaleness + time.Minute)
 	pass := search.ReembedPass{Run: working.Run, Identity: identity, Now: slow}
-	if err := e.store.ReembedWorkspace(ctx, pass, ws, embedder); err != nil {
+	if err := e.Store.ReembedWorkspace(ctx, pass, ws, embedder); err != nil {
 		t.Fatalf("the healthy pass: %v", err)
 	}
 
-	err := e.store.ClaimAndEnqueueReembedding(ctx,
+	err := e.Store.ClaimAndEnqueueReembedding(ctx,
 		search.ReembedClaim{Run: ids.NewV7(), TargetIdentity: identity, StealAfter: time.Hour},
 		func(pgx.Tx) error { return nil })
 	if !errors.Is(err, search.ErrReembeddingInFlight) {
@@ -263,21 +263,21 @@ func (p *probingEmbedder) Embed(ctx context.Context, req model.EmbedRequest) (mo
 // does to it. By the time the pass reaches its first embed, a forced confirm
 // must find a marker fresh enough to refuse.
 func TestReembedReportsProgressBeforeItsScanAndItsFirstEmbed(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	ctx := context.Background()
 	fake := ai.NewFakeClient()
 	delegate := fakeEmbedderNamed(t, fake, "model-slow-first-entity")
 	identity, _ := delegate.EmbedIdentity()
-	if err := e.store.SeedBinding(ctx, identity); err != nil {
+	if err := e.Store.SeedBinding(ctx, identity); err != nil {
 		t.Fatalf("SeedBinding: %v", err)
 	}
 	ws := ids.From[ids.WorkspaceKind](e.WS)
 
 	working := claimOf(identity)
-	if err := e.store.ClaimAndEnqueueReembedding(ctx, working, func(pgx.Tx) error { return nil }); err != nil {
+	if err := e.Store.ClaimAndEnqueueReembedding(ctx, working, func(pgx.Tx) error { return nil }); err != nil {
 		t.Fatalf("claiming the run: %v", err)
 	}
-	if err := e.store.SeedReembeddingFleet(ctx, working.Run, []ids.WorkspaceID{ws}, func(pgx.Tx) error { return nil }); err != nil {
+	if err := e.Store.SeedReembeddingFleet(ctx, working.Run, []ids.WorkspaceID{ws}, func(pgx.Tx) error { return nil }); err != nil {
 		t.Fatalf("seeding the run: %v", err)
 	}
 	for i := range 2 {
@@ -310,13 +310,13 @@ func TestReembedReportsProgressBeforeItsScanAndItsFirstEmbed(t *testing.T) {
 
 	var stealDuringFirstEmbed error
 	embedder := &probingEmbedder{Embedder: delegate, probe: func() {
-		stealDuringFirstEmbed = e.store.ClaimAndEnqueueReembedding(ctx,
+		stealDuringFirstEmbed = e.Store.ClaimAndEnqueueReembedding(ctx,
 			search.ReembedClaim{Run: ids.NewV7(), TargetIdentity: identity, StealAfter: time.Hour},
 			func(pgx.Tx) error { return nil })
 	}}
 
 	pass := search.ReembedPass{Run: working.Run, Identity: identity, Now: slowScan}
-	if err := e.store.ReembedWorkspace(ctx, pass, ws, embedder); err != nil {
+	if err := e.Store.ReembedWorkspace(ctx, pass, ws, embedder); err != nil {
 		t.Fatalf("the healthy pass: %v", err)
 	}
 	if !embedder.probed {
@@ -336,17 +336,17 @@ func TestReembedReportsProgressBeforeItsScanAndItsFirstEmbed(t *testing.T) {
 // explain why. An ordinary confirm must still be refused, so the escape hatch
 // cannot be mistaken for the normal path.
 func TestAForcedClaimTakesTheMarkerOffARunThatStoppedMoving(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	ctx := context.Background()
 	const identity = "fake/stuck@1024"
-	if err := e.store.SeedBinding(ctx, identity); err != nil {
+	if err := e.Store.SeedBinding(ctx, identity); err != nil {
 		t.Fatalf("SeedBinding: %v", err)
 	}
 	stuck := claimOf(identity)
-	if err := e.store.ClaimAndEnqueueReembedding(ctx, stuck, func(pgx.Tx) error { return nil }); err != nil {
+	if err := e.Store.ClaimAndEnqueueReembedding(ctx, stuck, func(pgx.Tx) error { return nil }); err != nil {
 		t.Fatalf("claiming the run that will wedge: %v", err)
 	}
-	if err := e.store.SeedReembeddingFleet(ctx, stuck.Run,
+	if err := e.Store.SeedReembeddingFleet(ctx, stuck.Run,
 		[]ids.WorkspaceID{ids.From[ids.WorkspaceKind](e.WS)}, func(pgx.Tx) error { return nil }); err != nil {
 		t.Fatalf("seeding the wedged run: %v", err)
 	}
@@ -355,22 +355,22 @@ func TestAForcedClaimTakesTheMarkerOffARunThatStoppedMoving(t *testing.T) {
 	// marker has not moved since.
 	ageMarkerPastTheStealWindow(t, e)
 
-	if err := e.store.ClaimAndEnqueueReembedding(ctx, claimOf(identity), func(pgx.Tx) error { return nil }); !errors.Is(err, search.ErrReembeddingInFlight) {
+	if err := e.Store.ClaimAndEnqueueReembedding(ctx, claimOf(identity), func(pgx.Tx) error { return nil }); !errors.Is(err, search.ErrReembeddingInFlight) {
 		t.Fatalf("an ordinary confirm over a stale marker = %v, want ErrReembeddingInFlight — stealing must be something a human asked for", err)
 	}
 
 	taking := search.ReembedClaim{Run: ids.NewV7(), TargetIdentity: identity, StealAfter: time.Hour}
-	if err := e.store.ClaimAndEnqueueReembedding(ctx, taking, func(pgx.Tx) error { return nil }); err != nil {
+	if err := e.Store.ClaimAndEnqueueReembedding(ctx, taking, func(pgx.Tx) error { return nil }); err != nil {
 		t.Fatalf("a forced confirm over a marker nothing is moving: %v", err)
 	}
 	// The taken-over marker belongs to the new run outright: the wedged run's
 	// pending set is gone, so its own straggler's BOOKKEEPING moves nothing.
 	// It says nothing about that straggler's embedding work, which a steal does
 	// not stop (search.ReembedClaim.StealAfter).
-	if err := e.store.FinishWorkspaceReembedding(ctx, stuck.Run, ids.From[ids.WorkspaceKind](e.WS)); err != nil {
+	if err := e.Store.FinishWorkspaceReembedding(ctx, stuck.Run, ids.From[ids.WorkspaceKind](e.WS)); err != nil {
 		t.Fatalf("the dispossessed run's straggler must be a no-op, got: %v", err)
 	}
-	_, status, _, err := e.store.PopulatedIdentity(ctx)
+	_, status, _, err := e.Store.PopulatedIdentity(ctx)
 	if err != nil {
 		t.Fatalf("PopulatedIdentity: %v", err)
 	}
@@ -379,7 +379,7 @@ func TestAForcedClaimTakesTheMarkerOffARunThatStoppedMoving(t *testing.T) {
 	}
 
 	// A run that IS moving keeps its marker, however old the wedged one was.
-	if err := e.store.ClaimAndEnqueueReembedding(ctx,
+	if err := e.Store.ClaimAndEnqueueReembedding(ctx,
 		search.ReembedClaim{Run: ids.NewV7(), TargetIdentity: identity, StealAfter: time.Hour},
 		func(pgx.Tx) error { return nil }); !errors.Is(err, search.ErrReembeddingInFlight) {
 		t.Fatalf("a forced confirm over a freshly claimed marker = %v, want ErrReembeddingInFlight", err)

--- a/backend/internal/compose/integration/report_graph_integration_test.go
+++ b/backend/internal/compose/integration/report_graph_integration_test.go
@@ -30,12 +30,11 @@ import (
 // and n open deals owned by the given user (nil = ownerless).
 func (e *SearchEnv) seedDealFixtures(t *testing.T, n int, owner *ids.UUID) {
 	t.Helper()
-	var orgID ids.UUID
-	pipelineID := e.seed(t, `INSERT INTO pipeline (id, workspace_id, name, is_default, position) VALUES ($1, $2, 'Sales', true, 0)`)
-	stageID := e.seed(t, `INSERT INTO stage (id, workspace_id, pipeline_id, name, position, semantic, win_probability) VALUES ($1, $2, $3, 'Qualify', 0, 'open', 10)`, pipelineID)
-	orgID = e.seed(t, `INSERT INTO organization (id, workspace_id, display_name, source, captured_by) VALUES ($1, $2, 'Report Org', 'manual', 'human:x')`)
+	pipelineID := e.Seed(t, `INSERT INTO pipeline (id, workspace_id, name, is_default, position) VALUES ($1, $2, 'Sales', true, 0)`)
+	stageID := e.Seed(t, `INSERT INTO stage (id, workspace_id, pipeline_id, name, position, semantic, win_probability) VALUES ($1, $2, $3, 'Qualify', 0, 'open', 10)`, pipelineID)
+	orgID := e.Seed(t, `INSERT INTO organization (id, workspace_id, display_name, source, captured_by) VALUES ($1, $2, 'Report Org', 'manual', 'human:x')`)
 	for i := 0; i < n; i++ {
-		e.seed(t, fmt.Sprintf(`INSERT INTO deal (id, workspace_id, name, pipeline_id, stage_id, organization_id, owner_id, amount_minor, currency, source, captured_by)
+		e.Seed(t, fmt.Sprintf(`INSERT INTO deal (id, workspace_id, name, pipeline_id, stage_id, organization_id, owner_id, amount_minor, currency, source, captured_by)
 			VALUES ($1, $2, 'Deal %d', $3, $4, $5, $6, 100000, 'EUR', 'manual', 'human:x')`, i),
 			pipelineID, stageID, orgID, owner)
 	}
@@ -59,7 +58,7 @@ func TestAdHocReportPlanCountsUnderRowScope(t *testing.T) {
 
 	// A team1 rep sees none of team2's deals — aggregates cannot leak
 	// what the lists hide.
-	res, err = provider.RunReport(e.asTeamRep(e.Rep1, e.Team1), datasource.ReportPlan{
+	res, err = provider.RunReport(e.AsTeamRep(e.Rep1, e.Team1), datasource.ReportPlan{
 		Entity: datasource.EntityDeal, GroupBy: []string{"status"},
 	})
 	if err != nil {
@@ -196,12 +195,12 @@ func TestAssembleContextFixedDepthWalk(t *testing.T) {
 	if err := e.Owner.QueryRow(context.Background(), `SELECT id FROM deal LIMIT 1`).Scan(&dealID); err != nil {
 		t.Fatal(err)
 	}
-	personID := e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Graph Contact', 'manual', 'human:x')`)
-	noteID := e.seed(t, `INSERT INTO activity (id, workspace_id, kind, subject, source, captured_by) VALUES ($1, $2, 'note', 'Kickoff call', 'manual', 'human:x')`)
-	taskID := e.seed(t, `INSERT INTO activity (id, workspace_id, kind, subject, is_done, source, captured_by) VALUES ($1, $2, 'task', 'Send offer', false, 'manual', 'human:x')`)
+	personID := e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Graph Contact', 'manual', 'human:x')`)
+	noteID := e.Seed(t, `INSERT INTO activity (id, workspace_id, kind, subject, source, captured_by) VALUES ($1, $2, 'note', 'Kickoff call', 'manual', 'human:x')`)
+	taskID := e.Seed(t, `INSERT INTO activity (id, workspace_id, kind, subject, is_done, source, captured_by) VALUES ($1, $2, 'task', 'Send offer', false, 'manual', 'human:x')`)
 	for _, activityID := range []ids.UUID{noteID, taskID} {
-		e.seed(t, `INSERT INTO activity_link (id, workspace_id, activity_id, entity_type, deal_id) VALUES ($1, $2, $3, 'deal', $4)`, activityID, dealID)
-		e.seed(t, `INSERT INTO activity_link (id, workspace_id, activity_id, entity_type, person_id) VALUES ($1, $2, $3, 'person', $4)`, activityID, personID)
+		e.Seed(t, `INSERT INTO activity_link (id, workspace_id, activity_id, entity_type, deal_id) VALUES ($1, $2, $3, 'deal', $4)`, activityID, dealID)
+		e.Seed(t, `INSERT INTO activity_link (id, workspace_id, activity_id, entity_type, person_id) VALUES ($1, $2, $3, 'person', $4)`, activityID, personID)
 	}
 
 	// AssembleContext never calls the embedder (it's Search's seam), but
@@ -241,9 +240,9 @@ func TestAssembleContextFixedDepthWalk(t *testing.T) {
 	}
 
 	// An anchor outside the caller's row scope assembles nothing.
-	foreignDeal := e.seed(t, `INSERT INTO deal (id, workspace_id, name, pipeline_id, stage_id, owner_id, source, captured_by)
+	foreignDeal := e.Seed(t, `INSERT INTO deal (id, workspace_id, name, pipeline_id, stage_id, owner_id, source, captured_by)
 		SELECT $1, $2, 'Foreign Deal', pipeline_id, stage_id, $3, 'manual', 'human:x' FROM deal LIMIT 1`, e.Rep3)
-	if _, err := retriever.AssembleContext(e.asTeamRep(e.Rep1, e.Team1),
+	if _, err := retriever.AssembleContext(e.AsTeamRep(e.Rep1, e.Team1),
 		datasource.EntityRef{Type: datasource.EntityDeal, ID: foreignDeal}, retrieval.AssembleOptions{}); err == nil {
 		t.Fatal("foreign anchor must be absent, not assembled")
 	}

--- a/backend/internal/compose/integration/report_graph_integration_test.go
+++ b/backend/internal/compose/integration/report_graph_integration_test.go
@@ -28,8 +28,9 @@ import (
 
 // seedDealFixtures plants a pipeline, one open stage, an organization
 // and n open deals owned by the given user (nil = ownerless).
-func (e *searchEnv) seedDealFixtures(t *testing.T, n int, owner *ids.UUID) (orgID ids.UUID) {
+func (e *SearchEnv) seedDealFixtures(t *testing.T, n int, owner *ids.UUID) {
 	t.Helper()
+	var orgID ids.UUID
 	pipelineID := e.seed(t, `INSERT INTO pipeline (id, workspace_id, name, is_default, position) VALUES ($1, $2, 'Sales', true, 0)`)
 	stageID := e.seed(t, `INSERT INTO stage (id, workspace_id, pipeline_id, name, position, semantic, win_probability) VALUES ($1, $2, $3, 'Qualify', 0, 'open', 10)`, pipelineID)
 	orgID = e.seed(t, `INSERT INTO organization (id, workspace_id, display_name, source, captured_by) VALUES ($1, $2, 'Report Org', 'manual', 'human:x')`)
@@ -38,11 +39,10 @@ func (e *searchEnv) seedDealFixtures(t *testing.T, n int, owner *ids.UUID) (orgI
 			VALUES ($1, $2, 'Deal %d', $3, $4, $5, $6, 100000, 'EUR', 'manual', 'human:x')`, i),
 			pipelineID, stageID, orgID, owner)
 	}
-	return orgID
 }
 
 func TestAdHocReportPlanCountsUnderRowScope(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	e.seedDealFixtures(t, 3, &e.Rep3) // owned by team2's rep
 	provider := compose.NewProvider(e.Pool)
 
@@ -71,7 +71,7 @@ func TestAdHocReportPlanCountsUnderRowScope(t *testing.T) {
 }
 
 func TestSchemaIntrospectionServesDescriptors(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	provider := compose.NewProvider(e.Pool)
 	objects, err := provider.ListObjects(context.Background())
 	if err != nil {
@@ -177,7 +177,7 @@ func TestPrebuiltReportOverHTTPAndVocabulary(t *testing.T) {
 }
 
 func TestRunReportToolThroughGovernedRegistry(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	e.seedDealFixtures(t, 2, nil)
 	registry := compose.NewRegistry(e.Pool, compose.SendPath{})
 	out, err := registry.Invoke(e.Admin(), "run_report", []byte(`{"report":"deals-by-stage"}`))
@@ -190,10 +190,10 @@ func TestRunReportToolThroughGovernedRegistry(t *testing.T) {
 }
 
 func TestAssembleContextFixedDepthWalk(t *testing.T) {
-	e := setupSearch(t)
-	orgID := e.seedDealFixtures(t, 1, nil)
+	e := SetupSearch(t)
+	e.seedDealFixtures(t, 1, nil)
 	var dealID ids.UUID
-	if err := e.owner.QueryRow(context.Background(), `SELECT id FROM deal LIMIT 1`).Scan(&dealID); err != nil {
+	if err := e.Owner.QueryRow(context.Background(), `SELECT id FROM deal LIMIT 1`).Scan(&dealID); err != nil {
 		t.Fatal(err)
 	}
 	personID := e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Graph Contact', 'manual', 'human:x')`)
@@ -212,7 +212,7 @@ func TestAssembleContextFixedDepthWalk(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewLocalModelPath: %v", err)
 	}
-	retriever := search.NewRetriever(e.store, modelPath.Embedder)
+	retriever := search.NewRetriever(e.Store, modelPath.Embedder)
 	assembled, err := retriever.AssembleContext(e.Admin(),
 		datasource.EntityRef{Type: datasource.EntityDeal, ID: dealID}, retrieval.AssembleOptions{MaxItems: 5})
 	if err != nil {
@@ -239,7 +239,6 @@ func TestAssembleContextFixedDepthWalk(t *testing.T) {
 		// the fixed-depth walk only follows conversation links.
 		t.Logf("note: org appears only when linked through an activity: %+v", sections["related_organizations"])
 	}
-	_ = orgID
 
 	// An anchor outside the caller's row scope assembles nothing.
 	foreignDeal := e.seed(t, `INSERT INTO deal (id, workspace_id, name, pipeline_id, stage_id, owner_id, source, captured_by)

--- a/backend/internal/compose/integration/report_project_integration_test.go
+++ b/backend/internal/compose/integration/report_project_integration_test.go
@@ -25,7 +25,7 @@ import (
 
 // seedProjects plants an anchor company and n live projects in one phase,
 // owned by the given user (nil = ownerless, i.e. workspace-shared).
-func (e *searchEnv) seedProjects(t *testing.T, phase string, owner *ids.UUID, n int) (orgID ids.UUID) {
+func (e *SearchEnv) seedProjects(t *testing.T, phase string, owner *ids.UUID, n int) (orgID ids.UUID) {
 	t.Helper()
 	orgID = e.seed(t, `INSERT INTO organization (id, workspace_id, display_name, source, captured_by)
 		VALUES ($1, $2, 'Project Org', 'manual', 'human:x')`)
@@ -40,7 +40,7 @@ func (e *searchEnv) seedProjects(t *testing.T, phase string, owner *ids.UUID, n 
 // projectReader mints a human holding project.read at the given row scope —
 // the report path gates on the object grant before any row scope applies, and
 // the shared searchReadGrants helper predates the project vocabulary.
-func (e *searchEnv) projectReader(user *ids.UUID, team *ids.UUID, scope principal.RowScope) context.Context {
+func (e *SearchEnv) projectReader(user *ids.UUID, team *ids.UUID, scope principal.RowScope) context.Context {
 	actor := principal.Principal{
 		Type: principal.PrincipalHuman, ID: "human:" + ids.NewV7().String(), UserID: ids.NewV7(),
 		Permissions: principal.Permissions{
@@ -59,7 +59,7 @@ func (e *searchEnv) projectReader(user *ids.UUID, team *ids.UUID, scope principa
 }
 
 func TestListFieldsServesTheProjectDescriptor(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	provider := compose.NewProvider(e.Pool)
 
 	fields, err := provider.ListFields(context.Background(), datasource.EntityProject)
@@ -78,7 +78,7 @@ func TestListFieldsServesTheProjectDescriptor(t *testing.T) {
 }
 
 func TestAdHocProjectReportCountsUnderRowScope(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	orgID := e.seedProjects(t, "delivering", &e.Rep3, 2)
 	provider := compose.NewProvider(e.Pool)
 
@@ -133,7 +133,7 @@ func TestAdHocProjectReportCountsUnderRowScope(t *testing.T) {
 }
 
 func TestAdHocProjectReportRefusesWithoutTheObjectGrant(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	e.seedProjects(t, "delivering", nil, 1)
 	provider := compose.NewProvider(e.Pool)
 

--- a/backend/internal/compose/integration/report_project_integration_test.go
+++ b/backend/internal/compose/integration/report_project_integration_test.go
@@ -27,10 +27,10 @@ import (
 // owned by the given user (nil = ownerless, i.e. workspace-shared).
 func (e *SearchEnv) seedProjects(t *testing.T, phase string, owner *ids.UUID, n int) (orgID ids.UUID) {
 	t.Helper()
-	orgID = e.seed(t, `INSERT INTO organization (id, workspace_id, display_name, source, captured_by)
+	orgID = e.Seed(t, `INSERT INTO organization (id, workspace_id, display_name, source, captured_by)
 		VALUES ($1, $2, 'Project Org', 'manual', 'human:x')`)
 	for i := 0; i < n; i++ {
-		e.seed(t, `INSERT INTO project (id, workspace_id, name, organization_id, owner_id, phase, source, captured_by)
+		e.Seed(t, `INSERT INTO project (id, workspace_id, name, organization_id, owner_id, phase, source, captured_by)
 			VALUES ($1, $2, $3, $4, $5, $6, 'manual', 'human:x')`,
 			fmt.Sprintf("%s Rollout %d", phase, i), orgID, owner, phase)
 	}
@@ -119,7 +119,7 @@ func TestAdHocProjectReportCountsUnderRowScope(t *testing.T) {
 
 	// The rep's own project is counted — the empty answer above is scope, not
 	// a plan that never matches.
-	e.seed(t, `INSERT INTO project (id, workspace_id, name, organization_id, owner_id, phase, source, captured_by)
+	e.Seed(t, `INSERT INTO project (id, workspace_id, name, organization_id, owner_id, phase, source, captured_by)
 		VALUES ($1, $2, 'Own Rollout', $3, $4, 'pursuing', 'manual', 'human:x')`, orgID, e.Rep1)
 	res, err = provider.RunReport(e.projectReader(&e.Rep1, &e.Team1, principal.RowScopeTeam), datasource.ReportPlan{
 		Entity: datasource.EntityProject, GroupBy: []string{"phase"},

--- a/backend/internal/compose/integration/search_integration_test.go
+++ b/backend/internal/compose/integration/search_integration_test.go
@@ -19,52 +19,15 @@ import (
 	"testing"
 
 	"github.com/gradionhq/margince/backend/internal/modules/search"
-	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
-
-// seed writes rows through the owner connection: this suite tests READ
-// semantics; the write shape has its own suites.
-func (e *SearchEnv) seed(t *testing.T, sql string, args ...any) ids.UUID {
-	t.Helper()
-	id := ids.NewV7()
-	if _, err := e.Owner.Exec(context.Background(), sql, append([]any{id, e.WS}, args...)...); err != nil {
-		t.Fatalf("seeding: %v", err)
-	}
-	return id
-}
-
-func searchReadGrants() map[string]principal.ObjectGrant {
-	grants := map[string]principal.ObjectGrant{}
-	for _, object := range []string{"person", "organization", "deal", "lead", "activity"} {
-		grants[object] = principal.ObjectGrant{Read: true}
-	}
-	return grants
-}
-
-func (e *SearchEnv) Admin() context.Context {
-	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
-	return principal.WithActor(ctx, principal.Principal{
-		Type: principal.PrincipalHuman, ID: "human:" + ids.NewV7().String(), UserID: ids.NewV7(),
-		Permissions: principal.Permissions{Objects: searchReadGrants(), RowScope: principal.RowScopeAll},
-	})
-}
-
-func (e *SearchEnv) asTeamRep(user, team ids.UUID) context.Context {
-	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
-	return principal.WithActor(ctx, principal.Principal{
-		Type: principal.PrincipalHuman, ID: "human:" + user.String(), UserID: user,
-		TeamIDs:     []ids.UUID{team},
-		Permissions: principal.Permissions{Objects: searchReadGrants(), RowScope: principal.RowScopeTeam},
-	})
-}
 
 // A role with NO person grant gets no person hits — search must not
 // out-see the entity lists (object RBAC before row scope).
 func TestSearchHonorsObjectRBAC(t *testing.T) {
 	e := SetupSearch(t)
-	e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Rostock Person', 'manual', 'human:x')`)
-	e.seed(t, `INSERT INTO organization (id, workspace_id, display_name, source, captured_by) VALUES ($1, $2, 'Rostock Werft', 'manual', 'human:x')`)
+	e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Rostock Person', 'manual', 'human:x')`)
+	e.Seed(t, `INSERT INTO organization (id, workspace_id, display_name, source, captured_by) VALUES ($1, $2, 'Rostock Werft', 'manual', 'human:x')`)
 
 	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
 	orgOnly := principal.WithActor(ctx, principal.Principal{
@@ -91,11 +54,11 @@ func TestSearchHonorsObjectRBAC(t *testing.T) {
 
 func TestSearchRanksAcrossObjectTypes(t *testing.T) {
 	e := SetupSearch(t)
-	e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Heike Hamburg', 'manual', 'human:x')`)
-	e.seed(t, `INSERT INTO organization (id, workspace_id, display_name, source, captured_by) VALUES ($1, $2, 'Hamburg Logistics GmbH', 'manual', 'human:x')`)
-	e.seed(t, `INSERT INTO lead (id, workspace_id, company_name, email, source, captured_by) VALUES ($1, $2, 'Hamburg Freight', 'lead@hamburg.test', 'manual', 'human:x')`)
-	e.seed(t, `INSERT INTO activity (id, workspace_id, kind, subject, body, source, captured_by) VALUES ($1, $2, 'note', 'Hamburg visit', 'Met the Hamburg team at the Hamburg office in Hamburg', 'manual', 'human:x')`)
-	e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Unrelated Munich', 'manual', 'human:x')`)
+	e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Heike Hamburg', 'manual', 'human:x')`)
+	e.Seed(t, `INSERT INTO organization (id, workspace_id, display_name, source, captured_by) VALUES ($1, $2, 'Hamburg Logistics GmbH', 'manual', 'human:x')`)
+	e.Seed(t, `INSERT INTO lead (id, workspace_id, company_name, email, source, captured_by) VALUES ($1, $2, 'Hamburg Freight', 'lead@hamburg.test', 'manual', 'human:x')`)
+	e.Seed(t, `INSERT INTO activity (id, workspace_id, kind, subject, body, source, captured_by) VALUES ($1, $2, 'note', 'Hamburg visit', 'Met the Hamburg team at the Hamburg office in Hamburg', 'manual', 'human:x')`)
+	e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Unrelated Munich', 'manual', 'human:x')`)
 
 	page, err := e.Store.Search(e.Admin(), search.Input{Query: "hamburg"})
 	if err != nil {
@@ -125,12 +88,12 @@ func TestSearchRanksAcrossObjectTypes(t *testing.T) {
 
 func TestSearchHitsCarryTheCallersRowScope(t *testing.T) {
 	e := SetupSearch(t)
-	e.seed(t, `INSERT INTO person (id, workspace_id, full_name, owner_id, source, captured_by) VALUES ($1, $2, 'Scoped Bremen', $3, 'manual', 'human:x')`, e.Rep3)
-	e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Shared Bremen', 'manual', 'human:x')`)
+	e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, owner_id, source, captured_by) VALUES ($1, $2, 'Scoped Bremen', $3, 'manual', 'human:x')`, e.Rep3)
+	e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Shared Bremen', 'manual', 'human:x')`)
 
 	// rep1 (team1, row_scope=team) must not see rep3's (team2) record —
 	// but the ownerless row is workspace-shared.
-	page, err := e.Store.Search(e.asTeamRep(e.Rep1, e.Team1), search.Input{Query: "bremen"})
+	page, err := e.Store.Search(e.AsTeamRep(e.Rep1, e.Team1), search.Input{Query: "bremen"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -149,7 +112,7 @@ func TestSearchHitsCarryTheCallersRowScope(t *testing.T) {
 
 func TestSearchExcludesArchivedRows(t *testing.T) {
 	e := SetupSearch(t)
-	e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by, archived_at) VALUES ($1, $2, 'Archived Kiel', 'manual', 'human:x', now())`)
+	e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by, archived_at) VALUES ($1, $2, 'Archived Kiel', 'manual', 'human:x', now())`)
 	page, err := e.Store.Search(e.Admin(), search.Input{Query: "kiel"})
 	if err != nil {
 		t.Fatal(err)
@@ -164,8 +127,8 @@ func TestSearchExcludesArchivedRows(t *testing.T) {
 // narrows is discovery.
 func TestSearchExcludesTheOwnCompany(t *testing.T) {
 	e := SetupSearch(t)
-	e.seed(t, `INSERT INTO organization (id, workspace_id, display_name, is_anchor, source, captured_by) VALUES ($1, $2, 'Rostock Consulting GmbH', true, 'manual', 'human:x')`)
-	customer := e.seed(t, `INSERT INTO organization (id, workspace_id, display_name, source, captured_by) VALUES ($1, $2, 'Rostock Freight AG', 'manual', 'human:x')`)
+	e.Seed(t, `INSERT INTO organization (id, workspace_id, display_name, is_anchor, source, captured_by) VALUES ($1, $2, 'Rostock Consulting GmbH', true, 'manual', 'human:x')`)
+	customer := e.Seed(t, `INSERT INTO organization (id, workspace_id, display_name, source, captured_by) VALUES ($1, $2, 'Rostock Freight AG', 'manual', 'human:x')`)
 
 	page, err := e.Store.Search(e.Admin(), search.Input{Query: "rostock"})
 	if err != nil {
@@ -180,7 +143,7 @@ func TestSearchRankedCursorWalksAllHitsOnce(t *testing.T) {
 	e := SetupSearch(t)
 	want := map[string]bool{}
 	for i := 0; i < 5; i++ {
-		id := e.seed(t, fmt.Sprintf(`INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Dresden Contact %d', 'manual', 'human:x')`, i))
+		id := e.Seed(t, fmt.Sprintf(`INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Dresden Contact %d', 'manual', 'human:x')`, i))
 		want[id.String()] = false
 	}
 	got := 0

--- a/backend/internal/compose/integration/search_integration_test.go
+++ b/backend/internal/compose/integration/search_integration_test.go
@@ -15,96 +15,20 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
-	"github.com/jackc/pgx/v5"
-
-	"github.com/jackc/pgx/v5/pgxpool"
-
 	"github.com/gradionhq/margince/backend/internal/modules/search"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
-	"github.com/gradionhq/margince/backend/internal/platform/testdb"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
-type searchEnv struct {
-	owner *pgx.Conn
-	Pool  *pgxpool.Pool
-	store *search.Store
-	WS    ids.UUID
-	Rep1  ids.UUID // team1
-	Rep3  ids.UUID // team2
-	Team1 ids.UUID
-	Team2 ids.UUID
-}
-
-func setupSearch(t *testing.T) *searchEnv {
-	t.Helper()
-	ownerDSN := os.Getenv("MARGINCE_TEST_DSN")
-	appDSN := os.Getenv("MARGINCE_TEST_APP_DSN")
-	if ownerDSN == "" || appDSN == "" {
-		t.Fatal("MARGINCE_TEST_DSN / MARGINCE_TEST_APP_DSN not set — run `make db-up` (integration tests fail loudly, they never skip)")
-	}
-	ctx := context.Background()
-	owner, err := pgx.Connect(ctx, ownerDSN)
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() {
-		if err := owner.Close(context.Background()); err != nil {
-			t.Errorf("closing owner connection: %v", err)
-		}
-	})
-	if err := testdb.EnsureSchema(ctx, owner); err != nil {
-		t.Fatal(err)
-	}
-	if err := testdb.Reset(ctx, owner); err != nil {
-		t.Fatal(err)
-	}
-
-	e := &searchEnv{
-		owner: owner, WS: ids.NewV7(),
-		Rep1: ids.NewV7(), Rep3: ids.NewV7(), Team1: ids.NewV7(), Team2: ids.NewV7(),
-	}
-	if _, err := owner.Exec(ctx, `INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Search', 'search', 'EUR')`, e.WS); err != nil {
-		t.Fatal(err)
-	}
-	for i, u := range []ids.UUID{e.Rep1, e.Rep3} {
-		if _, err := owner.Exec(ctx, `INSERT INTO app_user (id, workspace_id, email, display_name) VALUES ($1, $2, $3, 'Rep')`,
-			u, e.WS, fmt.Sprintf("rep%d@search.test", i)); err != nil {
-			t.Fatal(err)
-		}
-	}
-	for _, tm := range []ids.UUID{e.Team1, e.Team2} {
-		if _, err := owner.Exec(ctx, `INSERT INTO team (id, workspace_id, name) VALUES ($1, $2, $3)`, tm, e.WS, tm.String()); err != nil {
-			t.Fatal(err)
-		}
-	}
-	for u, tm := range map[ids.UUID]ids.UUID{e.Rep1: e.Team1, e.Rep3: e.Team2} {
-		if _, err := owner.Exec(ctx, `INSERT INTO team_membership (workspace_id, team_id, user_id) VALUES ($1, $2, $3)`, e.WS, tm, u); err != nil {
-			t.Fatal(err)
-		}
-	}
-
-	pool, err := database.NewPool(ctx, appDSN)
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(pool.Close)
-	e.Pool = pool
-	e.store = search.NewStore(pool)
-	return e
-}
-
 // seed writes rows through the owner connection: this suite tests READ
 // semantics; the write shape has its own suites.
-func (e *searchEnv) seed(t *testing.T, sql string, args ...any) ids.UUID {
+func (e *SearchEnv) seed(t *testing.T, sql string, args ...any) ids.UUID {
 	t.Helper()
 	id := ids.NewV7()
-	if _, err := e.owner.Exec(context.Background(), sql, append([]any{id, e.WS}, args...)...); err != nil {
+	if _, err := e.Owner.Exec(context.Background(), sql, append([]any{id, e.WS}, args...)...); err != nil {
 		t.Fatalf("seeding: %v", err)
 	}
 	return id
@@ -118,7 +42,7 @@ func searchReadGrants() map[string]principal.ObjectGrant {
 	return grants
 }
 
-func (e *searchEnv) Admin() context.Context {
+func (e *SearchEnv) Admin() context.Context {
 	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
 	return principal.WithActor(ctx, principal.Principal{
 		Type: principal.PrincipalHuman, ID: "human:" + ids.NewV7().String(), UserID: ids.NewV7(),
@@ -126,7 +50,7 @@ func (e *searchEnv) Admin() context.Context {
 	})
 }
 
-func (e *searchEnv) asTeamRep(user, team ids.UUID) context.Context {
+func (e *SearchEnv) asTeamRep(user, team ids.UUID) context.Context {
 	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
 	return principal.WithActor(ctx, principal.Principal{
 		Type: principal.PrincipalHuman, ID: "human:" + user.String(), UserID: user,
@@ -138,7 +62,7 @@ func (e *searchEnv) asTeamRep(user, team ids.UUID) context.Context {
 // A role with NO person grant gets no person hits — search must not
 // out-see the entity lists (object RBAC before row scope).
 func TestSearchHonorsObjectRBAC(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Rostock Person', 'manual', 'human:x')`)
 	e.seed(t, `INSERT INTO organization (id, workspace_id, display_name, source, captured_by) VALUES ($1, $2, 'Rostock Werft', 'manual', 'human:x')`)
 
@@ -150,7 +74,7 @@ func TestSearchHonorsObjectRBAC(t *testing.T) {
 			RowScope: principal.RowScopeAll,
 		},
 	})
-	page, err := e.store.Search(orgOnly, search.Input{Query: "rostock"})
+	page, err := e.Store.Search(orgOnly, search.Input{Query: "rostock"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -159,21 +83,21 @@ func TestSearchHonorsObjectRBAC(t *testing.T) {
 	}
 	// Explicitly requesting only the denied type answers an empty page,
 	// not an error — nothing to disclose.
-	page, err = e.store.Search(orgOnly, search.Input{Query: "rostock", Types: []string{"person"}})
+	page, err = e.Store.Search(orgOnly, search.Input{Query: "rostock", Types: []string{"person"}})
 	if err != nil || len(page.Hits) != 0 {
 		t.Fatalf("denied-type search → %v %+v, want an empty page", err, page.Hits)
 	}
 }
 
 func TestSearchRanksAcrossObjectTypes(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Heike Hamburg', 'manual', 'human:x')`)
 	e.seed(t, `INSERT INTO organization (id, workspace_id, display_name, source, captured_by) VALUES ($1, $2, 'Hamburg Logistics GmbH', 'manual', 'human:x')`)
 	e.seed(t, `INSERT INTO lead (id, workspace_id, company_name, email, source, captured_by) VALUES ($1, $2, 'Hamburg Freight', 'lead@hamburg.test', 'manual', 'human:x')`)
 	e.seed(t, `INSERT INTO activity (id, workspace_id, kind, subject, body, source, captured_by) VALUES ($1, $2, 'note', 'Hamburg visit', 'Met the Hamburg team at the Hamburg office in Hamburg', 'manual', 'human:x')`)
 	e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Unrelated Munich', 'manual', 'human:x')`)
 
-	page, err := e.store.Search(e.Admin(), search.Input{Query: "hamburg"})
+	page, err := e.Store.Search(e.Admin(), search.Input{Query: "hamburg"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -200,13 +124,13 @@ func TestSearchRanksAcrossObjectTypes(t *testing.T) {
 }
 
 func TestSearchHitsCarryTheCallersRowScope(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	e.seed(t, `INSERT INTO person (id, workspace_id, full_name, owner_id, source, captured_by) VALUES ($1, $2, 'Scoped Bremen', $3, 'manual', 'human:x')`, e.Rep3)
 	e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Shared Bremen', 'manual', 'human:x')`)
 
 	// rep1 (team1, row_scope=team) must not see rep3's (team2) record —
 	// but the ownerless row is workspace-shared.
-	page, err := e.store.Search(e.asTeamRep(e.Rep1, e.Team1), search.Input{Query: "bremen"})
+	page, err := e.Store.Search(e.asTeamRep(e.Rep1, e.Team1), search.Input{Query: "bremen"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -214,7 +138,7 @@ func TestSearchHitsCarryTheCallersRowScope(t *testing.T) {
 		t.Fatalf("row scope leaked into search: %+v", page.Hits)
 	}
 	// row_scope=all sees both.
-	page, err = e.store.Search(e.Admin(), search.Input{Query: "bremen"})
+	page, err = e.Store.Search(e.Admin(), search.Input{Query: "bremen"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -224,9 +148,9 @@ func TestSearchHitsCarryTheCallersRowScope(t *testing.T) {
 }
 
 func TestSearchExcludesArchivedRows(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	e.seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by, archived_at) VALUES ($1, $2, 'Archived Kiel', 'manual', 'human:x', now())`)
-	page, err := e.store.Search(e.Admin(), search.Input{Query: "kiel"})
+	page, err := e.Store.Search(e.Admin(), search.Input{Query: "kiel"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -239,11 +163,11 @@ func TestSearchExcludesArchivedRows(t *testing.T) {
 // one to find (ADR-0082/A127). It stays an ordinary row, readable by id — what
 // narrows is discovery.
 func TestSearchExcludesTheOwnCompany(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	e.seed(t, `INSERT INTO organization (id, workspace_id, display_name, is_anchor, source, captured_by) VALUES ($1, $2, 'Rostock Consulting GmbH', true, 'manual', 'human:x')`)
 	customer := e.seed(t, `INSERT INTO organization (id, workspace_id, display_name, source, captured_by) VALUES ($1, $2, 'Rostock Freight AG', 'manual', 'human:x')`)
 
-	page, err := e.store.Search(e.Admin(), search.Input{Query: "rostock"})
+	page, err := e.Store.Search(e.Admin(), search.Input{Query: "rostock"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -253,7 +177,7 @@ func TestSearchExcludesTheOwnCompany(t *testing.T) {
 }
 
 func TestSearchRankedCursorWalksAllHitsOnce(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	want := map[string]bool{}
 	for i := 0; i < 5; i++ {
 		id := e.seed(t, fmt.Sprintf(`INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Dresden Contact %d', 'manual', 'human:x')`, i))
@@ -262,7 +186,7 @@ func TestSearchRankedCursorWalksAllHitsOnce(t *testing.T) {
 	got := 0
 	cursor := ""
 	for pages := 0; pages < 5; pages++ {
-		page, err := e.store.Search(e.Admin(), search.Input{Query: "dresden", Limit: 2, Cursor: cursor})
+		page, err := e.Store.Search(e.Admin(), search.Input{Query: "dresden", Limit: 2, Cursor: cursor})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -284,8 +208,8 @@ func TestSearchRankedCursorWalksAllHitsOnce(t *testing.T) {
 }
 
 func TestSearchEmptyQueryIsAValidationError(t *testing.T) {
-	e := setupSearch(t)
-	_, err := e.store.Search(e.Admin(), search.Input{Query: "   "})
+	e := SetupSearch(t)
+	_, err := e.Store.Search(e.Admin(), search.Input{Query: "   "})
 	var bad *search.BadQueryError
 	if err == nil || !errors.As(err, &bad) || !strings.Contains(bad.Reason, "required") {
 		t.Fatalf("empty query → %v, want BadQueryError", err)
@@ -298,10 +222,10 @@ func TestSearchEmptyQueryIsAValidationError(t *testing.T) {
 // scale past a sequential scan. (Which plan the optimizer picks at a
 // given cardinality is its business; the index existing is ours.)
 func TestSearchEveryBranchHasAGinIndex(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	for _, table := range []string{"person", "organization", "deal", "lead", "activity"} {
 		var exists bool
-		err := e.owner.QueryRow(context.Background(), `
+		err := e.Owner.QueryRow(context.Background(), `
 			SELECT EXISTS (
 			  SELECT 1 FROM pg_index i
 			  JOIN pg_class idx ON idx.oid = i.indexrelid

--- a/backend/internal/compose/integration/searchenv.go
+++ b/backend/internal/compose/integration/searchenv.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/gradionhq/margince/backend/internal/modules/search"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/platform/testdb"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// SearchEnv is the second migrated-database fixture in this package, lighter
+// than Env: one workspace, two reps in two teams, and a search store over the
+// RLS-bound pool. Forty suites ride it, most of them — capture, the connectors,
+// leadscore, export — for the database handles rather than the store, which is
+// why it lives here rather than with the search suite that named it.
+type SearchEnv struct {
+	Owner *pgx.Conn
+	Pool  *pgxpool.Pool
+	Store *search.Store
+	WS    ids.UUID
+	Rep1  ids.UUID // team1
+	Rep3  ids.UUID // team2
+	Team1 ids.UUID
+	Team2 ids.UUID
+}
+
+// SetupSearch gives each test a clean, migrated database seeded with the
+// SearchEnv fixture. Like Setup it fails loudly without a database rather than
+// skipping, and it migrates once per process — see package testdb for what the
+// schema and data resets each cost.
+func SetupSearch(t *testing.T) *SearchEnv {
+	t.Helper()
+	ownerDSN := os.Getenv("MARGINCE_TEST_DSN")
+	appDSN := os.Getenv("MARGINCE_TEST_APP_DSN")
+	if ownerDSN == "" || appDSN == "" {
+		t.Fatal("MARGINCE_TEST_DSN / MARGINCE_TEST_APP_DSN not set — run `make db-up` (integration tests fail loudly, they never skip)")
+	}
+	ctx := context.Background()
+	owner, err := pgx.Connect(ctx, ownerDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := owner.Close(context.Background()); err != nil {
+			t.Errorf("closing owner connection: %v", err)
+		}
+	})
+	if err := testdb.EnsureSchema(ctx, owner); err != nil {
+		t.Fatal(err)
+	}
+	if err := testdb.Reset(ctx, owner); err != nil {
+		t.Fatal(err)
+	}
+
+	e := &SearchEnv{
+		Owner: owner, WS: ids.NewV7(),
+		Rep1: ids.NewV7(), Rep3: ids.NewV7(), Team1: ids.NewV7(), Team2: ids.NewV7(),
+	}
+	if _, err := owner.Exec(ctx, `INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Search', 'search', 'EUR')`, e.WS); err != nil {
+		t.Fatal(err)
+	}
+	for i, u := range []ids.UUID{e.Rep1, e.Rep3} {
+		if _, err := owner.Exec(ctx, `INSERT INTO app_user (id, workspace_id, email, display_name) VALUES ($1, $2, $3, 'Rep')`,
+			u, e.WS, fmt.Sprintf("rep%d@search.test", i)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, tm := range []ids.UUID{e.Team1, e.Team2} {
+		if _, err := owner.Exec(ctx, `INSERT INTO team (id, workspace_id, name) VALUES ($1, $2, $3)`, tm, e.WS, tm.String()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for u, tm := range map[ids.UUID]ids.UUID{e.Rep1: e.Team1, e.Rep3: e.Team2} {
+		if _, err := owner.Exec(ctx, `INSERT INTO team_membership (workspace_id, team_id, user_id) VALUES ($1, $2, $3)`, e.WS, tm, u); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	pool, err := database.NewPool(ctx, appDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+	e.Pool = pool
+	e.Store = search.NewStore(pool)
+	return e
+}

--- a/backend/internal/compose/integration/searchenv.go
+++ b/backend/internal/compose/integration/searchenv.go
@@ -18,13 +18,20 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/testdb"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
-// SearchEnv is the second migrated-database fixture in this package, lighter
-// than Env: one workspace, two reps in two teams, and a search store over the
-// RLS-bound pool. Forty suites ride it, most of them — capture, the connectors,
-// leadscore, export — for the database handles rather than the store, which is
-// why it lives here rather than with the search suite that named it.
+// SearchEnv is the second EXPORTED fixture here, after Env, and lighter than it:
+// one workspace, two reps in two teams, and a search store over the RLS-bound
+// pool. (It is not the second fixture in the package — several suites still build
+// their own; it is the second one a sibling package can import.)
+//
+// Most of its riders take it for the migrated database and the seeded workspace
+// rather than for the store: the capture suites reference Store zero times, as do
+// the connector, leadscore and export suites. The name records where it was first
+// needed, not what it now is, and it is due a better one — the reason it has not
+// been renamed here is only that this change is already a rename of everything
+// else, and one rename per pass is easier to verify than two.
 type SearchEnv struct {
 	Owner *pgx.Conn
 	Pool  *pgxpool.Pool
@@ -96,4 +103,53 @@ func SetupSearch(t *testing.T) *SearchEnv {
 	e.Pool = pool
 	e.Store = search.NewStore(pool)
 	return e
+}
+
+// Seed writes one row through the owner connection, minting its id and binding
+// the workspace. It rides the owner rather than the app pool because the suites
+// that use it are testing READ semantics — the write shape has its own suites,
+// and going through a store here would make the fixture depend on the thing
+// under test.
+func (e *SearchEnv) Seed(t *testing.T, sql string, args ...any) ids.UUID {
+	t.Helper()
+	id := ids.NewV7()
+	if _, err := e.Owner.Exec(context.Background(), sql, append([]any{id, e.WS}, args...)...); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+	return id
+}
+
+// searchReadGrants is read on every record type this fixture's principals can
+// reach. Read-only on purpose: the suites riding it assert what a caller may SEE,
+// so a grant that could write would let a fixture change the rows under its own
+// assertion.
+func searchReadGrants() map[string]principal.ObjectGrant {
+	grants := map[string]principal.ObjectGrant{}
+	for _, object := range []string{objPerson, objOrg, objDeal, "lead", objActivity} {
+		grants[object] = principal.ObjectGrant{Read: true}
+	}
+	return grants
+}
+
+// Admin is an unbounded reader: every record type, row scope all. The fixture's
+// positive control — what a caller with nothing hidden from them sees — against
+// which AsTeamRep's narrower view is the assertion.
+func (e *SearchEnv) Admin() context.Context {
+	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
+	return principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:" + ids.NewV7().String(), UserID: ids.NewV7(),
+		Permissions: principal.Permissions{Objects: searchReadGrants(), RowScope: principal.RowScopeAll},
+	})
+}
+
+// AsTeamRep is a rep bounded to one team's rows — the same grants as Admin with
+// row scope narrowed, so a suite comparing the two isolates row scope from object
+// RBAC rather than confounding them.
+func (e *SearchEnv) AsTeamRep(user, team ids.UUID) context.Context {
+	ctx := principal.WithWorkspaceID(context.Background(), e.WS)
+	return principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:" + user.String(), UserID: user,
+		TeamIDs:     []ids.UUID{team},
+		Permissions: principal.Permissions{Objects: searchReadGrants(), RowScope: principal.RowScopeTeam},
+	})
 }

--- a/backend/internal/compose/integration/signals_integration_test.go
+++ b/backend/internal/compose/integration/signals_integration_test.go
@@ -42,13 +42,13 @@ func (a signalStrengthAdapter) PersonStrength(ctx context.Context, id ids.Person
 	return signals.RelationshipStrength{Strength: rs.Strength, Bucket: rs.Bucket}, nil
 }
 
-func signalStore(e *searchEnv) *signals.Store {
+func signalStore(e *SearchEnv) *signals.Store {
 	return signals.NewStore(e.Pool, signalStrengthAdapter{people: people.NewStore(e.Pool)})
 }
 
 // signalActor is a full-scope human over the entities the warm room reads
 // and writes; scope selects own/team/all row visibility.
-func signalActor(e *searchEnv, user ids.UUID, scope principal.RowScope, teams []ids.UUID) context.Context {
+func signalActor(e *SearchEnv, user ids.UUID, scope principal.RowScope, teams []ids.UUID) context.Context {
 	grants := map[string]principal.ObjectGrant{}
 	for _, o := range []string{"signal", "person", "organization", "deal", "lead"} {
 		grants[o] = principal.ObjectGrant{Read: true, Create: true, Update: true, Delete: true}
@@ -65,14 +65,14 @@ func signalActor(e *searchEnv, user ids.UUID, scope principal.RowScope, teams []
 	})
 }
 
-func (e *searchEnv) adminSignals() context.Context {
+func (e *SearchEnv) adminSignals() context.Context {
 	return signalActor(e, ids.NewV7(), principal.RowScopeAll, nil)
 }
 
-func personCount(t *testing.T, e *searchEnv) int {
+func personCount(t *testing.T, e *SearchEnv) int {
 	t.Helper()
 	var n int
-	if err := e.owner.QueryRow(context.Background(),
+	if err := e.Owner.QueryRow(context.Background(),
 		`SELECT count(*) FROM person WHERE workspace_id = $1`, e.WS).Scan(&n); err != nil {
 		t.Fatal(err)
 	}
@@ -81,12 +81,12 @@ func personCount(t *testing.T, e *searchEnv) int {
 
 // seedOrgWithDomain plants an organization (owned by rep1) and a
 // registered domain the resolver's domain index can match.
-func (e *searchEnv) seedOrgWithDomain(t *testing.T, name, domain string) ids.UUID {
+func (e *SearchEnv) seedOrgWithDomain(t *testing.T, name, domain string) ids.UUID {
 	t.Helper()
 	orgID := e.seed(t,
 		`INSERT INTO organization (id, workspace_id, display_name, owner_id, source, captured_by)
 		 VALUES ($1, $2, $3, $4, 'manual', 'human:x')`, name, e.Rep1)
-	if _, err := e.owner.Exec(context.Background(),
+	if _, err := e.Owner.Exec(context.Background(),
 		`INSERT INTO organization_domain (id, workspace_id, organization_id, domain, source, captured_by)
 		 VALUES ($1, $2, $3, $4, 'manual', 'human:x')`, ids.NewV7(), e.WS, orgID, domain); err != nil {
 		t.Fatal(err)
@@ -97,17 +97,17 @@ func (e *searchEnv) seedOrgWithDomain(t *testing.T, name, domain string) ids.UUI
 // seedEmployedContact plants a person (owned by rep1) with a work email
 // and a current employment edge at the org — the shape the prior-interaction
 // match and the warm/cold join both read.
-func (e *searchEnv) seedEmployedContact(t *testing.T, orgID ids.UUID, name, email string) ids.UUID {
+func (e *SearchEnv) seedEmployedContact(t *testing.T, orgID ids.UUID, name, email string) ids.UUID {
 	t.Helper()
 	personID := e.seed(t,
 		`INSERT INTO person (id, workspace_id, full_name, owner_id, source, captured_by)
 		 VALUES ($1, $2, $3, $4, 'manual', 'human:x')`, name, e.Rep1)
-	if _, err := e.owner.Exec(context.Background(),
+	if _, err := e.Owner.Exec(context.Background(),
 		`INSERT INTO person_email (id, workspace_id, person_id, email, is_primary, source, captured_by)
 		 VALUES ($1, $2, $3, $4, true, 'manual', 'human:x')`, ids.NewV7(), e.WS, personID, email); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := e.owner.Exec(context.Background(),
+	if _, err := e.Owner.Exec(context.Background(),
 		`INSERT INTO relationship (id, workspace_id, kind, person_id, organization_id, source, captured_by)
 		 VALUES ($1, $2, 'employment', $3, $4, 'manual', 'human:x')`,
 		ids.NewV7(), e.WS, personID, orgID); err != nil {
@@ -118,15 +118,15 @@ func (e *searchEnv) seedEmployedContact(t *testing.T, orgID ids.UUID, name, emai
 
 // grantConsent records a granted consent for the person, so the resolver's
 // consent gate opens for the person link.
-func (e *searchEnv) grantConsent(t *testing.T, personID ids.UUID) {
+func (e *SearchEnv) grantConsent(t *testing.T, personID ids.UUID) {
 	t.Helper()
 	purposeID := ids.NewV7()
-	if _, err := e.owner.Exec(context.Background(),
+	if _, err := e.Owner.Exec(context.Background(),
 		`INSERT INTO consent_purpose (id, workspace_id, key, label) VALUES ($1, $2, 'outreach', 'Outreach')`,
 		purposeID, e.WS); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := e.owner.Exec(context.Background(),
+	if _, err := e.Owner.Exec(context.Background(),
 		`INSERT INTO person_consent (id, workspace_id, person_id, purpose_id, state, source)
 		 VALUES ($1, $2, $3, $4, 'granted', 'manual')`, ids.NewV7(), e.WS, personID, purposeID); err != nil {
 		t.Fatal(err)
@@ -149,7 +149,7 @@ func createRaw(t *testing.T, store *signals.Store, ctx context.Context, rawRef s
 // person another team owns does not exist for a team-scoped rep (404,
 // existence-hiding), while the workspace admin sees it.
 func TestSignalRowScopeFollowsSubjectEntity(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	store := signalStore(e)
 
 	foreignPerson := e.seed(t,
@@ -179,14 +179,14 @@ func TestSignalRowScopeFollowsSubjectEntity(t *testing.T) {
 // another team owns gets an unattributable drop, not a stamped
 // resolved_org_id that would leak the foreign org's id/existence.
 func TestResolverDoesNotAttributeToAnInvisibleOrg(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	store := signalStore(e)
 
 	// An org (with a matching domain) owned by rep3 — outside team1's scope.
 	foreignOrg := e.seed(t,
 		`INSERT INTO organization (id, workspace_id, display_name, owner_id, source, captured_by)
 		 VALUES ($1, $2, 'Foreign Co', $3, 'manual', 'human:x')`, e.Rep3)
-	if _, err := e.owner.Exec(context.Background(),
+	if _, err := e.Owner.Exec(context.Background(),
 		`INSERT INTO organization_domain (id, workspace_id, organization_id, domain, source, captured_by)
 		 VALUES ($1, $2, $3, 'foreign.example', 'manual', 'human:x')`, ids.NewV7(), e.WS, ids.UUID(foreignOrg)); err != nil {
 		t.Fatal(err)
@@ -224,7 +224,7 @@ func TestResolverDoesNotAttributeToAnInvisibleOrg(t *testing.T) {
 // organization and stays company-level — no person link, and no person
 // row is invented.
 func TestResolverAttributesToOrgWithoutCreatingAPerson(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	store := signalStore(e)
 	orgID := e.seedOrgWithDomain(t, "Acme", "acme.example")
 
@@ -253,7 +253,7 @@ func TestResolverAttributesToOrgWithoutCreatingAPerson(t *testing.T) {
 // A person link is set only where the match holds AND a consent grant is
 // on record; a matching contact WITHOUT consent stays company-level.
 func TestResolverPersonLinkIsConsentGated(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	store := signalStore(e)
 	admin := e.adminSignals()
 
@@ -289,7 +289,7 @@ func TestResolverPersonLinkIsConsentGated(t *testing.T) {
 // An unattributable raw_ref is dropped with the reason on record — never
 // kept as a person-level dossier, never linked to anyone.
 func TestResolverDropsTheUnattributable(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	store := signalStore(e)
 	admin := e.adminSignals()
 
@@ -316,7 +316,7 @@ func TestResolverDropsTheUnattributable(t *testing.T) {
 // writing from an address on no registered domain matches it and nothing else
 // (ADR-0082/A127).
 func TestResolverNeverAttributesToTheOwnCompany(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	store := signalStore(e)
 	admin := e.adminSignals()
 
@@ -356,7 +356,7 @@ func TestResolverNeverAttributesToTheOwnCompany(t *testing.T) {
 // we hold a live contact is warm (routes to the warm room) and answers
 // with the contact evidence; an org with no contact is cold.
 func TestWarmthClassifiesByOwnContactGraph(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	store := signalStore(e)
 	admin := e.adminSignals()
 
@@ -397,7 +397,7 @@ func TestWarmthClassifiesByOwnContactGraph(t *testing.T) {
 // message carrying the Art. 50 disclosure, and it mutates nothing (the
 // signal's version does not move).
 func TestIntroPathProposesWithoutMutating(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	store := signalStore(e)
 	admin := e.adminSignals()
 
@@ -409,7 +409,7 @@ func TestIntroPathProposesWithoutMutating(t *testing.T) {
 	}
 
 	var versionBefore int64
-	if err := e.owner.QueryRow(context.Background(),
+	if err := e.Owner.QueryRow(context.Background(),
 		`SELECT version FROM signal WHERE id = $1`, sigID).Scan(&versionBefore); err != nil {
 		t.Fatal(err)
 	}
@@ -426,7 +426,7 @@ func TestIntroPathProposesWithoutMutating(t *testing.T) {
 	}
 
 	var versionAfter int64
-	if err := e.owner.QueryRow(context.Background(),
+	if err := e.Owner.QueryRow(context.Background(),
 		`SELECT version FROM signal WHERE id = $1`, sigID).Scan(&versionAfter); err != nil {
 		t.Fatal(err)
 	}
@@ -439,7 +439,7 @@ func TestIntroPathProposesWithoutMutating(t *testing.T) {
 // create emits signal.detected, a resolve emits signal.resolved, each with
 // its audit row.
 func TestSignalMutationsWriteTheAuditOutboxPair(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	store := signalStore(e)
 	admin := e.adminSignals()
 	e.seedOrgWithDomain(t, "Audit Co", "audit.example")
@@ -453,10 +453,10 @@ func TestSignalMutationsWriteTheAuditOutboxPair(t *testing.T) {
 	assertAuditAndOutbox(t, e, sigID, "resolve", "signal.resolved")
 }
 
-func assertAuditAndOutbox(t *testing.T, e *searchEnv, sigID ids.SignalID, action, eventType string) {
+func assertAuditAndOutbox(t *testing.T, e *SearchEnv, sigID ids.SignalID, action, eventType string) {
 	t.Helper()
 	var audits int
-	if err := e.owner.QueryRow(context.Background(),
+	if err := e.Owner.QueryRow(context.Background(),
 		`SELECT count(*) FROM audit_log WHERE entity_type = 'signal' AND entity_id = $1 AND action = $2`,
 		sigID, action).Scan(&audits); err != nil {
 		t.Fatal(err)
@@ -465,7 +465,7 @@ func assertAuditAndOutbox(t *testing.T, e *searchEnv, sigID ids.SignalID, action
 		t.Fatalf("audit rows for %s = %d, want 1", action, audits)
 	}
 	var events int
-	if err := e.owner.QueryRow(context.Background(),
+	if err := e.Owner.QueryRow(context.Background(),
 		`SELECT count(*) FROM event_outbox WHERE envelope->>'type' = $1 AND envelope->'entity'->>'id' = $2::text`,
 		eventType, sigID).Scan(&events); err != nil {
 		t.Fatal(err)

--- a/backend/internal/compose/integration/signals_integration_test.go
+++ b/backend/internal/compose/integration/signals_integration_test.go
@@ -83,7 +83,7 @@ func personCount(t *testing.T, e *SearchEnv) int {
 // registered domain the resolver's domain index can match.
 func (e *SearchEnv) seedOrgWithDomain(t *testing.T, name, domain string) ids.UUID {
 	t.Helper()
-	orgID := e.seed(t,
+	orgID := e.Seed(t,
 		`INSERT INTO organization (id, workspace_id, display_name, owner_id, source, captured_by)
 		 VALUES ($1, $2, $3, $4, 'manual', 'human:x')`, name, e.Rep1)
 	if _, err := e.Owner.Exec(context.Background(),
@@ -99,7 +99,7 @@ func (e *SearchEnv) seedOrgWithDomain(t *testing.T, name, domain string) ids.UUI
 // match and the warm/cold join both read.
 func (e *SearchEnv) seedEmployedContact(t *testing.T, orgID ids.UUID, name, email string) ids.UUID {
 	t.Helper()
-	personID := e.seed(t,
+	personID := e.Seed(t,
 		`INSERT INTO person (id, workspace_id, full_name, owner_id, source, captured_by)
 		 VALUES ($1, $2, $3, $4, 'manual', 'human:x')`, name, e.Rep1)
 	if _, err := e.Owner.Exec(context.Background(),
@@ -152,7 +152,7 @@ func TestSignalRowScopeFollowsSubjectEntity(t *testing.T) {
 	e := SetupSearch(t)
 	store := signalStore(e)
 
-	foreignPerson := e.seed(t,
+	foreignPerson := e.Seed(t,
 		`INSERT INTO person (id, workspace_id, full_name, owner_id, source, captured_by)
 		 VALUES ($1, $2, 'Foreign Contact', $3, 'manual', 'human:x')`, e.Rep3)
 	personType := "person"
@@ -183,7 +183,7 @@ func TestResolverDoesNotAttributeToAnInvisibleOrg(t *testing.T) {
 	store := signalStore(e)
 
 	// An org (with a matching domain) owned by rep3 — outside team1's scope.
-	foreignOrg := e.seed(t,
+	foreignOrg := e.Seed(t,
 		`INSERT INTO organization (id, workspace_id, display_name, owner_id, source, captured_by)
 		 VALUES ($1, $2, 'Foreign Co', $3, 'manual', 'human:x')`, e.Rep3)
 	if _, err := e.Owner.Exec(context.Background(),
@@ -320,7 +320,7 @@ func TestResolverNeverAttributesToTheOwnCompany(t *testing.T) {
 	store := signalStore(e)
 	admin := e.adminSignals()
 
-	anchor := e.seed(t,
+	anchor := e.Seed(t,
 		`INSERT INTO organization (id, workspace_id, display_name, owner_id, is_anchor, source, captured_by)
 		 VALUES ($1, $2, $3, $4, true, 'manual', 'human:x')`, "Our Own Company", e.Rep1)
 	colleague := e.seedEmployedContact(t, anchor, "Robin Colleague", "robin@private.invalid")

--- a/backend/internal/compose/integration/workflow_integration_test.go
+++ b/backend/internal/compose/integration/workflow_integration_test.go
@@ -67,14 +67,13 @@ func enableLeadRouting(t *testing.T, e *SearchEnv, params map[string]any) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	var automationID ids.UUID
 	err = database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
-		return tx.QueryRow(context.Background(), `
+		_, err := tx.Exec(context.Background(), `
 			INSERT INTO automation (workspace_id, key, name, trigger, action, params, enabled)
 			VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid,
 			        'assign_lead_owner', 'Assign new leads an owner', '{"event_type":"lead.created"}', '{"kind":"assign_owner"}',
-			        $1, true)
-			RETURNING id`, paramsJSON).Scan(&automationID)
+			        $1, true)`, paramsJSON)
+		return err
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -84,7 +83,7 @@ func enableLeadRouting(t *testing.T, e *SearchEnv, params map[string]any) {
 func TestWorkflowRouteLeadAssignsExactlyOnce(t *testing.T) {
 	e := SetupSearch(t)
 	enableLeadRouting(t, e, map[string]any{"owners": []string{e.Rep1.String()}})
-	leadID := e.seed(t, `INSERT INTO lead (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Fresh Lead', 'manual', 'human:x')`)
+	leadID := e.Seed(t, `INSERT INTO lead (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Fresh Lead', 'manual', 'human:x')`)
 	engine := compose.NewWorkflowEngine(e.Pool)
 
 	env := kevents.Envelope{
@@ -180,7 +179,7 @@ func TestWorkflowEngineHonorsAutomationInstances(t *testing.T) {
 	}
 
 	// No automation rows at all: the registered handler stays silent.
-	first := e.seed(t, `INSERT INTO lead (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Ungated Lead', 'manual', 'human:x')`)
+	first := e.Seed(t, `INSERT INTO lead (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Ungated Lead', 'manual', 'human:x')`)
 	dispatch(first)
 	if got := ownerOf(first); got != nil {
 		t.Fatalf("unconfigured workspace assigned owner %v, want none", got)
@@ -199,7 +198,7 @@ func TestWorkflowEngineHonorsAutomationInstances(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	second := e.seed(t, `INSERT INTO lead (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Paused Lead', 'manual', 'human:x')`)
+	second := e.Seed(t, `INSERT INTO lead (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Paused Lead', 'manual', 'human:x')`)
 	dispatch(second)
 	if got := ownerOf(second); got != nil {
 		t.Fatalf("paused instance assigned owner %v, want none", got)
@@ -214,7 +213,7 @@ func TestWorkflowEngineHonorsAutomationInstances(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	third := e.seed(t, `INSERT INTO lead (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Live Lead', 'manual', 'human:x')`)
+	third := e.Seed(t, `INSERT INTO lead (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Live Lead', 'manual', 'human:x')`)
 	dispatch(third)
 	dispatch(third) // redelivery still applies exactly once
 	if got := ownerOf(third); got == nil || *got != e.Rep3 {

--- a/backend/internal/compose/integration/workflow_integration_test.go
+++ b/backend/internal/compose/integration/workflow_integration_test.go
@@ -29,7 +29,7 @@ import (
 // seedStarterAutomations enrolls the starter instances the way the
 // workspace bootstrap does — the engine fires nothing for a workspace
 // with no enabled automation rows (B-E15.4 gating).
-func seedStarterAutomations(t *testing.T, e *searchEnv) {
+func seedStarterAutomations(t *testing.T, e *SearchEnv) {
 	t.Helper()
 	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		return automation.SeedStarterAutomationsTx(context.Background(), tx)
@@ -43,7 +43,7 @@ func seedStarterAutomations(t *testing.T, e *searchEnv) {
 // instance — authorable but NOT one of the six seedStarterAutomations
 // enrolls (automations_catalog.go's Catalog doc), so a suite exercising
 // its own Match semantic must enable it explicitly.
-func enableStageChangeCreateTask(t *testing.T, e *searchEnv) {
+func enableStageChangeCreateTask(t *testing.T, e *SearchEnv) {
 	t.Helper()
 	err := database.WithWorkspaceTx(e.Admin(), e.Pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(), `
@@ -61,7 +61,7 @@ func enableStageChangeCreateTask(t *testing.T, e *searchEnv) {
 // enableLeadRouting inserts an ENABLED assign_lead_owner instance with
 // the given routing params — the configured state seedStarterAutomations
 // leaves for an admin to fill in (an unconfigured pool routes nobody).
-func enableLeadRouting(t *testing.T, e *searchEnv, params map[string]any) ids.UUID {
+func enableLeadRouting(t *testing.T, e *SearchEnv, params map[string]any) {
 	t.Helper()
 	paramsJSON, err := json.Marshal(params)
 	if err != nil {
@@ -79,11 +79,10 @@ func enableLeadRouting(t *testing.T, e *searchEnv, params map[string]any) ids.UU
 	if err != nil {
 		t.Fatal(err)
 	}
-	return automationID
 }
 
 func TestWorkflowRouteLeadAssignsExactlyOnce(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	enableLeadRouting(t, e, map[string]any{"owners": []string{e.Rep1.String()}})
 	leadID := e.seed(t, `INSERT INTO lead (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Fresh Lead', 'manual', 'human:x')`)
 	engine := compose.NewWorkflowEngine(e.Pool)
@@ -131,7 +130,7 @@ func TestWorkflowRouteLeadAssignsExactlyOnce(t *testing.T) {
 	// the assignment shipped its lead.updated through the outbox — the
 	// full write shape, not a bare column flip.
 	var actorType, action string
-	if err := e.owner.QueryRow(context.Background(),
+	if err := e.Owner.QueryRow(context.Background(),
 		`SELECT actor_type, action FROM audit_log WHERE entity_type = 'lead' AND entity_id = $1
 		 ORDER BY occurred_at DESC LIMIT 1`, leadID).Scan(&actorType, &action); err != nil {
 		t.Fatal(err)
@@ -140,7 +139,7 @@ func TestWorkflowRouteLeadAssignsExactlyOnce(t *testing.T) {
 		t.Fatalf("routing audited as %s/%s, want system/assign", actorType, action)
 	}
 	var outboxed int
-	if err := e.owner.QueryRow(context.Background(),
+	if err := e.Owner.QueryRow(context.Background(),
 		`SELECT count(*) FROM event_outbox WHERE envelope->>'type' = 'lead.updated'
 		 AND envelope->'entity'->>'id' = $1::text`, leadID).Scan(&outboxed); err != nil {
 		t.Fatal(err)
@@ -154,7 +153,7 @@ func TestWorkflowRouteLeadAssignsExactlyOnce(t *testing.T) {
 // nothing, a paused instance fires nothing, and enabling flips it live
 // on the very next event (no cache) with its params applied.
 func TestWorkflowEngineHonorsAutomationInstances(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	engine := compose.NewWorkflowEngine(e.Pool)
 
 	dispatch := func(leadID ids.UUID) {
@@ -235,7 +234,7 @@ func TestWorkflowEngineHonorsAutomationInstances(t *testing.T) {
 }
 
 func TestWorkflowStageChangeMatchGuardsSemantic(t *testing.T) {
-	e := setupSearch(t)
+	e := SetupSearch(t)
 	seedStarterAutomations(t, e)
 	// stage_change_create_task is authorable but not one of the six
 	// seeded templates (automations_catalog.go's Catalog doc) — this
@@ -244,7 +243,7 @@ func TestWorkflowStageChangeMatchGuardsSemantic(t *testing.T) {
 	enableStageChangeCreateTask(t, e)
 	e.seedDealFixtures(t, 1, nil)
 	var dealID ids.UUID
-	if err := e.owner.QueryRow(context.Background(), `SELECT id FROM deal LIMIT 1`).Scan(&dealID); err != nil {
+	if err := e.Owner.QueryRow(context.Background(), `SELECT id FROM deal LIMIT 1`).Scan(&dealID); err != nil {
 		t.Fatal(err)
 	}
 	engine := compose.NewWorkflowEngine(e.Pool)


### PR DESCRIPTION
Prerequisite for the next cut of #546. No file moves here — this makes the move possible, and keeps the two kinds of change in separate PRs.

## Why

`searchEnv` was declared in `search_integration_test.go`. Forty suites ride it, but a test file's type is unreachable from another package, so no group that depends on it can be split out. The capture suites are 16 of those forty.

It moves to a non-test file (`searchenv.go`, beside `harness.go`) and exports its name, constructor, and the two lowercase fields. Body unchanged, seeding unchanged, suites that keep riding it keep riding it.

## What the fixture turned out to be

Worth recording, because the name undersells it. Of the forty riders, most want the migrated database and the seeded workspace, not the search store — **the capture suites reference `.Store` exactly zero times**:

| what capture touches on the fixture | refs |
|---|---|
| `.Pool` | 72 |
| `.Rep1` | 61 |
| `.WS` | 38 |
| `.owner` | 9 |
| **`.store`** | **0** |

So this is the package's *second general-purpose fixture*, not a search-specific one — which is why it now sits beside `Env` rather than with the suite that named it. That also rules out the cheaper-looking alternative of re-pointing capture at `Env`: `SetupSearch` seeds a different workspace slug and a different user set, so swapping fixtures would be a behaviour change wearing a refactor's clothes. Renaming the fixture to match what it is can wait for someone with a better name; the export is what unblocks the split.

## How the field renames were made

`owner` and `store` are field names on several structs in this package (`e2e`'s `env`, `customfields`' `store`, `runner`'s `store`), so a blanket rename would have hit the wrong ones — the same class of mistake as the `Employ` collateral in #556.

Instead every site came from the type-checker: compile, take errors of the form `x.store undefined (type *SearchEnv … but does have field Store)`, fix exactly those lines, recompile. **87 sites over twelve rounds.** The loop keys on the exported field *existing*, which only the fixture and structs embedding it satisfy — `reembedFleetEnv` embeds `*SearchEnv` and was picked up correctly by that rule.

## Three lint findings that came with it

Strict lint re-reads a moved line as new, so `unparam` and `revive` got a fresh look at old code. One was cosmetic (the newly-exported constructor wanted a doc comment). The other two were real and are now gone:

- `seedDealFixtures` returned an `orgID` that its one interested caller assigned and then discarded three dozen lines later with `_ = orgID`.
- `enableLeadRouting` returned an automation id that none of its four callers has ever read.

## Verification

`make check-backend` green, `make craft-static` 0 findings across backend/extensions/fixtures, `go vet -tags=integration` clean. The change is a rename and a file move with no logic edits, and the type-checker drove every field site.

**Not run:** the integration lane. It rebuilds the shared migrated template and a parallel session is working in this tree; CI's shards are the check that matters for a rename.

Next: the capture suites move to `internal/compose/integration/capture` — 16 files, ~45 tests, a third lane slot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Made the search test fixture importable so sibling packages can use it, and tightened the migrate-once gate to judge all build-tagged integration files. This unblocks moving capture suites into their own package without changing behavior.

- **Refactors**
  - Moved the fixture from `search_integration_test.go` to `searchenv.go` beside `harness.go`.
  - Exported `SearchEnv`, `SetupSearch`, fields `Owner` and `Store`, and methods `Admin()`, `AsTeamRep(...)`, and `Seed(...)` (plus the shared grant helper), moving these methods into `searchenv.go` so imports actually work.
  - Widened the migrate-once gate to scan build-tagged integration files (not only `_test.go`), updated its wording, and excluded `internal/platform/testdb` by rule.
  - Updated package docs to note both shared harnesses and the broader gate.

- **Migration**
  - Use `integration.SetupSearch(t)` and `*integration.SearchEnv` in tests.
  - Replace: `e.owner`→`e.Owner`, `e.store`→`e.Store`, `e.seed(...)`→`e.Seed(...)`, `e.asTeamRep(...)`→`e.AsTeamRep(...)`, `e.admin()`→`e.Admin()`.

<sup>Written for commit d4ceeb6b1b30693a8b6d6f323de7294cdacbebe2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/563?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

