### PR TITLE
feat(search): a question compiles to a closed vocabulary, or it is refused

### DIFF
--- a/backend/internal/compose/integration/queryvocabulary_integration_test.go
+++ b/backend/internal/compose/integration/queryvocabulary_integration_test.go
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The query vocabulary as a client actually reaches it: over the composed
+// /mcp mount, with a real passport, a real workspace and the real custom-field
+// catalog behind it. The unit suite in modules/search proves the derivation;
+// this proves the WIRING — that compose injects the provider, that the
+// transport publishes it, and that the catalog read rides a workspace-bound
+// transaction rather than an unbound one that would silently answer nothing.
+
+import (
+	"encoding/json"
+	"net/http"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
+	"github.com/gradionhq/margince/backend/internal/modules/search"
+)
+
+// The published document as a CLIENT decodes it — declared here rather than
+// reused from the search package, so a renamed wire member fails this test
+// instead of travelling through it unnoticed.
+type vocabularyDoc struct {
+	Version     string                  `json:"version"`
+	Targets     []vocabularyTarget      `json:"targets"`
+	Unavailable []vocabularyUnavailable `json:"unavailable"`
+}
+
+type vocabularyTarget struct {
+	Target    string               `json:"target"`
+	Fields    []vocabularyField    `json:"fields"`
+	Relations []vocabularyRelation `json:"relations"`
+}
+
+type vocabularyField struct {
+	Name string   `json:"name"`
+	Kind string   `json:"kind"`
+	Ops  []string `json:"ops"`
+}
+
+type vocabularyRelation struct {
+	Name   string `json:"name"`
+	Target string `json:"target"`
+	Via    string `json:"via"`
+}
+
+type vocabularyUnavailable struct {
+	Op      string `json:"op"`
+	Answers string `json:"answers"`
+}
+
+func TestTheComposedMCPMountPublishesTheQueryVocabulary(t *testing.T) {
+	env := setupConnector(t)
+	bearer := readPassport(t, env.AppEnv, "query vocabulary reader")
+
+	// The catalogue advertises it, which is how a client finds it at all.
+	listed := mcpRPC(env.AppEnv, t, bearer, `{"jsonrpc":"2.0","id":1,"method":"resources/list"}`)
+	if !strings.Contains(listed, search.QuerySchemaURI) {
+		t.Fatalf("resources/list does not advertise %s: %s", search.QuerySchemaURI, listed)
+	}
+
+	doc := readVocabulary(env.AppEnv, t, bearer)
+	if doc.Version != search.PlanVersion {
+		t.Fatalf("published vocabulary is version %q, want %q", doc.Version, search.PlanVersion)
+	}
+
+	// The derivation survives the trip: the deal record's own contract fields
+	// and its derived organization hop are both there.
+	deal := dealVocabulary(t, doc)
+	if !slices.ContainsFunc(deal.Fields, func(f vocabularyField) bool {
+		return f.Name == "amount_minor" && f.Kind == "number"
+	}) {
+		t.Error("the published deal vocabulary has no amount_minor number field")
+	}
+	if !slices.ContainsFunc(deal.Relations, func(r vocabularyRelation) bool {
+		return r.Name == "organization" && r.Via == "organization_id"
+	}) {
+		t.Error("the published deal vocabulary has no derived organization hop")
+	}
+
+	// The declared-but-unanswerable operator arrives declared (SEARCH-AC-17).
+	if !slices.ContainsFunc(doc.Unavailable, func(u vocabularyUnavailable) bool {
+		return u.Op == "within_radius" && u.Answers == search.CodeDistanceRankingUnavailable
+	}) {
+		t.Error("within_radius is not published as unavailable, so a caller cannot tell it apart from one that works")
+	}
+}
+
+// SEARCH-AC-15 against the REAL catalog: a field added through the admin
+// surface is in the published vocabulary on the next read, and a retired one
+// is gone — with no deploy, no cache bust, and no edit to any list.
+func TestACustomFieldReachesThePublishedVocabularyWithoutADeploy(t *testing.T) {
+	// The schema pool is the owner-privileged connection the add-field engine
+	// runs its one ALTER TABLE on; without it the create answers 501 and this
+	// test would be asserting against a surface that is not mounted.
+	env := setupConnectorWith(t, compose.WithSchemaPool(SchemaPool(t)))
+	bearer := readPassport(t, env.AppEnv, "custom field reader")
+
+	before := readVocabulary(env.AppEnv, t, bearer)
+	if fieldNamed(dealVocabulary(t, before), "cf_renewal_risk") {
+		t.Fatal("the field under test already exists in the vocabulary")
+	}
+
+	status, created, problem := createCustomField(t, env.AppEnv, apptest.AnyMap{
+		"object": "deal", "label": "Renewal risk", "type": "text", "source": "ui",
+	})
+	if status != http.StatusCreated {
+		t.Fatalf("adding a custom field → %d %+v", status, problem)
+	}
+	if created.ColumnName != "cf_renewal_risk" {
+		t.Fatalf("the engine named the column %q; this test asks the vocabulary for cf_renewal_risk", created.ColumnName)
+	}
+
+	added := readVocabulary(env.AppEnv, t, bearer)
+	if !fieldNamed(dealVocabulary(t, added), "cf_renewal_risk") {
+		t.Fatal("a custom field active in the catalog is not in the published vocabulary")
+	}
+
+	var retired customFieldWire
+	if status := env.Call(t, "POST", "/v1/custom-fields/"+created.ID+"/retire", nil, nil, &retired); status != http.StatusOK {
+		t.Fatalf("retiring the custom field → %d", status)
+	}
+	if fieldNamed(dealVocabulary(t, readVocabulary(env.AppEnv, t, bearer)), "cf_renewal_risk") {
+		t.Error("a retired custom field is still published; the vocabulary is cached rather than derived")
+	}
+}
+
+// A URI this surface does not serve answers the protocol's not-found, which
+// is also what a document the caller cannot see answers.
+func TestAnUnservedResourceURIIsRefusedOverTheTransport(t *testing.T) {
+	env := setupConnector(t)
+	bearer := readPassport(t, env.AppEnv, "resource prober")
+
+	out := mcpRPC(env.AppEnv, t, bearer,
+		`{"jsonrpc":"2.0","id":9,"method":"resources/read","params":{"uri":"margince://schema/secrets"}}`)
+	if !strings.Contains(out, `"error"`) || !strings.Contains(out, "-32002") {
+		t.Fatalf("read of an unserved URI → %s, want a resource-not-found error", out)
+	}
+}
+
+// readPassport mints a read-scoped passport, which is the credential every
+// exchange in this file presents. It answers the bare token rather than a
+// header map: these exchanges post JSON-RPC bodies, so the header set differs
+// from the REST helper's next to it.
+func readPassport(t *testing.T, e *apptest.AppEnv, label string) string {
+	t.Helper()
+	var minted struct {
+		Token string `json:"token"`
+	}
+	if status := e.Call(t, "POST", "/v1/passports", apptest.AnyMap{
+		"label": label, "scopes": []string{"read"},
+	}, nil, &minted); status != http.StatusCreated || minted.Token == "" {
+		t.Fatalf("issue passport → %d", status)
+	}
+	return minted.Token
+}
+
+// mcpRPC posts one JSON-RPC exchange to the composed /mcp mount and returns
+// the raw body — the errors this file asserts on live in the envelope, not in
+// a decoded result.
+func mcpRPC(e *apptest.AppEnv, t *testing.T, bearer, payload string) string {
+	t.Helper()
+	got := raw(e, t, http.MethodPost, "/mcp", payload, map[string]string{
+		"Content-Type": "application/json", "Authorization": "Bearer " + bearer,
+	})
+	if got.StatusCode != http.StatusOK {
+		t.Fatalf("POST /mcp → %d %s", got.StatusCode, got.Body)
+	}
+	return got.Body
+}
+
+// readVocabulary fetches and decodes the published document.
+func readVocabulary(e *apptest.AppEnv, t *testing.T, bearer string) vocabularyDoc {
+	t.Helper()
+	body := mcpRPC(e, t, bearer,
+		`{"jsonrpc":"2.0","id":2,"method":"resources/read","params":{"uri":"`+search.QuerySchemaURI+`"}}`)
+
+	var envelope struct {
+		Result struct {
+			Contents []struct {
+				Text string `json:"text"`
+			} `json:"contents"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal([]byte(body), &envelope); err != nil {
+		t.Fatalf("resources/read body is not JSON-RPC: %v (%s)", err, body)
+	}
+	if len(envelope.Result.Contents) != 1 {
+		t.Fatalf("resources/read returned %d content blocks: %s", len(envelope.Result.Contents), body)
+	}
+	var doc vocabularyDoc
+	if err := json.Unmarshal([]byte(envelope.Result.Contents[0].Text), &doc); err != nil {
+		t.Fatalf("the published vocabulary is not JSON: %v", err)
+	}
+	return doc
+}
+
+// dealVocabulary is the one target every assertion in this file reads: the
+// deal record carries both halves of the derivation (contract fields and, in
+// the custom-field test, a workspace column) plus a derived hop.
+func dealVocabulary(t *testing.T, doc vocabularyDoc) vocabularyTarget {
+	t.Helper()
+	i := slices.IndexFunc(doc.Targets, func(target vocabularyTarget) bool { return target.Target == "deal" })
+	if i < 0 {
+		t.Fatal(`the published vocabulary has no "deal" target`)
+	}
+	return doc.Targets[i]
+}
+
+func fieldNamed(target vocabularyTarget, name string) bool {
+	return slices.ContainsFunc(target.Fields, func(f vocabularyField) bool { return f.Name == name })
+}

--- a/backend/internal/compose/mcpedge.go
+++ b/backend/internal/compose/mcpedge.go
@@ -39,8 +39,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgxpool"
+
 	"github.com/gradionhq/margince/backend/internal/modules/agents"
+	"github.com/gradionhq/margince/backend/internal/modules/customfields"
 	"github.com/gradionhq/margince/backend/internal/modules/identity"
+	"github.com/gradionhq/margince/backend/internal/modules/search"
 	"github.com/gradionhq/margince/backend/internal/platform/httperr"
 	"github.com/gradionhq/margince/backend/internal/platform/httpserver"
 	"github.com/gradionhq/margince/backend/internal/platform/ratelimit"
@@ -70,7 +74,7 @@ var errMissingBearer = errors.New("missing bearer token")
 // its time windows against an injectable clock — so a second instance would
 // hold a second cache and, worse, its own time.Now, silently escaping a clock
 // a test injected on the process's real service.
-func (s *Server) mcpHandler(auth *identity.Service, log *slog.Logger) http.Handler {
+func (s *Server) mcpHandler(pool *pgxpool.Pool, auth *identity.Service, log *slog.Logger) http.Handler {
 	if !s.mcpConnectorEnabled {
 		return nil
 	}
@@ -86,7 +90,15 @@ func (s *Server) mcpHandler(auth *identity.Service, log *slog.Logger) http.Handl
 	// operator can compare it against what their front end actually routes.
 	log.Info("mcp: consent screen redirect target", "location", identity.ConsentScreenPath)
 	return agents.NewHTTPHandler(s.toolRegistry, mcpAuthenticate(auth),
-		agents.ResourceMetadataChallenge, mcpServerName, mcpServerVersion, log)
+		agents.ResourceMetadataChallenge, mcpServerName, mcpServerVersion, log,
+		// The cross-module edge: composing the query vocabulary is the search
+		// module's job and publishing it is the transport's, and neither
+		// reaches for the other (ADR-0054 §3). It is wired here, once — and
+		// the custom-field half rides the same fieldcatalog seam every record
+		// store does, so a workspace's own columns are askable without this
+		// edge knowing anything about them.
+		agents.WithResourceProvider(search.NewQuerySchemaResource(
+			search.NewVocabularyResolver().WithFieldCatalog(customfields.NewService(pool, nil)))))
 }
 
 // mcpAuthenticate binds one request to its agent principal. It runs on EVERY

--- a/backend/internal/compose/routes.go
+++ b/backend/internal/compose/routes.go
@@ -148,7 +148,7 @@ func operationalMux(srv Server, pool *pgxpool.Pool, log *slog.Logger, identitySv
 	// gate signal: with the connector off none of these routes is
 	// registered, so the mux's own 404 answers all of them identically and
 	// nothing tells a prober which gate is closed.
-	if mcp := srv.mcpHandler(identitySvc, log); mcp != nil {
+	if mcp := srv.mcpHandler(pool, identitySvc, log); mcp != nil {
 		// ONE set of limiters for the whole group: the transport and the
 		// authorization server are two halves of one internet-facing surface,
 		// and a second construction would give each its own private ceilings.

--- a/backend/internal/modules/agents/dispatch.go
+++ b/backend/internal/modules/agents/dispatch.go
@@ -86,6 +86,12 @@ type Dispatcher struct {
 	bind     Binder
 	name     string
 	version  string
+	// resources publishes the read-only documents beside the tool surface
+	// (the query vocabulary today). Nil is a server with no resources, which
+	// is why the capability is advertised conditionally: claiming one with
+	// nothing behind it sends a client to a resources/read that can only
+	// fail.
+	resources mcp.ResourceProvider
 	// log receives the true cause of failures the tool client only sees
 	// generically — the client is an untrusted agent, so infrastructure
 	// detail (DSNs, hosts, wrap chains) stays server-side.
@@ -96,6 +102,14 @@ type Dispatcher struct {
 // are what initialize reports as serverInfo.
 func NewDispatcher(registry *Registry, bind Binder, name, version string) *Dispatcher {
 	return &Dispatcher{registry: registry, bind: bind, name: name, version: version, log: slog.Default()}
+}
+
+// WithResources wires the resource provider. Compose calls it: the documents
+// published here are composed by other modules (the query vocabulary is the
+// search module's), and a module never reaches for a sibling.
+func (s *Dispatcher) WithResources(provider mcp.ResourceProvider) *Dispatcher {
+	s.resources = provider
+	return s
 }
 
 // WithLogger routes server-side diagnostics to log. They are kept away from
@@ -144,15 +158,21 @@ func (s *Dispatcher) handle(ctx context.Context, req rpcRequest) rpcResponse {
 				return resp
 			}
 		}
+		// listChanged is FALSE on both capabilities because this server has no
+		// way to send the notification: notifications/*/list_changed travels
+		// on the GET SSE stream, and GET /mcp answers 405 here. Both surfaces
+		// really do change — each is filtered per caller — so the claim would
+		// promise a message that can never arrive.
+		capabilities := map[string]any{"tools": map[string]any{"listChanged": false}}
+		if s.resources != nil {
+			// subscribe is FALSE for the same reason, and separately: a
+			// per-caller document has no shared state to subscribe to.
+			capabilities["resources"] = map[string]any{"listChanged": false, "subscribe": false}
+		}
 		resp.Result = map[string]any{
 			"protocolVersion": negotiateProtocolVersion(params.ProtocolVersion),
-			// listChanged is FALSE because this server has no way to send the
-			// notification: notifications/tools/list_changed travels on the GET
-			// SSE stream, and GET /mcp answers 405 here. The surface really
-			// does change — tools/list is scope-filtered per caller — so the
-			// claim would promise a message that can never arrive.
-			"capabilities": map[string]any{"tools": map[string]any{"listChanged": false}},
-			"serverInfo":   map[string]any{fieldName: s.name, "version": s.version},
+			"capabilities":    capabilities,
+			"serverInfo":      map[string]any{fieldName: s.name, "version": s.version},
 		}
 	case "ping":
 		resp.Result = map[string]any{}
@@ -161,11 +181,19 @@ func (s *Dispatcher) handle(ctx context.Context, req rpcRequest) rpcResponse {
 	case "tools/call":
 		resp.Result = s.call(ctx, req.Params)
 	case "resources/list":
-		// This server has no resources; claude.ai calls this right after
-		// initialize regardless, and an unadvertised capability answering
-		// -32601 there reads as a broken server rather than a legitimate
-		// empty catalog.
-		resp.Result = map[string]any{"resources": []any{}}
+		// Answered even with no provider wired: claude.ai calls this right
+		// after initialize regardless, and an unadvertised capability
+		// answering -32601 there reads as a broken server rather than a
+		// legitimate empty catalog.
+		resp.Result = map[string]any{"resources": s.resourceList(ctx)}
+	case "resources/read":
+		// Assigned on separate branches so a failed read never carries a
+		// result alongside its error, which JSON-RPC forbids.
+		if result, rpcErr := s.readResource(ctx, req.Params); rpcErr != nil {
+			resp.Error = rpcErr
+		} else {
+			resp.Result = result
+		}
 	case "resources/templates/list":
 		resp.Result = map[string]any{"resourceTemplates": []any{}}
 	case "prompts/list":

--- a/backend/internal/modules/agents/httpmcp.go
+++ b/backend/internal/modules/agents/httpmcp.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/httpserver"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/mcp"
 )
 
 // mcpCallDeadline bounds one JSON-RPC exchange's response write. A dynamic
@@ -236,13 +237,28 @@ type httpMCPHandler struct {
 // its cause, so the one place that cause survives is this logger. A nil one
 // falls back to slog.Default(), which in a process that never called
 // SetDefault means the record is written somewhere nobody is reading.
-func NewHTTPHandler(registry *Registry, authenticate func(*http.Request) (context.Context, error), challenge func(*http.Request) string, name, version string, log *slog.Logger) http.Handler {
+func NewHTTPHandler(registry *Registry, authenticate func(*http.Request) (context.Context, error), challenge func(*http.Request) string, name, version string, log *slog.Logger, opts ...HTTPOption) http.Handler {
+	server := NewDispatcher(registry, bindAuthenticated, name, version).WithLogger(log)
+	for _, opt := range opts {
+		opt(server)
+	}
 	return &httpMCPHandler{
-		server:       NewDispatcher(registry, bindAuthenticated, name, version).WithLogger(log),
+		server:       server,
 		authenticate: authenticate,
 		challenge:    challenge,
 		sessions:     newSessionRegistry(),
 	}
+}
+
+// HTTPOption configures the dispatcher behind the HTTP transport. What it
+// carries is composed by OTHER modules and injected at the composition edge,
+// so it is variadic rather than a positional parameter: a caller that mounts
+// no such module does not have to name one.
+type HTTPOption func(*Dispatcher)
+
+// WithResourceProvider publishes read-only documents beside the tool surface.
+func WithResourceProvider(provider mcp.ResourceProvider) HTTPOption {
+	return func(d *Dispatcher) { d.WithResources(provider) }
 }
 
 // bindAuthenticated is the Binder the shared dispatcher gets on this

--- a/backend/internal/modules/agents/resources.go
+++ b/backend/internal/modules/agents/resources.go
@@ -80,6 +80,12 @@ func (s *Dispatcher) readResource(ctx context.Context, params json.RawMessage) (
 	if err := json.Unmarshal(params, &p); err != nil {
 		return resourceContents{}, &rpcError{Code: -32602, Message: "invalid params: " + err.Error()}
 	}
+	// An absent, null or empty uri is a request this server could not read,
+	// not a resource that is missing — a different thing for the caller to
+	// fix, and "" can never name a document any provider serves.
+	if p.URI == "" {
+		return resourceContents{}, &rpcError{Code: -32602, Message: "invalid params: resources/read needs a non-empty \"uri\""}
+	}
 	if s.resources == nil {
 		return resourceContents{}, &rpcError{Code: resourceNotFound, Message: "no resource at " + p.URI}
 	}

--- a/backend/internal/modules/agents/resources.go
+++ b/backend/internal/modules/agents/resources.go
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// resources/list and resources/read — the read-only half of the surface.
+//
+// A resource takes no arguments and changes nothing, so it does not ride the
+// tool admission gate. What it does ride is the caller's own context: every
+// provider composes its document from what THIS principal may read, which is
+// what keeps a resource from becoming the discovery channel the scope-filtered
+// tool list is careful not to be.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/mcp"
+)
+
+// resourceNotFound is the protocol's code for a URI the server does not
+// serve. It is also what a URI the CALLER cannot see answers, deliberately
+// indistinguishable — the same existence-hiding the record surface applies.
+const resourceNotFound = -32002
+
+// resourceDescriptor is one resources/list entry on the wire.
+type resourceDescriptor struct {
+	URI         string `json:"uri"`
+	Name        string `json:"name"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	//nolint:tagliatelle // mimeType is the MCP wire member, camelCase by the protocol
+	MIMEType string `json:"mimeType"`
+}
+
+// resourceContents is one resources/read result: the protocol carries a list
+// of blocks, and this server always answers with exactly one.
+type resourceContents struct {
+	Contents []resourceContentBlock `json:"contents"`
+}
+
+type resourceContentBlock struct {
+	URI string `json:"uri"`
+	//nolint:tagliatelle // mimeType is the MCP wire member, camelCase by the protocol
+	MIMEType string `json:"mimeType"`
+	Text     string `json:"text"`
+}
+
+// resourceList advertises what this caller may read. A server with no
+// provider answers an empty list rather than an error: an empty catalog is a
+// legitimate state, and a client that calls resources/list right after
+// initialize should not read it as a broken server.
+func (s *Dispatcher) resourceList(ctx context.Context) []resourceDescriptor {
+	if s.resources == nil {
+		return []resourceDescriptor{}
+	}
+	published := s.resources.Resources(ctx)
+	out := make([]resourceDescriptor, 0, len(published))
+	for _, r := range published {
+		if !readableByCaller(ctx, r) {
+			continue
+		}
+		out = append(out, resourceDescriptor{
+			URI: r.URI, Name: r.Name, Title: r.Title,
+			Description: r.Description, MIMEType: r.MIMEType,
+		})
+	}
+	return out
+}
+
+// readResource answers one document, or a protocol error — never both, which
+// is why the caller assigns them on separate branches.
+func (s *Dispatcher) readResource(ctx context.Context, params json.RawMessage) (resourceContents, *rpcError) {
+	var p struct {
+		URI string `json:"uri"`
+	}
+	if err := json.Unmarshal(params, &p); err != nil {
+		return resourceContents{}, &rpcError{Code: -32602, Message: "invalid params: " + err.Error()}
+	}
+	if s.resources == nil {
+		return resourceContents{}, &rpcError{Code: resourceNotFound, Message: "no resource at " + p.URI}
+	}
+	if !s.scopeAdmitsRead(ctx, p.URI) {
+		// The same answer an unknown URI gets: a caller whose scopes do not
+		// reach a document must not learn that it exists.
+		return resourceContents{}, &rpcError{Code: resourceNotFound, Message: "no resource at " + p.URI}
+	}
+	contents, err := s.resources.ReadResource(ctx, p.URI)
+	if errors.Is(err, apperrors.ErrNotFound) {
+		return resourceContents{}, &rpcError{Code: resourceNotFound, Message: "no resource at " + p.URI}
+	}
+	if err != nil {
+		// The cause is server-side knowledge (a pool fault, a wrapped SQL
+		// error); the client learns only that the read did not happen.
+		s.log.Error("mcp: reading resource", "uri", p.URI, "err", err)
+		return resourceContents{}, &rpcError{Code: -32603, Message: "the resource could not be read; retry, and if it persists ask an administrator to check the server logs"}
+	}
+	return resourceContents{Contents: []resourceContentBlock{{
+		URI: contents.URI, MIMEType: contents.MIMEType, Text: contents.Text,
+	}}}, nil
+}
+
+// readableByCaller reports whether the calling principal's passport scopes
+// reach this document. It mirrors the scope arm of the tool surface's own
+// filter (invocableByCaller) deliberately: a resource is a read, and a
+// surface that advertises what it will then refuse is a surface that lies.
+//
+// Humans and the system principal do not ride the scope model — their
+// authority is their RBAC, which the provider itself applies — so filtering
+// them by a passport scope they never carry would hide the whole catalogue.
+// A ctx with no principal shows nothing, which is the honest answer for a
+// caller that never authenticated.
+func readableByCaller(ctx context.Context, resource mcp.Resource) bool {
+	p, ok := principal.Actor(ctx)
+	if !ok {
+		return false
+	}
+	if p.Type != principal.PrincipalAgent {
+		return true
+	}
+	return p.Scopes.Has(resource.RequiredScope)
+}
+
+// scopeAdmitsRead answers whether this caller may read the named URI, by
+// asking the provider what it publishes and applying the same scope filter
+// the catalogue does. Going through the published set rather than a separate
+// per-URI lookup is what keeps the two answers from drifting: a document the
+// catalogue hides can never be readable.
+func (s *Dispatcher) scopeAdmitsRead(ctx context.Context, uri string) bool {
+	for _, r := range s.resources.Resources(ctx) {
+		if r.URI == uri {
+			return readableByCaller(ctx, r)
+		}
+	}
+	// Not published at all — ReadResource answers its own not-found, and this
+	// filter has nothing to say about a URI no provider claims.
+	return true
+}

--- a/backend/internal/modules/agents/resources_test.go
+++ b/backend/internal/modules/agents/resources_test.go
@@ -311,3 +311,28 @@ func readScopedProvider() stubResources {
 		},
 	}
 }
+
+// An absent, null or empty uri is a request this server could not read, not a
+// resource that is missing — a different thing for the caller to fix. The
+// boundary between the two answers is what this pins.
+func TestAnEmptyURIIsInvalidParamsRatherThanNotFound(t *testing.T) {
+	d := dispatcherWith(readScopedProvider())
+	for name, params := range map[string]string{
+		"an empty uri":  `{"uri":""}`,
+		"a null uri":    `{"uri":null}`,
+		"no uri at all": `{}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			resp := rpc(t, d, "resources/read", params)
+			if resp.Error == nil || resp.Error.Code != -32602 {
+				t.Fatalf("answered %+v; want -32602, not a not-found", resp.Error)
+			}
+			if !strings.Contains(resp.Error.Message, "uri") {
+				t.Errorf("the refusal does not name what to fix: %q", resp.Error.Message)
+			}
+			if resp.Result != nil {
+				t.Error("a refused read carried a result")
+			}
+		})
+	}
+}

--- a/backend/internal/modules/agents/resources_test.go
+++ b/backend/internal/modules/agents/resources_test.go
@@ -1,0 +1,313 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/mcp"
+)
+
+// stubResources stands in for whatever module composes a document. It is a
+// seam, which is what a stub is for; nothing here asserts how it was called.
+type stubResources struct {
+	published []mcp.Resource
+	contents  map[string]mcp.ResourceContents
+	err       error
+}
+
+func (s stubResources) Resources(context.Context) []mcp.Resource { return s.published }
+
+func (s stubResources) ReadResource(_ context.Context, uri string) (mcp.ResourceContents, error) {
+	if s.err != nil {
+		return mcp.ResourceContents{}, s.err
+	}
+	contents, ok := s.contents[uri]
+	if !ok {
+		return mcp.ResourceContents{}, apperrors.ErrNotFound
+	}
+	return contents, nil
+}
+
+func dispatcherWith(provider mcp.ResourceProvider) *Dispatcher {
+	d := NewDispatcher(NewRegistry(nil, nil), bindAuthenticated, "margince-crm", "test").WithLogger(discardLog())
+	if provider != nil {
+		d = d.WithResources(provider)
+	}
+	return d
+}
+
+// agentHolding is the context an authenticated passport call arrives on: the
+// resource surface is scope-filtered for agents exactly as the tool list is,
+// so a test that posted an actor-less context would be asserting against an
+// empty surface for the wrong reason.
+func agentHolding(scopes ...principal.Scope) context.Context {
+	return principal.WithActor(context.Background(), principal.Principal{
+		Type:   principal.PrincipalAgent,
+		ID:     "agent:test",
+		Scopes: principal.NewScopeSet(scopes...),
+	})
+}
+
+func rpc(t *testing.T, d *Dispatcher, method string, params string) rpcResponse {
+	t.Helper()
+	return rpcAs(agentHolding(principal.ScopeRead), t, d, method, params)
+}
+
+func rpcAs(ctx context.Context, t *testing.T, d *Dispatcher, method string, params string) rpcResponse {
+	t.Helper()
+	req := rpcRequest{JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: method}
+	if params != "" {
+		req.Params = json.RawMessage(params)
+	}
+	return d.handle(ctx, req)
+}
+
+// A wired provider's documents are advertised; the catalogue is what a client
+// reads instead of probing for URIs.
+func TestResourcesListAdvertisesTheWiredProvider(t *testing.T) {
+	d := dispatcherWith(stubResources{published: []mcp.Resource{{
+		URI: "margince://schema/query", Name: "query_vocabulary", Title: "Workspace query vocabulary",
+		Description: "what you may ask", MIMEType: "application/json",
+		RequiredScope: principal.ScopeRead,
+	}}})
+
+	result := decodeResult[resourceListResult](t, rpc(t, d, "resources/list", ""))
+	if len(result.Resources) != 1 {
+		t.Fatalf("resources/list returned %d entries", len(result.Resources))
+	}
+	r := result.Resources[0]
+	if r.URI == "" || r.Name == "" || r.Title == "" || r.Description == "" || r.MIMEType == "" {
+		t.Errorf("advertised resource is incomplete on the wire: %+v", r)
+	}
+}
+
+// resourceListResult and resourceReadResult decode what a CLIENT receives —
+// deliberately declared here rather than reusing the production types, so a
+// renamed json member fails these tests instead of travelling with them.
+type resourceListResult struct {
+	Resources []struct {
+		URI         string `json:"uri"`
+		Name        string `json:"name"`
+		Title       string `json:"title"`
+		Description string `json:"description"`
+		//nolint:tagliatelle // mimeType is the MCP wire member, camelCase by the protocol
+		MIMEType string `json:"mimeType"`
+	} `json:"resources"`
+}
+
+type resourceReadResult struct {
+	Contents []struct {
+		URI string `json:"uri"`
+		//nolint:tagliatelle // mimeType is the MCP wire member, camelCase by the protocol
+		MIMEType string `json:"mimeType"`
+		Text     string `json:"text"`
+	} `json:"contents"`
+}
+
+// With no provider the catalogue is empty rather than an error: claude.ai
+// calls resources/list right after initialize, and a -32601 there reads as a
+// broken server rather than an empty, valid catalog.
+func TestResourcesListIsEmptyRatherThanAnErrorWithNoProvider(t *testing.T) {
+	resp := rpc(t, dispatcherWith(nil), "resources/list", "")
+	if resp.Error != nil {
+		t.Fatalf("resources/list → error %d %q", resp.Error.Code, resp.Error.Message)
+	}
+	result := decodeResult[resourceListResult](t, resp)
+	if len(result.Resources) != 0 {
+		t.Errorf("a server with no provider advertised %d resources", len(result.Resources))
+	}
+}
+
+// The document comes back as the protocol's contents block, with the URI it
+// was asked for.
+func TestResourcesReadAnswersTheDocument(t *testing.T) {
+	d := dispatcherWith(stubResources{contents: map[string]mcp.ResourceContents{
+		"margince://schema/query": {URI: "margince://schema/query", MIMEType: "application/json", Text: `{"version":"v1"}`},
+	}})
+
+	result := decodeResult[resourceReadResult](t, rpc(t, d, "resources/read", `{"uri":"margince://schema/query"}`))
+	if len(result.Contents) != 1 {
+		t.Fatalf("resources/read returned %d content blocks", len(result.Contents))
+	}
+	if result.Contents[0].URI != "margince://schema/query" || result.Contents[0].Text != `{"version":"v1"}` {
+		t.Errorf("content block came back as %+v", result.Contents[0])
+	}
+}
+
+// A URI the server does not serve and one the CALLER cannot see answer
+// identically, which is the existence-hiding the record surface applies.
+func TestAnUnservedURIIsResourceNotFound(t *testing.T) {
+	for name, d := range map[string]*Dispatcher{
+		"no provider wired": dispatcherWith(nil),
+		"provider has no such document": dispatcherWith(stubResources{
+			contents: map[string]mcp.ResourceContents{"margince://schema/query": {}},
+		}),
+	} {
+		t.Run(name, func(t *testing.T) {
+			resp := rpc(t, d, "resources/read", `{"uri":"margince://schema/nothing"}`)
+			if resp.Error == nil || resp.Error.Code != resourceNotFound {
+				t.Fatalf("read of an unserved URI answered %+v; want code %d", resp.Error, resourceNotFound)
+			}
+			if resp.Result != nil {
+				t.Error("a failed read carried a result as well as an error")
+			}
+		})
+	}
+}
+
+// A provider fault reaches the untrusted client scrubbed: it learns the read
+// did not happen and nothing about why.
+func TestAProviderFaultIsScrubbedBeforeItReachesTheClient(t *testing.T) {
+	d := dispatcherWith(stubResources{err: errors.New("pgx: dial tcp 10.0.0.5:5432: connection refused")})
+	resp := rpc(t, d, "resources/read", `{"uri":"margince://schema/query"}`)
+	if resp.Error == nil || resp.Error.Code != -32603 {
+		t.Fatalf("provider fault answered %+v; want an internal error", resp.Error)
+	}
+	for _, leak := range []string{"pgx", "10.0.0.5", "connection refused"} {
+		if strings.Contains(resp.Error.Message, leak) {
+			t.Errorf("the scrubbed error leaks %q: %s", leak, resp.Error.Message)
+		}
+	}
+}
+
+// Malformed params are a protocol error, not a not-found: the client sent a
+// request this server could not read, which is a different fix.
+func TestMalformedResourceParamsAreAProtocolError(t *testing.T) {
+	resp := rpc(t, dispatcherWith(stubResources{}), "resources/read", `{"uri":`)
+	if resp.Error == nil || resp.Error.Code != -32602 {
+		t.Fatalf("malformed params answered %+v; want -32602", resp.Error)
+	}
+}
+
+// The capability is advertised only when something is behind it: claiming
+// resources with no provider sends a client to a read that can only fail.
+func TestTheResourcesCapabilityIsAdvertisedOnlyWhenItIsReal(t *testing.T) {
+	for name, tc := range map[string]struct {
+		provider mcp.ResourceProvider
+		want     bool
+	}{
+		"with a provider": {provider: stubResources{}, want: true},
+		"with none":       {provider: nil, want: false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			result := decodeResult[initializeResult](t,
+				rpc(t, dispatcherWith(tc.provider), methodInitialize, `{"protocolVersion":"2025-11-25"}`))
+			_, advertised := result.Capabilities["resources"]
+			if advertised != tc.want {
+				t.Errorf("resources capability advertised = %v, want %v", advertised, tc.want)
+			}
+			if _, ok := result.Capabilities["tools"]; !ok {
+				t.Error("the tools capability stopped being advertised")
+			}
+		})
+	}
+}
+
+// decodeResult round-trips a dispatcher result through JSON, which is the
+// only thing a client ever sees of it.
+// initializeResult reads only the capability map, which is all these tests
+// judge.
+type initializeResult struct {
+	Capabilities map[string]json.RawMessage `json:"capabilities"`
+}
+
+func decodeResult[T any](t *testing.T, resp rpcResponse) T {
+	t.Helper()
+	var into T
+	if resp.Error != nil {
+		t.Fatalf("call failed: %d %q", resp.Error.Code, resp.Error.Message)
+	}
+	raw, err := json.Marshal(resp.Result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(raw, &into); err != nil {
+		t.Fatal(err)
+	}
+	return into
+}
+
+// A resource is a read, and an agent whose passport does not carry the read
+// scope must not learn what the workspace holds — not even the NAMES of its
+// custom columns. The catalogue hides it and the read answers not-found, the
+// same pair an unknown URI gets, so scope cannot be probed either.
+func TestAPassportWithoutTheScopeNeitherSeesNorReadsTheDocument(t *testing.T) {
+	d := dispatcherWith(readScopedProvider())
+
+	listed := decodeResult[resourceListResult](t,
+		rpcAs(agentHolding(principal.ScopeDraft), t, d, "resources/list", ""))
+	if len(listed.Resources) != 0 {
+		t.Errorf("a draft-only passport is advertised %d read-scoped resources", len(listed.Resources))
+	}
+
+	resp := rpcAs(agentHolding(principal.ScopeDraft), t, d, "resources/read",
+		`{"uri":"margince://schema/query"}`)
+	if resp.Error == nil || resp.Error.Code != resourceNotFound {
+		t.Fatalf("out-of-scope read answered %+v; want the same not-found an unknown URI gets", resp.Error)
+	}
+	if resp.Result != nil {
+		t.Error("an out-of-scope read carried a result")
+	}
+}
+
+// The holder of the scope gets the document, so the filter above is a filter
+// and not an outage.
+func TestAPassportHoldingTheScopeSeesAndReadsTheDocument(t *testing.T) {
+	d := dispatcherWith(readScopedProvider())
+
+	listed := decodeResult[resourceListResult](t,
+		rpcAs(agentHolding(principal.ScopeRead), t, d, "resources/list", ""))
+	if len(listed.Resources) != 1 {
+		t.Fatalf("a read passport is advertised %d resources; want 1", len(listed.Resources))
+	}
+	read := decodeResult[resourceReadResult](t,
+		rpcAs(agentHolding(principal.ScopeRead), t, d, "resources/read", `{"uri":"margince://schema/query"}`))
+	if len(read.Contents) != 1 {
+		t.Fatalf("a read passport got %d content blocks", len(read.Contents))
+	}
+}
+
+// A human does not ride the scope model at all — their authority is their
+// RBAC, which the PROVIDER applies when it composes the document. Filtering
+// them by a passport scope they never carry would hide the whole catalogue.
+func TestAHumanIsNotFilteredByAPassportScope(t *testing.T) {
+	human := principal.WithActor(context.Background(), principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:test",
+	})
+	listed := decodeResult[resourceListResult](t,
+		rpcAs(human, t, dispatcherWith(readScopedProvider()), "resources/list", ""))
+	if len(listed.Resources) != 1 {
+		t.Errorf("a human is advertised %d resources; want the whole catalogue", len(listed.Resources))
+	}
+}
+
+// A caller that never authenticated sees nothing, which is the honest answer
+// for a principal-less context.
+func TestAnUnauthenticatedCallerSeesNoResources(t *testing.T) {
+	listed := decodeResult[resourceListResult](t,
+		rpcAs(context.Background(), t, dispatcherWith(readScopedProvider()), "resources/list", ""))
+	if len(listed.Resources) != 0 {
+		t.Errorf("a caller with no principal is advertised %d resources", len(listed.Resources))
+	}
+}
+
+func readScopedProvider() stubResources {
+	return stubResources{
+		published: []mcp.Resource{{
+			URI: "margince://schema/query", Name: "query_vocabulary", Title: "Workspace query vocabulary",
+			Description: "what you may ask", MIMEType: "application/json",
+			RequiredScope: principal.ScopeRead,
+		}},
+		contents: map[string]mcp.ResourceContents{
+			"margince://schema/query": {URI: "margince://schema/query", MIMEType: "application/json", Text: `{"version":"v1"}`},
+		},
+	}
+}

--- a/backend/internal/modules/search/queryfields.go
+++ b/backend/internal/modules/search/queryfields.go
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package search
+
+// The CORE half of the query vocabulary, derived from the generated contract
+// types rather than maintained as a list (C-7, SEARCH-AC-15).
+//
+// The contract is this repo's source of truth (P3), and the generated structs
+// ARE the contract — so a vocabulary read off them cannot drift from what the
+// API actually returns. A field added upstream is askable the moment the
+// contract regenerates; a field removed leaves with it. There is no second
+// place to update and therefore no second place to forget.
+//
+// Everything about a field is derived: its wire name from the json tag, its
+// kind from its Go type, its operators from its kind. The only hand-written
+// thing here is the BINDING from a searchable entity to its contract type —
+// Go reflection cannot enumerate a package's types — and the fitness function
+// in queryvocab_test.go fails the moment a searchable entity has no binding.
+
+import (
+	"reflect"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+)
+
+// contractRecords binds each searchable entity to the contract type that
+// declares its fields. It is a type binding, not a field list: nothing about
+// WHICH fields are askable is decided here.
+var contractRecords = map[string]reflect.Type{
+	entityPerson:       reflect.TypeOf(crmcontracts.Person{}),
+	entityOrganization: reflect.TypeOf(crmcontracts.Organization{}),
+	entityDeal:         reflect.TypeOf(crmcontracts.Deal{}),
+	entityLead:         reflect.TypeOf(crmcontracts.Lead{}),
+	entityProject:      reflect.TypeOf(crmcontracts.Project{}),
+	entityActivity:     reflect.TypeOf(crmcontracts.Activity{}),
+}
+
+// geoStructs names the contract types that carry a place rather than a value.
+// The parent member of one of these contributes a `geo` field (the operand
+// `within_radius` takes) on top of the ordinary exact predicates its leaves
+// contribute — so `address.city` matches exactly while `address` is the thing
+// a radius would be measured from.
+var geoStructs = map[reflect.Type]bool{
+	reflect.TypeOf(crmcontracts.Address{}): true,
+}
+
+// Scalar contract types that are values rather than objects, recognised by
+// identity because their Go kinds (struct, array) would otherwise send the
+// walk recursing into their internals.
+var (
+	timeType = reflect.TypeOf(time.Time{})
+	dateType = reflect.TypeOf(openapi_types.Date{})
+	uuidType = reflect.TypeOf(openapi_types.UUID{})
+)
+
+// walkedContracts memoizes the reflection walk: a Go type cannot change at
+// runtime, so the walk over one has exactly one answer for the life of the
+// process. The CATALOG half of the vocabulary is deliberately NOT cached
+// (SEARCH-AC-15 turns on it not being) — the two halves differ because their
+// sources do.
+var walkedContracts = sync.OnceValue(func() map[reflect.Type][]Field {
+	walked := make(map[reflect.Type][]Field, len(contractRecords))
+	for _, record := range contractRecords {
+		walked[record] = walkContractFields(record)
+	}
+	return walked
+})
+
+// contractFields answers the fields a predicate may name on one contract
+// record type.
+//
+// It CLONES the memoized walk. A caller appends its workspace's custom
+// columns to this result and sorts it, and both would otherwise reach through
+// the shared backing array into every later caller's vocabulary — one
+// workspace's private column becoming another's. The clone is the whole
+// defence, and it belongs here rather than at each call site, where the next
+// caller would have to know to write it.
+func contractFields(t reflect.Type) []Field {
+	return slices.Clone(walkedContracts()[t])
+}
+
+// walkContractFields is the walk itself. It descends exactly ONE level into a
+// nested object, which is what gives `address.city` while keeping the
+// vocabulary a flat, finite set. A deeper structure is a shape v1 has no path
+// syntax for, so it contributes nothing rather than contributing something
+// the validator could not spell.
+func walkContractFields(t reflect.Type) []Field {
+	var fields []Field
+	for i := range t.NumField() {
+		member := t.Field(i)
+		name, ok := wireName(member)
+		if !ok {
+			continue
+		}
+		inner := deref(member.Type)
+		if kind, isScalar := scalarKind(inner); isScalar {
+			fields = append(fields, newField(name, kind))
+			continue
+		}
+		if inner.Kind() != reflect.Struct {
+			// Slices, maps and interfaces are collections and free-form
+			// blobs (`emails`, `raw`, `social`). v1 predicates are `field op
+			// value` over a single value; there is no operator here that
+			// could mean anything against a list.
+			continue
+		}
+		if geoStructs[inner] {
+			fields = append(fields, newField(name, KindGeo))
+		}
+		fields = append(fields, nestedFields(name, inner)...)
+	}
+	return fields
+}
+
+// nestedFields contributes the scalar leaves of a nested object under a
+// dotted path. It does not recurse further: one level is the whole of v1's
+// path syntax.
+func nestedFields(prefix string, t reflect.Type) []Field {
+	var fields []Field
+	for i := range t.NumField() {
+		member := t.Field(i)
+		name, ok := wireName(member)
+		if !ok {
+			continue
+		}
+		if kind, isScalar := scalarKind(deref(member.Type)); isScalar {
+			fields = append(fields, newField(prefix+"."+name, kind))
+		}
+	}
+	return fields
+}
+
+// wireName answers the json member name of a struct field, and false for
+// anything the wire never carries — an unexported member, or the
+// `json:"-"` AdditionalProperties bag every generated record ends with.
+func wireName(member reflect.StructField) (string, bool) {
+	if !member.IsExported() {
+		return "", false
+	}
+	tag, ok := member.Tag.Lookup("json")
+	if !ok {
+		return "", false
+	}
+	name, _, _ := strings.Cut(tag, ",")
+	if name == "" || name == "-" {
+		return "", false
+	}
+	return name, true
+}
+
+// deref unwraps the pointer the generator puts on every optional member, so
+// the walk reasons about the value type in both cases.
+func deref(t reflect.Type) reflect.Type {
+	if t.Kind() == reflect.Pointer {
+		return t.Elem()
+	}
+	return t
+}
+
+// scalarKind maps a Go type onto the closed set of value shapes a predicate
+// can carry, and reports false for anything that is not a single value.
+// Identity is checked before kind: a UUID is an array and a timestamp a
+// struct, and both would otherwise be walked as containers.
+func scalarKind(t reflect.Type) (FieldKind, bool) {
+	switch t {
+	case timeType:
+		return KindTimestamp, true
+	case dateType:
+		return KindDate, true
+	case uuidType:
+		return KindID, true
+	}
+	switch t.Kind() {
+	case reflect.String:
+		return KindText, true
+	case reflect.Bool:
+		return KindBoolean, true
+	case reflect.Int, reflect.Int32, reflect.Int64, reflect.Float32, reflect.Float64:
+		return KindNumber, true
+	default:
+		return "", false
+	}
+}
+
+// relationSuffix is the contract's own spelling of a reference: a scalar id
+// member named `<record type>_id`. Deriving relations from it means the
+// traversal set is read off the same contract as the fields, so a new
+// reference is traversable the moment it exists.
+const relationSuffix = "_id"
+
+// contractRelations answers the depth-1 hops declared BY this record type:
+// every scalar id member whose stripped name is itself a searchable record
+// type. `deal.organization_id` gives deal the relation `organization`;
+// `deal.owner_id` gives nothing, because a user is not a record type this
+// module searches.
+func contractRelations(entity string, fields []Field) []Relation {
+	var relations []Relation
+	for _, f := range fields {
+		if f.Kind != KindID || !strings.HasSuffix(f.Name, relationSuffix) {
+			continue
+		}
+		target := strings.TrimSuffix(f.Name, relationSuffix)
+		if target == entity || contractRecords[target] == nil {
+			continue
+		}
+		relations = append(relations, Relation{Name: target, Target: target, Via: f.Name})
+	}
+	return relations
+}
+
+// inverseRelations answers the hops that land ON this record type: for every
+// OTHER searchable record declaring a reference to it, the reverse edge,
+// named for the referring type. `deal.organization_id` gives organization the
+// relation `deals`.
+//
+// The inverse direction is derived rather than declared for the same reason
+// the forward one is — and it is the direction that carries most of the
+// questions worth asking ("organizations with an open deal"), which a
+// forward-only derivation would leave unaskable while looking complete.
+func inverseRelations(entity string) []Relation {
+	var relations []Relation
+	for other, t := range contractRecords {
+		if other == entity {
+			continue
+		}
+		for _, r := range contractRelations(other, contractFields(t)) {
+			if r.Target == entity {
+				relations = append(relations, Relation{Name: other + "s", Target: other, Via: other + "." + r.Via})
+			}
+		}
+	}
+	return relations
+}

--- a/backend/internal/modules/search/queryplan.go
+++ b/backend/internal/modules/search/queryplan.go
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package search
+
+// The v1 query-plan grammar (search-and-retrieval SEARCH-PARAM-7 / A140).
+// A plan is what a natural-language layer compiles an utterance INTO, and
+// this file is the whole of what a plan may say: a target, exact predicates,
+// one similarity clause, one traversal hop, a limit.
+//
+// The grammar is the first half of the security boundary and the reason the
+// shape below has no free-text member anywhere a name is expected. There is
+// nowhere in it to put a table, a fragment of SQL or an expression: those can
+// only arrive as the VALUE of a closed member, where the vocabulary refuses
+// them. The second half is queryvalidate.go, which decides membership; this
+// file only decides shape.
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// PlanVersion is the only grammar this validator accepts. A plan naming any
+// other version is refused rather than interpreted: a v2 plan carries members
+// (grouping, ranking, multi-hop, coverage) whose absence a v1 executor would
+// silently ignore, and an ignored member is an answer to a different question.
+const PlanVersion = "v1"
+
+// Plan is one compiled question.
+type Plan struct {
+	Version string `json:"version"`
+	// Target names the record type the plan asks about, from the closed set
+	// this module already searches.
+	Target string      `json:"target"`
+	Where  []Predicate `json:"where,omitempty"`
+	// SimilarTo is the single similarity clause v1 admits (SEARCH-PARAM-7:
+	// "one similarity clause over the existing hybrid arm"). It is a member
+	// rather than a list precisely so a second one cannot be expressed.
+	SimilarTo string     `json:"similar_to,omitempty"`
+	Traverse  *Traversal `json:"traverse,omitempty"`
+	// Limit is the page size, bounded by the contract's CAP-PAGE window.
+	// Absent means the contract default; out of range is refused rather than
+	// clamped, because a clamp answers a narrower question than the one asked
+	// without saying so.
+	Limit *int `json:"limit,omitempty"`
+}
+
+// Predicate is one exact `field op value` clause. Value carries the operand
+// of a single-operand operator and Values the operand list of `in`; which
+// member an operator reads is part of the operator's own definition, so
+// filling the wrong one is a refusal, not a coercion.
+type Predicate struct {
+	Field  string            `json:"field"`
+	Op     string            `json:"op"`
+	Value  json.RawMessage   `json:"value,omitempty"`
+	Values []json.RawMessage `json:"values,omitempty"`
+}
+
+// Traversal is one relationship hop.
+//
+// Traverse nests DELIBERATELY. v1 admits depth 1, and the cap belongs to the
+// grammar rather than to a runtime budget — but a grammar that simply had no
+// member for a second hop would leave a strict decoder rejecting a depth-2
+// plan as a malformed document, which tells the caller nothing about the
+// limit it hit. Carrying the member and refusing it by name is what makes the
+// cap legible: `traversal_depth_exceeded`, naming the hop that was too many.
+type Traversal struct {
+	Relation string      `json:"relation"`
+	Where    []Predicate `json:"where,omitempty"`
+	Traverse *Traversal  `json:"traverse,omitempty"`
+}
+
+// DecodePlan parses a plan document STRICTLY: a member the grammar has no
+// place for is refused, never dropped. A dropped member is the permissive
+// default this whole feature exists to prevent — a plan carrying
+// `"raw_sql": "…"` that decodes cleanly into a Plan without it has been
+// silently narrowed into a different question whose answer looks like every
+// other answer.
+func DecodePlan(raw []byte) (Plan, error) {
+	// Duplicate members are checked BEFORE the struct decode, because the
+	// struct decode cannot see them: encoding/json silently takes the LAST
+	// value, so a plan carrying two `where` lists validates on the second and
+	// the first question is dropped without a word.
+	if refusal := refuseDuplicateMembers(raw); refusal != nil {
+		return Plan{}, refusal
+	}
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.DisallowUnknownFields()
+	var p Plan
+	if err := dec.Decode(&p); err != nil {
+		return Plan{}, planDecodeRefusal(err)
+	}
+	// A second JSON value after the plan is a document the caller did not
+	// mean to send; accepting the first and ignoring the rest is the same
+	// silent narrowing DisallowUnknownFields exists to stop.
+	if dec.More() {
+		return Plan{}, refuse("", CodeMalformedPlan,
+			"the request carries more than one JSON document; send exactly one query plan")
+	}
+	return p, nil
+}
+
+// jsonFrame is one open container while the duplicate-member scan walks a
+// document. Only objects carry a seen-set; an array frame exists so the scan
+// knows its elements are values rather than member names.
+type jsonFrame struct {
+	object    bool
+	seen      map[string]bool
+	expectKey bool
+}
+
+// refuseDuplicateMembers refuses a document that names the same member twice
+// inside one object, at any depth.
+//
+// It exists because DisallowUnknownFields does not cover this: a REPEATED
+// member is not an unknown one, and encoding/json resolves it last-wins in
+// silence. `{"target":"deal","where":[…],"where":[]}` decodes without error
+// into an unfiltered scan — the caller's actual question dropped, and the
+// answer indistinguishable from any other answer. That is the exact failure
+// SEARCH-AC-14 forbids, so the document is refused rather than resolved.
+//
+// A document that is not well-formed JSON answers nil here; the struct decode
+// that follows is what reports it, so there is one malformed-plan refusal
+// rather than two spellings of it.
+func refuseDuplicateMembers(raw []byte) *PlanRefusal {
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	var stack []*jsonFrame
+	top := func() *jsonFrame {
+		if len(stack) == 0 {
+			return nil
+		}
+		return stack[len(stack)-1]
+	}
+	for {
+		tok, err := dec.Token()
+		if err != nil {
+			// Neither outcome is this pass's to report: io.EOF is the clean
+			// end of a fully scanned document, and a syntax error is reported
+			// once by the struct decode that follows. Answering a refusal here
+			// would give a malformed plan two different spellings.
+			//nolint:nilerr // a scan fault is deliberately not a refusal; see above
+			return nil
+		}
+		frame := top()
+		if frame != nil && frame.object && frame.expectKey {
+			member, isKey := tok.(string)
+			if !isKey {
+				// The only non-string token where a member name may stand is
+				// the '}' closing this object.
+				stack = stack[:len(stack)-1]
+				valueConsumed(top())
+				continue
+			}
+			if frame.seen[member] {
+				return refuse(member, CodeDuplicateMember,
+					"the plan names "+quote(member)+" more than once; a member may appear once, "+
+						"and this server will not choose which of them you meant")
+			}
+			frame.seen[member] = true
+			frame.expectKey = false
+			continue
+		}
+		if delim, isDelim := tok.(json.Delim); isDelim {
+			switch delim {
+			case '{':
+				stack = append(stack, &jsonFrame{object: true, seen: map[string]bool{}, expectKey: true})
+			case '[':
+				stack = append(stack, &jsonFrame{})
+			case '}', ']':
+				stack = stack[:len(stack)-1]
+				valueConsumed(top())
+			}
+			continue
+		}
+		valueConsumed(frame)
+	}
+}
+
+// valueConsumed tells an enclosing object that its member's value is complete,
+// so the next token there is another member name.
+func valueConsumed(frame *jsonFrame) {
+	if frame != nil && frame.object {
+		frame.expectKey = true
+	}
+}

--- a/backend/internal/modules/search/queryplan.go
+++ b/backend/internal/modules/search/queryplan.go
@@ -18,6 +18,12 @@ package search
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
+	"io"
+	"reflect"
+	"slices"
+	"strings"
+	"sync"
 )
 
 // PlanVersion is the only grammar this validator accepts. A plan naming any
@@ -42,7 +48,13 @@ type Plan struct {
 	// Absent means the contract default; out of range is refused rather than
 	// clamped, because a clamp answers a narrower question than the one asked
 	// without saying so.
-	Limit *int `json:"limit,omitempty"`
+	//
+	// Raw rather than *int because a POINTER cannot tell an ABSENT member from
+	// an explicit null — encoding/json produces nil for both — and the two
+	// mean different things here: absent asks for the default, while null is
+	// a value the grammar does not have. Silently reading null as absent
+	// would answer a page size the caller never asked for.
+	Limit json.RawMessage `json:"limit,omitempty"`
 }
 
 // Predicate is one exact `field op value` clause. Value carries the operand
@@ -50,10 +62,14 @@ type Plan struct {
 // member an operator reads is part of the operator's own definition, so
 // filling the wrong one is a refusal, not a coercion.
 type Predicate struct {
-	Field  string            `json:"field"`
-	Op     string            `json:"op"`
-	Value  json.RawMessage   `json:"value,omitempty"`
-	Values []json.RawMessage `json:"values,omitempty"`
+	Field string `json:"field"`
+	Op    string `json:"op"`
+	// Both operands stay RAW for the same reason Limit does: a decoded slice
+	// cannot tell an absent `values` from an explicit null, so an operator
+	// filling the member it does not read with null would slip past the
+	// unused-operand refusal and be silently ignored.
+	Value  json.RawMessage `json:"value,omitempty"`
+	Values json.RawMessage `json:"values,omitempty"`
 }
 
 // Traversal is one relationship hop.
@@ -90,24 +106,50 @@ func DecodePlan(raw []byte) (Plan, error) {
 	if err := dec.Decode(&p); err != nil {
 		return Plan{}, planDecodeRefusal(err)
 	}
-	// A second JSON value after the plan is a document the caller did not
-	// mean to send; accepting the first and ignoring the rest is the same
-	// silent narrowing DisallowUnknownFields exists to stop.
-	if dec.More() {
+	// Anything after the plan is bytes the caller did not mean to send, and
+	// accepting the first value while ignoring the rest is the same silent
+	// narrowing DisallowUnknownFields exists to stop.
+	//
+	// The test is a second decode reaching io.EOF, not dec.More(). More()
+	// reports whether another VALUE follows, so a stray delimiter — a plan
+	// with a trailing `]` — leaves it false and the garbage accepted.
+	var trailing json.RawMessage
+	if err := dec.Decode(&trailing); !errors.Is(err, io.EOF) {
 		return Plan{}, refuse("", CodeMalformedPlan,
-			"the request carries more than one JSON document; send exactly one query plan")
+			"the request carries more than one query plan document, or bytes after the end of this one; send exactly one")
 	}
 	return p, nil
 }
 
-// jsonFrame is one open container while the duplicate-member scan walks a
-// document. Only objects carry a seen-set; an array frame exists so the scan
-// knows its elements are values rather than member names.
+// jsonFrame is one open container while the member scan walks a document.
+// Only objects carry a seen-set; an array frame exists so the scan knows its
+// elements are values rather than member names.
 type jsonFrame struct {
 	object    bool
 	seen      map[string]bool
 	expectKey bool
+	// member is the name whose value is currently being read, which is what
+	// tells a child container whether it is still grammar.
+	member string
+	// grammar marks a container the v1 GRAMMAR defines. An operand payload
+	// (the object a `within_radius` operand carries) is a caller-authored
+	// value, not grammar, so the canonical-spelling rule must not reach it —
+	// `{"center": …}` is a legitimate operand, not an unknown plan member.
+	// Repeated members are still refused inside one, because last-wins is
+	// just as silent there.
+	grammar bool
 }
+
+// The two operand members, named once so the grammar, the validator and the
+// payload boundary below cannot disagree about their spelling.
+const (
+	memberValue  = "value"
+	memberValues = "values"
+)
+
+// operandMembers are the grammar members whose VALUES are caller payloads.
+// Anything below one of them stops being grammar.
+var operandMembers = []string{memberValue, memberValues}
 
 // refuseDuplicateMembers refuses a document that names the same member twice
 // inside one object, at any depth.
@@ -151,21 +193,27 @@ func refuseDuplicateMembers(raw []byte) *PlanRefusal {
 				valueConsumed(top())
 				continue
 			}
+			if frame.grammar && !slices.Contains(canonicalMembers(), member) {
+				return unknownPlanMember(member)
+			}
 			if frame.seen[member] {
 				return refuse(member, CodeDuplicateMember,
 					"the plan names "+quote(member)+" more than once; a member may appear once, "+
 						"and this server will not choose which of them you meant")
 			}
 			frame.seen[member] = true
+			frame.member = member
 			frame.expectKey = false
 			continue
 		}
 		if delim, isDelim := tok.(json.Delim); isDelim {
 			switch delim {
 			case '{':
-				stack = append(stack, &jsonFrame{object: true, seen: map[string]bool{}, expectKey: true})
+				stack = append(stack, &jsonFrame{
+					object: true, seen: map[string]bool{}, expectKey: true, grammar: childIsGrammar(frame),
+				})
 			case '[':
-				stack = append(stack, &jsonFrame{})
+				stack = append(stack, &jsonFrame{grammar: childIsGrammar(frame)})
 			case '}', ']':
 				stack = stack[:len(stack)-1]
 				valueConsumed(top())
@@ -175,6 +223,44 @@ func refuseDuplicateMembers(raw []byte) *PlanRefusal {
 		valueConsumed(frame)
 	}
 }
+
+// childIsGrammar answers whether a container opening inside frame is still
+// part of the grammar. The root is; a container under `value` or `values` is
+// the caller's own payload; anything else inherits its parent.
+func childIsGrammar(frame *jsonFrame) bool {
+	if frame == nil {
+		return true
+	}
+	if frame.object && slices.Contains(operandMembers, frame.member) {
+		return false
+	}
+	return frame.grammar
+}
+
+// canonicalMembers is every member name the v1 grammar spells, derived from
+// the grammar's own struct tags rather than listed beside them.
+//
+// The scan needs it because encoding/json matches member names
+// CASE-INSENSITIVELY, and DisallowUnknownFields matches the same way: a plan
+// carrying `"TARGET": "person"` alongside `"target": "deal"` is neither an
+// unknown member nor — to a scan comparing exact strings — a duplicate, and
+// the decoder resolves it last-wins. The caller's target is silently replaced.
+// Requiring the canonical spelling is what closes that, and deriving the set
+// means a member added to the grammar is admitted without a second edit.
+var canonicalMembers = sync.OnceValue(func() []string {
+	var names []string
+	for _, t := range []reflect.Type{
+		reflect.TypeOf(Plan{}), reflect.TypeOf(Predicate{}), reflect.TypeOf(Traversal{}),
+	} {
+		for i := range t.NumField() {
+			name, _, _ := strings.Cut(t.Field(i).Tag.Get("json"), ",")
+			if name != "" && name != "-" && !slices.Contains(names, name) {
+				names = append(names, name)
+			}
+		}
+	}
+	return names
+})
 
 // valueConsumed tells an enclosing object that its member's value is complete,
 // so the next token there is another member name.

--- a/backend/internal/modules/search/queryrefusal.go
+++ b/backend/internal/modules/search/queryrefusal.go
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package search
+
+// The typed clarification a refused plan carries (SEARCH-AC-14): what was not
+// understood, where, and what to do instead. It rides apperrors.FieldFaults,
+// the plural fault form, so a plan with three bad predicates names all three
+// — a caller told about the first of three has to make three round trips to
+// learn what it could have learned in one.
+//
+// Implementing the shared fault interface is also what makes the refusal
+// legible on every transport at once: the httperr choke point renders it as a
+// 422 naming each path, and the MCP tool surface renders the same list
+// in-band, with neither side hand-writing a mapping.
+
+import (
+	"encoding/json"
+	"errors"
+	"regexp"
+	"slices"
+	"strings"
+
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+)
+
+// The refusal classes. One code per way a plan can fail to be a plan; the
+// caller branches on these, so they are contract surface and their spellings
+// are stable.
+const (
+	// CodeMalformedPlan: the document is not a well-formed plan at all.
+	CodeMalformedPlan = "malformed_plan"
+	// CodeDuplicateMember: one object names the same member twice. Refused
+	// because the JSON decoder would otherwise resolve it last-wins in
+	// silence, dropping the caller's first question.
+	CodeDuplicateMember = "duplicate_member"
+	// CodeUnknownPlanVersion: a grammar this validator does not implement.
+	CodeUnknownPlanVersion = "unknown_plan_version"
+	// CodeUnknownPlanMember: a member the v1 grammar has no place for —
+	// where a free expression or an embedded fragment most often arrives.
+	CodeUnknownPlanMember = "unknown_plan_member"
+	// CodeUnknownTarget: not a record type this workspace searches. A plan
+	// naming a TABLE lands here, since the target set is closed.
+	CodeUnknownTarget = "unknown_target"
+	// CodeUnknownField: not a field this caller may name on this target.
+	// A field the caller cannot read is reported with this code and this
+	// wording, identical to an invented one (SEARCH-AC-16).
+	CodeUnknownField = "unknown_field"
+	// CodeUnknownOperator: not an operator the field's type admits.
+	CodeUnknownOperator = "unknown_operator"
+	// CodeUnknownRelation: not a relationship the target declares.
+	CodeUnknownRelation = "unknown_relation"
+	// CodeSQLFragment: the token reads as SQL rather than as a name.
+	CodeSQLFragment = "sql_fragment"
+	// CodeFreeExpression: the token is an expression rather than a name.
+	CodeFreeExpression = "free_expression"
+	// CodeValueTypeMismatch: the operand shape does not match the field type.
+	CodeValueTypeMismatch = "value_type_mismatch"
+	// CodeValueMissing: the operator's operand member is absent or empty.
+	CodeValueMissing = "value_missing"
+	// CodeValueNotApplicable: the operand member this operator does not read
+	// was filled in — refused rather than ignored, since an ignored member is
+	// a question the caller asked and did not get answered.
+	CodeValueNotApplicable = "value_not_applicable"
+	// CodeLimitOutOfRange: outside the contract's CAP-PAGE window.
+	CodeLimitOutOfRange = "limit_out_of_range"
+	// CodeTraversalDepthExceeded: a second hop. Depth is capped in the
+	// grammar, so this is a refusal and never a truncation.
+	CodeTraversalDepthExceeded = "traversal_depth_exceeded"
+)
+
+// PlanRefusal is one or more typed clarifications about a single plan.
+type PlanRefusal struct {
+	Refusals []apperrors.FieldRefusal
+}
+
+// Error summarises the refusal for logs and errors.Is chains. The full,
+// caller-facing detail is in FieldFaults — this string is never the thing a
+// client renders.
+func (r *PlanRefusal) Error() string {
+	parts := make([]string, len(r.Refusals))
+	for i, f := range r.Refusals {
+		parts[i] = f.Field + ": " + f.Code
+	}
+	return "search: query plan refused (" + strings.Join(parts, ", ") + ")"
+}
+
+// FieldFaults renders every clarification, which is what a caller has to see
+// to fix the plan in one edit rather than several.
+func (r *PlanRefusal) FieldFaults() []apperrors.FieldRefusal { return r.Refusals }
+
+// refuse builds a single-clarification refusal. path is the plan-document
+// path of the offending member (`target`, `where[1].op`, `traverse.relation`)
+// so the caller can find it without guessing.
+func refuse(path, code, message string) *PlanRefusal {
+	return &PlanRefusal{Refusals: []apperrors.FieldRefusal{{Field: path, Code: code, Message: message}}}
+}
+
+// identifier is the shape every NAME in a plan has: a lowercase snake_case
+// word, optionally one dotted segment for a nested contract object
+// (`address.city`). It is not an admission test — membership is decided by
+// the resolved vocabulary — it only tells a refused token apart from an
+// expression, so the caller is told which of the two it sent.
+var identifier = regexp.MustCompile(`^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)?$`)
+
+// sqlTokens are the words that make a refused token read as SQL rather than
+// as a misspelled name.
+var sqlTokens = []string{
+	"select", "insert", "update", "delete", "drop", "alter", "truncate",
+	"union", "join", "from", "where", "having", "exec",
+}
+
+// classify explains an ALREADY-REFUSED token. It never decides admission:
+// membership in the resolved vocabulary is settled first and separately, and
+// this runs only on what that check has already rejected.
+//
+// The ordering is the whole point. A classifier consulted FIRST would be a
+// blocklist, and a blocklist admits everything it fails to recognise — the
+// permissive default SEARCH-PARAM-7 exists to prevent. Consulted last, the
+// worst it can do is choose a less apt wording for a refusal that has already
+// happened.
+func classify(token, unknownCode string) string {
+	switch {
+	case token == "":
+		// An omitted name is not an expression and not SQL — it is a plan
+		// that did not say what it was asking about, and calling it a free
+		// expression would send the caller looking for one.
+		return unknownCode
+	case looksLikeSQL(token):
+		return CodeSQLFragment
+	case !identifier.MatchString(token):
+		return CodeFreeExpression
+	default:
+		return unknownCode
+	}
+}
+
+// looksLikeSQL reports whether the token carries statement punctuation or a
+// SQL keyword as a whole word — `name` is a name, `select name` is not.
+func looksLikeSQL(token string) bool {
+	lower := strings.ToLower(token)
+	if strings.ContainsAny(lower, ";") || strings.Contains(lower, "--") || strings.Contains(lower, "/*") {
+		return true
+	}
+	words := strings.FieldsFunc(lower, func(r rune) bool { return r < 'a' || r > 'z' })
+	return slices.ContainsFunc(words, func(w string) bool { return slices.Contains(sqlTokens, w) })
+}
+
+// unknownFieldMember matches the standard library's DisallowUnknownFields
+// message, the one signal that distinguishes "you sent a member the grammar
+// lacks" from "this is not JSON". The member name it quotes is the caller's
+// own text, so passing it back leaks nothing.
+var unknownFieldMember = regexp.MustCompile(`^json: unknown field "([^"]*)"$`)
+
+// planDecodeRefusal turns a decode failure into the same typed clarification
+// every other refusal uses, so a caller has one shape to read rather than a
+// JSON error here and a plan refusal there.
+func planDecodeRefusal(err error) *PlanRefusal {
+	if m := unknownFieldMember.FindStringSubmatch(err.Error()); m != nil {
+		member := m[1]
+		return refuse(member, classify(member, CodeUnknownPlanMember),
+			"the v1 query plan has no member named "+quote(member)+
+				"; read margince://schema/query for the plan grammar")
+	}
+	var typeErr *json.UnmarshalTypeError
+	if errors.As(err, &typeErr) && typeErr.Field != "" {
+		return refuse(typeErr.Field, CodeValueTypeMismatch,
+			"the value of "+quote(typeErr.Field)+" is not the shape the v1 query plan gives it")
+	}
+	return refuse("", CodeMalformedPlan, "the request body is not a well-formed v1 query plan document")
+}
+
+// quote wraps a caller-supplied token for a message. Messages reach an
+// untrusted agent, so the token is quoted rather than concatenated bare —
+// an unquoted empty string reads as a missing word rather than as a value.
+func quote(s string) string { return `"` + s + `"` }

--- a/backend/internal/modules/search/queryrefusal.go
+++ b/backend/internal/modules/search/queryrefusal.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"regexp"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
@@ -157,10 +158,7 @@ var unknownFieldMember = regexp.MustCompile(`^json: unknown field "([^"]*)"$`)
 // JSON error here and a plan refusal there.
 func planDecodeRefusal(err error) *PlanRefusal {
 	if m := unknownFieldMember.FindStringSubmatch(err.Error()); m != nil {
-		member := m[1]
-		return refuse(member, classify(member, CodeUnknownPlanMember),
-			"the v1 query plan has no member named "+quote(member)+
-				"; read margince://schema/query for the plan grammar")
+		return unknownPlanMember(m[1])
 	}
 	var typeErr *json.UnmarshalTypeError
 	if errors.As(err, &typeErr) && typeErr.Field != "" {
@@ -170,7 +168,26 @@ func planDecodeRefusal(err error) *PlanRefusal {
 	return refuse("", CodeMalformedPlan, "the request body is not a well-formed v1 query plan document")
 }
 
-// quote wraps a caller-supplied token for a message. Messages reach an
-// untrusted agent, so the token is quoted rather than concatenated bare —
-// an unquoted empty string reads as a missing word rather than as a value.
-func quote(s string) string { return `"` + s + `"` }
+// unknownPlanMember is the ONE refusal a member the grammar lacks gets,
+// whether the raw scan caught it (a case-variant spelling, which the decoder
+// would resolve last-wins) or the strict decode did (a name the grammar has
+// never had). Two spellings of the same verdict would have a caller fixing
+// two different things.
+// It is deliberately NOT classified. classify explains a refused VOCABULARY
+// token, where a caller who pasted SQL needs to be told so; a member name is
+// a grammar question, and telling someone who wrote `"TARGET"` that they sent
+// a free expression sends them looking for one. The member they must fix is
+// named instead.
+func unknownPlanMember(member string) *PlanRefusal {
+	return refuse(member, CodeUnknownPlanMember,
+		"the v1 query plan has no member named "+quote(member)+
+			"; read margince://schema/query for the plan grammar")
+}
+
+// quote renders a caller-supplied token for a message.
+//
+// It ESCAPES rather than merely wrapping in quotes. The token is the caller's
+// own text, and a token carrying a quote or a newline concatenated bare would
+// end the quoted run early or split the message across lines — a refusal an
+// agent parses as two, or as one it cannot tell the boundaries of.
+func quote(s string) string { return strconv.Quote(s) }

--- a/backend/internal/modules/search/queryschema.go
+++ b/backend/internal/modules/search/queryschema.go
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package search
+
+// `margince://schema/query` — the vocabulary, published rather than implied
+// (SEARCH-PARAM-7). A client that has to guess what it may ask will guess
+// wrong, and every wrong guess is a refusal that reads like a bug.
+//
+// The document is composed PER CALLER from the same resolver the validator
+// uses, so what it advertises and what the validator admits are one
+// computation rather than two that can drift. That also means it is never a
+// discovery channel: it lists exactly the record types this principal can
+// already read.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/mcp"
+)
+
+// QuerySchemaURI is the resource's stable identity.
+const QuerySchemaURI = "margince://schema/query"
+
+// QuerySchemaResource publishes the query vocabulary.
+type QuerySchemaResource struct {
+	vocab *VocabularyResolver
+}
+
+// NewQuerySchemaResource builds the provider over a vocabulary resolver — the
+// same one the validator holds, so the published document and the admitted
+// plan cannot disagree.
+func NewQuerySchemaResource(vocab *VocabularyResolver) *QuerySchemaResource {
+	return &QuerySchemaResource{vocab: vocab}
+}
+
+// Resources advertises the one document this module publishes.
+func (r *QuerySchemaResource) Resources(context.Context) []mcp.Resource {
+	return []mcp.Resource{{
+		URI:   QuerySchemaURI,
+		Name:  "query_vocabulary",
+		Title: "Workspace query vocabulary",
+		// A vocabulary is a read of what the workspace holds — it names the
+		// record types and the workspace's own custom columns — so it is
+		// governed by the same scope a record read is.
+		RequiredScope: principal.ScopeRead,
+		MIMEType:      "application/json",
+		Description: "Everything a query plan may say, for you: the record types you can ask " +
+			"about, the fields you can name on each, the operators each field admits, and the " +
+			"single relationship hop a plan may take. A plan naming anything outside it is " +
+			"refused rather than approximated, so read this before composing one.",
+	}}
+}
+
+// ReadResource composes the document. An unknown URI answers ErrNotFound,
+// matching how every other read on this surface treats something the caller
+// cannot see.
+func (r *QuerySchemaResource) ReadResource(ctx context.Context, uri string) (mcp.ResourceContents, error) {
+	if uri != QuerySchemaURI {
+		return mcp.ResourceContents{}, fmt.Errorf("search: resource %q: %w", uri, apperrors.ErrNotFound)
+	}
+	vocab, err := r.vocab.Resolve(ctx)
+	if err != nil {
+		return mcp.ResourceContents{}, err
+	}
+	body, err := json.Marshal(querySchemaDocument(vocab))
+	if err != nil {
+		return mcp.ResourceContents{}, fmt.Errorf("search: rendering the query vocabulary: %w", err)
+	}
+	return mcp.ResourceContents{URI: uri, MIMEType: "application/json", Text: string(body)}, nil
+}
+
+// querySchemaDoc is the published shape. It is a hand-written wire type
+// rather than the internal Vocabulary because the two answer different
+// questions: the internal one carries what the validator needs to check a
+// plan, this one carries what a caller needs to write one.
+type querySchemaDoc struct {
+	Version string `json:"version"`
+	// Grammar states the three things v1 admits, in the caller's terms, so
+	// the shape of a plan does not have to be inferred from the field lists.
+	Grammar querySchemaGrammar  `json:"grammar"`
+	Targets []querySchemaTarget `json:"targets"`
+	// Unavailable declares the operators this deployment publishes but
+	// cannot answer, with the code they answer instead. Declaring them is
+	// the honest option: omitting `within_radius` sends a caller to a text
+	// match on a city name, which quietly returns the wrong answer.
+	Unavailable []querySchemaUnavailable `json:"unavailable"`
+}
+
+type querySchemaGrammar struct {
+	Predicates     string `json:"predicates"`
+	SemanticTarget string `json:"semantic_target"`
+	Traversal      string `json:"traversal"`
+	Limit          string `json:"limit"`
+	Refusal        string `json:"refusal"`
+}
+
+type querySchemaTarget struct {
+	Target    string                `json:"target"`
+	Fields    []querySchemaField    `json:"fields"`
+	Relations []querySchemaRelation `json:"relations"`
+}
+
+type querySchemaField struct {
+	Name string   `json:"name"`
+	Kind string   `json:"kind"`
+	Ops  []string `json:"ops"`
+}
+
+// querySchemaRelation is Relation's wire form, and a direct conversion of it
+// — a hop has nothing to hide from a caller. The conversion is deliberate:
+// adding a member to Relation without deciding whether callers should see it
+// stops compiling here.
+type querySchemaRelation struct {
+	Name   string `json:"name"`
+	Target string `json:"target"`
+	Via    string `json:"via"`
+}
+
+type querySchemaUnavailable struct {
+	Op      string `json:"op"`
+	Answers string `json:"answers"`
+	Because string `json:"because"`
+}
+
+// querySchemaDocument renders one caller's resolved vocabulary.
+func querySchemaDocument(vocab Vocabulary) querySchemaDoc {
+	doc := querySchemaDoc{
+		Version: vocab.Version,
+		// Never nil: a caller who may read nothing gets an empty list, the
+		// same wire shape everyone else gets, rather than a JSON null their
+		// client has to special-case.
+		Targets: []querySchemaTarget{},
+		Grammar: querySchemaGrammar{
+			Predicates: `{"field": <name below>, "op": <op the field admits>, "value": <operand>} — ` +
+				`or "values": [...] for "in". Clauses are combined with AND.`,
+			SemanticTarget: `"similar_to": <free text> — one similarity clause, ranked by the hybrid retriever.`,
+			Traversal: `"traverse": {"relation": <relation below>, "where": [...]} — exactly one hop. ` +
+				`A second hop is refused; ask it as its own query.`,
+			Limit: fmt.Sprintf("%q: 1..%d; omit for the default page.", "limit", maxPlanLimit),
+			Refusal: "Anything outside this vocabulary is refused with a typed clarification naming " +
+				"what was not understood. Nothing is coerced, and no plan is narrowed to the part " +
+				"that was recognised.",
+		},
+		Unavailable: []querySchemaUnavailable{{
+			Op:      OpWithinRadius,
+			Answers: CodeDistanceRankingUnavailable,
+			Because: "records carry no normalized coordinates yet; ask for a city or region as an exact predicate instead.",
+		}},
+	}
+	for _, target := range vocab.Targets {
+		doc.Targets = append(doc.Targets, querySchemaTargetOf(target))
+	}
+	return doc
+}
+
+func querySchemaTargetOf(target TargetVocabulary) querySchemaTarget {
+	out := querySchemaTarget{
+		Target:    target.Target,
+		Fields:    make([]querySchemaField, 0, len(target.Fields)),
+		Relations: make([]querySchemaRelation, 0, len(target.Relations)),
+	}
+	for _, f := range target.Fields {
+		out.Fields = append(out.Fields, querySchemaField{Name: f.Name, Kind: string(f.Kind), Ops: f.Ops})
+	}
+	for _, r := range target.Relations {
+		out.Relations = append(out.Relations, querySchemaRelation(r))
+	}
+	return out
+}
+
+var _ mcp.ResourceProvider = (*QuerySchemaResource)(nil)

--- a/backend/internal/modules/search/queryschema_test.go
+++ b/backend/internal/modules/search/queryschema_test.go
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package search
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"slices"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/fieldcatalog"
+)
+
+// readSchema fetches and decodes the published document for one caller.
+func readSchema(ctx context.Context, t *testing.T, resource *QuerySchemaResource) querySchemaDoc {
+	t.Helper()
+	contents, err := resource.ReadResource(ctx, QuerySchemaURI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if contents.MIMEType != "application/json" || contents.URI != QuerySchemaURI {
+		t.Fatalf("resource came back as %+v", contents)
+	}
+	var doc querySchemaDoc
+	if err := json.Unmarshal([]byte(contents.Text), &doc); err != nil {
+		t.Fatalf("published document is not JSON: %v", err)
+	}
+	return doc
+}
+
+// SEARCH-AC-17's other half: the operator is DECLARED in the published
+// vocabulary, with the code it answers. Omitting it would send a caller to a
+// text match on a city name, which quietly returns a different answer.
+func TestThePublishedVocabularyDeclaresWithinRadiusAsUnavailable(t *testing.T) {
+	doc := readSchema(readerFor("organization"), t, NewQuerySchemaResource(NewVocabularyResolver()))
+
+	i := slices.IndexFunc(doc.Unavailable, func(u querySchemaUnavailable) bool { return u.Op == OpWithinRadius })
+	if i < 0 {
+		t.Fatalf("%q is not declared unavailable; a caller cannot tell it apart from an operator that works", OpWithinRadius)
+	}
+	if doc.Unavailable[i].Answers != CodeDistanceRankingUnavailable {
+		t.Errorf("the declaration says it answers %q; want %q", doc.Unavailable[i].Answers, CodeDistanceRankingUnavailable)
+	}
+
+	org := targetIn(t, doc, "organization")
+	place := slices.IndexFunc(org.Fields, func(f querySchemaField) bool { return f.Name == "address" })
+	if place < 0 || !slices.Contains(org.Fields[place].Ops, OpWithinRadius) {
+		t.Error("the operator is declared unavailable but no field publishes it, so it can never be reached")
+	}
+	city := slices.IndexFunc(org.Fields, func(f querySchemaField) bool { return f.Name == "address.city" })
+	if city < 0 || !slices.Contains(org.Fields[city].Ops, OpEq) {
+		t.Error("city is not published as an exact predicate; it works today and must say so")
+	}
+}
+
+func targetIn(t *testing.T, doc querySchemaDoc, name string) querySchemaTarget {
+	t.Helper()
+	i := slices.IndexFunc(doc.Targets, func(target querySchemaTarget) bool { return target.Target == name })
+	if i < 0 {
+		t.Fatalf("published document has no %q target", name)
+	}
+	return doc.Targets[i]
+}
+
+// The document is composed per caller, from the same resolver the validator
+// uses — so what it advertises is exactly what a plan may say, and it never
+// advertises a record type the caller cannot read.
+func TestThePublishedVocabularyIsComposedPerCaller(t *testing.T) {
+	resource := NewQuerySchemaResource(NewVocabularyResolver())
+
+	wide := readSchema(readerFor("deal", "organization"), t, resource)
+	if len(wide.Targets) != 2 {
+		t.Fatalf("a caller reading two record types sees %d targets", len(wide.Targets))
+	}
+
+	narrow := readSchema(readerFor("organization"), t, resource)
+	for _, target := range narrow.Targets {
+		if target.Target == "deal" {
+			t.Error("the published document advertises a record type the caller cannot read")
+		}
+	}
+	for _, target := range narrow.Targets {
+		for _, r := range target.Relations {
+			if r.Target == "deal" {
+				t.Errorf("%s publishes a hop into a record type the caller cannot read", target.Target)
+			}
+		}
+	}
+}
+
+// Everything the document advertises is something a plan is actually allowed
+// to say. The two come from one resolver, and this is the test that keeps
+// them one: an advertised field the validator refuses is a refusal that reads
+// like a bug.
+func TestEveryPublishedFieldAndOperatorValidates(t *testing.T) {
+	ctx := readerFor("deal", "organization")
+	doc := readSchema(ctx, t, NewQuerySchemaResource(NewVocabularyResolver()))
+	validator := NewPlanValidator(NewVocabularyResolver())
+
+	for _, target := range doc.Targets {
+		for _, field := range target.Fields {
+			for _, op := range field.Ops {
+				plan := Plan{
+					Version: PlanVersion, Target: target.Target,
+					Where: []Predicate{operandFor(field, op)},
+				}
+				if _, err := validator.Validate(ctx, plan); err != nil {
+					t.Errorf("%s.%s %s is published but refused: %v", target.Target, field.Name, op, err)
+				}
+			}
+		}
+		for _, relation := range target.Relations {
+			plan := Plan{Version: PlanVersion, Target: target.Target, Traverse: &Traversal{Relation: relation.Name}}
+			if _, err := validator.Validate(ctx, plan); err != nil {
+				t.Errorf("%s hop %q is published but refused: %v", target.Target, relation.Name, err)
+			}
+		}
+	}
+}
+
+// operandFor builds an operand of the shape a published field's kind takes.
+func operandFor(field querySchemaField, op string) Predicate {
+	operand := json.RawMessage(`"x"`)
+	switch FieldKind(field.Kind) {
+	case KindNumber:
+		operand = json.RawMessage(`1`)
+	case KindBoolean:
+		operand = json.RawMessage(`true`)
+	case KindGeo:
+		operand = json.RawMessage(`{"center":"Stuttgart","radius_km":50}`)
+	case KindText, KindID, KindDate, KindTimestamp:
+	}
+	if op == OpIn {
+		return Predicate{Field: field.Name, Op: op, Values: []json.RawMessage{operand}}
+	}
+	return Predicate{Field: field.Name, Op: op, Value: operand}
+}
+
+// An unknown URI is not found — the same answer a URI the caller cannot see
+// gets, so the resource surface hides existence exactly as the record surface
+// does.
+func TestAnUnknownResourceURIIsNotFound(t *testing.T) {
+	_, err := NewQuerySchemaResource(NewVocabularyResolver()).
+		ReadResource(readerFor("deal"), "margince://schema/something-else")
+	if !errors.Is(err, apperrors.ErrNotFound) {
+		t.Fatalf("unknown URI answered %v; want ErrNotFound", err)
+	}
+}
+
+// The catalogue advertises the document with everything a client needs to
+// decide whether to fetch it.
+func TestTheResourceIsAdvertisedWithItsIdentity(t *testing.T) {
+	published := NewQuerySchemaResource(NewVocabularyResolver()).Resources(readerFor("deal"))
+	if len(published) != 1 {
+		t.Fatalf("the search module publishes %d resources; want 1", len(published))
+	}
+	r := published[0]
+	if r.URI != QuerySchemaURI || r.Name == "" || r.Title == "" || r.Description == "" || r.MIMEType == "" {
+		t.Errorf("resource advertised incompletely: %+v", r)
+	}
+}
+
+// The workspace's own columns are published too, so a caller never has to
+// discover a custom field by guessing at it.
+func TestTheWorkspacesOwnColumnsArePublished(t *testing.T) {
+	catalog := stubCatalog{columns: map[string][]fieldcatalog.Column{
+		"deal": {{Name: "cf_renewal_risk", Type: fieldcatalog.TypePicklist}},
+	}}
+	doc := readSchema(readerFor("deal"), t,
+		NewQuerySchemaResource(NewVocabularyResolver().WithFieldCatalog(catalog)))
+
+	deal := targetIn(t, doc, "deal")
+	if !slices.ContainsFunc(deal.Fields, func(f querySchemaField) bool { return f.Name == "cf_renewal_risk" }) {
+		t.Error("an active custom field is askable but not published, so a caller can only find it by guessing")
+	}
+}
+
+// A catalog fault refuses the read rather than publishing a silently smaller
+// vocabulary — a document missing the fields it should carry teaches a caller
+// a surface that is not there.
+func TestACatalogFaultRefusesThePublishedRead(t *testing.T) {
+	boom := errors.New("catalog unavailable")
+	_, err := NewQuerySchemaResource(NewVocabularyResolver().WithFieldCatalog(stubCatalog{err: boom})).
+		ReadResource(readerFor("deal"), QuerySchemaURI)
+	if !errors.Is(err, boom) {
+		t.Fatalf("read returned %v; want the catalog fault", err)
+	}
+}
+
+// The grammar section states the three things v1 admits, so the shape of a
+// plan does not have to be inferred from the field lists.
+func TestThePublishedDocumentStatesTheGrammar(t *testing.T) {
+	doc := readSchema(readerFor("deal"), t, NewQuerySchemaResource(NewVocabularyResolver()))
+	if doc.Version != PlanVersion {
+		t.Errorf("published version is %q; want %q", doc.Version, PlanVersion)
+	}
+	for name, clause := range map[string]string{
+		"predicates":      doc.Grammar.Predicates,
+		"semantic target": doc.Grammar.SemanticTarget,
+		"traversal":       doc.Grammar.Traversal,
+		"limit":           doc.Grammar.Limit,
+		"refusal":         doc.Grammar.Refusal,
+	} {
+		if clause == "" {
+			t.Errorf("the published grammar says nothing about %s", name)
+		}
+	}
+}

--- a/backend/internal/modules/search/queryschema_test.go
+++ b/backend/internal/modules/search/queryschema_test.go
@@ -134,7 +134,7 @@ func operandFor(field querySchemaField, op string) Predicate {
 	case KindText, KindID, KindDate, KindTimestamp:
 	}
 	if op == OpIn {
-		return Predicate{Field: field.Name, Op: op, Values: []json.RawMessage{operand}}
+		return Predicate{Field: field.Name, Op: op, Values: json.RawMessage("[" + string(operand) + "]")}
 	}
 	return Predicate{Field: field.Name, Op: op, Value: operand}
 }

--- a/backend/internal/modules/search/queryvalidate.go
+++ b/backend/internal/modules/search/queryvalidate.go
@@ -227,17 +227,37 @@ func fieldAdmitsOp(field Field, op string) bool {
 // it named none. A limit outside the CAP-PAGE window is REFUSED rather than
 // clamped: clamping answers a narrower question than the caller asked
 // without saying so, which is the silent narrowing SEARCH-AC-14 forbids.
-func effectiveLimit(limit *int) (int, []apperrors.FieldRefusal) {
-	if limit == nil {
+//
+// An ABSENT limit takes the default; an explicit null does not. Reading null
+// as absent would serve a page size the caller never asked for, and null is
+// simply not a value this grammar has.
+func effectiveLimit(raw json.RawMessage) (int, []apperrors.FieldRefusal) {
+	if len(raw) == 0 {
 		return storekit.ClampLimit(nil), nil
 	}
-	if *limit < 1 || *limit > maxPlanLimit {
+	var limit int
+	if isJSONNull(raw) || json.Unmarshal(raw, &limit) != nil {
+		return 0, []apperrors.FieldRefusal{{
+			Field: "limit", Code: CodeValueTypeMismatch,
+			Message: "limit must be a whole number between 1 and " + strconv.Itoa(maxPlanLimit) + ", or omitted for the default page",
+		}}
+	}
+	if limit < 1 || limit > maxPlanLimit {
 		return 0, []apperrors.FieldRefusal{{
 			Field: "limit", Code: CodeLimitOutOfRange,
 			Message: "limit must be between 1 and " + strconv.Itoa(maxPlanLimit) + "; ask for a page and follow it with another",
 		}}
 	}
-	return *limit, nil
+	return limit, nil
+}
+
+// isJSONNull reports whether a raw operand is the literal null. It is checked
+// EXPLICITLY everywhere an operand is judged, because json.Unmarshal accepts
+// null into every Go type without error and leaves the zero value behind — so
+// a null operand would otherwise pass as a valid number, string or boolean
+// and reach the executor as a zero the caller never wrote.
+func isJSONNull(raw json.RawMessage) bool {
+	return bytes.Equal(bytes.TrimSpace(raw), []byte("null"))
 }
 
 // maxPlanLimit is the contract's CAP-PAGE ceiling, DISCOVERED from the shared
@@ -278,34 +298,52 @@ func joinWithCommas(parts []string) string {
 // different question.
 func checkOperand(at string, field Field, clause Predicate) (apperrors.FieldRefusal, bool) {
 	// The operand member an operator does NOT read is refused when present
-	// rather than ignored. An ignored member is a plan half-answered: a
-	// caller who wrote `op: "eq"` and filled `values` meant the list, and
-	// silently matching on `value` instead answers a different question.
+	// rather than ignored — including when it is present as null. An ignored
+	// member is a plan half-answered: a caller who wrote `op: "eq"` and
+	// filled `values` meant the list, and silently matching on `value`
+	// instead answers a different question.
 	if unused, present := unusedOperand(clause); present {
 		return operandRefusal(at+"."+unused, CodeValueNotApplicable,
 			quote(clause.Op)+" reads "+quote(operandMember(clause.Op))+", not "+quote(unused)), true
 	}
 	if clause.Op == OpIn {
-		if len(clause.Values) == 0 {
-			return operandRefusal(at+".values", CodeValueMissing,
-				quote(OpIn)+" needs a non-empty "+quote("values")+" list"), true
-		}
-		for i, v := range clause.Values {
-			if !operandMatches(field.Kind, v) {
-				return operandRefusal(at+".values["+strconv.Itoa(i)+"]", CodeValueTypeMismatch,
-					operandMessage(clause.Field, field.Kind)), true
-			}
-		}
-		return apperrors.FieldRefusal{}, false
+		return checkListOperand(at, field, clause)
 	}
 	if len(clause.Value) == 0 {
-		return operandRefusal(at+".value", CodeValueMissing,
-			quote(clause.Op)+" needs a "+quote("value")), true
+		return operandRefusal(at+"."+memberValue, CodeValueMissing,
+			quote(clause.Op)+" needs a "+quote(memberValue)), true
 	}
 	if !operandMatches(field.Kind, clause.Value) {
-		return operandRefusal(at+".value", CodeValueTypeMismatch, operandMessage(clause.Field, field.Kind)), true
+		return operandRefusal(at+"."+memberValue, CodeValueTypeMismatch, operandMessage(clause.Field, field.Kind)), true
 	}
 	return apperrors.FieldRefusal{}, false
+}
+
+// checkListOperand judges the `in` operator's list: it must be present, be a
+// list, be non-empty, and every element must have the field's shape.
+func checkListOperand(at string, field Field, clause Predicate) (apperrors.FieldRefusal, bool) {
+	var values []json.RawMessage
+	if len(clause.Values) == 0 || isJSONNull(clause.Values) || json.Unmarshal(clause.Values, &values) != nil {
+		return listOperandMissing(at), true
+	}
+	if len(values) == 0 {
+		return listOperandMissing(at), true
+	}
+	for i, v := range values {
+		if !operandMatches(field.Kind, v) {
+			return operandRefusal(at+"."+memberValues+"["+strconv.Itoa(i)+"]", CodeValueTypeMismatch,
+				operandMessage(clause.Field, field.Kind)), true
+		}
+	}
+	return apperrors.FieldRefusal{}, false
+}
+
+// listOperandMissing is the one refusal an absent, null, non-list or empty
+// `in` operand gets: all four are the same thing to a caller — the list they
+// have to supply is not there.
+func listOperandMissing(at string) apperrors.FieldRefusal {
+	return operandRefusal(at+"."+memberValues, CodeValueMissing,
+		quote(OpIn)+" needs a non-empty "+quote(memberValues)+" list")
 }
 
 func operandRefusal(path, code, message string) apperrors.FieldRefusal {
@@ -316,18 +354,18 @@ func operandRefusal(path, code, message string) apperrors.FieldRefusal {
 // everything else a single value.
 func operandMember(op string) string {
 	if op == OpIn {
-		return "values"
+		return memberValues
 	}
-	return "value"
+	return memberValue
 }
 
 // unusedOperand answers the operand member this operator does NOT read, when
 // the plan filled it in anyway.
 func unusedOperand(clause Predicate) (string, bool) {
 	if clause.Op == OpIn {
-		return "value", len(clause.Value) > 0
+		return memberValue, len(clause.Value) > 0
 	}
-	return "values", clause.Values != nil
+	return memberValues, len(clause.Values) > 0
 }
 
 func operandMessage(field string, kind FieldKind) string {
@@ -359,6 +397,9 @@ func operandShape(kind FieldKind) string {
 // their FORMAT is the executor's business, and refusing a malformed date here
 // would duplicate a check with nothing to compare it to.
 func operandMatches(kind FieldKind, raw json.RawMessage) bool {
+	if isJSONNull(raw) {
+		return false
+	}
 	switch kind {
 	case KindNumber:
 		var v float64
@@ -392,6 +433,9 @@ type radiusOperand struct {
 // strict for the same reason the plan's is: a `unit: miles` this validator
 // drops is a request answered differently from the one that was sent.
 func geoOperandMatches(raw json.RawMessage) bool {
+	if isJSONNull(raw) {
+		return false
+	}
 	dec := json.NewDecoder(bytes.NewReader(raw))
 	dec.DisallowUnknownFields()
 	var operand radiusOperand

--- a/backend/internal/modules/search/queryvalidate.go
+++ b/backend/internal/modules/search/queryvalidate.go
@@ -1,0 +1,407 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package search
+
+// The validator — the security boundary of the whole query feature
+// (SEARCH-AC-14). Everything a plan says is checked for MEMBERSHIP in the
+// caller's resolved vocabulary, and anything outside it is refused with a
+// typed clarification. There is no branch here that narrows a plan to the
+// part it recognised: a query that half-parses is worse than one that fails,
+// because its answer looks like every other answer.
+//
+// No execution lives here or anywhere else yet. A ValidatedPlan is a plan the
+// executor may run, and producing it is the whole of this PR's job.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"math"
+	"slices"
+	"strconv"
+
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+)
+
+// ValidatedPlan is a plan every token of which is in the caller's vocabulary.
+// The executor takes one of these and nothing else, so a plan cannot reach
+// execution without having passed through here.
+type ValidatedPlan struct {
+	Plan Plan
+	// Target and Hop are the resolved vocabularies the plan was checked
+	// against, carried so the executor joins on the derived relation rather
+	// than re-deriving it from the plan's text.
+	Target TargetVocabulary
+	Hop    *Relation
+	// Limit is the effective page size: the plan's, or the contract default
+	// when it named none.
+	Limit int
+	// Unavailable names the predicates this deployment cannot answer as
+	// asked — today only `within_radius`, which is declared in the
+	// vocabulary and answers `distance_ranking_unavailable` (SEARCH-AC-17).
+	//
+	// A NON-EMPTY Unavailable is not advisory. The executor must answer with
+	// these notes rather than with rows: returning results while quietly
+	// dropping the predicate would be a ranking with nothing behind it,
+	// which is the failure declaring the operator exists to avoid.
+	Unavailable []Unavailable
+}
+
+// Unavailable is one predicate that validated but cannot be answered.
+type Unavailable struct {
+	// Path is the plan-document path of the predicate; Code the contract's
+	// machine name for why it cannot be answered.
+	Path string
+	Code string
+}
+
+// CodeDistanceRankingUnavailable is the answer `within_radius` gives until
+// normalized coordinates exist (SEARCH-AC-17). The operator is DECLARED
+// rather than omitted on purpose: omitting it sends a caller to a text match
+// on a city name, which quietly returns a different answer.
+const CodeDistanceRankingUnavailable = "distance_ranking_unavailable"
+
+// PlanValidator checks a plan against the caller's resolved vocabulary.
+type PlanValidator struct {
+	vocab *VocabularyResolver
+}
+
+// NewPlanValidator builds a validator over a vocabulary resolver.
+func NewPlanValidator(vocab *VocabularyResolver) *PlanValidator {
+	return &PlanValidator{vocab: vocab}
+}
+
+// Validate answers the validated plan, or a *PlanRefusal naming every token
+// that was not understood.
+//
+// It refuses the plan's VERSION and TARGET first and returns immediately on
+// either, because both decide what the rest of the plan even means: reporting
+// predicate refusals against a vocabulary the caller did not ask for would
+// name fields that have nothing to do with the question.
+func (v *PlanValidator) Validate(ctx context.Context, plan Plan) (ValidatedPlan, error) {
+	if plan.Version != PlanVersion {
+		return ValidatedPlan{}, refuse("version", CodeUnknownPlanVersion,
+			"this server validates query plans of version "+quote(PlanVersion)+" only")
+	}
+	vocab, err := v.vocab.Resolve(ctx, append([]string{plan.Target}, hopTargets(plan)...)...)
+	if err != nil {
+		return ValidatedPlan{}, err
+	}
+	target, ok := vocab.Target(plan.Target)
+	if !ok {
+		return ValidatedPlan{}, refuse("target", classify(plan.Target, CodeUnknownTarget),
+			"the query plan cannot ask about "+quote(plan.Target)+
+				"; read margince://schema/query for the record types available to you")
+	}
+
+	validated := ValidatedPlan{Plan: plan, Target: target}
+	var refusals []apperrors.FieldRefusal
+	refusals = append(refusals, checkPredicates(target, "where", plan.Where, &validated)...)
+	refusals = append(refusals, v.checkTraversal(vocab, plan.Traverse, &validated)...)
+	limit, limitRefusal := effectiveLimit(plan.Limit)
+	refusals = append(refusals, limitRefusal...)
+	validated.Limit = limit
+
+	if len(refusals) > 0 {
+		return ValidatedPlan{}, &PlanRefusal{Refusals: refusals}
+	}
+	return validated, nil
+}
+
+// hopTarget names the record type a traversal lands on, so Resolve reads that
+// vocabulary in the same pass. The relation is not resolved yet — the name is
+// mapped to a target only after the vocabulary exists — so this asks for
+// every record type SOME relation of that name could reach, which is at most
+// one per searchable entity and in practice one.
+func hopTargets(plan Plan) []string {
+	if plan.Traverse == nil {
+		return nil
+	}
+	var targets []string
+	for entity := range contractRecords {
+		if plan.Traverse.Relation == entity || plan.Traverse.Relation == entity+"s" {
+			targets = append(targets, entity)
+		}
+	}
+	return targets
+}
+
+// checkTraversal admits at most one hop. A nested second hop is refused by
+// NAME rather than dropped, so the caller learns the depth cap instead of
+// receiving an answer to the shallower question it did not ask.
+func (v *PlanValidator) checkTraversal(vocab Vocabulary, hop *Traversal, into *ValidatedPlan) []apperrors.FieldRefusal {
+	if hop == nil {
+		return nil
+	}
+	if hop.Traverse != nil {
+		return []apperrors.FieldRefusal{{
+			Field: "traverse.traverse", Code: CodeTraversalDepthExceeded,
+			Message: "a v1 query plan takes one relationship hop; ask the second hop as its own query",
+		}}
+	}
+	relation, ok := into.Target.Relation(hop.Relation)
+	if !ok {
+		return unknownRelation(into.Target.Target, hop.Relation)
+	}
+	hopVocab, ok := vocab.Target(relation.Target)
+	if !ok {
+		// Fail-closed, and the same refusal a caller would get for a hop that
+		// does not exist — so even reaching here discloses nothing. What keeps
+		// it unreachable is that relation NAMES and the narrowing in
+		// hopTargets are derived from the same entity names, which
+		// TestEveryDerivedRelationNameIsResolvableByTheValidatorsNarrowing
+		// asserts; rename one without the other and that test fails rather
+		// than a valid hop quietly refusing.
+		return unknownRelation(into.Target.Target, hop.Relation)
+	}
+	into.Hop = &relation
+	return checkPredicates(hopVocab, "traverse.where", hop.Where, into)
+}
+
+// unknownRelation is the ONE refusal a hop this caller may not take gets —
+// whether the relation never existed, or exists and lands on a record type
+// they cannot read. One spelling, because two would be a discovery channel.
+func unknownRelation(target, name string) []apperrors.FieldRefusal {
+	return []apperrors.FieldRefusal{{
+		Field: "traverse.relation", Code: classify(name, CodeUnknownRelation),
+		Message: quote(target) + " has no relationship named " + quote(name) +
+			"; read margince://schema/query for the hops available to you",
+	}}
+}
+
+// checkPredicates checks every clause of one where-list and returns a
+// refusal per bad clause — all of them, not the first.
+func checkPredicates(vocab TargetVocabulary, path string, clauses []Predicate, into *ValidatedPlan) []apperrors.FieldRefusal {
+	var refusals []apperrors.FieldRefusal
+	for i, clause := range clauses {
+		at := path + "[" + strconv.Itoa(i) + "]"
+		if refusal, ok := checkPredicate(vocab, at, clause, into); ok {
+			refusals = append(refusals, refusal)
+		}
+	}
+	return refusals
+}
+
+// checkPredicate checks one clause, reporting at most one refusal: the first
+// thing wrong with it decides what the rest of it even means, so an unknown
+// field is not also reported as an unknown operator.
+func checkPredicate(vocab TargetVocabulary, at string, clause Predicate, into *ValidatedPlan) (apperrors.FieldRefusal, bool) {
+	field, ok := vocab.Field(clause.Field)
+	if !ok {
+		// The wording here is the ONE a caller sees for both an invented
+		// field and a real field they may not read (SEARCH-AC-16). Nothing
+		// about it may vary with which of the two it was, or vocabulary
+		// probing becomes field discovery.
+		return apperrors.FieldRefusal{
+			Field: at + ".field", Code: classify(clause.Field, CodeUnknownField),
+			Message: "the query plan cannot name " + quote(clause.Field) + " on " + quote(vocab.Target) +
+				"; read margince://schema/query for the fields available to you",
+		}, true
+	}
+	if !fieldAdmitsOp(field, clause.Op) {
+		return apperrors.FieldRefusal{
+			Field: at + ".op", Code: classify(clause.Op, CodeUnknownOperator),
+			Message: quote(clause.Field) + " is a " + string(field.Kind) + " field and admits " +
+				joinQuoted(field.Ops) + "; " + quote(clause.Op) + " is not one of them",
+		}, true
+	}
+	if refusal, bad := checkOperand(at, field, clause); bad {
+		return refusal, true
+	}
+	if clause.Op == OpWithinRadius {
+		into.Unavailable = append(into.Unavailable, Unavailable{Path: at, Code: CodeDistanceRankingUnavailable})
+	}
+	return apperrors.FieldRefusal{}, false
+}
+
+// fieldAdmitsOp reports whether the operator is one this field's kind gives
+// it. Membership, not a blocklist: an operator absent from the kind's set is
+// refused whether or not this file has ever heard of it.
+func fieldAdmitsOp(field Field, op string) bool {
+	return slices.Contains(field.Ops, op)
+}
+
+// effectiveLimit answers the plan's page size, or the contract default when
+// it named none. A limit outside the CAP-PAGE window is REFUSED rather than
+// clamped: clamping answers a narrower question than the caller asked
+// without saying so, which is the silent narrowing SEARCH-AC-14 forbids.
+func effectiveLimit(limit *int) (int, []apperrors.FieldRefusal) {
+	if limit == nil {
+		return storekit.ClampLimit(nil), nil
+	}
+	if *limit < 1 || *limit > maxPlanLimit {
+		return 0, []apperrors.FieldRefusal{{
+			Field: "limit", Code: CodeLimitOutOfRange,
+			Message: "limit must be between 1 and " + strconv.Itoa(maxPlanLimit) + "; ask for a page and follow it with another",
+		}}
+	}
+	return *limit, nil
+}
+
+// maxPlanLimit is the contract's CAP-PAGE ceiling, DISCOVERED from the shared
+// clamp rather than restated here: asking the clamp for an absurd page
+// returns the ceiling itself, so a plan can never disagree with what every
+// other list on the surface will serve.
+var maxPlanLimit = storekit.ClampLimit(&absurdPageRequest)
+
+var absurdPageRequest = math.MaxInt32
+
+// joinQuoted renders an operator set for a refusal message.
+func joinQuoted(ops []string) string {
+	quoted := make([]string, len(ops))
+	for i, op := range ops {
+		quoted[i] = quote(op)
+	}
+	return joinWithCommas(quoted)
+}
+
+func joinWithCommas(parts []string) string {
+	out := ""
+	for i, p := range parts {
+		switch {
+		case i == 0:
+			out = p
+		case i == len(parts)-1:
+			out += " and " + p
+		default:
+			out += ", " + p
+		}
+	}
+	return out
+}
+
+// checkOperand checks the clause's value against the operator's arity and the
+// field's kind. It is where a plan that puts a string where a number belongs
+// is refused rather than coerced — a coerced operand silently asks a
+// different question.
+func checkOperand(at string, field Field, clause Predicate) (apperrors.FieldRefusal, bool) {
+	// The operand member an operator does NOT read is refused when present
+	// rather than ignored. An ignored member is a plan half-answered: a
+	// caller who wrote `op: "eq"` and filled `values` meant the list, and
+	// silently matching on `value` instead answers a different question.
+	if unused, present := unusedOperand(clause); present {
+		return operandRefusal(at+"."+unused, CodeValueNotApplicable,
+			quote(clause.Op)+" reads "+quote(operandMember(clause.Op))+", not "+quote(unused)), true
+	}
+	if clause.Op == OpIn {
+		if len(clause.Values) == 0 {
+			return operandRefusal(at+".values", CodeValueMissing,
+				quote(OpIn)+" needs a non-empty "+quote("values")+" list"), true
+		}
+		for i, v := range clause.Values {
+			if !operandMatches(field.Kind, v) {
+				return operandRefusal(at+".values["+strconv.Itoa(i)+"]", CodeValueTypeMismatch,
+					operandMessage(clause.Field, field.Kind)), true
+			}
+		}
+		return apperrors.FieldRefusal{}, false
+	}
+	if len(clause.Value) == 0 {
+		return operandRefusal(at+".value", CodeValueMissing,
+			quote(clause.Op)+" needs a "+quote("value")), true
+	}
+	if !operandMatches(field.Kind, clause.Value) {
+		return operandRefusal(at+".value", CodeValueTypeMismatch, operandMessage(clause.Field, field.Kind)), true
+	}
+	return apperrors.FieldRefusal{}, false
+}
+
+func operandRefusal(path, code, message string) apperrors.FieldRefusal {
+	return apperrors.FieldRefusal{Field: path, Code: code, Message: message}
+}
+
+// operandMember names the member an operator reads: `in` takes a list,
+// everything else a single value.
+func operandMember(op string) string {
+	if op == OpIn {
+		return "values"
+	}
+	return "value"
+}
+
+// unusedOperand answers the operand member this operator does NOT read, when
+// the plan filled it in anyway.
+func unusedOperand(clause Predicate) (string, bool) {
+	if clause.Op == OpIn {
+		return "value", len(clause.Value) > 0
+	}
+	return "values", clause.Values != nil
+}
+
+func operandMessage(field string, kind FieldKind) string {
+	return quote(field) + " is a " + string(kind) + " field; its operand must be a " + operandShape(kind)
+}
+
+// operandShape names the JSON shape a kind's operand takes, for the message.
+func operandShape(kind FieldKind) string {
+	switch kind {
+	case KindNumber:
+		return "number"
+	case KindBoolean:
+		return "boolean"
+	case KindGeo:
+		return `{"center": <text>, "radius_km": <number>}`
+	case KindText, KindID, KindDate, KindTimestamp:
+		return "string"
+	default:
+		return "string"
+	}
+}
+
+// operandMatches reports whether a raw JSON operand has the shape the kind
+// takes. Each kind decodes into its OWN Go type rather than into a generic
+// value that is then type-switched: decoding is the check, so a `1` offered
+// where a string belongs fails at the decode instead of after it.
+//
+// Dates and timestamps are strings on the wire (the contract's own encoding);
+// their FORMAT is the executor's business, and refusing a malformed date here
+// would duplicate a check with nothing to compare it to.
+func operandMatches(kind FieldKind, raw json.RawMessage) bool {
+	switch kind {
+	case KindNumber:
+		var v float64
+		return json.Unmarshal(raw, &v) == nil
+	case KindBoolean:
+		var v bool
+		return json.Unmarshal(raw, &v) == nil
+	case KindGeo:
+		return geoOperandMatches(raw)
+	case KindText, KindID, KindDate, KindTimestamp:
+		var v string
+		return json.Unmarshal(raw, &v) == nil
+	default:
+		return false
+	}
+}
+
+// radiusOperand is what `within_radius` takes: a place to measure from and a
+// distance. RadiusKM is a pointer so an ABSENT radius is distinguishable from
+// a zero one — both are refused, but for different reasons, and a plan that
+// meant `0` should not read as a plan that forgot.
+type radiusOperand struct {
+	Center   string   `json:"center"`
+	RadiusKM *float64 `json:"radius_km"`
+}
+
+// geoOperandMatches checks the radius operand's shape. The operator does not
+// run — it answers `distance_ranking_unavailable` — but the shape is still
+// checked, so the note a caller gets back is about this deployment's
+// capability rather than about their own malformed request. The decode is
+// strict for the same reason the plan's is: a `unit: miles` this validator
+// drops is a request answered differently from the one that was sent.
+func geoOperandMatches(raw json.RawMessage) bool {
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.DisallowUnknownFields()
+	var operand radiusOperand
+	if err := dec.Decode(&operand); err != nil {
+		return false
+	}
+	return operand.Center != "" && operand.RadiusKM != nil && *operand.RadiusKM > 0
+}
+
+// assertion that the refusal really is the plural fault form the transports
+// render; a refusal that stopped implementing it would degrade to an
+// unclassified internal error on the tool surface.
+var _ apperrors.FieldFaults = (*PlanRefusal)(nil)

--- a/backend/internal/modules/search/queryvalidate_test.go
+++ b/backend/internal/modules/search/queryvalidate_test.go
@@ -335,20 +335,26 @@ func TestAMalformedRadiusOperandIsRefusedRatherThanDeclaredUnavailable(t *testin
 // The classifier explains; it never admits. Whatever it thinks of a token,
 // the token is already out of the vocabulary by the time it is consulted.
 func TestTheClassifierOnlyExplainsARefusalItDidNotCause(t *testing.T) {
-	// A field named exactly like a SQL keyword IS in the vocabulary when the
-	// contract declares it, and the classifier's opinion never gets asked.
-	plan, err := validateJSON(readerFor("activity"), t,
-		`{"version":"v1","target":"activity","where":[{"field":"source","op":"eq","value":"import"}]}`)
+	// `converted_from_lead_id` is a real contract field AND one the classifier
+	// would call SQL if it were ever asked — it carries `from` as a whole
+	// word. It validates anyway, because membership is settled first and the
+	// classifier is only consulted about tokens already refused.
+	if !looksLikeSQL("converted_from_lead_id") {
+		t.Fatal("the fixture no longer exercises the classifier; pick a field it would call SQL")
+	}
+	plan, err := validateJSON(readerFor("person"), t,
+		`{"version":"v1","target":"person","where":[{"field":"converted_from_lead_id","op":"eq",`+
+			`"value":"00000000-0000-7000-8000-000000000001"}]}`)
 	if err != nil {
-		t.Fatalf("a legitimate contract field was refused: %v", err)
+		t.Fatalf("a legitimate contract field the classifier would call SQL was refused: %v", err)
 	}
 	if len(plan.Plan.Where) != 1 {
 		t.Fatalf("validated plan carries %d predicates", len(plan.Plan.Where))
 	}
 	// And a token the classifier has no opinion about is still refused,
 	// because membership — not shape — is what decides.
-	_, err = validateJSON(readerFor("activity"), t,
-		`{"version":"v1","target":"activity","where":[{"field":"innocent_looking_name","op":"eq","value":"x"}]}`)
+	_, err = validateJSON(readerFor("person"), t,
+		`{"version":"v1","target":"person","where":[{"field":"innocent_looking_name","op":"eq","value":"x"}]}`)
 	if codes := refusalCodes(t, err); !slices.Contains(codes, CodeUnknownField) {
 		t.Errorf("an unrecognised but harmless-looking token was refused with %v; want %q", codes, CodeUnknownField)
 	}
@@ -552,5 +558,128 @@ func TestTheDuplicateScanLeavesMalformedDocumentsToTheDecoder(t *testing.T) {
 	fault := singleFault(t, mustRefuse(readerFor("deal"), t, `{"version":"v1","target":`))
 	if fault.Code != CodeMalformedPlan {
 		t.Errorf("a truncated document was refused as %q; want %q", fault.Code, CodeMalformedPlan)
+	}
+}
+
+// encoding/json matches member names CASE-INSENSITIVELY, and so does
+// DisallowUnknownFields — so `TARGET` is neither unknown nor, to a scan
+// comparing exact strings, a duplicate, and the decoder resolves it
+// last-wins. The caller's target is silently replaced by one they did not
+// write. Only the canonical spelling is admitted.
+func TestACaseVariantMemberCannotOverwriteTheCanonicalOne(t *testing.T) {
+	for name, doc := range map[string]string{
+		"an upper-cased target":    `{"version":"v1","target":"deal","TARGET":"person"}`,
+		"a title-cased where":      `{"version":"v1","target":"deal","Where":[]}`,
+		"a variant inside a hop":   `{"version":"v1","target":"deal","traverse":{"Relation":"organization"}}`,
+		"a variant operand member": `{"version":"v1","target":"deal","where":[{"field":"name","op":"eq","VALUE":"x"}]}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := validateJSON(readerFor("deal", "organization", "person"), t, doc)
+			if codes := refusalCodes(t, err); !slices.Contains(codes, CodeUnknownPlanMember) {
+				t.Errorf("refused with %v; want %q", codes, CodeUnknownPlanMember)
+			}
+		})
+	}
+}
+
+// A caller's own operand payload is not grammar: `within_radius` takes an
+// object whose members the plan grammar has never heard of, and the
+// canonical-spelling rule must not reach into it.
+func TestAnOperandPayloadIsNotJudgedAgainstTheGrammarsMemberNames(t *testing.T) {
+	plan, err := validateJSON(readerFor("organization"), t, `{"version":"v1","target":"organization",
+		"where":[{"field":"address","op":"within_radius","value":{"center":"Stuttgart","radius_km":50}}]}`)
+	if err != nil {
+		t.Fatalf("a legitimate operand payload was refused as a plan member: %v", err)
+	}
+	if len(plan.Unavailable) != 1 {
+		t.Errorf("the radius predicate reports %v", plan.Unavailable)
+	}
+}
+
+// A repeated member inside an operand payload is still refused: last-wins is
+// exactly as silent there as it is in the grammar.
+func TestARepeatedMemberInsideAnOperandPayloadIsStillRefused(t *testing.T) {
+	_, err := validateJSON(readerFor("organization"), t, `{"version":"v1","target":"organization",
+		"where":[{"field":"address","op":"within_radius","value":{"center":"a","center":"b","radius_km":50}}]}`)
+	if codes := refusalCodes(t, err); !slices.Contains(codes, CodeDuplicateMember) {
+		t.Errorf("refused with %v; want %q", codes, CodeDuplicateMember)
+	}
+}
+
+// Bytes after the end of the plan are refused. dec.More() is not the test:
+// it reports whether another VALUE follows, so a stray delimiter leaves it
+// false and the garbage travels with an otherwise valid plan.
+func TestBytesAfterThePlanAreRefused(t *testing.T) {
+	for name, doc := range map[string]string{
+		"a trailing delimiter": `{"version":"v1","target":"deal"}]`,
+		"a second document":    `{"version":"v1","target":"deal"} {"version":"v1","target":"deal"}`,
+		"a trailing scalar":    `{"version":"v1","target":"deal"} 7`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := validateJSON(readerFor("deal"), t, doc)
+			if codes := refusalCodes(t, err); !slices.Contains(codes, CodeMalformedPlan) {
+				t.Errorf("refused with %v; want %q", codes, CodeMalformedPlan)
+			}
+		})
+	}
+}
+
+// json.Unmarshal accepts null into EVERY Go type without error and leaves the
+// zero value behind, so a null operand would otherwise pass as a valid
+// number, string or boolean and reach an executor as a zero nobody wrote.
+func TestANullOperandIsRefusedRatherThanReadAsAZero(t *testing.T) {
+	for name, tc := range map[string]struct{ doc, want string }{
+		"a null value":          {`{"field":"amount_minor","op":"gt","value":null}`, CodeValueTypeMismatch},
+		"a null text value":     {`{"field":"name","op":"eq","value":null}`, CodeValueTypeMismatch},
+		"a null boolean value":  {`{"field":"stalled","op":"eq","value":null}`, CodeValueTypeMismatch},
+		"a null inside a list":  {`{"field":"name","op":"in","values":["a",null]}`, CodeValueTypeMismatch},
+		"a null list":           {`{"field":"name","op":"in","values":null}`, CodeValueMissing},
+		"a null unused operand": {`{"field":"name","op":"eq","value":"a","values":null}`, CodeValueNotApplicable},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := validateJSON(readerFor("deal", "organization", "person"), t,
+				`{"version":"v1","target":"deal","where":[`+tc.doc+`]}`)
+			if codes := refusalCodes(t, err); !slices.Contains(codes, tc.want) {
+				t.Errorf("refused with %v; want %q", codes, tc.want)
+			}
+		})
+	}
+}
+
+// The geo operand has its own null case, on a target that actually carries a
+// place.
+func TestANullRadiusOperandIsRefused(t *testing.T) {
+	_, err := validateJSON(readerFor("organization"), t,
+		`{"version":"v1","target":"organization","where":[{"field":"address","op":"within_radius","value":null}]}`)
+	if codes := refusalCodes(t, err); !slices.Contains(codes, CodeValueTypeMismatch) {
+		t.Errorf("refused with %v; want %q", codes, CodeValueTypeMismatch)
+	}
+}
+
+// A null limit is not an omitted limit. Reading it as absent would serve a
+// page size the caller never asked for.
+func TestANullLimitIsRefusedRatherThanReadAsOmitted(t *testing.T) {
+	fault := singleFault(t, mustRefuse(readerFor("deal"), t, `{"version":"v1","target":"deal","limit":null}`))
+	if fault.Code != CodeValueTypeMismatch {
+		t.Errorf("a null limit was refused as %q; want %q", fault.Code, CodeValueTypeMismatch)
+	}
+	// And a limit of the wrong SHAPE is the same refusal, not a range error.
+	fault = singleFault(t, mustRefuse(readerFor("deal"), t, `{"version":"v1","target":"deal","limit":"25"}`))
+	if fault.Code != CodeValueTypeMismatch {
+		t.Errorf("a string limit was refused as %q; want %q", fault.Code, CodeValueTypeMismatch)
+	}
+}
+
+// A refusal message carries the caller's own token, so a token containing a
+// quote or a newline must not be able to end the quoted run early or split
+// the message across lines.
+func TestARefusalMessageSurvivesAHostileToken(t *testing.T) {
+	fault := singleFault(t, mustRefuse(readerFor("deal"), t,
+		`{"version":"v1","target":"deal","where":[{"field":"a\"b\nc","op":"eq","value":"x"}]}`))
+	if strings.Contains(fault.Message, "\n") {
+		t.Errorf("the refusal message spans lines: %q", fault.Message)
+	}
+	if !strings.Contains(fault.Message, `\"`) || !strings.Contains(fault.Message, `\n`) {
+		t.Errorf("the token was not escaped into the message: %q", fault.Message)
 	}
 }

--- a/backend/internal/modules/search/queryvalidate_test.go
+++ b/backend/internal/modules/search/queryvalidate_test.go
@@ -1,0 +1,556 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package search
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/fieldcatalog"
+)
+
+// validateJSON runs a plan document end to end — decode then validate — which
+// is the path a caller actually takes, so a refusal that only the decoder or
+// only the validator can produce is still exercised here.
+func validateJSON(ctx context.Context, t *testing.T, doc string) (ValidatedPlan, error) {
+	t.Helper()
+	plan, err := DecodePlan([]byte(doc))
+	if err != nil {
+		return ValidatedPlan{}, err
+	}
+	return NewPlanValidator(NewVocabularyResolver()).Validate(ctx, plan)
+}
+
+// refusalCodes reads the codes off a refusal, failing the test when the error
+// is not the typed clarification every refusal owes the caller.
+func refusalCodes(t *testing.T, err error) []string {
+	t.Helper()
+	if err == nil {
+		t.Fatal("plan accepted; want a refusal")
+	}
+	var faults apperrors.FieldFaults
+	if !errorAs(err, &faults) {
+		t.Fatalf("refusal is %T, which no transport can render as a clarification", err)
+	}
+	codes := make([]string, 0, len(faults.FieldFaults()))
+	for _, f := range faults.FieldFaults() {
+		if f.Message == "" {
+			t.Errorf("refusal at %q carries code %q and no message; a code alone does not say what to fix", f.Field, f.Code)
+		}
+		codes = append(codes, f.Code)
+	}
+	return codes
+}
+
+func errorAs(err error, target *apperrors.FieldFaults) bool {
+	faults, ok := err.(apperrors.FieldFaults)
+	if ok {
+		*target = faults
+	}
+	return ok
+}
+
+// SEARCH-AC-14, one case per refusal class. Every one of these is refused
+// with a code that names what was not understood — none is coerced, and none
+// is narrowed to the part that parsed.
+func TestAPlanOutsideTheVocabularyIsRefusedByClass(t *testing.T) {
+	ctx := readerFor("deal", "organization", "person")
+	for name, tc := range map[string]struct {
+		doc  string
+		want string
+	}{
+		"a table name as the target": {
+			doc:  `{"version":"v1","target":"public.deal"}`,
+			want: CodeUnknownTarget,
+		},
+		"a record type the caller cannot read": {
+			doc:  `{"version":"v1","target":"lead"}`,
+			want: CodeUnknownTarget,
+		},
+		"a SQL fragment as a field": {
+			doc:  `{"version":"v1","target":"deal","where":[{"field":"name FROM deal WHERE 1=1 --","op":"eq","value":"x"}]}`,
+			want: CodeSQLFragment,
+		},
+		"a SQL fragment as the target": {
+			doc:  `{"version":"v1","target":"deal; DROP TABLE deal"}`,
+			want: CodeSQLFragment,
+		},
+		"a free expression as a field": {
+			doc:  `{"version":"v1","target":"deal","where":[{"field":"amount_minor * 2","op":"gt","value":1}]}`,
+			want: CodeFreeExpression,
+		},
+		"an unknown field": {
+			doc:  `{"version":"v1","target":"deal","where":[{"field":"probability","op":"eq","value":"x"}]}`,
+			want: CodeUnknownField,
+		},
+		"an unknown operator": {
+			doc:  `{"version":"v1","target":"deal","where":[{"field":"name","op":"matches","value":"x"}]}`,
+			want: CodeUnknownOperator,
+		},
+		"an operator the field's kind does not admit": {
+			doc:  `{"version":"v1","target":"deal","where":[{"field":"name","op":"gt","value":"x"}]}`,
+			want: CodeUnknownOperator,
+		},
+		"a join the vocabulary lacks": {
+			doc:  `{"version":"v1","target":"deal","traverse":{"relation":"invoices"}}`,
+			want: CodeUnknownRelation,
+		},
+		"a second hop": {
+			doc:  `{"version":"v1","target":"deal","traverse":{"relation":"organization","traverse":{"relation":"deals"}}}`,
+			want: CodeTraversalDepthExceeded,
+		},
+		"a member the grammar has no place for": {
+			doc:  `{"version":"v1","target":"deal","sql":"select 1"}`,
+			want: CodeUnknownPlanMember,
+		},
+		"a plan of another version": {
+			doc:  `{"version":"v2","target":"deal"}`,
+			want: CodeUnknownPlanVersion,
+		},
+		"a document that is not a plan": {
+			doc:  `not json at all`,
+			want: CodeMalformedPlan,
+		},
+		"a second document after the plan": {
+			doc:  `{"version":"v1","target":"deal"} {"version":"v1","target":"deal"}`,
+			want: CodeMalformedPlan,
+		},
+		"a string where a number belongs": {
+			doc:  `{"version":"v1","target":"deal","where":[{"field":"amount_minor","op":"gt","value":"lots"}]}`,
+			want: CodeValueTypeMismatch,
+		},
+		"an operand the plan forgot": {
+			doc:  `{"version":"v1","target":"deal","where":[{"field":"name","op":"eq"}]}`,
+			want: CodeValueMissing,
+		},
+		"an empty in-list": {
+			doc:  `{"version":"v1","target":"deal","where":[{"field":"name","op":"in","values":[]}]}`,
+			want: CodeValueMissing,
+		},
+		"a page bigger than the surface serves": {
+			doc:  `{"version":"v1","target":"deal","limit":5000}`,
+			want: CodeLimitOutOfRange,
+		},
+		"a page of nothing": {
+			doc:  `{"version":"v1","target":"deal","limit":0}`,
+			want: CodeLimitOutOfRange,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := validateJSON(ctx, t, tc.doc)
+			if codes := refusalCodes(t, err); !slices.Contains(codes, tc.want) {
+				t.Errorf("refused with %v; want %q", codes, tc.want)
+			}
+		})
+	}
+}
+
+// A plan with several faults names all of them: a caller told about the first
+// of three has to make three round trips to learn what one answer could have
+// carried.
+func TestARefusalNamesEveryFaultInThePlan(t *testing.T) {
+	_, err := validateJSON(readerFor("deal"), t, `{"version":"v1","target":"deal","where":[
+		{"field":"probability","op":"eq","value":"x"},
+		{"field":"name","op":"gt","value":"x"},
+		{"field":"amount_minor","op":"gt","value":"lots"}],"limit":9000}`)
+	codes := refusalCodes(t, err)
+	for _, want := range []string{CodeUnknownField, CodeUnknownOperator, CodeValueTypeMismatch, CodeLimitOutOfRange} {
+		if !slices.Contains(codes, want) {
+			t.Errorf("refusal %v omits %q", codes, want)
+		}
+	}
+}
+
+// SEARCH-AC-16: a real field the caller may not read and an invented one are
+// refused IDENTICALLY. Anything that varied between the two would turn
+// vocabulary probing into field discovery.
+func TestADeniedNameAndAnInventedOneRefuseIdentically(t *testing.T) {
+	// `lead` and `organization` really exist — the contract declares both,
+	// and another principal can read them. `galaxies` and `nebulae` never
+	// existed. This caller must not be able to tell the two apart.
+	ctx := readerFor("deal")
+	for _, tc := range []struct{ name, real, invented, doc string }{
+		{
+			name: "a record type", real: "lead", invented: "galaxies",
+			doc: `{"version":"v1","target":%q}`,
+		},
+		{
+			name: "a relationship hop", real: "organization", invented: "nebulae",
+			doc: `{"version":"v1","target":"deal","traverse":{"relation":%q}}`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, realErr := validateJSON(ctx, t, fmt.Sprintf(tc.doc, tc.real))
+			_, inventedErr := validateJSON(ctx, t, fmt.Sprintf(tc.doc, tc.invented))
+			realFault, inventedFault := singleFault(t, realErr), singleFault(t, inventedErr)
+
+			if realFault.Code != inventedFault.Code {
+				t.Errorf("the real name refused as %q, the invented one as %q; the difference is a discovery channel",
+					realFault.Code, inventedFault.Code)
+			}
+			if realFault.Field != inventedFault.Field {
+				t.Errorf("the refusals point at different paths (%q vs %q)", realFault.Field, inventedFault.Field)
+			}
+			// Both messages quote the caller's OWN token, so they may differ
+			// by exactly that substitution and by nothing else.
+			realShape := strings.ReplaceAll(realFault.Message, quote(tc.real), "<token>")
+			inventedShape := strings.ReplaceAll(inventedFault.Message, quote(tc.invented), "<token>")
+			if realShape != inventedShape {
+				t.Errorf("refusal wording differs beyond the quoted token:\n real:     %s\n invented: %s",
+					realFault.Message, inventedFault.Message)
+			}
+		})
+	}
+}
+
+// The same equivalence on a FIELD the caller cannot read: the custom field
+// exists in the workspace, but not for a caller who cannot read its record
+// type — and the refusal must not say otherwise.
+func TestADeniedRecordTypesFieldIsRefusedAsAnUnknownTarget(t *testing.T) {
+	catalog := stubCatalog{columns: map[string][]fieldcatalog.Column{
+		"deal": {{Name: "cf_margin", Type: fieldcatalog.TypeNumber}},
+	}}
+	validator := NewPlanValidator(NewVocabularyResolver().WithFieldCatalog(catalog))
+
+	plan, err := DecodePlan([]byte(`{"version":"v1","target":"deal","where":[{"field":"cf_margin","op":"gt","value":1}]}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := validator.Validate(readerFor("deal"), plan); err != nil {
+		t.Fatalf("a caller who reads deals cannot ask about the workspace's own deal column: %v", err)
+	}
+	_, err = validator.Validate(readerFor("person"), plan)
+	fault := singleFault(t, err)
+	if fault.Code != CodeUnknownTarget {
+		t.Errorf("a caller who cannot read deals was refused with %q; want %q, which says nothing about what exists",
+			fault.Code, CodeUnknownTarget)
+	}
+}
+
+func singleFault(t *testing.T, err error) apperrors.FieldRefusal {
+	t.Helper()
+	if err == nil {
+		t.Fatal("plan accepted; want a refusal")
+	}
+	faults, ok := err.(apperrors.FieldFaults)
+	if !ok {
+		t.Fatalf("refusal is %T, not the typed clarification", err)
+	}
+	if len(faults.FieldFaults()) != 1 {
+		t.Fatalf("refusal carries %d clarifications; want exactly one", len(faults.FieldFaults()))
+	}
+	return faults.FieldFaults()[0]
+}
+
+// The whole of what v1 admits, in one plan.
+func TestTheThreeThingsV1AdmitsValidate(t *testing.T) {
+	plan, err := validateJSON(readerFor("deal", "organization"), t, `{
+		"version":"v1",
+		"target":"deal",
+		"where":[{"field":"status","op":"eq","value":"open"},
+		         {"field":"amount_minor","op":"gte","value":100000},
+		         {"field":"forecast_category","op":"in","values":["commit","best_case"]}],
+		"similar_to":"manufacturers who churned after a pilot",
+		"traverse":{"relation":"organization","where":[{"field":"address.city","op":"eq","value":"Stuttgart"}]},
+		"limit":25}`)
+	if err != nil {
+		t.Fatalf("the v1 grammar refused a v1 plan: %v", err)
+	}
+	if plan.Limit != 25 {
+		t.Errorf("limit resolved to %d, want 25", plan.Limit)
+	}
+	if plan.Hop == nil || plan.Hop.Target != "organization" || plan.Hop.Via != "organization_id" {
+		t.Errorf("hop resolved to %+v; want the derived organization edge", plan.Hop)
+	}
+	if len(plan.Unavailable) != 0 {
+		t.Errorf("a plan of answerable predicates reports %v unavailable", plan.Unavailable)
+	}
+}
+
+// An absent limit takes the contract default rather than an unbounded scan.
+func TestAPlanWithNoLimitTakesTheContractDefault(t *testing.T) {
+	plan, err := validateJSON(readerFor("deal"), t, `{"version":"v1","target":"deal"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.Limit != 50 {
+		t.Errorf("default page is %d; want the contract's 50", plan.Limit)
+	}
+}
+
+// SEARCH-AC-17: the radius operator is declared, so it is not an unknown
+// operator — and it answers with its unavailability rather than with a
+// ranking that has nothing behind it. City stays an ordinary exact match.
+func TestWithinRadiusValidatesAndAnswersItsUnavailability(t *testing.T) {
+	ctx := readerFor("organization")
+	plan, err := validateJSON(ctx, t, `{"version":"v1","target":"organization",
+		"where":[{"field":"address","op":"within_radius","value":{"center":"Stuttgart","radius_km":50}}]}`)
+	if err != nil {
+		t.Fatalf("a declared operator was refused: %v", err)
+	}
+	if len(plan.Unavailable) != 1 || plan.Unavailable[0].Code != CodeDistanceRankingUnavailable {
+		t.Fatalf("plan reports %v; want one %s note", plan.Unavailable, CodeDistanceRankingUnavailable)
+	}
+	if plan.Unavailable[0].Path != "where[0]" {
+		t.Errorf("the note points at %q rather than the predicate it belongs to", plan.Unavailable[0].Path)
+	}
+
+	exact, err := validateJSON(ctx, t, `{"version":"v1","target":"organization",
+		"where":[{"field":"address.city","op":"eq","value":"Stuttgart"}]}`)
+	if err != nil {
+		t.Fatalf("a city predicate was refused: %v", err)
+	}
+	if len(exact.Unavailable) != 0 {
+		t.Errorf("a city predicate reports %v unavailable; city and region work today", exact.Unavailable)
+	}
+}
+
+// A malformed radius operand is the CALLER's fault and says so, rather than
+// being reported as this deployment's missing capability.
+func TestAMalformedRadiusOperandIsRefusedRatherThanDeclaredUnavailable(t *testing.T) {
+	for name, doc := range map[string]string{
+		"no radius":     `{"center":"Stuttgart"}`,
+		"no center":     `{"radius_km":50}`,
+		"empty center":  `{"center":"","radius_km":50}`,
+		"zero radius":   `{"center":"Stuttgart","radius_km":0}`,
+		"a bare string": `"Stuttgart"`,
+		"an extra knob": `{"center":"Stuttgart","radius_km":50,"unit":"miles"}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := validateJSON(readerFor("organization"), t,
+				`{"version":"v1","target":"organization","where":[{"field":"address","op":"within_radius","value":`+doc+`}]}`)
+			if codes := refusalCodes(t, err); !slices.Contains(codes, CodeValueTypeMismatch) {
+				t.Errorf("refused with %v; want %q", codes, CodeValueTypeMismatch)
+			}
+		})
+	}
+}
+
+// The classifier explains; it never admits. Whatever it thinks of a token,
+// the token is already out of the vocabulary by the time it is consulted.
+func TestTheClassifierOnlyExplainsARefusalItDidNotCause(t *testing.T) {
+	// A field named exactly like a SQL keyword IS in the vocabulary when the
+	// contract declares it, and the classifier's opinion never gets asked.
+	plan, err := validateJSON(readerFor("activity"), t,
+		`{"version":"v1","target":"activity","where":[{"field":"source","op":"eq","value":"import"}]}`)
+	if err != nil {
+		t.Fatalf("a legitimate contract field was refused: %v", err)
+	}
+	if len(plan.Plan.Where) != 1 {
+		t.Fatalf("validated plan carries %d predicates", len(plan.Plan.Where))
+	}
+	// And a token the classifier has no opinion about is still refused,
+	// because membership — not shape — is what decides.
+	_, err = validateJSON(readerFor("activity"), t,
+		`{"version":"v1","target":"activity","where":[{"field":"innocent_looking_name","op":"eq","value":"x"}]}`)
+	if codes := refusalCodes(t, err); !slices.Contains(codes, CodeUnknownField) {
+		t.Errorf("an unrecognised but harmless-looking token was refused with %v; want %q", codes, CodeUnknownField)
+	}
+}
+
+func TestClassifyNamesTheShapeOfARefusedToken(t *testing.T) {
+	for token, want := range map[string]string{
+		"amount_minor":          CodeUnknownField,
+		"address.city":          CodeUnknownField,
+		"name; DROP TABLE deal": CodeSQLFragment,
+		"1 UNION SELECT 1":      CodeSQLFragment,
+		"name -- comment":       CodeSQLFragment,
+		"/* hi */ name":         CodeSQLFragment,
+		"amount * 2":            CodeFreeExpression,
+		"UPPER(name)":           CodeFreeExpression,
+		"Name":                  CodeFreeExpression,
+		"a.b.c":                 CodeFreeExpression,
+	} {
+		if got := classify(token, CodeUnknownField); got != want {
+			t.Errorf("classify(%q) = %q, want %q", token, got, want)
+		}
+	}
+}
+
+// A traversal's predicates are checked against the vocabulary of the record
+// the hop LANDS on, not the one it started from.
+func TestAHopsPredicatesAreCheckedAgainstTheHopsTarget(t *testing.T) {
+	ctx := readerFor("deal", "organization")
+	if _, err := validateJSON(ctx, t, `{"version":"v1","target":"deal",
+		"traverse":{"relation":"organization","where":[{"field":"industry","op":"eq","value":"manufacturing"}]}}`); err != nil {
+		t.Fatalf("an organization field was refused inside an organization hop: %v", err)
+	}
+	_, err := validateJSON(ctx, t, `{"version":"v1","target":"deal",
+		"traverse":{"relation":"organization","where":[{"field":"amount_minor","op":"gt","value":1}]}}`)
+	if codes := refusalCodes(t, err); !slices.Contains(codes, CodeUnknownField) {
+		t.Errorf("a deal field inside an organization hop was refused with %v; want %q", codes, CodeUnknownField)
+	}
+}
+
+// The decoder never drops what it does not recognise: a plan carrying an
+// unknown member comes back refused, not silently reduced to the members that
+// happened to fit.
+func TestTheDecoderRefusesRatherThanDropsAnUnknownMember(t *testing.T) {
+	_, err := DecodePlan([]byte(`{"version":"v1","target":"deal","where":[{"field":"name","op":"eq","value":"x","collate":"C"}]}`))
+	fault := singleFault(t, err)
+	if fault.Code != CodeUnknownPlanMember {
+		t.Errorf("an unknown predicate member was refused as %q; want %q", fault.Code, CodeUnknownPlanMember)
+	}
+	if !strings.Contains(fault.Message, "collate") {
+		t.Errorf("the refusal does not name the member the caller has to remove: %q", fault.Message)
+	}
+}
+
+// A refusal reaching an untrusted agent must not carry internals. The
+// messages quote the caller's own tokens and name the published vocabulary;
+// nothing else.
+func TestARefusalCarriesNoServerInternals(t *testing.T) {
+	_, err := validateJSON(readerFor("deal"), t,
+		`{"version":"v1","target":"deal","where":[{"field":"probability","op":"eq","value":"x"}]}`)
+	fault := singleFault(t, err)
+	for _, leak := range []string{"pgx", "SELECT", "workspace_id", "internal/", "sql:"} {
+		if strings.Contains(fault.Message, leak) {
+			t.Errorf("refusal message leaks %q: %s", leak, fault.Message)
+		}
+	}
+	if !strings.Contains(fault.Message, QuerySchemaURI) {
+		t.Errorf("refusal does not point at the published vocabulary: %s", fault.Message)
+	}
+}
+
+// A validated plan is the only thing an executor may run, so it carries the
+// resolved vocabulary rather than leaving the executor to re-derive it from
+// the plan's text.
+func TestAValidatedPlanCarriesWhatTheExecutorNeeds(t *testing.T) {
+	plan, err := validateJSON(readerFor("deal", "organization"), t,
+		`{"version":"v1","target":"deal","traverse":{"relation":"organization"}}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.Target.Target != "deal" {
+		t.Errorf("validated plan carries target %q", plan.Target.Target)
+	}
+	if len(plan.Target.Fields) == 0 {
+		t.Error("validated plan carries no resolved field set")
+	}
+	if plan.Hop == nil || plan.Hop.Via == "" {
+		t.Error("validated plan carries a hop with no derived join")
+	}
+}
+
+// The refusal renders through the shared fault interface, which is what makes
+// it legible on REST and on the tool surface without either hand-writing a
+// mapping.
+func TestARefusalIsTheSharedPluralFaultForm(t *testing.T) {
+	var refusal error = &PlanRefusal{Refusals: []apperrors.FieldRefusal{
+		{Field: "where[0].field", Code: CodeUnknownField, Message: "no"},
+	}}
+	if _, ok := refusal.(apperrors.FieldFaults); !ok {
+		t.Fatal("PlanRefusal is not the plural fault form")
+	}
+	if !strings.Contains(refusal.Error(), CodeUnknownField) {
+		t.Errorf("the log summary does not name the code: %s", refusal.Error())
+	}
+}
+
+// json.RawMessage operands round-trip: an operand this validator accepted is
+// the operand the executor will bind, byte for byte.
+func TestAnAcceptedOperandSurvivesValidationUnchanged(t *testing.T) {
+	plan, err := validateJSON(readerFor("deal"), t,
+		`{"version":"v1","target":"deal","where":[{"field":"amount_minor","op":"gte","value":100000}]}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got int64
+	if err := json.Unmarshal(plan.Plan.Where[0].Value, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got != 100000 {
+		t.Errorf("operand survived validation as %d", got)
+	}
+}
+
+// An operand member the operator does not read is refused rather than
+// ignored: a caller who filled `values` under `eq` meant the list, and
+// answering on `value` instead answers a question they did not ask.
+func TestTheOperandMemberAnOperatorDoesNotReadIsRefused(t *testing.T) {
+	for name, doc := range map[string]string{
+		"a list under eq":  `{"field":"name","op":"eq","value":"a","values":["a","b"]}`,
+		"a value under in": `{"field":"name","op":"in","value":"a","values":["a"]}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := validateJSON(readerFor("deal"), t,
+				`{"version":"v1","target":"deal","where":[`+doc+`]}`)
+			if codes := refusalCodes(t, err); !slices.Contains(codes, CodeValueNotApplicable) {
+				t.Errorf("refused with %v; want %q", codes, CodeValueNotApplicable)
+			}
+		})
+	}
+}
+
+// A plan that names nothing at all is refused as a missing name, not as an
+// expression — calling it one would send the caller looking for an expression
+// they never wrote.
+func TestAnOmittedNameIsRefusedAsMissingRatherThanAsAnExpression(t *testing.T) {
+	fault := singleFault(t, mustRefuse(readerFor("deal"), t, `{"version":"v1"}`))
+	if fault.Code != CodeUnknownTarget {
+		t.Errorf("a plan with no target was refused as %q; want %q", fault.Code, CodeUnknownTarget)
+	}
+}
+
+func mustRefuse(ctx context.Context, t *testing.T, doc string) error {
+	t.Helper()
+	_, err := validateJSON(ctx, t, doc)
+	return err
+}
+
+// A repeated member is refused rather than resolved. encoding/json takes the
+// LAST value in silence, so a plan carrying two `where` lists would validate
+// on the second and drop the caller's actual question — an answer that looks
+// exactly like every other answer, which is what SEARCH-AC-14 forbids.
+func TestARepeatedMemberIsRefusedRatherThanResolvedLastWins(t *testing.T) {
+	for name, doc := range map[string]string{
+		"two where lists": `{"version":"v1","target":"deal",
+			"where":[{"field":"status","op":"eq","value":"open"}],"where":[]}`,
+		"two targets": `{"version":"v1","target":"deal","target":"person"}`,
+		"a repeat inside a predicate": `{"version":"v1","target":"deal",
+			"where":[{"field":"status","field":"name","op":"eq","value":"x"}]}`,
+		"a repeat inside a traversal": `{"version":"v1","target":"deal",
+			"traverse":{"relation":"organization","relation":"project"}}`,
+		"a repeat inside a nested predicate": `{"version":"v1","target":"deal",
+			"traverse":{"relation":"organization","where":[{"field":"industry","op":"eq","op":"neq","value":"x"}]}}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := validateJSON(readerFor("deal", "organization", "person"), t, doc)
+			if codes := refusalCodes(t, err); !slices.Contains(codes, CodeDuplicateMember) {
+				t.Errorf("refused with %v; want %q", codes, CodeDuplicateMember)
+			}
+		})
+	}
+}
+
+// The same member name in DIFFERENT objects is ordinary, not a duplicate —
+// every predicate names a `field`, and a scan that refused that would refuse
+// every plan with two clauses.
+func TestTheSameMemberInDifferentObjectsIsNotADuplicate(t *testing.T) {
+	plan, err := validateJSON(readerFor("deal", "organization"), t, `{"version":"v1","target":"deal",
+		"where":[{"field":"status","op":"eq","value":"open"},{"field":"name","op":"eq","value":"x"}],
+		"traverse":{"relation":"organization","where":[{"field":"industry","op":"eq","value":"y"}]}}`)
+	if err != nil {
+		t.Fatalf("a plan with repeated member names across separate objects was refused: %v", err)
+	}
+	if len(plan.Plan.Where) != 2 {
+		t.Errorf("validated plan carries %d predicates, want 2", len(plan.Plan.Where))
+	}
+}
+
+// A malformed document is reported ONCE, by the decode that follows — the
+// duplicate scan must not turn a syntax error into a second spelling of the
+// same refusal.
+func TestTheDuplicateScanLeavesMalformedDocumentsToTheDecoder(t *testing.T) {
+	fault := singleFault(t, mustRefuse(readerFor("deal"), t, `{"version":"v1","target":`))
+	if fault.Code != CodeMalformedPlan {
+		t.Errorf("a truncated document was refused as %q; want %q", fault.Code, CodeMalformedPlan)
+	}
+}

--- a/backend/internal/modules/search/queryvocab.go
+++ b/backend/internal/modules/search/queryvocab.go
@@ -1,0 +1,282 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package search
+
+// The resolved query vocabulary: what a plan may name, for ONE caller, right
+// now (SEARCH-PARAM-7). It is composed rather than stored, from three sources
+// that each already answer their part of the question:
+//
+//   - the generated contract types, for the core fields (queryfields.go);
+//   - the live custom-field catalog, through the fieldcatalog seam, for the
+//     workspace's own columns;
+//   - object RBAC, for which record types this principal may read at all.
+//
+// Nothing here is a list to maintain, which is the property SEARCH-AC-15
+// tests: a custom field added is askable on the next resolve and a retired
+// one is gone, with no edit anywhere.
+//
+// The RBAC filter is what makes the vocabulary PER-CALLER (SEARCH-AC-16). A
+// record type the principal cannot read contributes no fields and no
+// relations, so naming one of its fields is refused exactly as an invented
+// name is — same code, same wording. A vocabulary that refused it differently
+// would be a field-discovery channel: probe until the wording changes.
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/fieldcatalog"
+)
+
+// FieldKind is the closed set of value shapes a predicate operand can have.
+// A field's kind decides its operators, so this set and the operator sets
+// below are the whole of what "op" may say.
+type FieldKind string
+
+// The seven kinds. Each maps onto one operator set below, and a field's kind
+// is derived from its declared type — never chosen.
+const (
+	KindText      FieldKind = "text"
+	KindNumber    FieldKind = "number"
+	KindBoolean   FieldKind = "boolean"
+	KindDate      FieldKind = "date"
+	KindTimestamp FieldKind = "timestamp"
+	KindID        FieldKind = "id"
+	// KindGeo is a place rather than a value: the operand `within_radius`
+	// measures from. It admits no exact operator — a place does not compare
+	// equal to anything — and its component values are askable as ordinary
+	// text through the nested leaves (`address.city`).
+	KindGeo FieldKind = "geo"
+)
+
+// The operators a plan may name. Named once so the operator sets, the validator and the
+// published document cannot disagree about their spelling.
+const (
+	OpEq           = "eq"
+	OpNeq          = "neq"
+	OpIn           = "in"
+	OpLt           = "lt"
+	OpLte          = "lte"
+	OpGt           = "gt"
+	OpGte          = "gte"
+	OpWithinRadius = "within_radius"
+)
+
+// operatorsByKind derives a field's operators from its kind. Ordered types
+// add the four comparisons; a boolean admits equality alone (`neq true` is
+// `eq false`, and offering both invites a plan that says the same thing two
+// ways); a place admits only the radius operator.
+var operatorsByKind = map[FieldKind][]string{
+	KindText:      {OpEq, OpNeq, OpIn},
+	KindID:        {OpEq, OpNeq, OpIn},
+	KindBoolean:   {OpEq},
+	KindNumber:    {OpEq, OpNeq, OpIn, OpLt, OpLte, OpGt, OpGte},
+	KindDate:      {OpEq, OpNeq, OpIn, OpLt, OpLte, OpGt, OpGte},
+	KindTimestamp: {OpEq, OpNeq, OpIn, OpLt, OpLte, OpGt, OpGte},
+	KindGeo:       {OpWithinRadius},
+}
+
+// Field is one member of the resolved vocabulary.
+type Field struct {
+	Name string
+	Kind FieldKind
+	// Ops is derived from Kind at construction. It is carried rather than
+	// re-derived on every check so the published document and the validator
+	// read the same value, not two computations of it.
+	Ops []string
+}
+
+// newField is the ONE way a Field comes into existence, so a field whose
+// operators disagree with its kind is unrepresentable.
+func newField(name string, kind FieldKind) Field {
+	return Field{Name: name, Kind: kind, Ops: operatorsByKind[kind]}
+}
+
+// Relation is one depth-1 hop.
+type Relation struct {
+	// Name is what a plan says; Target the record type the hop lands on,
+	// whose vocabulary the hop's predicates are checked against.
+	Name   string
+	Target string
+	// Via names the contract reference the edge is derived from. It is
+	// published so a caller can see WHY a hop exists, and it is what E2
+	// executes the join on.
+	Via string
+}
+
+// TargetVocabulary is everything askable about one record type.
+type TargetVocabulary struct {
+	Target    string
+	Fields    []Field
+	Relations []Relation
+}
+
+// Field answers the named field, and false when this caller may not name it.
+func (v TargetVocabulary) Field(name string) (Field, bool) {
+	i := slices.IndexFunc(v.Fields, func(f Field) bool { return f.Name == name })
+	if i < 0 {
+		return Field{}, false
+	}
+	return v.Fields[i], true
+}
+
+// Relation answers the named hop, and false when this caller may not take it.
+func (v TargetVocabulary) Relation(name string) (Relation, bool) {
+	i := slices.IndexFunc(v.Relations, func(r Relation) bool { return r.Name == name })
+	if i < 0 {
+		return Relation{}, false
+	}
+	return v.Relations[i], true
+}
+
+// Vocabulary is the resolved surface for one caller.
+type Vocabulary struct {
+	Version string
+	Targets []TargetVocabulary
+}
+
+// Target answers one record type's vocabulary, and false when the caller may
+// not read that type (or when no such type exists — indistinguishable by
+// design).
+func (v Vocabulary) Target(name string) (TargetVocabulary, bool) {
+	i := slices.IndexFunc(v.Targets, func(t TargetVocabulary) bool { return t.Target == name })
+	if i < 0 {
+		return TargetVocabulary{}, false
+	}
+	return v.Targets[i], true
+}
+
+// TargetNames lists the record types this caller may ask about, in order.
+// It is safe to disclose: they are exactly what the caller can already read.
+func (v Vocabulary) TargetNames() []string {
+	names := make([]string, len(v.Targets))
+	for i, t := range v.Targets {
+		names[i] = t.Target
+	}
+	return names
+}
+
+// VocabularyResolver composes the vocabulary for whoever is bound to the
+// context. It holds no cache: the catalog changes under it (a field is
+// retired mid-session) and RBAC changes under it (a passport is demoted), and
+// a cached vocabulary would keep answering with the surface as it was.
+type VocabularyResolver struct {
+	catalog fieldcatalog.Reader
+}
+
+// NewVocabularyResolver builds a resolver over the core contract fields
+// alone. Without a field catalog it is still correct, just narrower — the
+// same nil-seam pass-through every record store uses.
+func NewVocabularyResolver() *VocabularyResolver { return &VocabularyResolver{} }
+
+// WithFieldCatalog wires the custom-field half of the vocabulary.
+func (r *VocabularyResolver) WithFieldCatalog(catalog fieldcatalog.Reader) *VocabularyResolver {
+	r.catalog = catalog
+	return r
+}
+
+// Resolve composes the vocabulary for the caller bound to ctx, restricted to
+// the named record types (all of them when none are named, which is what the
+// published document asks for).
+//
+// Naming the types matters for cost, not for correctness: the validator
+// resolves the one or two a plan actually mentions, so a plan costs at most
+// two catalog reads rather than one per searchable entity.
+func (r *VocabularyResolver) Resolve(ctx context.Context, targets ...string) (Vocabulary, error) {
+	vocab := Vocabulary{Version: PlanVersion}
+	for _, branch := range searchBranches {
+		if len(targets) > 0 && !slices.Contains(targets, branch.entity) {
+			continue
+		}
+		if auth.Require(ctx, branch.entity, principal.ActionRead) != nil {
+			continue
+		}
+		target, err := r.resolveTarget(ctx, branch.entity)
+		if err != nil {
+			return Vocabulary{}, err
+		}
+		vocab.Targets = append(vocab.Targets, target)
+	}
+	return vocab, nil
+}
+
+// resolveTarget composes one record type's vocabulary from its contract
+// fields, its live custom columns and its derived relations.
+func (r *VocabularyResolver) resolveTarget(ctx context.Context, entity string) (TargetVocabulary, error) {
+	record, ok := contractRecords[entity]
+	if !ok {
+		// A searchable entity with no contract binding is a wiring defect,
+		// not a caller error: the fitness function fails on it, so reaching
+		// here means the check was removed rather than that the plan was bad.
+		return TargetVocabulary{}, fmt.Errorf("search: searchable entity %q has no contract record binding", entity)
+	}
+	fields := contractFields(record)
+	custom, err := r.customFields(ctx, entity)
+	if err != nil {
+		return TargetVocabulary{}, err
+	}
+	fields = append(fields, custom...)
+	slices.SortFunc(fields, func(a, b Field) int { return strings.Compare(a.Name, b.Name) })
+
+	relations := append(contractRelations(entity, fields), inverseRelations(entity)...)
+	relations = r.admittedRelations(ctx, relations)
+	slices.SortFunc(relations, func(a, b Relation) int { return strings.Compare(a.Name, b.Name) })
+
+	return TargetVocabulary{Target: entity, Fields: fields, Relations: relations}, nil
+}
+
+// admittedRelations drops the hops that land on a record type this caller may
+// not read. A hop is a read of the record it lands on, so admitting it would
+// let a plan filter deals by an organization the caller cannot see — and the
+// result count would disclose what the row scope hides.
+func (r *VocabularyResolver) admittedRelations(ctx context.Context, relations []Relation) []Relation {
+	return slices.DeleteFunc(relations, func(rel Relation) bool {
+		return auth.Require(ctx, rel.Target, principal.ActionRead) != nil
+	})
+}
+
+// customFields reads the workspace's live custom columns for this record type
+// through the fieldcatalog seam and gives each the kind its declared type
+// maps onto. The wire name IS the column name (`cf_priority`) — the same key
+// the record's own JSON carries — so a caller asks for a custom field with
+// the name it already reads back.
+func (r *VocabularyResolver) customFields(ctx context.Context, entity string) ([]Field, error) {
+	if r.catalog == nil {
+		return nil, nil
+	}
+	columns, err := r.catalog.ActiveColumns(ctx, entity)
+	if err != nil {
+		return nil, fmt.Errorf("search: resolving custom-field vocabulary for %s: %w", entity, err)
+	}
+	fields := make([]Field, 0, len(columns))
+	for _, c := range columns {
+		kind, ok := customFieldKinds[c.Type]
+		if !ok {
+			// A catalog type this vocabulary has no operators for is left
+			// OUT rather than admitted with a guessed operator set: an
+			// unasked field is a smaller failure than one that answers the
+			// wrong comparison.
+			continue
+		}
+		fields = append(fields, newField(c.Name, kind))
+	}
+	return fields, nil
+}
+
+// customFieldKinds maps the six closed custom-field types onto this
+// vocabulary's kinds. Both sets are closed and neither is this file's to
+// extend: a seventh custom-field type arrives with its own entry, and the
+// fitness function fails until it has one.
+var customFieldKinds = map[string]FieldKind{
+	fieldcatalog.TypeText:     KindText,
+	fieldcatalog.TypeNumber:   KindNumber,
+	fieldcatalog.TypeDate:     KindDate,
+	fieldcatalog.TypeCurrency: KindNumber,
+	fieldcatalog.TypePicklist: KindText,
+	fieldcatalog.TypeBoolean:  KindBoolean,
+}

--- a/backend/internal/modules/search/queryvocab.go
+++ b/backend/internal/modules/search/queryvocab.go
@@ -93,8 +93,14 @@ type Field struct {
 
 // newField is the ONE way a Field comes into existence, so a field whose
 // operators disagree with its kind is unrepresentable.
+//
+// Ops is CLONED off the kind's set. A Field travels out of this package — the
+// published document and any future executor both read it — and handing out
+// the map's own slice would let one caller's edit rewrite what every field of
+// that kind admits, for every later caller. Cloning here is the same defence
+// contractFields applies to the field list itself.
 func newField(name string, kind FieldKind) Field {
-	return Field{Name: name, Kind: kind, Ops: operatorsByKind[kind]}
+	return Field{Name: name, Kind: kind, Ops: slices.Clone(operatorsByKind[kind])}
 }
 
 // Relation is one depth-1 hop.

--- a/backend/internal/modules/search/queryvocab_test.go
+++ b/backend/internal/modules/search/queryvocab_test.go
@@ -409,3 +409,20 @@ func TestOneResolvesCustomColumnsDoNotLeakIntoTheNext(t *testing.T) {
 		}
 	}
 }
+
+// A Field travels out of this package, so its operator set must not be the
+// shared map's own slice — one caller's edit would rewrite what every field
+// of that kind admits, for every later caller.
+func TestAFieldsOperatorsAreNotTheSharedSetItself(t *testing.T) {
+	first := newField("a", KindNumber)
+	if len(first.Ops) == 0 {
+		t.Fatal("a number field admits no operators")
+	}
+	if &first.Ops[0] == &operatorsByKind[KindNumber][0] {
+		t.Fatal("a Field hands out the kind's own operator slice; a caller's edit would reach every other field")
+	}
+	first.Ops[0] = "mutated"
+	if newField("b", KindNumber).Ops[0] == "mutated" {
+		t.Error("editing one field's operators changed what the next field admits")
+	}
+}

--- a/backend/internal/modules/search/queryvocab_test.go
+++ b/backend/internal/modules/search/queryvocab_test.go
@@ -1,0 +1,411 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package search
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/fieldcatalog"
+)
+
+// readerFor builds a context whose principal may read exactly the named
+// record types and nothing else.
+func readerFor(objects ...string) context.Context {
+	grants := map[string]principal.ObjectGrant{}
+	for _, o := range objects {
+		grants[o] = principal.ObjectGrant{Read: true}
+	}
+	return principal.WithActor(context.Background(), principal.Principal{
+		Type:        principal.PrincipalHuman,
+		ID:          "human:test",
+		Permissions: principal.Permissions{Objects: grants, RowScope: principal.RowScopeAll},
+	})
+}
+
+// stubCatalog is the fieldcatalog seam, so a test can add and retire a custom
+// field without a database. The seam is the boundary; mocking it is what
+// mocking a boundary is for.
+type stubCatalog struct {
+	columns map[string][]fieldcatalog.Column
+	err     error
+}
+
+func (c stubCatalog) ActiveColumns(_ context.Context, object string) ([]fieldcatalog.Column, error) {
+	if c.err != nil {
+		return nil, c.err
+	}
+	return c.columns[object], nil
+}
+
+// SEARCH-AC-15's first half, as a fitness function: the vocabulary is a
+// derivation of the contract, not a list beside it. The walk here is
+// deliberately a SECOND, independent implementation of the rule — every
+// scalar json member of the contract record is askable — so a resolver that
+// grew a hand-maintained list would disagree with it the moment the contract
+// moved, which is the failure this criterion asks to be impossible to miss.
+func TestVocabularyIsDerivedFromTheContractNotAList(t *testing.T) {
+	resolver := NewVocabularyResolver()
+	for entity, record := range contractRecords {
+		vocab, err := resolver.Resolve(readerFor(entity), entity)
+		if err != nil {
+			t.Fatalf("%s: %v", entity, err)
+		}
+		target, ok := vocab.Target(entity)
+		if !ok {
+			t.Fatalf("%s: readable record type absent from its own vocabulary", entity)
+		}
+		for _, want := range independentlyDerivedScalars(record) {
+			if _, ok := target.Field(want); !ok {
+				t.Errorf("%s: contract member %q is not in the vocabulary; the vocabulary is not derived from the contract", entity, want)
+			}
+		}
+		for _, got := range target.Fields {
+			if strings.HasPrefix(got.Name, "cf_") {
+				continue
+			}
+			if !slices.Contains(independentlyDerivedScalars(record), got.Name) && got.Kind != KindGeo {
+				t.Errorf("%s: vocabulary offers %q, which the contract does not declare as a scalar", entity, got.Name)
+			}
+		}
+	}
+}
+
+// The fitness function above shares scalarKind with production, so a
+// mis-classification INSIDE it is invisible to both. These are the anchors
+// that pin it: a known field of each kind, by name, with the operator set its
+// kind must give it. Delete the time.Time identity check and every timestamp
+// silently leaves every vocabulary — this is what notices.
+func TestKnownFieldsResolveToTheKindTheirContractTypeGivesThem(t *testing.T) {
+	vocab, err := NewVocabularyResolver().Resolve(readerFor("deal"), "deal")
+	if err != nil {
+		t.Fatal(err)
+	}
+	deal, _ := vocab.Target("deal")
+	for _, want := range []struct {
+		name string
+		kind FieldKind
+		op   string
+	}{
+		{"created_at", KindTimestamp, OpGt},      // time.Time — a struct
+		{"expected_close_date", KindDate, OpLte}, // openapi_types.Date — a struct
+		{"id", KindID, OpIn},                     // openapi_types.UUID — an array
+		{"amount_minor", KindNumber, OpGte},      // *int64
+		{"name", KindText, OpEq},                 // string
+		{"close_date_provisional", KindBoolean, OpEq},
+		{"version", KindNumber, OpGt}, // RowVersion — an int64 alias
+	} {
+		field, ok := deal.Field(want.name)
+		if !ok {
+			t.Errorf("deal.%s is not in the vocabulary at all", want.name)
+			continue
+		}
+		if field.Kind != want.kind {
+			t.Errorf("deal.%s resolved as kind %q, want %q", want.name, field.Kind, want.kind)
+		}
+		if !slices.Contains(field.Ops, want.op) {
+			t.Errorf("deal.%s (%s) does not admit %q; its ops are %v", want.name, field.Kind, want.op, field.Ops)
+		}
+	}
+}
+
+// Every relation any record declares must be resolvable by the validator's
+// narrowing pass, or a published hop refuses for a caller who may take it.
+// The two are derived by separate rules (relation NAMING vs the name→target
+// guess), and this is what keeps them in agreement — renaming one without the
+// other fails here rather than in production.
+func TestEveryDerivedRelationNameIsResolvableByTheValidatorsNarrowing(t *testing.T) {
+	everything := make([]string, 0, len(contractRecords))
+	for entity := range contractRecords {
+		everything = append(everything, entity)
+	}
+	vocab, err := NewVocabularyResolver().Resolve(readerFor(everything...))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, target := range vocab.Targets {
+		for _, relation := range target.Relations {
+			narrowed := hopTargets(Plan{Traverse: &Traversal{Relation: relation.Name}})
+			if !slices.Contains(narrowed, relation.Target) {
+				t.Errorf("%s declares hop %q onto %q, but the validator's narrowing resolves it to %v",
+					target.Target, relation.Name, relation.Target, narrowed)
+			}
+		}
+	}
+}
+
+// independentlyDerivedScalars re-derives the expected field names from the
+// contract type without using the production walk.
+func independentlyDerivedScalars(t reflect.Type) []string {
+	var names []string
+	for i := range t.NumField() {
+		member := t.Field(i)
+		tag := member.Tag.Get("json")
+		name, _, _ := strings.Cut(tag, ",")
+		if !member.IsExported() || name == "" || name == "-" {
+			continue
+		}
+		inner := member.Type
+		if inner.Kind() == reflect.Pointer {
+			inner = inner.Elem()
+		}
+		if _, scalar := scalarKind(inner); scalar {
+			names = append(names, name)
+			continue
+		}
+		if inner.Kind() != reflect.Struct {
+			continue
+		}
+		for j := range inner.NumField() {
+			leaf := inner.Field(j)
+			leafName, _, _ := strings.Cut(leaf.Tag.Get("json"), ",")
+			if !leaf.IsExported() || leafName == "" || leafName == "-" {
+				continue
+			}
+			leafType := leaf.Type
+			if leafType.Kind() == reflect.Pointer {
+				leafType = leafType.Elem()
+			}
+			if _, scalar := scalarKind(leafType); scalar {
+				names = append(names, name+"."+leafName)
+			}
+		}
+	}
+	return names
+}
+
+// SEARCH-AC-15's second half: the custom-field catalog moves and the
+// vocabulary moves with it, with no edit anywhere.
+func TestACustomFieldEntersAndLeavesTheVocabularyWithTheCatalog(t *testing.T) {
+	catalog := stubCatalog{columns: map[string][]fieldcatalog.Column{
+		"deal": {{Name: "cf_renewal_risk", Type: fieldcatalog.TypePicklist}},
+	}}
+	ctx := readerFor("deal")
+
+	added, err := NewVocabularyResolver().WithFieldCatalog(catalog).Resolve(ctx, "deal")
+	if err != nil {
+		t.Fatal(err)
+	}
+	deal, _ := added.Target("deal")
+	field, ok := deal.Field("cf_renewal_risk")
+	if !ok {
+		t.Fatal("a custom field active in the catalog is not askable")
+	}
+	if field.Kind != KindText || !slices.Contains(field.Ops, OpIn) {
+		t.Errorf("picklist custom field resolved as %q with ops %v; want a text field admitting %q", field.Kind, field.Ops, OpIn)
+	}
+
+	retired, err := NewVocabularyResolver().WithFieldCatalog(stubCatalog{}).Resolve(ctx, "deal")
+	if err != nil {
+		t.Fatal(err)
+	}
+	deal, _ = retired.Target("deal")
+	if _, ok := deal.Field("cf_renewal_risk"); ok {
+		t.Error("a retired custom field is still askable; the vocabulary is cached or maintained rather than derived")
+	}
+}
+
+// SEARCH-AC-16: the vocabulary is per-caller, and what one caller cannot read
+// is simply absent for them rather than refused differently.
+func TestARecordTypeTheCallerCannotReadIsAbsentFromTheirVocabulary(t *testing.T) {
+	resolver := NewVocabularyResolver()
+
+	wide, err := resolver.Resolve(readerFor("deal", "organization"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := wide.Target("deal"); !ok {
+		t.Fatal("a readable record type is missing from the vocabulary")
+	}
+
+	narrow, err := resolver.Resolve(readerFor("organization"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := narrow.Target("deal"); ok {
+		t.Error("a record type the caller cannot read is in their vocabulary")
+	}
+	if slices.Contains(narrow.TargetNames(), "deal") {
+		t.Error("a record type the caller cannot read is advertised in their target list")
+	}
+}
+
+// A hop is a read of what it lands on, so a relation into a denied record
+// type is not offered — otherwise a plan could filter by rows the caller
+// cannot see and learn their contents from the count.
+func TestAHopIntoADeniedRecordTypeIsNotOffered(t *testing.T) {
+	resolver := NewVocabularyResolver()
+
+	both, err := resolver.Resolve(readerFor("deal", "organization"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	deal, _ := both.Target("deal")
+	if _, ok := deal.Relation("organization"); !ok {
+		t.Fatal("deal declares organization_id but the hop is not offered to a caller who reads both")
+	}
+
+	dealOnly, err := resolver.Resolve(readerFor("deal"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	deal, _ = dealOnly.Target("deal")
+	if _, ok := deal.Relation("organization"); ok {
+		t.Error("a hop into a record type the caller cannot read is offered")
+	}
+}
+
+// The inverse edge is derived too: organization never declares a deal
+// reference, but deal declares one to it.
+func TestTheInverseOfADeclaredReferenceIsTraversable(t *testing.T) {
+	vocab, err := NewVocabularyResolver().Resolve(readerFor("deal", "organization"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	org, _ := vocab.Target("organization")
+	relation, ok := org.Relation("deals")
+	if !ok {
+		t.Fatal("organization has no inverse hop for deal.organization_id")
+	}
+	if relation.Target != "deal" || relation.Via != "deal.organization_id" {
+		t.Errorf("inverse hop resolved to %+v; want a deal hop via deal.organization_id", relation)
+	}
+}
+
+// Every searchable entity must have a contract binding, or its vocabulary
+// cannot be derived at all. This is the check that fails when a seventh
+// searchable entity is added without one — the alternative being a runtime
+// error on the first plan that names it.
+func TestEverySearchableEntityHasAContractBinding(t *testing.T) {
+	for _, branch := range searchBranches {
+		if contractRecords[branch.entity] == nil {
+			t.Errorf("searchable entity %q has no contract record binding, so no vocabulary can be derived for it", branch.entity)
+		}
+	}
+	for entity := range contractRecords {
+		if !slices.ContainsFunc(searchBranches, func(b searchBranch) bool { return b.entity == entity }) {
+			t.Errorf("contract binding %q names an entity this module does not search", entity)
+		}
+	}
+}
+
+// The six closed custom-field types must each map onto a kind, or a
+// workspace's own column silently vanishes from its vocabulary.
+func TestEveryCustomFieldTypeHasAVocabularyKind(t *testing.T) {
+	for _, declared := range []string{
+		fieldcatalog.TypeText, fieldcatalog.TypeNumber, fieldcatalog.TypeDate,
+		fieldcatalog.TypeCurrency, fieldcatalog.TypePicklist, fieldcatalog.TypeBoolean,
+	} {
+		kind, ok := customFieldKinds[declared]
+		if !ok {
+			t.Errorf("custom-field type %q has no vocabulary kind, so a workspace column of that type is unaskable", declared)
+			continue
+		}
+		if len(operatorsByKind[kind]) == 0 {
+			t.Errorf("custom-field type %q maps to kind %q, which admits no operators", declared, kind)
+		}
+	}
+}
+
+// Every kind a field can carry must admit at least one operator, or a field
+// of that kind is in the vocabulary and unusable.
+func TestEveryFieldKindAdmitsAnOperator(t *testing.T) {
+	for _, kind := range []FieldKind{KindText, KindNumber, KindBoolean, KindDate, KindTimestamp, KindID, KindGeo} {
+		if len(newField("x", kind).Ops) == 0 {
+			t.Errorf("kind %q admits no operator", kind)
+		}
+	}
+}
+
+// A catalog fault is reported, never swallowed into a narrower vocabulary: a
+// silently smaller vocabulary refuses a legitimate field as unknown, which
+// reads to the caller exactly like a plan they got wrong.
+func TestACatalogFaultRefusesTheResolveRatherThanNarrowingIt(t *testing.T) {
+	boom := errors.New("catalog unavailable")
+	_, err := NewVocabularyResolver().WithFieldCatalog(stubCatalog{err: boom}).Resolve(readerFor("deal"), "deal")
+	if !errors.Is(err, boom) {
+		t.Fatalf("resolve returned %v; want the catalog fault", err)
+	}
+}
+
+// Collections and free-form blobs carry no single value, so no operator here
+// could mean anything against them.
+func TestCollectionsAndBlobsAreNotAskable(t *testing.T) {
+	vocab, err := NewVocabularyResolver().Resolve(readerFor("person"), "person")
+	if err != nil {
+		t.Fatal(err)
+	}
+	person, _ := vocab.Target("person")
+	for _, name := range []string{"emails", "phones", "raw", "social", "consent"} {
+		if _, ok := person.Field(name); ok {
+			t.Errorf("%q is askable, but it carries a collection or a free-form blob rather than a value", name)
+		}
+	}
+}
+
+// A nested contract object contributes its leaves under a dotted path, and
+// the object itself contributes the place a radius would be measured from.
+func TestANestedAddressContributesLeavesAndAPlace(t *testing.T) {
+	vocab, err := NewVocabularyResolver().Resolve(readerFor("organization"), "organization")
+	if err != nil {
+		t.Fatal(err)
+	}
+	org, _ := vocab.Target("organization")
+	city, ok := org.Field("address.city")
+	if !ok || city.Kind != KindText {
+		t.Fatalf("address.city resolved to %+v, %v; want an exact text predicate", city, ok)
+	}
+	place, ok := org.Field("address")
+	if !ok || place.Kind != KindGeo || !slices.Contains(place.Ops, OpWithinRadius) {
+		t.Fatalf("address resolved to %+v, %v; want a place admitting %q", place, ok, OpWithinRadius)
+	}
+	if slices.Contains(place.Ops, OpEq) {
+		t.Error("a place admits an equality predicate; a place does not compare equal to anything")
+	}
+}
+
+// The contract half of the vocabulary is memoized, and a resolve APPENDS its
+// workspace's custom columns to it and sorts the result. Both would reach
+// through a shared backing array into the next caller's vocabulary if the
+// memoized walk were handed out directly — one workspace's private column
+// becoming another's, and a retired one never leaving.
+func TestOneResolvesCustomColumnsDoNotLeakIntoTheNext(t *testing.T) {
+	withColumn := NewVocabularyResolver().WithFieldCatalog(stubCatalog{
+		columns: map[string][]fieldcatalog.Column{
+			"deal": {{Name: "cf_private_to_this_read", Type: fieldcatalog.TypeText}},
+		},
+	})
+	if _, err := withColumn.Resolve(readerFor("deal"), "deal"); err != nil {
+		t.Fatal(err)
+	}
+
+	// A DIFFERENT resolver over an empty catalog — the only thing the two
+	// share is the memoized contract walk.
+	plain, err := NewVocabularyResolver().Resolve(readerFor("deal"), "deal")
+	if err != nil {
+		t.Fatal(err)
+	}
+	deal, _ := plain.Target("deal")
+	if _, ok := deal.Field("cf_private_to_this_read"); ok {
+		t.Fatal("a custom column from one resolve appeared in another's vocabulary")
+	}
+
+	// The check above only bites while the memoized slice has spare capacity
+	// for the append to land in. Pin the property itself, so a contract whose
+	// field count happens to fill the allocation exactly cannot make this
+	// suite pass against the bug it describes.
+	for entity, record := range contractRecords {
+		if len(contractFields(record)) == 0 {
+			t.Fatalf("%s derives no fields, so the aliasing check below is vacuous", entity)
+		}
+		if &contractFields(record)[0] == &walkedContracts()[record][0] {
+			t.Errorf("%s: contractFields hands out the memoized slice itself; a caller's append reaches every other caller", entity)
+		}
+	}
+}

--- a/backend/internal/shared/ports/mcp/resource.go
+++ b/backend/internal/shared/ports/mcp/resource.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package mcp
+
+// The resource half of the governed surface: read-only documents a client
+// fetches to learn what it may ask, rather than probing the tool surface for
+// it. A resource is NOT a tool — it takes no arguments, changes nothing, and
+// carries no autonomy tier. What it does carry is the same per-caller
+// admission the tools ride: a provider composes its document from what THIS
+// principal may read, so a resource can never become a discovery channel for
+// what the caller is denied.
+
+import (
+	"context"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// Resource is one published document, as resources/list advertises it.
+type Resource struct {
+	// URI is the stable identity a client reads by; it is what
+	// resources/read echoes back.
+	URI string
+	// Name is the programmatic identifier; Title the human-readable display
+	// name a client shows in its place (the protocol's precedence is
+	// title > name, mirroring ToolSpec).
+	Name        string
+	Title       string
+	Description string
+	MIMEType    string
+	// RequiredScope is the passport scope an AGENT must hold to see or read
+	// this document, mirroring ToolSpec.RequiredScope. It is not optional
+	// governance: the query vocabulary names a workspace's own custom-field
+	// columns, so a passport with no read grant learning them would make the
+	// resource surface the discovery channel the scope-filtered tool list is
+	// careful not to be. A human's authority is their RBAC, not a scope, so
+	// the filter applies to agents alone.
+	RequiredScope principal.Scope
+}
+
+// ResourceContents is one resources/read result. Text only: every document
+// this surface publishes is a UTF-8 payload (JSON today), and a binary
+// member would be a shape no provider here can fill.
+type ResourceContents struct {
+	URI      string
+	MIMEType string
+	Text     string
+}
+
+// ResourceProvider publishes documents beside the tool surface. Both methods
+// take the bound caller's context because both answers are per-caller:
+// Resources lists only what this principal may read, and ReadResource
+// composes the document from the same narrowed view.
+//
+// An unknown (or caller-invisible) URI answers apperrors.ErrNotFound — the
+// two are deliberately indistinguishable, exactly as a row-scope miss is on
+// the record surface.
+type ResourceProvider interface {
+	Resources(ctx context.Context) []Resource
+	ReadResource(ctx context.Context, uri string) (ResourceContents, error)
+}


### PR DESCRIPTION
## A question compiles to a closed vocabulary, or it is refused

Track E's first PR — the plan DSL and its validator, which is the security
boundary of the whole workspace-query feature. **No execution**: E2 runs a
validated plan, E3 turns it into `query_workspace`. This PR's whole job is
producing a plan an executor may run, and refusing every plan it may not.

Implements **A140** (upstream [#1258](https://github.com/gradionhq/margince-foundation/pull/1258)) ·
`specs/subsystems/search-and-retrieval.md` SEARCH-PARAM-7, SEARCH-AC-14..17 ·
carries roadmap item **C-7**.

### What a plan may say

Three things, and nothing else:

```jsonc
{
  "version": "v1",
  "target": "deal",
  "where": [{"field": "status", "op": "eq", "value": "open"},
            {"field": "cf_renewal_risk", "op": "in", "values": ["high"]}],
  "similar_to": "manufacturers who churned after a pilot",
  "traverse": {"relation": "organization",
               "where": [{"field": "address.city", "op": "eq", "value": "Stuttgart"}]},
  "limit": 25
}
```

Every position that names something is a closed enumeration. There is nowhere
in the grammar to put a table, a SQL fragment or a free expression — those can
only arrive as the *value* of a closed member, where the vocabulary refuses
them.

### The vocabulary is derived, not maintained (C-7 / SEARCH-AC-15)

Two halves, neither of them a list:

| half | source |
|---|---|
| core fields | reflection over the **generated contract types** — the contract is this repo's source of truth (P3), so the vocabulary cannot drift from what the API returns |
| custom fields | the live `custom_field` catalog, through the `fieldcatalog` seam every record store already rides |

A field's *kind* comes from its Go type and its *operators* come from its
kind, so nothing about a field is chosen by hand. Nested contract objects
contribute their scalar leaves under a dotted path (`address.city`), which is
also where the geo predicates come from. **Relations are derived too**: a
scalar `<record type>_id` member declares a forward hop, and its inverse
declares one on the record it points at (`deal.organization_id` gives deal
`organization` and organization `deals`).

`TestVocabularyIsDerivedFromTheContractNotAList` re-derives the expected field
set independently and asserts the resolver admits exactly it — a hardcoded
list fails it the first time a contract field moves, which is what C-7 asks
for stated as a test rather than as a comment.

### Per-caller, and it does not leak (SEARCH-AC-16)

Resolution runs object RBAC per record type. A type the caller cannot read
contributes no fields and no relations, so naming one of its fields is refused
with the same code and the same wording an invented name gets. The test asserts
byte-equality of the two refusals modulo the caller's own quoted token — for a
record type (`lead`, which really exists) and for a hop (`organization`, which
really exists), against a principal who can read neither.

Hops are filtered the same way: a hop is a read of what it lands on, so a hop
into a denied record type is not offered — otherwise a plan could filter by
rows the caller cannot see and learn about them from the count.

### The refusal (SEARCH-AC-14)

A typed `PlanRefusal` implementing `apperrors.FieldFaults` — the plural form,
so a plan with three bad predicates names all three rather than the first. It
renders as a 422 on REST and in-band on the tool surface through the choke
point that already exists; no transport learns anything new.

Fifteen codes, one per refusal class: `malformed_plan`, `duplicate_member`,
`unknown_plan_version`, `unknown_plan_member`, `unknown_target`,
`unknown_field`, `unknown_operator`, `unknown_relation`, `sql_fragment`,
`free_expression`, `value_type_mismatch`, `value_missing`,
`value_not_applicable`, `limit_out_of_range`, `traversal_depth_exceeded`.
Table-driven, one case each.

**The allowlist decides; the classifier only explains.** `sql_fragment` and
`free_expression` are not a blocklist — membership in the resolved vocabulary
is settled first and separately, and the classifier runs only on what that
check has *already* rejected, to choose which wording the caller sees. A
classifier consulted first would be a blocklist, and a blocklist admits
everything it fails to recognise, which is the permissive default this whole
feature exists to prevent.

Two related choices, both refusals rather than silent narrowing:

- **The decoder is strict.** A plan carrying `"raw_sql": "…"` is refused, not
  decoded-minus-the-member. A dropped member is a different question answered
  as if it were the one asked.
- **A repeated member is refused.** `DisallowUnknownFields` does not cover
  this — a repeated member is not an unknown one, and `encoding/json` resolves
  it last-wins in silence, so `{"target":"deal","where":[…],"where":[]}`
  decodes into an unfiltered scan with the caller's real question dropped. A
  token-stream pass refuses it at any depth before the struct decode.
- **A case-variant member is refused.** `encoding/json` matches member names
  case-INSENSITIVELY, and so does `DisallowUnknownFields`, so
  `{"target":"deal","TARGET":"person"}` is neither unknown nor (to an
  exact-string scan) a duplicate — and last-wins replaces the caller's target
  with one they never wrote. Only the canonical spelling is admitted, and the
  canonical set is derived from the grammar's own struct tags. The rule stops
  at an operand payload: `{"center": …}` is a caller's value, not grammar.
- **Bytes after the plan are refused.** `dec.More()` reports whether another
  *value* follows, so a trailing `]` left it false and the garbage rode along
  with an otherwise valid plan. A second decode must reach `io.EOF`.
- **`null` is not a value this grammar has.** `json.Unmarshal` accepts null
  into every Go type with a nil error and leaves the zero behind, so a null
  operand passed as a valid number, string or boolean. `limit` and `values`
  are raw rather than pointers/slices for the same reason: nil cannot tell an
  absent member from an explicit null, and absent asks for the default while
  null asks for something the grammar cannot give.
- **`limit` out of the CAP-PAGE window is refused, not clamped.** The ceiling
  is discovered from `storekit.ClampLimit` rather than restated.
- **An operand member the operator does not read is refused, not ignored.**
  A caller who wrote `op: "eq"` and filled `values` meant the list; matching
  on `value` instead answers a different question silently.
- **A second traversal hop is refused BY NAME.** The grammar carries the
  nested member deliberately, so a depth-2 plan gets
  `traversal_depth_exceeded` rather than a malformed-document error that says
  nothing about the limit it hit.

### `within_radius` is declared and honest (SEARCH-AC-17)

It is in the published operator set for geo fields, and a plan using it
**validates** — carrying an `Unavailable` note with code
`distance_ranking_unavailable`. Not an error (that would be
unknown-vocabulary), not a ranking (there is nothing behind it). City and
region stay ordinary exact predicates and work today. A malformed radius
operand is still the caller's fault and says so, so the note a caller receives
is about this deployment's capability rather than their own bad request.

### Published, not implied — `margince://schema/query`

The MCP server answered `resources/list` with an empty list and had no
`resources/read`. It now has both:

- `shared/ports/mcp`: `Resource` + `ResourceProvider`, additive.
- `modules/search`: the provider, composing the caller's resolved vocabulary.
- `modules/agents`: `resources/read`, a real `resources/list`, and the
  `resources` capability advertised **only when a provider is wired** —
  claiming it with nothing behind it sends a client to a read that can only
  fail.
- **Scope-gated for agents**, mirroring the tool list. A resource declares a
  `RequiredScope`; the query vocabulary declares `read`, because it names the
  workspace's own custom-field columns. A passport without the read scope
  neither sees it in the catalogue nor reads it — and the refusal is the same
  `-32002` an unknown URI gets, so scope cannot be probed either. A human is
  not filtered by a scope they never carry; their RBAC is applied by the
  provider itself.
- `compose`: the cross-module edge, injected once.

`TestEveryPublishedFieldAndOperatorValidates` walks the published document and
validates a plan for every field × operator and every relation it advertises:
an advertised field the validator refuses is a refusal that reads like a bug,
and the two come from one resolver so they cannot drift.

### Verification

- `make check-backend` green; `make craft-static` 0/0/0; `make lint` clean.
- New-code statement coverage **96.7%**.
- Integration lane: the composed `/mcp` mount publishes the document to a real
  passport, a custom field added through the admin surface reaches the
  published vocabulary with no deploy and leaves when retired, and an unserved
  URI answers `-32002`.
- Guards were mutation-checked rather than assumed: filtering removed from
  `admittedRelations`, `DisallowUnknownFields` removed from the decoder, the
  duplicate-member scan removed, the memoized-walk clone removed, and the
  limit check turned into a clamp — each fails the test that describes it.
- **Two review rounds, both acted on.** An independent Fable pass before
  opening found silent last-wins on duplicate members and a resource surface
  that did not ride the passport-scope axis the tool list rides. The cubic
  reviewer then found four more decode holes of the same class — case-variant
  members, trailing bytes, null operands, and a shared operator slice — each
  verified empirically before fixing. Every fix has a guard that fails against
  the bug it describes, checked by mutation.

### Out of scope, named

- **Execution** — E2. Nothing here touches the retriever, the stores or the graph.
- **`query_workspace` the tool** — E3.
- **Grouping, ranking directives, multi-hop, the coverage contract** — v2,
  deferred upstream with R3.
- **REST surface** — MCP-only in v1; `crm.yaml` is untouched (roadmap Z-1
  re-derives it).
- **person → organization traversal** — person declares no scalar
  organization reference (employment is a `relationship` row), so the
  derivation honestly gives person no hop. Filed as a follow-up for E2 rather
  than papered over with a hand-maintained edge.
