### PR TITLE
fix(test): size Postgres's lock table for the lane, not for one app

### DIFF
--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -20,6 +20,16 @@ services:
     # pgvector ships inside the Postgres image: the search module's hybrid
     # retrieval needs the extension available at migrate time.
     image: pgvector/pgvector:pg16@sha256:1d533553fefe4f12e5d80c7b80622ba0c382abb5758856f52983d8789179f0fb
+    # The lock table, sized for the integration lane rather than for one app.
+    # Postgres pre-allocates max_locks_per_transaction * max_connections slots at
+    # boot and shares them across every backend, and the lane's reset takes one
+    # per relation — every table AND every index — inside a single transaction,
+    # on up to INTEGRATION_JOBS databases at once. At the default 64 that pool is
+    # exhausted well before max_connections is, and the failure is
+    # `out of shared memory (SQLSTATE 53200)` in whichever package happened to
+    # ask next. Slots are a few hundred bytes each, so this costs single-digit
+    # megabytes and buys the lane its concurrency back.
+    command: ["postgres", "-c", "max_locks_per_transaction=512"]
     environment:
       POSTGRES_USER: margince_owner
       POSTGRES_PASSWORD: dev


### PR DESCRIPTION
Closes #482.

`out of shared memory (SQLSTATE 53200)` has been failing the integration lane intermittently for weeks, in whichever package happened to ask next, and it had to be hand-diagnosed each time to tell it apart from a real failure.

## The cause is the lock table specifically

Postgres pre-allocates `max_locks_per_transaction * max_connections` lock slots at boot and **shares them across every backend** — the per-transaction name is misleading, it is a server-wide pool.

The lane's reset takes one slot per relation (every index as well as every table) inside a single transaction, and does that on up to `INTEGRATION_JOBS` databases at once. At the default 64, with `max_connections=100`, the pool runs out long before connections do.

512 costs single-digit megabytes.

## Verified against the reliable reproduction

Two consecutive lane runs with no Postgres restart between them.

| | before | after |
|---|---|---|
| 2nd consecutive run | fails with 53200 | green |
| 3rd consecutive run | — | green |
| 53200 occurrences | — | **0** |

## A measurement worth recording

This also lifts the ceiling on lane concurrency: `INTEGRATION_JOBS=16` now completes where it used to fail outright. That turns out **not** to be worth raising the default for — at 16 the lane measured *slower* than at 8 (200s vs 185s), so the lane is bound by the single Postgres container, not by CPU or by how many packages run at once. Only ~1.2 of 8 cores are busy during a run.

Recorded in the commit message so the next person reads the measurement rather than repeating it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raise Postgres lock slots to `max_locks_per_transaction=512` to stop intermittent `out of shared memory (SQLSTATE 53200)` in the integration lane and stabilize runs. Sized for the lane’s server-wide pool, not a single app.

- **Bug Fixes**
  - Set `max_locks_per_transaction=512` on the `pgvector/pgvector:pg16` container in `infra/docker-compose.dev.yml`.
  - Prevents lock pool exhaustion during lane resets across parallel DBs.
  - Validated on consecutive runs; restores reliability and supports higher lane concurrency; default job count unchanged.

<sup>Written for commit 353b62db869c299284f0a684f5e20993827754c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/671?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the development environment’s PostgreSQL configuration to support more locks per transaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->