### PR TITLE
fix(test): a Redis logical db per package, and a run that refuses to wrap

### DIFF
--- a/backend/internal/platform/events/bus_integration_test.go
+++ b/backend/internal/platform/events/bus_integration_test.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"strconv"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -32,27 +31,6 @@ import (
 	kevents "github.com/gradionhq/margince/backend/internal/shared/kernel/events"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
-
-// testRedisDB is the Redis logical database this lane isolates its streams in.
-// setup FlushDB's the whole db between tests, so it must never be db 0 — that
-// one is reserved for a running `make dev`, whose relay/subscriber use the
-// client default. The parallel runner hands each package a distinct db in
-// 1..15 via MARGINCE_TEST_REDIS_DB so concurrent packages never share a stream;
-// absent the env (a bare `go test`), db 15 is the isolated default. An
-// out-of-range or non-numeric value fails loudly rather than silently eating
-// the wrong db.
-func testRedisDB(t *testing.T) int {
-	t.Helper()
-	raw := os.Getenv("MARGINCE_TEST_REDIS_DB")
-	if raw == "" {
-		return 15
-	}
-	db, err := strconv.Atoi(raw)
-	if err != nil || db < 1 || db > 15 {
-		t.Fatalf("MARGINCE_TEST_REDIS_DB=%q is not a Redis db index in 1..15", raw)
-	}
-	return db
-}
 
 type busEnv struct {
 	pool *pgxpool.Pool
@@ -104,7 +82,7 @@ func setup(t *testing.T) *busEnv {
 	}
 	t.Cleanup(pool.Close)
 
-	rdb := redis.NewClient(&redis.Options{Addr: redisAddr, DB: testRedisDB(t)})
+	rdb := redis.NewClient(&redis.Options{Addr: redisAddr, DB: testdb.RedisDB(t)})
 	if err := rdb.Ping(ctx).Err(); err != nil {
 		t.Fatalf("redis at %s unreachable — run `make db-up`: %v", redisAddr, err)
 	}

--- a/backend/internal/platform/events/purge_integration_test.go
+++ b/backend/internal/platform/events/purge_integration_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/redis/go-redis/v9"
 
+	"github.com/gradionhq/margince/backend/internal/platform/testdb"
 	kevents "github.com/gradionhq/margince/backend/internal/shared/kernel/events"
 )
 
@@ -31,7 +32,7 @@ func purgeTestRedis(t *testing.T) (context.Context, *redis.Client) {
 	}
 	ctx := t.Context()
 
-	rdb := redis.NewClient(&redis.Options{Addr: redisAddr, DB: testRedisDB(t)})
+	rdb := redis.NewClient(&redis.Options{Addr: redisAddr, DB: testdb.RedisDB(t)})
 	if err := rdb.Ping(ctx).Err(); err != nil {
 		t.Fatalf("redis at %s unreachable — run `make db-up`: %v", redisAddr, err)
 	}

--- a/backend/internal/platform/overlaybudget/budgettest/budgettest.go
+++ b/backend/internal/platform/overlaybudget/budgettest/budgettest.go
@@ -13,33 +13,25 @@ package budgettest
 
 import (
 	"os"
-	"strconv"
 	"testing"
 
 	"github.com/redis/go-redis/v9"
 
 	"github.com/gradionhq/margince/backend/internal/platform/overlaybudget"
+	"github.com/gradionhq/margince/backend/internal/platform/testdb"
 )
 
-// Client returns a flushed Redis client on the isolated integration db
-// (MARGINCE_TEST_REDIS_DB, default 15; the parallel runner assigns each
-// package its own). It fails loudly (never skips) when Redis is not
-// provisioned — the same posture the DB fixtures take.
+// Client returns a flushed Redis client on the isolated integration db the
+// parallel runner assigned this package — see testdb.RedisDB. It fails loudly
+// (never skips) when Redis is not provisioned — the same posture the DB fixtures
+// take.
 func Client(t *testing.T) *redis.Client {
 	t.Helper()
 	addr := os.Getenv("MARGINCE_TEST_REDIS")
 	if addr == "" {
 		t.Fatal("MARGINCE_TEST_REDIS not set — run `make db-up` (integration tests fail loudly, they never skip)")
 	}
-	db := 15
-	if raw := os.Getenv("MARGINCE_TEST_REDIS_DB"); raw != "" {
-		n, err := strconv.Atoi(raw)
-		if err != nil || n < 1 || n > 15 {
-			t.Fatalf("MARGINCE_TEST_REDIS_DB=%q is not a Redis db index in 1..15", raw)
-		}
-		db = n
-	}
-	rdb := redis.NewClient(&redis.Options{Addr: addr, DB: db})
+	rdb := redis.NewClient(&redis.Options{Addr: addr, DB: testdb.RedisDB(t)})
 	// Register cleanup immediately, before the fatal Ping/FlushDB paths, so
 	// a setup failure still closes the client instead of leaking it.
 	t.Cleanup(func() {

--- a/backend/internal/platform/testdb/redis.go
+++ b/backend/internal/platform/testdb/redis.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package testdb
+
+import (
+	"os"
+	"strconv"
+	"testing"
+)
+
+// RedisDBs is the highest logical db the lane may assign, which is also how many
+// it may use, because db 0 is reserved for a running `make dev`.
+//
+// Two other places carry it and they are NOT all the same number. REDIS_DBS in
+// scripts/test-integration-parallel.sh is this same highest index; --databases in
+// infra/docker-compose.dev.yml is a TOTAL and so is one greater, since Redis
+// counts the reserved db 0. Raising the three to one value would take the lane's
+// top db away without saying so, which is why
+// TestRedisDBCountAgreesWithTheLaneAndTheServer asserts the offset rather than
+// equality — and asks the running server too, since a container started before a
+// raise keeps serving the old count whatever the file says.
+const RedisDBs = 63
+
+// defaultRedisDB is what a bare `go test` gets, outside the lane. Any db but 0
+// would do — 0 is the one a running `make dev` owns.
+const defaultRedisDB = 15
+
+// RedisDB is the ONE spelling of which Redis logical database an integration
+// test may touch. Every fixture that talks to Redis flushes its db between
+// tests, so this is an isolation boundary, not a preference: db 0 is excluded
+// because a running `make dev` owns it, and a value the lane never assigns is
+// refused rather than quietly redirected — a fixture that flushed the wrong db
+// would take out a package that has no idea it exists.
+func RedisDB(t *testing.T) int {
+	t.Helper()
+	raw := os.Getenv("MARGINCE_TEST_REDIS_DB")
+	if raw == "" {
+		return defaultRedisDB
+	}
+	db, err := strconv.Atoi(raw)
+	if err != nil || db < 1 || db > RedisDBs {
+		t.Fatalf("MARGINCE_TEST_REDIS_DB=%q is not a Redis db index in 1..%d — the parallel runner assigns one per package, so a value outside that range means the runner and this fixture disagree about how many there are",
+			raw, RedisDBs)
+	}
+	return db
+}

--- a/backend/internal/platform/testdb/redis_integration_test.go
+++ b/backend/internal/platform/testdb/redis_integration_test.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package testdb_test
+
+import (
+	"context"
+	"os"
+	"regexp"
+	"strconv"
+	"testing"
+
+	"github.com/redis/go-redis/v9"
+
+	"github.com/gradionhq/margince/backend/internal/platform/testdb"
+)
+
+// How many logical databases the lane may use is stated in three places that
+// cannot check each other: this package's RedisDBs, REDIS_DBS in the parallel
+// runner, and --databases in the compose file. Drift between them is silent in
+// the direction that matters — the runner assigns a db the server does not
+// serve, and the suite that drew it fails with `ERR DB index is out of range`,
+// naming Redis rather than the mismatch that caused it.
+//
+// Paths are relative to this package, which is three levels under backend/.
+const (
+	laneRunnerPath = "../../../../scripts/test-integration-parallel.sh"
+	composePath    = "../../../../infra/docker-compose.dev.yml"
+)
+
+// The declarations this reads. Anchored to the assignment rather than any
+// mention, so a comment naming the number cannot satisfy the gate.
+var (
+	laneRunnerDecl = regexp.MustCompile(`(?m)^REDIS_DBS=(\d+)$`)
+	composeDecl    = regexp.MustCompile(`--databases",\s*"(\d+)"`)
+)
+
+func TestRedisDBCountAgreesWithTheLaneAndTheServer(t *testing.T) {
+	t.Run("the parallel runner assigns from the same range", func(t *testing.T) {
+		if got := declaredInt(t, laneRunnerPath, laneRunnerDecl); got != testdb.RedisDBs {
+			t.Errorf("REDIS_DBS=%d in %s but testdb.RedisDBs=%d — the runner would assign a db this package rejects, or reject one it would accept",
+				got, laneRunnerPath, testdb.RedisDBs)
+		}
+	})
+
+	// The server serves indices 0..databases-1, and db 0 is reserved for a
+	// running `make dev`, so the lane's usable count is one less than declared.
+	t.Run("the compose file provisions one more than the lane uses", func(t *testing.T) {
+		if got := declaredInt(t, composePath, composeDecl); got != testdb.RedisDBs+1 {
+			t.Errorf("--databases %d in %s but testdb.RedisDBs=%d — Redis must serve %d so that db 1..%d exist alongside the reserved db 0",
+				got, composePath, testdb.RedisDBs, testdb.RedisDBs+1, testdb.RedisDBs)
+		}
+	})
+
+	// The file is what the container was asked for; this is what it actually
+	// serves. They differ whenever a container outlives a change to the file,
+	// which is the case no amount of agreement between the two files can catch.
+	t.Run("the running server serves that many", func(t *testing.T) {
+		addr := os.Getenv("MARGINCE_TEST_REDIS")
+		if addr == "" {
+			t.Fatal("MARGINCE_TEST_REDIS not set — run `make db-up` (integration tests fail loudly, they never skip)")
+		}
+		// Db 0, which every server has, rather than the db the lane assigned:
+		// go-redis SELECTs on the first command, so asking an under-provisioned
+		// server about a db it does not serve fails the SELECT and reports a
+		// Redis read error — naming Redis instead of the drift this test exists
+		// to name. Db 0 is the one a running `make dev` owns and no test may
+		// flush; CONFIG GET reads a server setting and touches no key in it.
+		rdb := redis.NewClient(&redis.Options{Addr: addr, DB: 0})
+		t.Cleanup(func() {
+			if err := rdb.Close(); err != nil {
+				t.Errorf("closing redis: %v", err)
+			}
+		})
+		ctx := context.Background()
+		res, err := rdb.ConfigGet(ctx, "databases").Result()
+		if err != nil {
+			t.Fatalf("reading the server's database count: %v", err)
+		}
+		raw, ok := res["databases"]
+		if !ok {
+			t.Fatalf("the server reported no `databases` setting (got %v)", res)
+		}
+		served, err := strconv.Atoi(raw)
+		if err != nil {
+			t.Fatalf("the server reported databases=%q, which is not a number", raw)
+		}
+		if served != testdb.RedisDBs+1 {
+			t.Errorf("the server at %s serves %d databases but the lane assigns up to db %d — recreate the container (`make db-down && make db-up`); a container started before the count was raised keeps the old one",
+				addr, served, testdb.RedisDBs)
+		}
+	})
+}
+
+// declaredInt reads the single number want matches in the file at path, failing
+// when the file does not exist or the declaration has moved — a gate that
+// silently matches nothing proves nothing.
+func declaredInt(t *testing.T, path string, want *regexp.Regexp) int {
+	t.Helper()
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	m := want.FindSubmatch(body)
+	if m == nil {
+		t.Fatalf("%s no longer declares %s — this gate reads that declaration, so it must be updated with the file", path, want)
+	}
+	n, err := strconv.Atoi(string(m[1]))
+	if err != nil {
+		t.Fatalf("%s declares %q, which is not a number", path, m[1])
+	}
+	return n
+}

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -42,6 +42,13 @@ services:
 
   redis:
     image: redis:7@sha256:595cc6f2bb3af6e03347b90deb6123c6aa2c81dea05ce08128de8a174b6ac67b
+    # 64 logical dbs, not the default 16. The integration lane gives each package
+    # its own db so two packages can never share one — several of them FLUSHDB
+    # between tests, which makes a shared db a silent corruption rather than a
+    # slowdown. The lane has more packages than 16 and keeps growing; keep this
+    # in step with REDIS_DBS in scripts/test-integration-parallel.sh, which
+    # refuses to run rather than wrap the mapping.
+    command: ["redis-server", "--databases", "64"]
     ports:
       - "56379:6379"
     healthcheck:

--- a/scripts/lib-testdb.sh
+++ b/scripts/lib-testdb.sh
@@ -18,10 +18,12 @@
 #     template's migrations grant the cluster-level margince_app role USAGE + table
 #     privileges (migration 0015), which the clone inherits, so the app role can
 #     connect and query without any per-clone GRANT.
-#   - Redis is a single shared instance passed through unchanged: only the events
-#     package touches Redis (its own logical db 15, flushed per test), so no two
-#     parallel packages contend for it. If a second Redis-using package is ever
-#     added, give each slot a private index here (and teach that test to read it).
+#   - Redis is a single shared instance, isolated by logical db rather than by
+#     instance: the parallel runner assigns each package its own index through
+#     MARGINCE_TEST_REDIS_DB and every Redis-using fixture reads it through
+#     testdb.RedisDB. More than one package touches Redis now, and the ones that
+#     do FLUSHDB between tests — so a shared index is a corruption, not
+#     contention. See REDIS_DBS in scripts/test-integration-parallel.sh.
 
 # parse_test_dsn: split MARGINCE_TEST_DSN (owner) and MARGINCE_TEST_APP_DSN (app)
 # into the reusable prefix/suffix each clone DSN is built from. Both DSNs point

--- a/scripts/test-integration-parallel.sh
+++ b/scripts/test-integration-parallel.sh
@@ -14,11 +14,12 @@
 #   MinIO    — a private bucket (MARGINCE_TEST_BLOBSTORE_BUCKET=<base>-p<idx>),
 #              auto-created by the blobstore store.
 #   Redis    — the one shared instance, but each package gets its own logical
-#              db (MARGINCE_TEST_REDIS_DB, mapped 1..15 by slot), so no two
-#              packages ever share a stream. Db 0 is reserved for `make dev`, so
-#              a running dev stack and this lane never collide either. Only the
-#              events package touches Redis today; the per-slot db keeps it
-#              collision-free if that ever changes.
+#              db (MARGINCE_TEST_REDIS_DB, mapped 1..REDIS_DBS by slot), so no
+#              two packages ever share a stream. Db 0 is reserved for `make dev`,
+#              so a running dev stack and this lane never collide either. More
+#              than one package touches Redis, and at least two FLUSHDB between
+#              tests, so this is an isolation boundary rather than a convenience
+#              — see the NPKGS guard below for what happens when it is short.
 # Within a package nothing changes — still -p 1, the same sequential model that is
 # green today — so no test file needs editing.
 #
@@ -112,6 +113,13 @@ GO_DIRS=(backend)
 
 ncpu() { sysctl -n hw.ncpu 2>/dev/null || nproc 2>/dev/null || echo 4; }
 JOBS="${INTEGRATION_JOBS:-$(( $(ncpu) < 8 ? $(ncpu) : 8 ))}"
+
+# Redis logical dbs available to the lane: every db the server serves except 0,
+# which `make dev` owns. Must match --databases in infra/docker-compose.dev.yml.
+# It is one PER PACKAGE, not per concurrent job — a package's keys must survive
+# the whole package, and a slot freed by a finished package cannot be handed on
+# while its successor is still reading.
+REDIS_DBS=63
 
 # Candidate packages: every directory in the module that holds test files. Which
 # of them belong to THIS lane is decided by the build-constraint scan in
@@ -312,6 +320,17 @@ done < "$GROUPED"
 rm -f "$GROUPED"
 
 NPKGS=$(wc -l < "$WORK" | tr -d ' ')
+# One Redis logical db per package, and there must be enough of them. Wrapping
+# the mapping instead is what this guard exists to prevent: two packages on one
+# db do not run slowly, they corrupt each other — platform/events and
+# overlaybudget's budgettest both FLUSHDB between tests, so a collision wipes the
+# other package's keys mid-test and the failure surfaces in whichever suite was
+# reading them, with nothing pointing back here. Redis serves REDIS_DBS+1
+# databases (infra/docker-compose.dev.yml); db 0 is reserved for `make dev`.
+if (( NPKGS > REDIS_DBS )); then
+  echo "FAIL: $NPKGS integration packages but only $REDIS_DBS Redis logical dbs — raise all three together: REDIS_DBS here, testdb.RedisDBs in backend/internal/platform/testdb/redis.go (same value), and --databases in infra/docker-compose.dev.yml (one MORE, it counts the reserved db 0)"
+  exit 1
+fi
 # Say what was left to the unit lane. An unreported exclusion and a broken
 # selector produce the same silence, and this lane's whole contract is that a
 # thinner run must never read as a passing one.
@@ -332,8 +351,10 @@ run_one() {
   local db="margince_it_p${idx}_$$"
   local log="$outdir/$idx.log"
   local bucket; bucket="$(bucket_for "$idx")"
-  # Redis logical db per slot, in 1..15 — db 0 stays reserved for `make dev`.
-  local redis_db=$(( 1 + (idx - 1) % 15 ))
+  # Redis logical db per slot — db 0 stays reserved for `make dev`. The modulo
+  # never wraps in practice: the NPKGS guard above refuses the run rather than
+  # let two packages land on one db.
+  local redis_db=$(( 1 + (idx - 1) % REDIS_DBS ))
   # Coverage args (empty unless COVERDIR is set — shard mode with a manifest
   # dir). -coverpkg=./... attributes cross-package exercise; binary output goes
   # to a per-package pod the CI fan-in merges.
@@ -365,6 +386,10 @@ run_one() {
   } > "$log" 2>&1
 }
 export -f run_one owner_clone_dsn app_clone_dsn make_clone drop_clone db_admin bucket_for
+# The workers run in re-exec'd shells, so a variable run_one reads must be
+# exported and not merely set. REDIS_DBS is the only one: unexported it expands
+# to empty, and `% ` is a division by zero rather than a wrong db.
+export REDIS_DBS
 
 # Fan out with a bounded worker pool. nl numbers the lines → stable per-job db
 # names + logs. The work line rides as a positional arg, not spliced into the


### PR DESCRIPTION
The lane gives every package private state on three axes — its own clone
database, its own MinIO bucket, its own Redis logical db. The Redis one had
quietly stopped holding.

The mapping was `1 + (idx-1) % 15`, so it wrapped. With 28 packages, package 16
lands on the same db as package 1, and the two can run at the same time.

## Why a shared db is not just contention

`platform/events` and `overlaybudget/budgettest` both `FLUSHDB` between tests. A
collision wipes the other package's keys mid-test, and the failure lands wherever
those keys were about to be read — with nothing pointing back at the mapping.

It cost a run: `internal/compose` and `internal/platform/events` both drew db 9,
and `TestResetDataAuditEvidenceCarriesTheSameCacheKeyTallyAsTheResponse` read
`cache_keys_deleted = 0` for a counter it had just written.

## What changes

- Redis serves 64 databases instead of the default 16.
- The lane **refuses to start** when there are more packages than dbs, rather
  than wrapping the modulo. Wrapping is the part worth removing: a lane whose
  isolation silently degrades as packages are added reads exactly like a lane
  that is still isolated.
- The 1..15 bound was spelled twice in Go — once in `events`, once in
  `budgettest` — and both copies rejected the wider assignment, which is how the
  widening announced itself. They become one `testdb.RedisDB`, so the number of
  dbs the lane may use is stated in three places that have to agree rather than
  five that merely happened to.

## Verification

`make test-integration` green — 28 packages, 1906 tests, 0 skips — with the
assigned dbs now 1..28, all distinct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Give each integration test package its own Redis logical DB and refuse to run if packages exceed available DBs, preventing `FLUSHDB` collisions in parallel runs. Centralizes DB selection via `backend/internal/platform/testdb.RedisDB` and expands Redis to 64 DBs.

- **Bug Fixes**
  - Redis now serves 64 DBs (`redis-server --databases 64`); db 0 stays reserved for `make dev`.
  - Runner sets and exports `REDIS_DBS=63`, assigns dbs 1..`REDIS_DBS`, and fails fast when `NPKGS > REDIS_DBS` instead of wrapping.
  - New `backend/internal/platform/testdb/redis.go` with `RedisDBs` and `RedisDB(t)`; used by `platform/events` and `overlaybudget/budgettest`.
  - Guard test (`backend/internal/platform/testdb/redis_integration_test.go`) keeps the runner, compose, and the running server counts in sync.
  - Prevents `FLUSHDB` collisions from `platform/events` and `overlaybudget/budgettest`.

- **Migration**
  - Recreate the dev Redis container: run `make db-up` (or `docker compose up -d --force-recreate redis`).

<sup>Written for commit dbae9cb16e662fba9e8075c1e36291749ada95b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved isolation for parallel integration tests using Redis, preventing database reuse between test packages.
  * Added validation to detect when more Redis databases are needed than are available.
  * Added consistency checks to ensure Redis database settings match across the test runner, development environment, and running server.

* **Test Improvements**
  * Standardized Redis test database selection and cleanup across integration tests.
  * Expanded support for isolated Redis databases during development and parallel testing.
  * Updated documentation for Redis database allocation and parallel execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->