### PR TITLE
docs(status): PR 5 and the outbound attachments already shipped in #602

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -135,16 +135,39 @@ is offered *instead of a score when the band is unknown*, but its own worked
 example also names one when the band was merely capped — this build follows
 the example.
 
-Still unbuilt beyond that: PR 5 (documents), PR 6 (attachments, `ADR-0086`),
-PR 8 (account-started email, `ADR-0087`), PR 9/10 (finance, `ADR-0083`). Each
-needs a backend capability built from scratch.
+**Since shipped, and NOT to be rebuilt.** PR #602 merged PR 5 and the outbound
+half of PR 6 together with the slices above. Check the tree before planning any
+of it again — a session on 2026-08-09 lost an hour re-scoping PR 5 from a stale
+local checkout of `main` that predated #602:
 
-`make check`, `make craft-static`, `check-fe` and the integration lane (0
-skips) are green. Nothing is pushed: this work stays in the worktree until it
-is tested locally.
+- **PR 5 — documents.** Migration `0195_document_metadata` (DOC-DDL-1: category,
+  title, doc_state, pinned, supersedes_id, the organization/deal/project/activity
+  roll-up columns, the provider identity pair and `declared_type`, plus the
+  partial unique index and the account index). Wire: `listOrganizationDocuments`
+  (DOC-WIRE-1) and `updateAttachmentMetadata` (DOC-WIRE-2). Store:
+  `activities/documents.go`. Frontend: `companydocuments.tsx`.
+- **PR 6, outbound half.** Migration `0196_outbound_attachments` (DOC-DDL-2,
+  `comms_outbound_attachment` — the immutable snapshot of what a sent message
+  carried) and the attachment-carriage gate in the comms dispatcher.
 
-**Next**, in plan order: PR 5 (documents), then PR 6/8 (attachments,
-account-started email) and PR 9/10 (finance) against their ADRs.
+Two deviations from the chapter, both deliberate and both visible in the
+contract: DOC-WIRE-3's `pinAttachment`/`unpinAttachment` are folded into
+`updateAttachmentMetadata` as a sparse `pinned` field rather than shipping as
+two more operations, and that patch is NOT version-guarded because `attachment`
+carries no version column — the contract says so in its own description rather
+than advertising a precondition the row cannot honour.
+
+**Still unbuilt:** the INBOUND half of PR 6 (MIME parts through the capture
+sink — bounds DOC-PARAM-3/4/5, filename sanitization, sniffed-over-declared
+content type, idempotency on the provider's message-and-part identity), PR 8
+(account-started email, `ADR-0087`), and PR 9/10 (finance, `ADR-0083`).
+`connector.NormalizedRecord` carries no parts today, and `mailmap.extractText`
+skips every `*mail.AttachmentHeader` part silently — that is the starting point.
+
+Known gap, filed rather than fixed: **issue #663** — an object written before a
+transaction that then fails is never reclaimed, and Art. 17 erasure cannot reach
+it because erasure finds bytes through the attachment row. It predates the
+capture work and affects the human upload path too (DOC-AC-9).
 
 ## Open — two follow-ups left by ADR-0082/A127 (the own company, and internal mail)
 


### PR DESCRIPTION
STATUS.md listed PR 5 (documents) and PR 6 (attachments) as unbuilt. Both had already merged in #602.

Shipped and recorded here so nobody rebuilds it:

- **PR 5** — migration `0195_document_metadata` (the whole DOC-DDL-1 column set), `listOrganizationDocuments` (DOC-WIRE-1), `updateAttachmentMetadata` (DOC-WIRE-2), `activities/documents.go`, `companydocuments.tsx`.
- **PR 6, outbound half** — migration `0196_outbound_attachments` (DOC-DDL-2) and the attachment-carriage gate in the comms dispatcher.

Two deliberate departures from `documents-and-files.md` are now written down rather than left to be rediscovered: DOC-WIRE-3's pin/unpin are folded into `updateAttachmentMetadata` as a sparse `pinned` field, and that patch is not version-guarded because `attachment` has no version column.

What is genuinely left is stated too — the **inbound** half of PR 6, where `connector.NormalizedRecord` carries no parts and `mailmap.extractText` skips every attachment part in silence — plus PR 8 and PR 9/10.

Also links issue #663 (DOC-AC-9: an object written before a failed transaction is never reclaimed, and Art. 17 erasure cannot reach it) from the pickup point, since it predates this work and affects the human upload path too.

An hour was lost re-scoping PR 5 from a local checkout of `main` that was fifty commits behind origin. The correction says so, because the next session is the one that pays for it.

Docs only — one file, no code.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update STATUS.md to mark PR 5 (documents) and the outbound half of PR 6 (attachments) as shipped in #602 so they aren’t rebuilt.

It lists what shipped (migrations `0195_document_metadata` and `0196_outbound_attachments`, `listOrganizationDocuments`, `updateAttachmentMetadata`, `activities/documents.go`, `companydocuments.tsx`), notes two contract changes (pin/unpin folded into `updateAttachmentMetadata`; no version guard for attachments), calls out what remains (inbound attachments with `connector.NormalizedRecord`/`mailmap.extractText` as the starting point, PR 8, PR 9/10), links issue #663, and records the stale `main` checkout that caused a re-scope.

<sup>Written for commit 69f41edd23ae730f4515a5cc6d3bb76cc6ecd451. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/664?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

