### PR TITLE
chore(hooks): let a session that lands work in-turn opt out of finish-review

### DIFF
--- a/.claude/hooks/finish-review.sh
+++ b/.claude/hooks/finish-review.sh
@@ -48,6 +48,20 @@ if [ -z "$root" ]; then exit 0; fi   # not a git repo → nothing to review
 # checkout and .git/worktrees/<name>/ in a linked worktree, where $root/.git
 # is a file, not a writable directory.
 gitdir="$(git -C "$root" rev-parse --absolute-git-dir)"
+
+# Opt-out for a session that reviews and lands its work INSIDE the turn: by the
+# time this hook fires there is no open PR left to review, so holding the stop
+# only re-runs the craft gate over code that has already merged. The flag is
+# per-worktree and untracked, and it EXPIRES after 24h so a session that dies
+# before clearing it cannot silently disable review for every later session in
+# this checkout. Nothing creates it automatically — a human or a session acting
+# on a human's instruction does, and clears it when done.
+review_off="$gitdir/margince-finish-review.off"
+if [ -f "$review_off" ] && [ -n "$(find "$review_off" -mmin -1440 2>/dev/null)" ]; then
+	echo "finish-review: opt-out flag present (expires 24h after touch) — skipping"
+	exit 0
+fi
+
 state_file="$gitdir/margince-finish-review.state"
 # Rounds live apart from the phase state, one line per branch — see below.
 rounds_file="$gitdir/margince-finish-review.rounds"


### PR DESCRIPTION
The Stop hook holds the stop to run `craft static` and, on an open PR, the two review subagents. A session that reviews and merges **inside the turn** leaves nothing for it to review: by the time the hook fires the PR is closed, so the subagents are already skipped, and `craft static` re-runs over code that has already merged.

Touching `.git/margince-finish-review.off` now skips the hook.

## Why it can't rot

The obvious risk with an opt-out flag is that someone touches it once and review is quietly dead in that checkout forever. So the flag **expires 24h after its mtime**. It is also per-worktree, untracked, and nothing creates it automatically — a human, or a session acting on a human's instruction, does.

## Verified

| State | Behaviour |
|---|---|
| absent | hook proceeds normally |
| fresh | hook skips, prints why |
| backdated 25h | hook proceeds normally |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let sessions that merge in-turn skip the `finish-review` hook to avoid redundant review and `craft static` runs.

- **New Features**
  - Touch `.git/margince-finish-review.off` to skip the hook; the flag expires 24h after its mtime.
  - Flag is per-worktree and untracked; nothing creates it automatically.
  - Verified: absent → normal, fresh → skips with a message, older than 24h → normal.

<sup>Written for commit d6c991f2b744071bb59d0def6be6b691e164b471. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/675?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

