### PR TITLE
feat(company): the KPI row asks a customer and a prospect different questions

### DIFF
--- a/backend/api/crm.yaml
+++ b/backend/api/crm.yaml
@@ -12201,10 +12201,52 @@ components:
         commercial:
           type: [object, 'null']
           description: Null when the caller has no deal grant.
-          required: [open_count, stalled_count]
+          required: [open_count, stalled_count, priced_count, converted_count]
           properties:
             open_count: { type: integer, minimum: 0 }
             stalled_count: { type: integer, minimum: 0 }
+            open_pipeline_minor_base:
+              type: [integer, 'null']
+              description: >-
+                The open pipeline in the workspace's base currency, integer minor units. Null
+                when NO open deal carries a figure that can be converted — distinct from zero,
+                which would claim a priced pipeline worth nothing.
+            priced_count:
+              type: integer
+              minimum: 0
+              description: >-
+                How many of `open_count` contributed to the sum. A deal with no amount, and one
+                whose currency has no conversion rate on its date, both contribute nothing —
+                so a total below `open_count` covers PART of the pipeline, and the page says so
+                rather than showing a figure that is quietly short (plan §4.2: never a
+                cross-currency sum without its conversion source).
+            converted_count:
+              type: integer
+              minimum: 0
+              description: >-
+                How many of `priced_count` needed a currency conversion to enter the sum — the
+                rest were already in the base. Zero means the total is a same-currency sum and
+                no rate stands behind it.
+            fx_as_of:
+              type: [string, 'null']
+              format: date
+              description: >-
+                The OLDEST rate date among the converted deals: each freezes its rate on its own
+                issue date, so this is the furthest back any part of the figure reaches. §4.2
+                forbids a cross-currency sum without an explicit conversion source and as-of
+                date, and this is that date. Null when nothing needed converting.
+            base_currency:
+              type: [string, 'null']
+              description: >-
+                The ISO-4217 currency `open_pipeline_minor_base` is expressed in — the
+                workspace's base. Travels WITH the figure rather than being looked up
+                separately, because a converted sum rendered under a currency fetched from
+                somewhere else is exactly the unlabelled cross-currency total §4.2 forbids.
+                Null whenever the figure is.
+            next_close_on:
+              type: [string, 'null']
+              format: date
+              description: The nearest expected close date among the open deals; null when none names one.
         signal:
           type: [object, 'null']
           description: >-

--- a/backend/internal/compose/org360/accountstate.go
+++ b/backend/internal/compose/org360/accountstate.go
@@ -14,6 +14,8 @@ package org360
 import (
 	"time"
 
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
 	crmcontracts "github.com/gradionhq/margince/backend/internal/contracts"
 	"github.com/gradionhq/margince/backend/internal/modules/activities"
 	"github.com/gradionhq/margince/backend/internal/platform/auth"
@@ -115,11 +117,33 @@ func (a *assembly) readStateStrip() error {
 	}
 	if in.pipeline {
 		strip.Commercial = new(struct {
-			OpenCount    int `json:"open_count"`
-			StalledCount int `json:"stalled_count"`
+			BaseCurrency          *string             `json:"base_currency,omitempty"`
+			ConvertedCount        int                 `json:"converted_count"`
+			FxAsOf                *openapi_types.Date `json:"fx_as_of,omitempty"`
+			NextCloseOn           *openapi_types.Date `json:"next_close_on,omitempty"`
+			OpenCount             int                 `json:"open_count"`
+			OpenPipelineMinorBase *int                `json:"open_pipeline_minor_base,omitempty"`
+			PricedCount           int                 `json:"priced_count"`
+			StalledCount          int                 `json:"stalled_count"`
 		})
 		strip.Commercial.OpenCount = in.open.OpenCount
 		strip.Commercial.StalledCount = len(in.open.Stalled)
+		strip.Commercial.PricedCount = in.open.Priced
+		// Null, not zero, when nothing could be priced: a zero would claim a
+		// pipeline that exists and is worth nothing, where the truth is that no
+		// open deal here carries a figure this page can convert (plan §4.2).
+		if in.open.Priced > 0 {
+			value := int(in.open.ValueMinorBase)
+			strip.Commercial.OpenPipelineMinorBase = &value
+			strip.Commercial.BaseCurrency = &in.open.BaseCurrency
+			strip.Commercial.ConvertedCount = in.open.Converted
+			if in.open.FXAsOf != nil {
+				strip.Commercial.FxAsOf = &openapi_types.Date{Time: *in.open.FXAsOf}
+			}
+		}
+		if in.open.NextCloseOn != nil {
+			strip.Commercial.NextCloseOn = &openapi_types.Date{Time: *in.open.NextCloseOn}
+		}
 	}
 	// The worst thing standing open, or nothing. Null covers BOTH "no signal"
 	// and "you may not read signals" on purpose: a strip that said "nothing is

--- a/backend/internal/compose/org360/pipelinefold.go
+++ b/backend/internal/compose/org360/pipelinefold.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package org360
+
+// What the account's open deals add up to, and what the page may honestly say
+// about that figure (plan §4.2). Separate from the query that scans them so the
+// money rules can be proven without a database.
+
+import (
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+// openRow is one open deal as the pipeline read scans it.
+type openRow struct {
+	id         ids.UUID
+	name       string
+	stalled    bool
+	idleSince  time.Time
+	stageMoves int
+	// amountMinor is the deal's own figure in its own currency; nil when the
+	// deal names no amount at all.
+	amountMinor *int64
+	// valueBase is the CONVERTED figure, and it is null on every open deal:
+	// the rate freezes on close (deals.deal_advance), so the generated column
+	// has nothing to compute from until then. Reading only this column would
+	// price the open pipeline at nothing forever, which is why the fold falls
+	// back to amountMinor for deals already in the base currency.
+	valueBase *int64
+	closeOn   *time.Time
+	currency  *string
+	rateDate  *time.Time
+	baseCcy   string
+}
+
+// baseValueOf answers what one open deal contributes to the base-currency
+// total, and whether a conversion stood behind it.
+//
+// A deal ALREADY in the base currency needs no rate, and contributes its own
+// figure. This is the ordinary case and the reason the fold cannot simply read
+// amount_minor_base: that generated column is null on every open deal, because
+// the rate freezes on CLOSE (deals.deal_advance). Summing it alone would price
+// the open pipeline at nothing on every installation, forever.
+//
+// A deal in another currency contributes only when a frozen rate AND its date
+// are both present. Refusing it otherwise is what keeps §4.2's rule true —
+// a converted figure always has a conversion behind it and a date to name —
+// and the deal still counts toward open_count, so the page reports a total
+// covering part of the pipeline rather than a silently short one.
+func baseValueOf(deal openRow) (value int64, converted bool, ok bool) {
+	if deal.currency != nil && *deal.currency == deal.baseCcy {
+		if deal.amountMinor == nil {
+			return 0, false, false
+		}
+		return *deal.amountMinor, false, true
+	}
+	if deal.valueBase == nil || deal.rateDate == nil {
+		return 0, false, false
+	}
+	return *deal.valueBase, true, true
+}
+
+// foldPipeline turns the scanned rows into the figures the page reports.
+//
+// Separate from the query so the MONEY rules can be proven without a database:
+// which deals enter the total, what the total means when some cannot, and what
+// provenance a converted figure has to carry (plan §4.2).
+func foldPipeline(open []openRow) pipeline {
+	out := pipeline{OpenCount: len(open), Stalled: make([]stalledDeal, 0, len(open))}
+	sorted := make([]string, 0, len(open))
+	for _, deal := range open {
+		sorted = append(sorted, deal.id.String())
+		if value, converted, ok := baseValueOf(deal); ok {
+			out.ValueMinorBase += value
+			out.Priced++
+			out.BaseCurrency = deal.baseCcy
+			if converted {
+				out.Converted++
+				// Only reached when a rate date exists: baseValueOf refuses a
+				// converted figure without one, so a converted total always has
+				// an as-of date behind it (plan §4.2).
+				if out.FXAsOf == nil || deal.rateDate.Before(*out.FXAsOf) {
+					out.FXAsOf = deal.rateDate
+				}
+			}
+		}
+		if deal.closeOn != nil && (out.NextCloseOn == nil || deal.closeOn.Before(*out.NextCloseOn)) {
+			out.NextCloseOn = deal.closeOn
+		}
+		if deal.stalled {
+			out.Stalled = append(out.Stalled, stalledDeal{
+				ID: deal.id, Name: deal.name,
+				IdleSince: deal.idleSince, StageMoves: deal.stageMoves,
+			})
+		}
+	}
+	// Sorted by id rather than by the read's order, so the digest depends on
+	// WHICH deals are open and on nothing else — a deal whose last activity moves
+	// must not read as a changed pipeline.
+	slices.Sort(sorted)
+	out.OpenDigest = strings.Join(sorted, ",")
+	return out
+}

--- a/backend/internal/compose/org360/pipelinefold_test.go
+++ b/backend/internal/compose/org360/pipelinefold_test.go
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 Gradion
+
+package org360
+
+// The money rules behind the company page's open-pipeline figure (plan §4.2).
+// They are proven here rather than through the database because what is at
+// stake is arithmetic and honesty, not SQL: which deals may enter a total, what
+// the total means when some of them cannot, and what a converted figure has to
+// carry beside it.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gradionhq/margince/backend/internal/shared/kernel/ids"
+)
+
+func day(t *testing.T, value string) time.Time {
+	t.Helper()
+	parsed, err := time.Parse(time.DateOnly, value)
+	if err != nil {
+		t.Fatalf("parsing %q: %v", value, err)
+	}
+	return parsed
+}
+
+// deal builds one scanned row the way the DEAL WRITER leaves it: an amount in
+// the deal's own currency, and — for an open deal — no frozen conversion rate,
+// because the rate freezes on close. A foreign-currency open deal therefore
+// carries a nil valueBase, which is exactly what the database returns.
+func deal(amount *int64, currency string, rateDate *time.Time) openRow {
+	row := openRow{
+		id: ids.NewV7(), name: "Deal", baseCcy: "EUR",
+		amountMinor: amount, currency: &currency, rateDate: rateDate,
+	}
+	// A closed-and-reopened deal is the only open row that carries a frozen
+	// rate, and the generated column follows the rate.
+	if amount != nil && currency != "EUR" && rateDate != nil {
+		converted := *amount
+		row.valueBase = &converted
+	}
+	return row
+}
+
+func amount(minor int64) *int64 { return &minor }
+
+// The case the whole figure rests on, and the one a column-only read gets
+// wrong: an ordinary open deal in the workspace's own currency. It has no
+// frozen FX rate — the rate freezes on close — so amount_minor_base is null,
+// and a total built from that column alone would price every open pipeline at
+// nothing on every installation.
+func TestAnOpenDealInTheBaseCurrencyIsPricedWithoutAnyFxRate(t *testing.T) {
+	out := foldPipeline([]openRow{
+		deal(amount(250000), "EUR", nil),
+		deal(amount(150000), "EUR", nil),
+	})
+
+	if out.Priced != 2 {
+		t.Fatalf("Priced = %d, want 2 — an open deal in the base currency needs no rate", out.Priced)
+	}
+	if out.ValueMinorBase != 400000 {
+		t.Fatalf("ValueMinorBase = %d, want 400000", out.ValueMinorBase)
+	}
+	if out.Converted != 0 || out.FXAsOf != nil {
+		t.Fatalf("Converted/FXAsOf = %d/%v, want 0/nil — nothing was converted",
+			out.Converted, out.FXAsOf)
+	}
+}
+
+// A foreign-currency deal with no frozen rate cannot be converted, so it must
+// not enter the total — and must still count as open, so the page reports a
+// partial figure rather than a silently short one.
+func TestAForeignOpenDealWithNoFrozenRateStaysOutOfTheTotal(t *testing.T) {
+	out := foldPipeline([]openRow{
+		deal(amount(100000), "EUR", nil),
+		deal(amount(999999), "USD", nil),
+	})
+
+	if out.ValueMinorBase != 100000 {
+		t.Fatalf("ValueMinorBase = %d, want 100000 — the unconvertible deal contributes nothing", out.ValueMinorBase)
+	}
+	if out.Priced != 1 || out.OpenCount != 2 {
+		t.Fatalf("Priced/OpenCount = %d/%d, want 1/2 — the gap is what the page discloses",
+			out.Priced, out.OpenCount)
+	}
+	if out.FXAsOf != nil {
+		t.Fatalf("FXAsOf = %v, want nil — no conversion happened", out.FXAsOf)
+	}
+}
+
+func TestAPipelineWhoseDealsCarryNoAmountIsPricedAtNothing(t *testing.T) {
+	out := foldPipeline([]openRow{
+		deal(nil, "EUR", nil),
+		deal(nil, "EUR", nil),
+	})
+
+	if out.OpenCount != 2 {
+		t.Fatalf("OpenCount = %d, want 2 — the deals are open whether or not they carry a figure", out.OpenCount)
+	}
+	// Priced == 0 is what tells the page to show no money. A zero TOTAL with a
+	// non-zero Priced would claim a pipeline that exists and is worth nothing.
+	if out.Priced != 0 {
+		t.Fatalf("Priced = %d, want 0 — nothing here could be added up", out.Priced)
+	}
+	if out.ValueMinorBase != 0 {
+		t.Fatalf("ValueMinorBase = %d, want 0", out.ValueMinorBase)
+	}
+}
+
+// A total that covers some of the pipeline must report how much, or a reader
+// takes a partial figure for the whole one.
+func TestAPartialTotalReportsHowManyDealsItCovers(t *testing.T) {
+	out := foldPipeline([]openRow{
+		deal(amount(150000), "EUR", nil),
+		deal(nil, "EUR", nil),
+		deal(amount(50000), "EUR", nil),
+	})
+
+	if out.ValueMinorBase != 200000 {
+		t.Fatalf("ValueMinorBase = %d, want 200000 (the two priced deals)", out.ValueMinorBase)
+	}
+	if out.Priced != 2 || out.OpenCount != 3 {
+		t.Fatalf("Priced/OpenCount = %d/%d, want 2/3 — the gap is what the page discloses",
+			out.Priced, out.OpenCount)
+	}
+}
+
+// §4.2 forbids a cross-currency sum without an explicit conversion source and
+// as-of date. The as-of is the OLDEST rate standing behind the figure: each
+// deal freezes its own, so that is how far back any part of the total reaches.
+func TestAConvertedTotalCarriesTheOldestRateDateBehindIt(t *testing.T) {
+	recent, older := day(t, "2026-07-01"), day(t, "2026-02-14")
+	out := foldPipeline([]openRow{
+		deal(amount(100000), "USD", &recent),
+		deal(amount(100000), "CHF", &older),
+		deal(amount(100000), "EUR", nil),
+	})
+
+	if out.Converted != 2 {
+		t.Fatalf("Converted = %d, want 2 — the euro deal needed no rate", out.Converted)
+	}
+	if out.FXAsOf == nil || !out.FXAsOf.Equal(older) {
+		t.Fatalf("FXAsOf = %v, want %v (the furthest back the figure reaches)", out.FXAsOf, older)
+	}
+}
+
+// A same-currency total has no rate behind it, and must not claim one.
+func TestASameCurrencyTotalNamesNoConversion(t *testing.T) {
+	out := foldPipeline([]openRow{
+		deal(amount(100000), "EUR", nil),
+		deal(amount(25000), "EUR", nil),
+	})
+
+	if out.Converted != 0 {
+		t.Fatalf("Converted = %d, want 0 — nothing was converted", out.Converted)
+	}
+	if out.FXAsOf != nil {
+		t.Fatalf("FXAsOf = %v, want nil — an as-of date here would name a rate that never applied", out.FXAsOf)
+	}
+	if out.BaseCurrency != "EUR" {
+		t.Fatalf("BaseCurrency = %q, want EUR", out.BaseCurrency)
+	}
+}
+
+// The nearest expected close is what a prospect's page reports, so it is the
+// minimum over the deals that name one — not the first the scan happened to
+// return, and not disturbed by deals that name none.
+func TestTheNextCloseIsTheNearestDateAnyOpenDealNames(t *testing.T) {
+	later, sooner := day(t, "2026-12-01"), day(t, "2026-09-30")
+	rows := []openRow{deal(nil, "EUR", nil), deal(nil, "EUR", nil), deal(nil, "EUR", nil)}
+	rows[0].closeOn = &later
+	rows[2].closeOn = &sooner
+
+	out := foldPipeline(rows)
+
+	if out.NextCloseOn == nil || !out.NextCloseOn.Equal(sooner) {
+		t.Fatalf("NextCloseOn = %v, want %v", out.NextCloseOn, sooner)
+	}
+}
+
+func TestAPipelineWithNoExpectedCloseNamesNoDate(t *testing.T) {
+	out := foldPipeline([]openRow{deal(amount(1000), "EUR", nil)})
+
+	if out.NextCloseOn != nil {
+		t.Fatalf("NextCloseOn = %v, want nil — no deal here names a close date", out.NextCloseOn)
+	}
+}

--- a/backend/internal/compose/org360/suggestionreads.go
+++ b/backend/internal/compose/org360/suggestionreads.go
@@ -27,8 +27,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"slices"
-	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -177,6 +175,31 @@ type pipeline struct {
 	// applied by the rule that lists them, AFTER dismissals are filtered out, so
 	// dismissing one suggestion reveals the next rather than shrinking the card.
 	Stalled []stalledDeal
+	// ValueMinorBase is the open pipeline in the workspace's base currency, and
+	// Priced counts how many of the open deals carry a figure at all.
+	//
+	// Both travel together because the sum alone cannot be read honestly: a
+	// deal with no amount, and one whose currency has no conversion rate, both
+	// contribute nothing, and a total that silently omits them reads as the
+	// whole pipeline. Priced < OpenCount is what lets the page say the figure
+	// covers part of it rather than showing a number that is quietly short.
+	ValueMinorBase int64
+	Priced         int
+	// NextCloseOn is the nearest expected close date among the open deals, or
+	// nil when none of them names one.
+	NextCloseOn *time.Time
+	// Converted counts the deals that needed a rate to enter the sum, and
+	// FXAsOf is the OLDEST rate date among them — each deal freezes its rate on
+	// its own date, so that is the furthest back any part of the figure reaches.
+	// Without both, the total is a cross-currency sum with no conversion source
+	// behind it, which is what plan §4.2 forbids showing.
+	Converted int
+	FXAsOf    *time.Time
+	// BaseCurrency is what ValueMinorBase is denominated in, read in the SAME
+	// statement as the figure so the two cannot come from different snapshots
+	// — a converted sum labelled with a currency fetched separately is the
+	// unlabelled cross-currency total the page must never show.
+	BaseCurrency string
 }
 
 // openPipeline reads every open deal on the account the caller may see, in one
@@ -211,7 +234,10 @@ func openPipeline(
 	rows, err := tx.Query(ctx, fmt.Sprintf(`
 		SELECT d.id, d.name, d.status, d.created_at, d.last_activity_at, d.wait_until,
 		       (SELECT count(*) FROM deal_stage_history h
-		         WHERE h.deal_id = d.id AND h.from_stage_id IS DISTINCT FROM h.to_stage_id)
+		         WHERE h.deal_id = d.id AND h.from_stage_id IS DISTINCT FROM h.to_stage_id),
+		       d.amount_minor, d.amount_minor_base, d.expected_close_date,
+		       d.currency, d.fx_rate_date,
+		       (SELECT base_currency FROM workspace WHERE id = d.workspace_id)
 		FROM deal d
 		%s
 		ORDER BY coalesce(d.last_activity_at, d.created_at), d.id`,
@@ -219,20 +245,14 @@ func openPipeline(
 	if err != nil {
 		return pipeline{}, fmt.Errorf("read the account's open pipeline: %w", err)
 	}
-	type openRow struct {
-		id         ids.UUID
-		name       string
-		stalled    bool
-		idleSince  time.Time
-		stageMoves int
-	}
 	open, err := pgx.CollectRows(rows, func(row pgx.CollectableRow) (openRow, error) {
 		var r openRow
 		var status string
 		var createdAt time.Time
 		var lastActivityAt, waitUntil *time.Time
 		if err := row.Scan(&r.id, &r.name, &status, &createdAt, &lastActivityAt, &waitUntil,
-			&r.stageMoves); err != nil {
+			&r.stageMoves, &r.amountMinor, &r.valueBase, &r.closeOn, &r.currency,
+			&r.rateDate, &r.baseCcy); err != nil {
 			return r, err
 		}
 		r.stalled = deals.IsStalled(status, createdAt, lastActivityAt, waitUntil, now)
@@ -248,23 +268,7 @@ func openPipeline(
 		return pipeline{}, err
 	}
 
-	out := pipeline{OpenCount: len(open), Stalled: make([]stalledDeal, 0, len(open))}
-	sorted := make([]string, 0, len(open))
-	for _, deal := range open {
-		sorted = append(sorted, deal.id.String())
-		if deal.stalled {
-			out.Stalled = append(out.Stalled, stalledDeal{
-				ID: deal.id, Name: deal.name,
-				IdleSince: deal.idleSince, StageMoves: deal.stageMoves,
-			})
-		}
-	}
-	// Sorted by id rather than by the read's order, so the digest depends on
-	// WHICH deals are open and on nothing else — a deal whose last activity moves
-	// must not read as a changed pipeline.
-	slices.Sort(sorted)
-	out.OpenDigest = strings.Join(sorted, ",")
-	return out, nil
+	return foldPipeline(open), nil
 }
 
 // hasOpenTask answers whether anything at all is scheduled on the account.

--- a/backend/internal/contracts/api_gen.go
+++ b/backend/internal/contracts/api_gen.go
@@ -12888,7 +12888,24 @@ type Organization360StateStrip struct {
 
 	// Commercial Null when the caller has no deal grant.
 	Commercial *struct {
-		OpenCount    int `json:"open_count"`
+		// BaseCurrency The ISO-4217 currency `open_pipeline_minor_base` is expressed in — the workspace's base. Travels WITH the figure rather than being looked up separately, because a converted sum rendered under a currency fetched from somewhere else is exactly the unlabelled cross-currency total §4.2 forbids. Null whenever the figure is.
+		BaseCurrency *string `json:"base_currency,omitempty"`
+
+		// ConvertedCount How many of `priced_count` needed a currency conversion to enter the sum — the rest were already in the base. Zero means the total is a same-currency sum and no rate stands behind it.
+		ConvertedCount int `json:"converted_count"`
+
+		// FxAsOf The OLDEST rate date among the converted deals: each freezes its rate on its own issue date, so this is the furthest back any part of the figure reaches. §4.2 forbids a cross-currency sum without an explicit conversion source and as-of date, and this is that date. Null when nothing needed converting.
+		FxAsOf *openapi_types.Date `json:"fx_as_of,omitempty"`
+
+		// NextCloseOn The nearest expected close date among the open deals; null when none names one.
+		NextCloseOn *openapi_types.Date `json:"next_close_on,omitempty"`
+		OpenCount   int                 `json:"open_count"`
+
+		// OpenPipelineMinorBase The open pipeline in the workspace's base currency, integer minor units. Null when NO open deal carries a figure that can be converted — distinct from zero, which would claim a priced pipeline worth nothing.
+		OpenPipelineMinorBase *int `json:"open_pipeline_minor_base,omitempty"`
+
+		// PricedCount How many of `open_count` contributed to the sum. A deal with no amount, and one whose currency has no conversion rate on its date, both contribute nothing — so a total below `open_count` covers PART of the pipeline, and the page says so rather than showing a figure that is quietly short (plan §4.2: never a cross-currency sum without its conversion source).
+		PricedCount  int `json:"priced_count"`
 		StalledCount int `json:"stalled_count"`
 	} `json:"commercial,omitempty"`
 

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -8026,6 +8026,24 @@ export interface components {
             commercial?: {
                 open_count: number;
                 stalled_count: number;
+                /** @description The open pipeline in the workspace's base currency, integer minor units. Null when NO open deal carries a figure that can be converted — distinct from zero, which would claim a priced pipeline worth nothing. */
+                open_pipeline_minor_base?: number | null;
+                /** @description How many of `open_count` contributed to the sum. A deal with no amount, and one whose currency has no conversion rate on its date, both contribute nothing — so a total below `open_count` covers PART of the pipeline, and the page says so rather than showing a figure that is quietly short (plan §4.2: never a cross-currency sum without its conversion source). */
+                priced_count: number;
+                /** @description How many of `priced_count` needed a currency conversion to enter the sum — the rest were already in the base. Zero means the total is a same-currency sum and no rate stands behind it. */
+                converted_count: number;
+                /**
+                 * Format: date
+                 * @description The OLDEST rate date among the converted deals: each freezes its rate on its own issue date, so this is the furthest back any part of the figure reaches. §4.2 forbids a cross-currency sum without an explicit conversion source and as-of date, and this is that date. Null when nothing needed converting.
+                 */
+                fx_as_of?: string | null;
+                /** @description The ISO-4217 currency `open_pipeline_minor_base` is expressed in — the workspace's base. Travels WITH the figure rather than being looked up separately, because a converted sum rendered under a currency fetched from somewhere else is exactly the unlabelled cross-currency total §4.2 forbids. Null whenever the figure is. */
+                base_currency?: string | null;
+                /**
+                 * Format: date
+                 * @description The nearest expected close date among the open deals; null when none names one.
+                 */
+                next_close_on?: string | null;
             } | null;
             /** @description The most serious thing standing open about this account, or null when nothing is open — and also null when the caller has no signal grant, because a strip that said "nothing" to someone who may not look would be answering a question it cannot answer. Exactly one: the strip states the worst, the signals card lists them all, and a reader who needs the rest opens it. */
             signal?: {

--- a/frontend/src/i18n/de.ts
+++ b/frontend/src/i18n/de.ts
@@ -572,6 +572,16 @@ export const de = {
   // Die drei Aussagen, mit denen die Übersicht beginnt, und was das
   // Ausführen eines Vorschlags bedeutet.
   "co.strip.title": "Wo dieser Account steht",
+  "co.strip.convertedAsOf": "{count} umgerechnet, Kurse vom {date}",
+  "co.strip.noOpenDeals": "Keine offenen Deals",
+  "co.strip.pipeline": "Offene Pipeline",
+  "co.strip.unpriced": "Keine umrechenbaren Beträge hinterlegt",
+  "co.strip.pricedPartly": "{priced} von {total} Deals mit Betrag",
+  "co.strip.expectedClose": "Erwarteter Abschluss",
+  "co.strip.health": "Beziehung",
+  "co.strip.healthActive": "Im Gespräch",
+  "co.strip.healthQuiet": "Still geworden",
+  "co.strip.noInboundEver": "Sie haben nie geschrieben",
   "co.strip.account": "Phase",
   "co.strip.engagement": "Wer am Zug ist",
   "co.strip.commercial": "Offene Arbeit",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -567,6 +567,16 @@ export const en = {
   // suggestion means. "Whose move" is the question the 0-100 score was
   // mistaken for.
   "co.strip.title": "Where this account stands",
+  "co.strip.convertedAsOf": "{count} converted, rates from {date}",
+  "co.strip.noOpenDeals": "No open deals",
+  "co.strip.pipeline": "Open pipeline",
+  "co.strip.unpriced": "No convertible amount on these deals",
+  "co.strip.pricedPartly": "{priced} of {total} deals priced",
+  "co.strip.expectedClose": "Expected close",
+  "co.strip.health": "Relationship",
+  "co.strip.healthActive": "In conversation",
+  "co.strip.healthQuiet": "Gone quiet",
+  "co.strip.noInboundEver": "They have never written",
   "co.strip.account": "Stage",
   "co.strip.engagement": "Whose move",
   "co.strip.commercial": "Open work",

--- a/frontend/src/i18n/vi.ts
+++ b/frontend/src/i18n/vi.ts
@@ -568,6 +568,16 @@ export const vi = {
   // suggestion means. "Whose move" is the question the 0-100 score was
   // mistaken for.
   "co.strip.title": "Tình hình tài khoản này",
+  "co.strip.convertedAsOf": "{count} đã quy đổi, tỷ giá từ {date}",
+  "co.strip.noOpenDeals": "Không có thương vụ mở",
+  "co.strip.pipeline": "Pipeline đang mở",
+  "co.strip.unpriced": "Không có giá trị quy đổi được",
+  "co.strip.pricedPartly": "{priced}/{total} thương vụ có giá trị",
+  "co.strip.expectedClose": "Dự kiến chốt",
+  "co.strip.health": "Quan hệ",
+  "co.strip.healthActive": "Đang trao đổi",
+  "co.strip.healthQuiet": "Đã lặng",
+  "co.strip.noInboundEver": "Họ chưa từng liên hệ",
   "co.strip.account": "Giai đoạn",
   "co.strip.engagement": "Đến lượt ai",
   "co.strip.commercial": "Việc đang mở",

--- a/frontend/src/screens/company360.test.tsx
+++ b/frontend/src/screens/company360.test.tsx
@@ -1217,6 +1217,186 @@ describe("company view — where the account stands, and what it is to us", () =
   });
 });
 
+// §4.2's "never render" list is the hard half of the KPI row, and each case
+// below is one of its bullets. They are about what the page must NOT claim,
+// which is exactly what a refactor loses silently.
+describe("company view — the KPI row never invents a figure", () => {
+  const commercial = (over: Record<string, unknown>) => ({
+    account: { lifecycle: "prospect", relationship_types: [] },
+    commercial: {
+      open_count: 2,
+      stalled_count: 0,
+      priced_count: 0,
+      converted_count: 0,
+      ...over,
+    },
+  });
+
+  it("shows no money at all when no open deal carries a convertible amount", async () => {
+    stub(view({ state_strip: commercial({}) }));
+    renderCompany();
+    const strip = await screen.findByRole("region", {
+      name: "Where this account stands",
+    });
+
+    // A zero here would claim a priced pipeline worth nothing. The truth is
+    // that the page cannot price this one, so it reports the count instead.
+    // No currency figure AT ALL — not merely no zero. A stray non-zero total
+    // would be the worse failure, and the loose form would have passed it.
+    expect(strip.textContent).not.toMatch(/[€$£]/);
+    expect(within(strip).getByText("2 open")).toBeTruthy();
+    expect(
+      within(strip).getByText("No convertible amount on these deals"),
+    ).toBeTruthy();
+  });
+
+  it("says an empty pipeline is empty, not unpriced", async () => {
+    stub(view({ state_strip: commercial({ open_count: 0 }) }));
+    renderCompany();
+    const strip = await screen.findByRole("region", {
+      name: "Where this account stands",
+    });
+
+    // "No convertible amount" on an account with nothing open reports a data
+    // problem where the truth is that nothing is running.
+    expect(within(strip).getByText("No open deals")).toBeTruthy();
+    expect(strip.textContent).not.toContain("No convertible amount");
+  });
+
+  it("names the conversion behind a cross-currency total", async () => {
+    stub(
+      view({
+        state_strip: commercial({
+          open_pipeline_minor_base: 4500000,
+          base_currency: "EUR",
+          priced_count: 2,
+          converted_count: 1,
+          fx_as_of: "2026-02-14",
+        }),
+      }),
+    );
+    renderCompany();
+    const strip = await screen.findByRole("region", {
+      name: "Where this account stands",
+    });
+
+    // §4.2 bars a cross-currency sum with no conversion source and as-of date.
+    // The date is the oldest rate behind the figure — how far back any part of
+    // it reaches.
+    // The DATE itself, not just the prefix: a dropped or wrong interpolation
+    // is exactly the failure this qualification exists to prevent.
+    expect(
+      within(strip).getByText(/1 converted, rates from .*2026/),
+    ).toBeTruthy();
+  });
+
+  it("keeps saying the pipeline is unpriced even when a deal has stalled", async () => {
+    stub(view({ state_strip: commercial({ stalled_count: 1 }) }));
+    renderCompany();
+    const strip = await screen.findByRole("region", {
+      name: "Where this account stands",
+    });
+
+    // A reader told only "1 stalled" has no way to know the pipeline carries
+    // no figure at all. Both qualifications are true, so both are shown.
+    expect(strip.textContent).toContain("No convertible amount on these deals");
+    expect(strip.textContent).toContain("1 stalled");
+  });
+
+  it("says how much of the pipeline a partial total covers", async () => {
+    stub(
+      view({
+        state_strip: commercial({
+          open_pipeline_minor_base: 4500000,
+          base_currency: "EUR",
+          priced_count: 1,
+        }),
+      }),
+    );
+    renderCompany();
+    const strip = await screen.findByRole("region", {
+      name: "Where this account stands",
+    });
+
+    // A sum covering one of two deals, shown bare, reads as the whole
+    // pipeline — the unlabelled cross-currency total §4.2 forbids.
+    expect(within(strip).getByText("1 of 2 deals priced")).toBeTruthy();
+  });
+
+  it("labels the sum of open deals Open pipeline, never revenue or potential", async () => {
+    stub(
+      view({
+        state_strip: commercial({
+          open_pipeline_minor_base: 4500000,
+          base_currency: "EUR",
+          priced_count: 2,
+        }),
+      }),
+    );
+    renderCompany();
+    const strip = await screen.findByRole("region", {
+      name: "Where this account stands",
+    });
+
+    expect(within(strip).getByText("Open pipeline")).toBeTruthy();
+    expect(strip.textContent).not.toMatch(/revenue|potential/i);
+  });
+
+  // §4.2 gives customers and prospects different questions. A customer's page
+  // is asked how the relationship stands; a prospect's is asked when the deal
+  // lands. Showing one set to both makes half the row noise.
+  it("asks a prospect when the deal closes, and a customer how it is going", async () => {
+    stub(
+      view({
+        state_strip: {
+          account: { lifecycle: "prospect", relationship_types: [] },
+          commercial: {
+            open_count: 1,
+            stalled_count: 0,
+            priced_count: 1,
+            converted_count: 0,
+            open_pipeline_minor_base: 100000,
+            base_currency: "EUR",
+            next_close_on: "2026-09-30",
+          },
+        },
+      }),
+    );
+    renderCompany();
+    let strip = await screen.findByRole("region", {
+      name: "Where this account stands",
+    });
+    expect(within(strip).getByText("Expected close")).toBeTruthy();
+    expect(within(strip).queryByText("Relationship")).toBeNull();
+
+    cleanup();
+    stub(
+      view({
+        health: { days_since_last_inbound: 90 },
+        state_strip: {
+          account: { lifecycle: "customer", relationship_types: [] },
+          commercial: {
+            open_count: 1,
+            stalled_count: 0,
+            priced_count: 1,
+            converted_count: 0,
+            open_pipeline_minor_base: 100000,
+            base_currency: "EUR",
+            next_close_on: "2026-09-30",
+          },
+        },
+      }),
+    );
+    renderCompany();
+    strip = await screen.findByRole("region", {
+      name: "Where this account stands",
+    });
+    expect(within(strip).getByText("Relationship")).toBeTruthy();
+    expect(within(strip).getByText("Gone quiet")).toBeTruthy();
+    expect(within(strip).queryByText("Expected close")).toBeNull();
+  });
+});
+
 describe("company view — the state strip", () => {
   it("leads with where the account stands, whose move it is, and what is open", async () => {
     stub(
@@ -1231,7 +1411,14 @@ describe("company view — the state strip", () => {
             last_inbound_at: "2026-04-30T09:00:00Z",
             last_outbound_at: "2026-07-17T09:00:00Z",
           },
-          commercial: { open_count: 2, stalled_count: 1 },
+          // The full wire shape, so this case fails if the contract moves
+          // under it rather than being silently accepted by a loose stub.
+          commercial: {
+            open_count: 2,
+            stalled_count: 1,
+            priced_count: 0,
+            converted_count: 0,
+          },
         },
       }),
     );
@@ -1243,7 +1430,7 @@ describe("company view — the state strip", () => {
     expect(within(strip).getByText("Former customer")).toBeTruthy();
     expect(within(strip).getByText("Waiting on them")).toBeTruthy();
     expect(within(strip).getByText("2 open")).toBeTruthy();
-    expect(within(strip).getByText("1 stalled")).toBeTruthy();
+    expect(strip.textContent).toContain("1 stalled");
   });
 
   it("states the worst thing standing open, in the words its producer wrote", async () => {

--- a/frontend/src/screens/company360.tsx
+++ b/frontend/src/screens/company360.tsx
@@ -16,7 +16,7 @@ import {
 import { Select } from "../design-system/select";
 import { formatDate, formatDateTime, formatMoney } from "../format/format";
 
-import { useLocale, useT } from "../i18n";
+import { type Locale, useLocale, useT } from "../i18n";
 import type { MessageKey } from "../i18n/en";
 import { problemMessageOf, throwProblem } from "./common";
 import "./company360.css";
@@ -1833,6 +1833,15 @@ const ENGAGEMENT_TONE: Partial<
  * from that would state a business conclusion the page has no basis for — the
  * one a rep would act on.
  */
+// The compact KPI row (plan §4.2): at most four cards, and WHICH four depends
+// on where the account stands. A customer is asked about money and health; a
+// prospect is asked about pipeline, timing and fit. Showing one set to both
+// makes half of them noise.
+//
+// What it must never render is the harder half of the rule, and every omission
+// below is one of its bullets: no €0 when the figure is unavailable, no
+// cross-currency sum without its conversion source, and nothing called
+// "revenue" that is only a count of open deals.
 export function StateStrip({
   view,
   lifecycleLabel,
@@ -1848,11 +1857,10 @@ export function StateStrip({
   if (!strip) {
     return null;
   }
-  const engagement = strip.engagement;
-  const commercial = strip.commercial;
   const types = strip.account.relationship_types ?? [];
-  const when = (at?: string | null) =>
-    at ? formatDate(at, locale, RECORD_ZONE) : undefined;
+  const customer =
+    strip.account.lifecycle === "customer" ||
+    strip.account.lifecycle === "former_customer";
   return (
     <section className="co-strip" aria-label={t("co.strip.title")}>
       <StatCard
@@ -1860,44 +1868,213 @@ export function StateStrip({
         value={lifecycleLabel(strip.account.lifecycle)}
         detail={types.length > 0 ? relationshipLabels(types) : undefined}
       />
-      {engagement && (
-        <StatCard
-          label={t("co.strip.engagement")}
-          value={t(ENGAGEMENT_LABELS[engagement.state])}
-          tone={ENGAGEMENT_TONE[engagement.state]}
-          detail={
-            engagement.last_inbound_at || engagement.last_outbound_at
-              ? t("co.strip.lastBoth", {
-                  inbound:
-                    when(engagement.last_inbound_at) ?? t("co.strip.never"),
-                  outbound:
-                    when(engagement.last_outbound_at) ?? t("co.strip.never"),
-                })
-              : undefined
-          }
-        />
+      {/* Four cards is the cap (§4.2). The account card always holds the
+          first slot; the signal, when one is open, takes the engagement slot
+          rather than adding a fifth — the worst thing standing open is the
+          more urgent reading of the two. */}
+      <PipelineCard commercial={strip.commercial} locale={locale} t={t} />
+      {customer ? (
+        <HealthStat health={view?.health} t={t} />
+      ) : (
+        <CloseDateStat commercial={strip.commercial} locale={locale} t={t} />
       )}
-      {strip.signal && (
+      {strip.signal ? (
         <StatCard
           label={t("co.strip.signal")}
           value={signalKindLabel(strip.signal.kind, t)}
           tone={signalTone(strip.signal.severity)}
           detail={strip.signal.summary}
         />
-      )}
-      {commercial && (
-        <StatCard
-          label={t("co.strip.commercial")}
-          value={t("co.strip.openDeals", { count: commercial.open_count })}
-          tone={commercial.stalled_count > 0 ? "warn" : undefined}
-          detail={
-            commercial.stalled_count > 0
-              ? t("co.strip.stalled", { count: commercial.stalled_count })
-              : undefined
-          }
-        />
+      ) : (
+        <EngagementStat engagement={strip.engagement} locale={locale} t={t} />
       )}
     </section>
+  );
+}
+
+type StripCommercial = NonNullable<
+  NonNullable<Organization360["state_strip"]>["commercial"]
+>;
+
+// Open pipeline, labelled as exactly what it is: the sum of open deals, never
+// "potential" and never "revenue" (§4.2). Absent when nothing on the account
+// carries a convertible figure — a €0 there would claim a priced pipeline
+// worth nothing, where the truth is the page cannot price it.
+function PipelineCard({
+  commercial,
+  locale,
+  t,
+}: Readonly<{
+  commercial?: StripCommercial | null;
+  locale: Locale;
+  t: ReturnType<typeof useT>;
+}>) {
+  if (!commercial) {
+    return null;
+  }
+  // No open deals is not an unpriced pipeline. Saying "no convertible amount"
+  // about an account that has nothing open reports a data problem where the
+  // truth is simply that nothing is running.
+  if (commercial.open_count === 0) {
+    return (
+      <StatCard
+        label={t("co.strip.pipeline")}
+        value={t("co.strip.noOpenDeals")}
+      />
+    );
+  }
+  const { open_pipeline_minor_base: value, base_currency: currency } =
+    commercial;
+  const stalled =
+    commercial.stalled_count > 0
+      ? t("co.strip.stalled", { count: commercial.stalled_count })
+      : undefined;
+  if (value == null || !currency) {
+    // Open deals with no priceable figure still say how many there are: the
+    // count is a fact, the money is not. The unpriced note is never dropped
+    // for the stalled one — a reader who is told only "1 stalled" has no way
+    // to know the pipeline was never priced at all.
+    return (
+      <StatCard
+        label={t("co.strip.pipeline")}
+        value={t("co.strip.openDeals", { count: commercial.open_count })}
+        detail={join(t("co.strip.unpriced"), stalled)}
+        tone={stalled ? "warn" : undefined}
+      />
+    );
+  }
+  // Everything qualifying this figure travels WITH it. §4.2 forbids a
+  // cross-currency sum without an explicit conversion source and as-of date,
+  // and forbids a total that silently covers only part of the pipeline — so a
+  // partial total names its share, and a converted one names the oldest rate
+  // date standing behind it.
+  const partial = commercial.priced_count < commercial.open_count;
+  const converted =
+    commercial.converted_count > 0 && commercial.fx_as_of
+      ? t("co.strip.convertedAsOf", {
+          count: commercial.converted_count,
+          date: formatDate(commercial.fx_as_of, locale, RECORD_ZONE),
+        })
+      : undefined;
+  return (
+    <StatCard
+      label={t("co.strip.pipeline")}
+      value={formatMoney(value, currency, locale)}
+      tone={stalled ? "warn" : undefined}
+      detail={join(
+        partial
+          ? t("co.strip.pricedPartly", {
+              priced: commercial.priced_count,
+              total: commercial.open_count,
+            })
+          : t("co.strip.openDeals", { count: commercial.open_count }),
+        converted,
+        stalled,
+      )}
+    />
+  );
+}
+
+// One detail line from the parts that apply. A card has room for one, and
+// dropping a part because another is present is how a qualification goes
+// missing exactly when it matters.
+function join(...parts: (string | undefined)[]): string {
+  return parts.filter(Boolean).join(" · ");
+}
+
+// When the next open deal is expected to close. A prospect's page is asked
+// "when?", and the answer is a date on a record rather than an assessment.
+function CloseDateStat({
+  commercial,
+  locale,
+  t,
+}: Readonly<{
+  commercial?: StripCommercial | null;
+  locale: Locale;
+  t: ReturnType<typeof useT>;
+}>) {
+  if (!commercial?.next_close_on) {
+    return null;
+  }
+  return (
+    <StatCard
+      label={t("co.strip.expectedClose")}
+      value={formatDate(commercial.next_close_on, locale, RECORD_ZONE)}
+    />
+  );
+}
+
+// Health as a STATUS with its reason, never a 0-100 verdict (§4.2). The card
+// below the fold decomposes it; this says which way it points and why, in one
+// line, so the row is readable without scrolling to the explanation.
+function HealthStat({
+  health,
+  t,
+}: Readonly<{ health?: Health; t: ReturnType<typeof useT> }>) {
+  if (!health) {
+    return null;
+  }
+  const days = health.days_since_last_inbound;
+  if (days == null) {
+    return (
+      <StatCard
+        label={t("co.strip.health")}
+        value={t("co.strip.noInboundEver")}
+        tone="warn"
+      />
+    );
+  }
+  return (
+    <StatCard
+      label={t("co.strip.health")}
+      value={
+        days <= HEALTH_QUIET_DAYS
+          ? t("co.strip.healthActive")
+          : t("co.strip.healthQuiet")
+      }
+      // Only the quiet side is toned. A healthy relationship is the ordinary
+      // case and needs no colour; the design system has no positive tone, and
+      // inventing one would make every calm account shout.
+      tone={days <= HEALTH_QUIET_DAYS ? undefined : "warn"}
+      detail={t("co.health.sinceInbound", { days })}
+    />
+  );
+}
+
+// The threshold that separates a live conversation from a quiet one. It names
+// a number the strip states rather than one the reader must infer from a date,
+// and it is deliberately the same span the dormant engagement state uses.
+const HEALTH_QUIET_DAYS = 30;
+
+function EngagementStat({
+  engagement,
+  locale,
+  t,
+}: Readonly<{
+  engagement?: NonNullable<Organization360["state_strip"]>["engagement"];
+  locale: Locale;
+  t: ReturnType<typeof useT>;
+}>) {
+  if (!engagement) {
+    return null;
+  }
+  const when = (at?: string | null) =>
+    at ? formatDate(at, locale, RECORD_ZONE) : undefined;
+  return (
+    <StatCard
+      label={t("co.strip.engagement")}
+      value={t(ENGAGEMENT_LABELS[engagement.state])}
+      tone={ENGAGEMENT_TONE[engagement.state]}
+      detail={
+        engagement.last_inbound_at || engagement.last_outbound_at
+          ? t("co.strip.lastBoth", {
+              inbound: when(engagement.last_inbound_at) ?? t("co.strip.never"),
+              outbound:
+                when(engagement.last_outbound_at) ?? t("co.strip.never"),
+            })
+          : undefined
+      }
+    />
   );
 }
 


### PR DESCRIPTION
Plan §4.2: at most four cards, and *which* four depends on where the account stands. The row showed one set to every company, and its commercial card reported a **count** of open deals where the plan asks for the pipeline's **value**.

Customers now get the relationship's state; prospects get the expected close date. Both get open pipeline in the base currency.

## What Codex caught — the feature didn't work

The first cut summed `deal.amount_minor_base`. That column is generated from the frozen FX rate, and **the rate freezes on close** — so it is null on every open deal. The pipeline figure would have read *"no convertible amount"* on every installation, forever.

The fold now takes a base-currency deal's own `amount_minor` (no rate needed) and converts only where a frozen rate **and** its date both exist.

My unit test had hidden this by hand-building a `valueBase` the real writer never produces — the seed-through-the-real-writer trap, caught by review rather than by the suite.

## §4.2's "never render" rules

- A converted total carries the **oldest rate date** behind it — the rule bars a cross-currency sum with no conversion source and as-of date.
- A deal that cannot be converted stays out of the total and still counts as open, so the card says it covers *part* of the pipeline.
- An account with nothing open says **"No open deals"**, not "unpriced".
- The unpriced note is no longer dropped when a deal is also stalled.
- Nothing is labelled revenue or potential; the sum of open deals is called **Open pipeline**.

## Tests

The fold moved to `pipelinefold.go` so the money rules are provable without a database. Reverting the base-currency arm turns its test red with `Priced = 0` — the number every installation would have seen.

Local gate: backend clean, craft clean, 1998 frontend tests, org360 integration green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the Company KPI row to show different cards for customers vs prospects and to correctly price the open pipeline in the workspace’s base currency. Prevents zeroed or silently short totals and adds clear conversion provenance.

- **New Features**
  - Customers see relationship status; prospects see the nearest expected close date.
  - New pipeline card shows "Open pipeline" in base currency, or "No open deals" when empty, or "No convertible amount on these deals" when unpriceable.
  - Partial totals disclose coverage (e.g., "{priced} of {total} deals priced"); converted sums show "{count} converted, rates from {date}".
  - API expands `commercial` with `open_pipeline_minor_base`, `priced_count`, `converted_count`, `fx_as_of`, `base_currency`, `next_close_on`.

- **Bug Fixes**
  - Fixed pipeline calculation that summed `amount_minor_base` (null for open deals). Now uses `amount_minor` for base-currency deals and includes converted values only when a frozen rate and date exist; unconvertible deals don’t enter the sum but still count as open.
  - Added unit tests for the money rules and frontend tests to enforce “never render” cases (no fake €0, no unlabeled cross-currency totals).

<sup>Written for commit 74fad4781f15f5a9726acd7bba3926f7ad024ab8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gradionhq/margince-poc-v1/pull/730?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Company overviews now show lifecycle-focused KPIs for pipeline value, pricing completeness, expected close dates, relationship health, and engagement.
  - Pipeline totals support base-currency conversion, conversion dates, open and stalled deal counts, and partial or unavailable pricing states.
  - Open deals are prioritized by expected close date for clearer forecasting.
- **Localization**
  - Added translated account overview messaging in English, German, and Vietnamese.

- **Tests**
  - Expanded coverage for pricing, currency conversion, pipeline states, stalled deals, and lifecycle messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->