### PR TITLE
docs: a test that supplies its own version of production becomes rule 6

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -445,3 +445,11 @@ the short form:
    to git, not the source. Same for test names.
 5. **Never rationalize a known gap in a comment** — restructure it away
    or gate it with a test.
+6. **A test that supplies its own version of production proves nothing
+   about production** — hand-inserted rows the real writer never writes,
+   or a hand-copied adapter mirroring what compose wires. Seed through
+   the real writer; if a test needs the wiring, reach for the wiring
+   (integration tests live directly in `package compose` so unexported
+   adapters are in scope). An unexpectedly uncovered new file usually
+   means a test double stands where the real thing should.
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -504,3 +504,11 @@ the short form:
    to git, not the source. Same for test names.
 5. **Never rationalize a known gap in a comment** — restructure it away
    or gate it with a test.
+6. **A test that supplies its own version of production proves nothing
+   about production** — hand-inserted rows the real writer never writes,
+   or a hand-copied adapter mirroring what compose wires. Seed through
+   the real writer; if a test needs the wiring, reach for the wiring
+   (integration tests live directly in `package compose` so unexported
+   adapters are in scope). An unexpectedly uncovered new file usually
+   means a test double stands where the real thing should.
+

--- a/README.md
+++ b/README.md
@@ -387,6 +387,23 @@ because getting it wrong once was expensive:
    happen (run-then-mark) or add the failing test that documents it
    honestly.
 
+6. **A test that supplies its own version of production proves nothing
+   about production.** Whatever a test substitutes for the real thing is
+   the part the real thing no longer has to get right. Two shapes, both
+   already shipped defects here: hand-inserted rows the real writer never
+   produces (a signal pass joined `activity_link` on an `entity_type`
+   capture never writes — every workspace found zero candidates, the job
+   reported success, the page rendered empty for a release), and a
+   hand-copied adapter mirroring what `compose` wires (a captured-file
+   suite built its own `FileKeeper`, so the production join could have
+   been deleted with nothing going red). Seed through the real writer, or
+   mirror its exact row shape; if a test needs the wiring, reach for the
+   wiring — integration tests live directly in `package compose` for
+   exactly this, so unexported adapters are in scope. The tell is writing
+   a struct in a test file whose fields mirror something `compose`
+   already builds, and an unexpectedly uncovered new file usually means a
+   test double stands where the real thing should.
+
 ## License
 
 **Business Source License 1.1** (`BUSL-1.1`) — see [LICENSE](LICENSE). Licensor:


### PR DESCRIPTION
Three shipped defects have come from the same mistake in two shapes. It earns a place beside the other five binding rules rather than being rediscovered a fourth time.

**Shape one — hand-inserted rows.** A signal pass joined `activity_link` on an `entity_type` capture never writes. Every real workspace found zero candidates, the hourly job reported success, and the company page rendered empty for a release. Green, because the fixture inserted that row shape by hand.

**Shape two — a hand-copied adapter.** The captured-file suite on #666 built its own `FileKeeper` and its own sink instead of the one `compose` wires, so `newCaptureSink` could have dropped the keeper entirely with nothing going red. Two reviewers found it independently — and so did the coverage gate, because a mirrored component is always the largest block of uncovered new code. That is the cheapest tell available and the rule names it.

The rule also carries the repo-specific way out: integration tests live directly in `package compose` (see `captureparticipant_integration_test.go`), so a test that needs unexported wiring has it in scope rather than needing a copy.

Long form in README beside the other five; short form mirrored in CLAUDE.md and AGENTS.md, matching how the existing rules are carried. `make check-craft-doc` green.

Docs only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add rule 6 to the testing rules: tests must not replace production with hand-made rows or hand-copied adapters. The README explains the rule and the fix (seed through the real writer; use `package compose` integration tests for unexported wiring), with a short form mirrored in `CLAUDE.md` and `AGENTS.md`.

<sup>Written for commit d8eb874d1363324b48b462655fc00583016832f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/668?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

