### PR TITLE
docs(status): the integration lane's cost is cut, so the record moves to the archive

### DIFF
--- a/STATUS-ARCHIVE.md
+++ b/STATUS-ARCHIVE.md
@@ -21,6 +21,69 @@
 > [CHANGELOG.md](CHANGELOG.md) and [README.md → *What works
 > today*](README.md#what-works-today).
 
+## 2026-08-08 — the integration lane got faster, and the measurement mattered more than the idea
+
+Closes #539. Landed as #556, #568, #574, #584 (splitting), #625 (a Redis-db
+collision the timing change exposed) and #626 (the connection sharing).
+
+Measured on one machine with Postgres restarted before each run: **220.5s wall
+and 512.3s summed before, 185.8s and 435.7s after** — about 15% off the wall
+clock. `compose/integration` went 188.3s to 160.6s, `compose` 74.5s to 59.2s.
+
+Two levers, and only the second was worth much.
+
+**Splitting packages is nearly spent.** The lane's wall clock cannot fall below
+its longest package, so `org360`, `capture` and the overlay suites became sibling
+packages under `compose/integration`. That is most of what splitting can give:
+ranked by measured seconds the tail of 116 clusters is 46% of the time, which no
+split reaches. `compose/integration/harness.go`'s package doc now states when a
+group is splittable and the two traps a split hits — a fixture is only importable
+if its METHODS are also in a non-test file, and once its type is foreign a suite
+cannot declare methods on it at all.
+
+**Sharing the connections was the real cut.** `testdb.Pool` gives each test
+PROCESS one pool per DSN instead of one per test. What sharing costs is the
+statement cache: a connection outliving a test also outlives any DDL that test
+ran, and pgx's default keeps a server-side prepared statement per connection, so
+a shared pool draws `SQLSTATE 0A000 "cached plan must not change result type"` in
+whichever suite runs next — a failure with nothing in it pointing at the DDL that
+caused it. The pools therefore run in `cache_describe`, which holds no
+server-side plan. Retiring connections at each reset was implemented first and
+discarded: it needs a list of which operations invalidate what, and most of the
+DDL is run by the tests themselves, so the reset is not in a position to keep
+that list.
+
+Three things this cost that are worth remembering.
+
+**The first version of the shared pool built its own pgxpool config and silently
+lost `jit=off`** — which `database.go` documents as 475ms of JIT behind 12ms of
+work on the `/search` union. The lane had been paying it. `testdb.Pool` now
+builds through `database.NewPool` and declares its differences as DSN parameters
+that constructor already honours, so the test pool is the product's pool with a
+named delta rather than a second constructor free to drift.
+
+**The timing change exposed a Redis-db collision that had been latent** (#625).
+The lane mapped packages onto logical dbs with `1 + (idx-1) % 15` and had grown
+past 15 packages, so two could share a db — and two of them `FLUSHDB` between
+tests, making a collision a corruption rather than a slowdown. Redis now serves
+64 dbs and the lane refuses to start rather than wrap the mapping.
+
+**Both `testdb` gates were mutation-tested, and one of them changed what I
+believed.** Rebuilding the pool from a bare `pgxpool.ParseConfig` turns the
+`jit` assertion red but leaves the typed-id slice bind green — under
+`cache_describe` the parameter OID always arrives from the server, so pgx never
+consults the registered type to encode `[]ids.PersonID`. The missing
+`RegisterIDTypes` was inert; the live loss was `jit`. Both assertions were kept
+with the asymmetry written down.
+
+Two obligations sharing creates are gated rather than documented, per the rule
+against rationalizing a gap in a comment: `Pool` refuses before `EnsureSchema`
+has run (a connection older than the migration's `DROP SCHEMA` would poison the
+whole package, not one test), and the fixtures assert the pool is quiesced at
+test end — closing the pool per test used to be an accidental backstop against a
+goroutine a test left running, and without it a half-stopped River client would
+write into the database the next test had just reset.
+
 ## 2026-08-07 — the integration lane's per-package timeout, and the lane it did not reach
 
 Closes #524 (#538 was the same report, closed as a duplicate of it).

--- a/STATUS.md
+++ b/STATUS.md
@@ -133,39 +133,36 @@ fallback), **#495** (auth rate limits are process-local, so N replicas multiply
 every ceiling by N), **#496** (audit-verb down migrations cannot see the rows
 their refusal probe checks for, under production RLS).
 
-## Open — the integration lane's cost, profiled
+## Open — the integration lane, what is left
 
-The lane is 1828 tests over 25 packages, ~493s summed (~300s wall, parallel).
-Profiled per test on 2026-08-06 because the suite *looked* inflated. It is not
-inflated by count: the slowest decile is 55% of the time and the fastest 1328
-tests together are 29%, so converting the small majority to unit tests would
-delete three-quarters of the suite to recover under a third of the runtime —
-and most of them assert database behaviour (RLS, CHECK→4xx, keyset pagination)
-that has no meaning without Postgres.
+The lane is 1938 tests over 29 packages, ~437s summed, ~186s wall. The two
+levers worth pulling have been pulled — package splitting and connection
+sharing, ~15% off the wall clock between them; see the archive for what each
+bought and what it cost. What remains is small and none of it is on the
+critical path:
 
-Where the cost actually is, and what is worth doing about it:
-
-- **#524** — `internal/compose/integration` is half the lane (960 tests) and
-  runs 258–302s against a 300s per-package timeout, so it flakes on a loaded
-  machine. CI shards 12 ways and never sees it; the unsharded local lane and
-  `make test-it` do. The 300s default is documented against the sharded
-  assumption, and the script already bumps to 900s for the whole-package case
-  but gates that on `COVERDIR` rather than on `SHARD_TOTAL == 1`.
-- **#539** — that package's setup forks about five Postgres backends per test.
-  Sharing them measured ~18% (170.9s vs a 209.6s baseline) and is **blocked**:
-  the harness drops `cf_*` columns between tests, so a pooled connection
-  outliving that DDL serves a stale plan and fails with SQLSTATE 0A000 in a
-  suite unrelated to custom fields. The issue records the design that would
-  unblock it and the four cheaper approaches that were measured and do not pay.
 - **#535** — table-driven tests calling their harness inside `t.Run`, re-seeding
   Postgres per case (~44s), which also hides that the property under test is pure.
 - **#536** — a few tests assert pure logic through a booted app; `check-test-lanes.sh`
   forbids the mirror case (a unit test opening real infra) but cannot see this one.
+- **#639** — two packages hand-roll the process pool `testdb.Pool` now owns.
+  Neither is broken today (neither runs DDL), but the hazard belongs to the
+  pattern rather than to those packages.
+- **#482** — `SQLSTATE 53200 out of shared memory`, still unfixed and now seen
+  in CI as well as locally. It costs a rerun and has to be hand-diagnosed each
+  time to tell it apart from a real failure; a `max_locks_per_transaction` bump
+  is the likely cheap fix.
 
-Two measurement notes for whoever picks this up. Run-to-run variance on the same
-commit is ~15%, so compare within one sitting on an idle machine. And both
-failures found while attempting #539 were order-dependent — they appeared only
-in a full-package or full-lane run, never in isolation.
+Do not expect much more from splitting: ranked by measured seconds, the tail of
+116 clusters is 46% of the time, which no split reaches.
+
+Three measurement notes for whoever picks this up. Run-to-run variance on the
+same commit is ~15%, so compare within one sitting on an idle machine.
+**Restart Postgres between runs** — #482 otherwise contaminates the second
+consecutive lane run, and a fresh container is worth ~25% on its own, so numbers
+taken across a restart boundary are not comparable to each other. And the
+failures found while doing #539 were all order-dependent: they appeared only in
+a full-package or full-lane run, never in isolation.
 
 ## Open — contract drift: the reset's response gained five fields
 


### PR DESCRIPTION
The lane profiling section had been open work in STATUS.md since 2026-08-06. Both levers it named have now been pulled — package splitting (#556, #568, #574, #584) and connection sharing (#539/#626) — so its narrative moves to STATUS-ARCHIVE.md, which is what STATUS.md's own header asks for: *this file carries open work only*.

**Measured**, one machine, Postgres restarted before each run: 220.5s wall / 512.3s summed → **185.8s / 435.7s**.

What stays in STATUS.md is what is still actionable: #535, #536, the new #639, and #482.

One measurement note is new and cost a wrong number earlier in the session: **restart Postgres between lane runs**. A fresh container is worth ~25% on its own, so two runs taken across a restart boundary are not comparable to each other.

The archive entry records three things worth not rediscovering — the first shared pool silently lost `jit=off` by building its own pgxpool config, the timing change exposed a latent Redis-db collision (#625), and mutation-testing the new gates showed the typed-id assertion *cannot* fail under `cache_describe` while the `jit` one can.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the integration-lane profiling from `STATUS.md` to `STATUS-ARCHIVE.md` now that package splitting and connection sharing have shipped, cutting wall time from 220.5s to 185.8s and summed time from 512.3s to 435.7s. `STATUS.md` now keeps only actionable follow-ups (#535, #536, #639, #482) and adds a note to restart Postgres between runs.

<sup>Written for commit 3b9f0c09da8d19f023f3223e0efeac1f9ce3519b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

