### PR TITLE
chore(env): .env.template serves every environment, and gates keep it true

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,214 +1,123 @@
 # Margince local environment template
-# Copy to .env.local (gitignored), fill in values, then: source .env.local
-# `make dev` (scripts/dev.sh) sources .env.local automatically.
+# Copy to .env.local (gitignored) and fill in what you need. `make dev`
+# (scripts/dev.sh) sources it automatically; for a direct binary launch
+# (`go run ./cmd/api`) source it yourself.
 #
-# Lines marked [required] make the binary exit at boot if unset.
-# Lines marked [optional] have a working default or disable a feature cleanly.
+# This file holds the blanks a HUMAN FILLS IN — secrets and per-machine paths.
+# It is not the catalog: docs/reference/configuration.md is the table of record
+# for every MARGINCE_* var, its flag, and its default. Two fitness functions
+# keep them honest (backend/envcontract_test.go) — a var Go code reads must be
+# documented there, and a var named here must still be read by Go code.
 #
-# Scope: the four process-role binaries under backend/cmd/ (api, worker, mcp,
-# migrate). Configuration is flags first; every var here is a documented flag
-# fallback or a test/dev switch. The table of record is
-# docs/reference/configuration.md — keep the two in sync.
+# [required] the binary exits at boot without it.
+# [optional] says on the same line what leaving it unset costs. Every optional
+#            var below disables something; none of them merely defaults.
 #
-# Note: `make …` already exports MARGINCE_ENV=dev and the MARGINCE_TEST_* DSNs
-# for the `make db-up` containers, so a Makefile-driven workflow needs none of
-# the test section below. This file matters for direct binary launches
-# (`go run ./cmd/api`, a built binary) and for the `make dev` BYOK key.
+# Scope: the three process-role binaries under backend/cmd/ — api, worker,
+# migrate. Vars that only have a working default (MARGINCE_LOG_LEVEL,
+# MARGINCE_LOG_FORMAT, MARGINCE_REDIS) and the integration lane's vars (which
+# backend/Makefile already exports) live only in configuration.md.
+#
+# Some of these are OVERRIDDEN by `make dev`, which passes its own flags and
+# command-prefix assignments: MARGINCE_ENV, MARGINCE_AI_ROUTING, and the four
+# object-storage vars below. Editing those here does not change the dev stack.
+# They are listed because a direct launch or a real deployment needs them.
 
 # ── Database ─────────────────────────────────────────────────────────────────
 
-# [required by api, worker, mcp] Postgres DSN, the runtime APP role (RLS
-# applies; never the owner role). Default matches `make db-up`.
+# [required by api and worker] Postgres DSN, the runtime APP role — RLS applies;
+# never the owner role. Default matches `make db-up`.
 MARGINCE_DSN=postgres://margince_app:margince_app_dev@localhost:55432/margince
 
-# cmd/migrate needs the OWNER role instead (it creates/alters objects):
+# cmd/migrate needs the OWNER role instead (it creates and alters objects):
 #   go run ./cmd/migrate up --dsn postgres://margince_owner:dev@localhost:55432/margince
 
-# [optional; api only] Postgres DSN, the OWNER role, for the custom-fields
-# runtime-DDL pool. This is the second pool the two schema-change operations —
-# createCustomField and updateCustomFieldOptions (picklist option edits) — run
-# their `ALTER TABLE … ADD COLUMN cf_*` through. Unset (the default), those two
-# answer 501 (ErrSchemaChangesUnavailable) and the /readyz customfields-schema-
-# pool probe is omitted; every other custom-field path (list, rename, retire/
-# archive) works without it. So set this to CREATE custom fields — `make dev`
-# does NOT wire it by default. Owner role, never the app role (runtime DDL).
+# [optional — unset: createCustomField and updateCustomFieldOptions answer 501
+# and /readyz drops the customfields-schema-pool probe; list/rename/retire still
+# work] Owner-role DSN for the custom-fields runtime-DDL pool. Not wired by dev.
 # MARGINCE_SCHEMA_DSN=postgres://margince_owner:dev@localhost:55432/margince
 
-# ── Redis (event bus / outbox relay) ─────────────────────────────────────────
+# ── AI runtime (BYOK) ────────────────────────────────────────────────────────
 
-# [optional] Redis address for api and worker. Default: localhost:56379
-# (the `make db-up` container). With the api's default --inline-relay=true an
-# unreachable Redis is a BOOT error: a committed write must never strand its
-# outbox row.
-# MARGINCE_REDIS=localhost:56379
-
-# ── Outbound webhooks (E10 / S-E10.6) ────────────────────────────────────────
-
-# [optional] base64-encoded 32-byte key that seals each outbound-webhook
-# signing secret at rest (AES-256-GCM). Set it to enable the mutating
-# /webhook-subscriptions surface (api) and the delivery worker (worker); unset,
-# the secret-bearing paths (create/rotate, delivery/replay) answer an honest
-# 503 rather than shipping an unsigned or guessable delivery; the read surface
-# (list/get/deliveries) still works. Generate: openssl rand -base64 32
-# MARGINCE_WEBHOOK_KEY=
-
-# ── Logging (api, worker, mcp) ───────────────────────────────────────────────
-
-# [optional] debug | info | warn | error. Default: info.
-# An invalid value is a boot error, never a silent default.
-# MARGINCE_LOG_LEVEL=info
-
-# [optional] text (slog text) | json. Default: text.
-# api and worker log to stdout; mcp logs to stderr (stdout is the stdio
-# protocol channel).
-# MARGINCE_LOG_FORMAT=text
-
-# ── Dev trust switches ───────────────────────────────────────────────────────
-
-# [optional] `dev` enables the dev-only trust switches (the X-Workspace-Slug
-# header instead of subdomain workspace resolution). The Makefiles export it;
-# set it yourself for direct binary launches. Production must not set it.
-# MARGINCE_ENV=dev
-
-# ── AI runtime (modules/ai) ──────────────────────────────────────────────────
-
-# [optional] Path to the ai-routing.yaml tier→model binding for api (cold-start
-# read-back) and worker (Surface-B runner + embeddings). Unset: the AI lanes
-# simply do not start; core CRUD and auth work normally.
-# `make install` / `make dev` seed a gitignored config/ai-routing.yaml from the
-# documented template config/ai-routing.example.yaml; edit it to bind your own
-# local models (never committed). Point at any path for a bespoke config.
+# [optional — unset: the AI lanes never start; CRUD and auth are unaffected]
+# Path to the tier→model binding. `make install` / `make dev` seed a gitignored
+# config/ai-routing.yaml from config/ai-routing.example.yaml.
 # MARGINCE_AI_ROUTING=config/ai-routing.yaml
 
-# [optional] BYOK cloud keys. Secrets live in the ENVIRONMENT, never the routing
-# config: at boot SelectBrain reads the bound cloud provider's key from its
-# conventional env var below and fails closed if it's missing (ADR-0020: we
-# provide no inference). `make dev` sources this file so the api/worker inherit
-# the vars; a production deploy exports them in the process environment. Set the
-# one matching your bound provider (the shipped default binds gemini).
+# [optional — unset: a bound cloud provider fails closed at boot, so the cold
+# start runs the offline fake] Keys live in the ENVIRONMENT, never in the
+# routing config (ADR-0020). Set the one your routing file binds; the shipped
+# default binds gemini.
 # GEMINI_API_KEY=
 # OPENAI_API_KEY=
 # ANTHROPIC_API_KEY=
-# OPENAI_COMPATIBLE_API_KEY=   # provider: openai_compatible (also needs base_url in the config)
-#
-# The admin "Refresh from sources" jobs (worker) get their sources from the
-# deployment config's `rates:` block, NOT env — see config/margince.example.yaml.
+# OPENAI_COMPATIBLE_API_KEY=   # provider openai_compatible; also needs base_url
 
-# ── Buyer-facing links (marketing mail) ──────────────────────────────────────
+# ── Secrets that gate a feature ──────────────────────────────────────────────
+# Each is read from the environment, never a CLI flag: argv is world-readable.
 
-# [optional] Canonical external scheme+host for buyer-facing links (RFC 8058
-# unsubscribe / preference center). Required to SEND marketing mail — a send
-# refuses rather than derive the token-bearing link from the request Host.
+# [optional — unset: the mutating /webhook-subscriptions paths answer 503 rather
+# than ship an unsigned delivery; the read surface still lists] base64 32-byte
+# key sealing outbound-webhook signing secrets at rest. openssl rand -base64 32
+# MARGINCE_WEBHOOK_KEY=
+
+# [optional — unset: the persisting connector-credential paths refuse loudly;
+# the transient one-shot IMAP pull still works] base64 of exactly 32 bytes, the
+# AES-256 root key sealing connector credentials. Set but not 32 bytes is a boot
+# error, never a silent fallback. `make dev` supplies a throwaway dev key.
+# MARGINCE_KEYVAULT_ROOT_KEY=
+
+# [optional — unset: /connectors/gmail/* stays a declared 501] The Google OAuth
+# app for read-only Gmail capture (Gmail API enabled, scope gmail.readonly).
+# Needs MARGINCE_KEYVAULT_ROOT_KEY too — the refresh token is sealed there.
+# Register this redirect URI on the api origin, not the SPA:
+#   <api-base>/v1/connectors/gmail/callback
+# MARGINCE_GMAIL_CLIENT_ID=
+# MARGINCE_GMAIL_CLIENT_SECRET=
+
+# [optional — unset: the OAuth connect flow refuses] HMAC key (>=32 bytes)
+# signing the connect `state`, which is the session-less callback's only auth.
+# `make dev` supplies a throwaway dev key.
+# MARGINCE_CONNECTOR_STATE_KEY=
+
+# ── External addressing ──────────────────────────────────────────────────────
+
+# [optional — unset: a marketing send refuses rather than derive the
+# token-bearing link from the request Host] Canonical external scheme+host for
+# buyer-facing links (RFC 8058 unsubscribe / preference center).
 # MARGINCE_PUBLIC_BASE_URL=https://crm.example.com
 
-# ── Object storage (blobstore — attachments) ─────────────────────────────────
+# [optional — defaults to MARGINCE_PUBLIC_BASE_URL] The api's externally
+# reachable base for the OAuth callback redirect_uri. Set it only when api and
+# SPA are on different origins — `make dev` is one (api on :8080).
+# MARGINCE_API_BASE_URL=
 
-# [optional] S3-compatible object store for attachment file bytes.
-# Set the endpoint to enable the /attachments endpoints, the
-# /readyz blobstore probe, and the erase-path object purge; leave it unset and
-# the attachment endpoints answer 501. Both api and worker read these. Secrets
-# come from the environment, never CLI flags (argv is world-readable). The
-# bucket is created on first connect. `make dev` points these at the compose
-# MinIO (localhost:59000) automatically.
+# ── Object storage (attachments, company logos) ──────────────────────────────
+
+# [optional — unset: /attachments answers 501, /readyz drops the blobstore
+# probe, and every company renders its monogram instead of a logo] S3-compatible
+# store, read by api and worker; the bucket is created on first connect.
+# `make dev` sets all four as command-prefix assignments — MinIO on
+# localhost:59000, bucket margince-dev — which OVERRIDE anything set here.
 # MARGINCE_BLOBSTORE_ENDPOINT=localhost:59000
 # MARGINCE_BLOBSTORE_ACCESS_KEY=minioadmin
 # MARGINCE_BLOBSTORE_SECRET_KEY=minioadmin
 # MARGINCE_BLOBSTORE_BUCKET=margince
-# MARGINCE_BLOBSTORE_REGION=us-east-1
-# MARGINCE_BLOBSTORE_USE_SSL=false
 
-# ── Secret vault (keyvault — connector credentials) ──────────────────────────
+# ── Posture and overlay ──────────────────────────────────────────────────────
 
-# [optional] The AES-256 root key that seals connector credentials at rest.
-# Base64 (standard encoding) of exactly 32 bytes. Set it to
-# enable the /readyz keyvault probe and the vault-backed connector-credential
-# path (Connect seals, Sync resolves); the worker migrates any legacy auth-bytea
-# rows onto the vault at boot. Leave it unset and the transient one-shot IMAP
-# pull still works (it persists no credential); the persisting paths refuse
-# loudly rather than store a credential in the clear. A key that is SET but not
-# 32 bytes is a boot error — never a silent fallback. Comes from the
-# environment, never a CLI flag (argv is world-readable). Both api and worker
-# read it. Generate one with: `openssl rand -base64 32`.
-# MARGINCE_KEYVAULT_ROOT_KEY=
+# [optional — unset: production posture, which disables every dev-only trust
+# switch] `dev` lets the api trust the X-Workspace-Slug header instead of
+# resolving the workspace from the subdomain. Fail-closed: only dev, staging and
+# test are non-production; anything else, including a typo, is production. The
+# Makefiles export dev; production must not set it.
+# MARGINCE_ENV=dev
 
-# ── Gmail capture connector (per-user mail capture; RC-8) ────────────────────
-
-# [optional] The Google OAuth app that authorizes read-only Gmail capture —
-# one app per deployment, created in Google Cloud (Gmail API enabled, scope
-# https://www.googleapis.com/auth/gmail.readonly). Set the id+secret to enable
-# /connectors/gmail/* on the api and the background sync poll on the worker;
-# leave them unset and that surface stays a declared 501. Also needs the vault
-# (MARGINCE_KEYVAULT_ROOT_KEY) — the refresh token is sealed there. Secrets
-# come from the environment, never CLI flags. Register this redirect URI in the
-# Google app (api origin, not the SPA): <api-base>/v1/connectors/gmail/callback
-# — e.g. http://localhost:8080/v1/connectors/gmail/callback for `make dev`.
-# MARGINCE_GMAIL_CLIENT_ID=
-# MARGINCE_GMAIL_CLIENT_SECRET=
-
-# [optional] HMAC key (>=32 bytes) that signs the OAuth connect `state` (the
-# session-less callback's only auth). Required for the connect flow. `make dev`
-# supplies a throwaway dev key when unset; set your own everywhere else.
-# MARGINCE_CONNECTOR_STATE_KEY=
-
-# [optional] The api's externally-reachable base for the callback redirect_uri.
-# Defaults to MARGINCE_PUBLIC_BASE_URL (same-origin deployments). Set it only
-# when the api is on a different origin than the SPA — e.g. `make dev` uses the
-# api port (http://localhost:8080) while the public/front origin is the SPA.
-# MARGINCE_API_BASE_URL=
-
-# ── HubSpot overlay mirror (worker sweep) ────────────────────────────────────
-
-# [optional; dev/demo] Cap the INITIAL mirror backfill at N records per object
-# class, so pointing a laptop at a real portal doesn't pull the whole thing
-# down. Unset or 0 = uncapped; a negative or non-numeric value is a boot error.
-# Only the backfill is capped — later incremental sweeps still bring in
-# anything the incumbent edits after the connect, so continuous sync keeps
-# working on the capped subset.
-# Do NOT change it while a backfill is mid-flight: the running count rides in
-# overlay_backfill_cursor as a "<count>|<inner>" prefix that the uncapped
-# adapter rejects, which fails that object class on every sweep until its
-# cursor row is cleared. Let the class converge first, or clear the row.
+# [optional — unset or 0: uncapped] Cap the INITIAL overlay mirror backfill at N
+# records per object class, so a laptop pointed at a real portal does not pull
+# the whole portal down. Later incremental sweeps still track edits, so
+# continuous sync keeps working on the capped subset. Do NOT change it
+# mid-backfill: the running count rides in overlay_backfill_cursor as a
+# "<count>|<inner>" prefix the uncapped adapter rejects, which fails that object
+# class on every sweep until its cursor row is cleared.
 # MARGINCE_OVERLAY_BACKFILL_LIMIT=5
-
-# The sweep interval itself is flag-only (no env fallback): the worker's
-# --overlay-reconcile-interval, default 2m. Every tick spends incumbent API
-# quota per object class even when nothing changed, so lengthen it on a dev box
-# — see docs/reference/configuration.md.
-
-# ── MCP server binary (cmd/mcp — separate process) ───────────────────────────
-
-# [required by mcp, stdio transport] The Agent Seat Passport token (mgp_…,
-# minted via POST /v1/passports). Deliberately an env var, not a flag: argv is
-# world-readable. Every call re-authenticates, so revocation binds mid-session.
-# MARGINCE_PASSPORT_TOKEN=
-
-# [required by mcp, stdio transport] Workspace slug the passport belongs to.
-# MARGINCE_WORKSPACE=demo-workspace
-
-# ── Integration-test lane (make test-integration) ────────────────────────────
-# backend/Makefile exports these for the `make db-up` containers; override only
-# to point the lane at different infrastructure. The lane runs on its OWN
-# `_test`-suffixed namespace — a separate `margince_test` Postgres database and
-# Redis logical db (never the dev `margince` DB or Redis db 0) — so it can run
-# concurrently with `make dev` without touching the same mutable state. The lane
-# fails loudly when the database is unreachable — it never skips.
-
-# MARGINCE_TEST_DSN=postgres://margince_owner:dev@localhost:55432/margince_test
-# MARGINCE_TEST_APP_DSN=postgres://margince_app:margince_app_dev@localhost:55432/margince_test
-# MARGINCE_TEST_REDIS=localhost:56379
-# [optional] Redis logical db for the test lane. Default 15. db 0 is reserved
-# for a running `make dev` (its relay/subscriber use the client default), so a
-# valid value is 1..15 — the parallel runner fans packages across that range so
-# concurrent packages never share a stream. An out-of-range value fails loudly.
-# MARGINCE_TEST_REDIS_DB=15
-# The blobstore lane points at the compose MinIO; the lane fails loudly if it
-# is unreachable — it never skips.
-# MARGINCE_TEST_BLOBSTORE_ENDPOINT=localhost:59000
-# MARGINCE_TEST_BLOBSTORE_ACCESS_KEY=minioadmin
-# MARGINCE_TEST_BLOBSTORE_SECRET_KEY=minioadmin
-# MARGINCE_TEST_BLOBSTORE_BUCKET=margince-test
-
-# [optional; make bench-perf only] The PERF-3/PERF-7 benchmark tier the
-# perfbench integration suite seeds — smb (default) or mid_market. An
-# unrecognized value fails the bench loudly.
-# MARGINCE_BENCH_TIER=smb

--- a/.env.template
+++ b/.env.template
@@ -1,117 +1,116 @@
-# Margince environment template — EVERY environment, not just a laptop
+# Margince environment template
 #
-# Locally: copy to .env.local (gitignored) and fill in what you need; `make dev`
-# (scripts/dev.sh) sources it automatically. In a deployment: this is the
-# annotated template docs/deployment.md points at — supply these through your
-# platform's env/secret mechanism, never by committing a filled-in copy.
+# Applies to every environment. Locally, copy this to .env.local (gitignored)
+# and set what is needed; `make dev` (scripts/dev.sh) sources it automatically,
+# and a direct binary launch requires sourcing it manually. In a deployment,
+# this is the annotated template referenced by docs/deployment.md: supply the
+# values through the platform's environment or secret mechanism rather than by
+# committing a filled-in copy.
 #
-# This file is the ESSENTIALS a human supplies. The complete catalog — every
-# var, its flag, its default — is docs/reference/configuration.md, and
-# docs/deployment.md covers the container-entrypoint specifics. Fitness
-# functions keep the set honest (backend/envcontract_test.go): a var Go code
-# reads must be documented, a var named here must be one the product reads, and
-# a var a deploy entrypoint hard-requires must appear here.
+# Scope: the variables an operator or developer supplies. The complete catalog
+# of every variable, its flag and its default is docs/reference/configuration.md;
+# container-entrypoint specifics are in docs/deployment.md.
+# backend/envcontract_test.go asserts that this file, that catalog and the deploy
+# entrypoints stay consistent with the code.
 #
-# [required]        the process refuses to boot without it.
-# [required for X]  the process boots fine and X does not work. Unset is a
-#                   DECLARED absence — a 501/503/404, never a broken state — but
-#                   it is not optional to anyone who wants X, so the label says
-#                   what you lose rather than calling it optional.
-# [optional]        genuinely safe to ignore; the default is right everywhere.
+# [required]       the process does not start without it.
+# [required for X] the process starts and X is unavailable. The affected route
+#                  returns a declared 501, 503 or 404 rather than failing, but
+#                  the variable is not optional where X is needed.
+# [optional]       the default is appropriate in every environment.
 #
-# Nothing here is uncommented on purpose: a template that ships a live value
-# ships whatever environment that value came from. Every example is a shape to
-# replace, never a credential to keep.
+# All entries are commented out. Example values show the expected form and are
+# not usable credentials.
 #
-# Roles: the three binaries under backend/cmd/ — api, worker, migrate.
+# Roles referenced below are the three binaries under backend/cmd: api, worker
+# and migrate.
 
-# ═══ Every environment must supply these ═════════════════════════════════════
+# ═══ Required in every environment ═══════════════════════════════════════════
 
-# [required] Postgres DSN, the runtime APP role — RLS applies to it; never the
-# owner role. `make dev` connects with its own APP_DSN and ignores this line, so
-# it matters for a direct launch and for every deployment.
+# [required] Postgres DSN for the runtime application role; row-level security
+# applies to it. Do not use the owner role here. `make dev` connects using its
+# own APP_DSN and ignores this value, so it applies to direct launches and to
+# deployments.
 # MARGINCE_DSN=postgres://margince_app:CHANGE_ME@db.internal:5432/margince
 
-# [required in a deployment] Path to the deployment config (bootstrap
-# organization + admin, seeds, email). Defaults to `margince.yaml` relative to
-# the working directory, which is right on a dev box and a coin-flip in a
-# container — name the mounted path explicitly.
+# [required in a deployment] Path to the deployment configuration file
+# (bootstrap organization and admin, seeds, email). Defaults to `margince.yaml`
+# resolved against the working directory; name the mounted path explicitly in a
+# container.
 # MARGINCE_CONFIG=/app/config/margince.yaml
 
 # [required in a deployment] Redis address for the event bus and outbox relay.
-# The default localhost:56379 is the `make db-up` container and is wrong
-# anywhere else. With the api's default --inline-relay=true an unreachable Redis
-# is a BOOT error: a committed write must never strand its outbox row.
+# The default, localhost:56379, is the `make db-up` container. With the api's
+# default --inline-relay=true an unreachable Redis is a boot error, so that a
+# committed write cannot strand its outbox row.
 # MARGINCE_REDIS=redis.internal:6379
 
 # [required to send marketing mail; also used for the OAuth callback] Canonical
-# external scheme+host for buyer-facing links (RFC 8058 unsubscribe /
-# preference center). A send refuses rather than derive a token-bearing link
-# from the request Host.
+# external scheme and host for buyer-facing links (RFC 8058 unsubscribe and
+# preference center). A send is refused rather than deriving a token-bearing
+# link from the request Host.
 # MARGINCE_PUBLIC_BASE_URL=https://crm.example.com
 
 # ═══ Observability ═══════════════════════════════════════════════════════════
 
-# [required to scrape /metrics — unset: the route answers 404] Shared secret
-# /metrics requires as a Bearer credential. This IS the access control for that endpoint: its
-# exposition is fleet-wide and carries every workspace's id, so it must never be
-# reachable unauthenticated or proxied to a tenant. Set it and give it to your
-# scraper.
+# [required to scrape /metrics — unset: the route returns 404] Shared secret
+# that /metrics requires as a Bearer credential, and the access control for that
+# endpoint. The exposition is fleet-wide and carries every workspace id, so the
+# endpoint must not be reachable unauthenticated or proxied to a tenant.
 # MARGINCE_METRICS_TOKEN=
 
-# [optional] debug | info | warn | error. Default info. An invalid value is a
-# boot error, never a silent default.
+# [optional] debug, info, warn or error. Default info. An invalid value is a
+# boot error rather than a silent fallback.
 # MARGINCE_LOG_LEVEL=info
 
-# [optional] text | json. Default text, which suits a terminal; a deployment
-# shipping to a log aggregator wants json.
+# [optional] text or json. Default text. Deployments forwarding to a log
+# aggregator generally want json.
 # MARGINCE_LOG_FORMAT=json
 
-# ═══ AI runtime (BYOK) ═══════════════════════════════════════════════════════
+# ═══ AI runtime (bring your own key) ═════════════════════════════════════════
 
-# [required for every AI lane — unset: they never start; CRUD and auth are
-# unaffected] Path to the tier→model binding. `make install` / `make dev` seed a gitignored
-# config/ai-routing.yaml from config/ai-routing.example.yaml and pass it as a
-# flag, so this line is for a direct launch or a deployment's mounted path.
+# [required for the AI lanes — unset: they do not start, and CRUD and
+# authentication are unaffected] Path to the tier-to-model binding.
+# `make install` and `make dev` seed a gitignored config/ai-routing.yaml from
+# config/ai-routing.example.yaml and pass it as a flag, so this value applies to
+# direct launches and to a deployment's mounted path.
 # MARGINCE_AI_ROUTING=/app/config/ai-routing.yaml
 
-# [required by whichever provider your routing file binds — unset: that provider
-# fails closed. `make dev` substitutes
-# --ai-fake and carries on; a direct or deployed launch given --ai-routing
-# REFUSES TO BOOT] Keys live in the ENVIRONMENT, never in the routing config
-# (ADR-0020). Set the one your routing file binds; the shipped default binds
-# gemini.
+# [required by the provider the routing file binds — unset: that provider fails
+# closed] `make dev` substitutes --ai-fake and continues; a direct or deployed
+# launch given --ai-routing does not start. Keys are read from the environment
+# and never from the routing configuration (ADR-0020). Set the one matching the
+# bound provider; the shipped default binds gemini.
 # GEMINI_API_KEY=
 # OPENAI_API_KEY=
 # ANTHROPIC_API_KEY=
 # OPENAI_COMPATIBLE_API_KEY=   # provider openai_compatible; also needs base_url
 
-# ═══ Secrets that gate a feature ═════════════════════════════════════════════
-# Pass these through the ENVIRONMENT. Equivalent flags exist for all but the
-# keyvault root key (--webhook-key, --connector-state-key,
-# --gmail-client-secret, --hubspot-app-secret), and they work — but argv is
-# world-readable, so a secret on the command line is readable by every process
-# on the host.
+# ═══ Feature-gating secrets ══════════════════════════════════════════════════
+# Supply these through the environment. Flags exist for all but the keyvault
+# root key (--webhook-key, --connector-state-key, --gmail-client-secret,
+# --hubspot-app-secret) and are functional, but argv is world-readable, so a
+# secret passed on the command line is visible to every process on the host.
 
-# [required to create or replay an outbound webhook — unset: those paths answer
-# 503 rather than ship an unsigned delivery; the read surface still lists]
-# base64 32-byte
-# key sealing outbound-webhook signing secrets at rest. openssl rand -base64 32
+# [required to create or replay an outbound webhook — unset: those paths return
+# 503 rather than sending an unsigned delivery, and the read surface continues
+# to list] base64-encoded 32-byte key sealing outbound-webhook signing secrets
+# at rest. Generate with: openssl rand -base64 32
 # MARGINCE_WEBHOOK_KEY=
 
-# [required to persist ANY connector credential — unset: those paths refuse
-# loudly rather than store a credential in the clear, though the transient
-# one-shot IMAP pull still works] base64 of exactly 32 bytes, the
-# AES-256 root key sealing connector credentials. Set but not 32 bytes is a boot
-# error, never a silent fallback. `make dev` supplies a throwaway dev key.
+# [required to persist a connector credential — unset: those paths refuse rather
+# than storing a credential unencrypted, and the transient one-shot IMAP pull is
+# unaffected] base64-encoded 32 bytes exactly: the AES-256 root key sealing
+# connector credentials. A value that is set but not 32 bytes is a boot error
+# rather than a fallback. `make dev` supplies a development key.
 # MARGINCE_KEYVAULT_ROOT_KEY=
 
 # [required for mail capture — unset: /connectors/gmail/* and
-# /connectors/graph/* stay declared 501s] The OAuth app authorizing each
-# capture connector — Google (Gmail API
-# enabled, scope gmail.readonly) and Microsoft Entra. Both also need
-# MARGINCE_KEYVAULT_ROOT_KEY: the refresh token is sealed there. Register the
-# redirect URI on the API origin, not the SPA:
+# /connectors/graph/* remain declared 501s] The OAuth application for each
+# capture connector: Google (Gmail API enabled, scope gmail.readonly) and
+# Microsoft Entra. Both also require MARGINCE_KEYVAULT_ROOT_KEY, since the
+# refresh token is sealed with it. Register the redirect URI against the API
+# origin rather than the SPA:
 #   <api-base>/v1/connectors/{gmail,graph}/callback
 # MARGINCE_GMAIL_CLIENT_ID=
 # MARGINCE_GMAIL_CLIENT_SECRET=
@@ -119,85 +118,85 @@
 # MARGINCE_GRAPH_CLIENT_SECRET=
 # MARGINCE_GRAPH_TENANT=common
 
-# [required for the OAuth connect flow — unset: it refuses] HMAC key (>=32 bytes)
-# signing the connect `state`, which is the session-less callback's only auth.
-# A key under 32 bytes disables the connect surface rather than signing weakly.
-# `make dev` supplies a throwaway dev key ONLY when the two Gmail app vars above
-# are both set — a Graph-only local setup has to set this itself.
+# [required for the OAuth connect flow — unset: the flow is refused] HMAC key of
+# at least 32 bytes signing the connect `state`, which is the only
+# authentication the session-less callback has. A shorter key disables the
+# connect surface rather than signing weakly. `make dev` supplies a development
+# key only when both Gmail application variables above are set; a Graph-only
+# local setup must set this explicitly.
 # MARGINCE_CONNECTOR_STATE_KEY=
 
 # [required for the HubSpot overlay webhook — unset: /webhooks/hubspot is not
-# mounted at all] The HubSpot app
-# client secret; verifies inbound overlay-webhook v3 signatures. Absent, the
-# route is missing rather than present-and-unverified.
+# mounted] The HubSpot application client secret, used to verify inbound
+# overlay-webhook v3 signatures. Without it the route is absent rather than
+# present and unverified.
 # MARGINCE_HUBSPOT_APP_SECRET=
 
 # [optional — defaults to MARGINCE_PUBLIC_BASE_URL] The api's externally
-# reachable base for the OAuth callback redirect_uri. Set it only when api and
-# SPA are on different origins — `make dev` is one (api on :8080).
+# reachable base for the OAuth callback redirect_uri. Set it only when the api
+# and the SPA are served from different origins, as under `make dev` (api on
+# port 8080).
 # MARGINCE_API_BASE_URL=
 
-# ═══ Object storage (attachments, company logos) ══════════════════════════════
+# ═══ Object storage (attachments, company logos) ═════════════════════════════
 
-# [required for attachments and company logos — unset: /attachments answers 501,
-# /readyz drops the blobstore probe, and every company renders its monogram
-# instead of a logo] S3-compatible store, read by api and worker; the bucket is
-# created on first connect. Art. 17 erasure also needs it: with attachment rows
-# present but no store reachable, erasure FAILS and rolls back rather than
-# stranding the bytes, and stays retryable until a store is configured.
-# `make dev` sets these as command-prefix assignments — MinIO on
-# localhost:59000, bucket margince-dev — which OVERRIDE anything set here.
+# [required for attachments and company logos — unset: /attachments returns 501,
+# /readyz omits the blobstore probe, and organizations render a monogram in
+# place of a logo] S3-compatible store read by both api and worker; the bucket
+# is created on first connect. Article 17 erasure also depends on it: with
+# attachment rows present and no store reachable, erasure fails and rolls back
+# rather than leaving the objects, and remains retryable until a store is
+# configured. `make dev` sets these as command-prefix assignments (MinIO on
+# localhost:59000, bucket margince-dev), which take precedence over values set
+# here.
 # MARGINCE_BLOBSTORE_ENDPOINT=s3.eu-central-1.amazonaws.com
 # MARGINCE_BLOBSTORE_ACCESS_KEY=
 # MARGINCE_BLOBSTORE_SECRET_KEY=
 # MARGINCE_BLOBSTORE_BUCKET=margince
 # MARGINCE_BLOBSTORE_REGION=us-east-1
-# TLS is OPT-IN: unset means plain HTTP, which puts the two keys above on the
-# wire. Fine for the local MinIO, not for anything else.
+# TLS is opt-in: unset means plain HTTP, which sends the access and secret keys
+# above in the clear. Appropriate for the local MinIO container only.
 # MARGINCE_BLOBSTORE_USE_SSL=true
 
-# ═══ Deployments only — the container entrypoint reads these ═════════════════
-# See docs/deployment.md; scripts/deploy/api-entrypoint.sh is what consumes them.
+# ═══ Deployment only — read by the container entrypoint ══════════════════════
+# Consumed by scripts/deploy/api-entrypoint.sh; see docs/deployment.md.
 
-# [required in a deployment] Postgres DSN, the OWNER role. The api entrypoint
-# refuses to boot without it: it runs the migrations and backs the
-# custom-fields DDL pool. Never the app role, and never the same credential you
-# put in MARGINCE_DSN.
+# [required in a deployment] Postgres DSN for the owner role. The api entrypoint
+# does not start without it: it runs the migrations and backs the custom-fields
+# DDL pool. Use the owner role rather than the application role, and a different
+# credential from MARGINCE_DSN.
 # MARGINCE_OWNER_DSN=postgres://margince_owner:CHANGE_ME@db.internal:5432/margince
 
-# [required on the FIRST boot of an empty database] The bootstrap admin
-# password. The entrypoint writes it to the file margince.yaml references
-# (default /app/secrets/admin-password); MARGINCE_ADMIN_PASSWORD_FILE overrides
-# that path. After the first boot neither is needed — rotate through the app.
+# [required on the first boot of an empty database] Bootstrap admin password.
+# The entrypoint writes it to the file margince.yaml references, by default
+# /app/secrets/admin-password; MARGINCE_ADMIN_PASSWORD_FILE overrides that path.
+# Neither is needed after the first boot; rotate the password through the
+# application.
 # MARGINCE_ADMIN_PASSWORD=
 # MARGINCE_ADMIN_PASSWORD_FILE=/app/secrets/admin-password
 
-# [required to scrape the WORKER — unset: it serves no HTTP at all] Address for
-# the worker's
-# own /healthz, /readyz and /metrics. The api serves those on its main port
-# regardless; the worker is silent until you give it an address. Bind it
-# somewhere only your scraper reaches.
+# [required to scrape the worker — unset: the worker serves no HTTP] Address for
+# the worker's own /healthz, /readyz and /metrics. The api serves those on its
+# main port regardless. Bind this to an address reachable only by the scraper.
 # MARGINCE_OBSERVE_ADDR=127.0.0.1:9101
 
 # ═══ Non-production only ═════════════════════════════════════════════════════
 
-# [optional — a production deployment must leave this UNSET] Unset means
-# production posture, which disables every dev-only destructive switch. This is
-# the one entry where setting the var REMOVES a protection rather than adding a
-# capability. `dev`, `staging` or `test` ENABLES those switches — today
-# POST /v1/admin/reset-data, which purges the installation's tenant data back to
-# first-boot state. Read that before setting it on any box holding data you
-# want: a staging environment seeded from a production copy is exactly where
-# this costs something. Fail-closed on parse: only those three values are
-# non-production, and anything else — including a typo — is production. The
-# Makefiles export dev; a production deployment must not set it at all.
+# [optional — a production deployment leaves this unset] Unset selects the
+# production posture, which disables the non-production destructive operations.
+# Setting it removes that protection rather than enabling a capability: `dev`,
+# `staging` and `test` enable POST /v1/admin/reset-data, which purges the
+# installation's tenant data to its first-boot state. Parsing is fail-closed —
+# only those three values are non-production, and any other value, including a
+# misspelling, is production. The Makefiles export `dev`.
 # MARGINCE_ENV=dev
 
-# [optional — unset or 0: uncapped] Cap the INITIAL overlay mirror backfill at N
-# records per object class, so a laptop pointed at a real portal does not pull
-# the whole portal down. Later incremental sweeps still track edits, so
-# continuous sync keeps working on the capped subset. Do NOT change it
-# mid-backfill: the running count rides in overlay_backfill_cursor as a
-# "<count>|<inner>" prefix the uncapped adapter rejects, which fails that object
-# class on every sweep until its cursor row is cleared.
+# [optional — unset or 0: uncapped] Caps the initial overlay mirror backfill at
+# N records per object class, which keeps a local run against a production
+# portal from mirroring the portal in full. Later incremental sweeps still pick
+# up edits, so continuous sync continues to operate on the capped subset. Do not
+# change this while a backfill is in progress: the running count is stored in
+# overlay_backfill_cursor as a "<count>|<inner>" prefix that the uncapped
+# adapter rejects, which fails that object class on every sweep until the cursor
+# row is cleared.
 # MARGINCE_OVERLAY_BACKFILL_LIMIT=5

--- a/.env.template
+++ b/.env.template
@@ -19,12 +19,17 @@
 # Source: backend/cmd/api/config.go, backend/cmd/worker/config.go
 
 # [required] Postgres DSN for the application role; row-level security applies.
-# Never the owner role. `make dev` uses its own APP_DSN and ignores this.
-# Example: postgres://margince_app:PASSWORD@db.internal:5432/margince
+# Never the owner role, and not for cmd/migrate — pass that an owner DSN
+# explicitly (`go run ./cmd/migrate up --dsn <owner-dsn>`), since it creates and
+# alters objects. `make dev` uses its own APP_DSN and ignores this.
+# Example: postgres://<app-role>:<password>@db.internal:5432/margince
 MARGINCE_DSN=
 
-# [required in a deployment] Path to margince.yaml. Defaults to margince.yaml in
-# the working directory. Example: /app/config/margince.yaml
+# [required to bootstrap an empty database; optional afterwards] Path to
+# margince.yaml, which carries the organization and bootstrap_admin a first boot
+# needs. Defaults to margince.yaml in the working directory; an existing
+# installation boots even when the file is absent. Example:
+# /app/config/margince.yaml
 MARGINCE_CONFIG=
 
 
@@ -40,9 +45,10 @@ MARGINCE_REDIS=
 # ---- External addressing ---------------------------------------------------
 # Source: backend/cmd/api/config.go
 
-# [required to send marketing mail] Canonical external scheme and host for
-# buyer-facing links. A send is refused rather than trusting the request Host.
-# Example: https://crm.example.com
+# [required to send marketing mail, and for the Gmail/Graph OAuth callback]
+# Canonical external scheme and host for buyer-facing links. A send is refused
+# rather than trusting the request Host, and a connect flow needs it alongside
+# the connector secret and state key. Example: https://crm.example.com
 MARGINCE_PUBLIC_BASE_URL=
 
 # [optional] Defaults to MARGINCE_PUBLIC_BASE_URL. Set only when the api and the

--- a/.env.template
+++ b/.env.template
@@ -12,8 +12,12 @@
 # reads must be documented, a var named here must be one the product reads, and
 # a var a deploy entrypoint hard-requires must appear here.
 #
-# [required] the process refuses to boot without it.
-# [optional] says on the same line what leaving it unset costs.
+# [required]        the process refuses to boot without it.
+# [required for X]  the process boots fine and X does not work. Unset is a
+#                   DECLARED absence — a 501/503/404, never a broken state — but
+#                   it is not optional to anyone who wants X, so the label says
+#                   what you lose rather than calling it optional.
+# [optional]        genuinely safe to ignore; the default is right everywhere.
 #
 # Nothing here is uncommented on purpose: a template that ships a live value
 # ships whatever environment that value came from. Every example is a shape to
@@ -48,8 +52,8 @@
 
 # ═══ Observability ═══════════════════════════════════════════════════════════
 
-# [optional — unset: /metrics answers 404] Shared secret /metrics requires as a
-# Bearer credential. This IS the access control for that endpoint: its
+# [required to scrape /metrics — unset: the route answers 404] Shared secret
+# /metrics requires as a Bearer credential. This IS the access control for that endpoint: its
 # exposition is fleet-wide and carries every workspace's id, so it must never be
 # reachable unauthenticated or proxied to a tenant. Set it and give it to your
 # scraper.
@@ -65,13 +69,14 @@
 
 # ═══ AI runtime (BYOK) ═══════════════════════════════════════════════════════
 
-# [optional — unset: the AI lanes never start; CRUD and auth are unaffected]
-# Path to the tier→model binding. `make install` / `make dev` seed a gitignored
+# [required for every AI lane — unset: they never start; CRUD and auth are
+# unaffected] Path to the tier→model binding. `make install` / `make dev` seed a gitignored
 # config/ai-routing.yaml from config/ai-routing.example.yaml and pass it as a
 # flag, so this line is for a direct launch or a deployment's mounted path.
 # MARGINCE_AI_ROUTING=/app/config/ai-routing.yaml
 
-# [optional — unset: a bound cloud provider fails closed. `make dev` substitutes
+# [required by whichever provider your routing file binds — unset: that provider
+# fails closed. `make dev` substitutes
 # --ai-fake and carries on; a direct or deployed launch given --ai-routing
 # REFUSES TO BOOT] Keys live in the ENVIRONMENT, never in the routing config
 # (ADR-0020). Set the one your routing file binds; the shipped default binds
@@ -88,19 +93,22 @@
 # world-readable, so a secret on the command line is readable by every process
 # on the host.
 
-# [optional — unset: the mutating /webhook-subscriptions paths answer 503 rather
-# than ship an unsigned delivery; the read surface still lists] base64 32-byte
+# [required to create or replay an outbound webhook — unset: those paths answer
+# 503 rather than ship an unsigned delivery; the read surface still lists]
+# base64 32-byte
 # key sealing outbound-webhook signing secrets at rest. openssl rand -base64 32
 # MARGINCE_WEBHOOK_KEY=
 
-# [optional — unset: the persisting connector-credential paths refuse loudly;
-# the transient one-shot IMAP pull still works] base64 of exactly 32 bytes, the
+# [required to persist ANY connector credential — unset: those paths refuse
+# loudly rather than store a credential in the clear, though the transient
+# one-shot IMAP pull still works] base64 of exactly 32 bytes, the
 # AES-256 root key sealing connector credentials. Set but not 32 bytes is a boot
 # error, never a silent fallback. `make dev` supplies a throwaway dev key.
 # MARGINCE_KEYVAULT_ROOT_KEY=
 
-# [optional — unset: /connectors/gmail/* and /connectors/graph/* stay declared
-# 501s] The OAuth app authorizing each capture connector — Google (Gmail API
+# [required for mail capture — unset: /connectors/gmail/* and
+# /connectors/graph/* stay declared 501s] The OAuth app authorizing each
+# capture connector — Google (Gmail API
 # enabled, scope gmail.readonly) and Microsoft Entra. Both also need
 # MARGINCE_KEYVAULT_ROOT_KEY: the refresh token is sealed there. Register the
 # redirect URI on the API origin, not the SPA:
@@ -111,14 +119,15 @@
 # MARGINCE_GRAPH_CLIENT_SECRET=
 # MARGINCE_GRAPH_TENANT=common
 
-# [optional — unset: the OAuth connect flow refuses] HMAC key (>=32 bytes)
+# [required for the OAuth connect flow — unset: it refuses] HMAC key (>=32 bytes)
 # signing the connect `state`, which is the session-less callback's only auth.
 # A key under 32 bytes disables the connect surface rather than signing weakly.
 # `make dev` supplies a throwaway dev key ONLY when the two Gmail app vars above
 # are both set — a Graph-only local setup has to set this itself.
 # MARGINCE_CONNECTOR_STATE_KEY=
 
-# [optional — unset: /webhooks/hubspot is not mounted at all] The HubSpot app
+# [required for the HubSpot overlay webhook — unset: /webhooks/hubspot is not
+# mounted at all] The HubSpot app
 # client secret; verifies inbound overlay-webhook v3 signatures. Absent, the
 # route is missing rather than present-and-unverified.
 # MARGINCE_HUBSPOT_APP_SECRET=
@@ -130,9 +139,12 @@
 
 # ═══ Object storage (attachments, company logos) ══════════════════════════════
 
-# [optional — unset: /attachments answers 501, /readyz drops the blobstore
-# probe, and every company renders its monogram instead of a logo] S3-compatible
-# store, read by api and worker; the bucket is created on first connect.
+# [required for attachments and company logos — unset: /attachments answers 501,
+# /readyz drops the blobstore probe, and every company renders its monogram
+# instead of a logo] S3-compatible store, read by api and worker; the bucket is
+# created on first connect. Art. 17 erasure also needs it: with attachment rows
+# present but no store reachable, erasure FAILS and rolls back rather than
+# stranding the bytes, and stays retryable until a store is configured.
 # `make dev` sets these as command-prefix assignments — MinIO on
 # localhost:59000, bucket margince-dev — which OVERRIDE anything set here.
 # MARGINCE_BLOBSTORE_ENDPOINT=s3.eu-central-1.amazonaws.com
@@ -160,7 +172,8 @@
 # MARGINCE_ADMIN_PASSWORD=
 # MARGINCE_ADMIN_PASSWORD_FILE=/app/secrets/admin-password
 
-# [optional — unset: the worker serves no HTTP at all] Address for the WORKER's
+# [required to scrape the WORKER — unset: it serves no HTTP at all] Address for
+# the worker's
 # own /healthz, /readyz and /metrics. The api serves those on its main port
 # regardless; the worker is silent until you give it an address. Bind it
 # somewhere only your scraper reaches.
@@ -168,8 +181,10 @@
 
 # ═══ Non-production only ═════════════════════════════════════════════════════
 
-# [optional — unset: production posture, which disables every dev-only
-# destructive switch] `dev`, `staging` or `test` ENABLES those switches — today
+# [optional — a production deployment must leave this UNSET] Unset means
+# production posture, which disables every dev-only destructive switch. This is
+# the one entry where setting the var REMOVES a protection rather than adding a
+# capability. `dev`, `staging` or `test` ENABLES those switches — today
 # POST /v1/admin/reset-data, which purges the installation's tenant data back to
 # first-boot state. Read that before setting it on any box holding data you
 # want: a staging environment seeded from a production copy is exactly where

--- a/.env.template
+++ b/.env.template
@@ -46,17 +46,21 @@ MARGINCE_DSN=postgres://margince_app:margince_app_dev@localhost:55432/margince
 # config/ai-routing.yaml from config/ai-routing.example.yaml.
 # MARGINCE_AI_ROUTING=config/ai-routing.yaml
 
-# [optional — unset: a bound cloud provider fails closed at boot, so the cold
-# start runs the offline fake] Keys live in the ENVIRONMENT, never in the
-# routing config (ADR-0020). Set the one your routing file binds; the shipped
-# default binds gemini.
+# [optional — unset: a bound cloud provider fails closed. `make dev` substitutes
+# --ai-fake and carries on; a direct or deployed launch given --ai-routing
+# REFUSES TO BOOT] Keys live in the ENVIRONMENT, never in the routing config
+# (ADR-0020). Set the one your routing file binds; the shipped default binds
+# gemini.
 # GEMINI_API_KEY=
 # OPENAI_API_KEY=
 # ANTHROPIC_API_KEY=
 # OPENAI_COMPATIBLE_API_KEY=   # provider openai_compatible; also needs base_url
 
 # ── Secrets that gate a feature ──────────────────────────────────────────────
-# Each is read from the environment, never a CLI flag: argv is world-readable.
+# Pass these through the ENVIRONMENT. Equivalent flags exist for all but the
+# keyvault root key (--webhook-key, --connector-state-key,
+# --gmail-client-secret), and they work — but argv is world-readable, so a
+# secret on the command line is readable by every process on the host.
 
 # [optional — unset: the mutating /webhook-subscriptions paths answer 503 rather
 # than ship an unsigned delivery; the read surface still lists] base64 32-byte
@@ -79,7 +83,9 @@ MARGINCE_DSN=postgres://margince_app:margince_app_dev@localhost:55432/margince
 
 # [optional — unset: the OAuth connect flow refuses] HMAC key (>=32 bytes)
 # signing the connect `state`, which is the session-less callback's only auth.
-# `make dev` supplies a throwaway dev key.
+# A key under 32 bytes disables the connect surface rather than signing weakly.
+# `make dev` supplies a throwaway dev key ONLY when the two Gmail app vars above
+# are both set — a Graph-only local setup has to set this itself.
 # MARGINCE_CONNECTOR_STATE_KEY=
 
 # ── External addressing ──────────────────────────────────────────────────────
@@ -105,13 +111,19 @@ MARGINCE_DSN=postgres://margince_app:margince_app_dev@localhost:55432/margince
 # MARGINCE_BLOBSTORE_ACCESS_KEY=minioadmin
 # MARGINCE_BLOBSTORE_SECRET_KEY=minioadmin
 # MARGINCE_BLOBSTORE_BUCKET=margince
+# TLS is OPT-IN: unset means plain HTTP, which puts the two keys above on the
+# wire. Fine for the local MinIO, not for anything else.
+# MARGINCE_BLOBSTORE_USE_SSL=false
 
 # ── Posture and overlay ──────────────────────────────────────────────────────
 
-# [optional — unset: production posture, which disables every dev-only trust
-# switch] `dev` lets the api trust the X-Workspace-Slug header instead of
-# resolving the workspace from the subdomain. Fail-closed: only dev, staging and
-# test are non-production; anything else, including a typo, is production. The
+# [optional — unset: production posture, which disables every dev-only
+# destructive switch] `dev`, `staging` or `test` ENABLES those switches — today
+# POST /v1/admin/reset-data, which purges the installation's tenant data back to
+# first-boot state. Read that before setting this on any box holding data you
+# want: a staging environment seeded from a production copy is exactly where
+# this costs something. Fail-closed on parse: only those three values are
+# non-production, and anything else — including a typo — is production. The
 # Makefiles export dev; production must not set it.
 # MARGINCE_ENV=dev
 

--- a/.env.template
+++ b/.env.template
@@ -1,202 +1,172 @@
-# Margince environment template
+# ============================================================================
+# Margince environment variables
 #
-# Applies to every environment. Locally, copy this to .env.local (gitignored)
-# and set what is needed; `make dev` (scripts/dev.sh) sources it automatically,
-# and a direct binary launch requires sourcing it manually. In a deployment,
-# this is the annotated template referenced by docs/deployment.md: supply the
-# values through the platform's environment or secret mechanism rather than by
-# committing a filled-in copy.
+# Copy to .env.local (gitignored) and fill in what you need. `make dev` sources
+# it automatically; a direct launch needs `source .env.local`. A deployment
+# supplies these through its own environment or secret store — do not commit a
+# filled-in copy. An empty value is treated as unset, so a blank line is safe.
 #
-# Scope: the variables an operator or developer supplies. The complete catalog
-# of every variable, its flag and its default is docs/reference/configuration.md;
-# container-entrypoint specifics are in docs/deployment.md.
-# backend/envcontract_test.go asserts that this file, that catalog and the deploy
-# entrypoints stay consistent with the code.
+#   [required]        the process does not start without it
+#   [required for X]  the process starts, X is unavailable (declared 501/503/404)
+#   [optional]        the default is fine in every environment
 #
-# [required]       the process does not start without it.
-# [required for X] the process starts and X is unavailable. The affected route
-#                  returns a declared 501, 503 or 404 rather than failing, but
-#                  the variable is not optional where X is needed.
-# [optional]       the default is appropriate in every environment.
-#
-# All entries are commented out. Example values show the expected form and are
-# not usable credentials.
-#
-# Roles referenced below are the three binaries under backend/cmd: api, worker
-# and migrate.
+# Every variable, flag and default: docs/reference/configuration.md
+# Deployment specifics: docs/deployment.md
+# ============================================================================
 
-# ═══ Required in every environment ═══════════════════════════════════════════
 
-# [required] Postgres DSN for the runtime application role; row-level security
-# applies to it. Do not use the owner role here. `make dev` connects using its
-# own APP_DSN and ignores this value, so it applies to direct launches and to
-# deployments.
-# MARGINCE_DSN=postgres://margince_app:CHANGE_ME@db.internal:5432/margince
+# ---- Database --------------------------------------------------------------
+# Source: backend/cmd/api/config.go, backend/cmd/worker/config.go
 
-# [required in a deployment] Path to the deployment configuration file
-# (bootstrap organization and admin, seeds, email). Defaults to `margince.yaml`
-# resolved against the working directory; name the mounted path explicitly in a
-# container.
-# MARGINCE_CONFIG=/app/config/margince.yaml
+# [required] Postgres DSN for the application role; row-level security applies.
+# Never the owner role. `make dev` uses its own APP_DSN and ignores this.
+# Example: postgres://margince_app:PASSWORD@db.internal:5432/margince
+MARGINCE_DSN=
 
-# [required in a deployment] Redis address for the event bus and outbox relay.
-# The default, localhost:56379, is the `make db-up` container. With the api's
-# default --inline-relay=true an unreachable Redis is a boot error, so that a
-# committed write cannot strand its outbox row.
-# MARGINCE_REDIS=redis.internal:6379
+# [required in a deployment] Path to margince.yaml. Defaults to margince.yaml in
+# the working directory. Example: /app/config/margince.yaml
+MARGINCE_CONFIG=
 
-# [required to send marketing mail; also used for the OAuth callback] Canonical
-# external scheme and host for buyer-facing links (RFC 8058 unsubscribe and
-# preference center). A send is refused rather than deriving a token-bearing
-# link from the request Host.
-# MARGINCE_PUBLIC_BASE_URL=https://crm.example.com
 
-# ═══ Observability ═══════════════════════════════════════════════════════════
+# ---- Event bus -------------------------------------------------------------
+# Source: backend/cmd/api/config.go
 
-# [required to scrape /metrics — unset: the route returns 404] Shared secret
-# that /metrics requires as a Bearer credential, and the access control for that
-# endpoint. The exposition is fleet-wide and carries every workspace id, so the
-# endpoint must not be reachable unauthenticated or proxied to a tenant.
-# MARGINCE_METRICS_TOKEN=
+# [required in a deployment] Redis address; default localhost:56379 is the
+# `make db-up` container. With --inline-relay (the default) an unreachable Redis
+# is a boot error. Example: redis.internal:6379
+MARGINCE_REDIS=
 
-# [optional] debug, info, warn or error. Default info. An invalid value is a
-# boot error rather than a silent fallback.
-# MARGINCE_LOG_LEVEL=info
 
-# [optional] text or json. Default text. Deployments forwarding to a log
-# aggregator generally want json.
-# MARGINCE_LOG_FORMAT=json
+# ---- External addressing ---------------------------------------------------
+# Source: backend/cmd/api/config.go
 
-# ═══ AI runtime (bring your own key) ═════════════════════════════════════════
+# [required to send marketing mail] Canonical external scheme and host for
+# buyer-facing links. A send is refused rather than trusting the request Host.
+# Example: https://crm.example.com
+MARGINCE_PUBLIC_BASE_URL=
 
-# [required for the AI lanes — unset: they do not start, and CRUD and
-# authentication are unaffected] Path to the tier-to-model binding.
-# `make install` and `make dev` seed a gitignored config/ai-routing.yaml from
-# config/ai-routing.example.yaml and pass it as a flag, so this value applies to
-# direct launches and to a deployment's mounted path.
-# MARGINCE_AI_ROUTING=/app/config/ai-routing.yaml
+# [optional] Defaults to MARGINCE_PUBLIC_BASE_URL. Set only when the api and the
+# SPA are on different origins, as under `make dev`.
+MARGINCE_API_BASE_URL=
 
-# [required by the provider the routing file binds — unset: that provider fails
-# closed] `make dev` substitutes --ai-fake and continues; a direct or deployed
-# launch given --ai-routing does not start. Keys are read from the environment
-# and never from the routing configuration (ADR-0020). Set the one matching the
-# bound provider; the shipped default binds gemini.
-# GEMINI_API_KEY=
-# OPENAI_API_KEY=
-# ANTHROPIC_API_KEY=
-# OPENAI_COMPATIBLE_API_KEY=   # provider openai_compatible; also needs base_url
 
-# ═══ Feature-gating secrets ══════════════════════════════════════════════════
-# Supply these through the environment. Flags exist for all but the keyvault
-# root key (--webhook-key, --connector-state-key, --gmail-client-secret,
-# --hubspot-app-secret) and are functional, but argv is world-readable, so a
-# secret passed on the command line is visible to every process on the host.
+# ---- Logging and metrics ---------------------------------------------------
+# Source: backend/cmd/api/config.go, backend/cmd/worker/config.go
 
-# [required to create or replay an outbound webhook — unset: those paths return
-# 503 rather than sending an unsigned delivery, and the read surface continues
-# to list] base64-encoded 32-byte key sealing outbound-webhook signing secrets
-# at rest. Generate with: openssl rand -base64 32
-# MARGINCE_WEBHOOK_KEY=
+# [optional] debug | info | warn | error. Default info; invalid values are a
+# boot error.
+MARGINCE_LOG_LEVEL=
 
-# [required to persist a connector credential — unset: those paths refuse rather
-# than storing a credential unencrypted, and the transient one-shot IMAP pull is
-# unaffected] base64-encoded 32 bytes exactly: the AES-256 root key sealing
-# connector credentials. A value that is set but not 32 bytes is a boot error
-# rather than a fallback. `make dev` supplies a development key.
-# MARGINCE_KEYVAULT_ROOT_KEY=
+# [optional] text | json. Default text; use json for a log aggregator.
+MARGINCE_LOG_FORMAT=
 
-# [required for mail capture — unset: /connectors/gmail/* and
-# /connectors/graph/* remain declared 501s] The OAuth application for each
-# capture connector: Google (Gmail API enabled, scope gmail.readonly) and
-# Microsoft Entra. Both also require MARGINCE_KEYVAULT_ROOT_KEY, since the
-# refresh token is sealed with it. Register the redirect URI against the API
-# origin rather than the SPA:
-#   <api-base>/v1/connectors/{gmail,graph}/callback
-# MARGINCE_GMAIL_CLIENT_ID=
-# MARGINCE_GMAIL_CLIENT_SECRET=
-# MARGINCE_GRAPH_CLIENT_ID=
-# MARGINCE_GRAPH_CLIENT_SECRET=
-# MARGINCE_GRAPH_TENANT=common
+# [required to scrape /metrics] Bearer secret the endpoint requires; unset, it
+# returns 404. The exposition is fleet-wide and carries every workspace id, so
+# this is the access control for it.
+MARGINCE_METRICS_TOKEN=
 
-# [required for the OAuth connect flow — unset: the flow is refused] HMAC key of
-# at least 32 bytes signing the connect `state`, which is the only
-# authentication the session-less callback has. A shorter key disables the
-# connect surface rather than signing weakly. `make dev` supplies a development
-# key only when both Gmail application variables above are set; a Graph-only
-# local setup must set this explicitly.
-# MARGINCE_CONNECTOR_STATE_KEY=
+# [required to scrape the worker] Address for the worker's own /healthz,
+# /readyz and /metrics; unset, it serves no HTTP. Example: 127.0.0.1:9101
+MARGINCE_OBSERVE_ADDR=
 
-# [required for the HubSpot overlay webhook — unset: /webhooks/hubspot is not
-# mounted] The HubSpot application client secret, used to verify inbound
-# overlay-webhook v3 signatures. Without it the route is absent rather than
-# present and unverified.
-# MARGINCE_HUBSPOT_APP_SECRET=
 
-# [optional — defaults to MARGINCE_PUBLIC_BASE_URL] The api's externally
-# reachable base for the OAuth callback redirect_uri. Set it only when the api
-# and the SPA are served from different origins, as under `make dev` (api on
-# port 8080).
-# MARGINCE_API_BASE_URL=
+# ---- AI runtime ------------------------------------------------------------
+# Source: backend/internal/modules/ai, config/ai-routing.example.yaml
 
-# ═══ Object storage (attachments, company logos) ═════════════════════════════
+# [required for the AI lanes] Path to the tier-to-model binding; unset, those
+# lanes do not start and nothing else is affected. `make dev` seeds
+# config/ai-routing.yaml and passes it as a flag.
+MARGINCE_AI_ROUTING=
 
-# [required for attachments and company logos — unset: /attachments returns 501,
-# /readyz omits the blobstore probe, and organizations render a monogram in
-# place of a logo] S3-compatible store read by both api and worker; the bucket
-# is created on first connect. Article 17 erasure also depends on it: with
-# attachment rows present and no store reachable, erasure fails and rolls back
-# rather than leaving the objects, and remains retryable until a store is
-# configured. `make dev` sets these as command-prefix assignments (MinIO on
-# localhost:59000, bucket margince-dev), which take precedence over values set
-# here.
-# MARGINCE_BLOBSTORE_ENDPOINT=s3.eu-central-1.amazonaws.com
-# MARGINCE_BLOBSTORE_ACCESS_KEY=
-# MARGINCE_BLOBSTORE_SECRET_KEY=
-# MARGINCE_BLOBSTORE_BUCKET=margince
-# MARGINCE_BLOBSTORE_REGION=us-east-1
-# TLS is opt-in: unset means plain HTTP, which sends the access and secret keys
-# above in the clear. Appropriate for the local MinIO container only.
-# MARGINCE_BLOBSTORE_USE_SSL=true
+# [required by the provider your routing file binds] Keys come from the
+# environment, never the routing file (ADR-0020). Unset, that provider fails
+# closed: `make dev` falls back to --ai-fake, a deployment does not start.
+GEMINI_API_KEY=
+OPENAI_API_KEY=
+ANTHROPIC_API_KEY=
+# provider openai_compatible; also needs base_url in the routing file
+OPENAI_COMPATIBLE_API_KEY=
 
-# ═══ Deployment only — read by the container entrypoint ══════════════════════
-# Consumed by scripts/deploy/api-entrypoint.sh; see docs/deployment.md.
 
-# [required in a deployment] Postgres DSN for the owner role. The api entrypoint
-# does not start without it: it runs the migrations and backs the custom-fields
-# DDL pool. Use the owner role rather than the application role, and a different
-# credential from MARGINCE_DSN.
-# MARGINCE_OWNER_DSN=postgres://margince_owner:CHANGE_ME@db.internal:5432/margince
+# ---- Feature-gating secrets ------------------------------------------------
+# Source: backend/cmd/api/config.go, backend/internal/platform/keyvault
+# Flags exist for all but the keyvault root key, but argv is world-readable —
+# pass secrets through the environment.
+
+# [required to create or replay an outbound webhook] base64 32-byte key sealing
+# webhook signing secrets at rest; unset, those paths return 503 rather than
+# sending unsigned. Generate: openssl rand -base64 32
+MARGINCE_WEBHOOK_KEY=
+
+# [required to persist a connector credential] base64 of exactly 32 bytes. Set
+# but wrong length is a boot error; unset, the persisting paths refuse rather
+# than storing a credential unencrypted. `make dev` supplies a dev key.
+MARGINCE_KEYVAULT_ROOT_KEY=
+
+# [required for mail capture] OAuth application per connector — Google (scope
+# gmail.readonly) and Microsoft Entra; unset, /connectors/gmail/* and
+# /connectors/graph/* stay declared 501s. Also needs the keyvault key above.
+# Redirect URI: <api-base>/v1/connectors/{gmail,graph}/callback
+MARGINCE_GMAIL_CLIENT_ID=
+MARGINCE_GMAIL_CLIENT_SECRET=
+MARGINCE_GRAPH_CLIENT_ID=
+MARGINCE_GRAPH_CLIENT_SECRET=
+# default: common (any organization)
+MARGINCE_GRAPH_TENANT=
+
+# [required for the OAuth connect flow] HMAC key of at least 32 bytes signing
+# the connect state. Shorter disables the connect surface rather than signing
+# weakly. `make dev` supplies one only when both Gmail variables are set.
+MARGINCE_CONNECTOR_STATE_KEY=
+
+# [required for the HubSpot overlay webhook] Verifies inbound v3 signatures;
+# unset, /webhooks/hubspot is not mounted rather than mounted unverified.
+MARGINCE_HUBSPOT_APP_SECRET=
+
+
+# ---- Object storage (attachments, company logos) ---------------------------
+# Source: backend/internal/platform/blobstore/env.go
+# [required for attachments and company logos] Unset, /attachments returns 501
+# and organizations render a monogram. `make dev` overrides these with the
+# compose MinIO. Erasure interaction: configuration.md.
+
+# Example: s3.eu-central-1.amazonaws.com
+MARGINCE_BLOBSTORE_ENDPOINT=
+MARGINCE_BLOBSTORE_ACCESS_KEY=
+MARGINCE_BLOBSTORE_SECRET_KEY=
+MARGINCE_BLOBSTORE_BUCKET=
+# default: us-east-1
+MARGINCE_BLOBSTORE_REGION=
+# TLS is opt-in: anything but `true` is plain HTTP, sending the keys above in
+# the clear. Acceptable for the local MinIO only.
+MARGINCE_BLOBSTORE_USE_SSL=
+
+
+# ---- Deployment only -------------------------------------------------------
+# Source: scripts/deploy/api-entrypoint.sh, docs/deployment.md
+
+# [required in a deployment] Postgres DSN for the owner role — runs migrations
+# and backs the custom-fields DDL pool. The entrypoint does not start without
+# it. Use a different credential from MARGINCE_DSN.
+MARGINCE_OWNER_DSN=
 
 # [required on the first boot of an empty database] Bootstrap admin password.
 # The entrypoint writes it to the file margince.yaml references, by default
-# /app/secrets/admin-password; MARGINCE_ADMIN_PASSWORD_FILE overrides that path.
-# Neither is needed after the first boot; rotate the password through the
-# application.
-# MARGINCE_ADMIN_PASSWORD=
-# MARGINCE_ADMIN_PASSWORD_FILE=/app/secrets/admin-password
+# /app/secrets/admin-password. Not needed afterwards; rotate in-app.
+MARGINCE_ADMIN_PASSWORD=
+MARGINCE_ADMIN_PASSWORD_FILE=
 
-# [required to scrape the worker — unset: the worker serves no HTTP] Address for
-# the worker's own /healthz, /readyz and /metrics. The api serves those on its
-# main port regardless. Bind this to an address reachable only by the scraper.
-# MARGINCE_OBSERVE_ADDR=127.0.0.1:9101
 
-# ═══ Non-production only ═════════════════════════════════════════════════════
+# ---- Non-production only ---------------------------------------------------
+# Source: backend/internal/shared/runtimeenv
 
-# [optional — a production deployment leaves this unset] Unset selects the
-# production posture, which disables the non-production destructive operations.
-# Setting it removes that protection rather than enabling a capability: `dev`,
-# `staging` and `test` enable POST /v1/admin/reset-data, which purges the
-# installation's tenant data to its first-boot state. Parsing is fail-closed —
-# only those three values are non-production, and any other value, including a
-# misspelling, is production. The Makefiles export `dev`.
-# MARGINCE_ENV=dev
+# [optional] Leave unset in production. dev | staging | test enable
+# POST /v1/admin/reset-data, which purges the installation's tenant data to its
+# first-boot state — setting this removes a protection rather than adding a
+# feature. Fail-closed: any other value means production.
+MARGINCE_ENV=
 
-# [optional — unset or 0: uncapped] Caps the initial overlay mirror backfill at
-# N records per object class, which keeps a local run against a production
-# portal from mirroring the portal in full. Later incremental sweeps still pick
-# up edits, so continuous sync continues to operate on the capped subset. Do not
-# change this while a backfill is in progress: the running count is stored in
-# overlay_backfill_cursor as a "<count>|<inner>" prefix that the uncapped
-# adapter rejects, which fails that object class on every sweep until the cursor
-# row is cleared.
-# MARGINCE_OVERLAY_BACKFILL_LIMIT=5
+# [optional] Caps the initial overlay mirror backfill at N records per object
+# class; unset or 0 is uncapped. Do not change it mid-backfill — see
+# configuration.md for the cursor state that makes this sticky.
+MARGINCE_OVERLAY_BACKFILL_LIMIT=

--- a/.env.template
+++ b/.env.template
@@ -3,11 +3,13 @@
 # (scripts/dev.sh) sources it automatically; for a direct binary launch
 # (`go run ./cmd/api`) source it yourself.
 #
-# This file holds the blanks a HUMAN FILLS IN — secrets and per-machine paths.
-# It is not the catalog: docs/reference/configuration.md is the table of record
-# for every MARGINCE_* var, its flag, and its default. Two fitness functions
-# keep them honest (backend/envcontract_test.go) — a var Go code reads must be
-# documented there, and a var named here must still be read by Go code.
+# This file holds the blanks a HUMAN FILLS IN for a LOCAL run — secrets and
+# per-machine paths. It is not the catalog: docs/reference/configuration.md is
+# the table of record for the binaries' own configuration (every var, its flag,
+# its default), and docs/deployment.md covers the vars only a deployment's
+# entrypoint reads. Fitness functions keep the three files honest
+# (backend/envcontract_test.go): a var Go code reads must be documented, and a
+# var named here or there must still be one the product reads.
 #
 # [required] the binary exits at boot without it.
 # [optional] says on the same line what leaving it unset costs. Every optional

--- a/.env.template
+++ b/.env.template
@@ -1,50 +1,75 @@
-# Margince local environment template
-# Copy to .env.local (gitignored) and fill in what you need. `make dev`
-# (scripts/dev.sh) sources it automatically; for a direct binary launch
-# (`go run ./cmd/api`) source it yourself.
+# Margince environment template — EVERY environment, not just a laptop
 #
-# This file holds the blanks a HUMAN FILLS IN for a LOCAL run — secrets and
-# per-machine paths. It is not the catalog: docs/reference/configuration.md is
-# the table of record for the binaries' own configuration (every var, its flag,
-# its default), and docs/deployment.md covers the vars only a deployment's
-# entrypoint reads. Fitness functions keep the three files honest
-# (backend/envcontract_test.go): a var Go code reads must be documented, and a
-# var named here or there must still be one the product reads.
+# Locally: copy to .env.local (gitignored) and fill in what you need; `make dev`
+# (scripts/dev.sh) sources it automatically. In a deployment: this is the
+# annotated template docs/deployment.md points at — supply these through your
+# platform's env/secret mechanism, never by committing a filled-in copy.
 #
-# [required] the binary exits at boot without it.
-# [optional] says on the same line what leaving it unset costs. Every optional
-#            var below disables something; none of them merely defaults.
+# This file is the ESSENTIALS a human supplies. The complete catalog — every
+# var, its flag, its default — is docs/reference/configuration.md, and
+# docs/deployment.md covers the container-entrypoint specifics. Fitness
+# functions keep the set honest (backend/envcontract_test.go): a var Go code
+# reads must be documented, a var named here must be one the product reads, and
+# a var a deploy entrypoint hard-requires must appear here.
 #
-# Scope: the three process-role binaries under backend/cmd/ — api, worker,
-# migrate. Vars that only have a working default (MARGINCE_LOG_LEVEL,
-# MARGINCE_LOG_FORMAT, MARGINCE_REDIS) and the integration lane's vars (which
-# backend/Makefile already exports) live only in configuration.md.
+# [required] the process refuses to boot without it.
+# [optional] says on the same line what leaving it unset costs.
 #
-# Some of these are OVERRIDDEN by `make dev`, which passes its own flags and
-# command-prefix assignments: MARGINCE_ENV, MARGINCE_AI_ROUTING, and the four
-# object-storage vars below. Editing those here does not change the dev stack.
-# They are listed because a direct launch or a real deployment needs them.
+# Nothing here is uncommented on purpose: a template that ships a live value
+# ships whatever environment that value came from. Every example is a shape to
+# replace, never a credential to keep.
+#
+# Roles: the three binaries under backend/cmd/ — api, worker, migrate.
 
-# ── Database ─────────────────────────────────────────────────────────────────
+# ═══ Every environment must supply these ═════════════════════════════════════
 
-# [required by api and worker] Postgres DSN, the runtime APP role — RLS applies;
-# never the owner role. Default matches `make db-up`.
-MARGINCE_DSN=postgres://margince_app:margince_app_dev@localhost:55432/margince
+# [required] Postgres DSN, the runtime APP role — RLS applies to it; never the
+# owner role. `make dev` connects with its own APP_DSN and ignores this line, so
+# it matters for a direct launch and for every deployment.
+# MARGINCE_DSN=postgres://margince_app:CHANGE_ME@db.internal:5432/margince
 
-# cmd/migrate needs the OWNER role instead (it creates and alters objects):
-#   go run ./cmd/migrate up --dsn postgres://margince_owner:dev@localhost:55432/margince
+# [required in a deployment] Path to the deployment config (bootstrap
+# organization + admin, seeds, email). Defaults to `margince.yaml` relative to
+# the working directory, which is right on a dev box and a coin-flip in a
+# container — name the mounted path explicitly.
+# MARGINCE_CONFIG=/app/config/margince.yaml
 
-# [optional — unset: createCustomField and updateCustomFieldOptions answer 501
-# and /readyz drops the customfields-schema-pool probe; list/rename/retire still
-# work] Owner-role DSN for the custom-fields runtime-DDL pool. Not wired by dev.
-# MARGINCE_SCHEMA_DSN=postgres://margince_owner:dev@localhost:55432/margince
+# [required in a deployment] Redis address for the event bus and outbox relay.
+# The default localhost:56379 is the `make db-up` container and is wrong
+# anywhere else. With the api's default --inline-relay=true an unreachable Redis
+# is a BOOT error: a committed write must never strand its outbox row.
+# MARGINCE_REDIS=redis.internal:6379
 
-# ── AI runtime (BYOK) ────────────────────────────────────────────────────────
+# [required to send marketing mail; also used for the OAuth callback] Canonical
+# external scheme+host for buyer-facing links (RFC 8058 unsubscribe /
+# preference center). A send refuses rather than derive a token-bearing link
+# from the request Host.
+# MARGINCE_PUBLIC_BASE_URL=https://crm.example.com
+
+# ═══ Observability ═══════════════════════════════════════════════════════════
+
+# [optional — unset: /metrics answers 404] Shared secret /metrics requires as a
+# Bearer credential. This IS the access control for that endpoint: its
+# exposition is fleet-wide and carries every workspace's id, so it must never be
+# reachable unauthenticated or proxied to a tenant. Set it and give it to your
+# scraper.
+# MARGINCE_METRICS_TOKEN=
+
+# [optional] debug | info | warn | error. Default info. An invalid value is a
+# boot error, never a silent default.
+# MARGINCE_LOG_LEVEL=info
+
+# [optional] text | json. Default text, which suits a terminal; a deployment
+# shipping to a log aggregator wants json.
+# MARGINCE_LOG_FORMAT=json
+
+# ═══ AI runtime (BYOK) ═══════════════════════════════════════════════════════
 
 # [optional — unset: the AI lanes never start; CRUD and auth are unaffected]
 # Path to the tier→model binding. `make install` / `make dev` seed a gitignored
-# config/ai-routing.yaml from config/ai-routing.example.yaml.
-# MARGINCE_AI_ROUTING=config/ai-routing.yaml
+# config/ai-routing.yaml from config/ai-routing.example.yaml and pass it as a
+# flag, so this line is for a direct launch or a deployment's mounted path.
+# MARGINCE_AI_ROUTING=/app/config/ai-routing.yaml
 
 # [optional — unset: a bound cloud provider fails closed. `make dev` substitutes
 # --ai-fake and carries on; a direct or deployed launch given --ai-routing
@@ -56,11 +81,12 @@ MARGINCE_DSN=postgres://margince_app:margince_app_dev@localhost:55432/margince
 # ANTHROPIC_API_KEY=
 # OPENAI_COMPATIBLE_API_KEY=   # provider openai_compatible; also needs base_url
 
-# ── Secrets that gate a feature ──────────────────────────────────────────────
+# ═══ Secrets that gate a feature ═════════════════════════════════════════════
 # Pass these through the ENVIRONMENT. Equivalent flags exist for all but the
 # keyvault root key (--webhook-key, --connector-state-key,
-# --gmail-client-secret), and they work — but argv is world-readable, so a
-# secret on the command line is readable by every process on the host.
+# --gmail-client-secret, --hubspot-app-secret), and they work — but argv is
+# world-readable, so a secret on the command line is readable by every process
+# on the host.
 
 # [optional — unset: the mutating /webhook-subscriptions paths answer 503 rather
 # than ship an unsigned delivery; the read surface still lists] base64 32-byte
@@ -73,13 +99,17 @@ MARGINCE_DSN=postgres://margince_app:margince_app_dev@localhost:55432/margince
 # error, never a silent fallback. `make dev` supplies a throwaway dev key.
 # MARGINCE_KEYVAULT_ROOT_KEY=
 
-# [optional — unset: /connectors/gmail/* stays a declared 501] The Google OAuth
-# app for read-only Gmail capture (Gmail API enabled, scope gmail.readonly).
-# Needs MARGINCE_KEYVAULT_ROOT_KEY too — the refresh token is sealed there.
-# Register this redirect URI on the api origin, not the SPA:
-#   <api-base>/v1/connectors/gmail/callback
+# [optional — unset: /connectors/gmail/* and /connectors/graph/* stay declared
+# 501s] The OAuth app authorizing each capture connector — Google (Gmail API
+# enabled, scope gmail.readonly) and Microsoft Entra. Both also need
+# MARGINCE_KEYVAULT_ROOT_KEY: the refresh token is sealed there. Register the
+# redirect URI on the API origin, not the SPA:
+#   <api-base>/v1/connectors/{gmail,graph}/callback
 # MARGINCE_GMAIL_CLIENT_ID=
 # MARGINCE_GMAIL_CLIENT_SECRET=
+# MARGINCE_GRAPH_CLIENT_ID=
+# MARGINCE_GRAPH_CLIENT_SECRET=
+# MARGINCE_GRAPH_TENANT=common
 
 # [optional — unset: the OAuth connect flow refuses] HMAC key (>=32 bytes)
 # signing the connect `state`, which is the session-less callback's only auth.
@@ -88,43 +118,64 @@ MARGINCE_DSN=postgres://margince_app:margince_app_dev@localhost:55432/margince
 # are both set — a Graph-only local setup has to set this itself.
 # MARGINCE_CONNECTOR_STATE_KEY=
 
-# ── External addressing ──────────────────────────────────────────────────────
-
-# [optional — unset: a marketing send refuses rather than derive the
-# token-bearing link from the request Host] Canonical external scheme+host for
-# buyer-facing links (RFC 8058 unsubscribe / preference center).
-# MARGINCE_PUBLIC_BASE_URL=https://crm.example.com
+# [optional — unset: /webhooks/hubspot is not mounted at all] The HubSpot app
+# client secret; verifies inbound overlay-webhook v3 signatures. Absent, the
+# route is missing rather than present-and-unverified.
+# MARGINCE_HUBSPOT_APP_SECRET=
 
 # [optional — defaults to MARGINCE_PUBLIC_BASE_URL] The api's externally
 # reachable base for the OAuth callback redirect_uri. Set it only when api and
 # SPA are on different origins — `make dev` is one (api on :8080).
 # MARGINCE_API_BASE_URL=
 
-# ── Object storage (attachments, company logos) ──────────────────────────────
+# ═══ Object storage (attachments, company logos) ══════════════════════════════
 
 # [optional — unset: /attachments answers 501, /readyz drops the blobstore
 # probe, and every company renders its monogram instead of a logo] S3-compatible
 # store, read by api and worker; the bucket is created on first connect.
-# `make dev` sets all four as command-prefix assignments — MinIO on
+# `make dev` sets these as command-prefix assignments — MinIO on
 # localhost:59000, bucket margince-dev — which OVERRIDE anything set here.
-# MARGINCE_BLOBSTORE_ENDPOINT=localhost:59000
-# MARGINCE_BLOBSTORE_ACCESS_KEY=minioadmin
-# MARGINCE_BLOBSTORE_SECRET_KEY=minioadmin
+# MARGINCE_BLOBSTORE_ENDPOINT=s3.eu-central-1.amazonaws.com
+# MARGINCE_BLOBSTORE_ACCESS_KEY=
+# MARGINCE_BLOBSTORE_SECRET_KEY=
 # MARGINCE_BLOBSTORE_BUCKET=margince
+# MARGINCE_BLOBSTORE_REGION=us-east-1
 # TLS is OPT-IN: unset means plain HTTP, which puts the two keys above on the
 # wire. Fine for the local MinIO, not for anything else.
-# MARGINCE_BLOBSTORE_USE_SSL=false
+# MARGINCE_BLOBSTORE_USE_SSL=true
 
-# ── Posture and overlay ──────────────────────────────────────────────────────
+# ═══ Deployments only — the container entrypoint reads these ═════════════════
+# See docs/deployment.md; scripts/deploy/api-entrypoint.sh is what consumes them.
+
+# [required in a deployment] Postgres DSN, the OWNER role. The api entrypoint
+# refuses to boot without it: it runs the migrations and backs the
+# custom-fields DDL pool. Never the app role, and never the same credential you
+# put in MARGINCE_DSN.
+# MARGINCE_OWNER_DSN=postgres://margince_owner:CHANGE_ME@db.internal:5432/margince
+
+# [required on the FIRST boot of an empty database] The bootstrap admin
+# password. The entrypoint writes it to the file margince.yaml references
+# (default /app/secrets/admin-password); MARGINCE_ADMIN_PASSWORD_FILE overrides
+# that path. After the first boot neither is needed — rotate through the app.
+# MARGINCE_ADMIN_PASSWORD=
+# MARGINCE_ADMIN_PASSWORD_FILE=/app/secrets/admin-password
+
+# [optional — unset: the worker serves no HTTP at all] Address for the WORKER's
+# own /healthz, /readyz and /metrics. The api serves those on its main port
+# regardless; the worker is silent until you give it an address. Bind it
+# somewhere only your scraper reaches.
+# MARGINCE_OBSERVE_ADDR=127.0.0.1:9101
+
+# ═══ Non-production only ═════════════════════════════════════════════════════
 
 # [optional — unset: production posture, which disables every dev-only
 # destructive switch] `dev`, `staging` or `test` ENABLES those switches — today
 # POST /v1/admin/reset-data, which purges the installation's tenant data back to
-# first-boot state. Read that before setting this on any box holding data you
+# first-boot state. Read that before setting it on any box holding data you
 # want: a staging environment seeded from a production copy is exactly where
 # this costs something. Fail-closed on parse: only those three values are
 # non-production, and anything else — including a typo — is production. The
-# Makefiles export dev; production must not set it.
+# Makefiles export dev; a production deployment must not set it at all.
 # MARGINCE_ENV=dev
 
 # [optional — unset or 0: uncapped] Cap the INITIAL overlay mirror backfill at N

--- a/backend/envcontract_test.go
+++ b/backend/envcontract_test.go
@@ -10,16 +10,16 @@ package backendarch
 //     docs/reference/configuration.md — the table of record for the binaries;
 //  2. every MARGINCE_* var .env.template names is still part of the product;
 //  3. every MARGINCE_* var configuration.md names is still part of the product;
-//  4. every MARGINCE_* var a deploy entrypoint HARD-REQUIRES is named in
+//  4. every MARGINCE_* var a deploy entrypoint hard-requires is named in
 //     .env.template — that file is the annotated template docs/deployment.md
 //     hands an operator, so a var the container refuses to boot without must
 //     not be discoverable only by reading the entrypoint script.
 //
-// Unstated, all three files drift apart: the template advertises credentials
-// for a process role that no longer exists, a secret an operator must
-// provision goes documented nowhere, and the table of record keeps a row for a
-// var nothing reads. Each failure is invisible until someone fills in a blank
-// and waits for an effect that can never arrive.
+// Unasserted, the three files drift apart: the template names credentials for a
+// process role that no longer exists, a secret an operator must provision goes
+// undocumented, and the reference doc keeps a row for a variable nothing reads.
+// None of those is visible at the point of failure — an operator supplies a
+// value and observes no effect, or looks for a variable and does not find it.
 //
 // What these gates do NOT cover, stated rather than implied:
 //
@@ -34,9 +34,10 @@ package backendarch
 //     env-shaped literal would match unrelated constants and trade a sharp
 //     gate for a noisy one.
 //   - Whole literals only. A name assembled at run time ("MARGINCE_" + provider
-//     + "_KEY") is invisible to every obligation here. None exists today, which
-//     is when the caveat is cheap to write down.
-//   - Presence, not truth. A var being NAMED in a document does not make the
+//     + "_KEY") is invisible to every obligation here. No such name exists in
+//     the tree today; the caveat is recorded so that adding one is a deliberate
+//     act rather than a silent gap.
+//   - Presence, not truth. A var being named in a document does not make the
 //     prose around it accurate, and .env.template now carries denser
 //     behavioural claims than the reference doc does. These gates stop a var
 //     disappearing; they cannot stop a description going stale.
@@ -72,10 +73,10 @@ const (
 
 // deploySurfaceRoots are the non-Go trees that configure a deployment: the
 // entrypoints and helper scripts, the compose/CI definitions, and the images.
-// A var read only here (MARGINCE_OWNER_DSN, hard-required by
-// scripts/deploy/api-entrypoint.sh, is the live example) is as real as one Go
-// reads, so obligations 2 and 3 must accept it — otherwise this file would
-// order a developer to delete the very var a container refuses to boot without.
+// A variable read only here is as real as one Go reads, so obligations 2 and 3
+// must accept it. MARGINCE_OWNER_DSN is the current example: it is required by
+// scripts/deploy/api-entrypoint.sh, and a Go-only definition of "live" would
+// report it as dead in a file whose purpose is to offer it to an operator.
 var deploySurfaceRoots = []string{"../scripts", "../infra", "../.github/workflows"}
 
 // walkTextFiles reads every file under root and hands each to visit. The trees
@@ -130,12 +131,12 @@ func envVarsReadByGoCode(t *testing.T) map[string]string {
 }
 
 // liveEnvVars is every MARGINCE_* name the product still mentions anywhere it
-// configures itself: Go literals plus the deploy surface. Deliberately
-// over-inclusive — a script that SETS a var for a child process counts the same
-// as one that reads it. That costs nothing here, because this set only ever
-// permits a name to appear in a document; requiring documentation is obligation
-// 1's job, and that one stays Go-only precisely because it cannot afford the
-// same fuzziness.
+// configures itself: Go literals plus the deploy surface. The set is
+// intentionally over-inclusive — a script that sets a variable for a child
+// process is counted the same as one that reads it — because it is only ever
+// used to permit a name to appear in a document. Obligation 1, which requires
+// documentation, stays Go-only for the opposite reason: there the same
+// imprecision would demand rows for variables no operator configures.
 func liveEnvVars(t *testing.T) map[string]string {
 	t.Helper()
 	live := envVarsReadByGoCode(t)
@@ -207,9 +208,9 @@ func TestEveryEnvVarIsDocumented(t *testing.T) {
 	}
 }
 
-// TestEnvTemplateNamesOnlyLiveVars: a template entry for a var nothing reads is
-// worse than absent — someone fills it in and waits for an effect that can
-// never arrive.
+// TestEnvTemplateNamesOnlyLiveVars: an entry for a variable nothing reads is
+// worse than no entry at all, because it invites an operator to supply a value
+// that cannot take effect.
 func TestEnvTemplateNamesOnlyLiveVars(t *testing.T) {
 	assertNamesOnlyLiveVars(t, envTemplate)
 }
@@ -223,9 +224,9 @@ func TestConfigurationDocNamesOnlyLiveVars(t *testing.T) {
 
 // entrypointRequired matches the shell form that makes a var mandatory:
 // `: "${MARGINCE_FOO:?message}"` aborts the entrypoint when FOO is unset. The
-// `:-default` form is deliberately NOT matched — a var with a fallback is not
-// something an operator must supply, so requiring it in the template would
-// pull the whole deploy surface in and drown the signal.
+// `:-default` form is deliberately not matched: a variable with a fallback is
+// not one an operator must supply, and requiring those in the template would
+// admit most of the deploy surface and leave the label meaningless.
 var entrypointRequired = regexp.MustCompile(`\$\{(MARGINCE_[A-Z0-9_]+):\?`)
 
 // TestEntrypointRequiredVarsAreInTheTemplate: a var the container refuses to

--- a/backend/envcontract_test.go
+++ b/backend/envcontract_test.go
@@ -3,13 +3,17 @@
 
 package backendarch
 
-// Environment-variable contract fitness functions. Three obligations, all
+// Environment-variable contract fitness functions. Four obligations, all
 // derived from the tree rather than a maintained list:
 //
 //  1. every MARGINCE_* var the Go code reads is named in
 //     docs/reference/configuration.md — the table of record for the binaries;
 //  2. every MARGINCE_* var .env.template names is still part of the product;
-//  3. every MARGINCE_* var configuration.md names is still part of the product.
+//  3. every MARGINCE_* var configuration.md names is still part of the product;
+//  4. every MARGINCE_* var a deploy entrypoint HARD-REQUIRES is named in
+//     .env.template — that file is the annotated template docs/deployment.md
+//     hands an operator, so a var the container refuses to boot without must
+//     not be discoverable only by reading the entrypoint script.
 //
 // Unstated, all three files drift apart: the template advertises credentials
 // for a process role that no longer exists, a secret an operator must
@@ -215,6 +219,44 @@ func TestEnvTemplateNamesOnlyLiveVars(t *testing.T) {
 // the one free to keep a row for a var that no longer exists.
 func TestConfigurationDocNamesOnlyLiveVars(t *testing.T) {
 	assertNamesOnlyLiveVars(t, configurationDoc)
+}
+
+// entrypointRequired matches the shell form that makes a var mandatory:
+// `: "${MARGINCE_FOO:?message}"` aborts the entrypoint when FOO is unset. The
+// `:-default` form is deliberately NOT matched — a var with a fallback is not
+// something an operator must supply, so requiring it in the template would
+// pull the whole deploy surface in and drown the signal.
+var entrypointRequired = regexp.MustCompile(`\$\{(MARGINCE_[A-Z0-9_]+):\?`)
+
+// TestEntrypointRequiredVarsAreInTheTemplate: a var the container refuses to
+// boot without belongs in the file an operator is handed, not only in the
+// script that rejects them. docs/deployment.md names .env.template as that
+// file, which is what makes this an obligation rather than a nicety.
+func TestEntrypointRequiredVarsAreInTheTemplate(t *testing.T) {
+	offered := namesIn(t, envTemplate)
+
+	required := map[string]string{}
+	walkTextFiles(t, "../scripts/deploy", func(path, text string) {
+		for _, m := range entrypointRequired.FindAllStringSubmatch(text, -1) {
+			if _, seen := required[m[1]]; !seen {
+				required[m[1]] = path
+			}
+		}
+	})
+	if len(required) == 0 {
+		t.Fatal("no `${MARGINCE_…:?}` requirement found under ../scripts/deploy — a sweep that scans nothing passes exactly like a clean one")
+	}
+
+	var missing []string
+	for _, name := range slices.Sorted(maps.Keys(required)) {
+		if !offered[name] {
+			missing = append(missing, name+" (required by "+required[name]+")")
+		}
+	}
+	if len(missing) > 0 {
+		t.Errorf("%d var(s) a deploy entrypoint refuses to boot without, absent from %s — add them, commented, with the value shape an operator must replace:\n\t%s",
+			len(missing), envTemplate, strings.Join(missing, "\n\t"))
+	}
 }
 
 func assertNamesOnlyLiveVars(t *testing.T, path string) {

--- a/backend/envcontract_test.go
+++ b/backend/envcontract_test.go
@@ -3,48 +3,62 @@
 
 package backendarch
 
-// Environment-variable contract fitness functions. Two obligations, both
+// Environment-variable contract fitness functions. Three obligations, all
 // derived from the tree rather than a maintained list:
 //
 //  1. every MARGINCE_* var the Go code reads is named in
-//     docs/reference/configuration.md — the table of record;
-//  2. every MARGINCE_* var .env.template names is still read by Go code.
+//     docs/reference/configuration.md — the table of record for the binaries;
+//  2. every MARGINCE_* var .env.template names is still part of the product;
+//  3. every MARGINCE_* var configuration.md names is still part of the product.
 //
-// Without these, both files drift freely and did: the template accumulated
-// vars for a retired process role while a dozen live vars — including two
-// secrets an operator must provision — were documented nowhere.
+// Unstated, all three files drift apart: the template advertises credentials
+// for a process role that no longer exists, a secret an operator must
+// provision goes documented nowhere, and the table of record keeps a row for a
+// var nothing reads. Each failure is invisible until someone fills in a blank
+// and waits for an effect that can never arrive.
 //
 // What these gates do NOT cover, stated rather than implied:
 //
-//   - Go readers only. MARGINCE_OWNER_DSN and MARGINCE_ADMIN_PASSWORD[_FILE]
-//     are read by deploy shell and compose, so nothing here constrains them.
+//   - Obligation 1 covers Go readers, in the licensed trees only. A var read
+//     solely by deploy shell or a workflow is documented in docs/deployment.md
+//     by hand, and cli/craft is a module of its own that no sweep here walks.
+//     Obligations 2 and 3 do count those non-Go readers, because there the
+//     question is merely whether a name is still real.
 //   - MARGINCE_-prefixed names only. The BYOK keys (GEMINI_API_KEY,
 //     OPENAI_API_KEY, ANTHROPIC_API_KEY, OPENAI_COMPATIBLE_API_KEY) carry
 //     provider-conventional names and are ungated. Widening the pattern to any
 //     env-shaped literal would match unrelated constants and trade a sharp
 //     gate for a noisy one.
-//   - Presence, not truth. A var being NAMED in configuration.md does not make
-//     the prose around it accurate. These gates stop a var disappearing from
-//     the docs, not a description going stale; no test can gate prose.
+//   - Whole literals only. A name assembled at run time ("MARGINCE_" + provider
+//     + "_KEY") is invisible to every obligation here. None exists today, which
+//     is when the caveat is cheap to write down.
+//   - Presence, not truth. A var being NAMED in a document does not make the
+//     prose around it accurate, and .env.template now carries denser
+//     behavioural claims than the reference doc does. These gates stop a var
+//     disappearing; they cannot stop a description going stale.
 
 import (
 	"io/fs"
+	"maps"
 	"os"
 	"path/filepath"
 	"regexp"
-	"sort"
+	"slices"
 	"strings"
 	"testing"
 )
 
-// envVarName matches one MARGINCE_* name. Applied to Go sources it is
-// deliberately anchored on the surrounding double quotes: the vars are read
-// through four wrapper helpers as well as os.Getenv (envOr, envIntOr,
-// envDuration, envDurationOr in cmd/api and cmd/worker), so keying on the call
-// would miss them — while keying on unquoted text would harvest `MARGINCE_X_*`
-// globs out of comments and invent vars that do not exist.
+// envVarName matches one MARGINCE_* name in prose — the reference doc and the
+// template, where names appear unquoted. Applied to those files it is why
+// .env.template may not write a `MARGINCE_FOO_*` glob: the glob yields the name
+// `MARGINCE_FOO_`, which nothing reads.
 var envVarName = regexp.MustCompile(`MARGINCE_[A-Z0-9_]+`)
 
+// quotedEnvVarName matches one MARGINCE_* name as a Go string literal. Keying
+// on the literal rather than on os.Getenv is what makes the Go sweep complete:
+// the vars are also read through four wrapper helpers in cmd/api and cmd/worker
+// (envOr, envIntOr, envDuration, envDurationOr). Keying on unquoted text
+// instead would harvest globs out of comments and invent vars that do not exist.
 var quotedEnvVarName = regexp.MustCompile(`"(MARGINCE_[A-Z0-9_]+)"`)
 
 const (
@@ -52,39 +66,58 @@ const (
 	envTemplate      = "../.env.template"
 )
 
-// envVarsReadByGoCode collects every MARGINCE_* name appearing as a string
-// literal in hand-written Go across the same trees the license sweep covers
+// deploySurfaceRoots are the non-Go trees that configure a deployment: the
+// entrypoints and helper scripts, the compose/CI definitions, and the images.
+// A var read only here (MARGINCE_OWNER_DSN, hard-required by
+// scripts/deploy/api-entrypoint.sh, is the live example) is as real as one Go
+// reads, so obligations 2 and 3 must accept it — otherwise this file would
+// order a developer to delete the very var a container refuses to boot without.
+var deploySurfaceRoots = []string{"../scripts", "../infra", "../.github/workflows"}
+
+// walkTextFiles reads every file under root and hands each to visit. The trees
+// swept here are small and text-only; a read error fails the test rather than
+// narrowing the sweep in silence.
+func walkTextFiles(t *testing.T, root string, visit func(path, text string)) {
+	t.Helper()
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		b, err := os.ReadFile(path) // #nosec G304 G122 -- path comes from walking a fixed root inside the trusted source tree
+		if err != nil {
+			return err
+		}
+		visit(filepath.ToSlash(path), string(b))
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking %s: %v", root, err)
+	}
+}
+
+// envVarsReadByGoCode maps each MARGINCE_* name a Go string literal spells to
+// the first file spelling it. The trees are the ones the license sweep covers
 // (licensedTrees, license_test.go): extensions/ and fixtures/ are separate
 // modules a `./...` from here never reaches, and a var a unit reads is as real
 // as one the backend reads. Sharing that list means a new tree enrolls in both
 // gates at once instead of silently in only one.
-func envVarsReadByGoCode(t *testing.T) map[string][]string {
+func envVarsReadByGoCode(t *testing.T) map[string]string {
 	t.Helper()
-	sites := map[string][]string{}
+	sites := map[string]string{}
 	for _, tree := range licensedTrees {
-		err := filepath.WalkDir(tree.root, func(path string, d fs.DirEntry, err error) error {
-			if err != nil {
-				return err
-			}
-			if d.IsDir() || !strings.HasSuffix(path, ".go") {
-				return nil
-			}
-			b, err := os.ReadFile(path) // #nosec G304 G122 -- path is a *.go file from walking the trusted source tree
-			if err != nil {
-				return err
-			}
-			text := string(b)
-			if isGenerated(path, text) {
-				return nil
+		walkTextFiles(t, tree.root, func(path, text string) {
+			if !strings.HasSuffix(path, ".go") || isGenerated(path, text) {
+				return
 			}
 			for _, m := range quotedEnvVarName.FindAllStringSubmatch(text, -1) {
-				sites[m[1]] = append(sites[m[1]], filepath.ToSlash(path))
+				if _, seen := sites[m[1]]; !seen {
+					sites[m[1]] = path
+				}
 			}
-			return nil
 		})
-		if err != nil {
-			t.Fatalf("walking %s: %v", tree.root, err)
-		}
 	}
 	if len(sites) == 0 {
 		t.Fatal("no MARGINCE_* env var found in any Go tree — a sweep that scans nothing passes exactly like a clean one")
@@ -92,13 +125,49 @@ func envVarsReadByGoCode(t *testing.T) map[string][]string {
 	return sites
 }
 
-// namesIn reads a documentation or template file and returns the set of
-// MARGINCE_* names it spells out. Matching whole names rather than searching
-// for substrings is what makes the gate exact in both directions: a doc that
-// mentions only MARGINCE_AICERT_MODEL must not be read as covering the
-// separate MARGINCE_AICERT, and an abbreviation like `MARGINCE_GMAIL_CLIENT_ID`
-// / `…_SECRET` covers only the name it actually writes out. A variable name a
-// reader cannot grep for is a variable name that is not documented.
+// liveEnvVars is every MARGINCE_* name the product still mentions anywhere it
+// configures itself: Go literals plus the deploy surface. Deliberately
+// over-inclusive — a script that SETS a var for a child process counts the same
+// as one that reads it. That costs nothing here, because this set only ever
+// permits a name to appear in a document; requiring documentation is obligation
+// 1's job, and that one stays Go-only precisely because it cannot afford the
+// same fuzziness.
+func liveEnvVars(t *testing.T) map[string]string {
+	t.Helper()
+	live := envVarsReadByGoCode(t)
+	for _, root := range deploySurfaceRoots {
+		walkTextFiles(t, root, func(path, text string) {
+			for _, name := range envVarName.FindAllString(text, -1) {
+				if _, seen := live[name]; !seen {
+					live[name] = path
+				}
+			}
+		})
+	}
+	images, err := filepath.Glob("../Dockerfile*")
+	if err != nil {
+		t.Fatalf("globbing Dockerfiles: %v", err)
+	}
+	for _, path := range images {
+		b, err := os.ReadFile(path) // #nosec G304 -- path comes from a fixed glob in the trusted source tree
+		if err != nil {
+			t.Fatalf("reading %s: %v", path, err)
+		}
+		for _, name := range envVarName.FindAllString(string(b), -1) {
+			if _, seen := live[name]; !seen {
+				live[name] = filepath.ToSlash(path)
+			}
+		}
+	}
+	return live
+}
+
+// namesIn returns the set of MARGINCE_* names a document spells out. Matching
+// whole names rather than searching for substrings is what makes the gates
+// exact in both directions: a doc mentioning only MARGINCE_AICERT_MODEL must
+// not be read as covering the separate MARGINCE_AICERT, and an abbreviation
+// like `MARGINCE_GMAIL_CLIENT_ID` / `…_SECRET` covers only the name it actually
+// writes out. A variable name a reader cannot grep for is not documented.
 func namesIn(t *testing.T, path string) map[string]bool {
 	t.Helper()
 	b, err := os.ReadFile(path) // #nosec G304 -- fixed path in the trusted source tree
@@ -115,54 +184,52 @@ func namesIn(t *testing.T, path string) map[string]bool {
 	return names
 }
 
-func sortedKeys(m map[string][]string) []string {
-	out := make([]string, 0, len(m))
-	for k := range m {
-		out = append(out, k)
-	}
-	sort.Strings(out)
-	return out
-}
-
-// TestEveryEnvVarIsDocumented: shipping a var the reference doc has never
-// heard of leaves an operator guessing, and a secret nobody wrote down cannot
-// be provisioned at all.
+// TestEveryEnvVarIsDocumented: shipping a var the reference doc has never heard
+// of leaves an operator guessing, and a secret nobody wrote down cannot be
+// provisioned at all.
 func TestEveryEnvVarIsDocumented(t *testing.T) {
 	documented := namesIn(t, configurationDoc)
 	sites := envVarsReadByGoCode(t)
 
 	var undocumented []string
-	for _, name := range sortedKeys(sites) {
+	for _, name := range slices.Sorted(maps.Keys(sites)) {
 		if !documented[name] {
-			undocumented = append(undocumented, name+" (read in "+sites[name][0]+")")
+			undocumented = append(undocumented, name+" (read in "+sites[name]+")")
 		}
 	}
 	if len(undocumented) > 0 {
-		t.Errorf("%d env var(s) read by Go code but not named in %s — add a row there (spell the name out in full; an abbreviated suffix does not count):\n\t%s",
+		t.Errorf("%d env var(s) read by Go code but not named in %s — add a row there, spelling the name out in full (an abbreviated suffix like `…_SECRET` does not count):\n\t%s",
 			len(undocumented), configurationDoc, strings.Join(undocumented, "\n\t"))
 	}
 }
 
-// TestEnvTemplateNamesOnlyLiveVars: a template entry for a var no code reads
-// is worse than absent — someone fills it in and waits for an effect that can
-// never arrive. This is how the template kept advertising a retired process
-// role's credentials.
-//
-// It also means .env.template must not write `MARGINCE_FOO_*` globs: the glob
-// yields the name `MARGINCE_FOO_`, which no code reads. Spell the vars out —
-// the template is meant to be copied, and a glob cannot be.
+// TestEnvTemplateNamesOnlyLiveVars: a template entry for a var nothing reads is
+// worse than absent — someone fills it in and waits for an effect that can
+// never arrive.
 func TestEnvTemplateNamesOnlyLiveVars(t *testing.T) {
-	sites := envVarsReadByGoCode(t)
+	assertNamesOnlyLiveVars(t, envTemplate)
+}
+
+// TestConfigurationDocNamesOnlyLiveVars holds the table of record to the same
+// bar as the template it now absorbs. Without it the more authoritative file is
+// the one free to keep a row for a var that no longer exists.
+func TestConfigurationDocNamesOnlyLiveVars(t *testing.T) {
+	assertNamesOnlyLiveVars(t, configurationDoc)
+}
+
+func assertNamesOnlyLiveVars(t *testing.T, path string) {
+	t.Helper()
+	live := liveEnvVars(t)
 
 	var dead []string
-	for name := range namesIn(t, envTemplate) {
-		if sites[name] == nil {
+	for name := range namesIn(t, path) {
+		if _, ok := live[name]; !ok {
 			dead = append(dead, name)
 		}
 	}
-	sort.Strings(dead)
+	slices.Sort(dead)
 	if len(dead) > 0 {
-		t.Errorf("%d var(s) named in %s that no Go code reads — delete them (or spell out a glob):\n\t%s",
-			len(dead), envTemplate, strings.Join(dead, "\n\t"))
+		t.Errorf("%d var(s) named in %s that nothing in the product reads — delete them. A `MARGINCE_FOO_*` glob counts as the name `MARGINCE_FOO_`, which nothing reads: spell such vars out instead of globbing them:\n\t%s",
+			len(dead), path, strings.Join(dead, "\n\t"))
 	}
 }

--- a/backend/envcontract_test.go
+++ b/backend/envcontract_test.go
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package backendarch
+
+// Environment-variable contract fitness functions. Two obligations, both
+// derived from the tree rather than a maintained list:
+//
+//  1. every MARGINCE_* var the Go code reads is named in
+//     docs/reference/configuration.md — the table of record;
+//  2. every MARGINCE_* var .env.template names is still read by Go code.
+//
+// Without these, both files drift freely and did: the template accumulated
+// vars for a retired process role while a dozen live vars — including two
+// secrets an operator must provision — were documented nowhere.
+//
+// What these gates do NOT cover, stated rather than implied:
+//
+//   - Go readers only. MARGINCE_OWNER_DSN and MARGINCE_ADMIN_PASSWORD[_FILE]
+//     are read by deploy shell and compose, so nothing here constrains them.
+//   - MARGINCE_-prefixed names only. The BYOK keys (GEMINI_API_KEY,
+//     OPENAI_API_KEY, ANTHROPIC_API_KEY, OPENAI_COMPATIBLE_API_KEY) carry
+//     provider-conventional names and are ungated. Widening the pattern to any
+//     env-shaped literal would match unrelated constants and trade a sharp
+//     gate for a noisy one.
+//   - Presence, not truth. A var being NAMED in configuration.md does not make
+//     the prose around it accurate. These gates stop a var disappearing from
+//     the docs, not a description going stale; no test can gate prose.
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// envVarName matches one MARGINCE_* name. Applied to Go sources it is
+// deliberately anchored on the surrounding double quotes: the vars are read
+// through four wrapper helpers as well as os.Getenv (envOr, envIntOr,
+// envDuration, envDurationOr in cmd/api and cmd/worker), so keying on the call
+// would miss them — while keying on unquoted text would harvest `MARGINCE_X_*`
+// globs out of comments and invent vars that do not exist.
+var envVarName = regexp.MustCompile(`MARGINCE_[A-Z0-9_]+`)
+
+var quotedEnvVarName = regexp.MustCompile(`"(MARGINCE_[A-Z0-9_]+)"`)
+
+const (
+	configurationDoc = "../docs/reference/configuration.md"
+	envTemplate      = "../.env.template"
+)
+
+// envVarsReadByGoCode collects every MARGINCE_* name appearing as a string
+// literal in hand-written Go across the same trees the license sweep covers
+// (licensedTrees, license_test.go): extensions/ and fixtures/ are separate
+// modules a `./...` from here never reaches, and a var a unit reads is as real
+// as one the backend reads. Sharing that list means a new tree enrolls in both
+// gates at once instead of silently in only one.
+func envVarsReadByGoCode(t *testing.T) map[string][]string {
+	t.Helper()
+	sites := map[string][]string{}
+	for _, tree := range licensedTrees {
+		err := filepath.WalkDir(tree.root, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() || !strings.HasSuffix(path, ".go") {
+				return nil
+			}
+			b, err := os.ReadFile(path) // #nosec G304 G122 -- path is a *.go file from walking the trusted source tree
+			if err != nil {
+				return err
+			}
+			text := string(b)
+			if isGenerated(path, text) {
+				return nil
+			}
+			for _, m := range quotedEnvVarName.FindAllStringSubmatch(text, -1) {
+				sites[m[1]] = append(sites[m[1]], filepath.ToSlash(path))
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walking %s: %v", tree.root, err)
+		}
+	}
+	if len(sites) == 0 {
+		t.Fatal("no MARGINCE_* env var found in any Go tree — a sweep that scans nothing passes exactly like a clean one")
+	}
+	return sites
+}
+
+// namesIn reads a documentation or template file and returns the set of
+// MARGINCE_* names it spells out. Matching whole names rather than searching
+// for substrings is what makes the gate exact in both directions: a doc that
+// mentions only MARGINCE_AICERT_MODEL must not be read as covering the
+// separate MARGINCE_AICERT, and an abbreviation like `MARGINCE_GMAIL_CLIENT_ID`
+// / `…_SECRET` covers only the name it actually writes out. A variable name a
+// reader cannot grep for is a variable name that is not documented.
+func namesIn(t *testing.T, path string) map[string]bool {
+	t.Helper()
+	b, err := os.ReadFile(path) // #nosec G304 -- fixed path in the trusted source tree
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	names := map[string]bool{}
+	for _, name := range envVarName.FindAllString(string(b), -1) {
+		names[name] = true
+	}
+	if len(names) == 0 {
+		t.Fatalf("%s names no MARGINCE_* var at all — a file that documents nothing cannot be the table of record", path)
+	}
+	return names
+}
+
+func sortedKeys(m map[string][]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestEveryEnvVarIsDocumented: shipping a var the reference doc has never
+// heard of leaves an operator guessing, and a secret nobody wrote down cannot
+// be provisioned at all.
+func TestEveryEnvVarIsDocumented(t *testing.T) {
+	documented := namesIn(t, configurationDoc)
+	sites := envVarsReadByGoCode(t)
+
+	var undocumented []string
+	for _, name := range sortedKeys(sites) {
+		if !documented[name] {
+			undocumented = append(undocumented, name+" (read in "+sites[name][0]+")")
+		}
+	}
+	if len(undocumented) > 0 {
+		t.Errorf("%d env var(s) read by Go code but not named in %s — add a row there (spell the name out in full; an abbreviated suffix does not count):\n\t%s",
+			len(undocumented), configurationDoc, strings.Join(undocumented, "\n\t"))
+	}
+}
+
+// TestEnvTemplateNamesOnlyLiveVars: a template entry for a var no code reads
+// is worse than absent — someone fills it in and waits for an effect that can
+// never arrive. This is how the template kept advertising a retired process
+// role's credentials.
+//
+// It also means .env.template must not write `MARGINCE_FOO_*` globs: the glob
+// yields the name `MARGINCE_FOO_`, which no code reads. Spell the vars out —
+// the template is meant to be copied, and a glob cannot be.
+func TestEnvTemplateNamesOnlyLiveVars(t *testing.T) {
+	sites := envVarsReadByGoCode(t)
+
+	var dead []string
+	for name := range namesIn(t, envTemplate) {
+		if sites[name] == nil {
+			dead = append(dead, name)
+		}
+	}
+	sort.Strings(dead)
+	if len(dead) > 0 {
+		t.Errorf("%d var(s) named in %s that no Go code reads — delete them (or spell out a glob):\n\t%s",
+			len(dead), envTemplate, strings.Join(dead, "\n\t"))
+	}
+}

--- a/backend/envcontract_test.go
+++ b/backend/envcontract_test.go
@@ -33,10 +33,12 @@ package backendarch
 //     provider-conventional names and are ungated. Widening the pattern to any
 //     env-shaped literal would match unrelated constants and trade a sharp
 //     gate for a noisy one.
-//   - Whole literals only. A name assembled at run time ("MARGINCE_" + provider
-//     + "_KEY") is invisible to every obligation here. No such name exists in
-//     the tree today; the caveat is recorded so that adding one is a deliberate
-//     act rather than a silent gap.
+//   - Whole double-quoted literals only. A name assembled at run time
+//     ("MARGINCE_" + provider + "_KEY"), or written as a backquoted raw string,
+//     is invisible to every obligation here. Neither appears in the tree today
+//     — every backquoted occurrence is prose in a comment or an error message —
+//     and the caveat is recorded so that adding one is a deliberate act rather
+//     than a silent gap.
 //   - Presence, not truth. A var being named in a document does not make the
 //     prose around it accurate, and .env.template now carries denser
 //     behavioural claims than the reference doc does. These gates stop a var
@@ -222,12 +224,19 @@ func TestConfigurationDocNamesOnlyLiveVars(t *testing.T) {
 	assertNamesOnlyLiveVars(t, configurationDoc)
 }
 
-// entrypointRequired matches the shell form that makes a var mandatory:
-// `: "${MARGINCE_FOO:?message}"` aborts the entrypoint when FOO is unset. The
-// `:-default` form is deliberately not matched: a variable with a fallback is
-// not one an operator must supply, and requiring those in the template would
-// admit most of the deploy surface and leave the label meaningless.
-var entrypointRequired = regexp.MustCompile(`\$\{(MARGINCE_[A-Z0-9_]+):\?`)
+// entrypointRequired matches the parameter-expansion forms that abort a script
+// on an unset variable: `${FOO:?msg}` and the colonless `${FOO?msg}`, which
+// differ only in whether an empty value also aborts. The `:-default` form is
+// deliberately not matched — a variable with a fallback is not one an operator
+// must supply, and requiring those would admit most of the deploy surface and
+// leave the label meaningless.
+//
+// Only these two forms are detected. A script can also make a variable
+// mandatory with an explicit guard (`[ -z "$FOO" ] && exit 1`) or by relying on
+// `set -u`, and obligation 4 would not see either. Neither appears in
+// scripts/deploy today; the limit is recorded so the gate is not read as
+// proving more than it does.
+var entrypointRequired = regexp.MustCompile(`\$\{(MARGINCE_[A-Z0-9_]+):?\?`)
 
 // TestEntrypointRequiredVarsAreInTheTemplate: a var the container refuses to
 // boot without belongs in the file an operator is handed, not only in the

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -28,6 +28,7 @@ configurable logger.
 | `--redis` | `MARGINCE_REDIS` | `localhost:56379` | Redis address (event bus) |
 | `--inline-relay` | — | `true` | run the outbox relay in-process; set `false` when `cmd/worker` runs it |
 | `--webhook-key` | `MARGINCE_WEBHOOK_KEY` | — | base64 32-byte key sealing outbound-webhook signing secrets at rest; unset = the mutating `/webhook-subscriptions` paths (create/rotate, replay) answer 503, never an unsigned fallback; the read surface still lists |
+| `--metrics-token` | `MARGINCE_METRICS_TOKEN` | — | shared secret `/metrics` requires as a Bearer credential. This is the access control the fleet-wide-exposition note below calls for: unset (the default) `/metrics` answers **404**, rather than serving per-workspace job telemetry to anyone who asks. Set it wherever the scraper can present it |
 | `--hubspot-app-secret` | `MARGINCE_HUBSPOT_APP_SECRET` | — | the HubSpot app client secret. Verifies inbound overlay-webhook v3 signatures and, when set, mounts `/webhooks/hubspot`; unset, that route is absent rather than present-and-unverified |
 | `--ai-routing` | `MARGINCE_AI_ROUTING` | — | path to `ai-routing.yaml`; enables the cold-start read-back, per-org enrichment, the Morning-Brief L2 re-order, and AI-drafted offer regeneration |
 | `--ai-fake` | — | `false` | offline fake model (dev/test only); drives the same AI surfaces as `--ai-routing` |
@@ -50,7 +51,9 @@ Operational endpoints (served next to `/v1`):
 - `/metrics` — Prometheus text format: `margince_outbox_unpublished`,
   `margince_relay_published_total`, `margince_pgxpool_conns{state=…}`, the
   AI router's counters, the overlay sync-health section, and the
-  **job-runtime section** below.
+  **job-runtime section** below. Gated by `--metrics-token`: without one the
+  route answers 404, so a deployment that wants scraping must set the token and
+  give it to the scraper.
 - `GET /v1/admin/job-health` — the per-workspace read of the same job
   table, for an admin rather than a scrape. See
   [Reading the job surfaces](#reading-the-job-surfaces).

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -28,6 +28,7 @@ configurable logger.
 | `--redis` | `MARGINCE_REDIS` | `localhost:56379` | Redis address (event bus) |
 | `--inline-relay` | — | `true` | run the outbox relay in-process; set `false` when `cmd/worker` runs it |
 | `--webhook-key` | `MARGINCE_WEBHOOK_KEY` | — | base64 32-byte key sealing outbound-webhook signing secrets at rest; unset = the mutating `/webhook-subscriptions` paths (create/rotate, replay) answer 503, never an unsigned fallback; the read surface still lists |
+| `--hubspot-app-secret` | `MARGINCE_HUBSPOT_APP_SECRET` | — | the HubSpot app client secret. Verifies inbound overlay-webhook v3 signatures and, when set, mounts `/webhooks/hubspot`; unset, that route is absent rather than present-and-unverified |
 | `--ai-routing` | `MARGINCE_AI_ROUTING` | — | path to `ai-routing.yaml`; enables the cold-start read-back, per-org enrichment, the Morning-Brief L2 re-order, and AI-drafted offer regeneration |
 | `--ai-fake` | — | `false` | offline fake model (dev/test only); drives the same AI surfaces as `--ai-routing` |
 | `--public-base-url` | `MARGINCE_PUBLIC_BASE_URL` | — | canonical external scheme+host for buyer-facing links (RFC 8058 unsubscribe / preference center); required to send marketing mail — a send refuses rather than derive the token-bearing link from the request Host — and for the Gmail/Graph OAuth callback |
@@ -404,8 +405,8 @@ runs the background sync.
 
 | Flag | Env | Role | Meaning |
 |---|---|---|---|
-| `--gmail-client-id` / `--gmail-client-secret` | `MARGINCE_GMAIL_CLIENT_ID` / `…_SECRET` | api + worker | the Google OAuth app; with the state key and `--public-base-url`, enables `/connectors/gmail/*` (api) and the sync poll (worker) |
-| `--graph-client-id` / `--graph-client-secret` | `MARGINCE_GRAPH_CLIENT_ID` / `…_SECRET` | api + worker | the Microsoft (Entra) app; same enablement shape for `/connectors/graph/*` |
+| `--gmail-client-id` / `--gmail-client-secret` | `MARGINCE_GMAIL_CLIENT_ID` / `MARGINCE_GMAIL_CLIENT_SECRET` | api + worker | the Google OAuth app; with the state key and `--public-base-url`, enables `/connectors/gmail/*` (api) and the sync poll (worker) |
+| `--graph-client-id` / `--graph-client-secret` | `MARGINCE_GRAPH_CLIENT_ID` / `MARGINCE_GRAPH_CLIENT_SECRET` | api + worker | the Microsoft (Entra) app; same enablement shape for `/connectors/graph/*` |
 | `--graph-tenant` | `MARGINCE_GRAPH_TENANT` | api + worker | Microsoft identity tenant (default `common` — any organization) |
 | `--connector-state-key` | `MARGINCE_CONNECTOR_STATE_KEY` | api | HMAC key (≥32 bytes) signing the OAuth connect `state`; required for both connect flows |
 | `--api-base-url` | `MARGINCE_API_BASE_URL` | api | the api's externally-reachable base for the OAuth callback `redirect_uri`; defaults to `--public-base-url`, set only when api and SPA are on different origins (e.g. dev). Messaging channels need NO public address of their own — Telegram ingress long-polls, so nothing is ever told where to reach this installation |
@@ -413,7 +414,7 @@ runs the background sync.
 | `--gmail-pubsub-topic` | `MARGINCE_GMAIL_PUBSUB_TOPIC` | worker | Gmail Pub/Sub topic (`projects/<p>/topics/<t>`); enables the push-watch register+renew job (empty = poll only) |
 | `--gmail-watch-interval` / `--gmail-watch-renew-within` | — | worker | push-watch maintenance scan (`6h`) / renew this far ahead of the 7-day expiry (`48h`) |
 | `--gmail-push-token` | `MARGINCE_GMAIL_PUSH_TOKEN` | api | shared secret on the Pub/Sub push subscription URL; enables `POST /webhooks/gmail` (empty = route absent) |
-| `--gmail-push-audience` / `--gmail-push-service-account` | `MARGINCE_GMAIL_PUSH_AUDIENCE` / `…_SERVICE_ACCOUNT` | api | OIDC audience + signing service-account email; set both and the push webhook also verifies Google's OIDC token |
+| `--gmail-push-audience` / `--gmail-push-service-account` | `MARGINCE_GMAIL_PUSH_AUDIENCE` / `MARGINCE_GMAIL_PUSH_SERVICE_ACCOUNT` | api | OIDC audience + signing service-account email; set both and the push webhook also verifies Google's OIDC token |
 | `--gmail-jwks-url` | `MARGINCE_GMAIL_JWKS_URL` | api | override Google's OIDC JWKS URL; test/dev only |
 
 ## Object storage (api, worker) — attachments and company logos
@@ -506,6 +507,12 @@ migrate <recreate-db|drop-db|db-exists> --dsn <owner-maintenance-dsn> --name <db
 | `MARGINCE_ENV` | api (`runtimeenv.Parse`) | Read at boot and parsed **fail-closed**: only the exact values `dev`, `staging`, or `test` yield a non-production posture; unset, `production`, or any unrecognized value ⇒ production, which disables every dev-only destructive switch (today: the admin data-reset endpoint below). The Makefile exports `dev`; production must not set it. |
 | `MARGINCE_TEST_DSN`, `MARGINCE_TEST_APP_DSN`, `MARGINCE_TEST_REDIS` | integration tests | owner DSN / app-role DSN / Redis address for the real-Postgres lane; exported by the Makefile. The lane runs on its own `_test` namespace (the `margince_test` DB, never the dev `margince` DB), so it can run alongside `make dev`. |
 | `MARGINCE_TEST_REDIS_DB` | integration tests | Redis logical db for the lane (default 15). db 0 is reserved for a running `make dev`; a valid value is 1..15, and the parallel runner assigns one per package so concurrent packages never share a stream. Out-of-range fails loudly. |
+| `MARGINCE_TEST_BLOBSTORE_ENDPOINT`, `MARGINCE_TEST_BLOBSTORE_ACCESS_KEY`, `MARGINCE_TEST_BLOBSTORE_SECRET_KEY`, `MARGINCE_TEST_BLOBSTORE_BUCKET` | integration tests | the object store the blobstore lane runs against; exported by the Makefile at the `make db-up` MinIO, on its own `margince-test` bucket. The endpoint being unset **fails** the lane rather than skipping it — a skipped storage gate reads exactly like a passing one. |
+| `MARGINCE_AICERT` | `make e2e-ai` | the AI-certification lane's runtime switch. The `e2e_llm` build tag keeps this paid, live lane out of every ordinary lane; once the tag is set, an empty value here **fails** rather than skips, so the lane can never report success for having done nothing. |
+| `MARGINCE_AICERT_TASK`, `MARGINCE_AICERT_MODEL`, `MARGINCE_AICERT_RUNS`, `MARGINCE_AICERT_TRACE` | `make e2e-ai` | narrow certification to one task / override the candidate model / repeat count / directory for the request+response dump. All optional: unset certifies everything the corpus covers, on the routing file's own bindings. Surfaced as `TASK=`, `MODEL=`, `RUNS=`, `TRACE=` on the make target. |
+| `MARGINCE_ANTHROPIC_KEY` | `ai` package smoke test | BYOK Anthropic key for the live Anthropic smoke test. Distinct from `ANTHROPIC_API_KEY`, which is what the **runtime** reads for a bound `anthropic` provider. |
+| `MARGINCE_BENCH_TIER` | `make bench-perf` | the PERF-3/PERF-7 seed tier the perfbench suite builds — `smb` (default) or `mid_market`. An unrecognized value fails the bench loudly. |
+| `MARGINCE_AITASK_DIR` | `worker aitask` | working directory for the `ai-probe` debug loop's artifacts (flag `--work-dir`, default the gitignored `.tmp/aitask/`). A fetched page carries whatever the source carried, so this stays out of the tree. |
 
 ### `POST /v1/admin/reset-data` — non-production data reset
 


### PR DESCRIPTION
## Why

`.env.template` was **unowned**. It is referenced by exactly one file in the tree — `scripts/dev.sh`, which only copies it to `.env.local` on first `make dev` — and asserted by no test, lint, or make target. It drifted in three directions at once:

| set | before |
|---|---|
| vars in `.env.template` | 30 |
| `MARGINCE_*` string literals in Go code | 46 |
| vars named in `docs/reference/configuration.md` | 37 |

- It advertised `MARGINCE_PASSPORT_TOKEN` and `MARGINCE_WORKSPACE` for the **retired `cmd/mcp` process role** (SCR-9), and its header still claimed *"the four process-role binaries under backend/cmd/ (api, worker, mcp, migrate)"* where three exist.
- **13 live vars were documented nowhere at all** — including two secrets, `MARGINCE_HUBSPOT_APP_SECRET` and `MARGINCE_GMAIL_PUSH_SERVICE_ACCOUNT`. An operator cannot provision a secret nobody wrote down.
- `[optional]` carried two incompatible meanings — *"has a working default"* (`MARGINCE_LOG_LEVEL`) and *"unset, and this feature is silently absent"* (`MARGINCE_BLOBSTORE_ENDPOINT` ⇒ `/attachments` answers 501). Collapsing those is why the object-storage block reads as safe to ignore.

## What

**A fitness function instead of a point fix** (`backend/envcontract_test.go`), joining the tree-derived gates already at `backend/` root and reusing `license_test.go`'s tree list so a new tree enrolls in both gates at once:

- `TestEveryEnvVarIsDocumented` — every `MARGINCE_*` named by a Go string literal must appear in `docs/reference/configuration.md`.
- `TestEnvTemplateNamesOnlyLiveVars` — every `MARGINCE_*` in `.env.template` must still be read by Go code.

Keying on the **quoted literal** is what makes this robust. Matching `os.Getenv(` would miss the four wrapper readers in `cmd/{api,worker}` (`envOr`, `envIntOr`, `envDuration`, `envDurationOr`); matching unquoted text harvests `MARGINCE_X_*` globs out of comments and invents vars that do not exist. Both alternatives were tried against the real tree first.

**`docs/reference/configuration.md`** gains 13 rows and spells out three abbreviated names (`MARGINCE_GMAIL_CLIENT_ID` / `…_SECRET` and two siblings). A variable name a reader cannot grep for is a variable name that is not documented.

**`.env.template`**: 215 → 123 lines. Keeps `[required]`/`[optional]`, but every `[optional]` now states its consequence on the label line:

```
# [optional — unset: /attachments answers 501, /readyz drops the blobstore
# probe, and every company renders its monogram instead of a logo]
```

Vars that merely default, and the integration lane's vars (`backend/Makefile:19-30` already exports them with `?=`), now live only in `configuration.md`.

## Reviewer notes

**The gates' limits are stated in the test, not left implied** — Go readers only (`MARGINCE_OWNER_DSN` and `MARGINCE_ADMIN_PASSWORD` are shell-read and uncovered), `MARGINCE_`-prefixed names only (the BYOK keys carry provider-conventional names), and **presence rather than truth**: these stop a var disappearing from the docs, not a description going stale. No test can gate prose.

**Three vars are inert under `make dev`** and are now marked as such: `scripts/dev.sh` passes `--ai-routing` as an explicit flag and sets `MARGINCE_ENV` / the four object-storage vars as command-prefix assignments, which beat exported values. Editing them in `.env.local` does not change the dev stack. Making them respect `.env.local` is a runtime change, deliberately out of scope → filed separately.

## Verification

- Both gates **fail on the pre-change tree** (16 undocumented vars; 3 dead template names) and pass after — confirmed before fixing, so neither gate is unproven.
- Mutation-tested: an added `os.Getenv("MARGINCE_NOPE_PROBE")` fails gate 1 naming the file; an added `MARGINCE_NOPE_TEMPLATE=` fails gate 2. Both green after revert.
- One finding was a genuine defect in this PR's own prose — the header phrase "the four `MARGINCE_BLOBSTORE_` vars" tripped the glob rule. The gate earned its place before it ever reached CI.
- `make check` exit 0 (backend + frontend), `make craft-static` 0 findings across all three trees, pre-push hook green.

Docs and one test only; no runtime code changes, no migration, no contract change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds env-contract tests to keep `.env.template` and `docs/reference/configuration.md` accurate across Go code and deploy surfaces, and rewrites the template to serve all environments with clear required semantics. Documents the `/metrics` token and connector settings; no runtime changes.

- **Refactors**
  - Added `backend/envcontract_test.go` gates:
    - Every `MARGINCE_*` read by Go is listed in `docs/reference/configuration.md`.
    - `.env.template` and the config doc may name only live vars (Go or deploy surfaces: `scripts/`, `infra/`, `.github/workflows`, Dockerfiles).
    - Deploy entrypoint `${VAR:?}`/`${VAR?}` vars must be present in `.env.template`.
  - `.env.template`: dotenv-style; labels unify to `[required]`, `[required for <capability>]`, `[optional]`; serves all environments. Includes deploy essentials (`MARGINCE_REDIS`, `MARGINCE_CONFIG`, `MARGINCE_OWNER_DSN`, `MARGINCE_ADMIN_PASSWORD`, `MARGINCE_OBSERVE_ADDR`), restores `MARGINCE_BLOBSTORE_USE_SSL`. Clarifies owner vs app DSN for `cmd/migrate`, and that `MARGINCE_PUBLIC_BASE_URL` also gates Gmail/Graph OAuth callbacks.

- **Docs**
  - Added `MARGINCE_METRICS_TOKEN` (required to scrape `/metrics`, otherwise 404) and `MARGINCE_HUBSPOT_APP_SECRET`.
  - Spelled out Gmail/Graph secrets (`MARGINCE_GMAIL_CLIENT_SECRET`, `MARGINCE_GRAPH_CLIENT_SECRET`); fixed Gmail push var to `MARGINCE_GMAIL_PUSH_SERVICE_ACCOUNT`.
  - Added test/perf and AI-cert envs (`MARGINCE_TEST_BLOBSTORE_*`, `MARGINCE_AICERT*`, `MARGINCE_BENCH_TIER`, `MARGINCE_AITASK_DIR`); `MARGINCE_ENV` gates `/v1/admin/reset-data`.

<sup>Written for commit 8e2590dcb8b51e52652fedfee3d1ffce09dd986b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/564?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Reorganized the environment configuration template for API, worker, and migration deployments.
  - Clarified required and optional settings for OAuth, webhooks, AI providers, external services, object storage, Redis, metrics, and observability.
  - Added documentation for metrics-token behavior, HubSpot webhook verification, Gmail and Microsoft OAuth variables, testing, benchmarking, and AI configuration.
  - Replaced development values with safe, commented placeholders and removed obsolete deployment entries.

- **Tests**
  - Added checks to keep environment documentation and deployment requirements synchronized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->