### PR TITLE
fix(people): the root dot is not part of a company's domain key, on either side

### DIFF
--- a/backend/internal/modules/people/companydomain.go
+++ b/backend/internal/modules/people/companydomain.go
@@ -87,6 +87,15 @@ func setCompanyDomain(ctx context.Context, tx pgx.Tx, orgID ids.OrganizationID, 
 // as "https://www.acme.com/about". The transport rejects an unparseable
 // website before it gets here; this guard keeps a malformed one out of the
 // domain index rather than storing it.
+//
+// It is the ONE reducer, and that is what the trailing dot is doing here. The
+// FQDN root form — `acme.example.`, and `https://acme.example./about`, where the
+// dot is inside the URL and trimming the string never reaches it — is the same
+// name to DNS and a different string to an index. Left in on the write side, one
+// company reachable by two spellings becomes two organizations, which is the
+// duplicate this module exists to prevent; left in on one side only, a read and
+// a write disagree about what they are looking at. The root dot is not part of
+// the key.
 func companyHost(website string) (string, error) {
 	if !strings.Contains(website, "://") {
 		website = "https://" + website
@@ -95,7 +104,12 @@ func companyHost(website string) (string, error) {
 	if err != nil || parsed.Hostname() == "" {
 		return "", fmt.Errorf("people: company website %q has no host", website)
 	}
-	return strings.TrimPrefix(strings.ToLower(parsed.Hostname()), "www."), nil
+	host := strings.TrimSuffix(strings.ToLower(parsed.Hostname()), ".")
+	host = strings.TrimPrefix(host, "www.")
+	if host == "" {
+		return "", fmt.Errorf("people: company website %q has no host", website)
+	}
+	return host, nil
 }
 
 // companyDomainWouldChange reports whether host differs from the anchor's

--- a/backend/internal/modules/people/companydomain_test.go
+++ b/backend/internal/modules/people/companydomain_test.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+import "testing"
+
+// companyHost is the ONE reducer the organization_domain index is keyed on: the
+// write path stores what it returns, and the resolve read looks up what it
+// returns. Every spelling of one company therefore has to come out the same, or
+// a read and a write disagree about which row they are holding — and two
+// spellings on the write side alone are two organizations for one company,
+// which is the duplicate this module exists to prevent.
+func TestCompanyHostReducesEverySpellingOfOneCompanyToOneKey(t *testing.T) {
+	for _, website := range []string{
+		"acme.example",
+		"ACME.example",
+		"www.acme.example",
+		"https://acme.example",
+		"https://www.acme.example/about",
+		"http://www.ACME.example/careers?ref=x",
+		// The FQDN root form, at the end of the string and inside a URL. The
+		// second is the one a string trim never reaches.
+		"acme.example.",
+		"www.acme.example.",
+		"https://www.acme.example./about",
+	} {
+		t.Run(website, func(t *testing.T) {
+			host, err := companyHost(website)
+			if err != nil {
+				t.Fatalf("companyHost(%q): %v", website, err)
+			}
+			if host != "acme.example" {
+				t.Errorf("companyHost(%q) = %q, want acme.example", website, host)
+			}
+		})
+	}
+}
+
+// A website with no host is refused rather than stored. A bare dot reduces to
+// nothing, and an empty key would match the first row with an empty domain.
+func TestCompanyHostRefusesAWebsiteWithNoHost(t *testing.T) {
+	for _, website := range []string{"", ".", "https://", "https:///path"} {
+		t.Run(website, func(t *testing.T) {
+			if host, err := companyHost(website); err == nil {
+				t.Errorf("companyHost(%q) = %q, want a refusal", website, host)
+			}
+		})
+	}
+}

--- a/backend/internal/modules/people/resolve.go
+++ b/backend/internal/modules/people/resolve.go
@@ -362,22 +362,14 @@ func companyDomains(c ResolveCandidate, consumerMail *freemail.Matcher) []string
 		// write path runs before storing a domain, so a claimed URL and a stored
 		// row meet in the middle instead of the caller's typing deciding whether
 		// this is an exact hit or a name guess.
-		// Whitespace comes off BEFORE companyHost, which prefixes a scheme onto
-		// anything without one and cannot parse a stray space. The FQDN root dot
-		// comes off AFTER, because it can sit inside a URL — `https://acme.example./x`
-		// — where trimming the string would never reach it. Both are the same
-		// name to DNS and a different string to an index, so an unstripped one is
-		// a key that matches nothing.
-		//
-		// Neither is companyHost's job: the write path it is shared with arrives
-		// through a transport that has already validated the string, and a tool
-		// argument has not.
-		host, err := companyHost(strings.TrimSpace(claimed))
-		if err != nil {
-			return
-		}
-		domain := strings.TrimSuffix(host, ".")
-		if domain == "" || consumerMail.IsConsumer(domain) {
+		// companyHost is what the organization_domain index is KEYED on, so a
+		// claimed URL and a stored row meet in the middle rather than at whatever
+		// this caller happened to type. The whitespace comes off first because
+		// companyHost prefixes a scheme onto anything without one and cannot
+		// parse a stray space — the write path it is shared with arrives through
+		// a transport that has already trimmed, and a tool argument has not.
+		domain, err := companyHost(strings.TrimSpace(claimed))
+		if err != nil || consumerMail.IsConsumer(domain) {
 			return
 		}
 		if _, dup := seen[domain]; dup {


### PR DESCRIPTION
**Follow-up to #635.** cubic raised this on that PR after it had already merged, so the fix lands on its own — same finding, same reviewer, one commit late.

## The defect

`website` carries no format constraint on the contract, so `acme.example.` and `https://acme.example./about` are both reachable input. The FQDN root form is the same name to DNS and a different string to an index.

#635 left the two sides disagreeing about it:

- the **resolve read** normalized through `companyHost` and then stripped the dot itself, looking up `acme.example`;
- **`companyHost`** — which is what every `organization_domain` write is keyed on — did not strip it, storing `acme.example.`.

So a company saved in the dotted form stored a row no lookup could reach, and a claim in the other form resolved to whichever organization happened to be keyed by the undotted name. `resolve_entities` would then answer `unresolved` for a company that exists, which is the one answer that leaves a caller free to create the duplicate.

## The fix

The stripping moves into `companyHost`, so the read and every organization-domain write share one reducer rather than agreeing by hand. That also closes a **write-side half nobody was looking for**: before this, two spellings of one company were two organizations — the duplicate this module exists to prevent, produced by the module itself.

Two forms, because they need different handling and the second is the one that bites:

- `acme.example.` — the dot ends the string.
- `https://acme.example./about` — the dot is *inside* the URL, where trimming the string never reaches it. My first attempt at this fix passed the first and failed the second, which is why both are in the table.

## Gated where the invariant lives

`companyHost` had no test of its own; it does now (`companydomain_test.go`), holding every spelling of one company to one key and refusing a website with no host — so the rule is checked at the reducer the write path uses, not only through the read that surfaced it.

## Existing rows

Not migrated, deliberately. A dotted row could only ever have been matched by an identically dotted claim, so it was already unreachable in practice, and this tree does not carry row-rewriting migrations. The undotted claim resolves it the moment the domain is re-saved.

## Gates

`make check-backend` green · `craft static --strict` clean · `make test-integration` — OK, 0 skips.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize company domains by stripping the trailing root dot in `companyHost` so reads and writes use the same key. This fixes unreachable rows and prevents duplicate organizations from `acme.example.` vs `acme.example`.

- **Bug Fixes**
  - Moved trailing `.` handling into `companyHost`; also lowercases, strips `www.`, and rejects inputs with no host.
  - Resolve path now relies on `companyHost` (after trimming spaces) instead of custom dot stripping.
  - Added unit tests to ensure all spellings reduce to `acme.example` and to refuse no-host inputs.

- **Migration**
  - No data migration. Dotted rows were effectively unreachable; re-saving the domain writes the undotted key.

<sup>Written for commit 1cb0d2dabd96f3df0c3907105517a14df28acb97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

