### PR TITLE
feat(finance): the schema for an ingested, read-only finance mirror (ADR-0083)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -18,6 +18,7 @@
 Every section in this file, in order. Read this list first and jump; nobody
 needs the whole file to start a session.
 
+- [Open — account-started outbound and the finance mirror (2026-08-09)](#open--account-started-outbound-and-the-finance-mirror-2026-08-09)
 - [Open — the settings mirror is a dual-write on ADR-0091's critical path](#open--the-settings-mirror-is-a-dual-write-on-adr-0091s-critical-path)
 - [Pick up here — ADR-0091 (A136): retiring the workspace tenant boundary](#pick-up-here--adr-0091-a136-retiring-the-workspace-tenant-boundary)
 - [Open — two follow-ups left by ADR-0082/A127 (the own company, and internal mail)](#open--two-follow-ups-left-by-adr-0082a127-the-own-company-and-internal-mail)
@@ -42,6 +43,33 @@ needs the whole file to start a session.
 - [Upstream spec raises owed from 2026-07-31](#upstream-spec-raises-owed-from-2026-07-31)
 - [Upstream spec reconciliation](#upstream-spec-reconciliation)
 - [Decisions owed](#decisions-owed)
+
+## Open — account-started outbound and the finance mirror (2026-08-09)
+
+ADR-0083/A128 and ADR-0087/A132 were ratified by the founder on 2026-08-09; the
+spec-side status change is `margince-foundation#1267`. The other five ADRs
+authored 2026-08-06 (A129, A130, A131, A133, A134) are still PROPOSED.
+
+**Account-started outbound (ADR-0087) — PR #685.** The send takes an origin
+(from an activity, or from an account) instead of an anchor id, so "Write email"
+from a company opens a composer without fabricating a placeholder activity.
+There is still exactly one send. `POST /v1/emails` carries the account-started
+surface; an address belonging to no person the sender can read refuses 422
+`recipient_not_on_file` and names the address.
+
+Left open: the operation is **human-only**. ADR-0087 §6's agent tool needs a
+decision-grant mapping before the verb can honestly be advertised — issue #688
+carries the four fitness tests that are its acceptance criteria. The
+account-started DRAFT (§3: grounded, fenced, auto-starting, writing nothing) is
+not built.
+
+**Finance mirror (ADR-0083) — PR #689.** The five tables only:
+`finance_connection`, `finance_external_customer`, `finance_customer_link`,
+`finance_invoice`, `finance_payment`. Migration 0202. No read path, no
+connector, no UI, no formulas — FIN-FORM-1..6 and FIN-AC-1..16 are almost all
+still open. `finance_invoice` joined `frozenRateTables` in deals, because an
+invoice freezes its FX rate on issue date and a base-currency change would
+restate money that already moved.
 
 ## Open — the settings mirror is a dual-write on ADR-0091's critical path
 

--- a/backend/.go-arch-lint.yml
+++ b/backend/.go-arch-lint.yml
@@ -68,6 +68,7 @@ components:
   people:      { in: internal/modules/people }
   privacy:     { in: internal/modules/privacy }
   deals:       { in: internal/modules/deals }
+  finance:     { in: internal/modules/finance }
   activities:  { in: internal/modules/activities }
   approvals:   { in: internal/modules/approvals }
   customfields: { in: internal/modules/customfields }
@@ -131,6 +132,9 @@ deps:
   privacy:
     mayDependOn: [contracts, platform]
     canUse: [pgx, oapi]
+  finance:
+    mayDependOn: [contracts, platform]
+    canUse: [pgx, oapi]
   deals:
     mayDependOn: [contracts, platform]
     # fpdf backs offer_pdf.go's branded PDF render (offers-depth arc 4a
@@ -171,7 +175,7 @@ deps:
     mayDependOn: [contracts, platform]
     canUse: [pgx, oapi]
   compose:
-    mayDependOn: [compose, identity, people, privacy, deals, activities, approvals, agents, automation, ai, search, capture, consent, collections, signals, customfields, quotas, overlay, migration, webhooks, comms, contracts, platform, migrations]
+    mayDependOn: [compose, identity, people, privacy, deals, activities, approvals, agents, automation, ai, search, capture, consent, collections, signals, customfields, quotas, overlay, migration, webhooks, comms, finance, contracts, platform, migrations]
     # xtext: the evidence gate normalizes page text to NFC before matching
     # (evidencematch.go) — Unicode normal forms need golang.org/x/text.
     # yaml: aicert's corpus loader parses scenario files directly — the
@@ -197,5 +201,5 @@ deps:
     mayDependOn: [contracts, compose]
     canUse: [yaml]
   cmd:
-    mayDependOn: [compose, identity, people, privacy, deals, activities, approvals, agents, automation, ai, search, capture, consent, collections, signals, customfields, quotas, overlay, migration, webhooks, comms, contracts, platform, migrations]
+    mayDependOn: [compose, identity, people, privacy, deals, activities, approvals, agents, automation, ai, search, capture, consent, collections, signals, customfields, quotas, overlay, migration, webhooks, comms, finance, contracts, platform, migrations]
     canUse: [pgx, redis, xterm, composition]

--- a/backend/internal/modules/deals/basecurrencyfreeze.go
+++ b/backend/internal/modules/deals/basecurrencyfreeze.go
@@ -27,10 +27,16 @@ import (
 // deals would let a workspace that has sent offers and closed nothing change
 // its base and silently restate every one of them.
 //
+// A mirrored INVOICE freezes on its issue date (FIN-PARAM-7/DM-FX-4), and that
+// figure was on a document the customer has already been sent and may have
+// already paid. It is the least restatable of the three: the other two are our
+// own records of our own intent, while an issued invoice is a fact about money
+// that moved.
+//
 // TestTheBaseCurrencyGuardCountsEveryFrozenRate derives this list from the
 // migrations, so a future table carrying the column fails that test rather than
 // quietly widening the hole.
-var frozenRateTables = []string{"deal", "offer"}
+var frozenRateTables = []string{"deal", "offer", "finance_invoice"}
 
 // BaseCurrencyFrozen reports whether the installation's base currency has
 // stopped being changeable, and says why.

--- a/backend/internal/modules/finance/doc.go
+++ b/backend/internal/modules/finance/doc.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+// Package finance owns the ingested finance mirror (ADR-0083/A128,
+// finance-ingestion.md): a bounded READ-ONLY import of an accounting
+// source, so the company page can answer whether a customer actually
+// pays us, and on time.
+//
+// It is a mirror, not an integration. The capability exposes no create
+// or update action on a finance record at all, and that posture is
+// expressed as the ABSENCE of a grant on the permission surface
+// (FIN-DDL-N-1) rather than as a runtime check — there is no code path
+// to reach and no flag to set wrongly. ADR-0094's removal of invoice
+// creation is unchanged in every particular: reading our own already
+// issued invoices back out of our own accounting system creates no
+// artifact and asserts no tax position.
+//
+// The mirror is subordinate. A customer link maps two identifiers and
+// never merges: an accounting customer never becomes an organization,
+// and an unmapped one is a visible state rather than an auto-created
+// company.
+//
+// Money is integer minor units in the issued currency, converted through
+// the existing effective-dated rate sheet and frozen on issue date
+// (DM-FX-4). A missing rate is the existing refusal — never a silent
+// conversion and never a zero.
+//
+// Tables owned: finance_connection, finance_external_customer,
+// finance_customer_link, finance_invoice, finance_payment.
+package finance

--- a/backend/migrations/core/0202_finance_mirror.down.sql
+++ b/backend/migrations/core/0202_finance_mirror.down.sql
@@ -1,0 +1,8 @@
+-- Dropped in dependency order: payments and invoices reference connections and
+-- organizations, and finance_invoice references itself through the credit-note
+-- pointer, which the table drop takes with it.
+DROP TABLE IF EXISTS finance_payment;
+DROP TABLE IF EXISTS finance_invoice;
+DROP TABLE IF EXISTS finance_customer_link;
+DROP TABLE IF EXISTS finance_external_customer;
+DROP TABLE IF EXISTS finance_connection;

--- a/backend/migrations/core/0202_finance_mirror.up.sql
+++ b/backend/migrations/core/0202_finance_mirror.up.sql
@@ -76,12 +76,21 @@ CREATE TABLE finance_customer_link (
   version              bigint NOT NULL DEFAULT 1,
   created_at           timestamptz NOT NULL DEFAULT now(),
   updated_at           timestamptz NOT NULL DEFAULT now(),
-  archived_at          timestamptz NULL,
-  -- One link each way per connection: an accounting customer maps to at most
-  -- one company, and a company to at most one accounting customer.
-  UNIQUE (workspace_id, connection_id, external_customer_id),
-  UNIQUE (workspace_id, connection_id, organization_id)
+  archived_at          timestamptz NULL
 );
+
+-- One link each way per connection: an accounting customer maps to at most one
+-- company, and a company to at most one accounting customer. Partial indexes
+-- rather than table constraints, because a RETIRED mapping must not block a new
+-- one — a human who unmaps a customer and maps it elsewhere is doing the
+-- ordinary thing, and an unconditional unique would refuse them forever.
+
+CREATE UNIQUE INDEX finance_customer_link_external_ux
+  ON finance_customer_link (workspace_id, connection_id, external_customer_id)
+  WHERE archived_at IS NULL;
+CREATE UNIQUE INDEX finance_customer_link_organization_ux
+  ON finance_customer_link (workspace_id, connection_id, organization_id)
+  WHERE archived_at IS NULL;
 
 -- FIN-DDL-3: a mirrored issued invoice. `void_at` is FIN-FORM-6's tombstone —
 -- a row is never deleted, so a record the source stops returning stays
@@ -101,7 +110,7 @@ CREATE TABLE finance_invoice (
   -- The provider's own word, kept for diagnosis: our vocabulary above is a
   -- normalization, and a mapping argument is unanswerable without the input.
   raw_status        text NULL,
-  currency          char(3) NOT NULL,
+  currency          char(3) NOT NULL CHECK (currency ~ '^[A-Z]{3}$'),
   net_minor         bigint NOT NULL,
   tax_minor         bigint NOT NULL DEFAULT 0,
   gross_minor       bigint NOT NULL,
@@ -128,6 +137,18 @@ CREATE TABLE finance_invoice (
   updated_at        timestamptz NOT NULL DEFAULT now(),
   archived_at       timestamptz NULL,
   UNIQUE (workspace_id, connection_id, external_id),
+  -- A frozen rate and the date it froze on are ONE fact (FIN-PARAM-7). A rate
+  -- without its date cannot be re-derived or audited; a date without a rate
+  -- converts nothing. Either both or neither.
+  CONSTRAINT finance_invoice_fx_pair
+    CHECK ((fx_rate_to_base IS NULL) = (fx_rate_date IS NULL)),
+  -- A credit note credits another invoice, never itself.
+  CONSTRAINT finance_invoice_credits_not_self
+    CHECK (credits_invoice_id IS NULL OR credits_invoice_id <> id),
+  -- void_at is FIN-FORM-6's tombstone, so it and the status must agree: a row
+  -- carrying a tombstone reads as void, and one that does not, does not.
+  CONSTRAINT finance_invoice_void_agrees
+    CHECK ((void_at IS NULL) = (status <> 'void')),
   CONSTRAINT finance_invoice_paid_status
     CHECK (fully_paid_at IS NULL OR status IN ('paid','credited','void'))
 );
@@ -157,7 +178,7 @@ CREATE TABLE finance_payment (
   external_id       text NOT NULL,
   invoice_id        uuid NULL,
   paid_at           timestamptz NOT NULL,
-  currency          char(3) NOT NULL,
+  currency          char(3) NOT NULL CHECK (currency ~ '^[A-Z]{3}$'),
   amount_minor      bigint NOT NULL,
   source_updated_at timestamptz NULL,
   sync_hash         text NOT NULL,
@@ -225,6 +246,21 @@ ALTER TABLE finance_payment
   ADD CONSTRAINT finance_payment_invoice_fk
   FOREIGN KEY (workspace_id, invoice_id)
   REFERENCES finance_invoice (workspace_id, id) ON DELETE RESTRICT;
+
+-- Every table carries version + updated_at, so every table takes the trigger
+-- that maintains them. Without it `version` never moves, and the optimistic
+-- concurrency the column exists for silently does nothing: a sync pass and a
+-- human edit would overwrite each other with no conflict ever reported.
+CREATE TRIGGER trg_finance_connection_updated BEFORE UPDATE ON finance_connection
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at_bump_version();
+CREATE TRIGGER trg_finance_external_customer_updated BEFORE UPDATE ON finance_external_customer
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at_bump_version();
+CREATE TRIGGER trg_finance_customer_link_updated BEFORE UPDATE ON finance_customer_link
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at_bump_version();
+CREATE TRIGGER trg_finance_invoice_updated BEFORE UPDATE ON finance_invoice
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at_bump_version();
+CREATE TRIGGER trg_finance_payment_updated BEFORE UPDATE ON finance_payment
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at_bump_version();
 
 -- Tenant isolation (FIN-AC-13): every finance table is workspace-scoped with
 -- row-level security enabled AND forced, so the owner role migrations run as

--- a/backend/migrations/core/0202_finance_mirror.up.sql
+++ b/backend/migrations/core/0202_finance_mirror.up.sql
@@ -1,0 +1,260 @@
+-- Finance ingestion (ADR-0083/A128, finance-ingestion.md FIN-DDL-1..5): a
+-- bounded READ-ONLY mirror of an accounting source, so the company page can
+-- answer "does this customer actually pay us, and on time?".
+--
+-- The read-only posture is expressed as the ABSENCE of a create/update grant
+-- on the permission surface (FIN-DDL-N-1), not as a runtime refusal. There is
+-- no code path to reach and no flag to set wrongly; a future contributor who
+-- wants to write an invoice must add an action, an ADR and a permission.
+--
+-- Every amount is an integer minor-unit value with an explicit currency
+-- (FIN-AC-5). No amount is a floating-point type anywhere in this schema.
+
+-- FIN-DDL-1: one configured accounting source.
+CREATE TABLE finance_connection (
+  id                uuid PRIMARY KEY DEFAULT uuidv7(),
+  workspace_id      uuid NOT NULL REFERENCES workspace(id) ON DELETE RESTRICT,
+  provider          text NOT NULL,
+  status            text NOT NULL DEFAULT 'connecting'
+                      CHECK (status IN ('connecting','active','error','disconnected')),
+  capabilities      jsonb NOT NULL DEFAULT '{}'::jsonb,
+  -- A vault handle, never a secret (FIN-PARAM-9/FIN-AC-12). The credential
+  -- itself appears in no row, log line, audit payload, API response or model
+  -- prompt.
+  credential_ref    text NOT NULL,
+  -- NULL means the backfill has not completed; a resumed run continues from
+  -- this checkpoint under the same run identity (FIN-AC-16).
+  sync_cursor       text NULL,
+  last_attempt_at   timestamptz NULL,
+  last_success_at   timestamptz NULL,
+  last_error_code   text NULL,
+  source            text NOT NULL,
+  captured_by       text NOT NULL,
+  version           bigint NOT NULL DEFAULT 1,
+  created_at        timestamptz NOT NULL DEFAULT now(),
+  updated_at        timestamptz NOT NULL DEFAULT now(),
+  archived_at       timestamptz NULL
+);
+
+-- FIN-DDL-5: the source's own customer directory, mirrored.
+--
+-- Without it there is nothing to link FROM, and the unmapped state FIN-AC-7
+-- requires could not be rendered — a candidate list cannot be drawn from a
+-- table of decisions already made. A row here carries no money and is not
+-- itself a finance record.
+CREATE TABLE finance_external_customer (
+  id                   uuid PRIMARY KEY DEFAULT uuidv7(),
+  workspace_id         uuid NOT NULL REFERENCES workspace(id) ON DELETE RESTRICT,
+  connection_id        uuid NOT NULL,
+  external_customer_id text NOT NULL,
+  display_name         text NOT NULL,
+  source_updated_at    timestamptz NULL,
+  sync_hash            text NOT NULL,
+  source               text NOT NULL,
+  captured_by          text NOT NULL,
+  version              bigint NOT NULL DEFAULT 1,
+  created_at           timestamptz NOT NULL DEFAULT now(),
+  updated_at           timestamptz NOT NULL DEFAULT now(),
+  archived_at          timestamptz NULL,
+  UNIQUE (workspace_id, connection_id, external_customer_id)
+);
+
+-- FIN-DDL-2: the deliberate mapping between an accounting customer and an
+-- organization. Never a merge, never automatic: an accounting customer does
+-- not become an organization, and an unmapped one is a visible state rather
+-- than an auto-created company (FIN-AC-7).
+CREATE TABLE finance_customer_link (
+  id                   uuid PRIMARY KEY DEFAULT uuidv7(),
+  workspace_id         uuid NOT NULL REFERENCES workspace(id) ON DELETE RESTRICT,
+  connection_id        uuid NOT NULL,
+  organization_id      uuid NOT NULL,
+  external_customer_id text NOT NULL,
+  source_updated_at    timestamptz NULL,
+  sync_hash            text NOT NULL,
+  source               text NOT NULL,
+  captured_by          text NOT NULL,
+  version              bigint NOT NULL DEFAULT 1,
+  created_at           timestamptz NOT NULL DEFAULT now(),
+  updated_at           timestamptz NOT NULL DEFAULT now(),
+  archived_at          timestamptz NULL,
+  -- One link each way per connection: an accounting customer maps to at most
+  -- one company, and a company to at most one accounting customer.
+  UNIQUE (workspace_id, connection_id, external_customer_id),
+  UNIQUE (workspace_id, connection_id, organization_id)
+);
+
+-- FIN-DDL-3: a mirrored issued invoice. `void_at` is FIN-FORM-6's tombstone —
+-- a row is never deleted, so a record the source stops returning stays
+-- readable as voided (FIN-AC-8).
+CREATE TABLE finance_invoice (
+  id                uuid PRIMARY KEY DEFAULT uuidv7(),
+  workspace_id      uuid NOT NULL REFERENCES workspace(id) ON DELETE RESTRICT,
+  connection_id     uuid NOT NULL,
+  organization_id   uuid NOT NULL,
+  external_id       text NOT NULL,
+  number            text NULL,
+  issued_at         date NOT NULL,
+  due_at            date NULL,
+  status            text NOT NULL
+                      CHECK (status IN ('draft','open','partially_paid','paid',
+                                        'overdue','disputed','credited','void')),
+  -- The provider's own word, kept for diagnosis: our vocabulary above is a
+  -- normalization, and a mapping argument is unanswerable without the input.
+  raw_status        text NULL,
+  currency          char(3) NOT NULL,
+  net_minor         bigint NOT NULL,
+  tax_minor         bigint NOT NULL DEFAULT 0,
+  gross_minor       bigint NOT NULL,
+  open_minor        bigint NOT NULL DEFAULT 0,
+  credited_minor    bigint NOT NULL DEFAULT 0,
+  -- Frozen on ISSUE date (FIN-PARAM-7/DM-FX-4). A missing rate is the existing
+  -- refusal, never a silent conversion and never a zero (FIN-AC-6).
+  fx_rate_to_base   numeric(20,10) NULL,
+  fx_rate_date      date NULL,
+  fully_paid_at     timestamptz NULL,
+  disputed_at       timestamptz NULL,
+  void_at           timestamptz NULL,
+  -- A credit note is an invoice row pointing at what it credits (FIN-DDL-N-3),
+  -- not a fifth table: one money table, one natural key, one upsert path.
+  credits_invoice_id uuid NULL,
+  source_updated_at timestamptz NULL,
+  -- The no-op detector (FIN-AC-9): an unchanged content hash writes no row, no
+  -- audit entry, no event and no version bump.
+  sync_hash         text NOT NULL,
+  source            text NOT NULL,
+  captured_by       text NOT NULL,
+  version           bigint NOT NULL DEFAULT 1,
+  created_at        timestamptz NOT NULL DEFAULT now(),
+  updated_at        timestamptz NOT NULL DEFAULT now(),
+  archived_at       timestamptz NULL,
+  UNIQUE (workspace_id, connection_id, external_id),
+  CONSTRAINT finance_invoice_paid_status
+    CHECK (fully_paid_at IS NULL OR status IN ('paid','credited','void'))
+);
+
+-- The company page's access path: this account's invoices, newest first.
+CREATE INDEX finance_invoice_account_ix
+  ON finance_invoice (workspace_id, organization_id, issued_at DESC);
+
+-- The open-balance path, which is the figure the page leads with.
+CREATE INDEX finance_invoice_open_ix
+  ON finance_invoice (workspace_id, organization_id)
+  WHERE open_minor > 0 AND void_at IS NULL;
+
+-- The credit-note pointer's own access path. Postgres indexes the referenced
+-- side for free and the referencing side never, so without this "which credit
+-- notes reduced this invoice?" scans every invoice in the workspace.
+CREATE INDEX finance_invoice_credits_ix
+  ON finance_invoice (workspace_id, credits_invoice_id)
+  WHERE credits_invoice_id IS NOT NULL;
+
+-- FIN-DDL-4: a mirrored payment, optionally against one invoice.
+CREATE TABLE finance_payment (
+  id                uuid PRIMARY KEY DEFAULT uuidv7(),
+  workspace_id      uuid NOT NULL REFERENCES workspace(id) ON DELETE RESTRICT,
+  connection_id     uuid NOT NULL,
+  organization_id   uuid NOT NULL,
+  external_id       text NOT NULL,
+  invoice_id        uuid NULL,
+  paid_at           timestamptz NOT NULL,
+  currency          char(3) NOT NULL,
+  amount_minor      bigint NOT NULL,
+  source_updated_at timestamptz NULL,
+  sync_hash         text NOT NULL,
+  source            text NOT NULL,
+  captured_by       text NOT NULL,
+  version           bigint NOT NULL DEFAULT 1,
+  created_at        timestamptz NOT NULL DEFAULT now(),
+  updated_at        timestamptz NOT NULL DEFAULT now(),
+  archived_at       timestamptz NULL,
+  UNIQUE (workspace_id, connection_id, external_id)
+);
+
+-- The invoice FK's referencing side, for "what paid this invoice?".
+CREATE INDEX finance_payment_invoice_ix
+  ON finance_payment (workspace_id, invoice_id)
+  WHERE invoice_id IS NOT NULL;
+
+-- The account's payment history, which FIN-FORM-3..5 read to answer whether a
+-- customer settles early or late.
+CREATE INDEX finance_payment_account_ix
+  ON finance_payment (workspace_id, organization_id, paid_at DESC);
+
+-- Composite (workspace_id, id) uniqueness, so every reference below can name
+-- the workspace as part of its target. A plain (id) foreign key is checked as
+-- the table owner and so bypasses RLS: it would accept a well-formed id
+-- belonging to ANOTHER workspace and persist a cross-tenant reference the
+-- application layer never sees. The composite form makes the database reject
+-- it (0019 did the same sweep for the core tables).
+ALTER TABLE finance_connection
+  ADD CONSTRAINT uq_finance_connection_ws_id UNIQUE (workspace_id, id);
+ALTER TABLE finance_invoice
+  ADD CONSTRAINT uq_finance_invoice_ws_id UNIQUE (workspace_id, id);
+
+ALTER TABLE finance_external_customer
+  ADD CONSTRAINT finance_external_customer_connection_fk
+  FOREIGN KEY (workspace_id, connection_id)
+  REFERENCES finance_connection (workspace_id, id) ON DELETE RESTRICT;
+
+ALTER TABLE finance_customer_link
+  ADD CONSTRAINT finance_customer_link_connection_fk
+  FOREIGN KEY (workspace_id, connection_id)
+  REFERENCES finance_connection (workspace_id, id) ON DELETE RESTRICT,
+  ADD CONSTRAINT finance_customer_link_organization_fk
+  FOREIGN KEY (workspace_id, organization_id)
+  REFERENCES organization (workspace_id, id) ON DELETE RESTRICT;
+
+ALTER TABLE finance_invoice
+  ADD CONSTRAINT finance_invoice_connection_fk
+  FOREIGN KEY (workspace_id, connection_id)
+  REFERENCES finance_connection (workspace_id, id) ON DELETE RESTRICT,
+  ADD CONSTRAINT finance_invoice_organization_fk
+  FOREIGN KEY (workspace_id, organization_id)
+  REFERENCES organization (workspace_id, id) ON DELETE RESTRICT,
+  ADD CONSTRAINT finance_invoice_credits_fk
+  FOREIGN KEY (workspace_id, credits_invoice_id)
+  REFERENCES finance_invoice (workspace_id, id) ON DELETE RESTRICT;
+
+ALTER TABLE finance_payment
+  ADD CONSTRAINT finance_payment_connection_fk
+  FOREIGN KEY (workspace_id, connection_id)
+  REFERENCES finance_connection (workspace_id, id) ON DELETE RESTRICT,
+  ADD CONSTRAINT finance_payment_organization_fk
+  FOREIGN KEY (workspace_id, organization_id)
+  REFERENCES organization (workspace_id, id) ON DELETE RESTRICT,
+  ADD CONSTRAINT finance_payment_invoice_fk
+  FOREIGN KEY (workspace_id, invoice_id)
+  REFERENCES finance_invoice (workspace_id, id) ON DELETE RESTRICT;
+
+-- Tenant isolation (FIN-AC-13): every finance table is workspace-scoped with
+-- row-level security enabled AND forced, so the owner role migrations run as
+-- is bound by it too. Unbound, the policy resolves to NULL and denies.
+ALTER TABLE finance_connection ENABLE ROW LEVEL SECURITY;
+ALTER TABLE finance_connection FORCE ROW LEVEL SECURITY;
+CREATE POLICY finance_connection_ws ON finance_connection
+  USING (workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid)
+  WITH CHECK (workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid);
+
+ALTER TABLE finance_external_customer ENABLE ROW LEVEL SECURITY;
+ALTER TABLE finance_external_customer FORCE ROW LEVEL SECURITY;
+CREATE POLICY finance_external_customer_ws ON finance_external_customer
+  USING (workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid)
+  WITH CHECK (workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid);
+
+ALTER TABLE finance_customer_link ENABLE ROW LEVEL SECURITY;
+ALTER TABLE finance_customer_link FORCE ROW LEVEL SECURITY;
+CREATE POLICY finance_customer_link_ws ON finance_customer_link
+  USING (workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid)
+  WITH CHECK (workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid);
+
+ALTER TABLE finance_invoice ENABLE ROW LEVEL SECURITY;
+ALTER TABLE finance_invoice FORCE ROW LEVEL SECURITY;
+CREATE POLICY finance_invoice_ws ON finance_invoice
+  USING (workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid)
+  WITH CHECK (workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid);
+
+ALTER TABLE finance_payment ENABLE ROW LEVEL SECURITY;
+ALTER TABLE finance_payment FORCE ROW LEVEL SECURITY;
+CREATE POLICY finance_payment_ws ON finance_payment
+  USING (workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid)
+  WITH CHECK (workspace_id = NULLIF(current_setting('app.workspace_id', true), '')::uuid);

--- a/backend/migrations/schema_fitness_integration_test.go
+++ b/backend/migrations/schema_fitness_integration_test.go
@@ -365,9 +365,9 @@ var rowScopedFKDecisions = gatekit.Waive(map[string]string{
 	// client-named company — the connector writes them, and it resolves the
 	// organization by reading the link that human already made, so a mirrored
 	// row can only land on a company somebody deliberately mapped.
-	"finance_customer_link.organization_id": "client-supplied and gated: the mapping write puts the named company through auth.EnsureLinkTarget before the link row is written",
-	"finance_invoice.organization_id":       "server-derived: resolved by the sync pass from the customer link a human already mapped, never from a request body",
-	"finance_payment.organization_id":       "server-derived: resolved by the sync pass from the customer link a human already mapped, never from a request body",
+	"finance_customer_link.organization_id": "schema only, no writer yet (#725): the mapping write does not exist, and when it lands it must put the named company through auth.EnsureLinkTarget — this entry is the obligation, not a record of one already met",
+	"finance_invoice.organization_id":       "schema only, no writer yet (#725): the sync pass does not exist, and when it lands it must resolve the organization from the customer link rather than from any request body",
+	"finance_payment.organization_id":       "schema only, no writer yet (#725): the sync pass does not exist, and when it lands it must resolve the organization from the customer link rather than from any request body",
 })
 
 // TestFK_rowScopedTargetsHaveVisibilityDecision derives the H1 obligation

--- a/backend/migrations/schema_fitness_integration_test.go
+++ b/backend/migrations/schema_fitness_integration_test.go
@@ -358,6 +358,16 @@ var rowScopedFKDecisions = gatekit.Waive(map[string]string{
 	// addresses the ghost row rather than naming a person.
 	"linkedin_connection.matched_person_id": "server-derived: resolved by the ghost matcher's own row-scoped lookup, never from a request body",
 	"linkedin_connection.matched_org_id":    "server-derived: resolved by the ghost matcher's own row-scoped lookup, never from a request body",
+	// The finance mirror (FIN-DDL-2..4). Exactly ONE of these three is
+	// client-supplied: the customer LINK is a human's mapping decision, so the
+	// company it names is gated by auth.EnsureLinkTarget at the write, exactly
+	// like an activity link. The invoice and payment rows never carry a
+	// client-named company — the connector writes them, and it resolves the
+	// organization by reading the link that human already made, so a mirrored
+	// row can only land on a company somebody deliberately mapped.
+	"finance_customer_link.organization_id": "client-supplied and gated: the mapping write puts the named company through auth.EnsureLinkTarget before the link row is written",
+	"finance_invoice.organization_id":       "server-derived: resolved by the sync pass from the customer link a human already mapped, never from a request body",
+	"finance_payment.organization_id":       "server-derived: resolved by the sync pass from the customer link a human already mapped, never from a request body",
 })
 
 // TestFK_rowScopedTargetsHaveVisibilityDecision derives the H1 obligation


### PR DESCRIPTION
First slice of finance ingestion: the five tables that let the company page answer **"does this customer actually pay us, and on time?"** Today the open balance, the overdue amount and the payment history exist nowhere in the product, so a rep opens the accounting system in another tab or guesses.

Schema and invariants only — no read path, no connector, no UI. Those follow.

## It is a mirror, not an integration

There is **no create or update action on a finance record anywhere**, and ADR-0083 asks for that posture to be the *absence of a grant* rather than a runtime refusal: no code path to reach, no flag to set wrongly. A contributor who wants to write an invoice must add an action, an ADR and a permission.

A94's removal of invoice creation is unchanged in every particular. Reading our own already-issued invoices back out of our own accounting system creates no artifact, asserts no tax position and produces nothing anyone could file.

## The five tables

| Table | What it holds |
|---|---|
| `finance_connection` | one configured accounting source; the credential is a **vault handle**, never a secret |
| `finance_external_customer` | the source's own customer directory, so *unmapped* is a visible state with named candidates |
| `finance_customer_link` | mappings **a human made** — an accounting customer never becomes an organization |
| `finance_invoice` | mirrored issued invoices; a credit note is a row pointing at what it credits, not a fifth table |
| `finance_payment` | mirrored payments, optionally against one invoice |

Every amount is integer minor units with an explicit currency. No floating-point amount exists in this schema.

## Three fitness tests failed first, and each was right

This is the part worth reviewing.

1. **`finance_invoice` joins `frozenRateTables`.** It carries `fx_rate_to_base`, frozen on issue date. Without this a workspace could change its base currency and silently restate every invoice — and unlike a deal or an offer, an issued invoice is a fact about money that already moved.
2. **Every FK is composite on `workspace_id`.** A plain `(id)` key is checked as the table owner and so bypasses RLS: it would accept a well-formed id belonging to another workspace and persist a cross-tenant reference. Required adding `(workspace_id, id)` uniqueness to `finance_connection` and `finance_invoice`.
3. **Each organization reference carries a visibility decision.** `finance_customer_link.organization_id` is client-supplied — a human picks the company — and is classified as gated at the write. The invoice and payment rows resolve theirs from that link, so a mirrored row can only land on a company somebody deliberately mapped.

RLS is enabled **and forced** on all five, so the owner role migrations run as is bound by it too.

## Notes

- Migration `0202`; `origin/main`'s highest was `0201` at push time.
- `internal/modules/finance` is registered in `.go-arch-lint.yml` with the standard module dependency set (`contracts`, `platform` only).
- ADR-0083/A128 was ratified by the founder on 2026-08-09; the spec-side status change is `margince-foundation#1267`.

Spec: ADR-0083 / A128, `finance-ingestion.md` FIN-DDL-1..5.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a read-only finance mirror schema so the company page can show open balance, overdue amounts, and payment history. Implements ADR-0083/A128; schema and invariants only — no connector, read path, or UI.

- New Features
  - Added five tables: finance_connection, finance_external_customer, finance_customer_link, finance_invoice, finance_payment (credit notes are invoices pointing to another invoice).
  - Read-only posture: no create/update grants for finance records.
  - Invoices freeze fx_rate_to_base on issue date and join deals’ frozenRateTables to prevent base-currency restatement.
  - Strong tenant isolation: composite FKs on (workspace_id, id), RLS enabled and forced; schema fitness entries record org-visibility obligations until writers exist.
  - Data integrity: integer minor-unit amounts with ISO currency checks; partial uniques on active finance_customer_link mappings; invariants for FX rate/date pair, void/status agreement, and “no self-credit”; targeted indexes for invoices, open balance, credits, and payment history; triggers bump updated_at/version on all tables.
  - Registered `internal/modules/finance` in `backend/.go-arch-lint.yml`, allowed `compose`/`cmd` to depend on `finance`, and recorded status in `STATUS.md`.

- Migration
  - Adds migration 0202_finance_mirror (up/down) to create schema, indexes, constraints, triggers, FKs, and RLS policies.

<sup>Written for commit bcd267914604004625692e1539beceb886d48a76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/689?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

