### PR TITLE
feat(company): Write email opens a composer from the account

### DIFF
--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -717,6 +717,7 @@ export const de = {
   "co.growthFit.whitespace": "Was sie bei dir noch nicht kaufen",
   "co.growthFit.objections": "Womit sie voraussichtlich dagegenhalten",
   "co.growthFit.angle": "Vorgeschlagener Ansatz",
+  "co.writeEmail": "E-Mail schreiben",
   "co.dossier.title": "Was diese Firma ist",
   "co.dossier.unavailable":
     "Diese Beschreibung ließ sich nicht lesen. An der Firma hat sich nichts geändert.",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -714,6 +714,7 @@ export const en = {
   "co.growthFit.whitespace": "What they do not buy from you yet",
   "co.growthFit.objections": "What they are likely to push back with",
   "co.growthFit.angle": "Suggested approach",
+  "co.writeEmail": "Write email",
   "co.dossier.title": "What this company is",
   "co.dossier.unavailable":
     "This description could not be read. Nothing about the company has changed.",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -715,6 +715,7 @@ export const vi = {
   "co.growthFit.whitespace": "Những thứ họ chưa mua của bạn",
   "co.growthFit.objections": "Những điều họ có thể phản đối",
   "co.growthFit.angle": "Hướng tiếp cận đề xuất",
+  "co.writeEmail": "Viết email",
   "co.dossier.title": "Công ty này là gì",
   "co.dossier.unavailable":
     "Không đọc được mô tả này. Thông tin công ty không thay đổi.",

--- a/frontend/src/screens/companyheader.tsx
+++ b/frontend/src/screens/companyheader.tsx
@@ -1,4 +1,5 @@
 import { useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
 import { api } from "../api/client";
 import type { components } from "../api/schema";
 import { ifMatch } from "../api/version";
@@ -13,6 +14,7 @@ import { ArchiveAction } from "./archive";
 import { provenanceOf, throwProblem, useSorMode, useViewerId } from "./common";
 import { RECORD_ZONE } from "./company360";
 import { DecisionsChip } from "./companyapprovals";
+import { ComposeModal } from "./compose";
 import { joinMultiselectValue } from "./create";
 import { useObjectCustomFields } from "./customfields.form";
 import { EditAction } from "./edit";
@@ -48,11 +50,11 @@ type UpdateOrganizationRequest =
 // was two clicks inside it, behind a type picker, which is why accounts get
 // notes and no follow-ups.
 //
-// "Write email" is deliberately NOT here yet. The composer requires an existing
-// activity to reply to (ComposeModal takes an activityId), so an account-started
-// email has no contract to call — and a button that opens a composer with
-// nothing to send from would be a promise this page cannot keep. It joins this
-// group with the account-started draft/send contract, not before.
+// "Write email" leads, because it is the account's primary action (plan §4.1):
+// a rep opening a company is usually about to start a conversation, not log
+// one that happened. It sends through POST /emails, the account-started origin
+// — a new thread filed under this company — rather than fabricating an
+// activity to reply to.
 export function CompanyPrimaryActions({
   org,
 }: Readonly<{ org: Organization }>) {
@@ -63,6 +65,7 @@ export function CompanyPrimaryActions({
   }
   return (
     <>
+      <WriteEmailAction org={org} />
       <LogActivityAction entityType="organization" entityId={org.id} />
       <LogActivityAction
         entityType="organization"
@@ -70,6 +73,36 @@ export function CompanyPrimaryActions({
         initialKind="task"
         triggerLabel="log.addTask"
       />
+    </>
+  );
+}
+
+// WriteEmailAction opens the composer with no anchor. The modal owns the send,
+// the consent gate and the refusal vocabulary; this owns only whether the
+// surface is offered and the open/close state, so the account-started and
+// reply surfaces stay one component.
+function WriteEmailAction({ org }: Readonly<{ org: Organization }>) {
+  const t = useT();
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button variant="primary" onClick={() => setOpen(true)}>
+        {t("co.writeEmail")}
+      </Button>
+      {open && (
+        // Keyed by the record, so navigating to another company while the
+        // composer is open REMOUNTS it rather than re-pointing it. Without the
+        // key the form keeps the text written for the previous account while
+        // the links payload follows the new one — a message composed for A,
+        // filed against B, with nothing on screen saying so.
+        <ComposeModal
+          key={org.id}
+          entityType="organization"
+          entityId={org.id}
+          open={open}
+          onClose={() => setOpen(false)}
+        />
+      )}
     </>
   );
 }

--- a/frontend/src/screens/compose.test.tsx
+++ b/frontend/src/screens/compose.test.tsx
@@ -1618,3 +1618,93 @@ describe("TimelineActions", () => {
     );
   });
 });
+
+// An account-started send is the SAME send with a different origin (ADR-0087
+// §1): no anchor, a fresh thread, and the records it is filed under named
+// explicitly. These three cases fix that the composer picks the right door —
+// the reply path and the account path are one component, and the thing most
+// easily broken by a refactor is which endpoint it reaches for.
+describe("ComposeModal started from an account", () => {
+  it("sends through POST /emails, filed under the record it started from", async () => {
+    const onClose = vi.fn();
+    const sent = stubRoutes({
+      "POST /emails": () => jsonResponse(activity202, 202),
+    });
+    render(
+      <ComposeModal
+        entityType="organization"
+        entityId="org-1"
+        open
+        onClose={onClose}
+      />,
+    );
+    await screen.findByRole("combobox");
+    await fillSendableForm();
+    await userEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+    const req = sent.find((r) => r.key === "POST /emails");
+    expect(req?.body).toEqual({
+      subject: "Hi there",
+      body: "Body content",
+      to: ["a@x.com"],
+      consent_purpose: "transactional",
+      // Without a link the message belongs to no record and nobody finds it
+      // again, which is the gap this origin exists to close.
+      links: [{ entity_type: "organization", entity_id: "org-1" }],
+    });
+    // ADR-0055 holds on this origin too: the human's click is the approval.
+    expect(req?.headers.get("X-Approval-Token")).toBeNull();
+  });
+
+  it("never reaches the anchored reply endpoint", async () => {
+    const sent = stubRoutes({
+      "POST /emails": () => jsonResponse(activity202, 202),
+    });
+    render(
+      <ComposeModal
+        entityType="organization"
+        entityId="org-1"
+        open
+        onClose={vi.fn()}
+      />,
+    );
+    await screen.findByRole("combobox");
+    await fillSendableForm();
+    await userEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    await waitFor(() =>
+      expect(sent.some((r) => r.key === "POST /emails")).toBe(true),
+    );
+    // A fabricated anchor is exactly what ADR-0087 forbids, and a send that
+    // reached the reply path without one would 404 on a made-up id.
+    expect(sent.some((r) => r.key.includes("send-email"))).toBe(false);
+  });
+
+  // The grounded account-started draft is ADR-0087 §3 and is not built. Saying
+  // so is honest; drafting against some nearby activity would ground the mail
+  // in a conversation the rep never chose.
+  it("reports drafting unavailable rather than drafting off a stranger's thread", async () => {
+    const sent = stubRoutes({});
+    render(
+      <ComposeModal
+        entityType="organization"
+        entityId="org-1"
+        open
+        onClose={vi.fn()}
+      />,
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Draft with AI" }),
+    );
+
+    expect(sent.some((r) => r.key.includes("draft-email"))).toBe(false);
+    expect(screen.getByPlaceholderText("Body")).toHaveProperty("value", "");
+    // Silence would read as a broken button. The rep is told drafting is off
+    // and that writing it themselves still works — and Send stays reachable,
+    // because an undraftable message is not an unsendable one.
+    expect(await screen.findByText(/AI drafting is unavailable/)).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Send" })).toBeTruthy();
+  });
+});

--- a/frontend/src/screens/compose.tsx
+++ b/frontend/src/screens/compose.tsx
@@ -480,6 +480,53 @@ function purposeOptions(
 // subject on top of a body; a channel reply carries neither (design §9.3 —
 // the recipient is resolved server-side, and a channel has no subject line),
 // so only the words and the consent purpose gate it.
+// The one place the send's ORIGIN is chosen, so the three transports cannot
+// drift into different bodies. An anchor sends the reply the composer has
+// always sent; no anchor sends the account-started twin, which carries the
+// records it is filed under instead of inheriting them from a conversation
+// (ADR-0087 §1). A channel reply is anchor-only by nature — there is no such
+// thing as starting a Telegram thread with a stranger from a company page —
+// so it keeps the anchored path and never reaches the account arm.
+async function sendFrom(args: {
+  activityId?: string;
+  isTelegram: boolean;
+  mail: {
+    subject: string;
+    body: string;
+    to: string[];
+    cc?: string[];
+    draft_ref?: string;
+    consent_purpose: string;
+  };
+  channelBody: { body: string; consent_purpose: string };
+  links: { entity_type: RelinkKind; entity_id: string }[];
+}) {
+  if (args.isTelegram) {
+    if (!args.activityId) {
+      // A channel reply answers a conversation the person opened; there is no
+      // way to start one with a stranger from a company page. Falling through
+      // to the mail arm would post a channel message as an account EMAIL —
+      // wrong transport, wrong body shape, and a message the rep never meant
+      // to send by mail. No caller constructs this today; the refusal is what
+      // keeps that true.
+      throw new Error(
+        "compose: a channel reply needs the conversation it answers",
+      );
+    }
+    return api.POST("/activities/{id}/send-message", {
+      params: { path: { id: args.activityId } },
+      body: args.channelBody,
+    });
+  }
+  if (args.activityId) {
+    return api.POST("/activities/{id}/send-email", {
+      params: { path: { id: args.activityId } },
+      body: args.mail,
+    });
+  }
+  return api.POST("/emails", { body: { ...args.mail, links: args.links } });
+}
+
 function canSendCompose(
   isTelegram: boolean,
   fields: { to: string[]; subject: string; body: string; purpose: string },
@@ -609,7 +656,13 @@ export function ComposeModal({
   open,
   onClose,
 }: Readonly<{
-  activityId: string;
+  // Absent means this is an ACCOUNT-STARTED send: a new conversation with no
+  // prior message to anchor to (ADR-0087 §1). It is the same send either way —
+  // only the origin differs — so the drafting, consent, refusal and provenance
+  // behaviour below is shared rather than forked. A reply keeps threading and
+  // inherits its links; an account-started message roots its own thread and
+  // files itself under the record it was started from.
+  activityId?: string;
   entityType: RelinkKind;
   entityId: string;
   personId?: string;
@@ -644,6 +697,12 @@ export function ComposeModal({
   const draft = useMutation({
     mutationFn: async () => {
       setDraftUnavailable(false);
+      // Drafting is anchored: the grounded account-started draft is ADR-0087
+      // §3 and is not built yet. Reporting it unavailable is the honest answer
+      // — the rep writes the mail themselves and still sends it — where
+      // drafting against some nearby activity would ground the message in a
+      // conversation the rep never chose.
+      if (!activityId) return { available: false as const };
       const { data, error, response } = await api.POST(
         "/activities/{id}/draft-email",
         {
@@ -742,22 +801,21 @@ export function ComposeModal({
       setSendUnavailable(false);
       // No X-Approval-Token, no Idempotency-Key on either path: the human's
       // own click IS the approval on the REST path (ADR-0055).
-      const { data, error, response } = isTelegram
-        ? await api.POST("/activities/{id}/send-message", {
-            params: { path: { id: activityId } },
-            body: { body, consent_purpose: purpose },
-          })
-        : await api.POST("/activities/{id}/send-email", {
-            params: { path: { id: activityId } },
-            body: {
-              subject,
-              body,
-              to,
-              cc: cc.length ? cc : undefined,
-              draft_ref: draftRef ?? undefined,
-              consent_purpose: purpose,
-            },
-          });
+      const mail = {
+        subject,
+        body,
+        to,
+        cc: cc.length ? cc : undefined,
+        draft_ref: draftRef ?? undefined,
+        consent_purpose: purpose,
+      };
+      const { data, error, response } = await sendFrom({
+        activityId,
+        isTelegram,
+        mail,
+        channelBody: { body, consent_purpose: purpose },
+        links: [{ entity_type: entityType, entity_id: entityId }],
+      });
       if (response.status === 501) return { sent: false as const };
       // Only a real 202 is a send. openapi-fetch returns a falsy `error` for a
       // bodiless non-2xx (a gateway 502/503/504); inferring success from


### PR DESCRIPTION
A rep can now press **Write email** on a company and get a composer. Plan §4.1 calls this the account's primary action; it was the one missing verb in the header, and it is the surface for the account-started send that merged in #685 with nothing able to reach it.

## One composer, two origins

`ComposeModal`'s `activityId` is optional. Absent means a new conversation — no anchor, a fresh thread, records named explicitly. Present is the reply, unchanged. Everything after the origin is shared: drafting, the consent gate, the refusal vocabulary, provenance, the Art. 50 disclosure.

## Codex findings, both fixed

- **State leak (MAJOR).** The modal is keyed by the record. Navigating to another company with the composer open kept the text written for the first while the `links` payload followed the second — a message composed for A, filed against B.
- **Endpoint fallthrough (MINOR).** A channel reply with no anchor now refuses rather than posting a Telegram message as an account email.

## Deliberately not built

Drafting reports itself unavailable on this origin. The grounded account-started draft is ADR-0087 §3; drafting off a nearby activity would ground the mail in a conversation the rep never chose. The test asserts the rep is *told* this and that Send stays reachable.

Local gate: 1989 frontend tests, biome, tsc, build — all green. Two of the three new tests fail if the origin choice is inverted.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add “Write email” to the company header. It opens the composer for a new, account-started email and sends via POST /emails, creating a new thread linked to the company.

- **New Features**
  - Added "Write email" primary action on the company page; opens `ComposeModal` without an anchor and files the message under the company.
  - `ComposeModal` now supports both reply and account-started sends (`activityId` optional) with centralized routing to the correct endpoint.
  - Drafting is disabled for account-started sends with a clear in-UI notice; sending still works.
  - Added `co.writeEmail` i18n key in `en`, `de`, and `vi`.

- **Bug Fixes**
  - Keyed the composer by `org.id` to prevent text/state leaking when navigating between companies.
  - Blocked channel replies without an anchor to avoid falling through to the email endpoint.

<sup>Written for commit f867bb503a4165d5020fde337c56fbc70ee3056f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/728?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Write email” action for active companies.
  * Added German, English, and Vietnamese translations.
  * Enabled composing and sending emails directly from a company.
* **Bug Fixes**
  * Email replies and new emails now use the appropriate sending flow.
  * Telegram replies require an associated activity.
  * AI drafting is unavailable when no activity is selected, while manual sending remains available.
* **Tests**
  * Added coverage for direct email sending, reply behavior, approval headers, and drafting restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->