### PR TITLE
docs(status): what the activity anchor left open, and what it learned the hard way

### DIFF
--- a/STATUS-ARCHIVE.md
+++ b/STATUS-ARCHIVE.md
@@ -21,6 +21,49 @@
 > [CHANGELOG.md](CHANGELOG.md) and [README.md → *What works
 > today*](README.md#what-works-today).
 
+## Session pickup — 2026-08-09 (a meeting becomes an anchor, and what the tool copy cost, PR #686)
+
+`prep_for_meeting`, `catch_me_up_on` and `GET /records/{entity_type}/{id}/context`
+took an `activity` anchor (closing #577). The event is dereferenced to the
+records it names — from `activity_link` and from the `activity_participant`
+rows capture matched to people — one becomes the subject by a stated
+precedence, and the ordinary record walk runs around that. An activity is still
+a link, not a thing links hang off; the graph kept exactly the anchors it had.
+Two follow-ups are open and carried in STATUS.md: [#687] and [#726].
+
+**Two things the next agent-surface branch should budget for.**
+
+Tool copy is load-bearing and has to be measured rather than reasoned about. A
+sentence recommending the new anchor — "name the captured calendar event itself
+when you have one" — made two `not_supported` bindings read the run's
+`calendar:…` trigger reference as an activity `record_id`;
+`meeting_prep_is_not_a_catchup` went to 0/3 on both, deterministically, with an
+identical failure detail every run. Warning against it in prose did not help
+(ministral stayed at 1/5). Saying nothing did (5/5) — the schema advertises what
+a tool accepts, and prose that also recommends it is what tipped them. So budget
+an `agent_loop` re-run per copy REVISION, not one per PR: three revisions cost
+three full re-certification passes across three bindings.
+
+And the two openrouter bindings cannot be read at three runs a scenario. Two
+consecutive runs of an UNCHANGED tree moved ministral 0.587 → 0.556 and deepseek
+0.62 → 0.51. Certify ministral at `RUNS=5` before trusting one of its numbers,
+and treat a single three-run delta on either as noise unless the failure detail
+is identical every run. `gemini-3.1-flash-lite` at 0.90 was the only binding
+stable enough to read anything from, and it was unaffected by every variant.
+
+The review loop found four things worth naming, all fixed in the PR: the
+dereference borrowed the hop-2 walk's shorter link list and so dropped
+`activity_link`'s lead arm (the discovery call a prep is most often for); the
+context walk had only ever applied ROW scope, so a caller with `activity.read`
+and no `deal.read` could be handed a deal's name; the bounded participant window
+was cut by id, which could drop an organizer before the precedence saw them; and
+`max_items` did not bound the two new sections. The first of those is the one to
+remember — its fitness gate derived the link vocabulary from a sibling Go map
+rather than from the DDL, so the gate passed against the bug it described.
+
+[#687]: https://github.com/gradionhq/margince-poc-v1/issues/687
+[#726]: https://github.com/gradionhq/margince-poc-v1/issues/726
+
 ## Resolved — the graph can answer "who do I know here" (PR #355)
 
 The `in_contact_with` edge used to join on who TYPED the activity

--- a/STATUS.md
+++ b/STATUS.md
@@ -18,6 +18,7 @@
 Every section in this file, in order. Read this list first and jump; nobody
 needs the whole file to start a session.
 
+- [Open — two follow-ups left by the activity anchor (#686, 2026-08-09)](#open--two-follow-ups-left-by-the-activity-anchor-686-2026-08-09)
 - [Open — account-started outbound and the finance mirror (2026-08-09)](#open--account-started-outbound-and-the-finance-mirror-2026-08-09)
 - [Open — the settings mirror is a dual-write on ADR-0091's critical path](#open--the-settings-mirror-is-a-dual-write-on-adr-0091s-critical-path)
 - [Pick up here — ADR-0091 (A136): retiring the workspace tenant boundary](#pick-up-here--adr-0091-a136-retiring-the-workspace-tenant-boundary)
@@ -43,6 +44,46 @@ needs the whole file to start a session.
 - [Upstream spec raises owed from 2026-07-31](#upstream-spec-raises-owed-from-2026-07-31)
 - [Upstream spec reconciliation](#upstream-spec-reconciliation)
 - [Decisions owed](#decisions-owed)
+
+## Open — two follow-ups left by the activity anchor (#686, 2026-08-09)
+
+`prep_for_meeting` and `catch_me_up_on` now take an `activity` anchor, and so
+does `GET /records/{entity_type}/{id}/context`: the event is dereferenced to the
+records it is about, one becomes the subject, and the ordinary walk runs around
+that. Two things it deliberately did not fix.
+
+**The context walk does not follow activity_link's lead arm — [#687].** A lead
+anchor answers with its profile and nothing else, because `anchorLinkColumn`
+maps only person / organization / deal / project. `activity_link` has carried
+`lead_id` since core `0038`, so a lead does have a timeline and the walk simply
+does not read it. #686 made a lead a first-class *subject* of an activity anchor
+and corrected a comment that asserted the opposite, but the lead's own
+neighborhood walk is still empty. Closing it means a `lead` entry in
+`anchorLinkColumn` and a decision about whether a lead should also be a hop-2
+neighbour, both of which change what an existing endpoint answers.
+
+**A weak model invents a record id from the trigger reference — [#726].** With
+`activity` in the anchor enum, the two `not_supported` agent_loop bindings
+sometimes call `prep_for_meeting{record_type: activity, record_id: <the run's
+`calendar:…` trigger ref>}` — a record that does not exist — instead of
+anchoring on the organization they were grounded with. It is an id-provenance
+error, not a tool-selection one. Three wordings were measured; only silence in
+the tool copy helped, and only on one binding. The durable fix is a statement in
+the runner's own system frame (a record id comes from something the run has
+read, never from the occurrence reference it was started with), which touches
+every task and needs its own certification pass.
+
+**Two things #686 learned that the next agent-surface branch should budget for.**
+Tool copy is load-bearing and has to be measured rather than reasoned about — a
+sentence recommending the new anchor cost `meeting_prep_is_not_a_catchup` 0/3 on
+two bindings, deterministically — so budget an `agent_loop` re-run per copy
+revision, not one per PR. And the two openrouter bindings cannot be read at
+n=3: two consecutive runs of an unchanged tree moved ministral 0.587 → 0.556 and
+deepseek 0.62 → 0.51, so certify ministral at `RUNS=5` and treat a single
+three-run delta as noise unless the failure detail is identical every run.
+
+[#687]: https://github.com/gradionhq/margince-poc-v1/issues/687
+[#726]: https://github.com/gradionhq/margince-poc-v1/issues/726
 
 ## Open — account-started outbound and the finance mirror (2026-08-09)
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -64,23 +64,19 @@ neighbour, both of which change what an existing endpoint answers.
 
 **A weak model invents a record id from the trigger reference — [#726].** With
 `activity` in the anchor enum, the two `not_supported` agent_loop bindings
-sometimes call `prep_for_meeting{record_type: activity, record_id: <the run's
-`calendar:…` trigger ref>}` — a record that does not exist — instead of
-anchoring on the organization they were grounded with. It is an id-provenance
+sometimes anchor on the run's own trigger reference instead of on the
+organization they were grounded with:
+
+```
+prep_for_meeting{record_type: "activity", record_id: "<the run's calendar: trigger ref>"}
+```
+
+That record does not exist, so the call 404s. It is an id-provenance
 error, not a tool-selection one. Three wordings were measured; only silence in
 the tool copy helped, and only on one binding. The durable fix is a statement in
 the runner's own system frame (a record id comes from something the run has
 read, never from the occurrence reference it was started with), which touches
 every task and needs its own certification pass.
-
-**Two things #686 learned that the next agent-surface branch should budget for.**
-Tool copy is load-bearing and has to be measured rather than reasoned about — a
-sentence recommending the new anchor cost `meeting_prep_is_not_a_catchup` 0/3 on
-two bindings, deterministically — so budget an `agent_loop` re-run per copy
-revision, not one per PR. And the two openrouter bindings cannot be read at
-n=3: two consecutive runs of an unchanged tree moved ministral 0.587 → 0.556 and
-deepseek 0.62 → 0.51, so certify ministral at `RUNS=5` and treat a single
-three-run delta as noise unless the failure detail is identical every run.
 
 [#687]: https://github.com/gradionhq/margince-poc-v1/issues/687
 [#726]: https://github.com/gradionhq/margince-poc-v1/issues/726


### PR DESCRIPTION
Session pickup for #686 (the `activity` context anchor, closing #577).

Two follow-ups it deliberately did not fix, both filed as issues and now carried
in STATUS.md:

- **[#687]** — the context walk does not follow `activity_link`'s lead arm, so a
  lead anchor still answers profile-only. `lead_id` has existed since core
  `0038`; #686 made a lead a first-class *subject* of an activity anchor and
  corrected a comment asserting the arm did not exist, but the lead's own walk
  is still empty. Closing it changes what an existing endpoint answers.
- **[#726]** — with `activity` in the anchor enum, the two `not_supported`
  agent_loop bindings sometimes build a `record_id` out of the run's
  `calendar:…` trigger reference. It is an id-provenance error and belongs in
  the runner's system frame, not in one tool's description.

And the two things that cost this session the most, recorded so the next
agent-surface branch does not pay them again: tool copy is load-bearing and must
be measured (one recommending sentence took `meeting_prep_is_not_a_catchup` to
0/3 on two bindings, deterministically), and the two openrouter bindings cannot
be read at n=3 — two consecutive runs of an unchanged tree moved ministral
0.587 → 0.556 and deepseek 0.62 → 0.51.

Docs only.

[#687]: https://github.com/gradionhq/margince-poc-v1/issues/687
[#726]: https://github.com/gradionhq/margince-poc-v1/issues/726

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Document the two open follow-ups from the `activity` anchor work (#686) in `STATUS.md` — the context walk still skips the lead arm (#687) and some `agent_loop` bindings build an invalid `record_id` from trigger refs (#726) — and move the session learnings to `STATUS-ARCHIVE.md`. Also add a TOC entry and fence the trigger-reference example for correct rendering.

<sup>Written for commit d58be78fb62f2dd469f893a88f1d0a290d27777c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/727?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added open work items for improving lead activity traversal and preventing inaccurate activity record IDs from calendar references.
  * Documented certification guidance for measuring tool-copy revisions and rerunning unstable bindings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->