### PR TITLE
refactor(test): the overlay suites become their own integration package

### DIFF
--- a/backend/internal/compose/dispatcher_test.go
+++ b/backend/internal/compose/dispatcher_test.go
@@ -14,7 +14,7 @@ package compose
 // touching a mirror store. d.native is left nil: the overlay=true seed
 // guarantees it is never dereferenced. The native-mode branch (and the
 // real cache-miss DB query) is proven end to end by
-// compose/integration/overlay_dispatch_integration_test.go, which needs
+// compose/integration/overlay/overlay_dispatch_integration_test.go, which needs
 // a real, migrated Postgres.
 
 import (

--- a/backend/internal/compose/integration/bundle.go
+++ b/backend/internal/compose/integration/bundle.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/csv"
+	"io"
+	"testing"
+)
+
+// Readers for the export bundle: a zip of CSVs. Exported because the suites that
+// assert on a bundle's contents sit on both sides of the overlay split — the
+// export suites here, the mirror-flip suite in the overlay package — and both
+// want the same parse rather than two that could disagree about a header row.
+
+// BundleEntries reads the produced ZIP into name→bytes.
+func BundleEntries(t *testing.T, raw []byte) map[string][]byte {
+	t.Helper()
+	zr, err := zip.NewReader(bytes.NewReader(raw), int64(len(raw)))
+	if err != nil {
+		t.Fatalf("opening bundle zip: %v", err)
+	}
+	entries := map[string][]byte{}
+	for _, f := range zr.File {
+		rc, err := f.Open()
+		if err != nil {
+			t.Fatalf("opening %s: %v", f.Name, err)
+		}
+		data, err := io.ReadAll(rc)
+		if err != nil {
+			t.Fatalf("reading %s: %v", f.Name, err)
+		}
+		if err := rc.Close(); err != nil {
+			t.Fatalf("closing %s: %v", f.Name, err)
+		}
+		entries[f.Name] = data
+	}
+	return entries
+}
+
+// CSVColumn parses a CSV entry and returns the values under one column —
+// the format-validity check (csv.Reader fails loudly on a malformed file)
+// doubling as the content probe.
+func CSVColumn(t *testing.T, raw []byte, column string) []string {
+	t.Helper()
+	records, err := csv.NewReader(bytes.NewReader(raw)).ReadAll()
+	if err != nil {
+		t.Fatalf("parsing csv: %v", err)
+	}
+	if len(records) == 0 {
+		t.Fatal("csv has no header row")
+	}
+	idx := -1
+	for i, h := range records[0] {
+		if h == column {
+			idx = i
+		}
+	}
+	if idx == -1 {
+		t.Fatalf("csv has no %q column; header=%v", column, records[0])
+	}
+	var out []string
+	for _, row := range records[1:] {
+		out = append(out, row[idx])
+	}
+	return out
+}

--- a/backend/internal/compose/integration/bundle.go
+++ b/backend/internal/compose/integration/bundle.go
@@ -19,6 +19,11 @@ import (
 // want the same parse rather than two that could disagree about a header row.
 
 // BundleEntries reads the produced ZIP into name→bytes.
+//
+// A repeated member name is a failure, not a last-one-wins overwrite: zip
+// permits duplicates, and a map would silently keep only the final copy — so a
+// bundle that shipped two conflicting overlay_mirror.csv entries would satisfy
+// every assertion against whichever came last.
 func BundleEntries(t *testing.T, raw []byte) map[string][]byte {
 	t.Helper()
 	zr, err := zip.NewReader(bytes.NewReader(raw), int64(len(raw)))
@@ -37,6 +42,9 @@ func BundleEntries(t *testing.T, raw []byte) map[string][]byte {
 		}
 		if err := rc.Close(); err != nil {
 			t.Fatalf("closing %s: %v", f.Name, err)
+		}
+		if _, dup := entries[f.Name]; dup {
+			t.Fatalf("the bundle carries %s twice — assertions would have read only the second copy", f.Name)
 		}
 		entries[f.Name] = data
 	}

--- a/backend/internal/compose/integration/capture/doc.go
+++ b/backend/internal/compose/integration/capture/doc.go
@@ -14,11 +14,8 @@
 // fixtures (SearchEnv mostly, Env in one suite) and its shared seed, job-wait and
 // HTTP-stub helpers; it owns its own connector stubs, seeding and assertions.
 //
-// One capture suite did NOT come along: capturedbykind_http_integration_test.go
-// drives the booted-app fixture, which was still trapped in a test file when
-// this package was carved out. It has since been promoted to
-// integration/apptest, so nothing holds that suite here any more — it should
-// join this package the next time someone is in the area.
+// One capture suite is not here: capturedbykind_http_integration_test.go rides
+// the booted-app fixture and lives in the parent package.
 //
 // The production capture module is imported as capturemod, because inside a
 // package named capture a bare capture.X reads as a self-reference.

--- a/backend/internal/compose/integration/capture/doc.go
+++ b/backend/internal/compose/integration/capture/doc.go
@@ -15,9 +15,10 @@
 // HTTP-stub helpers; it owns its own connector stubs, seeding and assertions.
 //
 // One capture suite did NOT come along: capturedbykind_http_integration_test.go
-// drives the booted-app fixture in the parent's e2e_integration_test.go, which is
-// declared in a test file and so is not importable. It stays there until that
-// fixture is promoted the way SearchEnv was.
+// drives the booted-app fixture, which was still trapped in a test file when
+// this package was carved out. It has since been promoted to
+// integration/apptest, so nothing holds that suite here any more — it should
+// join this package the next time someone is in the area.
 //
 // The production capture module is imported as capturemod, because inside a
 // package named capture a bare capture.X reads as a self-reference.

--- a/backend/internal/compose/integration/customfields_http_assertions_test.go
+++ b/backend/internal/compose/integration/customfields_http_assertions_test.go
@@ -415,7 +415,7 @@ func containsID(fields []customFieldWire, id string) bool {
 }
 
 // assertUnwired501 boots a SEPARATE server with no schema pool (the plain
-// setup(t) default) and proves both runtime-DDL operations answer 501
+// apptest.SetupApp default) and proves both runtime-DDL operations answer 501
 // rather than nil-derefing — renameCustomField/retireCustomField/
 // listCustomFields need no schema pool and are covered by the other
 // subtests above, all of which ride the schema-wired server.

--- a/backend/internal/compose/integration/e2e_agent_integration_test.go
+++ b/backend/internal/compose/integration/e2e_agent_integration_test.go
@@ -8,8 +8,8 @@ package integration
 // End-to-end lane, agent-governance slice: the passport Bearer surface
 // (mint → ride → revoke), the ADR-0055 governed agent writes (🟢 lands
 // with agent provenance, 🟡 stages an approval a human must decide), and
-// the C2 read-seat capability ceiling. Shares setup/env/call with
-// e2e_integration_test.go.
+// the C2 read-seat capability ceiling. Rides apptest.AppEnv, the same booted
+// application the rest of the e2e lane does.
 
 import (
 	"strings"

--- a/backend/internal/compose/integration/export_integration_test.go
+++ b/backend/internal/compose/integration/export_integration_test.go
@@ -13,12 +13,9 @@ package integration
 // would be a data breach, so that exclusion is a pinned test.
 
 import (
-	"archive/zip"
 	"bytes"
 	"context"
-	"encoding/csv"
 	"encoding/json"
-	"io"
 	"strings"
 	"testing"
 
@@ -123,59 +120,6 @@ func (e *SearchEnv) seedExportFixture(t *testing.T) exportFixture {
 	return f
 }
 
-// bundleEntries reads the produced ZIP into name→bytes.
-func bundleEntries(t *testing.T, raw []byte) map[string][]byte {
-	t.Helper()
-	zr, err := zip.NewReader(bytes.NewReader(raw), int64(len(raw)))
-	if err != nil {
-		t.Fatalf("opening bundle zip: %v", err)
-	}
-	entries := map[string][]byte{}
-	for _, f := range zr.File {
-		rc, err := f.Open()
-		if err != nil {
-			t.Fatalf("opening %s: %v", f.Name, err)
-		}
-		data, err := io.ReadAll(rc)
-		if err != nil {
-			t.Fatalf("reading %s: %v", f.Name, err)
-		}
-		if err := rc.Close(); err != nil {
-			t.Fatalf("closing %s: %v", f.Name, err)
-		}
-		entries[f.Name] = data
-	}
-	return entries
-}
-
-// csvColumn parses a CSV entry and returns the values under one column —
-// the format-validity check (csv.Reader fails loudly on a malformed file)
-// doubling as the content probe.
-func csvColumn(t *testing.T, raw []byte, column string) []string {
-	t.Helper()
-	records, err := csv.NewReader(bytes.NewReader(raw)).ReadAll()
-	if err != nil {
-		t.Fatalf("parsing csv: %v", err)
-	}
-	if len(records) == 0 {
-		t.Fatal("csv has no header row")
-	}
-	idx := -1
-	for i, h := range records[0] {
-		if h == column {
-			idx = i
-		}
-	}
-	if idx == -1 {
-		t.Fatalf("csv has no %q column; header=%v", column, records[0])
-	}
-	var out []string
-	for _, row := range records[1:] {
-		out = append(out, row[idx])
-	}
-	return out
-}
-
 func TestExportBundleCompleteAndValidOpenFormat(t *testing.T) {
 	e := SetupSearch(t)
 	f := e.seedExportFixture(t)
@@ -185,7 +129,7 @@ func TestExportBundleCompleteAndValidOpenFormat(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	entries := bundleEntries(t, buf.Bytes())
+	entries := BundleEntries(t, buf.Bytes())
 
 	// Every member CSV, the relational dump, the files manifest, and the
 	// bundle manifest are present.
@@ -200,7 +144,7 @@ func TestExportBundleCompleteAndValidOpenFormat(t *testing.T) {
 	}
 
 	// The admin (row_scope=all) sees both reps' rows — completeness.
-	if got := len(csvColumn(t, entries["person.csv"], "id")); got != 2 {
+	if got := len(CSVColumn(t, entries["person.csv"], "id")); got != 2 {
 		t.Fatalf("person.csv has %d rows, want 2 (both reps)", got)
 	}
 	if summary.RowCounts["deal"] != 2 || summary.RowCounts["relationship"] != 2 {
@@ -254,10 +198,10 @@ func TestExportRowScopeExcludesInvisibleRecords(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	entries := bundleEntries(t, buf.Bytes())
+	entries := BundleEntries(t, buf.Bytes())
 
 	assertOnlyID := func(file string, want, hidden ids.UUID) {
-		rowIDs := csvColumn(t, entries[file], "id")
+		rowIDs := CSVColumn(t, entries[file], "id")
 		set := map[string]bool{}
 		for _, id := range rowIDs {
 			set[id] = true
@@ -280,12 +224,12 @@ func TestExportRowScopeExcludesInvisibleRecords(t *testing.T) {
 		t.Fatalf("row-scope leak: relationship count = %d, want 1", got)
 	}
 	// The attachment (files manifest) hides the other rep's file.
-	entIDs := csvColumn(t, entries["attachment.csv"], "entity_id")
+	entIDs := CSVColumn(t, entries["attachment.csv"], "entity_id")
 	if len(entIDs) != 1 || entIDs[0] != f.rep1Person.String() {
 		t.Fatalf("row-scope leak in files manifest: attachment entity_ids = %v", entIDs)
 	}
 	// The audit_log excludes the row about the invisible person.
-	auditEntities := csvColumn(t, entries["audit_log.csv"], "entity_id")
+	auditEntities := CSVColumn(t, entries["audit_log.csv"], "entity_id")
 	for _, id := range auditEntities {
 		if id == f.rep3Person.String() {
 			t.Fatalf("row-scope leak: audit_log exposed an invisible person's row %s", id)
@@ -317,7 +261,7 @@ func TestExportOmitsObjectsWithoutReadGrant(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	entries := bundleEntries(t, buf.Bytes())
+	entries := BundleEntries(t, buf.Bytes())
 
 	if _, ok := entries["person.csv"]; !ok {
 		t.Fatal("granted object person was omitted")

--- a/backend/internal/compose/integration/extractionaccept_http_integration_test.go
+++ b/backend/internal/compose/integration/extractionaccept_http_integration_test.go
@@ -36,7 +36,7 @@ func uploadAttachmentHTTP(e *apptest.AppEnv, t *testing.T, entityType, entityID,
 	}
 	req.Header.Set("Content-Type", ctype)
 	req.Header.Set("X-Workspace-Slug", e.Slug)
-	resp, err := e.Client.Do(req) //nolint:bodyclose // closed by the deferred apptest.CloseBody on the next line; bodyclose only sees a Close in the same package, and the closer moved out with the fixture
+	resp, err := e.Client.Do(req) //nolint:bodyclose // closed by apptest.CloseBody below; bodyclose only recognises a Close in the same package
 	if err != nil {
 		t.Fatalf("upload: %v", err)
 	}
@@ -61,7 +61,7 @@ func uploadAttachmentHTTP(e *apptest.AppEnv, t *testing.T, entityType, entityID,
 // directly through the owner connection — there is no scan-verdict HTTP
 // endpoint (MarkScanResult is administrative, never a public API) — inside
 // a workspace-bound transaction so RLS (FORCE) admits the UPDATE. Mirrors
-// SetWorkspaceSeat's shape (e2e_integration_test.go). A fresh upload
+// SetWorkspaceSeat's shape (integration/apptest). A fresh upload
 // defaults to 'scanning' (0070), and the accept-write now scan-gates like
 // every other path over an attachment's bytes, so any HTTP scenario that
 // expects the accept to actually run its extractor must clear the gate

--- a/backend/internal/compose/integration/fieldhistory_http_integration_test.go
+++ b/backend/internal/compose/integration/fieldhistory_http_integration_test.go
@@ -11,7 +11,7 @@ package integration
 // drives — that suite calls privacy.ListFieldHistory directly, so the
 // query-validation branches and the JSON shape only exist at the
 // transport. This suite rides the same real-handler-stack e2e harness as
-// e2e_integration_test.go (TLS httptest server, session cookie, workspace
+// integration/apptest (TLS httptest server, session cookie, workspace
 // header) and reuses fieldhistory_integration_test.go's seedAuditDiffRow
 // to write the audit rows the handler reads back.
 

--- a/backend/internal/compose/integration/filteredexport_integration_test.go
+++ b/backend/internal/compose/integration/filteredexport_integration_test.go
@@ -79,7 +79,7 @@ func TestFilteredExportIsScopedAndFiltered(t *testing.T) {
 		t.Fatalf("row count = %d, want 1 (only the visible matching deal)", result.RowCount)
 	}
 
-	gotIDs := csvColumn(t, result.Body, "id")
+	gotIDs := CSVColumn(t, result.Body, "id")
 	set := map[string]bool{}
 	for _, id := range gotIDs {
 		set[id] = true
@@ -109,7 +109,7 @@ func TestFilteredExportOpenFormatsAndAudit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("csv export: %v", err)
 	}
-	if got := len(csvColumn(t, csvResult.Body, "id")); got != 2 {
+	if got := len(CSVColumn(t, csvResult.Body, "id")); got != 2 {
 		t.Fatalf("csv rows = %d, want 2 (both teams' commit deals)", got)
 	}
 

--- a/backend/internal/compose/integration/harness.go
+++ b/backend/internal/compose/integration/harness.go
@@ -5,27 +5,40 @@
 
 // Package integration holds the cross-module integration suites — the
 // compose charter exercised end to end over a real migrated Postgres —
-// and the shared harnesses they ride: Env here, and SearchEnv in
-// searchenv.go. Both live in non-test files so the white-box suites that
-// must stay inside their package (compose root, briefs) can import them;
-// both deliberately import modules and platform only, never compose, so no
-// import cycle can form.
+// and the shared fixtures they ride. There are three, all exported, all in
+// non-test files:
+//
+//   - Env, here — a migrated database plus the core stores.
+//   - SearchEnv, in searchenv.go — lighter, and despite the name mostly taken
+//     for the database rather than the search store.
+//   - apptest.AppEnv, in the apptest subpackage — the booted application behind
+//     a TLS test server.
+//
+// Env and SearchEnv live here because the white-box suites that must stay in
+// their own package (compose root, briefs) import them, so neither may import
+// compose. AppEnv boots a compose handler stack and therefore CANNOT live here:
+// that would close a cycle through those same white-box tests. It sits one level
+// down instead, and nothing in apptest may import this package, or the cycle
+// closes from the other side.
 //
 // Suites also live in sibling packages that import this one. That is how the
 // lane gets more than one scheduling slot: one package is one slot, and this
 // package is large enough to be the lane's long pole on its own. The set of such
 // packages is the subdirectories of this one, which is where to look rather than
-// a list here that the next split would have to remember to extend.
-// Split a group out when it is a closed seam — it rides an EXPORTED
-// fixture (Env or SearchEnv) rather than the booted-app fixture in
-// e2e_integration_test.go, and it neither needs nor owes an unexported helper
-// across the boundary. A helper that two such groups need is promoted here; one
-// that only a group needs stays with it.
+// a list here that the next split would have to remember to extend — apptest is
+// the exception, a fixture package rather than a suite slot.
 //
-// A fixture is only importable if its METHODS are in a non-test file too: a
-// method declared in a _test.go file is not part of the package a sibling
-// imports, so a group could hold the fixture and still be unable to build a
-// principal context or seed a row. Promote the methods with the type.
+// Split a group out when it is a closed seam: it rides one of the three exported
+// fixtures, and it neither needs nor owes an unexported helper across the
+// boundary. Any of the three will do — a group riding AppEnv is no longer stuck.
+// A helper that two such groups need is promoted here; one that only a group
+// needs stays with it.
+//
+// Two things a split reliably runs into. A fixture is only importable if its
+// METHODS are in a non-test file too, since a method declared in a _test.go file
+// is not part of the package a sibling imports. And once the fixture's type is
+// foreign, a suite cannot declare methods on it at all — helpers a group keeps
+// become plain functions taking the fixture.
 package integration
 
 import (

--- a/backend/internal/compose/integration/jobhealth_http_e2e_integration_test.go
+++ b/backend/internal/compose/integration/jobhealth_http_e2e_integration_test.go
@@ -424,7 +424,7 @@ func rawGet(t *testing.T, e *apptest.AppEnv, path string) string {
 	if err != nil {
 		t.Fatalf("building request: %v", err)
 	}
-	resp, err := e.Client.Do(req) //nolint:bodyclose // closed by the deferred apptest.CloseBody on the next line; bodyclose only sees a Close in the same package, and the closer moved out with the fixture
+	resp, err := e.Client.Do(req) //nolint:bodyclose // closed by apptest.CloseBody below; bodyclose only recognises a Close in the same package
 	if err != nil {
 		t.Fatalf("GET %s: %v", path, err)
 	}

--- a/backend/internal/compose/integration/mcp_handshake_integration_test.go
+++ b/backend/internal/compose/integration/mcp_handshake_integration_test.go
@@ -60,7 +60,7 @@ func TestAConnectorCompletesTheWholeHandshakeOnOneOrigin(t *testing.T) {
 	// initialize settles the protocol revision and mints the session id every
 	// later request on this connection carries.
 	const requested = "2025-06-18"
-	initialized := raw(e.AppEnv, t, http.MethodPost, "/mcp",
+	initialized := mcpRaw(e.AppEnv, t, http.MethodPost, "/mcp",
 		`{"jsonrpc":"2.0","id":2,"method":"initialize","params":{"protocolVersion":"`+requested+
 			`","clientInfo":{"name":"conformance","version":"1"}}}`,
 		map[string]string{"Content-Type": "application/json", "Authorization": "Bearer " + token})

--- a/backend/internal/compose/integration/mcp_transport_integration_test.go
+++ b/backend/internal/compose/integration/mcp_transport_integration_test.go
@@ -89,7 +89,7 @@ func listTools(e *apptest.AppEnv, t *testing.T, bearer string) httpResult {
 	if bearer != "" {
 		headers["Authorization"] = "Bearer " + bearer
 	}
-	return raw(e, t, http.MethodPost, "/mcp", `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`, headers)
+	return mcpRaw(e, t, http.MethodPost, "/mcp", `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`, headers)
 }
 
 // getJSON dereferences a discovery document the way a client does and fails
@@ -98,7 +98,7 @@ func listTools(e *apptest.AppEnv, t *testing.T, bearer string) httpResult {
 //craft:ignore naked-any a discovery document is an open JSON object by RFC 8414/9728 — asserting on it means reading it untyped
 func getJSON(e *apptest.AppEnv, t *testing.T, path string) map[string]any {
 	t.Helper()
-	got := raw(e, t, http.MethodGet, path, "", nil)
+	got := mcpRaw(e, t, http.MethodGet, path, "", nil)
 	if got.StatusCode != http.StatusOK {
 		t.Fatalf("GET %s → %d %s", path, got.StatusCode, got.Body)
 	}
@@ -112,7 +112,7 @@ func getJSON(e *apptest.AppEnv, t *testing.T, path string) map[string]any {
 // raw issues one request against the harness origin and returns the whole
 // outcome. It never decodes: the connector suite asserts on status codes and
 // headers as often as on bodies, and a 404 has no JSON to decode.
-func raw(e *apptest.AppEnv, t *testing.T, method, path, payload string, headers map[string]string) httpResult {
+func mcpRaw(e *apptest.AppEnv, t *testing.T, method, path, payload string, headers map[string]string) httpResult {
 	t.Helper()
 	var body io.Reader
 	if payload != "" {
@@ -125,7 +125,7 @@ func raw(e *apptest.AppEnv, t *testing.T, method, path, payload string, headers 
 	for k, v := range headers {
 		req.Header.Set(k, v)
 	}
-	resp, err := e.Client.Do(req) //nolint:bodyclose // closed by the deferred apptest.CloseBody on the next line; bodyclose only sees a Close in the same package, and the closer moved out with the fixture
+	resp, err := e.Client.Do(req) //nolint:bodyclose // closed by apptest.CloseBody below; bodyclose only recognises a Close in the same package
 	if err != nil {
 		t.Fatalf("%s %s: %v", method, path, err)
 	}
@@ -267,7 +267,7 @@ func TestConnectorGateOffRemovesEveryConnectorRoute(t *testing.T) {
 	}
 	var want, wantFrom string
 	for _, p := range probes {
-		got := raw(e, t, p.method, p.path, p.payload, nil)
+		got := mcpRaw(e, t, p.method, p.path, p.payload, nil)
 		if got.StatusCode != http.StatusNotFound {
 			t.Fatalf("%s %s → %d, want 404: the gate must remove the route, not guard it",
 				p.method, p.path, got.StatusCode)
@@ -330,7 +330,7 @@ func (e *connectorEnv) rpc(t *testing.T, bearer, protocolVersion, payload string
 	if protocolVersion != "" {
 		headers["MCP-Protocol-Version"] = protocolVersion
 	}
-	got := raw(e.AppEnv, t, http.MethodPost, "/mcp", payload, headers)
+	got := mcpRaw(e.AppEnv, t, http.MethodPost, "/mcp", payload, headers)
 	if got.StatusCode != http.StatusOK {
 		t.Fatalf("POST /mcp %s → %d %s", payload, got.StatusCode, got.Body)
 	}

--- a/backend/internal/compose/integration/oauth_consent_integration_test.go
+++ b/backend/internal/compose/integration/oauth_consent_integration_test.go
@@ -281,7 +281,7 @@ func (o *oauthEnv) authorizeNoFollow(t *testing.T, extra url.Values) (int, strin
 		return http.ErrUseLastResponse
 	}
 	defer func() { o.Client.CheckRedirect = nil }()
-	resp, err := o.Client.Do(req) //nolint:bodyclose // closed by the deferred apptest.CloseBody below; bodyclose only sees a Close in the same package, and the closer moved out with the fixture
+	resp, err := o.Client.Do(req) //nolint:bodyclose // closed by apptest.CloseBody below; bodyclose only recognises a Close in the same package
 	if err != nil {
 		t.Fatalf("authorize: %v", err)
 	}

--- a/backend/internal/compose/integration/oauth_integration_test.go
+++ b/backend/internal/compose/integration/oauth_integration_test.go
@@ -101,7 +101,7 @@ func (o *oauthEnv) authorizeRaw(t *testing.T, extra url.Values) (int, string) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp, err := o.Client.Do(req) //nolint:bodyclose // closed by apptest.CloseBody once the body is read, below; bodyclose only sees a Close in the same package, and the closer moved out with the fixture
+	resp, err := o.Client.Do(req) //nolint:bodyclose // closed by apptest.CloseBody below; bodyclose only recognises a Close in the same package
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -165,7 +165,7 @@ func (o *oauthEnv) postConsent(t *testing.T, form url.Values) (status int, locat
 	post.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	o.Client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
 	defer func() { o.Client.CheckRedirect = nil }()
-	resp, err := o.Client.Do(post) //nolint:bodyclose // closed by the deferred apptest.CloseBody below; bodyclose only sees a Close in the same package, and the closer moved out with the fixture
+	resp, err := o.Client.Do(post) //nolint:bodyclose // closed by apptest.CloseBody below; bodyclose only recognises a Close in the same package
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -249,7 +249,7 @@ func (o *oauthEnv) postToken(t *testing.T, form url.Values) (int, map[string]any
 		t.Fatal(err)
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	resp, err := o.Client.Do(req) //nolint:bodyclose // closed by the deferred apptest.CloseBody below; bodyclose only sees a Close in the same package, and the closer moved out with the fixture
+	resp, err := o.Client.Do(req) //nolint:bodyclose // closed by apptest.CloseBody below; bodyclose only recognises a Close in the same package
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -316,7 +316,7 @@ func TestOAuthConsentGateBlocksSilentAuthorization(t *testing.T) {
 	// GET answers with the consent screen, never a redirect carrying a code.
 	req, _ := http.NewRequest(http.MethodGet, o.TS.URL+"/oauth/authorize?"+q.Encode(), nil)
 	o.Client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
-	resp, err := o.Client.Do(req) //nolint:bodyclose // closed by the deferred apptest.CloseBody below; bodyclose only sees a Close in the same package, and the closer moved out with the fixture
+	resp, err := o.Client.Do(req) //nolint:bodyclose // closed by apptest.CloseBody below; bodyclose only recognises a Close in the same package
 	o.Client.CheckRedirect = nil
 	if err != nil {
 		t.Fatal(err)
@@ -342,7 +342,7 @@ func TestOAuthConsentGateBlocksSilentAuthorization(t *testing.T) {
 	post, _ := http.NewRequest(http.MethodPost, o.TS.URL+"/oauth/authorize", strings.NewReader(form.Encode()))
 	post.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	o.Client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
-	resp, err = o.Client.Do(post) //nolint:bodyclose // closed by the deferred apptest.CloseBody below; bodyclose only sees a Close in the same package, and the closer moved out with the fixture
+	resp, err = o.Client.Do(post) //nolint:bodyclose // closed by apptest.CloseBody below; bodyclose only recognises a Close in the same package
 	o.Client.CheckRedirect = nil
 	if err != nil {
 		t.Fatal(err)
@@ -359,7 +359,7 @@ func TestOAuthConsentGateBlocksSilentAuthorization(t *testing.T) {
 	post2, _ := http.NewRequest(http.MethodPost, o.TS.URL+"/oauth/authorize", strings.NewReader(form.Encode()))
 	post2.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	post2.Header.Set("Sec-Fetch-Site", "cross-site")
-	resp, err = o.Client.Do(post2) //nolint:bodyclose // closed by the deferred apptest.CloseBody below; bodyclose only sees a Close in the same package, and the closer moved out with the fixture
+	resp, err = o.Client.Do(post2) //nolint:bodyclose // closed by apptest.CloseBody below; bodyclose only recognises a Close in the same package
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -398,7 +398,7 @@ func TestOAuthRefusesDowngradesAndPrivilegedClients(t *testing.T) {
 			q[k] = vs
 		}
 		req, _ := http.NewRequest(http.MethodGet, o.TS.URL+"/oauth/authorize?"+q.Encode(), nil)
-		resp, err := o.Client.Do(req) //nolint:bodyclose // closed by the deferred apptest.CloseBody below; bodyclose only sees a Close in the same package, and the closer moved out with the fixture
+		resp, err := o.Client.Do(req) //nolint:bodyclose // closed by apptest.CloseBody below; bodyclose only recognises a Close in the same package
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/backend/internal/compose/integration/offerpdf_http_integration_test.go
+++ b/backend/internal/compose/integration/offerpdf_http_integration_test.go
@@ -118,7 +118,7 @@ func TestOfferPdfHTTP_DownloadAfterRenderReturnsTheRenderedBytes(t *testing.T) {
 		t.Fatalf("building pdf download request: %v", err)
 	}
 	req.Header.Set("X-Workspace-Slug", e.Slug)
-	resp, err := e.Client.Do(req) //nolint:bodyclose // closed by the deferred apptest.CloseBody below; bodyclose only sees a Close in the same package, and the closer moved out with the fixture
+	resp, err := e.Client.Do(req) //nolint:bodyclose // closed by apptest.CloseBody below; bodyclose only recognises a Close in the same package
 	if err != nil {
 		t.Fatalf("GET pdf: %v", err)
 	}

--- a/backend/internal/compose/integration/orgrollup_http_integration_test.go
+++ b/backend/internal/compose/integration/orgrollup_http_integration_test.go
@@ -12,7 +12,7 @@ package integration
 // the query-default/validation branches and the JSON shape (Money
 // envelopes, the restricted_excluded null-vs-empty distinction) only
 // exist at the transport. This suite rides the same real-handler-stack
-// e2e harness as e2e_integration_test.go (TLS httptest server, session
+// e2e harness apptest.AppEnv (TLS httptest server, session
 // cookie, workspace header) and reuses fieldhistory_http_integration_test.go's
 // fieldHistoryProblem/assertFieldHistoryValidation422 for the shared
 // httperr.Validation 422 shape, since the scope-enum rejection rides the

--- a/backend/internal/compose/integration/overlay/doc.go
+++ b/backend/internal/compose/integration/overlay/doc.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+// Package overlay holds the incumbent-CRM mirror's integration suites: the
+// acceptance surface and its budget, mirror-backed reads and their fail-closed
+// visibility, write-back and its audit, the continuous sync, the user map, the
+// tool surface, and the ADR-0071 overlay→native cutover with its flip and claim.
+//
+// A suite package split out of internal/compose/integration so the lane has
+// another scheduling slot. Chosen next because it was the most expensive remaining
+// cluster by measured time — 41s of the parent's 349s from only 36 tests — not
+// because it had the most files; ranking these cuts by file count is what made an
+// earlier estimate of the payoff wrong by a factor of three.
+//
+// Four of its suites ride the booted-app fixture in integration/apptest, which is
+// what made this cut possible: until that fixture was promoted out of a test file,
+// no group depending on it could leave.
+//
+// overlay_acceptance_seam_test.go deliberately stayed behind. It carries no
+// integration build tag, so it belongs to the unit lane rather than this one, and
+// it owns backendModuleRoot, which a webhooks suite there also reads.
+//
+// The production overlay module is imported as overlaymod, because inside a
+// package named overlay a bare overlay.X reads as a self-reference.
+package overlay

--- a/backend/internal/compose/integration/overlay/doc.go
+++ b/backend/internal/compose/integration/overlay/doc.go
@@ -9,14 +9,8 @@
 // tool surface, and the ADR-0071 overlay→native cutover with its flip and claim.
 //
 // A suite package split out of internal/compose/integration so the lane has
-// another scheduling slot. Chosen next because it was the most expensive remaining
-// cluster by measured time — 41s of the parent's 349s from only 36 tests — not
-// because it had the most files; ranking these cuts by file count is what made an
-// earlier estimate of the payoff wrong by a factor of three.
-//
-// Four of its suites ride the booted-app fixture in integration/apptest, which is
-// what made this cut possible: until that fixture was promoted out of a test file,
-// no group depending on it could leave.
+// another scheduling slot. Its suites ride integration.SearchEnv and
+// integration/apptest.AppEnv.
 //
 // overlay_acceptance_seam_test.go deliberately stayed behind. It carries no
 // integration build tag, so it belongs to the unit lane rather than this one, and

--- a/backend/internal/compose/integration/overlay/overlay_acceptance_budget_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_acceptance_budget_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package integration
+package overlay
 
 // The AC-OV-3/AC-OV-7 half of the AC-OV acceptance suite
 // (overlay_acceptance_test.go carries the suite's own scope doc): the two
@@ -16,7 +16,8 @@ import (
 	"time"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
-	"github.com/gradionhq/margince/backend/internal/modules/overlay"
+	"github.com/gradionhq/margince/backend/internal/compose/integration"
+	overlaymod "github.com/gradionhq/margince/backend/internal/modules/overlay"
 	"github.com/gradionhq/margince/backend/internal/modules/overlay/fake"
 	"github.com/gradionhq/margince/backend/internal/platform/overlaybudget"
 	"github.com/gradionhq/margince/backend/internal/platform/overlaybudget/budgettest"
@@ -45,7 +46,7 @@ func acceptanceBudgetMeter(t *testing.T) *overlaybudget.Meter {
 // the AC-OV-1 gate proves of every package above the seam.
 func contactsTranslator(canonical string) ([]string, bool) {
 	if canonical == "person" {
-		return []string{overlay.IncumbentClassContacts}, true
+		return []string{overlaymod.IncumbentClassContacts}, true
 	}
 	return nil, false
 }
@@ -67,23 +68,23 @@ func contactsTranslator(canonical string) ([]string, bool) {
 // to route the two kinds of read into different budgets; this test
 // proves the classification is correct without needing a timer at all.
 func TestAcceptance_AC_OV_3_MirrorReadMeetsBudget(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	ws, actorID := seedOverlayModeWorkspace(t)
 	ctx := overlayActorCtx(ws, actorID)
 
-	mirror := overlay.NewMirrorStore(e.Pool, stubOwnerEmails{})
+	mirror := overlaymod.NewMirrorStore(e.Pool, stubOwnerEmails{})
 	if err := mirror.UpsertUserMap(ctx, ids.From[ids.UserKind](actorID), "hubspot", "owner-1", "manual"); err != nil {
 		t.Fatalf("mapping the acting user to owner-1: %v", err)
 	}
 	mirrorTime := time.Now().UTC().Add(-time.Hour)
-	if err := mirror.Ingest(ctx, overlay.Record{
+	if err := mirror.Ingest(ctx, overlaymod.Record{
 		ObjectClass: "person", ExternalID: "100214862066",
 		Fields: map[string]any{"firstname": "Budget"}, ModifiedAt: mirrorTime, OwnerExternalID: "owner-1",
 	}); err != nil {
 		t.Fatalf("ingesting the mirror fixture: %v", err)
 	}
 
-	basicProvider := overlay.NewProvider(mirror, nil)
+	basicProvider := overlaymod.NewProvider(mirror, nil)
 	searchRes, err := basicProvider.Search(ctx, datasource.SearchQuery{EntityTypes: []datasource.EntityType{datasource.EntityPerson}, Limit: 10})
 	if err != nil || len(searchRes.Records) != 1 {
 		t.Fatalf("resolving the fixture's own ref: err=%v records=%d", err, len(searchRes.Records))
@@ -92,12 +93,12 @@ func TestAcceptance_AC_OV_3_MirrorReadMeetsBudget(t *testing.T) {
 
 	fakeInc := fake.New()
 	liveRec := fake.Rec("100214862066", map[string]any{"firstname": "Live"})
-	liveRec.ObjectClass = overlay.IncumbentClassContacts
-	fakeInc.Seed(overlay.IncumbentClassContacts, liveRec)
+	liveRec.ObjectClass = overlaymod.IncumbentClassContacts
+	fakeInc.Seed(overlaymod.IncumbentClassContacts, liveRec)
 
 	meter := acceptanceBudgetMeter(t)
-	ff := overlay.NewFreshnessReader(func(context.Context) (overlay.Incumbent, error) { return fakeInc, nil }, mirror, meter, contactsTranslator)
-	fullProvider := overlay.NewProvider(mirror, ff)
+	ff := overlaymod.NewFreshnessReader(func(context.Context) (overlaymod.Incumbent, error) { return fakeInc, nil }, mirror, meter, contactsTranslator)
+	fullProvider := overlaymod.NewProvider(mirror, ff)
 
 	before := meter.Snapshot(ctx, acceptanceIncumbent)
 	if _, err := fullProvider.Read(ctx, ref); err != nil {
@@ -133,23 +134,23 @@ func TestAcceptance_AC_OV_3_MirrorReadMeetsBudget(t *testing.T) {
 // freshness_integration_test.go's module-level proof one layer up the
 // composed stack.
 func TestAcceptance_AC_OV_7_ForceFreshDegrades(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	ws, actorID := seedOverlayModeWorkspace(t)
 	ctx := overlayActorCtx(ws, actorID)
 
-	mirror := overlay.NewMirrorStore(e.Pool, stubOwnerEmails{})
+	mirror := overlaymod.NewMirrorStore(e.Pool, stubOwnerEmails{})
 	if err := mirror.UpsertUserMap(ctx, ids.From[ids.UserKind](actorID), "hubspot", "owner-1", "manual"); err != nil {
 		t.Fatalf("mapping the acting user to owner-1: %v", err)
 	}
 	mirrorTime := time.Now().UTC().Add(-time.Hour)
-	if err := mirror.Ingest(ctx, overlay.Record{
+	if err := mirror.Ingest(ctx, overlaymod.Record{
 		ObjectClass: "person", ExternalID: "100214862077",
 		Fields: map[string]any{"firstname": "Shed"}, ModifiedAt: mirrorTime, OwnerExternalID: "owner-1",
 	}); err != nil {
 		t.Fatalf("ingesting the mirror fixture: %v", err)
 	}
 
-	basicProvider := overlay.NewProvider(mirror, nil)
+	basicProvider := overlaymod.NewProvider(mirror, nil)
 	searchRes, err := basicProvider.Search(ctx, datasource.SearchQuery{EntityTypes: []datasource.EntityType{datasource.EntityPerson}, Limit: 10})
 	if err != nil || len(searchRes.Records) != 1 {
 		t.Fatalf("resolving the fixture's own ref: err=%v records=%d", err, len(searchRes.Records))
@@ -158,8 +159,8 @@ func TestAcceptance_AC_OV_7_ForceFreshDegrades(t *testing.T) {
 
 	fakeInc := fake.New()
 	liveRec := fake.Rec("100214862077", map[string]any{"firstname": "Live"})
-	liveRec.ObjectClass = overlay.IncumbentClassContacts
-	fakeInc.Seed(overlay.IncumbentClassContacts, liveRec)
+	liveRec.ObjectClass = overlaymod.IncumbentClassContacts
+	fakeInc.Seed(overlaymod.IncumbentClassContacts, liveRec)
 
 	meter := acceptanceBudgetMeter(t)
 	// Push the window to shed (limit 10, shed at 8) via the POLLER lane —
@@ -172,8 +173,8 @@ func TestAcceptance_AC_OV_7_ForceFreshDegrades(t *testing.T) {
 		t.Fatalf("meter.Band = %q after loading to the shed threshold, want %q", got, overlaybudget.BandShed)
 	}
 
-	ff := overlay.NewFreshnessReader(func(context.Context) (overlay.Incumbent, error) { return fakeInc, nil }, mirror, meter, contactsTranslator)
-	overlayProvider := overlay.NewProvider(mirror, ff)
+	ff := overlaymod.NewFreshnessReader(func(context.Context) (overlaymod.Incumbent, error) { return fakeInc, nil }, mirror, meter, contactsTranslator)
+	overlayProvider := overlaymod.NewProvider(mirror, ff)
 	d := compose.NewDispatcher(compose.NewProvider(e.Pool), overlayProvider, e.Pool)
 
 	info, err := d.Freshness(ctx, ref)

--- a/backend/internal/compose/integration/overlay/overlay_acceptance_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_acceptance_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package integration
+package overlay
 
 // The AC-OV read+sync acceptance suite (design.md §8 — the
 // acceptance criteria as deterministic CI gates, not manual checks). One
@@ -16,12 +16,12 @@ package integration
 //
 // This suite reuses, rather than rebuilds, two things already proven
 // elsewhere:
-//   - the composed harness (Setup/Env, seedOverlayModeWorkspace,
+//   - the composed harness (integration.Setup/integration.Env, seedOverlayModeWorkspace,
 //     overlayActorCtx, stubOwnerEmails — overlay_dispatch_integration_test.go;
 //     openAppPool, the env HTTP harness — overlay_e2e_test.go).
 //   - the overlay/fake incumbent as the concurrent mutator every AC that
 //     needs a "live incumbent changed something" fixture drives — seeded
-//     and read by INCUMBENT class names (overlay.IncumbentClass*), never
+//     and read by INCUMBENT class names (overlaymod.IncumbentClass*), never
 //     the canonical entity name, per the seam rule fake's own doc and
 //     backfill.go's own doc both state.
 //
@@ -44,8 +44,9 @@ import (
 	"time"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration"
 	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
-	"github.com/gradionhq/margince/backend/internal/modules/overlay"
+	overlaymod "github.com/gradionhq/margince/backend/internal/modules/overlay"
 	"github.com/gradionhq/margince/backend/internal/modules/overlay/fake"
 	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
 	"github.com/gradionhq/margince/backend/internal/platform/overlaybudget"
@@ -64,21 +65,21 @@ import (
 // fixture (the numeric-external-id<->UUID bridge is internal to package
 // overlay) — resolved once via Search, then reused by every read verb the
 // caller exercises.
-func seedMirroredPersonFixture(t *testing.T, e *Env) (context.Context, *overlay.Provider, datasource.EntityRef) {
+func seedMirroredPersonFixture(t *testing.T, e *integration.Env) (context.Context, *overlaymod.Provider, datasource.EntityRef) {
 	t.Helper()
 	overlayWS, actorID := seedOverlayModeWorkspace(t)
 	ctx := overlayActorCtx(overlayWS, actorID)
-	mirror := overlay.NewMirrorStore(e.Pool, stubOwnerEmails{})
+	mirror := overlaymod.NewMirrorStore(e.Pool, stubOwnerEmails{})
 	if err := mirror.UpsertUserMap(ctx, ids.From[ids.UserKind](actorID), "hubspot", "owner-1", "manual"); err != nil {
 		t.Fatalf("mapping the acting user to owner-1: %v", err)
 	}
-	if err := mirror.Ingest(ctx, overlay.Record{
+	if err := mirror.Ingest(ctx, overlaymod.Record{
 		ObjectClass: "person", ExternalID: "100214862055",
 		Fields: map[string]any{"firstname": "Ada Overlay"}, ModifiedAt: time.Now().UTC(), OwnerExternalID: "owner-1",
 	}); err != nil {
 		t.Fatalf("ingesting the overlay fixture: %v", err)
 	}
-	provider := overlay.NewProvider(mirror, nil)
+	provider := overlaymod.NewProvider(mirror, nil)
 	found, err := provider.Search(ctx, datasource.SearchQuery{EntityTypes: []datasource.EntityType{datasource.EntityPerson}, Limit: 10})
 	if err != nil || len(found.Records) != 1 {
 		t.Fatalf("resolving the overlay fixture's own ref: err=%v records=%d", err, len(found.Records))
@@ -149,7 +150,7 @@ func assertEverySeamVerbIsClassifiedExactlyOnce(t *testing.T) {
 // future verb added to the seam fails this test until classified rather
 // than silently passing unclassified.
 func TestAcceptance_AC_OV_2_BoundedEquivalence_ReadSubset(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	personID := e.SeedPerson(t, "Ada Native", nil)
 	native := compose.NewProvider(e.Pool)
 	personRef := datasource.EntityRef{Type: datasource.EntityPerson, ID: personID}
@@ -282,7 +283,7 @@ func TestAcceptance_AC_OV_2_BoundedEquivalence_ReadSubset(t *testing.T) {
 // freshness_integration_test.go/reconcile_integration_test.go's own
 // queries document), so no workspace GUC is needed to read it, only to
 // filter by workspace in the query itself.
-func countAcceptanceMirrorConflictEvents(ctx context.Context, e *Env, ws, externalID string) (int, error) {
+func countAcceptanceMirrorConflictEvents(ctx context.Context, e *integration.Env, ws, externalID string) (int, error) {
 	var count int
 	err := e.Pool.QueryRow(
 		ctx,
@@ -304,14 +305,14 @@ func countAcceptanceMirrorConflictEvents(ctx context.Context, e *Env, ws, extern
 // must never win: Ingest's own staleness guard holds the mirror at its
 // current, fresher state, and Reconcile must emit nothing for a write
 // that never actually landed. Driven through the package-level
-// overlay.Reconcile with the fake incumbent as the concurrent mutator,
+// overlaymod.Reconcile with the fake incumbent as the concurrent mutator,
 // the same seam backfill_integration_test.go and
 // reconcile_integration_test.go already exercise a layer down.
 func TestAcceptance_AC_OV_8_IncumbentWinsConflict(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	ws, actorID := seedOverlayModeWorkspace(t)
 	ctx := overlayActorCtx(ws, actorID)
-	mirror := overlay.NewMirrorStore(e.Pool, stubOwnerEmails{})
+	mirror := overlaymod.NewMirrorStore(e.Pool, stubOwnerEmails{})
 	if err := mirror.UpsertUserMap(ctx, ids.From[ids.UserKind](actorID), "hubspot", "owner-1", "manual"); err != nil {
 		t.Fatalf("mapping the acting user to owner-1: %v", err)
 	}
@@ -322,13 +323,13 @@ func TestAcceptance_AC_OV_8_IncumbentWinsConflict(t *testing.T) {
 	oldBaseline := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
 	mirrorNewerBaseline := oldBaseline.Add(time.Hour)
 
-	if err := mirror.Ingest(ctx, overlay.Record{
+	if err := mirror.Ingest(ctx, overlaymod.Record{
 		ObjectClass: objectClass, ExternalID: winsExternalID,
 		Fields: map[string]any{"display_name": "Old"}, ModifiedAt: oldBaseline, OwnerExternalID: "owner-1",
 	}); err != nil {
 		t.Fatalf("seeding the pre-existing (wins-case) mirror row: %v", err)
 	}
-	if err := mirror.Ingest(ctx, overlay.Record{
+	if err := mirror.Ingest(ctx, overlaymod.Record{
 		ObjectClass: objectClass, ExternalID: reverseExternalID,
 		Fields: map[string]any{"display_name": "Current"}, ModifiedAt: mirrorNewerBaseline, OwnerExternalID: "owner-1",
 	}); err != nil {
@@ -347,13 +348,13 @@ func TestAcceptance_AC_OV_8_IncumbentWinsConflict(t *testing.T) {
 	winsRec.ObjectClass = objectClass
 	winsRec.ModifiedAt = oldBaseline.Add(30 * time.Minute) // strictly newer than the mirror's baseline
 	winsRec.OwnerExternalID = "owner-1"
-	fakeInc.Seed(overlay.IncumbentClassCompanies, winsRec)
+	fakeInc.Seed(overlaymod.IncumbentClassCompanies, winsRec)
 
 	reverseRec := fake.Rec(reverseExternalID, map[string]any{"display_name": "Stale From Incumbent"})
 	reverseRec.ObjectClass = objectClass
 	reverseRec.ModifiedAt = mirrorNewerBaseline.Add(-30 * time.Minute) // OLDER than the mirror's own current baseline
 	reverseRec.OwnerExternalID = "owner-1"
-	fakeInc.Seed(overlay.IncumbentClassCompanies, reverseRec)
+	fakeInc.Seed(overlaymod.IncumbentClassCompanies, reverseRec)
 
 	meter := acceptanceBudgetMeter(t)
 	watermark := oldBaseline.Add(-time.Second)
@@ -361,7 +362,7 @@ func TestAcceptance_AC_OV_8_IncumbentWinsConflict(t *testing.T) {
 	// the 15-minute skew grace), so the sweep's internal floor leaves it
 	// unchanged — this test is about the conflict/no-conflict distinction,
 	// not the floor.
-	if _, err := overlay.Reconcile(ctx, fakeInc, mirror, meter, overlay.IncumbentClassCompanies, watermark, oldBaseline); err != nil {
+	if _, err := overlaymod.Reconcile(ctx, fakeInc, mirror, meter, overlaymod.IncumbentClassCompanies, watermark, oldBaseline); err != nil {
 		t.Fatalf("Reconcile: %v", err)
 	}
 
@@ -405,7 +406,7 @@ func TestAcceptance_AC_OV_8_IncumbentWinsConflict(t *testing.T) {
 // workspace seedOverlayModeWorkspace mints.
 func seedUnmappedAppUser(t *testing.T, ws ids.UUID) ids.UUID {
 	t.Helper()
-	owner := OwnerConn(t)
+	owner := integration.OwnerConn(t)
 	userID := ids.NewV7()
 	if _, err := owner.Exec(context.Background(),
 		`INSERT INTO app_user (id, workspace_id, email, display_name) VALUES ($1, $2, $3, 'Unmapped')`,
@@ -425,10 +426,10 @@ func seedUnmappedAppUser(t *testing.T, ws ids.UUID) ids.UUID {
 // page and never a 403). The 2x-SLO staleness floor is branch-1b
 // (out of scope for this read-subset suite).
 func TestAcceptance_AC_OV_11_FailClosedVisibility_ReadSubset(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	ws, actorID := seedOverlayModeWorkspace(t)
 	ctx := overlayActorCtx(ws, actorID)
-	mirror := overlay.NewMirrorStore(e.Pool, stubOwnerEmails{})
+	mirror := overlaymod.NewMirrorStore(e.Pool, stubOwnerEmails{})
 	if err := mirror.UpsertUserMap(ctx, ids.From[ids.UserKind](actorID), "hubspot", "owner-1", "manual"); err != nil {
 		t.Fatalf("mapping the acting user to owner-1: %v", err)
 	}
@@ -438,19 +439,19 @@ func TestAcceptance_AC_OV_11_FailClosedVisibility_ReadSubset(t *testing.T) {
 	const nullOwnerExternalID = "100214862099"   // no owner at all
 	const ownedExternalID = "100214862100"       // owned by owner-1 — proves a real, visible row exists so the hidden cases aren't vacuous
 
-	if err := mirror.Ingest(ctx, overlay.Record{
+	if err := mirror.Ingest(ctx, overlaymod.Record{
 		ObjectClass: objectClass, ExternalID: hiddenOwnerExternalID,
 		Fields: map[string]any{"firstname": "OwnedByOther"}, ModifiedAt: time.Now().UTC(), OwnerExternalID: "owner-2",
 	}); err != nil {
 		t.Fatalf("ingesting the hidden-owner fixture: %v", err)
 	}
-	if err := mirror.Ingest(ctx, overlay.Record{
+	if err := mirror.Ingest(ctx, overlaymod.Record{
 		ObjectClass: objectClass, ExternalID: nullOwnerExternalID,
 		Fields: map[string]any{"firstname": "Unowned"}, ModifiedAt: time.Now().UTC(),
 	}); err != nil {
 		t.Fatalf("ingesting the null-owner fixture: %v", err)
 	}
-	if err := mirror.Ingest(ctx, overlay.Record{
+	if err := mirror.Ingest(ctx, overlaymod.Record{
 		ObjectClass: objectClass, ExternalID: ownedExternalID,
 		Fields: map[string]any{"firstname": "VisibleToOwner1"}, ModifiedAt: time.Now().UTC(), OwnerExternalID: "owner-1",
 	}); err != nil {
@@ -544,7 +545,7 @@ func TestAcceptance_OVA_AC_1_TeardownPurges(t *testing.T) {
 	}
 
 	pool := openAppPool(t)
-	mirror := overlay.NewMirrorStore(pool, stubOwnerEmails{})
+	mirror := overlaymod.NewMirrorStore(pool, stubOwnerEmails{})
 	adminCtx := overlayActorCtx(wsID, adminID)
 	if err := mirror.UpsertUserMap(adminCtx, ids.From[ids.UserKind](adminID), "hubspot", "owner-1", "manual"); err != nil {
 		t.Fatalf("mapping the admin to the fake incumbent owner: %v", err)
@@ -554,12 +555,12 @@ func TestAcceptance_OVA_AC_1_TeardownPurges(t *testing.T) {
 	dealRec := fake.Rec("700001", map[string]any{"dealname": "Big Deal"})
 	dealRec.ObjectClass = "deal"
 	dealRec.OwnerExternalID = "owner-1"
-	fakeInc.Seed(overlay.IncumbentClassDeals, dealRec)
-	fakeInc.SeedAssoc(overlay.IncumbentClassDeals, "700001", overlay.IncumbentClassCompanies, overlay.Assoc{
+	fakeInc.Seed(overlaymod.IncumbentClassDeals, dealRec)
+	fakeInc.SeedAssoc(overlaymod.IncumbentClassDeals, "700001", overlaymod.IncumbentClassCompanies, overlaymod.Assoc{
 		FromType: "deal", FromID: "700001", ToType: "organization", ToID: "800001",
 		TypeID: 5, Category: "HUBSPOT_DEFINED", Direction: "forward",
 	})
-	if _, err := overlay.Backfill(adminCtx, fakeInc, mirror, overlay.IncumbentClassDeals, time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)); err != nil {
+	if _, err := overlaymod.Backfill(adminCtx, fakeInc, mirror, overlaymod.IncumbentClassDeals, time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)); err != nil {
 		t.Fatalf("backfilling the fake incumbent's deals (with its company association): %v", err)
 	}
 
@@ -631,10 +632,10 @@ func TestAcceptance_OVA_AC_1_TeardownPurges(t *testing.T) {
 	// The native deals module also gates Search on real object-RBAC
 	// (unlike the overlay mirror's own visibility join adminCtx above was
 	// built for), so this call rebinds the same admin actor with
-	// AdminPerms, the harness's own full-access fixture.
+	// integration.AdminPerms, the harness's own full-access fixture.
 	adminNativeCtx := principal.WithActor(
 		principal.WithCorrelationID(principal.WithWorkspaceID(context.Background(), wsID), ids.NewV7()),
-		principal.Principal{Type: principal.PrincipalHuman, ID: "human:" + adminID.String(), UserID: adminID, Permissions: AdminPerms},
+		principal.Principal{Type: principal.PrincipalHuman, ID: "human:" + adminID.String(), UserID: adminID, Permissions: integration.AdminPerms},
 	)
 	postDisconnectDispatcher := compose.NewDispatcher(compose.NewProvider(pool), compose.NewOverlayProvider(pool, overlaybudget.New(nil, nil), nil), pool)
 	postTeardown, err := postDisconnectDispatcher.Search(adminNativeCtx, datasource.SearchQuery{EntityTypes: []datasource.EntityType{datasource.EntityDeal}, Limit: 10})

--- a/backend/internal/compose/integration/overlay/overlay_cutover_lifecycle_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_cutover_lifecycle_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package integration
+package overlay
 
 // The cutover lifecycle's back half (OVA-AC-6 c/d): a completed flip is
 // retired by disconnect — the mirror and its derivatives purge, native
@@ -36,7 +36,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/modules/deals"
-	"github.com/gradionhq/margince/backend/internal/modules/overlay"
+	overlaymod "github.com/gradionhq/margince/backend/internal/modules/overlay"
 	"github.com/gradionhq/margince/backend/internal/modules/overlay/fake"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -46,13 +46,13 @@ import (
 // snapshotIncumbent deep-copies the fake incumbent's whole record state
 // (via its own Backfill read) — the before/after byte-identity check
 // behind "the incumbent is never modified at any step".
-func snapshotIncumbent(t *testing.T, inc *fake.Adapter) map[string][]overlay.Record {
+func snapshotIncumbent(t *testing.T, inc *fake.Adapter) map[string][]overlaymod.Record {
 	t.Helper()
 	classes := append([]string{
-		overlay.IncumbentClassCompanies, overlay.IncumbentClassContacts,
-		overlay.IncumbentClassDeals, overlay.IncumbentClassLeads,
-	}, overlay.IncumbentEngagementClasses()...)
-	snap := map[string][]overlay.Record{}
+		overlaymod.IncumbentClassCompanies, overlaymod.IncumbentClassContacts,
+		overlaymod.IncumbentClassDeals, overlaymod.IncumbentClassLeads,
+	}, overlaymod.IncumbentEngagementClasses()...)
+	snap := map[string][]overlaymod.Record{}
 	for _, class := range classes {
 		page, err := inc.Backfill(context.Background(), class, "")
 		if err != nil {

--- a/backend/internal/compose/integration/overlay/overlay_dispatch_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_dispatch_integration_test.go
@@ -3,14 +3,14 @@
 
 //go:build integration
 
-package integration
+package overlay
 
 // Per-workspace SoR dispatch: compose.Dispatcher is the ONE
 // datasource.SystemOfRecordProvider every seam-injection point (the MCP
 // registry, the workflow engine, the ADR-0055 admission layer) now binds
 // to — it must route a native-mode workspace's calls to the native
 // composite Provider (Authoritative:true) and an overlay-mode
-// workspace's calls to the overlay.Provider (Authoritative:false),
+// workspace's calls to the overlaymod.Provider (Authoritative:false),
 // chosen per call from the context's workspace, never fixed at
 // construction time. This needs a real, migrated Postgres (RLS +
 // workspace.x_sor_mode + the mirror_visibility deny-join), so it is
@@ -22,8 +22,9 @@ import (
 	"time"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration"
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
-	"github.com/gradionhq/margince/backend/internal/modules/overlay"
+	overlaymod "github.com/gradionhq/margince/backend/internal/modules/overlay"
 	"github.com/gradionhq/margince/backend/internal/platform/overlaybudget"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -35,7 +36,7 @@ import (
 // (the harness's default fixture) dispatches Read to the native
 // composite Provider, whose Freshness is trivially authoritative.
 func TestDispatcherRoutesNativeWorkspaceReadsToTheNativeProvider(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	personID := e.SeedPerson(t, "Ada Native", nil)
 
 	d := compose.NewDispatcher(compose.NewProvider(e.Pool), compose.NewOverlayProvider(e.Pool, overlaybudget.New(nil, nil), nil), e.Pool)
@@ -51,20 +52,20 @@ func TestDispatcherRoutesNativeWorkspaceReadsToTheNativeProvider(t *testing.T) {
 
 // TestDispatcherRoutesOverlayWorkspaceReadsToTheOverlayProvider is the
 // overlay-mode half: a workspace with x_sor_mode='overlay' dispatches
-// Read/Search to overlay.Provider, which serves the mirror
+// Read/Search to overlaymod.Provider, which serves the mirror
 // (Authoritative:false, DS-AC-7) — and the contract-assembly helper
 // tags that Search result with the T2 external trust tier (design.md
 // §4.6).
 func TestDispatcherRoutesOverlayWorkspaceReadsToTheOverlayProvider(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	overlayWS, actorID := seedOverlayModeWorkspace(t)
 	ctx := overlayActorCtx(overlayWS, actorID)
 
-	mirror := overlay.NewMirrorStore(e.Pool, stubOwnerEmails{})
+	mirror := overlaymod.NewMirrorStore(e.Pool, stubOwnerEmails{})
 	if err := mirror.UpsertUserMap(ctx, ids.From[ids.UserKind](actorID), "hubspot", "owner-1", "manual"); err != nil {
 		t.Fatalf("mapping the acting user to owner-1: %v", err)
 	}
-	if err := mirror.Ingest(ctx, overlay.Record{
+	if err := mirror.Ingest(ctx, overlaymod.Record{
 		ObjectClass:     "person",
 		ExternalID:      "100214862042",
 		Fields:          map[string]any{"firstname": "Ada Overlay"},
@@ -112,13 +113,13 @@ func TestDispatcherRoutesOverlayWorkspaceReadsToTheOverlayProvider(t *testing.T)
 // 'overlay' from creation (the x_overlay_iff_incumbent CHECK requires
 // x_incumbent set in the same statement) plus one human app_user, via
 // the owner connection — the same "direct SQL, owner role bypasses RLS"
-// pattern SeedRow uses elsewhere in this harness. It opens its own
-// owner connection (via OwnerConn) rather than reusing the caller's
-// Env, since this workspace is intentionally a SECOND, independent
+// pattern integration.SeedRow uses elsewhere in this harness. It opens its own
+// owner connection (via integration.OwnerConn) rather than reusing the caller's
+// integration.Env, since this workspace is intentionally a SECOND, independent
 // tenant from the harness's own default fixture.
 func seedOverlayModeWorkspace(t *testing.T) (ws, user ids.UUID) {
 	t.Helper()
-	owner := OwnerConn(t)
+	owner := integration.OwnerConn(t)
 	ws = ids.NewV7()
 	if _, err := owner.Exec(context.Background(),
 		`INSERT INTO workspace (id, name, slug, base_currency, x_sor_mode, x_incumbent)
@@ -146,7 +147,7 @@ func seedOverlayModeWorkspace(t *testing.T) (ws, user ids.UUID) {
 // ones that actually run. RowScope is All because overlay ROW visibility is
 // the store's mirror_visibility deny-join (HubSpot-owner mapping), not the
 // RBAC owner predicate — an unmapped actor still sees zero rows despite
-// RowScopeAll. (ReadOnlyPerms would under-grant here: it omits
+// RowScopeAll. (integration.ReadOnlyPerms would under-grant here: it omits
 // organization/lead/activity, which these overlay tests also read.)
 var overlayReaderPerms = principal.Permissions{
 	RoleKeys: []string{"read_only"},
@@ -178,7 +179,7 @@ func overlayActorCtxWith(ws, user ids.UUID, perms principal.Permissions) context
 	})
 }
 
-// stubOwnerEmails is a no-op overlay.OwnerEmailResolver: this suite's
+// stubOwnerEmails is a no-op overlaymod.OwnerEmailResolver: this suite's
 // mirror_user_map row uses match_source="manual" (the human-override
 // path that never calls OwnerEmail) and Ingest's own revalidation
 // treats a resolution failure as "no email" and fails closed rather

--- a/backend/internal/compose/integration/overlay/overlay_e2e_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_e2e_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package integration
+package overlay
 
 // The full HubSpot-overlay read+sync path, end to end, over the
 // real handler stack + a real migrated Postgres. This is the ONE place
@@ -19,7 +19,7 @@ package integration
 // retained and PII-free.
 //
 // The fake incumbent is the SEAM the test drives Backfill with directly
-// (package-level overlay.Backfill, the same call jobs.go's poller and
+// (package-level overlaymod.Backfill, the same call jobs.go's poller and
 // backfill.go's own doc describe) — connect's own HTTP call still names
 // "hubspot" (branch 1's Connect only ever validates that one incumbent
 // name, connection.go's ConnectInput.validate), but never reaches a real
@@ -28,11 +28,11 @@ package integration
 // posture backfill_test.go and the fake package's own doc already
 // establish.
 //
-// This test needs a *pgxpool.Pool of its own (the apptest.AppEnv harness
-// exposes none) to drive compose.Dispatcher/overlay.Backfill directly —
-// openAppPool opens a second, independent app-role connection to the
-// SAME database the httptest server is backed by, so rows committed
-// through one are immediately visible through the other.
+// This test drives compose.Dispatcher/overlaymod.Backfill directly, and does it
+// on a pool of its own rather than apptest.AppEnv's. Not for want of access —
+// AppEnv.Pool is exported — but for INDEPENDENCE: openAppPool opens a second
+// app-role connection to the SAME database the httptest server is backed by, so
+// rows committed through one are immediately visible through the other.
 
 import (
 	"context"
@@ -47,7 +47,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/compose"
 	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
-	"github.com/gradionhq/margince/backend/internal/modules/overlay"
+	overlaymod "github.com/gradionhq/margince/backend/internal/modules/overlay"
 	"github.com/gradionhq/margince/backend/internal/modules/overlay/fake"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
@@ -196,7 +196,7 @@ func connectOverlayToTheFakeIncumbent(t *testing.T, e *apptest.AppEnv) (adminID,
 // admin's, the actor every mirror-backed read below runs as.
 func backfillOneMirroredContact(t *testing.T, pool *pgxpool.Pool, wsID, adminID ids.UUID) context.Context {
 	t.Helper()
-	mirror := overlay.NewMirrorStore(pool, stubOwnerEmails{})
+	mirror := overlaymod.NewMirrorStore(pool, stubOwnerEmails{})
 	adminCtx := overlayActorCtx(wsID, adminID)
 	if err := mirror.UpsertUserMap(adminCtx, ids.From[ids.UserKind](adminID), "hubspot", "owner-1", "manual"); err != nil {
 		t.Fatalf("mapping the admin to the fake incumbent owner: %v", err)
@@ -210,8 +210,8 @@ func backfillOneMirroredContact(t *testing.T, pool *pgxpool.Pool, wsID, adminID 
 	rec := fake.Rec("555000111", map[string]any{"first_name": "Ada", "last_name": "Overlay"})
 	rec.ObjectClass = "person"
 	rec.OwnerExternalID = "owner-1"
-	fakeInc.Seed(overlay.IncumbentClassContacts, rec)
-	if _, err := overlay.Backfill(adminCtx, fakeInc, mirror, overlay.IncumbentClassContacts, time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)); err != nil {
+	fakeInc.Seed(overlaymod.IncumbentClassContacts, rec)
+	if _, err := overlaymod.Backfill(adminCtx, fakeInc, mirror, overlaymod.IncumbentClassContacts, time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)); err != nil {
 		t.Fatalf("backfilling the fake incumbent's contacts: %v", err)
 	}
 	return adminCtx

--- a/backend/internal/compose/integration/overlay/overlay_flip_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_flip_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package integration
+package overlay
 
 // The overlay→native flip lane (OVA-AC-6 a/b + B-E18.26/27), over the
 // real composed HTTP stack + a real migrated Postgres, with the fake
@@ -61,10 +61,11 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration"
 	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/modules/migration"
-	"github.com/gradionhq/margince/backend/internal/modules/overlay"
+	overlaymod "github.com/gradionhq/margince/backend/internal/modules/overlay"
 	"github.com/gradionhq/margince/backend/internal/modules/overlay/fake"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
@@ -82,7 +83,7 @@ type flipEstate struct {
 	e       *apptest.AppEnv
 	wsID    ids.UUID
 	adminID ids.UUID
-	mirror  *overlay.MirrorStore
+	mirror  *overlaymod.MirrorStore
 	pool    *pgxpool.Pool
 	fakeInc *fake.Adapter
 	// adminCtx is a fully-granted admin principal bound to the workspace
@@ -167,7 +168,7 @@ func setupFlipEstate(t *testing.T) flipEstate {
 	}
 
 	pool := openAppPool(t)
-	mirror := overlay.NewMirrorStore(pool, stubOwnerEmails{})
+	mirror := overlaymod.NewMirrorStore(pool, stubOwnerEmails{})
 	adminCtx := flipAdminCtx(wsID, adminID)
 
 	if err := mirror.UpsertUserMap(adminCtx, ids.From[ids.UserKind](adminID), "hubspot", "owner-1", "manual"); err != nil {
@@ -188,21 +189,21 @@ func setupFlipEstate(t *testing.T) flipEstate {
 		rec.OwnerExternalID = "owner-1"
 		fakeInc.Seed(incumbentClass, rec)
 	}
-	// Child fields are seeded NESTED, the shape overlay.Apply actually
+	// Child fields are seeded NESTED, the shape overlaymod.Apply actually
 	// lands them in (mapping.go's TargetChild) — a flat "person_email.email"
 	// key is a shape the mapper never produces, and seeding one would let
 	// a writer that reads it flat pass while dropping every real email.
-	seed(overlay.IncumbentClassCompanies, "organization", "org-1", map[string]any{
+	seed(overlaymod.IncumbentClassCompanies, "organization", "org-1", map[string]any{
 		"display_name": "BÄR Pharma", "organization_domain": map[string]any{"domain": "baer-pharma.test"},
 	})
-	seed(overlay.IncumbentClassCompanies, "organization", "org-2", map[string]any{
+	seed(overlaymod.IncumbentClassCompanies, "organization", "org-2", map[string]any{
 		"display_name": "Gitex", "organization_domain": map[string]any{"domain": "gitex.test"},
 	})
-	seed(overlay.IncumbentClassContacts, "person", "p-1", map[string]any{
+	seed(overlaymod.IncumbentClassContacts, "person", "p-1", map[string]any{
 		"full_name": "Mor Anders", "first_name": "Mor", "last_name": "Anders",
 		"person_email": map[string]any{"email": "mor@baer-pharma.test"},
 	})
-	seed(overlay.IncumbentClassContacts, "person", "p-2", map[string]any{
+	seed(overlaymod.IncumbentClassContacts, "person", "p-2", map[string]any{
 		"full_name": "Riya Patel", "person_email": map[string]any{"email": "riya@gitex.test"},
 	})
 	// A contact the incumbent left unowned — the common case in a real
@@ -211,27 +212,27 @@ func setupFlipEstate(t *testing.T) flipEstate {
 	// at every tier, while the mirror row was hidden from every seat).
 	unowned := fake.Rec("p-unowned", map[string]any{"full_name": "Unassigned Contact"})
 	unowned.ObjectClass = "person"
-	fakeInc.Seed(overlay.IncumbentClassContacts, unowned)
-	seed(overlay.IncumbentClassDeals, "deal", "d-open", map[string]any{
+	fakeInc.Seed(overlaymod.IncumbentClassContacts, unowned)
+	seed(overlaymod.IncumbentClassDeals, "deal", "d-open", map[string]any{
 		"name": "Packaging QA", "stage_id": "appointmentscheduled", "amount_minor": int64(21200000), "currency": "EUR",
 	})
-	seed(overlay.IncumbentClassDeals, "deal", "d-won", map[string]any{
+	seed(overlaymod.IncumbentClassDeals, "deal", "d-won", map[string]any{
 		"name": "Filling Line", "stage_id": "closedwon", "amount_minor": int64(500000), "currency": "EUR",
 	})
-	seed(overlay.IncumbentClassLeads, "lead", "l-1", map[string]any{
+	seed(overlaymod.IncumbentClassLeads, "lead", "l-1", map[string]any{
 		"full_name": "Lars Prospect", "email": "lars@prospect.test",
 	})
-	seed(overlay.IncumbentClassEmails, "activity", "emails:900", map[string]any{
+	seed(overlaymod.IncumbentClassEmails, "activity", "emails:900", map[string]any{
 		"kind": "email", "subject": "Intro call follow-up", "body": "Notes from the call.",
 		"occurred_at": "2026-07-01T10:00:00Z", "direction": "outbound",
 	})
 
 	backfillClasses := append([]string{
-		overlay.IncumbentClassCompanies, overlay.IncumbentClassContacts,
-		overlay.IncumbentClassDeals, overlay.IncumbentClassLeads,
-	}, overlay.IncumbentEngagementClasses()...)
+		overlaymod.IncumbentClassCompanies, overlaymod.IncumbentClassContacts,
+		overlaymod.IncumbentClassDeals, overlaymod.IncumbentClassLeads,
+	}, overlaymod.IncumbentEngagementClasses()...)
 	for _, class := range backfillClasses {
-		if _, err := overlay.Backfill(adminCtx, fakeInc, mirror, class, connectedAt); err != nil {
+		if _, err := overlaymod.Backfill(adminCtx, fakeInc, mirror, class, connectedAt); err != nil {
 			t.Fatalf("backfilling %s: %v", class, err)
 		}
 	}
@@ -239,7 +240,7 @@ func setupFlipEstate(t *testing.T) flipEstate {
 	// The association edges (canonical vocabulary, the adapter's output
 	// shape): deal→organization FK, person→organization employment,
 	// activity→person link.
-	for _, a := range []overlay.Assoc{
+	for _, a := range []overlaymod.Assoc{
 		{FromType: "deal", FromID: "d-open", ToType: "organization", ToID: "org-1", TypeID: 5, Category: "HUBSPOT_DEFINED", Direction: "forward"},
 		{FromType: "person", FromID: "p-1", ToType: "organization", ToID: "org-1", TypeID: 1, Category: "HUBSPOT_DEFINED", Label: "primary", Direction: "forward"},
 		{FromType: "activity", FromID: "emails:900", ToType: "person", ToID: "p-1", TypeID: 9, Category: "HUBSPOT_DEFINED", Direction: "forward"},
@@ -655,7 +656,7 @@ func TestOverlayExportDownload(t *testing.T) {
 	// A real archive carrying BOTH halves of AC-OV-9: the mirror
 	// snapshot members, and the manifest line disclosing that canonical
 	// data still resides in the incumbent.
-	entries := bundleEntries(t, body)
+	entries := integration.BundleEntries(t, body)
 	var manifest struct {
 		CanonicalDataResidesIn string `json:"canonical_data_resides_in"`
 	}
@@ -674,7 +675,7 @@ func TestOverlayExportDownload(t *testing.T) {
 	// header — counted through the CSV reader, since a newline inside a
 	// quoted `fields` cell would inflate a line count and mask a
 	// dropped row.
-	if got := len(csvColumn(t, entries["overlay_mirror.csv"], "external_id")); got != 9 {
+	if got := len(integration.CSVColumn(t, entries["overlay_mirror.csv"], "external_id")); got != 9 {
 		t.Errorf("overlay_mirror.csv has %d rows, want the 9 seeded mirror records", got)
 	}
 

--- a/backend/internal/compose/integration/overlay/overlay_flipclaim_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_flipclaim_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package integration
+package overlay
 
 // The flip's claim and the liveness signal Disconnect reads off it,
 // against real Postgres advisory locks.

--- a/backend/internal/compose/integration/overlay/overlay_toolsurface_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_toolsurface_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package integration
+package overlay
 
 // Bounded equivalence on the AGENT surface (AC-OV-2 / ADR-0018): every tool
 // the production registry advertises must, for an overlay-mode workspace,
@@ -31,7 +31,8 @@ import (
 	"time"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
-	"github.com/gradionhq/margince/backend/internal/modules/overlay"
+	"github.com/gradionhq/margince/backend/internal/compose/integration"
+	overlaymod "github.com/gradionhq/margince/backend/internal/modules/overlay"
 	"github.com/gradionhq/margince/backend/internal/platform/overlaybudget"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -118,7 +119,7 @@ func nativeToolReaderPerms() principal.Permissions {
 }
 
 func TestOverlayAgentToolsRefuseRatherThanAnswerFromNativeTables(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	ws, user := seedOverlayModeWorkspace(t)
 	registry := compose.NewRegistry(e.Pool, compose.SendPath{})
 	// Every object grant a guarded read could need, so an unwired guard fails
@@ -151,15 +152,15 @@ func TestOverlayAgentToolsRefuseRatherThanAnswerFromNativeTables(t *testing.T) {
 // patch would pass through. The assertion that matters most is the negative
 // one: the mirror row is untouched, so nothing was pushed.
 func TestOverlayUpdateRecordRefusesAnAgentRatherThanWritingBack(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	overlayWS, actorID := seedOverlayModeWorkspace(t)
 	ctx := overlayActorCtx(overlayWS, actorID)
 
-	mirror := overlay.NewMirrorStore(e.Pool, stubOwnerEmails{})
+	mirror := overlaymod.NewMirrorStore(e.Pool, stubOwnerEmails{})
 	if err := mirror.UpsertUserMap(ctx, ids.From[ids.UserKind](actorID), "hubspot", "owner-1", "manual"); err != nil {
 		t.Fatalf("mapping the acting user to owner-1: %v", err)
 	}
-	if err := mirror.Ingest(ctx, overlay.Record{
+	if err := mirror.Ingest(ctx, overlaymod.Record{
 		ObjectClass:     "person",
 		ExternalID:      "100214862042",
 		Fields:          map[string]any{"firstname": "Ada", "lastname": "Overlay", "jobtitle": "Analyst"},
@@ -193,7 +194,7 @@ func TestOverlayUpdateRecordRefusesAnAgentRatherThanWritingBack(t *testing.T) {
 	// dead-ends, since the decidability probe and the redemption version pin
 	// both read tables a mirrored record has no row in.
 	var staged int
-	if err := OwnerConn(t).QueryRow(ctx,
+	if err := integration.OwnerConn(t).QueryRow(ctx,
 		`SELECT count(*) FROM approval WHERE workspace_id = $1`, overlayWS).Scan(&staged); err != nil {
 		t.Fatalf("counting staged approvals: %v", err)
 	}
@@ -221,15 +222,15 @@ func TestOverlayUpdateRecordRefusesAnAgentRatherThanWritingBack(t *testing.T) {
 // refusal has to live. Testing it here covers every one of those routes at
 // once rather than one route and a hope.
 func TestOverlayWritesRefuseAnUnreleasedAgentAtTheSeam(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	ws, actorID := seedOverlayModeWorkspace(t)
 	ctx := overlayActorCtx(ws, actorID)
 
-	mirror := overlay.NewMirrorStore(e.Pool, stubOwnerEmails{})
+	mirror := overlaymod.NewMirrorStore(e.Pool, stubOwnerEmails{})
 	if err := mirror.UpsertUserMap(ctx, ids.From[ids.UserKind](actorID), "hubspot", "owner-1", "manual"); err != nil {
 		t.Fatalf("mapping the acting user to owner-1: %v", err)
 	}
-	if err := mirror.Ingest(ctx, overlay.Record{
+	if err := mirror.Ingest(ctx, overlaymod.Record{
 		ObjectClass: "person", ExternalID: "100214862044",
 		Fields:     map[string]any{"firstname": "Seam", "lastname": "Backstop"},
 		ModifiedAt: time.Now().UTC(), OwnerExternalID: "owner-1",
@@ -292,7 +293,7 @@ func agentActorCtx(ws, user ids.UUID) context.Context {
 // x_sor_mode underneath with no invalidation, and assert the gate still
 // holds.
 func TestOverlayUpdateRecordEgressGateIgnoresAStaleNativeModeCache(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	ws, actorID := seedNativeModeWorkspaceForFlip(t)
 	ctx := overlayActorCtx(ws, actorID)
 	registry := compose.NewRegistry(e.Pool, compose.SendPath{})
@@ -306,16 +307,16 @@ func TestOverlayUpdateRecordEgressGateIgnoresAStaleNativeModeCache(t *testing.T)
 
 	// Flip to overlay the way a connect does, but WITHOUT Invalidate — the
 	// state a second replica is in for the rest of the TTL.
-	if _, err := OwnerConn(t).Exec(ctx,
+	if _, err := integration.OwnerConn(t).Exec(ctx,
 		`UPDATE workspace SET x_sor_mode = 'overlay', x_incumbent = 'hubspot' WHERE id = $1`, ws); err != nil {
 		t.Fatalf("flipping the workspace to overlay mode: %v", err)
 	}
 
-	mirror := overlay.NewMirrorStore(e.Pool, stubOwnerEmails{})
+	mirror := overlaymod.NewMirrorStore(e.Pool, stubOwnerEmails{})
 	if err := mirror.UpsertUserMap(ctx, ids.From[ids.UserKind](actorID), "hubspot", "owner-1", "manual"); err != nil {
 		t.Fatalf("mapping the acting user to owner-1: %v", err)
 	}
-	if err := mirror.Ingest(ctx, overlay.Record{
+	if err := mirror.Ingest(ctx, overlaymod.Record{
 		ObjectClass:     "person",
 		ExternalID:      "100214862043",
 		Fields:          map[string]any{"firstname": "Grace", "lastname": "Stale", "jobtitle": "Analyst"},
@@ -349,7 +350,7 @@ func TestOverlayUpdateRecordEgressGateIgnoresAStaleNativeModeCache(t *testing.T)
 // native window to cache.
 func seedNativeModeWorkspaceForFlip(t *testing.T) (ws, user ids.UUID) {
 	t.Helper()
-	owner := OwnerConn(t)
+	owner := integration.OwnerConn(t)
 	ws = ids.NewV7()
 	if _, err := owner.Exec(context.Background(),
 		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Pre-flip', $2, 'EUR')`,
@@ -381,7 +382,7 @@ func mergedFixtures(sets ...map[string]string) map[string]string {
 }
 
 func TestNativeAgentToolsAreNotRefusedByTheSoRModeGuard(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	registry := compose.NewRegistry(e.Pool, compose.SendPath{})
 	ctx := e.As(e.Rep1, nil, nativeToolReaderPerms())
 

--- a/backend/internal/compose/integration/overlay/overlay_usermap_http_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_usermap_http_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package integration
+package overlay
 
 // The admin user-map remedy loop, end to end over the composed overlay
 // service and a real migrated Postgres. Overlay visibility is fail-closed:
@@ -27,7 +27,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gradionhq/margince/backend/internal/modules/overlay"
+	"github.com/gradionhq/margince/backend/internal/compose/integration"
+	overlaymod "github.com/gradionhq/margince/backend/internal/modules/overlay"
 	"github.com/gradionhq/margince/backend/internal/modules/overlay/fake"
 	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
@@ -95,7 +96,7 @@ func overlayUserMapAdminCtx(ws, user ids.UUID) context.Context {
 func overlayAppUserEmail(t *testing.T, user ids.UUID) string {
 	t.Helper()
 	var email string
-	if err := OwnerConn(t).QueryRow(context.Background(),
+	if err := integration.OwnerConn(t).QueryRow(context.Background(),
 		`SELECT email FROM app_user WHERE id = $1`, user).Scan(&email); err != nil {
 		t.Fatalf("reading %s's stored email: %v", user, err)
 	}
@@ -108,7 +109,7 @@ func overlayAppUserEmail(t *testing.T, user ids.UUID) string {
 // and after the sweep declines to restore it — and each of them means the
 // same thing: existence-hiding ErrNotFound, never an empty-but-successful
 // read and never a 403.
-func requireContactHidden(ctx context.Context, t *testing.T, store *overlay.MirrorStore, why string) {
+func requireContactHidden(ctx context.Context, t *testing.T, store *overlaymod.MirrorStore, why string) {
 	t.Helper()
 	if _, err := store.Get(ctx, "person", mirroredContactID); !errors.Is(err, apperrors.ErrNotFound) {
 		t.Fatalf("mirror read = %v, want apperrors.ErrNotFound — %s", err, why)
@@ -116,7 +117,7 @@ func requireContactHidden(ctx context.Context, t *testing.T, store *overlay.Mirr
 }
 
 // userMapViewFor finds one user's row on an admin mapping page.
-func userMapViewFor(t *testing.T, page overlay.UserMapPage, user ids.UUID) overlay.UserMapView {
+func userMapViewFor(t *testing.T, page overlaymod.UserMapPage, user ids.UUID) overlaymod.UserMapView {
 	t.Helper()
 	for _, v := range page.Entries {
 		if v.AppUserID == ids.From[ids.UserKind](user) {
@@ -124,7 +125,7 @@ func userMapViewFor(t *testing.T, page overlay.UserMapPage, user ids.UUID) overl
 		}
 	}
 	t.Fatalf("user %s does not appear on the mapping page (%d entries) — the surface an admin acts on must list them", user, len(page.Entries))
-	return overlay.UserMapView{}
+	return overlaymod.UserMapView{}
 }
 
 // TestAnUnmappedAdminMapsThemselvesAndTheRecordsAppear walks the remedy an
@@ -132,7 +133,7 @@ func userMapViewFor(t *testing.T, page overlay.UserMapPage, user ids.UUID) overl
 // on the invariant the whole surface hangs on: an unmap is a decision, and
 // the sweep does not get to undo it.
 func TestAnUnmappedAdminMapsThemselvesAndTheRecordsAppear(t *testing.T) {
-	e := Setup(t)
+	e := integration.Setup(t)
 	ws, admin := seedOverlayModeWorkspace(t)
 	adminCtx := overlayUserMapAdminCtx(ws, admin)
 	adminUser := ids.From[ids.UserKind](admin)
@@ -140,14 +141,14 @@ func TestAnUnmappedAdminMapsThemselvesAndTheRecordsAppear(t *testing.T) {
 	fakeInc := fake.New()
 	fakeInc.SeedOwner(recordOwner, unmatchedOwnerEmail)
 
-	store := overlay.NewMirrorStore(e.Pool, fakeInc)
-	svc := overlay.NewService(e.Pool, keyvault.NewMemory(), store).
-		WithIncumbentFactory(func(string, string) overlay.Incumbent { return fakeInc })
+	store := overlaymod.NewMirrorStore(e.Pool, fakeInc)
+	svc := overlaymod.NewService(e.Pool, keyvault.NewMemory(), store).
+		WithIncumbentFactory(func(string, string) overlaymod.Incumbent { return fakeInc })
 
 	// The connection is what makes the owners directory readable, and the
 	// directory is what lets the page tell "no owner carries this email"
 	// apart from "we could not look".
-	if _, err := svc.Connect(adminCtx, overlay.ConnectInput{
+	if _, err := svc.Connect(adminCtx, overlaymod.ConnectInput{
 		Incumbent: "hubspot", Region: "eu1", Token: "pat-served-only-by-the-fake",
 	}); err != nil {
 		t.Fatalf("connecting the fake incumbent: %v", err)
@@ -155,14 +156,14 @@ func TestAnUnmappedAdminMapsThemselvesAndTheRecordsAppear(t *testing.T) {
 
 	// --- the incumbent owns one contact, through an owner who is not the
 	// admin: mirrored through the real backfill seam, not hand-inserted ---
-	fakeInc.Seed(overlay.IncumbentClassContacts, overlay.Record{
+	fakeInc.Seed(overlaymod.IncumbentClassContacts, overlaymod.Record{
 		ObjectClass:     "person",
 		ExternalID:      mirroredContactID,
 		Fields:          map[string]any{"first_name": "Ada", "last_name": "Overlay"},
 		ModifiedAt:      incumbentEpoch,
 		OwnerExternalID: recordOwner,
 	})
-	if _, err := overlay.Backfill(adminCtx, fakeInc, store, overlay.IncumbentClassContacts, incumbentEpoch); err != nil {
+	if _, err := overlaymod.Backfill(adminCtx, fakeInc, store, overlaymod.IncumbentClassContacts, incumbentEpoch); err != nil {
 		t.Fatalf("backfilling the fake incumbent's contacts: %v", err)
 	}
 

--- a/backend/internal/compose/integration/overlay/overlay_write_audit_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_write_audit_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package integration
+package overlay
 
 // The write-back GOVERNANCE story, proven over the real HTTP surface and a
 // real migrated Postgres: a human write against a workspace in overlay mode

--- a/backend/internal/compose/integration/overlay/overlay_write_shadow_integration_test.go
+++ b/backend/internal/compose/integration/overlay/overlay_write_shadow_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package integration
+package overlay
 
 // The write-shadow story (compose/overlaywriteshadow.go), proven over the
 // real HTTP surface + a real migrated Postgres: an ordinary REST update or
@@ -11,7 +11,7 @@ package integration
 // incumbent and answers with the re-mirrored row. The overlay-mode write
 // guard (compose/overlaywrite.go) admits a mirrored-type write the whole
 // way to a handler on the promise that a shadow serves it
-// (overlay.SupportsWrite); a supported write with no shadow falls through
+// (overlaymod.SupportsWrite); a supported write with no shadow falls through
 // to the native module handler's promoted method instead and commits to
 // the empty overlay-mode table — this file is what proves that promise
 // holds for every write the guard admits.
@@ -33,7 +33,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/compose"
 	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
-	"github.com/gradionhq/margince/backend/internal/modules/overlay"
+	overlaymod "github.com/gradionhq/margince/backend/internal/modules/overlay"
 	"github.com/gradionhq/margince/backend/internal/modules/overlay/fake"
 	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -50,7 +50,7 @@ import (
 type overlayWriteEnv struct {
 	*apptest.AppEnv
 	fake   *fake.Adapter
-	mirror *overlay.MirrorStore
+	mirror *overlaymod.MirrorStore
 	ctx    context.Context // workspace+admin-bound, for direct mirror/fake seeding
 }
 
@@ -63,7 +63,7 @@ func setupOverlayWrite(t *testing.T) overlayWriteEnv {
 		// Applied AFTER WithKeyvault so it wins: WithKeyvault's own
 		// SetOverlayIncumbentResolver call would otherwise install the
 		// real vaulted resolver last.
-		compose.WithOverlayIncumbentResolver(func(context.Context) (overlay.Incumbent, error) { return fakeInc, nil }))
+		compose.WithOverlayIncumbentResolver(func(context.Context) (overlaymod.Incumbent, error) { return fakeInc, nil }))
 	e.BootstrapWorkspace(t)
 
 	var conn map[string]any
@@ -90,7 +90,7 @@ func setupOverlayWrite(t *testing.T) overlayWriteEnv {
 		t.Fatalf("parsing workspace id: %v", err)
 	}
 
-	mirror := overlay.NewMirrorStore(e.Pool, stubOwnerEmails{})
+	mirror := overlaymod.NewMirrorStore(e.Pool, stubOwnerEmails{})
 	actorCtx := overlayActorCtx(wsID, adminID)
 	if err := mirror.UpsertUserMap(actorCtx, ids.From[ids.UserKind](adminID), "hubspot", "owner-1", "manual"); err != nil {
 		t.Fatalf("mapping the admin to the fake incumbent owner: %v", err)
@@ -122,7 +122,7 @@ var seedModifiedAt = time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 // refuses the very first write this test issues.
 func (e overlayWriteEnv) seed(t *testing.T, class, externalID string, fields map[string]any) {
 	t.Helper()
-	rec := overlay.Record{ExternalID: externalID, Fields: fields, ModifiedAt: seedModifiedAt}
+	rec := overlaymod.Record{ExternalID: externalID, Fields: fields, ModifiedAt: seedModifiedAt}
 	rec.ObjectClass = class
 	rec.OwnerExternalID = "owner-1"
 	e.fake.Seed(class, rec)

--- a/backend/internal/compose/integration/preference_center_integration_test.go
+++ b/backend/internal/compose/integration/preference_center_integration_test.go
@@ -59,7 +59,7 @@ func sendMarketing(t *testing.T, e *apptest.AppEnv, activityID, purpose, host, x
 	if xfProto != "" {
 		req.Header.Set("X-Forwarded-Proto", xfProto)
 	}
-	resp, err := e.Client.Do(req) //nolint:bodyclose // closed by the deferred apptest.CloseBody below; bodyclose only sees a Close in the same package, and the closer moved out with the fixture
+	resp, err := e.Client.Do(req) //nolint:bodyclose // closed by apptest.CloseBody below; bodyclose only recognises a Close in the same package
 	if err != nil {
 		t.Fatalf("send-email: %v", err)
 	}

--- a/backend/internal/compose/integration/public_booking_integration_test.go
+++ b/backend/internal/compose/integration/public_booking_integration_test.go
@@ -46,7 +46,7 @@ func publicCall(t *testing.T, e *apptest.AppEnv, method, path string, body any, 
 	for k, v := range headers {
 		req.Header.Set(k, v)
 	}
-	resp, err := e.TS.Client().Do(req) //nolint:bodyclose // closed by the deferred apptest.CloseBody below; bodyclose only sees a Close in the same package, and the closer moved out with the fixture
+	resp, err := e.TS.Client().Do(req) //nolint:bodyclose // closed by apptest.CloseBody below; bodyclose only recognises a Close in the same package
 	if err != nil {
 		t.Fatalf("%s %s: %v", method, path, err)
 	}

--- a/backend/internal/compose/integration/queryvocabulary_integration_test.go
+++ b/backend/internal/compose/integration/queryvocabulary_integration_test.go
@@ -167,7 +167,7 @@ func readPassport(t *testing.T, e *apptest.AppEnv, label string) string {
 // a decoded result.
 func mcpRPC(e *apptest.AppEnv, t *testing.T, bearer, payload string) string {
 	t.Helper()
-	got := raw(e, t, http.MethodPost, "/mcp", payload, map[string]string{
+	got := mcpRaw(e, t, http.MethodPost, "/mcp", payload, map[string]string{
 		"Content-Type": "application/json", "Authorization": "Bearer " + bearer,
 	})
 	if got.StatusCode != http.StatusOK {

--- a/backend/internal/compose/integration/quotas_http_integration_test.go
+++ b/backend/internal/compose/integration/quotas_http_integration_test.go
@@ -12,13 +12,13 @@ package integration
 // mapping (owner_xor_team_required, the two attainment 422s, the
 // currency CHECK's constraint_violated) and the JSON shape only exist at
 // this layer. Rides the same real-handler-stack e2e harness as
-// e2e_integration_test.go (TLS httptest server, session cookie, workspace
+// integration/apptest (TLS httptest server, session cookie, workspace
 // header).
 //
 // There is no /v1/teams or role-management endpoint yet (both are
 // fast-follow per crm.yaml's own NET-NEW comment) — the team fixture and
 // the rep-role demotion for the 403 scenario use the owner connection
-// directly, the same technique e2e_integration_test.go's
+// directly, the same technique apptest's
 // SetWorkspaceSeat already uses for seat_type.
 
 import (

--- a/backend/internal/compose/integration/recordhistory_http_integration_test.go
+++ b/backend/internal/compose/integration/recordhistory_http_integration_test.go
@@ -11,7 +11,7 @@ package integration
 // drives — that suite calls privacy.ListRecordHistory directly, so the
 // entity_type path-param validation, the malformed-cursor 422, and the
 // JSON shape only exist at the transport. This suite rides the same
-// real-handler-stack e2e harness as e2e_integration_test.go (TLS httptest
+// real-handler-stack e2e harness apptest.AppEnv (TLS httptest
 // server, session cookie, workspace header) and reuses
 // recordhistory_integration_test.go's seedRecordAuditRow/seedWorkspaceUser
 // plus fieldhistory_integration_test.go's seedAuditDiffRow to write the

--- a/backend/internal/compose/integration/requiredbodyids_http_integration_test.go
+++ b/backend/internal/compose/integration/requiredbodyids_http_integration_test.go
@@ -388,7 +388,7 @@ func postRawBody(t *testing.T, e *apptest.AppEnv, path, body string, headers map
 	for k, v := range headers {
 		req.Header.Set(k, v)
 	}
-	resp, err := e.Client.Do(req) //nolint:bodyclose // closed by the deferred apptest.CloseBody below; bodyclose only sees a Close in the same package, and the closer moved out with the fixture
+	resp, err := e.Client.Do(req) //nolint:bodyclose // closed by apptest.CloseBody below; bodyclose only recognises a Close in the same package
 	if err != nil {
 		t.Fatalf("POST %s: %v", path, err)
 	}

--- a/backend/internal/compose/integration/voicepreview_http_integration_test.go
+++ b/backend/internal/compose/integration/voicepreview_http_integration_test.go
@@ -89,7 +89,7 @@ func TestVoiceCorpusPreviewAndIngestStatsHTTP(t *testing.T) {
 		t.Fatal(err)
 	}
 	req.Header.Set("Content-Type", "application/json")
-	resp, err := e.Client.Do(req) //nolint:bodyclose // closed by the deferred apptest.CloseBody below; bodyclose only sees a Close in the same package, and the closer moved out with the fixture
+	resp, err := e.Client.Do(req) //nolint:bodyclose // closed by apptest.CloseBody below; bodyclose only recognises a Close in the same package
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/compose/lifecycleoverlay_test.go
+++ b/backend/internal/compose/lifecycleoverlay_test.go
@@ -13,18 +13,54 @@ package compose
 // This file proves the SET and the one seam guard. That each derived verb
 // actually answers ErrUnsupportedBySoR is proved where it can only be proved —
 // against a real overlay workspace, in
-// compose/integration/overlay_toolsurface_integration_test.go, whose
+// compose/integration/overlay/overlay_toolsurface_integration_test.go, whose
 // nativeOnlyAgentTools drives every one of them through the live registry.
 
 import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io/fs"
+	"path/filepath"
 	"testing"
 
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
+
+// overlayPinName is the integration suite two gates in this package defer to: it
+// drives every native-only verb through the live registry against a real overlay
+// workspace, so the lists here can be derived from it rather than hand-kept.
+const overlayPinName = "overlay_toolsurface_integration_test.go"
+
+// overlayPin locates that suite by NAME, anywhere under integration/.
+//
+// Not a fixed relative path, which is what both gates used to hold: the suite
+// moved once — into its own package, to give the lane another scheduling slot —
+// and both gates failed on a path rather than on anything about the code. A gate
+// that breaks when a file it only READS is relocated is asserting where the file
+// lives, which is not the obligation it exists for.
+func overlayPin(t *testing.T) string {
+	t.Helper()
+	var found string
+	err := filepath.WalkDir("integration", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() && d.Name() == overlayPinName {
+			found = path
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking integration/ for %s: %v", overlayPinName, err)
+	}
+	if found == "" {
+		t.Fatalf("%s is nowhere under integration/ — the pin these gates defer to is gone, "+
+			"so they would assert nothing", overlayPinName)
+	}
+	return found
+}
 
 // unservableRecordWriteVerbs derives the set: a verb that writes a record
 // (overlayRecordWriteTools) and has no seam verb the overlay provider can serve
@@ -61,7 +97,7 @@ func TestEveryUnservableRecordWriteVerbIsARegisteredToolTheOverlayPinDrives(t *t
 		if !driven[verb] {
 			t.Errorf("%s writes a record the overlay provider cannot serve, so an overlay workspace must "+
 				"meet a declared refusal on the TOOL path too — and nothing proves it does. Add it to "+
-				"nativeOnlyAgentTools in compose/integration/overlay_toolsurface_integration_test.go, "+
+				"nativeOnlyAgentTools in compose/integration/overlay/overlay_toolsurface_integration_test.go, "+
 				"which drives each verb through the live registry against a real overlay workspace.", verb)
 		}
 	}
@@ -72,7 +108,7 @@ func TestEveryUnservableRecordWriteVerbIsARegisteredToolTheOverlayPinDrives(t *t
 // with it while the pin covers something else.
 func overlayPinnedToolVerbs(t *testing.T) map[string]bool {
 	t.Helper()
-	const pin = "integration/overlay_toolsurface_integration_test.go"
+	pin := overlayPin(t)
 	// Two fixtures, because the two refusal mechanisms are different facts:
 	// nativeOnlyAgentTools are decorator-guarded, providerRefusedRecordWrites
 	// inherit the provider's own refusal. The same suite drives both.

--- a/backend/internal/compose/lifecycleoverlay_test.go
+++ b/backend/internal/compose/lifecycleoverlay_test.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"io/fs"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
@@ -35,31 +36,44 @@ const overlayPinName = "overlay_toolsurface_integration_test.go"
 
 // overlayPin locates that suite by NAME, anywhere under integration/.
 //
-// Not a fixed relative path, which is what both gates used to hold: the suite
-// moved once — into its own package, to give the lane another scheduling slot —
-// and both gates failed on a path rather than on anything about the code. A gate
-// that breaks when a file it only READS is relocated is asserting where the file
-// lives, which is not the obligation it exists for.
+// By name rather than by a fixed path, because a gate that breaks when a file it
+// only READS is relocated is asserting where the file lives, which is not the
+// obligation it exists for. The suites under integration/ are split into packages
+// as the lane needs scheduling slots, so that relocation is routine.
+//
+// Exactly one match, or this fails. Taking the last of several would be the
+// worse failure: a split in progress leaves two copies of a suite for as long as
+// it takes to delete the first, and both gates would silently derive their verb
+// lists from whichever the walk reached last — green against a stale pin, which
+// is the shape of every finding this gate exists to prevent.
 func overlayPin(t *testing.T) string {
 	t.Helper()
-	var found string
+	var found []string
 	err := filepath.WalkDir("integration", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 		if !d.IsDir() && d.Name() == overlayPinName {
-			found = path
+			found = append(found, path)
 		}
 		return nil
 	})
 	if err != nil {
 		t.Fatalf("walking integration/ for %s: %v", overlayPinName, err)
 	}
-	if found == "" {
-		t.Fatalf("%s is nowhere under integration/ — the pin these gates defer to is gone, "+
-			"so they would assert nothing", overlayPinName)
+	switch len(found) {
+	case 1:
+		return found[0]
+	case 0:
+		t.Fatalf("%s is nowhere under integration/ — the pin these gates defer to is gone, so they "+
+			"would assert nothing. Restore it, or point overlayPinName at whatever replaced it.",
+			overlayPinName)
+	default:
+		t.Fatalf("%d files named %s under integration/ (%s) — these gates cannot tell which one is "+
+			"the pin, and picking either would assert against a source nobody chose. Delete the "+
+			"stale copy, or rename it.", len(found), overlayPinName, strings.Join(found, ", "))
 	}
-	return found
+	return ""
 }
 
 // unservableRecordWriteVerbs derives the set: a verb that writes a record

--- a/backend/internal/compose/nativeonlytools_test.go
+++ b/backend/internal/compose/nativeonlytools_test.go
@@ -282,7 +282,7 @@ func TestSlippingGuardRefusesOnAStaleNativeCache(t *testing.T) {
 // wiring pin must cover exactly those tools.
 //
 // The unit specs above prove what a guard DOES given a mode; only
-// integration/overlay_toolsurface_integration_test.go proves a guard is actually
+// integration/overlay/overlay_toolsurface_integration_test.go proves a guard is actually
 // wired, and its map is written by hand. So the obligation is derived here:
 // declaring a guard enrols its tool.
 //
@@ -349,7 +349,7 @@ func TestEveryNativeOnlyGuardNamesAToolThePinCovers(t *testing.T) {
 		if named == 0 {
 			t.Errorf("%s names no tool the wiring pin covers. Its doc comment must name the tool(s) it "+
 				"guards, and each must appear in nativeOnlyAgentTools "+
-				"(compose/integration/overlay_toolsurface_integration_test.go) — a guard nothing drives "+
+				"(compose/integration/overlay/overlay_toolsurface_integration_test.go) — a guard nothing drives "+
 				"against a real overlay workspace is a guard nobody has tested.\ndoc: %q", guard, doc)
 		}
 	}
@@ -379,7 +379,7 @@ const nativeOnlyPrefix = "nativeOnly"
 // the whole point is that there be one.
 func pinnedNativeOnlyTools(t *testing.T) map[string]bool {
 	t.Helper()
-	const pinFile = "integration/overlay_toolsurface_integration_test.go"
+	pinFile := overlayPin(t)
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, pinFile, nil, 0)
 	if err != nil {

--- a/backend/jobfleetscan_test.go
+++ b/backend/jobfleetscan_test.go
@@ -182,14 +182,9 @@ func TestFleetEnumerationOnlyAtRatifiedSites(t *testing.T) {
 		// This gate judges PRODUCTION passes: the anti-pattern is one job row
 		// looping every tenant. An integration-tagged file is test harness — it
 		// never ships, and it has no job to take a workspace from — so it is out
-		// of scope by rule.
-		//
-		// goFilesUnder skips _test.go, which used to exclude the harness for free.
-		// It stopped doing so when a shared fixture was promoted into a non-test
-		// file to become importable, and the tempting fix — widening
-		// singleRowPredicates so the fixture's lookup stops matching — would have
-		// loosened a production gate tree-wide to accommodate a test. Scope is the
-		// thing that was wrong, so scope is what is fixed.
+		// of scope by rule. goFilesUnder's _test.go skip does not cover it: a
+		// shared fixture promoted into a non-test file to become importable is
+		// still harness.
 		//
 		// The migrate-once gate scopes the other way and INCLUDES these files, for
 		// the same reason read backwards: its obligation is about the integration

--- a/backend/jobfleetscan_test.go
+++ b/backend/jobfleetscan_test.go
@@ -40,15 +40,7 @@ const fleetScanMarker = "FROM workspace"
 // construction — with the exception of a SET-valued RHS, which setPredicates
 // takes back. Checked on the marker's own line and the one after it, because
 // the repo splits some query literals across lines.
-// slug is the workspace's other unique key (0002_identity.up.sql,
-// workspace_slug_unique), so a lookup by it reads exactly one row for the same
-// reason a lookup by id does. Named here rather than waived per file: a site
-// that resolves ONE workspace by its unique key is not the anti-pattern this
-// gate is about, and teaching that once beats granting it repeatedly.
-var singleRowPredicates = []string{
-	"WHERE id = ", "WHERE id=", "WHERE w.id = ",
-	"WHERE slug = ", "WHERE slug=",
-}
+var singleRowPredicates = []string{"WHERE id = ", "WHERE id=", "WHERE w.id = "}
 
 // setPredicates are the RHS spellings that equate id to a SET rather than to
 // one value. They look like a single-row predicate to the prefixes above and
@@ -187,6 +179,24 @@ func TestFleetEnumerationOnlyAtRatifiedSites(t *testing.T) {
 		t.Fatalf("walking internal: %v", err)
 	}
 	for _, path := range paths {
+		// This gate judges PRODUCTION passes: the anti-pattern is one job row
+		// looping every tenant. An integration-tagged file is test harness — it
+		// never ships, and it has no job to take a workspace from — so it is out
+		// of scope by rule.
+		//
+		// goFilesUnder skips _test.go, which used to exclude the harness for free.
+		// It stopped doing so when a shared fixture was promoted into a non-test
+		// file to become importable, and the tempting fix — widening
+		// singleRowPredicates so the fixture's lookup stops matching — would have
+		// loosened a production gate tree-wide to accommodate a test. Scope is the
+		// thing that was wrong, so scope is what is fixed.
+		//
+		// The migrate-once gate scopes the other way and INCLUDES these files, for
+		// the same reason read backwards: its obligation is about the integration
+		// lane, so a promoted fixture is exactly what it must still see.
+		if isIntegrationTagged(path) {
+			continue
+		}
 		src, err := os.ReadFile(path)
 		if err != nil {
 			t.Fatalf("reading %s: %v", path, err)


### PR DESCRIPTION
The last split of #546 worth making, and the first one whose payoff was **measured rather than projected**.

**Stacked on #574** — review the top commit; the rest is that PR.

## Chosen on time, not on file count

41s of the parent package's 349s from only 35 tests — the most expensive remaining cluster. Ranking by test count would have picked customfields (55 tests) or oauth (45), which are 18.0s and 14.3s. That mis-ranking is exactly what made my earlier estimate of the split programme's payoff wrong by a factor of three, so this one was picked off the per-test timings in a real lane run.

Four of the eleven files ride the booted-app fixture, which is the whole point of #574: until that fixture left a test file, no group depending on it could go anywhere.

## What it measured

One valid lane run (`OK: integration passed with 0 skips (28 packages)`, 1853 tests), so no cross-run normalisation:

```
./internal/compose/integration/overlay     75.64s    35 tests   12.6% of budget
./internal/compose/integration/org360      42.16s    61 tests    7.0% of budget
./internal/compose/integration/capture     33.12s    63 tests    5.5% of budget
./internal/compose/integration            260.22s   808 tests   43.4% of budget
wall: 296s
```

A lane's wall clock cannot go below its longest package. Unsplit, those four would be one package of **411s**, so the wall could not have been under that. It measured **296s**.

Two honest caveats on that figure. Each split package re-pays its own template clone and migrate-once, so the true unsplit total is somewhat below 411s — by summed test time the overlay suites are ~41s of work, not 75.6s, which puts the unsplit parent nearer 300–336s and this single cut's gain at **14–23%**. And I attempted a same-machine A/B against the unsplit tree; the control run died on `SQLSTATE 53200 — out of shared memory` (#482, back-to-back lane runs exhaust Postgres), so **I am not reporting a number from it**. The same-run counterfactual above needs no control.

## Two structural notes

**`overlay_acceptance_seam_test.go` stayed behind.** It carries no `//go:build integration`, so it belongs to the unit lane, and it both declares and consumes `backendModuleRoot`, which a webhooks suite there also reads. Leaving it removed the group's only outward debt.

**Two gates in `package compose` read this suite's source by hardcoded path** and failed on the move — on a path, not on anything about the code. That is the third path-keyed gate this programme has tripped, so it is fixed by *derivation* rather than repointing: they now resolve the pin by name anywhere under `integration/`. Mutation-tested, because a resolver that survives a move must not also survive the pin vanishing:

```
pin in place:                     PASS
pin removed:                      FAIL (names the file)
pin moved to integration/capture: PASS
```

Neither trap the capture move hit applies here — nothing declares a method on a foreign fixture in either direction, checked both ways.

## Verification

968 top-level tests before, 968 after. `make check-backend`, `make craft-static` (0 findings), `go vet -tags=integration` green, and the full lane run above.

## Where this leaves #546

**Stop splitting here.** The parent is still 260s and **88% of the wall clock**, but what remains is 116 clusters averaging under 1.5s each — 46% of the package in pieces too small to be worth a package. The better lever is #539: sharing the Postgres connections measured ~18% off this package's *work*, which reaches the long tail that splitting structurally cannot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the overlay integration suites into `internal/compose/integration/overlay`, added shared ZIP/CSV helpers, and replaced path-based gates with a name-based pin to keep assertions stable across moves; integration lane wall time down by ~14–23% (296s measured).

- **Refactors**
  - Moved overlay suites (acceptance, e2e, dispatch, flip/claim, write shadow/audit, tool surface, user map) to `internal/compose/integration/overlay`; kept `overlay_acceptance_seam_test.go` in the unit lane.
  - Added `integration.BundleEntries` and `integration.CSVColumn` in `integration/bundle.go`; export and filtered-export tests now reuse them.
  - Switched the suite to `package overlay` and imported the production module as `overlaymod`.
  - Replaced path-keyed gates with name-based resolution via an `overlayPin` that finds `overlay_toolsurface_integration_test.go` anywhere under `integration/` and fails if the pin is missing or duplicated.

- **Bug Fixes**
  - `BundleEntries` now fails on duplicate ZIP members to avoid last-one-wins assertions.
  - Scoped the fleet-enumeration gate to exclude integration-tagged non-test files and restored the original single-row predicates, preventing hidden fleet scans via `slug`.

<sup>Written for commit 07cba2888e70c6165a28a3a6b5981b70acc18128. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/584?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved integration test organization and shared test utilities.
  - Strengthened validation for exported ZIP and CSV data.
  - Made overlay test configuration discovery more resilient.
  - Refined fleet-scan coverage to better distinguish production code from integration tests.
  - Preserved existing test behavior while improving setup consistency and diagnostics.

- **Documentation**
  - Updated testing guidance and comments to reflect current integration harnesses and response-handling practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->