### PR TITLE
docs: note the CODEOWNERS coverage of extension paths

### DIFF
--- a/docs/how-to/add-an-extension.md
+++ b/docs/how-to/add-an-extension.md
@@ -11,6 +11,10 @@ An extension is its own Go module reaching the core through only the marker-allo
 flip. `extensions/de` (Germany), `extensions/yogi` (one served agent tool) and
 `fixtures/extensions/crm-hello` (the walking-skeleton reference) are the units to copy from.
 
+Extension paths — the units, the `backend/pkg/**` seam, the composition stub and generator — carry
+a [CODEOWNERS](../../.github/CODEOWNERS) entry, so a PR touching them automatically requests the
+tier owner's review.
+
 ## Scaffold the unit
 
 1. **Create the module directory** `extensions/<name>/` — the directory name is the canonical unit


### PR DESCRIPTION
Documents in the add-an-extension guide that extension paths carry a CODEOWNERS entry. Doubles as the live verification that a PR touching an owned path (`docs/how-to/add-an-extension.md`) gets the code-owner treatment in the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a note to `docs/how-to/add-an-extension.md` that extension units, the `backend/pkg/**` seam, and the composition stub and generator are covered by `CODEOWNERS`, so PRs touching them automatically request the tier owner's review.

<sup>Written for commit daf9ac493870d0fd3708c7318695851cf8db2b60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

