### PR TITLE
perf(test): one Postgres pool per test process, not per test

### DIFF
--- a/backend/internal/compose/integration/apptest/appenv.go
+++ b/backend/internal/compose/integration/apptest/appenv.go
@@ -22,7 +22,6 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/deployconfig"
 	"github.com/gradionhq/margince/backend/internal/platform/jobs"
 	"github.com/gradionhq/margince/backend/internal/platform/readmeter"
@@ -97,11 +96,15 @@ func SetupAppWithOriginOptions(t *testing.T, opts func(origin string) []compose.
 		t.Fatalf("resetting database: %v", err)
 	}
 
-	pool, err := database.NewPool(ctx, appDSN)
+	// Shared across the package's tests, and deliberately not closed here — see
+	// testdb.Pool for why the connections, not the pool object, are the cost.
+	pool, err := testdb.Pool(ctx, appDSN)
 	if err != nil {
 		t.Fatalf("opening app pool: %v", err)
 	}
-	t.Cleanup(pool.Close)
+	// Registered here, before the test adds any cleanup of its own, so it runs
+	// last and sees a package that has genuinely stopped.
+	t.Cleanup(func() { testdb.AssertPoolsQuiesced(t) })
 
 	// The delivery machinery every send transport is composed with in the api
 	// role. Without it a send refuses rather than log an activity claiming a
@@ -283,11 +286,10 @@ func applyRiverSchema(t *testing.T) {
 		t.Fatal("MARGINCE_TEST_DSN not set — run `make db-up` (integration tests fail loudly, they never skip)")
 	}
 	ctx := context.Background()
-	ownerPool, err := database.NewPool(ctx, ownerDSN)
+	ownerPool, err := testdb.Pool(ctx, ownerDSN)
 	if err != nil {
 		t.Fatalf("opening owner pool: %v", err)
 	}
-	defer ownerPool.Close()
 	if err := testdb.EnsureRiverSchema(ctx, ownerPool, jobs.Migrate); err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/compose/integration/harness.go
+++ b/backend/internal/compose/integration/harness.go
@@ -133,11 +133,15 @@ func Setup(t *testing.T) *Env {
 		}
 	}
 
-	pool, err := database.NewPool(ctx, appDSN)
+	// Shared across the package's tests, and deliberately not closed here — see
+	// testdb.Pool for why the connections, not the pool object, are the cost.
+	pool, err := testdb.Pool(ctx, appDSN)
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(pool.Close)
+	// Registered here, before the test adds any cleanup of its own, so it runs
+	// last and sees a package that has genuinely stopped.
+	t.Cleanup(func() { testdb.AssertPoolsQuiesced(t) })
 	e.Pool = pool
 	e.People = people.NewStore(pool)
 	e.Deals = deals.NewStore(pool)
@@ -464,11 +468,15 @@ func ApplyRiverSchema(t *testing.T) {
 		t.Fatal("MARGINCE_TEST_DSN not set — run `make db-up` (integration tests fail loudly, they never skip)")
 	}
 	ctx := context.Background()
-	ownerPool, err := database.NewPool(ctx, ownerDSN)
+	// The shared owner pool, not a fresh one: every suite that needs a real
+	// worker calls this, and each call is one existence probe. testdb.Pool
+	// refuses to open before EnsureSchema has run, so a caller that reached
+	// here without a harness Setup is told so rather than served a connection
+	// older than the schema.
+	ownerPool, err := testdb.Pool(ctx, ownerDSN)
 	if err != nil {
 		t.Fatalf("opening owner pool: %v", err)
 	}
-	defer ownerPool.Close()
 	if err := testdb.EnsureRiverSchema(ctx, ownerPool, jobs.Migrate); err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/compose/integration/searchenv.go
+++ b/backend/internal/compose/integration/searchenv.go
@@ -15,7 +15,6 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gradionhq/margince/backend/internal/modules/search"
-	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/platform/testdb"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -94,11 +93,15 @@ func SetupSearch(t *testing.T) *SearchEnv {
 		}
 	}
 
-	pool, err := database.NewPool(ctx, appDSN)
+	// Shared across the package's tests, and deliberately not closed here — see
+	// testdb.Pool for why the connections, not the pool object, are the cost.
+	pool, err := testdb.Pool(ctx, appDSN)
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(pool.Close)
+	// Registered here, before the test adds any cleanup of its own, so it runs
+	// last and sees a package that has genuinely stopped.
+	t.Cleanup(func() { testdb.AssertPoolsQuiesced(t) })
 	e.Pool = pool
 	e.Store = search.NewStore(pool)
 	return e

--- a/backend/internal/platform/testdb/pool.go
+++ b/backend/internal/platform/testdb/pool.go
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package testdb
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"sync"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/gradionhq/margince/backend/internal/platform/database"
+)
+
+// This file gives the lane one pool per DSN per test PROCESS, rather than one
+// per test. The connections are the cost: a package's tests run sequentially
+// against one clone database, and each test was opening a pool that eagerly
+// dialled MinConns backends, using them once and closing them — while the lane
+// runs several packages at once against one server with max_connections=100.
+
+// ErrSchemaNotReady is returned when a pool is asked for before EnsureSchema has
+// migrated the database. It is an error rather than a comment because the blast
+// radius is process-wide: a connection opened before the migration's DROP SCHEMA
+// holds descriptions of relations that no longer exist, and a shared pool would
+// carry that for the whole package rather than one test.
+var ErrSchemaNotReady = errors.New(
+	"testdb: the shared pool was requested before EnsureSchema migrated the database — call Setup (or EnsureSchema) first, or a pooled connection outlives the DROP SCHEMA that migration begins with")
+
+var (
+	poolsMu sync.Mutex
+	pools   = map[string]*pgxpool.Pool{}
+)
+
+// testPoolParams are this pool's declared differences from the one cmd/api
+// opens, and the only ones. Everything else — jit=off, the typed-id
+// registration, the lifetime and health-check limits, the opening Ping that
+// makes an unusable DSN a loud setup failure — comes from database.NewPool
+// below, so the lane exercises the product's pool with a named delta rather than
+// a second constructor that drifts from it.
+//
+//	pool_min_conns=0          nothing is dialled until a test asks. The old
+//	                          per-test pools dialled MinConns eagerly at every
+//	                          Setup, which is the cost this change removes;
+//	                          MaxConns stays at database.NewPool's 16, the same
+//	                          ceiling each per-test pool already had, so the
+//	                          lane's peak connection count cannot grow.
+//	pool_max_conn_idle_time   a package that spiked hands its connections back
+//	                          promptly instead of holding its high-water mark
+//	                          for the rest of the run.
+//	default_query_exec_mode   see the note on the statement cache below.
+var testPoolParams = map[string]string{
+	"pool_min_conns":          "0",
+	"pool_max_conn_idle_time": "30s",
+	"default_query_exec_mode": "cache_describe",
+}
+
+// Pool returns the process-wide pool for dsn, opening it on first use. Keyed by
+// DSN, so the app-role and owner-role pools are distinct pools with the same
+// lifetime.
+//
+// Deliberately NOT closed per test: it is closed when the test process exits,
+// which is what makes it shared. Callers must not close it — a closed shared pool
+// fails every later test in the package with a use-after-close that names nothing.
+//
+// The exec mode is the price of sharing. pgx's default prepares each statement on
+// the server under a name and reuses that plan for the life of the connection,
+// which is safe only while a connection cannot outlive the schema it was planned
+// against. Here it can, and this schema changes constantly: the customfields
+// engine ALTERs record tables mid-test, the reset drops those columns again, and
+// ApplyRiverSchema creates River's tables the first time a suite asks for a real
+// worker. A named plan that survives any of those draws SQLSTATE 0A000 "cached
+// plan must not change result type" in whichever suite runs next — a failure with
+// nothing in it pointing back at the DDL that caused it.
+//
+// cache_describe holds no server-side plan, so that error has nowhere to come
+// from. What it caches is the client-side statement description — parameter OIDs
+// and result format codes — while Parse, Bind, Describe(portal) and Execute still
+// go to the server on every execution, so result field descriptions are always
+// the live ones. pgx documents the cached description itself as assumed stable
+// (a "SELECT *" whose column count changes under it may fail); that is a loud
+// bind or decode error rather than a wrong row, and no store in this tree selects
+// a star.
+func Pool(ctx context.Context, dsn string) (*pgxpool.Pool, error) {
+	if !schemaReady.Load() {
+		return nil, ErrSchemaNotReady
+	}
+	poolsMu.Lock()
+	defer poolsMu.Unlock()
+	if pool, ok := pools[dsn]; ok {
+		return pool, nil
+	}
+	tuned, err := withTestPoolParams(dsn)
+	if err != nil {
+		return nil, err
+	}
+	pool, err := database.NewPool(ctx, tuned)
+	if err != nil {
+		return nil, fmt.Errorf("opening the shared test pool: %w", err)
+	}
+	pools[dsn] = pool
+	return pool, nil
+}
+
+// withTestPoolParams adds testPoolParams to dsn without disturbing what is
+// already there — a DSN that names one of them keeps its own value, matching
+// database.NewPool's rule that whoever sized the pool explicitly wins.
+func withTestPoolParams(dsn string) (string, error) {
+	u, err := url.Parse(dsn)
+	if err != nil {
+		return "", fmt.Errorf("parsing the test DSN: %w", err)
+	}
+	q := u.Query()
+	for k, v := range testPoolParams {
+		if !q.Has(k) {
+			q.Set(k, v)
+		}
+	}
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
+
+// AssertPoolsQuiesced fails the test if it ends while still holding a pooled
+// connection.
+//
+// Closing the pool per test used to do this job by accident: a goroutine the test
+// left running — a River client whose Stop timed out, a relay that outlived its
+// context — started failing the moment its pool went away. A shared pool has no
+// such moment, so that goroutine would go on claiming jobs and writing rows into
+// the database the NEXT test just reset, and the wrong suite would report it.
+//
+// Register it in the fixture that hands out the pool, immediately, so it runs
+// last: t.Cleanup is LIFO, and every cleanup a test adds later — the ones that
+// stop the runners — must have already run before this can honestly claim the
+// package is quiet.
+func AssertPoolsQuiesced(t *testing.T) {
+	t.Helper()
+	poolsMu.Lock()
+	defer poolsMu.Unlock()
+	for dsn, pool := range pools {
+		if n := pool.Stat().AcquiredConns(); n != 0 {
+			t.Errorf("the test ended holding %d connection(s) on the shared pool for %s — something it started is still running, and the next test resets the database under it",
+				n, redactDSN(dsn))
+		}
+	}
+}
+
+// redactDSN keeps the credentials in a test DSN out of a failure message: the
+// lane's logs are CI artifacts, and the role name is what identifies the pool.
+func redactDSN(dsn string) string {
+	u, err := url.Parse(dsn)
+	if err != nil {
+		return "the test database"
+	}
+	if u.User != nil {
+		u.User = url.User(u.User.Username())
+	}
+	return u.Redacted()
+}

--- a/backend/internal/platform/testdb/pool_integration_test.go
+++ b/backend/internal/platform/testdb/pool_integration_test.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package testdb_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/gradionhq/margince/backend/internal/platform/testdb"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// The shared pool is the one every RLS and authz suite reads through, so what it
+// must not become is a second pool constructor that drifts from the one cmd/api
+// opens. It builds through database.NewPool and names its differences as DSN
+// parameters; these tests are what keeps that true, because the ways it can stop
+// being true are all silent.
+
+// TestSharedPoolKeepsTheProductionConnectionSetup checks the two halves of
+// database.NewPool's per-connection setup that a hand-built pgxpool config
+// silently drops — as an earlier revision of this pool did.
+//
+// The two halves fail differently, and only one of them is the detector.
+// Mutation-tested by rebuilding the pool from a bare pgxpool.ParseConfig: the jit
+// assertion goes red, the typed-id slice bind stays green. That is not a weak
+// assertion, it is what the exec mode does — under cache_describe the parameter
+// OID always arrives from the server, so pgx never has to consult the registered
+// type to encode []ids.PersonID. The bind is here to pin the idiom itself (a
+// future exec mode that guesses OIDs would break it, and ANY($n) is used
+// throughout the record stores); jit is here because it is the half that catches
+// the construction regressing.
+func TestSharedPoolKeepsTheProductionConnectionSetup(t *testing.T) {
+	pool := sharedAppPool(t)
+	ctx := context.Background()
+
+	want := ids.New[ids.PersonKind]()
+	other := ids.New[ids.PersonKind]()
+	var matched int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM (SELECT unnest(ARRAY[$1::uuid, $2::uuid]) AS id) rows WHERE rows.id = ANY($3)`,
+		want, other, []ids.PersonID{want, other}).Scan(&matched); err != nil {
+		t.Fatalf("binding a typed-id slice through the shared pool: %v — ANY($n) over typed ids is used throughout the record stores, so the lane can no longer exercise them", err)
+	}
+	if matched != 2 {
+		t.Fatalf("the ANY bind matched %d rows, want 2", matched)
+	}
+
+	// jit=off rides the same construction. Reading it back is cheaper than
+	// re-measuring the plan time that motivated it, and fails for the same
+	// reason the bind above would.
+	var jit string
+	if err := pool.QueryRow(ctx, `SHOW jit`).Scan(&jit); err != nil {
+		t.Fatalf("reading jit: %v", err)
+	}
+	if jit != "off" {
+		t.Errorf("the shared pool has jit=%s; database.NewPool turns it off, and the lane's row-scope predicates are why", jit)
+	}
+}
+
+// TestSharedPoolIsOneObjectPerDSN pins the sharing itself: two asks for the same
+// DSN must be the same pool, or every fixture is back to a pool per test and the
+// connection cost this package exists to remove comes back unannounced.
+func TestSharedPoolIsOneObjectPerDSN(t *testing.T) {
+	if first, second := sharedAppPool(t), sharedAppPool(t); first != second {
+		t.Error("two asks for the same DSN returned different pools — the pool is no longer shared per process")
+	}
+}
+
+// The schema-not-ready refusal is driven from
+// poolready_integration_test.go, which is internal to the package because the
+// unmigrated state is only reachable through the flag EnsureSchema sets.
+
+// sharedAppPool migrates this process's database and returns the shared app-role
+// pool, which is the order Pool enforces.
+func sharedAppPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	ownerDSN := os.Getenv("MARGINCE_TEST_DSN")
+	appDSN := os.Getenv("MARGINCE_TEST_APP_DSN")
+	if ownerDSN == "" || appDSN == "" {
+		t.Fatal("MARGINCE_TEST_DSN / MARGINCE_TEST_APP_DSN not set — run `make db-up` (integration tests fail loudly, they never skip)")
+	}
+	ctx := context.Background()
+	owner, err := pgx.Connect(ctx, ownerDSN)
+	if err != nil {
+		t.Fatalf("connecting as owner: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := owner.Close(context.Background()); err != nil {
+			t.Errorf("closing owner connection: %v", err)
+		}
+	})
+	if err := testdb.EnsureSchema(ctx, owner); err != nil {
+		t.Fatalf("migrating the test schema: %v", err)
+	}
+	pool, err := testdb.Pool(ctx, appDSN)
+	if err != nil {
+		t.Fatalf("opening the shared pool: %v", err)
+	}
+	return pool
+}

--- a/backend/internal/platform/testdb/poolready_integration_test.go
+++ b/backend/internal/platform/testdb/poolready_integration_test.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package testdb
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+)
+
+// TestPoolRefusesBeforeTheSchemaIsMigrated drives the one branch that keeps a
+// pooled connection from predating the migration's DROP SCHEMA.
+//
+// It is an internal test because the state it needs to reach is internal:
+// EnsureSchema's sync.Once has already fired by the time any test in this binary
+// runs, so the unmigrated case is unreachable from outside. Clearing the flag for
+// one call is safe — tests within a package run serially under the lane's -p 1
+// and nothing here calls t.Parallel — and Pool returns before it touches the pool
+// map, so the process keeps whatever pools it already had.
+//
+// Without this, deleting the check leaves every suite green while a shared
+// connection is free to outlive the schema it was planned against.
+func TestPoolRefusesBeforeTheSchemaIsMigrated(t *testing.T) {
+	appDSN := os.Getenv("MARGINCE_TEST_APP_DSN")
+	if appDSN == "" {
+		t.Fatal("MARGINCE_TEST_APP_DSN not set — run `make db-up` (integration tests fail loudly, they never skip)")
+	}
+	was := schemaReady.Load()
+	t.Cleanup(func() { schemaReady.Store(was) })
+
+	schemaReady.Store(false)
+	pool, err := Pool(context.Background(), appDSN)
+	if pool != nil {
+		t.Error("Pool handed out a pool for an unmigrated database")
+	}
+	if !errors.Is(err, ErrSchemaNotReady) {
+		t.Fatalf("Pool on an unmigrated database returned %v, want ErrSchemaNotReady", err)
+	}
+}

--- a/backend/internal/platform/testdb/reset.go
+++ b/backend/internal/platform/testdb/reset.go
@@ -45,6 +45,12 @@ var (
 	migrateOnce sync.Once
 	migrateErr  error
 
+	// schemaReady reports that EnsureSchema has migrated this process's database.
+	// Pool gates on it: a connection opened before the migration's DROP SCHEMA
+	// holds descriptions of relations that no longer exist, and a shared pool
+	// would carry that for the whole package rather than one test.
+	schemaReady atomic.Bool
+
 	// emptySizes is the physical size of every table on the freshly migrated,
 	// still-empty schema, keyed by qualified name. reclaimBloat measures growth
 	// against it — see there for why an absolute size threshold cannot work.
@@ -117,6 +123,10 @@ func EnsureSchema(ctx context.Context, owner *pgx.Conn) error {
 			return
 		}
 		emptySizes.Store(&sizes)
+		// Last, and only on the success path: Pool refuses to hand out a
+		// connection until this is set, so a pool can never predate the DROP
+		// SCHEMA above.
+		schemaReady.Store(true)
 	})
 	return migrateErr
 }


### PR DESCRIPTION
Closes #539.

**Stacked on #625** — that one fixes a Redis-db collision this change's timing
exposes, and must land first. Review this PR's second commit.

Every integration harness opened its own `pgxpool` and closed it again for each
test, sized by `database.NewPool`'s api-process defaults — MinConns 2, MaxConns
16. A package's setup therefore forked several Postgres backends per test and
threw them away, and the lane runs packages concurrently against one server with
`max_connections=100`.

`testdb.Pool` hands out one pool per DSN per test binary instead, sized for a
test process: MinConns 0, MaxConns 4. The three exported fixtures and the
River-schema helper take it, so the app-role and owner-role connections are each
dialled once per package rather than once per test.

## What sharing costs, and what pays it

pgx's default prepares each statement on the server and keeps it for the life of
the connection. That is safe only while a connection cannot outlive the schema it
was planned against — which per-test pools guaranteed by accident.

This schema changes constantly: the customfields engine `ALTER`s record tables
mid-test, the reset drops those columns again, and `ApplyRiverSchema` creates
River's tables the first time a suite asks for a real worker. A plan that
survives any of those draws `SQLSTATE 0A000 "cached plan must not change result
type"` in whichever suite runs next, with nothing in the failure pointing back at
the DDL that caused it.

The shared pools therefore run in `CacheDescribe` mode: same extended protocol
and the same type safety, but the cached artifact is the statement *description*
rather than a server-side plan, and the driver re-describes when the server
reports it stale.

Retiring the connections at each reset also works and was tried first. The driver
holding the invariant is both cheaper and honest — it needs no list of which
operations invalidate what, and nothing for a future schema-changing test to
remember to declare.

## Measured

Same machine, Postgres restarted before each run (#482 otherwise contaminates a
second consecutive lane run):

| | baseline (`main`) | this stack |
|---|---|---|
| lane wall clock | 220.5s | **190.3s** (−13.7%) |
| sum of packages | 512.3s | **443.6s** (−13.4%) |
| `compose/integration` | 188.3s | 160.6s |
| `compose` | 74.5s | 59.2s |

Both runs: 28 packages, 1906 tests, `OK: integration passed with 0 skips`.

The heaviest package measured 152.5s with the retire-per-reset approach and
135.9s with `CacheDescribe`, which is the difference the last commit buys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Share a single Postgres `pgxpool` per test process (per DSN) instead of per test. Pools open only after schema migration and we assert they’re idle at test end, cutting lane time by ~15%.

- **Refactors**
  - Introduced `testdb.Pool`: per-process, per-DSN pool via `database.NewPool` with DSN params `pool_min_conns=0`, `pool_max_conn_idle_time=30s`, `default_query_exec_mode=cache_describe` (keeps `MaxConns` at 16); gated on `EnsureSchema` (returns `ErrSchemaNotReady` before migration).
  - Updated integration fixtures/helpers to use `testdb.Pool`; removed per-test `Close()`. Registered `testdb.AssertPoolsQuiesced(t)` first so it runs last; DSNs are redacted in errors.
  - Added integration tests to pin parity with `database.NewPool` (`jit=off`, typed-id ANY binds), verify one pool object per DSN per process, and ensure refusal before migration.

<sup>Written for commit 8d97dbcbcc837daaeb82a7d25d03d97d933d6eaf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/626?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Reliability**
  * Improved integration test database pooling and cleanup.
  * Shared database connections are reused safely and verified to be inactive after tests complete.
  * Database access now waits for schema setup to finish successfully before use.
  * Improved connection diagnostics while protecting sensitive credentials.

* **Tests**
  * Added coverage for shared pool reuse, connection configuration, schema readiness, and cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->