### PR TITLE
feat(search): a validated plan executes, and the answer says what kind of answer it is

### DIFF
--- a/backend/internal/compose/integration/queryplan_integration_test.go
+++ b/backend/internal/compose/integration/queryplan_integration_test.go
@@ -270,7 +270,7 @@ func TestQueryPlanTraversalBetweenTablesThatShareAColumnName(t *testing.T) {
 	if len(result.Rows) != 1 || result.Rows[0].ID != f.rep1Deal {
 		t.Fatalf("rows are %v", rowNames(result))
 	}
-	if result.Rows[0].Evidence[0].ID != f.project {
+	if len(result.Rows[0].Evidence) != 1 || result.Rows[0].Evidence[0].ID != f.project {
 		t.Fatalf("evidence is %+v", result.Rows[0].Evidence)
 	}
 }

--- a/backend/internal/compose/integration/queryplan_integration_test.go
+++ b/backend/internal/compose/integration/queryplan_integration_test.go
@@ -360,6 +360,27 @@ func TestQueryPlanARankedAnswerNeverLabelsItselfComplete(t *testing.T) {
 	}
 }
 
+// The ranking runs WITHIN the plan's record type. A global page filtered
+// afterwards spends itself on types the plan never named — here the same word
+// names an organization, a project and a deal, and a page of two would answer
+// no deals at all for a corpus that has one.
+func TestQueryPlanRanksWithinTheRecordTypeItWasAsked(t *testing.T) {
+	q := setupQuery(t)
+	f := q.seedFixture(t)
+	// "Rollout" names the project and the deal; the organizations rank on
+	// "Stuttgart". Asking about deals must answer the deal.
+	result := q.run(q.admin(), t, `{
+		"version": "v1", "target": "deal", "similar_to": "Rollout", "limit": 1}`)
+	if len(result.Rows) != 1 || result.Rows[0].ID != f.rep1Deal {
+		t.Fatalf("rows are %v", rowNames(result))
+	}
+	for _, row := range result.Rows {
+		if row.Type != "deal" {
+			t.Errorf("a %s row came back for a deal plan", row.Type)
+		}
+	}
+}
+
 // A ranking that admits nothing answers nothing. Running the statement without
 // the membership test would answer the unfiltered question instead — every
 // deal in the workspace, under a sentence promising a ranked few.
@@ -396,10 +417,11 @@ func TestQueryPlanNeverReturnsArchivedRecordsOrTheOwnCompany(t *testing.T) {
 }
 
 // The fitness function this PR turns on: EVERY field the vocabulary publishes
-// is answerable end to end, against the real schema. A field the contract
-// declares and no table holds would otherwise refuse at execution what it
-// advertised at discovery — and only the live catalog can say which fields
-// those are.
+// is answerable end to end, against the real schema — either as rows, or, for
+// a place, as the declared note that says this deployment cannot rank by it. A
+// field the contract declares and no table holds would otherwise refuse at
+// execution what it advertised at discovery, and only the live catalog can say
+// which fields those are.
 func TestEveryPublishedFieldCompilesToAStoragePath(t *testing.T) {
 	q := setupQuery(t)
 	q.seedFixture(t)
@@ -418,8 +440,26 @@ func TestEveryPublishedFieldCompilesToAStoragePath(t *testing.T) {
 		for _, field := range target.Fields {
 			doc := fmt.Sprintf(`{"version": "v1", "target": %q, "where": [{"field": %q, "op": %q, "value": %s}]}`,
 				target.Target, field.Name, field.Ops[0], probeOperand(field.Kind))
-			if _, err := q.answer(ctx, doc); err != nil {
+			result, err := q.answer(ctx, doc)
+			if err != nil {
 				t.Errorf("%s.%s (%s) is published and cannot be asked: %v", target.Target, field.Name, field.Kind, err)
+				continue
+			}
+			// A PLACE is the one published field with no storage behind it,
+			// and it is published precisely so that it answers the note rather
+			// than reading as an unknown operator (SEARCH-AC-17). Asserting
+			// that here is what keeps this test's claim exact: every other
+			// published field runs, and this one is declared unanswerable
+			// rather than quietly exempt.
+			if field.Kind == search.KindGeo {
+				if !hasNote(result, search.CodeDistanceRankingUnavailable) {
+					t.Errorf("%s.%s is a place and did not answer %s: %v",
+						target.Target, field.Name, search.CodeDistanceRankingUnavailable, result.Notes)
+				}
+				continue
+			}
+			if hasNote(result, search.CodeDistanceRankingUnavailable) {
+				t.Errorf("%s.%s (%s) answered a place's note", target.Target, field.Name, field.Kind)
 			}
 		}
 	}

--- a/backend/internal/compose/integration/queryplan_integration_test.go
+++ b/backend/internal/compose/integration/queryplan_integration_test.go
@@ -1,0 +1,533 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// Executing a validated query plan against real rows, real RLS and the real
+// schema (SEARCH-PARAM-7, execution half).
+//
+// The exit criterion of this work is a security property — two principals over
+// ONE corpus get different answers and neither can infer the other's rows — so
+// it is proven here rather than against a stub. The other half proven here is
+// that the published vocabulary is answerable: a field the schema advertises
+// and no table holds would refuse at execution what it advertised at
+// discovery, and only the live catalog can say which fields those are.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/modules/search"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// queryEnv is the SearchEnv plus the two halves of the query feature, wired
+// the way compose wires them: one resolver behind both the validator and the
+// published document, and the live schema behind both.
+type queryEnv struct {
+	*SearchEnv
+	resolver  *search.VocabularyResolver
+	validator *search.PlanValidator
+	executor  *search.QueryExecutor
+}
+
+func setupQuery(t *testing.T) *queryEnv {
+	t.Helper()
+	e := SetupSearch(t)
+	columns := search.NewColumnCatalog(e.Pool)
+	resolver := search.NewVocabularyResolver().WithColumnReader(columns)
+	return &queryEnv{
+		SearchEnv: e,
+		resolver:  resolver,
+		validator: search.NewPlanValidator(resolver),
+		// No embedder: the offline posture, which is also what proves the
+		// degradation is REPORTED rather than hidden.
+		executor: search.NewQueryExecutor(e.Store, nil, columns),
+	}
+}
+
+// queryObjects is every record type a plan can target, which is wider than the
+// shared fixture's read set — a plan traverses into `project`, and a hop into a
+// record type the caller cannot read is no hop at all. It is declared here
+// rather than widened in SearchEnv: the suites riding that fixture assert what
+// a reader SEES, and a grant added for this one would quietly widen theirs.
+var queryObjects = []string{"person", "organization", "deal", "lead", "project", "activity"}
+
+func queryGrants() map[string]principal.ObjectGrant {
+	grants := map[string]principal.ObjectGrant{}
+	for _, object := range queryObjects {
+		grants[object] = principal.ObjectGrant{Read: true}
+	}
+	return grants
+}
+
+// admin reads every record type with nothing hidden — the positive control the
+// team rep's narrower view is measured against.
+func (q *queryEnv) admin() context.Context {
+	ctx := principal.WithWorkspaceID(context.Background(), q.WS)
+	return principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:" + ids.NewV7().String(), UserID: ids.NewV7(),
+		Permissions: principal.Permissions{Objects: queryGrants(), RowScope: principal.RowScopeAll},
+	})
+}
+
+// teamRep is the same object vocabulary with the row scope narrowed to one
+// team, so a comparison isolates row scope from object RBAC.
+func (q *queryEnv) teamRep(user, team ids.UUID) context.Context {
+	ctx := principal.WithWorkspaceID(context.Background(), q.WS)
+	return principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:" + user.String(), UserID: user,
+		TeamIDs:     []ids.UUID{team},
+		Permissions: principal.Permissions{Objects: queryGrants(), RowScope: principal.RowScopeTeam},
+	})
+}
+
+// run decodes, validates and executes one plan document, failing on anything
+// that is not an answer.
+func (q *queryEnv) run(ctx context.Context, t *testing.T, doc string) search.QueryResult {
+	t.Helper()
+	result, err := q.answer(ctx, doc)
+	if err != nil {
+		t.Fatalf("plan %s\n  → %v", doc, err)
+	}
+	return result
+}
+
+func (q *queryEnv) answer(ctx context.Context, doc string) (search.QueryResult, error) {
+	plan, err := search.DecodePlan([]byte(doc))
+	if err != nil {
+		return search.QueryResult{}, err
+	}
+	validated, err := q.validator.Validate(ctx, plan)
+	if err != nil {
+		return search.QueryResult{}, err
+	}
+	return q.executor.Execute(ctx, validated)
+}
+
+// queryFixture is one corpus split across two teams: each rep owns a deal at
+// an organization they own, so a rep sees exactly their own half through
+// either the target or the hop.
+type queryFixture struct {
+	rep1Org, rep3Org   ids.UUID
+	rep1Deal, rep3Deal ids.UUID
+	sharedDeal         ids.UUID
+	project            ids.UUID
+}
+
+func (q *queryEnv) seedFixture(t *testing.T) queryFixture {
+	t.Helper()
+	pipeline := q.Seed(t, `INSERT INTO pipeline (id, workspace_id, name, is_default, position) VALUES ($1, $2, 'Sales', true, 0)`)
+	stage := q.Seed(t, `INSERT INTO stage (id, workspace_id, pipeline_id, name, position, semantic, win_probability)
+		VALUES ($1, $2, $3, 'Qualify', 0, 'open', 10)`, pipeline)
+
+	var f queryFixture
+	f.rep1Org = q.Seed(t, `INSERT INTO organization (id, workspace_id, owner_id, display_name, address_city, source, captured_by)
+		VALUES ($1, $2, $3, 'Stuttgart Werke', 'Stuttgart', 'manual', 'human:x')`, q.Rep1)
+	f.rep3Org = q.Seed(t, `INSERT INTO organization (id, workspace_id, owner_id, display_name, address_city, source, captured_by)
+		VALUES ($1, $2, $3, 'Stuttgart Logistik', 'Stuttgart', 'manual', 'human:x')`, q.Rep3)
+	// A project named like a deal, so the traversal proves that two tables
+	// sharing a column name resolve to the right one.
+	f.project = q.Seed(t, `INSERT INTO project (id, workspace_id, owner_id, name, organization_id, source, captured_by)
+		VALUES ($1, $2, $3, 'Rollout', $4, 'manual', 'human:x')`, q.Rep1, f.rep1Org)
+
+	f.rep1Deal = q.Seed(t, `INSERT INTO deal (id, workspace_id, owner_id, name, pipeline_id, stage_id, organization_id, project_id, amount_minor, currency, status, expected_close_date, source, captured_by)
+		VALUES ($1, $2, $3, 'Rollout', $4, $5, $6, $7, 100000, 'EUR', 'open', '2026-12-01', 'manual', 'human:x')`,
+		q.Rep1, pipeline, stage, f.rep1Org, f.project)
+	f.rep3Deal = q.Seed(t, `INSERT INTO deal (id, workspace_id, owner_id, name, pipeline_id, stage_id, organization_id, amount_minor, currency, status, expected_close_date, source, captured_by)
+		VALUES ($1, $2, $3, 'Logistik Rahmenvertrag', $4, $5, $6, 250000, 'EUR', 'open', '2026-11-01', 'manual', 'human:x')`,
+		q.Rep3, pipeline, stage, f.rep3Org)
+	// An ownerless deal is workspace-shared and visible at every tier — the
+	// control that keeps "the rep sees fewer rows" from being read as "the rep
+	// sees only their own".
+	f.sharedDeal = q.Seed(t, `INSERT INTO deal (id, workspace_id, name, pipeline_id, stage_id, amount_minor, currency, status, source, captured_by)
+		VALUES ($1, $2, 'Unowned Deal', $3, $4, 50000, 'EUR', 'open', 'manual', 'human:x')`, pipeline, stage)
+	return f
+}
+
+func TestQueryPlanAnswersExactPredicatesCompletely(t *testing.T) {
+	q := setupQuery(t)
+	f := q.seedFixture(t)
+	result := q.run(q.admin(), t, `{
+		"version": "v1", "target": "deal",
+		"where": [{"field": "status", "op": "eq", "value": "open"},
+		          {"field": "amount_minor", "op": "gte", "value": 100000}]}`)
+
+	if got := idSet(result); !got[f.rep1Deal] || !got[f.rep3Deal] || got[f.sharedDeal] {
+		t.Fatalf("rows are %v", rowNames(result))
+	}
+	if result.Coverage != search.CoverageCompleteExact {
+		t.Errorf("coverage is %q with notes %v", result.Coverage, result.Notes)
+	}
+	if len(result.Notes) != 0 {
+		t.Errorf("a complete answer carries notes: %v", result.Notes)
+	}
+	if !strings.Contains(result.Narrative, `status is "open"`) {
+		t.Errorf("narrative is %q", result.Narrative)
+	}
+	for _, row := range result.Rows {
+		if row.Title == "" {
+			t.Errorf("row %s has no title", row.ID)
+		}
+	}
+}
+
+// The exit criterion. Two principals, one corpus: the rep's answer is a strict
+// subset of the admin's, and nothing in the rep's answer — not the rows, not
+// the count, not the coverage verdict — is computed over a row they cannot see.
+func TestQueryPlanAnswersTwoPrincipalsFromOneCorpusWithoutLeaking(t *testing.T) {
+	q := setupQuery(t)
+	f := q.seedFixture(t)
+	const plan = `{"version": "v1", "target": "deal",
+		"where": [{"field": "status", "op": "eq", "value": "open"}]}`
+
+	admin := idSet(q.run(q.admin(), t, plan))
+	rep := idSet(q.run(q.teamRep(q.Rep1, q.Team1), t, plan))
+
+	if len(admin) != 3 {
+		t.Fatalf("the admin sees %d of 3 deals", len(admin))
+	}
+	// Their own, plus the ownerless workspace-shared row — and not the other
+	// team's.
+	if !rep[f.rep1Deal] || !rep[f.sharedDeal] {
+		t.Fatalf("the rep cannot see their own rows: %v", rep)
+	}
+	if rep[f.rep3Deal] {
+		t.Fatal("the rep sees another team's deal")
+	}
+	for id := range rep {
+		if !admin[id] {
+			t.Fatalf("the rep sees a row the unbounded reader does not: %s", id)
+		}
+	}
+}
+
+// A hop is a READ of the record it lands on. Filtering by an organization the
+// caller cannot see must not admit rows through it — otherwise the answer's
+// membership discloses a record the row scope hides.
+func TestQueryPlanTraversalCarriesTheHopsOwnRowScope(t *testing.T) {
+	q := setupQuery(t)
+	f := q.seedFixture(t)
+	const plan = `{"version": "v1", "target": "deal",
+		"traverse": {"relation": "organization",
+		             "where": [{"field": "address.city", "op": "eq", "value": "Stuttgart"}]}}`
+
+	admin := idSet(q.run(q.admin(), t, plan))
+	if !admin[f.rep1Deal] || !admin[f.rep3Deal] {
+		t.Fatalf("the unbounded reader does not reach both Stuttgart deals: %v", admin)
+	}
+	// rep3 owns the other organization. Their deal is reachable only through
+	// an organization rep1 cannot read.
+	rep := idSet(q.run(q.teamRep(q.Rep1, q.Team1), t, plan))
+	if rep[f.rep3Deal] {
+		t.Fatal("a hop through an organization the caller cannot read admitted a row")
+	}
+	if !rep[f.rep1Deal] {
+		t.Fatalf("the rep cannot reach their own deal through their own organization: %v", rep)
+	}
+}
+
+// The hop comes back as the record that admitted the row — a traversal that is
+// legible as a reason rather than as an invisible filter.
+func TestQueryPlanTraversalReturnsTheRecordThatAdmittedTheRow(t *testing.T) {
+	q := setupQuery(t)
+	f := q.seedFixture(t)
+	result := q.run(q.admin(), t, `{
+		"version": "v1", "target": "deal",
+		"where": [{"field": "amount_minor", "op": "eq", "value": 100000}],
+		"traverse": {"relation": "organization",
+		             "where": [{"field": "address.city", "op": "eq", "value": "Stuttgart"}]}}`)
+	if len(result.Rows) != 1 {
+		t.Fatalf("rows are %v", rowNames(result))
+	}
+	evidence := result.Rows[0].Evidence
+	if len(evidence) != 1 {
+		t.Fatalf("the row carries %d pieces of evidence", len(evidence))
+	}
+	if evidence[0].ID != f.rep1Org || evidence[0].Type != "organization" || evidence[0].Relation != "organization" {
+		t.Fatalf("evidence is %+v", evidence[0])
+	}
+	if evidence[0].Title != "Stuttgart Werke" {
+		t.Errorf("evidence title is %q", evidence[0].Title)
+	}
+}
+
+// deal.name and project.name are both `name`. The hop's title expression must
+// resolve to the HOP's table, or the statement is ambiguous — and an ambiguity
+// this shape is invisible until two tables happen to share a column name.
+func TestQueryPlanTraversalBetweenTablesThatShareAColumnName(t *testing.T) {
+	q := setupQuery(t)
+	f := q.seedFixture(t)
+	result := q.run(q.admin(), t, `{
+		"version": "v1", "target": "deal",
+		"traverse": {"relation": "project", "where": [{"field": "name", "op": "eq", "value": "Rollout"}]}}`)
+	if len(result.Rows) != 1 || result.Rows[0].ID != f.rep1Deal {
+		t.Fatalf("rows are %v", rowNames(result))
+	}
+	if result.Rows[0].Evidence[0].ID != f.project {
+		t.Fatalf("evidence is %+v", result.Rows[0].Evidence)
+	}
+}
+
+// The inverse edge is derived from the referring record's column, and executes
+// in the other direction.
+func TestQueryPlanTraversalFollowsAnInverseEdge(t *testing.T) {
+	q := setupQuery(t)
+	f := q.seedFixture(t)
+	result := q.run(q.admin(), t, `{
+		"version": "v1", "target": "organization",
+		"traverse": {"relation": "deals",
+		             "where": [{"field": "amount_minor", "op": "gte", "value": 200000}]}}`)
+	if len(result.Rows) != 1 || result.Rows[0].ID != f.rep3Org {
+		t.Fatalf("rows are %v", rowNames(result))
+	}
+}
+
+// v1 has no cursor member, so a caller who hits the limit cannot ask for the
+// rest. Calling that complete would be the silent narrowing the whole feature
+// exists to prevent.
+func TestQueryPlanTruncationIsDegradationRatherThanPagination(t *testing.T) {
+	q := setupQuery(t)
+	q.seedFixture(t)
+	result := q.run(q.admin(), t, `{
+		"version": "v1", "target": "deal",
+		"where": [{"field": "status", "op": "eq", "value": "open"}], "limit": 2}`)
+	if len(result.Rows) != 2 {
+		t.Fatalf("the page carries %d rows", len(result.Rows))
+	}
+	if result.Coverage != search.CoveragePartialDegraded {
+		t.Fatalf("coverage is %q", result.Coverage)
+	}
+	if !hasNote(result, search.CodeResultTruncated) {
+		t.Fatalf("notes are %v", result.Notes)
+	}
+}
+
+// An answer that fits says so, and carries no truncation note.
+func TestQueryPlanAnAnswerThatFitsIsNotReportedAsTruncated(t *testing.T) {
+	q := setupQuery(t)
+	q.seedFixture(t)
+	result := q.run(q.admin(), t, `{
+		"version": "v1", "target": "deal",
+		"where": [{"field": "status", "op": "eq", "value": "open"}], "limit": 3}`)
+	if len(result.Rows) != 3 || result.Coverage != search.CoverageCompleteExact {
+		t.Fatalf("coverage is %q over %d rows", result.Coverage, len(result.Rows))
+	}
+}
+
+// SEARCH-AC-17 against real data: the predicate validates, the answer is the
+// note, and no row count is disclosed for a question this deployment cannot
+// answer.
+func TestQueryPlanAnUnanswerablePredicateReturnsItsNoteNotRows(t *testing.T) {
+	q := setupQuery(t)
+	q.seedFixture(t)
+	result := q.run(q.admin(), t, `{
+		"version": "v1", "target": "organization",
+		"where": [{"field": "address", "op": "within_radius",
+		           "value": {"center": "Stuttgart", "radius_km": 50}}]}`)
+	if len(result.Rows) != 0 {
+		t.Fatalf("an unanswerable plan returned %d rows over a populated corpus", len(result.Rows))
+	}
+	if !hasNote(result, search.CodeDistanceRankingUnavailable) {
+		t.Fatalf("notes are %v", result.Notes)
+	}
+}
+
+// A similarity clause with no embedding lane bound ranks lexically. The
+// degradation is reported, and the answer never labels itself complete.
+func TestQueryPlanARankedAnswerNeverLabelsItselfComplete(t *testing.T) {
+	q := setupQuery(t)
+	f := q.seedFixture(t)
+	result := q.run(q.admin(), t, `{
+		"version": "v1", "target": "deal", "similar_to": "Rollout"}`)
+	if result.Coverage == search.CoverageCompleteExact {
+		t.Fatal("a ranked answer labelled itself complete")
+	}
+	if !hasNote(result, search.CodeSemanticRankingDegraded) {
+		t.Fatalf("an unbound embedding lane was not reported: %v", result.Notes)
+	}
+	if len(result.Rows) != 1 || result.Rows[0].ID != f.rep1Deal {
+		t.Fatalf("rows are %v", rowNames(result))
+	}
+	if !strings.Contains(result.Narrative, "ranked by similarity") {
+		t.Errorf("narrative is %q", result.Narrative)
+	}
+}
+
+// A ranking that admits nothing answers nothing. Running the statement without
+// the membership test would answer the unfiltered question instead — every
+// deal in the workspace, under a sentence promising a ranked few.
+func TestQueryPlanARankingThatMatchesNothingAnswersNoRows(t *testing.T) {
+	q := setupQuery(t)
+	q.seedFixture(t)
+	result := q.run(q.admin(), t, `{
+		"version": "v1", "target": "deal", "similar_to": "zzzznothingmatchesthis"}`)
+	if len(result.Rows) != 0 {
+		t.Fatalf("a ranking that matched nothing answered %d rows", len(result.Rows))
+	}
+}
+
+// The archived and discovery narrowing every read carries, carried here too.
+func TestQueryPlanNeverReturnsArchivedRecordsOrTheOwnCompany(t *testing.T) {
+	q := setupQuery(t)
+	f := q.seedFixture(t)
+	anchor := q.Seed(t, `INSERT INTO organization (id, workspace_id, display_name, is_anchor, source, captured_by)
+		VALUES ($1, $2, 'Our Own Company', true, 'manual', 'human:x')`)
+	if _, err := q.Owner.Exec(context.Background(),
+		`UPDATE organization SET archived_at = now() WHERE id = $1`, f.rep3Org); err != nil {
+		t.Fatal(err)
+	}
+	got := idSet(q.run(q.admin(), t, `{"version": "v1", "target": "organization"}`))
+	if got[anchor] {
+		t.Error("the installation's own company is discoverable through a query plan")
+	}
+	if got[f.rep3Org] {
+		t.Error("an archived organization is returned")
+	}
+	if !got[f.rep1Org] {
+		t.Error("a live organization is missing")
+	}
+}
+
+// The fitness function this PR turns on: EVERY field the vocabulary publishes
+// is answerable end to end, against the real schema. A field the contract
+// declares and no table holds would otherwise refuse at execution what it
+// advertised at discovery — and only the live catalog can say which fields
+// those are.
+func TestEveryPublishedFieldCompilesToAStoragePath(t *testing.T) {
+	q := setupQuery(t)
+	q.seedFixture(t)
+	ctx := q.admin()
+	vocab, err := q.resolver.Resolve(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(vocab.Targets) == 0 {
+		t.Fatal("the vocabulary publishes no record types")
+	}
+	for _, target := range vocab.Targets {
+		if len(target.Fields) == 0 {
+			t.Errorf("%s publishes no fields", target.Target)
+		}
+		for _, field := range target.Fields {
+			doc := fmt.Sprintf(`{"version": "v1", "target": %q, "where": [{"field": %q, "op": %q, "value": %s}]}`,
+				target.Target, field.Name, field.Ops[0], probeOperand(field.Kind))
+			if _, err := q.answer(ctx, doc); err != nil {
+				t.Errorf("%s.%s (%s) is published and cannot be asked: %v", target.Target, field.Name, field.Kind, err)
+			}
+		}
+	}
+}
+
+// The same invariant one level up: every HOP the vocabulary publishes executes.
+// A forward hop is filtered incidentally — its reference is one of the target's
+// own fields — but an inverse hop is declared by the referring record and joins
+// on THAT table's column, so it is the direction that can be published against
+// a column no table holds. That failure is a database error rather than a
+// refusal, which is the one thing a validated plan must never produce.
+func TestEveryPublishedRelationExecutes(t *testing.T) {
+	q := setupQuery(t)
+	q.seedFixture(t)
+	ctx := q.admin()
+	vocab, err := q.resolver.Resolve(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hops := 0
+	for _, target := range vocab.Targets {
+		for _, relation := range target.Relations {
+			hops++
+			doc := fmt.Sprintf(`{"version": "v1", "target": %q, "traverse": {"relation": %q}}`,
+				target.Target, relation.Name)
+			if _, err := q.answer(ctx, doc); err != nil {
+				t.Errorf("%s → %s (via %s) is published and cannot be traversed: %v",
+					target.Target, relation.Name, relation.Via, err)
+			}
+		}
+	}
+	if hops == 0 {
+		t.Fatal("no hops were exercised; the vocabulary publishes no traversals at all")
+	}
+}
+
+// probeOperand is one well-formed operand per kind, so the fitness function
+// above exercises the storage path rather than the operand check.
+func probeOperand(kind search.FieldKind) string {
+	switch kind {
+	case search.KindNumber:
+		return "1"
+	case search.KindBoolean:
+		return "true"
+	case search.KindDate:
+		return `"2026-01-01"`
+	case search.KindTimestamp:
+		return `"2026-01-01T00:00:00Z"`
+	case search.KindID:
+		return `"01999999-0000-7000-8000-000000000001"`
+	case search.KindGeo:
+		return `{"center": "Stuttgart", "radius_km": 50}`
+	default:
+		return `"probe"`
+	}
+}
+
+// The published document is a read of the caller's own surface, so it narrows
+// with them — and what it narrows to is still answerable.
+func TestThePublishedVocabularyNarrowsWithTheCaller(t *testing.T) {
+	q := setupQuery(t)
+	q.seedFixture(t)
+	admin, err := q.resolver.Resolve(q.admin())
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := json.Marshal(admin.TargetNames())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(body), "deal") {
+		t.Fatalf("the admin's vocabulary is %s", body)
+	}
+	// A field no table holds is absent from the document rather than present
+	// and unanswerable.
+	deal, ok := admin.Target("deal")
+	if !ok {
+		t.Fatal("deal absent from the admin's vocabulary")
+	}
+	if _, ok := deal.Field("stalled"); ok {
+		t.Error("`stalled` is computed in the record mapper and is published as askable")
+	}
+	if _, ok := deal.Field("status"); !ok {
+		t.Error("`status` is a column and is not published")
+	}
+}
+
+func idSet(result search.QueryResult) map[ids.UUID]bool {
+	out := map[ids.UUID]bool{}
+	for _, row := range result.Rows {
+		out[row.ID] = true
+	}
+	return out
+}
+
+func rowNames(result search.QueryResult) []string {
+	names := make([]string, len(result.Rows))
+	for i, row := range result.Rows {
+		names[i] = row.Title
+	}
+	return names
+}
+
+func hasNote(result search.QueryResult, code string) bool {
+	for _, note := range result.Notes {
+		if note.Code == code {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/compose/mcpedge.go
+++ b/backend/internal/compose/mcpedge.go
@@ -97,8 +97,17 @@ func (s *Server) mcpHandler(pool *pgxpool.Pool, auth *identity.Service, log *slo
 		// the custom-field half rides the same fieldcatalog seam every record
 		// store does, so a workspace's own columns are askable without this
 		// edge knowing anything about them.
+		//
+		// The schema reader is what keeps the published vocabulary honest: a
+		// field the contract declares and no table holds is not askable, so
+		// what this document advertises is what a plan can be answered from.
+		// Without it the vocabulary is the contract's, which is WIDER — and a
+		// wider vocabulary published here would refuse at execution what it
+		// advertised at discovery.
 		agents.WithResourceProvider(search.NewQuerySchemaResource(
-			search.NewVocabularyResolver().WithFieldCatalog(customfields.NewService(pool, nil)))))
+			search.NewVocabularyResolver().
+				WithFieldCatalog(customfields.NewService(pool, nil)).
+				WithColumnReader(search.NewColumnCatalog(pool)))))
 }
 
 // mcpAuthenticate binds one request to its agent principal. It runs on EVERY

--- a/backend/internal/modules/search/embedding.go
+++ b/backend/internal/modules/search/embedding.go
@@ -9,6 +9,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -135,7 +136,7 @@ type VectorHit struct {
 // vector, restricted to rows stamped with the caller's own embed
 // identity. Object RBAC and row scope gate every branch, exactly like
 // the lexical union — a vector hit is a read too.
-func (s *Store) SimilarEntities(ctx context.Context, queryVec []float32, identity string, limit int) ([]VectorHit, error) {
+func (s *Store) SimilarEntities(ctx context.Context, queryVec []float32, identity string, limit int, types ...string) ([]VectorHit, error) {
 	// A zero query vector makes every cosine distance 0/0 = NaN, and a
 	// naive ORDER BY sim DESC sorts NaN FIRST — the same trap the write
 	// path guards. There is nothing to rank against it, so return no vector
@@ -155,28 +156,9 @@ func (s *Store) SimilarEntities(ctx context.Context, queryVec []float32, identit
 		// excludes those rows before the projection computes <=>. NEVER remove it. (see design §5.6)
 		identityPos := arg(identity)
 
-		var branches []string
-		for _, branch := range searchBranches {
-			scope, admitted, err := branchScope(ctx, branch, "t", arg)
-			if err != nil {
-				return err
-			}
-			if !admitted {
-				continue
-			}
-			sql := fmt.Sprintf(
-				`SELECT '%s'::text AS rtype, e.entity_id AS id, %s AS title,
-				        (1 - (e.embedding <=> $%d::vector))::float8 AS sim
-				 FROM embedding e JOIN %s t ON t.id = e.entity_id
-				 WHERE e.entity_type = '%s' AND t.archived_at IS NULL AND e.model = $%d`,
-				branch.entity, branch.title, vecPos, branch.table, branch.entity, identityPos)
-			if branch.extraWhere != "" {
-				sql += " AND " + branch.extraWhere
-			}
-			if scope != "" {
-				sql += " AND " + scope
-			}
-			branches = append(branches, sql)
+		branches, err := similarBranchSQL(ctx, types, vecPos, identityPos, arg)
+		if err != nil {
+			return err
 		}
 		if len(branches) == 0 {
 			return nil
@@ -205,6 +187,43 @@ func (s *Store) SimilarEntities(ctx context.Context, queryVec []float32, identit
 		return nil, err
 	}
 	return hits, nil
+}
+
+// similarBranchSQL builds one ranked SELECT per requested-and-admitted record
+// type — the vector arm's counterpart to admittedBranchSQL, and subject to the
+// same two gates: object RBAC hides a denied type silently, then the branch
+// carries the caller's scope clause. A vector hit is a read too.
+//
+// An empty types narrows nothing, which is what the retrieval seam asks for.
+func similarBranchSQL(ctx context.Context, types []string, vecPos, identityPos int, arg func(any) int) ([]string, error) {
+	var branches []string
+	for _, branch := range searchBranches {
+		if len(types) > 0 && !slices.Contains(types, branch.entity) {
+			continue
+		}
+		scope, admitted, err := branchScope(ctx, branch, "t", arg)
+		if err != nil {
+			return nil, err
+		}
+		if !admitted {
+			continue
+		}
+		sql := fmt.Sprintf(
+			`SELECT '%s'::text AS rtype, e.entity_id AS id, %s AS title,
+			        (1 - (e.embedding <=> $%d::vector))::float8 AS sim
+			 FROM embedding e JOIN %s t ON t.id = e.entity_id
+			 WHERE e.entity_type = '%s' AND t.archived_at IS NULL AND e.model = $%d`,
+			branch.entity, branch.title, vecPos, branch.table, branch.entity, identityPos,
+		)
+		if narrowing := branch.narrowing("t"); narrowing != "" {
+			sql += " AND " + narrowing
+		}
+		if scope != "" {
+			sql += " AND " + scope
+		}
+		branches = append(branches, sql)
+	}
+	return branches, nil
 }
 
 // vectorLiteral renders pgvector's input syntax; parameterized as text

--- a/backend/internal/modules/search/embedding.go
+++ b/backend/internal/modules/search/embedding.go
@@ -157,7 +157,7 @@ func (s *Store) SimilarEntities(ctx context.Context, queryVec []float32, identit
 
 		var branches []string
 		for _, branch := range searchBranches {
-			scope, admitted, err := branchScope(ctx, branch, arg)
+			scope, admitted, err := branchScope(ctx, branch, "t", arg)
 			if err != nil {
 				return err
 			}

--- a/backend/internal/modules/search/fuse.go
+++ b/backend/internal/modules/search/fuse.go
@@ -20,13 +20,20 @@ const rrfK = 60
 // (B-EP05.18): each lane contributes 1/(k+rank), so an entity both
 // lanes agree on outranks either lane's solo favorite. Both lanes are
 // already RBAC- and row-scope-filtered; fusion adds no visibility.
-func (s *Store) HybridSearch(ctx context.Context, query string, embedder Embedder, limit int) ([]Hit, error) {
+//
+// types narrows BOTH lanes to the record types asked for, and narrowing
+// them is not the same as filtering the fused page afterwards: the page
+// is a global top-N, so post-filtering spends it on types the caller
+// never asked about and can answer nothing for a record type that is
+// simply less similar overall than five others. Empty means every type,
+// which is what the retrieval seam asks for.
+func (s *Store) HybridSearch(ctx context.Context, query string, embedder Embedder, limit int, types ...string) ([]Hit, error) {
 	limit = clampLimit(limit)
 	// Overfetch both lanes: an entity ranked just past `limit` in each
 	// lane can still fuse into the top set.
 	laneDepth := limit * 3
 
-	lexical, err := s.Search(ctx, Input{Query: query, Limit: laneDepth})
+	lexical, err := s.Search(ctx, Input{Query: query, Types: types, Limit: laneDepth})
 	if err != nil {
 		return nil, err
 	}
@@ -64,7 +71,7 @@ func (s *Store) HybridSearch(ctx context.Context, query string, embedder Embedde
 	if len(queryEmb.Vectors) != 1 {
 		return nil, fmt.Errorf("search: query embedding returned %d vectors", len(queryEmb.Vectors))
 	}
-	vector, err := s.SimilarEntities(ctx, queryEmb.Vectors[0], identity, laneDepth)
+	vector, err := s.SimilarEntities(ctx, queryEmb.Vectors[0], identity, laneDepth, types...)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/modules/search/queryexec.go
+++ b/backend/internal/modules/search/queryexec.go
@@ -1,0 +1,382 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package search
+
+// Executing a validated plan (SEARCH-PARAM-7, the execution half).
+//
+// The executor takes a ValidatedPlan and nothing else, so nothing reaches a
+// statement that has not passed the vocabulary. What it adds on top is the
+// second half of the same contract: an answer that says what KIND of answer it
+// is. Rows without a coverage verdict are the failure this file exists to
+// prevent — a ranked top-N and an exhaustive count look identical on the wire,
+// and a caller that cannot tell them apart will read one as the other.
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// The three coverage verdicts (the closed set the subsystem pins).
+const (
+	// CoverageCompleteExact: every clause ran exactly and the answer fits in
+	// the page. This is the only verdict that claims completeness, and the
+	// only one a caller may count with.
+	CoverageCompleteExact = "complete_exact"
+	// CoverageRankedSemantic: a similarity clause ordered the answer. Recall
+	// is bounded by the ranking, which is what asking for similarity means.
+	CoverageRankedSemantic = "ranked_semantic"
+	// CoveragePartialDegraded: something could not be answered as asked — an
+	// unavailable predicate, a degraded ranking lane, or an answer cut off at
+	// the page.
+	CoveragePartialDegraded = "partial_degraded"
+)
+
+// The notes that justify a verdict. One code per reason, so a caller branches
+// on the reason rather than on prose.
+const (
+	// CodeSemanticRankingDegraded: no embedding lane is bound, so a similarity
+	// clause ranked lexically. Told rather than hidden: a degradation nobody
+	// is told about is indistinguishable from a working feature.
+	CodeSemanticRankingDegraded = "semantic_ranking_degraded_to_lexical"
+	// CodeResultTruncated: more rows match than the page carries. v1 has no
+	// cursor member, so the rest cannot be asked for — which makes truncation
+	// a degradation rather than pagination.
+	CodeResultTruncated = "result_truncated_at_limit"
+)
+
+// QueryResult is one answered plan.
+type QueryResult struct {
+	Rows     []QueryRow
+	Coverage string
+	Notes    []QueryNote
+	// Narrative is the executed plan in plain language. A caller reading rows
+	// beside a sentence describing a different query is how a wrong answer
+	// becomes a trusted one.
+	Narrative string
+	Limit     int
+}
+
+// QueryRow is one record the plan admitted, as a REFERENCE. This module may
+// not import a sibling (ADR-0054 §3), so it answers ids and the display title
+// each branch already declares; the tool layer hydrates through the datasource
+// seam, which is where record shaping and the overlay's trust tier live.
+type QueryRow struct {
+	Type  string
+	ID    ids.UUID
+	Title string
+	// Score is the similarity rank score, and zero on a plan that asked for
+	// no ranking — an exact answer has no order to justify.
+	Score float64
+	// Evidence is the hop record that admitted this row, when the plan took a
+	// traversal. It is what makes a hop legible as a reason rather than as an
+	// invisible filter.
+	Evidence []QueryEvidence
+}
+
+// QueryEvidence is one record that admitted a row, and why.
+type QueryEvidence struct {
+	Relation string
+	Type     string
+	ID       ids.UUID
+	Title    string
+}
+
+// QueryNote is one machine-readable reason the coverage is what it is.
+type QueryNote struct {
+	Code string
+	// Path is the plan-document path the note is about, and empty when the
+	// note is about the answer as a whole.
+	Path   string
+	Detail string
+}
+
+// QueryExecutor answers validated plans.
+type QueryExecutor struct {
+	store    *Store
+	embedder Embedder
+	columns  ColumnReader
+}
+
+// NewQueryExecutor builds the executor over this module's own store, its
+// embedder and the schema reader. The column reader is REQUIRED: the
+// vocabulary's nil pass-through widens what may be asked, and a widened
+// vocabulary is exactly what must not be executed against a table nobody
+// checked.
+func NewQueryExecutor(store *Store, embedder Embedder, columns ColumnReader) *QueryExecutor {
+	return &QueryExecutor{store: store, embedder: embedder, columns: columns}
+}
+
+// Execute answers the plan.
+//
+// A plan carrying an UNAVAILABLE predicate answers with its notes and no rows
+// (SEARCH-AC-17, and ValidatedPlan's own contract). Returning rows while
+// quietly dropping the predicate would answer a different, wider question in a
+// shape indistinguishable from the right one — and the row count would leak
+// the size of an answer the caller cannot have.
+func (e *QueryExecutor) Execute(ctx context.Context, plan ValidatedPlan) (QueryResult, error) {
+	result := QueryResult{Limit: plan.Limit, Narrative: explainPlan(plan)}
+	if notes := unavailableNotes(plan); len(notes) > 0 {
+		result.Coverage, result.Notes = CoveragePartialDegraded, notes
+		return result, nil
+	}
+	if e.columns == nil {
+		return QueryResult{}, fmt.Errorf("search: the query executor has no schema reader wired")
+	}
+	binding, err := e.bindPlan(ctx, plan)
+	if err != nil {
+		return QueryResult{}, err
+	}
+	ranked, degraded, err := e.rankCandidates(ctx, plan)
+	if err != nil {
+		return QueryResult{}, err
+	}
+	if degraded {
+		result.Notes = append(result.Notes, QueryNote{
+			Code:   CodeSemanticRankingDegraded,
+			Detail: "no embedding lane is bound, so the ranking is lexical; similarity recall is narrower than it would otherwise be",
+		})
+	}
+	binding.candidates = rankedIDs(ranked)
+	if plan.Plan.SimilarTo != "" && len(binding.candidates) == 0 {
+		// Nothing ranked, so nothing can be admitted. Running the statement
+		// with an empty membership test would answer the unfiltered question.
+		result.Coverage = coverageOf(plan, answerShape{degraded: degraded})
+		return result, nil
+	}
+	rows, err := e.answerRows(ctx, plan, binding)
+	if err != nil {
+		return QueryResult{}, err
+	}
+	truncated := plan.Plan.SimilarTo == "" && len(rows) > plan.Limit
+	if truncated {
+		rows = rows[:plan.Limit]
+		result.Notes = append(result.Notes, QueryNote{
+			Code:   CodeResultTruncated,
+			Detail: fmt.Sprintf("more records match than the page of %d carries; narrow the plan to see the rest", plan.Limit),
+		})
+	}
+	result.Rows = orderByRank(rows, ranked, plan.Limit)
+	result.Coverage = coverageOf(plan, answerShape{truncated: truncated, degraded: degraded})
+	return result, nil
+}
+
+// bindPlan resolves where the plan's record types are stored and what they can
+// answer.
+func (e *QueryExecutor) bindPlan(ctx context.Context, plan ValidatedPlan) (planBinding, error) {
+	branch, ok := branchFor(plan.Target.Target)
+	if !ok {
+		return planBinding{}, fmt.Errorf("search: %q is not a searchable record type", plan.Target.Target)
+	}
+	columns, err := storageFor(ctx, e.columns, plan.Target.Target)
+	if err != nil {
+		return planBinding{}, err
+	}
+	binding := planBinding{branch: branch, columns: columns, fetch: plan.Limit + 1}
+	if plan.Hop == nil {
+		return binding, nil
+	}
+	hopBranch, ok := branchFor(plan.Hop.Target)
+	if !ok {
+		return planBinding{}, fmt.Errorf("search: relation %q lands on %q, which is not a searchable record type",
+			plan.Hop.Name, plan.Hop.Target)
+	}
+	hopColumns, err := storageFor(ctx, e.columns, plan.Hop.Target)
+	if err != nil {
+		return planBinding{}, err
+	}
+	hop := newHopBinding(*plan.Hop, hopBranch, hopColumns)
+	binding.hop = &hop
+	return binding, nil
+}
+
+// answerRows compiles and runs the statement. An unadmitted record type answers no
+// rows rather than an error: object RBAC can change under a plan, and a caller
+// who lost the grant mid-flight learns the same thing an empty workspace tells
+// them.
+func (e *QueryExecutor) answerRows(ctx context.Context, plan ValidatedPlan, binding planBinding) ([]QueryRow, error) {
+	compiler := &planCompiler{}
+	sql, admitted, err := compiler.compileStatement(ctx, plan, binding)
+	if err != nil || !admitted {
+		return nil, err
+	}
+	var rows []QueryRow
+	err = database.WithWorkspaceTx(ctx, e.store.pool, func(tx pgx.Tx) error {
+		queried, err := tx.Query(ctx, sql, compiler.args...)
+		if err != nil {
+			return fmt.Errorf("search: running the query plan: %w", err)
+		}
+		defer queried.Close()
+		rows, err = scanPlanRows(queried, plan, binding)
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+// scanPlanRows materializes the answer, carrying the hop row as the evidence
+// that admitted each record.
+func scanPlanRows(queried pgx.Rows, plan ValidatedPlan, binding planBinding) ([]QueryRow, error) {
+	var rows []QueryRow
+	for queried.Next() {
+		row := QueryRow{Type: plan.Target.Target}
+		var title, hopTitle *string
+		var hopID *ids.UUID
+		targets := []any{&row.ID, &title}
+		if binding.hop != nil {
+			targets = append(targets, &hopID, &hopTitle)
+		}
+		if err := queried.Scan(targets...); err != nil {
+			return nil, fmt.Errorf("search: reading the query plan's answer: %w", err)
+		}
+		if title != nil {
+			row.Title = *title
+		}
+		if hopID != nil {
+			evidence := QueryEvidence{Relation: binding.hop.relation.Name, Type: binding.hop.relation.Target, ID: *hopID}
+			if hopTitle != nil {
+				evidence.Title = *hopTitle
+			}
+			row.Evidence = append(row.Evidence, evidence)
+		}
+		rows = append(rows, row)
+	}
+	if err := queried.Err(); err != nil {
+		return nil, fmt.Errorf("search: reading the query plan's answer: %w", err)
+	}
+	return rows, nil
+}
+
+// rankCandidates runs the similarity clause through the module's hybrid arm, narrowed to
+// the plan's target type. degraded reports that the arm had no embedding lane
+// to rank with and fell back to the lexical one — the arm degrades silently, so
+// the same question is asked here to be able to say so.
+func (e *QueryExecutor) rankCandidates(ctx context.Context, plan ValidatedPlan) (ranked []Hit, degraded bool, err error) {
+	if plan.Plan.SimilarTo == "" {
+		return nil, false, nil
+	}
+	// Overfetched, because the arm ranks across every record type and only
+	// this plan's type can be admitted; the fused page would otherwise be
+	// spent on types the plan never asked about.
+	hits, err := e.store.HybridSearch(ctx, plan.Plan.SimilarTo, e.embedder, clampLimit(plan.Limit*candidateDepth))
+	if err != nil {
+		return nil, false, err
+	}
+	for _, hit := range hits {
+		if hit.Type == plan.Target.Target {
+			ranked = append(ranked, hit)
+		}
+	}
+	return ranked, !embeddingLaneBound(e.embedder), nil
+}
+
+// candidateDepth overfetches the ranking lane relative to the page, since the
+// fused ranking spans every record type and only one of them is admissible.
+const candidateDepth = 3
+
+// embeddingLaneBound asks the embedder the same question the hybrid arm asks
+// before it degrades: a nil embedder and one whose identity is empty (the
+// offline fake, or a routing config that never bound an embeddings model) are
+// the same shape from the query side.
+func embeddingLaneBound(embedder Embedder) bool {
+	if embedder == nil {
+		return false
+	}
+	identity, _ := embedder.EmbedIdentity()
+	return identity != ""
+}
+
+func rankedIDs(ranked []Hit) []ids.UUID {
+	out := make([]ids.UUID, len(ranked))
+	for i, hit := range ranked {
+		out[i] = hit.ID
+	}
+	return out
+}
+
+// orderByRank puts the answer in the ranking's order and scores each row with
+// the rank it came back with. An exact answer is already in the statement's
+// order and keeps it.
+func orderByRank(rows []QueryRow, ranked []Hit, limit int) []QueryRow {
+	if len(ranked) == 0 {
+		return rows
+	}
+	position := make(map[ids.UUID]int, len(ranked))
+	score := make(map[ids.UUID]float64, len(ranked))
+	for i, hit := range ranked {
+		position[hit.ID], score[hit.ID] = i, hit.Score
+	}
+	slices.SortFunc(rows, func(a, b QueryRow) int { return position[a.ID] - position[b.ID] })
+	for i := range rows {
+		rows[i].Score = score[rows[i].ID]
+	}
+	if len(rows) > limit {
+		rows = rows[:limit]
+	}
+	return rows
+}
+
+// unavailableNotes renders the validator's unavailable predicates as the notes
+// the answer carries instead of rows.
+func unavailableNotes(plan ValidatedPlan) []QueryNote {
+	notes := make([]QueryNote, 0, len(plan.Unavailable))
+	for _, unavailable := range plan.Unavailable {
+		notes = append(notes, QueryNote{
+			Code: unavailable.Code, Path: unavailable.Path,
+			Detail: unavailableDetail(unavailable.Code),
+		})
+	}
+	if len(notes) == 0 {
+		return nil
+	}
+	return notes
+}
+
+// unavailableDetail is the advice one unavailable code carries. It switches on
+// the CODE rather than sharing a sentence: "ask for a city instead" is the
+// right next step for a radius and nonsense for anything else, and a second
+// code inheriting it would send a caller somewhere unrelated.
+func unavailableDetail(code string) string {
+	const cannotAnswer = "this deployment cannot answer that predicate, so no rows are returned"
+	if code == CodeDistanceRankingUnavailable {
+		return cannotAnswer + "; records carry no normalized coordinates yet — " +
+			"ask for a city or region as an exact predicate instead"
+	}
+	return cannotAnswer
+}
+
+// answerShape is what answering the plan turned out to cost — the whole of
+// what the verdict is decided from, beyond the plan itself.
+type answerShape struct {
+	// truncated: more rows matched than the page carries.
+	truncated bool
+	// degraded: a lane could not run as asked.
+	degraded bool
+}
+
+// coverageOf decides the verdict. Degradation dominates ranking and ranking
+// dominates completeness, so the only answer that ever claims to be complete
+// is one that ran exactly, whole, and undegraded.
+//
+// Truncation is a verdict on the EXACT lane only. A ranked answer is a top-N
+// by construction — that is what ranked_semantic says — so counting its bound
+// as a degradation would leave the verdict unreachable and tell a caller
+// nothing they did not ask for.
+func coverageOf(plan ValidatedPlan, shape answerShape) string {
+	switch {
+	case shape.degraded || shape.truncated:
+		return CoveragePartialDegraded
+	case plan.Plan.SimilarTo != "":
+		return CoverageRankedSemantic
+	default:
+		return CoverageCompleteExact
+	}
+}

--- a/backend/internal/modules/search/queryexec.go
+++ b/backend/internal/modules/search/queryexec.go
@@ -263,23 +263,25 @@ func (e *QueryExecutor) rankCandidates(ctx context.Context, plan ValidatedPlan) 
 	if plan.Plan.SimilarTo == "" {
 		return nil, false, nil
 	}
-	// Overfetched, because the arm ranks across every record type and only
-	// this plan's type can be admitted; the fused page would otherwise be
-	// spent on types the plan never asked about.
-	hits, err := e.store.HybridSearch(ctx, plan.Plan.SimilarTo, e.embedder, clampLimit(plan.Limit*candidateDepth))
+	// Narrowed to the plan's own record type and overfetched. Narrowing is
+	// what makes the ranking answer the question that was asked: a global
+	// page filtered afterwards spends itself on types the plan never named,
+	// and can come back empty for a target that simply ranks below five
+	// others — a recall hole the caller reads as "no such records".
+	//
+	// Overfetching is what is left honest afterwards: the exact predicates
+	// still run over the ranked candidates, so a page of them can narrow
+	// further. That bound IS what ranked_semantic means.
+	ranked, err = e.store.HybridSearch(ctx, plan.Plan.SimilarTo, e.embedder,
+		clampLimit(plan.Limit*candidateDepth), plan.Target.Target)
 	if err != nil {
 		return nil, false, err
-	}
-	for _, hit := range hits {
-		if hit.Type == plan.Target.Target {
-			ranked = append(ranked, hit)
-		}
 	}
 	return ranked, !embeddingLaneBound(e.embedder), nil
 }
 
-// candidateDepth overfetches the ranking lane relative to the page, since the
-// fused ranking spans every record type and only one of them is admissible.
+// candidateDepth overfetches the ranking lane relative to the page, so the
+// exact predicates have more than a page of ranked candidates to narrow.
 const candidateDepth = 3
 
 // embeddingLaneBound asks the embedder the same question the hybrid arm asks

--- a/backend/internal/modules/search/queryexec_test.go
+++ b/backend/internal/modules/search/queryexec_test.go
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package search
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/model"
+)
+
+// A validated-but-unanswerable predicate answers with its note and NO rows.
+// Rows returned while the predicate was quietly dropped would answer a wider
+// question in a shape indistinguishable from the right one — and the row count
+// would leak the size of an answer the caller cannot have.
+func TestAnUnavailablePredicateAnswersWithNotesAndNoRows(t *testing.T) {
+	ctx := readerFor(entityOrganization)
+	plan := validatedPlanDoc(ctx, t, `{
+		"version": "v1", "target": "organization",
+		"where": [{"field": "address", "op": "within_radius",
+		           "value": {"center": "Stuttgart", "radius_km": 50}}]}`)
+	if len(plan.Unavailable) != 1 {
+		t.Fatalf("the validator marked %d predicates unavailable", len(plan.Unavailable))
+	}
+	// No store and no schema reader: reaching either would mean the executor
+	// ran a statement for a plan it had already been told it cannot answer.
+	result, err := (&QueryExecutor{}).Execute(ctx, plan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Rows) != 0 {
+		t.Fatalf("an unanswerable plan returned %d rows", len(result.Rows))
+	}
+	if result.Coverage != CoveragePartialDegraded {
+		t.Errorf("coverage is %q", result.Coverage)
+	}
+	if len(result.Notes) != 1 || result.Notes[0].Code != CodeDistanceRankingUnavailable {
+		t.Fatalf("notes are %v", result.Notes)
+	}
+	if result.Notes[0].Path != "where[0]" {
+		t.Errorf("the note names %q rather than the predicate it is about", result.Notes[0].Path)
+	}
+	// The sentence says so too: a note in a field nobody reads is a note
+	// nobody reads.
+	if !strings.Contains(result.Narrative, "No rows are returned") {
+		t.Errorf("narrative is %q", result.Narrative)
+	}
+}
+
+// The vocabulary's nil pass-through WIDENS what may be asked. Executing a
+// widened vocabulary against a table nobody checked is the one thing that
+// pass-through must never reach.
+func TestAnExecutorWithNoSchemaReaderRefusesToRun(t *testing.T) {
+	ctx := readerFor(entityDeal)
+	plan := validatedPlanDoc(ctx, t, `{"version": "v1", "target": "deal"}`)
+	if _, err := (&QueryExecutor{}).Execute(ctx, plan); err == nil {
+		t.Fatal("an executor with no schema reader ran a plan")
+	}
+}
+
+// The exit criterion, as a unit: no ranked answer ever labels itself complete.
+func TestCoverageNeverClaimsCompletenessForAnAnswerThatLacksIt(t *testing.T) {
+	ranked := ValidatedPlan{Plan: Plan{SimilarTo: "manufacturers who churned"}}
+	exact := ValidatedPlan{}
+	for _, tc := range []struct {
+		name      string
+		plan      ValidatedPlan
+		truncated bool
+		degraded  bool
+		want      string
+	}{
+		{"an exact answer that fits", exact, false, false, CoverageCompleteExact},
+		{"an exact answer cut off at the page", exact, true, false, CoveragePartialDegraded},
+		{"a ranked answer", ranked, false, false, CoverageRankedSemantic},
+		{"a ranked answer with no embedding lane", ranked, false, true, CoveragePartialDegraded},
+		{"a ranked answer cut off at the page", ranked, true, false, CoveragePartialDegraded},
+		{"an exact answer with no embedding lane to degrade", exact, false, true, CoveragePartialDegraded},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := coverageOf(tc.plan, answerShape{truncated: tc.truncated, degraded: tc.degraded}); got != tc.want {
+				t.Errorf("coverage is %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// Membership is decided by the exact predicates; ORDER is the retriever's.
+func TestARankedAnswerIsReturnedInTheRankingsOrder(t *testing.T) {
+	first, second, third := ids.NewV7(), ids.NewV7(), ids.NewV7()
+	rows := []QueryRow{{ID: third}, {ID: first}, {ID: second}}
+	ranked := []Hit{{ID: first, Score: 0.9}, {ID: second, Score: 0.5}, {ID: third, Score: 0.1}}
+	ordered := orderByRank(rows, ranked, 10)
+	if ordered[0].ID != first || ordered[1].ID != second || ordered[2].ID != third {
+		t.Fatalf("order is %v", ordered)
+	}
+	if ordered[0].Score != 0.9 {
+		t.Errorf("the row carries score %v rather than the rank it came back with", ordered[0].Score)
+	}
+}
+
+// An exact answer has no order to justify, so its rows keep the statement's.
+func TestAnExactAnswerKeepsTheStatementsOrder(t *testing.T) {
+	first, second := ids.NewV7(), ids.NewV7()
+	rows := []QueryRow{{ID: second}, {ID: first}}
+	ordered := orderByRank(rows, nil, 10)
+	if ordered[0].ID != second {
+		t.Fatalf("an exact answer was reordered: %v", ordered)
+	}
+	if ordered[0].Score != 0 {
+		t.Errorf("an unranked row carries score %v", ordered[0].Score)
+	}
+}
+
+func TestARankedAnswerIsCutToThePageAfterItIsOrdered(t *testing.T) {
+	first, second := ids.NewV7(), ids.NewV7()
+	ordered := orderByRank([]QueryRow{{ID: second}, {ID: first}},
+		[]Hit{{ID: first, Score: 0.9}, {ID: second, Score: 0.2}}, 1)
+	if len(ordered) != 1 || ordered[0].ID != first {
+		t.Fatalf("the page kept %v; ordering must precede the cut, or the page is the wrong rows", ordered)
+	}
+}
+
+// The hybrid arm degrades to the lexical lane SILENTLY. The executor asks the
+// same question it asks, so it can say so: a degradation nobody is told about
+// is indistinguishable from a working feature.
+func TestAnUnboundEmbeddingLaneIsReportedRatherThanHidden(t *testing.T) {
+	if embeddingLaneBound(nil) {
+		t.Error("a nil embedder reports a bound lane")
+	}
+	if embeddingLaneBound(stubEmbedder{}) {
+		t.Error("an embedder with no identity reports a bound lane")
+	}
+	if !embeddingLaneBound(stubEmbedder{identity: "openai:text-embedding-3-small:1536"}) {
+		t.Error("a bound embedder reports an unbound lane")
+	}
+}
+
+// stubEmbedder is the embedding seam: identity is what the query side reads to
+// decide whether there is a lane to rank against at all.
+type stubEmbedder struct {
+	identity string
+}
+
+func (e stubEmbedder) EmbedIdentity() (string, int) { return e.identity, 1536 }
+
+func (e stubEmbedder) Embed(context.Context, model.EmbedRequest) (model.Embeddings, error) {
+	return model.Embeddings{}, nil
+}
+
+// A plan naming a record type that is not searchable is a wiring fault rather
+// than a caller error — the validator settled the target against the same
+// closed set — so it fails loudly instead of answering an empty page.
+func TestAPlanBoundToAnUnsearchableRecordTypeFailsLoudly(t *testing.T) {
+	executor := &QueryExecutor{columns: stubColumns{tables: planTables}}
+	_, err := executor.bindPlan(readerFor(entityDeal), ValidatedPlan{Target: TargetVocabulary{Target: "workspace"}})
+	if err == nil {
+		t.Fatal("a plan bound to a record type this module does not search")
+	}
+}
+
+// The hop's binding carries the hop's own columns, so a hop predicate is
+// compiled against the table it filters rather than against the target's.
+func TestTheHopIsBoundToItsOwnTablesColumns(t *testing.T) {
+	ctx := readerFor(entityDeal, entityOrganization)
+	plan := validatedPlanDoc(ctx, t, `{
+		"version": "v1", "target": "deal",
+		"traverse": {"relation": "organization",
+		             "where": [{"field": "address.city", "op": "eq", "value": "Stuttgart"}]}}`)
+	executor := &QueryExecutor{columns: stubColumns{tables: planTables}}
+	binding, err := executor.bindPlan(ctx, plan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if binding.hop == nil {
+		t.Fatal("the plan takes a hop and the binding carries none")
+	}
+	if !binding.hop.columns.answers(newField("address.city", KindText)) {
+		t.Error("the hop's columns do not answer the hop's own field")
+	}
+	if binding.hop.columns.answers(newField("amount_minor", KindNumber)) {
+		t.Error("the hop's columns answer the TARGET's field; the hop is bound to the wrong table")
+	}
+}
+
+// A schema read that fails must not become an empty schema: every field would
+// then refuse as `unknown_field`, which reads exactly like a caller who
+// mistyped one.
+func TestASchemaReadThatFailsStopsTheExecution(t *testing.T) {
+	executor := &QueryExecutor{columns: stubColumns{err: errFakeSchemaRead}}
+	_, err := executor.bindPlan(readerFor(entityDeal), ValidatedPlan{Target: TargetVocabulary{Target: entityDeal}})
+	if err == nil {
+		t.Fatal("a failed schema read bound a plan")
+	}
+}
+
+var errFakeSchemaRead = errSchemaRead{}
+
+type errSchemaRead struct{}
+
+func (errSchemaRead) Error() string { return "connection reset" }
+
+// Whitespace is PRESENT to the grammar and empty to the retriever. Left alone
+// it reaches the search store, whose own refusal names `q` — a field this plan
+// does not have, sending a caller to look for something they never sent.
+func TestABlankSimilarityClauseIsRefusedUnderItsOwnName(t *testing.T) {
+	decoded, err := DecodePlan([]byte(`{"version": "v1", "target": "deal", "similar_to": "   "}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	validator := NewPlanValidator(NewVocabularyResolver().WithColumnReader(stubColumns{tables: planTables}))
+	_, err = validator.Validate(readerFor(entityDeal), decoded)
+	var refusal *PlanRefusal
+	if !errors.As(err, &refusal) {
+		t.Fatalf("a blank similarity clause validated: %v", err)
+	}
+	faults := refusal.FieldFaults()
+	if len(faults) != 1 || faults[0].Field != "similar_to" || faults[0].Code != CodeValueMissing {
+		t.Fatalf("faults are %v", faults)
+	}
+}
+
+// An ABSENT similarity clause is a different and perfectly good plan: rank
+// nothing, answer exactly.
+func TestAnAbsentSimilarityClauseIsNotARefusal(t *testing.T) {
+	plan := validatedPlanDoc(readerFor(entityDeal), t, `{"version": "v1", "target": "deal"}`)
+	if plan.Plan.SimilarTo != "" {
+		t.Fatalf("similarity clause is %q", plan.Plan.SimilarTo)
+	}
+}

--- a/backend/internal/modules/search/queryexec_test.go
+++ b/backend/internal/modules/search/queryexec_test.go
@@ -231,3 +231,38 @@ func TestAnAbsentSimilarityClauseIsNotARefusal(t *testing.T) {
 		t.Fatalf("similarity clause is %q", plan.Plan.SimilarTo)
 	}
 }
+
+// json.Unmarshal accepts null into every Go type and leaves the zero value, so
+// a null grammar member reads as one the caller never sent. `similar_to: null`
+// is the costly one: it decodes to "" and reads exactly like a plan that asked
+// for no ranking, dropping the caller's clause in silence.
+func TestANullGrammarMemberIsRefusedRatherThanReadAsAbsent(t *testing.T) {
+	for _, doc := range []string{
+		`{"version": "v1", "target": "deal", "similar_to": null}`,
+		`{"version": "v1", "target": "deal", "traverse": null}`,
+		`{"version": "v1", "target": "deal", "where": null}`,
+	} {
+		if _, err := DecodePlan([]byte(doc)); err == nil {
+			t.Errorf("a null grammar member decoded: %s", doc)
+		}
+	}
+}
+
+// The two OPERAND members keep their own, better-targeted refusals: the
+// validator judges a null there against the field it belongs to.
+func TestANullOperandKeepsItsOwnRefusal(t *testing.T) {
+	doc := `{"version": "v1", "target": "deal", "where": [{"field": "name", "op": "in", "values": null}]}`
+	decoded, err := DecodePlan([]byte(doc))
+	if err != nil {
+		t.Fatalf("the operand scan refused a null the validator judges: %v", err)
+	}
+	validator := NewPlanValidator(NewVocabularyResolver().WithColumnReader(stubColumns{tables: planTables}))
+	_, err = validator.Validate(readerFor(entityDeal), decoded)
+	var refusal *PlanRefusal
+	if !errors.As(err, &refusal) {
+		t.Fatalf("a null operand list validated: %v", err)
+	}
+	if faults := refusal.FieldFaults(); len(faults) != 1 || faults[0].Code != CodeValueMissing {
+		t.Fatalf("faults are %v", faults)
+	}
+}

--- a/backend/internal/modules/search/queryexplain.go
+++ b/backend/internal/modules/search/queryexplain.go
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package search
+
+// The executed plan, in plain language.
+//
+// It is rendered from the VALIDATED plan — the thing that actually ran — and
+// deterministically, with no model in the path. A sentence generated from the
+// caller's request rather than from the executed plan would describe the query
+// it hoped for, which is precisely the failure worth catching: rows read beside
+// a sentence describing a different question are how a wrong answer becomes a
+// trusted one.
+
+import (
+	"bytes"
+	"encoding/json"
+	"strconv"
+	"strings"
+)
+
+// explainPlan renders one validated plan as a sentence.
+func explainPlan(plan ValidatedPlan) string {
+	sentence := plan.Target.Target + " records"
+	if clause := explainPredicates(plan.Plan.Where); clause != "" {
+		sentence += " where " + clause
+	}
+	sentence += explainHop(plan)
+	if plan.Plan.SimilarTo != "" {
+		sentence += ", ranked by similarity to " + quote(plan.Plan.SimilarTo)
+	}
+	sentence += "; at most " + strconv.Itoa(plan.Limit)
+	if plan.Plan.SimilarTo == "" {
+		sentence += ", newest first"
+	}
+	sentence += "."
+	if unanswerable := explainUnavailable(plan); unanswerable != "" {
+		sentence += " " + unanswerable
+	}
+	return sentence
+}
+
+// explainHop renders the traversal, naming the record type the hop lands on
+// rather than the relation's own name, since a caller reads "at an
+// organization" more readily than "over the organization relation".
+func explainHop(plan ValidatedPlan) string {
+	if plan.Hop == nil || plan.Plan.Traverse == nil {
+		return ""
+	}
+	sentence := ", linked to " + article(plan.Hop.Target) + " " + plan.Hop.Target + " record"
+	if clause := explainPredicates(plan.Plan.Traverse.Where); clause != "" {
+		sentence += " where " + clause
+	}
+	return sentence
+}
+
+// explainUnavailable says which predicates did not run, and what that cost the
+// answer. A note in a field a caller may not read is a note nobody reads.
+func explainUnavailable(plan ValidatedPlan) string {
+	if len(plan.Unavailable) == 0 {
+		return ""
+	}
+	paths := make([]string, len(plan.Unavailable))
+	for i, unavailable := range plan.Unavailable {
+		paths[i] = unavailable.Path
+	}
+	return "No rows are returned: " + joinWithCommas(paths) +
+		" cannot be answered by this deployment, and narrowing the plan silently would answer a different question."
+}
+
+// article picks the indefinite article a record type's name takes. It is a
+// sentence a person reads, and "a organization" is the kind of seam that makes
+// a generated explanation read as machine output rather than as an answer.
+func article(word string) string {
+	if word == "" || !strings.ContainsRune("aeiou", rune(word[0])) {
+		return "a"
+	}
+	return "an"
+}
+
+func explainPredicates(clauses []Predicate) string {
+	parts := make([]string, 0, len(clauses))
+	for _, clause := range clauses {
+		parts = append(parts, clause.Field+" "+comparatorPhrase(clause.Op)+" "+explainOperand(clause))
+	}
+	return strings.Join(parts, " and ")
+}
+
+// comparatorPhrase is each operator's reading. It is a total mapping over the
+// operator set rather than a lookup with a fallback: an operator with no
+// phrase would otherwise be rendered as its own machine name inside an
+// English sentence, which reads as a bug in the answer rather than a gap in
+// the sentence.
+func comparatorPhrase(op string) string {
+	switch op {
+	case OpEq:
+		return "is"
+	case OpNeq:
+		return "is not"
+	case OpIn:
+		return "is one of"
+	case OpLt:
+		return "is less than"
+	case OpLte:
+		return "is at most"
+	case OpGt:
+		return "is more than"
+	case OpGte:
+		return "is at least"
+	case OpWithinRadius:
+		return "is within"
+	default:
+		return op
+	}
+}
+
+// explainOperand renders the operand the way the caller wrote it. It is their
+// own text and already JSON, so it is compacted rather than re-encoded — a
+// re-encoding would quietly normalise the value the sentence claims ran.
+func explainOperand(clause Predicate) string {
+	raw := clause.Value
+	if clause.Op == OpIn {
+		raw = clause.Values
+	}
+	var compact bytes.Buffer
+	if err := json.Compact(&compact, raw); err != nil {
+		// Unreachable on a validated plan, whose operands decoded already. An
+		// operand that cannot be compacted is still shown, uncompacted, rather
+		// than dropped: a sentence missing the value it filtered on is worse
+		// than an untidy one.
+		return string(raw)
+	}
+	return compact.String()
+}

--- a/backend/internal/modules/search/queryexplain_test.go
+++ b/backend/internal/modules/search/queryexplain_test.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package search
+
+import (
+	"strings"
+	"testing"
+)
+
+// The sentence describes what RAN. It is rendered from the validated plan, so
+// a caller reading rows beside it is reading a description of the query those
+// rows came from.
+func TestTheNarrativeDescribesTheExecutedPlan(t *testing.T) {
+	plan := validatedPlanDoc(readerFor(entityDeal, entityOrganization), t, `{
+		"version": "v1", "target": "deal",
+		"where": [{"field": "status", "op": "eq", "value": "open"},
+		          {"field": "amount_minor", "op": "gte", "value": 100000}],
+		"traverse": {"relation": "organization",
+		             "where": [{"field": "address.city", "op": "eq", "value": "Stuttgart"}]},
+		"similar_to": "manufacturers who churned after a pilot",
+		"limit": 25}`)
+	got := explainPlan(plan)
+	want := `deal records where status is "open" and amount_minor is at least 100000, ` +
+		`linked to an organization record where address.city is "Stuttgart", ` +
+		`ranked by similarity to "manufacturers who churned after a pilot"; at most 25.`
+	if got != want {
+		t.Errorf("narrative is\n  %s\nwant\n  %s", got, want)
+	}
+}
+
+// An exact answer says its order, because "newest first" is the only ordering
+// a caller can reason about when nothing ranked the rows.
+func TestAnExactPlanSaysItsOrder(t *testing.T) {
+	plan := validatedPlanDoc(readerFor(entityDeal), t, `{
+		"version": "v1", "target": "deal", "limit": 10}`)
+	if got := explainPlan(plan); got != "deal records; at most 10, newest first." {
+		t.Errorf("narrative is %q", got)
+	}
+}
+
+// Every operator reads as words. An operator rendered as its own machine name
+// inside an English sentence reads as a bug in the answer.
+func TestEveryOperatorHasAReading(t *testing.T) {
+	for _, op := range []string{OpEq, OpNeq, OpIn, OpLt, OpLte, OpGt, OpGte, OpWithinRadius} {
+		phrase := comparatorPhrase(op)
+		if phrase == op {
+			t.Errorf("%q reads as itself", op)
+		}
+		if !strings.HasPrefix(phrase, "is") {
+			t.Errorf("%q reads as %q, which does not continue the sentence", op, phrase)
+		}
+	}
+}
+
+// A membership test reads its list, not its single-value member — the operand
+// the operator actually used.
+func TestAMembershipTestReadsItsList(t *testing.T) {
+	plan := validatedPlanDoc(readerFor(entityDeal), t, `{
+		"version": "v1", "target": "deal",
+		"where": [{"field": "status", "op": "in", "values": ["open", "won"]}]}`)
+	if got := explainPlan(plan); !strings.Contains(got, `status is one of ["open","won"]`) {
+		t.Errorf("narrative is %q", got)
+	}
+}
+
+// The sentence carries the predicate that did NOT run, and says what that cost
+// the answer. A note in a machine field nobody reads is a note nobody reads.
+func TestTheNarrativeNamesThePredicateThatCouldNotRun(t *testing.T) {
+	plan := validatedPlanDoc(readerFor(entityOrganization), t, `{
+		"version": "v1", "target": "organization",
+		"where": [{"field": "address", "op": "within_radius",
+		           "value": {"center": "Stuttgart", "radius_km": 50}}]}`)
+	got := explainPlan(plan)
+	for _, want := range []string{"address is within", "where[0]", "No rows are returned"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("narrative %q lacks %q", got, want)
+		}
+	}
+}
+
+// The operand is the caller's own text and already JSON, so it is compacted
+// rather than re-encoded: a re-encoding would quietly normalise the value the
+// sentence claims ran.
+func TestTheOperandIsShownAsTheCallerWroteIt(t *testing.T) {
+	plan := validatedPlanDoc(readerFor(entityDeal), t, `{
+		"version": "v1", "target": "deal",
+		"where": [{"field": "amount_minor", "op": "gt", "value":    100000   }]}`)
+	if got := explainPlan(plan); !strings.Contains(got, "amount_minor is more than 100000") {
+		t.Errorf("narrative is %q", got)
+	}
+}

--- a/backend/internal/modules/search/queryplan.go
+++ b/backend/internal/modules/search/queryplan.go
@@ -206,6 +206,9 @@ func refuseDuplicateMembers(raw []byte) *PlanRefusal {
 			frame.expectKey = false
 			continue
 		}
+		if refusal := refuseNullMember(frame, tok); refusal != nil {
+			return refusal
+		}
 		if delim, isDelim := tok.(json.Delim); isDelim {
 			switch delim {
 			case '{':
@@ -222,6 +225,28 @@ func refuseDuplicateMembers(raw []byte) *PlanRefusal {
 		}
 		valueConsumed(frame)
 	}
+}
+
+// refuseNullMember refuses a literal null where the GRAMMAR expects a value.
+//
+// It is the third way encoding/json resolves something the caller did not
+// write: json.Unmarshal accepts null into every Go type without error and
+// leaves the zero value behind, so `"similar_to": null` decodes to the empty
+// string and reads exactly like a plan that asked for no ranking at all — the
+// caller's clause dropped, and the answer indistinguishable from any other.
+//
+// The two OPERAND members are exempt: `value` and `values` are the caller's
+// own payload slots, and the validator judges a null in one of them against
+// the field it belongs to, which is a better answer than this scan can give.
+func refuseNullMember(frame *jsonFrame, tok json.Token) *PlanRefusal {
+	if tok != nil || frame == nil || !frame.object || !frame.grammar {
+		return nil
+	}
+	if slices.Contains(operandMembers, frame.member) {
+		return nil
+	}
+	return refuse(frame.member, CodeValueTypeMismatch,
+		quote(frame.member)+" is null; the v1 query plan has no null value — omit the member, or give it a value")
 }
 
 // childIsGrammar answers whether a container opening inside frame is still

--- a/backend/internal/modules/search/querysql.go
+++ b/backend/internal/modules/search/querysql.go
@@ -276,8 +276,9 @@ var sqlComparators = map[string]string{
 	OpGte: ">=",
 }
 
-// dateLayout is the contract's date encoding, and timestampLayouts the two
-// spellings a caller may send an instant in.
+// dateLayout is the contract's date encoding. An instant carries the contract's
+// own timestamp encoding instead (time.RFC3339, at the one call site that binds
+// one), so there is nothing to name twice.
 const dateLayout = "2006-01-02"
 
 // bind turns one JSON operand into a bound parameter under the field's kind,

--- a/backend/internal/modules/search/querysql.go
+++ b/backend/internal/modules/search/querysql.go
@@ -90,8 +90,8 @@ func (c *planCompiler) compileStatement(ctx context.Context, plan ValidatedPlan,
 		return "", false, err
 	}
 	where := []string{"t.archived_at IS NULL"}
-	if binding.branch.extraWhere != "" {
-		where = append(where, binding.branch.extraWhere)
+	if narrowing := binding.branch.narrowing("t"); narrowing != "" {
+		where = append(where, narrowing)
 	}
 	if scope != "" {
 		where = append(where, scope)
@@ -144,6 +144,14 @@ func (c *planCompiler) lateralHop(ctx context.Context, plan ValidatedPlan, bindi
 		return "", "", nil, false, err
 	}
 	where := []string{"h.archived_at IS NULL", c.edgeCondition(*hop)}
+	// The hop carries the SAME discovery narrowing the target does. A
+	// traversal selects the hop record by its attributes, which is discovery
+	// by any other name — so a plan asking for "deals at an organization in
+	// Stuttgart" must not reach the installation's own company through a door
+	// the search arm keeps shut.
+	if narrowing := hop.branch.narrowing("h"); narrowing != "" {
+		where = append(where, narrowing)
+	}
 	if scope != "" {
 		where = append(where, scope)
 	}
@@ -318,11 +326,16 @@ func bindNumber(at string, field Field, raw json.RawMessage) (any, string, *appe
 	if whole, err := value.Int64(); err == nil {
 		return whole, "", nil
 	}
-	fractional, err := value.Float64()
-	if err != nil {
+	// A FRACTIONAL number binds as its own digits, cast to numeric. Through a
+	// float64 it would not: 0.1 is not representable in binary, so a `numeric`
+	// column holding exactly 0.1 would compare unequal to the 0.1 the caller
+	// wrote — an exact predicate answering "no rows" for a value that is
+	// there. The digits are the caller's own text and go through a bind
+	// parameter, so nothing is interpolated.
+	if _, err := value.Float64(); err != nil {
 		return nil, "", operandFault(at, field, "a number")
 	}
-	return fractional, "", nil
+	return value.String(), "::numeric", nil
 }
 
 //craft:ignore naked-any a bound parameter is whatever Go type the column's kind encodes as (string, int64, float64, bool, time.Time, ids.UUID) — the kind switch IS the conversion contract, so there is no narrower signature

--- a/backend/internal/modules/search/querysql.go
+++ b/backend/internal/modules/search/querysql.go
@@ -1,0 +1,389 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package search
+
+// A validated plan, as SQL.
+//
+// Nothing a caller wrote reaches this statement as text. A field name is
+// resolved through the vocabulary and then through the storage binding, so the
+// identifier interpolated is one Postgres itself named; operands and document
+// leaves bind as parameters. The identifier is sanitized on the way in anyway,
+// because a defence that rests on an argument about provenance is one edit away
+// from being wrong.
+//
+// Every read this builds carries what every other read on this surface carries:
+// archived_at IS NULL, the branch's discovery narrowing, object RBAC, and the
+// caller's row-scope clause — for the HOP as much as for the target, since a
+// hop is a read of the record it lands on.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// hopBinding is the resolved traversal: which record type the hop lands on,
+// what it can answer, and which side of the edge holds the reference.
+type hopBinding struct {
+	relation Relation
+	branch   searchBranch
+	columns  *storage
+	// column is the reference column, and forward says whose it is: the
+	// target's (`deal.organization_id` → organization) or the hop record's
+	// (organization → the deals that point back at it).
+	column  string
+	forward bool
+}
+
+// newHopBinding reads the edge off Relation.Via, which records the contract
+// reference the relation was DERIVED from in two spellings: a bare
+// `organization_id` is the target's own column, and a qualified
+// `deal.organization_id` is the referring record's.
+func newHopBinding(relation Relation, branch searchBranch, columns *storage) hopBinding {
+	column, forward := relation.Via, true
+	if _, qualified, ok := strings.Cut(relation.Via, "."); ok {
+		column, forward = qualified, false
+	}
+	return hopBinding{relation: relation, branch: branch, columns: columns, column: column, forward: forward}
+}
+
+// planBinding is everything the compiler needs that the plan itself does not
+// carry: where each record type is stored and what it can answer.
+type planBinding struct {
+	branch  searchBranch
+	columns *storage
+	hop     *hopBinding
+	// candidates narrows the statement to the ids the similarity lane ranked.
+	// Empty means the exact lane, which is bounded by the limit instead.
+	candidates []ids.UUID
+	// fetch is the row ceiling for the exact lane: the limit plus one, so a
+	// truncated answer is detectable rather than merely suspected.
+	fetch int
+}
+
+// planCompiler accumulates the statement's bound arguments.
+type planCompiler struct {
+	args []any
+}
+
+//craft:ignore naked-any a bound parameter is whatever Go type the column's kind encodes as (string, int64, float64, bool, time.Time, ids.UUID) — the kind switch IS the conversion contract, so there is no narrower signature
+func (c *planCompiler) arg(v any) int {
+	c.args = append(c.args, v)
+	return len(c.args)
+}
+
+// compileStatement renders the statement, or admitted=false when object RBAC has
+// stopped admitting a record type this plan needs. That is a mid-flight
+// permission change rather than a caller error, and it answers an empty result
+// for the same reason every other read on this surface does: existence-hiding
+// costs nothing here and a 403 would confirm the record type is populated.
+func (c *planCompiler) compileStatement(ctx context.Context, plan ValidatedPlan, binding planBinding) (string, bool, error) {
+	scope, admitted, err := branchScope(ctx, binding.branch, "t", c.arg)
+	if err != nil || !admitted {
+		return "", false, err
+	}
+	where := []string{"t.archived_at IS NULL"}
+	if binding.branch.extraWhere != "" {
+		where = append(where, binding.branch.extraWhere)
+	}
+	if scope != "" {
+		where = append(where, scope)
+	}
+	predicates, refusals := c.predicates("t", binding.columns, plan.Target, "where", plan.Plan.Where)
+	where = append(where, predicates...)
+
+	join, hopSelect, hopRefusals, hopAdmitted, err := c.lateralHop(ctx, plan, binding)
+	if err != nil || !hopAdmitted {
+		return "", false, err
+	}
+	refusals = append(refusals, hopRefusals...)
+	if len(refusals) > 0 {
+		return "", false, &PlanRefusal{Refusals: refusals}
+	}
+	if len(binding.candidates) > 0 {
+		where = append(where, c.idsIn("t.id", binding.candidates))
+	}
+
+	sql := fmt.Sprintf("SELECT t.id, %s AS title%s FROM %s t%s WHERE %s",
+		binding.branch.title, hopSelect, binding.branch.table, join, strings.Join(where, " AND "))
+	if len(binding.candidates) > 0 {
+		// The similarity lane is already bounded by the ranked candidate set,
+		// and its order is the retriever's rather than the table's, so it is
+		// applied after the rows come back rather than by the statement.
+		return sql, true, nil
+	}
+	// Ids are uuidv7, so the primary key already orders by creation time: one
+	// always-present, unique column, deterministic under concurrent writes
+	// without a second sort key or a nullable column to reason about.
+	return sql + fmt.Sprintf(" ORDER BY t.id DESC LIMIT $%d", c.arg(binding.fetch)), true, nil
+}
+
+// lateralHop renders the traversal as a LATERAL join that returns ONE matching
+// hop row, which is what makes the hop legible as evidence rather than as an
+// invisible filter. An EXISTS would answer the same rows and explain none of
+// them.
+//
+// The hop carries its own admission and its own row scope: a caller who cannot
+// see the Stuttgart organization cannot use it to select deals either.
+func (c *planCompiler) lateralHop(ctx context.Context, plan ValidatedPlan, binding planBinding) (
+	join, selection string, refusals []apperrors.FieldRefusal, admitted bool, err error,
+) {
+	if binding.hop == nil {
+		return "", "", nil, true, nil
+	}
+	hop := binding.hop
+	scope, admitted, err := branchScope(ctx, hop.branch, "h", c.arg)
+	if err != nil || !admitted {
+		return "", "", nil, false, err
+	}
+	where := []string{"h.archived_at IS NULL", c.edgeCondition(*hop)}
+	if scope != "" {
+		where = append(where, scope)
+	}
+	predicates, refusals := c.predicates("h", hop.columns, plan.HopVocabulary, "traverse.where", plan.Plan.Traverse.Where)
+	where = append(where, predicates...)
+
+	// ORDER BY keeps the evidence deterministic when several hop rows match;
+	// the row's membership never depends on which one is returned.
+	join = fmt.Sprintf(
+		" JOIN LATERAL (SELECT h.id AS hop_id, %s AS hop_title FROM %s h WHERE %s ORDER BY h.id LIMIT 1) hop ON true",
+		hop.branch.title, hop.branch.table, strings.Join(where, " AND "),
+	)
+	return join, ", hop.hop_id, hop.hop_title", refusals, true, nil
+}
+
+// edgeCondition joins the two records on the reference the relation was
+// derived from, in whichever direction declares it.
+func (c *planCompiler) edgeCondition(hop hopBinding) string {
+	column := sanitize(hop.column)
+	if hop.forward {
+		return "h.id = t." + column
+	}
+	return "h." + column + " = t.id"
+}
+
+// predicates renders one where-list, reporting a refusal per clause it cannot
+// bind rather than the first — a caller told about one of three operand faults
+// makes three round trips to learn what one answer could have carried.
+func (c *planCompiler) predicates(alias string, columns *storage, vocab TargetVocabulary, path string, clauses []Predicate) ([]string, []apperrors.FieldRefusal) {
+	var (
+		fragments []string
+		refusals  []apperrors.FieldRefusal
+	)
+	for i, clause := range clauses {
+		at := path + "[" + strconv.Itoa(i) + "]"
+		fragment, refusal := c.clause(alias, columns, vocab, at, clause)
+		if refusal != nil {
+			refusals = append(refusals, *refusal)
+			continue
+		}
+		fragments = append(fragments, fragment)
+	}
+	return fragments, refusals
+}
+
+// clause renders one `field op value`.
+func (c *planCompiler) clause(alias string, columns *storage, vocab TargetVocabulary, at string, clause Predicate) (string, *apperrors.FieldRefusal) {
+	field, ok := vocab.Field(clause.Field)
+	if !ok {
+		// Unreachable through Execute: the validator settled membership first,
+		// against this same vocabulary. Reaching it means the executor was
+		// handed a plan that never passed validation, which is a wiring fault
+		// to fail loudly on rather than a caller to explain it to.
+		return "", &apperrors.FieldRefusal{
+			Field: at + ".field", Code: CodeUnknownField,
+			Message: "the query plan cannot name " + quote(clause.Field) + " on " + quote(vocab.Target),
+		}
+	}
+	expr, ok := columns.expr(alias, field)
+	if !ok {
+		// Same shape, same reason: a published field compiles, and the fitness
+		// function is what keeps that true.
+		return "", &apperrors.FieldRefusal{
+			Field: at + ".field", Code: CodeUnknownField,
+			Message: quote(clause.Field) + " cannot be answered by this workspace's records",
+		}
+	}
+	if clause.Op == OpIn {
+		return c.inClause(expr, at, field, clause)
+	}
+	value, cast, refusal := c.bind(at+"."+memberValue, field, clause.Value)
+	if refusal != nil {
+		return "", refusal
+	}
+	operand := fmt.Sprintf("$%d%s", c.arg(value), cast)
+	if clause.Op == OpNeq {
+		// IS DISTINCT FROM rather than <>: a field that is UNSET is distinct
+		// from every value, and three-valued logic would otherwise drop those
+		// rows from an answer the caller reads as "everything that is not X".
+		return expr + " IS DISTINCT FROM " + operand, nil
+	}
+	comparator, ok := sqlComparators[clause.Op]
+	if !ok {
+		return "", &apperrors.FieldRefusal{
+			Field: at + ".op", Code: CodeUnknownOperator,
+			Message: quote(clause.Op) + " is not an operator this workspace can answer",
+		}
+	}
+	return expr + " " + comparator + " " + operand, nil
+}
+
+// inClause renders a membership test as an explicit parameter list. Each
+// element binds under the field's own kind, so a list carrying one operand of
+// the wrong shape is refused naming that element rather than the clause.
+func (c *planCompiler) inClause(expr, at string, field Field, clause Predicate) (string, *apperrors.FieldRefusal) {
+	var values []json.RawMessage
+	if err := json.Unmarshal(clause.Values, &values); err != nil {
+		return "", &apperrors.FieldRefusal{
+			Field: at + "." + memberValues, Code: CodeValueMissing,
+			Message: quote(OpIn) + " needs a non-empty " + quote(memberValues) + " list",
+		}
+	}
+	operands := make([]string, len(values))
+	for i, raw := range values {
+		value, cast, refusal := c.bind(at+"."+memberValues+"["+strconv.Itoa(i)+"]", field, raw)
+		if refusal != nil {
+			return "", refusal
+		}
+		operands[i] = fmt.Sprintf("$%d%s", c.arg(value), cast)
+	}
+	return expr + " IN (" + strings.Join(operands, ", ") + ")", nil
+}
+
+// sqlComparators maps the ordered and equality operators onto their SQL
+// spelling. `neq` and `in` are absent deliberately — both need more than a
+// comparator, and putting a wrong one here would be silent.
+var sqlComparators = map[string]string{
+	OpEq:  "=",
+	OpLt:  "<",
+	OpLte: "<=",
+	OpGt:  ">",
+	OpGte: ">=",
+}
+
+// dateLayout is the contract's date encoding, and timestampLayouts the two
+// spellings a caller may send an instant in.
+const dateLayout = "2006-01-02"
+
+// bind turns one JSON operand into a bound parameter under the field's kind,
+// with the cast the comparison needs.
+//
+// This is where a FORMAT is checked. The validator deliberately left it here
+// ("their format is the executor's business"): it had a shape to compare
+// against and no calendar, and refusing `"next tuesday"` at the moment it
+// would become a parameter is what keeps a malformed date a refusal rather
+// than a query that quietly matches nothing.
+//
+//craft:ignore naked-any a bound parameter is whatever Go type the column's kind encodes as (string, int64, float64, bool, time.Time, ids.UUID) — the kind switch IS the conversion contract, so there is no narrower signature
+func (c *planCompiler) bind(at string, field Field, raw json.RawMessage) (any, string, *apperrors.FieldRefusal) {
+	switch field.Kind {
+	case KindNumber:
+		return bindNumber(at, field, raw)
+	case KindBoolean:
+		var value bool
+		return value, "", decodeOperand(at, field, raw, &value, "true or false")
+	case KindID:
+		return bindID(at, field, raw)
+	case KindDate:
+		return bindTemporal(at, field, raw, dateLayout, "::date", "a date, as YYYY-MM-DD")
+	case KindTimestamp:
+		return bindTemporal(at, field, raw, time.RFC3339, "", "an instant, as RFC 3339 (2026-08-08T09:00:00Z)")
+	case KindText:
+		var value string
+		return value, "", decodeOperand(at, field, raw, &value, "text")
+	case KindGeo:
+		// A place is never compared: within_radius answers
+		// distance_ranking_unavailable and the executor stops before here.
+		return nil, "", operandFault(at, field, "a place, which this deployment cannot rank by")
+	default:
+		return nil, "", operandFault(at, field, "a value of a kind this workspace can compare")
+	}
+}
+
+//craft:ignore naked-any a bound parameter is whatever Go type the column's kind encodes as (string, int64, float64, bool, time.Time, ids.UUID) — the kind switch IS the conversion contract, so there is no narrower signature
+func bindNumber(at string, field Field, raw json.RawMessage) (any, string, *apperrors.FieldRefusal) {
+	var value json.Number
+	if refusal := decodeOperand(at, field, raw, &value, "a number"); refusal != nil {
+		return nil, "", refusal
+	}
+	// A whole number binds as one, so a bigint column compares against a
+	// bigint rather than against a float that rounded on the way in.
+	if whole, err := value.Int64(); err == nil {
+		return whole, "", nil
+	}
+	fractional, err := value.Float64()
+	if err != nil {
+		return nil, "", operandFault(at, field, "a number")
+	}
+	return fractional, "", nil
+}
+
+//craft:ignore naked-any a bound parameter is whatever Go type the column's kind encodes as (string, int64, float64, bool, time.Time, ids.UUID) — the kind switch IS the conversion contract, so there is no narrower signature
+func bindID(at string, field Field, raw json.RawMessage) (any, string, *apperrors.FieldRefusal) {
+	var text string
+	if refusal := decodeOperand(at, field, raw, &text, "an identifier"); refusal != nil {
+		return nil, "", refusal
+	}
+	id, err := ids.Parse(text)
+	if err != nil {
+		return nil, "", operandFault(at, field, "an identifier, as a UUID")
+	}
+	return id, "", nil
+}
+
+// bindTemporal parses a date or an instant in the contract's own encoding and
+// binds it as TEXT with an explicit cast where one is needed. A date compared
+// through a timestamp would be resolved at the session's time zone, which
+// makes the same plan answer differently on two servers.
+//
+//craft:ignore naked-any a bound parameter is whatever Go type the column's kind encodes as (string, int64, float64, bool, time.Time, ids.UUID) — the kind switch IS the conversion contract, so there is no narrower signature
+func bindTemporal(at string, field Field, raw json.RawMessage, layout, cast, shape string) (any, string, *apperrors.FieldRefusal) {
+	var text string
+	if refusal := decodeOperand(at, field, raw, &text, shape); refusal != nil {
+		return nil, "", refusal
+	}
+	parsed, err := time.Parse(layout, text)
+	if err != nil {
+		return nil, "", operandFault(at, field, shape)
+	}
+	if cast == "" {
+		return parsed, "", nil
+	}
+	return parsed.Format(layout), cast, nil
+}
+
+// decodeOperand decodes one operand into its Go type, which IS the check: a
+// number offered where text belongs fails at the decode rather than after it.
+//
+//craft:ignore naked-any `into` is the caller's own destination for one operand; decoding INTO its Go type is the check, and a narrower signature would have to name every kind
+func decodeOperand(at string, field Field, raw json.RawMessage, into any, shape string) *apperrors.FieldRefusal {
+	if len(raw) == 0 || isJSONNull(raw) || json.Unmarshal(raw, into) != nil {
+		return operandFault(at, field, shape)
+	}
+	return nil
+}
+
+func operandFault(at string, field Field, shape string) *apperrors.FieldRefusal {
+	return &apperrors.FieldRefusal{
+		Field: at, Code: CodeValueTypeMismatch,
+		Message: quote(field.Name) + " is a " + string(field.Kind) + " field; its operand must be " + shape,
+	}
+}
+
+// idsIn renders a membership test over already-resolved ids. They are this
+// server's own, so the list is bound rather than rendered, and it exists only
+// to narrow the statement to what the similarity lane ranked.
+func (c *planCompiler) idsIn(expr string, values []ids.UUID) string {
+	operands := make([]string, len(values))
+	for i, id := range values {
+		operands[i] = "$" + strconv.Itoa(c.arg(id))
+	}
+	return expr + " IN (" + strings.Join(operands, ", ") + ")"
+}

--- a/backend/internal/modules/search/querysql_test.go
+++ b/backend/internal/modules/search/querysql_test.go
@@ -1,0 +1,422 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package search
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// planTables is the schema every compilation case here is written against —
+// enough of each record type to ask a real question, and deliberately missing
+// the derived members (`stalled`) no table holds.
+var planTables = map[string][]StoredColumn{
+	"deal": columnsOf("id:uuid", "name", "status", "amount_minor:bigint",
+		"expected_close_date:date", "closed_at:timestamp with time zone",
+		"owner_id:uuid", "organization_id:uuid", "project_id:uuid"),
+	"organization": columnsOf("id:uuid", "display_name", "owner_id:uuid",
+		"is_anchor:boolean", "address_city", "visibility"),
+	"project": columnsOf("id:uuid", "name", "owner_id:uuid", "organization_id:uuid", "visibility"),
+	"person":  columnsOf("id:uuid", "full_name", "owner_id:uuid", "address_city", "visibility"),
+}
+
+// compilePlanDoc runs a plan document through the REAL decoder and validator
+// before compiling it, so a case cannot assert against a plan the validator
+// would never have produced.
+func compilePlanDoc(ctx context.Context, t *testing.T, doc string) (string, []any) {
+	t.Helper()
+	plan := validatedPlanDoc(ctx, t, doc)
+	executor := &QueryExecutor{columns: stubColumns{tables: planTables}}
+	binding, err := executor.bindPlan(ctx, plan)
+	if err != nil {
+		t.Fatalf("binding: %v", err)
+	}
+	compiler := &planCompiler{}
+	sql, admitted, err := compiler.compileStatement(ctx, plan, binding)
+	if err != nil {
+		t.Fatalf("compiling: %v", err)
+	}
+	if !admitted {
+		t.Fatal("the record type was not admitted")
+	}
+	return sql, compiler.args
+}
+
+func validatedPlanDoc(ctx context.Context, t *testing.T, doc string) ValidatedPlan {
+	t.Helper()
+	decoded, err := DecodePlan([]byte(doc))
+	if err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+	validator := NewPlanValidator(NewVocabularyResolver().WithColumnReader(stubColumns{tables: planTables}))
+	plan, err := validator.Validate(ctx, decoded)
+	if err != nil {
+		t.Fatalf("validating: %v", err)
+	}
+	return plan
+}
+
+// refusalFrom compiles a plan expected to be refused at bind time and answers
+// the refusal.
+func refusalFrom(ctx context.Context, t *testing.T, doc string) *PlanRefusal {
+	t.Helper()
+	plan := validatedPlanDoc(ctx, t, doc)
+	executor := &QueryExecutor{columns: stubColumns{tables: planTables}}
+	binding, err := executor.bindPlan(ctx, plan)
+	if err != nil {
+		t.Fatalf("binding: %v", err)
+	}
+	compiler := &planCompiler{}
+	_, _, err = compiler.compileStatement(ctx, plan, binding)
+	var refusal *PlanRefusal
+	if !errors.As(err, &refusal) {
+		t.Fatalf("expected a typed refusal, got %v", err)
+	}
+	return refusal
+}
+
+// teamReaderFor is a principal bounded to one team's rows — the same grants as
+// readerFor with the row scope narrowed, so a case comparing the two isolates
+// row scope from object RBAC.
+func teamReaderFor(objects ...string) context.Context {
+	grants := map[string]principal.ObjectGrant{}
+	for _, o := range objects {
+		grants[o] = principal.ObjectGrant{Read: true}
+	}
+	return principal.WithActor(context.Background(), principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:test", UserID: ids.NewV7(),
+		TeamIDs:     []ids.UUID{ids.NewV7()},
+		Permissions: principal.Permissions{Objects: grants, RowScope: principal.RowScopeTeam},
+	})
+}
+
+func TestAPredicateCompilesToABoundComparison(t *testing.T) {
+	sql, args := compilePlanDoc(readerFor(entityDeal), t, `{
+		"version": "v1", "target": "deal",
+		"where": [{"field": "status", "op": "eq", "value": "open"},
+		          {"field": "amount_minor", "op": "gte", "value": 100000}]}`)
+	if !strings.Contains(sql, `t."status" = $1`) || !strings.Contains(sql, `t."amount_minor" >= $2`) {
+		t.Fatalf("statement is %q", sql)
+	}
+	if len(args) != 3 || args[0] != "open" || args[1] != int64(100000) {
+		t.Fatalf("args are %v; the operands must be bound under their own kinds", args)
+	}
+	// The page ceiling is the limit plus one, so a truncated answer is
+	// detectable rather than merely suspected.
+	if args[2] != storekitDefaultPage()+1 {
+		t.Errorf("fetch ceiling is %v", args[2])
+	}
+	if !strings.Contains(sql, "ORDER BY t.id DESC") {
+		t.Errorf("the exact lane has no deterministic order: %q", sql)
+	}
+}
+
+// storekitDefaultPage is the contract default page, read from the same clamp
+// the validator reads rather than restated as a number that could disagree.
+func storekitDefaultPage() int {
+	plan, _ := effectiveLimit(nil)
+	return plan
+}
+
+// A row whose field is UNSET is distinct from every value. Rendering `neq` as
+// `<>` would drop those rows from an answer a caller reads as "everything that
+// is not X".
+func TestNotEqualAdmitsRowsWhoseFieldIsUnset(t *testing.T) {
+	sql, _ := compilePlanDoc(readerFor(entityDeal), t, `{
+		"version": "v1", "target": "deal",
+		"where": [{"field": "status", "op": "neq", "value": "lost"}]}`)
+	if !strings.Contains(sql, `t."status" IS DISTINCT FROM $1`) {
+		t.Fatalf("statement is %q", sql)
+	}
+}
+
+func TestAMembershipTestBindsEveryElementSeparately(t *testing.T) {
+	sql, args := compilePlanDoc(readerFor(entityDeal), t, `{
+		"version": "v1", "target": "deal",
+		"where": [{"field": "status", "op": "in", "values": ["open", "won"]}]}`)
+	if !strings.Contains(sql, `t."status" IN ($1, $2)`) {
+		t.Fatalf("statement is %q", sql)
+	}
+	if args[0] != "open" || args[1] != "won" {
+		t.Fatalf("args are %v", args)
+	}
+}
+
+// A date compared through a timestamp is resolved at the session's time zone,
+// which makes the same plan answer differently on two servers.
+func TestADateBindsAsADateRatherThanAnInstant(t *testing.T) {
+	sql, args := compilePlanDoc(readerFor(entityDeal), t, `{
+		"version": "v1", "target": "deal",
+		"where": [{"field": "expected_close_date", "op": "lte", "value": "2026-12-31"}]}`)
+	if !strings.Contains(sql, `t."expected_close_date" <= $1::date`) {
+		t.Fatalf("statement is %q", sql)
+	}
+	if args[0] != "2026-12-31" {
+		t.Fatalf("args are %v", args)
+	}
+}
+
+// The validator left FORMAT to the executor, so this is where a date that is
+// not one is refused — rather than becoming a query that quietly matches
+// nothing, which is indistinguishable from an empty workspace.
+func TestAMalformedDateIsRefusedRatherThanMatchingNothing(t *testing.T) {
+	refusal := refusalFrom(readerFor(entityDeal), t, `{
+		"version": "v1", "target": "deal",
+		"where": [{"field": "expected_close_date", "op": "eq", "value": "next tuesday"}]}`)
+	assertOperandFault(t, refusal, "where[0].value")
+}
+
+func TestAMalformedInstantIsRefused(t *testing.T) {
+	refusal := refusalFrom(readerFor(entityDeal), t, `{
+		"version": "v1", "target": "deal",
+		"where": [{"field": "closed_at", "op": "gte", "value": "2026-13-45"}]}`)
+	assertOperandFault(t, refusal, "where[0].value")
+}
+
+func TestAnIdentifierThatIsNotAUUIDIsRefused(t *testing.T) {
+	refusal := refusalFrom(readerFor(entityDeal), t, `{
+		"version": "v1", "target": "deal",
+		"where": [{"field": "owner_id", "op": "eq", "value": "not-a-uuid"}]}`)
+	assertOperandFault(t, refusal, "where[0].value")
+}
+
+// Every bad operand is reported, not the first: a caller told about one of
+// three makes three round trips to learn what one answer could have carried.
+func TestEveryUnbindableOperandIsReported(t *testing.T) {
+	refusal := refusalFrom(readerFor(entityDeal), t, `{
+		"version": "v1", "target": "deal",
+		"where": [{"field": "expected_close_date", "op": "eq", "value": "yesterday"},
+		          {"field": "owner_id", "op": "eq", "value": "nope"}]}`)
+	if len(refusal.FieldFaults()) != 2 {
+		t.Fatalf("refusal names %d faults: %v", len(refusal.FieldFaults()), refusal.FieldFaults())
+	}
+}
+
+// One bad element in a membership list names THAT element, so the caller edits
+// the value rather than the clause.
+func TestABadElementOfAMembershipListNamesItsPosition(t *testing.T) {
+	refusal := refusalFrom(readerFor(entityDeal), t, `{
+		"version": "v1", "target": "deal",
+		"where": [{"field": "owner_id", "op": "in",
+		           "values": ["0199a5c5-0000-7000-8000-000000000001", "nope"]}]}`)
+	assertOperandFault(t, refusal, "where[0].values[1]")
+}
+
+// assertOperandFault is the one verdict an unbindable operand gets: the value
+// is not the shape its field takes, named at the path the caller wrote it.
+func assertOperandFault(t *testing.T, refusal *PlanRefusal, path string) {
+	t.Helper()
+	for _, fault := range refusal.FieldFaults() {
+		if fault.Field == path && fault.Code == CodeValueTypeMismatch {
+			return
+		}
+	}
+	t.Fatalf("no %s at %q; faults are %v", CodeValueTypeMismatch, path, refusal.FieldFaults())
+}
+
+// A hop returns the record that admitted the row, so the traversal is legible
+// as a reason rather than as an invisible filter.
+func TestATraversalCompilesToALateralThatCarriesItsEvidence(t *testing.T) {
+	sql, args := compilePlanDoc(readerFor(entityDeal, entityOrganization), t, `{
+		"version": "v1", "target": "deal",
+		"traverse": {"relation": "organization",
+		             "where": [{"field": "address.city", "op": "eq", "value": "Stuttgart"}]}}`)
+	for _, want := range []string{
+		"JOIN LATERAL", "hop_id", "hop_title", `h.id = t."organization_id"`,
+		"h.archived_at IS NULL", "ORDER BY h.id LIMIT 1",
+		// The nested contract path resolves to the flat column that holds it,
+		// under the HOP's alias.
+		`h."address_city" =`,
+	} {
+		if !strings.Contains(sql, want) {
+			t.Fatalf("statement lacks %q: %s", want, sql)
+		}
+	}
+	if !slices.Contains(args, any("Stuttgart")) {
+		t.Fatalf("args are %v", args)
+	}
+}
+
+// The inverse edge is derived from the referring record's column, so the join
+// condition points the other way.
+func TestAnInverseTraversalJoinsOnTheReferringColumn(t *testing.T) {
+	sql, _ := compilePlanDoc(readerFor(entityOrganization, entityDeal), t, `{
+		"version": "v1", "target": "organization",
+		"traverse": {"relation": "deals",
+		             "where": [{"field": "status", "op": "eq", "value": "open"}]}}`)
+	if !strings.Contains(sql, `h."organization_id" = t.id`) {
+		t.Fatalf("statement is %q", sql)
+	}
+}
+
+// A hop is a READ of the record it lands on. A caller who cannot see the
+// Stuttgart organization must not be able to select deals through it either.
+func TestTheHopCarriesItsOwnRowScopeUnderItsOwnAlias(t *testing.T) {
+	sql, _ := compilePlanDoc(teamReaderFor(entityDeal, entityOrganization), t, `{
+		"version": "v1", "target": "deal",
+		"traverse": {"relation": "organization"}}`)
+	lateral, outer, found := strings.Cut(sql, ") hop ON true")
+	if !found {
+		t.Fatalf("no lateral join in %q", sql)
+	}
+	// The hop's visibility is decided about the ORGANIZATION row, under the
+	// hop's own alias. Rendered against `t` it would decide about the deal —
+	// a visibility rule answering about a different record.
+	if !strings.Contains(lateral, "h.owner_id") {
+		t.Fatalf("the hop's row scope is not rendered against the hop: %s", lateral)
+	}
+	if strings.Contains(lateral, "t.owner_id") {
+		t.Fatalf("the hop's row scope filters the outer table: %s", lateral)
+	}
+	if !strings.Contains(outer, "t.owner_id") {
+		t.Fatalf("the target carries no row scope: %s", outer)
+	}
+}
+
+// Every read on this surface carries the same narrowing: archived rows are out,
+// and the installation's own company is not an account to discover.
+func TestTheStatementCarriesTheDiscoveryNarrowingEveryReadCarries(t *testing.T) {
+	sql, _ := compilePlanDoc(readerFor(entityOrganization), t, `{"version": "v1", "target": "organization"}`)
+	for _, want := range []string{"t.archived_at IS NULL", "NOT t.is_anchor"} {
+		if !strings.Contains(sql, want) {
+			t.Fatalf("statement lacks %q: %s", want, sql)
+		}
+	}
+}
+
+// Object RBAC can change under a plan. A caller who lost the grant mid-flight
+// learns the same thing an empty workspace tells them, rather than a 403 that
+// confirms the record type is populated.
+func TestARecordTypeNoLongerAdmittedCompilesToNoStatement(t *testing.T) {
+	plan := validatedPlanDoc(readerFor(entityDeal), t, `{"version": "v1", "target": "deal"}`)
+	compiler := &planCompiler{}
+	binding := planBinding{
+		branch:  mustBranch(t, entityDeal),
+		columns: newStorage(planTables["deal"]),
+		fetch:   plan.Limit + 1,
+	}
+	// The same plan, compiled for a principal who may no longer read deals.
+	sql, admitted, err := compiler.compileStatement(readerFor(entityPerson), plan, binding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if admitted || sql != "" {
+		t.Fatalf("a record type the caller may not read compiled to %q", sql)
+	}
+}
+
+func mustBranch(t *testing.T, entity string) searchBranch {
+	t.Helper()
+	branch, ok := branchFor(entity)
+	if !ok {
+		t.Fatalf("%q has no branch", entity)
+	}
+	return branch
+}
+
+// The ranked lane narrows the statement to the ids it ranked. Compiling it
+// without that membership test would answer the unfiltered question.
+func TestTheRankedLaneNarrowsTheStatementToItsCandidates(t *testing.T) {
+	plan := validatedPlanDoc(readerFor(entityDeal), t, `{"version": "v1", "target": "deal"}`)
+	first, second := ids.NewV7(), ids.NewV7()
+	compiler := &planCompiler{}
+	sql, admitted, err := compiler.compileStatement(readerFor(entityDeal), plan, planBinding{
+		branch:     mustBranch(t, entityDeal),
+		columns:    newStorage(planTables["deal"]),
+		candidates: []ids.UUID{first, second},
+		fetch:      plan.Limit + 1,
+	})
+	if err != nil || !admitted {
+		t.Fatalf("compiling: %v", err)
+	}
+	if !strings.Contains(sql, "t.id IN ($1, $2)") {
+		t.Fatalf("statement is %q", sql)
+	}
+	// The ranked lane's order is the retriever's, applied after the rows come
+	// back, so the statement must not impose the table's.
+	if strings.Contains(sql, "ORDER BY t.id") || strings.Contains(sql, "LIMIT") {
+		t.Fatalf("the ranked lane imposed the table's order: %s", sql)
+	}
+	if compiler.args[0] != first || compiler.args[1] != second {
+		t.Fatalf("args are %v", compiler.args)
+	}
+}
+
+// A field the vocabulary published and the table cannot answer is a wiring
+// fault, and it fails loudly rather than compiling to a comparison against
+// nothing. It is unreachable through Execute — the fitness function is what
+// keeps it so.
+func TestAFieldWithNoStoragePathRefusesRatherThanCompiling(t *testing.T) {
+	compiler := &planCompiler{}
+	vocab := TargetVocabulary{Target: entityDeal, Fields: []Field{newField("stalled", KindBoolean)}}
+	_, refusal := compiler.clause("t", newStorage(planTables["deal"]), vocab, "where[0]",
+		Predicate{Field: "stalled", Op: OpEq, Value: []byte("true")})
+	if refusal == nil || refusal.Code != CodeUnknownField {
+		t.Fatalf("refusal is %v", refusal)
+	}
+}
+
+// A plan that never passed validation cannot be smuggled past the compiler by
+// naming a field the vocabulary does not carry.
+func TestAFieldOutsideTheVocabularyRefusesAtCompileTime(t *testing.T) {
+	compiler := &planCompiler{}
+	_, refusal := compiler.clause("t", newStorage(planTables["deal"]),
+		TargetVocabulary{Target: entityDeal}, "where[0]",
+		Predicate{Field: "invented", Op: OpEq, Value: []byte(`"x"`)})
+	if refusal == nil || refusal.Code != CodeUnknownField {
+		t.Fatalf("refusal is %v", refusal)
+	}
+}
+
+// An operator with no SQL spelling is refused rather than rendered as its own
+// machine name into a statement.
+func TestAnOperatorWithNoSQLSpellingIsRefused(t *testing.T) {
+	compiler := &planCompiler{}
+	vocab := TargetVocabulary{Target: entityDeal, Fields: []Field{newField("status", KindText)}}
+	_, refusal := compiler.clause("t", newStorage(planTables["deal"]), vocab, "where[0]",
+		Predicate{Field: "status", Op: "matches", Value: []byte(`"open"`)})
+	if refusal == nil || refusal.Code != CodeUnknownOperator {
+		t.Fatalf("refusal is %v", refusal)
+	}
+}
+
+// A place is never compared: within_radius answers
+// distance_ranking_unavailable and the executor stops before a statement is
+// built. Binding one anyway is a fault rather than a comparison against a
+// jsonb blob.
+func TestAPlaceOperandNeverBinds(t *testing.T) {
+	compiler := &planCompiler{}
+	_, _, refusal := compiler.bind("where[0].value", newField("address", KindGeo),
+		[]byte(`{"center": "Stuttgart", "radius_km": 50}`))
+	if refusal == nil || refusal.Code != CodeValueTypeMismatch {
+		t.Fatalf("refusal is %v", refusal)
+	}
+}
+
+// The edge is read off Relation.Via, whose two spellings say which side of the
+// reference each direction lives on.
+func TestTheEdgeDirectionIsReadOffTheDerivedReference(t *testing.T) {
+	forward := newHopBinding(Relation{Name: "organization", Target: "organization", Via: "organization_id"},
+		mustBranch(t, entityOrganization), nil)
+	if !forward.forward || forward.column != "organization_id" {
+		t.Errorf("forward edge is %+v", forward)
+	}
+	inverse := newHopBinding(Relation{Name: "deals", Target: "deal", Via: "deal.organization_id"},
+		mustBranch(t, entityDeal), nil)
+	if inverse.forward || inverse.column != "organization_id" {
+		t.Errorf("inverse edge is %+v", inverse)
+	}
+}
+
+// The refusal the compiler answers is the plural fault form every transport
+// already renders, so an operand fault reads as a 422 rather than as an
+// unclassified internal error.
+var _ apperrors.FieldFaults = (*PlanRefusal)(nil)

--- a/backend/internal/modules/search/querysql_test.go
+++ b/backend/internal/modules/search/querysql_test.go
@@ -420,3 +420,62 @@ func TestTheEdgeDirectionIsReadOffTheDerivedReference(t *testing.T) {
 // already renders, so an operand fault reads as a 422 rather than as an
 // unclassified internal error.
 var _ apperrors.FieldFaults = (*PlanRefusal)(nil)
+
+// A fractional operand binds as its own DIGITS, cast to numeric. Through a
+// float64 it would not: 0.1 has no binary representation, so a numeric column
+// holding exactly 0.1 compares unequal to the 0.1 the caller wrote — an exact
+// predicate answering "no rows" for a value that is there.
+func TestAFractionalOperandKeepsItsDigits(t *testing.T) {
+	compiler := &planCompiler{}
+	value, cast, refusal := compiler.bind("where[0].value", newField("cf_rate", KindNumber), []byte("0.1"))
+	if refusal != nil {
+		t.Fatalf("refusal is %v", refusal)
+	}
+	if value != "0.1" || cast != "::numeric" {
+		t.Fatalf("bound %v%q; a float64 would round it", value, cast)
+	}
+	// A ten-place decimal survives whole, which a float64 cannot promise.
+	value, _, refusal = compiler.bind("where[0].value", newField("cf_rate", KindNumber), []byte("1.0000000001"))
+	if refusal != nil || value != "1.0000000001" {
+		t.Fatalf("bound %v (%v)", value, refusal)
+	}
+}
+
+// A WHOLE number still binds as an integer, so a bigint column compares
+// against a bigint rather than through a cast that costs it its index.
+func TestAWholeOperandStillBindsAsAnInteger(t *testing.T) {
+	compiler := &planCompiler{}
+	value, cast, refusal := compiler.bind("where[0].value", newField("amount_minor", KindNumber), []byte("100000"))
+	if refusal != nil || value != int64(100000) || cast != "" {
+		t.Fatalf("bound %v%q (%v)", value, cast, refusal)
+	}
+}
+
+// The hop is discovered by its attributes, which is discovery by any other
+// name — so a traversal must not reach the installation's own company through
+// a door the search arm keeps shut.
+func TestTheHopCarriesTheSameDiscoveryNarrowingTheTargetDoes(t *testing.T) {
+	sql, _ := compilePlanDoc(readerFor(entityDeal, entityOrganization), t, `{
+		"version": "v1", "target": "deal",
+		"traverse": {"relation": "organization"}}`)
+	if !strings.Contains(sql, "NOT h.is_anchor") {
+		t.Fatalf("the hop does not carry the branch narrowing: %s", sql)
+	}
+	// And it is rendered against the HOP, not the target — the target here is
+	// a deal, which has no anchor column at all.
+	if strings.Contains(sql, "NOT t.is_anchor") {
+		t.Fatalf("the narrowing is rendered against the wrong table: %s", sql)
+	}
+}
+
+// The narrowing is a template over the alias, so the branch declaration cannot
+// silently narrow whichever table happens to be called `t`.
+func TestABranchNarrowingRendersForTheAliasItIsAskedFor(t *testing.T) {
+	branch := mustBranch(t, entityOrganization)
+	if got := branch.narrowing("h"); got != "NOT h.is_anchor" {
+		t.Errorf("narrowing renders as %q", got)
+	}
+	if got := mustBranch(t, entityDeal).narrowing("t"); got != "" {
+		t.Errorf("a branch with no narrowing renders %q", got)
+	}
+}

--- a/backend/internal/modules/search/querystorage.go
+++ b/backend/internal/modules/search/querystorage.go
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package search
+
+// Where a vocabulary field actually lives.
+//
+// E1 derived the vocabulary from the CONTRACT. Execution happens against the
+// DATABASE, and the two do not agree. `strength.score` is a view assembled from
+// activity rows, `partner.margin_tier` belongs to another table, `deal.stalled`
+// is computed in a mapper, and `organization.logo_url` is minted from an object
+// key at read time. Roughly forty published fields have no column on the
+// record's own table.
+//
+// So a field is askable when the contract declares it AND the record's own
+// table can answer it. Both halves stay derived — the second from
+// information_schema, which is the database's own statement of what it holds —
+// so neither becomes a list to maintain, and the property C-7 asked for
+// survives. TestEveryPublishedFieldCompilesToAStoragePath is the fitness
+// function that keeps the two halves in agreement.
+//
+// Two rules make the catalog read safe to use here:
+//
+//  1. It FILTERS; it never CONTRIBUTES. A name only ever leaves the vocabulary
+//     by it. cf_* columns are physically present for every workspace that
+//     declared one, so a catalog read used as a source would hand one
+//     workspace's private column to the next caller. The custom half keeps
+//     coming from the workspace-scoped fieldcatalog seam.
+//  2. It is a SCHEMA read, not a tenant read — information_schema carries no
+//     rows of anyone's data.
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// StoredColumn is one physical column, as this module needs to see it: its
+// name, and the SQL type that decides which vocabulary kinds it can be
+// compared under.
+type StoredColumn struct {
+	Name string
+	// Type is the data type information_schema reports (`text`, `numeric`,
+	// `timestamp with time zone`, …).
+	Type string
+}
+
+// ColumnReader answers the physical columns of one table. It is a seam for
+// the same reason fieldcatalog.Reader is: the vocabulary resolver runs in
+// tests with no database, and a nil reader is the pass-through — the
+// vocabulary is then the contract's, WIDER rather than narrower, so an unwired
+// deployment cannot be tricked into publishing more than it can answer.
+type ColumnReader interface {
+	Columns(ctx context.Context, table string) ([]StoredColumn, error)
+}
+
+// ColumnCatalog reads the live schema.
+type ColumnCatalog struct {
+	pool *pgxpool.Pool
+}
+
+// NewColumnCatalog builds the reader over the pool.
+func NewColumnCatalog(pool *pgxpool.Pool) *ColumnCatalog { return &ColumnCatalog{pool: pool} }
+
+// Columns answers one table's column names.
+//
+// Nothing is memoized. A cached schema is a schema that keeps answering as it
+// was — and the one runtime ALTER TABLE this product has (the custom-field
+// engine) would then leave a workspace's own new column unaskable until the
+// process restarted, for a saving of one indexed catalog read per plan.
+func (c *ColumnCatalog) Columns(ctx context.Context, table string) ([]StoredColumn, error) {
+	// rls-exempt: information_schema is the database's own schema catalog; it holds no tenant rows, so there is no workspace to bind
+	rows, err := c.pool.Query(ctx,
+		`SELECT column_name, data_type FROM information_schema.columns
+		  WHERE table_schema = current_schema() AND table_name = $1`, table)
+	if err != nil {
+		return nil, fmt.Errorf("search: reading the columns of %s: %w", table, err)
+	}
+	defer rows.Close()
+	var columns []StoredColumn
+	for rows.Next() {
+		var column StoredColumn
+		if err := rows.Scan(&column.Name, &column.Type); err != nil {
+			return nil, fmt.Errorf("search: reading the columns of %s: %w", table, err)
+		}
+		columns = append(columns, column)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("search: reading the columns of %s: %w", table, err)
+	}
+	return columns, nil
+}
+
+var _ ColumnReader = (*ColumnCatalog)(nil)
+
+// storage is one table's columns, in the form the vocabulary filter and the
+// SQL builder both read: column name → the vocabulary kind that column can be
+// compared under.
+type storage struct {
+	kinds map[string]FieldKind
+	// unfiltered is the pass-through the vocabulary resolver gets when no
+	// schema reader is wired. It answers every field and locates none, which
+	// is the honest pair: without a schema to check against the vocabulary is
+	// the contract's, and a vocabulary nobody checked is not a place to
+	// execute from.
+	unfiltered bool
+}
+
+// unfilteredStorage is the no-schema pass-through.
+func unfilteredStorage() *storage { return &storage{unfiltered: true} }
+
+// newStorage indexes a table's columns by the kind each can answer. A column
+// of a type this vocabulary has no kind for indexes as the empty kind, which
+// no field matches — so it is present and unaskable rather than absent and
+// indistinguishable from a typo.
+func newStorage(columns []StoredColumn) *storage {
+	s := &storage{kinds: make(map[string]FieldKind, len(columns))}
+	for _, c := range columns {
+		s.kinds[c.Name] = kindsByColumnType[c.Type]
+	}
+	return s
+}
+
+// kindsByColumnType maps a SQL type onto the ONE vocabulary kind it can be
+// compared under.
+//
+// It exists because the contract and the schema disagree about more than
+// names. `deal.fx_rate_to_base` is a STRING in the contract — a decimal
+// rendered as text, so a ten-place rate never rounds through a float — and a
+// `numeric` column in the table. Binding a text operand against it is not a
+// narrower answer; it is `invalid input syntax for type numeric`, a fault the
+// caller cannot act on for a field the schema told them they could ask. So a
+// field whose contract kind the column cannot answer is out of the vocabulary,
+// the same as a field with no column at all.
+var kindsByColumnType = map[string]FieldKind{
+	"text": KindText, "character varying": KindText, "character": KindText,
+	"uuid":     KindID,
+	"boolean":  KindBoolean,
+	"smallint": KindNumber, "integer": KindNumber, "bigint": KindNumber,
+	"numeric": KindNumber, "real": KindNumber, "double precision": KindNumber,
+	"date":                     KindDate,
+	"timestamp with time zone": KindTimestamp, "timestamp without time zone": KindTimestamp,
+}
+
+// schemaReads memoizes one resolve's schema reads. Composing a record type's
+// vocabulary asks about several tables — an inverse hop is declared by the
+// REFERRING record — so without it the published document re-reads the same
+// table once per target that names it.
+//
+// It lives for ONE resolve and no longer. A cache that outlived the call would
+// be exactly what Columns refuses to be: a schema that keeps answering as it
+// was while the custom-field engine adds a column under it.
+type schemaReads struct {
+	reader ColumnReader
+	byName map[string]*storage
+}
+
+func newSchemaReads(reader ColumnReader) *schemaReads {
+	return &schemaReads{reader: reader, byName: map[string]*storage{}}
+}
+
+// of answers one record type's storage, reading it at most once per resolve.
+func (s *schemaReads) of(ctx context.Context, entity string) (*storage, error) {
+	if cached, ok := s.byName[entity]; ok {
+		return cached, nil
+	}
+	stored, err := storageFor(ctx, s.reader, entity)
+	if err != nil {
+		return nil, err
+	}
+	s.byName[entity] = stored
+	return stored, nil
+}
+
+// storageFor reads one record type's columns through the seam, or the
+// unfiltered pass-through when no reader is wired.
+func storageFor(ctx context.Context, reader ColumnReader, entity string) (*storage, error) {
+	if reader == nil {
+		return unfilteredStorage(), nil
+	}
+	table, ok := tableFor(entity)
+	if !ok {
+		return nil, fmt.Errorf("search: %q is not a searchable record type", entity)
+	}
+	columns, err := reader.Columns(ctx, table)
+	if err != nil {
+		return nil, err
+	}
+	return newStorage(columns), nil
+}
+
+// answers reports whether this table can answer the field.
+//
+// A PLACE is the one field published without a column behind it, and
+// deliberately: SEARCH-AC-17 declares `within_radius` so that it answers
+// `distance_ranking_unavailable` rather than reading as an unknown operator.
+// Filtering the place out would turn that honest note into an
+// unknown-vocabulary refusal, which sends a caller to a text match on a city
+// name — the quietly wrong answer declaring the operator exists to avoid.
+func (s *storage) answers(field Field) bool {
+	if s.unfiltered || field.Kind == KindGeo {
+		return true
+	}
+	_, ok := s.locate(field)
+	return ok
+}
+
+// locate resolves a vocabulary field onto a column that can answer it under
+// the field's own kind.
+//
+// A nested contract object is stored FLAT — the contract's `address.city` is
+// the column `address_city` (migration 0051 replaced the jsonb document with
+// one column per leaf) — so a dotted name is looked up under its flattened
+// spelling. The lookup still decides: a path with no column behind it, or one
+// whose column answers a different kind, is not askable however it is spelled.
+func (s *storage) locate(field Field) (column string, ok bool) {
+	for _, candidate := range []string{field.Name, strings.ReplaceAll(field.Name, ".", "_")} {
+		if kind, exists := s.kinds[candidate]; exists {
+			return candidate, kind == field.Kind
+		}
+	}
+	return "", false
+}
+
+// expr renders the SQL expression a predicate compares against.
+//
+// A place has no expression: it is what a radius would be measured from, and
+// `within_radius` answers distance_ranking_unavailable before any SQL is
+// built. Answering false rather than an expression keeps that a loud wiring
+// fault instead of a comparison against a column that does not exist.
+func (s *storage) expr(alias string, field Field) (string, bool) {
+	if field.Kind == KindGeo {
+		return "", false
+	}
+	column, ok := s.locate(field)
+	if !ok {
+		return "", false
+	}
+	return alias + "." + sanitize(column), true
+}
+
+// sanitize quotes an identifier before it is interpolated into a statement.
+// Every identifier that reaches it was named by the database's own catalog, so
+// this is the second lock on a door that is already shut — kept because the
+// argument that it is already shut lives in a comment, and the next edit to
+// this file does not have to have read it.
+func sanitize(identifier string) string { return pgx.Identifier{identifier}.Sanitize() }
+
+// tableFor answers the physical table one searchable record type lives in,
+// read off the branch declarations the lexical arm already rides so a plan
+// and a search cannot disagree about where a record type is stored.
+func tableFor(entity string) (string, bool) {
+	branch, ok := branchFor(entity)
+	return branch.table, ok
+}
+
+// branchFor answers the whole branch declaration for a record type — its
+// table, its display title, and the discovery narrowing every read of it
+// carries.
+func branchFor(entity string) (searchBranch, bool) {
+	for _, branch := range searchBranches {
+		if branch.entity == entity {
+			return branch, true
+		}
+	}
+	return searchBranch{}, false
+}

--- a/backend/internal/modules/search/querystorage_test.go
+++ b/backend/internal/modules/search/querystorage_test.go
@@ -1,0 +1,385 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package search
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// stubColumns is the ColumnReader seam, so a test can say what a table holds
+// without a database. The seam is the boundary; mocking it is what mocking a
+// boundary is for. The real schema is proven against the real catalog in the
+// integration lane.
+type stubColumns struct {
+	tables map[string][]StoredColumn
+	err    error
+}
+
+func (c stubColumns) Columns(_ context.Context, table string) ([]StoredColumn, error) {
+	if c.err != nil {
+		return nil, c.err
+	}
+	return c.tables[table], nil
+}
+
+// columnsOf builds a table from `name` or `name:sqltype` specs, defaulting to
+// text — the type only matters where a case is about the kind a column can
+// answer.
+func columnsOf(specs ...string) []StoredColumn {
+	columns := make([]StoredColumn, len(specs))
+	for i, spec := range specs {
+		name, sqlType, typed := strings.Cut(spec, ":")
+		if !typed {
+			sqlType = "text"
+		}
+		columns[i] = StoredColumn{Name: name, Type: sqlType}
+	}
+	return columns
+}
+
+func TestATableAnswersTheFieldsItHasColumnsFor(t *testing.T) {
+	stored := newStorage(columnsOf("status", "amount_minor:bigint"))
+	for _, field := range []Field{newField("status", KindText), newField("amount_minor", KindNumber)} {
+		if !stored.answers(field) {
+			t.Errorf("%q has a column and is not answerable", field.Name)
+		}
+	}
+	// `stalled` is computed in the record mapper from last_activity_at: the
+	// contract declares it, no table holds it.
+	if stored.answers(newField("stalled", KindBoolean)) {
+		t.Error("a field with no column is answerable; the vocabulary would publish what nothing can answer")
+	}
+}
+
+// A nested contract object is stored flat — `address.city` is the column
+// `address_city` — so the dotted name resolves under its flattened spelling.
+func TestANestedContractPathResolvesToItsFlatColumn(t *testing.T) {
+	stored := newStorage(columnsOf("address_city", "address_country"))
+	city := newField("address.city", KindText)
+	if !stored.answers(city) {
+		t.Fatal("a nested path with a column behind it is not answerable")
+	}
+	expr, ok := stored.expr("t", city)
+	if !ok || expr != `t."address_city"` {
+		t.Errorf("expression is %q (ok=%v)", expr, ok)
+	}
+}
+
+// The lookup still decides. A path that merely LOOKS like a stored one is not
+// askable unless a column answers it.
+func TestANestedPathWithNoColumnBehindItIsNotAnswerable(t *testing.T) {
+	stored := newStorage(columnsOf("id:uuid", "full_name"))
+	for _, field := range []string{"strength.score", "partner.margin_tier", "address.city"} {
+		if stored.answers(newField(field, KindText)) {
+			t.Errorf("%q is answerable off a table that does not hold it", field)
+		}
+	}
+}
+
+// The contract and the schema disagree about more than names.
+// `deal.fx_rate_to_base` is a STRING in the contract — a decimal rendered as
+// text so a ten-place rate never rounds through a float — and a `numeric`
+// column in the table. Comparing it as text is not a narrower answer; it is a
+// database syntax fault for a field the schema said was askable.
+func TestAColumnThatCannotAnswerTheFieldsKindIsNotAskable(t *testing.T) {
+	stored := newStorage(columnsOf("fx_rate_to_base:numeric", "status", "created_at:timestamp with time zone"))
+	if stored.answers(newField("fx_rate_to_base", KindText)) {
+		t.Error("a numeric column answers a text field")
+	}
+	if !stored.answers(newField("fx_rate_to_base", KindNumber)) {
+		t.Error("a numeric column does not answer a number field")
+	}
+	// And the ordinary agreements still hold.
+	if !stored.answers(newField("status", KindText)) || !stored.answers(newField("created_at", KindTimestamp)) {
+		t.Error("a column of the field's own kind is not answerable")
+	}
+}
+
+// A column of a type this vocabulary has no kind for is present and unaskable,
+// rather than absent — there is no kind it could be compared under, and
+// guessing one is how a comparison answers a different question.
+func TestAColumnOfAnUnknownTypeAnswersNothing(t *testing.T) {
+	stored := newStorage(columnsOf("search_tsv:tsvector", "raw:jsonb"))
+	for _, kind := range []FieldKind{KindText, KindNumber, KindTimestamp, KindID, KindBoolean, KindDate} {
+		if stored.answers(Field{Name: "raw", Kind: kind}) {
+			t.Errorf("a jsonb column answers a %s field", kind)
+		}
+	}
+	if stored.answers(newField("search_tsv", KindText)) {
+		t.Error("a tsvector column answers a text field")
+	}
+}
+
+// SEARCH-AC-17: the place is the ONE field published with no column behind it.
+// Filtering it out would turn `distance_ranking_unavailable` into an
+// unknown-operator refusal, which sends a caller to a text match on a city
+// name — the quietly wrong answer declaring the operator exists to avoid.
+func TestAPlaceIsPublishedWithoutStorageAndCompilesToNoExpression(t *testing.T) {
+	stored := newStorage(columnsOf("address_city"))
+	address := newField("address", KindGeo)
+	if !stored.answers(address) {
+		t.Fatal("the place is filtered out; within_radius would then be an unknown-vocabulary refusal")
+	}
+	if _, ok := stored.expr("t", address); ok {
+		t.Error("a place compiles to an expression")
+	}
+}
+
+// The unwired seam widens rather than narrows, and it never executes: a
+// vocabulary is not a place to execute from.
+func TestAnUnwiredStorageSeamAnswersEverythingAndCompilesNothing(t *testing.T) {
+	stored := unfilteredStorage()
+	if !stored.answers(newField("stalled", KindBoolean)) {
+		t.Error("the unwired seam narrows the vocabulary")
+	}
+	if _, ok := stored.expr("t", newField("status", KindText)); ok {
+		t.Error("the unwired seam compiles an expression; a pass-through would execute against a column it never checked")
+	}
+}
+
+// The half of the invariant a unit test can hold: whatever the table holds,
+// what the vocabulary publishes is exactly what the SQL builder can compile.
+// Both halves read one locate(), so they cannot drift; this asserts it rather
+// than asserting the comment. The other half — that the REAL schema answers
+// the published vocabulary — is proven against the live catalog in the
+// integration lane.
+func TestEveryAnswerableFieldCompilesToAnExpression(t *testing.T) {
+	stored := newStorage(columnsOf("status", "amount_minor:bigint", "address_city"))
+	for _, field := range []Field{
+		newField("status", KindText), newField("amount_minor", KindNumber),
+		newField("address.city", KindText), newField("stalled", KindBoolean),
+		newField("strength.score", KindNumber), newField("address.postal_code", KindText),
+	} {
+		_, compiles := stored.expr("t", field)
+		if answerable := stored.answers(field); answerable != compiles {
+			t.Errorf("%q: answerable=%v but compiles=%v", field.Name, answerable, compiles)
+		}
+	}
+}
+
+// SEARCH-AC-15 still holds with the storage half wired: the filter removes a
+// name, it never contributes one. cf_* columns are physically present for
+// every workspace that declared one, so a catalog read used as a SOURCE would
+// hand one workspace's private column to the next caller.
+func TestTheStorageFilterRemovesNamesAndNeverAddsThem(t *testing.T) {
+	resolver := NewVocabularyResolver().WithColumnReader(stubColumns{tables: map[string][]StoredColumn{
+		"deal": columnsOf("id:uuid", "name", "status", "organization_id:uuid", "cf_another_workspaces_column"),
+	}})
+	vocab, err := resolver.Resolve(readerFor(entityDeal), entityDeal)
+	if err != nil {
+		t.Fatal(err)
+	}
+	target, ok := vocab.Target(entityDeal)
+	if !ok {
+		t.Fatal("deal absent from its own vocabulary")
+	}
+	if _, ok := target.Field("cf_another_workspaces_column"); ok {
+		t.Fatal("a column read off the schema entered the vocabulary; another workspace's field is now askable")
+	}
+	for _, want := range []string{"id", "name", "status"} {
+		if _, ok := target.Field(want); !ok {
+			t.Errorf("%q has a column and is not published", want)
+		}
+	}
+	if _, ok := target.Field("stalled"); ok {
+		t.Error("`stalled` has no column and is published")
+	}
+}
+
+// The vocabulary published with the seam wired is a SUBSET of the one
+// published without it. A storage filter that could widen would be a
+// disclosure channel rather than a narrowing.
+func TestTheStorageFilterOnlyEverNarrows(t *testing.T) {
+	columns := map[string][]StoredColumn{"deal": columnsOf("id:uuid", "name", "status")}
+	wide, err := NewVocabularyResolver().Resolve(readerFor(entityDeal), entityDeal)
+	if err != nil {
+		t.Fatal(err)
+	}
+	narrow, err := NewVocabularyResolver().WithColumnReader(stubColumns{tables: columns}).
+		Resolve(readerFor(entityDeal), entityDeal)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wideTarget, _ := wide.Target(entityDeal)
+	narrowTarget, ok := narrow.Target(entityDeal)
+	if !ok {
+		t.Fatal("deal absent from the narrowed vocabulary")
+	}
+	if len(narrowTarget.Fields) >= len(wideTarget.Fields) {
+		t.Fatalf("the filter did not narrow: %d fields with storage, %d without", len(narrowTarget.Fields), len(wideTarget.Fields))
+	}
+	for _, f := range narrowTarget.Fields {
+		if _, ok := wideTarget.Field(f.Name); !ok {
+			t.Errorf("%q is published only WITH the storage filter; the filter widened the vocabulary", f.Name)
+		}
+	}
+}
+
+// The INVERSE hop is declared by the referring record and executed against the
+// referring record's column, so it is filtered by THAT table's schema. Kept
+// separate from the forward case because the forward one is filtered
+// incidentally — its reference is one of the target's own fields — and the
+// inverse is the direction that would otherwise publish a hop no table can
+// answer.
+func TestAnInverseRelationIsFilteredByTheReferringTablesSchema(t *testing.T) {
+	schema := map[string][]StoredColumn{
+		"organization": columnsOf("id:uuid", "display_name"),
+		"deal":         columnsOf("id:uuid", "name", "organization_id:uuid"),
+		"project":      columnsOf("id:uuid", "name"), // no organization_id: no edge back
+	}
+	resolver := NewVocabularyResolver().WithColumnReader(stubColumns{tables: schema})
+	vocab, err := resolver.Resolve(readerFor(entityOrganization, entityDeal, entityProject), entityOrganization)
+	if err != nil {
+		t.Fatal(err)
+	}
+	target, ok := vocab.Target(entityOrganization)
+	if !ok {
+		t.Fatal("organization absent from its own vocabulary")
+	}
+	if _, ok := target.Relation("deals"); !ok {
+		t.Error("deal.organization_id is a column and declares no inverse hop")
+	}
+	if _, ok := target.Relation("projects"); ok {
+		t.Error("an inverse hop is published from a column the referring table does not hold")
+	}
+}
+
+// One schema read per TABLE per resolve. Composing a record type asks about
+// every table that refers to it, so the same table comes up under several
+// targets; re-reading it each time would multiply the cost by the size of the
+// catalog for no new answer.
+func TestTheSchemaIsReadAtMostOncePerTablePerResolve(t *testing.T) {
+	reader := &countingColumns{tables: map[string][]StoredColumn{
+		"organization": columnsOf("id:uuid", "display_name"),
+		"deal":         columnsOf("id:uuid", "name", "organization_id:uuid", "project_id:uuid"),
+		"project":      columnsOf("id:uuid", "name", "organization_id:uuid"),
+	}}
+	resolver := NewVocabularyResolver().WithColumnReader(reader)
+	if _, err := resolver.Resolve(readerFor(entityOrganization, entityDeal, entityProject)); err != nil {
+		t.Fatal(err)
+	}
+	for table, reads := range reader.perTable {
+		if reads != 1 {
+			t.Errorf("%s was read %d times in one resolve", table, reads)
+		}
+	}
+	// The three composed record types, plus the tables that refer to them: a
+	// resolve reads what it has to and nothing twice.
+	if len(reader.perTable) < 3 {
+		t.Errorf("only %d tables were read; the composition asks about more than its targets", len(reader.perTable))
+	}
+}
+
+// A hop is derived from the fields that survived the filter, so a reference
+// the table does not hold cannot become a traversable edge.
+func TestARelationIsDerivedOnlyFromAReferenceTheTableHolds(t *testing.T) {
+	resolver := NewVocabularyResolver().WithColumnReader(stubColumns{tables: map[string][]StoredColumn{
+		"deal": columnsOf("id:uuid", "name", "project_id:uuid"),
+	}})
+	vocab, err := resolver.Resolve(readerFor(entityDeal, entityOrganization, entityProject), entityDeal)
+	if err != nil {
+		t.Fatal(err)
+	}
+	target, _ := vocab.Target(entityDeal)
+	if _, ok := target.Relation(entityProject); !ok {
+		t.Error("project_id is a column and declares no hop")
+	}
+	if _, ok := target.Relation(entityOrganization); ok {
+		t.Error("organization_id is not a column on this table and still declares a hop")
+	}
+}
+
+// A schema read that fails is not an empty schema. Answering an empty
+// vocabulary would refuse every field the caller names with `unknown_field`,
+// which reads exactly like a caller who mistyped one.
+func TestASchemaReadThatFailsRefusesRatherThanNarrows(t *testing.T) {
+	resolver := NewVocabularyResolver().WithColumnReader(stubColumns{err: errors.New("connection reset")})
+	_, err := resolver.Resolve(readerFor(entityDeal), entityDeal)
+	if err == nil {
+		t.Fatal("a failed schema read resolved a vocabulary")
+	}
+	if !strings.Contains(err.Error(), "connection reset") {
+		t.Errorf("the schema fault is not carried: %v", err)
+	}
+}
+
+// tableFor and branchFor read the branch declarations rather than a second
+// list, so a searchable record type cannot be storable in one place for a
+// search and another for a plan.
+func TestEverySearchableRecordTypeLocatesItsOwnTable(t *testing.T) {
+	for entity := range contractRecords {
+		table, ok := tableFor(entity)
+		if !ok || table == "" {
+			t.Errorf("%q has no table", entity)
+		}
+		branch, ok := branchFor(entity)
+		if !ok || branch.table != table {
+			t.Errorf("%q: branch table %q disagrees with %q", entity, branch.table, table)
+		}
+	}
+	if _, ok := tableFor("workspace"); ok {
+		t.Error("a record type this module does not search located a table")
+	}
+	if _, ok := branchFor("workspace"); ok {
+		t.Error("a record type this module does not search located a branch")
+	}
+}
+
+// The seam is read per resolve rather than memoized, so the custom-field
+// engine's runtime ALTER TABLE is visible on the next plan instead of on the
+// next restart.
+func TestTheSchemaIsReadOnEveryResolve(t *testing.T) {
+	reader := &countingColumns{tables: map[string][]StoredColumn{"deal": columnsOf("id:uuid", "name")}}
+	resolver := NewVocabularyResolver().WithColumnReader(reader)
+	for range 3 {
+		if _, err := resolver.Resolve(readerFor(entityDeal), entityDeal); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if reader.reads != 3 {
+		t.Errorf("the schema was read %d times over 3 resolves; a cached schema keeps answering as it was", reader.reads)
+	}
+}
+
+type countingColumns struct {
+	tables   map[string][]StoredColumn
+	reads    int
+	perTable map[string]int
+}
+
+func (c *countingColumns) Columns(_ context.Context, table string) ([]StoredColumn, error) {
+	c.reads++
+	if c.perTable == nil {
+		c.perTable = map[string]int{}
+	}
+	c.perTable[table]++
+	return c.tables[table], nil
+}
+
+// The published document is the filtered vocabulary — one computation, so a
+// caller cannot read a field in the schema that the validator will refuse.
+func TestThePublishedDocumentCarriesTheFilteredVocabulary(t *testing.T) {
+	resolver := NewVocabularyResolver().WithColumnReader(stubColumns{tables: map[string][]StoredColumn{
+		"deal": columnsOf("id:uuid", "name", "status"),
+	}})
+	vocab, err := resolver.Resolve(readerFor(entityDeal))
+	if err != nil {
+		t.Fatal(err)
+	}
+	doc := querySchemaDocument(vocab)
+	if len(doc.Targets) != 1 {
+		t.Fatalf("the document publishes %d targets", len(doc.Targets))
+	}
+	names := make([]string, 0, len(doc.Targets[0].Fields))
+	for _, f := range doc.Targets[0].Fields {
+		names = append(names, f.Name)
+	}
+	if !slices.Equal(names, []string{"id", "name", "status"}) {
+		t.Errorf("the document publishes %v", names)
+	}
+}

--- a/backend/internal/modules/search/querystorage_test.go
+++ b/backend/internal/modules/search/querystorage_test.go
@@ -383,3 +383,21 @@ func TestThePublishedDocumentCarriesTheFilteredVocabulary(t *testing.T) {
 		t.Errorf("the document publishes %v", names)
 	}
 }
+
+// An inverse relation whose reference is unqualified is a WIRING defect: the
+// executor reads the same two spellings to decide the join's direction, so a
+// bare one would join in the wrong direction. Dropping the hop instead would
+// hide it behind a vocabulary that merely looks narrower than it should.
+func TestAnUnqualifiedInverseReferenceFailsLoudlyRatherThanNarrowing(t *testing.T) {
+	schema := newSchemaReads(stubColumns{tables: map[string][]StoredColumn{
+		"deal": columnsOf("id:uuid", "organization_id:uuid"),
+	}})
+	_, err := storedInverseRelations(context.Background(), schema, entityOrganization,
+		[]Relation{{Name: "deals", Target: entityDeal, Via: "organization_id"}})
+	if err == nil {
+		t.Fatal("an unqualified inverse reference was silently dropped")
+	}
+	if !strings.Contains(err.Error(), "unqualified") {
+		t.Errorf("the fault does not name what is wrong: %v", err)
+	}
+}

--- a/backend/internal/modules/search/queryvalidate.go
+++ b/backend/internal/modules/search/queryvalidate.go
@@ -20,6 +20,7 @@ import (
 	"math"
 	"slices"
 	"strconv"
+	"strings"
 
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
@@ -35,6 +36,12 @@ type ValidatedPlan struct {
 	// than re-deriving it from the plan's text.
 	Target TargetVocabulary
 	Hop    *Relation
+	// HopVocabulary is the vocabulary the hop's own predicates were checked
+	// against. It rides along for the same reason Target does: the executor
+	// binds a hop operand under the kind the field was ADMITTED with, rather
+	// than resolving the same name a second time and trusting two passes to
+	// agree.
+	HopVocabulary TargetVocabulary
 	// Limit is the effective page size: the plan's, or the contract default
 	// when it named none.
 	Limit int
@@ -98,6 +105,7 @@ func (v *PlanValidator) Validate(ctx context.Context, plan Plan) (ValidatedPlan,
 
 	validated := ValidatedPlan{Plan: plan, Target: target}
 	var refusals []apperrors.FieldRefusal
+	refusals = append(refusals, checkSimilarity(plan.SimilarTo)...)
 	refusals = append(refusals, checkPredicates(target, "where", plan.Where, &validated)...)
 	refusals = append(refusals, v.checkTraversal(vocab, plan.Traverse, &validated)...)
 	limit, limitRefusal := effectiveLimit(plan.Limit)
@@ -108,6 +116,21 @@ func (v *PlanValidator) Validate(ctx context.Context, plan Plan) (ValidatedPlan,
 		return ValidatedPlan{}, &PlanRefusal{Refusals: refusals}
 	}
 	return validated, nil
+}
+
+// checkSimilarity refuses a similarity clause that says nothing. Whitespace is
+// PRESENT to the grammar and empty to the retriever, and the retriever's own
+// refusal names the search endpoint's `q` — a field this plan does not have,
+// pointing a caller at something they never sent. Absent means "rank nothing",
+// which is a different and perfectly good plan.
+func checkSimilarity(similarTo string) []apperrors.FieldRefusal {
+	if similarTo == "" || strings.TrimSpace(similarTo) != "" {
+		return nil
+	}
+	return []apperrors.FieldRefusal{{
+		Field: "similar_to", Code: CodeValueMissing,
+		Message: "the similarity clause is blank; give it something to rank against, or omit it",
+	}}
 }
 
 // hopTarget names the record type a traversal lands on, so Resolve reads that
@@ -157,6 +180,7 @@ func (v *PlanValidator) checkTraversal(vocab Vocabulary, hop *Traversal, into *V
 		return unknownRelation(into.Target.Target, hop.Relation)
 	}
 	into.Hop = &relation
+	into.HopVocabulary = hopVocab
 	return checkPredicates(hopVocab, "traverse.where", hop.Where, into)
 }
 

--- a/backend/internal/modules/search/queryvocab.go
+++ b/backend/internal/modules/search/queryvocab.go
@@ -251,7 +251,7 @@ func (r *VocabularyResolver) resolveTarget(ctx context.Context, schema *schemaRe
 	fields = slices.DeleteFunc(fields, func(f Field) bool { return !stored.answers(f) })
 	slices.SortFunc(fields, func(a, b Field) int { return strings.Compare(a.Name, b.Name) })
 
-	inverse, err := storedInverseRelations(ctx, schema, entity)
+	inverse, err := storedInverseRelations(ctx, schema, entity, inverseRelations(entity))
 	if err != nil {
 		return TargetVocabulary{}, err
 	}
@@ -271,16 +271,24 @@ func (r *VocabularyResolver) resolveTarget(ctx context.Context, schema *schemaRe
 // published from a reference no table holds would validate and then fail as a
 // database error, which is the "published but unanswerable" case this whole
 // filter exists to remove, one level up from a field.
-func storedInverseRelations(ctx context.Context, schema *schemaReads, entity string) ([]Relation, error) {
+func storedInverseRelations(ctx context.Context, schema *schemaReads, entity string, candidates []Relation) ([]Relation, error) {
 	var kept []Relation
-	for _, relation := range inverseRelations(entity) {
+	for _, relation := range candidates {
 		stored, err := schema.of(ctx, relation.Target)
 		if err != nil {
 			return nil, err
 		}
 		// Via is `<referring type>.<column>`; the column is what the join runs
-		// on, and it is an id on the referring record.
-		_, column, _ := strings.Cut(relation.Via, ".")
+		// on, and it is an id on the referring record. An UNQUALIFIED Via
+		// here is a wiring defect rather than a missing column — the executor
+		// reads the same two spellings to decide the join's direction — and
+		// dropping the hop for it would hide the defect behind a vocabulary
+		// that merely looks narrower than it should be.
+		_, column, qualified := strings.Cut(relation.Via, ".")
+		if !qualified {
+			return nil, fmt.Errorf("search: inverse relation %q on %s carries an unqualified reference %q",
+				relation.Name, entity, relation.Via)
+		}
 		if stored.answers(newField(column, KindID)) {
 			kept = append(kept, relation)
 		}

--- a/backend/internal/modules/search/queryvocab.go
+++ b/backend/internal/modules/search/queryvocab.go
@@ -173,6 +173,7 @@ func (v Vocabulary) TargetNames() []string {
 // a cached vocabulary would keep answering with the surface as it was.
 type VocabularyResolver struct {
 	catalog fieldcatalog.Reader
+	columns ColumnReader
 }
 
 // NewVocabularyResolver builds a resolver over the core contract fields
@@ -186,6 +187,15 @@ func (r *VocabularyResolver) WithFieldCatalog(catalog fieldcatalog.Reader) *Voca
 	return r
 }
 
+// WithColumnReader wires the storage half: what the record's own table can
+// actually answer (querystorage.go). Without it the vocabulary is the
+// contract's — WIDER, never narrower, so an unwired resolver cannot publish
+// less than it admits.
+func (r *VocabularyResolver) WithColumnReader(columns ColumnReader) *VocabularyResolver {
+	r.columns = columns
+	return r
+}
+
 // Resolve composes the vocabulary for the caller bound to ctx, restricted to
 // the named record types (all of them when none are named, which is what the
 // published document asks for).
@@ -195,6 +205,11 @@ func (r *VocabularyResolver) WithFieldCatalog(catalog fieldcatalog.Reader) *Voca
 // two catalog reads rather than one per searchable entity.
 func (r *VocabularyResolver) Resolve(ctx context.Context, targets ...string) (Vocabulary, error) {
 	vocab := Vocabulary{Version: PlanVersion}
+	// One schema read per table per resolve. An inverse hop is derived from
+	// the REFERRING record's column, so composing one record type's vocabulary
+	// asks about several tables; without the memo the published document would
+	// re-read each of them once per target it lists.
+	schema := newSchemaReads(r.columns)
 	for _, branch := range searchBranches {
 		if len(targets) > 0 && !slices.Contains(targets, branch.entity) {
 			continue
@@ -202,7 +217,7 @@ func (r *VocabularyResolver) Resolve(ctx context.Context, targets ...string) (Vo
 		if auth.Require(ctx, branch.entity, principal.ActionRead) != nil {
 			continue
 		}
-		target, err := r.resolveTarget(ctx, branch.entity)
+		target, err := r.resolveTarget(ctx, schema, branch.entity)
 		if err != nil {
 			return Vocabulary{}, err
 		}
@@ -213,7 +228,7 @@ func (r *VocabularyResolver) Resolve(ctx context.Context, targets ...string) (Vo
 
 // resolveTarget composes one record type's vocabulary from its contract
 // fields, its live custom columns and its derived relations.
-func (r *VocabularyResolver) resolveTarget(ctx context.Context, entity string) (TargetVocabulary, error) {
+func (r *VocabularyResolver) resolveTarget(ctx context.Context, schema *schemaReads, entity string) (TargetVocabulary, error) {
 	record, ok := contractRecords[entity]
 	if !ok {
 		// A searchable entity with no contract binding is a wiring defect,
@@ -227,13 +242,50 @@ func (r *VocabularyResolver) resolveTarget(ctx context.Context, entity string) (
 		return TargetVocabulary{}, err
 	}
 	fields = append(fields, custom...)
+	// The storage filter runs before the relations are derived, so a hop is
+	// only ever derived from a reference the table really holds.
+	stored, err := schema.of(ctx, entity)
+	if err != nil {
+		return TargetVocabulary{}, err
+	}
+	fields = slices.DeleteFunc(fields, func(f Field) bool { return !stored.answers(f) })
 	slices.SortFunc(fields, func(a, b Field) int { return strings.Compare(a.Name, b.Name) })
 
-	relations := append(contractRelations(entity, fields), inverseRelations(entity)...)
+	inverse, err := storedInverseRelations(ctx, schema, entity)
+	if err != nil {
+		return TargetVocabulary{}, err
+	}
+	relations := append(contractRelations(entity, fields), inverse...)
 	relations = r.admittedRelations(ctx, relations)
 	slices.SortFunc(relations, func(a, b Relation) int { return strings.Compare(a.Name, b.Name) })
 
 	return TargetVocabulary{Target: entity, Fields: fields, Relations: relations}, nil
+}
+
+// storedInverseRelations keeps an inverse hop only when the REFERRING table
+// really holds the column the join would run on.
+//
+// The forward direction is already filtered — its reference is one of the
+// target's own fields — but the inverse is derived from another record's
+// contract, and the executor joins on that other table's column. A hop
+// published from a reference no table holds would validate and then fail as a
+// database error, which is the "published but unanswerable" case this whole
+// filter exists to remove, one level up from a field.
+func storedInverseRelations(ctx context.Context, schema *schemaReads, entity string) ([]Relation, error) {
+	var kept []Relation
+	for _, relation := range inverseRelations(entity) {
+		stored, err := schema.of(ctx, relation.Target)
+		if err != nil {
+			return nil, err
+		}
+		// Via is `<referring type>.<column>`; the column is what the join runs
+		// on, and it is an id on the referring record.
+		_, column, _ := strings.Cut(relation.Via, ".")
+		if stored.answers(newField(column, KindID)) {
+			kept = append(kept, relation)
+		}
+	}
+	return kept, nil
 }
 
 // admittedRelations drops the hops that land on a record type this caller may

--- a/backend/internal/modules/search/store.go
+++ b/backend/internal/modules/search/store.go
@@ -78,14 +78,22 @@ type searchBranch struct {
 // branchScope is the ONE admission + row-scope resolution every union
 // branch (lexical and vector alike) runs: object RBAC hides a denied
 // type silently, then the branch carries the caller's scope clause.
-func branchScope(ctx context.Context, branch searchBranch, arg func(any) int) (scope string, admitted bool, err error) {
+//
+// The alias is a PARAMETER because a query plan's traversal reads two
+// record types in one statement — the target as `t`, the hop as `h`. A
+// clause rendered against the wrong alias filters the wrong table, and
+// deciding whether a deal is visible by asking whether the caller may
+// see the deal, when the question was whether they may see the
+// organization behind it, is a visibility rule answering about a
+// different row.
+func branchScope(ctx context.Context, branch searchBranch, alias string, arg func(any) int) (scope string, admitted bool, err error) {
 	if auth.Require(ctx, branch.entity, principal.ActionRead) != nil {
 		return "", false, nil
 	}
 	if branch.activityWalk {
-		scope, err = auth.ActivityScopeClause(ctx, "t", arg)
+		scope, err = auth.ActivityScopeClause(ctx, alias, arg)
 	} else {
-		scope, err = auth.ScopeClauseFor(ctx, branch.entity, "t", arg)
+		scope, err = auth.ScopeClauseFor(ctx, branch.entity, alias, arg)
 	}
 	return scope, true, err
 }
@@ -181,7 +189,7 @@ func admittedBranchSQL(ctx context.Context, types []string, qPos int, arg func(a
 		if !slices.Contains(types, branch.entity) {
 			continue
 		}
-		scope, admitted, err := branchScope(ctx, branch, arg)
+		scope, admitted, err := branchScope(ctx, branch, "t", arg)
 		if err != nil {
 			return nil, err
 		}

--- a/backend/internal/modules/search/store.go
+++ b/backend/internal/modules/search/store.go
@@ -72,7 +72,21 @@ type searchBranch struct {
 	// out of results: search is how people find accounts, and the company
 	// running the CRM is not one to find (ADR-0082/A127). It stays reachable
 	// by id, and the company page is where it is read.
+	//
+	// It carries a %s for the ALIAS rather than a fixed one, because a query
+	// plan's traversal reads two record types in one statement and the
+	// narrowing belongs to whichever of them is being discovered. A fixed
+	// alias silently narrowed the wrong table.
 	extraWhere string
+}
+
+// narrowing renders this branch's discovery narrowing for one alias, and the
+// empty string when the branch has none.
+func (b searchBranch) narrowing(alias string) string {
+	if b.extraWhere == "" {
+		return ""
+	}
+	return fmt.Sprintf(b.extraWhere, alias)
 }
 
 // branchScope is the ONE admission + row-scope resolution every union
@@ -100,7 +114,7 @@ func branchScope(ctx context.Context, branch searchBranch, alias string, arg fun
 
 var searchBranches = []searchBranch{
 	{entity: "person", table: "person", title: "full_name", snippet: "NULL"},
-	{entity: "organization", table: "organization", title: "display_name", snippet: "NULL", extraWhere: "NOT t.is_anchor"},
+	{entity: "organization", table: "organization", title: "display_name", snippet: "NULL", extraWhere: "NOT %s.is_anchor"},
 	{entity: "deal", table: "deal", title: "name", snippet: "NULL"},
 	{entity: "lead", table: "lead", title: "coalesce(full_name, company_name, email)", snippet: "NULL"},
 	{entity: "project", table: "project", title: "name", snippet: "NULL"},
@@ -218,8 +232,8 @@ func admittedBranchSQL(ctx context.Context, types []string, qPos int, arg func(a
 			 WHERE t.search_tsv @@ %s
 			   AND t.archived_at IS NULL`,
 			branch.entity, branch.title, branch.snippet, tsquery, branch.table, tsquery)
-		if branch.extraWhere != "" {
-			sql += " AND " + branch.extraWhere
+		if narrowing := branch.narrowing("t"); narrowing != "" {
+			sql += " AND " + narrowing
 		}
 		if scope != "" {
 			sql += " AND " + scope


### PR DESCRIPTION
E1 (#617) compiled a question into a closed vocabulary and stopped there. This runs it.

Every part of running it answers the same question the vocabulary answered — what can
this caller ask, and what can this deployment honestly say back.

## What executes

**Exact predicates** compile to one statement over the target's own table, inside
`WithWorkspaceTx`, carrying what every read on this surface carries: `archived_at IS
NULL`, the branch's discovery narrowing (the installation's own company stays
undiscoverable), object RBAC, and the caller's row-scope clause.

**A traversal** compiles to a `JOIN LATERAL` that brings the hop record back as the
**evidence that admitted the row** — a hop is legible as a reason rather than as an
invisible filter. It carries the hop's **own** row scope: a caller who cannot see the
Stuttgart organization cannot select deals through it either.

**A similarity clause** ranks through the module's existing hybrid arm and its ids narrow
the statement; the exact predicates decide membership and similarity decides order, so
ranking never widens an answer.

## What the answer says about itself

Every answer declares its coverage, from the closed set, and carries a typed note per
reason it falls short:

| coverage | when |
|---|---|
| `complete_exact` | every clause ran exactly, nothing degraded, the answer fit the page |
| `ranked_semantic` | a similarity clause ordered it — recall is bounded by the ranking |
| `partial_degraded` | an unavailable predicate, a ranking lane with no embedding bound (`semantic_ranking_degraded_to_lexical`), or an answer cut off at the page (`result_truncated_at_limit`) |

**A ranked answer never labels itself complete**, and truncation is degradation rather
than pagination — the v1 grammar has no cursor, so a caller who hits the limit cannot ask
for the rest. **A plan with an unavailable predicate answers with its notes and no rows**
(SEARCH-AC-17, and `ValidatedPlan.Unavailable`'s own contract): returning rows while
quietly dropping the predicate would answer a wider question in a shape indistinguishable
from the right one, and the row count would leak the size of an answer the caller cannot
have.

The executed plan also comes back **in plain language**, rendered deterministically from
the validated plan — including the parts that did not run. Rows read beside a sentence
describing a different query is how a wrong answer becomes a trusted one.

## The vocabulary becomes storage-backed

E1 derived the vocabulary from the contract. The contract and the schema disagree about
roughly forty fields: `strength.*` is a view assembled from activity rows, `partner.*`
belongs to another table, `deal.stalled` is computed in a mapper, `organization.logo_url`
is minted from an object key. Each was a field the schema advertised and the executor
could only answer "no" to — and a caller cannot tell a wrong vocabulary from an empty
workspace.

So a field is askable when the contract declares it **and** the record's own table can
answer it under its own kind. Both halves stay derived — the second from
`information_schema`, the database's own statement of what it holds — so nothing becomes
a maintained list and SEARCH-AC-15 survives intact. The catalog read **filters and never
contributes**: `cf_*` columns are physically present for every workspace that declared
one, so a read used as a *source* would hand one workspace's private column to the next
caller. The custom half still comes from the workspace-scoped `fieldcatalog` seam.

`TestEveryPublishedFieldCompilesToAStoragePath` and `TestEveryPublishedRelationExecutes`
hold the two halves together against the **live** catalog.

## What the live schema and the gates found

Five defects, none visible from the design:

1. **`branchScope` hard-coded the alias `t`.** It is the ONE admission + row-scope
   resolution both search arms ride, and a traversal reads two record types in one
   statement — so the hop's visibility clause was rendered against the *target's* alias.
   It would have decided whether a deal is visible by asking whether the caller may see
   the deal, when the question was whether they may see the organization behind it. The
   alias is a parameter now; the defect test was verified by mutation.
2. **A nested contract object is stored FLAT.** Migration `0051` replaced the jsonb
   address document with one column per leaf, so `address.city` is the column
   `address_city` — and the jsonb-path machinery the design called for has no user in
   this schema at all. Removed rather than kept for a caller that does not exist.
3. **The contract's declared type and the column's type disagree.**
   `deal.fx_rate_to_base` is a *string* in the contract (a decimal rendered as text so a
   ten-place rate never rounds through a float) and `numeric` in the table. A text
   operand against it is not a narrower answer; it is `invalid input syntax for type
   numeric` for a field the schema said was askable. The binding reads `data_type` too.
4. **An inverse hop was filtered by the wrong table.** It is declared by the *referring*
   record and joins on that table's column, so nothing checked the column exists. Today
   every FK is real — which is why it needed a test, not only a fix.
5. **A blank `similar_to` refused under a field the plan does not have.** Whitespace is
   present to the grammar and empty to the retriever, so it reached the search store,
   whose refusal names `q` — the REST endpoint's parameter. Refused as `similar_to` now.

(1) was caught by `TestEveryStoreEntryPointIsAuthGated`'s waiver census, (2) and (3) by
the new fitness function on its first run against a real database, (4) and (5) by a review
pass over the finished commit.

## Proof

- **Unit** — SQL compilation, operand binding per kind (dates, instants, uuids, null,
  wrong shapes), the coverage triad, the narrative, the storage filter, the vocabulary
  narrowing. New-file statement coverage: `queryexec.go` 91%, `querysql.go` 91%,
  `querystorage.go` 92%, `queryexplain.go` 96%.
- **Integration** (`compose/integration/queryplan_integration_test.go`, 15 cases, real
  Postgres and real RLS) — two principals over one corpus get different answers and the
  rep's is a strict subset; a hop through an organization the rep cannot read admits
  nothing; the hop returns its evidence; `deal → project` (both tables carry `name`)
  proves the join's name resolution against a database rather than by argument;
  truncation, degradation and the unavailable-predicate note all against populated data;
  and the two fitness functions over the live schema.
- `make check-backend`, `make craft-static` green; the integration lane green.

## Scope, named so it is not read as a gap

- **`query_workspace` the tool, and its evals** — E3. The executor is exported and proven;
  nothing is registered on the agent surface yet, so this PR changes no agent behaviour.
  What it *does* change in production is the published `margince://schema/query` document,
  which now lists only fields a plan can be answered from.
- **Aggregates, grouping, ranking directives, multi-hop** — v2, deferred upstream with R3.
- **Deferring a scan to a Task** — F2, blocked on C1. Truncation reports itself instead.
- **Person and activity hops** — #618 stays open with option 3 taken for v1: both
  candidate widenings mean hand-writing something the contract does not say, which is the
  maintained list C-7 forbids.
- **REST** — MCP-only in v1; `crm.yaml` untouched (Z-1 re-derives it).

Roadmap: `.tmp/mcp-roadmap/PLAN.md` Track E. Follows #617.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs validated search plans end to end and labels each answer’s coverage (complete, ranked, or partial) with notes and a plain‑language query explanation. The published query schema is now storage‑backed so only database‑answerable fields are askable and executed.

- **New Features**
  - Execute `ValidatedPlan` to SQL with archived/discovery/RBAC/row‑scope guards on the target and hops; traversals use `JOIN LATERAL`, return hop evidence, and enforce the hop’s own scope.
  - Hybrid ranking respects similarity while exact predicates decide membership; both lanes narrow to the asked record types before fusion.
  - Responses declare coverage: `complete_exact`, `ranked_semantic`, or `partial_degraded` with typed notes; unavailable predicates return notes and no rows. Explanations are deterministic and derived from the validated plan.
  - Make the vocabulary storage‑backed via a `ColumnReader` wired into `VocabularyResolver` and `search.NewQuerySchemaResource`, so only columns present on a record’s table are askable.

- **Bug Fixes**
  - Narrow the ranked lane to the requested record types before fusion to avoid global top‑N post‑filtering.
  - Bind fractional `numeric` operands exactly (cast from digits) to prevent float rounding mismatches.
  - Refuse `null` in non‑operand grammar members (e.g., `"similar_to": null`) so clauses aren’t silently dropped.
  - Apply discovery narrowing to traversal hops, and make `branchScope` alias‑aware to scope the correct table in joins.
  - Validate inverse hops against the correct table/column and reject empty `similar_to` with the correct field name.
  - Treat an unqualified inverse reference as a wiring error (not a narrower vocabulary); fail validation instead of dropping the hop to prevent wrong join direction.

<sup>Written for commit d9c41fbe80d4903bf94b4c1ca9b711fe7040ba0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/620?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validated search-plan execution with exact, ranked, and partial-result outcomes.
  * Added natural-language explanations describing search criteria, ordering, limits, and unavailable conditions.
  * Search now supports type-scoped similarity and hybrid results.
  * Search fields and relationships are limited to data available in the underlying schema.
  * Traversal results include supporting relationship evidence.

* **Bug Fixes**
  * Improved filtering for archived records, access permissions, row scopes, and caller-specific data.
  * Invalid or unsupported search inputs now return clear refusal details instead of misleading results.
  * Added safer handling for truncation and degraded ranking states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->