### PR TITLE
docs(status): C2 is the pickup point, and what it cost is worth writing down

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -510,6 +510,51 @@ Vite/React web UI. What is deliberately still stubbed (answering explicit
 The merge gate (`make check`), the real-Postgres integration lane
 (`make test-integration`), and the live-boot job are all green.
 
+## Session pickup — 2026-08-09 (C2: the session's implicit bound becomes four explicit counters, PR #647, merged `25016800`)
+
+ADR-0092 §4 and §6 in one change, in the order the ADR makes normative: the
+per-Passport counters go live BEFORE the MCP session registry is removed,
+because removing a bound and adding its replacement the other way round leaves
+the surface briefly unbounded. `platform/readmeter` became
+`platform/agentquota` (reads/writes/egress/calls/cost), CIMD joined DCR at the
+authorization server, and `agents/session.go` is gone — from **both** eras, since
+the id was never authority and keeping it for one would keep the replica pinning
+for the era with the most clients.
+
+**Nothing here is left open.** The follow-ups it declined to fold in are filed:
+[#645](https://github.com/gradionhq/margince-poc-v1/issues/645) (an approval's
+`workspace_id` answers as the zero uuid — pre-existing),
+[#646](https://github.com/gradionhq/margince-poc-v1/issues/646) (the REST *read*
+door consults the bound and charges nothing; the charge is per record and no
+single point on that door knows how many a handler served), and
+[#652](https://github.com/gradionhq/margince-poc-v1/issues/652) (a frontend
+flake in a file this PR does not touch).
+
+**What it cost, and why the next large PR should budget for it.** Three review
+passes, two bot passes and two live UATs found twenty-four defects, six of them
+serious, and the bot passes found their share AFTER the human-style reviews had
+run. Three lessons are recorded in
+[.tmp/mcp-roadmap/PROGRESS.md](.tmp/mcp-roadmap/PROGRESS.md) rather than here,
+because they generalize past this track:
+
+- **A quota counts what an agent DID.** Three separate charge points were wrong
+  in the same direction and every one read as correct: a `defer` charged a
+  REJECTED mutation, the call ceiling was charged before redemption so an invalid
+  token could exhaust a Passport's own ceiling, and a field-split path returned
+  past the charge. Ask "did the thing this counter names actually happen", not
+  "did this call arrive".
+- **Where a charge sits decides what it may refuse.** Before anything commits, an
+  uncountable call is not run; after a redemption, refusing burns a human's
+  approval on a call that never happened.
+- **NULL is not the zero uuid.** A target-less staging wrote NULL while every
+  dedup and decline probe compared `=` against `ids.UUID{}`, so two controls did
+  nothing, silently. Two reviewers found it independently and a live UAT
+  reproduced it.
+
+**Track C is complete; F2 is unblocked.** The next track to touch
+`modules/agents` should merge `main` early — this PR split `registry.go` into
+`registration.go`, deleted `session.go`, and rewrote both compose gates.
+
 ## Session pickup — 2026-08-06 (app chrome: the account menu, the app's scrollbars, and one orb, branch `fix/shell-chrome-and-one-orb`)
 
 Seven reported chrome defects, fixed as five invariants rather than five patches.


### PR DESCRIPTION
Track C is complete — #647 merged as `25016800`.

The pickup entry deliberately carries **what the next large PR should budget for** rather than a summary of the diff. Three review passes, two bot passes and two live UATs found twenty-four defects on that change, six of them serious, and the bot passes found their share *after* the human-style reviews had already run.

Three of the lessons generalize past that track, so they are recorded rather than left in a commit message:

- **A quota counts what an agent DID.** Three separate charge points were wrong in the same direction and each read as correct in review.
- **Where a charge sits decides what it may refuse.** Before anything commits, an uncountable call is not run; after a redemption, refusing burns a human's approval on a call that never happened.
- **NULL is not the zero uuid.** A target-less staging wrote NULL while every dedup and decline probe compared `=` against the zero value, so two controls did nothing, silently.

Also names the three issues C2 filed rather than folded in (#645, #646, #652), so none of them has to be rediscovered.

Docs only — no code, no gates affected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a STATUS entry for the C2 pickup to document the move from an implicit session bound to four explicit per‑Passport counters and the removal of the MCP session registry. It also notes the `platform/readmeter` → `platform/agentquota` rename, linked follow‑ups (#645, #646, #652), key lessons learned, and merge guidance for upcoming work.

<sup>Written for commit a2739230f21f4d93391aa0cd8cca6609e97513cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/653?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

