### PR TITLE
fix(ci): run the release-management container as the runner's uid

### DIFF
--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -70,11 +70,16 @@ jobs:
             exit 0
           fi
           # The image ENTRYPOINT is the CLI (WORKDIR /work); mount the checkout
-          # there and diff it with -repo. The container runs as root over a
-          # runner-owned mount, so inject safe.directory via git's env config
-          # (no writable config file needed) for the CLI's git subprocess.
+          # there and diff it with -repo. The image's own user is non-root and
+          # does not own the runner's checkout, so run as the runner's uid/gid —
+          # the CLI then writes the patch as the mount's owner. That uid has no
+          # passwd entry in the image, so point HOME at a writable path, and
+          # inject safe.directory via git's env config (no writable config file
+          # needed) for the CLI's git subprocess.
           docker run --rm \
+            --user "$(id -u):$(id -g)" \
             -v "$PWD":/work \
+            -e HOME=/tmp \
             -e GIT_CONFIG_COUNT=1 \
             -e GIT_CONFIG_KEY_0=safe.directory \
             -e GIT_CONFIG_VALUE_0='*' \


### PR DESCRIPTION
## Problem

Every push to `main` since 2026-08-05 18:17 UTC fails the `patch` workflow with

```
release-management: open main-<sha>.patch: permission denied
```

(latest instance: [run 31159072431](https://github.com/gradionhq/margince-poc-v1/actions/runs/31159072431/job/92805038258)).

## Cause

gradionhq/margince-constellation#206 (distroless runtime images by default, published 2026-08-05) moved the `release-management` CLI image to a **non-root user** — the image stayed Alpine + git as the allowlisted exception, but no longer runs as root. This workflow still ran the container with its default user and expected it to create the patch file inside the runner-owned checkout mount; root could, the new non-root user cannot.

## Fix

Run the container as the runner's own uid/gid (`--user "$(id -u):$(id -g)"`) so the CLI writes the patch as the mount's owner, and set `HOME=/tmp` since that uid has no passwd entry in the image. The existing `safe.directory` env-config injection stays for the CLI's git subprocess.

## Verification

The `patch` workflow triggers on push to `main` (plus `workflow_dispatch`), so the merge of this PR is itself the end-to-end test; I'll watch that run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `patch` workflow by running the `release-management` container as the runner’s UID/GID so it can write the patch file. Restores patch creation on pushes to `main` after the image switched to a non-root user.

- **Bug Fixes**
  - Run `docker run` with `--user "$(id -u):$(id -g)"` so the CLI can write `main-<sha>.patch` in the mounted checkout.
  - Set `HOME=/tmp` and keep `GIT_CONFIG_*` `safe.directory='*'` for the CLI’s git subprocess.

<sup>Written for commit f4d27dbbe2d469750b8c4dec848478080d4a1c22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/567?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved patch-generation workflow compatibility by running with non-root permissions.
  * Ensured the command-line process can operate reliably in environments without a user account entry.
  * Preserved repository safety configuration during patch generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->