### PR TITLE
fix(agents): the schema's claim about which arguments are required binds the surface

### DIFF
--- a/backend/internal/compose/agenttooldescriptions_test.go
+++ b/backend/internal/compose/agenttooldescriptions_test.go
@@ -296,27 +296,3 @@ func toolsListDescriptions(t *testing.T, registry *agents.Registry) map[string]s
 	}
 	return out
 }
-
-// A `required` entry naming a property the schema never declares would refuse
-// every call to that tool for a field no caller could learn about — a refusal
-// with no way out. The registry drops such an entry rather than enforcing it,
-// which is the safe half; this is the other half, catching the defect itself
-// where it can name the tool.
-func TestNoToolRequiresAnArgumentItsSchemaDoesNotDeclare(t *testing.T) {
-	for _, spec := range servedSurface(t).Specs() {
-		var schema struct {
-			Required   []string                   `json:"required"`
-			Properties map[string]json.RawMessage `json:"properties"`
-		}
-		if err := json.Unmarshal(spec.InputSchema, &schema); err != nil {
-			t.Errorf("%s: input schema is not readable: %v", spec.Name, err)
-			continue
-		}
-		for _, name := range schema.Required {
-			if _, declared := schema.Properties[name]; !declared {
-				t.Errorf("%s requires %q, which its own properties never declare — a caller reading "+
-					"tools/list has no way to learn the argument exists", spec.Name, name)
-			}
-		}
-	}
-}

--- a/backend/internal/compose/agenttooldescriptions_test.go
+++ b/backend/internal/compose/agenttooldescriptions_test.go
@@ -296,3 +296,27 @@ func toolsListDescriptions(t *testing.T, registry *agents.Registry) map[string]s
 	}
 	return out
 }
+
+// A `required` entry naming a property the schema never declares would refuse
+// every call to that tool for a field no caller could learn about — a refusal
+// with no way out. The registry drops such an entry rather than enforcing it,
+// which is the safe half; this is the other half, catching the defect itself
+// where it can name the tool.
+func TestNoToolRequiresAnArgumentItsSchemaDoesNotDeclare(t *testing.T) {
+	for _, spec := range servedSurface(t).Specs() {
+		var schema struct {
+			Required   []string                   `json:"required"`
+			Properties map[string]json.RawMessage `json:"properties"`
+		}
+		if err := json.Unmarshal(spec.InputSchema, &schema); err != nil {
+			t.Errorf("%s: input schema is not readable: %v", spec.Name, err)
+			continue
+		}
+		for _, name := range schema.Required {
+			if _, declared := schema.Properties[name]; !declared {
+				t.Errorf("%s requires %q, which its own properties never declare — a caller reading "+
+					"tools/list has no way to learn the argument exists", spec.Name, name)
+			}
+		}
+	}
+}

--- a/backend/internal/modules/agents/idargs_test.go
+++ b/backend/internal/modules/agents/idargs_test.go
@@ -248,7 +248,7 @@ func uuidProps(t *testing.T, name string, inputSchema json.RawMessage) (all, req
 
 // malformedCall renders a tools/call putting a non-canonical UUID in prop and
 // nothing else. Only the offending property is set: the refusal under test has
-// to happen while the arguments decode, before any other validation.
+// to happen while the arguments decode, once the call is otherwise complete.
 func malformedCall(t *testing.T, spec mcp.ToolSpec, prop string) json.RawMessage {
 	t.Helper()
 	const notAUUID = `"not-a-uuid"`

--- a/backend/internal/modules/agents/idargs_test.go
+++ b/backend/internal/modules/agents/idargs_test.go
@@ -252,13 +252,17 @@ func uuidProps(t *testing.T, name string, inputSchema json.RawMessage) (all, req
 func malformedCall(t *testing.T, spec mcp.ToolSpec, prop string) json.RawMessage {
 	t.Helper()
 	const notAUUID = `"not-a-uuid"`
-	// Every OTHER required argument is supplied, plausibly, so the call reaches
-	// the id check. The registry holds `required` before it holds shapes — an
-	// argument that is missing has no shape to be wrong about — so a call
-	// carrying only the malformed id would be refused for the arguments it also
-	// omitted, and this walk would stop testing what it is named for.
-	args := placeholdersForRequired(t, spec, prop)
-	if outer, nested, isNested := strings.Cut(prop, "[]."); isNested {
+	// Every OTHER required argument is supplied, plausibly, by the same helper
+	// the absent-id walk uses: the registry holds `required` before it holds
+	// shapes — an argument that is missing has no shape to be wrong about — so a
+	// call carrying only the malformed id would be refused for the arguments it
+	// also omitted, and this walk would stop testing what it is named for.
+	outer, nested, isNested := strings.Cut(prop, "[].")
+	var args map[string]json.RawMessage
+	if err := json.Unmarshal(absentIDArgs(t, spec.Name, spec.InputSchema, outer), &args); err != nil {
+		t.Fatalf("building a call for %s: %v", spec.Name, err)
+	}
+	if isNested {
 		args[outer] = json.RawMessage(fmt.Sprintf(`[{%q:%s}]`, nested, notAUUID))
 	} else {
 		args[prop] = json.RawMessage(notAUUID)
@@ -268,49 +272,6 @@ func malformedCall(t *testing.T, spec mcp.ToolSpec, prop string) json.RawMessage
 		t.Fatalf("building a call for %s: %v", spec.Name, err)
 	}
 	return json.RawMessage(fmt.Sprintf(`{"name":%q,"arguments":%s}`, spec.Name, encoded))
-}
-
-// placeholdersForRequired fills every required argument but `except` with a
-// value of the type its schema declares. The values are deliberately valid: this
-// walk is about ONE malformed id, so everything around it has to be right.
-func placeholdersForRequired(t *testing.T, spec mcp.ToolSpec, except string) map[string]json.RawMessage {
-	t.Helper()
-	var schema struct {
-		Required   []string `json:"required"`
-		Properties map[string]struct {
-			Type   string            `json:"type"`
-			Format string            `json:"format"`
-			Enum   []json.RawMessage `json:"enum"`
-			Items  json.RawMessage   `json:"items"`
-		} `json:"properties"`
-	}
-	if err := json.Unmarshal(spec.InputSchema, &schema); err != nil {
-		t.Fatalf("reading %s's schema: %v", spec.Name, err)
-	}
-	args := map[string]json.RawMessage{}
-	for _, name := range schema.Required {
-		prop, declared := schema.Properties[name]
-		if !declared || name == except || strings.HasPrefix(except, name+"[].") {
-			continue
-		}
-		switch {
-		case len(prop.Enum) > 0:
-			args[name] = prop.Enum[0]
-		case prop.Format == "uuid":
-			args[name] = json.RawMessage(`"0198f3a1-7c42-7e0b-9d51-2a6f4b8c1e11"`)
-		case prop.Type == "array":
-			args[name] = json.RawMessage(`[]`)
-		case prop.Type == "object":
-			args[name] = json.RawMessage(`{}`)
-		case prop.Type == "integer", prop.Type == "number":
-			args[name] = json.RawMessage(`1`)
-		case prop.Type == "boolean":
-			args[name] = json.RawMessage(`true`)
-		default:
-			args[name] = json.RawMessage(`"placeholder"`)
-		}
-	}
-	return args
 }
 
 func TestAMalformedIDIsRefusedAsTheCallersMistakeOnEveryTool(t *testing.T) {

--- a/backend/internal/modules/agents/idargs_test.go
+++ b/backend/internal/modules/agents/idargs_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/mcp"
 )
 
 // errSeamReached stands for "the tool accepted these arguments and called me".
@@ -248,13 +249,68 @@ func uuidProps(t *testing.T, name string, inputSchema json.RawMessage) (all, req
 // malformedCall renders a tools/call putting a non-canonical UUID in prop and
 // nothing else. Only the offending property is set: the refusal under test has
 // to happen while the arguments decode, before any other validation.
-func malformedCall(tool, prop string) json.RawMessage {
+func malformedCall(t *testing.T, spec mcp.ToolSpec, prop string) json.RawMessage {
+	t.Helper()
 	const notAUUID = `"not-a-uuid"`
-	args := fmt.Sprintf(`{%q:%s}`, prop, notAUUID)
+	// Every OTHER required argument is supplied, plausibly, so the call reaches
+	// the id check. The registry holds `required` before it holds shapes — an
+	// argument that is missing has no shape to be wrong about — so a call
+	// carrying only the malformed id would be refused for the arguments it also
+	// omitted, and this walk would stop testing what it is named for.
+	args := placeholdersForRequired(t, spec, prop)
 	if outer, nested, isNested := strings.Cut(prop, "[]."); isNested {
-		args = fmt.Sprintf(`{%q:[{%q:%s}]}`, outer, nested, notAUUID)
+		args[outer] = json.RawMessage(fmt.Sprintf(`[{%q:%s}]`, nested, notAUUID))
+	} else {
+		args[prop] = json.RawMessage(notAUUID)
 	}
-	return json.RawMessage(fmt.Sprintf(`{"name":%q,"arguments":%s}`, tool, args))
+	encoded, err := json.Marshal(args)
+	if err != nil {
+		t.Fatalf("building a call for %s: %v", spec.Name, err)
+	}
+	return json.RawMessage(fmt.Sprintf(`{"name":%q,"arguments":%s}`, spec.Name, encoded))
+}
+
+// placeholdersForRequired fills every required argument but `except` with a
+// value of the type its schema declares. The values are deliberately valid: this
+// walk is about ONE malformed id, so everything around it has to be right.
+func placeholdersForRequired(t *testing.T, spec mcp.ToolSpec, except string) map[string]json.RawMessage {
+	t.Helper()
+	var schema struct {
+		Required   []string `json:"required"`
+		Properties map[string]struct {
+			Type   string            `json:"type"`
+			Format string            `json:"format"`
+			Enum   []json.RawMessage `json:"enum"`
+			Items  json.RawMessage   `json:"items"`
+		} `json:"properties"`
+	}
+	if err := json.Unmarshal(spec.InputSchema, &schema); err != nil {
+		t.Fatalf("reading %s's schema: %v", spec.Name, err)
+	}
+	args := map[string]json.RawMessage{}
+	for _, name := range schema.Required {
+		prop, declared := schema.Properties[name]
+		if !declared || name == except || strings.HasPrefix(except, name+"[].") {
+			continue
+		}
+		switch {
+		case len(prop.Enum) > 0:
+			args[name] = prop.Enum[0]
+		case prop.Format == "uuid":
+			args[name] = json.RawMessage(`"0198f3a1-7c42-7e0b-9d51-2a6f4b8c1e11"`)
+		case prop.Type == "array":
+			args[name] = json.RawMessage(`[]`)
+		case prop.Type == "object":
+			args[name] = json.RawMessage(`{}`)
+		case prop.Type == "integer", prop.Type == "number":
+			args[name] = json.RawMessage(`1`)
+		case prop.Type == "boolean":
+			args[name] = json.RawMessage(`true`)
+		default:
+			args[name] = json.RawMessage(`"placeholder"`)
+		}
+	}
+	return args
 }
 
 func TestAMalformedIDIsRefusedAsTheCallersMistakeOnEveryTool(t *testing.T) {
@@ -274,7 +330,7 @@ func TestAMalformedIDIsRefusedAsTheCallersMistakeOnEveryTool(t *testing.T) {
 		allProps, _ := uuidProps(t, name, tool.Spec().InputSchema)
 		for _, prop := range allProps {
 			probed++
-			res := s.call(ctx, malformedCall(name, prop))
+			res := s.call(ctx, malformedCall(t, tool.Spec(), prop))
 			if res["isError"] != true {
 				t.Errorf("%s accepted %q as a UUID", name, prop)
 				continue

--- a/backend/internal/modules/agents/numargs.go
+++ b/backend/internal/modules/agents/numargs.go
@@ -22,6 +22,7 @@ package agents
 // buys — and is held where that cost is paid (bookingLinks).
 
 import (
+	"cmp"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -79,19 +80,42 @@ func declaredNumBounds(inputSchema json.RawMessage) []numBound {
 
 // requireDeclaredArgs holds a call to every claim its own tools/list entry makes
 // about its arguments: the required ones are there, the ids name something, and
-// the numbers sit inside the advertised range. Presence comes FIRST — an
-// argument that is missing has no shape and no range to be wrong about, and
-// naming both would tell a caller two things about one mistake. Invoke calls THIS rather than the two checks in turn, so a
-// claim read off the schema later cannot be wired into one of Invoke's two
-// placements and forgotten in the other.
+// the numbers sit inside the advertised range. Invoke calls THIS rather than the
+// three checks in turn, so a claim read off the schema later cannot be wired
+// into one of Invoke's two placements and forgotten in the other.
+//
+// Presence and the ids answer TOGETHER. Each collects faithfully on its own, but
+// they split the required arguments between them — the id-shaped ones belong to
+// idargs.go — so a call missing one of each was refused for the plain argument,
+// and told about the id only after the caller had fixed the first and called
+// again. That is the call-per-field waste all three of these files say the
+// collection exists to end, reappearing at the seam between them.
+//
+// The bounds stay separate: an argument that is missing has no range to be wrong
+// about, so there is nothing to say about it in the same breath.
 func (r *Registry) requireDeclaredArgs(name string, args json.RawMessage) error {
-	if err := r.requireDeclaredPresence(name, args); err != nil {
-		return err
-	}
-	if err := r.requireDeclaredIDs(name, args); err != nil {
+	if err := joinArgRefusals(r.requireDeclaredPresence(name, args), r.requireDeclaredIDs(name, args)); err != nil {
 		return err
 	}
 	return r.requireDeclaredBounds(name, args)
+}
+
+// joinArgRefusals answers with both refusals when both fired, and with whichever
+// one did otherwise.
+//
+// A refusal this surface did not build is passed through UNJOINED. Both checks
+// answer *BadArgsError for an argument the caller got wrong, and anything else —
+// an authority error surfacing from a lookup, a wrapped infrastructure fault —
+// is not a sentence to splice into another one.
+func joinArgRefusals(first, second error) error {
+	var firstArgs, secondArgs *BadArgsError
+	if !errors.As(first, &firstArgs) || !errors.As(second, &secondArgs) {
+		return cmp.Or(first, second)
+	}
+	return &BadArgsError{
+		Cause:    fmt.Errorf("%w; %w", firstArgs.Cause, secondArgs.Cause),
+		Guidance: firstArgs.Guidance,
+	}
 }
 
 // requireDeclaredBounds holds every supplied value to the range its tool

--- a/backend/internal/modules/agents/numargs.go
+++ b/backend/internal/modules/agents/numargs.go
@@ -103,13 +103,23 @@ func (r *Registry) requireDeclaredArgs(name string, args json.RawMessage) error 
 // joinArgRefusals answers with both refusals when both fired, and with whichever
 // one did otherwise.
 //
-// A refusal this surface did not build is passed through UNJOINED. Both checks
-// answer *BadArgsError for an argument the caller got wrong, and anything else —
-// an authority error surfacing from a lookup, a wrapped infrastructure fault —
-// is not a sentence to splice into another one.
+// A refusal this surface did not build WINS, unjoined. Both checks answer
+// *BadArgsError for an argument the caller got wrong; anything else — an
+// authority error surfacing from a lookup, a wrapped infrastructure fault — is
+// not a sentence to splice into another one, and it must not be dropped in
+// favour of one either. Answering the argument refusal while a real failure was
+// also in hand would tell a caller to fix its arguments and try again, against
+// a server that was going to fail anyway.
 func joinArgRefusals(first, second error) error {
 	var firstArgs, secondArgs *BadArgsError
-	if !errors.As(first, &firstArgs) || !errors.As(second, &secondArgs) {
+	firstIsArgs, secondIsArgs := errors.As(first, &firstArgs), errors.As(second, &secondArgs)
+	if first != nil && !firstIsArgs {
+		return first
+	}
+	if second != nil && !secondIsArgs {
+		return second
+	}
+	if !firstIsArgs || !secondIsArgs {
 		return cmp.Or(first, second)
 	}
 	return &BadArgsError{

--- a/backend/internal/modules/agents/numargs.go
+++ b/backend/internal/modules/agents/numargs.go
@@ -78,11 +78,16 @@ func declaredNumBounds(inputSchema json.RawMessage) []numBound {
 }
 
 // requireDeclaredArgs holds a call to every claim its own tools/list entry makes
-// about its arguments: the ids name something, and the numbers sit inside the
-// advertised range. Invoke calls THIS rather than the two checks in turn, so a
+// about its arguments: the required ones are there, the ids name something, and
+// the numbers sit inside the advertised range. Presence comes FIRST — an
+// argument that is missing has no shape and no range to be wrong about, and
+// naming both would tell a caller two things about one mistake. Invoke calls THIS rather than the two checks in turn, so a
 // claim read off the schema later cannot be wired into one of Invoke's two
 // placements and forgotten in the other.
 func (r *Registry) requireDeclaredArgs(name string, args json.RawMessage) error {
+	if err := r.requireDeclaredPresence(name, args); err != nil {
+		return err
+	}
 	if err := r.requireDeclaredIDs(name, args); err != nil {
 		return err
 	}

--- a/backend/internal/modules/agents/registry.go
+++ b/backend/internal/modules/agents/registry.go
@@ -39,6 +39,11 @@ type Registry struct {
 	// supplied value to it, so `minimum`/`maximum` bind the surface instead of
 	// describing an intention.
 	numArgs map[string][]numBound
+	// requiredArgs[tool] is what that tool's schema says it cannot run without,
+	// read off the schema once at registration. Invoke holds a call to it, so
+	// `required` binds the surface rather than describing an intention that
+	// each handler then re-states in its own words.
+	requiredArgs map[string][]string
 	// approvals closes the 🟡 loop (stage on refusal, redeem on retry).
 	// Nil is a legal composition — the gate still refuses; refused calls
 	// just have nowhere to land.
@@ -51,11 +56,12 @@ type Registry struct {
 
 func NewRegistry(approvals Approvals, gate *auth.Gate) *Registry {
 	return &Registry{
-		tools:     map[string]mcp.Tool{},
-		idArgs:    map[string]idArgSpec{},
-		numArgs:   map[string][]numBound{},
-		approvals: approvals,
-		gate:      gate,
+		tools:        map[string]mcp.Tool{},
+		idArgs:       map[string]idArgSpec{},
+		numArgs:      map[string][]numBound{},
+		requiredArgs: map[string][]string{},
+		approvals:    approvals,
+		gate:         gate,
 	}
 }
 
@@ -134,6 +140,7 @@ func (r *Registry) Register(t mcp.Tool) {
 	r.tools[spec.Name] = t
 	r.idArgs[spec.Name] = declaredIDArgs(spec.InputSchema)
 	r.numArgs[spec.Name] = declaredNumBounds(spec.InputSchema)
+	r.requiredArgs[spec.Name] = declaredRequired(spec.InputSchema)
 }
 
 // Invoke runs the admission gate, then the tool. There is no other path

--- a/backend/internal/modules/agents/requiredargs.go
+++ b/backend/internal/modules/agents/requiredargs.go
@@ -112,10 +112,29 @@ func readRequiredList(raw json.RawMessage) []string {
 	if len(raw) == 0 {
 		return nil
 	}
-	var names []string
-	if err := json.Unmarshal(raw, &names); err != nil || names == nil {
+	// Element by element, because []string hides two things: a null element
+	// decodes to "" without error, which would go on to be reported as a
+	// requirement with no name, and a repeated name would be reported twice in
+	// one refusal. JSON Schema says the list holds unique strings.
+	var elements []json.RawMessage
+	if err := json.Unmarshal(raw, &elements); err != nil || elements == nil {
 		//craft:ignore panic-in-domain composition-time registration assertion — fires only while cmd wiring runs, never on a request path
 		panic("crmagents: input schema's `required` is not a list of strings: " + string(raw))
+	}
+	names := make([]string, 0, len(elements))
+	seen := make(map[string]bool, len(elements))
+	for _, element := range elements {
+		var name string
+		if err := json.Unmarshal(element, &name); err != nil || name == "" {
+			//craft:ignore panic-in-domain composition-time registration assertion — fires only while cmd wiring runs, never on a request path
+			panic("crmagents: input schema's `required` holds " + string(element) + ", which names no property")
+		}
+		if seen[name] {
+			//craft:ignore panic-in-domain composition-time registration assertion — fires only while cmd wiring runs, never on a request path
+			panic("crmagents: input schema's `required` names " + name + " twice; JSON Schema's list holds unique names, and a repeat would be reported twice in one refusal")
+		}
+		seen[name] = true
+		names = append(names, name)
 	}
 	return names
 }

--- a/backend/internal/modules/agents/requiredargs.go
+++ b/backend/internal/modules/agents/requiredargs.go
@@ -10,8 +10,8 @@ package agents
 // `required` is the first thing a client reads to build a call, and it was the
 // last of the schema's claims with nothing behind it. The uuid check held
 // presence for id-shaped arguments and the numeric check held ranges, so a
-// missing `q`, `kind` or `segment` reached whichever handler happened to check
-// for it — and the reason one spelling at one chokepoint wins is the reason
+// missing `kind`, `segment` or `record_type` reached whichever handler happened
+// to check for it — and the reason one spelling at one chokepoint wins is the reason
 // idargs.go already gives: thirteen handlers each failed to make their own
 // schema's `required` true, one at a time.
 //
@@ -39,6 +39,15 @@ import (
 // serve, and the schema is a literal in whatever registered the tool — so this
 // fails the BOOT, which is the only moment it can still be fixed, and covers a
 // composed extension unit exactly as it covers a core tool.
+//
+// This rests on an assumption worth stating where it binds: every schema this
+// surface serves is a FLAT literal listing its own properties. JSON Schema also
+// lets `required` name a property supplied by `additionalProperties`,
+// `patternProperties` or an `allOf` branch, none of which this reader walks — so
+// a unit shipping a composed schema would be refused here for a shape that is
+// legitimate. Nothing on this surface writes one today, and assertObjectSchemas
+// does not yet forbid it; the day a unit needs one, this reader is what has to
+// learn about it rather than the unit having to flatten.
 //
 // The id-shaped arguments are left to idargs.go. Both would otherwise refuse the
 // same missing argument, and the caller would be told about it twice, in two
@@ -117,7 +126,7 @@ func (r *Registry) requireDeclaredPresence(name string, args json.RawMessage) er
 	}
 	return &BadArgsError{
 		Cause: errors.New(refusalSubject(missing) + " required by this tool's input schema"),
-		Guidance: fmt.Sprintf("supply %s — the schema tools/list advertises lists %s as required",
+		Guidance: fmt.Sprintf("supply %s — the schema advertised on tools/list names %s as required",
 			refusalNoun(missing), strings.Join(missing, ", ")),
 	}
 }

--- a/backend/internal/modules/agents/requiredargs.go
+++ b/backend/internal/modules/agents/requiredargs.go
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// The claim a tool's schema makes about which arguments a call MUST carry, and
+// its enforcement — the third sibling of idargs.go and numargs.go, at the same
+// chokepoint and for the same reason.
+//
+// `required` is the first thing a client reads to build a call, and it was the
+// last of the schema's claims with nothing behind it. The uuid check held
+// presence for id-shaped arguments and the numeric check held ranges, so a
+// missing `q`, `kind` or `segment` reached whichever handler happened to check
+// for it — and the reason one spelling at one chokepoint wins is the reason
+// idargs.go already gives: thirteen handlers each failed to make their own
+// schema's `required` true, one at a time.
+//
+// WHAT THIS DOES NOT TAKE FROM A HANDLER. Presence is not the same claim as
+// meaning. A blank string is present; an enum value outside its list is
+// present; a body that is only whitespace is present. Those stay with the
+// handler that knows what they mean — this holds the one claim the schema
+// itself makes, and holds it identically for every tool.
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// declaredRequired reads a schema's `required` list once, at registration,
+// keeping only the names the schema also DECLARES as properties.
+//
+// The intersection matters. A `required` entry naming an undeclared property is
+// a schema defect, and enforcing it would refuse every call to that tool for a
+// field no caller could ever learn about — a refusal with no way out. The gate
+// that catches the defect itself is a fitness test over the registry, where it
+// can name the tool at boot instead of at a caller.
+//
+// The id-shaped arguments are left to idargs.go. Both would otherwise refuse the
+// same missing argument, and the caller would be told about it twice, in two
+// different sentences.
+func declaredRequired(inputSchema json.RawMessage) []string {
+	var schema struct {
+		Required   []string `json:"required"`
+		Properties map[string]struct {
+			Type   string `json:"type"`
+			Format string `json:"format"`
+		} `json:"properties"`
+	}
+	// assertObjectSchemas has already confirmed this is valid JSON declaring an
+	// object, but it decodes only `type`. A schema whose `required` is not a
+	// list of strings gets here and fails — a defect in whatever registered it,
+	// named while cmd wiring boots rather than on a request.
+	if err := json.Unmarshal(inputSchema, &schema); err != nil {
+		//craft:ignore panic-in-domain composition-time registration assertion — fires only while cmd wiring runs, never on a request path
+		panic("crmagents: input schema declares an unreadable `required`: " + err.Error())
+	}
+	names := make([]string, 0, len(schema.Required))
+	for _, name := range schema.Required {
+		prop, declared := schema.Properties[name]
+		if !declared || (prop.Type == "string" && prop.Format == "uuid") {
+			continue
+		}
+		names = append(names, name)
+	}
+	// Sorted, so a call missing two arguments is refused in the same words every
+	// time rather than in the order the schema happened to list them.
+	sort.Strings(names)
+	return names
+}
+
+// requireDeclaredPresence holds a call to the arguments its tool says it cannot
+// run without.
+//
+// An explicit null counts as ABSENT. A caller that spells out `{"q": null}` has
+// supplied no query, and answering "present" there would hand the handler a
+// zero value it would have to re-refuse in its own words — which is the
+// arrangement this replaces.
+//
+// Every missing argument is named before answering, for the reason the id check
+// gives: reporting them one per round trip is accurate and still wasteful, since
+// an agent then spends a call per field to learn what one refusal could have
+// told it.
+func (r *Registry) requireDeclaredPresence(name string, args json.RawMessage) error {
+	r.mu.RLock()
+	required := r.requiredArgs[name]
+	r.mu.RUnlock()
+	if len(required) == 0 {
+		return nil
+	}
+	present, isObject := argsAsObject(args)
+	if !isObject {
+		// Not an object at all, so there are no members to look for. The shape
+		// verdict belongs to the steps that own it — the argument split, then the
+		// handler's own decode — each of which names what it wanted; a second,
+		// vaguer answer to the same question is worse than none.
+		return nil
+	}
+	var missing []string
+	for _, argument := range required {
+		raw, supplied := present[argument]
+		if !supplied || isJSONNull(raw) {
+			missing = append(missing, "`"+argument+"`")
+		}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	return &BadArgsError{
+		Cause: errors.New(refusalSubject(missing) + " required by this tool's input schema"),
+		Guidance: fmt.Sprintf("supply %s — the schema tools/list advertises lists %s as required",
+			refusalNoun(missing), strings.Join(missing, ", ")),
+	}
+}
+
+// refusalSubject renders the missing arguments as the subject of a sentence
+// that agrees with itself: one argument "is", several "are".
+func refusalSubject(missing []string) string {
+	if len(missing) == 1 {
+		return missing[0] + " is missing and is"
+	}
+	return strings.Join(missing, ", ") + " are missing and are"
+}
+
+// refusalNoun names what to supply, in the same number.
+func refusalNoun(missing []string) string {
+	if len(missing) == 1 {
+		return "it"
+	}
+	return "all of them"
+}
+
+// isJSONNull reports whether an argument arrived as the literal null — supplied
+// in the sense that the key is there, and absent in the sense that matters.
+func isJSONNull(raw json.RawMessage) bool {
+	return string(raw) == "null"
+}

--- a/backend/internal/modules/agents/requiredargs.go
+++ b/backend/internal/modules/agents/requiredargs.go
@@ -15,6 +15,15 @@ package agents
 // idargs.go already gives: thirteen handlers each failed to make their own
 // schema's `required` true, one at a time.
 //
+// SCOPE: top-level properties, like numargs.go's bounds and idargs.go's own
+// presence rule. A `required` inside an array's `items` — `links[].entity_type`,
+// `aggregates[].fn` — is a claim about a member GIVEN its parent, and the parent
+// is optional on some of those tools, so it cannot be held here without
+// inventing a rule about when the parent counts. Those stay where they already
+// are: the provider re-validates an activity's links, and the report engine
+// refuses an aggregate it cannot read. Reaching them from here is a real
+// improvement and a larger one.
+//
 // WHAT THIS DOES NOT TAKE FROM A HANDLER. Presence is not the same claim as
 // meaning. A blank string is present; an enum value outside its list is
 // present; a body that is only whitespace is present. Those stay with the
@@ -54,7 +63,13 @@ import (
 // different sentences.
 func declaredRequired(inputSchema json.RawMessage) []string {
 	var schema struct {
-		Required   []string `json:"required"`
+		// RawMessage rather than []string, because the two failures a schema can
+		// have here are different and only one of them is a decode error: a
+		// `required` that is a number or an object fails to decode, and a
+		// `required: null` decodes into a nil slice indistinguishable from an
+		// absent one. Both are invalid JSON Schema, and a reader claiming to
+		// refuse "anything that is not a list of strings" has to refuse both.
+		Required   json.RawMessage `json:"required"`
 		Properties map[string]struct {
 			Type   string `json:"type"`
 			Format string `json:"format"`
@@ -68,8 +83,9 @@ func declaredRequired(inputSchema json.RawMessage) []string {
 		//craft:ignore panic-in-domain composition-time registration assertion — fires only while cmd wiring runs, never on a request path
 		panic("crmagents: input schema declares an unreadable `required`: " + err.Error())
 	}
-	names := make([]string, 0, len(schema.Required))
-	for _, name := range schema.Required {
+	required := readRequiredList(schema.Required)
+	names := make([]string, 0, len(required))
+	for _, name := range required {
 		prop, declared := schema.Properties[name]
 		if !declared {
 			//craft:ignore panic-in-domain composition-time registration assertion — fires only while cmd wiring runs, never on a request path
@@ -84,6 +100,23 @@ func declaredRequired(inputSchema json.RawMessage) []string {
 	// Sorted, so a call missing two arguments is refused in the same words every
 	// time rather than in the order the schema happened to list them.
 	sort.Strings(names)
+	return names
+}
+
+// readRequiredList decodes the `required` keyword, refusing every spelling that
+// is not what JSON Schema defines it as. Absent is legal and means nothing is
+// required; `null` is NOT absent — it is a present member holding the wrong
+// thing, and accepting it would serve a schema this reader claims to have
+// checked.
+func readRequiredList(raw json.RawMessage) []string {
+	if len(raw) == 0 {
+		return nil
+	}
+	var names []string
+	if err := json.Unmarshal(raw, &names); err != nil || names == nil {
+		//craft:ignore panic-in-domain composition-time registration assertion — fires only while cmd wiring runs, never on a request path
+		panic("crmagents: input schema's `required` is not a list of strings: " + string(raw))
+	}
 	return names
 }
 

--- a/backend/internal/modules/agents/requiredargs.go
+++ b/backend/internal/modules/agents/requiredargs.go
@@ -29,14 +29,16 @@ import (
 	"strings"
 )
 
-// declaredRequired reads a schema's `required` list once, at registration,
-// keeping only the names the schema also DECLARES as properties.
+// declaredRequired reads a schema's `required` list once, at registration.
 //
-// The intersection matters. A `required` entry naming an undeclared property is
-// a schema defect, and enforcing it would refuse every call to that tool for a
-// field no caller could ever learn about — a refusal with no way out. The gate
-// that catches the defect itself is a fitness test over the registry, where it
-// can name the tool at boot instead of at a caller.
+// A `required` entry naming an UNDECLARED property is refused here rather than
+// dropped. Dropping it would leave the surface advertising a requirement the
+// registry ignores, so a caller and a handler would be working from different
+// contracts with nothing saying so; enforcing it would refuse every call to
+// that tool for a field no caller could ever learn about. Neither is a state to
+// serve, and the schema is a literal in whatever registered the tool — so this
+// fails the BOOT, which is the only moment it can still be fixed, and covers a
+// composed extension unit exactly as it covers a core tool.
 //
 // The id-shaped arguments are left to idargs.go. Both would otherwise refuse the
 // same missing argument, and the caller would be told about it twice, in two
@@ -60,7 +62,12 @@ func declaredRequired(inputSchema json.RawMessage) []string {
 	names := make([]string, 0, len(schema.Required))
 	for _, name := range schema.Required {
 		prop, declared := schema.Properties[name]
-		if !declared || (prop.Type == "string" && prop.Format == "uuid") {
+		if !declared {
+			//craft:ignore panic-in-domain composition-time registration assertion — fires only while cmd wiring runs, never on a request path
+			panic(fmt.Sprintf("crmagents: input schema requires %q, which its own properties never declare — "+
+				"a caller reading tools/list has no way to learn the argument exists", name))
+		}
+		if prop.Type == "string" && prop.Format == "uuid" {
 			continue
 		}
 		names = append(names, name)

--- a/backend/internal/modules/agents/requiredargs_test.go
+++ b/backend/internal/modules/agents/requiredargs_test.go
@@ -122,3 +122,52 @@ func TestARequiredEntryNamingAnUndeclaredPropertyFailsRegistration(t *testing.T)
 		declaredRequired(json.RawMessage(`{"type":"object","required":["ghost"],"properties":{}}`))
 	})
 }
+
+// A schema whose `required` is not a list of strings is a defect in whatever
+// registered it — an extension unit, most likely — and it is named while cmd
+// wiring boots rather than on a caller's first request.
+//
+// Called directly, like its siblings' equivalents: the registration path reaches
+// declaredIDArgs first, whose own decode of the same malformed input panics
+// before this one runs, so a test that went through Register would prove the
+// other check rather than this one.
+func TestAnUnreadableRequiredListIsRefusedAtRegistration(t *testing.T) {
+	mustPanic(t, "a required list that is not a list of strings cannot be enforced", func() {
+		declaredRequired(json.RawMessage(`{"type":"object","required":"q","properties":{"q":{"type":"string"}}}`))
+	})
+}
+
+// Arguments that are not an object at all carry no members to look for. The
+// shape verdict belongs to the steps that own it — the argument split, then the
+// handler's own decode — each of which names what it wanted; a second, vaguer
+// answer to the same question is worse than none.
+//
+// Also called directly: Invoke always hands this the canonical object
+// splitApproval produced, so the branch is unreachable from there.
+func TestNonObjectArgumentsAreLeftToTheStepsThatOwnTheirShape(t *testing.T) {
+	r := requiringRegistry(t)
+	if err := r.requireDeclaredPresence("requires_things", json.RawMessage(`"a bare string"`)); err != nil {
+		t.Errorf("non-object arguments were refused here as %v, where the shape is not this check's to judge", err)
+	}
+}
+
+// The promise this whole collection exists for, held ACROSS the presence and id
+// checks rather than within each.
+//
+// A call missing a plain argument and an id was refused for the plain one, and
+// only told about the id after the caller had fixed the first and called again —
+// which is the call-per-field waste the collection was built to end, reappearing
+// at the seam between two checks that each collect faithfully on their own.
+func TestOneRefusalNamesAMissingArgumentAndAMissingIDTogether(t *testing.T) {
+	r := requiringRegistry(t)
+	_, err := r.Invoke(scopedAgentCtx(principal.ScopeRead), "requires_things", json.RawMessage(`{"kind":"note"}`))
+	if err == nil {
+		t.Fatal("a call missing both a required argument and a required id was admitted")
+	}
+	for _, want := range []string{"`q`", "anchor_id"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("refusal %q does not name %s — the caller learns about it only on the next round trip",
+				err, want)
+		}
+	}
+}

--- a/backend/internal/modules/agents/requiredargs_test.go
+++ b/backend/internal/modules/agents/requiredargs_test.go
@@ -171,3 +171,53 @@ func TestOneRefusalNamesAMissingArgumentAndAMissingIDTogether(t *testing.T) {
 		}
 	}
 }
+
+// `required: null` is a present member holding the wrong thing, which decodes
+// into the same nil slice an ABSENT `required` gives — so accepting it would
+// serve a schema this reader claims to have checked. Both invalid spellings are
+// refused; an absent one is legal and means nothing is required.
+func TestAnInvalidRequiredKeywordIsRefusedInEverySpelling(t *testing.T) {
+	for name, schema := range map[string]string{
+		"a null required":      `{"type":"object","required":null,"properties":{"q":{"type":"string"}}}`,
+		"a string required":    `{"type":"object","required":"q","properties":{"q":{"type":"string"}}}`,
+		"an object required":   `{"type":"object","required":{"q":true},"properties":{"q":{"type":"string"}}}`,
+		"a non-string element": `{"type":"object","required":[7],"properties":{"q":{"type":"string"}}}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			mustPanic(t, "a `required` that is not a list of strings cannot be enforced", func() {
+				declaredRequired(json.RawMessage(schema))
+			})
+		})
+	}
+	if named := declaredRequired(json.RawMessage(`{"type":"object","properties":{"q":{"type":"string"}}}`)); len(named) != 0 {
+		t.Errorf("an absent `required` yielded %v, where it means nothing is required", named)
+	}
+}
+
+// A refusal this surface did not build wins, unjoined. Answering the argument
+// refusal while a real failure was also in hand would tell a caller to fix its
+// arguments and try again, against a server that was going to fail anyway.
+func TestARealFailureIsNotDroppedInFavourOfAnArgumentRefusal(t *testing.T) {
+	argRefusal := &BadArgsError{Cause: errors.New("`q` is missing"), Guidance: "supply it"}
+	realFailure := errors.New("the authority lookup failed")
+
+	for name, joined := range map[string]error{
+		"the real failure came first":  joinArgRefusals(realFailure, argRefusal),
+		"the real failure came second": joinArgRefusals(argRefusal, realFailure),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if !errors.Is(joined, realFailure) {
+				t.Errorf("joined = %v, want the real failure rather than the argument refusal", joined)
+			}
+			var badArgs *BadArgsError
+			if errors.As(joined, &badArgs) {
+				t.Error("a real failure was reported as a caller's argument mistake")
+			}
+		})
+	}
+	// And with nothing real in hand, both argument refusals are still joined.
+	both := joinArgRefusals(argRefusal, &BadArgsError{Cause: errors.New("`id` is required")})
+	if both == nil || !strings.Contains(both.Error(), "`q`") || !strings.Contains(both.Error(), "`id`") {
+		t.Errorf("joined = %v, want both argument refusals in one answer", both)
+	}
+}

--- a/backend/internal/modules/agents/requiredargs_test.go
+++ b/backend/internal/modules/agents/requiredargs_test.go
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/mcp"
+)
+
+// requiringTool is a tool whose schema declares two non-uuid required
+// arguments, one optional one, and a required uuid — enough to show what this
+// chokepoint holds and what it leaves to its siblings.
+func requiringTool() echoTool {
+	spec := objectSpec("requires_things", principal.ScopeRead)
+	spec.InputSchema = json.RawMessage(`{"type":"object","required":["q","kind","anchor_id"],"properties":{
+		"q":{"type":"string"},
+		"kind":{"type":"string"},
+		"anchor_id":{"type":"string","format":"uuid"},
+		"limit":{"type":"integer"}},
+		"additionalProperties":false}`)
+	return echoTool{spec: spec, out: json.RawMessage(`{"ok":true}`)}
+}
+
+func requiringRegistry(t *testing.T) *Registry {
+	t.Helper()
+	r := NewRegistry(nil, auth.NewGate(fullSeatAuthority{}))
+	r.Register(requiringTool())
+	return r
+}
+
+// The claim itself: a call omitting an argument its own tools/list entry says is
+// required is refused AT THE REGISTRY, before any handler runs.
+func TestACallMissingARequiredArgumentIsRefusedAtTheChokepoint(t *testing.T) {
+	r := requiringRegistry(t)
+	ctx := scopedAgentCtx(principal.ScopeRead)
+	_, err := r.Invoke(ctx, "requires_things",
+		json.RawMessage(`{"kind":"note","anchor_id":"0198f3a1-7c42-7e0b-9d51-2a6f4b8c1e11"}`))
+	var badArgs *BadArgsError
+	if !asBadArgs(err, &badArgs) {
+		t.Fatalf("err = %v, want *BadArgsError", err)
+	}
+	if !strings.Contains(err.Error(), "`q`") {
+		t.Errorf("refusal %q does not name the missing argument", err)
+	}
+}
+
+// Every missing argument in one answer. Reporting them one per round trip is
+// accurate and still wasteful: an agent then spends a call per field to learn
+// what one refusal could have told it.
+func TestOneRefusalNamesEveryMissingRequiredArgument(t *testing.T) {
+	r := requiringRegistry(t)
+	_, err := r.Invoke(scopedAgentCtx(principal.ScopeRead), "requires_things",
+		json.RawMessage(`{"anchor_id":"0198f3a1-7c42-7e0b-9d51-2a6f4b8c1e11"}`))
+	if err == nil {
+		t.Fatal("a call missing two required arguments was admitted")
+	}
+	for _, want := range []string{"`kind`", "`q`"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("refusal %q does not name %s", err, want)
+		}
+	}
+}
+
+// An explicit null is ABSENT. A caller spelling out `{"q": null}` has supplied
+// no query, and answering "present" would hand the handler a zero value it
+// would have to re-refuse in its own words — the arrangement this replaces.
+func TestAnExplicitNullIsTreatedAsAMissingArgument(t *testing.T) {
+	r := requiringRegistry(t)
+	_, err := r.Invoke(scopedAgentCtx(principal.ScopeRead), "requires_things",
+		json.RawMessage(`{"q":null,"kind":"note","anchor_id":"0198f3a1-7c42-7e0b-9d51-2a6f4b8c1e11"}`))
+	if err == nil || !strings.Contains(err.Error(), "`q`") {
+		t.Fatalf("err = %v, want the null argument reported as missing", err)
+	}
+}
+
+// And the other direction, so the check cannot pass by refusing everything: a
+// complete call reaches its handler, and an OPTIONAL argument may be omitted.
+func TestACompleteCallReachesTheHandlerWithoutItsOptionalArguments(t *testing.T) {
+	r := requiringRegistry(t)
+	out, err := r.Invoke(scopedAgentCtx(principal.ScopeRead), "requires_things",
+		json.RawMessage(`{"q":"anything","kind":"note","anchor_id":"0198f3a1-7c42-7e0b-9d51-2a6f4b8c1e11"}`))
+	if err != nil {
+		t.Fatalf("a complete call was refused: %v", err)
+	}
+	if string(out) != `{"ok":true}` {
+		t.Errorf("out = %s, want the handler's own answer", out)
+	}
+}
+
+// A required UUID stays idargs.go's: both checks would otherwise refuse the same
+// missing argument, and the caller would be told about it twice in two different
+// sentences.
+func TestARequiredUUIDIsLeftToTheIdCheck(t *testing.T) {
+	if named := declaredRequired(requiringTool().spec.InputSchema); len(named) != 2 {
+		t.Fatalf("declaredRequired = %v, want the two non-uuid arguments only", named)
+	}
+	r := requiringRegistry(t)
+	_, err := r.Invoke(scopedAgentCtx(principal.ScopeRead), "requires_things",
+		json.RawMessage(`{"q":"anything","kind":"note"}`))
+	if err == nil {
+		t.Fatal("a call missing its required uuid was admitted")
+	}
+	// One sentence about it, from the check that owns id-shaped arguments.
+	if strings.Count(err.Error(), "anchor_id") != 1 {
+		t.Errorf("refusal %q reports the same missing argument more than once", err)
+	}
+}
+
+// A `required` entry naming a property the schema never declares would refuse
+// every call to that tool for a field no caller could learn about — a refusal
+// with no way out. It is dropped here and caught at boot by the fitness test
+// over the registry, where it can name the tool instead of a caller.
+func TestARequiredEntryNamingAnUndeclaredPropertyIsNotEnforced(t *testing.T) {
+	named := declaredRequired(json.RawMessage(`{"type":"object","required":["ghost"],"properties":{}}`))
+	if len(named) != 0 {
+		t.Errorf("declaredRequired = %v, want nothing enforceable", named)
+	}
+}
+
+// asBadArgs is errors.As with the one target this file cares about, named so
+// the assertions above read as what they check rather than as plumbing.
+func asBadArgs(err error, target **BadArgsError) bool {
+	for err != nil {
+		if bad, ok := err.(*BadArgsError); ok {
+			*target = bad
+			return true
+		}
+		unwrapped, ok := err.(interface{ Unwrap() error })
+		if !ok {
+			return false
+		}
+		err = unwrapped.Unwrap()
+	}
+	return false
+}
+
+var _ = mcp.ToolSpec{}

--- a/backend/internal/modules/agents/requiredargs_test.go
+++ b/backend/internal/modules/agents/requiredargs_test.go
@@ -182,6 +182,12 @@ func TestAnInvalidRequiredKeywordIsRefusedInEverySpelling(t *testing.T) {
 		"a string required":    `{"type":"object","required":"q","properties":{"q":{"type":"string"}}}`,
 		"an object required":   `{"type":"object","required":{"q":true},"properties":{"q":{"type":"string"}}}`,
 		"a non-string element": `{"type":"object","required":[7],"properties":{"q":{"type":"string"}}}`,
+		// A null element decodes to "" without error, which would become a
+		// requirement with no name to report; a repeat would be reported twice
+		// in one refusal. JSON Schema's list holds unique strings.
+		"a null element":  `{"type":"object","required":[null],"properties":{"q":{"type":"string"}}}`,
+		"an empty name":   `{"type":"object","required":[""],"properties":{"q":{"type":"string"}}}`,
+		"a repeated name": `{"type":"object","required":["q","q"],"properties":{"q":{"type":"string"}}}`,
 	} {
 		t.Run(name, func(t *testing.T) {
 			mustPanic(t, "a `required` that is not a list of strings cannot be enforced", func() {

--- a/backend/internal/modules/agents/requiredargs_test.go
+++ b/backend/internal/modules/agents/requiredargs_test.go
@@ -5,12 +5,12 @@ package agents
 
 import (
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
-	"github.com/gradionhq/margince/backend/internal/shared/ports/mcp"
 )
 
 // requiringTool is a tool whose schema declares two non-uuid required
@@ -42,7 +42,7 @@ func TestACallMissingARequiredArgumentIsRefusedAtTheChokepoint(t *testing.T) {
 	_, err := r.Invoke(ctx, "requires_things",
 		json.RawMessage(`{"kind":"note","anchor_id":"0198f3a1-7c42-7e0b-9d51-2a6f4b8c1e11"}`))
 	var badArgs *BadArgsError
-	if !asBadArgs(err, &badArgs) {
+	if !errors.As(err, &badArgs) {
 		t.Fatalf("err = %v, want *BadArgsError", err)
 	}
 	if !strings.Contains(err.Error(), "`q`") {
@@ -112,52 +112,13 @@ func TestARequiredUUIDIsLeftToTheIdCheck(t *testing.T) {
 	}
 }
 
-// A `required` entry naming a property the schema never declares would refuse
-// every call to that tool for a field no caller could learn about — a refusal
-// with no way out. It is dropped here and caught at boot by the fitness test
-// over the registry, where it can name the tool instead of a caller.
-func TestARequiredEntryNamingAnUndeclaredPropertyIsNotEnforced(t *testing.T) {
-	named := declaredRequired(json.RawMessage(`{"type":"object","required":["ghost"],"properties":{}}`))
-	if len(named) != 0 {
-		t.Errorf("declaredRequired = %v, want nothing enforceable", named)
-	}
-}
-
-// asBadArgs is errors.As with the one target this file cares about, named so
-// the assertions above read as what they check rather than as plumbing.
-func asBadArgs(err error, target **BadArgsError) bool {
-	for err != nil {
-		if bad, ok := err.(*BadArgsError); ok {
-			*target = bad
-			return true
-		}
-		unwrapped, ok := err.(interface{ Unwrap() error })
-		if !ok {
-			return false
-		}
-		err = unwrapped.Unwrap()
-	}
-	return false
-}
-
-var _ = mcp.ToolSpec{}
-
-// A schema whose `required` is not a list of strings is a defect in whatever
-// registered it — an extension unit, most likely — and it is named while cmd
-// wiring boots rather than on a caller's first request.
-func TestAnUnreadableRequiredListIsRefusedAtRegistration(t *testing.T) {
-	mustPanic(t, "a required list that is not a list of strings cannot be enforced", func() {
-		declaredRequired(json.RawMessage(`{"type":"object","required":"q","properties":{"q":{"type":"string"}}}`))
+// A `required` entry naming a property the schema never declares leaves a
+// caller and a handler working from different contracts. Dropping it would hide
+// that; enforcing it would refuse every call for a field no caller could learn
+// about. So the BOOT fails instead — which also reaches a composed extension
+// unit, where a fitness test over the core registry would not.
+func TestARequiredEntryNamingAnUndeclaredPropertyFailsRegistration(t *testing.T) {
+	mustPanic(t, "a requirement no caller could discover has no correct call", func() {
+		declaredRequired(json.RawMessage(`{"type":"object","required":["ghost"],"properties":{}}`))
 	})
-}
-
-// Arguments that are not an object at all carry no members to look for. The
-// shape verdict belongs to the steps that own it — the argument split, then the
-// handler's own decode — each of which names what it wanted; a second, vaguer
-// answer to the same question is worse than none.
-func TestNonObjectArgumentsAreLeftToTheStepsThatOwnTheirShape(t *testing.T) {
-	r := requiringRegistry(t)
-	if err := r.requireDeclaredPresence("requires_things", json.RawMessage(`"a bare string"`)); err != nil {
-		t.Errorf("non-object arguments were refused here as %v, where the shape is not this check's to judge", err)
-	}
 }

--- a/backend/internal/modules/agents/requiredargs_test.go
+++ b/backend/internal/modules/agents/requiredargs_test.go
@@ -141,3 +141,23 @@ func asBadArgs(err error, target **BadArgsError) bool {
 }
 
 var _ = mcp.ToolSpec{}
+
+// A schema whose `required` is not a list of strings is a defect in whatever
+// registered it — an extension unit, most likely — and it is named while cmd
+// wiring boots rather than on a caller's first request.
+func TestAnUnreadableRequiredListIsRefusedAtRegistration(t *testing.T) {
+	mustPanic(t, "a required list that is not a list of strings cannot be enforced", func() {
+		declaredRequired(json.RawMessage(`{"type":"object","required":"q","properties":{"q":{"type":"string"}}}`))
+	})
+}
+
+// Arguments that are not an object at all carry no members to look for. The
+// shape verdict belongs to the steps that own it — the argument split, then the
+// handler's own decode — each of which names what it wanted; a second, vaguer
+// answer to the same question is worse than none.
+func TestNonObjectArgumentsAreLeftToTheStepsThatOwnTheirShape(t *testing.T) {
+	r := requiringRegistry(t)
+	if err := r.requireDeclaredPresence("requires_things", json.RawMessage(`"a bare string"`)); err != nil {
+		t.Errorf("non-object arguments were refused here as %v, where the shape is not this check's to judge", err)
+	}
+}

--- a/backend/internal/modules/agents/tools_comms_test.go
+++ b/backend/internal/modules/agents/tools_comms_test.go
@@ -362,15 +362,17 @@ func TestStagingRefusesASendOrBookingExecutionWouldRefuse(t *testing.T) {
 			wantNamed: "`to` is empty",
 		},
 		{
-			name:      "a meeting that ends before it starts is not bookable",
-			tool:      "book_meeting",
-			args:      `{"start":"2026-08-10T15:00:00Z","end":"2026-08-10T14:00:00Z","subject":"s"}`,
+			name: "a meeting that ends before it starts is not bookable",
+			tool: "book_meeting",
+			args: fmt.Sprintf(`{"start":"2026-08-10T15:00:00Z","end":"2026-08-10T14:00:00Z","subject":"s",`+
+				`"links":[{"entity_type":"person","entity_id":%q}]}`, anchor),
 			wantNamed: "does not follow `start`",
 		},
 		{
-			name:      "a meeting of zero length is not bookable either",
-			tool:      "book_meeting",
-			args:      `{"start":"2026-08-10T15:00:00Z","end":"2026-08-10T15:00:00Z","subject":"s"}`,
+			name: "a meeting of zero length is not bookable either",
+			tool: "book_meeting",
+			args: fmt.Sprintf(`{"start":"2026-08-10T15:00:00Z","end":"2026-08-10T15:00:00Z","subject":"s",`+
+				`"links":[{"entity_type":"person","entity_id":%q}]}`, anchor),
 			wantNamed: "does not follow `start`",
 		},
 	} {


### PR DESCRIPTION
## What this changes

The MCP registry already held two of a tool's own `InputSchema` claims at one chokepoint,
generically, for every tool:

- **uuid-shaped arguments** — present and well-formed (`idargs.go`)
- **numeric bounds** — inside the declared `minimum`/`maximum` (`numargs.go`)

`required` for any other property was left to whichever handler remembered to check it. It
is now the third sibling: read off the schema once at registration, enforced at
`Registry.Invoke` before any handler runs.

`idargs.go`'s own doc says why one spelling at one chokepoint wins — thirteen handlers each
failed to make their own schema's `required` true, one at a time. That reasoning applies
unchanged here.

Closes #578. Also closes #480 as stale: `enrich` **is** registered, verified by the parity
gate and by the live UAT on #598.

## What it deliberately does not take from a handler

Presence is not meaning. A blank string is present; an enum value outside its list is
present; a body that is only whitespace is present. Those stay with the handler that knows
what they mean — this holds the one claim the schema itself makes, identically for every
tool.

## Two decisions worth reviewing

**A `required` entry naming an undeclared property fails the BOOT.** Dropping it would
leave the surface advertising a requirement the registry ignores — a caller and a handler
working from different contracts with nothing saying so. Enforcing it would refuse every
call to that tool for a field no caller could ever learn about. Neither is a state to
serve, and the schema is a literal in whatever registered the tool.

This replaced a compose-side fitness test, which review showed could not see the case that
matters: its sweep is the core registry by construction, so a composed **extension** unit
could have booted with a contradictory schema and had its requirement quietly ignored. The
test is gone rather than left standing — with the refusal at the door it could no longer
fail.

The panic states the assumption it rests on: every schema here is a flat literal. JSON
Schema also admits a property supplied by `additionalProperties`, `patternProperties` or an
`allOf` branch, none of which this reader walks. Nothing writes one today.

**Presence and the ids answer together.** Each check collected faithfully on its own, but
they split the required arguments between them — so a call missing one of each was refused
for the plain argument and told about the id only after the caller had fixed the first and
called again. That is exactly the call-per-field waste three comments in these files say
the collection exists to end, reappearing at the seam between them. **Both the code review
and the live UAT found this independently, from opposite ends.**

## Two existing tests were passing for the wrong reason

The malformed-id sweep sent *only* the bad id, and two booking cases omitted the `links`
their schema requires. Once presence is checked first, both were refused for arguments they
had never supplied. Both fixtures now send everything else the schema asks for, so each
tests the one thing it is named for — and the malformed-id walk still requires the refusal
to name the malformed property, so a presence-shaped refusal fails it.

## UAT — live stack, proof captured

Driven against a live local stack through the real `/mcp` surface with a minted passport.

| check | result |
|---|---|
| a missing required argument is refused **before the handler runs** — proven by an activity count unchanged across the refusal | PASS |
| one refusal names every missing argument (`send_email {}` → `body`, `consent_purpose`, `subject`, `to`) | PASS |
| an explicit `null` counts as absent — byte-identical refusal to the omitted case | PASS |
| a complete call still works and returns the activity | PASS |
| **no false refusals** — all 31 tools / 50 required names swept: every `required` name is declared in `properties`, 0 mismatches | PASS |
| a required uuid is reported exactly once, not twice | PASS |
| after the fix: one refusal names the plain arguments **and** the missing id, re-verified on a rebuilt binary | PASS |

The no-false-refusals sweep is the check that mattered: this runs before every tool call, so
a `required` entry a caller could reasonably omit would break a working tool. The reviews
walked all 30 schemas and their handlers for the same question and found none — every
refusal this adds replaces a later, vaguer one, and never a success.

## Coverage

**100% of changed executable statements**, measured line-by-line against
`git diff origin/main...HEAD`.

## Scope note

PLAN.md's A4 bundles three separable changes. This is the argument-discipline one, shipped
complete. Retry safety (idempotency keys on the mutating tools) is a different invariant
needing a seam over compose's existing claim table, and #577 — `prep_for_meeting`'s missing
anchor for an unlinked calendar activity — is a catalog gap rather than argument
discipline, whose own issue says the better fix is the larger one. Both follow separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces `required` tool arguments at the registry and returns a single refusal listing all missing inputs across presence and UUID checks. Boot now fails fast for undeclared or invalid `required` entries (including null elements, empty or duplicate names), and non-argument errors pass through unjoined.

- **Bug Fixes**
  - Read `required` once at registration; reject invalid forms (`null`, string/object, null elements, empty names, duplicates).
  - Join presence and UUID refusals into one `BadArgsError`; real failures outrank and return unjoined.
  - Presence check ignores non-object args; scope is top-level properties; explicit `null` counts as absent.

<sup>Written for commit c77db7bce8c55d4f78f3dd1150ad7aa0c616ad14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/607?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation to ensure required tool arguments are provided before execution.
  * Missing and `null` arguments are clearly reported together, with schema-based guidance.
  * Required argument definitions are checked during tool registration.

* **Bug Fixes**
  * Improved combined reporting for missing arguments and invalid IDs.
  * Strengthened validation of malformed UUIDs and linked entities in meeting requests.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->