### PR TITLE
chore: add CODEOWNERS for the extension tier

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# Code owners are requested for review automatically on any PR touching
+# their paths. Later entries win over earlier ones for overlapping paths.
+
+# The extension tier (ADR-0069) and every seam that defines it.
+/extensions/                        @lstrojny
+/backend/pkg/                       @lstrojny
+/composition/                       @lstrojny
+/fixtures/extensions/               @lstrojny
+/backend/tools/gen-composition/     @lstrojny
+/backend/extensions_arch_test.go    @lstrojny
+/docs/how-to/add-an-extension.md    @lstrojny
+/docs/explanation/extensibility.md  @lstrojny


### PR DESCRIPTION
## What

Adds `.github/CODEOWNERS` routing review of everything extension-related to @lstrojny:

- `extensions/` — the extension units (ADR-0069 tier)
- `backend/pkg/` — the marker-allowlisted seam extensions import
- `composition/` — the committed vanilla composition stub
- `fixtures/extensions/` — the fixture unit
- `backend/tools/gen-composition/` — the composition generator
- `backend/extensions_arch_test.go` — the arch fitness test for the tier
- the two extension docs pages (`add-an-extension.md`, `extensibility.md`)

## Why

PRs touching the extension tier or any seam that defines it should automatically request review from the tier's owner.

Note for an admin: for these reviews to be *blocking*, "Require review from Code Owners" must be enabled in branch protection for `main` — this file alone only auto-requests the review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated code ownership rules to route relevant changes to the appropriate reviewer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->