### PR TITLE
refactor(test): the booted-app fixture becomes importable, in its own package

### DIFF
--- a/backend/internal/compose/integration/activity_lifecycle_integration_test.go
+++ b/backend/internal/compose/integration/activity_lifecycle_integration_test.go
@@ -11,61 +11,26 @@ package integration
 // association whose target passes the visibility probe.
 
 import (
-	"context"
-	"io"
-	"log/slog"
 	"net/http"
-	"os"
-	"path/filepath"
 	"testing"
 
-	"github.com/gradionhq/margince/backend/internal/compose"
-	"github.com/gradionhq/margince/backend/internal/platform/deployconfig"
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 )
-
-// bootstrapWorkspaceSession provisions the installation's organization
-// through the A107 boot path (configuration-driven, exactly what cmd/api
-// runs at startup) and signs its admin in over HTTP — the arrange step
-// every e2e scenario shares. The login also primes the server's
-// singleton-organization resolution before a test seeds any
-// cross-tenant rows directly.
-func bootstrapWorkspaceSession(t *testing.T, e *env, organizationName, adminEmail, adminName string) {
-	t.Helper()
-	pwFile := filepath.Join(t.TempDir(), "admin-password")
-	if err := os.WriteFile(pwFile, []byte("correct-horse-battery"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	cfg := deployconfig.Config{
-		Version:      1,
-		Organization: deployconfig.Organization{Name: organizationName},
-		BootstrapAdmin: &deployconfig.BootstrapAdmin{
-			Email: adminEmail, DisplayName: adminName, PasswordFile: pwFile,
-		},
-	}
-	if err := compose.EnsureInstallation(context.Background(), e.pool, slog.New(slog.NewTextHandler(io.Discard, nil)), cfg); err != nil {
-		t.Fatalf("bootstrap: %v", err)
-	}
-	if status := e.call(t, "POST", "/v1/auth/login", anyMap{
-		"email": adminEmail, "password": "correct-horse-battery",
-	}, nil, nil); status != http.StatusOK {
-		t.Fatalf("login → %d", status)
-	}
-}
 
 // seedTaskAndTarget logs one task activity plus a person for it to be
 // relinked onto, returning both ids.
-func seedTaskAndTarget(t *testing.T, e *env) (personID, taskID string) {
+func seedTaskAndTarget(t *testing.T, e *apptest.AppEnv) (personID, taskID string) {
 	t.Helper()
 	var person struct {
 		ID string `json:"id"`
 	}
-	if status := e.call(t, "POST", "/v1/people", anyMap{"full_name": "Task Target"}, nil, &person); status != http.StatusCreated {
+	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{"full_name": "Task Target"}, nil, &person); status != http.StatusCreated {
 		t.Fatalf("create person → %d", status)
 	}
 	var task struct {
 		ID string `json:"id"`
 	}
-	if status := e.call(t, "POST", "/v1/activities", anyMap{
+	if status := e.Call(t, "POST", "/v1/activities", apptest.AnyMap{
 		"kind": "task", "subject": "Send offer",
 	}, nil, &task); status != http.StatusCreated {
 		t.Fatalf("log task → %d", status)
@@ -74,9 +39,9 @@ func seedTaskAndTarget(t *testing.T, e *env) (personID, taskID string) {
 }
 
 func TestActivityUpdateArchiveRelink(t *testing.T) {
-	e := setup(t)
-	e.slug = "act-e2e"
-	bootstrapWorkspaceSession(t, e, "Act E2E", "act@fable.test", "Admin")
+	e := apptest.SetupApp(t)
+	e.Slug = "act-e2e"
+	apptest.BootstrapWorkspaceSession(t, e, "Act E2E", "act@fable.test", "Admin")
 	personID, taskID := seedTaskAndTarget(t, e)
 
 	// Completing the task stamps done_at with it.
@@ -84,7 +49,7 @@ func TestActivityUpdateArchiveRelink(t *testing.T) {
 		IsDone bool    `json:"is_done"`
 		DoneAt *string `json:"done_at"`
 	}
-	if status := e.call(t, "PATCH", "/v1/activities/"+taskID, anyMap{"is_done": true}, nil, &updated); status != http.StatusOK {
+	if status := e.Call(t, "PATCH", "/v1/activities/"+taskID, apptest.AnyMap{"is_done": true}, nil, &updated); status != http.StatusOK {
 		t.Fatalf("complete task → %d", status)
 	}
 	if !updated.IsDone || updated.DoneAt == nil {
@@ -94,7 +59,7 @@ func TestActivityUpdateArchiveRelink(t *testing.T) {
 	var problem struct {
 		Code string `json:"code"`
 	}
-	if status := e.call(t, "PATCH", "/v1/activities/"+taskID, anyMap{"subject": "x"},
+	if status := e.Call(t, "PATCH", "/v1/activities/"+taskID, apptest.AnyMap{"subject": "x"},
 		map[string]string{"If-Match": "999"}, &problem); status != http.StatusConflict || problem.Code != "version_skew" {
 		t.Fatalf("stale If-Match → %d %q", status, problem.Code)
 	}
@@ -104,16 +69,16 @@ func TestActivityUpdateArchiveRelink(t *testing.T) {
 	// Archive is the soft flag (same semantics as every entity): the
 	// record stays readable by id, stamped archived_at, and further
 	// mutations refuse.
-	if status := e.call(t, "DELETE", "/v1/activities/"+taskID, nil, nil, nil); status != http.StatusOK {
+	if status := e.Call(t, "DELETE", "/v1/activities/"+taskID, nil, nil, nil); status != http.StatusOK {
 		t.Fatalf("archive → %d", status)
 	}
 	var archived struct {
 		ArchivedAt *string `json:"archived_at"`
 	}
-	if status := e.call(t, "GET", "/v1/activities/"+taskID, nil, nil, &archived); status != http.StatusOK || archived.ArchivedAt == nil {
+	if status := e.Call(t, "GET", "/v1/activities/"+taskID, nil, nil, &archived); status != http.StatusOK || archived.ArchivedAt == nil {
 		t.Fatalf("archive did not stamp: %d %+v", status, archived)
 	}
-	if status := e.call(t, "PATCH", "/v1/activities/"+taskID, anyMap{"subject": "zombie"}, nil, nil); status != http.StatusNotFound {
+	if status := e.Call(t, "PATCH", "/v1/activities/"+taskID, apptest.AnyMap{"subject": "zombie"}, nil, nil); status != http.StatusNotFound {
 		t.Fatalf("mutating an archived activity → %d, want 404", status)
 	}
 }
@@ -122,18 +87,18 @@ func TestActivityUpdateArchiveRelink(t *testing.T) {
 // an idempotent association onto a visible person, replay-silent in the
 // audit trail, with invisible targets (person and lead alike) reading
 // as absent.
-func assertRelinkIdempotentAndVisibilityScoped(t *testing.T, e *env, taskID, personID string) {
+func assertRelinkIdempotentAndVisibilityScoped(t *testing.T, e *apptest.AppEnv, taskID, personID string) {
 	t.Helper()
 	// Relink: idempotent association onto a visible person.
 	for i := 0; i < 2; i++ {
-		if status := e.call(t, "POST", "/v1/activities/"+taskID+"/relink", anyMap{
+		if status := e.Call(t, "POST", "/v1/activities/"+taskID+"/relink", apptest.AnyMap{
 			"entity_type": "person", "entity_id": personID,
 		}, nil, nil); status != http.StatusOK {
 			t.Fatalf("relink (round %d) → %d", i, status)
 		}
 	}
 	var links int
-	if err := e.owner.QueryRow(t.Context(),
+	if err := e.Owner.QueryRow(t.Context(),
 		`SELECT count(*) FROM activity_link WHERE person_id = $1`, personID).Scan(&links); err != nil {
 		t.Fatal(err)
 	}
@@ -142,7 +107,7 @@ func assertRelinkIdempotentAndVisibilityScoped(t *testing.T, e *env, taskID, per
 	}
 	// One relink audit row despite two calls (the replay is a no-op).
 	var relinks int
-	if err := e.owner.QueryRow(t.Context(),
+	if err := e.Owner.QueryRow(t.Context(),
 		`SELECT count(*) FROM audit_log WHERE action = 'activity_relink'`).Scan(&relinks); err != nil {
 		t.Fatal(err)
 	}
@@ -150,25 +115,25 @@ func assertRelinkIdempotentAndVisibilityScoped(t *testing.T, e *env, taskID, per
 		t.Fatalf("relink audits = %d, want 1 (idempotent replay is silent)", relinks)
 	}
 	// An invisible relink target reads as absent (H1).
-	if status := e.call(t, "POST", "/v1/activities/"+taskID+"/relink", anyMap{
+	if status := e.Call(t, "POST", "/v1/activities/"+taskID+"/relink", apptest.AnyMap{
 		"entity_type": "person", "entity_id": "00000000-0000-7000-8000-00000000dead",
 	}, nil, nil); status != http.StatusNotFound {
 		t.Fatalf("invisible relink target → %d, want 404", status)
 	}
 	// The lead arm (0038): relinking onto a real lead lands on the lead's
 	// timeline; a guessed lead id reads as absent like any other target.
-	var lead anyMap
-	if status := e.call(t, "POST", "/v1/leads", anyMap{
+	var lead apptest.AnyMap
+	if status := e.Call(t, "POST", "/v1/leads", apptest.AnyMap{
 		"full_name": "Relink Lead", "email": "relink@lead.test", "source": "manual",
 	}, nil, &lead); status != http.StatusCreated {
 		t.Fatalf("create lead → %d", status)
 	}
-	if status := e.call(t, "POST", "/v1/activities/"+taskID+"/relink", anyMap{
+	if status := e.Call(t, "POST", "/v1/activities/"+taskID+"/relink", apptest.AnyMap{
 		"entity_type": "lead", "entity_id": lead["id"],
 	}, nil, nil); status != http.StatusOK {
 		t.Fatalf("lead relink → %d, want 200", status)
 	}
-	if status := e.call(t, "POST", "/v1/activities/"+taskID+"/relink", anyMap{
+	if status := e.Call(t, "POST", "/v1/activities/"+taskID+"/relink", apptest.AnyMap{
 		"entity_type": "lead", "entity_id": "00000000-0000-7000-8000-00000000dead",
 	}, nil, nil); status != http.StatusNotFound {
 		t.Fatalf("guessed lead relink → %d, want 404", status)

--- a/backend/internal/compose/integration/activity_remindat_integration_test.go
+++ b/backend/internal/compose/integration/activity_remindat_integration_test.go
@@ -12,19 +12,21 @@ package integration
 import (
 	"net/http"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 )
 
 func TestRemindAtIsTaskOnlyAndRoundTrips(t *testing.T) {
-	e := setup(t)
-	e.slug = "reminders"
-	bootstrapWorkspaceSession(t, e, "Reminders", "admin@reminders.test", "Admin")
+	e := apptest.SetupApp(t)
+	e.Slug = "reminders"
+	apptest.BootstrapWorkspaceSession(t, e, "Reminders", "admin@reminders.test", "Admin")
 
 	// Round-trip on create: the reminder lands and reads back.
 	var created struct {
 		ID       string  `json:"id"`
 		RemindAt *string `json:"remind_at"`
 	}
-	if status := e.call(t, "POST", "/v1/activities", anyMap{
+	if status := e.Call(t, "POST", "/v1/activities", apptest.AnyMap{
 		"kind": "task", "subject": "Call back", "remind_at": "2026-07-08T09:00:00Z",
 	}, nil, &created); status != http.StatusCreated {
 		t.Fatalf("create task with remind_at → %d", status)
@@ -37,7 +39,7 @@ func TestRemindAtIsTaskOnlyAndRoundTrips(t *testing.T) {
 	var patched struct {
 		RemindAt *string `json:"remind_at"`
 	}
-	if status := e.call(t, "PATCH", "/v1/activities/"+created.ID, anyMap{
+	if status := e.Call(t, "PATCH", "/v1/activities/"+created.ID, apptest.AnyMap{
 		"remind_at": "2026-07-09T10:30:00Z",
 	}, nil, &patched); status != http.StatusOK {
 		t.Fatalf("patch remind_at → %d", status)
@@ -51,7 +53,7 @@ func TestRemindAtIsTaskOnlyAndRoundTrips(t *testing.T) {
 	var problem struct {
 		Code string `json:"code"`
 	}
-	status := e.call(t, "POST", "/v1/activities", anyMap{
+	status := e.Call(t, "POST", "/v1/activities", apptest.AnyMap{
 		"kind": "note", "body": "no reminders on notes", "remind_at": "2026-07-08T09:00:00Z",
 	}, nil, &problem)
 	if status != http.StatusUnprocessableEntity {
@@ -63,10 +65,10 @@ func TestRemindAtIsTaskOnlyAndRoundTrips(t *testing.T) {
 	var note struct {
 		ID string `json:"id"`
 	}
-	if s := e.call(t, "POST", "/v1/activities", anyMap{"kind": "note", "body": "plain"}, nil, &note); s != http.StatusCreated {
+	if s := e.Call(t, "POST", "/v1/activities", apptest.AnyMap{"kind": "note", "body": "plain"}, nil, &note); s != http.StatusCreated {
 		t.Fatalf("create note → %d", s)
 	}
-	if s := e.call(t, "PATCH", "/v1/activities/"+note.ID, anyMap{"remind_at": "2026-07-08T09:00:00Z"}, nil, nil); s != http.StatusUnprocessableEntity {
+	if s := e.Call(t, "PATCH", "/v1/activities/"+note.ID, apptest.AnyMap{"remind_at": "2026-07-08T09:00:00Z"}, nil, nil); s != http.StatusUnprocessableEntity {
 		t.Fatalf("patch remind_at onto a note → %d, want 422", s)
 	}
 }

--- a/backend/internal/compose/integration/agent_humanonly_read_integration_test.go
+++ b/backend/internal/compose/integration/agent_humanonly_read_integration_test.go
@@ -18,17 +18,19 @@ package integration
 import (
 	"net/http"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 )
 
 func TestAgentBearerIsRefusedOnHumanOnlyReads(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 
 	var minted struct {
 		PassportID string `json:"passport_id"`
 		Token      string `json:"token"`
 	}
-	if status := e.call(t, "POST", "/v1/passports", anyMap{
+	if status := e.Call(t, "POST", "/v1/passports", apptest.AnyMap{
 		"label": "human-only read probe", "scopes": []string{"read"},
 	}, nil, &minted); status != http.StatusCreated {
 		t.Fatalf("issue passport → %d", status)
@@ -70,7 +72,7 @@ func TestAgentBearerIsRefusedOnHumanOnlyReads(t *testing.T) {
 			var problem struct {
 				Code string `json:"code"`
 			}
-			status := e.call(t, "GET", route, nil, bearer, &problem)
+			status := e.Call(t, "GET", route, nil, bearer, &problem)
 			if status != http.StatusForbidden {
 				t.Errorf("agent GET %s → %d, want 403 (the contract declares it human-only)", route, status)
 			}
@@ -82,7 +84,7 @@ func TestAgentBearerIsRefusedOnHumanOnlyReads(t *testing.T) {
 
 	// The gate narrows the annotated exceptions, it does not close the read
 	// surface: an ordinary agent-readable route still answers.
-	if status := e.call(t, "GET", "/v1/people", nil, bearer, nil); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/people", nil, bearer, nil); status != http.StatusOK {
 		t.Errorf("agent GET /v1/people → %d, want 200 — an unannotated read stays agent-readable", status)
 	}
 }

--- a/backend/internal/compose/integration/agent_versionpin_integration_test.go
+++ b/backend/internal/compose/integration/agent_versionpin_integration_test.go
@@ -25,18 +25,20 @@ package integration
 import (
 	"net/http"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 )
 
 func TestApprovedOfferArchiveRefusesAfterTheAgentRewritesTheTerms(t *testing.T) {
-	e := setup(t)
-	e.slug = "offers-pin"
-	bootstrapWorkspaceSession(t, e, "Offers Pin", "pin@fable.test", "Admin")
+	e := apptest.SetupApp(t)
+	e.Slug = "offers-pin"
+	apptest.BootstrapWorkspaceSession(t, e, "Offers Pin", "pin@fable.test", "Admin")
 	dealID := offerFixture(t, e)
 
 	var minted struct {
 		Token string `json:"token"`
 	}
-	if status := e.call(t, "POST", "/v1/passports", anyMap{
+	if status := e.Call(t, "POST", "/v1/passports", apptest.AnyMap{
 		// The version-pin race this test proves happens inside archive_record's
 		// approval, so the passport must be able to spend `write` to get there.
 		"label": "pin agent", "scopes": []string{"read", "write"},
@@ -52,9 +54,9 @@ func TestApprovedOfferArchiveRefusesAfterTheAgentRewritesTheTerms(t *testing.T) 
 			ID string `json:"id"`
 		} `json:"line_items"`
 	}
-	if status := e.call(t, "POST", "/v1/deals/"+dealID+"/offers", anyMap{
+	if status := e.Call(t, "POST", "/v1/deals/"+dealID+"/offers", apptest.AnyMap{
 		"currency": "EUR", "source": "mcp",
-		"line_items": []anyMap{{"description": "Pilot", "quantity": 1, "unit_price_minor": 250000, "tax_rate": 19.0}},
+		"line_items": []apptest.AnyMap{{"description": "Pilot", "quantity": 1, "unit_price_minor": 250000, "tax_rate": 19.0}},
 	}, bearer, &offer); status != http.StatusCreated {
 		t.Fatalf("agent offer draft → %d", status)
 	}
@@ -68,7 +70,7 @@ func TestApprovedOfferArchiveRefusesAfterTheAgentRewritesTheTerms(t *testing.T) 
 		Code   string `json:"code"`
 		Detail string `json:"detail"`
 	}
-	if status := e.call(t, "DELETE", "/v1/offers/"+offer.ID, nil, bearer, &problem); status != http.StatusForbidden ||
+	if status := e.Call(t, "DELETE", "/v1/offers/"+offer.ID, nil, bearer, &problem); status != http.StatusForbidden ||
 		problem.Code != "approval_required" {
 		t.Fatalf("agent archive → %d %q, want 403 approval_required", status, problem.Code)
 	}
@@ -76,7 +78,7 @@ func TestApprovedOfferArchiveRefusesAfterTheAgentRewritesTheTerms(t *testing.T) 
 
 	// The staged row carries a pin the agent never supplied.
 	var pin *int64
-	if err := e.owner.QueryRow(t.Context(),
+	if err := e.Owner.QueryRow(t.Context(),
 		`SELECT target_version FROM approval WHERE id = $1`, approvalID).Scan(&pin); err != nil {
 		t.Fatal(err)
 	}
@@ -85,13 +87,13 @@ func TestApprovedOfferArchiveRefusesAfterTheAgentRewritesTheTerms(t *testing.T) 
 	}
 
 	// The human approves the offer they were shown: Pilot at 250000 minor.
-	if status := e.call(t, "POST", "/v1/approvals/"+approvalID+"/approve", anyMap{}, nil, nil); status != http.StatusOK {
+	if status := e.Call(t, "POST", "/v1/approvals/"+approvalID+"/approve", apptest.AnyMap{}, nil, nil); status != http.StatusOK {
 		t.Fatalf("human approve → %d", status)
 	}
 
 	// The agent then rewrites the priced terms through the auto_execute
 	// child route. The offer's version moves; the approval's does not.
-	if status := e.call(t, "PATCH", "/v1/offers/"+offer.ID+"/line-items/"+offer.LineItems[0].ID, anyMap{
+	if status := e.Call(t, "PATCH", "/v1/offers/"+offer.ID+"/line-items/"+offer.LineItems[0].ID, apptest.AnyMap{
 		"unit_price_minor": 100,
 	}, bearer, nil); status != http.StatusOK {
 		t.Fatalf("agent line-item rewrite → %d", status)
@@ -105,14 +107,14 @@ func TestApprovedOfferArchiveRefusesAfterTheAgentRewritesTheTerms(t *testing.T) 
 	var refusal struct {
 		Code string `json:"code"`
 	}
-	if status := e.call(t, "DELETE", "/v1/offers/"+offer.ID, nil, withToken, &refusal); status != http.StatusConflict ||
+	if status := e.Call(t, "DELETE", "/v1/offers/"+offer.ID, nil, withToken, &refusal); status != http.StatusConflict ||
 		refusal.Code != "version_skew" {
 		t.Fatalf("redeeming against rewritten terms → %d %q, want 409 version_skew", status, refusal.Code)
 	}
 
 	// And nothing was archived.
 	var after offerBody
-	if status := e.call(t, "GET", "/v1/offers/"+offer.ID, nil, bearer, &after); status != http.StatusOK || after.Status != "draft" {
+	if status := e.Call(t, "GET", "/v1/offers/"+offer.ID, nil, bearer, &after); status != http.StatusOK || after.Status != "draft" {
 		t.Fatalf("offer status = %q after a refused redemption, want draft", after.Status)
 	}
 }

--- a/backend/internal/compose/integration/agentscope_integration_test.go
+++ b/backend/internal/compose/integration/agentscope_integration_test.go
@@ -23,6 +23,8 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 )
 
 // scopeRefusalCode is what apperrors.ErrScopeExceeded maps to in
@@ -43,16 +45,16 @@ type capRefusal struct {
 }
 
 func TestEnrichRefusesAPassportWithoutTheEnrichCap(t *testing.T) {
-	e := setup(t)
-	e.slug = "enrich-scope"
-	bootstrapWorkspaceSession(t, e, "Enrich Scope", "enrich@fable.test", "Admin")
+	e := apptest.SetupApp(t)
+	e.Slug = "enrich-scope"
+	apptest.BootstrapWorkspaceSession(t, e, "Enrich Scope", "enrich@fable.test", "Admin")
 
 	var org struct {
 		ID string `json:"id"`
 	}
-	if status := e.call(t, "POST", "/v1/organizations", anyMap{
+	if status := e.Call(t, "POST", "/v1/organizations", apptest.AnyMap{
 		"display_name": "Acme GmbH", "source": "ui",
-		"domains": []anyMap{{"domain": "acme.example", "is_primary": true}},
+		"domains": []apptest.AnyMap{{"domain": "acme.example", "is_primary": true}},
 	}, nil, &org); status != http.StatusCreated {
 		t.Fatalf("create org → %d", status)
 	}
@@ -61,7 +63,7 @@ func TestEnrichRefusesAPassportWithoutTheEnrichCap(t *testing.T) {
 	writeOnly := passportBearer(t, e, "write-only agent", "read", "write")
 
 	var refusal capRefusal
-	status := e.call(t, "POST", "/v1/organizations/"+org.ID+"/enrich", nil, writeOnly, &refusal)
+	status := e.Call(t, "POST", "/v1/organizations/"+org.ID+"/enrich", nil, writeOnly, &refusal)
 	if status != http.StatusForbidden || refusal.Code != scopeRefusalCode || refusal.Type != scopeRefusalType {
 		t.Fatalf("enrich on read+write → %d %q %q, want 403 %s / %s",
 			status, refusal.Code, refusal.Type, scopeRefusalCode, scopeRefusalType)
@@ -88,13 +90,13 @@ func TestEnrichRefusesAPassportWithoutTheEnrichCap(t *testing.T) {
 	// request and answers before the handler runs, so no website is fetched
 	// on this path at all.
 	var staged capRefusal
-	status = e.call(t, "POST", "/v1/organizations/"+org.ID+"/enrich", nil, withEnrich, &staged)
+	status = e.Call(t, "POST", "/v1/organizations/"+org.ID+"/enrich", nil, withEnrich, &staged)
 	if status != http.StatusForbidden || staged.Code != "approval_required" {
 		t.Fatalf("enrich with the enrich cap → %d %q, want 403 approval_required (the 🟡 gate)", status, staged.Code)
 	}
 	approvalID := extractStagedApprovalID(t, staged.Detail)
 	var kind string
-	if err := e.owner.QueryRow(t.Context(),
+	if err := e.Owner.QueryRow(t.Context(),
 		`SELECT kind FROM approval WHERE id = $1`, approvalID).Scan(&kind); err != nil {
 		t.Fatal(err)
 	}
@@ -112,9 +114,9 @@ func TestEnrichRefusesAPassportWithoutTheEnrichCap(t *testing.T) {
 // can tell "you may never do this" from "mint a passport with the right
 // cap and retry."
 func TestOfferSendRefusesAnyAgentAsHumanOnly(t *testing.T) {
-	e := setup(t)
-	e.slug = "send-scope"
-	bootstrapWorkspaceSession(t, e, "Send Scope", "send@fable.test", "Admin")
+	e := apptest.SetupApp(t)
+	e.Slug = "send-scope"
+	apptest.BootstrapWorkspaceSession(t, e, "Send Scope", "send@fable.test", "Admin")
 	dealID := offerFixture(t, e)
 
 	// The broadest passport short of a human session: even every cap the
@@ -124,15 +126,15 @@ func TestOfferSendRefusesAnyAgentAsHumanOnly(t *testing.T) {
 	// Drafting is 🟢 under `write` and still is: send being human-only is
 	// not a blanket tightening of the offer surface.
 	var offer offerBody
-	if status := e.call(t, "POST", "/v1/deals/"+dealID+"/offers", anyMap{
+	if status := e.Call(t, "POST", "/v1/deals/"+dealID+"/offers", apptest.AnyMap{
 		"currency": "EUR", "source": "mcp",
-		"line_items": []anyMap{{"description": "Pilot", "quantity": 1, "unit_price_minor": 250000, "tax_rate": 19.0}},
+		"line_items": []apptest.AnyMap{{"description": "Pilot", "quantity": 1, "unit_price_minor": 250000, "tax_rate": 19.0}},
 	}, bearer, &offer); status != http.StatusCreated {
 		t.Fatalf("agent 🟢 offer draft → %d", status)
 	}
 
 	var refusal capRefusal
-	status := e.call(t, "POST", "/v1/offers/"+offer.ID+"/send", nil, bearer, &refusal)
+	status := e.Call(t, "POST", "/v1/offers/"+offer.ID+"/send", nil, bearer, &refusal)
 	if status != http.StatusForbidden || refusal.Code != "permission_denied" {
 		t.Fatalf("agent send → %d %q, want 403 permission_denied (human-only)", status, refusal.Code)
 	}
@@ -151,19 +153,19 @@ func TestOfferSendRefusesAnyAgentAsHumanOnly(t *testing.T) {
 	// Nothing left the workspace, and nothing is waiting in an inbox to say
 	// it might.
 	var still offerBody
-	if status := e.call(t, "GET", "/v1/offers/"+offer.ID, nil, bearer, &still); status != http.StatusOK || still.Status != "draft" {
+	if status := e.Call(t, "GET", "/v1/offers/"+offer.ID, nil, bearer, &still); status != http.StatusOK || still.Status != "draft" {
 		t.Fatalf("offer after the refused send = %q, want draft", still.Status)
 	}
 }
 
 // passportBearer mints a passport with exactly scopes and returns the
 // Authorization header an agent principal presents.
-func passportBearer(t *testing.T, e *env, label string, scopes ...string) map[string]string {
+func passportBearer(t *testing.T, e *apptest.AppEnv, label string, scopes ...string) map[string]string {
 	t.Helper()
 	var minted struct {
 		Token string `json:"token"`
 	}
-	if status := e.call(t, "POST", "/v1/passports", anyMap{
+	if status := e.Call(t, "POST", "/v1/passports", apptest.AnyMap{
 		"label": label, "scopes": scopes,
 	}, nil, &minted); status != http.StatusCreated {
 		t.Fatalf("issue passport %q → %d", label, status)
@@ -177,10 +179,10 @@ func passportBearer(t *testing.T, e *env, label string, scopes ...string) map[st
 // assertNothingStaged proves the refusal was a cap refusal and not the 🟡
 // admission wearing the same status: a staged approval is a durable
 // authority object, so its absence is the observable difference.
-func assertNothingStaged(t *testing.T, e *env, what string) {
+func assertNothingStaged(t *testing.T, e *apptest.AppEnv, what string) {
 	t.Helper()
 	var staged int
-	if err := e.owner.QueryRow(t.Context(), `SELECT count(*) FROM approval`).Scan(&staged); err != nil {
+	if err := e.Owner.QueryRow(t.Context(), `SELECT count(*) FROM approval`).Scan(&staged); err != nil {
 		t.Fatal(err)
 	}
 	if staged != 0 {

--- a/backend/internal/compose/integration/agenttools_http_integration_test.go
+++ b/backend/internal/compose/integration/agenttools_http_integration_test.go
@@ -8,6 +8,8 @@ package integration
 import (
 	"net/http"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 )
 
 type agentToolWire struct {
@@ -21,11 +23,11 @@ type agentToolListWire struct {
 }
 
 func TestListAgentToolsMirrorsTheGovernedSurface(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 
 	var page agentToolListWire
-	status := e.call(t, "GET", "/v1/agent-tools", nil, nil, &page)
+	status := e.Call(t, "GET", "/v1/agent-tools", nil, nil, &page)
 	if status != http.StatusOK {
 		t.Fatalf("GET /agent-tools status = %d, want 200", status)
 	}

--- a/backend/internal/compose/integration/aicalls_integration_test.go
+++ b/backend/internal/compose/integration/aicalls_integration_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/modules/ai"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
@@ -26,11 +27,11 @@ type seededAiCalls struct {
 	older  ids.UUID
 }
 
-func seedAiCallTrace(t *testing.T, e *env) seededAiCalls {
+func seedAiCallTrace(t *testing.T, e *apptest.AppEnv) seededAiCalls {
 	t.Helper()
 	var workspaceID ids.UUID
-	if err := e.owner.QueryRow(context.Background(),
-		`SELECT id FROM workspace WHERE slug = $1`, e.slug).Scan(&workspaceID); err != nil {
+	if err := e.Owner.QueryRow(context.Background(),
+		`SELECT id FROM workspace WHERE slug = $1`, e.Slug).Scan(&workspaceID); err != nil {
 		t.Fatalf("workspace lookup: %v", err)
 	}
 	newest, retry, older := ids.NewV7(), ids.NewV7(), ids.NewV7()
@@ -41,17 +42,17 @@ func seedAiCallTrace(t *testing.T, e *env) seededAiCalls {
 		tokens_in, tokens_out, latency_ms, error_sentinel, logical_call_id,
 		attempt, is_terminal, attempt_reason, served_model, occurred_at)
 		VALUES ($1,$2,$3,'cheap_cloud','gemini','gemini-2.5-flash',$4,$5,$6,$7,$8,$9,$10,$11,$12,'gemini-2.5-flash',$13)`
-	if _, err := e.owner.Exec(context.Background(), insert, retry, workspaceID,
+	if _, err := e.Owner.Exec(context.Background(), insert, retry, workspaceID,
 		"capture_classify", "retry", 100, 0, 400, "provider_unavailable", logical,
 		1, false, "", base.Add(-time.Minute)); err != nil {
 		t.Fatalf("seed retry: %v", err)
 	}
-	if _, err := e.owner.Exec(context.Background(), insert, newest, workspaceID,
+	if _, err := e.Owner.Exec(context.Background(), insert, newest, workspaceID,
 		"capture_classify", "terminal", 100, 20, 900, nil, logical,
 		2, true, "retry_on_5xx", base); err != nil {
 		t.Fatalf("seed terminal: %v", err)
 	}
-	if _, err := e.owner.Exec(context.Background(), insert, older, workspaceID,
+	if _, err := e.Owner.Exec(context.Background(), insert, older, workspaceID,
 		"enrich", "older", 40, 8, 120, nil, older,
 		1, true, "", base.Add(-2*time.Hour)); err != nil {
 		t.Fatalf("seed older call: %v", err)
@@ -59,12 +60,12 @@ func seedAiCallTrace(t *testing.T, e *env) seededAiCalls {
 	// A task whose ONLY row is non-terminal (an in-flight first attempt) must
 	// never reach the trace filter's task set — the list is terminal-only, so
 	// the option would filter to an empty page.
-	if _, err := e.owner.Exec(context.Background(), insert, ids.NewV7(), workspaceID,
+	if _, err := e.Owner.Exec(context.Background(), insert, ids.NewV7(), workspaceID,
 		"draft_reply", "inflight", 10, 0, 50, "provider_unavailable", ids.NewV7(),
 		1, false, "", base.Add(-3*time.Hour)); err != nil {
 		t.Fatalf("seed non-terminal-only call: %v", err)
 	}
-	if _, err := e.owner.Exec(context.Background(), `
+	if _, err := e.Owner.Exec(context.Background(), `
 		INSERT INTO ai_call_payload (workspace_id, ai_call_id, request_payload, response_payload)
 		VALUES ($1, $2, $3, $4)`, workspaceID, newest,
 		`{"system":"classify safely","messages":[{"role":"user","content":"hello"}]}`,
@@ -75,12 +76,12 @@ func seedAiCallTrace(t *testing.T, e *env) seededAiCalls {
 }
 
 func TestAiCallsListPagesTerminalCallsNewestFirst(t *testing.T) {
-	e := setupWithOptions(t, compose.WithAiPayloadCaptureFlag(true))
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupAppWithOptions(t, compose.WithAiPayloadCaptureFlag(true))
+	e.BootstrapWorkspace(t)
 	seeded := seedAiCallTrace(t, e)
 
 	var first crmcontracts.AiCallListResponse
-	if status := e.call(t, http.MethodGet, "/v1/ai/calls?limit=1", nil, nil, &first); status != http.StatusOK {
+	if status := e.Call(t, http.MethodGet, "/v1/ai/calls?limit=1", nil, nil, &first); status != http.StatusOK {
 		t.Fatalf("first page status = %d", status)
 	}
 	if len(first.Data) != 1 || ids.UUID(first.Data[0].Id) != seeded.newest || !first.Page.HasMore || first.Page.NextCursor == nil {
@@ -89,7 +90,7 @@ func TestAiCallsListPagesTerminalCallsNewestFirst(t *testing.T) {
 
 	var second crmcontracts.AiCallListResponse
 	path := "/v1/ai/calls?limit=1&cursor=" + url.QueryEscape(*first.Page.NextCursor)
-	if status := e.call(t, http.MethodGet, path, nil, nil, &second); status != http.StatusOK {
+	if status := e.Call(t, http.MethodGet, path, nil, nil, &second); status != http.StatusOK {
 		t.Fatalf("second page status = %d", status)
 	}
 	if len(second.Data) != 1 || ids.UUID(second.Data[0].Id) != seeded.older {
@@ -111,7 +112,7 @@ func TestAiCallsListPagesTerminalCallsNewestFirst(t *testing.T) {
 	} {
 		var filtered crmcontracts.AiCallListResponse
 		path := "/v1/ai/calls?task=" + url.QueryEscape(task)
-		if status := e.call(t, http.MethodGet, path, nil, nil, &filtered); status != http.StatusOK {
+		if status := e.Call(t, http.MethodGet, path, nil, nil, &filtered); status != http.StatusOK {
 			t.Fatalf("task %s status = %d", task, status)
 		}
 		if len(filtered.Data) != 1 || ids.UUID(filtered.Data[0].Id) != wantID {
@@ -121,12 +122,12 @@ func TestAiCallsListPagesTerminalCallsNewestFirst(t *testing.T) {
 }
 
 func TestAiCallDetailCarriesLadderAndPayload(t *testing.T) {
-	e := setupWithOptions(t, compose.WithAiPayloadCaptureFlag(true))
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupAppWithOptions(t, compose.WithAiPayloadCaptureFlag(true))
+	e.BootstrapWorkspace(t)
 	seeded := seedAiCallTrace(t, e)
 
 	var detail crmcontracts.AiCall
-	if status := e.call(t, http.MethodGet, "/v1/ai/calls/"+seeded.newest.String(), nil, nil, &detail); status != http.StatusOK {
+	if status := e.Call(t, http.MethodGet, "/v1/ai/calls/"+seeded.newest.String(), nil, nil, &detail); status != http.StatusOK {
 		t.Fatalf("detail status = %d", status)
 	}
 	if len(detail.Attempts) != 2 || detail.Attempts[0].Attempt != 1 || !detail.Attempts[1].IsTerminal {
@@ -141,7 +142,7 @@ func TestAiCallDetailCarriesLadderAndPayload(t *testing.T) {
 	}
 
 	var older crmcontracts.AiCall
-	if status := e.call(t, http.MethodGet, "/v1/ai/calls/"+seeded.older.String(), nil, nil, &older); status != http.StatusOK {
+	if status := e.Call(t, http.MethodGet, "/v1/ai/calls/"+seeded.older.String(), nil, nil, &older); status != http.StatusOK {
 		t.Fatalf("older detail status = %d", status)
 	}
 	if older.PayloadCaptured || older.Payload != nil {
@@ -150,12 +151,12 @@ func TestAiCallDetailCarriesLadderAndPayload(t *testing.T) {
 }
 
 func TestAiCallIsInvisibleAcrossTenants(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 	seeded := seedAiCallTrace(t, e)
 
 	workspaceB := ids.NewV7()
-	if _, err := e.owner.Exec(context.Background(),
+	if _, err := e.Owner.Exec(context.Background(),
 		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'AI Two', 'ai-two', 'EUR')`,
 		workspaceB); err != nil {
 		t.Fatalf("seed second workspace: %v", err)
@@ -174,21 +175,21 @@ func TestAiCallIsInvisibleAcrossTenants(t *testing.T) {
 			RowScope: principal.RowScopeAll,
 		},
 	})
-	if _, err := ai.NewCallReadStore(e.pool).GetCall(ctx, seeded.newest); !errors.Is(err, apperrors.ErrNotFound) {
+	if _, err := ai.NewCallReadStore(e.Pool).GetCall(ctx, seeded.newest); !errors.Is(err, apperrors.ErrNotFound) {
 		t.Fatalf("cross-tenant detail err = %v, want ErrNotFound", err)
 	}
 }
 
 func TestAiCallsRefusedWithoutAutomationGrant(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 	seeded := seedAiCallTrace(t, e)
 	demoteToRep(t, e)
 
-	if status := e.call(t, http.MethodGet, "/v1/ai/calls", nil, nil, nil); status != http.StatusForbidden {
+	if status := e.Call(t, http.MethodGet, "/v1/ai/calls", nil, nil, nil); status != http.StatusForbidden {
 		t.Fatalf("rep list status = %d, want 403", status)
 	}
-	if status := e.call(t, http.MethodGet, "/v1/ai/calls/"+seeded.newest.String(), nil, nil, nil); status != http.StatusForbidden {
+	if status := e.Call(t, http.MethodGet, "/v1/ai/calls/"+seeded.newest.String(), nil, nil, nil); status != http.StatusForbidden {
 		t.Fatalf("rep detail status = %d, want 403", status)
 	}
 }

--- a/backend/internal/compose/integration/aiusage_http_integration_test.go
+++ b/backend/internal/compose/integration/aiusage_http_integration_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -23,17 +24,17 @@ import (
 // two days, one with two tiers of the same task — through the owner
 // connection under the workspace GUC, exactly as the meter's upsert lands
 // them.
-func seedAiUsage(t *testing.T, e *env) {
+func seedAiUsage(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
 	ctx := context.Background()
-	tx, err := e.owner.Begin(ctx)
+	tx, err := e.Owner.Begin(ctx)
 	if err != nil {
 		t.Fatalf("begin: %v", err)
 	}
 	//craft:ignore swallowed-errors error-path safety net only — the Commit below is asserted, after which this rollback is a designed no-op
 	defer func() { _ = tx.Rollback(ctx) }()
 	var wsID string
-	if err := tx.QueryRow(ctx, `SELECT id FROM workspace WHERE slug = $1`, e.slug).Scan(&wsID); err != nil {
+	if err := tx.QueryRow(ctx, `SELECT id FROM workspace WHERE slug = $1`, e.Slug).Scan(&wsID); err != nil {
 		t.Fatalf("workspace lookup: %v", err)
 	}
 	if _, err := tx.Exec(ctx, `SELECT set_config('app.workspace_id', $1, true)`, wsID); err != nil {
@@ -80,13 +81,13 @@ type aiUsageDTO struct {
 }
 
 func TestAiUsageOverHTTP(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 
 	// A fresh workspace: no spend yet, but the report and its budget
 	// block still answer — the spend is never invisible, even at zero.
 	var usage aiUsageDTO
-	if status := e.call(t, "GET", "/v1/ai/usage", nil, nil, &usage); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/ai/usage", nil, nil, &usage); status != http.StatusOK {
 		t.Fatalf("GET /ai/usage → %d, want 200", status)
 	}
 	if usage.Budget.Band == "" {
@@ -98,7 +99,7 @@ func TestAiUsageOverHTTP(t *testing.T) {
 
 	// Two metered days: the report groups day × task × tier as recorded.
 	seedAiUsage(t, e)
-	if status := e.call(t, "GET", "/v1/ai/usage?from=2026-07-01&to=2026-07-14", nil, nil, &usage); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/ai/usage?from=2026-07-01&to=2026-07-14", nil, nil, &usage); status != http.StatusOK {
 		t.Fatalf("windowed GET /ai/usage → %d, want 200", status)
 	}
 	if len(usage.Days) != 2 {
@@ -116,10 +117,10 @@ func TestAiUsageOverHTTP(t *testing.T) {
 	}
 
 	// The refusals, before the aggregation runs: inverted, then over-wide.
-	if status := e.call(t, "GET", "/v1/ai/usage?from=2026-07-14&to=2026-07-01", nil, nil, nil); status != http.StatusUnprocessableEntity {
+	if status := e.Call(t, "GET", "/v1/ai/usage?from=2026-07-14&to=2026-07-01", nil, nil, nil); status != http.StatusUnprocessableEntity {
 		t.Fatalf("inverted window → %d, want 422", status)
 	}
-	if status := e.call(t, "GET", "/v1/ai/usage?from=2020-01-01&to=2026-07-14", nil, nil, nil); status != http.StatusUnprocessableEntity {
+	if status := e.Call(t, "GET", "/v1/ai/usage?from=2020-01-01&to=2026-07-14", nil, nil, nil); status != http.StatusUnprocessableEntity {
 		t.Fatalf("over-wide window → %d, want 422 (366-day cap)", status)
 	}
 }
@@ -133,9 +134,9 @@ func TestAiUsageOverHTTP(t *testing.T) {
 // day + task + TIER, the same grain as the wire) so the merge attaches
 // this call's cost to the one report line it belongs to, not a
 // broadcast across every tier row of the task.
-func seedAiCall(t *testing.T, e *env, wsID string, task, tier, provider, model string, tokensIn, tokensOut int, occurredAt time.Time) {
+func seedAiCall(t *testing.T, e *apptest.AppEnv, wsID string, task, tier, provider, model string, tokensIn, tokensOut int, occurredAt time.Time) {
 	t.Helper()
-	if _, err := e.owner.Exec(context.Background(), `
+	if _, err := e.Owner.Exec(context.Background(), `
 		INSERT INTO ai_call (workspace_id, task, tier, provider, model_id, request_fingerprint,
 		  tokens_in, tokens_out, occurred_at, logical_call_id)
 		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`,
@@ -146,9 +147,9 @@ func seedAiCall(t *testing.T, e *env, wsID string, task, tier, provider, model s
 }
 
 // seedAiModelRate inserts one ai_model_rate row effective on day.
-func seedAiModelRate(t *testing.T, e *env, wsID string, day time.Time) {
+func seedAiModelRate(t *testing.T, e *apptest.AppEnv, wsID string, day time.Time) {
 	t.Helper()
-	if _, err := e.owner.Exec(context.Background(), `
+	if _, err := e.Owner.Exec(context.Background(), `
 		INSERT INTO ai_model_rate (workspace_id, provider, model_id, input_per_mtok_microusd,
 		  output_per_mtok_microusd, cache_read_per_mtok_microusd, cache_write_per_mtok_microusd, effective_date)
 		VALUES ($1,'anthropic','claude-test-model',5000000,25000000,500000,6250000,$2)`,
@@ -167,12 +168,12 @@ func seedAiModelRate(t *testing.T, e *env, wsID string, day time.Time) {
 // summing cost_est_minor across a task's tier rows. A day/task with no
 // matching rate omits cost_est_minor instead of reporting a fabricated 0.
 func TestAiUsageCostOverHTTP(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 	seedAiUsage(t, e)
 	ctx := context.Background()
 	var wsID string
-	if err := e.owner.QueryRow(ctx, `SELECT id FROM workspace WHERE slug = $1`, e.slug).Scan(&wsID); err != nil {
+	if err := e.Owner.QueryRow(ctx, `SELECT id FROM workspace WHERE slug = $1`, e.Slug).Scan(&wsID); err != nil {
 		t.Fatalf("workspace lookup: %v", err)
 	}
 
@@ -200,7 +201,7 @@ func TestAiUsageCostOverHTTP(t *testing.T) {
 	seedAiCall(t, e, wsID, "enrich", "cheap_cloud", "anthropic", "no-rate-model", 500, 100, time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC))
 
 	var usage aiUsageDTO
-	if status := e.call(t, "GET", "/v1/ai/usage?from=2026-07-01&to=2026-07-31", nil, nil, &usage); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/ai/usage?from=2026-07-01&to=2026-07-31", nil, nil, &usage); status != http.StatusOK {
 		t.Fatalf("GET /ai/usage → %d, want 200", status)
 	}
 	if usage.Budget.Currency == nil || *usage.Budget.Currency != "USD" {

--- a/backend/internal/compose/integration/approval_idless_target_integration_test.go
+++ b/backend/internal/compose/integration/approval_idless_target_integration_test.go
@@ -17,17 +17,19 @@ package integration
 import (
 	"net/http"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 )
 
 func TestStagedCreateWithNoTargetIDIsListedAndDecidable(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 	org := anchorOrg(t, e, "Northwind")
 
 	var minted struct {
 		Token string `json:"token"`
 	}
-	if status := e.call(t, "POST", "/v1/passports", anyMap{
+	if status := e.Call(t, "POST", "/v1/passports", apptest.AnyMap{
 		"label": "create agent", "scopes": []string{"read", "write"},
 	}, nil, &minted); status != http.StatusCreated {
 		t.Fatalf("issue passport → %d", status)
@@ -36,12 +38,12 @@ func TestStagedCreateWithNoTargetIDIsListedAndDecidable(t *testing.T) {
 
 	// createProject is confirm-first, so the agent's call stages instead of
 	// writing. The identical body is the redemption key, so it is sent twice.
-	body := anyMap{"name": "Warehouse rollout", "organization_id": org, "source": "mcp"}
+	body := apptest.AnyMap{"name": "Warehouse rollout", "organization_id": org, "source": "mcp"}
 	var problem struct {
 		Code   string `json:"code"`
 		Detail string `json:"detail"`
 	}
-	if status := e.call(t, "POST", "/v1/projects", body, bearer, &problem); status != http.StatusForbidden ||
+	if status := e.Call(t, "POST", "/v1/projects", body, bearer, &problem); status != http.StatusForbidden ||
 		problem.Code != "approval_required" {
 		t.Fatalf("agent project create → %d %q, want 403 approval_required", status, problem.Code)
 	}
@@ -50,7 +52,7 @@ func TestStagedCreateWithNoTargetIDIsListedAndDecidable(t *testing.T) {
 	// The shape this test is about: the type the approved call will write, and
 	// no row for a scope probe to resolve.
 	var targetType, targetID *string
-	if err := e.owner.QueryRow(t.Context(),
+	if err := e.Owner.QueryRow(t.Context(),
 		`SELECT target_entity_type, target_entity_id FROM approval WHERE id = $1`,
 		approvalID).Scan(&targetType, &targetID); err != nil {
 		t.Fatal(err)
@@ -65,7 +67,7 @@ func TestStagedCreateWithNoTargetIDIsListedAndDecidable(t *testing.T) {
 	assertDecidableInTheInbox(t, e, approvalID, "project")
 
 	// And the decision releases the identical call, which lands the project.
-	if status := e.call(t, "POST", "/v1/approvals/"+approvalID+"/approve", anyMap{}, nil, nil); status != http.StatusOK {
+	if status := e.Call(t, "POST", "/v1/approvals/"+approvalID+"/approve", apptest.AnyMap{}, nil, nil); status != http.StatusOK {
 		t.Fatalf("human approve → %d", status)
 	}
 	withToken := map[string]string{
@@ -75,7 +77,7 @@ func TestStagedCreateWithNoTargetIDIsListedAndDecidable(t *testing.T) {
 		ID   string `json:"id"`
 		Name string `json:"name"`
 	}
-	if status := e.call(t, "POST", "/v1/projects", body, withToken, &created); status != http.StatusCreated {
+	if status := e.Call(t, "POST", "/v1/projects", body, withToken, &created); status != http.StatusCreated {
 		t.Fatalf("approved retry → %d, want 201 — the approval must release the staged create", status)
 	}
 	if created.ID == "" || created.Name != "Warehouse rollout" {

--- a/backend/internal/compose/integration/approval_targetarms_integration_test.go
+++ b/backend/internal/compose/integration/approval_targetarms_integration_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	"github.com/gradionhq/margince/backend/internal/modules/webhooks"
 )
 
@@ -32,30 +33,30 @@ func TestConfirmFirstArchivesAreDecidableForEveryTargetArm(t *testing.T) {
 	if err != nil {
 		t.Fatalf("cipher: %v", err)
 	}
-	e := setupWithOptions(t, compose.WithWebhookSigningKey(cipher))
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupAppWithOptions(t, compose.WithWebhookSigningKey(cipher))
+	e.BootstrapWorkspace(t)
 	bearer := agentBearer(t, e, "target-arm agent")
 
 	t.Run("list", func(t *testing.T) {
-		id := createdID(t, e, "/v1/lists", anyMap{"name": "Q3 Targets", "entity_type": "person"})
+		id := createdID(t, e, "/v1/lists", apptest.AnyMap{"name": "Q3 Targets", "entity_type": "person"})
 		releaseStagedCall(t, e, bearer, "DELETE", "/v1/lists/"+id, nil, "list")
 	})
 
 	t.Run("tag", func(t *testing.T) {
-		id := createdID(t, e, "/v1/tags", anyMap{"name": "Champion"})
+		id := createdID(t, e, "/v1/tags", apptest.AnyMap{"name": "Champion"})
 		releaseStagedCall(t, e, bearer, "DELETE", "/v1/tags/"+id, nil, "tag")
 	})
 
 	t.Run("saved_view", func(t *testing.T) {
-		id := createdID(t, e, "/v1/views", anyMap{
-			"resource": "people", "name": "My people", "query": anyMap{"columns": []any{"full_name"}},
+		id := createdID(t, e, "/v1/views", apptest.AnyMap{
+			"resource": "people", "name": "My people", "query": apptest.AnyMap{"columns": []any{"full_name"}},
 		})
 		releaseStagedCall(t, e, bearer, "DELETE", "/v1/views/"+id, nil, "saved_view")
 	})
 
 	t.Run("offer_template", func(t *testing.T) {
-		id := createdID(t, e, "/v1/offer-templates", anyMap{
-			"name": "Standard DE", "layout": anyMap{"logo_url": "https://example.test/logo.png"},
+		id := createdID(t, e, "/v1/offer-templates", apptest.AnyMap{
+			"name": "Standard DE", "layout": apptest.AnyMap{"logo_url": "https://example.test/logo.png"},
 		})
 		releaseStagedCall(t, e, bearer, "DELETE", "/v1/offer-templates/"+id, nil, "offer_template")
 	})
@@ -66,13 +67,13 @@ func TestConfirmFirstArchivesAreDecidableForEveryTargetArm(t *testing.T) {
 				ID string `json:"id"`
 			} `json:"subscription"`
 		}
-		if status := e.call(t, "POST", "/v1/webhook-subscriptions", anyMap{
+		if status := e.Call(t, "POST", "/v1/webhook-subscriptions", apptest.AnyMap{
 			"target_url": "https://ok.example/hook", "event_types": []string{"deal.created"},
 		}, nil, &created); status != http.StatusCreated {
 			t.Fatalf("create subscription → %d", status)
 		}
 		releaseStagedCall(t, e, bearer, "PATCH", "/v1/webhook-subscriptions/"+created.Subscription.ID,
-			anyMap{"state": "paused"}, "webhook_subscription")
+			apptest.AnyMap{"state": "paused"}, "webhook_subscription")
 	})
 }
 
@@ -90,8 +91,8 @@ func TestAStagedPatchIsRefusedWhenItsTargetMovedBeforeTheApproval(t *testing.T) 
 	if err != nil {
 		t.Fatalf("cipher: %v", err)
 	}
-	e := setupWithOptions(t, compose.WithWebhookSigningKey(cipher))
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupAppWithOptions(t, compose.WithWebhookSigningKey(cipher))
+	e.BootstrapWorkspace(t)
 	bearer := agentBearer(t, e, "skew agent")
 
 	var created struct {
@@ -100,19 +101,19 @@ func TestAStagedPatchIsRefusedWhenItsTargetMovedBeforeTheApproval(t *testing.T) 
 			Version int64  `json:"version"`
 		} `json:"subscription"`
 	}
-	if status := e.call(t, "POST", "/v1/webhook-subscriptions", anyMap{
+	if status := e.Call(t, "POST", "/v1/webhook-subscriptions", apptest.AnyMap{
 		"target_url": "https://ok.example/hook", "event_types": []string{"deal.created"},
 	}, nil, &created); status != http.StatusCreated {
 		t.Fatalf("create subscription → %d", status)
 	}
 	path := "/v1/webhook-subscriptions/" + created.Subscription.ID
-	staged := anyMap{"state": "paused"}
+	staged := apptest.AnyMap{"state": "paused"}
 
 	var problem struct {
 		Code   string `json:"code"`
 		Detail string `json:"detail"`
 	}
-	if status := e.call(t, "PATCH", path, staged, bearer, &problem); status != http.StatusForbidden ||
+	if status := e.Call(t, "PATCH", path, staged, bearer, &problem); status != http.StatusForbidden ||
 		problem.Code != "approval_required" {
 		t.Fatalf("agent patch → %d %q, want 403 approval_required", status, problem.Code)
 	}
@@ -125,7 +126,7 @@ func TestAStagedPatchIsRefusedWhenItsTargetMovedBeforeTheApproval(t *testing.T) 
 			Version int64 `json:"version"`
 		} `json:"subscription"`
 	}
-	if status := e.call(t, "PATCH", path, anyMap{"event_types": []string{"deal.updated"}}, nil, &edited); status != http.StatusOK {
+	if status := e.Call(t, "PATCH", path, apptest.AnyMap{"event_types": []string{"deal.updated"}}, nil, &edited); status != http.StatusOK {
 		t.Fatalf("admin re-point → %d", status)
 	}
 	if edited.Subscription.Version == created.Subscription.Version {
@@ -133,7 +134,7 @@ func TestAStagedPatchIsRefusedWhenItsTargetMovedBeforeTheApproval(t *testing.T) 
 			edited.Subscription.Version)
 	}
 
-	if status := e.call(t, "POST", "/v1/approvals/"+approvalID+"/approve", anyMap{}, nil, nil); status != http.StatusOK {
+	if status := e.Call(t, "POST", "/v1/approvals/"+approvalID+"/approve", apptest.AnyMap{}, nil, nil); status != http.StatusOK {
 		t.Fatalf("human approve → %d", status)
 	}
 	withToken := map[string]string{"X-Approval-Token": approvalID}
@@ -144,7 +145,7 @@ func TestAStagedPatchIsRefusedWhenItsTargetMovedBeforeTheApproval(t *testing.T) 
 		Code   string `json:"code"`
 		Detail string `json:"detail"`
 	}{}
-	if status := e.call(t, "PATCH", path, staged, withToken, &problem); status != http.StatusConflict ||
+	if status := e.Call(t, "PATCH", path, staged, withToken, &problem); status != http.StatusConflict ||
 		problem.Code != "version_skew" {
 		t.Fatalf("release over a moved row → %d %q, want 409 version_skew — the approval authorized the row "+
 			"the human saw, not whatever it became", status, problem.Code)
@@ -155,12 +156,12 @@ func TestAStagedPatchIsRefusedWhenItsTargetMovedBeforeTheApproval(t *testing.T) 
 // agent call carries. A passport is the credential the tool surface and REST
 // alike admit an agent under (ADR-0055), so it is what a confirm-first refusal
 // has to be provoked with.
-func agentBearer(t *testing.T, e *env, label string) map[string]string {
+func agentBearer(t *testing.T, e *apptest.AppEnv, label string) map[string]string {
 	t.Helper()
 	var minted struct {
 		Token string `json:"token"`
 	}
-	if status := e.call(t, "POST", "/v1/passports", anyMap{
+	if status := e.Call(t, "POST", "/v1/passports", apptest.AnyMap{
 		"label": label, "scopes": []string{"read", "write"},
 	}, nil, &minted); status != http.StatusCreated {
 		t.Fatalf("issue passport → %d", status)
@@ -170,12 +171,12 @@ func agentBearer(t *testing.T, e *env, label string) map[string]string {
 
 // createdID creates one record as the bootstrap admin over their session and
 // returns its id — the human-owned row a later agent call stages against.
-func createdID(t *testing.T, e *env, path string, body anyMap) string {
+func createdID(t *testing.T, e *apptest.AppEnv, path string, body apptest.AnyMap) string {
 	t.Helper()
 	var created struct {
 		ID string `json:"id"`
 	}
-	if status := e.call(t, "POST", path, body, nil, &created); status != http.StatusCreated {
+	if status := e.Call(t, "POST", path, body, nil, &created); status != http.StatusCreated {
 		t.Fatalf("POST %s → %d", path, status)
 	}
 	if created.ID == "" {
@@ -190,13 +191,13 @@ func createdID(t *testing.T, e *env, path string, body anyMap) string {
 //
 // The identical body is sent twice because the diff_hash binding is what makes an
 // approval authorize THIS call and no other.
-func releaseStagedCall(t *testing.T, e *env, bearer map[string]string, method, path string, body anyMap, wantTargetType string) {
+func releaseStagedCall(t *testing.T, e *apptest.AppEnv, bearer map[string]string, method, path string, body apptest.AnyMap, wantTargetType string) {
 	t.Helper()
 	var problem struct {
 		Code   string `json:"code"`
 		Detail string `json:"detail"`
 	}
-	if status := e.call(t, method, path, body, bearer, &problem); status != http.StatusForbidden ||
+	if status := e.Call(t, method, path, body, bearer, &problem); status != http.StatusForbidden ||
 		problem.Code != "approval_required" {
 		t.Fatalf("agent %s %s → %d %q, want 403 approval_required", method, path, status, problem.Code)
 	}
@@ -204,7 +205,7 @@ func releaseStagedCall(t *testing.T, e *env, bearer map[string]string, method, p
 
 	assertDecidableInTheInbox(t, e, approvalID, wantTargetType)
 
-	if status := e.call(t, "POST", "/v1/approvals/"+approvalID+"/approve", anyMap{}, nil, nil); status != http.StatusOK {
+	if status := e.Call(t, "POST", "/v1/approvals/"+approvalID+"/approve", apptest.AnyMap{}, nil, nil); status != http.StatusOK {
 		t.Fatalf("human approve → %d, want 200 — a row the inbox lists and cannot decide is the same dead "+
 			"end one step later", status)
 	}
@@ -214,7 +215,7 @@ func releaseStagedCall(t *testing.T, e *env, bearer map[string]string, method, p
 	}
 	// Every route here answers 200 on release: an archive returns the archived
 	// row and the subscription patch the updated one.
-	if status := e.call(t, method, path, body, withToken, nil); status != http.StatusOK {
+	if status := e.Call(t, method, path, body, withToken, nil); status != http.StatusOK {
 		t.Fatalf("approved retry → %d, want 200 — the decision must release the staged call", status)
 	}
 }

--- a/backend/internal/compose/integration/apptest/appenv.go
+++ b/backend/internal/compose/integration/apptest/appenv.go
@@ -248,10 +248,9 @@ func BootstrapWorkspaceSession(t *testing.T, e *AppEnv, organizationName, adminE
 	}
 }
 
-// CloseBody closes a response body and fails the test if it cannot, so a leaked
-// body is a red test rather than a slow drip nobody attributes.
-// CloseBody closes a response body and fails the test on a dirty close —
-// a broken close can hide a truncated read.
+// CloseBody closes a response body and fails the test on a dirty close: a
+// broken close can hide a truncated read, and a leaked body should be a red
+// test rather than a slow drip nobody attributes.
 func CloseBody(t *testing.T, resp *http.Response) {
 	t.Helper()
 	if err := resp.Body.Close(); err != nil {

--- a/backend/internal/compose/integration/apptest/appenv.go
+++ b/backend/internal/compose/integration/apptest/appenv.go
@@ -1,0 +1,288 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package apptest
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/cookiejar"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/platform/deployconfig"
+	"github.com/gradionhq/margince/backend/internal/platform/jobs"
+	"github.com/gradionhq/margince/backend/internal/platform/testdb"
+)
+
+// AppEnv is the heaviest of the three exported fixtures: a real compose handler
+// stack behind a TLS test server, with a cookie-jar client already logged in.
+// integration.Env and integration.SearchEnv give a suite a migrated database;
+// this gives it the running application, which is what a suite asserting
+// transport, session auth or an RFC 7807 body actually needs.
+//
+// It is AppEnv rather than Env because integration.Env is the database fixture.
+// TLS rather than plain HTTP because the session cookie is Secure per ADR-0043,
+// and a plain server would drop it and fail every authenticated call for a reason
+// unrelated to the test.
+type AppEnv struct {
+	TS     *httptest.Server
+	Client *http.Client
+	Slug   string
+	Owner  *pgx.Conn
+	Pool   *pgxpool.Pool
+}
+
+// SetupApp boots the default harness server — no schema pool, so the
+// customfields runtime-DDL operations answer their generated 501 (the
+// unwired-by-default posture). Suites that need the schema pool wired
+// (customfields_http_integration_test.go) call SetupAppWithOptions directly with
+// compose.WithSchemaPool(integration.SchemaPool(t)).
+func SetupApp(t *testing.T) *AppEnv {
+	t.Helper()
+	return SetupAppWithOptions(t)
+}
+
+// SetupAppWithOptions is SetupApp's body, parameterized over extra compose
+// options so a suite that needs a boot-optional seam (e.g. the
+// customfields schema pool) can wire it without duplicating the
+// migrate-and-boot ceremony every other suite in this package shares.
+func SetupAppWithOptions(t *testing.T, opts ...compose.Option) *AppEnv {
+	t.Helper()
+	return SetupAppWithOriginOptions(t, func(string) []compose.Option { return opts })
+}
+
+// SetupAppWithOriginOptions is SetupAppWithOptions for a suite whose wiring must
+// name the harness's OWN origin — the RFC 8414/9728 discovery documents carry
+// absolute URLs, and a suite asserting what a real client dereferences cannot
+// hardcode a port the OS assigns. The listener is opened before the handler is
+// composed, so the origin is known without booting twice.
+func SetupAppWithOriginOptions(t *testing.T, opts func(origin string) []compose.Option) *AppEnv {
+	t.Helper()
+	ownerDSN := os.Getenv("MARGINCE_TEST_DSN")
+	appDSN := os.Getenv("MARGINCE_TEST_APP_DSN")
+	if ownerDSN == "" || appDSN == "" {
+		t.Fatal("MARGINCE_TEST_DSN / MARGINCE_TEST_APP_DSN not set — run `make db-up` (integration tests fail loudly, they never skip)")
+	}
+	ctx := context.Background()
+
+	owner, err := pgx.Connect(ctx, ownerDSN)
+	if err != nil {
+		t.Fatalf("connecting as owner: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := owner.Close(context.Background()); err != nil {
+			t.Errorf("closing owner connection: %v", err)
+		}
+	})
+
+	if err := testdb.EnsureSchema(ctx, owner); err != nil {
+		t.Fatalf("migrating schema: %v", err)
+	}
+	if err := testdb.Reset(ctx, owner); err != nil {
+		t.Fatalf("resetting database: %v", err)
+	}
+
+	pool, err := database.NewPool(ctx, appDSN)
+	if err != nil {
+		t.Fatalf("opening app pool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	// The delivery machinery every send transport is composed with in the api
+	// role. Without it a send refuses rather than log an activity claiming a
+	// message went out, so a harness missing it would test the refusal in
+	// every suite that sends — including the consent and preference-center
+	// suites, whose subject is what happens AFTER a send is accepted.
+	applyRiverSchema(t)
+	sendInserter, err := jobs.NewInserter(pool, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err != nil {
+		t.Fatalf("jobs.NewInserter: %v", err)
+	}
+	// Unstarted, so the listener's port is known before the handler is
+	// composed: StartTLS below serves the same handler NewTLSServer would.
+	ts := httptest.NewUnstartedServer(nil)
+	origin := "https://" + ts.Listener.Addr().String()
+	allOpts := append([]compose.Option{
+		compose.WithPublicBaseURL("https://mail.example.test"),
+		compose.WithDelivery(compose.NewDeliveryStager(pool, sendInserter)),
+	}, opts(origin)...)
+	ts.Config.Handler = compose.New(pool, slog.New(slog.NewTextHandler(os.Stderr, nil)), allOpts...)
+	ts.StartTLS()
+	t.Cleanup(ts.Close)
+
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("cookie jar: %v", err)
+	}
+	client := ts.Client()
+	client.Jar = jar
+
+	return &AppEnv{TS: ts, Client: client, Slug: "fable-e2e", Owner: owner, Pool: pool}
+}
+
+// BootstrapWorkspace provisions the organization + admin (the A107 boot
+// path) and leaves the admin session cookie in the client jar — the
+// first step of every e2e scenario.
+func (e *AppEnv) BootstrapWorkspace(t *testing.T) {
+	t.Helper()
+	BootstrapWorkspaceSession(t, e, "Fable E2E", "ada@example.com", "Ada Admin")
+	e.Slug = "fable-e2e" // slugify("Fable E2E")
+}
+
+// SetWorkspaceSeat flips a workspace's users to a seat type through the
+// owner connection, inside a workspace-bound transaction so RLS (FORCE)
+// admits the UPDATE. Used to drive the read-seat ceiling from a test.
+func (e *AppEnv) SetWorkspaceSeat(t *testing.T, slug, seat string) {
+	t.Helper()
+	ctx := context.Background()
+	tx, err := e.Owner.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	//craft:ignore swallowed-errors error-path safety net only — the Commit below is asserted, after which this rollback is a designed no-op
+	defer func() { _ = tx.Rollback(ctx) }()
+	var wsID string
+	if err := tx.QueryRow(ctx, `SELECT id FROM workspace WHERE slug = $1`, slug).Scan(&wsID); err != nil {
+		t.Fatalf("workspace lookup: %v", err)
+	}
+	if _, err := tx.Exec(ctx, `SELECT set_config('app.workspace_id', $1, true)`, wsID); err != nil {
+		t.Fatalf("set guc: %v", err)
+	}
+	if _, err := tx.Exec(ctx, `UPDATE app_user SET seat_type = $2 WHERE workspace_id = $1`, wsID, seat); err != nil {
+		t.Fatalf("seat update: %v", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+}
+
+// Call issues one API request with the dev workspace header and decodes
+// the JSON response into out (when non-nil), returning the status code.
+//
+//craft:ignore naked-any the test transport seam: body/out are whichever request/response shapes the scenario exercises
+func (e *AppEnv) Call(t *testing.T, method, path string, body any, headers map[string]string, out any) int {
+	t.Helper()
+	var reqBody io.Reader
+	if body != nil {
+		raw, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshaling request: %v", err)
+		}
+		reqBody = bytes.NewReader(raw)
+	}
+	req, err := http.NewRequestWithContext(context.Background(), method, e.TS.URL+path, reqBody)
+	if err != nil {
+		t.Fatalf("building request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := e.Client.Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, path, err)
+	}
+	defer CloseBody(t, resp)
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("reading response: %v", err)
+	}
+	if out != nil && len(raw) > 0 {
+		if err := json.Unmarshal(raw, out); err != nil {
+			t.Fatalf("%s %s: decoding %q: %v", method, path, raw, err)
+		}
+	}
+	return resp.StatusCode
+}
+
+// AnyMap is the shape a scenario builds an ad-hoc JSON request body in, and
+// reads a response into when it asserts on one or two fields rather than a
+// typed struct. An alias, not a new type, so it interchanges freely with the
+// map literals the suites already write.
+type AnyMap = map[string]any
+
+// BootstrapWorkspaceSession provisions the installation's organization through
+// the A107 boot path — configuration-driven, exactly what cmd/api runs at
+// startup — and signs its admin in over HTTP. The arrange step every e2e
+// scenario shares. The login also primes the server's singleton-organization
+// resolution before a test seeds any cross-tenant rows directly.
+//
+// It lives here rather than with a suite because BootstrapWorkspace above calls
+// it, and a non-test file cannot reach a helper declared in a _test.go one.
+func BootstrapWorkspaceSession(t *testing.T, e *AppEnv, organizationName, adminEmail, adminName string) {
+	t.Helper()
+	pwFile := filepath.Join(t.TempDir(), "admin-password")
+	if err := os.WriteFile(pwFile, []byte("correct-horse-battery"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg := deployconfig.Config{
+		Version:      1,
+		Organization: deployconfig.Organization{Name: organizationName},
+		BootstrapAdmin: &deployconfig.BootstrapAdmin{
+			Email: adminEmail, DisplayName: adminName, PasswordFile: pwFile,
+		},
+	}
+	if err := compose.EnsureInstallation(context.Background(), e.Pool, slog.New(slog.NewTextHandler(io.Discard, nil)), cfg); err != nil {
+		t.Fatalf("bootstrap: %v", err)
+	}
+	if status := e.Call(t, "POST", "/v1/auth/login", AnyMap{
+		"email": adminEmail, "password": "correct-horse-battery",
+	}, nil, nil); status != http.StatusOK {
+		t.Fatalf("login → %d", status)
+	}
+}
+
+// CloseBody closes a response body and fails the test if it cannot, so a leaked
+// body is a red test rather than a slow drip nobody attributes.
+// CloseBody closes a response body and fails the test on a dirty close —
+// a broken close can hide a truncated read.
+func CloseBody(t *testing.T, resp *http.Response) {
+	t.Helper()
+	if err := resp.Body.Close(); err != nil {
+		t.Errorf("closing response body: %v", err)
+	}
+}
+
+// applyRiverSchema gives the booted app River's schema on the harness-migrated
+// database, as cmd/migrate does after core and custom.
+//
+// A near-copy of integration.ApplyRiverSchema, and deliberately so. This package
+// exists to break an import cycle: package compose's own white-box tests import
+// package integration, so nothing there may import compose — and this fixture
+// boots a compose handler stack. Importing integration back from here would
+// close the cycle the other way round, because integration's suites import this
+// package. Twelve duplicated lines are what that boundary costs, and the
+// original cannot move here either: package compose's tests use it too, and
+// would then reach compose through it.
+func applyRiverSchema(t *testing.T) {
+	t.Helper()
+	ownerDSN := os.Getenv("MARGINCE_TEST_DSN")
+	if ownerDSN == "" {
+		t.Fatal("MARGINCE_TEST_DSN not set — run `make db-up` (integration tests fail loudly, they never skip)")
+	}
+	ctx := context.Background()
+	ownerPool, err := database.NewPool(ctx, ownerDSN)
+	if err != nil {
+		t.Fatalf("opening owner pool: %v", err)
+	}
+	defer ownerPool.Close()
+	if err := testdb.EnsureRiverSchema(ctx, ownerPool, jobs.Migrate); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/backend/internal/compose/integration/apptest/doc.go
+++ b/backend/internal/compose/integration/apptest/doc.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+// Package apptest holds AppEnv, the booted-application fixture: a real compose
+// handler stack behind a TLS test server, with a cookie-jar client already
+// logged in. Env and SearchEnv next door hand a suite a migrated database; this
+// hands it the running application, which is what a suite asserting transport,
+// session auth or an RFC 7807 body needs.
+//
+// It is a package of its own because of an import cycle, not for tidiness.
+// Package compose's white-box tests import package integration, so nothing in
+// integration may import compose — and this fixture boots a compose handler
+// stack. One level down, importing compose is free, and integration's suites
+// import this package rather than the other way round.
+//
+// That direction is load-bearing: nothing here may import
+// internal/compose/integration, or the cycle closes from this side instead.
+// applyRiverSchema is duplicated from there for exactly that reason, and says so.
+//
+// The fixture is exported down to its fields because suite packages split out of
+// integration ride it from outside. A method declared on it in another package is
+// illegal Go, so a helper a suite keeps for itself is a function taking *AppEnv,
+// not a method on it.
+package apptest

--- a/backend/internal/compose/integration/automation_runs_preview_integration_test.go
+++ b/backend/internal/compose/integration/automation_runs_preview_integration_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -48,15 +49,15 @@ type automationRunsPage struct {
 // createRouteLeadAutomation creates one valid assign_lead_owner instance
 // over the API and returns its id (it lands paused; runs/preview do not
 // care).
-func createRouteLeadAutomation(t *testing.T, e *env) string {
+func createRouteLeadAutomation(t *testing.T, e *apptest.AppEnv) string {
 	t.Helper()
 	var created struct {
 		ID  string `json:"id"`
 		Key string `json:"key"`
 	}
-	if status := e.call(t, "POST", "/v1/automations", anyMap{
+	if status := e.Call(t, "POST", "/v1/automations", apptest.AnyMap{
 		"key": "assign_lead_owner", "name": "Router under observation",
-		"params": anyMap{"owners": []string{"0198c0de-0000-7000-8000-000000000001"}, "cap_per_owner": 3},
+		"params": apptest.AnyMap{"owners": []string{"0198c0de-0000-7000-8000-000000000001"}, "cap_per_owner": 3},
 	}, nil, &created); status != http.StatusCreated {
 		t.Fatalf("create automation → %d", status)
 	}
@@ -65,11 +66,11 @@ func createRouteLeadAutomation(t *testing.T, e *env) string {
 
 // workspaceIDBySlug resolves the bootstrapped tenant's id through the
 // owner connection for RLS-free seeding.
-func workspaceIDBySlug(t *testing.T, e *env) string {
+func workspaceIDBySlug(t *testing.T, e *apptest.AppEnv) string {
 	t.Helper()
 	var wsID string
-	if err := e.owner.QueryRow(context.Background(),
-		`SELECT id FROM workspace WHERE slug = $1`, e.slug).Scan(&wsID); err != nil {
+	if err := e.Owner.QueryRow(context.Background(),
+		`SELECT id FROM workspace WHERE slug = $1`, e.Slug).Scan(&wsID); err != nil {
 		t.Fatalf("workspace lookup: %v", err)
 	}
 	return wsID
@@ -82,14 +83,14 @@ func workspaceIDBySlug(t *testing.T, e *env) string {
 // shape (nil for a clean run) — this suite seeds rows directly at the DB,
 // bypassing the engine, so it must match that shape for the HTTP read
 // side (ListRuns/wireAutomationRun) to render the reason correctly.
-func seedWorkflowRun(t *testing.T, e *env, wsID, automationID, status string, planned, applied *string, detail []byte, at time.Time) {
+func seedWorkflowRun(t *testing.T, e *apptest.AppEnv, wsID, automationID, status string, planned, applied *string, detail []byte, at time.Time) {
 	t.Helper()
 	runID := ids.NewV7().String()
 	plannedJSON := "[]"
 	if planned != nil {
 		plannedJSON = *planned
 	}
-	if _, err := e.owner.Exec(context.Background(), `
+	if _, err := e.Owner.Exec(context.Background(), `
 		INSERT INTO workflow_run (id, workspace_id, handler, idempotency_key, trigger_event, planned, applied, status, detail, created_at)
 		VALUES ($1, $2, 'assign_lead_owner', $3, $4, $5, $6, $7, $8, $9)`,
 		runID, wsID, fmt.Sprintf("assign_lead_owner:%s@%s", runID, automationID),
@@ -123,8 +124,8 @@ func requireStr(t *testing.T, field string, got *string, want string) {
 }
 
 func TestAutomationRunHistoryAndPreviewOverHTTP(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 	autoID := createRouteLeadAutomation(t, e)
 
 	assertRunsStartEmptyAndHideAbsentInstances(t, e, autoID)
@@ -135,10 +136,10 @@ func TestAutomationRunHistoryAndPreviewOverHTTP(t *testing.T) {
 // assertRunsStartEmptyAndHideAbsentInstances pins the empty-history page
 // shape, existence-hiding on an unknown id, and the 422 on an outcome
 // outside the wire vocabulary.
-func assertRunsStartEmptyAndHideAbsentInstances(t *testing.T, e *env, autoID string) {
+func assertRunsStartEmptyAndHideAbsentInstances(t *testing.T, e *apptest.AppEnv, autoID string) {
 	t.Helper()
 	var page automationRunsPage
-	if status := e.call(t, "GET", "/v1/automations/"+autoID+"/runs", nil, nil, &page); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/automations/"+autoID+"/runs", nil, nil, &page); status != http.StatusOK {
 		t.Fatalf("runs on a never-fired automation → %d", status)
 	}
 	if page.Data == nil || len(page.Data) != 0 || page.Page.HasMore {
@@ -146,10 +147,10 @@ func assertRunsStartEmptyAndHideAbsentInstances(t *testing.T, e *env, autoID str
 	}
 
 	unknown := ids.NewV7().String()
-	if status := e.call(t, "GET", "/v1/automations/"+unknown+"/runs", nil, nil, nil); status != http.StatusNotFound {
+	if status := e.Call(t, "GET", "/v1/automations/"+unknown+"/runs", nil, nil, nil); status != http.StatusNotFound {
 		t.Fatalf("runs on an unknown automation → %d, want 404", status)
 	}
-	if status := e.call(t, "GET", "/v1/automations/"+autoID+"/runs?outcome=exploded", nil, nil, nil); status != 422 {
+	if status := e.Call(t, "GET", "/v1/automations/"+autoID+"/runs?outcome=exploded", nil, nil, nil); status != 422 {
 		t.Fatalf("outcome outside the vocabulary → %d, want 422", status)
 	}
 }
@@ -158,7 +159,7 @@ func assertRunsStartEmptyAndHideAbsentInstances(t *testing.T, e *env, autoID str
 // engine status and checks the wire mapping: reason rides only reasoned
 // outcomes, approval_required marks the parked/blocked ones, and the
 // fired run names its action kinds and first target.
-func assertRunsRenderEveryOutcomeWithItsTrace(t *testing.T, e *env, autoID string) {
+func assertRunsRenderEveryOutcomeWithItsTrace(t *testing.T, e *apptest.AppEnv, autoID string) {
 	t.Helper()
 	wsID := workspaceIDBySlug(t, e)
 	targetLead := ids.NewV7().String()
@@ -172,7 +173,7 @@ func assertRunsRenderEveryOutcomeWithItsTrace(t *testing.T, e *env, autoID strin
 		reason("staged as approval "+ids.NewV7().String()+"; awaiting the human decision"), base.Add(2*time.Minute))
 
 	var page automationRunsPage
-	if status := e.call(t, "GET", "/v1/automations/"+autoID+"/runs", nil, nil, &page); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/automations/"+autoID+"/runs", nil, nil, &page); status != http.StatusOK {
 		t.Fatalf("runs → %d", status)
 	}
 	if len(page.Data) != 3 {
@@ -212,7 +213,7 @@ func assertRunsRenderEveryOutcomeWithItsTrace(t *testing.T, e *env, autoID strin
 
 	// The wire outcome filter narrows to exactly the fired run.
 	var onlyFired automationRunsPage
-	if status := e.call(t, "GET", "/v1/automations/"+autoID+"/runs?outcome=fired", nil, nil, &onlyFired); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/automations/"+autoID+"/runs?outcome=fired", nil, nil, &onlyFired); status != http.StatusOK {
 		t.Fatalf("outcome=fired → %d", status)
 	}
 	if len(onlyFired.Data) != 1 || onlyFired.Data[0].ID != fired.ID {
@@ -224,19 +225,19 @@ func assertRunsRenderEveryOutcomeWithItsTrace(t *testing.T, e *env, autoID strin
 // assign_lead_owner recipe counts the open unrouted lead pool, the draft
 // override previews another catalog type before saving, the editor's 422
 // vocabulary matches a save's, and the whole thing leaves zero rows.
-func assertPreviewMeasuresWithoutWriting(t *testing.T, e *env, autoID string) {
+func assertPreviewMeasuresWithoutWriting(t *testing.T, e *apptest.AppEnv, autoID string) {
 	t.Helper()
 	var lead struct {
 		ID string `json:"id"`
 	}
-	if status := e.call(t, "POST", "/v1/leads", anyMap{
+	if status := e.Call(t, "POST", "/v1/leads", apptest.AnyMap{
 		"full_name": "Uma Unrouted", "source": "manual",
 	}, nil, &lead); status != http.StatusCreated {
 		t.Fatalf("create lead → %d", status)
 	}
 
 	var rowsBefore int
-	if err := e.owner.QueryRow(context.Background(), `
+	if err := e.Owner.QueryRow(context.Background(), `
 		SELECT (SELECT count(*) FROM audit_log)
 		     + (SELECT count(*) FROM event_outbox)
 		     + (SELECT count(*) FROM workflow_run)`).Scan(&rowsBefore); err != nil {
@@ -250,7 +251,7 @@ func assertPreviewMeasuresWithoutWriting(t *testing.T, e *env, autoID string) {
 		Sample               *[]string `json:"sample"`
 		ExcludedByPermission *int      `json:"excluded_by_permission"`
 	}
-	if status := e.call(t, "POST", "/v1/automations/"+autoID+"/preview", anyMap{}, nil, &preview); status != http.StatusOK {
+	if status := e.Call(t, "POST", "/v1/automations/"+autoID+"/preview", apptest.AnyMap{}, nil, &preview); status != http.StatusOK {
 		t.Fatalf("preview → %d", status)
 	}
 	if preview.MatchesNow != 1 || preview.WindowDays != 30 {
@@ -272,7 +273,7 @@ func assertPreviewMeasuresWithoutWriting(t *testing.T, e *env, autoID string) {
 		MatchesNow int `json:"matches_now"`
 		WindowDays int `json:"window_days"`
 	}
-	if status := e.call(t, "POST", "/v1/automations/"+autoID+"/preview", anyMap{
+	if status := e.Call(t, "POST", "/v1/automations/"+autoID+"/preview", apptest.AnyMap{
 		"key": "stage_change_create_task", "window_days": 7,
 	}, nil, &draft); status != http.StatusOK {
 		t.Fatalf("draft-override preview → %d", status)
@@ -282,19 +283,19 @@ func assertPreviewMeasuresWithoutWriting(t *testing.T, e *env, autoID string) {
 	}
 
 	// The editor's preview 422s match its save 422s.
-	if status := e.call(t, "POST", "/v1/automations/"+autoID+"/preview", anyMap{"key": "invented_type"}, nil, nil); status != 422 {
+	if status := e.Call(t, "POST", "/v1/automations/"+autoID+"/preview", apptest.AnyMap{"key": "invented_type"}, nil, nil); status != 422 {
 		t.Fatalf("preview with a non-catalog key → %d, want 422", status)
 	}
-	if status := e.call(t, "POST", "/v1/automations/"+autoID+"/preview", anyMap{"window_days": 0}, nil, nil); status != 422 {
+	if status := e.Call(t, "POST", "/v1/automations/"+autoID+"/preview", apptest.AnyMap{"window_days": 0}, nil, nil); status != 422 {
 		t.Fatalf("preview with a zero window → %d, want 422", status)
 	}
 	unknown := ids.NewV7().String()
-	if status := e.call(t, "POST", "/v1/automations/"+unknown+"/preview", anyMap{}, nil, nil); status != http.StatusNotFound {
+	if status := e.Call(t, "POST", "/v1/automations/"+unknown+"/preview", apptest.AnyMap{}, nil, nil); status != http.StatusNotFound {
 		t.Fatalf("preview on an unknown automation → %d, want 404 (existence-hiding, like Get)", status)
 	}
 
 	var rowsAfter int
-	if err := e.owner.QueryRow(context.Background(), `
+	if err := e.Owner.QueryRow(context.Background(), `
 		SELECT (SELECT count(*) FROM audit_log)
 		     + (SELECT count(*) FROM event_outbox)
 		     + (SELECT count(*) FROM workflow_run)`).Scan(&rowsAfter); err != nil {

--- a/backend/internal/compose/integration/automations_integration_test.go
+++ b/backend/internal/compose/integration/automations_integration_test.go
@@ -14,11 +14,13 @@ package integration
 import (
 	"net/http"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 )
 
 func TestAutomationCatalogAndCRUD(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 
 	assertAutomationCatalogIsClosed(t, e)
 	assertBootstrapSeededStartersEnabled(t, e)
@@ -27,14 +29,14 @@ func TestAutomationCatalogAndCRUD(t *testing.T) {
 
 	// Enable under a stale If-Match is refused; the current version wins.
 	stale := map[string]string{"If-Match": "99"}
-	if status := e.call(t, "PATCH", "/v1/automations/"+createdID, anyMap{"status": "enabled"}, stale, nil); status != http.StatusConflict {
+	if status := e.Call(t, "PATCH", "/v1/automations/"+createdID, apptest.AnyMap{"status": "enabled"}, stale, nil); status != http.StatusConflict {
 		t.Fatalf("stale If-Match → %d, want 409 version_skew", status)
 	}
 	var updated struct {
 		Status  string `json:"status"`
 		Version int    `json:"version"`
 	}
-	if status := e.call(t, "PATCH", "/v1/automations/"+createdID, anyMap{"status": "enabled"},
+	if status := e.Call(t, "PATCH", "/v1/automations/"+createdID, apptest.AnyMap{"status": "enabled"},
 		map[string]string{"If-Match": "1"}, &updated); status != http.StatusOK {
 		t.Fatalf("enable → %d", status)
 	}
@@ -43,18 +45,18 @@ func TestAutomationCatalogAndCRUD(t *testing.T) {
 	}
 
 	// Delete is a soft archive: 204, then the instance reads as absent.
-	if status := e.call(t, "DELETE", "/v1/automations/"+createdID, nil, nil, nil); status != http.StatusNoContent {
+	if status := e.Call(t, "DELETE", "/v1/automations/"+createdID, nil, nil, nil); status != http.StatusNoContent {
 		t.Fatalf("delete → %d", status)
 	}
-	if status := e.call(t, "GET", "/v1/automations/"+createdID, nil, nil, nil); status != http.StatusNotFound {
+	if status := e.Call(t, "GET", "/v1/automations/"+createdID, nil, nil, nil); status != http.StatusNotFound {
 		t.Fatalf("get after delete → %d, want 404", status)
 	}
 
 	// Config is an audited fact end to end.
 	var audit struct {
-		Data []anyMap `json:"data"`
+		Data []apptest.AnyMap `json:"data"`
 	}
-	if status := e.call(t, "GET", "/v1/audit-log?entity_type=automation", nil, nil, &audit); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/audit-log?entity_type=automation", nil, nil, &audit); status != http.StatusOK {
 		t.Fatalf("audit read → %d", status)
 	}
 	if len(audit.Data) != 3 {
@@ -66,7 +68,7 @@ func TestAutomationCatalogAndCRUD(t *testing.T) {
 // authorable library — the six seeded templates plus assign_lead_owner
 // and stage_change_create_task (authorable, never seeded) — every
 // entry auto_execute and shipping a params schema for the editor form.
-func assertAutomationCatalogIsClosed(t *testing.T, e *env) {
+func assertAutomationCatalogIsClosed(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
 	// The catalog is the closed authorable library.
 	var catalog struct {
@@ -76,7 +78,7 @@ func assertAutomationCatalogIsClosed(t *testing.T, e *env) {
 			ParamsSchema map[string]any `json:"params_schema"`
 		} `json:"data"`
 	}
-	if status := e.call(t, "GET", "/v1/automations/catalog", nil, nil, &catalog); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/automations/catalog", nil, nil, &catalog); status != http.StatusOK {
 		t.Fatalf("catalog → %d", status)
 	}
 	if len(catalog.Data) != 8 {
@@ -95,7 +97,7 @@ func assertAutomationCatalogIsClosed(t *testing.T, e *env) {
 // assertBootstrapSeededStartersEnabled checks the workspace bootstrap
 // seeded EXACTLY the six starter templates already enabled (UAT.md:72)
 // — the recorded deviation from the API path's created-paused rule.
-func assertBootstrapSeededStartersEnabled(t *testing.T, e *env) {
+func assertBootstrapSeededStartersEnabled(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
 	// Bootstrap seeded the six starters ENABLED (system floor, recorded
 	// deviation from created-paused which governs the API path).
@@ -107,7 +109,7 @@ func assertBootstrapSeededStartersEnabled(t *testing.T, e *env) {
 			Version int    `json:"version"`
 		} `json:"data"`
 	}
-	if status := e.call(t, "GET", "/v1/automations", nil, nil, &listed); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/automations", nil, nil, &listed); status != http.StatusOK {
 		t.Fatalf("list → %d", status)
 	}
 	if len(listed.Data) != 6 {
@@ -123,21 +125,21 @@ func assertBootstrapSeededStartersEnabled(t *testing.T, e *env) {
 // assertAutomationCreateValidatesParams checks create refuses anything
 // outside the catalog contract: unknown keys, mistyped params, and
 // out-of-schema knobs (the anti-DSL guard) are all 422s.
-func assertAutomationCreateValidatesParams(t *testing.T, e *env) {
+func assertAutomationCreateValidatesParams(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
 	// An unknown catalog key and out-of-schema params are 422s.
-	if status := e.call(t, "POST", "/v1/automations", anyMap{
-		"key": "invented_type", "name": "Nope", "params": anyMap{},
+	if status := e.Call(t, "POST", "/v1/automations", apptest.AnyMap{
+		"key": "invented_type", "name": "Nope", "params": apptest.AnyMap{},
 	}, nil, nil); status != 422 {
 		t.Fatalf("unknown key → %d, want 422", status)
 	}
-	if status := e.call(t, "POST", "/v1/automations", anyMap{
-		"key": "assign_lead_owner", "name": "Bad params", "params": anyMap{"cap_per_owner": "soon"},
+	if status := e.Call(t, "POST", "/v1/automations", apptest.AnyMap{
+		"key": "assign_lead_owner", "name": "Bad params", "params": apptest.AnyMap{"cap_per_owner": "soon"},
 	}, nil, nil); status != 422 {
 		t.Fatalf("mistyped param → %d, want 422", status)
 	}
-	if status := e.call(t, "POST", "/v1/automations", anyMap{
-		"key": "assign_lead_owner", "name": "Rogue knob", "params": anyMap{"rule_body": "if x then y"},
+	if status := e.Call(t, "POST", "/v1/automations", apptest.AnyMap{
+		"key": "assign_lead_owner", "name": "Rogue knob", "params": apptest.AnyMap{"rule_body": "if x then y"},
 	}, nil, nil); status != 422 {
 		t.Fatalf("out-of-schema param → %d, want 422 (the anti-DSL guard)", status)
 	}
@@ -145,7 +147,7 @@ func assertAutomationCreateValidatesParams(t *testing.T, e *env) {
 
 // createPausedAutomation creates a valid assign_lead_owner instance,
 // asserts it lands paused and round-trips its config, and returns its id.
-func createPausedAutomation(t *testing.T, e *env) string {
+func createPausedAutomation(t *testing.T, e *apptest.AppEnv) string {
 	t.Helper()
 	// A valid create lands PAUSED and round-trips.
 	var created struct {
@@ -154,9 +156,9 @@ func createPausedAutomation(t *testing.T, e *env) string {
 		Params  map[string]any `json:"params"`
 		Version int            `json:"version"`
 	}
-	if status := e.call(t, "POST", "/v1/automations", anyMap{
+	if status := e.Call(t, "POST", "/v1/automations", apptest.AnyMap{
 		"key": "assign_lead_owner", "name": "Slow-lane routing",
-		"params": anyMap{"owners": []string{"0198c0de-0000-7000-8000-000000000001"}, "cap_per_owner": 3},
+		"params": apptest.AnyMap{"owners": []string{"0198c0de-0000-7000-8000-000000000001"}, "cap_per_owner": 3},
 	}, nil, &created); status != http.StatusCreated {
 		t.Fatalf("create → %d", status)
 	}
@@ -167,7 +169,7 @@ func createPausedAutomation(t *testing.T, e *env) string {
 		Name   string         `json:"name"`
 		Params map[string]any `json:"params"`
 	}
-	if status := e.call(t, "GET", "/v1/automations/"+created.ID, nil, nil, &fetched); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/automations/"+created.ID, nil, nil, &fetched); status != http.StatusOK {
 		t.Fatalf("get → %d", status)
 	}
 	if fetched.Name != "Slow-lane routing" || fetched.Params["cap_per_owner"] != float64(3) {
@@ -179,21 +181,21 @@ func createPausedAutomation(t *testing.T, e *env) string {
 // An agent passport cannot touch automation config: standing automation
 // authority stays human (the ADR-0055 human-only class).
 func TestAutomationConfigRejectsAgents(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 
 	var minted struct {
 		Token string `json:"token"`
 	}
-	if status := e.call(t, "POST", "/v1/passports", anyMap{
+	if status := e.Call(t, "POST", "/v1/passports", apptest.AnyMap{
 		"label": "automation prober", "scopes": []string{"read", "write"},
 	}, nil, &minted); status != http.StatusCreated {
 		t.Fatalf("mint → %d", status)
 	}
 	bearer := map[string]string{"Authorization": "Bearer " + minted.Token}
 
-	if status := e.call(t, "POST", "/v1/automations", anyMap{
-		"key": "assign_lead_owner", "name": "Agent-made", "params": anyMap{},
+	if status := e.Call(t, "POST", "/v1/automations", apptest.AnyMap{
+		"key": "assign_lead_owner", "name": "Agent-made", "params": apptest.AnyMap{},
 	}, bearer, nil); status != http.StatusForbidden {
 		t.Fatalf("agent create automation → %d, want 403", status)
 	}

--- a/backend/internal/compose/integration/booking_consent_integration_test.go
+++ b/backend/internal/compose/integration/booking_consent_integration_test.go
@@ -18,17 +18,18 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
 // bookingAt shapes one /v1/bookings body for a fixed Tuesday slot,
 // linked to the person; extra fields merge over the base.
-func bookingAt(start time.Time, personID string, extra anyMap) anyMap {
-	body := anyMap{
+func bookingAt(start time.Time, personID string, extra apptest.AnyMap) apptest.AnyMap {
+	body := apptest.AnyMap{
 		"start":   start,
 		"end":     start.Add(30 * time.Minute),
 		"subject": "Consented discovery call",
-		"links":   []anyMap{{"entity_type": "person", "entity_id": personID}},
+		"links":   []apptest.AnyMap{{"entity_type": "person", "entity_id": personID}},
 	}
 	for k, v := range extra {
 		body[k] = v
@@ -37,20 +38,20 @@ func bookingAt(start time.Time, personID string, extra anyMap) anyMap {
 }
 
 func TestBookingConsentPassthrough(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 	purposeID := seededTransactionalPurposeID(t, e)
 
 	var person struct {
 		ID string `json:"id"`
 	}
-	if status := e.call(t, "POST", "/v1/people", anyMap{"full_name": "Carla Consenting"}, nil, &person); status != http.StatusCreated {
+	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{"full_name": "Carla Consenting"}, nil, &person); status != http.StatusCreated {
 		t.Fatalf("create person → %d", status)
 	}
 
 	// A fixed Tuesday keeps every slot inside business hours.
 	tuesday := time.Date(2026, 7, 14, 10, 0, 0, 0, time.UTC)
-	consent := anyMap{
+	consent := apptest.AnyMap{
 		"purpose_id":     purposeID,
 		"policy_version": "pp-2026-01",
 		"wording":        "You agree we may contact you about this meeting.",
@@ -64,37 +65,37 @@ func TestBookingConsentPassthrough(t *testing.T) {
 // assertConsentRefusalsLeaveNothingBehind drives every unrecordable
 // consent shape and proves each refused before a single write: no
 // meeting, no consent state, and the slot still free.
-func assertConsentRefusalsLeaveNothingBehind(t *testing.T, e *env, personID string, tuesday time.Time, purposeID string) {
+func assertConsentRefusalsLeaveNothingBehind(t *testing.T, e *apptest.AppEnv, personID string, tuesday time.Time, purposeID string) {
 	t.Helper()
 	slot := tuesday // 10:00 — reused by every refusal, then proven free
 
 	// An unknown purpose cannot be recorded.
-	unknownPurpose := bookingAt(slot, personID, anyMap{
-		"consent": anyMap{"purpose_id": ids.NewV7().String(), "policy_version": "pp-2026-01"},
+	unknownPurpose := bookingAt(slot, personID, apptest.AnyMap{
+		"consent": apptest.AnyMap{"purpose_id": ids.NewV7().String(), "policy_version": "pp-2026-01"},
 	})
-	if status := e.call(t, "POST", "/v1/bookings", unknownPurpose, nil, nil); status != 422 {
+	if status := e.Call(t, "POST", "/v1/bookings", unknownPurpose, nil, nil); status != 422 {
 		t.Fatalf("booking with an unknown consent purpose → %d, want 422", status)
 	}
 
 	// The wording version shown to the subject is the proof's anchor.
-	noPolicy := bookingAt(slot, personID, anyMap{
-		"consent": anyMap{"purpose_id": purposeID},
+	noPolicy := bookingAt(slot, personID, apptest.AnyMap{
+		"consent": apptest.AnyMap{"purpose_id": purposeID},
 	})
-	if status := e.call(t, "POST", "/v1/bookings", noPolicy, nil, nil); status != 422 {
+	if status := e.Call(t, "POST", "/v1/bookings", noPolicy, nil, nil); status != 422 {
 		t.Fatalf("booking consent without policy_version → %d, want 422", status)
 	}
 
 	// Consent is person-keyed: no linked person, nothing to attach to.
-	subjectless := bookingAt(slot, personID, anyMap{
-		"links":   []anyMap{},
-		"consent": anyMap{"purpose_id": purposeID, "policy_version": "pp-2026-01"},
+	subjectless := bookingAt(slot, personID, apptest.AnyMap{
+		"links":   []apptest.AnyMap{},
+		"consent": apptest.AnyMap{"purpose_id": purposeID, "policy_version": "pp-2026-01"},
 	})
-	if status := e.call(t, "POST", "/v1/bookings", subjectless, nil, nil); status != 422 {
+	if status := e.Call(t, "POST", "/v1/bookings", subjectless, nil, nil); status != 422 {
 		t.Fatalf("booking consent without a linked person → %d, want 422", status)
 	}
 
 	var meetings, consents int
-	if err := e.owner.QueryRow(context.Background(), `
+	if err := e.Owner.QueryRow(context.Background(), `
 		SELECT (SELECT count(*) FROM activity WHERE kind = 'meeting'),
 		       (SELECT count(*) FROM person_consent)`).Scan(&meetings, &consents); err != nil {
 		t.Fatal(err)
@@ -104,23 +105,23 @@ func assertConsentRefusalsLeaveNothingBehind(t *testing.T, e *env, personID stri
 	}
 
 	// The refused slot was never taken: booking it now succeeds.
-	if status := e.call(t, "POST", "/v1/bookings", bookingAt(slot, personID, nil), nil, nil); status != http.StatusCreated {
+	if status := e.Call(t, "POST", "/v1/bookings", bookingAt(slot, personID, nil), nil, nil); status != http.StatusCreated {
 		t.Fatalf("re-booking the slot a refused consent named → %d, want 201 (the refusal must not consume it)", status)
 	}
 }
 
 // assertConsentlessBookingStaysPlain books without a consent block and
 // proves the meeting lands with zero consent side effects.
-func assertConsentlessBookingStaysPlain(t *testing.T, e *env, personID string, tuesday time.Time) {
+func assertConsentlessBookingStaysPlain(t *testing.T, e *apptest.AppEnv, personID string, tuesday time.Time) {
 	t.Helper()
 	var booked struct {
 		Kind string `json:"kind"`
 	}
-	if status := e.call(t, "POST", "/v1/bookings", bookingAt(tuesday.Add(time.Hour), personID, nil), nil, &booked); status != http.StatusCreated || booked.Kind != "meeting" {
+	if status := e.Call(t, "POST", "/v1/bookings", bookingAt(tuesday.Add(time.Hour), personID, nil), nil, &booked); status != http.StatusCreated || booked.Kind != "meeting" {
 		t.Fatalf("consentless booking → %d %+v, want a plain 201 meeting", status, booked)
 	}
 	var consents int
-	if err := e.owner.QueryRow(context.Background(), `SELECT count(*) FROM person_consent`).Scan(&consents); err != nil {
+	if err := e.Owner.QueryRow(context.Background(), `SELECT count(*) FROM person_consent`).Scan(&consents); err != nil {
 		t.Fatal(err)
 	}
 	if consents != 0 {
@@ -131,15 +132,15 @@ func assertConsentlessBookingStaysPlain(t *testing.T, e *env, personID string, t
 // assertConsentedBookingLandsGrantWithProof books with the consent block
 // and proves both facts of the seam: the meeting on the timeline AND the
 // person_consent grant carrying the passthrough proof verbatim.
-func assertConsentedBookingLandsGrantWithProof(t *testing.T, e *env, personID string, tuesday time.Time, purposeID string, consent anyMap) {
+func assertConsentedBookingLandsGrantWithProof(t *testing.T, e *apptest.AppEnv, personID string, tuesday time.Time, purposeID string, consent apptest.AnyMap) {
 	t.Helper()
-	if status := e.call(t, "POST", "/v1/bookings",
-		bookingAt(tuesday.Add(2*time.Hour), personID, anyMap{"consent": consent}), nil, nil); status != http.StatusCreated {
+	if status := e.Call(t, "POST", "/v1/bookings",
+		bookingAt(tuesday.Add(2*time.Hour), personID, apptest.AnyMap{"consent": consent}), nil, nil); status != http.StatusCreated {
 		t.Fatalf("consented booking → %d", status)
 	}
 
 	var state string
-	if err := e.owner.QueryRow(context.Background(),
+	if err := e.Owner.QueryRow(context.Background(),
 		`SELECT state FROM person_consent WHERE person_id = $1 AND purpose_id = $2`,
 		personID, purposeID).Scan(&state); err != nil {
 		t.Fatalf("reading the consent state the booking recorded: %v", err)
@@ -148,7 +149,7 @@ func assertConsentedBookingLandsGrantWithProof(t *testing.T, e *env, personID st
 		t.Fatalf("consent state = %q, want granted", state)
 	}
 	var policyVersion, policyText string
-	if err := e.owner.QueryRow(context.Background(), `
+	if err := e.Owner.QueryRow(context.Background(), `
 		SELECT policy_version, policy_text FROM consent_event
 		WHERE person_id = $1 AND purpose_id = $2`,
 		personID, purposeID).Scan(&policyVersion, &policyText); err != nil {

--- a/backend/internal/compose/integration/brief_e2e_integration_test.go
+++ b/backend/internal/compose/integration/brief_e2e_integration_test.go
@@ -15,11 +15,13 @@ import (
 	"net/http"
 	"testing"
 	"time"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 )
 
 func TestMorningBriefHTTPSurface(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 	stages := discoverSeededPipeline(t, e)
 
 	// Two deals closing this week clear the §10 honest-short bar on timing
@@ -28,13 +30,13 @@ func TestMorningBriefHTTPSurface(t *testing.T) {
 	snoozableID := createDealClosingThisWeek(t, e, stages, "Also closing, but not today's problem")
 
 	// Before any run, the home read is an honest 404 — no brief yet.
-	if status := e.call(t, "GET", "/v1/brief", nil, nil, nil); status != http.StatusNotFound {
+	if status := e.Call(t, "GET", "/v1/brief", nil, nil, nil); status != http.StatusNotFound {
 		t.Fatalf("GET /v1/brief before generate = %d, want 404", status)
 	}
 
 	// Generate the brief: ranks the candidate set and persists a run.
 	var generated briefResponse
-	if status := e.call(t, "POST", "/v1/brief", nil, nil, &generated); status != http.StatusCreated {
+	if status := e.Call(t, "POST", "/v1/brief", nil, nil, &generated); status != http.StatusCreated {
 		t.Fatalf("POST /v1/brief = %d, want 201", status)
 	}
 	if generated.Id == "" || generated.CandidateCount < 2 || len(generated.Items) < 2 {
@@ -48,7 +50,7 @@ func TestMorningBriefHTTPSurface(t *testing.T) {
 
 	// The home read re-reads the same persisted run (no re-rank).
 	var read briefResponse
-	if status := e.call(t, "GET", "/v1/brief", nil, nil, &read); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/brief", nil, nil, &read); status != http.StatusOK {
 		t.Fatalf("GET /v1/brief = %d, want 200", status)
 	}
 	if read.Id != generated.Id || len(read.Items) != len(generated.Items) {
@@ -58,20 +60,20 @@ func TestMorningBriefHTTPSurface(t *testing.T) {
 	// A mark on an item that is not in the acting rep's runs is 404
 	// existence-hiding — the same shape another rep's item would take.
 	foreign := "00000000-0000-7000-8000-000000000000"
-	if status := e.call(t, "POST", "/v1/brief/items/"+foreign+"/act", nil, nil, nil); status != http.StatusNotFound {
+	if status := e.Call(t, "POST", "/v1/brief/items/"+foreign+"/act", nil, nil, nil); status != http.StatusNotFound {
 		t.Fatalf("mark on a non-owned item = %d, want 404 (existence-hiding)", status)
 	}
 
 	// The rep's own item marks acted; a second mark is a conflict, never a
 	// silent overwrite.
 	var acted briefItemResponse
-	if status := e.call(t, "POST", "/v1/brief/items/"+item.Id+"/act", nil, nil, &acted); status != http.StatusOK {
+	if status := e.Call(t, "POST", "/v1/brief/items/"+item.Id+"/act", nil, nil, &acted); status != http.StatusOK {
 		t.Fatalf("mark own item acted = %d, want 200", status)
 	}
 	if acted.State != "acted" {
 		t.Fatalf("marked item state = %q, want acted", acted.State)
 	}
-	if status := e.call(t, "POST", "/v1/brief/items/"+item.Id+"/dismiss", nil, nil, nil); status != http.StatusConflict {
+	if status := e.Call(t, "POST", "/v1/brief/items/"+item.Id+"/dismiss", nil, nil, nil); status != http.StatusConflict {
 		t.Fatalf("double mark = %d, want 409", status)
 	}
 
@@ -80,12 +82,12 @@ func TestMorningBriefHTTPSurface(t *testing.T) {
 
 // createDealClosingThisWeek seeds one open deal whose close date clears
 // the §10 timing bar, so it ranks into the rep's brief.
-func createDealClosingThisWeek(t *testing.T, e *env, stages seededStages, name string) string {
+func createDealClosingThisWeek(t *testing.T, e *apptest.AppEnv, stages seededStages, name string) string {
 	t.Helper()
 	var created struct {
 		Id string `json:"id"`
 	}
-	if status := e.call(t, "POST", "/v1/deals", anyMap{
+	if status := e.Call(t, "POST", "/v1/deals", apptest.AnyMap{
 		"name":                name,
 		"pipeline_id":         stages.pipelineID,
 		"stage_id":            stages.open,
@@ -100,18 +102,18 @@ func createDealClosingThisWeek(t *testing.T, e *env, stages seededStages, name s
 // assertSnoozeHidesItem drives the snooze verb (A77/AC-home-6): a snooze
 // into the past is refused, a future one lands, and the home read hides
 // the item while snoozed_until lies ahead.
-func assertSnoozeHidesItem(t *testing.T, e *env, toSnooze briefItemResponse) {
+func assertSnoozeHidesItem(t *testing.T, e *apptest.AppEnv, toSnooze briefItemResponse) {
 	t.Helper()
 	past := time.Now().UTC().Add(-time.Hour).Format(time.RFC3339)
-	if status := e.call(t, "POST", "/v1/brief/items/"+toSnooze.Id+"/snooze",
-		anyMap{"snoozed_until": past}, nil, nil); status != http.StatusUnprocessableEntity {
+	if status := e.Call(t, "POST", "/v1/brief/items/"+toSnooze.Id+"/snooze",
+		apptest.AnyMap{"snoozed_until": past}, nil, nil); status != http.StatusUnprocessableEntity {
 		t.Fatalf("snooze into the past = %d, want 422", status)
 	}
 
 	until := time.Now().UTC().Add(48 * time.Hour).Format(time.RFC3339)
 	var snoozed briefItemResponse
-	if status := e.call(t, "POST", "/v1/brief/items/"+toSnooze.Id+"/snooze",
-		anyMap{"snoozed_until": until}, nil, &snoozed); status != http.StatusOK {
+	if status := e.Call(t, "POST", "/v1/brief/items/"+toSnooze.Id+"/snooze",
+		apptest.AnyMap{"snoozed_until": until}, nil, &snoozed); status != http.StatusOK {
 		t.Fatalf("snooze = %d, want 200", status)
 	}
 	if snoozed.State != "snoozed" || snoozed.SnoozedUntil == "" {
@@ -119,7 +121,7 @@ func assertSnoozeHidesItem(t *testing.T, e *env, toSnooze briefItemResponse) {
 	}
 
 	var afterSnooze briefResponse
-	if status := e.call(t, "GET", "/v1/brief", nil, nil, &afterSnooze); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/brief", nil, nil, &afterSnooze); status != http.StatusOK {
 		t.Fatalf("GET /v1/brief after snooze = %d, want 200", status)
 	}
 	for _, it := range afterSnooze.Items {

--- a/backend/internal/compose/integration/capturedbykind_http_integration_test.go
+++ b/backend/internal/compose/integration/capturedbykind_http_integration_test.go
@@ -20,11 +20,13 @@ package integration
 import (
 	"net/http"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 )
 
 func TestCapturedByKindRefusesAValueOutsideTheEnum(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 
 	for _, path := range []string{
 		"/v1/people?captured_by_kind=ai",
@@ -37,7 +39,7 @@ func TestCapturedByKindRefusesAValueOutsideTheEnum(t *testing.T) {
 		"/v1/organizations?captured_by_kind=",
 		"/v1/leads?captured_by_kind=",
 	} {
-		if status := e.call(t, "GET", path, nil, nil, nil); status != http.StatusUnprocessableEntity {
+		if status := e.Call(t, "GET", path, nil, nil, nil); status != http.StatusUnprocessableEntity {
 			t.Errorf("GET %s = %d, want 422 — an unusable provenance kind must be refused, not answered with an unfiltered page", path, status)
 		}
 	}
@@ -50,13 +52,13 @@ func TestCapturedByKindRefusesAValueOutsideTheEnum(t *testing.T) {
 		"/v1/leads?captured_by_kind=connector",
 		"/v1/people?captured_by_kind=system",
 	} {
-		if status := e.call(t, "GET", path, nil, nil, nil); status != http.StatusOK {
+		if status := e.Call(t, "GET", path, nil, nil, nil); status != http.StatusOK {
 			t.Errorf("GET %s = %d, want 200", path, status)
 		}
 	}
 
 	// Omitting the parameter entirely is the one thing that means "no filter".
-	if status := e.call(t, "GET", "/v1/people", nil, nil, nil); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/people", nil, nil, nil); status != http.StatusOK {
 		t.Errorf("GET /v1/people = %d, want 200 — an absent filter is not an unusable one", status)
 	}
 }

--- a/backend/internal/compose/integration/channelsend_integration_test.go
+++ b/backend/internal/compose/integration/channelsend_integration_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
 )
 
@@ -42,7 +43,7 @@ const (
 )
 
 type channelSendEnv struct {
-	*env
+	*apptest.AppEnv
 	activityID string
 	personID   string
 	ws, user   string
@@ -62,7 +63,7 @@ func setupChannelSend(t *testing.T) *channelSendEnv {
 	if err != nil {
 		t.Fatalf("building the local vault: %v", err)
 	}
-	e := setupWithOptions(t, compose.WithKeyvault(vault),
+	e := apptest.SetupAppWithOptions(t, compose.WithKeyvault(vault),
 		// The Google app is configured only to make the connect registry — and
 		// with it the pre-flight — exist. Nothing here sends mail.
 		compose.WithGmailCapture(compose.GmailConfig{
@@ -70,18 +71,18 @@ func setupChannelSend(t *testing.T) *channelSendEnv {
 			StateKey: "0123456789abcdef0123456789abcdef", PublicBaseURL: channelSendBaseURL,
 		}, compose.CaptureConfig{}),
 		compose.WithPublicBaseURL(channelSendBaseURL))
-	e.slug = "channel-send-e2e"
-	bootstrapWorkspaceSession(t, e, "Channel Send E2E", "rep@fable.test", "Admin")
+	e.Slug = "channel-send-e2e"
+	apptest.BootstrapWorkspaceSession(t, e, "Channel Send E2E", "rep@fable.test", "Admin")
 
-	c := &channelSendEnv{env: e}
+	c := &channelSendEnv{AppEnv: e}
 	var person struct {
 		ID string `json:"id"`
 	}
-	if status := e.call(t, "POST", "/v1/people", anyMap{"full_name": "Telegram Buyer"}, nil, &person); status != http.StatusCreated {
+	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{"full_name": "Telegram Buyer"}, nil, &person); status != http.StatusCreated {
 		t.Fatalf("create person → %d", status)
 	}
 	c.personID = person.ID
-	if err := e.inWorkspace(t, e.slug, func(tx pgx.Tx) error {
+	if err := inWorkspace(e, t, e.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(),
 			`SELECT workspace_id, id FROM app_user WHERE email = $1`, "rep@fable.test").Scan(&c.ws, &c.user)
 	}); err != nil {
@@ -99,7 +100,7 @@ func setupChannelSend(t *testing.T) *channelSendEnv {
 // reads out of it, not how ingress puts it there.
 func (c *channelSendEnv) bindIdentity(t *testing.T) {
 	t.Helper()
-	if err := c.inWorkspace(t, c.slug, func(tx pgx.Tx) error {
+	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(), `
 			INSERT INTO person_channel_identity
 				(workspace_id, person_id, provider, channel_user_id, username, source, captured_by)
@@ -116,7 +117,7 @@ func (c *channelSendEnv) bindIdentity(t *testing.T) {
 // the shape capture leaves behind.
 func (c *channelSendEnv) seedInboundMessage(t *testing.T) {
 	t.Helper()
-	if err := c.inWorkspace(t, c.slug, func(tx pgx.Tx) error {
+	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		ctx := context.Background()
 		if err := tx.QueryRow(ctx, `
 			INSERT INTO activity (workspace_id, kind, body, occurred_at, direction,
@@ -146,7 +147,7 @@ func (c *channelSendEnv) grantConsent(t *testing.T, key string) {
 			Key string `json:"key"`
 		} `json:"data"`
 	}
-	if status := c.call(t, "GET", "/v1/consent-purposes", nil, nil, &purposes); status != http.StatusOK {
+	if status := c.Call(t, "GET", "/v1/consent-purposes", nil, nil, &purposes); status != http.StatusOK {
 		t.Fatalf("list purposes → %d", status)
 	}
 	var purposeID string
@@ -158,7 +159,7 @@ func (c *channelSendEnv) grantConsent(t *testing.T, key string) {
 	if purposeID == "" {
 		t.Fatalf("bootstrap seeded no %q purpose: %+v", key, purposes.Data)
 	}
-	if status := c.call(t, "POST", "/v1/people/"+c.personID+"/consent", anyMap{
+	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent", apptest.AnyMap{
 		"purpose_id": purposeID, "new_state": "granted", "lawful_basis": "consent",
 	}, nil, nil); status != http.StatusOK {
 		t.Fatalf("record consent → %d", status)
@@ -170,7 +171,7 @@ func (c *channelSendEnv) grantConsent(t *testing.T, key string) {
 // vault — so its value is deliberately opaque here.
 func (c *channelSendEnv) connectBot(t *testing.T) {
 	t.Helper()
-	if err := c.inWorkspace(t, c.slug, func(tx pgx.Tx) error {
+	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(), `
 			INSERT INTO channel_connection
 				(workspace_id, provider, channel_id, channel_label, credential_ref, status, connected_by)
@@ -197,7 +198,7 @@ func (c *channelSendEnv) sendReply(t *testing.T, purpose, body string, headers m
 			} `json:"errors"`
 		} `json:"details"`
 	}
-	status = c.call(t, "POST", "/v1/activities/"+c.activityID+"/send-message", anyMap{
+	status = c.Call(t, "POST", "/v1/activities/"+c.activityID+"/send-message", apptest.AnyMap{
 		"body": body, "consent_purpose": purpose,
 	}, headers, &answer)
 	if errs := answer.Details.Errors; len(errs) > 0 {
@@ -212,7 +213,7 @@ func (c *channelSendEnv) mintPassport(t *testing.T, scopes []string) string {
 	var minted struct {
 		Token string `json:"token"`
 	}
-	if status := c.call(t, "POST", "/v1/passports", anyMap{"label": "reply agent", "scopes": scopes}, nil, &minted); status != http.StatusCreated {
+	if status := c.Call(t, "POST", "/v1/passports", apptest.AnyMap{"label": "reply agent", "scopes": scopes}, nil, &minted); status != http.StatusCreated {
 		t.Fatalf("issue passport → %d", status)
 	}
 	return minted.Token
@@ -231,7 +232,7 @@ func (c *channelSendEnv) sendReplyAs(t *testing.T, scopes []string, purpose stri
 func (c *channelSendEnv) stagedChannelDeliveries(t *testing.T) int {
 	t.Helper()
 	var n int
-	if err := c.inWorkspace(t, c.slug, func(tx pgx.Tx) error {
+	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(),
 			`SELECT count(*) FROM comms_outbound WHERE channel_user_id IS NOT NULL`).Scan(&n)
 	}); err != nil {
@@ -245,7 +246,7 @@ func (c *channelSendEnv) stagedChannelDeliveries(t *testing.T) int {
 func (c *channelSendEnv) outboundActivities(t *testing.T) int {
 	t.Helper()
 	var n int
-	if err := c.inWorkspace(t, c.slug, func(tx pgx.Tx) error {
+	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(),
 			`SELECT count(*) FROM activity WHERE direction = 'outbound'`).Scan(&n)
 	}); err != nil {
@@ -320,7 +321,7 @@ func TestSendMessageAcceptsAHumanCallerWithoutAToken(t *testing.T) {
 	// caller.
 	var recipient, body, provider string
 	var subject, messageID *string
-	if err := c.inWorkspace(t, c.slug, func(tx pgx.Tx) error {
+	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(),
 			`SELECT channel_user_id, body, provider, subject, message_id
 			   FROM comms_outbound WHERE channel_user_id IS NOT NULL`).
@@ -345,7 +346,7 @@ func TestSendMessageAcceptsAHumanCallerWithoutAToken(t *testing.T) {
 // park where the rep never looks.
 func TestSendMessageRefusesWhenNoBotIsBoundForTheChannel(t *testing.T) {
 	c := setupChannelSend(t)
-	if err := c.inWorkspace(t, c.slug, func(tx pgx.Tx) error {
+	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(), `UPDATE channel_connection SET status = 'disconnected'`)
 		return err
 	}); err != nil {
@@ -410,7 +411,7 @@ func TestSendMessageRefusesWithoutConsentForThePurpose(t *testing.T) {
 // reply must be refused on reachability rather than accepted and parked.
 func TestSendMessageRefusesAnUnreachablePerson(t *testing.T) {
 	c := setupChannelSend(t)
-	if err := c.inWorkspace(t, c.slug, func(tx pgx.Tx) error {
+	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(),
 			`UPDATE person_channel_identity SET blocked_at = now() WHERE channel_user_id = $1`, channelSendAccountID)
 		return err
@@ -441,7 +442,7 @@ func TestSentMessageLandsAsAnOutboundActivity(t *testing.T) {
 		Direction string `json:"direction"`
 		Body      string `json:"body"`
 	}
-	if status := c.call(t, "POST", "/v1/activities/"+c.activityID+"/send-message", anyMap{
+	if status := c.Call(t, "POST", "/v1/activities/"+c.activityID+"/send-message", apptest.AnyMap{
 		"body": "On its way.", "consent_purpose": "transactional",
 	}, nil, &sent); status != http.StatusAccepted {
 		t.Fatalf("human reply → %d", status)
@@ -452,7 +453,7 @@ func TestSentMessageLandsAsAnOutboundActivity(t *testing.T) {
 
 	var threadKey, linkedPerson string
 	var deliveryActivity string
-	if err := c.inWorkspace(t, c.slug, func(tx pgx.Tx) error {
+	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		ctx := context.Background()
 		if err := tx.QueryRow(ctx,
 			`SELECT coalesce(thread_key, '') FROM activity WHERE id = $1`, sent.ID).Scan(&threadKey); err != nil {

--- a/backend/internal/compose/integration/channelsend_mcp_integration_test.go
+++ b/backend/internal/compose/integration/channelsend_mcp_integration_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/platform/jobs"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -54,14 +55,14 @@ import (
 func (c *channelSendEnv) sendMessageInvoker(t *testing.T, agentToken string) func(args string) (string, error) {
 	t.Helper()
 	ApplyRiverSchema(t)
-	inserter, err := jobs.NewInserter(c.pool, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	inserter, err := jobs.NewInserter(c.Pool, slog.New(slog.NewTextHandler(io.Discard, nil)))
 	if err != nil {
 		t.Fatalf("jobs.NewInserter: %v", err)
 	}
-	registry := compose.NewRegistry(c.pool, compose.SendPath{
-		Delivery: compose.NewDeliveryStager(c.pool, inserter),
+	registry := compose.NewRegistry(c.Pool, compose.SendPath{
+		Delivery: compose.NewDeliveryStager(c.Pool, inserter),
 	})
-	authSvc := identity.NewService(c.pool)
+	authSvc := identity.NewService(c.Pool)
 	return func(args string) (string, error) {
 		wsID, err := authSvc.InstallationWorkspace(context.Background())
 		if err != nil {
@@ -101,7 +102,7 @@ func TestSendMessageMCPLoopStagesApprovesAndRedeemsAgainstRealPostgres(t *testin
 	}
 	c.assertNoOutboundEffect(t, "a staged-but-not-yet-approved send_message call")
 
-	if status := c.call(t, "POST", "/v1/approvals/"+staged.ApprovalID.String()+"/approve", anyMap{}, nil, nil); status != http.StatusOK {
+	if status := c.Call(t, "POST", "/v1/approvals/"+staged.ApprovalID.String()+"/approve", apptest.AnyMap{}, nil, nil); status != http.StatusOK {
 		t.Fatalf("human approve → %d", status)
 	}
 
@@ -128,7 +129,7 @@ func TestSendMessageMCPLoopStagesApprovesAndRedeemsAgainstRealPostgres(t *testin
 	// delivery anchors on — otherwise the response could name any activity while
 	// the delivery transmits a different one.
 	var deliveryActivity string
-	if err := c.inWorkspace(t, c.slug, func(tx pgx.Tx) error {
+	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(),
 			`SELECT activity_id::text FROM comms_outbound WHERE channel_user_id IS NOT NULL`).Scan(&deliveryActivity)
 	}); err != nil {

--- a/backend/internal/compose/integration/channelsend_no_gmail_integration_test.go
+++ b/backend/internal/compose/integration/channelsend_no_gmail_integration_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
 )
 
@@ -51,19 +52,19 @@ func setupChannelSendNoGmail(t *testing.T) *channelSendEnv {
 	if err != nil {
 		t.Fatalf("building the local vault: %v", err)
 	}
-	e := setupWithOptions(t, compose.WithKeyvault(vault))
-	e.slug = "channel-send-no-gmail-e2e"
-	bootstrapWorkspaceSession(t, e, "Channel Send No-Gmail E2E", "rep@fable.test", "Admin")
+	e := apptest.SetupAppWithOptions(t, compose.WithKeyvault(vault))
+	e.Slug = "channel-send-no-gmail-e2e"
+	apptest.BootstrapWorkspaceSession(t, e, "Channel Send No-Gmail E2E", "rep@fable.test", "Admin")
 
-	c := &channelSendEnv{env: e}
+	c := &channelSendEnv{AppEnv: e}
 	var person struct {
 		ID string `json:"id"`
 	}
-	if status := e.call(t, "POST", "/v1/people", anyMap{"full_name": "Telegram Buyer"}, nil, &person); status != http.StatusCreated {
+	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{"full_name": "Telegram Buyer"}, nil, &person); status != http.StatusCreated {
 		t.Fatalf("create person → %d", status)
 	}
 	c.personID = person.ID
-	if err := e.inWorkspace(t, e.slug, func(tx pgx.Tx) error {
+	if err := inWorkspace(e, t, e.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(),
 			`SELECT workspace_id, id FROM app_user WHERE email = $1`, "rep@fable.test").Scan(&c.ws, &c.user)
 	}); err != nil {

--- a/backend/internal/compose/integration/collections_integration_test.go
+++ b/backend/internal/compose/integration/collections_integration_test.go
@@ -13,17 +13,19 @@ package integration
 import (
 	"net/http"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 )
 
-func setupCollections(t *testing.T) (*env, string) {
+func setupCollections(t *testing.T) (*apptest.AppEnv, string) {
 	t.Helper()
-	e := setup(t)
-	e.slug = "collections-e2e"
-	bootstrapWorkspaceSession(t, e, "Collections E2E", "org@fable.test", "Admin")
+	e := apptest.SetupApp(t)
+	e.Slug = "collections-e2e"
+	apptest.BootstrapWorkspaceSession(t, e, "Collections E2E", "org@fable.test", "Admin")
 	var person struct {
 		ID string `json:"id"`
 	}
-	if status := e.call(t, "POST", "/v1/people", anyMap{"full_name": "List Target"}, nil, &person); status != http.StatusCreated {
+	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{"full_name": "List Target"}, nil, &person); status != http.StatusCreated {
 		t.Fatalf("create person → %d", status)
 	}
 	return e, person.ID
@@ -35,19 +37,19 @@ func TestListsLifecycleAndMembership(t *testing.T) {
 	var list struct {
 		ID string `json:"id"`
 	}
-	if status := e.call(t, "POST", "/v1/lists", anyMap{
+	if status := e.Call(t, "POST", "/v1/lists", apptest.AnyMap{
 		"name": "Q3 Targets", "entity_type": "person",
 	}, nil, &list); status != http.StatusCreated {
 		t.Fatalf("create list → %d", status)
 	}
 	// A static list refuses a definition; a dynamic one demands it.
-	if status := e.call(t, "POST", "/v1/lists", anyMap{
+	if status := e.Call(t, "POST", "/v1/lists", apptest.AnyMap{
 		"name": "Broken", "entity_type": "person", "list_type": "dynamic",
 	}, nil, nil); status != 422 {
 		t.Fatalf("definition-less dynamic list → %d, want 422", status)
 	}
 
-	if status := e.call(t, "POST", "/v1/lists/"+list.ID+"/members", anyMap{
+	if status := e.Call(t, "POST", "/v1/lists/"+list.ID+"/members", apptest.AnyMap{
 		"entity_type": "person", "entity_id": personID,
 	}, nil, nil); status != http.StatusCreated {
 		t.Fatalf("add member → %d", status)
@@ -55,19 +57,19 @@ func TestListsLifecycleAndMembership(t *testing.T) {
 	var problem struct {
 		Code string `json:"code"`
 	}
-	if status := e.call(t, "POST", "/v1/lists/"+list.ID+"/members", anyMap{
+	if status := e.Call(t, "POST", "/v1/lists/"+list.ID+"/members", apptest.AnyMap{
 		"entity_type": "person", "entity_id": personID,
 	}, nil, &problem); status != http.StatusConflict {
 		t.Fatalf("duplicate member → %d, want 409", status)
 	}
 	// A wrong-typed member is refused before any probe.
-	if status := e.call(t, "POST", "/v1/lists/"+list.ID+"/members", anyMap{
+	if status := e.Call(t, "POST", "/v1/lists/"+list.ID+"/members", apptest.AnyMap{
 		"entity_type": "deal", "entity_id": personID,
 	}, nil, nil); status != 422 {
 		t.Fatalf("type-mismatched member → %d, want 422", status)
 	}
 	// A member reference outside visibility is absent (H1).
-	if status := e.call(t, "POST", "/v1/lists/"+list.ID+"/members", anyMap{
+	if status := e.Call(t, "POST", "/v1/lists/"+list.ID+"/members", apptest.AnyMap{
 		"entity_type": "person", "entity_id": "00000000-0000-7000-8000-00000000dead",
 	}, nil, nil); status != http.StatusNotFound {
 		t.Fatalf("invisible member target → %d, want 404", status)
@@ -78,11 +80,11 @@ func TestListsLifecycleAndMembership(t *testing.T) {
 			EntityID string `json:"entity_id"`
 		} `json:"data"`
 	}
-	if status := e.call(t, "GET", "/v1/lists/"+list.ID+"/members", nil, nil, &members); status != http.StatusOK || len(members.Data) != 1 {
+	if status := e.Call(t, "GET", "/v1/lists/"+list.ID+"/members", nil, nil, &members); status != http.StatusOK || len(members.Data) != 1 {
 		t.Fatalf("list members → %d %+v", status, members)
 	}
 
-	if status := e.call(t, "DELETE", "/v1/lists/"+list.ID, nil, nil, nil); status != http.StatusOK {
+	if status := e.Call(t, "DELETE", "/v1/lists/"+list.ID, nil, nil, nil); status != http.StatusOK {
 		t.Fatalf("archive list → %d", status)
 	}
 	var lists struct {
@@ -90,7 +92,7 @@ func TestListsLifecycleAndMembership(t *testing.T) {
 			ID string `json:"id"`
 		} `json:"data"`
 	}
-	if status := e.call(t, "GET", "/v1/lists", nil, nil, &lists); status != http.StatusOK || len(lists.Data) != 0 {
+	if status := e.Call(t, "GET", "/v1/lists", nil, nil, &lists); status != http.StatusOK || len(lists.Data) != 0 {
 		t.Fatalf("archived list still listed: %+v", lists)
 	}
 }
@@ -101,30 +103,30 @@ func TestTagsLifecycleAndApplication(t *testing.T) {
 	var tag struct {
 		ID string `json:"id"`
 	}
-	if status := e.call(t, "POST", "/v1/tags", anyMap{"name": "Champion", "color": "#ff6b00"}, nil, &tag); status != http.StatusCreated {
+	if status := e.Call(t, "POST", "/v1/tags", apptest.AnyMap{"name": "Champion", "color": "#ff6b00"}, nil, &tag); status != http.StatusCreated {
 		t.Fatalf("create tag → %d", status)
 	}
 	// The name is unique case-insensitively.
-	if status := e.call(t, "POST", "/v1/tags", anyMap{"name": "champion"}, nil, nil); status != http.StatusConflict {
+	if status := e.Call(t, "POST", "/v1/tags", apptest.AnyMap{"name": "champion"}, nil, nil); status != http.StatusConflict {
 		t.Fatalf("duplicate tag name → %d, want 409", status)
 	}
 
-	if status := e.call(t, "POST", "/v1/tags/"+tag.ID+"/apply", anyMap{
+	if status := e.Call(t, "POST", "/v1/tags/"+tag.ID+"/apply", apptest.AnyMap{
 		"entity_type": "person", "entity_id": personID,
 	}, nil, nil); status != http.StatusCreated {
 		t.Fatalf("apply tag → %d", status)
 	}
-	if status := e.call(t, "POST", "/v1/tags/"+tag.ID+"/apply", anyMap{
+	if status := e.Call(t, "POST", "/v1/tags/"+tag.ID+"/apply", apptest.AnyMap{
 		"entity_type": "person", "entity_id": personID,
 	}, nil, nil); status != http.StatusConflict {
 		t.Fatalf("re-apply → %d, want 409", status)
 	}
 
-	if status := e.call(t, "DELETE", "/v1/tags/"+tag.ID, nil, nil, nil); status != http.StatusOK {
+	if status := e.Call(t, "DELETE", "/v1/tags/"+tag.ID, nil, nil, nil); status != http.StatusOK {
 		t.Fatalf("archive tag → %d", status)
 	}
 	// An archived tag reads as absent for new applications.
-	if status := e.call(t, "POST", "/v1/tags/"+tag.ID+"/apply", anyMap{
+	if status := e.Call(t, "POST", "/v1/tags/"+tag.ID+"/apply", apptest.AnyMap{
 		"entity_type": "person", "entity_id": personID,
 	}, nil, nil); status != http.StatusNotFound {
 		t.Fatalf("apply on archived tag → %d, want 404", status)

--- a/backend/internal/compose/integration/comms_send_integration_test.go
+++ b/backend/internal/compose/integration/comms_send_integration_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	"github.com/gradionhq/margince/backend/internal/modules/activities"
 	"github.com/gradionhq/margince/backend/internal/modules/capture"
 	"github.com/gradionhq/margince/backend/internal/modules/capture/gmail"
@@ -94,7 +95,7 @@ func (p *preflightEnv) sendExpectingAcceptance(t *testing.T, purpose, subject, b
 	var sent struct {
 		ID string `json:"id"`
 	}
-	status := p.call(t, "POST", "/v1/activities/"+p.activityID+"/send-email", anyMap{
+	status := p.Call(t, "POST", "/v1/activities/"+p.activityID+"/send-email", apptest.AnyMap{
 		"subject": subject, "body": body,
 		"to": []string{"buyer@preflight.test"}, "consent_purpose": purpose,
 	}, nil, &sent)
@@ -114,7 +115,7 @@ func (p *preflightEnv) deliveryFor(t *testing.T, activityID ids.UUID) (ids.UUID,
 	t.Helper()
 	var id ids.UUID
 	var messageID string
-	if err := p.inWorkspace(t, p.slug, func(tx pgx.Tx) error {
+	if err := inWorkspace(p.AppEnv, t, p.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(),
 			`SELECT id, message_id FROM comms_outbound WHERE activity_id = $1`, activityID).Scan(&id, &messageID)
 	}); err != nil {
@@ -178,10 +179,10 @@ func (p *preflightEnv) dispatchOnce(t *testing.T, deliveryID ids.UUID, stampAs s
 	// would not be exercised by these tests, and the pacing knobs below are
 	// deliberately inert (no policies, a bound nothing here reaches).
 	dispatcher := comms.NewDispatcher(
-		comms.NewStore(p.pool, time.Now, activities.NewStore(p.pool)),
+		comms.NewStore(p.Pool, time.Now, activities.NewStore(p.Pool)),
 		stubMailbox{sender: gmailConnector, auth: auth},
-		compose.NewSendSeatAuthority(p.pool),
-		consent.NewGate(consent.NewStore(p.pool)),
+		compose.NewSendSeatAuthority(p.Pool),
+		consent.NewGate(consent.NewStore(p.Pool)),
 		nil, time.Now, 24*time.Hour, 10,
 	)
 	// A job carries no session. The scope comes from the composition rather
@@ -249,12 +250,12 @@ func TestCapturedCopyOfASentEmailCollapsesOntoTheSameActivity(t *testing.T) {
 			echo.NaturalKey.SourceID, messageID)
 	}
 
-	if _, err := capture.NewSink(p.pool).Upsert(p.connectorCtx(t), echo); err != nil {
+	if _, err := capture.NewSink(p.Pool).Upsert(p.connectorCtx(t), echo); err != nil {
 		t.Fatalf("capturing the provider's own copy: %v", err)
 	}
 
 	var rows int
-	if err := p.inWorkspace(t, p.slug, func(tx pgx.Tx) error {
+	if err := inWorkspace(p.AppEnv, t, p.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(),
 			`SELECT count(*) FROM activity WHERE source_system = $1 AND source_id = $2`,
 			sourceSystem, messageID).Scan(&rows)
@@ -270,7 +271,7 @@ func TestCapturedCopyOfASentEmailCollapsesOntoTheSameActivity(t *testing.T) {
 	// has to be stamped at send or the conversation has no identity.
 	var id ids.UUID
 	var threadKey *string
-	if err := p.inWorkspace(t, p.slug, func(tx pgx.Tx) error {
+	if err := inWorkspace(p.AppEnv, t, p.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(),
 			`SELECT id, thread_key FROM activity WHERE source_system = $1 AND source_id = $2`,
 			sourceSystem, messageID).Scan(&id, &threadKey)
@@ -319,7 +320,7 @@ func (p *preflightEnv) grantMarketingConsent(t *testing.T) {
 			Key string `json:"key"`
 		} `json:"data"`
 	}
-	if status := p.call(t, "GET", "/v1/consent-purposes", nil, nil, &purposes); status != http.StatusOK {
+	if status := p.Call(t, "GET", "/v1/consent-purposes", nil, nil, &purposes); status != http.StatusOK {
 		t.Fatalf("list purposes → %d", status)
 	}
 	var marketing string
@@ -334,12 +335,12 @@ func (p *preflightEnv) grantMarketingConsent(t *testing.T) {
 	var issued struct {
 		Token string `json:"token"`
 	}
-	if status := p.call(t, "POST", "/v1/people/"+p.personID+"/consent/double-opt-in", anyMap{
+	if status := p.Call(t, "POST", "/v1/people/"+p.personID+"/consent/double-opt-in", apptest.AnyMap{
 		"purpose_id": marketing, "deliver": false,
 	}, nil, &issued); status != http.StatusCreated {
 		t.Fatalf("issue the double-opt-in token → %d", status)
 	}
-	if status := p.call(t, "POST", "/v1/people/"+p.personID+"/consent", anyMap{
+	if status := p.Call(t, "POST", "/v1/people/"+p.personID+"/consent", apptest.AnyMap{
 		"purpose_id": marketing, "new_state": "granted",
 		"lawful_basis": "consent", "double_opt_in_token": issued.Token,
 	}, nil, nil); status != http.StatusOK {
@@ -410,7 +411,7 @@ func TestASenderDowngradedToAReadSeatParksAStagedDelivery(t *testing.T) {
 // path reads out of the row, not how the admin endpoint puts it there.
 func (p *preflightEnv) deactivateSender(t *testing.T) {
 	t.Helper()
-	if err := p.inWorkspace(t, p.slug, func(tx pgx.Tx) error {
+	if err := inWorkspace(p.AppEnv, t, p.Slug, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(),
 			`UPDATE app_user SET status = 'deactivated' WHERE id = $1`, p.user)
 		return err
@@ -425,7 +426,7 @@ func (p *preflightEnv) deactivateSender(t *testing.T) {
 // from.
 func (p *preflightEnv) downgradeSenderToReadSeat(t *testing.T) {
 	t.Helper()
-	if err := p.inWorkspace(t, p.slug, func(tx pgx.Tx) error {
+	if err := inWorkspace(p.AppEnv, t, p.Slug, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(),
 			`UPDATE app_user SET seat_type = 'read' WHERE id = $1`, p.user)
 		return err
@@ -438,7 +439,7 @@ func (p *preflightEnv) downgradeSenderToReadSeat(t *testing.T) {
 func (p *preflightEnv) deliveryReason(t *testing.T, deliveryID ids.UUID) string {
 	t.Helper()
 	var reason *string
-	if err := p.inWorkspace(t, p.slug, func(tx pgx.Tx) error {
+	if err := inWorkspace(p.AppEnv, t, p.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(),
 			`SELECT reason FROM comms_outbound WHERE id = $1`, deliveryID).Scan(&reason)
 	}); err != nil {

--- a/backend/internal/compose/integration/company_http_integration_test.go
+++ b/backend/internal/compose/integration/company_http_integration_test.go
@@ -15,6 +15,8 @@ import (
 	"net/http"
 	"strconv"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 )
 
 type companyProfileDTO struct {
@@ -69,8 +71,8 @@ func orAbsent(value *string) string {
 
 // wellFormedCompany is a submission every required field of which is filled —
 // the base a test perturbs one field of, so a 422 can only be about that field.
-func wellFormedCompany() anyMap {
-	return anyMap{
+func wellFormedCompany() apptest.AnyMap {
+	return apptest.AnyMap{
 		"display_name":  "Acme GmbH",
 		"offer_summary": "Revenue operations software",
 		"icp":           "RevOps at SaaS scale-ups",
@@ -80,17 +82,17 @@ func wellFormedCompany() anyMap {
 // The gate's whole contract: a bare installation has not described itself, and
 // the SAME GET answers the company once a human has saved it.
 func TestCompanyIs404UntilAHumanSavesItOverHTTP(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 
-	if status := e.call(t, "GET", "/v1/company", nil, nil, nil); status != http.StatusNotFound {
+	if status := e.Call(t, "GET", "/v1/company", nil, nil, nil); status != http.StatusNotFound {
 		t.Fatalf("GET /company on a bare installation → %d, want 404 (the onboarding signal)", status)
 	}
 
 	body := wellFormedCompany()
 	body["website"] = "https://www.acme.example/about"
 	var saved companyProfileDTO
-	if status := e.call(t, "PUT", "/v1/company", body, nil, &saved); status != http.StatusOK {
+	if status := e.Call(t, "PUT", "/v1/company", body, nil, &saved); status != http.StatusOK {
 		t.Fatalf("PUT /company → %d, want 200", status)
 	}
 	// The website is stored and returned as the bare domain — the same handle a
@@ -100,7 +102,7 @@ func TestCompanyIs404UntilAHumanSavesItOverHTTP(t *testing.T) {
 	}
 
 	var got companyProfileDTO
-	if status := e.call(t, "GET", "/v1/company", nil, nil, &got); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/company", nil, nil, &got); status != http.StatusOK {
 		t.Fatalf("GET /company after save → %d, want 200", status)
 	}
 	if got.OrganizationID != saved.OrganizationID || got.DisplayName != "Acme GmbH" {
@@ -123,8 +125,8 @@ func TestCompanyIs404UntilAHumanSavesItOverHTTP(t *testing.T) {
 // or whitespace-only, is a 422 that NAMES that field — the human is told which
 // answer is missing rather than left to guess.
 func TestCompanyRequiredFieldsAreNamedIndividually(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 
 	required := []string{"display_name", "offer_summary", "icp"}
 	cases := []struct {
@@ -145,7 +147,7 @@ func TestCompanyRequiredFieldsAreNamedIndividually(t *testing.T) {
 					body[field] = tc.value
 				}
 				var problem companyProblem
-				status := e.call(t, "PUT", "/v1/company", body, nil, &problem)
+				status := e.Call(t, "PUT", "/v1/company", body, nil, &problem)
 				if status != http.StatusUnprocessableEntity {
 					t.Fatalf("PUT /company without %s → %d, want 422", field, status)
 				}
@@ -158,7 +160,7 @@ func TestCompanyRequiredFieldsAreNamedIndividually(t *testing.T) {
 
 	// Nothing above was persisted: a refused submission leaves the
 	// installation undescribed.
-	if status := e.call(t, "GET", "/v1/company", nil, nil, nil); status != http.StatusNotFound {
+	if status := e.Call(t, "GET", "/v1/company", nil, nil, nil); status != http.StatusNotFound {
 		t.Fatalf("a refused save created a company anyway (GET → %d, want 404)", status)
 	}
 }
@@ -166,12 +168,12 @@ func TestCompanyRequiredFieldsAreNamedIndividually(t *testing.T) {
 // Website is optional and forgiving of what a human types, but an answer that
 // could not name a host is refused rather than stored.
 func TestCompanyWebsiteIsOptionalAndNormalised(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 
 	// The typed-by-hand path: no website read at all, no website typed either.
 	var typed companyProfileDTO
-	if status := e.call(t, "PUT", "/v1/company", wellFormedCompany(), nil, &typed); status != http.StatusOK {
+	if status := e.Call(t, "PUT", "/v1/company", wellFormedCompany(), nil, &typed); status != http.StatusOK {
 		t.Fatalf("a company typed by hand with no website → %d, want 200", status)
 	}
 	if typed.Website != nil {
@@ -184,7 +186,7 @@ func TestCompanyWebsiteIsOptionalAndNormalised(t *testing.T) {
 	var problem companyProblem
 	body := wellFormedCompany()
 	body["website"] = "not a url at all"
-	if status := e.call(t, "PUT", "/v1/company", body, nil, &problem); status != http.StatusUnprocessableEntity {
+	if status := e.Call(t, "PUT", "/v1/company", body, nil, &problem); status != http.StatusUnprocessableEntity {
 		t.Fatalf("an unparseable website → %d, want 422", status)
 	}
 	if len(problem.Details.Errors) != 1 || problem.Details.Errors[0].Field != "website" {
@@ -195,7 +197,7 @@ func TestCompanyWebsiteIsOptionalAndNormalised(t *testing.T) {
 	bare := wellFormedCompany()
 	bare["website"] = "acme.example"
 	var withBare companyProfileDTO
-	if status := e.call(t, "PUT", "/v1/company", bare, nil, &withBare); status != http.StatusOK {
+	if status := e.Call(t, "PUT", "/v1/company", bare, nil, &withBare); status != http.StatusOK {
 		t.Fatalf("a bare-domain website → %d, want 200", status)
 	}
 	if withBare.Website == nil || *withBare.Website != "acme.example" {
@@ -206,14 +208,14 @@ func TestCompanyWebsiteIsOptionalAndNormalised(t *testing.T) {
 // Saving twice is an UPDATE of the installation's own company — never a second
 // one. An optional field sent empty is cleared; one omitted is left as it was.
 func TestCompanySavingTwiceUpdatesTheAnchorOverHTTP(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 
 	first := wellFormedCompany()
 	first["usp"] = "Evidence, not guesses"
 	first["industry"] = "B2B SaaS"
 	var saved companyProfileDTO
-	if status := e.call(t, "PUT", "/v1/company", first, nil, &saved); status != http.StatusOK {
+	if status := e.Call(t, "PUT", "/v1/company", first, nil, &saved); status != http.StatusOK {
 		t.Fatalf("first save → %d", status)
 	}
 
@@ -222,7 +224,7 @@ func TestCompanySavingTwiceUpdatesTheAnchorOverHTTP(t *testing.T) {
 	second["display_name"] = "Acme SE"
 	second["usp"] = ""
 	var again companyProfileDTO
-	if status := e.call(t, "PUT", "/v1/company", second, nil, &again); status != http.StatusOK {
+	if status := e.Call(t, "PUT", "/v1/company", second, nil, &again); status != http.StatusOK {
 		t.Fatalf("second save → %d", status)
 	}
 	if again.OrganizationID != saved.OrganizationID {
@@ -246,7 +248,7 @@ func TestCompanySavingTwiceUpdatesTheAnchorOverHTTP(t *testing.T) {
 			ID string `json:"id"`
 		} `json:"data"`
 	}
-	if status := e.call(t, "GET", "/v1/organizations?include_anchor=true", nil, nil, &orgs); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/organizations?include_anchor=true", nil, nil, &orgs); status != http.StatusOK {
 		t.Fatalf("list organizations → %d", status)
 	}
 	if len(orgs.Data) != 1 || orgs.Data[0].ID != saved.OrganizationID {
@@ -260,7 +262,7 @@ func TestCompanySavingTwiceUpdatesTheAnchorOverHTTP(t *testing.T) {
 			ID string `json:"id"`
 		} `json:"data"`
 	}
-	if status := e.call(t, "GET", "/v1/organizations", nil, nil, &selling); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/organizations", nil, nil, &selling); status != http.StatusOK {
 		t.Fatalf("list organizations → %d", status)
 	}
 	if len(selling.Data) != 0 {
@@ -269,15 +271,15 @@ func TestCompanySavingTwiceUpdatesTheAnchorOverHTTP(t *testing.T) {
 }
 
 func TestCompanyContextScopesAreBoundedOverHTTP(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 
 	var saved companyProfileDTO
-	if status := e.call(t, "PUT", "/v1/company", wellFormedCompany(), nil, &saved); status != http.StatusOK {
+	if status := e.Call(t, "PUT", "/v1/company", wellFormedCompany(), nil, &saved); status != http.StatusOK {
 		t.Fatalf("save company → %d", status)
 	}
 	var context companyContextDTO
-	if status := e.call(t, "GET", "/v1/company/context?scopes=offer,positioning", nil, nil, &context); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/company/context?scopes=offer,positioning", nil, nil, &context); status != http.StatusOK {
 		t.Fatalf("GET scoped company context → %d", status)
 	}
 	if context.OrganizationID != saved.OrganizationID || context.SchemaVersion != 1 || len(context.Fingerprint) != 64 {
@@ -294,7 +296,7 @@ func TestCompanyContextScopesAreBoundedOverHTTP(t *testing.T) {
 	}
 
 	var problem companyProblem
-	if status := e.call(t, "GET", "/v1/company/context?scopes=everything", nil, nil, &problem); status != http.StatusUnprocessableEntity {
+	if status := e.Call(t, "GET", "/v1/company/context?scopes=everything", nil, nil, &problem); status != http.StatusUnprocessableEntity {
 		t.Fatalf("unknown context scope → %d, want 422", status)
 	}
 	if len(problem.Details.Errors) != 1 || problem.Details.Errors[0].Field != "scopes" {
@@ -306,13 +308,13 @@ func TestCompanyContextScopesAreBoundedOverHTTP(t *testing.T) {
 // but never make it true, exactly as it may stage an approval and never approve
 // it. A write-scoped passport is still refused.
 func TestCompanyPutRefusesAnAgentPassport(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 
 	var minted struct {
 		Token string `json:"token"`
 	}
-	if status := e.call(t, "POST", "/v1/passports", anyMap{
+	if status := e.Call(t, "POST", "/v1/passports", apptest.AnyMap{
 		"label": "read-back agent", "scopes": []string{"read", "write"},
 	}, nil, &minted); status != http.StatusCreated {
 		t.Fatalf("issue passport → %d", status)
@@ -320,12 +322,12 @@ func TestCompanyPutRefusesAnAgentPassport(t *testing.T) {
 	bearer := map[string]string{"Authorization": "Bearer " + minted.Token}
 
 	var problem companyProblem
-	status := e.call(t, "PUT", "/v1/company", wellFormedCompany(), bearer, &problem)
+	status := e.Call(t, "PUT", "/v1/company", wellFormedCompany(), bearer, &problem)
 	if status != http.StatusForbidden || problem.Code != "permission_denied" {
 		t.Fatalf("agent PUT /company → %d %q, want 403 permission_denied", status, problem.Code)
 	}
 	// Refused means refused: the agent's submission did not become the company.
-	if getStatus := e.call(t, "GET", "/v1/company", nil, nil, nil); getStatus != http.StatusNotFound {
+	if getStatus := e.Call(t, "GET", "/v1/company", nil, nil, nil); getStatus != http.StatusNotFound {
 		t.Fatalf("the agent's refused PUT still saved a company (GET → %d, want 404)", getStatus)
 	}
 }

--- a/backend/internal/compose/integration/consent_integration_test.go
+++ b/backend/internal/compose/integration/consent_integration_test.go
@@ -16,10 +16,12 @@ import (
 	"net/http"
 	"testing"
 	"time"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 )
 
 type consentEnv struct {
-	*env
+	*apptest.AppEnv
 	personID   string
 	activityID string
 	purposes   map[string]string // key -> id
@@ -27,25 +29,25 @@ type consentEnv struct {
 
 func setupConsent(t *testing.T) *consentEnv {
 	t.Helper()
-	e := setup(t)
-	e.slug = "consent-e2e"
-	bootstrapWorkspaceSession(t, e, "Consent E2E", "dpo@fable.test", "Admin")
+	e := apptest.SetupApp(t)
+	e.Slug = "consent-e2e"
+	apptest.BootstrapWorkspaceSession(t, e, "Consent E2E", "dpo@fable.test", "Admin")
 
 	var person struct {
 		ID string `json:"id"`
 	}
-	if status := e.call(t, "POST", "/v1/people", anyMap{
+	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{
 		"full_name": "Consent Subject",
-		"emails":    []anyMap{{"email": "subject@consent.test"}},
+		"emails":    []apptest.AnyMap{{"email": "subject@consent.test"}},
 	}, nil, &person); status != http.StatusCreated {
 		t.Fatalf("create person → %d", status)
 	}
 	var activity struct {
 		ID string `json:"id"`
 	}
-	if status := e.call(t, "POST", "/v1/activities", anyMap{
+	if status := e.Call(t, "POST", "/v1/activities", apptest.AnyMap{
 		"kind": "email", "subject": "Inbound question", "direction": "inbound",
-		"links": []anyMap{{"entity_type": "person", "entity_id": person.ID}},
+		"links": []apptest.AnyMap{{"entity_type": "person", "entity_id": person.ID}},
 	}, nil, &activity); status != http.StatusCreated {
 		t.Fatalf("log anchor activity → %d", status)
 	}
@@ -56,7 +58,7 @@ func setupConsent(t *testing.T) *consentEnv {
 			Key string `json:"key"`
 		} `json:"data"`
 	}
-	if status := e.call(t, "GET", "/v1/consent-purposes", nil, nil, &purposeList); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/consent-purposes", nil, nil, &purposeList); status != http.StatusOK {
 		t.Fatalf("list purposes → %d", status)
 	}
 	purposes := map[string]string{}
@@ -66,7 +68,7 @@ func setupConsent(t *testing.T) *consentEnv {
 	if purposes["transactional"] == "" || purposes["marketing_email"] == "" {
 		t.Fatalf("bootstrap did not seed the purpose catalog: %+v", purposeList.Data)
 	}
-	return &consentEnv{env: e, personID: person.ID, activityID: activity.ID, purposes: purposes}
+	return &consentEnv{AppEnv: e, personID: person.ID, activityID: activity.ID, purposes: purposes}
 }
 
 func (c *consentEnv) send(t *testing.T, purpose string) (int, string) {
@@ -74,7 +76,7 @@ func (c *consentEnv) send(t *testing.T, purpose string) (int, string) {
 	var problem struct {
 		Code string `json:"code"`
 	}
-	status := c.call(t, "POST", "/v1/activities/"+c.activityID+"/send-email", anyMap{
+	status := c.Call(t, "POST", "/v1/activities/"+c.activityID+"/send-email", apptest.AnyMap{
 		"subject": "Re: Inbound question", "body": "answer",
 		"to": []string{"subject@consent.test"}, "consent_purpose": purpose,
 	}, nil, &problem)
@@ -88,8 +90,8 @@ func TestConsentDefaultDenySuppressesSends(t *testing.T) {
 	var draft struct {
 		Subject string `json:"subject"`
 	}
-	if status := c.call(t, "POST", "/v1/activities/"+c.activityID+"/draft-email",
-		anyMap{"intent": "friendly nudge"}, nil, &draft); status != http.StatusOK {
+	if status := c.Call(t, "POST", "/v1/activities/"+c.activityID+"/draft-email",
+		apptest.AnyMap{"intent": "friendly nudge"}, nil, &draft); status != http.StatusOK {
 		t.Fatalf("draft → %d", status)
 	}
 	if draft.Subject != "Re: Inbound question" {
@@ -106,7 +108,7 @@ func TestConsentDefaultDenySuppressesSends(t *testing.T) {
 	}
 
 	// Grant transactional; the send under THAT purpose flows.
-	if status := c.call(t, "POST", "/v1/people/"+c.personID+"/consent", anyMap{
+	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent", apptest.AnyMap{
 		"purpose_id": c.purposes["transactional"], "new_state": "granted", "lawful_basis": "consent",
 	}, nil, nil); status != http.StatusOK {
 		t.Fatalf("record consent → %d", status)
@@ -120,7 +122,7 @@ func TestConsentDefaultDenySuppressesSends(t *testing.T) {
 	}
 
 	// Withdrawal re-blocks.
-	if status := c.call(t, "POST", "/v1/people/"+c.personID+"/consent", anyMap{
+	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent", apptest.AnyMap{
 		"purpose_id": c.purposes["transactional"], "new_state": "withdrawn",
 	}, nil, nil); status != http.StatusOK {
 		t.Fatalf("withdraw → %d", status)
@@ -137,7 +139,7 @@ func TestConsentGateIsNotAnOracleForUnauthorizedCallers(t *testing.T) {
 	var problem struct {
 		Code string `json:"code"`
 	}
-	status := c.call(t, "POST", "/v1/activities/00000000-0000-7000-8000-000000000001/send-email", anyMap{
+	status := c.Call(t, "POST", "/v1/activities/00000000-0000-7000-8000-000000000001/send-email", apptest.AnyMap{
 		"subject": "probe", "body": "probe",
 		"to": []string{"subject@consent.test"}, "consent_purpose": "transactional",
 	}, nil, &problem)
@@ -153,14 +155,14 @@ func TestConsentDoubleOptInNorm(t *testing.T) {
 	var problem struct {
 		Code string `json:"code"`
 	}
-	status := c.call(t, "POST", "/v1/people/"+c.personID+"/consent", anyMap{
+	status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent", apptest.AnyMap{
 		"purpose_id": c.purposes["marketing_email"], "new_state": "granted",
 	}, nil, &problem)
 	if status != 422 {
 		t.Fatalf("DOI-less marketing grant → %d, want 422", status)
 	}
 	// A fabricated token proves nothing: only a server-issued one confirms.
-	if status := c.call(t, "POST", "/v1/people/"+c.personID+"/consent", anyMap{
+	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent", apptest.AnyMap{
 		"purpose_id": c.purposes["marketing_email"], "new_state": "granted",
 		"double_opt_in_token": "doi-token-forged",
 	}, nil, nil); status != 422 {
@@ -171,7 +173,7 @@ func TestConsentDoubleOptInNorm(t *testing.T) {
 	// no mint/delivery endpoint yet, so issuance rides the store seam),
 	// the confirming grant presents it, and the send flows.
 	token := c.issueDOIToken(t, c.purposes["marketing_email"])
-	if status := c.call(t, "POST", "/v1/people/"+c.personID+"/consent", anyMap{
+	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent", apptest.AnyMap{
 		"purpose_id": c.purposes["marketing_email"], "new_state": "granted",
 		"double_opt_in_token": token,
 	}, nil, nil); status != http.StatusOK {
@@ -183,12 +185,12 @@ func TestConsentDoubleOptInNorm(t *testing.T) {
 
 	// The token is single-use: after a withdrawal the consumed token
 	// cannot resurrect the grant.
-	if status := c.call(t, "POST", "/v1/people/"+c.personID+"/consent", anyMap{
+	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent", apptest.AnyMap{
 		"purpose_id": c.purposes["marketing_email"], "new_state": "withdrawn",
 	}, nil, nil); status != http.StatusOK {
 		t.Fatalf("withdraw → %d", status)
 	}
-	if status := c.call(t, "POST", "/v1/people/"+c.personID+"/consent", anyMap{
+	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent", apptest.AnyMap{
 		"purpose_id": c.purposes["marketing_email"], "new_state": "granted",
 		"double_opt_in_token": token,
 	}, nil, nil); status != 422 {
@@ -206,7 +208,7 @@ func (c *consentEnv) issueDOIToken(t *testing.T, purposeID string) string {
 		Token     string     `json:"token"`
 		ExpiresAt *time.Time `json:"expires_at"`
 	}
-	if status := c.call(t, "POST", "/v1/people/"+c.personID+"/consent/double-opt-in", anyMap{
+	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent/double-opt-in", apptest.AnyMap{
 		"purpose_id": purposeID, "deliver": false,
 	}, nil, &issued); status != http.StatusCreated {
 		t.Fatalf("issue DOI token → %d", status)
@@ -225,7 +227,7 @@ func TestDOIIssuanceSupersedesAndValidatesPurpose(t *testing.T) {
 	c := setupConsent(t)
 
 	// transactional does not require double opt-in → 422.
-	if status := c.call(t, "POST", "/v1/people/"+c.personID+"/consent/double-opt-in", anyMap{
+	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent/double-opt-in", apptest.AnyMap{
 		"purpose_id": c.purposes["transactional"],
 	}, nil, nil); status != 422 {
 		t.Fatalf("DOI issuance for a non-DOI purpose → %d, want 422", status)
@@ -235,14 +237,14 @@ func TestDOIIssuanceSupersedesAndValidatesPurpose(t *testing.T) {
 	second := c.issueDOIToken(t, c.purposes["marketing_email"])
 
 	// The superseded first token no longer redeems…
-	if status := c.call(t, "POST", "/v1/people/"+c.personID+"/consent", anyMap{
+	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent", apptest.AnyMap{
 		"purpose_id": c.purposes["marketing_email"], "new_state": "granted",
 		"double_opt_in_token": first,
 	}, nil, nil); status != 422 {
 		t.Fatalf("superseded token redeemed → %d, want 422", status)
 	}
 	// …the fresh one does.
-	if c.call(t, "POST", "/v1/people/"+c.personID+"/consent", anyMap{
+	if c.Call(t, "POST", "/v1/people/"+c.personID+"/consent", apptest.AnyMap{
 		"purpose_id": c.purposes["marketing_email"], "new_state": "granted",
 		"double_opt_in_token": second,
 	}, nil, nil) != http.StatusOK {
@@ -251,9 +253,9 @@ func TestDOIIssuanceSupersedesAndValidatesPurpose(t *testing.T) {
 
 	// Issuance is an audited fact.
 	var audit struct {
-		Data []anyMap `json:"data"`
+		Data []apptest.AnyMap `json:"data"`
 	}
-	if status := c.call(t, "GET", "/v1/audit-log?entity_type=consent_doi_token", nil, nil, &audit); status != http.StatusOK {
+	if status := c.Call(t, "GET", "/v1/audit-log?entity_type=consent_doi_token", nil, nil, &audit); status != http.StatusOK {
 		t.Fatalf("audit read → %d", status)
 	}
 	if len(audit.Data) != 2 {
@@ -264,7 +266,7 @@ func TestDOIIssuanceSupersedesAndValidatesPurpose(t *testing.T) {
 func TestConsentProofLogIsAppendOnlyAndIdempotent(t *testing.T) {
 	c := setupConsent(t)
 	grant := func() int {
-		return c.call(t, "POST", "/v1/people/"+c.personID+"/consent", anyMap{
+		return c.Call(t, "POST", "/v1/people/"+c.personID+"/consent", apptest.AnyMap{
 			"purpose_id": c.purposes["transactional"], "new_state": "granted",
 		}, nil, nil)
 	}
@@ -284,7 +286,7 @@ func TestConsentProofLogIsAppendOnlyAndIdempotent(t *testing.T) {
 			NewState string `json:"new_state"`
 		} `json:"events"`
 	}
-	if status := c.call(t, "GET", "/v1/people/"+c.personID+"/consent", nil, nil, &state); status != http.StatusOK {
+	if status := c.Call(t, "GET", "/v1/people/"+c.personID+"/consent", nil, nil, &state); status != http.StatusOK {
 		t.Fatalf("get consent → %d", status)
 	}
 	if len(state.Events) != 1 {
@@ -300,11 +302,11 @@ func TestConsentProofLogIsAppendOnlyAndIdempotent(t *testing.T) {
 	}
 	// The consent change is audited and on the bus.
 	var audits, events int
-	if err := c.owner.QueryRow(t.Context(),
+	if err := c.Owner.QueryRow(t.Context(),
 		`SELECT count(*) FROM audit_log WHERE action = 'consent_grant'`).Scan(&audits); err != nil {
 		t.Fatal(err)
 	}
-	if err := c.owner.QueryRow(t.Context(),
+	if err := c.Owner.QueryRow(t.Context(),
 		fmt.Sprintf(`SELECT count(*) FROM event_outbox WHERE envelope->>'type' = '%s'`, "consent.changed")).Scan(&events); err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/compose/integration/consumermaildomain_http_integration_test.go
+++ b/backend/internal/compose/integration/consumermaildomain_http_integration_test.go
@@ -16,6 +16,8 @@ package integration
 import (
 	"net/http"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 )
 
 type consumerMailDomainDTO struct {
@@ -29,13 +31,13 @@ type consumerMailDomainListDTO struct {
 }
 
 func TestConsumerMailDomainsOverHTTP(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 
 	// A workspace that has said nothing: the shipped baseline decides every
 	// domain, and the list is empty rather than absent.
 	var list consumerMailDomainListDTO
-	if status := e.call(t, "GET", "/v1/capture/consumer-mail-domains", nil, nil, &list); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/capture/consumer-mail-domains", nil, nil, &list); status != http.StatusOK {
 		t.Fatalf("GET → %d, want 200", status)
 	}
 	if len(list.Data) != 0 {
@@ -44,7 +46,7 @@ func TestConsumerMailDomainsOverHTTP(t *testing.T) {
 
 	// A provider the shipped dataset missed, and a domain it wrongly claims.
 	var added consumerMailDomainDTO
-	if status := e.call(t, "POST", "/v1/capture/consumer-mail-domains",
+	if status := e.Call(t, "POST", "/v1/capture/consumer-mail-domains",
 		map[string]string{"domain": "Regional-Mail.Example", "kind": "extra"}, nil, &added); status != http.StatusCreated {
 		t.Fatalf("POST extra → %d, want 201", status)
 	}
@@ -54,7 +56,7 @@ func TestConsumerMailDomainsOverHTTP(t *testing.T) {
 		t.Fatalf("created %+v, want the normalized domain", added)
 	}
 	var carved consumerMailDomainDTO
-	if status := e.call(t, "POST", "/v1/capture/consumer-mail-domains",
+	if status := e.Call(t, "POST", "/v1/capture/consumer-mail-domains",
 		map[string]string{"domain": "mail.gmx.de", "kind": "never"}, nil, &carved); status != http.StatusCreated {
 		t.Fatalf("POST never → %d, want 201", status)
 	}
@@ -63,7 +65,7 @@ func TestConsumerMailDomainsOverHTTP(t *testing.T) {
 		t.Fatalf("carve-out stored as %q, want gmx.de", carved.Domain)
 	}
 
-	if status := e.call(t, "GET", "/v1/capture/consumer-mail-domains", nil, nil, &list); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/capture/consumer-mail-domains", nil, nil, &list); status != http.StatusOK {
 		t.Fatalf("GET → %d, want 200", status)
 	}
 	if len(list.Data) != 2 {
@@ -73,7 +75,7 @@ func TestConsumerMailDomainsOverHTTP(t *testing.T) {
 	// Re-adding the same domain is the same entry, not a second row: a domain
 	// cannot be both added and carved out.
 	var readded consumerMailDomainDTO
-	if status := e.call(t, "POST", "/v1/capture/consumer-mail-domains",
+	if status := e.Call(t, "POST", "/v1/capture/consumer-mail-domains",
 		map[string]string{"domain": "regional-mail.example", "kind": "never"}, nil, &readded); status != http.StatusCreated {
 		t.Fatalf("re-POST → %d, want 201", status)
 	}
@@ -83,13 +85,13 @@ func TestConsumerMailDomainsOverHTTP(t *testing.T) {
 
 	// Withdrawing returns the workspace to the baseline's own answer, and doing
 	// it twice is not an error — the caller's intent is already satisfied.
-	if status := e.call(t, "DELETE", "/v1/capture/consumer-mail-domains/"+added.ID, nil, nil, nil); status != http.StatusNoContent {
+	if status := e.Call(t, "DELETE", "/v1/capture/consumer-mail-domains/"+added.ID, nil, nil, nil); status != http.StatusNoContent {
 		t.Fatalf("DELETE → %d, want 204", status)
 	}
-	if status := e.call(t, "DELETE", "/v1/capture/consumer-mail-domains/"+added.ID, nil, nil, nil); status != http.StatusNoContent {
+	if status := e.Call(t, "DELETE", "/v1/capture/consumer-mail-domains/"+added.ID, nil, nil, nil); status != http.StatusNoContent {
 		t.Fatalf("repeat DELETE → %d, want 204", status)
 	}
-	if status := e.call(t, "GET", "/v1/capture/consumer-mail-domains", nil, nil, &list); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/capture/consumer-mail-domains", nil, nil, &list); status != http.StatusOK {
 		t.Fatalf("GET → %d, want 200", status)
 	}
 	if len(list.Data) != 1 || list.Data[0].Domain != "gmx.de" {
@@ -98,8 +100,8 @@ func TestConsumerMailDomainsOverHTTP(t *testing.T) {
 }
 
 func TestConsumerMailDomainsRefusesWhatTheMatcherCouldNeverRead(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 
 	// Each of these would sit in the list looking like a correction while
 	// matching nothing — or, for a bare public suffix, matching a whole TLD.
@@ -110,7 +112,7 @@ func TestConsumerMailDomainsRefusesWhatTheMatcherCouldNeverRead(t *testing.T) {
 		{"domain": "acme.example", "kind": "maybe"},
 		{"domain": "", "kind": "extra"},
 	} {
-		if status := e.call(t, "POST", "/v1/capture/consumer-mail-domains", bad, nil, nil); status != http.StatusUnprocessableEntity {
+		if status := e.Call(t, "POST", "/v1/capture/consumer-mail-domains", bad, nil, nil); status != http.StatusUnprocessableEntity {
 			t.Errorf("POST %v → %d, want 422", bad, status)
 		}
 	}

--- a/backend/internal/compose/integration/cursor_integration_test.go
+++ b/backend/internal/compose/integration/cursor_integration_test.go
@@ -17,17 +17,19 @@ package integration
 import (
 	"net/http"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 )
 
 func TestMalformedCursorAnswers4xxEverywhere(t *testing.T) {
-	e := setup(t)
+	e := apptest.SetupApp(t)
 
-	bootstrapWorkspaceSession(t, e, "Cursor Probe", "admin@cursor.test", "Admin")
-	e.slug = "cursor-probe"
+	apptest.BootstrapWorkspaceSession(t, e, "Cursor Probe", "admin@cursor.test", "Admin")
+	e.Slug = "cursor-probe"
 
 	// /lists/{id}/members needs a real list to point at.
-	var list anyMap
-	if status := e.call(t, "POST", "/v1/lists", anyMap{
+	var list apptest.AnyMap
+	if status := e.Call(t, "POST", "/v1/lists", apptest.AnyMap{
 		"name": "Probe", "entity_type": "person",
 	}, nil, &list); status != http.StatusCreated {
 		t.Fatalf("create list = %d %v", status, list)
@@ -47,8 +49,8 @@ func TestMalformedCursorAnswers4xxEverywhere(t *testing.T) {
 		"/v1/search?q=probe&" + garbage,
 	}
 	for _, path := range endpoints {
-		var problem anyMap
-		status := e.call(t, "GET", path, nil, nil, &problem)
+		var problem apptest.AnyMap
+		status := e.Call(t, "GET", path, nil, nil, &problem)
 		if status < 400 || status > 499 {
 			t.Errorf("GET %s with a malformed cursor = %d %v, want a 4xx problem", path, status, problem)
 		}

--- a/backend/internal/compose/integration/customfields_http_assertions_test.go
+++ b/backend/internal/compose/integration/customfields_http_assertions_test.go
@@ -15,14 +15,15 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
 // assertValidationDetails proves the contract's exact multi-field 422 shape:
 // details.errors[{field,code}], no fabricated message.
-func assertValidationDetails(t *testing.T, e *env) {
+func assertValidationDetails(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
-	status, _, problem := createCustomField(t, e, anyMap{
+	status, _, problem := createCustomField(t, e, apptest.AnyMap{
 		"object": "deal", "label": "Budget ceiling", "type": "currency", "source": "ui",
 	})
 	if status != http.StatusUnprocessableEntity {
@@ -39,9 +40,9 @@ func assertValidationDetails(t *testing.T, e *env) {
 
 // assertStructuralChangeRefused proves the contract's structural_change_refused
 // 422 example verbatim, including details.route.
-func assertStructuralChangeRefused(t *testing.T, e *env) {
+func assertStructuralChangeRefused(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
-	status, _, problem := createCustomField(t, e, anyMap{
+	status, _, problem := createCustomField(t, e, apptest.AnyMap{
 		"object": "deal", "label": "Renewal formula", "type": "text", "source": "ui",
 	})
 	if status != http.StatusUnprocessableEntity {
@@ -57,9 +58,9 @@ func assertStructuralChangeRefused(t *testing.T, e *env) {
 
 // assertDuplicateSlugConflict proves the per-workspace duplicate-slug 409:
 // the same (object, label) pair refused the second time.
-func assertDuplicateSlugConflict(t *testing.T, e *env) {
+func assertDuplicateSlugConflict(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
-	body := anyMap{"object": "deal", "label": "Renewal Window", "type": "text", "source": "ui"}
+	body := apptest.AnyMap{"object": "deal", "label": "Renewal Window", "type": "text", "source": "ui"}
 	first, field, _ := createCustomField(t, e, body)
 	if first != http.StatusCreated {
 		t.Fatalf("first create status = %d, want 201: %+v", first, field)
@@ -72,10 +73,10 @@ func assertDuplicateSlugConflict(t *testing.T, e *env) {
 
 // assertRetireUnknownID proves a nonexistent id answers the ordinary
 // existence-hiding 404, not a schema-pool-shaped error.
-func assertRetireUnknownID(t *testing.T, e *env) {
+func assertRetireUnknownID(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
 	var problem customFieldProblem
-	status := e.call(t, "POST", "/v1/custom-fields/"+ids.NewV7().String()+"/retire", nil, nil, &problem)
+	status := e.Call(t, "POST", "/v1/custom-fields/"+ids.NewV7().String()+"/retire", nil, nil, &problem)
 	if status != http.StatusNotFound {
 		t.Fatalf("status = %d, want 404: %+v", status, problem)
 	}
@@ -83,10 +84,10 @@ func assertRetireUnknownID(t *testing.T, e *env) {
 
 // assertListInvalidObject proves the closed object vocabulary is enforced
 // on List too, with the same single-field details.errors shape.
-func assertListInvalidObject(t *testing.T, e *env) {
+func assertListInvalidObject(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
 	var problem customFieldProblem
-	status := e.call(t, "GET", "/v1/custom-fields?object=bogus", nil, nil, &problem)
+	status := e.Call(t, "GET", "/v1/custom-fields?object=bogus", nil, nil, &problem)
 	if status != http.StatusUnprocessableEntity {
 		t.Fatalf("status = %d, want 422: %+v", status, problem)
 	}
@@ -98,17 +99,17 @@ func assertListInvalidObject(t *testing.T, e *env) {
 // assertNotPicklistOptionsEdit proves an options edit on a non-picklist
 // field answers the contract's dedicated not_picklist code, not the
 // generic validation_error.
-func assertNotPicklistOptionsEdit(t *testing.T, e *env) {
+func assertNotPicklistOptionsEdit(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
-	status, field, problem := createCustomField(t, e, anyMap{
+	status, field, problem := createCustomField(t, e, apptest.AnyMap{
 		"object": "deal", "label": "Not A Picklist", "type": "text", "source": "ui",
 	})
 	if status != http.StatusCreated {
 		t.Fatalf("create status = %d, want 201: %+v", status, problem)
 	}
 	var notPicklist customFieldProblem
-	optStatus := e.call(t, "PATCH", "/v1/custom-fields/"+field.ID+"/options",
-		anyMap{"options": []string{"a"}}, nil, &notPicklist)
+	optStatus := e.Call(t, "PATCH", "/v1/custom-fields/"+field.ID+"/options",
+		apptest.AnyMap{"options": []string{"a"}}, nil, &notPicklist)
 	if optStatus != http.StatusUnprocessableEntity {
 		t.Fatalf("status = %d, want 422: %+v", optStatus, notPicklist)
 	}
@@ -121,9 +122,9 @@ func assertNotPicklistOptionsEdit(t *testing.T, e *env) {
 // header is a 422 client error caught before the store is ever called,
 // and a stale (correct-shape, wrong-value) version is the store's own
 // ErrVersionSkew, wire-mapped to 409 like every other versioned PATCH.
-func assertRenameConcurrencyErrors(t *testing.T, e *env) {
+func assertRenameConcurrencyErrors(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
-	status, field, problem := createCustomField(t, e, anyMap{
+	status, field, problem := createCustomField(t, e, apptest.AnyMap{
 		"object": "deal", "label": "Concurrency Subject", "type": "text", "source": "ui",
 	})
 	if status != http.StatusCreated {
@@ -131,15 +132,15 @@ func assertRenameConcurrencyErrors(t *testing.T, e *env) {
 	}
 
 	var malformed customFieldProblem
-	malformedStatus := e.call(t, "PATCH", "/v1/custom-fields/"+field.ID,
-		anyMap{"label": "Whatever"}, map[string]string{"If-Match": "not-a-number"}, &malformed)
+	malformedStatus := e.Call(t, "PATCH", "/v1/custom-fields/"+field.ID,
+		apptest.AnyMap{"label": "Whatever"}, map[string]string{"If-Match": "not-a-number"}, &malformed)
 	if malformedStatus != http.StatusUnprocessableEntity {
 		t.Fatalf("malformed If-Match status = %d, want 422: %+v", malformedStatus, malformed)
 	}
 
 	var skew customFieldProblem
-	skewStatus := e.call(t, "PATCH", "/v1/custom-fields/"+field.ID,
-		anyMap{"label": "Whatever"}, map[string]string{"If-Match": "999999"}, &skew)
+	skewStatus := e.Call(t, "PATCH", "/v1/custom-fields/"+field.ID,
+		apptest.AnyMap{"label": "Whatever"}, map[string]string{"If-Match": "999999"}, &skew)
 	if skewStatus != http.StatusConflict {
 		t.Fatalf("stale If-Match status = %d, want 409: %+v", skewStatus, skew)
 	}
@@ -150,9 +151,9 @@ func assertRenameConcurrencyErrors(t *testing.T, e *env) {
 
 // assertSixTypesCreate covers CUSTOM-FIELDS-PARAM-1: every closed field
 // type creates end to end with the shape its type requires.
-func assertSixTypesCreate(t *testing.T, e *env) {
+func assertSixTypesCreate(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
-	cases := []anyMap{
+	cases := []apptest.AnyMap{
 		{"object": "deal", "label": "Renewal Date", "type": "date", "source": "ui"},
 		{"object": "deal", "label": "Seat Count", "type": "number", "source": "ui"},
 		{"object": "deal", "label": "Deal Notes", "type": "text", "source": "ui"},
@@ -182,10 +183,10 @@ func assertSixTypesCreate(t *testing.T, e *env) {
 // text creates cleanly, the catalog stores the label byte-for-byte, the
 // derived column identifier is alnum-only, and the person table — the
 // object this field attaches to — is provably intact afterward.
-func assertInjectionLabel(t *testing.T, e *env) {
+func assertInjectionLabel(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
 	hostile := `Notes'); DROP TABLE person; --`
-	status, field, problem := createCustomField(t, e, anyMap{
+	status, field, problem := createCustomField(t, e, apptest.AnyMap{
 		"object": "person", "label": hostile, "type": "text", "source": "ui",
 	})
 	if status != http.StatusCreated {
@@ -199,8 +200,8 @@ func assertInjectionLabel(t *testing.T, e *env) {
 	}
 
 	// The person table survives: an ordinary person write still round-trips.
-	var person anyMap
-	if status := e.call(t, "POST", "/v1/people", anyMap{
+	var person apptest.AnyMap
+	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{
 		"full_name": "Injection Survivor", "source": "ui",
 	}, nil, &person); status != http.StatusCreated {
 		t.Fatalf("person table did not survive the injection attempt: create status = %d %v", status, person)
@@ -209,9 +210,9 @@ func assertInjectionLabel(t *testing.T, e *env) {
 
 // assertRenameStable proves CUSTOM-FIELDS-WIRE-3: rename updates label
 // only, column_name never moves.
-func assertRenameStable(t *testing.T, e *env) {
+func assertRenameStable(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
-	status, field, problem := createCustomField(t, e, anyMap{
+	status, field, problem := createCustomField(t, e, apptest.AnyMap{
 		"object": "deal", "label": "Original Label", "type": "text", "source": "ui",
 	})
 	if status != http.StatusCreated {
@@ -220,7 +221,7 @@ func assertRenameStable(t *testing.T, e *env) {
 	originalColumn := field.ColumnName
 
 	var renamed customFieldWire
-	renameStatus := e.call(t, "PATCH", "/v1/custom-fields/"+field.ID, anyMap{"label": "Renamed Label"}, nil, &renamed)
+	renameStatus := e.Call(t, "PATCH", "/v1/custom-fields/"+field.ID, apptest.AnyMap{"label": "Renamed Label"}, nil, &renamed)
 	if renameStatus != http.StatusOK {
 		t.Fatalf("rename status = %d, want 200: %+v", renameStatus, renamed)
 	}
@@ -234,9 +235,9 @@ func assertRenameStable(t *testing.T, e *env) {
 
 // assertRetire proves CUSTOM-FIELDS-WIRE-4/AC-13: status flips, archived_at
 // stays null — retire is a status flip, never an archive.
-func assertRetire(t *testing.T, e *env) {
+func assertRetire(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
-	status, field, problem := createCustomField(t, e, anyMap{
+	status, field, problem := createCustomField(t, e, apptest.AnyMap{
 		"object": "deal", "label": "To Be Retired", "type": "text", "source": "ui",
 	})
 	if status != http.StatusCreated {
@@ -244,7 +245,7 @@ func assertRetire(t *testing.T, e *env) {
 	}
 
 	var retired customFieldWire
-	retireStatus := e.call(t, "POST", "/v1/custom-fields/"+field.ID+"/retire", nil, nil, &retired)
+	retireStatus := e.Call(t, "POST", "/v1/custom-fields/"+field.ID+"/retire", nil, nil, &retired)
 	if retireStatus != http.StatusOK {
 		t.Fatalf("retire status = %d, want 200: %+v", retireStatus, retired)
 	}
@@ -259,9 +260,9 @@ func assertRetire(t *testing.T, e *env) {
 // assertRetiredFieldFrozen proves retirement is terminal on the wire: a
 // retired field refuses rename and options edits with the contract's 409
 // conflict, while a repeat retire stays the 200 no-op.
-func assertRetiredFieldFrozen(t *testing.T, e *env) {
+func assertRetiredFieldFrozen(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
-	status, field, problem := createCustomField(t, e, anyMap{
+	status, field, problem := createCustomField(t, e, apptest.AnyMap{
 		"object": "deal", "label": "Frozen Route", "type": "picklist",
 		"options": []string{"direct", "reseller"}, "source": "ui",
 	})
@@ -269,26 +270,26 @@ func assertRetiredFieldFrozen(t *testing.T, e *env) {
 		t.Fatalf("create status = %d, want 201: %+v", status, problem)
 	}
 	var retired customFieldWire
-	if s := e.call(t, "POST", "/v1/custom-fields/"+field.ID+"/retire", nil, nil, &retired); s != http.StatusOK {
+	if s := e.Call(t, "POST", "/v1/custom-fields/"+field.ID+"/retire", nil, nil, &retired); s != http.StatusOK {
 		t.Fatalf("retire status = %d, want 200: %+v", s, retired)
 	}
 
 	var renameProblem customFieldProblem
-	renameStatus := e.call(t, "PATCH", "/v1/custom-fields/"+field.ID,
-		anyMap{"label": "Thawed Route"}, nil, &renameProblem)
+	renameStatus := e.Call(t, "PATCH", "/v1/custom-fields/"+field.ID,
+		apptest.AnyMap{"label": "Thawed Route"}, nil, &renameProblem)
 	if renameStatus != http.StatusConflict || renameProblem.Code != "conflict" {
 		t.Fatalf("rename on retired = %d/%q, want 409/conflict: %+v", renameStatus, renameProblem.Code, renameProblem)
 	}
 
 	var optionsProblem customFieldProblem
-	optionsStatus := e.call(t, "PATCH", "/v1/custom-fields/"+field.ID+"/options",
-		anyMap{"options": []string{"direct"}}, nil, &optionsProblem)
+	optionsStatus := e.Call(t, "PATCH", "/v1/custom-fields/"+field.ID+"/options",
+		apptest.AnyMap{"options": []string{"direct"}}, nil, &optionsProblem)
 	if optionsStatus != http.StatusConflict || optionsProblem.Code != "conflict" {
 		t.Fatalf("options on retired = %d/%q, want 409/conflict: %+v", optionsStatus, optionsProblem.Code, optionsProblem)
 	}
 
 	var again customFieldWire
-	if s := e.call(t, "POST", "/v1/custom-fields/"+field.ID+"/retire", nil, nil, &again); s != http.StatusOK {
+	if s := e.Call(t, "POST", "/v1/custom-fields/"+field.ID+"/retire", nil, nil, &again); s != http.StatusOK {
 		t.Fatalf("repeat retire status = %d, want the 200 no-op: %+v", s, again)
 	}
 }
@@ -296,9 +297,9 @@ func assertRetiredFieldFrozen(t *testing.T, e *env) {
 // assertUnknownCreateKey proves a typo'd request key answers the
 // unknown_field 422 instead of being silently dropped — the create
 // request schema deliberately has no additionalProperties catch-all.
-func assertUnknownCreateKey(t *testing.T, e *env) {
+func assertUnknownCreateKey(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
-	status, _, problem := createCustomField(t, e, anyMap{
+	status, _, problem := createCustomField(t, e, apptest.AnyMap{
 		"object": "deal", "label": "Typo Subject", "type": "currency",
 		"curency": "USD", "source": "ui",
 	})
@@ -314,9 +315,9 @@ func assertUnknownCreateKey(t *testing.T, e *env) {
 // assertOptionsLifecycle proves CUSTOM-FIELDS-PARAM-5: an options edit
 // replaces the set and regenerates the CHECK, and emptying the set is
 // refused with the contract's exact lastOption shape.
-func assertOptionsLifecycle(t *testing.T, e *env) {
+func assertOptionsLifecycle(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
-	status, field, problem := createCustomField(t, e, anyMap{
+	status, field, problem := createCustomField(t, e, apptest.AnyMap{
 		"object": "deal", "label": "Deployment Region", "type": "picklist",
 		"options": []string{"us-east", "eu-west", "apac"}, "source": "ui",
 	})
@@ -325,8 +326,8 @@ func assertOptionsLifecycle(t *testing.T, e *env) {
 	}
 
 	var updated customFieldWire
-	optStatus := e.call(t, "PATCH", "/v1/custom-fields/"+field.ID+"/options",
-		anyMap{"options": []string{"eu-west", "apac", "sa-east"}}, nil, &updated)
+	optStatus := e.Call(t, "PATCH", "/v1/custom-fields/"+field.ID+"/options",
+		apptest.AnyMap{"options": []string{"eu-west", "apac", "sa-east"}}, nil, &updated)
 	if optStatus != http.StatusOK {
 		t.Fatalf("options update status = %d, want 200: %+v", optStatus, updated)
 	}
@@ -335,8 +336,8 @@ func assertOptionsLifecycle(t *testing.T, e *env) {
 	}
 
 	var lastOptionProblem customFieldProblem
-	emptyStatus := e.call(t, "PATCH", "/v1/custom-fields/"+field.ID+"/options",
-		anyMap{"options": []string{}}, nil, &lastOptionProblem)
+	emptyStatus := e.Call(t, "PATCH", "/v1/custom-fields/"+field.ID+"/options",
+		apptest.AnyMap{"options": []string{}}, nil, &lastOptionProblem)
 	if emptyStatus != http.StatusUnprocessableEntity {
 		t.Fatalf("empty-options status = %d, want 422: %+v", emptyStatus, lastOptionProblem)
 	}
@@ -348,27 +349,27 @@ func assertOptionsLifecycle(t *testing.T, e *env) {
 
 // assertListFiltering proves CUSTOM-FIELDS-WIRE-1: omitted status returns
 // both lifecycle states, and object/status each narrow correctly.
-func assertListFiltering(t *testing.T, e *env) {
+func assertListFiltering(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
-	activeStatus, active, activeProblem := createCustomField(t, e, anyMap{
+	activeStatus, active, activeProblem := createCustomField(t, e, apptest.AnyMap{
 		"object": "lead", "label": "Lead Source Detail", "type": "text", "source": "ui",
 	})
 	if activeStatus != http.StatusCreated {
 		t.Fatalf("create active field status = %d: %+v", activeStatus, activeProblem)
 	}
-	retiringStatus, retiring, retiringProblem := createCustomField(t, e, anyMap{
+	retiringStatus, retiring, retiringProblem := createCustomField(t, e, apptest.AnyMap{
 		"object": "lead", "label": "Lead Legacy Field", "type": "text", "source": "ui",
 	})
 	if retiringStatus != http.StatusCreated {
 		t.Fatalf("create field-to-retire status = %d: %+v", retiringStatus, retiringProblem)
 	}
 	var retired customFieldWire
-	if s := e.call(t, "POST", "/v1/custom-fields/"+retiring.ID+"/retire", nil, nil, &retired); s != http.StatusOK {
+	if s := e.Call(t, "POST", "/v1/custom-fields/"+retiring.ID+"/retire", nil, nil, &retired); s != http.StatusOK {
 		t.Fatalf("retire status = %d, want 200: %+v", s, retired)
 	}
 
 	var both customFieldListWire
-	if s := e.call(t, "GET", "/v1/custom-fields?object=lead", nil, nil, &both); s != http.StatusOK {
+	if s := e.Call(t, "GET", "/v1/custom-fields?object=lead", nil, nil, &both); s != http.StatusOK {
 		t.Fatalf("list status = %d, want 200: %+v", s, both)
 	}
 	if !containsID(both.Data, active.ID) || !containsID(both.Data, retiring.ID) {
@@ -376,7 +377,7 @@ func assertListFiltering(t *testing.T, e *env) {
 	}
 
 	var activeOnly customFieldListWire
-	if s := e.call(t, "GET", "/v1/custom-fields?object=lead&status=active", nil, nil, &activeOnly); s != http.StatusOK {
+	if s := e.Call(t, "GET", "/v1/custom-fields?object=lead&status=active", nil, nil, &activeOnly); s != http.StatusOK {
 		t.Fatalf("list active status = %d, want 200: %+v", s, activeOnly)
 	}
 	if !containsID(activeOnly.Data, active.ID) || containsID(activeOnly.Data, retiring.ID) {
@@ -384,7 +385,7 @@ func assertListFiltering(t *testing.T, e *env) {
 	}
 
 	var retiredOnly customFieldListWire
-	if s := e.call(t, "GET", "/v1/custom-fields?object=lead&status=retired", nil, nil, &retiredOnly); s != http.StatusOK {
+	if s := e.Call(t, "GET", "/v1/custom-fields?object=lead&status=retired", nil, nil, &retiredOnly); s != http.StatusOK {
 		t.Fatalf("list retired status = %d, want 200: %+v", s, retiredOnly)
 	}
 	if containsID(retiredOnly.Data, active.ID) || !containsID(retiredOnly.Data, retiring.ID) {
@@ -396,7 +397,7 @@ func assertListFiltering(t *testing.T, e *env) {
 	// (`activity`, `relationship`) answers 422 and would prove nothing about
 	// filtering.
 	var otherObject customFieldListWire
-	if s := e.call(t, "GET", "/v1/custom-fields?object=organization", nil, nil, &otherObject); s != http.StatusOK {
+	if s := e.Call(t, "GET", "/v1/custom-fields?object=organization", nil, nil, &otherObject); s != http.StatusOK {
 		t.Fatalf("list other-object status = %d, want 200: %+v", s, otherObject)
 	}
 	if containsID(otherObject.Data, active.ID) || containsID(otherObject.Data, retiring.ID) {
@@ -420,11 +421,11 @@ func containsID(fields []customFieldWire, id string) bool {
 // subtests above, all of which ride the schema-wired server.
 func assertUnwired501(t *testing.T) {
 	t.Helper()
-	unwired := setup(t)
-	unwired.bootstrapWorkspace(t)
+	unwired := apptest.SetupApp(t)
+	unwired.BootstrapWorkspace(t)
 
 	var createProblem customFieldProblem
-	createStatus := unwired.call(t, "POST", "/v1/custom-fields", anyMap{
+	createStatus := unwired.Call(t, "POST", "/v1/custom-fields", apptest.AnyMap{
 		"object": "deal", "label": "Never Lands", "type": "date", "source": "ui",
 	}, nil, &createProblem)
 	if createStatus != http.StatusNotImplemented {
@@ -432,8 +433,8 @@ func assertUnwired501(t *testing.T) {
 	}
 
 	var optionsProblem customFieldProblem
-	optionsStatus := unwired.call(t, "PATCH", "/v1/custom-fields/"+ids.NewV7().String()+"/options",
-		anyMap{"options": []string{"a", "b"}}, nil, &optionsProblem)
+	optionsStatus := unwired.Call(t, "PATCH", "/v1/custom-fields/"+ids.NewV7().String()+"/options",
+		apptest.AnyMap{"options": []string{"a", "b"}}, nil, &optionsProblem)
 	if optionsStatus != http.StatusNotImplemented {
 		t.Fatalf("options status = %d, want 501: %+v", optionsStatus, optionsProblem)
 	}

--- a/backend/internal/compose/integration/customfields_http_integration_test.go
+++ b/backend/internal/compose/integration/customfields_http_integration_test.go
@@ -37,6 +37,7 @@ import (
 	"testing"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 )
 
 // customFieldWire mirrors the contract's CustomField field by field,
@@ -91,10 +92,10 @@ var cfColumnName = regexp.MustCompile(`^cf_[a-z0-9_]+$`)
 // admin session in the client jar — every subtest below rides this one
 // bootstrapped workspace, since the custom-field catalog is workspace-shared
 // admin config with no per-row scope to isolate between subtests.
-func schemaWiredEnv(t *testing.T) *env {
+func schemaWiredEnv(t *testing.T) *apptest.AppEnv {
 	t.Helper()
-	e := setupWithOptions(t, compose.WithSchemaPool(SchemaPool(t)))
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupAppWithOptions(t, compose.WithSchemaPool(SchemaPool(t)))
+	e.BootstrapWorkspace(t)
 	return e
 }
 
@@ -106,10 +107,10 @@ func schemaWiredEnv(t *testing.T) *env {
 // number http.StatusCode, while CustomField's own `status` is the
 // lifecycle string (active/retired) — unmarshaling one body into the
 // other's struct would fail on that type mismatch, not just leave zeros.
-func createCustomField(t *testing.T, e *env, body anyMap) (int, customFieldWire, customFieldProblem) {
+func createCustomField(t *testing.T, e *apptest.AppEnv, body apptest.AnyMap) (int, customFieldWire, customFieldProblem) {
 	t.Helper()
 	var raw json.RawMessage
-	status := e.call(t, "POST", "/v1/custom-fields", body, nil, &raw)
+	status := e.Call(t, "POST", "/v1/custom-fields", body, nil, &raw)
 	var field customFieldWire
 	var problem customFieldProblem
 	if len(raw) == 0 {

--- a/backend/internal/compose/integration/customfields_values_http_integration_test.go
+++ b/backend/internal/compose/integration/customfields_values_http_integration_test.go
@@ -15,13 +15,15 @@ package integration
 import (
 	"net/http"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 )
 
 // assertWireCF asserts one top-level custom-field key on a decoded wire
 // payload.
 //
 //craft:ignore naked-any want is whichever JSON-decoded shape the wire carries for the field's type (string/bool/float64) — the assertion seam mirrors env.call's out
-func assertWireCF(t *testing.T, payload anyMap, key string, want any) {
+func assertWireCF(t *testing.T, payload apptest.AnyMap, key string, want any) {
 	t.Helper()
 	if payload[key] != want {
 		t.Fatalf("wire %s = %v (%T), want top-level %v", key, payload[key], payload[key], want)
@@ -30,10 +32,10 @@ func assertWireCF(t *testing.T, payload anyMap, key string, want any) {
 
 // createWithCF posts one record body and returns the decoded response
 // plus its id, asserting the 201.
-func createWithCF(t *testing.T, e *env, path string, body anyMap) (anyMap, string) {
+func createWithCF(t *testing.T, e *apptest.AppEnv, path string, body apptest.AnyMap) (apptest.AnyMap, string) {
 	t.Helper()
-	var created anyMap
-	if status := e.call(t, "POST", path, body, nil, &created); status != http.StatusCreated {
+	var created apptest.AnyMap
+	if status := e.Call(t, "POST", path, body, nil, &created); status != http.StatusCreated {
 		t.Fatalf("POST %s status = %d (%v)", path, status, created)
 	}
 	id, ok := created["id"].(string)
@@ -43,29 +45,29 @@ func createWithCF(t *testing.T, e *env, path string, body anyMap) (anyMap, strin
 	return created, id
 }
 
-func assertPersonWireRoundTrip(t *testing.T, e *env, col string) {
+func assertPersonWireRoundTrip(t *testing.T, e *apptest.AppEnv, col string) {
 	t.Helper()
-	created, id := createWithCF(t, e, "/v1/people", anyMap{
+	created, id := createWithCF(t, e, "/v1/people", apptest.AnyMap{
 		"full_name": "Ada Lovelace", "source": "ui", col: "gold",
 	})
 	assertWireCF(t, created, col, "gold")
 
-	var got anyMap
-	if status := e.call(t, "GET", "/v1/people/"+id, nil, nil, &got); status != http.StatusOK {
+	var got apptest.AnyMap
+	if status := e.Call(t, "GET", "/v1/people/"+id, nil, nil, &got); status != http.StatusOK {
 		t.Fatalf("get person status = %d", status)
 	}
 	assertWireCF(t, got, col, "gold")
 
-	var updated anyMap
-	if status := e.call(t, "PATCH", "/v1/people/"+id, anyMap{col: "silver"}, nil, &updated); status != http.StatusOK {
+	var updated apptest.AnyMap
+	if status := e.Call(t, "PATCH", "/v1/people/"+id, apptest.AnyMap{col: "silver"}, nil, &updated); status != http.StatusOK {
 		t.Fatalf("update person status = %d (%v)", status, updated)
 	}
 	assertWireCF(t, updated, col, "silver")
 
 	var list struct {
-		Data []anyMap `json:"data"`
+		Data []apptest.AnyMap `json:"data"`
 	}
-	if status := e.call(t, "GET", "/v1/people", nil, nil, &list); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/people", nil, nil, &list); status != http.StatusOK {
 		t.Fatalf("list people status = %d", status)
 	}
 	if len(list.Data) != 1 {
@@ -74,15 +76,15 @@ func assertPersonWireRoundTrip(t *testing.T, e *env, col string) {
 	assertWireCF(t, list.Data[0], col, "silver")
 }
 
-func assertOrganizationWireRoundTrip(t *testing.T, e *env, col string) {
+func assertOrganizationWireRoundTrip(t *testing.T, e *apptest.AppEnv, col string) {
 	t.Helper()
-	created, id := createWithCF(t, e, "/v1/organizations", anyMap{
+	created, id := createWithCF(t, e, "/v1/organizations", apptest.AnyMap{
 		"display_name": "Acme GmbH", "source": "ui", col: "emea",
 	})
 	assertWireCF(t, created, col, "emea")
 
-	var got anyMap
-	if status := e.call(t, "GET", "/v1/organizations/"+id, nil, nil, &got); status != http.StatusOK {
+	var got apptest.AnyMap
+	if status := e.Call(t, "GET", "/v1/organizations/"+id, nil, nil, &got); status != http.StatusOK {
 		t.Fatalf("get organization status = %d", status)
 	}
 	assertWireCF(t, got, col, "emea")
@@ -91,31 +93,31 @@ func assertOrganizationWireRoundTrip(t *testing.T, e *env, col string) {
 // assertDealWireRoundTrip mirrors assertPersonWireRoundTrip's full
 // create/get/update/list shape for the deal object — one of the four
 // core objects the fieldcatalog seam rides (person/organization/deal/lead).
-func assertDealWireRoundTrip(t *testing.T, e *env, col string) {
+func assertDealWireRoundTrip(t *testing.T, e *apptest.AppEnv, col string) {
 	t.Helper()
 	stages := discoverSeededPipeline(t, e)
-	created, id := createWithCF(t, e, "/v1/deals", anyMap{
+	created, id := createWithCF(t, e, "/v1/deals", apptest.AnyMap{
 		"name": "Acme Renewal", "pipeline_id": stages.pipelineID, "stage_id": stages.open,
 		"source": "ui", col: "enterprise",
 	})
 	assertWireCF(t, created, col, "enterprise")
 
-	var got anyMap
-	if status := e.call(t, "GET", "/v1/deals/"+id, nil, nil, &got); status != http.StatusOK {
+	var got apptest.AnyMap
+	if status := e.Call(t, "GET", "/v1/deals/"+id, nil, nil, &got); status != http.StatusOK {
 		t.Fatalf("get deal status = %d", status)
 	}
 	assertWireCF(t, got, col, "enterprise")
 
-	var updated anyMap
-	if status := e.call(t, "PATCH", "/v1/deals/"+id, anyMap{col: "mid-market"}, nil, &updated); status != http.StatusOK {
+	var updated apptest.AnyMap
+	if status := e.Call(t, "PATCH", "/v1/deals/"+id, apptest.AnyMap{col: "mid-market"}, nil, &updated); status != http.StatusOK {
 		t.Fatalf("update deal status = %d (%v)", status, updated)
 	}
 	assertWireCF(t, updated, col, "mid-market")
 
 	var list struct {
-		Data []anyMap `json:"data"`
+		Data []apptest.AnyMap `json:"data"`
 	}
-	if status := e.call(t, "GET", "/v1/deals", nil, nil, &list); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/deals", nil, nil, &list); status != http.StatusOK {
 		t.Fatalf("list deals status = %d", status)
 	}
 	if len(list.Data) != 1 {
@@ -127,29 +129,29 @@ func assertDealWireRoundTrip(t *testing.T, e *env, col string) {
 // assertLeadWireRoundTrip mirrors the deal round trip for the lead object,
 // the fourth fieldcatalog-riding core object — create/get/update/list all
 // carry the cf key top-level over the wire.
-func assertLeadWireRoundTrip(t *testing.T, e *env, col string) {
+func assertLeadWireRoundTrip(t *testing.T, e *apptest.AppEnv, col string) {
 	t.Helper()
-	created, id := createWithCF(t, e, "/v1/leads", anyMap{
+	created, id := createWithCF(t, e, "/v1/leads", apptest.AnyMap{
 		"full_name": "Grace Hopper", "source": "ui", col: "champion",
 	})
 	assertWireCF(t, created, col, "champion")
 
-	var got anyMap
-	if status := e.call(t, "GET", "/v1/leads/"+id, nil, nil, &got); status != http.StatusOK {
+	var got apptest.AnyMap
+	if status := e.Call(t, "GET", "/v1/leads/"+id, nil, nil, &got); status != http.StatusOK {
 		t.Fatalf("get lead status = %d", status)
 	}
 	assertWireCF(t, got, col, "champion")
 
-	var updated anyMap
-	if status := e.call(t, "PATCH", "/v1/leads/"+id, anyMap{col: "detractor"}, nil, &updated); status != http.StatusOK {
+	var updated apptest.AnyMap
+	if status := e.Call(t, "PATCH", "/v1/leads/"+id, apptest.AnyMap{col: "detractor"}, nil, &updated); status != http.StatusOK {
 		t.Fatalf("update lead status = %d (%v)", status, updated)
 	}
 	assertWireCF(t, updated, col, "detractor")
 
 	var list struct {
-		Data []anyMap `json:"data"`
+		Data []apptest.AnyMap `json:"data"`
 	}
-	if status := e.call(t, "GET", "/v1/leads", nil, nil, &list); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/leads", nil, nil, &list); status != http.StatusOK {
 		t.Fatalf("list leads status = %d", status)
 	}
 	if len(list.Data) != 1 {
@@ -161,9 +163,9 @@ func assertLeadWireRoundTrip(t *testing.T, e *env, col string) {
 // sixTypeWireFields creates one active field of every closed type on the
 // person object and returns each type's physical column name, keyed by
 // type — the wire-level twin of TestCustomFieldValues_AllSixTypesRoundTrip.
-func sixTypeWireFields(t *testing.T, e *env) map[string]string {
+func sixTypeWireFields(t *testing.T, e *apptest.AppEnv) map[string]string {
 	t.Helper()
-	specs := map[string]anyMap{
+	specs := map[string]apptest.AnyMap{
 		"text":     {"object": "person", "label": "Note", "type": "text", "source": "ui"},
 		"number":   {"object": "person", "label": "Score", "type": "number", "source": "ui"},
 		"date":     {"object": "person", "label": "Renewal", "type": "date", "source": "ui"},
@@ -187,10 +189,10 @@ func sixTypeWireFields(t *testing.T, e *env) map[string]string {
 // a real create-then-get over the compose stack — the store-level
 // suite's AllSixTypesRoundTrip already proves the value semantics; this
 // proves the same shapes survive the HTTP marshal/unmarshal round trip.
-func assertSixTypesWireRoundTrip(t *testing.T, e *env) {
+func assertSixTypesWireRoundTrip(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
 	cols := sixTypeWireFields(t, e)
-	want := anyMap{
+	want := apptest.AnyMap{
 		cols["text"]:     "prefers morning calls",
 		cols["number"]:   42.5,
 		cols["date"]:     "2026-07-11",
@@ -198,7 +200,7 @@ func assertSixTypesWireRoundTrip(t *testing.T, e *env) {
 		cols["picklist"]: "partner",
 		cols["boolean"]:  true,
 	}
-	body := anyMap{"full_name": "Grace Hopper", "source": "ui"}
+	body := apptest.AnyMap{"full_name": "Grace Hopper", "source": "ui"}
 	for col, v := range want {
 		body[col] = v
 	}
@@ -207,8 +209,8 @@ func assertSixTypesWireRoundTrip(t *testing.T, e *env) {
 		assertWireCF(t, created, col, v)
 	}
 
-	var got anyMap
-	if status := e.call(t, "GET", "/v1/people/"+id, nil, nil, &got); status != http.StatusOK {
+	var got apptest.AnyMap
+	if status := e.Call(t, "GET", "/v1/people/"+id, nil, nil, &got); status != http.StatusOK {
 		t.Fatalf("get person status = %d", status)
 	}
 	for col, v := range want {
@@ -216,10 +218,10 @@ func assertSixTypesWireRoundTrip(t *testing.T, e *env) {
 	}
 }
 
-func assertPicklistCheckViolation422(t *testing.T, e *env, col string) {
+func assertPicklistCheckViolation422(t *testing.T, e *apptest.AppEnv, col string) {
 	t.Helper()
 	var problem customFieldProblem
-	status := e.call(t, "POST", "/v1/people", anyMap{
+	status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{
 		"full_name": "Bad Option", "source": "ui", col: "bogus",
 	}, nil, &problem)
 	if status != http.StatusUnprocessableEntity {
@@ -233,26 +235,26 @@ func assertPicklistCheckViolation422(t *testing.T, e *env, col string) {
 func TestCustomFieldValuesHTTP(t *testing.T) {
 	e := schemaWiredEnv(t)
 
-	status, tier, problem := createCustomField(t, e, anyMap{
+	status, tier, problem := createCustomField(t, e, apptest.AnyMap{
 		"object": "person", "label": "Tier", "type": "picklist",
 		"options": []string{"gold", "silver"}, "source": "ui",
 	})
 	if status != http.StatusCreated {
 		t.Fatalf("create person field status = %d: %+v", status, problem)
 	}
-	status, region, problem := createCustomField(t, e, anyMap{
+	status, region, problem := createCustomField(t, e, apptest.AnyMap{
 		"object": "organization", "label": "Region", "type": "text", "source": "ui",
 	})
 	if status != http.StatusCreated {
 		t.Fatalf("create organization field status = %d: %+v", status, problem)
 	}
-	status, segment, problem := createCustomField(t, e, anyMap{
+	status, segment, problem := createCustomField(t, e, apptest.AnyMap{
 		"object": "deal", "label": "Segment", "type": "text", "source": "ui",
 	})
 	if status != http.StatusCreated {
 		t.Fatalf("create deal field status = %d: %+v", status, problem)
 	}
-	status, persona, problem := createCustomField(t, e, anyMap{
+	status, persona, problem := createCustomField(t, e, apptest.AnyMap{
 		"object": "lead", "label": "Persona", "type": "text", "source": "ui",
 	})
 	if status != http.StatusCreated {

--- a/backend/internal/compose/integration/customfields_vocab_http_integration_test.go
+++ b/backend/internal/compose/integration/customfields_vocab_http_integration_test.go
@@ -17,18 +17,19 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
 // listPeopleNames GETs /v1/people with the given query string and
 // returns the page's full_name column in order.
-func listPeopleNames(t *testing.T, e *env, query string) []string {
+func listPeopleNames(t *testing.T, e *apptest.AppEnv, query string) []string {
 	t.Helper()
 	var list struct {
-		Data []anyMap `json:"data"`
+		Data []apptest.AnyMap `json:"data"`
 	}
-	if status := e.call(t, "GET", "/v1/people"+query, nil, nil, &list); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/people"+query, nil, nil, &list); status != http.StatusOK {
 		t.Fatalf("GET /v1/people%s status = %d", query, status)
 	}
 	names := make([]string, len(list.Data))
@@ -48,7 +49,7 @@ func listPeopleNames(t *testing.T, e *env, query string) []string {
 // twin of TestCustomFieldVocab_SortPaginatesStably, proving the cursor
 // keeps paging correctly (no repeat, no skip) when it travels as an
 // opaque query-string token instead of a direct store call.
-func walkCFSortedPagesOverWire(t *testing.T, e *env, col string) []string {
+func walkCFSortedPagesOverWire(t *testing.T, e *apptest.AppEnv, col string) []string {
 	t.Helper()
 	var walked []string
 	query := "?sort=" + col + "&limit=1"
@@ -57,13 +58,13 @@ func walkCFSortedPagesOverWire(t *testing.T, e *env, col string) []string {
 			t.Fatalf("pagination did not terminate after %d pages (walked %v)", page, walked)
 		}
 		var list struct {
-			Data []anyMap `json:"data"`
+			Data []apptest.AnyMap `json:"data"`
 			Page struct {
 				HasMore    bool    `json:"has_more"`
 				NextCursor *string `json:"next_cursor"`
 			} `json:"page"`
 		}
-		if status := e.call(t, "GET", "/v1/people"+query, nil, nil, &list); status != http.StatusOK {
+		if status := e.Call(t, "GET", "/v1/people"+query, nil, nil, &list); status != http.StatusOK {
 			t.Fatalf("GET /v1/people%s status = %d", query, status)
 		}
 		for _, row := range list.Data {
@@ -85,10 +86,10 @@ func walkCFSortedPagesOverWire(t *testing.T, e *env, col string) []string {
 
 // assert422Code GETs the path and asserts the validation problem's one
 // field error carries the expected machine code.
-func assert422Code(t *testing.T, e *env, path, wantCode string) {
+func assert422Code(t *testing.T, e *apptest.AppEnv, path, wantCode string) {
 	t.Helper()
 	var problem customFieldProblem
-	status := e.call(t, "GET", path, nil, nil, &problem)
+	status := e.Call(t, "GET", path, nil, nil, &problem)
 	if status != http.StatusUnprocessableEntity {
 		t.Fatalf("GET %s status = %d, want 422 (%+v)", path, status, problem)
 	}
@@ -101,9 +102,9 @@ func assert422Code(t *testing.T, e *env, path, wantCode string) {
 // hostile-cursor refusals over the wire: a crafted token whose sort key
 // does not parse as the column's type, and a well-formed token minted
 // under one sort reused under another.
-func assertCursorSortRefusals(t *testing.T, e *env) {
+func assertCursorSortRefusals(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
-	status, score, problem := createCustomField(t, e, anyMap{
+	status, score, problem := createCustomField(t, e, apptest.AnyMap{
 		"object": "person", "label": "Score", "type": "number", "source": "ui",
 	})
 	if status != http.StatusCreated {
@@ -129,7 +130,7 @@ func assertCursorSortRefusals(t *testing.T, e *env) {
 			} `json:"page"`
 		}
 		path := "/v1/people?sort=" + score.ColumnName + "&limit=1"
-		if status := e.call(t, "GET", path, nil, nil, &list); status != http.StatusOK {
+		if status := e.Call(t, "GET", path, nil, nil, &list); status != http.StatusOK {
 			t.Fatalf("GET %s status = %d", path, status)
 		}
 		if !list.Page.HasMore || list.Page.NextCursor == "" {
@@ -142,7 +143,7 @@ func assertCursorSortRefusals(t *testing.T, e *env) {
 func TestCustomFieldVocabHTTP(t *testing.T) {
 	e := schemaWiredEnv(t)
 
-	status, tier, problem := createCustomField(t, e, anyMap{
+	status, tier, problem := createCustomField(t, e, apptest.AnyMap{
 		"object": "person", "label": "Tier", "type": "text", "source": "ui",
 	})
 	if status != http.StatusCreated {
@@ -150,9 +151,9 @@ func TestCustomFieldVocabHTTP(t *testing.T) {
 	}
 	col := tier.ColumnName
 
-	createWithCF(t, e, "/v1/people", anyMap{"full_name": "Person B", "source": "ui", col: "beta"})
-	createWithCF(t, e, "/v1/people", anyMap{"full_name": "Person A", "source": "ui", col: "alpha"})
-	createWithCF(t, e, "/v1/people", anyMap{"full_name": "Person N", "source": "ui"})
+	createWithCF(t, e, "/v1/people", apptest.AnyMap{"full_name": "Person B", "source": "ui", col: "beta"})
+	createWithCF(t, e, "/v1/people", apptest.AnyMap{"full_name": "Person A", "source": "ui", col: "alpha"})
+	createWithCF(t, e, "/v1/people", apptest.AnyMap{"full_name": "Person N", "source": "ui"})
 
 	t.Run("cf_ sort orders the page, NULL last", func(t *testing.T) {
 		got := listPeopleNames(t, e, "?sort="+col)

--- a/backend/internal/compose/integration/datareset_http_e2e_integration_test.go
+++ b/backend/internal/compose/integration/datareset_http_e2e_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	"github.com/gradionhq/margince/backend/internal/platform/deployconfig"
 	"github.com/gradionhq/margince/backend/internal/shared/runtimeenv"
 )
@@ -20,16 +21,16 @@ import (
 // successful reset. Reaching 200 also proves the live session path populates
 // the admin RoleKeys that RequireAdmin gates on.
 func TestResetDataOverHTTP(t *testing.T) {
-	e := setupWithOptions(t,
+	e := apptest.SetupAppWithOptions(t,
 		compose.WithDataReset(nil, deployconfig.Seeds{}, runtimeenv.Development),
 		compose.WithNonProduction(runtimeenv.Development),
 	)
-	bootstrapWorkspaceSession(t, e, "Fable E2E", "ada@example.com", "Ada Admin")
+	apptest.BootstrapWorkspaceSession(t, e, "Fable E2E", "ada@example.com", "Ada Admin")
 
 	var me struct {
 		NonProduction bool `json:"non_production"`
 	}
-	if code := e.call(t, "GET", "/v1/me", nil, nil, &me); code != 200 {
+	if code := e.Call(t, "GET", "/v1/me", nil, nil, &me); code != 200 {
 		t.Fatalf("GET /me = %d, want 200", code)
 	}
 	if !me.NonProduction {
@@ -37,7 +38,7 @@ func TestResetDataOverHTTP(t *testing.T) {
 	}
 
 	// Wrong confirmation is refused before anything is deleted.
-	if code := e.call(t, "POST", "/v1/admin/reset-data", anyMap{"confirmation": "wrong"}, nil, nil); code != 422 {
+	if code := e.Call(t, "POST", "/v1/admin/reset-data", apptest.AnyMap{"confirmation": "wrong"}, nil, nil); code != 422 {
 		t.Fatalf("reset with wrong confirmation = %d, want 422", code)
 	}
 
@@ -46,7 +47,7 @@ func TestResetDataOverHTTP(t *testing.T) {
 		Status        string `json:"status"`
 		TablesCleared int    `json:"tables_cleared"`
 	}
-	if code := e.call(t, "POST", "/v1/admin/reset-data", anyMap{"confirmation": "Fable E2E"}, nil, &out); code != 200 {
+	if code := e.Call(t, "POST", "/v1/admin/reset-data", apptest.AnyMap{"confirmation": "Fable E2E"}, nil, &out); code != 200 {
 		t.Fatalf("reset with the org name = %d, want 200", code)
 	}
 	if out.Status != "reset" {

--- a/backend/internal/compose/integration/dedupequeue_http_integration_test.go
+++ b/backend/internal/compose/integration/dedupequeue_http_integration_test.go
@@ -15,6 +15,8 @@ package integration
 import (
 	"net/http"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 )
 
 type dedupeCandidateDTO struct {
@@ -42,20 +44,20 @@ type dedupeListDTO struct {
 
 // seedOrgPairHTTP creates an incumbent org and a same-stem near-duplicate
 // through the real create endpoint; the create records the queue pair.
-func seedOrgPairHTTP(t *testing.T, e *env, stem, incumbentDomain, dupDomain string) (incumbentID string) {
+func seedOrgPairHTTP(t *testing.T, e *apptest.AppEnv, stem, incumbentDomain, dupDomain string) (incumbentID string) {
 	t.Helper()
 	var org struct {
 		ID string `json:"id"`
 	}
-	if status := e.call(t, "POST", "/v1/organizations", anyMap{
+	if status := e.Call(t, "POST", "/v1/organizations", apptest.AnyMap{
 		"display_name": stem + " GmbH",
-		"domains":      []anyMap{{"domain": incumbentDomain, "is_primary": true}},
+		"domains":      []apptest.AnyMap{{"domain": incumbentDomain, "is_primary": true}},
 	}, nil, &org); status != http.StatusCreated {
 		t.Fatalf("incumbent create → %d, want 201", status)
 	}
-	if status := e.call(t, "POST", "/v1/organizations", anyMap{
+	if status := e.Call(t, "POST", "/v1/organizations", apptest.AnyMap{
 		"display_name": stem + " Inc",
-		"domains":      []anyMap{{"domain": dupDomain, "is_primary": true}},
+		"domains":      []apptest.AnyMap{{"domain": dupDomain, "is_primary": true}},
 	}, nil, nil); status != http.StatusCreated {
 		t.Fatalf("fuzzy create must still 201, got %d", status)
 	}
@@ -63,12 +65,12 @@ func seedOrgPairHTTP(t *testing.T, e *env, stem, incumbentDomain, dupDomain stri
 }
 
 func TestDedupeQueueOverHTTP(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 	incumbentID := seedOrgPairHTTP(t, e, "Umbrella Holdings", "umbrella.example", "umbrella-us.example")
 
 	var queue dedupeListDTO
-	if status := e.call(t, "GET", "/v1/dedupe/candidates", nil, nil, &queue); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/dedupe/candidates", nil, nil, &queue); status != http.StatusOK {
 		t.Fatalf("list → %d, want 200", status)
 	}
 	if len(queue.Data) != 1 {
@@ -83,73 +85,73 @@ func TestDedupeQueueOverHTTP(t *testing.T) {
 	}
 
 	var one dedupeCandidateDTO
-	if status := e.call(t, "GET", "/v1/dedupe/candidates/"+c.ID, nil, nil, &one); status != http.StatusOK || one.ID != c.ID {
+	if status := e.Call(t, "GET", "/v1/dedupe/candidates/"+c.ID, nil, nil, &one); status != http.StatusOK || one.ID != c.ID {
 		t.Fatalf("get → %d (id %s), want 200 for %s", status, one.ID, c.ID)
 	}
-	if status := e.call(t, "GET", "/v1/dedupe/candidates/00000000-0000-7000-8000-000000000000", nil, nil, nil); status != http.StatusNotFound {
+	if status := e.Call(t, "GET", "/v1/dedupe/candidates/00000000-0000-7000-8000-000000000000", nil, nil, nil); status != http.StatusNotFound {
 		t.Fatalf("unknown id → %d, want 404", status)
 	}
-	if status := e.call(t, "GET", "/v1/dedupe/candidates?cursor=%21broken", nil, nil, nil); status != http.StatusUnprocessableEntity {
+	if status := e.Call(t, "GET", "/v1/dedupe/candidates?cursor=%21broken", nil, nil, nil); status != http.StatusUnprocessableEntity {
 		t.Fatalf("malformed cursor → %d, want 422", status)
 	}
 
 	// DH-EXT-2 refusals: an unknown verb and a merge without a winner.
-	if status := e.call(t, "POST", "/v1/dedupe/candidates/"+c.ID+"/disposition",
-		anyMap{"disposition": "merge"}, nil, nil); status != http.StatusUnprocessableEntity {
+	if status := e.Call(t, "POST", "/v1/dedupe/candidates/"+c.ID+"/disposition",
+		apptest.AnyMap{"disposition": "merge"}, nil, nil); status != http.StatusUnprocessableEntity {
 		t.Fatalf("merge without winner → %d, want 422", status)
 	}
 
 	// Dismiss, verify the flip, refuse the second decision, undo.
 	var decided dedupeCandidateDTO
-	if status := e.call(t, "POST", "/v1/dedupe/candidates/"+c.ID+"/disposition",
-		anyMap{"disposition": "not_a_duplicate"}, nil, &decided); status != http.StatusOK || decided.Status != "not_a_duplicate" {
+	if status := e.Call(t, "POST", "/v1/dedupe/candidates/"+c.ID+"/disposition",
+		apptest.AnyMap{"disposition": "not_a_duplicate"}, nil, &decided); status != http.StatusOK || decided.Status != "not_a_duplicate" {
 		t.Fatalf("dismiss → %d/%s, want 200/not_a_duplicate", status, decided.Status)
 	}
-	if status := e.call(t, "POST", "/v1/dedupe/candidates/"+c.ID+"/disposition",
-		anyMap{"disposition": "not_a_duplicate"}, nil, nil); status != http.StatusConflict {
+	if status := e.Call(t, "POST", "/v1/dedupe/candidates/"+c.ID+"/disposition",
+		apptest.AnyMap{"disposition": "not_a_duplicate"}, nil, nil); status != http.StatusConflict {
 		t.Fatalf("second decision → %d, want 409", status)
 	}
 	var reopened dedupeCandidateDTO
-	if status := e.call(t, "POST", "/v1/dedupe/candidates/"+c.ID+"/undo", nil, nil, &reopened); status != http.StatusOK || reopened.Status != "open" {
+	if status := e.Call(t, "POST", "/v1/dedupe/candidates/"+c.ID+"/undo", nil, nil, &reopened); status != http.StatusOK || reopened.Status != "open" {
 		t.Fatalf("undo → %d/%s, want 200/open", status, reopened.Status)
 	}
 
 	// Merge: the winner survives, and a merged pair cannot be undone.
 	var merged dedupeCandidateDTO
-	if status := e.call(t, "POST", "/v1/dedupe/candidates/"+c.ID+"/disposition",
-		anyMap{"disposition": "merge", "winner_id": incumbentID}, nil, &merged); status != http.StatusOK || merged.Status != "merged" {
+	if status := e.Call(t, "POST", "/v1/dedupe/candidates/"+c.ID+"/disposition",
+		apptest.AnyMap{"disposition": "merge", "winner_id": incumbentID}, nil, &merged); status != http.StatusOK || merged.Status != "merged" {
 		t.Fatalf("merge → %d/%s, want 200/merged", status, merged.Status)
 	}
-	if status := e.call(t, "POST", "/v1/dedupe/candidates/"+c.ID+"/undo", nil, nil, nil); status != http.StatusConflict {
+	if status := e.Call(t, "POST", "/v1/dedupe/candidates/"+c.ID+"/undo", nil, nil, nil); status != http.StatusConflict {
 		t.Fatalf("undo on merged → %d, want 409 (PO-AC-M6: no merge reversal)", status)
 	}
 
 	// The decided pair filters by status; the open queue is empty again.
 	var open dedupeListDTO
-	if status := e.call(t, "GET", "/v1/dedupe/candidates?status=open", nil, nil, &open); status != http.StatusOK || len(open.Data) != 0 {
+	if status := e.Call(t, "GET", "/v1/dedupe/candidates?status=open", nil, nil, &open); status != http.StatusOK || len(open.Data) != 0 {
 		t.Fatalf("open list after merge → %d with %d rows, want 200 with 0", status, len(open.Data))
 	}
 	var mergedList dedupeListDTO
-	if status := e.call(t, "GET", "/v1/dedupe/candidates?status=merged&entity_type=organization", nil, nil, &mergedList); status != http.StatusOK || len(mergedList.Data) != 1 {
+	if status := e.Call(t, "GET", "/v1/dedupe/candidates?status=merged&entity_type=organization", nil, nil, &mergedList); status != http.StatusOK || len(mergedList.Data) != 1 {
 		t.Fatalf("merged list → %d with %d rows, want 200 with 1", status, len(mergedList.Data))
 	}
 }
 
 func TestDedupeQueuePagesOverHTTP(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 	seedOrgPairHTTP(t, e, "Vandelay Industries", "vandelay.example", "vandelay-us.example")
 	seedOrgPairHTTP(t, e, "Initech Systems", "initech.example", "initech-us.example")
 
 	var page1 dedupeListDTO
-	if status := e.call(t, "GET", "/v1/dedupe/candidates?limit=1", nil, nil, &page1); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/dedupe/candidates?limit=1", nil, nil, &page1); status != http.StatusOK {
 		t.Fatalf("page 1 → %d, want 200", status)
 	}
 	if len(page1.Data) != 1 || page1.Page == nil || !page1.Page.HasMore || page1.Page.NextCursor == nil {
 		t.Fatalf("page 1 = %d rows, page %+v — want 1 row with a next cursor", len(page1.Data), page1.Page)
 	}
 	var page2 dedupeListDTO
-	if status := e.call(t, "GET", "/v1/dedupe/candidates?limit=1&cursor="+*page1.Page.NextCursor, nil, nil, &page2); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/dedupe/candidates?limit=1&cursor="+*page1.Page.NextCursor, nil, nil, &page2); status != http.StatusOK {
 		t.Fatalf("page 2 → %d, want 200", status)
 	}
 	if len(page2.Data) != 1 || page2.Data[0].ID == page1.Data[0].ID {

--- a/backend/internal/compose/integration/dsr_erasure_integration_test.go
+++ b/backend/internal/compose/integration/dsr_erasure_integration_test.go
@@ -14,12 +14,14 @@ import (
 	"context"
 	"net/http"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 )
 
 func TestBootstrapSeedsDefaultRetentionPolicies(t *testing.T) {
 	e := setupRelationships(t)
 
-	rows, err := e.owner.Query(context.Background(), `
+	rows, err := e.Owner.Query(context.Background(), `
 		SELECT object_type, coalesce(category, ''), retain_days, action
 		FROM retention_policy ORDER BY object_type, retain_days`)
 	if err != nil {
@@ -58,12 +60,12 @@ func TestFulfillingAnErasureDSRExecutesTheErasure(t *testing.T) {
 	var dsr struct {
 		ID string `json:"id"`
 	}
-	if status := e.call(t, "POST", "/v1/data-subject-requests", anyMap{
+	if status := e.Call(t, "POST", "/v1/data-subject-requests", apptest.AnyMap{
 		"kind": "erasure", "subject_ref": e.personID, "due_at": "2026-08-01T00:00:00Z",
 	}, nil, &dsr); status != http.StatusCreated {
 		t.Fatalf("create DSR → %d", status)
 	}
-	if status := e.call(t, "PATCH", "/v1/data-subject-requests/"+dsr.ID, anyMap{
+	if status := e.Call(t, "PATCH", "/v1/data-subject-requests/"+dsr.ID, apptest.AnyMap{
 		"status": "fulfilled", "resolution": "erased per Art. 17",
 	}, nil, nil); status != http.StatusOK {
 		t.Fatalf("fulfill DSR → %d", status)
@@ -72,7 +74,7 @@ func TestFulfillingAnErasureDSRExecutesTheErasure(t *testing.T) {
 	var person struct {
 		FullName string `json:"full_name"`
 	}
-	if status := e.call(t, "GET", "/v1/people/"+e.personID, nil, nil, &person); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/people/"+e.personID, nil, nil, &person); status != http.StatusOK {
 		t.Fatalf("read person → %d", status)
 	}
 	if person.FullName != "Erased Subject" {

--- a/backend/internal/compose/integration/dsr_integration_test.go
+++ b/backend/internal/compose/integration/dsr_integration_test.go
@@ -13,6 +13,8 @@ import (
 	"net/http"
 	"testing"
 	"time"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 )
 
 func TestDataSubjectRequestLifecycle(t *testing.T) {
@@ -23,30 +25,30 @@ func TestDataSubjectRequestLifecycle(t *testing.T) {
 		ID     string `json:"id"`
 		Status string `json:"status"`
 	}
-	if status := c.call(t, "POST", "/v1/data-subject-requests", anyMap{
+	if status := c.Call(t, "POST", "/v1/data-subject-requests", apptest.AnyMap{
 		"kind": "erasure", "subject_ref": c.personID, "due_at": due,
 	}, nil, &dsr); status != http.StatusCreated || dsr.Status != "open" {
 		t.Fatalf("create DSR → %d %+v", status, dsr)
 	}
 
 	// Closing without a resolution refuses.
-	if status := c.call(t, "PATCH", "/v1/data-subject-requests/"+dsr.ID, anyMap{
+	if status := c.Call(t, "PATCH", "/v1/data-subject-requests/"+dsr.ID, apptest.AnyMap{
 		"status": "fulfilled",
 	}, nil, nil); status != 422 {
 		t.Fatalf("resolution-less close → %d, want 422", status)
 	}
-	if status := c.call(t, "PATCH", "/v1/data-subject-requests/"+dsr.ID, anyMap{
+	if status := c.Call(t, "PATCH", "/v1/data-subject-requests/"+dsr.ID, apptest.AnyMap{
 		"status": "in_progress",
 	}, nil, nil); status != http.StatusOK {
 		t.Fatalf("start → %d", status)
 	}
-	if status := c.call(t, "PATCH", "/v1/data-subject-requests/"+dsr.ID, anyMap{
+	if status := c.Call(t, "PATCH", "/v1/data-subject-requests/"+dsr.ID, apptest.AnyMap{
 		"status": "fulfilled", "resolution": "erased person + activities per retention policy",
 	}, nil, nil); status != http.StatusOK {
 		t.Fatalf("fulfill → %d", status)
 	}
 	// A closed request never reopens.
-	if status := c.call(t, "PATCH", "/v1/data-subject-requests/"+dsr.ID, anyMap{
+	if status := c.Call(t, "PATCH", "/v1/data-subject-requests/"+dsr.ID, apptest.AnyMap{
 		"status": "open",
 	}, nil, nil); status != 422 {
 		t.Fatalf("reopen → %d, want 422", status)
@@ -57,7 +59,7 @@ func TestDataSubjectRequestLifecycle(t *testing.T) {
 			ID string `json:"id"`
 		} `json:"data"`
 	}
-	if status := c.call(t, "GET", "/v1/data-subject-requests", nil, nil, &list); status != http.StatusOK || len(list.Data) != 1 {
+	if status := c.Call(t, "GET", "/v1/data-subject-requests", nil, nil, &list); status != http.StatusOK || len(list.Data) != 1 {
 		t.Fatalf("list → %d %+v", status, list)
 	}
 
@@ -65,13 +67,13 @@ func TestDataSubjectRequestLifecycle(t *testing.T) {
 	var minted struct {
 		Token string `json:"token"`
 	}
-	if status := c.call(t, "POST", "/v1/passports", anyMap{
+	if status := c.Call(t, "POST", "/v1/passports", apptest.AnyMap{
 		"label": "dsr probe", "scopes": []string{"read", "write"},
 	}, nil, &minted); status != http.StatusCreated {
 		t.Fatalf("mint passport → %d", status)
 	}
 	bearer := map[string]string{"Authorization": "Bearer " + minted.Token}
-	if status := c.call(t, "POST", "/v1/data-subject-requests", anyMap{
+	if status := c.Call(t, "POST", "/v1/data-subject-requests", apptest.AnyMap{
 		"kind": "access", "subject_ref": "x", "due_at": due,
 	}, bearer, nil); status != http.StatusForbidden {
 		t.Fatalf("agent DSR create → %d, want 403 (human-only)", status)

--- a/backend/internal/compose/integration/e2e_agent_integration_test.go
+++ b/backend/internal/compose/integration/e2e_agent_integration_test.go
@@ -14,6 +14,8 @@ package integration
 import (
 	"strings"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 )
 
 // The agent path on the REST surface (ADR-0013: agents are clients of the
@@ -21,8 +23,8 @@ import (
 // the read scope, writes refused without the write scope, revocation as
 // the kill switch.
 func TestEndToEnd_passportBearerSurface(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 
 	// A human session mints the passport; the response carries the token
 	// exactly once.
@@ -30,7 +32,7 @@ func TestEndToEnd_passportBearerSurface(t *testing.T) {
 		PassportID string `json:"passport_id"`
 		Token      string `json:"token"`
 	}
-	if status := e.call(t, "POST", "/v1/passports", anyMap{
+	if status := e.Call(t, "POST", "/v1/passports", apptest.AnyMap{
 		"label": "e2e agent", "scopes": []string{"read"},
 	}, nil, &minted); status != 201 {
 		t.Fatalf("issue passport → %d", status)
@@ -46,7 +48,7 @@ func TestEndToEnd_passportBearerSurface(t *testing.T) {
 	var listed struct {
 		Data []map[string]any `json:"data"`
 	}
-	if status := e.call(t, "GET", "/v1/passports", nil, nil, &listed); status != 200 {
+	if status := e.Call(t, "GET", "/v1/passports", nil, nil, &listed); status != 200 {
 		t.Fatalf("list passports → %d", status)
 	}
 	if len(listed.Data) != 1 {
@@ -69,19 +71,19 @@ func TestEndToEnd_passportBearerSurface(t *testing.T) {
 	// agent bearer is refused with the same permission_denied a human-only
 	// mutation answers, not the incidental 401 the handler used to give for
 	// wanting a session identity.
-	if status := e.call(t, "GET", "/v1/passports", nil, bearer, nil); status != 403 {
+	if status := e.Call(t, "GET", "/v1/passports", nil, bearer, nil); status != 403 {
 		t.Fatalf("agent bearer lists passports → %d, want 403 (human-only read)", status)
 	}
 
 	// The read scope reads…
-	if status := e.call(t, "GET", "/v1/people", nil, bearer, nil); status != 200 {
+	if status := e.Call(t, "GET", "/v1/people", nil, bearer, nil); status != 200 {
 		t.Fatalf("bearer GET /people → %d", status)
 	}
 	// …and cannot write: refused with the scope code, and no row lands.
 	var problem struct {
 		Code string `json:"code"`
 	}
-	status := e.call(t, "POST", "/v1/people", anyMap{
+	status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{
 		"full_name": "Should not exist", "source": "mcp", "captured_by": "x",
 	}, bearer, &problem)
 	if status != 403 || problem.Code != "scope_exceeds_grantor" {
@@ -89,15 +91,15 @@ func TestEndToEnd_passportBearerSurface(t *testing.T) {
 	}
 
 	// Bad tokens are 401, not 500.
-	if status := e.call(t, "GET", "/v1/people", nil, map[string]string{"Authorization": "Bearer mgp_bogus"}, nil); status != 401 {
+	if status := e.Call(t, "GET", "/v1/people", nil, map[string]string{"Authorization": "Bearer mgp_bogus"}, nil); status != 401 {
 		t.Fatalf("bogus bearer → %d", status)
 	}
 
 	// Revoke over HTTP (session-authenticated); the token dies with it.
-	if status := e.call(t, "DELETE", "/v1/passports/"+minted.PassportID, nil, nil, nil); status != 204 {
+	if status := e.Call(t, "DELETE", "/v1/passports/"+minted.PassportID, nil, nil, nil); status != 204 {
 		t.Fatalf("revoke → %d", status)
 	}
-	if status := e.call(t, "GET", "/v1/people", nil, bearer, nil); status != 401 {
+	if status := e.Call(t, "GET", "/v1/people", nil, bearer, nil); status != 401 {
 		t.Fatalf("revoked bearer still reads: %d", status)
 	}
 }
@@ -109,13 +111,13 @@ func TestEndToEnd_passportBearerSurface(t *testing.T) {
 // rejected on principal type; human-only config ops reject the agent
 // outright.
 func TestEndToEnd_agentWritesGovernedOnREST(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 
 	var minted struct {
 		Token string `json:"token"`
 	}
-	if status := e.call(t, "POST", "/v1/passports", anyMap{
+	if status := e.Call(t, "POST", "/v1/passports", apptest.AnyMap{
 		"label": "write agent", "scopes": []string{"read", "write"},
 	}, nil, &minted); status != 201 {
 		t.Fatalf("issue passport → %d", status)
@@ -128,7 +130,7 @@ func TestEndToEnd_agentWritesGovernedOnREST(t *testing.T) {
 		ID         string `json:"id"`
 		CapturedBy string `json:"captured_by"`
 	}
-	if status := e.call(t, "POST", "/v1/people", anyMap{
+	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{
 		"full_name": "Governed Green Write", "source": "mcp", "captured_by": "human:forged",
 	}, bearer, &created); status != 201 {
 		t.Fatalf("write-scope 🟢 REST mutation → %d, want 201 (ADR-0055 admits governed agent writes)", status)
@@ -143,11 +145,11 @@ func TestEndToEnd_agentWritesGovernedOnREST(t *testing.T) {
 		Code   string `json:"code"`
 		Detail string `json:"detail"`
 	}
-	status := e.call(t, "DELETE", "/v1/people/"+created.ID, nil, bearer, &problem)
+	status := e.Call(t, "DELETE", "/v1/people/"+created.ID, nil, bearer, &problem)
 	if status != 403 || problem.Code != "approval_required" {
 		t.Fatalf("🟡 REST mutation → %d %q, want 403 approval_required", status, problem.Code)
 	}
-	if getStatus := e.call(t, "GET", "/v1/people/"+created.ID, nil, bearer, nil); getStatus != 200 {
+	if getStatus := e.Call(t, "GET", "/v1/people/"+created.ID, nil, bearer, nil); getStatus != 200 {
 		t.Fatalf("staged archive must not have executed; GET → %d", getStatus)
 	}
 	approvalID := extractStagedApprovalID(t, problem.Detail)
@@ -156,26 +158,26 @@ func TestEndToEnd_agentWritesGovernedOnREST(t *testing.T) {
 	var denyBody struct {
 		Code string `json:"code"`
 	}
-	if status := e.call(t, "POST", "/v1/approvals/"+approvalID+"/approve", anyMap{}, bearer, &denyBody); status != 403 || denyBody.Code != "permission_denied" {
+	if status := e.Call(t, "POST", "/v1/approvals/"+approvalID+"/approve", apptest.AnyMap{}, bearer, &denyBody); status != 403 || denyBody.Code != "permission_denied" {
 		t.Fatalf("agent self-approval → %d %q, want 403 permission_denied", status, denyBody.Code)
 	}
 
 	// Human-only config surface rejects the agent whatever its scopes.
-	if status := e.call(t, "POST", "/v1/pipelines", anyMap{"name": "Shadow"}, bearer, &denyBody); status != 403 || denyBody.Code != "permission_denied" {
+	if status := e.Call(t, "POST", "/v1/pipelines", apptest.AnyMap{"name": "Shadow"}, bearer, &denyBody); status != 403 || denyBody.Code != "permission_denied" {
 		t.Fatalf("agent on human-only pipeline config → %d %q, want 403 permission_denied", status, denyBody.Code)
 	}
 
 	// A human approves; the agent repeats the IDENTICAL request with the
 	// approval token and the effect lands exactly once.
-	if status := e.call(t, "POST", "/v1/approvals/"+approvalID+"/approve", anyMap{}, nil, nil); status != 200 {
+	if status := e.Call(t, "POST", "/v1/approvals/"+approvalID+"/approve", apptest.AnyMap{}, nil, nil); status != 200 {
 		t.Fatalf("human approve → %d", status)
 	}
 	withToken := map[string]string{"Authorization": "Bearer " + minted.Token, "X-Approval-Token": approvalID}
-	if status := e.call(t, "DELETE", "/v1/people/"+created.ID, nil, withToken, nil); status != 200 {
+	if status := e.Call(t, "DELETE", "/v1/people/"+created.ID, nil, withToken, nil); status != 200 {
 		t.Fatalf("approved retry → %d, want the archive to execute", status)
 	}
 	// Single-use: the same token cannot authorize a second effect.
-	if e.call(t, "DELETE", "/v1/people/"+created.ID, nil, withToken, &problem) == 200 {
+	if e.Call(t, "DELETE", "/v1/people/"+created.ID, nil, withToken, &problem) == 200 {
 		t.Fatal("a consumed approval token authorized a second effect")
 	}
 }
@@ -201,14 +203,14 @@ func extractStagedApprovalID(t *testing.T, detail string) string {
 // bootstrap admin is a full seat that mutates; flipping the workspace to
 // read seats turns the same authenticated call into a 403.
 func TestEndToEnd_readSeatCannotMutate(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 
 	// A full-seat admin creates freely.
 	var created struct {
 		ID string `json:"id"`
 	}
-	if status := e.call(t, "POST", "/v1/people", anyMap{
+	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{
 		"full_name": "Full Seat Made", "source": "manual", "captured_by": "admin",
 	}, nil, &created); status != 201 {
 		t.Fatalf("full-seat create → %d", status)
@@ -216,22 +218,22 @@ func TestEndToEnd_readSeatCannotMutate(t *testing.T) {
 
 	// Demote to a read seat; the live seat is read at authentication, so the
 	// same session now hits the ceiling.
-	e.setWorkspaceSeat(t, e.slug, "read")
+	e.SetWorkspaceSeat(t, e.Slug, "read")
 
 	// Reads still succeed…
-	if status := e.call(t, "GET", "/v1/people", nil, nil, nil); status != 200 {
+	if status := e.Call(t, "GET", "/v1/people", nil, nil, nil); status != 200 {
 		t.Fatalf("read-seat GET → %d", status)
 	}
 	// …every mutation is refused with the seat code, before RBAC.
 	var problem struct {
 		Code string `json:"code"`
 	}
-	if status := e.call(t, "POST", "/v1/people", anyMap{
+	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{
 		"full_name": "Read Seat Blocked", "source": "manual", "captured_by": "admin",
 	}, nil, &problem); status != 403 || problem.Code != "seat_tier_insufficient" {
 		t.Fatalf("read-seat create → %d %q, want 403 seat_tier_insufficient", status, problem.Code)
 	}
-	if status := e.call(t, "PATCH", "/v1/people/"+created.ID, anyMap{"title": "X"}, nil, &problem); status != 403 || problem.Code != "seat_tier_insufficient" {
+	if status := e.Call(t, "PATCH", "/v1/people/"+created.ID, apptest.AnyMap{"title": "X"}, nil, &problem); status != 403 || problem.Code != "seat_tier_insufficient" {
 		t.Fatalf("read-seat update → %d %q, want 403 seat_tier_insufficient", status, problem.Code)
 	}
 }

--- a/backend/internal/compose/integration/e2e_integration_test.go
+++ b/backend/internal/compose/integration/e2e_integration_test.go
@@ -13,200 +13,11 @@ package integration
 // e2e_agent_integration_test.go.
 
 import (
-	"bytes"
-	"context"
-	"encoding/json"
-	"io"
-	"log/slog"
 	"net/http"
-	"net/http/cookiejar"
-	"net/http/httptest"
-	"os"
 	"testing"
 
-	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
-
-	"github.com/gradionhq/margince/backend/internal/compose"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
-	"github.com/gradionhq/margince/backend/internal/platform/jobs"
-	"github.com/gradionhq/margince/backend/internal/platform/testdb"
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 )
-
-type env struct {
-	ts     *httptest.Server
-	client *http.Client
-	slug   string
-	owner  *pgx.Conn
-	pool   *pgxpool.Pool
-}
-
-// setup boots the default harness server — no schema pool, so the
-// customfields runtime-DDL operations answer their generated 501
-// (the unwired-by-default posture). Suites that need the
-// schema pool wired (customfields_http_integration_test.go) call
-// setupWithOptions directly with compose.WithSchemaPool(SchemaPool(t)).
-func setup(t *testing.T) *env {
-	t.Helper()
-	return setupWithOptions(t)
-}
-
-// setupWithOptions is setup's body, parameterized over extra compose
-// options so a suite that needs a boot-optional seam (e.g. the
-// customfields schema pool) can wire it without duplicating the
-// migrate-and-boot ceremony every other suite in this package shares.
-func setupWithOptions(t *testing.T, opts ...compose.Option) *env {
-	t.Helper()
-	return setupWithOriginOptions(t, func(string) []compose.Option { return opts })
-}
-
-// setupWithOriginOptions is setupWithOptions for a suite whose wiring must
-// name the harness's OWN origin — the RFC 8414/9728 discovery documents carry
-// absolute URLs, and a suite asserting what a real client dereferences cannot
-// hardcode a port the OS assigns. The listener is opened before the handler is
-// composed, so the origin is known without booting twice.
-func setupWithOriginOptions(t *testing.T, opts func(origin string) []compose.Option) *env {
-	t.Helper()
-	ownerDSN := os.Getenv("MARGINCE_TEST_DSN")
-	appDSN := os.Getenv("MARGINCE_TEST_APP_DSN")
-	if ownerDSN == "" || appDSN == "" {
-		t.Fatal("MARGINCE_TEST_DSN / MARGINCE_TEST_APP_DSN not set — run `make db-up` (integration tests fail loudly, they never skip)")
-	}
-	ctx := context.Background()
-
-	owner, err := pgx.Connect(ctx, ownerDSN)
-	if err != nil {
-		t.Fatalf("connecting as owner: %v", err)
-	}
-	t.Cleanup(func() {
-		if err := owner.Close(context.Background()); err != nil {
-			t.Errorf("closing owner connection: %v", err)
-		}
-	})
-
-	if err := testdb.EnsureSchema(ctx, owner); err != nil {
-		t.Fatalf("migrating schema: %v", err)
-	}
-	if err := testdb.Reset(ctx, owner); err != nil {
-		t.Fatalf("resetting database: %v", err)
-	}
-
-	pool, err := database.NewPool(ctx, appDSN)
-	if err != nil {
-		t.Fatalf("opening app pool: %v", err)
-	}
-	t.Cleanup(pool.Close)
-
-	// The delivery machinery every send transport is composed with in the api
-	// role. Without it a send refuses rather than log an activity claiming a
-	// message went out, so a harness missing it would test the refusal in
-	// every suite that sends — including the consent and preference-center
-	// suites, whose subject is what happens AFTER a send is accepted.
-	ApplyRiverSchema(t)
-	sendInserter, err := jobs.NewInserter(pool, slog.New(slog.NewTextHandler(io.Discard, nil)))
-	if err != nil {
-		t.Fatalf("jobs.NewInserter: %v", err)
-	}
-	// Unstarted, so the listener's port is known before the handler is
-	// composed: StartTLS below serves the same handler NewTLSServer would.
-	ts := httptest.NewUnstartedServer(nil)
-	origin := "https://" + ts.Listener.Addr().String()
-	allOpts := append([]compose.Option{
-		compose.WithPublicBaseURL("https://mail.example.test"),
-		compose.WithDelivery(compose.NewDeliveryStager(pool, sendInserter)),
-	}, opts(origin)...)
-	ts.Config.Handler = compose.New(pool, slog.New(slog.NewTextHandler(os.Stderr, nil)), allOpts...)
-	ts.StartTLS()
-	t.Cleanup(ts.Close)
-
-	jar, err := cookiejar.New(nil)
-	if err != nil {
-		t.Fatalf("cookie jar: %v", err)
-	}
-	client := ts.Client()
-	client.Jar = jar
-
-	return &env{ts: ts, client: client, slug: "fable-e2e", owner: owner, pool: pool}
-}
-
-// bootstrapWorkspace provisions the organization + admin (the A107 boot
-// path) and leaves the admin session cookie in the client jar — the
-// first step of every e2e scenario.
-func (e *env) bootstrapWorkspace(t *testing.T) {
-	t.Helper()
-	bootstrapWorkspaceSession(t, e, "Fable E2E", "ada@example.com", "Ada Admin")
-	e.slug = "fable-e2e" // slugify("Fable E2E")
-}
-
-// setWorkspaceSeat flips a workspace's users to a seat type through the
-// owner connection, inside a workspace-bound transaction so RLS (FORCE)
-// admits the UPDATE. Used to drive the read-seat ceiling from a test.
-func (e *env) setWorkspaceSeat(t *testing.T, slug, seat string) {
-	t.Helper()
-	ctx := context.Background()
-	tx, err := e.owner.Begin(ctx)
-	if err != nil {
-		t.Fatalf("begin: %v", err)
-	}
-	//craft:ignore swallowed-errors error-path safety net only — the Commit below is asserted, after which this rollback is a designed no-op
-	defer func() { _ = tx.Rollback(ctx) }()
-	var wsID string
-	if err := tx.QueryRow(ctx, `SELECT id FROM workspace WHERE slug = $1`, slug).Scan(&wsID); err != nil {
-		t.Fatalf("workspace lookup: %v", err)
-	}
-	if _, err := tx.Exec(ctx, `SELECT set_config('app.workspace_id', $1, true)`, wsID); err != nil {
-		t.Fatalf("set guc: %v", err)
-	}
-	if _, err := tx.Exec(ctx, `UPDATE app_user SET seat_type = $2 WHERE workspace_id = $1`, wsID, seat); err != nil {
-		t.Fatalf("seat update: %v", err)
-	}
-	if err := tx.Commit(ctx); err != nil {
-		t.Fatalf("commit: %v", err)
-	}
-}
-
-// call issues one API request with the dev workspace header and decodes
-// the JSON response into out (when non-nil), returning the status code.
-//
-//craft:ignore naked-any the test transport seam: body/out are whichever request/response shapes the scenario exercises
-func (e *env) call(t *testing.T, method, path string, body any, headers map[string]string, out any) int {
-	t.Helper()
-	var reqBody io.Reader
-	if body != nil {
-		raw, err := json.Marshal(body)
-		if err != nil {
-			t.Fatalf("marshaling request: %v", err)
-		}
-		reqBody = bytes.NewReader(raw)
-	}
-	req, err := http.NewRequest(method, e.ts.URL+path, reqBody)
-	if err != nil {
-		t.Fatalf("building request: %v", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	for k, v := range headers {
-		req.Header.Set(k, v)
-	}
-
-	resp, err := e.client.Do(req)
-	if err != nil {
-		t.Fatalf("%s %s: %v", method, path, err)
-	}
-	defer closeBody(t, resp)
-
-	raw, err := io.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatalf("reading response: %v", err)
-	}
-	if out != nil && len(raw) > 0 {
-		if err := json.Unmarshal(raw, out); err != nil {
-			t.Fatalf("%s %s: decoding %q: %v", method, path, raw, err)
-		}
-	}
-	return resp.StatusCode
-}
-
-type anyMap = map[string]any
 
 // seededStages is the seeded default pipeline's stage vocabulary a
 // scenario advances deals through.
@@ -219,7 +30,7 @@ type seededStages struct {
 
 // discoverSeededPipeline asserts the bootstrap seeded exactly one default
 // pipeline with its six stages and resolves the semantic stage ids.
-func discoverSeededPipeline(t *testing.T, e *env) seededStages {
+func discoverSeededPipeline(t *testing.T, e *apptest.AppEnv) seededStages {
 	t.Helper()
 	var pipelines struct {
 		Data []struct {
@@ -231,7 +42,7 @@ func discoverSeededPipeline(t *testing.T, e *env) seededStages {
 			} `json:"stages"`
 		} `json:"data"`
 	}
-	if status := e.call(t, "GET", "/v1/pipelines", nil, nil, &pipelines); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/pipelines", nil, nil, &pipelines); status != http.StatusOK {
 		t.Fatalf("pipelines status = %d", status)
 	}
 	if len(pipelines.Data) != 1 || !pipelines.Data[0].IsDefault || len(pipelines.Data[0].Stages) != 6 {
@@ -256,13 +67,13 @@ func discoverSeededPipeline(t *testing.T, e *env) seededStages {
 // exercisePersonWriteInvariants runs the person write shape: create with
 // server-stamped provenance, duplicate-email 409 with the existing id,
 // If-Match version skew, then the versioned update. Returns the person id.
-func exercisePersonWriteInvariants(t *testing.T, e *env, adminUserID string) string {
+func exercisePersonWriteInvariants(t *testing.T, e *apptest.AppEnv, adminUserID string) string {
 	t.Helper()
-	var person anyMap
-	status := e.call(t, "POST", "/v1/people", anyMap{
+	var person apptest.AnyMap
+	status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{
 		"full_name": "Grace Hopper",
 		"source":    "ui",
-		"emails":    []anyMap{{"email": "grace@navy.mil", "is_primary": true}},
+		"emails":    []apptest.AnyMap{{"email": "grace@navy.mil", "is_primary": true}},
 	}, nil, &person)
 	if status != http.StatusCreated {
 		t.Fatalf("create person = %d %v", status, person)
@@ -272,28 +83,28 @@ func exercisePersonWriteInvariants(t *testing.T, e *env, adminUserID string) str
 		t.Errorf("captured_by = %v; the server must stamp the acting principal", person["captured_by"])
 	}
 
-	var dup anyMap
-	status = e.call(t, "POST", "/v1/people", anyMap{
+	var dup apptest.AnyMap
+	status = e.Call(t, "POST", "/v1/people", apptest.AnyMap{
 		"full_name": "Grace Clone",
 		"source":    "ui",
-		"emails":    []anyMap{{"email": "grace@navy.mil"}},
+		"emails":    []apptest.AnyMap{{"email": "grace@navy.mil"}},
 	}, nil, &dup)
 	if status != http.StatusConflict {
 		t.Fatalf("duplicate email = %d, want 409", status)
 	}
-	if dup["details"].(anyMap)["existing_id"] != personID {
+	if dup["details"].(apptest.AnyMap)["existing_id"] != personID {
 		t.Errorf("409 existing_id = %v, want %s", dup["details"], personID)
 	}
 
-	var conflict anyMap
-	status = e.call(t, "PATCH", "/v1/people/"+personID, anyMap{"title": "Rear Admiral"},
+	var conflict apptest.AnyMap
+	status = e.Call(t, "PATCH", "/v1/people/"+personID, apptest.AnyMap{"title": "Rear Admiral"},
 		map[string]string{"If-Match": "42"}, &conflict)
 	if status != http.StatusConflict || conflict["code"] != "version_skew" {
 		t.Fatalf("stale If-Match = %d %v, want 409 version_skew", status, conflict)
 	}
 
-	var person2 anyMap
-	status = e.call(t, "PATCH", "/v1/people/"+personID, anyMap{"title": "Rear Admiral"},
+	var person2 apptest.AnyMap
+	status = e.Call(t, "PATCH", "/v1/people/"+personID, apptest.AnyMap{"title": "Rear Admiral"},
 		map[string]string{"If-Match": "1"}, &person2)
 	if status != http.StatusOK || person2["version"].(float64) != 2 {
 		t.Fatalf("If-Match update = %d version %v, want 200 v2", status, person2["version"])
@@ -304,20 +115,20 @@ func exercisePersonWriteInvariants(t *testing.T, e *env, adminUserID string) str
 // exerciseDealToWon creates the organization + deal, asserts losing
 // without a reason is refused, and closes the deal as won. Returns the
 // deal id.
-func exerciseDealToWon(t *testing.T, e *env, stages seededStages) string {
+func exerciseDealToWon(t *testing.T, e *apptest.AppEnv, stages seededStages) string {
 	t.Helper()
-	var org anyMap
-	status := e.call(t, "POST", "/v1/organizations", anyMap{
+	var org apptest.AnyMap
+	status := e.Call(t, "POST", "/v1/organizations", apptest.AnyMap{
 		"display_name": "Acme GmbH",
 		"source":       "ui",
-		"domains":      []anyMap{{"domain": "acme.example", "is_primary": true}},
+		"domains":      []apptest.AnyMap{{"domain": "acme.example", "is_primary": true}},
 	}, nil, &org)
 	if status != http.StatusCreated {
 		t.Fatalf("create org = %d %v", status, org)
 	}
 
-	var deal anyMap
-	status = e.call(t, "POST", "/v1/deals", anyMap{
+	var deal apptest.AnyMap
+	status = e.Call(t, "POST", "/v1/deals", apptest.AnyMap{
 		"name":            "Acme rollout",
 		"amount_minor":    250_000_00,
 		"currency":        "EUR",
@@ -332,13 +143,13 @@ func exerciseDealToWon(t *testing.T, e *env, stages seededStages) string {
 	dealID := deal["id"].(string)
 
 	// Losing without a reason is refused (deal_lost_reason).
-	var lostErr anyMap
-	status = e.call(t, "POST", "/v1/deals/"+dealID+"/advance", anyMap{"to_stage_id": stages.lost}, nil, &lostErr)
+	var lostErr apptest.AnyMap
+	status = e.Call(t, "POST", "/v1/deals/"+dealID+"/advance", apptest.AnyMap{"to_stage_id": stages.lost}, nil, &lostErr)
 	if status != http.StatusUnprocessableEntity {
 		t.Fatalf("lost without reason = %d %v, want 422", status, lostErr)
 	}
 
-	status = e.call(t, "POST", "/v1/deals/"+dealID+"/advance", anyMap{"to_stage_id": stages.won}, nil, &deal)
+	status = e.Call(t, "POST", "/v1/deals/"+dealID+"/advance", apptest.AnyMap{"to_stage_id": stages.won}, nil, &deal)
 	if status != http.StatusOK || deal["status"] != "won" || deal["closed_at"] == nil {
 		t.Fatalf("advance to won = %d %v", status, deal)
 	}
@@ -348,23 +159,23 @@ func exerciseDealToWon(t *testing.T, e *env, stages seededStages) string {
 // exerciseActivityIdempotentCapture logs an email activity against the
 // deal and replays the identical capture, asserting the replay is a
 // silent 200 onto the same activity.
-func exerciseActivityIdempotentCapture(t *testing.T, e *env, dealID string) {
+func exerciseActivityIdempotentCapture(t *testing.T, e *apptest.AppEnv, dealID string) {
 	t.Helper()
 	// --- activity: log against the deal, idempotent capture replay ---
-	var activity anyMap
-	logReq := anyMap{
+	var activity apptest.AnyMap
+	logReq := apptest.AnyMap{
 		"kind":          "email",
 		"subject":       "Signed!",
 		"source":        "email:msg-1",
 		"source_system": "gmail",
 		"source_id":     "msg-1",
-		"links":         []anyMap{{"entity_type": "deal", "entity_id": dealID}},
+		"links":         []apptest.AnyMap{{"entity_type": "deal", "entity_id": dealID}},
 	}
-	if status := e.call(t, "POST", "/v1/activities", logReq, nil, &activity); status != http.StatusCreated {
+	if status := e.Call(t, "POST", "/v1/activities", logReq, nil, &activity); status != http.StatusCreated {
 		t.Fatalf("log activity = %d %v", status, activity)
 	}
-	var replay anyMap
-	if status := e.call(t, "POST", "/v1/activities", logReq, nil, &replay); status != http.StatusOK {
+	var replay apptest.AnyMap
+	if status := e.Call(t, "POST", "/v1/activities", logReq, nil, &replay); status != http.StatusOK {
 		t.Fatalf("capture replay = %d, want 200 (idempotent)", status)
 	}
 	if replay["id"] != activity["id"] {
@@ -373,27 +184,27 @@ func exerciseActivityIdempotentCapture(t *testing.T, e *env, dealID string) {
 }
 
 func TestEndToEnd_coreSalesFlow(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 
 	// The cookie authenticates /me.
-	var me anyMap
-	if status := e.call(t, "GET", "/v1/me", nil, nil, &me); status != http.StatusOK {
+	var me apptest.AnyMap
+	if status := e.Call(t, "GET", "/v1/me", nil, nil, &me); status != http.StatusOK {
 		t.Fatalf("/me status = %d", status)
 	}
-	if got := me["user"].(anyMap)["email"]; got != "ada@example.com" {
+	if got := me["user"].(apptest.AnyMap)["email"]; got != "ada@example.com" {
 		t.Fatalf("/me email = %v", got)
 	}
 
 	stages := discoverSeededPipeline(t, e)
-	personID := exercisePersonWriteInvariants(t, e, me["user"].(anyMap)["id"].(string))
+	personID := exercisePersonWriteInvariants(t, e, me["user"].(apptest.AnyMap)["id"].(string))
 	dealID := exerciseDealToWon(t, e, stages)
 
 	exerciseActivityIdempotentCapture(t, e, dealID)
 
 	// --- lead: segregated, dedupes on email ---
-	var lead anyMap
-	status := e.call(t, "POST", "/v1/leads", anyMap{
+	var lead apptest.AnyMap
+	status := e.Call(t, "POST", "/v1/leads", apptest.AnyMap{
 		"full_name":    "Cold Prospect",
 		"email":        "cold@example.org",
 		"company_name": "Unknown AG",
@@ -402,7 +213,7 @@ func TestEndToEnd_coreSalesFlow(t *testing.T) {
 	if status != http.StatusCreated {
 		t.Fatalf("create lead = %d %v", status, lead)
 	}
-	status = e.call(t, "POST", "/v1/leads", anyMap{
+	status = e.Call(t, "POST", "/v1/leads", apptest.AnyMap{
 		"email":  "cold@example.org",
 		"source": "import:batch-2",
 	}, nil, nil)
@@ -411,17 +222,17 @@ func TestEndToEnd_coreSalesFlow(t *testing.T) {
 	}
 
 	// --- archive cascades and stays fetchable by id ---
-	var person anyMap
-	if status := e.call(t, "DELETE", "/v1/people/"+personID, nil, nil, &person); status != http.StatusOK {
+	var person apptest.AnyMap
+	if status := e.Call(t, "DELETE", "/v1/people/"+personID, nil, nil, &person); status != http.StatusOK {
 		t.Fatalf("archive person = %d", status)
 	}
 	if person["archived_at"] == nil {
 		t.Error("archived person carries no archived_at")
 	}
 	var people struct {
-		Data []anyMap `json:"data"`
+		Data []apptest.AnyMap `json:"data"`
 	}
-	if status := e.call(t, "GET", "/v1/people", nil, nil, &people); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/people", nil, nil, &people); status != http.StatusOK {
 		t.Fatalf("list people = %d", status)
 	}
 	for _, p := range people.Data {
@@ -432,10 +243,10 @@ func TestEndToEnd_coreSalesFlow(t *testing.T) {
 
 	// --- the governance audit view reflects the session's own trail ---
 	var audit struct {
-		Data []anyMap `json:"data"`
-		Page anyMap   `json:"page"`
+		Data []apptest.AnyMap `json:"data"`
+		Page apptest.AnyMap   `json:"page"`
 	}
-	if status := e.call(t, "GET", "/v1/audit-log?entity_type=person&action=archive", nil, nil, &audit); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/audit-log?entity_type=person&action=archive", nil, nil, &audit); status != http.StatusOK {
 		t.Fatalf("audit log = %d", status)
 	}
 	found := false
@@ -450,38 +261,38 @@ func TestEndToEnd_coreSalesFlow(t *testing.T) {
 }
 
 func TestEndToEnd_authAndSurfaceBoundaries(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 
 	// An unimplemented contract operation answers an explicit 501.
-	var problem anyMap
-	if status := e.call(t, "POST", "/v1/coldstart", anyMap{"url": "https://example.com"}, nil, &problem); status != http.StatusNotImplemented {
+	var problem apptest.AnyMap
+	if status := e.Call(t, "POST", "/v1/coldstart", apptest.AnyMap{"url": "https://example.com"}, nil, &problem); status != http.StatusNotImplemented {
 		t.Fatalf("unimplemented op = %d %v, want 501", status, problem)
 	}
 
 	// Logout revokes; the session no longer authenticates.
-	if status := e.call(t, "POST", "/v1/auth/logout", nil, nil, nil); status != http.StatusNoContent {
+	if status := e.Call(t, "POST", "/v1/auth/logout", nil, nil, nil); status != http.StatusNoContent {
 		t.Fatalf("logout = %d", status)
 	}
-	if status := e.call(t, "GET", "/v1/me", nil, nil, nil); status != http.StatusUnauthorized {
+	if status := e.Call(t, "GET", "/v1/me", nil, nil, nil); status != http.StatusUnauthorized {
 		t.Fatalf("/me after logout = %d, want 401", status)
 	}
 
 	// Login re-authenticates with fresh credentials.
-	var me anyMap
-	if status := e.call(t, "POST", "/v1/auth/login", anyMap{
+	var me apptest.AnyMap
+	if status := e.Call(t, "POST", "/v1/auth/login", apptest.AnyMap{
 		"email":    "ada@example.com",
 		"password": "correct-horse-battery",
 	}, nil, &me); status != http.StatusOK {
 		t.Fatalf("login = %d", status)
 	}
-	if status := e.call(t, "GET", "/v1/me", nil, nil, &me); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/me", nil, nil, &me); status != http.StatusOK {
 		t.Fatalf("/me after login = %d", status)
 	}
 
 	// Wrong password is a 401 that does not say which half was wrong.
-	var authErr anyMap
-	if status := e.call(t, "POST", "/v1/auth/login", anyMap{
+	var authErr apptest.AnyMap
+	if status := e.Call(t, "POST", "/v1/auth/login", apptest.AnyMap{
 		"email":    "ada@example.com",
 		"password": "wrong",
 	}, nil, &authErr); status != http.StatusUnauthorized {

--- a/backend/internal/compose/integration/embedreindex_fanout_integration_test.go
+++ b/backend/internal/compose/integration/embedreindex_fanout_integration_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	"github.com/gradionhq/margince/backend/internal/modules/ai"
 	"github.com/gradionhq/margince/backend/internal/modules/search"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -143,19 +144,19 @@ func TestEmbedReindexForceTakesTheMarkerBackFromAWedgedRun(t *testing.T) {
 	router := embedReindexRouter(t, "reindex-wedged-v1")
 	e := setupEmbedReindex(t, router)
 
-	if status, _, _ := embedConfirm(t, e, anyMap{"force": true}); status != http.StatusAccepted {
+	if status, _, _ := embedConfirm(t, e, apptest.AnyMap{"force": true}); status != http.StatusAccepted {
 		t.Fatalf("first confirm -> %d, want 202", status)
 	}
 	// A forced confirm while the run is genuinely moving must still be refused:
 	// the marker was claimed a moment ago, so nothing here is stale.
-	if status, _, problem := embedConfirm(t, e, anyMap{"force": true}); status != http.StatusConflict || problem.Code != "reindex_running" {
+	if status, _, problem := embedConfirm(t, e, apptest.AnyMap{"force": true}); status != http.StatusConflict || problem.Code != "reindex_running" {
 		t.Fatalf("forced confirm over a live run -> %d %+v, want 409 reindex_running", status, problem)
 	}
 
 	// The run's only child was killed outright: its workspace never left the set
 	// and the marker has not moved since. Aged rather than waited out — a suite
 	// that waited an hour is a suite nobody runs.
-	if _, err := e.owner.Exec(context.Background(),
+	if _, err := e.Owner.Exec(context.Background(),
 		`UPDATE embed_store_binding SET updated_at = now() - interval '2 hours' WHERE singleton`); err != nil {
 		t.Fatalf("ageing the wedged marker: %v", err)
 	}
@@ -163,7 +164,7 @@ func TestEmbedReindexForceTakesTheMarkerBackFromAWedgedRun(t *testing.T) {
 	if status, _, problem := embedConfirm(t, e, nil); status != http.StatusConflict || problem.Code != "reindex_running" {
 		t.Fatalf("bare confirm over a wedged marker -> %d %+v, want 409 — taking a run's marker away is something a human asks for", status, problem)
 	}
-	status, confirmed, problem := embedConfirm(t, e, anyMap{"force": true})
+	status, confirmed, problem := embedConfirm(t, e, apptest.AnyMap{"force": true})
 	if status != http.StatusAccepted {
 		t.Fatalf("forced confirm over a wedged marker -> %d %+v, want 202 — an installation with no way back answers 409 forever", status, problem)
 	}

--- a/backend/internal/compose/integration/embedreindex_integration_test.go
+++ b/backend/internal/compose/integration/embedreindex_integration_test.go
@@ -33,6 +33,7 @@ import (
 	"time"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	"github.com/gradionhq/margince/backend/internal/modules/ai"
 	"github.com/gradionhq/margince/backend/internal/modules/search"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
@@ -107,7 +108,7 @@ func embedReindexRouter(t *testing.T, modelName string) *ai.Router {
 // (the vacuous "nothing populated yet, nothing configured differently"
 // baseline binding_integration_test.go's SeedBinding test proves), and
 // leaves the bootstrap admin's session in the client jar.
-func setupEmbedReindex(t *testing.T, router *ai.Router) *env {
+func setupEmbedReindex(t *testing.T, router *ai.Router) *apptest.AppEnv {
 	t.Helper()
 	appDSN := os.Getenv("MARGINCE_TEST_APP_DSN")
 	if appDSN == "" {
@@ -130,18 +131,18 @@ func setupEmbedReindex(t *testing.T, router *ai.Router) *env {
 		t.Fatalf("jobs.NewInserter: %v", err)
 	}
 
-	e := setupWithOptions(t, compose.WithEmbedReindex(router, inserter))
+	e := apptest.SetupAppWithOptions(t, compose.WithEmbedReindex(router, inserter))
 	// The confirm handler enqueues into river_job on ITS OWN transaction
 	// (search.Store.ClaimAndEnqueueReembedding), so the schema must exist
 	// before the FIRST confirm call, not merely before a worker starts —
 	// applyRiverSchema is idempotent (existence-guarded), so every
 	// caller of this setup pays for it at most once per process.
 	ApplyRiverSchema(t)
-	bootstrapWorkspaceSession(t, e, "Embed Reindex E2E", "embed-reindex@fable.test", "Admin")
-	e.slug = "embed-reindex-e2e" // slugify("Embed Reindex E2E")
+	apptest.BootstrapWorkspaceSession(t, e, "Embed Reindex E2E", "embed-reindex@fable.test", "Admin")
+	e.Slug = "embed-reindex-e2e" // slugify("Embed Reindex E2E")
 
 	identity, _ := router.EmbedIdentity()
-	if err := search.NewStore(e.pool).SeedBinding(ctx, identity); err != nil {
+	if err := search.NewStore(e.Pool).SeedBinding(ctx, identity); err != nil {
 		t.Fatalf("SeedBinding: %v", err)
 	}
 	return e
@@ -151,10 +152,10 @@ func setupEmbedReindex(t *testing.T, router *ai.Router) *env {
 // there is no /v1/workspaces endpoint to read it from, so this reads it
 // the same way demoteToRep/setWorkspaceSeat already do (owner connection,
 // by slug).
-func embedReindexWorkspaceID(t *testing.T, e *env) string {
+func embedReindexWorkspaceID(t *testing.T, e *apptest.AppEnv) string {
 	t.Helper()
 	var wsID string
-	if err := e.owner.QueryRow(context.Background(), `SELECT id FROM workspace WHERE slug = $1`, e.slug).Scan(&wsID); err != nil {
+	if err := e.Owner.QueryRow(context.Background(), `SELECT id FROM workspace WHERE slug = $1`, e.Slug).Scan(&wsID); err != nil {
 		t.Fatalf("workspace lookup: %v", err)
 	}
 	return wsID
@@ -165,16 +166,16 @@ func embedReindexWorkspaceID(t *testing.T, e *env) string {
 // binding_integration_test.go's TestReindexNeededAfterStaleIdentityRow
 // proves at the store: an entity with an embedding row, just not a
 // CURRENT one, must still count as pending.
-func seedStaleEmbeddingRow(t *testing.T, e *env, wsID string) {
+func seedStaleEmbeddingRow(t *testing.T, e *apptest.AppEnv, wsID string) {
 	t.Helper()
 	ctx := context.Background()
 	var personID string
-	if err := e.owner.QueryRow(ctx,
+	if err := e.Owner.QueryRow(ctx,
 		`INSERT INTO person (workspace_id, full_name, source, captured_by) VALUES ($1, 'Stale Row Person', 'manual', 'human:x') RETURNING id`,
 		wsID).Scan(&personID); err != nil {
 		t.Fatalf("seeding the stale-row person: %v", err)
 	}
-	if _, err := e.owner.Exec(ctx, `
+	if _, err := e.Owner.Exec(ctx, `
 		INSERT INTO embedding (workspace_id, entity_type, entity_id, chunk_ix, chunk_hash, model, embedding)
 		VALUES ($1, 'person', $2, 0, 'stale-hash', 'fake/stale-identity@1024', '[1,2,3]'::vector)`,
 		wsID, personID); err != nil {
@@ -189,11 +190,11 @@ func seedStaleEmbeddingRow(t *testing.T, e *env, wsID string) {
 // store pass standing in for it. The three always-on periodic passes
 // are given a long interval so they don't interleave noise into this
 // suite's completion/cancellation stream.
-func newEmbedReindexRunner(t *testing.T, e *env, embedder search.Embedder) *jobs.Runner {
+func newEmbedReindexRunner(t *testing.T, e *apptest.AppEnv, embedder search.Embedder) *jobs.Runner {
 	t.Helper()
 	ApplyRiverSchema(t)
 	quiet := slog.New(slog.NewTextHandler(io.Discard, nil))
-	runner, err := compose.NewJobRunner(e.pool, quiet, compose.JobRunnerConfig{
+	runner, err := compose.NewJobRunner(e.Pool, quiet, compose.JobRunnerConfig{
 		CloseDateInterval: time.Hour,
 		ReconcileInterval: time.Hour,
 		TimeScanInterval:  time.Hour,
@@ -225,12 +226,12 @@ func startEmbedReindexRunner(t *testing.T, runner *jobs.Runner) {
 // embedStatus/embedPreview/embedConfirm are the three ops' thin call
 // wrappers — every scenario below drives the SAME transport, never the
 // store directly (that coverage is binding_integration_test.go's).
-func embedStatus(t *testing.T, e *env) (int, embedReindexStatusWire, embedReindexProblem) {
+func embedStatus(t *testing.T, e *apptest.AppEnv) (int, embedReindexStatusWire, embedReindexProblem) {
 	t.Helper()
 	return embedReindexDecode[embedReindexStatusWire](t, e, "GET", "/v1/embeddings/reindex/status", nil)
 }
 
-func embedPreview(t *testing.T, e *env) (int, embedReindexPreviewWire, embedReindexProblem) {
+func embedPreview(t *testing.T, e *apptest.AppEnv) (int, embedReindexPreviewWire, embedReindexProblem) {
 	t.Helper()
 	return embedReindexDecode[embedReindexPreviewWire](t, e, "GET", "/v1/embeddings/reindex/preview", nil)
 }
@@ -244,7 +245,7 @@ func embedPreview(t *testing.T, e *env) (int, embedReindexPreviewWire, embedRein
 // keeps the ContentLength==0 path genuinely exercised).
 //
 //craft:ignore naked-any a type parameter would box the literal-nil body a bare confirm depends on (see above)
-func embedConfirm(t *testing.T, e *env, body any) (int, embedReindexStatusWire, embedReindexProblem) {
+func embedConfirm(t *testing.T, e *apptest.AppEnv, body any) (int, embedReindexStatusWire, embedReindexProblem) {
 	t.Helper()
 	return embedReindexDecode[embedReindexStatusWire](t, e, "POST", "/v1/embeddings/reindex", body)
 }
@@ -257,10 +258,10 @@ func embedConfirm(t *testing.T, e *env, body any) (int, embedReindexStatusWire, 
 // success shape, so the status code must pick the target type first).
 //
 //craft:ignore naked-any body passes embedConfirm's nil-preserving contract through to the harness call
-func embedReindexDecode[T any](t *testing.T, e *env, method, path string, body any) (int, T, embedReindexProblem) {
+func embedReindexDecode[T any](t *testing.T, e *apptest.AppEnv, method, path string, body any) (int, T, embedReindexProblem) {
 	t.Helper()
 	var raw json.RawMessage
-	status := e.call(t, method, path, body, nil, &raw)
+	status := e.Call(t, method, path, body, nil, &raw)
 	var success T
 	var problem embedReindexProblem
 	if len(raw) == 0 {
@@ -418,7 +419,7 @@ func TestEmbedReindexConfirmLifecycle(t *testing.T) {
 	// The released marker is claimable again: the run gave it back, rather
 	// than the confirm having to wait for a job row to age out of some
 	// uniqueness window.
-	if status, _, _ := embedConfirm(t, e, anyMap{"force": true}); status != http.StatusAccepted {
+	if status, _, _ := embedConfirm(t, e, apptest.AnyMap{"force": true}); status != http.StatusAccepted {
 		t.Fatalf("confirm after the run released -> %d, want 202", status)
 	}
 }
@@ -439,7 +440,7 @@ func TestEmbedReindexRepeatConfirmIsRefusedAfterItsDispatcherFinishes(t *testing
 	if status, _, _ := embedConfirm(t, e, nil); status != http.StatusAccepted {
 		t.Fatalf("first confirm -> %d, want 202", status)
 	}
-	tag, err := e.owner.Exec(context.Background(),
+	tag, err := e.Owner.Exec(context.Background(),
 		`UPDATE river_job SET state = 'completed', finalized_at = now() WHERE kind = 'embed_reindex' AND state != 'completed'`)
 	if err != nil {
 		t.Fatalf("finalizing the dispatcher row: %v", err)
@@ -466,13 +467,13 @@ func TestEmbedReindexConfirmRefusesIdentityDrift(t *testing.T) {
 	wsID := embedReindexWorkspaceID(t, e)
 	seedStaleEmbeddingRow(t, e, wsID)
 
-	status, _, problem := embedConfirm(t, e, anyMap{"previewed_identity": "fake/someone-else@1024"})
+	status, _, problem := embedConfirm(t, e, apptest.AnyMap{"previewed_identity": "fake/someone-else@1024"})
 	if status != http.StatusConflict || problem.Code != "reindex_identity_drift" {
 		t.Fatalf("drifted confirm -> %d %+v, want 409 reindex_identity_drift", status, problem)
 	}
 
 	identity, _ := router.EmbedIdentity()
-	status, confirmed, _ := embedConfirm(t, e, anyMap{"previewed_identity": identity})
+	status, confirmed, _ := embedConfirm(t, e, apptest.AnyMap{"previewed_identity": identity})
 	if status != http.StatusAccepted {
 		t.Fatalf("matching-identity confirm -> %d, want 202 (the drifted attempt must not have left a live claim)", status)
 	}
@@ -502,7 +503,7 @@ func TestEmbedReindexIdentityMismatchedJobCancels(t *testing.T) {
 	// force=true: this scenario is about the WORKER's own drift guard,
 	// not about whether the store happens to derive reindex-needed —
 	// force is the affordance that lets the enqueue happen regardless.
-	status, confirmed, _ := embedConfirm(t, e, anyMap{"force": true})
+	status, confirmed, _ := embedConfirm(t, e, apptest.AnyMap{"force": true})
 	if status != http.StatusAccepted || confirmed.Status != "reembedding" {
 		t.Fatalf("confirm -> %d %+v, want 202/reembedding", status, confirmed)
 	}
@@ -520,7 +521,7 @@ func TestEmbedReindexIdentityMismatchedJobCancels(t *testing.T) {
 	AwaitKindCompleted(waitCtx, t, sub, "embed_reindex_workspace")
 
 	var jobState string
-	if err := e.owner.QueryRow(context.Background(),
+	if err := e.Owner.QueryRow(context.Background(),
 		`SELECT state FROM river_job WHERE kind = 'embed_reindex_workspace' ORDER BY id DESC LIMIT 1`).Scan(&jobState); err != nil {
 		t.Fatalf("reading the job's terminal state: %v", err)
 	}
@@ -538,7 +539,7 @@ func TestEmbedReindexIdentityMismatchedJobCancels(t *testing.T) {
 	if st.PopulatedIdentity != before {
 		t.Fatalf("populated_identity = %q, want it unmoved at %q — a cancelled run re-embedded nothing and must claim nothing", st.PopulatedIdentity, before)
 	}
-	if status, _, problem := embedConfirm(t, e, anyMap{"force": true}); status != http.StatusAccepted {
+	if status, _, problem := embedConfirm(t, e, apptest.AnyMap{"force": true}); status != http.StatusAccepted {
 		t.Fatalf("re-confirm after the drifted run cancelled -> %d %+v, want 202 — the marker is what the next run needs back", status, problem)
 	}
 }
@@ -567,7 +568,7 @@ func TestEmbedReindexForceReindexWhenNotNeeded(t *testing.T) {
 		t.Fatalf("bare confirm on a caught-up store -> %d %+v, want 409 reindex_not_needed", status, problem)
 	}
 
-	status, forced, _ := embedConfirm(t, e, anyMap{"force": true})
+	status, forced, _ := embedConfirm(t, e, apptest.AnyMap{"force": true})
 	if status != http.StatusAccepted {
 		t.Fatalf("forced confirm -> %d, want 202 (force is the rebuild affordance)", status)
 	}

--- a/backend/internal/compose/integration/embedreindex_integration_test.go
+++ b/backend/internal/compose/integration/embedreindex_integration_test.go
@@ -116,9 +116,9 @@ func setupEmbedReindex(t *testing.T, router *ai.Router) *apptest.AppEnv {
 	}
 	ctx := context.Background()
 
-	// A separate pool from the pointed-at-the-same-DSN pool env's own
-	// setupWithOptions opens below — jobs.NewInserter just needs SOME
-	// pool reaching the same Postgres, not the exact same *pgxpool.Pool
+	// A separate pool from the pointed-at-the-same-DSN pool that
+	// apptest.SetupAppWithOptions opens below — jobs.NewInserter just needs
+	// SOME pool reaching the same Postgres, not the exact same *pgxpool.Pool
 	// object (mirrors SchemaPool(t)'s own separate-connection precedent).
 	wirePool, err := database.NewPool(ctx, appDSN)
 	if err != nil {
@@ -150,7 +150,7 @@ func setupEmbedReindex(t *testing.T, router *ai.Router) *apptest.AppEnv {
 
 // embedReindexWorkspaceID resolves the bootstrapped workspace's raw id —
 // there is no /v1/workspaces endpoint to read it from, so this reads it
-// the same way demoteToRep/setWorkspaceSeat already do (owner connection,
+// the same way demoteToRep/SetWorkspaceSeat already do (owner connection,
 // by slug).
 func embedReindexWorkspaceID(t *testing.T, e *apptest.AppEnv) string {
 	t.Helper()
@@ -238,7 +238,7 @@ func embedPreview(t *testing.T, e *apptest.AppEnv) (int, embedReindexPreviewWire
 
 // embedConfirm issues the confirm call. body is nil for a bare confirm
 // (an empty request — decodeEmbedReindexStart's zero-value path) or an
-// anyMap carrying previewed_identity/force; passed straight through as
+// apptest.AnyMap carrying previewed_identity/force; passed straight through as
 // `any` so a literal nil stays a true nil interface (never a boxed nil
 // map, which would marshal to the 4-byte literal "null" instead of an
 // empty body — harmless to the handler's own decode either way, but this

--- a/backend/internal/compose/integration/extractionaccept_http_integration_test.go
+++ b/backend/internal/compose/integration/extractionaccept_http_integration_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/ports/extraction"
 )
 
-// uploadAttachmentHTTP drives the real multipart upload endpoint (e.call
+// uploadAttachmentHTTP drives the real multipart upload endpoint (e.Call
 // only speaks JSON) and returns the new attachment's id.
 func uploadAttachmentHTTP(e *apptest.AppEnv, t *testing.T, entityType, entityID, filename string) string {
 	t.Helper()
@@ -61,7 +61,7 @@ func uploadAttachmentHTTP(e *apptest.AppEnv, t *testing.T, entityType, entityID,
 // directly through the owner connection — there is no scan-verdict HTTP
 // endpoint (MarkScanResult is administrative, never a public API) — inside
 // a workspace-bound transaction so RLS (FORCE) admits the UPDATE. Mirrors
-// setWorkspaceSeat's shape (e2e_integration_test.go). A fresh upload
+// SetWorkspaceSeat's shape (e2e_integration_test.go). A fresh upload
 // defaults to 'scanning' (0070), and the accept-write now scan-gates like
 // every other path over an attachment's bytes, so any HTTP scenario that
 // expects the accept to actually run its extractor must clear the gate

--- a/backend/internal/compose/integration/extractionaccept_http_integration_test.go
+++ b/backend/internal/compose/integration/extractionaccept_http_integration_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	"github.com/gradionhq/margince/backend/internal/platform/blobstore"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/extraction"
@@ -26,20 +27,20 @@ import (
 
 // uploadAttachmentHTTP drives the real multipart upload endpoint (e.call
 // only speaks JSON) and returns the new attachment's id.
-func (e *env) uploadAttachmentHTTP(t *testing.T, entityType, entityID, filename string) string {
+func uploadAttachmentHTTP(e *apptest.AppEnv, t *testing.T, entityType, entityID, filename string) string {
 	t.Helper()
 	body, ctype := multipartAttachment(t, entityType, entityID, filename, []byte("attachment bytes"))
-	req, err := http.NewRequest(http.MethodPost, e.ts.URL+"/v1/attachments", body)
+	req, err := http.NewRequest(http.MethodPost, e.TS.URL+"/v1/attachments", body)
 	if err != nil {
 		t.Fatalf("building upload request: %v", err)
 	}
 	req.Header.Set("Content-Type", ctype)
-	req.Header.Set("X-Workspace-Slug", e.slug)
-	resp, err := e.client.Do(req)
+	req.Header.Set("X-Workspace-Slug", e.Slug)
+	resp, err := e.Client.Do(req) //nolint:bodyclose // closed by the deferred apptest.CloseBody on the next line; bodyclose only sees a Close in the same package, and the closer moved out with the fixture
 	if err != nil {
 		t.Fatalf("upload: %v", err)
 	}
-	defer closeBody(t, resp)
+	defer apptest.CloseBody(t, resp)
 	raw, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("reading upload response: %v", err)
@@ -65,17 +66,17 @@ func (e *env) uploadAttachmentHTTP(t *testing.T, entityType, entityID, filename 
 // every other path over an attachment's bytes, so any HTTP scenario that
 // expects the accept to actually run its extractor must clear the gate
 // first.
-func (e *env) markAttachmentCleanHTTP(t *testing.T, attID string) {
+func markAttachmentCleanHTTP(e *apptest.AppEnv, t *testing.T, attID string) {
 	t.Helper()
 	ctx := context.Background()
-	tx, err := e.owner.Begin(ctx)
+	tx, err := e.Owner.Begin(ctx)
 	if err != nil {
 		t.Fatalf("begin: %v", err)
 	}
 	//craft:ignore swallowed-errors error-path safety net only — the Commit below is asserted, after which this rollback is a designed no-op
 	defer func() { _ = tx.Rollback(ctx) }()
 	var wsID string
-	if err := tx.QueryRow(ctx, `SELECT id FROM workspace WHERE slug = $1`, e.slug).Scan(&wsID); err != nil {
+	if err := tx.QueryRow(ctx, `SELECT id FROM workspace WHERE slug = $1`, e.Slug).Scan(&wsID); err != nil {
 		t.Fatalf("workspace lookup: %v", err)
 	}
 	if _, err := tx.Exec(ctx, `SELECT set_config('app.workspace_id', $1, true)`, wsID); err != nil {
@@ -103,7 +104,7 @@ type acceptProblemWire struct {
 // assertAcceptHTTPHappyPath drives the accept over the wire — the edited
 // amount lands as human provenance, the extracted currency as
 // ai-extracted — and reads the deal back through the API.
-func assertAcceptHTTPHappyPath(t *testing.T, e *env, attID, dealID string) {
+func assertAcceptHTTPHappyPath(t *testing.T, e *apptest.AppEnv, attID, dealID string) {
 	t.Helper()
 	var resp struct {
 		DealID   string `json:"deal_id"`
@@ -113,9 +114,9 @@ func assertAcceptHTTPHappyPath(t *testing.T, e *env, attID, dealID string) {
 			Provenance string `json:"provenance"`
 		} `json:"accepted"`
 	}
-	status := e.call(t, "POST", "/v1/attachments/"+attID+"/extraction:accept", anyMap{
+	status := e.Call(t, "POST", "/v1/attachments/"+attID+"/extraction:accept", apptest.AnyMap{
 		"field_keys": []string{"amount_minor", "currency"},
-		"edits":      anyMap{"amount_minor": "200000"},
+		"edits":      apptest.AnyMap{"amount_minor": "200000"},
 	}, nil, &resp)
 	if status != http.StatusOK {
 		t.Fatalf("accept = %d %+v", status, resp)
@@ -129,8 +130,8 @@ func assertAcceptHTTPHappyPath(t *testing.T, e *env, attID, dealID string) {
 		t.Errorf("accepted = %+v, want the edited amount as human and the extracted currency as ai-extracted", resp.Accepted)
 	}
 
-	var got anyMap
-	if status := e.call(t, "GET", "/v1/deals/"+dealID, nil, nil, &got); status != http.StatusOK {
+	var got apptest.AnyMap
+	if status := e.Call(t, "GET", "/v1/deals/"+dealID, nil, nil, &got); status != http.StatusOK {
 		t.Fatalf("read back deal = %d", status)
 	}
 	if got["amount_minor"] != float64(200000) || got["currency"] != "EUR" {
@@ -140,18 +141,18 @@ func assertAcceptHTTPHappyPath(t *testing.T, e *env, attID, dealID string) {
 
 // assertAcceptHTTPNonDeal422 uploads a person-scoped attachment and checks
 // the typed unsupported_entity_type refusal.
-func assertAcceptHTTPNonDeal422(t *testing.T, e *env) {
+func assertAcceptHTTPNonDeal422(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
-	var person anyMap
-	if status := e.call(t, "POST", "/v1/people", anyMap{
+	var person apptest.AnyMap
+	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{
 		"full_name": "Attachment Holder", "source": "ui",
 	}, nil, &person); status != http.StatusCreated {
 		t.Fatalf("create person = %d %v", status, person)
 	}
-	personAtt := e.uploadAttachmentHTTP(t, "person", person["id"].(string), "cv.pdf")
+	personAtt := uploadAttachmentHTTP(e, t, "person", person["id"].(string), "cv.pdf")
 
 	var problem acceptProblemWire
-	status := e.call(t, "POST", "/v1/attachments/"+personAtt+"/extraction:accept", anyMap{
+	status := e.Call(t, "POST", "/v1/attachments/"+personAtt+"/extraction:accept", apptest.AnyMap{
 		"field_keys": []string{"amount_minor"},
 	}, nil, &problem)
 	if status != http.StatusUnprocessableEntity || problem.Code != "unsupported_entity_type" {
@@ -161,10 +162,10 @@ func assertAcceptHTTPNonDeal422(t *testing.T, e *env) {
 
 // assertAcceptHTTPValidation422 posts the given field_keys and checks the
 // validation_error problem names exactly one offending field/code.
-func assertAcceptHTTPValidation422(t *testing.T, e *env, attID string, fieldKeys []string, wantField, wantCode string) {
+func assertAcceptHTTPValidation422(t *testing.T, e *apptest.AppEnv, attID string, fieldKeys []string, wantField, wantCode string) {
 	t.Helper()
 	var problem acceptProblemWire
-	status := e.call(t, "POST", "/v1/attachments/"+attID+"/extraction:accept", anyMap{
+	status := e.Call(t, "POST", "/v1/attachments/"+attID+"/extraction:accept", apptest.AnyMap{
 		"field_keys": fieldKeys,
 	}, nil, &problem)
 	if status != http.StatusUnprocessableEntity || problem.Code != "validation_error" {
@@ -180,19 +181,19 @@ func TestAcceptAttachmentExtractionHTTP(t *testing.T) {
 	// write (the compose.WithExtractor wiring); its map fills in after the
 	// upload mints the attachment id.
 	fx := extraction.FixtureExtractor{Fields: map[string][]extraction.ExtractedField{}}
-	e := setupWithOptions(t, compose.WithExtractor(fx), compose.WithBlobstore(blobstore.NewMemory()))
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupAppWithOptions(t, compose.WithExtractor(fx), compose.WithBlobstore(blobstore.NewMemory()))
+	e.BootstrapWorkspace(t)
 	stages := discoverSeededPipeline(t, e)
 
-	var deal anyMap
-	if status := e.call(t, "POST", "/v1/deals", anyMap{
+	var deal apptest.AnyMap
+	if status := e.Call(t, "POST", "/v1/deals", apptest.AnyMap{
 		"name": "HTTP Accept Deal", "pipeline_id": stages.pipelineID,
 		"stage_id": stages.open, "source": "ui",
 	}, nil, &deal); status != http.StatusCreated {
 		t.Fatalf("create deal = %d %v", status, deal)
 	}
 	dealID := deal["id"].(string)
-	attID := e.uploadAttachmentHTTP(t, "deal", dealID, "quote.pdf")
+	attID := uploadAttachmentHTTP(e, t, "deal", dealID, "quote.pdf")
 	fx.Fields[attID] = []extraction.ExtractedField{
 		{Field: "amount_minor", Value: "150000", SourceQuote: "Total: EUR 1,500.00", PageOrSection: "p.2", Confidence: "high"},
 		{Field: "currency", Value: "EUR", SourceQuote: "all amounts in EUR", PageOrSection: "p.2", Confidence: "medium"},
@@ -201,7 +202,7 @@ func TestAcceptAttachmentExtractionHTTP(t *testing.T) {
 	// gate (TestAcceptAttachmentExtractionScanGateHTTP owns that) — clear
 	// the upload default ('scanning') so every subtest below reaches the
 	// extractor.
-	e.markAttachmentCleanHTTP(t, attID)
+	markAttachmentCleanHTTP(e, t, attID)
 
 	t.Run("200 persists the fields and flips the edited provenance", func(t *testing.T) {
 		assertAcceptHTTPHappyPath(t, e, attID, dealID)
@@ -216,7 +217,7 @@ func TestAcceptAttachmentExtractionHTTP(t *testing.T) {
 		assertAcceptHTTPValidation422(t, e, attID, []string{"probability"}, "field_keys[0]", "not_grounded")
 	})
 	t.Run("404 for a missing attachment", func(t *testing.T) {
-		status := e.call(t, "POST", "/v1/attachments/"+ids.NewV7().String()+"/extraction:accept", anyMap{
+		status := e.Call(t, "POST", "/v1/attachments/"+ids.NewV7().String()+"/extraction:accept", apptest.AnyMap{
 			"field_keys": []string{"amount_minor"},
 		}, nil, nil)
 		if status != http.StatusNotFound {
@@ -233,33 +234,33 @@ func TestAcceptAttachmentExtractionHTTP(t *testing.T) {
 // deal field.
 func TestAcceptAttachmentExtractionScanGateHTTP(t *testing.T) {
 	fx := extraction.FixtureExtractor{Fields: map[string][]extraction.ExtractedField{}}
-	e := setupWithOptions(t, compose.WithExtractor(fx), compose.WithBlobstore(blobstore.NewMemory()))
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupAppWithOptions(t, compose.WithExtractor(fx), compose.WithBlobstore(blobstore.NewMemory()))
+	e.BootstrapWorkspace(t)
 	stages := discoverSeededPipeline(t, e)
 
-	var deal anyMap
-	if status := e.call(t, "POST", "/v1/deals", anyMap{
+	var deal apptest.AnyMap
+	if status := e.Call(t, "POST", "/v1/deals", apptest.AnyMap{
 		"name": "Scan Gate Accept Deal", "pipeline_id": stages.pipelineID,
 		"stage_id": stages.open, "source": "ui",
 	}, nil, &deal); status != http.StatusCreated {
 		t.Fatalf("create deal = %d %v", status, deal)
 	}
 	dealID := deal["id"].(string)
-	attID := e.uploadAttachmentHTTP(t, "deal", dealID, "quote.pdf")
+	attID := uploadAttachmentHTTP(e, t, "deal", dealID, "quote.pdf")
 	fx.Fields[attID] = []extraction.ExtractedField{
 		{Field: "amount_minor", Value: "150000", SourceQuote: "Total: EUR 1,500.00", PageOrSection: "p.2", Confidence: "high"},
 	}
 
 	var problem acceptProblemWire
-	status := e.call(t, "POST", "/v1/attachments/"+attID+"/extraction:accept", anyMap{
+	status := e.Call(t, "POST", "/v1/attachments/"+attID+"/extraction:accept", apptest.AnyMap{
 		"field_keys": []string{"amount_minor"},
 	}, nil, &problem)
 	if status != http.StatusConflict || problem.Code != "scan_pending" {
 		t.Fatalf("accept while scanning = %d code %q, want 409 scan_pending", status, problem.Code)
 	}
 
-	var got anyMap
-	if status := e.call(t, "GET", "/v1/deals/"+dealID, nil, nil, &got); status != http.StatusOK {
+	var got apptest.AnyMap
+	if status := e.Call(t, "GET", "/v1/deals/"+dealID, nil, nil, &got); status != http.StatusOK {
 		t.Fatalf("read back deal = %d", status)
 	}
 	if got["amount_minor"] != nil {

--- a/backend/internal/compose/integration/fieldhistory_http_integration_test.go
+++ b/backend/internal/compose/integration/fieldhistory_http_integration_test.go
@@ -88,7 +88,7 @@ func assertFieldHistoryValidation422(t *testing.T, status int, problem fieldHist
 
 // fieldHistoryHTTPEnv resolves the workspace id the HTTP harness's
 // bootstrap created and opens a second pgxpool.Pool onto the same live
-// schema — exactly how setup() itself pairs its owner connection with an
+// schema — exactly how apptest.SetupApp itself pairs its owner connection with an
 // app pool — so the store-level suite's seedAuditDiffRow can write
 // straight through the real audit-spine path this handler reads back.
 func fieldHistoryHTTPEnv(t *testing.T, e *apptest.AppEnv) *Env {

--- a/backend/internal/compose/integration/fieldhistory_http_integration_test.go
+++ b/backend/internal/compose/integration/fieldhistory_http_integration_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -90,12 +91,12 @@ func assertFieldHistoryValidation422(t *testing.T, status int, problem fieldHist
 // schema — exactly how setup() itself pairs its owner connection with an
 // app pool — so the store-level suite's seedAuditDiffRow can write
 // straight through the real audit-spine path this handler reads back.
-func fieldHistoryHTTPEnv(t *testing.T, e *env) *Env {
+func fieldHistoryHTTPEnv(t *testing.T, e *apptest.AppEnv) *Env {
 	t.Helper()
 	ctx := context.Background()
 	var ws ids.UUID
-	if err := e.owner.QueryRow(ctx, `SELECT id FROM workspace WHERE slug = $1`, e.slug).Scan(&ws); err != nil {
-		t.Fatalf("resolving workspace id for %q: %v", e.slug, err)
+	if err := e.Owner.QueryRow(ctx, `SELECT id FROM workspace WHERE slug = $1`, e.Slug).Scan(&ws); err != nil {
+		t.Fatalf("resolving workspace id for %q: %v", e.Slug, err)
 	}
 	appDSN := os.Getenv("MARGINCE_TEST_APP_DSN")
 	pool, err := database.NewPool(ctx, appDSN)
@@ -155,10 +156,10 @@ type fieldHistoryHTTPFixture struct {
 
 // seedFieldHistoryHTTPFixture creates the subject and seeds the two audit
 // diff rows the happy-path subtest below asserts on.
-func seedFieldHistoryHTTPFixture(t *testing.T, e *env, dbEnv *Env) fieldHistoryHTTPFixture {
+func seedFieldHistoryHTTPFixture(t *testing.T, e *apptest.AppEnv, dbEnv *Env) fieldHistoryHTTPFixture {
 	t.Helper()
-	var person anyMap
-	if status := e.call(t, "POST", "/v1/people", anyMap{
+	var person apptest.AnyMap
+	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{
 		"full_name": "History Wire Subject",
 		"source":    "ui",
 	}, nil, &person); status != http.StatusCreated {
@@ -188,10 +189,10 @@ func seedFieldHistoryHTTPFixture(t *testing.T, e *env, dbEnv *Env) fieldHistoryH
 // data[0] carries the required scalar fields plus the newest (agent) row's
 // passport/evidence, the seeded human diff surfaces with both absent, and
 // the page envelope is present.
-func assertFieldHistoryHappyPath(t *testing.T, e *env, fx fieldHistoryHTTPFixture) {
+func assertFieldHistoryHappyPath(t *testing.T, e *apptest.AppEnv, fx fieldHistoryHTTPFixture) {
 	t.Helper()
 	var page fieldHistoryListWire
-	status := e.call(t, "GET", "/v1/field-history?entity_type=person&entity_id="+fx.personID.String(), nil, nil, &page)
+	status := e.Call(t, "GET", "/v1/field-history?entity_type=person&entity_id="+fx.personID.String(), nil, nil, &page)
 	if status != http.StatusOK {
 		t.Fatalf("field-history status = %d, want 200: %+v", status, page)
 	}
@@ -235,8 +236,8 @@ func assertFieldHistoryHappyPath(t *testing.T, e *env, fx fieldHistoryHTTPFixtur
 }
 
 func TestFieldHistoryHTTP(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 	dbEnv := fieldHistoryHTTPEnv(t, e)
 	fx := seedFieldHistoryHTTPFixture(t, e, dbEnv)
 
@@ -246,20 +247,20 @@ func TestFieldHistoryHTTP(t *testing.T) {
 
 	t.Run("422 invalid entity_type", func(t *testing.T) {
 		var problem fieldHistoryProblem
-		status := e.call(t, "GET", "/v1/field-history?entity_type=bogus&entity_id="+ids.NewV7().String(), nil, nil, &problem)
+		status := e.Call(t, "GET", "/v1/field-history?entity_type=bogus&entity_id="+ids.NewV7().String(), nil, nil, &problem)
 		assertFieldHistoryValidation422(t, status, problem, "entity_type", "invalid_entity_type")
 	})
 
 	t.Run("422 invalid actor_type", func(t *testing.T) {
 		var problem fieldHistoryProblem
-		status := e.call(t, "GET",
+		status := e.Call(t, "GET",
 			"/v1/field-history?entity_type=person&entity_id="+ids.NewV7().String()+"&actor_type=bogus", nil, nil, &problem)
 		assertFieldHistoryValidation422(t, status, problem, "actor_type", "invalid_actor_type")
 	})
 
 	t.Run("422 malformed cursor", func(t *testing.T) {
 		var problem fieldHistoryProblem
-		status := e.call(t, "GET",
+		status := e.Call(t, "GET",
 			"/v1/field-history?entity_type=person&entity_id="+ids.NewV7().String()+"&cursor=!!!notatoken", nil, nil, &problem)
 		assertFieldHistoryValidation422(t, status, problem, "cursor", "malformed_cursor")
 	})

--- a/backend/internal/compose/integration/filteredexport_integration_test.go
+++ b/backend/internal/compose/integration/filteredexport_integration_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
@@ -229,9 +230,9 @@ func lastSystemLog(t *testing.T, e *SearchEnv, action string) (gotAction string,
 // filtered export returns a CSV download, and an out-of-vocabulary filter
 // answers 422 — proving the transport wiring and error mapping.
 func TestFilteredExportHTTPEndToEnd(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
-	if status := e.call(t, "POST", "/v1/auth/login", anyMap{
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
+	if status := e.Call(t, "POST", "/v1/auth/login", apptest.AnyMap{
 		"email": "ada@example.com", "password": "correct-horse-battery",
 	}, nil, nil); status != http.StatusOK {
 		t.Fatalf("login → %d", status)
@@ -239,21 +240,21 @@ func TestFilteredExportHTTPEndToEnd(t *testing.T) {
 
 	// A valid filter with no matching rows still returns a CSV (header row):
 	// the endpoint is wired and the open format is honest on an empty slice.
-	body, err := json.Marshal(anyMap{
+	body, err := json.Marshal(apptest.AnyMap{
 		"object": "deal",
-		"filter": anyMap{"field": "forecast_category", "op": "eq", "value": "commit"},
+		"filter": apptest.AnyMap{"field": "forecast_category", "op": "eq", "value": "commit"},
 		"format": "csv",
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	req, err := http.NewRequest("POST", e.ts.URL+"/v1/exports", bytes.NewReader(body))
+	req, err := http.NewRequest("POST", e.TS.URL+"/v1/exports", bytes.NewReader(body))
 	if err != nil {
 		t.Fatal(err)
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-Workspace-Slug", e.slug)
-	resp, err := e.client.Do(req)
+	req.Header.Set("X-Workspace-Slug", e.Slug)
+	resp, err := e.Client.Do(req)
 	if err != nil {
 		t.Fatalf("export request: %v", err)
 	}
@@ -280,9 +281,9 @@ func TestFilteredExportHTTPEndToEnd(t *testing.T) {
 	var problem struct {
 		Code string `json:"code"`
 	}
-	if status := e.call(t, "POST", "/v1/exports", anyMap{
+	if status := e.Call(t, "POST", "/v1/exports", apptest.AnyMap{
 		"object": "deal",
-		"filter": anyMap{"field": "amount_minor", "op": "eq", "value": 1},
+		"filter": apptest.AnyMap{"field": "amount_minor", "op": "eq", "value": 1},
 		"format": "csv",
 	}, nil, &problem); status != http.StatusUnprocessableEntity {
 		t.Fatalf("out-of-vocabulary filter → %d, want 422", status)

--- a/backend/internal/compose/integration/grants_integration_test.go
+++ b/backend/internal/compose/integration/grants_integration_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	"github.com/gradionhq/margince/backend/internal/modules/people"
 	"github.com/gradionhq/margince/backend/internal/modules/search"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
@@ -74,7 +75,7 @@ func TestRecordGrantHTTPLifecycle(t *testing.T) {
 		ID string `json:"id"`
 	}
 	// Sharing with a random subject refuses (the subject must exist).
-	if status := e.call(t, "POST", "/v1/record-grants", anyMap{
+	if status := e.Call(t, "POST", "/v1/record-grants", apptest.AnyMap{
 		"record_type": "person", "record_id": e.personID,
 		"subject_type": "user", "subject_id": "00000000-0000-7000-8000-00000000dead",
 		"access": "read",
@@ -86,10 +87,10 @@ func TestRecordGrantHTTPLifecycle(t *testing.T) {
 			ID string `json:"id"`
 		} `json:"user"`
 	}
-	if status := e.call(t, "GET", "/v1/me", nil, nil, &admin); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/me", nil, nil, &admin); status != http.StatusOK {
 		t.Fatalf("me → %d", status)
 	}
-	if status := e.call(t, "POST", "/v1/record-grants", anyMap{
+	if status := e.Call(t, "POST", "/v1/record-grants", apptest.AnyMap{
 		"record_type": "person", "record_id": e.personID,
 		"subject_type": "user", "subject_id": admin.User.ID,
 		"access": "write", "reason": "deal desk assist",
@@ -97,7 +98,7 @@ func TestRecordGrantHTTPLifecycle(t *testing.T) {
 		t.Fatalf("create grant → %d", status)
 	}
 	// Duplicate share → 409.
-	if status := e.call(t, "POST", "/v1/record-grants", anyMap{
+	if status := e.Call(t, "POST", "/v1/record-grants", apptest.AnyMap{
 		"record_type": "person", "record_id": e.personID,
 		"subject_type": "user", "subject_id": admin.User.ID,
 		"access": "read",
@@ -110,15 +111,15 @@ func TestRecordGrantHTTPLifecycle(t *testing.T) {
 			ID string `json:"id"`
 		} `json:"data"`
 	}
-	if status := e.call(t, "GET", "/v1/record-grants?record_type=person&record_id="+e.personID, nil, nil, &listed); status != http.StatusOK || len(listed.Data) != 1 {
+	if status := e.Call(t, "GET", "/v1/record-grants?record_type=person&record_id="+e.personID, nil, nil, &listed); status != http.StatusOK || len(listed.Data) != 1 {
 		t.Fatalf("list grants → %d %+v", status, listed)
 	}
-	if status := e.call(t, "DELETE", "/v1/record-grants/"+grant.ID, nil, nil, nil); status != http.StatusNoContent {
+	if status := e.Call(t, "DELETE", "/v1/record-grants/"+grant.ID, nil, nil, nil); status != http.StatusNoContent {
 		t.Fatalf("revoke → %d", status)
 	}
 	// The share and the revocation are both audited facts.
 	var shares, unshares int
-	if err := e.owner.QueryRow(t.Context(),
+	if err := e.Owner.QueryRow(t.Context(),
 		`SELECT count(*) FILTER (WHERE action = 'record_share'),
 		        count(*) FILTER (WHERE action = 'record_unshare') FROM audit_log`).Scan(&shares, &unshares); err != nil {
 		t.Fatal(err)

--- a/backend/internal/compose/integration/humanprecedence_createtime_integration_test.go
+++ b/backend/internal/compose/integration/humanprecedence_createtime_integration_test.go
@@ -21,11 +21,13 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 )
 
 func TestAgentCannotSilentlyOverwriteCreateTimeHumanValues(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 
 	var pipelines struct {
 		Data []struct {
@@ -36,7 +38,7 @@ func TestAgentCannotSilentlyOverwriteCreateTimeHumanValues(t *testing.T) {
 			} `json:"stages"`
 		} `json:"data"`
 	}
-	if status := e.call(t, "GET", "/v1/pipelines", nil, nil, &pipelines); status != http.StatusOK || len(pipelines.Data) == 0 {
+	if status := e.Call(t, "GET", "/v1/pipelines", nil, nil, &pipelines); status != http.StatusOK || len(pipelines.Data) == 0 {
 		t.Fatalf("pipelines → %d", status)
 	}
 	pipelineID := pipelines.Data[0].ID
@@ -53,7 +55,7 @@ func TestAgentCannotSilentlyOverwriteCreateTimeHumanValues(t *testing.T) {
 	var deal struct {
 		ID string `json:"id"`
 	}
-	if status := e.call(t, "POST", "/v1/deals", anyMap{
+	if status := e.Call(t, "POST", "/v1/deals", apptest.AnyMap{
 		"name": "Acme renewal", "pipeline_id": pipelineID, "stage_id": stageID,
 		"amount_minor": 25000000, "currency": "EUR",
 		"expected_close_date": "2026-12-31", "source": "manual",
@@ -64,7 +66,7 @@ func TestAgentCannotSilentlyOverwriteCreateTimeHumanValues(t *testing.T) {
 	var minted struct {
 		Token string `json:"token"`
 	}
-	if status := e.call(t, "POST", "/v1/passports", anyMap{
+	if status := e.Call(t, "POST", "/v1/passports", apptest.AnyMap{
 		"label": "create-time precedence agent", "scopes": []string{"read", "write"},
 	}, nil, &minted); status != http.StatusCreated {
 		t.Fatalf("issue passport → %d", status)
@@ -80,7 +82,7 @@ func TestAgentCannotSilentlyOverwriteCreateTimeHumanValues(t *testing.T) {
 		Code   string `json:"code"`
 		Detail string `json:"detail"`
 	}
-	if status := e.call(t, "PATCH", "/v1/deals/"+deal.ID, anyMap{
+	if status := e.Call(t, "PATCH", "/v1/deals/"+deal.ID, apptest.AnyMap{
 		"amount_minor": 100, "expected_close_date": "2027-06-30",
 	}, bearer, &problem); status != http.StatusForbidden || problem.Code != "approval_required" {
 		t.Fatalf("agent money patch → %d %q, want 403 approval_required — the human typed those values at create",
@@ -93,7 +95,7 @@ func TestAgentCannotSilentlyOverwriteCreateTimeHumanValues(t *testing.T) {
 		TargetType string `json:"target_entity_type"`
 		Summary    string `json:"summary"`
 	}
-	if status := e.call(t, "GET", "/v1/approvals/"+approvalID, nil, nil, &staged); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/approvals/"+approvalID, nil, nil, &staged); status != http.StatusOK {
 		t.Fatalf("read the staged approval → %d", status)
 	}
 	if staged.TargetType != "deal" {
@@ -110,7 +112,7 @@ func TestAgentCannotSilentlyOverwriteCreateTimeHumanValues(t *testing.T) {
 		AmountMinor       int64  `json:"amount_minor"`
 		ExpectedCloseDate string `json:"expected_close_date"`
 	}
-	if status := e.call(t, "GET", "/v1/deals/"+deal.ID, nil, bearer, &current); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/deals/"+deal.ID, nil, bearer, &current); status != http.StatusOK {
 		t.Fatalf("read back → %d", status)
 	}
 	if current.AmountMinor != 25000000 {
@@ -126,8 +128,8 @@ func TestAgentCannotSilentlyOverwriteCreateTimeHumanValues(t *testing.T) {
 // it stays auto-execute — the gate exists to stop a silent overwrite, not to
 // stop the agent working.
 func TestAgentStillFillsAnEmptyFieldWithoutApproval(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 
 	personID, agentToken := stagePersonAndAgent(t, e, "Petra Human", "empty-field agent")
 	bearer := map[string]string{"Authorization": "Bearer " + agentToken}
@@ -138,7 +140,7 @@ func TestAgentStillFillsAnEmptyFieldWithoutApproval(t *testing.T) {
 			ApprovalID string `json:"approval_id"`
 		} `json:"staged_approval"`
 	}
-	if status := e.call(t, "PATCH", "/v1/people/"+personID, anyMap{"title": "Founder"}, bearer, &patched); status != http.StatusOK {
+	if status := e.Call(t, "PATCH", "/v1/people/"+personID, apptest.AnyMap{"title": "Founder"}, bearer, &patched); status != http.StatusOK {
 		t.Fatalf("agent fills an empty field → %d", status)
 	}
 	if patched.StagedApproval != nil && patched.StagedApproval.ApprovalID != "" {

--- a/backend/internal/compose/integration/humanprecedence_integration_test.go
+++ b/backend/internal/compose/integration/humanprecedence_integration_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
@@ -28,22 +29,22 @@ import (
 )
 
 func TestEndToEnd_humanEditPrecedenceOnAgentUpdate(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 
 	// A HUMAN types the person's name — full_name is now human-owned per
 	// the audit trail.
 	var person struct {
 		ID string `json:"id"`
 	}
-	if status := e.call(t, "POST", "/v1/people", anyMap{"full_name": "Greta Human"}, nil, &person); status != 201 {
+	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{"full_name": "Greta Human"}, nil, &person); status != 201 {
 		t.Fatalf("human create → %d", status)
 	}
 
 	var minted struct {
 		Token string `json:"token"`
 	}
-	if status := e.call(t, "POST", "/v1/passports", anyMap{
+	if status := e.Call(t, "POST", "/v1/passports", apptest.AnyMap{
 		"label": "precedence agent", "scopes": []string{"read", "write"},
 	}, nil, &minted); status != 201 {
 		t.Fatalf("issue passport → %d", status)
@@ -52,12 +53,12 @@ func TestEndToEnd_humanEditPrecedenceOnAgentUpdate(t *testing.T) {
 
 	// A field no human ever wrote updates 🟢 — the reversible-and-logged
 	// path stays open.
-	if status := e.call(t, "PATCH", "/v1/people/"+person.ID, anyMap{"title": "CTO"}, bearer, nil); status != 200 {
+	if status := e.Call(t, "PATCH", "/v1/people/"+person.ID, apptest.AnyMap{"title": "CTO"}, bearer, nil); status != 200 {
 		t.Fatalf("agent patch of a never-human field → %d, want 200 (🟢)", status)
 	}
 	// A field the AGENT last wrote stays 🟢 too — precedence protects
 	// people, not machines.
-	if status := e.call(t, "PATCH", "/v1/people/"+person.ID, anyMap{"title": "VP Engineering"}, bearer, nil); status != 200 {
+	if status := e.Call(t, "PATCH", "/v1/people/"+person.ID, apptest.AnyMap{"title": "VP Engineering"}, bearer, nil); status != 200 {
 		t.Fatalf("agent re-patch of its own field → %d, want 200 (🟢)", status)
 	}
 
@@ -66,37 +67,37 @@ func TestEndToEnd_humanEditPrecedenceOnAgentUpdate(t *testing.T) {
 		Code   string `json:"code"`
 		Detail string `json:"detail"`
 	}
-	status := e.call(t, "PATCH", "/v1/people/"+person.ID, anyMap{"full_name": "Greta Machine"}, bearer, &problem)
+	status := e.Call(t, "PATCH", "/v1/people/"+person.ID, apptest.AnyMap{"full_name": "Greta Machine"}, bearer, &problem)
 	if status != 403 || problem.Code != "approval_required" {
 		t.Fatalf("agent overwrite of a human field → %d %q, want 403 approval_required", status, problem.Code)
 	}
 	var current struct {
 		FullName string `json:"full_name"`
 	}
-	if status := e.call(t, "GET", "/v1/people/"+person.ID, nil, bearer, &current); status != 200 || current.FullName != "Greta Human" {
+	if status := e.Call(t, "GET", "/v1/people/"+person.ID, nil, bearer, &current); status != 200 || current.FullName != "Greta Human" {
 		t.Fatalf("staged overwrite must not have executed: %d %q", status, current.FullName)
 	}
 	approvalID := extractStagedApprovalID(t, problem.Detail)
 
 	// A human decision releases it; the identical retry lands the patch.
-	if status := e.call(t, "POST", "/v1/approvals/"+approvalID+"/approve", anyMap{}, nil, nil); status != 200 {
+	if status := e.Call(t, "POST", "/v1/approvals/"+approvalID+"/approve", apptest.AnyMap{}, nil, nil); status != 200 {
 		t.Fatalf("human approve → %d", status)
 	}
 	withToken := map[string]string{"Authorization": "Bearer " + minted.Token, "X-Approval-Token": approvalID}
-	if status := e.call(t, "PATCH", "/v1/people/"+person.ID, anyMap{"full_name": "Greta Machine"}, withToken, nil); status != 200 {
+	if status := e.Call(t, "PATCH", "/v1/people/"+person.ID, apptest.AnyMap{"full_name": "Greta Machine"}, withToken, nil); status != 200 {
 		t.Fatalf("approved retry → %d, want the patch to execute", status)
 	}
-	if status := e.call(t, "GET", "/v1/people/"+person.ID, nil, bearer, &current); status != 200 || current.FullName != "Greta Machine" {
+	if status := e.Call(t, "GET", "/v1/people/"+person.ID, nil, bearer, &current); status != 200 || current.FullName != "Greta Machine" {
 		t.Fatalf("approved overwrite did not land: %d %q", status, current.FullName)
 	}
 
 	// The redemption was consumed exactly once: the identical retry with
 	// the same token changes nothing further.
 	before := current.FullName
-	if status := e.call(t, "PATCH", "/v1/people/"+person.ID, anyMap{"full_name": "Greta Machine"}, withToken, &problem); status != 403 {
+	if status := e.Call(t, "PATCH", "/v1/people/"+person.ID, apptest.AnyMap{"full_name": "Greta Machine"}, withToken, &problem); status != 403 {
 		t.Fatalf("re-redeeming a consumed approval → %d, want 403", status)
 	}
-	if status := e.call(t, "GET", "/v1/people/"+person.ID, nil, bearer, &current); status != 200 || current.FullName != before {
+	if status := e.Call(t, "GET", "/v1/people/"+person.ID, nil, bearer, &current); status != 200 || current.FullName != before {
 		t.Fatalf("consumed token must not write again: %d %q", status, current.FullName)
 	}
 }
@@ -113,19 +114,19 @@ func TestEndToEnd_humanEditPrecedenceOnAgentUpdate(t *testing.T) {
 // because it was the last object to gain the catch-all (custom fields on
 // records); the protection is now uniform across person/org/deal/lead.
 func TestEndToEnd_caseVariantKeyCannotBypassPrecedence(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 
 	var lead struct {
 		ID string `json:"id"`
 	}
-	if status := e.call(t, "POST", "/v1/leads", anyMap{"full_name": "Otto Human"}, nil, &lead); status != 201 {
+	if status := e.Call(t, "POST", "/v1/leads", apptest.AnyMap{"full_name": "Otto Human"}, nil, &lead); status != 201 {
 		t.Fatalf("human create lead → %d", status)
 	}
 	var minted struct {
 		Token string `json:"token"`
 	}
-	if status := e.call(t, "POST", "/v1/passports", anyMap{
+	if status := e.Call(t, "POST", "/v1/passports", apptest.AnyMap{
 		"label": "variant agent", "scopes": []string{"read", "write"},
 	}, nil, &minted); status != 201 {
 		t.Fatalf("issue passport → %d", status)
@@ -137,7 +138,7 @@ func TestEndToEnd_caseVariantKeyCannotBypassPrecedence(t *testing.T) {
 	var patched struct {
 		FullName string `json:"full_name"`
 	}
-	if status := e.call(t, "PATCH", "/v1/leads/"+lead.ID, anyMap{"FULL_NAME": "Otto Machine"}, bearer, &patched); status != 200 {
+	if status := e.Call(t, "PATCH", "/v1/leads/"+lead.ID, apptest.AnyMap{"FULL_NAME": "Otto Machine"}, bearer, &patched); status != 200 {
 		t.Fatalf("case-variant patch → %d, want 200 (dropped, not written)", status)
 	}
 	if patched.FullName != "Otto Human" {
@@ -147,7 +148,7 @@ func TestEndToEnd_caseVariantKeyCannotBypassPrecedence(t *testing.T) {
 	var current struct {
 		FullName string `json:"full_name"`
 	}
-	if status := e.call(t, "GET", "/v1/leads/"+lead.ID, nil, bearer, &current); status != 200 || current.FullName != "Otto Human" {
+	if status := e.Call(t, "GET", "/v1/leads/"+lead.ID, nil, bearer, &current); status != 200 || current.FullName != "Otto Human" {
 		t.Fatalf("human value must survive the case-variant attempt: %d %q", status, current.FullName)
 	}
 }
@@ -155,18 +156,18 @@ func TestEndToEnd_caseVariantKeyCannotBypassPrecedence(t *testing.T) {
 // stagePersonAndAgent is the scenario floor the split tests share: a
 // HUMAN creates the person (full_name becomes human-owned per the audit
 // trail) and mints a read+write passport for the acting agent.
-func stagePersonAndAgent(t *testing.T, e *env, fullName, label string) (personID, agentToken string) {
+func stagePersonAndAgent(t *testing.T, e *apptest.AppEnv, fullName, label string) (personID, agentToken string) {
 	t.Helper()
 	var person struct {
 		ID string `json:"id"`
 	}
-	if status := e.call(t, "POST", "/v1/people", anyMap{"full_name": fullName}, nil, &person); status != 201 {
+	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{"full_name": fullName}, nil, &person); status != 201 {
 		t.Fatalf("human create → %d", status)
 	}
 	var minted struct {
 		Token string `json:"token"`
 	}
-	if status := e.call(t, "POST", "/v1/passports", anyMap{
+	if status := e.Call(t, "POST", "/v1/passports", apptest.AnyMap{
 		"label": label, "scopes": []string{"read", "write"},
 	}, nil, &minted); status != 201 {
 		t.Fatalf("issue passport → %d", status)
@@ -177,7 +178,7 @@ func stagePersonAndAgent(t *testing.T, e *env, fullName, label string) (personID
 // mcpAgentInvoker builds the governed tool registry over the shared
 // database and returns an Invoke closure that re-authenticates the
 // passport per call, exactly as the stdio/hosted transports do.
-func mcpAgentInvoker(t *testing.T, e *env, agentToken string) func(tool, args string) (json.RawMessage, error) {
+func mcpAgentInvoker(t *testing.T, agentToken string) func(tool, args string) (json.RawMessage, error) {
 	t.Helper()
 	pool, err := database.NewPool(context.Background(), envDSN(t))
 	if err != nil {
@@ -206,13 +207,13 @@ func mcpAgentInvoker(t *testing.T, e *env, agentToken string) func(tool, args st
 // the 200 response names the split, and the approved replay of ONLY the
 // staged fields — the ADR-0036-bound sub-patch — lands the overwrite.
 func TestEndToEnd_perFieldSplitOnAgentRESTUpdate(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 
 	personID, agentToken := stagePersonAndAgent(t, e, "Petra Human", "split agent")
 	// The human TYPES the title in an update: the per-field audit image
 	// makes title human-owned alongside the created full_name.
-	if status := e.call(t, "PATCH", "/v1/people/"+personID, anyMap{"title": "Founder"}, nil, nil); status != 200 {
+	if status := e.Call(t, "PATCH", "/v1/people/"+personID, apptest.AnyMap{"title": "Founder"}, nil, nil); status != 200 {
 		t.Fatalf("human title patch → %d", status)
 	}
 	bearer := map[string]string{"Authorization": "Bearer " + agentToken}
@@ -229,7 +230,7 @@ func TestEndToEnd_perFieldSplitOnAgentRESTUpdate(t *testing.T) {
 			Message    string          `json:"message"`
 		} `json:"staged_approval"`
 	}
-	status := e.call(t, "PATCH", "/v1/people/"+personID, anyMap{
+	status := e.Call(t, "PATCH", "/v1/people/"+personID, apptest.AnyMap{
 		"first_name": "Petra", "full_name": "Petra Machine", "title": "CEO",
 	}, bearer, &split)
 	if status != 200 {
@@ -245,7 +246,7 @@ func TestEndToEnd_perFieldSplitOnAgentRESTUpdate(t *testing.T) {
 
 	// A human approves; the agent replays ONLY the staged fields with the
 	// token — the sub-patch is what the approval is bound to.
-	if status := e.call(t, "POST", "/v1/approvals/"+split.StagedApproval.ApprovalID+"/approve", anyMap{}, nil, nil); status != 200 {
+	if status := e.Call(t, "POST", "/v1/approvals/"+split.StagedApproval.ApprovalID+"/approve", apptest.AnyMap{}, nil, nil); status != 200 {
 		t.Fatalf("human approve → %d", status)
 	}
 	withToken := map[string]string{"Authorization": "Bearer " + agentToken, "X-Approval-Token": split.StagedApproval.ApprovalID}
@@ -255,15 +256,15 @@ func TestEndToEnd_perFieldSplitOnAgentRESTUpdate(t *testing.T) {
 	var problem struct {
 		Code string `json:"code"`
 	}
-	if status := e.call(t, "PATCH", "/v1/people/"+personID, anyMap{"full_name": "Petra Impostor", "title": "CEO"}, withToken, &problem); status != 403 || problem.Code != "approval_token_invalid" {
+	if status := e.Call(t, "PATCH", "/v1/people/"+personID, apptest.AnyMap{"full_name": "Petra Impostor", "title": "CEO"}, withToken, &problem); status != 403 || problem.Code != "approval_token_invalid" {
 		t.Fatalf("tampered replay → %d %q, want 403 approval_token_invalid", status, problem.Code)
 	}
 
-	var replay anyMap
+	var replay apptest.AnyMap
 	if err := json.Unmarshal(split.StagedApproval.Replay, &replay); err != nil {
 		t.Fatalf("staged replay body is not an object: %v", err)
 	}
-	if status := e.call(t, "PATCH", "/v1/people/"+personID, replay, withToken, nil); status != 200 {
+	if status := e.Call(t, "PATCH", "/v1/people/"+personID, replay, withToken, nil); status != 200 {
 		t.Fatalf("approved replay of the staged sub-patch → %d, want 200", status)
 	}
 	var current struct {
@@ -271,7 +272,7 @@ func TestEndToEnd_perFieldSplitOnAgentRESTUpdate(t *testing.T) {
 		Title     string `json:"title"`
 		FirstName string `json:"first_name"`
 	}
-	if status := e.call(t, "GET", "/v1/people/"+personID, nil, bearer, &current); status != 200 ||
+	if status := e.Call(t, "GET", "/v1/people/"+personID, nil, bearer, &current); status != 200 ||
 		current.FullName != "Petra Machine" || current.Title != "CEO" || current.FirstName != "Petra" {
 		t.Fatalf("post-approval record = %+v, want the released overwrite plus the earlier auto-execute write", current)
 	}
@@ -280,8 +281,8 @@ func TestEndToEnd_perFieldSplitOnAgentRESTUpdate(t *testing.T) {
 // A rejection writes nothing: the human-owned field stays as typed and
 // the staged approval opens no door afterwards.
 func TestEndToEnd_rejectedSplitWritesNothing(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 
 	personID, agentToken := stagePersonAndAgent(t, e, "Rita Human", "rejected agent")
 	bearer := map[string]string{"Authorization": "Bearer " + agentToken}
@@ -291,12 +292,12 @@ func TestEndToEnd_rejectedSplitWritesNothing(t *testing.T) {
 			ApprovalID string `json:"approval_id"`
 		} `json:"staged_approval"`
 	}
-	if status := e.call(t, "PATCH", "/v1/people/"+personID, anyMap{
+	if status := e.Call(t, "PATCH", "/v1/people/"+personID, apptest.AnyMap{
 		"first_name": "Rita", "full_name": "Rita Machine",
 	}, bearer, &split); status != 200 || split.StagedApproval.ApprovalID == "" {
 		t.Fatalf("mixed patch → %d %+v, want 200 with a staged approval", status, split)
 	}
-	if status := e.call(t, "POST", "/v1/approvals/"+split.StagedApproval.ApprovalID+"/reject", anyMap{"reason": "keep my spelling"}, nil, nil); status != 200 {
+	if status := e.Call(t, "POST", "/v1/approvals/"+split.StagedApproval.ApprovalID+"/reject", apptest.AnyMap{"reason": "keep my spelling"}, nil, nil); status != 200 {
 		t.Fatalf("human reject → %d", status)
 	}
 
@@ -304,14 +305,14 @@ func TestEndToEnd_rejectedSplitWritesNothing(t *testing.T) {
 	var problem struct {
 		Code string `json:"code"`
 	}
-	if status := e.call(t, "PATCH", "/v1/people/"+personID, anyMap{"full_name": "Rita Machine"}, withToken, &problem); status != 403 || problem.Code != "approval_token_invalid" {
+	if status := e.Call(t, "PATCH", "/v1/people/"+personID, apptest.AnyMap{"full_name": "Rita Machine"}, withToken, &problem); status != 403 || problem.Code != "approval_token_invalid" {
 		t.Fatalf("replaying a rejected staging → %d %q, want 403 approval_token_invalid", status, problem.Code)
 	}
 	var current struct {
 		FullName  string `json:"full_name"`
 		FirstName string `json:"first_name"`
 	}
-	if status := e.call(t, "GET", "/v1/people/"+personID, nil, bearer, &current); status != 200 ||
+	if status := e.Call(t, "GET", "/v1/people/"+personID, nil, bearer, &current); status != 200 ||
 		current.FullName != "Rita Human" || current.FirstName != "Rita" {
 		t.Fatalf("post-rejection record = %+v, want the human name intact and only the auto-execute write applied", current)
 	}
@@ -358,11 +359,11 @@ func personNameAndTitle(t *testing.T, invoke func(tool, args string) (json.RawMe
 // applies its auto-execute half and stages the human-owned residue, and the
 // approved replay (staged fields + approval_id) redeems exactly once.
 func TestEndToEnd_perFieldSplitOnMCPUpdate(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 
 	personID, agentToken := stagePersonAndAgent(t, e, "Mona Human", "mcp split agent")
-	invoke := mcpAgentInvoker(t, e, agentToken)
+	invoke := mcpAgentInvoker(t, agentToken)
 
 	// Auto-execute-only: a field no human wrote updates without any staging.
 	out, err := invoke("update_record", fmt.Sprintf(
@@ -410,7 +411,7 @@ func TestEndToEnd_perFieldSplitOnMCPUpdate(t *testing.T) {
 	}
 
 	// A human approves; the replay redeems and lands exactly the field.
-	if status := e.call(t, "POST", "/v1/approvals/"+result.StagedApproval.ApprovalID+"/approve", anyMap{}, nil, nil); status != 200 {
+	if status := e.Call(t, "POST", "/v1/approvals/"+result.StagedApproval.ApprovalID+"/approve", apptest.AnyMap{}, nil, nil); status != 200 {
 		t.Fatalf("human approve → %d", status)
 	}
 	if _, err := invoke("update_record", replay); err != nil {

--- a/backend/internal/compose/integration/idempotency_integration_test.go
+++ b/backend/internal/compose/integration/idempotency_integration_test.go
@@ -18,31 +18,33 @@ import (
 	"net/http"
 	"reflect"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 )
 
 func TestIdempotencyKeyReplay(t *testing.T) {
-	e := setup(t)
+	e := apptest.SetupApp(t)
 
-	bootstrapWorkspaceSession(t, e, "Idem Probe", "admin@idem.test", "Admin")
-	e.slug = "idem-probe"
+	apptest.BootstrapWorkspaceSession(t, e, "Idem Probe", "admin@idem.test", "Admin")
+	e.Slug = "idem-probe"
 
 	keyed := map[string]string{"Idempotency-Key": "lead-retry-1"}
-	leadReq := anyMap{
+	leadReq := apptest.AnyMap{
 		"full_name":    "Retry Prospect",
 		"email":        "retry@example.org",
 		"company_name": "Retry AG",
 		"source":       "import:idem",
 	}
 
-	var first anyMap
-	if status := e.call(t, "POST", "/v1/leads", leadReq, keyed, &first); status != http.StatusCreated {
+	var first apptest.AnyMap
+	if status := e.Call(t, "POST", "/v1/leads", leadReq, keyed, &first); status != http.StatusCreated {
 		t.Fatalf("keyed create lead = %d %v", status, first)
 	}
 
 	// The replay is byte-identical: same status, same body — NOT the 409
 	// the natural email dedupe would answer if the request re-executed.
-	var replay anyMap
-	if status := e.call(t, "POST", "/v1/leads", leadReq, keyed, &replay); status != http.StatusCreated {
+	var replay apptest.AnyMap
+	if status := e.Call(t, "POST", "/v1/leads", leadReq, keyed, &replay); status != http.StatusCreated {
 		t.Fatalf("keyed replay = %d %v, want the original 201", status, replay)
 	}
 	if !reflect.DeepEqual(first, replay) {
@@ -51,9 +53,9 @@ func TestIdempotencyKeyReplay(t *testing.T) {
 
 	// Exactly one lead landed.
 	var leads struct {
-		Data []anyMap `json:"data"`
+		Data []apptest.AnyMap `json:"data"`
 	}
-	if status := e.call(t, "GET", "/v1/leads", nil, nil, &leads); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/leads", nil, nil, &leads); status != http.StatusOK {
 		t.Fatalf("list leads = %d", status)
 	}
 	if len(leads.Data) != 1 {
@@ -61,8 +63,8 @@ func TestIdempotencyKeyReplay(t *testing.T) {
 	}
 
 	// The same key with a DIFFERENT body is a conflict, never a replay.
-	var problem anyMap
-	status := e.call(t, "POST", "/v1/leads", anyMap{
+	var problem apptest.AnyMap
+	status := e.Call(t, "POST", "/v1/leads", apptest.AnyMap{
 		"full_name": "Different Intent",
 		"email":     "other@example.org",
 		"source":    "import:idem",
@@ -79,21 +81,21 @@ func TestIdempotencyKeyReplay(t *testing.T) {
 // middleware hands back the pre-erasure snapshot every live read path now
 // refuses. The replay probe is live-only for exactly that reason.
 func TestIdempotencyReplayRefusesAnArchivedRecord(t *testing.T) {
-	e := setup(t)
+	e := apptest.SetupApp(t)
 
-	bootstrapWorkspaceSession(t, e, "Idem Erase", "admin@idemerase.test", "Admin")
-	e.slug = "idem-erase"
+	apptest.BootstrapWorkspaceSession(t, e, "Idem Erase", "admin@idemerase.test", "Admin")
+	e.Slug = "idem-erase"
 
 	keyed := map[string]string{"Idempotency-Key": "lead-erase-1"}
-	leadReq := anyMap{
+	leadReq := apptest.AnyMap{
 		"full_name":    "Erasable Prospect",
 		"email":        "erasable@example.org",
 		"company_name": "Erasable AG",
 		"source":       "import:idem",
 	}
 
-	var first anyMap
-	if status := e.call(t, "POST", "/v1/leads", leadReq, keyed, &first); status != http.StatusCreated {
+	var first apptest.AnyMap
+	if status := e.Call(t, "POST", "/v1/leads", leadReq, keyed, &first); status != http.StatusCreated {
 		t.Fatalf("keyed create lead = %d %v", status, first)
 	}
 	leadID, _ := first["id"].(string)
@@ -103,17 +105,17 @@ func TestIdempotencyReplayRefusesAnArchivedRecord(t *testing.T) {
 
 	// The positive control, BEFORE the record goes: the replay works, so a
 	// later refusal is the archive doing it and not the mechanism being broken.
-	var live anyMap
-	if status := e.call(t, "POST", "/v1/leads", leadReq, keyed, &live); status != http.StatusCreated {
+	var live apptest.AnyMap
+	if status := e.Call(t, "POST", "/v1/leads", leadReq, keyed, &live); status != http.StatusCreated {
 		t.Fatalf("replay while the record is live = %d %v, want the original 201", status, live)
 	}
 
-	if status := e.call(t, "DELETE", "/v1/leads/"+leadID, nil, nil, nil); status != http.StatusOK {
+	if status := e.Call(t, "DELETE", "/v1/leads/"+leadID, nil, nil, nil); status != http.StatusOK {
 		t.Fatalf("archiving the lead = %d, want 200", status)
 	}
 
-	var problem anyMap
-	status := e.call(t, "POST", "/v1/leads", leadReq, keyed, &problem)
+	var problem apptest.AnyMap
+	status := e.Call(t, "POST", "/v1/leads", leadReq, keyed, &problem)
 	if status != http.StatusNotFound {
 		t.Fatalf("replay after the record was archived = %d %v, want 404 — the recorded body is a snapshot of a record that no longer exists",
 			status, problem)
@@ -127,27 +129,27 @@ func TestIdempotencyReplayRefusesAnArchivedRecord(t *testing.T) {
 // operation with no natural-key dedupe behind it: without transport
 // idempotency a retried createQuota lands a second, identical target.
 func TestIdempotencyKeyReplay_createQuota(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 
-	var me anyMap
-	if status := e.call(t, "GET", "/v1/me", nil, nil, &me); status != http.StatusOK {
+	var me apptest.AnyMap
+	if status := e.Call(t, "GET", "/v1/me", nil, nil, &me); status != http.StatusOK {
 		t.Fatalf("/me = %d", status)
 	}
-	adminID := me["user"].(anyMap)["id"].(string)
+	adminID := me["user"].(apptest.AnyMap)["id"].(string)
 
 	keyed := map[string]string{"Idempotency-Key": "quota-retry-1"}
-	quotaReq := anyMap{
+	quotaReq := apptest.AnyMap{
 		"owner_id": adminID, "period_start": "2026-01-01", "period_end": "2026-03-31",
 		"target_minor": 1000000, "currency": "EUR",
 	}
 
-	var first anyMap
-	if status := e.call(t, "POST", "/v1/quotas", quotaReq, keyed, &first); status != http.StatusCreated {
+	var first apptest.AnyMap
+	if status := e.Call(t, "POST", "/v1/quotas", quotaReq, keyed, &first); status != http.StatusCreated {
 		t.Fatalf("keyed create quota = %d %v", status, first)
 	}
-	var replay anyMap
-	if status := e.call(t, "POST", "/v1/quotas", quotaReq, keyed, &replay); status != http.StatusCreated {
+	var replay apptest.AnyMap
+	if status := e.Call(t, "POST", "/v1/quotas", quotaReq, keyed, &replay); status != http.StatusCreated {
 		t.Fatalf("keyed replay = %d %v, want the original 201", status, replay)
 	}
 	if !reflect.DeepEqual(first, replay) {
@@ -155,9 +157,9 @@ func TestIdempotencyKeyReplay_createQuota(t *testing.T) {
 	}
 
 	var quotas struct {
-		Data []anyMap `json:"data"`
+		Data []apptest.AnyMap `json:"data"`
 	}
-	if status := e.call(t, "GET", "/v1/quotas", nil, nil, &quotas); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/quotas", nil, nil, &quotas); status != http.StatusOK {
 		t.Fatalf("list quotas = %d", status)
 	}
 	if len(quotas.Data) != 1 {
@@ -165,8 +167,8 @@ func TestIdempotencyKeyReplay_createQuota(t *testing.T) {
 	}
 
 	// The same key with a DIFFERENT body is a conflict, never a replay.
-	var problem anyMap
-	status := e.call(t, "POST", "/v1/quotas", anyMap{
+	var problem apptest.AnyMap
+	status := e.Call(t, "POST", "/v1/quotas", apptest.AnyMap{
 		"owner_id": adminID, "period_start": "2026-04-01", "period_end": "2026-06-30",
 		"target_minor": 2000000, "currency": "EUR",
 	}, keyed, &problem)
@@ -176,31 +178,31 @@ func TestIdempotencyKeyReplay_createQuota(t *testing.T) {
 }
 
 func TestIdempotencyKeyReplay_logActivity(t *testing.T) {
-	e := setup(t)
+	e := apptest.SetupApp(t)
 
-	bootstrapWorkspaceSession(t, e, "Idem Activity", "admin@idem-act.test", "Admin")
-	e.slug = "idem-activity"
+	apptest.BootstrapWorkspaceSession(t, e, "Idem Activity", "admin@idem-act.test", "Admin")
+	e.Slug = "idem-activity"
 
-	var person anyMap
-	if status := e.call(t, "POST", "/v1/people", anyMap{
+	var person apptest.AnyMap
+	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{
 		"full_name": "Idem Person", "source": "ui",
 	}, nil, &person); status != http.StatusCreated {
 		t.Fatalf("create person = %d %v", status, person)
 	}
 
 	keyed := map[string]string{"Idempotency-Key": "act-retry-1"}
-	logReq := anyMap{
+	logReq := apptest.AnyMap{
 		"kind":    "note",
 		"subject": "Keyed note",
 		"source":  "ui",
-		"links":   []anyMap{{"entity_type": "person", "entity_id": person["id"]}},
+		"links":   []apptest.AnyMap{{"entity_type": "person", "entity_id": person["id"]}},
 	}
 
-	var first, replay anyMap
-	if status := e.call(t, "POST", "/v1/activities", logReq, keyed, &first); status != http.StatusCreated {
+	var first, replay apptest.AnyMap
+	if status := e.Call(t, "POST", "/v1/activities", logReq, keyed, &first); status != http.StatusCreated {
 		t.Fatalf("keyed log activity = %d %v", status, first)
 	}
-	if status := e.call(t, "POST", "/v1/activities", logReq, keyed, &replay); status != http.StatusCreated {
+	if status := e.Call(t, "POST", "/v1/activities", logReq, keyed, &replay); status != http.StatusCreated {
 		t.Fatalf("keyed activity replay = %d %v, want the original 201", status, replay)
 	}
 	if first["id"] != replay["id"] {
@@ -208,9 +210,9 @@ func TestIdempotencyKeyReplay_logActivity(t *testing.T) {
 	}
 
 	var activities struct {
-		Data []anyMap `json:"data"`
+		Data []apptest.AnyMap `json:"data"`
 	}
-	if status := e.call(t, "GET", "/v1/activities", nil, nil, &activities); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/activities", nil, nil, &activities); status != http.StatusOK {
 		t.Fatalf("list activities = %d", status)
 	}
 	if len(activities.Data) != 1 {

--- a/backend/internal/compose/integration/installation_integration_test.go
+++ b/backend/internal/compose/integration/installation_integration_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	"github.com/gradionhq/margince/backend/internal/modules/ai"
 	"github.com/gradionhq/margince/backend/internal/platform/deployconfig"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -31,7 +32,7 @@ import (
 func boolPtr(v bool) *bool { return &v }
 
 func TestBootstrapSeedsFollowTheDeploymentConfiguration(t *testing.T) {
-	e := setup(t)
+	e := apptest.SetupApp(t)
 	pwFile := filepath.Join(t.TempDir(), "admin-password")
 	if err := os.WriteFile(pwFile, []byte("correct-horse-battery"), 0o600); err != nil {
 		t.Fatal(err)
@@ -57,14 +58,14 @@ func TestBootstrapSeedsFollowTheDeploymentConfiguration(t *testing.T) {
 			BookingPage:        boolPtr(false),
 		},
 	}
-	if err := compose.EnsureInstallation(context.Background(), e.pool, slog.New(slog.NewTextHandler(io.Discard, nil)), cfg); err != nil {
+	if err := compose.EnsureInstallation(context.Background(), e.Pool, slog.New(slog.NewTextHandler(io.Discard, nil)), cfg); err != nil {
 		t.Fatalf("bootstrap: %v", err)
 	}
 	ctx := context.Background()
 
 	// The configured pipeline: the two open stages plus the module-owned
 	// Won/Lost terminal pair, in order.
-	rows, err := e.owner.Query(ctx,
+	rows, err := e.Owner.Query(ctx,
 		`SELECT s.name, s.semantic FROM stage s JOIN pipeline p ON p.id = s.pipeline_id
 		 WHERE p.name = 'Projects' ORDER BY s.position`)
 	if err != nil {
@@ -95,12 +96,12 @@ func TestBootstrapSeedsFollowTheDeploymentConfiguration(t *testing.T) {
 	// The consent catalog: the module-invariant transactional lane plus
 	// exactly the configured purpose.
 	var purposes int
-	if err := e.owner.QueryRow(ctx,
+	if err := e.Owner.QueryRow(ctx,
 		`SELECT count(*) FROM consent_purpose WHERE key IN ('transactional','newsletter')`).Scan(&purposes); err != nil {
 		t.Fatal(err)
 	}
 	var total, automations, bookingPages int
-	if err := e.owner.QueryRow(ctx, `SELECT count(*) FROM consent_purpose`).Scan(&total); err != nil {
+	if err := e.Owner.QueryRow(ctx, `SELECT count(*) FROM consent_purpose`).Scan(&total); err != nil {
 		t.Fatal(err)
 	}
 	if purposes != 2 || total != 2 {
@@ -108,10 +109,10 @@ func TestBootstrapSeedsFollowTheDeploymentConfiguration(t *testing.T) {
 	}
 
 	// The toggles: no starter automations, no booking page.
-	if err := e.owner.QueryRow(ctx, `SELECT count(*) FROM automation`).Scan(&automations); err != nil {
+	if err := e.Owner.QueryRow(ctx, `SELECT count(*) FROM automation`).Scan(&automations); err != nil {
 		t.Fatal(err)
 	}
-	if err := e.owner.QueryRow(ctx, `SELECT count(*) FROM booking_page`).Scan(&bookingPages); err != nil {
+	if err := e.Owner.QueryRow(ctx, `SELECT count(*) FROM booking_page`).Scan(&bookingPages); err != nil {
 		t.Fatal(err)
 	}
 	if automations != 0 || bookingPages != 0 {
@@ -121,13 +122,13 @@ func TestBootstrapSeedsFollowTheDeploymentConfiguration(t *testing.T) {
 	// The organization carries the configured currency; the admin signs in
 	// through the normal login.
 	var currency string
-	if err := e.owner.QueryRow(ctx, `SELECT base_currency FROM workspace WHERE name = 'Configured Org'`).Scan(&currency); err != nil {
+	if err := e.Owner.QueryRow(ctx, `SELECT base_currency FROM workspace WHERE name = 'Configured Org'`).Scan(&currency); err != nil {
 		t.Fatal(err)
 	}
 	if currency != "USD" {
 		t.Fatalf("base_currency = %q, want the configured USD", currency)
 	}
-	if status := e.call(t, "POST", "/v1/auth/login", anyMap{
+	if status := e.Call(t, "POST", "/v1/auth/login", apptest.AnyMap{
 		"email": "ops@configured.test", "password": "correct-horse-battery",
 	}, nil, nil); status != http.StatusOK {
 		t.Fatalf("configured admin login → %d", status)
@@ -144,7 +145,7 @@ func TestBootstrapSeedsFollowTheDeploymentConfiguration(t *testing.T) {
 		{"installation.timezone", `"Europe/Berlin"`},
 	} {
 		var got string
-		if err := e.pool.QueryRow(context.Background(),
+		if err := e.Pool.QueryRow(context.Background(),
 			`SELECT value::text FROM setting WHERE key = $1`, want.key).Scan(&got); err != nil {
 			t.Fatalf("reading the seeded %s: %v", want.key, err)
 		}
@@ -163,17 +164,17 @@ func TestBootstrapSeedsFollowTheDeploymentConfiguration(t *testing.T) {
 // every one of that workspace's ai_call rows UNPRICED with no operator
 // action able to explain why.
 func TestBootstrapSeedsTheAiModelRatePriceSheet(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 	ctx := context.Background()
 
 	var wsID string
-	if err := e.owner.QueryRow(ctx, `SELECT id FROM workspace WHERE slug = $1`, e.slug).Scan(&wsID); err != nil {
+	if err := e.Owner.QueryRow(ctx, `SELECT id FROM workspace WHERE slug = $1`, e.Slug).Scan(&wsID); err != nil {
 		t.Fatalf("workspace lookup: %v", err)
 	}
 
 	var total int
-	if err := e.owner.QueryRow(ctx, `SELECT count(*) FROM ai_model_rate WHERE workspace_id = $1`, wsID).Scan(&total); err != nil {
+	if err := e.Owner.QueryRow(ctx, `SELECT count(*) FROM ai_model_rate WHERE workspace_id = $1`, wsID).Scan(&total); err != nil {
 		t.Fatal(err)
 	}
 	want := len(ai.SeedModelRates(time.Now().UTC()))
@@ -184,7 +185,7 @@ func TestBootstrapSeedsTheAiModelRatePriceSheet(t *testing.T) {
 	// Every seeded row belongs to the ONE workspace the bootstrap created
 	// — no cross-tenant leakage from a missing/blank workspace_id.
 	var other int
-	if err := e.owner.QueryRow(ctx, `SELECT count(*) FROM ai_model_rate WHERE workspace_id != $1`, wsID).Scan(&other); err != nil {
+	if err := e.Owner.QueryRow(ctx, `SELECT count(*) FROM ai_model_rate WHERE workspace_id != $1`, wsID).Scan(&other); err != nil {
 		t.Fatal(err)
 	}
 	if other != 0 {
@@ -193,26 +194,26 @@ func TestBootstrapSeedsTheAiModelRatePriceSheet(t *testing.T) {
 }
 
 func TestSecondActiveWorkspaceTurnsTheSurfaceUnavailable(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 
 	// A second active workspace violates the single-organization
 	// invariant. A server binding AFTER that point (fresh process, no
 	// cached singleton) must answer 503 on every request — an operator
 	// condition, never an auth failure.
-	if _, err := e.owner.Exec(context.Background(),
+	if _, err := e.Owner.Exec(context.Background(),
 		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Rogue Second', 'rogue-second', 'EUR')`,
 		ids.NewV7()); err != nil {
 		t.Fatal(err)
 	}
-	fresh := httptest.NewServer(compose.New(e.pool, slog.New(slog.NewTextHandler(io.Discard, nil))))
+	fresh := httptest.NewServer(compose.New(e.Pool, slog.New(slog.NewTextHandler(io.Discard, nil))))
 	t.Cleanup(fresh.Close)
 
 	resp, err := fresh.Client().Get(fresh.URL + "/v1/auth/capabilities")
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { closeBody(t, resp) })
+	t.Cleanup(func() { apptest.CloseBody(t, resp) })
 	if resp.StatusCode != http.StatusServiceUnavailable {
 		t.Fatalf("multi-workspace surface answered %d, want 503 (availability, not auth)", resp.StatusCode)
 	}

--- a/backend/internal/compose/integration/jobhealth_http_e2e_integration_test.go
+++ b/backend/internal/compose/integration/jobhealth_http_e2e_integration_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	"github.com/gradionhq/margince/backend/internal/platform/jobs"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
@@ -64,7 +65,7 @@ type riverRow struct {
 // seedRiverRow writes one row through the OWNER connection: river_job has
 // no RLS, and this fixture deliberately writes rows the app would refuse to
 // create, including another workspace's.
-func seedRiverRow(t *testing.T, e *env, r riverRow) {
+func seedRiverRow(t *testing.T, e *apptest.AppEnv, r riverRow) {
 	t.Helper()
 	ctx := context.Background()
 
@@ -102,7 +103,7 @@ func seedRiverRow(t *testing.T, e *env, r riverRow) {
 		finalizedAt = &now
 	}
 
-	if _, err := e.owner.Exec(ctx, `
+	if _, err := e.Owner.Exec(ctx, `
 		INSERT INTO river_job
 		    (state, kind, queue, args, tags, errors, max_attempts, attempt,
 		     created_at, scheduled_at, finalized_at)
@@ -115,11 +116,11 @@ func seedRiverRow(t *testing.T, e *env, r riverRow) {
 
 // callerWorkspace answers the id of the workspace the bootstrapped admin
 // session belongs to — the one the endpoint must scope itself to.
-func callerWorkspace(t *testing.T, e *env) string {
+func callerWorkspace(t *testing.T, e *apptest.AppEnv) string {
 	t.Helper()
 	var id string
-	if err := e.owner.QueryRow(context.Background(),
-		`SELECT id FROM workspace WHERE slug = $1`, e.slug).Scan(&id); err != nil {
+	if err := e.Owner.QueryRow(context.Background(),
+		`SELECT id FROM workspace WHERE slug = $1`, e.Slug).Scan(&id); err != nil {
 		t.Fatalf("resolving the caller's workspace: %v", err)
 	}
 	return id
@@ -141,8 +142,8 @@ func kindOf(report jobHealthDTO, kind string) (int, bool) {
 // because river_job has no RLS to impose it, so a second workspace has to
 // be present or the test proves nothing.
 func TestJobHealthReportsThisWorkspacesDeadWorkAndNotAnotherWorkspacesAnything(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 	mine := callerWorkspace(t, e)
 	theirs := ids.NewV7().String()
 
@@ -170,7 +171,7 @@ func TestJobHealthReportsThisWorkspacesDeadWorkAndNotAnotherWorkspacesAnything(t
 	seedRiverRow(t, e, riverRow{kind: "not_a_declared_dispatcher", state: "discarded", attempt: 3})
 
 	var report jobHealthDTO
-	if status := e.call(t, "GET", "/v1/admin/job-health", nil, nil, &report); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/admin/job-health", nil, nil, &report); status != http.StatusOK {
 		t.Fatalf("GET /admin/job-health → %d, want 200", status)
 	}
 
@@ -225,8 +226,8 @@ func TestJobHealthReportsThisWorkspacesDeadWorkAndNotAnotherWorkspacesAnything(t
 // provider cause must not travel, and the panic stack River stores beside
 // it must not either.
 func TestJobHealthReportsAVettedSentenceForAFaultedWorkerAndSubstitutesForARawOne(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 	mine := callerWorkspace(t, e)
 
 	vetted := "the record this job names no longer exists"
@@ -243,7 +244,7 @@ func TestJobHealthReportsAVettedSentenceForAFaultedWorkerAndSubstitutesForARawOn
 	})
 
 	var report jobHealthDTO
-	if status := e.call(t, "GET", "/v1/admin/job-health", nil, nil, &report); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/admin/job-health", nil, nil, &report); status != http.StatusOK {
 		t.Fatalf("GET /admin/job-health → %d, want 200", status)
 	}
 
@@ -288,15 +289,15 @@ func TestJobHealthReportsAVettedSentenceForAFaultedWorkerAndSubstitutesForARawOn
 // attempt error while the contract still requires failed_at and reason.
 // Scanning a null into either turns the endpoint into a 500.
 func TestJobHealthCountsACancelledRowThatCarriesNoAttemptErrorAtAll(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 	mine := callerWorkspace(t, e)
 
 	seedRiverRow(t, e, riverRow{
 		kind: "cancelled_pass", state: "cancelled", workspace: mine,
 	})
 	var report jobHealthDTO
-	if status := e.call(t, "GET", "/v1/admin/job-health", nil, nil, &report); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/admin/job-health", nil, nil, &report); status != http.StatusOK {
 		t.Fatalf("GET /admin/job-health → %d, want 200: a cancelled row with no attempt "+
 			"error must not fail the read", status)
 	}
@@ -332,13 +333,13 @@ func TestJobHealthCountsACancelledRowThatCarriesNoAttemptErrorAtAll(t *testing.T
 // view of the dispatchers, and a read-scoped passport satisfies every
 // object grant an admin could mint.
 func TestJobHealthRefusesAPassportOverHTTP(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 
 	var minted struct {
 		Token string `json:"token"`
 	}
-	if status := e.call(t, "POST", "/v1/passports", anyMap{
+	if status := e.Call(t, "POST", "/v1/passports", apptest.AnyMap{
 		"label": "job health probe", "scopes": []string{"read"},
 	}, nil, &minted); status != http.StatusCreated {
 		t.Fatalf("issue passport → %d", status)
@@ -347,7 +348,7 @@ func TestJobHealthRefusesAPassportOverHTTP(t *testing.T) {
 	var problem struct {
 		Code string `json:"code"`
 	}
-	status := e.call(t, "GET", "/v1/admin/job-health", nil,
+	status := e.Call(t, "GET", "/v1/admin/job-health", nil,
 		map[string]string{"Authorization": "Bearer " + minted.Token}, &problem)
 	if status != http.StatusForbidden {
 		t.Errorf("agent GET /admin/job-health → %d, want 403 (the contract declares it human-only)", status)
@@ -361,11 +362,11 @@ func TestJobHealthRefusesAPassportOverHTTP(t *testing.T) {
 // case. An installation with nothing queued is a real state, and a client
 // must be able to tell it from a failure.
 func TestJobHealthOnAnIdleFleetIsAnEmptyReportNotAnError(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 
 	var report jobHealthDTO
-	if status := e.call(t, "GET", "/v1/admin/job-health", nil, nil, &report); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/admin/job-health", nil, nil, &report); status != http.StatusOK {
 		t.Fatalf("GET /admin/job-health on an idle fleet → %d, want 200", status)
 	}
 	if report.WorkspaceID == "" {
@@ -387,19 +388,19 @@ func TestJobHealthOnAnIdleFleetIsAnEmptyReportNotAnError(t *testing.T) {
 // table through different scopes, and a tagged row must reach the admin
 // read exactly as an untagged one does.
 func TestJobHealthIgnoresTheSweepTagWhenScopingRows(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 	mine := callerWorkspace(t, e)
 
 	seedRiverRow(t, e, riverRow{kind: "tagged_pass", state: "discarded", workspace: mine, attempt: 3})
-	if _, err := e.owner.Exec(context.Background(),
+	if _, err := e.Owner.Exec(context.Background(),
 		`UPDATE river_job SET tags = ARRAY[$1]::varchar(255)[] WHERE kind = 'tagged_pass'`,
 		jobs.SweepTag); err != nil {
 		t.Fatalf("tagging the fixture row: %v", err)
 	}
 
 	var report jobHealthDTO
-	if status := e.call(t, "GET", "/v1/admin/job-health", nil, nil, &report); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/admin/job-health", nil, nil, &report); status != http.StatusOK {
 		t.Fatalf("GET /admin/job-health → %d, want 200", status)
 	}
 	i, ok := kindOf(report, "tagged_pass")
@@ -417,17 +418,17 @@ func TestJobHealthIgnoresTheSweepTagWhenScopingRows(t *testing.T) {
 // decodes into a typed struct, which drops every field the struct does not
 // declare — and an undeclared field is precisely where an unnoticed leak
 // would sit.
-func rawGet(t *testing.T, e *env, path string) string {
+func rawGet(t *testing.T, e *apptest.AppEnv, path string) string {
 	t.Helper()
-	req, err := http.NewRequest(http.MethodGet, e.ts.URL+path, nil)
+	req, err := http.NewRequest(http.MethodGet, e.TS.URL+path, nil)
 	if err != nil {
 		t.Fatalf("building request: %v", err)
 	}
-	resp, err := e.client.Do(req)
+	resp, err := e.Client.Do(req) //nolint:bodyclose // closed by the deferred apptest.CloseBody on the next line; bodyclose only sees a Close in the same package, and the closer moved out with the fixture
 	if err != nil {
 		t.Fatalf("GET %s: %v", path, err)
 	}
-	defer closeBody(t, resp)
+	defer apptest.CloseBody(t, resp)
 	raw, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("reading response: %v", err)
@@ -450,8 +451,8 @@ func containsIgnoringCase(haystack, needle string) bool {
 // "recent" in the field name is a lie, and the 50 an operator sees would
 // be an arbitrary 50 rather than the newest.
 func TestJobHealthCapsTheFailureListAndOrdersItNewestFirst(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 	mine := callerWorkspace(t, e)
 
 	// 60 failures, finalized at ascending times, so the newest are the
@@ -461,7 +462,7 @@ func TestJobHealthCapsTheFailureListAndOrdersItNewestFirst(t *testing.T) {
 		seedRiverRow(t, e, riverRow{
 			kind: "capped_pass", state: "discarded", workspace: mine, attempt: 3,
 		})
-		if _, err := e.owner.Exec(context.Background(),
+		if _, err := e.Owner.Exec(context.Background(),
 			`UPDATE river_job SET finalized_at = now() - make_interval(mins => $1)
 			 WHERE kind = 'capped_pass' AND finalized_at IS NOT NULL
 			   AND id = (SELECT max(id) FROM river_job WHERE kind = 'capped_pass')`,
@@ -471,7 +472,7 @@ func TestJobHealthCapsTheFailureListAndOrdersItNewestFirst(t *testing.T) {
 	}
 
 	var report jobHealthDTO
-	if status := e.call(t, "GET", "/v1/admin/job-health", nil, nil, &report); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/admin/job-health", nil, nil, &report); status != http.StatusOK {
 		t.Fatalf("GET /admin/job-health → %d, want 200", status)
 	}
 
@@ -519,22 +520,22 @@ func parseFailedAt(t *testing.T, raw string) time.Time {
 // 401 for a call with no session, and that answer comes from the session
 // middleware rather than from the handler, so only the real wire proves it.
 func TestJobHealthRefusesAnUnauthenticatedCallOverHTTP(t *testing.T) {
-	e := setup(t)
+	e := apptest.SetupApp(t)
 	// Bootstrapped, so the installation EXISTS — an unbootstrapped one
 	// answers 503 for every route and would prove nothing about this
 	// endpoint — and then stripped of its session cookie, so the request
 	// carries no credential of any kind.
-	e.bootstrapWorkspace(t)
+	e.BootstrapWorkspace(t)
 	jar, err := cookiejar.New(nil)
 	if err != nil {
 		t.Fatalf("fresh cookie jar: %v", err)
 	}
-	e.client.Jar = jar
+	e.Client.Jar = jar
 
 	var problem struct {
 		Code string `json:"code"`
 	}
-	status := e.call(t, "GET", "/v1/admin/job-health", nil, nil, &problem)
+	status := e.Call(t, "GET", "/v1/admin/job-health", nil, nil, &problem)
 	if status != http.StatusUnauthorized {
 		t.Errorf("unauthenticated GET /admin/job-health → %d, want 401", status)
 	}

--- a/backend/internal/compose/integration/leadscore_override_integration_test.go
+++ b/backend/internal/compose/integration/leadscore_override_integration_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	"github.com/gradionhq/margince/backend/internal/modules/activities"
 	"github.com/gradionhq/margince/backend/internal/modules/people"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
@@ -149,13 +150,13 @@ func logInboundReply(t *testing.T, ctx context.Context, activityStore *activitie
 // contract: a human PATCH setting score with no reason answers 422 with
 // the validation-error field shape.
 func TestLeadScoreOverrideRejectsMissingReasonOverHTTP(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 
 	var lead struct {
 		ID string `json:"id"`
 	}
-	if status := e.call(t, "POST", "/v1/leads", anyMap{"full_name": "Otto Lead", "source": "manual"}, nil, &lead); status != http.StatusCreated {
+	if status := e.Call(t, "POST", "/v1/leads", apptest.AnyMap{"full_name": "Otto Lead", "source": "manual"}, nil, &lead); status != http.StatusCreated {
 		t.Fatalf("create lead → %d", status)
 	}
 
@@ -168,7 +169,7 @@ func TestLeadScoreOverrideRejectsMissingReasonOverHTTP(t *testing.T) {
 			} `json:"errors"`
 		} `json:"details"`
 	}
-	if status := e.call(t, "PATCH", "/v1/leads/"+lead.ID, anyMap{"score": 80}, nil, &problem); status != http.StatusUnprocessableEntity {
+	if status := e.Call(t, "PATCH", "/v1/leads/"+lead.ID, apptest.AnyMap{"score": 80}, nil, &problem); status != http.StatusUnprocessableEntity {
 		t.Fatalf("score without reason → %d, want 422", status)
 	}
 	if problem.Code != "validation_error" ||

--- a/backend/internal/compose/integration/linkedin_http_integration_test.go
+++ b/backend/internal/compose/integration/linkedin_http_integration_test.go
@@ -15,6 +15,8 @@ import (
 	"mime/multipart"
 	"net/http"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 )
 
 type importSummaryDTO struct {
@@ -26,7 +28,7 @@ type importSummaryDTO struct {
 }
 
 // uploadExport posts a CSV as multipart, the way the browser does.
-func (e *env) uploadExport(t *testing.T, csv string) (int, importSummaryDTO) {
+func uploadExport(e *apptest.AppEnv, t *testing.T, csv string) (int, importSummaryDTO) {
 	t.Helper()
 	var body bytes.Buffer
 	writer := multipart.NewWriter(&body)
@@ -41,14 +43,14 @@ func (e *env) uploadExport(t *testing.T, csv string) (int, importSummaryDTO) {
 		t.Fatalf("closing the multipart writer: %v", err)
 	}
 
-	req, err := http.NewRequest(http.MethodPost, e.ts.URL+"/v1/me/linkedin-connections", &body)
+	req, err := http.NewRequest(http.MethodPost, e.TS.URL+"/v1/me/linkedin-connections", &body)
 	if err != nil {
 		t.Fatalf("building the request: %v", err)
 	}
 	req.Header.Set("Content-Type", writer.FormDataContentType())
-	req.Header.Set("X-Workspace-Slug", e.slug)
+	req.Header.Set("X-Workspace-Slug", e.Slug)
 
-	resp, err := e.client.Do(req)
+	resp, err := e.Client.Do(req)
 	if err != nil {
 		t.Fatalf("uploading: %v", err)
 	}
@@ -76,10 +78,10 @@ Andreas,Müller,https://x,,Acme GmbH,Head of IT,02 Feb 2023
 `
 
 func TestUploadingAnExportImportsItAndReportsWhatItDid(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 
-	status, got := e.uploadExport(t, exportWithPreamble)
+	status, got := uploadExport(e, t, exportWithPreamble)
 	if status != http.StatusOK {
 		t.Fatalf("upload status = %d, want 200", status)
 	}
@@ -99,7 +101,7 @@ func TestUploadingAnExportImportsItAndReportsWhatItDid(t *testing.T) {
 	// Re-uploading a refreshed export updates rather than duplicating —
 	// people re-export regularly, and a doubled network makes every reach
 	// count a lie.
-	status, again := e.uploadExport(t, exportWithPreamble)
+	status, again := uploadExport(e, t, exportWithPreamble)
 	if status != http.StatusOK {
 		t.Fatalf("re-upload status = %d", status)
 	}
@@ -109,19 +111,19 @@ func TestUploadingAnExportImportsItAndReportsWhatItDid(t *testing.T) {
 }
 
 func TestAnExactAddressMatchConfirmsOverHTTP(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 
 	// A contact carrying the address the export names.
-	var person anyMap
-	if status := e.call(t, "POST", "/v1/people", anyMap{
+	var person apptest.AnyMap
+	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{
 		"full_name": "Dana Buyer",
-		"emails":    []anyMap{{"email": "dana@acme.test", "is_primary": true}},
+		"emails":    []apptest.AnyMap{{"email": "dana@acme.test", "is_primary": true}},
 	}, nil, &person); status != http.StatusCreated {
 		t.Fatalf("creating the contact: %d", status)
 	}
 
-	status, got := e.uploadExport(t, exportWithPreamble)
+	status, got := uploadExport(e, t, exportWithPreamble)
 	if status != http.StatusOK {
 		t.Fatalf("upload status = %d", status)
 	}
@@ -138,12 +140,12 @@ func TestAnExactAddressMatchConfirmsOverHTTP(t *testing.T) {
 }
 
 func TestAFileThatIsNotAnExportIsRefusedWithAReadableReason(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 
 	// Picking the wrong file is a mistake a sentence can fix. Answering 500
 	// would send someone to support for something they can solve themselves.
-	status, _ := e.uploadExport(t, "id,amount\n1,20\n")
+	status, _ := uploadExport(e, t, "id,amount\n1,20\n")
 	if status != http.StatusUnprocessableEntity {
 		t.Errorf("a non-export answered %d, want 422", status)
 	}

--- a/backend/internal/compose/integration/mcp_deadline_integration_test.go
+++ b/backend/internal/compose/integration/mcp_deadline_integration_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/model"
 )
 
@@ -79,7 +80,7 @@ func TestASlowToolCallOutlivesTheServersWriteDeadline(t *testing.T) {
 	// harness's own server has none, so the wall under test would not exist
 	// there; setup runs against that one because a deadline this tight
 	// refuses every ordinary response, including the ones that seed this test.
-	strict := httptest.NewUnstartedServer(e.ts.Config.Handler)
+	strict := httptest.NewUnstartedServer(e.TS.Config.Handler)
 	strict.Config.WriteTimeout = expiredWriteDeadline
 	strict.Start()
 	t.Cleanup(strict.Close)
@@ -89,7 +90,7 @@ func TestASlowToolCallOutlivesTheServersWriteDeadline(t *testing.T) {
 	// cannot reach a client here — without this the test would pass just as
 	// happily against a server that has no deadline at all.
 	if resp, err := client.Get(strict.URL + "/healthz"); err == nil {
-		closeBody(t, resp)
+		apptest.CloseBody(t, resp)
 		t.Fatalf("GET /healthz answered %d although the server write deadline had expired: the wall under test is not armed", resp.StatusCode)
 	}
 
@@ -97,7 +98,7 @@ func TestASlowToolCallOutlivesTheServersWriteDeadline(t *testing.T) {
 	var thread struct {
 		ID string `json:"id"`
 	}
-	if status := e.call(t, "POST", "/v1/activities", anyMap{
+	if status := e.Call(t, "POST", "/v1/activities", apptest.AnyMap{
 		"kind": "email", "subject": "Renewal terms", "body": "What would renewal look like?",
 		"direction": "inbound",
 	}, nil, &thread); status != http.StatusCreated {
@@ -106,7 +107,7 @@ func TestASlowToolCallOutlivesTheServersWriteDeadline(t *testing.T) {
 	var minted struct {
 		Token string `json:"token"`
 	}
-	if status := e.call(t, "POST", "/v1/passports", anyMap{
+	if status := e.Call(t, "POST", "/v1/passports", apptest.AnyMap{
 		"label": "slow caller", "scopes": []string{"read", "draft"},
 	}, nil, &minted); status != http.StatusCreated {
 		t.Fatalf("issue passport → %d", status)
@@ -137,7 +138,7 @@ func TestASlowToolCallOutlivesTheServersWriteDeadline(t *testing.T) {
 	if err != nil {
 		t.Fatalf("the held tools/call never delivered a response: %v", err)
 	}
-	defer closeBody(t, resp)
+	defer apptest.CloseBody(t, resp)
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("reading the held tools/call response: %v", err)

--- a/backend/internal/compose/integration/mcp_handshake_integration_test.go
+++ b/backend/internal/compose/integration/mcp_handshake_integration_test.go
@@ -16,6 +16,8 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 )
 
 // TestAConnectorCompletesTheWholeHandshakeOnOneOrigin is the phase's headline
@@ -33,7 +35,7 @@ func TestAConnectorCompletesTheWholeHandshakeOnOneOrigin(t *testing.T) {
 	var registered struct {
 		ClientID string `json:"client_id"`
 	}
-	if status := e.call(t, "POST", advertised.register, anyMap{
+	if status := e.Call(t, "POST", advertised.register, apptest.AnyMap{
 		"client_name": "one-origin connector", "redirect_uris": []string{oauthRedirect},
 	}, nil, &registered); status != http.StatusCreated || registered.ClientID == "" {
 		t.Fatalf("DCR at %s → %d %+v", advertised.register, status, registered)
@@ -58,7 +60,7 @@ func TestAConnectorCompletesTheWholeHandshakeOnOneOrigin(t *testing.T) {
 	// initialize settles the protocol revision and mints the session id every
 	// later request on this connection carries.
 	const requested = "2025-06-18"
-	initialized := e.raw(t, http.MethodPost, "/mcp",
+	initialized := raw(e.AppEnv, t, http.MethodPost, "/mcp",
 		`{"jsonrpc":"2.0","id":2,"method":"initialize","params":{"protocolVersion":"`+requested+
 			`","clientInfo":{"name":"conformance","version":"1"}}}`,
 		map[string]string{"Content-Type": "application/json", "Authorization": "Bearer " + token})
@@ -112,16 +114,16 @@ type advertisedEndpoints struct {
 // instead of much later as an unexplained client error.
 func (e *connectorEnv) discover(t *testing.T) advertisedEndpoints {
 	t.Helper()
-	unauth := e.listTools(t, "")
+	unauth := listTools(e.AppEnv, t, "")
 	if unauth.StatusCode != http.StatusUnauthorized {
 		t.Fatalf("unauthenticated POST /mcp → %d, want 401", unauth.StatusCode)
 	}
-	resourceDoc := e.getJSON(t, e.pathOn(t, resourceMetadataParam(t, unauth.Header.Get("WWW-Authenticate"))))
+	resourceDoc := getJSON(e.AppEnv, t, e.pathOn(t, resourceMetadataParam(t, unauth.Header.Get("WWW-Authenticate"))))
 	servers, ok := resourceDoc["authorization_servers"].([]any)
 	if !ok || len(servers) != 1 || servers[0] != e.origin {
 		t.Fatalf("authorization_servers = %v, want [%s]", resourceDoc["authorization_servers"], e.origin)
 	}
-	asDoc := e.getJSON(t, "/.well-known/oauth-authorization-server")
+	asDoc := getJSON(e.AppEnv, t, "/.well-known/oauth-authorization-server")
 	out := advertisedEndpoints{
 		register:  e.pathOn(t, stringField(t, asDoc, "registration_endpoint")),
 		authorize: e.pathOn(t, stringField(t, asDoc, "authorization_endpoint")),

--- a/backend/internal/compose/integration/mcp_transport_integration_test.go
+++ b/backend/internal/compose/integration/mcp_transport_integration_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
@@ -37,7 +38,7 @@ import (
 // documents carry ABSOLUTE URLs — an assertion about what a client
 // dereferences cannot hardcode a port the OS assigns.
 type connectorEnv struct {
-	*env
+	*apptest.AppEnv
 	origin string
 }
 
@@ -57,7 +58,7 @@ func setupConnector(t *testing.T) *connectorEnv {
 // asserts against.
 func setupConnectorWith(t *testing.T, extra ...compose.Option) *connectorEnv {
 	t.Helper()
-	e := setupWithOriginOptions(t, func(origin string) []compose.Option {
+	e := apptest.SetupAppWithOriginOptions(t, func(origin string) []compose.Option {
 		// The advertised resource comes from configuration, exactly as
 		// --public-base-url supplies it in a deployment — never from the
 		// Host header, which an attacker controls.
@@ -65,9 +66,9 @@ func setupConnectorWith(t *testing.T, extra ...compose.Option) *connectorEnv {
 			compose.WithMCPConnector(), compose.WithMCPResource(origin + "/mcp"),
 		}, extra...)
 	})
-	e.slug = "mcp-connector" // slugify("MCP Connector")
-	bootstrapWorkspaceSession(t, e, "MCP Connector", "granter@fable.test", "Admin")
-	return &connectorEnv{env: e, origin: e.ts.URL}
+	e.Slug = "mcp-connector" // slugify("MCP Connector")
+	apptest.BootstrapWorkspaceSession(t, e, "MCP Connector", "granter@fable.test", "Admin")
+	return &connectorEnv{AppEnv: e, origin: e.TS.URL}
 }
 
 // httpResult is one exchange's outcome with the body already drained and
@@ -82,22 +83,22 @@ type httpResult struct {
 // admission assertion needs: whether this credential gets in at all. An empty
 // bearer sends NO Authorization header — the unauthenticated shape a client
 // starts its discovery from, which is not the same as an empty credential.
-func (e *env) listTools(t *testing.T, bearer string) httpResult {
+func listTools(e *apptest.AppEnv, t *testing.T, bearer string) httpResult {
 	t.Helper()
 	headers := map[string]string{"Content-Type": "application/json"}
 	if bearer != "" {
 		headers["Authorization"] = "Bearer " + bearer
 	}
-	return e.raw(t, http.MethodPost, "/mcp", `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`, headers)
+	return raw(e, t, http.MethodPost, "/mcp", `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`, headers)
 }
 
 // getJSON dereferences a discovery document the way a client does and fails
 // on anything but a 200 with a JSON object.
 //
 //craft:ignore naked-any a discovery document is an open JSON object by RFC 8414/9728 — asserting on it means reading it untyped
-func (e *env) getJSON(t *testing.T, path string) map[string]any {
+func getJSON(e *apptest.AppEnv, t *testing.T, path string) map[string]any {
 	t.Helper()
-	got := e.raw(t, http.MethodGet, path, "", nil)
+	got := raw(e, t, http.MethodGet, path, "", nil)
 	if got.StatusCode != http.StatusOK {
 		t.Fatalf("GET %s → %d %s", path, got.StatusCode, got.Body)
 	}
@@ -111,24 +112,24 @@ func (e *env) getJSON(t *testing.T, path string) map[string]any {
 // raw issues one request against the harness origin and returns the whole
 // outcome. It never decodes: the connector suite asserts on status codes and
 // headers as often as on bodies, and a 404 has no JSON to decode.
-func (e *env) raw(t *testing.T, method, path, payload string, headers map[string]string) httpResult {
+func raw(e *apptest.AppEnv, t *testing.T, method, path, payload string, headers map[string]string) httpResult {
 	t.Helper()
 	var body io.Reader
 	if payload != "" {
 		body = strings.NewReader(payload)
 	}
-	req, err := http.NewRequest(method, e.ts.URL+path, body)
+	req, err := http.NewRequest(method, e.TS.URL+path, body)
 	if err != nil {
 		t.Fatalf("building %s %s: %v", method, path, err)
 	}
 	for k, v := range headers {
 		req.Header.Set(k, v)
 	}
-	resp, err := e.client.Do(req)
+	resp, err := e.Client.Do(req) //nolint:bodyclose // closed by the deferred apptest.CloseBody on the next line; bodyclose only sees a Close in the same package, and the closer moved out with the fixture
 	if err != nil {
 		t.Fatalf("%s %s: %v", method, path, err)
 	}
-	defer closeBody(t, resp)
+	defer apptest.CloseBody(t, resp)
 	raw, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("%s %s: reading response: %v", method, path, err)
@@ -141,7 +142,7 @@ func (e *env) raw(t *testing.T, method, path, payload string, headers map[string
 // that URL is served here, and it points at this same issuer.
 func TestMCPIsServedAtTheAPIOriginWithDiscovery(t *testing.T) {
 	env := setupConnector(t)
-	resp := env.listTools(t, "")
+	resp := listTools(env.AppEnv, t, "")
 	if resp.StatusCode != http.StatusUnauthorized {
 		t.Fatalf("unauthenticated POST /mcp → %d, want 401", resp.StatusCode)
 	}
@@ -150,7 +151,7 @@ func TestMCPIsServedAtTheAPIOriginWithDiscovery(t *testing.T) {
 	if !strings.HasPrefix(metaURL, env.origin) {
 		t.Fatalf("resource_metadata = %q, want an absolute URL on %s", metaURL, env.origin)
 	}
-	doc := env.getJSON(t, strings.TrimPrefix(metaURL, env.origin))
+	doc := getJSON(env.AppEnv, t, strings.TrimPrefix(metaURL, env.origin))
 	if doc["resource"] != env.origin+"/mcp" {
 		t.Fatalf("resource = %v, want %s/mcp", doc["resource"], env.origin)
 	}
@@ -161,7 +162,7 @@ func TestMCPIsServedAtTheAPIOriginWithDiscovery(t *testing.T) {
 	if !ok || len(servers) != 1 || servers[0] != env.origin {
 		t.Fatalf("authorization_servers = %v, want [%s]", doc["authorization_servers"], env.origin)
 	}
-	asDoc := env.getJSON(t, "/.well-known/oauth-authorization-server")
+	asDoc := getJSON(env.AppEnv, t, "/.well-known/oauth-authorization-server")
 	if asDoc["issuer"] != env.origin || asDoc["token_endpoint"] != env.origin+"/oauth/token" {
 		t.Fatalf("authorization-server metadata = %v, want issuer+token endpoint on %s", asDoc, env.origin)
 	}
@@ -191,21 +192,21 @@ func TestMCPOnTheAPIServesTheAPIsOwnToolSurface(t *testing.T) {
 	var minted struct {
 		Token string `json:"token"`
 	}
-	if status := env.call(t, "POST", "/v1/passports", anyMap{
+	if status := env.Call(t, "POST", "/v1/passports", apptest.AnyMap{
 		"label": "connector client", "scopes": []string{"read"},
 	}, nil, &minted); status != http.StatusCreated {
 		t.Fatalf("issue passport → %d", status)
 	}
 
 	var rest agentToolListWire
-	if status := env.call(t, "GET", "/v1/agent-tools", nil, nil, &rest); status != http.StatusOK {
+	if status := env.Call(t, "GET", "/v1/agent-tools", nil, nil, &rest); status != http.StatusOK {
 		t.Fatalf("GET /v1/agent-tools → %d", status)
 	}
 	if len(rest.Data) == 0 {
 		t.Fatal("the REST agent surface reports no tools, so there is nothing to compare the transport against")
 	}
 
-	got := env.listTools(t, minted.Token)
+	got := listTools(env.AppEnv, t, minted.Token)
 	if got.StatusCode != http.StatusOK {
 		t.Fatalf("authenticated POST /mcp → %d %s", got.StatusCode, got.Body)
 	}
@@ -248,7 +249,7 @@ func TestMCPOnTheAPIServesTheAPIsOwnToolSurface(t *testing.T) {
 // live with no off switch; answering the group with anything but the mux's
 // own 404 would tell a prober which gate is closed.
 func TestConnectorGateOffRemovesEveryConnectorRoute(t *testing.T) {
-	e := setup(t) // the default deployment posture: the connector undeclared
+	e := apptest.SetupApp(t) // the default deployment posture: the connector undeclared
 
 	// Every route the gate mounts, and nothing may be left out: an endpoint
 	// missing from this list is an endpoint nobody proved the gate covers.
@@ -266,7 +267,7 @@ func TestConnectorGateOffRemovesEveryConnectorRoute(t *testing.T) {
 	}
 	var want, wantFrom string
 	for _, p := range probes {
-		got := e.raw(t, p.method, p.path, p.payload, nil)
+		got := raw(e, t, p.method, p.path, p.payload, nil)
 		if got.StatusCode != http.StatusNotFound {
 			t.Fatalf("%s %s → %d, want 404: the gate must remove the route, not guard it",
 				p.method, p.path, got.StatusCode)
@@ -329,7 +330,7 @@ func (e *connectorEnv) rpc(t *testing.T, bearer, protocolVersion, payload string
 	if protocolVersion != "" {
 		headers["MCP-Protocol-Version"] = protocolVersion
 	}
-	got := e.raw(t, http.MethodPost, "/mcp", payload, headers)
+	got := raw(e.AppEnv, t, http.MethodPost, "/mcp", payload, headers)
 	if got.StatusCode != http.StatusOK {
 		t.Fatalf("POST /mcp %s → %d %s", payload, got.StatusCode, got.Body)
 	}

--- a/backend/internal/compose/integration/messageidentity_integration_test.go
+++ b/backend/internal/compose/integration/messageidentity_integration_test.go
@@ -57,7 +57,7 @@ func replyFrom(quoting string) []byte {
 func (p *preflightEnv) activityOnTheStampedIdentity(t *testing.T) ids.UUID {
 	t.Helper()
 	var found []ids.UUID
-	if err := p.inWorkspace(t, p.slug, func(tx pgx.Tx) error {
+	if err := inWorkspace(p.AppEnv, t, p.Slug, func(tx pgx.Tx) error {
 		rows, err := tx.Query(context.Background(),
 			`SELECT id FROM activity WHERE source_system = 'gmail' AND source_id = $1`, gmailStamped)
 		if err != nil {
@@ -87,7 +87,7 @@ func (p *preflightEnv) activityOnTheStampedIdentity(t *testing.T) ids.UUID {
 func (p *preflightEnv) countActivities(t *testing.T, where string, args ...any) int {
 	t.Helper()
 	var n int
-	if err := p.inWorkspace(t, p.slug, func(tx pgx.Tx) error {
+	if err := inWorkspace(p.AppEnv, t, p.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(), `SELECT count(*) FROM activity WHERE `+where, args...).Scan(&n)
 	}); err != nil {
 		t.Fatalf("counting the activities matching %q: %v", where, err)
@@ -103,7 +103,7 @@ func (p *preflightEnv) captureEcho(t *testing.T, stored []byte) {
 	if err != nil {
 		t.Fatalf("the provider's stored copy does not parse:\n%s\n%v", stored, err)
 	}
-	if _, err := capture.NewSink(p.pool).Upsert(p.connectorCtx(t),
+	if _, err := capture.NewSink(p.Pool).Upsert(p.connectorCtx(t),
 		msg.AttestSentByOwner(true).ToRecord("gmail", stored)); err != nil {
 		t.Fatalf("capturing the provider's own copy: %v", err)
 	}
@@ -162,7 +162,7 @@ func TestAnEchoCapturedBeforeTransmitIsAbsorbedByTheReceiptItself(t *testing.T) 
 	// may destroy.
 	var archived bool
 	var released bool
-	if err := p.inWorkspace(t, p.slug, func(tx pgx.Tx) error {
+	if err := inWorkspace(p.AppEnv, t, p.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(),
 			`SELECT archived_at IS NOT NULL, source_id IS NULL FROM activity WHERE id = $1`, echo).
 			Scan(&archived, &released)
@@ -178,7 +178,7 @@ func TestAnEchoCapturedBeforeTransmitIsAbsorbedByTheReceiptItself(t *testing.T) 
 	// Zero breadcrumbs is what distinguishes an absorb that worked from a
 	// reconcile that silently degraded to "receipt recorded, one duplicate".
 	var faults int
-	if err := p.inWorkspace(t, p.slug, func(tx pgx.Tx) error {
+	if err := inWorkspace(p.AppEnv, t, p.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(),
 			`SELECT count(*) FROM system_log WHERE action = 'comms_identity_reconcile_failed'`).Scan(&faults)
 	}); err != nil {
@@ -209,7 +209,7 @@ func TestAGmailRewrittenIdentityStillYieldsOneActivityAndOneReplyTarget(t *testi
 		t.Fatalf("the stamped identity resolves to %s, want the send's own activity %s", id, sentActivity)
 	}
 	var deliveryMessageID string
-	if err := p.inWorkspace(t, p.slug, func(tx pgx.Tx) error {
+	if err := inWorkspace(p.AppEnv, t, p.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(),
 			`SELECT message_id FROM comms_outbound WHERE id = $1`, deliveryID).Scan(&deliveryMessageID)
 	}); err != nil {
@@ -237,7 +237,7 @@ func TestAGmailRewrittenIdentityStillYieldsOneActivityAndOneReplyTarget(t *testi
 	// and must land on the send.
 	p.captureEcho(t, replyFrom(gmailStamped))
 	var matched ids.UUID
-	if err := p.inWorkspace(t, p.slug, func(tx pgx.Tx) error {
+	if err := inWorkspace(p.AppEnv, t, p.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(), `
 			SELECT (envelope->'payload'->>'matched_outbound_activity_id')::uuid
 			  FROM event_outbox

--- a/backend/internal/compose/integration/network_http_integration_test.go
+++ b/backend/internal/compose/integration/network_http_integration_test.go
@@ -12,6 +12,8 @@ package integration
 import (
 	"net/http"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 )
 
 type networkColleagueDTO struct {
@@ -39,18 +41,18 @@ type coverageRiskDTO struct {
 
 type dealCoverageDTO struct {
 	DealID       string            `json:"deal_id"`
-	Stakeholders []anyMap          `json:"stakeholders"`
-	OurSide      []anyMap          `json:"our_side"`
+	Stakeholders []apptest.AnyMap  `json:"stakeholders"`
+	OurSide      []apptest.AnyMap  `json:"our_side"`
 	Risks        []coverageRiskDTO `json:"risks"`
 }
 
 func TestPersonNetworkAnswersHonestlyWhenNobodyKnowsThem(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 
-	var person anyMap
-	if status := e.call(t, "POST", "/v1/people",
-		anyMap{"full_name": "Unknown Contact"}, nil, &person); status != http.StatusCreated {
+	var person apptest.AnyMap
+	if status := e.Call(t, "POST", "/v1/people",
+		apptest.AnyMap{"full_name": "Unknown Contact"}, nil, &person); status != http.StatusCreated {
 		t.Fatalf("creating the contact: %d", status)
 	}
 	id, _ := person["id"].(string)
@@ -59,7 +61,7 @@ func TestPersonNetworkAnswersHonestlyWhenNobodyKnowsThem(t *testing.T) {
 	// and not an error. "The account is cold" is the useful answer here, and
 	// the surface has to be able to say it.
 	var got personNetworkDTO
-	if status := e.call(t, "GET", "/v1/people/"+id+"/network", nil, nil, &got); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/people/"+id+"/network", nil, nil, &got); status != http.StatusOK {
 		t.Fatalf("network status = %d, want 200", status)
 	}
 	if got.PersonID != id {
@@ -71,13 +73,13 @@ func TestPersonNetworkAnswersHonestlyWhenNobodyKnowsThem(t *testing.T) {
 }
 
 func TestPersonNetworkHidesAContactTheCallerCannotRead(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 
 	// A person id that does not exist is indistinguishable from one this
 	// caller may not see — existence is not disclosed, here as everywhere.
-	var body anyMap
-	if status := e.call(t, "GET",
+	var body apptest.AnyMap
+	if status := e.Call(t, "GET",
 		"/v1/people/019fb000-0000-7000-8000-00000000dead/network", nil, nil, &body); status != http.StatusNotFound {
 		t.Errorf("an unknown contact answered %d, want 404 — a network read must not "+
 			"confirm that a record exists when the person read would not", status)
@@ -85,17 +87,17 @@ func TestPersonNetworkHidesAContactTheCallerCannotRead(t *testing.T) {
 }
 
 func TestDealCoverageFlagsAThreadlessDealAndExplainsWhy(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 
-	var pipelines anyMap
-	if status := e.call(t, "GET", "/v1/pipelines", nil, nil, &pipelines); status != http.StatusOK {
+	var pipelines apptest.AnyMap
+	if status := e.Call(t, "GET", "/v1/pipelines", nil, nil, &pipelines); status != http.StatusOK {
 		t.Fatalf("listing pipelines: %d", status)
 	}
 	pipeline, stage := firstPipelineAndStage(t, pipelines)
 
-	var deal anyMap
-	if status := e.call(t, "POST", "/v1/deals", anyMap{
+	var deal apptest.AnyMap
+	if status := e.Call(t, "POST", "/v1/deals", apptest.AnyMap{
 		"name": "Threadless", "pipeline_id": pipeline, "stage_id": stage, "source": "ui",
 	}, nil, &deal); status != http.StatusCreated {
 		t.Fatalf("creating the deal: %d", status)
@@ -103,7 +105,7 @@ func TestDealCoverageFlagsAThreadlessDealAndExplainsWhy(t *testing.T) {
 	dealID, _ := deal["id"].(string)
 
 	var got dealCoverageDTO
-	if status := e.call(t, "GET", "/v1/deals/"+dealID+"/coverage", nil, nil, &got); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/deals/"+dealID+"/coverage", nil, nil, &got); status != http.StatusOK {
 		t.Fatalf("coverage status = %d, want 200", status)
 	}
 	if got.DealID != dealID {
@@ -128,36 +130,36 @@ func TestDealCoverageFlagsAThreadlessDealAndExplainsWhy(t *testing.T) {
 }
 
 func TestDealCoverageHidesADealTheCallerCannotRead(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 
 	// The coverage payload names the deal's people, so a caller who cannot
 	// read the deal must not learn who sits on it.
-	var body anyMap
-	if status := e.call(t, "GET",
+	var body apptest.AnyMap
+	if status := e.Call(t, "GET",
 		"/v1/deals/019fb000-0000-7000-8000-00000000beef/coverage", nil, nil, &body); status != http.StatusNotFound {
 		t.Errorf("an unknown deal answered %d, want 404", status)
 	}
 }
 
 func TestDealCoverageDistinguishesADepartedChampionFromADepartedStakeholder(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
-	org, deal := e.dealAtAnAccount(t, "Bär Pharma", "Renewal")
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
+	org, deal := dealAtAnAccount(e, t, "Bär Pharma", "Renewal")
 
 	// Two people who used to work there and one who still does. The rule
 	// demands EVIDENCE of a departure — an ended employment plus no live one —
 	// so the third person proves the flag is about leaving and not about
 	// having no employment row.
-	gone := e.contactAt(t, org, "Departed Champion", "2026-01-31")
-	alsoGone := e.contactAt(t, org, "Departed Legal", "2026-02-28")
-	stayed := e.contactAt(t, org, "Still There", "")
+	gone := contactAt(e, t, org, "Departed Champion", "2026-01-31")
+	alsoGone := contactAt(e, t, org, "Departed Legal", "2026-02-28")
+	stayed := contactAt(e, t, org, "Still There", "")
 
-	e.stakeholder(t, deal, gone, "champion")
-	e.stakeholder(t, deal, alsoGone, "legal")
-	e.stakeholder(t, deal, stayed, "user")
+	stakeholder(e, t, deal, gone, "champion")
+	stakeholder(e, t, deal, alsoGone, "legal")
+	stakeholder(e, t, deal, stayed, "user")
 
-	risks := e.coverageRisks(t, deal)
+	risks := coverageRisks(e, t, deal)
 	champion := findRisk(risks, "champion_left")
 	if champion == nil {
 		t.Fatalf("the champion left the account and no champion_left risk fired: %+v", risks)
@@ -184,42 +186,42 @@ func TestDealCoverageDistinguishesADepartedChampionFromADepartedStakeholder(t *t
 }
 
 func TestDealCoverageDoesNotCallARehiredStakeholderDeparted(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
-	org, deal := e.dealAtAnAccount(t, "Voss Systems", "Expansion")
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
+	org, deal := dealAtAnAccount(e, t, "Voss Systems", "Expansion")
 
 	// A role change recorded as end-then-start, which is how most CRMs record
 	// a promotion. The closed row is real and so is the live one, and only the
 	// live one decides: flagging this would announce a resignation every time
 	// somebody changed job title.
-	person := e.contactAt(t, org, "Promoted Person", "2026-01-31")
-	e.employ(t, person, org, "2026-02-01", "")
-	e.stakeholder(t, deal, person, "champion")
+	person := contactAt(e, t, org, "Promoted Person", "2026-01-31")
+	employ(e, t, person, org, "2026-02-01", "")
+	stakeholder(e, t, deal, person, "champion")
 
-	risks := e.coverageRisks(t, deal)
+	risks := coverageRisks(e, t, deal)
 	if findRisk(risks, "champion_left") != nil {
 		t.Errorf("a stakeholder with a live employment was reported as departed: %+v", risks)
 	}
 }
 
 func TestGoingColdFiresOnTheReportingWindowAndCarriesTheDayCount(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
-	_, deal := e.dealAtAnAccount(t, "Kessler GmbH", "Silent")
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
+	_, deal := dealAtAnAccount(e, t, "Kessler GmbH", "Silent")
 
 	// A brand-new deal has been silent since it was created, which is zero
 	// days — not cold. The flag must not fire on the day a rep writes a deal
 	// down.
-	if findRisk(e.coverageRisks(t, deal), "going_cold") != nil {
+	if findRisk(coverageRisks(e, t, deal), "going_cold") != nil {
 		t.Error("a deal created moments ago was flagged as going cold")
 	}
 
 	// Age the last touch past REPORT-PARAM-2's window. Written through the
 	// owner connection because no API sets this column — it is maintained by
 	// the capture path, and the point of the test is the read, not the write.
-	e.ageLastTouch(t, deal, 41)
+	ageLastTouch(e, t, deal, 41)
 
-	risks := e.coverageRisks(t, deal)
+	risks := coverageRisks(e, t, deal)
 	cold := findRisk(risks, "going_cold")
 	if cold == nil {
 		t.Fatalf("a deal untouched for 41 days raised no going_cold risk: %+v", risks)
@@ -241,15 +243,15 @@ func TestGoingColdFiresOnTheReportingWindowAndCarriesTheDayCount(t *testing.T) {
 }
 
 func TestAWonDealIsNotGoingCold(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
-	_, deal := e.dealAtAnAccount(t, "Brandt Automotive", "Delivered")
-	e.ageLastTouch(t, deal, 400)
-	e.closeWon(t, deal)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
+	_, deal := dealAtAnAccount(e, t, "Brandt Automotive", "Delivered")
+	ageLastTouch(e, t, deal, 400)
+	closeWon(e, t, deal)
 
 	// Silence after the close is delivery, not decay. Flagging it would train
 	// a rep to ignore the flag on the deals where it means something.
-	if findRisk(e.coverageRisks(t, deal), "going_cold") != nil {
+	if findRisk(coverageRisks(e, t, deal), "going_cold") != nil {
 		t.Error("a won deal silent for 400 days was flagged as going cold")
 	}
 }
@@ -257,10 +259,10 @@ func TestAWonDealIsNotGoingCold(t *testing.T) {
 // --- fixture helpers ---
 
 // coverageRisks reads one deal's findings through the real endpoint.
-func (e *env) coverageRisks(t *testing.T, dealID string) []coverageRiskDTO {
+func coverageRisks(e *apptest.AppEnv, t *testing.T, dealID string) []coverageRiskDTO {
 	t.Helper()
 	var got dealCoverageDTO
-	if status := e.call(t, "GET", "/v1/deals/"+dealID+"/coverage", nil, nil, &got); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/deals/"+dealID+"/coverage", nil, nil, &got); status != http.StatusOK {
 		t.Fatalf("coverage status = %d, want 200", status)
 	}
 	return got.Risks
@@ -278,23 +280,23 @@ func findRisk(risks []coverageRiskDTO, kind string) *coverageRiskDTO {
 // dealAtAnAccount creates an organization and an open deal owned by it — the
 // shape every departure rule needs, since a deal with no account has nobody to
 // have left.
-func (e *env) dealAtAnAccount(t *testing.T, orgName, dealName string) (org, deal string) {
+func dealAtAnAccount(e *apptest.AppEnv, t *testing.T, orgName, dealName string) (org, deal string) {
 	t.Helper()
-	var created anyMap
-	if status := e.call(t, "POST", "/v1/organizations",
-		anyMap{"display_name": orgName, "source": "ui"}, nil, &created); status != http.StatusCreated {
+	var created apptest.AnyMap
+	if status := e.Call(t, "POST", "/v1/organizations",
+		apptest.AnyMap{"display_name": orgName, "source": "ui"}, nil, &created); status != http.StatusCreated {
 		t.Fatalf("creating the account: %d", status)
 	}
 	org, _ = created["id"].(string)
 
-	var pipelines anyMap
-	if status := e.call(t, "GET", "/v1/pipelines", nil, nil, &pipelines); status != http.StatusOK {
+	var pipelines apptest.AnyMap
+	if status := e.Call(t, "GET", "/v1/pipelines", nil, nil, &pipelines); status != http.StatusOK {
 		t.Fatalf("listing pipelines: %d", status)
 	}
 	pipeline, stage := firstPipelineAndStage(t, pipelines)
 
-	var made anyMap
-	if status := e.call(t, "POST", "/v1/deals", anyMap{
+	var made apptest.AnyMap
+	if status := e.Call(t, "POST", "/v1/deals", apptest.AnyMap{
 		"name": dealName, "pipeline_id": pipeline, "stage_id": stage,
 		"organization_id": org, "source": "ui",
 	}, nil, &made); status != http.StatusCreated {
@@ -311,37 +313,37 @@ const hiredOn = "2020-01-01"
 
 // contactAt creates a person and their employment at the account. An empty
 // endedAt means they still work there.
-func (e *env) contactAt(t *testing.T, org, name, endedAt string) string {
+func contactAt(e *apptest.AppEnv, t *testing.T, org, name, endedAt string) string {
 	t.Helper()
-	var person anyMap
-	if status := e.call(t, "POST", "/v1/people",
-		anyMap{"full_name": name}, nil, &person); status != http.StatusCreated {
+	var person apptest.AnyMap
+	if status := e.Call(t, "POST", "/v1/people",
+		apptest.AnyMap{"full_name": name}, nil, &person); status != http.StatusCreated {
 		t.Fatalf("creating %s: %d", name, status)
 	}
 	id, _ := person["id"].(string)
-	e.employ(t, id, org, hiredOn, endedAt)
+	employ(e, t, id, org, hiredOn, endedAt)
 	return id
 }
 
-func (e *env) employ(t *testing.T, person, org, startedAt, endedAt string) {
+func employ(e *apptest.AppEnv, t *testing.T, person, org, startedAt, endedAt string) {
 	t.Helper()
-	body := anyMap{
+	body := apptest.AnyMap{
 		"kind": "employment", "person_id": person, "organization_id": org,
 		"started_at": startedAt, "source": "ui",
 	}
 	if endedAt != "" {
 		body["ended_at"] = endedAt
 	}
-	var out anyMap
-	if status := e.call(t, "POST", "/v1/relationships", body, nil, &out); status != http.StatusCreated {
+	var out apptest.AnyMap
+	if status := e.Call(t, "POST", "/v1/relationships", body, nil, &out); status != http.StatusCreated {
 		t.Fatalf("recording employment: %d (%v)", status, out)
 	}
 }
 
-func (e *env) stakeholder(t *testing.T, deal, person, role string) {
+func stakeholder(e *apptest.AppEnv, t *testing.T, deal, person, role string) {
 	t.Helper()
-	var out anyMap
-	if status := e.call(t, "POST", "/v1/relationships", anyMap{
+	var out apptest.AnyMap
+	if status := e.Call(t, "POST", "/v1/relationships", apptest.AnyMap{
 		"kind": "deal_stakeholder", "deal_id": deal, "person_id": person,
 		"role": role, "source": "ui",
 	}, nil, &out); status != http.StatusCreated {
@@ -352,25 +354,25 @@ func (e *env) stakeholder(t *testing.T, deal, person, role string) {
 // ageLastTouch backdates the deal's last captured touch. Written as owner
 // because no API writes this column — capture maintains it — and the behaviour
 // under test is how the coverage read interprets it.
-func (e *env) ageLastTouch(t *testing.T, deal string, days int) {
+func ageLastTouch(e *apptest.AppEnv, t *testing.T, deal string, days int) {
 	t.Helper()
-	if _, err := e.owner.Exec(t.Context(),
+	if _, err := e.Owner.Exec(t.Context(),
 		`UPDATE deal SET last_activity_at = now() - make_interval(days => $2) WHERE id = $1`,
 		deal, days); err != nil {
 		t.Fatalf("backdating the deal's last touch: %v", err)
 	}
 }
 
-func (e *env) closeWon(t *testing.T, deal string) {
+func closeWon(e *apptest.AppEnv, t *testing.T, deal string) {
 	t.Helper()
-	if _, err := e.owner.Exec(t.Context(),
+	if _, err := e.Owner.Exec(t.Context(),
 		`UPDATE deal SET status = 'won', closed_at = now() WHERE id = $1`, deal); err != nil {
 		t.Fatalf("closing the deal as won: %v", err)
 	}
 }
 
 // firstPipelineAndStage picks the default pipeline and its first stage.
-func firstPipelineAndStage(t *testing.T, listed anyMap) (pipeline, stage string) {
+func firstPipelineAndStage(t *testing.T, listed apptest.AnyMap) (pipeline, stage string) {
 	t.Helper()
 	data, _ := listed["data"].([]any)
 	if len(data) == 0 {

--- a/backend/internal/compose/integration/oauth_consent_integration_test.go
+++ b/backend/internal/compose/integration/oauth_consent_integration_test.go
@@ -20,6 +20,8 @@ import (
 	"slices"
 	"strings"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 )
 
 // consentCookieName is the double-submit cookie the authorize GET arms. Spelled
@@ -36,7 +38,7 @@ func (o *oauthEnv) mintPassport(t *testing.T, label string, scopes []string) str
 	var minted struct {
 		ID string `json:"passport_id"`
 	}
-	if status := o.call(t, "POST", "/v1/passports", anyMap{
+	if status := o.Call(t, "POST", "/v1/passports", apptest.AnyMap{
 		"label": label, "scopes": scopes,
 	}, nil, &minted); status != http.StatusCreated {
 		t.Fatalf("mint %q → %d", label, status)
@@ -46,7 +48,7 @@ func (o *oauthEnv) mintPassport(t *testing.T, label string, scopes []string) str
 
 func (o *oauthEnv) revokePassport(t *testing.T, id string) {
 	t.Helper()
-	if status := o.call(t, "DELETE", "/v1/passports/"+id, nil, nil, nil); status != http.StatusNoContent {
+	if status := o.Call(t, "DELETE", "/v1/passports/"+id, nil, nil, nil); status != http.StatusNoContent {
 		t.Fatalf("revoke %s → %d", id, status)
 	}
 }
@@ -55,7 +57,7 @@ func (o *oauthEnv) revokePassport(t *testing.T, id string) {
 func (o *oauthEnv) consentRequest(t *testing.T, scope string) consentRequestWire {
 	t.Helper()
 	var got consentRequestWire
-	status := o.call(t, "GET",
+	status := o.Call(t, "GET",
 		"/v1/oauth/consent-request?client_id="+url.QueryEscape(o.clientID)+
 			"&scope="+url.QueryEscape(scope), nil, nil, &got)
 	if status != http.StatusOK {
@@ -85,7 +87,7 @@ func TestSelectablePassportsExcludesEveryUnlendableShape(t *testing.T) {
 	revoked := o.mintPassport(t, "revoked", []string{"read"})
 	o.revokePassport(t, revoked)
 	bound := o.mintPassport(t, "bound", []string{"read"})
-	if _, err := o.owner.Exec(ctx,
+	if _, err := o.Owner.Exec(ctx,
 		`WITH new_grant AS (
 		   INSERT INTO oauth_grant (workspace_id, client_id, user_id, scopes, refresh_allowed)
 		   SELECT workspace_id, $2, on_behalf_of, ARRAY['read']::text[], false
@@ -149,7 +151,7 @@ func TestSelectablePassportsExcludesAnExpiredPassport(t *testing.T) {
 	ctx := context.Background()
 
 	expired := o.mintPassport(t, "expired", []string{"read"})
-	if _, err := o.owner.Exec(ctx,
+	if _, err := o.Owner.Exec(ctx,
 		`UPDATE passport SET expires_at = now() - interval '1 minute' WHERE id = $1`, expired); err != nil {
 		t.Fatalf("backdating a passport's expiry: %v", err)
 	}
@@ -176,12 +178,12 @@ func TestSelectablePassportsExcludesAnotherUsersPassport(t *testing.T) {
 	var other struct {
 		ID string `json:"id"`
 	}
-	if status := o.call(t, "POST", "/v1/users", anyMap{
+	if status := o.Call(t, "POST", "/v1/users", apptest.AnyMap{
 		"email": "otherhuman@acme.test", "display_name": "Other Human", "role": "rep",
 	}, nil, &other); status != http.StatusCreated {
 		t.Fatalf("inviting a second user → %d", status)
 	}
-	if _, err := o.owner.Exec(ctx,
+	if _, err := o.Owner.Exec(ctx,
 		`INSERT INTO passport (workspace_id, on_behalf_of, granted_by, label, scopes, token_hash, expires_at)
 		 SELECT workspace_id, id, id, 'not mine', ARRAY['read']::text[], 'other-user-'||id, now() + interval '1 day'
 		 FROM app_user WHERE id = $1`, other.ID); err != nil {
@@ -199,14 +201,14 @@ func TestSelectablePassportsExcludesAnotherUsersPassport(t *testing.T) {
 // /oauth/register, but that endpoint is itself part of the connector's
 // gated route group — unavailable in exactly the deployment state (connector
 // off) a test needs a live client to probe.
-func registerClientDirectly(t *testing.T, e *env, clientID string) {
+func registerClientDirectly(t *testing.T, e *apptest.AppEnv, clientID string) {
 	t.Helper()
 	ctx := context.Background()
 	var wsID string
-	if err := e.owner.QueryRow(ctx, `SELECT id FROM workspace WHERE slug = $1`, e.slug).Scan(&wsID); err != nil {
+	if err := e.Owner.QueryRow(ctx, `SELECT id FROM workspace WHERE slug = $1`, e.Slug).Scan(&wsID); err != nil {
 		t.Fatalf("looking up the workspace: %v", err)
 	}
-	if _, err := e.owner.Exec(ctx,
+	if _, err := e.Owner.Exec(ctx,
 		`INSERT INTO oauth_client (workspace_id, client_id, client_name, redirect_uris)
 		 VALUES ($1, $2, 'directly registered', ARRAY['https://client.example/cb']::text[])`,
 		wsID, clientID); err != nil {
@@ -234,26 +236,26 @@ func TestConsentRequestFollowsTheConnectorSwitch(t *testing.T) {
 	var unbindable [2]int
 
 	t.Run("off", func(t *testing.T) {
-		e := setup(t)
-		e.bootstrapWorkspace(t)
+		e := apptest.SetupApp(t)
+		e.BootstrapWorkspace(t)
 		registerClientDirectly(t, e, clientID)
 
-		status := e.call(t, "GET", "/v1/oauth/consent-request?client_id="+clientID+"&scope=read", nil, nil, nil)
+		status := e.Call(t, "GET", "/v1/oauth/consent-request?client_id="+clientID+"&scope=read", nil, nil, nil)
 		if status != http.StatusNotFound {
 			t.Fatalf("consent-request for a live client, connector off → %d, want 404", status)
 		}
-		unbindable[0] = e.call(t, "GET", "/v1/oauth/consent-request?client_id="+clientID, nil, nil, nil)
+		unbindable[0] = e.Call(t, "GET", "/v1/oauth/consent-request?client_id="+clientID, nil, nil, nil)
 	})
 
 	t.Run("on", func(t *testing.T) {
 		c := setupConnector(t)
-		registerClientDirectly(t, c.env, clientID)
+		registerClientDirectly(t, c.AppEnv, clientID)
 
-		status := c.call(t, "GET", "/v1/oauth/consent-request?client_id="+clientID+"&scope=read", nil, nil, nil)
+		status := c.Call(t, "GET", "/v1/oauth/consent-request?client_id="+clientID+"&scope=read", nil, nil, nil)
 		if status != http.StatusOK {
 			t.Fatalf("consent-request for the same live client, connector on → %d, want 200", status)
 		}
-		unbindable[1] = c.call(t, "GET", "/v1/oauth/consent-request?client_id="+clientID, nil, nil, nil)
+		unbindable[1] = c.Call(t, "GET", "/v1/oauth/consent-request?client_id="+clientID, nil, nil, nil)
 	})
 
 	if unbindable[0] != http.StatusUnprocessableEntity || unbindable[1] != unbindable[0] {
@@ -269,21 +271,21 @@ func TestConsentRequestFollowsTheConnectorSwitch(t *testing.T) {
 func (o *oauthEnv) authorizeNoFollow(t *testing.T, extra url.Values) (int, string, string, []*http.Cookie) {
 	t.Helper()
 	req, err := http.NewRequest(http.MethodGet,
-		o.ts.URL+"/oauth/authorize?"+o.authorizeQuery(extra).Encode(), nil)
+		o.TS.URL+"/oauth/authorize?"+o.authorizeQuery(extra).Encode(), nil)
 	if err != nil {
 		t.Fatalf("building the authorize request: %v", err)
 	}
 	// o.client carries the signed-in human's session in its jar and trusts the
 	// harness's TLS certificate; a fresh http.Client would have neither.
-	o.client.CheckRedirect = func(*http.Request, []*http.Request) error {
+	o.Client.CheckRedirect = func(*http.Request, []*http.Request) error {
 		return http.ErrUseLastResponse
 	}
-	defer func() { o.client.CheckRedirect = nil }()
-	resp, err := o.client.Do(req)
+	defer func() { o.Client.CheckRedirect = nil }()
+	resp, err := o.Client.Do(req) //nolint:bodyclose // closed by the deferred apptest.CloseBody below; bodyclose only sees a Close in the same package, and the closer moved out with the fixture
 	if err != nil {
 		t.Fatalf("authorize: %v", err)
 	}
-	defer closeBody(t, resp)
+	defer apptest.CloseBody(t, resp)
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("reading body: %v", err)

--- a/backend/internal/compose/integration/oauth_consent_refusal_integration_test.go
+++ b/backend/internal/compose/integration/oauth_consent_refusal_integration_test.go
@@ -27,6 +27,8 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 )
 
 // consentScreenHandback reads the fragment a refused consent POST answered with
@@ -245,7 +247,7 @@ func TestAnUnauthenticatedAuthorizeGetRoutesTheHumanToSignIn(t *testing.T) {
 	o := setupOAuth(t)
 
 	req, err := http.NewRequest(http.MethodGet,
-		o.ts.URL+"/oauth/authorize?"+o.authorizeQuery(nil).Encode(), nil)
+		o.TS.URL+"/oauth/authorize?"+o.authorizeQuery(nil).Encode(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -255,7 +257,7 @@ func TestAnUnauthenticatedAuthorizeGetRoutesTheHumanToSignIn(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer closeBody(t, resp)
+	defer apptest.CloseBody(t, resp)
 
 	if resp.StatusCode != http.StatusFound {
 		t.Fatalf("unauthenticated authorize GET → %d, want 302 to the consent screen (a JSON 401 is a dead end)", resp.StatusCode)

--- a/backend/internal/compose/integration/oauth_grant_integration_test.go
+++ b/backend/internal/compose/integration/oauth_grant_integration_test.go
@@ -56,7 +56,7 @@ func TestCodeExchangeIssuesAGrantAndItsFirstRefreshToken(t *testing.T) {
 		refreshAllowed bool
 		revokedAt      *time.Time
 	)
-	if err := o.owner.QueryRow(ctx,
+	if err := o.Owner.QueryRow(ctx,
 		`SELECT id, scopes, refresh_allowed, revoked_at FROM oauth_grant`).
 		Scan(&grantID, &grantScopes, &refreshAllowed, &revokedAt); err != nil {
 		t.Fatalf("reading the grant: %v", err)
@@ -71,7 +71,7 @@ func TestCodeExchangeIssuesAGrantAndItsFirstRefreshToken(t *testing.T) {
 	// The passport the client calls with points at that grant, so revoking
 	// the connection reaches the credential.
 	var stamped string
-	if err := o.owner.QueryRow(ctx,
+	if err := o.Owner.QueryRow(ctx,
 		`SELECT oauth_grant_id FROM passport WHERE token_hash = $1`,
 		sha256Hex(body["access_token"].(string))).Scan(&stamped); err != nil {
 		t.Fatalf("reading the minted passport's grant: %v", err)
@@ -88,7 +88,7 @@ func TestCodeExchangeIssuesAGrantAndItsFirstRefreshToken(t *testing.T) {
 		replacedBy *string
 		expiresAt  time.Time
 	)
-	if err := o.owner.QueryRow(ctx,
+	if err := o.Owner.QueryRow(ctx,
 		`SELECT token_hash, consumed_at, replaced_by, expires_at FROM oauth_refresh_token WHERE grant_id = $1`,
 		grantID).Scan(&tokenHash, &consumedAt, &replacedBy, &expiresAt); err != nil {
 		t.Fatalf("reading the refresh row under the grant: %v", err)
@@ -124,7 +124,7 @@ func TestCodeExchangeAfterTheHumanIsDeactivatedIssuesNoGrant(t *testing.T) {
 
 	// Every member, so the assertion does not depend on WHICH fixture user the
 	// consent screen bound the code to.
-	if _, err := o.owner.Exec(ctx,
+	if _, err := o.Owner.Exec(ctx,
 		`UPDATE app_user SET status = 'deactivated' WHERE status = 'active'`); err != nil {
 		t.Fatalf("deactivating the consenting members: %v", err)
 	}
@@ -197,7 +197,7 @@ func TestCodeExchangeWithoutOfflineAccessReturnsNoRefreshToken(t *testing.T) {
 
 	assertOwnerCount(t, o, 1, `SELECT count(*) FROM oauth_grant`)
 	var refreshAllowed bool
-	if err := o.owner.QueryRow(context.Background(),
+	if err := o.Owner.QueryRow(context.Background(),
 		`SELECT refresh_allowed FROM oauth_grant`).Scan(&refreshAllowed); err != nil {
 		t.Fatalf("reading the grant: %v", err)
 	}

--- a/backend/internal/compose/integration/oauth_integration_test.go
+++ b/backend/internal/compose/integration/oauth_integration_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 )
 
 type oauthEnv struct {
@@ -56,7 +57,7 @@ func setupOAuthWith(t *testing.T, extra ...compose.Option) *oauthEnv {
 	var registered struct {
 		ClientID string `json:"client_id"`
 	}
-	if status := e.call(t, "POST", "/oauth/register", anyMap{
+	if status := e.Call(t, "POST", "/oauth/register", apptest.AnyMap{
 		"client_name": "night agent", "redirect_uris": []string{oauthRedirect},
 	}, nil, &registered); status != http.StatusCreated || registered.ClientID == "" {
 		t.Fatalf("DCR → %d %+v", status, registered)
@@ -96,11 +97,11 @@ func (o *oauthEnv) authorizeQuery(extra url.Values) url.Values {
 // "want 200" check would abort the test before the assertion runs.
 func (o *oauthEnv) authorizeRaw(t *testing.T, extra url.Values) (int, string) {
 	t.Helper()
-	req, err := http.NewRequest(http.MethodGet, o.ts.URL+"/oauth/authorize?"+o.authorizeQuery(extra).Encode(), nil)
+	req, err := http.NewRequest(http.MethodGet, o.TS.URL+"/oauth/authorize?"+o.authorizeQuery(extra).Encode(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp, err := o.client.Do(req)
+	resp, err := o.Client.Do(req) //nolint:bodyclose // closed by apptest.CloseBody once the body is read, below; bodyclose only sees a Close in the same package, and the closer moved out with the fixture
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -108,7 +109,7 @@ func (o *oauthEnv) authorizeRaw(t *testing.T, extra url.Values) (int, string) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	closeBody(t, resp)
+	apptest.CloseBody(t, resp)
 	return resp.StatusCode, string(body)
 }
 
@@ -157,18 +158,18 @@ func (o *oauthEnv) armConsent(t *testing.T, extra url.Values) url.Values {
 // assertion target rather than whatever it points at.
 func (o *oauthEnv) postConsent(t *testing.T, form url.Values) (status int, location, body string) {
 	t.Helper()
-	post, err := http.NewRequest(http.MethodPost, o.ts.URL+"/oauth/authorize", strings.NewReader(form.Encode()))
+	post, err := http.NewRequest(http.MethodPost, o.TS.URL+"/oauth/authorize", strings.NewReader(form.Encode()))
 	if err != nil {
 		t.Fatal(err)
 	}
 	post.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	o.client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
-	defer func() { o.client.CheckRedirect = nil }()
-	resp, err := o.client.Do(post)
+	o.Client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	defer func() { o.Client.CheckRedirect = nil }()
+	resp, err := o.Client.Do(post) //nolint:bodyclose // closed by the deferred apptest.CloseBody below; bodyclose only sees a Close in the same package, and the closer moved out with the fixture
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer closeBody(t, resp)
+	defer apptest.CloseBody(t, resp)
 	raw, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("reading the consent POST's body: %v", err)
@@ -222,15 +223,6 @@ func (o *oauthEnv) authorize(t *testing.T, extra url.Values) string {
 	return granted.Query().Get("code")
 }
 
-// closeBody closes a response body and fails the test on a dirty close —
-// a broken close can hide a truncated read.
-func closeBody(t *testing.T, resp *http.Response) {
-	t.Helper()
-	if err := resp.Body.Close(); err != nil {
-		t.Errorf("closing response body: %v", err)
-	}
-}
-
 // exchange drives POST /oauth/token for the authorization-code grant and
 // returns status + parsed body.
 func (o *oauthEnv) exchange(t *testing.T, form url.Values) (int, map[string]any) {
@@ -252,16 +244,16 @@ func (o *oauthEnv) exchange(t *testing.T, form url.Values) (int, map[string]any)
 // in how the suite drives them.
 func (o *oauthEnv) postToken(t *testing.T, form url.Values) (int, map[string]any) {
 	t.Helper()
-	req, err := http.NewRequest(http.MethodPost, o.ts.URL+"/oauth/token", strings.NewReader(form.Encode()))
+	req, err := http.NewRequest(http.MethodPost, o.TS.URL+"/oauth/token", strings.NewReader(form.Encode()))
 	if err != nil {
 		t.Fatal(err)
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	resp, err := o.client.Do(req)
+	resp, err := o.Client.Do(req) //nolint:bodyclose // closed by the deferred apptest.CloseBody below; bodyclose only sees a Close in the same package, and the closer moved out with the fixture
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer closeBody(t, resp)
+	defer apptest.CloseBody(t, resp)
 	var body map[string]any
 	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil && !errors.Is(err, io.EOF) {
 		t.Fatalf("token response is not JSON: %v", err)
@@ -277,7 +269,7 @@ func TestOAuthHandshakeMintsAWorkingPassport(t *testing.T) {
 		TokenEndpoint string   `json:"token_endpoint"`
 		Methods       []string `json:"code_challenge_methods_supported"`
 	}
-	if status := o.call(t, "GET", "/.well-known/oauth-authorization-server", nil, nil, &metadata); status != http.StatusOK {
+	if status := o.Call(t, "GET", "/.well-known/oauth-authorization-server", nil, nil, &metadata); status != http.StatusOK {
 		t.Fatalf("discovery → %d", status)
 	}
 	if !strings.HasSuffix(metadata.TokenEndpoint, "/oauth/token") || len(metadata.Methods) != 1 || metadata.Methods[0] != "S256" {
@@ -306,7 +298,7 @@ func TestOAuthHandshakeMintsAWorkingPassport(t *testing.T) {
 
 	// The minted Bearer works on the resource surface.
 	bearer := map[string]string{"Authorization": "Bearer " + token}
-	if status := o.call(t, "GET", "/v1/people", nil, bearer, nil); status != http.StatusOK {
+	if status := o.Call(t, "GET", "/v1/people", nil, bearer, nil); status != http.StatusOK {
 		t.Fatalf("bearer GET /v1/people → %d", status)
 	}
 }
@@ -322,14 +314,14 @@ func TestOAuthConsentGateBlocksSilentAuthorization(t *testing.T) {
 		"code_challenge": {o.challenge()}, "code_challenge_method": {"S256"},
 	}
 	// GET answers with the consent screen, never a redirect carrying a code.
-	req, _ := http.NewRequest(http.MethodGet, o.ts.URL+"/oauth/authorize?"+q.Encode(), nil)
-	o.client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
-	resp, err := o.client.Do(req)
-	o.client.CheckRedirect = nil
+	req, _ := http.NewRequest(http.MethodGet, o.TS.URL+"/oauth/authorize?"+q.Encode(), nil)
+	o.Client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	resp, err := o.Client.Do(req) //nolint:bodyclose // closed by the deferred apptest.CloseBody below; bodyclose only sees a Close in the same package, and the closer moved out with the fixture
+	o.Client.CheckRedirect = nil
 	if err != nil {
 		t.Fatal(err)
 	}
-	closeBody(t, resp)
+	apptest.CloseBody(t, resp)
 	location := resp.Header.Get("Location")
 	if resp.StatusCode != http.StatusFound || !strings.HasPrefix(location, "/#/oauth-consent?") {
 		t.Fatalf("GET authorize → %d %q, want the consent screen, never a code", resp.StatusCode, location)
@@ -347,15 +339,15 @@ func TestOAuthConsentGateBlocksSilentAuthorization(t *testing.T) {
 		form[k] = vs
 	}
 	form.Set("consent", "forged")
-	post, _ := http.NewRequest(http.MethodPost, o.ts.URL+"/oauth/authorize", strings.NewReader(form.Encode()))
+	post, _ := http.NewRequest(http.MethodPost, o.TS.URL+"/oauth/authorize", strings.NewReader(form.Encode()))
 	post.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	o.client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
-	resp, err = o.client.Do(post)
-	o.client.CheckRedirect = nil
+	o.Client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	resp, err = o.Client.Do(post) //nolint:bodyclose // closed by the deferred apptest.CloseBody below; bodyclose only sees a Close in the same package, and the closer moved out with the fixture
+	o.Client.CheckRedirect = nil
 	if err != nil {
 		t.Fatal(err)
 	}
-	closeBody(t, resp)
+	apptest.CloseBody(t, resp)
 	if location := resp.Header.Get("Location"); strings.Contains(location, "code=") {
 		t.Fatalf("forged consent POST → %q, which carries a code", location)
 	}
@@ -364,14 +356,14 @@ func TestOAuthConsentGateBlocksSilentAuthorization(t *testing.T) {
 	// A browser-stamped cross-site POST is refused OUTRIGHT — no redirect, not
 	// even to the consent screen. This is not a human who took too long: the
 	// initiator was another site, so there is nobody to send back to a screen.
-	post2, _ := http.NewRequest(http.MethodPost, o.ts.URL+"/oauth/authorize", strings.NewReader(form.Encode()))
+	post2, _ := http.NewRequest(http.MethodPost, o.TS.URL+"/oauth/authorize", strings.NewReader(form.Encode()))
 	post2.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	post2.Header.Set("Sec-Fetch-Site", "cross-site")
-	resp, err = o.client.Do(post2)
+	resp, err = o.Client.Do(post2) //nolint:bodyclose // closed by the deferred apptest.CloseBody below; bodyclose only sees a Close in the same package, and the closer moved out with the fixture
 	if err != nil {
 		t.Fatal(err)
 	}
-	closeBody(t, resp)
+	apptest.CloseBody(t, resp)
 	if resp.StatusCode != http.StatusForbidden {
 		t.Fatalf("cross-site consent POST → %d, want 403", resp.StatusCode)
 	}
@@ -385,7 +377,7 @@ func TestOAuthRefusesDowngradesAndPrivilegedClients(t *testing.T) {
 
 	// No confidential clients, ever.
 	var problem map[string]any
-	if status := o.call(t, "POST", "/oauth/register", anyMap{
+	if status := o.Call(t, "POST", "/oauth/register", apptest.AnyMap{
 		"client_name": "privileged", "redirect_uris": []string{oauthRedirect},
 		"token_endpoint_auth_method": "client_secret_basic",
 	}, nil, &problem); status != http.StatusBadRequest {
@@ -405,12 +397,12 @@ func TestOAuthRefusesDowngradesAndPrivilegedClients(t *testing.T) {
 		for k, vs := range extra {
 			q[k] = vs
 		}
-		req, _ := http.NewRequest(http.MethodGet, o.ts.URL+"/oauth/authorize?"+q.Encode(), nil)
-		resp, err := o.client.Do(req)
+		req, _ := http.NewRequest(http.MethodGet, o.TS.URL+"/oauth/authorize?"+q.Encode(), nil)
+		resp, err := o.Client.Do(req) //nolint:bodyclose // closed by the deferred apptest.CloseBody below; bodyclose only sees a Close in the same package, and the closer moved out with the fixture
 		if err != nil {
 			t.Fatal(err)
 		}
-		closeBody(t, resp)
+		apptest.CloseBody(t, resp)
 		if resp.StatusCode != http.StatusBadRequest {
 			t.Fatalf("%s → %d, want 400", name, resp.StatusCode)
 		}
@@ -445,7 +437,7 @@ func TestAuthorizeRefusesAForeignResourceBeforeMintingACode(t *testing.T) {
 		t.Fatalf("authorize with a foreign resource → %d %s, want 400 invalid_target", status, body)
 	}
 	var codes int
-	if err := o.owner.QueryRow(context.Background(),
+	if err := o.Owner.QueryRow(context.Background(),
 		`SELECT count(*) FROM oauth_authorization_code`).Scan(&codes); err != nil {
 		t.Fatal(err)
 	}
@@ -462,7 +454,7 @@ func TestAuthorizeRefusesAForeignResourceBeforeMintingACode(t *testing.T) {
 func assertOwnerCount(t *testing.T, o *oauthEnv, want int, query string, args ...any) {
 	t.Helper()
 	var got int
-	if err := o.owner.QueryRow(context.Background(), query, args...).Scan(&got); err != nil {
+	if err := o.Owner.QueryRow(context.Background(), query, args...).Scan(&got); err != nil {
 		t.Fatalf("counting rows for %s: %v", query, err)
 	}
 	if got != want {

--- a/backend/internal/compose/integration/oauth_lend_integration_test.go
+++ b/backend/internal/compose/integration/oauth_lend_integration_test.go
@@ -21,6 +21,8 @@ import (
 	"slices"
 	"strings"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 )
 
 // approve is one consent decision that LENDS a named passport: the GET arms the
@@ -159,7 +161,7 @@ func TestApproveAuditsWhichPassportWasLent(t *testing.T) {
 	// The human whose authority was lent, derived from the row the flow itself
 	// wrote rather than restated — the audit actor must be that same human.
 	var human string
-	if err := o.owner.QueryRow(ctx,
+	if err := o.Owner.QueryRow(ctx,
 		`SELECT on_behalf_of FROM passport WHERE id = $1`, lent).Scan(&human); err != nil {
 		t.Fatalf("reading the lent passport's human: %v", err)
 	}
@@ -172,7 +174,7 @@ func TestApproveAuditsWhichPassportWasLent(t *testing.T) {
 		action, actorType, actorID, entityID string
 		afterJSON                            []byte
 	)
-	if err := o.owner.QueryRow(ctx, `
+	if err := o.Owner.QueryRow(ctx, `
 		SELECT action, actor_type, actor_id, entity_id, after
 		FROM audit_log WHERE entity_type = 'oauth_authorization_code'`).
 		Scan(&action, &actorType, &actorID, &entityID, &afterJSON); err != nil {
@@ -185,7 +187,7 @@ func TestApproveAuditsWhichPassportWasLent(t *testing.T) {
 	// It hangs off the code the consent produced, which is what makes the two
 	// rows one fact rather than two coincidences.
 	var codeID string
-	if err := o.owner.QueryRow(ctx, `SELECT id FROM oauth_authorization_code`).Scan(&codeID); err != nil {
+	if err := o.Owner.QueryRow(ctx, `SELECT id FROM oauth_authorization_code`).Scan(&codeID); err != nil {
 		t.Fatalf("reading the authorization code row: %v", err)
 	}
 	if entityID != codeID {
@@ -326,13 +328,13 @@ func TestAPendingConsentDoesNotSurviveItsHumansDeactivation(t *testing.T) {
 	// no way back. A second admin is what the guard is protecting against, so
 	// inviting one is what lets the real endpoint run.
 	var second userWire
-	if status := o.call(t, "POST", "/v1/users", anyMap{
+	if status := o.Call(t, "POST", "/v1/users", apptest.AnyMap{
 		"email": "second-admin@fable.test", "display_name": "Second Admin", "role": "admin",
 	}, nil, &second); status != http.StatusCreated {
 		t.Fatalf("inviting a second admin → %d", status)
 	}
 	granter := o.userIDByEmail(t, "granter@fable.test")
-	if status := o.call(t, "POST", "/v1/users/"+granter+"/deactivate", anyMap{
+	if status := o.Call(t, "POST", "/v1/users/"+granter+"/deactivate", apptest.AnyMap{
 		"reason": "left the company",
 	}, nil, nil); status != http.StatusOK {
 		t.Fatalf("deactivate → %d", status)
@@ -342,7 +344,7 @@ func TestAPendingConsentDoesNotSurviveItsHumansDeactivation(t *testing.T) {
 	// restores nothing else. Driven over SQL rather than the endpoint because
 	// the deactivation just revoked the only session this suite can call with,
 	// and whether an admin can log in is not what this test is about.
-	if _, err := o.owner.Exec(context.Background(),
+	if _, err := o.Owner.Exec(context.Background(),
 		`UPDATE app_user SET status = 'active' WHERE id = $1`, granter); err != nil {
 		t.Fatalf("reactivating the human: %v", err)
 	}
@@ -370,7 +372,7 @@ func TestAPendingConsentDoesNotSurviveItsHumansDeactivation(t *testing.T) {
 func (o *oauthEnv) userIDByEmail(t *testing.T, email string) string {
 	t.Helper()
 	var id string
-	if err := o.owner.QueryRow(context.Background(),
+	if err := o.Owner.QueryRow(context.Background(),
 		`SELECT id FROM app_user WHERE email = $1`, email).Scan(&id); err != nil {
 		t.Fatalf("resolving %s: %v", email, err)
 	}

--- a/backend/internal/compose/integration/oauth_refresh_integration_test.go
+++ b/backend/internal/compose/integration/oauth_refresh_integration_test.go
@@ -101,12 +101,12 @@ func (o *oauthEnv) presentInParallel(refreshToken string, n int) []renewal {
 // present posts one already-encoded token-endpoint form, reporting failures
 // as values so it is safe to call off the test goroutine.
 func (o *oauthEnv) present(form string) renewal {
-	req, err := http.NewRequest(http.MethodPost, o.ts.URL+"/oauth/token", strings.NewReader(form))
+	req, err := http.NewRequest(http.MethodPost, o.TS.URL+"/oauth/token", strings.NewReader(form))
 	if err != nil {
 		return renewal{err: err}
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	resp, err := o.client.Do(req)
+	resp, err := o.Client.Do(req)
 	if err != nil {
 		return renewal{err: err}
 	}
@@ -135,7 +135,7 @@ func (o *oauthEnv) grantRevoked(t *testing.T) bool {
 	t.Helper()
 	assertOwnerCount(t, o, 1, `SELECT count(*) FROM oauth_grant`)
 	var revokedAt *time.Time
-	if err := o.owner.QueryRow(context.Background(),
+	if err := o.Owner.QueryRow(context.Background(),
 		`SELECT revoked_at FROM oauth_grant`).Scan(&revokedAt); err != nil {
 		t.Fatalf("reading the grant: %v", err)
 	}
@@ -154,7 +154,7 @@ func (o *oauthEnv) assertChainLinked(t *testing.T, presented, successor string) 
 		consumedAt *time.Time
 		replacedBy *string
 	)
-	if err := o.owner.QueryRow(ctx,
+	if err := o.Owner.QueryRow(ctx,
 		`SELECT consumed_at, replaced_by FROM oauth_refresh_token WHERE token_hash = $1`,
 		sha256Hex(presented)).Scan(&consumedAt, &replacedBy); err != nil {
 		t.Fatalf("reading the presented refresh row: %v", err)
@@ -166,7 +166,7 @@ func (o *oauthEnv) assertChainLinked(t *testing.T, presented, successor string) 
 		successorID string
 		expiresAt   time.Time
 	)
-	if err := o.owner.QueryRow(ctx,
+	if err := o.Owner.QueryRow(ctx,
 		`SELECT id, expires_at FROM oauth_refresh_token WHERE token_hash = $1`,
 		sha256Hex(successor)).Scan(&successorID, &expiresAt); err != nil {
 		t.Fatalf("reading the successor refresh row: %v", err)
@@ -183,7 +183,7 @@ func (o *oauthEnv) assertChainLinked(t *testing.T, presented, successor string) 
 // authority — the only question a connector's user actually cares about.
 func (o *oauthEnv) accessTokenWorks(t *testing.T, accessToken string) bool {
 	t.Helper()
-	status := o.call(t, "GET", "/v1/people", nil, map[string]string{"Authorization": "Bearer " + accessToken}, nil)
+	status := o.Call(t, "GET", "/v1/people", nil, map[string]string{"Authorization": "Bearer " + accessToken}, nil)
 	switch status {
 	case http.StatusOK:
 		return true
@@ -358,7 +358,7 @@ func TestReplayedRefreshOutsideTheWindowRevokesEverything(t *testing.T) {
 	// Age the consumption past the grace window instead of waiting for it:
 	// the rule is a comparison against a clock, so moving the timestamp
 	// proves the same transition a sleep would.
-	if _, err := o.owner.Exec(context.Background(),
+	if _, err := o.Owner.Exec(context.Background(),
 		`UPDATE oauth_refresh_token SET consumed_at = now() - interval '5 minutes' WHERE token_hash = $1`,
 		sha256Hex(firstRefresh)); err != nil {
 		t.Fatalf("ageing the consumption: %v", err)
@@ -436,7 +436,7 @@ func TestRefreshNarrowsScopesButNeverWidensThem(t *testing.T) {
 	}
 	narrowed, _ := body["access_token"].(string)
 	var scopes []string
-	if err := o.owner.QueryRow(context.Background(),
+	if err := o.Owner.QueryRow(context.Background(),
 		`SELECT scopes FROM passport WHERE token_hash = $1`,
 		sha256Hex(narrowed)).Scan(&scopes); err != nil {
 		t.Fatalf("reading the rotated passport: %v", err)

--- a/backend/internal/compose/integration/oauth_revocation_integration_test.go
+++ b/backend/internal/compose/integration/oauth_revocation_integration_test.go
@@ -23,6 +23,8 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 )
 
 // connectedClient is a connector that finished the handshake: the harness, the
@@ -48,7 +50,7 @@ func setupConnectedClient(t *testing.T) *connectedClient {
 // answer that sends a client back to the human for consent.
 func (c *connectedClient) callMCP(t *testing.T) int {
 	t.Helper()
-	return c.listTools(t, c.access).StatusCode
+	return listTools(c.AppEnv, t, c.access).StatusCode
 }
 
 // refreshSucceeds reports whether the client can still mint itself a fresh
@@ -74,11 +76,11 @@ func (c *connectedClient) refreshSucceeds(t *testing.T) bool {
 func (c *connectedClient) revokePassport(t *testing.T) {
 	t.Helper()
 	var passportID string
-	if err := c.owner.QueryRow(context.Background(),
+	if err := c.Owner.QueryRow(context.Background(),
 		`SELECT id FROM passport WHERE token_hash = $1`, sha256Hex(c.access)).Scan(&passportID); err != nil {
 		t.Fatalf("reading the passport the client holds: %v", err)
 	}
-	if status := c.call(t, "DELETE", "/v1/passports/"+passportID, nil, nil, nil); status != http.StatusNoContent {
+	if status := c.Call(t, "DELETE", "/v1/passports/"+passportID, nil, nil, nil); status != http.StatusNoContent {
 		t.Fatalf("DELETE /v1/passports/%s → %d", passportID, status)
 	}
 }
@@ -118,7 +120,7 @@ func (o *oauthEnv) deleteClient(t *testing.T) {
 // session, so posting through it exercises the session-authenticated path and
 // says nothing about the one every real client takes.
 func (o *oauthEnv) sessionlessClient() *http.Client {
-	return &http.Client{Transport: o.ts.Client().Transport}
+	return &http.Client{Transport: o.TS.Client().Transport}
 }
 
 // revoke posts one presented token to RFC 7009 and returns the status alone
@@ -131,7 +133,7 @@ func (o *oauthEnv) revoke(t *testing.T, token, tokenTypeHint string) int {
 	if tokenTypeHint != "" {
 		form.Set("token_type_hint", tokenTypeHint)
 	}
-	req, err := http.NewRequest(http.MethodPost, o.ts.URL+"/oauth/revoke", strings.NewReader(form.Encode()))
+	req, err := http.NewRequest(http.MethodPost, o.TS.URL+"/oauth/revoke", strings.NewReader(form.Encode()))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -140,7 +142,7 @@ func (o *oauthEnv) revoke(t *testing.T, token, tokenTypeHint string) int {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer closeBody(t, resp)
+	defer apptest.CloseBody(t, resp)
 	return resp.StatusCode
 }
 
@@ -151,7 +153,7 @@ func (o *oauthEnv) revoke(t *testing.T, token, tokenTypeHint string) int {
 //craft:ignore naked-any pgx query arguments are untyped by the driver's own signature
 func (o *oauthEnv) cut(t *testing.T, statement string, args ...any) {
 	t.Helper()
-	tag, err := o.owner.Exec(context.Background(), statement, args...)
+	tag, err := o.Owner.Exec(context.Background(), statement, args...)
 	if err != nil {
 		t.Fatalf("cutting the connection off with %s: %v", statement, err)
 	}
@@ -287,7 +289,7 @@ func TestALocallyMintedPassportIsUnaffectedByADeadConnector(t *testing.T) {
 	var minted struct {
 		Token string `json:"token"`
 	}
-	if status := c.call(t, "POST", "/v1/passports", anyMap{
+	if status := c.Call(t, "POST", "/v1/passports", apptest.AnyMap{
 		"label": "local agent", "scopes": []string{"read"},
 	}, nil, &minted); status != http.StatusCreated {
 		t.Fatalf("issue a local passport → %d", status)
@@ -296,7 +298,7 @@ func TestALocallyMintedPassportIsUnaffectedByADeadConnector(t *testing.T) {
 	c.disableClient(t)
 	c.revokeGrant(t)
 
-	if code := c.listTools(t, minted.Token).StatusCode; code != http.StatusOK {
+	if code := listTools(c.AppEnv, t, minted.Token).StatusCode; code != http.StatusOK {
 		t.Fatalf("locally minted passport → %d, want 200: it answers to no grant", code)
 	}
 	if code := c.callMCP(t); code != http.StatusUnauthorized {
@@ -316,7 +318,7 @@ func TestALocallyMintedPassportIsUnaffectedByADeadConnector(t *testing.T) {
 // concluded from what the same client gets away with elsewhere.
 func (o *oauthEnv) sessionlessGet(t *testing.T, path string) int {
 	t.Helper()
-	req, err := http.NewRequest(http.MethodGet, o.ts.URL+path, nil)
+	req, err := http.NewRequest(http.MethodGet, o.TS.URL+path, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -324,7 +326,7 @@ func (o *oauthEnv) sessionlessGet(t *testing.T, path string) int {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer closeBody(t, resp)
+	defer apptest.CloseBody(t, resp)
 	return resp.StatusCode
 }
 
@@ -427,7 +429,7 @@ func TestDiscoveryAdvertisesTheRevocationEndpoint(t *testing.T) {
 	var metadata struct {
 		RevocationEndpoint string `json:"revocation_endpoint"`
 	}
-	if status := o.call(t, "GET", "/.well-known/oauth-authorization-server", nil, nil, &metadata); status != http.StatusOK {
+	if status := o.Call(t, "GET", "/.well-known/oauth-authorization-server", nil, nil, &metadata); status != http.StatusOK {
 		t.Fatalf("discovery → %d", status)
 	}
 	if !strings.HasSuffix(metadata.RevocationEndpoint, "/oauth/revoke") {

--- a/backend/internal/compose/integration/oauth_surface_integration_test.go
+++ b/backend/internal/compose/integration/oauth_surface_integration_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	"github.com/gradionhq/margince/backend/internal/modules/agents"
 	"github.com/gradionhq/margince/backend/internal/modules/approvals"
 	"github.com/gradionhq/margince/backend/internal/modules/identity"
@@ -43,13 +44,13 @@ func TestApprovalTokenIsASignedEffectBoundJWS(t *testing.T) {
 	var person struct {
 		ID string `json:"id"`
 	}
-	if status := o.call(t, "POST", "/v1/people", anyMap{"full_name": "JWS Target"}, nil, &person); status != http.StatusCreated {
+	if status := o.Call(t, "POST", "/v1/people", apptest.AnyMap{"full_name": "JWS Target"}, nil, &person); status != http.StatusCreated {
 		t.Fatalf("create person → %d", status)
 	}
 	var problem struct {
 		Detail string `json:"detail"`
 	}
-	if status := o.call(t, "DELETE", "/v1/people/"+person.ID, nil, agentBearer, &problem); status != http.StatusForbidden {
+	if status := o.Call(t, "DELETE", "/v1/people/"+person.ID, nil, agentBearer, &problem); status != http.StatusForbidden {
 		t.Fatalf("agent archive → %d, want staged 403", status)
 	}
 	approvalID := extractStagedApprovalID(t, problem.Detail)
@@ -57,7 +58,7 @@ func TestApprovalTokenIsASignedEffectBoundJWS(t *testing.T) {
 	var approved struct {
 		ApprovalToken *string `json:"approval_token"`
 	}
-	if status := o.call(t, "POST", "/v1/approvals/"+approvalID+"/approve", anyMap{}, nil, &approved); status != http.StatusOK {
+	if status := o.Call(t, "POST", "/v1/approvals/"+approvalID+"/approve", apptest.AnyMap{}, nil, &approved); status != http.StatusOK {
 		t.Fatalf("approve → %d", status)
 	}
 	if approved.ApprovalToken == nil || strings.Count(*approved.ApprovalToken, ".") != 2 {
@@ -70,7 +71,7 @@ func TestApprovalTokenIsASignedEffectBoundJWS(t *testing.T) {
 	}
 	t.Cleanup(pool.Close)
 	var wsRaw string
-	if err := o.owner.QueryRow(context.Background(), `SELECT id FROM workspace WHERE slug = $1`, o.slug).Scan(&wsRaw); err != nil {
+	if err := o.Owner.QueryRow(context.Background(), `SELECT id FROM workspace WHERE slug = $1`, o.Slug).Scan(&wsRaw); err != nil {
 		t.Fatal(err)
 	}
 	wsID, err := ids.Parse(wsRaw)
@@ -134,7 +135,7 @@ func TestHostedMCPTransportSharesTheGovernedSurface(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer closeBody(t, resp)
+		defer apptest.CloseBody(t, resp)
 		raw, _ := io.ReadAll(resp.Body)
 		return resp.StatusCode, string(raw)
 	}
@@ -151,11 +152,11 @@ func TestHostedMCPTransportSharesTheGovernedSurface(t *testing.T) {
 	// Revocation binds between two calls: kill the passport via the
 	// session surface, the next hosted call answers 401 + RFC 9728.
 	var passportID string
-	if err := o.owner.QueryRow(context.Background(),
+	if err := o.Owner.QueryRow(context.Background(),
 		`SELECT id FROM passport WHERE token_hash = $1`, sha256Hex(token)).Scan(&passportID); err != nil {
 		t.Fatal(err)
 	}
-	if status := o.call(t, "DELETE", "/v1/passports/"+passportID, nil, nil, nil); status != http.StatusNoContent {
+	if status := o.Call(t, "DELETE", "/v1/passports/"+passportID, nil, nil, nil); status != http.StatusNoContent {
 		t.Fatalf("revoke → %d", status)
 	}
 	req, _ := http.NewRequest(http.MethodPost, hosted.URL, strings.NewReader(`{"jsonrpc":"2.0","id":3,"method":"tools/list"}`))
@@ -164,7 +165,7 @@ func TestHostedMCPTransportSharesTheGovernedSurface(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer closeBody(t, resp)
+	defer apptest.CloseBody(t, resp)
 	if resp.StatusCode != http.StatusUnauthorized || !strings.Contains(resp.Header.Get("WWW-Authenticate"), "oauth-protected-resource") {
 		t.Fatalf("revoked bearer → %d %q, want 401 + RFC 9728 pointer", resp.StatusCode, resp.Header.Get("WWW-Authenticate"))
 	}

--- a/backend/internal/compose/integration/offerpdf_http_integration_test.go
+++ b/backend/internal/compose/integration/offerpdf_http_integration_test.go
@@ -22,18 +22,19 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
 func TestOfferPdfHTTP_DownloadBeforeRenderReturns404(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 	dealID := offerFixture(t, e)
 
-	var offer anyMap
-	if status := e.call(t, "POST", "/v1/deals/"+dealID+"/offers", anyMap{
+	var offer apptest.AnyMap
+	if status := e.Call(t, "POST", "/v1/deals/"+dealID+"/offers", apptest.AnyMap{
 		"currency": "EUR", "source": "manual",
-		"line_items": []anyMap{{"description": "Retainer", "quantity": 1, "unit_price_minor": 500000, "tax_rate": 19.0}},
+		"line_items": []apptest.AnyMap{{"description": "Retainer", "quantity": 1, "unit_price_minor": 500000, "tax_rate": 19.0}},
 	}, nil, &offer); status != http.StatusCreated {
 		t.Fatalf("create offer for pdf download = %d %v", status, offer)
 	}
@@ -42,29 +43,29 @@ func TestOfferPdfHTTP_DownloadBeforeRenderReturns404(t *testing.T) {
 		t.Fatalf("create offer for pdf download response carries no id: %v", offer)
 	}
 
-	if status := e.call(t, "GET", "/v1/offers/"+offerID+"/pdf", nil, nil, nil); status != http.StatusNotFound {
+	if status := e.Call(t, "GET", "/v1/offers/"+offerID+"/pdf", nil, nil, nil); status != http.StatusNotFound {
 		t.Fatalf("download pdf before any render = %d, want 404", status)
 	}
 }
 
 func TestOfferPdfHTTP_DownloadNonexistentOfferReturns404(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 
-	if status := e.call(t, "GET", "/v1/offers/"+ids.NewV7().String()+"/pdf", nil, nil, nil); status != http.StatusNotFound {
+	if status := e.Call(t, "GET", "/v1/offers/"+ids.NewV7().String()+"/pdf", nil, nil, nil); status != http.StatusNotFound {
 		t.Fatalf("download pdf for an offer that was never created = %d, want 404", status)
 	}
 }
 
 func TestOfferPdfHTTP_DownloadWhenTheBlobIsGoneReturns404(t *testing.T) {
 	e, blob := setupWithBlobstore(t)
-	e.bootstrapWorkspace(t)
+	e.BootstrapWorkspace(t)
 	dealID := offerFixture(t, e)
 
-	var offer anyMap
-	if status := e.call(t, "POST", "/v1/deals/"+dealID+"/offers", anyMap{
+	var offer apptest.AnyMap
+	if status := e.Call(t, "POST", "/v1/deals/"+dealID+"/offers", apptest.AnyMap{
 		"currency": "EUR", "source": "manual",
-		"line_items": []anyMap{{"description": "Retainer", "quantity": 1, "unit_price_minor": 500000, "tax_rate": 19.0}},
+		"line_items": []apptest.AnyMap{{"description": "Retainer", "quantity": 1, "unit_price_minor": 500000, "tax_rate": 19.0}},
 	}, nil, &offer); status != http.StatusCreated {
 		t.Fatalf("create offer for pdf download = %d %v", status, offer)
 	}
@@ -74,7 +75,7 @@ func TestOfferPdfHTTP_DownloadWhenTheBlobIsGoneReturns404(t *testing.T) {
 	}
 
 	var rendered renderedOffer
-	if status := e.call(t, "POST", "/v1/offers/"+offerID+"/render", anyMap{}, nil, &rendered); status != http.StatusOK {
+	if status := e.Call(t, "POST", "/v1/offers/"+offerID+"/render", apptest.AnyMap{}, nil, &rendered); status != http.StatusOK {
 		t.Fatalf("render offer = %d %+v, want 200", status, rendered)
 	}
 
@@ -85,20 +86,20 @@ func TestOfferPdfHTTP_DownloadWhenTheBlobIsGoneReturns404(t *testing.T) {
 		t.Fatalf("delete the rendered blob out from under its ref: %v", err)
 	}
 
-	if status := e.call(t, "GET", "/v1/offers/"+offerID+"/pdf", nil, nil, nil); status != http.StatusNotFound {
+	if status := e.Call(t, "GET", "/v1/offers/"+offerID+"/pdf", nil, nil, nil); status != http.StatusNotFound {
 		t.Fatalf("download pdf after the blob is gone = %d, want 404", status)
 	}
 }
 
 func TestOfferPdfHTTP_DownloadAfterRenderReturnsTheRenderedBytes(t *testing.T) {
 	e, _ := setupWithBlobstore(t)
-	e.bootstrapWorkspace(t)
+	e.BootstrapWorkspace(t)
 	dealID := offerFixture(t, e)
 
-	var offer anyMap
-	if status := e.call(t, "POST", "/v1/deals/"+dealID+"/offers", anyMap{
+	var offer apptest.AnyMap
+	if status := e.Call(t, "POST", "/v1/deals/"+dealID+"/offers", apptest.AnyMap{
 		"currency": "EUR", "source": "manual",
-		"line_items": []anyMap{{"description": "Retainer", "quantity": 1, "unit_price_minor": 500000, "tax_rate": 19.0}},
+		"line_items": []apptest.AnyMap{{"description": "Retainer", "quantity": 1, "unit_price_minor": 500000, "tax_rate": 19.0}},
 	}, nil, &offer); status != http.StatusCreated {
 		t.Fatalf("create offer for pdf download = %d %v", status, offer)
 	}
@@ -108,20 +109,20 @@ func TestOfferPdfHTTP_DownloadAfterRenderReturnsTheRenderedBytes(t *testing.T) {
 	}
 
 	var rendered renderedOffer
-	if status := e.call(t, "POST", "/v1/offers/"+offerID+"/render", anyMap{}, nil, &rendered); status != http.StatusOK {
+	if status := e.Call(t, "POST", "/v1/offers/"+offerID+"/render", apptest.AnyMap{}, nil, &rendered); status != http.StatusOK {
 		t.Fatalf("render offer = %d %+v, want 200", status, rendered)
 	}
 
-	req, err := http.NewRequest(http.MethodGet, e.ts.URL+"/v1/offers/"+offerID+"/pdf", nil)
+	req, err := http.NewRequest(http.MethodGet, e.TS.URL+"/v1/offers/"+offerID+"/pdf", nil)
 	if err != nil {
 		t.Fatalf("building pdf download request: %v", err)
 	}
-	req.Header.Set("X-Workspace-Slug", e.slug)
-	resp, err := e.client.Do(req)
+	req.Header.Set("X-Workspace-Slug", e.Slug)
+	resp, err := e.Client.Do(req) //nolint:bodyclose // closed by the deferred apptest.CloseBody below; bodyclose only sees a Close in the same package, and the closer moved out with the fixture
 	if err != nil {
 		t.Fatalf("GET pdf: %v", err)
 	}
-	defer closeBody(t, resp)
+	defer apptest.CloseBody(t, resp)
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("download pdf after render = %d, want 200", resp.StatusCode)
 	}

--- a/backend/internal/compose/integration/offerregenerate_http_integration_test.go
+++ b/backend/internal/compose/integration/offerregenerate_http_integration_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	"github.com/gradionhq/margince/backend/internal/modules/ai"
 	"github.com/gradionhq/margince/backend/internal/modules/search"
 	"github.com/gradionhq/margince/backend/internal/modules/signals"
@@ -40,7 +41,7 @@ import (
 // SchemaPool(t) already established for WithSchemaPool. fake is handed
 // back so the caller can script it AFTER seeding its deal context (the
 // scripted candidate needs to cite a source_id minted during that seed).
-func setupWithOfferDraft(t *testing.T) (*env, *ai.FakeClient) {
+func setupWithOfferDraft(t *testing.T) (*apptest.AppEnv, *ai.FakeClient) {
 	t.Helper()
 	appDSN := os.Getenv("MARGINCE_TEST_APP_DSN")
 	if appDSN == "" {
@@ -63,22 +64,22 @@ func setupWithOfferDraft(t *testing.T) (*env, *ai.FakeClient) {
 	if err != nil {
 		t.Fatalf("NewLocalModelPath: %v", err)
 	}
-	return setupWithOptions(t, compose.WithOfferDraft(modelPath.OfferDraft, retriever)), fake
+	return apptest.SetupAppWithOptions(t, compose.WithOfferDraft(modelPath.OfferDraft, retriever)), fake
 }
 
 // seedDealContextActivity logs one activity linked to the deal — "the
 // deal's captured context" the offerDrafter reads — and returns the
 // source_id a scripted candidate must cite to ground against it.
-func seedDealContextActivity(t *testing.T, e *env, wsID, dealID, subject string) string {
+func seedDealContextActivity(t *testing.T, e *apptest.AppEnv, wsID, dealID, subject string) string {
 	t.Helper()
 	activityID := ids.NewV7()
-	if _, err := e.owner.Exec(context.Background(),
+	if _, err := e.Owner.Exec(context.Background(),
 		`INSERT INTO activity (id, workspace_id, kind, subject, occurred_at, source, captured_by)
 		 VALUES ($1, $2, 'note', $3, '2026-07-01T10:00:00Z', 'manual', 'human:x')`,
 		activityID, wsID, subject); err != nil {
 		t.Fatalf("seed deal context activity: %v", err)
 	}
-	if _, err := e.owner.Exec(context.Background(),
+	if _, err := e.Owner.Exec(context.Background(),
 		`INSERT INTO activity_link (workspace_id, activity_id, entity_type, deal_id) VALUES ($1, $2, 'deal', $3)`,
 		wsID, activityID, dealID); err != nil {
 		t.Fatalf("link deal context activity: %v", err)
@@ -89,10 +90,10 @@ func seedDealContextActivity(t *testing.T, e *env, wsID, dealID, subject string)
 // wsIDBySlug resolves the workspace's own id — the raw-SQL activity seed
 // above needs it, and the HTTP surface never exposes a workspace's id by
 // its slug.
-func wsIDBySlug(t *testing.T, e *env, slug string) string {
+func wsIDBySlug(t *testing.T, e *apptest.AppEnv, slug string) string {
 	t.Helper()
 	var wsID string
-	if err := e.owner.QueryRow(context.Background(), `SELECT id FROM workspace WHERE slug = $1`, slug).Scan(&wsID); err != nil {
+	if err := e.Owner.QueryRow(context.Background(), `SELECT id FROM workspace WHERE slug = $1`, slug).Scan(&wsID); err != nil {
 		t.Fatalf("resolve workspace id for slug %q: %v", slug, err)
 	}
 	return wsID
@@ -101,10 +102,10 @@ func wsIDBySlug(t *testing.T, e *env, slug string) string {
 // stagedLineCount counts proposal_state='staged' rows on one offer — the
 // same check offerdraft_integration_test.go's Env.WsCount runs, over
 // this file's own raw owner connection.
-func stagedLineCount(t *testing.T, e *env, offerID string) int {
+func stagedLineCount(t *testing.T, e *apptest.AppEnv, offerID string) int {
 	t.Helper()
 	var n int
-	if err := e.owner.QueryRow(context.Background(),
+	if err := e.Owner.QueryRow(context.Background(),
 		`SELECT count(*) FROM offer_line_item WHERE offer_id = $1 AND proposal_state = 'staged'`, offerID).Scan(&n); err != nil {
 		t.Fatalf("count staged offer lines: %v", err)
 	}
@@ -152,9 +153,9 @@ func containsDescription(descriptions []string, want string) bool {
 
 func TestOfferRegenerateHTTP_GroundedAIDraftStagesAndDisclosesWithoutMovingTotals(t *testing.T) {
 	e, fake := setupWithOfferDraft(t)
-	e.slug = "offer-regen-ai"
-	bootstrapWorkspaceSession(t, e, "Offer Regen AI", "offerai@fable.test", "Admin")
-	wsID := wsIDBySlug(t, e, e.slug)
+	e.Slug = "offer-regen-ai"
+	apptest.BootstrapWorkspaceSession(t, e, "Offer Regen AI", "offerai@fable.test", "Admin")
+	wsID := wsIDBySlug(t, e, e.Slug)
 	dealID := offerFixture(t, e)
 	source := seedDealContextActivity(t, e, wsID, dealID,
 		`Client said: "we'd want a kickoff workshop" and agreed to 20000 cents for it.`)
@@ -165,12 +166,12 @@ func TestOfferRegenerateHTTP_GroundedAIDraftStagesAndDisclosesWithoutMovingTotal
 	]}`)
 
 	sent := createOfferInCurrency(t, e, dealID, "EUR")
-	if status := e.call(t, "POST", "/v1/offers/"+sent.ID+"/send", nil, nil, nil); status != http.StatusOK {
+	if status := e.Call(t, "POST", "/v1/offers/"+sent.ID+"/send", nil, nil, nil); status != http.StatusOK {
 		t.Fatalf("send offer for AI regenerate → %d", status)
 	}
 
 	var regenerated regeneratedOffer
-	if status := e.call(t, "POST", "/v1/offers/"+sent.ID+"/regenerate", nil, nil, &regenerated); status != http.StatusCreated {
+	if status := e.Call(t, "POST", "/v1/offers/"+sent.ID+"/regenerate", nil, nil, &regenerated); status != http.StatusCreated {
 		t.Fatalf("AI regenerate → %d %+v, want 201", status, regenerated)
 	}
 	if regenerated.Revision != 2 || regenerated.Status != "draft" {
@@ -205,9 +206,9 @@ func TestOfferRegenerateHTTP_GroundedAIDraftStagesAndDisclosesWithoutMovingTotal
 
 func TestOfferRegenerateHTTP_UngroundedCandidateFallsBackToMechanicalCloneOnly(t *testing.T) {
 	e, fake := setupWithOfferDraft(t)
-	e.slug = "offer-regen-ungrounded"
-	bootstrapWorkspaceSession(t, e, "Offer Regen Ungrounded", "ungrounded@fable.test", "Admin")
-	wsID := wsIDBySlug(t, e, e.slug)
+	e.Slug = "offer-regen-ungrounded"
+	apptest.BootstrapWorkspaceSession(t, e, "Offer Regen Ungrounded", "ungrounded@fable.test", "Admin")
+	wsID := wsIDBySlug(t, e, e.Slug)
 	dealID := offerFixture(t, e)
 	seedDealContextActivity(t, e, wsID, dealID, "Client mentioned they liked our website.")
 	fake.Script(`{"lines":[
@@ -217,12 +218,12 @@ func TestOfferRegenerateHTTP_UngroundedCandidateFallsBackToMechanicalCloneOnly(t
 	]}`)
 
 	sent := createOfferInCurrency(t, e, dealID, "EUR")
-	if status := e.call(t, "POST", "/v1/offers/"+sent.ID+"/send", nil, nil, nil); status != http.StatusOK {
+	if status := e.Call(t, "POST", "/v1/offers/"+sent.ID+"/send", nil, nil, nil); status != http.StatusOK {
 		t.Fatalf("send offer for AI regenerate → %d", status)
 	}
 
 	var regenerated regeneratedOffer
-	if status := e.call(t, "POST", "/v1/offers/"+sent.ID+"/regenerate", nil, nil, &regenerated); status != http.StatusCreated {
+	if status := e.Call(t, "POST", "/v1/offers/"+sent.ID+"/regenerate", nil, nil, &regenerated); status != http.StatusCreated {
 		t.Fatalf("regenerate with ungrounded candidate → %d %+v, want 201", status, regenerated)
 	}
 	if regenerated.AiGenerated != nil && *regenerated.AiGenerated {
@@ -251,8 +252,8 @@ func TestOfferRegenerateHTTP_UngroundedCandidateFallsBackToMechanicalCloneOnly(t
 // whether or not an AI brain is wired.
 func TestOfferRegenerateHTTP_NonSentOfferRefusesMechanically(t *testing.T) {
 	e, _ := setupWithOfferDraft(t)
-	e.slug = "offer-regen-not-sent"
-	bootstrapWorkspaceSession(t, e, "Offer Regen Not Sent", "notsent@fable.test", "Admin")
+	e.Slug = "offer-regen-not-sent"
+	apptest.BootstrapWorkspaceSession(t, e, "Offer Regen Not Sent", "notsent@fable.test", "Admin")
 	dealID := offerFixture(t, e)
 	draft := createOfferInCurrency(t, e, dealID, "EUR")
 
@@ -265,7 +266,7 @@ func TestOfferRegenerateHTTP_NonSentOfferRefusesMechanically(t *testing.T) {
 			} `json:"errors"`
 		} `json:"details"`
 	}
-	if status := e.call(t, "POST", "/v1/offers/"+draft.ID+"/regenerate", nil, nil, &problem); status != http.StatusUnprocessableEntity ||
+	if status := e.Call(t, "POST", "/v1/offers/"+draft.ID+"/regenerate", nil, nil, &problem); status != http.StatusUnprocessableEntity ||
 		len(problem.Details.Errors) == 0 || problem.Details.Errors[0].Code != "offer_not_sent" {
 		t.Fatalf("regenerate a draft offer → %d %+v, want 422 offer_not_sent", status, problem)
 	}
@@ -278,20 +279,20 @@ func TestOfferRegenerateHTTP_NonSentOfferRefusesMechanically(t *testing.T) {
 // caller never loses the revision it just minted behind a 500.
 func TestOfferRegenerateHTTP_MalformedModelResponseFallsBackToMechanicalClone(t *testing.T) {
 	e, fake := setupWithOfferDraft(t)
-	e.slug = "offer-regen-malformed"
-	bootstrapWorkspaceSession(t, e, "Offer Regen Malformed", "malformed@fable.test", "Admin")
-	wsID := wsIDBySlug(t, e, e.slug)
+	e.Slug = "offer-regen-malformed"
+	apptest.BootstrapWorkspaceSession(t, e, "Offer Regen Malformed", "malformed@fable.test", "Admin")
+	wsID := wsIDBySlug(t, e, e.Slug)
 	dealID := offerFixture(t, e)
 	seedDealContextActivity(t, e, wsID, dealID, "Client asked about a custom rollout plan.")
 	fake.Script(`this is not json at all`)
 
 	sent := createOfferInCurrency(t, e, dealID, "EUR")
-	if status := e.call(t, "POST", "/v1/offers/"+sent.ID+"/send", nil, nil, nil); status != http.StatusOK {
+	if status := e.Call(t, "POST", "/v1/offers/"+sent.ID+"/send", nil, nil, nil); status != http.StatusOK {
 		t.Fatalf("send offer for AI regenerate → %d", status)
 	}
 
 	var regenerated regeneratedOffer
-	if status := e.call(t, "POST", "/v1/offers/"+sent.ID+"/regenerate", nil, nil, &regenerated); status != http.StatusCreated {
+	if status := e.Call(t, "POST", "/v1/offers/"+sent.ID+"/regenerate", nil, nil, &regenerated); status != http.StatusCreated {
 		t.Fatalf("regenerate over a malformed model response → %d %+v, want 201 (the mechanical mint already committed)", status, regenerated)
 	}
 	if regenerated.Revision != 2 || regenerated.Status != "draft" {

--- a/backend/internal/compose/integration/offerregenerate_http_integration_test.go
+++ b/backend/internal/compose/integration/offerregenerate_http_integration_test.go
@@ -36,7 +36,7 @@ import (
 // production wiring rides (cmd/api's offerDraftOptions), just fed a
 // scripted fake in place of the routed model (the --ai-fake dev path).
 // The retriever needs its own pool at option-construction time, before
-// setupWithOptions has opened the harness's own — the same "a boot
+// apptest.SetupAppWithOptions has opened the harness's own — the same "a boot
 // option built from a pool opens ITS OWN, ahead of the harness's" shape
 // SchemaPool(t) already established for WithSchemaPool. fake is handed
 // back so the caller can script it AFTER seeding its deal context (the

--- a/backend/internal/compose/integration/offerrender_http_integration_test.go
+++ b/backend/internal/compose/integration/offerrender_http_integration_test.go
@@ -25,16 +25,17 @@ import (
 	"testing"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	"github.com/gradionhq/margince/backend/internal/platform/blobstore"
 )
 
 // setupWithBlobstore boots the e2e harness with an in-memory object store
 // wired in, returning both the harness and the SAME store instance so the
 // test can independently verify the object the render handler wrote.
-func setupWithBlobstore(t *testing.T) (*env, blobstore.Store) {
+func setupWithBlobstore(t *testing.T) (*apptest.AppEnv, blobstore.Store) {
 	t.Helper()
 	blob := blobstore.NewMemory()
-	e := setupWithOptions(t, compose.WithBlobstore(blob))
+	e := apptest.SetupAppWithOptions(t, compose.WithBlobstore(blob))
 	return e, blob
 }
 
@@ -45,13 +46,13 @@ type renderedOffer struct {
 
 func TestOfferRenderHTTP_PostRenderReturns200WithPdfAssetRefAndTheBlobExists(t *testing.T) {
 	e, blob := setupWithBlobstore(t)
-	e.bootstrapWorkspace(t)
+	e.BootstrapWorkspace(t)
 	dealID := offerFixture(t, e)
 
-	var offer anyMap
-	if status := e.call(t, "POST", "/v1/deals/"+dealID+"/offers", anyMap{
+	var offer apptest.AnyMap
+	if status := e.Call(t, "POST", "/v1/deals/"+dealID+"/offers", apptest.AnyMap{
 		"currency": "EUR", "source": "manual",
-		"line_items": []anyMap{{"description": "Retainer", "quantity": 1, "unit_price_minor": 500000, "tax_rate": 19.0}},
+		"line_items": []apptest.AnyMap{{"description": "Retainer", "quantity": 1, "unit_price_minor": 500000, "tax_rate": 19.0}},
 	}, nil, &offer); status != http.StatusCreated {
 		t.Fatalf("create offer for render = %d %v", status, offer)
 	}
@@ -61,7 +62,7 @@ func TestOfferRenderHTTP_PostRenderReturns200WithPdfAssetRefAndTheBlobExists(t *
 	}
 
 	var rendered renderedOffer
-	if status := e.call(t, "POST", "/v1/offers/"+offerID+"/render", anyMap{}, nil, &rendered); status != http.StatusOK {
+	if status := e.Call(t, "POST", "/v1/offers/"+offerID+"/render", apptest.AnyMap{}, nil, &rendered); status != http.StatusOK {
 		t.Fatalf("render offer = %d %+v, want 200", status, rendered)
 	}
 	if rendered.ID != offerID {
@@ -97,7 +98,7 @@ func TestOfferRenderHTTP_PostRenderReturns200WithPdfAssetRefAndTheBlobExists(t *
 	// re-render still reclaims its now-superseded PREVIOUS ref rather than
 	// accumulating orphans, and stays 200.
 	var renderedAgain renderedOffer
-	if status := e.call(t, "POST", "/v1/offers/"+offerID+"/render", anyMap{}, nil, &renderedAgain); status != http.StatusOK {
+	if status := e.Call(t, "POST", "/v1/offers/"+offerID+"/render", apptest.AnyMap{}, nil, &renderedAgain); status != http.StatusOK {
 		t.Fatalf("second render = %d", status)
 	}
 	if renderedAgain.PdfAssetRef == rendered.PdfAssetRef {
@@ -126,7 +127,7 @@ func TestOfferRenderHTTP_PostRenderReturns200WithPdfAssetRefAndTheBlobExists(t *
 type raceLineAdder struct {
 	blobstore.Store
 	t       *testing.T
-	e       *env
+	e       *apptest.AppEnv
 	offerID string
 	// putKey records the exact per-attempt key the render handler wrote —
 	// each render mints a fresh key, so the test cannot reconstruct it from
@@ -147,8 +148,8 @@ func (r *raceLineAdder) Put(ctx context.Context, key string, body io.Reader, siz
 		return err
 	}
 	r.putKey = key
-	var line anyMap
-	status := r.e.call(r.t, "POST", "/v1/offers/"+r.offerID+"/line-items", anyMap{
+	var line apptest.AnyMap
+	status := r.e.Call(r.t, "POST", "/v1/offers/"+r.offerID+"/line-items", apptest.AnyMap{
 		"description": "Concurrent Line", "quantity": 1.0, "unit_price_minor": 1000,
 	}, nil, &line)
 	if status != http.StatusCreated {
@@ -167,15 +168,15 @@ func (r *raceLineAdder) Put(ctx context.Context, key string, body io.Reader, siz
 // must be reclaimed — no orphan object survives a rejected render.
 func TestOfferRenderHTTP_ConcurrentLineEditBetweenPrepareAndSetRejectsWithVersionSkewAndReclaimsTheBlob(t *testing.T) {
 	race := &raceLineAdder{Store: blobstore.NewMemory()}
-	e := setupWithOptions(t, compose.WithBlobstore(race))
+	e := apptest.SetupAppWithOptions(t, compose.WithBlobstore(race))
 	race.t, race.e = t, e
-	e.bootstrapWorkspace(t)
+	e.BootstrapWorkspace(t)
 	dealID := offerFixture(t, e)
 
-	var offer anyMap
-	if status := e.call(t, "POST", "/v1/deals/"+dealID+"/offers", anyMap{
+	var offer apptest.AnyMap
+	if status := e.Call(t, "POST", "/v1/deals/"+dealID+"/offers", apptest.AnyMap{
 		"currency": "EUR", "source": "manual",
-		"line_items": []anyMap{{"description": "Retainer", "quantity": 1, "unit_price_minor": 500000, "tax_rate": 19.0}},
+		"line_items": []apptest.AnyMap{{"description": "Retainer", "quantity": 1, "unit_price_minor": 500000, "tax_rate": 19.0}},
 	}, nil, &offer); status != http.StatusCreated {
 		t.Fatalf("create offer for render = %d %v", status, offer)
 	}
@@ -188,7 +189,7 @@ func TestOfferRenderHTTP_ConcurrentLineEditBetweenPrepareAndSetRejectsWithVersio
 	var problem struct {
 		Code string `json:"code"`
 	}
-	status := e.call(t, "POST", "/v1/offers/"+offerID+"/render", anyMap{}, nil, &problem)
+	status := e.Call(t, "POST", "/v1/offers/"+offerID+"/render", apptest.AnyMap{}, nil, &problem)
 	if race.hookErr != nil {
 		t.Fatal(race.hookErr)
 	}
@@ -207,8 +208,8 @@ func TestOfferRenderHTTP_ConcurrentLineEditBetweenPrepareAndSetRejectsWithVersio
 	}
 
 	// The rejected render must not have moved pdf_asset_ref at all.
-	var got anyMap
-	if status := e.call(t, "GET", "/v1/offers/"+offerID, nil, nil, &got); status != http.StatusOK {
+	var got apptest.AnyMap
+	if status := e.Call(t, "GET", "/v1/offers/"+offerID, nil, nil, &got); status != http.StatusOK {
 		t.Fatalf("get offer after rejected render = %d", status)
 	}
 	if got["pdf_asset_ref"] != nil {
@@ -230,7 +231,7 @@ func TestOfferRenderHTTP_ConcurrentLineEditBetweenPrepareAndSetRejectsWithVersio
 type raceDoubleRenderer struct {
 	blobstore.Store
 	t       *testing.T
-	e       *env
+	e       *apptest.AppEnv
 	offerID string
 	nested  bool
 	// hookErr captures a failure from the nested render below. Put runs on
@@ -251,7 +252,7 @@ func (r *raceDoubleRenderer) Put(ctx context.Context, key string, body io.Reader
 	}
 	r.nested = true
 	var winner renderedOffer
-	status := r.e.call(r.t, "POST", "/v1/offers/"+r.offerID+"/render", anyMap{}, nil, &winner)
+	status := r.e.Call(r.t, "POST", "/v1/offers/"+r.offerID+"/render", apptest.AnyMap{}, nil, &winner)
 	if status != http.StatusOK {
 		r.hookErr = fmt.Errorf("nested concurrent render = %d %+v, want 200", status, winner)
 	}
@@ -271,15 +272,15 @@ func (r *raceDoubleRenderer) Put(ctx context.Context, key string, body io.Reader
 // blob it itself wrote, so the winner's committed blob must survive.
 func TestOfferRenderHTTP_ConcurrentDoubleRenderLoserReclaimsOnlyItsOwnBlob(t *testing.T) {
 	race := &raceDoubleRenderer{Store: blobstore.NewMemory()}
-	e := setupWithOptions(t, compose.WithBlobstore(race))
+	e := apptest.SetupAppWithOptions(t, compose.WithBlobstore(race))
 	race.t, race.e = t, e
-	e.bootstrapWorkspace(t)
+	e.BootstrapWorkspace(t)
 	dealID := offerFixture(t, e)
 
-	var offer anyMap
-	if status := e.call(t, "POST", "/v1/deals/"+dealID+"/offers", anyMap{
+	var offer apptest.AnyMap
+	if status := e.Call(t, "POST", "/v1/deals/"+dealID+"/offers", apptest.AnyMap{
 		"currency": "EUR", "source": "manual",
-		"line_items": []anyMap{{"description": "Retainer", "quantity": 1, "unit_price_minor": 500000, "tax_rate": 19.0}},
+		"line_items": []apptest.AnyMap{{"description": "Retainer", "quantity": 1, "unit_price_minor": 500000, "tax_rate": 19.0}},
 	}, nil, &offer); status != http.StatusCreated {
 		t.Fatalf("create offer for render = %d %v", status, offer)
 	}
@@ -292,7 +293,7 @@ func TestOfferRenderHTTP_ConcurrentDoubleRenderLoserReclaimsOnlyItsOwnBlob(t *te
 	var problem struct {
 		Code string `json:"code"`
 	}
-	status := e.call(t, "POST", "/v1/offers/"+offerID+"/render", anyMap{}, nil, &problem)
+	status := e.Call(t, "POST", "/v1/offers/"+offerID+"/render", apptest.AnyMap{}, nil, &problem)
 	if race.hookErr != nil {
 		t.Fatal(race.hookErr)
 	}
@@ -300,8 +301,8 @@ func TestOfferRenderHTTP_ConcurrentDoubleRenderLoserReclaimsOnlyItsOwnBlob(t *te
 		t.Fatalf("outer render racing a nested concurrent render = %d %+v, want 409 version_skew", status, problem)
 	}
 
-	var got anyMap
-	if status := e.call(t, "GET", "/v1/offers/"+offerID, nil, nil, &got); status != http.StatusOK {
+	var got apptest.AnyMap
+	if status := e.Call(t, "GET", "/v1/offers/"+offerID, nil, nil, &got); status != http.StatusOK {
 		t.Fatalf("get offer after the race = %d", status)
 	}
 	winnerRef, ok := got["pdf_asset_ref"].(string)

--- a/backend/internal/compose/integration/offerrender_http_integration_test.go
+++ b/backend/internal/compose/integration/offerrender_http_integration_test.go
@@ -12,7 +12,7 @@ package integration
 // over the real handler stack, including the TOCTOU fence between the
 // prepare read and the set write. The unwired-blobstore 501 shape is
 // already covered by offertemplate_http_integration_test.go's
-// assertRenderOfferNotImplementedWithoutBlobstore (the default setup()
+// assertRenderOfferNotImplementedWithoutBlobstore (the default apptest.SetupApp
 // harness wires no blobstore at all), so it is not repeated here.
 
 import (
@@ -137,7 +137,7 @@ type raceLineAdder struct {
 	// hookErr captures a failure from the injected call below. Put runs on
 	// the outer render request's own handler goroutine, so a t.Fatalf here
 	// would Goexit that goroutine before it writes the render's HTTP
-	// response — hanging the test goroutine's e.call for the render POST
+	// response — hanging the test goroutine's e.Call for the render POST
 	// forever. Recording the failure and asserting it from the test
 	// goroutine, after the outer call returns, avoids that deadlock.
 	hookErr error
@@ -237,7 +237,7 @@ type raceDoubleRenderer struct {
 	// hookErr captures a failure from the nested render below. Put runs on
 	// the outer render request's own handler goroutine, so a t.Fatalf here
 	// would Goexit that goroutine before it writes the outer render's HTTP
-	// response — hanging the test goroutine's e.call for the outer render
+	// response — hanging the test goroutine's e.Call for the outer render
 	// POST forever. Recording the failure and asserting it from the test
 	// goroutine, after the outer call returns, avoids that deadlock.
 	hookErr error

--- a/backend/internal/compose/integration/offers_integration_test.go
+++ b/backend/internal/compose/integration/offers_integration_test.go
@@ -17,11 +17,13 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 )
 
 // offerFixture bootstraps a workspace + session and returns the seeded
 // default pipeline's first open stage plus a deal to hang offers on.
-func offerFixture(t *testing.T, e *env) (dealID string) {
+func offerFixture(t *testing.T, e *apptest.AppEnv) (dealID string) {
 	t.Helper()
 	var pipelines struct {
 		Data []struct {
@@ -32,7 +34,7 @@ func offerFixture(t *testing.T, e *env) (dealID string) {
 			} `json:"stages"`
 		} `json:"data"`
 	}
-	if status := e.call(t, "GET", "/v1/pipelines", nil, nil, &pipelines); status != http.StatusOK || len(pipelines.Data) == 0 {
+	if status := e.Call(t, "GET", "/v1/pipelines", nil, nil, &pipelines); status != http.StatusOK || len(pipelines.Data) == 0 {
 		t.Fatalf("pipelines → %d %+v", status, pipelines)
 	}
 	var stageID string
@@ -48,7 +50,7 @@ func offerFixture(t *testing.T, e *env) (dealID string) {
 	var deal struct {
 		ID string `json:"id"`
 	}
-	if status := e.call(t, "POST", "/v1/deals", anyMap{
+	if status := e.Call(t, "POST", "/v1/deals", apptest.AnyMap{
 		"name": "Offer-bearing deal", "pipeline_id": pipelines.Data[0].ID, "stage_id": stageID, "source": "manual",
 	}, nil, &deal); status != http.StatusCreated {
 		t.Fatalf("create deal → %d", status)
@@ -104,7 +106,7 @@ func reconcile(t *testing.T, o offerBody) {
 // createRateCardProduct creates the Consulting-day rate-card product,
 // asserting money is integer minor units and a live SKU is unique.
 // Returns the product id.
-func createRateCardProduct(t *testing.T, e *env) string {
+func createRateCardProduct(t *testing.T, e *apptest.AppEnv) string {
 	t.Helper()
 	// Rate-card product: money is integer minor units; SKU unique when present.
 	var product struct {
@@ -112,13 +114,13 @@ func createRateCardProduct(t *testing.T, e *env) string {
 		UnitPriceMinor int64  `json:"unit_price_minor"`
 		Version        int64  `json:"version"`
 	}
-	if status := e.call(t, "POST", "/v1/products", anyMap{
+	if status := e.Call(t, "POST", "/v1/products", apptest.AnyMap{
 		"name": "Consulting day", "sku": "CONS-DAY", "unit": "day",
 		"unit_price_minor": 120000, "currency": "EUR", "default_tax_rate": 19.0, "source": "manual",
 	}, nil, &product); status != http.StatusCreated {
 		t.Fatalf("create product → %d", status)
 	}
-	if status := e.call(t, "POST", "/v1/products", anyMap{
+	if status := e.Call(t, "POST", "/v1/products", apptest.AnyMap{
 		"name": "Duplicate", "sku": "CONS-DAY", "unit_price_minor": 1, "currency": "EUR", "source": "manual",
 	}, nil, nil); status != http.StatusConflict {
 		t.Fatalf("duplicate live sku → %d, want 409", status)
@@ -128,7 +130,7 @@ func createRateCardProduct(t *testing.T, e *env) string {
 
 // assertOfferTotalsAreDerived checks a client-supplied total on the
 // offer header is a 422 — totals are derived (P11).
-func assertOfferTotalsAreDerived(t *testing.T, e *env, dealID string) {
+func assertOfferTotalsAreDerived(t *testing.T, e *apptest.AppEnv, dealID string) {
 	t.Helper()
 	// A client-supplied total is rejected 422 — totals are derived (P11).
 	var problem struct {
@@ -140,7 +142,7 @@ func assertOfferTotalsAreDerived(t *testing.T, e *env, dealID string) {
 			} `json:"errors"`
 		} `json:"details"`
 	}
-	if status := e.call(t, "POST", "/v1/deals/"+dealID+"/offers", anyMap{
+	if status := e.Call(t, "POST", "/v1/deals/"+dealID+"/offers", apptest.AnyMap{
 		"currency": "EUR", "source": "manual", "net_minor": 999999,
 	}, nil, &problem); status != http.StatusUnprocessableEntity || problem.Details.Errors[0].Code != "totals_derived" {
 		t.Fatalf("client-supplied net_minor → %d %+v, want 422 totals_derived", status, problem)
@@ -148,9 +150,9 @@ func assertOfferTotalsAreDerived(t *testing.T, e *env, dealID string) {
 }
 
 func TestOfferProductSnapshotAndDerivedTotals(t *testing.T) {
-	e := setup(t)
-	e.slug = "offers-e2e"
-	bootstrapWorkspaceSession(t, e, "Offers E2E", "offers@fable.test", "Admin")
+	e := apptest.SetupApp(t)
+	e.Slug = "offers-e2e"
+	apptest.BootstrapWorkspaceSession(t, e, "Offers E2E", "offers@fable.test", "Admin")
 	dealID := offerFixture(t, e)
 	productID := createRateCardProduct(t, e)
 	assertOfferTotalsAreDerived(t, e, dealID)
@@ -159,9 +161,9 @@ func TestOfferProductSnapshotAndDerivedTotals(t *testing.T) {
 	// 2 days × 1200.00 @19% → net 240000, tax 45600
 	// 3 × 99.99 − 10% = 269.97…→ 26997 @7% → tax 1890 (1889.79 → 1890)
 	var offer offerBody
-	if status := e.call(t, "POST", "/v1/deals/"+dealID+"/offers", anyMap{
+	if status := e.Call(t, "POST", "/v1/deals/"+dealID+"/offers", apptest.AnyMap{
 		"currency": "EUR", "source": "manual",
-		"line_items": []anyMap{
+		"line_items": []apptest.AnyMap{
 			{"product_id": productID, "quantity": 2},
 			{"description": "Licence", "quantity": 3, "unit_price_minor": 9999, "discount_pct": 10.0, "tax_rate": 7.0},
 		},
@@ -179,11 +181,11 @@ func TestOfferProductSnapshotAndDerivedTotals(t *testing.T) {
 
 	// Snapshot semantics (B-E03.17): re-pricing the product must NOT
 	// mutate the existing line.
-	if status := e.call(t, "PATCH", "/v1/products/"+productID, anyMap{"unit_price_minor": 999999}, nil, nil); status != http.StatusOK {
+	if status := e.Call(t, "PATCH", "/v1/products/"+productID, apptest.AnyMap{"unit_price_minor": 999999}, nil, nil); status != http.StatusOK {
 		t.Fatalf("re-price product → %d", status)
 	}
 	var after offerBody
-	if status := e.call(t, "GET", "/v1/offers/"+offer.ID, nil, nil, &after); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/offers/"+offer.ID, nil, nil, &after); status != http.StatusOK {
 		t.Fatalf("get offer → %d", status)
 	}
 	if after.LineItems[0].UnitPriceMinor != 120000 || after.NetMinor != offer.NetMinor {
@@ -196,7 +198,7 @@ func TestOfferProductSnapshotAndDerivedTotals(t *testing.T) {
 // exerciseDraftLineWrites runs the draft line-item write shape: a
 // smuggled client total is 422, and add/update/remove each recompute
 // the derived totals with zero drift.
-func exerciseDraftLineWrites(t *testing.T, e *env, offer offerBody) {
+func exerciseDraftLineWrites(t *testing.T, e *apptest.AppEnv, offer offerBody) {
 	t.Helper()
 	// A total smuggled into a line-item write is 422 too.
 	var problem struct {
@@ -208,7 +210,7 @@ func exerciseDraftLineWrites(t *testing.T, e *env, offer offerBody) {
 			} `json:"errors"`
 		} `json:"details"`
 	}
-	if status := e.call(t, "POST", "/v1/offers/"+offer.ID+"/line-items", anyMap{
+	if status := e.Call(t, "POST", "/v1/offers/"+offer.ID+"/line-items", apptest.AnyMap{
 		"description": "Sneaky", "quantity": 1, "unit_price_minor": 100, "line_total_minor": 1,
 	}, nil, &problem); status != http.StatusUnprocessableEntity {
 		t.Fatalf("client-supplied line_total_minor → %d, want 422", status)
@@ -216,7 +218,7 @@ func exerciseDraftLineWrites(t *testing.T, e *env, offer offerBody) {
 
 	// Draft line CRUD recomputes the totals every time.
 	var withLine offerBody
-	if status := e.call(t, "POST", "/v1/offers/"+offer.ID+"/line-items", anyMap{
+	if status := e.Call(t, "POST", "/v1/offers/"+offer.ID+"/line-items", apptest.AnyMap{
 		"description": "Support", "quantity": 1.5, "unit_price_minor": 20000, "tax_rate": 19.0,
 	}, nil, &withLine); status != http.StatusCreated {
 		t.Fatalf("add line → %d", status)
@@ -228,7 +230,7 @@ func exerciseDraftLineWrites(t *testing.T, e *env, offer offerBody) {
 
 	lineID := withLine.LineItems[len(withLine.LineItems)-1].ID
 	var updated offerBody
-	if status := e.call(t, "PATCH", "/v1/offers/"+offer.ID+"/line-items/"+lineID, anyMap{
+	if status := e.Call(t, "PATCH", "/v1/offers/"+offer.ID+"/line-items/"+lineID, apptest.AnyMap{
 		"quantity": 2.0,
 	}, nil, &updated); status != http.StatusOK {
 		t.Fatalf("update line → %d", status)
@@ -239,7 +241,7 @@ func exerciseDraftLineWrites(t *testing.T, e *env, offer offerBody) {
 	reconcile(t, updated)
 
 	var removed offerBody
-	if status := e.call(t, "DELETE", "/v1/offers/"+offer.ID+"/line-items/"+lineID, nil, nil, &removed); status != http.StatusOK {
+	if status := e.Call(t, "DELETE", "/v1/offers/"+offer.ID+"/line-items/"+lineID, nil, nil, &removed); status != http.StatusOK {
 		t.Fatalf("remove line → %d", status)
 	}
 	if removed.NetMinor != offer.NetMinor {
@@ -249,25 +251,25 @@ func exerciseDraftLineWrites(t *testing.T, e *env, offer offerBody) {
 }
 
 func TestOfferLifecycleSendAcceptRegenerate(t *testing.T) {
-	e := setup(t)
-	e.slug = "offers-life"
-	bootstrapWorkspaceSession(t, e, "Offers Life", "life@fable.test", "Admin")
+	e := apptest.SetupApp(t)
+	e.Slug = "offers-life"
+	apptest.BootstrapWorkspaceSession(t, e, "Offers Life", "life@fable.test", "Admin")
 	dealID := offerFixture(t, e)
 
 	var wsID string
-	if err := e.owner.QueryRow(context.Background(),
-		`SELECT id FROM workspace WHERE slug = $1`, e.slug).Scan(&wsID); err != nil {
+	if err := e.Owner.QueryRow(context.Background(),
+		`SELECT id FROM workspace WHERE slug = $1`, e.Slug).Scan(&wsID); err != nil {
 		t.Fatal(err)
 	}
 
 	// An empty draft has nothing to send.
 	var empty offerBody
-	if status := e.call(t, "POST", "/v1/deals/"+dealID+"/offers", anyMap{
+	if status := e.Call(t, "POST", "/v1/deals/"+dealID+"/offers", apptest.AnyMap{
 		"currency": "EUR", "source": "manual",
 	}, nil, &empty); status != http.StatusCreated {
 		t.Fatalf("create empty offer → %d", status)
 	}
-	if status := e.call(t, "POST", "/v1/offers/"+empty.ID+"/send", nil, nil, nil); status != http.StatusUnprocessableEntity {
+	if status := e.Call(t, "POST", "/v1/offers/"+empty.ID+"/send", nil, nil, nil); status != http.StatusUnprocessableEntity {
 		t.Fatalf("send empty offer → %d, want 422", status)
 	}
 
@@ -275,15 +277,15 @@ func TestOfferLifecycleSendAcceptRegenerate(t *testing.T) {
 	assertSendFreezesDailyFxRate(t, e, wsID, usd.ID)
 
 	// A sent offer is immutable: header, lines and re-send all refuse.
-	if status := e.call(t, "PATCH", "/v1/offers/"+usd.ID, anyMap{"intro_text": "rewrite"}, nil, nil); status != http.StatusUnprocessableEntity {
+	if status := e.Call(t, "PATCH", "/v1/offers/"+usd.ID, apptest.AnyMap{"intro_text": "rewrite"}, nil, nil); status != http.StatusUnprocessableEntity {
 		t.Fatalf("patch sent offer → %d, want 422", status)
 	}
-	if status := e.call(t, "POST", "/v1/offers/"+usd.ID+"/line-items", anyMap{
+	if status := e.Call(t, "POST", "/v1/offers/"+usd.ID+"/line-items", apptest.AnyMap{
 		"description": "Late line", "quantity": 1, "unit_price_minor": 1,
 	}, nil, nil); status != http.StatusUnprocessableEntity {
 		t.Fatalf("add line to sent offer → %d, want 422", status)
 	}
-	if status := e.call(t, "POST", "/v1/offers/"+usd.ID+"/send", nil, nil, nil); status != http.StatusUnprocessableEntity {
+	if status := e.Call(t, "POST", "/v1/offers/"+usd.ID+"/send", nil, nil, nil); status != http.StatusUnprocessableEntity {
 		t.Fatalf("re-send sent offer → %d, want 422", status)
 	}
 
@@ -291,22 +293,22 @@ func TestOfferLifecycleSendAcceptRegenerate(t *testing.T) {
 
 	// Reject: a second sent offer takes the decline (with reason).
 	eur := createOfferInCurrency(t, e, dealID, "EUR")
-	if e.call(t, "POST", "/v1/offers/"+eur.ID+"/send", nil, nil, nil) != http.StatusOK {
+	if e.Call(t, "POST", "/v1/offers/"+eur.ID+"/send", nil, nil, nil) != http.StatusOK {
 		t.Fatal("send EUR offer failed")
 	}
 	var rejected offerBody
-	if status := e.call(t, "POST", "/v1/offers/"+eur.ID+"/reject", anyMap{"reason": "budget cut"}, nil, &rejected); status != http.StatusOK || rejected.Status != "rejected" {
+	if status := e.Call(t, "POST", "/v1/offers/"+eur.ID+"/reject", apptest.AnyMap{"reason": "budget cut"}, nil, &rejected); status != http.StatusOK || rejected.Status != "rejected" {
 		t.Fatalf("reject → %d %q", status, rejected.Status)
 	}
 
 	// Regenerate: a third sent offer mints revision 2 as a fresh draft
 	// and the original becomes superseded — never mutated in place.
 	third := createOfferInCurrency(t, e, dealID, "EUR")
-	if e.call(t, "POST", "/v1/offers/"+third.ID+"/send", nil, nil, nil) != http.StatusOK {
+	if e.Call(t, "POST", "/v1/offers/"+third.ID+"/send", nil, nil, nil) != http.StatusOK {
 		t.Fatal("send third offer failed")
 	}
 	var nextRev offerBody
-	if status := e.call(t, "POST", "/v1/offers/"+third.ID+"/regenerate", nil, nil, &nextRev); status != http.StatusCreated {
+	if status := e.Call(t, "POST", "/v1/offers/"+third.ID+"/regenerate", nil, nil, &nextRev); status != http.StatusCreated {
 		t.Fatalf("regenerate → %d", status)
 	}
 	if nextRev.Revision != 2 || nextRev.Status != "draft" || nextRev.OfferNumber != third.OfferNumber || len(nextRev.LineItems) != 1 {
@@ -319,7 +321,7 @@ func TestOfferLifecycleSendAcceptRegenerate(t *testing.T) {
 		t.Fatalf("ai_generated = %v, want absent with no offerDrafter wired", *nextRev.AiGenerated)
 	}
 	var prior offerBody
-	if status := e.call(t, "GET", "/v1/offers/"+third.ID, nil, nil, &prior); status != http.StatusOK || prior.Status != "superseded" {
+	if status := e.Call(t, "GET", "/v1/offers/"+third.ID, nil, nil, &prior); status != http.StatusOK || prior.Status != "superseded" {
 		t.Fatalf("prior revision after regenerate = %d %q, want superseded", 200, prior.Status)
 	}
 
@@ -328,12 +330,12 @@ func TestOfferLifecycleSendAcceptRegenerate(t *testing.T) {
 
 // createOfferInCurrency creates a one-line Retainer offer on the deal in
 // the given currency.
-func createOfferInCurrency(t *testing.T, e *env, dealID, currency string) offerBody {
+func createOfferInCurrency(t *testing.T, e *apptest.AppEnv, dealID, currency string) offerBody {
 	t.Helper()
 	var o offerBody
-	if status := e.call(t, "POST", "/v1/deals/"+dealID+"/offers", anyMap{
+	if status := e.Call(t, "POST", "/v1/deals/"+dealID+"/offers", apptest.AnyMap{
 		"currency": currency, "source": "manual",
-		"line_items": []anyMap{{"description": "Retainer", "quantity": 1, "unit_price_minor": 500000, "tax_rate": 19.0}},
+		"line_items": []apptest.AnyMap{{"description": "Retainer", "quantity": 1, "unit_price_minor": 500000, "tax_rate": 19.0}},
 	}, nil, &o); status != http.StatusCreated {
 		t.Fatalf("create %s offer → %d", currency, status)
 	}
@@ -343,21 +345,21 @@ func createOfferInCurrency(t *testing.T, e *env, dealID, currency string) offerB
 // assertSendFreezesDailyFxRate covers FX honesty (RT-PR-C2): sending a
 // USD offer with no daily rate is a hard 422 — never rate=1 — and with
 // a seeded rate, send freezes it onto the offer.
-func assertSendFreezesDailyFxRate(t *testing.T, e *env, wsID, offerID string) {
+func assertSendFreezesDailyFxRate(t *testing.T, e *apptest.AppEnv, wsID, offerID string) {
 	t.Helper()
 	var problem struct {
 		Detail string `json:"detail"`
 	}
-	if status := e.call(t, "POST", "/v1/offers/"+offerID+"/send", nil, nil, &problem); status != http.StatusUnprocessableEntity {
+	if status := e.Call(t, "POST", "/v1/offers/"+offerID+"/send", nil, nil, &problem); status != http.StatusUnprocessableEntity {
 		t.Fatalf("send with missing fx rate → %d, want 422", status)
 	}
-	if _, err := e.owner.Exec(context.Background(),
+	if _, err := e.Owner.Exec(context.Background(),
 		`INSERT INTO fx_rate (workspace_id, from_currency, to_currency, rate, rate_date)
 		 VALUES ($1, 'USD', 'EUR', 0.9200000000, current_date)`, wsID); err != nil {
 		t.Fatal(err)
 	}
 	var sent offerBody
-	if status := e.call(t, "POST", "/v1/offers/"+offerID+"/send", nil, nil, &sent); status != http.StatusOK {
+	if status := e.Call(t, "POST", "/v1/offers/"+offerID+"/send", nil, nil, &sent); status != http.StatusOK {
 		t.Fatalf("send with seeded fx rate → %d", status)
 	}
 	if sent.Status != "sent" || !strings.HasPrefix(sent.FxRate, "0.92") {
@@ -368,10 +370,10 @@ func assertSendFreezesDailyFxRate(t *testing.T, e *env, wsID, offerID string) {
 // assertAcceptSyncsDealAmount covers accept: status flips, accepted_at
 // lands, the DEAL takes the accepted gross as its headline amount
 // (forecast honesty), and a second accept refuses — accept is terminal.
-func assertAcceptSyncsDealAmount(t *testing.T, e *env, dealID, offerID string) {
+func assertAcceptSyncsDealAmount(t *testing.T, e *apptest.AppEnv, dealID, offerID string) {
 	t.Helper()
 	var accepted offerBody
-	if status := e.call(t, "POST", "/v1/offers/"+offerID+"/accept", nil, nil, &accepted); status != http.StatusOK {
+	if status := e.Call(t, "POST", "/v1/offers/"+offerID+"/accept", nil, nil, &accepted); status != http.StatusOK {
 		t.Fatalf("accept → %d", status)
 	}
 	if accepted.Status != "accepted" || accepted.AcceptedAt == "" {
@@ -381,7 +383,7 @@ func assertAcceptSyncsDealAmount(t *testing.T, e *env, dealID, offerID string) {
 		AmountMinor int64  `json:"amount_minor"`
 		Currency    string `json:"currency"`
 	}
-	if status := e.call(t, "GET", "/v1/deals/"+dealID, nil, nil, &deal); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/deals/"+dealID, nil, nil, &deal); status != http.StatusOK {
 		t.Fatalf("get deal → %d", status)
 	}
 	if deal.AmountMinor != accepted.GrossMinor || deal.Currency != "USD" {
@@ -389,7 +391,7 @@ func assertAcceptSyncsDealAmount(t *testing.T, e *env, dealID, offerID string) {
 			deal.AmountMinor, deal.Currency, accepted.GrossMinor)
 	}
 	// Accept is terminal: a second accept refuses.
-	if status := e.call(t, "POST", "/v1/offers/"+offerID+"/accept", nil, nil, nil); status != http.StatusUnprocessableEntity {
+	if status := e.Call(t, "POST", "/v1/offers/"+offerID+"/accept", nil, nil, nil); status != http.StatusUnprocessableEntity {
 		t.Fatalf("double accept → %d, want 422", status)
 	}
 }
@@ -397,10 +399,10 @@ func assertAcceptSyncsDealAmount(t *testing.T, e *env, dealID, offerID string) {
 // assertOfferEventTrail checks every lifecycle fact shipped through the
 // outbox: 4 creates + 1 regenerate-create; 3 sends; 1 accept (+ its
 // paired deal.updated); 1 reject; 1 supersede.
-func assertOfferEventTrail(t *testing.T, e *env) {
+func assertOfferEventTrail(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
 	var created, sentN, acceptedN, rejectedN, supersededN, dealUpdated int
-	if err := e.owner.QueryRow(context.Background(), `
+	if err := e.Owner.QueryRow(context.Background(), `
 		SELECT count(*) FILTER (WHERE envelope->>'type' = 'offer.created'),
 		       count(*) FILTER (WHERE envelope->>'type' = 'offer.sent'),
 		       count(*) FILTER (WHERE envelope->>'type' = 'offer.accepted'),
@@ -423,15 +425,15 @@ func assertOfferEventTrail(t *testing.T, e *env) {
 // a human session sending the same offer end to end still works, which is
 // the behaviour that must not have regressed by tightening the agent side.
 func TestOfferSendIsHumanOnlyButTheHumanPathStillWorks(t *testing.T) {
-	e := setup(t)
-	e.slug = "offers-agent"
-	bootstrapWorkspaceSession(t, e, "Offers Agent", "agent@fable.test", "Admin")
+	e := apptest.SetupApp(t)
+	e.Slug = "offers-agent"
+	apptest.BootstrapWorkspaceSession(t, e, "Offers Agent", "agent@fable.test", "Admin")
 	dealID := offerFixture(t, e)
 
 	var minted struct {
 		Token string `json:"token"`
 	}
-	if status := e.call(t, "POST", "/v1/passports", anyMap{
+	if status := e.Call(t, "POST", "/v1/passports", apptest.AnyMap{
 		// Even the broadest cap the contract knows for this surface does not
 		// reach a human-only verb — there is no cap that would.
 		"label": "offer agent", "scopes": []string{"read", "write", "send"},
@@ -442,9 +444,9 @@ func TestOfferSendIsHumanOnlyButTheHumanPathStillWorks(t *testing.T) {
 
 	// 🟢 create_record: the agent drafts the offer, provenance is the agent.
 	var offer offerBody
-	if status := e.call(t, "POST", "/v1/deals/"+dealID+"/offers", anyMap{
+	if status := e.Call(t, "POST", "/v1/deals/"+dealID+"/offers", apptest.AnyMap{
 		"currency": "EUR", "source": "mcp",
-		"line_items": []anyMap{{"description": "Pilot", "quantity": 1, "unit_price_minor": 250000, "tax_rate": 19.0}},
+		"line_items": []apptest.AnyMap{{"description": "Pilot", "quantity": 1, "unit_price_minor": 250000, "tax_rate": 19.0}},
 	}, bearer, &offer); status != http.StatusCreated {
 		t.Fatalf("agent 🟢 offer draft → %d", status)
 	}
@@ -454,27 +456,27 @@ func TestOfferSendIsHumanOnlyButTheHumanPathStillWorks(t *testing.T) {
 		Code   string `json:"code"`
 		Detail string `json:"detail"`
 	}
-	if status := e.call(t, "POST", "/v1/offers/"+offer.ID+"/send", nil, bearer, &problem); status != http.StatusForbidden || problem.Code != "permission_denied" {
+	if status := e.Call(t, "POST", "/v1/offers/"+offer.ID+"/send", nil, bearer, &problem); status != http.StatusForbidden || problem.Code != "permission_denied" {
 		t.Fatalf("agent send → %d %q, want 403 permission_denied (human-only)", status, problem.Code)
 	}
 	if !strings.Contains(problem.Detail, "human-only") {
 		t.Fatalf("refusal %q does not say the verb is human-only", problem.Detail)
 	}
 	var still offerBody
-	if status := e.call(t, "GET", "/v1/offers/"+offer.ID, nil, bearer, &still); status != http.StatusOK || still.Status != "draft" {
+	if status := e.Call(t, "GET", "/v1/offers/"+offer.ID, nil, bearer, &still); status != http.StatusOK || still.Status != "draft" {
 		t.Fatalf("offer after the refused agent send = %q, want draft", still.Status)
 	}
 
 	// The human path is unaffected: the same agent-drafted offer, sent by
 	// the human session, executes end to end.
 	var sent offerBody
-	if status := e.call(t, "POST", "/v1/offers/"+offer.ID+"/send", nil, nil, &sent); status != http.StatusOK || sent.Status != "sent" {
+	if status := e.Call(t, "POST", "/v1/offers/"+offer.ID+"/send", nil, nil, &sent); status != http.StatusOK || sent.Status != "sent" {
 		t.Fatalf("human send → %d %q, want 200 sent", status, sent.Status)
 	}
 
 	// Recording the buyer's decision is a human attestation: the agent is
 	// rejected outright on accept, whatever its scopes.
-	if status := e.call(t, "POST", "/v1/offers/"+offer.ID+"/accept", nil, bearer, nil); status != http.StatusForbidden {
+	if status := e.Call(t, "POST", "/v1/offers/"+offer.ID+"/accept", nil, bearer, nil); status != http.StatusForbidden {
 		t.Fatalf("agent accept → %d, want 403 (human-only)", status)
 	}
 }

--- a/backend/internal/compose/integration/offertemplate_http_integration_test.go
+++ b/backend/internal/compose/integration/offertemplate_http_integration_test.go
@@ -224,8 +224,9 @@ func assertOfferTemplateMissingLayout422(t *testing.T, e *apptest.AppEnv) {
 
 // assertRenderOfferNotImplementedWithoutBlobstore proves the render
 // endpoint's 501 fallback: the PDF renderer itself is fully implemented
-// (offer_pdf.go, offer_render.go), but THIS suite's setup() harness wires
-// no blobstore (compose.WithBlobstore is never passed), so RenderOffer's
+// (offer_pdf.go, offer_render.go), but the apptest.SetupApp harness this
+// suite rides wires no blobstore (compose.WithBlobstore is never passed),
+// so RenderOffer's
 // own h.blob == nil check correctly answers 501 rather than nil-derefing —
 // the same unwired-by-omission posture as the attachments seam. The
 // wired-blobstore success path (a real render, a real blob, real bytes)

--- a/backend/internal/compose/integration/offertemplate_http_integration_test.go
+++ b/backend/internal/compose/integration/offertemplate_http_integration_test.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -32,8 +33,8 @@ type offerTemplateProblem struct {
 }
 
 func TestOfferTemplatesHTTP(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 
 	var createdID string
 	t.Run("201 create with defaults", func(t *testing.T) {
@@ -65,11 +66,11 @@ func TestOfferTemplatesHTTP(t *testing.T) {
 	})
 }
 
-func assertOfferTemplateCreate201(t *testing.T, e *env) string {
+func assertOfferTemplateCreate201(t *testing.T, e *apptest.AppEnv) string {
 	t.Helper()
-	var created anyMap
-	status := e.call(t, "POST", "/v1/offer-templates", anyMap{
-		"name": "HTTP Standard DE", "layout": anyMap{"logo_url": "https://example.test/logo.png"},
+	var created apptest.AnyMap
+	status := e.Call(t, "POST", "/v1/offer-templates", apptest.AnyMap{
+		"name": "HTTP Standard DE", "layout": apptest.AnyMap{"logo_url": "https://example.test/logo.png"},
 	}, nil, &created)
 	if status != http.StatusCreated {
 		t.Fatalf("create = %d %v", status, created)
@@ -87,11 +88,11 @@ func assertOfferTemplateCreate201(t *testing.T, e *env) string {
 	return id
 }
 
-func assertOfferTemplateNameDuplicate409(t *testing.T, e *env) {
+func assertOfferTemplateNameDuplicate409(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
 	var problem offerTemplateProblem
-	status := e.call(t, "POST", "/v1/offer-templates", anyMap{
-		"name": "HTTP Standard DE", "layout": anyMap{},
+	status := e.Call(t, "POST", "/v1/offer-templates", apptest.AnyMap{
+		"name": "HTTP Standard DE", "layout": apptest.AnyMap{},
 	}, nil, &problem)
 	if status != http.StatusConflict || problem.Code != "offer_template_name_duplicate" {
 		t.Fatalf("duplicate name create = %d %+v, want 409 offer_template_name_duplicate", status, problem)
@@ -101,19 +102,19 @@ func assertOfferTemplateNameDuplicate409(t *testing.T, e *env) {
 	}
 }
 
-func assertOfferTemplateDefaultConflict409(t *testing.T, e *env) {
+func assertOfferTemplateDefaultConflict409(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
-	var firstDefault anyMap
-	status := e.call(t, "POST", "/v1/offer-templates", anyMap{
-		"name": "HTTP DE Default", "layout": anyMap{}, "is_default": true,
+	var firstDefault apptest.AnyMap
+	status := e.Call(t, "POST", "/v1/offer-templates", apptest.AnyMap{
+		"name": "HTTP DE Default", "layout": apptest.AnyMap{}, "is_default": true,
 	}, nil, &firstDefault)
 	if status != http.StatusCreated {
 		t.Fatalf("seed default template = %d %v", status, firstDefault)
 	}
 
 	var problem offerTemplateProblem
-	status = e.call(t, "POST", "/v1/offer-templates", anyMap{
-		"name": "HTTP DE Default Two", "layout": anyMap{}, "is_default": true,
+	status = e.Call(t, "POST", "/v1/offer-templates", apptest.AnyMap{
+		"name": "HTTP DE Default Two", "layout": apptest.AnyMap{}, "is_default": true,
 	}, nil, &problem)
 	if status != http.StatusConflict || problem.Code != "offer_template_default_conflict" {
 		t.Fatalf("default conflict create = %d %+v, want 409 offer_template_default_conflict", status, problem)
@@ -123,23 +124,23 @@ func assertOfferTemplateDefaultConflict409(t *testing.T, e *env) {
 	}
 }
 
-func assertOfferTemplateGet(t *testing.T, e *env, id string) {
+func assertOfferTemplateGet(t *testing.T, e *apptest.AppEnv, id string) {
 	t.Helper()
-	var got anyMap
-	if status := e.call(t, "GET", "/v1/offer-templates/"+id, nil, nil, &got); status != http.StatusOK || got["id"] != id {
+	var got apptest.AnyMap
+	if status := e.Call(t, "GET", "/v1/offer-templates/"+id, nil, nil, &got); status != http.StatusOK || got["id"] != id {
 		t.Fatalf("get = %d %+v, want 200 id=%s", status, got, id)
 	}
-	if status := e.call(t, "GET", "/v1/offer-templates/"+ids.NewV7().String(), nil, nil, nil); status != http.StatusNotFound {
+	if status := e.Call(t, "GET", "/v1/offer-templates/"+ids.NewV7().String(), nil, nil, nil); status != http.StatusNotFound {
 		t.Fatalf("get unknown template = %d, want 404", status)
 	}
 }
 
-func assertOfferTemplateList(t *testing.T, e *env, seededID string) {
+func assertOfferTemplateList(t *testing.T, e *apptest.AppEnv, seededID string) {
 	t.Helper()
 	var deList struct {
-		Data []anyMap `json:"data"`
+		Data []apptest.AnyMap `json:"data"`
 	}
-	if status := e.call(t, "GET", "/v1/offer-templates?locale=de-DE", nil, nil, &deList); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/offer-templates?locale=de-DE", nil, nil, &deList); status != http.StatusOK {
 		t.Fatalf("list locale=de-DE = %d", status)
 	}
 	found := false
@@ -156,31 +157,31 @@ func assertOfferTemplateList(t *testing.T, e *env, seededID string) {
 	}
 }
 
-func assertOfferTemplateUpdate(t *testing.T, e *env, id string) {
+func assertOfferTemplateUpdate(t *testing.T, e *apptest.AppEnv, id string) {
 	t.Helper()
-	var updated anyMap
-	status := e.call(t, "PUT", "/v1/offer-templates/"+id, anyMap{
+	var updated apptest.AnyMap
+	status := e.Call(t, "PUT", "/v1/offer-templates/"+id, apptest.AnyMap{
 		"name": "HTTP Standard DE v2", "locale": "de-DE", "is_default": false,
-		"layout": anyMap{"footer_text": "v2"},
+		"layout": apptest.AnyMap{"footer_text": "v2"},
 	}, map[string]string{"If-Match": "1"}, &updated)
 	if status != http.StatusOK || updated["name"] != "HTTP Standard DE v2" || updated["version"].(float64) != 2 {
 		t.Fatalf("update = %d %+v, want 200 name=... version=2", status, updated)
 	}
 
 	var stale offerTemplateProblem
-	status = e.call(t, "PUT", "/v1/offer-templates/"+id, anyMap{
-		"name": "HTTP Standard DE v3", "locale": "de-DE", "is_default": false, "layout": anyMap{},
+	status = e.Call(t, "PUT", "/v1/offer-templates/"+id, apptest.AnyMap{
+		"name": "HTTP Standard DE v3", "locale": "de-DE", "is_default": false, "layout": apptest.AnyMap{},
 	}, map[string]string{"If-Match": "1"}, &stale)
 	if status != http.StatusConflict || stale.Code != "version_skew" {
 		t.Fatalf("stale If-Match = %d %+v, want 409 version_skew", status, stale)
 	}
 }
 
-func assertOfferTemplateArchive(t *testing.T, e *env) {
+func assertOfferTemplateArchive(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
-	var created anyMap
-	status := e.call(t, "POST", "/v1/offer-templates", anyMap{
-		"name": "HTTP Archivable", "layout": anyMap{},
+	var created apptest.AnyMap
+	status := e.Call(t, "POST", "/v1/offer-templates", apptest.AnyMap{
+		"name": "HTTP Archivable", "layout": apptest.AnyMap{},
 	}, nil, &created)
 	if status != http.StatusCreated {
 		t.Fatalf("create to archive = %d %v", status, created)
@@ -190,18 +191,18 @@ func assertOfferTemplateArchive(t *testing.T, e *env) {
 		t.Fatalf("create to archive response carries no id: %v", created)
 	}
 
-	var archived anyMap
-	status = e.call(t, "DELETE", "/v1/offer-templates/"+id, nil, nil, &archived)
+	var archived apptest.AnyMap
+	status = e.Call(t, "DELETE", "/v1/offer-templates/"+id, nil, nil, &archived)
 	if status != http.StatusOK || archived["archived_at"] == nil || archived["id"] != id {
 		t.Fatalf("archive = %d %+v, want 200 + the full entity with archived_at set", status, archived)
 	}
-	var stillGettable anyMap
-	if status := e.call(t, "GET", "/v1/offer-templates/"+id, nil, nil, &stillGettable); status != http.StatusOK || stillGettable["archived_at"] == nil {
+	var stillGettable apptest.AnyMap
+	if status := e.Call(t, "GET", "/v1/offer-templates/"+id, nil, nil, &stillGettable); status != http.StatusOK || stillGettable["archived_at"] == nil {
 		t.Fatalf("get archived template = %d %+v, want 200 with archived_at set", status, stillGettable)
 	}
 }
 
-func assertOfferTemplateMissingLayout422(t *testing.T, e *env) {
+func assertOfferTemplateMissingLayout422(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
 	var problem struct {
 		Code    string `json:"code"`
@@ -212,7 +213,7 @@ func assertOfferTemplateMissingLayout422(t *testing.T, e *env) {
 			} `json:"errors"`
 		} `json:"details"`
 	}
-	status := e.call(t, "POST", "/v1/offer-templates", anyMap{"name": "No Layout"}, nil, &problem)
+	status := e.Call(t, "POST", "/v1/offer-templates", apptest.AnyMap{"name": "No Layout"}, nil, &problem)
 	if status != http.StatusUnprocessableEntity || problem.Code != "validation_error" {
 		t.Fatalf("missing layout = %d %+v, want 422 validation_error", status, problem)
 	}
@@ -231,13 +232,13 @@ func assertOfferTemplateMissingLayout422(t *testing.T, e *env) {
 // lives in offerrender_http_integration_test.go. A dedicated deal+offer
 // is seeded fresh here because offerFixture (offers_integration_test.go)
 // is this suite's only source of a valid deal/pipeline pair.
-func assertRenderOfferNotImplementedWithoutBlobstore(t *testing.T, e *env) {
+func assertRenderOfferNotImplementedWithoutBlobstore(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
 	dealID := offerFixture(t, e)
-	var offer anyMap
-	status := e.call(t, "POST", "/v1/deals/"+dealID+"/offers", anyMap{
+	var offer apptest.AnyMap
+	status := e.Call(t, "POST", "/v1/deals/"+dealID+"/offers", apptest.AnyMap{
 		"currency": "EUR", "source": "manual",
-		"line_items": []anyMap{{"description": "Retainer", "quantity": 1, "unit_price_minor": 500000, "tax_rate": 19.0}},
+		"line_items": []apptest.AnyMap{{"description": "Retainer", "quantity": 1, "unit_price_minor": 500000, "tax_rate": 19.0}},
 	}, nil, &offer)
 	if status != http.StatusCreated {
 		t.Fatalf("create offer for render = %d %v", status, offer)
@@ -246,7 +247,7 @@ func assertRenderOfferNotImplementedWithoutBlobstore(t *testing.T, e *env) {
 	if !ok {
 		t.Fatalf("create offer for render response carries no id: %v", offer)
 	}
-	status = e.call(t, "POST", "/v1/offers/"+offerID+"/render", anyMap{}, nil, nil)
+	status = e.Call(t, "POST", "/v1/offers/"+offerID+"/render", apptest.AnyMap{}, nil, nil)
 	if status != http.StatusNotImplemented {
 		t.Fatalf("renderOffer without a wired blobstore = %d, want 501", status)
 	}

--- a/backend/internal/compose/integration/onboarding_state_http_integration_test.go
+++ b/backend/internal/compose/integration/onboarding_state_http_integration_test.go
@@ -8,6 +8,8 @@ package integration
 import (
 	"net/http"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 )
 
 type onboardingStateDTO struct {
@@ -21,12 +23,12 @@ type onboardingStateDTO struct {
 	Version          int            `json:"version"`
 }
 
-func onboardingStateBody(version int, step string) anyMap {
-	return anyMap{
+func onboardingStateBody(version int, step string) apptest.AnyMap {
+	return apptest.AnyMap{
 		"expected_version":   version,
 		"step":               step,
 		"source_mode":        "manual",
-		"company_draft":      anyMap{"display_name": "Acme draft"},
+		"company_draft":      apptest.AnyMap{"display_name": "Acme draft"},
 		"selected_fact_keys": []string{},
 		"voice_skipped":      false,
 		"connect_skipped":    false,
@@ -38,15 +40,15 @@ func onboardingHeaders(key string) map[string]string {
 }
 
 func TestOnboardingStateResumesAndRejectsStaleTabs(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 
-	if status := e.call(t, http.MethodGet, "/v1/onboarding/state", nil, nil, nil); status != http.StatusNotFound {
+	if status := e.Call(t, http.MethodGet, "/v1/onboarding/state", nil, nil, nil); status != http.StatusNotFound {
 		t.Fatalf("initial state status = %d, want 404", status)
 	}
 
 	var created onboardingStateDTO
-	status := e.call(t, http.MethodPut, "/v1/onboarding/state",
+	status := e.Call(t, http.MethodPut, "/v1/onboarding/state",
 		onboardingStateBody(0, "read"), onboardingHeaders("onboarding-create"), &created)
 	if status != http.StatusOK {
 		t.Fatalf("create state status = %d, want 200", status)
@@ -56,40 +58,40 @@ func TestOnboardingStateResumesAndRejectsStaleTabs(t *testing.T) {
 	}
 
 	var resumed onboardingStateDTO
-	if status := e.call(t, http.MethodGet, "/v1/onboarding/state", nil, nil, &resumed); status != http.StatusOK {
+	if status := e.Call(t, http.MethodGet, "/v1/onboarding/state", nil, nil, &resumed); status != http.StatusOK {
 		t.Fatalf("resume state status = %d, want 200", status)
 	}
 	if resumed.Version != created.Version || resumed.CompanyDraft["display_name"] != "Acme draft" {
 		t.Fatalf("resumed state = %+v, want the persisted draft", resumed)
 	}
 
-	var blocked anyMap
-	status = e.call(t, http.MethodPut, "/v1/onboarding/state",
+	var blocked apptest.AnyMap
+	status = e.Call(t, http.MethodPut, "/v1/onboarding/state",
 		onboardingStateBody(1, "voice"), onboardingHeaders("onboarding-blocked"), &blocked)
 	if status != http.StatusConflict || blocked["code"] != "conflict" {
 		t.Fatalf("creator bypass = %d %+v, want 409 conflict", status, blocked)
 	}
 
-	if status := e.call(t, http.MethodPut, "/v1/company", wellFormedCompany(), nil, nil); status != http.StatusOK {
+	if status := e.Call(t, http.MethodPut, "/v1/company", wellFormedCompany(), nil, nil); status != http.StatusOK {
 		t.Fatalf("saving minimum company = %d, want 200", status)
 	}
 
 	var advanced onboardingStateDTO
-	status = e.call(t, http.MethodPut, "/v1/onboarding/state",
+	status = e.Call(t, http.MethodPut, "/v1/onboarding/state",
 		onboardingStateBody(1, "voice"), onboardingHeaders("onboarding-advance"), &advanced)
 	if status != http.StatusOK || advanced.Path != "creator" || advanced.Version != 2 {
 		t.Fatalf("advanced state = %d %+v, want creator/v2", status, advanced)
 	}
 
-	var stale anyMap
-	status = e.call(t, http.MethodPut, "/v1/onboarding/state",
+	var stale apptest.AnyMap
+	status = e.Call(t, http.MethodPut, "/v1/onboarding/state",
 		onboardingStateBody(1, "connect"), onboardingHeaders("onboarding-stale"), &stale)
 	if status != http.StatusConflict || stale["code"] != "version_skew" {
 		t.Fatalf("stale tab = %d %+v, want 409 version_skew", status, stale)
 	}
 
 	var unchanged onboardingStateDTO
-	if status := e.call(t, http.MethodGet, "/v1/onboarding/state", nil, nil, &unchanged); status != http.StatusOK {
+	if status := e.Call(t, http.MethodGet, "/v1/onboarding/state", nil, nil, &unchanged); status != http.StatusOK {
 		t.Fatalf("state after stale write = %d, want 200", status)
 	}
 	if unchanged.Step != "voice" || unchanged.Version != 2 {

--- a/backend/internal/compose/integration/orgrollup_http_integration_test.go
+++ b/backend/internal/compose/integration/orgrollup_http_integration_test.go
@@ -28,6 +28,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -73,14 +74,14 @@ type orgRollupFxProblem struct {
 
 // createOrgRollupOrg creates one organization through the real write path,
 // optionally hanging it under parentID (empty = a root).
-func createOrgRollupOrg(t *testing.T, e *env, name, parentID string) string {
+func createOrgRollupOrg(t *testing.T, e *apptest.AppEnv, name, parentID string) string {
 	t.Helper()
-	body := anyMap{"display_name": name, "source": "ui"}
+	body := apptest.AnyMap{"display_name": name, "source": "ui"}
 	if parentID != "" {
 		body["parent_org_id"] = parentID
 	}
-	var org anyMap
-	if status := e.call(t, "POST", "/v1/organizations", body, nil, &org); status != http.StatusCreated {
+	var org apptest.AnyMap
+	if status := e.Call(t, "POST", "/v1/organizations", body, nil, &org); status != http.StatusCreated {
 		t.Fatalf("create organization %q = %d %v", name, status, org)
 	}
 	return org["id"].(string)
@@ -90,7 +91,7 @@ func createOrgRollupOrg(t *testing.T, e *env, name, parentID string) string {
 // open stage and its live win probability, so the happy-path assertion
 // below can compute the expected weighted-pipeline figure exactly rather
 // than asserting a mere non-zero value.
-func orgRollupOpenStage(t *testing.T, e *env) (pipelineID, stageID string, winProbability int) {
+func orgRollupOpenStage(t *testing.T, e *apptest.AppEnv) (pipelineID, stageID string, winProbability int) {
 	t.Helper()
 	var pipelines struct {
 		Data []struct {
@@ -102,7 +103,7 @@ func orgRollupOpenStage(t *testing.T, e *env) (pipelineID, stageID string, winPr
 			} `json:"stages"`
 		} `json:"data"`
 	}
-	if status := e.call(t, "GET", "/v1/pipelines", nil, nil, &pipelines); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/pipelines", nil, nil, &pipelines); status != http.StatusOK {
 		t.Fatalf("list pipelines = %d", status)
 	}
 	if len(pipelines.Data) != 1 {
@@ -121,10 +122,10 @@ func orgRollupOpenStage(t *testing.T, e *env) (pipelineID, stageID string, winPr
 // createOrgRollupOpenDeal opens one deal on org through the real write
 // path; amountMinor is the caller's choice so the rollup's weighted-value
 // rounding stays exact arithmetic in the caller's test, not a guess.
-func createOrgRollupOpenDeal(t *testing.T, e *env, pipelineID, stageID, orgID string, amountMinor int64, currency string) {
+func createOrgRollupOpenDeal(t *testing.T, e *apptest.AppEnv, pipelineID, stageID, orgID string, amountMinor int64, currency string) {
 	t.Helper()
-	var deal anyMap
-	status := e.call(t, "POST", "/v1/deals", anyMap{
+	var deal apptest.AnyMap
+	status := e.Call(t, "POST", "/v1/deals", apptest.AnyMap{
 		"name":            "Rollup HTTP Deal",
 		"amount_minor":    amountMinor,
 		"currency":        currency,
@@ -150,10 +151,10 @@ const orgRollupHTTPDealAmountMinor = 1_000_000
 // over the seeded deal and the seeded stage's live win probability, both
 // money objects always carry the workspace base currency, and
 // restricted_excluded decodes as a real (non-nil) empty array.
-func assertOrgRollupTreeHappyPath(t *testing.T, e *env, root string, winProbability int) {
+func assertOrgRollupTreeHappyPath(t *testing.T, e *apptest.AppEnv, root string, winProbability int) {
 	t.Helper()
 	var rollup orgRollupResponseWire
-	status := e.call(t, "GET", "/v1/organizations/"+root+"/hierarchy-rollup", nil, nil, &rollup)
+	status := e.Call(t, "GET", "/v1/organizations/"+root+"/hierarchy-rollup", nil, nil, &rollup)
 	if status != http.StatusOK {
 		t.Fatalf("rollup status = %d, want 200: %+v", status, rollup)
 	}
@@ -184,10 +185,10 @@ func assertOrgRollupTreeHappyPath(t *testing.T, e *env, root string, winProbabil
 
 // assertOrgRollupSelfScope drives scope=self on child and checks it
 // reports the child alone — the parent's deal never rolls down.
-func assertOrgRollupSelfScope(t *testing.T, e *env, child string) {
+func assertOrgRollupSelfScope(t *testing.T, e *apptest.AppEnv, child string) {
 	t.Helper()
 	var rollup orgRollupResponseWire
-	status := e.call(t, "GET", "/v1/organizations/"+child+"/hierarchy-rollup?scope=self", nil, nil, &rollup)
+	status := e.Call(t, "GET", "/v1/organizations/"+child+"/hierarchy-rollup?scope=self", nil, nil, &rollup)
 	if status != http.StatusOK {
 		t.Fatalf("self rollup status = %d, want 200: %+v", status, rollup)
 	}
@@ -205,13 +206,13 @@ func assertOrgRollupSelfScope(t *testing.T, e *env, child string) {
 // assertOrgRollupFXUnavailable seeds a fresh root with an open USD deal and
 // no stored USD->EUR rate, and checks the wire shape of the resulting
 // fx_rate_unavailable refusal.
-func assertOrgRollupFXUnavailable(t *testing.T, e *env, pipelineID, stageID string) {
+func assertOrgRollupFXUnavailable(t *testing.T, e *apptest.AppEnv, pipelineID, stageID string) {
 	t.Helper()
 	fxRoot := createOrgRollupOrg(t, e, "Rollup HTTP FX Root", "")
 	createOrgRollupOpenDeal(t, e, pipelineID, stageID, fxRoot, 10_000, "USD") // no USD->EUR rate on file
 
 	var problem orgRollupFxProblem
-	status := e.call(t, "GET", "/v1/organizations/"+fxRoot+"/hierarchy-rollup", nil, nil, &problem)
+	status := e.Call(t, "GET", "/v1/organizations/"+fxRoot+"/hierarchy-rollup", nil, nil, &problem)
 	if status != http.StatusUnprocessableEntity {
 		t.Fatalf("fx-unavailable status = %d, want 422: %+v", status, problem)
 	}
@@ -227,8 +228,8 @@ func assertOrgRollupFXUnavailable(t *testing.T, e *env, pipelineID, stageID stri
 }
 
 func TestOrgRollupHTTP(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 	pipelineID, stageID, winProbability := orgRollupOpenStage(t, e)
 
 	root := createOrgRollupOrg(t, e, "Rollup HTTP Root", "")
@@ -245,7 +246,7 @@ func TestOrgRollupHTTP(t *testing.T) {
 
 	t.Run("422 invalid scope", func(t *testing.T) {
 		var problem fieldHistoryProblem
-		status := e.call(t, "GET", "/v1/organizations/"+root+"/hierarchy-rollup?scope=bogus", nil, nil, &problem)
+		status := e.Call(t, "GET", "/v1/organizations/"+root+"/hierarchy-rollup?scope=bogus", nil, nil, &problem)
 		assertFieldHistoryValidation422(t, status, problem, "scope", "invalid_enum")
 	})
 
@@ -254,7 +255,7 @@ func TestOrgRollupHTTP(t *testing.T) {
 	})
 
 	t.Run("404 nonexistent organization", func(t *testing.T) {
-		status := e.call(t, "GET", "/v1/organizations/"+ids.NewV7().String()+"/hierarchy-rollup", nil, nil, nil)
+		status := e.Call(t, "GET", "/v1/organizations/"+ids.NewV7().String()+"/hierarchy-rollup", nil, nil, nil)
 		if status != http.StatusNotFound {
 			t.Fatalf("nonexistent org rollup status = %d, want 404", status)
 		}

--- a/backend/internal/compose/integration/outbox_integration_test.go
+++ b/backend/internal/compose/integration/outbox_integration_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/events"
 )
 
@@ -58,18 +59,18 @@ func stagedPersonCreated(t *testing.T, owner *pgx.Conn) stagedEnvelope {
 }
 
 func TestWriteStagesOneCompleteEnvelope(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 
-	var me anyMap
-	if status := e.call(t, "GET", "/v1/me", nil, nil, &me); status != http.StatusOK {
+	var me apptest.AnyMap
+	if status := e.Call(t, "GET", "/v1/me", nil, nil, &me); status != http.StatusOK {
 		t.Fatalf("/me status = %d", status)
 	}
 
-	var person anyMap
-	if status := e.call(t, "POST", "/v1/people", anyMap{
+	var person apptest.AnyMap
+	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{
 		"full_name": "Grace Hopper",
-		"emails":    []anyMap{{"email": "grace@example.com"}},
+		"emails":    []apptest.AnyMap{{"email": "grace@example.com"}},
 	}, nil, &person); status != http.StatusCreated {
 		t.Fatalf("create person status = %d, body %v", status, person)
 	}
@@ -120,10 +121,10 @@ func TestWriteStagesOneCompleteEnvelope(t *testing.T) {
 }
 
 func TestFailedLoginIsAuditedAndThrottled(t *testing.T) {
-	e := setup(t)
-	bootstrapWorkspaceSession(t, e, "Fable E2E", "ada@example.com", "Admin")
+	e := apptest.SetupApp(t)
+	apptest.BootstrapWorkspaceSession(t, e, "Fable E2E", "ada@example.com", "Admin")
 
-	if status := e.call(t, "POST", "/v1/auth/login", anyMap{
+	if status := e.Call(t, "POST", "/v1/auth/login", apptest.AnyMap{
 		"email": "ada@example.com", "password": "wrong-password-entirely",
 	}, nil, nil); status != http.StatusUnauthorized {
 		t.Fatalf("bad login status = %d, want 401", status)
@@ -154,18 +155,18 @@ func TestFailedLoginIsAuditedAndThrottled(t *testing.T) {
 	// account-existence oracle. The in-process 429 flood throttle sits in
 	// front for distinct-email sprays; on a single account the lock wins.
 	for i := 2; i <= 5; i++ {
-		if status := e.call(t, "POST", "/v1/auth/login", anyMap{
+		if status := e.Call(t, "POST", "/v1/auth/login", apptest.AnyMap{
 			"email": "ada@example.com", "password": "wrong-password-entirely",
 		}, nil, nil); status != http.StatusUnauthorized {
 			t.Fatalf("failure %d = %d, want 401", i, status)
 		}
 	}
-	if status := e.call(t, "POST", "/v1/auth/login", anyMap{
+	if status := e.Call(t, "POST", "/v1/auth/login", apptest.AnyMap{
 		"email": "ada@example.com", "password": "wrong-password-entirely",
 	}, nil, nil); status != http.StatusUnauthorized {
 		t.Fatalf("attempt past the lock threshold = %d, want 401 (a locked account reads as bad credentials)", status)
 	}
-	if status := e.call(t, "POST", "/v1/auth/login", anyMap{
+	if status := e.Call(t, "POST", "/v1/auth/login", apptest.AnyMap{
 		"email": "ada@example.com", "password": "correct-horse-battery",
 	}, nil, nil); status != http.StatusUnauthorized {
 		t.Fatalf("correct password on a locked account = %d, want 401 (indistinguishable from an unknown email)", status)

--- a/backend/internal/compose/integration/overlay_acceptance_integration_test.go
+++ b/backend/internal/compose/integration/overlay_acceptance_integration_test.go
@@ -44,6 +44,7 @@ import (
 	"time"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	"github.com/gradionhq/margince/backend/internal/modules/overlay"
 	"github.com/gradionhq/margince/backend/internal/modules/overlay/fake"
 	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
@@ -515,26 +516,26 @@ func TestAcceptance_AC_OV_11_FailClosedVisibility_ReadSubset(t *testing.T) {
 // surface and checks the tables its own fixture populates.
 func TestAcceptance_OVA_AC_1_TeardownPurges(t *testing.T) {
 	vault := keyvault.NewMemory()
-	e := setupWithOptions(t, compose.WithKeyvault(vault))
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupAppWithOptions(t, compose.WithKeyvault(vault))
+	e.BootstrapWorkspace(t)
 
 	var conn map[string]any
-	if status := e.call(t, "POST", "/v1/overlay/connection", anyMap{
+	if status := e.Call(t, "POST", "/v1/overlay/connection", apptest.AnyMap{
 		"incumbent": "hubspot", "region": "eu1", "privateAppToken": "fake-token-never-used",
 	}, nil, &conn); status != http.StatusCreated {
 		t.Fatalf("connect overlay = %d %v", status, conn)
 	}
 
-	var me anyMap
-	if status := e.call(t, "GET", "/v1/me", nil, nil, &me); status != http.StatusOK {
+	var me apptest.AnyMap
+	if status := e.Call(t, "GET", "/v1/me", nil, nil, &me); status != http.StatusOK {
 		t.Fatalf("/me status = %d", status)
 	}
-	adminID, err := ids.Parse(me["user"].(anyMap)["id"].(string))
+	adminID, err := ids.Parse(me["user"].(apptest.AnyMap)["id"].(string))
 	if err != nil {
 		t.Fatalf("parsing admin user id: %v", err)
 	}
 	var wsIDStr string
-	if err := e.owner.QueryRow(context.Background(), `SELECT id FROM workspace WHERE slug = $1`, e.slug).Scan(&wsIDStr); err != nil {
+	if err := e.Owner.QueryRow(context.Background(), `SELECT id FROM workspace WHERE slug = $1`, e.Slug).Scan(&wsIDStr); err != nil {
 		t.Fatalf("looking up the workspace id: %v", err)
 	}
 	wsID, err := ids.Parse(wsIDStr)
@@ -563,10 +564,10 @@ func TestAcceptance_OVA_AC_1_TeardownPurges(t *testing.T) {
 	}
 
 	var seededMirror, seededAssoc int
-	if err := e.owner.QueryRow(context.Background(), `SELECT count(*) FROM overlay_mirror WHERE workspace_id = $1`, wsIDStr).Scan(&seededMirror); err != nil {
+	if err := e.Owner.QueryRow(context.Background(), `SELECT count(*) FROM overlay_mirror WHERE workspace_id = $1`, wsIDStr).Scan(&seededMirror); err != nil {
 		t.Fatalf("counting the seeded mirror rows: %v", err)
 	}
-	if err := e.owner.QueryRow(context.Background(), `SELECT count(*) FROM overlay_association WHERE workspace_id = $1`, wsIDStr).Scan(&seededAssoc); err != nil {
+	if err := e.Owner.QueryRow(context.Background(), `SELECT count(*) FROM overlay_association WHERE workspace_id = $1`, wsIDStr).Scan(&seededAssoc); err != nil {
 		t.Fatalf("counting the seeded association rows: %v", err)
 	}
 	if seededMirror == 0 || seededAssoc == 0 {
@@ -584,7 +585,7 @@ func TestAcceptance_OVA_AC_1_TeardownPurges(t *testing.T) {
 	// table, and its fixed-window counters expire on their own TTL. There
 	// is no PG row for disconnect to purge.
 
-	if code := e.call(t, "DELETE", "/v1/overlay/connection", nil, nil, nil); code != http.StatusAccepted {
+	if code := e.Call(t, "DELETE", "/v1/overlay/connection", nil, nil, nil); code != http.StatusAccepted {
 		t.Fatalf("disconnect overlay = %d, want 202", code)
 	}
 
@@ -594,7 +595,7 @@ func TestAcceptance_OVA_AC_1_TeardownPurges(t *testing.T) {
 	counts := map[string]int{}
 	for _, table := range []string{"overlay_mirror", "overlay_association", "mirror_visibility", "mirror_user_map", "overlay_backfill_cursor", "overlay_reconcile_watermark"} {
 		var n int
-		if err := e.owner.QueryRow(context.Background(), fmt.Sprintf(`SELECT count(*) FROM %s WHERE workspace_id = $1`, table), wsIDStr).Scan(&n); err != nil {
+		if err := e.Owner.QueryRow(context.Background(), fmt.Sprintf(`SELECT count(*) FROM %s WHERE workspace_id = $1`, table), wsIDStr).Scan(&n); err != nil {
 			t.Fatalf("counting %s: %v", table, err)
 		}
 		counts[table] = n
@@ -606,7 +607,7 @@ func TestAcceptance_OVA_AC_1_TeardownPurges(t *testing.T) {
 	}
 
 	var tombstoneCount int
-	if err := e.owner.QueryRow(context.Background(), `SELECT count(*) FROM overlay_tombstone WHERE workspace_id = $1`, wsIDStr).Scan(&tombstoneCount); err != nil {
+	if err := e.Owner.QueryRow(context.Background(), `SELECT count(*) FROM overlay_tombstone WHERE workspace_id = $1`, wsIDStr).Scan(&tombstoneCount); err != nil {
 		t.Fatalf("counting overlay_tombstone rows: %v", err)
 	}
 	if tombstoneCount == 0 {
@@ -652,7 +653,7 @@ func TestAcceptance_OVA_AC_1_TeardownPurges(t *testing.T) {
 			After      map[string]any `json:"after"`
 		} `json:"data"`
 	}
-	if code := e.call(t, "GET", "/v1/audit-log?entity_type=incumbent_connection&action=archive", nil, nil, &audit); code != http.StatusOK {
+	if code := e.Call(t, "GET", "/v1/audit-log?entity_type=incumbent_connection&action=archive", nil, nil, &audit); code != http.StatusOK {
 		t.Fatalf("audit log = %d", code)
 	}
 	if len(audit.Data) != 1 {

--- a/backend/internal/compose/integration/overlay_cutover_lifecycle_integration_test.go
+++ b/backend/internal/compose/integration/overlay_cutover_lifecycle_integration_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
 	"github.com/gradionhq/margince/backend/internal/modules/overlay"
@@ -74,10 +75,10 @@ func TestOverlayCutoverRetirementAndReconstruction(t *testing.T) {
 		t.Fatalf("writing the pre-flip export: %v", err)
 	}
 	var verdict crmcontracts.OverlayFlipPreflight
-	if code := e.call(t, "POST", "/v1/overlay/flip:preflight", anyMap{}, nil, &verdict); code != http.StatusOK || !verdict.Ready {
+	if code := e.Call(t, "POST", "/v1/overlay/flip:preflight", apptest.AnyMap{}, nil, &verdict); code != http.StatusOK || !verdict.Ready {
 		t.Fatalf("preflight = %d ready=%v blocking=%v", code, verdict.Ready, verdict.Blocking)
 	}
-	if code := e.call(t, "POST", "/v1/overlay/flip", anyMap{
+	if code := e.Call(t, "POST", "/v1/overlay/flip", apptest.AnyMap{
 		"confirmation_phrase": "FLIP TO SOR",
 	}, nil, nil); code != http.StatusAccepted {
 		t.Fatalf("execute = %d", code)
@@ -87,7 +88,7 @@ func TestOverlayCutoverRetirementAndReconstruction(t *testing.T) {
 	// already native; the disconnect revokes the connection and purges
 	// the mirror + derivatives, while native data, audit, and the
 	// export bundle remain.
-	if code := e.call(t, "DELETE", "/v1/overlay/connection", nil, nil, nil); code != http.StatusAccepted {
+	if code := e.Call(t, "DELETE", "/v1/overlay/connection", nil, nil, nil); code != http.StatusAccepted {
 		t.Fatalf("disconnect after flip = %d, want 202", code)
 	}
 
@@ -214,13 +215,13 @@ func seedCleanWorkspace(t *testing.T, f flipEstate) context.Context {
 	t.Helper()
 	ctx := context.Background()
 	ws := ids.NewV7()
-	if _, err := f.e.owner.Exec(ctx,
+	if _, err := f.e.Owner.Exec(ctx,
 		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Clean Rebuild', $2, 'EUR')`,
 		ws, "clean-rebuild-"+ws.String()); err != nil {
 		t.Fatalf("seeding the clean workspace: %v", err)
 	}
 	user := ids.New[ids.UserKind]()
-	if _, err := f.e.owner.Exec(ctx,
+	if _, err := f.e.Owner.Exec(ctx,
 		`INSERT INTO app_user (id, workspace_id, email, display_name) VALUES ($1, $2, $3, 'Rebuild Admin')`,
 		user, ws, "rebuild-"+user.String()+"@clean.test"); err != nil {
 		t.Fatalf("seeding the clean workspace admin: %v", err)

--- a/backend/internal/compose/integration/overlay_e2e_integration_test.go
+++ b/backend/internal/compose/integration/overlay_e2e_integration_test.go
@@ -28,7 +28,7 @@ package integration
 // posture backfill_test.go and the fake package's own doc already
 // establish.
 //
-// This test needs a *pgxpool.Pool of its own (the env/setup() harness
+// This test needs a *pgxpool.Pool of its own (the apptest.AppEnv harness
 // exposes none) to drive compose.Dispatcher/overlay.Backfill directly —
 // openAppPool opens a second, independent app-role connection to the
 // SAME database the httptest server is backed by, so rows committed

--- a/backend/internal/compose/integration/overlay_e2e_integration_test.go
+++ b/backend/internal/compose/integration/overlay_e2e_integration_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/modules/overlay"
 	"github.com/gradionhq/margince/backend/internal/modules/overlay/fake"
@@ -93,10 +94,10 @@ func openAppPool(t *testing.T) *pgxpool.Pool {
 // seedSecondAppUser inserts one more human app_user into ws through the
 // owner connection — an "unmapped" second actor sharing the workspace,
 // deliberately never given a mirror_user_map row.
-func seedSecondAppUser(t *testing.T, e *env, wsID ids.UUID, email string) ids.UUID {
+func seedSecondAppUser(t *testing.T, e *apptest.AppEnv, wsID ids.UUID, email string) ids.UUID {
 	t.Helper()
 	userID := ids.NewV7()
-	if _, err := e.owner.Exec(context.Background(),
+	if _, err := e.Owner.Exec(context.Background(),
 		`INSERT INTO app_user (id, workspace_id, email, display_name) VALUES ($1, $2, $3, 'Unmapped User')`,
 		userID, wsID, email); err != nil {
 		t.Fatalf("seeding the unmapped app_user: %v", err)
@@ -108,8 +109,8 @@ func seedSecondAppUser(t *testing.T, e *env, wsID ids.UUID, email string) ids.UU
 // proven over the real composed HTTP + package path together.
 func TestOverlayReadAndSyncEndToEnd(t *testing.T) {
 	vault := keyvault.NewMemory()
-	e := setupWithOptions(t, compose.WithKeyvault(vault))
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupAppWithOptions(t, compose.WithKeyvault(vault))
+	e.BootstrapWorkspace(t)
 
 	assertOverlayOpsGatedInNativeMode(t, e)
 	adminID, wsID, wsIDStr := connectOverlayToTheFakeIncumbent(t, e)
@@ -135,21 +136,21 @@ func TestOverlayReadAndSyncEndToEnd(t *testing.T) {
 // hubspot.Adapter from the connection's own vaulted region+token — see
 // compose/jobs.go's reconcileConnection — so this suite never calls it
 // against a connected workspace; T11 bars real-network reliance in a test).
-func assertOverlayOpsGatedInNativeMode(t *testing.T, e *env) {
+func assertOverlayOpsGatedInNativeMode(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
 	for _, path := range []string{"/v1/overlay/sync-status", "/v1/overlay/budget"} {
-		if code := e.call(t, "GET", path, nil, nil, nil); code != http.StatusNotFound {
+		if code := e.Call(t, "GET", path, nil, nil, nil); code != http.StatusNotFound {
 			t.Fatalf("GET %s in native mode = %d, want 404 mode_not_overlay", path, code)
 		}
 	}
-	if code := e.call(t, "POST", "/v1/overlay/reconcile", nil, nil, nil); code != http.StatusNotFound {
+	if code := e.Call(t, "POST", "/v1/overlay/reconcile", nil, nil, nil); code != http.StatusNotFound {
 		t.Fatalf("reconcile in native mode = %d, want 404 mode_not_overlay", code)
 	}
 
 	// While still native, the shadowed read ops (compose/overlayread.go)
 	// delegate to the native module handlers — the ordinary native page
 	// answers, proving the mode fallthrough side of the dispatch.
-	if code := e.call(t, "GET", "/v1/people", nil, nil, nil); code != http.StatusOK {
+	if code := e.Call(t, "GET", "/v1/people", nil, nil, nil); code != http.StatusOK {
 		t.Fatalf("native-mode GET /v1/people through the shadowed op = %d, want 200", code)
 	}
 }
@@ -159,10 +160,10 @@ func assertOverlayOpsGatedInNativeMode(t *testing.T, e *env) {
 // to reach a real HubSpot in this test: every mirror row lands through the fake
 // incumbent's own Backfill call, never through hubspot.Adapter) and resolves
 // the identities the rest of the scenario reads records as.
-func connectOverlayToTheFakeIncumbent(t *testing.T, e *env) (adminID, wsID ids.UUID, wsIDStr string) {
+func connectOverlayToTheFakeIncumbent(t *testing.T, e *apptest.AppEnv) (adminID, wsID ids.UUID, wsIDStr string) {
 	t.Helper()
 	var conn map[string]any
-	if status := e.call(t, "POST", "/v1/overlay/connection", anyMap{
+	if status := e.Call(t, "POST", "/v1/overlay/connection", apptest.AnyMap{
 		"incumbent":       "hubspot",
 		"region":          "eu1",
 		"privateAppToken": "fake-token-never-used",
@@ -170,15 +171,15 @@ func connectOverlayToTheFakeIncumbent(t *testing.T, e *env) (adminID, wsID ids.U
 		t.Fatalf("connect overlay = %d %v", status, conn)
 	}
 
-	var me anyMap
-	if status := e.call(t, "GET", "/v1/me", nil, nil, &me); status != http.StatusOK {
+	var me apptest.AnyMap
+	if status := e.Call(t, "GET", "/v1/me", nil, nil, &me); status != http.StatusOK {
 		t.Fatalf("/me status = %d", status)
 	}
-	adminID, err := ids.Parse(me["user"].(anyMap)["id"].(string))
+	adminID, err := ids.Parse(me["user"].(apptest.AnyMap)["id"].(string))
 	if err != nil {
 		t.Fatalf("parsing admin user id: %v", err)
 	}
-	if err := e.owner.QueryRow(context.Background(), `SELECT id FROM workspace WHERE slug = $1`, e.slug).Scan(&wsIDStr); err != nil {
+	if err := e.Owner.QueryRow(context.Background(), `SELECT id FROM workspace WHERE slug = $1`, e.Slug).Scan(&wsIDStr); err != nil {
 		t.Fatalf("looking up the workspace id: %v", err)
 	}
 	wsID, err = ids.Parse(wsIDStr)
@@ -218,10 +219,10 @@ func backfillOneMirroredContact(t *testing.T, pool *pgxpool.Pool, wsID, adminID 
 
 // assertSyncStatusReportsAConvergedBackfill is bullet 1: GET
 // /v1/overlay/sync-status shows fresh + backfill complete.
-func assertSyncStatusReportsAConvergedBackfill(t *testing.T, e *env) {
+func assertSyncStatusReportsAConvergedBackfill(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
 	var status syncStatusWire
-	if code := e.call(t, "GET", "/v1/overlay/sync-status", nil, nil, &status); code != http.StatusOK {
+	if code := e.Call(t, "GET", "/v1/overlay/sync-status", nil, nil, &status); code != http.StatusOK {
 		t.Fatalf("sync-status = %d", code)
 	}
 	found := false
@@ -247,10 +248,10 @@ func assertSyncStatusReportsAConvergedBackfill(t *testing.T, e *env) {
 
 // assertBudgetAnswersOnceConnected pins that GetOverlayBudget also answers now
 // that the workspace is connected.
-func assertBudgetAnswersOnceConnected(t *testing.T, e *env) {
+func assertBudgetAnswersOnceConnected(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
 	var budget budgetWire
-	if code := e.call(t, "GET", "/v1/overlay/budget", nil, nil, &budget); code != http.StatusOK {
+	if code := e.Call(t, "GET", "/v1/overlay/budget", nil, nil, &budget); code != http.StatusOK {
 		t.Fatalf("budget = %d", code)
 	}
 	if budget.Band == "" || budget.Window == "" {
@@ -291,10 +292,10 @@ func assertDispatchedReadCarriesExternalTrust(adminCtx context.Context, t *testi
 // serves the SAME mirror rows (design.md §4.1 "Overlay does not fork the data
 // API"): list, get, and search answer through the real composed HTTP stack,
 // typed, stamped source=overlay, and search-tagged trust_tier=external.
-func assertHumanRestSurfaceServesTheMirror(t *testing.T, e *env) {
+func assertHumanRestSurfaceServesTheMirror(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
 	var peoplePage crmcontracts.PersonListResponse
-	if code := e.call(t, "GET", "/v1/people", nil, nil, &peoplePage); code != http.StatusOK {
+	if code := e.Call(t, "GET", "/v1/people", nil, nil, &peoplePage); code != http.StatusOK {
 		t.Fatalf("overlay-mode GET /v1/people = %d", code)
 	}
 	if len(peoplePage.Data) != 1 {
@@ -305,14 +306,14 @@ func assertHumanRestSurfaceServesTheMirror(t *testing.T, e *env) {
 		t.Fatalf("mirrored person on the wire = %q/source=%q, want Ada Overlay/source=overlay", wirePerson.FullName, wirePerson.Source)
 	}
 	var gotPerson crmcontracts.Person
-	if code := e.call(t, "GET", "/v1/people/"+wirePerson.Id.String(), nil, nil, &gotPerson); code != http.StatusOK {
+	if code := e.Call(t, "GET", "/v1/people/"+wirePerson.Id.String(), nil, nil, &gotPerson); code != http.StatusOK {
 		t.Fatalf("overlay-mode GET /v1/people/{id} = %d", code)
 	}
 	if gotPerson.FullName != "Ada Overlay" {
 		t.Fatalf("GET-by-id FullName = %q, want Ada Overlay", gotPerson.FullName)
 	}
 	var searchPage crmcontracts.SearchResponse
-	if code := e.call(t, "GET", "/v1/search?q=Ada", nil, nil, &searchPage); code != http.StatusOK {
+	if code := e.Call(t, "GET", "/v1/search?q=Ada", nil, nil, &searchPage); code != http.StatusOK {
 		t.Fatalf("overlay-mode GET /v1/search = %d", code)
 	}
 	if len(searchPage.Data) != 1 {
@@ -326,7 +327,7 @@ func assertHumanRestSurfaceServesTheMirror(t *testing.T, e *env) {
 	}
 	// A list dial the mirror cannot answer is refused with 422 naming the
 	// parameter — never silently ignored (overlayread.go's own contract).
-	if code := e.call(t, "GET", "/v1/people?sort=-created_at", nil, nil, nil); code != http.StatusUnprocessableEntity {
+	if code := e.Call(t, "GET", "/v1/people?sort=-created_at", nil, nil, nil); code != http.StatusUnprocessableEntity {
 		t.Fatalf("overlay-mode sorted people list = %d, want 422 unsupported_in_overlay_mode", code)
 	}
 	// captured_by_kind is the same rule and matters more, because being ignored
@@ -341,7 +342,7 @@ func assertHumanRestSurfaceServesTheMirror(t *testing.T, e *env) {
 		"/v1/organizations?ai_written=true",
 		"/v1/leads?ai_written=true",
 	} {
-		if code := e.call(t, "GET", path, nil, nil, nil); code != http.StatusUnprocessableEntity {
+		if code := e.Call(t, "GET", path, nil, nil, nil); code != http.StatusUnprocessableEntity {
 			t.Errorf("overlay-mode %s = %d, want 422 — a provenance filter the mirror cannot answer must be refused, never ignored", path, code)
 		}
 	}
@@ -358,7 +359,7 @@ func assertHumanRestSurfaceServesTheMirror(t *testing.T, e *env) {
 		// looking like the opt-in was honoured (ADR-0082/A127).
 		"/v1/organizations?include_anchor=true",
 	} {
-		if code := e.call(t, "GET", path, nil, nil, nil); code != http.StatusUnprocessableEntity {
+		if code := e.Call(t, "GET", path, nil, nil, nil); code != http.StatusUnprocessableEntity {
 			t.Errorf("overlay-mode %s = %d, want 422 — a filter with no mirror column must be refused, never ignored", path, code)
 		}
 	}
@@ -370,7 +371,7 @@ func assertHumanRestSurfaceServesTheMirror(t *testing.T, e *env) {
 // a ctx principal with no mirror_user_map row at all, existence-hiding rather
 // than an empty-but-successful page; see visibility.go's own doc on
 // resolveActingMirrorUserID).
-func assertUnmappedUserSeesZeroRows(t *testing.T, e *env, dispatcher *compose.Dispatcher, wsID ids.UUID) {
+func assertUnmappedUserSeesZeroRows(t *testing.T, e *apptest.AppEnv, dispatcher *compose.Dispatcher, wsID ids.UUID) {
 	t.Helper()
 	unmappedID := seedSecondAppUser(t, e, wsID, "unmapped@overlay.test")
 	unmappedCtx := overlayActorCtx(wsID, unmappedID)
@@ -384,20 +385,20 @@ func assertUnmappedUserSeesZeroRows(t *testing.T, e *env, dispatcher *compose.Di
 // assertDisconnectPurgesTheMirrorAndRetainsTheAudit is bullet 4: DELETE
 // /v1/overlay/connection → mirror empty, tombstone present, connection audit
 // RETAINED + PII-scrubbed.
-func assertDisconnectPurgesTheMirrorAndRetainsTheAudit(t *testing.T, e *env, wsIDStr string) {
+func assertDisconnectPurgesTheMirrorAndRetainsTheAudit(t *testing.T, e *apptest.AppEnv, wsIDStr string) {
 	t.Helper()
-	if code := e.call(t, "DELETE", "/v1/overlay/connection", nil, nil, nil); code != http.StatusAccepted {
+	if code := e.Call(t, "DELETE", "/v1/overlay/connection", nil, nil, nil); code != http.StatusAccepted {
 		t.Fatalf("disconnect overlay = %d, want 202", code)
 	}
 
 	var mirrorCount, tombstoneCount int
-	if err := e.owner.QueryRow(context.Background(), `SELECT count(*) FROM overlay_mirror WHERE workspace_id = $1`, wsIDStr).Scan(&mirrorCount); err != nil {
+	if err := e.Owner.QueryRow(context.Background(), `SELECT count(*) FROM overlay_mirror WHERE workspace_id = $1`, wsIDStr).Scan(&mirrorCount); err != nil {
 		t.Fatalf("counting overlay_mirror rows: %v", err)
 	}
 	if mirrorCount != 0 {
 		t.Errorf("overlay_mirror still has %d rows after disconnect, want 0", mirrorCount)
 	}
-	if err := e.owner.QueryRow(context.Background(), `SELECT count(*) FROM overlay_tombstone WHERE workspace_id = $1`, wsIDStr).Scan(&tombstoneCount); err != nil {
+	if err := e.Owner.QueryRow(context.Background(), `SELECT count(*) FROM overlay_tombstone WHERE workspace_id = $1`, wsIDStr).Scan(&tombstoneCount); err != nil {
 		t.Fatalf("counting overlay_tombstone rows: %v", err)
 	}
 	if tombstoneCount == 0 {
@@ -412,7 +413,7 @@ func assertDisconnectPurgesTheMirrorAndRetainsTheAudit(t *testing.T, e *env, wsI
 			After      map[string]any `json:"after"`
 		} `json:"data"`
 	}
-	if code := e.call(t, "GET", "/v1/audit-log?entity_type=incumbent_connection&action=archive", nil, nil, &audit); code != http.StatusOK {
+	if code := e.Call(t, "GET", "/v1/audit-log?entity_type=incumbent_connection&action=archive", nil, nil, &audit); code != http.StatusOK {
 		t.Fatalf("audit log = %d", code)
 	}
 	if len(audit.Data) != 1 {
@@ -434,7 +435,7 @@ func assertDisconnectPurgesTheMirrorAndRetainsTheAudit(t *testing.T, e *env, wsI
 // a shadow being unwired — the unit specs cover the guard itself — and the SPA
 // hiding these screens is exactly why the callers left (an agent, a direct API
 // client) have nothing else protecting them.
-func assertReportOpsRefusedInOverlay(t *testing.T, e *env) {
+func assertReportOpsRefusedInOverlay(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
 	for _, op := range []struct{ method, path string }{
 		{"POST", "/v1/reports/deals-by-stage"},
@@ -443,7 +444,7 @@ func assertReportOpsRefusedInOverlay(t *testing.T, e *env) {
 		var problem struct {
 			Code string `json:"code"`
 		}
-		code := e.call(t, op.method, op.path, nil, nil, &problem)
+		code := e.Call(t, op.method, op.path, nil, nil, &problem)
 		if code != http.StatusUnprocessableEntity || problem.Code != "unsupported_by_sor" {
 			t.Fatalf("overlay-mode %s %s = %d %q, want 422 unsupported_by_sor",
 				op.method, op.path, code, problem.Code)

--- a/backend/internal/compose/integration/overlay_flip_integration_test.go
+++ b/backend/internal/compose/integration/overlay_flip_integration_test.go
@@ -61,6 +61,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/modules/migration"
 	"github.com/gradionhq/margince/backend/internal/modules/overlay"
@@ -78,7 +79,7 @@ import (
 // one lead, and one email activity — plus the association edges the
 // detangling asserts on.
 type flipEstate struct {
-	e       *env
+	e       *apptest.AppEnv
 	wsID    ids.UUID
 	adminID ids.UUID
 	mirror  *overlay.MirrorStore
@@ -131,20 +132,20 @@ func flipAdminCtx(ws, user ids.UUID) context.Context {
 func setupFlipEstate(t *testing.T) flipEstate {
 	t.Helper()
 	vault := keyvault.NewMemory()
-	e := setupWithOptions(t, compose.WithKeyvault(vault))
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupAppWithOptions(t, compose.WithKeyvault(vault))
+	e.BootstrapWorkspace(t)
 
-	if status := e.call(t, "POST", "/v1/overlay/connection", anyMap{
+	if status := e.Call(t, "POST", "/v1/overlay/connection", apptest.AnyMap{
 		"incumbent": "hubspot", "region": "eu1", "privateAppToken": "fake-token-never-used",
 	}, nil, nil); status != http.StatusCreated {
 		t.Fatalf("connect overlay = %d", status)
 	}
 
-	var me anyMap
-	if status := e.call(t, "GET", "/v1/me", nil, nil, &me); status != http.StatusOK {
+	var me apptest.AnyMap
+	if status := e.Call(t, "GET", "/v1/me", nil, nil, &me); status != http.StatusOK {
 		t.Fatalf("/me = %d", status)
 	}
-	user, ok := me["user"].(anyMap)
+	user, ok := me["user"].(apptest.AnyMap)
 	if !ok {
 		t.Fatalf("/me carried no user object: %v", me)
 	}
@@ -157,7 +158,7 @@ func setupFlipEstate(t *testing.T) flipEstate {
 		t.Fatalf("parsing admin id: %v", err)
 	}
 	var wsIDStr string
-	if err := e.owner.QueryRow(context.Background(), `SELECT id FROM workspace WHERE slug = $1`, e.slug).Scan(&wsIDStr); err != nil {
+	if err := e.Owner.QueryRow(context.Background(), `SELECT id FROM workspace WHERE slug = $1`, e.Slug).Scan(&wsIDStr); err != nil {
 		t.Fatalf("workspace lookup: %v", err)
 	}
 	wsID, err := ids.Parse(wsIDStr)
@@ -304,7 +305,7 @@ func (f flipEstate) nativeEstateRows(t *testing.T) map[string]int {
 
 func (f flipEstate) workspaceMode(t *testing.T) (mode string, incumbent *string) {
 	t.Helper()
-	if err := f.e.owner.QueryRow(context.Background(),
+	if err := f.e.Owner.QueryRow(context.Background(),
 		`SELECT x_sor_mode, x_incumbent FROM workspace WHERE id = $1`, f.wsID).Scan(&mode, &incumbent); err != nil {
 		t.Fatalf("reading workspace mode: %v", err)
 	}
@@ -318,7 +319,7 @@ func TestOverlayFlipPreflightBlocksHonestly(t *testing.T) {
 	// 1. Everything green EXCEPT the pre-flip export: not ready, the
 	// export_missing reason named, nothing sealed (F1's no-op return).
 	var verdict crmcontracts.OverlayFlipPreflight
-	if code := e.call(t, "POST", "/v1/overlay/flip:preflight", anyMap{}, nil, &verdict); code != http.StatusOK {
+	if code := e.Call(t, "POST", "/v1/overlay/flip:preflight", apptest.AnyMap{}, nil, &verdict); code != http.StatusOK {
 		t.Fatalf("preflight = %d", code)
 	}
 	if verdict.Ready || !hasBlocking(verdict, "export_missing") {
@@ -332,7 +333,7 @@ func TestOverlayFlipPreflightBlocksHonestly(t *testing.T) {
 	// blocking reason + the emergency disclosure; the workspace stays in
 	// overlay on its last mirror and nothing is partially migrated.
 	f.setConnectionStatus(t, "revoked")
-	if code := e.call(t, "POST", "/v1/overlay/flip:preflight", anyMap{}, nil, &verdict); code != http.StatusOK {
+	if code := e.Call(t, "POST", "/v1/overlay/flip:preflight", apptest.AnyMap{}, nil, &verdict); code != http.StatusOK {
 		t.Fatalf("preflight (revoked) = %d", code)
 	}
 	if verdict.Ready || !hasBlocking(verdict, "incumbent_unreachable") {
@@ -358,8 +359,8 @@ func TestOverlayFlipPreflightBlocksHonestly(t *testing.T) {
 	}
 
 	// The execute op is blocked with the flip-blocked sentinel.
-	var problem anyMap
-	if code := e.call(t, "POST", "/v1/overlay/flip", anyMap{
+	var problem apptest.AnyMap
+	if code := e.Call(t, "POST", "/v1/overlay/flip", apptest.AnyMap{
 		"confirmation_phrase": "FLIP TO SOR",
 	}, nil, &problem); code != http.StatusConflict {
 		t.Fatalf("execute while blocked = %d %v, want 409", code, problem)
@@ -383,7 +384,7 @@ func TestOverlayFlipPreflightBlocksHonestly(t *testing.T) {
 	// seals the snapshot, and previews parity with ZERO rows written.
 	f.setConnectionStatus(t, "active")
 	f.writePreflipExport(t)
-	if code := e.call(t, "POST", "/v1/overlay/flip:preflight", anyMap{}, nil, &verdict); code != http.StatusOK {
+	if code := e.Call(t, "POST", "/v1/overlay/flip:preflight", apptest.AnyMap{}, nil, &verdict); code != http.StatusOK {
 		t.Fatalf("preflight (green) = %d", code)
 	}
 	if !verdict.Ready || len(verdict.Blocking) != 0 {
@@ -412,7 +413,7 @@ func TestOverlayFlipPreflightBlocksHonestly(t *testing.T) {
 	}
 
 	// 4. The typed-phrase gate: a wrong phrase never runs the flip.
-	if code := e.call(t, "POST", "/v1/overlay/flip", anyMap{
+	if code := e.Call(t, "POST", "/v1/overlay/flip", apptest.AnyMap{
 		"confirmation_phrase": "flip to sor",
 	}, nil, &problem); code != http.StatusUnprocessableEntity {
 		t.Fatalf("wrong-phrase execute = %d, want 422", code)
@@ -434,12 +435,12 @@ func TestOverlayFlipFreshSyncExecute(t *testing.T) {
 	f.writePreflipExport(t)
 
 	var verdict crmcontracts.OverlayFlipPreflight
-	if code := e.call(t, "POST", "/v1/overlay/flip:preflight", anyMap{}, nil, &verdict); code != http.StatusOK || !verdict.Ready {
+	if code := e.Call(t, "POST", "/v1/overlay/flip:preflight", apptest.AnyMap{}, nil, &verdict); code != http.StatusOK || !verdict.Ready {
 		t.Fatalf("green preflight = %d ready=%v", code, verdict.Ready)
 	}
 
 	var accepted crmcontracts.OverlayFlipAccepted
-	if code := e.call(t, "POST", "/v1/overlay/flip", anyMap{
+	if code := e.Call(t, "POST", "/v1/overlay/flip", apptest.AnyMap{
 		"confirmation_phrase": "FLIP TO SOR",
 	}, nil, &accepted); code != http.StatusAccepted {
 		t.Fatalf("execute = %d %+v", code, accepted)
@@ -531,18 +532,18 @@ func TestOverlayFlipFreshSyncExecute(t *testing.T) {
 
 	// The lifecycle ops fall back to mode_not_overlay, /me reports
 	// native, and the native read serves the imported person.
-	if code := e.call(t, "GET", "/v1/overlay/sync-status", nil, nil, nil); code != http.StatusNotFound {
+	if code := e.Call(t, "GET", "/v1/overlay/sync-status", nil, nil, nil); code != http.StatusNotFound {
 		t.Errorf("sync-status after flip = %d, want 404 mode_not_overlay", code)
 	}
-	var me anyMap
-	if code := e.call(t, "GET", "/v1/me", nil, nil, &me); code != http.StatusOK {
+	var me apptest.AnyMap
+	if code := e.Call(t, "GET", "/v1/me", nil, nil, &me); code != http.StatusOK {
 		t.Fatalf("/me = %d", code)
 	}
-	if sor, ok := me["system_of_record"].(anyMap); !ok || sor["mode"] != "native" {
+	if sor, ok := me["system_of_record"].(apptest.AnyMap); !ok || sor["mode"] != "native" {
 		t.Errorf("/me system_of_record = %v, want native", me["system_of_record"])
 	}
 	var people crmcontracts.PersonListResponse
-	if code := e.call(t, "GET", "/v1/people", nil, nil, &people); code != http.StatusOK {
+	if code := e.Call(t, "GET", "/v1/people", nil, nil, &people); code != http.StatusOK {
 		t.Fatalf("GET /v1/people after flip = %d", code)
 	}
 	if len(people.Data) != 3 {
@@ -551,7 +552,7 @@ func TestOverlayFlipFreshSyncExecute(t *testing.T) {
 
 	// A second execute is refused: the flip is one-way (the lifecycle op
 	// answers mode_not_overlay once native).
-	if code := e.call(t, "POST", "/v1/overlay/flip", anyMap{
+	if code := e.Call(t, "POST", "/v1/overlay/flip", apptest.AnyMap{
 		"confirmation_phrase": "FLIP TO SOR",
 	}, nil, nil); code != http.StatusNotFound {
 		t.Errorf("second execute = %d, want 404 mode_not_overlay", code)
@@ -565,8 +566,8 @@ func TestOverlayFlipEmergencyCutover(t *testing.T) {
 	// Refused while the incumbent is reachable — the never-substituted
 	// guarantee holds in BOTH directions.
 	f.writePreflipExport(t)
-	var problem anyMap
-	if code := e.call(t, "POST", "/v1/overlay/flip", anyMap{
+	var problem apptest.AnyMap
+	if code := e.Call(t, "POST", "/v1/overlay/flip", apptest.AnyMap{
 		"mode": "emergency", "confirmation_phrase": "FLIP TO SOR",
 	}, nil, &problem); code != http.StatusConflict {
 		t.Fatalf("emergency while reachable = %d, want 409", code)
@@ -581,7 +582,7 @@ func TestOverlayFlipEmergencyCutover(t *testing.T) {
 	f.setConnectionStatus(t, "revoked")
 
 	var accepted crmcontracts.OverlayFlipAccepted
-	if code := e.call(t, "POST", "/v1/overlay/flip", anyMap{
+	if code := e.Call(t, "POST", "/v1/overlay/flip", apptest.AnyMap{
 		"mode": "emergency", "confirmation_phrase": "FLIP TO SOR",
 	}, nil, &accepted); code != http.StatusAccepted {
 		t.Fatalf("emergency execute = %d %+v", code, accepted)
@@ -626,11 +627,11 @@ func TestOverlayExportDownload(t *testing.T) {
 		t.Fatal("no export has happened yet")
 	}
 
-	req, err := http.NewRequest(http.MethodGet, e.ts.URL+"/v1/overlay/export", nil)
+	req, err := http.NewRequest(http.MethodGet, e.TS.URL+"/v1/overlay/export", nil)
 	if err != nil {
 		t.Fatalf("building the export request: %v", err)
 	}
-	resp, err := e.client.Do(req)
+	resp, err := e.Client.Do(req)
 	if err != nil {
 		t.Fatalf("GET /v1/overlay/export: %v", err)
 	}
@@ -682,7 +683,7 @@ func TestOverlayExportDownload(t *testing.T) {
 		t.Errorf("export audit rows = %d, want exactly 1", got)
 	}
 	var verdict crmcontracts.OverlayFlipPreflight
-	if code := e.call(t, "POST", "/v1/overlay/flip:preflight", anyMap{}, nil, &verdict); code != http.StatusOK {
+	if code := e.Call(t, "POST", "/v1/overlay/flip:preflight", apptest.AnyMap{}, nil, &verdict); code != http.StatusOK {
 		t.Fatalf("preflight after export = %d", code)
 	}
 	if hasBlocking(verdict, "export_missing") {
@@ -720,7 +721,7 @@ func TestAbortedExportDoesNotSatisfyTheFlipGate(t *testing.T) {
 
 	// And the preflight still blocks on it.
 	var verdict crmcontracts.OverlayFlipPreflight
-	if code := f.e.call(t, "POST", "/v1/overlay/flip:preflight", anyMap{}, nil, &verdict); code != http.StatusOK {
+	if code := f.e.Call(t, "POST", "/v1/overlay/flip:preflight", apptest.AnyMap{}, nil, &verdict); code != http.StatusOK {
 		t.Fatalf("preflight = %d", code)
 	}
 	if !hasBlocking(verdict, "export_missing") {
@@ -772,11 +773,11 @@ func TestAFlipAdoptsAHalfLandedDealAndFinishesClosingIt(t *testing.T) {
 	})
 
 	var verdict crmcontracts.OverlayFlipPreflight
-	if code := e.call(t, "POST", "/v1/overlay/flip:preflight", anyMap{}, nil, &verdict); code != http.StatusOK || !verdict.Ready {
+	if code := e.Call(t, "POST", "/v1/overlay/flip:preflight", apptest.AnyMap{}, nil, &verdict); code != http.StatusOK || !verdict.Ready {
 		t.Fatalf("green preflight = %d ready=%v", code, verdict.Ready)
 	}
 	var accepted crmcontracts.OverlayFlipAccepted
-	if code := e.call(t, "POST", "/v1/overlay/flip", anyMap{
+	if code := e.Call(t, "POST", "/v1/overlay/flip", apptest.AnyMap{
 		"confirmation_phrase": "FLIP TO SOR",
 	}, nil, &accepted); code != http.StatusAccepted {
 		t.Fatalf("execute = %d %+v", code, accepted)

--- a/backend/internal/compose/integration/overlay_write_audit_integration_test.go
+++ b/backend/internal/compose/integration/overlay_write_audit_integration_test.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 )
 
@@ -40,9 +41,9 @@ type auditRow struct {
 // last. It reads through the owner pool deliberately: the assertion is that
 // the row EXISTS and names the right principal, which must not depend on the
 // reader's own row scope.
-func auditRowsFor(t *testing.T, e *env, entityType, entityID string) []auditRow {
+func auditRowsFor(t *testing.T, e *apptest.AppEnv, entityType, entityID string) []auditRow {
 	t.Helper()
-	rows, err := e.owner.Query(context.Background(), `
+	rows, err := e.Owner.Query(context.Background(), `
 		SELECT action, entity_type, actor_type, actor_id, coalesce(evidence, '{}'::jsonb)
 		  FROM audit_log
 		 WHERE entity_type = $1 AND entity_id = $2
@@ -67,9 +68,9 @@ func auditRowsFor(t *testing.T, e *env, entityType, entityID string) []auditRow 
 }
 
 // outboxTypesFor reads the event types staged for one entity.
-func outboxTypesFor(t *testing.T, e *env, entityType, entityID string) []string {
+func outboxTypesFor(t *testing.T, e *apptest.AppEnv, entityType, entityID string) []string {
 	t.Helper()
-	rows, err := e.owner.Query(context.Background(), `
+	rows, err := e.Owner.Query(context.Background(), `
 		SELECT envelope->>'type'
 		  FROM event_outbox
 		 WHERE envelope->'entity'->>'type' = $1 AND envelope->'entity'->>'id' = $2
@@ -99,10 +100,10 @@ func outboxTypesFor(t *testing.T, e *env, entityType, entityID string) []string 
 func TestOverlayUpdateWritesTheAuditTrail(t *testing.T) {
 	e := setupOverlayWrite(t)
 	e.seed(t, "deal", "9201", map[string]any{"name": "Acme Renewal", "currency": "USD"})
-	id := firstListedID(t, e.env, "/v1/deals")
+	id := firstListedID(t, e.AppEnv, "/v1/deals")
 
 	var deal crmcontracts.Deal
-	if status := e.call(t, "PATCH", "/v1/deals/"+id, anyMap{"name": "Acme Renewal — Q3"}, nil, &deal); status != http.StatusOK {
+	if status := e.Call(t, "PATCH", "/v1/deals/"+id, apptest.AnyMap{"name": "Acme Renewal — Q3"}, nil, &deal); status != http.StatusOK {
 		t.Fatalf("PATCH /v1/deals/%s = %d", id, status)
 	}
 
@@ -113,7 +114,7 @@ func TestOverlayUpdateWritesTheAuditTrail(t *testing.T) {
 		t.Errorf("overlay deal body captured_by = %v, want the required provenance value", deal.CapturedBy)
 	}
 
-	audits := auditRowsFor(t, e.env, "deal", id)
+	audits := auditRowsFor(t, e.AppEnv, "deal", id)
 	if len(audits) != 1 {
 		t.Fatalf("audit_log rows for the updated deal = %d, want exactly 1 — an overlay write must leave the same trail a native write leaves", len(audits))
 	}
@@ -135,7 +136,7 @@ func TestOverlayUpdateWritesTheAuditTrail(t *testing.T) {
 		t.Errorf("audit evidence = %s, want it to name the incumbent record the write landed on", got.evidence)
 	}
 
-	if types := outboxTypesFor(t, e.env, "deal", id); len(types) != 1 || types[0] != "deal.updated" {
+	if types := outboxTypesFor(t, e.AppEnv, "deal", id); len(types) != 1 || types[0] != "deal.updated" {
 		t.Errorf("staged events = %v, want exactly [deal.updated] — a subscriber must not need to know which system of record served the write", types)
 	}
 }
@@ -147,13 +148,13 @@ func TestOverlayUpdateWritesTheAuditTrail(t *testing.T) {
 func TestOverlayArchiveWritesTheAuditTrail(t *testing.T) {
 	e := setupOverlayWrite(t)
 	e.seed(t, "person", "9202", map[string]any{"first_name": "Ada", "last_name": "Overlay"})
-	id := firstListedID(t, e.env, "/v1/people")
+	id := firstListedID(t, e.AppEnv, "/v1/people")
 
-	if status := e.call(t, "DELETE", "/v1/people/"+id, nil, nil, nil); status != http.StatusOK {
+	if status := e.Call(t, "DELETE", "/v1/people/"+id, nil, nil, nil); status != http.StatusOK {
 		t.Fatalf("DELETE /v1/people/%s = %d", id, status)
 	}
 
-	audits := auditRowsFor(t, e.env, "person", id)
+	audits := auditRowsFor(t, e.AppEnv, "person", id)
 	if len(audits) != 1 {
 		t.Fatalf("audit_log rows for the archived person = %d, want exactly 1 — a record removed from the customer's CRM with no audit row has no answer to who removed it", len(audits))
 	}
@@ -164,7 +165,7 @@ func TestOverlayArchiveWritesTheAuditTrail(t *testing.T) {
 		t.Errorf("audit actor_type = %q, want %q", audits[0].actorType, "human")
 	}
 
-	types := outboxTypesFor(t, e.env, "person", id)
+	types := outboxTypesFor(t, e.AppEnv, "person", id)
 	if !containsString(types, "person.archived") {
 		t.Errorf("staged events = %v, want them to include person.archived", types)
 	}
@@ -177,13 +178,13 @@ func TestOverlayArchiveWritesTheAuditTrail(t *testing.T) {
 func TestOverlayRefusedWriteLeavesNoAuditTrail(t *testing.T) {
 	e := setupOverlayWrite(t)
 	e.seed(t, "lead", "9203", map[string]any{"full_name": "Refused Lead"})
-	id := firstListedID(t, e.env, "/v1/leads")
+	id := firstListedID(t, e.AppEnv, "/v1/leads")
 
 	// Archive is not a verb the mirror serves for a lead.
-	if status := e.call(t, "DELETE", "/v1/leads/"+id, nil, nil, nil); status != http.StatusUnprocessableEntity {
+	if status := e.Call(t, "DELETE", "/v1/leads/"+id, nil, nil, nil); status != http.StatusUnprocessableEntity {
 		t.Fatalf("DELETE /v1/leads/%s = %d, want 422 unsupported_by_sor", id, status)
 	}
-	if audits := auditRowsFor(t, e.env, "lead", id); len(audits) != 0 {
+	if audits := auditRowsFor(t, e.AppEnv, "lead", id); len(audits) != 0 {
 		t.Errorf("audit_log rows after a refused archive = %d, want 0 — a refusal is not a mutation", len(audits))
 	}
 }

--- a/backend/internal/compose/integration/overlay_write_shadow_integration_test.go
+++ b/backend/internal/compose/integration/overlay_write_shadow_integration_test.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/modules/overlay"
 	"github.com/gradionhq/margince/backend/internal/modules/overlay/fake"
@@ -47,7 +48,7 @@ import (
 // nothing to do with the write-shadow code under test (overlay_e2e_test.go
 // establishes the same fixture shape for the read side).
 type overlayWriteEnv struct {
-	*env
+	*apptest.AppEnv
 	fake   *fake.Adapter
 	mirror *overlay.MirrorStore
 	ctx    context.Context // workspace+admin-bound, for direct mirror/fake seeding
@@ -58,30 +59,30 @@ func setupOverlayWrite(t *testing.T) overlayWriteEnv {
 	fakeInc := fake.New()
 	fakeInc.SeedOwner("owner-1", "owner@overlay.test")
 	vault := keyvault.NewMemory()
-	e := setupWithOptions(t, compose.WithKeyvault(vault),
+	e := apptest.SetupAppWithOptions(t, compose.WithKeyvault(vault),
 		// Applied AFTER WithKeyvault so it wins: WithKeyvault's own
 		// SetOverlayIncumbentResolver call would otherwise install the
 		// real vaulted resolver last.
 		compose.WithOverlayIncumbentResolver(func(context.Context) (overlay.Incumbent, error) { return fakeInc, nil }))
-	e.bootstrapWorkspace(t)
+	e.BootstrapWorkspace(t)
 
 	var conn map[string]any
-	if status := e.call(t, "POST", "/v1/overlay/connection", anyMap{
+	if status := e.Call(t, "POST", "/v1/overlay/connection", apptest.AnyMap{
 		"incumbent": "hubspot", "region": "eu1", "privateAppToken": "fake-token-never-used",
 	}, nil, &conn); status != http.StatusCreated {
 		t.Fatalf("connect overlay = %d %v", status, conn)
 	}
 
-	var me anyMap
-	if status := e.call(t, "GET", "/v1/me", nil, nil, &me); status != http.StatusOK {
+	var me apptest.AnyMap
+	if status := e.Call(t, "GET", "/v1/me", nil, nil, &me); status != http.StatusOK {
 		t.Fatalf("/me status = %d", status)
 	}
-	adminID, err := ids.Parse(me["user"].(anyMap)["id"].(string))
+	adminID, err := ids.Parse(me["user"].(apptest.AnyMap)["id"].(string))
 	if err != nil {
 		t.Fatalf("parsing admin user id: %v", err)
 	}
 	var wsIDStr string
-	if err := e.owner.QueryRow(context.Background(), `SELECT id FROM workspace WHERE slug = $1`, e.slug).Scan(&wsIDStr); err != nil {
+	if err := e.Owner.QueryRow(context.Background(), `SELECT id FROM workspace WHERE slug = $1`, e.Slug).Scan(&wsIDStr); err != nil {
 		t.Fatalf("looking up the workspace id: %v", err)
 	}
 	wsID, err := ids.Parse(wsIDStr)
@@ -89,12 +90,12 @@ func setupOverlayWrite(t *testing.T) overlayWriteEnv {
 		t.Fatalf("parsing workspace id: %v", err)
 	}
 
-	mirror := overlay.NewMirrorStore(e.pool, stubOwnerEmails{})
+	mirror := overlay.NewMirrorStore(e.Pool, stubOwnerEmails{})
 	actorCtx := overlayActorCtx(wsID, adminID)
 	if err := mirror.UpsertUserMap(actorCtx, ids.From[ids.UserKind](adminID), "hubspot", "owner-1", "manual"); err != nil {
 		t.Fatalf("mapping the admin to the fake incumbent owner: %v", err)
 	}
-	return overlayWriteEnv{env: e, fake: fakeInc, mirror: mirror, ctx: actorCtx}
+	return overlayWriteEnv{AppEnv: e, fake: fakeInc, mirror: mirror, ctx: actorCtx}
 }
 
 // seedModifiedAt is deliberately a fixed instant well before fake.Adapter's
@@ -135,14 +136,14 @@ func (e overlayWriteEnv) seed(t *testing.T, class, externalID string, fields map
 // externalIDToUUID) is unexported, so the honest way to learn it from this
 // black-box package is the same one a real client would use: list and read
 // the id back off the wire.
-func firstListedID(t *testing.T, e *env, path string) string {
+func firstListedID(t *testing.T, e *apptest.AppEnv, path string) string {
 	t.Helper()
 	var page struct {
 		Data []struct {
 			ID string `json:"id"`
 		} `json:"data"`
 	}
-	if status := e.call(t, "GET", path, nil, nil, &page); status != http.StatusOK {
+	if status := e.Call(t, "GET", path, nil, nil, &page); status != http.StatusOK {
 		t.Fatalf("GET %s = %d", path, status)
 	}
 	if len(page.Data) != 1 {
@@ -157,10 +158,10 @@ func firstListedID(t *testing.T, e *env, path string) string {
 func TestOverlayUpdateDealWritesBackAndReturnsTheMirroredRow(t *testing.T) {
 	e := setupOverlayWrite(t)
 	e.seed(t, "deal", "9001", map[string]any{"name": "Acme Renewal", "currency": "USD"})
-	id := firstListedID(t, e.env, "/v1/deals")
+	id := firstListedID(t, e.AppEnv, "/v1/deals")
 
 	var deal crmcontracts.Deal
-	if status := e.call(t, "PATCH", "/v1/deals/"+id, anyMap{"name": "Acme Renewal — Q3"}, nil, &deal); status != http.StatusOK {
+	if status := e.Call(t, "PATCH", "/v1/deals/"+id, apptest.AnyMap{"name": "Acme Renewal — Q3"}, nil, &deal); status != http.StatusOK {
 		t.Fatalf("PATCH /v1/deals/%s = %d", id, status)
 	}
 	if deal.Name != "Acme Renewal — Q3" {
@@ -188,10 +189,10 @@ func TestOverlayUpdateDealWritesBackAndReturnsTheMirroredRow(t *testing.T) {
 func TestOverlayArchivePersonWritesBack(t *testing.T) {
 	e := setupOverlayWrite(t)
 	e.seed(t, "person", "9101", map[string]any{"first_name": "Ada", "last_name": "Overlay"})
-	id := firstListedID(t, e.env, "/v1/people")
+	id := firstListedID(t, e.AppEnv, "/v1/people")
 
 	var person crmcontracts.Person
-	if status := e.call(t, "DELETE", "/v1/people/"+id, nil, nil, &person); status != http.StatusOK {
+	if status := e.Call(t, "DELETE", "/v1/people/"+id, nil, nil, &person); status != http.StatusOK {
 		t.Fatalf("DELETE /v1/people/%s = %d, want 200 (architecture/11 §8: never a bare 204 for a domain row)", id, status)
 	}
 	if person.FullName != "Ada Overlay" {
@@ -210,7 +211,7 @@ func TestOverlayArchivePersonWritesBack(t *testing.T) {
 	// — the upstream question is what archive means when the system of record
 	// is an incumbent, and this assertion is what will fail loudly the day
 	// that answer lands.
-	if status := e.call(t, "GET", "/v1/people/"+id, nil, nil, nil); status != http.StatusNotFound {
+	if status := e.Call(t, "GET", "/v1/people/"+id, nil, nil, nil); status != http.StatusNotFound {
 		t.Fatalf("GET the archived person = %d, want 404 (the mirror row is purged by the archive itself)", status)
 	}
 }
@@ -222,15 +223,15 @@ func TestOverlayUnsupportedWritesStillRefused(t *testing.T) {
 	e := setupOverlayWrite(t)
 	placeholder := ids.NewV7().String()
 
-	if status := e.call(t, "POST", "/v1/deals/"+placeholder+"/advance",
-		anyMap{"to_stage_id": placeholder}, nil, nil); status != http.StatusUnprocessableEntity {
+	if status := e.Call(t, "POST", "/v1/deals/"+placeholder+"/advance",
+		apptest.AnyMap{"to_stage_id": placeholder}, nil, nil); status != http.StatusUnprocessableEntity {
 		t.Fatalf("advance_deal in overlay mode = %d, want 422 unsupported_by_sor", status)
 	}
-	if status := e.call(t, "POST", "/v1/people",
-		anyMap{"full_name": "Should Never Land"}, nil, nil); status != http.StatusUnprocessableEntity {
+	if status := e.Call(t, "POST", "/v1/people",
+		apptest.AnyMap{"full_name": "Should Never Land"}, nil, nil); status != http.StatusUnprocessableEntity {
 		t.Fatalf("create person in overlay mode = %d, want 422 unsupported_by_sor", status)
 	}
-	if status := e.call(t, "DELETE", "/v1/activities/"+placeholder, nil, nil, nil); status != http.StatusUnprocessableEntity {
+	if status := e.Call(t, "DELETE", "/v1/activities/"+placeholder, nil, nil, nil); status != http.StatusUnprocessableEntity {
 		t.Fatalf("archive activity in overlay mode = %d, want 422 unsupported_by_sor", status)
 	}
 	// DELETE /v1/leads/{id} is disqualify_lead (a lifecycle verb, not a
@@ -239,14 +240,14 @@ func TestOverlayUnsupportedWritesStillRefused(t *testing.T) {
 	// (overlaywrite_test.go's "lead disqualify refused in overlay"), so a
 	// policy regen or a new overlayWriteVerbs entry sending it to
 	// DisqualifyLead's native handler fails a test here too.
-	if status := e.call(t, "DELETE", "/v1/leads/"+placeholder, nil, nil, nil); status != http.StatusUnprocessableEntity {
+	if status := e.Call(t, "DELETE", "/v1/leads/"+placeholder, nil, nil, nil); status != http.StatusUnprocessableEntity {
 		t.Fatalf("disqualify lead in overlay mode = %d, want 422 unsupported_by_sor", status)
 	}
 
 	var personCount int
-	if err := e.owner.QueryRow(
+	if err := e.Owner.QueryRow(
 		context.Background(),
-		`SELECT count(*) FROM person WHERE workspace_id = (SELECT id FROM workspace WHERE slug = $1)`, e.slug,
+		`SELECT count(*) FROM person WHERE workspace_id = (SELECT id FROM workspace WHERE slug = $1)`, e.Slug,
 	).Scan(&personCount); err != nil {
 		t.Fatalf("counting native person rows: %v", err)
 	}
@@ -263,7 +264,7 @@ func TestOverlayTagWriteStillWorks(t *testing.T) {
 	e := setupOverlayWrite(t)
 
 	var tag crmcontracts.Tag
-	if status := e.call(t, "POST", "/v1/tags", anyMap{"name": "hot-lead"}, nil, &tag); status != http.StatusCreated {
+	if status := e.Call(t, "POST", "/v1/tags", apptest.AnyMap{"name": "hot-lead"}, nil, &tag); status != http.StatusCreated {
 		t.Fatalf("POST /v1/tags in overlay mode = %d, want 201", status)
 	}
 	if tag.Name != "hot-lead" {
@@ -278,10 +279,10 @@ func TestOverlayTagWriteStillWorks(t *testing.T) {
 func TestOverlayUpdateIgnoresIfMatch(t *testing.T) {
 	e := setupOverlayWrite(t)
 	e.seed(t, "person", "9102", map[string]any{"first_name": "Grace", "last_name": "Overlay"})
-	id := firstListedID(t, e.env, "/v1/people")
+	id := firstListedID(t, e.AppEnv, "/v1/people")
 
 	var person crmcontracts.Person
-	status := e.call(t, "PATCH", "/v1/people/"+id, anyMap{"first_name": "Grace2"},
+	status := e.Call(t, "PATCH", "/v1/people/"+id, apptest.AnyMap{"first_name": "Grace2"},
 		map[string]string{"If-Match": "999"}, &person)
 	if status != http.StatusOK {
 		t.Fatalf("PATCH with a stale If-Match = %d, want 200 (If-Match is not evaluated on the overlay path)", status)
@@ -307,11 +308,11 @@ func TestOverlayUpdateIgnoresIfMatch(t *testing.T) {
 func TestOverlayUpdateDropsUnmappedFields(t *testing.T) {
 	e := setupOverlayWrite(t)
 	e.seed(t, "person", "9103", map[string]any{"first_name": "Rosalind", "last_name": "Overlay"})
-	id := firstListedID(t, e.env, "/v1/people")
+	id := firstListedID(t, e.AppEnv, "/v1/people")
 
 	var person crmcontracts.Person
-	status := e.call(t, "PATCH", "/v1/people/"+id,
-		anyMap{"first_name": "Rosalind2", "owner_id": ids.NewV7().String()}, nil, &person)
+	status := e.Call(t, "PATCH", "/v1/people/"+id,
+		apptest.AnyMap{"first_name": "Rosalind2", "owner_id": ids.NewV7().String()}, nil, &person)
 	if status != http.StatusOK {
 		t.Fatalf("PATCH with an owner_id field = %d, want 200", status)
 	}
@@ -337,7 +338,7 @@ type overlayUpdateCase struct {
 	path       string
 	externalID string
 	seedFields map[string]any
-	patch      anyMap
+	patch      apptest.AnyMap
 	field      string
 	want       string
 }
@@ -370,20 +371,20 @@ type overlayArchiveCase struct {
 // uniform proof per type rather than five ad hoc ones.
 func TestOverlayWriteShadowsRoundTripEveryMirroredType(t *testing.T) {
 	updates := []overlayUpdateCase{
-		{"person", "/v1/people", "9301", map[string]any{"first_name": "Marie"}, anyMap{"first_name": "Marie2"}, "first_name", "Marie2"},
-		{"organization", "/v1/organizations", "9302", map[string]any{"display_name": "Acme Org"}, anyMap{"display_name": "Acme Org 2"}, "display_name", "Acme Org 2"},
-		{"deal", "/v1/deals", "9303", map[string]any{"name": "Widget Deal"}, anyMap{"name": "Widget Deal 2"}, "name", "Widget Deal 2"},
-		{"lead", "/v1/leads", "9304", map[string]any{"full_name": "Grace Lead"}, anyMap{"full_name": "Grace Lead 2"}, "full_name", "Grace Lead 2"},
-		{"activity", "/v1/activities", "9305", map[string]any{"kind": "call", "subject": "Intro Call"}, anyMap{"subject": "Intro Call 2"}, "subject", "Intro Call 2"},
+		{"person", "/v1/people", "9301", map[string]any{"first_name": "Marie"}, apptest.AnyMap{"first_name": "Marie2"}, "first_name", "Marie2"},
+		{"organization", "/v1/organizations", "9302", map[string]any{"display_name": "Acme Org"}, apptest.AnyMap{"display_name": "Acme Org 2"}, "display_name", "Acme Org 2"},
+		{"deal", "/v1/deals", "9303", map[string]any{"name": "Widget Deal"}, apptest.AnyMap{"name": "Widget Deal 2"}, "name", "Widget Deal 2"},
+		{"lead", "/v1/leads", "9304", map[string]any{"full_name": "Grace Lead"}, apptest.AnyMap{"full_name": "Grace Lead 2"}, "full_name", "Grace Lead 2"},
+		{"activity", "/v1/activities", "9305", map[string]any{"kind": "call", "subject": "Intro Call"}, apptest.AnyMap{"subject": "Intro Call 2"}, "subject", "Intro Call 2"},
 	}
 	for _, tc := range updates {
 		t.Run("update/"+tc.entityType, func(t *testing.T) {
 			e := setupOverlayWrite(t)
 			e.seed(t, tc.entityType, tc.externalID, tc.seedFields)
-			id := firstListedID(t, e.env, tc.path)
+			id := firstListedID(t, e.AppEnv, tc.path)
 
-			var body anyMap
-			if status := e.call(t, "PATCH", tc.path+"/"+id, tc.patch, nil, &body); status != http.StatusOK {
+			var body apptest.AnyMap
+			if status := e.Call(t, "PATCH", tc.path+"/"+id, tc.patch, nil, &body); status != http.StatusOK {
 				t.Fatalf("PATCH %s/%s = %d", tc.path, id, status)
 			}
 			if got, _ := body[tc.field].(string); got != tc.want {
@@ -401,10 +402,10 @@ func TestOverlayWriteShadowsRoundTripEveryMirroredType(t *testing.T) {
 		t.Run("archive/"+tc.entityType, func(t *testing.T) {
 			e := setupOverlayWrite(t)
 			e.seed(t, tc.entityType, tc.externalID, tc.seedFields)
-			id := firstListedID(t, e.env, tc.path)
+			id := firstListedID(t, e.AppEnv, tc.path)
 
-			var body anyMap
-			if status := e.call(t, "DELETE", tc.path+"/"+id, nil, nil, &body); status != http.StatusOK {
+			var body apptest.AnyMap
+			if status := e.Call(t, "DELETE", tc.path+"/"+id, nil, nil, &body); status != http.StatusOK {
 				t.Fatalf("DELETE %s/%s = %d, want 200", tc.path, id, status)
 			}
 			if got, _ := body[tc.field].(string); got != tc.want {
@@ -427,7 +428,7 @@ func TestMirroredOrganizationsStateTheyAreNotTheOwnCompany(t *testing.T) {
 	e.seed(t, "organization", "9320", map[string]any{"display_name": "Mirrored Org"})
 
 	var page crmcontracts.OrganizationListResponse
-	if status := e.call(t, "GET", "/v1/organizations", nil, nil, &page); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/organizations", nil, nil, &page); status != http.StatusOK {
 		t.Fatalf("GET /v1/organizations = %d", status)
 	}
 	if len(page.Data) != 1 {

--- a/backend/internal/compose/integration/partner_lifecycle_integration_test.go
+++ b/backend/internal/compose/integration/partner_lifecycle_integration_test.go
@@ -14,6 +14,8 @@ package integration
 import (
 	"net/http"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 )
 
 // partnerWire is the contract Partner shape as this suite reads it.
@@ -34,14 +36,14 @@ func TestPartnerLifecycleFieldsRoundTrip(t *testing.T) {
 
 	// Upsert with the full lifecycle block.
 	var upserted partnerWire
-	if status := e.call(t, "PUT", "/v1/organizations/"+e.orgID+"/partner", anyMap{
+	if status := e.Call(t, "PUT", "/v1/organizations/"+e.orgID+"/partner", apptest.AnyMap{
 		"partner_role":       "consulting",
 		"cert_status":        "applied",
 		"relationship_stage": "in_conversation",
 		"next_step":          "Send the partnership one-pager",
 		"next_step_due_at":   "2026-08-01",
 		"served_segments":    []string{"manufacturing", "fintech"},
-		"gate_metrics":       anyMap{"certified_staff": 4, "retention_rate": 87},
+		"gate_metrics":       apptest.AnyMap{"certified_staff": 4, "retention_rate": 87},
 	}, nil, &upserted); status != http.StatusOK {
 		t.Fatalf("upsert partner with lifecycle fields → %d", status)
 	}
@@ -51,7 +53,7 @@ func TestPartnerLifecycleFieldsRoundTrip(t *testing.T) {
 
 	// The read-back returns exactly what was written.
 	var fetched partnerWire
-	if status := e.call(t, "GET", "/v1/organizations/"+e.orgID+"/partner", nil, nil, &fetched); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/organizations/"+e.orgID+"/partner", nil, nil, &fetched); status != http.StatusOK {
 		t.Fatalf("get partner → %d", status)
 	}
 	if fetched.OrganizationID != e.orgID || fetched.PartnerRole != "consulting" || fetched.CertStatus != "applied" {
@@ -75,14 +77,14 @@ func TestPartnerLifecycleFieldsRoundTrip(t *testing.T) {
 
 	// A stage outside the closed lifecycle vocabulary is refused at the
 	// seam — 422, and the stored stage stands.
-	if status := e.call(t, "PUT", "/v1/organizations/"+e.orgID+"/partner", anyMap{
+	if status := e.Call(t, "PUT", "/v1/organizations/"+e.orgID+"/partner", apptest.AnyMap{
 		"partner_role":       "consulting",
 		"relationship_stage": "best_friends",
 	}, map[string]string{"If-Match": "1"}, nil); status != 422 {
 		t.Fatalf("unknown relationship_stage → %d, want 422", status)
 	}
 	var after partnerWire
-	if status := e.call(t, "GET", "/v1/organizations/"+e.orgID+"/partner", nil, nil, &after); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/organizations/"+e.orgID+"/partner", nil, nil, &after); status != http.StatusOK {
 		t.Fatalf("get partner after refusal → %d", status)
 	}
 	if after.RelationshipStage != "in_conversation" {

--- a/backend/internal/compose/integration/pipeline_config_integration_test.go
+++ b/backend/internal/compose/integration/pipeline_config_integration_test.go
@@ -13,29 +13,31 @@ package integration
 import (
 	"net/http"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 )
 
 func TestPipelineStageConfigLifecycle(t *testing.T) {
-	e := setup(t)
-	e.slug = "cfg-e2e"
-	bootstrapWorkspaceSession(t, e, "Cfg E2E", "cfg@fable.test", "Admin")
+	e := apptest.SetupApp(t)
+	e.Slug = "cfg-e2e"
+	apptest.BootstrapWorkspaceSession(t, e, "Cfg E2E", "cfg@fable.test", "Admin")
 
 	var second struct {
 		ID        string `json:"id"`
 		IsDefault bool   `json:"is_default"`
 	}
-	if status := e.call(t, "POST", "/v1/pipelines", anyMap{
-		"name": "Partnerships", "stages": []anyMap{{"name": "Scout", "position": 1}},
+	if status := e.Call(t, "POST", "/v1/pipelines", apptest.AnyMap{
+		"name": "Partnerships", "stages": []apptest.AnyMap{{"name": "Scout", "position": 1}},
 	}, nil, &second); status != http.StatusCreated {
 		t.Fatalf("create pipeline → %d", status)
 	}
 
 	// Promoting the new pipeline demotes the seeded default in one tx.
-	if status := e.call(t, "PATCH", "/v1/pipelines/"+second.ID, anyMap{"is_default": true}, nil, nil); status != http.StatusOK {
+	if status := e.Call(t, "PATCH", "/v1/pipelines/"+second.ID, apptest.AnyMap{"is_default": true}, nil, nil); status != http.StatusOK {
 		t.Fatalf("promote default → %d", status)
 	}
 	var defaults int
-	if err := e.owner.QueryRow(t.Context(),
+	if err := e.Owner.QueryRow(t.Context(),
 		`SELECT count(*) FROM pipeline WHERE is_default`).Scan(&defaults); err != nil {
 		t.Fatal(err)
 	}
@@ -47,13 +49,13 @@ func TestPipelineStageConfigLifecycle(t *testing.T) {
 		ID             string `json:"id"`
 		WinProbability int    `json:"win_probability"`
 	}
-	if status := e.call(t, "POST", "/v1/stages", anyMap{
+	if status := e.Call(t, "POST", "/v1/stages", apptest.AnyMap{
 		"pipeline_id": second.ID, "name": "Won", "position": 2, "semantic": "won",
 	}, nil, &stage); status != http.StatusCreated {
 		t.Fatalf("create stage → %d", status)
 	}
 	// A colliding position is a 409, not a 500.
-	if status := e.call(t, "POST", "/v1/stages", anyMap{
+	if status := e.Call(t, "POST", "/v1/stages", apptest.AnyMap{
 		"pipeline_id": second.ID, "name": "Dup", "position": 2,
 	}, nil, nil); status != http.StatusConflict {
 		t.Fatalf("position collision → %d, want 409", status)
@@ -63,14 +65,14 @@ func TestPipelineStageConfigLifecycle(t *testing.T) {
 	}
 
 	// Rename → stage.updated; reorder → ONE pipeline.updated.
-	if status := e.call(t, "PATCH", "/v1/stages/"+stage.ID, anyMap{"name": "Closed Won"}, nil, nil); status != http.StatusOK {
+	if status := e.Call(t, "PATCH", "/v1/stages/"+stage.ID, apptest.AnyMap{"name": "Closed Won"}, nil, nil); status != http.StatusOK {
 		t.Fatalf("rename stage → %d", status)
 	}
-	if status := e.call(t, "PATCH", "/v1/stages/"+stage.ID, anyMap{"position": 5}, nil, nil); status != http.StatusOK {
+	if status := e.Call(t, "PATCH", "/v1/stages/"+stage.ID, apptest.AnyMap{"position": 5}, nil, nil); status != http.StatusOK {
 		t.Fatalf("reorder stage → %d", status)
 	}
 	var stageUpdated, pipelineUpdated int
-	if err := e.owner.QueryRow(t.Context(),
+	if err := e.Owner.QueryRow(t.Context(),
 		`SELECT count(*) FILTER (WHERE envelope->>'type' = 'stage.updated'),
 		        count(*) FILTER (WHERE envelope->>'type' = 'pipeline.updated')
 		 FROM event_outbox`).Scan(&stageUpdated, &pipelineUpdated); err != nil {
@@ -85,10 +87,10 @@ func TestPipelineStageConfigLifecycle(t *testing.T) {
 			ID string `json:"id"`
 		} `json:"data"`
 	}
-	if status := e.call(t, "GET", "/v1/stages?pipeline_id="+second.ID, nil, nil, &stages); status != http.StatusOK || len(stages.Data) != 2 {
+	if status := e.Call(t, "GET", "/v1/stages?pipeline_id="+second.ID, nil, nil, &stages); status != http.StatusOK || len(stages.Data) != 2 {
 		t.Fatalf("list stages → %d %+v", status, stages)
 	}
-	if status := e.call(t, "GET", "/v1/stages/"+stage.ID, nil, nil, nil); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/stages/"+stage.ID, nil, nil, nil); status != http.StatusOK {
 		t.Fatalf("get stage → %d", status)
 	}
 }
@@ -103,19 +105,19 @@ func TestDealStakeholdersView(t *testing.T) {
 			} `json:"stages"`
 		} `json:"data"`
 	}
-	if status := e.call(t, "GET", "/v1/pipelines", nil, nil, &pipelines); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/pipelines", nil, nil, &pipelines); status != http.StatusOK {
 		t.Fatalf("pipelines → %d", status)
 	}
 	var deal struct {
 		ID string `json:"id"`
 	}
-	if status := e.call(t, "POST", "/v1/deals", anyMap{
+	if status := e.Call(t, "POST", "/v1/deals", apptest.AnyMap{
 		"name": "Stakeholder Deal", "pipeline_id": pipelines.Data[0].ID,
 		"stage_id": pipelines.Data[0].Stages[0].ID,
 	}, nil, &deal); status != http.StatusCreated {
 		t.Fatalf("create deal → %d", status)
 	}
-	if status := e.call(t, "POST", "/v1/relationships", anyMap{
+	if status := e.Call(t, "POST", "/v1/relationships", apptest.AnyMap{
 		"kind": "deal_stakeholder", "deal_id": deal.ID, "person_id": e.personID,
 		"role": "champion", "source": "ui",
 	}, nil, nil); status != http.StatusCreated {
@@ -127,14 +129,14 @@ func TestDealStakeholdersView(t *testing.T) {
 			Role string `json:"role"`
 		} `json:"data"`
 	}
-	if status := e.call(t, "GET", "/v1/deals/"+deal.ID+"/stakeholders", nil, nil, &stakeholders); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/deals/"+deal.ID+"/stakeholders", nil, nil, &stakeholders); status != http.StatusOK {
 		t.Fatalf("stakeholders → %d", status)
 	}
 	if len(stakeholders.Data) != 1 || stakeholders.Data[0].Role != "champion" {
 		t.Fatalf("stakeholder view: %+v", stakeholders)
 	}
 	// An unknown deal answers absent, not an empty page.
-	if status := e.call(t, "GET", "/v1/deals/00000000-0000-7000-8000-00000000dead/stakeholders", nil, nil, nil); status != http.StatusNotFound {
+	if status := e.Call(t, "GET", "/v1/deals/00000000-0000-7000-8000-00000000dead/stakeholders", nil, nil, nil); status != http.StatusNotFound {
 		t.Fatalf("unknown deal stakeholders → %d, want 404", status)
 	}
 }

--- a/backend/internal/compose/integration/preference_center_integration_test.go
+++ b/backend/internal/compose/integration/preference_center_integration_test.go
@@ -24,6 +24,8 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 )
 
 // sendMarketing issues an authenticated send-email and returns the status
@@ -33,20 +35,20 @@ import (
 // (transmittedBody), not this response: the API caller is not the recipient
 // and has nothing to unsubscribe from. host/xfProto let a test forge the
 // request origin to prove the emitted link ignores them.
-func sendMarketing(t *testing.T, e *env, activityID, purpose, host, xfProto string) (int, string) {
+func sendMarketing(t *testing.T, e *apptest.AppEnv, activityID, purpose, host, xfProto string) (int, string) {
 	t.Helper()
-	raw, err := json.Marshal(anyMap{
+	raw, err := json.Marshal(apptest.AnyMap{
 		"subject": "Newsletter", "body": "hello", "to": []string{"subject@consent.test"}, "consent_purpose": purpose,
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	req, err := http.NewRequest("POST", e.ts.URL+"/v1/activities/"+activityID+"/send-email", bytes.NewReader(raw))
+	req, err := http.NewRequest("POST", e.TS.URL+"/v1/activities/"+activityID+"/send-email", bytes.NewReader(raw))
 	if err != nil {
 		t.Fatal(err)
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-Workspace-Slug", e.slug)
+	req.Header.Set("X-Workspace-Slug", e.Slug)
 	// The forgeable request-origin signals a proxied deployment would carry:
 	// the send must ignore ALL of them and use the configured base, or the
 	// tokenized link could be pointed at an attacker's domain.
@@ -57,11 +59,11 @@ func sendMarketing(t *testing.T, e *env, activityID, purpose, host, xfProto stri
 	if xfProto != "" {
 		req.Header.Set("X-Forwarded-Proto", xfProto)
 	}
-	resp, err := e.client.Do(req)
+	resp, err := e.Client.Do(req) //nolint:bodyclose // closed by the deferred apptest.CloseBody below; bodyclose only sees a Close in the same package, and the closer moved out with the fixture
 	if err != nil {
 		t.Fatalf("send-email: %v", err)
 	}
-	defer closeBody(t, resp)
+	defer apptest.CloseBody(t, resp)
 	payload, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
@@ -87,7 +89,7 @@ func sendMarketing(t *testing.T, e *env, activityID, purpose, host, xfProto stri
 func transmittedBody(t *testing.T, c *consentEnv) string {
 	t.Helper()
 	var body string
-	if err := c.owner.QueryRow(context.Background(),
+	if err := c.Owner.QueryRow(context.Background(),
 		`SELECT body FROM comms_outbound ORDER BY id DESC LIMIT 1`).Scan(&body); err != nil {
 		t.Fatalf("reading the staged delivery: %v", err)
 	}
@@ -123,7 +125,7 @@ func tokenFromLink(t *testing.T, link string) string {
 
 func grantPurpose(t *testing.T, c *consentEnv, purposeID string) {
 	t.Helper()
-	if status := c.call(t, "POST", "/v1/people/"+c.personID+"/consent", anyMap{
+	if status := c.Call(t, "POST", "/v1/people/"+c.personID+"/consent", apptest.AnyMap{
 		"purpose_id": purposeID, "new_state": "granted", "lawful_basis": "consent",
 	}, nil, nil); status != http.StatusOK {
 		t.Fatalf("grant %s → %d", purposeID, status)
@@ -137,7 +139,7 @@ func createNewsletterPurpose(t *testing.T, c *consentEnv) string {
 	var newsletter struct {
 		ID string `json:"id"`
 	}
-	if status := c.call(t, "POST", "/v1/consent-purposes", anyMap{
+	if status := c.Call(t, "POST", "/v1/consent-purposes", apptest.AnyMap{
 		"key": "newsletter", "label": "Newsletter", "requires_double_opt_in": false,
 	}, nil, &newsletter); status != http.StatusCreated {
 		t.Fatalf("create newsletter purpose → %d", status)
@@ -156,7 +158,7 @@ func sendAndAssertUnsubscribeLink(t *testing.T, c *consentEnv) string {
 	t.Helper()
 	// The marketing send carries the one-click link, built from the
 	// configured base — NOT from the request Host.
-	status, _ := sendMarketing(t, c.env, c.activityID, "newsletter", "", "")
+	status, _ := sendMarketing(t, c.AppEnv, c.activityID, "newsletter", "", "")
 	if status != http.StatusAccepted {
 		t.Fatalf("marketing send → %d, want 202", status)
 	}
@@ -174,7 +176,7 @@ func sendAndAssertUnsubscribeLink(t *testing.T, c *consentEnv) string {
 	// delivery, so a hostile send refused before staging would leave this
 	// assertion re-reading the benign one above and passing without ever
 	// proving the forged headers were ignored.
-	hostileStatus, _ := sendMarketing(t, c.env, c.activityID, "newsletter", "evil.example.com", "http")
+	hostileStatus, _ := sendMarketing(t, c.AppEnv, c.activityID, "newsletter", "evil.example.com", "http")
 	if hostileStatus != http.StatusAccepted {
 		t.Fatalf("hostile-origin marketing send → %d, want 202 — the link assertion below needs this send to have staged", hostileStatus)
 	}
@@ -185,7 +187,7 @@ func sendAndAssertUnsubscribeLink(t *testing.T, c *consentEnv) string {
 
 	// A transactional (locked) send has nothing to unsubscribe from, so
 	// nothing is appended to what the sender wrote.
-	if _, tbody := sendMarketing(t, c.env, c.activityID, "transactional", "", ""); strings.Contains(tbody, "/unsubscribe") {
+	if _, tbody := sendMarketing(t, c.AppEnv, c.activityID, "transactional", "", ""); strings.Contains(tbody, "/unsubscribe") {
 		t.Fatalf("transactional send carried an unsubscribe link:\n%s", tbody)
 	}
 	return token
@@ -204,7 +206,7 @@ type prefView struct {
 func readPreferenceView(t *testing.T, c *consentEnv, token string) prefView {
 	t.Helper()
 	var v prefView
-	if s := publicCall(t, c.env, "GET", "/v1/public/preferences/"+token, nil, nil, &v); s != http.StatusOK {
+	if s := publicCall(t, c.AppEnv, "GET", "/v1/public/preferences/"+token, nil, nil, &v); s != http.StatusOK {
 		t.Fatalf("preference center GET → %d", s)
 	}
 	return v
@@ -230,11 +232,11 @@ func purposeStateOf(t *testing.T, v prefView, key string) (string, bool) {
 func assertWithdrawalProvenanceAndWriteShape(t *testing.T, c *consentEnv, token, newsletterID string) {
 	t.Helper()
 	// Idempotent: a repeat one-click writes no second proof row.
-	if s := publicCall(t, c.env, "POST", "/v1/public/preferences/"+token+"/unsubscribe?purpose=newsletter", nil, nil, nil); s != http.StatusOK {
+	if s := publicCall(t, c.AppEnv, "POST", "/v1/public/preferences/"+token+"/unsubscribe?purpose=newsletter", nil, nil, nil); s != http.StatusOK {
 		t.Fatalf("idempotent unsubscribe → %d", s)
 	}
 	var withdrawEvents int
-	if err := c.owner.QueryRow(context.Background(),
+	if err := c.Owner.QueryRow(context.Background(),
 		`SELECT count(*) FROM consent_event WHERE new_state = 'withdrawn' AND purpose_id = $1`, newsletterID).Scan(&withdrawEvents); err != nil {
 		t.Fatal(err)
 	}
@@ -245,7 +247,7 @@ func assertWithdrawalProvenanceAndWriteShape(t *testing.T, c *consentEnv, token,
 	// The withdrawal's provenance is the preference center + the confined
 	// public principal — never `manual`, never a workspace user.
 	var source, capturedBy, actorType string
-	if err := c.owner.QueryRow(context.Background(), `
+	if err := c.Owner.QueryRow(context.Background(), `
 		SELECT ce.source, ce.captured_by,
 		       (SELECT actor_type FROM audit_log WHERE action = 'consent_withdraw' LIMIT 1)
 		FROM consent_event ce WHERE ce.new_state = 'withdrawn' AND ce.purpose_id = $1 LIMIT 1`,
@@ -259,11 +261,11 @@ func assertWithdrawalProvenanceAndWriteShape(t *testing.T, c *consentEnv, token,
 
 	// The withdrawal rides the standard write shape: audited + emitted.
 	var audits, events int
-	if err := c.owner.QueryRow(context.Background(),
+	if err := c.Owner.QueryRow(context.Background(),
 		`SELECT count(*) FROM audit_log WHERE action = 'consent_withdraw'`).Scan(&audits); err != nil {
 		t.Fatal(err)
 	}
-	if err := c.owner.QueryRow(context.Background(),
+	if err := c.Owner.QueryRow(context.Background(),
 		`SELECT count(*) FROM event_outbox WHERE envelope->>'type' = 'consent.changed'`).Scan(&events); err != nil {
 		t.Fatal(err)
 	}
@@ -295,7 +297,7 @@ func TestPreferenceCenterOneClickUnsubscribe(t *testing.T) {
 	// A GET/prefetch on the unsubscribe path must NOT withdraw (RFC 8058
 	// mandates POST for exactly this — a scanner following the link must
 	// not opt anyone out).
-	if s := publicCall(t, c.env, "GET", "/v1/public/preferences/"+token+"/unsubscribe", nil, nil, nil); s != http.StatusMethodNotAllowed {
+	if s := publicCall(t, c.AppEnv, "GET", "/v1/public/preferences/"+token+"/unsubscribe", nil, nil, nil); s != http.StatusMethodNotAllowed {
 		t.Fatalf("GET on the unsubscribe path → %d, want 405", s)
 	}
 	if s, _ := purposeStateOf(t, readPreferenceView(t, c, token), "newsletter"); s != "granted" {
@@ -306,7 +308,7 @@ func TestPreferenceCenterOneClickUnsubscribe(t *testing.T) {
 	var unsub struct {
 		Unsubscribed []string `json:"unsubscribed"`
 	}
-	if s := publicCall(t, c.env, "POST", "/v1/public/preferences/"+token+"/unsubscribe?purpose=newsletter", nil, nil, &unsub); s != http.StatusOK {
+	if s := publicCall(t, c.AppEnv, "POST", "/v1/public/preferences/"+token+"/unsubscribe?purpose=newsletter", nil, nil, &unsub); s != http.StatusOK {
 		t.Fatalf("one-click unsubscribe → %d", s)
 	}
 	if len(unsub.Unsubscribed) != 1 || unsub.Unsubscribed[0] != "newsletter" {
@@ -339,7 +341,7 @@ func TestPreferenceTokenNeverReachesTheRecordedActivity(t *testing.T) {
 	c := setupConsent(t)
 	grantPurpose(t, c, createNewsletterPurpose(t, c))
 
-	status, recorded := sendMarketing(t, c.env, c.activityID, "newsletter", "", "")
+	status, recorded := sendMarketing(t, c.AppEnv, c.activityID, "newsletter", "", "")
 	if status != http.StatusAccepted {
 		t.Fatalf("marketing send → %d, want 202", status)
 	}
@@ -358,7 +360,7 @@ func TestPreferenceTokenNeverReachesTheRecordedActivity(t *testing.T) {
 			Body *string `json:"body"`
 		} `json:"data"`
 	}
-	if s := c.call(t, "GET", "/v1/activities?kind=email&limit=50", nil, nil, &page); s != http.StatusOK {
+	if s := c.Call(t, "GET", "/v1/activities?kind=email&limit=50", nil, nil, &page); s != http.StatusOK {
 		t.Fatalf("timeline read → %d", s)
 	}
 	if len(page.Data) == 0 {
@@ -378,7 +380,7 @@ func TestPreferenceTokenNeverReachesTheRecordedActivity(t *testing.T) {
 		t.Fatalf("the recorded body lost the unsubscribe footer entirely:\n%s", recorded)
 	}
 	// And the redacted link is inert: it is not a token the public edge honors.
-	if s := publicCall(t, c.env, "GET",
+	if s := publicCall(t, c.AppEnv, "GET",
 		"/v1/public/preferences/"+tokenFromLink(t, unsubscribeLinkIn(t, recorded)), nil, nil, nil); s != http.StatusNotFound {
 		t.Fatalf("the recorded stand-in resolved on the public edge → %d, want 404", s)
 	}
@@ -390,13 +392,13 @@ func TestPreferenceTokenNeverReachesTheRecordedActivity(t *testing.T) {
 func TestPreferenceCenterTokenGuards(t *testing.T) {
 	c := setupConsent(t)
 
-	if s := publicCall(t, c.env, "GET", "/v1/public/preferences/pref_does_not_exist", nil, nil, nil); s != http.StatusNotFound {
+	if s := publicCall(t, c.AppEnv, "GET", "/v1/public/preferences/pref_does_not_exist", nil, nil, nil); s != http.StatusNotFound {
 		t.Fatalf("unknown token GET → %d, want 404", s)
 	}
-	if s := publicCall(t, c.env, "POST", "/v1/public/preferences/pref_does_not_exist/unsubscribe?purpose=newsletter", nil, nil, nil); s != http.StatusNotFound {
+	if s := publicCall(t, c.AppEnv, "POST", "/v1/public/preferences/pref_does_not_exist/unsubscribe?purpose=newsletter", nil, nil, nil); s != http.StatusNotFound {
 		t.Fatalf("unknown token unsubscribe → %d, want 404", s)
 	}
-	if s := publicCall(t, c.env, "GET", "/v1/public/preferences/", nil, nil, nil); s != http.StatusNotFound {
+	if s := publicCall(t, c.AppEnv, "GET", "/v1/public/preferences/", nil, nil, nil); s != http.StatusNotFound {
 		t.Fatalf("empty token → %d, want 404", s)
 	}
 }
@@ -409,31 +411,31 @@ func TestPreferenceCenterRevokedTokenReadsAsAbsent(t *testing.T) {
 	var newsletter struct {
 		ID string `json:"id"`
 	}
-	if status := c.call(t, "POST", "/v1/consent-purposes", anyMap{
+	if status := c.Call(t, "POST", "/v1/consent-purposes", apptest.AnyMap{
 		"key": "newsletter", "label": "Newsletter", "requires_double_opt_in": false,
 	}, nil, &newsletter); status != http.StatusCreated {
 		t.Fatalf("create newsletter purpose → %d", status)
 	}
 	grantPurpose(t, c, newsletter.ID)
 
-	sendMarketing(t, c.env, c.activityID, "newsletter", "", "")
+	sendMarketing(t, c.AppEnv, c.activityID, "newsletter", "", "")
 	token := tokenFromLink(t, unsubscribeLinkIn(t, transmittedBody(t, c)))
 
 	// Live token resolves.
-	if s := publicCall(t, c.env, "GET", "/v1/public/preferences/"+token, nil, nil, nil); s != http.StatusOK {
+	if s := publicCall(t, c.AppEnv, "GET", "/v1/public/preferences/"+token, nil, nil, nil); s != http.StatusOK {
 		t.Fatalf("live token GET → %d, want 200", s)
 	}
 
-	if _, err := c.owner.Exec(context.Background(),
+	if _, err := c.Owner.Exec(context.Background(),
 		`UPDATE preference_token SET revoked_at = now() WHERE token = $1`, token); err != nil {
 		t.Fatalf("revoke token: %v", err)
 	}
 
 	// Revoked → 404, indistinguishable from an unknown token.
-	if s := publicCall(t, c.env, "GET", "/v1/public/preferences/"+token, nil, nil, nil); s != http.StatusNotFound {
+	if s := publicCall(t, c.AppEnv, "GET", "/v1/public/preferences/"+token, nil, nil, nil); s != http.StatusNotFound {
 		t.Fatalf("revoked token GET → %d, want 404 (must read as absent)", s)
 	}
-	if s := publicCall(t, c.env, "POST", "/v1/public/preferences/"+token+"/unsubscribe?purpose=newsletter", nil, nil, nil); s != http.StatusNotFound {
+	if s := publicCall(t, c.AppEnv, "POST", "/v1/public/preferences/"+token+"/unsubscribe?purpose=newsletter", nil, nil, nil); s != http.StatusNotFound {
 		t.Fatalf("revoked token unsubscribe → %d, want 404", s)
 	}
 }
@@ -447,20 +449,20 @@ func TestPreferenceCenterRejectsOversizedChoiceArray(t *testing.T) {
 	var newsletter struct {
 		ID string `json:"id"`
 	}
-	if status := c.call(t, "POST", "/v1/consent-purposes", anyMap{
+	if status := c.Call(t, "POST", "/v1/consent-purposes", apptest.AnyMap{
 		"key": "newsletter", "label": "Newsletter", "requires_double_opt_in": false,
 	}, nil, &newsletter); status != http.StatusCreated {
 		t.Fatalf("create newsletter purpose → %d", status)
 	}
 	grantPurpose(t, c, newsletter.ID)
-	sendMarketing(t, c.env, c.activityID, "newsletter", "", "")
+	sendMarketing(t, c.AppEnv, c.activityID, "newsletter", "", "")
 	token := tokenFromLink(t, unsubscribeLinkIn(t, transmittedBody(t, c)))
 
-	choices := make([]anyMap, 0, 100)
+	choices := make([]apptest.AnyMap, 0, 100)
 	for i := 0; i < 100; i++ {
-		choices = append(choices, anyMap{"purpose_key": "newsletter", "state": "withdrawn"})
+		choices = append(choices, apptest.AnyMap{"purpose_key": "newsletter", "state": "withdrawn"})
 	}
-	if s := publicCall(t, c.env, "PUT", "/v1/public/preferences/"+token, anyMap{"choices": choices}, nil, nil); s != http.StatusUnprocessableEntity {
+	if s := publicCall(t, c.AppEnv, "PUT", "/v1/public/preferences/"+token, apptest.AnyMap{"choices": choices}, nil, nil); s != http.StatusUnprocessableEntity {
 		t.Fatalf("oversized choices PUT → %d, want 422", s)
 	}
 }
@@ -472,7 +474,7 @@ func TestPreferenceCenterRateLimited(t *testing.T) {
 
 	last := 0
 	for i := 0; i < 21; i++ {
-		last = publicCall(t, c.env, "POST", "/v1/public/preferences/pref_flood_probe/unsubscribe?purpose=newsletter", nil, nil, nil)
+		last = publicCall(t, c.AppEnv, "POST", "/v1/public/preferences/pref_flood_probe/unsubscribe?purpose=newsletter", nil, nil, nil)
 	}
 	if last != http.StatusTooManyRequests {
 		t.Fatalf("21st burst unsubscribe → %d, want 429", last)

--- a/backend/internal/compose/integration/project_http_integration_test.go
+++ b/backend/internal/compose/integration/project_http_integration_test.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -86,12 +87,12 @@ func (p projectProblem) fieldName() string {
 
 // anchorOrg creates the company a project hangs from. A project has exactly
 // one, and the contract requires it at create time.
-func anchorOrg(t *testing.T, e *env, name string) string {
+func anchorOrg(t *testing.T, e *apptest.AppEnv, name string) string {
 	t.Helper()
 	var org struct {
 		ID string `json:"id"`
 	}
-	if status := e.call(t, "POST", "/v1/organizations", anyMap{
+	if status := e.Call(t, "POST", "/v1/organizations", apptest.AnyMap{
 		"display_name": name, "source": "manual",
 	}, nil, &org); status != http.StatusCreated {
 		t.Fatalf("POST /organizations → %d, want 201", status)
@@ -100,12 +101,12 @@ func anchorOrg(t *testing.T, e *env, name string) string {
 }
 
 // anchorPerson creates someone to put on a project's roster.
-func anchorPerson(t *testing.T, e *env, full string) string {
+func anchorPerson(t *testing.T, e *apptest.AppEnv, full string) string {
 	t.Helper()
 	var person struct {
 		ID string `json:"id"`
 	}
-	if status := e.call(t, "POST", "/v1/people", anyMap{
+	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{
 		"full_name": full, "source": "manual",
 	}, nil, &person); status != http.StatusCreated {
 		t.Fatalf("POST /people → %d, want 201", status)
@@ -117,12 +118,12 @@ func anchorPerson(t *testing.T, e *env, full string) string {
 // appears in the list, takes a PATCH, moves phase only through /advance, and
 // archives.
 func TestProjectLifecycleOverHTTP(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 	org := anchorOrg(t, e, "Northwind")
 
 	var created projectDTO
-	if status := e.call(t, "POST", "/v1/projects", anyMap{
+	if status := e.Call(t, "POST", "/v1/projects", apptest.AnyMap{
 		"name": "Warehouse rollout", "key": "WHR", "organization_id": org, "source": "manual",
 	}, nil, &created); status != http.StatusCreated {
 		t.Fatalf("POST /projects → %d, want 201", status)
@@ -135,7 +136,7 @@ func TestProjectLifecycleOverHTTP(t *testing.T) {
 	}
 
 	var read projectDTO
-	if status := e.call(t, "GET", "/v1/projects/"+created.ID, nil, nil, &read); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/projects/"+created.ID, nil, nil, &read); status != http.StatusOK {
 		t.Fatalf("GET /projects/{id} → %d, want 200", status)
 	}
 	if read.ID != created.ID || read.Name != "Warehouse rollout" {
@@ -143,7 +144,7 @@ func TestProjectLifecycleOverHTTP(t *testing.T) {
 	}
 
 	var listed projectListDTO
-	if status := e.call(t, "GET", "/v1/projects?organization_id="+org, nil, nil, &listed); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/projects?organization_id="+org, nil, nil, &listed); status != http.StatusOK {
 		t.Fatalf("GET /projects → %d, want 200", status)
 	}
 	if len(listed.Data) != 1 || listed.Data[0].ID != created.ID {
@@ -151,7 +152,7 @@ func TestProjectLifecycleOverHTTP(t *testing.T) {
 	}
 
 	var patched projectDTO
-	if status := e.call(t, "PATCH", "/v1/projects/"+created.ID, anyMap{
+	if status := e.Call(t, "PATCH", "/v1/projects/"+created.ID, apptest.AnyMap{
 		"description": "Two sites, one cutover.",
 	}, nil, &patched); status != http.StatusOK {
 		t.Fatalf("PATCH /projects/{id} → %d, want 200", status)
@@ -164,7 +165,7 @@ func TestProjectLifecycleOverHTTP(t *testing.T) {
 	}
 
 	var advanced projectDTO
-	if status := e.call(t, "POST", "/v1/projects/"+created.ID+"/advance", anyMap{
+	if status := e.Call(t, "POST", "/v1/projects/"+created.ID+"/advance", apptest.AnyMap{
 		"to_phase": "pursuing",
 	}, nil, &advanced); status != http.StatusOK {
 		t.Fatalf("POST /projects/{id}/advance → %d, want 200", status)
@@ -173,21 +174,21 @@ func TestProjectLifecycleOverHTTP(t *testing.T) {
 		t.Fatalf("phase = %q after advancing, want pursuing", advanced.Phase)
 	}
 
-	if status := e.call(t, "DELETE", "/v1/projects/"+created.ID, nil, nil, nil); status != http.StatusNoContent {
+	if status := e.Call(t, "DELETE", "/v1/projects/"+created.ID, nil, nil, nil); status != http.StatusNoContent {
 		t.Fatalf("DELETE /projects/{id} → %d, want 204", status)
 	}
 	// Archiving is not deleting: the project stays readable by id, stamped
 	// with when it was retired, so everything that pointed at it still
 	// resolves. What it leaves is the live LIST.
 	var archived projectDTO
-	if status := e.call(t, "GET", "/v1/projects/"+created.ID, nil, nil, &archived); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/projects/"+created.ID, nil, nil, &archived); status != http.StatusOK {
 		t.Fatalf("GET on an archived project → %d, want 200 — archive is not delete", status)
 	}
 	if archived.ArchivedAt == nil {
 		t.Fatal("an archived project came back with no archived_at")
 	}
 	var live projectListDTO
-	if status := e.call(t, "GET", "/v1/projects?organization_id="+org, nil, nil, &live); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/projects?organization_id="+org, nil, nil, &live); status != http.StatusOK {
 		t.Fatalf("GET /projects → %d, want 200", status)
 	}
 	if len(live.Data) != 0 {
@@ -198,17 +199,17 @@ func TestProjectLifecycleOverHTTP(t *testing.T) {
 // The key is the human handle, so a second live project may not take one that
 // is already in use — and the refusal says which key, not a server fault.
 func TestProjectKeyCollisionIsRefusedOverHTTP(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 	org := anchorOrg(t, e, "Contoso")
 
-	body := anyMap{"name": "First", "key": "DUP", "organization_id": org, "source": "manual"}
-	if status := e.call(t, "POST", "/v1/projects", body, nil, nil); status != http.StatusCreated {
+	body := apptest.AnyMap{"name": "First", "key": "DUP", "organization_id": org, "source": "manual"}
+	if status := e.Call(t, "POST", "/v1/projects", body, nil, nil); status != http.StatusCreated {
 		t.Fatalf("first POST /projects → %d, want 201", status)
 	}
 
 	var problem projectProblem
-	status := e.call(t, "POST", "/v1/projects", anyMap{
+	status := e.Call(t, "POST", "/v1/projects", apptest.AnyMap{
 		"name": "Second", "key": "dup", "organization_id": org, "source": "manual",
 	}, nil, &problem)
 	if status != http.StatusConflict {
@@ -227,25 +228,25 @@ func TestProjectKeyCollisionIsRefusedOverHTTP(t *testing.T) {
 // Closing is the one phase move that must say why: a closed project with no
 // reason is a record nobody can interpret later.
 func TestClosingAProjectOverHTTPRequiresAReason(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 	org := anchorOrg(t, e, "Initech")
 
 	var project projectDTO
-	if status := e.call(t, "POST", "/v1/projects", anyMap{
+	if status := e.Call(t, "POST", "/v1/projects", apptest.AnyMap{
 		"name": "Migration", "organization_id": org, "source": "manual",
 	}, nil, &project); status != http.StatusCreated {
 		t.Fatalf("POST /projects → %d, want 201", status)
 	}
 
-	if status := e.call(t, "POST", "/v1/projects/"+project.ID+"/advance", anyMap{
+	if status := e.Call(t, "POST", "/v1/projects/"+project.ID+"/advance", apptest.AnyMap{
 		"to_phase": "closed",
 	}, nil, nil); status != http.StatusUnprocessableEntity {
 		t.Fatalf("closing with no reason → %d, want 422", status)
 	}
 
 	var closed projectDTO
-	if status := e.call(t, "POST", "/v1/projects/"+project.ID+"/advance", anyMap{
+	if status := e.Call(t, "POST", "/v1/projects/"+project.ID+"/advance", apptest.AnyMap{
 		"to_phase": "closed", "reason": "delivered",
 	}, nil, &closed); status != http.StatusOK {
 		t.Fatalf("closing with a reason → %d, want 200", status)
@@ -258,8 +259,8 @@ func TestClosingAProjectOverHTTPRequiresAReason(t *testing.T) {
 // The contract requires a name and an anchor company; neither is something the
 // server can invent, so both are refused at the edge rather than defaulted.
 func TestCreateProjectRefusesAnIncompleteBodyOverHTTP(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 	org := anchorOrg(t, e, "Umbrella")
 
 	// The shape of the refusal differs by cause and each is asserted exactly:
@@ -272,22 +273,22 @@ func TestCreateProjectRefusesAnIncompleteBodyOverHTTP(t *testing.T) {
 	// no row to protect when no id was supplied. Answering 404 to an omitted id
 	// sends the caller looking for a company it never named.
 	for name, tc := range map[string]struct {
-		body anyMap
+		body apptest.AnyMap
 		want int
 	}{
-		"no name":    {anyMap{"organization_id": org, "source": "manual"}, http.StatusUnprocessableEntity},
-		"blank name": {anyMap{"name": "   ", "organization_id": org, "source": "manual"}, http.StatusUnprocessableEntity},
+		"no name":    {apptest.AnyMap{"organization_id": org, "source": "manual"}, http.StatusUnprocessableEntity},
+		"blank name": {apptest.AnyMap{"name": "   ", "organization_id": org, "source": "manual"}, http.StatusUnprocessableEntity},
 		"organization_id omitted": {
-			anyMap{"name": "Orphan", "source": "manual"},
+			apptest.AnyMap{"name": "Orphan", "source": "manual"},
 			http.StatusUnprocessableEntity,
 		},
 		"organization_id names nothing visible": {
-			anyMap{"name": "Orphan", "organization_id": ids.NewV7().String(), "source": "manual"},
+			apptest.AnyMap{"name": "Orphan", "organization_id": ids.NewV7().String(), "source": "manual"},
 			http.StatusNotFound,
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			if status := e.call(t, "POST", "/v1/projects", tc.body, nil, nil); status != tc.want {
+			if status := e.Call(t, "POST", "/v1/projects", tc.body, nil, nil); status != tc.want {
 				t.Fatalf("%s → %d, want %d", name, status, tc.want)
 			}
 		})
@@ -296,12 +297,12 @@ func TestCreateProjectRefusesAnIncompleteBodyOverHTTP(t *testing.T) {
 	// A blank name is refused on the way IN and on the way through: a rule
 	// that only one verb carries is a rule the other verb erases.
 	var project projectDTO
-	if status := e.call(t, "POST", "/v1/projects", anyMap{
+	if status := e.Call(t, "POST", "/v1/projects", apptest.AnyMap{
 		"name": "Named", "organization_id": org, "source": "manual",
 	}, nil, &project); status != http.StatusCreated {
 		t.Fatalf("POST /projects → %d, want 201", status)
 	}
-	if status := e.call(t, "PATCH", "/v1/projects/"+project.ID, anyMap{
+	if status := e.Call(t, "PATCH", "/v1/projects/"+project.ID, apptest.AnyMap{
 		"name": "   ",
 	}, nil, nil); status != http.StatusUnprocessableEntity {
 		t.Fatalf("PATCH to a blank name → %d, want 422", status)
@@ -312,20 +313,20 @@ func TestCreateProjectRefusesAnIncompleteBodyOverHTTP(t *testing.T) {
 // role correction, never a second edge. That is the whole contract of a PUT
 // here, and it is the property a uniqueness race must not break.
 func TestProjectStakeholderRosterOverHTTP(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 	org := anchorOrg(t, e, "Stark Industries")
 	person := anchorPerson(t, e, "Pepper Potts")
 
 	var project projectDTO
-	if status := e.call(t, "POST", "/v1/projects", anyMap{
+	if status := e.Call(t, "POST", "/v1/projects", apptest.AnyMap{
 		"name": "Arc reactor", "organization_id": org, "source": "manual",
 	}, nil, &project); status != http.StatusCreated {
 		t.Fatalf("POST /projects → %d, want 201", status)
 	}
 
 	var edge relationshipDTO
-	if status := e.call(t, "PUT", "/v1/projects/"+project.ID+"/stakeholders", anyMap{
+	if status := e.Call(t, "PUT", "/v1/projects/"+project.ID+"/stakeholders", apptest.AnyMap{
 		"person_id": person, "role": "sponsor",
 	}, nil, &edge); status != http.StatusOK {
 		t.Fatalf("PUT stakeholder → %d, want 200", status)
@@ -336,7 +337,7 @@ func TestProjectStakeholderRosterOverHTTP(t *testing.T) {
 
 	// The same person again: the role moves, the edge does not multiply.
 	var recorrected relationshipDTO
-	if status := e.call(t, "PUT", "/v1/projects/"+project.ID+"/stakeholders", anyMap{
+	if status := e.Call(t, "PUT", "/v1/projects/"+project.ID+"/stakeholders", apptest.AnyMap{
 		"person_id": person, "role": "project_lead",
 	}, nil, &recorrected); status != http.StatusOK {
 		t.Fatalf("re-attaching → %d, want 200", status)
@@ -350,7 +351,7 @@ func TestProjectStakeholderRosterOverHTTP(t *testing.T) {
 	}
 
 	var roster relationshipListDTO
-	if status := e.call(t, "GET", "/v1/projects/"+project.ID+"/stakeholders", nil, nil, &roster); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/projects/"+project.ID+"/stakeholders", nil, nil, &roster); status != http.StatusOK {
 		t.Fatalf("GET stakeholders → %d, want 200", status)
 	}
 	if len(roster.Data) != 1 {
@@ -359,12 +360,12 @@ func TestProjectStakeholderRosterOverHTTP(t *testing.T) {
 
 	// Detaching archives the edge: the person's involvement stays on the
 	// record, it simply stops being current.
-	if status := e.call(t, "DELETE",
+	if status := e.Call(t, "DELETE",
 		fmt.Sprintf("/v1/projects/%s/stakeholders/%s", project.ID, person), nil, nil, nil); status != http.StatusNoContent {
 		t.Fatalf("DELETE stakeholder → %d, want 204", status)
 	}
 	var afterDetach relationshipListDTO
-	if status := e.call(t, "GET", "/v1/projects/"+project.ID+"/stakeholders", nil, nil, &afterDetach); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/projects/"+project.ID+"/stakeholders", nil, nil, &afterDetach); status != http.StatusOK {
 		t.Fatalf("GET stakeholders after detach → %d, want 200", status)
 	}
 	if len(afterDetach.Data) != 0 {
@@ -375,29 +376,29 @@ func TestProjectStakeholderRosterOverHTTP(t *testing.T) {
 // A read seat may look at a project and may not change one. The ceiling is the
 // seat, not the role, so it applies to every write on this surface.
 func TestAReadSeatCannotWriteAProjectOverHTTP(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 	org := anchorOrg(t, e, "Cyberdyne")
 	person := anchorPerson(t, e, "Miles Dyson")
 
 	var project projectDTO
-	if status := e.call(t, "POST", "/v1/projects", anyMap{
+	if status := e.Call(t, "POST", "/v1/projects", apptest.AnyMap{
 		"name": "Skynet", "organization_id": org, "source": "manual",
 	}, nil, &project); status != http.StatusCreated {
 		t.Fatalf("POST /projects → %d, want 201", status)
 	}
 
-	e.setWorkspaceSeat(t, e.slug, "read")
+	e.SetWorkspaceSeat(t, e.Slug, "read")
 
-	if status := e.call(t, "GET", "/v1/projects/"+project.ID, nil, nil, nil); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/projects/"+project.ID, nil, nil, nil); status != http.StatusOK {
 		t.Fatalf("a read seat reading a project → %d, want 200", status)
 	}
-	if status := e.call(t, "PATCH", "/v1/projects/"+project.ID, anyMap{
+	if status := e.Call(t, "PATCH", "/v1/projects/"+project.ID, apptest.AnyMap{
 		"description": "not allowed",
 	}, nil, nil); status != http.StatusForbidden {
 		t.Fatalf("a read seat patching a project → %d, want 403", status)
 	}
-	if status := e.call(t, "POST", "/v1/projects/"+project.ID+"/advance", anyMap{
+	if status := e.Call(t, "POST", "/v1/projects/"+project.ID+"/advance", apptest.AnyMap{
 		"to_phase": "pursuing",
 	}, nil, nil); status != http.StatusForbidden {
 		t.Fatalf("a read seat advancing a phase → %d, want 403", status)
@@ -405,12 +406,12 @@ func TestAReadSeatCannotWriteAProjectOverHTTP(t *testing.T) {
 	// The roster is part of the project's writable state, so both stakeholder
 	// verbs sit behind the same ceiling. Detach is asserted because it is the
 	// one that used to check only the relationship grant.
-	if status := e.call(t, "PUT", "/v1/projects/"+project.ID+"/stakeholders", anyMap{
+	if status := e.Call(t, "PUT", "/v1/projects/"+project.ID+"/stakeholders", apptest.AnyMap{
 		"person_id": person, "role": "sponsor",
 	}, nil, nil); status != http.StatusForbidden {
 		t.Fatalf("a read seat attaching a stakeholder → %d, want 403", status)
 	}
-	if status := e.call(t, "DELETE",
+	if status := e.Call(t, "DELETE",
 		fmt.Sprintf("/v1/projects/%s/stakeholders/%s", project.ID, person), nil, nil, nil); status != http.StatusForbidden {
 		t.Fatalf("a read seat detaching a stakeholder → %d, want 403", status)
 	}
@@ -425,17 +426,17 @@ func TestAReadSeatCannotWriteAProjectOverHTTP(t *testing.T) {
 // caller whose existing link is invisible to them, so it must name neither
 // the project nor its id — only what happened and what to do instead.
 func TestASecondProjectLinkIsRefusedWithoutNamingTheFirst(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 	org := anchorOrg(t, e, "Wayne Enterprises")
 
 	var first, second projectDTO
-	if status := e.call(t, "POST", "/v1/projects", anyMap{
+	if status := e.Call(t, "POST", "/v1/projects", apptest.AnyMap{
 		"name": "Applied Sciences", "organization_id": org, "source": "manual",
 	}, nil, &first); status != http.StatusCreated {
 		t.Fatalf("POST /projects → %d, want 201", status)
 	}
-	if status := e.call(t, "POST", "/v1/projects", anyMap{
+	if status := e.Call(t, "POST", "/v1/projects", apptest.AnyMap{
 		"name": "Batcave retrofit", "organization_id": org, "source": "manual",
 	}, nil, &second); status != http.StatusCreated {
 		t.Fatalf("POST /projects → %d, want 201", status)
@@ -444,9 +445,9 @@ func TestASecondProjectLinkIsRefusedWithoutNamingTheFirst(t *testing.T) {
 	var activity struct {
 		ID string `json:"id"`
 	}
-	if status := e.call(t, "POST", "/v1/activities", anyMap{
+	if status := e.Call(t, "POST", "/v1/activities", apptest.AnyMap{
 		"kind": "note", "source": "manual",
-		"links": []anyMap{{"entity_type": "project", "entity_id": first.ID}},
+		"links": []apptest.AnyMap{{"entity_type": "project", "entity_id": first.ID}},
 	}, nil, &activity); status != http.StatusCreated {
 		t.Fatalf("POST /activities → %d, want 201", status)
 	}
@@ -454,7 +455,7 @@ func TestASecondProjectLinkIsRefusedWithoutNamingTheFirst(t *testing.T) {
 	// A second project without asking to replace: the index refuses, and the
 	// caller must be told that in terms they can act on.
 	var problem projectProblem
-	status := e.call(t, "POST", "/v1/activities/"+activity.ID+"/relink", anyMap{
+	status := e.Call(t, "POST", "/v1/activities/"+activity.ID+"/relink", apptest.AnyMap{
 		"entity_type": "project", "entity_id": second.ID, "replace_existing_of_type": false,
 	}, nil, &problem)
 	if status != http.StatusUnprocessableEntity {
@@ -476,7 +477,7 @@ func TestASecondProjectLinkIsRefusedWithoutNamingTheFirst(t *testing.T) {
 
 	// Asking to replace moves it, so the refusal really was about the rule
 	// and not about the caller's authority.
-	if status := e.call(t, "POST", "/v1/activities/"+activity.ID+"/relink", anyMap{
+	if status := e.Call(t, "POST", "/v1/activities/"+activity.ID+"/relink", apptest.AnyMap{
 		"entity_type": "project", "entity_id": second.ID, "replace_existing_of_type": true,
 	}, nil, nil); status != http.StatusOK {
 		t.Fatalf("relink with replace → %d, want 200", status)
@@ -488,12 +489,12 @@ func TestASecondProjectLinkIsRefusedWithoutNamingTheFirst(t *testing.T) {
 // untyped 500, or under the wrong code, is a promise broken — so each arm is
 // provoked here through the real schema rule that raises it.
 func TestEachProjectRefusalAnswersItsOwnCode(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 	org := anchorOrg(t, e, "Refusal GmbH")
 
 	var project projectDTO
-	if status := e.call(t, "POST", "/v1/projects", anyMap{
+	if status := e.Call(t, "POST", "/v1/projects", apptest.AnyMap{
 		"name": "Baseline", "organization_id": org, "source": "manual",
 	}, nil, &project); status != http.StatusCreated {
 		t.Fatalf("POST /projects → %d, want 201", status)
@@ -503,7 +504,7 @@ func TestEachProjectRefusalAnswersItsOwnCode(t *testing.T) {
 		// Letter-led on purpose: a bare number would match dates, amounts and
 		// order numbers in an inbound subject line.
 		var problem projectProblem
-		if status := e.call(t, "POST", "/v1/projects", anyMap{
+		if status := e.Call(t, "POST", "/v1/projects", apptest.AnyMap{
 			"name": "Numeric", "key": "2026", "organization_id": org, "source": "manual",
 		}, nil, &problem); status != http.StatusUnprocessableEntity {
 			t.Fatalf("a numeric key → %d, want 422", status)
@@ -518,7 +519,7 @@ func TestEachProjectRefusalAnswersItsOwnCode(t *testing.T) {
 
 	t.Run("an end date before the start", func(t *testing.T) {
 		var problem projectProblem
-		if status := e.call(t, "PATCH", "/v1/projects/"+project.ID, anyMap{
+		if status := e.Call(t, "PATCH", "/v1/projects/"+project.ID, apptest.AnyMap{
 			"started_at": "2026-06-01", "ended_at": "2026-01-01",
 		}, nil, &problem); status != http.StatusUnprocessableEntity {
 			t.Fatalf("an inverted date range → %d, want 422", status)
@@ -533,7 +534,7 @@ func TestEachProjectRefusalAnswersItsOwnCode(t *testing.T) {
 
 	t.Run("closing without a reason", func(t *testing.T) {
 		var problem projectProblem
-		if status := e.call(t, "POST", "/v1/projects/"+project.ID+"/advance", anyMap{
+		if status := e.Call(t, "POST", "/v1/projects/"+project.ID+"/advance", apptest.AnyMap{
 			"to_phase": "closed",
 		}, nil, &problem); status != http.StatusUnprocessableEntity {
 			t.Fatalf("closing with no reason → %d, want 422", status)
@@ -552,7 +553,7 @@ func TestEachProjectRefusalAnswersItsOwnCode(t *testing.T) {
 		// a 422 about the rule rather than a server fault.
 		other := anchorOrg(t, e, "Elsewhere AG")
 		var elsewhere projectDTO
-		if status := e.call(t, "POST", "/v1/projects", anyMap{
+		if status := e.Call(t, "POST", "/v1/projects", apptest.AnyMap{
 			"name": "Their work", "organization_id": other, "source": "manual",
 		}, nil, &elsewhere); status != http.StatusCreated {
 			t.Fatalf("POST /projects → %d, want 201", status)
@@ -568,14 +569,14 @@ func TestEachProjectRefusalAnswersItsOwnCode(t *testing.T) {
 		// Not a skip: bootstrapping seeds the default pipeline, so an empty
 		// list means the fixture broke, and skipping here would retire the
 		// only check on a rule that lives in a constraint trigger.
-		if status := e.call(t, "GET", "/v1/pipelines", nil, nil, &pipelines); status != http.StatusOK {
+		if status := e.Call(t, "GET", "/v1/pipelines", nil, nil, &pipelines); status != http.StatusOK {
 			t.Fatalf("GET /pipelines → %d, want 200", status)
 		}
 		if len(pipelines.Data) == 0 || len(pipelines.Data[0].Stages) == 0 {
 			t.Fatal("the bootstrapped workspace has no pipeline with stages — the fixture no longer seeds one")
 		}
 		var problem projectProblem
-		status := e.call(t, "POST", "/v1/deals", anyMap{
+		status := e.Call(t, "POST", "/v1/deals", apptest.AnyMap{
 			"name": "Mismatched", "organization_id": org, "project_id": elsewhere.ID,
 			"pipeline_id": pipelines.Data[0].ID, "stage_id": pipelines.Data[0].Stages[0].ID,
 			"source": "manual",
@@ -596,12 +597,12 @@ func TestEachProjectRefusalAnswersItsOwnCode(t *testing.T) {
 // must not silently win: the write is refused so the client re-reads rather
 // than overwriting someone else's change.
 func TestAStaleVersionCannotOverwriteAProject(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 	org := anchorOrg(t, e, "Skew GmbH")
 
 	var project projectDTO
-	if status := e.call(t, "POST", "/v1/projects", anyMap{
+	if status := e.Call(t, "POST", "/v1/projects", apptest.AnyMap{
 		"name": "Contended", "organization_id": org, "source": "manual",
 	}, nil, &project); status != http.StatusCreated {
 		t.Fatalf("POST /projects → %d, want 201", status)
@@ -609,7 +610,7 @@ func TestAStaleVersionCannotOverwriteAProject(t *testing.T) {
 	stale := strconv.Itoa(project.Version)
 
 	// Someone else moves first.
-	if status := e.call(t, "PATCH", "/v1/projects/"+project.ID, anyMap{
+	if status := e.Call(t, "PATCH", "/v1/projects/"+project.ID, apptest.AnyMap{
 		"description": "first writer",
 	}, nil, nil); status != http.StatusOK {
 		t.Fatalf("first PATCH → %d, want 200", status)
@@ -619,7 +620,7 @@ func TestAStaleVersionCannotOverwriteAProject(t *testing.T) {
 	// different 4xx would be a different promise, so accepting either would
 	// let the surface change contracts without anything noticing.
 	var problem projectProblem
-	if status := e.call(t, "PATCH", "/v1/projects/"+project.ID, anyMap{
+	if status := e.Call(t, "PATCH", "/v1/projects/"+project.ID, apptest.AnyMap{
 		"description": "second writer",
 	}, map[string]string{"If-Match": stale}, &problem); status != http.StatusConflict {
 		t.Fatalf("a stale If-Match → %d, want 409", status)
@@ -627,16 +628,16 @@ func TestAStaleVersionCannotOverwriteAProject(t *testing.T) {
 	if problem.Code != "version_skew" {
 		t.Errorf("refusal code = %q, want version_skew", problem.Code)
 	}
-	if n := e.callDescription(t, project.ID); n != "first writer" {
+	if n := callDescription(e, t, project.ID); n != "first writer" {
 		t.Fatalf("description = %q — the stale write landed anyway", n)
 	}
 }
 
 // callDescription reads one project's description back over the wire.
-func (e *env) callDescription(t *testing.T, id string) string {
+func callDescription(e *apptest.AppEnv, t *testing.T, id string) string {
 	t.Helper()
 	var out projectDTO
-	if status := e.call(t, "GET", "/v1/projects/"+id, nil, nil, &out); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/projects/"+id, nil, nil, &out); status != http.StatusOK {
 		t.Fatalf("GET /projects/{id} → %d, want 200", status)
 	}
 	if out.Description == nil {

--- a/backend/internal/compose/integration/public_booking_integration_test.go
+++ b/backend/internal/compose/integration/public_booking_integration_test.go
@@ -20,13 +20,15 @@ import (
 	"net/http"
 	"testing"
 	"time"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 )
 
 // publicCall hits the API with NO cookie jar and NO workspace header —
 // the anonymous booker's actual shape.
 //
 //craft:ignore naked-any generic JSON test helper: body and out are each call's own shape
-func publicCall(t *testing.T, e *env, method, path string, body any, headers map[string]string, out any) int {
+func publicCall(t *testing.T, e *apptest.AppEnv, method, path string, body any, headers map[string]string, out any) int {
 	t.Helper()
 	var reqBody io.Reader
 	if body != nil {
@@ -36,7 +38,7 @@ func publicCall(t *testing.T, e *env, method, path string, body any, headers map
 		}
 		reqBody = bytes.NewReader(raw)
 	}
-	req, err := http.NewRequest(method, e.ts.URL+path, reqBody)
+	req, err := http.NewRequest(method, e.TS.URL+path, reqBody)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -44,11 +46,11 @@ func publicCall(t *testing.T, e *env, method, path string, body any, headers map
 	for k, v := range headers {
 		req.Header.Set(k, v)
 	}
-	resp, err := e.ts.Client().Do(req)
+	resp, err := e.TS.Client().Do(req) //nolint:bodyclose // closed by the deferred apptest.CloseBody below; bodyclose only sees a Close in the same package, and the closer moved out with the fixture
 	if err != nil {
 		t.Fatalf("%s %s: %v", method, path, err)
 	}
-	defer closeBody(t, resp)
+	defer apptest.CloseBody(t, resp)
 	raw, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
@@ -63,10 +65,10 @@ func publicCall(t *testing.T, e *env, method, path string, body any, headers map
 
 // bookingSlug reads the bootstrap-seeded page slug through the owner
 // connection (booking_page is the non-RLS resolver).
-func bookingSlug(t *testing.T, e *env) string {
+func bookingSlug(t *testing.T, e *apptest.AppEnv) string {
 	t.Helper()
 	var slug string
-	if err := e.owner.QueryRow(context.Background(), `SELECT slug FROM booking_page`).Scan(&slug); err != nil {
+	if err := e.Owner.QueryRow(context.Background(), `SELECT slug FROM booking_page`).Scan(&slug); err != nil {
 		t.Fatalf("reading the seeded booking page: %v", err)
 	}
 	return slug
@@ -84,7 +86,7 @@ func nextMonday() time.Time {
 // seededTransactionalPurposeID reads the bootstrap-seeded consent
 // catalog as the admin session and resolves the transactional purpose
 // the booker will consent to.
-func seededTransactionalPurposeID(t *testing.T, e *env) string {
+func seededTransactionalPurposeID(t *testing.T, e *apptest.AppEnv) string {
 	t.Helper()
 	var purposes struct {
 		Data []struct {
@@ -92,7 +94,7 @@ func seededTransactionalPurposeID(t *testing.T, e *env) string {
 			Key string `json:"key"`
 		} `json:"data"`
 	}
-	if status := e.call(t, "GET", "/v1/consent-purposes", nil, nil, &purposes); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/consent-purposes", nil, nil, &purposes); status != http.StatusOK {
 		t.Fatalf("purposes → %d", status)
 	}
 	var purposeID string
@@ -109,7 +111,7 @@ func seededTransactionalPurposeID(t *testing.T, e *env) string {
 
 // assertAnonymousAvailability checks the no-session availability read:
 // 200 with free/busy slots only, and an unknown slug reads as absent.
-func assertAnonymousAvailability(t *testing.T, e *env, base, window string) {
+func assertAnonymousAvailability(t *testing.T, e *apptest.AppEnv, base, window string) {
 	t.Helper()
 	// Anonymous availability: 200, free/busy slots only.
 	var avail struct {
@@ -134,27 +136,27 @@ func assertAnonymousAvailability(t *testing.T, e *env, base, window string) {
 // assertBookingRequiresValidConsent checks consent is validated before
 // any write: no consent and a bogus purpose are both 422s that leave
 // zero person rows behind.
-func assertBookingRequiresValidConsent(t *testing.T, e *env, base string, monday time.Time) {
+func assertBookingRequiresValidConsent(t *testing.T, e *apptest.AppEnv, base string, monday time.Time) {
 	t.Helper()
 	// A booking without consent is refused before any write.
-	noConsent := anyMap{
+	noConsent := apptest.AnyMap{
 		"start": monday.Add(1 * time.Hour), "end": monday.Add(90 * time.Minute),
-		"booker": anyMap{"name": "Anna Anonymous", "email": "anna@visitor.example"},
+		"booker": apptest.AnyMap{"name": "Anna Anonymous", "email": "anna@visitor.example"},
 	}
 	if status := publicCall(t, e, "POST", base, noConsent, nil, nil); status != 422 {
 		t.Fatalf("booking without consent → %d, want 422", status)
 	}
 	// A bogus purpose is refused before any write too.
-	badPurpose := anyMap{
+	badPurpose := apptest.AnyMap{
 		"start": monday.Add(1 * time.Hour), "end": monday.Add(90 * time.Minute),
-		"booker":  anyMap{"name": "Anna Anonymous", "email": "anna@visitor.example"},
-		"consent": anyMap{"purpose_id": "018f0000-0000-7000-8000-000000000000", "policy_version": "pp-2026-01"},
+		"booker":  apptest.AnyMap{"name": "Anna Anonymous", "email": "anna@visitor.example"},
+		"consent": apptest.AnyMap{"purpose_id": "018f0000-0000-7000-8000-000000000000", "policy_version": "pp-2026-01"},
 	}
 	if status := publicCall(t, e, "POST", base, badPurpose, nil, nil); status != 422 {
 		t.Fatalf("booking with unknown purpose → %d, want 422", status)
 	}
 	var persons int
-	if err := e.owner.QueryRow(context.Background(), `SELECT count(*) FROM person`).Scan(&persons); err != nil {
+	if err := e.Owner.QueryRow(context.Background(), `SELECT count(*) FROM person`).Scan(&persons); err != nil {
 		t.Fatal(err)
 	}
 	if persons != 0 {
@@ -166,13 +168,13 @@ func assertBookingRequiresValidConsent(t *testing.T, e *env, base string, monday
 // else disclosed) plus a second slot under a case-folded email,
 // asserting the booker lands as ONE person. Returns the first booking
 // body so the taken slot can be re-posted.
-func bookHappyPathSlot(t *testing.T, e *env, base string, monday time.Time, consent anyMap) anyMap {
+func bookHappyPathSlot(t *testing.T, e *apptest.AppEnv, base string, monday time.Time, consent apptest.AnyMap) apptest.AnyMap {
 	t.Helper()
 	// The happy path: 201 with the slot and NOTHING else.
-	booking := anyMap{
+	booking := apptest.AnyMap{
 		"start": monday.Add(1 * time.Hour), "end": monday.Add(90 * time.Minute),
 		"subject": "Intro call",
-		"booker":  anyMap{"name": "Anna Anonymous", "email": "anna@visitor.example"},
+		"booker":  apptest.AnyMap{"name": "Anna Anonymous", "email": "anna@visitor.example"},
 		"consent": consent,
 	}
 	var confirmation map[string]any
@@ -184,16 +186,16 @@ func bookHappyPathSlot(t *testing.T, e *env, base string, monday time.Time, cons
 	}
 
 	// The booker exists once; a second booking re-uses the person.
-	second := anyMap{
+	second := apptest.AnyMap{
 		"start": monday.Add(3 * time.Hour), "end": monday.Add(3*time.Hour + 30*time.Minute),
-		"booker":  anyMap{"name": "Anna Anonymous", "email": "ANNA@visitor.example"},
+		"booker":  apptest.AnyMap{"name": "Anna Anonymous", "email": "ANNA@visitor.example"},
 		"consent": consent,
 	}
 	if status := publicCall(t, e, "POST", base, second, nil, nil); status != http.StatusCreated {
 		t.Fatalf("second booking → %d", status)
 	}
 	var persons int
-	if err := e.owner.QueryRow(context.Background(), `SELECT count(*) FROM person`).Scan(&persons); err != nil {
+	if err := e.Owner.QueryRow(context.Background(), `SELECT count(*) FROM person`).Scan(&persons); err != nil {
 		t.Fatal(err)
 	}
 	if persons != 1 {
@@ -205,12 +207,12 @@ func bookHappyPathSlot(t *testing.T, e *env, base string, monday time.Time, cons
 // assertBookingProofAndProvenance checks the consent proof carries the
 // passthrough verbatim under the system principal, and the meeting's
 // provenance is the public surface — never "manual".
-func assertBookingProofAndProvenance(t *testing.T, e *env) {
+func assertBookingProofAndProvenance(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
 	// The consent proof carries the passthrough verbatim, attributed to
 	// the system principal; the audit stream owns the whole capture.
 	var policyVersion, policyText, source, actorType string
-	if err := e.owner.QueryRow(context.Background(), `
+	if err := e.Owner.QueryRow(context.Background(), `
 		SELECT policy_version, policy_text, source,
 		       (SELECT actor_type FROM audit_log WHERE action = 'consent_grant' LIMIT 1)
 		FROM consent_event LIMIT 1`).Scan(&policyVersion, &policyText, &source, &actorType); err != nil {
@@ -224,7 +226,7 @@ func assertBookingProofAndProvenance(t *testing.T, e *env) {
 
 	// The meeting's provenance is the public surface, never "manual".
 	var activitySource string
-	if err := e.owner.QueryRow(context.Background(),
+	if err := e.Owner.QueryRow(context.Background(),
 		`SELECT source FROM activity WHERE kind = 'meeting' LIMIT 1`).Scan(&activitySource); err != nil {
 		t.Fatal(err)
 	}
@@ -236,27 +238,27 @@ func assertBookingProofAndProvenance(t *testing.T, e *env) {
 // assertWithdrawalStandsAgainstBooking covers the consent-hijack guard:
 // a withdrawal on record STANDS — an anonymous booking naming the same
 // email may proceed but cannot flip the state back to granted.
-func assertWithdrawalStandsAgainstBooking(t *testing.T, e *env, base string, monday time.Time, purposeID string, consent anyMap) {
+func assertWithdrawalStandsAgainstBooking(t *testing.T, e *apptest.AppEnv, base string, monday time.Time, purposeID string, consent apptest.AnyMap) {
 	t.Helper()
 	var annaID string
-	if err := e.owner.QueryRow(context.Background(), `SELECT id FROM person`).Scan(&annaID); err != nil {
+	if err := e.Owner.QueryRow(context.Background(), `SELECT id FROM person`).Scan(&annaID); err != nil {
 		t.Fatal(err)
 	}
-	if status := e.call(t, "POST", "/v1/people/"+annaID+"/consent", anyMap{
+	if status := e.Call(t, "POST", "/v1/people/"+annaID+"/consent", apptest.AnyMap{
 		"purpose_id": purposeID, "new_state": "withdrawn",
 	}, nil, nil); status != http.StatusOK {
 		t.Fatalf("withdraw → %d", status)
 	}
-	fourth := anyMap{
+	fourth := apptest.AnyMap{
 		"start": monday.Add(7 * time.Hour), "end": monday.Add(7*time.Hour + 30*time.Minute),
-		"booker":  anyMap{"name": "Anna Anonymous", "email": "anna@visitor.example"},
+		"booker":  apptest.AnyMap{"name": "Anna Anonymous", "email": "anna@visitor.example"},
 		"consent": consent,
 	}
 	if status := publicCall(t, e, "POST", base, fourth, nil, nil); status != http.StatusCreated {
 		t.Fatalf("booking after withdrawal → %d (the booking may proceed; the consent flip may not)", status)
 	}
 	var stateAfter string
-	if err := e.owner.QueryRow(context.Background(),
+	if err := e.Owner.QueryRow(context.Background(),
 		`SELECT state FROM person_consent WHERE person_id = $1 AND purpose_id = $2`,
 		annaID, purposeID).Scan(&stateAfter); err != nil {
 		t.Fatal(err)
@@ -272,12 +274,12 @@ func assertWithdrawalStandsAgainstBooking(t *testing.T, e *env, base string, mon
 // another (see idempotentOperations' exemption). A keyed retry therefore
 // re-executes and the slot's natural key refuses it — a duplicate meeting
 // never lands, but neither does a stranger's recorded response.
-func assertIdempotencyKeyNotClaimed(t *testing.T, e *env, base string, monday time.Time, consent anyMap) {
+func assertIdempotencyKeyNotClaimed(t *testing.T, e *apptest.AppEnv, base string, monday time.Time, consent apptest.AnyMap) {
 	t.Helper()
 	replayKey := map[string]string{"Idempotency-Key": "public-replay-1"}
-	third := anyMap{
+	third := apptest.AnyMap{
 		"start": monday.Add(5 * time.Hour), "end": monday.Add(5*time.Hour + 30*time.Minute),
-		"booker":  anyMap{"name": "Anna Anonymous", "email": "anna@visitor.example"},
+		"booker":  apptest.AnyMap{"name": "Anna Anonymous", "email": "anna@visitor.example"},
 		"consent": consent,
 	}
 	if status := publicCall(t, e, "POST", base, third, replayKey, nil); status != http.StatusCreated {
@@ -290,7 +292,7 @@ func assertIdempotencyKeyNotClaimed(t *testing.T, e *env, base string, monday ti
 		t.Fatalf("keyed retry → %d %q, want 409 slot_taken (the header is ignored on the anonymous edge; the slot guard refuses the duplicate)", status, problem.Code)
 	}
 	var meetings int
-	if err := e.owner.QueryRow(context.Background(),
+	if err := e.Owner.QueryRow(context.Background(),
 		`SELECT count(*) FROM activity WHERE kind = 'meeting'`).Scan(&meetings); err != nil {
 		t.Fatal(err)
 	}
@@ -300,8 +302,8 @@ func assertIdempotencyKeyNotClaimed(t *testing.T, e *env, base string, monday ti
 }
 
 func TestPublicBookingEndToEnd(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 	slug := bookingSlug(t, e)
 	monday := nextMonday()
 	purposeID := seededTransactionalPurposeID(t, e)
@@ -312,7 +314,7 @@ func TestPublicBookingEndToEnd(t *testing.T) {
 	assertAnonymousAvailability(t, e, base, window)
 	assertBookingRequiresValidConsent(t, e, base, monday)
 
-	consent := anyMap{"purpose_id": purposeID, "policy_version": "pp-2026-01", "wording": "You agree we may contact you about this meeting."}
+	consent := apptest.AnyMap{"purpose_id": purposeID, "policy_version": "pp-2026-01", "wording": "You agree we may contact you about this meeting."}
 	booking := bookHappyPathSlot(t, e, base, monday, consent)
 	assertBookingProofAndProvenance(t, e)
 	assertWithdrawalStandsAgainstBooking(t, e, base, monday, purposeID, consent)
@@ -331,13 +333,13 @@ func TestPublicBookingEndToEnd(t *testing.T) {
 // The anonymous surface is throttled per slug: a flood of booking posts
 // meets 429 long before it meets the calendar.
 func TestPublicBookingRateLimited(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 	slug := bookingSlug(t, e)
 
 	last := 0
 	for i := 0; i < 21; i++ {
-		last = publicCall(t, e, "POST", "/v1/public/booking/"+slug, anyMap{}, nil, nil)
+		last = publicCall(t, e, "POST", "/v1/public/booking/"+slug, apptest.AnyMap{}, nil, nil)
 	}
 	if last != http.StatusTooManyRequests {
 		t.Fatalf("21st burst booking → %d, want 429", last)

--- a/backend/internal/compose/integration/quotas_http_integration_test.go
+++ b/backend/internal/compose/integration/quotas_http_integration_test.go
@@ -19,7 +19,7 @@ package integration
 // fast-follow per crm.yaml's own NET-NEW comment) — the team fixture and
 // the rep-role demotion for the 403 scenario use the owner connection
 // directly, the same technique e2e_integration_test.go's
-// setWorkspaceSeat already uses for seat_type.
+// SetWorkspaceSeat already uses for seat_type.
 
 import (
 	"context"

--- a/backend/internal/compose/integration/quotas_http_integration_test.go
+++ b/backend/internal/compose/integration/quotas_http_integration_test.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -48,10 +49,10 @@ type quotaProblem struct {
 
 // seedQuotaTeam creates one team directly via the owner connection —
 // there is no /v1/teams endpoint yet.
-func seedQuotaTeam(t *testing.T, e *env, name string) string {
+func seedQuotaTeam(t *testing.T, e *apptest.AppEnv, name string) string {
 	t.Helper()
 	ctx := context.Background()
-	tx, err := e.owner.Begin(ctx)
+	tx, err := e.Owner.Begin(ctx)
 	if err != nil {
 		t.Fatalf("begin: %v", err)
 	}
@@ -59,7 +60,7 @@ func seedQuotaTeam(t *testing.T, e *env, name string) string {
 	defer func() { _ = tx.Rollback(ctx) }()
 
 	var wsID, teamID string
-	if err := tx.QueryRow(ctx, `SELECT id FROM workspace WHERE slug = $1`, e.slug).Scan(&wsID); err != nil {
+	if err := tx.QueryRow(ctx, `SELECT id FROM workspace WHERE slug = $1`, e.Slug).Scan(&wsID); err != nil {
 		t.Fatalf("workspace lookup: %v", err)
 	}
 	if err := tx.QueryRow(ctx,
@@ -78,10 +79,10 @@ func seedQuotaTeam(t *testing.T, e *env, name string) string {
 // quotas_integration_test.go's TestQuotaRBAC_RepReadsButNeverMutates
 // proves at the store. Irreversible for the rest of this env — callers
 // run it last.
-func demoteToRep(t *testing.T, e *env) {
+func demoteToRep(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
 	ctx := context.Background()
-	tx, err := e.owner.Begin(ctx)
+	tx, err := e.Owner.Begin(ctx)
 	if err != nil {
 		t.Fatalf("begin: %v", err)
 	}
@@ -89,7 +90,7 @@ func demoteToRep(t *testing.T, e *env) {
 	defer func() { _ = tx.Rollback(ctx) }()
 
 	var wsID string
-	if err := tx.QueryRow(ctx, `SELECT id FROM workspace WHERE slug = $1`, e.slug).Scan(&wsID); err != nil {
+	if err := tx.QueryRow(ctx, `SELECT id FROM workspace WHERE slug = $1`, e.Slug).Scan(&wsID); err != nil {
 		t.Fatalf("workspace lookup: %v", err)
 	}
 	if _, err := tx.Exec(ctx, `SELECT set_config('app.workspace_id', $1, true)`, wsID); err != nil {
@@ -120,10 +121,10 @@ func demoteToRep(t *testing.T, e *env) {
 // createAndCloseQuotaDeal opens a deal owned by ownerID and advances it
 // straight to the seeded pipeline's won stage, so its amount counts
 // toward an owner-quota's attainment.
-func createAndCloseQuotaDeal(t *testing.T, e *env, stages seededStages, ownerID string, amountMinor int64, currency string) string {
+func createAndCloseQuotaDeal(t *testing.T, e *apptest.AppEnv, stages seededStages, ownerID string, amountMinor int64, currency string) string {
 	t.Helper()
-	var deal anyMap
-	status := e.call(t, "POST", "/v1/deals", anyMap{
+	var deal apptest.AnyMap
+	status := e.Call(t, "POST", "/v1/deals", apptest.AnyMap{
 		"name": "Quota Attainment Deal", "amount_minor": amountMinor, "currency": currency,
 		"pipeline_id": stages.pipelineID, "stage_id": stages.open, "owner_id": ownerID, "source": "ui",
 	}, nil, &deal)
@@ -131,7 +132,7 @@ func createAndCloseQuotaDeal(t *testing.T, e *env, stages seededStages, ownerID 
 		t.Fatalf("create quota deal = %d %v", status, deal)
 	}
 	dealID := deal["id"].(string)
-	status = e.call(t, "POST", "/v1/deals/"+dealID+"/advance", anyMap{"to_stage_id": stages.won}, nil, &deal)
+	status = e.Call(t, "POST", "/v1/deals/"+dealID+"/advance", apptest.AnyMap{"to_stage_id": stages.won}, nil, &deal)
 	if status != http.StatusOK || deal["status"] != "won" {
 		t.Fatalf("advance quota deal to won = %d %v", status, deal)
 	}
@@ -139,14 +140,14 @@ func createAndCloseQuotaDeal(t *testing.T, e *env, stages seededStages, ownerID 
 }
 
 func TestQuotasHTTP(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 
-	var me anyMap
-	if status := e.call(t, "GET", "/v1/me", nil, nil, &me); status != http.StatusOK {
+	var me apptest.AnyMap
+	if status := e.Call(t, "GET", "/v1/me", nil, nil, &me); status != http.StatusOK {
 		t.Fatalf("/me = %d", status)
 	}
-	adminID := me["user"].(anyMap)["id"].(string)
+	adminID := me["user"].(apptest.AnyMap)["id"].(string)
 	teamID := seedQuotaTeam(t, e, "Quota HTTP Team")
 
 	var ownerQuotaID, teamQuotaID string
@@ -200,10 +201,10 @@ func TestQuotasHTTP(t *testing.T) {
 // assertQuotaCreate201 creates one owner-quota and one team-quota through
 // the real write path, checking the XOR shape lands correctly on each
 // side and the fresh-row invariants (version 1, no archived_at).
-func assertQuotaCreate201(t *testing.T, e *env, ownerID, teamID string) (ownerQuotaID, teamQuotaID string) {
+func assertQuotaCreate201(t *testing.T, e *apptest.AppEnv, ownerID, teamID string) (ownerQuotaID, teamQuotaID string) {
 	t.Helper()
-	var owned anyMap
-	status := e.call(t, "POST", "/v1/quotas", anyMap{
+	var owned apptest.AnyMap
+	status := e.Call(t, "POST", "/v1/quotas", apptest.AnyMap{
 		"owner_id": ownerID, "period_start": "2020-01-01", "period_end": "2030-12-31",
 		"target_minor": 1000000, "currency": "EUR",
 	}, nil, &owned)
@@ -220,8 +221,8 @@ func assertQuotaCreate201(t *testing.T, e *env, ownerID, teamID string) (ownerQu
 		t.Errorf("a fresh quota carries version 1 and no archived_at, got %+v", owned)
 	}
 
-	var team anyMap
-	status = e.call(t, "POST", "/v1/quotas", anyMap{
+	var team apptest.AnyMap
+	status = e.Call(t, "POST", "/v1/quotas", apptest.AnyMap{
 		"team_id": teamID, "period_start": "2026-01-01", "period_end": "2026-03-31",
 		"target_minor": 5000000, "currency": "EUR",
 	}, nil, &team)
@@ -238,9 +239,9 @@ func assertQuotaCreate201(t *testing.T, e *env, ownerID, teamID string) (ownerQu
 // request-body values — nil omits the key entirely — and checks the
 // contract's exact owner_xor_team_required details.errors shape for both
 // the both-set and neither-set violations.
-func assertQuotaXOR422(t *testing.T, e *env, ownerID, teamID *string) {
+func assertQuotaXOR422(t *testing.T, e *apptest.AppEnv, ownerID, teamID *string) {
 	t.Helper()
-	body := anyMap{"period_start": "2026-01-01", "period_end": "2026-03-31", "target_minor": 1000, "currency": "EUR"}
+	body := apptest.AnyMap{"period_start": "2026-01-01", "period_end": "2026-03-31", "target_minor": 1000, "currency": "EUR"}
 	if ownerID != nil {
 		body["owner_id"] = *ownerID
 	}
@@ -248,7 +249,7 @@ func assertQuotaXOR422(t *testing.T, e *env, ownerID, teamID *string) {
 		body["team_id"] = *teamID
 	}
 	var problem quotaProblem
-	status := e.call(t, "POST", "/v1/quotas", body, nil, &problem)
+	status := e.Call(t, "POST", "/v1/quotas", body, nil, &problem)
 	if status != http.StatusUnprocessableEntity {
 		t.Fatalf("owner-xor-team violation = %d, want 422: %+v", status, problem)
 	}
@@ -258,32 +259,32 @@ func assertQuotaXOR422(t *testing.T, e *env, ownerID, teamID *string) {
 	}
 }
 
-func assertQuotaGet(t *testing.T, e *env, id string) {
+func assertQuotaGet(t *testing.T, e *apptest.AppEnv, id string) {
 	t.Helper()
-	var got anyMap
-	if status := e.call(t, "GET", "/v1/quotas/"+id, nil, nil, &got); status != http.StatusOK || got["id"] != id {
+	var got apptest.AnyMap
+	if status := e.Call(t, "GET", "/v1/quotas/"+id, nil, nil, &got); status != http.StatusOK || got["id"] != id {
 		t.Fatalf("get quota = %d %+v, want 200 id=%s", status, got, id)
 	}
-	if status := e.call(t, "GET", "/v1/quotas/"+ids.NewV7().String(), nil, nil, nil); status != http.StatusNotFound {
+	if status := e.Call(t, "GET", "/v1/quotas/"+ids.NewV7().String(), nil, nil, nil); status != http.StatusNotFound {
 		t.Fatalf("get unknown quota = %d, want 404", status)
 	}
 }
 
-func assertQuotaList(t *testing.T, e *env, ownerQuotaID, teamQuotaID, ownerID, teamID string) {
+func assertQuotaList(t *testing.T, e *apptest.AppEnv, ownerQuotaID, teamQuotaID, ownerID, teamID string) {
 	t.Helper()
 	var byOwner struct {
-		Data []anyMap `json:"data"`
+		Data []apptest.AnyMap `json:"data"`
 	}
-	if status := e.call(t, "GET", "/v1/quotas?owner_id="+ownerID, nil, nil, &byOwner); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/quotas?owner_id="+ownerID, nil, nil, &byOwner); status != http.StatusOK {
 		t.Fatalf("list by owner_id = %d", status)
 	}
 	if len(byOwner.Data) != 1 || byOwner.Data[0]["id"] != ownerQuotaID {
 		t.Fatalf("owner_id filter = %+v, want exactly the owner quota", byOwner.Data)
 	}
 	var byTeam struct {
-		Data []anyMap `json:"data"`
+		Data []apptest.AnyMap `json:"data"`
 	}
-	if status := e.call(t, "GET", "/v1/quotas?team_id="+teamID, nil, nil, &byTeam); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/quotas?team_id="+teamID, nil, nil, &byTeam); status != http.StatusOK {
 		t.Fatalf("list by team_id = %d", status)
 	}
 	if len(byTeam.Data) != 1 || byTeam.Data[0]["id"] != teamQuotaID {
@@ -296,21 +297,21 @@ func assertQuotaList(t *testing.T, e *env, ownerQuotaID, teamQuotaID, ownerID, t
 // quota's (2026 Q1), so sort=period_start puts the owner quota first and
 // sort=-period_start reverses that — while a field outside the quota
 // vocabulary answers the established 422 sort_field_not_allowed shape.
-func assertQuotaListSort(t *testing.T, e *env, ownerQuotaID, teamQuotaID string) {
+func assertQuotaListSort(t *testing.T, e *apptest.AppEnv, ownerQuotaID, teamQuotaID string) {
 	t.Helper()
 	var asc struct {
-		Data []anyMap `json:"data"`
+		Data []apptest.AnyMap `json:"data"`
 	}
-	if status := e.call(t, "GET", "/v1/quotas?sort=period_start", nil, nil, &asc); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/quotas?sort=period_start", nil, nil, &asc); status != http.StatusOK {
 		t.Fatalf("sort=period_start = %d", status)
 	}
 	if len(asc.Data) != 2 || asc.Data[0]["id"] != ownerQuotaID || asc.Data[1]["id"] != teamQuotaID {
 		t.Fatalf("sort=period_start order = %+v, want [owner %s, team %s]", asc.Data, ownerQuotaID, teamQuotaID)
 	}
 	var desc struct {
-		Data []anyMap `json:"data"`
+		Data []apptest.AnyMap `json:"data"`
 	}
-	if status := e.call(t, "GET", "/v1/quotas?sort=-period_start", nil, nil, &desc); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/quotas?sort=-period_start", nil, nil, &desc); status != http.StatusOK {
 		t.Fatalf("sort=-period_start = %d", status)
 	}
 	if len(desc.Data) != 2 || desc.Data[0]["id"] != teamQuotaID || desc.Data[1]["id"] != ownerQuotaID {
@@ -318,7 +319,7 @@ func assertQuotaListSort(t *testing.T, e *env, ownerQuotaID, teamQuotaID string)
 	}
 
 	var problem quotaProblem
-	status := e.call(t, "GET", "/v1/quotas?sort=banana", nil, nil, &problem)
+	status := e.Call(t, "GET", "/v1/quotas?sort=banana", nil, nil, &problem)
 	if status != http.StatusUnprocessableEntity || problem.Code != "validation_error" {
 		t.Fatalf("sort=banana = %d %+v, want 422 validation_error", status, problem)
 	}
@@ -331,24 +332,24 @@ func assertQuotaListSort(t *testing.T, e *env, ownerQuotaID, teamQuotaID string)
 // assertQuotaUpdate drives the merge-PATCH happy path (version 1→2),
 // then the same If-Match value replayed (now stale, 409 version_skew),
 // then a non-numeric If-Match (422 validation_error/malformed_if_match).
-func assertQuotaUpdate(t *testing.T, e *env, id string) {
+func assertQuotaUpdate(t *testing.T, e *apptest.AppEnv, id string) {
 	t.Helper()
-	var updated anyMap
-	status := e.call(t, "PATCH", "/v1/quotas/"+id, anyMap{"target_minor": 2000000},
+	var updated apptest.AnyMap
+	status := e.Call(t, "PATCH", "/v1/quotas/"+id, apptest.AnyMap{"target_minor": 2000000},
 		map[string]string{"If-Match": "1"}, &updated)
 	if status != http.StatusOK || updated["target_minor"].(float64) != 2000000 || updated["version"].(float64) != 2 {
 		t.Fatalf("update = %d %+v, want 200 target=2000000 version=2", status, updated)
 	}
 
 	var stale quotaProblem
-	status = e.call(t, "PATCH", "/v1/quotas/"+id, anyMap{"target_minor": 3000000},
+	status = e.Call(t, "PATCH", "/v1/quotas/"+id, apptest.AnyMap{"target_minor": 3000000},
 		map[string]string{"If-Match": "1"}, &stale)
 	if status != http.StatusConflict || stale.Code != "version_skew" {
 		t.Fatalf("stale If-Match = %d %+v, want 409 version_skew", status, stale)
 	}
 
 	var malformed quotaProblem
-	status = e.call(t, "PATCH", "/v1/quotas/"+id, anyMap{"target_minor": 3000000},
+	status = e.Call(t, "PATCH", "/v1/quotas/"+id, apptest.AnyMap{"target_minor": 3000000},
 		map[string]string{"If-Match": "not-a-version"}, &malformed)
 	if status != http.StatusUnprocessableEntity || malformed.Code != "validation_error" {
 		t.Fatalf("malformed If-Match = %d %+v, want 422 validation_error", status, malformed)
@@ -358,10 +359,10 @@ func assertQuotaUpdate(t *testing.T, e *env, id string) {
 // assertQuotaArchive archives a dedicated fresh quota (not one reused by
 // the other scenarios) and checks the 200-with-entity shape plus the
 // house single-get convention: an archived quota stays fetchable by id.
-func assertQuotaArchive(t *testing.T, e *env, ownerID string) {
+func assertQuotaArchive(t *testing.T, e *apptest.AppEnv, ownerID string) {
 	t.Helper()
-	var created anyMap
-	status := e.call(t, "POST", "/v1/quotas", anyMap{
+	var created apptest.AnyMap
+	status := e.Call(t, "POST", "/v1/quotas", apptest.AnyMap{
 		"owner_id": ownerID, "period_start": "2026-01-01", "period_end": "2026-03-31",
 		"target_minor": 100, "currency": "EUR",
 	}, nil, &created)
@@ -370,14 +371,14 @@ func assertQuotaArchive(t *testing.T, e *env, ownerID string) {
 	}
 	id := created["id"].(string)
 
-	var archived anyMap
-	status = e.call(t, "DELETE", "/v1/quotas/"+id, nil, nil, &archived)
+	var archived apptest.AnyMap
+	status = e.Call(t, "DELETE", "/v1/quotas/"+id, nil, nil, &archived)
 	if status != http.StatusOK || archived["archived_at"] == nil || archived["id"] != id {
 		t.Fatalf("archive = %d %+v, want 200 + the full entity with archived_at set", status, archived)
 	}
 
-	var stillGettable anyMap
-	if status := e.call(t, "GET", "/v1/quotas/"+id, nil, nil, &stillGettable); status != http.StatusOK || stillGettable["archived_at"] == nil {
+	var stillGettable apptest.AnyMap
+	if status := e.Call(t, "GET", "/v1/quotas/"+id, nil, nil, &stillGettable); status != http.StatusOK || stillGettable["archived_at"] == nil {
 		t.Fatalf("get archived quota = %d %+v, want 200 with archived_at set", status, stillGettable)
 	}
 }
@@ -391,7 +392,7 @@ func assertQuotaArchive(t *testing.T, e *env, ownerID string) {
 // the generated decode nor merge-PATCH, so the store's refusal is what
 // keeps a negative revenue target out — on create and on the patched
 // merged state alike.
-func assertQuotaNegativeTarget(t *testing.T, e *env, ownerID string) {
+func assertQuotaNegativeTarget(t *testing.T, e *apptest.AppEnv, ownerID string) {
 	t.Helper()
 	assertNegativeTarget422 := func(status int, problem quotaProblem, path string) {
 		t.Helper()
@@ -405,29 +406,29 @@ func assertQuotaNegativeTarget(t *testing.T, e *env, ownerID string) {
 	}
 
 	var problem quotaProblem
-	status := e.call(t, "POST", "/v1/quotas", anyMap{
+	status := e.Call(t, "POST", "/v1/quotas", apptest.AnyMap{
 		"owner_id": ownerID, "period_start": "2026-01-01", "period_end": "2026-03-31",
 		"target_minor": -1, "currency": "EUR",
 	}, nil, &problem)
 	assertNegativeTarget422(status, problem, "create")
 
-	var created anyMap
-	if status := e.call(t, "POST", "/v1/quotas", anyMap{
+	var created apptest.AnyMap
+	if status := e.Call(t, "POST", "/v1/quotas", apptest.AnyMap{
 		"owner_id": ownerID, "period_start": "2027-01-01", "period_end": "2027-03-31",
 		"target_minor": 1000, "currency": "EUR",
 	}, nil, &created); status != http.StatusCreated {
 		t.Fatalf("seed quota for the patch scenario = %d %+v", status, created)
 	}
 	var patched quotaProblem
-	status = e.call(t, "PATCH", "/v1/quotas/"+created["id"].(string), anyMap{"target_minor": -1},
+	status = e.Call(t, "PATCH", "/v1/quotas/"+created["id"].(string), apptest.AnyMap{"target_minor": -1},
 		map[string]string{"If-Match": "1"}, &patched)
 	assertNegativeTarget422(status, patched, "patch")
 }
 
-func assertQuotaInvalidCurrency(t *testing.T, e *env, ownerID string) {
+func assertQuotaInvalidCurrency(t *testing.T, e *apptest.AppEnv, ownerID string) {
 	t.Helper()
 	var problem quotaProblem
-	status := e.call(t, "POST", "/v1/quotas", anyMap{
+	status := e.Call(t, "POST", "/v1/quotas", apptest.AnyMap{
 		"owner_id": ownerID, "period_start": "2026-01-01", "period_end": "2026-03-31",
 		"target_minor": 1000, "currency": "eur",
 	}, nil, &problem)
@@ -444,10 +445,10 @@ func assertQuotaInvalidCurrency(t *testing.T, e *env, ownerID string) {
 // the quota_period_valid CHECK (0067) — a quota measuring a negative
 // window is refused with the same typed 422 as the currency CHECK, never
 // stored or answered with an opaque 500.
-func assertQuotaInvertedPeriod(t *testing.T, e *env, ownerID string) {
+func assertQuotaInvertedPeriod(t *testing.T, e *apptest.AppEnv, ownerID string) {
 	t.Helper()
 	var problem quotaProblem
-	status := e.call(t, "POST", "/v1/quotas", anyMap{
+	status := e.Call(t, "POST", "/v1/quotas", apptest.AnyMap{
 		"owner_id": ownerID, "period_start": "2026-03-31", "period_end": "2026-01-01",
 		"target_minor": 1000, "currency": "EUR",
 	}, nil, &problem)
@@ -464,10 +465,10 @@ func assertQuotaInvertedPeriod(t *testing.T, e *env, ownerID string) {
 // checks every golden number the contract's worked example names:
 // closed_won_minor, target_minor/currency, the uncapped attainment_pct,
 // the signed gap, the band, and the per-deal decomposition.
-func assertQuotaAttainmentHappy(t *testing.T, e *env, ownerID string) {
+func assertQuotaAttainmentHappy(t *testing.T, e *apptest.AppEnv, ownerID string) {
 	t.Helper()
-	var quota anyMap
-	status := e.call(t, "POST", "/v1/quotas", anyMap{
+	var quota apptest.AnyMap
+	status := e.Call(t, "POST", "/v1/quotas", apptest.AnyMap{
 		"owner_id": ownerID, "period_start": "2020-01-01", "period_end": "2030-12-31",
 		"target_minor": 1000000, "currency": "EUR",
 	}, nil, &quota)
@@ -479,8 +480,8 @@ func assertQuotaAttainmentHappy(t *testing.T, e *env, ownerID string) {
 	stages := discoverSeededPipeline(t, e)
 	dealID := createAndCloseQuotaDeal(t, e, stages, ownerID, 1_500_000, "EUR")
 
-	var att anyMap
-	status = e.call(t, "GET", "/v1/quotas/"+quotaID+"/attainment", nil, nil, &att)
+	var att apptest.AnyMap
+	status = e.Call(t, "GET", "/v1/quotas/"+quotaID+"/attainment", nil, nil, &att)
 	if status != http.StatusOK {
 		t.Fatalf("attainment = %d %v", status, att)
 	}
@@ -506,7 +507,7 @@ func assertQuotaAttainmentHappy(t *testing.T, e *env, ownerID string) {
 	if !ok || len(deals) != 1 {
 		t.Fatalf("contributing_deals = %v, want exactly one entry", att["contributing_deals"])
 	}
-	first, _ := deals[0].(anyMap)
+	first, _ := deals[0].(apptest.AnyMap)
 	if first["deal_id"] != dealID || first["base_value_minor"].(float64) != 1_500_000 {
 		t.Errorf("contributing_deals[0] = %+v, want deal_id=%s base_value_minor=1500000", first, dealID)
 	}
@@ -515,10 +516,10 @@ func assertQuotaAttainmentHappy(t *testing.T, e *env, ownerID string) {
 	}
 }
 
-func assertQuotaAttainmentTargetZero(t *testing.T, e *env, ownerID string) {
+func assertQuotaAttainmentTargetZero(t *testing.T, e *apptest.AppEnv, ownerID string) {
 	t.Helper()
-	var quota anyMap
-	status := e.call(t, "POST", "/v1/quotas", anyMap{
+	var quota apptest.AnyMap
+	status := e.Call(t, "POST", "/v1/quotas", apptest.AnyMap{
 		"owner_id": ownerID, "period_start": "2026-01-01", "period_end": "2026-03-31",
 		"target_minor": 0, "currency": "EUR",
 	}, nil, &quota)
@@ -526,7 +527,7 @@ func assertQuotaAttainmentTargetZero(t *testing.T, e *env, ownerID string) {
 		t.Fatalf("create zero-target quota = %d %v", status, quota)
 	}
 	var problem quotaProblem
-	status = e.call(t, "GET", "/v1/quotas/"+quota["id"].(string)+"/attainment", nil, nil, &problem)
+	status = e.Call(t, "GET", "/v1/quotas/"+quota["id"].(string)+"/attainment", nil, nil, &problem)
 	if status != http.StatusUnprocessableEntity || problem.Code != "attainment_target_zero" {
 		t.Fatalf("zero-target attainment = %d %+v, want 422 attainment_target_zero", status, problem)
 	}
@@ -536,10 +537,10 @@ func assertQuotaAttainmentTargetZero(t *testing.T, e *env, ownerID string) {
 // with no stored fx_rate row and checks the wire detail names the
 // failure honestly without leaking the from/to currency pair the store's
 // wrapped sentinel carries for the server log.
-func assertQuotaAttainmentComputationFailed(t *testing.T, e *env, ownerID string) {
+func assertQuotaAttainmentComputationFailed(t *testing.T, e *apptest.AppEnv, ownerID string) {
 	t.Helper()
-	var quota anyMap
-	status := e.call(t, "POST", "/v1/quotas", anyMap{
+	var quota apptest.AnyMap
+	status := e.Call(t, "POST", "/v1/quotas", apptest.AnyMap{
 		"owner_id": ownerID, "period_start": "2026-01-01", "period_end": "2026-03-31",
 		"target_minor": 1000, "currency": "GBP",
 	}, nil, &quota)
@@ -547,7 +548,7 @@ func assertQuotaAttainmentComputationFailed(t *testing.T, e *env, ownerID string
 		t.Fatalf("create foreign-currency quota = %d %v", status, quota)
 	}
 	var problem quotaProblem
-	status = e.call(t, "GET", "/v1/quotas/"+quota["id"].(string)+"/attainment", nil, nil, &problem)
+	status = e.Call(t, "GET", "/v1/quotas/"+quota["id"].(string)+"/attainment", nil, nil, &problem)
 	if status != http.StatusUnprocessableEntity || problem.Code != "attainment_computation_failed" {
 		t.Fatalf("missing-fx attainment = %d %+v, want 422 attainment_computation_failed", status, problem)
 	}
@@ -562,11 +563,11 @@ func assertQuotaAttainmentComputationFailed(t *testing.T, e *env, ownerID string
 // assertQuotaRepCannotCreate demotes the session's own user to rep
 // (0068: read-only on quota) and checks the object gate refuses a create
 // over REST exactly as it does at the store.
-func assertQuotaRepCannotCreate(t *testing.T, e *env, ownerID string) {
+func assertQuotaRepCannotCreate(t *testing.T, e *apptest.AppEnv, ownerID string) {
 	t.Helper()
 	demoteToRep(t, e)
 	var problem quotaProblem
-	status := e.call(t, "POST", "/v1/quotas", anyMap{
+	status := e.Call(t, "POST", "/v1/quotas", apptest.AnyMap{
 		"owner_id": ownerID, "period_start": "2026-01-01", "period_end": "2026-03-31",
 		"target_minor": 1000, "currency": "EUR",
 	}, nil, &problem)

--- a/backend/internal/compose/integration/raterefresh_http_integration_test.go
+++ b/backend/internal/compose/integration/raterefresh_http_integration_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/riverqueue/river"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 )
 
 type fakeRateEnqueue struct {
@@ -32,19 +33,19 @@ func (f *fakeRateEnqueue) Enqueue(_ context.Context, args river.JobArgs, opts *r
 
 func TestProposeRefreshEndpointsEnqueue(t *testing.T) {
 	fake := &fakeRateEnqueue{}
-	e := setupWithOptions(t, compose.WithRateRefresh(fake))
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupAppWithOptions(t, compose.WithRateRefresh(fake))
+	e.BootstrapWorkspace(t)
 
 	var out struct {
 		Status string `json:"status"`
 	}
-	if status := e.call(t, "POST", "/v1/fx-rates/propose-refresh", nil, nil, &out); status != http.StatusAccepted {
+	if status := e.Call(t, "POST", "/v1/fx-rates/propose-refresh", nil, nil, &out); status != http.StatusAccepted {
 		t.Fatalf("POST /fx-rates/propose-refresh → %d, want 202", status)
 	}
 	if out.Status != "enqueued" {
 		t.Fatalf("status = %q, want enqueued", out.Status)
 	}
-	if status := e.call(t, "POST", "/v1/ai-model-rates/propose-refresh", nil, nil, &out); status != http.StatusAccepted {
+	if status := e.Call(t, "POST", "/v1/ai-model-rates/propose-refresh", nil, nil, &out); status != http.StatusAccepted {
 		t.Fatalf("POST /ai-model-rates/propose-refresh → %d, want 202", status)
 	}
 	if len(fake.calls) != 2 {

--- a/backend/internal/compose/integration/rates_http_integration_test.go
+++ b/backend/internal/compose/integration/rates_http_integration_test.go
@@ -15,6 +15,8 @@ import (
 	"net/http"
 	"testing"
 	"time"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 )
 
 type fxRateDTO struct {
@@ -28,28 +30,28 @@ type fxRateListDTO struct {
 	Data []fxRateDTO `json:"data"`
 }
 
-func (e *env) baseCurrency(t *testing.T) string {
+func baseCurrency(e *apptest.AppEnv, t *testing.T) string {
 	t.Helper()
 	var base string
-	if err := e.owner.QueryRow(context.Background(),
-		`SELECT base_currency FROM workspace WHERE slug = $1`, e.slug).Scan(&base); err != nil {
+	if err := e.Owner.QueryRow(context.Background(),
+		`SELECT base_currency FROM workspace WHERE slug = $1`, e.Slug).Scan(&base); err != nil {
 		t.Fatalf("base currency lookup: %v", err)
 	}
 	return base
 }
 
 func TestFxRatesOverHTTP(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 	today := time.Now().UTC().Format("2006-01-02")
 
 	from := "USD"
-	if e.baseCurrency(t) == "USD" {
+	if baseCurrency(e, t) == "USD" {
 		from = "GBP"
 	}
 
 	var created fxRateDTO
-	if status := e.call(t, "POST", "/v1/fx-rates",
+	if status := e.Call(t, "POST", "/v1/fx-rates",
 		map[string]any{"from_currency": from, "rate": "0.92", "effective_date": today}, nil, &created); status != http.StatusCreated {
 		t.Fatalf("POST /fx-rates → %d, want 201", status)
 	}
@@ -59,7 +61,7 @@ func TestFxRatesOverHTTP(t *testing.T) {
 	}
 
 	var list fxRateListDTO
-	if status := e.call(t, "GET", "/v1/fx-rates", nil, nil, &list); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/fx-rates", nil, nil, &list); status != http.StatusOK {
 		t.Fatalf("GET /fx-rates → %d, want 200", status)
 	}
 	if len(list.Data) != 1 || list.Data[0].FromCurrency != from {
@@ -68,7 +70,7 @@ func TestFxRatesOverHTTP(t *testing.T) {
 
 	// A past effective date is a clean 422, not a 500.
 	past := time.Now().UTC().AddDate(0, 0, -1).Format("2006-01-02")
-	if status := e.call(t, "POST", "/v1/fx-rates",
+	if status := e.Call(t, "POST", "/v1/fx-rates",
 		map[string]any{"from_currency": from, "rate": "0.9", "effective_date": past}, nil, nil); status != http.StatusUnprocessableEntity {
 		t.Fatalf("past-date POST /fx-rates → %d, want 422", status)
 	}
@@ -89,12 +91,12 @@ type aiModelRateListDTO struct {
 }
 
 func TestAiModelRatesOverHTTP(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 	today := time.Now().UTC().Format("2006-01-02")
 
 	var created aiModelRateDTO
-	if status := e.call(t, "POST", "/v1/ai-model-rates", map[string]any{
+	if status := e.Call(t, "POST", "/v1/ai-model-rates", map[string]any{
 		"provider": "anthropic", "model_id": "claude-opus-4-8",
 		"input_per_mtok": "5.00", "output_per_mtok": "25",
 		"cache_read_per_mtok": "0.5", "cache_write_per_mtok": "6.25",
@@ -110,7 +112,7 @@ func TestAiModelRatesOverHTTP(t *testing.T) {
 	// The workspace bootstrap seeds default model rates; our upsert corrects
 	// the opus row in place, so the list contains opus at our input of 5.
 	var list aiModelRateListDTO
-	if status := e.call(t, "GET", "/v1/ai-model-rates", nil, nil, &list); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/ai-model-rates", nil, nil, &list); status != http.StatusOK {
 		t.Fatalf("GET /ai-model-rates → %d, want 200", status)
 	}
 	found := false
@@ -127,7 +129,7 @@ func TestAiModelRatesOverHTTP(t *testing.T) {
 	}
 
 	past := time.Now().UTC().AddDate(0, 0, -1).Format("2006-01-02")
-	if status := e.call(t, "POST", "/v1/ai-model-rates", map[string]any{
+	if status := e.Call(t, "POST", "/v1/ai-model-rates", map[string]any{
 		"provider": "anthropic", "model_id": "m",
 		"input_per_mtok": "1", "output_per_mtok": "1",
 		"cache_read_per_mtok": "0", "cache_write_per_mtok": "0",

--- a/backend/internal/compose/integration/recordcontext_http_integration_test.go
+++ b/backend/internal/compose/integration/recordcontext_http_integration_test.go
@@ -18,6 +18,8 @@ package integration
 import (
 	"net/http"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 )
 
 type contextRefWire struct {
@@ -46,19 +48,19 @@ type contextResponseWire struct {
 // log-activity-with-links shapes activity_lifecycle_integration_test.go
 // and consent_integration_test.go already exercise), returning the
 // person's id — the anchor this suite walks context from.
-func seedPersonWithActivity(t *testing.T, e *env) string {
+func seedPersonWithActivity(t *testing.T, e *apptest.AppEnv) string {
 	t.Helper()
 	var person struct {
 		ID string `json:"id"`
 	}
-	if status := e.call(t, "POST", "/v1/people", anyMap{
+	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{
 		"full_name": "Context Anchor",
 	}, nil, &person); status != http.StatusCreated {
 		t.Fatalf("create person → %d", status)
 	}
-	if status := e.call(t, "POST", "/v1/activities", anyMap{
+	if status := e.Call(t, "POST", "/v1/activities", apptest.AnyMap{
 		"kind": "note", "body": "Discussed renewal terms",
-		"links": []anyMap{{"entity_type": "person", "entity_id": person.ID}},
+		"links": []apptest.AnyMap{{"entity_type": "person", "entity_id": person.ID}},
 	}, nil, nil); status != http.StatusCreated {
 		t.Fatalf("log anchor activity → %d", status)
 	}
@@ -66,12 +68,12 @@ func seedPersonWithActivity(t *testing.T, e *env) string {
 }
 
 func TestGetRecordContextReturnsAnchorAndIsRowScoped(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 	pid := seedPersonWithActivity(t, e)
 
 	var got contextResponseWire
-	status := e.call(t, "GET", "/v1/records/person/"+pid+"/context?max_items=5", nil, nil, &got)
+	status := e.Call(t, "GET", "/v1/records/person/"+pid+"/context?max_items=5", nil, nil, &got)
 	if status != http.StatusOK {
 		t.Fatalf("status = %d, want 200", status)
 	}
@@ -85,14 +87,14 @@ func TestGetRecordContextReturnsAnchorAndIsRowScoped(t *testing.T) {
 	// Isolation: a random uuid the caller cannot see yields an empty
 	// picture, not an oracle that resurfaces another tenant's neighborhood.
 	var empty contextResponseWire
-	status = e.call(t, "GET", "/v1/records/person/018f3a1b-0000-7000-8000-0000deadbeef/context", nil, nil, &empty)
+	status = e.Call(t, "GET", "/v1/records/person/018f3a1b-0000-7000-8000-0000deadbeef/context", nil, nil, &empty)
 	if status != http.StatusNotFound && (status != http.StatusOK || len(empty.Sections) != 0) {
 		t.Fatalf("unknown anchor status = %d, sections = %+v — want 404 or an empty picture", status, empty.Sections)
 	}
 
 	t.Run("422 invalid entity_type", func(t *testing.T) {
 		var problem fieldHistoryProblem
-		status := e.call(t, "GET", "/v1/records/bogus/"+pid+"/context", nil, nil, &problem)
+		status := e.Call(t, "GET", "/v1/records/bogus/"+pid+"/context", nil, nil, &problem)
 		assertFieldHistoryValidation422(t, status, problem, "entity_type", "invalid_entity_type")
 	})
 
@@ -101,13 +103,13 @@ func TestGetRecordContextReturnsAnchorAndIsRowScoped(t *testing.T) {
 	// where a negative bound would panic on a negative index.
 	t.Run("422 max_items below the contract minimum", func(t *testing.T) {
 		var problem fieldHistoryProblem
-		status := e.call(t, "GET", "/v1/records/person/"+pid+"/context?max_items=-1", nil, nil, &problem)
+		status := e.Call(t, "GET", "/v1/records/person/"+pid+"/context?max_items=-1", nil, nil, &problem)
 		assertFieldHistoryValidation422(t, status, problem, "max_items", "out_of_range")
 	})
 
 	t.Run("422 max_items above the contract maximum", func(t *testing.T) {
 		var problem fieldHistoryProblem
-		status := e.call(t, "GET", "/v1/records/person/"+pid+"/context?max_items=999", nil, nil, &problem)
+		status := e.Call(t, "GET", "/v1/records/person/"+pid+"/context?max_items=999", nil, nil, &problem)
 		assertFieldHistoryValidation422(t, status, problem, "max_items", "out_of_range")
 	})
 
@@ -120,11 +122,11 @@ func TestGetRecordContextReturnsAnchorAndIsRowScoped(t *testing.T) {
 		var lead struct {
 			ID string `json:"id"`
 		}
-		if s := e.call(t, "POST", "/v1/leads", anyMap{"full_name": "Context Lead"}, nil, &lead); s != http.StatusCreated {
+		if s := e.Call(t, "POST", "/v1/leads", apptest.AnyMap{"full_name": "Context Lead"}, nil, &lead); s != http.StatusCreated {
 			t.Fatalf("create lead → %d", s)
 		}
 		var got contextResponseWire
-		status := e.call(t, "GET", "/v1/records/lead/"+lead.ID+"/context", nil, nil, &got)
+		status := e.Call(t, "GET", "/v1/records/lead/"+lead.ID+"/context", nil, nil, &got)
 		if status != http.StatusOK {
 			t.Fatalf("lead context status = %d, want 200", status)
 		}

--- a/backend/internal/compose/integration/recordhistory_http_integration_test.go
+++ b/backend/internal/compose/integration/recordhistory_http_integration_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -61,10 +62,10 @@ type recordHistoryHTTPFixture struct {
 	adaID    ids.UUID
 }
 
-func seedRecordHistoryHTTPFixture(t *testing.T, e *env, dbEnv *Env) recordHistoryHTTPFixture {
+func seedRecordHistoryHTTPFixture(t *testing.T, e *apptest.AppEnv, dbEnv *Env) recordHistoryHTTPFixture {
 	t.Helper()
-	var person anyMap
-	if status := e.call(t, "POST", "/v1/people", anyMap{
+	var person apptest.AnyMap
+	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{
 		"full_name": "Record History Subject",
 		"source":    "ui",
 	}, nil, &person); status != http.StatusCreated {
@@ -93,10 +94,10 @@ func seedRecordHistoryHTTPFixture(t *testing.T, e *env, dbEnv *Env) recordHistor
 // chronological ordering, the genesis line's resolved display name, the
 // human diff's exact (no-phantom-key) before/after images, and the
 // agent line's woven-in delegated authority.
-func assertRecordHistoryHappyPath(t *testing.T, e *env, fx recordHistoryHTTPFixture) {
+func assertRecordHistoryHappyPath(t *testing.T, e *apptest.AppEnv, fx recordHistoryHTTPFixture) {
 	t.Helper()
 	var page recordHistoryListWire
-	status := e.call(t, "GET", "/v1/records/person/"+fx.personID.String()+"/history", nil, nil, &page)
+	status := e.Call(t, "GET", "/v1/records/person/"+fx.personID.String()+"/history", nil, nil, &page)
 	if status != http.StatusOK {
 		t.Fatalf("record-history status = %d, want 200: %+v", status, page)
 	}
@@ -158,8 +159,8 @@ func assertRecordHistoryHappyPath(t *testing.T, e *env, fx recordHistoryHTTPFixt
 }
 
 func TestRecordHistoryHTTP(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 	dbEnv := fieldHistoryHTTPEnv(t, e)
 	fx := seedRecordHistoryHTTPFixture(t, e, dbEnv)
 
@@ -169,13 +170,13 @@ func TestRecordHistoryHTTP(t *testing.T) {
 
 	t.Run("422 invalid entity_type", func(t *testing.T) {
 		var problem fieldHistoryProblem
-		status := e.call(t, "GET", "/v1/records/bogus/"+ids.NewV7().String()+"/history", nil, nil, &problem)
+		status := e.Call(t, "GET", "/v1/records/bogus/"+ids.NewV7().String()+"/history", nil, nil, &problem)
 		assertFieldHistoryValidation422(t, status, problem, "entity_type", "invalid_entity_type")
 	})
 
 	t.Run("422 malformed cursor", func(t *testing.T) {
 		var problem fieldHistoryProblem
-		status := e.call(t, "GET",
+		status := e.Call(t, "GET",
 			"/v1/records/person/"+fx.personID.String()+"/history?cursor=!!!notatoken", nil, nil, &problem)
 		assertFieldHistoryValidation422(t, status, problem, "cursor", "malformed_cursor")
 	})
@@ -190,7 +191,7 @@ func TestRecordHistoryHTTP(t *testing.T) {
 			if cursor != "" {
 				reqURL += "&cursor=" + cursor
 			}
-			status := e.call(t, "GET", reqURL, nil, nil, &got)
+			status := e.Call(t, "GET", reqURL, nil, nil, &got)
 			if status != http.StatusOK {
 				t.Fatalf("page %d status = %d: %+v", page, status, got)
 			}

--- a/backend/internal/compose/integration/relationship_integration_test.go
+++ b/backend/internal/compose/integration/relationship_integration_test.go
@@ -14,29 +14,31 @@ import (
 	"net/http"
 	"slices"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 )
 
 type relEnv struct {
-	*env
+	*apptest.AppEnv
 	personID string
 	orgID    string
 }
 
 func setupRelationships(t *testing.T) *relEnv {
 	t.Helper()
-	e := setup(t)
-	e.slug = "rel-e2e"
-	bootstrapWorkspaceSession(t, e, "Rel E2E", "rel@fable.test", "Admin")
+	e := apptest.SetupApp(t)
+	e.Slug = "rel-e2e"
+	apptest.BootstrapWorkspaceSession(t, e, "Rel E2E", "rel@fable.test", "Admin")
 	var person, org struct {
 		ID string `json:"id"`
 	}
-	if status := e.call(t, "POST", "/v1/people", anyMap{"full_name": "Edge Person"}, nil, &person); status != http.StatusCreated {
+	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{"full_name": "Edge Person"}, nil, &person); status != http.StatusCreated {
 		t.Fatalf("create person → %d", status)
 	}
-	if status := e.call(t, "POST", "/v1/organizations", anyMap{"display_name": "Edge Org"}, nil, &org); status != http.StatusCreated {
+	if status := e.Call(t, "POST", "/v1/organizations", apptest.AnyMap{"display_name": "Edge Org"}, nil, &org); status != http.StatusCreated {
 		t.Fatalf("create org → %d", status)
 	}
-	return &relEnv{env: e, personID: person.ID, orgID: org.ID}
+	return &relEnv{AppEnv: e, personID: person.ID, orgID: org.ID}
 }
 
 func TestRelationshipLifecycle(t *testing.T) {
@@ -46,7 +48,7 @@ func TestRelationshipLifecycle(t *testing.T) {
 		ID      string `json:"id"`
 		Version int64  `json:"version"`
 	}
-	if status := e.call(t, "POST", "/v1/relationships", anyMap{
+	if status := e.Call(t, "POST", "/v1/relationships", apptest.AnyMap{
 		"kind": "employment", "person_id": e.personID, "organization_id": e.orgID,
 		"role": "cto", "is_current_primary": true, "source": "ui",
 	}, nil, &first); status != http.StatusCreated {
@@ -57,10 +59,10 @@ func TestRelationshipLifecycle(t *testing.T) {
 	var org2 struct {
 		ID string `json:"id"`
 	}
-	if status := e.call(t, "POST", "/v1/organizations", anyMap{"display_name": "Second Org"}, nil, &org2); status != http.StatusCreated {
+	if status := e.Call(t, "POST", "/v1/organizations", apptest.AnyMap{"display_name": "Second Org"}, nil, &org2); status != http.StatusCreated {
 		t.Fatalf("create org2 → %d", status)
 	}
-	if status := e.call(t, "POST", "/v1/relationships", anyMap{
+	if status := e.Call(t, "POST", "/v1/relationships", apptest.AnyMap{
 		"kind": "employment", "person_id": e.personID, "organization_id": org2.ID,
 		"is_current_primary": true, "source": "ui",
 	}, nil, nil); status != http.StatusCreated {
@@ -72,7 +74,7 @@ func TestRelationshipLifecycle(t *testing.T) {
 			IsCurrentPrimary bool   `json:"is_current_primary"`
 		} `json:"data"`
 	}
-	if status := e.call(t, "GET", "/v1/relationships?person_id="+e.personID+"&kind=employment", nil, nil, &listed); status != http.StatusOK || len(listed.Data) != 2 {
+	if status := e.Call(t, "GET", "/v1/relationships?person_id="+e.personID+"&kind=employment", nil, nil, &listed); status != http.StatusOK || len(listed.Data) != 2 {
 		t.Fatalf("list → %d %+v", status, listed)
 	}
 	primaries := 0
@@ -89,27 +91,27 @@ func TestRelationshipLifecycle(t *testing.T) {
 	var problem struct {
 		Code string `json:"code"`
 	}
-	status := e.call(t, "PATCH", "/v1/relationships/"+first.ID, anyMap{"role": "ceo"},
+	status := e.Call(t, "PATCH", "/v1/relationships/"+first.ID, apptest.AnyMap{"role": "ceo"},
 		map[string]string{"If-Match": "999"}, &problem)
 	if status != http.StatusConflict || problem.Code != "version_skew" {
 		t.Fatalf("stale If-Match → %d %q, want 409 version_skew", status, problem.Code)
 	}
-	if status := e.call(t, "PATCH", "/v1/relationships/"+first.ID, anyMap{"role": "ceo"}, nil, nil); status != http.StatusOK {
+	if status := e.Call(t, "PATCH", "/v1/relationships/"+first.ID, apptest.AnyMap{"role": "ceo"}, nil, nil); status != http.StatusOK {
 		t.Fatalf("update → %d", status)
 	}
 
-	if status := e.call(t, "DELETE", "/v1/relationships/"+first.ID, nil, nil, nil); status != http.StatusOK {
+	if status := e.Call(t, "DELETE", "/v1/relationships/"+first.ID, nil, nil, nil); status != http.StatusOK {
 		t.Fatalf("archive → %d", status)
 	}
 
 	// A malformed endpoint shape is a 422, not a DB error.
-	if status := e.call(t, "POST", "/v1/relationships", anyMap{
+	if status := e.Call(t, "POST", "/v1/relationships", apptest.AnyMap{
 		"kind": "employment", "person_id": e.personID, "source": "ui",
 	}, nil, nil); status != 422 {
 		t.Fatalf("shape-violating edge → %d, want 422", status)
 	}
 	// An invisible endpoint reads as absent (H1).
-	if status := e.call(t, "POST", "/v1/relationships", anyMap{
+	if status := e.Call(t, "POST", "/v1/relationships", apptest.AnyMap{
 		"kind": "employment", "person_id": "00000000-0000-7000-8000-00000000dead",
 		"organization_id": e.orgID, "source": "ui",
 	}, nil, nil); status != http.StatusNotFound {
@@ -142,7 +144,7 @@ func TestArchivingAnEdgeStagesForAnAgentAndPinsItsVersion(t *testing.T) {
 		ID      string `json:"id"`
 		Version int64  `json:"version"`
 	}
-	if status := e.call(t, "POST", "/v1/relationships", anyMap{
+	if status := e.Call(t, "POST", "/v1/relationships", apptest.AnyMap{
 		"kind": "employment", "person_id": e.personID, "organization_id": e.orgID,
 		"role": "cto", "source": "ui",
 	}, nil, &edge); status != http.StatusCreated {
@@ -152,7 +154,7 @@ func TestArchivingAnEdgeStagesForAnAgentAndPinsItsVersion(t *testing.T) {
 	var minted struct {
 		Token string `json:"token"`
 	}
-	if status := e.call(t, "POST", "/v1/passports", anyMap{
+	if status := e.Call(t, "POST", "/v1/passports", apptest.AnyMap{
 		"label": "edge agent", "scopes": []string{"read", "write"},
 	}, nil, &minted); status != http.StatusCreated {
 		t.Fatalf("issue passport → %d", status)
@@ -163,7 +165,7 @@ func TestArchivingAnEdgeStagesForAnAgentAndPinsItsVersion(t *testing.T) {
 		Code   string `json:"code"`
 		Detail string `json:"detail"`
 	}
-	status := e.call(t, "DELETE", "/v1/relationships/"+edge.ID, nil, bearer, &problem)
+	status := e.Call(t, "DELETE", "/v1/relationships/"+edge.ID, nil, bearer, &problem)
 	if status != http.StatusForbidden || problem.Code != "approval_required" {
 		t.Fatalf("agent archive → %d %q, want 403 approval_required", status, problem.Code)
 	}
@@ -173,7 +175,7 @@ func TestArchivingAnEdgeStagesForAnAgentAndPinsItsVersion(t *testing.T) {
 	// the archive against whatever the edge had drifted to inside the TTL — and a
 	// nil pin is exactly what a target type the seam cannot read produces.
 	var pin *int64
-	if err := e.owner.QueryRow(t.Context(),
+	if err := e.Owner.QueryRow(t.Context(),
 		`SELECT target_version FROM approval WHERE id = $1`, approvalID).Scan(&pin); err != nil {
 		t.Fatal(err)
 	}
@@ -185,7 +187,7 @@ func TestArchivingAnEdgeStagesForAnAgentAndPinsItsVersion(t *testing.T) {
 		t.Errorf("target_version = %d, want the edge's own %d", *pin, edge.Version)
 	}
 
-	assertDecidableInTheInbox(t, e.env, approvalID, "relationship")
+	assertDecidableInTheInbox(t, e.AppEnv, approvalID, "relationship")
 
 	// The edge is untouched while the approval is pending.
 	var parked struct {
@@ -194,7 +196,7 @@ func TestArchivingAnEdgeStagesForAnAgentAndPinsItsVersion(t *testing.T) {
 			ArchivedAt *string `json:"archived_at"`
 		} `json:"data"`
 	}
-	if got := e.call(t, "GET", "/v1/relationships?person_id="+e.personID+"&kind=employment", nil, nil, &parked); got != http.StatusOK {
+	if got := e.Call(t, "GET", "/v1/relationships?person_id="+e.personID+"&kind=employment", nil, nil, &parked); got != http.StatusOK {
 		t.Fatalf("list while parked → %d", got)
 	}
 	for _, rel := range parked.Data {
@@ -205,7 +207,7 @@ func TestArchivingAnEdgeStagesForAnAgentAndPinsItsVersion(t *testing.T) {
 
 	// And it can be REJECTED, which is the half a caller cannot fake: a decision
 	// runs the same visibility predicate as the list.
-	if got := e.call(t, "POST", "/v1/approvals/"+approvalID+"/reject", anyMap{
+	if got := e.Call(t, "POST", "/v1/approvals/"+approvalID+"/reject", apptest.AnyMap{
 		"reason": "probe",
 	}, nil, nil); got != http.StatusOK {
 		t.Fatalf("deciding the staged archive → %d, want 200 — a row the inbox lists and cannot decide is "+
@@ -216,15 +218,15 @@ func TestArchivingAnEdgeStagesForAnAgentAndPinsItsVersion(t *testing.T) {
 func TestPartnerPromotionLifecycle(t *testing.T) {
 	e := setupRelationships(t)
 
-	if status := e.call(t, "GET", "/v1/organizations/"+e.orgID+"/partner", nil, nil, nil); status != http.StatusNotFound {
+	if status := e.Call(t, "GET", "/v1/organizations/"+e.orgID+"/partner", nil, nil, nil); status != http.StatusNotFound {
 		t.Fatalf("non-partner org → %d, want 404", status)
 	}
 	var partner struct {
 		CertStatus string `json:"cert_status"`
 	}
-	if status := e.call(t, "PUT", "/v1/organizations/"+e.orgID+"/partner", anyMap{
+	if status := e.Call(t, "PUT", "/v1/organizations/"+e.orgID+"/partner", apptest.AnyMap{
 		"partner_role": "consulting", "cert_status": "certified",
-		"gate_metrics": anyMap{"certified_staff": 3, "retention_rate": 90},
+		"gate_metrics": apptest.AnyMap{"certified_staff": 3, "retention_rate": 90},
 	}, nil, &partner); status != http.StatusOK || partner.CertStatus != "certified" {
 		t.Fatalf("upsert partner → %d %+v", status, partner)
 	}
@@ -233,7 +235,7 @@ func TestPartnerPromotionLifecycle(t *testing.T) {
 	var org struct {
 		RelationshipTypes []string `json:"relationship_types"`
 	}
-	if status := e.call(t, "GET", "/v1/organizations/"+e.orgID, nil, nil, &org); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/organizations/"+e.orgID, nil, nil, &org); status != http.StatusOK {
 		t.Fatalf("org after promotion → %d", status)
 	}
 	if !slices.Contains(org.RelationshipTypes, "partner") {
@@ -244,10 +246,10 @@ func TestPartnerPromotionLifecycle(t *testing.T) {
 			OrganizationID string `json:"organization_id"`
 		} `json:"data"`
 	}
-	if status := e.call(t, "GET", "/v1/partners?cert_status=certified", nil, nil, &partners); status != http.StatusOK || len(partners.Data) != 1 {
+	if status := e.Call(t, "GET", "/v1/partners?cert_status=certified", nil, nil, &partners); status != http.StatusOK || len(partners.Data) != 1 {
 		t.Fatalf("list partners → %d %+v", status, partners)
 	}
-	if status := e.call(t, "GET", "/v1/partners?cert_status=suspended", nil, nil, &partners); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/partners?cert_status=suspended", nil, nil, &partners); status != http.StatusOK {
 		t.Fatalf("filtered list → %d", status)
 	}
 }
@@ -257,7 +259,7 @@ func TestPartnerPromotionLifecycle(t *testing.T) {
 // or reject, and `decidable` backs the list, the single read and the decision
 // alike — so an approval whose target type the inbox has no visibility rule for
 // is a zombie, and the fan-out that would have told anyone is dropped too.
-func assertDecidableInTheInbox(t *testing.T, e *env, approvalID, wantTargetType string) {
+func assertDecidableInTheInbox(t *testing.T, e *apptest.AppEnv, approvalID, wantTargetType string) {
 	t.Helper()
 	var inbox struct {
 		Data []struct {
@@ -265,7 +267,7 @@ func assertDecidableInTheInbox(t *testing.T, e *env, approvalID, wantTargetType 
 			TargetType string `json:"target_entity_type"`
 		} `json:"data"`
 	}
-	if got := e.call(t, "GET", "/v1/approvals?status=pending", nil, nil, &inbox); got != http.StatusOK {
+	if got := e.Call(t, "GET", "/v1/approvals?status=pending", nil, nil, &inbox); got != http.StatusOK {
 		t.Fatalf("list approvals → %d", got)
 	}
 	for _, a := range inbox.Data {
@@ -275,7 +277,7 @@ func assertDecidableInTheInbox(t *testing.T, e *env, approvalID, wantTargetType 
 		if a.TargetType != wantTargetType {
 			t.Errorf("the staged row's target_entity_type is %q, want %q", a.TargetType, wantTargetType)
 		}
-		if got := e.call(t, "GET", "/v1/approvals/"+approvalID, nil, nil, nil); got != http.StatusOK {
+		if got := e.Call(t, "GET", "/v1/approvals/"+approvalID, nil, nil, nil); got != http.StatusOK {
 			t.Fatalf("GET the staged approval → %d, want 200", got)
 		}
 		return
@@ -298,7 +300,7 @@ func TestAnApprovalStaysDecidableAfterItsEdgeIsArchived(t *testing.T) {
 	var edge struct {
 		ID string `json:"id"`
 	}
-	if status := e.call(t, "POST", "/v1/relationships", anyMap{
+	if status := e.Call(t, "POST", "/v1/relationships", apptest.AnyMap{
 		"kind": "employment", "person_id": e.personID, "organization_id": e.orgID,
 		"role": "cfo", "source": "ui",
 	}, nil, &edge); status != http.StatusCreated {
@@ -308,7 +310,7 @@ func TestAnApprovalStaysDecidableAfterItsEdgeIsArchived(t *testing.T) {
 	var minted struct {
 		Token string `json:"token"`
 	}
-	if status := e.call(t, "POST", "/v1/passports", anyMap{
+	if status := e.Call(t, "POST", "/v1/passports", apptest.AnyMap{
 		"label": "archived edge agent", "scopes": []string{"read", "write"},
 	}, nil, &minted); status != http.StatusCreated {
 		t.Fatalf("issue passport → %d", status)
@@ -317,7 +319,7 @@ func TestAnApprovalStaysDecidableAfterItsEdgeIsArchived(t *testing.T) {
 	var problem struct {
 		Detail string `json:"detail"`
 	}
-	if status := e.call(t, "DELETE", "/v1/relationships/"+edge.ID, nil,
+	if status := e.Call(t, "DELETE", "/v1/relationships/"+edge.ID, nil,
 		map[string]string{"Authorization": "Bearer " + minted.Token}, &problem); status != http.StatusForbidden {
 		t.Fatalf("agent archive → %d, want 403 approval_required", status)
 	}
@@ -325,14 +327,14 @@ func TestAnApprovalStaysDecidableAfterItsEdgeIsArchived(t *testing.T) {
 
 	// The human archives the edge themselves, which is exactly the race the
 	// approval was staged into: the target is gone before anyone decided.
-	if status := e.call(t, "DELETE", "/v1/relationships/"+edge.ID, nil, nil, nil); status != http.StatusOK {
+	if status := e.Call(t, "DELETE", "/v1/relationships/"+edge.ID, nil, nil, nil); status != http.StatusOK {
 		t.Fatalf("human archive → %d", status)
 	}
 
 	// The staged row must STILL be visible and rejectable. If it were not, the
 	// approval would sit pending until its TTL with no way to clear it.
-	assertDecidableInTheInbox(t, e.env, approvalID, "relationship")
-	if got := e.call(t, "POST", "/v1/approvals/"+approvalID+"/reject", anyMap{
+	assertDecidableInTheInbox(t, e.AppEnv, approvalID, "relationship")
+	if got := e.Call(t, "POST", "/v1/approvals/"+approvalID+"/reject", apptest.AnyMap{
 		"reason": "already archived",
 	}, nil, nil); got != http.StatusOK {
 		t.Errorf("rejecting an approval whose edge was archived → %d, want 200 — a human must be able to "+

--- a/backend/internal/compose/integration/report_graph_integration_test.go
+++ b/backend/internal/compose/integration/report_graph_integration_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	"github.com/gradionhq/margince/backend/internal/modules/ai"
 	"github.com/gradionhq/margince/backend/internal/modules/search"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -104,14 +105,14 @@ func TestSchemaIntrospectionServesDescriptors(t *testing.T) {
 }
 
 func TestPrebuiltReportOverHTTPAndVocabulary(t *testing.T) {
-	e := setup(t)
-	e.slug = "reports-e2e"
-	bootstrapWorkspaceSession(t, e, "Reports E2E", "rep@fable.test", "Admin")
+	e := apptest.SetupApp(t)
+	e.Slug = "reports-e2e"
+	apptest.BootstrapWorkspaceSession(t, e, "Reports E2E", "rep@fable.test", "Admin")
 
 	var org struct {
 		ID string `json:"id"`
 	}
-	if status := e.call(t, "POST", "/v1/organizations", anyMap{"display_name": "Acme"}, nil, &org); status != http.StatusCreated {
+	if status := e.Call(t, "POST", "/v1/organizations", apptest.AnyMap{"display_name": "Acme"}, nil, &org); status != http.StatusCreated {
 		t.Fatalf("create org → %d", status)
 	}
 	var pipelines struct {
@@ -123,7 +124,7 @@ func TestPrebuiltReportOverHTTPAndVocabulary(t *testing.T) {
 			} `json:"stages"`
 		} `json:"data"`
 	}
-	if status := e.call(t, "GET", "/v1/pipelines", nil, nil, &pipelines); status != http.StatusOK || len(pipelines.Data) == 0 {
+	if status := e.Call(t, "GET", "/v1/pipelines", nil, nil, &pipelines); status != http.StatusOK || len(pipelines.Data) == 0 {
 		t.Fatalf("list pipelines → %d %+v", status, pipelines)
 	}
 	stageID := ""
@@ -137,7 +138,7 @@ func TestPrebuiltReportOverHTTPAndVocabulary(t *testing.T) {
 		t.Fatalf("no open stage in the seeded pipeline: %+v", pipelines)
 	}
 	for i := 0; i < 2; i++ {
-		if status := e.call(t, "POST", "/v1/deals", anyMap{
+		if status := e.Call(t, "POST", "/v1/deals", apptest.AnyMap{
 			"name": fmt.Sprintf("Acme Deal %d", i), "pipeline_id": pipelines.Data[0].ID,
 			"stage_id": stageID, "organization_id": org.ID,
 		}, nil, nil); status != http.StatusCreated {
@@ -150,7 +151,7 @@ func TestPrebuiltReportOverHTTPAndVocabulary(t *testing.T) {
 		Columns []string         `json:"columns"`
 		Rows    []map[string]any `json:"rows"`
 	}
-	if status := e.call(t, "POST", "/v1/reports/open-deals-per-company", nil, nil, &result); status != http.StatusOK {
+	if status := e.Call(t, "POST", "/v1/reports/open-deals-per-company", nil, nil, &result); status != http.StatusOK {
 		t.Fatalf("runReport → %d", status)
 	}
 	if result.Report != "open-deals-per-company" || len(result.Rows) != 1 {
@@ -164,13 +165,13 @@ func TestPrebuiltReportOverHTTPAndVocabulary(t *testing.T) {
 	var problem struct {
 		Code string `json:"code"`
 	}
-	status := e.call(t, "POST", "/v1/reports/open-deals-per-company",
-		anyMap{"group_by": []string{"captured_by"}}, nil, &problem)
+	status := e.Call(t, "POST", "/v1/reports/open-deals-per-company",
+		apptest.AnyMap{"group_by": []string{"captured_by"}}, nil, &problem)
 	if status != 422 || problem.Code != "report_field_not_allowed" {
 		t.Fatalf("OOV field → %d %q, want 422 report_field_not_allowed", status, problem.Code)
 	}
 	// Unknown report keys are absent.
-	if status := e.call(t, "POST", "/v1/reports/definitely-not-a-report", nil, nil, nil); status != http.StatusNotFound {
+	if status := e.Call(t, "POST", "/v1/reports/definitely-not-a-report", nil, nil, nil); status != http.StatusNotFound {
 		t.Fatalf("unknown report → %d, want 404", status)
 	}
 }

--- a/backend/internal/compose/integration/requiredbodyids_http_integration_test.go
+++ b/backend/internal/compose/integration/requiredbodyids_http_integration_test.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -66,20 +67,20 @@ type requiredIDFixtures struct {
 	deal, subjectUser              string
 }
 
-func seedRequiredIDFixtures(t *testing.T, e *env) requiredIDFixtures {
+func seedRequiredIDFixtures(t *testing.T, e *apptest.AppEnv) requiredIDFixtures {
 	t.Helper()
 	var out requiredIDFixtures
-	out.person = createAndID(t, e, "/v1/people", anyMap{"full_name": "Merge Source"})
-	out.organization = createAndID(t, e, "/v1/organizations", anyMap{"display_name": "Merge Org"})
-	out.activity = createAndID(t, e, "/v1/activities", anyMap{
+	out.person = createAndID(t, e, "/v1/people", apptest.AnyMap{"full_name": "Merge Source"})
+	out.organization = createAndID(t, e, "/v1/organizations", apptest.AnyMap{"display_name": "Merge Org"})
+	out.activity = createAndID(t, e, "/v1/activities", apptest.AnyMap{
 		"kind": "note", "body": "relink probe",
-		"links": []anyMap{{"entity_type": "person", "entity_id": out.person}},
+		"links": []apptest.AnyMap{{"entity_type": "person", "entity_id": out.person}},
 	})
-	out.list = createAndID(t, e, "/v1/lists", anyMap{
+	out.list = createAndID(t, e, "/v1/lists", apptest.AnyMap{
 		"name": "Required IDs", "entity_type": "person", "list_type": "static",
 	})
-	out.tag = createAndID(t, e, "/v1/tags", anyMap{"name": "required-ids"})
-	out.project = createAndID(t, e, "/v1/projects", anyMap{
+	out.tag = createAndID(t, e, "/v1/tags", apptest.AnyMap{"name": "required-ids"})
+	out.project = createAndID(t, e, "/v1/projects", apptest.AnyMap{
 		"name": "Stakeholder probe", "organization_id": out.organization, "source": "manual",
 	})
 	out.deal = seedDealForRequiredIDs(t, e)
@@ -91,7 +92,7 @@ func seedRequiredIDFixtures(t *testing.T, e *env) requiredIDFixtures {
 			ID string `json:"id"`
 		} `json:"data"`
 	}
-	if status := e.call(t, "GET", "/v1/users", nil, nil, &users); status != http.StatusOK || len(users.Data) == 0 {
+	if status := e.Call(t, "GET", "/v1/users", nil, nil, &users); status != http.StatusOK || len(users.Data) == 0 {
 		t.Fatalf("list users → %d (%d users)", status, len(users.Data))
 	}
 	out.subjectUser = users.Data[0].ID
@@ -101,12 +102,12 @@ func seedRequiredIDFixtures(t *testing.T, e *env) requiredIDFixtures {
 // createAndID posts one fixture and returns its id, failing loudly if the create
 // itself was refused — a fixture that silently did not exist would turn every row
 // below into a 404 about the path.
-func createAndID(t *testing.T, e *env, path string, body anyMap) string {
+func createAndID(t *testing.T, e *apptest.AppEnv, path string, body apptest.AnyMap) string {
 	t.Helper()
 	var created struct {
 		ID string `json:"id"`
 	}
-	if status := e.call(t, "POST", path, body, nil, &created); status != http.StatusCreated {
+	if status := e.Call(t, "POST", path, body, nil, &created); status != http.StatusCreated {
 		t.Fatalf("POST %s → %d, want 201", path, status)
 	}
 	if created.ID == "" {
@@ -119,7 +120,7 @@ func createAndID(t *testing.T, e *env, path string, body anyMap) string {
 // the id under test, so the status difference cannot come from anything else.
 type requiredIDCase struct {
 	method, path      string
-	omitted, supplied anyMap
+	omitted, supplied apptest.AnyMap
 	field             string
 }
 
@@ -134,64 +135,64 @@ func requiredIDCases(f requiredIDFixtures, absent string) map[string]requiredIDC
 		// that has to keep up: one rule, one answer, whichever surface asks.
 		"AdvanceDealRequest.to_stage_id": {
 			method: "POST", path: "/v1/deals/" + f.deal + "/advance",
-			omitted: anyMap{}, supplied: anyMap{"to_stage_id": absent}, field: "to_stage_id",
+			omitted: apptest.AnyMap{}, supplied: apptest.AnyMap{"to_stage_id": absent}, field: "to_stage_id",
 		},
 		"CreateStageRequest.pipeline_id": {
 			method: "POST", path: "/v1/stages",
-			omitted:  anyMap{"name": "Orphan stage", "position": 9},
-			supplied: anyMap{"name": "Orphan stage", "position": 9, "pipeline_id": absent},
+			omitted:  apptest.AnyMap{"name": "Orphan stage", "position": 9},
+			supplied: apptest.AnyMap{"name": "Orphan stage", "position": 9, "pipeline_id": absent},
 			field:    "pipeline_id",
 		},
 		"MergePersonJSONBody.target_id": {
 			method: "POST", path: "/v1/people/" + f.person + "/merge",
-			omitted: anyMap{}, supplied: anyMap{"target_id": absent}, field: "target_id",
+			omitted: apptest.AnyMap{}, supplied: apptest.AnyMap{"target_id": absent}, field: "target_id",
 		},
 		"MergeOrganizationJSONBody.target_id": {
 			method: "POST", path: "/v1/organizations/" + f.organization + "/merge",
-			omitted: anyMap{}, supplied: anyMap{"target_id": absent}, field: "target_id",
+			omitted: apptest.AnyMap{}, supplied: apptest.AnyMap{"target_id": absent}, field: "target_id",
 		},
 		"RelinkActivityJSONBody.entity_id": {
 			method: "POST", path: "/v1/activities/" + f.activity + "/relink",
-			omitted:  anyMap{"entity_type": "person"},
-			supplied: anyMap{"entity_type": "person", "entity_id": absent},
+			omitted:  apptest.AnyMap{"entity_type": "person"},
+			supplied: apptest.AnyMap{"entity_type": "person", "entity_id": absent},
 			field:    "entity_id",
 		},
 		"RecordConsentRequest.purpose_id": {
 			method: "POST", path: "/v1/people/" + f.person + "/consent",
-			omitted:  anyMap{"new_state": "granted"},
-			supplied: anyMap{"new_state": "granted", "purpose_id": absent},
+			omitted:  apptest.AnyMap{"new_state": "granted"},
+			supplied: apptest.AnyMap{"new_state": "granted", "purpose_id": absent},
 			field:    "purpose_id",
 		},
 		"IssueDoubleOptInJSONBody.purpose_id": {
 			method: "POST", path: "/v1/people/" + f.person + "/consent/double-opt-in",
-			omitted: anyMap{}, supplied: anyMap{"purpose_id": absent}, field: "purpose_id",
+			omitted: apptest.AnyMap{}, supplied: apptest.AnyMap{"purpose_id": absent}, field: "purpose_id",
 		},
 		"AddListMemberRequest.entity_id": {
 			method: "POST", path: "/v1/lists/" + f.list + "/members",
-			omitted:  anyMap{"entity_type": "person"},
-			supplied: anyMap{"entity_type": "person", "entity_id": absent},
+			omitted:  apptest.AnyMap{"entity_type": "person"},
+			supplied: apptest.AnyMap{"entity_type": "person", "entity_id": absent},
 			field:    "entity_id",
 		},
 		"ApplyTagRequest.entity_id": {
 			method: "POST", path: "/v1/tags/" + f.tag + "/apply",
-			omitted:  anyMap{"entity_type": "person"},
-			supplied: anyMap{"entity_type": "person", "entity_id": absent},
+			omitted:  apptest.AnyMap{"entity_type": "person"},
+			supplied: apptest.AnyMap{"entity_type": "person", "entity_id": absent},
 			field:    "entity_id",
 		},
 		"SetProjectStakeholderRequest.person_id": {
 			method: "PUT", path: "/v1/projects/" + f.project + "/stakeholders",
-			omitted:  anyMap{"role": "sponsor"},
-			supplied: anyMap{"role": "sponsor", "person_id": absent},
+			omitted:  apptest.AnyMap{"role": "sponsor"},
+			supplied: apptest.AnyMap{"role": "sponsor", "person_id": absent},
 			field:    "person_id",
 		},
 		// Two required ids, so two rows: a guard that named only the first would
 		// leave the second answering not-found for a subject nobody sent.
 		"CreateRecordGrantRequest.record_id": {
 			method: "POST", path: "/v1/record-grants",
-			omitted: anyMap{
+			omitted: apptest.AnyMap{
 				"access": "read", "record_type": "person", "subject_type": "user", "subject_id": f.subjectUser,
 			},
-			supplied: anyMap{
+			supplied: apptest.AnyMap{
 				"access": "read", "record_type": "person", "subject_type": "user",
 				"subject_id": f.subjectUser, "record_id": absent,
 			},
@@ -199,10 +200,10 @@ func requiredIDCases(f requiredIDFixtures, absent string) map[string]requiredIDC
 		},
 		"CreateRecordGrantRequest.subject_id": {
 			method: "POST", path: "/v1/record-grants",
-			omitted: anyMap{
+			omitted: apptest.AnyMap{
 				"access": "read", "record_type": "person", "subject_type": "user", "record_id": f.person,
 			},
-			supplied: anyMap{
+			supplied: apptest.AnyMap{
 				"access": "read", "record_type": "person", "subject_type": "user",
 				"record_id": f.person, "subject_id": absent,
 			},
@@ -212,14 +213,14 @@ func requiredIDCases(f requiredIDFixtures, absent string) map[string]requiredIDC
 }
 
 func TestAnOmittedRequiredIDIsNamedAndASuppliedOneStaysHidden(t *testing.T) {
-	e := setup(t)
-	e.slug = "required-ids"
-	bootstrapWorkspaceSession(t, e, "Required IDs", "ids@fable.test", "Admin")
+	e := apptest.SetupApp(t)
+	e.Slug = "required-ids"
+	apptest.BootstrapWorkspaceSession(t, e, "Required IDs", "ids@fable.test", "Admin")
 
 	for name, tc := range requiredIDCases(seedRequiredIDFixtures(t, e), ids.NewV7().String()) {
 		t.Run(name+"/omitted names the field", func(t *testing.T) {
 			var problem problemBody
-			status := e.call(t, tc.method, tc.path, tc.omitted, nil, &problem)
+			status := e.Call(t, tc.method, tc.path, tc.omitted, nil, &problem)
 			if status != http.StatusUnprocessableEntity {
 				t.Fatalf("→ %d, want 422 (a bare 404 is the defect this closes): %+v", status, problem)
 			}
@@ -230,7 +231,7 @@ func TestAnOmittedRequiredIDIsNamedAndASuppliedOneStaysHidden(t *testing.T) {
 		})
 		t.Run(name+"/supplied but invisible stays a 404", func(t *testing.T) {
 			var problem problemBody
-			status := e.call(t, tc.method, tc.path, tc.supplied, nil, &problem)
+			status := e.Call(t, tc.method, tc.path, tc.supplied, nil, &problem)
 			if status != http.StatusNotFound {
 				t.Fatalf("→ %d, want 404: a well-formed id that names nothing must not be distinguishable "+
 					"from one the caller may not see, or the status code enumerates rows: %+v", status, problem)
@@ -249,7 +250,7 @@ func TestAnOmittedRequiredIDIsNamedAndASuppliedOneStaysHidden(t *testing.T) {
 // seedDealForRequiredIDs opens one deal in the workspace's seeded default
 // pipeline and returns its id — the advance route needs a real deal in the path,
 // or its 404 would be about the deal rather than about the stage.
-func seedDealForRequiredIDs(t *testing.T, e *env) string {
+func seedDealForRequiredIDs(t *testing.T, e *apptest.AppEnv) string {
 	t.Helper()
 	var pipelines struct {
 		Data []struct {
@@ -260,7 +261,7 @@ func seedDealForRequiredIDs(t *testing.T, e *env) string {
 			} `json:"stages"`
 		} `json:"data"`
 	}
-	if status := e.call(t, "GET", "/v1/pipelines", nil, nil, &pipelines); status != http.StatusOK || len(pipelines.Data) == 0 {
+	if status := e.Call(t, "GET", "/v1/pipelines", nil, nil, &pipelines); status != http.StatusOK || len(pipelines.Data) == 0 {
 		t.Fatalf("list pipelines → %d (%d pipelines)", status, len(pipelines.Data))
 	}
 	pipeline := pipelines.Data[0]
@@ -277,7 +278,7 @@ func seedDealForRequiredIDs(t *testing.T, e *env) string {
 	var deal struct {
 		ID string `json:"id"`
 	}
-	if status := e.call(t, "POST", "/v1/deals", anyMap{
+	if status := e.Call(t, "POST", "/v1/deals", apptest.AnyMap{
 		"name": "Advance probe", "pipeline_id": pipeline.ID, "stage_id": open,
 		"currency": "EUR", "amount_minor": 1000, "source": "ui",
 	}, nil, &deal); status != http.StatusCreated {
@@ -294,15 +295,15 @@ func seedDealForRequiredIDs(t *testing.T, e *env) string {
 // it. One rule must read the same on both, or the asymmetry has simply moved from
 // one transport to one credential type.
 func TestAPassportReadsTheSameRefusalAsASessionForAnOmittedStage(t *testing.T) {
-	e := setup(t)
-	e.slug = "required-ids-agent"
-	bootstrapWorkspaceSession(t, e, "Required IDs Agent", "agent-ids@fable.test", "Admin")
+	e := apptest.SetupApp(t)
+	e.Slug = "required-ids-agent"
+	apptest.BootstrapWorkspaceSession(t, e, "Required IDs Agent", "agent-ids@fable.test", "Admin")
 	deal := seedDealForRequiredIDs(t, e)
 
 	var minted struct {
 		Token string `json:"token"`
 	}
-	if status := e.call(t, "POST", "/v1/passports", anyMap{
+	if status := e.Call(t, "POST", "/v1/passports", apptest.AnyMap{
 		"label": "stage agent", "scopes": []string{"read", "write"},
 	}, nil, &minted); status != http.StatusCreated {
 		t.Fatalf("issue passport → %d", status)
@@ -310,8 +311,8 @@ func TestAPassportReadsTheSameRefusalAsASessionForAnOmittedStage(t *testing.T) {
 	bearer := map[string]string{"Authorization": "Bearer " + minted.Token}
 
 	var asSession, asPassport problemBody
-	sessionStatus := e.call(t, "POST", "/v1/deals/"+deal+"/advance", anyMap{}, nil, &asSession)
-	passportStatus := e.call(t, "POST", "/v1/deals/"+deal+"/advance", anyMap{}, bearer, &asPassport)
+	sessionStatus := e.Call(t, "POST", "/v1/deals/"+deal+"/advance", apptest.AnyMap{}, nil, &asSession)
+	passportStatus := e.Call(t, "POST", "/v1/deals/"+deal+"/advance", apptest.AnyMap{}, bearer, &asPassport)
 
 	if sessionStatus != http.StatusUnprocessableEntity || passportStatus != http.StatusUnprocessableEntity {
 		t.Fatalf("session → %d, passport → %d; want 422 from both", sessionStatus, passportStatus)
@@ -377,9 +378,9 @@ type rawAnswer struct {
 
 // postRawBody sends bytes verbatim. env.call marshals its body, so it can never
 // produce the malformed-JSON case the gate has to tell apart from an omitted key.
-func postRawBody(t *testing.T, e *env, path, body string, headers map[string]string) rawAnswer {
+func postRawBody(t *testing.T, e *apptest.AppEnv, path, body string, headers map[string]string) rawAnswer {
 	t.Helper()
-	req, err := http.NewRequest(http.MethodPost, e.ts.URL+path, strings.NewReader(body))
+	req, err := http.NewRequest(http.MethodPost, e.TS.URL+path, strings.NewReader(body))
 	if err != nil {
 		t.Fatalf("building request: %v", err)
 	}
@@ -387,11 +388,11 @@ func postRawBody(t *testing.T, e *env, path, body string, headers map[string]str
 	for k, v := range headers {
 		req.Header.Set(k, v)
 	}
-	resp, err := e.client.Do(req)
+	resp, err := e.Client.Do(req) //nolint:bodyclose // closed by the deferred apptest.CloseBody below; bodyclose only sees a Close in the same package, and the closer moved out with the fixture
 	if err != nil {
 		t.Fatalf("POST %s: %v", path, err)
 	}
-	defer closeBody(t, resp)
+	defer apptest.CloseBody(t, resp)
 	raw, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("reading response: %v", err)

--- a/backend/internal/compose/integration/roster_integration_test.go
+++ b/backend/internal/compose/integration/roster_integration_test.go
@@ -17,6 +17,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -41,10 +42,10 @@ type rosterTeam struct {
 
 // wsID resolves a workspace's id by slug through the owner connection
 // (workspace is the one non-tenant table, so no GUC is needed to read it).
-func wsID(t *testing.T, e *env, slug string) ids.UUID {
+func wsID(t *testing.T, e *apptest.AppEnv, slug string) ids.UUID {
 	t.Helper()
 	var id ids.UUID
-	if err := e.owner.QueryRow(context.Background(), `SELECT id FROM workspace WHERE slug = $1`, slug).Scan(&id); err != nil {
+	if err := e.Owner.QueryRow(context.Background(), `SELECT id FROM workspace WHERE slug = $1`, slug).Scan(&id); err != nil {
 		t.Fatalf("resolving workspace %q: %v", slug, err)
 	}
 	return id
@@ -61,10 +62,10 @@ func stmt(sql string, args ...any) seedStmt { return seedStmt{sql: sql, args: ar
 // seedInWorkspace runs setup statements inside a workspace-bound
 // transaction: app_user/team/team_membership are FORCE-RLS tables, so the
 // owner must set app.workspace_id even to insert. Mirrors setWorkspaceSeat.
-func seedInWorkspace(t *testing.T, e *env, ws ids.UUID, stmts ...seedStmt) {
+func seedInWorkspace(t *testing.T, e *apptest.AppEnv, ws ids.UUID, stmts ...seedStmt) {
 	t.Helper()
 	ctx := context.Background()
-	tx, err := e.owner.Begin(ctx)
+	tx, err := e.Owner.Begin(ctx)
 	if err != nil {
 		t.Fatalf("begin: %v", err)
 	}
@@ -84,10 +85,10 @@ func seedInWorkspace(t *testing.T, e *env, ws ids.UUID, stmts ...seedStmt) {
 }
 
 func TestRosterReadsUsersAndTeams(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t) // workspace "fable-e2e" + admin ada@example.com, session in the jar
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t) // workspace "fable-e2e" + admin ada@example.com, session in the jar
 
-	wsA := wsID(t, e, e.slug)
+	wsA := wsID(t, e, e.Slug)
 	rep, bob, deskTeam := ids.NewV7(), ids.NewV7(), ids.NewV7()
 	seedInWorkspace(
 		t, e, wsA,
@@ -101,7 +102,7 @@ func TestRosterReadsUsersAndTeams(t *testing.T) {
 	// A second tenant with its own member — its rows must never surface
 	// under workspace A's session (RLS row-scope). Seed workspace B (a
 	// non-tenant row) then its user inside B's GUC.
-	if _, err := e.owner.Exec(context.Background(),
+	if _, err := e.Owner.Exec(context.Background(),
 		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Other', 'fable-other', 'EUR')`,
 		ids.NewV7()); err != nil {
 		t.Fatalf("seeding workspace B: %v", err)
@@ -129,7 +130,7 @@ func TestRosterReadsUsersAndTeams(t *testing.T) {
 	var users struct {
 		Data []rosterUser `json:"data"`
 	}
-	if status := e.call(t, "GET", "/v1/users", nil, nil, &users); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/users", nil, nil, &users); status != http.StatusOK {
 		t.Fatalf("list users → %d, want 200", status)
 	}
 	got := map[string]rosterUser{}
@@ -178,7 +179,7 @@ func TestRosterReadsUsersAndTeams(t *testing.T) {
 	var filtered struct {
 		Data []rosterUser `json:"data"`
 	}
-	if status := e.call(t, "GET", "/v1/users?q=REP", nil, nil, &filtered); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/users?q=REP", nil, nil, &filtered); status != http.StatusOK {
 		t.Fatalf("list users?q=REP → %d, want 200", status)
 	}
 	if len(filtered.Data) != 1 || filtered.Data[0].Email != "rep@example.com" {
@@ -189,7 +190,7 @@ func TestRosterReadsUsersAndTeams(t *testing.T) {
 	var teams struct {
 		Data []rosterTeam `json:"data"`
 	}
-	if status := e.call(t, "GET", "/v1/teams", nil, nil, &teams); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/teams", nil, nil, &teams); status != http.StatusOK {
 		t.Fatalf("list teams → %d, want 200", status)
 	}
 	var desk *rosterTeam
@@ -215,10 +216,10 @@ func TestRosterReadsUsersAndTeams(t *testing.T) {
 // the two mappings differ; a regression that inlined the admin mapping into the
 // response loop would pass it and leak here.
 func TestRosterWithholdsRoleKeysFromANonAdmin(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t) // admin ada@example.com, session in the jar
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t) // admin ada@example.com, session in the jar
 
-	wsA := wsID(t, e, e.slug)
+	wsA := wsID(t, e, e.Slug)
 	rep := ids.NewV7()
 	seedInWorkspace(
 		t, e, wsA,
@@ -236,7 +237,7 @@ func TestRosterWithholdsRoleKeysFromANonAdmin(t *testing.T) {
 	var asAdmin struct {
 		Data []rosterUser `json:"data"`
 	}
-	if status := e.call(t, "GET", "/v1/users", nil, nil, &asAdmin); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/users", nil, nil, &asAdmin); status != http.StatusOK {
 		t.Fatalf("admin list users → %d, want 200", status)
 	}
 	for _, u := range asAdmin.Data {
@@ -249,7 +250,7 @@ func TestRosterWithholdsRoleKeysFromANonAdmin(t *testing.T) {
 	}
 
 	// Now the deny arm, from the rep's own session.
-	if status := e.call(t, "POST", "/v1/auth/login", anyMap{
+	if status := e.Call(t, "POST", "/v1/auth/login", apptest.AnyMap{
 		"email": "rep@example.com", "password": "correct-horse-battery",
 	}, nil, nil); status != http.StatusOK {
 		t.Fatalf("rep login → %d, want 200", status)
@@ -257,7 +258,7 @@ func TestRosterWithholdsRoleKeysFromANonAdmin(t *testing.T) {
 	var asRep struct {
 		Data []rosterUser `json:"data"`
 	}
-	if status := e.call(t, "GET", "/v1/users", nil, nil, &asRep); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/users", nil, nil, &asRep); status != http.StatusOK {
 		t.Fatalf("rep list users → %d, want 200", status)
 	}
 	if len(asRep.Data) == 0 {
@@ -275,7 +276,7 @@ func TestRosterWithholdsRoleKeysFromANonAdmin(t *testing.T) {
 	var repWidened struct {
 		Data []rosterUser `json:"data"`
 	}
-	if status := e.call(t, "GET", "/v1/users?include_inactive=true", nil, nil, &repWidened); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/users?include_inactive=true", nil, nil, &repWidened); status != http.StatusOK {
 		t.Fatalf("rep list users (include_inactive) → %d, want 200", status)
 	}
 	for _, u := range repWidened.Data {
@@ -289,15 +290,15 @@ func TestRosterWithholdsRoleKeysFromANonAdmin(t *testing.T) {
 // transport, but no cookie jar) against each roster endpoint and expects a
 // 401 — both /v1/users and /v1/teams are authenticated-only, and either
 // could lose that gate independently, so both are exercised.
-func assertRosterUnauthorized(t *testing.T, e *env) {
+func assertRosterUnauthorized(t *testing.T, e *apptest.AppEnv) {
 	t.Helper()
-	noSession := &http.Client{Transport: e.client.Transport}
+	noSession := &http.Client{Transport: e.Client.Transport}
 	for _, path := range []string{"/v1/users", "/v1/teams"} {
-		req, err := http.NewRequest(http.MethodGet, e.ts.URL+path, nil)
+		req, err := http.NewRequest(http.MethodGet, e.TS.URL+path, nil)
 		if err != nil {
 			t.Fatalf("building request for %s: %v", path, err)
 		}
-		req.Header.Set("X-Workspace-Slug", e.slug)
+		req.Header.Set("X-Workspace-Slug", e.Slug)
 		resp, err := noSession.Do(req)
 		if err != nil {
 			t.Fatalf("GET %s (no session): %v", path, err)

--- a/backend/internal/compose/integration/roster_integration_test.go
+++ b/backend/internal/compose/integration/roster_integration_test.go
@@ -61,7 +61,7 @@ func stmt(sql string, args ...any) seedStmt { return seedStmt{sql: sql, args: ar
 
 // seedInWorkspace runs setup statements inside a workspace-bound
 // transaction: app_user/team/team_membership are FORCE-RLS tables, so the
-// owner must set app.workspace_id even to insert. Mirrors setWorkspaceSeat.
+// owner must set app.workspace_id even to insert. Mirrors SetWorkspaceSeat.
 func seedInWorkspace(t *testing.T, e *apptest.AppEnv, ws ids.UUID, stmts ...seedStmt) {
 	t.Helper()
 	ctx := context.Background()

--- a/backend/internal/compose/integration/runner_integration_test.go
+++ b/backend/internal/compose/integration/runner_integration_test.go
@@ -28,9 +28,9 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	"github.com/gradionhq/margince/backend/internal/modules/agents/runner"
 	"github.com/gradionhq/margince/backend/internal/modules/ai"
-
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	kevents "github.com/gradionhq/margince/backend/internal/shared/kernel/events"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -38,7 +38,7 @@ import (
 )
 
 type runnerEnv struct {
-	*env
+	*apptest.AppEnv
 	pool  *pgxpool.Pool
 	svc   *compose.RunnerService
 	store *runner.Store
@@ -51,15 +51,15 @@ type runnerEnv struct {
 
 func setupRunner(t *testing.T) *runnerEnv {
 	t.Helper()
-	e := setup(t)
-	e.slug = "runner-e2e"
+	e := apptest.SetupApp(t)
+	e.Slug = "runner-e2e"
 
-	bootstrapWorkspaceSession(t, e, "Runner E2E", "runner@fable.test", "Admin")
+	apptest.BootstrapWorkspaceSession(t, e, "Runner E2E", "runner@fable.test", "Admin")
 
 	var minted struct {
 		PassportID string `json:"passport_id"`
 	}
-	if status := e.call(t, "POST", "/v1/passports", anyMap{
+	if status := e.Call(t, "POST", "/v1/passports", apptest.AnyMap{
 		"label": "overnight runner", "scopes": []string{"read", "write"},
 	}, nil, &minted); status != http.StatusCreated {
 		t.Fatalf("issue passport → %d", status)
@@ -76,7 +76,7 @@ func setupRunner(t *testing.T) *runnerEnv {
 	t.Cleanup(pool.Close)
 
 	var wsRaw string
-	if err := e.owner.QueryRow(context.Background(), `SELECT id FROM workspace WHERE slug = 'runner-e2e'`).Scan(&wsRaw); err != nil {
+	if err := e.Owner.QueryRow(context.Background(), `SELECT id FROM workspace WHERE slug = 'runner-e2e'`).Scan(&wsRaw); err != nil {
 		t.Fatalf("workspace lookup: %v", err)
 	}
 	wsID, err := ids.Parse(wsRaw)
@@ -97,7 +97,7 @@ func setupRunner(t *testing.T) *runnerEnv {
 	}
 	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
 	return &runnerEnv{
-		env:        e,
+		AppEnv:     e,
 		pool:       pool,
 		svc:        compose.NewRunnerService(pool, modelPath.AgentLoop, modelPath.DraftReply, nil, logger, nil, compose.SendPath{}),
 		store:      runner.NewStore(pool),
@@ -209,7 +209,7 @@ func TestRunnerConfirmationRequiredSuspendApproveResume(t *testing.T) {
 	var person struct {
 		ID string `json:"id"`
 	}
-	if status := re.call(t, "POST", "/v1/people", anyMap{"full_name": "Stale Duplicate"}, nil, &person); status != http.StatusCreated {
+	if status := re.Call(t, "POST", "/v1/people", apptest.AnyMap{"full_name": "Stale Duplicate"}, nil, &person); status != http.StatusCreated {
 		t.Fatalf("create person → %d", status)
 	}
 
@@ -229,12 +229,12 @@ func TestRunnerConfirmationRequiredSuspendApproveResume(t *testing.T) {
 	var parked struct {
 		ArchivedAt *string `json:"archived_at"`
 	}
-	if got := re.call(t, "GET", "/v1/people/"+person.ID, nil, nil, &parked); got != http.StatusOK || parked.ArchivedAt != nil {
+	if got := re.Call(t, "GET", "/v1/people/"+person.ID, nil, nil, &parked); got != http.StatusOK || parked.ArchivedAt != nil {
 		t.Fatalf("target mutated while approval pending: GET → %d archived_at=%v", got, parked.ArchivedAt)
 	}
 
 	// A human approves in the same inbox every surface stages into.
-	if got := re.call(t, "POST", "/v1/approvals/"+*approvalID+"/approve", anyMap{}, nil, nil); got != http.StatusOK {
+	if got := re.Call(t, "POST", "/v1/approvals/"+*approvalID+"/approve", apptest.AnyMap{}, nil, nil); got != http.StatusOK {
 		t.Fatalf("approve → %d", got)
 	}
 
@@ -251,7 +251,7 @@ func TestRunnerConfirmationRequiredSuspendApproveResume(t *testing.T) {
 	var after struct {
 		ArchivedAt *string `json:"archived_at"`
 	}
-	if got := re.call(t, "GET", "/v1/people/"+person.ID, nil, nil, &after); got != http.StatusOK || after.ArchivedAt == nil {
+	if got := re.Call(t, "GET", "/v1/people/"+person.ID, nil, nil, &after); got != http.StatusOK || after.ArchivedAt == nil {
 		t.Fatalf("approved archive did not land: GET → %d archived_at=%v; trace: %+v", got, after.ArchivedAt, trace)
 	}
 	// The trace is one continuous record across the approval gap.
@@ -266,7 +266,7 @@ func TestRunnerConfirmationRequiredRejectionReplansWithoutEffect(t *testing.T) {
 	var person struct {
 		ID string `json:"id"`
 	}
-	if status := re.call(t, "POST", "/v1/people", anyMap{"full_name": "Keep Me"}, nil, &person); status != http.StatusCreated {
+	if status := re.Call(t, "POST", "/v1/people", apptest.AnyMap{"full_name": "Keep Me"}, nil, &person); status != http.StatusCreated {
 		t.Fatalf("create person → %d", status)
 	}
 
@@ -281,7 +281,7 @@ func TestRunnerConfirmationRequiredRejectionReplansWithoutEffect(t *testing.T) {
 	if approvalID == nil {
 		t.Fatal("no staged approval")
 	}
-	if got := re.call(t, "POST", "/v1/approvals/"+*approvalID+"/reject", anyMap{"reason": "not a duplicate"}, nil, nil); got != http.StatusOK {
+	if got := re.Call(t, "POST", "/v1/approvals/"+*approvalID+"/reject", apptest.AnyMap{"reason": "not a duplicate"}, nil, nil); got != http.StatusOK {
 		t.Fatalf("reject → %d", got)
 	}
 	if err := re.svc.HandleEvent(context.Background(), decidedEnvelope(re.wsID, *approvalID, "rejected")); err != nil {
@@ -295,7 +295,7 @@ func TestRunnerConfirmationRequiredRejectionReplansWithoutEffect(t *testing.T) {
 	var after struct {
 		ArchivedAt *string `json:"archived_at"`
 	}
-	if got := re.call(t, "GET", "/v1/people/"+person.ID, nil, nil, &after); got != http.StatusOK || after.ArchivedAt != nil {
+	if got := re.Call(t, "GET", "/v1/people/"+person.ID, nil, nil, &after); got != http.StatusOK || after.ArchivedAt != nil {
 		t.Fatalf("rejected action executed anyway: GET → %d archived_at=%v", got, after.ArchivedAt)
 	}
 }
@@ -355,7 +355,7 @@ func TestRunnerResumeIsClaimedSoARedeliveryIsANoOp(t *testing.T) {
 	var person struct {
 		ID string `json:"id"`
 	}
-	if status := re.call(t, "POST", "/v1/people", anyMap{"full_name": "Resume Once"}, nil, &person); status != http.StatusCreated {
+	if status := re.Call(t, "POST", "/v1/people", apptest.AnyMap{"full_name": "Resume Once"}, nil, &person); status != http.StatusCreated {
 		t.Fatalf("create person → %d", status)
 	}
 
@@ -373,7 +373,7 @@ func TestRunnerResumeIsClaimedSoARedeliveryIsANoOp(t *testing.T) {
 	if approvalID == nil {
 		t.Fatal("no staged approval")
 	}
-	if got := re.call(t, "POST", "/v1/approvals/"+*approvalID+"/approve", anyMap{}, nil, nil); got != http.StatusOK {
+	if got := re.Call(t, "POST", "/v1/approvals/"+*approvalID+"/approve", apptest.AnyMap{}, nil, nil); got != http.StatusOK {
 		t.Fatalf("approve → %d", got)
 	}
 

--- a/backend/internal/compose/integration/runnerreap_integration_test.go
+++ b/backend/internal/compose/integration/runnerreap_integration_test.go
@@ -129,7 +129,7 @@ func TestTheSweepCannotReachAnotherTenantsRuns(t *testing.T) {
 func (re *runnerEnv) otherWorkspace(t *testing.T) ids.UUID {
 	t.Helper()
 	id := ids.NewV7()
-	if _, err := re.owner.Exec(context.Background(),
+	if _, err := re.Owner.Exec(context.Background(),
 		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Other Tenant', $2, 'EUR')`,
 		id, "reap-other-"+id.String()); err != nil {
 		t.Fatalf("seeding the second workspace: %v", err)
@@ -142,7 +142,7 @@ func (re *runnerEnv) otherWorkspace(t *testing.T) ids.UUID {
 func (re *runnerEnv) seedRunIn(t *testing.T, wsID ids.UUID, triggerRef string, staleFor time.Duration) ids.UUID {
 	t.Helper()
 	id := ids.NewV7()
-	if _, err := re.owner.Exec(context.Background(), `
+	if _, err := re.Owner.Exec(context.Background(), `
 		INSERT INTO agent_run (id, workspace_id, agent_spec, goal, trigger_ref, status, updated_at)
 		VALUES ($1, $2, 'morning_brief', 'another tenant''s run', $3, 'running',
 		        now() - ($4 * interval '1 microsecond'))`,
@@ -164,7 +164,7 @@ func (re *runnerEnv) seedRun(t *testing.T, triggerRef, status string, staleFor t
 		snapshot := `{"tool":"update_record","args":{}}`
 		pending = &snapshot
 	}
-	if _, err := re.owner.Exec(context.Background(), `
+	if _, err := re.Owner.Exec(context.Background(), `
 		INSERT INTO agent_run (id, workspace_id, agent_spec, goal, trigger_ref, status, updated_at,
 		                       approval_id, pending)
 		VALUES ($1, $2, 'morning_brief', 'seeded for the sweep', $3, $4,
@@ -179,7 +179,7 @@ func (re *runnerEnv) seedRun(t *testing.T, triggerRef, status string, staleFor t
 func (re *runnerEnv) seedApproval(t *testing.T) ids.UUID {
 	t.Helper()
 	id := ids.NewV7()
-	if _, err := re.owner.Exec(context.Background(), `
+	if _, err := re.Owner.Exec(context.Background(), `
 		INSERT INTO approval (id, workspace_id, kind, proposed_by, target_entity_type, target_entity_id,
 		                      summary, proposed_change, diff_hash, expires_at)
 		VALUES ($1, $2, 'advance_deal', 'agent:test', 'deal', $3,
@@ -227,7 +227,7 @@ func (re *runnerEnv) runState(t *testing.T, runID ids.UUID) sweptRun {
 func (re *runnerEnv) statusAsOwner(t *testing.T, runID ids.UUID) string {
 	t.Helper()
 	var status string
-	if err := re.owner.QueryRow(context.Background(),
+	if err := re.Owner.QueryRow(context.Background(),
 		`SELECT status FROM agent_run WHERE id = $1`, runID).Scan(&status); err != nil {
 		t.Fatalf("reading run %s as the owner: %v", runID, err)
 	}

--- a/backend/internal/compose/integration/scheduling_integration_test.go
+++ b/backend/internal/compose/integration/scheduling_integration_test.go
@@ -15,6 +15,8 @@ import (
 	"net/http"
 	"testing"
 	"time"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 )
 
 func TestAvailabilityAndBooking(t *testing.T) {
@@ -32,7 +34,7 @@ func TestAvailabilityAndBooking(t *testing.T) {
 			End   time.Time `json:"end"`
 		} `json:"slots"`
 	}
-	if status := e.call(t, "GET", "/v1/availability?"+window, nil, nil, &avail); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/availability?"+window, nil, nil, &avail); status != http.StatusOK {
 		t.Fatalf("availability → %d", status)
 	}
 	if len(avail.Slots) == 0 {
@@ -50,9 +52,9 @@ func TestAvailabilityAndBooking(t *testing.T) {
 		ID   string `json:"id"`
 		Kind string `json:"kind"`
 	}
-	if status := e.call(t, "POST", "/v1/bookings", anyMap{
+	if status := e.Call(t, "POST", "/v1/bookings", apptest.AnyMap{
 		"start": first.Start, "end": first.End, "subject": "Discovery call",
-		"links": []anyMap{{"entity_type": "person", "entity_id": e.personID}},
+		"links": []apptest.AnyMap{{"entity_type": "person", "entity_id": e.personID}},
 	}, nil, &booked); status != http.StatusCreated || booked.Kind != "meeting" {
 		t.Fatalf("book → %d %+v", status, booked)
 	}
@@ -61,14 +63,14 @@ func TestAvailabilityAndBooking(t *testing.T) {
 	var problem struct {
 		Code string `json:"code"`
 	}
-	if status := e.call(t, "POST", "/v1/bookings", anyMap{
+	if status := e.Call(t, "POST", "/v1/bookings", apptest.AnyMap{
 		"start": first.Start, "end": first.End,
-		"links": []anyMap{{"entity_type": "person", "entity_id": e.personID}},
+		"links": []apptest.AnyMap{{"entity_type": "person", "entity_id": e.personID}},
 	}, nil, &problem); status != http.StatusConflict || problem.Code != "slot_taken" {
 		t.Fatalf("double-book → %d %q, want 409 slot_taken", status, problem.Code)
 	}
 	// …and availability no longer proposes it.
-	if status := e.call(t, "GET", "/v1/availability?"+window, nil, nil, &avail); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/availability?"+window, nil, nil, &avail); status != http.StatusOK {
 		t.Fatalf("availability after booking → %d", status)
 	}
 	for _, s := range avail.Slots {
@@ -78,9 +80,9 @@ func TestAvailabilityAndBooking(t *testing.T) {
 	}
 
 	// A link target outside visibility refuses the booking (H1).
-	if status := e.call(t, "POST", "/v1/bookings", anyMap{
+	if status := e.Call(t, "POST", "/v1/bookings", apptest.AnyMap{
 		"start": first.Start.Add(3 * time.Hour), "end": first.End.Add(3 * time.Hour),
-		"links": []anyMap{{"entity_type": "person", "entity_id": "00000000-0000-7000-8000-00000000dead"}},
+		"links": []apptest.AnyMap{{"entity_type": "person", "entity_id": "00000000-0000-7000-8000-00000000dead"}},
 	}, nil, nil); status != http.StatusNotFound {
 		t.Fatalf("booking with invisible link → %d, want 404", status)
 	}

--- a/backend/internal/compose/integration/send_preflight_integration_test.go
+++ b/backend/internal/compose/integration/send_preflight_integration_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
 )
@@ -46,7 +47,7 @@ const (
 )
 
 type preflightEnv struct {
-	*env
+	*apptest.AppEnv
 	activityID string
 	personID   string
 	ws, user   string
@@ -55,10 +56,10 @@ type preflightEnv struct {
 // inWorkspace runs fn on the owner connection under the bootstrapped
 // workspace's GUC. FORCE RLS applies to the owner too, so a tenant table is
 // unreachable without it.
-func (e *env) inWorkspace(t *testing.T, slug string, fn func(pgx.Tx) error) error {
+func inWorkspace(e *apptest.AppEnv, t *testing.T, slug string, fn func(pgx.Tx) error) error {
 	t.Helper()
 	ctx := context.Background()
-	tx, err := e.owner.Begin(ctx)
+	tx, err := e.Owner.Begin(ctx)
 	if err != nil {
 		return err
 	}
@@ -137,25 +138,25 @@ func setupPreflightIn(t *testing.T, extra ...compose.Option) *preflightEnv {
 	// without a boot-configured base to build it from, so the fixture
 	// carries one — an install that can send at all has one.
 	opts = append(opts, compose.WithPublicBaseURL(preflightBaseURL))
-	e := setupWithOptions(t, opts...)
-	e.slug = "preflight-e2e"
-	bootstrapWorkspaceSession(t, e, "Preflight E2E", "sender@fable.test", "Admin")
+	e := apptest.SetupAppWithOptions(t, opts...)
+	e.Slug = "preflight-e2e"
+	apptest.BootstrapWorkspaceSession(t, e, "Preflight E2E", "sender@fable.test", "Admin")
 
 	var person struct {
 		ID string `json:"id"`
 	}
-	if status := e.call(t, "POST", "/v1/people", anyMap{
+	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{
 		"full_name": "Consented Buyer",
-		"emails":    []anyMap{{"email": "buyer@preflight.test"}},
+		"emails":    []apptest.AnyMap{{"email": "buyer@preflight.test"}},
 	}, nil, &person); status != http.StatusCreated {
 		t.Fatalf("create person → %d", status)
 	}
 	var activity struct {
 		ID string `json:"id"`
 	}
-	if status := e.call(t, "POST", "/v1/activities", anyMap{
+	if status := e.Call(t, "POST", "/v1/activities", apptest.AnyMap{
 		"kind": "email", "subject": "Inbound question", "direction": "inbound",
-		"links": []anyMap{{"entity_type": "person", "entity_id": person.ID}},
+		"links": []apptest.AnyMap{{"entity_type": "person", "entity_id": person.ID}},
 	}, nil, &activity); status != http.StatusCreated {
 		t.Fatalf("log anchor activity → %d", status)
 	}
@@ -168,7 +169,7 @@ func setupPreflightIn(t *testing.T, extra ...compose.Option) *preflightEnv {
 			Key string `json:"key"`
 		} `json:"data"`
 	}
-	if status := e.call(t, "GET", "/v1/consent-purposes", nil, nil, &purposes); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/consent-purposes", nil, nil, &purposes); status != http.StatusOK {
 		t.Fatalf("list purposes → %d", status)
 	}
 	var transactional string
@@ -180,20 +181,20 @@ func setupPreflightIn(t *testing.T, extra ...compose.Option) *preflightEnv {
 	if transactional == "" {
 		t.Fatalf("bootstrap seeded no transactional purpose: %+v", purposes.Data)
 	}
-	if status := e.call(t, "POST", "/v1/people/"+person.ID+"/consent", anyMap{
+	if status := e.Call(t, "POST", "/v1/people/"+person.ID+"/consent", apptest.AnyMap{
 		"purpose_id": transactional, "new_state": "granted", "lawful_basis": "consent",
 	}, nil, nil); status != http.StatusOK {
 		t.Fatalf("record consent → %d", status)
 	}
 
 	var ws, user string
-	if err := e.inWorkspace(t, e.slug, func(tx pgx.Tx) error {
+	if err := inWorkspace(e, t, e.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(),
 			`SELECT workspace_id, id FROM app_user WHERE email = $1`, "sender@fable.test").Scan(&ws, &user)
 	}); err != nil {
 		t.Fatalf("resolving the acting human: %v", err)
 	}
-	return &preflightEnv{env: e, activityID: activity.ID, personID: person.ID, ws: ws, user: user}
+	return &preflightEnv{AppEnv: e, activityID: activity.ID, personID: person.ID, ws: ws, user: user}
 }
 
 // send issues the authenticated send and returns the status plus the
@@ -217,7 +218,7 @@ func (p *preflightEnv) send(t *testing.T) (status int, code, message string) {
 			} `json:"errors"`
 		} `json:"details"`
 	}
-	status = p.call(t, "POST", "/v1/activities/"+p.activityID+"/send-email", anyMap{
+	status = p.Call(t, "POST", "/v1/activities/"+p.activityID+"/send-email", apptest.AnyMap{
 		"subject": "Re: Inbound question", "body": "answer",
 		"to": []string{"buyer@preflight.test"}, "consent_purpose": "transactional",
 	}, nil, &problem)
@@ -232,7 +233,7 @@ func (p *preflightEnv) send(t *testing.T) (status int, code, message string) {
 func (p *preflightEnv) stagedDeliveries(t *testing.T) int {
 	t.Helper()
 	var n int
-	if err := p.inWorkspace(t, p.slug, func(tx pgx.Tx) error {
+	if err := inWorkspace(p.AppEnv, t, p.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(), `SELECT count(*) FROM comms_outbound`).Scan(&n)
 	}); err != nil {
 		t.Fatalf("counting staged deliveries: %v", err)
@@ -245,7 +246,7 @@ func (p *preflightEnv) stagedDeliveries(t *testing.T) int {
 // reads out of the row, not how the OAuth callback puts it there.
 func (p *preflightEnv) connect(t *testing.T, providerScopes ...string) {
 	t.Helper()
-	if err := p.inWorkspace(t, p.slug, func(tx pgx.Tx) error {
+	if err := inWorkspace(p.AppEnv, t, p.Slug, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(), `
 			INSERT INTO capture_connection (workspace_id, provider, user_id, scopes, status, auth, provider_scopes)
 			VALUES ($1, 'gmail', $2, '{}', 'connected', $3, $4)

--- a/backend/internal/compose/integration/send_preflight_integration_test.go
+++ b/backend/internal/compose/integration/send_preflight_integration_test.go
@@ -79,7 +79,7 @@ func inWorkspace(e *apptest.AppEnv, t *testing.T, slug string, fn func(pgx.Tx) e
 }
 
 // preflightAppPool opens a second pool onto the same database, because the
-// vault WithGmailCapture needs must exist before setupWithOptions opens the
+// vault WithGmailCapture needs must exist before apptest.SetupAppWithOptions opens the
 // harness's own (the separate-connection precedent setupEmbedReindex uses).
 func preflightAppPool(t *testing.T) *pgxpool.Pool {
 	t.Helper()
@@ -98,7 +98,7 @@ func preflightAppPool(t *testing.T) *pgxpool.Pool {
 // setupPreflight boots the api composition WITH the Google app configured, so
 // the connect registry — and with it the pre-flight — is actually wired. The
 // keyvault rides a separate pool for the same database: WithGmailCapture needs
-// a vault before setupWithOptions has opened the harness's own.
+// a vault before apptest.SetupAppWithOptions has opened the harness's own.
 func setupPreflight(t *testing.T) *preflightEnv {
 	t.Helper()
 	gmailCfg := compose.GmailConfig{

--- a/backend/internal/compose/integration/strength_http_integration_test.go
+++ b/backend/internal/compose/integration/strength_http_integration_test.go
@@ -16,6 +16,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -35,12 +36,12 @@ type strengthWire struct {
 	ContributingActivityIds []string `json:"contributing_activity_ids"`
 }
 
-func seedStrengthPersonWithActivities(t *testing.T, e *env) string {
+func seedStrengthPersonWithActivities(t *testing.T, e *apptest.AppEnv) string {
 	t.Helper()
 	var person struct {
 		ID string `json:"id"`
 	}
-	if status := e.call(t, "POST", "/v1/people", anyMap{
+	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{
 		"full_name": "Strength Target", "source": "ui",
 	}, nil, &person); status != http.StatusCreated {
 		t.Fatalf("create person → %d", status)
@@ -51,9 +52,9 @@ func seedStrengthPersonWithActivities(t *testing.T, e *env) string {
 	// a live recency/frequency/reciprocity signal rather than a bare
 	// zero-interaction "none" bucket.
 	for _, direction := range []string{"inbound", "outbound"} {
-		if status := e.call(t, "POST", "/v1/activities", anyMap{
+		if status := e.Call(t, "POST", "/v1/activities", apptest.AnyMap{
 			"kind": "email", "subject": "Touch", "source": "ui", "direction": direction,
-			"links": []anyMap{{"entity_id": person.ID, "entity_type": "person"}},
+			"links": []apptest.AnyMap{{"entity_id": person.ID, "entity_type": "person"}},
 		}, nil, nil); status != http.StatusCreated {
 			t.Fatalf("log %s activity → %d", direction, status)
 		}
@@ -66,13 +67,13 @@ func seedStrengthPersonWithActivities(t *testing.T, e *env) string {
 // 0..100, and factors whose product (rounded) equals the score — the
 // same §4 formula the domain computes, just surfaced over the wire.
 func TestPersonStrengthHTTPReconciles(t *testing.T) {
-	e := setup(t)
-	e.slug = "strength-e2e"
-	bootstrapWorkspaceSession(t, e, "Strength E2E", "admin@strength.test", "Admin")
+	e := apptest.SetupApp(t)
+	e.Slug = "strength-e2e"
+	apptest.BootstrapWorkspaceSession(t, e, "Strength E2E", "admin@strength.test", "Admin")
 	personID := seedStrengthPersonWithActivities(t, e)
 
 	var wire strengthWire
-	if status := e.call(t, "GET", "/v1/people/"+personID+"/strength", nil, nil, &wire); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/people/"+personID+"/strength", nil, nil, &wire); status != http.StatusOK {
 		t.Fatalf("GET strength → %d", status)
 	}
 
@@ -106,11 +107,11 @@ func TestPersonStrengthHTTPReconciles(t *testing.T) {
 // rather than disclosing anything about it — existence-hiding, matching
 // every other row-scoped read.
 func TestPersonStrengthHTTPMissingIs404(t *testing.T) {
-	e := setup(t)
-	e.slug = "strength-404"
-	bootstrapWorkspaceSession(t, e, "Strength 404", "admin@strength404.test", "Admin")
+	e := apptest.SetupApp(t)
+	e.Slug = "strength-404"
+	apptest.BootstrapWorkspaceSession(t, e, "Strength 404", "admin@strength404.test", "Admin")
 
-	if status := e.call(t, "GET", "/v1/people/"+ids.NewV7().String()+"/strength", nil, nil, nil); status != http.StatusNotFound {
+	if status := e.Call(t, "GET", "/v1/people/"+ids.NewV7().String()+"/strength", nil, nil, nil); status != http.StatusNotFound {
 		t.Errorf("missing person strength = %d, want 404", status)
 	}
 }
@@ -119,27 +120,27 @@ func TestPersonStrengthHTTPMissingIs404(t *testing.T) {
 // current employees' strength) surfaces the same employee's score it
 // computed for the person-level endpoint above.
 func TestOrganizationStrengthHTTPReconciles(t *testing.T) {
-	e := setup(t)
-	e.slug = "org-strength-e2e"
-	bootstrapWorkspaceSession(t, e, "Org Strength E2E", "admin@orgstrength.test", "Admin")
+	e := apptest.SetupApp(t)
+	e.Slug = "org-strength-e2e"
+	apptest.BootstrapWorkspaceSession(t, e, "Org Strength E2E", "admin@orgstrength.test", "Admin")
 
 	var org struct {
 		ID string `json:"id"`
 	}
-	if status := e.call(t, "POST", "/v1/organizations", anyMap{
+	if status := e.Call(t, "POST", "/v1/organizations", apptest.AnyMap{
 		"display_name": "Strength Co", "source": "ui",
 	}, nil, &org); status != http.StatusCreated {
 		t.Fatalf("create organization → %d", status)
 	}
 	personID := seedStrengthPersonWithActivities(t, e)
-	if status := e.call(t, "POST", "/v1/relationships", anyMap{
+	if status := e.Call(t, "POST", "/v1/relationships", apptest.AnyMap{
 		"kind": "employment", "person_id": personID, "organization_id": org.ID,
 	}, nil, nil); status != http.StatusCreated {
 		t.Fatalf("create employment relationship → %d", status)
 	}
 
 	var wire strengthWire
-	if status := e.call(t, "GET", "/v1/organizations/"+org.ID+"/strength", nil, nil, &wire); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/organizations/"+org.ID+"/strength", nil, nil, &wire); status != http.StatusOK {
 		t.Fatalf("GET org strength → %d", status)
 	}
 	if wire.Score <= 0 {
@@ -150,11 +151,11 @@ func TestOrganizationStrengthHTTPReconciles(t *testing.T) {
 // TestOrganizationStrengthHTTPMissingIs404 mirrors the person-level 404:
 // a nonexistent organization id discloses nothing about it either.
 func TestOrganizationStrengthHTTPMissingIs404(t *testing.T) {
-	e := setup(t)
-	e.slug = "org-strength-404"
-	bootstrapWorkspaceSession(t, e, "Org Strength 404", "admin@orgstrength404.test", "Admin")
+	e := apptest.SetupApp(t)
+	e.Slug = "org-strength-404"
+	apptest.BootstrapWorkspaceSession(t, e, "Org Strength 404", "admin@orgstrength404.test", "Admin")
 
-	if status := e.call(t, "GET", "/v1/organizations/"+ids.NewV7().String()+"/strength", nil, nil, nil); status != http.StatusNotFound {
+	if status := e.Call(t, "GET", "/v1/organizations/"+ids.NewV7().String()+"/strength", nil, nil, nil); status != http.StatusNotFound {
 		t.Errorf("missing organization strength = %d, want 404", status)
 	}
 }

--- a/backend/internal/compose/integration/telegram_fixture_integration_test.go
+++ b/backend/internal/compose/integration/telegram_fixture_integration_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/riverqueue/river"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	"github.com/gradionhq/margince/backend/internal/modules/capture"
 	"github.com/gradionhq/margince/backend/internal/modules/capture/telegram"
 	"github.com/gradionhq/margince/backend/internal/platform/jobs"
@@ -177,7 +178,7 @@ func (f *fakeTelegramAPI) SendMessage(_ context.Context, _ string, m telegram.Ou
 // real router with the channel surfaces wired, plus the ids and credentials
 // every test needs to address it.
 type telegramEnv struct {
-	*env
+	*apptest.AppEnv
 	vault keyvault.Vault
 	api   *fakeTelegramAPI
 	// inserter is an insert-only River client, used to put one poll job on the
@@ -223,14 +224,14 @@ func setupTelegram(t *testing.T) *telegramEnv {
 
 	// Option ORDER is the contract WithChannelSurface states: the transport is
 	// composed first, and WithKeyvault is what hands it the vault it seals with.
-	e := setupWithOptions(t,
+	e := apptest.SetupAppWithOptions(t,
 		compose.WithChannelSurface(),
 		compose.WithKeyvault(vault),
 	)
-	bootstrapWorkspaceSession(t, e, telegramWorkspaceName, telegramAdminEmail, "Telegram Admin")
-	e.slug = telegramWorkspaceSlug
+	apptest.BootstrapWorkspaceSession(t, e, telegramWorkspaceName, telegramAdminEmail, "Telegram Admin")
+	e.Slug = telegramWorkspaceSlug
 
-	c := &telegramEnv{env: e, vault: vault, api: api, inserter: inserter, log: quiet}
+	c := &telegramEnv{AppEnv: e, vault: vault, api: api, inserter: inserter, log: quiet}
 	c.resolveActors(t)
 	return c
 }
@@ -241,7 +242,7 @@ func setupTelegram(t *testing.T) *telegramEnv {
 // carries a real composite foreign key.
 func (c *telegramEnv) resolveActors(t *testing.T) {
 	t.Helper()
-	if err := c.inWorkspace(t, c.slug, func(tx pgx.Tx) error {
+	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(),
 			`SELECT workspace_id, id FROM app_user WHERE email = $1`, telegramAdminEmail).Scan(&c.ws, &c.admin)
 	}); err != nil {
@@ -306,7 +307,7 @@ func (c *telegramEnv) strangerRepCtx(t *testing.T, objects map[string]principal.
 // to the same vault the server holds so a token sealed here is a token the
 // poller can unseal.
 func (c *telegramEnv) channelStore() *capture.ChannelStore {
-	return capture.NewChannelStore(c.pool, c.vault, c.api, c.log)
+	return capture.NewChannelStore(c.Pool, c.vault, c.api, c.log)
 }
 
 // connectBot binds the workspace's bot and records the live connection.
@@ -435,7 +436,7 @@ func (c *telegramEnv) pollNow(t *testing.T, sub <-chan *river.Event, wantOffset 
 func (c *telegramEnv) pollCursor(t *testing.T) int64 {
 	t.Helper()
 	var offset int64
-	if err := c.inWorkspace(t, c.slug, func(tx pgx.Tx) error {
+	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(),
 			`SELECT poll_offset FROM channel_connection WHERE id = $1`, c.conn.ID).Scan(&offset)
 	}); err != nil {
@@ -449,7 +450,7 @@ func (c *telegramEnv) pollCursor(t *testing.T) int64 {
 // the batch was never acknowledged, so the next poll asks for it again.
 func (c *telegramEnv) rewindPollCursor(t *testing.T, offset int64) {
 	t.Helper()
-	if err := c.inWorkspace(t, c.slug, func(tx pgx.Tx) error {
+	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(),
 			`UPDATE channel_connection SET poll_offset = $2 WHERE id = $1`, c.conn.ID, offset)
 		return err
@@ -465,7 +466,7 @@ func (c *telegramEnv) rewindPollCursor(t *testing.T, offset int64) {
 func (c *telegramEnv) count(t *testing.T, query string, args ...any) int {
 	t.Helper()
 	var n int
-	if err := c.inWorkspace(t, c.slug, func(tx pgx.Tx) error {
+	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(), query, args...).Scan(&n)
 	}); err != nil {
 		t.Fatalf("counting (%s): %v", query, err)
@@ -490,7 +491,7 @@ func (c *telegramEnv) rawCaptures(t *testing.T, updateID int64) int {
 func (c *telegramEnv) ingestJobs(t *testing.T) int {
 	t.Helper()
 	var n int
-	if err := c.pool.QueryRow(context.Background(),
+	if err := c.Pool.QueryRow(context.Background(),
 		`SELECT count(*) FROM river_job WHERE kind = $1 AND args->>'connection_id' = $2`,
 		compose.TelegramIngestArgs{}.Kind(), c.conn.ID.String()).Scan(&n); err != nil {
 		t.Fatalf("counting ingest jobs: %v", err)
@@ -510,7 +511,7 @@ func newTelegramWorker(t *testing.T, c *telegramEnv, cfg compose.JobRunnerConfig
 	ApplyRiverSchema(t)
 	cfg.CloseDateInterval, cfg.ReconcileInterval, cfg.TimeScanInterval = time.Hour, time.Hour, time.Hour
 	cfg.ChannelVault, cfg.ChannelAPI = c.vault, c.api
-	runner, err := compose.NewJobRunner(c.pool, c.log, cfg)
+	runner, err := compose.NewJobRunner(c.Pool, c.log, cfg)
 	if err != nil {
 		t.Fatalf("NewJobRunner: %v", err)
 	}

--- a/backend/internal/compose/integration/telegram_fixture_integration_test.go
+++ b/backend/internal/compose/integration/telegram_fixture_integration_test.go
@@ -204,7 +204,7 @@ type telegramEnv struct {
 func setupTelegram(t *testing.T) *telegramEnv {
 	t.Helper()
 	quiet := slog.New(slog.NewTextHandler(io.Discard, nil))
-	// The vault and the job inserter both need a pool before setupWithOptions
+	// The vault and the job inserter both need a pool before apptest.SetupAppWithOptions
 	// has opened the harness's own — the separate-connection precedent
 	// setupPreflight uses for exactly this reason.
 	pool := preflightAppPool(t)

--- a/backend/internal/compose/integration/telegram_identity_integration_test.go
+++ b/backend/internal/compose/integration/telegram_identity_integration_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	"github.com/gradionhq/margince/backend/internal/modules/capture"
 	"github.com/gradionhq/margince/backend/internal/modules/people"
 	"github.com/gradionhq/margince/backend/internal/modules/privacy"
@@ -85,7 +86,7 @@ func TestAC_TG_6_IdentityPhoneDisagreementIsAConflictNotAMerge(t *testing.T) {
 	admin := c.adminStoreCtx(t)
 	var routed ids.PersonID
 	var conflict *people.LaneConflict
-	if err := database.WithWorkspaceTx(admin, c.pool, func(tx pgx.Tx) error {
+	if err := database.WithWorkspaceTx(admin, c.Pool, func(tx pgx.Tx) error {
 		res, err := people.DedupePerson(admin, tx, people.PersonCandidate{
 			FullName:          "Phone Half",
 			Phones:            []string{phone},
@@ -105,7 +106,7 @@ func TestAC_TG_6_IdentityPhoneDisagreementIsAConflictNotAMerge(t *testing.T) {
 		t.Fatal("two exact lanes named different people and no conflict was reported — the disagreement would be resolved silently")
 	}
 
-	recorded, err := people.NewStore(c.pool).EnqueueIdentityConflict(admin, *conflict,
+	recorded, err := people.NewStore(c.Pool).EnqueueIdentityConflict(admin, *conflict,
 		"telegram:"+fmt.Sprintf("%d", telegramBotID)+":"+account+":1", "connector:telegram")
 	if err != nil {
 		t.Fatalf("EnqueueIdentityConflict: %v", err)
@@ -134,7 +135,7 @@ func (c *telegramEnv) assertConflictIsReviewable(t *testing.T, channelPerson, ph
 			} `json:"evidence"`
 		} `json:"data"`
 	}
-	if status := c.call(t, "GET", "/v1/dedupe/candidates?entity_type=person", nil, nil, &queue); status != http.StatusOK {
+	if status := c.Call(t, "GET", "/v1/dedupe/candidates?entity_type=person", nil, nil, &queue); status != http.StatusOK {
 		t.Fatalf("GET /v1/dedupe/candidates → %d, want 200", status)
 	}
 	if len(queue.Data) != 1 {
@@ -201,14 +202,14 @@ func (c *telegramEnv) assertNothingWasMerged(t *testing.T, channelPerson, phoneP
 // a record the product itself would have produced.
 func (c *telegramEnv) seedPerson(t *testing.T, name string, phone *string) string {
 	t.Helper()
-	body := anyMap{"full_name": name}
+	body := apptest.AnyMap{"full_name": name}
 	if phone != nil {
-		body["phones"] = []anyMap{{"phone": *phone, "phone_type": "mobile"}}
+		body["phones"] = []apptest.AnyMap{{"phone": *phone, "phone_type": "mobile"}}
 	}
 	var created struct {
 		ID string `json:"id"`
 	}
-	if status := c.call(t, "POST", "/v1/people", body, nil, &created); status != http.StatusCreated {
+	if status := c.Call(t, "POST", "/v1/people", body, nil, &created); status != http.StatusCreated {
 		t.Fatalf("seeding person %q → %d", name, status)
 	}
 	return created.ID
@@ -220,7 +221,7 @@ func (c *telegramEnv) seedPerson(t *testing.T, name string, phone *string) strin
 // there (which AC-TG-3 already proves).
 func (c *telegramEnv) bindChannelIdentity(t *testing.T, person string, identity connector.ChannelIdentity) {
 	t.Helper()
-	if err := c.inWorkspace(t, c.slug, func(tx pgx.Tx) error {
+	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(), `
 			INSERT INTO person_channel_identity
 			  (workspace_id, person_id, provider, channel_user_id, username, source, captured_by)
@@ -313,8 +314,8 @@ func TestTwoConcurrentFirstMessagesYieldOnePersonAndTwoActivities(t *testing.T) 
 	first := telegramUpdate{updateID: 5701, messageID: 71, senderID: 770701, username: "racer", firstName: "Nadia", text: "first"}
 	second := telegramUpdate{updateID: 5702, messageID: 72, senderID: 770701, username: "racer", firstName: "Nadia", text: "second"}
 
-	sink := capture.NewSink(c.pool).
-		WithChannelEnsurer(channelEnsureForwarder{store: people.NewStore(c.pool)})
+	sink := capture.NewSink(c.Pool).
+		WithChannelEnsurer(channelEnsureForwarder{store: people.NewStore(c.Pool)})
 	ctx := c.channelConnectorCtx(t)
 
 	start := make(chan struct{})
@@ -354,7 +355,7 @@ func TestTwoConcurrentFirstMessagesYieldOnePersonAndTwoActivities(t *testing.T) 
 	// across two people is the failure this convergence exists to prevent.
 	var links int
 	var linkedPeople int
-	if err := c.inWorkspace(t, c.slug, func(tx pgx.Tx) error {
+	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(), `
 			SELECT count(*), count(DISTINCT l.person_id)
 			  FROM activity_link l JOIN activity a ON a.id = l.activity_id
@@ -407,7 +408,7 @@ func TestErasedSubjectsNextMessageIsAcceptedAndPersistsNothing(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := privacy.NewEraser(c.pool).ErasePerson(c.adminStoreCtx(t), person, "acceptance-suite"); err != nil {
+	if err := privacy.NewEraser(c.Pool).ErasePerson(c.adminStoreCtx(t), person, "acceptance-suite"); err != nil {
 		t.Fatalf("ErasePerson: %v", err)
 	}
 	if n := c.channelIdentities(t, before); n != 0 {
@@ -457,7 +458,7 @@ func (c *telegramEnv) accountSuppressed(t *testing.T, account string) bool {
 	t.Helper()
 	ctx := principal.WithWorkspaceID(context.Background(), c.workspaceID(t))
 	var answer bool
-	if err := database.WithWorkspaceTx(ctx, c.pool, func(tx pgx.Tx) error {
+	if err := database.WithWorkspaceTx(ctx, c.Pool, func(tx pgx.Tx) error {
 		var err error
 		answer, err = storekit.ChannelIdentitySuppressed(ctx, tx, "telegram", account)
 		return err

--- a/backend/internal/compose/integration/telegram_ingress_integration_test.go
+++ b/backend/internal/compose/integration/telegram_ingress_integration_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	"github.com/gradionhq/margince/backend/internal/modules/people"
 	"github.com/gradionhq/margince/backend/internal/modules/privacy"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
@@ -50,7 +51,7 @@ const captureLatencyBudget = 60 * time.Second
 // marker, not a captured conversation.
 func (c *telegramEnv) capturedMessage(t *testing.T, u telegramUpdate) (activityID, personID string) {
 	t.Helper()
-	if err := c.inWorkspace(t, c.slug, func(tx pgx.Tx) error {
+	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(), `
 			SELECT a.id::text, l.person_id::text
 			  FROM activity a
@@ -106,7 +107,7 @@ func TestAC_TG_3_UnknownSenderBecomesOwnerlessWorkspaceVisiblePerson(t *testing.
 	var owned struct {
 		ID string `json:"id"`
 	}
-	if status := c.call(t, "POST", "/v1/people", anyMap{
+	if status := c.Call(t, "POST", "/v1/people", apptest.AnyMap{
 		"full_name": "Owned By The Admin", "owner_id": c.admin,
 	}, nil, &owned); status != 201 {
 		t.Fatalf("seeding the owned control person → %d", status)
@@ -118,7 +119,7 @@ func TestAC_TG_3_UnknownSenderBecomesOwnerlessWorkspaceVisiblePerson(t *testing.
 
 	var ownerID *string
 	var fullName string
-	if err := c.inWorkspace(t, c.slug, func(tx pgx.Tx) error {
+	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(),
 			`SELECT owner_id::text, full_name FROM person WHERE id = $1`, personID).
 			Scan(&ownerID, &fullName)
@@ -141,7 +142,7 @@ func TestAC_TG_3_UnknownSenderBecomesOwnerlessWorkspaceVisiblePerson(t *testing.
 		t.Errorf("%d email rows beside the channel identity, want 0", n)
 	}
 	var boundUsername, identitySource, identityCapturedBy string
-	if err := c.inWorkspace(t, c.slug, func(tx pgx.Tx) error {
+	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(), `
 			SELECT username, source, captured_by FROM person_channel_identity
 			 WHERE provider = 'telegram' AND channel_user_id = $1`, u.account()).
@@ -171,7 +172,7 @@ func (c *telegramEnv) assertWorkspaceVisible(t *testing.T, personID, ownedPerson
 	reader := c.strangerRepCtx(t, map[string]principal.ObjectGrant{
 		"person": {Read: true}, "activity": {Read: true},
 	})
-	store := people.NewStore(c.pool)
+	store := people.NewStore(c.Pool)
 
 	shared, err := ids.ParseAs[ids.PersonKind](personID)
 	if err != nil {
@@ -240,7 +241,7 @@ func TestAC_TG_4_RedeliveryYieldsExactlyOneActivity(t *testing.T) {
 	// The job-level replay: River's ladder can hand the same job to a worker
 	// twice, and the domain natural key is the only thing standing between that
 	// and a duplicated conversation.
-	if _, err := c.owner.Exec(context.Background(), `
+	if _, err := c.Owner.Exec(context.Background(), `
 		UPDATE river_job SET state = 'available', finalized_at = NULL, attempt = 0
 		 WHERE kind = $1 AND args->>'connection_id' = $2`,
 		compose.TelegramIngestArgs{}.Kind(), c.conn.ID.String()); err != nil {
@@ -279,7 +280,7 @@ func TestAC_TG_5_MailGatesAreNoOpsForAChannelRecord(t *testing.T) {
 	c := setupTelegramConnected(t)
 	// The workspace's own mail domain, so the colleagues gate has something to
 	// find if anything asks it about a record with no domain.
-	if err := c.inWorkspace(t, c.slug, func(tx pgx.Tx) error {
+	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(),
 			`INSERT INTO workspace_email_domain (workspace_id, domain) VALUES ($1, 'own-house.test')`, c.ws)
 		return err
@@ -352,7 +353,7 @@ func TestCaptureLatencyIsMeasuredOnTheAsyncPathNotThePollCommit(t *testing.T) {
 	}
 
 	injectedReceipt := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
-	if err := c.inWorkspace(t, c.slug, func(tx pgx.Tx) error {
+	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(),
 			`UPDATE raw_capture SET received_at = $2
 			  WHERE source_system = 'telegram' AND payload->>'update_id' = $1`,
@@ -363,7 +364,7 @@ func TestCaptureLatencyIsMeasuredOnTheAsyncPathNotThePollCommit(t *testing.T) {
 	}
 
 	var receivedAt, createdAt, occurredAt time.Time
-	if err := c.inWorkspace(t, c.slug, func(tx pgx.Tx) error {
+	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		ctx := context.Background()
 		if err := tx.QueryRow(ctx,
 			`SELECT received_at FROM raw_capture
@@ -426,7 +427,7 @@ func TestOneInboundMessageLeavesOneRawEvidenceRowAndIsExportedOnce(t *testing.T)
 	if err != nil {
 		t.Fatal(err)
 	}
-	pkg, err := privacy.AssembleSAR(c.adminStoreCtx(t), c.pool, ids.From[ids.PersonKind](person))
+	pkg, err := privacy.AssembleSAR(c.adminStoreCtx(t), c.Pool, ids.From[ids.PersonKind](person))
 	if err != nil {
 		t.Fatalf("AssembleSAR: %v", err)
 	}

--- a/backend/internal/compose/integration/telegram_integration_test.go
+++ b/backend/internal/compose/integration/telegram_integration_test.go
@@ -76,7 +76,7 @@ func TestAC_TG_1_ConnectValidatesSealsAndRecordsAuditOnly(t *testing.T) {
 func (c *telegramEnv) assertTokenSealed(t *testing.T) {
 	t.Helper()
 	var credentialRef string
-	if err := c.inWorkspace(t, c.slug, func(tx pgx.Tx) error {
+	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(),
 			`SELECT credential_ref FROM channel_connection WHERE id = $1`, c.conn.ID).Scan(&credentialRef)
 	}); err != nil {
@@ -161,7 +161,7 @@ func (c *telegramEnv) assertConnectionIsWorkspaceOwned(t *testing.T) {
 			Provider string `json:"provider"`
 		} `json:"data"`
 	}
-	if status := c.call(t, "GET", "/v1/channel-connections", nil, nil, &listed); status != http.StatusOK {
+	if status := c.Call(t, "GET", "/v1/channel-connections", nil, nil, &listed); status != http.StatusOK {
 		t.Fatalf("GET /v1/channel-connections → %d, want 200 (501 means the transport is not wired)", status)
 	}
 	if len(listed.Data) != 1 || listed.Data[0].ID != c.conn.ID.String() ||

--- a/backend/internal/compose/integration/telegram_roundtrip_integration_test.go
+++ b/backend/internal/compose/integration/telegram_roundtrip_integration_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	"github.com/gradionhq/margince/backend/internal/modules/capture"
 	"github.com/gradionhq/margince/backend/internal/modules/capture/telegram"
 	"github.com/gradionhq/margince/backend/internal/modules/identity"
@@ -47,7 +48,7 @@ import (
 // registry missing the connector reads as "this installation has no Telegram
 // integration" and parks every reply.
 func (c *telegramEnv) sendRegistry() *capture.Registry {
-	registry := capture.NewRegistry(c.pool, capture.NewSink(c.pool), identity.NewService(c.pool), c.vault)
+	registry := capture.NewRegistry(c.Pool, capture.NewSink(c.Pool), identity.NewService(c.Pool), c.vault)
 	registry.Register(telegram.New(c.api))
 	return registry
 }
@@ -63,7 +64,7 @@ func (c *telegramEnv) grantConsent(t *testing.T, personID, purposeKey string) {
 			Key string `json:"key"`
 		} `json:"data"`
 	}
-	if status := c.call(t, "GET", "/v1/consent-purposes", nil, nil, &purposes); status != http.StatusOK {
+	if status := c.Call(t, "GET", "/v1/consent-purposes", nil, nil, &purposes); status != http.StatusOK {
 		t.Fatalf("list consent purposes → %d", status)
 	}
 	var purposeID string
@@ -75,7 +76,7 @@ func (c *telegramEnv) grantConsent(t *testing.T, personID, purposeKey string) {
 	if purposeID == "" {
 		t.Fatalf("the bootstrap seeded no %q consent purpose", purposeKey)
 	}
-	if status := c.call(t, "POST", "/v1/people/"+personID+"/consent", anyMap{
+	if status := c.Call(t, "POST", "/v1/people/"+personID+"/consent", apptest.AnyMap{
 		"purpose_id": purposeID, "new_state": "granted", "lawful_basis": "consent",
 	}, nil, nil); status != http.StatusOK {
 		t.Fatalf("record consent → %d", status)
@@ -118,7 +119,7 @@ func TestInboundThenReplyRoundTrip(t *testing.T) {
 		Direction string `json:"direction"`
 		Body      string `json:"body"`
 	}
-	status := c.call(t, "POST", "/v1/activities/"+activityID+"/send-message", anyMap{
+	status := c.Call(t, "POST", "/v1/activities/"+activityID+"/send-message", apptest.AnyMap{
 		"body": reply, "consent_purpose": "transactional",
 	}, nil, &sent)
 	if status != http.StatusAccepted {
@@ -180,7 +181,7 @@ func TestCustomerReplyNamesTheChannelItArrivedOn(t *testing.T) {
 	// The rep answers, which is what puts an outbound activity in this chat's
 	// thread for the customer's next message to match against.
 	c.grantConsent(t, personID, "transactional")
-	if status := c.call(t, "POST", "/v1/activities/"+activityID+"/send-message", anyMap{
+	if status := c.Call(t, "POST", "/v1/activities/"+activityID+"/send-message", apptest.AnyMap{
 		"body": repReply, "consent_purpose": "transactional",
 	}, nil, nil); status != http.StatusAccepted {
 		t.Fatalf("the rep's reply → %d, want 202", status)
@@ -198,7 +199,7 @@ func TestCustomerReplyNamesTheChannelItArrivedOn(t *testing.T) {
 		t.Fatalf("%d engagement.reply events, want exactly 1 — the formula emits once per inbound message", n)
 	}
 	var channel, contactID string
-	if err := c.inWorkspace(t, c.slug, func(tx pgx.Tx) error {
+	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(), `
 			SELECT envelope->'payload'->>'channel',
 			       coalesce(envelope->'payload'->>'contact_id', '')
@@ -249,7 +250,7 @@ func TestAnArchivedOutboundIsNotAConversationToReplyInto(t *testing.T) {
 	var sent struct {
 		ID string `json:"id"`
 	}
-	if status := c.call(t, "POST", "/v1/activities/"+activityID+"/send-message", anyMap{
+	if status := c.Call(t, "POST", "/v1/activities/"+activityID+"/send-message", apptest.AnyMap{
 		"body": "We are — hall 4.", "consent_purpose": "transactional",
 	}, nil, &sent); status != http.StatusAccepted {
 		t.Fatalf("the rep's reply → %d, want 202", status)
@@ -258,7 +259,7 @@ func TestAnArchivedOutboundIsNotAConversationToReplyInto(t *testing.T) {
 
 	// The rep takes their message back off the timeline, leaving the thread with
 	// no LIVE outbound in it.
-	if err := c.inWorkspace(t, c.slug, func(tx pgx.Tx) error {
+	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		_, err := tx.Exec(context.Background(),
 			`UPDATE activity SET archived_at = now() WHERE id = $1`, sent.ID)
 		return err
@@ -320,7 +321,7 @@ func TestAForgedThreadKeyCannotReplyIntoAnotherMediumsConversation(t *testing.T)
 
 	// A real outbound goes into the Telegram conversation.
 	c.grantConsent(t, personID, "transactional")
-	if status := c.call(t, "POST", "/v1/activities/"+activityID+"/send-message", anyMap{
+	if status := c.Call(t, "POST", "/v1/activities/"+activityID+"/send-message", apptest.AnyMap{
 		"body": "Sending it over today.", "consent_purpose": "transactional",
 	}, nil, nil); status != http.StatusAccepted {
 		t.Fatalf("the rep's reply → %d, want 202", status)
@@ -330,7 +331,7 @@ func TestAForgedThreadKeyCannotReplyIntoAnotherMediumsConversation(t *testing.T)
 	// The thread key that outbound is filed under is what an attacker would
 	// forge, so the test reads the real one rather than reconstructing it.
 	var forged string
-	if err := c.inWorkspace(t, c.slug, func(tx pgx.Tx) error {
+	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(),
 			`SELECT thread_key FROM activity WHERE id = $1`, activityID).Scan(&forged)
 	}); err != nil {
@@ -356,7 +357,7 @@ func TestAForgedThreadKeyCannotReplyIntoAnotherMediumsConversation(t *testing.T)
 		},
 		ThreadKey: forged,
 	}
-	if _, err := capture.NewSink(c.pool).Upsert(c.mailConnectorCtx(t), mail); err != nil {
+	if _, err := capture.NewSink(c.Pool).Upsert(c.mailConnectorCtx(t), mail); err != nil {
 		t.Fatalf("capturing the stranger's mail: %v — it must land as an ordinary activity, "+
 			"or this test proves a refusal rather than the thread scan", err)
 	}
@@ -385,7 +386,7 @@ func (c *telegramEnv) assertSubjectAccessDescribesTheReply(t *testing.T, personI
 	if err != nil {
 		t.Fatal(err)
 	}
-	pkg, err := privacy.AssembleSAR(c.adminStoreCtx(t), c.pool, person)
+	pkg, err := privacy.AssembleSAR(c.adminStoreCtx(t), c.Pool, person)
 	if err != nil {
 		t.Fatalf("AssembleSAR: %v", err)
 	}
@@ -440,7 +441,7 @@ func (c *telegramEnv) assertDeliveryRecorded(t *testing.T, sentActivityID string
 	var recipient, status, deliveryActivity string
 	var providerMessageID *string
 	var subject, messageID *string
-	if err := c.inWorkspace(t, c.slug, func(tx pgx.Tx) error {
+	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(), `
 			SELECT channel_user_id, status, activity_id::text, provider_message_id, subject, message_id
 			  FROM comms_outbound WHERE channel_user_id IS NOT NULL`).
@@ -470,7 +471,7 @@ func (c *telegramEnv) assertDeliveryRecorded(t *testing.T, sentActivityID string
 	// Capture joins inbound messages against outbound activities on thread_key,
 	// so a reply filed anywhere else reads as a message out of nowhere.
 	var threadKey, linkedPerson string
-	if err := c.inWorkspace(t, c.slug, func(tx pgx.Tx) error {
+	if err := inWorkspace(c.AppEnv, t, c.Slug, func(tx pgx.Tx) error {
 		ctx := context.Background()
 		if err := tx.QueryRow(ctx,
 			`SELECT coalesce(thread_key, '') FROM activity WHERE id = $1`, sentActivityID).Scan(&threadKey); err != nil {

--- a/backend/internal/compose/integration/users_admin_http_integration_test.go
+++ b/backend/internal/compose/integration/users_admin_http_integration_test.go
@@ -13,6 +13,8 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 )
 
 type userWire struct {
@@ -31,12 +33,12 @@ type userListWire struct {
 }
 
 func TestAdminUserManagementOverHTTP(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 
 	// Invite a member.
 	var invited userWire
-	if status := e.call(t, "POST", "/v1/users", map[string]any{
+	if status := e.Call(t, "POST", "/v1/users", map[string]any{
 		"email": "Newbie@Acme.test", "display_name": "New Bie", "role": "rep",
 	}, nil, &invited); status != http.StatusCreated {
 		t.Fatalf("invite -> %d, want 201", status)
@@ -49,7 +51,7 @@ func TestAdminUserManagementOverHTTP(t *testing.T) {
 
 	// A duplicate email refuses, and says so in words.
 	var dupe refusalWire
-	if status := e.call(t, "POST", "/v1/users", map[string]any{
+	if status := e.Call(t, "POST", "/v1/users", map[string]any{
 		"email": "newbie@acme.test", "display_name": "Dupe", "role": "rep",
 	}, nil, &dupe); status != http.StatusConflict {
 		t.Fatalf("duplicate invite -> %d, want 409", status)
@@ -60,7 +62,7 @@ func TestAdminUserManagementOverHTTP(t *testing.T) {
 	// documentation, not binding validation, so a mistyped key reaches the
 	// server here too and must not read as "no such member".
 	var badRole refusalWire
-	if status := e.call(t, "POST", "/v1/users", map[string]any{
+	if status := e.Call(t, "POST", "/v1/users", map[string]any{
 		"email": "badrole@acme.test", "display_name": "Bad Role", "role": "no-such-role",
 	}, nil, &badRole); status != http.StatusNotFound {
 		t.Fatalf("invite with an undefined role -> %d, want 404", status)
@@ -68,17 +70,17 @@ func TestAdminUserManagementOverHTTP(t *testing.T) {
 	assertActionableRefusal(t, "invite with an undefined role", badRole, "unknown_role")
 
 	// Malformed input is refused before any member is created.
-	if status := e.call(t, "POST", "/v1/users", map[string]any{
+	if status := e.Call(t, "POST", "/v1/users", map[string]any{
 		"email": "not-an-email", "display_name": "X", "role": "rep",
 	}, nil, nil); status != http.StatusUnprocessableEntity {
 		t.Fatalf("invite with a malformed email -> %d, want 422", status)
 	}
-	if status := e.call(t, "POST", "/v1/users", map[string]any{
+	if status := e.Call(t, "POST", "/v1/users", map[string]any{
 		"email": "blank@acme.test", "display_name": "   ", "role": "rep",
 	}, nil, nil); status != http.StatusUnprocessableEntity {
 		t.Fatalf("invite with a blank display name -> %d, want 422", status)
 	}
-	if status := e.call(t, "POST", base+"/deactivate", map[string]any{
+	if status := e.Call(t, "POST", base+"/deactivate", map[string]any{
 		"reason": strings.Repeat("x", 501),
 	}, nil, nil); status != http.StatusUnprocessableEntity {
 		t.Fatalf("deactivate with an over-long reason -> %d, want 422", status)
@@ -86,7 +88,7 @@ func TestAdminUserManagementOverHTTP(t *testing.T) {
 
 	// The active-only roster shows the invited member.
 	var roster userListWire
-	if status := e.call(t, "GET", "/v1/users", nil, nil, &roster); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/users", nil, nil, &roster); status != http.StatusOK {
 		t.Fatalf("list users -> %d, want 200", status)
 	}
 	if !containsUser(roster.Data, invited.ID) {
@@ -102,7 +104,7 @@ func TestAdminUserManagementOverHTTP(t *testing.T) {
 
 	// Change role. The response reports the role now held, not the one replaced.
 	var afterRole userWire
-	if status := e.call(t, "PATCH", base+"/role", map[string]any{"role": "manager"}, nil, &afterRole); status != http.StatusOK {
+	if status := e.Call(t, "PATCH", base+"/role", map[string]any{"role": "manager"}, nil, &afterRole); status != http.StatusOK {
 		t.Fatalf("change role -> %d, want 200", status)
 	}
 	assertRoles(t, "change role", afterRole, "manager")
@@ -111,26 +113,26 @@ func TestAdminUserManagementOverHTTP(t *testing.T) {
 	// one, and the code is what lets a client tell an admin which mistake they
 	// made instead of sending them to look for a member who is right there.
 	var unknownRole refusalWire
-	if status := e.call(t, "PATCH", base+"/role", map[string]any{"role": "no-such-role"}, nil, &unknownRole); status != http.StatusNotFound {
+	if status := e.Call(t, "PATCH", base+"/role", map[string]any{"role": "no-such-role"}, nil, &unknownRole); status != http.StatusNotFound {
 		t.Fatalf("change role to an undefined role -> %d, want 404", status)
 	}
 	assertActionableRefusal(t, "an undefined role", unknownRole, "unknown_role")
 
 	// Deactivate: the member drops from the active roster but is visible with include_inactive.
 	var afterOff userWire
-	if status := e.call(t, "POST", base+"/deactivate", nil, nil, &afterOff); status != http.StatusOK {
+	if status := e.Call(t, "POST", base+"/deactivate", nil, nil, &afterOff); status != http.StatusOK {
 		t.Fatalf("deactivate -> %d, want 200", status)
 	}
 	if afterOff.Status != "deactivated" {
 		t.Fatalf("deactivated member status = %q, want deactivated", afterOff.Status)
 	}
 	var activeOnly userListWire
-	e.call(t, "GET", "/v1/users", nil, nil, &activeOnly)
+	e.Call(t, "GET", "/v1/users", nil, nil, &activeOnly)
 	if containsUser(activeOnly.Data, invited.ID) {
 		t.Fatalf("active-only roster still lists the deactivated member %s", invited.ID)
 	}
 	var withInactive userListWire
-	e.call(t, "GET", "/v1/users?include_inactive=true", nil, nil, &withInactive)
+	e.Call(t, "GET", "/v1/users?include_inactive=true", nil, nil, &withInactive)
 	if !containsUser(withInactive.Data, invited.ID) {
 		t.Fatalf("include_inactive roster missing the deactivated member %s", invited.ID)
 	}
@@ -138,7 +140,7 @@ func TestAdminUserManagementOverHTTP(t *testing.T) {
 	// widened+filtered query, and the one whose bind numbering is longest.
 	// Without this the suite executes that string nowhere.
 	var withInactiveFiltered userListWire
-	if status := e.call(t, "GET", "/v1/users?include_inactive=true&q=NEWBIE", nil, nil, &withInactiveFiltered); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/users?include_inactive=true&q=NEWBIE", nil, nil, &withInactiveFiltered); status != http.StatusOK {
 		t.Fatalf("include_inactive + q -> %d, want 200", status)
 	}
 	if len(withInactiveFiltered.Data) != 1 || withInactiveFiltered.Data[0].ID != invited.ID {
@@ -150,7 +152,7 @@ func TestAdminUserManagementOverHTTP(t *testing.T) {
 
 	// Reactivate.
 	var afterOn userWire
-	if status := e.call(t, "POST", base+"/reactivate", nil, nil, &afterOn); status != http.StatusOK {
+	if status := e.Call(t, "POST", base+"/reactivate", nil, nil, &afterOn); status != http.StatusOK {
 		t.Fatalf("reactivate -> %d, want 200", status)
 	}
 	if afterOn.Status != "active" {
@@ -160,10 +162,10 @@ func TestAdminUserManagementOverHTTP(t *testing.T) {
 	// A SUSPENDED member is not merely deactivated — the hold was placed for a
 	// different reason (e.g. lockout), so reactivating would quietly clear it.
 	// The refusal has to explain that, or an admin reads it as a broken button.
-	seedInWorkspace(t, e, wsID(t, e, e.slug),
+	seedInWorkspace(t, e, wsID(t, e, e.Slug),
 		stmt(`UPDATE app_user SET status = 'suspended' WHERE id = $1::uuid`, invited.ID))
 	var suspended refusalWire
-	if status := e.call(t, "POST", base+"/reactivate", nil, nil, &suspended); status != http.StatusConflict {
+	if status := e.Call(t, "POST", base+"/reactivate", nil, nil, &suspended); status != http.StatusConflict {
 		t.Fatalf("reactivating a suspended member -> %d, want 409", status)
 	}
 	assertActionableRefusal(t, "reactivating a suspended member", suspended, "not_deactivated")
@@ -171,10 +173,10 @@ func TestAdminUserManagementOverHTTP(t *testing.T) {
 	// An INVITED member reaches the same refusal, and it must not describe them
 	// as suspended — they are simply waiting to set a password, which is a
 	// different problem with a different fix.
-	seedInWorkspace(t, e, wsID(t, e, e.slug),
+	seedInWorkspace(t, e, wsID(t, e, e.Slug),
 		stmt(`UPDATE app_user SET status = 'invited' WHERE id = $1::uuid`, invited.ID))
 	var stillInvited refusalWire
-	if status := e.call(t, "POST", base+"/reactivate", nil, nil, &stillInvited); status != http.StatusConflict {
+	if status := e.Call(t, "POST", base+"/reactivate", nil, nil, &stillInvited); status != http.StatusConflict {
 		t.Fatalf("reactivating an invited member -> %d, want 409", status)
 	}
 	assertActionableRefusal(t, "reactivating an invited member", stillInvited, "not_deactivated")
@@ -190,15 +192,15 @@ func TestAdminUserManagementOverHTTP(t *testing.T) {
 			ID string `json:"id"`
 		} `json:"user"`
 	}
-	if status := e.call(t, "GET", "/v1/me", nil, nil, &me); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/me", nil, nil, &me); status != http.StatusOK {
 		t.Fatalf("GET /me -> %d, want 200", status)
 	}
 	var offLast, demoteLast refusalWire
-	if status := e.call(t, "POST", "/v1/users/"+me.User.ID+"/deactivate", nil, nil, &offLast); status != http.StatusConflict {
+	if status := e.Call(t, "POST", "/v1/users/"+me.User.ID+"/deactivate", nil, nil, &offLast); status != http.StatusConflict {
 		t.Fatalf("deactivating the last admin -> %d, want 409", status)
 	}
 	assertActionableRefusal(t, "deactivating the last admin", offLast, "last_active_admin")
-	if status := e.call(t, "PATCH", "/v1/users/"+me.User.ID+"/role", map[string]any{"role": "rep"}, nil, &demoteLast); status != http.StatusConflict {
+	if status := e.Call(t, "PATCH", "/v1/users/"+me.User.ID+"/role", map[string]any{"role": "rep"}, nil, &demoteLast); status != http.StatusConflict {
 		t.Fatalf("demoting the last admin -> %d, want 409", status)
 	}
 	assertActionableRefusal(t, "demoting the last admin", demoteLast, "last_active_admin")

--- a/backend/internal/compose/integration/voice_integration_test.go
+++ b/backend/internal/compose/integration/voice_integration_test.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	"github.com/gradionhq/margince/backend/internal/modules/ai"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -92,10 +93,10 @@ and follow up on Friday.</v>
 
 // createVoiceProfile is the shared first step: one caller-owned user
 // profile, asserted to land collecting and unbuilt.
-func createVoiceProfile(t *testing.T, e *env) voiceProfileWire {
+func createVoiceProfile(t *testing.T, e *apptest.AppEnv) voiceProfileWire {
 	t.Helper()
 	var created voiceProfileWire
-	if status := e.call(t, "POST", "/v1/voice-profiles", anyMap{}, nil, &created); status != http.StatusCreated {
+	if status := e.Call(t, "POST", "/v1/voice-profiles", apptest.AnyMap{}, nil, &created); status != http.StatusCreated {
 		t.Fatalf("create → %d", status)
 	}
 	if created.Status != "collecting" || created.Maturity != "collecting" || created.ProfileVersion != 0 || created.OwnerID == nil {
@@ -105,23 +106,23 @@ func createVoiceProfile(t *testing.T, e *env) voiceProfileWire {
 }
 
 func TestVoiceProfileLifecycle(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 	created := createVoiceProfile(t, e)
 	base := "/v1/voice-profiles/" + created.ID
 
 	// One live personal profile per user: a second create conflicts.
-	if status := e.call(t, "POST", "/v1/voice-profiles", anyMap{}, nil, nil); status != http.StatusConflict {
+	if status := e.Call(t, "POST", "/v1/voice-profiles", apptest.AnyMap{}, nil, nil); status != http.StatusConflict {
 		t.Fatalf("second create → %d, want 409", status)
 	}
 
 	// The human-authored half edits under If-Match; skew is refused.
-	if status := e.call(t, "PATCH", base, anyMap{"personality_md": "Direct, warm, no filler."},
+	if status := e.Call(t, "PATCH", base, apptest.AnyMap{"personality_md": "Direct, warm, no filler."},
 		map[string]string{"If-Match": "99"}, nil); status != http.StatusConflict {
 		t.Fatalf("stale If-Match → %d, want 409", status)
 	}
 	var edited voiceProfileWire
-	if status := e.call(t, "PATCH", base, anyMap{"personality_md": "Direct, warm, no filler."},
+	if status := e.Call(t, "PATCH", base, apptest.AnyMap{"personality_md": "Direct, warm, no filler."},
 		map[string]string{"If-Match": "1"}, &edited); status != http.StatusOK {
 		t.Fatalf("personality edit → %d", status)
 	}
@@ -130,19 +131,19 @@ func TestVoiceProfileLifecycle(t *testing.T) {
 	}
 
 	// Archive returns the terminal representation, then reads are absent.
-	if status := e.call(t, "DELETE", base, nil, map[string]string{"If-Match": "2"}, nil); status != http.StatusOK {
+	if status := e.Call(t, "DELETE", base, nil, map[string]string{"If-Match": "2"}, nil); status != http.StatusOK {
 		t.Fatalf("archive → %d", status)
 	}
-	if status := e.call(t, "GET", base, nil, nil, nil); status != http.StatusNotFound {
+	if status := e.Call(t, "GET", base, nil, nil, nil); status != http.StatusNotFound {
 		t.Fatalf("get after archive → %d, want 404", status)
 	}
-	if status := e.call(t, "GET", base+"/sources", nil, nil, nil); status != http.StatusNotFound {
+	if status := e.Call(t, "GET", base+"/sources", nil, nil, nil); status != http.StatusNotFound {
 		t.Fatalf("sources after archive → %d, want 404 (the corpus rides its parent)", status)
 	}
 }
 
 // ingest posts one corpus source and asserts the 201.
-func ingest(t *testing.T, e *env, base string, body anyMap) voiceIngestResponse {
+func ingest(t *testing.T, e *apptest.AppEnv, base string, body apptest.AnyMap) voiceIngestResponse {
 	t.Helper()
 	kind, _ := body["kind"].(string)
 	if _, ok := body["register"]; !ok {
@@ -155,20 +156,20 @@ func ingest(t *testing.T, e *env, base string, body anyMap) voiceIngestResponse 
 		body["format"] = "text"
 	}
 	var resp voiceIngestResponse
-	if status := e.call(t, "POST", base+"/sources", body, nil, &resp); status != http.StatusCreated {
+	if status := e.Call(t, "POST", base+"/sources", body, nil, &resp); status != http.StatusCreated {
 		t.Fatalf("ingest %v → %d", body["source_ref"], status)
 	}
 	return resp
 }
 
 func TestVoiceCorpusIngestAndMeter(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 	created := createVoiceProfile(t, e)
 	base := "/v1/voice-profiles/" + created.ID
 
 	// A pasted post: social register, words counted.
-	post := ingest(t, e, base, anyMap{
+	post := ingest(t, e, base, apptest.AnyMap{
 		"kind": "linkedin", "source_label": "LinkedIn posts", "source_ref": "post-2026-06",
 		"content": "Shipping beats planning. We shipped the audit story this week and it landed.",
 	})
@@ -181,7 +182,7 @@ func TestVoiceCorpusIngestAndMeter(t *testing.T) {
 
 	// A both-sided transcript: spoken register by default, and ONLY the
 	// owner's 20 words enter — zero other-party text (§B1.2).
-	transcript := ingest(t, e, base, anyMap{
+	transcript := ingest(t, e, base, apptest.AnyMap{
 		"kind": "transcript", "source_label": "Discovery call", "source_ref": "call-77",
 		"format": "transcript", "speaker_label": "Ada Admin", "content": voiceTestVTT,
 	})
@@ -194,7 +195,7 @@ func TestVoiceCorpusIngestAndMeter(t *testing.T) {
 
 	// Idempotency: re-ingesting source_ref post-2026-06 replaces the row
 	// — same source count, new word count, no double-counted meter.
-	reingested := ingest(t, e, base, anyMap{
+	reingested := ingest(t, e, base, apptest.AnyMap{
 		"kind": "linkedin", "source_label": "LinkedIn posts", "source_ref": "post-2026-06",
 		"content": "Five clean words replace thirteen.",
 	})
@@ -207,7 +208,7 @@ func TestVoiceCorpusIngestAndMeter(t *testing.T) {
 
 	// A rich enough source moves the band; the boundary logic itself is
 	// unit-tested — here the wire meter reflects the stored corpus.
-	bulk := ingest(t, e, base, anyMap{
+	bulk := ingest(t, e, base, apptest.AnyMap{
 		"kind": "document", "source_label": "Blog archive", "source_ref": "blog-dump",
 		"content": strings.Repeat("wort ", 8500),
 	})
@@ -217,7 +218,7 @@ func TestVoiceCorpusIngestAndMeter(t *testing.T) {
 
 	// Excluding a source pulls it from the meter (manifest opt-out).
 	var excluded voiceIngestResponse
-	if status := e.call(t, "PATCH", base+"/sources/"+bulk.Source.ID, anyMap{
+	if status := e.Call(t, "PATCH", base+"/sources/"+bulk.Source.ID, apptest.AnyMap{
 		"included": false,
 	}, nil, &excluded); status != http.StatusOK {
 		t.Fatalf("exclude → %d", status)
@@ -232,7 +233,7 @@ func TestVoiceCorpusIngestAndMeter(t *testing.T) {
 		Data    []voiceSourceWire `json:"data"`
 		Summary voiceSummaryWire  `json:"summary"`
 	}
-	if status := e.call(t, "GET", base+"/sources", nil, nil, &manifest); status != http.StatusOK {
+	if status := e.Call(t, "GET", base+"/sources", nil, nil, &manifest); status != http.StatusOK {
 		t.Fatalf("manifest → %d", status)
 	}
 	if len(manifest.Data) != 3 || manifest.Summary.SourceCount != 2 {
@@ -241,25 +242,25 @@ func TestVoiceCorpusIngestAndMeter(t *testing.T) {
 }
 
 func TestVoiceBuildQueuesOnlyAtTheProvisionalThreshold(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 	created := createVoiceProfile(t, e)
 	base := "/v1/voice-profiles/" + created.ID
 
-	ingest(t, e, base, anyMap{
+	ingest(t, e, base, apptest.AnyMap{
 		"kind": "document", "source_label": "Working sample", "source_ref": "threshold",
 		"content": strings.Repeat("word ", 799),
 	})
-	if status := e.call(t, "POST", base+"/builds", anyMap{"reason": "onboarding"}, nil, nil); status != http.StatusUnprocessableEntity {
+	if status := e.Call(t, "POST", base+"/builds", apptest.AnyMap{"reason": "onboarding"}, nil, nil); status != http.StatusUnprocessableEntity {
 		t.Fatalf("build below 800 words → %d, want 422", status)
 	}
 
-	ingest(t, e, base, anyMap{
+	ingest(t, e, base, apptest.AnyMap{
 		"kind": "document", "source_label": "Working sample", "source_ref": "threshold",
 		"content": strings.Repeat("word ", 800),
 	})
 	var queued voiceBuildWire
-	if status := e.call(t, "POST", base+"/builds", anyMap{"reason": "onboarding"}, nil, &queued); status != http.StatusAccepted {
+	if status := e.Call(t, "POST", base+"/builds", apptest.AnyMap{"reason": "onboarding"}, nil, &queued); status != http.StatusAccepted {
 		t.Fatalf("build at 800 words → %d, want 202", status)
 	}
 	if queued.ProfileID != created.ID || queued.Status != "queued" || queued.SourceCount != 1 || queued.SourceHash == "" || queued.ResultVersion != nil {
@@ -267,14 +268,14 @@ func TestVoiceBuildQueuesOnlyAtTheProvisionalThreshold(t *testing.T) {
 	}
 
 	var replay voiceBuildWire
-	if status := e.call(t, "POST", base+"/builds", anyMap{"reason": "manual"}, nil, &replay); status != http.StatusAccepted {
+	if status := e.Call(t, "POST", base+"/builds", apptest.AnyMap{"reason": "manual"}, nil, &replay); status != http.StatusAccepted {
 		t.Fatalf("active-build replay → %d, want 202", status)
 	}
 	if replay.ID != queued.ID {
 		t.Fatalf("active-build replay id = %s, want %s", replay.ID, queued.ID)
 	}
 	var polled voiceBuildWire
-	if status := e.call(t, "GET", base+"/builds/"+queued.ID, nil, nil, &polled); status != http.StatusOK {
+	if status := e.Call(t, "GET", base+"/builds/"+queued.ID, nil, nil, &polled); status != http.StatusOK {
 		t.Fatalf("poll build → %d", status)
 	}
 	if polled.ID != queued.ID || polled.Version != 1 {
@@ -287,8 +288,8 @@ func TestVoiceBuildQueuesOnlyAtTheProvisionalThreshold(t *testing.T) {
 // formats — never a size-derived estimate. Real extraction is deferred
 // (B-E07.5c).
 func TestVoiceBinaryDocumentIngestIsRefusedWith422(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 	created := createVoiceProfile(t, e)
 
 	for _, format := range []string{"docx", "pdf"} {
@@ -296,7 +297,7 @@ func TestVoiceBinaryDocumentIngestIsRefusedWith422(t *testing.T) {
 			Code   string `json:"code"`
 			Detail string `json:"detail"`
 		}
-		if status := e.call(t, "POST", "/v1/voice-profiles/"+created.ID+"/sources", anyMap{
+		if status := e.Call(t, "POST", "/v1/voice-profiles/"+created.ID+"/sources", apptest.AnyMap{
 			"kind": "document", "register": "long_form", "source_label": "office upload", "source_ref": "bin-" + format,
 			"format": format, "content": "opaque binary payload",
 		}, nil, &problem); status != http.StatusUnprocessableEntity {
@@ -312,7 +313,7 @@ func TestVoiceBinaryDocumentIngestIsRefusedWith422(t *testing.T) {
 		Data    []voiceSourceWire `json:"data"`
 		Summary voiceSummaryWire  `json:"summary"`
 	}
-	if status := e.call(t, "GET", "/v1/voice-profiles/"+created.ID+"/sources", nil, nil, &manifest); status != http.StatusOK {
+	if status := e.Call(t, "GET", "/v1/voice-profiles/"+created.ID+"/sources", nil, nil, &manifest); status != http.StatusOK {
 		t.Fatalf("manifest → %d", status)
 	}
 	if len(manifest.Data) != 0 || manifest.Summary.TotalWords != 0 {
@@ -323,11 +324,11 @@ func TestVoiceBinaryDocumentIngestIsRefusedWith422(t *testing.T) {
 // A labelled transcript without the owner's label is refused whole —
 // never half-ingested with the other side included (§B1.2).
 func TestVoiceTranscriptIngestRequiresTheOwnersSpeakerLabel(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 	created := createVoiceProfile(t, e)
 
-	if status := e.call(t, "POST", "/v1/voice-profiles/"+created.ID+"/sources", anyMap{
+	if status := e.Call(t, "POST", "/v1/voice-profiles/"+created.ID+"/sources", apptest.AnyMap{
 		"kind": "transcript", "register": "spoken", "source_label": "Unattributed", "source_ref": "call-78",
 		"format": "transcript", "content": voiceTestVTT,
 	}, nil, nil); status != 422 {
@@ -339,20 +340,20 @@ func TestVoiceTranscriptIngestRequiresTheOwnersSpeakerLabel(t *testing.T) {
 // human's consented personal material and the derived voice is their
 // identity asset (the ADR-0055 human-only class).
 func TestVoiceProfileMutationsRejectAgents(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 
 	var minted struct {
 		Token string `json:"token"`
 	}
-	if status := e.call(t, "POST", "/v1/passports", anyMap{
+	if status := e.Call(t, "POST", "/v1/passports", apptest.AnyMap{
 		"label": "voice prober", "scopes": []string{"read", "write"},
 	}, nil, &minted); status != http.StatusCreated {
 		t.Fatalf("mint → %d", status)
 	}
 	bearer := map[string]string{"Authorization": "Bearer " + minted.Token}
 
-	if status := e.call(t, "POST", "/v1/voice-profiles", anyMap{}, bearer, nil); status != http.StatusForbidden {
+	if status := e.Call(t, "POST", "/v1/voice-profiles", apptest.AnyMap{}, bearer, nil); status != http.StatusForbidden {
 		t.Fatalf("agent create voice profile → %d, want 403", status)
 	}
 }
@@ -364,11 +365,11 @@ func TestVoiceProfileMutationsRejectAgents(t *testing.T) {
 // the assertion runs through the store — the same RBAC + row-scope path
 // the HTTP surface drives.
 func TestVoiceProfileIsInvisibleAcrossTenants(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 
 	var created voiceProfileWire
-	if status := e.call(t, "POST", "/v1/voice-profiles", anyMap{}, nil, &created); status != http.StatusCreated {
+	if status := e.Call(t, "POST", "/v1/voice-profiles", apptest.AnyMap{}, nil, &created); status != http.StatusCreated {
 		t.Fatalf("create → %d", status)
 	}
 
@@ -376,11 +377,11 @@ func TestVoiceProfileIsInvisibleAcrossTenants(t *testing.T) {
 	// (which binds the process, not the schema — RLS still isolates rows).
 	ctx := context.Background()
 	wsB, userB := ids.NewV7(), ids.NewV7()
-	if _, err := e.owner.Exec(ctx,
+	if _, err := e.Owner.Exec(ctx,
 		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Voice Two', 'voice-two', 'EUR')`, wsB); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := e.owner.Exec(ctx,
+	if _, err := e.Owner.Exec(ctx,
 		`INSERT INTO app_user (id, workspace_id, email, display_name) VALUES ($1, $2, 'bea@example.com', 'Bea Boss')`,
 		userB, wsB); err != nil {
 		t.Fatal(err)
@@ -395,7 +396,7 @@ func TestVoiceProfileIsInvisibleAcrossTenants(t *testing.T) {
 		},
 	})
 
-	store := ai.NewVoiceStore(e.pool)
+	store := ai.NewVoiceStore(e.Pool)
 	profileID, err := ids.Parse(created.ID)
 	if err != nil {
 		t.Fatalf("created profile id: %v", err)

--- a/backend/internal/compose/integration/voice_lifecycle_http_integration_test.go
+++ b/backend/internal/compose/integration/voice_lifecycle_http_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -65,25 +66,25 @@ const voiceLifecycleEvaluation = `{
   "passed": true
 }`
 
-func seedVoiceLifecycleHistory(t *testing.T, e *env, profileID string) (ids.UUID, ids.UUID) {
+func seedVoiceLifecycleHistory(t *testing.T, e *apptest.AppEnv, profileID string) (ids.UUID, ids.UUID) {
 	t.Helper()
 	ctx := context.Background()
 	var workspaceID, ownerID ids.UUID
-	if err := e.owner.QueryRow(
+	if err := e.Owner.QueryRow(
 		ctx,
 		`SELECT workspace_id, owner_id FROM voice_profile WHERE id = $1`, profileID,
 	).Scan(&workspaceID, &ownerID); err != nil {
 		t.Fatal(err)
 	}
 	capturedBy := "human:" + ownerID.String()
-	if _, err := e.owner.Exec(ctx, `
+	if _, err := e.Owner.Exec(ctx, `
 		UPDATE voice_profile
 		SET status = 'ready', voice_profile_md = 'active version 1', profile_version = 1,
 		    active_source_hash = 'active-hash', last_built_at = now(), updated_at = now()
 		WHERE id = $1`, profileID); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := e.owner.Exec(ctx, `
+	if _, err := e.Owner.Exec(ctx, `
 		INSERT INTO voice_profile_version
 		  (workspace_id, voice_profile_id, profile_version, status, voice_profile_md,
 		   profile_json, stats_json, source_hash, source_count, reason,
@@ -102,7 +103,7 @@ func seedVoiceLifecycleHistory(t *testing.T, e *env, profileID string) (ids.UUID
 
 func seedVoiceLifecycleCandidate(
 	t *testing.T,
-	e *env,
+	e *apptest.AppEnv,
 	workspaceID ids.UUID,
 	profileID string,
 	profileVersion int,
@@ -112,7 +113,7 @@ func seedVoiceLifecycleCandidate(
 	t.Helper()
 	ctx := context.Background()
 	artifact := "candidate version " + strconv.Itoa(profileVersion)
-	if _, err := e.owner.Exec(ctx, `
+	if _, err := e.Owner.Exec(ctx, `
 		INSERT INTO voice_profile_version
 		  (workspace_id, voice_profile_id, profile_version, status, voice_profile_md,
 		   profile_json, stats_json, source_hash, source_count, reason, predecessor_version,
@@ -127,7 +128,7 @@ func seedVoiceLifecycleCandidate(
 		voiceLifecycleEvaluation, capturedBy); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := e.owner.Exec(ctx, `
+	if _, err := e.Owner.Exec(ctx, `
 		INSERT INTO voice_profile_delta
 		  (workspace_id, voice_profile_id, from_version, to_version, classification,
 		   activation_outcome, delta_json)
@@ -138,10 +139,10 @@ func seedVoiceLifecycleCandidate(
 	}
 }
 
-func seedVoiceDraftSignal(t *testing.T, e *env, workspaceID ids.UUID, profileID string, ownerID ids.UUID, draftRef string) {
+func seedVoiceDraftSignal(t *testing.T, e *apptest.AppEnv, workspaceID ids.UUID, profileID string, ownerID ids.UUID, draftRef string) {
 	t.Helper()
 	hash := sha256.Sum256([]byte(draftRef))
-	if _, err := e.owner.Exec(context.Background(), `
+	if _, err := e.Owner.Exec(context.Background(), `
 		INSERT INTO voice_learning_signal
 		  (workspace_id, voice_profile_id, profile_version, draft_ref_hash, outcome,
 		   generated_original, transformations, retention_until, source, captured_by)
@@ -153,16 +154,16 @@ func seedVoiceDraftSignal(t *testing.T, e *env, workspaceID ids.UUID, profileID 
 }
 
 func TestVoiceLifecycleHTTPRoundTrip(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 	created := createVoiceProfile(t, e)
 	base := "/v1/voice-profiles/" + created.ID
-	removable := ingest(t, e, base, anyMap{
+	removable := ingest(t, e, base, apptest.AnyMap{
 		"kind": "email", "source_label": "Removable sample", "source_ref": "remove-me",
 		"content": "This source proves permanent removal through the governed HTTP lifecycle.",
 	})
 	var removed voiceSourceWire
-	if status := e.call(t, "DELETE", base+"/sources/"+removable.Source.ID, nil,
+	if status := e.Call(t, "DELETE", base+"/sources/"+removable.Source.ID, nil,
 		map[string]string{"If-Match": strconv.Itoa(removable.Source.Version)}, &removed); status != http.StatusOK {
 		t.Fatalf("delete corpus source → %d", status)
 	}
@@ -171,46 +172,46 @@ func TestVoiceLifecycleHTTPRoundTrip(t *testing.T) {
 	}
 	workspaceID, ownerID := seedVoiceLifecycleHistory(t, e, created.ID)
 
-	if status := e.call(t, "GET", base+"/versions?cursor=not-a-cursor", nil, nil, nil); status != http.StatusUnprocessableEntity {
+	if status := e.Call(t, "GET", base+"/versions?cursor=not-a-cursor", nil, nil, nil); status != http.StatusUnprocessableEntity {
 		t.Fatalf("invalid version cursor → %d, want 422", status)
 	}
-	if status := e.call(t, "GET", base+"/deltas?cursor=not-a-cursor", nil, nil, nil); status != http.StatusUnprocessableEntity {
+	if status := e.Call(t, "GET", base+"/deltas?cursor=not-a-cursor", nil, nil, nil); status != http.StatusUnprocessableEntity {
 		t.Fatalf("invalid delta cursor → %d, want 422", status)
 	}
-	if status := e.call(t, "POST", base+"/versions/2/apply", nil,
+	if status := e.Call(t, "POST", base+"/versions/2/apply", nil,
 		map[string]string{"If-Match": "not-a-version"}, nil); status != http.StatusUnprocessableEntity {
 		t.Fatalf("invalid apply If-Match → %d, want 422", status)
 	}
-	if status := e.call(t, "POST", base+"/versions/2/reject", nil,
+	if status := e.Call(t, "POST", base+"/versions/2/reject", nil,
 		map[string]string{"If-Match": "0"}, nil); status != http.StatusUnprocessableEntity {
 		t.Fatalf("invalid reject If-Match → %d, want 422", status)
 	}
-	if status := e.call(t, "POST", base+"/corpus/clear", nil,
+	if status := e.Call(t, "POST", base+"/corpus/clear", nil,
 		map[string]string{"If-Match": "invalid"}, nil); status != http.StatusUnprocessableEntity {
 		t.Fatalf("invalid clear If-Match → %d, want 422", status)
 	}
-	if status := e.call(t, "GET", base+"/builds/"+ids.NewV7().String(), nil, nil, nil); status != http.StatusNotFound {
+	if status := e.Call(t, "GET", base+"/builds/"+ids.NewV7().String(), nil, nil, nil); status != http.StatusNotFound {
 		t.Fatalf("unknown build → %d, want 404", status)
 	}
-	if status := e.call(t, "POST", base+"/versions/99/rollback", nil, nil, nil); status != http.StatusNotFound {
+	if status := e.Call(t, "POST", base+"/versions/99/rollback", nil, nil, nil); status != http.StatusNotFound {
 		t.Fatalf("unknown rollback version → %d, want 404", status)
 	}
-	if status := e.call(t, "GET", "/v1/voice-profiles/"+ids.NewV7().String()+"/learning", nil, nil, nil); status != http.StatusNotFound {
+	if status := e.Call(t, "GET", "/v1/voice-profiles/"+ids.NewV7().String()+"/learning", nil, nil, nil); status != http.StatusNotFound {
 		t.Fatalf("unknown learning profile → %d, want 404", status)
 	}
-	if status := e.call(t, "POST", base+"/draft-rejections", anyMap{"draft_ref": ""}, nil, nil); status != http.StatusUnprocessableEntity {
+	if status := e.Call(t, "POST", base+"/draft-rejections", apptest.AnyMap{"draft_ref": ""}, nil, nil); status != http.StatusUnprocessableEntity {
 		t.Fatalf("empty draft reference → %d, want 422", status)
 	}
 
 	var firstPage voiceVersionPageWire
-	if status := e.call(t, "GET", base+"/versions?limit=1", nil, nil, &firstPage); status != http.StatusOK {
+	if status := e.Call(t, "GET", base+"/versions?limit=1", nil, nil, &firstPage); status != http.StatusOK {
 		t.Fatalf("list versions → %d", status)
 	}
 	if len(firstPage.Data) != 1 || !firstPage.Page.HasMore || firstPage.Page.NextCursor == nil {
 		t.Fatalf("first version page = %+v, want one row and a cursor", firstPage)
 	}
 	var secondPage voiceVersionPageWire
-	if status := e.call(t, "GET", base+"/versions?limit=1&cursor="+*firstPage.Page.NextCursor, nil, nil, &secondPage); status != http.StatusOK {
+	if status := e.Call(t, "GET", base+"/versions?limit=1&cursor="+*firstPage.Page.NextCursor, nil, nil, &secondPage); status != http.StatusOK {
 		t.Fatalf("second version page → %d", status)
 	}
 	if len(secondPage.Data) != 1 || secondPage.Page.HasMore {
@@ -218,7 +219,7 @@ func TestVoiceLifecycleHTTPRoundTrip(t *testing.T) {
 	}
 
 	var applied voiceVersionWire
-	if status := e.call(t, "POST", base+"/versions/2/apply", nil,
+	if status := e.Call(t, "POST", base+"/versions/2/apply", nil,
 		map[string]string{"If-Match": "1"}, &applied); status != http.StatusOK {
 		t.Fatalf("apply candidate → %d", status)
 	}
@@ -228,7 +229,7 @@ func TestVoiceLifecycleHTTPRoundTrip(t *testing.T) {
 
 	seedVoiceLifecycleCandidate(t, e, workspaceID, created.ID, 3, 2, "human:"+ownerID.String())
 	var rejected voiceVersionWire
-	if status := e.call(t, "POST", base+"/versions/3/reject", nil,
+	if status := e.Call(t, "POST", base+"/versions/3/reject", nil,
 		map[string]string{"If-Match": "1"}, &rejected); status != http.StatusOK {
 		t.Fatalf("reject candidate → %d", status)
 	}
@@ -237,14 +238,14 @@ func TestVoiceLifecycleHTTPRoundTrip(t *testing.T) {
 	}
 
 	var deltas voiceDeltaPageWire
-	if status := e.call(t, "GET", base+"/deltas?limit=1", nil, nil, &deltas); status != http.StatusOK {
+	if status := e.Call(t, "GET", base+"/deltas?limit=1", nil, nil, &deltas); status != http.StatusOK {
 		t.Fatalf("list deltas → %d", status)
 	}
 	if len(deltas.Data) != 1 || !deltas.Page.HasMore || deltas.Page.NextCursor == nil {
 		t.Fatalf("delta page = %+v, want one row and a cursor", deltas)
 	}
 	var remainingDeltas voiceDeltaPageWire
-	if status := e.call(t, "GET", base+"/deltas?limit=10&cursor="+*deltas.Page.NextCursor, nil, nil, &remainingDeltas); status != http.StatusOK {
+	if status := e.Call(t, "GET", base+"/deltas?limit=10&cursor="+*deltas.Page.NextCursor, nil, nil, &remainingDeltas); status != http.StatusOK {
 		t.Fatalf("remaining deltas → %d", status)
 	}
 	if len(remainingDeltas.Data) != 1 {
@@ -254,14 +255,14 @@ func TestVoiceLifecycleHTTPRoundTrip(t *testing.T) {
 	draftRef := "draft:lifecycle-http"
 	seedVoiceDraftSignal(t, e, workspaceID, created.ID, ownerID, draftRef)
 	var beforeReject voiceLearningSummaryWire
-	if status := e.call(t, "GET", base+"/learning", nil, nil, &beforeReject); status != http.StatusOK {
+	if status := e.Call(t, "GET", base+"/learning", nil, nil, &beforeReject); status != http.StatusOK {
 		t.Fatalf("learning summary → %d", status)
 	}
 	if beforeReject.Drafted != 1 || beforeReject.Rejected != 0 {
 		t.Fatalf("learning summary before rejection = %+v", beforeReject)
 	}
 	var afterReject voiceLearningSummaryWire
-	if status := e.call(t, "POST", base+"/draft-rejections", anyMap{"draft_ref": draftRef}, nil, &afterReject); status != http.StatusOK {
+	if status := e.Call(t, "POST", base+"/draft-rejections", apptest.AnyMap{"draft_ref": draftRef}, nil, &afterReject); status != http.StatusOK {
 		t.Fatalf("reject draft → %d", status)
 	}
 	if afterReject.Drafted != 0 || afterReject.Rejected != 1 {
@@ -269,7 +270,7 @@ func TestVoiceLifecycleHTTPRoundTrip(t *testing.T) {
 	}
 
 	var rolledBack voiceVersionWire
-	if status := e.call(t, "POST", base+"/versions/1/rollback", nil, nil, &rolledBack); status != http.StatusCreated {
+	if status := e.Call(t, "POST", base+"/versions/1/rollback", nil, nil, &rolledBack); status != http.StatusCreated {
 		t.Fatalf("rollback → %d", status)
 	}
 	if rolledBack.ProfileVersion != 4 || rolledBack.Status != "active" || rolledBack.VoiceProfileMD != "active version 1" {
@@ -277,11 +278,11 @@ func TestVoiceLifecycleHTTPRoundTrip(t *testing.T) {
 	}
 
 	var profile voiceProfileWire
-	if status := e.call(t, "GET", base, nil, nil, &profile); status != http.StatusOK {
+	if status := e.Call(t, "GET", base, nil, nil, &profile); status != http.StatusOK {
 		t.Fatalf("profile after rollback → %d", status)
 	}
 	var cleared voiceProfileWire
-	if status := e.call(t, "POST", base+"/corpus/clear", nil,
+	if status := e.Call(t, "POST", base+"/corpus/clear", nil,
 		map[string]string{"If-Match": strconv.Itoa(profile.Version)}, &cleared); status != http.StatusOK {
 		t.Fatalf("clear corpus → %d", status)
 	}

--- a/backend/internal/compose/integration/voice_sendoutcome_integration_test.go
+++ b/backend/internal/compose/integration/voice_sendoutcome_integration_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -39,7 +40,7 @@ const voiceSentBody = "Thanks for the call — the pricing follows tomorrow."
 // human's voice profile, a consented recipient under an unsubscribable
 // purpose, and the anchor the send threads onto.
 type voiceSendEnv struct {
-	*env
+	*apptest.AppEnv
 	workspaceID ids.UUID
 	ownerID     ids.UUID
 	profileID   string
@@ -48,12 +49,12 @@ type voiceSendEnv struct {
 
 func setupVoiceSend(t *testing.T) *voiceSendEnv {
 	t.Helper()
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 	profile := createVoiceProfile(t, e)
 
 	var workspaceID, ownerID ids.UUID
-	if err := e.owner.QueryRow(context.Background(),
+	if err := e.Owner.QueryRow(context.Background(),
 		`SELECT workspace_id, owner_id FROM voice_profile WHERE id = $1`, profile.ID).
 		Scan(&workspaceID, &ownerID); err != nil {
 		t.Fatalf("resolving the profile's workspace and owner: %v", err)
@@ -62,9 +63,9 @@ func setupVoiceSend(t *testing.T) *voiceSendEnv {
 	var person struct {
 		ID string `json:"id"`
 	}
-	if status := e.call(t, "POST", "/v1/people", anyMap{
+	if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{
 		"full_name": "Draft Reader",
-		"emails":    []anyMap{{"email": "reader@buyer.test"}},
+		"emails":    []apptest.AnyMap{{"email": "reader@buyer.test"}},
 	}, nil, &person); status != http.StatusCreated {
 		t.Fatalf("create person → %d", status)
 	}
@@ -74,12 +75,12 @@ func setupVoiceSend(t *testing.T) *voiceSendEnv {
 	var purpose struct {
 		ID string `json:"id"`
 	}
-	if status := e.call(t, "POST", "/v1/consent-purposes", anyMap{
+	if status := e.Call(t, "POST", "/v1/consent-purposes", apptest.AnyMap{
 		"key": "newsletter", "label": "Newsletter", "requires_double_opt_in": false,
 	}, nil, &purpose); status != http.StatusCreated {
 		t.Fatalf("create consent purpose → %d", status)
 	}
-	if status := e.call(t, "POST", "/v1/people/"+person.ID+"/consent", anyMap{
+	if status := e.Call(t, "POST", "/v1/people/"+person.ID+"/consent", apptest.AnyMap{
 		"purpose_id": purpose.ID, "new_state": "granted", "lawful_basis": "consent",
 	}, nil, nil); status != http.StatusOK {
 		t.Fatalf("record consent → %d", status)
@@ -87,15 +88,15 @@ func setupVoiceSend(t *testing.T) *voiceSendEnv {
 	var activity struct {
 		ID string `json:"id"`
 	}
-	if status := e.call(t, "POST", "/v1/activities", anyMap{
+	if status := e.Call(t, "POST", "/v1/activities", apptest.AnyMap{
 		"kind": "email", "subject": "Pricing question", "direction": "inbound",
-		"links": []anyMap{{"entity_type": "person", "entity_id": person.ID}},
+		"links": []apptest.AnyMap{{"entity_type": "person", "entity_id": person.ID}},
 	}, nil, &activity); status != http.StatusCreated {
 		t.Fatalf("log anchor activity → %d", status)
 	}
 
 	return &voiceSendEnv{
-		env: e, workspaceID: workspaceID, ownerID: ownerID,
+		AppEnv: e, workspaceID: workspaceID, ownerID: ownerID,
 		profileID: profile.ID, activityID: activity.ID,
 	}
 }
@@ -119,14 +120,14 @@ func (e *voiceSendEnv) openVoiceDraft(t *testing.T, opts voiceDraftOptions) (ref
 	profileID, ownerID := any(e.profileID), e.ownerID
 	if opts.foreignOwner {
 		var colleague ids.UUID
-		if err := e.owner.QueryRow(ctx, `
+		if err := e.Owner.QueryRow(ctx, `
 			INSERT INTO app_user (workspace_id, email, display_name)
 			VALUES ($1, $2, 'Colleague') RETURNING id`,
 			e.workspaceID, "colleague-"+ids.NewV7().String()+"@example.test").Scan(&colleague); err != nil {
 			t.Fatalf("seeding the colleague: %v", err)
 		}
 		var foreign ids.UUID
-		if err := e.owner.QueryRow(ctx, `
+		if err := e.Owner.QueryRow(ctx, `
 			INSERT INTO voice_profile (workspace_id, owner_id, scope, status, source, captured_by)
 			VALUES ($1, $2, 'user', 'ready', 'ui', $3) RETURNING id`,
 			e.workspaceID, colleague, "human:"+colleague.String()).Scan(&foreign); err != nil {
@@ -141,7 +142,7 @@ func (e *voiceSendEnv) openVoiceDraft(t *testing.T, opts voiceDraftOptions) (ref
 	if opts.erased {
 		generated, erasedAt = nil, time.Now().UTC()
 	}
-	if err := e.owner.QueryRow(ctx, `
+	if err := e.Owner.QueryRow(ctx, `
 		INSERT INTO voice_learning_signal
 		  (workspace_id, voice_profile_id, draft_ref_hash, outcome, generated_original,
 		   content_erased_at, retention_until, source, captured_by)
@@ -161,7 +162,7 @@ func (e *voiceSendEnv) send(t *testing.T, ref, body string) ids.UUID {
 	var sent struct {
 		ID string `json:"id"`
 	}
-	if status := e.call(t, "POST", "/v1/activities/"+e.activityID+"/send-email", anyMap{
+	if status := e.Call(t, "POST", "/v1/activities/"+e.activityID+"/send-email", apptest.AnyMap{
 		"to": []string{"reader@buyer.test"}, "subject": "Pricing",
 		"body": body, "consent_purpose": "newsletter", "draft_ref": ref,
 	}, nil, &sent); status != http.StatusAccepted {
@@ -179,7 +180,7 @@ func (e *voiceSendEnv) send(t *testing.T, ref, body string) ids.UUID {
 func (e *voiceSendEnv) transmittedBody(t *testing.T, activityID ids.UUID) string {
 	t.Helper()
 	var body string
-	if err := e.inWorkspace(t, e.slug, func(tx pgx.Tx) error {
+	if err := inWorkspace(e.AppEnv, t, e.Slug, func(tx pgx.Tx) error {
 		return tx.QueryRow(context.Background(),
 			`SELECT body FROM comms_outbound WHERE activity_id = $1`, activityID).Scan(&body)
 	}); err != nil {
@@ -200,7 +201,7 @@ type voiceSignal struct {
 func (e *voiceSendEnv) readSignal(t *testing.T, signal ids.UUID) voiceSignal {
 	t.Helper()
 	var row voiceSignal
-	if err := e.owner.QueryRow(context.Background(), `
+	if err := e.Owner.QueryRow(context.Background(), `
 		SELECT outcome, similarity::double precision, generated_original, content_erased_at, version
 		FROM voice_learning_signal WHERE id = $1`, signal).Scan(
 		&row.outcome, &row.similarity, &row.generatedOriginal, &row.contentErasedAt, &row.version); err != nil {

--- a/backend/internal/compose/integration/voicepreview_http_integration_test.go
+++ b/backend/internal/compose/integration/voicepreview_http_integration_test.go
@@ -15,6 +15,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 )
 
 type voicePreviewWire struct {
@@ -47,14 +49,14 @@ const previewMeetingTranscript = "00:00:00 Lars Jankowfsky\n" +
 	"And a second turn of mine."
 
 func TestVoiceCorpusPreviewAndIngestStatsHTTP(t *testing.T) {
-	e := setup(t)
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupApp(t)
+	e.BootstrapWorkspace(t)
 	created := createVoiceProfile(t, e)
 	base := "/v1/voice-profiles/" + created.ID
 
 	var preview voicePreviewWire
-	if status := e.call(t, "POST", base+"/sources/preview",
-		anyMap{"format": "transcript", "content": previewMeetingTranscript},
+	if status := e.Call(t, "POST", base+"/sources/preview",
+		apptest.AnyMap{"format": "transcript", "content": previewMeetingTranscript},
 		nil, &preview); status != http.StatusOK {
 		t.Fatalf("preview → %d", status)
 	}
@@ -78,20 +80,20 @@ func TestVoiceCorpusPreviewAndIngestStatsHTTP(t *testing.T) {
 
 	// The raw request keeps the response headers: the refusal contract is
 	// the 422 body AND its problem+json media type.
-	rawBody, err := json.Marshal(anyMap{"format": "docx", "content": "binary"})
+	rawBody, err := json.Marshal(apptest.AnyMap{"format": "docx", "content": "binary"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	req, err := http.NewRequest("POST", e.ts.URL+base+"/sources/preview", bytes.NewReader(rawBody))
+	req, err := http.NewRequest("POST", e.TS.URL+base+"/sources/preview", bytes.NewReader(rawBody))
 	if err != nil {
 		t.Fatal(err)
 	}
 	req.Header.Set("Content-Type", "application/json")
-	resp, err := e.client.Do(req)
+	resp, err := e.Client.Do(req) //nolint:bodyclose // closed by the deferred apptest.CloseBody below; bodyclose only sees a Close in the same package, and the closer moved out with the fixture
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer closeBody(t, resp)
+	defer apptest.CloseBody(t, resp)
 	if resp.StatusCode != http.StatusUnprocessableEntity {
 		t.Fatalf("unknown format preview → %d, want 422", resp.StatusCode)
 	}
@@ -116,7 +118,7 @@ func TestVoiceCorpusPreviewAndIngestStatsHTTP(t *testing.T) {
 			SpeakersSeen   []string `json:"speakers_seen"`
 		} `json:"ingest_stats"`
 	}
-	if status := e.call(t, "POST", base+"/sources", anyMap{
+	if status := e.Call(t, "POST", base+"/sources", apptest.AnyMap{
 		"kind": "transcript", "register": "spoken", "source_label": "Meeting",
 		"source_ref": "meeting-1", "format": "transcript",
 		"speaker_label": "Lars Jankowfsky", "content": previewMeetingTranscript,
@@ -135,7 +137,7 @@ func TestVoiceCorpusPreviewAndIngestStatsHTTP(t *testing.T) {
 	}
 
 	var unlabeled problemWire
-	if status := e.call(t, "POST", base+"/sources", anyMap{
+	if status := e.Call(t, "POST", base+"/sources", apptest.AnyMap{
 		"kind": "transcript", "register": "spoken", "source_label": "Meeting",
 		"source_ref": "meeting-2", "format": "transcript",
 		"content": previewMeetingTranscript,

--- a/backend/internal/compose/integration/webhooks_integration_test.go
+++ b/backend/internal/compose/integration/webhooks_integration_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	"github.com/gradionhq/margince/backend/internal/modules/identity"
 	"github.com/gradionhq/margince/backend/internal/modules/webhooks"
 	kevents "github.com/gradionhq/margince/backend/internal/shared/kernel/events"
@@ -68,7 +69,7 @@ func (f failingResolver) SeatType(context.Context, ids.UUID, ids.UUID) (principa
 // so a test can both register a subscription (over HTTP) and drive the
 // deliverer (against the same DB, sealing under the same key).
 type webhookEnv struct {
-	*env
+	*apptest.AppEnv
 	pool   *pgxpool.Pool
 	cipher *webhooks.Cipher
 	wsID   ids.UUID
@@ -83,15 +84,15 @@ func setupWebhooks(t *testing.T) *webhookEnv {
 	if err != nil {
 		t.Fatalf("cipher: %v", err)
 	}
-	e := setupWithOptions(t, compose.WithWebhookSigningKey(cipher))
-	e.bootstrapWorkspace(t)
+	e := apptest.SetupAppWithOptions(t, compose.WithWebhookSigningKey(cipher))
+	e.BootstrapWorkspace(t)
 
 	var wsID ids.UUID
-	if err := e.owner.QueryRow(context.Background(),
-		`SELECT id FROM workspace WHERE slug = $1`, e.slug).Scan(&wsID); err != nil {
+	if err := e.Owner.QueryRow(context.Background(),
+		`SELECT id FROM workspace WHERE slug = $1`, e.Slug).Scan(&wsID); err != nil {
 		t.Fatalf("workspace lookup: %v", err)
 	}
-	return &webhookEnv{env: e, pool: e.pool, cipher: cipher, wsID: wsID}
+	return &webhookEnv{AppEnv: e, pool: e.Pool, cipher: cipher, wsID: wsID}
 }
 
 // receiver is a controllable webhook endpoint: it records every POST and
@@ -205,7 +206,7 @@ func (we *webhookEnv) createSubscription(t *testing.T, target string, eventTypes
 		} `json:"subscription"`
 		SigningSecret string `json:"signing_secret"`
 	}
-	status := we.call(t, "POST", "/v1/webhook-subscriptions", anyMap{
+	status := we.Call(t, "POST", "/v1/webhook-subscriptions", apptest.AnyMap{
 		"target_url": target, "event_types": eventTypes,
 	}, nil, &created)
 	if status != http.StatusCreated {
@@ -241,19 +242,19 @@ func TestWebhookSubscriptionCRUDOverHTTP(t *testing.T) {
 	we := setupWebhooks(t)
 
 	// http:// is rejected at create.
-	if status := we.call(t, "POST", "/v1/webhook-subscriptions", anyMap{
+	if status := we.Call(t, "POST", "/v1/webhook-subscriptions", apptest.AnyMap{
 		"target_url": "http://insecure.example/hook", "event_types": []string{"deal.created"},
 	}, nil, nil); status != 422 {
 		t.Fatalf("http target → %d, want 422", status)
 	}
 	// An unknown event type is rejected.
-	if status := we.call(t, "POST", "/v1/webhook-subscriptions", anyMap{
+	if status := we.Call(t, "POST", "/v1/webhook-subscriptions", apptest.AnyMap{
 		"target_url": "https://ok.example/hook", "event_types": []string{"nonsense.happened"},
 	}, nil, nil); status != 422 {
 		t.Fatalf("unknown event type → %d, want 422", status)
 	}
 	// A pipeline (entity-less) event type is not subscribable (BYO-EVT-4).
-	if status := we.call(t, "POST", "/v1/webhook-subscriptions", anyMap{
+	if status := we.Call(t, "POST", "/v1/webhook-subscriptions", apptest.AnyMap{
 		"target_url": "https://ok.example/hook", "event_types": []string{"capture.received"},
 	}, nil, nil); status != 422 {
 		t.Fatalf("pipeline event type → %d, want 422", status)
@@ -268,7 +269,7 @@ func TestWebhookSubscriptionCRUDOverHTTP(t *testing.T) {
 			SigningSecret string `json:"signing_secret"`
 		} `json:"data"`
 	}
-	if status := we.call(t, "GET", "/v1/webhook-subscriptions", nil, nil, &list); status != http.StatusOK {
+	if status := we.Call(t, "GET", "/v1/webhook-subscriptions", nil, nil, &list); status != http.StatusOK {
 		t.Fatalf("list → %d", status)
 	}
 	if len(list.Data) != 1 || list.Data[0].ID != subID {
@@ -280,7 +281,7 @@ func TestWebhookSubscriptionCRUDOverHTTP(t *testing.T) {
 
 	// The secret is NEVER returned by a read.
 	var got map[string]any
-	if status := we.call(t, "GET", "/v1/webhook-subscriptions/"+subID, nil, nil, &got); status != http.StatusOK {
+	if status := we.Call(t, "GET", "/v1/webhook-subscriptions/"+subID, nil, nil, &got); status != http.StatusOK {
 		t.Fatalf("get → %d", status)
 	}
 	if _, leaked := got["signing_secret"]; leaked {
@@ -294,7 +295,7 @@ func TestWebhookSubscriptionCRUDOverHTTP(t *testing.T) {
 	var rotated struct {
 		SigningSecret string `json:"signing_secret"`
 	}
-	if status := we.call(t, "POST", "/v1/webhook-subscriptions/"+subID+"/rotate-secret", nil, nil, &rotated); status != http.StatusOK {
+	if status := we.Call(t, "POST", "/v1/webhook-subscriptions/"+subID+"/rotate-secret", nil, nil, &rotated); status != http.StatusOK {
 		t.Fatalf("rotate → %d", status)
 	}
 	if rotated.SigningSecret == "" || rotated.SigningSecret == secret {
@@ -303,18 +304,18 @@ func TestWebhookSubscriptionCRUDOverHTTP(t *testing.T) {
 
 	// An empty update body is a 422 at runtime, matching the contract's
 	// minProperties:1 — never a silent no-op.
-	if status := we.call(t, "PATCH", "/v1/webhook-subscriptions/"+subID, anyMap{}, nil, nil); status != 422 {
+	if status := we.Call(t, "PATCH", "/v1/webhook-subscriptions/"+subID, apptest.AnyMap{}, nil, nil); status != 422 {
 		t.Fatalf("empty PATCH → %d, want 422", status)
 	}
 
 	// Pause via PATCH, then archive.
-	if status := we.call(t, "PATCH", "/v1/webhook-subscriptions/"+subID, anyMap{"state": "paused"}, nil, nil); status != http.StatusOK {
+	if status := we.Call(t, "PATCH", "/v1/webhook-subscriptions/"+subID, apptest.AnyMap{"state": "paused"}, nil, nil); status != http.StatusOK {
 		t.Fatalf("pause → %d", status)
 	}
-	if status := we.call(t, "DELETE", "/v1/webhook-subscriptions/"+subID, nil, nil, nil); status != http.StatusOK {
+	if status := we.Call(t, "DELETE", "/v1/webhook-subscriptions/"+subID, nil, nil, nil); status != http.StatusOK {
 		t.Fatalf("archive → %d", status)
 	}
-	if status := we.call(t, "GET", "/v1/webhook-subscriptions/"+subID, nil, nil, nil); status != http.StatusNotFound {
+	if status := we.Call(t, "GET", "/v1/webhook-subscriptions/"+subID, nil, nil, nil); status != http.StatusNotFound {
 		t.Fatalf("archived subscription still visible → %d, want 404", status)
 	}
 }
@@ -406,7 +407,7 @@ func TestWebhookFanOutStopsAtRevokedOwner(t *testing.T) {
 	// Revoke the owner (the bootstrap admin) by archiving the user row,
 	// through a workspace-bound owner tx so FORCE RLS admits the update.
 	ctx := context.Background()
-	tx, err := we.owner.Begin(ctx)
+	tx, err := we.Owner.Begin(ctx)
 	if err != nil {
 		t.Fatalf("begin: %v", err)
 	}
@@ -686,7 +687,7 @@ func (we *webhookEnv) execInWorkspace(t *testing.T, sql string, args ...any) int
 func (we *webhookEnv) inWorkspaceTx(t *testing.T, run func(pgx.Tx) error) {
 	t.Helper()
 	ctx := context.Background()
-	tx, err := we.owner.Begin(ctx)
+	tx, err := we.Owner.Begin(ctx)
 	if err != nil {
 		t.Fatalf("begin: %v", err)
 	}
@@ -765,7 +766,7 @@ func TestWebhookRetryThenDeadLetterThenReplay(t *testing.T) {
 			Status string `json:"status"`
 		} `json:"data"`
 	}
-	if status := we.call(t, "GET", "/v1/webhook-subscriptions/"+subID+"/deliveries", nil, nil, &deliveries); status != http.StatusOK {
+	if status := we.Call(t, "GET", "/v1/webhook-subscriptions/"+subID+"/deliveries", nil, nil, &deliveries); status != http.StatusOK {
 		t.Fatalf("list deliveries → %d", status)
 	}
 	if len(deliveries.Data) != 1 || deliveries.Data[0].Status != "dead_lettered" {
@@ -778,7 +779,7 @@ func TestWebhookRetryThenDeadLetterThenReplay(t *testing.T) {
 	// answers 200 with the re-attempted delivery — exercising the handler
 	// path; the direct-engine replay below then proves the delivered path
 	// against the injectable (unguarded) test client.
-	if status := we.call(t, "POST", "/v1/webhook-subscriptions/"+subID+"/deliveries/"+deliveryID+"/replay", nil, nil, nil); status != http.StatusOK {
+	if status := we.Call(t, "POST", "/v1/webhook-subscriptions/"+subID+"/deliveries/"+deliveryID+"/replay", nil, nil, nil); status != http.StatusOK {
 		t.Fatalf("http replay → %d, want 200", status)
 	}
 
@@ -836,7 +837,7 @@ func assertDeliveryStatus(t *testing.T, we *webhookEnv, subID, wantStatus string
 			Attempts int    `json:"attempts"`
 		} `json:"data"`
 	}
-	if status := we.call(t, "GET", "/v1/webhook-subscriptions/"+subID+"/deliveries", nil, nil, &deliveries); status != http.StatusOK {
+	if status := we.Call(t, "GET", "/v1/webhook-subscriptions/"+subID+"/deliveries", nil, nil, &deliveries); status != http.StatusOK {
 		t.Fatalf("list deliveries → %d", status)
 	}
 	if len(deliveries.Data) != 1 {
@@ -869,8 +870,8 @@ func mustParseUUID(t *testing.T, s string) ids.UUID {
 // documented wire contract (or vice versa) is still caught.
 func TestDealStageChangedPayloadConformsToPublicSchema(t *testing.T) {
 	we := setupWebhooks(t)
-	stages := discoverSeededPipeline(t, we.env)
-	dealID := exerciseDealToWon(t, we.env, stages)
+	stages := discoverSeededPipeline(t, we.AppEnv)
+	dealID := exerciseDealToWon(t, we.AppEnv, stages)
 
 	data := realEventPayload(t, we, "deal.stage_changed", dealID)
 	schema := publicEventSchema(t, "PublicEventDealStageChanged")
@@ -891,8 +892,8 @@ func TestDealStageChangedPayloadConformsToPublicSchema(t *testing.T) {
 // level (wireenvelope_test.go covers the pure mapping in isolation).
 func TestPublicEventEnvelopeConformsToPublicSchema(t *testing.T) {
 	we := setupWebhooks(t)
-	stages := discoverSeededPipeline(t, we.env)
-	dealID := exerciseDealToWon(t, we.env, stages)
+	stages := discoverSeededPipeline(t, we.AppEnv)
+	dealID := exerciseDealToWon(t, we.AppEnv, stages)
 	env := realEventEnvelope(t, we, "deal.stage_changed", dealID)
 
 	rcv := newReceiver(t, http.StatusOK)
@@ -926,7 +927,7 @@ func TestPublicEventEnvelopeConformsToPublicSchema(t *testing.T) {
 func realEventEnvelope(t *testing.T, we *webhookEnv, eventType, entityID string) kevents.Envelope {
 	t.Helper()
 	var raw []byte
-	err := we.owner.QueryRow(context.Background(),
+	err := we.Owner.QueryRow(context.Background(),
 		`SELECT envelope FROM event_outbox
 		 WHERE envelope->>'type' = $1 AND envelope->'entity'->>'id' = $2
 		 ORDER BY seq DESC LIMIT 1`,

--- a/backend/jobfleetscan_test.go
+++ b/backend/jobfleetscan_test.go
@@ -40,7 +40,15 @@ const fleetScanMarker = "FROM workspace"
 // construction — with the exception of a SET-valued RHS, which setPredicates
 // takes back. Checked on the marker's own line and the one after it, because
 // the repo splits some query literals across lines.
-var singleRowPredicates = []string{"WHERE id = ", "WHERE id=", "WHERE w.id = "}
+// slug is the workspace's other unique key (0002_identity.up.sql,
+// workspace_slug_unique), so a lookup by it reads exactly one row for the same
+// reason a lookup by id does. Named here rather than waived per file: a site
+// that resolves ONE workspace by its unique key is not the anti-pattern this
+// gate is about, and teaching that once beats granting it repeatedly.
+var singleRowPredicates = []string{
+	"WHERE id = ", "WHERE id=", "WHERE w.id = ",
+	"WHERE slug = ", "WHERE slug=",
+}
 
 // setPredicates are the RHS spellings that equate id to a SET rather than to
 // one value. They look like a single-row predicate to the prefixes above and


### PR DESCRIPTION
The third and last integration fixture to become importable, and the prerequisite every remaining suite group in #546 was waiting on. `AppEnv`, its three constructors, the three methods every suite calls and the `AnyMap` alias now live in `internal/compose/integration/apptest`.

**Stacked on #568** — review the top commit; the rest is that PR.

## Why a separate package, not a non-test file next to harness.go

Because the build refused the obvious thing. `package compose`'s own white-box tests import `package integration`, so nothing there may import `compose` — and this fixture boots a compose handler stack:

```
package .../internal/compose/integration
	imports .../internal/compose/integration/apptest from activity_lifecycle_integration_test.go
	imports .../internal/compose/integration from appenv.go: import cycle not allowed in test
```

`harness.go`'s doc has stated that constraint since it was written. I identified it earlier in this work, then put the fixture there anyway; the compiler corrected me. One level down, importing compose is free.

The direction is load-bearing in **both** senses: `apptest` must not import `integration` either, or the cycle closes from that side, since `integration`'s suites import `apptest`. `applyRiverSchema` is duplicated across that boundary for exactly that reason and says so — and the original cannot move here, because `package compose`'s tests use it too and would then reach compose through it.

The type is `AppEnv`, not `Env`: `integration.Env` is the database fixture.

## What moved, and what deliberately did not

Moving the type to another package makes **every method on it illegal outside that package**, so the sixteen a suite kept for itself are now plain functions taking the fixture. Only three were promoted with it — `Call`, `BootstrapWorkspace`, `SetWorkspaceSeat` — plus the two package-level helpers those call, which a non-test file cannot reach in a `_test.go` one.

`inWorkspace` looked shared at twelve files and is not: all twelve are outbound messaging. `listTools`/`getJSON`/`raw` are the MCP suites. Those travel with their own group, which is the rule the package doc states.

## Scope note

The plan called for a smaller first step — type promotion with fields left unexported. I did the whole promotion instead, because stopping there ships an **inert** PR: a fixture whose fields no sibling can read. That is exactly the defect review caught in #563, and both halves touch the same 76 files, so splitting doubles the review surface rather than halving it.

## Four gates had something to say once the code left a test file

Same discovery as the migrate-once gate two changes ago: a gate keyed on the `_test.go` suffix silently judges less when a fixture is promoted.

- **noctx** wanted `NewRequestWithContext`. Right — test files were exempt, a non-test file is not.
- **bodyclose** lost sight of every close, because the closer moved out with the fixture. Waived per site, and the sweep **refused to waive one where it could not first see the `CloseBody`** — that one turned out to close eight lines down rather than deferred, so its waiver says that instead of the boilerplate reason.
- **revive** wanted the docs to name the exported symbols. They described unexported ones.
- **the fleet-scan gate** flagged the fixture's workspace lookup. `slug` is a unique key (`0002_identity.up.sql`, `workspace_slug_unique`), so a lookup by it reads one row for the same reason a lookup by id does. The gate is taught that once rather than granted a waiver per site. Mutation-tested: a bare `SELECT id FROM workspace` and a `WHERE slug = ANY(...)` set-read both still fail it, so widening the predicate did not blind it.

## Verification

- **Importability is checked, not claimed.** A throwaway sibling package calling `SetupApp`, `BootstrapWorkspace`, `SetWorkspaceSeat` and `Call` compiles; it would not have before. #563 asserted this and was wrong, so it is a test now.
- **968 top-level tests before, 968 after.**
- `make check-backend`, `make lint` (0 issues), `make craft-static` (0 findings), `go vet -tags=integration` — green.
- **The full integration lane was run** on this tree: `OK: integration passed with 0 skips (27 packages, parallel)`, 397s wall.

## What it buys, measured

Now that the lane has actually been run back-to-back on one machine, with untouched packages as a control: the split so far cuts the lane's floor about **20%**, not the 3× I projected earlier from a model. The parent is still 349.6s and 88% of the wall clock. This PR adds no speed of its own — it is the prerequisite that makes the remaining cuts possible, and by measured seconds only overlay (41.3s) is still worth cutting before the better lever, #539.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promoted the booted-app integration fixture into `internal/compose/integration/apptest` as `AppEnv`, making it importable and removing the compose/integration import cycle. All integration suites now use this package; behavior is unchanged, and comments/docs were updated (including removing a duplicate `CloseBody` doc).

- **Refactors**
  - Added `apptest` with `AppEnv` (TLS test server + cookie-jar client) and `AnyMap`.
  - Public API: `SetupApp`, `SetupAppWithOptions`, `SetupAppWithOriginOptions`, `Call`, `BootstrapWorkspace`, `SetWorkspaceSeat`; helper `BootstrapWorkspaceSession`; `CloseBody`.
  - Exported `AppEnv` fields: `Slug`, `Owner`, `Pool`, `TS`, `Client`; suites updated.
  - Kept suite-specific helpers local (e.g., MCP); duplicated `ApplyRiverSchema` to avoid cycles.
  - Tightened workspace lookup by slug; addressed lints (`NewRequestWithContext`, response body closes); added package docs on import direction.
  - Swept and fixed stale comments to match promoted symbols; removed the duplicate `CloseBody` doc block.

- **Migration**
  - Import `github.com/gradionhq/margince/backend/internal/compose/integration/apptest`.
  - Replace setup: `setup(...)` → `apptest.SetupApp(...)` (or `SetupAppWithOptions`, `SetupAppWithOriginOptions`).
  - Replace env members and calls: `e.slug/owner/pool/ts/client` → `e.Slug/Owner/Pool/TS/Client`; `e.call(...)` → `e.Call(...)`; `e.bootstrapWorkspace(...)` → `e.BootstrapWorkspace(...)`.
  - Use `apptest.BootstrapWorkspaceSession`, `apptest.AnyMap`, and `apptest.CloseBody` where needed.

<sup>Written for commit d981a774c785a6165bfb5fd4db0c68b65823c8ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/574?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

