### PR TITLE
feat(agents): an agent's reading is bounded, per record, at the one admission point

### DIFF
--- a/backend/cmd/api/boot.go
+++ b/backend/cmd/api/boot.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/deployconfig"
 	"github.com/gradionhq/margince/backend/internal/platform/jobs"
 	"github.com/gradionhq/margince/backend/internal/platform/overlaybudget"
+	"github.com/gradionhq/margince/backend/internal/platform/readmeter"
 	"github.com/gradionhq/margince/backend/internal/shared/runtimeenv"
 )
 
@@ -146,7 +147,12 @@ func overlayOptions(cfg apiConfig, deployCfg deployconfig.Config, rdb *redis.Cli
 	// here, not in compose); WithOverlayMeter Rebinds the Server's shared
 	// instance to it.
 	overlayMeter := overlaybudget.New(rdb, compose.OverlayBudgetConfig(deployCfg.EffectiveOverlayBudget()))
-	opts := []compose.Option{compose.WithOverlayMeter(overlayMeter)}
+	// The MCP-SESS-READS bound rides the SAME Redis. It is wired here, beside
+	// the other meter, because this is the role that serves agent principals:
+	// left fail-closed, an api with Redis configured would refuse every agent
+	// read it was perfectly able to count.
+	readMeter := readmeter.New(rdb, readmeter.DefaultLimit, readmeter.DefaultWindow)
+	opts := []compose.Option{compose.WithOverlayMeter(overlayMeter), compose.WithReadMeter(readMeter)}
 
 	// The HubSpot webhook-as-signal receiver (OVA-WIRE-10) mounts only when the
 	// app client secret is configured — it verifies the inbound v3 signature

--- a/backend/internal/compose/agentgate.go
+++ b/backend/internal/compose/agentgate.go
@@ -60,6 +60,14 @@ func agentGate(reg *agents.Registry, staging agents.Approvals, stages agents.Sta
 				return
 			}
 			if !mutatingMethod(r.Method) {
+				// The read bound binds BOTH doors. A Passport that spent its
+				// window through the MCP surface must not be able to keep
+				// reading the same records over /v1 — one credential governed
+				// two ways is the hole ADR-0055 exists to close.
+				if err := gate.AdmitRead(ctx); err != nil {
+					httperr.Write(w, r, err)
+					return
+				}
 				refuseHumanOnlyRead(w, r, next)
 				return
 			}

--- a/backend/internal/compose/agentgate.go
+++ b/backend/internal/compose/agentgate.go
@@ -60,15 +60,7 @@ func agentGate(reg *agents.Registry, staging agents.Approvals, stages agents.Sta
 				return
 			}
 			if !mutatingMethod(r.Method) {
-				// The read bound binds BOTH doors. A Passport that spent its
-				// window through the MCP surface must not be able to keep
-				// reading the same records over /v1 — one credential governed
-				// two ways is the hole ADR-0055 exists to close.
-				if err := gate.AdmitRead(ctx); err != nil {
-					httperr.Write(w, r, err)
-					return
-				}
-				refuseHumanOnlyRead(w, r, next)
+				refuseAgentRead(w, r, next, gate)
 				return
 			}
 			spec, resolve, pol, body, ok := prepareAgentGate(w, r, reg, deps)
@@ -84,7 +76,31 @@ func agentGate(reg *agents.Registry, staging agents.Approvals, stages agents.Sta
 	}
 }
 
-// refuseHumanOnlyRead applies x-agent-access to a NON-mutating agent call.
+// refuseAgentRead answers a NON-mutating agent call: its governance class
+// first, then its volume.
+//
+// The order is deliberate. `x-agent-access: human-only` says this route is not
+// an agent's to read AT ALL, and that answer must not depend on how much the
+// agent happens to have read today — a caller told "you are over your read
+// budget" would reasonably retry tomorrow against a route that will never be
+// theirs.
+//
+// The bound itself binds BOTH doors: a Passport that spent its window through
+// the MCP surface must not keep reading the same records over /v1. One
+// credential governed two ways is the hole ADR-0055 exists to close.
+func refuseAgentRead(w http.ResponseWriter, r *http.Request, next http.Handler, gate *auth.Gate) {
+	if refusedAsHumanOnly(w, r) {
+		return
+	}
+	if err := gate.AdmitRead(r.Context()); err != nil {
+		httperr.Write(w, r, err)
+		return
+	}
+	next.ServeHTTP(w, r)
+}
+
+// refusedAsHumanOnly applies x-agent-access to a NON-mutating agent call, and
+// reports whether it answered the request itself.
 //
 // A read has no tier to admit and no change to stage, but it does have a
 // governance class, and `x-agent-access: human-only` binds a `get:` exactly
@@ -100,14 +116,15 @@ func agentGate(reg *agents.Registry, staging agents.Approvals, stages agents.Sta
 // admitted. The table now carries every ANNOTATED read, and an unannotated
 // read is ordinary agent-readable data whose authority is the granting
 // human's RBAC and row scope at the store, unchanged.
-func refuseHumanOnlyRead(w http.ResponseWriter, r *http.Request, next http.Handler) {
+func refusedAsHumanOnly(w http.ResponseWriter, r *http.Request) bool {
 	pattern := chi.RouteContext(r.Context()).RoutePattern()
-	if pol, known := agentPolicies[r.Method+" "+pattern]; known && pol.Access != accessTool {
-		httperr.Write(w, r, fmt.Errorf(
-			"agent gate: %s is %s: %w", pol.Op, pol.Access, apperrors.ErrPermissionDenied))
-		return
+	pol, known := agentPolicies[r.Method+" "+pattern]
+	if !known || pol.Access == accessTool {
+		return false
 	}
-	next.ServeHTTP(w, r)
+	httperr.Write(w, r, fmt.Errorf(
+		"agent gate: %s is %s: %w", pol.Op, pol.Access, apperrors.ErrPermissionDenied))
+	return true
 }
 
 // prepareAgentGate resolves the admission inputs for a mutating agent call:

--- a/backend/internal/compose/integration/agentreadbound_integration_test.go
+++ b/backend/internal/compose/integration/agentreadbound_integration_test.go
@@ -15,15 +15,10 @@ package integration
 // own Server with a live bound. Without it nothing would prove the REST door
 // enforces the bound at all.
 //
-// WHAT IS PROVEN HERE, precisely. The window is spent by charging the meter
-// DIRECTLY rather than by reading over REST, because REST reads are consulted
-// against the bound and not yet CHARGED against it (poc-v1#623). That is not a
-// convenience; it is the property under test stated honestly. The hole this
-// closes is a passport spending its window through the MCP door and then
-// continuing to read the same records through /v1 — one credential, two doors,
-// one of them unbounded. Charging directly IS that spent window, without
-// standing up a JSON-RPC client to produce it.
-
+// The window is spent by charging the meter directly: that IS a window already
+// spent through the MCP door, which is the shape this bound has to answer —
+// one credential presenting at a second door must meet the same counter.
+//
 import (
 	"net/http"
 	"testing"
@@ -80,8 +75,18 @@ func TestASpentWindowRefusesTheSamePassportOnTheRestDoor(t *testing.T) {
 
 	spendWindow(t, e, meter, passport, 100)
 
-	if status := e.Call(t, "GET", "/v1/people", nil, bearer, nil); status == http.StatusOK {
-		t.Error("a passport that spent its window was served again over REST; /v1 is outside the bound")
+	// The QUOTA response specifically: a 403 or a 500 would also fail an
+	// is-not-200 check while meaning something entirely different.
+	var problem struct {
+		Code string `json:"code"`
+	}
+	status := e.Call(t, "GET", "/v1/people", nil, bearer, &problem)
+
+	if status != http.StatusTooManyRequests {
+		t.Errorf("a passport that spent its window → %d, want 429; /v1 is outside the bound", status)
+	}
+	if problem.Code != "rate_limited" {
+		t.Errorf("the refusal carried code %q, want \"rate_limited\" — a caller branches on the code, not the prose", problem.Code)
 	}
 }
 

--- a/backend/internal/compose/integration/agentreadbound_integration_test.go
+++ b/backend/internal/compose/integration/agentreadbound_integration_test.go
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// The MCP-SESS-READS bound on the REST door, over the REAL HTTP stack with a
+// real passport.
+//
+// The shared app harness composes readmeter.Unmetered() — it serves no Redis,
+// and a meter that cannot reach its counter fails closed, which would refuse
+// every agent read in suites testing something else. That is the right default
+// for those suites and the wrong one for this property, so this file builds its
+// own Server with a live bound. Without it nothing would prove the REST door
+// enforces the bound at all.
+//
+// WHAT IS PROVEN HERE, precisely. The window is spent by charging the meter
+// DIRECTLY rather than by reading over REST, because REST reads are consulted
+// against the bound and not yet CHARGED against it (poc-v1#623). That is not a
+// convenience; it is the property under test stated honestly. The hole this
+// closes is a passport spending its window through the MCP door and then
+// continuing to read the same records through /v1 — one credential, two doors,
+// one of them unbounded. Charging directly IS that spent window, without
+// standing up a JSON-RPC client to produce it.
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
+	"github.com/gradionhq/margince/backend/internal/platform/overlaybudget/budgettest"
+	"github.com/gradionhq/margince/backend/internal/platform/readmeter"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// boundedApp is the app under a live read bound, plus the meter itself so a
+// test can put the window into whatever state it is about.
+func boundedApp(t *testing.T, slug string, limit int) (*apptest.AppEnv, *readmeter.Meter) {
+	t.Helper()
+	meter := readmeter.New(budgettest.Client(t), limit, time.Hour)
+	e := apptest.SetupAppWithOptions(t, compose.WithReadMeter(meter))
+	e.Slug = slug
+	apptest.BootstrapWorkspaceSession(t, e, "Read Bound", slug+"@fable.test", "Admin")
+	return e, meter
+}
+
+// spendWindow charges the meter against one passport, as the MCP door would.
+func spendWindow(t *testing.T, e *apptest.AppEnv, meter *readmeter.Meter, passport ids.UUID, records int) {
+	t.Helper()
+	var ws ids.UUID
+	if err := e.Owner.QueryRow(t.Context(), `SELECT id FROM workspace LIMIT 1`).Scan(&ws); err != nil {
+		t.Fatalf("reading the workspace id: %v", err)
+	}
+	ctx := principal.WithWorkspaceID(t.Context(), ws)
+	ctx = principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalAgent, ID: "agent:" + passport.String(), PassportID: passport,
+	})
+	if err := meter.Consume(ctx, records); err != nil {
+		t.Fatalf("spending the window: %v", err)
+	}
+}
+
+// A passport that has spent its window is refused on the REST door too. Before
+// this, contractAPI built its gate with no bound and the agent gate returned
+// early on every non-mutating method, so /v1 sat outside the control entirely.
+func TestASpentWindowRefusesTheSamePassportOnTheRestDoor(t *testing.T) {
+	e, meter := boundedApp(t, "read-bound-rest", 100)
+	bearer, passport := passportWithID(t, e, "reading agent", "read")
+	seedPeople(t, e, 2)
+
+	// Served under the bound first, so the refusal below is the bound firing
+	// rather than the route being closed to agents for some other reason.
+	if status := e.Call(t, "GET", "/v1/people", nil, bearer, nil); status != http.StatusOK {
+		t.Fatalf("an agent read under the bound → %d, want 200", status)
+	}
+
+	spendWindow(t, e, meter, passport, 100)
+
+	if status := e.Call(t, "GET", "/v1/people", nil, bearer, nil); status == http.StatusOK {
+		t.Error("a passport that spent its window was served again over REST; /v1 is outside the bound")
+	}
+}
+
+// A HUMAN session is never touched by it, however much any agent has read. A
+// busy agent must not be able to lock its own operator out of the product it is
+// acting inside.
+func TestAHumanSessionIsUnaffectedByASpentAgentWindow(t *testing.T) {
+	e, meter := boundedApp(t, "read-bound-human", 100)
+	_, passport := passportWithID(t, e, "reading agent", "read")
+	seedPeople(t, e, 2)
+
+	spendWindow(t, e, meter, passport, 500)
+
+	if status := e.Call(t, "GET", "/v1/people", nil, nil, nil); status != http.StatusOK {
+		t.Errorf("a human read → %d after an agent spent its window; humans are outside this bound", status)
+	}
+}
+
+// passportWithID mints a passport and returns both the header an agent presents
+// and the id the meter counts against.
+func passportWithID(t *testing.T, e *apptest.AppEnv, label string, scopes ...string) (map[string]string, ids.UUID) {
+	t.Helper()
+	var minted struct {
+		ID    ids.UUID `json:"passport_id"`
+		Token string   `json:"token"`
+	}
+	if status := e.Call(t, "POST", "/v1/passports", apptest.AnyMap{
+		"label": label, "scopes": scopes,
+	}, nil, &minted); status != http.StatusCreated {
+		t.Fatalf("issue passport %q → %d", label, status)
+	}
+	if minted.Token == "" || minted.ID.IsZero() {
+		t.Fatalf("passport %q minted without a token or an id", label)
+	}
+	return map[string]string{"Authorization": "Bearer " + minted.Token}, minted.ID
+}
+
+// seedPeople gives the list something to return, so the admitted read is a real
+// one rather than an empty page.
+func seedPeople(t *testing.T, e *apptest.AppEnv, n int) {
+	t.Helper()
+	for i := range n {
+		if status := e.Call(t, "POST", "/v1/people", apptest.AnyMap{
+			"full_name": "Metered Person " + string(rune('A'+i)),
+		}, nil, nil); status != http.StatusCreated {
+			t.Fatalf("seeding person %d → %d", i, status)
+		}
+	}
+}

--- a/backend/internal/compose/integration/apptest/appenv.go
+++ b/backend/internal/compose/integration/apptest/appenv.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/deployconfig"
 	"github.com/gradionhq/margince/backend/internal/platform/jobs"
+	"github.com/gradionhq/margince/backend/internal/platform/readmeter"
 	"github.com/gradionhq/margince/backend/internal/platform/testdb"
 )
 
@@ -119,6 +120,12 @@ func SetupAppWithOriginOptions(t *testing.T, opts func(origin string) []compose.
 	allOpts := append([]compose.Option{
 		compose.WithPublicBaseURL("https://mail.example.test"),
 		compose.WithDelivery(compose.NewDeliveryStager(pool, sendInserter)),
+		// This harness serves no Redis, and a meter that cannot reach its
+		// counter fails CLOSED — correct in production, and it would refuse
+		// every agent read in a lane that is testing something else. Declaring
+		// the app under test unbounded is the honest spelling: a suite that
+		// wants the bound composes its own metered Server.
+		compose.WithReadMeter(readmeter.Unmetered()),
 	}, opts(origin)...)
 	ts.Config.Handler = compose.New(pool, slog.New(slog.NewTextHandler(os.Stderr, nil)), allOpts...)
 	ts.StartTLS()

--- a/backend/internal/compose/registry.go
+++ b/backend/internal/compose/registry.go
@@ -49,7 +49,14 @@ func registryWithDraftBrain(pool *pgxpool.Pool, brain completer, resolveIncumben
 	return registryWithGate(pool, auth.NewGate(identity.NewService(pool)), newReplyDrafter(pool, brain, nil), resolveIncumbent, send, companyEnricher{})
 }
 
-func registryWithGate(pool *pgxpool.Pool, gate *auth.Gate, drafter activities.EmailDrafter, resolveIncumbent func(context.Context) (overlay.Incumbent, error), send SendPath, enricher agents.CompanyEnricher) *agents.Registry {
+// registryWithGate composes the tool surface. The read-bound charger arrives as
+// an option rather than a parameter because only the API server — the one role
+// that serves agent principals through the MCP and REST doors — has a meter to
+// charge. The Surface-B runner and the workflow paths run as the human or the
+// system that started them, and readmeter governs agents only, so a registry
+// built without one is not an unmetered agent surface; it is a surface no agent
+// reaches.
+func registryWithGate(pool *pgxpool.Pool, gate *auth.Gate, drafter activities.EmailDrafter, resolveIncumbent func(context.Context) (overlay.Incumbent, error), send SendPath, enricher agents.CompanyEnricher, opts ...agents.RegistryOption) *agents.Registry {
 	// The Dispatcher is the datasource seam every core/slipping tool
 	// rides: a native-mode workspace lands on the composite SoR
 	// Provider exactly as before, an overlay-mode workspace's reads land
@@ -65,7 +72,7 @@ func registryWithGate(pool *pgxpool.Pool, gate *auth.Gate, drafter activities.Em
 	// NewOverlayMeter like the REST surface's, sharing the same per-workspace
 	// windows.
 	provider := NewDispatcher(NewProvider(pool), NewOverlayProvider(pool, failClosedOverlayMeter(), resolveIncumbent), pool)
-	registry := agents.NewRegistry(approvalsAdapter{svc: approvals.NewService(pool)}, gate)
+	registry := agents.NewRegistry(approvalsAdapter{svc: approvals.NewService(pool)}, gate, opts...)
 	// The guards take the Dispatcher as an overlayModeChecker — the interface
 	// whose method IS the uncached read, so no wiring here can hand them the
 	// cached mode. See overlayModeChecker for why that distinction is typed.

--- a/backend/internal/compose/routes.go
+++ b/backend/internal/compose/routes.go
@@ -37,7 +37,10 @@ import (
 // admission layer, idempotency, and the overlay-mode write guard wrapped
 // around it (outermost last — see the wrap-order note inline).
 func contractAPI(srv Server, pool *pgxpool.Pool, identitySvc *identity.Service) http.Handler {
-	gate := auth.NewGate(identitySvc)
+	// The SAME meter the tool registry charges: this door refuses on the bound
+	// the other door pays into, so a Passport cannot spend its window on one
+	// and keep reading on the other.
+	gate := auth.NewGate(identitySvc, auth.WithReadBound(srv.readMeter))
 	// This registry admits REST calls; it never INVOKES a tool — a REST enrich
 	// runs scrapeHandlers, not the tool — so the enricher here supplies only the
 	// spec's cap and tier, and the ZERO value supplies those. Deliberately not

--- a/backend/internal/compose/server.go
+++ b/backend/internal/compose/server.go
@@ -43,6 +43,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/httpserver"
 	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
 	"github.com/gradionhq/margince/backend/internal/platform/overlaybudget"
+	"github.com/gradionhq/margince/backend/internal/platform/readmeter"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
@@ -225,6 +226,15 @@ type Server struct {
 	// at all. WithOverlayMeter Rebinds this shared pointer to the live
 	// Redis-backed meter at boot.
 	overlayMeter *overlaybudget.Meter
+	// readMeter is the MCP-SESS-READS bound this role enforces on agent
+	// reads, shared by the two things that must agree about it: the admission
+	// gate that REFUSES on it and the tool registry that CHARGES it.
+	//
+	// Always non-nil (newServer constructs it unconditionally, fail-closed
+	// with no Redis), and WithReadMeter Rebinds this ONE pointer to the live
+	// Redis-backed meter at boot — so no option order can leave the gate
+	// enforcing a different counter from the one the registry pays into.
+	readMeter *readmeter.Meter
 	// overlayBackfillLimit bounds the overlay initial mirror backfill per
 	// object class (dev/demo — WithOverlayBackfillLimit); 0 is uncapped.
 	overlayBackfillLimit int
@@ -361,6 +371,10 @@ func newServer(pool *pgxpool.Pool, log *slog.Logger, authH authHandlers, dealsH 
 		// doc). Fail-closed until WithOverlayMeter Rebinds it with the live
 		// Redis client + config.
 		overlayMeter: failClosedOverlayMeter(),
+		// Fail-closed until WithReadMeter Rebinds it: a role serving the agent
+		// surface with no Redis cannot tell whether an agent has passed its
+		// read bound, and answers that it has.
+		readMeter: readmeter.New(nil, readmeter.DefaultLimit, readmeter.DefaultWindow),
 	}
 	srv.wireCaptureSettingsSurface(pool)
 	srv.wireExportSurface(pool, log)
@@ -391,8 +405,13 @@ func newServer(pool *pgxpool.Pool, log *slog.Logger, authH authHandlers, dealsH 
 func (s *Server) rebuildToolRegistry(pool *pgxpool.Pool) {
 	// The closure captures s and reads s.vault LAZILY at request time, so
 	// rebuilding before WithKeyvault installs the vault is fine.
-	s.toolRegistry = registryWithGate(pool, auth.NewGate(identity.NewService(pool)),
-		s.replyDrafter, s.resolveOverlayIncumbent(pool), s.send, companyEnricher{srv: s})
+	// The gate and the registry take the SAME meter pointer: one refuses on the
+	// bound, the other pays into it, and a surface where those were two
+	// counters would step an agent up against a number nothing was charging.
+	s.toolRegistry = registryWithGate(pool,
+		auth.NewGate(identity.NewService(pool), auth.WithReadBound(s.readMeter)),
+		s.replyDrafter, s.resolveOverlayIncumbent(pool), s.send, companyEnricher{srv: s},
+		agents.WithReadCharger(s.readMeter))
 }
 
 // signalStrength bridges people's §4 relationship-strength computation to

--- a/backend/internal/compose/serveroptions.go
+++ b/backend/internal/compose/serveroptions.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gradionhq/margince/backend/internal/platform/keyvault"
 	"github.com/gradionhq/margince/backend/internal/platform/mailer"
 	"github.com/gradionhq/margince/backend/internal/platform/overlaybudget"
+	"github.com/gradionhq/margince/backend/internal/platform/readmeter"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/extraction"
 	"github.com/gradionhq/margince/backend/internal/shared/runtimeenv"
 )
@@ -211,6 +212,21 @@ func WithOverlayBackfillLimit(limit int) Option {
 // no Redis.
 func WithOverlayMeter(meter *overlaybudget.Meter) Option {
 	return func(s *Server, _ *pgxpool.Pool) { s.overlayMeter.RebindFrom(meter) }
+}
+
+// WithReadMeter Rebinds the Server's shared MCP-SESS-READS meter to the live,
+// Redis-backed one cmd built. newServer constructs it fail-closed (nil Redis)
+// and hands that ONE pointer to both halves of the bound — the admission gate
+// that refuses on it and the tool registry that charges it — so this
+// RebindFrom reaches both together and they can never end up counting against
+// different windows.
+//
+// Taking the already-built *readmeter.Meter (not a *redis.Client) keeps the
+// raw-Redis dependency in cmd, never in compose. Without this option the meter
+// stays fail-closed: a role serving the agent surface with no Redis cannot
+// tell whether an agent has passed its read bound, and answers that it has.
+func WithReadMeter(meter *readmeter.Meter) Option {
+	return func(s *Server, _ *pgxpool.Pool) { s.readMeter.RebindFrom(meter) }
 }
 
 // readinessChecks assembles the /readyz dependency probes for this role.

--- a/backend/internal/modules/agents/envelope.go
+++ b/backend/internal/modules/agents/envelope.go
@@ -291,6 +291,12 @@ func provenanceOf(rec datasource.Record) (source, capturedBy string) {
 // can follow says nothing about how far the row behind it can be trusted. A
 // handler whose answer carries record CONTENT calls noteRecord (it holds the
 // row) or noteDerivedContent (it does not).
+// It CHARGES the read bound, for the same reason noteRecord does: naming a
+// record to an agent is handing that record over. The intent tools answer with
+// ids and derived prose rather than rows, so if only noteRecord charged, the
+// tools that surface the most records per call — the slipping sweep, the
+// coverage reads, the catch-up — would be the cheapest reads on the surface.
+// That is precisely the failure A139 named, one tool family over.
 func noteEvidence(ctx context.Context, recordType datasource.EntityType, id ids.UUID) {
 	facts := factsOn(ctx)
 	if facts == nil || id.IsZero() {
@@ -298,6 +304,7 @@ func noteEvidence(ctx context.Context, recordType datasource.EntityType, id ids.
 	}
 	facts.mu.Lock()
 	defer facts.mu.Unlock()
+	facts.served++
 	facts.addRef(EvidenceRef{RecordType: recordType, RecordID: id})
 }
 

--- a/backend/internal/modules/agents/envelope.go
+++ b/backend/internal/modules/agents/envelope.go
@@ -180,6 +180,12 @@ type envelopeFacts struct {
 	authoritative bool
 	warnings      []Warning
 	warned        map[string]struct{}
+	// served counts records HANDED OVER, which is not the same number as the
+	// evidence list's length: evidence dedupes by value, because one record
+	// read twice is one thing to cite. The read bound asks a different
+	// question — how much has this agent been given — and deduping it would
+	// let a handler that reads the same page twice pay for it once.
+	served int
 }
 
 func newEnvelopeFacts() *envelopeFacts {
@@ -220,6 +226,7 @@ func noteRecord(ctx context.Context, rec datasource.Record) {
 	source, capturedBy := provenanceOf(rec)
 	facts.mu.Lock()
 	defer facts.mu.Unlock()
+	facts.served++
 	facts.addRef(EvidenceRef{
 		RecordType: rec.Ref.Type, RecordID: rec.Ref.ID,
 		Source: source, CapturedBy: capturedBy,
@@ -230,6 +237,13 @@ func noteRecord(ctx context.Context, rec datasource.Record) {
 		(facts.oldestSync.IsZero() || stamp.Before(facts.oldestSync)) {
 		facts.oldestSync = stamp
 	}
+}
+
+// servedCount is what the call handed over, for the read bound to charge.
+func (f *envelopeFacts) servedCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.served
 }
 
 // tierOf reads one record's tier off what it was STAMPED with, which is the only

--- a/backend/internal/modules/agents/readbound.go
+++ b/backend/internal/modules/agents/readbound.go
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// What this surface OWES the read bound (MCP-SESS-READS,
+// api-rate-limits-and-abuse §2.2).
+//
+// The bound has two halves and they live apart on purpose. platform/auth
+// decides admission on it — that is the ONE place a governed action is admitted,
+// and a quota is an admission term ("scope ∧ tier ∧ quota"). This file is the
+// other half: what an answer COSTS, charged where records leave the surface.
+// Splitting them is what keeps a registry from being able to admit itself.
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/mcp"
+)
+
+// ReadCharger records records handed over against the caller's read bound.
+// Registry only ever charges; reading the bound and refusing on it belongs to
+// the one admission point, so this half of the seam cannot be used to decide
+// anything.
+type ReadCharger interface {
+	Consume(ctx context.Context, n int) error
+}
+
+// RegistryOption configures a Registry at construction.
+type RegistryOption func(*Registry)
+
+// WithReadCharger installs the meter tool results are charged against. It is
+// the same pointer compose hands the admission gate as its ReadBound, so the
+// half that refuses and the half that pays can never end up counting against
+// different windows. A registry without one records nothing — the composition
+// no agent principal reaches (see auth.WithReadBound).
+func WithReadCharger(reads ReadCharger) RegistryOption {
+	return func(r *Registry) { r.reads = reads }
+}
+
+// chargeReads records what one answer handed over against MCP-SESS-READS, at
+// the one place every tool's result passes through. Charging per TOOL instead
+// would be a list to maintain, and the read tool added next is the one that
+// forgets — which is exactly how a densely-joined answer becomes the cheapest
+// bulk read on the surface (A139).
+//
+// It charges only after a SUCCESSFUL answer: the bound counts records the agent
+// was actually given, and a handler that failed gave it none.
+//
+// A charge that cannot be recorded REFUSES the answer. If the surface cannot
+// count what it is about to hand over, it does not hand it over — the same
+// fail-closed rule the gate applies on the way in, applied on the way out.
+//
+// Logging and serving anyway was tried and is wrong. It looks contained,
+// because the gate fails closed while the counter is unreachable — but a charge
+// lost to a TRANSIENT write error is lost for good: Redis recovers, the counter
+// is short by those records, and the agent reads them again for free. Every
+// blip would quietly raise the ceiling.
+//
+// The caller is told the truth: the read was made and could not be accounted
+// for, so it was not served. Retrying once the counter is reachable both counts
+// and answers.
+func (r *Registry) chargeReads(ctx context.Context, spec mcp.ToolSpec, served int) error {
+	if r.reads == nil || served <= 0 {
+		return nil
+	}
+	if err := r.reads.Consume(ctx, served); err != nil {
+		slog.ErrorContext(ctx, "recording served records against the read bound failed",
+			"tool", spec.Name, "records", served, "err", err)
+		return fmt.Errorf(
+			"crmagents: %s read %d records that could not be counted against this agent's read bound, so the answer is withheld: %w",
+			spec.Name, served, apperrors.ErrBudgetExceeded)
+	}
+	return nil
+}

--- a/backend/internal/modules/agents/readbound.go
+++ b/backend/internal/modules/agents/readbound.go
@@ -18,7 +18,6 @@ import (
 	"log/slog"
 
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
-	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/mcp"
 )
 
@@ -77,8 +76,8 @@ func (r *Registry) chargeReads(ctx context.Context, spec mcp.ToolSpec, served in
 		return nil
 	}
 	slog.ErrorContext(ctx, "recording served records against the read bound failed",
-		"tool", spec.Name, "records", served, "scope", spec.RequiredScope, "err", err)
-	if spec.RequiredScope != principal.ScopeRead {
+		"tool", spec.Name, "records", served, "read_only", spec.ReadOnly(), "err", err)
+	if !spec.ReadOnly() {
 		// The effect already happened. Reporting it as a failure is worse than
 		// an uncounted read.
 		return nil

--- a/backend/internal/modules/agents/readbound.go
+++ b/backend/internal/modules/agents/readbound.go
@@ -18,6 +18,7 @@ import (
 	"log/slog"
 
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/mcp"
 )
 
@@ -50,29 +51,39 @@ func WithReadCharger(reads ReadCharger) RegistryOption {
 // It charges only after a SUCCESSFUL answer: the bound counts records the agent
 // was actually given, and a handler that failed gave it none.
 //
-// A charge that cannot be recorded REFUSES the answer. If the surface cannot
-// count what it is about to hand over, it does not hand it over — the same
-// fail-closed rule the gate applies on the way in, applied on the way out.
+// A charge that cannot be recorded REFUSES a READ, and only a read. If the
+// surface cannot count what it is about to hand over, it does not hand it over
+// — the gate's rule on the way in, applied on the way out.
 //
-// Logging and serving anyway was tried and is wrong. It looks contained,
+// A WRITE is served anyway, and the asymmetry is the whole point. By the time
+// this runs the mutation has committed and any approval it redeemed is
+// consumed: `send_email` has SENT. Withholding that result would report a
+// completed, irreversible act as a failure, and the caller — reasonably —
+// retries it. An uncounted read is a small accounting loss; a second email is
+// not. So a write is logged and returned, and the read bound absorbs the
+// undercount.
+//
+// Logging and serving a READ was tried and is wrong. It looks contained,
 // because the gate fails closed while the counter is unreachable — but a charge
 // lost to a TRANSIENT write error is lost for good: Redis recovers, the counter
-// is short by those records, and the agent reads them again for free. Every
-// blip would quietly raise the ceiling.
-//
-// The caller is told the truth: the read was made and could not be accounted
-// for, so it was not served. Retrying once the counter is reachable both counts
-// and answers.
+// comes back short, and those records are read again for free. Every blip would
+// quietly raise the ceiling.
 func (r *Registry) chargeReads(ctx context.Context, spec mcp.ToolSpec, served int) error {
 	if r.reads == nil || served <= 0 {
 		return nil
 	}
-	if err := r.reads.Consume(ctx, served); err != nil {
-		slog.ErrorContext(ctx, "recording served records against the read bound failed",
-			"tool", spec.Name, "records", served, "err", err)
-		return fmt.Errorf(
-			"crmagents: %s read %d records that could not be counted against this agent's read bound, so the answer is withheld: %w",
-			spec.Name, served, apperrors.ErrBudgetExceeded)
+	err := r.reads.Consume(ctx, served)
+	if err == nil {
+		return nil
 	}
-	return nil
+	slog.ErrorContext(ctx, "recording served records against the read bound failed",
+		"tool", spec.Name, "records", served, "scope", spec.RequiredScope, "err", err)
+	if spec.RequiredScope != principal.ScopeRead {
+		// The effect already happened. Reporting it as a failure is worse than
+		// an uncounted read.
+		return nil
+	}
+	return fmt.Errorf(
+		"crmagents: %s read %d records that could not be counted against this agent's read bound, so the answer is withheld: %w",
+		spec.Name, served, apperrors.ErrBudgetExceeded)
 }

--- a/backend/internal/modules/agents/readcharge_test.go
+++ b/backend/internal/modules/agents/readcharge_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
@@ -61,18 +62,51 @@ func readToolSpec(name string) mcp.ToolSpec {
 	}
 }
 
-func chargingRegistry(t *testing.T, tool mcp.Tool) (*Registry, *countingCharger, context.Context) {
+// chargingRegistry is the ONE setup every test here shares: a registry with a
+// counting charger, the tool under test registered, and an agent context
+// holding scope. Options vary only what a given test is about.
+func chargingRegistry(t *testing.T, tool mcp.Tool, opts ...chargeTestOption) (*Registry, *countingCharger, context.Context) {
 	t.Helper()
-	charger := &countingCharger{}
-	r := NewRegistry(nil, auth.NewGate(fullSeatAuthority{}), WithReadCharger(charger))
+	cfg := chargeTest{charger: &countingCharger{}, scope: principal.ScopeRead}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	r := NewRegistry(nil, auth.NewGate(fullSeatAuthority{}), WithReadCharger(cfg.charger))
+	if cfg.noCharger {
+		r = NewRegistry(nil, auth.NewGate(fullSeatAuthority{}))
+	}
 	r.Register(tool)
 	ctx := principal.WithWorkspaceID(context.Background(), ids.NewV7())
 	ctx = principal.WithActor(ctx, principal.Principal{
 		Type: principal.PrincipalAgent, ID: "agent:t", OnBehalfOf: ids.NewV7(),
 		PassportID: ids.NewV7(),
-		Scopes:     principal.NewScopeSet(principal.ScopeRead),
+		Scopes:     principal.NewScopeSet(cfg.scope),
 	})
-	return r, charger, ctx
+	return r, cfg.charger, ctx
+}
+
+type chargeTest struct {
+	charger   *countingCharger
+	scope     principal.Scope
+	noCharger bool
+}
+
+type chargeTestOption func(*chargeTest)
+
+// withChargerError makes the meter unreachable, so a test can say what an
+// uncountable read does.
+func withChargerError(err error) chargeTestOption {
+	return func(c *chargeTest) { c.charger.err = err }
+}
+
+// withScope runs the caller under a scope other than read.
+func withScope(s principal.Scope) chargeTestOption {
+	return func(c *chargeTest) { c.scope = s }
+}
+
+// withNoCharger composes the registry with no meter at all.
+func withNoCharger() chargeTestOption {
+	return func(c *chargeTest) { c.noCharger = true }
 }
 
 // The charge is PER RECORD, taken where records leave the surface. One call
@@ -96,15 +130,7 @@ func TestAnAnswerChargesForEveryRecordItServed(t *testing.T) {
 // and reusing that count for the bound would let a handler that reads a page
 // twice pay for it once.
 func TestARecordServedTwiceIsChargedTwice(t *testing.T) {
-	charger := &countingCharger{}
-	r := NewRegistry(nil, auth.NewGate(fullSeatAuthority{}), WithReadCharger(charger))
-	repeated := ids.NewV7()
-	r.Register(&repeatingTool{spec: readToolSpec("read_record"), id: repeated, times: 3})
-	ctx := principal.WithWorkspaceID(context.Background(), ids.NewV7())
-	ctx = principal.WithActor(ctx, principal.Principal{
-		Type: principal.PrincipalAgent, ID: "agent:t", OnBehalfOf: ids.NewV7(),
-		PassportID: ids.NewV7(), Scopes: principal.NewScopeSet(principal.ScopeRead),
-	})
+	r, charger, ctx := chargingRegistry(t, &repeatingTool{spec: readToolSpec("read_record"), id: ids.NewV7(), times: 3})
 
 	if _, err := r.Invoke(ctx, "read_record", json.RawMessage(`{}`)); err != nil {
 		t.Fatal(err)
@@ -160,26 +186,23 @@ func TestAnAnswerWithNoRecordsChargesNothing(t *testing.T) {
 	}
 }
 
-// A charge that cannot be recorded must not fail the call: the records have
-// already left the surface, and answering with an error would hide a completed
-// read while still leaving it uncounted. Nothing is spent through the gap —
-// the gate reads the same counter and fails closed when it is unreachable.
-func TestACountingFailureDoesNotFailTheAnswer(t *testing.T) {
-	charger := &countingCharger{err: errors.New("redis is unreachable")}
-	r := NewRegistry(nil, auth.NewGate(fullSeatAuthority{}), WithReadCharger(charger))
-	r.Register(&servingTool{spec: readToolSpec("search_records"), records: 5})
-	ctx := principal.WithWorkspaceID(context.Background(), ids.NewV7())
-	ctx = principal.WithActor(ctx, principal.Principal{
-		Type: principal.PrincipalAgent, ID: "agent:t", OnBehalfOf: ids.NewV7(),
-		PassportID: ids.NewV7(), Scopes: principal.NewScopeSet(principal.ScopeRead),
-	})
+// A read that cannot be COUNTED is not served. Logging and answering anyway
+// looks contained — the gate fails closed while the counter is down — but a
+// charge lost to a transient write error is lost for good: the counter comes
+// back short and those records are read again for free. Every blip would
+// quietly raise the ceiling.
+func TestAnAnswerThatCannotBeCountedIsWithheld(t *testing.T) {
+	r, _, ctx := chargingRegistry(t,
+		&servingTool{spec: readToolSpec("search_records"), records: 5},
+		withChargerError(errors.New("redis is unreachable")))
 
 	out, err := r.Invoke(ctx, "search_records", json.RawMessage(`{}`))
-	if err != nil {
-		t.Fatalf("an unrecordable charge failed the answer: %v", err)
+
+	if !errors.Is(err, apperrors.ErrBudgetExceeded) {
+		t.Fatalf("an uncountable read → %v, want ErrBudgetExceeded", err)
 	}
-	if len(out) == 0 {
-		t.Error("the answer came back empty")
+	if out != nil {
+		t.Error("the answer was served anyway; a read that cannot be counted must not be handed over")
 	}
 }
 
@@ -188,16 +211,9 @@ func TestACountingFailureDoesNotFailTheAnswer(t *testing.T) {
 // over; a surface where a read-back was free would meter one door and leave
 // the other open beside it.
 func TestAWriteThatReturnsARecordStillCharges(t *testing.T) {
-	charger := &countingCharger{}
-	r := NewRegistry(nil, auth.NewGate(fullSeatAuthority{}), WithReadCharger(charger))
 	spec := readToolSpec("update_record")
 	spec.RequiredScope = principal.ScopeWrite
-	r.Register(&servingTool{spec: spec, records: 1})
-	ctx := principal.WithWorkspaceID(context.Background(), ids.NewV7())
-	ctx = principal.WithActor(ctx, principal.Principal{
-		Type: principal.PrincipalAgent, ID: "agent:t", OnBehalfOf: ids.NewV7(),
-		PassportID: ids.NewV7(), Scopes: principal.NewScopeSet(principal.ScopeWrite),
-	})
+	r, charger, ctx := chargingRegistry(t, &servingTool{spec: spec, records: 1}, withScope(principal.ScopeWrite))
 
 	if _, err := r.Invoke(ctx, "update_record", json.RawMessage(`{}`)); err != nil {
 		t.Fatal(err)
@@ -212,13 +228,7 @@ func TestAWriteThatReturnsARecordStillCharges(t *testing.T) {
 // The Surface-B runner builds one, and it runs as the human or the system that
 // started it — neither of whom this bound governs.
 func TestARegistryWithNoChargerServesNormally(t *testing.T) {
-	r := NewRegistry(nil, auth.NewGate(fullSeatAuthority{}))
-	r.Register(&servingTool{spec: readToolSpec("search_records"), records: 3})
-	ctx := principal.WithWorkspaceID(context.Background(), ids.NewV7())
-	ctx = principal.WithActor(ctx, principal.Principal{
-		Type: principal.PrincipalAgent, ID: "agent:t", OnBehalfOf: ids.NewV7(),
-		PassportID: ids.NewV7(), Scopes: principal.NewScopeSet(principal.ScopeRead),
-	})
+	r, _, ctx := chargingRegistry(t, &servingTool{spec: readToolSpec("search_records"), records: 3}, withNoCharger())
 
 	if _, err := r.Invoke(ctx, "search_records", json.RawMessage(`{}`)); err != nil {
 		t.Fatalf("a registry with no read charger failed to serve: %v", err)

--- a/backend/internal/modules/agents/readcharge_test.go
+++ b/backend/internal/modules/agents/readcharge_test.go
@@ -224,3 +224,37 @@ func TestARegistryWithNoChargerServesNormally(t *testing.T) {
 		t.Fatalf("a registry with no read charger failed to serve: %v", err)
 	}
 }
+
+// namingTool answers the way the intent tools do — with ids and derived prose
+// rather than rows, through noteEvidence.
+type namingTool struct {
+	spec  mcp.ToolSpec
+	names int
+}
+
+func (n *namingTool) Spec() mcp.ToolSpec { return n.spec }
+
+func (n *namingTool) Handle(ctx context.Context, _ json.RawMessage) (json.RawMessage, error) {
+	noteDerivedContent(ctx)
+	for range n.names {
+		noteEvidence(ctx, "deal", ids.NewV7())
+	}
+	return json.RawMessage(`{}`), nil
+}
+
+// A tool that NAMES records without holding their rows still charges for them.
+// The intent family — the slipping sweep, the coverage reads, the catch-up —
+// answers this way, and each surfaces many records per call. If only the tools
+// that hold rows charged, the ones that surface the most records would be the
+// cheapest reads on the surface: A139's failure, one tool family over.
+func TestAToolThatNamesRecordsChargesForThem(t *testing.T) {
+	r, charger, ctx := chargingRegistry(t, &namingTool{spec: readToolSpec("whats_slipping_this_week"), names: 50})
+
+	if _, err := r.Invoke(ctx, "whats_slipping_this_week", json.RawMessage(`{}`)); err != nil {
+		t.Fatal(err)
+	}
+
+	if charger.charged != 50 {
+		t.Errorf("a 50-record answer built from named records charged %d", charger.charged)
+	}
+}

--- a/backend/internal/modules/agents/readcharge_test.go
+++ b/backend/internal/modules/agents/readcharge_test.go
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/datasource"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/mcp"
+)
+
+// countingCharger is the read bound as the registry uses it: it only ever
+// receives charges, which is the whole of this half of the seam.
+type countingCharger struct {
+	charged int
+	calls   int
+	err     error
+}
+
+func (c *countingCharger) Consume(_ context.Context, n int) error {
+	c.calls++
+	c.charged += n
+	return c.err
+}
+
+// servingTool hands back the records it was built with, through the ONE place
+// a datasource.Record becomes tool output — so it exercises the charge point
+// the real tools ride rather than a parallel one written for the test.
+type servingTool struct {
+	spec    mcp.ToolSpec
+	records int
+	fail    bool
+}
+
+func (s *servingTool) Spec() mcp.ToolSpec { return s.spec }
+
+func (s *servingTool) Handle(ctx context.Context, _ json.RawMessage) (json.RawMessage, error) {
+	for range s.records {
+		newWireRecord(ctx, datasource.Record{
+			Ref: datasource.EntityRef{Type: "person", ID: ids.NewV7()},
+		})
+	}
+	if s.fail {
+		return nil, errors.New("the handler failed after reading")
+	}
+	return json.RawMessage(`{}`), nil
+}
+
+func readToolSpec(name string) mcp.ToolSpec {
+	return mcp.ToolSpec{
+		Name: name, Title: name, Version: testToolVersion, Description: describedForRegistration,
+		InputSchema:   json.RawMessage(`{"type":"object"}`),
+		RequiredScope: principal.ScopeRead, Tier: mcp.TierAutoExecute,
+	}
+}
+
+func chargingRegistry(t *testing.T, tool mcp.Tool) (*Registry, *countingCharger, context.Context) {
+	t.Helper()
+	charger := &countingCharger{}
+	r := NewRegistry(nil, auth.NewGate(fullSeatAuthority{}), WithReadCharger(charger))
+	r.Register(tool)
+	ctx := principal.WithWorkspaceID(context.Background(), ids.NewV7())
+	ctx = principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalAgent, ID: "agent:t", OnBehalfOf: ids.NewV7(),
+		PassportID: ids.NewV7(),
+		Scopes:     principal.NewScopeSet(principal.ScopeRead),
+	})
+	return r, charger, ctx
+}
+
+// The charge is PER RECORD, taken where records leave the surface. One call
+// answering twenty records costs twenty, which is the whole of what
+// "per-record, not per-call" means — and the reason it is charged here rather
+// than in each tool is that the tool added next is the one that would forget.
+func TestAnAnswerChargesForEveryRecordItServed(t *testing.T) {
+	r, charger, ctx := chargingRegistry(t, &servingTool{spec: readToolSpec("search_records"), records: 20})
+
+	if _, err := r.Invoke(ctx, "search_records", json.RawMessage(`{}`)); err != nil {
+		t.Fatal(err)
+	}
+
+	if charger.charged != 20 {
+		t.Errorf("a 20-record answer charged %d records", charger.charged)
+	}
+}
+
+// The same record served twice in one answer is charged twice. The envelope's
+// evidence list dedupes by value — one record read twice is one thing to cite —
+// and reusing that count for the bound would let a handler that reads a page
+// twice pay for it once.
+func TestARecordServedTwiceIsChargedTwice(t *testing.T) {
+	charger := &countingCharger{}
+	r := NewRegistry(nil, auth.NewGate(fullSeatAuthority{}), WithReadCharger(charger))
+	repeated := ids.NewV7()
+	r.Register(&repeatingTool{spec: readToolSpec("read_record"), id: repeated, times: 3})
+	ctx := principal.WithWorkspaceID(context.Background(), ids.NewV7())
+	ctx = principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalAgent, ID: "agent:t", OnBehalfOf: ids.NewV7(),
+		PassportID: ids.NewV7(), Scopes: principal.NewScopeSet(principal.ScopeRead),
+	})
+
+	if _, err := r.Invoke(ctx, "read_record", json.RawMessage(`{}`)); err != nil {
+		t.Fatal(err)
+	}
+
+	if charger.charged != 3 {
+		t.Errorf("one record served three times charged %d; the bound counts what was handed over, not what is citable", charger.charged)
+	}
+}
+
+type repeatingTool struct {
+	spec  mcp.ToolSpec
+	id    ids.UUID
+	times int
+}
+
+func (rt *repeatingTool) Spec() mcp.ToolSpec { return rt.spec }
+
+func (rt *repeatingTool) Handle(ctx context.Context, _ json.RawMessage) (json.RawMessage, error) {
+	for range rt.times {
+		newWireRecord(ctx, datasource.Record{Ref: datasource.EntityRef{Type: "person", ID: rt.id}})
+	}
+	return json.RawMessage(`{}`), nil
+}
+
+// A failed handler served nothing, so it costs nothing. Charging it would step
+// an agent up for records it never received — and an agent could be locked out
+// by a fault on our side rather than by its own reading.
+func TestAFailedAnswerChargesNothing(t *testing.T) {
+	r, charger, ctx := chargingRegistry(t, &servingTool{spec: readToolSpec("search_records"), records: 20, fail: true})
+
+	if _, err := r.Invoke(ctx, "search_records", json.RawMessage(`{}`)); err == nil {
+		t.Fatal("the failing handler reported success")
+	}
+
+	if charger.calls != 0 {
+		t.Errorf("a failed answer charged the read bound %d times", charger.calls)
+	}
+}
+
+// An answer that carries no records at all does not touch the meter. Worth
+// pinning because the alternative — charging one per CALL as a floor — is the
+// per-call metering A139 rejects, and it would arrive by accident.
+func TestAnAnswerWithNoRecordsChargesNothing(t *testing.T) {
+	r, charger, ctx := chargingRegistry(t, &servingTool{spec: readToolSpec("list_pipelines")})
+
+	if _, err := r.Invoke(ctx, "list_pipelines", json.RawMessage(`{}`)); err != nil {
+		t.Fatal(err)
+	}
+
+	if charger.calls != 0 {
+		t.Errorf("a record-free answer charged the read bound %d times", charger.calls)
+	}
+}
+
+// A charge that cannot be recorded must not fail the call: the records have
+// already left the surface, and answering with an error would hide a completed
+// read while still leaving it uncounted. Nothing is spent through the gap —
+// the gate reads the same counter and fails closed when it is unreachable.
+func TestACountingFailureDoesNotFailTheAnswer(t *testing.T) {
+	charger := &countingCharger{err: errors.New("redis is unreachable")}
+	r := NewRegistry(nil, auth.NewGate(fullSeatAuthority{}), WithReadCharger(charger))
+	r.Register(&servingTool{spec: readToolSpec("search_records"), records: 5})
+	ctx := principal.WithWorkspaceID(context.Background(), ids.NewV7())
+	ctx = principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalAgent, ID: "agent:t", OnBehalfOf: ids.NewV7(),
+		PassportID: ids.NewV7(), Scopes: principal.NewScopeSet(principal.ScopeRead),
+	})
+
+	out, err := r.Invoke(ctx, "search_records", json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("an unrecordable charge failed the answer: %v", err)
+	}
+	if len(out) == 0 {
+		t.Error("the answer came back empty")
+	}
+}
+
+// A write tool that hands a record back still COUNTS toward the window, even
+// though the bound never refuses one. The read bound measures records handed
+// over; a surface where a read-back was free would meter one door and leave
+// the other open beside it.
+func TestAWriteThatReturnsARecordStillCharges(t *testing.T) {
+	charger := &countingCharger{}
+	r := NewRegistry(nil, auth.NewGate(fullSeatAuthority{}), WithReadCharger(charger))
+	spec := readToolSpec("update_record")
+	spec.RequiredScope = principal.ScopeWrite
+	r.Register(&servingTool{spec: spec, records: 1})
+	ctx := principal.WithWorkspaceID(context.Background(), ids.NewV7())
+	ctx = principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalAgent, ID: "agent:t", OnBehalfOf: ids.NewV7(),
+		PassportID: ids.NewV7(), Scopes: principal.NewScopeSet(principal.ScopeWrite),
+	})
+
+	if _, err := r.Invoke(ctx, "update_record", json.RawMessage(`{}`)); err != nil {
+		t.Fatal(err)
+	}
+
+	if charger.charged != 1 {
+		t.Errorf("a write's read-back charged %d records", charger.charged)
+	}
+}
+
+// A registry composed without a charger records nothing and does not crash.
+// The Surface-B runner builds one, and it runs as the human or the system that
+// started it — neither of whom this bound governs.
+func TestARegistryWithNoChargerServesNormally(t *testing.T) {
+	r := NewRegistry(nil, auth.NewGate(fullSeatAuthority{}))
+	r.Register(&servingTool{spec: readToolSpec("search_records"), records: 3})
+	ctx := principal.WithWorkspaceID(context.Background(), ids.NewV7())
+	ctx = principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalAgent, ID: "agent:t", OnBehalfOf: ids.NewV7(),
+		PassportID: ids.NewV7(), Scopes: principal.NewScopeSet(principal.ScopeRead),
+	})
+
+	if _, err := r.Invoke(ctx, "search_records", json.RawMessage(`{}`)); err != nil {
+		t.Fatalf("a registry with no read charger failed to serve: %v", err)
+	}
+}

--- a/backend/internal/modules/agents/readcharge_test.go
+++ b/backend/internal/modules/agents/readcharge_test.go
@@ -268,3 +268,23 @@ func TestAToolThatNamesRecordsChargesForThem(t *testing.T) {
 		t.Errorf("a 50-record answer built from named records charged %d", charger.charged)
 	}
 }
+
+// A WRITE whose charge fails is still served. By the time the charge runs the
+// mutation has committed and any approval it redeemed is consumed — send_email
+// has SENT. Reporting that as a failure invites the caller to retry an
+// irreversible act, and a second email costs more than an uncounted read.
+func TestAWriteIsServedEvenWhenItsChargeCannotBeRecorded(t *testing.T) {
+	spec := readToolSpec("send_email")
+	spec.RequiredScope = principal.ScopeWrite
+	r, _, ctx := chargingRegistry(t, &servingTool{spec: spec, records: 1},
+		withScope(principal.ScopeWrite),
+		withChargerError(errors.New("redis is unreachable")))
+
+	out, err := r.Invoke(ctx, "send_email", json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("a committed write was reported as failed because it could not be counted: %v", err)
+	}
+	if len(out) == 0 {
+		t.Error("the write's result was withheld")
+	}
+}

--- a/backend/internal/modules/agents/registry.go
+++ b/backend/internal/modules/agents/registry.go
@@ -15,7 +15,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log/slog"
 	"sort"
 	"strings"
 	"sync"
@@ -63,26 +62,6 @@ type Registry struct {
 	// the same meter and does the refusing; the split is deliberate — a bound
 	// is enforced where admission is decided and paid where records leave.
 	reads ReadCharger
-}
-
-// ReadCharger records records handed over against the caller's read bound.
-// Registry only ever charges; reading the bound and refusing on it belongs to
-// the one admission point, so this half of the seam cannot be used to decide
-// anything.
-type ReadCharger interface {
-	Consume(ctx context.Context, n int) error
-}
-
-// RegistryOption configures a Registry at construction.
-type RegistryOption func(*Registry)
-
-// WithReadCharger installs the meter tool results are charged against. It is
-// the same pointer compose hands the admission gate as its ReadBound, so the
-// half that refuses and the half that pays can never end up counting against
-// different windows. A registry without one records nothing — the composition
-// no agent principal reaches (see auth.WithReadBound).
-func WithReadCharger(reads ReadCharger) RegistryOption {
-	return func(r *Registry) { r.reads = reads }
 }
 
 // NewRegistry builds the tool surface over its approvals engine and admission
@@ -302,33 +281,19 @@ func (r *Registry) handle(ctx context.Context, t mcp.Tool, spec mcp.ToolSpec, ar
 	if err != nil {
 		return nil, err
 	}
-	r.chargeReads(ctx, spec, facts.servedCount())
-	return sealEnvelope(spec, trace, facts, out)
-}
-
-// chargeReads records what one answer handed over against MCP-SESS-READS, at
-// the one place every tool's result passes through. Charging per TOOL instead
-// would be a list to maintain, and the read tool added next is the one that
-// forgets — which is exactly how a densely-joined answer becomes the cheapest
-// bulk read on the surface (A139).
-//
-// It charges only after a SUCCESSFUL answer: the bound counts records the agent
-// was actually given, and a handler that failed gave it none.
-//
-// A charge that cannot be recorded is logged rather than returned. The records
-// have already left the surface, so failing the call here would hide a
-// completed read behind an error AND still leave it uncounted. Nothing is
-// spent through the gap either: the gate reads the same counter and fails
-// closed when it is unreachable, so the next call is refused rather than
-// waved through.
-func (r *Registry) chargeReads(ctx context.Context, spec mcp.ToolSpec, served int) {
-	if r.reads == nil || served <= 0 {
-		return
+	sealed, err := sealEnvelope(spec, trace, facts, out)
+	if err != nil {
+		return nil, err
 	}
-	if err := r.reads.Consume(ctx, served); err != nil {
-		slog.ErrorContext(ctx, "recording served records against the read bound failed",
-			"tool", spec.Name, "records", served, "err", err)
+	// Charged AFTER sealing and BEFORE returning: at this point the answer
+	// exists but has not reached the caller, so a charge that cannot be
+	// recorded can still refuse it. An answer sealed and then charged in the
+	// other order would spend the window on a result a marshalling failure was
+	// about to discard.
+	if err := r.chargeReads(ctx, spec, facts.servedCount()); err != nil {
+		return nil, err
 	}
+	return sealed, nil
 }
 
 // tierResolverFor builds the resolver Admit consults for the call's tier. A

--- a/backend/internal/modules/agents/registry.go
+++ b/backend/internal/modules/agents/registry.go
@@ -15,6 +15,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"sort"
 	"strings"
 	"sync"
@@ -58,10 +59,37 @@ type Registry struct {
 	// granting human's authority live per call. A nil gate fails closed
 	// for agent principals (Gate.Admit owns that rule).
 	gate *auth.Gate
+	// reads is the MCP-SESS-READS meter this surface CHARGES. The gate holds
+	// the same meter and does the refusing; the split is deliberate — a bound
+	// is enforced where admission is decided and paid where records leave.
+	reads ReadCharger
 }
 
-func NewRegistry(approvals Approvals, gate *auth.Gate) *Registry {
-	return &Registry{
+// ReadCharger records records handed over against the caller's read bound.
+// Registry only ever charges; reading the bound and refusing on it belongs to
+// the one admission point, so this half of the seam cannot be used to decide
+// anything.
+type ReadCharger interface {
+	Consume(ctx context.Context, n int) error
+}
+
+// RegistryOption configures a Registry at construction.
+type RegistryOption func(*Registry)
+
+// WithReadCharger installs the meter tool results are charged against. It is
+// the same pointer compose hands the admission gate as its ReadBound, so the
+// half that refuses and the half that pays can never end up counting against
+// different windows. A registry without one records nothing — the composition
+// no agent principal reaches (see auth.WithReadBound).
+func WithReadCharger(reads ReadCharger) RegistryOption {
+	return func(r *Registry) { r.reads = reads }
+}
+
+// NewRegistry builds the tool surface over its approvals engine and admission
+// gate. Options add the dependencies only some roles have — today, the meter
+// served records are charged against.
+func NewRegistry(approvals Approvals, gate *auth.Gate, opts ...RegistryOption) *Registry {
+	r := &Registry{
 		tools:        map[string]mcp.Tool{},
 		specs:        map[string]mcp.ToolSpec{},
 		idArgs:       map[string]idArgSpec{},
@@ -70,6 +98,10 @@ func NewRegistry(approvals Approvals, gate *auth.Gate) *Registry {
 		approvals:    approvals,
 		gate:         gate,
 	}
+	for _, opt := range opts {
+		opt(r)
+	}
+	return r
 }
 
 var _ mcp.Registry = (*Registry)(nil)
@@ -237,7 +269,7 @@ func (r *Registry) Invoke(ctx context.Context, name string, in json.RawMessage) 
 			}
 			ctx = marked
 		}
-		return handle(ctx, t, spec, args)
+		return r.handle(ctx, t, spec, args)
 	case !errors.Is(err, apperrors.ErrRequiresApproval) || r.approvals == nil:
 		return nil, err
 	case !approvalID.IsZero():
@@ -245,7 +277,7 @@ func (r *Registry) Invoke(ctx context.Context, name string, in json.RawMessage) 
 		if rErr != nil {
 			return nil, rErr
 		}
-		return handle(marked, t, spec, args)
+		return r.handle(marked, t, spec, args)
 	default:
 		return nil, r.stageRefusedCall(ctx, t, spec.Name, args, diffHash, err)
 	}
@@ -262,7 +294,7 @@ func (r *Registry) Invoke(ctx context.Context, name string, in json.RawMessage) 
 // The failure path deliberately seals nothing: a refusal is an error, and an
 // error carries the sentinel and the message the caller acts on, not a document
 // with an empty payload inside it.
-func handle(ctx context.Context, t mcp.Tool, spec mcp.ToolSpec, args json.RawMessage) (json.RawMessage, error) {
+func (r *Registry) handle(ctx context.Context, t mcp.Tool, spec mcp.ToolSpec, args json.RawMessage) (json.RawMessage, error) {
 	ctx, trace := withTrace(ctx)
 	ctx, facts := withEnvelopeFacts(ctx)
 	noteRowScope(ctx)
@@ -270,7 +302,33 @@ func handle(ctx context.Context, t mcp.Tool, spec mcp.ToolSpec, args json.RawMes
 	if err != nil {
 		return nil, err
 	}
+	r.chargeReads(ctx, spec, facts.servedCount())
 	return sealEnvelope(spec, trace, facts, out)
+}
+
+// chargeReads records what one answer handed over against MCP-SESS-READS, at
+// the one place every tool's result passes through. Charging per TOOL instead
+// would be a list to maintain, and the read tool added next is the one that
+// forgets — which is exactly how a densely-joined answer becomes the cheapest
+// bulk read on the surface (A139).
+//
+// It charges only after a SUCCESSFUL answer: the bound counts records the agent
+// was actually given, and a handler that failed gave it none.
+//
+// A charge that cannot be recorded is logged rather than returned. The records
+// have already left the surface, so failing the call here would hide a
+// completed read behind an error AND still leave it uncounted. Nothing is
+// spent through the gap either: the gate reads the same counter and fails
+// closed when it is unreachable, so the next call is refused rather than
+// waved through.
+func (r *Registry) chargeReads(ctx context.Context, spec mcp.ToolSpec, served int) {
+	if r.reads == nil || served <= 0 {
+		return
+	}
+	if err := r.reads.Consume(ctx, served); err != nil {
+		slog.ErrorContext(ctx, "recording served records against the read bound failed",
+			"tool", spec.Name, "records", served, "err", err)
+	}
 }
 
 // tierResolverFor builds the resolver Admit consults for the call's tier. A

--- a/backend/internal/platform/auth/admit.go
+++ b/backend/internal/platform/auth/admit.go
@@ -173,3 +173,30 @@ func deniedIfGone(what, tool string, err error) error {
 	}
 	return fmt.Errorf("gate: %s: resolving %s: %w", tool, what, err)
 }
+
+// AdmitRead applies the READ QUOTA alone, for a call that has no tool spec to
+// admit against — the ADR-0055 REST surface's non-mutating half.
+//
+// It exists because that path has no tier to resolve and no scope to check
+// against a spec (a GET's authority is the granting human's RBAC at the store),
+// but it does spend the same bound. Without it a Passport that tripped the
+// counter through the MCP door could keep reading the very same records through
+// /v1 — one credential, two doors, one of them unbounded. ADR-0055's whole
+// claim is that those two doors are governed alike.
+//
+// Non-agents are admitted untouched, exactly as Admit leaves them.
+func (g *Gate) AdmitRead(ctx context.Context) error {
+	if g == nil || g.reads == nil {
+		return nil
+	}
+	p, ok := principal.Actor(ctx)
+	if !ok || p.Type != principal.PrincipalAgent {
+		return nil
+	}
+	if reading := g.reads.Read(ctx); reading.Exceeded {
+		return fmt.Errorf(
+			"gate: this agent has been handed %d records against a limit of %d for this window; it may read again when the window rolls, or once an operator raises the limit: %w",
+			reading.Observed, reading.Limit, apperrors.ErrBudgetExceeded)
+	}
+	return nil
+}

--- a/backend/internal/platform/auth/admit.go
+++ b/backend/internal/platform/auth/admit.go
@@ -2,8 +2,8 @@
 // SPDX-FileCopyrightText: 2026 Gradion
 
 // Package auth is the ONE admission point for governed agent actions
-// (interfaces.md §2, ADR-0055): scope ∧ seat ∧ tier, resolved against the
-// calling Principal, BEFORE any handler runs — whether the action arrives
+// (interfaces.md §2, ADR-0055): scope ∧ seat ∧ tier ∧ quota, resolved against
+// the calling Principal, BEFORE any handler runs — whether the action arrives
 // as an MCP tool call or a mutating REST operation. It is its own package
 // so nothing else can mint an admitted capability — Surface A (inbound
 // agents) and Surface B (our own runner) both enter here, and there is no
@@ -15,11 +15,21 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/gradionhq/margince/backend/internal/platform/readmeter"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/authz"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/mcp"
 )
+
+// ReadBound answers whether the calling agent has been handed more records
+// this window than MCP-SESS-READS allows. It is an interface rather than the
+// concrete meter so this package — the one admission point — stays testable
+// without a Redis client, and so a deployment that has not composed a bound is
+// a visible nil rather than a meter that silently answers "plenty".
+type ReadBound interface {
+	Read(ctx context.Context) readmeter.Reading
+}
 
 // Gate admits governed actions. Its authority source is the
 // shared/ports/authz seam: identity implements it, the composition root
@@ -28,10 +38,33 @@ import (
 // instead of surviving on whatever the transport stamped earlier.
 type Gate struct {
 	authority authz.Resolver
+	reads     ReadBound
 }
 
-func NewGate(authority authz.Resolver) *Gate {
-	return &Gate{authority: authority}
+// GateOption configures a Gate at construction. Variadic rather than
+// positional so the six existing composition sites are not rewritten every
+// time the gate grows a dependency, which is how one of them ends up passing
+// nil by copy-paste.
+type GateOption func(*Gate)
+
+// WithReadBound installs the MCP-SESS-READS meter. A gate built WITHOUT one
+// does not enforce the read bound at all, which is a real composition rather
+// than an oversight: the Surface-B runner and the workflow paths build a gate
+// and run as the human or system that started them, whom this bound does not
+// govern. The api server — the one role an agent principal ever reaches —
+// passes it, from the same pointer it gives the registry that charges it.
+func WithReadBound(reads ReadBound) GateOption {
+	return func(g *Gate) { g.reads = reads }
+}
+
+// NewGate builds the admission point over its authority seam. Options add
+// the dependencies only some roles have — today, the read bound.
+func NewGate(authority authz.Resolver, opts ...GateOption) *Gate {
+	g := &Gate{authority: authority}
+	for _, opt := range opts {
+		opt(g)
+	}
+	return g
 }
 
 // Admit decides whether the context's principal may run the action with
@@ -41,8 +74,8 @@ func NewGate(authority authz.Resolver) *Gate {
 //
 // The decision order is deliberate: scope first (a caller without the
 // verb never learns the tier, and pays no authority read), then the live
-// seat ceiling, then tier. A 🟡 outcome (declared or dynamically
-// resolved) returns ErrRequiresApproval. On admission the returned
+// seat ceiling, then the read quota, then tier. A 🟡 outcome (declared or
+// dynamically resolved) returns ErrRequiresApproval. On admission the returned
 // context carries the principal refreshed with the re-derived authority,
 // so downstream store RBAC runs on current grants.
 func (g *Gate) Admit(ctx context.Context, spec mcp.ToolSpec, resolve func() (mcp.TierResolverInput, error)) (context.Context, error) {
@@ -93,6 +126,23 @@ func (g *Gate) Admit(ctx context.Context, spec mcp.ToolSpec, resolve func() (mcp
 	if spec.RequiredScope != principal.ScopeRead && !seat.CanMutate() {
 		return ctx, fmt.Errorf("gate: %s needs a full seat; %s acts for a read seat: %w",
 			spec.Name, p.ID, apperrors.ErrSeatTierInsufficient)
+	}
+
+	// Quota, the third term of "scope ∧ tier ∧ quota" (interfaces.md §2). It
+	// runs AFTER scope and seat so a caller who may not run the verb at all
+	// never learns that a quota exists, let alone how much of it is spent.
+	//
+	// It binds READ-scoped tools only. The bound is MCP-SESS-READS and it
+	// counts records handed over; refusing a write because reading was heavy
+	// would enforce a limit nobody wrote. A write that returns a record still
+	// COUNTS toward the window (the charge point is where records leave the
+	// surface, not here) — it is only the refusal that is read-scoped.
+	if spec.RequiredScope == principal.ScopeRead && g.reads != nil {
+		if reading := g.reads.Read(ctx); reading.Exceeded {
+			return ctx, fmt.Errorf(
+				"gate: %s: this agent has been handed %d records against a limit of %d for this window; it may read again when the window rolls, or once an operator raises the limit: %w",
+				spec.Name, reading.Observed, reading.Limit, apperrors.ErrBudgetExceeded)
+		}
 	}
 
 	tier := spec.Tier

--- a/backend/internal/platform/auth/admit.go
+++ b/backend/internal/platform/auth/admit.go
@@ -132,12 +132,15 @@ func (g *Gate) Admit(ctx context.Context, spec mcp.ToolSpec, resolve func() (mcp
 	// runs AFTER scope and seat so a caller who may not run the verb at all
 	// never learns that a quota exists, let alone how much of it is spent.
 	//
-	// It binds READ-scoped tools only. The bound is MCP-SESS-READS and it
+	// It binds READ-ONLY tools only, through the spec's own predicate rather
+	// than a second scope comparison — one definition of "this tool only
+	// reads", so the refusal here and the charge in the agents registry cannot
+	// drift apart as scope semantics evolve. The bound is MCP-SESS-READS and it
 	// counts records handed over; refusing a write because reading was heavy
 	// would enforce a limit nobody wrote. A write that returns a record still
 	// COUNTS toward the window (the charge point is where records leave the
 	// surface, not here) — it is only the refusal that is read-scoped.
-	if spec.RequiredScope == principal.ScopeRead && g.reads != nil {
+	if spec.ReadOnly() && g.reads != nil {
 		if reading := g.reads.Read(ctx); reading.Exceeded {
 			return ctx, fmt.Errorf(
 				"gate: %s: this agent has been handed %d records against a limit of %d for this window; it may read again when the window rolls, or once an operator raises the limit: %w",

--- a/backend/internal/platform/auth/admitquota_test.go
+++ b/backend/internal/platform/auth/admitquota_test.go
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package auth
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/platform/readmeter"
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/mcp"
+)
+
+// spentBound is the read bound as the gate sees it: a fixed answer, so a test
+// says what the meter concluded without standing up Redis to conclude it.
+type spentBound struct {
+	reading readmeter.Reading
+	asked   int
+}
+
+func (s *spentBound) Read(context.Context) readmeter.Reading {
+	s.asked++
+	return s.reading
+}
+
+func boundGate(reading readmeter.Reading) (*Gate, *spentBound) {
+	bound := &spentBound{reading: reading}
+	return NewGate(&stubAuthority{seat: principal.SeatFull}, WithReadBound(bound)), bound
+}
+
+var (
+	readSpec  = mcp.ToolSpec{Name: "search_records", RequiredScope: principal.ScopeRead, Tier: mcp.TierAutoExecute}
+	writeSpec = mcp.ToolSpec{Name: "update_record", RequiredScope: principal.ScopeWrite, Tier: mcp.TierAutoExecute}
+)
+
+// AC-MCP-1: an agent past MCP-SESS-READS is stepped up on its NEXT read call.
+// The sentinel is the spec's own for MCP-SESS-* (interfaces.md §0,
+// ErrBudgetExceeded), so a client branches on the registry rather than on
+// prose.
+func TestAReadIsRefusedOnceTheAgentHasPassedItsReadBound(t *testing.T) {
+	gate, _ := boundGate(readmeter.Reading{Observed: 2001, Limit: 2000, Exceeded: true})
+
+	_, err := gate.Admit(agentCtx(principal.ScopeRead), readSpec, noResolve)
+
+	if !errors.Is(err, apperrors.ErrBudgetExceeded) {
+		t.Fatalf("a read past the bound → %v, want ErrBudgetExceeded", err)
+	}
+	// The numbers are what a human is asked to confirm against, so they have to
+	// reach the caller rather than only the log.
+	if msg := err.Error(); !strings.Contains(msg, "2001") || !strings.Contains(msg, "2000") {
+		t.Errorf("the refusal does not say what was read against what limit: %q", msg)
+	}
+}
+
+// The bound counts RECORDS READ. Refusing a write because reading was heavy
+// would enforce a limit nobody wrote — and would take a confirm-first action's
+// staging away for a reason unrelated to it.
+func TestAWriteIsNotRefusedByTheReadBound(t *testing.T) {
+	gate, bound := boundGate(readmeter.Reading{Observed: 9999, Limit: 2000, Exceeded: true})
+
+	if _, err := gate.Admit(agentCtx(principal.ScopeWrite), writeSpec, noResolve); err != nil {
+		t.Fatalf("a write was refused by the READ bound: %v", err)
+	}
+	if bound.asked != 0 {
+		t.Error("the read bound was consulted for a write-scoped tool")
+	}
+}
+
+// A caller who may not run the verb at all must not learn that a quota exists,
+// let alone how much of it is spent. Scope is checked first, and the bound is
+// never asked.
+func TestAnOutOfScopeCallerNeverLearnsTheQuotaExists(t *testing.T) {
+	gate, bound := boundGate(readmeter.Reading{Observed: 9999, Limit: 2000, Exceeded: true})
+
+	_, err := gate.Admit(agentCtx(principal.ScopeWrite), readSpec, noResolve)
+
+	if !errors.Is(err, apperrors.ErrScopeExceeded) {
+		t.Fatalf("out of scope → %v, want ErrScopeExceeded", err)
+	}
+	if bound.asked != 0 {
+		t.Error("the read bound was consulted for a caller who may not run the verb")
+	}
+}
+
+// A read seat is refused for a write BEFORE the read bound is consulted, so
+// the two refusals cannot be confused: one is a licensing ceiling no approval
+// lifts, the other a volume threshold a human can release.
+func TestTheSeatCeilingIsAnsweredBeforeTheReadBound(t *testing.T) {
+	bound := &spentBound{reading: readmeter.Reading{Exceeded: true}}
+	gate := NewGate(&stubAuthority{seat: principal.SeatRead}, WithReadBound(bound))
+
+	_, err := gate.Admit(agentCtx(principal.ScopeWrite), writeSpec, noResolve)
+
+	if !errors.Is(err, apperrors.ErrSeatTierInsufficient) {
+		t.Fatalf("a read seat running a write → %v, want ErrSeatTierInsufficient", err)
+	}
+}
+
+// Under the bound, a read is admitted exactly as before. Stated so the control
+// is proven to be a threshold rather than a refusal that happens to fire.
+func TestAReadUnderTheBoundIsAdmitted(t *testing.T) {
+	gate, bound := boundGate(readmeter.Reading{Observed: 1999, Limit: 2000})
+
+	if _, err := gate.Admit(agentCtx(principal.ScopeRead), readSpec, noResolve); err != nil {
+		t.Fatalf("a read under the bound → %v, want admitted", err)
+	}
+	if bound.asked != 1 {
+		t.Errorf("the bound was consulted %d times for one read", bound.asked)
+	}
+}
+
+// A human never enters this path at all — the gate returns before any agent
+// check — so a busy agent cannot lock its own operator out of the product.
+func TestAHumanIsNeverRefusedByTheReadBound(t *testing.T) {
+	gate, bound := boundGate(readmeter.Reading{Observed: 9999, Limit: 2000, Exceeded: true})
+	ctx := principal.WithWorkspaceID(context.Background(), testWorkspace)
+	ctx = principal.WithActor(ctx, principal.Principal{Type: principal.PrincipalHuman, ID: "human:rep"})
+
+	if _, err := gate.Admit(ctx, readSpec, noResolve); err != nil {
+		t.Fatalf("a human was refused by the agent read bound: %v", err)
+	}
+	if bound.asked != 0 {
+		t.Error("the read bound was consulted for a human")
+	}
+}
+
+// A gate composed WITHOUT a bound does not enforce one. That is a real
+// composition — the Surface-B runner and the workflow paths build one, and
+// they run as the human or system that started them, whom the bound does not
+// govern anyway. Asserted so the nil is a decision rather than an accident
+// nobody notices until an agent surface is built without a meter.
+func TestAGateWithNoReadBoundDoesNotEnforceOne(t *testing.T) {
+	if _, err := fullSeatGate().Admit(agentCtx(principal.ScopeRead), readSpec, noResolve); err != nil {
+		t.Fatalf("a gate with no read bound refused a read: %v", err)
+	}
+}

--- a/backend/internal/platform/auth/admitquota_test.go
+++ b/backend/internal/platform/auth/admitquota_test.go
@@ -138,3 +138,52 @@ func TestAGateWithNoReadBoundDoesNotEnforceOne(t *testing.T) {
 		t.Fatalf("a gate with no read bound refused a read: %v", err)
 	}
 }
+
+// The REST door refuses on the SAME bound the MCP door charges. Without this a
+// Passport could spend its window through /mcp and then keep reading the very
+// same records through /v1 — one credential, two doors, one of them unbounded,
+// which is exactly what ADR-0055 says must not be possible.
+func TestTheRestReadPathRefusesOnTheSameBound(t *testing.T) {
+	gate, bound := boundGate(readmeter.Reading{Observed: 2001, Limit: 2000, Exceeded: true})
+
+	err := gate.AdmitRead(agentCtx(principal.ScopeRead))
+
+	if !errors.Is(err, apperrors.ErrBudgetExceeded) {
+		t.Fatalf("a REST agent read past the bound → %v, want ErrBudgetExceeded", err)
+	}
+	if bound.asked != 1 {
+		t.Errorf("the bound was consulted %d times for one REST read", bound.asked)
+	}
+}
+
+// Under the bound the REST read passes through untouched.
+func TestARestReadUnderTheBoundIsAdmitted(t *testing.T) {
+	gate, _ := boundGate(readmeter.Reading{Observed: 10, Limit: 2000})
+
+	if err := gate.AdmitRead(agentCtx(principal.ScopeRead)); err != nil {
+		t.Fatalf("a REST read under the bound → %v, want admitted", err)
+	}
+}
+
+// A human's REST read is never touched by the agent bound — their authority is
+// RBAC at the store, and a busy agent must not lock its operator out of the UI.
+func TestAHumansRestReadIsNeverRefusedByTheBound(t *testing.T) {
+	gate, bound := boundGate(readmeter.Reading{Observed: 9999, Limit: 2000, Exceeded: true})
+	ctx := principal.WithWorkspaceID(context.Background(), testWorkspace)
+	ctx = principal.WithActor(ctx, principal.Principal{Type: principal.PrincipalHuman, ID: "human:rep"})
+
+	if err := gate.AdmitRead(ctx); err != nil {
+		t.Fatalf("a human's REST read was refused by the agent bound: %v", err)
+	}
+	if bound.asked != 0 {
+		t.Error("the bound was consulted for a human's REST read")
+	}
+}
+
+// A gate with no bound composed admits, rather than failing closed on a
+// dependency the deployment never declared.
+func TestARestReadOnAGateWithNoBoundIsAdmitted(t *testing.T) {
+	if err := fullSeatGate().AdmitRead(agentCtx(principal.ScopeRead)); err != nil {
+		t.Fatalf("a REST read on a gate with no bound → %v", err)
+	}
+}

--- a/backend/internal/platform/readmeter/meter.go
+++ b/backend/internal/platform/readmeter/meter.go
@@ -205,8 +205,11 @@ func (m *Meter) usable(ctx context.Context) (ws ids.UUID, agent string, ok bool)
 }
 
 // bucket is the fixed window a moment falls in.
+// It divides in NANOSECONDS rather than whole seconds: a sub-second window
+// truncates to zero seconds and the division panics, and a window is a
+// caller-supplied duration with nothing stopping it being 500ms.
 func (m *Meter) bucket() int64 {
-	return m.now().UTC().Unix() / int64(m.window.Seconds())
+	return m.now().UTC().UnixNano() / int64(m.window)
 }
 
 // Consume records n records served to ctx's Passport.
@@ -281,7 +284,9 @@ func (m *Meter) counter(ctx context.Context, key string) (int, error) {
 
 // ttlSeconds covers the window plus an hour of clock-skew slack, so a counter
 // never outlives its window (over-counting a later one) nor expires inside it
-// (under-counting this one).
+// (under-counting this one). Redis expiry has one-second granularity, so a
+// sub-second window still gets a whole second at minimum — the slack already
+// guarantees that, and it is named here so the floor is not a surprise.
 func (m *Meter) ttlSeconds() int {
-	return int((m.window + time.Hour).Seconds())
+	return max(1, int((m.window + time.Hour).Seconds()))
 }

--- a/backend/internal/platform/readmeter/meter.go
+++ b/backend/internal/platform/readmeter/meter.go
@@ -168,25 +168,36 @@ local total = redis.call('INCRBY', KEYS[1], n)
 if total == n then redis.call('EXPIRE', KEYS[1], tonumber(ARGV[2])) end
 return total`)
 
-// meteredAgent names the counter one call belongs to, and reports whether this
-// caller is inside the control at all.
+// governed reports whether this caller is inside the control at all.
 //
-// ONLY an agent is metered. A human's authority is RBAC at the store and they
-// answered for the action themselves; this bound exists to make an AGENT's bulk
-// reading visible to the human who granted it. That is the same line
-// auth.Gate.Admit already draws, drawn again here so the meter is safe to call
-// from anywhere rather than only from behind the gate.
+// ONLY an agent is. A human's authority is RBAC at the store and they answered
+// for the action themselves; this bound exists to make an AGENT's bulk reading
+// visible to the human who granted it. That is the same line auth.Gate.Admit
+// draws, drawn again here so the meter is safe to call from anywhere rather
+// than only from behind the gate.
+func governed(ctx context.Context) bool {
+	actor, present := principal.Actor(ctx)
+	return present && actor.Type == principal.PrincipalAgent
+}
+
+// counterFor names the counter a governed call belongs to, and reports whether
+// one could be named at all.
 //
-// The key is the Passport, and falls back to the principal's own id when there
-// is none. Every agent principal this product mints carries a Passport
+// The two "no" answers this package gives are DIFFERENT and must not be folded
+// together. `governed` says the caller is outside the control — admit. This
+// says the caller is inside it and the meter cannot identify them — refuse. An
+// agent with no workspace bound to its context is the second: it is a caller
+// this bound governs whose counter cannot be built, and admitting it would be a
+// free pass handed out by a wiring fault.
+//
+// The key is the Passport, falling back to the principal's own id. Every agent
+// principal this product mints carries a Passport
 // (identity.AgentIdentity.Principal), so the fallback is not a live path — but
 // keying on something ALWAYS present is what stops a future agent principal
-// without one from being silently exempt. An agent that cannot be identified at
-// all is not a caller this meter can bound, and says so by returning false,
-// which the read side turns into a refusal rather than a free pass.
-func (m *Meter) meteredAgent(ctx context.Context) (ws ids.UUID, agent string, metered bool) {
+// without one from being silently exempt.
+func counterFor(ctx context.Context) (ws ids.UUID, agent string, named bool) {
 	actor, present := principal.Actor(ctx)
-	if !present || actor.Type != principal.PrincipalAgent {
+	if !present {
 		return ws, "", false
 	}
 	if actor.PassportID != (ids.UUID{}) {
@@ -198,10 +209,13 @@ func (m *Meter) meteredAgent(ctx context.Context) (ws ids.UUID, agent string, me
 	return ws, agent, bound && agent != ""
 }
 
-// usable reports that the meter can actually reach its counter for this call.
+// usable reports that the meter can actually reach this call's counter.
 func (m *Meter) usable(ctx context.Context) (ws ids.UUID, agent string, ok bool) {
-	ws, agent, metered := m.meteredAgent(ctx)
-	return ws, agent, metered && m.rdb != nil
+	if !governed(ctx) || m.rdb == nil {
+		return ws, "", false
+	}
+	ws, agent, named := counterFor(ctx)
+	return ws, agent, named
 }
 
 // bucket is the fixed window a moment falls in.
@@ -254,14 +268,14 @@ func (m *Meter) add(ctx context.Context, key string, n int) error {
 //     the fail-closed branch: the meter does not know whether the threshold has
 //     been passed, and a control that cannot answer must not answer "no".
 func (m *Meter) Read(ctx context.Context) Reading {
-	if m.unbounded {
+	if m.unbounded || !governed(ctx) {
 		return Reading{Limit: m.limit}
 	}
-	ws, agent, metered := m.meteredAgent(ctx)
-	if !metered {
-		return Reading{Limit: m.limit}
-	}
-	if m.rdb == nil {
+	ws, agent, named := counterFor(ctx)
+	if !named || m.rdb == nil {
+		// Governed, and unidentifiable or uncountable. Both are the
+		// fail-closed branch: this caller is inside the control and the meter
+		// cannot answer for them.
 		return Reading{Limit: m.limit, Exceeded: true}
 	}
 	observed, err := m.counter(ctx, m.countKey(ws, agent, m.bucket()))

--- a/backend/internal/platform/readmeter/meter.go
+++ b/backend/internal/platform/readmeter/meter.go
@@ -1,0 +1,288 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// Package readmeter is the MCP-SESS-READS consumption meter
+// (api-rate-limits-and-abuse §2.2): how many RECORDS an agent has been handed
+// inside one window, and whether that has passed the threshold at which a
+// human must confirm before it is handed any more.
+//
+// PER RECORD, NOT PER CALL. That is the whole control. The spec's own wording
+// is that the bound exists "so a single search_records returning 5,000 rows
+// trips it — closing the obvious evasion", and A139 repeats it for the brief:
+// metered per call, a densely-joined read is the cheapest bulk read on the
+// surface and the step-up threshold never sees it.
+//
+// PER PASSPORT, NOT PER SESSION, which departs from the name. ADR-0055 made a
+// Passport a REST credential governed exactly like MCP, and a REST call has no
+// session to count against — so a per-session counter would meter one half of
+// one surface. ADR-0092/A141 ratifies per-Passport read/write/egress/cost
+// counters as the forward shape and the session registry is removed with it,
+// so keying on the Passport is the key that survives that change rather than
+// the one it would have to undo. The window is a fixed one with expiry, in the
+// same mechanism (and the same spelling) as platform/overlaybudget.
+//
+// FAIL-CLOSED. With no Redis, or a Redis that errors, the meter cannot know
+// whether the threshold has been passed — and a control that cannot answer
+// must not answer "no". It reports the threshold as passed, and the read is
+// refused. The consequence is deliberate and worth stating plainly: while the
+// counter is unreachable, agent reads stop. Human sessions never enter this
+// path; their authority is RBAC at the store.
+//
+// It lives in the platform tier and owns no domain: both doors onto the
+// governed surface charge it — the MCP tool dispatcher and the ADR-0055 REST
+// agent gate — and neither may import the other.
+package readmeter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// DefaultLimit is MCP-SESS-READS: the records a Passport may be handed inside
+// one window before the next read demands human confirmation
+// (api-rate-limits-and-abuse §2.2). It is a default and mode-tunable, and §4.2
+// makes lowering it below a floor an ADR matter — it is a security control,
+// not a performance knob.
+const DefaultLimit = 2000
+
+// DefaultWindow is the span one counter covers. The spec names the bound after
+// a session; ADR-0055 and ADR-0092 leave the Passport as the only thing both
+// doors share, so the Passport's rolling day is what "session" resolves to
+// here. It is stated in the tool copy an agent reads, so the surface and the
+// operator use the same words.
+const DefaultWindow = 24 * time.Hour
+
+// keyPrefix is the namespace every read counter shares. Named because a writer
+// that spelled it differently would leave counters nothing else can find.
+const keyPrefix = "msr:"
+
+// Meter counts records served to one Passport inside a window. The zero value
+// is not usable; construct with New or NewWithClock.
+type Meter struct {
+	rdb    *redis.Client
+	limit  int
+	window time.Duration
+	now    func() time.Time
+}
+
+// New constructs a Meter over rdb using the real wall clock. A nil rdb is
+// allowed and makes the meter fail-closed — every read reports the threshold
+// passed, because a counter that cannot be read cannot show headroom.
+func New(rdb *redis.Client, limit int, window time.Duration) *Meter {
+	return NewWithClock(rdb, limit, window, time.Now)
+}
+
+// NewWithClock takes the clock as a dependency so the fixed window a charge
+// lands in is asserted by advancing time rather than by sleeping against the
+// real one (T11): the clock's reading picks both the Redis key and the expiry,
+// deterministically.
+func NewWithClock(rdb *redis.Client, limit int, window time.Duration, now func() time.Time) *Meter {
+	if limit <= 0 {
+		limit = DefaultLimit
+	}
+	if window <= 0 {
+		window = DefaultWindow
+	}
+	return &Meter{rdb: rdb, limit: limit, window: window, now: now}
+}
+
+// RebindFrom copies src's client and configuration onto this meter — the
+// boot-time injection point compose uses WITHOUT itself naming a Redis client
+// (that dependency stays in the cmd/platform tiers). newServer constructs a
+// fail-closed meter and shares that ONE pointer with every charge point; a
+// WithReadMeter option rebinds it from the live meter once the Redis client
+// and the deployment config are known, so every holder sees the live meter
+// without re-plumbing. Called at server assembly, before any request is
+// served, so it never races a charge — the same discipline
+// overlaybudget.Meter.RebindFrom follows.
+func (m *Meter) RebindFrom(src *Meter) {
+	m.rdb, m.limit, m.window, m.now = src.rdb, src.limit, src.window, src.now
+}
+
+// Limit is the configured threshold, for the refusal envelope to report.
+func (m *Meter) Limit() int { return m.limit }
+
+// Reading is what the meter knows about one Passport's window.
+type Reading struct {
+	// Observed is the records served in this window so far.
+	Observed int
+	// Limit is the threshold Observed is judged against, including any
+	// headroom a human has already granted this window.
+	Limit int
+	// Exceeded reports that the next read needs human confirmation. It is a
+	// field rather than a comparison the caller makes, so the fail-closed
+	// answer cannot be reconstructed wrongly by a second caller.
+	Exceeded bool
+}
+
+// countKey is one agent's counter for one window bucket. The bucket comes
+// from the injected clock, never Redis TIME, so rollover is deterministic
+// under test.
+func (m *Meter) countKey(ws ids.UUID, agent string, bucket int64) string {
+	return fmt.Sprintf(keyPrefix+"%s:%s:reads:%d", ws.String(), agent, bucket)
+}
+
+// grantKey holds the extra headroom a human granted for this window by
+// approving a step-up. It is a SEPARATE key from the count deliberately:
+// resetting the count would erase the evidence of how much this agent has
+// read, and the audit question "how many records did it see" must stay
+// answerable after the human said continue.
+func (m *Meter) grantKey(ws ids.UUID, agent string, bucket int64) string {
+	return fmt.Sprintf(keyPrefix+"%s:%s:grant:%d", ws.String(), agent, bucket)
+}
+
+// addScript adds n to a window counter and returns the new total, setting the
+// fixed-window expiry on FIRST write only — so the window is fixed rather than
+// sliding, and a busy Passport's counter does not renew itself into never
+// resetting. Both counters this package keeps (the count and the granted
+// headroom) have exactly this shape. ARGV=[n, ttlSeconds].
+var addScript = redis.NewScript(`
+local n = tonumber(ARGV[1])
+local total = redis.call('INCRBY', KEYS[1], n)
+if total == n then redis.call('EXPIRE', KEYS[1], tonumber(ARGV[2])) end
+return total`)
+
+// meteredAgent names the counter one call belongs to, and reports whether this
+// caller is inside the control at all.
+//
+// ONLY an agent is metered. A human's authority is RBAC at the store and they
+// answered for the action themselves; this bound exists to make an AGENT's bulk
+// reading visible to the human who granted it. That is the same line
+// auth.Gate.Admit already draws, drawn again here so the meter is safe to call
+// from anywhere rather than only from behind the gate.
+//
+// The key is the Passport, and falls back to the principal's own id when there
+// is none. Every agent principal this product mints carries a Passport
+// (identity.AgentIdentity.Principal), so the fallback is not a live path — but
+// keying on something ALWAYS present is what stops a future agent principal
+// without one from being silently exempt. An agent that cannot be identified at
+// all is not a caller this meter can bound, and says so by returning false,
+// which the read side turns into a refusal rather than a free pass.
+func (m *Meter) meteredAgent(ctx context.Context) (ws ids.UUID, agent string, metered bool) {
+	actor, present := principal.Actor(ctx)
+	if !present || actor.Type != principal.PrincipalAgent {
+		return ws, "", false
+	}
+	if actor.PassportID != (ids.UUID{}) {
+		agent = actor.PassportID.String()
+	} else {
+		agent = actor.ID
+	}
+	ws, bound := principal.WorkspaceID(ctx)
+	return ws, agent, bound && agent != ""
+}
+
+// usable reports that the meter can actually reach its counter for this call.
+func (m *Meter) usable(ctx context.Context) (ws ids.UUID, agent string, ok bool) {
+	ws, agent, metered := m.meteredAgent(ctx)
+	return ws, agent, metered && m.rdb != nil
+}
+
+// bucket is the fixed window a moment falls in.
+func (m *Meter) bucket() int64 {
+	return m.now().UTC().Unix() / int64(m.window.Seconds())
+}
+
+// Consume records n records served to ctx's Passport.
+//
+// It records UNCONDITIONALLY and never refuses: the spec's mechanism is that
+// crossing the threshold refuses the NEXT read call, not that it truncates the
+// answer in flight (§2.4). Records already selected have already been read;
+// pretending otherwise by dropping them would under-count the exposure the
+// meter exists to measure.
+//
+// A non-positive n is a no-op — an empty page served nothing. A call with no
+// Passport (a human, or the system) is not metered and records nothing.
+func (m *Meter) Consume(ctx context.Context, n int) error {
+	if n <= 0 {
+		return nil
+	}
+	ws, agent, ok := m.usable(ctx)
+	if !ok {
+		return nil
+	}
+	if err := m.add(ctx, m.countKey(ws, agent, m.bucket()), n); err != nil {
+		return fmt.Errorf("readmeter: recording %d served records: %w", n, err)
+	}
+	return nil
+}
+
+// add applies one counter's increment and its first-write expiry.
+func (m *Meter) add(ctx context.Context, key string, n int) error {
+	return addScript.Run(ctx, m.rdb, []string{key}, n, m.ttlSeconds()).Err()
+}
+
+// Grant adds n records of headroom for the rest of the current window — what
+// an approved step-up buys. The count itself is untouched, so the answer to
+// "how many records has this agent been handed" survives the grant.
+func (m *Meter) Grant(ctx context.Context, n int) error {
+	if n <= 0 {
+		return fmt.Errorf("readmeter: a step-up grant must be positive, got %d", n)
+	}
+	ws, agent, ok := m.usable(ctx)
+	if !ok {
+		return fmt.Errorf("readmeter: no metered agent on this call to grant headroom to")
+	}
+	if err := m.add(ctx, m.grantKey(ws, agent, m.bucket()), n); err != nil {
+		return fmt.Errorf("readmeter: granting %d records of headroom: %w", n, err)
+	}
+	return nil
+}
+
+// Read answers what the meter knows about ctx's agent before a read tool
+// serves anything.
+//
+// The two "no" answers are different and must not be folded together:
+//
+//   - NOT METERED — a human, the system, a call with no actor. These are
+//     outside the control by design, and reading as not-exceeded is correct.
+//     Refusing them would deny the product to its own users on a bound written
+//     for agents.
+//   - METERED BUT UNANSWERABLE — an agent whose counter cannot be read. This is
+//     the fail-closed branch: the meter does not know whether the threshold has
+//     been passed, and a control that cannot answer must not answer "no".
+func (m *Meter) Read(ctx context.Context) Reading {
+	ws, agent, metered := m.meteredAgent(ctx)
+	if !metered {
+		return Reading{Limit: m.limit}
+	}
+	if m.rdb == nil {
+		return Reading{Limit: m.limit, Exceeded: true}
+	}
+	bucket := m.bucket()
+	observed, err := m.counter(ctx, m.countKey(ws, agent, bucket))
+	if err != nil {
+		return Reading{Limit: m.limit, Exceeded: true}
+	}
+	granted, err := m.counter(ctx, m.grantKey(ws, agent, bucket))
+	if err != nil {
+		return Reading{Observed: observed, Limit: m.limit, Exceeded: true}
+	}
+	limit := m.limit + granted
+	return Reading{Observed: observed, Limit: limit, Exceeded: observed >= limit}
+}
+
+// counter reads one window key, treating a missing key (redis.Nil) as zero —
+// nothing charged this window yet — and surfacing every other error so the
+// caller fails closed.
+func (m *Meter) counter(ctx context.Context, key string) (int, error) {
+	v, err := m.rdb.Get(ctx, key).Int()
+	if err != nil && !errors.Is(err, redis.Nil) {
+		return 0, err
+	}
+	return v, nil
+}
+
+// ttlSeconds covers the window plus an hour of clock-skew slack, so a counter
+// never outlives its window (over-counting a later one) nor expires inside it
+// (under-counting this one).
+func (m *Meter) ttlSeconds() int {
+	return int((m.window + time.Hour).Seconds())
+}

--- a/backend/internal/platform/readmeter/meter.go
+++ b/backend/internal/platform/readmeter/meter.go
@@ -79,6 +79,10 @@ type Meter struct {
 	limit  int
 	window time.Duration
 	now    func() time.Time
+	// unbounded marks the meter Unmetered built: it admits every read and
+	// records none, because this composition declared no bound rather than
+	// failed to reach one.
+	unbounded bool
 }
 
 // New constructs a Meter over rdb using the real wall clock. A nil rdb is
@@ -86,6 +90,23 @@ type Meter struct {
 // passed, because a counter that cannot be read cannot show headroom.
 func New(rdb *redis.Client, limit int, window time.Duration) *Meter {
 	return NewWithClock(rdb, limit, window, time.Now)
+}
+
+// Unmetered is a meter that counts nothing and bounds nothing — for a
+// composition that DECLARES it serves no bounded agent surface.
+//
+// It is not the same thing as a meter that cannot reach its counter, and the
+// difference is the whole of why it is a named constructor rather than a nil.
+// A meter with no Redis fails CLOSED, because it was asked to bound an agent
+// and could not answer. This one was never asked: the test harness and any
+// role that serves no agent principals compose it on purpose, and a reader who
+// finds it knows a decision was taken rather than a dependency forgotten.
+//
+// Nothing in a production api path may use it. cmd/api wires the Redis-backed
+// meter, and a deployment that misconfigures Redis gets the loud refusal rather
+// than this.
+func Unmetered() *Meter {
+	return &Meter{limit: DefaultLimit, window: DefaultWindow, now: time.Now, unbounded: true}
 }
 
 // NewWithClock takes the clock as a dependency so the fixed window a charge
@@ -112,7 +133,7 @@ func NewWithClock(rdb *redis.Client, limit int, window time.Duration, now func()
 // served, so it never races a charge — the same discipline
 // overlaybudget.Meter.RebindFrom follows.
 func (m *Meter) RebindFrom(src *Meter) {
-	m.rdb, m.limit, m.window, m.now = src.rdb, src.limit, src.window, src.now
+	m.rdb, m.limit, m.window, m.now, m.unbounded = src.rdb, src.limit, src.window, src.now, src.unbounded
 }
 
 // Limit is the configured threshold, for the refusal envelope to report.
@@ -230,6 +251,9 @@ func (m *Meter) add(ctx context.Context, key string, n int) error {
 //     the fail-closed branch: the meter does not know whether the threshold has
 //     been passed, and a control that cannot answer must not answer "no".
 func (m *Meter) Read(ctx context.Context) Reading {
+	if m.unbounded {
+		return Reading{Limit: m.limit}
+	}
 	ws, agent, metered := m.meteredAgent(ctx)
 	if !metered {
 		return Reading{Limit: m.limit}

--- a/backend/internal/platform/readmeter/meter.go
+++ b/backend/internal/platform/readmeter/meter.go
@@ -3,8 +3,17 @@
 
 // Package readmeter is the MCP-SESS-READS consumption meter
 // (api-rate-limits-and-abuse §2.2): how many RECORDS an agent has been handed
-// inside one window, and whether that has passed the threshold at which a
-// human must confirm before it is handed any more.
+// inside one window, and whether that has passed the threshold beyond which it
+// is handed no more.
+//
+// WHAT THIS IS AND IS NOT. It is the BOUND — the counter and the threshold that
+// A139 calls "the load-bearing half". It is not yet the §2.4 LADDER: crossing
+// the threshold refuses the next read (ErrBudgetExceeded, the sentinel
+// interfaces.md §0 reserves for MCP-SESS-*), and the only release is the window
+// rolling or an operator raising the limit. Confirm-and-continue — a human
+// releasing the window from the approval surface — belongs with the rest of the
+// per-Passport counters and the step-up ladder in ADR-0092/C-6, and is
+// deliberately absent here rather than half-built.
 //
 // PER RECORD, NOT PER CALL. That is the whole control. The spec's own wording
 // is that the bound exists "so a single search_records returning 5,000 rows
@@ -46,10 +55,10 @@ import (
 )
 
 // DefaultLimit is MCP-SESS-READS: the records a Passport may be handed inside
-// one window before the next read demands human confirmation
-// (api-rate-limits-and-abuse §2.2). It is a default and mode-tunable, and §4.2
-// makes lowering it below a floor an ADR matter — it is a security control,
-// not a performance knob.
+// one window before its next read is refused (api-rate-limits-and-abuse §2.2).
+// It is a default and mode-tunable — the operator's lever until the step-up
+// ladder lands — and §4.2 makes lowering it below a floor an ADR matter, since
+// it is a security control rather than a performance knob.
 const DefaultLimit = 2000
 
 // DefaultWindow is the span one counter covers. The spec names the bound after
@@ -113,12 +122,11 @@ func (m *Meter) Limit() int { return m.limit }
 type Reading struct {
 	// Observed is the records served in this window so far.
 	Observed int
-	// Limit is the threshold Observed is judged against, including any
-	// headroom a human has already granted this window.
+	// Limit is the threshold Observed is judged against.
 	Limit int
-	// Exceeded reports that the next read needs human confirmation. It is a
-	// field rather than a comparison the caller makes, so the fail-closed
-	// answer cannot be reconstructed wrongly by a second caller.
+	// Exceeded reports that the next read must be refused. It is a field
+	// rather than a comparison the caller makes, so the fail-closed answer
+	// cannot be reconstructed wrongly by a second caller.
 	Exceeded bool
 }
 
@@ -129,20 +137,10 @@ func (m *Meter) countKey(ws ids.UUID, agent string, bucket int64) string {
 	return fmt.Sprintf(keyPrefix+"%s:%s:reads:%d", ws.String(), agent, bucket)
 }
 
-// grantKey holds the extra headroom a human granted for this window by
-// approving a step-up. It is a SEPARATE key from the count deliberately:
-// resetting the count would erase the evidence of how much this agent has
-// read, and the audit question "how many records did it see" must stay
-// answerable after the human said continue.
-func (m *Meter) grantKey(ws ids.UUID, agent string, bucket int64) string {
-	return fmt.Sprintf(keyPrefix+"%s:%s:grant:%d", ws.String(), agent, bucket)
-}
-
-// addScript adds n to a window counter and returns the new total, setting the
+// addScript adds n to the window counter and returns the new total, setting the
 // fixed-window expiry on FIRST write only — so the window is fixed rather than
-// sliding, and a busy Passport's counter does not renew itself into never
-// resetting. Both counters this package keeps (the count and the granted
-// headroom) have exactly this shape. ARGV=[n, ttlSeconds].
+// sliding, and a busy agent's counter does not renew itself into never
+// resetting. ARGV=[n, ttlSeconds].
 var addScript = redis.NewScript(`
 local n = tonumber(ARGV[1])
 local total = redis.call('INCRBY', KEYS[1], n)
@@ -214,26 +212,9 @@ func (m *Meter) Consume(ctx context.Context, n int) error {
 	return nil
 }
 
-// add applies one counter's increment and its first-write expiry.
+// add applies the counter's increment and its first-write expiry.
 func (m *Meter) add(ctx context.Context, key string, n int) error {
 	return addScript.Run(ctx, m.rdb, []string{key}, n, m.ttlSeconds()).Err()
-}
-
-// Grant adds n records of headroom for the rest of the current window — what
-// an approved step-up buys. The count itself is untouched, so the answer to
-// "how many records has this agent been handed" survives the grant.
-func (m *Meter) Grant(ctx context.Context, n int) error {
-	if n <= 0 {
-		return fmt.Errorf("readmeter: a step-up grant must be positive, got %d", n)
-	}
-	ws, agent, ok := m.usable(ctx)
-	if !ok {
-		return fmt.Errorf("readmeter: no metered agent on this call to grant headroom to")
-	}
-	if err := m.add(ctx, m.grantKey(ws, agent, m.bucket()), n); err != nil {
-		return fmt.Errorf("readmeter: granting %d records of headroom: %w", n, err)
-	}
-	return nil
 }
 
 // Read answers what the meter knows about ctx's agent before a read tool
@@ -256,17 +237,11 @@ func (m *Meter) Read(ctx context.Context) Reading {
 	if m.rdb == nil {
 		return Reading{Limit: m.limit, Exceeded: true}
 	}
-	bucket := m.bucket()
-	observed, err := m.counter(ctx, m.countKey(ws, agent, bucket))
+	observed, err := m.counter(ctx, m.countKey(ws, agent, m.bucket()))
 	if err != nil {
 		return Reading{Limit: m.limit, Exceeded: true}
 	}
-	granted, err := m.counter(ctx, m.grantKey(ws, agent, bucket))
-	if err != nil {
-		return Reading{Observed: observed, Limit: m.limit, Exceeded: true}
-	}
-	limit := m.limit + granted
-	return Reading{Observed: observed, Limit: limit, Exceeded: observed >= limit}
+	return Reading{Observed: observed, Limit: m.limit, Exceeded: observed >= m.limit}
 }
 
 // counter reads one window key, treating a missing key (redis.Nil) as zero —

--- a/backend/internal/platform/readmeter/meter_integration_test.go
+++ b/backend/internal/platform/readmeter/meter_integration_test.go
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package readmeter
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/platform/overlaybudget/budgettest"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// The Redis fixture is budgettest's: it is the platform tier's shared
+// flushed-client helper (isolated db, fails loudly rather than skipping), and
+// it is named after the meter it was written for rather than after what it
+// does. Re-reading MARGINCE_TEST_REDIS here would be a second spelling of the
+// same fixture for no gain.
+
+// meteredCall builds a context for one Passport, and the clock the meter reads
+// its window from, so a test can advance time rather than sleep.
+func meteredCall(t *testing.T, passport ids.UUID) context.Context {
+	t.Helper()
+	ctx := principal.WithWorkspaceID(t.Context(), ids.New[ids.WorkspaceKind]().UUID)
+	return principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalAgent, ID: "agent:reader", PassportID: passport,
+	})
+}
+
+// The bound's arithmetic, end to end: records accumulate ACROSS calls, and the
+// threshold is crossed by their sum rather than by any single call. This is
+// what "per record, not per call" means operationally — four reads of 30 trip a
+// limit of 100 that no one of them approaches.
+func TestRecordsAccumulateAcrossCallsUntilTheThresholdIsCrossed(t *testing.T) {
+	meter := New(budgettest.Client(t), 100, time.Hour)
+	ctx := meteredCall(t, ids.New[ids.PassportKind]().UUID)
+
+	for range 3 {
+		if err := meter.Consume(ctx, 30); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if reading := meter.Read(ctx); reading.Exceeded || reading.Observed != 90 {
+		t.Fatalf("after 90 of 100 records the meter read %+v; it should be under the threshold", reading)
+	}
+
+	if err := meter.Consume(ctx, 30); err != nil {
+		t.Fatal(err)
+	}
+
+	reading := meter.Read(ctx)
+	if !reading.Exceeded {
+		t.Errorf("120 records did not cross a threshold of 100: %+v", reading)
+	}
+	if reading.Observed != 120 {
+		t.Errorf("the meter observed %d records, not the 120 it was handed — the count is what the human is shown", reading.Observed)
+	}
+}
+
+// A single call over the threshold trips it on its own. This is the evasion
+// §2.2 names by hand: "a single search_records returning 5,000 rows trips it".
+func TestOneOversizedCallTripsTheThresholdByItself(t *testing.T) {
+	meter := New(budgettest.Client(t), 100, time.Hour)
+	ctx := meteredCall(t, ids.New[ids.PassportKind]().UUID)
+
+	if err := meter.Consume(ctx, 5000); err != nil {
+		t.Fatal(err)
+	}
+
+	if reading := meter.Read(ctx); !reading.Exceeded {
+		t.Errorf("a 5,000-record answer did not trip a 100-record threshold: %+v", reading)
+	}
+}
+
+// An approved step-up releases the agent WITHOUT erasing what it has read: the
+// count stays, the limit moves. A human asked to confirm a second time must
+// see the true running total, not a total reset by the first confirmation.
+func TestAStepUpGrantRaisesTheLimitAndLeavesTheCountIntact(t *testing.T) {
+	meter := New(budgettest.Client(t), 100, time.Hour)
+	ctx := meteredCall(t, ids.New[ids.PassportKind]().UUID)
+	if err := meter.Consume(ctx, 120); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := meter.Grant(ctx, 100); err != nil {
+		t.Fatal(err)
+	}
+
+	reading := meter.Read(ctx)
+	if reading.Exceeded {
+		t.Errorf("an approved step-up did not release the read: %+v", reading)
+	}
+	if reading.Observed != 120 {
+		t.Errorf("the step-up reset the count to %d; the audit answer to \"how many records did it see\" is gone", reading.Observed)
+	}
+	if reading.Limit != 200 {
+		t.Errorf("the granted limit is %d, not the 100 default plus the 100 granted", reading.Limit)
+	}
+}
+
+// Two Passports reading the same workspace do not spend each other's budget —
+// otherwise one busy agent would step-up every other agent the workspace runs.
+func TestOnePassportsReadingDoesNotRefuseAnother(t *testing.T) {
+	client := budgettest.Client(t)
+	meter := New(client, 100, time.Hour)
+	busy := meteredCall(t, ids.New[ids.PassportKind]().UUID)
+	quiet := meteredCall(t, ids.New[ids.PassportKind]().UUID)
+
+	if err := meter.Consume(busy, 500); err != nil {
+		t.Fatal(err)
+	}
+
+	if !meter.Read(busy).Exceeded {
+		t.Error("the busy Passport was not stepped up")
+	}
+	if meter.Read(quiet).Exceeded {
+		t.Error("a Passport that has read nothing was stepped up by another agent's reading")
+	}
+}
+
+// The window is FIXED with expiry, so a Passport that crossed the threshold is
+// released when the window rolls — asserted by advancing the injected clock
+// rather than by waiting for one.
+func TestTheWindowRollsOverAndReleasesTheThreshold(t *testing.T) {
+	now := time.Date(2026, 8, 8, 9, 0, 0, 0, time.UTC)
+	meter := NewWithClock(budgettest.Client(t), 100, time.Hour, func() time.Time { return now })
+	ctx := meteredCall(t, ids.New[ids.PassportKind]().UUID)
+	if err := meter.Consume(ctx, 200); err != nil {
+		t.Fatal(err)
+	}
+	if !meter.Read(ctx).Exceeded {
+		t.Fatal("200 records did not cross a threshold of 100 inside the window")
+	}
+
+	now = now.Add(time.Hour)
+
+	reading := meter.Read(ctx)
+	if reading.Exceeded {
+		t.Errorf("the next window inherited the previous one's count: %+v", reading)
+	}
+	if reading.Observed != 0 {
+		t.Errorf("a fresh window opened at %d records", reading.Observed)
+	}
+}
+
+// A step-up granted in one window does not release the next one. A human
+// confirming "read 200 more today" has not confirmed tomorrow.
+func TestAStepUpGrantDoesNotSurviveIntoTheNextWindow(t *testing.T) {
+	now := time.Date(2026, 8, 8, 9, 0, 0, 0, time.UTC)
+	meter := NewWithClock(budgettest.Client(t), 100, time.Hour, func() time.Time { return now })
+	ctx := meteredCall(t, ids.New[ids.PassportKind]().UUID)
+	if err := meter.Grant(ctx, 1000); err != nil {
+		t.Fatal(err)
+	}
+
+	now = now.Add(time.Hour)
+	if err := meter.Consume(ctx, 150); err != nil {
+		t.Fatal(err)
+	}
+
+	if reading := meter.Read(ctx); !reading.Exceeded {
+		t.Errorf("the previous window's step-up grant released this one: %+v", reading)
+	}
+}

--- a/backend/internal/platform/readmeter/meter_integration_test.go
+++ b/backend/internal/platform/readmeter/meter_integration_test.go
@@ -76,32 +76,6 @@ func TestOneOversizedCallTripsTheThresholdByItself(t *testing.T) {
 	}
 }
 
-// An approved step-up releases the agent WITHOUT erasing what it has read: the
-// count stays, the limit moves. A human asked to confirm a second time must
-// see the true running total, not a total reset by the first confirmation.
-func TestAStepUpGrantRaisesTheLimitAndLeavesTheCountIntact(t *testing.T) {
-	meter := New(budgettest.Client(t), 100, time.Hour)
-	ctx := meteredCall(t, ids.New[ids.PassportKind]().UUID)
-	if err := meter.Consume(ctx, 120); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := meter.Grant(ctx, 100); err != nil {
-		t.Fatal(err)
-	}
-
-	reading := meter.Read(ctx)
-	if reading.Exceeded {
-		t.Errorf("an approved step-up did not release the read: %+v", reading)
-	}
-	if reading.Observed != 120 {
-		t.Errorf("the step-up reset the count to %d; the audit answer to \"how many records did it see\" is gone", reading.Observed)
-	}
-	if reading.Limit != 200 {
-		t.Errorf("the granted limit is %d, not the 100 default plus the 100 granted", reading.Limit)
-	}
-}
-
 // Two Passports reading the same workspace do not spend each other's budget —
 // otherwise one busy agent would step-up every other agent the workspace runs.
 func TestOnePassportsReadingDoesNotRefuseAnother(t *testing.T) {
@@ -144,25 +118,5 @@ func TestTheWindowRollsOverAndReleasesTheThreshold(t *testing.T) {
 	}
 	if reading.Observed != 0 {
 		t.Errorf("a fresh window opened at %d records", reading.Observed)
-	}
-}
-
-// A step-up granted in one window does not release the next one. A human
-// confirming "read 200 more today" has not confirmed tomorrow.
-func TestAStepUpGrantDoesNotSurviveIntoTheNextWindow(t *testing.T) {
-	now := time.Date(2026, 8, 8, 9, 0, 0, 0, time.UTC)
-	meter := NewWithClock(budgettest.Client(t), 100, time.Hour, func() time.Time { return now })
-	ctx := meteredCall(t, ids.New[ids.PassportKind]().UUID)
-	if err := meter.Grant(ctx, 1000); err != nil {
-		t.Fatal(err)
-	}
-
-	now = now.Add(time.Hour)
-	if err := meter.Consume(ctx, 150); err != nil {
-		t.Fatal(err)
-	}
-
-	if reading := meter.Read(ctx); !reading.Exceeded {
-		t.Errorf("the previous window's step-up grant released this one: %+v", reading)
 	}
 }

--- a/backend/internal/platform/readmeter/meter_integration_test.go
+++ b/backend/internal/platform/readmeter/meter_integration_test.go
@@ -21,23 +21,38 @@ import (
 // does. Re-reading MARGINCE_TEST_REDIS here would be a second spelling of the
 // same fixture for no gain.
 
-// meteredCall builds a context for one Passport, and the clock the meter reads
-// its window from, so a test can advance time rather than sleep.
-func meteredCall(t *testing.T, passport ids.UUID) context.Context {
+// meteredCall builds a context for one Passport inside workspace ws. The
+// workspace is a PARAMETER because the isolation test has to hold it fixed:
+// minting a fresh one per call would separate the two Passports by workspace as
+// well, and the test would pass without ever proving per-Passport isolation.
+func meteredCall(t *testing.T, ws ids.UUID, passport ids.UUID) context.Context {
 	t.Helper()
-	ctx := principal.WithWorkspaceID(t.Context(), ids.New[ids.WorkspaceKind]().UUID)
+	ctx := principal.WithWorkspaceID(t.Context(), ws)
 	return principal.WithActor(ctx, principal.Principal{
 		Type: principal.PrincipalAgent, ID: "agent:reader", PassportID: passport,
 	})
 }
+
+// frozen is the clock every test here reads. The window a charge lands in must
+// be chosen by the test, not by whether the suite happened to run across a UTC
+// boundary — a bound tested against the wall clock is a bound that fails on the
+// hour (T11).
+func frozen(at *time.Time) func() time.Time { return func() time.Time { return *at } }
+
+// aWorkspace is one workspace id, for the tests that need only that they have one.
+func aWorkspace() ids.UUID { return ids.New[ids.WorkspaceKind]().UUID }
+
+// aPassport is one Passport id.
+func aPassport() ids.UUID { return ids.New[ids.PassportKind]().UUID }
 
 // The bound's arithmetic, end to end: records accumulate ACROSS calls, and the
 // threshold is crossed by their sum rather than by any single call. This is
 // what "per record, not per call" means operationally — four reads of 30 trip a
 // limit of 100 that no one of them approaches.
 func TestRecordsAccumulateAcrossCallsUntilTheThresholdIsCrossed(t *testing.T) {
-	meter := New(budgettest.Client(t), 100, time.Hour)
-	ctx := meteredCall(t, ids.New[ids.PassportKind]().UUID)
+	at := time.Date(2026, 8, 8, 9, 0, 0, 0, time.UTC)
+	meter := NewWithClock(budgettest.Client(t), 100, time.Hour, frozen(&at))
+	ctx := meteredCall(t, aWorkspace(), aPassport())
 
 	for range 3 {
 		if err := meter.Consume(ctx, 30); err != nil {
@@ -64,8 +79,9 @@ func TestRecordsAccumulateAcrossCallsUntilTheThresholdIsCrossed(t *testing.T) {
 // A single call over the threshold trips it on its own. This is the evasion
 // §2.2 names by hand: "a single search_records returning 5,000 rows trips it".
 func TestOneOversizedCallTripsTheThresholdByItself(t *testing.T) {
-	meter := New(budgettest.Client(t), 100, time.Hour)
-	ctx := meteredCall(t, ids.New[ids.PassportKind]().UUID)
+	at := time.Date(2026, 8, 8, 9, 0, 0, 0, time.UTC)
+	meter := NewWithClock(budgettest.Client(t), 100, time.Hour, frozen(&at))
+	ctx := meteredCall(t, aWorkspace(), aPassport())
 
 	if err := meter.Consume(ctx, 5000); err != nil {
 		t.Fatal(err)
@@ -79,10 +95,12 @@ func TestOneOversizedCallTripsTheThresholdByItself(t *testing.T) {
 // Two Passports reading the same workspace do not spend each other's budget —
 // otherwise one busy agent would step-up every other agent the workspace runs.
 func TestOnePassportsReadingDoesNotRefuseAnother(t *testing.T) {
-	client := budgettest.Client(t)
-	meter := New(client, 100, time.Hour)
-	busy := meteredCall(t, ids.New[ids.PassportKind]().UUID)
-	quiet := meteredCall(t, ids.New[ids.PassportKind]().UUID)
+	at := time.Date(2026, 8, 8, 9, 0, 0, 0, time.UTC)
+	meter := NewWithClock(budgettest.Client(t), 100, time.Hour, frozen(&at))
+	// ONE workspace, two Passports — the whole point of the test.
+	ws := aWorkspace()
+	busy := meteredCall(t, ws, aPassport())
+	quiet := meteredCall(t, ws, aPassport())
 
 	if err := meter.Consume(busy, 500); err != nil {
 		t.Fatal(err)
@@ -100,9 +118,9 @@ func TestOnePassportsReadingDoesNotRefuseAnother(t *testing.T) {
 // released when the window rolls — asserted by advancing the injected clock
 // rather than by waiting for one.
 func TestTheWindowRollsOverAndReleasesTheThreshold(t *testing.T) {
-	now := time.Date(2026, 8, 8, 9, 0, 0, 0, time.UTC)
-	meter := NewWithClock(budgettest.Client(t), 100, time.Hour, func() time.Time { return now })
-	ctx := meteredCall(t, ids.New[ids.PassportKind]().UUID)
+	at := time.Date(2026, 8, 8, 9, 0, 0, 0, time.UTC)
+	meter := NewWithClock(budgettest.Client(t), 100, time.Hour, frozen(&at))
+	ctx := meteredCall(t, aWorkspace(), aPassport())
 	if err := meter.Consume(ctx, 200); err != nil {
 		t.Fatal(err)
 	}
@@ -110,7 +128,7 @@ func TestTheWindowRollsOverAndReleasesTheThreshold(t *testing.T) {
 		t.Fatal("200 records did not cross a threshold of 100 inside the window")
 	}
 
-	now = now.Add(time.Hour)
+	at = at.Add(time.Hour)
 
 	reading := meter.Read(ctx)
 	if reading.Exceeded {

--- a/backend/internal/platform/readmeter/meter_test.go
+++ b/backend/internal/platform/readmeter/meter_test.go
@@ -210,3 +210,35 @@ func TestAnUnusableConfiguredWindowFallsBackToTheSpecDefault(t *testing.T) {
 		t.Error("the window fallback did not produce a usable bucket")
 	}
 }
+
+// Unmetered and "cannot reach the counter" must never be the same thing. One is
+// a composition that declared no bound; the other is a bound that could not
+// answer, and only the second may refuse. Collapsing them would make every
+// Redis outage look like a deliberate opt-out.
+func TestAnUnmeteredCompositionAdmitsWhereAnUnreachableOneRefuses(t *testing.T) {
+	declared, unreachable := Unmetered(), New(nil, DefaultLimit, DefaultWindow)
+	ctx := agentCtx(t)
+
+	if declared.Read(ctx).Exceeded {
+		t.Error("a composition that declared no read bound refused an agent read")
+	}
+	if !unreachable.Read(ctx).Exceeded {
+		t.Error("a bound that cannot reach its counter admitted an agent read")
+	}
+	if err := declared.Consume(ctx, 5000); err != nil {
+		t.Errorf("charging an unmetered composition failed: %v", err)
+	}
+}
+
+// The rebind carries the unbounded flag too, so a Server that starts unmetered
+// and is later rebound to a real meter actually becomes bounded — and one
+// rebound to Unmetered does not keep enforcing a counter nothing pays into.
+func TestRebindingCarriesWhetherTheCompositionIsBounded(t *testing.T) {
+	shared := New(nil, DefaultLimit, DefaultWindow)
+
+	shared.RebindFrom(Unmetered())
+
+	if shared.Read(agentCtx(t)).Exceeded {
+		t.Error("rebinding to an unmetered composition left the meter refusing")
+	}
+}

--- a/backend/internal/platform/readmeter/meter_test.go
+++ b/backend/internal/platform/readmeter/meter_test.go
@@ -260,3 +260,37 @@ func TestASubSecondWindowBucketsRatherThanDividingByZero(t *testing.T) {
 		t.Errorf("a sub-second window asked Redis for a %ds expiry, which never expires", meter.ttlSeconds())
 	}
 }
+
+// An agent whose counter cannot be NAMED is refused, not admitted. A call with
+// no workspace bound is the live shape of this: the gate's MCP path rejects it
+// before the quota, but the REST path has no such check, so a meter that
+// admitted it would hand out a free pass on a wiring fault.
+func TestAnAgentWithNoWorkspaceIsRefusedRatherThanUnmetered(t *testing.T) {
+	meter := Unmetered() // even an unmetered composition must not be the reason
+	if meter.Read(t.Context()).Exceeded {
+		t.Fatal("an unmetered composition refused a call")
+	}
+
+	bounded := New(nil, DefaultLimit, DefaultWindow)
+	ctx := principal.WithActor(t.Context(), principal.Principal{
+		Type: principal.PrincipalAgent, ID: "agent:no-workspace",
+		PassportID: ids.New[ids.PassportKind]().UUID,
+	})
+
+	if !bounded.Read(ctx).Exceeded {
+		t.Error("an agent with no workspace bound escaped the read bound entirely")
+	}
+}
+
+// And the other side of that branch stays intact: a human with no workspace is
+// still outside the control, not refused by it.
+func TestAHumanWithNoWorkspaceIsStillUnmetered(t *testing.T) {
+	meter := New(nil, DefaultLimit, DefaultWindow)
+	ctx := principal.WithActor(t.Context(), principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:rep",
+	})
+
+	if meter.Read(ctx).Exceeded {
+		t.Error("a human with no workspace was refused by the agent read bound")
+	}
+}

--- a/backend/internal/platform/readmeter/meter_test.go
+++ b/backend/internal/platform/readmeter/meter_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
-// agentCtx is a call carrying a Passport — the only kind of caller this bound
-// is written for.
+// agentCtx is an agent call carrying a Passport — the caller this bound is
+// written for.
 func agentCtx(t *testing.T) context.Context {
 	t.Helper()
 	ctx := principal.WithWorkspaceID(t.Context(), ids.New[ids.WorkspaceKind]().UUID)
@@ -24,8 +24,8 @@ func agentCtx(t *testing.T) context.Context {
 	})
 }
 
-// humanCtx is a call with no Passport. Humans are outside this control: their
-// authority is RBAC at the store.
+// humanCtx is a human call. Humans are outside this control: their authority
+// is RBAC at the store, and they answered for the action themselves.
 func humanCtx(t *testing.T) context.Context {
 	t.Helper()
 	ctx := principal.WithWorkspaceID(t.Context(), ids.New[ids.WorkspaceKind]().UUID)
@@ -55,9 +55,9 @@ func TestAnUnreachableCounterRefusesTheAgentRatherThanAdmittingIt(t *testing.T) 
 }
 
 // The other side of the same branch, and the reason it is a branch at all: an
-// unreachable counter and a caller who is not metered both make resolve say
-// no, and only one of them may be refused. Conflating them would deny the
-// product to its own users on a bound written for agents.
+// unreachable counter and a caller this bound does not govern are both "no",
+// and only one of them may be refused. Conflating them would deny the product
+// to its own users on a bound written for agents.
 func TestAHumanIsNotMeteredEvenWhenTheCounterIsUnreachable(t *testing.T) {
 	meter := New(nil, DefaultLimit, DefaultWindow)
 
@@ -71,15 +71,15 @@ func TestAHumanIsNotMeteredEvenWhenTheCounterIsUnreachable(t *testing.T) {
 	}
 }
 
-// A call with no actor at all — a background job, an unauthenticated path
-// reaching the meter by mistake — carries no Passport and so is not metered.
-// It is asserted rather than assumed because the alternative reading (treat
-// "no actor" as fail-closed) would break every internal read path.
+// A call with no actor at all — a background job, an internal read reaching the
+// meter by mistake — is not an agent and so is not metered. Asserted rather
+// than assumed because the alternative reading (treat "no actor" as
+// fail-closed) would refuse every internal read path in the product.
 func TestACallWithNoActorIsNotMetered(t *testing.T) {
 	meter := New(nil, DefaultLimit, DefaultWindow)
 
 	if meter.Read(t.Context()).Exceeded {
-		t.Error("a call with no actor was refused by a bound that only governs Passports")
+		t.Error("a call with no actor was refused by a bound that only governs agents")
 	}
 }
 
@@ -94,20 +94,6 @@ func TestChargingAnUnmeteredCallerRecordsNothingAndDoesNotFail(t *testing.T) {
 	}
 	if err := meter.Consume(agentCtx(t), 0); err != nil {
 		t.Errorf("charging an empty page failed: %v", err)
-	}
-}
-
-// Granting headroom to a caller the meter does not govern is a wiring fault,
-// not a silent no-op: a step-up approval that quietly grants nothing would
-// leave the agent refused forever with a human believing they had released it.
-func TestGrantingHeadroomToAnUngovernedCallerIsAnError(t *testing.T) {
-	meter := New(nil, DefaultLimit, DefaultWindow)
-
-	if err := meter.Grant(humanCtx(t), 500); err == nil {
-		t.Error("granting step-up headroom to a human reported success")
-	}
-	if err := meter.Grant(agentCtx(t), 0); err == nil {
-		t.Error("a zero-record step-up grant reported success; it releases nothing")
 	}
 }
 
@@ -177,47 +163,50 @@ func TestTheCounterOutlivesItsWindowByTheSkewSlackOnly(t *testing.T) {
 	}
 }
 
-// A window's grant is keyed to that window, not to the Passport at large, so
-// releasing one window's reading cannot silently release the next one's.
-func TestTheGrantIsScopedToTheWindowItWasGivenIn(t *testing.T) {
-	now := time.Date(2026, 8, 8, 9, 0, 0, 0, time.UTC)
-	meter := NewWithClock(nil, DefaultLimit, time.Hour, func() time.Time { return now })
-	ws, passport := ids.New[ids.WorkspaceKind]().UUID, ids.New[ids.PassportKind]().UUID.String()
-
-	first := meter.grantKey(ws, passport, meter.bucket())
-	now = now.Add(time.Hour)
-	second := meter.grantKey(ws, passport, meter.bucket())
-
-	if first == second {
-		t.Error("one window's step-up grant is stored under the next window's key, so it never expires")
-	}
-}
-
-// The count and the grant are separate keys on purpose: a step-up must not
-// erase the evidence of how much the agent has already been handed, because
-// "how many records did it see" has to stay answerable after the human said
-// continue.
-func TestTheGrantDoesNotShareTheCountersKey(t *testing.T) {
-	meter := New(nil, DefaultLimit, DefaultWindow)
-	ws, passport := ids.New[ids.WorkspaceKind]().UUID, ids.New[ids.PassportKind]().UUID.String()
-
-	if meter.countKey(ws, passport, 1) == meter.grantKey(ws, passport, 1) {
-		t.Error("a step-up grant increments the same key as the read count, erasing the audit answer")
-	}
-}
-
 // Two Passports in one workspace, and one Passport across two workspaces, each
 // get their own counter. Sharing either would let one agent's reading refuse
 // another's.
 func TestEachPassportAndWorkspaceCountsSeparately(t *testing.T) {
 	meter := New(nil, DefaultLimit, DefaultWindow)
 	ws, other := ids.New[ids.WorkspaceKind]().UUID, ids.New[ids.WorkspaceKind]().UUID
-	passport, second := ids.New[ids.PassportKind]().UUID.String(), ids.New[ids.PassportKind]().UUID.String()
+	passport, second := ids.New[ids.PassportKind]().String(), ids.New[ids.PassportKind]().String()
 
 	if meter.countKey(ws, passport, 1) == meter.countKey(ws, second, 1) {
 		t.Error("two Passports in one workspace share a read counter")
 	}
 	if meter.countKey(ws, passport, 1) == meter.countKey(other, passport, 1) {
 		t.Error("one Passport shares a read counter across two workspaces")
+	}
+}
+
+// The rebind is what keeps the two halves of the bound on ONE counter: compose
+// builds a fail-closed meter, hands the SAME pointer to the gate that refuses
+// and the registry that charges, and cmd rebinds it once Redis is known. If the
+// rebind did not reach a holder, that holder would keep enforcing against a
+// meter nothing pays into.
+func TestRebindingReachesEveryHolderOfTheSharedPointer(t *testing.T) {
+	shared := New(nil, DefaultLimit, DefaultWindow)
+	held := shared // the gate's copy of the pointer, taken before the rebind
+
+	shared.RebindFrom(New(nil, 50, time.Hour))
+
+	if held.Limit() != 50 {
+		t.Errorf("a holder that took the pointer before the rebind still reads limit %d, not the rebound 50", held.Limit())
+	}
+}
+
+// A non-positive window is a misconfiguration, not an instruction to divide by
+// zero when the bucket is computed. It falls back to the spec's default for the
+// same reason the limit does.
+func TestAnUnusableConfiguredWindowFallsBackToTheSpecDefault(t *testing.T) {
+	meter := NewWithClock(nil, DefaultLimit, 0, func() time.Time {
+		return time.Date(2026, 8, 8, 9, 0, 0, 0, time.UTC)
+	})
+
+	if meter.window != DefaultWindow {
+		t.Errorf("a zero window resolved to %s, not the %s default", meter.window, DefaultWindow)
+	}
+	if meter.bucket() <= 0 {
+		t.Error("the window fallback did not produce a usable bucket")
 	}
 }

--- a/backend/internal/platform/readmeter/meter_test.go
+++ b/backend/internal/platform/readmeter/meter_test.go
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package readmeter
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// agentCtx is a call carrying a Passport — the only kind of caller this bound
+// is written for.
+func agentCtx(t *testing.T) context.Context {
+	t.Helper()
+	ctx := principal.WithWorkspaceID(t.Context(), ids.New[ids.WorkspaceKind]().UUID)
+	return principal.WithActor(ctx, principal.Principal{
+		Type:       principal.PrincipalAgent,
+		ID:         "agent:reader",
+		PassportID: ids.New[ids.PassportKind]().UUID,
+	})
+}
+
+// humanCtx is a call with no Passport. Humans are outside this control: their
+// authority is RBAC at the store.
+func humanCtx(t *testing.T) context.Context {
+	t.Helper()
+	ctx := principal.WithWorkspaceID(t.Context(), ids.New[ids.WorkspaceKind]().UUID)
+	return principal.WithActor(ctx, principal.Principal{
+		Type:   principal.PrincipalHuman,
+		ID:     "human:reader",
+		UserID: ids.New[ids.UserKind]().UUID,
+	})
+}
+
+// The sharpest property in the package: a meter that cannot reach its counter
+// does not know whether the threshold has been passed, and a control that
+// cannot answer must not answer "no". Written first because failing OPEN here
+// would make the whole bound removable by stopping one process.
+func TestAnUnreachableCounterRefusesTheAgentRatherThanAdmittingIt(t *testing.T) {
+	meter := New(nil, DefaultLimit, DefaultWindow)
+
+	reading := meter.Read(agentCtx(t))
+
+	if !reading.Exceeded {
+		t.Error("a meter with no counter admitted an agent read; the bound is removable by stopping Redis")
+	}
+	if reading.Limit != DefaultLimit {
+		t.Errorf("the refusal reported limit %d, not the configured %d — a caller cannot act on a limit that is not the real one",
+			reading.Limit, DefaultLimit)
+	}
+}
+
+// The other side of the same branch, and the reason it is a branch at all: an
+// unreachable counter and a caller who is not metered both make resolve say
+// no, and only one of them may be refused. Conflating them would deny the
+// product to its own users on a bound written for agents.
+func TestAHumanIsNotMeteredEvenWhenTheCounterIsUnreachable(t *testing.T) {
+	meter := New(nil, DefaultLimit, DefaultWindow)
+
+	reading := meter.Read(humanCtx(t))
+
+	if reading.Exceeded {
+		t.Error("a human session was refused by the agent read bound")
+	}
+	if reading.Observed != 0 {
+		t.Errorf("a human accrued %d metered reads; humans are outside this control", reading.Observed)
+	}
+}
+
+// A call with no actor at all — a background job, an unauthenticated path
+// reaching the meter by mistake — carries no Passport and so is not metered.
+// It is asserted rather than assumed because the alternative reading (treat
+// "no actor" as fail-closed) would break every internal read path.
+func TestACallWithNoActorIsNotMetered(t *testing.T) {
+	meter := New(nil, DefaultLimit, DefaultWindow)
+
+	if meter.Read(t.Context()).Exceeded {
+		t.Error("a call with no actor was refused by a bound that only governs Passports")
+	}
+}
+
+// Charging an unmetered caller is a no-op rather than an error: the charge
+// points are shared by both doors and both kinds of caller, and a handler that
+// had to ask "is this an agent?" before every charge would eventually forget.
+func TestChargingAnUnmeteredCallerRecordsNothingAndDoesNotFail(t *testing.T) {
+	meter := New(nil, DefaultLimit, DefaultWindow)
+
+	if err := meter.Consume(humanCtx(t), 25); err != nil {
+		t.Errorf("charging a human failed: %v", err)
+	}
+	if err := meter.Consume(agentCtx(t), 0); err != nil {
+		t.Errorf("charging an empty page failed: %v", err)
+	}
+}
+
+// Granting headroom to a caller the meter does not govern is a wiring fault,
+// not a silent no-op: a step-up approval that quietly grants nothing would
+// leave the agent refused forever with a human believing they had released it.
+func TestGrantingHeadroomToAnUngovernedCallerIsAnError(t *testing.T) {
+	meter := New(nil, DefaultLimit, DefaultWindow)
+
+	if err := meter.Grant(humanCtx(t), 500); err == nil {
+		t.Error("granting step-up headroom to a human reported success")
+	}
+	if err := meter.Grant(agentCtx(t), 0); err == nil {
+		t.Error("a zero-record step-up grant reported success; it releases nothing")
+	}
+}
+
+// An agent principal that carries no Passport is STILL metered, under its own
+// principal id. Every agent this product mints carries one
+// (identity.AgentIdentity.Principal), so this is not a live path — but keying
+// on the Passport alone would make "an agent without one" a silent exemption
+// from the bound, and the next principal shape that appears would inherit it.
+func TestAnAgentWithNoPassportIsStillMetered(t *testing.T) {
+	meter := New(nil, DefaultLimit, DefaultWindow)
+	ctx := principal.WithWorkspaceID(t.Context(), ids.New[ids.WorkspaceKind]().UUID)
+	ctx = principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalAgent, ID: "agent:passportless",
+	})
+
+	if !meter.Read(ctx).Exceeded {
+		t.Error("an agent with no Passport escaped the read bound entirely")
+	}
+}
+
+// A zero or negative configured limit would make every agent read refuse (or,
+// worse under a different sign convention, admit unboundedly). It falls back
+// to the spec's default rather than trusting a misconfiguration.
+func TestAnUnusableConfiguredLimitFallsBackToTheSpecDefault(t *testing.T) {
+	for _, limit := range []int{0, -1} {
+		if got := New(nil, limit, DefaultWindow).Limit(); got != DefaultLimit {
+			t.Errorf("a configured limit of %d resolved to %d, not the %d default", limit, got, DefaultLimit)
+		}
+	}
+	if got := New(nil, 50, DefaultWindow).Limit(); got != 50 {
+		t.Errorf("a configured limit of 50 resolved to %d", got)
+	}
+}
+
+// The window bucket comes from the injected clock, so rollover is a property
+// asserted by advancing time rather than by sleeping (T11). Two moments inside
+// one window share a bucket; two moments either side of it do not.
+func TestTheWindowBucketRollsOverWithTheInjectedClock(t *testing.T) {
+	now := time.Date(2026, 8, 8, 9, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+	meter := NewWithClock(nil, DefaultLimit, time.Hour, clock)
+
+	first := meter.bucket()
+	now = now.Add(59 * time.Minute)
+	if meter.bucket() != first {
+		t.Error("two moments inside one window landed in different buckets")
+	}
+	now = now.Add(2 * time.Minute)
+	if meter.bucket() == first {
+		t.Error("a moment past the window boundary stayed in the previous bucket")
+	}
+}
+
+// The counter's expiry must outlive its window and not by so much that it
+// survives into a later one. An expiry shorter than the window under-counts
+// (the agent's reads vanish mid-window); a much longer one over-counts.
+func TestTheCounterOutlivesItsWindowByTheSkewSlackOnly(t *testing.T) {
+	meter := New(nil, DefaultLimit, 24*time.Hour)
+
+	ttl := time.Duration(meter.ttlSeconds()) * time.Second
+
+	if ttl <= 24*time.Hour {
+		t.Errorf("a counter with a %s expiry dies inside its own 24h window", ttl)
+	}
+	if ttl > 25*time.Hour {
+		t.Errorf("a counter with a %s expiry survives into the window after its own", ttl)
+	}
+}
+
+// A window's grant is keyed to that window, not to the Passport at large, so
+// releasing one window's reading cannot silently release the next one's.
+func TestTheGrantIsScopedToTheWindowItWasGivenIn(t *testing.T) {
+	now := time.Date(2026, 8, 8, 9, 0, 0, 0, time.UTC)
+	meter := NewWithClock(nil, DefaultLimit, time.Hour, func() time.Time { return now })
+	ws, passport := ids.New[ids.WorkspaceKind]().UUID, ids.New[ids.PassportKind]().UUID.String()
+
+	first := meter.grantKey(ws, passport, meter.bucket())
+	now = now.Add(time.Hour)
+	second := meter.grantKey(ws, passport, meter.bucket())
+
+	if first == second {
+		t.Error("one window's step-up grant is stored under the next window's key, so it never expires")
+	}
+}
+
+// The count and the grant are separate keys on purpose: a step-up must not
+// erase the evidence of how much the agent has already been handed, because
+// "how many records did it see" has to stay answerable after the human said
+// continue.
+func TestTheGrantDoesNotShareTheCountersKey(t *testing.T) {
+	meter := New(nil, DefaultLimit, DefaultWindow)
+	ws, passport := ids.New[ids.WorkspaceKind]().UUID, ids.New[ids.PassportKind]().UUID.String()
+
+	if meter.countKey(ws, passport, 1) == meter.grantKey(ws, passport, 1) {
+		t.Error("a step-up grant increments the same key as the read count, erasing the audit answer")
+	}
+}
+
+// Two Passports in one workspace, and one Passport across two workspaces, each
+// get their own counter. Sharing either would let one agent's reading refuse
+// another's.
+func TestEachPassportAndWorkspaceCountsSeparately(t *testing.T) {
+	meter := New(nil, DefaultLimit, DefaultWindow)
+	ws, other := ids.New[ids.WorkspaceKind]().UUID, ids.New[ids.WorkspaceKind]().UUID
+	passport, second := ids.New[ids.PassportKind]().UUID.String(), ids.New[ids.PassportKind]().UUID.String()
+
+	if meter.countKey(ws, passport, 1) == meter.countKey(ws, second, 1) {
+		t.Error("two Passports in one workspace share a read counter")
+	}
+	if meter.countKey(ws, passport, 1) == meter.countKey(other, passport, 1) {
+		t.Error("one Passport shares a read counter across two workspaces")
+	}
+}

--- a/backend/internal/platform/readmeter/meter_test.go
+++ b/backend/internal/platform/readmeter/meter_test.go
@@ -242,3 +242,21 @@ func TestRebindingCarriesWhetherTheCompositionIsBounded(t *testing.T) {
 		t.Error("rebinding to an unmetered composition left the meter refusing")
 	}
 }
+
+// A window is a caller-supplied duration and nothing stops it being sub-second.
+// Bucketing in whole seconds truncated that to zero and divided by it, so the
+// first read of a 500ms window panicked rather than answering.
+func TestASubSecondWindowBucketsRatherThanDividingByZero(t *testing.T) {
+	now := time.Date(2026, 8, 8, 9, 0, 0, 0, time.UTC)
+	meter := NewWithClock(nil, DefaultLimit, 500*time.Millisecond, func() time.Time { return now })
+
+	first := meter.bucket()
+	now = now.Add(600 * time.Millisecond)
+
+	if meter.bucket() == first {
+		t.Error("a 500ms window did not roll after 600ms")
+	}
+	if meter.ttlSeconds() < 1 {
+		t.Errorf("a sub-second window asked Redis for a %ds expiry, which never expires", meter.ttlSeconds())
+	}
+}


### PR DESCRIPTION
## What this is

`MCP-SESS-READS` — the bound on how many **records** an agent may be handed inside one
window — has been specified since the rate-limits chapter was written and enforced
nowhere. Not partially: absent. No counter, no refusal, no audit. `agents/doc.go` said so
in one line ("per-agent quota is specified but not yet enforced") and the session registry
counted *sessions*, not records. So `search_records` and `read_record` have always been
able to hand over an estate without anything noticing, and `AC-MCP-1` has never had an
implementation to gate.

This lands the bound. It is the half **A139** calls "the load-bearing half", and it is a
prerequisite for the two bulk reads B2 adds next (`list_records` and the agent-readable
brief) — metered per call, a densely-joined answer is the cheapest bulk read on the
surface and the D3 step-up never sees it.

## The three decisions worth disagreeing with

**Per record, not per call.** §2.2 sets the bound "so a single `search_records` returning
5,000 rows trips it — closing the obvious evasion". The charge is taken where records
LEAVE the surface — `newWireRecord` and `noteEvidence`, the two places a record becomes
tool output — rather than per tool. Charging per tool is a list to maintain, and the read
tool added next is the one that forgets.

**Per agent, not per session** — which departs from the name on purpose. ADR-0055 made a
Passport a REST credential governed exactly like MCP, and a REST call has no session to
count against, so a per-session counter would meter one half of one surface. ADR-0092/A141
ratifies per-Passport counters as the forward shape and removes the session registry with
it, so this is the key that survives C2 rather than the one it would have to undo.

**Fail-closed.** With no Redis the meter cannot know whether the threshold has been
passed, and a control that cannot answer must not answer "no". **Consequence, stated
plainly: while the counter is unreachable, agent reads stop.** Humans never enter this
path — their authority is RBAC at the store. Redis is already a hard runtime dependency
for the outbox relay, so this widens an existing dependency rather than adding one, but it
widens it onto the read path.

## Behaviour change

**Existing agent clients start being refused past the threshold.** Metering only new tools
would leave `search_records` as the evasion §2.2 explicitly closes, so the bound binds
every read. A Passport past 2,000 records in its window now gets `ErrBudgetExceeded`
where it previously got rows. That is the control working.

## What is deliberately NOT here

**The §2.4 ladder.** Crossing the threshold refuses the next read; the release is the
window rolling or the operator's configured limit — not a human confirming from the
approval surface. Confirm-and-continue was designed and dropped: `approvals.decisionGrants`
is object+action based (`deal:update`, `activity:create`) and "may this agent keep reading"
is neither, so the mapping would have been guessed. It belongs with the rest of the
per-Passport counters and the ladder in **ADR-0092/C-6 (C2)**. The `Grant` method this
branch briefly carried was removed rather than left as an exported method with no caller;
C2 adds it back with its caller.

**The audit event on crossing** (`05` D6) — same reason, same place.

Both are filed rather than forgotten.

## Review found two holes the design did not

An independent review of the finished branch caught two ways around the control, both
fixed in `50026c97`:

1. **REST was outside the bound entirely.** `contractAPI` built its gate without one, and
   the agent gate returned early on every non-mutating method — so a Passport could spend
   its window through `/mcp` and keep reading the same records through `/v1`, neither
   refused nor counted. One credential governed two ways is the hole ADR-0055 exists to
   close. Both doors now refuse on the one meter the tool surface charges.
2. **Naming a record is handing it over.** Only `noteRecord` charged; the intent family —
   the slipping sweep, the coverage reads, the catch-up — answers with ids and derived
   prose through `noteEvidence`. So the tools surfacing the MOST records per call were the
   cheapest reads on the surface: A139's failure one tool family over. Fixed in the one
   place rather than in ten tools.

It also correctly caught a comment claiming more than the code delivers — "nothing is
spent through the gap" — when a charge lost to a transient write failure is lost for good.
The bound is a floor on what an agent has been handed, never an exact count, and it says
so now.

## Tests

31 tests. The load-bearing properties are **mutation-verified** — each was run against the
defect it describes and confirmed to fail:

- fail-open instead of fail-closed → `TestAnUnreachableCounterRefusesTheAgentRatherThanAdmittingIt`
- `noteEvidence` stops charging → `TestAToolThatNamesRecordsChargesForThem`

Coverage on new code: `platform/readmeter` **93.0%** (unit + real-Redis lane),
`modules/agents` 84.3%; every new function in `platform/auth` is 94–100%.

## Gates

`make check-backend` green · `craft static --strict` clean on all three trees ·
`readmeter` integration lane green against real Redis. Backend-only — `crm.yaml` and the
generated contract are untouched.

## Follow-ups filed

- REST agent reads are now **refused** on the bound but not yet **charged** against it, so
  the bound is not yet transport-symmetric. Charging them needs response-shape-aware
  counting.
- The step-up ladder and the audit-on-crossing → C2 (ADR-0092/C-6).
- `crm.yaml:1949` still annotates `advance_deal` with `tier_resolver:
  target_stage_semantic` after #610 shipped the either-endpoint rule. Spotted in passing,
  unverified as to whether the annotation is load-bearing, not touched here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per-record agent read quota across MCP and REST using a shared `readmeter`, enforced at admission and charged at response. Also unifies the read-only check via `mcp.ToolSpec.ReadOnly()` so the gate and charger stay aligned.

- **New Features**
  - Shared `readmeter`: per-Passport fixed window (default 2000 records / 24h), fail-closed; `readmeter.Unmetered()` for roles/tests that don’t serve agents.
  - `auth.Gate` enforces the bound for read-only tools and REST via `AdmitRead`; `agents.Registry` charges after sealing; both doors share one meter via `auth.WithReadBound` and `compose.WithReadMeter`.

- **Bug Fixes**
  - Charging failures now withhold reads only; writes are logged and returned to avoid retrying irreversible actions.
  - Agents with no identifiable counter (e.g., missing workspace) are refused rather than bypassing the bound; REST refusals return 429 with code `rate_limited`.
  - Non-mutating agent routes apply `x-agent-access: human-only` before quota checks to avoid misleading “over budget” messages.
  - Gate and charger use `mcp.ToolSpec.ReadOnly()` to consistently scope the bound to reads.

<sup>Written for commit cb6aae3ce384d83eaddb1d7b42973c0e96ca2a2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/622?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added read limits for agent requests across API and tool-based access.
  * Read usage is tracked per agent and reset automatically after the configured time window.
  * Responses are charged based on records served, including records returned through write actions.
* **Bug Fixes**
  * Agents exceeding their read limit are refused consistently across supported access paths.
  * Human sessions and write operations remain unaffected by agent read limits.
  * Requests are safely denied when read usage cannot be reliably recorded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->