### PR TITLE
feat(activities): an email can start from an account, not only from a reply

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -2838,6 +2838,66 @@ paths:
               schema: { $ref: '#/components/schemas/Problem' }
         '422': { $ref: '#/components/responses/ValidationError' }
 
+  /emails:
+    post:
+      tags: [Activities, AI]
+      operationId: sendAccountEmail
+      summary: Start a new email conversation from a record — 🟡 confirm-first / gated.
+      description: |
+        The account-started twin of `send_email` (ADR-0087/A132). "Write email" from a company,
+        a person or a deal is a NEW conversation: there is no prior message to anchor to, and
+        the product refuses to fabricate a placeholder activity to obtain one — that would put a
+        timeline entry on the record for a message nobody has sent yet.
+
+        This is the SAME send. Authorization order, the default-deny per-purpose consent gate,
+        deliverability derivation, message-identity minting and the single-transaction staging of
+        activity + delivery + job are the ones `send_email` runs; only the ORIGIN differs. The
+        message roots a fresh thread at its own newly minted identity, and `links` says which
+        records it belongs to instead of inheriting them from an anchor.
+
+        Two refusals are specific to naming your own addressees and your own links:
+
+        - every address in `to`/`cc` must belong to a person the sender can READ, or the send is
+          refused 422 `recipient_not_on_file` naming the address — a fix the composer can offer
+          ("attach this address to a contact"), rather than mail to a string nobody is
+          accountable for;
+        - every entry in `links` is row-scope probed, so a record the caller cannot see is
+          refused 404 exactly as reading it directly would be.
+
+        Tier matches the operation it mirrors: an agent presenting a passport is confirm-first
+        and stages for approval; a human's own call is their confirmation (ADR-0055).
+      x-mcp-tool: { verb: send_account_email, record_type: activity, tier: confirmation_required, scope: send }
+      parameters:
+        - $ref: '#/components/parameters/IdempotencyKey'
+        - $ref: '#/components/parameters/ApprovalToken'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/SendAccountEmailRequest' }
+      responses:
+        '202':
+          description: Accepted for send (queued); the resulting outbound activity is logged.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Activity' }
+        '403':
+          description: Approval token missing for a 🟡 send, or RBAC denied.
+          content:
+            application/problem+json:
+              schema: { $ref: '#/components/schemas/Problem' }
+        '404':
+          description: A named link target does not exist, or is outside the caller's row scope.
+          content:
+            application/problem+json:
+              schema: { $ref: '#/components/schemas/Problem' }
+        '409':
+          description: 'Consent not granted for the send purpose (`code: consent_not_granted`) — suppressed.'
+          content:
+            application/problem+json:
+              schema: { $ref: '#/components/schemas/Problem' }
+        '422': { $ref: '#/components/responses/ValidationError' }
+
   /activities/{id}/send-message:
     parameters:
       - $ref: '#/components/parameters/Id'
@@ -13687,6 +13747,16 @@ components:
         entity_type: { type: string, enum: [person, organization, deal, lead, project] }
         entity_id: { type: string, format: uuid }
 
+    ActivityLinkInput:
+      type: object
+      description: |
+        One record an activity is filed under, as a caller supplies it. The read shape
+        (ActivityLink) carries the ids the server assigned; this carries only the target.
+      required: [entity_type, entity_id]
+      properties:
+        entity_type: { type: string, enum: [person, organization, deal, lead, project] }
+        entity_id: { type: string, format: uuid }
+
     Activity:
       type: object
       description: |
@@ -13975,6 +14045,39 @@ components:
             The consent purpose this send falls under (e.g. `transactional`, `marketing_email`).
             The send is suppressed (409 `consent_not_granted`) unless every recipient has an active
             `granted` `person_consent` for THIS purpose (default-deny per purpose, A22/ADR-0011).
+
+    SendAccountEmailRequest:
+      type: object
+      required: [subject, body, to, consent_purpose, links]
+      description: |
+        One account-started send. It is SendEmailRequest plus the `links` an anchor would
+        otherwise have supplied — the records this new conversation belongs to.
+      properties:
+        subject: { type: string }
+        body: { type: string, description: The (possibly edited) final body that is sent. }
+        to: { type: array, items: { type: string, format: email } }
+        cc: { type: array, items: { type: string, format: email } }
+        draft_ref:
+          type: [string, 'null']
+          description: |
+            Opaque reference returned by the drafting operation, exactly as on `send_email`.
+            Omit for independently composed mail.
+        consent_purpose:
+          type: string
+          description: |
+            The consent purpose this send falls under. Default-deny per purpose (A22/ADR-0011):
+            suppressed 409 `consent_not_granted` unless every recipient has an active `granted`
+            `person_consent` for THIS purpose.
+        links:
+          type: array
+          minItems: 1
+          description: |
+            The records this conversation is filed under — the company it was started from, and
+            optionally the person and deal it concerns. At least one is required: a message
+            belonging to no record is one nobody will find again, which is the gap this
+            operation exists to close. Each target is row-scope probed, so an id the caller
+            cannot see is refused 404.
+          items: { $ref: '#/components/schemas/ActivityLinkInput' }
 
     SendMessageRequest:
       type: object

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -14060,7 +14060,13 @@ components:
       properties:
         subject: { type: string }
         body: { type: string, description: The (possibly edited) final body that is sent. }
-        to: { type: array, items: { type: string, format: email } }
+        to:
+          type: array
+          minItems: 1
+          description: |
+            At least one addressee. A send whose To: line is empty is refused 422 before
+            anything is staged — `cc` alone does not make a message addressed to anyone.
+          items: { type: string, format: email }
         cc: { type: array, items: { type: string, format: email } }
         draft_ref:
           type: [string, 'null']

--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -2864,12 +2864,17 @@ paths:
         - every entry in `links` is row-scope probed, so a record the caller cannot see is
           refused 404 exactly as reading it directly would be.
 
-        Tier matches the operation it mirrors: an agent presenting a passport is confirm-first
-        and stages for approval; a human's own call is their confirmation (ADR-0055).
-      x-mcp-tool: { verb: send_account_email, record_type: activity, tier: confirmation_required, scope: send }
+        HUMAN-ONLY for now, and deliberately so. ADR-0087 §6 gives the agent surface this
+        operation at the same 🟡 tier as the reply, but a 🟡 agent call STAGES for approval, and a
+        staged row is only releasable when its kind maps onto a grantable object in approvals.
+        Registering the verb without that mapping would advertise a tool whose every call clears
+        admission and is then refused at staging — a governed verb no agent can reach and no human
+        can release. The composer surface ships first; the agent tool follows with its
+        decision-grant mapping, tool spec and staging test as one change.
+      x-agent-access: human-only
+      security: [ { cookieAuth: [] } ]   # human session only — rejects agent bearer/Passport
       parameters:
         - $ref: '#/components/parameters/IdempotencyKey'
-        - $ref: '#/components/parameters/ApprovalToken'
       requestBody:
         required: true
         content:
@@ -2882,7 +2887,7 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/Activity' }
         '403':
-          description: Approval token missing for a 🟡 send, or RBAC denied.
+          description: RBAC denied, or an agent principal presented a passport to a human-only operation.
           content:
             application/problem+json:
               schema: { $ref: '#/components/schemas/Problem' }

--- a/backend/internal/compose/agentpolicy_gen.go
+++ b/backend/internal/compose/agentpolicy_gen.go
@@ -286,7 +286,7 @@ var agentPolicies = map[string]agentPolicy{
 	"POST /v1/deals/{id}/offers":                                         {Op: "createOffer", Access: "tool", Tool: "create_record", RecordType: "offer", Tier: "auto_execute", Scope: "write"},
 	"POST /v1/dedupe/candidates/{id}/disposition":                        {Op: "disposeDedupeCandidate", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/dedupe/candidates/{id}/undo":                               {Op: "undoDedupeDisposition", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
-	"POST /v1/emails":                                                    {Op: "sendAccountEmail", Access: "tool", Tool: "send_account_email", RecordType: "activity", Tier: "confirmation_required", Scope: "send"},
+	"POST /v1/emails":                                                    {Op: "sendAccountEmail", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/embeddings/reindex":                                        {Op: "EmbedReindexStart", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/exports":                                                   {Op: "createFilteredExport", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/fx-rates":                                                  {Op: "setFxRate", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},

--- a/backend/internal/compose/agentpolicy_gen.go
+++ b/backend/internal/compose/agentpolicy_gen.go
@@ -286,6 +286,7 @@ var agentPolicies = map[string]agentPolicy{
 	"POST /v1/deals/{id}/offers":                                         {Op: "createOffer", Access: "tool", Tool: "create_record", RecordType: "offer", Tier: "auto_execute", Scope: "write"},
 	"POST /v1/dedupe/candidates/{id}/disposition":                        {Op: "disposeDedupeCandidate", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/dedupe/candidates/{id}/undo":                               {Op: "undoDedupeDisposition", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
+	"POST /v1/emails":                                                    {Op: "sendAccountEmail", Access: "tool", Tool: "send_account_email", RecordType: "activity", Tier: "confirmation_required", Scope: "send"},
 	"POST /v1/embeddings/reindex":                                        {Op: "EmbedReindexStart", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/exports":                                                   {Op: "createFilteredExport", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},
 	"POST /v1/fx-rates":                                                  {Op: "setFxRate", Access: "human-only", Tool: "", RecordType: "", Tier: "", Scope: ""},

--- a/backend/internal/compose/comms.go
+++ b/backend/internal/compose/comms.go
@@ -71,7 +71,7 @@ func (c commsAdapter) DraftEmail(ctx context.Context, anchor ids.UUID, intent st
 // anyway, and naming a reference here would only make that refusal look like
 // an accident of wiring.
 func (c commsAdapter) SendEmail(ctx context.Context, anchor ids.UUID, in agents.SendEmailArgs) (agents.SendEmailResult, error) {
-	sent, err := c.store.SendEmail(ctx, ids.From[ids.ActivityKind](anchor), activities.SendEmailInput{
+	sent, err := c.store.SendEmail(ctx, activities.FromActivity(ids.From[ids.ActivityKind](anchor)), activities.SendEmailInput{
 		Recipients:     append(append([]string{}, in.To...), in.Cc...),
 		Cc:             append([]string{}, in.Cc...),
 		Subject:        in.Subject,

--- a/backend/internal/compose/commschannel.go
+++ b/backend/internal/compose/commschannel.go
@@ -82,3 +82,16 @@ var _ activities.ChannelReachability = channelReachability{}
 func (channelReachability) ReachableChannelIdentities(ctx context.Context, tx pgx.Tx, personID ids.UUID, provider string) ([]connector.ChannelIdentity, error) {
 	return people.ReachableChannelIdentities(ctx, tx, ids.From[ids.PersonKind](personID), provider)
 }
+
+// recipientDirectory is the mail twin of the edge above: an account-started
+// send names its own addressees, and person_email is the people module's
+// table. Stateless for the same reason — one query on the caller's own
+// transaction, so the addresses resolve in the same snapshot that stages
+// the message.
+type recipientDirectory struct{}
+
+var _ activities.RecipientDirectory = recipientDirectory{}
+
+func (recipientDirectory) VisibleAddresses(ctx context.Context, tx pgx.Tx, addresses []string) (map[string]bool, error) {
+	return people.VisibleAddresses(ctx, tx, addresses)
+}

--- a/backend/internal/compose/integration/capture/capture_tiergate_integration_test.go
+++ b/backend/internal/compose/integration/capture/capture_tiergate_integration_test.go
@@ -285,7 +285,7 @@ func TestCaptureTierGateHonorsCorrespondenceFromACRMOriginatedSend(t *testing.T)
 		t.Fatalf("seed anchor: %v", err)
 	}
 
-	if _, err := activities.NewStore(e.Pool).SendEmail(ctx, ids.From[ids.ActivityKind](anchorID),
+	if _, err := activities.NewStore(e.Pool).SendEmail(ctx, activities.FromActivity(ids.From[ids.ActivityKind](anchorID)),
 		activities.SendEmailInput{
 			Recipients:     []string{"Team@News.Prospect.Example"},
 			Subject:        "Following up",

--- a/backend/internal/compose/replayscope.go
+++ b/backend/internal/compose/replayscope.go
@@ -137,6 +137,12 @@ var replayableOperations = map[string]replayTarget{
 	"PATCH /v1/activities/{id}":           {object: tableActivity, table: tableActivity, idPath: "id"},
 	"POST /v1/activities/{id}/relink":     {object: tableActivity, table: tableActivity, idPath: "id"},
 	"POST /v1/activities/{id}/send-email": {object: tableActivity, table: tableActivity, idPath: "id"},
+	// The account-started send answers with the outbound activity it wrote,
+	// so its replay is gated on that activity exactly as the reply's is. The
+	// route carries no id of its own — the origin is in the body — which is
+	// why the target is resolved from the RESPONSE's id rather than a path
+	// parameter.
+	"POST /v1/emails": {object: tableActivity, table: tableActivity, idPath: "id"},
 	// The channel reply answers with the outbound activity it wrote, so its
 	// replay is gated on that activity exactly as the mail send's is. It matters
 	// more here, not less: a channel send is irreversible with no provider-side

--- a/backend/internal/compose/sendpath.go
+++ b/backend/internal/compose/sendpath.go
@@ -106,6 +106,10 @@ func (s *Server) applySendPath(pool *pgxpool.Pool) {
 		// mail surface does.
 		WithChannelDelivery(send.Delivery).
 		WithChannelReachability(send.ChannelRecipients).
+		// Wired unconditionally, like the unsubscribe linker below: it needs
+		// nothing but the caller's transaction, so a deployment cannot forget
+		// it and leave an account-started send unable to resolve anyone.
+		WithRecipientDirectory(recipientDirectory{}).
 		WithSendAuthority(send.SendAuthority).
 		WithDraftOutcome(send.DraftOutcome)
 }
@@ -123,6 +127,7 @@ func sendStore(pool *pgxpool.Pool, send SendPath) *activities.Store {
 		WithPublicBaseURL(send.PublicBaseURL).
 		WithSendAuthority(send.SendAuthority).
 		WithChannelReachability(send.ChannelRecipients).
+		WithRecipientDirectory(recipientDirectory{}).
 		WithDraftOutcome(send.DraftOutcome)
 }
 

--- a/backend/internal/compose/sendvoiceoutcome_integration_test.go
+++ b/backend/internal/compose/sendvoiceoutcome_integration_test.go
@@ -219,7 +219,7 @@ func TestBothSendTransportsCarryTheDraftOutcomeRecorder(t *testing.T) {
 		stager := &recordingStager{}
 		store := sendStore(e.Pool, SendPath{PublicBaseURL: voiceSendBaseURL, Delivery: stager})
 
-		if _, err := store.SendEmail(e.ctx, ids.From[ids.ActivityKind](e.anchor),
+		if _, err := store.SendEmail(e.ctx, activities.FromActivity(ids.From[ids.ActivityKind](e.anchor)),
 			e.draftedSend(draft.ref), consent.NewGate(consent.NewStore(e.Pool)), stager); err != nil {
 			t.Fatalf("send through the tool surface's store: %v", err)
 		}
@@ -369,14 +369,14 @@ func TestConcurrentSendsSharingADraftReferenceLeaveOneOutcomeAndBothTransmit(t *
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		_, winnerErr = winnerStore.SendEmail(e.ctx, anchor, e.draftedSend(draft.ref), gate, winnerStager)
+		_, winnerErr = winnerStore.SendEmail(e.ctx, activities.FromActivity(anchor), e.draftedSend(draft.ref), gate, winnerStager)
 	}()
 	holder := awaitLockHolder(t, winner.locked)
 
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		_, loserErr = loserStore.SendEmail(e.ctx, anchor, e.draftedSend(draft.ref), gate, loserStager)
+		_, loserErr = loserStore.SendEmail(e.ctx, activities.FromActivity(anchor), e.draftedSend(draft.ref), gate, loserStager)
 	}()
 	waitForBlockedOn(t, e, holder)
 

--- a/backend/internal/compose/stubs_gen.go
+++ b/backend/internal/compose/stubs_gen.go
@@ -467,6 +467,10 @@ func (stubs) GetMorningDigest(w nethttp.ResponseWriter, r *nethttp.Request, para
 	httperr.NotImplemented(w, r, "GetMorningDigest")
 }
 
+func (stubs) SendAccountEmail(w nethttp.ResponseWriter, r *nethttp.Request, params crmcontracts.SendAccountEmailParams) {
+	httperr.NotImplemented(w, r, "SendAccountEmail")
+}
+
 func (stubs) EmbedReindexStart(w nethttp.ResponseWriter, r *nethttp.Request) {
 	httperr.NotImplemented(w, r, "EmbedReindexStart")
 }

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -17258,15 +17258,6 @@ type SendAccountEmailParams struct {
 	// than half-honouring it, so read this contract, not the client, to know which calls are safe
 	// to retry blind.
 	IdempotencyKey *IdempotencyKey `json:"Idempotency-Key,omitempty"`
-
-	// XApprovalToken A signed, single-use approval token (see schema `ApprovalToken`) minted by
-	// POST /approvals/{id}/approve, authorizing exactly one 🟡 confirm-first operation. It is a
-	// compact JWS whose claims **bind** the token to a specific approval, effect, tenant and
-	// principal — it is NOT a bare opaque string (ADR-0036). The server rejects a token that is
-	// expired, already consumed, or whose `diff_hash`/`workspace_id`/`passport_id`/`tool` does not
-	// match the operation being executed (`403 code: approval_token_invalid`). Required when an
-	// AGENT principal invokes a 🟡 operation; a human's direct call is itself the approval.
-	XApprovalToken *ApprovalToken `json:"X-Approval-Token,omitempty"`
 }
 
 // GetFieldHistoryParams defines parameters for GetFieldHistory.
@@ -33286,8 +33277,6 @@ func (siw *ServerInterfaceWrapper) SendAccountEmail(w http.ResponseWriter, r *ht
 
 	ctx := r.Context()
 
-	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
-
 	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
 
 	r = r.WithContext(ctx)
@@ -33313,25 +33302,6 @@ func (siw *ServerInterfaceWrapper) SendAccountEmail(w http.ResponseWriter, r *ht
 		}
 
 		params.IdempotencyKey = &IdempotencyKey
-
-	}
-
-	// ------------- Optional header parameter "X-Approval-Token" -------------
-	if valueList, found := headers[http.CanonicalHeaderKey("X-Approval-Token")]; found {
-		var XApprovalToken ApprovalToken
-		n := len(valueList)
-		if n != 1 {
-			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Approval-Token", Count: n})
-			return
-		}
-
-		err = runtime.BindStyledParameterWithOptions("simple", "X-Approval-Token", valueList[0], &XApprovalToken, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false, Type: "string", Format: ""})
-		if err != nil {
-			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Approval-Token", Err: err})
-			return
-		}
-
-		params.XApprovalToken = &XApprovalToken
 
 	}
 

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -243,6 +243,33 @@ func (e ActivityLinkEntityType) Valid() bool {
 	}
 }
 
+// Defines values for ActivityLinkInputEntityType.
+const (
+	ActivityLinkInputEntityTypeDeal         ActivityLinkInputEntityType = "deal"
+	ActivityLinkInputEntityTypeLead         ActivityLinkInputEntityType = "lead"
+	ActivityLinkInputEntityTypeOrganization ActivityLinkInputEntityType = "organization"
+	ActivityLinkInputEntityTypePerson       ActivityLinkInputEntityType = "person"
+	ActivityLinkInputEntityTypeProject      ActivityLinkInputEntityType = "project"
+)
+
+// Valid indicates whether the value is a known member of the ActivityLinkInputEntityType enum.
+func (e ActivityLinkInputEntityType) Valid() bool {
+	switch e {
+	case ActivityLinkInputEntityTypeDeal:
+		return true
+	case ActivityLinkInputEntityTypeLead:
+		return true
+	case ActivityLinkInputEntityTypeOrganization:
+		return true
+	case ActivityLinkInputEntityTypePerson:
+		return true
+	case ActivityLinkInputEntityTypeProject:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for AddConsumerMailDomainRequestKind.
 const (
 	AddConsumerMailDomainRequestKindExtra AddConsumerMailDomainRequestKind = "extra"
@@ -7592,22 +7619,22 @@ func (e VoiceProfileEvaluationRepeatsPerPrompt) Valid() bool {
 
 // Defines values for VoiceProfileVersionReason.
 const (
-	Automatic  VoiceProfileVersionReason = "automatic"
-	Manual     VoiceProfileVersionReason = "manual"
-	Onboarding VoiceProfileVersionReason = "onboarding"
-	Rollback   VoiceProfileVersionReason = "rollback"
+	VoiceProfileVersionReasonAutomatic  VoiceProfileVersionReason = "automatic"
+	VoiceProfileVersionReasonManual     VoiceProfileVersionReason = "manual"
+	VoiceProfileVersionReasonOnboarding VoiceProfileVersionReason = "onboarding"
+	VoiceProfileVersionReasonRollback   VoiceProfileVersionReason = "rollback"
 )
 
 // Valid indicates whether the value is a known member of the VoiceProfileVersionReason enum.
 func (e VoiceProfileVersionReason) Valid() bool {
 	switch e {
-	case Automatic:
+	case VoiceProfileVersionReasonAutomatic:
 		return true
-	case Manual:
+	case VoiceProfileVersionReasonManual:
 		return true
-	case Onboarding:
+	case VoiceProfileVersionReasonOnboarding:
 		return true
-	case Rollback:
+	case VoiceProfileVersionReasonRollback:
 		return true
 	default:
 		return false
@@ -8958,6 +8985,16 @@ type ActivityLink struct {
 
 // ActivityLinkEntityType defines model for ActivityLink.EntityType.
 type ActivityLinkEntityType string
+
+// ActivityLinkInput One record an activity is filed under, as a caller supplies it. The read shape
+// (ActivityLink) carries the ids the server assigned; this carries only the target.
+type ActivityLinkInput struct {
+	EntityId   openapi_types.UUID          `json:"entity_id"`
+	EntityType ActivityLinkInputEntityType `json:"entity_type"`
+}
+
+// ActivityLinkInputEntityType defines model for ActivityLinkInput.EntityType.
+type ActivityLinkInputEntityType string
 
 // ActivityListResponse defines model for ActivityListResponse.
 type ActivityListResponse struct {
@@ -15006,6 +15043,32 @@ type SearchResultTrustTier string
 // SearchResultType defines model for SearchResult.Type.
 type SearchResultType string
 
+// SendAccountEmailRequest One account-started send. It is SendEmailRequest plus the `links` an anchor would
+// otherwise have supplied — the records this new conversation belongs to.
+type SendAccountEmailRequest struct {
+	// Body The (possibly edited) final body that is sent.
+	Body string                 `json:"body"`
+	Cc   *[]openapi_types.Email `json:"cc,omitempty"`
+
+	// ConsentPurpose The consent purpose this send falls under. Default-deny per purpose (A22/ADR-0011):
+	// suppressed 409 `consent_not_granted` unless every recipient has an active `granted`
+	// `person_consent` for THIS purpose.
+	ConsentPurpose string `json:"consent_purpose"`
+
+	// DraftRef Opaque reference returned by the drafting operation, exactly as on `send_email`.
+	// Omit for independently composed mail.
+	DraftRef *string `json:"draft_ref,omitempty"`
+
+	// Links The records this conversation is filed under — the company it was started from, and
+	// optionally the person and deal it concerns. At least one is required: a message
+	// belonging to no record is one nobody will find again, which is the gap this
+	// operation exists to close. Each target is row-scope probed, so an id the caller
+	// cannot see is refused 404.
+	Links   []ActivityLinkInput   `json:"links"`
+	Subject string                `json:"subject"`
+	To      []openapi_types.Email `json:"to"`
+}
+
 // SendEmailRequest defines model for SendEmailRequest.
 type SendEmailRequest struct {
 	// Body The (possibly edited) final body that is sent.
@@ -17176,6 +17239,34 @@ type ListDedupeCandidatesParamsEntityType string
 type GetMorningDigestParams struct {
 	// Date A specific digest day; default: the latest generated.
 	Date *openapi_types.Date `form:"date,omitempty" json:"date,omitempty"`
+}
+
+// SendAccountEmailParams defines parameters for SendAccountEmail.
+type SendAccountEmailParams struct {
+	// IdempotencyKey Client-supplied key making a mutation safe to retry — an update exactly as much as a
+	// create (API-CC-6). **Scope:** the key is unique within
+	// `(workspace_id, principal, request-path)` and retained **24h**; a replay within that window
+	// returns the original status + body. Reusing the same key with a *different* request body
+	// returns `409 code: idempotency_key_conflict` (never a silent replay of mismatched intent).
+	// **On an update behind `If-Match`** the key is what separates "not applied" from "applied,
+	// answer lost": without it the blind retry answers `409 version_skew`, because the first
+	// attempt already bumped the version.
+	// **Precedence vs natural keys:** on `logActivity`/`createLead`, the Idempotency-Key (transport
+	// retry-safety) is checked first; if absent, the `(source_system, source_id)` natural key
+	// (data-model dedupe) governs. The two never both create a row. **Declaring this parameter is
+	// what makes an operation replay-safe** — an operation that omits it ignores the header rather
+	// than half-honouring it, so read this contract, not the client, to know which calls are safe
+	// to retry blind.
+	IdempotencyKey *IdempotencyKey `json:"Idempotency-Key,omitempty"`
+
+	// XApprovalToken A signed, single-use approval token (see schema `ApprovalToken`) minted by
+	// POST /approvals/{id}/approve, authorizing exactly one 🟡 confirm-first operation. It is a
+	// compact JWS whose claims **bind** the token to a specific approval, effect, tenant and
+	// principal — it is NOT a bare opaque string (ADR-0036). The server rejects a token that is
+	// expired, already consumed, or whose `diff_hash`/`workspace_id`/`passport_id`/`tool` does not
+	// match the operation being executed (`403 code: approval_token_invalid`). Required when an
+	// AGENT principal invokes a 🟡 operation; a human's direct call is itself the approval.
+	XApprovalToken *ApprovalToken `json:"X-Approval-Token,omitempty"`
 }
 
 // GetFieldHistoryParams defines parameters for GetFieldHistory.
@@ -19522,6 +19613,9 @@ type CreateOfferJSONRequestBody = CreateOfferRequest
 
 // DisposeDedupeCandidateJSONRequestBody defines body for DisposeDedupeCandidate for application/json ContentType.
 type DisposeDedupeCandidateJSONRequestBody = DedupeDispositionRequest
+
+// SendAccountEmailJSONRequestBody defines body for SendAccountEmail for application/json ContentType.
+type SendAccountEmailJSONRequestBody = SendAccountEmailRequest
 
 // EmbedReindexStartJSONRequestBody defines body for EmbedReindexStart for application/json ContentType.
 type EmbedReindexStartJSONRequestBody = EmbedReindexStartRequest
@@ -25831,6 +25925,9 @@ type ServerInterface interface {
 	// The calling user's morning digest — what capture did overnight.
 	// (GET /digest)
 	GetMorningDigest(w http.ResponseWriter, r *http.Request, params GetMorningDigestParams)
+	// Start a new email conversation from a record — 🟡 confirm-first / gated.
+	// (POST /emails)
+	SendAccountEmail(w http.ResponseWriter, r *http.Request, params SendAccountEmailParams)
 	// Confirm and start a fleet-wide reindex.
 	// (POST /embeddings/reindex)
 	EmbedReindexStart(w http.ResponseWriter, r *http.Request)
@@ -27133,6 +27230,12 @@ func (_ Unimplemented) UndoDedupeDisposition(w http.ResponseWriter, r *http.Requ
 // The calling user's morning digest — what capture did overnight.
 // (GET /digest)
 func (_ Unimplemented) GetMorningDigest(w http.ResponseWriter, r *http.Request, params GetMorningDigestParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Start a new email conversation from a record — 🟡 confirm-first / gated.
+// (POST /emails)
+func (_ Unimplemented) SendAccountEmail(w http.ResponseWriter, r *http.Request, params SendAccountEmailParams) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -33166,6 +33269,74 @@ func (siw *ServerInterfaceWrapper) GetMorningDigest(w http.ResponseWriter, r *ht
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.GetMorningDigest(w, r, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// SendAccountEmail operation middleware
+func (siw *ServerInterfaceWrapper) SendAccountEmail(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	ctx = context.WithValue(ctx, CookieAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params SendAccountEmailParams
+
+	headers := r.Header
+
+	// ------------- Optional header parameter "Idempotency-Key" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("Idempotency-Key")]; found {
+		var IdempotencyKey IdempotencyKey
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "Idempotency-Key", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithOptions("simple", "Idempotency-Key", valueList[0], &IdempotencyKey, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false, Type: "string", Format: ""})
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "Idempotency-Key", Err: err})
+			return
+		}
+
+		params.IdempotencyKey = &IdempotencyKey
+
+	}
+
+	// ------------- Optional header parameter "X-Approval-Token" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("X-Approval-Token")]; found {
+		var XApprovalToken ApprovalToken
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Approval-Token", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Approval-Token", valueList[0], &XApprovalToken, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false, Type: "string", Format: ""})
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Approval-Token", Err: err})
+			return
+		}
+
+		params.XApprovalToken = &XApprovalToken
+
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.SendAccountEmail(w, r, params)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -43927,6 +44098,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/digest", wrapper.GetMorningDigest)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/emails", wrapper.SendAccountEmail)
 	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/embeddings/reindex", wrapper.EmbedReindexStart)

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -15064,9 +15064,12 @@ type SendAccountEmailRequest struct {
 	// belonging to no record is one nobody will find again, which is the gap this
 	// operation exists to close. Each target is row-scope probed, so an id the caller
 	// cannot see is refused 404.
-	Links   []ActivityLinkInput   `json:"links"`
-	Subject string                `json:"subject"`
-	To      []openapi_types.Email `json:"to"`
+	Links   []ActivityLinkInput `json:"links"`
+	Subject string              `json:"subject"`
+
+	// To At least one addressee. A send whose To: line is empty is refused 422 before
+	// anything is staged — `cc` alone does not make a message addressed to anyone.
+	To []openapi_types.Email `json:"to"`
 }
 
 // SendEmailRequest defines model for SendEmailRequest.

--- a/backend/internal/modules/activities/draftoutcome_integration_test.go
+++ b/backend/internal/modules/activities/draftoutcome_integration_test.go
@@ -87,7 +87,7 @@ func TestSendEmailProceedsWhenNoDraftOutcomeRecorderIsWired(t *testing.T) {
 	stager := &recordingStager{}
 
 	if _, err := e.store(stubUnsubscribeLinker{}).SendEmail(
-		e.as(principal.RowScopeAll), anchor, draftedSendInput("transactional"), stubConsentGate{}, stager); err != nil {
+		e.as(principal.RowScopeAll), FromActivity(anchor), draftedSendInput("transactional"), stubConsentGate{}, stager); err != nil {
 		t.Fatalf("SendEmail with no learning loop wired: %v", err)
 	}
 	if n := e.outboundCount(t); n != 1 {
@@ -106,7 +106,7 @@ func TestSendEmailProceedsWhenTheDraftReferenceResolvesNoSignal(t *testing.T) {
 	recorder := &recordingDraftOutcome{recorded: false}
 
 	if _, err := e.store(stubUnsubscribeLinker{}).WithDraftOutcome(recorder).SendEmail(
-		e.as(principal.RowScopeAll), anchor, draftedSendInput("transactional"), stubConsentGate{}, stager); err != nil {
+		e.as(principal.RowScopeAll), FromActivity(anchor), draftedSendInput("transactional"), stubConsentGate{}, stager); err != nil {
 		t.Fatalf("SendEmail over an unresolvable draft reference: %v", err)
 	}
 	if len(recorder.calls) != 1 {
@@ -133,7 +133,7 @@ func TestSendEmailRollsBackTheWholeSendWhenTheLearningWriteFaults(t *testing.T) 
 	recorder := &recordingDraftOutcome{err: fault}
 
 	_, err := e.store(stubUnsubscribeLinker{}).WithDraftOutcome(recorder).SendEmail(
-		e.as(principal.RowScopeAll), anchor, draftedSendInput("transactional"), stubConsentGate{}, stager)
+		e.as(principal.RowScopeAll), FromActivity(anchor), draftedSendInput("transactional"), stubConsentGate{}, stager)
 	if !errors.Is(err, fault) {
 		t.Fatalf("SendEmail over a faulting learning write → %v, want the fault", err)
 	}
@@ -165,7 +165,7 @@ func TestDraftOutcomeJudgesTheApprovedBodyNotTheTransmittedFooter(t *testing.T) 
 	in := draftedSendInput("marketing_email")
 	in.Recipients, in.Cc = []string{"buyer@example.test"}, nil
 	if _, err := e.store(linker).WithDraftOutcome(recorder).SendEmail(
-		e.as(principal.RowScopeAll), anchor, in, stubConsentGate{}, stager); err != nil {
+		e.as(principal.RowScopeAll), FromActivity(anchor), in, stubConsentGate{}, stager); err != nil {
 		t.Fatalf("SendEmail: %v", err)
 	}
 
@@ -190,7 +190,7 @@ func TestSendEmailAsksNothingOfTheLearningLoopWithoutADraftReference(t *testing.
 	recorder := &recordingDraftOutcome{}
 
 	if _, err := e.store(stubUnsubscribeLinker{}).WithDraftOutcome(recorder).SendEmail(
-		e.as(principal.RowScopeAll), anchor, sendInput("transactional"), stubConsentGate{}, stager); err != nil {
+		e.as(principal.RowScopeAll), FromActivity(anchor), sendInput("transactional"), stubConsentGate{}, stager); err != nil {
 		t.Fatalf("SendEmail: %v", err)
 	}
 	if len(recorder.calls) != 0 {

--- a/backend/internal/modules/activities/email.go
+++ b/backend/internal/modules/activities/email.go
@@ -214,6 +214,15 @@ func (s *Store) SendEmail(ctx context.Context, origin SendOrigin, in SendEmailIn
 
 	var sent crmcontracts.Activity
 	err = s.tx(ctx, func(tx pgx.Tx) error {
+		// An account-started send names its own addressees, so each must
+		// belong to someone this sender can read (ADR-0087 §2). It runs
+		// AFTER the consent gate: the gate is the recipients' own answer
+		// about being written to at all, and a caller must not learn that a
+		// stranger withheld consent by watching which of two refusals a
+		// typed address produces.
+		if err := s.resolveRecipients(ctx, tx, origin, in.Recipients); err != nil {
+			return err
+		}
 		chain, err := origin.threading(ctx, tx, messageID)
 		if err != nil {
 			return err

--- a/backend/internal/modules/activities/email.go
+++ b/backend/internal/modules/activities/email.go
@@ -20,7 +20,6 @@ import (
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
-	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
@@ -178,11 +177,16 @@ func (s *Store) refuseUnsendable(ctx context.Context, in SendEmailInput, gate Co
 	return gate.RequireGrantedForEmails(ctx, in.Recipients, in.ConsentPurpose)
 }
 
-// SendEmail runs the governed send: anchor visibility → the guard sequence
+// SendEmail runs the governed send: origin resolution → the guard sequence
 // above → deliverability → the outbound activity and its delivery, committed
 // together in the write shape.
-func (s *Store) SendEmail(ctx context.Context, anchorID ids.ActivityID, in SendEmailInput, gate ConsentGate, stager DeliveryStager) (crmcontracts.Activity, error) {
-	anchor, err := s.GetActivity(ctx, anchorID, storekit.LiveOnly)
+//
+// There is exactly one send. A reply and an account-started message differ
+// only in the origin they arrive with (ADR-0087 §1); every invariant below
+// the resolution — the authorization order, the consent gate, deliverability,
+// identity minting, single-transaction staging — is reached by both.
+func (s *Store) SendEmail(ctx context.Context, origin SendOrigin, in SendEmailInput, gate ConsentGate, stager DeliveryStager) (crmcontracts.Activity, error) {
+	links, err := origin.resolve(ctx, s)
 	if err != nil {
 		return crmcontracts.Activity{}, err
 	}
@@ -205,12 +209,12 @@ func (s *Store) SendEmail(ctx context.Context, anchorID ids.ActivityID, in SendE
 		recordedBody:    derived.recorded,
 		listUnsubscribe: derived.listUnsubscribe,
 		to:              toRecipients(in.Recipients, in.Cc),
-		links:           inheritedLinks(anchor),
+		links:           links,
 	}
 
 	var sent crmcontracts.Activity
 	err = s.tx(ctx, func(tx pgx.Tx) error {
-		chain, err := anchorThreading(ctx, tx, anchorID, messageID)
+		chain, err := origin.threading(ctx, tx, messageID)
 		if err != nil {
 			return err
 		}
@@ -297,21 +301,6 @@ func (m outboundMessage) delivery(activityID ids.UUID, chain threading) Delivery
 		ThreadKey:       chain.threadKey,
 		ListUnsubscribe: m.listUnsubscribe,
 	}
-}
-
-// inheritedLinks carries the anchor's own links onto the reply, so the sent
-// message lands on the same records' timelines as the conversation it
-// answers. The links were already visibility-checked as part of reading the
-// anchor, and each one is re-checked at insert.
-func inheritedLinks(anchor crmcontracts.Activity) []ActivityLinkInput {
-	if anchor.Links == nil {
-		return nil
-	}
-	links := make([]ActivityLinkInput, 0, len(*anchor.Links))
-	for _, l := range *anchor.Links {
-		links = append(links, ActivityLinkInput{EntityType: string(l.EntityType), EntityID: ids.UUID(l.EntityId)})
-	}
-	return links
 }
 
 // messageIDDomain is the right-hand side of every minted Message-ID: the

--- a/backend/internal/modules/activities/email_integration_test.go
+++ b/backend/internal/modules/activities/email_integration_test.go
@@ -297,7 +297,7 @@ func TestSendEmailStampsTheUnbracketedMessageIDAsTheSourceKey(t *testing.T) {
 	stager := &recordingStager{}
 
 	sent, err := e.store(stubUnsubscribeLinker{}).SendEmail(
-		e.as(principal.RowScopeAll), anchor, sendInput("transactional"), stubConsentGate{}, stager)
+		e.as(principal.RowScopeAll), FromActivity(anchor), sendInput("transactional"), stubConsentGate{}, stager)
 	if err != nil {
 		t.Fatalf("SendEmail: %v", err)
 	}
@@ -340,7 +340,7 @@ func TestSendEmailStampsTheThreadKeyFromTheAnchor(t *testing.T) {
 	stager := &recordingStager{}
 
 	sent, err := e.store(stubUnsubscribeLinker{}).SendEmail(
-		e.as(principal.RowScopeAll), anchor, sendInput("transactional"), stubConsentGate{}, stager)
+		e.as(principal.RowScopeAll), FromActivity(anchor), sendInput("transactional"), stubConsentGate{}, stager)
 	if err != nil {
 		t.Fatalf("SendEmail: %v", err)
 	}
@@ -377,7 +377,7 @@ func TestSendEmailThreadsAnAnchorThatHasAKeyButNoMessageIdentity(t *testing.T) {
 	stager := &recordingStager{}
 
 	if _, err := e.store(stubUnsubscribeLinker{}).SendEmail(
-		e.as(principal.RowScopeAll), anchor, sendInput("transactional"), stubConsentGate{}, stager); err != nil {
+		e.as(principal.RowScopeAll), FromActivity(anchor), sendInput("transactional"), stubConsentGate{}, stager); err != nil {
 		t.Fatalf("SendEmail: %v", err)
 	}
 
@@ -407,7 +407,7 @@ func TestSendEmailRecordsTheOutboundCorrespondenceEvidence(t *testing.T) {
 	in.Recipients = []string{"Buyer@Example.test", "boss@example.test"}
 	in.Cc = []string{"boss@example.test"}
 	sent, err := e.store(stubUnsubscribeLinker{}).SendEmail(
-		e.as(principal.RowScopeAll), anchor, in, stubConsentGate{}, stager)
+		e.as(principal.RowScopeAll), FromActivity(anchor), in, stubConsentGate{}, stager)
 	if err != nil {
 		t.Fatalf("SendEmail: %v", err)
 	}
@@ -432,7 +432,7 @@ func TestSendEmailWithoutAnchorContextRootsANewThread(t *testing.T) {
 	stager := &recordingStager{}
 
 	sent, err := e.store(stubUnsubscribeLinker{}).SendEmail(
-		e.as(principal.RowScopeAll), anchor, sendInput("transactional"), stubConsentGate{}, stager)
+		e.as(principal.RowScopeAll), FromActivity(anchor), sendInput("transactional"), stubConsentGate{}, stager)
 	if err != nil {
 		t.Fatalf("SendEmail: %v", err)
 	}

--- a/backend/internal/modules/activities/email_refusals_integration_test.go
+++ b/backend/internal/modules/activities/email_refusals_integration_test.go
@@ -31,7 +31,7 @@ func TestSendEmailDerivesUnsubscribeHeadersForAMarketingPurpose(t *testing.T) {
 	linker := stubUnsubscribeLinker{token: testUnsubscribeTok, ok: true}
 
 	sent, err := e.store(linker).SendEmail(
-		e.as(principal.RowScopeAll), anchor, soloSendInput("marketing_email"), stubConsentGate{}, stager)
+		e.as(principal.RowScopeAll), FromActivity(anchor), soloSendInput("marketing_email"), stubConsentGate{}, stager)
 	if err != nil {
 		t.Fatalf("SendEmail: %v", err)
 	}
@@ -74,7 +74,7 @@ func TestSendEmailDerivesNoUnsubscribeHeadersForATransactionalPurpose(t *testing
 	linker := stubUnsubscribeLinker{token: testUnsubscribeTok, ok: false}
 
 	if _, err := e.store(linker).SendEmail(
-		e.as(principal.RowScopeAll), anchor, sendInput("transactional"), stubConsentGate{}, stager); err != nil {
+		e.as(principal.RowScopeAll), FromActivity(anchor), sendInput("transactional"), stubConsentGate{}, stager); err != nil {
 		t.Fatalf("SendEmail: %v", err)
 	}
 
@@ -100,7 +100,7 @@ func TestSendEmailRefusesAMultiAddresseeSendThatCarriesAnUnsubscribeToken(t *tes
 
 	// sendInput addresses buyer@ and cc's boss@ — two people, one token.
 	_, err := e.store(linker).SendEmail(
-		e.as(principal.RowScopeAll), anchor, sendInput("marketing_email"), stubConsentGate{}, stager)
+		e.as(principal.RowScopeAll), FromActivity(anchor), sendInput("marketing_email"), stubConsentGate{}, stager)
 	var refusal *SharedUnsubscribeTokenError
 	if !errors.As(err, &refusal) {
 		t.Fatalf("multi-addressee marketing send → %v, want a SharedUnsubscribeTokenError", err)
@@ -129,7 +129,7 @@ func TestSendEmailRefusesAMarketingSendWithNoConfiguredPublicBaseURL(t *testing.
 	store := NewStore(e.pool).WithUnsubscribe(stubUnsubscribeLinker{token: testUnsubscribeTok, ok: true})
 
 	_, err := store.SendEmail(
-		e.as(principal.RowScopeAll), anchor, soloSendInput("marketing_email"), stubConsentGate{}, stager)
+		e.as(principal.RowScopeAll), FromActivity(anchor), soloSendInput("marketing_email"), stubConsentGate{}, stager)
 	if err == nil || !strings.Contains(err.Error(), "public base URL is not configured") {
 		t.Fatalf("marketing send with no public base URL → %v, want a refusal naming the missing configuration", err)
 	}
@@ -150,7 +150,7 @@ func TestSendEmailRefusesWhenTheUnsubscribeLinkerFails(t *testing.T) {
 	linkerDown := errors.New("preference store unreachable")
 
 	_, err := e.store(stubUnsubscribeLinker{err: linkerDown}).SendEmail(
-		e.as(principal.RowScopeAll), anchor, soloSendInput("marketing_email"), stubConsentGate{}, stager)
+		e.as(principal.RowScopeAll), FromActivity(anchor), soloSendInput("marketing_email"), stubConsentGate{}, stager)
 	if !errors.Is(err, linkerDown) {
 		t.Fatalf("send with a failing unsubscribe linker → %v, want the linker's own error", err)
 	}
@@ -169,7 +169,7 @@ func TestSendEmailAcceptsAMultiAddresseeSendThatCarriesNoUnsubscribeToken(t *tes
 	linker := stubUnsubscribeLinker{token: testUnsubscribeTok, ok: false}
 
 	if _, err := e.store(linker).SendEmail(
-		e.as(principal.RowScopeAll), anchor, sendInput("transactional"), stubConsentGate{}, stager); err != nil {
+		e.as(principal.RowScopeAll), FromActivity(anchor), sendInput("transactional"), stubConsentGate{}, stager); err != nil {
 		t.Fatalf("multi-addressee transactional send → %v, want acceptance", err)
 	}
 	staged := stager.only(t)
@@ -190,7 +190,7 @@ func TestSendEmailCommitsNoActivityWhenStagingFails(t *testing.T) {
 	stager := &recordingStager{err: errors.New("delivery table unavailable")}
 
 	_, err := e.store(stubUnsubscribeLinker{}).SendEmail(
-		e.as(principal.RowScopeAll), anchor, sendInput("transactional"), stubConsentGate{}, stager)
+		e.as(principal.RowScopeAll), FromActivity(anchor), sendInput("transactional"), stubConsentGate{}, stager)
 	if err == nil {
 		t.Fatal("SendEmail reported success though staging refused")
 	}
@@ -209,7 +209,7 @@ func TestSendEmailRefusesWhenTheMailboxHoldsNoSendGrant(t *testing.T) {
 	stager := &recordingStager{}
 	store := e.store(stubUnsubscribeLinker{}).WithSendAuthority(&stubSendAuthority{capable: false})
 
-	_, err := store.SendEmail(e.as(principal.RowScopeAll), anchor, sendInput("transactional"), stubConsentGate{}, stager)
+	_, err := store.SendEmail(e.as(principal.RowScopeAll), FromActivity(anchor), sendInput("transactional"), stubConsentGate{}, stager)
 	var refusal *MailboxNotSendCapableError
 	if !errors.As(err, &refusal) {
 		t.Fatalf("send with no send-capable mailbox → %v, want a MailboxNotSendCapableError", err)
@@ -232,7 +232,7 @@ func TestSendEmailRefusesAnAnchorOutsideTheCallersRowScope(t *testing.T) {
 	stager := &recordingStager{}
 
 	_, err := e.store(stubUnsubscribeLinker{}).SendEmail(
-		e.as(principal.RowScopeOwn), anchor, sendInput("transactional"), stubConsentGate{}, stager)
+		e.as(principal.RowScopeOwn), FromActivity(anchor), sendInput("transactional"), stubConsentGate{}, stager)
 	if !errors.Is(err, apperrors.ErrNotFound) {
 		t.Fatalf("send anchored to another rep's activity → %v, want ErrNotFound (existence-hiding)", err)
 	}
@@ -255,7 +255,7 @@ func TestSendEmailAnswersAnUnauthorizedCallerBeforeTheWiringGuards(t *testing.T)
 	// Composed with NO delivery machinery: the wiring guard would fire on this
 	// call if it ran first.
 	_, err := e.store(stubUnsubscribeLinker{}).SendEmail(
-		e.as(principal.RowScopeOwn), anchor, sendInput("transactional"), stubConsentGate{}, nil)
+		e.as(principal.RowScopeOwn), FromActivity(anchor), sendInput("transactional"), stubConsentGate{}, nil)
 	if errors.Is(err, errNoDeliveryStager) {
 		t.Fatal("an unauthorized caller learned the send path has no delivery machinery wired")
 	}
@@ -271,7 +271,7 @@ func TestSendEmailAnswersAMissingCreateGrantBeforeTheWiringGuards(t *testing.T) 
 	anchor := e.seedAnchor(t, "", "")
 
 	_, err := e.store(stubUnsubscribeLinker{}).SendEmail(
-		e.readOnly(), anchor, sendInput("transactional"), stubConsentGate{}, nil)
+		e.readOnly(), FromActivity(anchor), sendInput("transactional"), stubConsentGate{}, nil)
 	if errors.Is(err, errNoDeliveryStager) {
 		t.Fatal("a caller with no create grant learned the send path has no delivery machinery wired")
 	}
@@ -288,7 +288,7 @@ func TestSendEmailRefusesAnAuthorizedSendWithNoDeliveryMachinery(t *testing.T) {
 	anchor := e.seedAnchor(t, "", "")
 
 	_, err := e.store(stubUnsubscribeLinker{}).SendEmail(
-		e.as(principal.RowScopeAll), anchor, sendInput("transactional"), stubConsentGate{}, nil)
+		e.as(principal.RowScopeAll), FromActivity(anchor), sendInput("transactional"), stubConsentGate{}, nil)
 	if !errors.Is(err, errNoDeliveryStager) {
 		t.Fatalf("send with no delivery stager → %v, want errNoDeliveryStager", err)
 	}
@@ -309,7 +309,7 @@ func TestSendEmailAnswersTheMailboxRefusalBeforeTheConsentGate(t *testing.T) {
 	gate := &recordingConsentGate{err: apperrors.ErrConsentNotGranted}
 	store := e.store(stubUnsubscribeLinker{}).WithSendAuthority(&stubSendAuthority{capable: false})
 
-	_, err := store.SendEmail(e.as(principal.RowScopeAll), anchor, sendInput("transactional"), gate, stager)
+	_, err := store.SendEmail(e.as(principal.RowScopeAll), FromActivity(anchor), sendInput("transactional"), gate, stager)
 	var refusal *MailboxNotSendCapableError
 	if !errors.As(err, &refusal) {
 		t.Fatalf("send with no send grant → %v, want a MailboxNotSendCapableError", err)
@@ -329,7 +329,7 @@ func TestSendEmailThreadsOntoNothingWhenTheAnchorIsNotMail(t *testing.T) {
 	stager := &recordingStager{}
 
 	sent, err := e.store(stubUnsubscribeLinker{}).SendEmail(
-		e.as(principal.RowScopeAll), anchor, sendInput("transactional"), stubConsentGate{}, stager)
+		e.as(principal.RowScopeAll), FromActivity(anchor), sendInput("transactional"), stubConsentGate{}, stager)
 	if err != nil {
 		t.Fatalf("SendEmail: %v", err)
 	}
@@ -413,7 +413,7 @@ func TestSendEmailRefusesAMessageWhoseAddresseeLineIsEmpty(t *testing.T) {
 			in.Recipients, in.Cc = tc.recipients, tc.cc
 
 			_, err := e.store(stubUnsubscribeLinker{}).SendEmail(
-				e.as(principal.RowScopeAll), anchor, in, stubConsentGate{}, stager)
+				e.as(principal.RowScopeAll), FromActivity(anchor), in, stubConsentGate{}, stager)
 
 			var refusal *NoRecipientsError
 			if !errors.As(err, &refusal) {

--- a/backend/internal/modules/activities/handlers_email.go
+++ b/backend/internal/modules/activities/handlers_email.go
@@ -233,6 +233,9 @@ func sendInputFrom(to []openapi_types.Email, cc *[]openapi_types.Email, subject,
 	}
 }
 
+// SendEmail answers an existing conversation: the activity in the path is the
+// anchor whose threading chain the reply continues and whose record links it
+// inherits. Its account-started twin above shares everything after the origin.
 func (h Handlers) SendEmail(w http.ResponseWriter, r *http.Request, id crmcontracts.Id, _ crmcontracts.SendEmailParams) {
 	var req crmcontracts.SendEmailRequest
 	if !httperr.Decode(w, r, &req) {

--- a/backend/internal/modules/activities/handlers_email.go
+++ b/backend/internal/modules/activities/handlers_email.go
@@ -193,7 +193,7 @@ func (h Handlers) SendEmail(w http.ResponseWriter, r *http.Request, id crmcontra
 	// derived by the store, on the message, where the MCP send tool reaches
 	// it too. It belongs on the mail, not on this response to the API
 	// caller, who is not the recipient and has nothing to unsubscribe from.
-	sent, err := h.store.SendEmail(r.Context(), pathID[ids.ActivityKind](id), SendEmailInput{
+	sent, err := h.store.SendEmail(r.Context(), FromActivity(pathID[ids.ActivityKind](id)), SendEmailInput{
 		Recipients:     recipients,
 		Cc:             cc,
 		Subject:        req.Subject,

--- a/backend/internal/modules/activities/handlers_email.go
+++ b/backend/internal/modules/activities/handlers_email.go
@@ -59,6 +59,14 @@ func (h Handlers) WithSendAuthority(authority SendAuthority) Handlers {
 	return h
 }
 
+// WithRecipientDirectory returns handlers whose account-started sends resolve
+// every typed address to a person the sender can read, so a rep is told which
+// address is not on file instead of mailing someone the record cannot name.
+func (h Handlers) WithRecipientDirectory(dir RecipientDirectory) Handlers {
+	h.store = h.store.WithRecipientDirectory(dir)
+	return h
+}
+
 // WithEmailDrafter returns handlers whose draft endpoint uses the injected
 // compose path. Drafting only proposes text; the send endpoint remains a
 // separate consent-gated operation.
@@ -160,47 +168,83 @@ func DeterministicEmailDraft(topic, intent string) (subject, body string) {
 	return subject, b.String()
 }
 
+// SendAccountEmail starts a NEW conversation from a record rather than
+// answering one. It differs from SendEmail in exactly two places — the origin
+// it builds and the links that origin carries — and shares the send itself,
+// so the consent gate, deliverability and the staging transaction cannot
+// drift between the two surfaces (ADR-0087 §1).
+func (h Handlers) SendAccountEmail(w http.ResponseWriter, r *http.Request, _ crmcontracts.SendAccountEmailParams) {
+	var req crmcontracts.SendAccountEmailRequest
+	if !httperr.Decode(w, r, &req) {
+		return
+	}
+	links := make([]ActivityLinkInput, 0, len(req.Links))
+	for _, l := range req.Links {
+		links = append(links, ActivityLinkInput{EntityType: string(l.EntityType), EntityID: ids.UUID(l.EntityId)})
+	}
+	if len(links) == 0 {
+		// A message filed under nothing is one nobody finds again, which is
+		// the gap this operation exists to close. The contract says minItems,
+		// and nothing in this stack validates a request against the schema.
+		writeStoreErr(w, r, &RequiredFieldError{Field: "links"})
+		return
+	}
+
+	sent, err := h.store.SendEmail(r.Context(), FromAccount(links), sendInputFrom(
+		req.To, req.Cc, req.Subject, req.Body, req.ConsentPurpose, req.DraftRef,
+	), h.consent, h.delivery)
+	if err != nil {
+		writeStoreErr(w, r, err)
+		return
+	}
+	httperr.WriteJSON(w, http.StatusAccepted, sent)
+}
+
+// sendInputFrom builds the send's input from the fields both mail surfaces
+// carry. One spelling, because the merged consent list is a rule rather than
+// a convenience: consent is owed to every addressee, so Recipients is To+Cc
+// and Cc is a subset of it. A second hand-rolled copy would eventually merge
+// one of them differently and mail somebody the gate never asked about.
+func sendInputFrom(to []openapi_types.Email, cc *[]openapi_types.Email, subject, body, purpose string, draftRef *string) SendEmailInput {
+	var ccAddresses []string
+	if cc != nil {
+		ccAddresses = make([]string, 0, len(*cc))
+		for _, addr := range *cc {
+			ccAddresses = append(ccAddresses, string(addr))
+		}
+	}
+	recipients := make([]string, 0, len(to)+len(ccAddresses))
+	for _, addr := range to {
+		recipients = append(recipients, string(addr))
+	}
+	recipients = append(recipients, ccAddresses...)
+
+	ref := ""
+	if draftRef != nil {
+		ref = *draftRef
+	}
+	return SendEmailInput{
+		Recipients:     recipients,
+		Cc:             ccAddresses,
+		Subject:        subject,
+		Body:           body,
+		ConsentPurpose: purpose,
+		DraftRef:       ref,
+	}
+}
+
 func (h Handlers) SendEmail(w http.ResponseWriter, r *http.Request, id crmcontracts.Id, _ crmcontracts.SendEmailParams) {
 	var req crmcontracts.SendEmailRequest
 	if !httperr.Decode(w, r, &req) {
 		return
 	}
-	// Recipients is the merged addressee list the consent gate answers on;
-	// cc travels separately so the delivery can render a To: and a Cc: line
-	// that address each person once.
-	var cc []string
-	if req.Cc != nil {
-		cc = make([]string, 0, len(*req.Cc))
-		for _, addr := range *req.Cc {
-			cc = append(cc, string(addr))
-		}
-	}
-	recipients := make([]string, 0, len(req.To)+len(cc))
-	for _, addr := range req.To {
-		recipients = append(recipients, string(addr))
-	}
-	recipients = append(recipients, cc...)
-
-	// The contract field is nullable, and its absence is the ordinary case:
-	// mail composed without a served draft resolves no learning signal, which
-	// the empty string says to the send path.
-	draftRef := ""
-	if req.DraftRef != nil {
-		draftRef = *req.DraftRef
-	}
-
 	// Deliverability — the RFC 8058 header and the visible footer — is
 	// derived by the store, on the message, where the MCP send tool reaches
 	// it too. It belongs on the mail, not on this response to the API
 	// caller, who is not the recipient and has nothing to unsubscribe from.
-	sent, err := h.store.SendEmail(r.Context(), FromActivity(pathID[ids.ActivityKind](id)), SendEmailInput{
-		Recipients:     recipients,
-		Cc:             cc,
-		Subject:        req.Subject,
-		Body:           req.Body,
-		ConsentPurpose: req.ConsentPurpose,
-		DraftRef:       draftRef,
-	}, h.consent, h.delivery)
+	sent, err := h.store.SendEmail(r.Context(), FromActivity(pathID[ids.ActivityKind](id)), sendInputFrom(
+		req.To, req.Cc, req.Subject, req.Body, req.ConsentPurpose, req.DraftRef,
+	), h.consent, h.delivery)
 	if err != nil {
 		writeStoreErr(w, r, err)
 		return

--- a/backend/internal/modules/activities/handlers_email_test.go
+++ b/backend/internal/modules/activities/handlers_email_test.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package activities
+
+// The wire→input mapping both mail surfaces share. It is worth its own test
+// because the merge it performs is a RULE rather than a convenience: consent
+// is owed to every addressee, so Recipients is To+Cc and Cc is a subset of
+// it. A surface that merged differently would mail somebody the consent gate
+// was never asked about.
+
+import (
+	"testing"
+
+	openapi_types "github.com/oapi-codegen/runtime/types"
+)
+
+func emails(addresses ...string) []openapi_types.Email {
+	out := make([]openapi_types.Email, 0, len(addresses))
+	for _, addr := range addresses {
+		out = append(out, openapi_types.Email(addr))
+	}
+	return out
+}
+
+func TestSendInputMergesEveryAddresseeForTheConsentGate(t *testing.T) {
+	cc := emails("boss@example.test")
+	in := sendInputFrom(emails("buyer@example.test"), &cc, "Pricing", "As discussed.", "transactional", nil)
+
+	// The gate answers on Recipients, so a cc'd person must appear there or
+	// they receive mail nobody asked consent for.
+	want := []string{"buyer@example.test", "boss@example.test"}
+	if len(in.Recipients) != len(want) {
+		t.Fatalf("Recipients = %v, want the merged To+Cc list %v", in.Recipients, want)
+	}
+	for i, addr := range want {
+		if in.Recipients[i] != addr {
+			t.Fatalf("Recipients[%d] = %q, want %q", i, in.Recipients[i], addr)
+		}
+	}
+	if len(in.Cc) != 1 || in.Cc[0] != "boss@example.test" {
+		t.Fatalf("Cc = %v, want the cc list travelling separately so the delivery can render two lines", in.Cc)
+	}
+	// The To: line is what remains once the Cc addresses come out.
+	if to := toRecipients(in.Recipients, in.Cc); len(to) != 1 || to[0] != "buyer@example.test" {
+		t.Fatalf("To: = %v, want the merged list minus the cc'd address", to)
+	}
+}
+
+func TestSendInputWithoutCcCarriesOnlyTheAddressees(t *testing.T) {
+	in := sendInputFrom(emails("buyer@example.test"), nil, "Pricing", "As discussed.", "transactional", nil)
+
+	if len(in.Recipients) != 1 || in.Recipients[0] != "buyer@example.test" {
+		t.Fatalf("Recipients = %v, want just the one addressee", in.Recipients)
+	}
+	if len(in.Cc) != 0 {
+		t.Fatalf("Cc = %v, want empty when the request carried none", in.Cc)
+	}
+}
+
+// The contract field is nullable and its absence is the ordinary case: mail
+// composed without a served draft resolves no learning signal, which the
+// empty string is how the send path is told.
+func TestSendInputResolvesNoDraftWhenNoneWasServed(t *testing.T) {
+	in := sendInputFrom(emails("buyer@example.test"), nil, "Pricing", "Body", "transactional", nil)
+	if in.DraftRef != "" {
+		t.Fatalf("DraftRef = %q, want empty so no voice outcome is inferred", in.DraftRef)
+	}
+
+	ref := "draft-42"
+	withDraft := sendInputFrom(emails("buyer@example.test"), nil, "Pricing", "Body", "transactional", &ref)
+	if withDraft.DraftRef != ref {
+		t.Fatalf("DraftRef = %q, want %q — the send closes the signal that draft opened", withDraft.DraftRef, ref)
+	}
+}

--- a/backend/internal/modules/activities/sendorigin.go
+++ b/backend/internal/modules/activities/sendorigin.go
@@ -20,6 +20,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
 	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
 )
@@ -63,15 +64,24 @@ func (e *NoSendOriginError) Error() string {
 	return "send has no origin: name the activity it replies to, or the records it starts from"
 }
 
-// resolve reads whatever the origin needs BEFORE the guard sequence runs,
-// so an unreadable anchor answers with the row-scope verdict and nothing
-// else. An account origin reads nothing here: its links are probed at
-// insert, inside the transaction, where a link target that disappeared
-// between the two is still caught.
+// resolve reads whatever the origin needs BEFORE the guard sequence runs, so
+// a record the caller cannot see answers with the row-scope verdict and
+// nothing else.
+//
+// BOTH origins probe here, and the account one has to. Deferring its links to
+// the insert would let a caller name a company they cannot see and still reach
+// the consent gate, which answers about the RECIPIENTS — so the refusal they
+// got back would disclose whether strangers had consented, and it would be a
+// 409 where the row-scope answer is 404. The probe at insert stays: it runs
+// inside the staging transaction and still catches a target archived between
+// the two reads.
 func (o SendOrigin) resolve(ctx context.Context, s *Store) ([]ActivityLinkInput, error) {
 	if !o.isReply() {
 		if len(o.links) == 0 {
 			return nil, &NoSendOriginError{}
+		}
+		if err := s.probeLinkTargets(ctx, o.links); err != nil {
+			return nil, err
 		}
 		return o.links, nil
 	}
@@ -80,6 +90,22 @@ func (o SendOrigin) resolve(ctx context.Context, s *Store) ([]ActivityLinkInput,
 		return nil, err
 	}
 	return inheritedLinks(anchor), nil
+}
+
+// probeLinkTargets refuses an account-started send whose named records the
+// caller cannot read, before any later guard can answer about anyone else.
+func (s *Store) probeLinkTargets(ctx context.Context, links []ActivityLinkInput) error {
+	return s.tx(ctx, func(tx pgx.Tx) error {
+		for _, link := range links {
+			if linkColumn(link.EntityType) == "" {
+				return &InvalidLinkTypeError{EntityType: link.EntityType}
+			}
+			if err := auth.EnsureLinkTarget(ctx, tx, link.EntityType, link.EntityID); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
 }
 
 // threading derives the conversation chain this send carries, inside the

--- a/backend/internal/modules/activities/sendorigin.go
+++ b/backend/internal/modules/activities/sendorigin.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package activities
+
+// A send starts either as a reply or as a new conversation, and ADR-0087
+// makes that choice explicit rather than inferring it from a missing anchor.
+// An accidentally absent anchor would otherwise become a new conversation
+// silently, losing a reply's threading with no signal anyone could see.
+//
+// Both origins resolve to the SAME two facts — the threading chain the
+// message carries and the record links its timeline row inherits — and
+// everything after that resolution is one code path, which is what keeps
+// the authorization order, the consent gate, deliverability derivation,
+// identity minting and the single-transaction staging from forking.
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+
+	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
+	"github.com/gradionhq/margince/backend/internal/platform/database/storekit"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// SendOrigin is where one outbound message starts. Exactly one of the two
+// constructors below produces a usable value; the zero value refuses, so a
+// caller that forgets to name an origin cannot accidentally send anything.
+type SendOrigin struct {
+	// anchor is the activity being replied to. Zero on an account-started
+	// send, which is the only way the two are told apart.
+	anchor ids.ActivityID
+	// links are the record links an account-started message is filed under,
+	// supplied explicitly because there is no anchor to inherit them from.
+	// Each is row-scope probed at insert by insertActivityLinks.
+	links []ActivityLinkInput
+}
+
+// FromActivity is the reply origin: the anchor is read, its threading chain
+// is continued, and the new activity inherits its record links.
+func FromActivity(anchor ids.ActivityID) SendOrigin {
+	return SendOrigin{anchor: anchor}
+}
+
+// FromAccount is the account-started origin: no anchor, a fresh thread
+// rooted at this message's own newly minted identity, and record links
+// named by the caller.
+func FromAccount(links []ActivityLinkInput) SendOrigin {
+	return SendOrigin{links: links}
+}
+
+// isReply reports whether this origin continues an existing conversation.
+func (o SendOrigin) isReply() bool { return o.anchor.UUID != ids.UUID{} }
+
+// NoSendOriginError refuses a send whose origin was never named. It is a
+// composition defect on any first-party transport — both handlers construct
+// an origin — so it carries no FieldFault: there is no request field a
+// caller could correct.
+type NoSendOriginError struct{}
+
+func (e *NoSendOriginError) Error() string {
+	return "send has no origin: name the activity it replies to, or the records it starts from"
+}
+
+// resolve reads whatever the origin needs BEFORE the guard sequence runs,
+// so an unreadable anchor answers with the row-scope verdict and nothing
+// else. An account origin reads nothing here: its links are probed at
+// insert, inside the transaction, where a link target that disappeared
+// between the two is still caught.
+func (o SendOrigin) resolve(ctx context.Context, s *Store) ([]ActivityLinkInput, error) {
+	if !o.isReply() {
+		if len(o.links) == 0 {
+			return nil, &NoSendOriginError{}
+		}
+		return o.links, nil
+	}
+	anchor, err := s.GetActivity(ctx, o.anchor, storekit.LiveOnly)
+	if err != nil {
+		return nil, err
+	}
+	return inheritedLinks(anchor), nil
+}
+
+// threading derives the conversation chain this send carries, inside the
+// staging transaction. An account-started message answers nothing, so it
+// roots the thread at its own identity — the same key capture derives when
+// it later reads that root message back out of the mailbox.
+func (o SendOrigin) threading(ctx context.Context, tx pgx.Tx, messageID string) (threading, error) {
+	if !o.isReply() {
+		return threading{threadKey: messageID}, nil
+	}
+	return anchorThreading(ctx, tx, o.anchor, messageID)
+}
+
+// inheritedLinks carries the anchor's own links onto the reply, so the sent
+// message lands on the same records' timelines as the conversation it
+// answers. The links were already visibility-checked as part of reading the
+// anchor, and each one is re-checked at insert.
+func inheritedLinks(anchor crmcontracts.Activity) []ActivityLinkInput {
+	if anchor.Links == nil {
+		return nil
+	}
+	links := make([]ActivityLinkInput, 0, len(*anchor.Links))
+	for _, l := range *anchor.Links {
+		links = append(links, ActivityLinkInput{EntityType: string(l.EntityType), EntityID: ids.UUID(l.EntityId)})
+	}
+	return links
+}

--- a/backend/internal/modules/activities/sendorigin_integration_test.go
+++ b/backend/internal/modules/activities/sendorigin_integration_test.go
@@ -26,6 +26,20 @@ import (
 
 // seedOrganization writes a company as the table owner — the record a rep
 // opens when they press "Write email", which the send path did not create.
+//
+// Written directly rather than through the organization writer, which this
+// module may not import (a module never imports a sibling). What is under
+// test is the SEND, and the only property of this row the send path reads is
+// whether the caller's row scope reaches it — owner_id and workspace_id,
+// both set here exactly as the writer sets them. Nothing downstream reads a
+// field the writer would have derived, so a hand-inserted row and a written
+// one are indistinguishable to everything this file asserts.
+//
+// The moment a case here depends on what the organization writer DOES —
+// its validation, its audit row, its event — the case belongs in a compose
+// integration test with the real wiring, not in a widened fixture.
+// messageidentity_absorb_integration_test.go seeds the same way for the same
+// reason.
 func (e *sendEnv) seedOrganization(t *testing.T) ids.UUID {
 	t.Helper()
 	id := ids.NewV7()

--- a/backend/internal/modules/activities/sendorigin_integration_test.go
+++ b/backend/internal/modules/activities/sendorigin_integration_test.go
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package activities
+
+// An account-started send over a real migrated Postgres (ADR-0087 §1): it
+// reaches the SAME governed path a reply reaches, roots its own thread, and
+// files itself on the records the caller named — each of which is row-scope
+// probed at insert, so a caller cannot link a message onto a record they
+// may not see.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// seedOrganization writes a company as the table owner — the record a rep
+// opens when they press "Write email", which the send path did not create.
+func (e *sendEnv) seedOrganization(t *testing.T) ids.UUID {
+	t.Helper()
+	id := ids.NewV7()
+	if _, err := e.owner.Exec(context.Background(),
+		`INSERT INTO organization (id, workspace_id, display_name, owner_id, source, captured_by)
+		 VALUES ($1, $2, 'Buyer GmbH', $3, 'manual', 'human:x')`,
+		id, e.ws, e.rep); err != nil {
+		t.Fatalf("seeding the organization: %v", err)
+	}
+	return id
+}
+
+func accountOrigin(org ids.UUID) SendOrigin {
+	return FromAccount([]ActivityLinkInput{{EntityType: "organization", EntityID: org}})
+}
+
+// The whole point of the origin: a message with no anchor still sends, and
+// the timeline row it leaves behind is filed under the company it was
+// started from rather than under nothing.
+func TestAnAccountStartedSendFilesItselfOnTheRecordItWasStartedFrom(t *testing.T) {
+	e := setupSend(t)
+	org := e.seedOrganization(t)
+	stager := &recordingStager{}
+
+	sent, err := e.store(stubUnsubscribeLinker{}).SendEmail(
+		e.as(principal.RowScopeAll), accountOrigin(org), sendInput("transactional"), stubConsentGate{}, stager)
+	if err != nil {
+		t.Fatalf("account-started SendEmail: %v", err)
+	}
+
+	if sent.Links == nil || len(*sent.Links) != 1 {
+		t.Fatalf("account-started send wrote links %v, want exactly the organization it was started from", sent.Links)
+	}
+	link := (*sent.Links)[0]
+	if string(link.EntityType) != "organization" || ids.UUID(link.EntityId) != org {
+		t.Fatalf("link = %s/%s, want organization/%s", link.EntityType, link.EntityId, org)
+	}
+	if sent.SourceId == nil {
+		t.Fatal("account-started send carries no source_id; the provider's echo would create a second timeline row")
+	}
+}
+
+// A new conversation has no ancestry to carry, and its root is its own
+// identity — the key capture derives when it reads that root back out of
+// the mailbox, which is what lets a reply to this message join this thread.
+func TestAnAccountStartedSendRootsAFreshThreadAtItsOwnIdentity(t *testing.T) {
+	e := setupSend(t)
+	org := e.seedOrganization(t)
+	stager := &recordingStager{}
+
+	sent, err := e.store(stubUnsubscribeLinker{}).SendEmail(
+		e.as(principal.RowScopeAll), accountOrigin(org), sendInput("transactional"), stubConsentGate{}, stager)
+	if err != nil {
+		t.Fatalf("account-started SendEmail: %v", err)
+	}
+
+	staged := stager.only(t)
+	if staged.InReplyTo != "" || len(staged.References) != 0 {
+		t.Fatalf("a message that answers nothing staged In-Reply-To %q / References %v, want both empty",
+			staged.InReplyTo, staged.References)
+	}
+	if staged.ThreadKey != staged.MessageID {
+		t.Fatalf("thread key = %q, want this message's own identity %q (a root is its own key)",
+			staged.ThreadKey, staged.MessageID)
+	}
+	if got := e.storedThreadKey(t, ids.UUID(sent.Id)); got != staged.MessageID {
+		t.Fatalf("stored thread_key = %q, want %q — a reply-detection join reads the stored key", got, staged.MessageID)
+	}
+}
+
+// The links arrive from the caller rather than from a record the send path
+// already read, so the row-scope probe at insert is the only thing standing
+// between a guessed UUID and a message filed on someone else's company.
+func TestAnAccountStartedSendRefusesALinkTheCallerCannotSee(t *testing.T) {
+	e := setupSend(t)
+	stager := &recordingStager{}
+	// A well-formed id for a company that exists in no workspace this caller
+	// can reach — the shape a guessed or cross-tenant identifier takes.
+	unseen := ids.NewV7()
+
+	_, err := e.store(stubUnsubscribeLinker{}).SendEmail(
+		e.as(principal.RowScopeAll), accountOrigin(unseen), sendInput("transactional"), stubConsentGate{}, stager)
+
+	if !errors.Is(err, apperrors.ErrNotFound) {
+		t.Fatalf("send linked to an invisible record = %v, want ErrNotFound (existence-hiding)", err)
+	}
+	if len(stager.staged) != 0 {
+		t.Fatalf("a refused send staged %d deliveries, want none", len(stager.staged))
+	}
+}
+
+// An origin nobody named is a wiring defect, and it must refuse rather than
+// resolve to "no anchor" — which is exactly the silent new conversation
+// ADR-0087 rejects making the anchor merely optional to avoid.
+func TestASendWithNoOriginRefusesRatherThanStartingAConversation(t *testing.T) {
+	e := setupSend(t)
+	stager := &recordingStager{}
+
+	_, err := e.store(stubUnsubscribeLinker{}).SendEmail(
+		e.as(principal.RowScopeAll), SendOrigin{}, sendInput("transactional"), stubConsentGate{}, stager)
+
+	var noOrigin *NoSendOriginError
+	if !errors.As(err, &noOrigin) {
+		t.Fatalf("send with no origin = %v, want NoSendOriginError", err)
+	}
+	if len(stager.staged) != 0 {
+		t.Fatalf("a send with no origin staged %d deliveries, want none", len(stager.staged))
+	}
+}
+
+// The reply path's guard order is the invariant the refactor most easily
+// breaks: authorization must refuse before the consent gate answers, and
+// that has to hold on the new origin too, or an account-started send
+// becomes a way to learn a stranger's consent state.
+func TestAnAccountStartedSendRefusesOnAuthorizationBeforeConsentAnswers(t *testing.T) {
+	e := setupSend(t)
+	org := e.seedOrganization(t)
+	gate := &countingConsentGate{}
+
+	_, err := e.store(stubUnsubscribeLinker{}).SendEmail(
+		e.readOnly(), accountOrigin(org), sendInput("transactional"), gate, &recordingStager{})
+
+	if !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Fatalf("account-started send without create = %v, want ErrPermissionDenied", err)
+	}
+	if gate.calls != 0 {
+		t.Fatalf("the consent gate answered %d times for a caller who may not send; authorization must refuse first", gate.calls)
+	}
+}
+
+// countingConsentGate grants every request and counts being asked, so a
+// test can assert the gate was never REACHED — a gate that refuses would
+// prove nothing about ordering, since the send fails either way.
+type countingConsentGate struct {
+	stubConsentGate
+	calls int
+}
+
+func (g *countingConsentGate) RequireGrantedForEmails(context.Context, []string, string) error {
+	g.calls++
+	return nil
+}

--- a/backend/internal/modules/activities/sendorigin_integration_test.go
+++ b/backend/internal/modules/activities/sendorigin_integration_test.go
@@ -137,6 +137,30 @@ func TestAnAccountStartedSendRefusesALinkTheCallerCannotSee(t *testing.T) {
 	}
 }
 
+// A link the caller cannot see must refuse BEFORE the consent gate answers.
+// The gate answers about the RECIPIENTS, so reaching it would tell a caller
+// who named a company they cannot see whether strangers had consented — and
+// would answer 409 where the row-scope verdict is 404.
+func TestAnUnreadableLinkRefusesBeforeTheConsentGateAnswers(t *testing.T) {
+	e := setupSend(t)
+	stager := &recordingStager{}
+	gate := &countingConsentGate{}
+	unseen := ids.NewV7()
+
+	_, err := e.accountStore().SendEmail(
+		e.as(principal.RowScopeAll), accountOrigin(unseen), sendInput("transactional"), gate, stager)
+
+	if !errors.Is(err, apperrors.ErrNotFound) {
+		t.Fatalf("send linked to an invisible record = %v, want ErrNotFound (existence-hiding)", err)
+	}
+	if gate.calls != 0 {
+		t.Fatalf("the consent gate answered %d times for a caller who named a record they cannot see; that answer is about the recipients, not the link", gate.calls)
+	}
+	if len(stager.staged) != 0 {
+		t.Fatalf("a refused send staged %d deliveries, want none", len(stager.staged))
+	}
+}
+
 // An origin nobody named is a wiring defect, and it must refuse rather than
 // resolve to "no anchor" — which is exactly the silent new conversation
 // ADR-0087 rejects making the anchor merely optional to avoid.

--- a/backend/internal/modules/activities/sendorigin_integration_test.go
+++ b/backend/internal/modules/activities/sendorigin_integration_test.go
@@ -243,6 +243,39 @@ func TestAnAccountStartedSendNamesTheAddressThatIsNotOnFile(t *testing.T) {
 	}
 }
 
+// A cc'd address is an addressee, and consent is owed to everyone who
+// receives the message however they were addressed — so the guard must refuse
+// an unresolvable Cc exactly as it refuses an unresolvable To.
+//
+// It is checked because Recipients is the MERGED To+Cc list, not because the
+// guard looks at Cc separately. That merge is the load-bearing part, and this
+// test names the cc'd address specifically so a future change that stopped
+// merging would fail here rather than quietly ship a cc-shaped hole.
+func TestAnAccountStartedSendRefusesAnUnresolvableCcAddress(t *testing.T) {
+	e := setupSend(t)
+	org := e.seedOrganization(t)
+	stager := &recordingStager{}
+	// The To: address resolves; the address that appears ONLY in Cc does not.
+	directory := partialRecipients{known: map[string]bool{"buyer@example.test": true}}
+	in := sendInput("transactional")
+	in.Recipients = []string{"buyer@example.test", "assistant@example.test"}
+	in.Cc = []string{"assistant@example.test"}
+
+	_, err := e.store(stubUnsubscribeLinker{}).WithRecipientDirectory(directory).SendEmail(
+		e.as(principal.RowScopeAll), accountOrigin(org), in, stubConsentGate{}, stager)
+
+	var unresolved *UnresolvedRecipientError
+	if !errors.As(err, &unresolved) {
+		t.Fatalf("send cc'ing an address on no contact = %v, want UnresolvedRecipientError", err)
+	}
+	if unresolved.Address != "assistant@example.test" {
+		t.Fatalf("refusal names %q, want the cc'd address that failed to resolve", unresolved.Address)
+	}
+	if len(stager.staged) != 0 {
+		t.Fatalf("a refused send staged %d deliveries, want none", len(stager.staged))
+	}
+}
+
 // A REPLY's addressees come from a conversation the workspace already
 // captured, so refusing them would block answering mail the product itself
 // put on the timeline. The directory must not be consulted there at all.

--- a/backend/internal/modules/activities/sendorigin_integration_test.go
+++ b/backend/internal/modules/activities/sendorigin_integration_test.go
@@ -14,7 +14,10 @@ package activities
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
+
+	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
 	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
@@ -39,6 +42,26 @@ func accountOrigin(org ids.UUID) SendOrigin {
 	return FromAccount([]ActivityLinkInput{{EntityType: "organization", EntityID: org}})
 }
 
+// knownRecipients answers that every address sendInput carries is on file —
+// the ordinary case, so a test about threading or links is not also a test
+// about address resolution.
+type knownRecipients struct{}
+
+func (knownRecipients) VisibleAddresses(_ context.Context, _ pgx.Tx, addresses []string) (map[string]bool, error) {
+	visible := make(map[string]bool, len(addresses))
+	for _, addr := range addresses {
+		visible[strings.ToLower(strings.TrimSpace(addr))] = true
+	}
+	return visible, nil
+}
+
+// accountStore is the send path wired the way compose wires it for an
+// account-started send: the recipient directory is not optional there, so a
+// test that omitted it would be testing a surface no deployment runs.
+func (e *sendEnv) accountStore() *Store {
+	return e.store(stubUnsubscribeLinker{}).WithRecipientDirectory(knownRecipients{})
+}
+
 // The whole point of the origin: a message with no anchor still sends, and
 // the timeline row it leaves behind is filed under the company it was
 // started from rather than under nothing.
@@ -47,7 +70,7 @@ func TestAnAccountStartedSendFilesItselfOnTheRecordItWasStartedFrom(t *testing.T
 	org := e.seedOrganization(t)
 	stager := &recordingStager{}
 
-	sent, err := e.store(stubUnsubscribeLinker{}).SendEmail(
+	sent, err := e.accountStore().SendEmail(
 		e.as(principal.RowScopeAll), accountOrigin(org), sendInput("transactional"), stubConsentGate{}, stager)
 	if err != nil {
 		t.Fatalf("account-started SendEmail: %v", err)
@@ -73,7 +96,7 @@ func TestAnAccountStartedSendRootsAFreshThreadAtItsOwnIdentity(t *testing.T) {
 	org := e.seedOrganization(t)
 	stager := &recordingStager{}
 
-	sent, err := e.store(stubUnsubscribeLinker{}).SendEmail(
+	sent, err := e.accountStore().SendEmail(
 		e.as(principal.RowScopeAll), accountOrigin(org), sendInput("transactional"), stubConsentGate{}, stager)
 	if err != nil {
 		t.Fatalf("account-started SendEmail: %v", err)
@@ -103,7 +126,7 @@ func TestAnAccountStartedSendRefusesALinkTheCallerCannotSee(t *testing.T) {
 	// can reach — the shape a guessed or cross-tenant identifier takes.
 	unseen := ids.NewV7()
 
-	_, err := e.store(stubUnsubscribeLinker{}).SendEmail(
+	_, err := e.accountStore().SendEmail(
 		e.as(principal.RowScopeAll), accountOrigin(unseen), sendInput("transactional"), stubConsentGate{}, stager)
 
 	if !errors.Is(err, apperrors.ErrNotFound) {
@@ -142,7 +165,7 @@ func TestAnAccountStartedSendRefusesOnAuthorizationBeforeConsentAnswers(t *testi
 	org := e.seedOrganization(t)
 	gate := &countingConsentGate{}
 
-	_, err := e.store(stubUnsubscribeLinker{}).SendEmail(
+	_, err := e.accountStore().SendEmail(
 		e.readOnly(), accountOrigin(org), sendInput("transactional"), gate, &recordingStager{})
 
 	if !errors.Is(err, apperrors.ErrPermissionDenied) {
@@ -151,6 +174,101 @@ func TestAnAccountStartedSendRefusesOnAuthorizationBeforeConsentAnswers(t *testi
 	if gate.calls != 0 {
 		t.Fatalf("the consent gate answered %d times for a caller who may not send; authorization must refuse first", gate.calls)
 	}
+}
+
+// An account-started send names its own addressees, so a typed address that
+// belongs to nobody on file is the caller's to fix — and the refusal has to
+// say WHICH address, or the composer cannot offer the fix.
+func TestAnAccountStartedSendNamesTheAddressThatIsNotOnFile(t *testing.T) {
+	e := setupSend(t)
+	org := e.seedOrganization(t)
+	stager := &recordingStager{}
+	// buyer@example.test resolves; boss@example.test does not.
+	directory := partialRecipients{known: map[string]bool{"buyer@example.test": true}}
+
+	_, err := e.store(stubUnsubscribeLinker{}).WithRecipientDirectory(directory).SendEmail(
+		e.as(principal.RowScopeAll), accountOrigin(org), sendInput("transactional"), stubConsentGate{}, stager)
+
+	var unresolved *UnresolvedRecipientError
+	if !errors.As(err, &unresolved) {
+		t.Fatalf("send to an address on no contact = %v, want UnresolvedRecipientError", err)
+	}
+	if unresolved.Address != "boss@example.test" {
+		t.Fatalf("refusal names %q, want the address that failed to resolve", unresolved.Address)
+	}
+	field, code, _ := unresolved.FieldFault()
+	if field != "to" || code != "recipient_not_on_file" {
+		t.Fatalf("FieldFault() = (%q, %q), want (\"to\", \"recipient_not_on_file\")", field, code)
+	}
+	if len(stager.staged) != 0 {
+		t.Fatalf("a refused send staged %d deliveries, want none", len(stager.staged))
+	}
+}
+
+// A REPLY's addressees come from a conversation the workspace already
+// captured, so refusing them would block answering mail the product itself
+// put on the timeline. The directory must not be consulted there at all.
+func TestAReplyDoesNotRequireItsAddressesToBeOnFile(t *testing.T) {
+	e := setupSend(t)
+	anchor := e.seedAnchor(t, "", "")
+	directory := &countingRecipients{}
+
+	if _, err := e.store(stubUnsubscribeLinker{}).WithRecipientDirectory(directory).SendEmail(
+		e.as(principal.RowScopeAll), FromActivity(anchor), sendInput("transactional"),
+		stubConsentGate{}, &recordingStager{}); err != nil {
+		t.Fatalf("reply SendEmail: %v", err)
+	}
+
+	if directory.calls != 0 {
+		t.Fatalf("the reply path resolved addresses %d times; a captured conversation's addressees are evidence, not a lookup", directory.calls)
+	}
+}
+
+// A surface wired without a directory must refuse an account-started send
+// rather than mail an address it never resolved — the same fail-closed rule
+// the consent gate and the delivery stager follow.
+func TestAnAccountStartedSendRefusesWithNoRecipientDirectoryWired(t *testing.T) {
+	e := setupSend(t)
+	org := e.seedOrganization(t)
+	stager := &recordingStager{}
+
+	_, err := e.store(stubUnsubscribeLinker{}).SendEmail(
+		e.as(principal.RowScopeAll), accountOrigin(org), sendInput("transactional"), stubConsentGate{}, stager)
+
+	var unwired *NoRecipientDirectoryError
+	if !errors.As(err, &unwired) {
+		t.Fatalf("account-started send with no directory = %v, want NoRecipientDirectoryError", err)
+	}
+	if len(stager.staged) != 0 {
+		t.Fatalf("a refused send staged %d deliveries, want none", len(stager.staged))
+	}
+}
+
+// partialRecipients knows some addresses and not others — the state a
+// composer is in when a rep types an address nobody has filed yet.
+type partialRecipients struct{ known map[string]bool }
+
+func (d partialRecipients) VisibleAddresses(_ context.Context, _ pgx.Tx, addresses []string) (map[string]bool, error) {
+	visible := make(map[string]bool, len(addresses))
+	for _, addr := range addresses {
+		normalized := strings.ToLower(strings.TrimSpace(addr))
+		if d.known[normalized] {
+			visible[normalized] = true
+		}
+	}
+	return visible, nil
+}
+
+// countingRecipients resolves everything and counts being asked, so a test
+// can assert the reply path never REACHED it.
+type countingRecipients struct {
+	knownRecipients
+	calls int
+}
+
+func (d *countingRecipients) VisibleAddresses(ctx context.Context, tx pgx.Tx, addresses []string) (map[string]bool, error) {
+	d.calls++
+	return d.knownRecipients.VisibleAddresses(ctx, tx, addresses)
 }
 
 // countingConsentGate grants every request and counts being asked, so a

--- a/backend/internal/modules/activities/sendrecipient.go
+++ b/backend/internal/modules/activities/sendrecipient.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package activities
+
+// An account-started send names its own addressees, which a reply never
+// does — a reply inherits the conversation it answers. So this is the one
+// outbound path where a caller can type an address that belongs to nobody
+// on file, and ADR-0087 §2 refuses that rather than accepting it.
+//
+// The refusal is a FIELD fault naming the address, not a generic validation
+// error, because the composer's job at that moment is to offer the fix:
+// attach this address to a contact, or pick a different recipient. A caller
+// who cannot see which address was the problem cannot act on either.
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// RecipientDirectory answers whether an address belongs to a person the
+// caller may read. The people capability implements it and compose injects
+// it, because a module never imports a sibling.
+//
+// It answers about VISIBILITY, not existence: an address on a person the
+// caller's row scope excludes is answered the same as one on nobody at all.
+// Telling the two apart would leak the existence of a record through a
+// composer field, which is the disclosure the row-scope gate exists to
+// prevent everywhere else.
+type RecipientDirectory interface {
+	// VisibleAddresses returns the subset of addresses that belong to a
+	// person this caller can read, normalized lowercase.
+	VisibleAddresses(ctx context.Context, tx pgx.Tx, addresses []string) (map[string]bool, error)
+}
+
+// WithRecipientDirectory returns a store whose account-started sends resolve
+// their addressees. A store without one refuses an account-started send
+// rather than mailing an address nobody is accountable for.
+func (s *Store) WithRecipientDirectory(dir RecipientDirectory) *Store {
+	clone := *s
+	clone.recipients = dir
+	return &clone
+}
+
+// UnresolvedRecipientError refuses an account-started send that names an
+// address belonging to no person the sender can see.
+//
+// It carries ONE address even when several failed, because the composer
+// fixes them one at a time and the first unresolved address is the one the
+// rep is looking at. The count travels beside it so the message can say
+// there are more without listing addresses the caller may not be entitled
+// to reason about.
+type UnresolvedRecipientError struct {
+	Address string
+	More    int
+}
+
+func (e *UnresolvedRecipientError) Error() string {
+	msg := "no contact you can see has the address " + e.Address +
+		" — add it to a person's record, or pick a different recipient"
+	switch {
+	case e.More == 1:
+		msg += " (and 1 other address like it)"
+	case e.More > 1:
+		msg += " (and " + strconv.Itoa(e.More) + " other addresses like it)"
+	}
+	return msg
+}
+
+// FieldFault names the address the caller must correct.
+func (e *UnresolvedRecipientError) FieldFault() (field, code, message string) {
+	return "to", "recipient_not_on_file", e.Error()
+}
+
+// NoRecipientDirectoryError refuses an account-started send on a surface
+// wired without address resolution. Like errNoDeliveryStager it is a
+// composition defect rather than a client-correctable condition, so it
+// carries no FieldFault and must surface as the 500 it is — a caller told
+// to fix their address list would be told something untrue.
+type NoRecipientDirectoryError struct{}
+
+func (e *NoRecipientDirectoryError) Error() string {
+	return "activities: account-started send has no recipient directory wired"
+}
+
+// resolveRecipients refuses before anything is staged when an addressee
+// belongs to nobody the sender can read.
+//
+// A REPLY skips this entirely, and that is the decision rather than an
+// oversight: its addressees come from a conversation the workspace already
+// captured, so an address on it is evidence of correspondence that happened
+// whether or not anyone ever filed a contact for it. Refusing there would
+// block answering mail the product itself put on the timeline.
+func (s *Store) resolveRecipients(ctx context.Context, tx pgx.Tx, origin SendOrigin, recipients []string) error {
+	if origin.isReply() {
+		return nil
+	}
+	if s.recipients == nil {
+		return &NoRecipientDirectoryError{}
+	}
+	visible, err := s.recipients.VisibleAddresses(ctx, tx, recipients)
+	if err != nil {
+		return err
+	}
+	var first string
+	unresolved := 0
+	for _, addr := range recipients {
+		if normalized := strings.ToLower(strings.TrimSpace(addr)); !visible[normalized] {
+			if first == "" {
+				first = addr
+			}
+			unresolved++
+		}
+	}
+	if unresolved > 0 {
+		return &UnresolvedRecipientError{Address: first, More: unresolved - 1}
+	}
+	return nil
+}

--- a/backend/internal/modules/activities/store.go
+++ b/backend/internal/modules/activities/store.go
@@ -51,6 +51,11 @@ type Store struct {
 	// directly, and a signal closed on one transport only is a corpus built
 	// from half the sends.
 	draftOutcome DraftOutcomeRecorder
+	// recipients resolves an account-started send's addressees to people the
+	// sender may read; nil fails that path CLOSED
+	// (WithRecipientDirectory wires it). A reply never consults it — its
+	// addressees come from the captured conversation it answers.
+	recipients RecipientDirectory
 }
 
 func NewStore(pool *pgxpool.Pool) *Store {

--- a/backend/internal/modules/people/visibleaddresses.go
+++ b/backend/internal/modules/people/visibleaddresses.go
@@ -16,6 +16,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
 )
 
 // VisibleAddresses returns the subset of addresses that belong to a live
@@ -32,6 +33,14 @@ import (
 // lowercased (its person_email_norm CHECK), and a caller types whatever
 // case they like.
 func VisibleAddresses(ctx context.Context, tx pgx.Tx, addresses []string) (map[string]bool, error) {
+	// Both halves of the gate, in the usual order. The row scope below answers
+	// WHICH contacts this caller may read; the object grant answers whether
+	// they may read contacts at all. A seat with no person grant whose row
+	// scope happens to match would otherwise confirm that an address is on
+	// somebody's record — which is a read of that record.
+	if err := auth.Require(ctx, "person", principal.ActionRead); err != nil {
+		return nil, err
+	}
 	normalized := make([]string, 0, len(addresses))
 	for _, addr := range addresses {
 		if trimmed := strings.ToLower(strings.TrimSpace(addr)); trimmed != "" {

--- a/backend/internal/modules/people/visibleaddresses.go
+++ b/backend/internal/modules/people/visibleaddresses.go
@@ -51,7 +51,7 @@ func VisibleAddresses(ctx context.Context, tx pgx.Tx, addresses []string) (map[s
 		return nil, err
 	}
 	if visible == "" {
-		visible = "true"
+		visible = sqlAlwaysVisible
 	}
 	rows, err := tx.Query(ctx, fmt.Sprintf(`
 		SELECT DISTINCT pe.email

--- a/backend/internal/modules/people/visibleaddresses.go
+++ b/backend/internal/modules/people/visibleaddresses.go
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package people
+
+// Which of these addresses belongs to a contact the caller may read — the
+// question an account-started send asks before it will mail a typed address
+// (ADR-0087 §2). The send path owns the refusal; this owns the lookup,
+// because person_email is this module's table and no sibling reads it.
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/platform/auth"
+)
+
+// VisibleAddresses returns the subset of addresses that belong to a live
+// person this caller can read, keyed lowercase.
+//
+// Row scope is applied to the PERSON, not to the address: an address is
+// visible exactly when the contact carrying it is. An out-of-scope person's
+// address is therefore absent from the result and indistinguishable from an
+// address nobody has — which is the existence-hiding answer the row-scope
+// gate gives everywhere else, and the reason the caller learns "not on file"
+// rather than "not yours".
+//
+// Addresses are matched lowercased because person_email stores them
+// lowercased (its person_email_norm CHECK), and a caller types whatever
+// case they like.
+func VisibleAddresses(ctx context.Context, tx pgx.Tx, addresses []string) (map[string]bool, error) {
+	normalized := make([]string, 0, len(addresses))
+	for _, addr := range addresses {
+		if trimmed := strings.ToLower(strings.TrimSpace(addr)); trimmed != "" {
+			normalized = append(normalized, trimmed)
+		}
+	}
+	found := make(map[string]bool, len(normalized))
+	if len(normalized) == 0 {
+		return found, nil
+	}
+
+	var args []any
+	arg := func(v any) int { args = append(args, v); return len(args) }
+	addressPos := arg(normalized)
+	visible, err := auth.ScopeClauseFor(ctx, "person", "p", arg)
+	if err != nil {
+		return nil, err
+	}
+	if visible == "" {
+		visible = "true"
+	}
+	rows, err := tx.Query(ctx, fmt.Sprintf(`
+		SELECT DISTINCT pe.email
+		  FROM person_email pe
+		  JOIN person p ON p.id = pe.person_id AND p.archived_at IS NULL
+		 WHERE pe.email = ANY($%d::text[])
+		   AND pe.archived_at IS NULL
+		   AND (%s)`, addressPos, visible), args...)
+	if err != nil {
+		return nil, fmt.Errorf("people: resolving recipient addresses: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var email string
+		if err := rows.Scan(&email); err != nil {
+			return nil, fmt.Errorf("people: resolving recipient addresses: %w", err)
+		}
+		found[email] = true
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("people: resolving recipient addresses: %w", err)
+	}
+	return found, nil
+}

--- a/backend/internal/modules/people/visibleaddresses_integration_test.go
+++ b/backend/internal/modules/people/visibleaddresses_integration_test.go
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+//go:build integration
+
+package people
+
+// Resolving an address to a contact is a READ of that contact, so it carries
+// both halves of the gate: the object grant answers whether this caller may
+// read people at all, and the row scope answers which ones. An account-started
+// send asks this question about addresses a human typed, which is why the
+// object half matters — a seat with no person grant must not be able to
+// confirm that an address is on somebody's record.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/gradionhq/margince/backend/internal/shared/apperrors"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/principal"
+)
+
+// seedAddress puts one address on one person, the way an import or a capture
+// leaves it behind.
+func (e *privacyEnv) seedAddress(t *testing.T, person ids.PersonID, email string) {
+	t.Helper()
+	ctx := e.as(e.owner, principal.RowScopeAll)
+	if err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `
+			INSERT INTO person_email (workspace_id, person_id, email, source, captured_by)
+			VALUES ($1, $2, $3, 'gmail:seed', 'connector:gmail')`,
+			e.ws, person, email)
+		return err
+	}); err != nil {
+		t.Fatalf("seeding the address: %v", err)
+	}
+}
+
+// withoutPersonGrant binds a caller whose row scope reaches everything and
+// whose object grants do NOT include person — the seat that would otherwise
+// learn an address is on file without being allowed to read contacts.
+func (e *privacyEnv) withoutPersonGrant() context.Context {
+	ctx := principal.WithWorkspaceID(context.Background(), e.ws)
+	ctx = principal.WithCorrelationID(ctx, ids.NewV7())
+	return principal.WithActor(ctx, principal.Principal{
+		Type: principal.PrincipalHuman, ID: "human:" + e.owner.String(), UserID: e.owner,
+		Permissions: principal.Permissions{
+			RoleKeys: []string{"rep"},
+			Objects: map[string]principal.ObjectGrant{
+				"organization": {Read: true},
+			},
+			RowScope: principal.RowScopeAll,
+		},
+	})
+}
+
+func TestVisibleAddressesResolvesAnAddressOnAContactTheCallerCanRead(t *testing.T) {
+	e := setupCapturePrivacy(t)
+	person := e.capturePerson(t, "workspace")
+	e.seedAddress(t, person, "buyer@resolve.test")
+
+	ctx := e.as(e.owner, principal.RowScopeAll)
+	var found map[string]bool
+	if err := e.store.tx(ctx, func(tx pgx.Tx) (err error) {
+		found, err = VisibleAddresses(ctx, tx, []string{"Buyer@Resolve.Test"})
+		return err
+	}); err != nil {
+		t.Fatalf("VisibleAddresses: %v", err)
+	}
+
+	// Asked in mixed case on purpose: person_email stores lowercase, and a
+	// human types whatever they like.
+	if !found["buyer@resolve.test"] {
+		t.Fatalf("address not resolved (%v); a contact the caller can read carries it", found)
+	}
+}
+
+func TestVisibleAddressesRefusesACallerWithNoPersonGrant(t *testing.T) {
+	e := setupCapturePrivacy(t)
+	person := e.capturePerson(t, "workspace")
+	e.seedAddress(t, person, "buyer@resolve.test")
+
+	ctx := e.withoutPersonGrant()
+	err := e.store.tx(ctx, func(tx pgx.Tx) error {
+		_, resolveErr := VisibleAddresses(ctx, tx, []string{"buyer@resolve.test"})
+		return resolveErr
+	})
+
+	if !errors.Is(err, apperrors.ErrPermissionDenied) {
+		t.Fatalf("resolving addresses without the person grant = %v, want ErrPermissionDenied", err)
+	}
+}
+
+// An address on a contact this caller's row scope excludes answers exactly
+// like an address nobody has. Telling the two apart would disclose the
+// existence of a record through a composer field.
+func TestVisibleAddressesHidesAnAddressOnAnUnreachableContact(t *testing.T) {
+	e := setupCapturePrivacy(t)
+	// Owner-visible and owned by e.owner, so capture privacy hides it from
+	// everyone else — even the admin, who is not on the owner's team.
+	person := e.capturePerson(t, "owner")
+	e.seedAddress(t, person, "private@resolve.test")
+
+	ctx := e.as(e.admin, principal.RowScopeAll)
+	var found map[string]bool
+	if err := e.store.tx(ctx, func(tx pgx.Tx) (err error) {
+		found, err = VisibleAddresses(ctx, tx, []string{"private@resolve.test"})
+		return err
+	}); err != nil {
+		t.Fatalf("VisibleAddresses: %v", err)
+	}
+
+	if found["private@resolve.test"] {
+		t.Fatal("an owner-private contact's address resolved for a caller who cannot read that contact")
+	}
+}

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -1734,6 +1734,47 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/emails": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Start a new email conversation from a record — 🟡 confirm-first / gated.
+         * @description The account-started twin of `send_email` (ADR-0087/A132). "Write email" from a company,
+         *     a person or a deal is a NEW conversation: there is no prior message to anchor to, and
+         *     the product refuses to fabricate a placeholder activity to obtain one — that would put a
+         *     timeline entry on the record for a message nobody has sent yet.
+         *
+         *     This is the SAME send. Authorization order, the default-deny per-purpose consent gate,
+         *     deliverability derivation, message-identity minting and the single-transaction staging of
+         *     activity + delivery + job are the ones `send_email` runs; only the ORIGIN differs. The
+         *     message roots a fresh thread at its own newly minted identity, and `links` says which
+         *     records it belongs to instead of inheriting them from an anchor.
+         *
+         *     Two refusals are specific to naming your own addressees and your own links:
+         *
+         *     - every address in `to`/`cc` must belong to a person the sender can READ, or the send is
+         *       refused 422 `recipient_not_on_file` naming the address — a fix the composer can offer
+         *       ("attach this address to a contact"), rather than mail to a string nobody is
+         *       accountable for;
+         *     - every entry in `links` is row-scope probed, so a record the caller cannot see is
+         *       refused 404 exactly as reading it directly would be.
+         *
+         *     Tier matches the operation it mirrors: an agent presenting a passport is confirm-first
+         *     and stages for approval; a human's own call is their confirmation (ADR-0055).
+         */
+        post: operations["sendAccountEmail"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/activities/{id}/send-message": {
         parameters: {
             query?: never;
@@ -9425,6 +9466,16 @@ export interface components {
             entity_id: string;
         };
         /**
+         * @description One record an activity is filed under, as a caller supplies it. The read shape
+         *     (ActivityLink) carries the ids the server assigned; this carries only the target.
+         */
+        ActivityLinkInput: {
+            /** @enum {string} */
+            entity_type: "person" | "organization" | "deal" | "lead" | "project";
+            /** Format: uuid */
+            entity_id: string;
+        };
+        /**
          * @description A polymorphic timeline item. Mirrors the `activity` table + `activity_link`.
          *     **Per-kind field constraints** (enforced server-side to match the DB `activity_task_fields`
          *     CHECK; the OpenAPI cannot express these conditionally): `due_at`/`assignee_id`/`is_done`/
@@ -9722,6 +9773,36 @@ export interface components {
              *     `granted` `person_consent` for THIS purpose (default-deny per purpose, A22/ADR-0011).
              */
             consent_purpose: string;
+        };
+        /**
+         * @description One account-started send. It is SendEmailRequest plus the `links` an anchor would
+         *     otherwise have supplied — the records this new conversation belongs to.
+         */
+        SendAccountEmailRequest: {
+            subject: string;
+            /** @description The (possibly edited) final body that is sent. */
+            body: string;
+            to: string[];
+            cc?: string[];
+            /**
+             * @description Opaque reference returned by the drafting operation, exactly as on `send_email`.
+             *     Omit for independently composed mail.
+             */
+            draft_ref?: string | null;
+            /**
+             * @description The consent purpose this send falls under. Default-deny per purpose (A22/ADR-0011):
+             *     suppressed 409 `consent_not_granted` unless every recipient has an active `granted`
+             *     `person_consent` for THIS purpose.
+             */
+            consent_purpose: string;
+            /**
+             * @description The records this conversation is filed under — the company it was started from, and
+             *     optionally the person and deal it concerns. At least one is required: a message
+             *     belonging to no record is one nobody will find again, which is the gap this
+             *     operation exists to close. Each target is row-scope probed, so an id the caller
+             *     cannot see is refused 404.
+             */
+            links: components["schemas"]["ActivityLinkInput"][];
         };
         /**
          * @description One channel reply. It carries no subject and no addressee list, and that absence is the
@@ -16834,6 +16915,86 @@ export interface operations {
             };
             /** @description Approval token missing for a 🟡 send, or RBAC denied. */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["Problem"];
+                };
+            };
+            /** @description Consent not granted for the send purpose (`code: consent_not_granted`) — suppressed. */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["Problem"];
+                };
+            };
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    sendAccountEmail: {
+        parameters: {
+            query?: never;
+            header?: {
+                /**
+                 * @description Client-supplied key making a mutation safe to retry — an update exactly as much as a
+                 *     create (API-CC-6). **Scope:** the key is unique within
+                 *     `(workspace_id, principal, request-path)` and retained **24h**; a replay within that window
+                 *     returns the original status + body. Reusing the same key with a *different* request body
+                 *     returns `409 code: idempotency_key_conflict` (never a silent replay of mismatched intent).
+                 *     **On an update behind `If-Match`** the key is what separates "not applied" from "applied,
+                 *     answer lost": without it the blind retry answers `409 version_skew`, because the first
+                 *     attempt already bumped the version.
+                 *     **Precedence vs natural keys:** on `logActivity`/`createLead`, the Idempotency-Key (transport
+                 *     retry-safety) is checked first; if absent, the `(source_system, source_id)` natural key
+                 *     (data-model dedupe) governs. The two never both create a row. **Declaring this parameter is
+                 *     what makes an operation replay-safe** — an operation that omits it ignores the header rather
+                 *     than half-honouring it, so read this contract, not the client, to know which calls are safe
+                 *     to retry blind.
+                 */
+                "Idempotency-Key"?: components["parameters"]["IdempotencyKey"];
+                /**
+                 * @description A signed, single-use approval token (see schema `ApprovalToken`) minted by
+                 *     POST /approvals/{id}/approve, authorizing exactly one 🟡 confirm-first operation. It is a
+                 *     compact JWS whose claims **bind** the token to a specific approval, effect, tenant and
+                 *     principal — it is NOT a bare opaque string (ADR-0036). The server rejects a token that is
+                 *     expired, already consumed, or whose `diff_hash`/`workspace_id`/`passport_id`/`tool` does not
+                 *     match the operation being executed (`403 code: approval_token_invalid`). Required when an
+                 *     AGENT principal invokes a 🟡 operation; a human's direct call is itself the approval.
+                 */
+                "X-Approval-Token"?: components["parameters"]["ApprovalToken"];
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SendAccountEmailRequest"];
+            };
+        };
+        responses: {
+            /** @description Accepted for send (queued); the resulting outbound activity is logged. */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Activity"];
+                };
+            };
+            /** @description Approval token missing for a 🟡 send, or RBAC denied. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["Problem"];
+                };
+            };
+            /** @description A named link target does not exist, or is outside the caller's row scope. */
+            404: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -9787,6 +9787,10 @@ export interface components {
             subject: string;
             /** @description The (possibly edited) final body that is sent. */
             body: string;
+            /**
+             * @description At least one addressee. A send whose To: line is empty is refused 422 before
+             *     anything is staged — `cc` alone does not make a message addressed to anyone.
+             */
             to: string[];
             cc?: string[];
             /**

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -1765,8 +1765,13 @@ export interface paths {
          *     - every entry in `links` is row-scope probed, so a record the caller cannot see is
          *       refused 404 exactly as reading it directly would be.
          *
-         *     Tier matches the operation it mirrors: an agent presenting a passport is confirm-first
-         *     and stages for approval; a human's own call is their confirmation (ADR-0055).
+         *     HUMAN-ONLY for now, and deliberately so. ADR-0087 §6 gives the agent surface this
+         *     operation at the same 🟡 tier as the reply, but a 🟡 agent call STAGES for approval, and a
+         *     staged row is only releasable when its kind maps onto a grantable object in approvals.
+         *     Registering the verb without that mapping would advertise a tool whose every call clears
+         *     admission and is then refused at staging — a governed verb no agent can reach and no human
+         *     can release. The composer surface ships first; the agent tool follows with its
+         *     decision-grant mapping, tool spec and staging test as one change.
          */
         post: operations["sendAccountEmail"];
         delete?: never;
@@ -16955,16 +16960,6 @@ export interface operations {
                  *     to retry blind.
                  */
                 "Idempotency-Key"?: components["parameters"]["IdempotencyKey"];
-                /**
-                 * @description A signed, single-use approval token (see schema `ApprovalToken`) minted by
-                 *     POST /approvals/{id}/approve, authorizing exactly one 🟡 confirm-first operation. It is a
-                 *     compact JWS whose claims **bind** the token to a specific approval, effect, tenant and
-                 *     principal — it is NOT a bare opaque string (ADR-0036). The server rejects a token that is
-                 *     expired, already consumed, or whose `diff_hash`/`workspace_id`/`passport_id`/`tool` does not
-                 *     match the operation being executed (`403 code: approval_token_invalid`). Required when an
-                 *     AGENT principal invokes a 🟡 operation; a human's direct call is itself the approval.
-                 */
-                "X-Approval-Token"?: components["parameters"]["ApprovalToken"];
             };
             path?: never;
             cookie?: never;
@@ -16984,7 +16979,7 @@ export interface operations {
                     "application/json": components["schemas"]["Activity"];
                 };
             };
-            /** @description Approval token missing for a 🟡 send, or RBAC denied. */
+            /** @description RBAC denied, or an agent principal presented a passport to a human-only operation. */
             403: {
                 headers: {
                     [name: string]: unknown;


### PR DESCRIPTION
## What a user can do now

Press "Write email" on a company, a person or a deal and actually get a composer. Until now every outbound message was anchored to an existing activity, so a new conversation — the company page's primary action — had nothing to anchor to and could not open.

## The shape

**There is still exactly one send.** The send takes an *origin* instead of an anchor id:

- **from an activity** — the existing reply, unchanged;
- **from an account** — no anchor, a fresh thread rooted at its own newly minted identity, record links supplied explicitly.

Everything after the origin resolves is the same code: the authorization order, the default-deny per-purpose consent gate, deliverability derivation, message-identity minting, and the single-transaction staging of activity + delivery + job. ADR-0087 rejects forking the send precisely because those five invariants would then have two homes and eventually two behaviours.

The reply path is refactored, not duplicated, and the suite that already covered it asserts it unchanged — the ADR names that as an explicit exit condition.

## Two refusals a reply never needs

An account-started send names its own addressees and its own links, so:

- **`recipient_not_on_file` (422)** — an address belonging to no person the sender can read refuses, and the fault **names the address**, because the composer's job at that moment is to offer the fix. Resolution is by *visibility*: an out-of-scope person's address answers exactly like one nobody has.
- **Link targets are row-scope probed** — a guessed or cross-tenant id refuses 404, the same answer reading it directly would give.

A **reply skips address resolution entirely**. Its addressees come from a conversation the workspace already captured, so refusing them would block answering mail the product itself put on the timeline.

## Refusals that fail closed

- No origin at all → refuses. ADR-0087 rejects making the anchor merely optional: an accidentally absent one would silently become a new conversation, losing a reply's threading with no signal.
- No recipient directory wired → refuses rather than mailing an address it never resolved.

## Notes for review

- `person_email` is the people module's table, so the lookup lives there and compose injects it — the same edge shape as channel reachability beside it.
- `POST /v1/emails` is registered in `replayableOperations`; the root fitness suite caught its absence, which would have let a retried request send twice.
- Both new guards were mutation-checked: reverting each one turns its test red for the stated reason.

Spec: ADR-0087 / A132.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Start a new outbound email directly from a company, person, or deal. Adds human-only `POST /v1/emails` and unifies replies and account-origin sends under one governed send path with idempotency and replay safety.

- **New Features**
  - New API: `POST /v1/emails` starts a new conversation with explicit `links`; confirm-first/gated, idempotent, replay-safe, returns the outbound `Activity`.
  - Account-origin sends resolve recipients via the contact directory: every `to`/`cc` must belong to a visible person or 422 `recipient_not_on_file` (names the address). Cc-only addresses are enforced. Replies skip this check.
  - New threads root at their own Message-ID; `links` are row-scope probed and unseen targets 404.
  - Human-only surface: cookie session only; agent tokens are refused.

- **Bug Fixes**
  - Link targets are now probed during origin resolution, before consent, so an unreadable link returns 404 (no consent-state leak via 409).
  - Recipient resolution enforces both the `person` read grant and row scope to prevent confirming addresses without people-read permission.
  - Contract now requires at least one `to` address (minItems: 1) to match runtime validation.

<sup>Written for commit c7d427d3ab224bbe02547627375ef9335cd64e39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/685?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for starting new account-originated email conversations through the CRM API.
  - Emails can be linked to specific records and begin fresh conversation threads.
  - Added recipient validation based on visible, known email addresses.
  - Added support for replaying account-originated email sends safely.

- **Bug Fixes**
  - Improved authorization and consent handling for account-originated messages.
  - Replies continue using existing conversation recipients without requiring additional recipient lookup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->