### PR TITLE
feat(company): the account page is two columns, not three

### DIFF
--- a/frontend/src/screens/company360.test.tsx
+++ b/frontend/src/screens/company360.test.tsx
@@ -414,23 +414,25 @@ describe("company view — consent is per purpose", () => {
   });
 });
 
-describe("company view — the rails belong to the account, not to a tab", () => {
-  it("keeps both side columns mounted when the reader switches tab", async () => {
+describe("company view — the context column belongs to the account, not to a tab", () => {
+  it("keeps the context column mounted when the reader switches tab", async () => {
     stub(view(), 200, partnerOrg);
     renderCompany();
 
     await screen.findByRole("complementary", { name: "Business" });
-    expect(screen.getByRole("complementary", { name: "Profile" })).toBeTruthy();
 
     await userEvent.click(screen.getByRole("button", { name: "Partner" }));
 
-    // Partner and History used to render in a header-only frame, so both
-    // rails unmounted, the grid re-columned under the reader, and every query
-    // behind them refetched on the way back.
+    // Partner and History used to render in a header-only frame, so the side
+    // column unmounted, the grid re-columned under the reader, and every query
+    // behind it refetched on the way back.
     expect(
       screen.getByRole("complementary", { name: "Business" }),
     ).toBeTruthy();
-    expect(screen.getByRole("complementary", { name: "Profile" })).toBeTruthy();
+    // There is no second landmark to check any more: the profile, documents,
+    // facts and tools disclosures live INSIDE the Business column (plan §4 —
+    // one context column, not two), so they ride on its mount.
+    expect(screen.queryByRole("complementary", { name: "Profile" })).toBeNull();
   });
 
   it("does not refetch the account when the reader switches tab and back", async () => {

--- a/frontend/src/screens/organizations.test.tsx
+++ b/frontend/src/screens/organizations.test.tsx
@@ -1860,11 +1860,15 @@ describe("CompanyScreen — Ask Margince", () => {
 });
 
 // The page must not re-column itself under the reader. RecordView picks its
-// grid template from which zones are present, so a right rail that arrives
-// with the composite read moves the whole middle column — and everything the
-// reader was looking at — sideways the moment it lands.
+// grid template from which zones are present, so a context column that arrives
+// with the composite read moves the work column — and everything the reader was
+// looking at — sideways the moment it lands.
+//
+// TWO columns, not three (plan §4): a work column and one context column. The
+// left rail is gone; its folded reference cards sit under the business context
+// on the right.
 describe("CompanyScreen — the layout does not shift as the read lands", () => {
-  it("holds the three-column template while the 360 is still in flight", async () => {
+  it("holds the two-column template while the 360 is still in flight", async () => {
     let releaseView: (() => void) | undefined;
     const held = new Promise<void>((resolve) => {
       releaseView = resolve;
@@ -1892,13 +1896,70 @@ describe("CompanyScreen — the layout does not shift as the read lands", () => 
     const { container } = render(<CompanyScreen id="o-1" />);
     await screen.findByText("Brandt Automotive GmbH");
     const zonesWhileLoading = container.querySelector(".record-zones");
-    expect(zonesWhileLoading?.className).toContain("record-zones-both");
+    expect(zonesWhileLoading?.className).toContain("record-zones-aside");
+    // A three-column template would put the account's story in the middle
+    // 5/11ths, which is what §4 tells the implementer not to preserve.
+    expect(zonesWhileLoading?.className).not.toContain("record-zones-both");
     releaseView?.();
     await waitFor(() =>
       expect(container.querySelector(".record-zones")?.className).toContain(
-        "record-zones-both",
+        "record-zones-aside",
       ),
     );
+  });
+
+  // §4: "Do not preserve a three-column layout if it forces the daily-action
+  // surface below the fold." The work column now takes 7/10ths instead of
+  // 5/11ths, and the reference cards a reader opens occasionally sit under the
+  // business context rather than claiming a column of their own.
+  it("gives the account's story the work column, with no second rail", async () => {
+    stubFetch(companyBackstop, { org360 });
+    const { container } = render(<CompanyScreen id="o-1" />);
+    await screen.findByText("Brandt Automotive GmbH");
+
+    await waitFor(() =>
+      expect(container.querySelector(".record-zones")?.className).toContain(
+        "record-zones-aside",
+      ),
+    );
+    expect(container.querySelector(".record-rail")).toBeNull();
+    // The reference material did not vanish with its column — it moved, and
+    // it is still folded shut rather than standing open in the reader's way.
+    expect(screen.getAllByText("Company profile").length).toBeGreaterThan(0);
+  });
+
+  // Moving those cards into the context column is a LAYOUT change and must not
+  // become an availability change. None of them comes from the 360 — each runs
+  // its own read — so they must be on the page before that read lands, and
+  // stay there if it never does.
+  it("offers the reference cards before the 360 read lands", async () => {
+    let releaseView: (() => void) | undefined;
+    const held = new Promise<void>((resolve) => {
+      releaseView = resolve;
+    });
+    const { fetchMock } = stubFetch(companyBackstop);
+    const held360 = vi.fn(async (request: Request) => {
+      if (new URL(request.url).pathname.endsWith("/360")) {
+        await held;
+      }
+      return fetchMock(request);
+    });
+    vi.stubGlobal("fetch", held360);
+
+    const { container } = render(<CompanyScreen id="o-1" />);
+    await screen.findByText("Brandt Automotive GmbH");
+
+    // Asserted on the disclosure summaries a reader actually clicks: these
+    // words also appear in the app's navigation, so a bare text match would
+    // pass on a page that had lost every one of these cards.
+    const summaries = () =>
+      Array.from(container.querySelectorAll(".disclosure-summary")).map((el) =>
+        el.textContent?.trim(),
+      );
+    await waitFor(() => expect(summaries()).toContain("Company profile"));
+    expect(summaries()).toContain("Documents");
+    expect(summaries()).toContain("Data & tools");
+    releaseView?.();
   });
 });
 

--- a/frontend/src/screens/organizations.tsx
+++ b/frontend/src/screens/organizations.tsx
@@ -1918,48 +1918,20 @@ function CompanyPage({
       // page: a whole form in the header's action strip pushed the account's
       // own story below the fold before a word of it was read.
       actions={<CompanyPrimaryActions org={org} />}
-      rail={
-        overlay ? undefined : (
-          <>
-            {/* The company's own statements, folded away. The BRIEF says what
-                this company is, in two sentences, at the top of the page —
-                these sixteen fields are where those sentences come from and
-                where a reader goes when two are not enough. Standing open
-                they were a wall of paragraphs, every value underlined, that
-                nobody read before a call. */}
-            <Disclosure summary={t("co.profile.title")}>
-              <ProfileFieldsCard orgId={org.id} onOpenHistory={showChanges} />
-            </Disclosure>
-            {/* The account's contracts, offers and legal files. Folded away
-                like the rest of the rail: a reader opens it when they are
-                looking for a document, not on every page load. */}
-            <Disclosure summary={t("docs.title")}>
-              <CompanyDocumentsCard orgId={org.id} />
-            </Disclosure>
-            <Disclosure summary={t("co.evidence.title")}>
-              <FactsCard orgId={org.id} onOpenHistory={showChanges} />
-            </Disclosure>
-            <Disclosure summary={t("co.relationships.title")}>
-              <RelationshipsTab scope={{ organization_id: org.id }} />
-            </Disclosure>
-            {/* One-off tools and configuration, folded away. Standing open
-                they carried the same weight as the facts a rep opens the page
-                for, and they are used a fraction as often. */}
-            <Disclosure summary={t("co.tools.title")}>
-              <CustomFieldsCard object="organization" record={org} />
-              <HierarchyRollupCard orgId={org.id} />
-              <EnrichCard orgId={org.id} />
-              <DeepReadCard orgId={org.id} />
-            </Disclosure>
-          </>
-        )
-      }
+      // ONE context column, not two. The plan (§4) says the page is a header,
+      // a primary work column and a secondary truth/context column, and not to
+      // preserve a three-column layout if it pushes the daily-action surface
+      // down. A left rail of five folded disclosures took a third of the width
+      // to say nothing until opened, and squeezed the account's own story into
+      // the middle 5/11ths. Those disclosures now sit under the business
+      // context on the right, in the order a rep reaches for them.
       aside={businessRail({
         org,
         view,
         overlay,
         failed,
         readOnly: Boolean(org.archived_at),
+        onOpenHistory: showChanges,
         t,
       })}
       // The chronology is the account's story and belongs to the overview.
@@ -2267,6 +2239,7 @@ function businessRail({
   overlay,
   failed,
   readOnly,
+  onOpenHistory,
   t,
 }: Readonly<{
   org: Organization;
@@ -2276,6 +2249,8 @@ function businessRail({
   // An archived company takes no new deals, tags or list rows, so it shows no
   // verb that would only be refused.
   readOnly: boolean;
+  // Where an evidence mark leads: the record's change history, on its own tab.
+  onOpenHistory: () => void;
   // Passed rather than read: this assembles a tree, it is not a component,
   // so it has no hook context of its own.
   t: ReturnType<typeof useT>;
@@ -2322,6 +2297,7 @@ function businessRail({
             listAction={readOnly ? undefined : <ListAction orgId={org.id} />}
           />
         </Disclosure>
+        <ReferenceDisclosures org={org} onOpenHistory={onOpenHistory} t={t} />
       </>
     );
   }
@@ -2341,6 +2317,7 @@ function businessRail({
         <section className="card co-card">
           <Skeleton width="100%" height={64} />
         </section>
+        <ReferenceDisclosures org={org} onOpenHistory={onOpenHistory} t={t} />
       </>
     );
   }
@@ -2354,6 +2331,50 @@ function businessRail({
       <DealsCard />
       <SignalsCard orgId={org.id} />
       <TagsCard />
+      <ReferenceDisclosures org={org} onOpenHistory={onOpenHistory} t={t} />
+    </>
+  );
+}
+
+// The reference material a reader opens when the summary above is not enough.
+//
+// It renders in EVERY branch, because none of it comes from the 360: each card
+// runs its own read. It used to occupy a whole column of its own, folded shut —
+// a third of the page's width saying nothing until clicked, while the account's
+// own story ran in the middle 5/11ths (plan §4). Moving it here is a layout
+// change and must not become an availability change: a failed 360 hides what
+// the 360 answered, not the company's profile, its documents or its files.
+function ReferenceDisclosures({
+  org,
+  onOpenHistory,
+  t,
+}: Readonly<{
+  org: Organization;
+  onOpenHistory: () => void;
+  t: ReturnType<typeof useT>;
+}>): ReactNode {
+  return (
+    <>
+      <Disclosure summary={t("co.profile.title")}>
+        <ProfileFieldsCard orgId={org.id} onOpenHistory={onOpenHistory} />
+      </Disclosure>
+      <Disclosure summary={t("docs.title")}>
+        <CompanyDocumentsCard orgId={org.id} />
+      </Disclosure>
+      <Disclosure summary={t("co.evidence.title")}>
+        <FactsCard orgId={org.id} onOpenHistory={onOpenHistory} />
+      </Disclosure>
+      <Disclosure summary={t("co.relationships.title")}>
+        <RelationshipsTab scope={{ organization_id: org.id }} />
+      </Disclosure>
+      {/* One-off tools and configuration, last: used a fraction as often as
+          anything above them. */}
+      <Disclosure summary={t("co.tools.title")}>
+        <CustomFieldsCard object="organization" record={org} />
+        <HierarchyRollupCard orgId={org.id} />
+        <EnrichCard orgId={org.id} />
+        <DeepReadCard orgId={org.id} />
+      </Disclosure>
     </>
   );
 }


### PR DESCRIPTION
Plan §4 says: *"Do not preserve a three-column layout if it forces the daily-action surface below the fold."* The page kept one. A left rail of five folded disclosures took a third of the width to say nothing until opened, while the account's own story ran in the middle 5/11ths.

**Now:** a work column at 7/10ths, and one context column. The reference cards — profile fields, documents, facts, relationships, tools — moved under the business context, ordered by how often a rep reaches for them.

## What Codex caught

The first cut put those five cards inside the branch that renders only once the `/360` read succeeds. **None of them comes from the 360** — each runs its own read. A slow or failed 360 would have hidden the company's profile, its documents and its files: a layout change quietly becoming an availability change.

They are now one `ReferenceDisclosures` component rendered from all three branches (loaded, loading, failed), with a test that holds them on the page while the 360 is still in flight. That test fails if the loading branch drops them again.

## Tests

Two existing tests asserted `record-zones-both`; they now assert `record-zones-aside` and keep their original invariant — the grid must not re-column under the reader as the read lands. A new test pins the shape and fails if a second rail returns.

Local gate: 169 files, 1990 tests, biome, tsc, build — green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched the company account page to two columns: a 7/10ths work column and one context column. Removed the left rail and moved profile, documents, facts, relationships, and tools under the business context to keep work above the fold and prevent layout shifts.

- **Refactors**
  - Replaced the three-column template with `record-zones-aside`; removed the left rail.
  - Introduced `ReferenceDisclosures` for profile, documents, facts, relationships, and tools under the context column.
  - Rendered `ReferenceDisclosures` in all `/360` states (loaded, loading, failed).

- **Bug Fixes**
  - Stopped hiding reference cards when `/360` is slow or fails; they load independently.
  - Kept the context column mounted across tab switches to avoid refetches and reflow.
  - Updated tests to assert `record-zones-aside`; added a test to prevent a second rail and to keep references visible while `/360` is in flight.

<sup>Written for commit a4ede298e97f51beadb9474718f0b5d1f7442868. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/729?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

