### PR TITLE
feat(agents): the dispatcher speaks 2026-07-28 alongside the handshake era

### DIFF
--- a/backend/internal/compose/integration/mcp_modernframing_integration_test.go
+++ b/backend/internal/compose/integration/mcp_modernframing_integration_test.go
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+// Both framings, end to end on the real origin, against a real database
+// (ADR-0092/A141). The unit suite proves each framing's rules; only this one
+// proves that the route compose actually mounts — behind its Origin guard, its
+// rate limits and its per-request authenticate closure — serves them BOTH, and
+// that a call in either framing lands the same effect in the same workspace.
+//
+// The handshake half is not decoration. C2 removes the session registry for
+// modern clients, and the legacy framing is where that change can break every
+// connected client; a suite that exercised only the modern path would not
+// notice (ADR-0092, Consequences).
+
+import (
+	"encoding/json"
+	"maps"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// The per-request metadata a modern client sends, spelled as the specification
+// writes it — this suite is a client, so it must not read the server's own
+// constants for what to put on the wire.
+const (
+	modernRevision = "2026-07-28"
+	modernMeta     = `"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28",` +
+		`"io.modelcontextprotocol/clientCapabilities":{}}`
+)
+
+// modernHeaders is what a conforming modern POST carries: the credential, plus
+// the body members this transport mirrors so an intermediary can route without
+// parsing the body.
+func modernHeaders(bearer map[string]string, method, name string) map[string]string {
+	headers := map[string]string{
+		"Content-Type":         "application/json",
+		"MCP-Protocol-Version": modernRevision,
+		"Mcp-Method":           method,
+	}
+	if name != "" {
+		headers["Mcp-Name"] = name
+	}
+	maps.Copy(headers, bearer)
+	return headers
+}
+
+// TestBothFramingsConnectAndLandTheSameEffect is the headline claim: one
+// server, two eras, and a record created through either one.
+func TestBothFramingsConnectAndLandTheSameEffect(t *testing.T) {
+	e := setupConnector(t)
+	bearer := passportBearer(t, e.AppEnv, "dual-era client", "read", "write")
+
+	t.Run("a modern client needs no handshake", func(t *testing.T) {
+		discovered := mcpRaw(e.AppEnv, t, http.MethodPost, "/mcp",
+			`{"jsonrpc":"2.0","id":1,"method":"server/discover","params":{`+modernMeta+`}}`,
+			modernHeaders(bearer, "server/discover", ""))
+		if discovered.StatusCode != http.StatusOK {
+			t.Fatalf("server/discover → %d %s", discovered.StatusCode, discovered.Body)
+		}
+		// Discovery is what a client reads INSTEAD of probing, so it must name
+		// the revision this client is already speaking.
+		result := rpcResult(t, discovered.Body)
+		versions, ok := result["supportedVersions"].([]any)
+		if !ok || len(versions) == 0 || versions[0] != modernRevision {
+			t.Fatalf("supportedVersions = %v, want the modern revision first", result["supportedVersions"])
+		}
+		if result["resultType"] != "complete" {
+			t.Errorf("resultType = %v, want complete", result["resultType"])
+		}
+
+		// The tool list is filtered by this passport's scopes, so the copy it
+		// hands back may never be shared with another caller.
+		listed := mcpRaw(e.AppEnv, t, http.MethodPost, "/mcp",
+			`{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{`+modernMeta+`}}`,
+			modernHeaders(bearer, "tools/list", ""))
+		if listed.StatusCode != http.StatusOK {
+			t.Fatalf("tools/list → %d %s", listed.StatusCode, listed.Body)
+		}
+		if scope := rpcResult(t, listed.Body)["cacheScope"]; scope != "private" {
+			t.Errorf("tools/list cacheScope = %v, want private — a shared entry on a "+
+				"scope-filtered catalog is a disclosure that never reaches the server to be audited", scope)
+		}
+
+		// And the call itself, with no session ever minted: this is what lets a
+		// modern conversation land on any replica.
+		called := mcpRaw(e.AppEnv, t, http.MethodPost, "/mcp",
+			`{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{`+modernMeta+
+				`,"name":"create_record","arguments":{"record_type":"person",`+
+				`"fields":{"full_name":"Modern Framing Person"}}}}`,
+			modernHeaders(bearer, "tools/call", "create_record"))
+		if called.StatusCode != http.StatusOK {
+			t.Fatalf("tools/call → %d %s", called.StatusCode, called.Body)
+		}
+		if got := called.Header.Get("Mcp-Session-Id"); got != "" {
+			t.Errorf("a modern exchange minted the session id %q", got)
+		}
+		if text := toolText(t, rpcResult(t, called.Body)); !strings.Contains(text, "Modern Framing Person") {
+			t.Fatalf("tools/call answered %q, which does not carry the record it created", text)
+		}
+	})
+
+	t.Run("a handshake client still opens a session", func(t *testing.T) {
+		initialized := mcpRaw(e.AppEnv, t, http.MethodPost, "/mcp",
+			`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25"}}`,
+			withContentType(bearer))
+		if initialized.StatusCode != http.StatusOK {
+			t.Fatalf("initialize → %d %s", initialized.StatusCode, initialized.Body)
+		}
+		session := initialized.Header.Get("Mcp-Session-Id")
+		if session == "" {
+			t.Fatal("initialize minted no session, so the handshake era lost the state it depends on")
+		}
+		negotiated, _ := rpcResult(t, initialized.Body)["protocolVersion"].(string)
+		if negotiated != "2025-11-25" {
+			t.Fatalf("negotiated %q, want the revision this client asked for", negotiated)
+		}
+
+		called := mcpRaw(e.AppEnv, t, http.MethodPost, "/mcp",
+			`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"create_record",`+
+				`"arguments":{"record_type":"person","fields":{"full_name":"Handshake Era Person"}}}}`,
+			legacyHeaders(bearer, negotiated, session))
+		if called.StatusCode != http.StatusOK {
+			t.Fatalf("tools/call → %d %s", called.StatusCode, called.Body)
+		}
+		if text := toolText(t, rpcResult(t, called.Body)); !strings.Contains(text, "Handshake Era Person") {
+			t.Fatalf("tools/call answered %q, which does not carry the record it created", text)
+		}
+	})
+
+	// Both eras ended in a real effect or the assertions above were satisfied
+	// by a surface answering from nothing.
+	for _, created := range []string{"Modern Framing Person", "Handshake Era Person"} {
+		var found int
+		if err := e.Owner.QueryRow(t.Context(),
+			`SELECT count(*) FROM person WHERE full_name = $1`, created).Scan(&found); err != nil {
+			t.Fatal(err)
+		}
+		if found != 1 {
+			t.Errorf("%q exists %d times, want exactly one — the call answered without writing", created, found)
+		}
+	}
+}
+
+// withContentType is the handshake era's opening request: a credential and
+// nothing else, because a client that has not negotiated has no revision to
+// declare.
+func withContentType(bearer map[string]string) map[string]string {
+	headers := map[string]string{"Content-Type": "application/json"}
+	maps.Copy(headers, bearer)
+	return headers
+}
+
+// legacyHeaders is what a connected handshake client carries on every request
+// after initialize.
+func legacyHeaders(bearer map[string]string, negotiated, session string) map[string]string {
+	headers := withContentType(bearer)
+	headers["MCP-Protocol-Version"] = negotiated
+	headers["Mcp-Session-Id"] = session
+	return headers
+}
+
+// A gateway routes on the header and this server executes the body. When the
+// two disagree the request is refused at the edge — before the tool the header
+// named, and before the tool the body named, runs at all.
+//
+// The status and the body are one answer: a dual-era client reads a 400 and
+// looks for a recognized modern error inside it, so a bare 400 would send a
+// working client back to the handshake.
+func TestAModernRequestWhoseHeaderContradictsItsBodyRunsNothing(t *testing.T) {
+	e := setupConnector(t)
+	bearer := passportBearer(t, e.AppEnv, "mismatching client", "read", "write")
+
+	refused := mcpRaw(e.AppEnv, t, http.MethodPost, "/mcp",
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{`+modernMeta+
+			`,"name":"create_record","arguments":{"record_type":"person",`+
+			`"fields":{"full_name":"Never Created"}}}}`,
+		// The header names a read, the body calls a write.
+		modernHeaders(bearer, "tools/call", "read_record"))
+
+	if refused.StatusCode != http.StatusBadRequest {
+		t.Fatalf("mismatched header → %d %s, want 400", refused.StatusCode, refused.Body)
+	}
+	if code := rpcErrorCode(t, refused.Body); code != -32020 {
+		t.Errorf("error code = %d, want -32020 HeaderMismatch", code)
+	}
+	var created int
+	if err := e.Owner.QueryRow(t.Context(),
+		`SELECT count(*) FROM person WHERE full_name = $1`, "Never Created").Scan(&created); err != nil {
+		t.Fatal(err)
+	}
+	if created != 0 {
+		t.Errorf("the refused call created %d record(s) — it was refused after it ran", created)
+	}
+}
+
+// The compatibility window is a decision a client can read rather than
+// discover by breaking: a revision outside it is refused with the list of
+// revisions that are inside it, both eras included.
+func TestARevisionOutsideTheWindowIsRefusedWithTheSupportedList(t *testing.T) {
+	e := setupConnector(t)
+	bearer := passportBearer(t, e.AppEnv, "stale client", "read")
+
+	headers := withContentType(bearer)
+	headers["MCP-Protocol-Version"] = "2025-03-26"
+	refused := mcpRaw(e.AppEnv, t, http.MethodPost, "/mcp",
+		`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`, headers)
+
+	if refused.StatusCode != http.StatusBadRequest {
+		t.Fatalf("the dropped revision → %d %s, want 400", refused.StatusCode, refused.Body)
+	}
+	if code := rpcErrorCode(t, refused.Body); code != -32022 {
+		t.Fatalf("error code = %d, want -32022 UnsupportedProtocolVersion", code)
+	}
+	for _, served := range []string{modernRevision, "2025-11-25", "2025-06-18"} {
+		if !strings.Contains(refused.Body, served) {
+			t.Errorf("the refusal %s does not name %q, so the client cannot retry on it", refused.Body, served)
+		}
+	}
+}
+
+// rpcErrorCode reads the JSON-RPC error code off a refusal. It is the mirror
+// of rpcResult, which fails ON an error member — here the error IS the answer
+// under test.
+func rpcErrorCode(t *testing.T, body string) int {
+	t.Helper()
+	var envelope struct {
+		Error *struct {
+			Code int `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(body), &envelope); err != nil {
+		t.Fatalf("refusal does not decode as JSON-RPC: %v (%s)", err, body)
+	}
+	if envelope.Error == nil {
+		t.Fatalf("refusal carries no JSON-RPC error member, so a dual-era client reads it as a legacy server: %s", body)
+	}
+	return envelope.Error.Code
+}

--- a/backend/internal/compose/integration/mcp_modernframing_integration_test.go
+++ b/backend/internal/compose/integration/mcp_modernframing_integration_test.go
@@ -132,6 +132,27 @@ func TestBothFramingsConnectAndLandTheSameEffect(t *testing.T) {
 		}
 	})
 
+	t.Run("a revision outside the window connects in neither", func(t *testing.T) {
+		// The deny arm belongs beside the allow arms: the same origin, the same
+		// credential, and the one revision the window dropped (ADR-0092 §3).
+		headers := withContentType(bearer)
+		headers["MCP-Protocol-Version"] = "2025-03-26"
+		refused := mcpRaw(e.AppEnv, t, http.MethodPost, "/mcp",
+			`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`, headers)
+
+		if refused.StatusCode != http.StatusBadRequest {
+			t.Fatalf("the dropped revision → %d %s, want 400", refused.StatusCode, refused.Body)
+		}
+		if code := rpcErrorCode(t, refused.Body); code != -32022 {
+			t.Fatalf("error code = %d, want -32022 UnsupportedProtocolVersion", code)
+		}
+		for _, served := range []string{modernRevision, "2025-11-25", "2025-06-18"} {
+			if !strings.Contains(refused.Body, served) {
+				t.Errorf("the refusal %s does not name %q, so the client cannot retry on it", refused.Body, served)
+			}
+		}
+	})
+
 	// Both eras ended in a real effect or the assertions above were satisfied
 	// by a surface answering from nothing.
 	for _, created := range []string{"Modern Framing Person", "Handshake Era Person"} {
@@ -195,31 +216,6 @@ func TestAModernRequestWhoseHeaderContradictsItsBodyRunsNothing(t *testing.T) {
 	}
 	if created != 0 {
 		t.Errorf("the refused call created %d record(s) — it was refused after it ran", created)
-	}
-}
-
-// The compatibility window is a decision a client can read rather than
-// discover by breaking: a revision outside it is refused with the list of
-// revisions that are inside it, both eras included.
-func TestARevisionOutsideTheWindowIsRefusedWithTheSupportedList(t *testing.T) {
-	e := setupConnector(t)
-	bearer := passportBearer(t, e.AppEnv, "stale client", "read")
-
-	headers := withContentType(bearer)
-	headers["MCP-Protocol-Version"] = "2025-03-26"
-	refused := mcpRaw(e.AppEnv, t, http.MethodPost, "/mcp",
-		`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`, headers)
-
-	if refused.StatusCode != http.StatusBadRequest {
-		t.Fatalf("the dropped revision → %d %s, want 400", refused.StatusCode, refused.Body)
-	}
-	if code := rpcErrorCode(t, refused.Body); code != -32022 {
-		t.Fatalf("error code = %d, want -32022 UnsupportedProtocolVersion", code)
-	}
-	for _, served := range []string{modernRevision, "2025-11-25", "2025-06-18"} {
-		if !strings.Contains(refused.Body, served) {
-			t.Errorf("the refusal %s does not name %q, so the client cannot retry on it", refused.Body, served)
-		}
 	}
 }
 

--- a/backend/internal/modules/agents/conformance_test.go
+++ b/backend/internal/modules/agents/conformance_test.go
@@ -250,7 +250,7 @@ func TestInitializeDoesNotClaimAListChangedItCannotSend(t *testing.T) {
 
 	resp := s.handle(context.Background(), rpcRequest{
 		JSONRPC: jsonRPCVersion, ID: json.RawMessage(`1`), Method: methodInitialize,
-	})
+	}, legacyFraming)
 
 	result, ok := resp.Result.(map[string]any)
 	if !ok {

--- a/backend/internal/modules/agents/dispatch.go
+++ b/backend/internal/modules/agents/dispatch.go
@@ -24,11 +24,9 @@ package agents
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"log/slog"
 	"slices"
 
-	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 	"github.com/gradionhq/margince/backend/internal/shared/ports/mcp"
 )
 
@@ -148,11 +146,19 @@ type rpcError struct {
 	Code    int    `json:"code"`
 	Message string `json:"message"`
 	// Data carries the structured half of an error a client is expected to act
-	// on rather than display — the version list an UnsupportedProtocolVersion
-	// refusal must name, today. It is omitted when there is nothing to act on,
-	// and it is a JSON object rather than `any` so the wire shape of an error
-	// stays as constrained as the wire shape of a result.
-	Data map[string]any `json:"data,omitempty"`
+	// on rather than display. It is omitted when there is nothing to act on,
+	// and it is TYPED so the wire shape of an error stays as constrained as the
+	// wire shape of a result.
+	Data *rpcErrorData `json:"data,omitempty"`
+}
+
+// rpcErrorData is every structured member a JSON-RPC error on this surface can
+// carry. There is exactly one producer today — the UnsupportedProtocolVersion
+// refusal, whose whole point is that a client can read `supported` and retry —
+// and naming the shape keeps the next one from being an open map.
+type rpcErrorData struct {
+	Supported []string `json:"supported,omitempty"`
+	Requested string   `json:"requested,omitempty"`
 }
 
 type rpcResponse struct {
@@ -263,7 +269,14 @@ func (s *Dispatcher) initialize(rawParams json.RawMessage) (map[string]any, *rpc
 	// negotiator's absent-value default rather than an error.
 	if len(rawParams) > 0 {
 		if err := json.Unmarshal(rawParams, &params); err != nil {
-			return nil, &rpcError{Code: codeInvalidParams, Message: "invalid params: " + err.Error()}
+			// The decoder's own message names Go types, which is server-side
+			// detail an untrusted client has no use for. It is told what to
+			// send instead.
+			s.log.Warn("mcp: initialize params did not decode", "err", err)
+			return nil, &rpcError{
+				Code:    codeInvalidParams,
+				Message: `invalid params: initialize takes an object whose "protocolVersion" is a string`,
+			}
 		}
 	}
 	return map[string]any{
@@ -296,108 +309,6 @@ func (s *Dispatcher) capabilities() map[string]any {
 // initialize result, the modern era in every result's _meta.
 func (s *Dispatcher) identity() map[string]any {
 	return map[string]any{fieldName: s.name, "version": s.version}
-}
-
-// invocableByCaller reports whether the calling principal's passport scopes
-// would let it invoke spec at all. It mirrors the scope arm of auth.Gate.Admit
-// deliberately — a surface that advertises what the gate will refuse is a
-// surface that lies, and the client's only way to discover the truth is to
-// call and be denied.
-//
-// It answers the SCOPE axis only, which is what §5.7 promises. The seat
-// ceiling and object RBAC are re-derived per call through the authority seam
-// and are a named follow-up (§10.2); this filter must not pretend to enforce
-// them, and Registry.Invoke remains the authority for every one of them.
-//
-// A ctx with no principal shows nothing rather than everything: the caller of
-// a tools/list that never authenticated has no scopes, and an empty surface is
-// the honest answer.
-func invocableByCaller(ctx context.Context, spec mcp.ToolSpec) bool {
-	p, ok := principal.Actor(ctx)
-	if !ok {
-		return false
-	}
-	// Humans and the system principal do not ride the scope model — their
-	// authority is their RBAC, enforced at the store — so filtering them by a
-	// passport scope they never carry would hide the whole surface.
-	if p.Type != principal.PrincipalAgent {
-		return true
-	}
-	return p.Scopes.Has(spec.RequiredScope)
-}
-
-// DescribeForClient is the description one tool is advertised with: what the
-// tool is FOR, written on its spec, followed by how this server will govern the
-// call. It is exported because tools/list is not the only surface that serves
-// it — the operator console reads the same text through GET /v1/agent-tools,
-// and a second rendering there would be a second answer to what a client is
-// told.
-//
-// The order is the point. The written text answers the question a model is
-// actually asking — which of thirty tools serves this goal — and the governance
-// clause answers what happens once it has chosen. A description carrying only
-// the second tells a model the passport scope of every tool and the purpose of
-// none.
-//
-// The tier and scope are re-stated from the spec the admission gate enforces,
-// so they cannot disagree with it. The crm.yaml operation family is NOT here:
-// it is developer documentation, and a model has no use for the name of an
-// endpoint it has no way to call. It stays on ToolSpec.OpenAPIOp, which is what
-// the contract-parity gate reads.
-func DescribeForClient(spec mcp.ToolSpec) string {
-	// Every arm is named, and the fallthrough is the CONSERVATIVE reading, not
-	// the convenient one: the admission gate treats anything that is not
-	// TierAutoExecute as confirm-first, so a tier added without updating this
-	// switch must not be advertised as running unattended. The same posture
-	// tierWire takes on the REST side, for the same reason.
-	tier := "a person approves every call before it runs"
-	switch spec.Tier {
-	case mcp.TierAutoExecute:
-		tier = "runs immediately"
-	case mcp.TierConfirmationRequired:
-		tier = "a person approves every call before it runs"
-	case mcp.TierDynamic:
-		tier = "some calls run immediately and others a person approves first, decided per call from its arguments"
-	}
-	return fmt.Sprintf("%s (Governance: %s; requires passport scope %q.)", spec.Description, tier, spec.RequiredScope)
-}
-
-func (s *Dispatcher) toolList(ctx context.Context) []map[string]any {
-	specs := s.registry.Specs()
-	tools := make([]map[string]any, 0, len(specs))
-	for _, spec := range specs {
-		if !invocableByCaller(ctx, spec) {
-			continue
-		}
-		tool := map[string]any{
-			fieldName: spec.Name,
-			// Top-level title outranks annotations.title for display, and both
-			// outrank the name. Registry.Register refuses a title-less tool, so
-			// neither is ever the empty string here.
-			fieldTitle:    spec.Title,
-			"description": DescribeForClient(spec),
-			"inputSchema": spec.InputSchema,
-			// The two hints this server can state as FACTS, both read off the
-			// spec the admission gate itself enforces rather than restated by
-			// hand: what a tool may change is its scope, and whether it leaves
-			// the workspace is its egress flag.
-			//
-			// destructiveHint and idempotentHint are deliberately absent: their
-			// protocol defaults (destructive, non-idempotent) are already the
-			// conservative reading, and only the looser value would need a
-			// per-tool judgement, with nothing to hold it true.
-			"annotations": map[string]any{
-				fieldTitle:      spec.Title,
-				"readOnlyHint":  spec.ReadOnly(),
-				"openWorldHint": spec.Egress,
-			},
-		}
-		if spec.OutputSchema != nil {
-			tool["outputSchema"] = spec.OutputSchema
-		}
-		tools = append(tools, tool)
-	}
-	return tools
 }
 
 func (s *Dispatcher) call(ctx context.Context, params json.RawMessage) map[string]any {

--- a/backend/internal/modules/agents/dispatch.go
+++ b/backend/internal/modules/agents/dispatch.go
@@ -38,13 +38,13 @@ import (
 // silently downgrades every client, so this is verified against the spec when
 // it changes.
 //
-// The window is written down rather than implied (ADR-0092 §3): 2025-03-26 is
-// dropped, so a client still on it falls back to the newest revision this
-// server offers instead of being served a framing nobody maintains. 2024-11-05
-// was never here — it predates Streamable HTTP (HTTP+SSE only), a transport
-// this server does not serve. The modern era is not in this list because it
-// establishes no session at all; it is modernProtocolVersion, and
-// supportedProtocolVersions is the two of them together.
+// The window is a written-down decision rather than an implied one (ADR-0092
+// §3), and it is exactly these two. A client on any older revision is answered
+// the newest of them instead of a framing nobody maintains; 2024-11-05 is
+// outside it for a second reason, since it predates Streamable HTTP (HTTP+SSE
+// only) and this server serves no other transport. The modern era is not in
+// this list because it establishes no session at all — it is
+// modernProtocolVersion, and supportedProtocolVersions is the two together.
 var legacyProtocolVersions = []string{"2025-11-25", "2025-06-18"}
 
 // The JSON-RPC and MCP wire tokens both framings repeat. Named once so a typo
@@ -149,8 +149,10 @@ type rpcError struct {
 	Message string `json:"message"`
 	// Data carries the structured half of an error a client is expected to act
 	// on rather than display — the version list an UnsupportedProtocolVersion
-	// refusal must name, today. It is omitted when there is nothing to act on.
-	Data any `json:"data,omitempty"`
+	// refusal must name, today. It is omitted when there is nothing to act on,
+	// and it is a JSON object rather than `any` so the wire shape of an error
+	// stays as constrained as the wire shape of a result.
+	Data map[string]any `json:"data,omitempty"`
 }
 
 type rpcResponse struct {
@@ -173,33 +175,22 @@ func (s *Dispatcher) handle(ctx context.Context, req rpcRequest, fr framing) rpc
 }
 
 func (s *Dispatcher) dispatch(ctx context.Context, req rpcRequest, fr framing) rpcResponse {
+	if answered, owned := s.eraOwned(req, fr); owned {
+		return answered
+	}
 	resp := rpcResponse{JSONRPC: jsonRPCVersion, ID: req.ID}
-	switch {
-	// initialize and server/discover are each one era's own method. Answering
-	// either in the other framing would tell a client it had reached a server
-	// of the era it was probing for, which is exactly the question those two
-	// calls exist to settle.
-	case req.Method == methodInitialize && !fr.modern:
-		if result, rpcErr := s.initialize(req.Params); rpcErr != nil {
-			resp.Error = rpcErr
-		} else {
-			resp.Result = result
-		}
-	case req.Method == methodDiscover && fr.modern:
-		resp.Result = s.discover()
-	case req.Method == methodPing:
-		resp.Result = map[string]any{}
-	case req.Method == methodToolsList:
+	switch req.Method {
+	case methodToolsList:
 		resp.Result = map[string]any{"tools": s.toolList(ctx)}
-	case req.Method == methodToolsCall:
+	case methodToolsCall:
 		resp.Result = s.call(ctx, req.Params)
-	case req.Method == methodResourcesList:
+	case methodResourcesList:
 		// Answered even with no provider wired: claude.ai calls this right
 		// after initialize regardless, and an unadvertised capability
 		// answering -32601 there reads as a broken server rather than a
 		// legitimate empty catalog.
 		resp.Result = map[string]any{"resources": s.resourceList(ctx)}
-	case req.Method == methodResourcesRead:
+	case methodResourcesRead:
 		// Assigned on separate branches so a failed read never carries a
 		// result alongside its error, which JSON-RPC forbids.
 		if result, rpcErr := s.readResource(ctx, req.Params); rpcErr != nil {
@@ -207,14 +198,57 @@ func (s *Dispatcher) dispatch(ctx context.Context, req rpcRequest, fr framing) r
 		} else {
 			resp.Result = result
 		}
-	case req.Method == methodResourceTemplatesList:
+	case methodResourceTemplatesList:
 		resp.Result = map[string]any{"resourceTemplates": []any{}}
-	case req.Method == methodPromptsList:
+	case methodPromptsList:
 		resp.Result = map[string]any{"prompts": []any{}}
 	default:
-		resp.Error = &rpcError{Code: codeMethodNotFound, Message: "method not found: " + req.Method}
+		return methodNotFound(req)
 	}
 	return resp
+}
+
+// eraOwned answers the calls that exist in ONE framing only, and reports
+// whether the method was one of them at all.
+//
+// Each era's opening call belongs here because answering the other era's would
+// tell a client it had reached the kind of server it was probing for, which is
+// exactly the question those two calls exist to settle. ping is here for a
+// different reason: the 2026-07-28 revision REMOVED it along with the handshake
+// it kept alive, so it stays answered only in the era that still defines it.
+func (s *Dispatcher) eraOwned(req rpcRequest, fr framing) (rpcResponse, bool) {
+	resp := rpcResponse{JSONRPC: jsonRPCVersion, ID: req.ID}
+	switch req.Method {
+	case methodInitialize:
+		if fr.modern {
+			return methodNotFound(req), true
+		}
+		if result, rpcErr := s.initialize(req.Params); rpcErr != nil {
+			resp.Error = rpcErr
+		} else {
+			resp.Result = result
+		}
+	case methodDiscover:
+		if !fr.modern {
+			return methodNotFound(req), true
+		}
+		resp.Result = s.discover()
+	case methodPing:
+		if fr.modern {
+			return methodNotFound(req), true
+		}
+		resp.Result = map[string]any{}
+	default:
+		return rpcResponse{}, false
+	}
+	return resp, true
+}
+
+func methodNotFound(req rpcRequest) rpcResponse {
+	return rpcResponse{
+		JSONRPC: jsonRPCVersion, ID: req.ID,
+		Error: &rpcError{Code: codeMethodNotFound, Message: "method not found: " + req.Method},
+	}
 }
 
 // initialize answers the handshake era's opening call: the revision this

--- a/backend/internal/modules/agents/dispatch.go
+++ b/backend/internal/modules/agents/dispatch.go
@@ -4,10 +4,16 @@
 package agents
 
 // The MCP method dispatcher: the protocol subset a tools-only server needs —
-// initialize, tools/list, tools/call, ping — with every call routed through
-// the Registry, which means through the admission gate. Tool failures travel
-// IN-BAND as isError results (the agent should read them and adapt); only
-// malformed JSON-RPC is a protocol error.
+// tools/list, tools/call, ping, the resource reads, and each era's own opening
+// call — with every call routed through the Registry, which means through the
+// admission gate. Tool failures travel IN-BAND as isError results (the agent
+// should read them and adapt); only malformed JSON-RPC is a protocol error.
+//
+// It answers TWO framings, and the difference between them stops at parsing
+// and rendering: modern.go decides which era a request is in and what its
+// answer carries, while every arm below reaches records through the one
+// registry. A framing able to alter what a call may do would be a second
+// admission path, which ADR-0055 forbids.
 //
 // It owns no transport. httpmcp.go builds one of these per handler and feeds
 // it decoded requests, so method dispatch, the tool surface and the
@@ -26,29 +32,36 @@ import (
 	"github.com/gradionhq/margince/backend/internal/shared/ports/mcp"
 )
 
-// supportedProtocolVersions are the MCP revisions this server satisfies,
-// NEWEST FIRST. initialize echoes the client's requested revision when we
-// support it and otherwise answers with the newest — a stale list silently
-// downgrades every modern client, so this is verified against the spec when
+// legacyProtocolVersions are the handshake-era MCP revisions this server
+// satisfies, NEWEST FIRST. initialize echoes the client's requested revision
+// when we support it and otherwise answers with the newest — a stale list
+// silently downgrades every client, so this is verified against the spec when
 // it changes.
 //
-// The list stops at 2025-11-25 on purpose: 2026-07-28 and later are a
-// different era — the spec's own terminology names them "modern" — with no
-// initialize handshake at all (the protocol version travels per-request in
-// the _meta key io.modelcontextprotocol/protocolVersion, server/discover is
-// mandatory, and a version mismatch answers UnsupportedProtocolVersionError
-// -32022). This server is "legacy": it establishes a session via initialize,
-// full stop. Prepending a modern revision here would advertise a handshake
-// this server does not honor; modern-era support is a named follow-up.
-// 2024-11-05 is excluded too — it predates Streamable HTTP (HTTP+SSE only),
-// a transport this server does not serve.
-var supportedProtocolVersions = []string{"2025-11-25", "2025-06-18", "2025-03-26"}
+// The window is written down rather than implied (ADR-0092 §3): 2025-03-26 is
+// dropped, so a client still on it falls back to the newest revision this
+// server offers instead of being served a framing nobody maintains. 2024-11-05
+// was never here — it predates Streamable HTTP (HTTP+SSE only), a transport
+// this server does not serve. The modern era is not in this list because it
+// establishes no session at all; it is modernProtocolVersion, and
+// supportedProtocolVersions is the two of them together.
+var legacyProtocolVersions = []string{"2025-11-25", "2025-06-18"}
 
-// The JSON-RPC and MCP wire tokens both transports repeat. Named once so a
-// typo in one of them cannot make a handler answer a member no client reads.
+// The JSON-RPC and MCP wire tokens both framings repeat. Named once so a typo
+// in one of them cannot make a handler answer a member no client reads — and,
+// for the method names, so the dispatch switch and the caching contract in
+// modern.go cannot name two different sets of methods.
 const (
-	jsonRPCVersion   = "2.0"
-	methodInitialize = "initialize"
+	jsonRPCVersion              = "2.0"
+	methodInitialize            = "initialize"
+	methodPing                  = "ping"
+	methodDiscover              = "server/discover"
+	methodToolsList             = "tools/list"
+	methodToolsCall             = "tools/call"
+	methodResourcesList         = "resources/list"
+	methodResourcesRead         = "resources/read"
+	methodResourceTemplatesList = "resources/templates/list"
+	methodPromptsList           = "prompts/list"
 	// fieldName is the "name" member of both serverInfo and a tools/list
 	// entry — the same identifier in both, so it stays one spelling.
 	fieldName = "name"
@@ -61,15 +74,17 @@ const (
 	fieldTitle = "title"
 )
 
-// negotiateProtocolVersion answers the client's requested MCP revision when
-// this server satisfies it, and otherwise the newest revision this server
-// satisfies — never the client's unsupported one, which would silently
-// promise a handshake we cannot honor.
-func negotiateProtocolVersion(requested string) string {
-	if slices.Contains(supportedProtocolVersions, requested) {
+// negotiateLegacyVersion answers the client's requested MCP revision when this
+// server satisfies it in the handshake era, and otherwise the newest one it
+// does — never the client's unsupported one, which would silently promise a
+// handshake we cannot honor. It never answers the modern revision: initialize
+// is the legacy era's own method, and a client that reached it has already
+// told us which era it speaks.
+func negotiateLegacyVersion(requested string) string {
+	if slices.Contains(legacyProtocolVersions, requested) {
 		return requested
 	}
-	return supportedProtocolVersions[0]
+	return legacyProtocolVersions[0]
 }
 
 // Binder authenticates one tool call: it returns a context carrying the
@@ -132,6 +147,10 @@ type rpcRequest struct {
 type rpcError struct {
 	Code    int    `json:"code"`
 	Message string `json:"message"`
+	// Data carries the structured half of an error a client is expected to act
+	// on rather than display — the version list an UnsupportedProtocolVersion
+	// refusal must name, today. It is omitted when there is nothing to act on.
+	Data any `json:"data,omitempty"`
 }
 
 type rpcResponse struct {
@@ -141,52 +160,46 @@ type rpcResponse struct {
 	Error   *rpcError       `json:"error,omitempty"`
 }
 
-func (s *Dispatcher) handle(ctx context.Context, req rpcRequest) rpcResponse {
+// handle answers one decoded request in the framing the transport decided for
+// it. The framing chooses which methods exist and how the answer is rendered;
+// every arm below that reaches a record reaches it through the same registry,
+// so it cannot choose what the call may do.
+func (s *Dispatcher) handle(ctx context.Context, req rpcRequest, fr framing) rpcResponse {
+	resp := s.dispatch(ctx, req, fr)
+	if fr.modern {
+		return s.finishModern(resp, req.Method)
+	}
+	return resp
+}
+
+func (s *Dispatcher) dispatch(ctx context.Context, req rpcRequest, fr framing) rpcResponse {
 	resp := rpcResponse{JSONRPC: jsonRPCVersion, ID: req.ID}
-	switch req.Method {
-	case methodInitialize:
-		var params struct {
-			//nolint:tagliatelle // protocolVersion is the MCP wire member, camelCase by the protocol
-			ProtocolVersion string `json:"protocolVersion"`
+	switch {
+	// initialize and server/discover are each one era's own method. Answering
+	// either in the other framing would tell a client it had reached a server
+	// of the era it was probing for, which is exactly the question those two
+	// calls exist to settle.
+	case req.Method == methodInitialize && !fr.modern:
+		if result, rpcErr := s.initialize(req.Params); rpcErr != nil {
+			resp.Error = rpcErr
+		} else {
+			resp.Result = result
 		}
-		// Params is optional on the wire; only unmarshal when the client sent
-		// some, so an omitted field (not malformed JSON) falls through to the
-		// negotiator's absent-value default rather than an error.
-		if len(req.Params) > 0 {
-			if err := json.Unmarshal(req.Params, &params); err != nil {
-				resp.Error = &rpcError{Code: -32602, Message: "invalid params: " + err.Error()}
-				return resp
-			}
-		}
-		// listChanged is FALSE on both capabilities because this server has no
-		// way to send the notification: notifications/*/list_changed travels
-		// on the GET SSE stream, and GET /mcp answers 405 here. Both surfaces
-		// really do change — each is filtered per caller — so the claim would
-		// promise a message that can never arrive.
-		capabilities := map[string]any{"tools": map[string]any{"listChanged": false}}
-		if s.resources != nil {
-			// subscribe is FALSE for the same reason, and separately: a
-			// per-caller document has no shared state to subscribe to.
-			capabilities["resources"] = map[string]any{"listChanged": false, "subscribe": false}
-		}
-		resp.Result = map[string]any{
-			"protocolVersion": negotiateProtocolVersion(params.ProtocolVersion),
-			"capabilities":    capabilities,
-			"serverInfo":      map[string]any{fieldName: s.name, "version": s.version},
-		}
-	case "ping":
+	case req.Method == methodDiscover && fr.modern:
+		resp.Result = s.discover()
+	case req.Method == methodPing:
 		resp.Result = map[string]any{}
-	case "tools/list":
+	case req.Method == methodToolsList:
 		resp.Result = map[string]any{"tools": s.toolList(ctx)}
-	case "tools/call":
+	case req.Method == methodToolsCall:
 		resp.Result = s.call(ctx, req.Params)
-	case "resources/list":
+	case req.Method == methodResourcesList:
 		// Answered even with no provider wired: claude.ai calls this right
 		// after initialize regardless, and an unadvertised capability
 		// answering -32601 there reads as a broken server rather than a
 		// legitimate empty catalog.
 		resp.Result = map[string]any{"resources": s.resourceList(ctx)}
-	case "resources/read":
+	case req.Method == methodResourcesRead:
 		// Assigned on separate branches so a failed read never carries a
 		// result alongside its error, which JSON-RPC forbids.
 		if result, rpcErr := s.readResource(ctx, req.Params); rpcErr != nil {
@@ -194,14 +207,61 @@ func (s *Dispatcher) handle(ctx context.Context, req rpcRequest) rpcResponse {
 		} else {
 			resp.Result = result
 		}
-	case "resources/templates/list":
+	case req.Method == methodResourceTemplatesList:
 		resp.Result = map[string]any{"resourceTemplates": []any{}}
-	case "prompts/list":
+	case req.Method == methodPromptsList:
 		resp.Result = map[string]any{"prompts": []any{}}
 	default:
-		resp.Error = &rpcError{Code: -32601, Message: "method not found: " + req.Method}
+		resp.Error = &rpcError{Code: codeMethodNotFound, Message: "method not found: " + req.Method}
 	}
 	return resp
+}
+
+// initialize answers the handshake era's opening call: the revision this
+// server will speak with THIS client, what it can do, and who it is.
+func (s *Dispatcher) initialize(rawParams json.RawMessage) (map[string]any, *rpcError) {
+	var params struct {
+		//nolint:tagliatelle // protocolVersion is the MCP wire member, camelCase by the protocol
+		ProtocolVersion string `json:"protocolVersion"`
+	}
+	// Params is optional on the wire; only unmarshal when the client sent
+	// some, so an omitted field (not malformed JSON) falls through to the
+	// negotiator's absent-value default rather than an error.
+	if len(rawParams) > 0 {
+		if err := json.Unmarshal(rawParams, &params); err != nil {
+			return nil, &rpcError{Code: codeInvalidParams, Message: "invalid params: " + err.Error()}
+		}
+	}
+	return map[string]any{
+		"protocolVersion": negotiateLegacyVersion(params.ProtocolVersion),
+		"capabilities":    s.capabilities(),
+		"serverInfo":      s.identity(),
+	}, nil
+}
+
+// capabilities is what this server claims it can do, answered identically to
+// both eras — initialize reports it to a handshake client and server/discover
+// to a modern one, and two spellings of one claim is how a client ends up
+// told different things by the same server.
+//
+// listChanged is FALSE on both entries because this server has no way to send
+// the notification: notifications/*/list_changed travels on a stream this
+// transport does not open. Both surfaces really do change — each is filtered
+// per caller — so the claim would promise a message that can never arrive.
+func (s *Dispatcher) capabilities() map[string]any {
+	capabilities := map[string]any{"tools": map[string]any{"listChanged": false}}
+	if s.resources != nil {
+		// subscribe is FALSE for the same reason, and separately: a
+		// per-caller document has no shared state to subscribe to.
+		capabilities["resources"] = map[string]any{"listChanged": false, "subscribe": false}
+	}
+	return capabilities
+}
+
+// identity is the serverInfo both framings report — the handshake era in its
+// initialize result, the modern era in every result's _meta.
+func (s *Dispatcher) identity() map[string]any {
+	return map[string]any{fieldName: s.name, "version": s.version}
 }
 
 // invocableByCaller reports whether the calling principal's passport scopes

--- a/backend/internal/modules/agents/dispatch_test.go
+++ b/backend/internal/modules/agents/dispatch_test.go
@@ -247,8 +247,8 @@ func TestToolListAdvertisesOnlyWhatTheCallersScopesAdmit(t *testing.T) {
 
 	listed := func(ctx context.Context) []string {
 		resp := s.handle(ctx, rpcRequest{
-			JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "tools/list",
-		})
+			JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: methodToolsList,
+		}, legacyFraming)
 		result, ok := resp.Result.(map[string]any)
 		if !ok {
 			t.Fatalf("result = %#v", resp.Result)
@@ -303,11 +303,19 @@ func TestInitializeNegotiatesTheClientsProtocolRevision(t *testing.T) {
 	s := NewDispatcher(NewRegistry(nil, nil), bindAuthenticated, "margince-crm", "test")
 	for _, tc := range []struct{ name, requested, want string }{
 		{
-			"echoes a supported revision", supportedProtocolVersions[len(supportedProtocolVersions)-1],
-			supportedProtocolVersions[len(supportedProtocolVersions)-1],
+			"echoes a supported revision", legacyProtocolVersions[len(legacyProtocolVersions)-1],
+			legacyProtocolVersions[len(legacyProtocolVersions)-1],
 		},
-		{"newest when unsupported", "1999-01-01", supportedProtocolVersions[0]},
-		{"newest when absent", "", supportedProtocolVersions[0]},
+		{"newest when unsupported", "1999-01-01", legacyProtocolVersions[0]},
+		{"newest when absent", "", legacyProtocolVersions[0]},
+		// A revision the window dropped is not served back to the client that
+		// asked for it: it gets the newest one this server does speak, which
+		// is the only answer a handshake can honour.
+		{"the dropped 2025-03-26 falls back", "2025-03-26", legacyProtocolVersions[0]},
+		// initialize is the handshake era's own call, so it never negotiates
+		// the modern revision — that one is declared per request and needs no
+		// handshake at all.
+		{"never the modern revision", modernProtocolVersion, legacyProtocolVersions[0]},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			params := `{}`
@@ -315,9 +323,9 @@ func TestInitializeNegotiatesTheClientsProtocolRevision(t *testing.T) {
 				params = fmt.Sprintf(`{"protocolVersion":%q}`, tc.requested)
 			}
 			resp := s.handle(context.Background(), rpcRequest{
-				JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: "initialize",
+				JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: methodInitialize,
 				Params: json.RawMessage(params),
-			})
+			}, legacyFraming)
 			result, ok := resp.Result.(map[string]any)
 			if !ok {
 				t.Fatalf("result = %#v", resp.Result)

--- a/backend/internal/modules/agents/httpmcp.go
+++ b/backend/internal/modules/agents/httpmcp.go
@@ -177,12 +177,18 @@ func ResourceMetadataChallenge(r *http.Request) string {
 	return `Bearer resource_metadata="` + httpserver.RequestOrigin(r) + `/.well-known/oauth-protected-resource", scope="read draft"` // NOSONAR: RFC 9728 challenge, not a secret
 }
 
-// writeRPCResponse writes one JSON-RPC response, framed per the client's
-// Accept header (DESIGN §5.3): `text/event-stream` gets a single `data:`
-// frame and then the stream closes — there is no ongoing push on this
+// writeRPCResponse writes one JSON-RPC response under status, framed per the
+// client's Accept header (DESIGN §5.3): `text/event-stream` gets a single
+// `data:` frame and then the stream closes — there is no ongoing push on this
 // path, only the one exchange the request asked for. Anything else,
 // including an absent Accept, gets the plain JSON body.
-func writeRPCResponse(w http.ResponseWriter, r *http.Request, resp rpcResponse) {
+//
+// The status is a parameter because the modern framing pins one for several of
+// its answers — 400 for a malformed or mismatched request, 404 for a method
+// this server does not answer — and it is those statuses, together with a
+// recognized JSON-RPC error body, that let a dual-era client tell a modern
+// server from a legacy one.
+func writeRPCResponse(w http.ResponseWriter, r *http.Request, resp rpcResponse, status int) {
 	body, err := json.Marshal(resp)
 	if err != nil {
 		// Every field of resp is a type this package constructs (rpcResponse,
@@ -198,11 +204,13 @@ func writeRPCResponse(w http.ResponseWriter, r *http.Request, resp rpcResponse) 
 	}
 	if strings.Contains(r.Header.Get("Accept"), "text/event-stream") {
 		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(status)
 		//craft:ignore swallowed-errors a failed write means the client hung up — there is no channel left to report on
 		_, _ = w.Write([]byte("data: " + string(body) + "\n\n"))
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
 	//craft:ignore swallowed-errors a failed write of the JSON-RPC result means the client hung up
 	_, _ = w.Write(body)
 }
@@ -321,12 +329,15 @@ func (h *httpMCPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.servePost(w, r)
 }
 
-// servePost handles the one JSON-RPC exchange a POST carries: parse,
-// negotiate the protocol version, dispatch through the shared stdio
-// handler, and — on a successful initialize — mint and register the
-// session this connection now owns.
+// servePost handles the one JSON-RPC exchange a POST carries: parse, decide
+// which framing the request is in, hold it to that framing's preconditions,
+// and dispatch.
+//
+// The era is decided HERE and nowhere else, and it travels down as a value.
+// Deciding it twice is how the two framings would start to disagree about a
+// request, and the framing decides how a call is parsed — never what it may
+// do, which is the registry's business either way.
 func (h *httpMCPHandler) servePost(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
 	body, err := io.ReadAll(io.LimitReader(r.Body, 8<<20))
 	if err != nil {
 		httperr.Write(w, r, &httperr.DetailedError{
@@ -338,29 +349,25 @@ func (h *httpMCPHandler) servePost(w http.ResponseWriter, r *http.Request) {
 	}
 	var req rpcRequest
 	if err := json.Unmarshal(body, &req); err != nil {
-		writeRPCResponse(w, r, rpcResponse{JSONRPC: jsonRPCVersion, Error: &rpcError{Code: -32700, Message: "parse error"}})
+		writeRPCResponse(w, r,
+			rpcResponse{JSONRPC: jsonRPCVersion, Error: &rpcError{Code: -32700, Message: "parse error"}},
+			http.StatusOK)
 		return
 	}
-	// A present-and-unsupported MCP-Protocol-Version is refused with a
-	// plain 400 whose body is prose, NEVER a modern-era -32022
-	// UnsupportedProtocolVersionError: the spec has a dual-era client
-	// identify a legacy server by seeing a 4xx without a recognized
-	// modern error body, and only then fall back to initialize. A -32022
-	// body would read as a modern server rejecting a mismatched version,
-	// so the client would retry with a modern (handshake-free,
-	// _meta-carrying) request this server can never serve — turning a
-	// working fallback into a hard failure. initialize itself is exempt:
-	// negotiation for that call happens through its own request body,
-	// not this header, and older clients omit the header entirely until
-	// they have a negotiated version to send.
-	if v := r.Header.Get("MCP-Protocol-Version"); req.Method != methodInitialize && v != "" &&
-		!slices.Contains(supportedProtocolVersions, v) {
-		httperr.Write(w, r, &httperr.DetailedError{
-			Status: http.StatusBadRequest,
-			Code:   "unsupported_protocol_version",
-			Detail: "Unsupported MCP-Protocol-Version; this server supports: " +
-				strings.Join(supportedProtocolVersions, ", ") + ".",
-		})
+	fr, refusal := modernPrecheck(req.Params, r.Header.Get(headerProtocolVersion))
+	if refusal == nil && fr.modern {
+		refusal = validateModernHeaders(r.Header, req, fr)
+	}
+	if refusal != nil {
+		// Every modern precondition failure is a 400 carrying a recognized
+		// JSON-RPC error, which is the pair a dual-era client reads: the status
+		// alone would send it back to the handshake, and the body alone would
+		// not be seen.
+		writeRPCResponse(w, r, rpcResponse{JSONRPC: jsonRPCVersion, ID: req.ID, Error: refusal},
+			http.StatusBadRequest)
+		return
+	}
+	if !fr.modern && !h.legacyVersionServed(w, r, req) {
 		return
 	}
 	if req.ID == nil {
@@ -368,6 +375,35 @@ func (h *httpMCPHandler) servePost(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusAccepted)
 		return
 	}
+	h.exchange(w, r, req, fr)
+}
+
+// legacyVersionServed refuses a handshake-era request that names a revision
+// outside the compatibility window, and reports whether the caller may
+// proceed.
+//
+// The refusal is the modern -32022, listing every revision this server serves.
+// It used to be a prose 400 on purpose — a -32022 would have told a dual-era
+// client this was a modern server and sent it to a framing this server could
+// not answer. It can answer that framing now, so naming what is supported is
+// what actually helps: the client reads `supported` and retries rather than
+// guessing. initialize is exempt because it negotiates through its own body,
+// and a client has no version to put in this header until initialize has
+// answered one.
+func (h *httpMCPHandler) legacyVersionServed(w http.ResponseWriter, r *http.Request, req rpcRequest) bool {
+	v := r.Header.Get(headerProtocolVersion)
+	if req.Method == methodInitialize || v == "" || slices.Contains(legacyProtocolVersions, v) {
+		return true
+	}
+	writeRPCResponse(w, r,
+		rpcResponse{JSONRPC: jsonRPCVersion, ID: req.ID, Error: unsupportedProtocolVersion(v)},
+		http.StatusBadRequest)
+	return false
+}
+
+// exchange dispatches one request and writes its answer under the status its
+// framing pins.
+func (h *httpMCPHandler) exchange(w http.ResponseWriter, r *http.Request, req rpcRequest, fr framing) {
 	// A dynamic tool call can block on a model call, which modules/ai
 	// budgets at 120s per request; the api's server-wide WriteTimeout is
 	// 30s. Extend the deadline for THIS route only — raising the server's
@@ -382,11 +418,17 @@ func (h *httpMCPHandler) servePost(w http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
-	resp := h.server.handle(ctx, req)
-	if req.Method == methodInitialize && resp.Error == nil {
+	ctx := r.Context()
+	resp := h.server.handle(ctx, req, fr)
+	status := http.StatusOK
+	if fr.modern {
+		// A modern call mints no session: it carries its own state, and an
+		// Mcp-Session-Id it presented anyway is ignored rather than echoed.
+		status = modernStatus(resp)
+	} else if req.Method == methodInitialize && resp.Error == nil {
 		h.mintSession(ctx, w)
 	}
-	writeRPCResponse(w, r, resp)
+	writeRPCResponse(w, r, resp, status)
 }
 
 // mintSession registers a fresh session under the passport that just

--- a/backend/internal/modules/agents/httpmcp.go
+++ b/backend/internal/modules/agents/httpmcp.go
@@ -21,7 +21,6 @@ import (
 	"net/http"
 	"slices"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/gradionhq/margince/backend/internal/platform/httperr"
@@ -47,120 +46,6 @@ const mcpCallDeadline = 150 * time.Second
 // a module never imports a sibling: compose composes both and therefore owns
 // the classification (see compose/mcpedge.go).
 var ErrAuthUnavailable = errors.New("agents: the credential could not be verified")
-
-// sessionKey identifies one live MCP session. The session id ALONE is
-// deliberately not enough to act on (DESIGN §10.4): every request
-// re-authenticates via the Bearer passport, which is where authority
-// comes from, so the id itself is unvalidated. Pairing it with the
-// presenting passport means DELETE can only ever close a session that
-// passport itself opened — keying on the id alone would let any
-// authenticated agent close another connector's session by guessing or
-// replaying its value.
-type sessionKey struct {
-	passportID ids.UUID
-	sessionID  string
-}
-
-// The two caps that make the registry a BOUNDED structure. Without them
-// `initialize` (240/min per passport at the edge) grows it forever: nothing but
-// an exact-match DELETE ever removed an entry, a client that crashes or drops
-// its connection never sends one, and every refresh rotation brings a fresh
-// passport with a fresh allowance of its own. The symptom of the unbounded
-// version is an api whose memory climbs until it is restarted, with no metric
-// naming the cause.
-//
-// Per passport, because a client legitimately holds ONE session: the cap is
-// above one only so a client reconnecting before its DELETE lands is not
-// squeezed, and the OLDEST entry gives way rather than the newest being
-// refused — the newest is the session the client is actually using.
-//
-// Across the whole registry, because the passport dimension is otherwise
-// unbounded on its own. The per-passport cap is what keeps one credential from
-// evicting everyone else's sessions to reach the global one.
-const (
-	maxSessionsPerPassport = 8
-	maxSessions            = 4096
-)
-
-// sessionRegistry is in-process bookkeeping for open MCP sessions,
-// scoped to ONE handler instance rather than a package-level global —
-// a global would leak state between two handlers (or two tests) in the
-// same process.
-//
-// The value is the insertion SEQUENCE, which is what "evict the oldest" reads:
-// a counter rather than a timestamp, so eviction order is exact and needs no
-// clock to be deterministic in a test.
-type sessionRegistry struct {
-	mu       sync.Mutex
-	sessions map[sessionKey]uint64
-	inserted uint64
-}
-
-func newSessionRegistry() *sessionRegistry {
-	return &sessionRegistry{sessions: make(map[sessionKey]uint64)}
-}
-
-// register records a new session under the presenting passport, evicting
-// whatever the caps above require. An evicted entry only ever costs its owner a
-// 404 on a DELETE it may never send.
-func (r *sessionRegistry) register(passportID ids.UUID, sessionID string) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.evictForLocked(passportID)
-	r.inserted++
-	r.sessions[sessionKey{passportID, sessionID}] = r.inserted
-}
-
-// evictForLocked makes room for one more session under passportID: its own
-// oldest goes when that passport is at its cap, and otherwise the registry's
-// oldest goes when the whole map is at its. Both scans walk the map, which is
-// bounded by maxSessions by construction.
-func (r *sessionRegistry) evictForLocked(passportID ids.UUID) {
-	if r.evictOldestLocked(func(key sessionKey) bool { return key.passportID == passportID },
-		maxSessionsPerPassport) {
-		return
-	}
-	r.evictOldestLocked(func(sessionKey) bool { return true }, maxSessions)
-}
-
-// evictOldestLocked drops the lowest-sequence entry matching `counts` if at
-// least `limit` entries match it, and reports whether it evicted anything.
-func (r *sessionRegistry) evictOldestLocked(counts func(sessionKey) bool, limit int) bool {
-	matching := 0
-	var oldest sessionKey
-	oldestAt := uint64(0)
-	for key, at := range r.sessions {
-		if !counts(key) {
-			continue
-		}
-		matching++
-		if oldestAt == 0 || at < oldestAt {
-			oldest, oldestAt = key, at
-		}
-	}
-	if matching < limit {
-		return false
-	}
-	delete(r.sessions, oldest)
-	return true
-}
-
-// close removes the session sessionID owned by passportID. It reports
-// false, leaving the registry untouched, when no session exists under
-// that exact pair — including a sessionID that IS live but under a
-// different passport. Those two cases must read identically: telling
-// them apart would let a DELETE probe confirm another connector's
-// session id is currently open.
-func (r *sessionRegistry) close(passportID ids.UUID, sessionID string) bool {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	key := sessionKey{passportID, sessionID}
-	if _, ok := r.sessions[key]; !ok {
-		return false
-	}
-	delete(r.sessions, key)
-	return true
-}
 
 // ResourceMetadataChallenge builds the RFC 9728 WWW-Authenticate challenge a
 // 401 on this transport carries: the "Bearer" scheme name plus a pointer at
@@ -323,6 +208,14 @@ func (h *httpMCPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// this needs saying to the linter as well as to the reader.
 	r = r.WithContext(ctx) //nolint:contextcheck // ctx is derived from r.Context() inside the injected authenticate closure
 	if r.Method == http.MethodDelete {
+		if duplicatedVersionHeader(r.Header) {
+			httperr.Write(w, r, &httperr.DetailedError{
+				Status: http.StatusBadRequest,
+				Code:   "ambiguous_protocol_version",
+				Detail: "This request names more than one protocol version, so there is no version to act on.",
+			})
+			return
+		}
 		if servesAsModern(declaredTransportVersion(r.Header)) {
 			// The modern revision has no protocol-level session, so it has
 			// nothing to tear down. Answering 405 tells a client that named
@@ -372,6 +265,21 @@ func (h *httpMCPHandler) servePost(w http.ResponseWriter, r *http.Request) {
 		writeRPCResponse(w, r,
 			rpcResponse{JSONRPC: jsonRPCVersion, Error: &rpcError{Code: codeParseError, Message: "parse error"}},
 			status)
+		return
+	}
+	// Before either era looks at it: a version header sent twice has two
+	// readings, and no path here acts on one. The answer is a JSON-RPC error
+	// rather than a plain 4xx so a modern client recognizes it as this server
+	// refusing rather than as a legacy server to fall back to.
+	if duplicatedVersionHeader(r.Header) {
+		writeRPCResponse(w, r, rpcResponse{
+			JSONRPC: jsonRPCVersion, ID: req.ID,
+			Error: &rpcError{
+				Code: codeHeaderMismatch,
+				Message: "header mismatch: " + headerProtocolVersion + " was sent more than once, so this " +
+					"server and an intermediary between us could read different versions from it",
+			},
+		}, http.StatusBadRequest)
 		return
 	}
 	fr, refusal := modernPrecheck(req.Params, declaredTransportVersion(r.Header))

--- a/backend/internal/modules/agents/httpmcp.go
+++ b/backend/internal/modules/agents/httpmcp.go
@@ -361,9 +361,17 @@ func (h *httpMCPHandler) servePost(w http.ResponseWriter, r *http.Request) {
 	}
 	var req rpcRequest
 	if err := json.Unmarshal(body, &req); err != nil {
+		// The body is what normally decides the era, and this one does not
+		// decode, so the header is the only thing left that can say. A caller
+		// that named the modern revision gets the status that framing pins for
+		// a malformed request; anything else keeps the answer it always had.
+		status := http.StatusOK
+		if servesAsModern(r.Header.Get(headerProtocolVersion)) {
+			status = http.StatusBadRequest
+		}
 		writeRPCResponse(w, r,
 			rpcResponse{JSONRPC: jsonRPCVersion, Error: &rpcError{Code: codeParseError, Message: "parse error"}},
-			http.StatusOK)
+			status)
 		return
 	}
 	fr, refusal := modernPrecheck(req.Params, r.Header.Get(headerProtocolVersion))

--- a/backend/internal/modules/agents/httpmcp.go
+++ b/backend/internal/modules/agents/httpmcp.go
@@ -323,6 +323,18 @@ func (h *httpMCPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// this needs saying to the linter as well as to the reader.
 	r = r.WithContext(ctx) //nolint:contextcheck // ctx is derived from r.Context() inside the injected authenticate closure
 	if r.Method == http.MethodDelete {
+		if servesAsModern(r.Header.Get(headerProtocolVersion)) {
+			// The modern revision has no protocol-level session, so it has
+			// nothing to tear down. Answering 405 tells a client that named
+			// that revision what is true of it, rather than letting it close a
+			// session it could not have opened.
+			httperr.Write(w, r, &httperr.DetailedError{
+				Status: http.StatusMethodNotAllowed,
+				Code:   "method_not_allowed",
+				Detail: "This protocol revision establishes no session, so there is none to close.",
+			})
+			return
+		}
 		h.teardownSession(w, r)
 		return
 	}
@@ -350,7 +362,7 @@ func (h *httpMCPHandler) servePost(w http.ResponseWriter, r *http.Request) {
 	var req rpcRequest
 	if err := json.Unmarshal(body, &req); err != nil {
 		writeRPCResponse(w, r,
-			rpcResponse{JSONRPC: jsonRPCVersion, Error: &rpcError{Code: -32700, Message: "parse error"}},
+			rpcResponse{JSONRPC: jsonRPCVersion, Error: &rpcError{Code: codeParseError, Message: "parse error"}},
 			http.StatusOK)
 		return
 	}
@@ -371,7 +383,13 @@ func (h *httpMCPHandler) servePost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if req.ID == nil {
-		// A notification gets no response by JSON-RPC rule.
+		// A notification gets no response by JSON-RPC rule — but it is judged
+		// by the same framing rules first, which is why this sits below them.
+		// The 2026-07-28 revision leaves a notification's header requirements
+		// undefined and defines no client-to-server notification over this
+		// transport at all, so no conforming client reaches here; holding one
+		// to the request rules is the conservative reading, and inventing a
+		// laxer path would be a second way in.
 		w.WriteHeader(http.StatusAccepted)
 		return
 	}
@@ -382,14 +400,12 @@ func (h *httpMCPHandler) servePost(w http.ResponseWriter, r *http.Request) {
 // outside the compatibility window, and reports whether the caller may
 // proceed.
 //
-// The refusal is the modern -32022, listing every revision this server serves.
-// It used to be a prose 400 on purpose — a -32022 would have told a dual-era
-// client this was a modern server and sent it to a framing this server could
-// not answer. It can answer that framing now, so naming what is supported is
-// what actually helps: the client reads `supported` and retries rather than
-// guessing. initialize is exempt because it negotiates through its own body,
-// and a client has no version to put in this header until initialize has
-// answered one.
+// The refusal names every revision this server serves, in both eras, so the
+// client retries on one of them rather than guessing — which it can only do
+// because this server does answer the modern framing a dual-era client would
+// retry with. initialize is exempt: it negotiates through its own body, and a
+// client has no version to put in this header until initialize has answered
+// one.
 func (h *httpMCPHandler) legacyVersionServed(w http.ResponseWriter, r *http.Request, req rpcRequest) bool {
 	v := r.Header.Get(headerProtocolVersion)
 	if req.Method == methodInitialize || v == "" || slices.Contains(legacyProtocolVersions, v) {

--- a/backend/internal/modules/agents/httpmcp.go
+++ b/backend/internal/modules/agents/httpmcp.go
@@ -323,7 +323,7 @@ func (h *httpMCPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// this needs saying to the linter as well as to the reader.
 	r = r.WithContext(ctx) //nolint:contextcheck // ctx is derived from r.Context() inside the injected authenticate closure
 	if r.Method == http.MethodDelete {
-		if servesAsModern(r.Header.Get(headerProtocolVersion)) {
+		if servesAsModern(declaredTransportVersion(r.Header)) {
 			// The modern revision has no protocol-level session, so it has
 			// nothing to tear down. Answering 405 tells a client that named
 			// that revision what is true of it, rather than letting it close a
@@ -366,7 +366,7 @@ func (h *httpMCPHandler) servePost(w http.ResponseWriter, r *http.Request) {
 		// that named the modern revision gets the status that framing pins for
 		// a malformed request; anything else keeps the answer it always had.
 		status := http.StatusOK
-		if servesAsModern(r.Header.Get(headerProtocolVersion)) {
+		if servesAsModern(declaredTransportVersion(r.Header)) {
 			status = http.StatusBadRequest
 		}
 		writeRPCResponse(w, r,
@@ -374,7 +374,7 @@ func (h *httpMCPHandler) servePost(w http.ResponseWriter, r *http.Request) {
 			status)
 		return
 	}
-	fr, refusal := modernPrecheck(req.Params, r.Header.Get(headerProtocolVersion))
+	fr, refusal := modernPrecheck(req.Params, declaredTransportVersion(r.Header))
 	if refusal == nil && fr.modern {
 		refusal = validateModernHeaders(r.Header, req, fr)
 	}

--- a/backend/internal/modules/agents/httpmcp_test.go
+++ b/backend/internal/modules/agents/httpmcp_test.go
@@ -13,6 +13,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -112,31 +113,52 @@ func authenticatedForTest(*http.Request) (context.Context, error) {
 	return context.Background(), nil
 }
 
-// A present-and-unsupported MCP-Protocol-Version must be refused with a
-// plain 400 whose body is prose, never a modern-era -32022 body — a
-// -32022 body would tell a dual-era client this is a MODERN server, and it
-// would retry with a handshake-free request this legacy server cannot
-// serve, turning a working fallback into a hard failure.
-func TestUnsupportedProtocolVersionHeaderIsRejectedWithPlain400(t *testing.T) {
+// A handshake-era request naming a revision outside the compatibility window
+// is refused with a 400 carrying -32022 and the list of revisions this server
+// does serve. The list is what makes the refusal actionable: a client reads
+// `supported` and retries on one of them instead of guessing, and both eras
+// are in it because this server answers both.
+//
+// The dropped 2025-03-26 is in the table because dropping it is the visible
+// half of the compatibility window (ADR-0092 §3) — a client still on it must
+// be refused here rather than quietly served.
+func TestUnsupportedProtocolVersionHeaderIsRefusedWithTheSupportedList(t *testing.T) {
 	h := NewHTTPHandler(NewRegistry(nil, nil), authenticatedForTest,
 		func(*http.Request) string { return "" }, "margince-crm", "test", discardLog())
 
-	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"ping"}`))
-	req.Header.Set("MCP-Protocol-Version", "1999-01-01")
-	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, req)
+	for _, requested := range []string{"1999-01-01", "2025-03-26"} {
+		t.Run(requested, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/mcp",
+				strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"ping"}`))
+			req.Header.Set(headerProtocolVersion, requested)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusBadRequest {
-		t.Fatalf("status = %d, want 400", rec.Code)
-	}
-	body := rec.Body.String()
-	if strings.Contains(body, "-32022") || strings.Contains(body, "UnsupportedProtocolVersionError") {
-		t.Fatalf("body %q must not carry a modern-era -32022 error, or a dual-era client will retry a handshake this server does not serve", body)
-	}
-	for _, rev := range supportedProtocolVersions {
-		if !strings.Contains(body, rev) {
-			t.Errorf("body %q must name the supported revision %q", body, rev)
-		}
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400", rec.Code)
+			}
+			var resp struct {
+				Error struct {
+					Code int `json:"code"`
+					Data struct {
+						Supported []string `json:"supported"`
+						Requested string   `json:"requested"`
+					} `json:"data"`
+				} `json:"error"`
+			}
+			if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+				t.Fatalf("decoding %q: %v", rec.Body.String(), err)
+			}
+			if resp.Error.Code != codeUnsupportedProtocolVersion {
+				t.Errorf("error code = %d, want %d", resp.Error.Code, codeUnsupportedProtocolVersion)
+			}
+			if resp.Error.Data.Requested != requested {
+				t.Errorf("data.requested = %q, want %q", resp.Error.Data.Requested, requested)
+			}
+			if !slices.Equal(resp.Error.Data.Supported, supportedProtocolVersions()) {
+				t.Errorf("data.supported = %v, want %v", resp.Error.Data.Supported, supportedProtocolVersions())
+			}
+		})
 	}
 }
 
@@ -404,7 +426,7 @@ func TestResourcesAndPromptsAnswerEmptyRatherThanMethodNotFound(t *testing.T) {
 	for _, method := range []string{"resources/list", "resources/templates/list", "prompts/list"} {
 		resp := s.handle(context.Background(), rpcRequest{
 			JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: method,
-		})
+		}, legacyFraming)
 		if resp.Error != nil {
 			t.Errorf("%s → error %d %q, want an empty result", method, resp.Error.Code, resp.Error.Message)
 		}

--- a/backend/internal/modules/agents/httpmcp_test.go
+++ b/backend/internal/modules/agents/httpmcp_test.go
@@ -119,9 +119,14 @@ func authenticatedForTest(*http.Request) (context.Context, error) {
 // `supported` and retries on one of them instead of guessing, and both eras
 // are in it because this server answers both.
 //
-// The dropped 2025-03-26 is in the table because dropping it is the visible
-// half of the compatibility window (ADR-0092 §3) — a client still on it must
-// be refused here rather than quietly served.
+// 2025-03-26 is in the table because it is the revision the window dropped
+// (ADR-0092 §3) — but read what this actually proves. The header was
+// introduced in 2025-06-18, so a genuine 2025-03-26 client never sends one;
+// what is refused here is an implementation that knows the header and names a
+// revision outside the window. A header-LESS request is still served, because
+// the handshake-era revisions this server does serve only say a client SHOULD
+// send it, and refusing every client that omits it would break the era this
+// window exists to keep working.
 func TestUnsupportedProtocolVersionHeaderIsRefusedWithTheSupportedList(t *testing.T) {
 	h := NewHTTPHandler(NewRegistry(nil, nil), authenticatedForTest,
 		func(*http.Request) string { return "" }, "margince-crm", "test", discardLog())

--- a/backend/internal/modules/agents/httpmodern.go
+++ b/backend/internal/modules/agents/httpmodern.go
@@ -187,16 +187,26 @@ func headerMismatch(header, member string) *rpcError {
 	}
 }
 
-// declaredTransportVersion is the protocol version the transport names, and
-// the empty string when it names MORE than one.
+// duplicatedVersionHeader reports whether the transport named more than one
+// protocol version.
 //
-// A duplicated version header has two readings — Get answers the first, an
-// intermediary may route on the last — so it declares nothing this server will
-// act on. It is used wherever the header alone decides an era; the mirrored
-// comparison refuses the duplicate outright, so a request whose body already
-// declared itself modern is still caught rather than quietly demoted.
+// Nothing on this surface acts on such a request, in either era. Get answers
+// the first value while an intermediary may route on the last, so a version
+// header sent twice has two readings and no way to say which was meant — and
+// that is as true of a handshake-era request as of a modern one, which is why
+// this is checked before the era is decided rather than inside one framing.
+func duplicatedVersionHeader(header http.Header) bool {
+	return len(header.Values(headerProtocolVersion)) > 1
+}
+
+// declaredTransportVersion is the protocol version the transport names, and
+// the empty string when it names more than one.
+//
+// It is the same rule as above, for the one path that runs BEFORE the refusal:
+// a body that does not decode is answered without ever reaching the era check,
+// and a duplicated header must not select a framing's status there either.
 func declaredTransportVersion(header http.Header) string {
-	if len(header.Values(headerProtocolVersion)) != 1 {
+	if duplicatedVersionHeader(header) {
 		return ""
 	}
 	return header.Get(headerProtocolVersion)

--- a/backend/internal/modules/agents/httpmodern.go
+++ b/backend/internal/modules/agents/httpmodern.go
@@ -21,9 +21,11 @@ import (
 	"strings"
 )
 
-// The mirrored headers. Case is irrelevant on the wire (RFC 9110) and
-// http.Header canonicalizes on both sides of Get, so these are the canonical
-// spellings rather than a claim about what a client sends.
+// The mirrored headers, in the specification's own spelling — which is NOT
+// Go's canonical form for the first of them (textproto canonicalizes it to
+// Mcp-Protocol-Version). That difference is invisible because every read here
+// goes through http.Header.Get, which canonicalizes its argument; a direct map
+// index on one of these would silently miss.
 const (
 	headerProtocolVersion = "MCP-Protocol-Version"
 	headerMethod          = "Mcp-Method"
@@ -38,16 +40,51 @@ const (
 	base64SentinelSuffix = "?="
 )
 
-// modernNamedMethods maps each method whose body carries a name to the params
-// member holding it, which is what Mcp-Name mirrors.
+// mirroredName is how one method's name is read out of its params — and it is
+// deliberately the SAME reading its handler makes, not an equivalent one.
+//
+// This is the whole safety of the mirror. A map lookup and a struct decode do
+// not agree on a JSON object: encoding/json matches members case-insensitively
+// and takes the LAST of a duplicate pair, so a body carrying both
+// {"name":"harmless","NAME":"read_record"} reads as `harmless` to a map and as
+// `read_record` to the handler. Comparing the header against the first would
+// admit exactly the request the mirror exists to refuse — a gateway allowing
+// one tool while the server runs another.
+type mirroredName func(json.RawMessage) string
+
+// modernNamedMethods maps each method whose body carries a name to that reader.
 //
 // It lists the name-carrying methods THIS server answers. The specification
 // also names prompts/get; this server has no prompts and answers that -32601,
 // and demanding a header for a method that does not exist would refuse the
 // caller for the wrong reason.
-var modernNamedMethods = map[string]string{
-	methodToolsCall:     "name",
-	methodResourcesRead: "uri",
+var modernNamedMethods = map[string]mirroredName{
+	methodToolsCall:     calledToolName,
+	methodResourcesRead: readResourceURI,
+}
+
+// calledToolName reads the tool a tools/call body invokes, through the same
+// shape Dispatcher.call decodes.
+func calledToolName(params json.RawMessage) string {
+	var p struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(params, &p); err != nil {
+		return ""
+	}
+	return p.Name
+}
+
+// readResourceURI reads the document a resources/read body asks for, through
+// the same shape Dispatcher.readResource decodes.
+func readResourceURI(params json.RawMessage) string {
+	var p struct {
+		URI string `json:"uri"`
+	}
+	if err := json.Unmarshal(params, &p); err != nil {
+		return ""
+	}
+	return p.URI
 }
 
 // validateModernHeaders holds a modern request to the mirroring contract: the
@@ -68,46 +105,37 @@ func validateModernHeaders(header http.Header, req rpcRequest, fr framing) *rpcE
 	if header.Get(headerMethod) != req.Method {
 		return headerMismatch(headerMethod, "method")
 	}
-	member, named := modernNamedMethods[req.Method]
+	readName, named := modernNamedMethods[req.Method]
 	if !named {
+		// A method that mirrors no name must present none. A header naming a
+		// tool on a call that invokes none tells an intermediary metering or
+		// filtering on Mcp-Name about an invocation that never happens.
+		if header.Get(headerName) != "" {
+			return &rpcError{
+				Code: codeHeaderMismatch,
+				Message: "header mismatch: " + headerName + " names something on a method whose body " +
+					"names nothing, so it describes a call this server will not make",
+			}
+		}
 		return nil
 	}
-	return validateMirroredName(header.Get(headerName), req.Params, member)
+	return validateMirroredName(header.Get(headerName), req.Params, readName)
 }
 
-// validateMirroredName compares the Mcp-Name header with the params member it
-// mirrors. Absent on both sides is admissible: a body that names nothing is
-// answered by the dispatcher, which can say what is actually missing, and a
-// header requirement here would report the wrong fault.
-func validateMirroredName(presented string, params json.RawMessage, member string) *rpcError {
-	inBody := paramsMember(params, member)
-	if presented == "" && inBody == "" {
-		return nil
-	}
+// validateMirroredName compares the Mcp-Name header with the name its method's
+// handler will act on.
+//
+// The header is REQUIRED on every one of these methods, not merely when the
+// body happens to name something: an absent one is a validation failure in its
+// own right. A body that names nothing therefore cannot be rescued by a client
+// that also sends nothing — and it would be malformed anyway, since the name is
+// the one param each of these methods cannot be called without.
+func validateMirroredName(presented string, params json.RawMessage, readName mirroredName) *rpcError {
 	decoded, ok := decodeHeaderValue(presented)
-	if !ok || decoded != inBody {
-		return headerMismatch(headerName, "params."+member)
+	if presented == "" || !ok || decoded != readName(params) {
+		return headerMismatch(headerName, "the name its own body invokes")
 	}
 	return nil
-}
-
-// paramsMember reads one string member out of a request's params, answering
-// the empty string when the params are absent, are not an object, or hold
-// something other than a string there. Each of those is a body that does not
-// name what the header claims, which is the only question this file asks.
-func paramsMember(params json.RawMessage, member string) string {
-	if len(params) == 0 {
-		return ""
-	}
-	var members map[string]json.RawMessage
-	if err := json.Unmarshal(params, &members); err != nil {
-		return ""
-	}
-	var value string
-	if err := json.Unmarshal(members[member], &value); err != nil {
-		return ""
-	}
-	return value
 }
 
 // decodeHeaderValue resolves the Base64 sentinel a client must use for any
@@ -137,8 +165,8 @@ func decodeHeaderValue(presented string) (string, bool) {
 func headerMismatch(header, member string) *rpcError {
 	return &rpcError{
 		Code: codeHeaderMismatch,
-		Message: "header mismatch: " + header + " is missing or does not match " + member +
-			" in the request body, which is what this server executes",
+		Message: "header mismatch: " + header + " is missing or disagrees with " + member +
+			", and the body is what this server executes",
 	}
 }
 

--- a/backend/internal/modules/agents/httpmodern.go
+++ b/backend/internal/modules/agents/httpmodern.go
@@ -99,6 +99,19 @@ func readResourceURI(params json.RawMessage) string {
 // its length is not, and naming the header and the member it contradicts is
 // what a client author acts on anyway.
 func validateModernHeaders(header http.Header, req rpcRequest, fr framing) *rpcError {
+	// A mirrored header sent TWICE is the same defect as a body member sent
+	// twice, one layer up: Get answers the first value while an intermediary
+	// may route on the last, so the two readings can disagree with nothing on
+	// the wire to say which was meant. One value or none.
+	for _, mirrored := range []string{headerProtocolVersion, headerMethod, headerName} {
+		if len(header.Values(mirrored)) > 1 {
+			return &rpcError{
+				Code: codeHeaderMismatch,
+				Message: "header mismatch: " + mirrored + " was sent more than once, so this server " +
+					"and an intermediary between us could read different values from it",
+			}
+		}
+	}
 	if header.Get(headerProtocolVersion) != fr.version {
 		return headerMismatch(headerProtocolVersion, "_meta["+metaProtocolVersion+"]")
 	}

--- a/backend/internal/modules/agents/httpmodern.go
+++ b/backend/internal/modules/agents/httpmodern.go
@@ -145,7 +145,11 @@ func validateModernHeaders(header http.Header, req rpcRequest, fr framing) *rpcE
 // the one param each of these methods cannot be called without.
 func validateMirroredName(presented string, params json.RawMessage, readName mirroredName) *rpcError {
 	decoded, ok := decodeHeaderValue(presented)
-	if presented == "" || !ok || decoded != readName(params) {
+	// The DECODED value carries the emptiness test, not the presented one:
+	// `=?base64??=` is a non-empty header that decodes to nothing, and it would
+	// otherwise agree with a body that names nothing — leaving an intermediary
+	// metering an empty name the mirror was supposed to have refused.
+	if !ok || decoded == "" || decoded != readName(params) {
 		return headerMismatch(headerName, "the name its own body invokes")
 	}
 	return nil
@@ -181,6 +185,21 @@ func headerMismatch(header, member string) *rpcError {
 		Message: "header mismatch: " + header + " is missing or disagrees with " + member +
 			", and the body is what this server executes",
 	}
+}
+
+// declaredTransportVersion is the protocol version the transport names, and
+// the empty string when it names MORE than one.
+//
+// A duplicated version header has two readings — Get answers the first, an
+// intermediary may route on the last — so it declares nothing this server will
+// act on. It is used wherever the header alone decides an era; the mirrored
+// comparison refuses the duplicate outright, so a request whose body already
+// declared itself modern is still caught rather than quietly demoted.
+func declaredTransportVersion(header http.Header) string {
+	if len(header.Values(headerProtocolVersion)) != 1 {
+		return ""
+	}
+	return header.Get(headerProtocolVersion)
 }
 
 // modernStatus is the HTTP status one dispatched modern response carries. An

--- a/backend/internal/modules/agents/httpmodern.go
+++ b/backend/internal/modules/agents/httpmodern.go
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// The transport half of the 2026-07-28 framing: the headers a modern POST
+// mirrors its body into, and the HTTP status each answer carries.
+//
+// Why mirroring is checked at all, rather than trusted or ignored: the headers
+// exist so an intermediary can route and rate-limit without parsing the body,
+// and the body remains what this server executes. A request whose header says
+// one tool and whose body calls another is the shape where those two readings
+// part company — a gateway allows what a server then does not run, or the
+// reverse. The specification closes it by making the server compare, and
+// answer -32020 when they disagree.
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"strings"
+)
+
+// The mirrored headers. Case is irrelevant on the wire (RFC 9110) and
+// http.Header canonicalizes on both sides of Get, so these are the canonical
+// spellings rather than a claim about what a client sends.
+const (
+	headerProtocolVersion = "MCP-Protocol-Version"
+	headerMethod          = "Mcp-Method"
+	headerName            = "Mcp-Name"
+)
+
+// The sentinel that wraps a header value a client had to Base64-encode —
+// because it is not plain ASCII, is padded with whitespace, or would itself
+// have looked like this sentinel.
+const (
+	base64SentinelPrefix = "=?base64?"
+	base64SentinelSuffix = "?="
+)
+
+// modernNamedMethods maps each method whose body carries a name to the params
+// member holding it, which is what Mcp-Name mirrors.
+//
+// It lists the name-carrying methods THIS server answers. The specification
+// also names prompts/get; this server has no prompts and answers that -32601,
+// and demanding a header for a method that does not exist would refuse the
+// caller for the wrong reason.
+var modernNamedMethods = map[string]string{
+	methodToolsCall:     "name",
+	methodResourcesRead: "uri",
+}
+
+// validateModernHeaders holds a modern request to the mirroring contract: the
+// required headers are present, and each says the same thing its body does.
+//
+// It answers a refusal rather than writing one, so the transport keeps the one
+// place that decides a status. It runs AFTER the body precheck because the
+// body is the source of truth — a request that has not yet declared a version
+// has nothing for a header to disagree with.
+//
+// No refusal echoes the value it read. The header is caller-controlled and
+// its length is not, and naming the header and the member it contradicts is
+// what a client author acts on anyway.
+func validateModernHeaders(header http.Header, req rpcRequest, fr framing) *rpcError {
+	if header.Get(headerProtocolVersion) != fr.version {
+		return headerMismatch(headerProtocolVersion, "_meta["+metaProtocolVersion+"]")
+	}
+	if header.Get(headerMethod) != req.Method {
+		return headerMismatch(headerMethod, "method")
+	}
+	member, named := modernNamedMethods[req.Method]
+	if !named {
+		return nil
+	}
+	return validateMirroredName(header.Get(headerName), req.Params, member)
+}
+
+// validateMirroredName compares the Mcp-Name header with the params member it
+// mirrors. Absent on both sides is admissible: a body that names nothing is
+// answered by the dispatcher, which can say what is actually missing, and a
+// header requirement here would report the wrong fault.
+func validateMirroredName(presented string, params json.RawMessage, member string) *rpcError {
+	inBody := paramsMember(params, member)
+	if presented == "" && inBody == "" {
+		return nil
+	}
+	decoded, ok := decodeHeaderValue(presented)
+	if !ok || decoded != inBody {
+		return headerMismatch(headerName, "params."+member)
+	}
+	return nil
+}
+
+// paramsMember reads one string member out of a request's params, answering
+// the empty string when the params are absent, are not an object, or hold
+// something other than a string there. Each of those is a body that does not
+// name what the header claims, which is the only question this file asks.
+func paramsMember(params json.RawMessage, member string) string {
+	if len(params) == 0 {
+		return ""
+	}
+	var members map[string]json.RawMessage
+	if err := json.Unmarshal(params, &members); err != nil {
+		return ""
+	}
+	var value string
+	if err := json.Unmarshal(members[member], &value); err != nil {
+		return ""
+	}
+	return value
+}
+
+// decodeHeaderValue resolves the Base64 sentinel a client must use for any
+// value that cannot travel as plain ASCII, and reports whether the value could
+// be read at all.
+//
+// A value that merely looks like the sentinel is not treated as a literal:
+// clients are required to encode even a plain-ASCII value that matches the
+// pattern, so an undecodable one is a malformed header rather than a name that
+// happens to spell it.
+func decodeHeaderValue(presented string) (string, bool) {
+	payload, wrapped := strings.CutPrefix(presented, base64SentinelPrefix)
+	if !wrapped {
+		return presented, true
+	}
+	payload, wrapped = strings.CutSuffix(payload, base64SentinelSuffix)
+	if !wrapped {
+		return presented, true
+	}
+	decoded, err := base64.StdEncoding.DecodeString(payload)
+	if err != nil {
+		return "", false
+	}
+	return string(decoded), true
+}
+
+func headerMismatch(header, member string) *rpcError {
+	return &rpcError{
+		Code: codeHeaderMismatch,
+		Message: "header mismatch: " + header + " is missing or does not match " + member +
+			" in the request body, which is what this server executes",
+	}
+}
+
+// modernStatus is the HTTP status one dispatched modern response carries. An
+// unknown method answers 404 with its JSON-RPC error, which is how a dual-era
+// client tells a modern server that lacks the method from a legacy server that
+// does not host the endpoint at all.
+func modernStatus(resp rpcResponse) int {
+	if resp.Error != nil && resp.Error.Code == codeMethodNotFound {
+		return http.StatusNotFound
+	}
+	return http.StatusOK
+}

--- a/backend/internal/modules/agents/httpmodern_test.go
+++ b/backend/internal/modules/agents/httpmodern_test.go
@@ -455,6 +455,68 @@ func TestTheMirrorComparesTheNameTheDispatcherWillExecute(t *testing.T) {
 	}
 }
 
+// A mirrored header sent twice is the same defect as a body member sent twice,
+// one layer up: Get answers the first value while an intermediary may route on
+// the last, and nothing on the wire says which was meant.
+func TestAMirroredHeaderSentTwiceIsRefused(t *testing.T) {
+	srv := modernServer(t)
+	for _, mirrored := range []string{headerProtocolVersion, headerMethod, headerName} {
+		t.Run(mirrored, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodPost, srv.URL, strings.NewReader(modernCallBody))
+			if err != nil {
+				t.Fatalf("NewRequest: %v", err)
+			}
+			for name, value := range modernCallHeaders() {
+				req.Header.Set(name, value)
+			}
+			// A second value that AGREES with the first is still refused: the
+			// point is that two readings exist, not that they differ.
+			req.Header.Add(mirrored, req.Header.Get(mirrored))
+
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("Do: %v", err)
+			}
+			defer func() {
+				if err := resp.Body.Close(); err != nil {
+					t.Errorf("closing response body: %v", err)
+				}
+			}()
+
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400", resp.StatusCode)
+			}
+		})
+	}
+}
+
+// A body that does not decode leaves the header as the only thing that can say
+// which era the caller meant, and a caller that named the modern revision is
+// owed that framing's status for a malformed request.
+func TestAMalformedBodyAnswers400WhenTheHeaderNamesTheModernRevision(t *testing.T) {
+	srv := modernServer(t)
+	for _, tc := range []struct {
+		name       string
+		version    string
+		wantStatus int
+	}{
+		{"named modern", modernProtocolVersion, http.StatusBadRequest},
+		{"named nothing", "", http.StatusOK},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			status, body := modernPOST(t, srv, `{"jsonrpc":"2.0","id":1,`,
+				map[string]string{headerProtocolVersion: tc.version})
+
+			if status != tc.wantStatus {
+				t.Errorf("status = %d, want %d", status, tc.wantStatus)
+			}
+			if got := errorCode(t, body); got != codeParseError {
+				t.Errorf("code = %d, want %d", got, codeParseError)
+			}
+		})
+	}
+}
+
 // A method that mirrors no name must present none. A header naming a tool on a
 // call that invokes none tells an intermediary metering or filtering on
 // Mcp-Name about an invocation that never happens.

--- a/backend/internal/modules/agents/httpmodern_test.go
+++ b/backend/internal/modules/agents/httpmodern_test.go
@@ -562,6 +562,48 @@ func TestADuplicatedVersionHeaderDeclaresNoEra(t *testing.T) {
 	}
 }
 
+// And no path acts on one at all. The demotion above keeps a duplicated header
+// from CHOOSING an era; this is the refusal that keeps either era from serving
+// it, including the handshake path, which reads the header with its own Get and
+// would otherwise act on whichever value came first.
+func TestNoVerbActsOnADuplicatedVersionHeader(t *testing.T) {
+	srv := modernServer(t)
+	for _, tc := range []struct{ name, method, body string }{
+		// A legacy-framed POST: no _meta, and a version that IS in the window,
+		// so nothing but the duplication can refuse it.
+		{"a handshake-era POST", http.MethodPost, `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`},
+		{"a session teardown", http.MethodDelete, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var body io.Reader
+			if tc.body != "" {
+				body = strings.NewReader(tc.body)
+			}
+			req, err := http.NewRequest(tc.method, srv.URL, body)
+			if err != nil {
+				t.Fatalf("NewRequest: %v", err)
+			}
+			req.Header.Add(headerProtocolVersion, legacyProtocolVersions[0])
+			req.Header.Add(headerProtocolVersion, "1999-01-01")
+			req.Header.Set("Mcp-Session-Id", "01234567-89ab-cdef-0123-456789abcdef")
+
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("Do: %v", err)
+			}
+			defer func() {
+				if err := resp.Body.Close(); err != nil {
+					t.Errorf("closing response body: %v", err)
+				}
+			}()
+
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400", resp.StatusCode)
+			}
+		})
+	}
+}
+
 // A method that mirrors no name must present none. A header naming a tool on a
 // call that invokes none tells an intermediary metering or filtering on
 // Mcp-Name about an invocation that never happens.

--- a/backend/internal/modules/agents/httpmodern_test.go
+++ b/backend/internal/modules/agents/httpmodern_test.go
@@ -1,0 +1,417 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// The transport half of the modern framing: the headers a POST mirrors its
+// body into, and the statuses that let a dual-era client tell which kind of
+// server it reached.
+//
+// Every case here drives a real listener rather than httptest.NewRecorder,
+// because dispatch extends the write deadline through http.ResponseController
+// and the recorder's ResponseWriter does not implement it.
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// modernServer is the /mcp transport over one read tool, with the caller
+// authenticated as an agent holding the read scope — the tool list and the
+// call both need one, since an unauthenticated caller is shown nothing.
+func modernServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	registry := NewRegistry(nil, auth.NewGate(fullSeatAuthority{}))
+	registry.Register(echoTool{
+		spec: objectSpec("read_record", principal.ScopeRead),
+		out:  json.RawMessage(`{"ok":true}`),
+	})
+	h := NewHTTPHandler(registry,
+		func(r *http.Request) (context.Context, error) {
+			return principal.WithActor(principal.WithWorkspaceID(r.Context(), ids.NewV7()),
+				principal.Principal{
+					Type: principal.PrincipalAgent, ID: "agent:modern", OnBehalfOf: ids.NewV7(),
+					Scopes: principal.NewScopeSet(principal.ScopeRead),
+				}), nil
+		},
+		func(*http.Request) string { return "" }, "margince-crm", "test", discardLog())
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// modernPOST sends one modern request, letting a caller bend any header the
+// mirroring contract is about.
+func modernPOST(t *testing.T, srv *httptest.Server, body string, headers map[string]string) (int, map[string]json.RawMessage) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, srv.URL, strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	for name, value := range headers {
+		if value == "" {
+			req.Header.Del(name)
+			continue
+		}
+		req.Header.Set(name, value)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			t.Errorf("closing response body: %v", err)
+		}
+	}()
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("reading the response: %v", err)
+	}
+	var decoded map[string]json.RawMessage
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &decoded); err != nil {
+			t.Fatalf("decoding %q: %v", raw, err)
+		}
+	}
+	return resp.StatusCode, decoded
+}
+
+// modernCallBody is a conforming tools/call, and modernCallHeaders the headers
+// that mirror it. Every case below starts from this pair and breaks one thing.
+const modernCallBody = `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{` +
+	modernMetaJSON + `,"name":"read_record","arguments":{}}}`
+
+func modernCallHeaders() map[string]string {
+	return map[string]string{
+		headerProtocolVersion: modernProtocolVersion,
+		headerMethod:          "tools/call",
+		headerName:            "read_record",
+	}
+}
+
+// errorCode reads the JSON-RPC error code off a response, or fails when the
+// response carries none.
+func errorCode(t *testing.T, body map[string]json.RawMessage) int {
+	t.Helper()
+	var rpcErr struct {
+		Code int `json:"code"`
+	}
+	if err := json.Unmarshal(body["error"], &rpcErr); err != nil {
+		t.Fatalf("no JSON-RPC error in %v: %v", body, err)
+	}
+	return rpcErr.Code
+}
+
+// The headers exist so an intermediary can route without parsing the body,
+// and the body is what this server executes. Every case here is that pair
+// disagreeing — a gateway that allowed one tool while the server ran another,
+// or a required header a router had nothing to read.
+func TestAModernPostMustMirrorItsBodyIntoItsHeaders(t *testing.T) {
+	srv := modernServer(t)
+	for _, tc := range []struct {
+		name  string
+		bend  map[string]string
+		wantK int
+	}{
+		{"the protocol version header is absent", map[string]string{headerProtocolVersion: ""}, codeHeaderMismatch},
+		{
+			"the protocol version header names another revision than the body",
+			map[string]string{headerProtocolVersion: "2025-11-25"},
+			codeHeaderMismatch,
+		},
+		{"the method header is absent", map[string]string{headerMethod: ""}, codeHeaderMismatch},
+		{
+			"the method header names another method than the body",
+			map[string]string{headerMethod: "tools/list"},
+			codeHeaderMismatch,
+		},
+		{"the name header is absent", map[string]string{headerName: ""}, codeHeaderMismatch},
+		{
+			"the name header names another TOOL than the body calls",
+			map[string]string{headerName: "send_email"},
+			codeHeaderMismatch,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			headers := modernCallHeaders()
+			for name, value := range tc.bend {
+				headers[name] = value
+			}
+
+			status, body := modernPOST(t, srv, modernCallBody, headers)
+
+			if status != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400", status)
+			}
+			if got := errorCode(t, body); got != tc.wantK {
+				t.Errorf("code = %d, want %d", got, tc.wantK)
+			}
+			if _, answered := body["result"]; answered {
+				t.Error("a refused request was answered as well as refused")
+			}
+		})
+	}
+}
+
+// A conforming modern call is served, and it mints no session: a modern call
+// carries its own state, so there is no id to hand back and nothing pinning
+// the conversation to this replica.
+func TestAConformingModernCallIsServedAndMintsNoSession(t *testing.T) {
+	srv := modernServer(t)
+	req, err := http.NewRequest(http.MethodPost, srv.URL, strings.NewReader(modernCallBody))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	for name, value := range modernCallHeaders() {
+		req.Header.Set(name, value)
+	}
+	// A client that presented one anyway is ignored rather than echoed.
+	req.Header.Set("Mcp-Session-Id", "01234567-89ab-cdef-0123-456789abcdef")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			t.Errorf("closing response body: %v", err)
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		refused, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("status = %d, and its body could not be read: %v", resp.StatusCode, err)
+		}
+		t.Fatalf("status = %d (%s), want 200", resp.StatusCode, refused)
+	}
+	if got := resp.Header.Get("Mcp-Session-Id"); got != "" {
+		t.Errorf("Mcp-Session-Id = %q — a modern call establishes no session", got)
+	}
+}
+
+// A name that cannot travel as plain ASCII arrives Base64-wrapped, and the
+// server decodes before comparing. A value that only LOOKS like the sentinel
+// is not a literal: clients must encode even a plain-ASCII value matching the
+// pattern, so one that does not decode is a malformed header.
+func TestAMirroredNameMayArriveBase64Encoded(t *testing.T) {
+	srv := modernServer(t)
+	body := `{"jsonrpc":"2.0","id":1,"method":"resources/read","params":{` +
+		modernMetaJSON + `,"uri":"margince://schema/query"}}`
+	encoded := base64SentinelPrefix +
+		base64.StdEncoding.EncodeToString([]byte("margince://schema/query")) + base64SentinelSuffix
+
+	for _, tc := range []struct {
+		name      string
+		presented string
+		wantCode  int
+	}{
+		// No provider is wired, so a mirrored name that MATCHES reaches the
+		// dispatcher and earns the modern resource-not-found code. That it got
+		// that far is the assertion: the header was accepted.
+		{"decoded and matching", encoded, codeInvalidParams},
+		{"decoded and naming another document", base64SentinelPrefix +
+			base64.StdEncoding.EncodeToString([]byte("margince://schema/other")) + base64SentinelSuffix, codeHeaderMismatch},
+		{"wrapped in the sentinel but not decodable", base64SentinelPrefix + "!!!not-base64!!!" + base64SentinelSuffix, codeHeaderMismatch},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, answered := modernPOST(t, srv, body, map[string]string{
+				headerProtocolVersion: modernProtocolVersion,
+				headerMethod:          "resources/read",
+				headerName:            tc.presented,
+			})
+
+			if got := errorCode(t, answered); got != tc.wantCode {
+				t.Errorf("code = %d, want %d", got, tc.wantCode)
+			}
+		})
+	}
+}
+
+// The statuses are how a dual-era client tells this server apart from a legacy
+// one that does not host the endpoint at all: a modern refusal is a 4xx
+// carrying a recognized JSON-RPC error, and anything else sends the client
+// back to the handshake.
+func TestModernRefusalsCarryTheStatusTheirClientReads(t *testing.T) {
+	srv := modernServer(t)
+	for _, tc := range []struct {
+		name       string
+		body       string
+		headers    map[string]string
+		wantStatus int
+		wantCode   int
+	}{
+		{
+			"a method this server does not answer",
+			`{"jsonrpc":"2.0","id":1,"method":"tools/rename","params":{` + modernMetaJSON + `}}`,
+			map[string]string{headerProtocolVersion: modernProtocolVersion, headerMethod: "tools/rename"},
+			http.StatusNotFound, codeMethodNotFound,
+		},
+		{
+			"a body that declares no version under a header that does",
+			`{"jsonrpc":"2.0","id":1,"method":"ping","params":{}}`,
+			map[string]string{headerProtocolVersion: modernProtocolVersion, headerMethod: "ping"},
+			http.StatusBadRequest, codeInvalidParams,
+		},
+		{
+			"a version this server does not serve per request",
+			`{"jsonrpc":"2.0","id":1,"method":"ping","params":{"_meta":{` +
+				`"io.modelcontextprotocol/protocolVersion":"2099-01-01",` +
+				`"io.modelcontextprotocol/clientCapabilities":{}}}}`,
+			map[string]string{headerProtocolVersion: "2099-01-01", headerMethod: "ping"},
+			http.StatusBadRequest, codeUnsupportedProtocolVersion,
+		},
+		{
+			"the handshake era's own opening call, sent modern",
+			`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{` + modernMetaJSON + `}}`,
+			map[string]string{headerProtocolVersion: modernProtocolVersion, headerMethod: "initialize"},
+			http.StatusNotFound, codeMethodNotFound,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			status, body := modernPOST(t, srv, tc.body, tc.headers)
+
+			if status != tc.wantStatus {
+				t.Errorf("status = %d, want %d", status, tc.wantStatus)
+			}
+			if got := errorCode(t, body); got != tc.wantCode {
+				t.Errorf("code = %d, want %d", got, tc.wantCode)
+			}
+		})
+	}
+}
+
+// The handshake era is untouched by any of this: a legacy client still
+// initializes, is answered a legacy revision, and is handed the session id it
+// closes with DELETE.
+func TestTheHandshakeEraStillOpensASession(t *testing.T) {
+	srv := modernServer(t)
+	req, err := http.NewRequest(http.MethodPost, srv.URL,
+		strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25"}}`))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			t.Errorf("closing response body: %v", err)
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if resp.Header.Get("Mcp-Session-Id") == "" {
+		t.Error("initialize minted no session id — the handshake era still needs one")
+	}
+	var answered struct {
+		Result struct {
+			//nolint:tagliatelle // protocolVersion is the MCP wire member, camelCase by the protocol
+			ProtocolVersion string `json:"protocolVersion"`
+			//nolint:tagliatelle // resultType is the modern framing's member, absent here on purpose
+			ResultType string `json:"resultType"`
+		} `json:"result"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&answered); err != nil {
+		t.Fatalf("decoding the handshake: %v", err)
+	}
+	if answered.Result.ProtocolVersion != "2025-11-25" {
+		t.Errorf("negotiated %q, want the revision the client asked for", answered.Result.ProtocolVersion)
+	}
+	if answered.Result.ResultType != "" {
+		t.Errorf("a handshake result carries %q — that member belongs to the other era", answered.Result.ResultType)
+	}
+}
+
+// decodeHeaderValue's own cases, including the two the wire makes ambiguous.
+func TestDecodingAMirroredHeaderValue(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		presented string
+		want      string
+		wantOK    bool
+	}{
+		{"a plain value passes through", "read_record", "read_record", true},
+		{"a wrapped value is decoded", base64SentinelPrefix +
+			base64.StdEncoding.EncodeToString([]byte("Hello, 世界")) + base64SentinelSuffix, "Hello, 世界", true},
+		{"an unterminated sentinel is a plain value", "=?base64?read_record", "=?base64?read_record", true},
+		{"a wrapped value that is not base64 cannot be read", base64SentinelPrefix + "%%%" + base64SentinelSuffix, "", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := decodeHeaderValue(tc.presented)
+
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if got != tc.want {
+				t.Errorf("decoded = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// A body that names nothing is not a body that agrees with a header. Each
+// case here is a params shape that carries no readable name, and a header
+// presented against any of them is a mismatch rather than a match against the
+// empty string.
+func TestABodyThatNamesNothingMatchesNoPresentedHeader(t *testing.T) {
+	for _, tc := range []struct{ name, params string }{
+		{"params are not an object", `[1,2]`},
+		{"the member is absent", `{"arguments":{}}`},
+		{"the member is not a string", `{"name":42}`},
+		{"there are no params at all", ``},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			params := json.RawMessage(tc.params)
+			if tc.params == "" {
+				params = nil
+			}
+
+			if got := paramsMember(params, "name"); got != "" {
+				t.Fatalf("read %q out of a body that names nothing", got)
+			}
+			if refusal := validateMirroredName("read_record", params, "name"); refusal == nil {
+				t.Error("a presented name matched a body that carries none")
+			}
+			// And with nothing presented either, the dispatcher gets to report
+			// what is actually wrong with the body.
+			if refusal := validateMirroredName("", params, "name"); refusal != nil {
+				t.Errorf("refused %d %q, want the dispatcher to answer instead", refusal.Code, refusal.Message)
+			}
+		})
+	}
+}
+
+// No refusal echoes the value it read back at the caller. The header is
+// caller-controlled and its length is not, and naming the header and the
+// member it contradicts is what a client author acts on anyway.
+func TestAHeaderMismatchDoesNotEchoWhatTheCallerSent(t *testing.T) {
+	srv := modernServer(t)
+	headers := modernCallHeaders()
+	headers[headerName] = strings.Repeat("A", 4096)
+
+	_, body := modernPOST(t, srv, modernCallBody, headers)
+
+	if strings.Contains(string(body["error"]), strings.Repeat("A", 32)) {
+		t.Errorf("the refusal echoed the caller's own header value: %s", body["error"])
+	}
+	if !strings.Contains(string(body["error"]), headerName) {
+		t.Errorf("the refusal %s must name the header that disagreed", body["error"])
+	}
+}

--- a/backend/internal/modules/agents/httpmodern_test.go
+++ b/backend/internal/modules/agents/httpmodern_test.go
@@ -225,6 +225,10 @@ func TestAMirroredNameMayArriveBase64Encoded(t *testing.T) {
 		{"decoded and naming another document", base64SentinelPrefix +
 			base64.StdEncoding.EncodeToString([]byte("margince://schema/other")) + base64SentinelSuffix, codeHeaderMismatch},
 		{"wrapped in the sentinel but not decodable", base64SentinelPrefix + "!!!not-base64!!!" + base64SentinelSuffix, codeHeaderMismatch},
+		// A non-empty header that decodes to NOTHING. It would agree with a
+		// body that names nothing, which is the one agreement this check must
+		// never admit — so the emptiness test is on the decoded value.
+		{"the sentinel wrapped around nothing", base64SentinelPrefix + base64SentinelSuffix, codeHeaderMismatch},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			_, answered := modernPOST(t, srv, body, map[string]string{
@@ -392,7 +396,9 @@ func TestABodyThatNamesNothingMatchesNoHeaderAtAll(t *testing.T) {
 				if got := readName(params); got != "" {
 					t.Fatalf("read %q out of a body that names nothing", got)
 				}
-				for _, presented := range []string{"read_record", ""} {
+				// The empty spelling and its Base64 disguise are the same value,
+				// and neither may agree with a body that names nothing.
+				for _, presented := range []string{"read_record", "", base64SentinelPrefix + base64SentinelSuffix} {
 					if refusal := validateMirroredName(presented, params, readName); refusal == nil {
 						t.Errorf("Mcp-Name %q was accepted against a body that carries no name", presented)
 					}
@@ -514,6 +520,45 @@ func TestAMalformedBodyAnswers400WhenTheHeaderNamesTheModernRevision(t *testing.
 				t.Errorf("code = %d, want %d", got, codeParseError)
 			}
 		})
+	}
+}
+
+// The no-two-readings rule reaches every place the header alone decides an era,
+// not only the mirrored comparison: a version header sent twice declares
+// nothing this server acts on, so it cannot select the modern framing's status
+// for a body that never decoded.
+func TestADuplicatedVersionHeaderDeclaresNoEra(t *testing.T) {
+	if got := declaredTransportVersion(http.Header{
+		http.CanonicalHeaderKey(headerProtocolVersion): []string{modernProtocolVersion, modernProtocolVersion},
+	}); got != "" {
+		t.Errorf("declared %q from a header sent twice, want nothing", got)
+	}
+	if got := declaredTransportVersion(http.Header{
+		http.CanonicalHeaderKey(headerProtocolVersion): []string{modernProtocolVersion},
+	}); got != modernProtocolVersion {
+		t.Errorf("declared %q, want %q", got, modernProtocolVersion)
+	}
+
+	srv := modernServer(t)
+	req, err := http.NewRequest(http.MethodPost, srv.URL, strings.NewReader(`{"jsonrpc":"2.0","id":1,`))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Add(headerProtocolVersion, modernProtocolVersion)
+	req.Header.Add(headerProtocolVersion, modernProtocolVersion)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			t.Errorf("closing response body: %v", err)
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200 — a duplicated header must not select the modern status", resp.StatusCode)
 	}
 }
 

--- a/backend/internal/modules/agents/httpmodern_test.go
+++ b/backend/internal/modules/agents/httpmodern_test.go
@@ -366,35 +366,142 @@ func TestDecodingAMirroredHeaderValue(t *testing.T) {
 	}
 }
 
-// A body that names nothing is not a body that agrees with a header. Each
-// case here is a params shape that carries no readable name, and a header
-// presented against any of them is a mismatch rather than a match against the
-// empty string.
-func TestABodyThatNamesNothingMatchesNoPresentedHeader(t *testing.T) {
-	for _, tc := range []struct{ name, params string }{
-		{"params are not an object", `[1,2]`},
-		{"the member is absent", `{"arguments":{}}`},
-		{"the member is not a string", `{"name":42}`},
-		{"there are no params at all", ``},
+// A body that names nothing is not a body that agrees with a header. Each case
+// here is a params shape carrying no readable name, and NEITHER a presented
+// header nor an absent one is a match: the header is required on this method,
+// so sending nothing is a validation failure rather than a way to agree with a
+// body that says nothing either.
+func TestABodyThatNamesNothingMatchesNoHeaderAtAll(t *testing.T) {
+	// Both readers, because both methods carry the rule and a gap in either is
+	// a method whose header goes unchecked.
+	for reader, readName := range map[string]mirroredName{
+		"tools/call": calledToolName, "resources/read": readResourceURI,
+	} {
+		for _, tc := range []struct{ name, params string }{
+			{"params are not an object", `[1,2]`},
+			{"the member is absent", `{"arguments":{}}`},
+			{"the member is not a string", `{"name":42,"uri":42}`},
+			{"there are no params at all", ``},
+		} {
+			t.Run(reader+": "+tc.name, func(t *testing.T) {
+				params := json.RawMessage(tc.params)
+				if tc.params == "" {
+					params = nil
+				}
+
+				if got := readName(params); got != "" {
+					t.Fatalf("read %q out of a body that names nothing", got)
+				}
+				for _, presented := range []string{"read_record", ""} {
+					if refusal := validateMirroredName(presented, params, readName); refusal == nil {
+						t.Errorf("Mcp-Name %q was accepted against a body that carries no name", presented)
+					}
+				}
+			})
+		}
+	}
+}
+
+// THE defect this whole file exists to prevent, and the one shape that gets
+// past a mirror that reads the body its own way.
+//
+// encoding/json matches members case-insensitively and takes the LAST of a
+// duplicate pair, so a body carrying both `name` and `NAME` reads as one tool
+// to a map lookup and as another to the handler. A mirror comparing the header
+// against the first would admit exactly what it exists to refuse: a gateway
+// allowing one tool while this server runs another. Each row below is a body
+// whose two readings could differ, and the assertion is that the ONE the
+// dispatcher will execute is the one the header had to match.
+func TestTheMirrorComparesTheNameTheDispatcherWillExecute(t *testing.T) {
+	for _, tc := range []struct{ name, params, executes string }{
+		{"a case-variant member", `{"NAME":"read_record","arguments":{}}`, "read_record"},
+		{
+			"a benign name shadowed by a case variant",
+			`{"name":"harmless_tool","NAME":"read_record","arguments":{}}`, "read_record",
+		},
+		{
+			"a duplicate member, last one winning",
+			`{"name":"harmless_tool","name":"read_record","arguments":{}}`, "read_record",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			params := json.RawMessage(tc.params)
-			if tc.params == "" {
-				params = nil
+			// What the handler will act on, decoded exactly as Dispatcher.call
+			// decodes it. This is the value the header must be held to.
+			var executed struct {
+				Name string `json:"name"`
+			}
+			if err := json.Unmarshal(params, &executed); err != nil {
+				t.Fatalf("decoding as the dispatcher does: %v", err)
+			}
+			if executed.Name != tc.executes {
+				t.Fatalf("this body executes %q, not the %q the case is written around",
+					executed.Name, tc.executes)
 			}
 
-			if got := paramsMember(params, "name"); got != "" {
-				t.Fatalf("read %q out of a body that names nothing", got)
+			// A header naming anything else is refused...
+			if refusal := validateMirroredName("harmless_tool", params, calledToolName); refusal == nil {
+				t.Errorf("Mcp-Name %q was accepted for a body that executes %q — "+
+					"a gateway would allow one tool while this server ran another",
+					"harmless_tool", executed.Name)
 			}
-			if refusal := validateMirroredName("read_record", params, "name"); refusal == nil {
-				t.Error("a presented name matched a body that carries none")
-			}
-			// And with nothing presented either, the dispatcher gets to report
-			// what is actually wrong with the body.
-			if refusal := validateMirroredName("", params, "name"); refusal != nil {
-				t.Errorf("refused %d %q, want the dispatcher to answer instead", refusal.Code, refusal.Message)
+			// ...and the header naming what actually runs is admitted, so the
+			// rule refuses a mismatch rather than refusing everything.
+			if refusal := validateMirroredName(executed.Name, params, calledToolName); refusal != nil {
+				t.Errorf("Mcp-Name %q was refused for the tool the dispatcher executes: %q",
+					executed.Name, refusal.Message)
 			}
 		})
+	}
+}
+
+// A method that mirrors no name must present none. A header naming a tool on a
+// call that invokes none tells an intermediary metering or filtering on
+// Mcp-Name about an invocation that never happens.
+func TestAPresentedNameIsRefusedOnAMethodThatCarriesNone(t *testing.T) {
+	srv := modernServer(t)
+
+	status, body := modernPOST(t, srv,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{`+modernMetaJSON+`}}`,
+		map[string]string{
+			headerProtocolVersion: modernProtocolVersion,
+			headerMethod:          "tools/list",
+			headerName:            "send_email",
+		})
+
+	if status != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", status)
+	}
+	if got := errorCode(t, body); got != codeHeaderMismatch {
+		t.Errorf("code = %d, want %d", got, codeHeaderMismatch)
+	}
+}
+
+// The modern revision establishes no session, so it has nothing to tear down.
+// A DELETE that names it is answered 405 rather than being routed into the
+// handshake era's session registry, where it could only ever look for a
+// session it had no way to open.
+func TestADeleteNamingTheModernRevisionIsRefused(t *testing.T) {
+	srv := modernServer(t)
+	req, err := http.NewRequest(http.MethodDelete, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set(headerProtocolVersion, modernProtocolVersion)
+	req.Header.Set("Mcp-Session-Id", "01234567-89ab-cdef-0123-456789abcdef")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			t.Errorf("closing response body: %v", err)
+		}
+	}()
+
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", resp.StatusCode)
 	}
 }
 

--- a/backend/internal/modules/agents/modern.go
+++ b/backend/internal/modules/agents/modern.go
@@ -1,0 +1,326 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// The 2026-07-28 framing, served beside the handshake era (ADR-0092/A141).
+//
+// A modern request carries its own protocol version, identity and capabilities
+// in `_meta`, so it needs no session and could be answered by any replica; a
+// legacy request arrives after `initialize` and is parsed exactly as it was
+// before. What the two share is everything that decides AUTHORITY: both reach
+// the same Registry.Invoke, and nothing in this file touches admission. A
+// framing able to alter what a call may do would be a second admission path,
+// which ADR-0055 forbids.
+//
+// This file owns the BODY half of the framing — era detection, the `_meta`
+// contract, server/discover, and the members every modern result carries. The
+// header half is httpmodern.go, because mirroring belongs to the transport
+// that carries the headers.
+
+import (
+	"encoding/json"
+	"fmt"
+	"slices"
+)
+
+// modernProtocolVersion is the revision this server serves in the modern
+// framing. It is a single value rather than a list because there is exactly
+// one modern revision to serve: the day a second one exists, the compatibility
+// window it joins is a spec decision (ADR-0092 §3), not a slice this file
+// grows quietly.
+const modernProtocolVersion = "2026-07-28"
+
+// The reserved `_meta` keys this server reads and writes. Their prefix is
+// reserved to MCP by the specification, which is also why they are spelled
+// once here: a typo in one produces a request that looks like it declared
+// nothing, and the framing would silently read it as legacy.
+const (
+	metaProtocolVersion    = "io.modelcontextprotocol/protocolVersion"
+	metaClientCapabilities = "io.modelcontextprotocol/clientCapabilities"
+	metaServerInfo         = "io.modelcontextprotocol/serverInfo"
+)
+
+// The MCP error codes the modern framing answers with. -32020..-32099 is the
+// sub-range the specification reserves for itself, so a code from it may only
+// ever be emitted with the meaning the spec gives it.
+const (
+	codeHeaderMismatch             = -32020
+	codeUnsupportedProtocolVersion = -32022
+	codeInvalidParams              = -32602
+	codeMethodNotFound             = -32601
+)
+
+// The members a modern result carries.
+const (
+	// fieldResultType is required on every modern result. This server answers
+	// only "complete": the other value, "input_required", belongs to a
+	// multi-round-trip call, and no tool here asks its caller for input —
+	// a 🟡 tool stages through the approvals engine, which is a Margince
+	// surface a human visits, not a round trip to the agent's client.
+	fieldResultType    = "resultType"
+	resultTypeComplete = "complete"
+	fieldMeta          = "_meta"
+	fieldTTLMs         = "ttlMs"
+	fieldCacheScope    = "cacheScope"
+	cacheScopePublic   = "public"
+	cacheScopePrivate  = "private"
+)
+
+// How long a client may consider a catalog fresh.
+//
+// A TTL is a freshness hint, never a permission: a client reusing a
+// minute-old tools/list cannot call anything with it, because every call
+// re-authenticates and the gate re-derives scope, seat and RBAC from live
+// state. That is what makes a non-zero TTL defensible on a scope-filtered
+// catalog at all — the stale copy can mislead a client about what it may try,
+// and cannot make the attempt succeed.
+const (
+	catalogCacheTTLMs  = 60_000
+	discoverCacheTTLMs = 300_000
+)
+
+// modernPrivateCatalogs are the cacheable methods whose answer is composed
+// from the CALLING principal's own context — the tool list is scope-filtered
+// per passport and every resource is assembled from what this principal may
+// read. A shared cache entry on any of them is a disclosure that never reaches
+// the server to be audited (ADR-0092 §5), so all of them answer `private`.
+//
+// The two that happen to answer an empty list today are in here for the same
+// reason as the rest: they are answered by the same per-caller code path, and
+// `public` is a claim about every future answer, not just this one.
+var modernPrivateCatalogs = []string{
+	methodToolsList, methodPromptsList, methodResourcesList, methodResourceTemplatesList, methodResourcesRead,
+}
+
+// framing is the protocol era ONE request is parsed under. It is decided once,
+// by the transport, and travels down as a value: a second place asking "which
+// era is this" is how the two framings would start to disagree.
+type framing struct {
+	modern bool
+	// version is the revision the request declared for itself. It is
+	// meaningful only in the modern framing, where the version is a property
+	// of the call; a legacy call's version belongs to its session.
+	version string
+}
+
+// legacyFraming is the handshake era, named rather than spelled as a zero
+// value so a reader of a call site can see which era is meant.
+var legacyFraming = framing{}
+
+// modernMeta is the per-request protocol metadata a modern client sends. Both
+// members are POINTERS because their absence is the condition being tested:
+// the specification makes each required, and a missing one is a malformed
+// request rather than an empty value.
+type modernMeta struct {
+	//nolint:tagliatelle // the wire member is a reserved reverse-DNS key, spelled by the protocol
+	ProtocolVersion *string `json:"io.modelcontextprotocol/protocolVersion"`
+	//nolint:tagliatelle // the wire member is a reserved reverse-DNS key, spelled by the protocol
+	ClientCapabilities *json.RawMessage `json:"io.modelcontextprotocol/clientCapabilities"`
+}
+
+// servesAsModern reports whether version names the revision this server serves
+// in the modern framing.
+func servesAsModern(version string) bool { return version == modernProtocolVersion }
+
+// supportedProtocolVersions is every revision this server serves, newest
+// first: what server/discover advertises and what an UnsupportedProtocolVersion
+// refusal lists. The modern revision leads because a client choosing from this
+// list should choose it.
+func supportedProtocolVersions() []string {
+	return append([]string{modernProtocolVersion}, legacyProtocolVersions...)
+}
+
+// metaOf reads the modern per-request metadata out of a request's params.
+//
+// Params that do not decode into an object carry no declaration, which is the
+// honest answer rather than an error: JSON-RPC permits positional params, this
+// protocol does not use them, and a request whose params are not an object has
+// not declared a protocol version by any reading. The legacy path reports
+// whatever is actually wrong with such a body when it tries to use it.
+func metaOf(params json.RawMessage) modernMeta {
+	var envelope struct {
+		//nolint:tagliatelle // _meta is the protocol's own member name, underscore and all
+		Meta modernMeta `json:"_meta"`
+	}
+	if len(params) == 0 {
+		return modernMeta{}
+	}
+	if err := json.Unmarshal(params, &envelope); err != nil {
+		return modernMeta{}
+	}
+	return envelope.Meta
+}
+
+// modernPrecheck decides one request's era and, for a modern request, whether
+// the body satisfies the framing's own preconditions. It answers the framing
+// plus the refusal to write INSTEAD of dispatching, nil when there is none.
+//
+// transportVersion is the version the transport named alongside the body (the
+// MCP-Protocol-Version header on HTTP), and it is load-bearing rather than a
+// convenience. Without it, a caller could name the modern revision in the
+// header — where every intermediary routes on it — send a body carrying no
+// `_meta`, and be parsed as legacy, skipping every check below. With it, that
+// request is modern and missing a required field, which is what the
+// specification says it is.
+func modernPrecheck(params json.RawMessage, transportVersion string) (framing, *rpcError) {
+	meta := metaOf(params)
+	switch {
+	case meta.ProtocolVersion != nil:
+		return modernPreconditions(framing{modern: true, version: *meta.ProtocolVersion}, meta)
+	case servesAsModern(transportVersion):
+		return modernPreconditions(framing{modern: true}, meta)
+	default:
+		return legacyFraming, nil
+	}
+}
+
+// modernPreconditions holds a modern request to the two things every one of
+// them must carry, in the order the specification puts them: a required field
+// that is absent is a malformed request (-32602), and a version this server
+// does not serve is a refusal that names what it does serve (-32022) so the
+// client can retry rather than guess.
+//
+// -32021 MissingRequiredClientCapability is deliberately never emitted. No
+// tool on this surface needs sampling, elicitation or roots, so there is no
+// capability whose absence could stop a call; a server that demanded one it
+// never uses would refuse callers for nothing.
+func modernPreconditions(fr framing, meta modernMeta) (framing, *rpcError) {
+	for _, missing := range []struct {
+		absent bool
+		key    string
+	}{
+		{meta.ProtocolVersion == nil, metaProtocolVersion},
+		{meta.ClientCapabilities == nil, metaClientCapabilities},
+	} {
+		if missing.absent {
+			return fr, &rpcError{
+				Code: codeInvalidParams,
+				Message: fmt.Sprintf("invalid params: a %s request must carry _meta[%q]",
+					modernProtocolVersion, missing.key),
+			}
+		}
+	}
+	if !servesAsModern(fr.version) {
+		return fr, unsupportedProtocolVersion(fr.version)
+	}
+	return fr, nil
+}
+
+// unsupportedProtocolVersion is the refusal that names every revision this
+// server serves. The message says how the handshake-era ones are reached,
+// because the `supported` list alone would tell a modern client that a version
+// it cannot use per-request is available to it.
+func unsupportedProtocolVersion(requested string) *rpcError {
+	return &rpcError{
+		Code: codeUnsupportedProtocolVersion,
+		Message: fmt.Sprintf("unsupported protocol version %q: this server serves %s per request, "+
+			"and %v through the initialize handshake",
+			requested, modernProtocolVersion, legacyProtocolVersions),
+		Data: map[string]any{"supported": supportedProtocolVersions(), "requested": requested},
+	}
+}
+
+// discover answers server/discover: the supported revisions, the capabilities
+// and the identity a client would otherwise learn by probing three list
+// methods. It reads NOTHING from the caller's context, which is the property
+// that lets its result be cached publicly.
+func (s *Dispatcher) discover() map[string]any {
+	return map[string]any{
+		"supportedVersions": supportedProtocolVersions(),
+		"capabilities":      s.capabilities(),
+		// Guidance for the model on the other side of the client, kept to what
+		// is true of every tool: the per-tool text is DescribeForClient's, and
+		// a second description of the governance here would be a second answer
+		// to the same question.
+		"instructions": "A governed CRM tool surface. Every call re-authenticates and is bounded by " +
+			"the granting human's own permissions, so a tool may refuse a record this passport cannot " +
+			"reach. Tools that a person must approve say so in their own description; calling one " +
+			"stages the effect for review rather than performing it.",
+	}
+}
+
+// finishModern renders one dispatched response in the modern framing: the
+// members every modern result carries, and the codes this era spells
+// differently.
+//
+// A legacy response is returned untouched. The framing decides how a call is
+// rendered as well as parsed, and a member a 2025-11-25 client never reads is
+// not worth handing to one that validates strictly.
+func (s *Dispatcher) finishModern(resp rpcResponse, method string) rpcResponse {
+	if resp.Error != nil {
+		// -32002 was retired with the handshake era and its meaning moved to
+		// -32602. Remapping here rather than at the raise site keeps ONE
+		// resource-not-found path: the legacy framing still answers the code
+		// its own clients recognize.
+		if resp.Error.Code == resourceNotFound {
+			resp.Error = &rpcError{Code: codeInvalidParams, Message: resp.Error.Message}
+		}
+		return resp
+	}
+	members := map[string]any{
+		fieldResultType: resultTypeComplete,
+		fieldMeta:       map[string]any{metaServerInfo: s.identity()},
+	}
+	if hint, ok := modernCacheHint(method); ok {
+		members[fieldTTLMs], members[fieldCacheScope] = hint.ttlMs, hint.scope
+	}
+	resp.Result = modernResult{inner: resp.Result, members: members}
+	return resp
+}
+
+// cacheHint is what a client may do with one result: how long it stays fresh,
+// and who may hold the copy.
+type cacheHint struct {
+	ttlMs int
+	scope string
+}
+
+// modernCacheHint answers the caching contract for a method's complete result.
+// The specification makes the hint a MUST on exactly these methods, so the
+// answer is a closed set rather than a default: a method not named here must
+// carry no hint, and tools/call is the one that matters — a tool result is not
+// a catalog and must never be served twice.
+func modernCacheHint(method string) (cacheHint, bool) {
+	if method == methodDiscover {
+		return cacheHint{ttlMs: discoverCacheTTLMs, scope: cacheScopePublic}, true
+	}
+	if slices.Contains(modernPrivateCatalogs, method) {
+		return cacheHint{ttlMs: catalogCacheTTLMs, scope: cacheScopePrivate}, true
+	}
+	return cacheHint{}, false
+}
+
+// modernResult renders a handler's own result value with the framing's members
+// merged into it.
+//
+// It merges at the JSON level rather than by rebuilding a map, so a handler's
+// bytes reach the client as the handler wrote them: a round trip through
+// map[string]any would widen every integer to a float64, and the two renderings
+// of one answer would disagree on exactly the results that carry a count.
+type modernResult struct {
+	inner   any
+	members map[string]any
+}
+
+func (m modernResult) MarshalJSON() ([]byte, error) {
+	body, err := json.Marshal(m.inner)
+	if err != nil {
+		return nil, fmt.Errorf("marshalling the result to decorate: %w", err)
+	}
+	decorated := map[string]json.RawMessage{}
+	if err := json.Unmarshal(body, &decorated); err != nil {
+		// Every method's result is an object; a non-object here is this
+		// server's own defect, and the transport turns it into a 500 rather
+		// than shipping a result the framing cannot describe.
+		return nil, fmt.Errorf("a modern result must be a JSON object: %w", err)
+	}
+	for name, value := range m.members {
+		member, err := json.Marshal(value)
+		if err != nil {
+			return nil, fmt.Errorf("marshalling the %q member: %w", name, err)
+		}
+		decorated[name] = member
+	}
+	return json.Marshal(decorated)
+}

--- a/backend/internal/modules/agents/modern.go
+++ b/backend/internal/modules/agents/modern.go
@@ -292,7 +292,7 @@ func unsupportedProtocolVersion(requested string) *rpcError {
 		Message: fmt.Sprintf("unsupported protocol version %q: this server serves %s per request, "+
 			"and %s through the initialize handshake",
 			echoed, modernProtocolVersion, strings.Join(legacyProtocolVersions, ", ")),
-		Data: map[string]any{"supported": supportedProtocolVersions(), "requested": echoed},
+		Data: &rpcErrorData{Supported: supportedProtocolVersions(), Requested: echoed},
 	}
 }
 

--- a/backend/internal/modules/agents/modern.go
+++ b/backend/internal/modules/agents/modern.go
@@ -22,6 +22,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"slices"
+	"strings"
+	"unicode/utf8"
 )
 
 // modernProtocolVersion is the revision this server serves in the modern
@@ -41,14 +43,21 @@ const (
 	metaServerInfo         = "io.modelcontextprotocol/serverInfo"
 )
 
-// The MCP error codes the modern framing answers with. -32020..-32099 is the
-// sub-range the specification reserves for itself, so a code from it may only
-// ever be emitted with the meaning the spec gives it.
+// The JSON-RPC codes this server answers with, in both eras — named once so
+// the package cannot end up with two spellings of one code.
+const (
+	codeParseError     = -32700
+	codeMethodNotFound = -32601
+	codeInvalidParams  = -32602
+	codeInternalError  = -32603
+)
+
+// The two codes the MODERN framing adds. -32020..-32099 is the sub-range the
+// specification reserves for itself, so a code from it may only ever be
+// emitted with the meaning the spec gives it — and never invented here.
 const (
 	codeHeaderMismatch             = -32020
 	codeUnsupportedProtocolVersion = -32022
-	codeInvalidParams              = -32602
-	codeMethodNotFound             = -32601
 )
 
 // The members a modern result carries.
@@ -67,30 +76,42 @@ const (
 	cacheScopePrivate  = "private"
 )
 
-// How long a client may consider a catalog fresh.
+// How long a client may consider an answer fresh. There are three numbers
+// because there are three kinds of answer, and the argument that licenses a
+// non-zero TTL holds for only two of them.
 //
-// A TTL is a freshness hint, never a permission: a client reusing a
-// minute-old tools/list cannot call anything with it, because every call
-// re-authenticates and the gate re-derives scope, seat and RBAC from live
-// state. That is what makes a non-zero TTL defensible on a scope-filtered
-// catalog at all — the stale copy can mislead a client about what it may try,
-// and cannot make the attempt succeed.
+// A TTL is a freshness hint, never a permission. A client reusing a minute-old
+// CATALOG cannot call anything with it: every call re-authenticates and the
+// gate re-derives scope, seat and RBAC from live state, so a stale menu can
+// mislead a client about what it may try and cannot make the attempt succeed.
+// Discovery is the same argument over an answer that does not vary at all.
+//
+// A DOCUMENT is not a menu. A resources/read result IS the content, so a stale
+// copy is the disclosure rather than a hint about one, and nothing downstream
+// re-checks it. This server therefore promises no freshness on a read and asks
+// the client to come back — which the specification spells `0`, and which
+// leaves the required member present rather than absent.
 const (
 	catalogCacheTTLMs  = 60_000
 	discoverCacheTTLMs = 300_000
+	documentCacheTTLMs = 0
 )
 
-// modernPrivateCatalogs are the cacheable methods whose answer is composed
-// from the CALLING principal's own context — the tool list is scope-filtered
-// per passport and every resource is assembled from what this principal may
-// read. A shared cache entry on any of them is a disclosure that never reaches
-// the server to be audited (ADR-0092 §5), so all of them answer `private`.
+// modernPrivateCatalogs are the cacheable LISTS. Two of them are scope-filtered
+// per caller today — the tool list by passport scopes, the resource list by
+// what this principal may read — and a shared cache entry on either is a
+// disclosure that never reaches the server to be audited (ADR-0092 §5).
 //
-// The two that happen to answer an empty list today are in here for the same
-// reason as the rest: they are answered by the same per-caller code path, and
-// `public` is a claim about every future answer, not just this one.
+// The other two answer nothing at all today, and they are `private` for a
+// different reason: `public` is a claim about every future answer, not just
+// this one, and the cheapest way to never make that claim wrongly is to never
+// make it here.
+//
+// resources/read is deliberately NOT in this list. It is also private, but it
+// is a document rather than a catalog and carries its own TTL for the reason
+// above.
 var modernPrivateCatalogs = []string{
-	methodToolsList, methodPromptsList, methodResourcesList, methodResourceTemplatesList, methodResourcesRead,
+	methodToolsList, methodPromptsList, methodResourcesList, methodResourceTemplatesList,
 }
 
 // framing is the protocol era ONE request is parsed under. It is decided once,
@@ -108,16 +129,26 @@ type framing struct {
 // value so a reader of a call site can see which era is meant.
 var legacyFraming = framing{}
 
-// modernMeta is the per-request protocol metadata a modern client sends. Both
-// members are POINTERS because their absence is the condition being tested:
-// the specification makes each required, and a missing one is a malformed
-// request rather than an empty value.
+// modernMeta is the per-request protocol metadata a modern client sends, held
+// as the RAW members rather than decoded values.
+//
+// Raw, because this type answers two different questions and they must not be
+// confused: whether the request DECLARED itself modern at all, and whether what
+// it declared is well formed. A member present but of the wrong type is a
+// modern request with a malformed field — it must be refused, never demoted to
+// the other era, which is what decoding straight into typed fields would do
+// with a version sent as a number.
 type modernMeta struct {
-	//nolint:tagliatelle // the wire member is a reserved reverse-DNS key, spelled by the protocol
-	ProtocolVersion *string `json:"io.modelcontextprotocol/protocolVersion"`
-	//nolint:tagliatelle // the wire member is a reserved reverse-DNS key, spelled by the protocol
-	ClientCapabilities *json.RawMessage `json:"io.modelcontextprotocol/clientCapabilities"`
+	version      json.RawMessage
+	capabilities json.RawMessage
 }
+
+// declared reports whether the body claims the modern framing at all. EITHER
+// reserved per-request key is enough: the specification's dual-era rule keys on
+// a request "carrying modern per-request `_meta`", and a body that carries one
+// of the two has done so — with the other one missing, which is a refusal
+// rather than a reason to read it as a handshake-era call.
+func (m modernMeta) declared() bool { return m.version != nil || m.capabilities != nil }
 
 // servesAsModern reports whether version names the revision this server serves
 // in the modern framing.
@@ -133,15 +164,19 @@ func supportedProtocolVersions() []string {
 
 // metaOf reads the modern per-request metadata out of a request's params.
 //
-// Params that do not decode into an object carry no declaration, which is the
-// honest answer rather than an error: JSON-RPC permits positional params, this
-// protocol does not use them, and a request whose params are not an object has
-// not declared a protocol version by any reading. The legacy path reports
-// whatever is actually wrong with such a body when it tries to use it.
+// Params that do not decode into an object carrying a `_meta` object declare
+// nothing, which is the honest answer rather than an error: JSON-RPC permits
+// positional params, this protocol does not use them, and such a body has not
+// declared a protocol version by any reading. The legacy path reports whatever
+// is actually wrong with it when it tries to use it.
+//
+// The reserved keys are matched EXACTLY. encoding/json would match them
+// case-insensitively, and nothing else on this path reads them, so exact is
+// both correct and the stricter of the two.
 func metaOf(params json.RawMessage) modernMeta {
 	var envelope struct {
 		//nolint:tagliatelle // _meta is the protocol's own member name, underscore and all
-		Meta modernMeta `json:"_meta"`
+		Meta map[string]json.RawMessage `json:"_meta"`
 	}
 	if len(params) == 0 {
 		return modernMeta{}
@@ -149,7 +184,10 @@ func metaOf(params json.RawMessage) modernMeta {
 	if err := json.Unmarshal(params, &envelope); err != nil {
 		return modernMeta{}
 	}
-	return envelope.Meta
+	return modernMeta{
+		version:      envelope.Meta[metaProtocolVersion],
+		capabilities: envelope.Meta[metaClientCapabilities],
+	}
 }
 
 // modernPrecheck decides one request's era and, for a modern request, whether
@@ -165,14 +203,10 @@ func metaOf(params json.RawMessage) modernMeta {
 // specification says it is.
 func modernPrecheck(params json.RawMessage, transportVersion string) (framing, *rpcError) {
 	meta := metaOf(params)
-	switch {
-	case meta.ProtocolVersion != nil:
-		return modernPreconditions(framing{modern: true, version: *meta.ProtocolVersion}, meta)
-	case servesAsModern(transportVersion):
-		return modernPreconditions(framing{modern: true}, meta)
-	default:
+	if !meta.declared() && !servesAsModern(transportVersion) {
 		return legacyFraming, nil
 	}
+	return modernPreconditions(meta)
 }
 
 // modernPreconditions holds a modern request to the two things every one of
@@ -185,21 +219,19 @@ func modernPrecheck(params json.RawMessage, transportVersion string) (framing, *
 // tool on this surface needs sampling, elicitation or roots, so there is no
 // capability whose absence could stop a call; a server that demanded one it
 // never uses would refuse callers for nothing.
-func modernPreconditions(fr framing, meta modernMeta) (framing, *rpcError) {
-	for _, missing := range []struct {
-		absent bool
-		key    string
-	}{
-		{meta.ProtocolVersion == nil, metaProtocolVersion},
-		{meta.ClientCapabilities == nil, metaClientCapabilities},
-	} {
-		if missing.absent {
-			return fr, &rpcError{
-				Code: codeInvalidParams,
-				Message: fmt.Sprintf("invalid params: a %s request must carry _meta[%q]",
-					modernProtocolVersion, missing.key),
-			}
-		}
+func modernPreconditions(meta modernMeta) (framing, *rpcError) {
+	fr := framing{modern: true}
+	version, malformed := declaredVersion(meta.version)
+	if malformed != nil {
+		return fr, malformed
+	}
+	fr.version = version
+	// Capabilities this server cannot READ are capabilities it would have to
+	// assume, which is the one thing a declaration exists to stop — so present
+	// is not enough, and a JSON null (which the wire allows anywhere) is the
+	// same as absent.
+	if !isJSONObject(meta.capabilities) {
+		return fr, missingModernField(metaClientCapabilities, "an object")
 	}
 	if !servesAsModern(fr.version) {
 		return fr, unsupportedProtocolVersion(fr.version)
@@ -207,18 +239,80 @@ func modernPreconditions(fr framing, meta modernMeta) (framing, *rpcError) {
 	return fr, nil
 }
 
+// declaredVersion reads the revision a modern body names, or the refusal for a
+// body that names one this server cannot read. A member of the wrong type is
+// NOT an absent member: the request declared itself modern and got the
+// declaration wrong, and demoting it to the handshake era would serve a
+// malformed modern call instead of refusing it.
+func declaredVersion(raw json.RawMessage) (string, *rpcError) {
+	var version string
+	// A JSON null unmarshals into a string WITHOUT error, leaving it empty, so
+	// the empty check is not belt-and-braces: it is what folds absent, null and
+	// "" into the one refusal each of them deserves.
+	if err := json.Unmarshal(raw, &version); err != nil || version == "" {
+		return "", missingModernField(metaProtocolVersion, "a string")
+	}
+	return version, nil
+}
+
+func missingModernField(key, shape string) *rpcError {
+	return &rpcError{
+		Code: codeInvalidParams,
+		Message: fmt.Sprintf("invalid params: a %s request must carry _meta[%q] as %s",
+			modernProtocolVersion, key, shape),
+	}
+}
+
+// isJSONObject reports whether raw is a JSON object — false for an absent
+// member, for a null, and for every other JSON type.
+//
+// The nil-map check carries the null case, which is the one a reader will
+// doubt: a JSON null unmarshals into a map without error and leaves it nil, so
+// testing only the error would call `null` an object.
+func isJSONObject(raw json.RawMessage) bool {
+	var object map[string]json.RawMessage
+	return json.Unmarshal(raw, &object) == nil && object != nil
+}
+
 // unsupportedProtocolVersion is the refusal that names every revision this
 // server serves. The message says how the handshake-era ones are reached,
 // because the `supported` list alone would tell a modern client that a version
 // it cannot use per-request is available to it.
+//
+// What it echoes back is BOUNDED. `requested` is caller-controlled and its
+// length is not — a body is admitted up to 8 MiB — and it is reflected twice,
+// so an unbounded echo would answer a large refused request with a larger
+// response. A protocol revision is a date; anything longer than that is not
+// one, and the client already knows what it sent.
 func unsupportedProtocolVersion(requested string) *rpcError {
+	echoed := boundedEcho(requested)
 	return &rpcError{
 		Code: codeUnsupportedProtocolVersion,
 		Message: fmt.Sprintf("unsupported protocol version %q: this server serves %s per request, "+
-			"and %v through the initialize handshake",
-			requested, modernProtocolVersion, legacyProtocolVersions),
-		Data: map[string]any{"supported": supportedProtocolVersions(), "requested": requested},
+			"and %s through the initialize handshake",
+			echoed, modernProtocolVersion, strings.Join(legacyProtocolVersions, ", ")),
+		Data: map[string]any{"supported": supportedProtocolVersions(), "requested": echoed},
 	}
+}
+
+// maxEchoedVersion is how much of a refused version travels back to its
+// sender. A revision is a ten-character date, so this is generous for anything
+// a client meant and short for anything else.
+const maxEchoedVersion = 32
+
+// boundedEcho is caller-controlled text cut to a length this server chose,
+// on a rune boundary — a cut through the middle of a multi-byte character
+// would put invalid UTF-8 into a JSON string, which the encoder then silently
+// rewrites into replacement characters.
+func boundedEcho(value string) string {
+	if len(value) <= maxEchoedVersion {
+		return value
+	}
+	cut := value[:maxEchoedVersion]
+	for len(cut) > 0 && !utf8.ValidString(cut) {
+		cut = cut[:len(cut)-1]
+	}
+	return cut + "…"
 }
 
 // discover answers server/discover: the supported revisions, the capabilities
@@ -282,10 +376,12 @@ type cacheHint struct {
 // carry no hint, and tools/call is the one that matters — a tool result is not
 // a catalog and must never be served twice.
 func modernCacheHint(method string) (cacheHint, bool) {
-	if method == methodDiscover {
+	switch {
+	case method == methodDiscover:
 		return cacheHint{ttlMs: discoverCacheTTLMs, scope: cacheScopePublic}, true
-	}
-	if slices.Contains(modernPrivateCatalogs, method) {
+	case method == methodResourcesRead:
+		return cacheHint{ttlMs: documentCacheTTLMs, scope: cacheScopePrivate}, true
+	case slices.Contains(modernPrivateCatalogs, method):
 		return cacheHint{ttlMs: catalogCacheTTLMs, scope: cacheScopePrivate}, true
 	}
 	return cacheHint{}, false

--- a/backend/internal/modules/agents/modern.go
+++ b/backend/internal/modules/agents/modern.go
@@ -20,6 +20,7 @@ package agents
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -404,12 +405,18 @@ func (m modernResult) MarshalJSON() ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("marshalling the result to decorate: %w", err)
 	}
-	decorated := map[string]json.RawMessage{}
+	// Every method's result is an object; anything else here is this server's
+	// own defect, and the transport turns it into a 500 rather than shipping a
+	// result the framing cannot describe.
+	var decorated map[string]json.RawMessage
 	if err := json.Unmarshal(body, &decorated); err != nil {
-		// Every method's result is an object; a non-object here is this
-		// server's own defect, and the transport turns it into a 500 rather
-		// than shipping a result the framing cannot describe.
 		return nil, fmt.Errorf("a modern result must be a JSON object: %w", err)
+	}
+	// A JSON null decodes into a map WITHOUT error and leaves it nil, so this
+	// is not a second spelling of the check above: without it, a null result
+	// reaches the loop below and panics on the first member assigned to it.
+	if decorated == nil {
+		return nil, errors.New("a modern result must be a JSON object, and this one is null")
 	}
 	for name, value := range m.members {
 		member, err := json.Marshal(value)

--- a/backend/internal/modules/agents/modern_test.go
+++ b/backend/internal/modules/agents/modern_test.go
@@ -1,0 +1,601 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// What the 2026-07-28 framing obliges this server to do with a request's body,
+// and the property that makes serving two framings safe: they differ in how a
+// call is parsed and rendered, and in nothing that decides what it may do.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// The wire tokens, spelled here as the specification writes them rather than
+// read off the constants the code writes. A test that reads the same constant
+// proves only that this server is self-consistent, and a typo in a reserved
+// `_meta` key produces a request that looks like it declared nothing — which
+// this framing reads as the OTHER era.
+func TestTheProtocolTokensAreSpelledAsTheSpecificationWritesThem(t *testing.T) {
+	for _, tc := range []struct{ got, want string }{
+		{modernProtocolVersion, "2026-07-28"},
+		{metaProtocolVersion, "io.modelcontextprotocol/protocolVersion"},
+		{metaClientCapabilities, "io.modelcontextprotocol/clientCapabilities"},
+		{metaServerInfo, "io.modelcontextprotocol/serverInfo"},
+		{methodDiscover, "server/discover"},
+		{headerProtocolVersion, "MCP-Protocol-Version"},
+		{headerMethod, "Mcp-Method"},
+		{headerName, "Mcp-Name"},
+	} {
+		if tc.got != tc.want {
+			t.Errorf("token = %q, want the protocol's own spelling %q", tc.got, tc.want)
+		}
+	}
+	for _, tc := range []struct {
+		got  int
+		want int
+		name string
+	}{
+		{codeHeaderMismatch, -32020, "HeaderMismatch"},
+		{codeUnsupportedProtocolVersion, -32022, "UnsupportedProtocolVersion"},
+	} {
+		if tc.got != tc.want {
+			t.Errorf("%s = %d, want %d — the sub-range is reserved to the specification, "+
+				"so a code may only carry the meaning it gives it", tc.name, tc.got, tc.want)
+		}
+	}
+}
+
+// modernMetaJSON is the per-request metadata a conforming modern client sends,
+// written out rather than built from the constants for the reason above.
+const modernMetaJSON = `"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28",` +
+	`"io.modelcontextprotocol/clientCapabilities":{}}`
+
+// modernParams wraps a call's own params in that metadata.
+func modernParams(inner string) json.RawMessage {
+	if inner == "" {
+		return json.RawMessage(`{` + modernMetaJSON + `}`)
+	}
+	return json.RawMessage(`{` + modernMetaJSON + `,` + inner + `}`)
+}
+
+// The era is the ONE question this framing asks first, and both of its inputs
+// are load-bearing. A request whose body declares a version is modern. So is
+// one whose transport names the modern revision and whose body declares
+// nothing — because every intermediary between the client and here routes on
+// that header, and reading such a request as legacy would let a caller be
+// routed as modern while skipping every modern check.
+func TestTheEraIsDecidedByTheBodyOrByTheHeaderThatNamesIt(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		params           json.RawMessage
+		transportVersion string
+		wantModern       bool
+		wantRefusalCode  int
+	}{
+		{"a body that declares the modern revision", modernParams(""), modernProtocolVersion, true, 0},
+		{
+			"a body that declares it while the transport says nothing",
+			modernParams(""), "", true, 0,
+		},
+		{
+			"a transport naming the modern revision over a body that declares nothing",
+			json.RawMessage(`{}`), modernProtocolVersion, true, codeInvalidParams,
+		},
+		{"neither", json.RawMessage(`{}`), "", false, 0},
+		{"neither, with no params at all", nil, "", false, 0},
+		{
+			"a legacy transport version over a legacy body",
+			json.RawMessage(`{}`), legacyProtocolVersions[0], false, 0,
+		},
+		{
+			"params that are not an object declare nothing",
+			json.RawMessage(`[1,2]`), "", false, 0,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fr, refusal := modernPrecheck(tc.params, tc.transportVersion)
+
+			if fr.modern != tc.wantModern {
+				t.Fatalf("modern = %v, want %v", fr.modern, tc.wantModern)
+			}
+			switch {
+			case tc.wantRefusalCode == 0 && refusal != nil:
+				t.Fatalf("refused with %d %q, want admission", refusal.Code, refusal.Message)
+			case tc.wantRefusalCode != 0 && refusal == nil:
+				t.Fatalf("admitted, want refusal %d", tc.wantRefusalCode)
+			case refusal != nil && refusal.Code != tc.wantRefusalCode:
+				t.Fatalf("refusal code = %d, want %d", refusal.Code, tc.wantRefusalCode)
+			}
+		})
+	}
+}
+
+// Both per-request fields are required, and their absence is a malformed
+// request rather than an empty value — the distinction the pointer members
+// exist to keep.
+func TestAModernRequestMustCarryItsVersionAndItsCapabilities(t *testing.T) {
+	for _, tc := range []struct{ name, params, wantNamed string }{
+		{
+			"no capabilities",
+			`{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28"}}`,
+			metaClientCapabilities,
+		},
+		{
+			"capabilities but no version, over a modern transport",
+			`{"_meta":{"io.modelcontextprotocol/clientCapabilities":{}}}`,
+			metaProtocolVersion,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, refusal := modernPrecheck(json.RawMessage(tc.params), modernProtocolVersion)
+
+			if refusal == nil {
+				t.Fatal("admitted a request missing a required _meta field")
+			}
+			if refusal.Code != codeInvalidParams {
+				t.Errorf("code = %d, want %d", refusal.Code, codeInvalidParams)
+			}
+			if !strings.Contains(refusal.Message, tc.wantNamed) {
+				t.Errorf("message %q must name the missing field %q", refusal.Message, tc.wantNamed)
+			}
+		})
+	}
+}
+
+// A version this server does not serve per-request is refused with the list it
+// does serve, so the client retries rather than guesses. An empty
+// capabilities object is admitted in the same breath: no tool here needs
+// sampling, elicitation or roots, so there is nothing whose absence could
+// refuse a caller.
+func TestAnUnservedModernVersionIsRefusedWithEveryVersionThisServerServes(t *testing.T) {
+	for _, requested := range []string{"2025-11-25", "2025-03-26", "1999-01-01"} {
+		t.Run(requested, func(t *testing.T) {
+			params := fmt.Sprintf(`{"_meta":{"io.modelcontextprotocol/protocolVersion":%q,`+
+				`"io.modelcontextprotocol/clientCapabilities":{}}}`, requested)
+
+			_, refusal := modernPrecheck(json.RawMessage(params), "")
+
+			if refusal == nil || refusal.Code != codeUnsupportedProtocolVersion {
+				t.Fatalf("refusal = %#v, want %d", refusal, codeUnsupportedProtocolVersion)
+			}
+			data, ok := refusal.Data.(map[string]any)
+			if !ok {
+				t.Fatalf("data = %#v, want the supported/requested pair a client acts on", refusal.Data)
+			}
+			supported, ok := data["supported"].([]string)
+			if !ok || !slices.Equal(supported, supportedProtocolVersions()) {
+				t.Errorf("data.supported = %#v, want %v", data["supported"], supportedProtocolVersions())
+			}
+			if data["requested"] != requested {
+				t.Errorf("data.requested = %v, want %q", data["requested"], requested)
+			}
+		})
+	}
+}
+
+// supportedProtocolVersions is what a client chooses from, so the modern
+// revision leads it and every legacy revision in the window follows.
+func TestTheSupportedListLeadsWithTheModernRevisionAndCarriesTheWholeWindow(t *testing.T) {
+	got := supportedProtocolVersions()
+
+	want := append([]string{modernProtocolVersion}, legacyProtocolVersions...)
+	if !slices.Equal(got, want) {
+		t.Fatalf("supported = %v, want %v", got, want)
+	}
+	if slices.Contains(got, "2025-03-26") {
+		t.Error("2025-03-26 left the compatibility window (ADR-0092 §3) and must not be advertised")
+	}
+}
+
+// modernDispatcher is a server with one read tool, which is enough for every
+// rendering question here: the framing decides how an answer is wrapped, not
+// what is in it.
+func modernDispatcher(t *testing.T) *Dispatcher {
+	t.Helper()
+	registry := NewRegistry(nil, auth.NewGate(fullSeatAuthority{}))
+	registry.Register(echoTool{
+		spec: objectSpec("read_record", principal.ScopeRead),
+		out:  json.RawMessage(`{"ok":true}`),
+	})
+	return NewDispatcher(registry, bindAuthenticated, "margince-crm", "test").WithLogger(discardLog())
+}
+
+// modernRPC dispatches one modern call and returns the rendered result.
+func modernRPC(ctx context.Context, t *testing.T, s *Dispatcher, method string, params json.RawMessage) map[string]json.RawMessage {
+	t.Helper()
+	fr, refusal := modernPrecheck(params, modernProtocolVersion)
+	if refusal != nil {
+		t.Fatalf("%s refused before dispatch: %d %q", method, refusal.Code, refusal.Message)
+	}
+	resp := s.handle(ctx, rpcRequest{
+		JSONRPC: jsonRPCVersion, ID: json.RawMessage(`1`), Method: method, Params: params,
+	}, fr)
+	if resp.Error != nil {
+		t.Fatalf("%s → error %d %q", method, resp.Error.Code, resp.Error.Message)
+	}
+	body, err := json.Marshal(resp.Result)
+	if err != nil {
+		t.Fatalf("marshalling the %s result: %v", method, err)
+	}
+	var members map[string]json.RawMessage
+	if err := json.Unmarshal(body, &members); err != nil {
+		t.Fatalf("the %s result is not a JSON object: %v", method, err)
+	}
+	return members
+}
+
+// Every modern result says what kind of result it is and who answered it —
+// including the ones whose payload is empty, because a client reads those
+// members before it reads anything else.
+func TestEveryModernResultNamesItsTypeAndItsServer(t *testing.T) {
+	s := modernDispatcher(t)
+	ctx := scopedAgentCtx(principal.ScopeRead)
+
+	for _, method := range append([]string{methodPing, methodDiscover, methodToolsCall}, modernPrivateCatalogs...) {
+		t.Run(method, func(t *testing.T) {
+			params := modernParams("")
+			switch method {
+			case methodToolsCall:
+				params = modernParams(`"name":"read_record","arguments":{}`)
+			case methodResourcesRead:
+				// No provider is wired, so this one answers a refusal rather
+				// than a result — covered by its own test below.
+				t.Skip("resources/read with no provider is a refusal, asserted separately")
+			}
+
+			members := modernRPC(ctx, t, s, method, params)
+
+			if got := string(members[fieldResultType]); got != `"`+resultTypeComplete+`"` {
+				t.Errorf("%s = %s, want %q", fieldResultType, got, resultTypeComplete)
+			}
+			var meta map[string]json.RawMessage
+			if err := json.Unmarshal(members[fieldMeta], &meta); err != nil {
+				t.Fatalf("no _meta on the result: %v", err)
+			}
+			if !strings.Contains(string(meta[metaServerInfo]), `"margince-crm"`) {
+				t.Errorf("_meta[%q] = %s, want this server's identity", metaServerInfo, meta[metaServerInfo])
+			}
+		})
+	}
+}
+
+// A cacheable catalog says how long it stays fresh and who may hold it. Every
+// catalog this server composes reads the CALLER's own context, so a shared
+// cache entry would hand one agent another's surface — a disclosure that never
+// reaches the server to be audited (ADR-0092 §5).
+func TestEveryCallerDerivedCatalogIsCachedPrivately(t *testing.T) {
+	s := modernDispatcher(t)
+	ctx := scopedAgentCtx(principal.ScopeRead)
+
+	for _, method := range modernPrivateCatalogs {
+		if method == methodResourcesRead {
+			continue // a refusal, and refusals carry no hint at all
+		}
+		t.Run(method, func(t *testing.T) {
+			members := modernRPC(ctx, t, s, method, modernParams(""))
+
+			if got := string(members[fieldCacheScope]); got != `"`+cacheScopePrivate+`"` {
+				t.Errorf("%s = %s, want %q", fieldCacheScope, got, cacheScopePrivate)
+			}
+			if got := string(members[fieldTTLMs]); got != fmt.Sprint(catalogCacheTTLMs) {
+				t.Errorf("%s = %s, want %d", fieldTTLMs, got, catalogCacheTTLMs)
+			}
+		})
+	}
+}
+
+// server/discover is the one response allowed a shared cache, and this is what
+// licenses it: the same bytes for every caller. If it ever grows a member
+// derived from who asked, this fails rather than a gateway quietly serving one
+// agent's answer to another.
+func TestDiscoverAnswersEveryCallerIdentically(t *testing.T) {
+	s := modernDispatcher(t)
+	readOnly := scopedAgentCtx(principal.ScopeRead)
+	privileged := principal.WithActor(principal.WithWorkspaceID(context.Background(), ids.NewV7()),
+		principal.Principal{
+			Type: principal.PrincipalAgent, ID: "agent:privileged", OnBehalfOf: ids.NewV7(),
+			Scopes: principal.NewScopeSet(principal.ScopeRead, principal.ScopeWrite, principal.ScopeSend),
+		})
+
+	first := modernRPC(readOnly, t, s, methodDiscover, modernParams(""))
+	second := modernRPC(privileged, t, s, methodDiscover, modernParams(""))
+	unauthenticated := modernRPC(context.Background(), t, s, methodDiscover, modernParams(""))
+
+	for _, other := range []map[string]json.RawMessage{second, unauthenticated} {
+		for member, value := range first {
+			if string(other[member]) != string(value) {
+				t.Fatalf("discover.%s differs by caller (%s vs %s) — it is cached %q, "+
+					"so a caller-derived member here is a disclosure",
+					member, value, other[member], cacheScopePublic)
+			}
+		}
+	}
+	if got := string(first[fieldCacheScope]); got != `"`+cacheScopePublic+`"` {
+		t.Errorf("%s = %s, want %q", fieldCacheScope, got, cacheScopePublic)
+	}
+}
+
+// Discovery is what a client reads INSTEAD of probing, so it must name every
+// revision this server serves and the same capabilities initialize reports.
+func TestDiscoverAdvertisesTheWholeWindowAndTheSameCapabilitiesAsInitialize(t *testing.T) {
+	s := modernDispatcher(t)
+
+	members := modernRPC(scopedAgentCtx(principal.ScopeRead), t, s, methodDiscover, modernParams(""))
+
+	var versions []string
+	if err := json.Unmarshal(members["supportedVersions"], &versions); err != nil {
+		t.Fatalf("supportedVersions: %v", err)
+	}
+	if !slices.Equal(versions, supportedProtocolVersions()) {
+		t.Errorf("supportedVersions = %v, want %v", versions, supportedProtocolVersions())
+	}
+	handshake, rpcErr := s.initialize(nil)
+	if rpcErr != nil {
+		t.Fatalf("initialize: %#v", rpcErr)
+	}
+	fromHandshake, err := json.Marshal(handshake["capabilities"])
+	if err != nil {
+		t.Fatalf("marshalling the handshake capabilities: %v", err)
+	}
+	if string(members["capabilities"]) != string(fromHandshake) {
+		t.Errorf("discover claims %s and initialize claims %s — one server, one claim",
+			members["capabilities"], fromHandshake)
+	}
+}
+
+// A tool result is not a catalog: it is one caller's answer to one question
+// and must never be served twice. The caching contract is a closed set, so a
+// method that is not in it carries no hint at all.
+func TestAToolResultCarriesNoCachingHint(t *testing.T) {
+	s := modernDispatcher(t)
+
+	members := modernRPC(scopedAgentCtx(principal.ScopeRead), t, s, methodToolsCall,
+		modernParams(`"name":"read_record","arguments":{}`))
+
+	for _, member := range []string{fieldTTLMs, fieldCacheScope} {
+		if _, present := members[member]; present {
+			t.Errorf("tools/call result carries %q — a tool answer is not cacheable", member)
+		}
+	}
+}
+
+// Each era owns its opening call. Answering the other era's would tell a
+// client it had reached the server it was probing for, which is the one thing
+// those two calls exist to settle.
+func TestEachEraAnswersOnlyItsOwnOpeningCall(t *testing.T) {
+	s := modernDispatcher(t)
+	for _, tc := range []struct {
+		name   string
+		method string
+		fr     framing
+	}{
+		{"initialize in the modern framing", methodInitialize, framing{modern: true, version: modernProtocolVersion}},
+		{"server/discover in the handshake framing", methodDiscover, legacyFraming},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := s.handle(context.Background(), rpcRequest{
+				JSONRPC: jsonRPCVersion, ID: json.RawMessage(`1`), Method: tc.method,
+			}, tc.fr)
+
+			if resp.Error == nil || resp.Error.Code != codeMethodNotFound {
+				t.Fatalf("error = %#v, want %d method not found", resp.Error, codeMethodNotFound)
+			}
+			if resp.Result != nil {
+				t.Errorf("result = %#v alongside an error, which JSON-RPC forbids", resp.Result)
+			}
+		})
+	}
+}
+
+// -32002 was retired with the handshake era and its meaning moved to -32602.
+// The legacy framing still answers the code its own clients recognize, so the
+// remap is a rendering decision rather than a change at the raise site.
+func TestAResourceRefusalCarriesTheCodeItsOwnEraUses(t *testing.T) {
+	s := modernDispatcher(t)
+	read := func(fr framing) *rpcError {
+		return s.handle(scopedAgentCtx(principal.ScopeRead), rpcRequest{
+			JSONRPC: jsonRPCVersion, ID: json.RawMessage(`1`), Method: methodResourcesRead,
+			Params: modernParams(`"uri":"margince://schema/query"`),
+		}, fr).Error
+	}
+
+	modern := read(framing{modern: true, version: modernProtocolVersion})
+	if modern == nil || modern.Code != codeInvalidParams {
+		t.Fatalf("modern refusal = %#v, want %d — -32002 must not be emitted in this era", modern, codeInvalidParams)
+	}
+	legacy := read(legacyFraming)
+	if legacy == nil || legacy.Code != resourceNotFound {
+		t.Fatalf("legacy refusal = %#v, want %d", legacy, resourceNotFound)
+	}
+}
+
+// A handshake-era client never reads the modern members, and a client that
+// validates strictly would refuse a result carrying them.
+func TestALegacyResultIsRenderedExactlyAsItWasBefore(t *testing.T) {
+	s := modernDispatcher(t)
+
+	resp := s.handle(scopedAgentCtx(principal.ScopeRead), rpcRequest{
+		JSONRPC: jsonRPCVersion, ID: json.RawMessage(`1`), Method: methodToolsList,
+	}, legacyFraming)
+
+	body, err := json.Marshal(resp.Result)
+	if err != nil {
+		t.Fatalf("marshalling the result: %v", err)
+	}
+	for _, member := range []string{fieldResultType, fieldMeta, fieldTTLMs, fieldCacheScope} {
+		if strings.Contains(string(body), `"`+member+`"`) {
+			t.Errorf("a legacy result carries the modern member %q: %s", member, body)
+		}
+	}
+}
+
+// The caching contract names methods by hand, and a name that no longer
+// dispatches would leave a MUST unmet in silence. Deriving the check from the
+// dispatcher is what keeps the two sets from drifting apart.
+func TestEveryMethodDeclaredCacheableIsAnsweredByThisServer(t *testing.T) {
+	s := modernDispatcher(t)
+
+	for _, method := range append([]string{methodDiscover}, modernPrivateCatalogs...) {
+		if _, cacheable := modernCacheHint(method); !cacheable {
+			t.Fatalf("%s is in the cacheable set but carries no hint", method)
+		}
+		resp := s.handle(scopedAgentCtx(principal.ScopeRead), rpcRequest{
+			JSONRPC: jsonRPCVersion, ID: json.RawMessage(`1`), Method: method,
+			Params: modernParams(""),
+		}, framing{modern: true, version: modernProtocolVersion})
+		if resp.Error != nil && resp.Error.Code == codeMethodNotFound {
+			t.Errorf("%s is declared cacheable and this server does not answer it", method)
+		}
+	}
+}
+
+// The property that makes two framings safe: they decide how a call is parsed
+// and rendered, and nothing else. The same tool, called by the same
+// under-scoped principal, is refused identically in both — and the same tool
+// called by a principal that holds the scope answers the same bytes.
+func TestBothFramingsReachOneAdmissionGate(t *testing.T) {
+	s := modernDispatcher(t)
+	modern := framing{modern: true, version: modernProtocolVersion}
+	call := func(ctx context.Context, fr framing) map[string]any {
+		resp := s.handle(ctx, rpcRequest{
+			JSONRPC: jsonRPCVersion, ID: json.RawMessage(`1`), Method: methodToolsCall,
+			Params: modernParams(`"name":"read_record","arguments":{}`),
+		}, fr)
+		if resp.Error != nil {
+			t.Fatalf("tools/call → protocol error %d %q, want an in-band result", resp.Error.Code, resp.Error.Message)
+		}
+		result, ok := resp.Result.(map[string]any)
+		if ok {
+			return result
+		}
+		decorated, ok := resp.Result.(modernResult)
+		if !ok {
+			t.Fatalf("result = %#v", resp.Result)
+		}
+		inner, ok := decorated.inner.(map[string]any)
+		if !ok {
+			t.Fatalf("decorated result = %#v", decorated.inner)
+		}
+		return inner
+	}
+
+	// A passport without the read scope is refused, in band, by the registry —
+	// the same registry both framings call.
+	underScoped := scopedAgentCtx(principal.ScopeDraft)
+	legacyRefusal, modernRefusal := call(underScoped, legacyFraming), call(underScoped, modern)
+	if legacyRefusal["isError"] != true || modernRefusal["isError"] != true {
+		t.Fatalf("an under-scoped call was admitted: legacy=%v modern=%v", legacyRefusal, modernRefusal)
+	}
+	if fmt.Sprint(legacyRefusal["content"]) != fmt.Sprint(modernRefusal["content"]) {
+		t.Errorf("the two framings refuse differently:\nlegacy %v\nmodern %v",
+			legacyRefusal["content"], modernRefusal["content"])
+	}
+
+	// And an admitted call answers the same thing through either framing. The
+	// comparison is the tool's own payload rather than the whole envelope,
+	// because one member of that envelope — the trace id — is minted per call
+	// and would differ between any two calls at all, including two in the same
+	// framing.
+	scoped := scopedAgentCtx(principal.ScopeRead)
+	answer := func(fr framing) string {
+		sealed, ok := call(scoped, fr)["structuredContent"].(json.RawMessage)
+		if !ok {
+			t.Fatalf("no structuredContent on an admitted %v call", fr)
+		}
+		return string(payloadOf(t, sealed))
+	}
+	if got, want := answer(modern), answer(legacyFraming); got != want {
+		t.Errorf("the two framings answer differently:\nmodern %s\nlegacy %s", got, want)
+	}
+}
+
+// The tool surface a caller is shown is scope-filtered in both framings —
+// the filter is the dispatcher's, and a framing that re-implemented it would
+// be the second answer this design exists to prevent.
+func TestBothFramingsFilterTheToolListByTheCallersScopes(t *testing.T) {
+	registry := NewRegistry(nil, auth.NewGate(fullSeatAuthority{}))
+	for name, scope := range map[string]principal.Scope{
+		"read_record": principal.ScopeRead, "send_email": principal.ScopeSend,
+	} {
+		registry.Register(echoTool{spec: objectSpec(name, scope), out: json.RawMessage(`{}`)})
+	}
+	s := NewDispatcher(registry, bindAuthenticated, "margince-crm", "test").WithLogger(discardLog())
+	ctx := scopedAgentCtx(principal.ScopeRead)
+
+	names := func(fr framing) []string {
+		resp := s.handle(ctx, rpcRequest{
+			JSONRPC: jsonRPCVersion, ID: json.RawMessage(`1`), Method: methodToolsList,
+			Params: modernParams(""),
+		}, fr)
+		body, err := json.Marshal(resp.Result)
+		if err != nil {
+			t.Fatalf("marshalling tools/list: %v", err)
+		}
+		var listed struct {
+			Tools []struct {
+				Name string `json:"name"`
+			} `json:"tools"`
+		}
+		if err := json.Unmarshal(body, &listed); err != nil {
+			t.Fatalf("decoding tools/list: %v", err)
+		}
+		out := make([]string, 0, len(listed.Tools))
+		for _, tool := range listed.Tools {
+			out = append(out, tool.Name)
+		}
+		return out
+	}
+
+	modern, legacy := names(framing{modern: true, version: modernProtocolVersion}), names(legacyFraming)
+	if !slices.Equal(modern, []string{"read_record"}) {
+		t.Errorf("modern tools/list = %v, want only the tool this passport may invoke", modern)
+	}
+	if !slices.Equal(modern, legacy) {
+		t.Errorf("modern tools/list = %v, legacy = %v — one surface, one filter", modern, legacy)
+	}
+}
+
+// A result this server cannot render as an object is its own defect, and it
+// must surface as one rather than as a result the framing cannot describe.
+func TestAModernResultThatIsNotAnObjectIsReportedRatherThanShipped(t *testing.T) {
+	_, err := json.Marshal(modernResult{
+		inner:   []string{"not", "an", "object"},
+		members: map[string]any{fieldResultType: resultTypeComplete},
+	})
+
+	if err == nil {
+		t.Fatal("a non-object result marshalled cleanly, so the framing's own members went missing in silence")
+	}
+	if !strings.Contains(err.Error(), "must be a JSON object") {
+		t.Errorf("error = %v, want it to name what is wrong", err)
+	}
+}
+
+// The handler's own bytes reach the client unchanged. A round trip through
+// map[string]any would widen this version past float64's exact integer range,
+// and the decorated result would disagree with the text block beside it.
+func TestDecoratingAResultDoesNotRewriteTheHandlersBytes(t *testing.T) {
+	const exact = `{"version":9007199254740993}`
+
+	body, err := json.Marshal(modernResult{
+		inner:   map[string]any{"structuredContent": json.RawMessage(exact)},
+		members: map[string]any{fieldResultType: resultTypeComplete},
+	})
+	if err != nil {
+		t.Fatalf("marshalling: %v", err)
+	}
+
+	if !strings.Contains(string(body), `9007199254740993`) {
+		t.Errorf("result = %s, want the handler's integer unchanged", body)
+	}
+}

--- a/backend/internal/modules/agents/modern_test.go
+++ b/backend/internal/modules/agents/modern_test.go
@@ -758,16 +758,29 @@ func TestBothFramingsFilterTheToolListByTheCallersScopes(t *testing.T) {
 // A result this server cannot render as an object is its own defect, and it
 // must surface as one rather than as a result the framing cannot describe.
 func TestAModernResultThatIsNotAnObjectIsReportedRatherThanShipped(t *testing.T) {
-	_, err := json.Marshal(modernResult{
-		inner:   []string{"not", "an", "object"},
-		members: map[string]any{fieldResultType: resultTypeComplete},
-	})
+	for _, tc := range []struct {
+		name  string
+		inner any
+	}{
+		{"an array", []string{"not", "an", "object"}},
+		// A null decodes into a map WITHOUT error and leaves it nil, so this
+		// case reaches the member loop and panics unless it is caught by name.
+		{"a null", nil},
+		{"a nil map, which marshals to null", map[string]any(nil)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := json.Marshal(modernResult{
+				inner:   tc.inner,
+				members: map[string]any{fieldResultType: resultTypeComplete},
+			})
 
-	if err == nil {
-		t.Fatal("a non-object result marshalled cleanly, so the framing's own members went missing in silence")
-	}
-	if !strings.Contains(err.Error(), "must be a JSON object") {
-		t.Errorf("error = %v, want it to name what is wrong", err)
+			if err == nil {
+				t.Fatal("it marshalled cleanly, so the framing's own members went missing in silence")
+			}
+			if !strings.Contains(err.Error(), "must be a JSON object") {
+				t.Errorf("error = %v, want it to name what is wrong", err)
+			}
+		})
 	}
 }
 

--- a/backend/internal/modules/agents/modern_test.go
+++ b/backend/internal/modules/agents/modern_test.go
@@ -14,10 +14,12 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/mcp"
 )
 
 // The wire tokens, spelled here as the specification writes them rather than
@@ -101,6 +103,30 @@ func TestTheEraIsDecidedByTheBodyOrByTheHeaderThatNamesIt(t *testing.T) {
 			"params that are not an object declare nothing",
 			json.RawMessage(`[1,2]`), "", false, 0,
 		},
+		// EITHER reserved key is a declaration. A body naming only its
+		// capabilities has claimed the modern framing and got the declaration
+		// wrong — serving it as a handshake-era call would answer a malformed
+		// modern request instead of refusing it.
+		{
+			"capabilities alone, with no transport version",
+			json.RawMessage(`{"_meta":{"io.modelcontextprotocol/clientCapabilities":{}}}`), "",
+			true, codeInvalidParams,
+		},
+		// And a version of the wrong TYPE is a declaration too. Reading it as
+		// an absent one would demote the request to the other era, which is the
+		// same escape by a different door.
+		{
+			"a version sent as a number",
+			json.RawMessage(`{"_meta":{"io.modelcontextprotocol/protocolVersion":20260728,` +
+				`"io.modelcontextprotocol/clientCapabilities":{}}}`), "",
+			true, codeInvalidParams,
+		},
+		{
+			"a version sent as null",
+			json.RawMessage(`{"_meta":{"io.modelcontextprotocol/protocolVersion":null,` +
+				`"io.modelcontextprotocol/clientCapabilities":{}}}`), "",
+			true, codeInvalidParams,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			fr, refusal := modernPrecheck(tc.params, tc.transportVersion)
@@ -120,9 +146,9 @@ func TestTheEraIsDecidedByTheBodyOrByTheHeaderThatNamesIt(t *testing.T) {
 	}
 }
 
-// Both per-request fields are required, and their absence is a malformed
-// request rather than an empty value — the distinction the pointer members
-// exist to keep.
+// Both per-request fields are required, and a request that carries one of them
+// wrongly is malformed rather than empty — which is why the metadata is held
+// raw and each member judged on its own.
 func TestAModernRequestMustCarryItsVersionAndItsCapabilities(t *testing.T) {
 	for _, tc := range []struct{ name, params, wantNamed string }{
 		{
@@ -135,18 +161,40 @@ func TestAModernRequestMustCarryItsVersionAndItsCapabilities(t *testing.T) {
 			`{"_meta":{"io.modelcontextprotocol/clientCapabilities":{}}}`,
 			metaProtocolVersion,
 		},
+		// A JSON null unmarshals into a map WITHOUT error, leaving it nil, so a
+		// check that read only the error would call `null` an object.
+		{
+			"capabilities present as null",
+			`{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28",` +
+				`"io.modelcontextprotocol/clientCapabilities":null}}`,
+			metaClientCapabilities,
+		},
+		// And present-but-unreadable is refused too: capabilities this server
+		// cannot read are capabilities it would have to assume.
+		{
+			"capabilities present as an array",
+			`{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28",` +
+				`"io.modelcontextprotocol/clientCapabilities":[]}}`,
+			metaClientCapabilities,
+		},
+		{
+			"capabilities present as a string",
+			`{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28",` +
+				`"io.modelcontextprotocol/clientCapabilities":"tools"}}`,
+			metaClientCapabilities,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			_, refusal := modernPrecheck(json.RawMessage(tc.params), modernProtocolVersion)
 
 			if refusal == nil {
-				t.Fatal("admitted a request missing a required _meta field")
+				t.Fatal("admitted a request whose required _meta field is missing or unreadable")
 			}
 			if refusal.Code != codeInvalidParams {
 				t.Errorf("code = %d, want %d", refusal.Code, codeInvalidParams)
 			}
 			if !strings.Contains(refusal.Message, tc.wantNamed) {
-				t.Errorf("message %q must name the missing field %q", refusal.Message, tc.wantNamed)
+				t.Errorf("message %q must name the field at fault %q", refusal.Message, tc.wantNamed)
 			}
 		})
 	}
@@ -168,9 +216,9 @@ func TestAnUnservedModernVersionIsRefusedWithEveryVersionThisServerServes(t *tes
 			if refusal == nil || refusal.Code != codeUnsupportedProtocolVersion {
 				t.Fatalf("refusal = %#v, want %d", refusal, codeUnsupportedProtocolVersion)
 			}
-			data, ok := refusal.Data.(map[string]any)
-			if !ok {
-				t.Fatalf("data = %#v, want the supported/requested pair a client acts on", refusal.Data)
+			data := refusal.Data
+			if data == nil {
+				t.Fatal("the refusal carries no data, so a client has nothing to retry on")
 			}
 			supported, ok := data["supported"].([]string)
 			if !ok || !slices.Equal(supported, supportedProtocolVersions()) {
@@ -180,6 +228,31 @@ func TestAnUnservedModernVersionIsRefusedWithEveryVersionThisServerServes(t *tes
 				t.Errorf("data.requested = %v, want %q", data["requested"], requested)
 			}
 		})
+	}
+}
+
+// A refusal answers a request; it does not amplify one. The version is
+// caller-controlled and its length is not — a body is admitted up to 8 MiB and
+// the value is reflected twice — so what travels back is cut to a length this
+// server chose.
+func TestARefusedVersionIsNotEchoedBackWhole(t *testing.T) {
+	huge := strings.Repeat("A", 200_000)
+
+	refusal := unsupportedProtocolVersion(huge)
+
+	rendered, err := json.Marshal(refusal)
+	if err != nil {
+		t.Fatalf("marshalling the refusal: %v", err)
+	}
+	if len(rendered) > 1_000 {
+		t.Errorf("a %d-byte version produced a %d-byte refusal — the echo is unbounded",
+			len(huge), len(rendered))
+	}
+	// Multi-byte input is cut on a rune boundary: a cut through the middle of a
+	// character would put invalid UTF-8 into a JSON string, which the encoder
+	// silently rewrites into replacement characters.
+	if !utf8.ValidString(boundedEcho(strings.Repeat("é", 200))) {
+		t.Error("the bounded echo cut a multi-byte character in half")
 	}
 }
 
@@ -241,7 +314,7 @@ func TestEveryModernResultNamesItsTypeAndItsServer(t *testing.T) {
 	s := modernDispatcher(t)
 	ctx := scopedAgentCtx(principal.ScopeRead)
 
-	for _, method := range append([]string{methodPing, methodDiscover, methodToolsCall}, modernPrivateCatalogs...) {
+	for _, method := range append([]string{methodDiscover, methodToolsCall}, modernPrivateCatalogs...) {
 		t.Run(method, func(t *testing.T) {
 			params := modernParams("")
 			switch method {
@@ -369,10 +442,12 @@ func TestAToolResultCarriesNoCachingHint(t *testing.T) {
 	}
 }
 
-// Each era owns its opening call. Answering the other era's would tell a
-// client it had reached the server it was probing for, which is the one thing
-// those two calls exist to settle.
-func TestEachEraAnswersOnlyItsOwnOpeningCall(t *testing.T) {
+// A method belongs to the era that defines it. Answering another era's opening
+// call would tell a client it had reached the server it was probing for, which
+// is the one thing those two calls exist to settle — and answering a method
+// the modern revision REMOVED would advertise a surface that revision does not
+// have.
+func TestAMethodIsAnsweredOnlyInTheEraThatDefinesIt(t *testing.T) {
 	s := modernDispatcher(t)
 	for _, tc := range []struct {
 		name   string
@@ -381,6 +456,9 @@ func TestEachEraAnswersOnlyItsOwnOpeningCall(t *testing.T) {
 	}{
 		{"initialize in the modern framing", methodInitialize, framing{modern: true, version: modernProtocolVersion}},
 		{"server/discover in the handshake framing", methodDiscover, legacyFraming},
+		// ping went with the handshake it kept alive: a stateless request has
+		// no session to keep.
+		{"ping in the modern framing", methodPing, framing{modern: true, version: modernProtocolVersion}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			resp := s.handle(context.Background(), rpcRequest{
@@ -439,23 +517,71 @@ func TestALegacyResultIsRenderedExactlyAsItWasBefore(t *testing.T) {
 	}
 }
 
-// The caching contract names methods by hand, and a name that no longer
-// dispatches would leave a MUST unmet in silence. Deriving the check from the
-// dispatcher is what keeps the two sets from drifting apart.
-func TestEveryMethodDeclaredCacheableIsAnsweredByThisServer(t *testing.T) {
+// The six operations the specification makes carry a caching hint, spelled out
+// as IT spells them rather than read back off this server's own set.
+//
+// Reading the set the code declares would make this test agree with any set the
+// code declared, including one a method had quietly dropped out of — the MUST
+// would go unmet in silence, which is exactly the drift a fitness test is for.
+// The methods are also checked against the dispatcher, so a name here that no
+// longer answers fails rather than passing on a -32601.
+func TestEveryOperationTheProtocolMakesCacheableCarriesAHint(t *testing.T) {
 	s := modernDispatcher(t)
 
-	for _, method := range append([]string{methodDiscover}, modernPrivateCatalogs...) {
-		if _, cacheable := modernCacheHint(method); !cacheable {
-			t.Fatalf("%s is in the cacheable set but carries no hint", method)
-		}
-		resp := s.handle(scopedAgentCtx(principal.ScopeRead), rpcRequest{
-			JSONRPC: jsonRPCVersion, ID: json.RawMessage(`1`), Method: method,
-			Params: modernParams(""),
-		}, framing{modern: true, version: modernProtocolVersion})
-		if resp.Error != nil && resp.Error.Code == codeMethodNotFound {
-			t.Errorf("%s is declared cacheable and this server does not answer it", method)
-		}
+	for _, method := range []string{
+		"server/discover", "tools/list", "prompts/list",
+		"resources/list", "resources/templates/list", "resources/read",
+	} {
+		t.Run(method, func(t *testing.T) {
+			hint, cacheable := modernCacheHint(method)
+			if !cacheable {
+				t.Fatalf("%s carries no caching hint, and the specification makes one a MUST", method)
+			}
+			if hint.ttlMs < 0 {
+				t.Errorf("ttlMs = %d, and the specification requires >= 0", hint.ttlMs)
+			}
+			if hint.scope != cacheScopePublic && hint.scope != cacheScopePrivate {
+				t.Errorf("cacheScope = %q, want one of the two values the protocol defines", hint.scope)
+			}
+			resp := s.handle(scopedAgentCtx(principal.ScopeRead), rpcRequest{
+				JSONRPC: jsonRPCVersion, ID: json.RawMessage(`1`), Method: method,
+				Params: modernParams(`"uri":"margince://schema/query"`),
+			}, framing{modern: true, version: modernProtocolVersion})
+			if resp.Error != nil && resp.Error.Code == codeMethodNotFound {
+				t.Errorf("%s is declared cacheable and this server does not answer it", method)
+			}
+		})
+	}
+}
+
+// A document is not a catalog. resources/read answers the CONTENT, so a stale
+// copy is the disclosure rather than a menu that misleads — this server
+// promises no freshness on one and says so with a zero TTL, which keeps the
+// required member present rather than absent.
+func TestADocumentReadPromisesNoFreshnessAndIsNeverShared(t *testing.T) {
+	s := modernDispatcher(t).WithResources(stubResources{
+		published: []mcp.Resource{{
+			URI: "margince://schema/query", Name: "query_vocabulary", Title: "Workspace query vocabulary",
+			Description: "what you may ask", MIMEType: "application/json",
+			RequiredScope: principal.ScopeRead,
+		}},
+		contents: map[string]mcp.ResourceContents{
+			"margince://schema/query": {URI: "margince://schema/query", MIMEType: "application/json", Text: `{"fields":[]}`},
+		},
+	})
+
+	members := modernRPC(scopedAgentCtx(principal.ScopeRead), t, s, methodResourcesRead,
+		modernParams(`"uri":"margince://schema/query"`))
+
+	if got := string(members[fieldCacheScope]); got != `"`+cacheScopePrivate+`"` {
+		t.Errorf("%s = %s, want %q", fieldCacheScope, got, cacheScopePrivate)
+	}
+	if got := string(members[fieldTTLMs]); got != "0" {
+		t.Errorf("%s = %s, want 0 — a document read is not a catalog, and this server "+
+			"promises no freshness on content whose readability it re-derives per call", fieldTTLMs, got)
+	}
+	if _, present := members["contents"]; !present {
+		t.Errorf("the read answered no contents: %v", members)
 	}
 }
 
@@ -516,6 +642,70 @@ func TestBothFramingsReachOneAdmissionGate(t *testing.T) {
 	}
 	if got, want := answer(modern), answer(legacyFraming); got != want {
 		t.Errorf("the two framings answer differently:\nmodern %s\nlegacy %s", got, want)
+	}
+}
+
+// The conformance obligation that has to survive the second framing: a tool
+// declaring an outputSchema MUST answer with structured content conforming to
+// it, and the serialized JSON stays beside it in a text block.
+//
+// The modern framing merges its own members into that same result object, so
+// this is where decoration could quietly cost a result its structuredContent —
+// or widen the handler's bytes on the way through. Both renderings are checked
+// against the handler's own answer, byte for byte.
+func TestTheStructuredContentObligationHoldsInBothFramings(t *testing.T) {
+	const answer = `{"record_type":"deal","version":9007199254740993,"name":"Acme"}`
+	s := NewDispatcher(NewRegistry(nil, auth.NewGate(fullSeatAuthority{})), bindAuthenticated, "margince-crm", "test").
+		WithLogger(discardLog())
+	s.registry.Register(echoTool{
+		spec: objectSpec("read_record", principal.ScopeRead),
+		out:  json.RawMessage(answer),
+	})
+
+	for _, tc := range []struct {
+		name string
+		fr   framing
+	}{
+		{"the handshake era", legacyFraming},
+		{"the modern era", framing{modern: true, version: modernProtocolVersion}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := s.handle(scopedAgentCtx(principal.ScopeRead), rpcRequest{
+				JSONRPC: jsonRPCVersion, ID: json.RawMessage(`1`), Method: methodToolsCall,
+				Params: modernParams(`"name":"read_record","arguments":{}`),
+			}, tc.fr)
+			if resp.Error != nil {
+				t.Fatalf("tools/call → %d %q", resp.Error.Code, resp.Error.Message)
+			}
+			rendered, err := json.Marshal(resp.Result)
+			if err != nil {
+				t.Fatalf("marshalling the result: %v", err)
+			}
+			var result struct {
+				//nolint:tagliatelle // structuredContent is the MCP wire member, camelCase by the protocol
+				StructuredContent json.RawMessage `json:"structuredContent"`
+				Content           []struct {
+					Text string `json:"text"`
+				} `json:"content"`
+			}
+			if err := json.Unmarshal(rendered, &result); err != nil {
+				t.Fatalf("decoding the result: %v", err)
+			}
+
+			if len(result.StructuredContent) == 0 {
+				t.Fatalf("no structuredContent on a tool that declares an outputSchema: %s", rendered)
+			}
+			if got := string(payloadOf(t, result.StructuredContent)); got != answer {
+				t.Errorf("structuredContent payload = %s, want the handler's bytes unchanged %s", got, answer)
+			}
+			if len(result.Content) != 1 {
+				t.Fatalf("content = %v, want exactly one block", result.Content)
+			}
+			if result.Content[0].Text != string(result.StructuredContent) {
+				t.Errorf("the two renderings of one answer disagree:\ntext %s\nstructured %s",
+					result.Content[0].Text, result.StructuredContent)
+			}
+		})
 	}
 }
 

--- a/backend/internal/modules/agents/modern_test.go
+++ b/backend/internal/modules/agents/modern_test.go
@@ -220,12 +220,11 @@ func TestAnUnservedModernVersionIsRefusedWithEveryVersionThisServerServes(t *tes
 			if data == nil {
 				t.Fatal("the refusal carries no data, so a client has nothing to retry on")
 			}
-			supported, ok := data["supported"].([]string)
-			if !ok || !slices.Equal(supported, supportedProtocolVersions()) {
-				t.Errorf("data.supported = %#v, want %v", data["supported"], supportedProtocolVersions())
+			if !slices.Equal(data.Supported, supportedProtocolVersions()) {
+				t.Errorf("data.supported = %v, want %v", data.Supported, supportedProtocolVersions())
 			}
-			if data["requested"] != requested {
-				t.Errorf("data.requested = %v, want %q", data["requested"], requested)
+			if data.Requested != requested {
+				t.Errorf("data.requested = %q, want %q", data.Requested, requested)
 			}
 		})
 	}

--- a/backend/internal/modules/agents/resources.go
+++ b/backend/internal/modules/agents/resources.go
@@ -78,13 +78,13 @@ func (s *Dispatcher) readResource(ctx context.Context, params json.RawMessage) (
 		URI string `json:"uri"`
 	}
 	if err := json.Unmarshal(params, &p); err != nil {
-		return resourceContents{}, &rpcError{Code: -32602, Message: "invalid params: " + err.Error()}
+		return resourceContents{}, &rpcError{Code: codeInvalidParams, Message: "invalid params: " + err.Error()}
 	}
 	// An absent, null or empty uri is a request this server could not read,
 	// not a resource that is missing — a different thing for the caller to
 	// fix, and "" can never name a document any provider serves.
 	if p.URI == "" {
-		return resourceContents{}, &rpcError{Code: -32602, Message: "invalid params: resources/read needs a non-empty \"uri\""}
+		return resourceContents{}, &rpcError{Code: codeInvalidParams, Message: "invalid params: resources/read needs a non-empty \"uri\""}
 	}
 	if s.resources == nil {
 		return resourceContents{}, &rpcError{Code: resourceNotFound, Message: "no resource at " + p.URI}
@@ -102,7 +102,7 @@ func (s *Dispatcher) readResource(ctx context.Context, params json.RawMessage) (
 		// The cause is server-side knowledge (a pool fault, a wrapped SQL
 		// error); the client learns only that the read did not happen.
 		s.log.Error("mcp: reading resource", "uri", p.URI, "err", err)
-		return resourceContents{}, &rpcError{Code: -32603, Message: "the resource could not be read; retry, and if it persists ask an administrator to check the server logs"}
+		return resourceContents{}, &rpcError{Code: codeInternalError, Message: "the resource could not be read; retry, and if it persists ask an administrator to check the server logs"}
 	}
 	return resourceContents{Contents: []resourceContentBlock{{
 		URI: contents.URI, MIMEType: contents.MIMEType, Text: contents.Text,

--- a/backend/internal/modules/agents/resources_test.go
+++ b/backend/internal/modules/agents/resources_test.go
@@ -67,7 +67,7 @@ func rpcAs(ctx context.Context, t *testing.T, d *Dispatcher, method string, para
 	if params != "" {
 		req.Params = json.RawMessage(params)
 	}
-	return d.handle(ctx, req)
+	return d.handle(ctx, req, legacyFraming)
 }
 
 // A wired provider's documents are advertised; the catalogue is what a client

--- a/backend/internal/modules/agents/session.go
+++ b/backend/internal/modules/agents/session.go
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// The handshake era's session bookkeeping: what `initialize` mints, what
+// `DELETE /mcp` closes, and the two caps that keep the structure bounded.
+//
+// It is one file on purpose. A modern call carries its own state and mints
+// nothing here, so this is the whole of what the older framing needs and the
+// newer one does not — and it is what C2 removes once the per-Passport volume
+// counters that currently ride on it are live (ADR-0092 §6).
+
+import (
+	"sync"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// sessionKey identifies one live MCP session. The session id ALONE is
+// deliberately not enough to act on (DESIGN §10.4): every request
+// re-authenticates via the Bearer passport, which is where authority
+// comes from, so the id itself is unvalidated. Pairing it with the
+// presenting passport means DELETE can only ever close a session that
+// passport itself opened — keying on the id alone would let any
+// authenticated agent close another connector's session by guessing or
+// replaying its value.
+type sessionKey struct {
+	passportID ids.UUID
+	sessionID  string
+}
+
+// The two caps that make the registry a BOUNDED structure. Without them
+// `initialize` (240/min per passport at the edge) grows it forever: nothing but
+// an exact-match DELETE ever removed an entry, a client that crashes or drops
+// its connection never sends one, and every refresh rotation brings a fresh
+// passport with a fresh allowance of its own. The symptom of the unbounded
+// version is an api whose memory climbs until it is restarted, with no metric
+// naming the cause.
+//
+// Per passport, because a client legitimately holds ONE session: the cap is
+// above one only so a client reconnecting before its DELETE lands is not
+// squeezed, and the OLDEST entry gives way rather than the newest being
+// refused — the newest is the session the client is actually using.
+//
+// Across the whole registry, because the passport dimension is otherwise
+// unbounded on its own. The per-passport cap is what keeps one credential from
+// evicting everyone else's sessions to reach the global one.
+const (
+	maxSessionsPerPassport = 8
+	maxSessions            = 4096
+)
+
+// sessionRegistry is in-process bookkeeping for open MCP sessions,
+// scoped to ONE handler instance rather than a package-level global —
+// a global would leak state between two handlers (or two tests) in the
+// same process.
+//
+// The value is the insertion SEQUENCE, which is what "evict the oldest" reads:
+// a counter rather than a timestamp, so eviction order is exact and needs no
+// clock to be deterministic in a test.
+type sessionRegistry struct {
+	mu       sync.Mutex
+	sessions map[sessionKey]uint64
+	inserted uint64
+}
+
+func newSessionRegistry() *sessionRegistry {
+	return &sessionRegistry{sessions: make(map[sessionKey]uint64)}
+}
+
+// register records a new session under the presenting passport, evicting
+// whatever the caps above require. An evicted entry only ever costs its owner a
+// 404 on a DELETE it may never send.
+func (r *sessionRegistry) register(passportID ids.UUID, sessionID string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.evictForLocked(passportID)
+	r.inserted++
+	r.sessions[sessionKey{passportID, sessionID}] = r.inserted
+}
+
+// evictForLocked makes room for one more session under passportID: its own
+// oldest goes when that passport is at its cap, and otherwise the registry's
+// oldest goes when the whole map is at its. Both scans walk the map, which is
+// bounded by maxSessions by construction.
+func (r *sessionRegistry) evictForLocked(passportID ids.UUID) {
+	if r.evictOldestLocked(func(key sessionKey) bool { return key.passportID == passportID },
+		maxSessionsPerPassport) {
+		return
+	}
+	r.evictOldestLocked(func(sessionKey) bool { return true }, maxSessions)
+}
+
+// evictOldestLocked drops the lowest-sequence entry matching `counts` if at
+// least `limit` entries match it, and reports whether it evicted anything.
+func (r *sessionRegistry) evictOldestLocked(counts func(sessionKey) bool, limit int) bool {
+	matching := 0
+	var oldest sessionKey
+	oldestAt := uint64(0)
+	for key, at := range r.sessions {
+		if !counts(key) {
+			continue
+		}
+		matching++
+		if oldestAt == 0 || at < oldestAt {
+			oldest, oldestAt = key, at
+		}
+	}
+	if matching < limit {
+		return false
+	}
+	delete(r.sessions, oldest)
+	return true
+}
+
+// close removes the session sessionID owned by passportID. It reports
+// false, leaving the registry untouched, when no session exists under
+// that exact pair — including a sessionID that IS live but under a
+// different passport. Those two cases must read identically: telling
+// them apart would let a DELETE probe confirm another connector's
+// session id is currently open.
+func (r *sessionRegistry) close(passportID ids.UUID, sessionID string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	key := sessionKey{passportID, sessionID}
+	if _, ok := r.sessions[key]; !ok {
+		return false
+	}
+	delete(r.sessions, key)
+	return true
+}

--- a/backend/internal/modules/agents/toollist.go
+++ b/backend/internal/modules/agents/toollist.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package agents
+
+// What a caller is SHOWN: the tool list tools/list answers, filtered to what
+// this principal could invoke at all, and the description each entry carries.
+//
+// It sits beside the dispatcher rather than inside it because advertising and
+// dispatching answer different questions. This decides what a client is told
+// exists; the gate decides what it may do. The two must agree without being the
+// same code — a surface that advertises what the gate will refuse is a surface
+// that lies, and the client's only way to learn the truth is to call and be
+// denied.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+	"github.com/gradionhq/margince/backend/internal/shared/ports/mcp"
+)
+
+// invocableByCaller reports whether the calling principal's passport scopes
+// would let it invoke spec at all. It mirrors the scope arm of auth.Gate.Admit
+// deliberately — a surface that advertises what the gate will refuse is a
+// surface that lies, and the client's only way to discover the truth is to
+// call and be denied.
+//
+// It answers the SCOPE axis only, which is what §5.7 promises. The seat
+// ceiling and object RBAC are re-derived per call through the authority seam
+// and are a named follow-up (§10.2); this filter must not pretend to enforce
+// them, and Registry.Invoke remains the authority for every one of them.
+//
+// A ctx with no principal shows nothing rather than everything: the caller of
+// a tools/list that never authenticated has no scopes, and an empty surface is
+// the honest answer.
+func invocableByCaller(ctx context.Context, spec mcp.ToolSpec) bool {
+	p, ok := principal.Actor(ctx)
+	if !ok {
+		return false
+	}
+	// Humans and the system principal do not ride the scope model — their
+	// authority is their RBAC, enforced at the store — so filtering them by a
+	// passport scope they never carry would hide the whole surface.
+	if p.Type != principal.PrincipalAgent {
+		return true
+	}
+	return p.Scopes.Has(spec.RequiredScope)
+}
+
+// DescribeForClient is the description one tool is advertised with: what the
+// tool is FOR, written on its spec, followed by how this server will govern the
+// call. It is exported because tools/list is not the only surface that serves
+// it — the operator console reads the same text through GET /v1/agent-tools,
+// and a second rendering there would be a second answer to what a client is
+// told.
+//
+// The order is the point. The written text answers the question a model is
+// actually asking — which of thirty tools serves this goal — and the governance
+// clause answers what happens once it has chosen. A description carrying only
+// the second tells a model the passport scope of every tool and the purpose of
+// none.
+//
+// The tier and scope are re-stated from the spec the admission gate enforces,
+// so they cannot disagree with it. The crm.yaml operation family is NOT here:
+// it is developer documentation, and a model has no use for the name of an
+// endpoint it has no way to call. It stays on ToolSpec.OpenAPIOp, which is what
+// the contract-parity gate reads.
+func DescribeForClient(spec mcp.ToolSpec) string {
+	// Every arm is named, and the fallthrough is the CONSERVATIVE reading, not
+	// the convenient one: the admission gate treats anything that is not
+	// TierAutoExecute as confirm-first, so a tier added without updating this
+	// switch must not be advertised as running unattended. The same posture
+	// tierWire takes on the REST side, for the same reason.
+	tier := "a person approves every call before it runs"
+	switch spec.Tier {
+	case mcp.TierAutoExecute:
+		tier = "runs immediately"
+	case mcp.TierConfirmationRequired:
+		tier = "a person approves every call before it runs"
+	case mcp.TierDynamic:
+		tier = "some calls run immediately and others a person approves first, decided per call from its arguments"
+	}
+	return fmt.Sprintf("%s (Governance: %s; requires passport scope %q.)", spec.Description, tier, spec.RequiredScope)
+}
+
+func (s *Dispatcher) toolList(ctx context.Context) []map[string]any {
+	specs := s.registry.Specs()
+	tools := make([]map[string]any, 0, len(specs))
+	for _, spec := range specs {
+		if !invocableByCaller(ctx, spec) {
+			continue
+		}
+		tool := map[string]any{
+			fieldName: spec.Name,
+			// Top-level title outranks annotations.title for display, and both
+			// outrank the name. Registry.Register refuses a title-less tool, so
+			// neither is ever the empty string here.
+			fieldTitle:    spec.Title,
+			"description": DescribeForClient(spec),
+			"inputSchema": spec.InputSchema,
+			// The two hints this server can state as FACTS, both read off the
+			// spec the admission gate itself enforces rather than restated by
+			// hand: what a tool may change is its scope, and whether it leaves
+			// the workspace is its egress flag.
+			//
+			// destructiveHint and idempotentHint are deliberately absent: their
+			// protocol defaults (destructive, non-idempotent) are already the
+			// conservative reading, and only the looser value would need a
+			// per-tool judgement, with nothing to hold it true.
+			"annotations": map[string]any{
+				fieldTitle:      spec.Title,
+				"readOnlyHint":  spec.ReadOnly(),
+				"openWorldHint": spec.Egress,
+			},
+		}
+		if spec.OutputSchema != nil {
+			tool["outputSchema"] = spec.OutputSchema
+		}
+		tools = append(tools, tool)
+	}
+	return tools
+}

--- a/docs/reference/agent-tools.md
+++ b/docs/reference/agent-tools.md
@@ -258,47 +258,86 @@ Two properties worth relying on:
 `backend/internal/modules/agents/dispatch.go` behind the transport in
 `httpmcp.go`.
 
-**Methods answered:** `initialize`, `ping`, `tools/list`, `tools/call`,
-`resources/list`, `resources/templates/list`, `prompts/list`. Anything else is
-`-32601 method not found`.
+**Two framings, one dispatcher, chosen per request** (ADR-0092/A141). A request
+that declares its own protocol version in
+`params._meta["io.modelcontextprotocol/protocolVersion"]` — or whose
+`MCP-Protocol-Version` header names the modern revision — is served as
+**modern** (`2026-07-28`): no handshake, no session, and everything the call
+needs travels with it. Anything else is served as **handshake-era** exactly as
+before. The framing decides how a call is *parsed and rendered*, never what it
+may do: both reach the same registry and the same admission gate.
 
-**Protocol versions**, newest first: `2025-11-25`, `2025-06-18`, `2025-03-26`.
-`initialize` echoes the client's requested revision when the server satisfies it,
-and otherwise answers with the newest — never the client's unsupported one, which
-would promise a handshake the server cannot honor. A *present* and unsupported
-`MCP-Protocol-Version` header on a non-`initialize` request is refused with a
-plain `400` whose body is prose, deliberately **not** a `-32022`
-`UnsupportedProtocolVersionError`: a dual-era client identifies this server as
-legacy by seeing a 4xx *without* a recognized modern error body and then falls
-back to `initialize`. `2024-11-05` is excluded because it predates Streamable
-HTTP.
+**Methods answered:** `ping`, `tools/list`, `tools/call`, `resources/list`,
+`resources/read`, `resources/templates/list`, `prompts/list`, plus each era's
+own opening call — `initialize` in the handshake framing and `server/discover`
+in the modern one. Each is `-32601` in the *other* framing, because answering it
+would tell a client it had reached the era it was probing for. Anything else is
+`-32601 method not found` — with HTTP `404` in the modern framing, which is what
+lets a dual-era client tell this server from one that does not host the endpoint.
 
-**`resources/list` and `prompts/list` answer empty rather than `-32601`.** This
-server has no resources and no prompts, but claude.ai calls both right after
-`initialize` regardless, and an unadvertised capability answering "method not
-found" reads as a broken server rather than as a legitimate empty catalog.
+**Protocol versions**, newest first: `2026-07-28` (modern, per request),
+`2025-11-25` and `2025-06-18` (handshake era). `2025-03-26` was **dropped** from
+the compatibility window; `2024-11-05` was never served, because it predates
+Streamable HTTP. `initialize` echoes the client's requested revision when the
+server satisfies it in the handshake era, and otherwise answers with the newest
+one it does — never the client's unsupported one, and never the modern
+revision, which needs no handshake. A version this server does not serve is
+refused `400` with `-32022 UnsupportedProtocolVersion` and a `data.supported`
+list naming every revision it does, so a client retries rather than guesses.
+
+**A modern request must carry what it declares.** `_meta` must hold both
+`io.modelcontextprotocol/protocolVersion` and
+`io.modelcontextprotocol/clientCapabilities` (absent → `400` + `-32602`), and
+the `MCP-Protocol-Version`, `Mcp-Method` and `Mcp-Name` headers must each say
+what the body says (missing or contradicting → `400` + `-32020 HeaderMismatch`).
+The headers exist so an intermediary can route without parsing the body; the
+body is what this server executes, and the comparison is what stops those two
+readings from parting company. `Mcp-Name` may arrive Base64-sentinel encoded
+(`=?base64?…?=`) and is decoded before comparison.
+`-32021 MissingRequiredClientCapability` is never emitted: no tool here needs
+sampling, elicitation or roots.
+
+**Every modern result carries `resultType: "complete"` and
+`_meta["io.modelcontextprotocol/serverInfo"]`**, and every cacheable one carries
+`ttlMs` + `cacheScope`. `server/discover` is `public` — its bytes are the same
+for every caller, and a test holds that claim. Every catalog
+(`tools/list`, `resources/*`, `prompts/list`) is **`private`**: they are
+filtered per passport, and a shared cache entry on a scope-filtered response is
+a disclosure that never reaches the server to be audited. A TTL is a freshness
+hint, never a permission — every call re-authenticates, so a stale catalog
+cannot make a refused call succeed. A `tools/call` result carries no hint at all.
+
+**`resources/list` and `prompts/list` answer empty rather than `-32601`** when
+nothing is wired. claude.ai calls both right after `initialize` regardless, and
+an unadvertised capability answering "method not found" reads as a broken server
+rather than as a legitimate empty catalog. A `resources/read` refusal answers
+`-32002` in the handshake era and `-32602` in the modern one, which retired
+that code.
 
 **`GET /mcp` is `405`.** The transport serves `POST` (one JSON-RPC exchange) and
 `DELETE` (close the session this passport opened); the GET SSE stream is a later
-phase. That is also why `initialize` reports
-`capabilities.tools.listChanged: false` — the notification travels on the GET
-stream, so claiming it would promise a message that can never arrive. The surface
-really does change per caller, but the honest answer is that this server cannot
-announce it.
+phase. That is also why the capabilities report
+`tools.listChanged: false` — the notification travels on a stream this transport
+does not open, so claiming it would promise a message that can never arrive. The
+surface really does change per caller, but the honest answer is that this server
+cannot announce it.
 
 **A tool result carries the answer twice.** Every registered tool declares an
 `outputSchema`, so a successful `tools/call` returns the serialized JSON both in
 a `TextContent` block and as `structuredContent` — the same bytes passed through
 rather than a re-marshalled copy, so a client comparing the two never finds a
-widened integer or a reordered key. What is actually checked is object-ness, not
-the full schema; every `outputSchema` on this surface is the bare
-`{"type":"object"}`, for which the two are the same claim.
+widened integer or a reordered key. What is checked is the **declared schema** —
+each tool advertises the exact shape its handler marshals, and a result that
+misses it is withheld from `structuredContent` and logged as this server's own
+defect rather than served in violation of a promise it just made.
 
-**Sessions.** A successful `initialize` mints one and returns it as
-`Mcp-Session-Id`. `DELETE /mcp` closes only the session the *presenting*
-passport opened; a session id that does not exist under that passport — whether
-it never existed or belongs to someone else — answers `404` identically, so a
-probe cannot tell the two apart.
+**Sessions, in the handshake era only.** A successful `initialize` mints one and
+returns it as `Mcp-Session-Id`. `DELETE /mcp` closes only the session the
+*presenting* passport opened; a session id that does not exist under that
+passport — whether it never existed or belongs to someone else — answers `404`
+identically, so a probe cannot tell the two apart. A **modern** call mints none,
+and an `Mcp-Session-Id` presented on one is ignored rather than echoed: a call
+that carries its own state can land on any replica.
 
 **Every call re-authenticates.** The binder runs per call, not per session, so
 revoking the passport or demoting the granting human takes effect on the very

--- a/docs/reference/agent-tools.md
+++ b/docs/reference/agent-tools.md
@@ -267,11 +267,14 @@ needs travels with it. Anything else is served as **handshake-era** exactly as
 before. The framing decides how a call is *parsed and rendered*, never what it
 may do: both reach the same registry and the same admission gate.
 
-**Methods answered:** `ping`, `tools/list`, `tools/call`, `resources/list`,
-`resources/read`, `resources/templates/list`, `prompts/list`, plus each era's
-own opening call — `initialize` in the handshake framing and `server/discover`
-in the modern one. Each is `-32601` in the *other* framing, because answering it
-would tell a client it had reached the era it was probing for. Anything else is
+**Methods answered in both framings:** `tools/list`, `tools/call`,
+`resources/list`, `resources/read`, `resources/templates/list`, `prompts/list`.
+
+**Methods each era owns:** `initialize` and `ping` in the handshake framing,
+`server/discover` in the modern one. Each is `-32601` in the *other* framing.
+For the two opening calls, answering one would tell a client it had reached the
+era it was probing for; `ping` is simply gone — the `2026-07-28` revision
+removed it along with the handshake it kept alive. Anything else is
 `-32601 method not found` — with HTTP `404` in the modern framing, which is what
 lets a dual-era client tell this server from one that does not host the endpoint.
 
@@ -319,9 +322,11 @@ cannot make a refused call succeed. A `tools/call` result carries no hint at all
 **`resources/list` and `prompts/list` answer empty rather than `-32601`** when
 nothing is wired. claude.ai calls both right after `initialize` regardless, and
 an unadvertised capability answering "method not found" reads as a broken server
-rather than as a legitimate empty catalog. A `resources/read` refusal answers
-`-32002` in the handshake era and `-32602` in the modern one, which retired
-that code.
+rather than as a legitimate empty catalog. A `resources/read` **not-found**
+refusal answers `-32002` in the handshake era and `-32602` in the modern one,
+which retired that code; the rest of that method's refusal surface is
+era-independent — a missing or empty `uri` is `-32602` in both, and a read that
+fails internally is `-32603` in both.
 
 **`GET /mcp` is `405`.** The transport serves `POST` (one JSON-RPC exchange) and
 `DELETE` (close the session this passport opened); the GET SSE stream is a later

--- a/docs/reference/agent-tools.md
+++ b/docs/reference/agent-tools.md
@@ -292,10 +292,19 @@ the `MCP-Protocol-Version`, `Mcp-Method` and `Mcp-Name` headers must each say
 what the body says (missing or contradicting → `400` + `-32020 HeaderMismatch`).
 The headers exist so an intermediary can route without parsing the body; the
 body is what this server executes, and the comparison is what stops those two
-readings from parting company. `Mcp-Name` may arrive Base64-sentinel encoded
-(`=?base64?…?=`) and is decoded before comparison.
+readings from parting company — and the comparison is against the value the
+handler will actually act on, decoded exactly as the handler decodes it, because
+`encoding/json` matches members case-insensitively and takes the last of a
+duplicate pair while a map lookup does neither.
 `-32021 MissingRequiredClientCapability` is never emitted: no tool here needs
 sampling, elicitation or roots.
+
+**One caveat for anyone putting a gateway in front of `/mcp`.** `Mcp-Name` may
+arrive Base64-sentinel encoded (`=?base64?…?=`), and the protocol lets a client
+encode *any* value that way, including plain ASCII. This server decodes before
+comparing; an intermediary that filters on the raw header without implementing
+the sentinel is bypassed by encoding the value. Route on these headers only if
+you decode them the same way.
 
 **Every modern result carries `resultType: "complete"` and
 `_meta["io.modelcontextprotocol/serverInfo"]`**, and every cacheable one carries


### PR DESCRIPTION
One dispatcher, two framings, chosen per request — **ADR-0092 / A141**, and the [C-5](../../.tmp/mcp-roadmap/PROGRESS.md) row of the MCP roadmap. A modern client's call declares its own protocol version, identity and capabilities in `_meta` and needs no session; a handshake-era call still arrives after `initialize` and is parsed exactly as before.

**The framing decides how a call is parsed and rendered, never what it may do.** Both paths reach the same `Registry.Invoke` — the one admission gate ADR-0055 pins — and `TestBothFramingsReachOneAdmissionGate` holds it: the same tool, called by the same under-scoped principal, is refused identically in both, and an admitted call answers the same payload through either.

## What `2026-07-28` turned out to be

`dispatch.go` carried a comment describing the modern era from partial knowledge. It was right about the shape — per-request `_meta`, no `initialize`, `server/discover`, `-32022` — and did not know about four obligations that are also part of the revision. Each was read off the published spec, not inferred:

| obligation | what the tree assumed |
|---|---|
| **HTTP header mirroring.** `Mcp-Method` and `Mcp-Name` are REQUIRED on every modern POST and must match the body; a mismatch is `-32020 HeaderMismatch` + 400 | nothing |
| **`resultType`** on every modern result | nothing |
| **`ttlMs` + `cacheScope`** are a MUST on six operations' complete results | ADR-0092 §5 named the scope; the members were unknown |
| **`-32002` is retired**, replaced by `-32602` — and this server emits it today from `resources/read` | nothing |

`ping` also went with the handshake it kept alive, so it is answered only in the era that still defines it.

## The one rule that decides the era

> A request is **modern** when its body carries either reserved `_meta` key, **or** its `MCP-Protocol-Version` header names a version this server serves as modern.

Both clauses are hole-closers rather than redundancy. Without the header clause, a caller could name the modern revision where every intermediary routes on it, send a body with no `_meta`, and be parsed as legacy — skipping every modern check. Without "either key", a body naming only its capabilities was served as a handshake-era call instead of refused as a malformed modern one. A member of the wrong *type* is a declaration too, which is why the metadata is held raw and each member judged on its own.

The era is decided **once**, in the transport, and travels down as a value.

## Cache scope

`private` on all four caller-derived catalogs — the tool list is scope-filtered per passport, the resource list per what the principal may read — because a shared entry on a scope-filtered response is a disclosure that never reaches the server to be audited. `public` only on `server/discover`, and **a test holds that claim** by asking three different principals and comparing byte for byte. `resources/read` is neither: a document read *is* the content, so a stale copy is the disclosure rather than a menu, and it promises no freshness (`ttlMs: 0`).

A TTL is never a permission. Every call re-authenticates, so a minute-old catalog can mislead a client about what it may try and cannot make the attempt succeed.

## The compatibility window

`2025-11-25` and `2025-06-18` stay; **`2025-03-26` is dropped** (ADR-0092 §3). A version outside the window is now refused with `-32022` and the supported list rather than prose — the prose existed because a `-32022` would have sent a dual-era client to a framing this server could not answer, and it can answer it now.

## What four review passes changed

Codex, an adversarial pass, a craftsmanship pass and a security redteam. **The one that mattered most is a defect a passing test suite could not see:**

- **The mirror and the dispatcher read the same body member two different ways.** `encoding/json` matches members case-insensitively and takes the **last** of a duplicate pair; a map lookup does neither. A body carrying `{"name":"harmless_tool","NAME":"read_record"}` read as `harmless_tool` to the header check and as `read_record` to the handler — so a gateway allowlisting on `Mcp-Name` would permit one tool while this server ran another, which is verbatim the split the check exists to close. Both sides decode through the same shape now, and the defect test drives the three bodies whose two readings can differ. Server-side authority was never bypassable (the gate, RBAC and the read meter all still ran); what was defeated was the mirroring guarantee itself.
- **An unsupported-version refusal echoed a caller-controlled string twice, unbounded**, against an 8 MiB body cap — a 200 KB version produced a 400 KB refusal. It is cut to a length this server chose, on a rune boundary. The sibling rule was already written down for `-32020` and this path was the missing copy of it.
- **`Mcp-Name` was optional when the body named nothing**, and a header presented on a method that names nothing was accepted and ignored. Both are `-32020` now.
- **The cacheable set was self-referential**: every test iterated the set the code declares, so dropping a method from it left the suite green with a MUST unmet. The set is now asserted against the six methods the specification names.
- Four claims the code did not keep: a TTL comment arguing about catalogs while `resources/read` sat in the set, a comment calling two hardcoded empty lists "per-caller", a `%v` on a Go slice inside a client-facing message, and a test comment claiming a real `2025-03-26` client is refused here — it never sends the header at all, since the header was introduced in `2025-06-18`.

**One finding was declined**, with reasoning rather than silently: Codex called it a spec violation that `resources/list` and `prompts/list` answer empty rather than `-32601` when no capability is advertised. No MUST in the revision requires that — the changelog, which lists every change, does not mention it — and the leniency is a documented, deliberate accommodation for a client that calls both right after `initialize`. In production compose always wires the resource provider, so the case is theoretical besides.

## Proof

- **Both framings in the conformance suite** (C-5's condition): the `outputSchema` → `structuredContent` MUST, plus the text block beside it, asserted byte for byte through *each* framing — that is where decoration could quietly cost a result its structured content or widen the handler's integers.
- **Integration lane, real Postgres, real origin**: a modern client and a `2025-11-25` client both connect and each lands a record; a header/body mismatch is refused with **nothing written**; the dropped revision is refused with the supported list.
- **Six mutation checks**, each confirming a guard fails against the bug it describes: the era hole, the cache scope, header mirroring, the `-32002` remap, and the two readings above.
- Coverage 86.0% on `modules/agents`; every new function 75–100%, the three below 100% being error branches.
- `make check-backend` green; `craft static --strict` clean on `backend/`, `extensions/` and `fixtures/`.

## Not an aicert change

C1 registers no tool, retires none, and edits no prompt or corpus text, so no record's pin moves and the record-currency gate stays green — verified, not assumed.

## Deliberately not here

The **session registry stays**. Removing it is C2, and ADR-0092 §6 makes that ordering normative: the per-Passport volume counters must be live first. A modern call already mints no session, so this leaves the surface with fewer sessions and never fewer bounds. CIMD is C2's row. MRTR, `subscriptions/listen`, the GET stream, `x-mcp-header` and pagination are each a MAY that nothing here needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the 2026‑07‑28 modern MCP framing alongside the legacy handshake, selected per request. Tightens mirroring, era detection, and error responses so modern clients get clear 400s and consistent semantics.

- **New Features**
  - Dual framing: modern if body has reserved `_meta` (including wrong types) or the `MCP-Protocol-Version` header names a modern version; otherwise legacy.
  - Modern obligations: require mirrored `Mcp-Method`/`Mcp-Name` headers, `resultType` on all results, `ttlMs` + `cacheScope` on six cacheable methods; remap retired `-32002` to `-32602`; add `server/discover`; `ping` is legacy-only.
  - Cache scopes: `private` for caller-derived catalogs; `public` only for `server/discover`; `resources/read` is non-cacheable (`ttlMs: 0`).
  - Compatibility window: support `2025-11-25` and `2025-06-18`; drop `2025-03-26`; reject others with `-32022` and a bounded `supported` list.
  - Tests/docs: conformance for both framings; integration against real origin/DB; docs updated in `docs/reference/agent-tools.md`.

- **Bug Fixes**
  - No verb acts on a duplicated `MCP-Protocol-Version` header: POST returns `-32020` with a modern error body; DELETE returns plain 400; a duplicated header no longer selects the era, with demotion used only for the early path when the body fails to decode.
  - Duplicate mirrored headers (`Mcp-Method`, `Mcp-Name`, `MCP-Protocol-Version`) are rejected with `-32020` + 400; base64-decoded `Mcp-Name` emptiness is enforced.
  - Mirroring and dispatch now decode through the same shape to avoid case/duplicate-key mismatches; if the body fails to decode and a modern version is named, return the modern framing’s 400; structured error payloads are typed; decorating a `null` result takes the defect path instead of panicking.
  - Echoed version strings in `-32022` are safely bounded; `Mcp-Name` is required only on name-carrying methods and rejected on methods that don’t name anything; the cacheable set is asserted against the spec; `resources/read` invalid params use `-32602`.

<sup>Written for commit 04658ce0b25d3b2ede08f627d0c23322b8912bb8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/636?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for modern and legacy MCP protocol framings.
  - Modern requests now support per-request processing without sessions.
  - Added protocol discovery, version negotiation, capability metadata, and scope-aware tool listings.
  - Added structured responses, cache guidance, and improved resource and tool error handling.
  - Added validation for request headers, methods, versions, names, and malformed payloads.

- **Documentation**
  - Updated MCP reference documentation with framing, negotiation, sessions, metadata, caching, and error behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->