### PR TITLE
refactor(test): the job fan-out suites become their own package

### DIFF
--- a/backend/internal/compose/integration/ai_call_integration_test.go
+++ b/backend/internal/compose/integration/ai_call_integration_test.go
@@ -255,7 +255,7 @@ func TestEmbedCallRetentionAgesOutOverAgeEmbeddingRows(t *testing.T) {
 	underAge := seedEmbedCall(t, e, 10)
 
 	svc := privacy.NewRetentionService(e.Pool, nil, slog.New(slog.NewTextHandler(os.Stderr, nil)))
-	if err := svc.EvaluateWorkspace(retentionPassCtx(e.WS)); err != nil {
+	if err := svc.EvaluateWorkspace(RetentionPassCtx(e.WS)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -295,7 +295,7 @@ func TestAICallPayloadRetentionAgesOutContentKeepingMetadata(t *testing.T) {
 		VALUES (NULLIF(current_setting('app.workspace_id', true), '')::uuid, 'ai_call_payload', 'content', 365, 'erase')`)
 
 	svc := privacy.NewRetentionService(e.Pool, nil, slog.New(slog.NewTextHandler(os.Stderr, nil)))
-	if err := svc.EvaluateWorkspace(retentionPassCtx(e.WS)); err != nil {
+	if err := svc.EvaluateWorkspace(RetentionPassCtx(e.WS)); err != nil {
 		t.Fatal(err)
 	}
 

--- a/backend/internal/compose/integration/channelidentity_lifecycle_integration_test.go
+++ b/backend/internal/compose/integration/channelidentity_lifecycle_integration_test.go
@@ -151,7 +151,7 @@ func TestRetentionAnonymizeDropsTheChannelIdentityWithoutSuppressingIt(t *testin
 	e.WsExec(t, `UPDATE person SET created_at = now() - interval '800 days' WHERE id = $1`, person)
 
 	svc := privacy.NewRetentionService(e.Pool, nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
-	if err := svc.EvaluateWorkspace(retentionPassCtx(e.WS)); err != nil {
+	if err := svc.EvaluateWorkspace(RetentionPassCtx(e.WS)); err != nil {
 		t.Fatalf("retention pass: %v", err)
 	}
 

--- a/backend/internal/compose/integration/doc.go
+++ b/backend/internal/compose/integration/doc.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+// Package integration holds the cross-module integration suites — the
+// compose charter exercised end to end over a real migrated Postgres —
+// and the shared fixtures they ride. Three of those carry a database or a booted
+// app, and every suite starts from one of them — all exported, all in non-test
+// files:
+//
+//   - Env, here — a migrated database plus the core stores.
+//   - SearchEnv, in searchenv.go — lighter, and despite the name mostly taken
+//     for the database rather than the search store.
+//   - apptest.AppEnv, in the apptest subpackage — the booted application behind
+//     a TLS test server.
+//
+// Env and SearchEnv live here because the white-box suites that must stay in
+// their own package (compose root, briefs) import them, so neither may import
+// compose. AppEnv boots a compose handler stack and therefore CANNOT live here:
+// that would close a cycle through those same white-box tests. It sits one level
+// down instead, and nothing in apptest may import this package, or the cycle
+// closes from the other side.
+//
+// That rule is what decides where a promoted helper goes, and it is the first
+// thing a split runs into. A helper this package can hold becomes exported here
+// (SeedExtraWorkspace in seed.go, RetentionPassCtx in scope.go); one that needs
+// compose cannot, and joins a fixture subpackage instead — jobtest holds the
+// River job-runner ceremony for exactly that reason. The compiler reports the
+// violation as "import cycle not allowed in test", which names neither this file
+// nor the helper you just moved.
+//
+// Suites also live in sibling packages that import this one. That is how the
+// lane gets more than one scheduling slot: one package is one slot, and this
+// package is large enough to be the lane's long pole on its own. Which
+// subdirectories are those is answered by reading them rather than by a list
+// here that each split would have to remember to extend — a subdirectory
+// declaring Test functions is a suite slot, one declaring none is a fixture
+// package that exists because it must import compose (see below).
+//
+// Split a group out when it is a closed seam: it neither needs nor owes an
+// unexported helper across the boundary. It may ride any of the exported
+// fixtures, and more than one — a group is not stuck because it mixes them.
+// A helper that two such groups need is promoted here; one that only a group
+// needs stays with it.
+//
+// The unexported helpers are the visible half of that seam. The invisible half is
+// process-global state, because one package is one binary: anything an init()
+// arms — a jurisdiction pack, a registry — arms it for THIS binary only, and a
+// suite that moves out leaves it behind without a compile error. That is worse
+// than a missing helper, since the suite still runs; it just proves less. Check
+// what the group's package registers before moving it, and take the registration
+// along.
+//
+// Two things a split reliably runs into. A fixture is only importable if its
+// METHODS are in a non-test file too, since a method declared in a _test.go file
+// is not part of the package a sibling imports. And once the fixture's type is
+// foreign, a suite cannot declare methods on it at all — helpers a group keeps
+// become plain functions taking the fixture.
+package integration

--- a/backend/internal/compose/integration/embedreindex_fanout_integration_test.go
+++ b/backend/internal/compose/integration/embedreindex_fanout_integration_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/gradionhq/margince/backend/internal/compose"
 	"github.com/gradionhq/margince/backend/internal/compose/integration/apptest"
+	"github.com/gradionhq/margince/backend/internal/compose/integration/jobtest"
 	"github.com/gradionhq/margince/backend/internal/modules/ai"
 	"github.com/gradionhq/margince/backend/internal/modules/search"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -65,8 +66,8 @@ func setupReembedFleet(t *testing.T) *reembedFleetEnv {
 // reached every workspace it is ever going to.
 func TestEmbedReindexFansOutOneJobPerLiveWorkspaceAndFailsOnlyTheFailedTenant(t *testing.T) {
 	re := setupReembedFleet(t)
-	healthy := seedExtraWorkspace(t, re.Owner, "reindex-healthy", false)
-	archived := seedExtraWorkspace(t, re.Owner, "reindex-archived", true)
+	healthy := SeedExtraWorkspace(t, re.Owner, "reindex-healthy", false)
+	archived := SeedExtraWorkspace(t, re.Owner, "reindex-archived", true)
 
 	// Both live tenants get an entity to embed, so each child has real work and
 	// the victim's write actually reaches the fault.
@@ -81,7 +82,7 @@ func TestEmbedReindexFansOutOneJobPerLiveWorkspaceAndFailsOnlyTheFailedTenant(t 
 	// complete on a later attempt and read as green — the outcome this denies.
 	failEmbeddingWritesFor(t, re.Owner, re.WS)
 
-	runner, completed, failed := startTestJobRunner(t, re.Pool, compose.JobRunnerConfig{
+	runner, completed, failed := jobtest.StartTestJobRunner(t, re.Pool, compose.JobRunnerConfig{
 		CloseDateInterval: time.Hour,
 		ReconcileInterval: time.Hour,
 		TimeScanInterval:  time.Hour,
@@ -94,7 +95,7 @@ func TestEmbedReindexFansOutOneJobPerLiveWorkspaceAndFailsOnlyTheFailedTenant(t 
 	waitCtx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 	defer cancel()
 	kind := compose.EmbedReindexWorkspaceArgs{}.Kind()
-	outcomes := awaitWorkspaceJobOutcomes(waitCtx, t, completed, failed, kind, 2)
+	outcomes := jobtest.AwaitWorkspaceJobOutcomes(waitCtx, t, completed, failed, kind, 2)
 
 	if _, fannedOut := outcomes[healthy.String()]; !fannedOut {
 		t.Errorf("no re-embed ran for workspace %s — a tenant the fan-out skipped keeps a stale index, and no row records that it did not", healthy)
@@ -185,7 +186,7 @@ func TestEmbedReindexDispatcherWithAnEmptyFleetHandsTheMarkerBack(t *testing.T) 
 		t.Fatalf("archiving the only workspace: %v", err)
 	}
 
-	runner, completed, _ := startTestJobRunner(t, re.Pool, compose.JobRunnerConfig{
+	runner, completed, _ := jobtest.StartTestJobRunner(t, re.Pool, compose.JobRunnerConfig{
 		CloseDateInterval: time.Hour,
 		ReconcileInterval: time.Hour,
 		TimeScanInterval:  time.Hour,
@@ -196,7 +197,7 @@ func TestEmbedReindexDispatcherWithAnEmptyFleetHandsTheMarkerBack(t *testing.T) 
 	}
 	waitCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
-	awaitKindsCompleted(waitCtx, t, completed, compose.EmbedReindexArgs{}.Kind())
+	jobtest.AwaitKindsCompleted(waitCtx, t, completed, compose.EmbedReindexArgs{}.Kind())
 
 	populated, status, _, err := re.Store.PopulatedIdentity(context.Background())
 	if err != nil {

--- a/backend/internal/compose/integration/fieldhistory_integration_test.go
+++ b/backend/internal/compose/integration/fieldhistory_integration_test.go
@@ -462,7 +462,7 @@ func TestFieldHistoryExcludesRetentionArchiveMeta(t *testing.T) {
 	_, _, staleDeal, _ := seedOverAgeRecords(t, e)
 
 	svc := privacy.NewRetentionService(e.Pool, nil, slog.New(slog.NewTextHandler(os.Stderr, nil)))
-	if err := svc.EvaluateWorkspace(retentionPassCtx(e.WS)); err != nil {
+	if err := svc.EvaluateWorkspace(RetentionPassCtx(e.WS)); err != nil {
 		t.Fatalf("retention pass: %v", err)
 	}
 

--- a/backend/internal/compose/integration/harness.go
+++ b/backend/internal/compose/integration/harness.go
@@ -3,42 +3,6 @@
 
 //go:build integration
 
-// Package integration holds the cross-module integration suites — the
-// compose charter exercised end to end over a real migrated Postgres —
-// and the shared fixtures they ride. There are three, all exported, all in
-// non-test files:
-//
-//   - Env, here — a migrated database plus the core stores.
-//   - SearchEnv, in searchenv.go — lighter, and despite the name mostly taken
-//     for the database rather than the search store.
-//   - apptest.AppEnv, in the apptest subpackage — the booted application behind
-//     a TLS test server.
-//
-// Env and SearchEnv live here because the white-box suites that must stay in
-// their own package (compose root, briefs) import them, so neither may import
-// compose. AppEnv boots a compose handler stack and therefore CANNOT live here:
-// that would close a cycle through those same white-box tests. It sits one level
-// down instead, and nothing in apptest may import this package, or the cycle
-// closes from the other side.
-//
-// Suites also live in sibling packages that import this one. That is how the
-// lane gets more than one scheduling slot: one package is one slot, and this
-// package is large enough to be the lane's long pole on its own. The set of such
-// packages is the subdirectories of this one, which is where to look rather than
-// a list here that the next split would have to remember to extend — apptest is
-// the exception, a fixture package rather than a suite slot.
-//
-// Split a group out when it is a closed seam: it rides one of the three exported
-// fixtures, and it neither needs nor owes an unexported helper across the
-// boundary. Any of the three will do — a group riding AppEnv is no longer stuck.
-// A helper that two such groups need is promoted here; one that only a group
-// needs stays with it.
-//
-// Two things a split reliably runs into. A fixture is only importable if its
-// METHODS are in a non-test file too, since a method declared in a _test.go file
-// is not part of the package a sibling imports. And once the fixture's type is
-// foreign, a suite cannot declare methods on it at all — helpers a group keeps
-// become plain functions taking the fixture.
 package integration
 
 import (
@@ -454,10 +418,10 @@ var SchedulerPerms = principal.Permissions{
 	RowScope: principal.RowScopeTeam,
 }
 
-// ApplyRiverSchema gives this package's suites River's schema on the
-// harness-migrated database, as cmd/migrate does after core and custom. Several
-// suites here and in package compose drive a real River runner and each needs it
-// present.
+// ApplyRiverSchema gives a suite River's schema on the harness-migrated
+// database, as cmd/migrate does after core and custom. Every suite that drives a
+// real River runner needs it present, and those sit here, in package compose,
+// and in the sibling suite packages alike.
 //
 // Call it AFTER Setup — testdb.EnsureRiverSchema explains why the order matters
 // and why the guard probes the table rather than a flag.

--- a/backend/internal/compose/integration/jobfanout/agentscheduler_integration_test.go
+++ b/backend/internal/compose/integration/jobfanout/agentscheduler_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package integration
+package jobfanout
 
 // The Surface-B agent scheduler is one job row per live tenant. Its failure
 // mode is the opposite of the sweeps beside it: a tenant whose occurrence
@@ -20,6 +20,8 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration"
+	"github.com/gradionhq/margince/backend/internal/compose/integration/jobtest"
 	"github.com/gradionhq/margince/backend/internal/modules/agents/runner"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -150,8 +152,8 @@ func assertOccurrencesSeeded(t *testing.T, owner *pgx.Conn, ws ids.UUID, now tim
 // the same to every workspace behind it.
 func TestAgentSchedulerReportsTheWorkspaceWhoseSchedulingFailed(t *testing.T) {
 	re := setupRunner(t)
-	owner := OwnerConn(t)
-	healthy := seedExtraWorkspace(t, owner, "scheduler-healthy", false)
+	owner := integration.OwnerConn(t)
+	healthy := integration.SeedExtraWorkspace(t, owner, "scheduler-healthy", false)
 
 	const trigger = "morning_brief:fleet-isolation"
 	// Both tenants get real due work, seeded before the fault is armed: the
@@ -194,9 +196,9 @@ func TestAgentSchedulerReportsTheWorkspaceWhoseSchedulingFailed(t *testing.T) {
 // writes fail is the only row that fails.
 func TestAgentSchedulerFansOutOneJobPerLiveWorkspaceAndFailsOnlyTheFailedTenant(t *testing.T) {
 	re := setupRunner(t)
-	owner := OwnerConn(t)
-	healthy := seedExtraWorkspace(t, owner, "scheduler-healthy", false)
-	archived := seedExtraWorkspace(t, owner, "scheduler-archived", true)
+	owner := integration.OwnerConn(t)
+	healthy := integration.SeedExtraWorkspace(t, owner, "scheduler-healthy", false)
+	archived := integration.SeedExtraWorkspace(t, owner, "scheduler-archived", true)
 
 	const trigger = "morning_brief:fanout"
 	seedDueRunnerJob(t, owner, re.wsID, trigger)
@@ -207,7 +209,7 @@ func TestAgentSchedulerFansOutOneJobPerLiveWorkspaceAndFailsOnlyTheFailedTenant(
 	failRunnerJobWritesFor(t, owner, re.wsID)
 
 	now := afterEveryDueHour()
-	_, completed, failed := startTestJobRunner(t, re.pool, compose.JobRunnerConfig{
+	_, completed, failed := jobtest.StartTestJobRunner(t, re.pool, compose.JobRunnerConfig{
 		CloseDateInterval: time.Hour,
 		ReconcileInterval: time.Hour,
 		TimeScanInterval:  time.Hour,
@@ -218,7 +220,7 @@ func TestAgentSchedulerFansOutOneJobPerLiveWorkspaceAndFailsOnlyTheFailedTenant(
 	waitCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 	kind := compose.AgentSchedulerWorkspaceArgs{}.Kind()
-	outcomes := awaitWorkspaceJobOutcomes(waitCtx, t, completed, failed, kind, 2)
+	outcomes := jobtest.AwaitWorkspaceJobOutcomes(waitCtx, t, completed, failed, kind, 2)
 
 	if _, fannedOut := outcomes[healthy.String()]; !fannedOut {
 		t.Errorf("no scheduling pass ran for workspace %s — a tenant the fan-out skipped gets no brief and no at-risk sweep, and no row records that it did not", healthy)
@@ -257,17 +259,17 @@ func TestAgentSchedulerFansOutOneJobPerLiveWorkspaceAndFailsOnlyTheFailedTenant(
 // a dispatcher wired to a constant instead of the operator's --runner-interval
 // looks identical at boot and then never runs again — every workspace's due
 // occurrences unseeded from that moment on, with every gate green. Two
-// dispatches less than dispatchGapBound apart can only happen if a cadence far
+// dispatches less than jobtest.DispatchGapBound apart can only happen if a cadence far
 // shorter than that flag's own default is what River is scheduling on.
 func TestAgentSchedulerDispatchRepeatsOnItsConfiguredInterval(t *testing.T) {
 	re := setupRunner(t)
 
-	_, completed, _ := startTestJobRunner(t, re.pool, compose.JobRunnerConfig{
+	_, completed, _ := jobtest.StartTestJobRunner(t, re.pool, compose.JobRunnerConfig{
 		CloseDateInterval: time.Hour,
 		ReconcileInterval: time.Hour,
 		TimeScanInterval:  time.Hour,
 		AgentScheduler: compose.AgentSchedulerConfig{
-			Interval: dispatchInterval, Service: re.svc,
+			Interval: jobtest.DispatchInterval, Service: re.svc,
 		},
 	})
 	// Generous compared with the gap bound: a run this slow is a sick machine,
@@ -275,10 +277,10 @@ func TestAgentSchedulerDispatchRepeatsOnItsConfiguredInterval(t *testing.T) {
 	waitCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 	kind := compose.AgentSchedulerArgs{}.Kind()
-	first, second := awaitTwoDispatchArrivals(waitCtx, t, completed, kind)
-	if gap := second.Sub(first); gap > dispatchGapBound {
+	first, second := jobtest.AwaitTwoDispatchArrivals(waitCtx, t, completed, kind)
+	if gap := second.Sub(first); gap > jobtest.DispatchGapBound {
 		t.Fatalf("the two %s dispatches were %s apart, over the %s bound — the schedule is not the configured %s interval but some larger constant, and --runner-interval's own 30s default is the one that would look exactly like this",
-			kind, gap, dispatchGapBound, dispatchInterval)
+			kind, gap, jobtest.DispatchGapBound, jobtest.DispatchInterval)
 	}
 }
 
@@ -292,7 +294,7 @@ func TestAgentSchedulerDispatchRepeatsOnItsConfiguredInterval(t *testing.T) {
 func TestAgentSchedulerWithoutAnIntervalSchedulesNothingButStillWorksAQueuedRow(t *testing.T) {
 	re := setupRunner(t)
 
-	jobRunner, completed, _ := startTestJobRunner(t, re.pool, compose.JobRunnerConfig{
+	jobRunner, completed, _ := jobtest.StartTestJobRunner(t, re.pool, compose.JobRunnerConfig{
 		CloseDateInterval: time.Hour,
 		ReconcileInterval: time.Hour,
 		TimeScanInterval:  time.Hour,
@@ -312,7 +314,7 @@ func TestAgentSchedulerWithoutAnIntervalSchedulesNothingButStillWorksAQueuedRow(
 	// half of the claim: a queued row is still worked with no schedule present.
 	waitCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
-	awaitKindsCompleted(waitCtx, t, completed,
+	jobtest.AwaitKindsCompleted(waitCtx, t, completed,
 		compose.CloseDateSweepArgs{}.Kind(), compose.AgentSchedulerWorkspaceArgs{}.Kind())
 
 	var dispatched int

--- a/backend/internal/compose/integration/jobfanout/privacyretention_integration_test.go
+++ b/backend/internal/compose/integration/jobfanout/privacyretention_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package integration
+package jobfanout
 
 // The GDPR retention pass is one job row per tenant. A workspace whose pass
 // fails must say so — a retention pass that failed and reported success leaves
@@ -20,22 +20,12 @@ import (
 	"github.com/riverqueue/river"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration"
+	"github.com/gradionhq/margince/backend/internal/compose/integration/jobtest"
 	"github.com/gradionhq/margince/backend/internal/modules/privacy"
 	"github.com/gradionhq/margince/backend/internal/platform/jobs"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
-	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
-
-// retentionPassCtx is the scope the retention workspace worker binds before it
-// calls the engine: the tenant, the system actor, and a fresh correlation id.
-// The engine writes an audit row and an outbox event per record it retires, so
-// a suite that bound only the workspace would be exercising a pass whose
-// provenance production never has.
-func retentionPassCtx(ws ids.UUID) context.Context {
-	ctx := principal.WithWorkspaceID(context.Background(), ws)
-	ctx = principal.WithActor(ctx, principal.Principal{Type: principal.PrincipalSystem, ID: "system"})
-	return principal.WithCorrelationID(ctx, ids.NewV7())
-}
 
 // seedRetentionTenant plants the lead/unconverted anonymize policy and one
 // over-age unconverted lead in ws, through the owner connection so a workspace
@@ -47,7 +37,7 @@ func seedRetentionTenant(t *testing.T, owner *pgx.Conn, ws ids.UUID) ids.UUID {
 		VALUES ($1, 'lead', 'unconverted', 365, 'anonymize')`, ws); err != nil {
 		t.Fatalf("seeding the retention policy for %s: %v", ws, err)
 	}
-	return SeedRow(t, owner, `
+	return integration.SeedRow(t, owner, `
 		INSERT INTO lead (id, workspace_id, full_name, status, source, captured_by, created_at)
 		VALUES ($1, $2, 'Over-age Lead', 'new', 'manual', 'human:x', now() - interval '400 days')`, ws)
 }
@@ -117,23 +107,23 @@ func leadName(t *testing.T, owner *pgx.Conn, lead ids.UUID) string {
 // an error. A pass that reported success is indistinguishable from a pass that
 // had nothing to do — and what it hides is subject data kept past its policy.
 func TestRetentionReportsTheWorkspaceWhosePassFailed(t *testing.T) {
-	e := Setup(t)
-	owner := OwnerConn(t)
-	victim := seedExtraWorkspace(t, owner, "victim", false)
+	e := integration.Setup(t)
+	owner := integration.OwnerConn(t)
+	victim := integration.SeedExtraWorkspace(t, owner, "victim", false)
 	victimLead := seedRetentionTenant(t, owner, victim)
 	healthyLead := seedRetentionTenant(t, owner, e.WS)
 	failLeadWritesFor(t, owner, victim)
 
 	svc := privacy.NewRetentionService(e.Pool, nil, slog.New(slog.DiscardHandler))
 
-	if err := svc.EvaluateWorkspace(retentionPassCtx(e.WS)); err != nil {
+	if err := svc.EvaluateWorkspace(integration.RetentionPassCtx(e.WS)); err != nil {
 		t.Fatalf("the healthy tenant's pass: %v", err)
 	}
 	if got := leadName(t, owner, healthyLead); got != "Anonymized Lead" {
 		t.Fatalf("the healthy tenant's over-age lead is %q, want the anonymized tombstone — a pass that acted on nothing would make the assertion below vacuous", got)
 	}
 
-	err := svc.EvaluateWorkspace(retentionPassCtx(victim))
+	err := svc.EvaluateWorkspace(integration.RetentionPassCtx(victim))
 	if got := leadName(t, owner, victimLead); got != "Over-age Lead" {
 		t.Fatalf("the fault injection did not hold: the victim's lead is %q, so its pass never failed", got)
 	}
@@ -145,9 +135,9 @@ func TestRetentionReportsTheWorkspaceWhosePassFailed(t *testing.T) {
 // startRetentionRunner boots a job runner whose retention dispatcher ticks on
 // the given interval, and returns it with the shared fan-out harness's
 // completion and failure channels.
-func startRetentionRunner(t *testing.T, e *Env, interval time.Duration) (*jobs.Runner, <-chan *river.Event, <-chan *river.Event) {
+func startRetentionRunner(t *testing.T, e *integration.Env, interval time.Duration) (*jobs.Runner, <-chan *river.Event, <-chan *river.Event) {
 	t.Helper()
-	return startTestJobRunner(t, e.Pool, compose.JobRunnerConfig{
+	return jobtest.StartTestJobRunner(t, e.Pool, compose.JobRunnerConfig{
 		CloseDateInterval: time.Hour,
 		ReconcileInterval: time.Hour,
 		TimeScanInterval:  time.Hour,
@@ -161,11 +151,11 @@ func startRetentionRunner(t *testing.T, e *Env, interval time.Duration) (*jobs.R
 // subject data inside it — each row names its own tenant on the wire, and the
 // tenant whose pass failed is the only row that fails.
 func TestPrivacyRetentionFansOutOneJobPerWorkspaceAndFailsOnlyTheFailedTenant(t *testing.T) {
-	e := Setup(t)
-	ApplyRiverSchema(t)
-	owner := OwnerConn(t)
-	victim := seedExtraWorkspace(t, owner, "victim", false)
-	archived := seedExtraWorkspace(t, owner, "archived", true)
+	e := integration.Setup(t)
+	integration.ApplyRiverSchema(t)
+	owner := integration.OwnerConn(t)
+	victim := integration.SeedExtraWorkspace(t, owner, "victim", false)
+	archived := integration.SeedExtraWorkspace(t, owner, "archived", true)
 	victimLead := seedRetentionTenant(t, owner, victim)
 	healthyLead := seedRetentionTenant(t, owner, e.WS)
 	failLeadWritesFor(t, owner, victim)
@@ -174,7 +164,7 @@ func TestPrivacyRetentionFansOutOneJobPerWorkspaceAndFailsOnlyTheFailedTenant(t 
 	_, completed, failed := startRetentionRunner(t, e, time.Hour)
 	waitCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
 	defer cancel()
-	outcomes := awaitWorkspaceJobOutcomes(waitCtx, t, completed, failed,
+	outcomes := jobtest.AwaitWorkspaceJobOutcomes(waitCtx, t, completed, failed,
 		compose.PrivacyRetentionWorkspaceArgs{}.Kind(), 3)
 
 	for _, ws := range []ids.UUID{e.WS, victim, archived} {
@@ -226,22 +216,22 @@ func TestPrivacyRetentionFansOutOneJobPerWorkspaceAndFailsOnlyTheFailedTenant(t 
 // is, so a dispatcher wired to a constant instead of the operator's
 // --retention-interval looks identical at boot and then never runs again — a
 // dead storage-limitation obligation with every gate green. Two dispatches less
-// than dispatchGapBound apart can only happen if a cadence far shorter than any
+// than jobtest.DispatchGapBound apart can only happen if a cadence far shorter than any
 // constant in reach is what River is scheduling on.
 func TestPrivacyRetentionDispatchRepeatsOnItsConfiguredInterval(t *testing.T) {
-	e := Setup(t)
-	ApplyRiverSchema(t)
+	e := integration.Setup(t)
+	integration.ApplyRiverSchema(t)
 
-	_, completed, _ := startRetentionRunner(t, e, dispatchInterval)
+	_, completed, _ := startRetentionRunner(t, e, jobtest.DispatchInterval)
 	// Generous compared with the gap bound: a run this slow is a sick machine,
 	// and the assertion that decides the outcome is the gap below, not this.
 	waitCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 	kind := compose.PrivacyRetentionArgs{}.Kind()
-	first, second := awaitTwoDispatchArrivals(waitCtx, t, completed, kind)
-	if gap := second.Sub(first); gap > dispatchGapBound {
+	first, second := jobtest.AwaitTwoDispatchArrivals(waitCtx, t, completed, kind)
+	if gap := second.Sub(first); gap > jobtest.DispatchGapBound {
 		t.Fatalf("the two %s dispatches were %s apart, over the %s bound — the schedule is not the configured %s interval but some larger constant, and the gmail_sync dispatcher's declared 30s scan is the one that would look exactly like this",
-			kind, gap, dispatchGapBound, dispatchInterval)
+			kind, gap, jobtest.DispatchGapBound, jobtest.DispatchInterval)
 	}
 }
 
@@ -254,8 +244,8 @@ func TestPrivacyRetentionDispatchRepeatsOnItsConfiguredInterval(t *testing.T) {
 // Registering no schedule is the honest reading; the WORKERS still register,
 // so a row an earlier boot queued is still worked rather than stranded.
 func TestPrivacyRetentionWithoutAnIntervalSchedulesNothingButStillWorksAQueuedRow(t *testing.T) {
-	e := Setup(t)
-	ApplyRiverSchema(t)
+	e := integration.Setup(t)
+	integration.ApplyRiverSchema(t)
 
 	runner, completed, _ := startRetentionRunner(t, e, 0)
 	if err := runner.Enqueue(context.Background(),
@@ -272,7 +262,7 @@ func TestPrivacyRetentionWithoutAnIntervalSchedulesNothingButStillWorksAQueuedRo
 	// half of the claim: a queued row is still worked with no schedule present.
 	waitCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
-	awaitKindsCompleted(waitCtx, t, completed,
+	jobtest.AwaitKindsCompleted(waitCtx, t, completed,
 		compose.CloseDateSweepArgs{}.Kind(), compose.PrivacyRetentionWorkspaceArgs{}.Kind())
 
 	var dispatched int

--- a/backend/internal/compose/integration/jobfanout/runner_integration_test.go
+++ b/backend/internal/compose/integration/jobfanout/runner_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package integration
+package jobfanout
 
 // The Surface-B runner end to end (architecture/07): a scheduled job
 // executes the reason-act-observe loop on the offline fake brain against
@@ -110,8 +110,9 @@ func setupRunner(t *testing.T) *runnerEnv {
 
 // tick runs ONE workspace's scheduler pass, under the bound context and the
 // clock reading the job worker hands it in production — the fan-out that puts
-// a tenant's pass on its own job row is agentscheduler_fanout's subject, not
-// this suite's.
+// a tenant's pass on its own job row is
+// TestAgentSchedulerFansOutOneJobPerLiveWorkspaceAndFailsOnlyTheFailedTenant's
+// subject, not this suite's.
 func (re *runnerEnv) tick(t *testing.T) {
 	t.Helper()
 	if err := re.svc.TickWorkspace(re.wsCtx, time.Now()); err != nil {

--- a/backend/internal/compose/integration/jobfanout/runnerreap_integration_test.go
+++ b/backend/internal/compose/integration/jobfanout/runnerreap_integration_test.go
@@ -3,7 +3,7 @@
 
 //go:build integration
 
-package integration
+package jobfanout
 
 // What these prove: the tenant's scheduling pass closes a run that was stranded
 // in 'running', leaves every run that is still going anywhere, and cannot reach
@@ -24,6 +24,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration"
 	"github.com/gradionhq/margince/backend/internal/platform/database"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -125,16 +126,13 @@ func TestTheSweepCannotReachAnotherTenantsRuns(t *testing.T) {
 	}
 }
 
-// otherWorkspace mints a second tenant to sweep against.
+// otherWorkspace mints a second tenant to sweep against. One spelling of the
+// workspace INSERT, shared with the fan-out suites next door: a tenant seeded a
+// second way is a tenant whose shape a cross-tenant refusal was never really
+// tested against.
 func (re *runnerEnv) otherWorkspace(t *testing.T) ids.UUID {
 	t.Helper()
-	id := ids.NewV7()
-	if _, err := re.Owner.Exec(context.Background(),
-		`INSERT INTO workspace (id, name, slug, base_currency) VALUES ($1, 'Other Tenant', $2, 'EUR')`,
-		id, "reap-other-"+id.String()); err != nil {
-		t.Fatalf("seeding the second workspace: %v", err)
-	}
-	return id
+	return integration.SeedExtraWorkspace(t, re.Owner, "reap-other", false)
 }
 
 // seedRunIn writes an abandoned run into an arbitrary workspace, which seedRun

--- a/backend/internal/compose/integration/jobtest/jobtest.go
+++ b/backend/internal/compose/integration/jobtest/jobtest.go
@@ -3,14 +3,19 @@
 
 //go:build integration
 
-package integration
-
-// The ceremony every fan-out suite shares: an extra tenant to fan out to, a
-// job runner subscribed before it starts, and the two awaits that read River's
-// event stream instead of polling a table. Each converted pass asserts the same
-// three things about itself — one row per tenant, each naming its tenant on the
-// wire, and only the failed tenant's row failing — so the reading of River's
-// events belongs here rather than once per suite.
+// Package jobtest is the ceremony every job fan-out suite shares: a River job
+// runner subscribed before it starts, and the awaits that read River's event
+// stream instead of polling a table. Each converted pass asserts the same three
+// things about itself — one row per tenant, each naming its tenant on the wire,
+// and only the failed tenant's row failing — so the reading of River's events
+// belongs here rather than once per suite.
+//
+// It is a package of its own for the reason apptest is: it needs compose to build
+// a runner, and package integration may never import compose, because compose's
+// own white-box tests import integration. Suites on both sides of that line
+// import it — integration/jobfanout and integration itself — so everything here
+// is exported.
+package jobtest
 
 import (
 	"context"
@@ -19,33 +24,27 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/riverqueue/river"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
 	"github.com/gradionhq/margince/backend/internal/platform/jobs"
-	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
 
-// seedExtraWorkspace mints an additional tenant. archived names a workspace
-// nobody looks at any more, which still holds everything it held the day it was
-// archived — some passes are owed on it and some deliberately skip it, so a
-// fan-out suite states which by seeding one.
-func seedExtraWorkspace(t *testing.T, owner *pgx.Conn, name string, archived bool) ids.UUID {
-	t.Helper()
-	ws := ids.NewV7()
-	archivedAt := "NULL"
-	if archived {
-		archivedAt = "now()"
-	}
-	if _, err := owner.Exec(context.Background(), `
-		INSERT INTO workspace (id, name, slug, base_currency, archived_at)
-		VALUES ($1, $2, $3, 'EUR', `+archivedAt+`)`, ws, name, name+"-"+ws.String()); err != nil {
-		t.Fatalf("seeding the %s workspace: %v", name, err)
-	}
-	return ws
-}
+// DispatchInterval is the cadence a repeat-schedule suite configures, and
+// DispatchGapBound is what separates "scheduled on the configured interval"
+// from "scheduled on some larger constant": three times the interval, which
+// leaves a correct schedule ample slack while excluding every constant actually
+// in reach — the gmail_sync dispatcher's declared 30s scan, and the
+// tens-of-seconds defaults the interval flags themselves carry
+// (--runner-interval, --retention-interval, --webhook-retry-interval), which are
+// the likeliest miswiring of all. The bound is on the GAP
+// between two dispatches rather than on the whole run, because a deadline on the
+// run would also pass for any constant smaller than the deadline.
+const (
+	DispatchInterval = 2 * time.Second
+	DispatchGapBound = 3 * DispatchInterval
+)
 
 // recordWorkspaceJobOutcome files one workspace job's outcome under the tenant
 // its args name, reading the WIRE key rather than a decoded args struct — the
@@ -67,7 +66,7 @@ func recordWorkspaceJobOutcome(t *testing.T, into map[string]bool, ev *river.Eve
 	into[args.Workspace] = completed
 }
 
-// awaitWorkspaceJobOutcomes collects one outcome per tenant until want distinct
+// AwaitWorkspaceJobOutcomes collects one outcome per tenant until want distinct
 // workspaces have reported, or the deadline fires. No polling, no sleep.
 //
 // A tenant's LATEST report overwrites its earlier ones, and the wait ends the
@@ -78,7 +77,7 @@ func recordWorkspaceJobOutcome(t *testing.T, into map[string]bool, ev *river.Eve
 // PERMANENT faults, so the first report is also the only one and the verdict is
 // determined; a suite that plants a RETRYABLE fault needs a different collector,
 // not a longer deadline.
-func awaitWorkspaceJobOutcomes(ctx context.Context, t *testing.T, completed, failed <-chan *river.Event, kind string, want int) map[string]bool {
+func AwaitWorkspaceJobOutcomes(ctx context.Context, t *testing.T, completed, failed <-chan *river.Event, kind string, want int) map[string]bool {
 	t.Helper()
 	outcomes := make(map[string]bool, want)
 	for len(outcomes) < want {
@@ -94,9 +93,9 @@ func awaitWorkspaceJobOutcomes(ctx context.Context, t *testing.T, completed, fai
 	return outcomes
 }
 
-// awaitKindsCompleted blocks until every named kind has reported one
+// AwaitKindsCompleted blocks until every named kind has reported one
 // completion, or the deadline fires. No polling, no sleep.
-func awaitKindsCompleted(ctx context.Context, t *testing.T, completed <-chan *river.Event, kinds ...string) {
+func AwaitKindsCompleted(ctx context.Context, t *testing.T, completed <-chan *river.Event, kinds ...string) {
 	t.Helper()
 	pending := make(map[string]struct{}, len(kinds))
 	for _, kind := range kinds {
@@ -114,21 +113,7 @@ func awaitKindsCompleted(ctx context.Context, t *testing.T, completed <-chan *ri
 	}
 }
 
-// dispatchInterval is the cadence a repeat-schedule suite configures, and
-// dispatchGapBound is what separates "scheduled on the configured interval"
-// from "scheduled on some larger constant": three times the interval, which
-// leaves a correct schedule ample slack while excluding every constant actually
-// in reach — the gmail_sync dispatcher's declared 30s scan, and the
-// tens-of-seconds defaults these flags carry, which are the likeliest
-// miswiring of all. The bound is on the GAP
-// between two dispatches rather than on the whole run, because a deadline on the
-// run would also pass for any constant smaller than the deadline.
-const (
-	dispatchInterval = 2 * time.Second
-	dispatchGapBound = 3 * dispatchInterval
-)
-
-// awaitTwoDispatchArrivals blocks until two DISTINCT jobs of kind have
+// AwaitTwoDispatchArrivals blocks until two DISTINCT jobs of kind have
 // completed, and reports when each arrived. It is the observer's clock, not the
 // job's own timestamps: what a repeat-schedule suite is asking is whether a
 // SECOND dispatch happened soon, and the reader can trust the arrival.
@@ -136,7 +121,7 @@ const (
 // RunOnStart fires once whatever the cadence is, so the first arrival proves
 // nothing about the schedule and every such suite needs the second — which is
 // why this waits here rather than once per pass.
-func awaitTwoDispatchArrivals(ctx context.Context, t *testing.T, completed <-chan *river.Event, kind string) (first, second time.Time) {
+func AwaitTwoDispatchArrivals(ctx context.Context, t *testing.T, completed <-chan *river.Event, kind string) (first, second time.Time) {
 	t.Helper()
 	seen := make(map[int64]struct{}, 2)
 	for len(seen) < 2 {
@@ -162,11 +147,11 @@ func awaitTwoDispatchArrivals(ctx context.Context, t *testing.T, completed <-cha
 	return first, second
 }
 
-// startTestJobRunner boots a worker-role job runner over cfg and returns it
+// StartTestJobRunner boots a worker-role job runner over cfg and returns it
 // with its completion and failure channels, subscribed BEFORE Start so the
 // RunOnStart round's outcomes are never missed. The runner is stopped in
 // cleanup.
-func startTestJobRunner(t *testing.T, pool *pgxpool.Pool, cfg compose.JobRunnerConfig) (*jobs.Runner, <-chan *river.Event, <-chan *river.Event) {
+func StartTestJobRunner(t *testing.T, pool *pgxpool.Pool, cfg compose.JobRunnerConfig) (*jobs.Runner, <-chan *river.Event, <-chan *river.Event) {
 	t.Helper()
 	runner, err := compose.NewJobRunner(pool, slog.New(slog.DiscardHandler), cfg)
 	if err != nil {

--- a/backend/internal/compose/integration/privacy_comms_integration_test.go
+++ b/backend/internal/compose/integration/privacy_comms_integration_test.go
@@ -488,7 +488,7 @@ func TestRetentionRedactsTheDeliveryOfAnAgedOutActivity(t *testing.T) {
 	fresh := seedDelivery(t, e, "10 days", "This week's message", "still within the window", "sent", mailRecipientEmail, ids.UUID{})
 
 	svc := privacy.NewRetentionService(e.Pool, nil, slog.New(slog.NewTextHandler(os.Stderr, nil)))
-	if err := svc.EvaluateWorkspace(retentionPassCtx(e.WS)); err != nil {
+	if err := svc.EvaluateWorkspace(RetentionPassCtx(e.WS)); err != nil {
 		t.Fatalf("Evaluate: %v", err)
 	}
 

--- a/backend/internal/compose/integration/reembed_integration_test.go
+++ b/backend/internal/compose/integration/reembed_integration_test.go
@@ -154,7 +154,7 @@ func TestReembedWorkspaceCostsOnlyTheWorkspaceThatCannotWrite(t *testing.T) {
 		t.Fatalf("SeedBinding: %v", err)
 	}
 
-	healthy := seedExtraWorkspace(t, e.Owner, "reembed-healthy", false)
+	healthy := SeedExtraWorkspace(t, e.Owner, "reembed-healthy", false)
 	e.Seed(t, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Faulted Tenant Person', 'manual', 'human:x')`)
 	healthyPersonID := ids.NewV7()
 	if _, err := e.Owner.Exec(ctx, `INSERT INTO person (id, workspace_id, full_name, source, captured_by) VALUES ($1, $2, 'Healthy Tenant Person', 'manual', 'human:x')`,
@@ -247,7 +247,7 @@ func TestReembedRunMarkerIsReleasedByTheLastWorkspaceOutAndNotBefore(t *testing.
 	if err := e.Store.SeedBinding(ctx, populated); err != nil {
 		t.Fatalf("SeedBinding: %v", err)
 	}
-	second := seedExtraWorkspace(t, e.Owner, "reembed-marker", false)
+	second := SeedExtraWorkspace(t, e.Owner, "reembed-marker", false)
 
 	run := claimOf(target)
 	if err := e.Store.ClaimAndEnqueueReembedding(ctx, run, func(pgx.Tx) error { return nil }); err != nil {

--- a/backend/internal/compose/integration/retention_integration_test.go
+++ b/backend/internal/compose/integration/retention_integration_test.go
@@ -118,7 +118,7 @@ func TestRetentionActsOnOverAgeRecordsAndHonorsLegalHold(t *testing.T) {
 	staleLead, heldLead, staleDeal, transcript := seedOverAgeRecords(t, e)
 
 	svc := privacy.NewRetentionService(e.Pool, nil, slog.New(slog.NewTextHandler(os.Stderr, nil)))
-	if err := svc.EvaluateWorkspace(retentionPassCtx(e.WS)); err != nil {
+	if err := svc.EvaluateWorkspace(RetentionPassCtx(e.WS)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -164,7 +164,7 @@ func TestRetentionActsOnOverAgeRecordsAndHonorsLegalHold(t *testing.T) {
 	}
 
 	// A second pass is idempotent: everything due is already acted.
-	if err := svc.EvaluateWorkspace(retentionPassCtx(e.WS)); err != nil {
+	if err := svc.EvaluateWorkspace(RetentionPassCtx(e.WS)); err != nil {
 		t.Fatal(err)
 	}
 	var second int
@@ -212,7 +212,7 @@ func TestRetentionErasesOverAgeVoiceSignalPlaintext(t *testing.T) {
 	}
 
 	svc := privacy.NewRetentionService(e.Pool, nil, slog.New(slog.NewTextHandler(os.Stderr, nil)))
-	if err := svc.EvaluateWorkspace(retentionPassCtx(e.WS)); err != nil {
+	if err := svc.EvaluateWorkspace(RetentionPassCtx(e.WS)); err != nil {
 		t.Fatal(err)
 	}
 

--- a/backend/internal/compose/integration/retention_jurisdiction_integration_test.go
+++ b/backend/internal/compose/integration/retention_jurisdiction_integration_test.go
@@ -47,7 +47,11 @@ func (gobdFloorClasses) Classes() []jurisdiction.RetentionClass {
 }
 
 // init mirrors the arming the composed boot performs: the registry is
-// process-global, so registering once arms the floor for this binary.
+// process-global, so registering once arms the floor for THIS BINARY — and one
+// package is one binary. A retention suite in a sibling package runs with no pack
+// registered, which is not a weaker version of this suite but the opposite of it:
+// a destructive pass over correspondence would go green precisely because the
+// floor that shields it is absent. A suite that moves out takes this with it.
 func init() {
 	jurisdiction.Register(gobdFloorPack{})
 }
@@ -90,7 +94,7 @@ func TestStatutoryFloorShieldsCorrespondenceFromDestruction(t *testing.T) {
 	}
 
 	svc := privacy.NewRetentionService(e.Pool, nil, slog.New(slog.NewTextHandler(os.Stderr, nil)))
-	if err := svc.EvaluateWorkspace(retentionPassCtx(e.WS)); err != nil {
+	if err := svc.EvaluateWorkspace(RetentionPassCtx(e.WS)); err != nil {
 		t.Fatal(err)
 	}
 

--- a/backend/internal/compose/integration/scope.go
+++ b/backend/internal/compose/integration/scope.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package integration
+
+import (
+	"context"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// Scopes a worker binds before it calls an engine — the counterpart to
+// harness.go's As, which builds the scope a HUMAN request arrives with. Separate
+// from it because a suite reaching for one of these is asking a different
+// question: not "what may this caller see" but "what provenance does the row this
+// pass writes carry".
+
+// RetentionPassCtx is the scope the retention workspace worker binds before it
+// calls the engine: the tenant, the system actor, and a fresh correlation id.
+// The engine writes an audit row and an outbox event per record it retires, so a
+// suite that bound only the workspace would be exercising a pass whose provenance
+// production never has.
+//
+// Exported because a sibling suite package (integration/jobfanout) binds the same
+// scope. The actor is a SYSTEM principal, which no row-scope clause narrows — so
+// this builds the scope a PASS runs under, and a suite asserting who may SEE a
+// row wants Env.As instead, which can be denied.
+func RetentionPassCtx(ws ids.UUID) context.Context {
+	ctx := principal.WithWorkspaceID(context.Background(), ws)
+	ctx = principal.WithActor(ctx, principal.Principal{Type: principal.PrincipalSystem, ID: "system"})
+	return principal.WithCorrelationID(ctx, ids.NewV7())
+}

--- a/backend/internal/compose/integration/seed.go
+++ b/backend/internal/compose/integration/seed.go
@@ -101,6 +101,29 @@ func LinkActivity(t *testing.T, owner *pgx.Conn, ws, activity ids.UUID, entityTy
 	}
 }
 
+// SeedExtraWorkspace mints an additional tenant. archived names a workspace
+// nobody looks at any more, which still holds everything it held the day it was
+// archived — some passes are owed on it and some deliberately skip it, so a
+// fan-out suite states which by seeding one.
+//
+// Exported because the fan-out suites in sibling packages need a second tenant
+// too, and a workspace row is the one thing none of them can mint any other way:
+// workspace is outside RLS and no endpoint creates one.
+func SeedExtraWorkspace(t *testing.T, owner *pgx.Conn, name string, archived bool) ids.UUID {
+	t.Helper()
+	ws := ids.NewV7()
+	archivedAt := "NULL"
+	if archived {
+		archivedAt = "now()"
+	}
+	if _, err := owner.Exec(context.Background(), `
+		INSERT INTO workspace (id, name, slug, base_currency, archived_at)
+		VALUES ($1, $2, $3, 'EUR', `+archivedAt+`)`, ws, name, name+"-"+ws.String()); err != nil {
+		t.Fatalf("seeding the %s workspace: %v", name, err)
+	}
+	return ws
+}
+
 // SeedRow inserts one row through the owner connection and returns its id.
 func SeedRow(t *testing.T, owner *pgx.Conn, sql string, ws ids.UUID) ids.UUID {
 	t.Helper()

--- a/backend/internal/compose/integration/webhookretry_fanout_integration_test.go
+++ b/backend/internal/compose/integration/webhookretry_fanout_integration_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/compose"
+	"github.com/gradionhq/margince/backend/internal/compose/integration/jobtest"
 	"github.com/gradionhq/margince/backend/internal/modules/webhooks"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -149,7 +150,7 @@ func parkDueDeliveryIn(t *testing.T, we *webhookEnv, owner *pgx.Conn, ws ids.UUI
 func TestWebhookRetryReportsTheWorkspaceWhoseDueScanFailed(t *testing.T) {
 	we := setupWebhooks(t)
 	owner := OwnerConn(t)
-	healthy := seedExtraWorkspace(t, owner, "healthy", false)
+	healthy := SeedExtraWorkspace(t, owner, "healthy", false)
 
 	rcv := newReceiver(t, http.StatusInternalServerError) // endpoint is down
 	now := time.Now().UTC()
@@ -202,8 +203,8 @@ func TestWebhookRetryReportsTheWorkspaceWhoseDueScanFailed(t *testing.T) {
 func TestWebhookRetryFansOutOneJobPerLiveWorkspaceAndFailsOnlyTheFailedTenant(t *testing.T) {
 	we := setupWebhooks(t)
 	owner := OwnerConn(t)
-	healthy := seedExtraWorkspace(t, owner, "healthy", false)
-	archived := seedExtraWorkspace(t, owner, "archived", true)
+	healthy := SeedExtraWorkspace(t, owner, "healthy", false)
+	archived := SeedExtraWorkspace(t, owner, "archived", true)
 
 	rcv := newReceiver(t, http.StatusInternalServerError)
 	now := time.Now().UTC()
@@ -218,7 +219,7 @@ func TestWebhookRetryFansOutOneJobPerLiveWorkspaceAndFailsOnlyTheFailedTenant(t 
 	// tenant as green — the exact outcome this test denies.
 	failDueScansFor(t, owner, we.wsID)
 
-	_, completed, failed := startTestJobRunner(t, we.pool, compose.JobRunnerConfig{
+	_, completed, failed := jobtest.StartTestJobRunner(t, we.pool, compose.JobRunnerConfig{
 		CloseDateInterval: time.Hour,
 		ReconcileInterval: time.Hour,
 		TimeScanInterval:  time.Hour,
@@ -229,7 +230,7 @@ func TestWebhookRetryFansOutOneJobPerLiveWorkspaceAndFailsOnlyTheFailedTenant(t 
 	waitCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 	kind := compose.WebhookRetryWorkspaceArgs{}.Kind()
-	outcomes := awaitWorkspaceJobOutcomes(waitCtx, t, completed, failed, kind, 2)
+	outcomes := jobtest.AwaitWorkspaceJobOutcomes(waitCtx, t, completed, failed, kind, 2)
 
 	if _, fannedOut := outcomes[healthy.String()]; !fannedOut {
 		t.Errorf("no retry sweep ran for workspace %s — a tenant the fan-out skipped keeps its deliveries parked and no row records that it did", healthy)
@@ -261,19 +262,19 @@ func TestWebhookRetryFansOutOneJobPerLiveWorkspaceAndFailsOnlyTheFailedTenant(t 
 // a dispatcher wired to a constant instead of the operator's
 // --webhook-retry-interval looks identical at boot and then never runs again —
 // every parked delivery in the fleet stranded, with every gate green. Two
-// dispatches less than dispatchGapBound apart can only happen if a cadence far
+// dispatches less than jobtest.DispatchGapBound apart can only happen if a cadence far
 // shorter than that flag's own default is what River is scheduling on.
 func TestWebhookRetryDispatchRepeatsOnItsConfiguredInterval(t *testing.T) {
 	we := setupWebhooks(t)
 	now := time.Now().UTC()
 	rcv := newReceiver(t, http.StatusInternalServerError)
 
-	_, completed, _ := startTestJobRunner(t, we.pool, compose.JobRunnerConfig{
+	_, completed, _ := jobtest.StartTestJobRunner(t, we.pool, compose.JobRunnerConfig{
 		CloseDateInterval: time.Hour,
 		ReconcileInterval: time.Hour,
 		TimeScanInterval:  time.Hour,
 		WebhookRetry: compose.WebhookRetryConfig{
-			Interval: dispatchInterval, Deliverer: newTestDeliverer(we, &now, rcv.server.Client()),
+			Interval: jobtest.DispatchInterval, Deliverer: newTestDeliverer(we, &now, rcv.server.Client()),
 		},
 	})
 	// Generous compared with the gap bound: a run this slow is a sick machine,
@@ -281,10 +282,10 @@ func TestWebhookRetryDispatchRepeatsOnItsConfiguredInterval(t *testing.T) {
 	waitCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 	kind := compose.WebhookRetryArgs{}.Kind()
-	first, second := awaitTwoDispatchArrivals(waitCtx, t, completed, kind)
-	if gap := second.Sub(first); gap > dispatchGapBound {
+	first, second := jobtest.AwaitTwoDispatchArrivals(waitCtx, t, completed, kind)
+	if gap := second.Sub(first); gap > jobtest.DispatchGapBound {
 		t.Fatalf("the two %s dispatches were %s apart, over the %s bound — the schedule is not the configured %s interval but some larger constant, and --webhook-retry-interval's own 30s default is the one that would look exactly like this",
-			kind, gap, dispatchGapBound, dispatchInterval)
+			kind, gap, jobtest.DispatchGapBound, jobtest.DispatchInterval)
 	}
 }
 
@@ -301,7 +302,7 @@ func TestWebhookRetryWithoutAnIntervalSchedulesNothingButStillWorksAQueuedRow(t 
 	rcv := newReceiver(t, http.StatusInternalServerError)
 	deliverer := newTestDeliverer(we, &now, rcv.server.Client())
 
-	runner, completed, _ := startTestJobRunner(t, we.pool, compose.JobRunnerConfig{
+	runner, completed, _ := jobtest.StartTestJobRunner(t, we.pool, compose.JobRunnerConfig{
 		CloseDateInterval: time.Hour,
 		ReconcileInterval: time.Hour,
 		TimeScanInterval:  time.Hour,
@@ -321,7 +322,7 @@ func TestWebhookRetryWithoutAnIntervalSchedulesNothingButStillWorksAQueuedRow(t 
 	// half of the claim: a queued row is still worked with no schedule present.
 	waitCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
-	awaitKindsCompleted(waitCtx, t, completed,
+	jobtest.AwaitKindsCompleted(waitCtx, t, completed,
 		compose.CloseDateSweepArgs{}.Kind(), compose.WebhookRetryWorkspaceArgs{}.Kind())
 
 	var dispatched int

--- a/backend/retentionscope_test.go
+++ b/backend/retentionscope_test.go
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package backendarch
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// retentionScopeBuilder is the fixture whose reach this gate bounds, and
+// retentionScopeSink is the one call it may feed.
+const (
+	retentionScopeBuilder = "RetentionPassCtx"
+	retentionScopeSink    = "EvaluateWorkspace"
+)
+
+// TestRetentionPassCtxOnlyDrivesTheRetentionPass keeps a context that cannot be
+// denied from becoming the subject of an assertion about denial.
+//
+// integration.RetentionPassCtx binds a SYSTEM principal, because that is the
+// provenance the retention worker actually writes rows under and a suite binding
+// only the workspace would exercise a pass production never runs. But
+// auth.Unbounded reports true for a system principal, and auth.Require and
+// auth.EnsureVisible short-circuit for it — so a visibility or row-scope
+// assertion made THROUGH this context passes whatever the row scope is. Such a
+// test looks exactly like the gate it is impersonating.
+//
+// The fixture is exported (a sibling suite package needs it), which is what puts
+// it within reach of every suite in the tree rather than the one file that
+// declared it. So the bound is enforced here instead of asked for in a comment:
+// it may be passed to the retention engine and nowhere else. A second legitimate
+// sink is a deliberate act — add it to this gate and say why.
+func TestRetentionPassCtxOnlyDrivesTheRetentionPass(t *testing.T) {
+	fset := token.NewFileSet()
+	checked := 0
+	err := filepath.WalkDir("internal", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		file, perr := parser.ParseFile(fset, path, nil, 0)
+		if perr != nil {
+			return perr
+		}
+		// Every call whose argument list contains a RetentionPassCtx call is a
+		// legitimate sink; anything else that calls it is not passing the scope
+		// straight into a pass.
+		sinks := map[ast.Node]bool{}
+		ast.Inspect(file, func(n ast.Node) bool {
+			outer, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			for _, arg := range outer.Args {
+				if inner, ok := arg.(*ast.CallExpr); ok && callsNamed(inner, retentionScopeBuilder) {
+					sinks[inner] = calleeName(outer) == retentionScopeSink
+				}
+			}
+			return true
+		})
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok || !callsNamed(call, retentionScopeBuilder) {
+				return true
+			}
+			checked++
+			if !sinks[call] {
+				t.Errorf("%s: %s is used somewhere other than an argument to %s — a system principal cannot be denied, so any visibility or row-scope claim made through it holds vacuously",
+					fset.Position(call.Pos()), retentionScopeBuilder, retentionScopeSink)
+			}
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking internal: %v", err)
+	}
+	// A gate that matched nothing proves nothing: the fixture was renamed, or the
+	// walk stopped reaching the suites that use it.
+	if checked == 0 {
+		t.Fatalf("no call to %s anywhere under internal/ — this gate has stopped watching what it names", retentionScopeBuilder)
+	}
+}
+
+// callsNamed reports whether call invokes a function named name, as either a
+// bare identifier (in-package) or a package selector (from a sibling).
+func callsNamed(call *ast.CallExpr, name string) bool {
+	return calleeName(call) == name
+}
+
+// calleeName is the called function's own name, ignoring any qualifier.
+func calleeName(call *ast.CallExpr) string {
+	switch fun := call.Fun.(type) {
+	case *ast.Ident:
+		return fun.Name
+	case *ast.SelectorExpr:
+		return fun.Sel.Name
+	}
+	return ""
+}


### PR DESCRIPTION
The lane's wall clock cannot fall below its longest package, and `internal/compose/integration` is that package by a wide margin. This moves the periodic job-dispatch suites out into `integration/jobfanout`.

## Measured, same sitting, Postgres restarted before each run

| | control (`main`) | this branch |
|---|---|---|
| `compose/integration` | 159.1s | **139.2s** (−12.5%) |
| lane wall clock | 190.7s | 185.3s (−2.8%) |

Green at 30 packages, 0 skips.

**Be honest about that second row.** The package shed 20s and the lane shed 5. Wall clock is no longer purely bound by the longest package — there is ~46s between the longest package and the lane's wall time that further splitting cannot reach. I'd stop splitting after this one unless that gap is attacked first; #671 documents what I found when I went looking for it.

## Three helpers had to be promoted, and the import rule decided where each could go

- `SeedExtraWorkspace` (seed.go) and `RetentionPassCtx` (new scope.go) are exported from this package: both sides need them, neither needs `compose`.
- The River job-runner ceremony **could not follow them**. It builds a runner, so it needs `compose` — and package `integration` may never import `compose`, because `compose`'s own white-box tests import `integration`. The compiler reports this as `import cycle not allowed in test`, which names neither the helper nor the file that moved. It becomes the `jobtest` package, for the same reason `apptest` exists.

That rule is now written into the package doc, since it is the first thing the next split will hit.

`harness.go` was one line under the 500-line ceiling, so recording the rule pushed it over. The package doc moves to `doc.go`, which is where it belongs anyway.

The suites that stayed — embed-reindex and webhook-retry fan-out, reembed — were already sharing that ceremony, so they take it from `jobtest` too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split periodic job fan-out integration suites into a dedicated `integration/jobfanout` package to improve parallelism and reduce CI time. Also fixed flaky test failures by switching the shared test DB pool to `describe_exec` so it’s safe under schema changes. `compose/integration` runtime drops ~12.5% (159s→139s); lane wall clock drops ~3%.

- **Refactors**
  - Moved `agentscheduler`, `privacyretention`, `runner`, `runnerreap` suites to `integration/jobfanout`.
  - Promoted helpers to `integration`: `SeedExtraWorkspace` (seed.go) and `RetentionPassCtx` (scope.go).
  - Added a guard test (`backend/retentionscope_test.go`) to ensure `RetentionPassCtx` is only passed to `EvaluateWorkspace`.
  - Extracted River runner test harness to `integration/jobtest` to avoid `compose` import cycles; exposes `StartTestJobRunner`, event awaiters, and repeat-interval constants (`DispatchInterval`, `DispatchGapBound`).
  - Updated remaining suites (`embedreindex`, `webhookretry` fan-out, `reembed`) to use `integration/jobtest`.
  - Moved package docs from `harness.go` to `doc.go`. Tests-only; no production code.

- **Bug Fixes**
  - Shared test DB pool now uses `default_query_exec_mode=describe_exec` (was `cache_describe`) to avoid stale caches across schema changes, fixing intermittent XX000/0A000 errors (e.g., “cache lookup failed for type …”).

<sup>Written for commit 6fb663fbe615673cac234681b20734376dcb6855. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/672?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

